### PR TITLE
bluetooth: a2dp: add bt_a2dp_stream_create_pdu

### DIFF
--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -21,8 +21,6 @@
 extern "C" {
 #endif
 
-#define BT_A2DP_STREAM_BUF_RESERVE (12U + BT_L2CAP_BUF_SIZE(0))
-
 /** SBC IE length */
 #define BT_A2DP_SBC_IE_LENGTH      (4U)
 /** MPEG1,2 IE length */
@@ -854,6 +852,21 @@ uint32_t bt_a2dp_get_mtu(struct bt_a2dp_stream *stream);
  */
 int bt_a2dp_stream_send(struct bt_a2dp_stream *stream, struct net_buf *buf, uint16_t seq_num,
 			uint32_t ts);
+
+/**
+ * @brief Allocate a net_buf for bt_a2dp_stream_send
+ *
+ * This function allocates a buffer from the specified pool, reserves
+ * sufficient headroom for protocol headers required by L2CAP over Bluetooth, fills
+ * the AVDTP header.
+ *
+ * @param pool    The buffer pool to allocate from.
+ * @param timeout Non-negative waiting period to obtain a buffer or one of
+ *                the special values K_NO_WAIT and K_FOREVER.
+ *
+ * @return A newly allocated net_buf.
+ */
+struct net_buf *bt_a2dp_stream_create_pdu(struct net_buf_pool *pool, k_timeout_t timeout);
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -973,6 +973,26 @@ uint32_t bt_a2dp_get_mtu(struct bt_a2dp_stream *stream)
 }
 
 #if defined(CONFIG_BT_A2DP_SOURCE)
+struct net_buf *bt_a2dp_stream_create_pdu(struct net_buf_pool *pool, k_timeout_t timeout)
+{
+	struct net_buf *buf;
+
+	buf = bt_l2cap_create_pdu_timeout(pool, 0, timeout);
+	if (buf == NULL) {
+		return NULL;
+	}
+
+	/* add AVDTP header */
+	if (net_buf_tailroom(buf) < sizeof(struct bt_avdtp_media_hdr)) {
+		net_buf_unref(buf);
+		return NULL;
+	}
+
+	net_buf_add(buf, sizeof(struct bt_avdtp_media_hdr));
+
+	return buf;
+}
+
 int bt_a2dp_stream_send(struct bt_a2dp_stream *stream, struct net_buf *buf, uint16_t seq_num,
 			uint32_t ts)
 {
@@ -982,7 +1002,7 @@ int bt_a2dp_stream_send(struct bt_a2dp_stream *stream, struct net_buf *buf, uint
 		return -EINVAL;
 	}
 
-	media_hdr = net_buf_push(buf, sizeof(struct bt_avdtp_media_hdr));
+	media_hdr = (struct bt_avdtp_media_hdr *)buf->data;
 	memset(media_hdr, 0, sizeof(struct bt_avdtp_media_hdr));
 
 	if (stream->local_ep->codec_type == BT_A2DP_SBC) {

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -779,8 +779,11 @@ static int cmd_send_media(const struct shell *sh, int32_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	buf = net_buf_alloc(&a2dp_tx_pool, K_FOREVER);
-	net_buf_reserve(buf, BT_A2DP_STREAM_BUF_RESERVE);
+	buf = bt_a2dp_stream_create_pdu(&a2dp_tx_pool, K_FOREVER);
+	if (buf == NULL) {
+		shell_error(sh, "fail to allocate buffer");
+		return -ENOEXEC;
+	}
 
 	/* num of frames is 1 */
 	net_buf_add_u8(buf, (uint8_t)BT_A2DP_SBC_MEDIA_HDR_ENCODE(1, 0, 0, 0));


### PR DESCRIPTION
use bt_a2dp_stream_create_pdu to create the stream pdu net buf, then application can use the buf->len to check whether the buf's size exceeds the l2cap mtu.