### PR TITLE
arch: arm: cortex_a_r: specify icache/dcache for Cortex-A9

### DIFF
--- a/arch/arm/core/cortex_a_r/Kconfig
+++ b/arch/arm/core/cortex_a_r/Kconfig
@@ -26,6 +26,8 @@ config CPU_CORTEX_A9
 	bool
 	select CPU_AARCH32_CORTEX_A
 	select ARMV7_A
+	select CPU_HAS_ICACHE
+	select CPU_HAS_DCACHE
 	help
 	  This option signifies the use of a Cortex-A9 CPU.
 


### PR DESCRIPTION
Specify that the Cortex-A9 CPU, although sizes vary as they are implementation specific, always has both an L1 dcache and icache. This enables the use of the facilities provided in arch/arm/core/cortex_a_r/cache.c.