### PR TITLE
ci: manifest: install west, do not use requirement file

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -20,23 +20,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: 3.12
-          cache: pip
-          cache-dependency-path: scripts/requirements-actions.txt
-
-      - name: Install Python packages
-        run: |
-          cd zephyrproject/zephyr
-          pip install -r scripts/requirements-actions.txt --require-hashes
-
       - name: west setup
         env:
           BASE_REF: ${{ github.base_ref }}
         working-directory: zephyrproject/zephyr
         run: |
+          pip install west==1.4.0
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
           west init -l . || true


### PR DESCRIPTION
We only need west, so not go about installing packages using the
scripts/requirements-actions.txt file.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
