### PR TITLE
doc: shields: fix wrong board name for mimxrt1170_evk//cm7

### DIFF
--- a/boards/shields/rk055hdmipi4m/doc/index.rst
+++ b/boards/shields/rk055hdmipi4m/doc/index.rst
@@ -55,7 +55,7 @@ example:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/display
-   :board: mixmrt1170_evk_cm7
+   :board: mimxrt1170_evk//cm7
    :shield: rk055hdmipi4m
    :goals: build
 

--- a/boards/shields/rk055hdmipi4ma0/doc/index.rst
+++ b/boards/shields/rk055hdmipi4ma0/doc/index.rst
@@ -55,7 +55,7 @@ example:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/display
-   :board: mixmrt1170_evk_cm7
+   :board: mimxrt1170_evk//cm7
    :shield: rk055hdmipi4ma0
    :goals: build
 


### PR DESCRIPTION
fix a typo in board name (mixm... instead of mimx...) and actually use a proper board name anyway since it looks like this was still using a HWMv1 name.
Fixes zephyrproject-rtos/zephyr#95015