### PR TITLE
net: context: Make sure TCP allocation is not leaked

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -646,6 +646,13 @@ int net_context_get(sa_family_t family, enum net_sock_type type, uint16_t proto,
 	k_sem_give(&contexts_lock);
 
 	if (ret < 0) {
+		if (ret == -EADDRINUSE &&
+		    !net_if_is_ip_offloaded(net_if_get_default()) &&
+		    proto == IPPROTO_TCP) {
+			/* Free the TCP context that we allocated earlier */
+			net_tcp_put(&contexts[i]);
+		}
+
 		return ret;
 	}
 


### PR DESCRIPTION
If we have allocated a TCP connection, and if after that we get an error like EADDRINUSE, then we must de-allocate the TCP connection otherwise there is a buffer/connection leak.

Fixes #95768