### PR TITLE
drivers: ethernet: phy: update ksz8081 with interrupt support

### DIFF
--- a/drivers/ethernet/phy/phy_microchip_ksz8081.c
+++ b/drivers/ethernet/phy/phy_microchip_ksz8081.c
@@ -561,11 +561,6 @@ static int phy_mc_ksz8081_init(const struct device *dev)
 	mdio_bus_enable(config->mdio_dev);
 	k_busy_wait(100000);
 
-	ret = ksz8081_init_int_gpios(dev);
-	if (ret) {
-		return ret;
-	}
-
 	ret = ksz8081_init_reset_gpios(dev);
 	if (ret) {
 		return ret;
@@ -574,6 +569,11 @@ static int phy_mc_ksz8081_init(const struct device *dev)
 
 	/* Reset PHY */
 	ret = phy_mc_ksz8081_reset(dev);
+	if (ret) {
+		return ret;
+	}
+
+	ret = ksz8081_init_int_gpios(dev);
 	if (ret) {
 		return ret;
 	}

--- a/drivers/ethernet/phy/phy_microchip_ksz8081.c
+++ b/drivers/ethernet/phy/phy_microchip_ksz8081.c
@@ -54,9 +54,9 @@ struct mc_ksz8081_config {
 };
 
 /* arbitrarily defined internal driver flags */
-#define KSZ8081_DO_AUTONEG_FLAG 0x1
-#define KSZ8081_SILENCE_DEBUG_LOGS 0x2
-#define KSZ8081_LINK_STATE_VALID 0x3
+#define KSZ8081_DO_AUTONEG_FLAG BIT(0)
+#define KSZ8081_SILENCE_DEBUG_LOGS BIT(1)
+#define KSZ8081_LINK_STATE_VALID BIT(2)
 
 struct mc_ksz8081_data {
 	const struct device *dev;


### PR DESCRIPTION
Following changes are included in this PR:
 - fix the internal flags for auto-negotiation
 - adjust ksz8081_init_int_gpios() to after phy_mc_ksz8081_reset()
 - add support for ksz8081 interrupt mode (the commit is the one dropped in https://github.com/zephyrproject-rtos/zephyr/pull/90711#issuecomment-3243799385)
