### PR TITLE
boards: st: stm32f4_disco: enable CAN1 to support CAN2 on STM32 BxCAN

### DIFF
--- a/boards/st/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/st/stm32f4_disco/stm32f4_disco.dts
@@ -157,6 +157,12 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&can1 {
+	pinctrl-0 = <&can1_rx_pd0 &can1_tx_pd1>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &can2 {
 	pinctrl-0 = <&can2_rx_pb5 &can2_tx_pb13>;
 	pinctrl-names = "default";


### PR DESCRIPTION
CAN2 requires CAN1 to be enabled because both controllers share the
same hardware filter banks. The master-can-reg property in the CAN2
node points to CAN1, making it the hardware filter master. Set CAN1
status to "okay" in the device tree to ensure proper CAN2 operation.

fixes: #95282