### PR TITLE
[doc]: correct board target for xiao_nrf54l15

### DIFF
--- a/boards/seeed/xiao_nrf54l15/doc/index.rst
+++ b/boards/seeed/xiao_nrf54l15/doc/index.rst
@@ -78,7 +78,7 @@ Here is an example for the :zephyr:code-sample:`hello_world` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: xiao_nrf54l15
+   :board: xiao_nrf54l15/nrf54l15/cpuapp
    :goals: flash
 
 Open a serial terminal (minicom, putty, etc.) connecting to the UCB CDC ACM serial port.
@@ -87,7 +87,7 @@ Reset the board and you should see the following message in the terminal:
 
 .. code-block:: console
 
-   Hello World! xiao_nrf54l15
+   Hello World! xiao_nrf54l15/nrf54l15/cpuapp
 
 
 .. _Seeed Studio XIAO nRF54L15:


### PR DESCRIPTION
This corrects the board referred to as "xiao_nrf54l15" to the correct target "xiao_nrf54l15/nrf54l15/cpuapp".

Just following the docs are they are now will lead to the following error:

```
CMake Error at C:/Users/thele/Desktop/nowatch/code/zephyr/zephyr/cmake/modules/boards.cmake:285 (message):
  Board qualifiers `/nrf54l15` for board `xiao_nrf54l15` not found.  Please
  specify a valid board target.

  Valid board targets for xiao_nrf54l15 are:

  xiao_nrf54l15/nrf54l15/cpuapp

  xiao_nrf54l15/nrf54l15/cpuflpr

  xiao_nrf54l15/nrf54l15/cpuflpr/xip

Call Stack (most recent call first):
  C:/Users/thele/Desktop/nowatch/code/zephyr/zephyr/cmake/modules/zephyr_default.cmake:131 (include)
  C:/Users/thele/Desktop/nowatch/code/zephyr/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:66 (include)
  C:/Users/thele/Desktop/nowatch/code/zephyr/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:92 (include_boilerplate)
  CMakeLists.txt:5 (find_package)


-- Configuring incomplete, errors occurred!
```
