### PR TITLE
boards: ti: lp_em_cc2340r5: Add support for debug and flash

### DIFF
--- a/boards/ti/lp_em_cc2340r5/board.cmake
+++ b/boards/ti/lp_em_cc2340r5/board.cmake
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Fabian Pflug
+#
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=CC2340R5" "--iface=swd")
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/ti/lp_em_cc2340r5/doc/index.rst
+++ b/boards/ti/lp_em_cc2340r5/doc/index.rst
@@ -86,9 +86,51 @@ Programming and Debugging
 The LP_EM_CC2340R5 requires an external debug probe such as the LP-XDS110 or
 LP-XDS110ET.
 
-Currently there is no debug support in Zephyr for the LP_EM_CC2340R5, and the
-built binaries for this target must be flashed/debugged using either Uniflash
-or Code Composer Studio.
+Alternativly a J-Link could be used on the J4 header, in combination with a 3.3V
+power supply over the pinheader.
+Debugging and flashing is currently only tested using a J-Link on the J4 header.
+
+To get a console, connect an external USB to UART converter with:
+
++----+-------+
+| TX | DIO22 |
++----+-------+
+| RX | DIO20 |
++----+-------+
+
+Then you can connect to it from you PC:
+
+.. code-block:: console
+
+   $ microcom -p <tty_device>
+
+Replace :code:`<tty_device>` with the port of your USB to UART converter.
+For example, :code:`/dev/ttyUSB0`.
+
+Flashing
+========
+
+Applications for the ``CC2340R5 LaunchPad`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
+Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: lp_em_cc2340r5
+   :goals: build flash
+
+Debugging
+=========
+
+You can debug an application in the usual way. Here is an example for the
+:zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: lp_em_cc2340r5
+   :goals: debug
 
 References
 **********

--- a/soc/ti/simplelink/cc23x0/CMakeLists.txt
+++ b/soc/ti/simplelink/cc23x0/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Copyright (c) 2024 Texas Instruments Incorporated
 # Copyright (c) 2024 BayLibre, SAS
+# Copyright (c) 2025 Fabian Pflug
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -10,3 +11,17 @@ zephyr_include_directories(.)
 zephyr_linker_sources_ifdef(CONFIG_HAS_TI_CCFG SECTIONS ccfg.ld)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
+
+set(checksums_calculated_file ${PROJECT_BINARY_DIR}/${KERNEL_NAME}_crc32.hex  CACHE PATH "crc checksums inserted")
+
+set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+    # Create a new file with correct crc32 checksums
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/ti_ccfg_crc32_calculate.py
+    ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME}
+    ${checksums_calculated_file}
+)
+
+# runners_yaml_props_target controls the file used by "west flash"
+set_property(TARGET runners_yaml_props_target PROPERTY hex_file ${checksums_calculated_file})
+
+set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts ${checksums_calculated_file})

--- a/soc/ti/simplelink/cc23x0/Kconfig.defconfig
+++ b/soc/ti/simplelink/cc23x0/Kconfig.defconfig
@@ -16,4 +16,7 @@ config SYS_CLOCK_TICKS_PER_SEC
 config NUM_IRQS
 	default 19
 
+config BUILD_OUTPUT_BIN
+	default n
+
 endif

--- a/soc/ti/simplelink/cc23x0/ti_ccfg_crc32_calculate.py
+++ b/soc/ti/simplelink/cc23x0/ti_ccfg_crc32_calculate.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Fabian Pflug
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from zlib import crc32
+
+from intelhex import IntelHex
+
+CRC_LEN = 4
+TI_CCFG_SECTION_START = 0x4E020000
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} source_file target_file")
+        sys.exit(1)
+
+    handle = IntelHex()
+    handle.loadhex(sys.argv[1])
+
+    # data from https://www.ti.com/lit/ug/swcu193a/swcu193a.pdf table 9-2 CRC Locations
+    sections = [
+        (0x0, 0xC),
+        (0x10, 0x74C),
+        (0x750, 0x7CC),
+        (0x7D0, 0x7FC),
+    ]
+
+    for start, end in sections:
+        data = handle.gets(TI_CCFG_SECTION_START + start, end - start)
+        crc = (crc32(data) & 0xFFFFFFFF).to_bytes(CRC_LEN, "little")
+        handle.puts(TI_CCFG_SECTION_START + end, crc)
+
+    handle.write_hex_file(sys.argv[2])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Created a tool to generate the crc32 sum and write it inside the .hex file and put it as a post-build command step.

Now debugging and flashing the devboard using J-Link is possible.