### PR TITLE
net: config: sntp: improve logging

### DIFF
--- a/subsys/net/lib/config/init_clock_sntp.c
+++ b/subsys/net/lib/config/init_clock_sntp.c
@@ -53,13 +53,14 @@ int net_init_clock_via_sntp(void)
 	int res = sntp_init_helper(&ts);
 
 	if (res < 0) {
-		LOG_ERR("Cannot set time using SNTP");
+		LOG_ERR("Cannot set time using SNTP: %d", res);
 		goto end;
 	}
 
 	tspec.tv_sec = ts.seconds;
 	tspec.tv_nsec = ((uint64_t)ts.fraction * (1000 * 1000 * 1000)) >> 32;
 	res = sys_clock_settime(SYS_CLOCK_REALTIME, &tspec);
+	LOG_DBG("Time synced using SNTP");
 
 end:
 #ifdef CONFIG_NET_CONFIG_SNTP_INIT_RESYNC
@@ -74,16 +75,8 @@ end:
 #ifdef CONFIG_NET_CONFIG_SNTP_INIT_RESYNC
 static void sntp_resync_handler(struct k_work *work)
 {
-	int res;
-
 	ARG_UNUSED(work);
-
-	res = net_init_clock_via_sntp();
-	if (res < 0) {
-		LOG_ERR("Cannot resync time using SNTP");
-		return;
-	}
-	LOG_DBG("Time resynced using SNTP");
+	(void)net_init_clock_via_sntp();
 }
 #endif /* CONFIG_NET_CONFIG_SNTP_INIT_RESYNC */
 


### PR DESCRIPTION
Print return code on error and remove logging in `sntp_resync_handler` since it calls `net_init_clock_via_sntp` which already does logging.