### PR TITLE
samples: Bluetooth: Fix BAP unicast client and server buffer counts

### DIFF
--- a/samples/bluetooth/bap_unicast_client/overlay-bt_ll_sw_split.conf
+++ b/samples/bluetooth/bap_unicast_client/overlay-bt_ll_sw_split.conf
@@ -1,17 +1,23 @@
+# Zephyr Bluetooth Controller needs 3 Tx Buffers enqueued as the Number of Completed Packets event
+# is returned one ISO interval later, i.e. the PDU flush is checked at the prepare of radio events.
+CONFIG_BT_ISO_TX_BUF_COUNT=6
+
+# Zephyr Bluetooth Controller
 CONFIG_BT_LL_SW_SPLIT=y
-CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX=1650
-CONFIG_BT_CTLR_ISO_TX_BUFFERS=4
+
+# Supports the highest advertising data that is set in a single HCI command in
+# Zephyr Bluetooth Controller
+CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX=191
+
+# Number of supported streams
 CONFIG_BT_CTLR_ISOAL_SOURCES=2
 CONFIG_BT_CTLR_ISOAL_SINKS=1
+
+# Numbe of ISO Tx Buffers
+CONFIG_BT_CTLR_ISO_TX_BUFFERS=6
 
 # Support the highest SDU size required by any BAP LC3 presets (155) + 8 bytes of HCI ISO Data
 # packet overhead (the Packet_Sequence_Number, ISO_SDU_Length, Packet_Status_Flag fields; and
 # the optional Time_Stamp field, if supplied)
 CONFIG_BT_CTLR_ISO_TX_BUFFER_SIZE=163
 CONFIG_BT_CTLR_ISO_TX_SDU_LEN_MAX=155
-
-CONFIG_BT_CTLR_ADVANCED_FEATURES=y
-CONFIG_BT_CTLR_CONN_ISO_LOW_LATENCY_POLICY=y
-
-# Use the below if the sample is sending stale packet sequence number
-# CONFIG_BT_CTLR_ISOAL_SN_STRICT=n

--- a/samples/bluetooth/bap_unicast_server/overlay-bt_ll_sw_split.conf
+++ b/samples/bluetooth/bap_unicast_server/overlay-bt_ll_sw_split.conf
@@ -1,15 +1,22 @@
+# Zephyr Bluetooth Controller needs 3 Tx Buffers enqueued as the Number of Completed Packets event
+# is returned one ISO interval later, i.e. the PDU flush is checked at the prepare of radio events.
+CONFIG_BT_ISO_TX_BUF_COUNT=3
+
+# Zephyr Bluetooth Controller
 CONFIG_BT_LL_SW_SPLIT=y
+
+# Zephyr Controller tested maximum advertising data that can be set in a single HCI command
 CONFIG_BT_CTLR_ADV_DATA_LEN_MAX=191
-CONFIG_BT_CTLR_ISO_TX_BUFFERS=2
+
+# Number of supported streams
 CONFIG_BT_CTLR_ISOAL_SOURCES=1
 CONFIG_BT_CTLR_ISOAL_SINKS=2
+
+# Numbe of ISO Tx Buffers
+CONFIG_BT_CTLR_ISO_TX_BUFFERS=3
 
 # Support the highest SDU size required by any BAP LC3 presets (155) + 8 bytes of HCI ISO Data
 # packet overhead (the Packet_Sequence_Number, ISO_SDU_Length, Packet_Status_Flag fields; and
 # the optional Time_Stamp field, if supplied)
 CONFIG_BT_CTLR_ISO_TX_BUFFER_SIZE=163
 CONFIG_BT_CTLR_ISO_TX_SDU_LEN_MAX=155
-
-# Use the below if the sample is sending stale packet sequence number
-# CONFIG_BT_CTLR_ADVANCED_FEATURES=y
-# CONFIG_BT_CTLR_ISOAL_SN_STRICT=n


### PR DESCRIPTION
Fix BAP unicast and server sample ISO Tx buffer count to match the minimum required to consistently transmit SDUs in every ISO interval.