### PR TITLE
documentation: detail k_timer_start period update to be updated

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1741,6 +1741,9 @@ void k_timer_init(struct k_timer *timer,
  * The timer's status is reset to zero and the timer begins counting down
  * using the new duration and period values.
  *
+ * This routine neither updates nor has any other effect on the specified
+ * timer if @a duration is K_FOREVER.
+ *
  * @param timer     Address of timer.
  * @param duration  Initial timer duration.
  * @param period    Timer period.


### PR DESCRIPTION
k_timer_start is not updating the period of the timer if the duration is K_FOREVER.