### PR TITLE
subsys: tracing: Added board qualifier to SEGGER SystemView

### DIFF
--- a/subsys/tracing/sysview/sysview_config.c
+++ b/subsys/tracing/sysview/sysview_config.c
@@ -58,6 +58,10 @@ static void cbSendSystemDesc(void)
 				   CONFIG_SOC_FAMILY " " CONFIG_ARCH);
 	SEGGER_SYSVIEW_SendSysDesc("O=Zephyr");
 
+#ifdef CONFIG_BOARD_QUALIFIERS
+	SEGGER_SYSVIEW_SendSysDesc("C=" CONFIG_BOARD_QUALIFIERS);
+#endif
+
 #ifdef CONFIG_SYMTAB
 	char isr_desc[SEGGER_SYSVIEW_MAX_STRING_LEN];
 


### PR DESCRIPTION
Added CONFIG_BOARD_QUALIFIERS as target core to SEGGER SystemView config.

The "Core" will now show up as e.g. "nrf5340/cpuapp".
Please let me know if there is a better define which could be used.