### PR TITLE
include: devicetree: gpio: add doxygen to all GPIO headers header files

### DIFF
--- a/dts/bindings/gpio/arduino-mkr-header.yaml
+++ b/dts/bindings/gpio/arduino-mkr-header.yaml
@@ -33,6 +33,8 @@ description: |
         4  D4                   D7       7
         5  D5                   D6       6
 
+    Use ARDUINO_MKR_HEADER_* constants in <zephyr/dt-bindings/gpio/arduino-mkr-header.h> to refer to
+    specific pins using convenient constant names.
 
 compatible: "arduino-mkr-header"
 

--- a/dts/bindings/gpio/arduino-nano-header.yaml
+++ b/dts/bindings/gpio/arduino-nano-header.yaml
@@ -32,6 +32,8 @@ description: |
         11 D11                  3V3    -
         12 D12                  D13    13
 
+    Use ARDUINO_NANO_HEADER_* constants in <zephyr/dt-bindings/gpio/arduino-nano-header.h>
+    to refer to specific pins using convenient constant names.
 
 compatible: "arduino-nano-header"
 

--- a/dts/bindings/gpio/raspberrypi,csi-connector.yaml
+++ b/dts/bindings/gpio/raspberrypi,csi-connector.yaml
@@ -19,6 +19,9 @@ description: |
     3   I2C_SCL  pin 13 (15-pin based) / pin 20 (22-pin based)
     4   I2C_SDA  pin 14 (15-pin based) / pin 21 (22-pin based)
 
+  Use CSI_* constants in <zephyr/dt-bindings/gpio/raspberrypi-csi-connector.h>
+  to refer to specific pins using convenient constant names.
+
   For reference only, Raspberry 15-pin Connector layout:
     1   GND
     2   CSI_D0_N

--- a/dts/bindings/gpio/st-morpho-header.yaml
+++ b/dts/bindings/gpio/st-morpho-header.yaml
@@ -9,6 +9,9 @@ description: |
   any Nucleo board. They can be used to connect shields. All signals and power
   pins of the STM32 are available on the ST morpho connector.
 
+  Use ST_MORPHO_* constants in <zephyr/dt-bindings/gpio/st-morpho-header.h>
+  to refer to specific pins using convenient constant names.
+
 compatible: "st-morpho-header"
 
 include: [gpio-nexus.yaml, base.yaml]

