### PR TITLE
drivers: hwinfo: native: report reset cause

### DIFF
--- a/boards/native/native_sim/reboot_bottom.c
+++ b/boards/native/native_sim/reboot_bottom.c
@@ -13,6 +13,7 @@
 #include <nsi_tasks.h>
 #include <nsi_tracing.h>
 #include <nsi_cmdline.h>
+#include <nsi_host_trampolines.h>
 
 static const char module[] = "native_sim_reboot";
 
@@ -62,6 +63,9 @@ void maybe_reboot(void)
 	if (close_open_fds() < 0) {
 		nsi_exit(1);
 	}
+
+	/* Let's set an environment variable which the native_sim hw_info driver may check */
+	(void)nsi_host_setenv("NATIVE_SIM_RESET_CAUSE", "SOFTWARE", 1);
 
 	nsi_print_warning("%s: Restarting process.\n", module);
 

--- a/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
+++ b/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
@@ -27,6 +27,7 @@ int nsi_host_close(int fd);
 /* void nsi_host_exit (int status); Use nsi_exit() instead */
 void nsi_host_free(void *ptr);
 char *nsi_host_getcwd(char *buf, unsigned long size);
+char *nsi_host_getenv(const char *name);
 int nsi_host_isatty(int fd);
 void *nsi_host_malloc(unsigned long size);
 int nsi_host_open(const char *pathname, int flags);
@@ -34,6 +35,7 @@ int nsi_host_open(const char *pathname, int flags);
 long nsi_host_random(void);
 long nsi_host_read(int fd, void *buffer, unsigned long size);
 void *nsi_host_realloc(void *ptr, unsigned long size);
+int nsi_host_setenv(const char *name, const char *value, int overwrite);
 void nsi_host_srandom(unsigned int seed);
 char *nsi_host_strdup(const char *s);
 long nsi_host_write(int fd, const void *buffer, unsigned long size);

--- a/scripts/native_simulator/common/src/nsi_host_trampolines.c
+++ b/scripts/native_simulator/common/src/nsi_host_trampolines.c
@@ -31,6 +31,11 @@ char *nsi_host_getcwd(char *buf, unsigned long size)
 	return getcwd(buf, size);
 }
 
+char *nsi_host_getenv(const char *name)
+{
+	return getenv(name);
+}
+
 int nsi_host_isatty(int fd)
 {
 	return isatty(fd);
@@ -59,6 +64,11 @@ long nsi_host_read(int fd, void *buffer, unsigned long size)
 void *nsi_host_realloc(void *ptr, unsigned long size)
 {
 	return realloc(ptr, size);
+}
+
+int nsi_host_setenv(const char *name, const char *value, int overwrite)
+{
+	return setenv(name, value, overwrite);
 }
 
 void nsi_host_srandom(unsigned int seed)

--- a/tests/boards/native_sim/reset_hw_info/CMakeLists.txt
+++ b/tests/boards/native_sim/reset_hw_info/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(native_reset_hw_info)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/boards/native_sim/reset_hw_info/prj.conf
+++ b/tests/boards/native_sim/reset_hw_info/prj.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_REBOOT=y
+CONFIG_NATIVE_SIM_REBOOT=y
+CONFIG_HWINFO=y

--- a/tests/boards/native_sim/reset_hw_info/src/main.c
+++ b/tests/boards/native_sim/reset_hw_info/src/main.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/sys/reboot.h>
+#include <nsi_main.h>
+
+int main(void)
+{
+	uint32_t cause;
+	int err;
+
+	err = hwinfo_get_reset_cause(&cause);
+	if (err != 0) {
+		posix_print_error_and_exit("hwinfo_get_reset_cause() failed %i\n", err);
+	}
+
+	if (cause == RESET_POR) {
+		printf("This seems like the first start => Resetting\n");
+		sys_reboot(SYS_REBOOT_WARM);
+	} else if (cause == RESET_SOFTWARE) {
+		printf("Booted after SOFTWARE reset => we are done\n");
+	}
+	nsi_exit(0);
+}

--- a/tests/boards/native_sim/reset_hw_info/testcase.yaml
+++ b/tests/boards/native_sim/reset_hw_info/testcase.yaml
@@ -1,0 +1,16 @@
+tests:
+  boards.native_sim.reset_hw_info:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "(.*)Booting Zephyr OS build(.*)"
+        - "This seems like the first start => Resetting"
+        - "(.*)Booting Zephyr OS build(.*)"
+        - "Booted after SOFTWARE reset => we are done"


### PR DESCRIPTION
This PR adds support for reporting the reset cause to native_sim.

The default is to report POR (Power-On Reset).
If the system is rebooted using `sys_reboot()`, the reset cause is set to SOFTWARE.