### PR TITLE
PocketBeagle 2 support I-RAM and D-RAM seperation

### DIFF
--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_m4.yaml
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_m4.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-ram: 192
+ram: 256
 vendor: beagle
 supported:
   - uart

--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_m4_defconfig
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_m4_defconfig
@@ -7,8 +7,9 @@
 # Platform Configuration
 CONFIG_CORTEX_M_SYSTICK=y
 
-# Zephyr Kernel Configuration
-CONFIG_XIP=n
+# XIP is required to place text and data sections in I-RAM and D-RAM
+# respectively.
+CONFIG_XIP=y
 
 # Serial Driver
 CONFIG_SERIAL=y

--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6254_m4.yaml
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6254_m4.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-ram: 192
+ram: 256
 vendor: beagle
 supported:
   - uart

--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6254_m4_defconfig
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6254_m4_defconfig
@@ -7,8 +7,9 @@
 # Platform Configuration
 CONFIG_CORTEX_M_SYSTICK=y
 
-# Zephyr Kernel Configuration
-CONFIG_XIP=n
+# XIP is required to place text and data sections in I-RAM and D-RAM
+# respectively.
+CONFIG_XIP=y
 
 # Serial Driver
 CONFIG_SERIAL=y

--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_m4-common.dtsi
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_m4-common.dtsi
@@ -12,7 +12,11 @@
 	compatible = "beagle,pocketbeagle_2_m4";
 
 	chosen {
-		zephyr,sram = &sram0;
+		/* Split and place TEXT and DATA in I-RAM and D-RAM respectively. `sram_icode`
+		 * is a section in internal SRAM, not an external flash.
+		 */
+		zephyr,flash = &sram_icode;
+		zephyr,sram = &sram_dcode;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,ipc = &ipc0;

--- a/boards/phytec/phyboard_lyra/phyboard_lyra_am6234_m4.yaml
+++ b/boards/phytec/phyboard_lyra/phyboard_lyra_am6234_m4.yaml
@@ -4,5 +4,5 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-ram: 192
+ram: 256
 vendor: phytec

--- a/boards/ti/sk_am62/sk_am62_am6234_m4.yaml
+++ b/boards/ti/sk_am62/sk_am62_am6234_m4.yaml
@@ -4,5 +4,5 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-ram: 192
+ram: 256
 vendor: ti

--- a/dts/arm/ti/am62x_m4.dtsi
+++ b/dts/arm/ti/am62x_m4.dtsi
@@ -25,14 +25,30 @@
 		};
 	};
 
+	/*
+	 * I-RAM and D-RAM can be used in unified mode, i.e. instruction code and data can be placed
+	 * in any bank. Since unaligned accesses are converted internally by the CM4 into
+	 * aligned accesses of smaller sizes, even accessing unaligned data at the boundary
+	 * between I-RAM and D-RAM should not cause problems in unified mode. However, note
+	 * that using unified mode can have a performance penalty.
+	 */
 	sram0: memory@0 {
 		compatible = "mmio-sram";
-		reg = <0x0 DT_SIZE_K(192)>;		/* 192 KB of SRAM (I-Code) */
-	};
+		reg = <0x0 DT_SIZE_K(256)>;
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
 
-	sram1: memory1@40000 {
-		compatible = "mmio-sram";
-		reg = <0x40000 DT_SIZE_K(64)>;		/* 64 KB of SRAM (D-Code) */
+		/* 192 KB of SRAM (I-Code) */
+		sram_icode: memory@0 {
+			device_type = "memory";
+			reg = <0x00000000 DT_SIZE_K(192)>;
+		};
+
+		/* 64 KB of SRAM (D-Code) */
+		sram_dcode: memory@30000 {
+			device_type = "memory";
+			reg = <0x00030000 DT_SIZE_K(64)>;
+		};
 	};
 
 	sysclk: system-clock {

--- a/samples/subsys/logging/dictionary/sample.yaml
+++ b/samples/subsys/logging/dictionary/sample.yaml
@@ -5,6 +5,9 @@ tests:
   sample.logger.basic.dictionary:
     build_only: true
     tags: logging
+    platform_exclude:
+      - pocketbeagle_2/am6232/m4
+      - pocketbeagle_2/am6254/m4
     integration_platforms:
       - qemu_x86
       - qemu_x86_64
@@ -12,6 +15,9 @@ tests:
     build_only: true
     tags: logging
     filter: CONFIG_CPU_HAS_FPU
+    platform_exclude:
+      - pocketbeagle_2/am6232/m4
+      - pocketbeagle_2/am6254/m4
     extra_configs:
       - CONFIG_FPU=y
     integration_platforms:
@@ -21,6 +27,9 @@ tests:
     build_only: true
     tags: logging
     filter: CONFIG_CPU_HAS_FPU
+    platform_exclude:
+      - pocketbeagle_2/am6232/m4
+      - pocketbeagle_2/am6254/m4
     extra_configs:
       - CONFIG_FPU=y
       - CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE=y
@@ -61,6 +70,9 @@ tests:
     build_only: true
     tags: logging
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT and CONFIG_UART_CONSOLE
+    platform_exclude:
+      - pocketbeagle_2/am6232/m4
+      - pocketbeagle_2/am6254/m4
     integration_platforms:
       - qemu_x86
       - qemu_x86_64


### PR DESCRIPTION
The M4F allows concurrent fetch for instruction code and data via dedicated buses (I-Code and D-Code, respectively).

The following patch series allows splitting the code and data sections between I-RAM and D-RAM respectively.

Additionally, it makes the SRAM a single node, with the i-ram and d-ram regions represented by child nodes. This allows for use in unified mode, i.e. instruction code and data code can be placed in any bank.

It also fixes the incorrect D-RAM address that was present in the old node.

<img width="662" height="156" alt="image" src="https://github.com/user-attachments/assets/f2c71ff4-bc72-44a5-a01e-6c425b70f5ff" />
