### PR TITLE
drivers: flash: restore stm32 xspi mutex on memory mapping

### DIFF
--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -1206,7 +1206,10 @@ static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
 
 	/* Do reads through memory-mapping instead of indirect */
 	if (!stm32_xspi_is_memorymap(dev)) {
+		xspi_lock_thread(dev);
 		ret = stm32_xspi_set_memorymap(dev);
+		xspi_unlock_thread(dev);
+
 		if (ret != 0) {
 			LOG_ERR("READ: failed to set memory mapped");
 			return ret;


### PR DESCRIPTION
Fix stm32 XSPI driver to restore the bus command concurrent access protection that was mistakenly removed on memory mapping operation by commit e5620e07c998 ("drivers: flash: stm32 xspi flash read with memcopy when executing").