### PR TITLE
ci: coverage: add a flag for test coverage

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -239,3 +239,4 @@ jobs:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/reports/merged.xml
+          flags: unittests-coverage


### PR DESCRIPTION
Add a flag for test coverage, to distinguish from doxygen coverage.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
