### PR TITLE
Bluetooth: Host: Add support for user-defined fixed L2CAP channels.

### DIFF
--- a/doc/connectivity/bluetooth/api/l2cap.rst
+++ b/doc/connectivity/bluetooth/api/l2cap.rst
@@ -3,10 +3,44 @@
 Logical Link Control and Adaptation Protocol (L2CAP)
 ####################################################
 
-L2CAP layer enables connection-oriented channels which can be enable with the
-configuration option: :kconfig:option:`CONFIG_BT_L2CAP_DYNAMIC_CHANNEL`. This channels
+L2CAP layer enables connection-oriented channels which can be enabled with the
+configuration option: :kconfig:option:`CONFIG_BT_L2CAP_DYNAMIC_CHANNEL`. These channels
 support segmentation and reassembly transparently, they also support credit
 based flow control making it suitable for data streams.
+
+The user can also define fixed channels using the :c:macro:`BT_L2CAP_FIXED_CHANNEL_DEFINE`
+macro. Fixed channels are initialized upon connection, and do not support segmentation. An example
+of how to define a fixed channel is shown below.
+
+.. code-block:: c
+
+   static struct bt_l2cap_chan fixed_chan[CONFIG_BT_MAX_CONN];
+
+   /* Callbacks are assumed to be defined prior. */
+   static struct bt_l2cap_chan_ops ops = {
+       .recv = recv_cb,
+       .sent = sent_cb,
+       .connected = connected_cb,
+       .disconnected = disconnected_cb,
+   };
+
+   static int l2cap_fixed_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+   {
+       uint8_t conn_index = bt_conn_index(conn);
+
+       *chan = &fixed_chan[conn_index];
+
+       **chan = (struct bt_l2cap_chan){
+           .ops = &ops,
+       };
+
+       return 0;
+   }
+
+   BT_L2CAP_FIXED_CHANNEL_DEFINE(fixed_channel) = {
+       .cid = 0x0010,
+       .accept = l2cap_fixed_accept,
+   };
 
 Channels instances are represented by the :c:struct:`bt_l2cap_chan` struct which
 contains the callbacks in the :c:struct:`bt_l2cap_chan_ops` struct to inform

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3489,7 +3489,10 @@ static int bt_att_accept(struct bt_conn *conn, struct bt_l2cap_chan **ch)
  * placed as the last one to ensure that SMP channel is properly initialized before bt_att_connected
  * tries to send security request.
  */
-BT_L2CAP_CHANNEL_DEFINE(z_att_fixed_chan, BT_L2CAP_CID_ATT, bt_att_accept, NULL);
+BT_L2CAP_FIXED_CHANNEL_DEFINE(z_att_fixed_chan) = {
+	.cid = BT_L2CAP_CID_ATT,
+	.accept = bt_att_accept,
+};
 
 #if defined(CONFIG_BT_EATT)
 static k_timeout_t credit_based_connection_delay(struct bt_conn *conn)

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -26,12 +26,6 @@ enum l2cap_conn_list_action {
 	BT_L2CAP_CHAN_DETACH,
 };
 
-#define BT_L2CAP_CID_BR_SIG             0x0001
-#define BT_L2CAP_CID_ATT                0x0004
-#define BT_L2CAP_CID_LE_SIG             0x0005
-#define BT_L2CAP_CID_SMP                0x0006
-#define BT_L2CAP_CID_BR_SMP             0x0007
-
 #define BT_L2CAP_PSM_RFCOMM             0x0003
 
 struct bt_l2cap_hdr {
@@ -163,19 +157,6 @@ struct bt_l2cap_ecred_reconf_req {
 struct bt_l2cap_ecred_reconf_rsp {
 	uint16_t result;
 } __packed;
-
-struct bt_l2cap_fixed_chan {
-	uint16_t		cid;
-	int (*accept)(struct bt_conn *conn, struct bt_l2cap_chan **chan);
-	bt_l2cap_chan_destroy_t destroy;
-};
-
-#define BT_L2CAP_CHANNEL_DEFINE(_name, _cid, _accept, _destroy)         \
-	const STRUCT_SECTION_ITERABLE(bt_l2cap_fixed_chan, _name) = {   \
-				.cid = _cid,                            \
-				.accept = _accept,                      \
-				.destroy = _destroy,                    \
-			}
 
 /* Notify L2CAP channels of a new connection */
 void bt_l2cap_connected(struct bt_conn *conn);

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -6354,7 +6354,10 @@ static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 	return -ENOMEM;
 }
 
-BT_L2CAP_CHANNEL_DEFINE(smp_fixed_chan, BT_L2CAP_CID_SMP, bt_smp_accept, NULL);
+BT_L2CAP_FIXED_CHANNEL_DEFINE(smp_fixed_chan) = {
+	.cid = BT_L2CAP_CID_SMP,
+	.accept = bt_smp_accept,
+};
 #if defined(CONFIG_BT_CLASSIC)
 BT_L2CAP_BR_CHANNEL_DEFINE(smp_br_fixed_chan, BT_L2CAP_CID_BR_SMP,
 			bt_smp_br_accept);

--- a/subsys/bluetooth/host/smp_null.c
+++ b/subsys/bluetooth/host/smp_null.c
@@ -102,7 +102,10 @@ static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 	return -ENOMEM;
 }
 
