### PR TITLE
arch: arm: cortex_r: define MPU RASR size for ROM

### DIFF
--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -238,8 +238,9 @@ SECTIONS
 
     __rodata_region_end = .;
     __rom_region_end = .;
-    MPU_ALIGN(__rodata_region_end - __rom_region_start);
-    _image_rom_end_order = (LOG2CEIL(__rom_region_end) - 1) << 1;
+    __rom_region_size = __rom_region_end - __rom_region_start;
+    MPU_ALIGN(__rom_region_size);
+    _image_rom_mpu_rasr_size = (LOG2CEIL(__rom_region_size) - 1) << 1;
 
     GROUP_END(ROMABLE_REGION)
 

--- a/soc/renesas/rz/rzv2h/cr8/arm_mpu_regions.c
+++ b/soc/renesas/rz/rzv2h/cr8/arm_mpu_regions.c
@@ -44,7 +44,7 @@
 
 /* clang-format on */
 
-extern uint32_t _image_rom_end_order;
+extern uint32_t _image_rom_mpu_rasr_size;
 static const struct arm_mpu_region mpu_regions[] = {
 
 	/* clang-format off */
@@ -56,7 +56,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 
 	MPU_REGION_ENTRY("SRAM",
 			0x00000000,
-			((uint32_t)&_image_rom_end_order),
+			((uint32_t)&_image_rom_mpu_rasr_size),
 			MPUTYPE_READ_ONLY_PRIV),
 
 	MPU_REGION_ENTRY("REGISTERS",

--- a/soc/renode/cortex_r8_virtual/arm_mpu_regions.c
+++ b/soc/renode/cortex_r8_virtual/arm_mpu_regions.c
@@ -37,7 +37,7 @@
 				| (2 << MPU_RASR_TEX_Pos)) \
 	}
 
-extern uint32_t _image_rom_end_order;
+extern uint32_t _image_rom_mpu_rasr_size;
 static const struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("FLASH0",
 			0xc0000000,
@@ -51,7 +51,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 
 	MPU_REGION_ENTRY("SRAM",
 			0x00000000,
-			((uint32_t)&_image_rom_end_order),
+			((uint32_t)&_image_rom_mpu_rasr_size),
 			MPUTYPE_READ_ONLY_PRIV),
 
 	MPU_REGION_ENTRY("REGISTERS",

--- a/soc/xlnx/zynqmp/arm_mpu_regions.c
+++ b/soc/xlnx/zynqmp/arm_mpu_regions.c
@@ -36,7 +36,7 @@
 				| (2 << MPU_RASR_TEX_Pos)) \
 	}
 
-extern uint32_t _image_rom_end_order;
+extern uint32_t _image_rom_mpu_rasr_size;
 static const struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("FLASH0",
 			0xc0000000,
@@ -50,7 +50,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 
 	MPU_REGION_ENTRY("SRAM",
 			0x00000000,
-			((uint32_t)&_image_rom_end_order),
+			((uint32_t)&_image_rom_mpu_rasr_size),
 			MPUTYPE_READ_ONLY_PRIV),
 
 	MPU_REGION_ENTRY("REGISTERS",


### PR DESCRIPTION
Userspace threads need unpriviliged read access to .text and .rodata, both of which reside in the ROM region. However, in non-XIP builds, data resides on the RAM, for which, unpriviliged access is turned off by default (check REGION_RAM_ATTR). For this, MPU must be configured and Cortex-R allows only sizes that are powers of 2.

To solve this problem, the symbol _image_rom_end_order was added, which take the end address of ROM section, gets the next highest power of 2, subtracts one (RASR size value is decremented), and does a single left shift (RASR size field position). This is then directly used in the compile time symbol mpu_config by several SoCs.

This works for these SOCs since their ROM start address is 0x0, making the end address and the size the same value. So we,

- Fix this by using the ROM size and not the end address for this value
- Also define __rom_region_size as it is one of the extern symbols in linker-defs.h
- Rename _image_rom_end_order to _image_rom_mpu_rasr_size which is more appropriate in all places including all SoC MPU configurations.