### PR TITLE
bluetooth: a2dp set right endpoint state for start and abort cmd

### DIFF
--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -774,6 +774,12 @@ static int bt_a2dp_get_capabilities_cb(struct bt_avdtp_req *req, struct net_buf 
 	return 0;
 }
 
+static void bt_a2dp_init_req(struct bt_avdtp_req *req, bt_avdtp_func_t cb)
+{
+	memset(req, 0, sizeof(*req));
+	req->func = cb;
+}
+
 static int bt_a2dp_get_sep_caps(struct bt_a2dp *a2dp)
 {
 	int err;
@@ -793,7 +799,8 @@ static int bt_a2dp_get_sep_caps(struct bt_a2dp *a2dp)
 		    BT_AVDTP_AUDIO) {
 			memset(&a2dp->get_capabilities_param, 0U,
 			       sizeof(a2dp->get_capabilities_param));
-			a2dp->get_capabilities_param.req.func = bt_a2dp_get_capabilities_cb;
+			bt_a2dp_init_req(&a2dp->get_capabilities_param.req,
+					 bt_a2dp_get_capabilities_cb);
 			a2dp->get_capabilities_param.stream_endpoint_id =
 				a2dp->discover_cb_param->seps_info[a2dp->get_cap_index].id;
 
@@ -899,7 +906,7 @@ int bt_a2dp_discover(struct bt_a2dp *a2dp, struct bt_a2dp_discover_param *param)
 	}
 
 	a2dp->discover_cb_param = param;
-	a2dp->discover_param.req.func = bt_a2dp_discover_cb;
+	bt_a2dp_init_req(&a2dp->discover_param.req, bt_a2dp_discover_cb);
 
 	err = bt_avdtp_discover(&a2dp->session, &a2dp->discover_param);
 	if (err) {
@@ -928,7 +935,7 @@ static inline void bt_a2dp_stream_config_set_param(struct bt_a2dp *a2dp,
 						   struct bt_avdtp_sep *sep)
 {
 	memset(&a2dp->set_config_param, 0U, sizeof(a2dp->set_config_param));
-	a2dp->set_config_param.req.func = cb;
+	bt_a2dp_init_req(&a2dp->set_config_param.req, cb);
 	a2dp->set_config_param.acp_stream_ep_id = remote_id;
 	a2dp->set_config_param.int_stream_endpoint_id = int_id;
 	a2dp->set_config_param.media_type = BT_AVDTP_AUDIO;
@@ -1125,6 +1132,12 @@ static int bt_a2dp_delay_report_cb(struct bt_avdtp_req *req, struct net_buf *buf
 }
 #endif
 
+static void bt_a2dp_init_ctrl_req(struct bt_avdtp_ctrl_params *ctrl_param, bt_avdtp_func_t cb)
+{
+	memset(ctrl_param, 0U, sizeof(*ctrl_param));
+	ctrl_param->req.func = cb;
+}
+
 static int bt_a2dp_stream_ctrl_pre(struct bt_a2dp_stream *stream, bt_avdtp_func_t cb)
 {
 	struct bt_a2dp *a2dp;
@@ -1138,8 +1151,7 @@ static int bt_a2dp_stream_ctrl_pre(struct bt_a2dp_stream *stream, bt_avdtp_func_
 		return -EBUSY;
 	}
 
-	memset(&a2dp->ctrl_param, 0U, sizeof(a2dp->ctrl_param));
-	a2dp->ctrl_param.req.func = cb;
+	bt_a2dp_init_ctrl_req(&a2dp->ctrl_param, cb);
 	a2dp->ctrl_param.acp_stream_ep_id = stream->remote_ep != NULL
 						    ? stream->remote_ep->sep.sep_info.id
 						    : stream->remote_ep_id;

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -596,6 +596,11 @@ static void avdtp_set_status(struct bt_avdtp_req *req, struct net_buf *buf, uint
 	} else if (msg_type == BT_AVDTP_REJECT) {
 		if (buf->len >= sizeof(req->status)) {
 			req->status = net_buf_pull_u8(buf);
+
+			if (req->status == BT_AVDTP_SUCCESS) {
+				LOG_WRN("Reject frame with success status");
+				req->status = BT_AVDTP_BAD_HEADER_FORMAT;
+			}
 		} else {
 			LOG_WRN("Invalid RSP frame");
 			req->status = BT_AVDTP_BAD_LENGTH;

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -1134,7 +1134,7 @@ static void avdtp_open_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8_
 	}
 }
 
-static void avdtp_handle_reject(struct net_buf *buf, struct bt_avdtp_req *req)
+static void avdtp_handle_reject_with_acp_seid(struct net_buf *buf, struct bt_avdtp_req *req)
 {
 	if (buf->len >= sizeof(uint8_t)) {
 		uint8_t acp_seid;
@@ -1211,14 +1211,24 @@ static void avdtp_start_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8
 
 	k_work_cancel_delayable(&session->timeout_work);
 
-	if (msg_type == BT_AVDTP_ACCEPT) {
-		bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_STREAMING);
-	} else if (msg_type == BT_AVDTP_REJECT) {
-		avdtp_handle_reject(buf, req);
+	if (msg_type == BT_AVDTP_REJECT) {
+		avdtp_handle_reject_with_acp_seid(buf, req);
 	}
 
 	if (req->status == BT_AVDTP_SUCCESS) {
 		avdtp_set_status(req, buf, msg_type);
+	}
+
+	if (req->status == BT_AVDTP_SUCCESS) {
+		bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_STREAMING);
+	} else {
+		/* From spec, if start cmd's initiator is sink, the endpoint state is set as
+		 * AVDTP_STREAMING after sending start cmd. So if cmd fail, need to change back
+		 * as AVDTP_OPEN.
+		 */
+		if (CTRL_REQ(req)->sep->sep_info.tsep == BT_AVDTP_SINK) {
+			bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_OPEN);
+		}
 	}
 
 	bt_avdtp_clear_req(session);
@@ -1402,14 +1412,16 @@ static void avdtp_suspend_rsp(struct bt_avdtp *session, struct net_buf *buf, uin
 
 	k_work_cancel_delayable(&session->timeout_work);
 
-	if (msg_type == BT_AVDTP_ACCEPT) {
-		bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_OPEN);
-	} else if (msg_type == BT_AVDTP_REJECT) {
-		avdtp_handle_reject(buf, req);
+	if (msg_type == BT_AVDTP_REJECT) {
+		avdtp_handle_reject_with_acp_seid(buf, req);
 	}
 
 	if (req->status == BT_AVDTP_SUCCESS) {
 		avdtp_set_status(req, buf, msg_type);
+	}
+
+	if (req->status == BT_AVDTP_SUCCESS) {
+		bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_OPEN);
 	}
 
 	bt_avdtp_clear_req(session);

--- a/subsys/bluetooth/host/classic/avdtp_internal.h
+++ b/subsys/bluetooth/host/classic/avdtp_internal.h
@@ -99,6 +99,7 @@ typedef int (*bt_avdtp_func_t)(struct bt_avdtp_req *req, struct net_buf *buf);
 struct bt_avdtp_req {
 	uint8_t sig;
 	uint8_t tid;
+	/* set it as 0 (BT_AVDTP_SUCCESS) before giving the req to avdtp */
 	uint8_t status;
 	bt_avdtp_func_t func;
 };


### PR DESCRIPTION
If the start cmd fail, need set back as OPEN state.