### PR TITLE
boards: esp32s3_eye: Add SDHC support

### DIFF
--- a/boards/espressif/esp32s3_eye/esp32s3_eye-pinctrl.dtsi
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye-pinctrl.dtsi
@@ -50,6 +50,15 @@
 			input-enable;
 			bias-disable;
 		};
+	};
 
+	sdhc0_default: sdhc0_default {
+		group1 {
+			pinmux = <SDHC0_CMD_GPIO38>,
+				 <SDHC0_CLKOUT_GPIO39>,
+				 <SDHC0_DATA0_GPIO40>;
+			bias-pull-up;
+			output-high;
+		};
 	};
 };

--- a/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.dts
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.dts
@@ -21,6 +21,7 @@
 		watchdog0 = &wdt0;
 		sw0 = &button0;
 		led0 = &green_led;
+		sdhc0 = &sdhc0;
 	};
 
 	chosen {
@@ -32,6 +33,7 @@
 		zephyr,bt-hci = &esp32_bt_hci;
 		zephyr,display = &st7789v;
 		zephyr,camera = &lcd_cam;
+		zephyr,sdhc = &sdhc0;
 	};
 
 	buttons {
@@ -207,4 +209,21 @@
 
 &wifi {
 	status = "okay";
+};
+
+&sdhc {
+	sdhc0: sdhc@0 {
+		status = "okay";
+
+		pinctrl-0 = <&sdhc0_default>;
+		pinctrl-names = "default";
+		max-bus-freq = <52000000>;
+		bus-width = <1>;
+
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			disk-name = "SD";
+			status = "okay";
+		};
+	};
 };

--- a/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.yaml
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.yaml
@@ -14,6 +14,7 @@ supported:
   - watchdog
   - entropy
   - pwm
+  - sdhc
   - dma
   - input
   - video


### PR DESCRIPTION
Add SDHC support to esp32s3_eye.