### PR TITLE
west.yml: Update hal_stm32 with recent cube packages

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -245,7 +245,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 3a4b521441607646ec43bece2c53f333ce7f9b69
+      revision: 2459cda20429a15d4a5eb5ca4140a0c19618f3bf
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Updated hal_stm32 modules:
stm32f4xx to Version 1.28.3
stm32f7xx to Version 1.17.4
stm32mp2xx to Version 1.2.0
stm32u0xx to Version 1.3.0
stm32u3xx to Version 1.2.0
stm32u5xx to Version 1.8.0
stm32wbxx to Version 1.23.0 and its lib/stm32 to version 1.23.0

Refer to the https://github.com/zephyrproject-rtos/hal_stm32/pull/310
