### PR TITLE
Bluetooth: BAP: Add missing ep check in client_qos

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -3328,6 +3328,11 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 			continue;
 		}
 
+		if (stream->ep == NULL) {
+			/* Only consider configured streams */
+			continue;
+		}
+
 		ep = stream->ep;
 		dir = ep->dir;
 


### PR DESCRIPTION
The bt_bap_unicast_client_qos function was recently modified to check for presentation delay, however it did not consider that a unicast group may contain streams that are not configured, and thus do not have endpoints.

Add a stream->ep != NULL check to only consider configured streams.