### PR TITLE
ci: Fix various maintainer file check bugs

### DIFF
--- a/.github/workflows/maintainer_check.yml
+++ b/.github/workflows/maintainer_check.yml
@@ -30,14 +30,14 @@ jobs:
         run: |
           pip install -r scripts/requirements-actions.txt --require-hashes
 
-      - name: Fetch MAINTAINERS.yml from mainline
+      - name: Fetch MAINTAINERS.yml from pull request
         run: |
-          git fetch origin main
-          git show origin/main:MAINTAINERS.yml > mainline_MAINTAINERS.yml
+          git fetch origin pull/${{ github.event.pull_request.number }}/head
+          git show FETCH_HEAD:MAINTAINERS.yml > pr_MAINTAINERS.yml
 
       - name: Check maintainer file changes
         env:
           GITHUB_TOKEN: ${{ secrets.ZB_PR_ASSIGNER_GITHUB_TOKEN }}
         run: |
           python  ./scripts/ci/check_maintainer_changes.py  \
-            --repo zephyrproject-rtos/zephyr mainline_MAINTAINERS.yml MAINTAINERS.yml
+            --repo zephyrproject-rtos/zephyr MAINTAINERS.yml pr_MAINTAINERS.yml

--- a/scripts/ci/check_maintainer_changes.py
+++ b/scripts/ci/check_maintainer_changes.py
@@ -30,8 +30,8 @@ def check_github_access(usernames, repo_fullname, token):
     missing_access = set()
     for username in usernames:
         try:
-            collab = repo.get_collaborator_permission(username)
-            # Permissions: admin, maintain, write, triage, read
+            collab = repo.get_collaborator_role_name(username)
+            # Roles: admin, maintain, write, triage, read
             if collab not in ("admin", "maintain", "write", "triage"):
                 missing_access.add(username)
         except Exception:

--- a/scripts/requirements-actions.in
+++ b/scripts/requirements-actions.in
@@ -17,7 +17,7 @@ natsort
 ply>=3.10
 psutil>=5.6.6
 pyelftools>=0.29
-pygithub
+pygithub>=2.7.0
 pykwalify
 pylint>=3
 pyserial

--- a/scripts/requirements-actions.txt
+++ b/scripts/requirements-actions.txt
@@ -302,10 +302,6 @@ cryptography==45.0.5 \
     --hash=sha256:e74d30ec9c7cb2f404af331d5b4099a9b322a8a6b25c4632755c8757345baac5 \
     --hash=sha256:f3562c2f23c612f2e4a6964a61d942f891d29ee320edb62ff48ffb99f3de9ae8
     # via pyjwt
-deprecated==1.2.18 \
-    --hash=sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d \
-    --hash=sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec
-    # via pygithub
 dill==0.4.0 \
     --hash=sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0 \
     --hash=sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049
@@ -816,9 +812,9 @@ pyelftools==0.32 \
     --hash=sha256:013df952a006db5e138b1edf6d8a68ecc50630adbd0d83a2d41e7f846163d738 \
     --hash=sha256:6de90ee7b8263e740c8715a925382d4099b354f29ac48ea40d840cf7aa14ace5
     # via -r requirements-actions.in
-pygithub==2.6.1 \
-    --hash=sha256:6f2fa6d076ccae475f9fc392cc6cdbd54db985d4f69b8833a28397de75ed6ca3 \
-    --hash=sha256:b5c035392991cca63959e9453286b41b54d83bf2de2daa7d7ff7e4312cebf3bf
+pygithub==2.8.1 \
+    --hash=sha256:23a0a5bca93baef082e03411bf0ce27204c32be8bfa7abc92fe4a3e132936df0 \
+    --hash=sha256:341b7c78521cb07324ff670afd1baa2bf5c286f8d9fd302c1798ba594a5400c9
     # via -r requirements-actions.in
 pygments==2.19.2 \
     --hash=sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887 \
@@ -1344,9 +1340,7 @@ wrapt==1.17.2 \
     --hash=sha256:f917c1180fdb8623c2b75a99192f4025e412597c50b2ac870f156de8fb101119 \
     --hash=sha256:fc78a84e2dfbc27afe4b2bd7c80c8db9bca75cc5b85df52bfe634596a1da846b \
     --hash=sha256:ff04ef6eec3eee8a5efef2401495967a916feaa353643defcc03fc74fe213b58
-    # via
-    #   deprecated
-    #   python-can
+    # via python-can
 xlsxwriter==3.2.5 \
     --hash=sha256:4f4824234e1eaf9d95df9a8fe974585ff91d0f5e3d3f12ace5b71e443c1c6abd \
     --hash=sha256:7e88469d607cdc920151c0ab3ce9cf1a83992d4b7bc730c5ffdd1a12115a7dbe


### PR DESCRIPTION
This series includes two major bug fixes for the maintainer file check CI workflow and script:

```
ci: maintainer_check: Check out PR MAINTAINERS file

The commit 31ef45e2f11543a07773fd0e802efe2409da9638 converted the
maintainer check workflow from `pull_request` to `pull_request_target` --
this caused the "checkout" action to check out the base branch instead of
the pull request branch and effectively made the workflow compare the
mainline MAINTAINERS.yml against itself.

This commit reworks the workflow such that it checks out the pull request
MAINTAINERS.yml separately and compare it against the mainline
MAINTAINERS.yml checked out by the "checkout" action.

Note that the `requirements-actions.txt` and `check_maintainer_changes.py`
files used in this workflow are checked out from the base branch (i.e. does
not contain any modifications) and therefore do not pose a security risk.
```

```
scripts: check_maintainer_changes: Fix GitHub user access check

The PyGithub `Repository.get_collaborator_permission` function invokes the
GitHub REST API `/repos/{owner}/{repo}/collaborators/{username}/permission`
and returns the value of the `permission` attribute in the response.

As per the GitHub documentation [1], the `permission` attribute "provides
the legacy base roles of admin, write, read and none, where the maintain
role is mapped to write and the triage role is mapped to read", and this
caused the users with `triage` permission level (i.e. the users in the
`contributors` team) to be incorrectly flagged by the script.

This commit updates the script to use the `get_collaborator_role_name`
function, which correctly returns the up-to-date user permission/role name,
including `maintain` and `triage`.

Note that the `get_collaborator_role_name` function is only available in
PyGithub>=2.7.0.

[1] https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#get-repository-permissions-for-a-user
```

---

Tested in:

* Adding a user without at least triage permission level: https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/17572093396/job/49910016162?pr=372 
* Adding a user with triage permission level: https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/17572097484/job/49910026500?pr=373