### PR TITLE
drivers: i2c: stm32: fix format warning

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -32,7 +32,7 @@ LOG_MODULE_REGISTER(i2c_ll_stm32_v2);
 #include "i2c_ll_stm32.h"
 #include "i2c-priv.h"
 
-#define I2C_STM32_TRANSFER_TIMEOUT_MSEC  500
+#define I2C_STM32_TRANSFER_TIMEOUT_MSEC 500
 
 #ifdef CONFIG_I2C_STM32_V2_TIMING
 /* Use the algorithm to calcuate the I2C timing */


### PR DESCRIPTION
This prevents a format compliance warning leading to a CI pipeline error.