### PR TITLE
net: shell: dns: use int type for %.*s format specifier

### DIFF
--- a/subsys/net/lib/shell/dns.c
+++ b/subsys/net/lib/shell/dns.c
@@ -65,7 +65,7 @@ static void dns_result_cb(enum dns_resolve_status status,
 					 info->ai_srv.priority,
 					 info->ai_srv.weight,
 					 info->ai_srv.port,
-					 info->ai_srv.targetlen,
+					 (int)info->ai_srv.targetlen,
 					 info->ai_srv.target);
 				break;
 			}


### PR DESCRIPTION
The `%.*s` format specifier expects an int so cast the size_t targetlen to an int.

Fixes an issue spotted in CI for:

    west twister -p native_sim/native/64 -s sample.net.dns_resolve.mdns

https://github.com/zephyrproject-rtos/zephyr/actions/runs/17429020315/job/49483298603?pr=95310