### PR TITLE
Add support MBOX driver for Renesas RZ/V2L

### DIFF
--- a/boards/renesas/rzg3s_smarc/doc/index.rst
+++ b/boards/renesas/rzg3s_smarc/doc/index.rst
@@ -48,6 +48,8 @@ The Renesas RZ/G3S MPU documentation can be found at `RZ/G3S Group Website`_
 
 	RZ/G3S block diagram (Credit: Renesas Electronics Corporation)
 
+Detailed hardware features for the board can be found at `RZG3S-EVKIT Website`_
+
 Multi-OS processing
 *******************
 
@@ -241,10 +243,10 @@ References
 .. target-notes::
 
 .. _RZ/G3S Group Website:
-   https://www.renesas.com/us/en/products/microcontrollers-microprocessors/rz-mpus/rzg3s-general-purpose-microprocessors-single-core-arm-cortex-a55-11-ghz-cpu-and-dual-core-cortex-m33-250
+   https://www.renesas.com/en/products/rz-g3s
 
 .. _RZG3S-EVKIT Website:
-   https://www.renesas.com/us/en/products/microcontrollers-microprocessors/rz-mpus/rzg3s-evkit-evaluation-board-kit-rzg3s-mpu
+   https://www.renesas.com/en/design-resources/boards-kits/rz-g3s-evkit
 
 .. _SMARC EVK of RZ/G3S Linux Start-up Guide:
-   https://www.renesas.com/us/en/document/gde/smarc-evk-rzg3s-linux-start-guide-rev104
+   https://www.renesas.com/en/document/gde/smarc-evk-rzg3s-linux-start-guide-rev106

--- a/boards/renesas/rzv2l_smarc/doc/index.rst
+++ b/boards/renesas/rzv2l_smarc/doc/index.rst
@@ -49,6 +49,13 @@ The Renesas RZ/V2L MPU documentation can be found at `RZ/V2L Group Website`_
 
 Detailed hardware features for the board can be found at `RZV2L-EVKIT Website`_
 
+Multi-OS processing
+*******************
+
+The RZ/V2L-EVKIT allows different applications to be executed in RZ/V2L SoC. With its multi-core architecture,
+each core can operate independently to perform customized tasks or exchange data using the OpenAMP framework.
+Please see :zephyr:code-sample:`rz-openamp-linux-zephyr` sample for reference.
+
 Supported Features
 ==================
 
@@ -92,14 +99,15 @@ to run Zephyr on Cortex-M33 with u-boot. The minimal steps are described below.
 1. Follow ''2.2 Building Images'' of `SMARC EVK of RZ/V2L Linux Start-up Guide`_ to prepare the build environment.
 
 2. At step (4), follow step ''2. Download Multi-OS Package'' and ''3. Add the layer for Multi-OS Package''
-   of ''3.2 OpenAMP related stuff Integration for RZ/V2L'' of `RZ/V2L Quick Start Guide for RZ/V Multi-OS Package`_
+   of ''3.2 Integration of OpenAMP related stuff'' of `RZ/V2L Quick Start Guide for RZ/V Multi-OS Package`_
    to add the layer for Multi-OS Package.
 
 .. code-block:: console
 
    $ cd ~/rzv_vlp_<pkg ver>
-   $ unzip <Multi-OS Dir>/r01an7254ej0300-rzv-multi-os-pkg.zip
-   $ tar zxvf r01an7254ej0300-rzv-multi-os-pkg/meta-rz-features_multi-os_v3.0.0.tar.gz
+   $ unzip <Multi-OS Dir>/r01an7254ej0311-rzv-multi-os-pkg.zip
+   $ tar zxvf r01an7254ej0311-rzv-multi-os-pkg/meta-rz-features_multi-os_v3.1.1.tar.gz
+   $ cd build
    $ bitbake-layers add-layer ../meta-rz-features/meta-rz-multi-os/meta-rzv2l
 
 3. Start the build:
@@ -155,13 +163,13 @@ References
 .. target-notes::
 
 .. _RZ/V2L Group Website:
-   https://www.renesas.com/en/products/microcontrollers-microprocessors/rz-mpus/rzv2l-general-purpose-microprocessor-equipped-renesas-original-ai-accelerator-drp-ai-12ghz-dual-core-arm
+   https://www.renesas.com/en/products/rz-v2l
 
 .. _RZV2L-EVKIT Website:
