### PR TITLE
drivers: stm32: bbram: clarify error when RTC/BBRAM misconfigured

### DIFF
--- a/dts/bindings/memory-controllers/st,stm32-bbram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-bbram.yaml
@@ -10,6 +10,9 @@ description: |
   by system reset or when the device wakes up from Standby mode. They are
   reset by a backup domain reset.
 
+  Note: Since STM32 BBRAM is in RTC backup domain, STM32 RTC node must be
+        enabled if STM32 BBRAM node is enabled.
+
 compatible: "st,stm32-bbram"
 
 include: base.yaml


### PR DESCRIPTION
Improve the error path and message when backup domain or RTC/BBRAM is not configured correctly, so users see a clear hint to enable the required Kconfig/DT settings instead of a vague failure.

updated the discription in st,stm32-bbram.yaml to enable the RTC

	modified:   drivers/bbram/bbram_stm32.c
	modified:   dts/bindings/memory-controllers/st,stm32-bbram.yaml

Fixes zephyrproject-rtos/zephyr#55495
https://github.com/zephyrproject-rtos/zephyr/issues/55495