### PR TITLE
lora: optional packet CRC and `lora_airtime`

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -232,6 +232,10 @@ DeviceTree
 Libraries / Subsystems
 **********************
 
+* LoRa/LoRaWAN
+
+   * :c:func:`lora_airtime`
+
 Other notable changes
 *********************
 

--- a/drivers/lora/lora_basics_modem/lbm_common.c
+++ b/drivers/lora/lora_basics_modem/lbm_common.c
@@ -79,7 +79,7 @@ int lbm_lora_config(const struct device *dev, struct lora_modem_config *lora_con
 			.preamble_len_in_symb = lora_config->preamble_len,
 			.header_type = RAL_LORA_PKT_EXPLICIT,
 			.pld_len_in_bytes = UINT8_MAX,
-			.crc_is_on = true,
+			.crc_is_on = !lora_config->packet_crc_disable,
 			.invert_iq_is_on = lora_config->iq_inverted,
 		},
 		.rf_freq_in_hz = lora_config->frequency,

--- a/drivers/lora/loramac_node/sx126x.c
+++ b/drivers/lora/loramac_node/sx126x.c
@@ -465,6 +465,7 @@ static int sx126x_lora_init(const struct device *dev)
 
 static DEVICE_API(lora, sx126x_lora_api) = {
 	.config = sx12xx_lora_config,
+	.airtime = sx12xx_airtime,
 	.send = sx12xx_lora_send,
 	.send_async = sx12xx_lora_send_async,
 	.recv = sx12xx_lora_recv,

--- a/drivers/lora/loramac_node/sx127x.c
+++ b/drivers/lora/loramac_node/sx127x.c
@@ -627,6 +627,7 @@ static int sx127x_lora_init(const struct device *dev)
 
 static DEVICE_API(lora, sx127x_lora_api) = {
 	.config = sx12xx_lora_config,
+	.airtime = sx12xx_airtime,
 	.send = sx12xx_lora_send,
 	.send_async = sx12xx_lora_send_async,
 	.recv = sx12xx_lora_recv,

--- a/drivers/lora/loramac_node/sx12xx_common.c
+++ b/drivers/lora/loramac_node/sx12xx_common.c
@@ -337,6 +337,8 @@ int sx12xx_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user
 int sx12xx_lora_config(const struct device *dev,
 		       struct lora_modem_config *config)
 {
+	bool crc = !config->packet_crc_disable;
+
 	/* Ensure available, decremented after configuration */
 	if (!modem_acquire(&dev_data)) {
 		return -EBUSY;
@@ -351,13 +353,13 @@ int sx12xx_lora_config(const struct device *dev,
 		Radio.SetTxConfig(MODEM_LORA, config->tx_power, 0,
 				  config->bandwidth, config->datarate,
 				  config->coding_rate, config->preamble_len,
-				  false, true, 0, 0, config->iq_inverted, 4000);
+				  false, crc, 0, 0, config->iq_inverted, 4000);
 	} else {
 		/* TODO: Get symbol timeout value from config parameters */
 		Radio.SetRxConfig(MODEM_LORA, config->bandwidth,
 				  config->datarate, config->coding_rate,
 				  0, config->preamble_len, 10, false, 0,
-				  false, 0, 0, config->iq_inverted, true);
+				  crc, false, 0, config->iq_inverted, true);
 	}
 
 	Radio.SetPublicNetwork(config->public_network);

--- a/drivers/lora/loramac_node/sx12xx_common.c
+++ b/drivers/lora/loramac_node/sx12xx_common.c
@@ -192,6 +192,16 @@ static void sx12xx_ev_rx_error(void)
 	}
 }
 
