### PR TITLE
posix: Ensure POSIX API subfeatures are not built with host libC

### DIFF
--- a/lib/posix/options/Kconfig.aio
+++ b/lib/posix/options/Kconfig.aio
@@ -4,6 +4,7 @@
 
 config POSIX_ASYNCHRONOUS_IO
 	bool "POSIX asynchronous I/O"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Enable this option for asynchronous I/O. This option is present for conformance purposes
 	  only. All functions listed in <aio.h> return -1 and set errno to ENOSYS.

--- a/lib/posix/options/Kconfig.barrier
+++ b/lib/posix/options/Kconfig.barrier
@@ -6,6 +6,7 @@
 
 menuconfig POSIX_BARRIERS
 	bool "POSIX barriers"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here to enable POSIX barriers.
 

--- a/lib/posix/options/Kconfig.c_lib_ext
+++ b/lib/posix/options/Kconfig.c_lib_ext
@@ -4,6 +4,7 @@
 
 menuconfig POSIX_C_LIB_EXT
 	bool "POSIX general C library extension"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here and Zephyr will provide an implementation of the POSIX_C_LIB_EXT Option
 	  Group, consisting of fnmatch(), getopt(), getsubopt(), optarg, opterr, optind, optopt,

--- a/lib/posix/options/Kconfig.device_io
+++ b/lib/posix/options/Kconfig.device_io
@@ -10,6 +10,7 @@ config POSIX_DEVICE_IO
 	select ZVFS
 	select ZVFS_POLL
 	select ZVFS_SELECT
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here and Zephyr will provide an implementation of the POSIX_DEVICE_IO Option
 	  Group such as FD_CLR(), FD_ISSET(), FD_SET(), FD_ZERO(), close(), fdopen(), fileno(), open(),

--- a/lib/posix/options/Kconfig.fd_mgmt
+++ b/lib/posix/options/Kconfig.fd_mgmt
@@ -4,6 +4,7 @@
 
 menuconfig POSIX_FD_MGMT
 	bool "POSIX file descriptor management"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here and Zephyr will provide implementations for the POSIX_FD_MGMT Option Group.
 	  This includes support for dup(), dup2(), fcntl(), fseeko(), ftello(), ftruncate(),

--- a/lib/posix/options/Kconfig.file_system_r
+++ b/lib/posix/options/Kconfig.file_system_r
@@ -6,6 +6,7 @@ config POSIX_FILE_SYSTEM_R
 	bool "Thread-Safe File System"
 	select FILE_SYSTEM
 	select FDTABLE
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here and Zephyr will provide an implementation of the POSIX_FILE_SYSTEM_R
 	  Option Group, consisting of readdir_r().

--- a/lib/posix/options/Kconfig.fs
+++ b/lib/posix/options/Kconfig.fs
@@ -7,6 +7,7 @@ menuconfig POSIX_FILE_SYSTEM
 	default y if POSIX_API
 	select FILE_SYSTEM
 	select FDTABLE
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  This enables POSIX style file system related APIs.
 

--- a/lib/posix/options/Kconfig.mem
+++ b/lib/posix/options/Kconfig.mem
@@ -18,6 +18,7 @@ config POSIX_SHARED_MEMORY_OBJECTS
 	select SYS_HASH_FUNC32_DJB2
 	select FDTABLE
 	select POSIX_MAPPED_FILES
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here and Zephyr will provide implementations of shm_open() and shm_unlink().
 
@@ -27,6 +28,7 @@ config POSIX_SHARED_MEMORY_OBJECTS
 
 config POSIX_MAPPED_FILES
 	bool "POSIX memory-mapped files"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here and Zephyr will provide support for mmap(), msync(), and munmap().
 
@@ -41,6 +43,7 @@ if POSIX_MAPPED_FILES
 
 config POSIX_MEMLOCK
 	bool "POSIX memory locking"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here and Zephyr will provide support for mlockall() and munlockall().
 
@@ -55,6 +58,7 @@ config POSIX_MEMLOCK
 config POSIX_MEMLOCK_RANGE
 	bool "POSIX range memory locking"
 	imply DEMAND_PAGING
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here and Zephyr will provide support for mlock() and munlock().
 
@@ -69,6 +73,7 @@ endif
 
 config POSIX_MEMORY_PROTECTION
 	bool "POSIX memory protection"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here and Zephyr will provide support for mprotect().
 

