### PR TITLE
drivers: serial: pl011: reduce device's base address accesses

### DIFF
--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -133,16 +133,22 @@ static void pl011_disable_fifo(const struct device *dev)
 
 static void pl011_set_flow_control(const struct device *dev, bool rts, bool cts)
 {
+	volatile struct pl011_regs *uart = get_uart(dev);
+	uint32_t cr = uart->cr;
+
 	if (rts) {
-		get_uart(dev)->cr |= PL011_CR_RTSEn;
+		cr |= PL011_CR_RTSEn;
 	} else {
-		get_uart(dev)->cr &= ~PL011_CR_RTSEn;
+		cr &= ~PL011_CR_RTSEn;
 	}
+
 	if (cts) {
-		get_uart(dev)->cr |= PL011_CR_CTSEn;
+		cr |= PL011_CR_CTSEn;
 	} else {
-		get_uart(dev)->cr &= ~PL011_CR_CTSEn;
+		cr &= ~PL011_CR_CTSEn;
 	}
+
+	uart->cr = cr;
 }
 
 static int pl011_set_baudrate(const struct device *dev,
@@ -151,6 +157,7 @@ static int pl011_set_baudrate(const struct device *dev,
 	/* Avoiding float calculations, bauddiv is left shifted by 6 */
 	uint64_t bauddiv = (((uint64_t)clk) << PL011_FBRD_WIDTH)
 				/ (baudrate * 16U);
+	volatile struct pl011_regs *uart = get_uart(dev);
 
 	/* Valid bauddiv value
 	 * uart_clk (min) >= 16 x baud_rate (max)
@@ -161,8 +168,8 @@ static int pl011_set_baudrate(const struct device *dev,
 		return -EINVAL;
 	}
 
-	get_uart(dev)->ibrd = bauddiv >> PL011_FBRD_WIDTH;
-	get_uart(dev)->fbrd = bauddiv & ((1u << PL011_FBRD_WIDTH) - 1u);
+	uart->ibrd = bauddiv >> PL011_FBRD_WIDTH;
+	uart->fbrd = bauddiv & ((1u << PL011_FBRD_WIDTH) - 1u);
 
 	barrier_dmem_fence_full();
 
@@ -170,7 +177,7 @@ static int pl011_set_baudrate(const struct device *dev,
 	 * lcr_h write must always be performed at the end
 	 * ARM DDI 0183F, Pg 3-13
 	 */
-	get_uart(dev)->lcr_h = get_uart(dev)->lcr_h;
+	uart->lcr_h = uart->lcr_h;
 
 	return 0;
 }
@@ -178,56 +185,63 @@ static int pl011_set_baudrate(const struct device *dev,
 static bool pl011_is_readable(const struct device *dev)
 {
 	struct pl011_data *data = dev->data;
+	volatile struct pl011_regs *uart = get_uart(dev);
+	uint32_t cr = uart->cr;
 
 	if (!data->sbsa &&
-	    (!(get_uart(dev)->cr & PL011_CR_UARTEN) || !(get_uart(dev)->cr & PL011_CR_RXE))) {
+	    (!(cr & PL011_CR_UARTEN) || !(cr & PL011_CR_RXE))) {
 		return false;
 	}
 
-	return (get_uart(dev)->fr & PL011_FR_RXFE) == 0U;
+	return (uart->fr & PL011_FR_RXFE) == 0U;
 }
 
 static int pl011_poll_in(const struct device *dev, unsigned char *c)
 {
+	volatile struct pl011_regs *uart = get_uart(dev);
+
 	if (!pl011_is_readable(dev)) {
 		return -1;
 	}
 
 	/* got a character */
-	*c = (unsigned char)get_uart(dev)->dr;
+	*c = (unsigned char)uart->dr;
 
-	return get_uart(dev)->rsr & PL011_RSR_ERROR_MASK;
+	return uart->rsr & PL011_RSR_ERROR_MASK;
 }
 
 static void pl011_poll_out(const struct device *dev,
 					     unsigned char c)
 {
+	volatile struct pl011_regs *uart = get_uart(dev);
+
 	/* Wait for space in FIFO */
-	while (get_uart(dev)->fr & PL011_FR_TXFF) {
+	while (uart->fr & PL011_FR_TXFF) {
 		; /* Wait */
 	}
 
 	/* Send a character */
-	get_uart(dev)->dr = (uint32_t)c;
+	uart->dr = (uint32_t)c;
 }
 
 static int pl011_err_check(const struct device *dev)
 {
+	uint32_t rsr = get_uart(dev)->rsr;
 	int errors = 0;
 
-	if (get_uart(dev)->rsr & PL011_RSR_ECR_OE) {
+	if (rsr & PL011_RSR_ECR_OE) {
 		errors |= UART_ERROR_OVERRUN;
 	}
 
-	if (get_uart(dev)->rsr & PL011_RSR_ECR_BE) {
+	if (rsr & PL011_RSR_ECR_BE) {
 		errors |= UART_BREAK;
 	}
 
-	if (get_uart(dev)->rsr & PL011_RSR_ECR_PE) {
+	if (rsr & PL011_RSR_ECR_PE) {
 		errors |= UART_ERROR_PARITY;
 	}
 
-	if (get_uart(dev)->rsr & PL011_RSR_ECR_FE) {
+	if (rsr & PL011_RSR_ECR_FE) {
 		errors |= UART_ERROR_FRAMING;
 	}
 
@@ -240,6 +254,7 @@ static int pl011_runtime_configure_internal(const struct device *dev,
 {
 	const struct pl011_config *config = dev->config;
 	struct pl011_data *data = dev->data;
+	volatile struct pl011_regs *uart = get_uart(dev);
 	uint32_t lcrh;
 	int ret = -ENOTSUP;
 
@@ -252,7 +267,7 @@ static int pl011_runtime_configure_internal(const struct device *dev,
 		pl011_disable_fifo(dev);
 	}
 
-	lcrh = get_uart(dev)->lcr_h & ~(PL011_LCRH_FORMAT_MASK | PL011_LCRH_STP2);
+	lcrh = uart->lcr_h & ~(PL011_LCRH_FORMAT_MASK | PL011_LCRH_STP2);
 
 	switch (cfg->parity) {
 	case UART_CFG_PARITY_NONE:
@@ -314,7 +329,7 @@ static int pl011_runtime_configure_internal(const struct device *dev,
 	}
 
 	/* Update settings */
-	get_uart(dev)->lcr_h = lcrh;
+	uart->lcr_h = lcrh;
 
 	memcpy(&data->uart_cfg, cfg, sizeof(data->uart_cfg));
 
@@ -353,10 +368,11 @@ static int pl011_runtime_config_get(const struct device *dev,
 static int pl011_fifo_fill(const struct device *dev,
 				    const uint8_t *tx_data, int len)
 {
+	volatile struct pl011_regs *uart = get_uart(dev);
 	int num_tx = 0U;
 
-	while (!(get_uart(dev)->fr & PL011_FR_TXFF) && (len - num_tx > 0)) {
-		get_uart(dev)->dr = tx_data[num_tx++];
+	while (!(uart->fr & PL011_FR_TXFF) && (len - num_tx > 0)) {
+		uart->dr = tx_data[num_tx++];
 	}
 	return num_tx;
 }
@@ -364,10 +380,11 @@ static int pl011_fifo_fill(const struct device *dev,
 static int pl011_fifo_read(const struct device *dev,
 				    uint8_t *rx_data, const int len)
 {
+	volatile struct pl011_regs *uart = get_uart(dev);
 	int num_rx = 0U;
 
-	while ((len - num_rx > 0) && !(get_uart(dev)->fr & PL011_FR_RXFE)) {
-		rx_data[num_rx++] = get_uart(dev)->dr;
+	while ((len - num_rx > 0) && !(uart->fr & PL011_FR_RXFE)) {
+		rx_data[num_rx++] = uart->dr;
 	}
 
 	return num_rx;
@@ -376,8 +393,9 @@ static int pl011_fifo_read(const struct device *dev,
 static void pl011_irq_tx_enable(const struct device *dev)
 {
 	struct pl011_data *data = dev->data;
+	volatile struct pl011_regs *uart = get_uart(dev);
 
-	get_uart(dev)->imsc |= PL011_IMSC_TXIM;
+	uart->imsc |= PL011_IMSC_TXIM;
 	if (!data->sw_call_txdrdy) {
 		return;
 	}
@@ -405,7 +423,7 @@ static void pl011_irq_tx_enable(const struct device *dev)
 	 * FIFO threshold may never be reached, and the hardware TX interrupt
 	 * will never trigger.
 	 */
-	while (get_uart(dev)->imsc & PL011_IMSC_TXIM) {
+	while (uart->imsc & PL011_IMSC_TXIM) {
 		K_SPINLOCK(&data->irq_cb_lock) {
 			data->irq_cb(dev, data->irq_cb_data);
 		}
@@ -429,14 +447,15 @@ static int pl011_irq_tx_complete(const struct device *dev)
 static int pl011_irq_tx_ready(const struct device *dev)
 {
 	struct pl011_data *data = dev->data;
+	volatile struct pl011_regs *uart = get_uart(dev);
 
-	if (!data->sbsa && !(get_uart(dev)->cr & PL011_CR_TXE)) {
+	if (!data->sbsa && !(uart->cr & PL011_CR_TXE)) {
 		return false;
 	}
 
-	return ((get_uart(dev)->imsc & PL011_IMSC_TXIM) &&
+	return ((uart->imsc & PL011_IMSC_TXIM) &&
 		/* Check for TX interrupt status is set or TX FIFO is empty. */
-		(get_uart(dev)->ris & PL011_RIS_TXRIS || get_uart(dev)->fr & PL011_FR_TXFE));
+		(uart->ris & PL011_RIS_TXRIS || uart->fr & PL011_FR_TXFE));
 }
 
 static void pl011_irq_rx_enable(const struct device *dev)
@@ -451,14 +470,15 @@ static void pl011_irq_rx_disable(const struct device *dev)
 
 static int pl011_irq_rx_ready(const struct device *dev)
 {
+	volatile struct pl011_regs *uart = get_uart(dev);
 	struct pl011_data *data = dev->data;
 
-	if (!data->sbsa && !(get_uart(dev)->cr & PL011_CR_RXE)) {
+	if (!data->sbsa && !(uart->cr & PL011_CR_RXE)) {
 		return false;
 	}
 
-	return ((get_uart(dev)->imsc & PL011_IMSC_RXIM) &&
-		(!(get_uart(dev)->fr & PL011_FR_RXFE)));
+	return ((uart->imsc & PL011_IMSC_RXIM) &&
+		(!(uart->fr & PL011_FR_RXFE)));
 }
 
 static void pl011_irq_err_enable(const struct device *dev)
@@ -523,9 +543,13 @@ static int pl011_init(const struct device *dev)
 {
 	const struct pl011_config *config = dev->config;
 	struct pl011_data *data = dev->data;
+	volatile struct pl011_regs *uart;
 	int ret;
 
 	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+
+	/* Must be placed after DEVICE_MMIO_MAP */
+	uart = get_uart(dev);
 
 #if defined(CONFIG_RESET)
 	if (config->reset.dev) {
@@ -575,7 +599,7 @@ static int pl011_init(const struct device *dev)
 		pl011_runtime_configure_internal(dev, &data->uart_cfg, false);
 
 		/* Setting transmit and receive interrupt FIFO level */
-		get_uart(dev)->ifls = FIELD_PREP(PL011_IFLS_TXIFLSEL_M, TXIFLSEL_1_8_FULL)
+		uart->ifls = FIELD_PREP(PL011_IFLS_TXIFLSEL_M, TXIFLSEL_1_8_FULL)
 			| FIELD_PREP(PL011_IFLS_RXIFLSEL_M, RXIFLSEL_1_2_FULL);
 
 		/* Enabling the FIFOs */
@@ -584,14 +608,14 @@ static int pl011_init(const struct device *dev)
 		}
 	}
 	/* initialize all IRQs as masked */
-	get_uart(dev)->imsc = 0U;
-	get_uart(dev)->icr = PL011_IMSC_MASK_ALL;
+	uart->imsc = 0U;
+	uart->icr = PL011_IMSC_MASK_ALL;
 
 	if (!data->sbsa) {
-		get_uart(dev)->dmacr = 0U;
+		uart->dmacr = 0U;
 		barrier_isync_fence_full();
-		get_uart(dev)->cr &= ~PL011_CR_SIREN;
-		get_uart(dev)->cr |= PL011_CR_RXE | PL011_CR_TXE;
+		uart->cr &= ~PL011_CR_SIREN;
+		uart->cr |= PL011_CR_RXE | PL011_CR_TXE;
 		barrier_isync_fence_full();
 	}
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN


### PR DESCRIPTION
In several functions, the UART registers are accessed multiple times through the `get_uart(dev)` inline function. This results in repeated dereferencing of the device's base address.

This commit caches the UART register struct pointer in a local variable `uart` at the beginning of each relevant function.

For registers where repeated access is not needed, the value is read once into a temporary variable. Modifications, if any, are applied to the temporary copy, and the result is written back once.