### PR TITLE
sd: disk ioctl get card cid command #66460

### DIFF
--- a/include/zephyr/drivers/disk.h
+++ b/include/zephyr/drivers/disk.h
@@ -68,6 +68,10 @@ extern "C" {
  * requested, but this operation is inherently unsafe.
  */
 #define DISK_IOCTL_CTRL_DEINIT			7
+/* Get Card identification info. Only available with SDMMC and SDIO.
+ * Takes a struct sd_cid pointer as the `buf` parameter from sd/sd_spec.h
+ */
+#define DISK_IOCTL_GET_CARD_CID			8
 
 /**
  * @brief Possible return bitmasks for disk_status()

--- a/include/zephyr/drivers/disk.h
+++ b/include/zephyr/drivers/disk.h
@@ -68,8 +68,9 @@ extern "C" {
  * requested, but this operation is inherently unsafe.
  */
 #define DISK_IOCTL_CTRL_DEINIT			7
-/* Get Card identification info. Only available with SDMMC and SDIO.
- * Takes a struct sd_cid pointer as the `buf` parameter from sd/sd_spec.h
+/** Get Card identification (CID) register value.
+ * Passed buffer must be four 32-bit integer long to hold CID register value
+ * read from the card.
  */
 #define DISK_IOCTL_GET_CARD_CID			8
 

--- a/include/zephyr/sd/sd.h
+++ b/include/zephyr/sd/sd.h
@@ -79,6 +79,7 @@ struct sd_card {
 	uint16_t flags; /*!< Card flags */
 	uint8_t bus_width; /*!< Desired bus width */
 	uint32_t cccr_flags; /*!< SDIO CCCR data */
+	struct sd_cid cid; /*!< Card CID data */
 	struct sdio_func func0; /*!< Function 0 common card data */
 
 	/* NOTE: The buffer is accessed as a uint32_t* by the SD subsystem, so must be

--- a/include/zephyr/sd/sd.h
+++ b/include/zephyr/sd/sd.h
@@ -79,7 +79,6 @@ struct sd_card {
 	uint16_t flags; /*!< Card flags */
 	uint8_t bus_width; /*!< Desired bus width */
 	uint32_t cccr_flags; /*!< SDIO CCCR data */
-	struct sd_cid cid; /*!< Card CID data */
 	struct sdio_func func0; /*!< Function 0 common card data */
 
 	/* NOTE: The buffer is accessed as a uint32_t* by the SD subsystem, so must be

--- a/subsys/sd/mmc.c
+++ b/subsys/sd/mmc.c
@@ -102,9 +102,10 @@ int mmc_card_init(struct sd_card *card)
 {
 	int ret = 0;
 	uint32_t ocr_arg = 0U;
-	/* Keep CSDs on stack for reduced RAM usage */
+	/* Keep CSDs/CID on stack for reduced RAM usage */
 	struct sd_csd card_csd = {0};
 	struct mmc_ext_csd card_ext_csd = {0};
+	uint32_t cid[4] = {0};
 
 	/* SPI is not supported for MMC */
 	if (card->host_props.is_spi) {
@@ -132,7 +133,7 @@ int mmc_card_init(struct sd_card *card)
 	}
 
 	/* CMD2 */
-	ret = card_read_cid(card);
+	ret = card_read_cid(card, cid);
 	if (ret) {
 		return ret;
 	}

--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -286,8 +286,7 @@ int card_read_cid(struct sd_card *card)
 	uint32_t cid[4];
 	int ret;
 #if defined(CONFIG_SDMMC_STACK) || defined(CONFIG_SDIO_STACK)
-	/* Keep CID on stack for reduced RAM usage */
-	struct sd_cid card_cid = {0};
+	memset(&card->cid, 0, sizeof(card->cid));
 #endif
 
 	if (card->host_props.is_spi && IS_ENABLED(CONFIG_SDHC_SUPPORTS_SPI_MODE)) {
@@ -310,9 +309,9 @@ int card_read_cid(struct sd_card *card)
 #endif
 #if defined(CONFIG_SDMMC_STACK) || defined(CONFIG_SDIO_STACK)
 	/* Decode SD CID */
-	sdmmc_decode_cid(&card_cid, cid);
-	LOG_DBG("Card MID: 0x%x, OID: %c%c", card_cid.manufacturer,
-		((char *)&card_cid.application)[0], ((char *)&card_cid.application)[1]);
+	sdmmc_decode_cid(&card->cid, cid);
+	LOG_DBG("Card MID: 0x%x, OID: %c%c", card->cid.manufacturer,
+		((char *)&card->cid.application)[0], ((char *)&card->cid.application)[1]);
 #endif
 
 	return 0;
@@ -804,6 +803,13 @@ int card_ioctl(struct sd_card *card, uint8_t cmd, void *buf)
 		/* Power down the card */
 		card->bus_io.power_mode = SDHC_POWER_OFF;
 		ret = sdhc_set_io(card->sdhc, &card->bus_io);
+		break;
+	case DISK_IOCTL_GET_CARD_CID:
+#if defined(CONFIG_SDMMC_STACK) || defined(CONFIG_SDIO_STACK)
+		(*(struct sd_cid *)buf) = card->cid;
+#else
+		ret = -ENOTSUP;
+#endif
 		break;
 	default:
 		ret = -ENOTSUP;

--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -281,12 +281,12 @@ int sdmmc_read_csd(struct sd_card *card)
 }
 
 /* Reads card identification register, and decodes it */
-int card_read_cid(struct sd_card *card)
+int card_read_cid(struct sd_card *card, uint32_t *cid)
 {
-	uint32_t cid[4];
 	int ret;
 #if defined(CONFIG_SDMMC_STACK) || defined(CONFIG_SDIO_STACK)
-	memset(&card->cid, 0, sizeof(card->cid));
+	/* Keep CID on stack for reduced RAM usage */
+	struct sd_cid card_cid = {0};
 #endif
 
 	if (card->host_props.is_spi && IS_ENABLED(CONFIG_SDHC_SUPPORTS_SPI_MODE)) {
@@ -309,9 +309,9 @@ int card_read_cid(struct sd_card *card)
 #endif
 #if defined(CONFIG_SDMMC_STACK) || defined(CONFIG_SDIO_STACK)
 	/* Decode SD CID */
-	sdmmc_decode_cid(&card->cid, cid);
-	LOG_DBG("Card MID: 0x%x, OID: %c%c", card->cid.manufacturer,
-		((char *)&card->cid.application)[0], ((char *)&card->cid.application)[1]);
+	sdmmc_decode_cid(&card_cid, cid);
+	LOG_DBG("Card MID: 0x%x, OID: %c%c", card_cid.manufacturer,
+		((char *)&card_cid.application)[0], ((char *)&card_cid.application)[1]);
 #endif
 
 	return 0;
@@ -805,11 +805,7 @@ int card_ioctl(struct sd_card *card, uint8_t cmd, void *buf)
 		ret = sdhc_set_io(card->sdhc, &card->bus_io);
 		break;
 	case DISK_IOCTL_GET_CARD_CID:
-#if defined(CONFIG_SDMMC_STACK) || defined(CONFIG_SDIO_STACK)
-		(*(struct sd_cid *)buf) = card->cid;
-#else
-		ret = -ENOTSUP;
-#endif
+		ret = card_read_cid(card, buf);
 		break;
 	default:
 		ret = -ENOTSUP;

--- a/subsys/sd/sd_ops.h
+++ b/subsys/sd/sd_ops.h
@@ -17,7 +17,7 @@ int sdmmc_switch_voltage(struct sd_card *card);
 /*
  * Reads card identification register, and decodes it
  */
-int card_read_cid(struct sd_card *card);
+int card_read_cid(struct sd_card *card, uint32_t *cid);
 
 /*
  * Read card specific data register

--- a/subsys/sd/sdio.c
+++ b/subsys/sd/sdio.c
@@ -549,6 +549,7 @@ int sdio_card_init(struct sd_card *card)
 {
 	int ret;
 	uint32_t ocr_arg = 0U;
+	uint32_t cid[4] = {0};
 
 	/* Probe card with SDIO OCR CM5 */
 	ret = sdio_send_ocr(card, ocr_arg);
@@ -609,7 +610,7 @@ int sdio_card_init(struct sd_card *card)
 		if ((card->flags & SD_MEM_PRESENT_FLAG) &&
 			((card->flags & SD_SDHC_FLAG) == 0)) {
 			/* We must send CMD2 to get card cid */
-			ret = card_read_cid(card);
+			ret = card_read_cid(card, cid);
 			if (ret) {
 				return ret;
 			}

--- a/subsys/sd/sdmmc.c
+++ b/subsys/sd/sdmmc.c
@@ -610,6 +610,7 @@ int sdmmc_card_init(struct sd_card *card)
 {
 	int ret;
 	uint32_t ocr_arg = 0U;
+	uint32_t cid[4] = {0};
 
 	/* First send a probing OCR */
 	if (IS_ENABLED(CONFIG_SDHC_SUPPORTS_SPI_MODE) && card->host_props.is_spi) {
@@ -695,7 +696,7 @@ int sdmmc_card_init(struct sd_card *card)
 		}
 	}
 	/* Read the card's CID (card identification register) */
-	ret = card_read_cid(card);
+	ret = card_read_cid(card, cid);
 	if (ret) {
 		return ret;
 	}


### PR DESCRIPTION
I also wanted access to card CID (#66460) so added a disk ioctl command to retrieve this - cached in `sd_card struct` rather than stack in `card_read_cid`.

Some option questions/opinions:

* Should I re-order and re-number commands so it appears before INIT/DEINIT? Just tidier before CTRL commands I guess.
* The `struct sd_cid` could be behind the `CONFIG_SDMMC_STACK`.. guard since it's only used in this case.
* Even cleaner, could just return cid_raw since it's read in all configurations (or another command to get this)? I have to admit, I don't fully understand why the raw value is always read but only decoded with SDMMC and otherwise discarded.