### PR TITLE
llvm: Get rid of warnings and add CMAKE_GDB

### DIFF
--- a/cmake/bintools/llvm/target.cmake
+++ b/cmake/bintools/llvm/target.cmake
@@ -32,5 +32,7 @@ find_program(CMAKE_READELF NAMES
                            readelf
                            ${find_program_binutils_args})
 
+find_program(CMAKE_GDB     gdb  PATHS ${find_program_binutils_args})
+
 # Use the gnu binutil abstraction
 include(${ZEPHYR_BASE}/cmake/bintools/llvm/target_bintools.cmake)

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -104,6 +104,11 @@ set_compiler_property(PROPERTY warning_error_coding_guideline
 # No printf-return-value optimizations in clang
 set_compiler_property(PROPERTY no_printf_return_value)
 
+# Clang does not support "-Wno-volatile"
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a "-std=c++2a" "-Wno-register")
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp20 "-std=c++20" "-Wno-register")
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b "-std=c++2b" "-Wno-register")
+
 ###################################################
 # This section covers all remaining C / C++ flags #
 ###################################################

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -3,33 +3,15 @@ include(${ZEPHYR_BASE}/cmake/compiler/gcc/compiler_flags.cmake)
 
 # Now, let's overwrite the flags that are different in clang.
 
-# No property flag, clang doesn't understand fortify at all
-set_compiler_property(PROPERTY security_fortify_compile_time)
-set_compiler_property(PROPERTY security_fortify_run_time)
+########################################################
+# Setting compiler properties for gcc / g++ compilers. #
+########################################################
+
+#####################################################
+# This section covers flags related to optimization #
+#####################################################
+
 set_compiler_property(PROPERTY optimization_fast -O3 -ffast-math)
-
-# No printf-return-value optimizations in clang
-set_compiler_property(PROPERTY no_printf_return_value)
-
-# No property flag, this is used by the POSIX arch based targets when building with the host libC,
-# But clang has problems compiling these with -fno-freestanding.
-check_set_compiler_property(PROPERTY hosted)
-
-# clang flags for coverage generation
-if (CONFIG_COVERAGE_NATIVE_SOURCE)
-  set_compiler_property(PROPERTY coverage -fprofile-instr-generate -fcoverage-mapping)
-else()
-  set_compiler_property(PROPERTY coverage --coverage -fno-inline)
-endif()
-
-# clang flag for colourful diagnostic messages
-set_compiler_property(PROPERTY diagnostic -fcolor-diagnostics)
-
-# clang flag to save temporary object files
-set_compiler_property(PROPERTY save_temps -save-temps)
-
-# clang doesn't handle the -T flag
-set_compiler_property(PROPERTY linker_script -Wl,-T)
 
 #######################################################
 # This section covers flags related to warning levels #
@@ -114,6 +96,41 @@ set_compiler_property(PROPERTY warning_error_coding_guideline
                       -Wconversion
                       -Woverride-init
 )
+
+###########################################################################
+# This section covers flags related to C or C++ standards / standard libs #
+###########################################################################
+
+# No printf-return-value optimizations in clang
+set_compiler_property(PROPERTY no_printf_return_value)
+
+###################################################
+# This section covers all remaining C / C++ flags #
+###################################################
+
+# clang flags for coverage generation
+if (CONFIG_COVERAGE_NATIVE_SOURCE)
+  set_compiler_property(PROPERTY coverage -fprofile-instr-generate -fcoverage-mapping)
+else()
+  set_compiler_property(PROPERTY coverage --coverage -fno-inline)
+endif()
+
+# No property flag, clang doesn't understand fortify at all
+set_compiler_property(PROPERTY security_fortify_compile_time)
+set_compiler_property(PROPERTY security_fortify_run_time)
+
+# No property flag, this is used by the POSIX arch based targets when building with the host libC,
+# But clang has problems compiling these with -fno-freestanding.
+check_set_compiler_property(PROPERTY hosted)
+
+# clang flag to save temporary object files
+set_compiler_property(PROPERTY save_temps -save-temps)
+
+# clang doesn't handle the -T flag
+set_compiler_property(PROPERTY linker_script -Wl,-T)
+
+# clang flag for colourful diagnostic messages
+set_compiler_property(PROPERTY diagnostic -fcolor-diagnostics)
 
 set_compiler_property(PROPERTY no_global_merge "-mno-global-merge")
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -805,7 +805,7 @@ struct _static_thread_data {
 				     _k_thread_stack_##name, stack_size,\
 				     entry, p1, p2, p3, prio, options,	\
 				     delay, name);			\
-	const k_tid_t name = (k_tid_t)&_k_thread_obj_##name
+	__maybe_unused const k_tid_t name = (k_tid_t)&_k_thread_obj_##name
 
 /**
  * INTERNAL_HIDDEN @endcond


### PR DESCRIPTION
* Reorganized clang/compiler_flags.cmake to match the order of gcc/compiler_flags.cmake
* Removed "-Wno-volatile" from clang flags as its not supported
* Exported CMAKE_GDB variable under target.cmake
* Added `__maybe_unused` to thread ID, as clang will otherwise genrate -Wunused-const-variable warnings