### PR TITLE
ST: STM32: Add Stm32C051 support

### DIFF
--- a/dts/arm/st/c0/stm32c051.dtsi
+++ b/dts/arm/st/c0/stm32c051.dtsi
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ * Copyright (c) 2025 Thomas Stranger
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/c0/stm32c031.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32c051", "st,stm32c0", "simple-bus";
+
+		timers2: timers@40000000  {
+			compatible = "st,stm32-timers";
+			reg = <0x40000000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
+				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
+			interrupts = <15 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
+			interrupts = <24 0>;
+			interrupt-names = "global";
+			status = "disabled";
+		};
+
+		spi2: spi@40003800 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
+			interrupts = <26 0>;
+			interrupt-names = "global";
+			status = "disabled";
+		};
+
+		dma1: dma@40020000 {
+			interrupts = <9 0 10 0 10 0 11 0 11 0>;
+			dma-requests = <5>;
+		};
+
+		dmamux1: dmamux@40020800 {
+			dma-channels = <5>;
+		};
+	};
+};

--- a/dts/arm/st/c0/stm32c051X6.dtsi
+++ b/dts/arm/st/c0/stm32c051X6.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Thomas Stranger
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/c0/stm32c051.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(12)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(32)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/c0/stm32c051X8.dtsi
+++ b/dts/arm/st/c0/stm32c051X8.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Thomas Stranger
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/c0/stm32c051.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(12)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(64)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/c0/stm32c071.dtsi
+++ b/dts/arm/st/c0/stm32c071.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/c0/stm32c031.dtsi>
+#include <st/c0/stm32c051.dtsi>
 
 / {
 	clocks {
@@ -20,41 +20,6 @@
 	soc {
 		compatible = "st,stm32c071", "st,stm32c0", "simple-bus";
 
-		timers2: timers@40000000  {
-			compatible = "st,stm32-timers";
-			reg = <0x40000000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
-				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 0U)>;
-			interrupts = <15 0>;
-			interrupt-names = "global";
-			st,prescaler = <0>;
-			status = "disabled";
-
-			pwm {
-				compatible = "st,stm32-pwm";
-				status = "disabled";
-				#pwm-cells = <3>;
-			};
-
-			counter {
-				compatible = "st,stm32-counter";
-				status = "disabled";
-			};
-		};
-
-		i2c2: i2c@40005800 {
-			compatible = "st,stm32-i2c-v2";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
-			interrupts = <24 0>;
-			interrupt-names = "global";
-			status = "disabled";
-		};
-
 		usb: usb@40005c00 {
 			compatible = "st,stm32-usb";
 			reg = <0x40005c00 0x400>;
@@ -67,26 +32,6 @@
 			clocks = <&rcc STM32_CLOCK(APB1, 13)>,
 				 <&rcc STM32_SRC_HSE USB_SEL(1)>;
 			status = "disabled";
-		};
-
-		spi2: spi@40003800 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <26 0>;
-			interrupt-names = "global";
-			status = "disabled";
-		};
-
-		dma1: dma@40020000 {
-			interrupts = <9 0 10 0 10 0 11 0 11 0>;
-			dma-requests = <5>;
-		};
-
-		dmamux1: dmamux@40020800 {
-			dma-channels = <5>;
 		};
 	};
 

--- a/dts/arm/st/c0/stm32c091.dtsi
+++ b/dts/arm/st/c0/stm32c091.dtsi
@@ -4,15 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/c0/stm32c071.dtsi>
-
-/* STM32C091 is a superset of the C071 with the exception of USB support.
- * Since C071 provides the same set of peripheral as the C051,
- * along with the addition of USB, once the C051 is introduced,
- * it can be included instead, and the delete-node can be removed.
- */
-/delete-node/ &usb;
-/delete-node/ &usb_fs_phy;
+#include <st/c0/stm32c051.dtsi>
 
 / {
 	soc {
@@ -68,8 +60,4 @@
 			dma-requests = <53>;
 		};
 	};
-};
-
-&exti {
-	num-lines = <32>;
 };

--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -5,6 +5,7 @@ family:
     socs:
     - name: stm32c011xx
     - name: stm32c031xx
+    - name: stm32c051xx
     - name: stm32c071xx
     - name: stm32c091xx
     - name: stm32c092xx

--- a/soc/st/stm32/stm32c0x/Kconfig.defconfig.stm32c051xx
+++ b/soc/st/stm32/stm32c0x/Kconfig.defconfig.stm32c051xx
@@ -1,0 +1,12 @@
+# STMicroelectronics STM32C051xx MCU
+
+# Copyright (c) 2024 STMicroelectronics
+# Copyright (c) 2025 Thomas Stranger
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32C051XX
+
+config NUM_IRQS
+	default 29
+
+endif # SOC_STM32C051XX

--- a/soc/st/stm32/stm32c0x/Kconfig.soc
+++ b/soc/st/stm32/stm32c0x/Kconfig.soc
@@ -18,6 +18,10 @@ config SOC_STM32C031XX
 	bool
 	select SOC_SERIES_STM32C0X
 
+config SOC_STM32C051XX
+	bool
+	select SOC_SERIES_STM32C0X
+
 config SOC_STM32C071XX
 	bool
 	select SOC_SERIES_STM32C0X
@@ -33,6 +37,7 @@ config SOC_STM32C092XX
 config SOC
 	default "stm32c011xx" if SOC_STM32C011XX
 	default "stm32c031xx" if SOC_STM32C031XX
+	default "stm32c051xx" if SOC_STM32C051XX
 	default "stm32c071xx" if SOC_STM32C071XX
 	default "stm32c091xx" if SOC_STM32C091XX
 	default "stm32c092xx" if SOC_STM32C092XX


### PR DESCRIPTION
Adds definitions for the the STM32C051 parts of the STM32C0 Series.

This completes the Series so far, and avoids having to delete the usb nodes for the STM32C091 dts files as discussed in https://github.com/zephyrproject-rtos/zephyr/pull/93263#discussion_r2225390498