### PR TITLE
Bluetooth: Audio: Unicast cast presentation and info

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -102,6 +102,8 @@ New APIs and options
     * :c:func:`bt_bap_broadcast_source_foreach_stream`
     * :c:func:`bt_cap_initiator_broadcast_foreach_stream`
     * :c:struct:`bt_bap_stream` now contains an ``iso`` field as a reference to the ISO channel
+    * :c:func:`bt_bap_unicast_group_get_info`
+    * :c:func:`bt_cap_unicast_group_get_info`
 
   * Host
 

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -54,6 +54,9 @@ extern "C" {
 /** An invalid Broadcast ID */
 #define BT_BAP_INVALID_BROADCAST_ID 0xFFFFFFFFU
 
+/** Value that represents an unset presentation delay value */
+#define BT_BAP_PD_UNSET 0xFFFFFFFFU
+
 /**
  * @brief Recommended connectable advertising parameters
  *
@@ -1743,6 +1746,33 @@ typedef bool (*bt_bap_unicast_group_foreach_stream_func_t)(struct bt_bap_stream 
 int bt_bap_unicast_group_foreach_stream(struct bt_bap_unicast_group *unicast_group,
 					bt_bap_unicast_group_foreach_stream_func_t func,
 					void *user_data);
+
+/** Structure holding information of audio stream endpoint */
+struct bt_bap_unicast_group_info {
+	/** Presentation delay for sink ASEs
+	 *
+	 * Will be @ref BT_BAP_PD_UNSET if no sink ASEs have been QoS configured
+	 */
+	uint32_t sink_pd;
+
+	/** Presentation delay for source ASEs
+	 *
+	 * Will be @ref BT_BAP_PD_UNSET if no source ASEs have been QoS configured
+	 */
+	uint32_t source_pd;
+};
+
+/**
+ * @brief Return structure holding information of unicast group
+ *
+ * @param unicast_group The unicast group object.
+ * @param info          The structure object to be filled with the info.
+ *
+ * @retval 0 Success
+ * @retval -EINVAL  @p unicast_group or @p info are NULL
+ */
+int bt_bap_unicast_group_get_info(const struct bt_bap_unicast_group *unicast_group,
+				  struct bt_bap_unicast_group_info *info);
 
 /** Unicast Client callback structure */
 struct bt_bap_unicast_client_cb {

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -424,6 +424,24 @@ int bt_cap_unicast_group_foreach_stream(struct bt_cap_unicast_group *unicast_gro
 					bt_cap_unicast_group_foreach_stream_func_t func,
 					void *user_data);
 
+/** Structure holding information of audio stream endpoint */
+struct bt_cap_unicast_group_info {
+	/** Pointer to the underlying Basic Audio Profile unicast group */
+	const struct bt_bap_unicast_group *unicast_group;
+};
+
+/**
+ * @brief Return structure holding information of unicast group
+ *
+ * @param unicast_group The unicast group object.
+ * @param info          The structure object to be filled with the info.
+ *
+ * @retval 0 Success
+ * @retval -EINVAL  @p unicast_group or @p info are NULL
+ */
+int bt_cap_unicast_group_get_info(const struct bt_cap_unicast_group *unicast_group,
+				  struct bt_cap_unicast_group_info *info);
+
 /** Stream specific parameters for the bt_cap_initiator_unicast_audio_start() function */
 struct bt_cap_unicast_audio_start_stream_param {
 	/** Coordinated or ad-hoc set member. */

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -37,8 +37,6 @@
 #define BROADCAST_STREAM_CNT 0
 #endif /* CONFIG_BT_BAP_BROADCAST_SOURCE */
 
-#define BT_BAP_PD_UNSET 0xFFFFFFFFU /* Valid value range uses 24 bits, but is stored in 32 */
-
 /* Temp struct declarations to handle circular dependencies */
 struct bt_bap_unicast_group;
 struct bt_bap_broadcast_source;

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -37,6 +37,8 @@
 #define BROADCAST_STREAM_CNT 0
 #endif /* CONFIG_BT_BAP_BROADCAST_SOURCE */
 
+#define BT_BAP_PD_UNSET 0xFFFFFFFFU /* Valid value range uses 24 bits, but is stored in 32 */
+
 /* Temp struct declarations to handle circular dependencies */
 struct bt_bap_unicast_group;
 struct bt_bap_broadcast_source;
@@ -94,6 +96,11 @@ struct bt_bap_unicast_group {
 	/* The ISO API for CIG creation requires an array of pointers to ISO channels */
 	struct bt_iso_chan *cis[UNICAST_GROUP_STREAM_CNT];
 	sys_slist_t streams;
+
+	/* Configured sink presentation delay */
+	uint32_t sink_pd;
+	/* Configured source presentation delay */
+	uint32_t source_pd;
 };
 
 #if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -852,6 +852,36 @@ static void unicast_client_ep_qos_update(struct bt_bap_ep *ep,
 	iso_io_qos->rtn = qos->rtn;
 }
 
+static void check_and_reset_group_pd(struct bt_bap_unicast_group *group, enum bt_audio_dir dir)
+{
+	bool dir_in_idle_or_config_state = true;
+	struct bt_bap_stream *stream;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
+		if (stream->ep == NULL || stream->ep->dir != dir) {
+			continue;
+		}
+
+		if (stream->ep->status.state == BT_BAP_EP_STATE_IDLE ||
+		    stream->ep->status.state == BT_BAP_EP_STATE_CODEC_CONFIGURED) {
+			continue;
+		} else {
+			dir_in_idle_or_config_state = false;
+			break;
+		}
+	}
+
+	if (dir_in_idle_or_config_state) {
+		if (dir == BT_AUDIO_DIR_SINK) {
+			group->sink_pd = BT_BAP_PD_UNSET;
+		} else if (dir == BT_AUDIO_DIR_SOURCE) {
+			group->source_pd = BT_BAP_PD_UNSET;
+		} else {
+			__ASSERT(false, "Invalid dir %d", dir);
+		}
+	}
+}
+
 static void unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_simple *buf)
 {
 	struct bt_bap_unicast_client_ep *client_ep =
@@ -932,6 +962,14 @@ static void unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_
 	unicast_client_ep_set_codec_cfg(ep, cfg->codec.id, sys_le16_to_cpu(cfg->codec.cid),
 					sys_le16_to_cpu(cfg->codec.vid), cc, cfg->cc_len, NULL);
 
+	/* Every time a stream enters the codec configured state, there is a chance that all streams
+	 * in that direction has exited the QoS configured state, and we need to update the stored
+	 * presentation delay
+	 */
+	if (stream->group != NULL) {
+		check_and_reset_group_pd((struct bt_bap_unicast_group *)stream->group, ep->dir);
+	}
+
 	/* Notify upper layer */
 	if (stream->ops != NULL && stream->ops->configured != NULL) {
 		stream->ops->configured(stream, pref);
@@ -943,8 +981,10 @@ static void unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_
 static void unicast_client_ep_qos_state(struct bt_bap_ep *ep, struct net_buf_simple *buf,
 					uint8_t old_state)
 {
+	const enum bt_audio_dir dir = ep->dir;
 	const struct bt_bap_stream_ops *ops;
 	struct bt_ascs_ase_status_qos *qos;
+	struct bt_bap_unicast_group *group;
 	struct bt_bap_stream *stream;
 
 	ep->receiver_ready = false;
@@ -1009,9 +1049,35 @@ static void unicast_client_ep_qos_state(struct bt_bap_ep *ep, struct net_buf_sim
 
 	LOG_DBG("dir %s cig 0x%02x cis 0x%02x codec 0x%02x interval %u "
 		"framing 0x%02x phy 0x%02x rtn %u latency %u pd %u",
-		bt_audio_dir_str(ep->dir), ep->cig_id, ep->cis_id, stream->codec_cfg->id,
+		bt_audio_dir_str(dir), ep->cig_id, ep->cis_id, stream->codec_cfg->id,
 		stream->qos->interval, stream->qos->framing, stream->qos->phy, stream->qos->rtn,
 		stream->qos->latency, stream->qos->pd);
+
+	__ASSERT_NO_MSG(stream->group != NULL);
+	group = (struct bt_bap_unicast_group *)stream->group;
+	if (dir == BT_AUDIO_DIR_SINK) {
+		if (group->sink_pd == BT_BAP_PD_UNSET) {
+			group->sink_pd = stream->qos->pd;
+		} else {
+			if (group->sink_pd != stream->qos->pd) {
+				LOG_WRN("Sink stream %p PD %u does not match the sink PD %u of the "
+					"group %p",
+					stream, stream->qos->pd, group->sink_pd, group);
+			}
+		}
+	} else if (dir == BT_AUDIO_DIR_SOURCE) {
+		if (group->source_pd == BT_BAP_PD_UNSET) {
+			group->source_pd = stream->qos->pd;
+		} else {
+			if (group->source_pd != stream->qos->pd) {
+				LOG_WRN("Source stream %p PD %u does not match the source PD %u of "
+					"the group %p",
+					stream, stream->qos->pd, group->source_pd, group);
+			}
+		}
+	} else {
+		__ASSERT(false, "Invalid dir %d", dir);
+	}
 
 	/* Disconnect ISO if connected */
 	if (bt_bap_stream_can_disconnect(stream)) {
@@ -2632,6 +2698,8 @@ static struct bt_bap_unicast_group *unicast_group_alloc(void)
 
 			group->allocated = true;
 			group->index = i;
+			group->sink_pd = BT_BAP_PD_UNSET;
+			group->source_pd = BT_BAP_PD_UNSET;
 
 			break;
 		}
@@ -3224,11 +3292,15 @@ int bt_bap_unicast_client_config(struct bt_bap_stream *stream,
 
 int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group)
 {
+	bool source_qos_configured_on_other_conn;
+	bool sink_qos_configured_on_other_conn;
 	struct bt_bap_stream *stream;
 	struct bt_ascs_config_op *op;
 	struct net_buf_simple *buf;
 	struct bt_bap_ep *ep;
 	bool conn_stream_found;
+	uint32_t source_pd;
+	uint32_t sink_pd;
 	int err;
 
 	if (conn == NULL) {
@@ -3237,18 +3309,55 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 		return -ENOTCONN;
 	}
 
+	if (group == NULL) {
+		LOG_DBG("group is NULL");
+
+		return -EINVAL;
+	}
+
+	/* Validate streams before starting the QoS execution */
+	source_qos_configured_on_other_conn = false;
+	sink_qos_configured_on_other_conn = false;
+
 	/* Used to determine if a stream for the supplied connection pointer
 	 * was actually found
 	 */
 	conn_stream_found = false;
+	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
+		enum bt_audio_dir dir;
 
-	/* Validate streams before starting the QoS execution */
+		if (stream->conn == conn) {
+			conn_stream_found = true;
+			continue;
+		}
+
+		ep = stream->ep;
+		dir = ep->dir;
+
+		if (ep->status.state >= BT_BAP_EP_STATE_QOS_CONFIGURED) {
+			if (dir == BT_AUDIO_DIR_SINK) {
+				sink_qos_configured_on_other_conn = true;
+			} else if (dir == BT_AUDIO_DIR_SOURCE) {
+				source_qos_configured_on_other_conn = true;
+			} else {
+				__ASSERT(false, "Invalid dir %d", dir);
+			}
+		}
+	}
+
+	if (!conn_stream_found) {
+		LOG_DBG("No streams in the group %p for conn %p", group, conn);
+		return -EINVAL;
+	}
+
+	source_pd = group->source_pd;
+	sink_pd = group->sink_pd;
+
 	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
 		if (stream->conn != conn) {
 			/* Channel not part of this ACL, skip */
 			continue;
 		}
-		conn_stream_found = true;
 
 		ep = stream->ep;
 		if (ep == NULL) {
@@ -3272,10 +3381,43 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 			return -EINVAL;
 		}
 
-		/* Verify ep->dir */
+		/* Verify ep->dir and presentation delay. If the group already has a configured
+		 * presentation delay in a direction, we compare the stream's presentation delay
+		 * with the group's presentation delay, and if they differ we reject the request.
+		 * As per the BAP spec section 7.1, all streams in a direction shall have the same
+		 * presentation delay. The group presentation delay is set once any endpoint in a
+		 * direction has changed state to "QoS configured" or "above", and cleared again if
+		 * all endpoints for that direction enters the codec configured or idle state.
+		 * The check for presentation delay is also conditional on whether other devices are
+		 * involved - If there is only a single connection that has ASEs in a QoS Configured
+		 * state or "above", then we can freely modify the presentation delay.
+		 */
 		switch (ep->dir) {
 		case BT_AUDIO_DIR_SINK:
+			if (sink_pd == BT_BAP_PD_UNSET) {
+				sink_pd = stream->qos->pd;
+			} else {
+				if (sink_qos_configured_on_other_conn &&
+				    sink_pd != stream->qos->pd) {
+					LOG_DBG("Sink stream %p did not have the same PD %u as "
+						"other sink streams %u",
+						stream, stream->qos->pd, sink_pd);
+					return -EINVAL;
+				}
+			}
+			break;
 		case BT_AUDIO_DIR_SOURCE:
+			if (source_pd == BT_BAP_PD_UNSET) {
+				source_pd = stream->qos->pd;
+			} else {
+				if (source_qos_configured_on_other_conn &&
+				    source_pd != stream->qos->pd) {
+					LOG_DBG("Source stream %p did not have the same PD %u as "
+						"other source streams %u",
+						stream, stream->qos->pd, source_pd);
+					return -EINVAL;
+				}
+			}
 			break;
 		default:
 			__ASSERT(false, "invalid endpoint dir: %u", ep->dir);
@@ -3289,11 +3431,6 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 			LOG_ERR("Could not find bap_iso for stream %p", stream);
 			return -EINVAL;
 		}
-	}
-
-	if (!conn_stream_found) {
-		LOG_DBG("No streams in the group %p for conn %p", group, conn);
-		return -EINVAL;
 	}
 
 	/* Generate the control point write */

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -3252,6 +3252,25 @@ int bt_bap_unicast_group_foreach_stream(struct bt_bap_unicast_group *unicast_gro
 	return 0;
 }
 
+int bt_bap_unicast_group_get_info(const struct bt_bap_unicast_group *unicast_group,
+				  struct bt_bap_unicast_group_info *info)
+{
+	if (unicast_group == NULL) {
+		LOG_DBG("unicast_group is NULL");
+		return -EINVAL;
+	}
+
+	if (info == NULL) {
+		LOG_DBG("info is NULL");
+		return -EINVAL;
+	}
+
+	info->sink_pd = unicast_group->sink_pd;
+	info->source_pd = unicast_group->source_pd;
+
+	return 0;
+}
+
 int bt_bap_unicast_client_config(struct bt_bap_stream *stream,
 				 const struct bt_audio_codec_cfg *codec_cfg)
 {

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1111,6 +1111,24 @@ int bt_cap_unicast_group_foreach_stream(struct bt_cap_unicast_group *unicast_gro
 						   bap_unicast_group_foreach_stream_cb, &data);
 }
 
+int bt_cap_unicast_group_get_info(const struct bt_cap_unicast_group *unicast_group,
+				  struct bt_cap_unicast_group_info *info)
+{
+	if (unicast_group == NULL) {
+		LOG_DBG("unicast_group is NULL");
+		return -EINVAL;
+	}
+
+	if (info == NULL) {
+		LOG_DBG("info is NULL");
+		return -EINVAL;
+	}
+
+	info->unicast_group = unicast_group->bap_unicast_group;
+
+	return 0;
+}
+
 static bool valid_unicast_audio_start_param(const struct bt_cap_unicast_audio_start_param *param)
 {
 	struct bt_bap_unicast_group *unicast_group = NULL;

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
@@ -413,3 +413,39 @@ static ZTEST_F(cap_initiator_test_unicast_group,
 
 	zassert_equal(cnt, expect_cnt, "Unexpected cnt (%zu != %zu)", cnt, expect_cnt);
 }
+
+static ZTEST_F(cap_initiator_test_unicast_group, test_initiator_unicast_group_get_info)
+{
+	struct bt_cap_unicast_group_info cap_info;
+	int err;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_get_info(fixture->unicast_group, &cap_info);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	zassert_not_null(cap_info.unicast_group);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_get_info_inval_null_group)
+{
+	struct bt_cap_unicast_group_info cap_info;
+	int err;
+
+	err = bt_cap_unicast_group_get_info(NULL, &cap_info);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_get_info_inval_null_info)
+{
+	int err;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_get_info(fixture->unicast_group, NULL);
+	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
+}

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -623,6 +623,7 @@ static void codec_configure_streams(size_t stream_cnt)
 static void qos_configure_streams(struct bt_bap_unicast_group *unicast_group,
 				  size_t stream_cnt)
 {
+	struct bt_bap_unicast_group_info info;
 	int err;
 
 	UNSET_FLAG(flag_stream_qos_configured);
@@ -639,6 +640,23 @@ static void qos_configure_streams(struct bt_bap_unicast_group *unicast_group,
 
 	while (atomic_get(&flag_stream_qos_configured) != stream_cnt) {
 		(void)k_sleep(K_MSEC(1));
+	}
+
+	err = bt_bap_unicast_group_get_info(unicast_group, &info);
+	if (err != 0) {
+		FAIL("Unable to QoS configure streams: %d\n", err);
+		return;
+	}
+
+	if (info.sink_pd != preset_16_2_1.qos.pd) {
+		FAIL("Unexpected sink PD %u (expected %u)\n", info.sink_pd, preset_16_2_1.qos.pd);
+		return;
+	}
+
+	if (info.source_pd != preset_16_2_1.qos.pd) {
+		FAIL("Unexpected source PD %u (expected %u)\n", info.source_pd,
+		     preset_16_2_1.qos.pd);
+		return;
 	}
 }
 

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -644,6 +644,50 @@ static void unicast_group_create(struct bt_cap_unicast_group **out_unicast_group
 	}
 }
 
+static bool unicast_group_foreach_stream_cb(struct bt_cap_stream *cap_stream, void *user_data)
+{
+	const uint32_t expected_pd = cap_stream->bap_stream.qos->pd;
+	struct bt_cap_unicast_group *unicast_group = user_data;
+	struct bt_bap_unicast_group_info bap_info;
+	struct bt_cap_unicast_group_info cap_info;
+	struct bt_bap_ep_info ep_info;
+	int err;
+
+	err = bt_bap_ep_get_info(cap_stream->bap_stream.ep, &ep_info);
+	if (err != 0) {
+		FAIL("Failed to get EP info: %d\n", err);
+		return true;
+	}
+
+	err = bt_cap_unicast_group_get_info(unicast_group, &cap_info);
+	if (err != 0) {
+		FAIL("Failed to get CAP unicast group info: %d\n", err);
+		return true;
+	}
+
+	err = bt_bap_unicast_group_get_info(cap_info.unicast_group, &bap_info);
+	if (err != 0) {
+		FAIL("Failed to get BAP unicast group info: %d\n", err);
+		return true;
+	}
+
+	if (ep_info.dir == BT_AUDIO_DIR_SINK) {
+		if (bap_info.sink_pd != expected_pd) {
+			FAIL("Unexpected sink PD %u (expected %u)\n", bap_info.sink_pd,
+			     expected_pd);
+			return true;
+		}
+	} else {
+		if (bap_info.source_pd != expected_pd) {
+			FAIL("Unexpected source PD %u (expected %u)\n", bap_info.source_pd,
+			     expected_pd);
+			return true;
+		}
+	}
+
+	return false;
+}
+
 static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group, bool wait)
 {
 	struct bt_cap_unicast_audio_start_stream_param stream_param[2];
@@ -676,6 +720,13 @@ static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group, bool
 		WAIT_FOR_FLAG(flag_started);
 		/* let other devices know we have started what we wanted */
 		backchannel_sync_send_all();
+
+		err = bt_cap_unicast_group_foreach_stream(
+			unicast_group, unicast_group_foreach_stream_cb, unicast_group);
+		if (err != 0) {
+			FAIL("Failed iterate on unicast group: %d\n", err);
+			return;
+		}
 	}
 }
 


### PR DESCRIPTION
Adds two new functions, `bt_cap_unicast_group_get_info` and `bt_bap_unicast_group_get_info` that can be used to get the presentation delay of a unicast group. Additionally the presentation delay from the application and remote is validated in BAP now. 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/95144