### PR TITLE
net: config: sntp: add resync interval range

### DIFF
--- a/subsys/net/lib/config/Kconfig
+++ b/subsys/net/lib/config/Kconfig
@@ -248,10 +248,12 @@ if NET_CONFIG_SNTP_INIT_RESYNC
 config NET_CONFIG_SNTP_INIT_RESYNC_INTERVAL
 	int "SNTP resync interval (sec)"
 	default 3600
+	range 15 $(UINT32_MAX)
 
 config NET_CONFIG_SNTP_INIT_RESYNC_ON_FAILURE_INTERVAL
 	int "SNTP resync interval (sec) on failure"
 	default NET_CONFIG_SNTP_INIT_RESYNC_INTERVAL
+	range 15 $(UINT32_MAX)
 	help
 	  If the SNTP request fails, then this is the interval to wait
 	  before trying again.


### PR DESCRIPTION
RFC4330 section 10 states:

A client MUST NOT under any conditions use a poll interval less then 15 seconds.