### PR TITLE
modules: hostap: WPA Auto security supports WPA/WPA2 mixed mode

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -408,6 +408,8 @@ enum wifi_security_type wpas_key_mgmt_to_zephyr(bool is_hapd, void *config, int 
 			return WIFI_SECURITY_TYPE_SAE_HNP;
 		}
 	case WPA_KEY_MGMT_SAE | WPA_KEY_MGMT_PSK:
+	case WPA_KEY_MGMT_SAE | WPA_KEY_MGMT_PSK_SHA256:
+	case WPA_KEY_MGMT_SAE | WPA_KEY_MGMT_PSK_SHA256 | WPA_KEY_MGMT_PSK:
 		return WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL;
 	case WPA_KEY_MGMT_FT_PSK:
 		return WIFI_SECURITY_TYPE_FT_PSK;
@@ -809,12 +811,17 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				goto out;
 			}
 		} else if (params->security == WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL) {
-			if (!wpa_cli_cmd_v("set_network %d psk \"%s\"", resp.network_id,
-					   psk_null_terminated)) {
-				goto out;
-			}
-
 			if (params->sae_password) {
+				if ((params->sae_password_length < WIFI_PSK_MIN_LEN) ||
+				    (params->sae_password_length > WIFI_SAE_PSWD_MAX_LEN)) {
+					wpa_printf(MSG_ERROR,
+						"Passphrase should be in range (%d-%d) characters",
+						WIFI_PSK_MIN_LEN, WIFI_SAE_PSWD_MAX_LEN);
+					goto out;
+				}
+				strncpy(sae_null_terminated, params->sae_password,
+					WIFI_SAE_PSWD_MAX_LEN);
+				sae_null_terminated[params->sae_password_length] = '\0';
 				if (!wpa_cli_cmd_v("set_network %d sae_password \"%s\"",
 						   resp.network_id, sae_null_terminated)) {
 					goto out;
@@ -826,20 +833,29 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				}
 			}
 
+			if (!wpa_cli_cmd_v("set_network %d psk \"%s\"", resp.network_id,
+					   psk_null_terminated)) {
+				goto out;
+			}
+
 			if (!wpa_cli_cmd_v("set sae_pwe 2")) {
 				goto out;
 			}
 
-			if (!wpa_cli_cmd_v("set_network %d key_mgmt WPA-PSK SAE",
+			if (!wpa_cli_cmd_v("set_network %d key_mgmt WPA-PSK WPA-PSK-SHA256 SAE",
 					   resp.network_id)) {
 				goto out;
 			}
 
-			if (!wpa_cli_cmd_v("set_network %d group CCMP", resp.network_id)) {
+			if (!wpa_cli_cmd_v("set_network %d proto WPA RSN", resp.network_id)) {
 				goto out;
 			}
 
-			if (!wpa_cli_cmd_v("set_network %d pairwise CCMP", resp.network_id)) {
+			if (!wpa_cli_cmd_v("set_network %d group TKIP CCMP", resp.network_id)) {
+				goto out;
+			}
+
+			if (!wpa_cli_cmd_v("set_network %d pairwise TKIP CCMP", resp.network_id)) {
 				goto out;
 			}
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -799,15 +799,14 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 						   resp.network_id)) {
 					goto out;
 				}
-			} else {
-				if (!wpa_cli_cmd_v("set_network %d group CCMP", resp.network_id)) {
-					goto out;
-				}
+			}
 
-				if (!wpa_cli_cmd_v("set_network %d pairwise CCMP",
-						   resp.network_id)) {
-					goto out;
-				}
+			if (!wpa_cli_cmd_v("set_network %d group TKIP CCMP", resp.network_id)) {
+				goto out;
+			}
+
+			if (!wpa_cli_cmd_v("set_network %d pairwise TKIP CCMP", resp.network_id)) {
+				goto out;
 			}
 		} else if (params->security == WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL) {
 			if (!wpa_cli_cmd_v("set_network %d psk \"%s\"", resp.network_id,


### PR DESCRIPTION
1) Fix WPA2-PSK connection failures
When the external AP is in WPA/WPA2 mixed mode, the group cipher uses
    TKIP, the group cipher mismatches, so the connection fails.
    Fix: set the WPA2 group cipher to TKIP + CCMP by default.
2) WPA Auto security supports WPA/WPA2 mixed mode
WPA Auto security adds support for WPA/WPA2/WPA3 PSK security.
Supports auto security mode, enabling STA to select the most secure mode
among WPA, WPA2, and WPA3 based on the capabilities of the AP.