### PR TITLE
include: devicetree: show DT helpers in their respective device sections

### DIFF
--- a/include/zephyr/devicetree/can.h
+++ b/include/zephyr/devicetree/can.h
@@ -19,6 +19,7 @@ extern "C" {
 /**
  * @defgroup devicetree-can Devicetree CAN API
  * @ingroup devicetree
+ * @ingroup can_interface
  * @{
  */
 

--- a/include/zephyr/devicetree/clocks.h
+++ b/include/zephyr/devicetree/clocks.h
@@ -19,6 +19,7 @@ extern "C" {
 /**
  * @defgroup devicetree-clocks Devicetree Clocks API
  * @ingroup devicetree
+ * @ingroup clock_control_interface
  * @{
  */
 

--- a/include/zephyr/devicetree/display.h
+++ b/include/zephyr/devicetree/display.h
@@ -19,6 +19,7 @@ extern "C" {
 /**
  * @defgroup devicetree-display Devicetree Display API
  * @ingroup devicetree
+ * @ingroup display_interface
  * @{
  */
 

--- a/include/zephyr/devicetree/dma.h
+++ b/include/zephyr/devicetree/dma.h
@@ -19,6 +19,7 @@ extern "C" {
 /**
  * @defgroup devicetree-dmas Devicetree DMA API
  * @ingroup devicetree
+ * @ingroup dma_interface
  * @{
  */
 

--- a/include/zephyr/devicetree/gpio.h
+++ b/include/zephyr/devicetree/gpio.h
@@ -20,6 +20,7 @@ extern "C" {
 /**
  * @defgroup devicetree-gpio Devicetree GPIO API
  * @ingroup devicetree
+ * @ingroup gpio_interface
  * @{
  */
 

--- a/include/zephyr/devicetree/mbox.h
+++ b/include/zephyr/devicetree/mbox.h
@@ -19,6 +19,7 @@ extern "C" {
 /**
  * @defgroup devicetree-mbox Devicetree MBOX API
  * @ingroup devicetree
+ * @ingroup mbox_interface
  * @{
  */
 

--- a/include/zephyr/devicetree/pinctrl.h
+++ b/include/zephyr/devicetree/pinctrl.h
@@ -14,6 +14,7 @@
 /**
  * @defgroup devicetree-pinctrl Pin control
  * @ingroup devicetree
+ * @ingroup pinctrl_interface
  * @{
  */
 

--- a/include/zephyr/devicetree/pwms.h
+++ b/include/zephyr/devicetree/pwms.h
@@ -19,6 +19,7 @@ extern "C" {
 /**
  * @defgroup devicetree-pwms Devicetree PWMs API
  * @ingroup devicetree
+ * @ingroup pwm_interface
  * @{
  */
 

--- a/include/zephyr/devicetree/reset.h
+++ b/include/zephyr/devicetree/reset.h
@@ -19,6 +19,7 @@ extern "C" {
 /**
  * @defgroup devicetree-reset-controller Devicetree Reset Controller API
  * @ingroup devicetree
+ * @ingroup reset_controller_interface
  * @{
  */
 

--- a/include/zephyr/devicetree/spi.h
+++ b/include/zephyr/devicetree/spi.h
@@ -19,6 +19,7 @@ extern "C" {
 /**
  * @defgroup devicetree-spi Devicetree SPI API
  * @ingroup devicetree
+ * @ingroup spi_interface
  * @{
  */
 


### PR DESCRIPTION
The various DT helpers benefit from being shown in their respective device sections as it's expected that some users will be looking there rather than generic Devicetree help pages.