### PR TITLE
fs: zms: fix no-cache + no-double-write

### DIFF
--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -1505,7 +1505,12 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 	wlk_addr = fs->lookup_cache[zms_lookup_cache_pos(id)];
 
 	if (wlk_addr == ZMS_LOOKUP_CACHE_NO_ADDR) {
-		goto no_cached_entry;
+		if (len > 0) {
+			goto no_cached_entry;
+		} else {
+			/* skip delete entry for non-existing entry */
+			return 0;
+		}
 	}
 #else
 	wlk_addr = fs->ate_wra;

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -1498,9 +1498,11 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 	}
 
 #ifdef CONFIG_ZMS_NO_DOUBLE_WRITE
+	uint64_t wlk_addr;
+
 	/* find latest entry with same id */
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
-	uint64_t wlk_addr = fs->lookup_cache[zms_lookup_cache_pos(id)];
+	wlk_addr = fs->lookup_cache[zms_lookup_cache_pos(id)];
 
 	if (wlk_addr == ZMS_LOOKUP_CACHE_NO_ADDR) {
 		goto no_cached_entry;

--- a/tests/subsys/fs/zms/src/main.c
+++ b/tests/subsys/fs/zms/src/main.c
@@ -757,9 +757,9 @@ ZTEST_F(zms, test_zms_cache_init)
 
 /*
  * Test that even after writing more ZMS IDs than the number of ZMS lookup cache
- * entries they all can be read correctly.
+ * entries they all can be read and deleted correctly.
  */
-ZTEST_F(zms, test_zms_cache_collission)
+ZTEST_F(zms, test_zms_cache_collision)
 {
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
 	int err;
@@ -779,6 +779,16 @@ ZTEST_F(zms, test_zms_cache_collission)
 		err = zms_read(&fixture->fs, id, &data, sizeof(data));
 		zassert_equal(err, sizeof(data), "zms_read call failure: %d", err);
 		zassert_equal(data, id, "incorrect data read");
+	}
+
+	for (int id = 0; id < CONFIG_ZMS_LOOKUP_CACHE_SIZE + 1; id++) {
+		err = zms_delete(&fixture->fs, id);
+		zassert_equal(0, err, "zms_delete failed: %d", err);
+	}
+
+	for (int id = 0; id < CONFIG_ZMS_LOOKUP_CACHE_SIZE + 1; id++) {
+		err = zms_read(&fixture->fs, id, &data, sizeof(data));
+		zassert_equal(-ENOENT, err, "zms_delete failed: %d", err);
 	}
 #endif
 }

--- a/tests/subsys/fs/zms/testcase.yaml
+++ b/tests/subsys/fs/zms/testcase.yaml
@@ -26,3 +26,17 @@ tests:
     platform_allow:
       - native_sim
       - qemu_x86
+  filesystem.zms.no_double_write:
+    extra_args:
+      - CONFIG_ZMS_NO_DOUBLE_WRITE=y
+    platform_allow:
+      - native_sim
+      - qemu_x86
+  filesystem.zms.no_double_write_cache:
+    extra_args:
+      - CONFIG_ZMS_NO_DOUBLE_WRITE=y
+      - CONFIG_ZMS_LOOKUP_CACHE=y
+      - CONFIG_ZMS_LOOKUP_CACHE_SIZE=64
+    platform_allow:
+      - native_sim
+      - qemu_x86


### PR DESCRIPTION
Fix a compiler error when `CONFIG_ZMS_NO_DOUBLE_WRITE=y` and `CONFIG_ZMS_LOOKUP_CACHE=n`.

Fixes #95614