### PR TITLE
twister: Solution two harness issue

### DIFF
--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -177,6 +177,9 @@ class TwisterConfigParser:
                 extracted_testsuite, v = extract_fields_from_arg_list(
                     {"CONF_FILE", "OVERLAY_CONFIG", "DTC_OVERLAY_FILE"}, v
                 )
+            elif k in ("harness", "harness_config"):
+                # Override common value with scenario value
+                d[k] = v
             if k in d:
                 if k == "filter":
                     d[k] = f"({d[k]}) and ({v})"
@@ -261,5 +264,4 @@ class TwisterConfigParser:
                         self.filename,
                         f"bad {kinfo['type']} value '{d[k]}' for key '{k}' in name '{name}'"
                     ) from None
-
         return d


### PR DESCRIPTION
Some test configuration could not be run because two harness are added to testplan. Each test configuration should contain only one harness and their configuration.
This commit override harness and their configuration using data from test suite rather than common area.

Observed for test scenarios:
* `samples/net/sockets/echo_server/sample.net.sockets.echo_server.nsos`
* `tests/drivers/spi/spi_loopback/drivers.spi.nrf54l_1mhz`
* `tests/drivers/spi/spi_loopback/drivers.spi.nrf54h_fast_2mhz`
* `tests/drivers/spi/spi_loopback/drivers.spi.nrf54lm20_16mhz_32mhz`