### PR TITLE
sw_isr_table: Remove unused macro parameter

### DIFF
--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -208,7 +208,7 @@ struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 /* Separated macro to create ISR table entry only.
  * Used by Z_ISR_DECLARE and ISR tables generation script.
  */
-#define _Z_ISR_TABLE_ENTRY(irq, func, param, sect) \
+#define _Z_ISR_TABLE_ENTRY(func, param, sect) \
 	static Z_DECL_ALIGN(struct _isr_table_entry)                                      \
 		__attribute__((section(sect)))                                            \
 		__used _MK_ISR_ELEMENT_NAME(func, __COUNTER__) = {                        \
@@ -220,7 +220,7 @@ struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 	_Z_ISR_DECLARE_C(irq, flags, func, param, counter)
 
 #define _Z_ISR_DECLARE_C(irq, flags, func, param, counter)                                         \
-	_Z_ISR_TABLE_ENTRY(irq, func, param, _MK_ISR_ELEMENT_SECTION(counter));                    \
+	_Z_ISR_TABLE_ENTRY(func, param, _MK_ISR_ELEMENT_SECTION(counter));                         \
 	static Z_DECL_ALIGN(struct _isr_list_sname) Z_GENERIC_SECTION(.intList) __used             \
 	_MK_ISR_NAME(func, counter) = {irq, flags, {_MK_ISR_ELEMENT_SECTION(counter)}}
 
@@ -237,7 +237,7 @@ struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 /* Separated macro to create ISR Direct table entry only.
  * Used by Z_ISR_DECLARE_DIRECT and ISR tables generation script.
  */
-#define _Z_ISR_DIRECT_TABLE_ENTRY(irq, func, sect)                                                 \
+#define _Z_ISR_DIRECT_TABLE_ENTRY(func, sect)                                                      \
 	COND_CODE_1(CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_ADDRESS, (                                     \
 			static Z_DECL_ALIGN(uintptr_t)                                             \
 			__attribute__((section(sect)))                                             \
@@ -255,7 +255,7 @@ struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 	_Z_ISR_DECLARE_DIRECT_C(irq, flags, func, counter)
 
 #define _Z_ISR_DECLARE_DIRECT_C(irq, flags, func, counter)                                         \
-	_Z_ISR_DIRECT_TABLE_ENTRY(irq, func, _MK_IRQ_ELEMENT_SECTION(counter));                    \
+	_Z_ISR_DIRECT_TABLE_ENTRY(func, _MK_IRQ_ELEMENT_SECTION(counter));                         \
 	static Z_DECL_ALIGN(struct _isr_list_sname) Z_GENERIC_SECTION(.intList)                    \
 		__used _MK_ISR_NAME(func, counter) = {                                             \
 			irq,                                                                       \

--- a/scripts/build/gen_isr_tables_parser_local.py
+++ b/scripts/build/gen_isr_tables_parser_local.py
@@ -237,23 +237,20 @@ BUILD_ASSERT(offsetof(struct _isr_table_entry, isr)
         return '.isr_shared.0x{:x}_client_num'.format(irq)
 
     def __isr_spurious_entry(self, irq):
-        return '_Z_ISR_TABLE_ENTRY({irq}, {func}, NULL, "{sect}");'.format(
-                irq = irq,
+        return '_Z_ISR_TABLE_ENTRY({func}, NULL, "{sect}");'.format(
                 func = self.__config.swt_spurious_handler,
                 sect = self.__isr_generated_section(irq)
             )
 
     def __isr_shared_entry(self, irq):
-        return '_Z_ISR_TABLE_ENTRY({irq}, {func}, {arg}, "{sect}");'.format(
-                irq = irq,
+        return '_Z_ISR_TABLE_ENTRY({func}, {arg}, "{sect}");'.format(
                 arg = '&{}[{}]'.format(self.__config.shared_array_name, irq),
                 func = self.__config.swt_shared_handler,
                 sect = self.__isr_generated_section(irq)
             )
 
     def __irq_spurious_entry(self, irq):
-        return '_Z_ISR_DIRECT_TABLE_ENTRY({irq}, {func}, "{sect}");'.format(
-                irq = irq,
+        return '_Z_ISR_DIRECT_TABLE_ENTRY({func}, "{sect}");'.format(
                 func = self.__config.vt_default_handler,
                 sect = self.__irq_spurious_section(irq)
             )


### PR DESCRIPTION
irq is not used by _Z_ISR_TABLE_ENTRY. Just remove it.