### PR TITLE
mgmt: hawkbit: Add option to not reboot system after update

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -156,6 +156,12 @@ New APIs and options
     * :c:macro:`LOG_HEXDUMP_INF_RATELIMIT_RATE` - Rate-limited info hexdump macro (explicit rate)
     * :c:macro:`LOG_HEXDUMP_DBG_RATELIMIT_RATE` - Rate-limited debug hexdump macro (explicit rate)
 
+* Management
+
+  * hawkBit
+
+    * :kconfig:option:`CONFIG_HAWKBIT_REBOOT_NONE`
+
 * Power management
 
    * :c:func:`pm_device_driver_deinit`

--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -220,6 +220,11 @@ config HAWKBIT_REBOOT_COLD
 	help
 	  Do a cold reboot after the update.
 
+config HAWKBIT_REBOOT_NONE
+	bool "Don't reboot after update"
+	help
+	  Do not reboot after the update.
+
 endchoice
 
 config HEAP_MEM_POOL_ADD_SIZE_HAWKBIT

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -1209,6 +1209,11 @@ static bool send_request(struct hawkbit_context *hb_context, enum hawkbit_http_r
 void hawkbit_reboot(void)
 {
 	hawkbit_event_raise(HAWKBIT_EVENT_BEFORE_REBOOT);
+
+	if (IS_ENABLED(CONFIG_HAWKBIT_REBOOT_NONE)) {
+		return;
+	}
+
 	LOG_PANIC();
 	sys_reboot(IS_ENABLED(CONFIG_HAWKBIT_REBOOT_COLD) ? SYS_REBOOT_COLD : SYS_REBOOT_WARM);
 }


### PR DESCRIPTION
Some applications might require cleanup prior to performing a system reboot. Add an option that disables hawkbits automatic reboots so that it can be postponed until the application is ready.