### PR TITLE
tests: Bluetooth: Audio: Increase timeout for AC tests

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/_ac_common.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/_ac_common.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=120
 BSIM_EXE=./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf
 
 cd ${BSIM_OUT_PATH}/bin


### PR DESCRIPTION
Increase the EXECUTE_TIMEOUT for the _ac_common.sh tests, as some of them occasionally times out when the CI servers are busy (especially for the cap_ac_11_ii tests).