-   https://www.renesas.com/en/products/microcontrollers-microprocessors/rz-mpus/rzv2l-evkit-smarc-som-evaluation-kit-rzv2l-mpu-ai-accelerator
+   https://www.renesas.com/en/design-resources/boards-kits/rz-v2l-evkit
 
 .. _SMARC EVK of RZ/V2L Linux Start-up Guide:
-   https://www.renesas.com/en/document/gde/smarc-evk-rzv2l-linux-start-guide-rev104
+   https://www.renesas.com/en/document/gde/rzv2l-linux-start-guide-rev105
 
 .. _RZ/V2L Quick Start Guide for RZ/V Multi-OS Package:
-   https://www.renesas.com/en/document/apn/rzv2l-quick-start-guide-rzv-multi-os-package-v300
+   https://www.renesas.com/en/document/apn/rzv2l-quick-start-guide-rzv-multi-os-package-v311

--- a/boards/renesas/rzv2l_smarc/rzv2l_smarc_r9a07g054l23gbg_cm33.yaml
+++ b/boards/renesas/rzv2l_smarc/rzv2l_smarc_r9a07g054l23gbg_cm33.yaml
@@ -11,4 +11,5 @@ supported:
   - pwm
   - adc
   - i2c
+  - mbox
 vendor: renesas

--- a/dts/arm/renesas/rz/rzv/r9a07g054.dtsi
+++ b/dts/arm/renesas/rz/rzv/r9a07g054.dtsi
@@ -827,6 +827,62 @@
 			interrupt-names = "rxi", "txi", "tei", "naki", "spi", "sti", "ali", "tmoi";
 			status = "disabled";
 		};
