### PR TITLE
doc: conf.py: fix warnings about docs appearing in index and index-tex

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -114,6 +114,14 @@ if not west_found:
 else:
     exclude_patterns.append("**/*west-not-found*")
 
+# Ensure only one of the two top-level indexes ever gets included.
+# This is a workaround for Sphinx issuing INFO notices about being referenced in
+# multiple toctrees.
+if tags.has("convertimages"):  # pylint: disable=undefined-variable  # noqa: F821
+    exclude_patterns.append("index.rst")
+else:
+    exclude_patterns.append("index-tex.rst")
+
 pygments_style = "sphinx"
 highlight_language = "none"
 


### PR DESCRIPTION
Implement a workaround to ensure only one of the two top-level indexes is included in the documentation build, preventing Sphinx from issuing INFO notices about documents being referenced in both index and index-tex toctrees.