### PR TITLE
Bluetooth: Controller: In-system profiling and CPU overhead assertions

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -39,6 +39,7 @@
 #include "ll_sw/pdu.h"
 
 #include "ll_sw/lll.h"
+#include "lll/lll_vendor.h"
 #include "lll/lll_adv_types.h"
 #include "ll_sw/lll_adv.h"
 #include "lll/lll_adv_pdu.h"
@@ -8957,13 +8958,14 @@ static void encode_control(struct node_rx_pdu *node_rx,
 
 #if defined(CONFIG_BT_CTLR_PROFILE_ISR)
 	case NODE_RX_TYPE_PROFILE:
-		LOG_INF("l: %u, %u, %u; t: %u, %u, %u; cpu: %u (%u), %u (%u), %u (%u), %u (%u).",
-			pdu_data->profile.lcur, pdu_data->profile.lmin, pdu_data->profile.lmax,
-			pdu_data->profile.cur, pdu_data->profile.min, pdu_data->profile.max,
-			pdu_data->profile.radio, pdu_data->profile.radio_ticks,
-			pdu_data->profile.lll, pdu_data->profile.lll_ticks,
-			pdu_data->profile.ull_high, pdu_data->profile.ull_high_ticks,
-			pdu_data->profile.ull_low, pdu_data->profile.ull_low_ticks);
+		printk("l: %u, %u, %u; t: %u, %u, %u; cpu: %u (%u), %u (%u), %u (%u), %u (%u) %u\n",
+		       pdu_data->profile.lcur, pdu_data->profile.lmin, pdu_data->profile.lmax,
+		       pdu_data->profile.cur, pdu_data->profile.min, pdu_data->profile.max,
+		       pdu_data->profile.radio, pdu_data->profile.radio_ticks,
+		       pdu_data->profile.lll, pdu_data->profile.lll_ticks,
+		       pdu_data->profile.ull_high, pdu_data->profile.ull_high_ticks,
+		       pdu_data->profile.ull_low, pdu_data->profile.ull_low_ticks,
+		       EVENT_OVERHEAD_START_US);
 		return;
 #endif /* CONFIG_BT_CTLR_PROFILE_ISR */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -101,7 +101,9 @@ ISR_DIRECT_DECLARE(radio_nrf5_isr)
 {
 	DEBUG_RADIO_ISR(1);
 
-	lll_prof_enter_radio();
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_enter_radio();
+	}
 
 	isr_radio();
 
@@ -109,7 +111,9 @@ ISR_DIRECT_DECLARE(radio_nrf5_isr)
 	ISR_DIRECT_PM();
 #endif /* !CONFIG_BT_CTLR_ZLI */
 
-	lll_prof_exit_radio();
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_exit_radio();
+	}
 
 	DEBUG_RADIO_ISR(0);
 
@@ -133,7 +137,9 @@ ISR_DIRECT_DECLARE(timer_nrf5_isr)
 {
 	DEBUG_RADIO_ISR(1);
 
-	lll_prof_enter_radio();
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_enter_radio();
+	}
 
 	isr_radio_tmr();
 
@@ -141,7 +147,9 @@ ISR_DIRECT_DECLARE(timer_nrf5_isr)
 	ISR_DIRECT_PM();
 #endif /* !CONFIG_BT_CTLR_ZLI */
 
-	lll_prof_exit_radio();
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_exit_radio();
+	}
 
 	DEBUG_RADIO_ISR(0);
 
@@ -160,7 +168,9 @@ static void rtc0_nrf5_isr(const void *arg)
 {
 	DEBUG_TICKER_ISR(1);
 
-	lll_prof_enter_ull_high();
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_enter_ull_high();
+	}
 
 	/* On compare0 run ticker worker instance0 */
 #if defined(CONFIG_BT_CTLR_NRF_GRTC)
