### PR TITLE
shields: devicetree: use arduino-header-r3.h constants in all shields

### DIFF
--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/display/ili9xxx.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -23,7 +24,7 @@
 	adafruit_2_8_tft_touch_v2_mipi_dbi: adafruit_2_8_tft_touch_v2_mipi_dbi {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
 		write-only;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -48,8 +49,8 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>,	/* D10 */
-		   <&arduino_header 10 GPIO_ACTIVE_LOW>;	/* D04 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>,
+		   <&arduino_header ARDUINO_HEADER_R3_D4 GPIO_ACTIVE_LOW>;
 
 	adafruit_2_8_tft_touch_v2_sdhc: sdhc@1 {
 		compatible = "zephyr,sdhc-spi-slot";
@@ -69,6 +70,6 @@
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		/* Uncomment if IRQ line is available (requires to solder jumper) */
-		/* int-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>; */ /* D7 */
+		/* int-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>; */
 	};
 };

--- a/boards/shields/adafruit_data_logger/adafruit_data_logger.overlay
+++ b/boards/shields/adafruit_data_logger/adafruit_data_logger.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+ #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		rtc = &rtc0_adafruit_data_logger;
@@ -16,7 +18,7 @@
 		 * pins "L1" and "Digital I/O 3".
 		 */
 		green_led_adafruit_data_logger: led_1__adafruit_data_logger {
-			gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>; /* D3 */
+			gpios = <&arduino_header ARDUINO_HEADER_R3_D3 GPIO_ACTIVE_HIGH>;
 			label = "User LED1";
 		};
 		/*
@@ -24,7 +26,7 @@
 		 * pins "L2" and "Digital I/O 4".
 		 */
 		red_led_adafruit_data_logger: led_2_adafruit_data_logger {
-			gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>; /* D4 */
+			gpios = <&arduino_header ARDUINO_HEADER_R3_D4 GPIO_ACTIVE_HIGH>;
 			label = "User LED2";
 		};
 	};
@@ -33,7 +35,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 
 	sdhc0_adafruit_data_logger: sdhc@0 {
 		compatible = "zephyr,sdhc-spi-slot";
@@ -61,7 +63,8 @@
 		 * Interrupt connection must be manually established using a jumper wire between
 		 * pins "SQ" and "Digital I/O 7".
 		 */
-		int1-gpios = <&arduino_header 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; /* D7 */
+		int1-gpios = <&arduino_header ARDUINO_HEADER_R3_D7
+			      (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		status = "okay";
 	};
 };

--- a/boards/shields/adafruit_winc1500/adafruit_winc1500.overlay
+++ b/boards/shields/adafruit_winc1500/adafruit_winc1500.overlay
@@ -4,17 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 0>;			/* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 0>;
 
 	winc1500_adafruit_winc1500: winc1500@0 {
 		status = "ok";
 		compatible = "atmel,winc1500";
 		reg = <0x0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>;	/* D7 */
-		reset-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>;	/* D5 */
-		enable-gpios = <&arduino_header 12 0>;			/* D6 */
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_LOW>;
+		enable-gpios = <&arduino_header ARDUINO_HEADER_R3_D6 0>;
 	};
 };

--- a/boards/shields/amg88xx/amg88xx_eval_kit.overlay
+++ b/boards/shields/amg88xx/amg88xx_eval_kit.overlay
@@ -4,14 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_i2c {
 	status = "okay";
 
 	amg88xx_amg88xx_eval_kit: amg88xx@68 {
 		compatible = "panasonic,amg88xx";
 		reg = <0x68>;
-		/* Pin D6 from Arduino Connector */
-		int-gpios = <&arduino_header 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		status = "okay";
 	};
 };

--- a/boards/shields/amg88xx/amg88xx_grid_eye_eval_shield.overlay
+++ b/boards/shields/amg88xx/amg88xx_grid_eye_eval_shield.overlay
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_i2c {
 	status = "okay";
 	amg88xx_amg88xx_grid_eye_eval_shield: amg88xx@68 {
 		compatible = "panasonic,amg88xx";
 		reg = <0x68>;
-		/* Pin D2 from Arduino Connector */
-		int-gpios = <&arduino_header 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		status = "okay";
 	};
 };

--- a/boards/shields/arceli_eth_w5500/arceli_eth_w5500.overlay
+++ b/boards/shields/arceli_eth_w5500/arceli_eth_w5500.overlay
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	status = "okay";
 
@@ -9,7 +11,7 @@
 		compatible = "wiznet,w5500";
 		reg = <0x0>;
 		spi-max-frequency = <80000000>;
