### PR TITLE
boards: renesas: add 3 LED support

### DIFF
--- a/boards/renesas/ek_ra4m2/ek_ra4m2.dts
+++ b/boards/renesas/ek_ra4m2/ek_ra4m2.dts
@@ -56,6 +56,8 @@
 
 	aliases {
 		led0 = &led1;
+		led1 = &led2;
+		led2 = &led3;
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdt;


### PR DESCRIPTION
The ek_ra4m2 board has 3 LED.