### PR TITLE
scripts: kconfig: use tabulate for printing hardenconfig results

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -529,10 +529,6 @@
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
     "UP038",    # https://docs.astral.sh/ruff/rules/non-pep604-isinstance
 ]
-"./scripts/kconfig/hardenconfig.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-]
 "./scripts/kconfig/kconfigfunctions.py" = [
     "B011",     # https://docs.astral.sh/ruff/rules/assert-false
     "SIM114",   # https://docs.astral.sh/ruff/rules/if-with-same-arms

--- a/doc/security/hardening-tool.rst
+++ b/doc/security/hardening-tool.rst
@@ -35,14 +35,20 @@ used instead.
 
 .. code-block:: console
 
-                  name                       |   current   |  recommended   ||    check result
-   ================================================================================================
-   CONFIG_BOOT_BANNER                        |      y      |       n        ||       FAIL
-   CONFIG_BUILD_OUTPUT_STRIPPED              |      n      |       y        ||       FAIL
-   CONFIG_FAULT_DUMP                         |      2      |       0        ||       FAIL
-   CONFIG_HW_STACK_PROTECTION                |      n      |       y        ||       FAIL
-   CONFIG_MPU_STACK_GUARD                    |      n      |       y        ||       FAIL
-   CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT     |      n      |       y        ||       FAIL
-   CONFIG_STACK_SENTINEL                     |      n      |       y        ||       FAIL
-   CONFIG_EARLY_CONSOLE                      |      y      |       n        ||       FAIL
-   CONFIG_PRINTK                             |      y      |       n        ||       FAIL
+   +---------------------------------------+-----------+---------------+----------------+
+   | Name                                  | Current   | Recommended   | Check result   |
+   +=======================================+===========+===============+================+
+   | CONFIG_BUILD_OUTPUT_STRIPPED          | n         | y             | FAIL           |
+   +---------------------------------------+-----------+---------------+----------------+
+   | CONFIG_FAULT_DUMP                     | 2         | 0             | FAIL           |
+   +---------------------------------------+-----------+---------------+----------------+
+   | CONFIG_MPU_STACK_GUARD                | n         | y             | FAIL           |
+   +---------------------------------------+-----------+---------------+----------------+
+   | CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT | n         | y             | FAIL           |
+   +---------------------------------------+-----------+---------------+----------------+
+   | CONFIG_STACK_SENTINEL                 | n         | y             | FAIL           |
+   +---------------------------------------+-----------+---------------+----------------+
+   | CONFIG_EXCEPTION_DEBUG                | y         | n             | FAIL           |
+   +---------------------------------------+-----------+---------------+----------------+
+   | CONFIG_PRINTK                         | y         | n             | FAIL           |
+   +---------------------------------------+-----------+---------------+----------------+

--- a/scripts/kconfig/hardenconfig.py
+++ b/scripts/kconfig/hardenconfig.py
@@ -12,8 +12,9 @@ from kconfiglib import standard_kconfig
 def hardenconfig(kconf):
     kconf.load_config()
 
-    hardened_kconf_filename = os.path.join(os.environ['ZEPHYR_BASE'],
-                                           'scripts', 'kconfig', 'hardened.csv')
+    hardened_kconf_filename = os.path.join(
+        os.environ['ZEPHYR_BASE'], 'scripts', 'kconfig', 'hardened.csv'
+    )
 
     options = compare_with_hardened_conf(kconf, hardened_kconf_filename)
 
@@ -21,7 +22,6 @@ def hardenconfig(kconf):
 
 
 class Option:
-
     def __init__(self, name, recommended, current=None, symbol=None):
         self.name = name
         self.recommended = recommended
@@ -51,12 +51,24 @@ def compare_with_hardened_conf(kconf, hardened_kconf_filename):
                 except KeyError:
                     symbol = None
                     current = None
-                options.append(Option(name=name, current=current,
-                                  recommended=recommended, symbol=symbol))
+                options.append(
+                    Option(name=name, current=current, recommended=recommended, symbol=symbol)
+                )
     for node in kconf.node_iter():
         for select in node.selects:
-            if kconf.syms["EXPERIMENTAL"] in select or kconf.syms["DEPRECATED"] in select or kconf.syms["NOT_SECURE"] in select:
-                options.append(Option(name=node.item.name, current=node.item.str_value, recommended='n', symbol=node.item))
+            if (
+                kconf.syms["EXPERIMENTAL"] in select
+                or kconf.syms["DEPRECATED"] in select
+                or kconf.syms["NOT_SECURE"] in select
+            ):
+                options.append(
+                    Option(
+                        name=node.item.name,
+                        current=node.item.str_value,
+                        recommended='n',
+                        symbol=node.item,
+                    )
+                )
 
     return options
 
@@ -71,8 +83,9 @@ def display_results(options):
     # TODO: add command line option to show all results
     for opt in options:
         if opt.result == 'FAIL' and opt.symbol.visibility != 0:
-            print('CONFIG_{:<43}|{:^13}|{:^20}'.format(
-                opt.name, opt.current, opt.recommended), end='')
+            print(
+                'CONFIG_{:<43}|{:^13}|{:^20}'.format(opt.name, opt.current, opt.recommended), end=''
+            )
             print('||{:^28}\n'.format(opt.result), end='')
     print()
 

--- a/scripts/kconfig/hardenconfig.py
+++ b/scripts/kconfig/hardenconfig.py
@@ -7,6 +7,7 @@ import csv
 import os
 
 from kconfiglib import standard_kconfig
+from tabulate import tabulate
 
 
 def hardenconfig(kconf):
@@ -74,19 +75,17 @@ def compare_with_hardened_conf(kconf, hardened_kconf_filename):
 
 
 def display_results(options):
-    # header
-    print('{:^50}|{:^13}|{:^20}'.format('name', 'current', 'recommended'), end='')
-    print('||{:^28}\n'.format('check result'), end='')
-    print('=' * 116)
+    table_data = []
+    headers = ['Name', 'Current', 'Recommended', 'Check result']
 
     # results, only printing options that have failed for now. It simplify the readability.
     # TODO: add command line option to show all results
     for opt in options:
         if opt.result == 'FAIL' and opt.symbol.visibility != 0:
-            print(
-                'CONFIG_{:<43}|{:^13}|{:^20}'.format(opt.name, opt.current, opt.recommended), end=''
-            )
-            print('||{:^28}\n'.format(opt.result), end='')
+            table_data.append([f'CONFIG_{opt.name}', opt.current, opt.recommended, opt.result])
+
+    if table_data:
+        print(tabulate(table_data, headers=headers, tablefmt='grid'))
     print()
 
 


### PR DESCRIPTION
Make use of `tabulate` to pretty print the results of the hardening tool instead of custom formatting.