### PR TITLE
ipc: Allow preemptive icmsg workqueue

### DIFF
--- a/subsys/ipc/ipc_service/lib/Kconfig.icmsg
+++ b/subsys/ipc/ipc_service/lib/Kconfig.icmsg
@@ -52,11 +52,11 @@ config IPC_SERVICE_BACKEND_ICMSG_WQ_STACK_SIZE
 config IPC_SERVICE_BACKEND_ICMSG_WQ_PRIORITY
 	int "Priority of RX work queue thread"
 	default -1
-	range -256 -1
 	help
 	  Priority of the ICMSG RX work queue thread.
-	  The ICMSG library in its simplicity requires the workqueue to execute
-	  at a cooperative priority.
+	  NOTE: If set to a preemptive priority then icmsg can no longer
+	  support icmsg_close(). This removes the ability to call
+	  deregister_ept() for some IPC backends.
 
 endif
 

--- a/subsys/ipc/ipc_service/lib/icmsg.c
+++ b/subsys/ipc/ipc_service/lib/icmsg.c
@@ -55,6 +55,9 @@ static const uint8_t magic[] = {0x45, 0x6d, 0x31, 0x6c, 0x31, 0x4b,
 static K_THREAD_STACK_DEFINE(icmsg_stack, CONFIG_IPC_SERVICE_BACKEND_ICMSG_WQ_STACK_SIZE);
 static struct k_work_q icmsg_workq;
 static struct k_work_q *const workq = &icmsg_workq;
+#if CONFIG_IPC_SERVICE_BACKEND_ICMSG_WQ_PRIORITY >= 0
+#define ICMSG_CLOSE_NOT_SUPPORTED
+#endif
 #else /* defined(CONFIG_IPC_SERVICE_BACKEND_ICMSG_WQ_ENABLE) */
 static struct k_work_q *const workq = &k_sys_work_q;
 #endif /* defined(CONFIG_IPC_SERVICE_BACKEND_ICMSG_WQ_ENABLE) */
@@ -475,6 +478,10 @@ int icmsg_close(const struct icmsg_config_t *conf,
 {
 	int ret = 0;
 	enum icmsg_state old_state;
+
+#if defined(ICMSG_CLOSE_NOT_SUPPORTED)
+	return -ENOTSUP;
+#endif
 
 	if (conf->unbound_mode != ICMSG_UNBOUND_MODE_DISABLE &&
 	    (UNBOUND_ENABLED || UNBOUND_DETECT)) {


### PR DESCRIPTION
icmsg had the icmsg_close() api added here:
https://github.com/zephyrproject-rtos/zephyr/pull/51082

This forced the workqueue priority to cooperative, but this is only required for the icmsg_close() api to function without race conditions. icmsg_close() is called by deregister_ept(), which is actually a very rare API. The only non test useage is in zephyr/drivers/bluetooth/hci/ipc.c. Having a preemptive workqueue allows a system integrator to reduce the impact of longer running IPC transactions on the system and schedule the load appropriately for their use case. Avoiding deregister_ept is easy in most applications.