### PR TITLE
fix(settings): add proper directory creation for FatFS mount points

### DIFF
--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -539,9 +539,15 @@ static int mkdir_for_file(const char *file_path)
 		if (i > 0 && file_path[i] == '/') {
 			dir_path[i] = '\0';
 
-			err = mkdir_if_not_exists(dir_path);
-			if (err) {
-				return err;
+			if (strrchr(dir_path, ':') == &dir_path[strlen(dir_path) - 1]) {
+				LOG_INF("FatFS root directory detected, skipping mkdir for path: "
+					"%s",
+					dir_path);
+			} else {
+				err = mkdir_if_not_exists(dir_path);
+				if (err) {
+					return err;
+				}
 			}
 		}
 


### PR DESCRIPTION
* Skip mkdir for FatFS root directories ending with ':' (e.g., "/SD:")
* Add detection logic in mkdir_for_file() to identify mount points
* Prevent unnecessary mkdir calls that would fail on FatFS root
* Add informative logging when skipping FatFS root directory creation

This fixes settings initialization failures when using FatFS with mount points like "/SD:/settings" where the root "/SD:" directory is managed by the filesystem driver and cannot be created manually.

The fix ensures that mkdir is only called for actual subdirectories within the mounted filesystem, not for the mount point itself.

Resolves settings backend initialization errors on embedded systems using SD card storage with FatFS.