### PR TITLE
drivers: serial: sam0: Fix rx ready

### DIFF
--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -847,7 +847,7 @@ static int uart_sam0_irq_rx_ready(const struct device *dev)
 	const struct uart_sam0_dev_cfg *config = dev->config;
 	SercomUsart * const regs = config->regs;
 
-	return regs->INTFLAG.bit.RXC != 0;
+	return (regs->INTFLAG.bit.RXC != 0) && (regs->INTENSET.bit.RXC != 0);
 }
 
 static int uart_sam0_fifo_read(const struct device *dev, uint8_t *rx_data,


### PR DESCRIPTION
The uart_sam0_irg_rx_ready() function always returns true, even if interrupt is disabled. This happens because the function do not evaluate if the interrupt is enable of not. This fixes the issue by adding the missing check.

This work continue the #95110 after written agreement.