### PR TITLE
tests: posix: common: use realtime clock instead of monotonic

### DIFF
--- a/tests/posix/common/src/mutex.c
+++ b/tests/posix/common/src/mutex.c
@@ -6,6 +6,7 @@
 
 #include <errno.h>
 #include <pthread.h>
+#include <time.h>
 
 #include <zephyr/sys/util.h>
 #include <zephyr/ztest.h>
@@ -182,7 +183,7 @@ static void *test_mutex_timedlock_fn(void *arg)
 	struct timespec time_point;
 	pthread_mutex_t *mtx = (pthread_mutex_t *)arg;
 
-	zassume_ok(clock_gettime(CLOCK_MONOTONIC, &time_point));
+	zassume_ok(clock_gettime(CLOCK_REALTIME, &time_point));
 	timespec_add_ms(&time_point, TIMEDLOCK_TIMEOUT_MS);
 
 	return INT_TO_POINTER(pthread_mutex_timedlock(mtx, &time_point));

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -6,6 +6,7 @@
 
 #include <pthread.h>
 #include <semaphore.h>
+#include <time.h>
 
 #include <zephyr/sys/util.h>
 #include <zephyr/ztest.h>
@@ -409,8 +410,8 @@ ZTEST(pthread, test_pthread_timedjoin)
 	};
 
 	/* setup timespecs when the thread is still running and when it is done */
-	clock_gettime(CLOCK_MONOTONIC, &not_done);
-	clock_gettime(CLOCK_MONOTONIC, &done);
+	clock_gettime(CLOCK_REALTIME, &not_done);
+	clock_gettime(CLOCK_REALTIME, &done);
 	not_done.tv_nsec += sleep_duration_ms / 2 * NSEC_PER_MSEC;
 	done.tv_nsec += sleep_duration_ms * 1.5 * NSEC_PER_MSEC;
 	while (not_done.tv_nsec >= NSEC_PER_SEC) {


### PR DESCRIPTION
This PR updates POSIX test files to use the realtime clock (`CLOCK_REALTIME`) instead of the monotonic clock (`CLOCK_MONOTONIC`) to ensure compatibility with systems that only guarantee availability of the realtime clock under `_POSIX_TIMERS`.

* Replaces `CLOCK_MONOTONIC` with `CLOCK_REALTIME` in timing-related test functions
* Adds `#include <time.h>` to both test files to ensure proper clock type definitions

Required by #88547