### PR TITLE
dts: arm: renesas: ra: Separate the OFS memory into individual regions

### DIFF
--- a/dts/arm/renesas/ra/ra2/ra2l1.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2l1.dtsi
@@ -524,10 +524,10 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_in_rom: option-setting-ofs-in-rom@400 {
+		option-setting-ofs-in-rom@400 {
 			reg = <0x00000400 0x3c>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 
 			option_setting_ofs0: option-setting-ofs0@400 {
 				compatible = "renesas,ofs-memory";
@@ -548,16 +548,15 @@
 			};
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@1010010 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@1010010 {
 			reg = <0x01010010 0x24>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_osis: option-setting-osis@1010018 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OSIS_MEMORY";
 				reg = <0x01010018 0x1c>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra2/ra2xx.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2xx.dtsi
@@ -393,10 +393,10 @@
 			};
 		};
 
-		option_setting_ofs_in_rom: option-setting-ofs-in-rom@400 {
+		option-setting-ofs-in-rom@400 {
 			reg = <0x00000400 0x3c>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 
 			option_setting_ofs0: option-setting-ofs0@400 {
 				compatible = "renesas,ofs-memory";
@@ -417,16 +417,15 @@
 			};
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@1010008 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@1010008 {
 			reg = <0x01010008 0x2c>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_osis: option-setting-osis@1010018 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OSIS_MEMORY";
 				reg = <0x01010018 0x1c>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra4/r7fa4c1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4c1bx.dtsi
@@ -535,64 +535,71 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a100 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a100 {
 			reg = <0x0100a100 0x200>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS0_MEMORY";
 				reg = <0x0100a100 0x4>;
 				status = "okay";
 			};
 
 			option_setting_dualsel: option-setting-dualsel@100a110 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_DUALSEL_MEMORY";
 				reg = <0x0100a110 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
 				reg = <0x0100a200 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
 				reg = <0x0100a210 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
 				reg = <0x0100a240 0xc>;
 				status = "okay";
 			};
 
 			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
 				reg = <0x0100a260 0xc>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
 				reg = <0x0100a280 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
 				reg = <0x0100a290 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
 				reg = <0x0100a2c0 0xc>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
@@ -69,46 +69,50 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a100 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a100 {
 			reg = <0x0100a100 0x200>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS0_MEMORY";
 				reg = <0x0100a100 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
 				reg = <0x0100a200 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
 				reg = <0x0100a240 0x4>;
 				status = "okay";
 			};
 
 			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
 				reg = <0x0100a260 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
 				reg = <0x0100a280 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
 				reg = <0x0100a2c0 0x4>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
@@ -122,40 +122,43 @@
 			};
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a100 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a100 {
 			reg = <0x0100a100 0x200>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS0_MEMORY";
 				reg = <0x0100a100 0x4>;
 				status = "okay";
 			};
 
 			option_setting_osis: option-setting-osis@100a120 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OSIS_MEMORY";
 				reg = <0x0100a120 0x10>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
 				reg = <0x0100a200 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
 				reg = <0x0100a240 0x4>;
 				status = "okay";
 			};
 
 			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
 				reg = <0x0100a260 0x4>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
@@ -576,64 +576,72 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a100 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a100 {
+			compatible = "renesas,ofs-memory";
 			reg = <0x0100a100 0x200>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS0_MEMORY";
 				reg = <0x0100a100 0x4>;
 				status = "okay";
 			};
 
 			option_setting_dualsel: option-setting-dualsel@100a110 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_DUALSEL_MEMORY";
 				reg = <0x0100a110 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
 				reg = <0x0100a200 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
 				reg = <0x0100a210 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
 				reg = <0x0100a240 0xc>;
 				status = "okay";
 			};
 
 			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
 				reg = <0x0100a260 0xc>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
 				reg = <0x0100a280 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
 				reg = <0x0100a290 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
 				reg = <0x0100a2c0 0xc>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
