### PR TITLE
lib: libc: minimal: Refactor stdbool.h for C23

### DIFF
--- a/lib/libc/minimal/include/stdbool.h
+++ b/lib/libc/minimal/include/stdbool.h
@@ -9,7 +9,7 @@
 #ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_STDBOOL_H_
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_STDBOOL_H_
 
-#ifndef __cplusplus
+#if !defined(__cplusplus) && __STDC_VERSION__ < 202311L
 #define bool   _Bool
 #define true   1
 #define false  0


### PR DESCRIPTION
Updated minimal libc to use the type "bool" which was introduced in C23 instead of defining it as a macro.

Link: https://en.cppreference.com/w/c/header/stdbool