### PR TITLE
drivers: gpio: silabs: Support EM4 wakeup interrupts

### DIFF
--- a/dts/arm/silabs/xg21/xg21.dtsi
+++ b/dts/arm/silabs/xg21/xg21.dtsi
@@ -351,6 +351,8 @@
 				reg = <0x5003c000 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <0>;
+				silabs,wakeup-pins = <5>;
 				status = "disabled";
 			};
 
@@ -359,6 +361,8 @@
 				reg = <0x5003c030 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <3>;
+				silabs,wakeup-pins = <1>;
 				status = "disabled";
 			};
 
@@ -367,6 +371,8 @@
 				reg = <0x5003c060 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <6>, <7>;
+				silabs,wakeup-pins = <0>, <5>;
 				status = "disabled";
 			};
 
@@ -375,6 +381,8 @@
 				reg = <0x5003c090 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <9>;
+				silabs,wakeup-pins = <2>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/silabs/xg22/xg22.dtsi
+++ b/dts/arm/silabs/xg22/xg22.dtsi
@@ -129,7 +129,7 @@
 			 * The minimum residency and exit latency is
 			 * managed by sl_power_manager on S2 devices.
 			 */
-			cpu-power-states = <&pstate_em1 &pstate_em2>;
+			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -157,6 +157,16 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
+			};
+
+			/*
+			 * EM4 is a shutdown state where all clocks are off. The device
+			 * is reset on wakeup from EM4.
+			 */
+			pstate_em4: em4 {
+				compatible = "zephyr,power-state";
+				power-state-name = "soft-off";
+				status = "disabled";
 			};
 		};
 	};
@@ -403,6 +413,8 @@
 				reg = <0x5003C000 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <0>;
+				silabs,wakeup-pins = <5>;
 				status = "disabled";
 			};
 
@@ -411,6 +423,8 @@
 				reg = <0x5003C030 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <3>, <4>;
+				silabs,wakeup-pins = <1>, <3>;
 				status = "disabled";
 			};
 
@@ -419,6 +433,8 @@
 				reg = <0x5003C060 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <6>, <7>, <8>;
+				silabs,wakeup-pins = <0>, <5>, <7>;
 				status = "disabled";
 			};
 
@@ -427,6 +443,8 @@
 				reg = <0x5003C090 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <9>;
+				silabs,wakeup-pins = <2>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/silabs/xg23/xg23.dtsi
+++ b/dts/arm/silabs/xg23/xg23.dtsi
@@ -149,7 +149,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&pstate_em1 &pstate_em2>;
+			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
 			/*
 			 * The minimum residency and exit latency is
 			 * managed by sl_power_manager on S2 devices.
@@ -181,6 +181,16 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
+			};
+
+			/*
+			 * EM4 is a shutdown state where all clocks are off. The device
+			 * is reset on wakeup from EM4.
+			 */
+			pstate_em4: em4 {
+				compatible = "zephyr,power-state";
+				power-state-name = "soft-off";
+				status = "disabled";
 			};
 		};
 	};
@@ -461,6 +471,8 @@
 				reg = <0x5003c030 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <0>;
+				silabs,wakeup-pins = <5>;
 				status = "disabled";
 			};
 
@@ -469,6 +481,8 @@
 				reg = <0x5003c060 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <3>, <4>;
+				silabs,wakeup-pins = <1>, <3>;
 				status = "disabled";
 			};
 
@@ -477,6 +491,8 @@
 				reg = <0x5003c090 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <6>, <7>, <8>;
+				silabs,wakeup-pins = <0>, <5>, <7>;
 				status = "disabled";
 			};
 
@@ -485,6 +501,8 @@
 				reg = <0x5003c0C0 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <9>, <10>;
+				silabs,wakeup-pins = <2>, <5>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/silabs/xg24/xg24.dtsi
+++ b/dts/arm/silabs/xg24/xg24.dtsi
@@ -139,7 +139,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&pstate_em1 &pstate_em2>;
+			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
 			/*
 			 * The minimum residency and exit latency is
 			 * managed by sl_power_manager on S2 devices.
@@ -171,6 +171,16 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
+			};
+
+			/*
+			 * EM4 is a shutdown state where all clocks are off. The device
+			 * is reset on wakeup from EM4.
+			 */
+			pstate_em4: em4 {
+				compatible = "zephyr,power-state";
+				power-state-name = "soft-off";
+				status = "disabled";
 			};
 		};
 	};
@@ -431,6 +441,8 @@
 				reg = <0x5003c030 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <0>;
+				silabs,wakeup-pins = <5>;
 				status = "disabled";
 			};
 
@@ -439,6 +451,8 @@
 				reg = <0x5003c060 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <3>, <4>;
+				silabs,wakeup-pins = <1>, <3>;
 				status = "disabled";
 			};
 
@@ -447,6 +461,8 @@
 				reg = <0x5003c090 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <6>, <7>, <8>;
+				silabs,wakeup-pins = <0>, <5>, <7>;
 				status = "disabled";
 			};
 
@@ -455,6 +471,8 @@
 				reg = <0x5003c0C0 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <9>, <10>;
+				silabs,wakeup-pins = <2>, <5>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/silabs/xg27/xg27.dtsi
+++ b/dts/arm/silabs/xg27/xg27.dtsi
@@ -138,7 +138,7 @@
 			 * The minimum residency and exit latency is
 			 * managed by sl_power_manager on S2 devices.
 			 */
