### PR TITLE
boards: atmel: Fix devicetree style

### DIFF
--- a/boards/atmel/sam/sam4e_xpro/sam4e_xpro.dts
+++ b/boards/atmel/sam/sam4e_xpro/sam4e_xpro.dts
@@ -52,75 +52,87 @@
 		compatible = "atmel-xplained-pro-header";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           Shared */
-		gpio-map =	<0  0 &piob  2 0>,	/* AFE AD0          */
-				<1  0 &piob  3 0>,	/* AFE AD1          */
-				<2  0 &pioa 24 0>,	/* GPIO             */
-				<3  0 &pioa 25 0>,	/* GPIO             */
-				<4  0 &pioa 15 0>,	/* TIOA1            */
-				<5  0 &pioa 16 0>,	/* TIOB1            */
-				<6  0 &pioa 11 0>,	/* WKUP7            */
-				<7  0 &piod 25 0>,	/* GPIO             */
-				<8  0 &pioa  3 0>,	/* TWD0        EXTx */
-				<9  0 &pioa  4 0>,	/* TWCK0       EXTx */
-				<10 0 &pioa 21 0>,	/* RXD1             */
-				<11 0 &pioa 22 0>,	/* TXD1             */
-				<12 0 &piob 14 0>,	/* SPI(NPCS1)       */
-				<13 0 &pioa 13 0>,	/* SPI(MOSI)   EXTx */
-				<14 0 &pioa 12 0>,	/* SPI(MISO)   EXTx */
-				<15 0 &pioa 14 0>;	/* SPI(SCK)    EXTx */
-							/* GND              */
-							/* +3.3V            */
+		gpio-map-pass-thru = <0 0x3f>;
+
+		/* dts-format off */
+					      /*           Shared */
+		gpio-map = <0  0 &piob  2 0>, /* AFE AD0          */
+			   <1  0 &piob  3 0>, /* AFE AD1          */
+			   <2  0 &pioa 24 0>, /* GPIO             */
+			   <3  0 &pioa 25 0>, /* GPIO             */
+			   <4  0 &pioa 15 0>, /* TIOA1            */
+			   <5  0 &pioa 16 0>, /* TIOB1            */
+			   <6  0 &pioa 11 0>, /* WKUP7            */
+			   <7  0 &piod 25 0>, /* GPIO             */
+			   <8  0 &pioa  3 0>, /* TWD0        EXTx */
+			   <9  0 &pioa  4 0>, /* TWCK0       EXTx */
+			   <10 0 &pioa 21 0>, /* RXD1             */
+			   <11 0 &pioa 22 0>, /* TXD1             */
+			   <12 0 &piob 14 0>, /* SPI(NPCS1)       */
+			   <13 0 &pioa 13 0>, /* SPI(MOSI)   EXTx */
+			   <14 0 &pioa 12 0>, /* SPI(MISO)   EXTx */
+			   <15 0 &pioa 14 0>; /* SPI(SCK)    EXTx */
+					      /* GND              */
+					      /* +3.3V            */
+		/* dts-format on */
 	};
 
 	ext2_header: xplained-pro-connector2 {
 		compatible = "atmel-xplained-pro-header";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           Shared */
-		gpio-map =    /*<0  0 -      - 0>,	   -                */
-			      /*<1  0 -      - 0>,	   -                */
-				<2  0 &pioe  2 0>,	/* GPIO        EBDG */
-				<3  0 &piob  5 0>,	/* GPIO        EDBG */
-				<4  0 &piod 21 0>,	/* PWMHI1           */
-			      /*<5  0 -      - 0>,	   -                */
-				<6  0 &piod 29 0>,	/* GPIO        ETH  */
-				<7  0 &piob  4 0>,	/* GPIO             */
-				<8  0 &pioa  3 0>,	/* TWD0        EXTx */
-				<9  0 &pioa  4 0>,	/* TWCK0       EXTx */
-				<10 0 &pioa  5 0>,	/* URXD1       EXT3 */
-				<11 0 &pioa  6 0>,	/* UTXD1       EXT3 */
-				<12 0 &piod 23 0>,	/* GPIO             */
-				<13 0 &pioa 13 0>,	/* SPI(MOSI)   EXTx */
-				<14 0 &pioa 12 0>,	/* SPI(MISO)   EXTx */
-				<15 0 &pioa 14 0>;	/* SPI(SCK)    EXTx */
-							/* GND              */
-							/* +3.3V            */
+		gpio-map-pass-thru = <0 0x3f>;
+
+		/* dts-format off */
+						/*           Shared */
+		gpio-map = /*<0  0 -      - 0>,	   -                */
+			   /*<1  0 -      - 0>,	   -                */
+			     <2  0 &pioe  2 0>,	/* GPIO        EBDG */
+			     <3  0 &piob  5 0>,	/* GPIO        EDBG */
+			     <4  0 &piod 21 0>,	/* PWMHI1           */
+			   /*<5  0 -      - 0>,	   -                */
+			     <6  0 &piod 29 0>,	/* GPIO        ETH  */
+			     <7  0 &piob  4 0>,	/* GPIO             */
+			     <8  0 &pioa  3 0>,	/* TWD0        EXTx */
+			     <9  0 &pioa  4 0>,	/* TWCK0       EXTx */
+			     <10 0 &pioa  5 0>,	/* URXD1       EXT3 */
+			     <11 0 &pioa  6 0>,	/* UTXD1       EXT3 */
+			     <12 0 &piod 23 0>,	/* GPIO             */
+			     <13 0 &pioa 13 0>,	/* SPI(MOSI)   EXTx */
+			     <14 0 &pioa 12 0>,	/* SPI(MISO)   EXTx */
+			     <15 0 &pioa 14 0>;	/* SPI(SCK)    EXTx */
+						/* GND              */
+						/* +3.3V            */
+		/* dts-format on */
 	};
 
 	ext3_header: xplained-pro-connector3 {
 		compatible = "atmel-xplained-pro-header";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           Shared */
-		gpio-map =	<0  0 &pioa 17 0>,	/* AFE AD0          */
-				<1  0 &pioc 13 0>,	/* AFE AD6          */
-				<2  0 &piod 28 0>,	/* GPIO             */
-				<3  0 &piod 17 0>,	/* GPIO             */
-				<4  0 &piod 20 0>,	/* PWMH0            */
-				<5  0 &piod 24 0>,	/* PWML0            */
-				<6  0 &pioe  1 0>,	/* GPIO             */
-				<7  0 &piod 26 0>,	/* GPIO             */
-				<8  0 &pioa  3 0>,	/* TWD0        EXTx */
-				<9  0 &pioa  4 0>,	/* TWCK0       EXTx */
-				<10 0 &pioa  5 0>,	/* URXD1       EXT2 */
-				<11 0 &pioa  6 0>,	/* UTXD1       EXT2 */
-				<12 0 &piod 30 0>,	/* GPIO             */
-				<13 0 &pioa 13 0>,	/* SPI(MOSI)   EXTx */
-				<14 0 &pioa 12 0>,	/* SPI(MISO)   EXTx */
-				<15 0 &pioa 14 0>;	/* SPI(SCK)    EXTx */
-							/* GND              */
-							/* +3.3V            */
+		gpio-map-pass-thru = <0 0x3f>;
+
+		/* dts-format off */
+					      /*           Shared */
+		gpio-map = <0  0 &pioa 17 0>, /* AFE AD0          */
+			   <1  0 &pioc 13 0>, /* AFE AD6          */
+			   <2  0 &piod 28 0>, /* GPIO             */
+			   <3  0 &piod 17 0>, /* GPIO             */
+			   <4  0 &piod 20 0>, /* PWMH0            */
+			   <5  0 &piod 24 0>, /* PWML0            */
+			   <6  0 &pioe  1 0>, /* GPIO             */
+			   <7  0 &piod 26 0>, /* GPIO             */
+			   <8  0 &pioa  3 0>, /* TWD0        EXTx */
+			   <9  0 &pioa  4 0>, /* TWCK0       EXTx */
+			   <10 0 &pioa  5 0>, /* URXD1       EXT2 */
+			   <11 0 &pioa  6 0>, /* UTXD1       EXT2 */
+			   <12 0 &piod 30 0>, /* GPIO             */
+			   <13 0 &pioa 13 0>, /* SPI(MOSI)   EXTx */
+			   <14 0 &pioa 12 0>, /* SPI(MISO)   EXTx */
+			   <15 0 &pioa 14 0>; /* SPI(SCK)    EXTx */
+					      /* GND              */
+					      /* +3.3V            */
+		/* dts-format on */
 	};
 };
 