+
+		/* CA55_0 <-> CM33 */
+		mbox1: mhu@40400020 {
+			compatible = "renesas,rz-mhu-mbox";
+			channel = <1>;
+			reg = <0x40400020 0x20>;
+			tx-mask = <0x00000002>; /* Channel 1 is for TX */
+			rx-mask = <0x00000001>; /* Channel 0 is for RX */
+			channels-count = <2>;
+			interrupts = <69 2>;
+			interrupt-names = "mhuns";
+			#mbox-cells = <1>;
+			status = "disabled";
+		};
+
+		/* CA55_1 <-> CM33 */
+		mbox3: mhu@40400060 {
+			compatible = "renesas,rz-mhu-mbox";
+			channel = <3>;
+			reg = <0x40400060 0x20>;
+			tx-mask = <0x00000002>; /* Channel 1 is for TX */
+			rx-mask = <0x00000001>; /* Channel 0 is for RX */
+			channels-count = <2>;
+			interrupts = <71 2>;
+			interrupt-names = "mhuns";
+			#mbox-cells = <1>;
+			status = "disabled";
+		};
+
+		/* CM33 <-> CA55_0 */
+		mbox4: mhu@40400080 {
+			compatible = "renesas,rz-mhu-mbox";
+			channel = <4>;
+			reg = <0x40400080 0x20>;
+			tx-mask = <0x00000002>; /* Channel 1 is for TX */
+			rx-mask = <0x00000001>; /* Channel 0 is for RX */
+			channels-count = <2>;
+			interrupts = <78 2>;
+			interrupt-names = "mhuns";
+			#mbox-cells = <1>;
+			status = "disabled";
+		};
+
+		/* CM33 <-> CA55_1 */
+		mbox5: mhu@404000a0 {
+			compatible = "renesas,rz-mhu-mbox";
+			channel = <5>;
+			reg = <0x404000a0 0x20>;
+			tx-mask = <0x00000002>; /* Channel 1 is for TX */
+			rx-mask = <0x00000001>; /* Channel 0 is for RX */
+			channels-count = <2>;
+			interrupts = <79 2>;
+			interrupt-names = "mhuns";
+			#mbox-cells = <1>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/samples/boards/renesas/openamp_linux_zephyr/README.rst
+++ b/samples/boards/renesas/openamp_linux_zephyr/README.rst
@@ -20,7 +20,8 @@ Building the application
 Zephyr
 ======
 
-Build command:
+Build command for RZ/G3S-SMARC
+------------------------------
 
 .. zephyr-app-commands::
    :zephyr-app: samples/boards/renesas/openamp_linux_zephyr
@@ -28,18 +29,30 @@ Build command:
    :goals: build
    :compact:
 
+Build command for RZ/V2L-SMARC
+------------------------------
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/renesas/openamp_linux_zephyr
+   :board: rzv2l_smarc/r9a07g054l23gbg/cm33
+   :goals: build
+   :compact:
+
 Running the sample
-*************************
+******************
 
 Linux setup
 ===========
 
-The sample currently supports the Linux RZ/G Multi-OS Package V2.2.0. The build steps for Renesas Multi-OS Package V2.2.0 are described below.
+For RZ/G3S-SMARC
+----------------
 
-1. Follow the procedures in ''3.Multi-OS Package Setup'' of `Release Note for RZ/G Multi-OS Package V2.2.0 <https://www.renesas.com/en/document/rln/release-note-rzg-multi-os-package-v220?r=1522841>`_
+The sample currently supports the Linux RZ/G Multi-OS Package v3.0.0. The build steps for Renesas Multi-OS Package are described below.
+
+1. Follow the procedures in ''3.2 Integration of Multi-OS Package related stuff'' of `Quick Start Guide for RZ/G3S Multi-OS Package`_
    without initiating the build process.
-2. For RZ/G3S, add ``PLAT_M33_BOOT_SUPPORT=1`` by following this guide:
-   `RZ/G3S SMARC Evaluation Board Kit <https://docs.zephyrproject.org/latest/boards/renesas/rzg3s_smarc/doc/index.html#programming-and-debugging>`_
+
+2. For RZ/G3S, add ``PLAT_M33_BOOT_SUPPORT=1`` by following this guide: `RZ/G3S SMARC Evaluation Board Kit`_
 
 3. Insert the highlighted lines of code into the following file: meta-rz-features/meta-rz-multi-os/meta-rzg3s/recipes-example/rpmsg-sample/files/platform_info.c
 
@@ -63,12 +76,44 @@ The sample currently supports the Linux RZ/G Multi-OS Package V2.2.0. The build 
 
 4. Start the build.
 
-5. For deploying bootloader files, Linux kernel image, device tree and rootfs, follow the procedures in ''3.5.1 In case of configuring CA55 as Boot CPU'' of `Release Note for RZ/G Multi-OS Package V2.2.0 <https://www.renesas.com/en/document/rln/release-note-rzg-multi-os-package-v220?r=1522841>`_
+5. For deploying bootloader files, Linux kernel image, device tree and rootfs, please refer to: `SMARC EVK of RZ/G3S Linux Start-up Guide`_
+
+For RZ/V2L-SMARC
+----------------
+
+The sample currently supports the Linux RZ/V Multi-OS Package v3.1.1. The build steps for Renesas Multi-OS Package are described below.
+
+1. Follow the steps (1) and (2) from the ''Flashing'' section of `RZ/V2L SMARC Evaluation Board Kit`_
+
+2. Insert the highlighted lines of code into the following file: meta-rz-features/meta-rz-multi-os/meta-rzv2l/recipes-example/rpmsg-sample/files/platform_info.c
+
+   .. code-block:: c
+      :emphasize-lines: 5,6,7,8,9,10
+
+      if (ret) {
+      LPRINTF("failed rpmsg_init_vdev");
+      goto err;
+      }
+      /* RPMsg virtio enables callback for avail flags */
+      ret = virtqueue_enable_cb(rpmsg_vdev->rvq);
+      if (ret) {
+         LPRINTF("Failed release availability flags");
+         goto err;
+      }
+      #ifndef __linux__ /* uC3 */
+      start_ipi_task(rproc);
+      #endif
+      return rpmsg_virtio_get_rpmsg_device(rpmsg_vdev);
+
+3. Start the build.
+
+4. For deploying bootloader files, Linux kernel image, device tree and rootfs, follow the steps (4) to (8) from the ''Flashing'' section of
+`RZ/V2L SMARC Evaluation Board Kit`_
 
 Zephyr setup
 ============
 
-1. Flash the sample to the board.
+1. Flash the sample to the board by following the ''Flashing'' instructions for your board.
 
 2. Open a serial terminal (minicom, putty, etc.) and connect to the board with the following
    settings:
@@ -173,3 +218,20 @@ The following message will appear on the Zephyr console.
       I: OpenAMP[remote] Linux sample client responder started
       I: OpenAMP demo ended
       I: OpenAMP Linux sample client responder ended
+
+References
+**********
+
+.. target-notes::
+
+.. _Quick Start Guide for RZ/G3S Multi-OS Package:
+   https://www.renesas.com/en/document/qsg/quick-start-guide-rzg3s-multi-os-package
+
+.. _RZ/G3S SMARC Evaluation Board Kit:
+   https://docs.zephyrproject.org/latest/boards/renesas/rzg3s_smarc/doc/index.html#programming-and-debugging
+
+.. _SMARC EVK of RZ/G3S Linux Start-up Guide:
+   https://www.renesas.com/en/document/gde/smarc-evk-rzg3s-linux-start-guide-rev106
+
+.. _RZ/V2L SMARC Evaluation Board Kit:
+   https://docs.zephyrproject.org/latest/boards/renesas/rzv2l_smarc/doc/index.html#flashing

--- a/samples/boards/renesas/openamp_linux_zephyr/boards/rzv2l_smarc_r9a07g054l23gbg_cm33.overlay
+++ b/samples/boards/renesas/openamp_linux_zephyr/boards/rzv2l_smarc_r9a07g054l23gbg_cm33.overlay
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/*
+	 * Allocating whole openamp region as reserved memory
+	 * to save MPU entries
+	 */
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		openamp_shm: memory-region@62F00000 {
+			compatible = "zephyr,memory-region";
+			reg = <0x62F00000 0x900000>;
+			zephyr,memory-region = "openamp_memory";
+			zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
+		};
+	};
+
+	chosen {
+		zephyr,ipc_shm = &vring_shm0;
+		zephyr,ipc = &mbox_consumer;
+	};
+
+	vring_ctrl0: memory@63000000 {
+		compatible = "mmio-sram";
+		reg = <0x63000000 0x50000>;
+	};
+
+	vring_ctrl1: memory@63050000 {
+		compatible = "mmio-sram";
+		reg = <0x63050000 0x50000>;
+	};
+
+	vring_shm0: memory@63200000 {
+		compatible = "mmio-sram";
+		reg = <0x63200000 0x300000>;
+	};
+
+	rsctbl: memory@62F00000 {
+		compatible = "mmio-sram";
+		reg = <0x62F00000 0x1000>;
+	};
+
+	mhu1_shm: memory@62F01008 {
+		compatible = "mmio-sram";
+		reg = <0x62F01008 0x8>;
+	};
+
+	mhu3_shm: memory@62F01018 {
+		compatible = "mmio-sram";
+		reg = <0x62F01018 0x8>;
+	};
+
+	mhu4_shm: memory@62F01020 {
+		compatible = "mmio-sram";
+		reg = <0x62F01020 0x8>;
+	};
+
+	mhu5_shm: memory@62F01028 {
+		compatible = "mmio-sram";
+		reg = <0x62F01028 0x8>;
+	};
+
+	mbox_consumer: mbox-consumer {
+		compatible = "vnd,mbox-consumer";
+		mboxes = <&mbox1 1>, <&mbox1 0>;
+		mbox-names = "tx", "rx";
+	};
+
+};
+
+&mbox1 {
+	shared-memory = <&mhu1_shm>;
+	status = "okay";
+};

