### PR TITLE
lora: optional disable CRC

### DIFF
--- a/drivers/lora/lora_basics_modem/lbm_common.c
+++ b/drivers/lora/lora_basics_modem/lbm_common.c
@@ -79,7 +79,7 @@ int lbm_lora_config(const struct device *dev, struct lora_modem_config *lora_con
 			.preamble_len_in_symb = lora_config->preamble_len,
 			.header_type = RAL_LORA_PKT_EXPLICIT,
 			.pld_len_in_bytes = UINT8_MAX,
-			.crc_is_on = true,
+			.crc_is_on = !lora_config->packet_crc_disable,
 			.invert_iq_is_on = lora_config->iq_inverted,
 		},
 		.rf_freq_in_hz = lora_config->frequency,

--- a/drivers/lora/loramac_node/sx12xx_common.c
+++ b/drivers/lora/loramac_node/sx12xx_common.c
@@ -337,6 +337,8 @@ int sx12xx_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user
 int sx12xx_lora_config(const struct device *dev,
 		       struct lora_modem_config *config)
 {
+	bool crc = !config->packet_crc_disable;
+
 	/* Ensure available, decremented after configuration */
 	if (!modem_acquire(&dev_data)) {
 		return -EBUSY;
@@ -351,13 +353,13 @@ int sx12xx_lora_config(const struct device *dev,
 		Radio.SetTxConfig(MODEM_LORA, config->tx_power, 0,
 				  config->bandwidth, config->datarate,
 				  config->coding_rate, config->preamble_len,
-				  false, true, 0, 0, config->iq_inverted, 4000);
+				  false, crc, 0, 0, config->iq_inverted, 4000);
 	} else {
 		/* TODO: Get symbol timeout value from config parameters */
 		Radio.SetRxConfig(MODEM_LORA, config->bandwidth,
 				  config->datarate, config->coding_rate,
 				  0, config->preamble_len, 10, false, 0,
-				  false, 0, 0, config->iq_inverted, true);
+				  crc, false, 0, config->iq_inverted, true);
 	}
 
 	Radio.SetPublicNetwork(config->public_network);

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -123,6 +123,9 @@ struct lora_modem_config {
 	 * interacting with a public network.
 	 */
 	bool public_network;
+
+	/** Set to true to disable the 16-bit payload CRC */
+	bool packet_crc_disable;
 };
 
 /**


### PR DESCRIPTION
Add the option to disable the builtin 16 bit CRC on the LoRa payload.

The conditional is inverted `packet_crc_disable` vs `packet_crc_enable` to maintain the behavior of current applications that do not assign to the variable.