### PR TITLE
sensor: Doxygen docs for FDC2X1X, PAT9136, and AFBR-S50 extended API

### DIFF
--- a/include/zephyr/drivers/sensor/afbr_s50.h
+++ b/include/zephyr/drivers/sensor/afbr_s50.h
@@ -30,6 +30,9 @@ extern "C" {
 /** Disregard pixel reading if contains this value */
 #define AFBR_PIXEL_INVALID_VALUE 0x80000000
 
+/**
+ * Custom sensor channels for AFBR-S50
+ */
 enum sensor_channel_afbr_s50 {
 	/**
 	 * Obtain matrix of pixels, with readings in meters.

--- a/include/zephyr/drivers/sensor/fdc2x1x.h
+++ b/include/zephyr/drivers/sensor/fdc2x1x.h
@@ -6,11 +6,19 @@
 
 /**
  * @file
- * @brief Extended public API for the Texas Instruments FDC2X1X
+ * @brief Header file for extended sensor API of FDC2X1X sensor
+ * @ingroup fdc2x1x_interface
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_FDC2X1X_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_FDC2X1X_H_
+
+/**
+ * @brief Texas Instruments FDC2X1X capacitive sensor
+ * @defgroup fdc2x1x_interface FDC2X1X
+ * @ingroup sensor_interface_ext
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,14 +26,17 @@ extern "C" {
 
 #include <zephyr/drivers/sensor.h>
 
+/**
+ * Custom sensor channels for FDC2X1X
+ */
 enum sensor_channel_fdc2x1x {
-	/** CH0 Capacitance, in Picofarad **/
+	/** CH0 Capacitance, in picofarad **/
 	SENSOR_CHAN_FDC2X1X_CAPACITANCE_CH0 = SENSOR_CHAN_PRIV_START,
-	/** CH1 Capacitance, in Picofarad **/
+	/** CH1 Capacitance, in picofarad **/
 	SENSOR_CHAN_FDC2X1X_CAPACITANCE_CH1,
-	/** CH2 Capacitance, in Picofarad **/
+	/** CH2 Capacitance, in picofarad **/
 	SENSOR_CHAN_FDC2X1X_CAPACITANCE_CH2,
-	/** CH3 Capacitance, in Picofarad **/
+	/** CH3 Capacitance, in picofarad **/
 	SENSOR_CHAN_FDC2X1X_CAPACITANCE_CH3,
 
 	/** CH0 Frequency, in MHz **/
@@ -41,5 +52,9 @@ enum sensor_channel_fdc2x1x {
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_FDC2X1X_ */

--- a/include/zephyr/drivers/sensor/pat9136.h
+++ b/include/zephyr/drivers/sensor/pat9136.h
@@ -5,8 +5,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of PAT9136 sensor
+ * @ingroup pat9136_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_PAT9136_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_PAT9136_H_
+
+/**
+ * @brief Pixart PAT9136 optical flow sensor
+ * @defgroup pat9136_interface PAT9136
+ * @ingroup sensor_interface_ext
+ * @{
+ */
 
 #include <zephyr/drivers/sensor.h>
 
@@ -14,7 +27,10 @@
 extern "C" {
 #endif
 
-/** This sensor does have the ability to provide DXY in meaningful units, and
+/**
+ * Custom sensor channels for PAT9136
+ *
+ * This sensor does have the ability to provide DXY in meaningful units, and
  * since the standard channels' unit is in points (SENSOR_CHAN_POS_DX,
  * SENSOR_CHAN_POS_DY, SENSOR_CHAN_POS_DXYZ), we've captured the following
  * channels to provide an alternative for this sensor.
@@ -34,5 +50,9 @@ enum sensor_channel_pat9136 {
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_PAT9136_H_ */


### PR DESCRIPTION
Complete the Doxygen documentation for a couple more sensor drivers.