### PR TITLE
doc: smf: fix smf_hierarchical_initial graphviz warning in state diagram

### DIFF
--- a/doc/services/smf/index.rst
+++ b/doc/services/smf/index.rst
@@ -551,7 +551,7 @@ state. The statechart for this test is below.
       STATE_B [shape = box];
       STATE_C [shape = box];
       STATE_D [shape = box];
-      DC[shape=point height=0 width=0 label=<>]
+      DC[shape=point height=0 width=0 label="" style="invis"]
 
       subgraph cluster_root {
          label = "ROOT";


### PR DESCRIPTION
Modified the smf_hierarchical_initial digraph so that it doesn't use a `<>` label as that makes recent (more recent than what we have in CI, that is) versions of graphviz unhappy (warning).
Still renders mostly the same: https://builds.zephyrproject.io/zephyr/pr/95482/docs/services/smf/index.html#state-machine-example-with-initial-transitions-and-transition-to-self