### PR TITLE
Lptmr counter prescaler fix

### DIFF
--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -178,15 +178,17 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 		.info = {							\
 			.max_top_value =					\
 				GENMASK(DT_INST_PROP(n, resolution) - 1, 0),	\
-			.freq = DT_INST_PROP(n, clock_frequency) /		\
-				DT_INST_PROP(n, prescaler),			\
+			.freq = COND_CODE_1(DT_NODE_HAS_PROP(n, prescale_glitch_filter),	\
+				(DT_INST_PROP(n, clock_frequency) /		\
+					(1 << (DT_INST_PROP(n, prescale_glitch_filter)))),		\
+				(DT_INST_PROP(n, clock_frequency))),	\
 			.flags = COUNTER_CONFIG_INFO_COUNT_UP,			\
 			.channels = 0,						\
 		},								\
 		.base = (LPTMR_Type *)DT_INST_REG_ADDR(n),			\
 		.clk_source = DT_INST_PROP(n, clk_source),			\
-		.bypass_prescaler_glitch =					\
-			1 - DT_INST_PROP(n, timer_mode_sel),			\
+		.bypass_prescaler_glitch = COND_CODE_1(DT_NODE_HAS_PROP(n, 		\
+			prescale_glitch_filter), (false), (true)),		\
 		.mode = DT_INST_PROP(n, timer_mode_sel),			\
 		.pin = DT_INST_PROP_OR(n, input_pin, 0),			\
 		.polarity = DT_INST_PROP(n, active_low),			\
@@ -200,6 +202,5 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 		&mcux_lptmr_config_##n,						\
 		POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY,			\
 		&mcux_lptmr_driver_api);
-
 
 DT_INST_FOREACH_STATUS_OKAY(COUNTER_MCUX_LPTMR_DEVICE_INIT)

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -69,3 +69,8 @@
 &lpit3_channel3 {
 	status = "okay";
 };
+
+&lptmr3 {
+	status = "okay";
+	prescale-glitch-filter = <10>;
+};


### PR DESCRIPTION
For current code, if timer_mode_sel is set to 0(Time Counter Mode), bypass_prescaler_glitch  will be 1-0 = 1, which means the prescaler does not work on time counter mode. But this setting is very useful, especially for long timing count.

In this PR:
1. Update bypass_prescaler_glitch setting: If prescale_glitch_filter has been set, then bypass_prescaler_glitch should be false, to make prescale_glitch_filter work.

2. If prescale_glitch_filter has been set, , then clock frequency should be divided by prescaler setting. 

3. Enable lptmr3 on mimxrt1180_evk/cm33 for test