### PR TITLE
boards: stm32: Fix User LD1 pin assignment

### DIFF
--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q.dtsi
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q.dtsi
@@ -13,7 +13,7 @@
 		compatible = "gpio-leds";
 
 		green_led: led_1 {
-			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
 


### PR DESCRIPTION
boards: nucleo_h755zi_q: Fix green LED pin assignment

The green LED (User LD1) on the NUCLEO-H755ZI-Q board was previously configured
to use pin PA5 in the Device Tree source file (nucleo_h755zi_q.dtsi).

However, according to the board's user manual (UM2408), User LD1 can be connected
to either PA5 or PB0 depending on the solder bridge configuration:

PB0: SB65 OFF, SB54 ON (default configuration)  
PA5: SB65 ON, SB54 OFF  

Since PB0 is the default configuration on most boards out of the box, this patch
updates the green_led node to use pin PB0 (&gpiob 0) instead of PA5.

Reference:  
NUCLEO-H755ZI-Q User Manual: https://www.st.com/resource/en/user_manual/um2408-stm32h7-nucleo144-board-mb1364-stmicroelectronics.pdf

Signed-off-by: Le Viet Duc <levietduc0712@gmail.com>