### PR TITLE
soc: nxp: imx95: increase ROM_START_OFFSET in case of BOOTLOADER_MCUBOOT

### DIFF
--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
@@ -57,4 +57,7 @@ config IDLE_STACK_SIZE
 	default 640
 endif
 
+config ROM_START_OFFSET
+	default 0x800 if BOOTLOADER_MCUBOOT
+
 endif # SOC_MIMX9596_M7


### PR DESCRIPTION
The insertion of MCUBOOT header will shift the rom code ahead with 0x800 bytes because of memory alignment. The ROM_START_OFFSET is set conditionally just like other ARM M-core architectures of the same kind.