### PR TITLE
tests: drivers: build_all: sensor: spi: correct reg

### DIFF
--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -463,7 +463,7 @@ test_spi_adxl366: adxl366@37 {
 
 test_spi_icm42686: icm42686@38 {
 	compatible = "invensense,icm42686", "invensense,icm4268x";
-	reg = <0x1a>;
+	reg = <0x38>;
 	spi-max-frequency = <24000000>;
 	int-gpios = <&test_gpio 0 0>;
 };


### PR DESCRIPTION
Align the `reg` property with the address specified in the dts node for the icm42686.