### PR TITLE
drivers: clock: stm32_ll_h7: fix max. frequency defines for stm32H7RS

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -144,10 +144,10 @@
 #define AHB_FREQ_MAX		280000000UL
 #define APBx_FREQ_MAX		140000000UL
 #elif defined(CONFIG_SOC_SERIES_STM32H7RSX)
-/* All h7RS SoC with maximum 500MHz SYSCLK (refer to Datasheet DS14359 rev 1) */
-#define SYSCLK_FREQ_MAX		500000000UL
-#define AHB_FREQ_MAX		250000000UL
-#define APBx_FREQ_MAX		125000000UL
+/* All h7RS SoC with maximum 600MHz SYSCLK (refer to Datasheet DS14359 rev 4) */
+#define SYSCLK_FREQ_MAX		600000000UL
+#define AHB_FREQ_MAX		300000000UL
+#define APBx_FREQ_MAX		150000000UL
 #else
 /* Default: All h7 SoC with maximum 280MHz SYSCLK */
 #define SYSCLK_FREQ_MAX		280000000UL


### PR DESCRIPTION
The maximum frequencies for SYSCLK, AHB and APB bus have changed since the first issue of the datasheet (where the current values were taken from). Setting values according to the up- to-date datasheet.

<img width="732" height="280" alt="grafik" src="https://github.com/user-attachments/assets/16f7cdc6-ff99-42a2-81cf-a8989737d427" />

[Datasheet DS14359 rev 4 for STM32H7S3x8 and STM32H7S7x8](https://www.st.com/resource/en/datasheet/stm32h7s3a8.pdf)

## Changes:
- Update the `#defines` for `SYSCLK_FREQ_MAX`, `AHB_FREQ_MAX` and `APBx_FREQ_MAX`

## Testing Status:
- Using these max clock settings on the NUCLEO-H7S3L8 with my custom projects.