### PR TITLE
drivers: clock: ccm_rev2: do custom handling of MX93's TPM clocks

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -217,6 +217,16 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 			clock_root = (kCLOCK_Root_Tpm4 + instance - 3);
 		}
 		break;
+#elif defined(CONFIG_SOC_MIMX9352_A55) || defined(CONFIG_SOC_MIMX9352_M33)
+	case IMX_CCM_TPM_CLK:
+		switch (instance) {
+		case 2:
+			clock_root = kCLOCK_Root_BusWakeup;
+			break;
+		default:
+			clock_root = kCLOCK_Root_Tpm1 + instance;
+		}
+		break;
 #else
 	case IMX_CCM_TPM_CLK:
 		clock_root = kCLOCK_Root_Tpm1 + instance;


### PR DESCRIPTION
As per the i.MX93's TRM, section "30.2 System Clocks", the root clock of TPM3 is not TPM3_CLK_ROOT, but, rather, BUS_WAKEUP_CLK_ROOT. Therefore, if clock_control_get_rate() using the IMX_CCM_TPM3_CLK clock ID, the root clock will have to be set to kCLOCK_Root_BusWakeup instead of kCLOCK_Root_Tpm3.