### PR TITLE
west.yml: MCUboot synchronization from v3.7-branch

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -287,7 +287,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 7a29b5a6a10f9179cac3935645c2a1356dafb2b6
+      revision: 6127fc06a54d7a364626a96a33ae652703b505e4
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  6127fc06a54d7a364626a96a33ae652703b505e4

Brings following Zephyr relevant fixes:

  - 6127fc06 bootutil: Fixed security counter overflow detected to late
  - 45f96eb7 boot/boot_serial: build-time skip of the erasing of img status page
  - a3166c52 boot: zephyr: boards: nrf52: Fix minimal config
  - 29ea8ef4 boot: zephyr: Remove reference to old Kconfigs
  - 0c1950df boot: bootutil: image_validate: Add error on security counter fail
  - 4d2f3b7f bootutil: Remove pointless includes of asn1 headers
  - 9d7d58d9 boot: bootutil: declare fih_panic_loop() as noreturn
  - 11c0611a bootutil: Unify app_max_size() implementations

Fixes #95787