### PR TITLE
doc: update SDK compatibilty URL

### DIFF
--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -229,6 +229,6 @@ Zephyr SDK installation
             the initial setup.
 
 .. _Zephyr SDK Releases: https://github.com/zephyrproject-rtos/sdk-ng/tags
-.. _Zephyr SDK Version Compatibility Matrix: https://github.com/zephyrproject-rtos/sdk-ng/wiki/Zephyr-SDK-Version-Compatibility-Matrix
+.. _Zephyr SDK Version Compatibility Matrix: https://github.com/zephyrproject-rtos/sdk-ng/wiki/Zephyr-Version-Compatibility#zephyr-sdk-version-compatibility-matrix
 
 .. toolchain_zephyr_sdk_install_end


### PR DESCRIPTION
Zephyr Version Compatibility page get moved in sdk-ng project. This patch updates to URL to match the new page name.