### PR TITLE
drivers: flash: spi-nor: add write-block-size for mcuboot

### DIFF
--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -133,3 +133,13 @@ properties:
       output data at a higher clock rate than the standard read command.  This
       property indicates that the device supports the fast read command with
       8 dummy cycles after the address phase of the command.
+
+  write-block-size:
+    type: int
+    description: |
+      Address alignment required by flash write operations.
+
+      For SPI NOR devices, this is always 1 byte. This property is
+      only here, because it is expected to be available by mcuboot.
+    const: 1
+    default: 1


### PR DESCRIPTION
add write-block-size in dt for spi-nor. The cmake
functions related to mcuboot in the build system
want this prop to be set. It's not meant to be changed.