### PR TITLE
dts: arm: st: h7: remove HASH node from H755xx

### DIFF
--- a/dts/arm/st/h7/stm32h755.dtsi
+++ b/dts/arm/st/h7/stm32h755.dtsi
@@ -18,13 +18,5 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
-
-		hash: cryp@48021400 {
-			compatible = "st,stm32-cryp";
-			reg = <0x48021400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
-			interrupts = <80 0>;
-			status = "disabled";
-		};
 	};
 };


### PR DESCRIPTION
~~Fix node name and compatible string for HASH peripheral node in stm32h755 DTSI.~~

Remove the hash node from STM32755x SoC DTSI. The node was broken (wrong node name and compatible property) and seems unused and moreover most STM32H7xx have an HASH peripheral so a proper fix would rather be to add the node to all relevant SoC. This will be done later, if the need arises and after proper validation.
