### PR TITLE
sensor: voltage_divider: request calibration

### DIFF
--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -191,6 +191,7 @@ static int voltage_init(const struct device *dev)
 
 	data->sequence.buffer = &data->raw;
 	data->sequence.buffer_size = sizeof(data->raw);
+	data->sequence.calibrate = true;
 
 	return pm_device_driver_init(dev, pm_action);
 }


### PR DESCRIPTION
Request calibration of the ADC in the voltage divider driver to improve the accuracy of the measured voltages.