### PR TITLE
drivers: i2s: stm32 sai fix H7xx dma configuration

### DIFF
--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -286,9 +286,11 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	hdma->Instance = __LL_DMA_GET_STREAM_INSTANCE(stream->reg, stream->dma_channel);
 	hdma->Init.PeriphDataAlignment = DMA_PDATAALIGN_HALFWORD;
-	hdma->Init.MemDataAlignment = DMA_PDATAALIGN_HALFWORD;
+	hdma->Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;
 	hdma->Init.Priority = DMA_PRIORITY_HIGH;
 	hdma->Init.FIFOMode = DMA_FIFOMODE_DISABLE;
+	hdma->Init.PeriphInc = DMA_PINC_DISABLE;
+	hdma->Init.MemInc = DMA_MINC_ENABLE;
 #else
 	hdma->Instance = LL_DMA_GET_CHANNEL_INSTANCE(stream->reg, stream->dma_channel);
 	hdma->Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
@@ -307,10 +309,7 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 	if (stream->dma_cfg.channel_direction == (enum dma_channel_direction)MEMORY_TO_PERIPHERAL) {
 		hdma->Init.Direction = DMA_MEMORY_TO_PERIPH;
 
-#if defined(CONFIG_SOC_SERIES_STM32H7X)
-		hdma->Init.PeriphInc = DMA_PINC_DISABLE;
-		hdma->Init.MemInc = DMA_MINC_ENABLE;
-#else
+#if !defined(CONFIG_SOC_SERIES_STM32H7X)
 		hdma->Init.SrcInc = DMA_SINC_INCREMENTED;
 		hdma->Init.DestInc = DMA_DINC_FIXED;
 #endif
@@ -319,10 +318,7 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 	} else {
 		hdma->Init.Direction = DMA_PERIPH_TO_MEMORY;
 
-#if defined(CONFIG_SOC_SERIES_STM32H7X)
-		hdma->Init.PeriphInc = DMA_PINC_ENABLE;
-		hdma->Init.MemInc = DMA_MINC_DISABLE;
-#else
+#if !defined(CONFIG_SOC_SERIES_STM32H7X)
 		hdma->Init.SrcInc = DMA_SINC_FIXED;
 		hdma->Init.DestInc = DMA_DINC_INCREMENTED;
 #endif


### PR DESCRIPTION
This PR fixes SAI DMA configuration for STM32H7xx series

`PeriphInc` and `MemInc` should be as follows for both TX & RX:
```
hdma->Init.PeriphInc = DMA_PINC_DISABLE;
hdma->Init.MemInc = DMA_MINC_ENABLE;
```

`MemDataAlignment` should be set to `DMA_MDATAALIGN_HALFWORD`

`hdma->Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;`