### PR TITLE
kernel: do not include ksched.h in subsys/soc code

### DIFF
--- a/arch/arc/core/smp.c
+++ b/arch/arc/core/smp.c
@@ -11,13 +11,13 @@
  */
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
+#include <zephyr/irq.h>
 #include <zephyr/kernel_structs.h>
-#include <ksched.h>
 #include <ipi.h>
 #include <zephyr/init.h>
-#include <zephyr/irq.h>
 #include <zephyr/platform/hooks.h>
 #include <arc_irq_offload.h>
+#include <kernel_arch_func.h>
 
 volatile struct {
 	arch_cpustart_t fn;

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -5,7 +5,6 @@
 
 #include <zephyr/kernel/thread_stack.h>
 #include <zephyr/kernel.h>
-#include <ksched.h>
 #include <zephyr/arch/arm/cortex_a_r/lib_helpers.h>
 #include <zephyr/drivers/interrupt_controller/gic.h>
 #include <ipi.h>

--- a/arch/arm/core/cortex_a_r/thread.c
+++ b/arch/arm/core/cortex_a_r/thread.c
@@ -14,8 +14,8 @@
  */
 
 #include <zephyr/kernel.h>
+#include <kernel_internal.h>
 #include <zephyr/llext/symbol.h>
-#include <ksched.h>
 #include <zephyr/sys/barrier.h>
 #include <stdbool.h>
 #include <cmsis_core.h>

--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -15,8 +15,8 @@
  */
 
 #include <zephyr/kernel.h>
+#include <kernel_internal.h>
 #include <zephyr/llext/symbol.h>
-#include <ksched.h>
 #include <zephyr/sys/barrier.h>
 #include <stdbool.h>
 #include <cmsis_core.h>

--- a/arch/arm/core/cortex_m/thread_abort.c
+++ b/arch/arm/core/cortex_m/thread_abort.c
@@ -19,7 +19,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/sections.h>
-#include <ksched.h>
 #include <kswap.h>
 #include <zephyr/sys/__assert.h>
 

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -15,7 +15,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
 #include <zephyr/kernel_structs.h>
-#include <ksched.h>
+#include <kernel_arch_interface.h>
 #include <ipi.h>
 #include <zephyr/init.h>
 #include <zephyr/arch/arm64/mm.h>

--- a/arch/arm64/core/thread.c
+++ b/arch/arm64/core/thread.c
@@ -12,7 +12,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <ksched.h>
+#include <kernel_internal.h>
 #include <zephyr/arch/cpu.h>
 
 /*

--- a/arch/riscv/core/ipi_clint.c
+++ b/arch/riscv/core/ipi_clint.c
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ipi.h>
-#include <ksched.h>
-
 #include <zephyr/kernel.h>
+#include <kernel_arch_interface.h>
+#include <ipi.h>
 
 #define CLINT_NODE DT_NODELABEL(clint)
 #if !DT_NODE_EXISTS(CLINT_NODE)

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
-#include <ksched.h>
+#include <kernel_internal.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/arch/riscv/irq.h>

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <ksched.h>
+#include <kernel_internal.h>
 #include <zephyr/arch/riscv/csr.h>
 #include <stdio.h>
 #include <pmp.h>

--- a/arch/rx/core/thread.c
+++ b/arch/rx/core/thread.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <ksched.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -4,7 +4,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <ksched.h>
 #include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <zephyr/arch/common/exc_handle.h>

--- a/arch/x86/core/ia32/thread.c
+++ b/arch/x86/core/ia32/thread.c
@@ -13,7 +13,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <ksched.h>
 #include <zephyr/arch/x86/mmustructs.h>
 #include <kswap.h>
 #include <x86_mmu.h>

--- a/arch/x86/core/intel64/fatal.c
+++ b/arch/x86/core/intel64/fatal.c
@@ -4,7 +4,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <ksched.h>
 #include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <zephyr/logging/log.h>

--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -4,7 +4,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <ksched.h>
 #include <zephyr/arch/cpu.h>
 #include <kernel_arch_data.h>
 #include <kernel_arch_func.h>

--- a/arch/x86/core/intel64/smp.c
+++ b/arch/x86/core/intel64/smp.c
@@ -8,7 +8,7 @@
 #include <kernel_arch_data.h>
 #include <x86_mmu.h>
 #include <zephyr/init.h>
-#include <ksched.h>
+#include <ipi.h>
 
 #define NR_IRQ_VECTORS (IV_NR_VECTORS - IV_IRQS)  /* # vectors free for IRQs */
 

--- a/arch/x86/core/intel64/thread.c
+++ b/arch/x86/core/intel64/thread.c
@@ -4,7 +4,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <ksched.h>
 #include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <offsets_short.h>

--- a/arch/x86/core/userspace.c
+++ b/arch/x86/core/userspace.c
@@ -7,10 +7,10 @@
 #include <errno.h>
 
 #include <zephyr/kernel.h>
+#include <kernel_internal.h>
 #include <zephyr/sys/speculation.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <kernel_arch_func.h>
-#include <ksched.h>
 #include <x86_mmu.h>
 
 BUILD_ASSERT((CONFIG_PRIVILEGED_STACK_SIZE > 0) &&

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -6,7 +6,6 @@
 #include <string.h>
 #include <xtensa_asm2_context.h>
 #include <zephyr/kernel.h>
-#include <ksched.h>
 #include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kswap.h>

--- a/kernel/include/ipi.h
+++ b/kernel/include/ipi.h
@@ -17,6 +17,8 @@
 	(IS_ENABLED(CONFIG_IPI_OPTIMIZE) ? BIT(cpu_id) : IPI_ALL_CPUS_MASK)
 
 
+void z_sched_ipi(void);
+
 /* defined in ipi.c when CONFIG_SMP=y */
 #ifdef CONFIG_SMP
 void flag_ipi(uint32_t ipi_mask);

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -16,6 +16,7 @@
 
 #include <zephyr/kernel.h>
 #include <kernel_arch_interface.h>
+#include <kthread.h>
 #include <string.h>
 
 #ifndef _ASMLANGUAGE
@@ -144,9 +145,6 @@ extern int z_stack_adjust_initialized;
 extern struct k_thread z_main_thread;
 
 
-#ifdef CONFIG_MULTITHREADING
-extern struct k_thread z_idle_threads[CONFIG_MP_MAX_NUM_CPUS];
-#endif /* CONFIG_MULTITHREADING */
 K_KERNEL_PINNED_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 				    CONFIG_ISR_STACK_SIZE);
 K_THREAD_STACK_DECLARE(z_main_stack, CONFIG_MAIN_STACK_SIZE);

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -65,12 +65,10 @@ void *z_get_next_switch_handle(void *interrupted);
 
 void z_time_slice(void);
 void z_reset_time_slice(struct k_thread *curr);
-void z_sched_ipi(void);
 void z_sched_start(struct k_thread *thread);
 void z_ready_thread(struct k_thread *thread);
 void z_requeue_current(struct k_thread *curr);
 struct k_thread *z_swap_next_thread(void);
-void z_thread_abort(struct k_thread *thread);
 void move_thread_to_end_of_prio_q(struct k_thread *thread);
 bool thread_is_sliceable(struct k_thread *thread);
 

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -30,6 +30,10 @@
 extern struct k_spinlock z_thread_monitor_lock;
 #endif /* CONFIG_THREAD_MONITOR */
 
+#ifdef CONFIG_MULTITHREADING
+extern struct k_thread z_idle_threads[CONFIG_MP_MAX_NUM_CPUS];
+#endif /* CONFIG_MULTITHREADING */
+
 void idle(void *unused1, void *unused2, void *unused3);
 
 /* clean up when a thread is aborted */
@@ -42,6 +46,7 @@ void z_thread_monitor_exit(struct k_thread *thread);
 	} while (false)
 #endif /* CONFIG_THREAD_MONITOR */
 
