### PR TITLE
soc: silabs: Support image properties for Series 2

### DIFF
--- a/soc/silabs/silabs_s2/CMakeLists.txt
+++ b/soc/silabs/silabs_s2/CMakeLists.txt
@@ -2,3 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources(soc.c)
+zephyr_sources_ifdef(CONFIG_SOC_SILABS_IMAGE_PROPERTIES soc_image_properties.c)
+zephyr_linker_sources_ifdef(CONFIG_SOC_SILABS_IMAGE_PROPERTIES RODATA soc_image_properties.ld)

--- a/soc/silabs/silabs_s2/Kconfig
+++ b/soc/silabs/silabs_s2/Kconfig
@@ -10,6 +10,19 @@ config SOC_FAMILY_SILABS_S2
 	select SOC_EARLY_INIT_HOOK
 	select HAS_SILABS_SISDK
 
+config SOC_SILABS_IMAGE_PROPERTIES
+	bool "Include application properties data structure in image"
+	default y if MCUBOOT
+	help
+	  Include the Silicon Labs application properties data structure in the
+	  the firmware image. This allows the SE and Gecko bootloader to access
+	  information about the image, such as its version and capabilities. If
+	  MCUboot is used, only the MCUboot image itself needs the image
+	  properties data structure to enable the SE to perform secure boot
+	  verification of the bootloader. MCUboot uses its own TLV format to
+	  verify the application. If Gecko bootloader is used, the Zephyr
+	  application image also needs the data structure.
+
 rsource "*/Kconfig"
 
 config ARM_SECURE_FIRMWARE

--- a/soc/silabs/silabs_s2/soc_image_properties.c
+++ b/soc/silabs/silabs_s2/soc_image_properties.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#if defined __has_include
+#if __has_include("app_version.h")
+#include "app_version.h"
+#define SOC_IMAGE_VERSION APPVERSION
+#endif
+#endif
+
+#if !defined(SOC_IMAGE_VERSION)
+#include <zephyr/version.h>
+#define SOC_IMAGE_VERSION KERNELVERSION
+#endif
+
+#if !defined(SOC_IMAGE_TYPE)
+#define SOC_IMAGE_TYPE                                                                             \
+	((IS_ENABLED(CONFIG_MCUBOOT) ? BIT(6) : 0) | (IS_ENABLED(CONFIG_BT) ? BIT(3) : 0))
+#endif
+
+#if !defined(SOC_IMAGE_CAPABILITIES)
+#define SOC_IMAGE_CAPABILITIES 0
+#endif
+
+#if !defined(SOC_IMAGE_PRODUCT_ID)
+#define SOC_IMAGE_PRODUCT_ID {0}
+#endif
+
+struct image_info {
+	uint32_t type;
+	uint32_t version;
+	uint32_t capabilities;
+	uint8_t id[16];
+};
+
+struct image_properties {
+	uint8_t magic[16];
+	uint32_t header_version;
+	uint32_t signature_type;
+	uint32_t signature_location;
+	struct image_info info;
+	void *cert;
+	void *token_location;
+};
+
+const struct image_properties image_props __attribute__((used, section(".image_properties"))) = {
+	.magic = {0x13, 0xb7, 0x79, 0xfa, 0xc9, 0x25, 0xdd, 0xb7, 0xad, 0xf3, 0xcf, 0xe0, 0xf1,
+		  0xb6, 0x14, 0xb8},
+	.header_version = 0x0101,
+	.signature_type = 0,
+	.signature_location = 0,
+	.info = {.type = SOC_IMAGE_TYPE,
+		 .version = SOC_IMAGE_VERSION,
+		 .capabilities = SOC_IMAGE_CAPABILITIES,
+		 .id = SOC_IMAGE_PRODUCT_ID},
+	.cert = NULL,
+	.token_location = NULL,
+};

--- a/soc/silabs/silabs_s2/soc_image_properties.ld
+++ b/soc/silabs/silabs_s2/soc_image_properties.ld
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Ensure that image properties section is preserved in the final binary.
+ */
+
+_image_properties_start = .;
+KEEP(*(.image_properties));
+_image_properties_end = .;
+_image_properties_size = ABSOLUTE(_image_properties_end - _image_properties_start);


### PR DESCRIPTION
Add image properties data structure to Series 2 binaries. This data structure is used by the SE or bootloader to enforce secure boot, and by other tools to extract image information.

Use the app version if set, or fall back to the kernel version for the image version field. Set image type based on Kconfig options.

Enable the data structure by default in MCUboot images, since it's needed for the SE to secure boot the image. Disable it by default in other images, since MCUboot doesn't use it. Users of Gecko bootloader must manually enable it.