### PR TITLE
boards: arm: fix full_name for fvp_baser_aemv8r

### DIFF
--- a/boards/arm/fvp_baser_aemv8r/board.yml
+++ b/boards/arm/fvp_baser_aemv8r/board.yml
@@ -1,6 +1,6 @@
 board:
   name: fvp_baser_aemv8r
-  full_name: Debug with Arm DS
+  full_name: FVP BaseR AEMv8-R
   vendor: arm
   socs:
   - name: fvp_aemv8r_aarch64


### PR DESCRIPTION
Ensure the board's full name shows up correctly in the docs.