### PR TITLE
Bluetooth: Controller: Fix Central and Peripheral ISO single timer use

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -549,7 +549,9 @@ static void isr_tx(void *param)
 #if defined(CONFIG_BT_CTLR_PROFILE_ISR) || \
 	defined(HAL_RADIO_GPIO_HAVE_PA_PIN)
 	radio_tmr_end_capture();
-#endif /* CONFIG_BT_CTLR_PROFILE_ISR */
+#endif /* CONFIG_BT_CTLR_PROFILE_ISR ||
+	* HAL_RADIO_GPIO_HAVE_PA_PIN
+	*/
 
 #if defined(HAL_RADIO_GPIO_HAVE_LNA_PIN)
 	radio_gpio_lna_setup();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -466,11 +466,23 @@ static void isr_tx(void *param)
 	struct node_rx_pdu *node_rx;
 	uint32_t hcto;
 
+	/* Call to ensure packet/event timer accumulates the elapsed time
+	 * under single timer use.
+	 */
+	(void)radio_is_tx_done();
+
 	/* Clear radio tx status and events */
 	lll_isr_tx_status_reset();
 
 	/* Close subevent, one tx-rx chain */
-	radio_switch_complete_and_disable();
+	if (IS_ENABLED(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)) {
+		/* Required under single time tIFS switching, to accumulate the packet
+		 * timer value at the time of clear on radio end.
+		 */
+		radio_switch_complete_end_capture_and_disable();
+	} else {
+		radio_switch_complete_and_disable();
+	}
 
 	/* Get reference to CIS LLL context */
 	cis_lll = param;


### PR DESCRIPTION
Fix incorrect LLL scheduling of subsequent subevents when using single timer implementation, due to missing call to accumulate the last PDU end timestamp which is essential to setup next radio start and to setup header complete timeout.

Relates to commit 373dc0db71d1 ("Bluetooth: Controller: Single timer use Extended Advertising nRF54L support").

Relates to commit 6e8f081385e4 ("Bluetooth: Controller: Fix peripheral assert under single timer use").