### PR TITLE
samples: Fix documentation formatting for pressure polling sample

### DIFF
--- a/samples/sensor/pressure_polling/README.rst
+++ b/samples/sensor/pressure_polling/README.rst
@@ -45,8 +45,6 @@ Sample Output
 
 .. code-block:: console
 
-## Default configuration
-
    Found device "icp101xx@63", getting sensor data
    Starting pressure and altitude polling sample.
    temp 25.49 Cel, pressure 96.271438 kPa, altitude 447.208465 m


### PR DESCRIPTION
The sample output is not rendered properly, as can be seen on https://docs.zephyrproject.org/latest/samples/sensor/pressure_polling/README.html

Adjust the formatting so that the code block is rendered properly. The text "## Default configuration" does not appear in the sample output.