--- a/boards/atmel/sam/sam4s_xplained/sam4s_xplained.dts
+++ b/boards/atmel/sam/sam4s_xplained/sam4s_xplained.dts
@@ -69,68 +69,84 @@
 		compatible = "atmel-xplained-header";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           Shared */
-		gpio-map =	<0 0 &pioa  3 0>,	/* TWD0           y */
-				<1 0 &pioa  4 0>,	/* TWCK0          y */
-				<2 0 &piob  2 0>,	/* URXD1            */
-				<3 0 &piob  3 0>,	/* UTXD1            */
-				<4 0 &pioa 31 0>,	/* SPI(CS)          */
-				<5 0 &pioa 13 0>,	/* SPI(MOSI)      y */
-				<6 0 &pioa 12 0>,	/* SPI(MISO)      y */
-				<7 0 &pioa 14 0>;	/* SPI(SCK)       y */
-							/* GND              */
-							/* +3.3V            */
+		gpio-map-pass-thru = <0 0x3f>;
+
+		/* dts-format off */
+					     /*           Shared */
+		gpio-map = <0 0 &pioa  3 0>, /* TWD0           y */
+			   <1 0 &pioa  4 0>, /* TWCK0          y */
+			   <2 0 &piob  2 0>, /* URXD1            */
+			   <3 0 &piob  3 0>, /* UTXD1            */
+			   <4 0 &pioa 31 0>, /* SPI(CS)          */
+			   <5 0 &pioa 13 0>, /* SPI(MOSI)      y */
+			   <6 0 &pioa 12 0>, /* SPI(MISO)      y */
+			   <7 0 &pioa 14 0>; /* SPI(SCK)       y */
+					     /* GND              */
+					     /* +3.3V            */
+		/* dts-format on */
 	};
 
 	xplained2_header: xplained-connector2 {
 		compatible = "atmel-xplained-header";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           Shared */
-		gpio-map =	<0 0 &pioa 22 0>,	/* GPIO             */
-				<1 0 &pioc 12 0>,	/* GPIO             */
-				<2 0 &piob  0 0>,	/* GPIO             */
-				<3 0 &piob  1 0>,	/* GPIO             */
-				<4 0 &pioa 17 0>,	/* GPIO             */
-				<5 0 &pioa 21 0>,	/* GPIO             */
-				<6 0 &pioc 13 0>,	/* GPIO             */
-				<7 0 &pioc 15 0>;	/* GPIO             */
-							/* GND              */
-							/* +3.3V            */
+		gpio-map-pass-thru = <0 0x3f>;
+
+		/* dts-format off */
+					     /*           Shared */
+		gpio-map = <0 0 &pioa 22 0>, /* GPIO             */
+			   <1 0 &pioc 12 0>, /* GPIO             */
+			   <2 0 &piob  0 0>, /* GPIO             */
+			   <3 0 &piob  1 0>, /* GPIO             */
+			   <4 0 &pioa 17 0>, /* GPIO             */
+			   <5 0 &pioa 21 0>, /* GPIO             */
+			   <6 0 &pioc 13 0>, /* GPIO             */
+			   <7 0 &pioc 15 0>; /* GPIO             */
+					     /* GND              */
+					     /* +3.3V            */
+		/* dts-format on */
 	};
 
 	xplained3_header: xplained-connector3 {
 		compatible = "atmel-xplained-header";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           Shared */
-		gpio-map =	<0 0 &pioa 20 0>,	/* GPIO             */
-				<1 0 &pioa 11 0>,	/* GPIO             */
-				<2 0 &pioa 23 0>,	/* GPIO             */
-				<3 0 &pioa 18 0>,	/* GPIO             */
-				<4 0 &pioa 15 0>,	/* GPIO             */
-				<5 0 &pioa 16 0>,	/* GPIO             */
-				<6 0 &pioa  2 0>,	/* GPIO             */
-				<7 0 &pioc  2 0>;	/* GPIO             */
-							/* GND              */
-							/* +3.3V            */
+		gpio-map-pass-thru = <0 0x3f>;
+
+		/* dts-format off */
+					     /*           Shared */
+		gpio-map = <0 0 &pioa 20 0>, /* GPIO             */
+			   <1 0 &pioa 11 0>, /* GPIO             */
+			   <2 0 &pioa 23 0>, /* GPIO             */
+			   <3 0 &pioa 18 0>, /* GPIO             */
+			   <4 0 &pioa 15 0>, /* GPIO             */
+			   <5 0 &pioa 16 0>, /* GPIO             */
+			   <6 0 &pioa  2 0>, /* GPIO             */
+			   <7 0 &pioc  2 0>; /* GPIO             */
+					     /* GND              */
+					     /* +3.3V            */
+		/* dts-format on */
 	};
 
 	xplained4_header: xplained-connector4 {
 		compatible = "atmel-xplained-header";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           Shared */
-		gpio-map =	<0 0 &pioa  3 0>,	/* TWD0           y */
-				<1 0 &pioa  4 0>,	/* TWCK0          y */
-				<2 0 &piob  2 0>,	/* URXD1            */
-				<3 0 &piob  3 0>,	/* UTXD1            */
-				<4 0 &pioa 30 0>,	/* SPI(CS)          */
-				<5 0 &pioa 13 0>,	/* SPI(MOSI)      y */
-				<6 0 &pioa 12 0>,	/* SPI(MISO)      y */
-				<7 0 &pioa 14 0>;	/* SPI(SCK)       y */
-							/* GND              */
-							/* +3.3V            */
+		gpio-map-pass-thru = <0 0x3f>;
+
+		/* dts-format off */
+					     /*           Shared */
+		gpio-map = <0 0 &pioa  3 0>, /* TWD0           y */
+			   <1 0 &pioa  4 0>, /* TWCK0          y */
+			   <2 0 &piob  2 0>, /* URXD1            */
+			   <3 0 &piob  3 0>, /* UTXD1            */
+			   <4 0 &pioa 30 0>, /* SPI(CS)          */
+			   <5 0 &pioa 13 0>, /* SPI(MOSI)      y */
+			   <6 0 &pioa 12 0>, /* SPI(MISO)      y */
+			   <7 0 &pioa 14 0>; /* SPI(SCK)       y */
+					     /* GND              */
+					     /* +3.3V            */
+		/* dts-format on */
 	};
 };
 

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -77,79 +77,91 @@
 		compatible = "atmel-xplained-pro-header";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           Shared */
