### PR TITLE
boards: efm32gg11: Enable Si7210 Hall-effect sensor

### DIFF
--- a/boards/silabs/starter_kits/slstk3701a/slstk3701a.dts
+++ b/boards/silabs/starter_kits/slstk3701a/slstk3701a.dts
@@ -30,6 +30,15 @@
 		watchdog0 = &wdog0;
 	};
 
+	/* GPIOs that power up different sensors */
+	sensor_enable: sensor-enable {
+		compatible = "regulator-fixed";
+		regulator-name = "sensor_enable";
+		enable-gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
+		startup-delay-us = <100000>;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 
@@ -100,6 +109,12 @@
 	pinctrl-0 = <&i2c2_default>;
 	pinctrl-names = "default";
 	status = "okay";
+
+	si7210: si7210@30 {
+		compatible = "silabs,si7210";
+		reg = <0x30>;
+		vin-supply = <&sensor_enable>;
+	};
 };
 
 &rtcc0 {


### PR DESCRIPTION
Enable Si7210 Hall-effect sensor node under I2C2 in slstk3701a DTS for magnetic field sensing. Include a 3.3V fixed regulator (sensor-enable) via GPIO for power control.
