### PR TITLE
scripts: west_commands: build: Remove build warning

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -238,6 +238,9 @@ class Build(Forceable):
                 self.run_cmake = True
             else:
                 self._update_cache()
+                # Find board from cache if it wasn't specified
+                if not board:
+                    board, origin = self._find_board()
                 if (self.args.cmake or self.args.cmake_opts or
                         self.args.cmake_only or self.args.snippets or
                         self.args.shields or self.args.extra_conf_files or


### PR DESCRIPTION
For non-pristine build, there is warning, which is unnecessary. For example:

If I have run "west build -b frdm_ke17z ./samples/hello_world -p " before, after make some code changes, I want to run a non-pristine build: 
(.venv) ➜  zephyr git:(main) ✗ west build
WARNING: This looks like a fresh build and BOARD is unknown; so it probably won't work. To fix, use --board=<your-board>.
Note: to silence the above message, run 'west config build.board_warn false'
ninja: no work to do.

It's not a  fresh build and the "board" variable can be got from CMake Cache. 
This patch is trying to get board after cmake cache is got by "self._update_cache()".

This is a regression introduced by https://github.com/zephyrproject-rtos/zephyr/pull/94231