### PR TITLE
net: sockets: socket_service: Fixed issue that prevented reconfiguration

### DIFF
--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -260,7 +260,7 @@ restart:
 		}
 
 		/* Relocate after trigger work so the work gets done before restarting */
-		if (ret > 0 && ctx.events[0].revents) {
+		if (ctx.events[0].revents) {
 			zvfs_eventfd_read(ctx.events[0].fd, &value);
 			ctx.events[0].revents = 0;
 			NET_DBG("Received restart event.");


### PR DESCRIPTION
Once running, a socket service could not be reconfigured (i.e. changing file descriptors and/or events to be polled). This was due to an incorrect check at the end of the thread main loop of socket_service_thread that evaluated to false as variable ret is zero if trigger_work(), which is called previously for all returned events, returns successfully.