### PR TITLE
doc: usb: re-organize doxygen groups for usb hardware

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -22,6 +22,12 @@
 @{
 @}
 
+@brief Interfaces for USB hardware and associated standards.
+@defgroup usb_interfaces USB
+@ingroup io_interfaces
+@{
+@}
+
 @brief Multi Function Device Drivers APIs
 @defgroup mfd_interfaces Multi Function Device Drivers APIs
 @ingroup io_interfaces

--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -295,8 +295,8 @@ struct udc_data {
 
 /**
  * @brief New USB device controller (UDC) driver API
- * @defgroup udc_api USB device controller driver API
- * @ingroup io_interfaces
+ * @defgroup udc_api USB Device Controller
+ * @ingroup usb_interfaces
  * @since 3.3
  * @version 0.1.0
  * @{

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -20,8 +20,8 @@
 
 /**
  * @brief USB host controller (UHC) driver API
- * @defgroup uhc_api USB host controller driver API
- * @ingroup io_interfaces
+ * @defgroup uhc_api USB Host Controller
+ * @ingroup usb_interfaces
  * @since 3.3
  * @version 0.1.1
  * @{

--- a/include/zephyr/drivers/usb/usb_bc12.h
+++ b/include/zephyr/drivers/usb/usb_bc12.h
@@ -19,9 +19,9 @@ extern "C" {
 #endif
 
 /**
- * @brief BC1.2 driver APIs
- * @defgroup b12_interface BC1.2 driver APIs
- * @ingroup io_interfaces
+ * @brief USB Battery Charging (BC1.2) driver APIs
+ * @defgroup b12_interface Battery Charging (BC1.2)
+ * @ingroup usb_interfaces
  * @{
  */
 

--- a/include/zephyr/drivers/usb_c/usbc_tc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tc.h
@@ -15,9 +15,9 @@
 #define ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_TC_H_
 
 /**
- * @brief USB Type-C
+ * @brief Support for USB Type-C cables and connectors
  * @defgroup usb_type_c USB Type-C
- * @ingroup io_interfaces
+ * @ingroup usb_interfaces
  * @{
  */
 


### PR DESCRIPTION
USB host, device, Type-C, and BC1.2 are now all grouped under a top-level USB entry in the "Device drivers" doxygen group.

https://builds.zephyrproject.io/zephyr/pr/95181/docs/doxygen/html/group__usb__interface.html