### PR TITLE
libc: newlib: limits.h: include zephyr's posix limits

### DIFF
--- a/include/zephyr/posix/posix_limits.h
+++ b/include/zephyr/posix/posix_limits.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_ZEPHYR_POSIX_POSIX_LIMITS_H_
 #define ZEPHYR_INCLUDE_ZEPHYR_POSIX_POSIX_LIMITS_H_
 
+#if defined(_POSIX_C_SOURCE) || defined(__DOXYGEN__)
+
 /*
  * clang-format and checkpatch disagree on formatting here, so rely on checkpatch and disable
  * clang-format since checkpatch cannot be selectively disabled.
@@ -121,5 +123,7 @@
 #define SYMLINK_MAX              _POSIX_SYMLINK_MAX
 
 /* clang-format on */
+
+#endif
 
 #endif /* ZEPHYR_INCLUDE_ZEPHYR_POSIX_POSIX_LIMITS_H_ */

--- a/lib/libc/arcmwdt/include/limits.h
+++ b/lib/libc/arcmwdt/include/limits.h
@@ -8,23 +8,10 @@
 #define LIB_LIBC_ARCMWDT_INCLUDE_LIMITS_H_
 
 #include_next <limits.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#if defined(_POSIX_C_SOURCE) || defined(__DOXYGEN__)
-
 #include <zephyr/posix/posix_limits.h>
 
-#else
-
+#ifndef PATH_MAX
 #define PATH_MAX 256
-
 #endif
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif  /* ZEPHYR_LIB_LIBC_ARMSTDC_INCLUDE_LIMITS_H_ */
+#endif  /* LIB_LIBC_ARCMWDT_INCLUDE_LIMITS_H_ */

--- a/lib/libc/armstdc/include/limits.h
+++ b/lib/libc/armstdc/include/limits.h
@@ -8,23 +8,10 @@
 #define ZEPHYR_LIB_LIBC_ARMSTDC_INCLUDE_LIMITS_H_
 
 #include_next <limits.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#if defined(_POSIX_C_SOURCE) || defined(__DOXYGEN__)
-
 #include <zephyr/posix/posix_limits.h>
 
-#else
-
+#ifndef PATH_MAX
 #define PATH_MAX 256
-
-#endif
-
-#ifdef __cplusplus
-}
 #endif
 
 #endif  /* ZEPHYR_LIB_LIBC_ARMSTDC_INCLUDE_LIMITS_H_ */

--- a/lib/libc/iar/include/limits.h
+++ b/lib/libc/iar/include/limits.h
@@ -8,23 +8,10 @@
 #define ZEPHYR_LIB_LIBC_IAR_INCLUDE_LIMITS_H_
 
 #include_next <limits.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#if defined(_POSIX_C_SOURCE) || defined(__DOXYGEN__)
-
 #include <zephyr/posix/posix_limits.h>
 
-#else
-
+#ifndef PATH_MAX
 #define PATH_MAX 256
-
-#endif
-
-#ifdef __cplusplus
-}
 #endif
 
 #endif /* ZEPHYR_LIB_LIBC_IAR_INCLUDE_LIMITS_H_ */

--- a/lib/libc/newlib/include/limits.h
+++ b/lib/libc/newlib/include/limits.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_LIMITS_H_
+#define ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_LIMITS_H_
+
+#include_next <limits.h>
+#include <zephyr/posix/posix_limits.h>
+
+#endif /* ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_LIMITS_H_ */


### PR DESCRIPTION
* posix: limits: de-duplicate limit logic
* libc: newlib: limits.h: include posix limits from zephyr

Fixes #95194
Required by #88547