### PR TITLE
usb: udc: numaker: support numaker m46x/m55m1x hsusbd

### DIFF
--- a/drivers/usb/udc/Kconfig.numaker
+++ b/drivers/usb/udc/Kconfig.numaker
@@ -31,4 +31,18 @@ config UDC_NUMAKER_THREAD_PRIORITY
 	help
 	  Priority of the driver internal thread.
 
+config UDC_NUMAKER_DMA
+	bool "UDC NuMaker DMA support"
+	default y
+	depends on DT_HAS_NUVOTON_NUMAKER_HSUSBD_ENABLED
+	help
+	  This enables DMA transfer between user buffer and USB buffer.
+
+config UDC_NUMAKER_DMA_TIMEOUT_MS
+	int "UDC NuMaker DMA timeout"
+	default 2000
+	depends on UDC_NUMAKER_DMA
+	help
+	  This configures timeout of DMA transfer in milliseconds.
+
 endif # UDC_NUMAKER

--- a/drivers/usb/udc/Kconfig.numaker
+++ b/drivers/usb/udc/Kconfig.numaker
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config UDC_NUMAKER
-	bool "Nuvoton NuMaker USB 1.1 device controller"
+	bool "Nuvoton NuMaker USB device controller"
 	default y
-	depends on DT_HAS_NUVOTON_NUMAKER_USBD_ENABLED
+	depends on DT_HAS_NUVOTON_NUMAKER_USBD_ENABLED \
+		|| DT_HAS_NUVOTON_NUMAKER_HSUSBD_ENABLED
 	select PINCTRL
+	select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT if DT_HAS_NUVOTON_NUMAKER_HSUSBD_ENABLED
 	help
-	  Enable Nuvoton NuMaker USB 1.1 device controller driver
+	  Enable Nuvoton NuMaker USB device controller driver
 
 if UDC_NUMAKER
 

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -42,6 +42,10 @@ LOG_MODULE_REGISTER(udc_numaker, CONFIG_UDC_DRIVER_LOG_LEVEL);
 #define NUMAKER_USBD_DMABUF_SIZE_CTRLOUT 64
 #define NUMAKER_USBD_DMABUF_SIZE_CTRLIN  64
 
+#if !defined(USBD_ATTR_PWRDN_Msk)
+#define USBD_ATTR_PWRDN_Msk BIT(9)
+#endif
+
 enum numaker_usbd_msg_type {
 	/* Setup packet received */
 	NUMAKER_USBD_MSG_TYPE_SETUP,
@@ -345,8 +349,8 @@ static int numaker_usbd_hw_setup(const struct device *dev)
 	reset_line_toggle_dt(&config->reset);
 
 	/* Initialize USBD engine */
-	/* NOTE: BSP USBD driver: ATTR = 0x7D0 */
-	base->ATTR = USBD_ATTR_BYTEM_Msk | BIT(9) | USBD_ATTR_USBEN_Msk | BIT(6) |
+	/* NOTE: Per USBD spec, BIT(6) is hidden. */
+	base->ATTR = USBD_ATTR_BYTEM_Msk | USBD_ATTR_PWRDN_Msk | USBD_ATTR_USBEN_Msk | BIT(6) |
 		     USBD_ATTR_PHYEN_Msk;
 
 	/* Set SE0 for S/W disconnect */

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -1158,8 +1158,7 @@ static int numaker_usbd_msg_handle_out(const struct device *dev, struct numaker_
 	}
 
 	if (ep == USB_CONTROL_EP_OUT) {
-		__ASSERT_NO_MSG(net_buf_tailroom(buf) >= priv->ctrlout_tailroom);
-		data_len = priv->ctrlout_tailroom;
+		data_len = MIN(net_buf_tailroom(buf), priv->ctrlout_tailroom);
 	} else {
 		data_len = net_buf_tailroom(buf);
 	}
@@ -1172,7 +1171,9 @@ static int numaker_usbd_msg_handle_out(const struct device *dev, struct numaker_
 	}
 
 	if (data_rmn) {
-		LOG_ERR("Buffer queued for ep=0x%02x cannot accommodate packet", ep);
+		LOG_ERR("Buffer (%p) queued for ep=0x%02x cannot accommodate packet", buf, ep);
+		LOG_ERR("net_buf_tailroom(buf)=%d, data_len=%d, data_rmn=%d", net_buf_tailroom(buf),
+			data_len, data_rmn);
 		return -ENOBUFS;
 	}
 

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -1683,7 +1683,12 @@ static int udc_numaker_init(const struct device *dev)
 	/* Enable VBUS detect early */
 	if (data->caps.can_detect_vbus) {
 		base->INTEN = USBD_INT_FLDET;
+	} else {
+		base->INTEN = 0;
 	}
+
+	/* Enable USB wake-up early */
+	base->INTEN |= USBD_INT_WAKEUP;
 
 	return 0;
 }

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -572,7 +572,8 @@ static void numaker_usbd_ep_th(const struct device *dev, uint32_t ep_hw_idx)
 	if (ep == USB_EP_GET_ADDR(0, USB_EP_DIR_OUT)) {
 		struct numaker_usbd_ep *ep_ctrlout = priv->ep_pool + 0;
 
-		ep_ctrlout->mxpld_ctrlout = ep_base->MXPLD;
+		ep_ctrlout->mxpld_ctrlout = (ep_base->MXPLD & USBD_MXPLD_MXPLD_Msk) >>
+					    USBD_MXPLD_MXPLD_Pos;
 	}
 
 	/* Message for bottom-half processing */
