### PR TITLE
cpu_freq: Extend CPU frequency scaling to SMP

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -847,6 +847,20 @@ CMSIS-NN integration:
   tests:
     - libraries.cmsis_nn
 
+CPU Frequency Scaling:
+  status: maintained
+  maintainers:
+    - peter-mitsis
+    - seankyer
+  files:
+    - include/zephyr/cpu_freq/
+    - include/zephyr/cpu_load/
+    - subsys/cpu_load/
+    - subsys/cpu_freq/
+    - dts/bindings/p_state/
+  labels:
+    - "area: CPU Frequency Scaling"
+
 CRC:
   status: maintained
   maintainers:

--- a/doc/services/cpu_freq/index.rst
+++ b/doc/services/cpu_freq/index.rst
@@ -12,22 +12,22 @@ Overview
 ********
 
 The CPU Frequency Scaling subsystem in Zephyr provides a framework for SoC's to dynamically adjust
-their processor frequency based on a monitored metric and performance state (p-state) policy
+their processor frequency based on a monitored metric and performance state (P-state) policy
 algorithm.
 
 Design Goals
 ************
 
 The CPU Frequency Scaling subsystem aims to provide a framework that allows for any policy algorithm
-to work with any p-state driver and allows for each policy to make use of one, or many, metrics to
+to work with any P-state driver and allows for each policy to make use of one, or many, metrics to
 determine an optimal CPU frequency. The subsystem should be flexible enough to allow for SoC vendors
-to define custom p-states, thresholds and metrics.
+to define custom P-states, thresholds and metrics.
 
 P-state Policies
 ****************
 
-A p-state policy is an algorithm that determines what the optimal p-state is for the CPU based on
-the metrics it consumes and the thresholds defined per p-state. A policy can consume one, or many,
+A P-state policy is an algorithm that determines what the optimal P-state is for the CPU based on
+the metrics it consumes and the thresholds defined per P-state. A policy can consume one, or many,
 metrics to determine the optimal CPU frequency based on the desired statistics of the system.
 
 See :ref:`policies <cpu_freq_policies>` for a list of standard policies.
@@ -43,28 +43,28 @@ For an example of a metric in use, see the :ref:`on_demand <on_demand_policy>` p
 P-state Drivers
 ***************
 
-A SoC supporting the CPU Freq subsystem must implement a p-state driver that implements
+A SoC supporting the CPU Freq subsystem must implement a P-state driver that implements
 :c:func:`cpu_freq_pstate_set` which applies the passed in ``p_state`` to
 the CPU when called.
 
-A SoC must also provide the available p-states in devicetree by having a
-:dtcompatible:`zephyr,pstate` compatible node. The SoC may also define its own p-state binding,
+A SoC must also provide the available P-states in devicetree by having a
+:dtcompatible:`zephyr,pstate` compatible node. The SoC may also define its own P-state binding,
 which extends :dtcompatible:`zephyr,pstate` to include additional properties that may be used by
-the SoC's p-state driver.
+the SoC's P-state driver.
 
 Usage considerations
 ********************
 
 The CPU Frequency Scaling subsystem assumes that each CPU is clocked independently and that a
-p-state transition does not impact an unrelated CPU of the SoC.
+P-state transition does not impact an unrelated CPU of the SoC.
 
 The SoC supporting CPU Freq must uphold Zephyr's requirement that the system timer remains constant
 over the lifetime of the program. See :ref:`Kernel Timing <kernel_timing>` for more information.
 
 The CPU Frequency Scaling subsystem runs as a handler function to a ``k_timer``, which means it runs
-in interrupt context (IRQ). The SoC p-state driver must ensure that its implementation of
-:c:func:`cpu_freq_pstate_set` is IRQ context safe. If a p-state transition
-cannot be completed reasonably in an IRQ context, it is recommended that the p-state driver of the
+in interrupt context (IRQ). The SoC P-state driver must ensure that its implementation of
+:c:func:`cpu_freq_pstate_set` is IRQ context safe. If a P-state transition
+cannot be completed reasonably in an IRQ context, it is recommended that the P-state driver of the
 SoC implements its task as a workqueue item.
 
 CPU Frequency Scaling subsystem is not compatible with SMP as of now since the thread can migrate

--- a/doc/services/cpu_freq/index.rst
+++ b/doc/services/cpu_freq/index.rst
@@ -55,8 +55,11 @@ the SoC's P-state driver.
 Usage considerations
 ********************
 
-The CPU Frequency Scaling subsystem assumes that each CPU is clocked independently and that a
-P-state transition does not impact an unrelated CPU of the SoC.
+The CPU Frequency Scaling subsystem is designed to work on both UP and SMP system. On SMP systems,
+it is assumed by default that each of the CPUs are clocked at the same rate. Thus, should one CPU
+undergo a P-state transition, then all other CPUs will also undergo the same P-state transition.
+This can be overridden by the SoC by enabling the :kconfig:option:`CONFIG_CPU_FREQ_PER_CPU_SCALING`
+configuration option to allow each CPU to be clocked independently.
 
 The SoC supporting CPU Freq must uphold Zephyr's requirement that the system timer remains constant
 over the lifetime of the program. See :ref:`Kernel Timing <kernel_timing>` for more information.
@@ -66,6 +69,3 @@ in interrupt context (IRQ). The SoC P-state driver must ensure that its implemen
 :c:func:`cpu_freq_pstate_set` is IRQ context safe. If a P-state transition
 cannot be completed reasonably in an IRQ context, it is recommended that the P-state driver of the
 SoC implements its task as a workqueue item.
-
-CPU Frequency Scaling subsystem is not compatible with SMP as of now since the thread can migrate
-between cores during execution, causing per-CPU metrics to be attributed to the wrong CPU.

