### PR TITLE
ci: twister: fix result merge when there's only 1 runner

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Merge Test Results
         run: |
-          junitparser merge artifacts/*/twister.xml junit.xml
+          junitparser merge --glob artifacts/**/twister.xml junit.xml
           junit2html junit.xml junit-clang.html
 
       - name: Upload Unit Test Results in HTML

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -347,7 +347,7 @@ jobs:
 
       - name: Merge Test Results
         run: |
-          junitparser merge artifacts/*/*/twister.xml junit.xml
+          junitparser merge --glob artifacts/**/twister.xml junit.xml
           junit2html junit.xml junit.html
 
       - name: Upload Unit Test Results


### PR DESCRIPTION
The current test result merge command uses `artifacts/*/*/twister.xml` as an argument but that directory hierarchy only works if there's >1 runners. If twister decies to only schedule one, then the only file is going to be in

artifacts/twister-out/twister.xml

and the current command is going to fail with a file not found error.

Fix it by passing a list of all the twister.xml files found with find under manifest/, regardless of specific path.