### PR TITLE
drivers: i3c: add open-drain speed configuration API

### DIFF
--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -297,7 +297,7 @@ static int cmd_i3c_info(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-/* i3c speed <device> <speed> */
+/* i3c speed <device> <speed> [<od_min high_ns>] [<od_min low_ns>] */
 static int cmd_i3c_speed(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
@@ -320,6 +320,12 @@ static int cmd_i3c_speed(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	config.scl.i3c = speed;
+
+	if (argc == 5) {
+		/* This sets open-drain SCL high and low periods */
+		config.scl_od_min.high_ns = strtol(argv[ARGV_DEV + 2], NULL, 10);
+		config.scl_od_min.low_ns  = strtol(argv[ARGV_DEV + 3], NULL, 10);
+	}
 
 	ret = i3c_configure(dev, I3C_CONFIG_CONTROLLER, &config);
 	if (ret != 0) {
@@ -2390,8 +2396,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      cmd_i3c_info, 2, 1),
 	SHELL_CMD_ARG(speed, &dsub_i3c_device_name,
 		      "Set I3C device speed\n"
-		      "Usage: speed <device> <speed>",
-		      cmd_i3c_speed, 3, 0),
+		      "Usage: speed <device> <speed> [<od_min high_ns>] [<od_min low_ns>]",
+		      cmd_i3c_speed, 3, 2),
 	SHELL_CMD_ARG(recover, &dsub_i3c_device_name,
 		      "Recover I3C bus\n"
 		      "Usage: recover <device>",

--- a/dts/bindings/i3c/i3c-controller.yaml
+++ b/dts/bindings/i3c/i3c-controller.yaml
@@ -38,3 +38,20 @@ properties:
       is the address is used to communicate with itself after a handoff by
       a secondary controller. This is only used if the controller is a primary
       controller.
+
+  od-thigh-min-ns:
+    type: int
+    default: 24
+    description: |
+      Minimum high clock pulse length (ns) in Open-Drain mode for pure bus.
+      The default value is from Section 4.3.11.2 & Table 49 of the I3C
+      Basic Specifiction v1.2 (16-Dec-2024).
+
+  od-tlow-min-ns:
+    type: int
+    default: 200
+    description: |
+      Minimum low clock pulse length (ns) in Open-Drain mode.
+      The default value is from Section 4.3.11.2 & Table 49 of the I3C
+      Basic Specifiction v1.2 (16-Dec-2024).
+      Specifiction.

--- a/dts/bindings/i3c/snps,designware-i3c.yaml
+++ b/dts/bindings/i3c/snps,designware-i3c.yaml
@@ -12,19 +12,3 @@ include: [i3c-controller.yaml, pinctrl-device.yaml]
 properties:
   clocks:
     required: true
-
-  od-thigh-max-ns:
-    type: int
-    default: 41
-    description: |
-      Maximum high clock pulse length (ns) in Open-Drain mode.
-      The default is value from Section 6.2 of the I3C
-      Specifiction.
-
-  od-tlow-min-ns:
-    type: int
-    default: 200
-    description: |
-      Minimum low clock pulse length (ns) in Open-Drain mode.
-      The default is value from Section 6.2 of the I3C
-      Specifiction.

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -43,6 +43,14 @@ extern "C" {
 #endif
 
 /**
+ * @brief Max and min Open Drain timings.
+ *        Standard I3C SDR and I2C FM speed
+ */
+#define I3C_OD_TLOW_MIN_NS            200
+#define I3C_OD_MIXED_BUS_THIGH_MAX_NS 41
+#define I3C_OD_FIRST_BC_THIGH_MIN_NS  200
+
+/**
  * @name Bus Characteristic Register (BCR)
  * @anchor I3C_BCR
  *
@@ -463,6 +471,22 @@ struct i3c_config_controller {
 		/** SCL frequency (in Hz) for I2C transfers. */
 		uint32_t i2c;
 	} scl;
+
+	struct {
+		/**
+		 * Requested minimum SCL Open Drain High period in Nanoseconds
+		 *
+		 * Note:
+		 * - For the first broadcast message, spec requires tHIGH_OD >= 200 ns.
+		 * - For normal messages, tHIGH_OD must not exceed 41 ns (spec max).
+		 */
+		uint32_t high_ns;
+
+		/**
+		 * Requested minimum SCL Open-Drain LOW period in nanoseconds.
+		 */
+		uint32_t low_ns;
+	} scl_od_min;
 
 	/**
 	 * Bit mask of supported HDR modes (0 - 7).


### PR DESCRIPTION
Add new API to configure I3C open-drain speeds to meet timing requirements specified in the MIPI I3C specification for proper bus initialization and device compatibility.

Requirement (MIPI Specification for I3C Basic v1.2 (16-Dec-2024),
             Section 4.3.11.2 & Table 49):
- The MIPI I3C specification mandates different open-drain speeds during bus initialization as defined in "I3C Basic Open Drain Timing Parameters".
- The first broadcast address (7'h7E+W) must be transmitted at a slower open-drain speed to ensure visibility to all devices on the I3C bus, including legacy I2C devices. This slow speed (minimum 200ns Thigh) allows I2C devices to properly detect the I3C mode transition and disable their spike filters before switching to I3C mode. After the initial broadcast, normal I3C open-drain speeds can be used for regular operation.

Implementation:
    i3c.h
    - Add scl_od_min structure to i3c_config_controller for
      high/low period settings
    - Define Open-drain mixed bus SCL timing constants
    i3c_dw.c:
    - Add OD minimum high_ns and low_ns DT properties
    - Implement dw_i3c_init_scl_timing for runtime timing updates
    - Initialize scl_od_min configuration from device tree
    i3c_common.c:
    - Fetch current controller configuration
    - Invoke configure api inside bus_init to configure
      I3C open-drain high period for proper bus
      initialization and device compatibility.
    i3c_shell.c
    - Add SHELL support for configuring I3C open-drain speed modes.
    - Include open-drain timing configuration inside cmd_i3c_speed function.