### PR TITLE
kernel: queue length functions

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -143,6 +143,9 @@ New APIs and options
   * :c:macro:`K_THREAD_HW_SHADOW_STACK_ARRAY_DEFINE`
   * :c:macro:`K_THREAD_HW_SHADOW_STACK_ATTACH`
   * :c:macro:`k_thread_hw_shadow_stack_attach`
+  * :c:func:`k_fifo_len`
+  * :c:func:`k_lifo_len`
+  * :c:func:`k_queue_len`
 
 * Logging:
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2228,6 +2228,26 @@ static inline int z_impl_k_queue_is_empty(struct k_queue *queue)
 }
 
 /**
+ * @brief Query the length of a queue.
+ *
+ * Note that the length of the queue might already have changed by the time this
+ * function returns if other threads are also writing to or reading from the
+ * queue.
+ *
+ * @funcprops \isr_ok
+ *
+ * @param queue Address of the queue.
+ *
+ * @return Number of elements on the queue
+ */
+__syscall int k_queue_len(struct k_queue *queue);
+
+static inline int z_impl_k_queue_len(struct k_queue *queue)
+{
+	return sys_sflist_len(&queue->data_q);
+}
+
+/**
  * @brief Peek element at the head of queue.
  *
  * Return element from the head of queue without removing it.
@@ -2770,6 +2790,24 @@ struct k_fifo {
 	k_queue_is_empty(&(fifo)->_queue)
 
 /**
+ * @brief Query the length of a FIFO queue.
+ *
+ * Note that the length of the queue might already have changed by the time this
+ * function returns if other threads are also writing to or reading from the
+ * queue.
+ *
+ * @funcprops \isr_ok
+ *
+ * @param fifo Address of the queue.
+ *
+ * @return Number of elements on the queue
+ */
+#define k_fifo_len(fifo) \
+	({ \
+		k_queue_len(&(fifo)->_queue); \
+	})
+
+/**
  * @brief Peek element at the head of a FIFO queue.
  *
  * Return element from the head of FIFO queue without removing it. A usecase
@@ -2934,6 +2972,24 @@ struct k_lifo {
 	void *lg_ret = k_queue_get(&(lifo)->_queue, timeout); \
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_lifo, get, lifo, timeout, lg_ret); \
 	lg_ret; \
+	})
+
+/**
+ * @brief Query the length of a LIFO queue.
+ *
+ * Note that the length of the queue might already have changed by the time this
+ * function returns if other threads are also writing to or reading from the
+ * queue.
+ *
+ * @funcprops \isr_ok
+ *
+ * @param lifo Address of the queue.
+ *
+ * @return Number of elements on the queue
+ */
+#define k_lifo_len(lifo) \
+	({ \
+		k_queue_len(&(lifo)->_queue); \
 	})
 
 /**

--- a/tests/kernel/lifo/lifo_usage/src/main.c
+++ b/tests/kernel/lifo/lifo_usage/src/main.c
@@ -309,6 +309,30 @@ ZTEST(lifo_usage, test_timeout_non_empty_lifo)
 }
 
 /**
+ * @brief Test LIFO queue length operations
+ * @see k_lifo_len()
+ */
+ZTEST(lifo_usage, test_lifo_len)
+{
+	void *scratch_packet;
+	struct k_lifo lifo;
+
+	k_lifo_init(&lifo);
+
+	for (int i = 0; i < NUM_SCRATCH_LIFO_PACKETS; i++) {
+		scratch_packet = get_scratch_packet();
+		zassert_equal(i, k_lifo_len(&lifo));
+		k_lifo_put(&lifo, scratch_packet);
+	}
+
+	for (int i = 0; i < NUM_SCRATCH_LIFO_PACKETS; i++) {
+		zassert_equal(NUM_SCRATCH_LIFO_PACKETS - i, k_lifo_len(&lifo));
+		scratch_packet = k_lifo_get(&lifo, K_FOREVER);
+		put_scratch_packet(scratch_packet);
+	}
+}
+
+/**
  * @brief Test LIFO with timeout
  * @see k_lifo_put(), k_lifo_get()
  */

--- a/tests/kernel/queue/src/test_queue_loop.c
+++ b/tests/kernel/queue/src/test_queue_loop.c
@@ -115,3 +115,20 @@ ZTEST(queue_api_1cpu, test_queue_loop)
 		tqueue_read_write(&queue);
 	}
 }
+
+ZTEST(queue_api, test_queue_len)
+{
+	k_queue_init(&queue);
+
+	for (int i = 0; i < LIST_LEN; i++) {
+		zassert_equal(i, k_queue_len(&queue));
+		k_queue_append(&queue, (void *)&data[i]);
+	}
+
+	for (int i = 0; i < LIST_LEN; i++) {
+		zassert_equal(LIST_LEN - i, k_queue_len(&queue));
+		zassert_true(k_queue_remove(&queue, &data[i]));
+	}
+
+	zassert_equal(0, k_queue_len(&queue));
+}


### PR DESCRIPTION
Add functions for querying the number of elements currently pending on a `k_lifo`, `k_fifo`, or `k_queue`. These are instantaneous measures that may be incorrect by the time the function returns, i.e. the same behaviour as the `_is_empty` functions.

These are simple wrappers around `sys_sflist_len`.
The intent is to provide a function to query the number of `net_buf`'s currently free in a pool, and the pools utilize these queues internally.