### PR TITLE
boards: nordic: nrf9160dk: fix NS application SRAM

### DIFF
--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_ns.dts
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_ns.dts
@@ -11,7 +11,7 @@
 / {
 	chosen {
 		zephyr,flash = &flash0;
-		zephyr,sram = &sram0_ns;
+		zephyr,sram = &sram0_ns_app;
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 };


### PR DESCRIPTION
Fix the node configured as the application SRAM partition. This aligns this board with all the other Nordic DK `_ns` boards.