### PR TITLE
manifest: update hal_stm32 for DCMIPP fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -245,7 +245,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 465fb02d6e3e09f61d887f8a1a5049cfaf85a19d
+      revision: d3ff6cbee7c3a7162240457c7393d65436305ee5
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update the hal_stm32 in order to provide a DCMIPP HAL fix (HAL_DCMIPP_PIPE_SetConfig).

This is to integrate the HAL_STM32 PR#304
https://github.com/zephyrproject-rtos/hal_stm32/pull/304

(first version with pull/304/head in order to allow full testing)