### PR TITLE
Add support for arbitrary PM constraint lists from DT and substate change notifier, refactor RW612 power domain

### DIFF
--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -58,6 +58,7 @@ struct mcux_flexcomm_config {
 	void (*pm_unlock_work_fn)(struct k_work *);
 #endif
 #if FC_UART_IS_WAKEUP
+	struct pm_state_constraints lp_states;
 	void (*wakeup_cfg)(void);
 	clock_control_subsys_t lp_clock_subsys;
 #endif
@@ -1161,17 +1162,22 @@ static int mcux_flexcomm_init_common(const struct device *dev)
 }
 
 #if FC_UART_IS_WAKEUP
-static void mcux_flexcomm_pm_prepare_wake(const struct device *dev, enum pm_state state)
+static void mcux_flexcomm_pm_prepare_wake(const struct device *dev,
+					  enum pm_state state, uint8_t substate)
 {
 	const struct mcux_flexcomm_config *config = dev->config;
 	struct mcux_flexcomm_data *data = dev->data;
 	USART_Type *base = config->base;
+	struct pm_state_constraint match = {
+		.state = state,
+		.substate_id = substate,
+	};
 
 	/* Switch to the lowest possible baud rate, in order to
 	 * both minimize power consumption and also be able to
 	 * potentially wake up the chip from this mode.
 	 */
-	if (pm_policy_device_is_disabling_state(dev, state, 0)) {
+	if (pm_state_in_constraints(&config->lp_states, match)) {
 		clock_control_configure(config->clock_dev, config->lp_clock_subsys, NULL);
 		data->old_brg = base->BRG;
 		data->old_osr = base->OSR;
@@ -1180,13 +1186,18 @@ static void mcux_flexcomm_pm_prepare_wake(const struct device *dev, enum pm_stat
 	}
 }
 
-static void mcux_flexcomm_pm_restore_wake(const struct device *dev, enum pm_state state)
+static void mcux_flexcomm_pm_restore_wake(const struct device *dev,
+					  enum pm_state state, uint8_t substate)
 {
 	const struct mcux_flexcomm_config *config = dev->config;
 	struct mcux_flexcomm_data *data = dev->data;
 	USART_Type *base = config->base;
+	struct pm_state_constraint match = {
+		.state = state,
+		.substate_id = substate,
+	};
 
-	if (pm_policy_device_is_disabling_state(dev, state, 0)) {
+	if (pm_state_in_constraints(&config->lp_states, match)) {
 		clock_control_configure(config->clock_dev, config->clock_subsys, NULL);
 		base->OSR = data->old_osr;
 		base->BRG = data->old_brg;
@@ -1384,24 +1395,31 @@ static void serial_mcux_flexcomm_##n##_wakeup_cfg(void)				\
 #define UART_MCUX_FLEXCOMM_WAKEUP_CFG_BIND(n)					\
 		.wakeup_cfg = serial_mcux_flexcomm_##n##_wakeup_cfg,
 
+#define UART_MCUX_FLEXCOMM_LP_STATES_DEFINE(n)	\
+	PM_STATE_CONSTRAINTS_LIST_DEFINE(DT_DRV_INST(n), low_power_states);	\
+
+#define UART_MCUX_FLEXCOMM_LP_STATES_BIND(n)	\
+	.lp_states = PM_STATE_CONSTRAINTS_GET(DT_DRV_INST(n), low_power_states),\
+
 #define UART_MCUX_FLEXCOMM_PM_HANDLES_DEFINE(n)					\
-static void serial_mcux_flexcomm_##n##_pm_entry(enum pm_state state)		\
+static void serial_mcux_flexcomm_##n##_pm_entry(enum pm_state state, uint8_t substate) \
 {										\
 	IF_ENABLED(DT_INST_PROP(n, wakeup_source), (				\
-		mcux_flexcomm_pm_prepare_wake(DEVICE_DT_INST_GET(n), state);	\
+		mcux_flexcomm_pm_prepare_wake(DEVICE_DT_INST_GET(n), state, substate); \
 	))									\
 }										\
 										\
-static void serial_mcux_flexcomm_##n##_pm_exit(enum pm_state state)		\
+static void serial_mcux_flexcomm_##n##_pm_exit(enum pm_state state, uint8_t substate) \
 {										\
 	IF_ENABLED(DT_INST_PROP(n, wakeup_source), (				\
-		mcux_flexcomm_pm_restore_wake(DEVICE_DT_INST_GET(n), state);	\
+		mcux_flexcomm_pm_restore_wake(DEVICE_DT_INST_GET(n), state, substate); \
 	))									\
 }
 #define UART_MCUX_FLEXCOMM_PM_HANDLES_BIND(n)					\
 	.pm_handles = {								\
-			.state_entry = serial_mcux_flexcomm_##n##_pm_entry,	\
-			.state_exit = serial_mcux_flexcomm_##n##_pm_exit,	\
+			.substate_entry = serial_mcux_flexcomm_##n##_pm_entry,	\
+			.substate_exit = serial_mcux_flexcomm_##n##_pm_exit,	\
+			.report_substate = true,				\
 	},
 #define UART_MCUX_FLEXCOMM_LP_CLK_SUBSYS(n)					\
 	.lp_clock_subsys = (clock_control_subsys_t)				\
@@ -1411,6 +1429,8 @@ static void serial_mcux_flexcomm_##n##_pm_exit(enum pm_state state)		\
 #define UART_MCUX_FLEXCOMM_WAKEUP_CFG_BIND(n)
 #define UART_MCUX_FLEXCOMM_PM_HANDLES_DEFINE(n)
 #define UART_MCUX_FLEXCOMM_PM_HANDLES_BIND(n)
+#define UART_MCUX_FLEXCOMM_LP_STATES_DEFINE(n)
+#define UART_MCUX_FLEXCOMM_LP_STATES_BIND(n)
 #define UART_MCUX_FLEXCOMM_LP_CLK_SUBSYS(n)
 #endif /* FC_UART_IS_WAKEUP */
 
@@ -1423,6 +1443,7 @@ static const struct mcux_flexcomm_config mcux_flexcomm_##n##_config = {		\
 	.baud_rate = DT_INST_PROP(n, current_speed),				\
 	.parity = DT_INST_ENUM_IDX(n, parity),					\
 	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\
+	UART_MCUX_FLEXCOMM_LP_STATES_BIND(n)					\
 	UART_MCUX_FLEXCOMM_IRQ_CFG_FUNC_INIT(n)					\
 	UART_MCUX_FLEXCOMM_ASYNC_CFG(n)						\
 	UART_MCUX_FLEXCOMM_PM_UNLOCK_FUNC_BIND(n)				\
@@ -1448,7 +1469,10 @@ static struct mcux_flexcomm_data mcux_flexcomm_##n##_data = {			\
 										\
 	UART_MCUX_FLEXCOMM_IRQ_CFG_FUNC(n)					\
 										\
+	UART_MCUX_FLEXCOMM_LP_STATES_DEFINE(n)					\
+										\
 	UART_MCUX_FLEXCOMM_INIT_CFG(n)						\
+										\
 										\
 	DEVICE_DT_INST_DEFINE(n,						\
 			    &mcux_flexcomm_init,				\

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -272,6 +272,7 @@
 		dma-names = "rx", "tx";
 		zephyr,disabling-power-states = <&suspend &standby>;
 		power-domains = <&power_mode3_domain>;
+		low-power-states = <&suspend>;
 		status = "disabled";
 	};
 
@@ -286,6 +287,7 @@
 		dma-names = "rx", "tx";
 		zephyr,disabling-power-states = <&suspend &standby>;
 		power-domains = <&power_mode3_domain>;
+		low-power-states = <&suspend>;
 		status = "disabled";
 	};
 
@@ -300,6 +302,7 @@
 		dma-names = "rx", "tx";
 		zephyr,disabling-power-states = <&suspend &standby>;
 		power-domains = <&power_mode3_domain>;
+		low-power-states = <&suspend>;
 		status = "disabled";
 	};
 
@@ -314,6 +317,7 @@
 		dma-names = "rx", "tx";
 		zephyr,disabling-power-states = <&suspend &standby>;
 		power-domains = <&power_mode3_domain>;
+		low-power-states = <&suspend>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -85,10 +85,11 @@
 		ranges = <0x0 0x443C0000 DT_SIZE_K(140)>;
 	};
 
-	power_mode3_domain: power_mode3_domain {
+	peripheral_domain: peripheral-domain {
 		compatible = "power-domain-soc-state-change";
-		onoff-power-states = <&standby>;
 		#power-domain-cells = <0>;
+		zephyr,disabling-power-states = <&suspend &standby>;
+		onoff-power-states = <&standby>;
 	};
 
 	xtal32: xtal32 {
@@ -205,7 +206,7 @@
 		reg = <0x14000 0x1000>;
 		status = "okay";
 		interrupts = <123 0>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 	};
 
 	wwdt: watchdog@e000 {
@@ -213,7 +214,7 @@
 		reg = <0xe000 0x1000>;
 		interrupts = <0 0>;
 		status = "disabled";
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 		clk-divider = <1>;
 	};
 
@@ -229,7 +230,7 @@
 			#gpio-cells = <2>;
 			reg = <0>;
 			int-source = "pint";
-			power-domains = <&power_mode3_domain>;
+			power-domains = <&peripheral_domain>;
 		};
 
 		hsgpio1: gpio@1 {
@@ -238,7 +239,7 @@
 			#gpio-cells = <2>;
 			reg = <1>;
 			int-source = "pint";
-			power-domains = <&power_mode3_domain>;
+			power-domains = <&peripheral_domain>;
 		};
 	};
 
@@ -248,7 +249,7 @@
 		interrupts = <50 1>;
 		interrupt-names = "usb_otg";
 		num-bidir-endpoints = <8>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 		status = "disabled";
 	};
 
