### PR TITLE
spi: nrfx_spim: cleanup PM usage

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -101,8 +101,6 @@ static inline void finalize_spi_transaction(const struct device *dev, bool deact
 	if (NRF_SPIM_IS_320MHZ_SPIM(reg) && !(dev_data->ctx.config->operation & SPI_HOLD_ON_CS)) {
 		nrfy_spim_disable(reg);
 	}
-
-	pm_device_runtime_put_async(dev, K_NO_WAIT);
 }
 
 static inline uint32_t get_nrf_spim_frequency(uint32_t frequency)
@@ -343,12 +341,13 @@ static void finish_transaction(const struct device *dev, int error)
 	spi_context_complete(ctx, dev, error);
 	dev_data->busy = false;
 
-	if (dev_data->ctx.config->operation & SPI_LOCK_ON) {
-		/* Keep device resumed until call to spi_release() */
-		(void)pm_device_runtime_get(dev);
-	}
-
 	finalize_spi_transaction(dev, true);
+
+#ifdef CONFIG_SPI_ASYNC
+	if (ctx->asynchronous) {
+		pm_device_runtime_put_async(dev, K_NO_WAIT);
+	}
+#endif
 }
 
 static void transfer_next_chunk(const struct device *dev)
@@ -561,12 +560,12 @@ static int transceive(const struct device *dev,
 		} else if (error) {
 			finalize_spi_transaction(dev, true);
 		}
-	} else {
-		pm_device_runtime_put(dev);
 	}
 
 	spi_context_release(&dev_data->ctx, error);
-
+	if (error || !asynchronous) {
+		pm_device_runtime_put(dev);
+	}
 	return error;
 }
 


### PR DESCRIPTION
Release the PM constraint at the end of the context in which it was requested (`transceive`), instead of in a semi-related function (`finalize_spi_transaction`) which is also called by other API functions (`spi_release`). Asynchronous usage is released in the transaction complete callback.