### PR TITLE
drivers: flash: shell: Fix printing partitions without labels

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -733,8 +733,9 @@ static int cmd_page_info(const struct shell *sh, size_t argc, char *argv[])
 }
 
 #if DT_HAS_COMPAT_STATUS_OKAY(fixed_partitions)
-#define PRINT_PARTITION_INFO(part) shell_print(sh, "%-15s 0x%08x %d Kb", DT_PROP(part, label), \
-					  DT_REG_ADDR(part), DT_REG_SIZE(part) / 1024);
+#define PRINT_PARTITION_INFO(part)                                                                 \
+	shell_print(sh, "%-32s %-15s 0x%08x %d Kb", DT_NODE_FULL_NAME(part),                       \
+		    DT_PROP_OR(part, label, ""), DT_REG_ADDR(part), DT_REG_SIZE(part) / 1024);
 
 static int cmd_partitions(const struct shell *sh, size_t argc, char *argv[])
 {


### PR DESCRIPTION
Commit df0f74d491c851b3e7e970f898c5c2fc3aab5b80 added a shell command to be able to print out the partitions. However the label property is optional.

Print both the name and label if available.