### PR TITLE
MAINTAINERS: intentionally orphan vendor-prefixes.txt

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1066,6 +1066,8 @@ Devicetree:
     - include/zephyr/dt-bindings/dt-util.h
     - dts/binding-template.yaml
     - dts/bindings/base/
+  files-exclude:
+    - dts/bindings/vendor-prefixes.txt
   labels:
     - "area: Devicetree"
   tests:


### PR DESCRIPTION
I'm quite tired of getting spam requested on a dozen different PR every week due to every random company adding a DTS vendor prefix and that is the only DT related change on the PR (usually adding a new board, which I am not interested to review that)

There is 0 value to monitoring this file TBH by DT maintainers, just orphan it. 

BTW, usually I and @rruuaanng are the only one getting automatically added to review new board PR and I therefore suggest somebody who actually is interested in adding new boards to the project make some kind of area to capture those PRs. And probably this file is a good starting place because it will catch new boards added that don't fall into another area.