--- a/include/zephyr/dt-bindings/gpio/arduino-mkr-header.h
+++ b/include/zephyr/dt-bindings/gpio/arduino-mkr-header.h
@@ -1,33 +1,48 @@
-/**
+/*
  * Copyright (c) 2025 TOKITA Hiroshi
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Arduino MKR header pin constants
+ * @ingroup arduino-mkr-header
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ARDUINO_MKR_HEADER_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ARDUINO_MKR_HEADER_H_
 
-#define ARDUINO_MKR_HEADER_D0  0
-#define ARDUINO_MKR_HEADER_D1  1
-#define ARDUINO_MKR_HEADER_D2  2
-#define ARDUINO_MKR_HEADER_D3  3
-#define ARDUINO_MKR_HEADER_D4  4
-#define ARDUINO_MKR_HEADER_D5  5
-#define ARDUINO_MKR_HEADER_D6  6
-#define ARDUINO_MKR_HEADER_D7  7
-#define ARDUINO_MKR_HEADER_D8  8
-#define ARDUINO_MKR_HEADER_D9  9
-#define ARDUINO_MKR_HEADER_D10 10
-#define ARDUINO_MKR_HEADER_D11 11
-#define ARDUINO_MKR_HEADER_D12 12
-#define ARDUINO_MKR_HEADER_D13 13
-#define ARDUINO_MKR_HEADER_D14 14
-#define ARDUINO_MKR_HEADER_A0  15
-#define ARDUINO_MKR_HEADER_A1  16
-#define ARDUINO_MKR_HEADER_A2  17
-#define ARDUINO_MKR_HEADER_A3  18
-#define ARDUINO_MKR_HEADER_A4  19
-#define ARDUINO_MKR_HEADER_A5  20
-#define ARDUINO_MKR_HEADER_A6  21
+/**
+ * @defgroup arduino-mkr-header Arduino MKR header
+ * @brief Constants for pins exposed on Arduino MKR header
+ * @ingroup devicetree-gpio-pin-headers
+ * @{
+ */
+
+#define ARDUINO_MKR_HEADER_D0  0  /**< Digital pin 0 (D0) */
+#define ARDUINO_MKR_HEADER_D1  1  /**< Digital pin 1 (D1) */
+#define ARDUINO_MKR_HEADER_D2  2  /**< Digital pin 2 (D2) */
+#define ARDUINO_MKR_HEADER_D3  3  /**< Digital pin 3 (D3) */
+#define ARDUINO_MKR_HEADER_D4  4  /**< Digital pin 4 (D4) */
+#define ARDUINO_MKR_HEADER_D5  5  /**< Digital pin 5 (D5) */
+#define ARDUINO_MKR_HEADER_D6  6  /**< Digital pin 6 (D6) */
+#define ARDUINO_MKR_HEADER_D7  7  /**< Digital pin 7 (D7) */
+#define ARDUINO_MKR_HEADER_D8  8  /**< Digital pin 8 (D8/COPI) */
+#define ARDUINO_MKR_HEADER_D9  9  /**< Digital pin 9 (D9/SCK) */
+#define ARDUINO_MKR_HEADER_D10 10 /**< Digital pin 10 (D10/CIPO) */
+#define ARDUINO_MKR_HEADER_D11 11 /**< Digital pin 11 (D11/SDA) */
+#define ARDUINO_MKR_HEADER_D12 12 /**< Digital pin 12 (D12/SCL) */
+#define ARDUINO_MKR_HEADER_D13 13 /**< Digital pin 13 (D13/RX) */
+#define ARDUINO_MKR_HEADER_D14 14 /**< Digital pin 14 (D14/TX) */
+#define ARDUINO_MKR_HEADER_A0  15 /**< Analog pin 0 (A0/D15/DAC0) */
+#define ARDUINO_MKR_HEADER_A1  16 /**< Analog pin 1 (A1/D16) */
+#define ARDUINO_MKR_HEADER_A2  17 /**< Analog pin 2 (A2/D17) */
+#define ARDUINO_MKR_HEADER_A3  18 /**< Analog pin 3 (A3/D18) */
+#define ARDUINO_MKR_HEADER_A4  19 /**< Analog pin 4 (A4/D19) */
+#define ARDUINO_MKR_HEADER_A5  20 /**< Analog pin 5 (A5/D20) */
+#define ARDUINO_MKR_HEADER_A6  21 /**< Analog pin 6 (A6/D21) */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ARDUINO_MKR_HEADER_H_ */

