### PR TITLE
doc: _scripts: ensure twister.yaml file is considered in board catalog

### DIFF
--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -360,14 +360,14 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
         # Grab all the twister files for this board and use them to figure out all the archs it
         # supports.
         board_archs = set()
-        pattern = f"{board.name}*.yaml"
-        for twister_file in board.dir.glob(pattern):
-            try:
-                with open(twister_file) as f:
-                    board_data = yaml.safe_load(f)
-                    board_archs.add(board_data.get("arch"))
-            except Exception as e:
-                logger.error(f"Error parsing twister file {twister_file}: {e}")
+        for pattern in (f"{board.name}*.yaml", "twister.yaml"):
+            for twister_file in board.dir.glob(pattern):
+                try:
+                    with open(twister_file) as f:
+                        board_data = yaml.safe_load(f)
+                        board_archs.add(board_data.get("arch"))
+                except Exception as e:
+                    logger.error(f"Error parsing twister file {twister_file}: {e}")
 
         if doc_page and doc_page.is_relative_to(ZEPHYR_BASE):
             doc_page_path = doc_page.relative_to(ZEPHYR_BASE).as_posix()


### PR DESCRIPTION
Boards may use twister.yaml file to define Twister platforms, so board catalog should also parse them.

Fixes: zephyrproject-rtos/zephyr#95721.

The example URL from the issue linked above now works as expected

<img width="757" height="851" alt="image" src="https://github.com/user-attachments/assets/e0d9b4d9-fd07-4d65-bf3d-4f808e5d1a3b" />
