### PR TITLE
Bluetooth: BAP: Ep check fixes

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1447,7 +1447,7 @@ static struct bt_ascs_ase *ase_find(struct bt_conn *conn, uint8_t id)
 	return NULL;
 }
 
-bool bt_ascs_is_ase_ep(const struct bt_bap_ep *ep)
+bool bt_ascs_has_ep(const struct bt_bap_ep *ep)
 {
 	return PART_OF_ARRAY(ascs.ase_pool, ep);
 }

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -3258,4 +3258,5 @@ int bt_ascs_unregister(void)
 
 	return err;
 }
+
 #endif /* BT_BAP_UNICAST_SERVER */

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -352,7 +352,7 @@ int bt_ascs_init(const struct bt_bap_unicast_server_cb *cb);
 void bt_ascs_cleanup(void);
 
 int ascs_ep_set_state(struct bt_bap_ep *ep, enum bt_bap_ep_state state);
-bool bt_ascs_is_ase_ep(const struct bt_bap_ep *ep);
+bool bt_ascs_has_ep(const struct bt_bap_ep *ep);
 
 int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 		       struct bt_audio_codec_cfg *codec_cfg,

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -946,10 +946,10 @@ int bt_bap_broadcast_sink_register_cb(struct bt_bap_broadcast_sink_cb *cb)
 	return 0;
 }
 
-bool bt_bap_ep_is_broadcast_snk(const struct bt_bap_ep *ep)
+bool bt_bap_broadcast_sink_has_ep(const struct bt_bap_ep *ep)
 {
 	for (int i = 0; i < ARRAY_SIZE(broadcast_sink_eps); i++) {
-		if (PART_OF_ARRAY(broadcast_sink_eps[i], ep)) {
+		if (IS_ARRAY_ELEMENT(broadcast_sink_eps[i], ep)) {
 			return true;
 		}
 	}

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -244,10 +244,10 @@ static struct bt_iso_chan_ops broadcast_source_iso_ops = {
 	.disconnected = broadcast_source_iso_disconnected,
 };
 
-bool bt_bap_ep_is_broadcast_src(const struct bt_bap_ep *ep)
+bool bt_bap_broadcast_source_has_ep(const struct bt_bap_ep *ep)
 {
 	for (int i = 0; i < ARRAY_SIZE(broadcast_source_eps); i++) {
-		if (PART_OF_ARRAY(broadcast_source_eps[i], ep)) {
+		if (IS_ARRAY_ELEMENT(broadcast_source_eps[i], ep)) {
 			return true;
 		}
 	}

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -221,8 +221,3 @@ static inline const char *bt_bap_ep_state_str(enum bt_bap_ep_state state)
 		return "unknown";
 	}
 }
-
-bool bt_bap_ep_is_broadcast_snk(const struct bt_bap_ep *ep);
-bool bt_bap_ep_is_broadcast_src(const struct bt_bap_ep *ep);
-bool bt_bap_ep_is_unicast_client(const struct bt_bap_ep *ep);
-bool bt_bap_ep_is_unicast_server(const struct bt_bap_ep *ep);

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -225,3 +225,4 @@ static inline const char *bt_bap_ep_state_str(enum bt_bap_ep_state state)
 bool bt_bap_ep_is_broadcast_snk(const struct bt_bap_ep *ep);
 bool bt_bap_ep_is_broadcast_src(const struct bt_bap_ep *ep);
 bool bt_bap_ep_is_unicast_client(const struct bt_bap_ep *ep);
+bool bt_bap_ep_is_unicast_server(const struct bt_bap_ep *ep);

--- a/subsys/bluetooth/audio/bap_internal.h
+++ b/subsys/bluetooth/audio/bap_internal.h
@@ -142,3 +142,8 @@ static inline bool valid_bis_syncs(uint32_t bis_sync)
 
 	return true;
 }
+
+bool bt_bap_broadcast_sink_has_ep(const struct bt_bap_ep *ep);
+bool bt_bap_broadcast_source_has_ep(const struct bt_bap_ep *ep);
+bool bt_bap_unicast_client_has_ep(const struct bt_bap_ep *ep);
+bool bt_bap_unicast_server_has_ep(const struct bt_bap_ep *ep);

--- a/subsys/bluetooth/audio/bap_iso.c
+++ b/subsys/bluetooth/audio/bap_iso.c
@@ -26,6 +26,7 @@
 #include "bap_iso.h"
 #include "audio_internal.h"
 #include "bap_endpoint.h"
+#include "bap_internal.h"
 
 LOG_MODULE_REGISTER(bt_bap_iso, CONFIG_BT_BAP_ISO_LOG_LEVEL);
 
@@ -177,7 +178,7 @@ void bt_bap_setup_iso_data_path(struct bt_bap_stream *stream)
 	struct bt_bap_ep *ep = stream->ep;
 	struct bt_bap_iso *bap_iso = ep->iso;
 	const bool is_unicast_client =
-		IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && bt_bap_ep_is_unicast_client(ep);
+		IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && bt_bap_unicast_client_has_ep(ep);
 	struct bt_bap_iso_dir *iso_dir = bap_iso_get_iso_dir(is_unicast_client, bap_iso, ep->dir);
 	struct bt_iso_chan_path path = {0};
 	uint8_t dir;
@@ -216,7 +217,7 @@ void bt_bap_remove_iso_data_path(struct bt_bap_stream *stream)
 	struct bt_bap_ep *ep = stream->ep;
 	struct bt_bap_iso *bap_iso = ep->iso;
 	const bool is_unicast_client =
-		IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && bt_bap_ep_is_unicast_client(ep);
+		IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && bt_bap_unicast_client_has_ep(ep);
 	struct bt_bap_iso_dir *iso_dir = bap_iso_get_iso_dir(is_unicast_client, bap_iso, ep->dir);
 	uint8_t dir;
 	int err;
@@ -235,7 +236,7 @@ void bt_bap_remove_iso_data_path(struct bt_bap_stream *stream)
 
 static bool is_unicast_client_ep(struct bt_bap_ep *ep)
 {
-	return IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && bt_bap_ep_is_unicast_client(ep);
+	return IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && bt_bap_unicast_client_has_ep(ep);
 }
 
 void bt_bap_iso_bind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep)

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -154,12 +154,17 @@ int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info)
 				info->can_send = dir == BT_AUDIO_DIR_SINK;
 				info->can_recv = dir == BT_AUDIO_DIR_SOURCE;
 			}
