### PR TITLE
drivers: sensor: paj7620: Fix potential integer overflow in driver

### DIFF
--- a/drivers/sensor/pixart/paj7620/paj7620.c
+++ b/drivers/sensor/pixart/paj7620/paj7620.c
@@ -107,7 +107,7 @@ static int paj7620_set_sampling_rate(const struct device *dev, const struct sens
 	int ret;
 	int fps;
 	const struct paj7620_config *config = dev->config;
-	int64_t uval = val->val1 * 1000000 + val->val2;
+	int64_t uval = ((int64_t)val->val1 * (int64_t)1000000) + val->val2;
 
 	if (uval <= 120000000) {
 		fps = PAJ7620_NORMAL_SPEED;


### PR DESCRIPTION
Fix Coverity issue CID 524766: A potential integer overflow could occur in paj7620_set_sampling_rate() due to multiplication of sensor_value->val1 instance(which is of type int32_t) with 1000000 without typecasting it to int64_t.

This patch ensures that the integers are typecasted to int64_t before multiplication to avoid overflow.

Fixes #90482