### PR TITLE
SCA: Add IAR C-STAT support

### DIFF
--- a/cmake/sca/iar_c_stat/sca.cmake
+++ b/cmake/sca/iar_c_stat/sca.cmake
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2025, IAR Systems AB.
+
+cmake_minimum_required(VERSION 4.1.0)
+
+include(extensions)
+include(west)
+
+# Get IAR C-STAT
+cmake_path(GET CMAKE_C_COMPILER PARENT_PATH IAR_COMPILER_DIR)
+find_program(IAR_CSTAT icstat
+  HINTS ${IAR_COMPILER_DIR}
+  REQUIRED
+)
+message(STATUS "Found SCA: IAR C-STAT Static Analysis (${IAR_CSTAT})")
+find_program(IAR_CHECKS ichecks
+  HINTS ${IAR_COMPILER_DIR}
+  REQUIRED
+)
+
+zephyr_get(CSTAT_RULESET)
+zephyr_get(CSTAT_ANALYZE_THREADS)
+zephyr_get(CSTAT_ANALYZE_OPTS)
+zephyr_get(CSTAT_DB)
+zephyr_get(CSTAT_CLEANUP)
+
+# Create an output directory for IAR C-STAT
+set(output_dir ${CMAKE_BINARY_DIR}/sca/iar_c_stat)
+file(MAKE_DIRECTORY ${output_dir})
+
+# Set the IAR C-STAT ruleset
+set(iar_checks_arg --output=${output_dir}/cstat_sel_checks.txt)
+if(CSTAT_RULESET MATCHES "^(cert|security|misrac2004|misrac\\+\\+2008|misrac2012)")
+  set(iar_checks_arg ${iar_checks_arg} --default=${CSTAT_RULESET})
+elseif(CSTAT_RULESET MATCHES "^all")
+  set(iar_checks_arg ${iar_checks_arg} --all)
+else()
+  set(iar_checks_arg ${iar_checks_arg} --default=stdchecks)
+endif()
+execute_process(COMMAND ${IAR_CHECKS} ${iar_checks_arg})
+
+# Forwards the ruleset manifest file to icstat
+set(output_arg --checks=${output_dir}/cstat_sel_checks.txt)
+
+# Analsys parallelization
+if(CSTAT_ANALYZE_THREADS)
+  set(output_arg ${output_arg};--parallel=${CSTAT_ANALYZE_THREADS})
+endif()
+
+# Entrypoint for additional C-STAT options
+if(CSTAT_ANALYZE_OPTS)
+  set(output_arg ${output_arg};${CSTAT_ANALYZE_OPTS})
+endif()
+
+# Full path to the C-STAT SQLite database
+if(CSTAT_DB)
+  set(CSTAT_DB_PATH ${CSTAT_DB})
+else()
+  set(CSTAT_DB_PATH ${output_dir}/cstat.db)
+endif()
+set(output_arg ${output_arg};--db=${CSTAT_DB_PATH})
+
+# Clean-up C-STAT SQLite database
+if(CSTAT_CLEANUP)
+  execute_process(COMMAND ${IAR_CSTAT} clear --db=${CSTAT_DB_PATH})
+endif()
+
+# Enable IAR C-STAT Static Analysis (requires CMake v4.1+)
+set(CMAKE_C_ICSTAT ${IAR_CSTAT};${output_arg} CACHE INTERNAL "")
+set(CMAKE_CXX_ICSTAT ${IAR_CSTAT};${output_arg} CACHE INTERNAL "")

--- a/doc/develop/sca/iar_c_stat.rst
+++ b/doc/develop/sca/iar_c_stat.rst
@@ -1,0 +1,60 @@
+.. _icstat:
+
+IAR C-STAT support
+##################
+
+`IAR C-STAT <https://iar.com/cstat>`__ is a comprehensive static analysis tool for
+C/C++ source code. It can find errors and vulnerabilities supporting a number of
+coding standards such as MISRA C, MISRA C++, CERT C/C++ and CWE.
+
+Installing IAR C-STAT
+*********************
+
+IAR C-STAT comes pre-installed with the IAR Build Tools and with the IAR Embedded
+Workbench. Refer to your respective product's documentation for details.
+
+Building with IAR C-STAT
+************************
+
+To run IAR C-STAT, you will need CMake 4.1.0 or later. When building with
+:ref:`west build <west-building>` append the additional parameter to select
+IAR C-STAT ``-DZEPHYR_SCA_VARIANT=iar_c_stat``, e.g.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: stm32f429ii_aca
+   :gen-args: -DZEPHYR_SCA_VARIANT=iar_c_stat
+   :goals: build
+   :compact:
+
+Configuring IAR C-STAT
+***********************
+
+The IAR C-STAT accepts parameters for customizing the analysis.
+The following table lists the supported options.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``CSTAT_RULESET``
+     - The pre-defined ruleset to be used. (default: ``stdchecks``, accepted values: ``all,cert,misrac2004,misrac2012,misrac++2008,stdchecks,security``)
+   * - ``CSTAT_ANALYZE_THREADS``
+     - The number of threads to use in analysis. (default: <CPU count>)
+   * - ``CSTAT_ANALYZE_OPTS``
+     - Arguments passed to the ``analyze`` command directly. (e.g. ``--timeout=900;--deterministic;--fpe``)
+   * - ``CSTAT_DB``
+     - Override the default location of the C-STAT SQLite database. (e.g. ``/home/user/cstat.db``)
+   * - ``CSTAT_CLEANUP``
+     - Perform a cleanup of the C-STAT SQLite database. (e.g. ``true``)
+
+These parameters can be passed on the command line, or be set as environment
+variables. Below you will find an example of how to enable and combine
+non-standard rulesets at will:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: stm32f429ii_aca
+   :gen-args: -DZEPHYR_SCA_VARIANT=iar_c_stat -DCSTAT_RULESET=misrac2012,cert
+   :goals: build


### PR DESCRIPTION
This PR adds IAR C-STAT support in the Zephyr [Static Code Analysis (SCA)](https://docs.zephyrproject.org/latest/develop/sca/index.html) framework.

Reference: [`<LANG>_ICSTAT`](https://cmake.org/cmake/help/latest/prop_tgt/LANG_ICSTAT.html)

CC: @danielfl-iar, @micaelbo, @RobinKastberg