### PR TITLE
ci: set_assignee: fallback to next area if area has no maintainers

### DIFF
--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -102,7 +102,7 @@ def process_pr(gh, maintainer_file, number):
             for area_maintainer in area.maintainers:
                 found_maintainers[area_maintainer] += c
 
-            if 'Platform' in area.name:
+            if ('Platform' in area.name) and (len(area.maintainers) > 0):
                 is_instance = True
 
     area_counter = dict(sorted(area_counter.items(), key=lambda item: item[1], reverse=True))


### PR DESCRIPTION
fallback to next area if area has no maintainers.
If a Platform area has no maintainers, treat it
like it doesn't exist and don't remove the maintainers of the general area, so PRs are not unassigned, when there is a maintainer from a higher area.