### PR TITLE
kernel: arch: soc: introduce 'k_entry' symbol

### DIFF
--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -95,6 +95,7 @@ if(DEFINED CONFIG_ARCH_SUPPORTS_ROM_OFFSET)
   # note that the pattern will affect empty spaces created after FILL(0x00).
   zephyr_linker_sources(ROM_START SORT_KEY $ fill_with_zeros.ld)
   zephyr_linker_sources(ROM_START SORT_KEY 0x0 rom_start_offset.ld)
+  zephyr_linker_sources(ROM_START SORT_KEY $ k_entry.ld)
   # Handled in ld.cmake
 endif()
 

--- a/arch/common/k_entry.ld
+++ b/arch/common/k_entry.ld
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Baumer (www.baumer.com)
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Make CONFIG_KERNEL_ENTRY a compiler symbol accessible
+ * with in code files.
+ */
+PROVIDE(k_entry = CONFIG_KERNEL_ENTRY);

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016, Wind River Systems, Inc.
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +13,8 @@
 
 #ifndef ZEPHYR_INCLUDE_KERNEL_H_
 #define ZEPHYR_INCLUDE_KERNEL_H_
+
+#include <zephyr/kernel_entry.h>
 
 #if !defined(_ASMLANGUAGE)
 #include <zephyr/kernel_includes.h>

--- a/include/zephyr/kernel_entry.h
+++ b/include/zephyr/kernel_entry.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Baumer (www.baumer.com)
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_KERNEL_ENTRY_H_
+#define ZEPHYR_INCLUDE_KERNEL_ENTRY_H_
+
+#include <zephyr/toolchain.h>
+
+/**
+ * @defgroup kernel entry Kernel Entry
+ * @ingroup kernel_apis
+ * @{
+ *
+ * The k_entry is a label marking the very first assembly
+ * instruction executed to set up the CPU basics such as stack pointer and
+ * other CPU specific registers, memory protection, caches, etc.
+ * often implemented in files called crt0.S, reset.S, entry.S, start.S or similar.
+ *
+ * k_entry is zephyr's common entry point symbol for all architectures,
+ * storable in a pointer variable which may be made accessible to bootloaders.
+ *
+ * A bootloader shall be able, in a first stage, to jump to this symbol (address)
+ * and leave the responsibility of setting up the CPU correctly to the subsequent
+ * reset/entry/start assembly code. In further stages that assembly code needs
+ * to setup the C environment and enter the kernel.
+ *
+ */
+
+#if !defined(_ASMLANGUAGE)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void k_entry(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#else
+GTEXT(k_entry)
+#endif /* _ASMLANGUAGE */
+
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_KERNEL_VERSION_H_ */

--- a/soc/espressif/esp32c6/Kconfig.defconfig
+++ b/soc/espressif/esp32c6/Kconfig.defconfig
@@ -37,6 +37,9 @@ config MULTITHREADING
 config NUM_PREEMPT_PRIORITIES
 	default 0
 
+config KERNEL_ENTRY
+	default "reset_vector"
+
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
 

--- a/soc/espressif/esp32c6/default_lpcore.ld
+++ b/soc/espressif/esp32c6/default_lpcore.ld
@@ -28,7 +28,7 @@ _ram_len = _aligned_coproc_mem - _vector_table_len - ULP_SHARED_MEM_SIZE;
 _shared_mem_org = ULP_SHARED_MEM_ADDR;
 _shared_mem_len = ULP_SHARED_MEM_SIZE;
 
-ENTRY(reset_vector)
+ENTRY(CONFIG_KERNEL_ENTRY)
 
 MEMORY
 {

--- a/soc/mediatek/mt8xxx/linker.ld
+++ b/soc/mediatek/mt8xxx/linker.ld
@@ -21,7 +21,7 @@ MEMORY {
 #define RAMABLE_REGION dram
 #define ROMABLE_REGION dram
 
-ENTRY(mtk_adsp_boot_entry)
+ENTRY(CONFIG_KERNEL_ENTRY)
 
 SECTIONS {
 

--- a/soc/mediatek/mt8xxx/mt8186/Kconfig.defconfig
+++ b/soc/mediatek/mt8xxx/mt8186/Kconfig.defconfig
@@ -10,4 +10,7 @@ config NUM_2ND_LEVEL_AGGREGATORS
 config 2ND_LVL_INTR_00_OFFSET
 	default 2
 
+config KERNEL_ENTRY
+	default "mtk_adsp_boot_entry"
+
 endif

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -430,6 +430,26 @@
 #define sys_port_trace_k_timer_status_sync_exit(timer, result)                                     \
 	sys_trace_k_timer_status_sync_exit(timer, result)
 
+#if defined(USE_EVENT_TRACING)
+/*
+ * Search result for 'sys_trace_k_event_' in the code base:
+ *
+ * - subsys/tracing/ctf/tracing_ctf.h:
+ * - subsys/tracing/test/tracing_test.h:
+ *
+ * Search result for 'sys_trace_k_timer_' in the code base:
+ * - subsys/tracing/ctf/ctf_top.c:
+ * - subsys/tracing/ctf/tracing_ctf.h:
+ * - subsys/tracing/test/tracing_string_format_test.c:
+ * - subsys/tracing/test/tracing_test.h:
+ * - tests/subsys/tracing/tracing_api/src/main.c:
+ *
+ * ==============================================================
+ * Conclusion: for k_event there is no implementation!
+ * Hence make the macros void to at least get the code compiled.
+ * ==============================================================
+ */
+
 #define sys_port_trace_k_event_init(event) sys_trace_k_event_init(event)
 #define sys_port_trace_k_event_post_enter(event, events, events_mask)   \
 	sys_trace_k_event_post_enter(event, events, events_mask)
@@ -441,6 +461,14 @@
 	sys_trace_k_event_wait_blocking(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_exit(event, events, ret)   \
 	sys_trace_k_event_wait_exit(event, events, ret)
+#else
+#define sys_port_trace_k_event_init(event)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)
+#define sys_port_trace_k_event_wait_enter(event, events, options, timeout)
+#define sys_port_trace_k_event_wait_blocking(event, events, options, timeout)
+#define sys_port_trace_k_event_wait_exit(event, events, ret)
+#endif
 
 #define sys_port_trace_k_thread_abort_exit(thread) sys_trace_k_thread_abort_exit(thread)
 


### PR DESCRIPTION
# Issue

Zephyr does not provide a common compiler symbol usable as entry point for a bootloader to jump to.
The best comparable is the string behind `CONFIG_KERNEL_ENTRY` which is also used in the linker script `ENTRY(CONFIG_KERNEL_ENTRY)`

# User Story / Use Case

I want to have a common compiler/linker symbol with the address of the kernel entry point (equivalent to __start, __nuclei_start, entry, _MainEntry etc.) which I can place into a (const) variable `entry_point` in a firmware information block accessible by a bootloader, for the bootloader to simply jump to that address location with a function pointer with signature `void (*entry_point)(void)`

# Solution
- Define a common `k_entry` symbol in each architecture reset.S, start.S, entry.S etc. assembly file, making `k_entry` an equivalent to the different __start, entry, __nuclei_start etc. symbols by
  - Setting the CONFIG_KERNEL_ENTRY to the correct symbol e.g. __nuclei_start, rom_start, etc.
  - Making the content of CONFIG_KERNEL_ENTRY an "alias" symbol by using the PROVIDE() directive in the linker script.
- Declare (void)k_entry(void) as public function in a kernel header file

# Limitation

Not all cores are covered by this PR (mainly ESP32 with appcpu and procpu) and will have to be solved individually.