@@ -628,7 +629,7 @@ static void numaker_usbd_ep_copy_to_user(struct numaker_usbd_ep *ep_cur, uint8_t
 	if (ep_cur->addr == USB_CONTROL_EP_OUT) {
 		data_rmn = ep_cur->mxpld_ctrlout;
 	} else {
-		data_rmn = ep_base->MXPLD;
+		data_rmn = (ep_base->MXPLD & USBD_MXPLD_MXPLD_Msk) >> USBD_MXPLD_MXPLD_Pos;
 	}
 
 	*size_p = MIN(*size_p, data_rmn);

--- a/dts/arm/nuvoton/m46x.dtsi
+++ b/dts/arm/nuvoton/m46x.dtsi
@@ -615,6 +615,19 @@
 			disallow-iso-in-out-same-number;
 		};
 
+		hsusbd: hsusbd@40019000 {
+			compatible = "nuvoton,numaker-hsusbd";
+			reg = <0x40019000 0x1000>;
+			interrupts = <65 0>;
+			resets = <&rst NUMAKER_HSUSBD_RST>;
+			clocks = <&pcc NUMAKER_HSUSBD_MODULE NUMAKER_MODULE_NoMsk
+				  NUMAKER_MODULE_NoMsk>;
+			dma-buffer-size = <4096>;
+			status = "disabled";
+			/* 2 more for Control OUT/IN */
+			num-bidir-endpoints = <14>;
+		};
+
 		wwdt: watchdog@40040100 {
 			compatible = "nuvoton,numaker-wwdt";
 			reg = <0x40040100 0x10>;

--- a/dts/arm/nuvoton/m55m1x.dtsi
+++ b/dts/arm/nuvoton/m55m1x.dtsi
@@ -475,6 +475,18 @@
 			disallow-iso-in-out-same-number;
 		};
 
+		hsusbd: hsusbd@40205000 {
+			compatible = "nuvoton,numaker-hsusbd";
+			reg = <0x40205000 0x1000>;
+			interrupts = <61 0>;
+			resets = <&rst NUMAKER_SYS_HSUSBD0RST>;
+			clocks = <&pcc NUMAKER_HSUSBD0_MODULE 0 0>;
+			dma-buffer-size = <8192>;
+			status = "disabled";
+			/* 2 more for Control OUT/IN */
+			num-bidir-endpoints = <20>;
+		};
+
 		wwdt: watchdog@40240000 {
 			compatible = "nuvoton,numaker-wwdt";
 			reg = <0x40240000 0x10>;

--- a/dts/bindings/usb/nuvoton,numaker-hsusbd.yaml
+++ b/dts/bindings/usb/nuvoton,numaker-hsusbd.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2022 Nuvoton Technology Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton NuMaker high-speed USB 2.0 device controller
+
+compatible: "nuvoton,numaker-hsusbd"
+
+include: [usb-ep.yaml, reset-device.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  resets:
+    required: true
+
+  clocks:
+    required: true
+
+  dma-buffer-size:
+    type: int
+    required: true
+    description: |
+      Size of DMA buffer in bytes


### PR DESCRIPTION
This adds support for nuvoton numaker high-speed USB 2.0 device (`hsusbd`) and makes some fixes, including:
1. Support m46x/m55m1x `hsusbd`. This re-organizes `udc_numaker.c` to support both `usbd` and `hsusbd` in single file, but they cannot enable simultaneously.
2. Recycle dangling `net_buf` to recover from incomplete control transfer
3. Other fixes on `usbd`