--- a/lib/posix/options/Kconfig.mqueue
+++ b/lib/posix/options/Kconfig.mqueue
@@ -4,6 +4,7 @@
 
 menuconfig POSIX_MESSAGE_PASSING
 	bool "POSIX message queue support"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  This enabled POSIX message queue related APIs.
 

--- a/lib/posix/options/Kconfig.net
+++ b/lib/posix/options/Kconfig.net
@@ -10,6 +10,7 @@ menuconfig POSIX_NETWORKING
 	select NET_INTERFACE_NAME
 	select NET_SOCKETPAIR
 	select NET_SOCKETS
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Enable this option to support the POSIX networking API. This includes
 	  support for BSD Sockets.

--- a/lib/posix/options/Kconfig.proc1
+++ b/lib/posix/options/Kconfig.proc1
@@ -7,6 +7,7 @@
 menuconfig POSIX_SINGLE_PROCESS
 	bool "POSIX single process support"
 	# imply COMMON_LIBC_MALLOC # for env.c
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here to use confstr(), environ, errno, getenv(), setenv(), sysconf(), uname(),
 	  or unsetenv().

--- a/lib/posix/options/Kconfig.procN
+++ b/lib/posix/options/Kconfig.procN
@@ -4,6 +4,7 @@
 
 menuconfig POSIX_MULTI_PROCESS
 	bool "POSIX multi-process support"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Support for multi-processing.
 

--- a/lib/posix/options/Kconfig.pthread
+++ b/lib/posix/options/Kconfig.pthread
@@ -6,6 +6,7 @@
 
 menuconfig POSIX_THREADS
 	bool "POSIX thread support"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here to enable POSIX threads, mutexes, condition variables, and thread-specific
 	  storage.

--- a/lib/posix/options/Kconfig.rwlock
+++ b/lib/posix/options/Kconfig.rwlock
@@ -4,6 +4,7 @@
 
 menuconfig POSIX_READER_WRITER_LOCKS
 	bool "POSIX reader-writer locks"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here to enable POSIX reader-writer locks.
 

--- a/lib/posix/options/Kconfig.sched
+++ b/lib/posix/options/Kconfig.sched
@@ -6,6 +6,7 @@ menu "POSIX scheduler options"
 
 config POSIX_PRIORITY_SCHEDULING
 	bool "POSIX priority-based process scheduling"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  This enables POSIX scheduling APIs (_POSIX_PRIORITY_SCHEDULING).
 

--- a/lib/posix/options/Kconfig.semaphore
+++ b/lib/posix/options/Kconfig.semaphore
@@ -4,6 +4,7 @@
 
 menuconfig POSIX_SEMAPHORES
 	bool "POSIX semaphore support"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Enable this option for POSIX semaphore support.
 

--- a/lib/posix/options/Kconfig.signal
+++ b/lib/posix/options/Kconfig.signal
@@ -6,6 +6,7 @@ menu "POSIX signals"
 
 config POSIX_REALTIME_SIGNALS
 	bool "POSIX realtime signals"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Enable support for POSIX realtime signals.
 

--- a/lib/posix/options/Kconfig.spinlock
+++ b/lib/posix/options/Kconfig.spinlock
@@ -4,6 +4,7 @@
 
 menuconfig POSIX_SPIN_LOCKS
 	bool "POSIX spin locks"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here to enable POSIX spin locks.
 

--- a/lib/posix/options/Kconfig.sync_io
+++ b/lib/posix/options/Kconfig.sync_io
@@ -6,6 +6,7 @@ menu "POSIX synchronized I/O"
 
 config POSIX_FSYNC
 	bool "Support for fsync()"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here and Zephyr will provide an implementation of fsync().
 

--- a/lib/posix/options/Kconfig.timer
+++ b/lib/posix/options/Kconfig.timer
@@ -5,6 +5,7 @@
 
 menuconfig POSIX_TIMERS
 	bool "POSIX timers, clocks, and sleep functions"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Select 'y' here and Zephyr will provide implementations of clock_getres(), clock_gettime(),
 	  clock_settime(), nanosleep(), timer_create(), timer_delete(), timer_getoverrun(),


### PR DESCRIPTION
As it is possible to select some of these features without selecting the whole CONFIG_POSIX_API let's ensure we set NATIVE_LIBC_INCOMPATIBLE for them so when we build for native simulator based targets, we also use one of the embedded C libraries.

Relates to #95477 (fixes some issues which would be very similar to the original bug description)