### PR TITLE
drivers: interrupt_controller: stm32: Fix range handling

### DIFF
--- a/drivers/interrupt_controller/intc_gpio_stm32.c
+++ b/drivers/interrupt_controller/intc_gpio_stm32.c
@@ -102,7 +102,7 @@ static void stm32_intc_gpio_isr(const void *exti_range)
 	uint32_t line_num;
 
 	/* see which bits are set */
-	for (uint8_t i = 0; i <= range->len; i++) {
+	for (uint8_t i = 0; i < range->len; i++) {
 		line_num = range->start + i;
 
 		/* check if interrupt is pending */


### PR DESCRIPTION
When iterating over range, we were going one index too far.