### PR TITLE
dt-bindings: sensor: lsm9ds1: Fix misleading descriptions

### DIFF
--- a/dts/bindings/sensor/st,lsm9ds1.yaml
+++ b/dts/bindings/sensor/st,lsm9ds1.yaml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STMicroelectronics LSM9DS1 9-axis IMU (Inertial Measurement Unit) sensor
-    accessed through I2C bus.
+    STMicroelectronics LSM9DS1 3-axis accelerometer + gyroscope accessed
+    through I2C bus.
 
     This binding describe only the inertial part : accelerometer and gyroscope.
 

--- a/dts/bindings/sensor/st,lsm9ds1_mag.yaml
+++ b/dts/bindings/sensor/st,lsm9ds1_mag.yaml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STMicroelectronics LSM9DS1 9-axis IMU (Inertial Measurement Unit) sensor
-    accessed through I2C bus.
+    STMicroelectronics LSM9DS1-MAG 3-axis magnetometer accessed
+    through I2C bus.
 
     This binding describes only the magnetometer.
 


### PR DESCRIPTION
The LSM9DS1 bindings were described as a full 9-axis IMU, while each binding only covers one part of the device. This also made the "Supported features" section of the generated docs misleading, since it only shows the first sentence.

Update the descriptions to explicitly state whether they cover the accelerometer + gyroscope or the magnetometer.