### PR TITLE
intel_adsp: ace: Remove redundant HPSRAM init from D3 restore

### DIFF
--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -149,6 +149,10 @@ static int sys_mm_drv_hpsram_pwr(uint32_t bank_idx, bool enable, bool non_blocki
 
 	HPSRAM_REGS(bank_idx)->HSxPGCTL = !enable;
 
+	if (enable) {
+		HPSRAM_REGS(bank_idx)->HSxRMCTL = IS_ENABLED(CONFIG_SRAM_RETENTION_MODE);
+	}
+
 	if (!non_blocking) {
 		while (HPSRAM_REGS(bank_idx)->HSxPGISTS == enable) {
 			k_busy_wait(1);
@@ -911,6 +915,7 @@ __imr void adsp_mm_restore_context(void *storage_buffer)
 		/* turn on memory bank power, wait till the power is on */
 		__ASSERT_NO_MSG(bank_idx <= ace_hpsram_get_bank_count());
 		HPSRAM_REGS(bank_idx)->HSxPGCTL = 0;
+		HPSRAM_REGS(bank_idx)->HSxRMCTL = IS_ENABLED(CONFIG_SRAM_RETENTION_MODE);
 		while (HPSRAM_REGS(bank_idx)->HSxPGISTS == 1) {
 			/* k_busy_wait cannot be used here - not available */
 		}

--- a/soc/intel/intel_adsp/ace/boot.c
+++ b/soc/intel/intel_adsp/ace/boot.c
@@ -43,10 +43,6 @@ __imr void boot_d3_restore(void)
 #ifdef CONFIG_ADSP_DISABLE_L2CACHE_AT_BOOT
 	ADSP_L2PCFG_REG = 0;
 #endif
-
-	extern void hp_sram_init(uint32_t memory_size);
-	hp_sram_init(L2_SRAM_SIZE);
-
 	extern void lp_sram_init(void);
 	lp_sram_init();
 


### PR DESCRIPTION
Remove hp_sram_init() call from boot_d3_restore() as it's redundant and causes TLB access errors. The TLB driver's adsp_mm_restore_context() already handles all HPSRAM power management and content restoration.

The removed code was attempting to zero memory regions that are intentionally unmapped by the TLB driver for power optimization, causing access to disabled TLB entries during D3→D0 transitions.

Additionally, hp_sram_init() powers up all memory banks while the TLB restore function correctly enables only the banks that were actually used, maintaining proper power optimization.

Current flow causes errors in simulation which revealed this incorrect double initialization in test scenarios with minimal firmware configurations.