### PR TITLE
samples: bluetooth: bap_broadcast: add LIBLC3 support for MIMXRT1062

### DIFF
--- a/samples/bluetooth/bap_broadcast_sink/Kconfig
+++ b/samples/bluetooth/bap_broadcast_sink/Kconfig
@@ -49,7 +49,7 @@ config ENABLE_LC3
 	# By default let's enable it in the platforms we know are capable of supporting it
 	default y
 	depends on CPU_HAS_FPU && \
-		(ARCH_POSIX || SOC_COMPATIBLE_NRF52X || SOC_COMPATIBLE_NRF5340_CPUAPP)
+		(ARCH_POSIX || SOC_COMPATIBLE_NRF52X || SOC_COMPATIBLE_NRF5340_CPUAPP || SOC_MIMXRT1062)
 	select LIBLC3
 	select FPU
 

--- a/samples/bluetooth/bap_broadcast_source/Kconfig
+++ b/samples/bluetooth/bap_broadcast_source/Kconfig
@@ -25,7 +25,7 @@ config ENABLE_LC3
 	# By default let's enable it in the platforms we know are capable of supporting it
 	default y
 	depends on CPU_HAS_FPU && \
-		(ARCH_POSIX || SOC_COMPATIBLE_NRF52X || SOC_COMPATIBLE_NRF5340_CPUAPP)
+		(ARCH_POSIX || SOC_COMPATIBLE_NRF52X || SOC_COMPATIBLE_NRF5340_CPUAPP || SOC_MIMXRT1062)
 	select LIBLC3
 	select FPU
 


### PR DESCRIPTION
-Add LC3 encode/decode support for bap broadcast examples for i.MXRT1062 based platform