### PR TITLE
boards: silabs: xg29_rb4412a: add dht alias and regulator for si7021 sensor

### DIFF
--- a/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.dts
+++ b/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.dts
@@ -34,6 +34,7 @@
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdog0;
+		dht0 = &si7021;
 	};
 
 	leds {
@@ -144,6 +145,7 @@
 	si7021: si7021@40 {
 		compatible = "silabs,si7006";
 		reg = <0x40>;
+		vin-supply = <&sensor_enable>;
 	};
 };
 


### PR DESCRIPTION
This commit allows xg29_rb4412a board to correctly run the dht_polling sample.