### PR TITLE
tests: Bluetooth: Tester: Fix storing invalid broadcast ID

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -391,7 +391,7 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len, void *
 	struct bt_audio_codec_cfg codec_cfg;
 	const struct btp_bap_broadcast_source_setup_cmd *cp = cmd;
 	struct btp_bap_broadcast_source_setup_rp *rp = rsp;
-	uint32_t broadcast_id;
+	uint32_t broadcast_id = 0;
 
 	err = bt_rand(&broadcast_id, BT_AUDIO_BROADCAST_ID_SIZE);
 	if (err != 0) {


### PR DESCRIPTION
Broadcast ID is 24bits and uinitialized broadcast_id resulted in (pseudo) random failures since only 3 bytes were set by call to bt_rand().