-BT_L2CAP_CHANNEL_DEFINE(smp_fixed_chan, BT_L2CAP_CID_SMP, bt_smp_accept, NULL);
+BT_L2CAP_FIXED_CHANNEL_DEFINE(smp_fixed_chan) = {
+	.cid = BT_L2CAP_CID_SMP,
+	.accept = bt_smp_accept,
+};
 
 int bt_smp_init(void)
 {

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/README.rst
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/README.rst
@@ -1,0 +1,32 @@
+.. SPDX-License-Identifier: Apache-2.0
+L2CAP send on connect
+=====================
+
+Purpose
+-------
+This test demonstrates and verifies sending data over L2CAP channels on connection. This is done
+for both dynamic (ECRED and non-ECRED) and fixed channels.
+
+Test procedure
+--------------
+The test procedure is similar for dynamic and fixed channels, the differences being:
+- For dynamic channels, the connection needs to be established by first registering
+  a L2CAP server on the peripheral, then sending a connection request from the central.
+  For fixed channels, the connection is initialized automatically upon connection.
+- The fixed and dynamic channels use separate buffer pools.
+
+1. Central and peripheral initialize BT.
+   Peripheral registers a L2CAP server (Dynamic channels only).
+   Peripheral starts advertising and central starts scanning.
+   Central sends a connection request to the peripheral.
+
+2. Both devices wait for the connected callback.
+
+3. Central sends a channel connect request to the peripheral (Dynamic channels only).
+   On channel connection, both devices will send the same message over the channel,
+   and verify that the sent callback is called.
+
+4. Both devices wait for the data to be received, and verify that the received data
+   is correct.
+
+5. Central disconnects and both devices wait for the disconnected callback.

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests_scripts/send_on_connect_dynamic.sh
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests_scripts/send_on_connect_dynamic.sh
@@ -4,34 +4,34 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="l2cap_send_on_connect"
+simulation_id="l2cap_send_on_connect_dynamic"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_l2cap_send_on_connect_prj_conf \
-    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central
+    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -argstest fixed=0
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_l2cap_send_on_connect_prj_conf \
-    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral
+    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -argstest fixed=0
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=30e6 $@
 
 wait_for_background_jobs
 
-simulation_id="l2cap_send_on_connect_ecred"
+simulation_id="l2cap_send_on_connect_dynamic_ecred"
 
 cd ${BSIM_OUT_PATH}/bin
 
 Execute \
     ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_l2cap_send_on_connect_prj_conf_overlay-ecred_conf \
-    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central
+    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -argstest fixed=0
 
 Execute \
     ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_l2cap_send_on_connect_prj_conf_overlay-ecred_conf \
-    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral
+    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -argstest fixed=0
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=30e6 $@

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests_scripts/send_on_connect_fixed.sh
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests_scripts/send_on_connect_fixed.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+bsim_exe=./bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf
+simulation_id="send_on_connect_fixed"
+verbosity_level=2
+EXECUTE_TIMEOUT=30
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute "${bsim_exe}" \
+    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -argstest fixed=1
+
+Execute "${bsim_exe}" \
+    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -argstest fixed=1
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_length=30e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
Adds support for the user defining their own channels within the
fixed L2CAP channel range.

Adds a bsim test testing sending of data over such a channel.