### PR TITLE
Bluetooth: CSIP: Fix restore of CSIS on unregister

### DIFF
--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -1009,6 +1009,7 @@ int bt_csip_set_member_register(const struct bt_csip_set_member_register_param *
 
 int bt_csip_set_member_unregister(struct bt_csip_set_member_svc_inst *svc_inst)
 {
+	const struct bt_gatt_attr csis_definition[] = BT_CSIP_SERVICE_DEFINITION(svc_inst);
 	int err;
 
 	CHECKIF(svc_inst == NULL) {
@@ -1034,14 +1035,8 @@ int bt_csip_set_member_unregister(struct bt_csip_set_member_svc_inst *svc_inst)
 	}
 
 	/* Restore original declaration */
-
-	/* attrs_0 is an array of the original attributes, and while the actual number of attributes
-	 * may change, the size of the array stays the same, so we can use that to restore the
-	 * original attribute count
-	 */
-	(void)memcpy(svc_inst->service_p->attrs,
-		     (struct bt_gatt_attr[])BT_CSIP_SERVICE_DEFINITION(svc_inst), sizeof(attrs_0));
-	svc_inst->service_p->attr_count = ARRAY_SIZE(attrs_0);
+	(void)memcpy(svc_inst->service_p->attrs, csis_definition, sizeof(csis_definition));
+	svc_inst->service_p->attr_count = ARRAY_SIZE(csis_definition);
 
 	(void)k_work_cancel_delayable(&svc_inst->set_lock_timer);
 


### PR DESCRIPTION
The bt_csip_set_member_unregister function unregisters
a CSIS instance and restores the attributes to the original
state (the attributes may change during registration).
    
The previously solution had some issues with a check when
using picolib (‘__ssp_bos_check3’ undeclared), and this
fixes that by using a proper variable for the memcpy.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/95518