### PR TITLE
boards: nxp: frdm_mcxn947: deactivate eth phy on cpu1

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -260,7 +260,7 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 	phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0>;
-		status = "okay";
+		status = "disabled";
 	};
 };
 

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
@@ -161,6 +161,10 @@
 	status = "okay";
 };
 
+&phy {
+	status = "okay";
+};
+
 &wwdt0 {
 	status = "okay";
 };


### PR DESCRIPTION
deactivate eth phy on cpu1, because
mdio is also only activated on cpu0.

fixes: #95104