### PR TITLE
samples: cleanup sysbuild/hello_world sample

### DIFF
--- a/samples/sysbuild/hello_world/Kconfig.sysbuild
+++ b/samples/sysbuild/hello_world/Kconfig.sysbuild
@@ -3,5 +3,34 @@
 
 source "$(ZEPHYR_BASE)/share/sysbuild/Kconfig"
 
+choice REMOTE_NRF54H20_CORE
+	prompt "Remote nRF54h20 core"
+	default REMOTE_NRF54H20_CPUFLPR_CORE
+	depends on SOC_NRF54H20_CPUAPP
+
+config REMOTE_NRF54H20_CPUFLPR_CORE
+	bool "flpr core"
+
+config REMOTE_NRF54H20_CPUFLPR_XIP_CORE
+	bool "flpr/xip core"
+
+config REMOTE_NRF54H20_CPUPPR_CORE
+	bool "ppr core"
+
+config REMOTE_NRF54H20_CPUPPR_XIP_CORE
+	bool "ppr/xip core"
+
+config REMOTE_NRF54H20_CPURAD_CORE
+	bool "cpurad"
+
+endchoice
+
 config REMOTE_BOARD
-	string "The board used for remote target"
+	string
+	default "$(BOARD)/nrf5340/cpunet" if SOC_NRF5340_CPUAPP
+	default "$(BOARD)/nrf54l15/cpuflpr" if SOC_NRF54L15_CPUAPP
+	default "$(BOARD)/nrf54h20/cpurad" if SOC_NRF54H20_CPUAPP && REMOTE_NRF54H20_CPURAD_CORE
+	default "$(BOARD)/nrf54h20/cpuppr" if SOC_NRF54H20_CPUAPP && REMOTE_NRF54H20_CPUPPR_CORE
+	default "$(BOARD)/nrf54h20/cpuppr/xip" if SOC_NRF54H20_CPUAPP && REMOTE_NRF54H20_CPUPPR_XIP_CORE
+	default "$(BOARD)/nrf54h20/cpuflpr" if SOC_NRF54H20_CPUAPP && REMOTE_NRF54H20_CPUFLPR_CORE
+	default "$(BOARD)/nrf54h20/cpuflpr/xip" if SOC_NRF54H20_CPUAPP && REMOTE_NRF54H20_CPUFLPR_XIP_CORE

--- a/samples/sysbuild/hello_world/sample.yaml
+++ b/samples/sysbuild/hello_world/sample.yaml
@@ -17,14 +17,13 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    extra_args: SB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpurad:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+      - SB_CONFIG_REMOTE_NRF54H20_CPURAD_CORE=y
       - hello_world_CONFIG_SOC_NRF54H20_CPURAD_ENABLE=y
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpuppr:
     platform_allow:
@@ -32,7 +31,7 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr.conf
+      - SB_CONFIG_REMOTE_NRF54H20_CPUPPR_CORE=y
       - hello_world_SNIPPET=nordic-ppr
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpuppr_xip:
     platform_allow:
@@ -40,17 +39,20 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr_xip.conf
+      - SB_CONFIG_REMOTE_NRF54H20_CPUPPR_XIP_CORE=y
       - hello_world_SNIPPET=nordic-ppr-xip
-  sample.sysbuild.hello_world.nrf54l15dk_nrf54l15_cpuflpr:
+  sample.sysbuild.hello_world.nrf54l15_cpuflpr:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
+      - bl54l15_dvk/nrf54l15/cpuapp
+      - bl54l15u_dvk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
+      - bl54l15_dvk/nrf54l15/cpuapp
+      - bl54l15u_dvk/nrf54l15/cpuapp
     extra_args:
-      - SB_CONF_FILE=sysbuild/nrf54l15dk_nrf54l15_cpuflpr.conf
       - hello_world_SNIPPET=nordic-flpr
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpuflpr:
     platform_allow:
@@ -58,7 +60,7 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuflpr.conf
+      - SB_CONFIG_REMOTE_NRF54H20_CPUFLPR_CORE=y
       - hello_world_SNIPPET=nordic-flpr
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpuflpr_xip:
     platform_allow:
@@ -66,21 +68,5 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
+      - SB_CONFIG_REMOTE_NRF54H20_CPUFLPR_XIP_CORE=y
       - hello_world_SNIPPET=nordic-flpr-xip
-  sample.sysbuild.hello_world.bl54l15_dvk_nrf54l15_cpuflpr:
-    platform_allow:
-      - bl54l15_dvk/nrf54l15/cpuapp
-    integration_platforms:
-      - bl54l15_dvk/nrf54l15/cpuapp
-    extra_args:
-      - SB_CONF_FILE=sysbuild/bl54l15_dvk_nrf54l15_cpuflpr.conf
-      - hello_world_SNIPPET=nordic-flpr
-  sample.sysbuild.hello_world.bl54l15u_dvk_nrf54l15_cpuflpr:
-    platform_allow:
-      - bl54l15u_dvk/nrf54l15/cpuapp
-    integration_platforms:
-      - bl54l15u_dvk/nrf54l15/cpuapp
-    extra_args:
-      - SB_CONF_FILE=sysbuild/bl54l15u_dvk_nrf54l15_cpuflpr.conf
-      - hello_world_SNIPPET=nordic-flpr

