### PR TITLE
NXP support lptmr tickless function

### DIFF
--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -142,7 +142,7 @@
 	status = "okay";
 };
 
-&lptmr2 {
+&lptmr1 {
 	status = "okay";
 };
 

--- a/boards/nxp/imx95_evk_15x15/imx95_evk_15x15_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk_15x15/imx95_evk_15x15_mimx9596_m7.dts
@@ -82,3 +82,7 @@
 	pinctrl-0 = <&lpuart3_default>;
 	pinctrl-names = "default";
 };
+
+&lptmr1 {
+	status = "okay";
+};

--- a/drivers/timer/Kconfig.mcux_lptmr
+++ b/drivers/timer/Kconfig.mcux_lptmr
@@ -1,6 +1,7 @@
 # Copyright (c) 2014-2015 Wind River Systems, Inc.
 # Copyright (c) 2016 Cadence Design Systems, Inc.
 # Copyright (c) 2019 Intel Corp.
+# Copyright (c) 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config MCUX_LPTMR_TIMER
@@ -8,7 +9,7 @@ config MCUX_LPTMR_TIMER
 	default n
 	depends on DT_HAS_NXP_LPTMR_ENABLED
 	depends on !COUNTER_MCUX_LPTMR
-	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
+	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the NXP MCUX Low
 	  Power Timer (LPTMR) and provides the standard "system clock driver"

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -37,8 +37,25 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 #define CYCLES_PER_TICK ((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec() \
 			/ (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
 
-/* 32 bit cycle counter */
+/* Counter maximum value based on resolution */
+#define LPTMR_RESOLUTION DT_INST_PROP(0, resolution)
+#define COUNTER_MAX GENMASK(LPTMR_RESOLUTION - 1, 0)
+
+#define MAX_TICKS ((COUNTER_MAX / CYCLES_PER_TICK) - 1)
+#define MAX_CYCLES (MAX_TICKS * CYCLES_PER_TICK)
+#define MIN_DELAY MAX(1024U, ((uint32_t)CYCLES_PER_TICK/16U))
+
+/* 32 bit cycle counter, the variable only used in tickful mode */
 static volatile uint32_t cycles;
+
+/*
+ * Stores the current number of cycles the system has had announced to it,
+ * since the last rollover of the free running counter.
+ */
+static uint32_t announced_cycles;
+
+/* Lock on shared variables */
+static struct k_spinlock lock;
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
@@ -47,6 +64,59 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	if (idle && (ticks == K_TICKS_FOREVER)) {
 		LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
 	}
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	k_spinlock_key_t key;
+	uint32_t next, adj, now;
+
+	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
+	/* Clamp ticks. We subtract one since we round up to next tick */
+	ticks = CLAMP((ticks - 1), 0, (int32_t)MAX_TICKS);
+
+	key = k_spin_lock(&lock);
+
+	/* Read current timer value */
+	now = LPTMR_GetCurrentTimerCount(LPTMR_BASE);
+
+	/* Adjustment value, used to ensure next capture is on tick boundary */
+	adj = (now - announced_cycles) + (CYCLES_PER_TICK - 1);
+
+	next = ticks * CYCLES_PER_TICK;
+	/*
+	 * The following section rounds the capture value up to the next tick
+	 * boundary
+	 */
+	if (next <= MAX_CYCLES - adj) {
+		next += adj;
+	} else {
+		next = MAX_CYCLES;
+	}
+	next = (next / CYCLES_PER_TICK) * CYCLES_PER_TICK;
+
+	if ((int32_t)(next + announced_cycles - now) < MIN_DELAY) {
+		next += CYCLES_PER_TICK;
+	}
+
+	next += announced_cycles;
+
+	/* Update CMR safely while the timer is running.
+	 *
+	 * CMR writes are not hardware‑synchronized. If TCF is cleared while the
+	 * interrupt is still enabled, TCF may be reasserted in a narrow race window
+	 * and generate an unexpected interrupt.
+	 *
+	 * To avoid this, disable the LPTMR interrupt first, then clear TCF,
+	 * program the new compare value, and finally re-enable the interrupt.
+	 */
+	LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
+	LPTMR_ClearStatusFlags(LPTMR_BASE, kLPTMR_TimerCompareFlag);
+	LPTMR_SetTimerPeriod(LPTMR_BASE, next);
+	LPTMR_EnableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
+
+	k_spin_unlock(&lock, key);
 }
 
 void sys_clock_idle_exit(void)
@@ -64,7 +134,17 @@ void sys_clock_disable(void)
 
 uint32_t sys_clock_elapsed(void)
 {
-	return 0;
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return 0;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+	uint32_t now = LPTMR_GetCurrentTimerCount(LPTMR_BASE);
+
+	now -= announced_cycles;
+	k_spin_unlock(&lock, key);
+
+	return now / CYCLES_PER_TICK;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -75,11 +155,23 @@ uint32_t sys_clock_cycle_get_32(void)
 static void mcux_lptmr_timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
+	k_spinlock_key_t key;
+	uint32_t tick = 0;
 
-	cycles += CYCLES_PER_TICK;
+	key = k_spin_lock(&lock);
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		uint32_t now = LPTMR_GetCurrentTimerCount(LPTMR_BASE);
 
-	sys_clock_announce(1);
-	LPTMR_ClearStatusFlags(LPTMR_BASE, kLPTMR_TimerCompareFlag);
+		LPTMR_ClearStatusFlags(LPTMR_BASE, kLPTMR_TimerCompareFlag);
+		tick += (now - announced_cycles) / CYCLES_PER_TICK;
+		announced_cycles = now;
+	} else {
+		LPTMR_ClearStatusFlags(LPTMR_BASE, kLPTMR_TimerCompareFlag);
+		cycles += CYCLES_PER_TICK;
+	}
+
+	k_spin_unlock(&lock, key);
+	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? tick : 1);
 }
 
 static int sys_clock_driver_init(void)
