### PR TITLE
Optimize ambiq mspi controller and misc updates to mspi example

### DIFF
--- a/drivers/flash/flash_mspi_is25xX0xx.c
+++ b/drivers/flash/flash_mspi_is25xX0xx.c
@@ -565,7 +565,7 @@ static int flash_mspi_is25xX0xx_write(const struct device *flash, off_t offset, 
 	int      ret;
 	uint8_t *src = (uint8_t *)wdata;
 	int      i;
-#if CONFIG_FLASH_MSPI_XIP_READ
+#if CONFIG_FLASH_MSPI_HANDLE_CACHE && CONFIG_FLASH_MSPI_XIP_READ
 	off_t  addr = offset;
 	size_t size = len;
 #endif

--- a/drivers/mspi/mspi_ambiq_ap5.c
+++ b/drivers/mspi/mspi_ambiq_ap5.c
@@ -28,6 +28,11 @@ LOG_LEVEL_SET(CONFIG_MSPI_LOG_LEVEL);
 
 #define MSPI_BUSY            BIT(2)
 
+#define MSPI_LOG_HANDLE(mspi_dev)                                                                \
+		COND_CODE_1(CONFIG_LOG,                                                          \
+			(((const struct mspi_ambiq_config *)mspi_dev->config)->log),             \
+			())
+
 typedef int  (*mspi_ambiq_pwr_func_t)(void);
 typedef void (*irq_config_func_t)(void);
 
@@ -96,8 +101,7 @@ static int mspi_set_freq(enum mspi_data_rate data_rate, uint32_t freq)
 
 	switch (freq) {
 	case 125000000:
-		if (data_rate == MSPI_DATA_RATE_S_D_D ||
-		    data_rate == MSPI_DATA_RATE_DUAL) {
+		if (data_rate != MSPI_DATA_RATE_S_S_D) {
 			return AM_HAL_MSPI_CLK_250MHZ;
 		} else {
 			return AM_HAL_MSPI_CLK_INVALID;
@@ -476,8 +480,9 @@ static inline int mspi_verify_device(const struct device      *controller,
 				     const struct mspi_dev_id *dev_id)
 {
 	const struct mspi_ambiq_config *cfg = controller->config;
+
 	int device_index = cfg->mspicfg.num_periph;
-	int ret = 0;
+	int ret          = 0;
 
 	for (int i = 0; i < cfg->mspicfg.num_periph; i++) {
 		if (dev_id->ce.port == cfg->mspicfg.ce_group[i].port &&
@@ -498,67 +503,72 @@ static inline int mspi_verify_device(const struct device      *controller,
 
 static int mspi_ambiq_deinit(const struct device *controller)
 {
-	const struct mspi_ambiq_config *cfg = controller->config;
 	struct mspi_ambiq_data *data = controller->data;
+
 	int ret = 0;
 
 	if (!data->mspiHandle) {
-		LOG_INST_ERR(cfg->log, "%u, the mspi not yet initialized.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, the mspi not yet initialized.",
+							  __LINE__);
 		return -ENODEV;
 	}
 
 	if (k_mutex_lock(&data->lock, K_MSEC(CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE))) {
-		LOG_INST_ERR(cfg->log, "%u, fail to gain controller access.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, fail to gain controller access.",
+							  __LINE__);
 		return -EBUSY;
 	}
 
 	ret = pm_device_runtime_get(controller);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, failed pm_device_runtime_get.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, failed pm_device_runtime_get.",
+							  __LINE__);
 		goto e_deinit_return;
 	}
 
 	ret = pm_device_runtime_disable(controller);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, failed pm_device_runtime_disable.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, failed pm_device_runtime_disable.",
+							  __LINE__);
 		goto e_deinit_return;
 	}
 
 	ret = am_hal_mspi_interrupt_disable(data->mspiHandle, 0xFFFFFFFF);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, fail to disable interrupt, code:%d.",
-			     __LINE__, ret);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, fail to disable interrupt, code:%d.",
+							  __LINE__, ret);
 		ret = -EHOSTDOWN;
 		goto e_deinit_return;
 	}
 
 	ret = am_hal_mspi_interrupt_clear(data->mspiHandle, 0xFFFFFFFF);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, fail to clear interrupt, code:%d.",
-			     __LINE__, ret);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, fail to clear interrupt, code:%d.",
+							  __LINE__, ret);
 		ret = -EHOSTDOWN;
 		goto e_deinit_return;
 	}
 
 	ret = am_hal_mspi_disable(data->mspiHandle);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, fail to disable MSPI, code:%d.",
