### PR TITLE
boards: x86_64: adjust `CONFIG_MP_MAX_NUM_CPUS`

### DIFF
--- a/boards/acrn/acrn/acrn.dts
+++ b/boards/acrn/acrn/acrn.dts
@@ -17,6 +17,15 @@
 	model = "ACRN";
 	compatible = "acrn";
 
+	cpus {
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "intel,x86_64";
+			d-cache-line-size = <64>;
+			reg = <1>;
+		};
+	};
+
 	aliases {
 		uart-0 = &uart0;
 		uart-1 = &uart1;

--- a/dts/x86/intel/bartlett_lake_s.dtsi
+++ b/dts/x86/intel/bartlett_lake_s.dtsi
@@ -20,6 +20,13 @@
 			d-cache-line-size = <64>;
 			reg = <0>;
 		};
+
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "intel,bartlett-lake";
+			d-cache-line-size = <64>;
+			reg = <1>;
+		};
 	};
 
 	dram0: memory@0 {

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -20,6 +20,13 @@
 			d-cache-line-size = <64>;
 			reg = <0>;
 		};
+
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "intel,elkhart-lake", "intel,x86_64";
+			d-cache-line-size = <64>;
+			reg = <1>;
+		};
 	};
 
 	chosen {


### PR DESCRIPTION
Some x86_64 platforms have only one CPU defined in their respective devicetree files. This PR reflects that in Kconfig by changing the default value of the `CONFIG_MP_MAX_NUM_CPUS` for these platforms to 1.