### PR TITLE
subsys: modem: add macro MODEM_CHAT_MATCH_WILDCARD_DEFINE

### DIFF
--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -82,6 +82,10 @@ struct modem_chat_match {
 #define MODEM_CHAT_MATCH_DEFINE(_sym, _match, _separators, _callback)                              \
 	const static struct modem_chat_match _sym = MODEM_CHAT_MATCH(_match, _separators, _callback)
 
+#define MODEM_CHAT_MATCH_WILDCARD_DEFINE(_sym, _match, _separators, _callback)                     \
+	const static struct modem_chat_match _sym =                                                \
+		MODEM_CHAT_MATCH_WILDCARD(_match, _separators, _callback)
+
 /* Helper struct to match any response without callback. */
 extern const struct modem_chat_match modem_chat_any_match;
 


### PR DESCRIPTION
subsys: modem:

Add a macro `MODEM_CHAT_MATCH_WILDCARD_DEFINE`, it's complementary to `MODEM_CHAT_MATCH_DEFINE`

Example:
```
MODEM_CHAT_MATCH_DEFINE(ok_match, "OK", "", NULL); MODEM_CHAT_MATCH_WILDCARD_DEFINE(version_match, "\"?.?.?-???\"", "", ublox_match_sw_version_callback);

MODEM_CHAT_SCRIPT_CMDS_DEFINE(script_cmds,
                            MODEM_CHAT_SCRIPT_CMD_RESP("AT", ok_match),
                            MODEM_CHAT_SCRIPT_CMD_RESP("AT+VER?", version_match),
                         );
```
Old PR for ref: https://github.com/zephyrproject-rtos/zephyr/pull/94992

Signed-off-by: James Wu wu.zhuhua@gmail.com