### PR TITLE
drivers: sensor: a01nyub: use logical AND in condition

### DIFF
--- a/drivers/sensor/a01nyub/a01nyub.c
+++ b/drivers/sensor/a01nyub/a01nyub.c
@@ -142,7 +142,7 @@ static void a01nyub_uart_isr(const struct device *uart_dev, void *user_data)
 		 * If we do not read A01NYUB_HEADER on what we think is the
 		 * first byte, then reset the number of bytes read until we do
 		 */
-		if ((data->rd_data[0] != A01NYUB_HEADER) & (data->xfer_bytes == 1)) {
+		if ((data->rd_data[0] != A01NYUB_HEADER) && (data->xfer_bytes == 1)) {
 			LOG_DBG("First byte not header! Resetting # of bytes read.");
 			data->xfer_bytes = 0;
 		}


### PR DESCRIPTION
Fix typo where a bitwise AND was used instead of a logical AND.