### PR TITLE
twister: remove stray debug message

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -390,7 +390,7 @@ class BinaryHandler(Handler):
             self.returncode = proc.returncode
             if proc.returncode != 0:
                 self.instance.status = TwisterStatus.ERROR
-                self.instance.reason = f"BinaryHandler returned {proc.returncode}"
+                self.instance.reason = f"rc={proc.returncode}"
             self.try_kill_process_by_pid()
 
         self.execution_time = time.time() - start_time

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -207,7 +207,6 @@ class Handler:
             else:
                 self.instance.reason = self.instance.reason or "Unknown Error"
         elif harness.status != TwisterStatus.NONE:
-            print("got in here with status " + str(harness.status))
             self.instance.status = harness.status
             if harness.status in [TwisterStatus.FAIL, TwisterStatus.ERROR]:
                 self.instance.reason = harness.reason

--- a/scripts/tests/twister_blackbox/test_device.py
+++ b/scripts/tests/twister_blackbox/test_device.py
@@ -56,7 +56,7 @@ class TestDevice:
     def test_seed(self, capfd, out_path, seed):
         test_platforms = ['native_sim']
         path = os.path.join(TEST_DATA, 'tests', 'seed_native_sim')
-        args = ['--detailed-test-id', '--outdir', out_path, '-i', '-T', path, '-vv',] + \
+        args = ['--no-detailed-test-id', '--outdir', out_path, '-i', '-T', path, '-vv',] + \
                ['--seed', f'{seed[0]}'] + \
                [val for pair in zip(
                    ['-p'] * len(test_platforms), test_platforms
@@ -72,5 +72,5 @@ class TestDevice:
 
         assert str(sys_exit.value) == '1'
 
-        expected_line = r'seed_native_sim.dummy FAILED Failed \(rc=1\) \(native (\d+\.\d+)s/seed: {} <host>\)'.format(seed[0])
+        expected_line = r'seed_native_sim.dummy\s+FAILED rc=1 \(native (\d+\.\d+)s/seed: {} <host>\)'.format(seed[0])
         assert re.search(expected_line, err)


### PR DESCRIPTION
Remove leftover debug message.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
