### PR TITLE
MAINTAINERS: add entry for the firmware subsystem

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1583,6 +1583,18 @@ Documentation Infrastructure:
   tests:
     - drivers.fpga
 
+"Drivers: Firmware":
+  status: maintained
+  maintainers:
+    - LaurentiuM1234
+  files:
+    - drivers/firmware/
+    - include/zephyr/drivers/firmware/
+    - dts/bindings/firmware/
+    - doc/hardware/arch/arm-scmi.rst
+  labels:
+    - "area: Firmware"
+
 "Drivers: Flash":
   status: maintained
   maintainers:


### PR DESCRIPTION
The firmware subsystem has been around since Zephyr 4.0. Therefore, add an entry for it in the MAINTAINERS file such that changes will no longer go unnoticed. For now, nominate myself as its maintainer.