### PR TITLE
tests: drivers: sdhc: remove mimxrt700_evk/mimxrt798s/cm33_cpu0 platform

### DIFF
--- a/tests/drivers/sdhc/testcase.yaml
+++ b/tests/drivers/sdhc/testcase.yaml
@@ -12,3 +12,5 @@ tests:
     tags: sdhc
     integration_platforms:
       - mimxrt1064_evk
+    platform_exclude:
+      - mimxrt700_evk/mimxrt798s/cm33_cpu0


### PR DESCRIPTION
Limited by board design and soc, rt700 sdhc only support 1.8V output and there is no voltage level translators designed on board. So sdhc function on rt700 board can't meet SD3.0 compatible.

Fixes #94997