### PR TITLE
Bluetooth: Classic: l2cap: Fix ACL conn invalid issue

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -899,6 +899,11 @@ int bt_l2cap_br_send_cb(struct bt_conn *conn, uint16_t cid, struct net_buf *buf,
 		return -ESHUTDOWN;
 	}
 
+	if (ch->conn == NULL) {
+		LOG_WRN("ACL conn of chan %p is invalid", ch);
+		return -ENOTCONN;
+	}
+
 	br_chan = CONTAINER_OF(ch, struct bt_l2cap_br_chan, chan);
 
 	LOG_DBG("chan %p buf %p len %u", br_chan, buf, buf->len);


### PR DESCRIPTION
There is an issue found that the L2CAP BR channel attempts to send signaling commands through fixed channel when the ACL connect is broken. At this time, the ACL connect of fixed channel is invalid. Then the `__assert` occurs in function `bt_conn_ref()`.

Fixed the issue by checking the ACL conn of the L2CAP channel before sending the data.