### PR TITLE
soc: nordic: nrf54h: Add support for CPURAD DEBUG_WAIT

### DIFF
--- a/soc/nordic/nrf54h/Kconfig
+++ b/soc/nordic/nrf54h/Kconfig
@@ -88,12 +88,22 @@ config SOC_NRF54H20_CPURAD_ENABLE
 	  Radiocore, and also power will be requested to the Radiocore
 	  subsystem. The Radiocore will then start executing instructions.
 
+if SOC_NRF54H20_CPURAD_ENABLE
+
 config SOC_NRF54H20_CPURAD_ENABLE_CHECK_VTOR
 	bool "Check VTOR before booting Radio core"
 	default y
-	depends on SOC_NRF54H20_CPURAD_ENABLE
 	help
 	  Verify that VTOR is not 0xFFFFFFFF before booting the Radiocore.
+
+config SOC_NRF54H20_CPURAD_ENABLE_DEBUG_WAIT
+	bool "Boot the Radio core in DEBUGWAIT mode"
+	help
+	  Halt the Radio core immediately after reset. This ensures that a
+	  debugger can attach and take control from the very first
+	  instruction.
+
+endif # SOC_NRF54H20_CPURAD_ENABLE
 
 config SOC_NRF54H20_CPURAD
 	select SOC_NRF54H20_CPURAD_COMMON

--- a/soc/nordic/nrf54h/soc.c
+++ b/soc/nordic/nrf54h/soc.c
@@ -230,13 +230,12 @@ void soc_late_init_hook(void)
 		return;
 	}
 
-	/* Don't wait as this is not yet supported. */
-	bool cpu_wait = false;
+	bool cpu_wait = IS_ENABLED(CONFIG_SOC_NRF54H20_CPURAD_ENABLE_DEBUG_WAIT);
 
 	err_cpuconf = ironside_cpuconf(NRF_PROCESSOR_RADIOCORE, radiocore_address, cpu_wait, msg,
 				       msg_size);
 	__ASSERT(err_cpuconf == 0, "err_cpuconf was %d", err_cpuconf);
-#endif
+#endif /* CONFIG_SOC_NRF54H20_CPURAD_ENABLE */
 }
 #endif
 


### PR DESCRIPTION
Add support for halting the Radio core immediately after reset. This ensures that a debugger can attach and take control from the very first instruction.