### PR TITLE
drivers: misc: nordic_vpr_launcher: add DMA secure attribute support

### DIFF
--- a/dts/bindings/riscv/nordic,nrf-vpr-coprocessor.yaml
+++ b/dts/bindings/riscv/nordic,nrf-vpr-coprocessor.yaml
@@ -30,3 +30,8 @@ properties:
     type: boolean
     description: |
       Enables setting VPR core's secure attribute to secure.
+
+  enable-dma-secure:
+    type: boolean
+    description: |
+      Enables setting VPR core's DMA secure attribute to secure.


### PR DESCRIPTION
Extend vpr_launcher and device tree bindings to support configuring the DMA secure attribute.