### PR TITLE
tests: posix: add a test for types.h and _GNU_SOURCE

### DIFF
--- a/tests/posix/headers/src/types_h.c
+++ b/tests/posix/headers/src/types_h.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* _GNU_SOURCE causes extra headers to be included and can cause dependency
+ * loops
+ */
+#define _GNU_SOURCE
+
+#include <sys/types.h>


### PR DESCRIPTION
Test for https://github.com/zephyrproject-rtos/zephyr/pull/95355

--

This combination (with newlib) seems to catch some build failures due to include depdenency, adding a test file so it gets caught in CI.