### PR TITLE
drivers: ethernet: xlnx_gem: fix packet DMA configuration on ZynqMP

### DIFF
--- a/drivers/ethernet/Kconfig.xlnx_gem
+++ b/drivers/ethernet/Kconfig.xlnx_gem
@@ -11,6 +11,8 @@ menuconfig ETH_XLNX_GEM
 	default y
 	depends on DT_HAS_XLNX_GEM_ENABLED
 	depends on !QEMU_TARGET || (QEMU_TARGET && NET_QEMU_ETHERNET)
+	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
+	select CACHE_MANAGEMENT if DCACHE
 	help
 	  Enable Xilinx GEM Ethernet driver.
 

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -252,7 +252,7 @@ static void eth_xlnx_gem_iface_init(struct net_if *iface)
 
 	/* Initialize TX-related semaphores */
 	k_sem_init(&dev_data->tx_done_sem, 0, 1);
-	k_sem_init(&dev_data->txbd_ring.ring_sem, 1, 1);
+	k_sem_init(&dev_data->tx_bd_ring.ring_sem, 1, 1);
 
 	/* Initialize the device's interrupt */
 	dev_conf->config_func(dev);
@@ -398,20 +398,20 @@ static int eth_xlnx_gem_send(const struct device *dev, struct net_pkt *pkt)
 		   dev_conf->tx_buffer_size);
 
 	if (dev_conf->defer_txd_to_queue) {
-		k_sem_take(&(dev_data->txbd_ring.ring_sem), K_FOREVER);
+		k_sem_take(&(dev_data->tx_bd_ring.ring_sem), K_FOREVER);
 	} else {
 		sys_write32(ETH_XLNX_GEM_IXR_TX_COMPLETE_BIT,
 			    dev_conf->base_addr + ETH_XLNX_GEM_IDR_OFFSET);
 	}
 
-	if (bds_reqd > dev_data->txbd_ring.free_bds) {
+	if (bds_reqd > dev_data->tx_bd_ring.free_bds) {
 		LOG_ERR("%s cannot TX, packet length %hu requires "
 			"%hhu BDs, current free count = %hhu",
 			dev->name, tx_data_length, bds_reqd,
-			dev_data->txbd_ring.free_bds);
+			dev_data->tx_bd_ring.free_bds);
 
 		if (dev_conf->defer_txd_to_queue) {
-			k_sem_give(&(dev_data->txbd_ring.ring_sem));
+			k_sem_give(&(dev_data->tx_bd_ring.ring_sem));
 		} else {
 			sys_write32(ETH_XLNX_GEM_IXR_TX_COMPLETE_BIT,
 				    dev_conf->base_addr + ETH_XLNX_GEM_IER_OFFSET);
@@ -422,15 +422,15 @@ static int eth_xlnx_gem_send(const struct device *dev, struct net_pkt *pkt)
 		return -EIO;
 	}
 
-	curr_bd_idx = first_bd_idx = dev_data->txbd_ring.next_to_use;
-	reg_ctrl = (uint32_t)(&dev_data->txbd_ring.first_bd[curr_bd_idx].ctrl);
+	curr_bd_idx = first_bd_idx = dev_data->tx_bd_ring.next_to_use;
+	reg_ctrl = (uint32_t)(&dev_data->tx_bd_ring.first_bd[curr_bd_idx].ctrl);
 
-	dev_data->txbd_ring.next_to_use = (first_bd_idx + bds_reqd) %
-					  dev_conf->txbd_count;
-	dev_data->txbd_ring.free_bds -= bds_reqd;
+	dev_data->tx_bd_ring.next_to_use = (first_bd_idx + bds_reqd) %
+					  dev_conf->tx_bd_count;
+	dev_data->tx_bd_ring.free_bds -= bds_reqd;
 
 	if (dev_conf->defer_txd_to_queue) {
-		k_sem_give(&(dev_data->txbd_ring.ring_sem));
+		k_sem_give(&(dev_data->tx_bd_ring.ring_sem));
 	} else {
 		sys_write32(ETH_XLNX_GEM_IXR_TX_COMPLETE_BIT,
 			    dev_conf->base_addr + ETH_XLNX_GEM_IER_OFFSET);
@@ -452,16 +452,16 @@ static int eth_xlnx_gem_send(const struct device *dev, struct net_pkt *pkt)
 			     tx_data_remaining : dev_conf->tx_buffer_size);
 
 		/* Update current BD's control word */
-		reg_val = sys_read32(reg_ctrl) & (ETH_XLNX_GEM_TXBD_WRAP_BIT |
-			  ETH_XLNX_GEM_TXBD_USED_BIT);
+		reg_val = sys_read32(reg_ctrl) & (ETH_XLNX_GEM_TX_BD_WRAP_BIT |
+			  ETH_XLNX_GEM_TX_BD_USED_BIT);
 		reg_val |= (tx_data_remaining < dev_conf->tx_buffer_size) ?
 			   tx_data_remaining : dev_conf->tx_buffer_size;
 		sys_write32(reg_val, reg_ctrl);
 
 		if (tx_data_remaining > dev_conf->tx_buffer_size) {
 			/* Switch to next BD */
-			curr_bd_idx = (curr_bd_idx + 1) % dev_conf->txbd_count;
-			reg_ctrl = (uint32_t)(&dev_data->txbd_ring.first_bd[curr_bd_idx].ctrl);
+			curr_bd_idx = (curr_bd_idx + 1) % dev_conf->tx_bd_count;
+			reg_ctrl = (uint32_t)(&dev_data->tx_bd_ring.first_bd[curr_bd_idx].ctrl);
 		}
 
 		tx_data_remaining -= (tx_data_remaining < dev_conf->tx_buffer_size) ?
@@ -469,7 +469,7 @@ static int eth_xlnx_gem_send(const struct device *dev, struct net_pkt *pkt)
 	} while (tx_data_remaining > 0);
 
 	/* Set the 'last' bit in the current BD's control word */
