### PR TITLE
hal_ethos_u: decouple ETHOS_U_LOG_LEVEL from STDOUT_CONSOLE

### DIFF
--- a/modules/hal_ethos_u/Kconfig
+++ b/modules/hal_ethos_u/Kconfig
@@ -61,7 +61,7 @@ config ETHOS_U_NPU_NAME
 choice "ETHOS_U_LOG_LEVEL_CHOICE"
 	prompt "Max compiled-in log level for ETHOS_U"
 	default ETHOS_U_LOG_LEVEL_WRN
-	depends on STDOUT_CONSOLE
+	depends on LOG
 
 config ETHOS_U_LOG_LEVEL_NONE
 	bool "None"
@@ -85,7 +85,9 @@ endchoice
 
 config ETHOS_U_LOG_LEVEL
 	int
-	depends on STDOUT_CONSOLE
+	# Always define the symbol so C compiles cleanly even if LOG/console is off.
+	# When LOG is off, fall back to NONE (0).
+	default 0 if !LOG
 	default 0 if ETHOS_U_LOG_LEVEL_NONE
 	default 1 if ETHOS_U_LOG_LEVEL_ERR
 	default 2 if ETHOS_U_LOG_LEVEL_WRN


### PR DESCRIPTION
Previously the ETHOS_U_LOG_LEVEL choice and int symbol only existed when STDOUT_CONSOLE was enabled. This caused build and compile issues if logging was disabled, since CONFIG_ETHOS_U_LOG_LEVEL would be undefined and C code using LOG_MODULE_REGISTER() would fail.

- Replace dependency on STDOUT_CONSOLE with LOG.
- Ensure ETHOS_U_LOG_LEVEL is always defined, even when LOG is off. In that case default to 0 (NONE).

This guarantees a valid CONFIG_ETHOS_U_LOG_LEVEL is present in all configurations and allows clean builds regardless of console settings.