--- a/samples/sysbuild/hello_world/sysbuild.cmake
+++ b/samples/sysbuild/hello_world/sysbuild.cmake
@@ -1,15 +1,13 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if("${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
-  message(FATAL_ERROR "REMOTE_BOARD must be set to a valid board name")
+if(DEFINED SB_CONFIG_REMOTE_BOARD)
+  ExternalZephyrProject_Add(
+    APPLICATION remote
+    SOURCE_DIR ${APP_DIR}/remote
+    BOARD ${SB_CONFIG_REMOTE_BOARD}
+  )
+
+  add_dependencies(${DEFAULT_IMAGE} remote)
+  sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)
 endif()
-
-ExternalZephyrProject_Add(
-  APPLICATION remote
-  SOURCE_DIR ${APP_DIR}/remote
-  BOARD ${SB_CONFIG_REMOTE_BOARD}
-)
-
-add_dependencies(${DEFAULT_IMAGE} remote)
-sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)

--- a/samples/sysbuild/hello_world/sysbuild.cmake
+++ b/samples/sysbuild/hello_world/sysbuild.cmake
@@ -6,6 +6,7 @@ if(DEFINED SB_CONFIG_REMOTE_BOARD)
     APPLICATION remote
     SOURCE_DIR ${APP_DIR}/remote
     BOARD ${SB_CONFIG_REMOTE_BOARD}
+    BOARD_REVISION ${BOARD_REVISION}
   )
 
   add_dependencies(${DEFAULT_IMAGE} remote)

--- a/samples/sysbuild/hello_world/sysbuild/bl54l15_dvk_nrf54l15_cpuflpr.conf
+++ b/samples/sysbuild/hello_world/sysbuild/bl54l15_dvk_nrf54l15_cpuflpr.conf
@@ -1,6 +1,0 @@
-# Copyright (c) 2025 Nordic Semiconductor ASA
-# Copyright (c) 2025 Ezurio LLC
-#
-# SPDX-License-Identifier: Apache-2.0
-
-SB_CONFIG_REMOTE_BOARD="bl54l15_dvk/nrf54l15/cpuflpr"

--- a/samples/sysbuild/hello_world/sysbuild/bl54l15u_dvk_nrf54l15_cpuflpr.conf
+++ b/samples/sysbuild/hello_world/sysbuild/bl54l15u_dvk_nrf54l15_cpuflpr.conf
@@ -1,6 +1,0 @@
-# Copyright (c) 2025 Nordic Semiconductor ASA
-# Copyright (c) 2025 Ezurio LLC
-#
-# SPDX-License-Identifier: Apache-2.0
-
-SB_CONFIG_REMOTE_BOARD="bl54l15u_dvk/nrf54l15/cpuflpr"

--- a/samples/sysbuild/hello_world/sysbuild/nrf5340dk_nrf5340_cpunet.conf
+++ b/samples/sysbuild/hello_world/sysbuild/nrf5340dk_nrf5340_cpunet.conf
@@ -1,1 +1,0 @@
-SB_CONFIG_REMOTE_BOARD="nrf5340dk/nrf5340/cpunet"

--- a/samples/sysbuild/hello_world/sysbuild/nrf54h20dk_nrf54h20_cpuflpr.conf
+++ b/samples/sysbuild/hello_world/sysbuild/nrf54h20dk_nrf54h20_cpuflpr.conf
@@ -1,1 +1,0 @@
-SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpuflpr"

--- a/samples/sysbuild/hello_world/sysbuild/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
+++ b/samples/sysbuild/hello_world/sysbuild/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
@@ -1,1 +1,0 @@
-SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpuflpr/xip"

--- a/samples/sysbuild/hello_world/sysbuild/nrf54h20dk_nrf54h20_cpuppr.conf
+++ b/samples/sysbuild/hello_world/sysbuild/nrf54h20dk_nrf54h20_cpuppr.conf
@@ -1,1 +1,0 @@
-SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpuppr"

--- a/samples/sysbuild/hello_world/sysbuild/nrf54h20dk_nrf54h20_cpuppr_xip.conf
+++ b/samples/sysbuild/hello_world/sysbuild/nrf54h20dk_nrf54h20_cpuppr_xip.conf
@@ -1,1 +1,0 @@
-SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpuppr/xip"

--- a/samples/sysbuild/hello_world/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/samples/sysbuild/hello_world/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,1 +1,0 @@
-SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpurad"

--- a/samples/sysbuild/hello_world/sysbuild/nrf54l15dk_nrf54l15_cpuflpr.conf
+++ b/samples/sysbuild/hello_world/sysbuild/nrf54l15dk_nrf54l15_cpuflpr.conf
@@ -1,1 +1,0 @@
-SB_CONFIG_REMOTE_BOARD="nrf54l15dk/nrf54l15/cpuflpr"


### PR DESCRIPTION
Remove the prompt for REMOTE_BOARD.
REMOTE_BOARD should not be having a prompt or be configurable on command line.
Instead REMOTE_BOARD should be defined based on the SoC as this will allow creation of new boards using the same SoC, and thereby be able to build the sample out-of-the-box for any supported SoC.

This allows us to remove several single line config files.

For SoCs with more than two CPU clusters, such as the nRF54h20, then a choice is provided to select specific core.

Remove the REMOTE_BOARD restriction, as this sample will build and run even for single core SoCs, and may be useful for testing other sysbuild multi-image features even for single cores SoCs.