-		gpio-map =	<0  0 &pioc 31 0>,	/* AFE1 AD6         */
-				<1  0 &pioa 19 0>,	/* AFE0 AD8         */
-				<2  0 &piob  3 0>,	/* RTS0             */
-				<3  0 &piob  2 0>,	/* CTS0             */
-				<4  0 &pioa  0 0>,	/* PWMC0_H0         */
-				<5  0 &pioc 30 0>,	/* TIOB5            */
-				<6  0 &piod 28 0>,	/* WKUP5            */
-				<7  0 &pioa  5 0>,	/* GPIO             */
-				<8  0 &pioa  3 0>,	/* TWD0        EXT2 */
-				<9  0 &pioa  4 0>,	/* TWCK0       EXT2 */
-				<10 0 &piob  0 0>,	/* RXD0             */
-				<11 0 &piob  1 0>,	/* TXD0             */
-				<12 0 &piod 25 0>,	/* SPI0(NPCS1)      */
-				<13 0 &piod 21 0>,	/* SPI0(MOSI)  EXT2 */
-				<14 0 &piod 20 0>,	/* SPI0(MISO)  EXT2 */
-				<15 0 &piod 22 0>;	/* SPI0(SCK)   EXT2 */
-							/* GND              */
-							/* +3.3V            */
+		gpio-map-pass-thru = <0 0x3f>;
+
+		/* dts-format off */
+					      /*           Shared */
+		gpio-map = <0  0 &pioc 31 0>, /* AFE1 AD6         */
+			   <1  0 &pioa 19 0>, /* AFE0 AD8         */
+			   <2  0 &piob  3 0>, /* RTS0             */
+			   <3  0 &piob  2 0>, /* CTS0             */
+			   <4  0 &pioa  0 0>, /* PWMC0_H0         */
+			   <5  0 &pioc 30 0>, /* TIOB5            */
+			   <6  0 &piod 28 0>, /* WKUP5            */
+			   <7  0 &pioa  5 0>, /* GPIO             */
+			   <8  0 &pioa  3 0>, /* TWD0        EXT2 */
+			   <9  0 &pioa  4 0>, /* TWCK0       EXT2 */
+			   <10 0 &piob  0 0>, /* RXD0             */
+			   <11 0 &piob  1 0>, /* TXD0             */
+			   <12 0 &piod 25 0>, /* SPI0(NPCS1)      */
+			   <13 0 &piod 21 0>, /* SPI0(MOSI)  EXT2 */
+			   <14 0 &piod 20 0>, /* SPI0(MISO)  EXT2 */
+			   <15 0 &piod 22 0>; /* SPI0(SCK)   EXT2 */
+					      /* GND              */
+					      /* +3.3V            */
+		/* dts-format on */
 	};
 
 	ext2_header: xplained-pro-connector2 {
 		compatible = "atmel-xplained-pro-header";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           Shared */
-		gpio-map =	<0  0 &piod 30 0>,	/* AFE0 AD0         */
-				<1  0 &pioc 13 0>,	/* AFE1 AD1         */
-				<2  0 &pioa  6 0>,	/* GPIO             */
-				<3  0 &piod 11 0>,	/* GPIO             */
-				<4  0 &pioc 19 0>,	/* PWMC0_H2         */
-				<5  0 &piod 26 0>,	/* PWMC0_L2         */
-				<6  0 &pioa  2 0>,	/* WKUP2            */
-				<7  0 &pioa 24 0>,	/* GPIO             */
-				<8  0 &pioa  3 0>,	/* TWD0        EXT1 */
-				<9  0 &pioa  4 0>,	/* TWCK0       EXT1 */
-				<10 0 &pioa 21 0>,	/* RXD1             */
-				<11 0 &piob  4 0>,	/* TXD1             */
-				<12 0 &piod 27 0>,	/* SPI0(NPCS3)      */
-				<13 0 &piod 21 0>,	/* SPI0(MOSI)  EXT1 */
-				<14 0 &piod 20 0>,	/* SPI0(MISO)  EXT1 */
-				<15 0 &piod 22 0>;	/* SPI0(SCK)   EXT1 */
-							/* GND              */
-							/* +3.3V            */
+		gpio-map-pass-thru = <0 0x3f>;
+
+		/* dts-format off */
+					      /*           Shared */
+		gpio-map = <0  0 &piod 30 0>, /* AFE0 AD0         */
+			   <1  0 &pioc 13 0>, /* AFE1 AD1         */
+			   <2  0 &pioa  6 0>, /* GPIO             */
+			   <3  0 &piod 11 0>, /* GPIO             */
+			   <4  0 &pioc 19 0>, /* PWMC0_H2         */
+			   <5  0 &piod 26 0>, /* PWMC0_L2         */
+			   <6  0 &pioa  2 0>, /* WKUP2            */
+			   <7  0 &pioa 24 0>, /* GPIO             */
+			   <8  0 &pioa  3 0>, /* TWD0        EXT1 */
+			   <9  0 &pioa  4 0>, /* TWCK0       EXT1 */
+			   <10 0 &pioa 21 0>, /* RXD1             */
+			   <11 0 &piob  4 0>, /* TXD1             */
+			   <12 0 &piod 27 0>, /* SPI0(NPCS3)      */
+			   <13 0 &piod 21 0>, /* SPI0(MOSI)  EXT1 */
+			   <14 0 &piod 20 0>, /* SPI0(MISO)  EXT1 */
+			   <15 0 &piod 22 0>; /* SPI0(SCK)   EXT1 */
+					      /* GND              */
+					      /* +3.3V            */
+		/* dts-format on */
 	};
 
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;				/*       Shared */
-		gpio-map =	<ARDUINO_HEADER_R3_A0 0 &piod 26 0>,	/* TD           */
-				<ARDUINO_HEADER_R3_A1  0 &pioc 31 0>,	/* AFE1 AD6   y */
-				<ARDUINO_HEADER_R3_A2  0 &pioa 19 0>,	/* AFE0 AD8   y */
-				<ARDUINO_HEADER_R3_A3  0 &piod 30 0>,	/* AFE0 AD0   y */
-				<ARDUINO_HEADER_R3_A4  0 &pioc 13 0>,	/* AFE1 AD1   y */
-				<ARDUINO_HEADER_R3_A5  0 &pioe  0 0>,	/* AFE1 AD11    */
-				<ARDUINO_HEADER_R3_D0 0 &piod 28 0>,	/* URXD3        */
-				<ARDUINO_HEADER_R3_D1 0 &piod 30 0>,	/* UTXD3        */
-				<ARDUINO_HEADER_R3_D2 0 &pioa 0 0>,	/* PWMC0_H0     */
-				<ARDUINO_HEADER_R3_D3 0 &pioa 6 0>,	/* GPIO         */
-				<ARDUINO_HEADER_R3_D4 0 &piod 27 0>,	/* SPI0_NPCS3 y */
-				<ARDUINO_HEADER_R3_D5 0 &piod 11 0>,	/* PWMC0_H0     */
-				<ARDUINO_HEADER_R3_D6 0 &pioc 19 0>,	/* PWMC0_H2     */
-				<ARDUINO_HEADER_R3_D7 0 &pioa 2 0>,	/* PWMC0_H1     */
-				<ARDUINO_HEADER_R3_D8 0 &pioa 5 0>,	/* PWMC1_PWML3  */
-				<ARDUINO_HEADER_R3_D9 0 &pioc 9 0>,	/* TIOB7        */
-				<ARDUINO_HEADER_R3_D10 0 &piod 25 0>,	/* SPI0_NPCS1 y */
-				<ARDUINO_HEADER_R3_D11 0 &piod 21 0>,	/* SPI0_MOSI  y */
-				<ARDUINO_HEADER_R3_D12 0 &piod 20 0>,	/* SPI0_MISO  y */
-				<ARDUINO_HEADER_R3_D13 0 &piod 22 0>,	/* SPI0_SPCK  y */
-				<ARDUINO_HEADER_R3_D14 0 &pioa  3 0>,	/* TWD0       y */
-				<ARDUINO_HEADER_R3_D15 0 &pioa  4 0>;	/* TWCK0      y */
+		gpio-map-pass-thru = <0 0x3f>;
+
+		/* dts-format off */
+								 /*        Shared */
+		gpio-map = <ARDUINO_HEADER_R3_A0  0 &piod 26 0>, /* TD            */
+			   <ARDUINO_HEADER_R3_A1  0 &pioc 31 0>, /* AFE1 AD6    y */
+			   <ARDUINO_HEADER_R3_A2  0 &pioa 19 0>, /* AFE0 AD8    y */
+			   <ARDUINO_HEADER_R3_A3  0 &piod 30 0>, /* AFE0 AD0    y */
+			   <ARDUINO_HEADER_R3_A4  0 &pioc 13 0>, /* AFE1 AD1    y */
+			   <ARDUINO_HEADER_R3_A5  0 &pioe  0 0>, /* AFE1 AD11     */
+			   <ARDUINO_HEADER_R3_D0  0 &piod 28 0>, /* URXD3         */
+			   <ARDUINO_HEADER_R3_D1  0 &piod 30 0>, /* UTXD3         */
+			   <ARDUINO_HEADER_R3_D2  0 &pioa  0 0>, /* PWMC0_H0      */
+			   <ARDUINO_HEADER_R3_D3  0 &pioa  6 0>, /* GPIO          */
+			   <ARDUINO_HEADER_R3_D4  0 &piod 27 0>, /* SPI0_NPCS3  y */
+			   <ARDUINO_HEADER_R3_D5  0 &piod 11 0>, /* PWMC0_H0      */
+			   <ARDUINO_HEADER_R3_D6  0 &pioc 19 0>, /* PWMC0_H2      */
+			   <ARDUINO_HEADER_R3_D7  0 &pioa  2 0>, /* PWMC0_H1      */
+			   <ARDUINO_HEADER_R3_D8  0 &pioa  5 0>, /* PWMC1_PWML3   */
+			   <ARDUINO_HEADER_R3_D9  0 &pioc  9 0>, /* TIOB7         */
+			   <ARDUINO_HEADER_R3_D10 0 &piod 25 0>, /* SPI0_NPCS1  y */
+			   <ARDUINO_HEADER_R3_D11 0 &piod 21 0>, /* SPI0_MOSI   y */
+			   <ARDUINO_HEADER_R3_D12 0 &piod 20 0>, /* SPI0_MISO   y */
+			   <ARDUINO_HEADER_R3_D13 0 &piod 22 0>, /* SPI0_SPCK   y */
+			   <ARDUINO_HEADER_R3_D14 0 &pioa  3 0>, /* TWD0        y */
+			   <ARDUINO_HEADER_R3_D15 0 &pioa  4 0>; /* TWCK0       y */
+		/* dts-format on */
 	};
 };
 

