### PR TITLE
soc: xlnx: zynqmp: add nocache memory region support for the RPU

### DIFF
--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -322,6 +322,10 @@ SECTIONS
 
     __data_region_end = .;
 
+#ifdef CONFIG_NOCACHE_MEMORY
+    _nocache_mpu_size_bits = (LOG2CEIL(_nocache_ram_size) - 1) << 1;
+#endif
+
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_ocm), okay)
 GROUP_START(OCM)
 

--- a/soc/xlnx/zynqmp/Kconfig
+++ b/soc/xlnx/zynqmp/Kconfig
@@ -8,4 +8,5 @@ config SOC_XILINX_ZYNQMP_RPU
 	select SOC_RESET_HOOK
 	select SOC_EARLY_INIT_HOOK
 	select CPU_HAS_ARM_MPU
+	select ARM_MPU
 	select VFP_DP_D16


### PR DESCRIPTION
Add nocache memory support for the ZynqMP RPU. The required properties of the R5 CPU in the ZynqMP RPU are already there: the CPU has an ARM MMU and a data cache.

Add a nocache region entry with the corresponding memory attributes if CONFIG_NOCACHE_MEMORY is set, add the region size bits calculation in the arm arch's Cortex-A/-R linker command file. The nocache section itself is set up (aligned and populated, divided into load and noload sub-sections) via the nested inclusion of arch/common/nocache.ld in the Cortex-A/-R linker command file, as the size bits calculation is specific to the ARMv7 arch, perform the calculation in that context.

At the MPU region table level, make sure that the new nocache region as well as all regions that are nested within the outer 'sram' region are prioritized correctly (higher region index = higher priority) so that the memory attributes of the subsets nested within the generic 'sram' region take precedence over those of the outer region.