+void z_thread_abort(struct k_thread *thread);
 
 static inline void thread_schedule_new(struct k_thread *thread, k_timeout_t delay)
 {

--- a/soc/espressif/esp32/esp32-mp.c
+++ b/soc/espressif/esp32/esp32-mp.c
@@ -22,7 +22,6 @@
 #ifdef CONFIG_SMP
 
 #include <ipi.h>
-#include <ksched.h>
 
 #ifndef CONFIG_SOC_ESP32_PROCPU
 static struct k_spinlock loglock;

--- a/soc/intel/intel_adsp/ace/multiprocessing.c
+++ b/soc/intel/intel_adsp/ace/multiprocessing.c
@@ -13,7 +13,6 @@
 #include <zephyr/pm/pm.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/pm/device_runtime.h>
-#include <ksched.h>
 
 #include <soc.h>
 #include <adsp_boot.h>

--- a/soc/intel/intel_adsp/cavs/multiprocessing.c
+++ b/soc/intel/intel_adsp/cavs/multiprocessing.c
@@ -2,7 +2,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
-#include <ksched.h>
 #include <cavs-idc.h>
 #include <adsp_memory.h>
 #include <adsp_shim.h>

--- a/subsys/portability/cmsis_rtos_v1/cmsis_kernel.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_kernel.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <ksched.h>
 #include <cmsis_os.h>
 #include <kernel_internal.h>
 

--- a/subsys/portability/cmsis_rtos_v2/thread.c
+++ b/subsys/portability/cmsis_rtos_v2/thread.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <ksched.h>
+#include <kernel_internal.h>
 #include <stdio.h>
 #include <string.h>
 #include <zephyr/sys/atomic.h>

--- a/subsys/tracing/sysview/sysview.c
+++ b/subsys/tracing/sysview/sysview.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
+#include <kernel_internal.h>
 #include <zephyr/kernel_structs.h>
 #include <zephyr/init.h>
 #include <zephyr/debug/cpu_load.h>
-#include <ksched.h>
 
 #include <SEGGER_SYSVIEW.h>
 

--- a/subsys/tracing/sysview/sysview_config.c
+++ b/subsys/tracing/sysview/sysview_config.c
@@ -5,8 +5,8 @@
  */
 
 #include <zephyr/kernel.h>
+#include <kernel_internal.h>
 #include <SEGGER_SYSVIEW.h>
-#include <ksched.h>
 #ifdef CONFIG_SYMTAB
 #include <zephyr/debug/symtab.h>
 #include <zephyr/sw_isr_table.h>


### PR DESCRIPTION
Do not directly include and use APIs from ksched.h outside of the
kernel. For now do this using more suitable (ipi.h and
kernel_internal.h) internal APIs until more cleanup is done.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
