### PR TITLE
spi: add `spi_acquire` API

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -169,6 +169,10 @@ New APIs and options
 
    * :c:func:`pm_device_driver_deinit`
 
+* SPI
+
+   * :c:func:`spi_acquire`
+
 * Settings
 
    * :kconfig:option:`CONFIG_SETTINGS_TFM_ITS`

--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -257,6 +257,16 @@ static int spi_bitbang_transceive_async(const struct device *dev,
 }
 #endif
 
+int spi_bitbang_request(const struct device *dev,
+			const struct spi_config *config)
+{
+	struct spi_bitbang_data *data = dev->data;
+	struct spi_context *ctx = &data->ctx;
+
+	spi_context_lock(ctx, false, NULL, NULL, config);
+	return 0;
+}
+
 int spi_bitbang_release(const struct device *dev,
 			  const struct spi_config *config)
 {

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -90,6 +90,14 @@ static int spi_emul_io(const struct device *dev, const struct spi_config *config
 	return api->io(emul->target, config, tx_bufs, rx_bufs);
 }
 
+static int spi_emul_acquire(const struct device *dev, const struct spi_config *config)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(config);
+
+	return 0;
+}
+
 /**
  * @brief This is a no-op stub of the SPI API's `release` method to protect drivers under test
  *        from hitting a segmentation fault when using SPI_LOCK_ON plus spi_release()
@@ -135,6 +143,7 @@ static DEVICE_API(spi, spi_emul_api) = {
 #ifdef CONFIG_SPI_RTIO
 	.iodev_submit = spi_rtio_iodev_default_submit,
 #endif
+	.acquire = spi_emul_acquire,
 	.release = spi_emul_release,
 };
 

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -773,6 +773,16 @@ static int spi_stm32_configure(const struct device *dev,
 	return 0;
 }
 
+static int spi_stm32_acquire(const struct device *dev,
+			     const struct spi_config *config)
+{
+	struct spi_stm32_data *data = dev->data;
+
+	spi_context_lock(&data->ctx, false, NULL, NULL, config);
+
+	return 0;
+}
+
 static int spi_stm32_release(const struct device *dev,
 			     const struct spi_config *config)
 {
@@ -1388,6 +1398,7 @@ static DEVICE_API(spi, api_funcs) = {
 #ifdef CONFIG_SPI_RTIO
 	.iodev_submit = spi_rtio_iodev_default_submit,
 #endif
+	.acquire = spi_stm32_acquire,
 	.release = spi_stm32_release,
 };
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -313,6 +313,21 @@ static int spi_nrfx_transceive_async(const struct device *dev,
 }
 #endif /* CONFIG_SPI_ASYNC */
 
+
+static int spi_nrfx_acquire(const struct device *dev,
+			    const struct spi_config *spi_cfg)
+{
+	struct spi_nrfx_data *dev_data = dev->data;
+
+	if (spi_context_configured(&dev_data->ctx, spi_cfg)) {
+		return -EINVAL;
+	}
+
+	spi_context_lock(&dev_data->ctx, false, NULL, NULL, spi_cfg);
+
+	return 0;
+}
+
 static int spi_nrfx_release(const struct device *dev,
 			    const struct spi_config *spi_cfg)
 {
@@ -339,6 +354,7 @@ static DEVICE_API(spi, spi_nrfx_driver_api) = {
 #ifdef CONFIG_SPI_RTIO
 	.iodev_submit = spi_rtio_iodev_default_submit,
 #endif
+	.acquire = spi_nrfx_acquire,
 	.release = spi_nrfx_release,
 };
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -728,6 +728,20 @@ static int spi_nrfx_transceive_async(const struct device *dev,
 }
 #endif /* CONFIG_SPI_ASYNC */
 
+static int spi_nrfx_acquire(const struct device *dev,
+			    const struct spi_config *spi_cfg)
+{
+	struct spi_nrfx_data *dev_data = dev->data;
+
+	if (spi_context_configured(&dev_data->ctx, spi_cfg)) {
+		return -EINVAL;
+	}
+
+	spi_context_lock(&dev_data->ctx, false, NULL, NULL, spi_cfg);
+
+	return 0;
+}
+
 static int spi_nrfx_release(const struct device *dev,
 			    const struct spi_config *spi_cfg)
 {
@@ -755,6 +769,7 @@ static DEVICE_API(spi, spi_nrfx_driver_api) = {
 #ifdef CONFIG_SPI_RTIO
 	.iodev_submit = spi_rtio_iodev_default_submit,
 #endif
+	.acquire = spi_nrfx_acquire,
 	.release = spi_nrfx_release,
 };
 

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -796,6 +796,16 @@ static int spi_sam_transceive_async(const struct device *dev,
 }
 #endif /* CONFIG_SPI_ASYNC */
 
+static int spi_sam_acquire(const struct device *dev,
+			   const struct spi_config *config)
+{
+	struct spi_sam_data *data = dev->data;
+
+	spi_context_lock(&data->ctx, false, NULL, NULL, config);
+
+	return 0;
+}
+
 static int spi_sam_release(const struct device *dev,
 			   const struct spi_config *config)
 {
@@ -851,6 +861,7 @@ static DEVICE_API(spi, spi_sam_driver_api) = {
 #ifdef CONFIG_SPI_RTIO
 	.iodev_submit = spi_sam_iodev_submit,
 #endif
+	.acquire = spi_sam_acquire,
 	.release = spi_sam_release,
 };
 


### PR DESCRIPTION
Add a counterpart to the `spi_release` function call that locks the context without needing to initiate a transaction. This is intended to be used when SPI bus access needs to be blocked before the device is accessed.

One example of this requirement is power cycling an SD card, where the bus should be kept idle after power up until starting the switch from SD mode to SPI mode. This requires locking the bus before power is applied.

Currently no tests in this PR, there doesn't appear to be any tests of `spi_release` in the tree, happy to take suggestions on what to do.