### PR TITLE
boards: mimxrt1010_evk: doc: fix debug connector number

### DIFF
--- a/boards/nxp/mimxrt1010_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1010_evk/doc/index.rst
@@ -141,7 +141,7 @@ Configuring a Debug Probe
 =========================
 
 For the RT1010, J61/J62 are the SWD isolation jumpers, J22 is the DFU
-mode jumper, and J16 is the 10 pin JTAG/SWD header.
+mode jumper, and J55 is the 10 pin JTAG/SWD header.
 
 .. include:: ../../common/rt1xxx-lpclink2-debug.rst
    :start-after: rt1xxx-lpclink2-probes


### PR DESCRIPTION
The debug connector designation for JTAG/SWD is J55. J16 is for OPENSDA
"OPENDBG INTERFACE JTAG CONNECTOR"

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/94981#issuecomment-3228518928