@@ -88,7 +180,11 @@ static int sys_clock_driver_init(void)
 
 	LPTMR_GetDefaultConfig(&config);
 	config.timerMode = kLPTMR_TimerModeTimeCounter;
+#if defined(CONFIG_TICKLESS_KERNEL)
+	config.enableFreeRunning = true;
+#else
 	config.enableFreeRunning = false;
+#endif
 	config.prescalerClockSource = LPTMR_CLK_SOURCE;
 	config.bypassPrescaler = LPTMR_PRESCALER_BYPASS;
 	config.value = LPTMR_PRESCALER;

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Vestas Wind Systems A/S
- * Copyright (c) 2025 NXP
+ * Copyright (c) 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,6 +25,11 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 #define LPTMR_BASE ((LPTMR_Type *)(DT_INST_REG_ADDR(0)))
 #define LPTMR_CLK_SOURCE TO_LPTMR_CLK_SEL(DT_INST_PROP_OR(0, clk_source, 0))
 #define LPTMR_PRESCALER DT_INST_PROP_OR(0, prescale_glitch_filter, 0)
+/*
+ * Default must be false so prescale-glitch-filter can be used without requiring
+ * an explicit bypass property.
+ */
+#define LPTMR_PRESCALER_BYPASS DT_INST_PROP_OR(0, prescale_glitch_filter_bypass, false)
 #define LPTMR_IRQN DT_INST_IRQN(0)
 #define LPTMR_IRQ_PRIORITY DT_INST_IRQ(0, priority)
 
@@ -85,8 +90,8 @@ static int sys_clock_driver_init(void)
 	config.timerMode = kLPTMR_TimerModeTimeCounter;
 	config.enableFreeRunning = false;
 	config.prescalerClockSource = LPTMR_CLK_SOURCE;
-	config.bypassPrescaler = (LPTMR_PRESCALER == 0);
-	config.value = (LPTMR_PRESCALER == 0) ? 0 : (LPTMR_PRESCALER - 1);
+	config.bypassPrescaler = LPTMR_PRESCALER_BYPASS;
+	config.value = LPTMR_PRESCALER;
 
 	LPTMR_Init(LPTMR_BASE, &config);
 

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -19,6 +19,7 @@
 		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m7";
+			clock-frequency = <DT_FREQ_M(800)>;
 			cpu-power-states = <&wait &stop &suspend>;
 			reg = <0>;
 

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -612,6 +612,18 @@
 			status = "disabled";
 		};
 
+		lptmr1: timer@44300000 {
+			compatible = "nxp,lptmr";
+			reg = <0x44300000 DT_SIZE_K(4)>;
+			interrupts = <18 0>;
+			clocks = <&scmi_clk IMX95_CLK_LPTMR1>;
+			clock-frequency = <32768>;
+			clk-source = <2>;
+			prescale-glitch-filter-bypass;
+			resolution = <32>;
+			status = "disabled";
+		};
+
 		lptmr2: timer@424d0000 {
 			compatible = "nxp,lptmr";
 			reg = <0x424d0000 DT_SIZE_K(4)>;

--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
@@ -42,14 +42,29 @@ config 3RD_LEVEL_INTERRUPTS
 config NUM_IRQS
 	default 250 # 2ND_LVL_ISR_TBL_OFFSET + MAX_IRQ_PER_AGGREGATOR * NUM_2ND_LEVEL_AGGREGATORS
 
+# LPTMR cannot be shared with both the system timer and the counter simultaneously
+# as they now share the same compatible resource.
+# By default, when LPTMR is not used as a counter, it shows enabling LPTMR as the system clock.
+config MCUX_LPTMR_TIMER
+	default y if !COUNTER_MCUX_LPTMR
+
+config CORTEX_M_SYSTICK
+	default n if MCUX_LPTMR_TIMER
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 800000000
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
+	default $(dt_node_int_prop_int,/soc/timer@44300000,clock-frequency) if MCUX_LPTMR_TIMER
+
+config SYS_CLOCK_TICKS_PER_SEC
+	default 1024 if MCUX_LPTMR_TIMER
+	default 1000 if CORTEX_M_SYSTICK
 
 config CACHE_MANAGEMENT
 	default y
 
 config ETH_NXP_IMX_MSGINTR
 	default 2
+
 if PM
 # PM code that runs from the idle loop has a large
 # footprint. Hence increase the size when PM is enabled.

--- a/tests/application_development/ram_context_for_isr/testcase.yaml
+++ b/tests/application_development/ram_context_for_isr/testcase.yaml
@@ -13,6 +13,7 @@ tests:
       - mps4/corstone320/fvp
       - imx95_evk/mimx9596/m7
       - imx95_evk/mimx9596/m7/ddr
+      - imx95_evk/mimx9596/m7/flash
       - imx95_evk_15x15/mimx9596/m7
       - imx943_evk/mimx94398/m33
       - imx943_evk/mimx94398/m33/ddr

--- a/tests/drivers/counter/counter_basic_api/boards/imx95_evk_mimx9596_m7.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/imx95_evk_mimx9596_m7.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lptmr2 {
+	status = "okay";
+};


### PR DESCRIPTION
1. added lptmr tickless function
2. verified in imx95 m7 core which enabled PM and tickless
![Uploading image.png…]()
