### PR TITLE
drivers/bbram: Enable bbram driver for it51xxx series

### DIFF
--- a/dts/riscv/ite/it51xxx.dtsi
+++ b/dts/riscv/ite/it51xxx.dtsi
@@ -971,6 +971,14 @@
 			#wuc-cells = <1>;
 		};
 
+		bbram: bb-ram@f02200 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "ite,it8xxx2-bbram";
+			status = "okay";
+			reg = <0x00f02200 0x80>;
+		};
+
 		i2cbase: i2cbase@f04100 {
 			compatible = "ite,it51xxx-i2cbase";
 			reg = <0x00f04100 1

--- a/soc/ite/ec/it51xxx/chip_chipregs.h
+++ b/soc/ite/ec/it51xxx/chip_chipregs.h
@@ -341,6 +341,24 @@ struct gctrl_it51xxx_regs {
 
 /**
  *
+ * (22xxh) Battery-backed SRAM (BRAM) registers
+ *
+ */
+#ifndef __ASSEMBLER__
+/* Battery backed RAM indices. */
+#define BRAM_MAGIC_FIELD_OFFSET 0x7c
+
+enum bram_indices {
+	/* This field is used to indicate BRAM is valid or not. */
+	BRAM_IDX_VALID_FLAGS0 = BRAM_MAGIC_FIELD_OFFSET,
+	BRAM_IDX_VALID_FLAGS1,
+	BRAM_IDX_VALID_FLAGS2,
+	BRAM_IDX_VALID_FLAGS3
+};
+#endif /* !__ASSEMBLER__ */
+
+/**
+ *
  * (42xxh) SMBus Interface for target (SMB) registers
  *
  */


### PR DESCRIPTION
The BBRAM driver of it51xxx is compatible with it8xxx2.