### PR TITLE
drivers: audio: codec: Include errno.h in header

### DIFF
--- a/include/zephyr/audio/codec.h
+++ b/include/zephyr/audio/codec.h
@@ -24,6 +24,7 @@
  * @{
  */
 
+#include <errno.h>
 #include <zephyr/drivers/i2s.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Header uses errno so include it right here.

https://github.com/zephyrproject-rtos/zephyr/blob/97aebd33a1fb97cda6ecdfb11aa70bb7cf1d21f7/include/zephyr/audio/codec.h#L327