--- a/dts/bindings/p_state/zephyr,generic-pstate.yaml
+++ b/dts/bindings/p_state/zephyr,generic-pstate.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2025 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Generic Performance State (P-state) binding
+
+  Implement a generic P-state device node.
+
+  Example configuration:
+
+  performance-states {
+          pstate_0: pstate_0 {
+                  compatible = "zephyr,generic-pstate";
+                  load-threshold = <50>;
+                  pstate-id = <0>;
+          };
+          pstate_1: pstate_1 {
+                  compatible = "zephyr,generic-pstate";
+                  load-threshold = <20>;
+                  pstate-id = <1>;
+          };
+          pstate_2: pstate_2 {
+                  compatible = "zephyr,generic-pstate";
+                  load-threshold = <0>;
+                  pstate-id = <2>;
+          };
+  };
+
+compatible: "zephyr,generic-pstate"
+
+include: "zephyr,pstate.yaml"
+
+properties:
+  pstate-id:
+    type: int
+    required: true
+    description: |
+      Identifier of performance state. The state IDs shall be unique among all
+      sibling nodes. It is recommended that they begin at 0 and monotonically
+      increase with decreasing performance (increasing power savings).

--- a/dts/bindings/p_state/zephyr,pstate.yaml
+++ b/dts/bindings/p_state/zephyr,pstate.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: Common properties for performance states (pstate)
+description: Common properties for performance states (P-state)
 
 compatible: "zephyr,pstate"
 

