### PR TITLE
Fix write-block-size issue on mt35xu01gbba (imx95-evk)

### DIFF
--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -63,7 +63,7 @@
 		status = "okay";
 		jedec-id = [2c 5b 1b];
 		erase-block-size = <4096>;
-		write-block-size = <1>;
+		write-block-size = <2>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -1578,7 +1578,8 @@ static DEVICE_API(flash, flash_flexspi_nor_api) = {
 			.pages_size = SPI_NOR_SECTOR_SIZE,		\
 		},))							\
 		.flash_parameters = {					\
-			.write_block_size = NOR_WRITE_SIZE,		\
+			.write_block_size = DT_INST_PROP_OR(n,		\
+				write_block_size, NOR_WRITE_SIZE),	\
 			.erase_value = NOR_ERASE_VALUE,			\
 		},							\
 	};								\


### PR DESCRIPTION
- The mt35xu01gbba flash device on the imx95-evk has a write-block-size of 2 instead of 1.
- The value will now be taken from the DTS instead of being hardcoded.