### PR TITLE
tests: memc: ram: Add missing test case for sram0

### DIFF
--- a/tests/drivers/memc/ram/src/main.c
+++ b/tests/drivers/memc/ram/src/main.c
@@ -38,6 +38,9 @@ BUF_DEF(sdram1);
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sdram2))
 BUF_DEF(sdram2);
 #endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram0))
+BUF_DEF(sram0);
+#endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram1))
 BUF_DEF(sram1);
 #endif
@@ -77,6 +80,15 @@ ZTEST(test_ram, test_sdram2)
 {
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sdram2))
 	test_ram_rw(buf_sdram2, BUF_SIZE);
+#else
+	ztest_test_skip();
+#endif
+}
+
+ZTEST(test_ram, test_sram0)
+{
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram0))
+	test_ram_rw(buf_sram0, BUF_SIZE);
 #else
 	ztest_test_skip();
 #endif


### PR DESCRIPTION
This commit adds a missing test case for sram0.

Improves test coverage.
Ensures sram0 is validated like other SRAM regions.