### PR TITLE
doc: develop: west: alias: add example for auto-excluding platforms

### DIFF
--- a/doc/develop/west/alias.rst
+++ b/doc/develop/west/alias.rst
@@ -59,3 +59,11 @@ Override ``west update`` to check a local cache:
 .. code-block:: shell
 
    west config alias.update "update --path-cache $HOME/.cache/zephyrproject"
+
+Automatically exclude the 32-bit native simulator target when running :ref:`Twister
+<twister_script>` via west. This is especially useful when running on hosts systems without a 32-bit
+host C library (i.e. Linux/AArch64):
+
+.. code-block:: shell
+
+   west config alias.twister "twister --exclude-platform native_sim/native"


### PR DESCRIPTION
Add an example west alias for automatically excluding certain platforms when running Twister via west.

This is especially useful for excluding the 32-bit native_sim target when running on hosts systems without a 32-bit host C library (i.e. Linux/AArch64).

This was inspired by @carlescufi's talk on Demystifying West at ZDS 2025 in Amsterdam. Thank you for the hints! :)