--- a/include/zephyr/dt-bindings/gpio/arduino-nano-header.h
+++ b/include/zephyr/dt-bindings/gpio/arduino-nano-header.h
@@ -1,41 +1,56 @@
-/**
+/*
  * Copyright (c) 2025 TOKITA Hiroshi
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Arduino Nano header pin constants
+ * @ingroup arduino-nano-header
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ARDUINO_NANO_HEADER_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ARDUINO_NANO_HEADER_H_
 
-#define ARDUINO_NANO_HEADER_D0  0
-#define ARDUINO_NANO_HEADER_D1  1
-#define ARDUINO_NANO_HEADER_D2  2
-#define ARDUINO_NANO_HEADER_D3  3
-#define ARDUINO_NANO_HEADER_D4  4
-#define ARDUINO_NANO_HEADER_D5  5
-#define ARDUINO_NANO_HEADER_D6  6
-#define ARDUINO_NANO_HEADER_D7  7
-#define ARDUINO_NANO_HEADER_D8  8
-#define ARDUINO_NANO_HEADER_D9  9
-#define ARDUINO_NANO_HEADER_D10 10
-#define ARDUINO_NANO_HEADER_D11 11
-#define ARDUINO_NANO_HEADER_D12 12
-#define ARDUINO_NANO_HEADER_D13 13
-#define ARDUINO_NANO_HEADER_D14 14
-#define ARDUINO_NANO_HEADER_D15 15
-#define ARDUINO_NANO_HEADER_D16 16
-#define ARDUINO_NANO_HEADER_D17 17
-#define ARDUINO_NANO_HEADER_D18 18
-#define ARDUINO_NANO_HEADER_D19 19
-#define ARDUINO_NANO_HEADER_D20 20
-#define ARDUINO_NANO_HEADER_D21 21
-#define ARDUINO_NANO_HEADER_A0  14
-#define ARDUINO_NANO_HEADER_A1  15
-#define ARDUINO_NANO_HEADER_A2  16
-#define ARDUINO_NANO_HEADER_A3  19
-#define ARDUINO_NANO_HEADER_A4  18
-#define ARDUINO_NANO_HEADER_A5  18
-#define ARDUINO_NANO_HEADER_A6  20
-#define ARDUINO_NANO_HEADER_A7  21
+/**
+ * @defgroup arduino-nano-header Arduino Nano header
+ * @brief Constants for pins exposed on Arduino Nano header
+ * @ingroup devicetree-gpio-pin-headers
+ * @{
+ */
+
+#define ARDUINO_NANO_HEADER_D0  0  /**< Digital pin 0 (D0/RX) */
+#define ARDUINO_NANO_HEADER_D1  1  /**< Digital pin 1 (D1/TX) */
+#define ARDUINO_NANO_HEADER_D2  2  /**< Digital pin 2 (D2) */
+#define ARDUINO_NANO_HEADER_D3  3  /**< Digital pin 3 (D3) */
+#define ARDUINO_NANO_HEADER_D4  4  /**< Digital pin 4 (D4) */
+#define ARDUINO_NANO_HEADER_D5  5  /**< Digital pin 5 (D5) */
+#define ARDUINO_NANO_HEADER_D6  6  /**< Digital pin 6 (D6) */
+#define ARDUINO_NANO_HEADER_D7  7  /**< Digital pin 7 (D7) */
+#define ARDUINO_NANO_HEADER_D8  8  /**< Digital pin 8 (D8) */
+#define ARDUINO_NANO_HEADER_D9  9  /**< Digital pin 9 (D9) */
+#define ARDUINO_NANO_HEADER_D10 10 /**< Digital pin 10 (D10/SS) */
+#define ARDUINO_NANO_HEADER_D11 11 /**< Digital pin 11 (D11/COPI) */
+#define ARDUINO_NANO_HEADER_D12 12 /**< Digital pin 12 (D12/CIPO) */
+#define ARDUINO_NANO_HEADER_D13 13 /**< Digital pin 13 (D13/SCK) */
+#define ARDUINO_NANO_HEADER_D14 14 /**< Digital pin 14 (D14) */
+#define ARDUINO_NANO_HEADER_D15 15 /**< Digital pin 15 (D15) */
+#define ARDUINO_NANO_HEADER_D16 16 /**< Digital pin 16 (D16) */
+#define ARDUINO_NANO_HEADER_D17 17 /**< Digital pin 17 (D17) */
+#define ARDUINO_NANO_HEADER_D18 18 /**< Digital pin 18 (D18) */
+#define ARDUINO_NANO_HEADER_D19 19 /**< Digital pin 19 (D19) */
+#define ARDUINO_NANO_HEADER_D20 20 /**< Digital pin 20 (D20) */
+#define ARDUINO_NANO_HEADER_D21 21 /**< Digital pin 21 (D21) */
+#define ARDUINO_NANO_HEADER_A0  14 /**< Analog pin 0 (A0) */
+#define ARDUINO_NANO_HEADER_A1  15 /**< Analog pin 1 (A1) */
+#define ARDUINO_NANO_HEADER_A2  16 /**< Analog pin 2 (A2) */
+#define ARDUINO_NANO_HEADER_A3  19 /**< Analog pin 3 (A3) */
+#define ARDUINO_NANO_HEADER_A4  18 /**< Analog pin 4 (A4) */
+#define ARDUINO_NANO_HEADER_A5  19 /**< Analog pin 5 (A5) */
+#define ARDUINO_NANO_HEADER_A6  20 /**< Analog pin 6 (A6) */
+#define ARDUINO_NANO_HEADER_A7  21 /**< Analog pin 7 (A7) */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ARDUINO_NANO_HEADER_H_ */

