### PR TITLE
shields: devicetree: fix typos introduced using Arduino header constants

### DIFF
--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
@@ -16,7 +16,7 @@
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
 		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
-		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2-p.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2-p.overlay
@@ -16,7 +16,7 @@
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
 		dc-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_HIGH>;
-		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_LOW>;
 		write-only;
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
+++ b/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
@@ -30,7 +30,7 @@
 	lsm6dsl_6b_x_nucleo_iks01a2: lsm6dsl@6b {
 		compatible = "st,lsm6dsl";
 		reg = <0x6b>;
-		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_D4 GPIO_ACTIVE_HIGH
+		irq-gpios = <&arduino_header ARDUINO_HEADER_R3_D4 GPIO_ACTIVE_HIGH>;
 	};
 
 	lsm303agr_magn_1e_x_nucleo_iks01a2: lsm303agr-magn@1e {


### PR DESCRIPTION
Fix typo introduced in some shields DTS overlay files by commit c683b044d988 ("shields: devicetree: use arduino-header-r3.h constants in all shields").