### PR TITLE
Drivers: display: st7796s: Add display_set_orientation API

### DIFF
--- a/drivers/display/display_st7796s.h
+++ b/drivers/display/display_st7796s.h
@@ -35,6 +35,12 @@
 #define ST7796S_CMD_CSCON	0xF0 /* Command set control */
 
 #define ST7796S_CONTROL_16BIT 0x5 /* Sets control interface to 16 bit mode */
+
+#define ST7796S_MADCTL_MY  BIT(7) /* Set row address order */
+#define ST7796S_MADCTL_MX  BIT(6) /* Set column address order */
+#define ST7796S_MADCTL_MV  BIT(5) /* Set row/column exchange */
+#define ST7796S_MADCTL_ML  BIT(4) /* Set vertical refresh order */
+#define ST7796S_MADCTL_MH  BIT(2) /* Set horizontal refresh order */
 #define ST7796S_MADCTL_BGR BIT(3) /* Sets BGR color mode */
 
 


### PR DESCRIPTION
### **Drivers: display: st7796s: Add display_set_orientation API**

**Description**
Currently, the driver lacks support for changing the display orientation at runtime. This change implements the API to allow for hardware-based rotation using the `MADCTL` register.

**Implemented:**
This changes adds the implementation for the `display_set_orientation` API to the `ST7796S` display driver.

The implementation was tested on an `rd_rw612_bga` board with a 320x480 display using the ST7796S controller. The API now correctly handles rotations to 0, 90, 180, and 270 degrees by configuring the MY, MX, and MV bits of the MADCTL register.