### PR TITLE
.gitignore: Ignore direnv .envrc file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ doc/doc.warnings
 hide-defaults-note
 venv
 .venv
+.envrc
 .DS_Store
 .clangd
 new.info


### PR DESCRIPTION
Ignore the direnv `.envrc` file to automatically loads and unloads environment variables from the current directory.