### PR TITLE
github: hello_world_multiplatform: call twister through west

### DIFF
--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -73,7 +73,7 @@ jobs:
           elif [ "${{ runner.os }}" = "Windows" ]; then
             EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
           fi
-          ./scripts/twister --runtime-artifact-cleanup --force-color --inline-logs -T samples/hello_world -T samples/cpp/hello_world -v $EXTRA_TWISTER_FLAGS
+          west twister --runtime-artifact-cleanup --force-color --inline-logs -T samples/hello_world -T samples/cpp/hello_world -v $EXTRA_TWISTER_FLAGS
 
       - name: Upload artifacts
         if: failure()


### PR DESCRIPTION
Use "west twister" instead of calling twister directly, this can be useful to catch west regressions.