+uint32_t sx12xx_airtime(const struct device *dev, uint32_t data_len)
+{
+	return Radio.TimeOnAir(MODEM_LORA,
+			       dev_data.tx_cfg.bandwidth,
+			       dev_data.tx_cfg.datarate,
+			       dev_data.tx_cfg.coding_rate,
+			       dev_data.tx_cfg.preamble_len,
+			       0, data_len, !dev_data.tx_cfg.packet_crc_disable);
+}
+
 int sx12xx_lora_send(const struct device *dev, uint8_t *data,
 		     uint32_t data_len)
 {
@@ -214,13 +224,8 @@ int sx12xx_lora_send(const struct device *dev, uint8_t *data,
 	}
 
 	/* Calculate expected airtime of the packet */
-	air_time = Radio.TimeOnAir(MODEM_LORA,
-				   dev_data.tx_cfg.bandwidth,
-				   dev_data.tx_cfg.datarate,
-				   dev_data.tx_cfg.coding_rate,
-				   dev_data.tx_cfg.preamble_len,
-				   0, data_len, true);
-	LOG_DBG("Expected air time of %d bytes = %dms", data_len, air_time);
+	air_time = sx12xx_airtime(dev, data_len);
+	LOG_DBG("Expected air time of %u bytes = %u ms", data_len, air_time);
 
 	/* Wait for the packet to finish transmitting.
 	 * Use twice the tx duration to ensure that we are actually detecting

--- a/drivers/lora/loramac_node/sx12xx_common.h
+++ b/drivers/lora/loramac_node/sx12xx_common.h
@@ -31,6 +31,8 @@ int sx12xx_lora_recv(const struct device *dev, uint8_t *data, uint8_t size,
 
 int sx12xx_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user_data);
 
+uint32_t sx12xx_airtime(const struct device *dev, uint32_t data_len);
+
 int sx12xx_lora_config(const struct device *dev,
 		       struct lora_modem_config *config);
 

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -122,6 +122,9 @@ struct lora_modem_config {
 	 * interacting with a public network.
 	 */
 	bool public_network;
+
+	/** Set to true to disable the 16-bit payload CRC */
+	bool packet_crc_disable;
 };
 
 /**

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -152,6 +152,14 @@ typedef int (*lora_api_config)(const struct device *dev,
 			       struct lora_modem_config *config);
 
 /**
+ * @typedef lora_api_airtime()
+ * @brief Callback API for querying packet airtime
+ *
+ * @see lora_airtime() for argument descriptions.
+ */
+typedef uint32_t (*lora_api_airtime)(const struct device *dev, uint32_t data_len);
+
+/**
  * @typedef lora_api_send()
  * @brief Callback API for sending data over LoRa
  *
@@ -201,6 +209,7 @@ typedef int (*lora_api_test_cw)(const struct device *dev, uint32_t frequency,
 
 __subsystem struct lora_driver_api {
 	lora_api_config config;
+	lora_api_airtime airtime;
 	lora_api_send send;
 	lora_api_send_async send_async;
 	lora_api_recv recv;
@@ -225,6 +234,23 @@ static inline int lora_config(const struct device *dev,
 		(const struct lora_driver_api *)dev->api;
 
 	return api->config(dev, config);
+}
+
+/**
+ * @brief Query the airtime of a packet with a given length
+ *
+ * @note Uses the current radio configuration from @ref lora_config
+ *
+ * @param dev       LoRa device
+ * @param data_len  Length of the data
+ * @return Airtime of packet in milliseconds
+ */
+static inline uint32_t lora_airtime(const struct device *dev, uint32_t data_len)
+{
+	const struct lora_driver_api *api =
+		(const struct lora_driver_api *)dev->api;
+
+	return api->airtime(dev, data_len);
 }
 
 /**

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -42,7 +42,7 @@ void lora_receive_cb(const struct device *dev, uint8_t *data, uint16_t size,
 int main(void)
 {
 	const struct device *const lora_dev = DEVICE_DT_GET(DEFAULT_RADIO_NODE);
-	struct lora_modem_config config;
+	struct lora_modem_config config = {0};
 	int ret, len;
 	uint8_t data[MAX_DATA_LEN] = {0};
 	int16_t rssi;

--- a/samples/drivers/lora/send/src/main.c
+++ b/samples/drivers/lora/send/src/main.c
@@ -49,6 +49,8 @@ int main(void)
 		return 0;
 	}
 
+	LOG_INF("Expected packet airtime: %u ms", lora_airtime(lora_dev, MAX_DATA_LEN));
+
 	while (1) {
 		ret = lora_send(lora_dev, data, MAX_DATA_LEN);
 		if (ret < 0) {

--- a/samples/drivers/lora/send/src/main.c
+++ b/samples/drivers/lora/send/src/main.c
@@ -25,7 +25,7 @@ char data[MAX_DATA_LEN] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd', ' '
 int main(void)
 {
 	const struct device *const lora_dev = DEVICE_DT_GET(DEFAULT_RADIO_NODE);
-	struct lora_modem_config config;
+	struct lora_modem_config config = {0};
 	int ret;
 
 	if (!device_is_ready(lora_dev)) {


### PR DESCRIPTION
Add the option to disable the builtin 16 bit CRC on the LoRa payload. The conditional is inverted (`packet_crc_disable` vs `packet_crc_enable`) to maintain the behavior of current applications that do not assign to the variable.


Add a simple function that exposes the airtime of a packet of a given length.