### PR TITLE
drivers: flash_mspi: Implement flash API get_size

### DIFF
--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -387,6 +387,12 @@ static int api_erase(const struct device *dev, off_t addr, size_t size)
 	return rc;
 }
 
+static int api_get_size(const struct device *dev, uint64_t *size)
+{
+	*size = dev_flash_size(dev);
+	return 0;
+}
+
 static const
 struct flash_parameters *api_get_parameters(const struct device *dev)
 {
@@ -771,6 +777,7 @@ static DEVICE_API(flash, drv_api) = {
 	.read = api_read,
 	.write = api_write,
 	.erase = api_erase,
+	.get_size = api_get_size,
 	.get_parameters = api_get_parameters,
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 	.page_layout = api_page_layout,


### PR DESCRIPTION
This is one of the flash APIs which was missing in this driver. I am implementing a flash shim driver, and to calculate the layout pages from the exposed flash APIs, I need this implemented in the underlying driver.
https://docs.zephyrproject.org/apidoc/latest/group__flash__interface.html#ga471edb53a2b1abe3dff0f4e2d216521e

For testing, this works locally now:
```
    uint64_t size = 0;
    int status = flash_get_size(DEVICE_DT_GET(DT_NODELABEL(flash_macronix)), &size);
    if (status != 0) {
        console_printf("Error getting flash size: %d\n", status);
        return status;
    }
    LOG_INF("Flash size: %llu\n", size);
```

This gets correctly logged with `size = <67108864>;` in the device tree node.
```
[00:00:09.567,000] <inf> main: Flash size: 8388608
```