### PR TITLE
ec_host_cmd: shi: npcx: not reset when receiving bad data

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
@@ -346,11 +346,11 @@ static void shi_npcx_bad_received_data(const struct device *dev)
 	/* SHI receive bad data */
 	LOG_WRN("SHIBD");
 	LOG_HEXDUMP_DBG(data->in_msg, data->rx_ctx->len, "in_msg=");
-
-	/* Reset shi's state machine for error recovery */
-	shi_npcx_reset_prepare(dev);
-
-	LOG_DBG("END");
+	/*
+	 * When unexpected data is received, continuously send the code EC_SHI_RX_BAD_DATA (0xFB)
+	 * to the host on the output line. The SHI state machine is reset when the CS pin is
+	 * de-asserted.
+	 */
 }
 
 /*


### PR DESCRIPTION
  When the SHI driver receives data from the host and finds it is invalid (due to a checksum error or an unsupported protocol version), it currently resets the state machine, initializes the output buffer, and waits for CS de-assertion. Upon CS de-assertion, the driver resets the state machine and initializes the output buffer again. This commit removes the first redundant reset and re-initialization in the function `shi_npcx_bad_received_data()`, improving the driver’s efficiency.