### PR TITLE
Bluetooth: host: adv: revert 39cb574 to fix spurious error log

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1416,7 +1416,7 @@ void bt_le_adv_resume(void)
 	int err;
 
 	if (!adv) {
-		LOG_ERR("No valid legacy adv to resume");
+		LOG_DBG("No valid legacy adv to resume");
 		return;
 	}
 


### PR DESCRIPTION
Commit 39cb574 changed the log level from LOG_DBG to LOG_ERR in bt_le_adv_resume(). This causes the error log
"No valid legacy adv to resume" to appear during normal connection establishment when using bt_le_ext_adv_start(), even though the system is functioning correctly.

Revert the change to restore the original LOG_DBG level.

Fixes: #94954