### PR TITLE
soc/ambiq/apollo5x: fix Kconfig `ARMV8_1_M_PMU_EVENTCNT` being globally set

### DIFF
--- a/soc/ambiq/apollo5x/Kconfig
+++ b/soc/ambiq/apollo5x/Kconfig
@@ -43,3 +43,7 @@ config SOC_AMBIQ_DMA_BUFF_ALIGNMENT
 	default 1
 	help
 	  This option specifies the DMA buffers' alignment
+
+config ARMV8_1_M_PMU_EVENTCNT
+	int
+	default 8 if SOC_APOLLO510

--- a/soc/ambiq/apollo5x/Kconfig.soc
+++ b/soc/ambiq/apollo5x/Kconfig.soc
@@ -12,10 +12,6 @@ config SOC_APOLLO510
 	bool
 	select SOC_SERIES_APOLLO5X
 
-config ARMV8_1_M_PMU_EVENTCNT
-	int
-	default 8
-
 config SOC_SERIES
 	default "apollo5x" if SOC_SERIES_APOLLO5X
 


### PR DESCRIPTION
I found the `ARMV8_1_M_PMU_EVENTCNT` symbol being defined by `soc/ambiq/apollo5x/Kconfig.soc` even when building for an Arduino Giga board, based on an STM32H747, so I decided to investigate.

Other targets that define this symbol do it in the `Kconfig` file, and gate it with a `SOC_` model or series symbol. Defining a default in the `Kconfig.soc` instead applies it on every build, which is not desired.