### PR TITLE
tests: net: wifi: config: Actually disable advanced features

### DIFF
--- a/tests/net/wifi/configs/testcase.yaml
+++ b/tests/net/wifi/configs/testcase.yaml
@@ -65,7 +65,7 @@ tests:
       - CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP=y
   wifi.build.disable_advanced_feat:
     extra_configs:
-      - CONFIG_WIFI_NM_WPA_SUPPLICANT_ADVANCED_FEATURES=y
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_ADVANCED_FEATURES=n
   wifi.build.enterprise_runtime:
     extra_configs:
       - CONFIG_WIFI_SHELL_RUNTIME_CERTIFICATES=y


### PR DESCRIPTION
The test was supposed to disable the default enabled `CONFIG_WIFI_NM_WPA_SUPPLICANT_ADVANCED_FEATURES` instead of enabling it.