--- a/samples/boards/renesas/openamp_linux_zephyr/src/main_remote.c
+++ b/samples/boards/renesas/openamp_linux_zephyr/src/main_remote.c
@@ -122,7 +122,6 @@ static void new_service_cb(struct rpmsg_device *rdev, const char *name, uint32_t
 int mailbox_notify(void *priv, uint32_t id)
 {
 	ARG_UNUSED(priv);
-
 	mbox_send_dt(&tx_channel, NULL);
 	return 0;
 }
@@ -209,7 +208,6 @@ static void platform_deinit(void)
 static void cleanup_system(void)
 {
 	struct fw_resource_table *rsc_tbl = (struct fw_resource_table *)RSC_TABLE_ADDR;
-
 	rpmsg_deinit_vdev(&rvdev);
 	rproc_virtio_remove_vdev(rvdev.vdev);
 	/*
@@ -236,13 +234,6 @@ struct rpmsg_device *platform_create_rpmsg_vdev(unsigned int vdev_index, unsigne
 		return NULL;
 	}
 
-	/* Set gfeatures because they should be equal to dfeatures
-	 * when create_ept is called. As rproc_virtio_create_vdev
-	 * doesn't set them because its VIRTIO_DEVICE not DRIVER.
-	 * Assume the virtio driver support all remote features.
-	 */
-	virtio_set_features(vdev, 0x1);
-
 	/* wait master rpmsg init completion */
 	rproc_virtio_wait_remote_ready(vdev);
 
@@ -263,6 +254,13 @@ struct rpmsg_device *platform_create_rpmsg_vdev(unsigned int vdev_index, unsigne
 		LOG_ERR("failed to init vring 1");
 		goto failed;
 	}
+
+	/* Set gfeatures because they should be equal to dfeatures
+	 * when create_ept is called. As rproc_virtio_create_vdev
+	 * doesn't set them because its VIRTIO_DEVICE not DRIVER.
+	 * Assume the virtio driver support all remote features.
+	 */
+	virtio_set_features(vdev, 0x1);
 
 	rpmsg_virtio_init_shm_pool(&shpool, NULL, SHM_SIZE);
 	ret = rpmsg_init_vdev(&rvdev, vdev, ns_cb, shm_io, &shpool);

--- a/soc/renesas/rz/rzv2l/CMakeLists.txt
+++ b/soc/renesas/rz/rzv2l/CMakeLists.txt
@@ -6,3 +6,8 @@ zephyr_sources(soc.c)
 zephyr_include_directories(.)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
+
+zephyr_linker_sources_ifdef(CONFIG_OPENAMP
+  RODATA
+  resource_table.ld
+)

--- a/soc/renesas/rz/rzv2l/resource_table.ld
+++ b/soc/renesas/rz/rzv2l/resource_table.ld
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+KEEP(*(.resource_table*))

--- a/tests/drivers/mbox/mbox_error_cases/boards/rzv2l_smarc_r9a07g054l23gbg_cm33.overlay
+++ b/tests/drivers/mbox/mbox_error_cases/boards/rzv2l_smarc_r9a07g054l23gbg_cm33.overlay
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/*
+	 * Allocating whole openamp region as reserved memory
+	 * to save MPU entries
+	 */
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		openamp_shm: memory-region@62F00000 {
+			compatible = "zephyr,memory-region";
+			reg = <0x62F00000 0x900000>;
+			zephyr,memory-region = "openamp_memory";
+			zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
+		};
+	};
+
+	mhu1_shm: memory@62F01008 {
+		compatible = "mmio-sram";
+		reg = <0x62F01008 0x8>;
+	};
+
+	mhu3_shm: memory@62F01018 {
+		compatible = "mmio-sram";
+		reg = <0x62F01018 0x8>;
+	};
+
+	mhu4_shm: memory@62F01020 {
+		compatible = "mmio-sram";
+		reg = <0x62F01020 0x8>;
+	};
+
+	mhu5_shm: memory@62F01028 {
+		compatible = "mmio-sram";
+		reg = <0x62F01028 0x8>;
+	};
+
+	mbox-consumer {
+		compatible = "vnd,mbox-consumer";
+		mboxes = <&mbox1 1>, <&mbox1 4>, <&mbox3 0>, <&mbox3 3>;
+		mbox-names = "remote_valid", "remote_incorrect", "local_valid", "local_incorrect";
+	};
+
+};
+
+&mbox1 {
+	shared-memory = <&mhu1_shm>;
+	status = "okay";
+};
+
+&mbox3 {
+	shared-memory = <&mhu3_shm>;
+	status = "okay";
+};

--- a/west.yml
+++ b/west.yml
@@ -226,7 +226,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: 74c9186c0a01c53e320421bd0e8b85fc266f3260
+      revision: 6ff5c0662bc9ad4a126be28eab0addcb2454fe69
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Add support Mbox driver for Renesas RZ/V2L:

- Add device tree
- Add linker support for OpenAMP sample 
- Sample: support `samples/boards/renesas/openamp_linux_zephyr` sample
- Test: support `tests/drivers/mbox/mbox_error_cases` test


Besides that, this PR update document link for Renesas RZ/G3S

Need: https://github.com/zephyrproject-rtos/hal_renesas/pull/132 