### PR TITLE
posix: system_database_r: remove invalid compilation filters

### DIFF
--- a/lib/posix/options/grp.c
+++ b/lib/posix/options/grp.c
@@ -9,8 +9,6 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/posix/grp.h>
 
-#ifdef CONFIG_POSIX_THREAD_SAFE_FUNCTIONS
-
 int getgrnam_r(const char *name, struct group *grp, char *buffer, size_t bufsize,
 	       struct group **result)
 {
@@ -33,5 +31,3 @@ int getgrgid_r(gid_t gid, struct group *grp, char *buffer, size_t bufsize, struc
 
 	return ENOSYS;
 }
-
-#endif /* CONFIG_POSIX_THREAD_SAFE_FUNCTIONS */

--- a/lib/posix/options/pwd.c
+++ b/lib/posix/options/pwd.c
@@ -9,8 +9,6 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/posix/pwd.h>
 
-#ifdef CONFIG_POSIX_THREAD_SAFE_FUNCTIONS
-
 int getpwnam_r(const char *nam, struct passwd *pwd, char *buffer, size_t bufsize,
 	       struct passwd **result)
 {
@@ -33,5 +31,3 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buffer, size_t bufsize, stru
 
 	return ENOSYS;
 }
-
-#endif /* CONFIG_POSIX_THREAD_SAFE_FUNCTIONS */


### PR DESCRIPTION
The files `pwd.c` and `grp.c` both had incorrect preprocessor guards around the stubs that they were implementing. Functions were surrounded by

```cpp
#ifdef CONFIG_POSIX_THREAD_SAFE_FUNCTIONS
..
#endif
```

which is not at all accurate, since that subprofiling option group is `(CONFIG_)POSIX_SYSTEM_DATABASE_R`.

https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html

Remove the guards, since they are invalid anyway, and at least allow applications to link properly.

Required by #88547