### PR TITLE
include: drivers: rtc: counter: deprecate counter-based DS3231 driver

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -64,6 +64,8 @@ Removed APIs and options
 Deprecated APIs and options
 ===========================
 
+* :dtcompatible:`maxim,ds3231` is deprecated in favor of :dtcompatible:`maxim,ds3231-rtc`.
+
 New APIs and options
 ====================
 

--- a/dts/bindings/counter/maxim,ds3231.yaml
+++ b/dts/bindings/counter/maxim,ds3231.yaml
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: Maxim DS3231 I2C RTC/TCXO
+# This binding is deprecated in favor of maxim,ds3231-rtc.
+
+description: Maxim DS3231 I2C RTC/TCXO.
 
 compatible: "maxim,ds3231"
 

--- a/include/zephyr/drivers/rtc/maxim_ds3231.h
+++ b/include/zephyr/drivers/rtc/maxim_ds3231.h
@@ -207,9 +207,10 @@ extern "C" {
 #define MAXIM_DS3231_ALARM_FLAGS_AUTODISABLE BIT(7)
 
 /**
- * @brief RTC DS3231 Driver-Specific API
- * @defgroup rtc_ds3231_interface RTC DS3231 Interface
- * @ingroup io_interfaces
+ * @brief Interface for Maxim DS3231 RTC (using counter API).
+ * @defgroup rtc_ds3231_interface RTC DS3231 (legacy).
+ * @ingroup misc_interfaces
+ * @deprecated Use MFD driver instead. See `maxim,ds3231-rtc` compatible.
  * @{
  */
 

--- a/samples/drivers/counter/maxim_ds3231/README.rst
+++ b/samples/drivers/counter/maxim_ds3231/README.rst
@@ -7,6 +7,12 @@
 Overview
 ********
 
+.. warning::
+
+   The DS3231 driver demonstrated in this sample predates the introduction of
+   the RTC subsystem and is deprecated. RTC functionality for the DS3231 should
+   now be enabled by means of the :dtcompatible:`maxim,ds3231-rtc` compatible.
+
 The `DS3231`_ temperature-compensated real-time clock is a
 high-precision (2 ppm) battery backed clock that maintains civil time
 and supports alarms.  The `Chronodot`_ breakout board can be used to


### PR DESCRIPTION
There is a "native" RTC driver for DS3231 now (maxim,ds3231-rtc, one of the multiple functions implemented as MFD) so do all we can to discourage the use of the legacy, counter-API based, driver.

Flag the compatible as deprecated.