### PR TITLE
bluetooth: l2cap: support the classic l2cap rx flush timeout

### DIFF
--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -44,6 +44,18 @@ config BT_MAX_SCO_CONN
 	  Maximum number of simultaneous Bluetooth synchronous connections
 	  supported. The minimum (and default) number is 1.
 
+config BT_L2CAP_RX_FLUSH_TO
+	hex "Minimum Bluetooth L2CAP RX flush Timeout accepted in milliseconds"
+	default 0x0001 if BT_A2DP_SINK
+	default 0xFFFF
+	range 0x0001 0xFFFF
+	help
+	  This option configures minimum Bluetooth L2CAP RX flush timeout accepted during
+	  processing peer's l2cap flush timeout configuration.
+	  The flush timeout applies to all channels on the same ACL logical transport but
+	  may be overridden on a packet by packet basis by marking individual L2CAP packets
+	  as non-automatically-flushable via the Packet_Boundary_Flag in the HCI ACL Data packet.
+
 config BT_L2CAP_CONNLESS
 	bool "Bluetooth L2CAP connectionless data reception [EXPERIMENTAL]"
 	select EXPERIMENTAL

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -3894,8 +3894,21 @@ static uint16_t l2cap_br_conf_opt_flush_timeout(struct bt_l2cap_chan *chan, stru
 
 	LOG_DBG("Flush timeout %u", opt_to->timeout);
 
-	opt_to->timeout = sys_cpu_to_le16(0xffff);
-	result = BT_L2CAP_CONF_UNACCEPT;
+	opt_to->timeout = sys_le16_to_cpu(opt_to->timeout);
+
+	if (opt_to->timeout == 0) {
+		/* 0 is illegal value */
+		LOG_ERR("Flush timeout cannot be 0");
+		result = BT_L2CAP_CONF_REJECT;
+		goto done;
+	}
+
+	if (opt_to->timeout < CONFIG_BT_L2CAP_RX_FLUSH_TO) {
+		LOG_DBG("Flush timeout %u is too small", opt_to->timeout);
+		opt_to->timeout = sys_cpu_to_le16(CONFIG_BT_L2CAP_RX_FLUSH_TO);
+		result = BT_L2CAP_CONF_UNACCEPT;
+	}
+
 done:
 	return result;
 }

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -2800,8 +2800,20 @@ static uint16_t l2cap_br_conf_rsp_opt_flush_timeout(struct bt_l2cap_chan *chan, 
 
 	LOG_DBG("Flash timeout %u", opt_to->timeout);
 
-	opt_to->timeout = sys_cpu_to_le32(0xffff);
-	result = BT_L2CAP_CONF_UNACCEPT;
+	opt_to->timeout = sys_le16_to_cpu(opt_to->timeout);
+
+	if (opt_to->timeout == 0) {
+		/* 0 is illegal value */
+		LOG_ERR("Flush timeout cannot be 0");
+		result = BT_L2CAP_CONF_REJECT;
+		goto done;
+	}
+
+	/* For tx, only support the default value (0xFFFF - infinite amount of retransmissions) */
+	if (opt_to->timeout != 0xFFFF) {
+		result = BT_L2CAP_CONF_UNACCEPT;
+	}
+
 done:
 	return result;
 }


### PR DESCRIPTION
add one Kconfig `BT_L2CAP_RX_FLUSH_TO` to configure the minimum L2CAP RX flush timeout accepted during processing peer's l2cap flush timeout configuration.

My side's case:
When creating AVDTP l2cap stream channel, iPhone send l2cap_config with this `flush timeout` option, but current stack don't accept it directly, it leads that the A2DP function doesn't work well.