### PR TITLE
MAINTAINERS: Add maintainers for nRF IronSide SE

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6063,6 +6063,21 @@ nRF BSIM:
   tests:
     - boards.nrf52_bsim
 
+nRF IronSide SE Platforms:
+  status: maintained
+  maintainers:
+    - hakonfam
+  collaborators:
+    - "57300"
+    - jonathannilsen
+    - karstenkoenig
+    - SebastianBoe
+  files:
+    - soc/nordic/ironside/
+    - soc/nordic/common/uicr/
+  labels:
+    - "platform: nRF IronSide SE"
+
 nRF Platforms:
   status: maintained
   maintainers:


### PR DESCRIPTION
Add maintainers for nordic's IronSide SE.

The IronSide Secure Element provides a root-of-trust and cryptographic services to nrf54h20 and nrf9280 SoC's.