### PR TITLE
bluetooth: add macros for BT_BAP_PAST_SERVICE_DATA

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -163,6 +163,34 @@ extern "C" {
 	((_bis_bitfield) == 0U || (_bis_bitfield) == BT_BAP_BIS_SYNC_NO_PREF ||                    \
 	 BT_ISO_VALID_BIS_BITFIELD(_bis_bitfield))
 
+
+/** @brief flags for Periodic Advertising Sync Transfer (PAST) */
+enum bt_bap_past_flag {
+	/** No flag set for PAST Address matching source or ADV_EXT_IND */
+	BT_BAP_PAST_FLAG_NONE = 0,
+
+	/** Advertising Address does not match ADV_EXT_IND */
+	BT_BAP_PAST_FLAG_NO_MATCH_ADV_EXT_IND = BIT(0),
+
+	/** Advertising Address does not match the source */
+	BT_BAP_PAST_FLAG_NO_MATCH_SRC_ADDR = BIT(1),
+};
+
+/**
+ * @brief Helper to pack addr_type and src_id
+ *
+ * @param _past_flags past_addr_types bits0..7
+ * @param _src_id past_addr_types bits8..15
+ */
+#define BT_BAP_PAST_SERVICE_DATA(_past_flags, _src_id) \
+	((uint16_t)(_src_id) & 0xFFU) << 8U | ((uint16_t)(_past_flags) & 0xFFU)
+
+/** Extract BAP addr_type from 16-bit Service Data */
+#define BT_BAP_PAST_GET_SRC_ID(_data) (uint8_t)(((_data) & 0xFFU) >> 8U)
+
+/** Extract the BAP flags from 16-bit Service Data */
+#define BT_BAP_PAST_GET_FLAGS(_data) (uint8_t)(((_data) & 0xFFU))
+
 /**
  * @brief Helper to declare elements of bt_bap_qos_cfg
  *

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -132,6 +132,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 	char le_addr[BT_ADDR_LE_STR_LEN];
 	char bad_code[33];
 	bool is_bad_code;
+	struct bt_le_ext_adv_info info;
 
 	if (err != 0) {
 		bt_shell_error("BASS recv state read failed (%d)", err);
@@ -176,11 +177,13 @@ static void bap_broadcast_assistant_recv_state_cb(
 		}
 
 		if (per_adv_sync && IS_ENABLED(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)) {
+			uint8_t past_flags = BT_BAP_PAST_FLAG_NO_MATCH_ADV_EXT_IND;
+
 			bt_shell_print("Sending PAST");
 
 			err = bt_le_per_adv_sync_transfer(per_adv_sync,
-							  conn,
-							  BT_UUID_BASS_VAL);
+				conn,
+				BT_BAP_PAST_SERVICE_DATA(past_flags, state->src_id));
 
 			if (err != 0) {
 				bt_shell_error("Could not transfer periodic adv sync: %d", err);
@@ -213,10 +216,17 @@ static void bap_broadcast_assistant_recv_state_cb(
 
 		if (ext_adv != NULL && IS_ENABLED(CONFIG_BT_PER_ADV) &&
 		    IS_ENABLED(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)) {
+			uint8_t past_flags = BT_BAP_PAST_FLAG_NO_MATCH_ADV_EXT_IND;
+
+			err = bt_le_ext_adv_get_info(ext_adv, &info);
+			__ASSERT(err == 0, "Failed to get adv info: %d", err);
+
+
 			bt_shell_print("Sending local PAST");
 
-			err = bt_le_per_adv_set_info_transfer(ext_adv, conn,
-							      BT_UUID_BASS_VAL);
+			err = bt_le_per_adv_set_info_transfer(ext_adv,
+				conn,
+				BT_BAP_PAST_SERVICE_DATA(past_flags, state->src_id));
 
 			if (err != 0) {
 				bt_shell_error("Could not transfer per adv set info: %d", err);

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -1794,10 +1794,11 @@ uint8_t btp_bap_broadcast_assistant_send_past(const void *cmd, uint16_t cmd_len,
 					      uint16_t *rsp_len)
 {
 	int err;
-	uint16_t service_data;
 	struct bt_conn *conn;
 	struct bt_le_per_adv_sync *pa_sync;
 	const struct btp_bap_send_past_cmd *cp = cmd;
+	uint8_t past_flags = BT_BAP_PAST_FLAG_NO_MATCH_ADV_EXT_IND;
+	uint8_t src_id = cp->src_id;
 
 	LOG_DBG("");
 
@@ -1818,9 +1819,11 @@ uint8_t btp_bap_broadcast_assistant_send_past(const void *cmd, uint16_t cmd_len,
 	/* If octet 0 is set to 0, it means AdvA in PAST matches AdvA in ADV_EXT_IND.
 	 * Octet 1 shall be set to Source_ID.
 	 */
-	service_data = cp->src_id << 8;
 
-	err = bt_le_per_adv_sync_transfer(pa_sync, conn, service_data);
+	err = bt_le_per_adv_sync_transfer(pa_sync,
+			conn,
+			BT_BAP_PAST_SERVICE_DATA(past_flags, src_id));
+
 	if (err != 0) {
 		LOG_DBG("Could not transfer periodic adv sync: %d", err);
 

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -179,8 +179,14 @@ static void bap_broadcast_assistant_recv_state_cb(
 
 #if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)
 	if (state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ) {
-		err = bt_le_per_adv_sync_transfer(g_pa_sync, conn,
-						  BT_UUID_BASS_VAL);
+		uint8_t past_flags = BT_BAP_PAST_FLAG_NO_MATCH_ADV_EXT_IND;
+		
+		bt_le_per_adv_sync_get_info(g_pa_sync, &info);
+
+		err = bt_le_per_adv_sync_transfer(g_pa_sync,
+				conn,
+				BT_BAP_PAST_SERVICE_DATA(past_flags, state->src_id));
+
 		if (err != 0) {
 			FAIL("Could not transfer periodic adv sync: %d\n", err);
 			return;

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -487,6 +487,8 @@ bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
 	char le_addr[BT_ADDR_LE_STR_LEN];
 	char bad_code[BT_ISO_BROADCAST_CODE_SIZE * 2 + 1];
 	size_t acceptor_count = get_dev_cnt() - 2;
+	struct bt_le_ext_adv_info info;
+
 
 	if (err != 0) {
 		FAIL("BASS recv state read failed (%d)\n", err);
@@ -534,7 +536,14 @@ bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
 
 #if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)
 	if (state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ) {
-		err = bt_le_per_adv_sync_transfer(g_pa_sync, conn, BT_UUID_BASS_VAL);
+		uint8_t past_flags = BT_BAP_PAST_FLAG_NO_MATCH_ADV_EXT_IND;
+		struct bt_le_per_adv_sync_info per_adv_info;
+
+		bt_le_per_adv_sync_get_info(g_pa_sync, &per_adv_info);
+
+		err = bt_le_per_adv_sync_transfer(g_pa_sync,
+				conn,
+				BT_BAP_PAST_SERVICE_DATA(past_flags, state->src_id));
 		if (err != 0) {
 			FAIL("Could not transfer periodic adv sync: %d\n", err);
 			return;


### PR DESCRIPTION
This commit adds macros for packing and extracting PAST service data for BAP.
Fixes #95337 