### PR TITLE
tests: benchmarks: Increase min_ram for benchmark.thread_metric.interrupt

### DIFF
--- a/tests/benchmarks/thread_metric/testcase.yaml
+++ b/tests/benchmarks/thread_metric/testcase.yaml
@@ -46,6 +46,7 @@ tests:
       - CONFIG_TM_COOPERATIVE=y
 
   benchmark.thread_metric.interrupt:
+    min_ram: 24
     extra_configs:
       - CONFIG_TM_INTERRUPT=y
 


### PR DESCRIPTION
Similarly to #95242, Twister attempts to run this test on HiFive1, failing with `heap size is too small` on allocation attempt.

It happens early, during `bg_thread_main`, but the compilation report suggests the binary is fills out the RAM memory completely:

```
Memory region         Used Size  Region Size  %age Used
             ROM:       28644 B        12 MB      0.23%
             RAM:       16364 B        16 KB     99.88%
        IDT_LIST:          0 GB         4 KB      0.00%
```