--- a/boards/atmel/sam0/samr21_xpro/samr21_xpro.dts
+++ b/boards/atmel/sam0/samr21_xpro/samr21_xpro.dts
@@ -59,46 +59,58 @@
 		compatible = "atmel-xplained-pro-header";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           Shared */
-		gpio-map =	<0  0 &porta  6 0>,	/* ADC6             */
-				<1  0 &porta  7 0>,	/* ADC7             */
-				<2  0 &porta 13 0>,	/* GPIO             */
-				<3  0 &porta 28 0>,	/* GPIO             */
-				<4  0 &porta 18 0>,	/* PWM_T0_W2        */
-				<5  0 &porta 19 0>,	/* PWM_T0_W3        */
-				<6  0 &porta 22 0>,	/* GPIO             */
-				<7  0 &porta 23 0>,	/* GPIO             */
-				<8  0 &porta 16 0>,	/* TWD1        EXT2 */
-				<9  0 &porta 17 0>,	/* TWCK1       EXT2 */
-				<10 0 &porta  5 0>,	/* RXD0             */
-				<11 0 &porta  4 0>,	/* TXD0             */
-				<12 0 &portb  3 0>,	/* SPI5(SS)         */
-				<13 0 &portb 22 0>,	/* SPI5(MOSI)  EXTx */
-				<14 0 &portb  2 0>,	/* SPI5(MISO)  EXTx */
-				<15 0 &portb 23 0>;	/* SPI5(SCK)   EXTx */
+		gpio-map-pass-thru = <0 0x3f>;
+
+		/* dts-format off */
+					       /*           Shared */
+		gpio-map = <0  0 &porta  6 0>, /* ADC6             */
+			   <1  0 &porta  7 0>, /* ADC7             */
+			   <2  0 &porta 13 0>, /* GPIO             */
+			   <3  0 &porta 28 0>, /* GPIO             */
+			   <4  0 &porta 18 0>, /* PWM_T0_W2        */
+			   <5  0 &porta 19 0>, /* PWM_T0_W3        */
+			   <6  0 &porta 22 0>, /* GPIO             */
+			   <7  0 &porta 23 0>, /* GPIO             */
+			   <8  0 &porta 16 0>, /* TWD1        EXT2 */
+			   <9  0 &porta 17 0>, /* TWCK1       EXT2 */
+			   <10 0 &porta  5 0>, /* RXD0             */
+			   <11 0 &porta  4 0>, /* TXD0             */
+			   <12 0 &portb  3 0>, /* SPI5(SS)         */
+			   <13 0 &portb 22 0>, /* SPI5(MOSI)  EXTx */
+			   <14 0 &portb  2 0>, /* SPI5(MISO)  EXTx */
+			   <15 0 &portb 23 0>; /* SPI5(SCK)   EXTx */
+					       /* GND              */
+					       /* +3.3V            */
+		/* dts-format on */
 	};
 
 	ext2_header: xplained-pro-connector2 {
 		compatible = "atmel-xplained-pro-header";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           Shared */
-		gpio-map =    /*<0  0 -      - 0>,	   -                */
-			      /*<1  0 -      - 0>,	   -                */
-				<2  0 &porta 15 0>,	/* GPIO             */
-			      /*<3  0 -      - 0>,	   -                */
-			      /*<4  0 -      - 0>,	   -                */
-			      /*<5  0 -      - 0>,	   -                */
-			      /*<6  0 -      - 0>,	   -                */
-				<7  0 &porta  8 0>,	/* GPIO             */
-				<8  0 &porta 16 0>,	/* TWD1        EXT1 */
-				<9  0 &porta 17 0>,	/* TWCK1       EXT1 */
-			      /*<11 0 -      - 0>,	   -                */
-			      /*<12 0 -      - 0>,	   -                */
-				<12 0 &porta 14 0>,	/* GPIO             */
-				<13 0 &portb 22 0>,	/* SPI5(MOSI)  EXTx */
-				<14 0 &portb  2 0>,	/* SPI5(MISO)  EXTx */
-				<15 0 &portb 23 0>;	/* SPI5(SCK)   EXTx */
+		gpio-map-pass-thru = <0 0x3f>;
+
+		/* dts-format off */
+						 /*           Shared */
+		gpio-map = /*<0  0 -       - 0>,    -                */
+			   /*<1  0 -       - 0>,    -                */
+			     <2  0 &porta 15 0>, /* GPIO             */
+			   /*<3  0 -       - 0>,    -                */
+			   /*<4  0 -       - 0>,    -                */
+			   /*<5  0 -       - 0>,    -                */
+			   /*<6  0 -       - 0>,    -                */
+			     <7  0 &porta  8 0>, /* GPIO             */
+			     <8  0 &porta 16 0>, /* TWD1        EXT1 */
+			     <9  0 &porta 17 0>, /* TWCK1       EXT1 */
+			   /*<10 0 -       - 0>,    -                */
+			   /*<11 0 -       - 0>,    -                */
+			     <12 0 &porta 14 0>, /* GPIO             */
+			     <13 0 &portb 22 0>, /* SPI5(MOSI)  EXTx */
+			     <14 0 &portb  2 0>, /* SPI5(MISO)  EXTx */
+			     <15 0 &portb 23 0>; /* SPI5(SCK)   EXTx */
+						 /* GND              */
+						 /* +3.3V            */
+		/* dts-format on */
 	};
 };
 
@@ -176,8 +188,8 @@
 		slptr-gpios = <&porta 20 GPIO_ACTIVE_HIGH>;
 		dig2-gpios = <&portb 17 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		status = "okay";
-		tx-pwr-min = [01 11];	/* -17.0 dBm */
-		tx-pwr-max = [00 04];	/*   4.0 dBm */
+		tx-pwr-min = [01 11]; /* -17.0 dBm */
+		tx-pwr-max = [00 04]; /*   4.0 dBm */
 		tx-pwr-table = [00 01 03 04 05 05 06 06
 				07 07 07 08 08 09 09 0a
 				0a 0a 0b 0b 0b 0b 0c 0c


### PR DESCRIPTION
The Zephyr is implementing a linter to catch devicetree problems. This boards comments are exceptions and are formatted to be compliance with the linter. However due to the exception the linter check was disabled to avoid undesirable formatting and keep the original details in the comments.

There is no functional changes.

More details in #92805

CC: @kylebonnici