### PR TITLE
doc: index: redesign/restructure documentation landing page

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -1,0 +1,641 @@
+<style>
+  h1 {
+    display: none;
+  }
+
+  .admonition.welcome {
+      background: transparent;
+      border-left: 2px solid var(--navbar-scrollbar-active-color);
+      padding: 0 0 0 1rem;
+
+      .admonition-title {
+        color: var(--body-color);
+        background: transparent !important;
+        padding: 0;
+        margin: 0 0 0.25rem 0;
+        font-weight: 700;
+        font-size: 18px;
+        opacity: 1;
+
+        &::before {
+          display: none;
+        }
+      }
+
+      p {
+        color: var(--body-color);
+        font-size: 0.9rem;
+        opacity: 0.6;
+        line-height: 1.2em;
+      }
+  }
+
+  .landing-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding-top: 0.5rem;
+  }
+  .landing-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    margin-bottom: 2.5rem;
+    @media (min-width: 768px) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    &.three-col {
+      @media (min-width: 1024px) {
+        grid-template-columns: repeat(3, 1fr);
+      }
+    }
+  }
+
+  /* === SHARED CARD STYLES === */
+  .card-title {
+    font-size: 1.125rem;
+    font-weight: bold;
+    color: #fff;
+    margin-bottom: 0.25rem !important;
+  }
+  .card-description {
+    color: var(--navbar-level-1-color);
+    font-weight: 300;
+    font-size: 0.9rem !important;
+    margin: 0 !important;
+    opacity: 0.85;
+  }
+  .icon-wrapper i {
+    color: inherit;
+  }
+
+  /* === LANDING CARDS === */
+  .landing-card {
+    background-color: var(--navbar-background-color);
+    border-radius: 0.75rem;
+    padding: 1.5rem 2rem;
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    text-decoration: none;
+    position: relative;
+    overflow: hidden;
+    transition: all 0.15s ease 0.15s ease;
+    &:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+      text-decoration: none;
+      .landing-watermark {
+        transform: translateY(-50%) rotate(-8deg) scale(1.1);
+        opacity: 0.25;
+      }
+    }
+    .card-content {
+      flex: 1;
+      position: relative;
+      z-index: 2;
+    }
+    .card-description {
+      padding-right: 5rem;
+    }
+  }
+  .landing-watermark {
+    position: absolute;
+    right: 1.5rem;
+    top: 50%;
+    transform: translateY(-50%);
+    transform-origin: center center;
+    opacity: 0.12;
+    pointer-events: none;
+    transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    color: var(--navbar-scrollbar-color);
+    i {
+      font-size: 5rem !important;
+      line-height: 1;
+    }
+  }
+
+  /* === PERSONA CARDS === */
+  .persona-card {
+    background-color: var(--navbar-background-color);
+    border-radius: 0.75rem;
+    padding: 1.5rem 2rem;
+    position: relative;
+    overflow: hidden;
+    z-index: 1;
+    border: 1px solid transparent;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    transition: all 0.2s ease;
+    &:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+      border-color: rgba(255, 255, 255, 0.05);
+      .watermark {
+        transform: rotate(-10deg) scale(1.1);
+        opacity: 0.15;
+      }
+    }
+    .card-content {
+      position: relative;
+      z-index: 2;
+      flex: 1;
+    }
+    @media (max-width: 768px) {
+      .watermark {
+        bottom:1rem;
+        right: 1rem;
+
+        i {
+          font-size: 7rem !important;
+        }
+      }
+    }
+  }
+  .persona-header {
+    margin-bottom: 1.5rem;
+    h3 {
+      min-height: 3rem;
+      font-size: 1.25rem;
+      margin-top: 0;
+      margin-bottom: 0.5rem;
+    }
+    @media (max-width: 768px) {
+      z-index: 10;
+    }
+  }
+
+  /* Watermark */
+  .watermark {
+    position: absolute;
+    bottom: -1rem;
+    right: -1.5rem;
+    z-index: 0;
+    opacity: 0.05;
+    transform: rotate(0deg);
+    pointer-events: none;
+    transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    i {
+      font-size: 9rem !important;
+      line-height: 1;
+    }
+    @media (max-width: 768px) {
+      bottom: -0.5rem;
+      right: -0.5rem;
+      opacity: 0.15;
+      i {
+        font-size: 6rem !important;
+      }
+    }
+  }
+
+  /* Persona Type Colors */
+  .type-app {
+    .watermark i {
+      color: #0ea5e9;
+    }
+    .persona-link {
+      i {
+        color: #0ea5e9;
+      }
+      &:hover {
+        color: #38bdf8 !important;
+      }
+    }
+  }
+  .type-hw {
+    .watermark i {
+      color: #8b5cf6;
+    }
+    .persona-link {
+      i {
+        color: #8b5cf6;
+      }
+      &:hover {
+        color: #a78bfa !important;
+      }
+    }
+  }
+  .type-maker {
+    .watermark i {
+      color: #10b981;
+    }
+    .persona-link {
+      i {
+        color: #10b981;
+      }
+      &:hover {
+        color: #34d399 !important;
+      }
+    }
+  }
+
+  /* Persona Links */
+  .persona-list {
+    margin: 0 !important;
+    list-style: none;
+    padding: 0;
+    position: relative;
+    z-index: 2;
+    li {
+      list-style: none !important;
+      margin-left: 0 !important;
+      * {
+        margin-bottom: 0.1rem !important;
+      }
+    }
+  }
+  .persona-link {
+    display: flex;
+    align-items: center;
+    color: var(--navbar-level-1-color) !important;
+    font-size: 0.9rem;
+    text-decoration: none;
+    transition: color 0.2s;
+    i {
+      font-size: 0.75rem;
+      margin-right: 0.6rem;
+    }
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  /* === CONTRIBUTE CARD === */
+  .contribute-card {
+    background-color: var(--navbar-background-color);
+    border-radius: 0.5rem;
+    padding: 2rem;
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    text-decoration: none;
+    border: 1px solid transparent;
+    transition: all 0.1s ease;
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+      border-color: rgba(236, 72, 153, 0.5);
+      text-decoration: none;
+      .cta-text {
+        color: #fff;
+      }
+    }
+    @media (max-width: 768px) {
+      flex-direction: column;
+      text-align: center;
+      gap: 1rem;
+    }
+  }
+  .accent-contribute {
+    background-color: rgba(219, 39, 119, 0.15);
+    color: #f472b6;
+    width: 5rem;
+    height: 5rem;
+    border-radius: 0.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  .cta-text {
+    color: var(--navbar-level-1-color);
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: auto;
+    padding-left: 1rem;
+    white-space: nowrap;
+    @media (max-width: 768px) {
+      margin-left: 0;
+      padding-left: 0;
+    }
+  }
+
+  /* === REFERENCE CARDS === */
+  .reference-card {
+    background-color: var(--navbar-background-color);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    text-decoration: none;
+    transition: transform 0.1s ease;
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 8px rgba(0, 0, 0, 0.2);
+      text-decoration: none;
+      .reference-arrow {
+        opacity: 1;
+        transform: translateX(4px);
+      }
+    }
+    .icon-wrapper {
+      width: 2.5rem;
+      height: 2.5rem;
+      flex-shrink: 0;
+      border-radius: 0.4rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .card-title {
+      font-size: 1rem;
+      margin: 0;
+    }
+    .card-description {
+      font-weight: 100;
+    }
+  }
+  .reference-content {
+    flex: 1;
+  }
+  .reference-arrow {
+    flex-shrink: 0;
+    opacity: 0.5;
+    transition: all 0.2s ease;
+  }
+
+  /* === SECTION HEADERS === */
+  .section-header {
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+  .section-title {
+    font-size: 1.75rem;
+    font-weight: bold;
+    margin-bottom: 0.5rem !important;
+  }
+  .section-subtitle {
+    opacity: 0.6;
+    margin-top: 0.5rem;
+    font-size: 0.95rem;
+  }
+
+  /* === COLOR ACCENTS === */
+  .ref-api {
+    background-color: rgba(59, 130, 246, 0.2);
+    color: #60a5fa;
+  }
+  .ref-kconfig {
+    background-color: rgba(34, 197, 94, 0.2);
+    color: #4ade80;
+  }
+  .ref-dts {
+    background-color: rgba(168, 85, 247, 0.2);
+    color: #c084fc;
+  }
+  .ref-west {
+    background-color: rgba(239, 68, 68, 0.2);
+    color: #f87171;
+  }
+  .ref-glossary {
+    background-color: rgba(249, 115, 22, 0.2);
+    color: #fb923c;
+  }
+</style>
+
+<main class="landing-container">
+  <section>
+    <div class="landing-grid">
+      <a href="introduction/index.html" class="landing-card">
+        <div class="landing-watermark">
+          <i class="fa fa-info-circle" aria-hidden="true"></i>
+        </div>
+        <div class="card-content">
+          <h3 class="card-title">What is Zephyr?</h3>
+          <p class="card-description">Discover the core concepts, features, and architecture.</p>
+        </div>
+      </a>
+
+      <a href="develop/getting_started/index.html" class="landing-card">
+        <div class="landing-watermark">
+          <i class="fa fa-lightbulb-o" aria-hidden="true" style="font-size: 5.5rem !important;"></i>
+        </div>
+        <div class="card-content">
+          <h3 class="card-title">Getting Started</h3>
+          <p class="card-description">
+            A step-by-step guide to set up your environment & blink your first LED.
+          </p>
+        </div>
+      </a>
+
+      <a href="boards/index.html" class="landing-card">
+        <div class="landing-watermark">
+          <i class="fa fa-microchip" aria-hidden="true"></i>
+        </div>
+        <div class="card-content">
+          <h3 class="card-title">Supported Boards</h3>
+          <p class="card-description">Browse 1,000+ supported boards and shields.</p>
+        </div>
+      </a>
+
+      <a href="samples/index.html" class="landing-card">
+        <div class="landing-watermark">
+          <i class="fa fa-cogs" aria-hidden="true"></i>
+        </div>
+        <div class="card-content">
+          <h3 class="card-title">Code Samples</h3>
+          <p class="card-description">Explore hundreds of ready-to-run examples.</p>
+        </div>
+      </a>
+    </div>
+  </section>
+
+  <section style="margin-top: 3rem">
+    <div class="section-header">
+      <h2 class="section-title">Choose Your Starting Point</h2>
+      <p class="section-subtitle">
+        Find documentation tailored to what you're trying to accomplish.
+      </p>
+    </div>
+
+    <div class="landing-grid three-col">
+      <div class="persona-card type-app">
+        <div class="watermark">
+          <i class="fa fa-laptop" aria-hidden="true"></i>
+        </div>
+        <div class="card-content">
+          <div class="persona-header">
+            <h3 class="card-title">Building an Application</h3>
+            <p class="card-description">Use Zephyr APIs and services in your firmware.</p>
+          </div>
+          <ul class="persona-list">
+            <li>
+              <a href="kernel/services/" class="persona-link"><i class="fa fa-chevron-right"
+                  aria-hidden="true"></i><span>RTOS Kernel</span></a>
+            </li>
+            <li>
+              <a href="services/" class="persona-link"><i class="fa fa-chevron-right"
+                  aria-hidden="true"></i><span>Services</span></a>
+            </li>
+            <li>
+              <a href="develop/application/" class="persona-link"><i class="fa fa-chevron-right"
+                  aria-hidden="true"></i><span>Application development</span></a>
+            </li>
+            <li>
+              <a href="samples/" class="persona-link"><i class="fa fa-chevron-right"
+                  aria-hidden="true"></i><span>Code samples</span></a>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="persona-card type-hw">
+        <div class="watermark">
+          <i class="fa fa-microchip" aria-hidden="true"></i>
+        </div>
+        <div class="card-content">
+          <div class="persona-header">
+            <h3 class="card-title">Bringing Up New Hardware</h3>
+            <p class="card-description">Port and run Zephyr on hardware.</p>
+          </div>
+          <ul class="persona-list">
+            <li>
+              <a href="kernel/drivers/index.html" class="persona-link"><i class="fa fa-chevron-right"
+                aria-hidden="true"></i><span>Device Driver Model</span></a>
+            </li>
+            <li>
+                <a href="build/dts/index.html" class="persona-link"><i class="fa fa-chevron-right"
+                  aria-hidden="true"></i><span>Devicetree</span></a>
+            </li>
+            <li>
+              <a href="hardware/porting/board_porting.html" class="persona-link"><i
+                 class="fa fa-chevron-right" aria-hidden="true"></i>
+                <span>Board Porting Guide</span>
+              </a>
+            </li>
+            <li>
+              <a href="hardware/porting/soc_porting.html" class="persona-link"><i class="fa fa-chevron-right"
+                 aria-hidden="true"></i>
+                <span>SoC Porting Guide</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="persona-card type-maker">
+        <div class="watermark">
+          <i class="fa fa-cube" aria-hidden="true"></i>
+        </div>
+        <div class="card-content">
+          <div class="persona-header">
+            <h3 class="card-title">Going to Production</h3>
+            <p class="card-description">Considerations for using Zephyr in your product.</p>
+          </div>
+          <ul class="persona-list">
+            <li>
+              <a href="security/" class="persona-link">
+                <i class="fa fa-chevron-right" aria-hidden="true"></i><span>Security</span></a>
+            </li>
+            <li>
+              <a href="safety/" class="persona-link">
+                <i class="fa fa-chevron-right" aria-hidden="true"></i><span>Safety</span></a>
+            </li>
+            <li>
+              <a href="project/release_process.html#long-term-support-lts" class="persona-link">
+                <i class="fa fa-chevron-right aria-hidden=" true""></i>
+                <span>Long-term Support</span>
+              </a>
+            </li>
+            <li>
+              <a href="https://www.zephyrproject.org/products-running-zephyr/" class="persona-link"
+                 target="_blank">
+                <i class="fa fa-chevron-right" aria-hidden="true"></i>
+                <span>Product Showcase</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section style="margin-top: 1rem; margin-bottom: 3rem">
+    <a href="contribute/index.html" class="contribute-card">
+      <div class="accent-contribute">
+        <i class="fa fa-github" style="font-size: 3rem" aria-hidden="true"></i>
+      </div>
+      <div class="card-content">
+        <h2 class="card-title" style="font-size: 1.5rem; margin-bottom: 0.5rem">
+          Contribute to Zephyr
+        </h2>
+        <p class="card-description" style="font-size: 1rem; margin: 0">
+          The Zephyr Project is open source and community-driven.<br>
+          Learn how to report bugs, request new features, and submit pull requests.
+        </p>
+      </div>
+      <div class="cta-text">
+        <span>Read the Guidelines</span>
+        <i class="fa fa-arrow-right"></i>
+      </div>
+    </a>
+  </section>
+
+  <section>
+    <div class="section-header">
+      <h2 class="section-title">Core References</h2>
+      <p class="section-subtitle">Essential resources for in-depth information</p>
+    </div>
+
+    <div class="landing-grid three-col">
+      <a href="doxygen/html/" class="reference-card">
+        <div class="icon-wrapper ref-api">
+          <i class="fa fa-book" aria-hidden="true" style="font-size: 1.25rem"></i>
+        </div>
+        <div class="reference-content">
+          <h3 class="card-title">API Reference</h3>
+          <p class="card-description">Complete C API docs</p>
+        </div>
+        <i class="fa fa-arrow-right reference-arrow" style="color: #60a5fa"></i>
+      </a>
+
+      <a href="kconfig.html" class="reference-card">
+        <div class="icon-wrapper ref-kconfig">
+          <i class="fa fa-sliders" aria-hidden="true" style="font-size: 1.25rem"></i>
+        </div>
+        <div class="reference-content">
+          <h3 class="card-title">Kconfig</h3>
+          <p class="card-description">Configuration system</p>
+        </div>
+        <i class="fa fa-arrow-right reference-arrow" style="color: #4ade80"></i>
+      </a>
+
+      <a href="build/dts/api/bindings.html" class="reference-card">
+        <div class="icon-wrapper ref-dts">
+          <i class="fa fa-sitemap" aria-hidden="true" style="font-size: 1.25rem"></i>
+        </div>
+        <div class="reference-content">
+          <h3 class="card-title">Devicetree</h3>
+          <p class="card-description">Hardware bindings</p>
+        </div>
+        <i class="fa fa-arrow-right reference-arrow" style="color: #c084fc"></i>
+      </a>
+
+      <a href="develop/manifest/" class="reference-card">
+        <div class="icon-wrapper ref-west">
+          <i class="fa fa-code-fork" aria-hidden="true" style="font-size: 1.25rem"></i>
+        </div>
+        <div class="reference-content">
+          <h3 class="card-title">West Projects</h3>
+          <p class="card-description">Available projects</p>
+        </div>
+        <i class="fa fa-arrow-right reference-arrow" style="color: #f87171"></i>
+      </a>
+
+      <a href="glossary.html" class="reference-card">
+        <div class="icon-wrapper ref-glossary">
+          <i class="fa fa-font" aria-hidden="true" style="font-size: 1.25rem"></i>
+        </div>
+        <div class="reference-content">
+          <h3 class="card-title">Glossary</h3>
+          <p class="card-description">Key term definitions</p>
+        </div>
+        <i class="fa fa-arrow-right reference-arrow" style="color: #fb923c"></i>
+      </a>
+    </div>
+  </section>
+</main>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,90 +6,49 @@
 Zephyr Project Documentation
 ############################
 
-.. only:: release
-
-   Welcome to the Zephyr Project's documentation for version |version|.
-
-   Documentation for the latest (main) development branch of Zephyr
-   can be found at https://docs.zephyrproject.org/
-
-.. only:: (development or daily)
-
-   **Welcome to the Zephyr Project's documentation
-   for the main tree under development** (version |version|).
-
-Use the version selection menu on the left to view
-documentation for a specific version of Zephyr.
-
-
 .. raw:: html
 
-   <ul class="grid">
-       <li class="grid-item">
-	   <a href="introduction/index.html">
-	       <img alt="" src="_static/images/kite.png"/>
-	       <h2>Introduction</h2>
-	   </a>
-	   <p>Architecture, features &amp; licensing details</p>
-       </li>
-       <li class="grid-item">
-	   <a href="develop/getting_started/index.html">
-               <span class="grid-icon fa fa-map-signs"></span>
-	       <h2>Getting Started Guide</h2>
-	   </a>
-	   <p>Set up Zephyr, build &amp; run a sample application</p>
-       </li>
-       <li class="grid-item">
-	   <a href="samples/index.html">
-               <span class="grid-icon fa fa-cogs"></span>
-	       <h2>Samples and Demos</h2>
-	   </a>
-	   <p>Explore samples and demos for various boards</p>
-       </li>
-       <li class="grid-item">
-	   <a href="boards/index.html">
-               <span class="grid-icon fa fa-object-group"></span>
-	       <h2>Supported Boards</h2>
-	   </a>
-	   <p>List of supported boards and platforms</p>
-       </li>
-       <li class="grid-item">
-	   <a href="hardware/index.html">
-               <span class="grid-icon fa fa-sign-in"></span>
-	       <h2>Hardware Support</h2>
-	   </a>
-	   <p>Supported hardware and porting guides</p>
-       </li>
-       <li class="grid-item">
-	   <a href="security/index.html">
-               <span class="grid-icon fa fa-lock"></span>
-	       <h2>Security</h2>
-	   </a>
-	   <p>Security processes and guidelines</p>
-       </li>
-       <li class="grid-item">
-	   <a href="services/index.html">
-               <span class="grid-icon fa fa-puzzle-piece"></span>
-	       <h2>OS Services</h2>
-	   </a>
-	   <p>OS Services and usage guides</p>
-       </li>
-       <li class="grid-item">
-	   <a href="contribute/index.html">
-               <span class="grid-icon fa fa-github"></span>
-	       <h2>Contribution Guidelines</h2>
-	   </a>
-	   <p>How to submit patches and contribute to Zephyr</p>
-       </li>
-   </ul>
+   <script>
+     function openVersionSelector() {
+       // Open the mobile menu if visible
+       var mobileMenu = document.querySelector('[data-toggle="wy-nav-top"]');
+       if (mobileMenu && mobileMenu.offsetParent !== null) {
+         mobileMenu.click();
+       }
+       // Open the version selector
+       var versionSelector = document.querySelector('[data-toggle="rst-current-version"]');
+       if (versionSelector) {
+         versionSelector.click();
+       }
+     }
+   </script>
 
-For information about the changes and additions for past releases, please
-consult the published :ref:`zephyr_release_notes` documentation.
+.. only:: release
 
-The Zephyr OS is provided under the `Apache 2.0 license`_ (as found in
-the LICENSE file in the project's `GitHub repo`_).  The Zephyr OS also
-imports or reuses packages, scripts, and other files that use other
-licensing, as described in :ref:`Zephyr_Licensing`.
+   .. admonition:: Welcome to Zephyr Project Documentation for version |version|.
+      :class: welcome
+
+      .. raw:: html
+
+         <p>
+           Use the <a href="#" onclick="openVersionSelector(); return false;">version selector</a>
+           for other Zephyr versions.
+         </p>
+
+.. only:: development
+
+   .. admonition:: Welcome to Zephyr Project Documentation for the ``main`` tree (|version|).
+      :class: welcome
+
+      .. raw:: html
+
+         <p>
+           Use the <a href="#" onclick="openVersionSelector(); return false;">version selector</a>
+           for released versions.
+         </p>
+
+.. raw:: html
+   :file: index.html
 
 .. toctree::
    :maxdepth: 1
@@ -109,14 +68,3 @@ licensing, as described in :ref:`Zephyr_Licensing`.
    samples/index.rst
    boards/index.rst
    releases/index.rst
-
-Indices and Tables
-******************
-
-* :ref:`glossary`
-* :ref:`genindex`
-
-.. _Apache 2.0 license:
-   https://github.com/zephyrproject-rtos/zephyr/blob/main/LICENSE
-
-.. _GitHub repo: https://github.com/zephyrproject-rtos/zephyr


### PR DESCRIPTION
https://builds.zephyrproject.io/zephyr/pr/95357/docs/

<img width="2234" height="2895" alt="image" src="https://github.com/user-attachments/assets/fd7cf5ff-d704-43ee-8ac9-92523726b6ae" />

### Problem description

Our documentation is a great source of reference material that—usually and hopefully!—covers independent topics fairly extensively, but people are experiencing a steep learning curve and indicate they have issues knowing where to start when they have a problem to solve.

### Proposed Change (Summary)

Rework our documentation homepage so that we more clearly identify the main areas of interest for folks based on what they are trying to accomplish ; proposing to focus on tasks related to "application development", "hardware porting", and productization.

### Proposed Change (Detailed)

This PR refreshes the Zephyr documentation landing page with a more modern layout and improved navigation:
It introduces persona-based (Application Developer, Hardware Engineer, Product Maker) learning paths and makes reference pages (API, Kconfig, etc) more prominent.

The goal is to make the docs homepage more welcoming and help readers quickly find the most relevant entry points based on what they want to accomplish, while not completely losing folks that might have been using our good ol' tiles since all the shortcuts that are currently accessible from https://docs.zephyrproject.org/latest/ are still there one way or the other in the new proposal.

Note 1: Current implementation is a bunch of boilerplate HTML/CSS/Tailwind but I will clean it up in a second stage once this has enough buy-in from the community.

Probably missing at this point:
- ~~"Contributing" section~~

### Dependencies

None
