### PR TITLE
flash: nrf_qspi_nor: active dwell time

### DIFF
--- a/drivers/flash/Kconfig.nordic_qspi_nor
+++ b/drivers/flash/Kconfig.nordic_qspi_nor
@@ -61,4 +61,15 @@ config NORDIC_QSPI_NOR_TIMEOUT_MS
 	  a flash sector erase. The 500 ms default allows for
 	  most typical NOR flash chips to erase a sector.
 
+config NORDIC_QSPI_NOR_ACTIVE_DWELL_MS
+	int "Dwell period (ms) after last use to stay in active mode"
+	depends on PM_DEVICE_RUNTIME
+	default 10
+	help
+	  Flash accesses commonly occur in bursts, where entering and exiting DPD
+	  mode between each access adds significantly to the total operation time.
+	  This option controls how long to remain in active mode after each API
+	  call, eliminating the active->idle->active transition sequence if another
+	  transaction occurs before the dwell period expires.
+
 endif # NORDIC_QSPI_NOR

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -59,6 +59,12 @@ struct qspi_nor_config {
 	const struct pinctrl_dev_config *pcfg;
 };
 
+#ifdef CONFIG_NORDIC_QSPI_NOR_ACTIVE_DWELL_MS
+#define ACTIVE_DWELL_MS CONFIG_NORDIC_QSPI_NOR_ACTIVE_DWELL_MS
+#else
+#define ACTIVE_DWELL_MS 0
+#endif
+
 /* Status register bits */
 #define QSPI_SECTOR_SIZE SPI_NOR_SECTOR_SIZE
 #define QSPI_BLOCK_SIZE SPI_NOR_BLOCK_SIZE
@@ -363,7 +369,7 @@ static void qspi_release(const struct device *dev)
 
 	qspi_unlock(dev);
 
-	rc = pm_device_runtime_put(dev);
+	rc = pm_device_runtime_put_async(dev, K_MSEC(ACTIVE_DWELL_MS));
 	if (rc < 0) {
 		LOG_ERR("pm_device_runtime_put failed: %d", rc);
 	}


### PR DESCRIPTION
Asynchronously release the device after a small delay to minimise power state transitions under multiple sequential API calls (e.g. NVS).