### PR TITLE
flash: spi_nor: Fix VLA error when building with clang

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1376,7 +1376,7 @@ static int spi_nor_process_sfdp(const struct device *dev)
 
 		if (id == JESD216_SFDP_PARAM_ID_BFP) {
 			union {
-				uint32_t dw[MIN(php->len_dw, 20)];
+				uint32_t dw[20];
 				struct jesd216_bfp bfp;
 			} u_param;
 			const struct jesd216_bfp *bfp = &u_param.bfp;


### PR DESCRIPTION
The following error is issued by clang when building with SPI_NOR_SFDP_RUNTIME enabled:

error: fields must have a constant size: 'variable length array in structure' extension will never be supported
1379 | uint32_t dw[MIN(php->len_dw, 20)];

Instead, hardcode the array length to 20 32-bit words (it's instantiated in the stack anyway).