-	reg_val |= ETH_XLNX_GEM_TXBD_LAST_BIT;
+	reg_val |= ETH_XLNX_GEM_TX_BD_LAST_BIT;
 
 	/*
 	 * Clear the 'used' bits of all BDs involved in the current
@@ -480,7 +480,7 @@ static int eth_xlnx_gem_send(const struct device *dev, struct net_pkt *pkt)
 	 * flush all involved TX BDs' buffers from the L1 cache to
 	 * regular memory along the way.
 	 */
-	reg_val &= ~ETH_XLNX_GEM_TXBD_USED_BIT;
+	reg_val &= ~ETH_XLNX_GEM_TX_BD_USED_BIT;
 	sys_write32(reg_val, reg_ctrl);
 #ifdef CONFIG_DCACHE
 	sys_cache_data_flush_and_invd_range((void *)(dev_data->first_tx_buffer +
@@ -490,10 +490,10 @@ static int eth_xlnx_gem_send(const struct device *dev, struct net_pkt *pkt)
 
 	while (curr_bd_idx != first_bd_idx) {
 		curr_bd_idx = (curr_bd_idx != 0) ? (curr_bd_idx - 1) :
-			      (dev_conf->txbd_count - 1);
-		reg_ctrl = (uint32_t)(&dev_data->txbd_ring.first_bd[curr_bd_idx].ctrl);
+			      (dev_conf->tx_bd_count - 1);
+		reg_ctrl = (uint32_t)(&dev_data->tx_bd_ring.first_bd[curr_bd_idx].ctrl);
 		reg_val = sys_read32(reg_ctrl);
-		reg_val &= ~ETH_XLNX_GEM_TXBD_USED_BIT;
+		reg_val &= ~ETH_XLNX_GEM_TX_BD_USED_BIT;
 		sys_write32(reg_val, reg_ctrl);
 #ifdef CONFIG_DCACHE
 		sys_cache_data_flush_and_invd_range((void *)(dev_data->first_tx_buffer +
@@ -1387,21 +1387,21 @@ static void eth_xlnx_gem_configure_buffers(const struct device *dev)
 	 * can place packet data in the associated buffer. In the last BD,
 	 * the 'wrap' bit must be set.
 	 */
-	bdptr = dev_data->rxbd_ring.first_bd;
+	bdptr = dev_data->rx_bd_ring.first_bd;
 
-	for (buf_iter = 0; buf_iter < (dev_conf->rxbd_count - 1); buf_iter++) {
+	for (buf_iter = 0; buf_iter < (dev_conf->rx_bd_count - 1); buf_iter++) {
 		uint32_t addr = (uint32_t)dev_data->first_rx_buffer +
 				(buf_iter * dev_conf->rx_buffer_size);
 		/* Clear 'used' bit -> BD is owned by the controller */
-		bdptr->addr = addr & ~(ETH_XLNX_GEM_RXBD_USED_BIT | ETH_XLNX_GEM_RXBD_WRAP_BIT);
+		bdptr->addr = addr & ~(ETH_XLNX_GEM_RX_BD_USED_BIT | ETH_XLNX_GEM_RX_BD_WRAP_BIT);
 		bdptr->ctrl = 0x00000000;
 		++bdptr;
 	}
 
 	uint32_t last_rx_addr = (uint32_t)dev_data->first_rx_buffer +
 				(buf_iter * dev_conf->rx_buffer_size);
-	bdptr->addr = (((uint32_t)last_rx_addr) & ~ETH_XLNX_GEM_RXBD_USED_BIT) |
-		      ETH_XLNX_GEM_RXBD_WRAP_BIT;
+	bdptr->addr = (((uint32_t)last_rx_addr) & ~ETH_XLNX_GEM_RX_BD_USED_BIT) |
+		      ETH_XLNX_GEM_RX_BD_WRAP_BIT;
 	bdptr->ctrl = 0x00000000;
 
 	/*
@@ -1412,18 +1412,18 @@ static void eth_xlnx_gem_configure_buffers(const struct device *dev)
 	 * TX data to transmit. Indicate no data to transmit by setting
 	 * 'used' in all TX BDs. In the last BD, the 'wrap' bit must be set.
 	 */
-	bdptr = dev_data->txbd_ring.first_bd;
+	bdptr = dev_data->tx_bd_ring.first_bd;
 
-	for (buf_iter = 0; buf_iter < (dev_conf->txbd_count - 1); buf_iter++) {
+	for (buf_iter = 0; buf_iter < (dev_conf->tx_bd_count - 1); buf_iter++) {
 		bdptr->addr = (uint32_t)dev_data->first_tx_buffer +
 			      (buf_iter * dev_conf->tx_buffer_size);
-		bdptr->ctrl = ETH_XLNX_GEM_TXBD_USED_BIT;
+		bdptr->ctrl = ETH_XLNX_GEM_TX_BD_USED_BIT;
 		++bdptr;
 	}
 
 	bdptr->addr = (uint32_t)dev_data->first_tx_buffer +
 		      (buf_iter * (uint32_t)dev_conf->tx_buffer_size);
-	bdptr->ctrl = (ETH_XLNX_GEM_TXBD_WRAP_BIT | ETH_XLNX_GEM_TXBD_USED_BIT);
+	bdptr->ctrl = (ETH_XLNX_GEM_TX_BD_WRAP_BIT | ETH_XLNX_GEM_TX_BD_USED_BIT);
 
 #ifdef CONFIG_SOC_XILINX_ZYNQMP
 	/*
@@ -1433,23 +1433,23 @@ static void eth_xlnx_gem_configure_buffers(const struct device *dev)
 	 * BD indicate that there's no data to be transferred in there.
 	 */
 
-	bdptr = dev_data->rxbd_ring.tie_off_bd;
-	bdptr->addr = (uint32_t)dev_data->rx_tie_off_buffer | ETH_XLNX_GEM_RXBD_USED_BIT |
-		      ETH_XLNX_GEM_RXBD_WRAP_BIT;
+	bdptr = dev_data->rx_bd_ring.tie_off_bd;
+	bdptr->addr = (uint32_t)dev_data->rx_tie_off_buffer | ETH_XLNX_GEM_RX_BD_USED_BIT |
+		      ETH_XLNX_GEM_RX_BD_WRAP_BIT;
 	bdptr->ctrl = 0x00000000;
 
-	bdptr = dev_data->txbd_ring.tie_off_bd;
+	bdptr = dev_data->tx_bd_ring.tie_off_bd;
 	bdptr->addr = (uint32_t)dev_data->tx_tie_off_buffer;
-	bdptr->ctrl = ETH_XLNX_GEM_TXBD_WRAP_BIT | ETH_XLNX_GEM_TXBD_USED_BIT;
+	bdptr->ctrl = ETH_XLNX_GEM_TX_BD_WRAP_BIT | ETH_XLNX_GEM_TX_BD_USED_BIT;
 #endif /* CONFIG_SOC_XILINX_ZYNQMP */
 
 	/* Set free count/current index in the RX/TX BD ring data */
-	dev_data->rxbd_ring.next_to_process = 0;
-	dev_data->rxbd_ring.next_to_use     = 0;
-	dev_data->rxbd_ring.free_bds        = dev_conf->rxbd_count;
-	dev_data->txbd_ring.next_to_process = 0;
-	dev_data->txbd_ring.next_to_use     = 0;
-	dev_data->txbd_ring.free_bds        = dev_conf->txbd_count;
+	dev_data->rx_bd_ring.next_to_process = 0;
+	dev_data->rx_bd_ring.next_to_use     = 0;
+	dev_data->rx_bd_ring.free_bds        = dev_conf->rx_bd_count;
+	dev_data->tx_bd_ring.next_to_process = 0;
+	dev_data->tx_bd_ring.next_to_use     = 0;
+	dev_data->tx_bd_ring.free_bds        = dev_conf->tx_bd_count;
 
 	/*
 	 * Write pointers to the first RX/TX BD to the controller.
@@ -1459,16 +1459,16 @@ static void eth_xlnx_gem_configure_buffers(const struct device *dev)
 	 * registers must point to the single dummy tie-off BD for
 	 * both the RX and TX direction.
 	 */
-	sys_write32((uint32_t)dev_data->rxbd_ring.first_bd,
+	sys_write32((uint32_t)dev_data->rx_bd_ring.first_bd,
 		    dev_conf->base_addr + ETH_XLNX_GEM_RXQBASE_OFFSET);
-	sys_write32((uint32_t)dev_data->txbd_ring.first_bd,
+	sys_write32((uint32_t)dev_data->tx_bd_ring.first_bd,
 		    dev_conf->base_addr + ETH_XLNX_GEM_TXQBASE_OFFSET);
 #ifdef CONFIG_SOC_XILINX_ZYNQMP
 	sys_write32(0x00000000, dev_conf->base_addr + ETH_XLNX_GEM_RX1QBASEH_OFFSET);
-	sys_write32((uint32_t)dev_data->rxbd_ring.tie_off_bd,
+	sys_write32((uint32_t)dev_data->rx_bd_ring.tie_off_bd,
 		    dev_conf->base_addr + ETH_XLNX_GEM_RX1QBASEL_OFFSET);
 	sys_write32(0x00000000, dev_conf->base_addr + ETH_XLNX_GEM_TX1QBASEH_OFFSET);
-	sys_write32((uint32_t)dev_data->txbd_ring.tie_off_bd,
+	sys_write32((uint32_t)dev_data->tx_bd_ring.tie_off_bd,
 		    dev_conf->base_addr + ETH_XLNX_GEM_TX1QBASEL_OFFSET);
 #endif /* CONFIG_SOC_XILINX_ZYNQMP */
 }
@@ -1533,17 +1533,17 @@ static void eth_xlnx_gem_handle_rx_pending(const struct device *dev)
 	 */
 
 	while (1) {
-		curr_bd_idx = dev_data->rxbd_ring.next_to_process;
+		curr_bd_idx = dev_data->rx_bd_ring.next_to_process;
 		first_bd_idx = last_bd_idx = curr_bd_idx;
-		reg_addr = (uint32_t)(&dev_data->rxbd_ring.first_bd[first_bd_idx].addr);
-		reg_ctrl = (uint32_t)(&dev_data->rxbd_ring.first_bd[first_bd_idx].ctrl);
+		reg_addr = (uint32_t)(&dev_data->rx_bd_ring.first_bd[first_bd_idx].addr);
+		reg_ctrl = (uint32_t)(&dev_data->rx_bd_ring.first_bd[first_bd_idx].ctrl);
 
 		/*
 		 * Basic precondition checks for the current BD's
 		 * address and control words
 		 */
 		reg_val = sys_read32(reg_addr);
-		if ((reg_val & ETH_XLNX_GEM_RXBD_USED_BIT) == 0) {
+		if ((reg_val & ETH_XLNX_GEM_RX_BD_USED_BIT) == 0) {
 			/*
 			 * No new data contained in the current BD
 			 * -> break out of the RX loop
@@ -1551,7 +1551,7 @@ static void eth_xlnx_gem_handle_rx_pending(const struct device *dev)
 			break;
 		}
 		reg_val = sys_read32(reg_ctrl);
-		if ((reg_val & ETH_XLNX_GEM_RXBD_START_OF_FRAME_BIT) == 0) {
+		if ((reg_val & ETH_XLNX_GEM_RX_BD_START_OF_FRAME_BIT) == 0) {
 			/*
 			 * Although the current BD is marked as 'used', it
 			 * doesn't contain the SOF bit.
@@ -1568,21 +1568,21 @@ static void eth_xlnx_gem_handle_rx_pending(const struct device *dev)
 		 * of the received packet which spans multiple buffers.
 		 */
 		do {
-			reg_ctrl = (uint32_t)(&dev_data->rxbd_ring.first_bd[last_bd_idx].ctrl);
+			reg_ctrl = (uint32_t)(&dev_data->rx_bd_ring.first_bd[last_bd_idx].ctrl);
 			reg_val  = sys_read32(reg_ctrl);
 			rx_data_length = rx_data_remaining =
-					 (reg_val & ETH_XLNX_GEM_RXBD_FRAME_LENGTH_MASK);
-			if ((reg_val & ETH_XLNX_GEM_RXBD_END_OF_FRAME_BIT) == 0) {
-				last_bd_idx = (last_bd_idx + 1) % dev_conf->rxbd_count;
+					 (reg_val & ETH_XLNX_GEM_RX_BD_FRAME_LENGTH_MASK);
+			if ((reg_val & ETH_XLNX_GEM_RX_BD_END_OF_FRAME_BIT) == 0) {
+				last_bd_idx = (last_bd_idx + 1) % dev_conf->rx_bd_count;
 			}
-		} while ((reg_val & ETH_XLNX_GEM_RXBD_END_OF_FRAME_BIT) == 0);
+		} while ((reg_val & ETH_XLNX_GEM_RX_BD_END_OF_FRAME_BIT) == 0);
 
 		/*
 		 * Store the position of the first BD behind the end of the
 		 * frame currently being processed as 'next to process'
 		 */
-		dev_data->rxbd_ring.next_to_process = (last_bd_idx + 1) %
-						      dev_conf->rxbd_count;
+		dev_data->rx_bd_ring.next_to_process = (last_bd_idx + 1) %
+						      dev_conf->rx_bd_count;
 
 		/*
 		 * Allocate a destination packet from the network stack
@@ -1610,13 +1610,13 @@ static void eth_xlnx_gem_handle_rx_pending(const struct device *dev)
 			if (pkt != NULL) {
 #ifdef CONFIG_DCACHE
 				sys_cache_data_invd_range(
-					(void *)(dev_data->rxbd_ring.first_bd[curr_bd_idx].addr &
-					ETH_XLNX_GEM_RXBD_BUFFER_ADDR_MASK),
+					(void *)(dev_data->rx_bd_ring.first_bd[curr_bd_idx].addr &
+					ETH_XLNX_GEM_RX_BD_BUFFER_ADDR_MASK),
 					dev_conf->rx_buffer_size);
 #endif
 				net_pkt_write(pkt, (const void *)
-					      (dev_data->rxbd_ring.first_bd[curr_bd_idx].addr &
-					      ETH_XLNX_GEM_RXBD_BUFFER_ADDR_MASK),
+					      (dev_data->rx_bd_ring.first_bd[curr_bd_idx].addr &
+					      ETH_XLNX_GEM_RX_BD_BUFFER_ADDR_MASK),
 					      (rx_data_remaining < dev_conf->rx_buffer_size) ?
 					      rx_data_remaining : dev_conf->rx_buffer_size);
 			}
@@ -1628,13 +1628,13 @@ static void eth_xlnx_gem_handle_rx_pending(const struct device *dev)
 			 * processed, on to the next BD -> preserve the RX BD's
 			 * 'wrap' bit & address, but clear the 'used' bit.
 			 */
-			reg_addr = (uint32_t)(&dev_data->rxbd_ring.first_bd[curr_bd_idx].addr);
+			reg_addr = (uint32_t)(&dev_data->rx_bd_ring.first_bd[curr_bd_idx].addr);
 			reg_val	 = sys_read32(reg_addr);
-			reg_val &= ~ETH_XLNX_GEM_RXBD_USED_BIT;
+			reg_val &= ~ETH_XLNX_GEM_RX_BD_USED_BIT;
 			sys_write32(reg_val, reg_addr);
 
-			curr_bd_idx = (curr_bd_idx + 1) % dev_conf->rxbd_count;
-		} while (curr_bd_idx != ((last_bd_idx + 1) % dev_conf->rxbd_count));
+			curr_bd_idx = (curr_bd_idx + 1) % dev_conf->rx_bd_count;
+		} while (curr_bd_idx != ((last_bd_idx + 1) % dev_conf->rx_bd_count));
 
 		/* Propagate the received packet to the network stack */
 		if (pkt != NULL) {
@@ -1716,11 +1716,11 @@ static void eth_xlnx_gem_handle_tx_done(const struct device *dev)
 	 */
 
 	if (dev_conf->defer_txd_to_queue) {
-		k_sem_take(&(dev_data->txbd_ring.ring_sem), K_FOREVER);
+		k_sem_take(&(dev_data->tx_bd_ring.ring_sem), K_FOREVER);
 	}
 
-	curr_bd_idx = first_bd_idx = dev_data->txbd_ring.next_to_process;
-	reg_ctrl = (uint32_t)(&dev_data->txbd_ring.first_bd[curr_bd_idx].ctrl);
+	curr_bd_idx = first_bd_idx = dev_data->tx_bd_ring.next_to_process;
+	reg_ctrl = (uint32_t)(&dev_data->tx_bd_ring.first_bd[curr_bd_idx].ctrl);
 	reg_val  = sys_read32(reg_ctrl);
 
 	do {
@@ -1735,22 +1735,22 @@ static void eth_xlnx_gem_handle_tx_done(const struct device *dev)
 		 * Check if the BD we're currently looking at is the last BD
 		 * of the current transmission
 		 */
-		bd_is_last = ((reg_val & ETH_XLNX_GEM_TXBD_LAST_BIT) != 0) ? 1 : 0;
+		bd_is_last = ((reg_val & ETH_XLNX_GEM_TX_BD_LAST_BIT) != 0) ? 1 : 0;
 
 		/*
 		 * Reset control word of the current BD, clear everything but
 		 * the 'wrap' bit, then set the 'used' bit
 		 */
-		reg_val &= ETH_XLNX_GEM_TXBD_WRAP_BIT;
-		reg_val |= ETH_XLNX_GEM_TXBD_USED_BIT;
+		reg_val &= ETH_XLNX_GEM_TX_BD_WRAP_BIT;
+		reg_val |= ETH_XLNX_GEM_TX_BD_USED_BIT;
 		sys_write32(reg_val, reg_ctrl);
 
 		/* Move on to the next BD or break out of the loop */
 		if (bd_is_last == 1) {
 			break;
 		}
-		curr_bd_idx = (curr_bd_idx + 1) % dev_conf->txbd_count;
-		reg_ctrl = (uint32_t)(&dev_data->txbd_ring.first_bd[curr_bd_idx].ctrl);
+		curr_bd_idx = (curr_bd_idx + 1) % dev_conf->tx_bd_count;
+		reg_ctrl = (uint32_t)(&dev_data->tx_bd_ring.first_bd[curr_bd_idx].ctrl);
 		reg_val  = sys_read32(reg_ctrl);
 	} while (bd_is_last == 0 && curr_bd_idx != first_bd_idx);
 
@@ -1758,13 +1758,13 @@ static void eth_xlnx_gem_handle_tx_done(const struct device *dev)
 		LOG_WRN("%s TX done handling wrapped around", dev->name);
 	}
 
-	dev_data->txbd_ring.next_to_process =
-		(dev_data->txbd_ring.next_to_process + bds_processed) %
-		dev_conf->txbd_count;
-	dev_data->txbd_ring.free_bds += bds_processed;
+	dev_data->tx_bd_ring.next_to_process =
+		(dev_data->tx_bd_ring.next_to_process + bds_processed) %
+		dev_conf->tx_bd_count;
+	dev_data->tx_bd_ring.free_bds += bds_processed;
 
 	if (dev_conf->defer_txd_to_queue) {
-		k_sem_give(&(dev_data->txbd_ring.ring_sem));
+		k_sem_give(&(dev_data->tx_bd_ring.ring_sem));
 	}
 
 	/* Clear the TX status register */

--- a/drivers/ethernet/eth_xlnx_gem_priv.h
+++ b/drivers/ethernet/eth_xlnx_gem_priv.h
@@ -32,9 +32,9 @@
  * [01]       Wrap bit, last BD in RX BD ring
  * [00]       BD used bit
  */
-#define ETH_XLNX_GEM_RXBD_WRAP_BIT			0x00000002
-#define ETH_XLNX_GEM_RXBD_USED_BIT			0x00000001
-#define ETH_XLNX_GEM_RXBD_BUFFER_ADDR_MASK		0xFFFFFFFC
+#define ETH_XLNX_GEM_RX_BD_WRAP_BIT			0x00000002
+#define ETH_XLNX_GEM_RX_BD_USED_BIT			0x00000001
+#define ETH_XLNX_GEM_RX_BD_BUFFER_ADDR_MASK		0xFFFFFFFC
 
 /*
  * Receive Buffer Descriptor control word:
@@ -57,24 +57,24 @@
  * [13]       FCS status bit for FCS ignore mode
  * [12 .. 00] Data length of received frame
  */
-#define ETH_XLNX_GEM_RXBD_BCAST_BIT			0x80000000
-#define ETH_XLNX_GEM_RXBD_MCAST_HASH_MATCH_BIT		0x40000000
-#define ETH_XLNX_GEM_RXBD_UCAST_HASH_MATCH_BIT		0x20000000
-#define ETH_XLNX_GEM_RXBD_SPEC_ADDR_MATCH_BIT		0x08000000
-#define ETH_XLNX_GEM_RXBD_SPEC_ADDR_MASK		0x00000003
-#define ETH_XLNX_GEM_RXBD_SPEC_ADDR_SHIFT		25
-#define ETH_XLNX_GEM_RXBD_BIT24				0x01000000
-#define ETH_XLNX_GEM_RXBD_BITS23_22_MASK		0x00000003
-#define ETH_XLNX_GEM_RXBD_BITS23_22_SHIFT		22
-#define ETH_XLNX_GEM_RXBD_VLAN_TAG_DETECTED_BIT		0x00200000
-#define ETH_XLNX_GEM_RXBD_PRIO_TAG_DETECTED_BIT		0x00100000
-#define ETH_XLNX_GEM_RXBD_VLAN_PRIORITY_MASK		0x00000007
-#define ETH_XLNX_GEM_RXBD_VLAN_PRIORITY_SHIFT		17
-#define ETH_XLNX_GEM_RXBD_CFI_BIT			0x00010000
-#define ETH_XLNX_GEM_RXBD_END_OF_FRAME_BIT		0x00008000
-#define ETH_XLNX_GEM_RXBD_START_OF_FRAME_BIT		0x00004000
-#define ETH_XLNX_GEM_RXBD_FCS_STATUS_BIT		0x00002000
-#define ETH_XLNX_GEM_RXBD_FRAME_LENGTH_MASK		0x00001FFF
+#define ETH_XLNX_GEM_RX_BD_BCAST_BIT			0x80000000
+#define ETH_XLNX_GEM_RX_BD_MCAST_HASH_MATCH_BIT		0x40000000
+#define ETH_XLNX_GEM_RX_BD_UCAST_HASH_MATCH_BIT		0x20000000
+#define ETH_XLNX_GEM_RX_BD_SPEC_ADDR_MATCH_BIT		0x08000000
+#define ETH_XLNX_GEM_RX_BD_SPEC_ADDR_MASK		0x00000003
+#define ETH_XLNX_GEM_RX_BD_SPEC_ADDR_SHIFT		25
+#define ETH_XLNX_GEM_RX_BD_BIT24			0x01000000
+#define ETH_XLNX_GEM_RX_BD_BITS23_22_MASK		0x00000003
+#define ETH_XLNX_GEM_RX_BD_BITS23_22_SHIFT		22
+#define ETH_XLNX_GEM_RX_BD_VLAN_TAG_DETECTED_BIT	0x00200000
+#define ETH_XLNX_GEM_RX_BD_PRIO_TAG_DETECTED_BIT	0x00100000
+#define ETH_XLNX_GEM_RX_BD_VLAN_PRIORITY_MASK		0x00000007
+#define ETH_XLNX_GEM_RX_BD_VLAN_PRIORITY_SHIFT		17
+#define ETH_XLNX_GEM_RX_BD_CFI_BIT			0x00010000
+#define ETH_XLNX_GEM_RX_BD_END_OF_FRAME_BIT		0x00008000
+#define ETH_XLNX_GEM_RX_BD_START_OF_FRAME_BIT		0x00004000
+#define ETH_XLNX_GEM_RX_BD_FCS_STATUS_BIT		0x00002000
+#define ETH_XLNX_GEM_RX_BD_FRAME_LENGTH_MASK		0x00001FFF
 
 /* Transmit Buffer Descriptor bits & masks: comp. Zynq-7000 TRM, Table 16-3. */
 
@@ -91,17 +91,17 @@
  * [15]       Last buffer bit, indicates end of current TX frame
  * [13 .. 00] Data length in the BD's associated buffer
  */
-#define ETH_XLNX_GEM_TXBD_USED_BIT			0x80000000
-#define ETH_XLNX_GEM_TXBD_WRAP_BIT			0x40000000
-#define ETH_XLNX_GEM_TXBD_RETRY_BIT			0x20000000
-#define ETH_XLNX_GEM_TXBD_TX_FRAME_CORRUPT_BIT		0x08000000
-#define ETH_XLNX_GEM_TXBD_LATE_COLLISION_BIT		0x04000000
-#define ETH_XLNX_GEM_TXBD_CKSUM_OFFLOAD_ERROR_MASK	0x00000007
-#define ETH_XLNX_GEM_TXBD_CKSUM_OFFLOAD_ERROR_SHIFT	20
-#define ETH_XLNX_GEM_TXBD_NO_CRC_BIT			0x00010000
-#define ETH_XLNX_GEM_TXBD_LAST_BIT			0x00008000
-#define ETH_XLNX_GEM_TXBD_LEN_MASK			0x00003FFF
-#define ETH_XLNX_GEM_TXBD_ERR_MASK			0x3C000000
+#define ETH_XLNX_GEM_TX_BD_USED_BIT			0x80000000
+#define ETH_XLNX_GEM_TX_BD_WRAP_BIT			0x40000000
+#define ETH_XLNX_GEM_TX_BD_RETRY_BIT			0x20000000
+#define ETH_XLNX_GEM_TX_BD_TX_FRAME_CORRUPT_BIT		0x08000000
+#define ETH_XLNX_GEM_TX_BD_LATE_COLLISION_BIT		0x04000000
+#define ETH_XLNX_GEM_TX_BD_CKSUM_OFFLOAD_ERROR_MASK	0x00000007
+#define ETH_XLNX_GEM_TX_BD_CKSUM_OFFLOAD_ERROR_SHIFT	20
+#define ETH_XLNX_GEM_TX_BD_NO_CRC_BIT			0x00010000
+#define ETH_XLNX_GEM_TX_BD_LAST_BIT			0x00008000
+#define ETH_XLNX_GEM_TX_BD_LEN_MASK			0x00003FFF
+#define ETH_XLNX_GEM_TX_BD_ERR_MASK			0x3C000000
 
 #define ETH_XLNX_GEM_CKSUM_NO_ERROR			0x00000000
 #define ETH_XLNX_GEM_CKSUM_VLAN_HDR_ERROR		0x00000001
@@ -458,9 +458,9 @@ static const struct eth_xlnx_gem_dev_cfg eth_xlnx_gem##port##_dev_cfg = {\
 		(DT_INST_PROP(port, hw_rx_buffer_size)),\
 	.hw_rx_buffer_offset		= (uint8_t)\
 		(DT_INST_PROP(port, hw_rx_buffer_offset)),\
-	.rxbd_count			= (uint8_t)\
+	.rx_bd_count			= (uint8_t)\
 		(DT_INST_PROP(port, rx_buffer_descriptors)),\
-	.txbd_count			= (uint8_t)\
+	.tx_bd_count			= (uint8_t)\
 		(DT_INST_PROP(port, tx_buffer_descriptors)),\
 	.rx_buffer_size			= (((uint16_t)(DT_INST_PROP(port, rx_buffer_size)) +\
 		(ETH_XLNX_BUFFER_ALIGNMENT-1)) & ~(ETH_XLNX_BUFFER_ALIGNMENT-1)),\
@@ -510,8 +510,8 @@ static struct eth_xlnx_gem_dev_data eth_xlnx_gem##port##_dev_data = {\
 /* Buffer descriptor rings declaration macro */
 #define ETH_XLNX_GEM_BD_RINGS_DECL(port) \
 struct eth_xlnx_gem##port##_bd_rings_layout {\
-	struct eth_xlnx_gem_bd rxbd_ring[DT_INST_PROP(port, rx_buffer_descriptors)];\
-	struct eth_xlnx_gem_bd txbd_ring[DT_INST_PROP(port, tx_buffer_descriptors)];\
+	struct eth_xlnx_gem_bd rx_bd_ring[DT_INST_PROP(port, rx_buffer_descriptors)];\
+	struct eth_xlnx_gem_bd tx_bd_ring[DT_INST_PROP(port, tx_buffer_descriptors)];\
 	struct eth_xlnx_gem_bd tie_off_rx_bd;\
 	struct eth_xlnx_gem_bd tie_off_tx_bd;\
 }
@@ -559,10 +559,10 @@ static void eth_xlnx_gem##port##_irq_config(const struct device *dev)\
 /* RX/TX BD Ring initialization macro */
 #define ETH_XLNX_GEM_INIT_BD_RING(port) \
 if (dev_conf->base_addr == DT_REG_ADDR_BY_IDX(DT_INST(port, xlnx_gem), 0)) {\
-	dev_data->rxbd_ring.first_bd = &(eth_xlnx_gem##port##_bd_rings.rxbd_ring[0]);\
-	dev_data->rxbd_ring.tie_off_bd = &eth_xlnx_gem##port##_bd_rings.tie_off_rx_bd;\
-	dev_data->txbd_ring.first_bd = &(eth_xlnx_gem##port##_bd_rings.txbd_ring[0]);\
-	dev_data->txbd_ring.tie_off_bd = &eth_xlnx_gem##port##_bd_rings.tie_off_tx_bd;\
+	dev_data->rx_bd_ring.first_bd = &(eth_xlnx_gem##port##_bd_rings.rx_bd_ring[0]);\
+	dev_data->rx_bd_ring.tie_off_bd = &eth_xlnx_gem##port##_bd_rings.tie_off_rx_bd;\
+	dev_data->tx_bd_ring.first_bd = &(eth_xlnx_gem##port##_bd_rings.tx_bd_ring[0]);\
+	dev_data->tx_bd_ring.tie_off_bd = &eth_xlnx_gem##port##_bd_rings.tie_off_tx_bd;\
 	dev_data->first_rx_buffer = (uint8_t *)eth_xlnx_gem##port##_dma_area.rx_buffer;\
 	dev_data->first_tx_buffer = (uint8_t *)eth_xlnx_gem##port##_dma_area.tx_buffer;\
 	dev_data->rx_tie_off_buffer = eth_xlnx_gem##port##_dma_area.rx_tie_off_buffer;\
@@ -684,7 +684,7 @@ struct eth_xlnx_gem_bd {
  * counter as well as indices used to determine which BD shall be used
  * or evaluated for the next RX/TX operation.
  */
-struct eth_xlnx_gem_bdring {
+struct eth_xlnx_gem_bd_ring {
 	/* Concurrent modification protection */
 	struct k_sem		ring_sem;
 	/* Pointer to the first BD in the list */
@@ -730,8 +730,8 @@ struct eth_xlnx_gem_dev_cfg {
 	enum eth_xlnx_hwrx_buffer_size	hw_rx_buffer_size;
 	uint8_t				hw_rx_buffer_offset;
 
-	uint8_t				rxbd_count;
-	uint8_t				txbd_count;
+	uint8_t				rx_bd_count;
+	uint8_t				tx_bd_count;
 	uint16_t			rx_buffer_size;
 	uint16_t			tx_buffer_size;
 
@@ -787,8 +787,8 @@ struct eth_xlnx_gem_dev_data {
 	uint8_t				*rx_tie_off_buffer;
 	uint8_t				*tx_tie_off_buffer;
 
-	struct eth_xlnx_gem_bdring	rxbd_ring;
-	struct eth_xlnx_gem_bdring	txbd_ring;
+	struct eth_xlnx_gem_bd_ring	rx_bd_ring;
+	struct eth_xlnx_gem_bd_ring	tx_bd_ring;
 
 #ifdef CONFIG_NET_STATISTICS_ETHERNET
 	struct net_stats_eth		stats;


### PR DESCRIPTION
Add fixes for ZynqMP-based targets:

- Consider the retrofitted 64-bit RX/TX buffer descriptor ring  base address registers which didn't exist on the Zynq-7000 yet.
- Properly tie off the unused set of RX/TX BD ring base address registers as described in the ZynqMP TRM (UG1085 v2.4, chap. 34:  'GEM Ethernet', 'Programming Model', 'Initialize the controller',  p. 1064): indicate that there's no data to be transmitted via the  unused TX BD ring, and that no data can be placed via the unused  RX BD ring.
- Change the DMA layout: instead of having both the BD rings and  the packet buffers in non-cached memory or the Zynq's OCM, place  the BD rings in uncached memory but place the actual RX/TX packet  buffers in cached memory instead.
- Add the required cache maintenance operations for this layout.
- Select the required facilities for nocache memory and cache maintenance support in the driver's Kconfig file.
- Minor spelling unification as separate commit.

The fixes are backwards-compatible with operation on the Zynq-7000.