@@ -257,7 +258,7 @@
 		reg = <0x145000 0x200>;
 		interrupts = <50 1>;
 		interrupt-names = "usb_otg";
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 		status = "disabled";
 	};
 
@@ -271,8 +272,8 @@
 		dmas = <&dma0 0>, <&dma0 1>;
 		dma-names = "rx", "tx";
 		zephyr,disabling-power-states = <&suspend &standby>;
-		power-domains = <&power_mode3_domain>;
 		low-power-states = <&suspend>;
+		power-domains = <&peripheral_domain>;
 		status = "disabled";
 	};
 
@@ -286,8 +287,8 @@
 		dmas = <&dma0 2>, <&dma0 3>;
 		dma-names = "rx", "tx";
 		zephyr,disabling-power-states = <&suspend &standby>;
-		power-domains = <&power_mode3_domain>;
 		low-power-states = <&suspend>;
+		power-domains = <&peripheral_domain>;
 		status = "disabled";
 	};
 
@@ -301,8 +302,8 @@
 		dmas = <&dma0 4>, <&dma0 5>;
 		dma-names = "rx", "tx";
 		zephyr,disabling-power-states = <&suspend &standby>;
-		power-domains = <&power_mode3_domain>;
 		low-power-states = <&suspend>;
+		power-domains = <&peripheral_domain>;
 		status = "disabled";
 	};
 
