### PR TITLE
boards: nordic: Arduino SPI high drive strength

### DIFF
--- a/boards/nordic/nrf52833dk/nrf52833dk_nrf52833-pinctrl.dtsi
+++ b/boards/nordic/nrf52833dk/nrf52833dk_nrf52833-pinctrl.dtsi
@@ -129,6 +129,7 @@
 			psels = <NRF_PSEL(SPIM_SCK, 0, 23)>,
 				<NRF_PSEL(SPIM_MISO, 0, 22)>,
 				<NRF_PSEL(SPIM_MOSI, 0, 21)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
 		};
 	};
 

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840-pinctrl.dtsi
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840-pinctrl.dtsi
@@ -175,6 +175,7 @@
 			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
 				<NRF_PSEL(SPIM_MISO, 1, 14)>,
 				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
 		};
 	};
 

--- a/boards/nordic/nrf52dk/nrf52dk_nrf52832-pinctrl.dtsi
+++ b/boards/nordic/nrf52dk/nrf52dk_nrf52832-pinctrl.dtsi
@@ -106,6 +106,7 @@
 			psels = <NRF_PSEL(SPIM_SCK, 0, 25)>,
 				<NRF_PSEL(SPIM_MOSI, 0, 23)>,
 				<NRF_PSEL(SPIM_MISO, 0, 24)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
 		};
 	};
 

--- a/boards/nordic/nrf5340dk/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/nordic/nrf5340dk/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -112,6 +112,7 @@
 			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
 				<NRF_PSEL(SPIM_MISO, 1, 14)>,
 				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
 		};
 	};
 

--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common_pinctrl.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common_pinctrl.dtsi
@@ -108,6 +108,7 @@
 			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
 				<NRF_PSEL(SPIM_MISO, 1, 14)>,
 				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
 		};
 	};
 


### PR DESCRIPTION
All nRF development kits have long traces from the SoC to the Arduino header. Set the drive strength on the SPI ports to high to increase the chances that the default SPI frequency defined in shields works without errors.

This aligns the remaining DKs with the nRF91 DKs.