### PR TITLE
Revert "boards: nordic: nRF54L15DK: set HFXO clock latency to 854"

### DIFF
--- a/boards/nordic/nrf54l15dk/nrf54l15dk_common.dtsi
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_common.dtsi
@@ -108,9 +108,5 @@
 	pinctrl-names = "default", "sleep";
 };
 
-&hfxo {
-	startup-time-us = <854>;
-};
-
 /* Get a node label for wi-fi spi to use in shield files */
 wifi_spi: &spi22 {};


### PR DESCRIPTION
This reverts commit d0a076984b1082d51db41e2d1d61d7b48c1d3019.

The reason for reverting this is that the only safe startup time for 54L series is the one defined in the SoC .dtsi files (1650us), and other startup times are not reliable even when tested on a particular board.