@@ -176,15 +186,21 @@ static void rtc0_nrf5_isr(const void *arg)
 
 	mayfly_run(TICKER_USER_ID_ULL_HIGH);
 
-	lll_prof_exit_ull_high();
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_exit_ull_high();
+	}
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT) && \
 	(CONFIG_BT_CTLR_ULL_HIGH_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)
-	lll_prof_enter_ull_low();
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_enter_ull_low();
+	}
 
 	mayfly_run(TICKER_USER_ID_ULL_LOW);
 
-	lll_prof_exit_ull_low();
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_exit_ull_low();
+	}
 #endif
 
 	DEBUG_TICKER_ISR(0);
@@ -194,11 +210,15 @@ static void swi_lll_nrf5_isr(const void *arg)
 {
 	DEBUG_RADIO_ISR(1);
 
-	lll_prof_enter_lll();
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_enter_lll();
+	}
 
 	mayfly_run(TICKER_USER_ID_LLL);
 
-	lll_prof_exit_lll();
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_exit_lll();
+	}
 
 	DEBUG_RADIO_ISR(0);
 }
@@ -209,11 +229,15 @@ static void swi_ull_low_nrf5_isr(const void *arg)
 {
 	DEBUG_TICKER_JOB(1);
 
-	lll_prof_enter_ull_low();
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_enter_ull_low();
+	}
 
 	mayfly_run(TICKER_USER_ID_ULL_LOW);
 
-	lll_prof_exit_ull_low();
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_exit_ull_low();
+	}
 
 	DEBUG_TICKER_JOB(0);
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -726,11 +726,6 @@ static void isr_rx(void *param)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-		lll_prof_cputime_capture();
-		lll_prof_send();
-	}
-
 isr_rx_do_close:
 	radio_isr_set(isr_done, param);
 	radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -677,10 +677,6 @@ static void isr_tx_common(void *param,
 		radio_isr_set(isr_done, lll);
 		radio_disable();
 
-		if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-			lll_prof_send();
-		}
-
 		return;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof_internal.h
@@ -4,30 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if defined(CONFIG_BT_CTLR_PROFILE_ISR)
 void lll_prof_enter_radio(void);
 void lll_prof_exit_radio(void);
+uint16_t lll_prof_radio_get(void);
 void lll_prof_enter_lll(void);
 void lll_prof_exit_lll(void);
+uint16_t lll_prof_lll_get(void);
 void lll_prof_enter_ull_high(void);
 void lll_prof_exit_ull_high(void);
+uint16_t lll_prof_ull_high_get(void);
 void lll_prof_enter_ull_low(void);
 void lll_prof_exit_ull_low(void);
-#else
-static inline void lll_prof_enter_radio(void) {}
-static inline void lll_prof_exit_radio(void) {}
-static inline void lll_prof_enter_lll(void) {}
-static inline void lll_prof_exit_lll(void) {}
-static inline void lll_prof_enter_ull_high(void) {}
-static inline void lll_prof_exit_ull_high(void) {}
-static inline void lll_prof_enter_ull_low(void) {}
-static inline void lll_prof_exit_ull_low(void) {}
-#endif
+uint16_t lll_prof_ull_low_get(void);
 
 void lll_prof_latency_capture(void);
 uint16_t lll_prof_latency_get(void);
 void lll_prof_radio_end_backup(void);
 void lll_prof_cputime_capture(void);
+uint16_t lll_prof_cputime_get(void);
 void lll_prof_send(void);
 struct node_rx_pdu *lll_prof_reserve(void);
 void lll_prof_reserve_send(struct node_rx_pdu *rx);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -503,10 +503,6 @@ static void isr_rx_estab(void *param)
 	uint8_t trx_done;
 	uint8_t crc_ok;
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-		lll_prof_latency_capture();
-	}
-
 	/* Read radio status and events */
 	trx_done = radio_is_done();
 	if (trx_done) {
@@ -549,10 +545,6 @@ static void isr_rx_estab(void *param)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-		lll_prof_cputime_capture();
-	}
-
 	/* Calculate and place the drift information in done event */
 	e = ull_event_done_extra_get();
 	LL_ASSERT_ERR(e);
