### PR TITLE
drivers: sensor: st: lis2du12: fix LIS2DU12 initialization issue by setting ODR before software reset

### DIFF
--- a/drivers/sensor/st/lis2du12/lis2du12.c
+++ b/drivers/sensor/st/lis2du12/lis2du12.c
@@ -55,36 +55,6 @@ static int lis2du12_accel_range_to_fs_val(int32_t range)
 	return -EINVAL;
 }
 
-static inline int lis2du12_reboot(const struct device *dev)
-{
-	const struct lis2du12_config *cfg = dev->config;
-	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
-	lis2du12_status_t status;
-	uint8_t tries = 10;
-
-	if (lis2du12_init_set(ctx, LIS2DU12_RESET) < 0) {
-		return -EIO;
-	}
-
-	do {
-		if (!--tries) {
-			LOG_ERR("sw reset timed out");
-			return -ETIMEDOUT;
-		}
-		k_usleep(50);
-
-		if (lis2du12_status_get(ctx, &status) < 0) {
-			return -EIO;
-		}
-	} while (status.sw_reset != 0);
-
-	if (lis2du12_init_set(ctx, LIS2DU12_DRV_RDY) < 0) {
-		return -EIO;
-	}
-
-	return 0;
-}
-
 static int lis2du12_accel_set_fs_raw(const struct device *dev, uint8_t fs)
 {
 	const struct lis2du12_config *cfg = dev->config;
@@ -176,6 +146,36 @@ static int lis2du12_accel_config(const struct device *dev,
 	default:
 		LOG_WRN("Accel attribute %d not supported.", attr);
 		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static inline int lis2du12_reboot(const struct device *dev)
+{
+	const struct lis2du12_config *cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	lis2du12_status_t status;
+	uint8_t tries = 10;
+
+	if (lis2du12_init_set(ctx, LIS2DU12_RESET) < 0) {
+		return -EIO;
+	}
+
+	do {
+		if (!--tries) {
+			LOG_ERR("sw reset timed out");
+			return -ETIMEDOUT;
+		}
+		k_usleep(50);
+
+		if (lis2du12_status_get(ctx, &status) < 0) {
+			return -EIO;
+		}
+	} while (status.sw_reset != 0);
+
+	if (lis2du12_init_set(ctx, LIS2DU12_DRV_RDY) < 0) {
+		return -EIO;
 	}
 
 	return 0;

--- a/drivers/sensor/st/lis2du12/lis2du12.c
+++ b/drivers/sensor/st/lis2du12/lis2du12.c
@@ -158,6 +158,10 @@ static inline int lis2du12_reboot(const struct device *dev)
 	lis2du12_status_t status;
 	uint8_t tries = 10;
 
+	if (lis2du12_accel_set_odr_raw(dev, LIS2DU12_OFF) < 0) {
+		return -EIO;
+	}
+
 	if (lis2du12_init_set(ctx, LIS2DU12_RESET) < 0) {
 		return -EIO;
 	}


### PR DESCRIPTION
We encountered an initialization issue with the ST LIS2DU12 accelerometer. The same problem was previously reported in the Nordic DevZone:

https://devzone.nordicsemi.com/f/nordic-q-a/119068/bug-in-driver-for-the-lis2du12-accelerometer-sensor-at-init-step

Since no merge request with a fix was available, I am providing one here.
The fix was tested using a nucleo_l433rc_p connected to the LIS2DU12 via I²C and confirmed to work reliably.

This MR contains two commits:
1. Relocation of the reboot function to allow calling set_odr() before the reset.
2. The actual fix to ensure the sensor initializes correctly.
This way the fix is not hidden by the relocation