### PR TITLE
manifest: hal_nxp: integrate conn_fwk and ble binary blobs 25.06 release

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: c2279acd1e06aa17926cc8bd89812be691dd005f
+      revision: pull/596/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
-Connectivity framework clean up
-Update to 25.06 NXP release
-Removal of unnecessary dependencies and not
applicable features.