### PR TITLE
drivers: sensor: adxl367: fix for temperature readout

### DIFF
--- a/drivers/sensor/adi/adxl367/adxl367.c
+++ b/drivers/sensor/adi/adxl367/adxl367.c
@@ -743,29 +743,38 @@ int adxl367_get_accel_data(const struct device *dev,
 }
 
 /**
- * @brief Reads the raw temperature of the device. If ADXL367_TEMP_EN is not
- *        set, use adxl367_temp_read_en() first to enable temperature reading.
+ * @brief Reads the raw temperature of the device.
  *
- * @param dev      - The device structure.
- * @param raw_temp - Raw value of temperature.
+ * If ADXL367_TEMP_EN is not set, use adxl367_temp_read_en() first to enable temperature reading.
+ * Optionally checks the data ready status before reading temperature.
+ *
+ * @param dev            - The device structure.
+ * @param raw_temp       - Raw value of temperature.
+ * @param check_data_rdy - If true, waits for data ready status before reading temperature.
+ *                         If false, reads temperature directly. Note: The DATA_READY bit is
+ *                         cleared when data is read; set this flag to false if temperature from
+ *                         the same sample frame is needed after performing an axis(x,y,z) read.
  *
  * @return 0 in case of success, negative error code otherwise.
  */
-int adxl367_get_temp_data(const struct device *dev, int16_t *raw_temp)
+int adxl367_get_temp_data(const struct device *dev, int16_t *raw_temp, bool check_data_rdy)
 {
 	int ret;
 	uint8_t temp[2] = { 0 };
-	uint8_t reg_data, nready = 1U;
 	struct adxl367_data *data = dev->data;
 
-	while (nready != 0) {
-		ret = data->hw_tf->read_reg(dev, ADXL367_STATUS, &reg_data);
-		if (ret != 0) {
-			return ret;
-		}
+	if (check_data_rdy) {
+		uint8_t reg_data, nready = 1U;
 
-		if ((reg_data & ADXL367_STATUS_DATA_RDY) != 0) {
-			nready = 0U;
+		while (nready != 0) {
+			ret = data->hw_tf->read_reg(dev, ADXL367_STATUS, &reg_data);
+			if (ret != 0) {
+				return ret;
+			}
+
+			if ((reg_data & ADXL367_STATUS_DATA_RDY) != 0) {
+				nready = 0U;
+			}
 		}
 	}
 
@@ -879,8 +888,14 @@ static int adxl367_sample_fetch(const struct device *dev,
 	if (ret != 0) {
 		return ret;
 	}
+	const struct adxl367_dev_config *cfg = dev->config;
+	bool check_temp_data_ready = false;
 
-	return adxl367_get_temp_data(dev, &data->temp_val);
+	if (cfg->temp_en) {
+		ret = adxl367_get_temp_data(dev, &data->temp_val, check_temp_data_ready);
+	}
+
+	return ret;
 }
 #ifdef CONFIG_SENSOR_ASYNC_API
 void adxl367_accel_convert(struct sensor_value *val, int16_t value,

--- a/drivers/sensor/adi/adxl367/adxl367.h
+++ b/drivers/sensor/adi/adxl367/adxl367.h
@@ -442,7 +442,7 @@ void adxl367_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
 int adxl367_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder);
 int adxl367_get_accel_data(const struct device *dev,
 			   struct adxl367_xyz_accel_data *accel_data);
-int adxl367_get_temp_data(const struct device *dev, int16_t *raw_temp);
+int adxl367_get_temp_data(const struct device *dev, int16_t *raw_temp, bool check_data_rdy);
 void adxl367_accel_convert(struct sensor_value *val, int16_t value,
 				enum adxl367_range range);
 void adxl367_temp_convert(struct sensor_value *val, int16_t value);

--- a/drivers/sensor/adi/adxl367/adxl367_rtio.c
+++ b/drivers/sensor/adi/adxl367/adxl367_rtio.c
@@ -44,8 +44,9 @@ static void adxl367_submit_fetch(struct rtio_iodev_sqe *iodev_sqe)
 	}
 
 	enc_data->xyz.range = data->range;
+	bool check_temp_data_ready = false;
 
-	rc = adxl367_get_temp_data(dev, &enc_data->raw_temp);
+	rc = adxl367_get_temp_data(dev, &enc_data->raw_temp, check_temp_data_ready);
 	if (rc != 0) {
 		LOG_ERR("Failed to fetch temp samples");
 		rtio_iodev_sqe_err(iodev_sqe, rc);


### PR DESCRIPTION
### Fix to ensure temperature is sampled at the same timestamp as x,y,z axis data.
Fixes an issue where temperature data was being read 1 sample period after the corresponding x,y,z axis measurements. This also blocks the sample fetch api for adxl367 for one whole sample period. This change updates the driver sample fetch api to read both the axis and temperature data from the same sample frame. This ensures data consistency for applications that requires syncronized accel and temperature measurements.