### PR TITLE
boards: adafruit: esp32s3: make usb-serial as default

### DIFF
--- a/boards/adafruit/feather_esp32s3/adafruit_feather_esp32s3_procpu.dts
+++ b/boards/adafruit/feather_esp32s3/adafruit_feather_esp32s3_procpu.dts
@@ -25,8 +25,8 @@
 
 	chosen {
 		zephyr,sram = &sram1;
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
+		zephyr,console = &usb_serial;
+		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &esp32_bt_hci;
@@ -79,7 +79,7 @@
 };
 
 &usb_serial {
-	status = "disabled";
+	status = "okay";
 };
 
 &uart0 {

--- a/boards/adafruit/feather_esp32s3_tft/adafruit_feather_esp32s3_tft_procpu.dts
+++ b/boards/adafruit/feather_esp32s3_tft/adafruit_feather_esp32s3_tft_procpu.dts
@@ -27,8 +27,8 @@
 
 	chosen {
 		zephyr,sram = &sram1;
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
+		zephyr,console = &usb_serial;
+		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &esp32_bt_hci;
@@ -126,7 +126,7 @@
 };
 
 &usb_serial {
-	status = "disabled";
+	status = "okay";
 };
 
 &uart0 {


### PR DESCRIPTION
Adafruit feather board's use USB-serial interface
for shell-uart and console as default.