### PR TITLE
drivers: memc: stm32_xspi_psram: fix command size in x8 mode

### DIFF
--- a/drivers/memc/memc_stm32_xspi_psram.c
+++ b/drivers/memc/memc_stm32_xspi_psram.c
@@ -322,7 +322,8 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 	cmd.AddressMode = HAL_XSPI_ADDRESS_8_LINES;
 	cmd.AddressWidth = HAL_XSPI_ADDRESS_32_BITS;
 	cmd.AddressDTRMode = HAL_XSPI_ADDRESS_DTR_ENABLE;
-	cmd.DataMode = HAL_XSPI_DATA_16_LINES;
+	cmd.DataMode = DT_INST_PROP(0, io_x16_mode) ? HAL_XSPI_DATA_16_LINES
+						    : HAL_XSPI_DATA_8_LINES;
 	cmd.DataDTRMode = HAL_XSPI_DATA_DTR_ENABLE;
 	cmd.DummyCycles = DUMMY_CLK_CYCLES_WRITE;
 	cmd.DQSMode = HAL_XSPI_DQS_ENABLE;


### PR DESCRIPTION
This pull request fixes PSRAM initialization logic in the `memc_stm32_xspi_psram.c` driver for PSRAM in x8 mode by ensuring that the data line mode configuration accurately reflects the `io-x16-mode` property specified in the device tree.
