### PR TITLE
Enable ADC16 differential mode and vref selection

### DIFF
--- a/dts/arm/nxp/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxc_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -189,6 +189,7 @@
 			interrupts = <15 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			has-differential-mode;
 		};
 
 		i2c0: i2c@40066000 {

--- a/dts/bindings/adc/nxp,kinetis-adc16.yaml
+++ b/dts/bindings/adc/nxp,kinetis-adc16.yaml
@@ -52,5 +52,13 @@ properties:
     type: int
     description: hardware trigger source (See ADCxTRGSEL field in user manual for more details)
 
+  has-differential-mode:
+    type: boolean
+    description: |
+      Controller instance supports differential channel conversion.
+      This expresses the hardware capability of this particular ADC
+      instance and should be set in SoC dtsi. Board dts files should
+      not modify this.
+
 io-channel-cells:
   - input


### PR DESCRIPTION
1. Enabled ADC16 differential mode.
2. Enabled ADC16 reference voltage selection.