### PR TITLE
doc: release-notes: clarify where api changes go

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -48,12 +48,8 @@ https://docs.zephyrproject.org/latest/security/vulnerabilities.html
 API Changes
 ***********
 
-* RTIO
-
-  * :c:func:`rtio_is_spi`
-  * :c:func:`rtio_is_cspi`
-  * :c:func:`rtio_is_i3c`
-  * :c:func:`rtio_read_regs_async`
+..
+  Only removed, deprecated and new APIs, changes go in migration guide.
 
 Removed APIs and options
 ========================


### PR DESCRIPTION
API changes should be in the migration guide, release notes has everything else, that is deprecated, removed and new. Add a note to reflect that and avoid confusion.