### PR TITLE
stm32n6: Fix xspi devices configuration

### DIFF
--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -97,12 +97,6 @@
 	status = "okay";
 };
 
-&ic3 {
-	pll-src = <1>;
-	ic-div = <6>;
-	status = "okay";
-};
-
 &ic6 {
 	pll-src = <3>;
 	ic-div = <2>;
@@ -231,7 +225,7 @@ zephyr_udc0: &usbotg_hs1 {
 		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11>;
 	pinctrl-names = "default";
 	clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
-		 <&rcc STM32_SRC_IC3 XSPI1_SEL(2)>,
+		 <&rcc STM32_SRC_HCLK5 XSPI2_SEL(0)>,
 		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -144,12 +144,6 @@
 	status = "okay";
 };
 
-&ic3 {
-	pll-src = <1>;
-	ic-div = <6>;
-	status = "okay";
-};
-
 &ic4 {
 	pll-src = <2>;
 	ic-div = <32>;
@@ -342,7 +336,7 @@ zephyr_udc0: &usbotg_hs1 {
 		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11>;
 	pinctrl-names = "default";
 	clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
-		 <&rcc STM32_SRC_IC3 XSPI1_SEL(2)>,
+		 <&rcc STM32_SRC_HCLK5 XSPI2_SEL(0)>,
 		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 


### PR DESCRIPTION
This PR targets to fix 2 known issues around xspi devices configuration on stm32n6 based boards:
- Kernel clock copy/paste issue between xspi1 and xspi2
- Impossibility to run NOR device at expected freq of 200Mhz

For this second issue, I chose fixing the specific issue of the NOR configuration on the 2 impacted boards.
As metionned in the commit message, fixing the larger problem of configuring xspi devices more closely according to their type and specification is what MSPI API intends to solve, so I prefer let this general issue on MSPI driver development and for now
focus on fixing reported issues on flash xspi driver.