### PR TITLE
drivers: ethernet: xlnx_gem: invert RX/TX checksum offload behaviour

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -110,6 +110,17 @@ Ethernet
   the GPIO_ACTIVE_LOW flag when the reset is being used as active low. Previously the active-low
   nature was hard-coded into the driver. (:github:`91726`).
 
+* CRC checksum generation offloading to hardware is now explicitly disabled rather then explicitly
+  enabled in the Xilinx GEM Ethernet driver (:dtcompatible:`xlnx,gem`). By default, offloading is
+  now enabled by default to improve performance, however, offloading is always disabled for QEMU
+  targets due to the checksum generation in hardware not being emulated regardless of whether it
+  is explicitly disabled via the devicetree or not. (:github:`95435`)
+
+    * Replaced devicetree property ``rx-checksum-offload`` which enabled RX checksum offloading
+      ``disable-rx-checksum-offload`` which now actively disables it.
+    * Replaced devicetree property ``tx-checksum-offload`` which enabled TX checksum offloading
+      ``disable-tx-checksum-offload`` which now actively disables it.
+
 Networking
 **********
 

--- a/drivers/ethernet/eth_xlnx_gem_priv.h
+++ b/drivers/ethernet/eth_xlnx_gem_priv.h
@@ -453,7 +453,8 @@ static const struct eth_xlnx_gem_dev_cfg eth_xlnx_gem##port##_dev_cfg = {\
 	.enable_sgmii_mode		= DT_INST_PROP(port, sgmii_mode),\
 	.disable_reject_fcs_crc_errors	= DT_INST_PROP(port, disable_reject_fcs_crc_errors),\
 	.enable_rx_halfdup_while_tx	= DT_INST_PROP(port, rx_halfdup_while_tx),\
-	.enable_rx_chksum_offload	= DT_INST_PROP(port, rx_checksum_offload),\
+	.disable_rx_chksum_offload	= UTIL_OR(IS_ENABLED(CONFIG_QEMU_TARGET),\
+					  DT_INST_PROP(port, disable_rx_checksum_offload)),\
 	.disable_pause_copy		= DT_INST_PROP(port, disable_pause_copy),\
 	.discard_rx_fcs			= DT_INST_PROP(port, discard_rx_fcs),\
 	.discard_rx_length_errors	= DT_INST_PROP(port, discard_rx_length_errors),\
@@ -467,7 +468,8 @@ static const struct eth_xlnx_gem_dev_cfg eth_xlnx_gem##port##_dev_cfg = {\
 	.discard_non_vlan		= DT_INST_PROP(port, discard_non_vlan),\
 	.enable_fdx			= DT_INST_PROP(port, full_duplex),\
 	.disc_rx_ahb_unavail		= DT_INST_PROP(port, discard_rx_frame_ahb_unavail),\
-	.enable_tx_chksum_offload	= DT_INST_PROP(port, tx_checksum_offload),\
+	.disable_tx_chksum_offload	= UTIL_OR(IS_ENABLED(CONFIG_QEMU_TARGET),\
+					  DT_INST_PROP(port, disable_tx_checksum_offload)),\
 	.tx_buffer_size_full		= DT_INST_PROP(port, hw_tx_buffer_size_full),\
 	.enable_ahb_packet_endian_swap	= DT_INST_PROP(port, ahb_packet_endian_swap),\
 	.enable_ahb_md_endian_swap	= DT_INST_PROP(port, ahb_md_endian_swap)\
@@ -710,7 +712,7 @@ struct eth_xlnx_gem_dev_cfg {
 	bool				enable_sgmii_mode : 1;
 	bool				disable_reject_fcs_crc_errors : 1;
 	bool				enable_rx_halfdup_while_tx : 1;
-	bool				enable_rx_chksum_offload : 1;
+	bool				disable_rx_chksum_offload : 1;
 	bool				disable_pause_copy : 1;
 	bool				discard_rx_fcs : 1;
 	bool				discard_rx_length_errors : 1;
@@ -724,7 +726,7 @@ struct eth_xlnx_gem_dev_cfg {
 	bool				discard_non_vlan : 1;
 	bool				enable_fdx : 1;
 	bool				disc_rx_ahb_unavail : 1;
-	bool				enable_tx_chksum_offload : 1;
+	bool				disable_tx_chksum_offload : 1;
 	bool				tx_buffer_size_full : 1;
 	bool				enable_ahb_packet_endian_swap : 1;
 	bool				enable_ahb_md_endian_swap : 1;

--- a/dts/bindings/ethernet/xlnx,gem.yaml
+++ b/dts/bindings/ethernet/xlnx,gem.yaml
@@ -225,19 +225,21 @@ properties:
       Optional feature flag - Enable frames to be received in half-duplex
       mode while transmitting.
 
-  rx-checksum-offload:
+  disable-rx-checksum-offload:
     type: boolean
     description: |
-      Optional feature flag - Enable RX IP/TCP/UDP checksum offload to
-      hardware. Frames with bad IP, TCP or UDP checksums will be discarded.
-      This option is NOT supported by the QEMU implementation of the GEM!
+      Disable RX IPv4/IPv6/TCP/UDP checksum offload to hardware. Checksum
+      offloading is enabled by default, and automatically disabled for
+      QEMU targets, where hardware checksum offloading is not emulated,
+      without having to set this flag explicitly.
 
-  tx-checksum-offload:
+  disable-tx-checksum-offload:
     type: boolean
     description: |
-      Optional feature flag - Enable TX IP/TCP/UDP checksum offload to
-      hardware. This option is NOT supported by the QEMU implementation
-      of the GEM!
+      Disable TX IPv4/IPv6/TCP/UDP checksum offload to hardware. Checksum
+      offloading is enabled by default, and automatically disabled for
+      QEMU targets, where hardware checksum offloading is not emulated,
+      without having to set this flag explicitly.
 
   disable-pause-copy:
     type: boolean


### PR DESCRIPTION
Invert the RX/TX checksum offloading to hardware behaviour so that hardware checksum generation / evaluation for TCP/UDP packets on either IPv4 or IPv6 is enabled by default, but can be disabled explicitly. There are a few IP-based protocols out there for which such a feature is useful, e.g. AFDX / ARINC664.

This behaviour, which should optimize network performance, has become possible with the implementation of the device driver's get_config function, indicating to the network stack that HW checksum offloading is not supported for, e.g., ICMP packets. Before this implementation, enabling the HW checksum offloading resulted in invalid packets for any unsupported protocol and could therefore not be enabled by default.

For QEMU, which does not support the emulation of the HW checksum offloading, automatically disable the offloading.