### PR TITLE
maintainers: Remove Hubert Mis from hal_nordic collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5325,7 +5325,6 @@ West:
     - nika-nordic
     - masz-nordic
   collaborators:
-    - hubertmis
     - nordic-krch
     - kl-cruz
     - magp-nordic


### PR DESCRIPTION
Hubert no longer works at Nordic and has no plans to continue working on this platform.