### PR TITLE
drivers: i2s: nrfx: Allow MCK bypass for proper LRCK and MCK Ratios

### DIFF
--- a/drivers/i2s/Kconfig.nrfx
+++ b/drivers/i2s/Kconfig.nrfx
@@ -21,6 +21,14 @@ config I2S_NRFX_TX_BLOCK_COUNT
 	int "TX queue length"
 	default 4
 
+config I2S_NRFX_ALLOW_MCK_BYPASS
+	bool "Allow MCK bypass if a ratio exists"
+	depends on SOC_SERIES_NRF53X
+	help
+	  Search for a supported ratio directly from MCK and LRCK
+	  and enable bypass if a ratio exists. If not, fallback to
+	  the standard MCK selection mechanism.
+
 endif # I2S_NRFX
 
 menuconfig I2S_NRF_TDM

--- a/samples/drivers/i2s/echo/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/drivers/i2s/echo/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_I2S_NRFX_ALLOW_MCK_BYPASS=y

--- a/samples/drivers/i2s/echo/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/drivers/i2s/echo/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -22,7 +22,8 @@
 
 	i2s0_default_alt: i2s0_default_alt {
 		group1 {
-			psels = <NRF_PSEL(I2S_SCK_M, 1, 15)>,
+			psels = <NRF_PSEL(I2S_MCK, 0, 12)>,
+				<NRF_PSEL(I2S_SCK_M, 1, 15)>,
 				<NRF_PSEL(I2S_LRCK_M, 1, 12)>,
 				<NRF_PSEL(I2S_SDOUT, 1, 13)>,
 				<NRF_PSEL(I2S_SDIN, 1, 14)>;


### PR DESCRIPTION
nRF53 series SoCs have a dedicated configurable audio PLL and the ability to enable MCK bypass via a register value CONFIG.CLKCONFIG. This can enable higher MCK/LRCK ratios that some I2S peripherals require the host to generate. Allow an application developer to choose if they want to initially look for a bypass ratio and, if found, enable bypass in the NRFX driver. If not, the standard MCK calculation is conducted as normal.