### PR TITLE
dts: arm: atmel: refactor to use a common parent node for sam ethernet and mdio

### DIFF
--- a/boards/atmel/sam/sam_e70_xplained/pre_dt_board.cmake
+++ b/boards/atmel/sam/sam_e70_xplained/pre_dt_board.cmake
@@ -1,6 +1,0 @@
-# Copyright (c) 2024 Gerson Fernando Budke <nandojve@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
-
-# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
-# - /soc/ethernet@40050000 & /soc/mdio@40050000
-list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/atmel/sam/sam_v71_xult/pre_dt_board.cmake
+++ b/boards/atmel/sam/sam_v71_xult/pre_dt_board.cmake
@@ -1,6 +1,0 @@
-# Copyright (c) 2024 Gerson Fernando Budke <nandojve@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
-
-# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
-# - /soc/ethernet@40050000 & /soc/mdio@40050000
-list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2155,10 +2155,10 @@ static void eth0_irq_config(void)
 PINCTRL_DT_INST_DEFINE(0);
 
 static const struct eth_sam_dev_cfg eth0_config = {
-	.regs = (Gmac *)DT_INST_REG_ADDR(0),
+	.regs = (Gmac *)DT_REG_ADDR(DT_INST_PARENT(0)),
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 #ifdef CONFIG_SOC_FAMILY_ATMEL_SAM
-	.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0),
+	.clock_cfg = SAM_DT_CLOCK_PMC_CFG(0, DT_INST_PARENT(0)),
 #endif
 	.config_func = eth0_irq_config,
 	.phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, phy_handle))

--- a/drivers/mdio/mdio_sam.c
+++ b/drivers/mdio/mdio_sam.c
@@ -169,12 +169,14 @@ static DEVICE_API(mdio, mdio_sam_driver_api) = {
 
 #define MDIO_SAM_CLOCK(n)						\
 	COND_CODE_1(CONFIG_SOC_FAMILY_ATMEL_SAM,			\
-		(.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(n),), ()	\
+		(.clock_cfg =						\
+			SAM_DT_CLOCK_PMC_CFG(0, DT_INST_PARENT(n)),),	\
+		()							\
 	)
 
 #define MDIO_SAM_CONFIG(n)						\
 static const struct mdio_sam_dev_config mdio_sam_dev_config_##n = {	\
-	.regs = (Gmac *)DT_INST_REG_ADDR(n),				\
+	.regs = (Gmac *)DT_REG_ADDR(DT_INST_PARENT(n)),			\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
 	MDIO_SAM_CLOCK(n)						\
 };

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -165,24 +165,26 @@
 			status = "disabled";
 		};
 