--- a/include/zephyr/cpu_freq/cpu_freq.h
+++ b/include/zephyr/cpu_freq/cpu_freq.h
@@ -26,8 +26,12 @@ extern "C" {
 /**
  * @brief Request processor set the given performance state.
  *
- * To be implemented by the SoC. This API abstracts the hardware and SoC specific calls required to
- * change the performance state of the processor.
+ * To be implemented by the SoC. This API abstracts the hardware and SoC
+ * specific calls required to change the performance state of the current CPU.
+ * The caller must ensure that the current CPU does not change. If called from
+ * an ISR or a single CPU system, this restriction is automatically met. If
+ * called from a thread on an SMP system, either interrupts or the scheduler
+ * must be disabled to ensure the current CPU does not change.
  *
  * @note It is not guaranteed that the performance state will be set immediately, or at all.
  *

--- a/include/zephyr/cpu_freq/policy.h
+++ b/include/zephyr/cpu_freq/policy.h
@@ -29,15 +29,19 @@ extern "C" {
  */
 
 /**
- * @brief Get the next P-state from CPU Frequency Policy
+ * @brief Get the next P-state from CPU frequency scaling policy
  *
  * This function is implemented by a CPU Freq policy selected via Kconfig.
+ * The caller must ensure that the current CPU does not change. If called
+ * from an ISR or a single CPU system, this restriction is automatically met.
+ * If called from a thread on an SMP system, either interrupts or the scheduler
+ * must be disabled to ensure the current CPU does not change.
  *
- * @param pstate Pointer to the P-state struct where the next P-state is returned.
+ * @param pstate_out Pointer to the P-state struct where the next P-state is returned.
  *
  * @retval 0 in case of success, nonzero in case of failure.
  */
-int cpu_freq_policy_select_pstate(const struct pstate **pstate);
+int cpu_freq_policy_select_pstate(const struct pstate **pstate_out);
 
 /**
  * @}

--- a/include/zephyr/cpu_freq/policy.h
+++ b/include/zephyr/cpu_freq/policy.h
@@ -31,17 +31,44 @@ extern "C" {
 /**
  * @brief Get the next P-state from CPU frequency scaling policy
  *
- * This function is implemented by a CPU Freq policy selected via Kconfig.
- * The caller must ensure that the current CPU does not change. If called
- * from an ISR or a single CPU system, this restriction is automatically met.
- * If called from a thread on an SMP system, either interrupts or the scheduler
- * must be disabled to ensure the current CPU does not change.
+ * This function is implemented by a CPU frequency scaling policy selected via
+ * Kconfig. The caller must ensure that the current CPU does not change. If
+ * called from an ISR or a single CPU system, this restriction is automatically
+ * met. If called from a thread on an SMP system, either interrupts or the
+ * scheduler must be disabled to ensure the current CPU does not change.
  *
  * @param pstate_out Pointer to the P-state struct where the next P-state is returned.
  *
  * @retval 0 in case of success, nonzero in case of failure.
  */
 int cpu_freq_policy_select_pstate(const struct pstate **pstate_out);
+
+/**
+ * @brief Reset data structures used by CPU frequency scaling policy
+ *
+ * This function is implemented by a CPU frequency scaling policy selected via
+ * Kconfig. It resets any data structured needed by the policy. It is
+ * automatically invoked by the CPU frequency scaling subsystem and should not
+ * be called directly by application code.
+ */
+void cpu_freq_policy_reset(void);
+
+/**
+ * @brief Set the CPU frequency scaling P-state according to policy
+ *
+ * This function is implemented by a CPU frequency scaling policy selected via
+ * Kconfig. It accepts a P-state previously obtained by a call to
+ * :c:func:`cpu_freq_policy_select_pstate` and attempts to apply it according
+ * to the policy. The policy may choose to apply the selected P-state, or
+ * apply a different P-state, or ignore the request altogether. This function
+ * is automatically invoked by the CPU frequency scaling subsystem and should
+ * not be called directly by application code.
+ *
+ * @param state Pointer to a P-state
+ *
+ * @return Pointer to the applied P-state, or NULL if nothing applied
+ */
+const struct pstate *cpu_freq_policy_pstate_set(const struct pstate *state);
 
 /**
  * @}

--- a/samples/subsys/cpu_freq/on_demand/README.rst
+++ b/samples/subsys/cpu_freq/on_demand/README.rst
@@ -11,3 +11,9 @@ sample will print debug information like CPU load and CPU frequency subsystem lo
 console for visibility into the subsystem.
 
 The example will iterate through some simulated CPU processing scenarios in the main application.
+
+To use the pstate-stub.overlay file, build the sample with:
+
+.. code-block:: console
+
+   west build -b <board> -p -- -DDTC_OVERLAY_FILE=pstate-stub.overlay

--- a/samples/subsys/cpu_freq/on_demand/pstate-stub.overlay
+++ b/samples/subsys/cpu_freq/on_demand/pstate-stub.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	performance-states {
+		pstate_0: pstate_0 {
+			compatible = "zephyr,generic-pstate";
+			load-threshold = <50>;
+			pstate-id = <0>;
+		};
+		pstate_1: pstate_1 {
+			compatible = "zephyr,generic-pstate";
+			load-threshold = <20>;
+			pstate-id = <1>;
+		};
+		pstate_2: pstate_2 {
+			compatible = "zephyr,generic-pstate";
+			load-threshold = <0>;
+			pstate-id = <2>;
+		};
+	};
+};

--- a/samples/subsys/cpu_freq/on_demand/sample.yaml
+++ b/samples/subsys/cpu_freq/on_demand/sample.yaml
@@ -16,8 +16,9 @@ tests:
       type: multi_line
       regex:
         - "^.*<inf> cpu_freq_sample: Starting CPU Freq Subsystem Sample!"
-        - "^.*<dbg> cpu_load_metric: cpu_load_get: CPU[0-9]+ Execution cycles: [0-9]+, Total cycles: [0-9]+"
-        - "^.*<dbg> cpu_freq_policy_on_demand: cpu_freq_policy_select_pstate: Current CPU Load: \
-           [0-9]+%"
+        - "^.*<dbg> cpu_load_metric: cpu_load_get: CPU[0-9]+ Execution cycles: \
+           [0-9]+, Total cycles: [0-9]+"
+        - "^.*<dbg> cpu_freq_policy_on_demand: cpu_freq_policy_select_pstate: \
+           CPU[0-9]+ Load: [0-9]+%"
         - "^.*<dbg> cpu_freq_policy_on_demand: cpu_freq_policy_select_pstate: On-Demand Policy: \
            Selected P-state [0-9]+ with load_threshold=[0-9]+%"

--- a/samples/subsys/cpu_freq/on_demand/sample.yaml
+++ b/samples/subsys/cpu_freq/on_demand/sample.yaml
@@ -2,23 +2,36 @@ sample:
   description: CPU frequency scaling sample
   name: CPU Freq Sample
 common:
-  integration_platforms:
-    - native_sim
-    - native_sim/native/64
   tags: cpu_freq
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+      - "^.*<inf> cpu_freq_sample: Starting CPU Freq Subsystem Sample!"
+      - "^.*<dbg> cpu_load_metric: cpu_load_get: CPU[0-9]+ Execution cycles: \
+         [0-9]+, Total cycles: [0-9]+"
+      - "^.*<dbg> cpu_freq_policy_on_demand: cpu_freq_policy_select_pstate: \
+         CPU[0-9]+ Load: [0-9]+%"
+      - "^.*<dbg> cpu_freq_policy_on_demand: cpu_freq_policy_select_pstate: On-Demand Policy: \
+         Selected P-state [0-9]+ with load_threshold=[0-9]+%"
+
 tests:
-  sample.cpu_freq:
+  sample.cpu_freq.soc:
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64
     platform_allow:
       - native_sim
       - native_sim/native/64
-    harness: console
-    harness_config:
-      type: multi_line
-      regex:
-        - "^.*<inf> cpu_freq_sample: Starting CPU Freq Subsystem Sample!"
-        - "^.*<dbg> cpu_load_metric: cpu_load_get: CPU[0-9]+ Execution cycles: \
-           [0-9]+, Total cycles: [0-9]+"
-        - "^.*<dbg> cpu_freq_policy_on_demand: cpu_freq_policy_select_pstate: \
-           CPU[0-9]+ Load: [0-9]+%"
-        - "^.*<dbg> cpu_freq_policy_on_demand: cpu_freq_policy_select_pstate: On-Demand Policy: \
-           Selected P-state [0-9]+ with load_threshold=[0-9]+%"
+
+  sample.cpu_freq.stub:
+    integration_platforms:
+      - qemu_cortex_a53/qemu_cortex_a53/smp
+      - qemu_x86
+    platform_allow:
+      - qemu_cortex_a53/qemu_cortex_a53/smp
+      - qemu_x86
+    extra_dtc_overlay_files:
+      - pstate-stub.overlay
+    extra_configs:
+      - CONFIG_CPU_FREQ_PSTATE_SET_STUB=y

--- a/samples/subsys/cpu_freq/on_demand/sample.yaml
+++ b/samples/subsys/cpu_freq/on_demand/sample.yaml
@@ -16,7 +16,7 @@ tests:
       type: multi_line
       regex:
         - "^.*<inf> cpu_freq_sample: Starting CPU Freq Subsystem Sample!"
-        - "^.*<dbg> cpu_load_metric: cpu_load_get: Execution cycles: [0-9]+, Total cycles: [0-9]+"
+        - "^.*<dbg> cpu_load_metric: cpu_load_get: CPU[0-9]+ Execution cycles: [0-9]+, Total cycles: [0-9]+"
         - "^.*<dbg> cpu_freq_policy_on_demand: cpu_freq_policy_select_pstate: Current CPU Load: \
            [0-9]+%"
         - "^.*<dbg> cpu_freq_policy_on_demand: cpu_freq_policy_select_pstate: On-Demand Policy: \

--- a/soc/native/inf_clock/CMakeLists.txt
+++ b/soc/native/inf_clock/CMakeLists.txt
@@ -18,4 +18,4 @@ zephyr_library_include_directories(
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/posix/linker.ld CACHE INTERNAL "")
 
-zephyr_library_sources_ifdef(CONFIG_CPU_FREQ cpu_freq.c)
+zephyr_library_sources_ifdef(CONFIG_CPU_FREQ_PSTATE_SET_SOC cpu_freq.c)

--- a/soc/native/inf_clock/cpu_freq.c
+++ b/soc/native/inf_clock/cpu_freq.c
@@ -19,26 +19,26 @@ struct native_sim_config {
 int cpu_freq_pstate_set(const struct pstate *state)
 {
 	if (state == NULL) {
-		LOG_ERR("pstate is NULL");
+		LOG_ERR("SoC pstate is NULL");
 		return -EINVAL;
 	}
 
 	int state_id = ((const struct native_sim_config *)state->config)->state_id;
 
-	LOG_DBG("Setting performance state: %d", state_id);
+	LOG_DBG("SoC setting performance state: %d", state_id);
 
 	switch (state_id) {
 	case 0:
-		LOG_DBG("Setting P-state 0: Nominal Mode");
+		LOG_DBG("SoC setting P-state 0: Nominal Mode");
 		break;
 	case 1:
-		LOG_DBG("Setting P-state 1: Low Power Mode");
+		LOG_DBG("SoC setting P-state 1: Low Power Mode");
 		break;
 	case 2:
-		LOG_DBG("Setting P-state 2: Ultra-low Power Mode");
+		LOG_DBG("SoC setting P-state 2: Ultra-low Power Mode");
 		break;
 	default:
-		LOG_ERR("Unsupported P-state: %d", state_id);
+		LOG_ERR("SoC unsupported P-state: %d", state_id);
 		return -1;
 	}
 

--- a/subsys/cpu_freq/CMakeLists.txt
+++ b/subsys/cpu_freq/CMakeLists.txt
@@ -13,3 +13,4 @@ if(CONFIG_CPU_FREQ_POLICY_NONE)
 endif()
 
 zephyr_sources_ifdef(CONFIG_CPU_FREQ_POLICY_ON_DEMAND policies/on_demand/on_demand.c)
+zephyr_sources_ifdef(CONFIG_CPU_FREQ_PSTATE_SET_STUB cpu_freq_stub.c)

--- a/subsys/cpu_freq/Kconfig
+++ b/subsys/cpu_freq/Kconfig
@@ -4,12 +4,14 @@
 
 config HAS_CPU_FREQ
 	bool
+	help
+	  Enabled by the SoC if it has a DTS property indicating support for
+	  CPU frequency scaling.
 
 menuconfig CPU_FREQ
 	bool "CPU Frequency Scaling Subsystem"
 	select EXPERIMENTAL
 	depends on !SMP
-	depends on HAS_CPU_FREQ
 	help
 	  CPU Frequency scaling subsystem
 
@@ -42,5 +44,36 @@ config CPU_FREQ_POLICY_ON_DEMAND
 	select CPU_LOAD_METRIC
 
 endchoice # CPU_FREQ_POLICY
+
+choice CPU_FREQ_PSTATE_SET
+	prompt "Select method of setting CPU P-state"
+	default CPU_FREQ_PSTATE_SET_SOC if HAS_CPU_FREQ
+	default CPU_FREQ_PSTATE_SET_STUB
+	help
+	  The implementation used to set the CPU P-state.
+
+config CPU_FREQ_PSTATE_SET_STUB
+	bool "Stub P-state setter"
+	help
+	  A stub implementation that does nothing. This is useful for
+	  exercising the CPU frequency subsystem without actually
+	  changing the CPU frequency.
+
+config CPU_FREQ_PSTATE_SET_SOC
+	bool "SoC-specific P-state setter"
+	depends on HAS_CPU_FREQ
+	help
+	  A SoC-specific implementation that sets the CPU P-state using
+	  SoC-specific mechanisms. This requires the SoC to provide
+	  the necessary implementation of cpu_freq_pstate_set().
+
+config CPU_FREQ_PSTATE_SET_CUSTOM
+	bool "Custom P-state setter defined by the project"
+	help
+	  A custom implementation that sets the CPU P-state using
+	  project-specific mechanisms. This requires the project to provide
+	  the necessary implementation of cpu_freq_pstate_set().
+
+endchoice # CPU_FREQ_PSTATE_SET
 
 endif # CPU_FREQ

--- a/subsys/cpu_freq/Kconfig
+++ b/subsys/cpu_freq/Kconfig
@@ -11,7 +11,6 @@ config HAS_CPU_FREQ
 menuconfig CPU_FREQ
 	bool "CPU Frequency Scaling Subsystem"
 	select EXPERIMENTAL
-	depends on !SMP
 	help
 	  CPU Frequency scaling subsystem
 
@@ -27,6 +26,15 @@ config CPU_FREQ_INTERVAL_MS
 	help
 	  Controls the interval (in milliseconds) at which the CPU Frequency
 	  subsystem runs and evaluates the current policy.
+
+config CPU_FREQ_PER_CPU_SCALING
+	bool "Per-CPU frequency scaling"
+	default n
+	depends on SMP
+	help
+	  Enable per-CPU frequency scaling support. If disabled, setting the
+	  P-state will apply to the whole system instead of just the current CPU.
+	  This should be done at the SoC level.
 
 choice CPU_FREQ_POLICY
 	prompt "CPU Frequency Scaling Policy"

--- a/subsys/cpu_freq/cpu_freq.c
+++ b/subsys/cpu_freq/cpu_freq.c
@@ -12,14 +12,16 @@
 
 LOG_MODULE_REGISTER(cpu_freq, CONFIG_CPU_FREQ_LOG_LEVEL);
 
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+
+static struct k_ipi_work cpu_freq_work;
+
+#endif /* CONFIG_SMP && (CONFIG_MP_MAX_NUM_CPUS > 1) */
+
 static void cpu_freq_timer_handler(struct k_timer *timer);
 K_TIMER_DEFINE(cpu_freq_timer, cpu_freq_timer_handler, NULL);
 
-/*
- * Timer that expires periodically to execute the selected policy algorithm
- * and pass the next P-state to the P-state driver.
- */
-static void cpu_freq_timer_handler(struct k_timer *timer)
+static void cpu_freq_next_pstate(void)
 {
 	int ret;
 
@@ -34,16 +36,74 @@ static void cpu_freq_timer_handler(struct k_timer *timer)
 		return;
 	}
 
-	/* Set performance state using pstate driver */
-	ret = cpu_freq_policy_pstate_set(pstate_next);
-	if (ret) {
-		LOG_ERR("Failed to set performance state: %d", ret);
+	cpu_freq_policy_pstate_set(pstate_next);
+}
+
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+static void cpu_freq_ipi_handler(struct k_ipi_work *work)
+{
+	ARG_UNUSED(work);
+
+	cpu_freq_next_pstate();
+}
+#endif
+
+/*
+ * Timer that expires periodically to execute the selected policy algorithm
+ * and pass the next P-state to the P-state driver.
+ */
+static void cpu_freq_timer_handler(struct k_timer *timer)
+{
+	ARG_UNUSED(timer);
+
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+	uint32_t num_cpus = arch_num_cpus();
+	uint32_t target_cpus;
+	int ret;
+
+	__ASSERT(num_cpus <= 32U, "Too many CPUs");
+
+	/*
+	 * Create a bitmask identifying all the CPUs except the current CPU.
+	 * A special case is required for 32 CPUs since shifting a 32-bit
+	 * integer left by 32 bits is undefined behavior.
+	 */
+
+	target_cpus = (num_cpus == 32U) ? 0xFFFFFFFF : (1U << num_cpus) - 1U;
+	target_cpus ^= (1U << _current_cpu->id),
+
+	ret = k_ipi_work_add(&cpu_freq_work,
+			     target_cpus ^ (1U << _current_cpu->id),
+			     cpu_freq_ipi_handler);
+
+	if (ret != 0) {
+		/*
+		 * The previous CPU frequency work item has yet to finish
+		 * processing. Either one or more of the previously target CPUs
+		 * has been too busy to process it, and/or the CPU frequency
+		 * policy algorithm is taking too long to complete. Log the
+		 * error and try again on the next timer expiration.
+		 */
+
+		LOG_ERR("Failed to add IPI work: %d", ret);
+
 		return;
 	}
+	cpu_freq_policy_reset();
+
+	k_ipi_work_signal();
+#else
+	cpu_freq_policy_reset();
+#endif
+
+	cpu_freq_next_pstate();
 }
 
 static int cpu_freq_init(void)
 {
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+	k_ipi_work_init(&cpu_freq_work);
+#endif
 	k_timer_start(&cpu_freq_timer, K_MSEC(CONFIG_CPU_FREQ_INTERVAL_MS),
 		      K_MSEC(CONFIG_CPU_FREQ_INTERVAL_MS));
 	LOG_INF("CPU frequency subsystem initialized with interval %d ms",

--- a/subsys/cpu_freq/cpu_freq.c
+++ b/subsys/cpu_freq/cpu_freq.c
@@ -26,6 +26,8 @@ static void cpu_freq_timer_handler(struct k_timer *timer)
 	/* Get next performance state */
 	const struct pstate *pstate_next;
 
+	cpu_freq_policy_reset();
+
 	ret = cpu_freq_policy_select_pstate(&pstate_next);
 	if (ret) {
 		LOG_ERR("Failed to get pstate: %d", ret);
@@ -33,7 +35,7 @@ static void cpu_freq_timer_handler(struct k_timer *timer)
 	}
 
 	/* Set performance state using pstate driver */
-	ret = cpu_freq_pstate_set(pstate_next);
+	ret = cpu_freq_policy_pstate_set(pstate_next);
 	if (ret) {
 		LOG_ERR("Failed to set performance state: %d", ret);
 		return;

--- a/subsys/cpu_freq/cpu_freq_stub.c
+++ b/subsys/cpu_freq/cpu_freq_stub.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/cpu_freq/cpu_freq.h>
+#include <zephyr/cpu_freq/pstate.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(stub_cpu_freq, CONFIG_CPU_FREQ_LOG_LEVEL);
+
+struct stub_config {
+	int state_id;
+};
+
+int cpu_freq_pstate_set(const struct pstate *state)
+{
+	if (state == NULL) {
+		LOG_ERR("Stub pstate is NULL");
+		return -EINVAL;
+	}
+
+	int state_id = ((const struct stub_config *)state->config)->state_id;
+
+	LOG_DBG("Stub setting performance state: %d", state_id);
+
+	switch (state_id) {
+	case 0:
+		LOG_DBG("Stub setting P-state 0: Nominal Mode\n");
+		break;
+	case 1:
+		LOG_DBG("Stub setting P-state 1: Low Power Mode\n");
+		break;
+	case 2:
+		LOG_DBG("Stub setting P-state 2: Ultra-low Power Mode\n");
+		break;
+	default:
+		LOG_ERR("Stub unsupported P-state: %d", state_id);
+		return -1;
+	}
+
+	return 0;
+}
+
+#define DEFINE_STUB_CONFIG(node_id)                             \
+	static const struct stub_config                         \
+		_CONCAT(stub_config_, node_id) = {              \
+		.state_id = DT_PROP(node_id, pstate_id),        \
+	};                                                      \
+	PSTATE_DT_DEFINE(node_id, &_CONCAT(stub_config_, node_id))
+
+DT_FOREACH_CHILD_STATUS_OKAY(DT_PATH(performance_states), DEFINE_STUB_CONFIG)

--- a/subsys/cpu_freq/policies/on_demand/on_demand.c
+++ b/subsys/cpu_freq/policies/on_demand/on_demand.c
@@ -16,6 +16,23 @@ const struct pstate *soc_pstates[] = {
 	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(performance_states), PSTATE_DT_GET, (,))
 };
 
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1) && \
+	!defined(CONFIG_CPU_FREQ_PER_CPU_SCALING)
+
+/*
+ * IPI tracking is needed on SMP systems where all CPUs share the same
+ * frequency. The last CPU to call cpu_freq_best_pstate() sets the best
+ * P-state for all CPUs.
+ */
+
+#define CPU_FREQ_IPI_TRACKING
+
+static struct k_spinlock lock;
+static const struct pstate *pstate_best;
+static unsigned int num_unprocessed_cpus;
+
+#endif /* CONFIG_SMP && (CONFIG_MP_MAX_NUM_CPUS > 1) && !CONFIG_CPU_FREQ_PER_CPU_SCALING */
+
 /*
  * On-demand policy scans the list of P-states from the devicetree and selects the
  * first P-state where the cpu_load is greater than or equal to the trigger threshold
@@ -24,30 +41,38 @@ const struct pstate *soc_pstates[] = {
 int cpu_freq_policy_select_pstate(const struct pstate **pstate_out)
 {
 	int cpu_load;
+	int cpu_id = 0;
 
 	if (pstate_out == NULL) {
 		LOG_ERR("On-Demand Policy: pstate_out is NULL");
 		return -EINVAL;
 	}
 
-	cpu_load = cpu_load_get(0);
+#if defined(CONFIG_SMP)
+	/* The caller has already ensured that the CPU is fixed */
+	cpu_id = arch_curr_cpu()->id;
+#endif
+
+	cpu_load = cpu_load_get(cpu_id);
 	if (cpu_load < 0) {
 		LOG_ERR("Unable to retrieve CPU load");
 		return cpu_load;
 	}
 
-	LOG_DBG("Current CPU Load: %d%%", cpu_load);
+	LOG_DBG("CPU%d Load: %d%%", cpu_id, cpu_load);
 
 	for (int i = 0; i < ARRAY_SIZE(soc_pstates); i++) {
 		const struct pstate *state = soc_pstates[i];
 
 		if (cpu_load >= state->load_threshold) {
 			*pstate_out = state;
-			LOG_DBG("On-Demand Policy: Selected P-state %d with load_threshold=%d%%", i,
+			LOG_DBG("On-Demand Policy: Selected P-state "
+				"%d with load_threshold=%d%%", i,
 				state->load_threshold);
 			return 0;
 		}
 	}
+
 
 	LOG_ERR("On-Demand Policy: No suitable P-state found for CPU load %d%%", cpu_load);
 
@@ -56,18 +81,45 @@ int cpu_freq_policy_select_pstate(const struct pstate **pstate_out)
 
 void cpu_freq_policy_reset(void)
 {
-	/* No state to reset for on-demand policy */
+#ifdef CPU_FREQ_IPI_TRACKING
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	pstate_best = NULL;
+	num_unprocessed_cpus = arch_num_cpus();
+
+	k_spin_unlock(&lock, key);
+#endif
 }
 
 const struct pstate *cpu_freq_policy_pstate_set(const struct pstate *state)
 {
 	int rv;
 
-	rv = cpu_freq_pstate_set(pstate);
+
+#ifdef CPU_FREQ_IPI_TRACKING
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	if ((pstate_best == NULL) ||
+	    (state->load_threshold > pstate_best->load_threshold)) {
+		pstate_best = state;
+	}
+
+	__ASSERT(num_unprocessed_cpus != 0U, "cpu_freq: Out of sync");
+
+	num_unprocessed_cpus--;
+	if (num_unprocessed_cpus > 0) {
+		k_spin_unlock(&lock, key);
+		return NULL;
+	}
+	state = pstate_best;
+	k_spin_unlock(&lock, key);
+#endif
+
+	rv = cpu_freq_pstate_set(state);
 	if (rv != 0) {
 		LOG_ERR("Failed to set P-state: %d", rv);
 		return NULL;
 	}
 
-	return pstate;
+	return state;
 }

--- a/subsys/cpu_freq/policies/on_demand/on_demand.c
+++ b/subsys/cpu_freq/policies/on_demand/on_demand.c
@@ -53,3 +53,21 @@ int cpu_freq_policy_select_pstate(const struct pstate **pstate_out)
 
 	return -ENOTSUP;
 }
+
+void cpu_freq_policy_reset(void)
+{
+	/* No state to reset for on-demand policy */
+}
+
+const struct pstate *cpu_freq_policy_pstate_set(const struct pstate *state)
+{
+	int rv;
+
+	rv = cpu_freq_pstate_set(pstate);
+	if (rv != 0) {
+		LOG_ERR("Failed to set P-state: %d", rv);
+		return NULL;
+	}
+
+	return pstate;
+}

--- a/tests/subsys/cpu_freq/cpu_freq_soc/README.txt
+++ b/tests/subsys/cpu_freq/cpu_freq_soc/README.txt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+Not all platforms have an SoC defined pstate node in their device tree.
+For those that wish to use the pstate driver on such platforms, a stub overlay
+name 'pstate-sub.overlay' is provided for convenience. To use this overlay,
+enable CONFIG_CPU_FREQ_PSTATE_SET_STUB in the prj.conf and use the following
+command to build your project.
+
+west build -b <board> -- -DDTC_OVERLAY_FILE=pstate-stub.overlay

--- a/tests/subsys/cpu_freq/cpu_freq_soc/prj.conf
+++ b/tests/subsys/cpu_freq/cpu_freq_soc/prj.conf
@@ -10,3 +10,6 @@ CONFIG_CPU_FREQ_LOG_LEVEL_DBG=y
 CONFIG_CPU_FREQ_POLICY_ON_DEMAND=y
 # Long interval so test can run without automatic frequency changes
 CONFIG_CPU_FREQ_INTERVAL_MS=1000000
+
+# To use the stub pstate driver, uncomment the following line:
+# CONFIG_CPU_FREQ_PSTATE_SET_STUB=y

--- a/tests/subsys/cpu_freq/cpu_freq_soc/pstate-stub.overlay
+++ b/tests/subsys/cpu_freq/cpu_freq_soc/pstate-stub.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	performance-states {
+		pstate_0: pstate_0 {
+			compatible = "zephyr,generic-pstate";
+			load-threshold = <50>;
+			pstate-id = <0>;
+		};
+		pstate_1: pstate_1 {
+			compatible = "zephyr,generic-pstate";
+			load-threshold = <20>;
+			pstate-id = <1>;
+		};
+		pstate_2: pstate_2 {
+			compatible = "zephyr,generic-pstate";
+			load-threshold = <0>;
+			pstate-id = <2>;
+		};
+	};
+};

--- a/tests/subsys/cpu_freq/cpu_freq_soc/src/main.c
+++ b/tests/subsys/cpu_freq/cpu_freq_soc/src/main.c
@@ -22,9 +22,9 @@ ZTEST(cpu_freq_soc, test_soc_pstates)
 {
 	int ret;
 
-	zassert_true(ARRAY_SIZE(soc_pstates_dt) > 0, "No p-states defined in devicetree");
+	zassert_true(ARRAY_SIZE(soc_pstates_dt) > 0, "No P-states defined in devicetree");
 
-	LOG_INF("%d p-states defined for %s", ARRAY_SIZE(soc_pstates_dt), CONFIG_BOARD_TARGET);
+	LOG_INF("%d P-states defined for %s", ARRAY_SIZE(soc_pstates_dt), CONFIG_BOARD_TARGET);
 
 	zassert_equal(cpu_freq_pstate_set(NULL), -EINVAL, "Expected -EINVAL for NULL pstate");
 
@@ -33,7 +33,7 @@ ZTEST(cpu_freq_soc, test_soc_pstates)
 
 		/* Set performance state using pstate driver */
 		ret = cpu_freq_pstate_set(state);
-		zassert_equal(ret, 0, "Failed to set p-state %d", i);
+		zassert_equal(ret, 0, "Failed to set P-state %d", i);
 	}
 }
 

