### PR TITLE
drivers: wifi: esp32: Add default max managed interfaces

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -64,6 +64,9 @@ config ESP32_WIFI_AP_STA_MODE
 	  The Station/AP coexistence mode allows the ESP32 to operate as both a station and
 	  an access point simultaneously.
 
+config WIFI_NM_MAX_MANAGED_INTERFACES
+	default 2
+
 config ESP32_WIFI_STA_RECONNECT
 	bool "WiFi connection retry"
 	help


### PR DESCRIPTION
This Kconfig default value 2 of WIFI_NM_MAX_MANAGED_INTERFACES ensures WiFi network manager can properly handle both access point and station interfaces on ESP32 WiFi drivers.