### PR TITLE
soc: nordic: nrf54h20: enable PM_DEVICE_RUNTIME if PM by default

### DIFF
--- a/soc/nordic/nrf54h/Kconfig.defconfig
+++ b/soc/nordic/nrf54h/Kconfig.defconfig
@@ -35,6 +35,13 @@ config SPI_DW_HSSI
 config SPI_DW_ACCESS_WORD_ONLY
 	default y if SPI_DW
 
+if PM
+
+config PM_DEVICE
+	default y
+
+endif # PM
+
 if PM_DEVICE
 
 config PM_DEVICE_RUNTIME


### PR DESCRIPTION
PM on the nrf54h20 has minimal utility if power domains and devices are not managed at runtime, as these prevent the soc from entering sleep states in the first place. Enable PM_DEVICE by default if PM, which in turn enables PM_DEVICE_RUNTIME for devices and power domains.