### PR TITLE
MAINTAINERS: change label for  MAINTAINERS.yml

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3148,8 +3148,11 @@ MAINTAINERS file:
     - stephanosio
   files:
     - MAINTAINERS.yml
+    - scripts/get_maintainer.py
+    - scripts/set_assignees.py
+    - scripts/check_maintainers.py
   labels:
-    - "area: Process"
+    - "area: MAINTAINER File"
   description: >-
     Zephyr Maintainers File
 


### PR DESCRIPTION
Process is too general, make this more direct and visible in PRs.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