@@ -575,10 +567,6 @@ static void isr_rx_estab(void *param)
 	}
 
 	lll_isr_cleanup(param);
-
-	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-		lll_prof_send();
-	}
 }
 
 static void isr_rx(void *param)
@@ -773,10 +761,6 @@ static void isr_rx(void *param)
 	}
 
 isr_rx_done:
-	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-		lll_prof_cputime_capture();
-	}
-
 	uint8_t bis_idx_old = bis_idx;
 
 	new_burst = 0U;
@@ -1176,10 +1160,6 @@ isr_rx_ctrl:
 isr_rx_mic_failure:
 	isr_rx_done(param);
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-		lll_prof_send();
-	}
-
 	return;
 
 isr_rx_next_subevent:
@@ -1451,7 +1431,7 @@ isr_rx_next_subevent:
 		LL_ASSERT_DBG(false);
 	}
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR) && (trx_done != 0U)) {
 		lll_prof_send();
 	}
 }
@@ -1605,21 +1585,9 @@ isr_done_cleanup:
 
 static void isr_done(void *param)
 {
-	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-		lll_prof_latency_capture();
-	}
-
 	lll_isr_status_reset();
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-		lll_prof_cputime_capture();
-	}
-
 	isr_rx_done(param);
-
-	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-		lll_prof_send();
-	}
 }
 
 static uint16_t payload_index_get(const struct lll_sync_iso *lll)

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -88,6 +88,12 @@
 
 #include "hal/debug.h"
 
+#define TEST_TICKER_NODES         (TICKER_NODES)
+#define TEST_TICKER_TICKS_SLOT_US 100000U
+#define TEST_TICKER_INTERVAL_US   (((TEST_TICKER_TICKS_SLOT_US) + \
+				    (HAL_TICKER_RESCHEDULE_MARGIN_US)) * \
+				   (TEST_TICKER_NODES))
+
 #if defined(CONFIG_BT_BROADCASTER)
 #define BT_ADV_TICKER_NODES ((TICKER_ID_ADV_LAST) - (TICKER_ID_ADV_STOP) + 1)
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && (CONFIG_BT_CTLR_ADV_AUX_SET > 0)
@@ -555,6 +561,15 @@ static MFIFO_DEFINE(tx_ack, sizeof(struct lll_tx),
 
 static void *mark_disable;
 
+#if defined(CONFIG_BT_CTLR_TEST)
+static struct k_sem sem_test_ticker;
+static void test_ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift, uint32_t remainder,
+			   uint16_t lazy, uint8_t force, void *context);
+#if defined(CONFIG_BT_TICKER_EXT)
+static struct ticker_ext test_ticker_ext[TEST_TICKER_NODES];
+#endif /* CONFIG_BT_TICKER_EXT */
+#endif /* CONFIG_BT_CTLR_TEST */
+
 static inline int init_reset(void);
 static void perform_lll_reset(void *param);
 static inline void *mark_set(void **m, void *param);
