### PR TITLE
Add 32-bit counter support for PWM driver using TC peripheral

### DIFF
--- a/dts/bindings/pwm/atmel,sam0-tc-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam0-tc-pwm.yaml
@@ -45,6 +45,7 @@ properties:
     enum:
       - 8
       - 16
+      - 32
 
   prescaler:
     type: int

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/same54_xpro.conf
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/same54_xpro.conf
@@ -1,0 +1,1 @@
+CONFIG_GPIO=y

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/same54_xpro.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/same54_xpro.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Muhammed Asif
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Test requires jumper between:
+ *  - PA04 -- PA05
+ */
+
+/ {
+	zephyr,user {
+		pwms = <&tc0 1 PWM_MSEC(2)>;
+		gpios = <&porta 4 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&tc0 {
+	status = "okay";
+	compatible = "atmel,sam0-tc-pwm";
+	/* Gives a maximum period of 1.1s for 120MHz main clock */
+	prescaler = <4>;
+	#pwm-cells = <2>;
+
+	pinctrl-0 = <&tc0_default>;
+	pinctrl-names = "default";
+
+	channels = <2>;
+	counter-size = <32>;
+};
+
+&pinctrl {
+	tc0_default: tc0_default {
+		group1 {
+			pinmux = <PA5E_TC0_WO1>;
+		};
+	};
+};


### PR DESCRIPTION
## Description
This PR adds support for a 32-bit counter on SAM0 devices.

## Testing
Tested on the SAME54 Xplained Pro board (`same54_xpro`) using test cases with an overlay file.
