### PR TITLE
dts: st: stm32h7rs: Add fdcan1 and fdcan2 configuration

### DIFF
--- a/boards/st/nucleo_h7s3l8/doc/index.rst
+++ b/boards/st/nucleo_h7s3l8/doc/index.rst
@@ -161,6 +161,7 @@ and a ST morpho connector. Board is configured as follows:
 - LD3 : PB7
 - I2C : PB8, PB9
 - SPI1 NSS/SCK/MISO/MOSI : PD14PA5/PA6/PB5 (Arduino SPI)
+- FDCAN1 RX/TX : PD0, PD1
 
 System Clock
 ------------
@@ -180,6 +181,13 @@ Backup SRAM
 
 In order to test backup SRAM you may want to disconnect VBAT from VDD. You can
 do it by removing ``SB13`` jumper on the back side of the board.
+
+FDCAN
+=====
+
+The Nucleo H7S3L8 board does not have any onboard CAN transceiver. In order to
+use the FDCAN bus on this board, an external CAN bus transceiver must be
+connected to pins PD0 (RX) and PD1 (TX).
 
 Programming and Debugging
 *************************

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -20,6 +20,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,canbus = &fdcan1;
 	};
 
 	leds: leds {
@@ -164,6 +165,14 @@
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&fdcan1 {
+	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
+	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK(APB1_2, 8)>,
+		 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.yaml
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.yaml
@@ -13,4 +13,6 @@ supported:
   - entropy
   - adc
   - octospi
+  - can
+  - canfd
 vendor: st

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -502,6 +502,32 @@
 			status = "disabled";
 		};
 
+		fdcan1: can@4000a000 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a000 0x400>, <0x4000ac00 0x350>;
+			reg-names = "m_can", "message_ram";
+			/* common clock FDCAN 1 & 2 */
+			clocks = <&rcc STM32_CLOCK(APB1_2, 8)>,
+				 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
+			interrupts = <152 0>, <153 0>;
+			interrupt-names = "int0", "int1";
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			status = "disabled";
+		};
+
+		fdcan2: can@4000a400 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a400 0x400>, <0x4000ac00 0x6a0>;
+			reg-names = "m_can", "message_ram";
+			/* common clock FDCAN 1 & 2 */
+			clocks = <&rcc STM32_CLOCK(APB1_2, 8)>,
+				 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
+			interrupts = <154 0>, <155 0>;
+			interrupt-names = "int0", "int1";
+			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			status = "disabled";
+		};
+
 		xspi1: spi@52005000 {
 			compatible = "st,stm32-xspi";
 			reg = <0x52005000 0x1000>, <0x90000000 DT_SIZE_M(256)>;


### PR DESCRIPTION
This PR adds FDCAN support for STM32H7RS series microcontrollers.
As the H7RSx doesn't have the clock calibration unit (CCU) inside the FDCAN peripheral and a different message RAM size compared to H7x, I took the H5x configuration as template for this change. According to the reference manuals, the FDCAN peripheral is the same (except for register addresses, clock source and interrupt numbers). 

## Changes:
SoC support: Add FDCAN1 and FDCAN2 controller configurations for STM32H7RS series
- Includes register addresses, clock sources and interrupt definitions
- Board Support: Add FDCAN1 to NUCLEO_H7S3L8 board. PD0 (RX) and PD1 (TX) are used for interfacing an external CAN transceiver according to the breakout connector description in the board's schematic.

## Clock Configuration:
I added the second (optional) clock to the configuration (called domain clock in the driver), even if the HSE is already the default clock source. But programmers can then see more quickly how they can adjust the clock source.

## Testing Status:
- Tested on NUCLEO-H7S3L8 for FDCAN1 with external Waveshare SN65HVD230 CAN transceiver with samples/drivers/can/babbling.
- Tested on NUCLEO-H7S3L8 for FDCAN2 with external Waveshare SN65HVD230 CAN transceiver with custom board definition and app.
