### PR TITLE
usb: device_next: reduce log level to debug for internal status logs

### DIFF
--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -130,7 +130,7 @@ static int sreq_set_configuration(struct usbd_context *const uds_ctx)
 	const enum usbd_speed speed = usbd_bus_speed(uds_ctx);
 	int ret;
 
-	LOG_INF("Set Configuration Request value %u", setup->wValue);
+	LOG_DBG("Set Configuration Request value %u", setup->wValue);
 
 	/* Not specified if wLength is non-zero, treat as error */
 	if (setup->wValue > UINT8_MAX || setup->wLength) {
@@ -1115,7 +1115,7 @@ static struct net_buf *spool_data_out(struct net_buf *const buf)
 	struct udc_buf_info *bi;
 
 	while (next_buf) {
-		LOG_INF("spool %p", next_buf);
+		LOG_DBG("spool %p", next_buf);
 		next_buf = net_buf_frag_del(NULL, next_buf);
 		if (next_buf) {
 			bi = udc_get_buf_info(next_buf);
@@ -1154,7 +1154,7 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 		return err;
 	}
 
-	LOG_INF("Handle control %p ep 0x%02x, len %u, s:%u d:%u s:%u",
+	LOG_DBG("Handle control %p ep 0x%02x, len %u, s:%u d:%u s:%u",
 		buf, bi->ep, buf->len, bi->setup, bi->data, bi->status);
 
 	if (bi->setup && bi->ep == USB_CONTROL_EP_OUT) {
@@ -1212,7 +1212,7 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 
 	if (bi->status && bi->ep == USB_CONTROL_EP_OUT) {
 		if (ch9_get_ctrl_type(uds_ctx) == CTRL_AWAIT_STATUS_STAGE) {
-			LOG_INF("s-in-status finished");
+			LOG_DBG("s-in-status finished");
 		} else {
 			LOG_WRN("Awaited s-in-status not finished");
 		}
@@ -1226,7 +1226,7 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 		net_buf_unref(buf);
 
 		if (ch9_get_ctrl_type(uds_ctx) == CTRL_AWAIT_STATUS_STAGE) {
-			LOG_INF("s-(out)-status finished");
+			LOG_DBG("s-(out)-status finished");
 			if (unlikely(uds_ctx->ch9_data.post_status)) {
 				ret = post_status_stage(uds_ctx);
 			}

--- a/subsys/usb/device_next/usbd_init.c
+++ b/subsys/usb/device_next/usbd_init.c
@@ -163,7 +163,7 @@ static int init_configuration_inst(struct usbd_context *const uds_ctx,
 			}
 
 			class_ep_bm = 0;
-			LOG_INF("interface %u alternate %u",
+			LOG_DBG("interface %u alternate %u",
 				ifd->bInterfaceNumber, ifd->bAlternateSetting);
 		}
 
@@ -175,7 +175,7 @@ static int init_configuration_inst(struct usbd_context *const uds_ctx,
 				return ret;
 			}
 
-			LOG_INF("\tep 0x%02x mps 0x%04x interface ep-bm 0x%08x",
+			LOG_DBG("\tep 0x%02x mps 0x%04x interface ep-bm 0x%08x",
 				ed->bEndpointAddress,
 				sys_le16_to_cpu(ed->wMaxPacketSize),
 				class_ep_bm);
@@ -191,7 +191,7 @@ static int init_configuration_inst(struct usbd_context *const uds_ctx,
 	*nif = tmp_nif;
 	c_nd->ep_active |= class_ep_bm;
 
-	LOG_INF("Instance iface-bm 0x%08x ep-bm 0x%08x",
+	LOG_DBG("Instance iface-bm 0x%08x ep-bm 0x%08x",
 		c_nd->iface_bm, c_nd->ep_active);
 
 	return 0;
@@ -228,7 +228,7 @@ static int init_configuration(struct usbd_context *const uds_ctx,
 			return ret;
 		}
 
-		LOG_INF("Init class node %p, descriptor length %zu",
+		LOG_DBG("Init class node %p, descriptor length %zu",
 			c_nd->c_data, usbd_class_desc_len(c_nd->c_data, speed));
 		cfg_len += usbd_class_desc_len(c_nd->c_data, speed);
 	}
@@ -292,7 +292,7 @@ int usbd_init_configurations(struct usbd_context *const uds_ctx)
 				return ret;
 			}
 
-			LOG_INF("HS bNumConfigurations %u",
+			LOG_DBG("HS bNumConfigurations %u",
 				usbd_get_num_configs(uds_ctx, USBD_SPEED_HS));
 		}
 	}
@@ -307,7 +307,7 @@ int usbd_init_configurations(struct usbd_context *const uds_ctx)
 			return ret;
 		}
 
-		LOG_INF("FS bNumConfigurations %u",
+		LOG_DBG("FS bNumConfigurations %u",
 			usbd_get_num_configs(uds_ctx, USBD_SPEED_FS));
 	}
 

--- a/subsys/usb/device_next/usbd_interface.c
+++ b/subsys/usb/device_next/usbd_interface.c
@@ -94,7 +94,7 @@ static int usbd_interface_modify(struct usbd_context *const uds_ctx,
 				return ret;
 			}
 
-			LOG_INF("Modify interface %u ep 0x%02x by op %u ep_bm %x",
+			LOG_DBG("Modify interface %u ep 0x%02x by op %u ep_bm %x",
 				iface, ed->bEndpointAddress,
 				op, c_nd->ep_active);
 		}
@@ -183,7 +183,7 @@ int usbd_interface_set(struct usbd_context *const uds_ctx,
 		return ret;
 	}
 
-	LOG_INF("Set Interfaces %u, alternate %u -> %u", iface, cur_alt, alt);
+	LOG_DBG("Set Interfaces %u, alternate %u -> %u", iface, cur_alt, alt);
 	/*
 	 * Disable/enable endpoints even if the new alternate is the same as
 	 * the current one, forcing the endpoint to reset to defaults.


### PR DESCRIPTION
Reduce the log level to debug for a number of internal status logs within the USB device_next stack.