### PR TITLE
sensor: current_amp: optional high-range gain fallback

### DIFF
--- a/drivers/sensor/current_amp/current_amp.c
+++ b/drivers/sensor/current_amp/current_amp.c
@@ -18,7 +18,16 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(current_amp, CONFIG_SENSOR_LOG_LEVEL);
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(gain_extended_range)
+#define INST_HAS_EXTENDED_RANGE 1
+#endif
+
 struct current_sense_amplifier_data {
+#ifdef INST_HAS_EXTENDED_RANGE
+	const struct adc_channel_cfg *sample_channel_cfg;
+	struct adc_channel_cfg channel_cfg_extended_range;
+	int16_t adc_max;
+#endif /* INST_HAS_EXTENDED_RANGE */
 	struct adc_sequence sequence;
 	int16_t raw;
 };
@@ -37,6 +46,32 @@ static int fetch(const struct device *dev, enum sensor_channel chan)
 	if (ret != 0) {
 		LOG_ERR("adc_read: %d", ret);
 	}
+#ifdef INST_HAS_EXTENDED_RANGE
+	data->sample_channel_cfg = &config->port.channel_cfg;
+
+	/* Initial measurement hit the limits, and an alternate gain has been defined */
+	if ((data->raw == data->adc_max) && (config->gain_extended_range != 0xFF)) {
+		int ret2;
+
+		/* Reconfigure channel for the extended range setup.
+		 * Updating configurations should not fail since they were validated in `init`.
+		 */
+		ret = adc_channel_setup(config->port.dev, &data->channel_cfg_extended_range);
+		__ASSERT_NO_MSG(ret == 0);
+		/* Sample again at the higher range/lower resolution */
+		ret = adc_read_dt(&config->port, &data->sequence);
+		if (ret != 0) {
+			LOG_ERR("adc_read: %d", ret);
+		}
+
+		/* Put channel back to original configuration */
+		ret2 = adc_channel_setup_dt(&config->port);
+		__ASSERT_NO_MSG(ret2 == 0);
+
+		/* Sample was measured with the extended range configuration */
+		data->sample_channel_cfg = &data->channel_cfg_extended_range;
+	}
+#endif /* INST_HAS_EXTENDED_RANGE */
 
 	return ret;
 }
@@ -59,7 +94,12 @@ static int get(const struct device *dev, enum sensor_channel chan, struct sensor
 		return sensor_value_from_micro(val, 0);
 	}
 
+#ifdef INST_HAS_EXTENDED_RANGE
+	ret = adc_raw_to_x_dt_chan(adc_raw_to_microvolts, &config->port, data->sample_channel_cfg,
+				   &raw_val);
+#else
 	ret = adc_raw_to_millivolts_dt(&config->port, &raw_val);
+#endif
 	if (ret != 0) {
 		LOG_ERR("raw_to_mv: %d", ret);
 		return ret;
@@ -143,6 +183,22 @@ static int current_init(const struct device *dev)
 		}
 	}
 #endif
