### PR TITLE
Revert "tests: ram_context_for_isr: exclude STM32C0 boards"

### DIFF
--- a/tests/application_development/ram_context_for_isr/testcase.yaml
+++ b/tests/application_development/ram_context_for_isr/testcase.yaml
@@ -6,7 +6,6 @@ tests:
   application_development.ram_context_for_isr:
     # Exclude mps3/corstone310 because it uses another mechanism to support relocation
     # of the vector table (CONFIG_ROMSTART_RELOCATION_ROM).
-    # (Temporarily) Exclude STM32C0 platforms as last IRQ in vector is always used.
     platform_exclude:
       - mps3/corstone310/an555
       - mps3/corstone310/fvp
@@ -20,7 +19,3 @@ tests:
       - hexiwear/mkw40z4
       - frdm_kw41z/mkw41z4
       - frdm_kl25z/mkl25z4
-      - stm32c0116_dk/stm32c011xx
-      - nucleo_c031c6/stm32c031xx
-      - nucleo_c071rb/stm32c071xx
-      - nucleo_c092rc/stm32c092xx


### PR DESCRIPTION
This reverts commit 4f18ccd73b1d68a984dc44c41ea6c0444f53857e now that STM32C0 based target are supported by the test default configuration (see commit 7dbd60016c1e ("tests: ram_context_for_isr: Use Kconfig for IRQ config").