### PR TITLE
bluetooth: host a2dp : Fix issue about re_operate after cmd works fail

### DIFF
--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -522,6 +522,12 @@ static int bt_a2dp_set_config_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 	}
 
 	stream = ep->stream;
+	stream->codec_config.len = a2dp->set_config_param.codec_specific_ie_len;
+	memcpy(&stream->codec_config.codec_ie[0],
+	       a2dp->set_config_param.codec_specific_ie,
+	       (a2dp->set_config_param.codec_specific_ie_len > BT_A2DP_MAX_IE_LENGTH
+			? BT_A2DP_MAX_IE_LENGTH
+			: a2dp->set_config_param.codec_specific_ie_len));
 	LOG_DBG("SET CONFIGURATION result:%d", req->status);
 
 	if ((a2dp_cb != NULL) && (a2dp_cb->config_rsp != NULL)) {
@@ -798,7 +804,7 @@ static int bt_a2dp_ctrl_cb(struct bt_avdtp_req *req, bt_a2dp_rsp_cb rsp_cb, bt_a
 
 	stream = ep->stream;
 
-	if (clear_stream) {
+	if (clear_stream && req->status == BT_AVDTP_SUCCESS) {
 		ep->stream = NULL;
 	}
 

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -871,6 +871,7 @@ static void avdtp_process_configuration_cmd(struct bt_avdtp *session, struct net
 
 	if (!reconfig && !err && !avdtp_err_code) {
 		bt_avdtp_set_state(sep, AVDTP_CONFIGURED);
+		sep->session = session;
 	}
 
 	avdtp_sep_unlock(sep);
@@ -903,6 +904,7 @@ static void avdtp_process_configuration_rsp(struct bt_avdtp *session, struct net
 
 	if (req->status == BT_AVDTP_SUCCESS) {
 		avdtp_set_status(req, buf, msg_type);
+		SET_CONF_REQ(req)->sep->session = session;
 	}
 
 	bt_avdtp_clear_req(session);
@@ -1085,6 +1087,7 @@ static void avdtp_start_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8
 	if (msg_type == BT_AVDTP_ACCEPT) {
 		bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_STREAMING);
 	} else if (msg_type == BT_AVDTP_REJECT) {
+		bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_OPEN);
 		avdtp_handle_reject(buf, req);
 	}
 


### PR DESCRIPTION
The cases as follow:
case 1: if peer device reject close cmd, then send close cmd again, it works fail because the ep->stream is NULL.
case 2: if local device set configuration and peer device get configuration, it works fail because local device does not save configuration.