### PR TITLE
STM32mp257f_ev1: remove PAGESIZE macro to fix build error

### DIFF
--- a/include/zephyr/posix/posix_limits.h
+++ b/include/zephyr/posix/posix_limits.h
@@ -90,7 +90,6 @@
 #define MQ_PRIO_MAX                   _POSIX_MQ_PRIO_MAX
 #define OPEN_MAX                      CONFIG_POSIX_OPEN_MAX
 #define PAGE_SIZE                     CONFIG_POSIX_PAGE_SIZE
-#define PAGESIZE                      CONFIG_POSIX_PAGE_SIZE
 #define PATH_MAX                      _POSIX_PATH_MAX
 #define PTHREAD_DESTRUCTOR_ITERATIONS _POSIX_THREAD_DESTRUCTOR_ITERATIONS
 #define PTHREAD_KEYS_MAX \


### PR DESCRIPTION
Removed the '#define PAGESIZE CONFIG_POSIX_PAGE_SIZE' line from posix_limits.h.
This resolves a build issue caused by macro substitution when PAGESIZE is used as an identifier in some code.