### PR TITLE
fs: littlefs: Implement littlefs threadsafe config

### DIFF
--- a/modules/littlefs/zephyr_lfs_config.h
+++ b/modules/littlefs/zephyr_lfs_config.h
@@ -73,6 +73,9 @@ extern "C"
 #define LFS_ASSERT(test) __ASSERT_NO_MSG(test)
 #endif
 
+#ifdef CONFIG_FS_LITTLEFS_THREADSAFE
+#define LFS_THREADSAFE
+#endif
 
 /* Builtin functions, these may be replaced by more efficient */
 /* toolchain-specific implementations. LFS_NO_INTRINSICS falls back to a more */

--- a/subsys/fs/Kconfig.littlefs
+++ b/subsys/fs/Kconfig.littlefs
@@ -132,4 +132,10 @@ config FS_LITTLEFS_DISK_VERSION_NUMBER
 	help
 	  Set to 0 to use the latest littlefs disk version (LFS_DISK_VERSION).
 
+config FS_LITTLEFS_THREADSAFE
+	bool "Enabling locking on all littlefs APIs"
+	default 0
+	help
+	  Makes littlefs threadsafe by wrapping all public littlefs APIs in a lock
+
 endif # FILE_SYSTEM_LITTLEFS

--- a/tests/subsys/fs/littlefs/testcase.yaml
+++ b/tests/subsys/fs/littlefs/testcase.yaml
@@ -49,3 +49,7 @@ tests:
     extra_configs:
       - CONFIG_APP_TEST_CUSTOM=y
       - CONFIG_FS_LITTLEFS_FC_HEAP_SIZE=16384
+  filesystem.littlefs.api_lock:
+    timeout: 60
+    extra_configs:
+      - CONFIG_FS_LITTLEFS_THREADSAFE=y


### PR DESCRIPTION
Littlefs wraps each one of its public APIs with a lock. 
https://github.com/littlefs-project/littlefs/blob/8e251dd675da00342d45dac78b6f627f119aed03/lfs.c#L5957-L5960
https://github.com/littlefs-project/littlefs/pull/470

Implement the lock for Zephyr and expose the configuration.