@@ -778,6 +793,59 @@ int ll_init(struct k_sem *sem_rx)
 	err = ecb_ut();
 	if (err) {
 		return err;
+	}
+
+	k_sem_init(&sem_test_ticker, 0, TEST_TICKER_NODES);
+
+	const uint32_t ticks_now = ticker_ticks_now_get();
+
+	for (uint8_t ticker_id = 0U; ticker_id < TEST_TICKER_NODES; ticker_id++) {
+		uint32_t ret;
+
+#if defined(CONFIG_BT_TICKER_EXT)
+#if !defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+		test_ticker_ext[ticker_id].ticks_slot_window =
+			HAL_TICKER_US_TO_TICKS((TEST_TICKER_INTERVAL_US) +
+						(TEST_TICKER_TICKS_SLOT_US));
+#endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
+
+		ret = ticker_start_ext(
+#else /* !CONFIG_BT_TICKER_EXT */
+		ret = ticker_start(
+#endif /* !CONFIG_BT_TICKER_EXT */
+			  TICKER_INSTANCE_ID_CTLR /* instance */
+			, TICKER_USER_ID_THREAD /* user */
+			, ticker_id /* ticker id */
+			, ticks_now /* anchor point */
+			, HAL_TICKER_US_TO_TICKS(TEST_TICKER_INTERVAL_US) /* first interval */
+			, HAL_TICKER_US_TO_TICKS(TEST_TICKER_INTERVAL_US) /* periodic interval */
+			, HAL_TICKER_REMAINDER(TEST_TICKER_INTERVAL_US) /* remainder */
+			, 0 /* lazy */
+			, HAL_TICKER_US_TO_TICKS(TEST_TICKER_TICKS_SLOT_US) /* slot */
+			, test_ticker_cb /* timeout callback function */
+			, (void *)(uint32_t)ticker_id /* context */
+			, 0 /* op func */
+			, 0 /* op context */
+#if defined(CONFIG_BT_TICKER_EXT)
+			, &test_ticker_ext[ticker_id]
+#endif /* CONFIG_BT_TICKER_EXT */
+			);
+		LL_ASSERT_ERR(ret == TICKER_STATUS_SUCCESS);
+	}
+
+	for (uint8_t ticker_id = 0U; ticker_id < TEST_TICKER_NODES; ticker_id++) {
+		k_sem_take(&sem_test_ticker, K_FOREVER);
+	}
+
+	for (uint8_t ticker_id = 0U; ticker_id < TEST_TICKER_NODES; ticker_id++) {
+		uint32_t ret;
+
+		ret = ticker_stop(TICKER_INSTANCE_ID_CTLR,
+				  TICKER_USER_ID_THREAD,
+				  ticker_id,
+				  NULL,
+				  NULL);
+		LL_ASSERT_ERR(ret == TICKER_STATUS_SUCCESS);
 	}
 
 #if defined(CONFIG_BT_CTLR_CHAN_SEL_2)
@@ -2377,6 +2445,14 @@ void ull_drift_ticks_get(struct node_rx_event_done *done,
 	}
 }
 #endif /* CONFIG_BT_PERIPHERAL || CONFIG_BT_CTLR_SYNC_PERIODIC */
