### PR TITLE
tests: posix: Increase min_ram for xsi.single_process.newlib

### DIFF
--- a/tests/posix/xsi_single_process/testcase.yaml
+++ b/tests/posix/xsi_single_process/testcase.yaml
@@ -31,6 +31,7 @@ tests:
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE=256
+    min_ram: 24
   portability.xsi.single_process.picolibc:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED


### PR DESCRIPTION
Without this change, running the test for hifive1/fe310_g000 fails when trying to allocate space for env variables, with `heap size is too small`.

This change filters the platform in question out.