### PR TITLE
boards: silabs: Clean up flash partitions

### DIFF
--- a/boards/silabs/dev_kits/pg23_pk2504a/pg23_pk2504a.dts
+++ b/boards/silabs/dev_kits/pg23_pk2504a/pg23_pk2504a.dts
@@ -213,22 +213,22 @@
 			read-only;
 		};
 
-		/* Reserve 208 kB for the application in slot 0 */
+		/* Reserve 216 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			reg = <0x0000c000 DT_SIZE_K(208)>;
+			reg = <0x0000c000 DT_SIZE_K(216)>;
 			label = "image-0";
 		};
 
-		/* Reserve 208 kB for the application in slot 1 */
-		slot1_partition: partition@40000 {
-			reg = <0x00040000 DT_SIZE_K(208)>;
+		/* Reserve 216 kB for the application in slot 1 */
+		slot1_partition: partition@42000 {
+			reg = <0x00042000 DT_SIZE_K(216)>;
 			label = "image-1";
 		};
 
-		/* Reserve 32 kB for the scratch partition */
-		scratch_partition: partition@74000 {
-			reg = <0x00074000 DT_SIZE_K(32)>;
-			label = "image-scratch";
+		/* Reserve 32 kB for the storage partition */
+		storage_partition: partition@78000 {
+			reg = <0x00078000 DT_SIZE_K(32)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a.dts
+++ b/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a.dts
@@ -221,22 +221,22 @@
 			read-only;
 		};
 
-		/* Reserve 208 kB for the application in slot 0 */
+		/* Reserve 472 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			reg = <0x0000c000 DT_SIZE_K(208)>;
+			reg = <0x0000c000 DT_SIZE_K(472)>;
 			label = "image-0";
 		};
 
-		/* Reserve 208 kB for the application in slot 1 */
-		slot1_partition: partition@40000 {
-			reg = <0x00040000 DT_SIZE_K(208)>;
+		/* Reserve 472 kB for the application in slot 1 */
+		slot1_partition: partition@82000 {
+			reg = <0x00082000 DT_SIZE_K(472)>;
 			label = "image-1";
 		};
 
-		/* Reserve 32 kB for the scratch partition */
-		scratch_partition: partition@74000 {
-			reg = <0x00074000 DT_SIZE_K(32)>;
-			label = "image-scratch";
+		/* Reserve 32 kB for the storage partition */
+		storage_partition: partition@f8000 {
+			reg = <0x000f8000 DT_SIZE_K(32)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/dev_kits/sltb010a/sltb010a.dts
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a.dts
@@ -77,26 +77,26 @@
 	partitions {
 		/* Reserve 48 KiB for the bootloader */
 		boot_partition: partition@0 {
-			reg = <0x00000000 0x0000c000>;
+			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 224 KiB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			reg = <0x0000c000 0x00038000>;
+			reg = <0x0000c000 DT_SIZE_K(224)>;
 			label = "image-0";
 		};
 
 		/* Reserve 224 KiB for the application in slot 1 */
 		slot1_partition: partition@44000 {
-			reg = <0x00044000 0x00038000>;
+			reg = <0x00044000 DT_SIZE_K(224)>;
 			label = "image-1";
 		};
 
 		/* Set 16 KiB of storage at the end of the 512 KiB of flash */
 		storage_partition: partition@7c000 {
-			reg = <0x0007c000 0x00004000>;
+			reg = <0x0007c000 DT_SIZE_K(16)>;
 			label = "storage";
 		};
 	};

--- a/boards/silabs/dev_kits/xg22_ek2710a/xg22_ek2710a.dts
+++ b/boards/silabs/dev_kits/xg22_ek2710a/xg22_ek2710a.dts
@@ -181,26 +181,26 @@
 
 		/* Reserve 48 KiB for the bootloader */
 		boot_partition: partition@0 {
-			reg = <0x00000000 0x0000c000>;
+			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 224 KiB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			reg = <0x0000c000 0x00038000>;
+			reg = <0x0000c000 DT_SIZE_K(224)>;
 			label = "image-0";
 		};
 
 		/* Reserve 224 KiB for the application in slot 1 */
 		slot1_partition: partition@44000 {
-			reg = <0x00044000 0x00038000>;
+			reg = <0x00044000 DT_SIZE_K(224)>;
 			label = "image-1";
 		};
 
 		/* Set 16 KiB of storage at the end of the 512 KiB of flash */
 		storage_partition: partition@7c000 {
-			reg = <0x0007c000 0x00004000>;
+			reg = <0x0007c000 DT_SIZE_K(16)>;
 			label = "storage";
 		};
 	};

--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
@@ -256,32 +256,26 @@
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
-			reg = <0x0 0x0000c000>;
+			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
 		};
 
-		/* Reserve 464 kB for the application in slot 0 */
+		/* Reserve 728 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			reg = <0x0000c000 0x00074000>;
+			reg = <0x0000c000 DT_SIZE_K(728)>;
 			label = "image-0";
 		};
 
-		/* Reserve 464 kB for the application in slot 1 */
-		slot1_partition: partition@80000 {
-			reg = <0x00080000 0x00074000>;
+		/* Reserve 728 kB for the application in slot 1 */
+		slot1_partition: partition@c2000 {
+			reg = <0x000c2000 DT_SIZE_K(728)>;
 			label = "image-1";
 		};
 
-		/* Reserve 32 kB for the scratch partition */
-		scratch_partition: partition@f4000 {
-			reg = <0x000f4000 0x00008000>;
-			label = "image-scratch";
-		};
-
-		/* Set 528Kb of storage at the end of the 1024Kb of flash */
-		storage_partition: partition@fc000 {
-			reg = <0x000fc000 0x00084000>;
+		/* Set 32 kB of storage at the end of the 1536 kB of flash */
+		storage_partition: partition@178000 {
+			reg = <0x00178000 DT_SIZE_K(32)>;
 			label = "storage";
 		};
 	};

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
@@ -172,32 +172,26 @@
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
-			reg = <0x0 0x0000c000>;
+			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
 		};
 
-		/* Reserve 464 kB for the application in slot 0 */
+		/* Reserve 728 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			reg = <0x0000c000 0x00074000>;
+			reg = <0x0000c000 DT_SIZE_K(728)>;
 			label = "image-0";
 		};
 
-		/* Reserve 464 kB for the application in slot 1 */
-		slot1_partition: partition@80000 {
-			reg = <0x00080000 0x00074000>;
+		/* Reserve 728 kB for the application in slot 1 */
+		slot1_partition: partition@c2000 {
+			reg = <0x000c2000 DT_SIZE_K(728)>;
 			label = "image-1";
 		};
 
-		/* Reserve 32 kB for the scratch partition */
-		scratch_partition: partition@f4000 {
-			reg = <0x000f4000 0x00008000>;
-			label = "image-scratch";
-		};
-
-		/* Set 528Kb of storage at the end of the 1024Kb of flash */
-		storage_partition: partition@fc000 {
-			reg = <0x000fc000 0x00084000>;
+		/* Set 32 kB of storage at the end of the 1536 kB of flash */
+		storage_partition: partition@178000 {
+			reg = <0x00178000 DT_SIZE_K(32)>;
 			label = "storage";
 		};
 	};

--- a/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.dts
+++ b/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.dts
@@ -86,21 +86,21 @@
 			read-only;
 		};
 
-		/* Reserve 328 KiB for the application in slot 0 */
+		/* Reserve 344 KiB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			reg = <0x0000c000 0x00052000>;
+			reg = <0x0000c000 DT_SIZE_K(344)>;
 			label = "image-0";
 		};
 
-		/* Reserve 328 KiB for the application in slot 1 */
-		slot1_partition: partition@5e000 {
-			reg = <0x0005e000 0x00052000>;
+		/* Reserve 344 KiB for the application in slot 1 */
+		slot1_partition: partition@62000 {
+			reg = <0x00062000 DT_SIZE_K(344)>;
 			label = "image-1";
 		};
 
-		/* Set 64 KiB of storage at the end of the 768 KiB of flash */
-		storage_partition: partition@b0000 {
-			reg = <0x000b0000 0x00010000>;
+		/* Set 32 KiB of storage at the end of the 768 KiB of flash */
+		storage_partition: partition@b8000 {
+			reg = <0x000b8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};
 	};

--- a/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
+++ b/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
@@ -160,34 +160,27 @@
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
-			reg = <0x0 0x0000c000>;
+			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
 		};
 
-		/* Reserve 464 kB for the application in slot 0 */
+		/* Reserve 472 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			reg = <0x0000c000 0x00074000>;
+			reg = <0x0000c000 DT_SIZE_K(472)>;
 			label = "image-0";
 		};
 
-		/* Reserve 464 kB for the application in slot 1 */
-		slot1_partition: partition@80000 {
-			reg = <0x00080000 0x00074000>;
+		/* Reserve 472 kB for the application in slot 1 */
+		slot1_partition: partition@82000 {
+			reg = <0x00082000 DT_SIZE_K(472)>;
 			label = "image-1";
 		};
 
-		/* Reserve 32 kB for the scratch partition */
-		scratch_partition: partition@f4000 {
-			reg = <0x000f4000 0x00008000>;
-			label = "image-scratch";
-		};
-
-		/* Set 16Kb of storage at the end of the 1024Kb of flash */
-		storage_partition: partition@fc000 {
-			reg = <0x000fc000 0x00004000>;
+		/* Set 32Kb of storage at the end of the 1024Kb of flash */
+		storage_partition: partition@f8000 {
+			reg = <0x000f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};
-
 	};
 };

--- a/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
+++ b/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
@@ -261,27 +261,21 @@
 			read-only;
 		};
 
-		/* Reserve 208 kB for the application in slot 0 */
+		/* Reserve 216 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			reg = <0x0000c000 DT_SIZE_K(208)>;
+			reg = <0x0000c000 DT_SIZE_K(216)>;
 			label = "image-0";
 		};
 
-		/* Reserve 208 kB for the application in slot 1 */
-		slot1_partition: partition@40000 {
-			reg = <0x00040000 DT_SIZE_K(208)>;
+		/* Reserve 216 kB for the application in slot 1 */
+		slot1_partition: partition@42000 {
+			reg = <0x00042000 DT_SIZE_K(216)>;
 			label = "image-1";
 		};
 
-		/* Reserve 32 kB for the scratch partition */
-		scratch_partition: partition@74000 {
-			reg = <0x00074000 DT_SIZE_K(32)>;
-			label = "image-scratch";
-		};
-
-		/* Set 16 kB of storage at the end of the 1536 kB of flash */
-		storage_partition: partition@7c000 {
-			reg = <0x0007c000 DT_SIZE_K(16)>;
+		/* Set 32 kB of storage at the end of the 512 kB of flash */
+		storage_partition: partition@78000 {
+			reg = <0x00078000 DT_SIZE_K(32)>;
 			label = "storage";
 		};
 	};

--- a/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.dts
+++ b/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.dts
@@ -236,27 +236,21 @@
 			read-only;
 		};
 
-		/* Reserve 720 kB for the application in slot 0 */
+		/* Reserve 728 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			reg = <0x0000c000 0x000B4000>;
+			reg = <0x0000c000 DT_SIZE_K(728)>;
 			label = "image-0";
 		};
 
-		/* Reserve 720 kB for the application in slot 1 */
-		slot1_partition: partition@C0000 {
-			reg = <0x000C0000 0x000B4000>;
+		/* Reserve 728 kB for the application in slot 1 */
+		slot1_partition: partition@c2000 {
+			reg = <0x000c2000 DT_SIZE_K(728)>;
 			label = "image-1";
 		};
 
-		/* Reserve 32 kB for the scratch partition */
-		scratch_partition: partition@174000 {
-			reg = <0x00174000 DT_SIZE_K(32)>;
-			label = "image-scratch";
-		};
-
-		/* Set 16 kB of storage at the end of the 1536 kB of flash */
-		storage_partition: partition@17c000 {
-			reg = <0x0017c000 DT_SIZE_K(16)>;
+		/* Set 32 kB of storage at the end of the 1536 kB of flash */
+		storage_partition: partition@178000 {
+			reg = <0x00178000 DT_SIZE_K(32)>;
 			label = "storage";
 		};
 	};

--- a/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c.dts
+++ b/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c.dts
@@ -256,27 +256,21 @@
 			read-only;
 		};
 
-		/* Reserve 464 kB for the application in slot 0 */
+		/* Reserve 472 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			reg = <0x0000c000 DT_SIZE_K(464)>;
+			reg = <0x0000c000 DT_SIZE_K(472)>;
 			label = "image-0";
 		};
 
-		/* Reserve 464 kB for the application in slot 1 */
-		slot1_partition: partition@80000 {
-			reg = <0x00080000 DT_SIZE_K(464)>;
+		/* Reserve 472 kB for the application in slot 1 */
+		slot1_partition: partition@82000 {
+			reg = <0x00082000 DT_SIZE_K(472)>;
 			label = "image-1";
 		};
 
-		/* Reserve 32 kB for the scratch partition */
-		scratch_partition: partition@f00000 {
-			reg = <0x00f00000 DT_SIZE_K(32)>;
-			label = "image-scratch";
-		};
-
-		/* Set 16 kB of storage at the end of the 1024 kB of flash */
-		storage_partition: partition@7c000 {
-			reg = <0x0007c000 DT_SIZE_K(16)>;
+		/* Set 32 kB of storage at the end of the 1024 kB of flash */
+		storage_partition: partition@f8000 {
+			reg = <0x000f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};
 	};


### PR DESCRIPTION
Ensure that flash partitioning makes use of the entire flash with no overlapping regions. Remove scratch partitions.