@@ -157,46 +157,50 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a100 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a100 {
 			reg = <0x0100a100 0x200>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS0_MEMORY";
 				reg = <0x0100a100 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
 				reg = <0x0100a200 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
 				reg = <0x0100a240 0x4>;
 				status = "okay";
 			};
 
 			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
 				reg = <0x0100a260 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
 				reg = <0x0100a280 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
 				reg = <0x0100a2c0 0x4>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
@@ -170,58 +170,64 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a100 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a100 {
 			reg = <0x0100a100 0x200>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS0_MEMORY";
 				reg = <0x0100a100 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
 				reg = <0x0100a200 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
 				reg = <0x0100a210 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
 				reg = <0x0100a240 0x8>;
 				status = "okay";
 			};
 
 			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
 				reg = <0x0100a260 0x8>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
 				reg = <0x0100a280 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
 				reg = <0x0100a290 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
 				reg = <0x0100a2c0 0x8>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -463,10 +463,10 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_in_rom: option-setting-ofs-in-rom@400 {
+		option-setting-ofs-in-rom@400 {
 			reg = <0x00000400 0x3c>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 
 			option_setting_ofs0: option-setting-ofs0@400 {
 				compatible = "renesas,ofs-memory";
@@ -487,16 +487,15 @@
 			};
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@1010008 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@1010008 {
 			reg = <0x01010008 0x2c>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_osis: option-setting-osis@1010018 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OSIS_MEMORY";
 				reg = <0x01010018 0x1c>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
@@ -128,64 +128,71 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a100 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a100 {
 			reg = <0x0100a100 0x200>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS0_MEMORY";
 				reg = <0x0100a100 0x4>;
 				status = "okay";
 			};
 
 			option_setting_dualsel: option-setting-dualsel@100a110 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_DUALSEL_MEMORY";
 				reg = <0x0100a110 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
 				reg = <0x0100a200 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
 				reg = <0x0100a210 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
 				reg = <0x0100a240 0xc>;
 				status = "okay";
 			};
 
 			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
 				reg = <0x0100a260 0xc>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
 				reg = <0x0100a280 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
 				reg = <0x0100a290 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
 				reg = <0x0100a2c0 0xc>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -118,40 +118,43 @@
 			};
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a100 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a100 {
 			reg = <0x0100a100 0x200>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS0_MEMORY";
 				reg = <0x0100a100 0x4>;
 				status = "okay";
 			};
 
 			option_setting_osis: option-setting-osis@100a120 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OSIS_MEMORY";
 				reg = <0x0100a120 0x10>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
 				reg = <0x0100a200 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
 				reg = <0x0100a240 0x4>;
 				status = "okay";
 			};
 
 			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
 				reg = <0x0100a260 0x4>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
@@ -55,10 +55,10 @@
 			channel-available-mask = <0x300e7>;
 		};
 
