### PR TITLE
boards: st: Fix led node label in nucleo wl55jc DTS

### DIFF
--- a/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -36,7 +36,7 @@
 			label = "User LED2";
 		};
 
-		green_led_3: led_2 {
+		red_led_3: led_2 {
 			gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 			label = "User LED3";
 		};


### PR DESCRIPTION
The node label of the third LED incorrectly says that it is green while actually it is red [0].

[0] https://www.st.com/resource/en/user_manual/um2592-stm32wl-nucleo64-board-mb1389-stmicroelectronics.pdf