### PR TITLE
drivers: i3c: dw: Add clock subsystem support for DesignWare I3C

### DIFF
--- a/dts/bindings/i3c/snps,designware-i3c.yaml
+++ b/dts/bindings/i3c/snps,designware-i3c.yaml
@@ -7,7 +7,7 @@ description: >
 
 compatible: "snps,designware-i3c"
 
-include: i3c-controller.yaml
+include: [i3c-controller.yaml, pinctrl-device.yaml]
 
 properties:
   clocks:


### PR DESCRIPTION
Add support for clock subsystem configuration in the DesignWare I3C driver to enable proper clock control on platforms that require specific clock subsystem identifiers.

Changes include:
- Add clock_subsys field to dw_i3c_config structure
- Update clock_control_get_rate() and clock_control_on() calls to use the configured clock subsystem instead of NULL
- Use standard devicetree macro DT_INST_CLOCKS_CELL(n, clkid) for clock subsystem extraction

This follows the same pattern used by other I3C drivers (mcux, renesas_ra) and enables proper clock management for SoCs that require clock subsystem identifiers.