-		option_setting_ofs_in_rom: option-setting-ofs-in-rom@400 {
+		option-setting-ofs-in-rom@400 {
 			reg = <0x00000400 0x3c>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 
 			option_setting_ofs0: option-setting-ofs0@400 {
 				compatible = "renesas,ofs-memory";
@@ -79,16 +79,15 @@
 			};
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a150 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a150 {
 			reg = <0x0100a150 0x18>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_osis: option-setting-osis@100a150 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OSIS_MEMORY";
 				reg = <0x0100a150 0x10>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
@@ -86,10 +86,10 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_in_rom: option-setting-ofs-in-rom@400 {
+		option-setting-ofs-in-rom@400 {
 			reg = <0x00000400 0x3c>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 
 			option_setting_ofs0: option-setting-ofs0@400 {
 				compatible = "renesas,ofs-memory";
@@ -110,16 +110,15 @@
 			};
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a150 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a150 {
 			reg = <0x0100a150 0x18>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_osis: option-setting-osis@100a150 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OSIS_MEMORY";
 				reg = <0x0100a150 0x10>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
@@ -142,10 +142,10 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_in_rom: option-setting-ofs-in-rom@400 {
+		option-setting-ofs-in-rom@400 {
 			reg = <0x00000400 0x3c>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 
 			option_setting_ofs0: option-setting-ofs0@400 {
 				compatible = "renesas,ofs-memory";
@@ -166,16 +166,15 @@
 			};
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a150 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a150 {
 			reg = <0x0100a150 0x18>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_osis: option-setting-osis@100a150 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OSIS_MEMORY";
 				reg = <0x0100a150 0x10>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
@@ -239,64 +239,71 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a100 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a100 {
 			reg = <0x0100a100 0x200>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS0_MEMORY";
 				reg = <0x0100a100 0x4>;
 				status = "okay";
 			};
 
 			option_setting_dualsel: option-setting-dualsel@100a110 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_DUALSEL_MEMORY";
 				reg = <0x0100a110 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
 				reg = <0x0100a200 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
 				reg = <0x0100a210 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
 				reg = <0x0100a240 0x10>;
 				status = "okay";
 			};
 
 			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
 				reg = <0x0100a260 0x10>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
 				reg = <0x0100a280 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
 				reg = <0x0100a290 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
 				reg = <0x0100a2c0 0x10>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -292,64 +292,71 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_conf: option-setting-ofs-conf@100a100 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-conf@100a100 {
 			reg = <0x0100a100 0x200>;
-			zephyr,memory-region = "OFS_CONF_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS0_MEMORY";
 				reg = <0x0100a100 0x4>;
 				status = "okay";
 			};
 
 			option_setting_dualsel: option-setting-dualsel@100a110 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_DUALSEL_MEMORY";
 				reg = <0x0100a110 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
 				reg = <0x0100a200 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
 				reg = <0x0100a210 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
 				reg = <0x0100a240 0x10>;
 				status = "okay";
 			};
 
 			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
 				reg = <0x0100a260 0x10>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
 				reg = <0x0100a280 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
 				reg = <0x0100a290 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
 				reg = <0x0100a2c0 0x10>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -952,70 +952,78 @@
 			status = "disabled";
 		};
 
-		option_setting_ofs_cf_sec: option-setting-ofs-cf-sec@300a100 {
-			compatible = "zephyr,memory-region";
+		option-setting-ofs-cf-sec@300a100 {
 			reg = <0x0300a100 0x200>;
-			zephyr,memory-region = "OFS_CF_SEC_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_ofs0: option-setting-ofs0@300a100 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS0_MEMORY";
 				reg = <0x0300a100 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs2: option-setting-ofs2@300a104 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS2_MEMORY";
 				reg = <0x0300a104 0x4>;
 				status = "okay";
 			};
 
 			option_setting_dualsel: option-setting-dualsel@300a110 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_DUALSEL_MEMORY";
 				reg = <0x0300a110 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sec: option-setting-ofs1-sec@300a200 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
 				reg = <0x0300a200 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sec: option-setting-banksel-sec@300a210 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
 				reg = <0x0300a210 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sec: option-setting-bps-sec@300a240 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
 				reg = <0x0300a240 0x10>;
 				status = "okay";
 			};
 
 			option_setting_pbps_sec: option-setting-pbps-sec@300a260 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
 				reg = <0x0300a260 0x10>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sel: option-setting-ofs1-sel@300a280 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
 				reg = <0x0300a280 0x4>;
 				status = "okay";
 			};
 
 			option_setting_banksel_sel: option-setting-banksel-sel@300a290 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
 				reg = <0x0300a290 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sel: option-setting-bps-sel@300a2c0 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
 				reg = <0x0300a2c0 0x10>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra8/ra8x2.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x2.dtsi
@@ -1036,72 +1036,77 @@
 		};
 
 		option_setting_ofs_conf_sec: option-setting-ofs-conf-sec@2c9f040 {
-			compatible = "zephyr,memory-region";
 			reg = <0x02c9f040 0x3c0>;
-			zephyr,memory-region = "OFS_CONF_SEC_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_ofs0: option-setting-ofs0@2c9f040 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS0_MEMORY";
 				reg = <0x02c9f040 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs2: option-setting-ofs2@2c9f044 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS2_MEMORY";
 				reg = <0x02c9f044 0x4>;
 				status = "okay";
 			};
 
 			option_setting_sas: option-setting-sas@2c9f074 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_SAS_MEMORY";
 				reg = <0x02c9f074 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sec: option-setting-ofs1-sec@2c9f0c0 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
 				reg = <0x02c9f0c0 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs3_sec: option-setting-ofs3-sec@2c9f0c4 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS3_SEC_MEMORY";
 				reg = <0x02c9f0c4 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs1_sel: option-setting-ofs1-sel@2c9f120 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
 				reg = <0x02c9f120 0x4>;
 				status = "okay";
 			};
 
 			option_setting_ofs3_sel: option-setting-ofs3-sel@2c9f124 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OFS3_SEL_MEMORY";
 				reg = <0x02c9f124 0x4>;
 				status = "okay";
 			};
 
 			option_setting_bps_sec: option-setting-bps-sec@2c9f200 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
 				reg = <0x02c9f200 0x200>;
 				status = "okay";
 			};
 		};
 
 		option_setting_ofs_otp_sec: option-setting-ofs-otp-sec@2e07400 {
-			compatible = "zephyr,memory-region";
 			reg = <0x02e07400 0x120a30>;
-			zephyr,memory-region = "OFS_OTP_SEC_MEMORY";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "okay";
 
 			option_setting_otp_pbps_sec: option-setting-otp-pbps-sec@2e17700 {
-				compatible = "renesas,ofs-memory";
+				compatible = "zephyr,memory-region";
+				zephyr,memory-region = "OFS_OTP_PBPS_SEC_MEMORY";
 				reg = <0x02e17700 0x80>;
 				status = "okay";
 			};

--- a/soc/renesas/ra/ra2a1/sections.ld
+++ b/soc/renesas/ra/ra2a1/sections.ld
@@ -7,13 +7,9 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OSIS_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra2l1/sections.ld
+++ b/soc/renesas/ra/ra2l1/sections.ld
@@ -6,13 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OSIS_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra4c1/sections.ld
+++ b/soc/renesas/ra/ra4c1/sections.ld
@@ -6,69 +6,65 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_dualsel))
 SECTION_DATA_PROLOGUE(.option_setting_dualsel, DT_REG_ADDR(DT_NODELABEL(option_setting_dualsel)),)
 {
 	KEEP(*(.option_setting_dualsel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_DUALSEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sec))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sec)),)
 {
 	KEEP(*(.option_setting_banksel_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sel)),)
 {
 	KEEP(*(.option_setting_ofs1_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sel))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sel)),)
 {
 	KEEP(*(.option_setting_banksel_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sel))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sel)),)
 {
 	KEEP(*(.option_setting_bps_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra4e1/sections.ld
+++ b/soc/renesas/ra/ra4e1/sections.ld
@@ -6,48 +6,44 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sel)),)
 {
 	KEEP(*(.option_setting_ofs1_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sel))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sel)),)
 {
 	KEEP(*(.option_setting_bps_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra4e2/sections.ld
+++ b/soc/renesas/ra/ra4e2/sections.ld
@@ -6,41 +6,37 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OSIS_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra4l1/sections.ld
+++ b/soc/renesas/ra/ra4l1/sections.ld
@@ -6,69 +6,65 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_dualsel))
 SECTION_DATA_PROLOGUE(.option_setting_dualsel, DT_REG_ADDR(DT_NODELABEL(option_setting_dualsel)),)
 {
 	KEEP(*(.option_setting_dualsel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_DUALSEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sec))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sec)),)
 {
 	KEEP(*(.option_setting_banksel_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sel)),)
 {
 	KEEP(*(.option_setting_ofs1_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sel))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sel)),)
 {
 	KEEP(*(.option_setting_banksel_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sel))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sel)),)
 {
 	KEEP(*(.option_setting_bps_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra4m1/sections.ld
+++ b/soc/renesas/ra/ra4m1/sections.ld
@@ -7,13 +7,9 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OSIS_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra4m2/sections.ld
+++ b/soc/renesas/ra/ra4m2/sections.ld
@@ -6,48 +6,44 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sel)),)
 {
 	KEEP(*(.option_setting_ofs1_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sel))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sel)),)
 {
 	KEEP(*(.option_setting_bps_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra4m3/sections.ld
+++ b/soc/renesas/ra/ra4m3/sections.ld
@@ -6,62 +6,58 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sec))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sec)),)
 {
 	KEEP(*(.option_setting_banksel_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sel)),)
 {
 	KEEP(*(.option_setting_ofs1_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sel))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sel)),)
 {
 	KEEP(*(.option_setting_banksel_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sel))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sel)),)
 {
 	KEEP(*(.option_setting_bps_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra4w1/sections.ld
+++ b/soc/renesas/ra/ra4w1/sections.ld
@@ -6,13 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OSIS_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra6e1/sections.ld
+++ b/soc/renesas/ra/ra6e1/sections.ld
@@ -6,69 +6,65 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_dualsel))
 SECTION_DATA_PROLOGUE(.option_setting_dualsel, DT_REG_ADDR(DT_NODELABEL(option_setting_dualsel)),)
 {
 	KEEP(*(.option_setting_dualsel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_DUALSEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sec))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sec)),)
 {
 	KEEP(*(.option_setting_banksel_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sel)),)
 {
 	KEEP(*(.option_setting_ofs1_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sel))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sel)),)
 {
 	KEEP(*(.option_setting_banksel_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sel))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sel)),)
 {
 	KEEP(*(.option_setting_bps_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra6e2/sections.ld
+++ b/soc/renesas/ra/ra6e2/sections.ld
@@ -6,41 +6,37 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OSIS_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra6m1/sections.ld
+++ b/soc/renesas/ra/ra6m1/sections.ld
@@ -6,13 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OSIS_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra6m2/sections.ld
+++ b/soc/renesas/ra/ra6m2/sections.ld
@@ -6,13 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OSIS_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra6m3/sections.ld
+++ b/soc/renesas/ra/ra6m3/sections.ld
@@ -6,13 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OSIS_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra6m4/sections.ld
+++ b/soc/renesas/ra/ra6m4/sections.ld
@@ -6,69 +6,65 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_dualsel))
 SECTION_DATA_PROLOGUE(.option_setting_dualsel, DT_REG_ADDR(DT_NODELABEL(option_setting_dualsel)),)
 {
 	KEEP(*(.option_setting_dualsel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_DUALSEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sec))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sec)),)
 {
 	KEEP(*(.option_setting_banksel_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sel)),)
 {
 	KEEP(*(.option_setting_ofs1_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sel))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sel)),)
 {
 	KEEP(*(.option_setting_banksel_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sel))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sel)),)
 {
 	KEEP(*(.option_setting_bps_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra6m5/sections.ld
+++ b/soc/renesas/ra/ra6m5/sections.ld
@@ -6,69 +6,65 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_dualsel))
 SECTION_DATA_PROLOGUE(.option_setting_dualsel, DT_REG_ADDR(DT_NODELABEL(option_setting_dualsel)),)
 {
 	KEEP(*(.option_setting_dualsel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_DUALSEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sec))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sec)),)
 {
 	KEEP(*(.option_setting_banksel_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sel)),)
 {
 	KEEP(*(.option_setting_ofs1_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sel))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sel)),)
 {
 	KEEP(*(.option_setting_banksel_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sel))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sel)),)
 {
 	KEEP(*(.option_setting_bps_sel))
-} GROUP_LINK_IN(OFS_CONF_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf */

--- a/soc/renesas/ra/ra8d1/sections.ld
+++ b/soc/renesas/ra/ra8d1/sections.ld
@@ -6,76 +6,72 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_cf_sec))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs2))
 SECTION_DATA_PROLOGUE(.option_setting_ofs2, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs2)),)
 {
 	KEEP(*(.option_setting_ofs2))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS2_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_dualsel))
 SECTION_DATA_PROLOGUE(.option_setting_dualsel, DT_REG_ADDR(DT_NODELABEL(option_setting_dualsel)),)
 {
 	KEEP(*(.option_setting_dualsel))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_DUALSEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sec))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sec)),)
 {
 	KEEP(*(.option_setting_banksel_sec))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sel)),)
 {
 	KEEP(*(.option_setting_ofs1_sel))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sel))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sel)),)
 {
 	KEEP(*(.option_setting_banksel_sel))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sel))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sel)),)
 {
 	KEEP(*(.option_setting_bps_sel))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_cf_sec */

--- a/soc/renesas/ra/ra8m1/sections.ld
+++ b/soc/renesas/ra/ra8m1/sections.ld
@@ -6,76 +6,72 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_cf_sec))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs2))
 SECTION_DATA_PROLOGUE(.option_setting_ofs2, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs2)),)
 {
 	KEEP(*(.option_setting_ofs2))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS2_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_dualsel))
 SECTION_DATA_PROLOGUE(.option_setting_dualsel, DT_REG_ADDR(DT_NODELABEL(option_setting_dualsel)),)
 {
 	KEEP(*(.option_setting_dualsel))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_DUALSEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sec))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sec)),)
 {
 	KEEP(*(.option_setting_banksel_sec))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sel)),)
 {
 	KEEP(*(.option_setting_ofs1_sel))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sel))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sel)),)
 {
 	KEEP(*(.option_setting_banksel_sel))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sel))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sel)),)
 {
 	KEEP(*(.option_setting_bps_sel))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_cf_sec */

--- a/soc/renesas/ra/ra8p1/sections.ld
+++ b/soc/renesas/ra/ra8p1/sections.ld
@@ -6,73 +6,65 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_conf_sec))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CONF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs2))
 SECTION_DATA_PROLOGUE(.option_setting_ofs2, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs2)),)
 {
 	KEEP(*(.option_setting_ofs2))
-} GROUP_LINK_IN(OFS_CONF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS2_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
 SECTION_DATA_PROLOGUE(.option_setting_sas, DT_REG_ADDR(DT_NODELABEL(option_setting_sas)),)
 {
 	KEEP(*(.option_setting_sas))
-} GROUP_LINK_IN(OFS_CONF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_SAS_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CONF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs3_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs3_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs3_sec)),)
 {
 	KEEP(*(.option_setting_ofs3_sec))
-} GROUP_LINK_IN(OFS_CONF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS3_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sel)),)
 {
 	KEEP(*(.option_setting_ofs1_sel))
-} GROUP_LINK_IN(OFS_CONF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs3_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs3_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs3_sel)),)
 {
 	KEEP(*(.option_setting_ofs3_sel))
-} GROUP_LINK_IN(OFS_CONF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS3_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CONF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf_sec */
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_otp_sec))
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_otp_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_otp_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_otp_pbps_sec)),)
 {
 	KEEP(*(.option_setting_otp_pbps_sec))
-} GROUP_LINK_IN(OFS_OTP_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OTP_PBPS_SEC_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_conf_sec */

--- a/soc/renesas/ra/ra8t1/sections.ld
+++ b/soc/renesas/ra/ra8t1/sections.ld
@@ -6,76 +6,72 @@
 
 #include <zephyr/devicetree.h>
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs_cf_sec))
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
 	KEEP(*(.option_setting_ofs0))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS0_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs2))
 SECTION_DATA_PROLOGUE(.option_setting_ofs2, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs2)),)
 {
 	KEEP(*(.option_setting_ofs2))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS2_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_dualsel))
 SECTION_DATA_PROLOGUE(.option_setting_dualsel, DT_REG_ADDR(DT_NODELABEL(option_setting_dualsel)),)
 {
 	KEEP(*(.option_setting_dualsel))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_DUALSEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sec))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sec)),)
 {
 	KEEP(*(.option_setting_ofs1_sec))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sec))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sec)),)
 {
 	KEEP(*(.option_setting_banksel_sec))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sec)),)
 {
 	KEEP(*(.option_setting_bps_sec))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_pbps_sec))
 SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_setting_pbps_sec)),)
 {
 	KEEP(*(.option_setting_pbps_sec))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs1_sel))
 SECTION_DATA_PROLOGUE(.option_setting_ofs1_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1_sel)),)
 {
 	KEEP(*(.option_setting_ofs1_sel))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_OFS1_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_banksel_sel))
 SECTION_DATA_PROLOGUE(.option_setting_banksel_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_banksel_sel)),)
 {
 	KEEP(*(.option_setting_banksel_sel))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BANKSEL_SEL_MEMORY)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_bps_sel))
 SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_setting_bps_sel)),)
 {
 	KEEP(*(.option_setting_bps_sel))
-} GROUP_LINK_IN(OFS_CF_SEC_MEMORY)
+} GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
 #endif
