### PR TITLE
Bluetooth: BAP: Add NULL check in bt_bap_stream_detach

### DIFF
--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -531,8 +531,11 @@ void bt_bap_stream_detach(struct bt_bap_stream *stream)
 		stream->conn = NULL;
 	}
 	stream->codec_cfg = NULL;
-	stream->ep->stream = NULL;
-	stream->ep = NULL;
+
+	if (stream->ep != NULL) {
+		stream->ep->stream = NULL;
+		stream->ep = NULL;
+	}
 
 	if (!is_broadcast) {
 		const int err = bt_bap_stream_disconnect(stream);


### PR DESCRIPTION
If stream->ep is NULL, which is really shouldn't be, then we should not attempt to dereference it.
Add simple NULL check to ensure behavior, and make Sonarcloud happy.