### PR TITLE
do_not_merge: count all completed workflows as completed

### DIFF
--- a/scripts/ci/do_not_merge.py
+++ b/scripts/ci/do_not_merge.py
@@ -46,7 +46,7 @@ def workflow_delay(repo, pr):
         completed = set()
         for run in runs:
             print(f"{run.name}: {run.status} {run.conclusion} {run.html_url}")
-            if run.status == "completed" and run.conclusion == "success":
+            if run.status == "completed":
                 completed.add(run.name)
 
         if WAIT_FOR_WORKFLOWS.issubset(completed):


### PR DESCRIPTION
Drop the success check for completed workflow so that the job does not wait forever for workflows that have failed.