### PR TITLE
net: tcp: Print TCP connection info consistently

### DIFF
--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -139,7 +139,7 @@
 
 #define conn_state(_conn, _s)						\
 ({									\
-	NET_DBG("%s->%s",						\
+	NET_DBG("[%p] %s->%s", _conn,					\
 		tcp_state_to_str((_conn)->state, false),		\
 		tcp_state_to_str((_s), false));				\
 	(_conn)->state = _s;						\
@@ -147,12 +147,12 @@
 
 #define conn_send_data_dump(_conn)                                             \
 	({                                                                     \
-		NET_DBG("conn: %p total=%zd, unacked_len=%d, "                 \
+		NET_DBG("[%p] total=%zd, unacked_len=%d, "		       \
 			"send_win=%hu, mss=%hu",                               \
 			(_conn), net_pkt_get_len((_conn)->send_data),          \
 			_conn->unacked_len, _conn->send_win,                   \
 			(uint16_t)conn_mss((_conn)));                          \
-		NET_DBG("conn: %p send_data_timer=%hu, send_data_retries=%hu", \
+		NET_DBG("[%p] send_data_timer=%hu, send_data_retries=%hu",     \
 			(_conn),                                               \
 			(bool)k_ticks_to_ms_ceil32(                            \
 				k_work_delayable_remaining_get(                \


### PR DESCRIPTION
Print TCP connection pointer value for debug prints consistently so that it is easier to find debug prints that are related to a certain TCP connection.