### PR TITLE
boards: silabs: Add expansion header nexus node

### DIFF
--- a/boards/silabs/dev_kits/pg23_pk2504a/pg23_pk2504a.dts
+++ b/boards/silabs/dev_kits/pg23_pk2504a/pg23_pk2504a.dts
@@ -78,6 +78,20 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+
+	exp_header: exp-header {
+		compatible = "silabs,exp-header";
+		#gpio-cells = <2>;
+		gpio-map = <9 0 &gpioa 5 0>,
+			   <11 0 &gpiob 4 0>,
+			   <12 0 &gpiob 5 0>,
+			   <13 0 &gpioc 9 0>,
+			   <14 0 &gpiob 6 0>,
+			   <15 0 &gpioa 8 0>,
+			   <16 0 &gpioa 7 0>;
+		gpio-map-mask = <0xffffffff 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+	};
 };
 
 &timer0 {

--- a/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a.dts
+++ b/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a.dts
@@ -85,6 +85,23 @@
 		enable-gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
+
+	exp_header: exp-header {
+		compatible = "silabs,exp-header";
+		#gpio-cells = <2>;
+		gpio-map = <4 0 &gpiod 11 0>,
+			   <6 0 &gpiod 12 0>,
+			   <8 0 &gpiod 13 0>,
+			   <9 0 &gpiob 1 0>,
+			   <10 0 &gpiod 14 0>,
+			   <12 0 &gpiod 7 0>,
+			   <13 0 &gpioc 11 0>,
+			   <14 0 &gpiod 8 0>,
+			   <15 0 &gpiod 10 0>,
+			   <16 0 &gpiod 9 0>;
+		gpio-map-mask = <0xffffffff 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+	};
 };
 
 &timer0 {

--- a/boards/silabs/dev_kits/sltb010a/sltb010a_0.overlay
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a_0.overlay
@@ -17,3 +17,20 @@
 &sw_mic_enable {
 	enable-gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;
 };
+
+&exp_header {
+	gpio-map = <3 0 &gpioa 8 0>,
+		   <4 0 &gpioc 0 0>,
+		   <5 0 &gpioa 7 0>,
+		   <6 0 &gpioc 1 0>,
+		   <7 0 &gpioc 6 0>,
+		   <8 0 &gpioc 2 0>,
+		   <9 0 &gpioc 7 0>,
+		   <10 0 &gpiob 2 0>,
+		   <11 0 &gpiob 0 0>,
+		   <12 0 &gpioa 5 0>,
+		   <13 0 &gpiob 1 0>,
+		   <14 0 &gpioa 6 0>,
+		   <15 0 &gpiod 3 0>,
+		   <16 0 &gpiod 2 0>;
+};

--- a/boards/silabs/dev_kits/sltb010a/sltb010a_2.overlay
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a_2.overlay
@@ -26,3 +26,20 @@
 &sw_mic_enable {
 	enable-gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
 };
+
+&exp_header {
+	gpio-map = <3 0 &gpioa 8 0>,
+		   <4 0 &gpioc 0 0>,
+		   <5 0 &gpioa 7 0>,
+		   <6 0 &gpioc 1 0>,
+		   <7 0 &gpiob 0 0>,
+		   <8 0 &gpioc 2 0>,
+		   <9 0 &gpiob 1 0>,
+		   <10 0 &gpiob 2 0>,
+		   <11 0 &gpioa 4 0>,
+		   <12 0 &gpioa 5 0>,
+		   <13 0 &gpiob 3 0>,
+		   <14 0 &gpioa 6 0>,
+		   <15 0 &gpiod 3 0>,
+		   <16 0 &gpiod 2 0>;
+};

--- a/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
@@ -35,6 +35,13 @@
 		};
 	};
 
+	exp_header: exp-header {
+		compatible = "silabs,exp-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+	};
+
 	wake_up_trigger: gpio-wake-up  {
 		compatible = "silabs,gecko-wake-up-trigger";
 		gpios = <&gpioa 5 GPIO_ACTIVE_LOW>;

--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
@@ -97,6 +97,25 @@
 		regulator-name = "sensor_enable";
 		enable-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 	};
+
+	exp_header: exp-header {
+		compatible = "silabs,exp-header";
+		#gpio-cells = <2>;
+		gpio-map = <3 0 &gpiob 2 0>,
+			   <4 0 &gpioc 3 0>,
+			   <6 0 &gpioc 2 0>,
+			   <8 0 &gpioc 1 0>,
+			   <9 0 &gpiob 0 0>,
+			   <10 0 &gpioa 7 0>,
+			   <11 0 &gpiob 3 0>,
+			   <12 0 &gpioa 5 0>,
+			   <13 0 &gpiod 2 0>,
+			   <14 0 &gpioa 6 0>,
+			   <15 0 &gpioc 4 0>,
+			   <16 0 &gpioc 5 0>;
+		gpio-map-mask = <0xffffffff 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+	};
 };
 
 &timer0 {

--- a/boards/silabs/dev_kits/xg27_dk2602a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/xg27_dk2602a/thunderboard.dtsi
@@ -61,6 +61,26 @@
 		startup-delay-us = <100000>;
 	};
 
