### PR TITLE
drivers: i2s: nrf_tdm: Allow using 8 channels

### DIFF
--- a/drivers/i2s/i2s_nrf_tdm.c
+++ b/drivers/i2s/i2s_nrf_tdm.c
@@ -30,6 +30,10 @@ LOG_MODULE_REGISTER(tdm_nrf, CONFIG_I2S_LOG_LEVEL);
  */
 #define NRFX_TDM_STATUS_TRANSFER_STOPPED BIT(1)
 
+/* Maximum clock divider value. Corresponds to CKDIV2. */
+#define NRFX_TDM_MAX_SCK_DIV_VALUE TDM_CONFIG_SCK_DIV_SCKDIV_Max
+#define NRFX_TDM_MAX_MCK_DIV_VALUE TDM_CONFIG_MCK_DIV_DIV_Max
+
 #define NRFX_TDM_NUM_OF_CHANNELS (TDM_CONFIG_CHANNEL_NUM_NUM_Max + 1)
 
 #define NRFX_TDM_TX_CHANNELS_MASK                                                                  \
@@ -814,11 +818,11 @@ static int trigger_start(const struct device *dev)
 
 	nrf_tdm_sck_configure(drv_cfg->p_reg,
 			      drv_cfg->sck_src == ACLK ? NRF_TDM_SRC_ACLK : NRF_TDM_SRC_PCLK32M,
-			      false);
+			      nrfx_cfg->sck_setup > NRFX_TDM_MAX_SCK_DIV_VALUE);
 
 	nrf_tdm_mck_configure(drv_cfg->p_reg,
 			      drv_cfg->mck_src == ACLK ? NRF_TDM_SRC_ACLK : NRF_TDM_SRC_PCLK32M,
-			      false);
+			      nrfx_cfg->mck_setup > NRFX_TDM_MAX_MCK_DIV_VALUE);
 	/* If it is required to use certain HF clock, request it to be running
 	 * first. If not, start the transfer directly.
 	 */


### PR DESCRIPTION
TDM should have clock divider bypass enabled when calculated clock divider exceeds maximum allowed value which is `CKDIV2`.