### PR TITLE
dsp: utils: slim down includes

### DIFF
--- a/include/zephyr/dsp/utils.h
+++ b/include/zephyr/dsp/utils.h
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 #include <zephyr/kernel.h>
-#include <zephyr/dsp/dsp.h>
+#include <zephyr/dsp/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/subsys/dsp/utils/src/f32.c
+++ b/tests/subsys/dsp/utils/src/f32.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
+#include <zephyr/dsp/dsp.h>
 #include <zephyr/dsp/utils.h>
 
 #include "common/test_common.h"

--- a/tests/subsys/dsp/utils/src/f64.c
+++ b/tests/subsys/dsp/utils/src/f64.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
+#include <zephyr/dsp/dsp.h>
 #include <zephyr/dsp/utils.h>
 
 #include "common/test_common.h"

--- a/tests/subsys/dsp/utils/src/q15.c
+++ b/tests/subsys/dsp/utils/src/q15.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
+#include <zephyr/dsp/dsp.h>
 #include <zephyr/dsp/utils.h>
 
 #include "common/test_common.h"

--- a/tests/subsys/dsp/utils/src/q31.c
+++ b/tests/subsys/dsp/utils/src/q31.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
+#include <zephyr/dsp/dsp.h>
 #include <zephyr/dsp/utils.h>
 
 #include "common/test_common.h"

--- a/tests/subsys/dsp/utils/src/q7.c
+++ b/tests/subsys/dsp/utils/src/q7.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
+#include <zephyr/dsp/dsp.h>
 #include <zephyr/dsp/utils.h>
 
 #include "common/test_common.h"


### PR DESCRIPTION
The dsp/utils.h header itself only uses dsp/types.h and doesn't need the entire dsp/dsp.h.

This also facilitates using the dsp/utils.h in builds that don't enable a dsp backend at all which can be convenient for sensor drivers where the q31_t dsp type is used.