### PR TITLE
logging: backends: Use CMSIS 6 register defines in SWO initialization 

### DIFF
--- a/boards/ambiq/apollo3_evb/apollo3_evb.yaml
+++ b/boards/ambiq/apollo3_evb/apollo3_evb.yaml
@@ -15,6 +15,7 @@ supported:
   - gpio
   - spi
   - i2c
+  - logging
 testing:
   ignore_tags:
     - net

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb.yaml
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb.yaml
@@ -16,6 +16,7 @@ supported:
   - spi
   - i2c
   - mspi
+  - logging
 testing:
   ignore_tags:
     - net

--- a/samples/subsys/logging/logger/arm_itm_swo.overlay
+++ b/samples/subsys/logging/logger/arm_itm_swo.overlay
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&itm {
+	status = "okay";
+};

--- a/samples/subsys/logging/logger/sample.yaml
+++ b/samples/subsys/logging/logger/sample.yaml
@@ -65,3 +65,18 @@ tests:
     harness: keyboard
     extra_configs:
       - CONFIG_USERSPACE=y
+
+  sample.logger.swo:
+    arch_allow: arm
+    platform_allow:
+      - apollo3_evb
+      - apollo3p_evb
+    integration_platforms:
+      - apollo3_evb
+      - apollo3p_evb
+    tags:
+      - logging
+    filter: CONFIG_HAS_SWO
+    extra_args:
+      - EXTRA_CONF_FILE="arm_itm_swo.conf"
+      - DTC_OVERLAY_FILE="arm_itm_swo.overlay"

--- a/subsys/logging/backends/log_backend_swo.c
+++ b/subsys/logging/backends/log_backend_swo.c
@@ -94,23 +94,25 @@ static void log_backend_swo_init(struct log_backend const *const backend)
 {
 	/* Enable DWT and ITM units */
 	CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+#if (__CORTEX_M <= 7U)
 	/* Enable access to ITM registers */
 	ITM->LAR  = 0xC5ACCE55;
+#endif
 	/* Disable stimulus ports ITM_STIM0-ITM_STIM31 */
 	ITM->TER  = 0x0;
 	/* Disable ITM */
 	ITM->TCR  = 0x0;
 	/* Select TPIU encoding protocol */
-	TPI->SPPR = IS_ENABLED(CONFIG_LOG_BACKEND_SWO_PROTOCOL_NRZ) ? 2 : 1;
+	TPIU->SPPR = IS_ENABLED(CONFIG_LOG_BACKEND_SWO_PROTOCOL_NRZ) ? 2 : 1;
 	/* Set SWO baud rate prescaler value: SWO_clk = ref_clock/(ACPR + 1) */
-	TPI->ACPR = SWO_FREQ_DIV - 1;
+	TPIU->ACPR = SWO_FREQ_DIV - 1;
 	/* Enable unprivileged access to ITM stimulus ports */
 	ITM->TPR  = 0x0;
 	/* Configure Debug Watchpoint and Trace */
 	DWT->CTRL &= (DWT_CTRL_POSTPRESET_Msk | DWT_CTRL_POSTINIT_Msk | DWT_CTRL_CYCCNTENA_Msk);
 	DWT->CTRL |= (DWT_CTRL_POSTPRESET_Msk | DWT_CTRL_POSTINIT_Msk);
 	/* Configure Formatter and Flush Control Register */
-	TPI->FFCR = 0x00000100;
+	TPIU->FFCR = 0x00000100;
 	/* Enable ITM, set TraceBusID=1, no local timestamp generation */
 	ITM->TCR  = 0x0001000D;
 	/* Enable stimulus port used by the logger */


### PR DESCRIPTION
Since the Zephyr upstream is using ARM CMSIS 6 now, in logger subsys the SWO initialization which is still using CMSIS 5 registers will trigger compiling issue. This PR adapts the SWO initialization to CMSIS 6 and also creates a test item for building.

> C:/zephyr/subsys/logging/backends/log_backend_swo.c:104:9: error: 'TPI' undeclared (first use in this function); did you mean 'TPIU'?
>   104 |         TPI->SPPR = IS_ENABLED(CONFIG_LOG_BACKEND_SWO_PROTOCOL_NRZ) ? 2 : 1;
>       |         ^~~
>       |         TPIU