### PR TITLE
Add CONFIG_ARCH_POSIX_SPIN_ON_FATAL.

### DIFF
--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -41,6 +41,14 @@ config ARCH_POSIX_TRAP_ON_FATAL
 	  Raise a SIGTRAP signal on fatal error before exiting.
 	  This automatically suspends the target if a debugger is attached.
 
+config ARCH_POSIX_SPIN_ON_FATAL
+	bool "Spin endlessly on fatal error"
+	depends on !ARCH_POSIX_TRAP_ON_FATAL
+	help
+	  Spin endlessly on fatal error.
+	  This is useful when immediate termination is not desired,
+	  e.g. for flushing logs or manually attaching to the process.
+
 rsource "Kconfig.natsim_optional"
 
 endmenu

--- a/arch/posix/core/fatal.c
+++ b/arch/posix/core/fatal.c
@@ -23,6 +23,12 @@ FUNC_NORETURN void arch_system_halt(unsigned int reason)
 		nsi_raise_sigtrap();
 	}
 
+	if (IS_ENABLED(CONFIG_ARCH_POSIX_SPIN_ON_FATAL)) {
+		for (;;) {
+			k_sleep(K_MSEC(1));
+		}
+	}
+
 	posix_print_error_and_exit("Exiting due to fatal error\n");
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }


### PR DESCRIPTION
Useful for development. Also required for properly flushing the logs (including the core dump).