-			     __LINE__, ret);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, fail to disable MSPI, code:%d.",
+							  __LINE__, ret);
 		ret = -EHOSTDOWN;
 		goto e_deinit_return;
 	}
 
 	ret = am_hal_mspi_power_control(data->mspiHandle, AM_HAL_SYSCTRL_DEEPSLEEP, false);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, fail to power off MSPI, code:%d.",
-			     __LINE__, ret);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, fail to power off MSPI, code:%d.",
+							  __LINE__, ret);
 		ret = -EHOSTDOWN;
 		goto e_deinit_return;
 	}
 
 	ret = am_hal_mspi_deinitialize(data->mspiHandle);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, fail to deinit MSPI.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, fail to deinit MSPI, code:%d.",
+							  __LINE__, ret);
 		ret = -ENODEV;
 		goto e_deinit_return;
 	}
@@ -573,10 +583,10 @@ e_deinit_return:
 static int mspi_xfer_config(const struct device    *controller,
 			    const struct mspi_xfer *xfer)
 {
-	const struct mspi_ambiq_config *cfg = controller->config;
-	struct mspi_ambiq_data *data = controller->data;
-	am_hal_mspi_dev_config_t hal_dev_cfg = data->hal_dev_cfg;
-	am_hal_mspi_request_e eRequest;
+	struct mspi_ambiq_data  *data         = controller->data;
+	am_hal_mspi_dev_config_t hal_dev_cfg  = data->hal_dev_cfg;
+	am_hal_mspi_request_e    eRequest;
+
 	int ret = 0;
 
 	if (data->scramble_cfg.enable) {
@@ -587,15 +597,15 @@ static int mspi_xfer_config(const struct device    *controller,
 
 	ret = am_hal_mspi_disable(data->mspiHandle);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, fail to disable MSPI, code:%d.",
-			     __LINE__, ret);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, fail to disable MSPI, code:%d.",
+							  __LINE__, ret);
 		return -EHOSTDOWN;
 	}
 
 	ret = am_hal_mspi_control(data->mspiHandle, eRequest, NULL);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u,Unable to complete scramble config:%d.",
-			     __LINE__, data->scramble_cfg.enable);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, fail to turn scramble:%d.",
+							  __LINE__, data->scramble_cfg.enable);
 		return -EHOSTDOWN;
 	}
 
@@ -606,7 +616,8 @@ static int mspi_xfer_config(const struct device    *controller,
 		/* TODO - buggy, cmd can not be changed here */
 	}
 	if (cmd_length > AM_HAL_MSPI_INSTR_2_BYTE + 1) {
-		LOG_INST_ERR(cfg->log, "%u, cmd_length is too large.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, cmd_length is too large.",
+							  __LINE__);
 		return -ENOTSUP;
 	}
 	if (cmd_length == 0) {
@@ -617,7 +628,8 @@ static int mspi_xfer_config(const struct device    *controller,
 	}
 
 	if (xfer->addr_length > AM_HAL_MSPI_ADDR_4_BYTE + 1) {
-		LOG_INST_ERR(cfg->log, "%u, addr_length is too large.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, addr_length is too large.",
+							  __LINE__);
 		return -ENOTSUP;
 	}
 	if (xfer->addr_length == 0) {
@@ -636,15 +648,15 @@ static int mspi_xfer_config(const struct device    *controller,
 
 	ret = am_hal_mspi_device_configure(data->mspiHandle, &hal_dev_cfg);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, fail to configure MSPI, code:%d.",
-			     __LINE__, ret);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, fail to configure MSPI, code:%d.",
+							  __LINE__, ret);
 		return -EHOSTDOWN;
 	}
 
 	ret = am_hal_mspi_enable(data->mspiHandle);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, fail to enable MSPI, code:%d.",
-			     __LINE__, ret);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, fail to enable MSPI, code:%d.",
+							  __LINE__, ret);
 		return -EHOSTDOWN;
 	}
 
@@ -652,19 +664,24 @@ static int mspi_xfer_config(const struct device    *controller,
 	return ret;
 }
 
