### PR TITLE
ci: workflows: doc: change working directory for codecov upload

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -172,7 +172,9 @@ jobs:
         fail_ci_if_error: false
         verbose: true
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: zephyr/new.info
+        working-directory: zephyr
+        files: new.info
+        disable_search: true
         flags: doxygen-coverage
 
     - name: process-pr


### PR DESCRIPTION
Currently the workflow is correctly uploading to codecov but all the paths are prefixed with an extra `zephyr/`. Use the `working-directory` parameter to ensure the paths are correct.

Tested locally by doing the equivalent of what the action now does using the codecov CLI and I was able to both reproduce the bug as well as confirm the fix.