--- a/tests/subsys/cpu_freq/cpu_freq_soc/src/main.c
+++ b/tests/subsys/cpu_freq/cpu_freq_soc/src/main.c
@@ -10,10 +10,41 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/cpu_freq/cpu_freq.h>
 
+#define NUM_THREADS (2 * (CONFIG_MP_MAX_NUM_CPUS - 1))
+
 LOG_MODULE_REGISTER(cpu_freq_soc_test, LOG_LEVEL_INF);
 
 const struct pstate *soc_pstates_dt[] = {
 	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(performance_states), PSTATE_DT_GET, (,))};
+
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+static K_THREAD_STACK_ARRAY_DEFINE(busy_thread_stacks, NUM_THREADS, 1024);
+static struct k_thread busy_threads[NUM_THREADS];
+static struct k_sem busy_thread_sem[NUM_THREADS];
+
+/**
+ * For each extra CPU, two threads are created that ping-pong giving and taking
+ * semaphores. Not only does this keep the CPUs busy, it generates scheduling
+ * point IPIs which can be used to validate a test environment assumption--
+ * that the current schedule lock will be respected.
+ */
+static void give_take_helper(void *p1, void *p2, void *p3)
+{
+	int order = (int)(intptr_t)p1;
+	struct k_sem *sem1 = (struct k_sem *)p2;
+	struct k_sem *sem2 = (struct k_sem *)p3;
+
+	while (1) {
+		if ((order & 1) == 0) {
+			k_sem_give(sem1);
+			k_sem_take(sem2, K_FOREVER);
+		} else {
+			k_sem_give(sem2);
+			k_sem_take(sem1, K_FOREVER);
+		}
+	}
+}
+#endif
 
 /*
  * Test SoC integration of CPU Freq
@@ -21,20 +52,86 @@ const struct pstate *soc_pstates_dt[] = {
 ZTEST(cpu_freq_soc, test_soc_pstates)
 {
 	int ret;
+	int i;
 
 	zassert_true(ARRAY_SIZE(soc_pstates_dt) > 0, "No P-states defined in devicetree");
 
-	LOG_INF("%d P-states defined for %s", ARRAY_SIZE(soc_pstates_dt), CONFIG_BOARD_TARGET);
+	LOG_INF("%zu P-states defined for %s", ARRAY_SIZE(soc_pstates_dt), CONFIG_BOARD_TARGET);
 
 	zassert_equal(cpu_freq_pstate_set(NULL), -EINVAL, "Expected -EINVAL for NULL pstate");
 
-	for (int i = 0; i < ARRAY_SIZE(soc_pstates_dt); i++) {
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+	int priority;
+	unsigned int id1;
+	unsigned int id2;
+
+	priority = k_thread_priority_get(k_current_get());
+
+	for (i = 0; i < NUM_THREADS; i++) {
+		k_sem_init(&busy_thread_sem[i], 0, 1);
+	}
+
+	for (i = 0; i < NUM_THREADS; i++) {
+		k_thread_create(&busy_threads[i], busy_thread_stacks[i],
+				K_THREAD_STACK_SIZEOF(busy_thread_stacks[i]),
+				(k_thread_entry_t)give_take_helper,
+				(void *)(intptr_t)i,
+				&busy_thread_sem[i / 2],
+				&busy_thread_sem[1 + (i / 2)],
+				priority, 0, K_NO_WAIT);
+	}
+#endif
+
+	for (i = 0; i < ARRAY_SIZE(soc_pstates_dt); i++) {
 		const struct pstate *state = soc_pstates_dt[i];
+
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+		/*
+		 * Lock the scheduler to ensure that the current thread
+		 * does not migrate to another CPU.
+		 */
+		k_sched_lock();
+
+		id1 = arch_curr_cpu()->id;
+
+		/*
+		 * Validate the assumption that the current thread does not
+		 * migrate across CPUs before calling cpu_freq_pstate_set().
+		 */
+
+		for (int j = 0; j < 10; j++) {
+			k_busy_wait(10000);
+			id2 = arch_curr_cpu()->id;
+			zassert_equal(id1, id2,
+				      "Current CPU changed while scheduler locked");
+		}
+#endif
 
 		/* Set performance state using pstate driver */
 		ret = cpu_freq_pstate_set(state);
