### PR TITLE
drivers: nordic: replace semaphore in TWIM driver with mutex

### DIFF
--- a/include/zephyr/drivers/i2c/i2c_nrfx_twim.h
+++ b/include/zephyr/drivers/i2c/i2c_nrfx_twim.h
@@ -18,8 +18,7 @@
  *
  * @retval 0       If successful.
  * @retval -EBUSY  Returned without waiting.
- * @retval -EAGAIN Waiting period timed out,
- *                 or the underlying semaphore was reset during the waiting period.
+ * @retval -EAGAIN Waiting period timed out
  */
 int i2c_nrfx_twim_exclusive_access_acquire(const struct device *dev, k_timeout_t timeout);
 


### PR DESCRIPTION
Some devices on our systems require exclusive access to i2c buses for a set of transactions. Replace the semaphore used to gain exclusive access to the nordic TWIM bus with a mutex so we can call the i2c_nrfx_twim_exclusive_access_acquire() api and then execute multiple i2c transfers without another driver taking the bus in between

Test with twister:
`scripts/twister -v --device-testing --device-serial /dev/tty.usbmodem0010577226643 --device-serial-baud 115200 -p nrf54l15dk/nrf54l15/cpuapp -T tests/drivers/i2c/i2c_target_api --fixture i2c_bus_short`

`scripts/twister -v --device-testing --device-serial /dev/tty.usbmodem0010577226643 --device-serial-baud 115200 -p nrf54l15dk/nrf54l15/cpuapp -T tests/drivers/i2c/i2c_nrfx_twim --fixture i2c_bus_short`