### PR TITLE
github: hello_world_multiplatform: run on Ubuntu ARM

### DIFF
--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, windows-2022]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -72,6 +72,8 @@ jobs:
             EXTRA_TWISTER_FLAGS="-P native_sim --build-only"
           elif [ "${{ runner.os }}" = "Windows" ]; then
             EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
+          elif [ "${{ runner.os }}-${{ runner.arch }}" == "Linux-ARM64" ]; then
+            EXTRA_TWISTER_FLAGS="--exclude-platform native_sim/native"
           fi
           ./scripts/twister --runtime-artifact-cleanup --force-color --inline-logs -T samples/hello_world -T samples/cpp/hello_world -v $EXTRA_TWISTER_FLAGS
 


### PR DESCRIPTION
Add ubuntu-24.04-arm to the list of runners, while this runner is still flagged as being in beta, it's been around for more than one year and has been running for quite a long time in the action-zephyr-setup repository with no problems.

Adding it to the list so we get some coverage of the Linux/ARM toolchain and setup, easy enough to get rid of it if it causes problems.

Link: https://github.com/actions/partner-runner-images/
Link: https://github.blog/changelog/2024-06-24-github-actions-ubuntu-24-04-image-now-available-for-arm64-runners/