+
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+		/*
+		 * Validate the assumption that the current thread does not
+		 * migrate after calling cpu_freq_pstate_set().
+		 */
+		for (int j = 0; j < 10; j++) {
+			k_busy_wait(10000);
+			id2 = arch_curr_cpu()->id;
+			zassert_equal(id1, id2,
+				      "Current CPU changed while scheduler locked");
+		}
+
+		k_sched_unlock();
+#endif
 		zassert_equal(ret, 0, "Failed to set P-state %d", i);
 	}
+
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+	for (i = 0; i < NUM_THREADS; i++) {
+		k_thread_abort(&busy_threads[i]);
+	}
+#endif
 }
 
 ZTEST_SUITE(cpu_freq_soc, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/cpu_freq/cpu_freq_soc/testcase.yaml
+++ b/tests/subsys/cpu_freq/cpu_freq_soc/testcase.yaml
@@ -1,9 +1,23 @@
+common:
+  tags: cpu_freq
+
 tests:
+  # Use the SoC version of cpu_freq_pstate_set()
   subsys.cpu_freq.soc:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    tags: cpu_freq
     integration_platforms:
       - native_sim
       - native_sim/native/64
+
+  # Use the stub version of cpu_freq_pstate_set()
+  subsys.cpu_freq.stub:
+    extra_dtc_overlay_files:
+      - pstate-stub.overlay
+    platform_allow:
+      - qemu_cortex_a53/qemu_cortex_a53/smp
+    integration_platforms:
+      - qemu_cortex_a53/qemu_cortex_a53/smp
+    extra_configs:
+      - CONFIG_CPU_FREQ_PSTATE_SET_STUB=y

--- a/tests/subsys/cpu_freq/policies/on_demand/README.txt
+++ b/tests/subsys/cpu_freq/policies/on_demand/README.txt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+Not all platforms have an SoC defined pstate node in their device tree.
+For those that wish to use the pstate driver on such platforms, a stub overlay
+name 'pstate-sub.overlay' is provided for convenience. To use this overlay,
+enable CONFIG_CPU_FREQ_PSTATE_SET_STUB in the prj.conf and use the following
+command to build your project.
+
+west build -b <board> -- -DDTC_OVERLAY_FILE=pstate-stub.overlay

--- a/tests/subsys/cpu_freq/policies/on_demand/pstate-stub.overlay
+++ b/tests/subsys/cpu_freq/policies/on_demand/pstate-stub.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	performance-states {
+		pstate_0: pstate_0 {
+			compatible = "zephyr,generic-pstate";
+			load-threshold = <50>;
+			pstate-id = <0>;
+		};
+		pstate_1: pstate_1 {
+			compatible = "zephyr,generic-pstate";
+			load-threshold = <20>;
+			pstate-id = <1>;
+		};
+		pstate_2: pstate_2 {
+			compatible = "zephyr,generic-pstate";
+			load-threshold = <0>;
+			pstate-id = <2>;
+		};
+	};
+};

