### PR TITLE
samples: Bluetooth: Broadcast_sink: Fix PA skip value is not Reasonable

### DIFF
--- a/samples/bluetooth/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/main.c
@@ -52,7 +52,7 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_SCAN_SELF) || IS_ENABLED(CONFIG_SCAN_OFFLOAD),
 #endif /* CONFIG_SCAN_SELF */
 
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 5 /* Set the timeout relative to interval */
-#define PA_SYNC_SKIP                5
+#define PA_SYNC_SKIP                0
 #define NAME_LEN                    sizeof(CONFIG_TARGET_BROADCAST_NAME) + 1
 #define BROADCAST_DATA_ELEMENT_SIZE sizeof(int16_t)
 


### PR DESCRIPTION
Originally the pa skip value is 5, fw would scheduled pa sync every 6 pa interval in order to save pwr, but currently pa pkt ACAD field would take channel map update info, once skip these pkt , fw would happen sync lost issue. so decrease the skip value.