### PR TITLE
modules: tfm: disable SECURE_UART when TFM_LOG_LEVEL_SILENCE

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -44,5 +44,12 @@ Other subsystems
 Modules
 *******
 
+Trusted Firmware-M
+==================
+
+* The ``SECURE_UART1`` TF-M define is now controlled by Zephyr's
+  :kconfig:option:`CONFIG_TFM_SECURE_UART`. This option will override any platform values previously
+  specified in the TF-M repository.
+
 Architectures
 *************

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -156,6 +156,12 @@ if(CONFIG_BUILD_WITH_TFM)
     list(APPEND TFM_CMAKE_ARGS -DTFM_SPM_LOG_LEVEL=${TFM_SPM_LOG_LEVEL})
   endif()
 
+  if(CONFIG_TFM_SECURE_UART)
+    list(APPEND TFM_CMAKE_ARGS -DSECURE_UART1=1)
+  else()
+    list(APPEND TFM_CMAKE_ARGS -DSECURE_UART1=0)
+  endif()
+
   # Enable TFM partitions as specified in Kconfig
   foreach(partition ${TFM_VALID_PARTITIONS})
     if(CONFIG_${partition})

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -475,6 +475,15 @@ config TFM_SPM_LOG_LEVEL_SILENCE
 	bool "Off"
 endchoice
 
+config TFM_SECURE_UART
+	bool "TF-M configure UART instance as secure peripheral"
+	default y if SOC_FAMILY_NORDIC_NRF && !TFM_LOG_LEVEL_SILENCE
+	help
+	  Configure the UART instance as a secure peripheral for TF-M logging.
+	  This makes the UART instance unavailable to the non-secure application.
+	  When this option is selected the device tree node for the UART instance
+	  needs to be disabled for the non-secure application.
+
 config TFM_EXCEPTION_INFO_DUMP
 	bool "TF-M exception info dump"
 	default y


### PR DESCRIPTION
Explicitly disable the SECURE_UART TFM define when `CONFIG_TFM_LOG_LEVEL_SILENCE=y`. The secure UART is only enabled by default on nRF platforms to match the current TF-M defaults.

This results in the default values from the TF-M repo being overridden, e.g:
```
set(SECURE_UART1                        ON         CACHE BOOL      "Enable secure UART1")
```
