### PR TITLE
cmake: emu: Don't require ARMFVP_BIN_PATH environment variable

### DIFF
--- a/cmake/emu/armfvp.cmake
+++ b/cmake/emu/armfvp.cmake
@@ -1,10 +1,11 @@
 # Copyright (c) 2021-2022, 2025 Arm Limited (or its affiliates). All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_get(ARMFVP_BIN_PATH)
+
 find_program(
   ARMFVP
-  PATHS ENV ARMFVP_BIN_PATH
-  NO_DEFAULT_PATH
+  HINTS ${ARMFVP_BIN_PATH}
   NAMES ${ARMFVP_BIN_NAME}
   )
 


### PR DESCRIPTION
Enhance the armfvp emulator cmake handling to allow additional options for setting ARMFVP_BIN_PATH, relaxing the previous requirement to set in an environment variable. This makes it possible to run twister with multiple armfvp platforms located in different paths.