### PR TITLE
drivers: rtc: ds3231: fix uninitialized variable error

### DIFF
--- a/drivers/rtc/rtc_ds3231.c
+++ b/drivers/rtc/rtc_ds3231.c
@@ -74,9 +74,6 @@ static int rtc_ds3231_modify_register(const struct device *dev, uint8_t reg, uin
 		og_buf |= *buf;
 		*buf = og_buf;
 	}
-	if (err != 0) {
-		return err;
-	}
 	err = mfd_ds3231_i2c_set_registers(config->mfd, reg, buf, 1);
 	return err;
 }


### PR DESCRIPTION
Until recently this driver wasn't built in CI. Now that it is, clang is complaining about `err` possibly being uninitialized in case `bitmask` is 255. Fix it by actually removing code that was unnecessarily trying to access the uninitialized variable.

https://github.com/zephyrproject-rtos/zephyr/actions/runs/17425581062/job/49471927461

I am also really tempted to make the below just one line but that's probably out of scope for this hotfix :)

```c
		og_buf &= ~bitmask;
		*buf &= bitmask;
		og_buf |= *buf;
		*buf = og_buf;
```