### PR TITLE
boards: nordic: nrf54lm20dk: Add aliases for MCUboot button/LED

### DIFF
--- a/boards/nordic/nrf54lm20dk/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20a_cpuapp_common.dtsi
@@ -21,6 +21,11 @@
 		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,ieee802154 = &ieee802154;
 	};
+
+	aliases {
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
+	};
 };
 
 &cpuapp_sram {


### PR DESCRIPTION
Adds aliases so that these can be used by MCUboot