### PR TITLE
Xen Domain-0 and Domain-U interface enhancements for Zephyr

### DIFF
--- a/arch/arm64/core/xen/Kconfig
+++ b/arch/arm64/core/xen/Kconfig
@@ -33,3 +33,14 @@ config XEN_INTERFACE_VERSION
 	help
 	  Xen interface version to use. This is the version of the
 	  interface that Zephyr will use to communicate with the hypervisor.
+
+config XEN_DOMCTL_INTERFACE_VERSION
+	hex "Xen Domctl interface version"
+	default 0x17
+	range 0x15 0x17
+	depends on XEN
+	help
+	  Xen Domctl interface version to use. This is the version of the
+	  domctl interface that Zephyr will use to communicate with
+	  the hypervisor. The default value is the latest version supported
+	  by the kernel.

--- a/arch/arm64/core/xen/Kconfig
+++ b/arch/arm64/core/xen/Kconfig
@@ -44,3 +44,14 @@ config XEN_DOMCTL_INTERFACE_VERSION
 	  domctl interface that Zephyr will use to communicate with
 	  the hypervisor. The default value is the latest version supported
 	  by the kernel.
+
+config XEN_SYSCTL_INTERFACE_VERSION
+	hex "Xen Sysctl interface version"
+	default 0x15
+	range 0x15 0x15
+	depends on XEN
+	help
+	  Xen Sysctl interface version to use. This is the version of the
+	  domctl interface that Zephyr will use to communicate with
+	  the hypervisor. The default value is the latest version supported
+	  by the kernel.

--- a/arch/arm64/core/xen/hypercall.S
+++ b/arch/arm64/core/xen/hypercall.S
@@ -28,4 +28,5 @@ HYPERCALL(xen_version);
 
 #ifdef CONFIG_XEN_DOM0
 HYPERCALL(domctl);
+HYPERCALL(sysctl);
 #endif

--- a/arch/arm64/core/xen/hypercall.S
+++ b/arch/arm64/core/xen/hypercall.S
@@ -24,6 +24,7 @@ HYPERCALL(event_channel_op);
 HYPERCALL(hvm_op);
 HYPERCALL(memory_op);
 HYPERCALL(dm_op);
+HYPERCALL(xen_version);
 
 #ifdef CONFIG_XEN_DOM0
 HYPERCALL(domctl);

--- a/drivers/xen/CMakeLists.txt
+++ b/drivers/xen/CMakeLists.txt
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2021-2023 EPAM Systems
+# Copyright (c) 2021-2025 EPAM Systems
 
 zephyr_sources(hvm.c)
 zephyr_sources(events.c)
 zephyr_sources_ifdef(CONFIG_XEN_GRANT_TABLE gnttab.c)
 zephyr_sources(memory.c)
 zephyr_sources_ifdef(CONFIG_XEN_DMOP dmop.c)
+zephyr_sources(version.c)
 
 add_subdirectory_ifdef(CONFIG_XEN_DOM0 dom0)

--- a/drivers/xen/dom0/CMakeLists.txt
+++ b/drivers/xen/dom0/CMakeLists.txt
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2023 EPAM Systems
+# Copyright (c) 2023-2025 EPAM Systems
 
 zephyr_sources(domctl.c)
+zephyr_sources(sysctl.c)

--- a/drivers/xen/dom0/domctl.c
+++ b/drivers/xen/dom0/domctl.c
@@ -273,15 +273,23 @@ int xen_domctl_max_vcpus(int domid, int max_vcpus)
 	return do_domctl(&domctl);
 }
 
-int xen_domctl_createdomain(int domid, struct xen_domctl_createdomain *config)
+int xen_domctl_createdomain(int *domid, struct xen_domctl_createdomain *config)
 {
-	xen_domctl_t domctl = {
-		.cmd = XEN_DOMCTL_createdomain,
-		.domain = domid,
-		.u.createdomain = *config,
-	};
+	int ret;
+	xen_domctl_t domctl;
 
-	return do_domctl(&domctl);
+	if (!domid || !config) {
+		return -EINVAL;
+	}
+
+	domctl.cmd = XEN_DOMCTL_createdomain,
+	domctl.domain = *domid,
+	domctl.u.createdomain = *config,
+
+	ret = do_domctl(&domctl);
+	*domid = domctl.domain;
+
+	return ret;
 }
 
 int xen_domctl_destroydomain(int domid)

--- a/drivers/xen/dom0/domctl.c
+++ b/drivers/xen/dom0/domctl.c
@@ -304,3 +304,24 @@ int xen_domctl_cacheflush(int domid,  struct xen_domctl_cacheflush *cacheflush)
 
 	return do_domctl(&domctl);
 }
