### PR TITLE
bluetooth: host: conn: handle `bt_le_create_conn_cancel` error

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2232,7 +2232,10 @@ static void deferred_work(struct k_work *work)
 		 * auto connect flag if it was set, instead just cancel
 		 * connection directly
 		 */
-		bt_le_create_conn_cancel();
+		if (bt_le_create_conn_cancel() == -ENOBUFS) {
+			LOG_WRN("No buffers to cancel connection, retrying in 10 ms");
+			k_work_reschedule(dwork, K_MSEC(10));
+		}
 		return;
 	}
 


### PR DESCRIPTION
Handle the `bt_le_create_conn_cancel` call in the deferred worker failing due to insufficient command buffers.
This fixes `bt_conn_disconnect` silently failing and not triggering a disconnect under heavy buffer contention.