--- a/tests/subsys/cpu_freq/policies/on_demand/src/main.c
+++ b/tests/subsys/cpu_freq/policies/on_demand/src/main.c
@@ -27,20 +27,38 @@ ZTEST(cpu_freq_on_demand, test_pstates)
 	zassert_equal(cpu_freq_policy_select_pstate(NULL), -EINVAL,
 		      "Expected -EINVAL for NULL pstate_out");
 
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+	k_sched_lock();  /* Lock scheduler to prevent thread migration */
+#endif
+
 	/* Simulate high-load and get pstate */
 	k_busy_wait(WAIT_US);
 
 	/* Get pstate after a moment of high-load */
 	ret = cpu_freq_policy_select_pstate(&test_pstate);
+
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+	k_sched_unlock();
+#endif
+
 	zassert_equal(ret, 0, "Expected success from cpu_freq_policy_select_pstate");
 
 	int prev_threshold = test_pstate->load_threshold;
+
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+	k_sched_lock();
+#endif
 
 	/* Simulate low-load by sleeping, then getting pstate*/
 	k_sleep(K_USEC(WAIT_US));
 
 	/* Get pstate after a moment of low-load between calls to policy */
 	ret = cpu_freq_policy_select_pstate(&test_pstate);
+
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+	k_sched_unlock();
+#endif
+
 	zassert_equal(ret, 0, "Expected success from cpu_freq_policy_select_pstate");
 
 	zassert_not_equal(test_pstate->load_threshold, prev_threshold,

--- a/tests/subsys/cpu_freq/policies/on_demand/src/main.c
+++ b/tests/subsys/cpu_freq/policies/on_demand/src/main.c
@@ -44,7 +44,7 @@ ZTEST(cpu_freq_on_demand, test_pstates)
 	zassert_equal(ret, 0, "Expected success from cpu_freq_policy_select_pstate");
 
 	zassert_not_equal(test_pstate->load_threshold, prev_threshold,
-			  "Expected different p-state after sleep");
+			  "Expected different P-state after sleep");
 }
 
 ZTEST_SUITE(cpu_freq_on_demand, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/cpu_freq/policies/on_demand/testcase.yaml
+++ b/tests/subsys/cpu_freq/policies/on_demand/testcase.yaml
@@ -1,9 +1,23 @@
+common:
+  tags: cpu_freq
+
 tests:
-  subsys.cpu_freq.policies.on_demand:
+  # Use the SoC version of cpu_freq_pstate_set()
+  subsys.cpu_freq.soc.policies.on_demand:
     platform_allow:
       - native_sim
       - native_sim/native/64
-    tags: cpu_freq
     integration_platforms:
       - native_sim
       - native_sim/native/64
+
+  # Use the stub version of cpu_freq_pstate_set()
+  subsys.cpu_freq.stub.policies.on_demand:
+    extra_dtc_overlay_files:
+      - pstate-stub.overlay
+    platform_allow:
+      - qemu_cortex_a53/qemu_cortex_a53/smp
+    integration_platforms:
+      - qemu_cortex_a53/qemu_cortex_a53/smp
+    extra_configs:
+      - CONFIG_CPU_FREQ_PSTATE_SET_STUB=y


### PR DESCRIPTION
This set of commits extends the CPU frequency scaling to support SMP.

It extends the k_timer handler used to select the next p-state to send an IPI to each of the other CPUs/cores so that they can participate in setting the next p-state. This extension supports two models.

Model 1 -- each CPU may set its p-state independently of the others
Model 2 -- the system sets the next p-state to meet the needs of the CPU with the highest load.

Edit:
This also makes a (hopefully) minor tweaks to how the cpu_freq subsystem can be used.
A. The developer can choose which version of cpu_freq_pstate_set() to use ...
      A.1. A stubbed version (useful for testing, proof-of-concepts, ...)
      A.2. The version defined by the SoC (if it exists)
      A.3. A special custom version defined by the project (again useful for development)
B. A generic pstate DTS that multiple boards/platforms can leverage for proof-of-concepts, testing, ...