### PR TITLE
drivers: ethernet: ksz8081: fix compiling error about missing variable

### DIFF
--- a/drivers/ethernet/phy/phy_microchip_ksz8081.c
+++ b/drivers/ethernet/phy/phy_microchip_ksz8081.c
@@ -474,6 +474,7 @@ done:
 static int phy_mc_ksz8081_cfg_link(const struct device *dev, enum phy_link_speed speeds,
 				   enum phy_cfg_link_flag flags)
 {
+	__maybe_unused const struct mc_ksz8081_config *config = dev->config;
 	struct mc_ksz8081_data *data = dev->data;
 	int ret;
 


### PR DESCRIPTION
The missing variable `config` in `phy_mc_ksz8081_cfg_link()` maybe used by the macro `USING_INTERRUPT_GPIO`, add the variable to avoid compiling errors.

fixes: #95492

