### PR TITLE
STM32l562e_dk: Add missing label to storage_partition

### DIFF
--- a/boards/st/stm32l562e_dk/stm32l562e_dk.dts
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.dts
@@ -51,6 +51,7 @@
 
 		/* 2KB at the end of 512KB flash is set for storage */
 		storage_partition: partition@7f800 {
+			label = "storage";
 			reg = <0x0007f800 DT_SIZE_K(2)>;
 		};
 	};


### PR DESCRIPTION
This fixes a build error caused by the absence of a label.