+
+#ifdef INST_HAS_EXTENDED_RANGE
+	if (config->gain_extended_range != 0xFF) {
+		memcpy(&data->channel_cfg_extended_range, &config->port.channel_cfg,
+		       sizeof(data->channel_cfg_extended_range));
+		data->channel_cfg_extended_range.gain = config->gain_extended_range;
+		data->adc_max = (1 << config->port.resolution) - 1;
+
+		/* Test setup of configuration to catch invalid values */
+		ret = adc_channel_setup(config->port.dev, &data->channel_cfg_extended_range);
+		if (ret != 0) {
+			LOG_ERR("ext_setup: %d", ret);
+			return ret;
+		}
+	}
+#endif /* INST_HAS_EXTENDED_RANGE */
 
 	ret = adc_channel_setup_dt(&config->port);
 	if (ret != 0) {

--- a/dts/bindings/iio/afe/current-sense-amplifier.yaml
+++ b/dts/bindings/iio/afe/current-sense-amplifier.yaml
@@ -70,3 +70,49 @@ properties:
     description: |
      Raw ADC readings below this threshold are treated as noise and
      reported as 0 uA. The default value of 0 disables the threshold.
+
+  gain-extended-range:
+    type: string
+    description: |
+      Alternate gain to use if primary measurement hits limit:
+      - ADC_GAIN_1_6: x 1/6
+      - ADC_GAIN_1_5: x 1/5
+      - ADC_GAIN_1_4: x 1/4
+      - ADC_GAIN_1_3: x 1/3
+      - ADC_GAIN_2_5: x 2/5
+      - ADC_GAIN_1_2: x 1/2
+      - ADC_GAIN_2_3: x 2/3
+      - ADC_GAIN_4_5: x 4/5
+      - ADC_GAIN_1:   x 1
+      - ADC_GAIN_2:   x 2
+      - ADC_GAIN_3:   x 3
+      - ADC_GAIN_4:   x 4
+      - ADC_GAIN_6:   x 6
+      - ADC_GAIN_8:   x 8
+      - ADC_GAIN_12:  x 12
+      - ADC_GAIN_16:  x 16
+      - ADC_GAIN_24:  x 24
+      - ADC_GAIN_32:  x 32
+      - ADC_GAIN_64:  x 64
+      - ADC_GAIN_128: x 128
+    enum:
+      - "ADC_GAIN_1_6"
+      - "ADC_GAIN_1_5"
+      - "ADC_GAIN_1_4"
+      - "ADC_GAIN_1_3"
+      - "ADC_GAIN_2_5"
+      - "ADC_GAIN_1_2"
+      - "ADC_GAIN_2_3"
+      - "ADC_GAIN_4_5"
+      - "ADC_GAIN_1"
+      - "ADC_GAIN_2"
+      - "ADC_GAIN_3"
+      - "ADC_GAIN_4"
+      - "ADC_GAIN_6"
+      - "ADC_GAIN_8"
+      - "ADC_GAIN_12"
+      - "ADC_GAIN_16"
+      - "ADC_GAIN_24"
+      - "ADC_GAIN_32"
+      - "ADC_GAIN_64"
+      - "ADC_GAIN_128"

--- a/include/zephyr/drivers/adc/current_sense_amplifier.h
+++ b/include/zephyr/drivers/adc/current_sense_amplifier.h
@@ -18,6 +18,7 @@ struct current_sense_amplifier_dt_spec {
 	uint16_t sense_gain_div;
 	uint16_t noise_threshold;
 	int16_t zero_current_voltage_mv;
+	enum adc_gain gain_extended_range;
 	bool enable_calibration;
 };
 
@@ -40,6 +41,7 @@ struct current_sense_amplifier_dt_spec {
 		.sense_gain_div = DT_PROP(node_id, sense_gain_div),                                \
 		.noise_threshold = DT_PROP(node_id, zephyr_noise_threshold),                       \
 		.zero_current_voltage_mv = DT_PROP(node_id, zero_current_voltage_mv),              \
+		.gain_extended_range = DT_STRING_TOKEN_OR(node_id, gain_extended_range, 0xFF),     \
 		.enable_calibration = DT_PROP_OR(node_id, enable_calibration, false),              \
 	}
 

--- a/include/zephyr/drivers/adc/current_sense_amplifier.h
+++ b/include/zephyr/drivers/adc/current_sense_amplifier.h
@@ -68,4 +68,29 @@ current_sense_amplifier_scale_dt(const struct current_sense_amplifier_dt_spec *s
 	*v_to_i = (int32_t)tmp;
 }
 
+/**
+ * @brief Calculates the actual amperage from the measured voltage
+ *
+ * @param spec Current sensor specification from Devicetree.
+ * @param microvolts Measured voltage in microvolts.
+ *
+ * @return int32_t Corresponding scaled output current in microamps.
+ */
+static inline int32_t
+current_sense_amplifier_scale_ua_dt(const struct current_sense_amplifier_dt_spec *spec,
+				    int32_t microvolts)
+{
+	int64_t temp = microvolts;
+	/* Perform all multiplications first to limit rounding errors.
+	 * Micro-volts/milli-ohms would result in milli-amps, scale by factor of 1,000.
+	 * Proof that the following cannot overflow:
+	 *    (millivolts * micro_scale) * max_gain <= INT64_MAX
+	 *          (INT32_MAX * 1000) * UINT16_MAX <= INT64_MAX
+	 *                                   ~2**57 <= 2**63
+	 */
+	int64_t scaled = temp * 1000 * spec->sense_gain_div;
+	/* Perform final divisions */
+	return scaled / spec->sense_gain_mult / spec->sense_milli_ohms;
+}
+
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ADC_CURRENT_SENSE_AMPLIFIER_H_ */

--- a/tests/drivers/build_all/sensor/adc.dtsi
+++ b/tests/drivers/build_all/sensor/adc.dtsi
@@ -37,6 +37,14 @@ test_current: current_amp {
 	zero-current-voltage-mv = <0>;
 };
 
+test_current_alt_gain: current_amp_alt_gain {
+	compatible = "current-sense-amplifier";
+	io-channels = <&adc0 0>;
+	sense-resistor-milli-ohms = <2>;
+	sense-gain-mult = <50>;
+	gain-extended-range = "ADC_GAIN_1_6";
+};
+
 test_composite_fuel_gauge: composite_fuel_gauge {
 	compatible = "zephyr,fuel-gauge-composite";
 	status = "okay";


### PR DESCRIPTION
Add the option to specify an alternate ADC gain value to use if the initial measurement saturates the range. This enables higher data resolutions when the values are small compared to the maximum signal values, while still supporting the maximum.

As a concrete example, measuring charge currents from a small solar panel (0 - 50mA), while also supporting high USB charge currents (up to 1A).