### PR TITLE
maintainers.yml: litex: promote maass-hamburg to maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3054,9 +3054,9 @@ LiteX Platforms:
     - tgorochowik
     - kgugala
     - fkokosinski
+    - maass-hamburg
   collaborators:
     - mateusz-holenko
-    - maass-hamburg
   files:
     - boards/enjoydigital/litex_vexriscv/
     - drivers/*/*litex*

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3052,10 +3052,10 @@ LiteX Platforms:
   status: maintained
   maintainers:
     - tgorochowik
-    - kgugala
     - fkokosinski
     - maass-hamburg
   collaborators:
+    - kgugala
     - mateusz-holenko
   files:
     - boards/enjoydigital/litex_vexriscv/


### PR DESCRIPTION
promote myself to LiteX maintainer, as most latest changes and driver additions had been done by myself.