--- a/include/zephyr/dt-bindings/gpio/dvp-20pin-connector.h
+++ b/include/zephyr/dt-bindings/gpio/dvp-20pin-connector.h
@@ -2,11 +2,20 @@
  * Copyright (c) 2025 tinyVision.ai Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Arducam DVP 20-pin connector pin constants
+ * @ingroup dvp-20pin-connector
+ */
+
 #ifndef INCLUDE_ZEPHYR_DT_BINDINGS_GPIO_DVP_20PIN_CONNECTOR_H_
 #define INCLUDE_ZEPHYR_DT_BINDINGS_GPIO_DVP_20PIN_CONNECTOR_H_
 
 /**
- * @name Arducam DVP 20-pin or 18-pin connector pinout
+ * @defgroup dvp-20pin-connector Arducam DVP 20-pin connector
+ * @brief Constants for pins exposed on Arducam DVP 20-pin or 18-pin connector
+ * @ingroup devicetree-gpio-pin-headers
  * @{
  */
 #define DVP_20PIN_SCL	3	/**< I2C clock pin */

--- a/include/zephyr/dt-bindings/gpio/raspberrypi-csi-connector.h
+++ b/include/zephyr/dt-bindings/gpio/raspberrypi-csi-connector.h
@@ -2,11 +2,20 @@
  * Copyright (c) 2025 STMicroelectronics
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Raspberry Pi CSI camera connector pin constants
+ * @ingroup raspberrypi-csi-connector
+ */
+
 #ifndef INCLUDE_ZEPHYR_DT_BINDINGS_GPIO_RASPBERRYPI_CSI_CONNECTOR_H_
 #define INCLUDE_ZEPHYR_DT_BINDINGS_GPIO_RASPBERRYPI_CSI_CONNECTOR_H_
 
 /**
- * @name CSI camera connector GPIO list
+ * @defgroup raspberrypi-csi-connector Raspberry Pi CSI connector
+ * @brief Constants for pins exposed on Raspberry Pi CSI camera connector
+ * @ingroup devicetree-gpio-pin-headers
  * @{
  */
 #define CSI_IO0	1	/**< GPIO0 */

--- a/include/zephyr/dt-bindings/gpio/st-morpho-header.h
+++ b/include/zephyr/dt-bindings/gpio/st-morpho-header.h
@@ -2,161 +2,171 @@
  * Copyright (c) 2023 Teslabs Engineering S.L.
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief ST Morpho header pin constants
+ * @ingroup st-morpho-header
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ST_MORPHO_HEADER_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ST_MORPHO_HEADER_H_
+
+/**
+ * @defgroup st-morpho-header ST Morpho header
+ * @brief Constants for pins exposed on ST Morpho header
+ * @ingroup devicetree-gpio-pin-headers
+ * @{
+ */
 
 /** ST Morpho pin mask (0...143). */
 #define ST_MORPHO_PIN_MASK 0xFF
 
