### PR TITLE
libc : implement signal()

### DIFF
--- a/lib/libc/common/source/signal/signal.c
+++ b/lib/libc/common/source/signal/signal.c
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ */
+
+#include <errno.h>
+#include <signal.h>
+
+void (*signal(int signum, void (*handler)(int)))(int)
+{
+	ARG_UNUSED(signum);
+	ARG_UNUSED(handler);
+	errno = EINVAL;
+	return SIG_ERR;
+}


### PR DESCRIPTION
Creates implementation stub for signal() using sigaction.