### PR TITLE
drivers: sensor: bmi270: fix off-by-one error

### DIFF
--- a/drivers/sensor/bosch/bmi270/bmi270.c
+++ b/drivers/sensor/bosch/bmi270/bmi270.c
@@ -747,7 +747,7 @@ static int bmi270_init(const struct device *dev)
 		k_usleep(BMI270_CONFIG_FILE_POLL_PERIOD_US);
 	}
 
-	if (tries == BMI270_CONFIG_FILE_RETRIES) {
+	if (tries > BMI270_CONFIG_FILE_RETRIES) {
 		return -EIO;
 	}
 


### PR DESCRIPTION
When the loop completes without breaking, `tries` would be `BMI270_CONFIG_FILE_RETRIES + 1` so the error check was never hit.