+
+#if defined(CONFIG_BT_CTLR_TEST)
+static void test_ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift, uint32_t remainder,
+			   uint16_t lazy, uint8_t force, void *context)
+{
+	k_sem_give(&sem_test_ticker);
+}
+#endif /* CONFIG_BT_CTLR_TEST */
 
 static inline int init_reset(void)
 {


### PR DESCRIPTION
Updated in-system profiling for CPU usage with on target
measurements and added assertion checks.

Add in-system ticker_start and ticker_stop tests.

There is significant improved lower CPU use in Radio ISR (**2 ticks less**)and LLL ISR (**3 ticks less**) execution context when experimental LLL pipeline using ordered linked list is used (`nrf52833dk/nrf52833`), using:
* PR: https://github.com/zephyrproject-rtos/zephyr/pull/79444
* Commit: https://github.com/zephyrproject-rtos/zephyr/pull/79444/commits/d5aea11ee2cc7564b42b5f94698d27b56e4418da

```
[2025-10-11 07:41:49.567] l: 10, 3, 57; t: 7, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.573] l: 4, 3, 57; t: 24, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.579] 29787. [DEVICE]: 1C:2B:44:E1:A3:61 (random), AD evt type 5, Tx Pwr: 127, RSSI -34 Data status: 0, AD data len: 382 Name: Broadcaster Multipl$ C:0 S:0 D:0 SR:0 E:1 Pri PHY: LE 1M, Sec PHY: LE 2M, Interval: 0x0000 (0 ms), SID: 1
[2025-10-11 07:41:49.602] l: 8, 3, 57; t: 10, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.609] --- 1 messages dropped ---
[2025-10-11 07:41:49.612] l: 14, 3, 57; t: 10, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.618] l: 10, 3, 57; t: 15, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.625] l: 10, 3, 57; t: 7, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.631] l: 10, 3, 57; t: 13, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.637] l: 10, 3, 57; t: 15, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.643] l: 10, 3, 57; t: 7, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.650] l: 14, 3, 57; t: 15, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.657] l: 14, 3, 57; t: 7, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.663] l: 10, 3, 57; t: 15, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.669] l: 10, 3, 57; t: 7, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.677] l: 8, 3, 57; t: 10, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.684] l: 10, 3, 57; t: 10, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.690] l: 10, 3, 57; t: 15, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.698] l: 10, 3, 57; t: 7, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.705] l: 10, 3, 57; t: 13, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.711] l: 10, 3, 57; t: 15, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.717] l: 10, 3, 57; t: 7, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.723] l: 14, 3, 57; t: 14, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.730] l: 14, 3, 57; t: 16, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.736] l: 14, 3, 57; t: 7, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.742] l: 10, 3, 57; t: 15, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.749] l: 10, 3, 57; t: 7, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.756] l: 4, 3, 57; t: 24, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.764] 29788. [DEVICE]: 10:7C:45:1F:59:C4 (random), AD evt type 5, Tx Pwr: 127, RSSI -79 Data status: 0, AD data len: 382 Name: Broadcaster Multipl$ C:0 S:0 D:0 SR:0 E:1 Pri PHY: LE Coded, Sec PHY: LE Coded, Interval: 0x0000 (0 ms), SID: 3
[2025-10-11 07:41:49.787] l: 10, 3, 57; t: 10, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.793] l: 10, 3, 57; t: 15, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.801] l: 10, 3, 57; t: 7, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.808] l: 10, 3, 57; t: 13, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.814] l: 14, 3, 57; t: 16, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.820] l: 14, 3, 57; t: 7, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.826] l: 14, 3, 57; t: 14, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.832] l: 14, 3, 57; t: 16, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.838] l: 14, 3, 57; t: 7, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.845] l: 10, 3, 57; t: 15, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
[2025-10-11 07:41:49.851] l: 15, 3, 57; t: 15, 6, 27; cpu: 36 (3), 101 (4), 149 (8), 318 (12).
```

Comparing without that improvement:
```
[2025-10-11 07:25:09.850] --- 1 messages dropped ---
[2025-10-11 07:25:09.853] 903128. [DEVICE]: 3F:9D:0C:F1:F0:FB (random), AD evt type 5, Tx Pwr: 127, RSSI -32 Data status: 0, AD data len: 191 Name:  C:0 S:0 D:0 SR:0 E:1 Pri PHY: LE 1M, Sec PHY: LE 1M, Interval: 0x0000 (0 ms), SID: 2
[2025-10-11 07:25:09.873] --- 1 messages dropped ---
[2025-10-11 07:25:09.877] l: 14, 3, 103; t: 14, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:09.883] l: 14, 3, 103; t: 7, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:09.890] l: 10, 3, 103; t: 14, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:09.897] l: 10, 3, 103; t: 7, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:09.904] l: 10, 3, 103; t: 13, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:09.912] l: 57880, 21790, 10636; t: 6657, 65293, 76; cpu: 2070 (138), 53760 (40), 33769 (12), 47734 (14).
[2025-10-11 07:25:09.920] l: 58120, 25896, 103; t: 24, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:09.929] l: 9, 3, 103; t: 15, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:09.937] l: 10, 3, 103; t: 7, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:09.943] l: 4, 3, 103; t: 24, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:09.949] 903129. [DEVICE]: 20:FD:03:3A:F8:30 (random), AD evt type 5, Tx Pwr: 127, RSSI -33 Data status: 0, AD data len: 192 Name: Broadcaster Multiple C:0 S:0 D:0 SR:0 E:1 Pri PHY: LE Coded, Sec PHY: LE Coded, Interval: 0x0000 (0 ms), SID: 3
[2025-10-11 07:25:09.974] --- 8 messages dropped ---
[2025-10-11 07:25:09.977] l: 3, 3, 103; t: 22, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:09.984] l: 10, 3, 103; t: 13, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:09.990] l: 41992, 25916, 103; t: 7, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:09.997] l: 42008, 22076, 19353; t: 1537, 1809, 50459; cpu: 42453 (164), 2 (198), 47017 (0), 4578 (254).
[2025-10-11 07:25:10.006] 903131. [DEVICE]: 75:46:E3:01:22:0D (random), AD evt type 0, Tx Pwr: 127, RSSI -86 Data status: 0, AD data len: 18 Name:  C:1 S:1 D:0 SR:0 E:0 Pri PHY: LE 1M, Sec PHY: No packets, Interval: 0x0000 (0 ms), SID: 255
[2025-10-11 07:25:10.027] l: 3, 3, 103; t: 22, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.034] l: 10, 3, 103; t: 14, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.042] l: 10, 3, 103; t: 7, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.049] l: 4, 3, 103; t: 24, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.055] l: 14, 3, 103; t: 14, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.061] l: 14, 3, 103; t: 7, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.069] l: 10, 3, 103; t: 14, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.076] l: 10, 3, 103; t: 7, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.082] l: 8, 3, 103; t: 10, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.088] l: 10, 3, 103; t: 10, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.095] l: 14, 3, 103; t: 10, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.101] l: 10, 3, 103; t: 13, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.107] l: 41992, 25916, 103; t: 24, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.116] l: 12313, 15096, 64771; t: 42016, 18236, 16853; cpu: 65449 (0), 65535 (0), 0 (0), 0 (0).
[2025-10-11 07:25:10.125] l: 9, 3, 103; t: 8, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.133] l: 4, 3, 103; t: 24, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.140] 903132. [DEVICE]: 3F:9D:0C:F1:F0:FB (random), AD evt type 5, Tx Pwr: 127, RSSI -32 Data status: 0, AD data len: 192 Name: Broadcaster Multiple C:0 S:0 D:0 SR:0 E:1 Pri PHY: LE 1M, Sec PHY: LE 1M, Interval: 0x0000 (0 ms), SID: 2
[2025-10-11 07:25:10.163] --- 2 messages dropped ---
[2025-10-11 07:25:10.166] l: 18, 3, 103; t: 15, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.173] --- 1 messages dropped ---
[2025-10-11 07:25:10.178] l: 8, 3, 103; t: 9, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).
[2025-10-11 07:25:10.185] --- 4 messages dropped ---
[2025-10-11 07:25:10.188] l: 10, 3, 103; t: 10, 6, 26; cpu: 39 (5), 208 (7), 242 (12), 322 (14).

```


2025-10-13 (with ordered linked list use for LLL pipeline):

```
[2025-10-13 06:08:04.038] Starting Observer Broadcaster Demo
[2025-10-13 06:08:04.042] Thread analyze:
[2025-10-13 06:08:04.043]  BT RX WQ            : STACK: unused 1016 usage 184 / 1200 (15 %); CPU: 0 %
[2025-10-13 06:08:04.050]                      : Total CPU cycles used: 8
[2025-10-13 06:08:04.054]  thread_analyzer     : STACK: unused 720 usage 304 / 1024 (29 %); CPU: 2 %
[2025-10-13 06:08:04.061]                      : Total CPU cycles used: 191
[2025-10-13 06:08:04.065]  sysworkq            : STACK: unused 840 usage 184 / 1024 (17 %); CPU: 0 %
[2025-10-13 06:08:04.072]                      : Total CPU cycles used: 10
[2025-10-13 06:08:04.076]  logging             : STACK: unused 368 usage 400 / 768 (52 %); CPU: 85 %
[2025-10-13 06:08:04.083]                      : Total CPU cycles used: 8201
[2025-10-13 06:08:04.087]  idle                : STACK: unused 272 usage 48 / 320 (15 %); CPU: 0 %
[2025-10-13 06:08:04.094]                      : Total CPU cycles used: 0
[2025-10-13 06:08:04.098]  main                : STACK: unused 336 usage 688 / 1024 (67 %); CPU: 10 %
[2025-10-13 06:08:04.105]                      : Total CPU cycles used: 1046
[2025-10-13 06:08:04.109]  ISR0                : STACK: unused 1752 usage 296 / 2048 (14 %)
[2025-10-13 06:08:06.536] test_ticker_cb: 0/16 at 1604878 + 0 + 37 us (ULL_LOW 26 us)
[2025-10-13 06:08:06.541] test_ticker_cb: 1/16 at 1705028 + 100150 + 24 us (ULL_LOW 141 us)
[2025-10-13 06:08:06.547] test_ticker_cb: 2/16 at 1805178 + 200300 + 24 us (ULL_LOW 141 us)
[2025-10-13 06:08:06.553] test_ticker_cb: 3/16 at 1905328 + 300450 + 24 us (ULL_LOW 141 us)
[2025-10-13 06:08:06.559] test_ticker_cb: 4/16 at 2005478 + 400600 + 24 us (ULL_LOW 141 us)
[2025-10-13 06:08:06.565] test_ticker_cb: 5/16 at 2105628 + 500750 + 24 us (ULL_LOW 141 us)
[2025-10-13 06:08:06.570] test_ticker_cb: 6/16 at 2205778 + 600900 + 24 us (ULL_LOW 141 us)
[2025-10-13 06:08:06.576] test_ticker_cb: 7/16 at 2305928 + 701050 + 24 us (ULL_LOW 141 us)
[2025-10-13 06:08:06.582] test_ticker_cb: 8/16 at 2406078 + 801200 + 24 us (ULL_LOW 141 us)
[2025-10-13 06:08:06.588] test_ticker_cb: 9/16 at 2506228 + 901350 + 24 us (ULL_LOW 141 us)
[2025-10-13 06:08:07.143] test_ticker_cb: 10/16 at 2606378 + 1001500 + 26 us (ULL_LOW 141 us)
[2025-10-13 06:08:07.150] --- 6 messages dropped ---
[2025-10-13 06:08:07.153] [00:00:03.108,914] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[2025-10-13 06:08:07.161] [00:00:03.108,925] <inf> bt_hci_core: HW Variant: nRF54Lx (0x0005)
[2025-10-13 06:08:07.168] [00:00:03.108,935] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 4.2 Build 99
[2025-10-13 06:08:07.178] [00:00:03.109,314] <inf> bt_hci_core: HCI transport: Controller
[2025-10-13 06:08:07.184] [00:00:03.109,359] <inf> bt_hci_core: Identity: FB:32:82:2B:02:5B (random)
[2025-10-13 06:08:07.191] [00:00:03.109,371] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[2025-10-13 06:08:07.201] [00:00:03.109,382] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
[2025-10-13 06:08:07.208] Started Extended Advertising Set 0.
[2025-10-13 06:08:07.211] Started Extended Advertising Set 1.
[2025-10-13 06:08:07.214] Started Extended Advertising Set 2.
[2025-10-13 06:08:07.218] Started Extended Advertising Set 3.
[2025-10-13 06:08:07.221] Registered scan callbacks
[2025-10-13 06:08:07.223] Starting scanning...
[2025-10-13 06:08:07.225] success.
[2025-10-13 06:08:07.226] Stopping scanning...
[2025-10-13 06:08:07.228] Stopped scanning...
[2025-10-13 06:08:07.230] Starting scanning...
[2025-10-13 06:08:07.232] success.
[2025-10-13 06:08:07.233] l: 10, 10, 10; t: 9, 9, 9; cpu: 0 (0), 0 (36), 0 (76), 0 (141).
[2025-10-13 06:08:07.238] l: 10, 10, 10; t: 8, 8, 9; cpu: 22 (23), 0 (36), 17 (76), 28 (141).
[2025-10-13 06:08:07.245] l: 10, 10, 10; t: 4, 4, 9; cpu: 22 (23), 0 (36), 17 (76), 28 (141).
[2025-10-13 06:08:07.251] l: 7, 7, 10; t: 7, 4, 9; cpu: 22 (51), 0 (36), 17 (76), 28 (141).
[2025-10-13 06:08:07.258] l: 10, 7, 10; t: 8, 4, 9; cpu: 22 (51), 10 (36), 31 (76), 28 (141).
[2025-10-13 06:08:07.264] l: 9, 7, 10; t: 4, 4, 9; cpu: 22 (51), 10 (36), 31 (76), 28 (141).
[2025-10-13 06:08:07.271] l: 9, 7, 10; t: 8, 4, 9; cpu: 22 (52), 17 (36), 51 (80), 88 (141).
```

**Initial Latencies**
`[2025-10-13 06:08:06.536] test_ticker_cb: 0/16 at 1604878 + 0 + 37 us (ULL_LOW 26 us)`
Scheduling 16 ticker nodes in the future, max. ULL_LOW CPU use: **26 us**
Max. latency resolving 16 overlaps at first expiry: **37 us**
Of which, ISR Latency with CPU wake up: **10 us**

**Rescheduling overlap**
`[2025-10-13 06:08:06.541] test_ticker_cb: 1/16 at 1705028 + 100150 + 24 us (ULL_LOW 141 us)`
Reschedule one amongst 16 ticker nodes, max. ULL_LOW CPU use: **141 us**
Max. latency resolving (16 - n) on subsequent overlaps on expiry: **24 us**

**Radio ISR Latency**
```
[2025-10-13 06:40:57.801] l: 10, 1, 56; t: 7, 3, 27; cpu: 64 (67), 55 (56), 84 (144), 168 (178).
[2025-10-13 06:40:57.808] l: 13, 1, 56; t: 7, 3, 27; cpu: 64 (67), 55 (56), 84 (144), 168 (178).
[2025-10-13 06:40:57.814] l: 12, 1, 56; t: 4, 3, 27; cpu: 64 (67), 55 (56), 84 (144), 168 (178).
[2025-10-13 06:40:57.852] l: 36, 1, 56; t: 7, 3, 27; cpu: 64 (67), 55 (56), 84 (144), 168 (178).
[2025-10-13 06:40:57.859] l: 34, 1, 56; t: 7, 3, 27; cpu: 64 (67), 55 (56), 84 (144), 168 (178).
[2025-10-13 06:40:57.865] l: 37, 1, 56; t: 7, 3, 27; cpu: 64 (67), 55 (56), 84 (144), 168 (178).
[2025-10-13 06:40:57.871] l: 28, 1, 56; t: 7, 3, 27; cpu: 64 (67), 55 (56), 84 (144), 168 (178).
[2025-10-13 06:40:57.878] l: 24, 1, 56; t: 8, 3, 27; cpu: 64 (67), 55 (56), 84 (144), 168 (178).
[2025-10-13 06:40:57.884] l: 24, 1, 56; t: 5, 3, 27; cpu: 64 (67), 55 (56), 84 (144), 168 (178).
[2025-10-13 06:40:57.891] l: 41, 1, 56; t: 8, 3, 27; cpu: 64 (67), 55 (56), 84 (144), 168 (178).
```
Radio ISR Latency = LLL CPU usage? : **56 us**