### PR TITLE
drivers: nxp: flash_mcux_flexspi: fix id check on octal spi

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -185,12 +185,14 @@ static int flash_flexspi_nor_read_id_helper(struct flash_flexspi_nor_data *data,
 	return ret;
 }
 
+#if defined(CONFIG_FLASH_JESD216_API)
 static int flash_flexspi_nor_read_jedec_id(const struct device *dev, uint8_t *vendor_id)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
 
 	return flash_flexspi_nor_read_id_helper(data, vendor_id);
 }
+#endif
 
 static int flash_flexspi_nor_read_status(struct flash_flexspi_nor_data *data,
 		uint32_t *status)
@@ -1090,6 +1092,19 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 		return ret;
 	}
 
+	LOG_DBG("Jedec id: %02x %02x %02x", vendor_id & 0xff, (vendor_id>>8) & 0xff,
+		(vendor_id>>16) & 0xff);
+
+	if (data->jedec_id[0]) {
+		/* Check the JEDEC ID against the one from devicetree. */
+		if (memcmp((uint8_t *)&vendor_id, data->jedec_id, sizeof(data->jedec_id)) != 0) {
+			LOG_ERR("Jedec id %02x %02x %02x does not match devicetree %02x %02x %02x",
+				vendor_id & 0xff, (vendor_id>>8) & 0xff, (vendor_id>>16) & 0xff,
+				data->jedec_id[0], data->jedec_id[1], data->jedec_id[2]);
+			return -EINVAL;
+		}
+	}
+
 	/* Switch on manufacturer and vendor ID */
 	switch (vendor_id & 0xFFFFFF) {
 	case 0x16609d: /* IS25LP032 */
@@ -1457,7 +1472,6 @@ static int flash_flexspi_nor_init(const struct device *dev)
 {
 	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
-	uint8_t jedec_id[JESD216_READ_ID_LEN];
 
 	/* First step- use ROM pointer to controller device to create
 	 * a copy of the device structure in RAM we can use while in
@@ -1493,22 +1507,6 @@ static int flash_flexspi_nor_init(const struct device *dev)
 
 
 	memc_flexspi_reset(&data->controller);
-
-	if (flash_flexspi_nor_read_jedec_id(dev, jedec_id)) {
-		LOG_ERR("Could not read jedec id");
-		return -EIO;
-	}
-	LOG_DBG("Jedec id: %02x %02x %02x", jedec_id[0], jedec_id[1], jedec_id[2]);
-
-	if (data->jedec_id[0]) {
-		/* Check the JEDEC ID against the one from devicetree. */
-		if (memcmp(jedec_id, data->jedec_id, sizeof(jedec_id)) != 0) {
-			LOG_ERR("Jedec id %02x %02x %02x does not match devicetree %02x %02x %02x",
-				jedec_id[0], jedec_id[1], jedec_id[2],
-				data->jedec_id[0], data->jedec_id[1], data->jedec_id[2]);
-			return -EINVAL;
-		}
-	}
 
 	return 0;
 }


### PR DESCRIPTION
The jedec-id cannot be read after flash device is set to octal mode. This problem happens with the mt35xu01gbba on the imx95-evk. The driver won't init because of this.

Fixed by moving the jedec-id comparison to flash_flexspi_nor_check_jedec() which already reads the jedec-id when flash device is still in single spi mode.