+	exp_header: exp-header {
+		compatible = "silabs,exp-header";
+		#gpio-cells = <2>;
+		gpio-map = <3 0 &gpioa 8 0>,
+			   <4 0 &gpioc 0 0>,
+			   <5 0 &gpioa 7 0>,
+			   <6 0 &gpioc 1 0>,
+			   <7 0 &gpiob 0 0>,
+			   <8 0 &gpioc 2 0>,
+			   <9 0 &gpiob 1 0>,
+			   <10 0 &gpiob 2 0>,
+			   <11 0 &gpioa 4 0>,
+			   <12 0 &gpioa 5 0>,
+			   <13 0 &gpiob 3 0>,
+			   <14 0 &gpioa 6 0>,
+			   <15 0 &gpiod 3 0>,
+			   <16 0 &gpiod 2 0>;
+		gpio-map-mask = <0xffffffff 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+	};
 };
 
 &cpu0 {

--- a/boards/silabs/radio_boards/bg29_rb4420a/bg29_rb4420a.dts
+++ b/boards/silabs/radio_boards/bg29_rb4420a/bg29_rb4420a.dts
@@ -72,6 +72,23 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+
+	exp_header: exp-header {
+		compatible = "silabs,exp-header";
+		#gpio-cells = <2>;
+		gpio-map = <3 0 &gpioa 4 0>,
+			   <4 0 &gpioc 5 0>,
+			   <5 0 &gpioa 0 0>,
+			   <6 0 &gpioc 3 0>,
+			   <7 0 &gpiob 2 0>,
+			   <8 0 &gpioc 2 0>,
+			   <9 0 &gpiob 1 0>,
+			   <10 0 &gpioc 6 0>,
+			   <12 0 &gpioa 5 0>,
+			   <14 0 &gpioa 6 0>;
+		gpio-map-mask = <0xffffffff 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+	};
 };
 
 &cpu0 {

--- a/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
+++ b/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
@@ -62,6 +62,23 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+
+	exp_header: exp-header {
+		compatible = "silabs,exp-header";
+		#gpio-cells = <2>;
+		gpio-map = <4 0 &gpioc 0 0>,
+			   <6 0 &gpioc 1 0>,
+			   <7 0 &gpiod 2 0>,
+			   <8 0 &gpioc 2 0>,
+			   <9 0 &gpiod 3 0>,
+			   <10 0 &gpioc 3 0>,
+			   <11 0 &gpiob 0 0>,
+			   <12 0 &gpioa 5 0>,
+			   <13 0 &gpiob 1 0>,
+			   <14 0 &gpioa 6 0>;
+		gpio-map-mask = <0xffffffff 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+	};
 };
 
 &cpu0 {

--- a/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
+++ b/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
@@ -60,6 +60,23 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+
+	exp_header: exp-header {
+		compatible = "silabs,exp-header";
+		#gpio-cells = <2>;
+		gpio-map = <4 0 &gpioc 0 0>,
+			   <6 0 &gpioc 1 0>,
+			   <7 0 &gpiob 0 0>,
+			   <8 0 &gpioc 2 0>,
+			   <9 0 &gpiob 1 0>,
+			   <10 0 &gpioc 3 0>,
+			   <11 0 &gpiod 2 0>,
+			   <12 0 &gpioa 5 0>,
+			   <13 0 &gpiod 3 0>,
+			   <14 0 &gpioa 6 0>;
+		gpio-map-mask = <0xffffffff 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+	};
 };
 
 &cpu0 {

--- a/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
+++ b/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
@@ -86,6 +86,26 @@
 		regulator-name = "sensor_disp_enable";
 		status = "okay";
 	};
+
+	exp_header: exp-header {
+		compatible = "silabs,exp-header";
+		#gpio-cells = <2>;
+		gpio-map = <4 0 &gpioc 1 0>,
+			   <5 0 &gpioa 0 0>,
+			   <6 0 &gpioc 2 0>,
+			   <7 0 &gpioa 5 0>,
+			   <8 0 &gpioc 3 0>,
+			   <9 0 &gpiod 2 0>,
+			   <10 0 &gpioc 0 0>,
+			   <11 0 &gpioa 6 0>,
+			   <12 0 &gpioa 8 0>,
+			   <13 0 &gpioa 7 0>,
+			   <14 0 &gpioa 9 0>,
+			   <15 0 &gpioc 5 0>,
+			   <16 0 &gpioc 7 0>;
+		gpio-map-mask = <0xffffffff 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+	};
 };
 
 &timer0 {

--- a/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.dts
+++ b/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.dts
@@ -70,6 +70,27 @@
 		enable-gpios = <&gpiod 3 GPIO_ACTIVE_HIGH>;
 		regulator-name = "sensor_enable";
 	};
