### PR TITLE
dts: arm: renesas: ra: Define vbatts pins on RA4 and RA6

### DIFF
--- a/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
@@ -306,6 +306,7 @@
 	port-irq5-pins = <1 10>;
 	port-irq6-pins = <9>;
 	port-irq7-pins = <8>;
+	vbatts-pins = <2>;
 };
 
 &dac_global {

--- a/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
@@ -370,6 +370,7 @@
 	port-irq6-pins = <9>;
 	port-irq7-pins = <8>;
 	port-irq14-pins = <3>;
+	/delete-property/ vbatts-pins;
 };
 
 &ioport8 {

--- a/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
@@ -223,6 +223,7 @@
 	port-irq4-pins = <2>;
 	port-irq6-pins = <9>;
 	port-irq9-pins = <14>;
+	vbatts-pins = <2>;
 };
 
 &ioport5 {

--- a/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
@@ -102,6 +102,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <16>;
+			vbatts-pins = <2 3 4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -98,6 +98,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <16>;
+			vbatts-pins = <2 3 4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -366,6 +366,7 @@
 	port-irq6-pins = <9>;
 	port-irq7-pins = <8>;
 	port-irq14-pins = <3>;
+	/delete-property/ vbatts-pins;
 };
 
 &ioport8 {

--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -94,6 +94,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <16>;
+			vbatts-pins = <2 3 4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
@@ -93,6 +93,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <16>;
+			vbatts-pins = <2 3 4>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Define the vbatts-pins for the RA4E1, RA4M1, RA4M2, RA4M3, RA4W1 RA6E1, RA6M1, RA6M2, RA6M3, RA6M4, and RA6M5