### PR TITLE
test: subsys: disable settings.tfm_its test for lpcxpresso55s69 ns.

### DIFF
--- a/tests/subsys/settings/its/testcase.yaml
+++ b/tests/subsys/settings/its/testcase.yaml
@@ -10,3 +10,5 @@ tests:
       - max32657evkit/max32657/ns
       - nrf5340dk/nrf5340/cpuapp/ns
       - nrf54l15dk/nrf54l15/cpuapp/ns
+    platform_exclude:
+      - lpcxpresso55s69/lpc55s69/cpu0/ns


### PR DESCRIPTION
For lpcxpresso55s69 TF-M, it has persistent storage available, not applied for settings.tfm_its test.
Suggested by Owner to disable the test from https://github.com/zephyrproject-rtos/zephyr/issues/95119#issuecomment-3234081247