### PR TITLE
drivers: sdhc: lower init priority to fix AIROC WiFi initialization dependency

### DIFF
--- a/drivers/sdhc/Kconfig
+++ b/drivers/sdhc/Kconfig
@@ -25,7 +25,7 @@ source "drivers/sdhc/Kconfig.stm32"
 
 config SDHC_INIT_PRIORITY
 	int "SDHC driver init priority"
-	default 85
+	default 75
 	help
 	  SDHC driver system init priority
 


### PR DESCRIPTION
The AIROC WiFi driver uses the same initialization priority as the generic WiFi configuration (CONFIG_WIFI_INIT_PRIORITY = 80), but depends on SDHC controller for SDIO communication(for sdio bus). This creates a dependency violation:


The AIROC WiFi driver in airoc_wifi.c is defined with:

https://github.com/zephyrproject-rtos/zephyr/blob/09a034e8ce9e56b7dd158a9c82fe73587c4eb83b/drivers/wifi/infineon/airoc_wifi.c#L880-L882
This uses `CONFIG_WIFI_INIT_PRIORITY = 80`, but the SDHC dependency has priority 85, causing initialization order violation:

https://github.com/zephyrproject-rtos/zephyr/blob/09a034e8ce9e56b7dd158a9c82fe73587c4eb83b/drivers/sdhc/Kconfig#L26-L30


to reproduce, with `west build samples/net/wifi/shell -b arduino_giga_r1/stm32h747xx/m7 -d build -p always -- -DCONFIG_HEAP_M
EM_POOL_SIZE=24576` :
```
❯ west build samples/net/wifi/shell -b arduino_giga_r1/stm32h747xx/m7 -d build -p always -- -DCONFIG_HEAP_M
EM_POOL_SIZE=24576
-- west build: making build dir /home/bricl/zwksp/zephyr/build pristine
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: /home/bricl/zwksp/zephyr/samples/net/wifi/shell
-- CMake version: 4.0.3
-- Found Python3: /home/bricl/zephyrproject/.venv/bin/python3 (found suitable version "3.12.3", minimum required is "3.10") found components: Interpreter
-- Cache files will be written to: /home/bricl/.cache/zephyr
-- Zephyr version: 4.2.99 (/home/bricl/zwksp/zephyr)
-- Found west (found suitable version "1.4.0", minimum required is "0.14.0")
-- Board: arduino_giga_r1, qualifiers: stm32h747xx/m7
-- ZEPHYR_TOOLCHAIN_VARIANT not set, trying to locate Zephyr SDK
-- Found host-tools: zephyr 0.17.2 (/home/bricl/zephyr-sdk-0.17.2)
-- Found toolchain: zephyr 0.17.2 (/home/bricl/zephyr-sdk-0.17.2)
-- Found Dtc: /home/bricl/zephyr-sdk-0.17.2/sysroots/x86_64-pokysdk-linux/usr/bin/dtc (found suitable version "1.7.0", minimum required is "1.4.6")
-- Found BOARD.dts: /home/bricl/zwksp/zephyr/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
-- Generated zephyr.dts: /home/bricl/zwksp/zephyr/build/zephyr/zephyr.dts
-- Generated pickled edt: /home/bricl/zwksp/zephyr/build/zephyr/edt.pickle
-- Generated devicetree_generated.h: /home/bricl/zwksp/zephyr/build/zephyr/include/generated/zephyr/devicetree_generated.h
Parsing /home/bricl/zwksp/zephyr/Kconfig
Loaded configuration '/home/bricl/zwksp/zephyr/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7_defconfig'
Merged configuration '/home/bricl/zwksp/zephyr/samples/net/wifi/shell/prj.conf'
Merged configuration '/home/bricl/zwksp/zephyr/build/zephyr/misc/generated/extra_kconfig_options.conf'
Configuration saved to '/home/bricl/zwksp/zephyr/build/zephyr/.config'
Kconfig header saved to '/home/bricl/zwksp/zephyr/build/zephyr/include/generated/zephyr/autoconf.h'
-- Found GnuLd: /home/bricl/zephyr-sdk-0.17.2/arm-zephyr-eabi/arm-zephyr-eabi/bin/ld.bfd (found version "2.38")
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/bricl/zephyr-sdk-0.17.2/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
-- Using ccache: /usr/bin/ccache
-- Found gen_kobject_list: /home/bricl/zwksp/zephyr/scripts/build/gen_kobject_list.py
-- Configuring done (9.5s)
-- Generating done (0.2s)
-- Build files have been written to: /home/bricl/zwksp/zephyr/build
-- west build: building application

............
/home/bricl/zwksp/zephyr/scripts/build/check_init_priorities.py --elf-file=/home/bricl/zwksp/zephyr/build/zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      696912 B       768 KB     88.62%
             RAM:      110304 B       512 KB     21.04%
          EXTMEM:          0 GB       256 MB      0.00%
           SRAM1:          0 GB       128 KB      0.00%
           SRAM2:          0 GB       128 KB      0.00%
           SRAM3:          0 GB        32 KB      0.00%
           SRAM4:          0 GB        64 KB      0.00%
          SDRAM1:          0 GB         8 MB      0.00%
        IDT_LIST:          0 GB        32 KB      0.00%
Generating files from /home/bricl/zwksp/zephyr/build/zephyr/zephyr.elf for board: arduino_giga_r1
ERROR: Device initialization priority validation failed, the sequence of initialization calls does not match the devicetree dependencies.
ERROR: /soc/sdmmc@52007000/airoc-wifi <airoc_init> is initialized before its dependency /soc/sdmmc@52007000 <sdhc_stm32_init> (POST_KERNEL+3 < POST_KERNEL+4)
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/bin/cmake --build /home/bricl/zwksp/zephyr/build
```
**Solution**
Lower the SDHC driver initialization priority from 85 to 75 to make SDHC driver is initialized before AIROC WiFi driver


After this patch, with `west build samples/net/wifi/shell -b arduino_giga_r1/stm32h747xx/m7 -d build -p always -- -DCONFIG_HEAP_M
EM_POOL_SIZE=24576`: 

```
west build samples/net/wifi/shell -b arduino_giga_r1/stm32h747xx/m7 -d build -p always -- -DCONFIG_HEAP_M
EM_POOL_SIZE=24576
-- west build: making build dir /home/bricl/zwksp/zephyr/build pristine
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: /home/bricl/zwksp/zephyr/samples/net/wifi/shell
-- CMake version: 4.0.3

-- Zephyr version: 4.2.99 (/home/bricl/zwksp/zephyr), build: v4.2.0-2593-gae07d7778e54
[294/294] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      696912 B       768 KB     88.62%
             RAM:      110304 B       512 KB     21.04%
          EXTMEM:          0 GB       256 MB      0.00%
           SRAM1:          0 GB       128 KB      0.00%
           SRAM2:          0 GB       128 KB      0.00%
           SRAM3:          0 GB        32 KB      0.00%
           SRAM4:          0 GB        64 KB      0.00%
          SDRAM1:          0 GB         8 MB      0.00%
        IDT_LIST:          0 GB        32 KB      0.00%
Generating files from /home/bricl/zwksp/zephyr/build/zephyr/zephyr.elf for board: arduino_giga_r1
```

cc @ExaltZephyr 
