### PR TITLE
drivers: i3c: Correct initialization order by setting controller info…

### DIFF
--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -2373,14 +2373,17 @@ static int dw_i3c_init(const struct device *dev)
 	if (ret != 0) {
 		return ret;
 	}
-#endif /* CONFIG_I3C_CONTROLLER */
-	dw_i3c_enable_controller(config, true);
-#ifdef CONFIG_I3C_CONTROLLER
+
 	if (!(ctrl_config->is_secondary)) {
 		ret = set_controller_info(dev);
 		if (ret) {
 			return ret;
 		}
+	}
+#endif /* CONFIG_I3C_CONTROLLER */
+	dw_i3c_enable_controller(config, true);
+#ifdef CONFIG_I3C_CONTROLLER
+	if (!(ctrl_config->is_secondary)) {
 		/* Perform bus initialization - skip if no I3C devices are known. */
 		if (config->common.dev_list.num_i3c > 0) {
 			ret = i3c_bus_init(dev, &config->common.dev_list);


### PR DESCRIPTION
… before enabling controller

The current initialization sequence enables the I3C controller before setting the controller information, which can result in improper setup and cause the controller to not function as expected.

Fix the initialization order by ensuring that the controller information is set prior to enabling the controller.