+
+int xen_domctl_getvcpu(int domid, uint32_t vcpu, struct xen_domctl_getvcpuinfo *info)
+{
+	int ret;
+	xen_domctl_t domctl = {
+		.cmd = XEN_DOMCTL_getvcpuinfo,
+		.domain = domid,
+		.u.getvcpuinfo.vcpu = vcpu,
+	};
+
+	if (!info) {
+		return -EINVAL;
+	}
+
+	ret = do_domctl(&domctl);
+	if (!ret) {
+		*info = domctl.u.getvcpuinfo;
+	}
+
+	return ret;
+}

--- a/drivers/xen/dom0/domctl.c
+++ b/drivers/xen/dom0/domctl.c
@@ -16,7 +16,7 @@
 
 static int do_domctl(xen_domctl_t *domctl)
 {
-	domctl->interface_version = XEN_DOMCTL_INTERFACE_VERSION;
+	domctl->interface_version = CONFIG_XEN_DOMCTL_INTERFACE_VERSION;
 	return HYPERVISOR_domctl(domctl);
 }
 
@@ -105,6 +105,7 @@ int xen_domctl_getdomaininfo(int domid, xen_domctl_getdomaininfo_t *dom_info)
 	return 0;
 }
 
+#if CONFIG_XEN_DOMCTL_INTERFACE_VERSION >= 0x00000016
 int xen_domctl_get_paging_mempool_size(int domid, uint64_t *size)
 {
 	int rc;
@@ -133,6 +134,7 @@ int xen_domctl_set_paging_mempool_size(int domid, uint64_t size)
 
 	return do_domctl(&domctl);
 }
+#endif
 
 int xen_domctl_max_mem(int domid, uint64_t max_memkb)
 {

--- a/drivers/xen/dom0/domctl.c
+++ b/drivers/xen/dom0/domctl.c
@@ -105,7 +105,7 @@ int xen_domctl_getdomaininfo(int domid, xen_domctl_getdomaininfo_t *dom_info)
 	return 0;
 }
 
-int xen_domctl_get_paging_mempool_size(int domid, uint64_t *size_mb)
+int xen_domctl_get_paging_mempool_size(int domid, uint64_t *size)
 {
 	int rc;
 	xen_domctl_t domctl = {
@@ -118,17 +118,17 @@ int xen_domctl_get_paging_mempool_size(int domid, uint64_t *size_mb)
 		return rc;
 	}
 
-	*size_mb = domctl.u.paging_mempool.size;
+	*size = domctl.u.paging_mempool.size;
 
 	return 0;
 }
 
