### PR TITLE
dts: arm: adi: Proper MAX32690 flash1 settings

### DIFF
--- a/dts/arm/adi/max32/max32690.dtsi
+++ b/dts/arm/adi/max32/max32690.dtsi
@@ -100,7 +100,7 @@
 
 		sram7: memory@200d0000 {
 			compatible = "mmio-sram";
-			reg = <0x200d0000 DT_SIZE_K(64)>;
+			reg = <0x200d0000 DT_SIZE_K(192)>;
 		};
 
 		spixf: spixf@40027000 {

--- a/dts/arm/adi/max32/max32690.dtsi
+++ b/dts/arm/adi/max32/max32690.dtsi
@@ -124,11 +124,11 @@
 			#size-cells = <1>;
 			status = "okay";
 
-			flash1: flash@10080000 {
+			flash1: flash@10300000 {
 				compatible = "soc-nv-flash";
-				reg = <0x10080000 DT_SIZE_K(256)>;
+				reg = <0x10300000 DT_SIZE_K(256)>;
 				write-block-size = <16>;
-				erase-block-size = <16384>;
+				erase-block-size = <8192>;
 			};
 		};
 

--- a/tests/drivers/flash/common/boards/max32690_flash1_storage_partition.overlay
+++ b/tests/drivers/flash/common/boards/max32690_flash1_storage_partition.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,flash-controller = &flc1;
+		zephyr,flash = &flash1;
+	};
+};
+
+&flash1 {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		storage_partition: partition@0 {
+			label = "storage";
+			reg = <0x0 DT_SIZE_K(256)>;
+		};
+	};
+};

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -20,6 +20,15 @@ tests:
       - DTC_OVERLAY_FILE=boards/apard32690_max32690_m4_spixf_nor.overlay
     integration_platforms:
       - apard32690/max32690/m4
+  drivers.flash.common.max32_flash1:
+    platform_allow:
+      - apard32690/max32690/m4
+      - max32690evkit/max32690/m4
+    extra_args:
+      - DTC_OVERLAY_FILE=boards/max32690_flash1_storage_partition.overlay
+    integration_platforms:
+      - apard32690/max32690/m4
+      - max32690evkit/max32690/m4
   drivers.flash.common.nrf_qspi_nor.size_in_bytes:
     platform_allow: nrf52840dk/nrf52840
     extra_args:


### PR DESCRIPTION
Fix the MAX32690 flash1 node's address and erase size properties to match the datasheet. Add a test for that platform as well to verify the functionality of the FLC1 peripheral instance.

Also correct the sram7 size to match the hardware.