+
+	exp_header: exp-header {
+		compatible = "silabs,exp-header";
+		#gpio-cells = <2>;
+		gpio-map = <3 0 &gpiob 5 0>,
+			   <4 0 &gpioc 1 0>,
+			   <5 0 &gpioa 0 0>,
+			   <6 0 &gpioc 2 0>,
+			   <7 0 &gpioa 5 0>,
+			   <8 0 &gpioc 3 0>,
+			   <9 0 &gpiod 2 0>,
+			   <10 0 &gpioc 0 0>,
+			   <11 0 &gpioa 6 0>,
+			   <12 0 &gpioa 8 0>,
+			   <13 0 &gpioa 7 0>,
+			   <14 0 &gpioa 9 0>,
+			   <15 0 &gpioc 5 0>,
+			   <16 0 &gpioc 7 0>;
+		gpio-map-mask = <0xffffffff 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+	};
 };
 
 &cpu0 {

--- a/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c.dts
+++ b/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c.dts
@@ -85,6 +85,27 @@
 		regulator-name = "sensor_disp_enable";
 		status = "okay";
 	};
+
+	exp_header: exp-header {
+		compatible = "silabs,exp-header";
+		#gpio-cells = <2>;
+		gpio-map = <3 0 &gpioa 11 0>,
+			   <4 0 &gpiod 7 0>,
+			   <5 0 &gpioa 12 0>,
+			   <6 0 &gpiod 8 0>,
+			   <7 0 &gpioa 13 0>,
+			   <8 0 &gpiod 9 0>,
+			   <9 0 &gpioa 14 0>,
+			   <10 0 &gpiod 10 0>,
+			   <11 0 &gpiob 4 0>,
+			   <12 0 &gpiod 11 0>,
+			   <13 0 &gpiob 5 0>,
+			   <14 0 &gpiod 12 0>,
+			   <15 0 &gpioc 5 0>,
+			   <16 0 &gpioc 7 0>;
+		gpio-map-mask = <0xffffffff 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+	};
 };
 
 &bt_hci_silabs {

--- a/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.dts
+++ b/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.dts
@@ -79,6 +79,24 @@
 		enable-gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
 		regulator-name = "sensor_enable";
 	};
+
+	exp_header: exp-header {
+		compatible = "silabs,exp-header";
+		#gpio-cells = <2>;
+		gpio-map = <4 0 &gpioc 0 0>,
+			   <6 0 &gpioc 1 0>,
+			   <7 0 &gpiob 0 0>,
+			   <8 0 &gpioc 2 0>,
+			   <9 0 &gpiob 1 0>,
+			   <10 0 &gpioc 3 0>,
+			   <12 0 &gpioa 5 0>,
+			   <13 0 &gpioa 8 0>,
+			   <14 0 &gpioa 6 0>,
+			   <15 0 &gpiob 2 0>,
+			   <16 0 &gpiob 3 0>;
+		gpio-map-mask = <0xffffffff 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+	};
 };
 
 &cpu0 {

--- a/dts/bindings/gpio/silabs,exp-header.yaml
+++ b/dts/bindings/gpio/silabs,exp-header.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2025 Silicon Laboratories Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+title: Silicon Labs Kit Expansion Header
+
+description: |
+  GPIO pins exposed on the Expansion Header of Silicon Labs Pro Kits, Wireless Pro Kits,
+  Starter Kits and Wireless Starter Kits. Dev Kits also use the Expansion Header pinout
+  for their breakout pads.
+
+  The Expansion Header contains several I/O pins as well as VMCU, 3.3V and 5V power rails.
+
+    20 -o 3V3            BOARD_ID_SDA o- 19
+    18 -o 5V             BOARD_ID_SCL o- 17
+    16 -o I2C SDA             I2C SCL o- 15
+    14 -o UART RX                GPIO o- 13
+    12 -o UART TX                GPIO o- 11
+    10 -o SPI CS                 GPIO o- 9
+     8 -o SPI CLK                GPIO o- 7
+     6 -o SPI CIPO               GPIO o- 5
+     4 -o SPI COPI               GPIO o- 3
+     2 -o VMCU                    GND o- 1
+
+  Note: The BOARD_ID I2C lines are connected to the debugger, not to the SoC, so the usable
+  GPIOs range from pin 3 to pin 16. Not all pins are routed on all boards, depending on the
+  SoC used and board design.
+
+compatible: "silabs,exp-header"
+
+include: [gpio-nexus.yaml, base.yaml]


### PR DESCRIPTION
Add gpio-nexus binding and dts nodes for the expansion header on Series 2 boards.