### PR TITLE
LPTMR counter prescaler fix

### DIFF
--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -187,19 +187,21 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 			.max_top_value =					\
 				GENMASK(DT_INST_PROP(n, resolution) - 1, 0),	\
 			.freq = DT_INST_PROP(n, clock_frequency) /		\
-				DT_INST_PROP(n, prescaler),			\
+				BIT(DT_INST_PROP(n, prescale_glitch_filter)),	\
 			.flags = COUNTER_CONFIG_INFO_COUNT_UP,			\
 			.channels = 0,						\
 		},								\
 		.base = (LPTMR_Type *)DT_INST_REG_ADDR(n),			\
 		.clk_source = DT_INST_PROP(n, clk_source),			\
-		.bypass_prescaler_glitch =					\
-			1 - DT_INST_PROP(n, timer_mode_sel),			\
+		.bypass_prescaler_glitch = (DT_INST_PROP(n,			\
+			prescale_glitch_filter) == 0),				\
 		.mode = DT_INST_PROP(n, timer_mode_sel),			\
 		.pin = DT_INST_PROP_OR(n, input_pin, 0),			\
 		.polarity = DT_INST_PROP(n, active_low),			\
-		.prescaler_glitch = DT_INST_PROP(n, prescale_glitch_filter) +	\
-			DT_INST_PROP(n, timer_mode_sel) - 1,			\
+		.prescaler_glitch = (DT_INST_PROP(n,				\
+			prescale_glitch_filter) == 0) ? 0 : DT_INST_PROP(n,	\
+			prescale_glitch_filter) + DT_INST_PROP(n,		\
+			timer_mode_sel) - 1,					\
 		.irq_config_func = mcux_lptmr_irq_config_##n,			\
 	};									\
 										\
@@ -208,6 +210,5 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 		&mcux_lptmr_config_##n,						\
 		POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY,			\
 		&mcux_lptmr_driver_api);
-
 
 DT_INST_FOREACH_STATUS_OKAY(COUNTER_MCUX_LPTMR_DEVICE_INIT)

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -515,7 +515,7 @@
 			clocks = <&scmi_clk IMX95_CLK_LPTMR2>;
 			clock-frequency = <DT_FREQ_K(32)>;
 			clk-source = <2>;
-			prescaler = <1>;
+			prescale-glitch-filter = <0>;
 			resolution = <32>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_k32l2b3.dtsi
+++ b/dts/arm/nxp/nxp_k32l2b3.dtsi
@@ -283,7 +283,6 @@
 			reg = <0x40040000 0x1000>;
 			interrupts = <28 0>;
 			clock-frequency = <DT_FREQ_K(1)>;
-			prescaler = <1>;
 			prescale-glitch-filter = <1>;
 			clk-source = <1>;
 			resolution = <16>;

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -289,7 +289,7 @@
 			reg = <0x40040000 0x1000>;
 			interrupts = <58 0>;
 			clock-frequency = <DT_FREQ_K(128)>;
-			prescaler = <1>;
+			prescale-glitch-filter = <0>;
 			clk-source = <1>;
 			resolution = <16>;
 		};

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -190,7 +190,7 @@
 			reg = <0x40040000 0x1000>;
 			interrupts = <29 0>;
 			clock-frequency = <DT_FREQ_K(128)>;
-			prescaler = <1>;
+			prescale-glitch-filter = <0>;
 			clk-source = <1>;
 			resolution = <16>;
 		};

--- a/dts/arm/nxp/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/nxp_mcxa153.dtsi
@@ -270,7 +270,7 @@
 			reg = <0x400ab000 0x1000>;
 			interrupts = <55 0>;
 			clock-frequency = <16000>;
-			prescaler = <1>;
+			prescale-glitch-filter = <0>;
 			clk-source = <1>;
 			resolution = <32>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -504,7 +504,7 @@
 			reg = <0x400ab000 0x1000>;
 			interrupts = <55 0>;
 			clock-frequency = <16000>;
-			prescaler = <1>;
+			prescale-glitch-filter = <0>;
 			clk-source = <1>;
 			resolution = <32>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
@@ -196,7 +196,7 @@
 			reg = <0x400ab000 0x1000>;
 			interrupts = <55 0>;
 			clock-frequency = <16000>;
-			prescaler = <1>;
+			prescale-glitch-filter = <0>;
 			clk-source = <1>;
 			resolution = <32>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxc_common.dtsi
@@ -297,7 +297,6 @@
 			reg = <0x40040000 0x1000>;
 			interrupts = <28 0>;
 			clock-frequency = <1000>;
-			prescaler = <1>;
 			prescale-glitch-filter = <1>;
 			clk-source = <1>;
 			resolution = <16>;

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -873,7 +873,7 @@
 		reg = <0x4a000 0x1000>;
 		interrupts = <143 0>;
 		clock-frequency = <DT_FREQ_K(16)>;
-		prescaler = <1>;
+		prescale-glitch-filter = <0>;
 		clk-source = <1>;
 		resolution = <32>;
 	};
@@ -883,7 +883,7 @@
 		reg = <0x4b000 0x1000>;
 		interrupts = <144 0>;
 		clock-frequency = <DT_FREQ_K(16)>;
