### PR TITLE
Kconfig: Make soc/ as optional

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -27,7 +27,7 @@ source "boards/shields/*/Kconfig.defconfig"
 osource "$(KCONFIG_BOARD_DIR)/Kconfig.defconfig"
 
 # This loads Zephyr specific SoC root defconfigs
-source "$(KCONFIG_BINARY_DIR)/soc/Kconfig.defconfig"
+osource "$(KCONFIG_BINARY_DIR)/soc/Kconfig.defconfig"
 
 # This loads the toolchain defconfigs
 osource "$(TOOLCHAIN_KCONFIG_DIR)/Kconfig.defconfig"


### PR DESCRIPTION
For some boards there is no corresponding soc/
Example https://github.com/zephyrproject-rtos/zephyr/discussions/95167