-/**
- * @name ST Morpho pin identifiers
- * @{
- */
-#define ST_MORPHO_L_1	0
-#define ST_MORPHO_L_2	1
-#define ST_MORPHO_L_3	2
-#define ST_MORPHO_L_4	3
-#define ST_MORPHO_L_5	4
-#define ST_MORPHO_L_6	5
-#define ST_MORPHO_L_7	6
-#define ST_MORPHO_L_8	7
-#define ST_MORPHO_L_9	8
-#define ST_MORPHO_L_10	9
-#define ST_MORPHO_L_11	10
-#define ST_MORPHO_L_12	11
-#define ST_MORPHO_L_13	12
-#define ST_MORPHO_L_14	13
-#define ST_MORPHO_L_15	14
-#define ST_MORPHO_L_16	15
-#define ST_MORPHO_L_17	16
-#define ST_MORPHO_L_18	17
-#define ST_MORPHO_L_19	18
-#define ST_MORPHO_L_20	19
-#define ST_MORPHO_L_21	20
-#define ST_MORPHO_L_22	21
-#define ST_MORPHO_L_23	22
-#define ST_MORPHO_L_24	23
-#define ST_MORPHO_L_25	24
-#define ST_MORPHO_L_26	25
-#define ST_MORPHO_L_27	26
-#define ST_MORPHO_L_28	27
-#define ST_MORPHO_L_29	28
-#define ST_MORPHO_L_30	29
-#define ST_MORPHO_L_31	30
-#define ST_MORPHO_L_32	31
-#define ST_MORPHO_L_33	32
-#define ST_MORPHO_L_34	33
-#define ST_MORPHO_L_35	34
-#define ST_MORPHO_L_36	35
-#define ST_MORPHO_L_37	36
-#define ST_MORPHO_L_38	37
-#define ST_MORPHO_L_39	38
-#define ST_MORPHO_L_40	39
-#define ST_MORPHO_L_41	40
-#define ST_MORPHO_L_42	41
-#define ST_MORPHO_L_43	42
-#define ST_MORPHO_L_44	43
-#define ST_MORPHO_L_45	44
-#define ST_MORPHO_L_46	45
-#define ST_MORPHO_L_47	46
-#define ST_MORPHO_L_48	47
-#define ST_MORPHO_L_49	48
-#define ST_MORPHO_L_50	49
-#define ST_MORPHO_L_51	50
-#define ST_MORPHO_L_52	51
-#define ST_MORPHO_L_53	52
-#define ST_MORPHO_L_54	53
-#define ST_MORPHO_L_55	54
-#define ST_MORPHO_L_56	55
-#define ST_MORPHO_L_57	56
-#define ST_MORPHO_L_58	57
-#define ST_MORPHO_L_59	58
-#define ST_MORPHO_L_60	59
-#define ST_MORPHO_L_61	60
-#define ST_MORPHO_L_62	61
-#define ST_MORPHO_L_63	62
-#define ST_MORPHO_L_64	63
-#define ST_MORPHO_L_65	64
-#define ST_MORPHO_L_66	65
-#define ST_MORPHO_L_67	66
-#define ST_MORPHO_L_68	67
-#define ST_MORPHO_L_69	68
-#define ST_MORPHO_L_70	69
-#define ST_MORPHO_L_71	70
-#define ST_MORPHO_L_72	71
+#define ST_MORPHO_L_1  0  /**< Left pin 1 */
+#define ST_MORPHO_L_2  1  /**< Left pin 2 */
+#define ST_MORPHO_L_3  2  /**< Left pin 3 */
+#define ST_MORPHO_L_4  3  /**< Left pin 4 */
+#define ST_MORPHO_L_5  4  /**< Left pin 5 */
+#define ST_MORPHO_L_6  5  /**< Left pin 6 */
+#define ST_MORPHO_L_7  6  /**< Left pin 7 */
+#define ST_MORPHO_L_8  7  /**< Left pin 8 */
+#define ST_MORPHO_L_9  8  /**< Left pin 9 */
+#define ST_MORPHO_L_10 9  /**< Left pin 10 */
+#define ST_MORPHO_L_11 10 /**< Left pin 11 */
+#define ST_MORPHO_L_12 11 /**< Left pin 12 */
+#define ST_MORPHO_L_13 12 /**< Left pin 13 */
+#define ST_MORPHO_L_14 13 /**< Left pin 14 */
+#define ST_MORPHO_L_15 14 /**< Left pin 15 */
+#define ST_MORPHO_L_16 15 /**< Left pin 16 */
+#define ST_MORPHO_L_17 16 /**< Left pin 17 */
+#define ST_MORPHO_L_18 17 /**< Left pin 18 */
+#define ST_MORPHO_L_19 18 /**< Left pin 19 */
+#define ST_MORPHO_L_20 19 /**< Left pin 20 */
+#define ST_MORPHO_L_21 20 /**< Left pin 21 */
+#define ST_MORPHO_L_22 21 /**< Left pin 22 */
+#define ST_MORPHO_L_23 22 /**< Left pin 23 */
+#define ST_MORPHO_L_24 23 /**< Left pin 24 */
+#define ST_MORPHO_L_25 24 /**< Left pin 25 */
+#define ST_MORPHO_L_26 25 /**< Left pin 26 */
+#define ST_MORPHO_L_27 26 /**< Left pin 27 */
+#define ST_MORPHO_L_28 27 /**< Left pin 28 */
+#define ST_MORPHO_L_29 28 /**< Left pin 29 */
+#define ST_MORPHO_L_30 29 /**< Left pin 30 */
+#define ST_MORPHO_L_31 30 /**< Left pin 31 */
+#define ST_MORPHO_L_32 31 /**< Left pin 32 */
+#define ST_MORPHO_L_33 32 /**< Left pin 33 */
+#define ST_MORPHO_L_34 33 /**< Left pin 34 */
+#define ST_MORPHO_L_35 34 /**< Left pin 35 */
+#define ST_MORPHO_L_36 35 /**< Left pin 36 */
+#define ST_MORPHO_L_37 36 /**< Left pin 37 */
+#define ST_MORPHO_L_38 37 /**< Left pin 38 */
+#define ST_MORPHO_L_39 38 /**< Left pin 39 */
+#define ST_MORPHO_L_40 39 /**< Left pin 40 */
+#define ST_MORPHO_L_41 40 /**< Left pin 41 */
+#define ST_MORPHO_L_42 41 /**< Left pin 42 */
+#define ST_MORPHO_L_43 42 /**< Left pin 43 */
+#define ST_MORPHO_L_44 43 /**< Left pin 44 */
+#define ST_MORPHO_L_45 44 /**< Left pin 45 */
+#define ST_MORPHO_L_46 45 /**< Left pin 46 */
+#define ST_MORPHO_L_47 46 /**< Left pin 47 */
+#define ST_MORPHO_L_48 47 /**< Left pin 48 */
+#define ST_MORPHO_L_49 48 /**< Left pin 49 */
+#define ST_MORPHO_L_50 49 /**< Left pin 50 */
+#define ST_MORPHO_L_51 50 /**< Left pin 51 */
+#define ST_MORPHO_L_52 51 /**< Left pin 52 */
+#define ST_MORPHO_L_53 52 /**< Left pin 53 */
+#define ST_MORPHO_L_54 53 /**< Left pin 54 */
+#define ST_MORPHO_L_55 54 /**< Left pin 55 */
+#define ST_MORPHO_L_56 55 /**< Left pin 56 */
+#define ST_MORPHO_L_57 56 /**< Left pin 57 */
+#define ST_MORPHO_L_58 57 /**< Left pin 58 */
+#define ST_MORPHO_L_59 58 /**< Left pin 59 */
+#define ST_MORPHO_L_60 59 /**< Left pin 60 */
+#define ST_MORPHO_L_61 60 /**< Left pin 61 */
+#define ST_MORPHO_L_62 61 /**< Left pin 62 */
+#define ST_MORPHO_L_63 62 /**< Left pin 63 */
+#define ST_MORPHO_L_64 63 /**< Left pin 64 */
+#define ST_MORPHO_L_65 64 /**< Left pin 65 */
+#define ST_MORPHO_L_66 65 /**< Left pin 66 */
+#define ST_MORPHO_L_67 66 /**< Left pin 67 */
+#define ST_MORPHO_L_68 67 /**< Left pin 68 */
+#define ST_MORPHO_L_69 68 /**< Left pin 69 */
+#define ST_MORPHO_L_70 69 /**< Left pin 70 */
+#define ST_MORPHO_L_71 70 /**< Left pin 71 */
+#define ST_MORPHO_L_72 71 /**< Left pin 72 */
 
