### PR TITLE
arch: native: Fix undefined symbols

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -241,7 +241,7 @@ config XIP
 	  option increases both the code and data footprint of the image.
 
 
-if ARC || ARM || ARM64 || X86 || RISCV || RX
+if ARC || ARM || ARM64 || X86 || RISCV || RX || ARCH_POSIX
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_FLASH := zephyr,flash
@@ -264,7 +264,7 @@ config FLASH_BASE_ADDRESS
 	  normally set by the board's defconfig file and the user should generally
 	  avoid modifying it via the menu configuration.
 
-endif # ARM || ARM64 || ARC || X86 || RISCV || RX
+endif # ARM || ARM64 || ARC || X86 || RISCV || RX || ARCH_POSIX
 
 if ARCH_HAS_TRUSTED_EXECUTION
 


### PR DESCRIPTION
CONFIG_FLASH_SIZE and CONFIG_FLASH_BASE_ADDRESS symbols were not defined in native_sim even though it has a flash controller and flash defined.