### PR TITLE
Bluetooth: Audio: shell: docs: Update broadcast assistant documentation

### DIFF
--- a/doc/connectivity/bluetooth/shell/audio/bap_broadcast_assistant.rst
+++ b/doc/connectivity/bluetooth/shell/audio/bap_broadcast_assistant.rst
@@ -38,6 +38,8 @@ subscribe to all notifications.
                         [<pa_interval>] [<sync_bis>] [<metadata>]
    add_broadcast_id  : Add a source by broadcast ID <broadcast_id> <sync_pa>
                         [<sync_bis>] [<metadata>]
+   add_broadcast_name: Add a source by broadcast name <broadcast_name> <sync_pa>
+                        [<sync_bis>] [<metadata>]
    add_pa_sync       : Add a PA sync as a source <sync_pa> <broadcast_id>
                         [bis_index [bis_index [bix_index [...]]]]>
    mod_src           : Set sync <src_id> <sync_pa> [<pa_interval> | "unknown"] [<sync_bis>]


### PR DESCRIPTION
Updated the documentation for the BAP broadcast assistant client shell commands to include the previously added 'add_by_broadcast_name' command.