-		} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER)) {
+		} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) &&
+			   bt_bap_ep_is_unicast_server(ep)) {
 			/* dir is not initialized before the connection is set */
 			if (ep->stream->conn != NULL) {
 				info->can_send = dir == BT_AUDIO_DIR_SOURCE;
 				info->can_recv = dir == BT_AUDIO_DIR_SINK;
 			}
+		} else {
+			LOG_DBG("Invalid endpoint");
+
+			return -EINVAL;
 		}
 	}
 

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -36,6 +36,7 @@
 #include "../host/iso_internal.h"
 
 #include "audio_internal.h"
+#include "bap_internal.h"
 #include "bap_iso.h"
 #include "bap_endpoint.h"
 #include "bap_unicast_client_internal.h"
@@ -142,20 +143,21 @@ int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info)
 	info->can_send = false;
 	info->can_recv = false;
 	if (IS_ENABLED(CONFIG_BT_AUDIO_TX) && ep->stream != NULL) {
-		if (IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SOURCE) && bt_bap_ep_is_broadcast_src(ep)) {
+		if (IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SOURCE) &&
+		    bt_bap_broadcast_source_has_ep(ep)) {
 			info->can_send = true;
 		} else if (IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SINK) &&
-			   bt_bap_ep_is_broadcast_snk(ep)) {
+			   bt_bap_broadcast_sink_has_ep(ep)) {
 			info->can_recv = true;
 		} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
-			   bt_bap_ep_is_unicast_client(ep)) {
+			   bt_bap_unicast_client_has_ep(ep)) {
 			/* dir is not initialized before the connection is set */
 			if (ep->stream->conn != NULL) {
 				info->can_send = dir == BT_AUDIO_DIR_SINK;
 				info->can_recv = dir == BT_AUDIO_DIR_SOURCE;
 			}
 		} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) &&
