### PR TITLE
doc: releases: add shell mqtt backend kconfigs

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -164,6 +164,16 @@ New APIs and options
 
    * :kconfig:option:`CONFIG_SETTINGS_TFM_ITS`
 
+* Shell
+
+   * MQTT backend
+
+      * :kconfig:option:`CONFIG_SHELL_MQTT_TOPIC_RX_ID`
+      * :kconfig:option:`CONFIG_SHELL_MQTT_TOPIC_TX_ID`
+      * :kconfig:option:`CONFIG_SHELL_MQTT_CONNECT_TIMEOUT_MS`
+      * :kconfig:option:`CONFIG_SHELL_MQTT_WORK_DELAY_MS`
+      * :kconfig:option:`CONFIG_SHELL_MQTT_LISTEN_TIMEOUT_MS`
+
 .. zephyr-keep-sorted-stop
 
 New Boards


### PR DESCRIPTION
Add shell MQTT backend Kconfigs to release notes from commits ddc4479243180d93c4a453b905e1985194d16333 and
7c796c417e65c2f6ec549f7c05aca919515236d1.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/94541.