### PR TITLE
soc: nordic: Update UICR format and add secondary firmware support

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -166,5 +166,13 @@
 		periphconf_partition: partition@1ae000 {
 			reg = <0x1ae000 DT_SIZE_K(8)>;
 		};
+
+		secondary_partition: partition@1b0000 {
+			reg = <0x1b0000 DT_SIZE_K(64)>;
+		};
+
+		secondary_periphconf_partition: partition@1c0000 {
+			reg = <0x1c0000 DT_SIZE_K(8)>;
+		};
 	};
 };

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1264,6 +1264,8 @@ flagged.
         "FOO_SETTING_1",
         "FOO_SETTING_2",
         "GEN_UICR_GENERATE_PERIPHCONF", # Used in specialized build tool, not part of main Kconfig
+        "GEN_UICR_SECONDARY", # Used in specialized build tool, not part of main Kconfig
+        "GEN_UICR_SECONDARY_GENERATE_PERIPHCONF", # Used in specialized build tool, not part of main Kconfig
         "HEAP_MEM_POOL_ADD_SIZE_", # Used as an option matching prefix
         "HUGETLBFS",          # Linux, in boards/xtensa/intel_adsp_cavs25/doc
         "IAR_BUFFERED_WRITE",

--- a/soc/nordic/common/uicr/gen_uicr.py
+++ b/soc/nordic/common/uicr/gen_uicr.py
@@ -66,23 +66,38 @@ class Protectedmem(c.LittleEndianStructure):
     ]
 
 
-class Recovery(c.LittleEndianStructure):
+class Wdtstart(c.LittleEndianStructure):
     _pack_ = 1
     _fields_ = [
         ("ENABLE", c.c_uint32),
-        ("PROCESSOR", c.c_uint32),
-        ("INITSVTOR", c.c_uint32),
-        ("SIZE4KB", c.c_uint32),
+        ("INSTANCE", c.c_uint32),
+        ("CRV", c.c_uint32),
     ]
 
 
