### PR TITLE
boards: infineon: increase boostrap size for cyw920829

### DIFF
--- a/dts/arm/infineon/cat1b/cyw20829/cyw20829.dtsi
+++ b/dts/arm/infineon/cat1b/cyw20829/cyw20829.dtsi
@@ -7,7 +7,7 @@
 
 #include <mem.h>
 
-#define BOOTSTRAP_SIZE    DT_SIZE_K(12)
+#define BOOTSTRAP_SIZE    DT_SIZE_K(16)
 #define SRAM0_SIZE       (DT_SIZE_K(256) - BOOTSTRAP_SIZE)
 
 / {


### PR DESCRIPTION
Fix CI issues whereby arch.arm.swap.common.no_optimizations test is failing due to overlapping sections