### PR TITLE
drivers: flash: spi_nor: remove redundant write enable/disable

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1126,7 +1126,6 @@ static int spi_nor_write_protection_set(const struct device *dev,
 					bool write_protect)
 {
 	int ret = 0;
-	const struct spi_nor_config *cfg = dev->config;
 
 #if ANY_INST_HAS_WP_GPIOS
 	if (DEV_CFG(dev)->wp_gpios_exist && !write_protect) {
@@ -1135,7 +1134,7 @@ static int spi_nor_write_protection_set(const struct device *dev,
 #endif
 
 	if (IS_ENABLED(ANY_INST_REQUIRES_ULBPR)
-	    && cfg->requires_ulbpr_exist
+	    && DEV_CFG(dev)->requires_ulbpr_exist
 	    && !write_protect) {
 		ret = spi_nor_cmd_write(dev, SPI_NOR_CMD_ULBPR);
 	}

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1124,7 +1124,7 @@ static int spi_nor_erase(const struct device *dev, off_t addr, size_t size)
 static int spi_nor_write_protection_set(const struct device *dev,
 					bool write_protect)
 {
-	int ret;
+	int ret = 0;
 	const struct spi_nor_config *cfg = dev->config;
 
 #if ANY_INST_HAS_WP_GPIOS
@@ -1133,11 +1133,7 @@ static int spi_nor_write_protection_set(const struct device *dev,
 	}
 #endif
 
-	ret = spi_nor_cmd_write(dev, (write_protect) ?
-	      SPI_NOR_CMD_WRDI : SPI_NOR_CMD_WREN);
-
 	if (cfg->requires_ulbpr_exist
-	    && (ret == 0)
 	    && !write_protect) {
 		ret = spi_nor_cmd_write(dev, SPI_NOR_CMD_ULBPR);
 	}

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1129,7 +1129,7 @@ static int spi_nor_write_protection_set(const struct device *dev,
 	const struct spi_nor_config *cfg = dev->config;
 
 #if ANY_INST_HAS_WP_GPIOS
-	if (DEV_CFG(dev)->wp_gpios_exist && write_protect == false) {
+	if (DEV_CFG(dev)->wp_gpios_exist && !write_protect) {
 		gpio_pin_set_dt(&(DEV_CFG(dev)->wp), 0);
 	}
 #endif
@@ -1141,7 +1141,7 @@ static int spi_nor_write_protection_set(const struct device *dev,
 	}
 
 #if ANY_INST_HAS_WP_GPIOS
-	if (DEV_CFG(dev)->wp_gpios_exist && write_protect == true) {
+	if (DEV_CFG(dev)->wp_gpios_exist && write_protect) {
 		gpio_pin_set_dt(&(DEV_CFG(dev)->wp), 1);
 	}
 #endif

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -56,6 +56,7 @@ LOG_MODULE_REGISTER(spi_nor, CONFIG_FLASH_LOG_LEVEL);
 #define ANY_INST_HAS_FLSR \
 	DT_ANY_INST_HAS_BOOL_STATUS_OKAY(use_flag_status_register)
 #define ANY_INST_USE_FAST_READ DT_ANY_INST_HAS_BOOL_STATUS_OKAY(use_fast_read)
+#define ANY_INST_REQUIRES_ULBPR DT_ANY_INST_HAS_BOOL_STATUS_OKAY(requires_ulbpr)
 
 #ifdef CONFIG_SPI_NOR_ACTIVE_DWELL_MS
 #define ACTIVE_DWELL_MS CONFIG_SPI_NOR_ACTIVE_DWELL_MS
@@ -1133,7 +1134,8 @@ static int spi_nor_write_protection_set(const struct device *dev,
 	}
 #endif
 
-	if (cfg->requires_ulbpr_exist
+	if (IS_ENABLED(ANY_INST_REQUIRES_ULBPR)
+	    && cfg->requires_ulbpr_exist
 	    && !write_protect) {
 		ret = spi_nor_cmd_write(dev, SPI_NOR_CMD_ULBPR);
 	}


### PR DESCRIPTION
write enable already happens in the write/erase loop
before every write and erase. It is done in the loop,
because it is self cleaning after erase and write.
That is also the reason we don't need to disable it,
as it is automatically disabled after each write and erase.