### PR TITLE
Remove unnecessary DMA header includes

### DIFF
--- a/boards/adi/max32662evkit/max32662evkit.dts
+++ b/boards/adi/max32662evkit/max32662evkit.dts
@@ -10,7 +10,6 @@
 #include <adi/max32/max32662-pinctrl.dtsi>
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
-#include <zephyr/dt-bindings/dma/max32662_dma.h>
 #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {

--- a/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.dts
+++ b/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.dts
@@ -10,7 +10,6 @@
 #include <adi/max32/max32666-pinctrl.dtsi>
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
-#include <zephyr/dt-bindings/dma/max32666_dma.h>
 
 / {
 	model = "Analog Devices MAX32666EVKIT";

--- a/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.dts
+++ b/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.dts
@@ -10,7 +10,6 @@
 #include <adi/max32/max32666-pinctrl.dtsi>
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
-#include <zephyr/dt-bindings/dma/max32666_dma.h>
 
 / {
 	model = "Analog Devices MAX32666FTHR";

--- a/boards/adi/max32675evkit/max32675evkit.dts
+++ b/boards/adi/max32675evkit/max32675evkit.dts
@@ -10,7 +10,6 @@
 #include <adi/max32/max32675-pinctrl.dtsi>
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
-#include <zephyr/dt-bindings/dma/max32675_dma.h>
 
 / {
 	model = "Analog Devices MAX32675EVKIT";

--- a/dts/arm/adi/max32/max32666.dtsi
+++ b/dts/arm/adi/max32/max32666.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <adi/max32/max32xxx.dtsi>
+#include <zephyr/dt-bindings/dma/max32666_dma.h>
 
 &clk_ipo {
 	clock-frequency = <DT_FREQ_M(96)>;


### PR DESCRIPTION
This PR moves `max32666_dma.h` header inclusion from board .dts file to SoC .dtsi file and removes unnecessary DMA header includes from board .dts files.