### PR TITLE
[MXCHIP - AZ3166 IoT Dev kit] add accel0 alias for compatibility with accel_pooling sample

### DIFF
--- a/boards/mxchip/az3166_iotdevkit/az3166_iotdevkit.dts
+++ b/boards/mxchip/az3166_iotdevkit/az3166_iotdevkit.dts
@@ -25,6 +25,8 @@
 		red-pwm-led = &red_pwm_led;
 		green-pwm-led = &green_pwm_led;
 		blue-pwm-led = &blue_pwm_led;
+
+		accel0 = &lsm6dsl;
 	};
 
 	chosen {
@@ -140,7 +142,7 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 
-	lsm6dsl@6a {
+	lsm6dsl: lsm6dsl@6a {
 		compatible = "st,lsm6dsl";
 		reg = <0x6a>;
 	};


### PR DESCRIPTION
boards: mxchip: az3166_iotdevkit: Add "accel0" alias to dts

dts improvement for MXCHIP - AZ3166 IoT Dev kit. I added `accel0` alias for compatibility with the accel_pooling sample.

Signed-off-by: Alexandre Francoeur <afrancoeur@uzinakod.com>