### PR TITLE
scripts: west_commands: build: Fix warning during rebuild

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -193,21 +193,6 @@ class Build(Forceable):
         # Store legacy -s option locally
         source_dir = self.args.source_dir
         self._parse_remainder(remainder)
-        board, origin = self._find_board()
-        # Parse testcase.yaml or sample.yaml files for additional options.
-        if self.args.test_item:
-            # we get path + testitem
-            item = os.path.basename(self.args.test_item)
-            if self.args.source_dir:
-                test_path = self.args.source_dir
-            else:
-                test_path = os.path.dirname(self.args.test_item)
-            if test_path and os.path.exists(test_path):
-                self.args.source_dir = test_path
-                if not self._parse_test_item(item, board):
-                    self.die("No test metadata found")
-            else:
-                self.die("test item path does not exist")
 
         if source_dir:
             if self.args.source_dir:
@@ -263,6 +248,23 @@ class Build(Forceable):
                     yaml.dump(build_command, f, default_flow_style=False)
             except Exception as e:
                 self.wrn(f'Failed to create info file: {build_info_file},', e)
+
+        board, origin = self._find_board()
+
+        # Parse testcase.yaml or sample.yaml files for additional options.
+        if self.args.test_item:
+            # we get path + testitem
+            item = os.path.basename(self.args.test_item)
+            if self.args.source_dir:
+                test_path = self.args.source_dir
+            else:
+                test_path = os.path.dirname(self.args.test_item)
+            if test_path and os.path.exists(test_path):
+                self.args.source_dir = test_path
+                if not self._parse_test_item(item, board):
+                    self.die("No test metadata found")
+            else:
+                self.die("test item path does not exist")
 
         self._run_cmake(board, origin, self.args.cmake_opts)
         if args.cmake_only:


### PR DESCRIPTION
5718af02c522 introduced a regression where a warning was printed about unknown BOARD when rebuilding. Commit moved _find_board() to an earlier stage and that was failing during the rebuild. Instead of moving board finding earlier we can move parsing of the test_item to the later stage as it is needed only just before running cmake.

This is a regression introduced by https://github.com/zephyrproject-rtos/zephyr/pull/94231