-		int-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/boards/shields/atmel_rf2xx/atmel_rf2xx_arduino.overlay
+++ b/boards/shields/atmel_rf2xx/atmel_rf2xx_arduino.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	chosen {
 		zephyr,ieee802154 = &ieee802154_atmel_rf2xx_arduino;
@@ -13,21 +15,17 @@
 &arduino_spi {
 	status = "okay";
 
-	/* D10 */
-	cs-gpios = <&arduino_header 16
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10
 		    (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 
 	ieee802154_atmel_rf2xx_arduino: rf2xx@0 {
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
 		spi-max-frequency = <6000000>;
-		/*  D2 */
-		irq-gpios = <&arduino_header 8
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_D2
 			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
-		/*  D8 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;
-		/*  D9 */
-		slptr-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
+		slptr-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 };

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/display/ili9xxx.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -22,8 +23,8 @@
 
 	buydisplay_2_8_tft_touch_arduino_mipi_dbi {
 		compatible = "zephyr,mipi-dbi-spi";
-		dc-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>; /* D7 */
-		reset-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 		spi-dev = <&arduino_spi>;
 		write-only;
 		#address-cells = <1>;
@@ -49,7 +50,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; /* D9 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>;
 };
 
 &arduino_i2c {
@@ -57,6 +58,6 @@
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		/* Uncomment if IRQ line is available (requires to solder jumper) */
-		/* int-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>; */ /* D5 */
+		/* int-gpios = <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_LOW>; */
 	};
 };

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/display/ili9xxx.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -22,8 +23,8 @@
 
 	buydisplay_3_5_tft_touch_arduino_mipi_dbi {
 		compatible = "zephyr,mipi-dbi-spi";
-		dc-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>; /* D7 */
-		reset-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 		spi-dev = <&arduino_spi>;
 		write-only;
 		#address-cells = <1>;
@@ -48,7 +49,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; /* D9 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>;
 };
 
 &arduino_i2c {
@@ -56,6 +57,6 @@
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		/* Uncomment if IRQ line is available (requires to solder jumper) */
-		/* int-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>; */ /* D5 */
+		/* int-gpios = <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_LOW>; */
 	};
 };

--- a/boards/shields/dac80508_evm/dac80508_evm.overlay
+++ b/boards/shields/dac80508_evm/dac80508_evm.overlay
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 
 	dac80508_dac80508_evm: dac80508@0 {
 		compatible = "ti,dac80508";

--- a/boards/shields/eval_ad4052_ardz/eval_ad4052_ardz.overlay
+++ b/boards/shields/eval_ad4052_ardz/eval_ad4052_ardz.overlay
@@ -4,15 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	status = "okay";
 
 	adc4052_eval_ad4052_ardz: adc4052@0 {
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(2)>;
-		gp1-gpios = <&arduino_header 14 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
-		gp0-gpios = <&arduino_header 15 (GPIO_PULL_DOWN)>;
-		conversion-gpios = <&arduino_header 12 (GPIO_ACTIVE_HIGH | MAX32_GPIO_VSEL_VDDIOH)>;
+		gp1-gpios = <&arduino_header ARDUINO_HEADER_R3_D8
+			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+		gp0-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 (GPIO_PULL_DOWN)>;
+		conversion-gpios = <&arduino_header ARDUINO_HEADER_R3_D6
+				    (GPIO_ACTIVE_HIGH | MAX32_GPIO_VSEL_VDDIOH)>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		#io-channel-cells = <1>;

--- a/boards/shields/eval_adxl362_ardz/eval_adxl362_ardz.overlay
+++ b/boards/shields/eval_adxl362_ardz/eval_adxl362_ardz.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/sensor/adxl362.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 &arduino_spi {
 	status = "okay";
@@ -13,7 +14,7 @@
 		compatible = "adi,adxl362";
 		reg = <0x0>;
 		spi-max-frequency = <DT_FREQ_M(1)>;
-		int1-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
+		int1-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_HIGH>;
 		fifo-mode = <ADXL362_FIFO_MODE_STREAM>;
 		fifo-watermark = <0x80>;
 		status = "okay";

--- a/boards/shields/eval_adxl367_ardz/eval_adxl367_ardz.overlay
+++ b/boards/shields/eval_adxl367_ardz/eval_adxl367_ardz.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/sensor/adxl367.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	aliases {
@@ -19,7 +20,7 @@
 		compatible = "adi,adxl367";
 		reg = <0x0>;
 		spi-max-frequency = <DT_FREQ_M(1)>;
-		int1-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
+		int1-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_HIGH>;
 		fifo-mode = <ADXL367_FIFO_MODE_STREAM>;
 		status = "okay";
 	};

--- a/boards/shields/eval_adxl372_ardz/eval_adxl372_ardz.overlay
+++ b/boards/shields/eval_adxl372_ardz/eval_adxl372_ardz.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/sensor/adxl372.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 
 &arduino_spi {
@@ -14,7 +15,7 @@
 		compatible = "adi,adxl372";
 		reg = <0x0>;
 		spi-max-frequency = <DT_FREQ_M(1)>;
-		int1-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;
+		int1-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
 		fifo-mode = <ADXL372_FIFO_MODE_STREAMED>;
 		fifo-watermark = <0x80>;
 		status = "okay";

--- a/boards/shields/frdm_cr20a/frdm_cr20a.overlay
+++ b/boards/shields/frdm_cr20a/frdm_cr20a.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	chosen {
 		zephyr,ieee802154 = &ieee802154_frdm_cr20a;
@@ -17,9 +19,9 @@
 		compatible = "nxp,mcr20a";
 		reg = <0x0>;
 		spi-max-frequency = <4000000>;
-		irqb-gpios = <&arduino_header 8
-				(GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;	/* D2 */
-		reset-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>;	/* D5 */
+		irqb-gpios = <&arduino_header ARDUINO_HEADER_R3_D2
+				(GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_LOW>;
 		status = "okay";
 	};
 };

--- a/boards/shields/frdm_stbc_agm01/frdm_stbc_agm01.overlay
+++ b/boards/shields/frdm_stbc_agm01/frdm_stbc_agm01.overlay
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		magn0 = &fxos8700_1e_frdm_stbc_agm01;
@@ -14,14 +16,14 @@
 	fxos8700_1e_frdm_stbc_agm01: fxos8700@1e {
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
-		int1-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;
-		int2-gpios = <&arduino_header 10 GPIO_ACTIVE_LOW>;
+		int1-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_LOW>;
+		int2-gpios = <&arduino_header ARDUINO_HEADER_R3_D4 GPIO_ACTIVE_LOW>;
 	};
 
 	fxas21002_frdm_stbc_agm01: fxas21002@20 {
 		compatible = "nxp,fxas21002";
 		reg = <0x20>;
-		int1-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>;
-		int2-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;
+		int1-gpios = <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_LOW>;
+		int2-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/boards/shields/ftdi_vm800c/ftdi_vm800c.overlay
+++ b/boards/shields/ftdi_vm800c/ftdi_vm800c.overlay
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	status = "okay";
 
-	/* D10 */
-	cs-gpios = <&arduino_header 16
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10
 		    (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 
 	ft800_ftdi_vm800c: ft800@0 {
 		compatible = "ftdi,ft800";
 		reg = <0x0>;
 		spi-max-frequency = <8000000>;
-		/*  D2 */
-		irq-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_LOW>;
 
 		pclk = <5>;
 		pclk-pol = <1>;

--- a/boards/shields/inventek_eswifi/inventek_eswifi_arduino_spi.overlay
+++ b/boards/shields/inventek_eswifi/inventek_eswifi_arduino_spi.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	status = "okay";
 
-	/* D10 */
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 
 	wifi0_inventek_eswifi_arduino_spi: iwin@0 {
 		status = "okay";
@@ -16,13 +17,9 @@
 		spi-max-frequency = <2000000>;
 		reg = <0>;
 
-		/* D9 */
-		data-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;
-		/* D7 */
-		wakeup-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;
-		/* D6 */
-		resetn-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;
-		/* D5 */
-		boot0-gpios = <&arduino_header 11 GPIO_ACTIVE_HIGH>;
+		data-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
+		wakeup-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
+		resetn-gpios = <&arduino_header ARDUINO_HEADER_R3_D6 GPIO_ACTIVE_HIGH>;
+		boot0-gpios = <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/shields/inventek_eswifi/inventek_eswifi_arduino_uart.overlay
+++ b/boards/shields/inventek_eswifi/inventek_eswifi_arduino_uart.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_serial {
 	status = "okay";
 
@@ -11,9 +13,7 @@
 		status = "okay";
 		compatible = "inventek,eswifi-uart";
 
-		/* D7 */
-		wakeup-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;
-		/* D6 */
-		resetn-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;
+		wakeup-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
+		resetn-gpios = <&arduino_header ARDUINO_HEADER_R3_D6 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/shields/link_board_eth/link_board_eth.overlay
+++ b/boards/shields/link_board_eth/link_board_eth.overlay
@@ -4,14 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 
 	enc424j600_link_board_eth: enc424j600@0 {
 		compatible = "microchip,enc424j600";
 		spi-max-frequency = <14000000>;
-		int-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
+		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>;
 		status = "okay";
 		reg = <0>;
 	};

--- a/boards/shields/lmp90100_evb/lmp90100_evb.overlay
+++ b/boards/shields/lmp90100_evb/lmp90100_evb.overlay
@@ -6,6 +6,7 @@
 
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 &arduino_spi {
 	status = "okay";
@@ -15,7 +16,7 @@
 		reg = <0x0>;
 		spi-max-frequency = <1000000>;
 		/* Uncomment to use IRQ instead of polling: */
-		/* drdyb-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; */
+		/* drdyb-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>; */
 		#io-channel-cells = <1>;
 
 		lmp90100_gpio: gpio {

--- a/boards/shields/ls0xx_generic/ls013b7dh03.overlay
+++ b/boards/shields/ls0xx_generic/ls013b7dh03.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	chosen {
 		zephyr,display = &ls0xx_ls013b7dh03;
@@ -12,7 +14,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_HIGH>; /* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_HIGH>;
 
 	ls0xx_ls013b7dh03: ls0xx@0 {
 		compatible = "sharp,ls0xx";
@@ -20,8 +22,8 @@
 		reg = <0>;
 		width = <128>;
 		height = <128>;
-		extcomin-gpios = <&arduino_header 14 GPIO_ACTIVE_HIGH>; /* D8 */
+		extcomin-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_HIGH>;
 		extcomin-frequency = <60>; /* required if extcomin-gpios is defined */
-		disp-en-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>; /* D6 */
+		disp-en-gpios = <&arduino_header ARDUINO_HEADER_R3_D6 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/shields/max3421e/sparkfun_max3421e.overlay
+++ b/boards/shields/max3421e/sparkfun_max3421e.overlay
@@ -4,15 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 
 	zephyr_uhc0: max3421e@0 {
 		compatible = "maxim,max3421e_spi";
 		spi-max-frequency = <26000000>;
-		int-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
-		reset-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>;	/* D7 */
+		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>;
 		status = "okay";
 		reg = <0>;
 	};

--- a/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
+++ b/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
@@ -4,14 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 
 	mcp2515_dfrobot_can_bus_v2_0: can@0 {
 		compatible = "microchip,mcp2515";
 		spi-max-frequency = <1000000>;
-		int-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>; /* D2 */
+		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_LOW>;
 		status = "okay";
 		reg = <0x0>;
 		osc-freq = <16000000>;

--- a/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
+++ b/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
@@ -4,14 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 
 	mcp2515_keyestudio_can_bus_ks0411: can@0 {
 		compatible = "microchip,mcp2515";
 		spi-max-frequency = <1000000>;
-		int-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>; /* D8 */
+		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		status = "okay";
 		reg = <0x0>;
 		osc-freq = <16000000>;

--- a/boards/shields/npm1100_ek/npm1100_ek.overlay
+++ b/boards/shields/npm1100_ek/npm1100_ek.overlay
@@ -3,14 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	npm1100_ek_pmic: pmic {
 		compatible = "nordic,npm1100";
 
-		nordic,iset-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>; /* D2 */
+		nordic,iset-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_HIGH>;
 
 		npm1100_ek_buck: BUCK {
-			nordic,mode-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>; /* D3 */
+			nordic,mode-gpios = <&arduino_header ARDUINO_HEADER_R3_D3 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/boards/shields/nrf7002ek/nrf7002ek_coex.overlay
+++ b/boards/shields/nrf7002ek/nrf7002ek_coex.overlay
@@ -4,18 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+ #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	nrf_radio_coex: coex {
 		compatible = "nordic,nrf7002-coex";
 		status = "okay";
 
-		/* D2 */
-		status0-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
-		/* D3 */
-		req-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>;
-		/* D4 */
-		grant-gpios = <&arduino_header 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
-		/* D6 */
-		swctrl1-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;
+		status0-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_HIGH>;
+		req-gpios = <&arduino_header ARDUINO_HEADER_R3_D3 GPIO_ACTIVE_HIGH>;
+		grant-gpios = <&arduino_header ARDUINO_HEADER_R3_D4
+			       (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
+		swctrl1-gpios = <&arduino_header ARDUINO_HEADER_R3_D6 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/shields/nrf7002ek/nrf7002ek_common.dtsi
+++ b/boards/shields/nrf7002ek/nrf7002ek_common.dtsi
@@ -6,16 +6,14 @@
 
 /* Common assignments for any nRF70 shield */
 
-/* D0 */
-iovdd-ctrl-gpios = <&arduino_header 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
-/* D1 */
-bucken-gpios = <&arduino_header 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
-/* D7 */
-host-irq-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
+iovdd-ctrl-gpios = <&arduino_header ARDUINO_HEADER_R3_D0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+bucken-gpios = <&arduino_header ARDUINO_HEADER_R3_D1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+host-irq-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
 
 /* Short-range (SR) co-existence */
-/* D8 */
-srrf-switch-gpios = <&arduino_header 14 GPIO_ACTIVE_HIGH>;
+srrf-switch-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_HIGH>;
 
 /* Maximum TX power limits for 2.4 GHz */
 wifi-max-tx-pwr-2g-dsss = <21>;

--- a/boards/shields/openthread_rcp_arduino/openthread_rcp_arduino_spi.overlay
+++ b/boards/shields/openthread_rcp_arduino/openthread_rcp_arduino_spi.overlay
@@ -8,6 +8,8 @@
  * Overlay to enable support for OpenThread's RCP over SPI communication
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	chosen {
 		zephyr,hdlc-rcp-if = &hdlc_rcp_if;
@@ -23,7 +25,7 @@
 		reg = <0>;
 
 		spi-max-frequency = <1000000>; /* 1 MHz to support most devices */
-		int-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; /* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>; /* D8 */
+		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/boards/shields/reyax_lora/reyax_lora.overlay
+++ b/boards/shields/reyax_lora/reyax_lora.overlay
@@ -4,6 +4,7 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 /{
 	aliases {
@@ -18,6 +19,6 @@
 	rylr_lora_modem: rylr_lora_modem {
 			compatible = "reyax,rylrxxx";
 			status = "okay";
-			reset-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;
+			reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/boards/shields/seeed_w5500/seeed_w5500.overlay
+++ b/boards/shields/seeed_w5500/seeed_w5500.overlay
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	status = "okay";
 
@@ -10,6 +12,6 @@
 		compatible = "wiznet,w5500";
 		reg = <0x0>;
 		spi-max-frequency = <DT_FREQ_M(20)>;
-		int-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;	/* D2 */
+		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/boards/shields/semtech_sx1262mb2das/semtech_sx1262mb2das.overlay
+++ b/boards/shields/semtech_sx1262mb2das/semtech_sx1262mb2das.overlay
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		lora0 = &lora_semtech_sx1262mb2das;
@@ -12,17 +14,17 @@
 &arduino_spi {
 	status = "okay";
 
-	cs-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>;
 
 	lora_semtech_sx1262mb2das: sx1262@0 {
 		compatible = "semtech,sx1262";
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(8)>;
 		label = "SX1262";
-		reset-gpios = <&arduino_header 0 GPIO_ACTIVE_LOW>;
-		busy-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>;
-		antenna-enable-gpios = <&arduino_header 14 GPIO_ACTIVE_HIGH>;
-		dio1-gpios = <&arduino_header 11 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_A0 GPIO_ACTIVE_LOW>;
+		busy-gpios = <&arduino_header ARDUINO_HEADER_R3_D3 GPIO_ACTIVE_HIGH>;
+		antenna-enable-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_HIGH>;
+		dio1-gpios = <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_HIGH>;
 		dio2-tx-enable;
 		tcxo-power-startup-delay-ms = <5>;
 	};

--- a/boards/shields/semtech_sx1272mb2das/semtech_sx1272mb2das.overlay
+++ b/boards/shields/semtech_sx1272mb2das/semtech_sx1272mb2das.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		lora0 = &lora_semtech_sx1272mb2das;
@@ -13,19 +15,23 @@
 &arduino_spi {
 	status = "okay";
 
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 
 	lora_semtech_sx1272mb2das: lora@0 {
 		compatible = "semtech,sx1272";
 		reg = <0x0>;
 		spi-max-frequency = <3000000>;
 
-		reset-gpios = <&arduino_header 0 GPIO_ACTIVE_HIGH>;   /* A0 */
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_A0 GPIO_ACTIVE_HIGH>;
 
-		dio-gpios = <&arduino_header 8 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO0 is D2 */
-		            <&arduino_header 9 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO1 is D3 */
-			    <&arduino_header 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO2 is D4 */
-			    <&arduino_header 11 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;	   /* DIO3 is D5 */
+		dio-gpios = <&arduino_header ARDUINO_HEADER_R3_D2
+			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			    <&arduino_header ARDUINO_HEADER_R3_D3
+			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			    <&arduino_header ARDUINO_HEADER_R3_D4
+			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			    <&arduino_header ARDUINO_HEADER_R3_D5
+			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
 
 		power-amplifier-output = "rfo";
 	};

--- a/boards/shields/semtech_sx1276mb1mas/semtech_sx1276mb1mas.overlay
+++ b/boards/shields/semtech_sx1276mb1mas/semtech_sx1276mb1mas.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		lora0 = &lora_semtech_sx1276mb1mas;
@@ -13,22 +15,28 @@
 &arduino_spi {
 	status = "okay";
 
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 
 	lora_semtech_sx1276mb1mas: lora@0 {
 		compatible = "semtech,sx1276";
 		reg = <0x0>;
 		spi-max-frequency = <DT_FREQ_M(1)>;
 
-		reset-gpios = <&arduino_header 0 GPIO_ACTIVE_LOW>;   /* A0 */
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_A0 GPIO_ACTIVE_LOW>;
 
-		dio-gpios = <&arduino_header 8 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO0 is D2 */
-		            <&arduino_header 9 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO1 is D3 */
-			    <&arduino_header 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO2 is D4 */
-			    <&arduino_header 11 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO3 is D5 */
-			    <&arduino_header 14 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO4 is D8 */
-			    <&arduino_header 15 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;	   /* DIO5 is D9 */
+		dio-gpios = <&arduino_header ARDUINO_HEADER_R3_D2
+			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			    <&arduino_header ARDUINO_HEADER_R3_D3
+			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			    <&arduino_header ARDUINO_HEADER_R3_D4
+			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			    <&arduino_header ARDUINO_HEADER_R3_D5
+			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			    <&arduino_header ARDUINO_HEADER_R3_D8
+			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			    <&arduino_header ARDUINO_HEADER_R3_D9
+			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
 
-		rfo-enable-gpios = <&arduino_header 4 GPIO_ACTIVE_HIGH>; /* RXTX_EXT is A4 */
+		rfo-enable-gpios = <&arduino_header ARDUINO_HEADER_R3_A4 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/shields/sparkfun_sara_r4/sparkfun_sara_r4.overlay
+++ b/boards/shields/sparkfun_sara_r4/sparkfun_sara_r4.overlay
@@ -4,14 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_serial {
 	current-speed = <115200>;
 	status = "okay";
 
 	sara_r4 {
 		compatible = "u-blox,sara-r4";
-		mdm-power-gpios = <&arduino_header 11 0>; /* D5 */
-		mdm-reset-gpios = <&arduino_header 12 0>; /* D6 */
+		mdm-power-gpios = <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_HIGH>;
+		mdm-reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D6 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 };

--- a/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
+++ b/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	chosen {
 		zephyr,display = &ssd1306_ssd1306_128x64_spi;
@@ -26,7 +28,7 @@
 		segment-remap;
 		com-invdir;
 		prechargep = <0x22>;
-		data-cmd-gpios = <&arduino_header 15 0>;
-		/* reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>; */
+		data-cmd-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 0>;
+		/* reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>; */
 	};
 };

--- a/boards/shields/st7735r/st7735r_ada_160x128.overlay
+++ b/boards/shields/st7735r/st7735r_ada_160x128.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -14,8 +15,8 @@
 	mipi_dbi_st7735r_ada_160x128 {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -47,5 +48,5 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 };

--- a/boards/shields/st7789v_generic/st7789v_tl019fqv01.overlay
+++ b/boards/shields/st7789v_generic/st7789v_tl019fqv01.overlay
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -13,8 +14,8 @@
 	mipi_dbi_st7789v_tl019fqv01 {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		write-only;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -49,5 +50,5 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 };

--- a/boards/shields/st7789v_generic/st7789v_waveshare_240x240.overlay
+++ b/boards/shields/st7789v_generic/st7789v_waveshare_240x240.overlay
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -15,8 +16,8 @@
 	mipi_dbi_st7789v_waveshare_240x240 {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		write-only;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -51,5 +52,5 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 };

--- a/boards/shields/tcan4550evm/tcan4550evm.overlay
+++ b/boards/shields/tcan4550evm/tcan4550evm.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -14,7 +15,7 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 
 	tcan4x5x_tcan4550evm: can@0 {
 		compatible = "ti,tcan4x5x";
@@ -23,10 +24,10 @@
 		spi-max-frequency = <2000000>;
 		status = "okay";
 		clock-frequency = <40000000>;
-		device-state-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>; /* D6 */
-		device-wake-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>; /* D7 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_HIGH>; /* D8 */
-		int-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; /* D9 */
+		device-state-gpios = <&arduino_header ARDUINO_HEADER_R3_D6 GPIO_ACTIVE_HIGH>;
+		device-wake-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_HIGH>;
+		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>;
 		bosch,mram-cfg = <0x0 15 15 7 7 0 10 10>;
 		status = "okay";
 

--- a/boards/shields/ti_bp_bassensorsmkii/ti_bp_bassensorsmkii.overlay
+++ b/boards/shields/ti_bp_bassensorsmkii/ti_bp_bassensorsmkii.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		accel0 = &bmi160_ti_bp_bassensorsmkii;
@@ -16,7 +18,7 @@
 	bmi160_ti_bp_bassensorsmkii: bmi160@69 {
 		compatible = "bosch,bmi160";
 		reg = <0x69>;
-		int-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
+		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_HIGH>;
 	};
 
 	opt3001_ti_bp_bassensorsmkii: opt3001@44 {

--- a/boards/shields/waveshare_epaper/dts/waveshare_epaper_common.dtsi
+++ b/boards/shields/waveshare_epaper/dts/waveshare_epaper_common.dtsi
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>,	/* D10 */
-		   <&arduino_header 12 GPIO_ACTIVE_LOW>;	/* D04 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>,
+		   <&arduino_header ARDUINO_HEADER_R3_D4 GPIO_ACTIVE_LOW>;
 
 	waveshare_epaper_sdhc: sdhc@1 {
 		compatible = "zephyr,sdhc-spi-slot";

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
@@ -5,6 +5,7 @@
  */
 
 #include "waveshare_epaper_common.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -14,8 +15,8 @@
 	mipi_dbi_waveshare_epaper_gdeh0154a07 {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -25,7 +26,7 @@
 			reg = <0>;
 			width = <200>;
 			height = <200>;
-			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
+			busy-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
 
 			tssv = <0x80>;
 

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
@@ -5,6 +5,7 @@
  */
 
 #include "waveshare_epaper_common.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -14,8 +15,8 @@
 	mipi_dbi_waveshare_epaper_gdeh0213b1 {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -25,7 +26,7 @@
 			reg = <0>;
 			width = <250>;
 			height = <120>;
-			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
+			busy-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
 
 			full {
 				gdv = [10 0a];

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
@@ -5,6 +5,7 @@
  */
 
 #include "waveshare_epaper_common.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -14,8 +15,8 @@
 	mipi_dbi_waveshare_epaper_gdeh0213b72 {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -25,7 +26,7 @@
 			reg = <0>;
 			width = <250>;
 			height = <120>;
-			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
+			busy-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
 
 			full {
 				gdv = [15];

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
@@ -5,6 +5,7 @@
  */
 
 #include "waveshare_epaper_common.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -14,8 +15,8 @@
 	mipi_dbi_waveshare_epaper_gdeh029a1 {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -25,7 +26,7 @@
 			reg = <0>;
 			width = <296>;
 			height = <128>;
-			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
+			busy-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
 
 			softstart = [d7 d6 9d];
 

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2-p.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2-p.overlay
@@ -5,6 +5,7 @@
  */
 
 #include "waveshare_epaper_common.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -14,8 +15,8 @@
 	mipi_dbi_waveshare_epaper_gdew042t2-p {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW
 		write-only;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -30,7 +31,7 @@
 			reg = <0>;
 			width = <400>;
 			height = <300>;
-			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>; /* D7 */
+			busy-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>;
 
 			softstart = [ 17 17 17 ];
 

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2.overlay
@@ -4,6 +4,7 @@
  */
 
 #include "waveshare_epaper_common.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -13,8 +14,8 @@
 	mipi_dbi_waveshare_epaper_gdew042t2 {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		write-only;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -25,7 +26,7 @@
 			reg = <0>;
 			width = <400>;
 			height = <300>;
-			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>; /* D7 */
+			busy-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>;
 
 			softstart = [17 17 17];
 

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
@@ -5,6 +5,7 @@
  */
 
 #include "waveshare_epaper_common.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -14,8 +15,8 @@
 	mipi_dbi_waveshare_epaper_gdew075t7 {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		write-only;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -26,7 +27,7 @@
 			reg = <0>;
 			width = <800>;
 			height = <480>;
-			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>; /* D7 */
+			busy-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>;
 
 			softstart = [17 17 17 17];
 

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdey0213b74.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdey0213b74.overlay
@@ -5,6 +5,7 @@
  */
 
 #include "waveshare_epaper_common.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	chosen {
@@ -14,8 +15,8 @@
 	mipi_dbi_waveshare_epaper_gdey0213b74 {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -25,7 +26,7 @@
 			reg = <0>;
 			width = <250>;
 			height = <122>;
-			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
+			busy-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
 
 			tssv = <0x80>;
 

--- a/boards/shields/wnc_m14a2a/boards/frdm_k64f.overlay
+++ b/boards/shields/wnc_m14a2a/boards/frdm_k64f.overlay
@@ -8,6 +8,9 @@
  * WNC-M14A2A shield uses an odd UART available on *some* Arduino-R3-compatible
  * headers.  It needs to be defined individually.
  */
+
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &uart2 {
 	current-speed = <115200>;
 	hw-flow-control;
@@ -16,10 +19,10 @@
 	wnc_m14a2a: wncm14a2a {
 		status = "okay";
 		compatible = "wnc,m14a2a";
-		mdm-boot-mode-sel-gpios = <&arduino_header 7 GPIO_ACTIVE_HIGH>;   /* D1 */
-		mdm-power-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;	          /* D2 */
-		mdm-keep-awake-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;	  /* D6 */
-		mdm-reset-gpios = <&arduino_header 14 GPIO_ACTIVE_HIGH>;	  /* D8 */
-		mdm-shld-trans-ena-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>; /* D9 */
+		mdm-boot-mode-sel-gpios = <&arduino_header ARDUINO_HEADER_R3_D1 GPIO_ACTIVE_HIGH>;
+		mdm-power-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_LOW>;
+		mdm-keep-awake-gpios = <&arduino_header ARDUINO_HEADER_R3_D6 GPIO_ACTIVE_HIGH>;
+		mdm-reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_HIGH>;
+		mdm-shld-trans-ena-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/shields/wnc_m14a2a/boards/nrf52840dk_nrf52840.overlay
+++ b/boards/shields/wnc_m14a2a/boards/nrf52840dk_nrf52840.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &pinctrl {
 	uart1_default_alt: uart1_default_alt {
 		group1 {
@@ -41,10 +43,10 @@
 	wnc_m14a2a: wncm14a2a {
 		status = "okay";
 		compatible = "wnc,m14a2a";
-		mdm-boot-mode-sel-gpios = <&arduino_header 7 GPIO_ACTIVE_HIGH>;   /* D1 */
-		mdm-power-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;	          /* D2 */
-		mdm-keep-awake-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;	  /* D6 */
-		mdm-reset-gpios = <&arduino_header 14 GPIO_ACTIVE_HIGH>;	  /* D8 */
-		mdm-shld-trans-ena-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>; /* D9 */
+		mdm-boot-mode-sel-gpios = <&arduino_header ARDUINO_HEADER_R3_D1 GPIO_ACTIVE_HIGH>;
+		mdm-power-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_LOW>;
+		mdm-keep-awake-gpios = <&arduino_header ARDUINO_HEADER_R3_D6 GPIO_ACTIVE_HIGH>;
+		mdm-reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_HIGH>;
+		mdm-shld-trans-ena-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/shields/x_nucleo_bnrg2a1/x_nucleo_bnrg2a1.overlay
+++ b/boards/shields/x_nucleo_bnrg2a1/x_nucleo_bnrg2a1.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	 chosen {
 		 zephyr,bt-hci = &hci_spi;
@@ -11,13 +13,14 @@
  };
 
 &arduino_spi {
-	cs-gpios = <&arduino_header 1 GPIO_ACTIVE_LOW>;	/* A1 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_A1 GPIO_ACTIVE_LOW>;
 
 	hci_spi: bluenrg-2@0 {
 		compatible = "st,hci-spi-v2";
 		reg = <0>;
-		reset-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>;  /* D7 */
-		irq-gpios = <&arduino_header 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;  /* A0 */
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>;
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_A0
+			    (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		spi-cpha; /* CPHA=1 */
 		spi-hold-cs;
 		spi-max-frequency = <DT_FREQ_M(1)>;

--- a/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
+++ b/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
@@ -6,6 +6,7 @@
 
 #include <freq.h>
 #include <mem.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	aliases {
@@ -28,7 +29,7 @@
 		timeout = <5>;
 
 		/* if solder-bridge closed: arduino A1 pin on CN8 can wp */
-		/* wp-gpios = <&arduino_header 1 GPIO_ACTIVE_LOW>; */
+		/* wp-gpios = <&arduino_header ARDUINO_HEADER_R3_A1 GPIO_ACTIVE_LOW>; */
 	};
 
 	eeprom1_x_nucleo_eeprma2: eeprom@55 {
@@ -41,7 +42,7 @@
 		timeout = <5>;
 
 		/* if solder-bridge closed: arduino A1 pin on CN8 can wp */
-		/* wp-gpios = <&arduino_header 1 GPIO_ACTIVE_LOW>; */
+		/* wp-gpios = <&arduino_header ARDUINO_HEADER_R3_A1 GPIO_ACTIVE_LOW>; */
 	};
 
 	eeprom2_x_nucleo_eeprma2: eeprom@56 {
@@ -54,7 +55,7 @@
 		timeout = <5>;
 
 		/* if solder-bridge closed: arduino A1 pin on CN8 can wp */
-		/* wp-gpios = <&arduino_header 1 GPIO_ACTIVE_LOW>; */
+		/* wp-gpios = <&arduino_header ARDUINO_HEADER_R3_A1 GPIO_ACTIVE_LOW>; */
 	};
 
 	/* U4: unpopulated SO8N footprint for any I2C M24 EEPROM */
@@ -62,9 +63,9 @@
 
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header  8 GPIO_ACTIVE_LOW>, /* U5: eeprom4 */
-		   <&arduino_header 15 GPIO_ACTIVE_LOW>, /* U6: eeprom5 */
-		   <&arduino_header 16 GPIO_ACTIVE_LOW>; /* U7: eeprom6 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D2 GPIO_ACTIVE_LOW>, /* U5: eeprom4 */
+		   <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>, /* U6: eeprom5 */
+		   <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>; /* U7: eeprom6 */
 
 	/*
 	 * All chip select pins have an on board 10k pull-up resistor to VCC,
@@ -91,7 +92,7 @@
 		timeout = <5>;
 
 		/* if solder-bridge closed: arduino A0 pin on CN8 can wp */
-		/* wp-gpios = <&arduino_header 0 GPIO_ACTIVE_LOW>; */
+		/* wp-gpios = <&arduino_header ARDUINO_HEADER_R3_A0 GPIO_ACTIVE_LOW>; */
 	};
 
 	eeprom5_x_nucleo_eeprma2: eeprom_m95256@1 {
@@ -105,7 +106,7 @@
 		timeout = <5>;
 
 		/* if solder-bridge closed: arduino A0 pin on CN8 can wp */
-		/* wp-gpios = <&arduino_header 0 GPIO_ACTIVE_LOW>; */
+		/* wp-gpios = <&arduino_header ARDUINO_HEADER_R3_A0 GPIO_ACTIVE_LOW>; */
 	};
 
 	eeprom6_x_nucleo_eeprma2: eeprom_m95m04@2 {
@@ -120,7 +121,7 @@
 		timeout = <5>;
 
 		/* if solder-bridge closed: arduino A0 pin on CN8 can wp */
-		/* wp-gpios = <&arduino_header 0 GPIO_ACTIVE_LOW>; */
+		/* wp-gpios = <&arduino_header ARDUINO_HEADER_R3_A0 GPIO_ACTIVE_LOW>; */
 	};
 
 	/* U8: unpopulated SO8N footprint for any M95 SPI EEPROM */

--- a/boards/shields/x_nucleo_idb05a1/boards/stm32mp157c_dk2.overlay
+++ b/boards/shields/x_nucleo_idb05a1/boards/stm32mp157c_dk2.overlay
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_spi {
 	spbtle_rf_x_nucleo_idb05a1: spbtle-rf@0 {
-		cs-gpios = <&arduino_header 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;	      /* D10 */
-		irq-gpios = <&arduino_header 15 0>;	 /* D9 */
+		cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10
+			    (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 0>;
 	};
 };

--- a/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
+++ b/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	 chosen {
 		 zephyr,bt-hci = &spbtle_rf_x_nucleo_idb05a1;
@@ -11,13 +13,14 @@
  };
 
 &arduino_spi {
-	cs-gpios = <&arduino_header 1 GPIO_ACTIVE_LOW>;	      /* A1 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_A1 GPIO_ACTIVE_LOW>;
 
 	spbtle_rf_x_nucleo_idb05a1: spbtle-rf@0 {
 		compatible = "st,hci-spi-v1";
 		reg = <0>;
-		reset-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>; /* D7 */
-		irq-gpios = <&arduino_header 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;  /* A0 */
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>;
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_A0
+			     (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		spi-max-frequency = <DT_FREQ_M(2)>;
 		spi-hold-cs;
 	};

--- a/boards/shields/x_nucleo_iks01a1/x_nucleo_iks01a1.overlay
+++ b/boards/shields/x_nucleo_iks01a1/x_nucleo_iks01a1.overlay
@@ -4,6 +4,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		accel0 = &lsm6ds0_x_nucleo_iks01a1;
@@ -25,7 +28,7 @@
 	lis3mdl_magn_x_nucleo_iks01a1: lis3mdl-magn@1e {
 		compatible = "st,lis3mdl-magn";
 		reg = <0x1e>;
-		irq-gpios = <&arduino_header 5 GPIO_ACTIVE_HIGH>; /* DRDY on A5 */
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_A5 GPIO_ACTIVE_HIGH>;
 	};
 
 	lsm6ds0_x_nucleo_iks01a1: lsm6ds0@6b {

--- a/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
+++ b/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		magn0 = &lsm303agr_magn_1e_x_nucleo_iks01a2;
@@ -28,18 +30,18 @@
 	lsm6dsl_6b_x_nucleo_iks01a2: lsm6dsl@6b {
 		compatible = "st,lsm6dsl";
 		reg = <0x6b>;
-		irq-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;	/* D4 */
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_D4 GPIO_ACTIVE_HIGH
 	};
 
 	lsm303agr_magn_1e_x_nucleo_iks01a2: lsm303agr-magn@1e {
 		compatible = "st,lis2mdl","st,lsm303agr-magn";
 		reg = <0x1e>;
-		irq-gpios = <&arduino_header 3 GPIO_ACTIVE_HIGH>;	/* A3 */
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_A3 GPIO_ACTIVE_HIGH>;
 	};
 
 	lsm303agr_accel_19_x_nucleo_iks01a2: lsm303agr-accel@19 {
 		compatible = "st,lis2dh", "st,lsm303agr-accel";
 		reg = <0x19>;
-		irq-gpios = <&arduino_header 3 GPIO_ACTIVE_HIGH>;	/* A3 */
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_A3 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2_shub.overlay
+++ b/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2_shub.overlay
@@ -5,10 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 &arduino_i2c {
 	lsm6dsl_x_nucleo_iks01a2_shub: lsm6dsl@6b {
 		compatible = "st,lsm6dsl";
 		reg = <0x6b>;
-		irq-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;	/* D4 */
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_D4 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3.overlay
+++ b/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	aliases {
@@ -24,31 +25,31 @@
 	lps22hh_x_nucleo_iks01a3: lps22hh@5d {
 		compatible = "st,lps22hh";
 		reg = <0x5d>;
-		drdy-gpios =  <&arduino_header 12 GPIO_ACTIVE_HIGH>; /* D6 */
+		drdy-gpios =  <&arduino_header ARDUINO_HEADER_R3_D6 GPIO_ACTIVE_HIGH>;
 	};
 
 	stts751_x_nucleo_iks01a3: stts751@4a {
 		compatible = "st,stts751";
 		reg = <0x4a>;
-		drdy-gpios =  <&arduino_header 4 GPIO_ACTIVE_LOW>; /* A4 */
+		drdy-gpios =  <&arduino_header ARDUINO_HEADER_R3_A4 GPIO_ACTIVE_LOW>;
 	};
 
 	lis2mdl_1e_x_nucleo_iks01a3: lis2mdl@1e {
 		compatible = "st,lis2mdl";
 		reg = <0x1e>;
-		irq-gpios =  <&arduino_header 2 GPIO_ACTIVE_HIGH>; /* A2 */
+		irq-gpios =  <&arduino_header ARDUINO_HEADER_R3_A2 GPIO_ACTIVE_HIGH>;
 	};
 
 	lis2dw12_19_x_nucleo_iks01a3: lis2dw12@19 {
 		compatible = "st,lis2dw12";
 		reg = <0x19>;
-		irq-gpios =  <&arduino_header 3 GPIO_ACTIVE_HIGH>; /* A3 */
+		irq-gpios =  <&arduino_header ARDUINO_HEADER_R3_A3 GPIO_ACTIVE_HIGH>;
 	};
 
 	lsm6dso_6b_x_nucleo_iks01a3: lsm6dso@6b {
 		compatible = "st,lsm6dso";
 		reg = <0x6b>;
-		irq-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 */
+		irq-gpios =  <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_HIGH>;
 		int-pin = <2>;
 	};
 };

--- a/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3_shub.overlay
+++ b/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3_shub.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		accel0 = &lis2dw12_19_x_nucleo_iks01a3_shub;
@@ -16,13 +18,13 @@
 	lis2dw12_19_x_nucleo_iks01a3_shub: lis2dw12@19 {
 		compatible = "st,lis2dw12";
 		reg = <0x19>;
-		irq-gpios =  <&arduino_header 3 GPIO_ACTIVE_HIGH>; /* A3 */
+		irq-gpios =  <&arduino_header ARDUINO_HEADER_R3_A3 GPIO_ACTIVE_HIGH>;
 	};
 
 	lsm6dso_6b_x_nucleo_iks01a3_shub: lsm6dso@6b {
 		compatible = "st,lsm6dso";
 		reg = <0x6b>;
-		irq-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 */
+		irq-gpios =  <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_HIGH>;
 		int-pin = <2>;
 	};
 };

--- a/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1.overlay
+++ b/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1.overlay
@@ -13,6 +13,8 @@
  * ISM330DHCX, IIS2MDC and IIS2DLPC sensors are accessible from the main board mcu.
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		accel0 = &iis2dlpc_19_x_nucleo_iks02a1;
@@ -25,20 +27,20 @@
 	iis2dlpc_19_x_nucleo_iks02a1: iis2dlpc@19 {
 		compatible = "st,iis2dlpc";
 		reg = <0x19>;
-		drdy-gpios =  <&arduino_header 4 GPIO_ACTIVE_HIGH>; /* A4 - INT2 */
+		drdy-gpios =  <&arduino_header ARDUINO_HEADER_R3_A4 GPIO_ACTIVE_HIGH>;
 		drdy-int =  <2>;
 	};
 
 	iis2mdc_x_nucleo_iks02a1: iis2mdc@1e {
 		compatible = "st,iis2mdc";
 		reg = <0x1e>;
-		drdy-gpios =  <&arduino_header 2 GPIO_ACTIVE_HIGH>; /* A2 */
+		drdy-gpios =  <&arduino_header ARDUINO_HEADER_R3_A2 GPIO_ACTIVE_HIGH>;
 	};
 
 	ism330dhcx_6b_x_nucleo_iks02a1: ism330dhcx@6b {
 		compatible = "st,ism330dhcx";
 		reg = <0x6b>;
-		drdy-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 - INT2 */
+		drdy-gpios =  <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_HIGH>;
 		int-pin = <2>;
 	};
 };

--- a/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1_shub.overlay
+++ b/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1_shub.overlay
@@ -15,6 +15,8 @@
  * declared in DTS file.
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		accel0 = &iis2dlpc_19_x_nucleo_iks02a1_shub;
@@ -27,14 +29,14 @@
 	iis2dlpc_19_x_nucleo_iks02a1_shub: iis2dlpc@19 {
 		compatible = "st,iis2dlpc";
 		reg = <0x19>;
-		drdy-gpios =  <&arduino_header 4 GPIO_ACTIVE_HIGH>; /* A4 - INT2 */
+		drdy-gpios =  <&arduino_header ARDUINO_HEADER_R3_A4 GPIO_ACTIVE_HIGH>;
 		drdy-int =  <2>;
 	};
 
 	ism330dhcx_6b_x_nucleo_iks02a1_shub: ism330dhcx@6b {
 		compatible = "st,ism330dhcx";
 		reg = <0x6b>;
-		drdy-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 - INT2 */
+		drdy-gpios =  <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_HIGH>;
 		int-pin = <2>;
 	};
 };

--- a/boards/shields/x_nucleo_iks4a1/x_nucleo_iks4a1.overlay
+++ b/boards/shields/x_nucleo_iks4a1/x_nucleo_iks4a1.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		magn0 = &lis2mdl_1e_x_nucleo_iks4a1;
@@ -20,7 +22,7 @@
 		reg = <0x6a>;
 		accel-odr = <0x1b>;
 		gyro-odr = <0x11>;
-		irq-gpios =  <&arduino_header 5 GPIO_ACTIVE_HIGH>; /* A5 (PC0) */
+		irq-gpios =  <&arduino_header ARDUINO_HEADER_R3_A5 GPIO_ACTIVE_HIGH>;
 		drdy-pin = <1>;
 	};
 
@@ -29,7 +31,7 @@
 		reg = <0x6b>;
 		accel-odr = <0x02>;
 		gyro-odr = <0x02>;
-		int2-gpios =  <&arduino_header 10 GPIO_ACTIVE_HIGH>; /* D4 (PB5) */
+		int2-gpios =  <&arduino_header ARDUINO_HEADER_R3_D4 GPIO_ACTIVE_HIGH>;
 		drdy-pin = <2>;
 		drdy-pulsed;
 	};
@@ -37,20 +39,20 @@
 	lis2mdl_1e_x_nucleo_iks4a1: lis2mdl@1e {
 		compatible = "st,lis2mdl";
 		reg = <0x1e>;
-		irq-gpios =  <&arduino_header 2 GPIO_ACTIVE_HIGH>; /* A2 (PA4) */
+		irq-gpios =  <&arduino_header ARDUINO_HEADER_R3_A2 GPIO_ACTIVE_HIGH>;
 	};
 
 	lps22df_5d_x_nucleo_iks4a1: lps22df@5d {
 		compatible = "st,lps22df";
 		reg = <0x5d>;
 		drdy-pulsed;
-		drdy-gpios =  <&arduino_header 12 GPIO_ACTIVE_HIGH>; /* D6 (PB10) */
+		drdy-gpios =  <&arduino_header ARDUINO_HEADER_R3_D6 GPIO_ACTIVE_HIGH>;
 	};
 
 	lis2duxs12_1e_x_nucleo_iks4a1: lis2duxs12@19 {
 		compatible = "st,lis2duxs12";
 		reg = <0x19>;
-		int1-gpios =  <&arduino_header 3 GPIO_ACTIVE_HIGH>; /* A3 */
+		int1-gpios =  <&arduino_header ARDUINO_HEADER_R3_A3 GPIO_ACTIVE_HIGH>;
 	};
 
 };

--- a/boards/shields/x_nucleo_iks4a1/x_nucleo_iks4a1_shub1.overlay
+++ b/boards/shields/x_nucleo_iks4a1/x_nucleo_iks4a1_shub1.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		accel0 = &lsm6dsv16x_6b_x_nucleo_iks4a1;
@@ -16,7 +18,7 @@
 		reg = <0x6b>;
 		accel-odr = <0x02>;
 		gyro-odr = <0x02>;
-		int1-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 */
+		int1-gpios =  <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_HIGH>;
 		drdy-pin = <1>;
 	};
 };

--- a/boards/shields/x_nucleo_iks4a1/x_nucleo_iks4a1_shub2.overlay
+++ b/boards/shields/x_nucleo_iks4a1/x_nucleo_iks4a1_shub2.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	aliases {
 		accel0 = &lsm6dso16is_6a_x_nucleo_iks4a1_shub;
@@ -14,7 +16,7 @@
 	lsm6dso16is_6a_x_nucleo_iks4a1_shub: lsm6dso16is@6a {
 		compatible = "st,lsm6dso16is";
 		reg = <0x6a>;
-		irq-gpios =  <&arduino_header 5 GPIO_ACTIVE_HIGH>; /* A5 */
+		irq-gpios =  <&arduino_header ARDUINO_HEADER_R3_A5 GPIO_ACTIVE_HIGH>;
 		drdy-pin = <1>;
 	};
 };

--- a/boards/shields/x_nucleo_wb05kn1/x_nucleo_wb05kn1_spi.overlay
+++ b/boards/shields/x_nucleo_wb05kn1/x_nucleo_wb05kn1_spi.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	 chosen {
 		 zephyr,bt-hci = &hci_spi;
@@ -11,13 +13,14 @@
 };
 
 &arduino_spi {
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	      /* D10 */
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 
 	hci_spi: wb05n@0 {
 		compatible = "st,hci-spi-v2";
 		reg = <0>;
-		reset-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>; /* D7 */
-		irq-gpios = <&arduino_header 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;  /* A0 */
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>;
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_A0
+			     (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		spi-cpol; /* CPOL=1 */
 		spi-cpha; /* CPHA=1 */
 		spi-hold-cs;

--- a/dts/bindings/gpio/arduino-header-r3.yaml
+++ b/dts/bindings/gpio/arduino-header-r3.yaml
@@ -44,6 +44,8 @@ description: |
         4 A4                     D1    7
         5 A5                     D0    6
 
+    Use ARDUINO_HEADER_R3_* constants in <zephyr/dt-bindings/gpio/arduino-header-r3.h> to refer to
+    specific pins using convenient constant names.
 
 compatible: "arduino-header-r3"
 

--- a/include/zephyr/devicetree/gpio.h
+++ b/include/zephyr/devicetree/gpio.h
@@ -22,6 +22,11 @@ extern "C" {
  * @ingroup devicetree
  * @ingroup gpio_interface
  * @{
+ *
+ * @defgroup devicetree-gpio-pin-headers GPIO pin headers
+ * @brief Constants for pins exposed on common GPIO pin headers
+ * @{
+ * @}
  */
 
 /**

--- a/include/zephyr/dt-bindings/gpio/arduino-header-r3.h
+++ b/include/zephyr/dt-bindings/gpio/arduino-header-r3.h
@@ -1,33 +1,48 @@
-/**
+/*
  * Copyright (c) 2025 TOKITA Hiroshi
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Arduino Uno (R3) header pin constants
+ * @ingroup arduino-header-r3
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ARDUINO_HEADER_R3_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ARDUINO_HEADER_R3_H_
 
-#define ARDUINO_HEADER_R3_A0  0
-#define ARDUINO_HEADER_R3_A1  1
-#define ARDUINO_HEADER_R3_A2  2
-#define ARDUINO_HEADER_R3_A3  3
-#define ARDUINO_HEADER_R3_A4  4
-#define ARDUINO_HEADER_R3_A5  5
-#define ARDUINO_HEADER_R3_D0  6
-#define ARDUINO_HEADER_R3_D1  7
-#define ARDUINO_HEADER_R3_D2  8
-#define ARDUINO_HEADER_R3_D3  9
-#define ARDUINO_HEADER_R3_D4  10
-#define ARDUINO_HEADER_R3_D5  11
-#define ARDUINO_HEADER_R3_D6  12
-#define ARDUINO_HEADER_R3_D7  13
-#define ARDUINO_HEADER_R3_D8  14
-#define ARDUINO_HEADER_R3_D9  15
-#define ARDUINO_HEADER_R3_D10 16
-#define ARDUINO_HEADER_R3_D11 17
-#define ARDUINO_HEADER_R3_D12 18
-#define ARDUINO_HEADER_R3_D13 19
-#define ARDUINO_HEADER_R3_D14 20
-#define ARDUINO_HEADER_R3_D15 21
+/**
+ * @defgroup arduino-header-r3 Arduino Uno (R3) header
+ * @brief Constants for pins exposed on Arduino Uno (R3) header
+ * @ingroup devicetree-gpio-pin-headers
+ * @{
+ */
+
+#define ARDUINO_HEADER_R3_A0  0  /**< Analog pin 0 (A0) */
+#define ARDUINO_HEADER_R3_A1  1  /**< Analog pin 1 (A1) */
+#define ARDUINO_HEADER_R3_A2  2  /**< Analog pin 2 (A2) */
+#define ARDUINO_HEADER_R3_A3  3  /**< Analog pin 3 (A3) */
+#define ARDUINO_HEADER_R3_A4  4  /**< Analog pin 4 (A4) */
+#define ARDUINO_HEADER_R3_A5  5  /**< Analog pin 5 (A5) */
+#define ARDUINO_HEADER_R3_D0  6  /**< Digital pin 0 (D0) */
+#define ARDUINO_HEADER_R3_D1  7  /**< Digital pin 1 (D1) */
+#define ARDUINO_HEADER_R3_D2  8  /**< Digital pin 2 (D2) */
+#define ARDUINO_HEADER_R3_D3  9  /**< Digital pin 3 (D3) */
+#define ARDUINO_HEADER_R3_D4  10 /**< Digital pin 4 (D4) */
+#define ARDUINO_HEADER_R3_D5  11 /**< Digital pin 5 (D5) */
+#define ARDUINO_HEADER_R3_D6  12 /**< Digital pin 6 (D6) */
+#define ARDUINO_HEADER_R3_D7  13 /**< Digital pin 7 (D7) */
+#define ARDUINO_HEADER_R3_D8  14 /**< Digital pin 8 (D8) */
+#define ARDUINO_HEADER_R3_D9  15 /**< Digital pin 9 (D9) */
+#define ARDUINO_HEADER_R3_D10 16 /**< Digital pin 10 (D10) */
+#define ARDUINO_HEADER_R3_D11 17 /**< Digital pin 11 (D11) */
+#define ARDUINO_HEADER_R3_D12 18 /**< Digital pin 12 (D12) */
+#define ARDUINO_HEADER_R3_D13 19 /**< Digital pin 13 (D13) */
+#define ARDUINO_HEADER_R3_D14 20 /**< Digital pin 14 (D14) */
+#define ARDUINO_HEADER_R3_D15 21 /**< Digital pin 15 (D15) */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ARDUINO_HEADER_R3_H_ */


### PR DESCRIPTION
Make shield overlays less error prone and easier to maintain by switching to GPIO pin constants defined in arduino-header-r3.h.

Also start adding Doxygen docs for documenting available constants for common pin headers (see https://builds.zephyrproject.io/zephyr/pr/95320/docs/doxygen/html/group__devicetree-gpio-pin-headers.html)