### PR TITLE
renesas: smartbond: Update mcuboot partitioning scheme

### DIFF
--- a/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
+++ b/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
@@ -101,7 +101,7 @@
 };
 
 &flash0 {
-	reg = <0x16000000 DT_SIZE_M(1)>;
+	reg = <0x16000000 DT_SIZE_M(4)>;
 
 	partitions {
 		compatible = "fixed-partitions";
@@ -109,28 +109,33 @@
 		#size-cells = <1>;
 
 		/*
-		 * Flash area from 0x0000 to 0x2400 is reserved
-		 * for product header added by flasher.
+		 * By default, and due to executing from external flash memories, the I-cache
+		 * controller is employed so that no latencies are introduced.
+		 * Normally, the controller imposes that image's base address is aligned
+		 * to CACHE_FLASH_REG[FLASH_REGION_SIZE], which should reflect image's
+		 * size (should be configured on the fly at soc level based on the image size).
+		 * The controller should allow for a small offset, up to 0x1000 words,
+		 * in case image metadata should be appended.
+		 * The current scheme imposes that mcuboot should occupy up to 64kB which is the
+		 * minimum cacheable area and then slot0 and slot1 partition entries should follow
+		 * without gaps in between.
 		 */
 
 		boot_partition: partition@2400 {
 			label = "mcuboot";
-			reg = <0x000002400 0x00009c00>;
+			reg = <0x000002400 0x0000dc00>;
 		};
-
-		slot0_partition: partition@c000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x0000c000 0x00076000>;
+			reg = <0x00010000 DT_SIZE_K(512)>;
 		};
-
-		slot1_partition: partition@82000 {
+		slot1_partition: partition@90000 {
 			label = "image-1";
-			reg = <0x00082000 0x00076000>;
+			reg = <0x00090000 DT_SIZE_K(512)>;
 		};
-
-		storage_partition: partition@f8000 {
+		storage_partition: partition@110000 {
 			label = "storage";
-			reg = <0x000f8000 0x00008000>;
+			reg = <0x00110000 DT_SIZE_K(32)>;
 		};
 	};
 };

--- a/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
+++ b/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
@@ -89,7 +89,7 @@
 };
 
 &flash0 {
-	reg = <0x16000000 DT_SIZE_M(1)>;
+	reg = <0x16000000 DT_SIZE_M(4)>;
 
 	partitions {
 		compatible = "fixed-partitions";
@@ -97,28 +97,33 @@
 		#size-cells = <1>;
 
 		/*
-		 * Flash area from 0x0000 to 0x2400 is reserved
-		 * for product header added by flasher.
+		 * By default, and due to executing from external flash memories, the I-cache
+		 * controller is employed so that no latencies are introduced.
+		 * Normally, the controller imposes that image's base address is aligned
+		 * to CACHE_FLASH_REG[FLASH_REGION_SIZE], which should reflect image's
+		 * size (should be configured on the fly at soc level based on the image size).
+		 * The controller should allow for a small offset, up to 0x1000 words,
+		 * in case image metadata should be appended.
+		 * The current scheme imposes that mcuboot should occupy up to 64kB which is the
+		 * minimum cacheable area and then slot0 and slot1 partition entries should follow
+		 * without gaps in between.
 		 */
 
 		boot_partition: partition@2400 {
 			label = "mcuboot";
-			reg = <0x000002400 0x00009c00>;
+			reg = <0x000002400 0x0000dc00>;
 		};
-
-		slot0_partition: partition@c000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x0000c000 0x00076000>;
+			reg = <0x00010000 DT_SIZE_K(512)>;
 		};
-
-		slot1_partition: partition@82000 {
+		slot1_partition: partition@90000 {
 			label = "image-1";
-			reg = <0x00082000 0x00076000>;
+			reg = <0x00090000 DT_SIZE_K(512)>;
 		};
-
-		storage_partition: partition@f8000 {
+		storage_partition: partition@110000 {
 			label = "storage";
-			reg = <0x000f8000 0x00008000>;
+			reg = <0x00110000 DT_SIZE_K(32)>;
 		};
 	};
 };


### PR DESCRIPTION
The commit should deal with fixing board's flash memory capacity as well as updating the mcuboot partitioning scheme for Smartbond family of devices.