### PR TITLE
arch: xtensa: add support for CONFIG_PM_S2RAM

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -135,6 +135,7 @@ config XTENSA
 	select ARCH_HAS_DIRECTED_IPIS
 	select THREAD_STACK_INFO
 	select ARCH_HAS_THREAD_PRIV_STACK_SPACE_GET if USERSPACE
+	select ARCH_HAS_SUSPEND_TO_RAM
 	help
 	  Xtensa architecture
 

--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -30,6 +30,8 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.S syscall_helper.c)
 zephyr_library_sources_ifdef(CONFIG_LLEXT elf.c)
 zephyr_library_sources_ifdef(CONFIG_SMP smp.c)
 zephyr_library_sources_ifdef(CONFIG_XTENSA_HIFI_SHARING xtensa_hifi.S)
+zephyr_library_sources_ifdef(CONFIG_PM_S2RAM s2ram.c)
+zephyr_library_sources_ifdef(CONFIG_PM_S2RAM s2ram.S)
 
 zephyr_library_sources_ifdef(
   CONFIG_KERNEL_VM_USE_CUSTOM_MEM_RANGE_CHECK

--- a/arch/xtensa/core/s2ram.S
+++ b/arch/xtensa/core/s2ram.S
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Meta Platforms, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <xtensa/coreasm.h>
+#include <xtensa_s2ram.h>
+
+.global p2sram_entry
+.weak p2sram_saved_area
+
+	.text
+	.align 4
+p2sram_entry:
+        movi a4, p2sram_saved_area
+        beqz a4, p2sram_entry_no_saved_area
+        l32i a4, a4, XTENSA_S2RAM_SYSTEM_OFF_OFFSET
+
+        callx0 a4
+        ill
+p2sram_entry_no_saved_area:
+        retw
+
+	.size	p2sram_entry, . - p2sram_entry

--- a/arch/xtensa/core/s2ram.c
+++ b/arch/xtensa/core/s2ram.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Meta Platforms, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <xtensa/hal-certified.h>
+#include <xtensa/hal-core-state.h>
+
+#include <zephyr/arch/common/pm_s2ram.h>
+#include <xtensa_s2ram.h>
+
+struct xtensa_s2ram_save_area p2sram_saved_area;
+
+extern uint8_t p2sram_entry;
+int arch_pm_s2ram_suspend(pm_s2ram_system_off_fn_t system_off)
+{
+	p2sram_saved_area.magic = S2RAM_MAGIC;
+	p2sram_saved_area.system_off = (uintptr_t)system_off;
+	xthal_core_save(0, &p2sram_saved_area.core_state, (pm_s2ram_system_off_fn_t)&p2sram_entry);
+	p2sram_saved_area.magic = 0;
+	return 0;
+}

--- a/arch/xtensa/core/startup/reset_vector.S
+++ b/arch/xtensa/core/startup/reset_vector.S
@@ -12,6 +12,7 @@
 #include <xtensa/config/specreg.h>
 #include <xtensa/config/system.h>  /* for XSHAL_USE_ABSOLUTE_LITERALS only */
 #include <xtensa/xtruntime-core-state.h>
+#include <xtensa_s2ram.h>
 
 /*
  * The following reset vector avoids initializing certain registers already
@@ -359,6 +360,26 @@ _ResetHandler:
 	call0	xthal_core_restore_nw
 	/*  (does not return) */
 .Lcoldstart:
+#endif
+
+#ifdef CONFIG_PM_S2RAM
+	.weak p2sram_saved_area
+	.global	xthal_core_restore_nw
+	movi a2, p2sram_saved_area
+	beqz a2, .Lnop2sram_saved_area
+	l32i a1, a2, XTENSA_S2RAM_MAGIC_OFFSET
+	/* validate magic */
+	movi a3, S2RAM_MAGIC
+	bne a1, a3, .Lnop2sram_saved_area
+	/* load core_state address to a3 */
+	addi a3, a2, XTENSA_S2RAM_CORE_STATE_OFFSET
+	/* load flags to a2 */
+	movi a2, 0
+	call0	xthal_core_restore_nw
+	/*  (does not return) */
+	ill
+
+.Lnop2sram_saved_area:
 #endif
 
 #if XCHAL_HAVE_PREFETCH

--- a/arch/xtensa/include/xtensa_s2ram.h
+++ b/arch/xtensa/include/xtensa_s2ram.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 Meta Platforms, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_S2SRAM_H_
+#define ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_S2SRAM_H_
+
+#include <xtensa/hal-certified.h>
+#include <xtensa/hal-core-state.h>
+#include <xtensa/config/tie.h>
+
+#ifdef XCHAL_TOTAL_SA_ALIGN
+#define XTENSA_S2RAM_ALIGN (XCHAL_TOTAL_SA_ALIGN)
+#else
+#define XTENSA_S2RAM_ALIGN (16)
+#endif
+
+#define __S2RAM_ALIGN __aligned(XTENSA_S2RAM_ALIGN)
+#define S2RAM_MAGIC   0x53325241
+
+#define XTENSA_S2RAM_MAGIC_OFFSET      (0)
+#define XTENSA_S2RAM_SYSTEM_OFF_OFFSET (4)
+#define XTENSA_S2RAM_CORE_STATE_OFFSET (XTENSA_S2RAM_ALIGN)
+
+#ifndef __ASSEMBLER__
+
+#include <stdint.h>
+#include <zephyr/toolchain.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct xtensa_s2ram_save_area {
+	__S2RAM_ALIGN
+	uint32_t magic;
+	uintptr_t system_off;
+	/* for future use*/
+	uint32_t reserved[2];
+
+	__S2RAM_ALIGN
+	XthalCoreState core_state;
+};
+
+_Static_assert((offsetof(struct xtensa_s2ram_save_area, magic) == XTENSA_S2RAM_MAGIC_OFFSET),
+	       "magic must be at XTENSA_S2RAM_MAGIC_OFFSET");
+_Static_assert((offsetof(struct xtensa_s2ram_save_area, system_off) == 4),
+	       "system_off must be at XTENSA_S2RAM_SYSTEM_OFF_OFFSET");
+_Static_assert((offsetof(struct xtensa_s2ram_save_area, core_state) == XTENSA_S2RAM_ALIGN),
+	       "core_state must be at XTENSA_S2RAM_CORE_STATE_OFFSET");
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* __ASSEMBLER__ */
+
+#endif /* ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_S2SRAM_H_ */

--- a/include/zephyr/arch/common/pm_s2ram.h
+++ b/include/zephyr/arch/common/pm_s2ram.h
@@ -18,6 +18,8 @@
 GTEXT(arch_pm_s2ram_suspend);
 #else
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Fixes: #95574

Details:
- uses xthal_core_restore_nw to restore
- uses xthal_core_save to save context
- detection is via magic number in memory