### PR TITLE
drivers: i2c: stm32: fix compilation with DMA

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -14,6 +14,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
 #include <soc.h>
+#include <stm32_cache.h>
 #include <stm32_ll_i2c.h>
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>


### PR DESCRIPTION
fixes:
- implicit declaration of function 'stm32_buf_in_nocache'
- undefined reference to 'stm32_buf_in_nocache'

This is a follow up of the PR [95537](https://github.com/zephyrproject-rtos/zephyr/pull/95537).

Fixes #95724