### PR TITLE
Update nrf54l15dk_common.dtsi

### DIFF
--- a/boards/nordic/nrf54l15dk/nrf54l15dk_common.dtsi
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_common.dtsi
@@ -78,7 +78,6 @@
 		led1 = &led1;
 		led2 = &led2;
 		led3 = &led3;
-		pwm-led0 = &pwm_led1;
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;


### PR DESCRIPTION
Can not compile project - nRF54L15-DK does not contain &pwm_led0 - only 4 LEDs. Error while building: devicetree error: /aliases: undefined node label 'pwm_led0'. Please check it.