### PR TITLE
boards: pocketbeagle_2: a53: Use RAM from 0x80200000

### DIFF
--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am62_a53-common.dtsi
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am62_a53-common.dtsi
@@ -13,7 +13,7 @@
 	chosen {
 		zephyr,console = &uart6;
 		zephyr,shell-uart = &uart6;
-		zephyr,sram = &ddr0;
+		zephyr,sram = &a53_ddr_section;
 	};
 
 	aliases {
@@ -21,7 +21,20 @@
 	};
 
 	ddr0: memory@80000000 {
+		device_type = "memory";
 		reg = <0x80000000 DT_SIZE_M(512)>;
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+
+		/* Loading and starting code at RAM start will cause any calls to
+		 * Arm Trusted Firmware-A (TFA) to fail. This is because as described
+		 * in the docs [0], the first 2MiB is reserved for TFA.
+		 *
+		 * [0]: https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/latest/exports/docs/api_guide_am62x/MEMORY_MAP.html
+		 */
+		a53_ddr_section: memory@80200000 {
+			reg = <0x80200000 DT_SIZE_M(512 - 2)>;
+		};
 	};
 
 	leds: leds {


### PR DESCRIPTION
First 2MiB is reserved for Arm Trusted Firmware-A according the TI docs [0].

An update bb-zephyr-image [1] provides a custom boot script for u-boot which allows the old instructions to work (as opposed to having to load and execute the binary manually).

Tested using tests/arch/arm64/arm64_smc_call.

[0]: https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/latest/exports/docs/api_guide_am62x/MEMORY_MAP.html
[1]: https://github.com/beagleboard/bb-zephyr-images/pull/2