### PR TITLE
ci: set various ccache-cache-key parameters for the setup action

### DIFF
--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -63,6 +63,7 @@ jobs:
         with:
           app-path: zephyr
           toolchains: aarch64-zephyr-elf:arc-zephyr-elf:arc64-zephyr-elf:arm-zephyr-eabi:mips-zephyr-elf:riscv64-zephyr-elf:sparc-zephyr-elf:x86_64-zephyr-elf:xtensa-dc233c_zephyr-elf:xtensa-sample_controller32_zephyr-elf:rx-zephyr-elf
+          ccache-cache-key: hw-${{ matrix.os }}
 
       - name: Build firmware
         working-directory: zephyr

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -69,6 +69,7 @@ jobs:
         with:
           app-path: zephyr
           toolchains: all
+          enable-ccache: false
 
       - name: Environment Setup
         working-directory: zephyr

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -49,6 +49,7 @@ jobs:
       with:
         app-path: zephyr
         toolchains: all
+        enable-ccache: false
 
     - name: Run Pytest For Twister Black Box Tests
       if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
The setup action now supports caching the ccache objects, set a ccache-cache-key for the jobs that can benefit from it, disable it from the ones that don't really build anything.

--

Deps:
- https://github.com/zephyrproject-rtos/zephyr/pull/95686

Seems to be working alright, cuts the twister run to ~8min to ~6min or thereabout, not revolutionary but it's certainly working.