### PR TITLE
boards: nxp: add mikrobus_i2c to lpcxpresso55s69

### DIFF
--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -182,6 +182,9 @@ mikrobus_serial: &flexcomm2 {};
 
 mikrobus_spi: &hs_lspi {};
 
+mikrobus_i2c: &flexcomm4 {
+};
+
 &flexcomm0 {
 	pinctrl-0 = <&pinmux_flexcomm0_usart>;
 	pinctrl-names = "default";


### PR DESCRIPTION
This was missing despite other mikrobus labels being there. Verified against LPCXpresso55S69_Board_Schematic_RevA2_dec4.pdf