@@ -316,8 +317,8 @@
 		dmas = <&dma0 6>, <&dma0 7>;
 		dma-names = "rx", "tx";
 		zephyr,disabling-power-states = <&suspend &standby>;
-		power-domains = <&power_mode3_domain>;
 		low-power-states = <&suspend>;
+		power-domains = <&peripheral_domain>;
 		status = "disabled";
 	};
 
@@ -330,7 +331,7 @@
 		dmas = <&dma0 26>, <&dma0 27>;
 		dma-names = "rx", "tx";
 		zephyr,disabling-power-states = <&suspend &standby>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 		status = "disabled";
 	};
 
@@ -356,14 +357,14 @@
 			     <35 2>, <36 2>, <37 2>, <38 2>;
 		num-lines = <8>;
 		num-inputs = <64>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 	};
 
 	imu: nxp_wifi {
 		compatible = "nxp,wifi";
 		/* first index is the imu interrupt, the second is the wakeup done interrupt */
 		interrupts = <72 2>, <64 2>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 	};
 
 	dma0: dma-controller@104000 {
@@ -373,7 +374,7 @@
 		status = "disabled";
 		#dma-cells = <1>;
 		dma-channels = <33>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 	};
 
 	lcdic: lcdic@128000 {
@@ -386,7 +387,7 @@
 		clocks = <&clkctl1 MCUX_LCDIC_CLK>;
 		dmas = <&dma0 0>;
 		zephyr,disabling-power-states = <&suspend &standby>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 	};
 
 	rtc: rtc@30000 {
@@ -411,7 +412,7 @@
 		mode = <0>;
 		input = <0>;
 		prescale = <0>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 	};
 
 	ctimer1: ctimer@29000 {
@@ -424,7 +425,7 @@
 		mode = <0>;
 		input = <0>;
 		prescale = <0>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 	};
 
 	ctimer2: ctimer@2a000 {
@@ -437,7 +438,7 @@
 		mode = <0>;
 		input = <0>;
 		prescale = <0>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 	};
 
 	ctimer3: ctimer@2b000 {
@@ -450,7 +451,7 @@
 		mode = <0>;
 		input = <0>;
 		prescale = <0>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 	};
 
 	sctimer: pwm@146000 {
@@ -461,7 +462,7 @@
 		status = "disabled";
 		prescaler = <8>;
 		#pwm-cells = <3>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 	};
 
 	mrt0: mrt@2d000 {
@@ -474,7 +475,7 @@
 		resets = <&rstctl1 NXP_SYSCON_RESET(2, 8)>;
 		#address-cells = <1>;
 		#size-cells = <0>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 
 		mrt0_channel0: mrt0_channel@0 {
 			compatible = "nxp,mrt-channel";
@@ -511,7 +512,7 @@
 		resets = <&rstctl0 NXP_SYSCON_RESET(2, 26)>;
 		#address-cells = <1>;
 		#size-cells = <0>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 
 		mrt1_channel0: mrt1_channel@0 {
 			compatible = "nxp,mrt-channel";
@@ -546,7 +547,7 @@
 		interrupts = <25 0>;
 		status = "disabled";
 		clocks = <&clkctl1 MCUX_DMIC_CLK>;
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 
 		pdmc0: dmic-channel@0 {
 			reg = <0>;
@@ -584,7 +585,7 @@
 			interrupts = <112 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
-			power-domains = <&power_mode3_domain>;
+			power-domains = <&peripheral_domain>;
 		};
 
 		adc1: gau_adc1@38100 {
@@ -593,7 +594,7 @@
 			interrupts = <111 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
-			power-domains = <&power_mode3_domain>;
+			power-domains = <&peripheral_domain>;
 		};
 
 		dac0: dac@38200 {
@@ -602,7 +603,7 @@
 			interrupts = <108 0>;
 			status = "disabled";
 			#io-channel-cells = <0>;
-			power-domains = <&power_mode3_domain>;
+			power-domains = <&peripheral_domain>;
 		};
 	};
 
@@ -621,14 +622,14 @@
 
 	hci: hci_ble {
 		compatible = "nxp,hci-ble";
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 	};
 
 	hdlc_rcp_if: hdlc_rcp_if {
 		compatible = "nxp,hdlc-rcp-if";
 		interrupts = <90 2>, <82 2>;
 		interrupt-names = "hdlc_rcp_if_int", "wakeup_int";
-		power-domains = <&power_mode3_domain>;
+		power-domains = <&peripheral_domain>;
 	};
 
 	enet: enet@138000 {
@@ -643,7 +644,7 @@
 			nxp,mdio = <&enet_mdio>;
 			ptp-clock = <&enet_ptp_clock>;
 			status = "disabled";
-			power-domains = <&power_mode3_domain>;
+			power-domains = <&peripheral_domain>;
 		};
 
 		enet_mdio: mdio {
@@ -651,7 +652,7 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			power-domains = <&power_mode3_domain>;
+			power-domains = <&peripheral_domain>;
 		};
 
 		enet_ptp_clock: ptp-clock {
@@ -659,7 +660,7 @@
 			interrupts = <116 0>;
 			status = "disabled";
 			clocks = <&clkctl1 MCUX_ENET_PLL>;
-			power-domains = <&power_mode3_domain>;
+			power-domains = <&peripheral_domain>;
 		};
 	};
 };

--- a/dts/bindings/arm/nxp,lpc-flexcomm.yaml
+++ b/dts/bindings/arm/nxp,lpc-flexcomm.yaml
@@ -13,3 +13,10 @@ properties:
 
   interrupts:
     required: true
+
+  low-power-states:
+    type: phandles
+    description: |
+      power states which will put the uart into a "low power mode" in which it cannot
+      function with normal baud rate but will retain state
+      and activity on the RX line can cause wakeup if wakeup function is also enabled.

--- a/include/zephyr/pm/pm.h
+++ b/include/zephyr/pm/pm.h
@@ -55,16 +55,33 @@ extern "C" {
  */
 struct pm_notifier {
 	sys_snode_t _node;
-	/**
-	 * Application defined function for doing any target specific operations
-	 * for power state entry.
-	 */
-	void (*state_entry)(enum pm_state state);
-	/**
-	 * Application defined function for doing any target specific operations
-	 * for power state exit.
-	 */
-	void (*state_exit)(enum pm_state state);
+	union {
+		struct {
+			/**
+			 * Application defined function for doing any target specific operations
+			 * for power state entry.
+			 */
+			void (*state_entry)(enum pm_state state);
+			/**
+			 * Application defined function for doing any target specific operations
+			 * for power state exit.
+			 */
+			void (*state_exit)(enum pm_state state);
+		};
+		struct {
+			/**
+			 * Application defined function for doing any target specific operations
+			 * for power state entry. Reports the substate id additionally.
+			 */
+			void (*substate_entry)(enum pm_state state, uint8_t substate_id);
+			/**
+			 * Application defined function for doing any target specific operations
+			 * for power state exit. Reports the substate id additionally.
+			 */
+			void (*substate_exit)(enum pm_state state, uint8_t substate_id);
+		};
+	};
+	bool report_substate; /* 0 is for backwards compatibility that didn't report substates */
 };
 
 #if defined(CONFIG_PM) || defined(__DOXYGEN__)

--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -126,6 +126,36 @@ void pm_policy_state_lock_get(enum pm_state state, uint8_t substate_id);
 void pm_policy_state_lock_put(enum pm_state state, uint8_t substate_id);
 
 /**
+ * @brief Apply power state constraints by locking the specified states.
+ *
+ * This function locks all power states specified in the union of all constraints
+ * in the provided constraint list. Each constraint in the set contributes to
+ * determining which power states should be locked (not allowed), by increasing
+ * a reference count just as if pm_policy_state_lock_get was called on each constraints'
+ * states individually.
+ *
+ * @param constraints Pointer to the power state constraints set to apply.
+ *
+ * @see pm_policy_state_constraints_put()
+ */
+void pm_policy_state_constraints_get(struct pm_state_constraints *constraints);
+
+/**
+ * @brief Remove power state constraints by unlocking the specified states.
+ *
+ * This function unlocks all power states that were previously locked by a
+ * corresponding call to pm_policy_state_constraints_get() with the same
+ * constraint set. The function decreases the lock counter for each affected
+ * power state specified in the union of all constraints in the list, just as
+ * if pm_policy_state_put was called on all the constraints' states individually.
+ *
+ * @param constraints Pointer to the power state constraints set to remove.
+ *
+ * @see pm_policy_state_constraints_get()
+ */
+void pm_policy_state_constraints_put(struct pm_state_constraints *constraints);
+
+/**
  * @brief Check if a power state lock is active (not allowed).
  *
  * @param state Power state.

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -168,7 +168,8 @@ struct pm_state_info {
 };
 
 /**
- * Power state information needed to lock a power state.
+ * Information needed to be able to reference a power state as a constraint
+ * on some device or system functions.
  */
 struct pm_state_constraint {
 	 /**
@@ -183,6 +184,16 @@ struct pm_state_constraint {
 	  * @see pm_state
 	  **/
 	uint8_t substate_id;
+};
+
+/**
+ * Collection of multiple power state constraints.
+ */
+struct pm_state_constraints {
+	/** Array of power state constraints */
+	struct pm_state_constraint *list;
+	/** Number of constraints in the list */
+	size_t count;
 };
 
 /** @cond INTERNAL_HIDDEN */
@@ -359,6 +370,54 @@ struct pm_state_constraint {
 			Z_PM_STATE_FROM_DT_CPU, (), node_id)		       \
 	}
 
+/**
+ * @brief initialize a device pm constraint with information from devicetree.
+ *
+ * @param node_id Node identifier.
+ */
+#define PM_STATE_CONSTRAINT_INIT(node_id)                                     \
+	{                                                                     \
+		.state = PM_STATE_DT_INIT(node_id),                           \
+		.substate_id = DT_PROP_OR(node_id, substate_id, 0),           \
+	}
+
+#define Z_PM_STATE_CONSTRAINT_REF(node_id, phandle, idx)                        \
+	PM_STATE_CONSTRAINT_INIT(DT_PHANDLE_BY_IDX(node_id, phandle, idx))
+
+#define Z_PM_STATE_CONSTRAINTS_LIST_NAME(node_id, phandles)                   \
+	_CONCAT_4(node_id, _, phandles, _constraints)
+
+/**
+ * @brief Define a list of power state constraints from devicetree.
+ *
+ * This macro creates an array of pm_state_constraint structures initialized
+ * with power state information from the specified devicetree property.
+ *
+ * @param node_id Devicetree node identifier.
+ * @param prop Property name containing the list of power state phandles.
+ */
+#define PM_STATE_CONSTRAINTS_LIST_DEFINE(node_id, prop)                                    \
+	struct pm_state_constraint Z_PM_STATE_CONSTRAINTS_LIST_NAME(node_id, prop)[] =     \
+	{                                                                                  \
+		DT_FOREACH_PROP_ELEM_SEP(node_id, prop, Z_PM_STATE_CONSTRAINT_REF, (,))    \
+	}
+
+/**
+ * @brief Get power state constraints structure from devicetree.
+ *
+ * This macro creates a structure containing a pointer to the constraints list
+ * and the count of constraints, suitable for initializing a pm_state_constraints
+ * structure. Must be used after the PM_STATE_CONSTRAINTS_LIST_DEFINE call for the same
+ * @param prop to refer to the array of constraints.
+ *
+ * @param node_id Devicetree node identifier.
+ * @param prop Property name containing the list of power state phandles.
+ */
+#define PM_STATE_CONSTRAINTS_GET(node_id, prop)                                            \
+	{                                                                                  \
+		.list = Z_PM_STATE_CONSTRAINTS_LIST_NAME(node_id, prop),                   \
+		.count = DT_PROP_LEN(node_id, prop),                                       \
+	}
 
 #if defined(CONFIG_PM) || defined(__DOXYGEN__)
 /**
@@ -403,6 +462,18 @@ const char *pm_state_to_str(enum pm_state state);
  * @return 0 on success, -EINVAL if the string is invalid or NULL.
  */
 int pm_state_from_str(const char *name, enum pm_state *out);
+
+/**
+ * @brief Check if a power management constraint matches any in a set of constraints.
+ *
+ * @param constraints Pointer to the power state constraints structure.
+ * @param match The constraint to match against.
+ *
+ * @return true if the constraint matches, false otherwise.
+ */
+bool pm_state_in_constraints(const struct pm_state_constraints *constraints,
+			     const struct pm_state_constraint match);
+
 /**
  * @}
  */
@@ -428,6 +499,14 @@ static inline const struct pm_state_info *pm_state_get(uint8_t cpu,
 	return NULL;
 }
 
+static inline bool pm_state_in_constraints(struct pm_state_constraints *constraints,
+					   struct pm_state_constraint match)
+{
+	ARG_UNUSED(constraints);
+	ARG_UNUSED(match);
+
+	return false;
+}
 #endif /* CONFIG_PM */
 
 #ifdef __cplusplus

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -47,19 +47,29 @@ static inline void pm_state_notify(bool entering_state)
 {
 	struct pm_notifier *notifier;
 	k_spinlock_key_t pm_notifier_key;
-	void (*callback)(enum pm_state state);
+	union {
+		void (*without_substate)(enum pm_state state);
+		void (*with_substate)(enum pm_state state, uint8_t substate_id);
+	} callback;
 
 	pm_notifier_key = k_spin_lock(&pm_notifier_lock);
 	SYS_SLIST_FOR_EACH_CONTAINER(&pm_notifiers, notifier, _node) {
 		if (entering_state) {
-			callback = notifier->state_entry;
+			/* should be equivalent to also setting the "with substate" */
+			callback.without_substate = notifier->state_entry;
 		} else {
-			callback = notifier->state_exit;
+			/* should be equivalent to also setting the "with substate" */
+			callback.without_substate = notifier->state_exit;
 		}
 
-		if (callback) {
-			callback(z_cpus_pm_state[CPU_ID]->state);
-		}
+		if (callback.with_substate && notifier->report_substate) {
+			callback.with_substate(z_cpus_pm_state[CPU_ID]->state,
+					       z_cpus_pm_state[CPU_ID]->substate_id);
+		} else if (callback.without_substate) {
+			callback.without_substate(z_cpus_pm_state[CPU_ID]->state);
+		} else {
+			/* intentionally empty */
+		};
 	}
 	k_spin_unlock(&pm_notifier_lock, pm_notifier_key);
 }

--- a/subsys/pm/policy/policy_device_lock.c
+++ b/subsys/pm/policy/policy_device_lock.c
@@ -24,16 +24,6 @@ struct pm_state_device_constraint {
  */
 #define PM_CONSTRAINTS_NAME(node_id) _CONCAT(__devicepmconstraints_, node_id)
 
-/**
- * @brief initialize a device pm constraint with information from devicetree.
- *
- * @param node_id Node identifier.
- */
-#define PM_STATE_CONSTRAINT_INIT(node_id)                                     \
-	{                                                                     \
-		.state = PM_STATE_DT_INIT(node_id),                           \
-		.substate_id = DT_PROP_OR(node_id, substate_id, 0),           \
-	}
 
 /**
  * @brief Helper macro to define a device pm constraints.

--- a/subsys/pm/policy/policy_state_lock.c
+++ b/subsys/pm/policy/policy_state_lock.c
@@ -65,6 +65,14 @@ void pm_policy_state_lock_get(enum pm_state state, uint8_t substate_id)
 #endif
 }
 
+void pm_policy_state_constraints_get(struct pm_state_constraints *constraints)
+{
+	for (int i = 0; i < constraints->count; i++) {
+		pm_policy_state_lock_get(constraints->list[i].state,
+					 constraints->list[i].substate_id);
+	}
+}
+
 void pm_policy_state_lock_put(enum pm_state state, uint8_t substate_id)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(zephyr_power_state)
@@ -82,6 +90,14 @@ void pm_policy_state_lock_put(enum pm_state state, uint8_t substate_id)
 		}
 	}
 #endif
+}
+
+void pm_policy_state_constraints_put(struct pm_state_constraints *constraints)
+{
+	for (int i = 0; i < constraints->count; i++) {
+		pm_policy_state_lock_put(constraints->list[i].state,
+					 constraints->list[i].substate_id);
+	}
 }
 
 bool pm_policy_state_lock_is_active(enum pm_state state, uint8_t substate_id)

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -152,3 +152,20 @@ int pm_state_from_str(const char *name, enum pm_state *out)
 
 	return 0;
 }
+
+bool pm_state_in_constraints(const struct pm_state_constraints *constraints,
+			     const struct pm_state_constraint match)
+{
+	struct pm_state_constraint *constraints_list = constraints->list;
+	size_t num_constraints = constraints->count;
+	bool match_found = false;
+
+	for (int i = 0; i < num_constraints; i++) {
+		enum pm_state state = constraints_list[i].state;
+		uint8_t substate = constraints_list[i].substate_id;
+
+		match_found |= ((state == match.state) && (substate == match.substate_id));
+	}
+
+	return match_found;
+}

--- a/tests/subsys/pm/policy_api/app.overlay
+++ b/tests/subsys/pm/policy_api/app.overlay
@@ -37,6 +37,10 @@
 			substate-id = <100>;
 		};
 	};
+
+	zephyr,user {
+		test-states = <&state0 &state2>;
+	};
 };
 
 &cpu0 {

--- a/tests/subsys/pm/policy_api/src/main.c
+++ b/tests/subsys/pm/policy_api/src/main.c
@@ -258,6 +258,112 @@ ZTEST(policy_api, test_pm_policy_next_state_default_latency)
 	pm_policy_latency_request_remove(&req1);
 	zassert_equal(latency_cb_call_cnt, 1);
 }
+
+/**
+ * @brief Test pm_policy_state_constraints_get/put functions using devicetree
+ * test-states property and PM_STATE_CONSTRAINTS macros.
+ */
+ZTEST(policy_api, test_pm_policy_state_constraints)
+{
+	/* Define constraints list from the zephyr,user test-states property */
+	PM_STATE_CONSTRAINTS_LIST_DEFINE(DT_PATH(zephyr_user), test_states);
+
+	/* Get the constraints structure from devicetree */
+	struct pm_state_constraints test_constraints =
+		PM_STATE_CONSTRAINTS_GET(DT_PATH(zephyr_user), test_states);
+
+	/* Verify the constraints were parsed correctly from devicetree
+	 * test-states = <&state0 &state2> from app.overlay
+	 */
+	zassert_equal(test_constraints.count, 2,
+		      "Expected 2 constraints from test-states property");
+
+	/* Check that the constraints contain the expected states:
+	 * state0 (runtime-idle, substate 1) and state2 (suspend-to-ram, substate 100)
+	 */
+	bool found_runtime_idle = false;
+	bool found_suspend_to_ram = false;
+
+	for (size_t i = 0; i < test_constraints.count; i++) {
+		TC_PRINT("Constraint %zu: state=%d, substate_id=%d\n",
+			 i, test_constraints.list[i].state, test_constraints.list[i].substate_id);
+
+		if (test_constraints.list[i].state == PM_STATE_RUNTIME_IDLE &&
+		    test_constraints.list[i].substate_id == 1) {
+			found_runtime_idle = true;
+		}
+		if (test_constraints.list[i].state == PM_STATE_SUSPEND_TO_RAM &&
+		    test_constraints.list[i].substate_id == 100) {
+			found_suspend_to_ram = true;
+		}
+	}
+
+	zassert_true(found_runtime_idle,
+		     "Expected runtime-idle state with substate 1 in constraints");
+	zassert_true(found_suspend_to_ram,
+		     "Expected suspend-to-ram state with substate 100 in constraints");
+
+	/* Test that states are initially available */
+	zassert_false(pm_policy_state_lock_is_active(PM_STATE_RUNTIME_IDLE, 1),
+		      "runtime-idle substate 1 should be initially available");
+	zassert_false(pm_policy_state_lock_is_active(PM_STATE_SUSPEND_TO_RAM, 100),
+		      "suspend-to-ram substate 100 should be initially available");
+
+	/* Apply the constraints - this should lock the specified states */
+	pm_policy_state_constraints_get(&test_constraints);
+
+	/* Verify that the constrained states are now locked */
+	zassert_true(pm_policy_state_lock_is_active(PM_STATE_RUNTIME_IDLE, 1),
+		     "runtime-idle substate 1 should be locked after applying constraints");
+	zassert_true(pm_policy_state_lock_is_active(PM_STATE_SUSPEND_TO_RAM, 100),
+		     "suspend-to-ram substate 100 should be locked after applying constraints");
+
+	/* Verify that non-constrained states are still available */
+	zassert_false(pm_policy_state_lock_is_active(PM_STATE_SUSPEND_TO_RAM, 10),
+		      "suspend-to-ram substate 10 should not be locked");
+
+	/* Test that policy respects the constraints */
+	const struct pm_state_info *next;
+
+	/* This should not return the locked runtime-idle state,
+	 * but should return suspend-to-ram substate 10
+	 */
+	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(1100000));
+	zassert_not_null(next, "Policy should return an available state");
+	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM);
+	zassert_equal(next->substate_id, 10);
+
+	/* Remove the constraints - this should unlock the states */
+	pm_policy_state_constraints_put(&test_constraints);
+
+	/* Verify that the previously constrained states are now unlocked */
+	zassert_false(pm_policy_state_lock_is_active(PM_STATE_RUNTIME_IDLE, 1),
+		      "runtime-idle substate 1 should be unlocked after removing constraints");
+	zassert_false(pm_policy_state_lock_is_active(PM_STATE_SUSPEND_TO_RAM, 100),
+		      "suspend-to-ram substate 100 should be unlocked after removing constraints");
+
+	/* Verify policy works normally again */
+	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
+	zassert_not_null(next, "Policy should return a state after removing constraints");
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
+
+	/* Test multiple get/put cycles to verify reference counting */
+	pm_policy_state_constraints_get(&test_constraints);
+	pm_policy_state_constraints_get(&test_constraints);
+
+	zassert_true(pm_policy_state_lock_is_active(PM_STATE_RUNTIME_IDLE, 1),
+		     "runtime-idle substate 1 should remain locked with multiple gets");
+
+	/* First put should not unlock (reference count > 1) */
+	pm_policy_state_constraints_put(&test_constraints);
+	zassert_true(pm_policy_state_lock_is_active(PM_STATE_RUNTIME_IDLE, 1),
+		     "runtime-idle substate 1 should remain locked after first put");
+
+	/* Second put should unlock (reference count = 0) */
+	pm_policy_state_constraints_put(&test_constraints);
+	zassert_false(pm_policy_state_lock_is_active(PM_STATE_RUNTIME_IDLE, 1),
+		      "runtime-idle substate 1 should be unlocked after final put");
+}
 #else
 ZTEST(policy_api, test_pm_policy_next_state_default)
 {
@@ -270,6 +376,11 @@ ZTEST(policy_api, test_pm_policy_next_state_default_allowed)
 }
 
 ZTEST(policy_api, test_pm_policy_next_state_default_latency)
+{
+	ztest_test_skip();
+}
+
+ZTEST(policy_api, test_pm_policy_state_constraints)
 {
 	ztest_test_skip();
 }


### PR DESCRIPTION
Cherry-picked the RW612 DTS refactor from https://github.com/zephyrproject-rtos/zephyr/pull/89372 and realized it causes runtime failures due to for example the flexcomm driver is trying to use the `pm_policy_device_is_disabling_state` API which stops working if the disabling state is not directly defined on the device's node and is defined on the parent instead,  so fix this in the policy_device_lock.c by checking first parent domain constraints