-			cpu-power-states = <&pstate_em1 &pstate_em2>;
+			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -166,6 +166,16 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
+			};
+
+			/*
+			 * EM4 is a shutdown state where all clocks are off. The device
+			 * is reset on wakeup from EM4.
+			 */
+			pstate_em4: em4 {
+				compatible = "zephyr,power-state";
+				power-state-name = "soft-off";
+				status = "disabled";
 			};
 		};
 	};
@@ -412,6 +422,8 @@
 				reg = <0x5003C030 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <0>;
+				silabs,wakeup-pins = <5>;
 				status = "disabled";
 			};
 
@@ -420,6 +432,8 @@
 				reg = <0x5003C060 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <3>, <4>;
+				silabs,wakeup-pins = <1>, <3>;
 				status = "disabled";
 			};
 
@@ -428,6 +442,8 @@
 				reg = <0x5003C090 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <6>, <7>, <8>;
+				silabs,wakeup-pins = <0>, <5>, <7>;
 				status = "disabled";
 			};
 
@@ -436,6 +452,8 @@
 				reg = <0x5003C0C0 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <9>;
+				silabs,wakeup-pins = <2>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/silabs/xg28/xg28.dtsi
+++ b/dts/arm/silabs/xg28/xg28.dtsi
@@ -170,7 +170,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&pstate_em1 &pstate_em2>;
+			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
 			/*
 			 * The minimum residency and exit latency is
 			 * managed by sl_power_manager on S2 devices.
@@ -195,6 +195,16 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
+			};
+
+			/*
+			 * EM4 is a shutdown state where all clocks are off. The device
+			 * is reset on wakeup from EM4.
+			 */
+			pstate_em4: em4 {
+				compatible = "zephyr,power-state";
+				power-state-name = "soft-off";
+				status = "disabled";
 			};
 		};
 	};
@@ -475,6 +485,8 @@
 				reg = <0x5003c030 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <0>;
+				silabs,wakeup-pins = <5>;
 				status = "disabled";
 			};
 
@@ -483,6 +495,8 @@
 				reg = <0x5003c060 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <3>, <4>;
+				silabs,wakeup-pins = <1>, <3>;
 				status = "disabled";
 			};
 
@@ -491,6 +505,8 @@
 				reg = <0x5003c090 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <6>, <7>, <8>;
+				silabs,wakeup-pins = <0>, <5>, <7>;
 				status = "disabled";
 			};
 
@@ -499,6 +515,8 @@
 				reg = <0x5003c0c0 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <9>, <10>;
+				silabs,wakeup-pins = <2>, <5>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -146,7 +146,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&pstate_em1 &pstate_em2>;
+			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
 			/*
 			 * The minimum residency and exit latency is
 			 * managed by sl_power_manager on S2 devices.
@@ -178,6 +178,16 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
+			};
+
+			/*
+			 * EM4 is a shutdown state where all clocks are off. The device
+			 * is reset on wakeup from EM4.
+			 */
+			pstate_em4: em4 {
+				compatible = "zephyr,power-state";
+				power-state-name = "soft-off";
+				status = "disabled";
 			};
 		};
 	};
@@ -293,6 +303,8 @@
 				reg = <0x5003C030 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <0>;
+				silabs,wakeup-pins = <5>;
 				status = "disabled";
 			};
 
@@ -301,6 +313,8 @@
 				reg = <0x5003C060 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <3>, <4>;
+				silabs,wakeup-pins = <1>, <3>;
 				status = "disabled";
 			};
 
@@ -309,6 +323,8 @@
 				reg = <0x5003C090 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <6>, <7>, <8>;
+				silabs,wakeup-pins = <0>, <5>, <7>;
 				status = "disabled";
 			};
 
@@ -317,6 +333,8 @@
 				reg = <0x5003C0C0 0x30>;
 				gpio-controller;
 				#gpio-cells = <2>;
+				silabs,wakeup-ints = <9>;
+				silabs,wakeup-pins = <2>;
 				status = "disabled";
 			};
 		};

--- a/dts/bindings/gpio/silabs,gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,gpio-port.yaml
@@ -14,6 +14,18 @@ properties:
   "#gpio-cells":
     const: 2
 
+  silabs,wakeup-ints:
+    type: array
+    description: |
+      List of EM4 wakeup interrupt numbers for this port. The corresponding entry
+      in `silabs,wakeup-pins` indicates the pin associated with the interrupt number.
+
+  silabs,wakeup-pins:
+    type: array
+    description: |
+      List of EM4 wakeup capable pins for this port. The corresponding entry in
+      `silabs,wakeup-ints` indicates the interrupt number associated with the pin.
+
 gpio-cells:
   - pin
   - flags


### PR DESCRIPTION
EM4 wakeup interrupts are dedicated interrupts tied to specific pins that enable wakeup from EM4 through reset. Add support for using these interrupts instead of the regular interrupts when the GPIO_INT_TRIG_WAKE flag is set.

Since it's not possible to tell what pin is associated with what EM4WU interrupt at runtime, the driver must store a mapping table sourced from device tree. Add this mapping to the device tree.

Also add EM4 as a `soft-off` power state that is disabled by default. Marking it as disabled allows users to enter it with `pm_state_force()`, while preventing the power management subsystem from selecting the state automatically.