-		gmac: ethernet@40034000 {
-			compatible = "atmel,sam-gmac";
+		ethernet@40034000 {
+			compatible = "microchip,sam-ethernet-controller";
 			reg = <0x40034000 0x4000>;
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 44>;
-			interrupts = <44 0>;
-			interrupt-names = "gmac";
-			num-queues = <1>;
-			phy-connection-type = "mii";
-			status = "disabled";
-		};
 
-		mdio: mdio@40034000 {
-			compatible = "atmel,sam-mdio";
-			reg = <0x40034000 0x4000>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 44>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
+			gmac: ethernet {
+				compatible = "atmel,sam-gmac";
+				interrupts = <44 0>;
+				interrupt-names = "gmac";
+				num-queues = <1>;
+				phy-connection-type = "mii";
+				status = "disabled";
+			};
+
+			mdio: mdio {
+				compatible = "atmel,sam-mdio";
+				status = "disabled";
+				#address-cells = <1>;
+				#size-cells = <0>;
+			};
 		};
 
 		pinctrl: pinctrl@400e0e00 {

--- a/dts/arm/atmel/same5x.dtsi
+++ b/dts/arm/atmel/same5x.dtsi
@@ -10,24 +10,27 @@
 
 / {
 	soc {
-		gmac: ethernet@42000800 {
-			compatible = "atmel,sam0-gmac";
+		ethernet@42000800 {
+			compatible = "microchip,sam-ethernet-controller";
 			reg = <0x42000800 0x400>;
-			interrupts = <84 0>;
-			interrupt-names = "gmac";
-			status = "disabled";
 
-			num-queues = <1>;
-			local-mac-address = [00 00 00 00 00 00];
-		};
+			gmac: ethernet {
+				compatible = "atmel,sam0-gmac";
+				interrupts = <84 0>;
+				interrupt-names = "gmac";
+				status = "disabled";
 
-		mdio: mdio@42000800 {
-			compatible = "atmel,sam-mdio";
-			reg = <0x42000800 0x400>;
-			status = "disabled";
+				num-queues = <1>;
+				local-mac-address = [00 00 00 00 00 00];
+			};
 
-			#address-cells = <1>;
-			#size-cells = <0>;
+			mdio: mdio {
+				compatible = "atmel,sam-mdio";
+				status = "disabled";
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+			};
 		};
 
 		can0: can@42000000 {

--- a/dts/arm/atmel/samx7x.dtsi
+++ b/dts/arm/atmel/samx7x.dtsi
@@ -232,24 +232,26 @@
 			#io-channel-cells = <1>;
 		};
 
-		gmac: ethernet@40050000 {
-			compatible = "atmel,sam-gmac";
+		ethernet@40050000 {
+			compatible = "microchip,sam-ethernet-controller";
 			reg = <0x40050000 0x4000>;
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 39>;
-			interrupts = <39 0>, <66 0>, <67 0>;
-			interrupt-names = "gmac", "q1", "q2";
-			num-queues = <3>;
-			local-mac-address = [00 00 00 00 00 00];
-			status = "disabled";
-		};
 
-		mdio: mdio@40050000 {
-			compatible = "atmel,sam-mdio";
-			reg = <0x40050000 0x4000>;
-			clocks = <&pmc PMC_TYPE_PERIPHERAL 39>;
-			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <0>;
+			gmac: ethernet {
+				compatible = "atmel,sam-gmac";
+				interrupts = <39 0>, <66 0>, <67 0>;
+				interrupt-names = "gmac", "q1", "q2";
+				num-queues = <3>;
+				local-mac-address = [00 00 00 00 00 00];
+				status = "disabled";
+			};
+
+			mdio: mdio {
+				compatible = "atmel,sam-mdio";
+				status = "disabled";
+				#address-cells = <1>;
+				#size-cells = <0>;
+			};
 		};
 
 		tc3: tc@40054000 {

--- a/dts/bindings/ethernet/atmel,gmac-common.yaml
+++ b/dts/bindings/ethernet/atmel,gmac-common.yaml
@@ -7,9 +7,6 @@ include:
   - name: pinctrl-device.yaml
 
 properties:
-  reg:
-    required: true
-
   phy-handle:
     required: true
 

--- a/dts/bindings/ethernet/atmel,sam-gmac.yaml
+++ b/dts/bindings/ethernet/atmel,sam-gmac.yaml
@@ -6,7 +6,3 @@ description: Atmel SAM-family GMAC Ethernet
 compatible: "atmel,sam-gmac"
 
 include: atmel,gmac-common.yaml
-
-properties:
-  clocks:
-    required: true

--- a/dts/bindings/ethernet/microchip,sam-ethernet-controller.yaml
+++ b/dts/bindings/ethernet/microchip,sam-ethernet-controller.yaml
@@ -1,0 +1,15 @@
+# Copyright (C) 2025 Microchip Technology Inc. and its subsidiaries
+# SPDX-License-Identifier: Apache-2.0
+
+title: Microchip SAM Ethernet Controller
+
+description: |
+  Contains the Ethernet MAC and the MDIO as child nodes.
+
+compatible: "microchip,sam-ethernet-controller"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true


### PR DESCRIPTION
This pull request is to solve the issue mentioned at https://github.com/zephyrproject-rtos/zephyr/pull/95135#discussion_r2309564868

Changes:
 - refactor `ethernet@40050000` and `mdio@40050000` to use a common parent node
 - add yaml file for the new parent node
 - update the drivers to get the register address from the parent node
 - remove the suppress of compile warning `unique_unit_address_if_enabled`