-		prescaler = <1>;
+		prescale-glitch-filter = <0>;
 		clk-source = <1>;
 		resolution = <32>;
 	};

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -936,7 +936,7 @@
 		reg = <0x4a000 0x1000>;
 		interrupts = <143 0>;
 		clock-frequency = <DT_FREQ_K(16)>;
-		prescaler = <1>;
+		prescale-glitch-filter = <0>;
 		clk-source = <1>;
 		resolution = <32>;
 	};
@@ -946,7 +946,7 @@
 		reg = <0x4b000 0x1000>;
 		interrupts = <144 0>;
 		clock-frequency = <DT_FREQ_K(16)>;
-		prescaler = <1>;
+		prescale-glitch-filter = <0>;
 		clk-source = <1>;
 		resolution = <32>;
 	};

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -298,7 +298,7 @@
 		interrupts = <34 0>;
 		clock-frequency = <DT_FREQ_K(32)>;
 		clk-source = <2>;
-		prescaler = <1>;
+		prescale-glitch-filter = <0>;
 		resolution = <32>;
 		status = "disabled";
 	};
@@ -309,7 +309,7 @@
 		interrupts = <35 0>;
 		clock-frequency = <DT_FREQ_K(32)>;
 		clk-source = <2>;
-		prescaler = <1>;
+		prescale-glitch-filter = <0>;
 		resolution = <32>;
 		status = "disabled";
 	};

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -907,7 +907,7 @@
 		reg = <0x4300000 0x1000>;
 		interrupts = <18 0>;
 		clock-frequency = <DT_FREQ_M(80)>;
-		prescaler = <1>;
+		prescale-glitch-filter = <0>;
 		clk-source = <0>;
 		resolution = <32>;
 		status = "disabled";
@@ -918,7 +918,7 @@
 		reg = <0x24d0000 0x1000>;
 		interrupts = <67 0>;
 		clock-frequency = <DT_FREQ_M(80)>;
-		prescaler = <1>;
+		prescale-glitch-filter = <0>;
 		clk-source = <0>;
 		resolution = <32>;
 		status = "disabled";
@@ -929,7 +929,7 @@
 		reg = <0x2cd0000 0x1000>;
 		interrupts = <150 0>;
 		clock-frequency = <DT_FREQ_M(80)>;
-		prescaler = <1>;
+		prescale-glitch-filter = <0>;
 		clk-source = <0>;
 		resolution = <32>;
 		status = "disabled";

--- a/dts/bindings/counter/nxp,lptmr.yaml
+++ b/dts/bindings/counter/nxp,lptmr.yaml
@@ -16,8 +16,12 @@ properties:
     description: Counter clock frequency
 
   prescaler:
-    required: true
-    description: The frequency of the counter is divided by this value.
+    type: int
+    deprecated: true
+    description: |
+      This property has been deprecated and replaced by prescale-glitch-filter.
+      It no longer has any functional impact. Any value assigned to this property
+      will be disregarded. Consequently, the prescaler will be bypassed.
 
   clk-source:
     type: int
@@ -50,15 +54,19 @@ properties:
 
   prescale-glitch-filter:
     type: int
-    default: 1
-    enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    default: 0
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
     description: |
-      When in prescaler mode, the counter is incremented every
+      When in prescaler mode, if prescale-glitch-filter is 0, the prescaler
+        is bypassed, the selected prescaler clock increments Counter (CNR) on every
+        clock cycle. Otherwise the counter is incremented every
         2 ^ [prescaler-glitch-filter] clock cycles.
-      When in pulse mode, the counter is incremented every
-        2 ^ [prescaler-glitch-filter] rising edges detected
-        by the pin configured from the input-pin value.
-        Note, that the pulse mode cannot be 2 ^ 16.
+      When in pulse mode, if prescale-glitch-filter is 0, the glitch filter
+        is bypassed, the selected input source increments the value of Counter(CNR)
+        every time it asserts. Otherwise the counter is incremented every
+        2 ^ [prescaler-glitch-filter] rising edges detected by the pin configured
+        from the input-pin value.
+      Note, that the pulse mode cannot be 2 ^ 16.
 
   timer-mode-sel:
     type: int

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -69,3 +69,8 @@
 &lpit3_channel3 {
 	status = "okay";
 };
+
+&lptmr3 {
+	status = "okay";
+	prescale-glitch-filter = <10>;
+};


### PR DESCRIPTION
For previous code, if timer_mode_sel is set to 0(Time Counter Mode), bypass_prescaler_glitch will be 1-0 = 1, which means the prescaler does not work on time counter mode. But prescaler is very useful, especially for long timing count.

In this PR:
1. Update  prescale_glitch_filter in dts bindings,  add 0 in enum and the default value for this property has been changed to 0, to indicate  prescaler and glitch filter are disabled. 
  Have checked all of device tree settings, the prescaler property are all 1, which means the clock are not prescaled. And in previous driver code,  bypass_prescaler_glitch are always 1, the prescaler never works. Therefore this change will not bring running issue for existing boards.

2. If user sets prescale-glitch-filter properity other than 0, set bypass_prescaler_glitch to false to make prescaler work.

3. Calculate clock frequency with prescaler setting