### PR TITLE
lib: utils: bitarray: Optimize 32 bit bitarray by adding a dedicated function that case

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -435,6 +435,22 @@ extern "C" {
 #define IN_RANGE(val, min, max) ((val) >= (min) && (val) <= (max))
 
 /**
+ * Find number of contiguous bits which are not set in the bit mask (32 bits).
+ *
+ * It is possible to return immediately when requested number of bits is found or
+ * iterate over whole mask and return the best fit (smallest from available options).
+ *
+ * @param[in] mask 32 bit mask.
+ * @param[in] num_bits Number of bits to find.
+ * @param[in] total_bits Total number of LSB bits that can be used in the mask.
+ * @param[in] first_match If true returns when first match is found, else returns the best fit.
+ *
+ * @retval -1 Contiguous bits not found.
+ * @retval non-negative Starting index of the bits group.
+ */
+int bitmask_find_gap(uint32_t mask, size_t num_bits, size_t total_bits, bool first_match);
+
+/**
  * @brief Is @p x a power of two?
  * @param x value to check
  * @return true if @p x is a power of two, false otherwise

--- a/lib/utils/CMakeLists.txt
+++ b/lib/utils/CMakeLists.txt
@@ -8,6 +8,7 @@ zephyr_sources(
   rb.c
   timeutil.c
   bitarray.c
+  bitmask.c
   )
 
 zephyr_sources_ifdef(CONFIG_ONOFF onoff.c)

--- a/lib/utils/bitarray.c
+++ b/lib/utils/bitarray.c
@@ -513,6 +513,20 @@ int sys_bitarray_alloc(sys_bitarray_t *bitarray, size_t num_bits,
 		goto out;
 	}
 
+	if (bitarray->num_bits <= 32) {
+		int off;
+
+		off = bitmask_find_gap(bitarray->bundles[0], num_bits, bitarray->num_bits, false);
+		if (off < 0) {
+			ret = -ENOSPC;
+		} else {
+			bitarray->bundles[0] |= BIT_MASK(num_bits) << off;
+			*offset = off;
+			ret = 0;
+		}
+		goto out;
+	}
+
 	bit_idx = 0;
 
 	/* Find the first non-allocated bit by looking at bundles
@@ -660,7 +674,16 @@ int sys_bitarray_free(sys_bitarray_t *bitarray, size_t num_bits,
 	 * (offset to offset + num_bits) are all allocated before we clear
 	 * them.
 	 */
-	if (match_region(bitarray, offset, num_bits, true, &bd, NULL)) {
+	if (bitarray->num_bits <= 32) {
+		uint32_t mask = BIT_MASK(num_bits) << offset;
+
+		if ((mask & bitarray->bundles[0]) != mask) {
+			ret = -EFAULT;
+		} else {
+			bitarray->bundles[0] &= ~mask;
+			ret = 0;
+		}
+	} else if (match_region(bitarray, offset, num_bits, true, &bd, NULL)) {
 		set_region(bitarray, offset, num_bits, false, &bd);
 		ret = 0;
 	} else {

--- a/lib/utils/bitmask.c
+++ b/lib/utils/bitmask.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/math_extras.h>
+
+int bitmask_find_gap(uint32_t mask, size_t num_bits, size_t total_bits, bool first_match)
+{
+	uint32_t max = UINT32_MAX;
+	int max_loc = -1;
+
+	if (total_bits < 32) {
+		mask |= ~BIT_MASK(total_bits);
+	}
+
+	mask = ~mask;
+	while (mask != 0U) {
+		uint32_t block_size;
+		uint32_t loc;
+		int nidx;
+		uint32_t idx = 31 - u32_count_leading_zeros(mask);
+		uint32_t rmask = ~BIT_MASK(idx);
+
+		rmask |= mask;
+		rmask = ~rmask;
+		if (rmask != 0U) {
+			nidx = 31 - u32_count_leading_zeros(rmask);
+			block_size = idx - nidx;
+			loc = nidx + 1;
+			mask &= BIT_MASK(nidx);
+		} else {
+			mask = 0;
+			block_size = idx + 1;
+			loc = 0;
+		}
+
+		if ((block_size == num_bits) || (first_match && block_size > num_bits)) {
+			max_loc = loc;
+			max = block_size;
+			break;
+		} else if (block_size >= num_bits && block_size < max) {
+			max_loc = loc;
+			max = block_size;
+		}
+	}
+
+	return max_loc;
+}

--- a/tests/kernel/common/src/bitarray.c
+++ b/tests/kernel/common/src/bitarray.c
@@ -282,6 +282,39 @@ ZTEST(bitarray, test_bitarray_set_clear)
 		     "sys_bitarray_test_and_clear_bit() erroneously changed bitarray");
 }
 
+static void test_alloc_free_32(uint32_t mask, uint32_t mask_after, size_t num_bits,
+			       size_t exp_offset, int exp_ret)
+{
+	int ret;
+	size_t offset;
+
+	SYS_BITARRAY_DEFINE(ba_32, 32);
+
+	ba_32.bundles[0] = mask;
+
+	ret = sys_bitarray_alloc(&ba_32, num_bits, &offset);
+	zassert_equal(ret, exp_ret, "sys_bitarray_alloc() failed: %d", ret);
+	if (exp_ret < 0) {
+		return;
+	}
+	zassert_equal(offset, exp_offset,
+		      "sys_bitarray_alloc() offset expected %d, got %d", exp_offset, offset);
+	zassert_equal(ba_32.bundles[0], mask_after, "sys_bitarray_alloc() failed bits comparison");
+
+	ret = sys_bitarray_free(&ba_32, num_bits, offset);
+	zassert_equal(ret, 0, "sys_bitarray_free() failed: %d", ret);
+	zassert_equal(ba_32.bundles[0], mask, "sys_bitarray_alloc() failed bits comparison");
+}
+
+static void alloc_and_free_32_predefined(void)
+{
+	printk("Testing bit array alloc and free with predefined patterns using 32 bit array\n");
+
+	test_alloc_free_32(0x0F0F070F, 0x0F0FFF0F, 5, 11, 0);
+	test_alloc_free_32(0x33333333, 0xF3333333, 3, 0, -ENOSPC);
+	test_alloc_free_32(0x33333333, 0xF3333333, 2, 30, 0);
+}
+
 void alloc_and_free_predefined(void)
 {
 	int ret;
@@ -291,7 +324,7 @@ void alloc_and_free_predefined(void)
 
 	SYS_BITARRAY_DEFINE(ba_128, 128);
 
-	printk("Testing bit array alloc and free with predefined patterns\n");
+	printk("Testing bit array alloc and free with predefined patterns using 128 bit array\n");
 
 	/* Pre-populate the bits */
 	ba_128.bundles[0] = 0x0F0F070F;
@@ -514,6 +547,7 @@ ZTEST(bitarray, test_bitarray_alloc_free)
 	}
 
 	alloc_and_free_predefined();
+	alloc_and_free_32_predefined();
 
 	i = 1;
 	while (i < 65) {

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(testbinary
   main.c
   ${ZEPHYR_BASE}/lib/utils/dec.c
   ${ZEPHYR_BASE}/lib/utils/utf8.c
+  ${ZEPHYR_BASE}/lib/utils/bitmask.c
 )
 
 if(CONFIG_CPP)

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -1081,4 +1081,27 @@ ZTEST(util, test_util_memeq)
 	zassert_false(mem_area_matching_2);
 }
 
+static void test_single_bitmask_find_gap(uint32_t mask, size_t num_bits, size_t total_bits,
+					 bool first_match, int exp_rv, int line)
+{
+	int rv;
+
+	rv = bitmask_find_gap(mask, num_bits, total_bits, first_match);
+	zassert_equal(rv, exp_rv, "%d Unexpected rv:%d (exp:%d)", line, rv, exp_rv);
+}
+
+ZTEST(util, test_bitmask_find_gap)
+{
+	test_single_bitmask_find_gap(0x0F0F070F, 6, 32, true, -1, __LINE__);
+	test_single_bitmask_find_gap(0x0F0F070F, 5, 32, true, 11, __LINE__);
+	test_single_bitmask_find_gap(0x030F070F, 5, 32, true, 26, __LINE__);
+	test_single_bitmask_find_gap(0x030F070F, 5, 32, false, 11, __LINE__);
+	test_single_bitmask_find_gap(0x0F0F070F, 5, 32, true, 11, __LINE__);
+	test_single_bitmask_find_gap(0x030F070F, 5, 32, true, 26, __LINE__);
+	test_single_bitmask_find_gap(0x030F070F, 5, 32, false, 11, __LINE__);
+	test_single_bitmask_find_gap(0x0, 1, 32, true, 0, __LINE__);
+	test_single_bitmask_find_gap(0x1F1F071F, 4, 32, true, 11, __LINE__);
+	test_single_bitmask_find_gap(0x0000000F, 2, 6, false, 4, __LINE__);
+}
+
 ZTEST_SUITE(util, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Add function which finds contiguous number of bits which are not set in the 32 bit mask.

Use optimized approach in `sys_bitarray_alloc` and `sys_bitarray_free` if bitarray contains only a single 32 bit word. This approach is 2-3 times faster for 32 bit bitarray.
