### PR TITLE
Border Router packet forwarding between interfaces

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -1296,6 +1296,17 @@ static inline bool net_ipv6_is_addr_mcast_scope_raw(const uint8_t *addr,
 }
 /** @endcond */
 
+/** @cond INTERNAL_HIDDEN */
+static inline int net_ipv6_get_addr_mcast_scope_raw(const uint8_t *addr)
+{
+	if (addr[0] == 0xff) {
+		return (addr[1] & 0xF);
+	}
+
+	return -1;
+}
+/** @endcond */
+
 /**
  * @brief Check if the IPv6 address is a given scope multicast
  * address (FFyx::).
@@ -1326,6 +1337,18 @@ static inline bool net_ipv6_is_same_mcast_scope(const struct in6_addr *addr_1,
 {
 	return (addr_1->s6_addr[0] == 0xff) && (addr_2->s6_addr[0] == 0xff) &&
 			(addr_1->s6_addr[1] == addr_2->s6_addr[1]);
+}
+
+/**
+ * @brief Returns the scope of the given IPv6 address.
+ *
+ * @param addr IPv6 address
+ *
+ * @return Scope of the address, -1 if address is not multicast.
+ */
+static inline int net_ipv6_get_addr_mcast_scope(const struct in6_addr *addr)
+{
+	return net_ipv6_get_addr_mcast_scope_raw(addr->s6_addr);
 }
 
 /** @cond INTERNAL_HIDDEN */

--- a/samples/net/openthread/border_router/overlay-ot-rcp-host-wifi-nxp.conf
+++ b/samples/net/openthread/border_router/overlay-ot-rcp-host-wifi-nxp.conf
@@ -38,3 +38,8 @@ CONFIG_OPENTHREAD_MANUAL_START=y
 #Border Router mDNS host name and service base name
 CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_VENDOR_NAME="NXP"
 CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_BASE_SERVICE_NAME="NXP-BorderRouter"
+
+#As per Thread v1.2.0 Conformance, a Thread Border Router MUST be able to hold a Multicast Listener
+#Table in memory with at least 75 entries.
+#75 entries for conformance, 10 extra for other purposes, if any.
+CONFIG_NET_MAX_MCAST_ROUTES=85

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -179,6 +179,14 @@ static void ot_receive_handler(otMessage *message, void *context)
 		}
 	}
 
+#if defined(CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER)
+	if (!openthread_border_router_check_packet_forwarding_rules(pkt)) {
+		NET_DBG("Not injecting packet to Zephyr net stack "
+			"Packet not compliant with forwarding rules!");
+		goto out;
+	}
+#endif /* CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER */
+
 	NET_DBG("Injecting %s packet to Zephyr net stack",
 		PKT_IS_IPv4(pkt) ? "translated IPv4" : "Ip6");
 
@@ -271,6 +279,13 @@ int openthread_send(struct net_if *iface, struct net_pkt *pkt)
 	}
 
 	net_capture_pkt(iface, pkt);
+
+#if defined(CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER)
+	if (!openthread_border_router_check_packet_forwarding_rules(pkt)) {
+		net_pkt_unref(pkt);
+		return len;
+	}
+#endif /* CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER */
 
 	if (notify_new_tx_frame(pkt) != 0) {
 		net_pkt_unref(pkt);

--- a/subsys/net/l2/openthread/openthread_border_router.h
+++ b/subsys/net/l2/openthread/openthread_border_router.h
@@ -104,6 +104,7 @@ struct otbr_msg_ctx {
 		/** Generic OpenThread IPv6 address structure */
 		otIp6Address addr;
 
+		/** OpenThread IPv6 socket address structure */
 		otSockAddr sock_addr;
 	};
 };
@@ -128,6 +129,14 @@ void openthread_border_router_deallocate_message(void *msg);
  * @param msg_context Pointer to contained message.
  */
 void openthread_border_router_post_message(struct otbr_msg_ctx *msg_context);
+
+/**
+ * @brief Verifies if a packet respects the imposed OpenThread forwarding rules
+ * between Backbone and Thread interface.
+ *
+ * @param pkt Pointer to packet that will be checked.
+ */
+bool openthread_border_router_check_packet_forwarding_rules(struct net_pkt *pkt);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds packet forwarding rules between Adjacent Infrastructure Link and Thread Network.