### PR TITLE
scripts: valgrind: suppress missing clean-up in nct_new_thread()

### DIFF
--- a/scripts/valgrind.supp
+++ b/scripts/valgrind.supp
@@ -12,7 +12,8 @@
    Memcheck:Leak
    match-leak-kinds: reachable,possible
    ...
-   fun:posix_new_thread
+   fun:nct_new_thread
+   ...
    fun:arch_new_thread
 }
 {


### PR DESCRIPTION
Suppress memory leaks detected by valgrind originating from nct_new_thread(), part of the native_sim CPU thread emulation.

This covers calls to posix_new_thread() as well, since this function simply calls nct_new_thread (but may be optimized out by the compiler).


Inspired to use valgrind with native_sim by @aescolar's great talk on native_sim at ZDS 2025 in Amsterdam, thanks!