### PR TITLE
drivers: gpio: Fix GPIO_INT_WAKEUP use from devicetree

### DIFF
--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -794,6 +794,16 @@ enum gpio_int_trig {
 	GPIO_INT_TRIG_BOTH = GPIO_INT_LOW_0 | GPIO_INT_HIGH_1,
 	/* Trigger a system wakeup. */
 	GPIO_INT_TRIG_WAKE = GPIO_INT_WAKEUP,
+	/* Trigger a system wakeup when input state is (or transitions to)
+	 * physical low. (Edge Falling or Active Low)
+	 */
+	GPIO_INT_TRIG_WAKE_LOW = GPIO_INT_LOW_0 | GPIO_INT_WAKEUP,
+	/* Trigger a system wakeup when input state is (or transitions to)
+	 * physical high. (Edge Rising or Active High)
+	 */
+	GPIO_INT_TRIG_WAKE_HIGH = GPIO_INT_HIGH_1 | GPIO_INT_WAKEUP,
+	/* Trigger a system wakeup on pin rising or falling edge. */
+	GPIO_INT_TRIG_WAKE_BOTH = GPIO_INT_LOW_0 | GPIO_INT_HIGH_1 | GPIO_INT_WAKEUP,
 };
 
 __subsystem struct gpio_driver_api {

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -948,9 +948,11 @@ static inline int z_impl_gpio_pin_interrupt_configure(const struct device *port,
  *
  * This is equivalent to:
  *
- *     gpio_pin_interrupt_configure(spec->port, spec->pin, flags);
+ *     gpio_pin_interrupt_configure(spec->port, spec->pin, combined_flags);
  *
- * The <tt>spec->dt_flags</tt> value is not used.
+ * Where <tt>combined_flags</tt> is the combination of the <tt>flags</tt> argument
+ * and the <tt>GPIO_INT_WAKEUP</tt> flag from <tt>spec->dt_flags</tt> if set. Other
+ * flags from <tt>spec->dt_flags</tt> are ignored.
  *
  * @param spec GPIO specification from devicetree
  * @param flags interrupt configuration flags
@@ -959,7 +961,8 @@ static inline int z_impl_gpio_pin_interrupt_configure(const struct device *port,
 static inline int gpio_pin_interrupt_configure_dt(const struct gpio_dt_spec *spec,
 						  gpio_flags_t flags)
 {
-	return gpio_pin_interrupt_configure(spec->port, spec->pin, flags);
+	return gpio_pin_interrupt_configure(spec->port, spec->pin,
+					    flags | (spec->dt_flags & GPIO_INT_WAKEUP));
 }
 
 /**

--- a/include/zephyr/dt-bindings/gpio/gpio.h
+++ b/include/zephyr/dt-bindings/gpio/gpio.h
@@ -13,7 +13,7 @@
  */
 
 /** Mask for DT GPIO flags. */
-#define GPIO_DT_FLAGS_MASK 0x3F
+#define GPIO_DT_FLAGS_MASK 0x7F
 
 /**
  * @name GPIO pin active level flags


### PR DESCRIPTION
The `GPIO_INT_WAKEUP` flag was added to the devicetree bindings in #66587 with a driver implementation for LPC, and a bug was fixed in that implementation in #90832.

This PR fixes 3 additional issues:

* The flags mask in the binding header was missing the wakeup flag. This meant that gpio-nexus nodes that made use of the mask for their passthrough configuration did not propagate the flag.
* The flag was not propagated from `gpio_pin_interrupt_configure_dt` to the driver implementation, which is surprising when the flag is available in the binding header and related to interrupt configuration.
* The internal `enum gpio_int_trig` did not exhaustively enumerate all possible configurations using `GPIO_INT_WAKEUP`.