### PR TITLE
drivers: spi: litex: litespi: flush pending irq before enable

### DIFF
--- a/drivers/spi/spi_litex_litespi.c
+++ b/drivers/spi/spi_litex_litespi.c
@@ -215,8 +215,8 @@ static int spi_litex_xfer(const struct device *dev, const struct spi_config *con
 
 #if SPI_LITEX_ANY_HAS_IRQ
 	if (SPI_LITEX_HAS_IRQ) {
-		litex_write8(BIT(0), dev_config->master_ev_enable_addr);
 		litex_write8(BIT(0), dev_config->master_ev_pending_addr);
+		litex_write8(BIT(0), dev_config->master_ev_enable_addr);
 
 		spi_litex_spi_do_tx(dev);
 


### PR DESCRIPTION
flush pending irq before enableing the irq.

In the litex soc, if an irq is not enabled, it will it can still be registered and will be pending
if it occurs, it will just not be send to the cpu
until the irq is enabled.

The litex bios uses the spi controller without irq support and therefore doesn't reset the irq pending register