-int xen_domctl_set_paging_mempool_size(int domid, uint64_t size_mb)
+int xen_domctl_set_paging_mempool_size(int domid, uint64_t size)
 {
 	xen_domctl_t domctl = {
 		.cmd = XEN_DOMCTL_set_paging_mempool_size,
 		.domain = domid,
-		.u.paging_mempool.size = size_mb,
+		.u.paging_mempool.size = size,
 	};
 
 	return do_domctl(&domctl);

--- a/drivers/xen/dom0/sysctl.c
+++ b/drivers/xen/dom0/sysctl.c
@@ -11,7 +11,7 @@
 
 static int do_sysctl(xen_sysctl_t *sysctl)
 {
-	sysctl->interface_version = XEN_SYSCTL_INTERFACE_VERSION;
+	sysctl->interface_version = CONFIG_XEN_SYSCTL_INTERFACE_VERSION;
 	return HYPERVISOR_sysctl(sysctl);
 }
 

--- a/drivers/xen/dom0/sysctl.c
+++ b/drivers/xen/dom0/sysctl.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/arm64/hypercall.h>
+#include <zephyr/xen/dom0/sysctl.h>
+#include <zephyr/xen/generic.h>
+#include <zephyr/xen/public/xen.h>
+
+static int do_sysctl(xen_sysctl_t *sysctl)
+{
+	sysctl->interface_version = XEN_SYSCTL_INTERFACE_VERSION;
+	return HYPERVISOR_sysctl(sysctl);
+}
+
+int xen_sysctl_physinfo(struct xen_sysctl_physinfo *info)
+{
+	int ret;
+	xen_sysctl_t sysctl = {
+		.cmd = XEN_SYSCTL_physinfo,
+	};
+
+	if (!info) {
+		return -EINVAL;
+	}
+
+	ret = do_sysctl(&sysctl);
+	if (ret < 0) {
+		return ret;
+	}
+	*info = sysctl.u.physinfo;
+
+	return ret;
+}
+
+int xen_sysctl_getdomaininfo(struct xen_domctl_getdomaininfo *domaininfo,
+			     uint16_t first, uint16_t num)
+{
+	int ret;
+	xen_sysctl_t sysctl = {
+		.cmd = XEN_SYSCTL_getdomaininfolist,
+		.u.getdomaininfolist.first_domain = first,
+		.u.getdomaininfolist.max_domains  = num,
+	};
+
+	if (!domaininfo || !num) {
+		return -EINVAL;
+	}
+	set_xen_guest_handle(sysctl.u.getdomaininfolist.buffer, domaininfo);
+
+	ret = do_sysctl(&sysctl);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return sysctl.u.getdomaininfolist.num_domains;
+}

--- a/drivers/xen/version.c
+++ b/drivers/xen/version.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/arm64/hypercall.h>
+#include <zephyr/xen/generic.h>
+#include <zephyr/xen/public/version.h>
+#include <zephyr/xen/public/xen.h>
+#include <string.h>
+
+int xen_version(void)
+{
+	return HYPERVISOR_xen_version(XENVER_version, NULL);
+}
+
+int xen_version_extraversion(char *extra, int len)
+{
+	if (!extra || len < XEN_EXTRAVERSION_LEN) {
+		return -EINVAL;
+	}
+
+	memset(extra, 0, len);
+	return HYPERVISOR_xen_version(XENVER_extraversion, extra);
+}

--- a/include/zephyr/arch/arm64/hypercall.h
+++ b/include/zephyr/arch/arm64/hypercall.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (c) 2021-2023 EPAM Systems
+ * Copyright (c) 2021-2025 EPAM Systems
  */
 
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM64_HYPERCALL_H_
@@ -16,6 +16,7 @@ int HYPERVISOR_hvm_op(int op, void *param);
 int HYPERVISOR_memory_op(int op, void *param);
 int HYPERVISOR_grant_table_op(int op, void *uop, unsigned int count);
 int HYPERVISOR_dm_op(domid_t domid, unsigned int nr_bufs, struct xen_dm_op_buf *bufs);
+int HYPERVISOR_xen_version(int op, void *param);
 
 #ifdef CONFIG_XEN_DOM0
 int HYPERVISOR_domctl(void *param);

--- a/include/zephyr/arch/arm64/hypercall.h
+++ b/include/zephyr/arch/arm64/hypercall.h
@@ -20,6 +20,7 @@ int HYPERVISOR_xen_version(int op, void *param);
 
 #ifdef CONFIG_XEN_DOM0
 int HYPERVISOR_domctl(void *param);
+int HYPERVISOR_sysctl(void *param);
 #endif
 
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM64_HYPERCALL_H_ */

--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -19,8 +19,8 @@ int xen_domctl_resumedomain(int domid);
 int xen_domctl_getvcpucontext(int domid, int vcpu, vcpu_guest_context_t *ctxt);
 int xen_domctl_setvcpucontext(int domid, int vcpu, vcpu_guest_context_t *ctxt);
 int xen_domctl_getdomaininfo(int domid, xen_domctl_getdomaininfo_t *dom_info);
-int xen_domctl_get_paging_mempool_size(int domid, uint64_t *size_mb);
-int xen_domctl_set_paging_mempool_size(int domid, uint64_t size_mb);
+int xen_domctl_get_paging_mempool_size(int domid, uint64_t *size);
+int xen_domctl_set_paging_mempool_size(int domid, uint64_t size);
 int xen_domctl_max_mem(int domid, uint64_t max_memkb);
 int xen_domctl_set_address_size(int domid, int addr_size);
 int xen_domctl_iomem_permission(int domid, uint64_t first_mfn,

--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -34,5 +34,6 @@ int xen_domctl_max_vcpus(int domid, int max_vcpus);
 int xen_domctl_createdomain(int domid, struct xen_domctl_createdomain *config);
 int xen_domctl_cacheflush(int domid,  struct xen_domctl_cacheflush *cacheflush);
 int xen_domctl_destroydomain(int domid);
+int xen_domctl_getvcpu(int domid, uint32_t vcpu, struct xen_domctl_getvcpuinfo *info);
 
 #endif /* __XEN_DOM0_DOMCTL_H__ */

--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -3,6 +3,13 @@
  * Copyright (c) 2023 EPAM Systems
  *
  */
+
+/**
+ * @file
+ *
+ * @brief Xen Domain Control Interface
+ */
+
 #ifndef __XEN_DOM0_DOMCTL_H__
 #define __XEN_DOM0_DOMCTL_H__
 
@@ -12,28 +19,236 @@
 
 #include <zephyr/kernel.h>
 
+/**
+ * @brief Perform a scheduler operation on a specified domain.
+ *
+ * @param domid The ID of the domain on which the scheduler operation is to be performed.
+ * @param[in,out] sched_op A pointer to a `struct xen_domctl_scheduler_op` object that defines
+ *                         the specific scheduler operation to be performed.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_scheduler_op(int domid, struct xen_domctl_scheduler_op *sched_op);
+
+/**
+ * @brief Pauses a domain in the Xen hypervisor.
+ *
+ * @param domid The ID of the domain to be paused.
+ * @retval 0 on success.
+ * @retval -errno on failure.s
+ */
 int xen_domctl_pausedomain(int domid);
+
+/**
+ * @brief Unpauses a domain in the Xen hypervisor.
+ *
+ * @param domid The domain ID of the domain to be unpaused.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_unpausedomain(int domid);
+
+/**
+ * @brief Resumes a domain.
+ *
+ * This function resumes the execution of a domain in the shutdown state.
+ *
+ * @param domid The ID of the domain to be resumed.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_resumedomain(int domid);
+
+/**
+ * @brief Retrieves the virtual CPU context for a specific domain and virtual CPU.
+ * This function resumes the execution of a domain in the shutdown state.
+ *
+ * @param domid The ID of the domain.
+ * @param vcpu The ID of the virtual CPU.
+ * @param[out] ctxt Pointer to the `vcpu_guest_context_t` structure where the
+ *                  virtual CPU context will be stored.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_getvcpucontext(int domid, int vcpu, vcpu_guest_context_t *ctxt);
+
+/**
+ * @brief Sets the virtual CPU context for a specified domain and virtual CPU.
+ *
+ * @param domid The ID of the domain.
+ * @param vcpu The ID of the virtual CPU.
+ * @param ctxt Pointer to the virtual CPU guest context structure.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_setvcpucontext(int domid, int vcpu, vcpu_guest_context_t *ctxt);
+
+/**
+ * @brief Retrieves information about a Xen domain.
+ *
+ * @param domid The ID of the Xen domain to retrieve information for.
+ * @param[out] dom_info Pointer to the structure where the retrieved
+ *                      domain information will be stored.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_getdomaininfo(int domid, xen_domctl_getdomaininfo_t *dom_info);
+
+/**
+ * @brief Gets the paging mempool size for a specified domain.
+ *
+ * @param domid The ID of the domain.
+ * @param size pointer where to store size of the paging mempool.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_get_paging_mempool_size(int domid, uint64_t *size);
+
+/**
+ * @brief Sets the paging mempool size for a specified domain.
+ *
+ * @param domid The ID of the domain.
+ * @param size The size of the paging mempool in bytes.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_set_paging_mempool_size(int domid, uint64_t size);
+
+/**
+ * @brief Sets the maximum memory for a specified domain.
+ *
+ * @param domid The domain ID of the domain to set the maximum memory for.
+ * @param max_memkb The maximum memory (in kilobytes) to set for the domain.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_max_mem(int domid, uint64_t max_memkb);
+
+/**
+ * @brief Sets the address size for a specified domain.
+ *
+ * @param domid The ID of the domain.
+ * @param addr_size The address size to be set.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_set_address_size(int domid, int addr_size);
+
+/**
+ * @brief Set IOMEM permission for a domain.
+ *
+ * @param domid The ID of the domain for which IOMEM permission is being set.
+ * @param first_mfn The starting machine frame number of the memory range.
+ * @param nr_mfns The number of MFNs in the memory range.
+ * @param allow_access Flag indicating whether to allow or deny access to the
+ *                     specified memory range. A non-zero value allows access,
+ *                     while a zero value denies access.
+ *
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_iomem_permission(int domid, uint64_t first_mfn,
 				uint64_t nr_mfns, uint8_t allow_access);
+
+/**
+ * @brief Maps a range of machine memory to a range of guest memory.
+ *
+ * @param domid The domain ID of the target domain.
+ * @param first_gfn The first guest frame number to map.
+ * @param first_mfn The first machine frame number to map.
+ * @param nr_mfns The number of machine frames to map.
+ * @param add_mapping Flag indicating whether to add or remove the mapping.
+ *
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_memory_mapping(int domid, uint64_t first_gfn, uint64_t first_mfn,
 			      uint64_t nr_mfns, uint32_t add_mapping);
+
+/**
+ * @brief Assign a device to a guest. Sets up IOMMU structures.
+ *
+ * @param domid The ID of the domain to which the device is to be assigned.
+ * @param dtdev_path The path of the device tree device to be assigned.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_assign_dt_device(int domid, char *dtdev_path);
+
+/**
+ * @brief Binds a physical IRQ to a specified domain.
+ *
+ * Only supports SPI IRQs for now.
+ *
+ * @param domid The ID of the domain to bind the IRQ to.
+ * @param machine_irq The machine IRQ number to bind.
+ * @param irq_type The type of IRQ to bind (PT_IRQ_TYPE_SPI).
+ * @param bus The PCI bus number of the device generating the IRQ. (optional)
+ * @param device The PCI device number generating the IRQ. (optional)
+ * @param intx The PCI INTx line number of the device generating the IRQ. (optional)
+ * @param isa_irq The ISA IRQ number to bind. (optional)
+ * @param spi The shared peripheral interrupt (SPI) number to bind. (optional)
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_bind_pt_irq(int domid, uint32_t machine_irq, uint8_t irq_type, uint8_t bus,
 			   uint8_t device, uint8_t intx, uint8_t isa_irq, uint16_t spi);
+
+/**
+ * @brief Set the maximum number of vCPUs for a domain.
+ *
+ * The parameter passed to XEN_DOMCTL_max_vcpus must match the value passed to
+ * XEN_DOMCTL_createdomain.  This hypercall is in the process of being removed
+ * (once the failure paths in domain_create() have been improved), but is
+ * still required in the short term to allocate the vcpus themselves.
+ *
+ * @param domid The ID of the domain.
+ * @param max_vcpus Maximum number of vCPUs to set.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_max_vcpus(int domid, int max_vcpus);
+
+/**
+ * @brief Creates a new domain with the specified domain ID and configuration.
+ *
+ * @param domid The domain ID of the new domain.
+ * @param config Pointer to a structure containing the configuration for the new domain.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_createdomain(int domid, struct xen_domctl_createdomain *config);
+
+/**
+ * @brief Clean and invalidate caches associated with given region of
+ * guest memory.
+ *
+ * @param domid The ID of the domain for which the cache needs to be flushed.
+ * @param cacheflush A pointer to the `xen_domctl_cacheflush` structure that
+ *                   contains the cache flush parameters.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_cacheflush(int domid,  struct xen_domctl_cacheflush *cacheflush);
+
+/**
+ * @brief Destroys a Xen domain.
+ *
+ * @param domid The ID of the domain to be destroyed.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_destroydomain(int domid);
+
+/**
+ * @brief Retrieves information about a specific virtual CPU (vCPU) in a Xen domain.
+ *
+ * @param domid The ID of the domain.
+ * @param vcpu The index of the vCPU.
+ * @param[out] info Pointer to a structure to store the vCPU information.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
 int xen_domctl_getvcpu(int domid, uint32_t vcpu, struct xen_domctl_getvcpuinfo *info);
 
 #endif /* __XEN_DOM0_DOMCTL_H__ */

--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -212,12 +212,16 @@ int xen_domctl_max_vcpus(int domid, int max_vcpus);
 /**
  * @brief Creates a new domain with the specified domain ID and configuration.
  *
- * @param domid The domain ID of the new domain.
+ * NB. domid is an IN/OUT parameter for this operation.
+ * If it is specified as an invalid value (0 or >= DOMID_FIRST_RESERVED),
+ * an id is auto-allocated and returned.
+
+ * @param[in,out] domid Pointer to domain ID of the new domain.
  * @param config Pointer to a structure containing the configuration for the new domain.
  * @retval 0 on success.
  * @retval -errno on failure.
  */
-int xen_domctl_createdomain(int domid, struct xen_domctl_createdomain *config);
+int xen_domctl_createdomain(int *domid, struct xen_domctl_createdomain *config);
 
 /**
  * @brief Clean and invalidate caches associated with given region of

--- a/include/zephyr/xen/dom0/sysctl.h
+++ b/include/zephyr/xen/dom0/sysctl.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Xen System Control Interface
+ */
+
+#ifndef __XEN_DOM0_SYSCTL_H__
+#define __XEN_DOM0_SYSCTL_H__
+#include <zephyr/xen/generic.h>
+#include <zephyr/xen/public/sysctl.h>
+#include <zephyr/xen/public/xen.h>
+
+/**
+ * @brief Retrieves information about the host system.
+ *
+ * @param[out] info A pointer to a `struct xen_sysctl_physinfo` structure where the
+ *             retrieved information will be stored.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
+int xen_sysctl_physinfo(struct xen_sysctl_physinfo *info);
+
+/**
+ * @brief Retrieves information about Xen domains.
+ *
+ * @param[out] domaininfo A pointer to the `xen_domctl_getdomaininfo` structure
+ *                        to store the retrieved domain information.
+ * @param first The first domain ID to retrieve information for.
+ * @param num The maximum number of domains to retrieve information for.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
+int xen_sysctl_getdomaininfo(struct xen_domctl_getdomaininfo *domaininfo,
+			     uint16_t first, uint16_t num);
+
+#endif /* __XEN_DOM0_SYSCTL_H__ */

--- a/include/zephyr/xen/public/domctl.h
+++ b/include/zephyr/xen/public/domctl.h
@@ -195,6 +195,18 @@ struct xen_domctl_vcpucontext {
 	XEN_GUEST_HANDLE_64(vcpu_guest_context_t) ctxt; /* IN/OUT */
 };
 
+/* XEN_DOMCTL_getvcpuinfo */
+struct xen_domctl_getvcpuinfo {
+	/* IN variables. */
+	uint32_t vcpu;
+	/* OUT variables. */
+	uint8_t  online;                  /* currently online (not hotplugged)? */
+	uint8_t  blocked;                 /* blocked waiting for an event? */
+	uint8_t  running;                 /* currently scheduled on its CPU? */
+	uint64_aligned_t cpu_time;        /* total cpu time consumed (ns) */
+	uint32_t cpu;                     /* current mapping   */
+};
+
 /*
  * XEN_DOMCTL_max_vcpus:
  *
@@ -499,6 +511,7 @@ struct xen_domctl {
 		struct xen_domctl_getdomaininfo getdomaininfo;
 		struct xen_domctl_max_mem max_mem;
 		struct xen_domctl_vcpucontext vcpucontext;
+		struct xen_domctl_getvcpuinfo getvcpuinfo;
 		struct xen_domctl_max_vcpus max_vcpus;
 		struct xen_domctl_scheduler_op scheduler_op;
 		struct xen_domctl_iomem_permission iomem_permission;

--- a/include/zephyr/xen/public/domctl.h
+++ b/include/zephyr/xen/public/domctl.h
@@ -20,8 +20,6 @@
 #include "grant_table.h"
 #include "memory.h"
 
-#define XEN_DOMCTL_INTERFACE_VERSION 0x00000015
-
 /*
  * NB. xen_domctl.domain is an IN/OUT parameter for this operation.
  * If it is specified as an invalid value (0 or >= DOMID_FIRST_RESERVED),
@@ -411,6 +409,7 @@ struct xen_domctl_cacheflush {
 	xen_pfn_t start_pfn, nr_pfns;
 };
 
+#if CONFIG_XEN_DOMCTL_INTERFACE_VERSION >= 0x00000016
 /*
  * XEN_DOMCTL_get_paging_mempool_size / XEN_DOMCTL_set_paging_mempool_size.
  *
@@ -426,6 +425,7 @@ struct xen_domctl_cacheflush {
 struct xen_domctl_paging_mempool {
 	uint64_aligned_t size; /* Size in bytes. */
 };
+#endif
 
 struct xen_domctl {
 	uint32_t cmd;
@@ -497,8 +497,10 @@ struct xen_domctl {
 #define XEN_DOMCTL_get_cpu_policy		82
 #define XEN_DOMCTL_set_cpu_policy		83
 #define XEN_DOMCTL_vmtrace_op			84
+#if CONFIG_XEN_DOMCTL_INTERFACE_VERSION >= 0x00000016
 #define XEN_DOMCTL_get_paging_mempool_size	85
 #define XEN_DOMCTL_set_paging_mempool_size	86
+#endif
 #define XEN_DOMCTL_gdbsx_guestmemio		1000
 #define XEN_DOMCTL_gdbsx_pausevcpu		1001
 #define XEN_DOMCTL_gdbsx_unpausevcpu		1002
@@ -520,7 +522,9 @@ struct xen_domctl {
 		struct xen_domctl_bind_pt_irq bind_pt_irq;
 		struct xen_domctl_memory_mapping memory_mapping;
 		struct xen_domctl_cacheflush cacheflush;
+#if CONFIG_XEN_DOMCTL_INTERFACE_VERSION >= 0x00000016
 		struct xen_domctl_paging_mempool paging_mempool;
+#endif
 		uint8_t pad[128];
 	} u;
 };

--- a/include/zephyr/xen/public/sysctl.h
+++ b/include/zephyr/xen/public/sysctl.h
@@ -20,8 +20,6 @@
 #include "xen.h"
 #include "domctl.h"
 
-#define XEN_SYSCTL_INTERFACE_VERSION 0x00000015
-
 /*
  * Get physical information about the host machine
  */

--- a/include/zephyr/xen/public/sysctl.h
+++ b/include/zephyr/xen/public/sysctl.h
@@ -1,0 +1,148 @@
+/* SPDX-License-Identifier: MIT */
+/******************************************************************************
+ * sysctl.h
+ *
+ * System management operations. For use by node control stack.
+ *
+ * Copyright (c) 2002-2006, K Fraser
+ * Copyright (c) 2025 EPAM Systems
+ *
+ */
+
+#ifndef __XEN_PUBLIC_SYSCTL_H__
+#define __XEN_PUBLIC_SYSCTL_H__
+
+#if !defined(CONFIG_XEN_DOM0)
+#error "sysctl operations are intended for use by node control tools only"
+#endif
+
+#include <zephyr/sys/util_macro.h>
+#include "xen.h"
+#include "domctl.h"
+
+#define XEN_SYSCTL_INTERFACE_VERSION 0x00000015
+
+/*
+ * Get physical information about the host machine
+ */
+/* XEN_SYSCTL_physinfo */
+ /* The platform supports HVM guests. */
+#define _XEN_SYSCTL_PHYSCAP_hvm          0
+#define XEN_SYSCTL_PHYSCAP_hvm           BIT(_XEN_SYSCTL_PHYSCAP_hvm)
+ /* The platform supports PV guests. */
+#define _XEN_SYSCTL_PHYSCAP_pv           1
+#define XEN_SYSCTL_PHYSCAP_pv            BIT(_XEN_SYSCTL_PHYSCAP_pv)
+ /* The platform supports direct access to I/O devices with IOMMU. */
+#define _XEN_SYSCTL_PHYSCAP_directio     2
+#define XEN_SYSCTL_PHYSCAP_directio      BIT(_XEN_SYSCTL_PHYSCAP_directio)
+/* The platform supports Hardware Assisted Paging. */
+#define _XEN_SYSCTL_PHYSCAP_hap          3
+#define XEN_SYSCTL_PHYSCAP_hap           BIT(_XEN_SYSCTL_PHYSCAP_hap)
+/* The platform supports software paging. */
+#define _XEN_SYSCTL_PHYSCAP_shadow       4
+#define XEN_SYSCTL_PHYSCAP_shadow        BIT(_XEN_SYSCTL_PHYSCAP_shadow)
+/* The platform supports sharing of HAP page tables with the IOMMU. */
+#define _XEN_SYSCTL_PHYSCAP_iommu_hap_pt_share 5
+#define XEN_SYSCTL_PHYSCAP_iommu_hap_pt_share  BIT(_XEN_SYSCTL_PHYSCAP_iommu_hap_pt_share)
+#define XEN_SYSCTL_PHYSCAP_vmtrace       BIT(6)
+/* The platform supports vPMU. */
+#define XEN_SYSCTL_PHYSCAP_vpmu          BIT(7)
+
+/* Xen supports the Grant v1 and/or v2 ABIs. */
+#define XEN_SYSCTL_PHYSCAP_gnttab_v1     BIT(8)
+#define XEN_SYSCTL_PHYSCAP_gnttab_v2     BIT(9)
+
+/* Max XEN_SYSCTL_PHYSCAP_* constant.  Used for ABI checking. */
+#define XEN_SYSCTL_PHYSCAP_MAX XEN_SYSCTL_PHYSCAP_gnttab_v2
+
+struct xen_sysctl_physinfo {
+	uint32_t threads_per_core;
+	uint32_t cores_per_socket;
+	uint32_t nr_cpus;     /* # CPUs currently online */
+	uint32_t max_cpu_id;  /* Largest possible CPU ID on this host */
+	uint32_t nr_nodes;    /* # nodes currently online */
+	uint32_t max_node_id; /* Largest possible node ID on this host */
+	uint32_t cpu_khz;
+	uint32_t capabilities;/* XEN_SYSCTL_PHYSCAP_??? */
+	uint32_t arch_capabilities;/* XEN_SYSCTL_PHYSCAP_{X86,ARM,...}_??? */
+	uint32_t pad;
+	uint64_aligned_t total_pages;
+	uint64_aligned_t free_pages;
+	uint64_aligned_t scrub_pages;
+	uint64_aligned_t outstanding_pages;
+	uint64_aligned_t max_mfn; /* Largest possible MFN on this host */
+	uint32_t hw_cap[8];
+};
+
+/* XEN_SYSCTL_getdomaininfolist */
+struct xen_sysctl_getdomaininfolist {
+	/* IN variables. */
+	domid_t               first_domain;
+	uint32_t              max_domains;
+
+	XEN_GUEST_HANDLE_64(xen_domctl_getdomaininfo_t) buffer;
+	/* OUT variables. */
+	uint32_t              num_domains;
+};
+
+/* Get physical CPU information. */
+/* XEN_SYSCTL_getcpuinfo */
+struct xen_sysctl_cpuinfo {
+	uint64_aligned_t idletime;
+};
+
+typedef struct xen_sysctl_cpuinfo xen_sysctl_cpuinfo_t;
+DEFINE_XEN_GUEST_HANDLE(xen_sysctl_cpuinfo_t);
+
+struct xen_sysctl_getcpuinfo {
+	/* IN variables. */
+	uint32_t max_cpus;
+
+	XEN_GUEST_HANDLE_64(xen_sysctl_cpuinfo_t) info;
+	/* OUT variables. */
+	uint32_t nr_cpus;
+};
+
+struct xen_sysctl {
+	uint32_t cmd;
+#define XEN_SYSCTL_readconsole                    1
+#define XEN_SYSCTL_tbuf_op                        2
+#define XEN_SYSCTL_physinfo                       3
+#define XEN_SYSCTL_sched_id                       4
+#define XEN_SYSCTL_perfc_op                       5
+#define XEN_SYSCTL_getdomaininfolist              6
+#define XEN_SYSCTL_debug_keys                     7
+#define XEN_SYSCTL_getcpuinfo                     8
+#define XEN_SYSCTL_availheap                      9
+#define XEN_SYSCTL_get_pmstat                    10
+#define XEN_SYSCTL_cpu_hotplug                   11
+#define XEN_SYSCTL_pm_op                         12
+#define XEN_SYSCTL_page_offline_op               14
+#define XEN_SYSCTL_lockprof_op                   15
+#define XEN_SYSCTL_cputopoinfo                   16
+#define XEN_SYSCTL_numainfo                      17
+#define XEN_SYSCTL_cpupool_op                    18
+#define XEN_SYSCTL_scheduler_op                  19
+#define XEN_SYSCTL_coverage_op                   20
+#define XEN_SYSCTL_psr_cmt_op                    21
+#define XEN_SYSCTL_pcitopoinfo                   22
+#define XEN_SYSCTL_psr_alloc                     23
+/* #define XEN_SYSCTL_tmem_op                       24 */
+#define XEN_SYSCTL_get_cpu_levelling_caps        25
+#define XEN_SYSCTL_get_cpu_featureset            26
+#define XEN_SYSCTL_livepatch_op                  27
+/* #define XEN_SYSCTL_set_parameter              28 */
+#define XEN_SYSCTL_get_cpu_policy                29
+	uint32_t interface_version; /* XEN_SYSCTL_INTERFACE_VERSION */
+	union {
+		struct xen_sysctl_physinfo          physinfo;
+		struct xen_sysctl_getdomaininfolist getdomaininfolist;
+		struct xen_sysctl_getcpuinfo        getcpuinfo;
+		uint8_t                             pad[128];
+	} u;
+};
+
+typedef struct xen_sysctl xen_sysctl_t;
+DEFINE_XEN_GUEST_HANDLE(xen_sysctl_t);
+
+#endif /* __XEN_PUBLIC_SYSCTL_H__ */

--- a/include/zephyr/xen/public/version.h
+++ b/include/zephyr/xen/public/version.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: MIT */
+/******************************************************************************
+ * version.h
+ *
+ * Xen version, type, and compile information.
+ *
+ * Copyright (c) 2005, Nguyen Anh Quynh <aquynh@gmail.com>
+ * Copyright (c) 2005, Keir Fraser <keir@xensource.com>
+ *
+ * Copyright (c) 2025 EPAM Systems
+ */
+
+#ifndef __XEN_PUBLIC_VERSION_H__
+#define __XEN_PUBLIC_VERSION_H__
+
+#include "xen.h"
+
+/* NB. All ops return zero on success, except XENVER_{version,pagesize}
+ * XENVER_{version,pagesize,build_id}
+ */
+
+/* arg == NULL; returns major:minor (16:16). */
+#define XENVER_version      0
+
+/* arg == xen_extraversion_t. */
+#define XENVER_extraversion 1
+#define XEN_EXTRAVERSION_LEN 16
+
+#endif /* __XEN_PUBLIC_VERSION_H__ */

--- a/include/zephyr/xen/version.h
+++ b/include/zephyr/xen/version.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef __XEN_DOM0_VERSION_H__
+#define __XEN_DOM0_VERSION_H__
+#include <zephyr/xen/generic.h>
+#include <zephyr/xen/public/version.h>
+#include <zephyr/xen/public/xen.h>
+
+/**
+ * Get Xen hypervisor version integer encoded information
+ *
+ * @retval Xen version on success
+ * @retval -errno on error
+ */
+int xen_version(void);
+
+/**
+ * Get Xen hypervisor extra version string
+ *
+ * @param extra - buffer to store the extra version string
+ * @param len - maximum length of the buffer
+ * @retval 0 on success
+ * @retval -errno on error
+ */
+int xen_version_extraversion(char *extra, int len);
+
+#endif /* __XEN_DOM0_VERSION_H__ */


### PR DESCRIPTION
This PR contains few enhancements for Xen Domain-0 and Domain-U interface parts:
- add xen_version hypercall to allow Zephyr Domains dynamically detect Xen version they are running on;
- add Xen sysctl hypercall to expand Zephyr Domain-0 capabilities;
- add Xen getvcpuinfo domctl to allow Zephyr Domain-0 to gather VCPU stats and status information;
- fixes set/get_paging_mempool_size calls to avoid parameter name confusion;
- documents all implemented Zephyr Domain-0 domctl calls properly;
- add flexible mechanism for Domain ID allocation in domctl createdomain.
UPD.
- Kconfig option for configuring domctl and sysctl version (instead of hardcoded value in header).