-
-#endif /* option_setting_ofs_cf_sec */


### PR DESCRIPTION
Create separate memory regions for each OFS register.
With a single region the linker will gap fill the load segment with zeros between each option setting section that gets placed in the region when generating the .elf file.

This fixes a regression introduced in https://github.com/zephyrproject-rtos/zephyr/pull/93137, which can result in writing zeros to any areas of the OFS that aren't explicitly set when flashing the elf file, potentially permanently lock the flash.


An example seen on the RA6M4

```
> readelf -l build/zephyr/zephyr.elf

Elf file type is EXEC (Executable file)
Entry point 0x70e1
There are 7 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  EXIDX          0x013248 0x00013130 0x00013130 0x00008 0x00008 R   0x4
  LOAD           0x000118 0x00000000 0x00000000 0x1b7e4 0x1b7e4 RWE 0x8
  LOAD           0x01b900 0x20000000 0x0001b7e4 0x01208 0x01208 RWE 0x8
  LOAD           0x01cb08 0x0001c9ec 0x0001c9ec 0x00004 0x00004 RW  0x4
  LOAD           0x01cb0c 0x0100a100 0x0100a100 0x001cc 0x001cc R   0x4
  LOAD           0x000000 0x20001208 0x20001208 0x00000 0x04510 RW  0x8
  TLS            0x0143e8 0x000142d0 0x000142d0 0x00000 0x0002c R   0x4

 Section to Segment mapping:
  Segment Sections...
   00     .ARM.exidx
   01     rom_start text .ARM.exidx initlevel device_area sw_isr_table _static_thread_data_area adc_driver_api_area flash_driver_api_area gpio_driver_api_area i2c_driver_api_area led_driver_api_area pwm_driver_api_area rtc_driver_api_area sensor_driver_api_area spi_driver_api_area bbram_driver_api_area clock_control_driver_api_area regulator_driver_api_area uart_driver_api_area input_callback_area shell_area shell_root_cmds_area shell_subcmds_area shell_dynamic_subcmds_area cfb_font_area rodata
   02     .ramfunc datas device_states pm_device_slots_area k_heap_area k_msgq_area k_event_area
   03     .last_section
   04     .option_setting_ofs0 .option_setting_dualsel .option_setting_ofs1_sec .option_setting_banksel_sec .option_setting_bps_sec .option_setting_pbps_sec .option_setting_ofs1_sel .option_setting_banksel_sel .option_setting_bps_sel
   05     bss noinit
   06     tbss
```

load segment 4 will write 0x1cc byes to the OFS at 0x0100a100, the contents of which are:

```
> hexdump -s 0x01cb0c -n 0x1cc -C build/zephyr/zephyr.elf
0001cb0c  ff ff ff ff 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
0001cb2c  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
0001cc0c  ff fd ff ff 00 00 00 00  00 00 00 00 00 00 00 00  |................|
0001cc1c  ff ff ff ff 00 00 00 00  00 00 00 00 00 00 00 00  |................|
0001cc2c  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
0001cc4c  ff ff ff ff ff ff ff ff  ff ff ff ff 00 00 00 00  |................|
0001cc5c  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
0001cc6c  ff ff ff ff ff ff ff ff  ff ff ff ff 00 00 00 00  |................|
0001cc7c  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
0001cc8c  f8 f8 ff ff 00 00 00 00  00 00 00 00 00 00 00 00  |................|
0001cc9c  ff ff ff ff 00 00 00 00  00 00 00 00 00 00 00 00  |................|
0001ccac  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
0001cccc  ff ff ff ff ff ff ff ff  ff ff ff ff              |............|
0001ccd8
```