-class Its(c.LittleEndianStructure):
+class SecurestorageCrypto(c.LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [
+        ("APPLICATIONSIZE1KB", c.c_uint32),
+        ("RADIOCORESIZE1KB", c.c_uint32),
+    ]
+
+
+class SecurestorageIts(c.LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [
+        ("APPLICATIONSIZE1KB", c.c_uint32),
+        ("RADIOCORESIZE1KB", c.c_uint32),
+    ]
+
+
+class Securestorage(c.LittleEndianStructure):
     _pack_ = 1
     _fields_ = [
         ("ENABLE", c.c_uint32),
         ("ADDRESS", c.c_uint32),
-        ("APPLICATIONSIZE", c.c_uint32),
-        ("RADIOCORESIZE", c.c_uint32),
+        ("CRYPTO", SecurestorageCrypto),
+        ("ITS", SecurestorageIts),
     ]
 
 
@@ -104,6 +119,64 @@ class Mpcconf(c.LittleEndianStructure):
     ]
 
 
+class SecondaryTrigger(c.LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [
+        ("ENABLE", c.c_uint32),
+        ("RESETREAS", c.c_uint32),
+        ("RESERVED", c.c_uint32),
+    ]
+
+
+class SecondaryProtectedmem(c.LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [
+        ("ENABLE", c.c_uint32),
+        ("SIZE4KB", c.c_uint32),
+    ]
+
+
+class SecondaryWdtstart(c.LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [
+        ("ENABLE", c.c_uint32),
+        ("INSTANCE", c.c_uint32),
+        ("CRV", c.c_uint32),
+    ]
+
+
+class SecondaryPeriphconf(c.LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [
+        ("ENABLE", c.c_uint32),
+        ("ADDRESS", c.c_uint32),
+        ("MAXCOUNT", c.c_uint32),
+    ]
+
+
+class SecondaryMpcconf(c.LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [
+        ("ENABLE", c.c_uint32),
+        ("ADDRESS", c.c_uint32),
+        ("MAXCOUNT", c.c_uint32),
+    ]
+
+
+class Secondary(c.LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [
+        ("ENABLE", c.c_uint32),
+        ("PROCESSOR", c.c_uint32),
+        ("TRIGGER", SecondaryTrigger),
+        ("ADDRESS", c.c_uint32),
+        ("PROTECTEDMEM", SecondaryProtectedmem),
+        ("WDTSTART", SecondaryWdtstart),
+        ("PERIPHCONF", SecondaryPeriphconf),
+        ("MPCCONF", SecondaryMpcconf),
+    ]
+
+
 class Uicr(c.LittleEndianStructure):
     _pack_ = 1
     _fields_ = [
@@ -114,11 +187,14 @@ class Uicr(c.LittleEndianStructure):
         ("APPROTECT", Approtect),
         ("ERASEPROTECT", c.c_uint32),
         ("PROTECTEDMEM", Protectedmem),
-        ("RECOVERY", Recovery),
-        ("ITS", Its),
-        ("RESERVED2", c.c_uint32 * 7),
+        ("WDTSTART", Wdtstart),
+        ("RESERVED2", c.c_uint32),
+        ("SECURESTORAGE", Securestorage),
+        ("RESERVED3", c.c_uint32 * 5),
         ("PERIPHCONF", Periphconf),
         ("MPCCONF", Mpcconf),
+        ("SECONDARY", Secondary),
+        ("PADDING", c.c_uint32 * 15),
     ]
 
 

--- a/soc/nordic/common/uicr/gen_uicr.py
+++ b/soc/nordic/common/uicr/gen_uicr.py
@@ -255,6 +255,50 @@ def main() -> None:
         type=lambda s: int(s, 0),
         help="Absolute flash address of the UICR region (decimal or 0x-prefixed hex)",
     )
+    parser.add_argument(
+        "--secondary",
+        action="store_true",
+        help="Enable secondary firmware support in UICR",
+    )
+    parser.add_argument(
+        "--secondary-address",
+        default=None,
+        type=lambda s: int(s, 0),
+        help="Absolute flash address of the secondary firmware (decimal or 0x-prefixed hex)",
+    )
+    parser.add_argument(
+        "--secondary-periphconf-address",
+        default=None,
+        type=lambda s: int(s, 0),
+        help=(
+            "Absolute flash address of the secondary PERIPHCONF partition "
+            "(decimal or 0x-prefixed hex)"
+        ),
+    )
+    parser.add_argument(
+        "--secondary-periphconf-size",
+        default=None,
+        type=lambda s: int(s, 0),
+        help="Size in bytes of the secondary PERIPHCONF partition (decimal or 0x-prefixed hex)",
+    )
+    parser.add_argument(
+        "--in-secondary-periphconf-elf",
+        dest="in_secondary_periphconf_elfs",
+        default=[],
+        action="append",
+        type=argparse.FileType("rb"),
+        help=(
+            "Path to an ELF file to extract secondary PERIPHCONF data from. "
+            "Can be provided multiple times. The secondary PERIPHCONF data from each ELF file "
+            "is combined in a single list which is sorted by ascending address and cleared "
+            "of duplicate entries."
+        ),
+    )
+    parser.add_argument(
+        "--out-secondary-periphconf-hex",
+        type=argparse.FileType("w", encoding="utf-8"),
+        help="Path to write the secondary PERIPHCONF-only HEX file to",
+    )
     args = parser.parse_args()
 
     try:
@@ -267,6 +311,22 @@ def main() -> None:
             if args.periphconf_size is None:
                 raise ScriptError("--periphconf-size is required when --out-periphconf-hex is used")
 
+        # Validate secondary argument dependencies
+        if args.secondary and args.secondary_address is None:
+            raise ScriptError("--secondary-address is required when --secondary is used")
+
+        if args.out_secondary_periphconf_hex:
+            if args.secondary_periphconf_address is None:
+                raise ScriptError(
+                    "--secondary-periphconf-address is required when "
+                    "--out-secondary-periphconf-hex is used"
+                )
+            if args.secondary_periphconf_size is None:
+                raise ScriptError(
+                    "--secondary-periphconf-size is required when "
+                    "--out-secondary-periphconf-hex is used"
+                )
+
         init_values = DISABLED_VALUE.to_bytes(4, "little") * (c.sizeof(Uicr) // 4)
         uicr = Uicr.from_buffer_copy(init_values)
 
@@ -275,6 +335,7 @@ def main() -> None:
 
         # Process periphconf data first and configure UICR completely before creating hex objects
         periphconf_hex = IntelHex()
+        secondary_periphconf_hex = IntelHex()
 
         if args.out_periphconf_hex:
             periphconf_combined = extract_and_combine_periphconfs(args.in_periphconf_elfs)
@@ -301,6 +362,44 @@ def main() -> None:
 
             uicr.PERIPHCONF.MAXCOUNT = args.periphconf_size // 8
 
+        # Handle secondary firmware configuration
+        if args.secondary:
+            uicr.SECONDARY.ENABLE = ENABLED_VALUE
+            uicr.SECONDARY.ADDRESS = args.secondary_address
+
+            # Handle secondary periphconf if provided
+            if args.out_secondary_periphconf_hex:
+                secondary_periphconf_combined = extract_and_combine_periphconfs(
+                    args.in_secondary_periphconf_elfs
+                )
+
+                padding_len = args.secondary_periphconf_size - len(secondary_periphconf_combined)
+                secondary_periphconf_final = secondary_periphconf_combined + bytes(
+                    [0xFF for _ in range(padding_len)]
+                )
+
+                # Add secondary periphconf data to secondary periphconf hex object
+                secondary_periphconf_hex.frombytes(
+                    secondary_periphconf_final, offset=args.secondary_periphconf_address
+                )
+
+                # Configure UICR with secondary periphconf settings
+                uicr.SECONDARY.PERIPHCONF.ENABLE = ENABLED_VALUE
+                uicr.SECONDARY.PERIPHCONF.ADDRESS = args.secondary_periphconf_address
+
+                # MAXCOUNT is given in number of 8-byte peripheral
+                # configuration entries and secondary_periphconf_size is given in
+                # bytes. When setting MAXCOUNT based on the
+                # secondary_periphconf_size we must first assert that
+                # secondary_periphconf_size has not been misconfigured.
+                if args.secondary_periphconf_size % 8 != 0:
+                    raise ScriptError(
+                        f"args.secondary_periphconf_size was {args.secondary_periphconf_size}, "
+                        f"but must be divisible by 8"
+                    )
+
+                uicr.SECONDARY.PERIPHCONF.MAXCOUNT = args.secondary_periphconf_size // 8
+
         # Create UICR hex object with final UICR data
         uicr_hex = IntelHex()
         uicr_hex.frombytes(bytes(uicr), offset=args.uicr_address)
@@ -311,8 +410,11 @@ def main() -> None:
 
         if args.out_periphconf_hex:
             periphconf_hex.write_hex_file(args.out_periphconf_hex)
-
             merged_hex.fromdict(periphconf_hex.todict())
+
+        if args.out_secondary_periphconf_hex:
+            secondary_periphconf_hex.write_hex_file(args.out_secondary_periphconf_hex)
+            merged_hex.fromdict(secondary_periphconf_hex.todict())
 
         merged_hex.write_hex_file(args.out_merged_hex)
         uicr_hex.write_hex_file(args.out_uicr_hex)

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -51,8 +51,10 @@ endif()
 set(periphconf_args)
 set(periphconf_elfs)
 set(merged_hex_file ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.hex)
+set(secondary_periphconf_elfs)
 set(uicr_hex_file ${APPLICATION_BINARY_DIR}/zephyr/uicr.hex)
 set(periphconf_hex_file ${APPLICATION_BINARY_DIR}/zephyr/periphconf.hex)
+set(secondary_periphconf_hex_file ${APPLICATION_BINARY_DIR}/zephyr/secondary_periphconf.hex)
 
 # Get UICR absolute address from this image's devicetree
 dt_nodelabel(uicr_path NODELABEL "uicr" REQUIRED)
@@ -75,7 +77,14 @@ if(CONFIG_GEN_UICR_GENERATE_PERIPHCONF)
     if(EXISTS ${_dir}/zephyr/zephyr.dts)
       # Read CONFIG_KERNEL_BIN_NAME from the sibling's .config file
       parse_kconfig_value(${_dir}/zephyr/.config CONFIG_KERNEL_BIN_NAME kernel_bin_name)
-      list(APPEND periphconf_elfs ${_dir}/zephyr/${kernel_bin_name}.elf)
+      set(kernel_elf_path ${_dir}/zephyr/${kernel_bin_name}.elf)
+
+      # Check if this is secondary firmware by looking for the marker file
+      if(EXISTS ${_dir}/is_secondary_firmware.txt)
+        list(APPEND secondary_periphconf_elfs ${kernel_elf_path})
+      else()
+        list(APPEND periphconf_elfs ${kernel_elf_path})
+      endif()
     endif()
   endforeach()
 
@@ -92,21 +101,46 @@ if(CONFIG_GEN_UICR_GENERATE_PERIPHCONF)
   endforeach()
 endif(CONFIG_GEN_UICR_GENERATE_PERIPHCONF)
 
-# Generate hex files (merged, uicr-only, and periphconf-only)
+if(CONFIG_GEN_UICR_SECONDARY)
+  set(secondary_args --secondary)
+
+  # Compute SECONDARY partition absolute address from this image's devicetree
+  compute_partition_address_and_size("secondary_partition" SECONDARY_ADDRESS SECONDARY_SIZE)
+
+  list(APPEND secondary_args
+    --secondary-address ${SECONDARY_ADDRESS}
+    )
+
+  if(CONFIG_GEN_UICR_SECONDARY_GENERATE_PERIPHCONF)
+    # Compute SECONDARY_PERIPHCONF absolute address and size from this image's devicetree
+    compute_partition_address_and_size("secondary_periphconf_partition" SECONDARY_PERIPHCONF_ADDRESS SECONDARY_PERIPHCONF_SIZE)
+
+    list(APPEND secondary_args --secondary-periphconf-address ${SECONDARY_PERIPHCONF_ADDRESS})
+    list(APPEND secondary_args --secondary-periphconf-size ${SECONDARY_PERIPHCONF_SIZE})
+    list(APPEND secondary_args --out-secondary-periphconf-hex ${secondary_periphconf_hex_file})
+
+    foreach(elf ${secondary_periphconf_elfs})
+      list(APPEND secondary_args --in-secondary-periphconf-elf ${elf})
+    endforeach()
+  endif()
+endif()
+
+# Generate hex files (merged, uicr-only, periphconf-only, and secondary-periphconf-only)
 add_custom_command(
-  OUTPUT ${merged_hex_file} ${uicr_hex_file} ${periphconf_hex_file}
+  OUTPUT ${merged_hex_file} ${uicr_hex_file} ${periphconf_hex_file} ${secondary_periphconf_hex_file}
   COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${ZEPHYR_BASE}/scripts/dts/python-devicetree/src
           ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/soc/nordic/common/uicr/gen_uicr.py
           --uicr-address ${UICR_ADDRESS}
           --out-merged-hex ${merged_hex_file}
           --out-uicr-hex ${uicr_hex_file}
           ${periphconf_args}
-  DEPENDS ${periphconf_elfs}
+          ${secondary_args}
+  DEPENDS ${periphconf_elfs} ${secondary_periphconf_elfs}
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
-  COMMENT "Using gen_uicr.py to generate ${merged_hex_file} from ${periphconf_elfs}"
+  COMMENT "Using gen_uicr.py to generate ${merged_hex_file}, ${uicr_hex_file}, ${periphconf_hex_file}, and ${secondary_periphconf_hex_file} from ${periphconf_elfs} ${secondary_periphconf_elfs}"
 )
 
 # Add zephyr subdirectory to handle flash configuration with correct paths
 add_subdirectory(zephyr)
 
-add_custom_target(gen_uicr ALL DEPENDS ${merged_hex_file})
+add_custom_target(gen_uicr ALL DEPENDS ${merged_hex_file} ${uicr_hex_file} ${periphconf_hex_file} ${secondary_periphconf_hex_file})

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -19,6 +19,17 @@ find_package(Zephyr
 
 project(uicr)
 
+# Function to parse a Kconfig value from a .config file
+function(parse_kconfig_value config_file config_name output_var)
+  file(STRINGS ${config_file} config_lines ENCODING "UTF-8")
+  foreach(line ${config_lines})
+    if("${line}" MATCHES "^${config_name}=\"(.*)\"$")
+      set(${output_var} "${CMAKE_MATCH_1}" PARENT_SCOPE)
+      return()
+    endif()
+  endforeach()
+endfunction()
+
 # Function to compute partition absolute address and size from devicetree
 function(compute_partition_address_and_size partition_nodelabel output_address_var output_size_var)
   dt_nodelabel(partition_path NODELABEL ${partition_nodelabel} REQUIRED)
@@ -62,7 +73,9 @@ if(CONFIG_GEN_UICR_GENERATE_PERIPHCONF)
     endif()
 
     if(EXISTS ${_dir}/zephyr/zephyr.dts)
-      list(APPEND periphconf_elfs ${_dir}/zephyr/zephyr.elf)
+      # Read CONFIG_KERNEL_BIN_NAME from the sibling's .config file
+      parse_kconfig_value(${_dir}/zephyr/.config CONFIG_KERNEL_BIN_NAME kernel_bin_name)
+      list(APPEND periphconf_elfs ${_dir}/zephyr/${kernel_bin_name}.elf)
     endif()
   endforeach()
 

--- a/soc/nordic/common/uicr/gen_uicr/Kconfig
+++ b/soc/nordic/common/uicr/gen_uicr/Kconfig
@@ -7,7 +7,19 @@ config GEN_UICR_GENERATE_PERIPHCONF
 	bool "Generate PERIPHCONF hex alongside UICR"
 	default y
 	help
-	  When enabled, the UICR generator will emit periphconf.hex in addition to uicr.hex.
+	  When enabled, the UICR generator will populate the
+	  periphconf_partition partition.
+
+config GEN_UICR_SECONDARY
+	bool "Enable UICR.SECONDARY.ENABLE"
+
+config GEN_UICR_SECONDARY_GENERATE_PERIPHCONF
+	bool "Generate SECONDARY.PERIPHCONF hex alongside UICR"
+	default y
+	depends on GEN_UICR_SECONDARY
+	help
+	  When enabled, the UICR generator will populate the
+	  secondary_periphconf_partition partition.
 
 endmenu
 


### PR DESCRIPTION
Update Nordic UICR format to latest revision (v2.0) and add secondary firmware support to gen_uicr.py script.

Changes:
- Update UICR C struct with new Secondary firmware fields
- Add secondary firmware configuration support in gen_uicr.py
- New command-line options for secondary firmware address and PERIPHCONF

These changes support Nordic's IronSide SE architecture migration.