### PR TITLE
samples: adc_dt: correct pin allocation for xg29_rb4412a

### DIFF
--- a/samples/drivers/adc/adc_dt/boards/xg29_rb4412a.overlay
+++ b/samples/drivers/adc/adc_dt/boards/xg29_rb4412a.overlay
@@ -16,8 +16,8 @@
 &pinctrl {
 	adc0_default: adc0_default {
 		group0 {
-			/* Allocate odd bus 0 on GPIO port B to IADC for access to pin PB1 */
-			silabs,analog-bus = <ABUS_BODD0_IADC0>;
+			/* Allocate odd bus 0 on GPIO port C/D to IADC for access to pin PD3 */
+			silabs,analog-bus = <ABUS_CDODD0_IADC0>;
 		};
 	};
 };


### PR DESCRIPTION
Change the pin configuration (xg29_rb4412a) for the IADC to allocate odd bus 0 on GPIO port C/D instead of GPIO port B, allowing access to pin PD3.
Il resolves a bug and allows the sample to run correctly on the board.