### PR TITLE
tests: mgmt: mcumgr: img_mgmt_slot_info: Fix nRF5340 overlay

### DIFF
--- a/tests/subsys/mgmt/mcumgr/img_mgmt_slot_info/boards/nrf5340dk_nrf5340_cpuapp_dual_slot.overlay
+++ b/tests/subsys/mgmt/mcumgr/img_mgmt_slot_info/boards/nrf5340dk_nrf5340_cpuapp_dual_slot.overlay
@@ -5,8 +5,6 @@
  */
 
 /delete-node/ &boot_partition;
-/delete-node/ &slot0_ns_partition;
-/delete-node/ &slot1_ns_partition;
 /delete-node/ &slot0_partition;
 /delete-node/ &slot1_partition;
 
@@ -20,18 +18,22 @@
 			label = "mcuboot";
 			reg = <0x00000000 0x10000>;
 		};
+
 		slot0_partition: partition@10000 {
 			label = "image-0";
 			reg = <0x00010000 0x40000>;
 		};
+
 		slot1_partition: partition@50000 {
 			label = "image-1";
 			reg = <0x00050000 0x40000>;
 		};
+
 		slot2_partition: partition@90000 {
 			label = "image-2";
 			reg = <0x00090000 0x30000>;
 		};
+
 		slot3_partition: partition@c0000 {
 			label = "image-3";
 			reg = <0x000c0000 0x30000>;


### PR DESCRIPTION
Fixes deleting nodes in the overlay file that no longer exist