### PR TITLE
fs: Shell command ls to list file sizes

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -189,6 +189,10 @@ New APIs and options
       * :kconfig:option:`CONFIG_SHELL_MQTT_WORK_DELAY_MS`
       * :kconfig:option:`CONFIG_SHELL_MQTT_LISTEN_TIMEOUT_MS`
 
+* Storage
+
+    * :kconfig:option:`CONFIG_FILE_SYSTEM_SHELL_LS_SIZE`
+
 * Sys
 
   * :c:func:`sys_count_bits`

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -85,6 +85,13 @@ config FILE_SYSTEM_SHELL_BUFFER_SIZE
 	  maximum size that can be used with a read/write test. Note that this
 	  is used on the stack.
 
+config FILE_SYSTEM_SHELL_LS_SIZE
+	bool "File system shell ls command to also list size"
+	default y
+	help
+	  While listing files in the file system shell, also list the size of
+	  each file.
+
 endif # FILE_SYSTEM_SHELL
 
 config FILE_SYSTEM_MKFS

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -188,6 +188,7 @@ static int cmd_ls(const struct shell *sh, size_t argc, char **argv)
 
 	while (1) {
 		struct fs_dirent entry;
+		const char *name_end;
 
 		err = fs_readdir(&dir, &entry);
 		if (err != 0) {
@@ -200,7 +201,12 @@ static int cmd_ls(const struct shell *sh, size_t argc, char **argv)
 			break;
 		}
 
-		shell_print(sh, "%s%s", entry.name, (entry.type == FS_DIR_ENTRY_DIR) ? "/" : "");
+		name_end = (entry.type == FS_DIR_ENTRY_DIR) ? "/" : "";
+		if (IS_ENABLED(CONFIG_FILE_SYSTEM_SHELL_LS_SIZE)) {
+			shell_print(sh, "%8zu %s%s", entry.size, entry.name, name_end);
+		} else {
+			shell_print(sh, "%s%s", entry.name, name_end);
+		}
 	}
 
 	fs_closedir(&dir);


### PR DESCRIPTION
List the file size helps in developer debugging experience. Provide a config to disable new behavior in case any users depended on command output to be a list.

Now, it is much easier to notice if a file update, usually changing its size, has made it or not.
```
uart:~$ fs ls
       0 cal/
       0 data/

uart:~$ fs ls cal
    1000 file.txt

uart:~$ fs ls data
    1000 file2.txt
       0 another_file.bin
```