### PR TITLE
doc: releases: device_init() changes

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -26,6 +26,11 @@ Build System
 Kernel
 ******
 
+* :c:func:`device_init` Earlier releases returned a positive +errno value in case
+  of device init failure due to a bug. This is now fixed to return the correct
+  negative -errno value. Applications that implemented workarounds for this
+  issue should now update their code accordingly.
+
 Base Libraries
 **************
 


### PR DESCRIPTION
Document changes in device_init()  introduced by [PR 91221](https://github.com/zephyrproject-rtos/zephyr/pull/91221)