### PR TITLE
boards: frdm_mcxc444: Update TPM clock source

### DIFF
--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
@@ -176,7 +176,7 @@ i2c0: &i2c0 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_tpm0>;
 	pinctrl-names = "default";
-	clocks = <&sim KINETIS_SIM_OSCERCLK 0x103C 24>;
+	clocks = <&sim KINETIS_SIM_MCGPCLK 0x103C 24>;
 };
 
 zephyr_udc0: &usb {


### PR DESCRIPTION
1.Update TPM clock source to MCGPCLK(48MHz).
2.Verified tests/drivers/pwm/pwm_api.

Fixes #95000