### PR TITLE
doc: external_content: exclude backup files

### DIFF
--- a/doc/_extensions/zephyr/external_content.py
+++ b/doc/_extensions/zephyr/external_content.py
@@ -108,14 +108,19 @@ def sync_contents(app: Sphinx) -> None:
         if not f.is_dir()
     )
 
+    def _pattern_excludes(f):
+        # backup files
+        return f.match('.#*') or f.match('*~')
+
     for content in app.config.external_content_contents:
         prefix_src, glob = content
         for src in prefix_src.glob(glob):
             if src.is_dir():
                 to_copy.extend(
-                    [(f, prefix_src) for f in src.glob("**/*") if not f.is_dir()]
+                    [(f, prefix_src) for f in src.glob("**/*") if
+                     (not f.is_dir() and not _pattern_excludes(f))]
                 )
-            else:
+            elif not _pattern_excludes(src):
                 to_copy.append((src, prefix_src))
 
     for entry in to_copy:


### PR DESCRIPTION
For most people, this should be only an optimization.

For Emacs TRAMP (ssh) users, this fixes the following build failure when a file is not saved yet. This build failure happens because TRAMP creates backup files on the local host and seems to use deliberately broken symlinks as "bookmarks" to those local files.
```
file snippets/.#index.rst
 snippets/.#index.rst: broken symbolic link to userid@hostname.intel.com.966265369654
```
```
Traceback
=========

 Traceback (most recent call last):
   File "/usr/lib/python3.13/site-packages/sphinx/events.py", in emit
     results.append(listener.handler(self.app, *args))
                    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
   File " doc/_extensions/zephyr/external_content.py", in sync_contents
     shutil.copy(src, dst)
     ~~~~~~~~~~~^^^^^^^^^^
   File "/usr/lib/python3.13/shutil.py", line 428, in copy
     copyfile(src, dst, follow_symlinks=follow_symlinks)
     ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3.13/shutil.py", line 260, in copyfile
     with open(src, 'rb') as fsrc:
          ~~~~^^^^^^^^^^^
 FileNotFoundError: [Errno 2] No such file or directory:
                      '___/zephyr/snippets/.#index.rst'
```

Just for the record, these backup files were already discussed in commit bab7df9f9e4 (".gitignore: do not ignore .\#* files")