-			   bt_bap_ep_is_unicast_server(ep)) {
+			   bt_bap_unicast_server_has_ep(ep)) {
 			/* dir is not initialized before the connection is set */
 			if (ep->stream->conn != NULL) {
 				info->can_send = dir == BT_AUDIO_DIR_SOURCE;
@@ -502,8 +504,9 @@ bool bt_bap_stream_can_disconnect(const struct bt_bap_stream *stream)
 static bool bt_bap_stream_is_broadcast(const struct bt_bap_stream *stream)
 {
 	return (IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SOURCE) &&
-		bt_bap_ep_is_broadcast_src(stream->ep)) ||
-	       (IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SINK) && bt_bap_ep_is_broadcast_snk(stream->ep));
+		bt_bap_broadcast_source_has_ep(stream->ep)) ||
+	       (IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SINK) &&
+		bt_bap_broadcast_sink_has_ep(stream->ep));
 }
 
 enum bt_bap_ascs_reason bt_bap_stream_verify_qos(const struct bt_bap_stream *stream,

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -441,7 +441,7 @@ static struct bt_iso_chan_ops unicast_client_iso_ops = {
 	.disconnected = unicast_client_iso_disconnected,
 };
 
-bool bt_bap_ep_is_unicast_client(const struct bt_bap_ep *ep)
+bool bt_bap_unicast_client_has_ep(const struct bt_bap_ep *ep)
 {
 	for (size_t i = 0U; i < ARRAY_SIZE(uni_cli_insts); i++) {
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -222,3 +222,8 @@ void bt_bap_unicast_server_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t fun
 {
 	bt_ascs_foreach_ep(conn, func, user_data);
 }
+
+bool bt_bap_ep_is_unicast_server(const struct bt_bap_ep *ep)
+{
+	return bt_ascs_is_ase_ep(ep);
+}

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -106,7 +106,7 @@ int bt_bap_unicast_server_reconfig(struct bt_bap_stream *stream,
 
 	ep = stream->ep;
 
-	if (!bt_ascs_is_ase_ep(ep)) {
+	if (!bt_ascs_has_ep(ep)) {
 		LOG_DBG("ep %p not in ASCS", ep);
 		return -EINVAL;
 	}
@@ -131,7 +131,7 @@ int bt_bap_unicast_server_start(struct bt_bap_stream *stream)
 {
 	struct bt_bap_ep *ep = stream->ep;
 
-	if (!bt_ascs_is_ase_ep(ep)) {
+	if (!bt_ascs_has_ep(ep)) {
 		LOG_DBG("ep %p not in ASCS", ep);
 		return -EINVAL;
 	}
@@ -164,7 +164,7 @@ int bt_bap_unicast_server_metadata(struct bt_bap_stream *stream, const uint8_t m
 	int err;
 
 	ep = stream->ep;
-	if (!bt_ascs_is_ase_ep(ep)) {
+	if (!bt_ascs_has_ep(ep)) {
 		LOG_DBG("ep %p not in ASCS", ep);
 		return -EINVAL;
 	}
@@ -193,7 +193,7 @@ int bt_bap_unicast_server_metadata(struct bt_bap_stream *stream, const uint8_t m
 
 int bt_bap_unicast_server_disable(struct bt_bap_stream *stream)
 {
-	if (!bt_ascs_is_ase_ep(stream->ep)) {
+	if (!bt_ascs_has_ep(stream->ep)) {
 		LOG_DBG("ep %p not in ASCS", stream->ep);
 		return -EINVAL;
 	}
@@ -203,7 +203,7 @@ int bt_bap_unicast_server_disable(struct bt_bap_stream *stream)
 
 int bt_bap_unicast_server_release(struct bt_bap_stream *stream)
 {
-	if (!bt_ascs_is_ase_ep(stream->ep)) {
+	if (!bt_ascs_has_ep(stream->ep)) {
 		LOG_DBG("ep %p not in ASCS", stream->ep);
 		return -EINVAL;
 	}
@@ -223,7 +223,7 @@ void bt_bap_unicast_server_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t fun
 	bt_ascs_foreach_ep(conn, func, user_data);
 }
 
-bool bt_bap_ep_is_unicast_server(const struct bt_bap_ep *ep)
+bool bt_bap_unicast_server_has_ep(const struct bt_bap_ep *ep)
 {
-	return bt_ascs_is_ase_ep(ep);
+	return bt_ascs_has_ep(ep);
 }

--- a/tests/bluetooth/audio/ascs/uut/bap_unicast_client.c
+++ b/tests/bluetooth/audio/ascs/uut/bap_unicast_client.c
@@ -12,7 +12,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/ztest_assert.h>
 
-bool bt_bap_ep_is_unicast_client(const struct bt_bap_ep *ep)
+bool bt_bap_unicast_client_has_ep(const struct bt_bap_ep *ep)
 {
 	return false;
 }

--- a/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
@@ -26,7 +26,7 @@
 static struct bt_bap_unicast_client_cb *unicast_client_cb;
 static struct bt_bap_unicast_group bap_unicast_group;
 
-bool bt_bap_ep_is_unicast_client(const struct bt_bap_ep *ep)
+bool bt_bap_unicast_client_has_ep(const struct bt_bap_ep *ep)
 {
 	return true;
 }

--- a/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
@@ -28,7 +28,7 @@ static struct bt_bap_unicast_group bap_unicast_group;
 
 bool bt_bap_ep_is_unicast_client(const struct bt_bap_ep *ep)
 {
-	return false;
+	return true;
 }
 
 int bt_bap_unicast_client_config(struct bt_bap_stream *stream,


### PR DESCRIPTION
Modify the ep check functions to have better names and to be more strict, as well as adding a missing function. 