### PR TITLE
drivers: hwinfo: generalize the numaker config

### DIFF
--- a/drivers/hwinfo/Kconfig.numaker
+++ b/drivers/hwinfo/Kconfig.numaker
@@ -4,7 +4,7 @@
 config HWINFO_NUMAKER
 	bool "NuMaker hwinfo"
 	default y
-	depends on SOC_SERIES_M46X || SOC_SERIES_M55M1X
+	depends on DT_HAS_NUVOTON_NUMAKER_FMC_ENABLED
 	select HWINFO_HAS_DRIVER
 	select HAS_NUMAKER_FMC
 	help

--- a/drivers/hwinfo/Kconfig.numaker_rmc
+++ b/drivers/hwinfo/Kconfig.numaker_rmc
@@ -4,7 +4,7 @@
 config HWINFO_NUMAKER_RMC
 	bool "NuMaker hwinfo backed up by RMC"
 	default y
-	depends on SOC_SERIES_M2L31X
+	depends on DT_HAS_NUVOTON_NUMAKER_RMC_ENABLED
 	select HWINFO_HAS_DRIVER
 	select HAS_NUMAKER_RMC
 	help


### PR DESCRIPTION
This PR is to modify the numaker configuration to make it more general instead of depending on specific SoC.