### PR TITLE
NXP add scmi nxp irq mask interface

### DIFF
--- a/drivers/firmware/scmi/clk.c
+++ b/drivers/firmware/scmi/clk.c
@@ -110,11 +110,7 @@ int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_conf
 		return ret;
 	}
 
-	if (status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(status);
-	}
-
-	return 0;
+	return scmi_status_to_errno(status);
 }
 
 int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t *parent_id)
@@ -190,11 +186,7 @@ int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 		return ret;
 	}
 
-	if (status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(status);
-	}
-
-	return 0;
+	return scmi_status_to_errno(status);
 }
 
 int scmi_clock_config_set(struct scmi_protocol *proto,
@@ -244,11 +236,7 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 		return ret;
 	}
 
-	if (status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(status);
-	}
-
-	return 0;
+	return scmi_status_to_errno(status);
 }
 
 int scmi_clock_protocol_attributes(struct scmi_protocol *proto, uint32_t *attributes)

--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -82,3 +82,35 @@ int scmi_cpu_pd_lpm_set(struct scmi_cpu_pd_lpm_config *cfg)
 
 	return scmi_status_to_errno(status);
 }
+
+int scmi_cpu_set_irq_mask(struct scmi_cpu_irq_mask_config *cfg)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_CPU_DOMAIN);
+	struct scmi_message msg, reply;
+	int status, ret;
+
+	/* sanity checks */
+	if (!proto || !cfg) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_CPU_DOMAIN) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_CPU_DOMAIN_MSG_CPU_IRQ_WAKE_SET, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(*cfg);
+	msg.content = cfg;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(status);
+	reply.content = &status;
+
+	ret = scmi_send_message(proto, &msg, &reply, true);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return scmi_status_to_errno(status);
+}

--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -45,11 +45,7 @@ int scmi_cpu_sleep_mode_set(struct scmi_cpu_sleep_mode_config *cfg)
 		return ret;
 	}
 
-	if (status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(status);
-	}
-
-	return 0;
+	return scmi_status_to_errno(status);
 }
 
 int scmi_cpu_pd_lpm_set(struct scmi_cpu_pd_lpm_config *cfg)
@@ -84,9 +80,5 @@ int scmi_cpu_pd_lpm_set(struct scmi_cpu_pd_lpm_config *cfg)
 		return ret;
 	}
 
-	if (status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(status);
-	}
-
-	return 0;
+	return scmi_status_to_errno(status);
 }

--- a/drivers/firmware/scmi/pinctrl.c
+++ b/drivers/firmware/scmi/pinctrl.c
@@ -59,9 +59,5 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 		return ret;
 	}
 
-	if (status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(status);
-	}
-
-	return 0;
+	return scmi_status_to_errno(status);
 }

--- a/drivers/firmware/scmi/power.c
+++ b/drivers/firmware/scmi/power.c
@@ -94,9 +94,5 @@ int scmi_power_state_set(struct scmi_power_state_config *cfg)
 		return ret;
 	}
 
-	if (status != SCMI_SUCCESS) {
-		return scmi_status_to_errno(status);
-	}
-
-	return 0;
+	return scmi_status_to_errno(status);
 }

--- a/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
+++ b/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
@@ -23,6 +23,8 @@
 
 #define SCMI_CPU_MAX_PDCONFIGS_T 7U
 
+#define SCMI_CPU_IRQ_WAKE_NUM	22U
+
 /**
  * @struct scmi_cpu_sleep_mode_config
  *
@@ -50,6 +52,18 @@ struct scmi_cpu_pd_lpm_config {
 	uint32_t cpu_id;
 	uint32_t num_cfg;
 	struct scmi_pd_lpm_settings cfgs[SCMI_CPU_MAX_PDCONFIGS_T];
+};
+
+/**
+ * @struct scmi_cpu_irq_mask_config
+ *
+ * @brief Describes the parameters for the CPU_IRQ_WAKE_SET command
+ */
+struct scmi_cpu_irq_mask_config {
+	uint32_t cpu_id;
+	uint32_t mask_idx;
+	uint32_t num_mask;
+	uint32_t mask[SCMI_CPU_IRQ_WAKE_NUM];
 };
 
 /**
@@ -93,4 +107,14 @@ int scmi_cpu_sleep_mode_set(struct scmi_cpu_sleep_mode_config *cfg);
  * @retval negative errno if failure
  */
 int scmi_cpu_pd_lpm_set(struct scmi_cpu_pd_lpm_config *cfg);
+
+/**
+ * @brief Send the CPU_IRQ_WAKE_SET command and get its reply
+ *
+ * @param cfg pointer to structure containing configuration to be set
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_cpu_set_irq_mask(struct scmi_cpu_irq_mask_config *cfg);
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CPU_H_ */


### PR DESCRIPTION
1. Add scmi_cpu_set_irq_mask api for scmi nxp imx vendor, its aim to set cmc irq mask for nvic
2. verified it passed in imx95 m7