### PR TITLE
boards: nxp: mimxrt1170_evk & mimxrt1160_evk:  M4 improvements

### DIFF
--- a/boards/nxp/mimxrt1160_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1160_evk/Kconfig.defconfig
@@ -34,7 +34,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 if NETWORKING
 
 config NET_L2_ETHERNET
-	default y if CPU_CORTEX_M7 # No cache memory support is required for driver
+	default y if DT_HAS_NXP_ENET_ENABLED && NETWORKING
 
 endif # NETWORKING
 

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm4.dts
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm4.dts
@@ -24,7 +24,7 @@
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,flash-controller = &is25wp128;
-		zephyr,flash = &is25wp128;
+		zephyr,flash = &ocram_m4_itcm;
 		nxp,m4-partition = &slot1_partition;
 		zephyr,ipc = &mailbox_b;
 	};

--- a/boards/nxp/mimxrt1170_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1170_evk/Kconfig.defconfig
@@ -37,7 +37,7 @@ endif # DISK_DRIVERS
 if NETWORKING
 
 config NET_L2_ETHERNET
-	default y if CPU_CORTEX_M7 # No cache memory support is required for driver
+	default y if DT_HAS_NXP_ENET_ENABLED && NETWORKING
 
 endif # NETWORKING
 

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.dts
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.dts
@@ -25,7 +25,7 @@
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan2;
 		zephyr,flash-controller = &is25wp128;
-		zephyr,flash = &ocram;
+		zephyr,flash = &ocram_m4_itcm;
 		nxp,m4-partition = &slot1_partition;
 		zephyr,ipc = &mailbox_b;
 	};

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -951,6 +951,22 @@
 			compatible = "zephyr,memory-region", "mmio-sram";
 			zephyr,memory-region = "OCRAM";
 			reg = <0x20200000 DT_SIZE_K(256)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* The M7 core accesses the M4 TCMs through the OCRAM alias.
+			 * Add an OCRAM alias region just for the M4 ITCM.  The M4
+			 * memory map:
+			 *	0x1FFE_0000 - 0x1FFF_FFFF: ITCM/RAM_L/sram0, OCRAM 0x2020_0000
+			 *	0x2000_0000 - 0x2001_FFFF: DTCM/RAM_U/sram1, OCRAM 0x2022_0000
+			 *
+			 * The M7 core can access this OCRAM alias for M4 ITCM and copy
+			 * the M4 image here.
+			 */
+			ocram_m4_itcm: ocram_m4_itcm@20200000 {
+				compatible = "mmio-sram";
+				reg = <0x20200000 DT_SIZE_K(128)>;
+			};
 		};
 
 		lpadc1: adc@40050000 {

--- a/dts/arm/nxp/nxp_rt11xx_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx_cm4.dtsi
@@ -25,7 +25,8 @@
 	};
 
 	/*
-	 * SRAM0 & SRAM1 are available only to the M4 core. EDMA_LPSR interrupts are connected
+	 * SRAM0 & SRAM1 are TCMs for the M4 core, which the M7 can access through the OCRAM alias.
+	 * EDMA_LPSR interrupts are connected
 	 * to the M4 core alone, hence this EDMA controller has been designated M4 only.
 	 * GPIO's 9, 11 are available to both M4 and M7 cores, however the GPIO interrupts are
 	 * only accessible to the M4.
@@ -35,11 +36,13 @@
 	soc {
 		/delete-node/ dma-controller@40070000;
 
+		/* M4 ITCM RAM_L */
 		sram0: memory@1ffe0000 {
 			compatible = "mmio-sram";
 			reg = <0x1ffe0000 DT_SIZE_K(128)>;
 		};
 
+		/* M4 DTCM RAM_U */
 		sram1: memory@20000000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x20000000 DT_SIZE_K(128)>;

--- a/samples/drivers/mbox/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
+++ b/samples/drivers/mbox/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
@@ -6,7 +6,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 

--- a/samples/drivers/mbox/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
+++ b/samples/drivers/mbox/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
@@ -6,7 +6,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 

--- a/samples/drivers/mbox/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/samples/drivers/mbox/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -6,7 +6,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 

--- a/samples/drivers/mbox_data/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
+++ b/samples/drivers/mbox_data/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
@@ -6,7 +6,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 

--- a/samples/drivers/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
+++ b/samples/drivers/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
@@ -6,7 +6,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 

--- a/samples/drivers/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/samples/drivers/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -6,7 +6,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
@@ -9,7 +9,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
@@ -9,7 +9,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -9,7 +9,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
@@ -9,7 +9,6 @@
 / {
 	/* Switch to lpuart2, since primary core uses lpuart1 */
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,ipc_shm = &ocram2_overlay;

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
@@ -9,7 +9,6 @@
 / {
 	/* Switch to lpuart2, since primary core uses lpuart1 */
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,ipc_shm = &ocram2_overlay;

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -7,7 +7,6 @@
 / {
 	/* Switch to lpuart2, since primary core uses lpuart1 */
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,ipc_shm = &ocram2_overlay;

--- a/tests/drivers/mbox/mbox_data/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
+++ b/tests/drivers/mbox/mbox_data/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
@@ -6,7 +6,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 

--- a/tests/drivers/mbox/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
+++ b/tests/drivers/mbox/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
@@ -6,7 +6,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 

--- a/tests/drivers/mbox/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/tests/drivers/mbox/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -6,7 +6,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 


### PR DESCRIPTION
- Fixes issue where zephyr,flash in ocram node overlaps with physical SRAM sram1 used for zephyr,sram.
- Moves default zephyr,flash from external flash to M4 ITCM to improve performance.
- Updates overlays that moved zephyr,flash to ocram now use default
- enable M4 CONFIG_NET_L2_ETHERNET