### PR TITLE
uac2: rate limit ops->get_recv_buf error log

### DIFF
--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -378,7 +378,7 @@ static void schedule_iso_out_read(struct usbd_class_data *const c_data,
 	/* Prepare transfer to read audio OUT data from host */
 	data_buf = ctx->ops->get_recv_buf(dev, terminal, mps, ctx->user_data);
 	if (!data_buf) {
-		LOG_ERR("No data buffer for terminal %d", terminal);
+		LOG_ERR_RATELIMIT("No data buffer for terminal %d", terminal);
 		atomic_clear_bit(queued_bits, as_idx);
 		return;
 	}


### PR DESCRIPTION
Rate limit the get_recv_buf() callback from the application to reduce system trash when buffer pressure gets high.