+#ifdef CONFIG_PM_DEVICE
+#define PINCTRL_STATE_START PINCTRL_STATE_PRIV_START
 static int mspi_ambiq_pm_action(const struct device *controller, enum pm_device_action action)
 {
 	const struct mspi_ambiq_config *cfg  = controller->config;
 	struct mspi_ambiq_data         *data = controller->data;
-	int                             ret  = 0;
+
+	int ret = 0;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		/* Set pins to active state */
-		ret = pinctrl_apply_state(cfg->pcfg,
-					  PINCTRL_STATE_PRIV_START + data->dev_id->dev_idx);
-		if (ret < 0) {
-			return ret;
+		if (data->dev_id) {
+			/* Set pins to active state */
+			ret = pinctrl_apply_state(cfg->pcfg,
+						  PINCTRL_STATE_START + data->dev_id->dev_idx);
+			if (ret < 0) {
+				return ret;
+			}
 		}
 		ret = am_hal_mspi_power_control(data->mspiHandle, AM_HAL_SYSCTRL_WAKE, true);
 		if (ret) {
@@ -702,14 +719,17 @@ static int mspi_ambiq_pm_action(const struct device *controller, enum pm_device_
 
 	return ret;
 }
+#else
+#define PINCTRL_STATE_START PINCTRL_STATE_PRIV_START - 1
+#endif
 
 static int mspi_ambiq_config(const struct mspi_dt_spec *spec)
 {
-	const struct mspi_cfg *config = &spec->config;
-	const struct mspi_ambiq_config *cfg = spec->bus->config;
-	struct mspi_ambiq_data *data = spec->bus->data;
-	am_hal_mspi_config_t *hal_cfg = &data->hal_cfg;
-	am_hal_mspi_dqs_t dqs_cfg;
+	const struct mspi_cfg          *config  = &spec->config;
+	const struct mspi_ambiq_config *cfg     = spec->bus->config;
+	struct mspi_ambiq_data         *data    = spec->bus->data;
+	am_hal_mspi_config_t           *hal_cfg = &data->hal_cfg;
+	am_hal_mspi_dqs_t               dqs_cfg;
 
 	int ret = 0;
 
@@ -823,10 +843,11 @@ static int mspi_ambiq_dev_config(const struct device         *controller,
 				 const enum mspi_dev_cfg_mask param_mask,
 				 const struct mspi_dev_cfg   *dev_cfg)
 {
-	const struct mspi_ambiq_config *cfg = controller->config;
-	struct mspi_ambiq_data *data = controller->data;
-	am_hal_mspi_dev_config_t hal_dev_cfg = data->hal_dev_cfg;
-	am_hal_mspi_rxcfg_t hal_rx_cfg = data->hal_rx_cfg;
+	const struct mspi_ambiq_config *cfg         = controller->config;
+	struct mspi_ambiq_data         *data        = controller->data;
+	am_hal_mspi_dev_config_t        hal_dev_cfg = data->hal_dev_cfg;
+	am_hal_mspi_rxcfg_t             hal_rx_cfg  = data->hal_rx_cfg;
+
 	int ret = 0;
 
 	if (data->dev_id != dev_id) {
@@ -839,6 +860,8 @@ static int mspi_ambiq_dev_config(const struct device         *controller,
 		if (ret) {
 			goto e_return;
 		}
+
+		data->dev_id = (struct mspi_dev_id *)dev_id;
 
 		ret = pm_device_runtime_get(controller);
 		if (ret) {
@@ -855,17 +878,9 @@ static int mspi_ambiq_dev_config(const struct device         *controller,
 	if (param_mask == MSPI_DEVICE_CONFIG_NONE &&
 	    !cfg->mspicfg.sw_multi_periph) {
 		/* Do nothing except obtaining the controller lock */
-		data->dev_id = (struct mspi_dev_id *)dev_id;
 		return ret;
 
 	} else if (param_mask != MSPI_DEVICE_CONFIG_ALL) {
-		if (data->dev_id != dev_id) {
-			LOG_INST_ERR(cfg->log, "%u, config failed, must be the same device.",
-				     __LINE__);
-			ret = -EACCES;
-			goto e_return;
-		}
-
 		if ((param_mask & (~(MSPI_DEVICE_CONFIG_FREQUENCY |
 				     MSPI_DEVICE_CONFIG_IO_MODE |
 				     MSPI_DEVICE_CONFIG_CE_NUM |
@@ -1064,7 +1079,7 @@ static int mspi_ambiq_dev_config(const struct device         *controller,
 			ret = am_hal_mspi_control(data->mspiHandle,
 						  AM_HAL_MSPI_REQ_SET_INSTR_ADDR_LEN, &ia_cfg);
 			if (ret) {
-				LOG_INST_ERR(cfg->log, "%u, failed to configure device.",
+				LOG_INST_ERR(cfg->log, "%u, failed to configure addr_length.",
 					     __LINE__);
 				ret = -EHOSTDOWN;
 				goto e_return;
@@ -1100,17 +1115,14 @@ static int mspi_ambiq_dev_config(const struct device         *controller,
 
 	} else {
 
-		if (data->dev_id != dev_id) {
-			ret = pinctrl_apply_state(cfg->pcfg,
-						  PINCTRL_STATE_PRIV_START + dev_id->dev_idx);
-			if (ret) {
-				goto e_return;
-			}
+		ret = pinctrl_apply_state(cfg->pcfg,
+					  PINCTRL_STATE_START + dev_id->dev_idx);
+		if (ret) {
+			goto e_return;
 		}
 
 		if (memcmp(&data->dev_cfg, dev_cfg, sizeof(struct mspi_dev_cfg)) == 0) {
 			/** Nothing to config */
-			data->dev_id = (struct mspi_dev_id *)dev_id;
 			return ret;
 		}
 
@@ -1274,7 +1286,6 @@ static int mspi_ambiq_dev_config(const struct device         *controller,
 			goto e_return;
 		}
 		data->dev_cfg = *dev_cfg;
-		data->dev_id  = (struct mspi_dev_id *)dev_id;
 	}
 	data->hal_dev_cfg = hal_dev_cfg;
 	data->hal_rx_cfg  = hal_rx_cfg;
@@ -1297,7 +1308,8 @@ static int mspi_ambiq_xip_config(const struct device       *controller,
 	struct mspi_ambiq_data         *data = controller->data;
 	am_hal_mspi_request_e           eRequest;
 	am_hal_mspi_xip_config_t        hal_xip_cfg = data->hal_xip_cfg;
-	int                             ret         = 0;
+
+	int ret = 0;
 
 	if (dev_id != data->dev_id) {
 		LOG_INST_ERR(cfg->log, "%u, dev_id don't match.", __LINE__);
@@ -1348,18 +1360,19 @@ static int mspi_ambiq_scramble_config(const struct device            *controller
 				      const struct mspi_dev_id       *dev_id,
 				      const struct mspi_scramble_cfg *scramble_cfg)
 {
-	const struct mspi_ambiq_config *cfg         = controller->config;
-	struct mspi_ambiq_data         *data        = controller->data;
-	am_hal_mspi_xip_config_t        hal_xip_cfg = data->hal_xip_cfg;
-	am_hal_mspi_request_e           eRequest;
-	int                             ret = 0;
+	struct mspi_ambiq_data  *data        = controller->data;
+	am_hal_mspi_xip_config_t hal_xip_cfg = data->hal_xip_cfg;
+	am_hal_mspi_request_e    eRequest;
+
+	int ret = 0;
 
 	if (mspi_is_inp(controller)) {
 		return -EBUSY;
 	}
 
 	if (dev_id != data->dev_id) {
-		LOG_INST_ERR(cfg->log, "%u, dev_id don't match.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, dev_id don't match.",
+							  __LINE__);
 		return -ESTALE;
 	}
 
@@ -1374,15 +1387,16 @@ static int mspi_ambiq_scramble_config(const struct device            *controller
 
 	ret = am_hal_mspi_control(data->mspiHandle, AM_HAL_MSPI_REQ_SCRAMBLE_CONFIG, &hal_xip_cfg);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, fail to configure scramble, code:%d.",
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller),
+			     "%u, fail to configure scramble, code:%d.",
 			     __LINE__, ret);
 		return -EHOSTDOWN;
 	}
 
 	ret = am_hal_mspi_control(data->mspiHandle, eRequest, NULL);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, fail to set scramble enable:%d.",
-			     __LINE__, scramble_cfg->enable);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, fail to set scramble enable:%d.",
+							  __LINE__, scramble_cfg->enable);
 		return -EHOSTDOWN;
 	}
 
@@ -1396,26 +1410,28 @@ static int mspi_ambiq_timing_config(const struct device      *controller,
 				    const uint32_t            param_mask,
 				    void                     *timing_cfg)
 {
-	const struct mspi_ambiq_config *cfg         = controller->config;
-	struct mspi_ambiq_data         *data        = controller->data;
-	am_hal_mspi_dev_config_t        hal_dev_cfg = data->hal_dev_cfg;
-	struct mspi_ambiq_timing_cfg   *time_cfg    = timing_cfg;
-	am_hal_mspi_timing_scan_t       hal_timing  = data->hal_timing;
-	int                             ret         = 0;
+	struct mspi_ambiq_data       *data        = controller->data;
+	am_hal_mspi_dev_config_t      hal_dev_cfg = data->hal_dev_cfg;
+	struct mspi_ambiq_timing_cfg *time_cfg    = timing_cfg;
+	am_hal_mspi_timing_scan_t     hal_timing  = data->hal_timing;
+
+	int ret = 0;
 
 	if (mspi_is_inp(controller)) {
 		return -EBUSY;
 	}
 
 	if (dev_id != data->dev_id) {
-		LOG_INST_ERR(cfg->log, "%u, dev_id don't match.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, dev_id don't match.",
+							  __LINE__);
 		return -ESTALE;
 	}
 
 	if ((param_mask & (~(MSPI_AMBIQ_SET_RLC |
 			     MSPI_AMBIQ_SET_TXDQSDLY |
 			     MSPI_AMBIQ_SET_RXDQSDLY)))) {
-		LOG_INST_ERR(cfg->log, "%u, config type not supported.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, config type not supported.",
+							  __LINE__);
 		return -EINVAL;
 	}
 
@@ -1443,7 +1459,8 @@ static int mspi_ambiq_timing_config(const struct device      *controller,
 	ret = am_hal_mspi_control(data->mspiHandle,
 				  AM_HAL_MSPI_REQ_TIMING_SCAN_SET, &hal_timing);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, fail to configure timing.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, fail to configure timing.",
+							  __LINE__);
 		return -EHOSTDOWN;
 	}
 
@@ -1458,7 +1475,8 @@ static int mspi_ambiq_get_channel_status(const struct device *controller, uint8_
 
 	const struct mspi_ambiq_config *cfg  = controller->config;
 	struct mspi_ambiq_data         *data = controller->data;
-	int                             ret  = 0;
+
+	int ret = 0;
 
 	if (sys_read32(cfg->reg_base) & MSPI_BUSY) {
 		ret = -EBUSY;
@@ -1480,11 +1498,12 @@ static int mspi_ambiq_get_channel_status(const struct device *controller, uint8_
 static void mspi_ambiq_isr(const struct device *dev)
 {
 	struct mspi_ambiq_data *data = dev->data;
-	uint32_t                ui32Status;
 
-	am_hal_mspi_interrupt_status_get(data->mspiHandle, &ui32Status, false);
-	am_hal_mspi_interrupt_clear(data->mspiHandle, ui32Status);
-	am_hal_mspi_interrupt_service(data->mspiHandle, ui32Status);
+	uint32_t status;
+
+	am_hal_mspi_interrupt_status_get(data->mspiHandle, &status, false);
+	am_hal_mspi_interrupt_clear(data->mspiHandle, status);
+	am_hal_mspi_interrupt_service(data->mspiHandle, status);
 }
 
 /** Manage sync dma transceive */
@@ -1499,13 +1518,12 @@ static void hal_mspi_callback(void *pCallbackCtxt, uint32_t status)
 static int mspi_pio_prepare(const struct device        *controller,
 			    am_hal_mspi_pio_transfer_t *trans)
 {
-	const struct mspi_ambiq_config *cfg        = controller->config;
-	struct mspi_ambiq_data         *data       = controller->data;
-	const struct mspi_xfer         *xfer       = &data->ctx.xfer;
-	am_hal_mspi_instr_e             eInstrCfg  = data->hal_dev_cfg.eInstrCfg;
-	am_hal_mspi_addr_e              eAddrCfg   = data->hal_dev_cfg.eAddrCfg;
-	uint8_t                         cmd_length = xfer->cmd_length;
-	int                             ret        = 0;
+	struct mspi_ambiq_data *data       = controller->data;
+	const struct mspi_xfer *xfer       = &data->ctx.xfer;
+	am_hal_mspi_instr_e     eInstrCfg  = data->hal_dev_cfg.eInstrCfg;
+	am_hal_mspi_addr_e      eAddrCfg   = data->hal_dev_cfg.eAddrCfg;
+	uint8_t                 cmd_length = xfer->cmd_length;
+	int                     ret        = 0;
 
 	trans->bScrambling  = false;
 	trans->bSendAddr    = (xfer->addr_length != 0);
@@ -1519,7 +1537,8 @@ static int mspi_pio_prepare(const struct device        *controller,
 		cmd_length *= 2;
 	}
 	if (cmd_length > AM_HAL_MSPI_INSTR_2_BYTE + 1) {
-		LOG_INST_ERR(cfg->log, "%u, invalid cmd_length.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, invalid cmd_length.",
+							  __LINE__);
 		return -ENOTSUP;
 	}
 
@@ -1528,7 +1547,8 @@ static int mspi_pio_prepare(const struct device        *controller,
 	}
 
 	if (xfer->addr_length > AM_HAL_MSPI_ADDR_4_BYTE + 1) {
-		LOG_INST_ERR(cfg->log, "%u, invalid addr_length.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, invalid addr_length.",
+							  __LINE__);
 		return -ENOTSUP;
 	}
 
@@ -1548,7 +1568,9 @@ static int mspi_pio_prepare(const struct device        *controller,
 		ret = am_hal_mspi_control(data->mspiHandle, AM_HAL_MSPI_REQ_SET_INSTR_ADDR_LEN,
 					  &pConfig);
 		if (ret) {
-			LOG_INST_ERR(cfg->log, "%u, failed to configure device.", __LINE__);
+			LOG_INST_ERR(MSPI_LOG_HANDLE(controller),
+				     "%u, failed to set instr/addr length.",
+				     __LINE__);
 			ret = -EHOSTDOWN;
 		}
 
@@ -1566,14 +1588,13 @@ static int mspi_pio_transceive(const struct device          *controller,
 			       mspi_callback_handler_t       cb,
 			       struct mspi_callback_context *cb_ctx)
 {
-	const struct mspi_ambiq_config *cfg  = controller->config;
-	struct mspi_ambiq_data         *data = controller->data;
-	struct mspi_context            *ctx  = &data->ctx;
-	const struct mspi_xfer_packet  *packet;
-	uint32_t                        packet_idx;
-	am_hal_mspi_pio_transfer_t      trans;
-	int                             ret      = 0;
-	int                             cfg_flag = 0;
+	struct mspi_ambiq_data        *data = controller->data;
+	struct mspi_context           *ctx  = &data->ctx;
+	const struct mspi_xfer_packet *packet;
+	uint32_t                       packet_idx;
+	am_hal_mspi_pio_transfer_t     trans;
+	int                            ret      = 0;
+	int                            cfg_flag = 0;
 
 	if (xfer->num_packet == 0 ||
 	    !xfer->packets ||
@@ -1627,7 +1648,9 @@ static int mspi_pio_transceive(const struct device          *controller,
 
 		ret = am_hal_mspi_interrupt_enable(data->mspiHandle, AM_HAL_MSPI_INT_DMACMP);
 		if (ret) {
-			LOG_INST_ERR(cfg->log, "%u, failed to enable interrupt.", __LINE__);
+			LOG_INST_ERR(MSPI_LOG_HANDLE(controller),
+				     "%u, failed to enable interrupt. code:%d",
+				     __LINE__, ret);
 			ret = -EHOSTDOWN;
 			goto pio_err;
 		}
@@ -1681,12 +1704,11 @@ static int mspi_dma_transceive(const struct device          *controller,
 			       mspi_callback_handler_t       cb,
 			       struct mspi_callback_context *cb_ctx)
 {
-	const struct mspi_ambiq_config *cfg  = controller->config;
-	struct mspi_ambiq_data         *data = controller->data;
-	struct mspi_context            *ctx  = &data->ctx;
-	am_hal_mspi_dma_transfer_t      trans;
-	int                             ret      = 0;
-	int                             cfg_flag = 0;
+	struct mspi_ambiq_data    *data = controller->data;
+	struct mspi_context       *ctx  = &data->ctx;
+	am_hal_mspi_dma_transfer_t trans;
+	int                        ret      = 0;
+	int                        cfg_flag = 0;
 
 	if (xfer->num_packet == 0 ||
 	    !xfer->packets ||
@@ -1712,7 +1734,9 @@ static int mspi_dma_transceive(const struct device          *controller,
 
 	ret = am_hal_mspi_interrupt_enable(data->mspiHandle, AM_HAL_MSPI_INT_DMACMP);
 	if (ret) {
-		LOG_INST_ERR(cfg->log, "%u, failed to enable interrupt.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller),
+			     "%u, failed to enable interrupt. code:%d",
+			     __LINE__, ret);
 		ret = -EHOSTDOWN;
 		goto dma_err;
 	}
@@ -1781,13 +1805,13 @@ static int mspi_ambiq_transceive(const struct device      *controller,
 				 const struct mspi_dev_id *dev_id,
 				 const struct mspi_xfer   *xfer)
 {
-	const struct mspi_ambiq_config *cfg    = controller->config;
-	struct mspi_ambiq_data         *data   = controller->data;
-	mspi_callback_handler_t         cb     = NULL;
-	struct mspi_callback_context   *cb_ctx = NULL;
+	struct mspi_ambiq_data       *data   = controller->data;
+	mspi_callback_handler_t       cb     = NULL;
+	struct mspi_callback_context *cb_ctx = NULL;
 
 	if (dev_id != data->dev_id) {
-		LOG_INST_ERR(cfg->log, "%u, dev_id don't match.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, dev_id don't match.",
+							  __LINE__);
 		return -ESTALE;
 	}
 
@@ -1811,7 +1835,6 @@ static int mspi_ambiq_register_callback(const struct device          *controller
 					mspi_callback_handler_t       cb,
 					struct mspi_callback_context *ctx)
 {
-	const struct mspi_ambiq_config *cfg  = controller->config;
 	struct mspi_ambiq_data         *data = controller->data;
 
 	if (mspi_is_inp(controller)) {
@@ -1819,12 +1842,14 @@ static int mspi_ambiq_register_callback(const struct device          *controller
 	}
 
 	if (dev_id != data->dev_id) {
-		LOG_INST_ERR(cfg->log, "%u, dev_id don't match.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, dev_id don't match.",
+							  __LINE__);
 		return -ESTALE;
 	}
 
 	if (evt_type != MSPI_BUS_XFER_COMPLETE) {
-		LOG_INST_ERR(cfg->log, "%u, callback types not supported.", __LINE__);
+		LOG_INST_ERR(MSPI_LOG_HANDLE(controller), "%u, callback types not supported.",
+							  __LINE__);
 		return -ENOTSUP;
 	}
 
@@ -1980,7 +2005,6 @@ static DEVICE_API(mspi, mspi_ambiq_driver_api) = {
 	__attribute__((section(DT_INST_PROP_OR(n, cmdq_buffer_location, ".nocache"))));          \
 	static struct gpio_dt_spec ce_gpios##n[] = MSPI_CE_GPIOS_DT_SPEC_INST_GET(n);            \
 	static struct mspi_ambiq_data mspi_ambiq_data##n = {                                     \
-		.mspiHandle            = NULL,                                                   \
 		.hal_cfg               = MSPI_HAL_CONFIG(n, mspi_ambiq_cmdq##n,                  \
 					 DT_INST_PROP_OR(n, cmdq_buffer_size, 1024)),            \
 		.hal_dev_cfg           = MSPI_HAL_DEVICE_CONFIG(n),                              \
@@ -1988,16 +2012,8 @@ static DEVICE_API(mspi, mspi_ambiq_driver_api) = {
 		.hal_xip_misc_cfg      = MSPI_HAL_XIP_MISC_CONFIG(n),                            \
 		.hal_rx_cfg            = MSPI_HAL_RX_CFG(n),                                     \
 		.hal_dqs_cfg           = MSPI_HAL_DQS_CFG(n),                                    \
-		.dev_id                = 0,                                                      \
 		.lock                  = Z_MUTEX_INITIALIZER(mspi_ambiq_data##n.lock),           \
-		.dev_cfg               = {0},                                                    \
-		.xip_cfg               = {0},                                                    \
-		.scramble_cfg          = {0},                                                    \
-		.cbs                   = {0},                                                    \
-		.cb_ctxs               = {0},                                                    \
 		.ctx.lock              = Z_SEM_INITIALIZER(mspi_ambiq_data##n.ctx.lock, 0, 1),   \
-		.ctx.callback          = 0,                                                      \
-		.ctx.callback_ctx      = 0,                                                      \
 	};                                                                                       \
 	static const struct mspi_ambiq_config mspi_ambiq_config##n = {                           \
 		.reg_base              = DT_INST_REG_ADDR(n),                                    \

--- a/drivers/mspi/mspi_ambiq_timing_scan.c
+++ b/drivers/mspi/mspi_ambiq_timing_scan.c
@@ -493,5 +493,5 @@ int mspi_ambiq_timing_scan(const struct device           *dev,
 		}
 	}
 
-	return ret;
+	return 0;
 }

--- a/samples/drivers/memc/sample.yaml
+++ b/samples/drivers/memc/sample.yaml
@@ -3,9 +3,6 @@ sample:
   name: memc driver sample
 common:
   tags: memc
-  filter: dt_alias_exists("sram-ext")
-  integration_platforms:
-    - mimxrt595_evk/mimxrt595s/cm33
   harness: console
   harness_config:
     type: one_line
@@ -13,4 +10,12 @@ common:
       - "Read data matches written data"
 tests:
   sample.drivers.memc:
-    tags: memc
+    filter: dt_alias_exists("sram-ext")
+    integration_platforms:
+      - mimxrt595_evk/mimxrt595s/cm33
+  sample.drivers.memc.mspi:
+    tags: mspi
+    filter: dt_alias_exists("psram0")
+    integration_platforms:
+      - apollo3p_evb
+      - apollo510_evb

--- a/samples/drivers/mspi/mspi_timing_scan/README.rst
+++ b/samples/drivers/mspi/mspi_timing_scan/README.rst
@@ -20,7 +20,7 @@ They refers to an entry with the following bindings as a compatible:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/mspi/mspi_timing_scan
-   :board: apollo5_eb
+   :board: apollo510_evb
    :goals: build flash
    :compact:
 
@@ -30,6 +30,7 @@ Sample Output
 .. code-block:: console
 
    *** Booting Zephyr OS build zephyr-v3.4.0-27775-g750ed00d564b ***
+   Starting MSPI Timing Scan.
    <inf> mspi_ambiq_timing_scan: TxNeg=0, RxNeg=0, RxCap=0, Turnaround=5
    <inf> mspi_ambiq_timing_scan:     TxDQSDelay: 0, RxDQSDelay Scan = 0x0007FFFE, Window size = 18
    <inf> mspi_ambiq_timing_scan:     TxDQSDelay: 1, RxDQSDelay Scan = 0x0007FFFF, Window size = 19
@@ -44,3 +45,4 @@ Sample Output
    <inf> mspi_ambiq_timing_scan:     TxDQSDelay: 9, RxDQSDelay Scan = 0x00000000, Window size = 0
    <inf> mspi_ambiq_timing_scan:     TxDQSDelay: 10, RxDQSDelay Scan = 0x00000000, Window size = 0
    <inf> mspi_ambiq_timing_scan: Selected setting: TxNeg=0, RxNeg=0, RxCap=0, Turnaround=5,TxDQSDelay=2, RxDQSDelay=9
+   MSPI Timing Scan is successful.

--- a/samples/drivers/mspi/mspi_timing_scan/sample.yaml
+++ b/samples/drivers/mspi/mspi_timing_scan/sample.yaml
@@ -10,9 +10,7 @@ tests:
       type: multi_line
       ordered: true
       regex:
-        - "<inf> mspi_ambiq_timing_scan: TxNeg=0, RxNeg=0, RxCap=0, Turnaround=[0-9]*"
-        - "<inf> mspi_ambiq_timing_scan:     TxDQSDelay: [0-9]*, RxDQSDelay Scan = 0x[0-9]*,(.*)"
-        - "<inf> mspi_ambiq_timing_scan: Selected setting: TxNeg=0, RxNeg=0, RxCap=0, (.*)"
+        - "MSPI Timing Scan is successful."
     platform_allow:
       - apollo510_evb
     integration_platforms:
@@ -34,9 +32,7 @@ tests:
       type: multi_line
       ordered: true
       regex:
-        - "<inf> mspi_ambiq_timing_scan: TxNeg=0, RxNeg=0, RxCap=0, Turnaround=[0-9]*"
-        - "<inf> mspi_ambiq_timing_scan:     TxDQSDelay: [0-9]*, RxDQSDelay Scan = 0x[0-9]*,(.*)"
-        - "<inf> mspi_ambiq_timing_scan: Selected setting: TxNeg=0, RxNeg=0, RxCap=0, (.*)"
+        - "MSPI Timing Scan is successful."
     platform_allow:
       - apollo510_evb
     integration_platforms:

--- a/samples/drivers/mspi/mspi_timing_scan/src/main.c
+++ b/samples/drivers/mspi/mspi_timing_scan/src/main.c
@@ -48,13 +48,13 @@ int main(void)
 	struct mspi_ambiq_timing_scan scan;
 
 	if (!device_is_ready(tar_dev)) {
-		printk("%s: device not ready.\n", tar_dev->name);
+		printf("%s: device not ready.\n", tar_dev->name);
 		return 1;
 	}
 
 #if CONFIG_MEMC_MSPI
 	if (!tar_xip_cfg.enable) {
-		printk("Need to enable XIP for timing scan.\n");
+		printf("Need to enable XIP for timing scan.\n");
 		return 1;
 	}
 #endif
@@ -73,13 +73,13 @@ int main(void)
 				tar_xip_cfg.size / 2;
 #endif
 	scan.min_window       = 6;
-
+	printf("Starting MSPI Timing Scan.\n");
 	if (mspi_ambiq_timing_scan(tar_dev, tar_bus, &dev_id, timing_cfg_mask,
 				   (void *)&tar_timing_cfg, &scan)) {
-		printk("Failed to timing scan\n");
+		printf("Failed to timing scan\n");
 		return 1;
 	}
-
+	printf("MSPI Timing Scan is successful.\n");
 	printf("==========================\n");
 	return 0;
 }


### PR DESCRIPTION
1. optimize ambiq mspi controller and bug fixes
2. fix a potential compiler warning in is25 driver
3. update mspi examples for better CI.