-#define ST_MORPHO_R_1	72
-#define ST_MORPHO_R_2	73
-#define ST_MORPHO_R_3	74
-#define ST_MORPHO_R_4	75
-#define ST_MORPHO_R_5	76
-#define ST_MORPHO_R_6	77
-#define ST_MORPHO_R_7	78
-#define ST_MORPHO_R_8	79
-#define ST_MORPHO_R_9	80
-#define ST_MORPHO_R_10	81
-#define ST_MORPHO_R_11	82
-#define ST_MORPHO_R_12	83
-#define ST_MORPHO_R_13	84
-#define ST_MORPHO_R_14	85
-#define ST_MORPHO_R_15	86
-#define ST_MORPHO_R_16	87
-#define ST_MORPHO_R_17	88
-#define ST_MORPHO_R_18	89
-#define ST_MORPHO_R_19	90
-#define ST_MORPHO_R_20	91
-#define ST_MORPHO_R_21	92
-#define ST_MORPHO_R_22	93
-#define ST_MORPHO_R_23	94
-#define ST_MORPHO_R_24	95
-#define ST_MORPHO_R_25	96
-#define ST_MORPHO_R_26	97
-#define ST_MORPHO_R_27	98
-#define ST_MORPHO_R_28	99
-#define ST_MORPHO_R_29	100
-#define ST_MORPHO_R_30	101
-#define ST_MORPHO_R_31	102
-#define ST_MORPHO_R_32	103
-#define ST_MORPHO_R_33	104
-#define ST_MORPHO_R_34	105
-#define ST_MORPHO_R_35	106
-#define ST_MORPHO_R_36	107
-#define ST_MORPHO_R_37	108
-#define ST_MORPHO_R_38	109
-#define ST_MORPHO_R_39	110
-#define ST_MORPHO_R_40	111
-#define ST_MORPHO_R_41	112
-#define ST_MORPHO_R_42	113
-#define ST_MORPHO_R_43	114
-#define ST_MORPHO_R_44	115
-#define ST_MORPHO_R_45	116
-#define ST_MORPHO_R_46	117
-#define ST_MORPHO_R_47	118
-#define ST_MORPHO_R_48	119
-#define ST_MORPHO_R_49	120
-#define ST_MORPHO_R_50	121
-#define ST_MORPHO_R_51	122
-#define ST_MORPHO_R_52	123
-#define ST_MORPHO_R_53	124
-#define ST_MORPHO_R_54	125
-#define ST_MORPHO_R_55	126
-#define ST_MORPHO_R_56	127
-#define ST_MORPHO_R_57	128
-#define ST_MORPHO_R_58	129
-#define ST_MORPHO_R_59	130
-#define ST_MORPHO_R_60	131
-#define ST_MORPHO_R_61	132
-#define ST_MORPHO_R_62	133
-#define ST_MORPHO_R_63	134
-#define ST_MORPHO_R_64	135
-#define ST_MORPHO_R_65	136
-#define ST_MORPHO_R_66	137
-#define ST_MORPHO_R_67	138
-#define ST_MORPHO_R_68	139
-#define ST_MORPHO_R_69	140
-#define ST_MORPHO_R_70	141
-#define ST_MORPHO_R_71	142
-#define ST_MORPHO_R_72	143
+#define ST_MORPHO_R_1  72  /**< Right pin 1 */
+#define ST_MORPHO_R_2  73  /**< Right pin 2 */
+#define ST_MORPHO_R_3  74  /**< Right pin 3 */
+#define ST_MORPHO_R_4  75  /**< Right pin 4 */
+#define ST_MORPHO_R_5  76  /**< Right pin 5 */
+#define ST_MORPHO_R_6  77  /**< Right pin 6 */
+#define ST_MORPHO_R_7  78  /**< Right pin 7 */
+#define ST_MORPHO_R_8  79  /**< Right pin 8 */
+#define ST_MORPHO_R_9  80  /**< Right pin 9 */
+#define ST_MORPHO_R_10 81  /**< Right pin 10 */
+#define ST_MORPHO_R_11 82  /**< Right pin 11 */
+#define ST_MORPHO_R_12 83  /**< Right pin 12 */
+#define ST_MORPHO_R_13 84  /**< Right pin 13 */
+#define ST_MORPHO_R_14 85  /**< Right pin 14 */
+#define ST_MORPHO_R_15 86  /**< Right pin 15 */
+#define ST_MORPHO_R_16 87  /**< Right pin 16 */
+#define ST_MORPHO_R_17 88  /**< Right pin 17 */
+#define ST_MORPHO_R_18 89  /**< Right pin 18 */
+#define ST_MORPHO_R_19 90  /**< Right pin 19 */
+#define ST_MORPHO_R_20 91  /**< Right pin 20 */
+#define ST_MORPHO_R_21 92  /**< Right pin 21 */
+#define ST_MORPHO_R_22 93  /**< Right pin 22 */
+#define ST_MORPHO_R_23 94  /**< Right pin 23 */
+#define ST_MORPHO_R_24 95  /**< Right pin 24 */
+#define ST_MORPHO_R_25 96  /**< Right pin 25 */
+#define ST_MORPHO_R_26 97  /**< Right pin 26 */
+#define ST_MORPHO_R_27 98  /**< Right pin 27 */
+#define ST_MORPHO_R_28 99  /**< Right pin 28 */
+#define ST_MORPHO_R_29 100 /**< Right pin 29 */
+#define ST_MORPHO_R_30 101 /**< Right pin 30 */
+#define ST_MORPHO_R_31 102 /**< Right pin 31 */
+#define ST_MORPHO_R_32 103 /**< Right pin 32 */
+#define ST_MORPHO_R_33 104 /**< Right pin 33 */
+#define ST_MORPHO_R_34 105 /**< Right pin 34 */
+#define ST_MORPHO_R_35 106 /**< Right pin 35 */
+#define ST_MORPHO_R_36 107 /**< Right pin 36 */
+#define ST_MORPHO_R_37 108 /**< Right pin 37 */
+#define ST_MORPHO_R_38 109 /**< Right pin 38 */
+#define ST_MORPHO_R_39 110 /**< Right pin 39 */
+#define ST_MORPHO_R_40 111 /**< Right pin 40 */
+#define ST_MORPHO_R_41 112 /**< Right pin 41 */
+#define ST_MORPHO_R_42 113 /**< Right pin 42 */
+#define ST_MORPHO_R_43 114 /**< Right pin 43 */
+#define ST_MORPHO_R_44 115 /**< Right pin 44 */
+#define ST_MORPHO_R_45 116 /**< Right pin 45 */
+#define ST_MORPHO_R_46 117 /**< Right pin 46 */
+#define ST_MORPHO_R_47 118 /**< Right pin 47 */
+#define ST_MORPHO_R_48 119 /**< Right pin 48 */
+#define ST_MORPHO_R_49 120 /**< Right pin 49 */
+#define ST_MORPHO_R_50 121 /**< Right pin 50 */
+#define ST_MORPHO_R_51 122 /**< Right pin 51 */
+#define ST_MORPHO_R_52 123 /**< Right pin 52 */
+#define ST_MORPHO_R_53 124 /**< Right pin 53 */
+#define ST_MORPHO_R_54 125 /**< Right pin 54 */
+#define ST_MORPHO_R_55 126 /**< Right pin 55 */
+#define ST_MORPHO_R_56 127 /**< Right pin 56 */
+#define ST_MORPHO_R_57 128 /**< Right pin 57 */
+#define ST_MORPHO_R_58 129 /**< Right pin 58 */
+#define ST_MORPHO_R_59 130 /**< Right pin 59 */
+#define ST_MORPHO_R_60 131 /**< Right pin 60 */
+#define ST_MORPHO_R_61 132 /**< Right pin 61 */
+#define ST_MORPHO_R_62 133 /**< Right pin 62 */
+#define ST_MORPHO_R_63 134 /**< Right pin 63 */
+#define ST_MORPHO_R_64 135 /**< Right pin 64 */
+#define ST_MORPHO_R_65 136 /**< Right pin 65 */
+#define ST_MORPHO_R_66 137 /**< Right pin 66 */
+#define ST_MORPHO_R_67 138 /**< Right pin 67 */
+#define ST_MORPHO_R_68 139 /**< Right pin 68 */
+#define ST_MORPHO_R_69 140 /**< Right pin 69 */
+#define ST_MORPHO_R_70 141 /**< Right pin 70 */
+#define ST_MORPHO_R_71 142 /**< Right pin 71 */
+#define ST_MORPHO_R_72 143 /**< Right pin 72 */
 
 /** @} */
 


### PR DESCRIPTION
Document Arduino MKR, ST Morpho etc. so as to have them conveniently visible in the API reference

https://builds.zephyrproject.io/zephyr/pr/95349/docs/doxygen/html/group__devicetree-gpio-pin-headers.html

~This builds on top of #95320 as I basically realized it would be nice to have all GPIO nexuses showing up in the docs. I will rebase once the other PR is merged but would appreciate feedback on **everything but the first 3 commits** in this PR.~