### PR TITLE
drivers: power_domain: nrfs_gdpwr: depend on multithreading

### DIFF
--- a/drivers/power_domain/Kconfig.nrfs_gdpwr
+++ b/drivers/power_domain/Kconfig.nrfs_gdpwr
@@ -4,6 +4,7 @@
 config POWER_DOMAIN_NRFS_GDPWR
 	bool "NRFS Global Domain Power Request driver"
 	depends on DT_HAS_NORDIC_NRFS_GDPWR_ENABLED
+	depends on MULTITHREADING
 	select NRFS
 	select NRFS_GDPWR_SERVICE_ENABLED
 	default y


### PR DESCRIPTION
The NRFS GDPWR device driver requires NRFS which requires multithreading. Add dependency to Kconfig for the device driver to exclude it when building for single threaded apps like mcuboot.