### PR TITLE
dts: arm: st: n6: correct sai1_a address

### DIFF
--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1231,7 +1231,7 @@
 			status = "disabled";
 		};
 
-		sai1_a: sai1@452005804 {
+		sai1_a: sai1@52005804 {
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
When compiling, the following warning occurs:

Warning (simple_bus_reg): /soc/sai1@452005804: simple-bus unit address format error, expected "52005804"

Looking at table 3 in the reference manual[1] for the stm32n6 it seems that the sai1_a address simply had a typo, where a "4" was added in front of the correct address.

Fix the typo.

[1] RM0486 Rev 2: https://www.st.com/resource/en/reference_manual/rm0486-stm32n647657xx-armbased-32bit-mcus-stmicroelectronics.pdf