### PR TITLE
soc: esp32: expand shared memory and enable rpmsg sample

### DIFF
--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -151,12 +151,12 @@
 
 		shm0: memory@3ffe5630 {
 			compatible = "mmio-sram";
-			reg = <0x3ffe5630 0x4000>;
+			reg = <0x3ffe5630 0x8000>;
 		};
 
-		ipm0: ipm@3ffe9630 {
+		ipm0: ipm@3ffed630 {
 			compatible = "espressif,esp32-ipm";
-			reg = <0x3ffe9630 0x8>;
+			reg = <0x3ffed630 0x8>;
 			status = "disabled";
 			shared-memory = <&ipmmem0>;
 			shared-memory-size = <0x400>;
@@ -166,9 +166,9 @@
 			interrupt-parent = <&intc>;
 		};
 
-		mbox0: mbox@3ffe9638 {
+		mbox0: mbox@3ffed638 {
 			compatible = "espressif,mbox-esp32";
-			reg = <0x3ffe9638 0x8>;
+			reg = <0x3ffed638 0x8>;
 			status = "disabled";
 			shared-memory = <&ipmmem0>;
 			shared-memory-size = <0x400>;

--- a/samples/subsys/ipc/rpmsg_service/CMakeLists.txt
+++ b/samples/subsys/ipc/rpmsg_service/CMakeLists.txt
@@ -15,9 +15,4 @@ message(STATUS "${BOARD} compile as Master in this sample")
 
 enable_language(C ASM)
 
-if("${BOARD}" STREQUAL "esp32_devkitc" OR "${BOARD}" STREQUAL "esp32s3_devkitm")
-  set_source_files_properties(${REMOTE_ZEPHYR_DIR}/esp32_net_firmware.c PROPERTIES GENERATED TRUE)
-  target_sources(app PRIVATE src/main.c ${REMOTE_ZEPHYR_DIR}/esp32_net_firmware.c)
-else()
-  target_sources(app PRIVATE src/main.c)
-endif()
+target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/ipc/rpmsg_service/Kconfig.sysbuild
+++ b/samples/subsys/ipc/rpmsg_service/Kconfig.sysbuild
@@ -9,3 +9,5 @@ config RPMSG_REMOTE_BOARD
 	default "mps2/an521/cpu1" if $(BOARD) = "mps2"
 	default "v2m_musca_b1/musca_b1/ns" if $(BOARD) = "v2m_musca_b1"
 	default "stm32h747i_disco/stm32h747xx/m4" if $(BOARD) = "stm32h747i_disco"
+	default "esp32s3_devkitc/esp32s3/appcpu" if $(BOARD) = "esp32s3_devkitc"
+	default "esp32_devkitc/esp32/appcpu" if $(BOARD) = "esp32_devkitc"

--- a/samples/subsys/ipc/rpmsg_service/boards/esp32_devkitc_procpu.overlay
+++ b/samples/subsys/ipc/rpmsg_service/boards/esp32_devkitc_procpu.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ipc_shm = &shm0;
+		zephyr,ipc = &ipm0;
+	};
+};
+
+&ipm0 {
+	status = "okay";
+};

--- a/samples/subsys/ipc/rpmsg_service/boards/esp32s3_devkitc_procpu.overlay
+++ b/samples/subsys/ipc/rpmsg_service/boards/esp32s3_devkitc_procpu.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ipc_shm = &shm0;
+		zephyr,ipc = &ipm0;
+	};
+};
+
+&ipm0 {
+	status = "okay";
+};

--- a/samples/subsys/ipc/rpmsg_service/remote/boards/esp32_devkitc_appcpu.overlay
+++ b/samples/subsys/ipc/rpmsg_service/remote/boards/esp32_devkitc_appcpu.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ipc_shm = &shm0;
+		zephyr,ipc = &ipm0;
+	};
+};
+
+&ipm0 {
+	status = "okay";
+};

--- a/samples/subsys/ipc/rpmsg_service/remote/boards/esp32s3_devkitc_appcpu.overlay
+++ b/samples/subsys/ipc/rpmsg_service/remote/boards/esp32s3_devkitc_appcpu.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ipc_shm = &shm0;
+		zephyr,ipc = &ipm0;
+	};
+};
+
+&ipm0 {
+	status = "okay";
+};


### PR DESCRIPTION
Increase the allocated shared memory region used by the
Inter-Processor Messaging (IPM) driver. The previous size
was insufficient and caused failures when running the
OpenAMP and RPMsg samples on ESP32. This change ensures
enough space is available for message buffers and prevents
runtime errors.

Add configuration and overlay files for the ESP32 and
ESP32-S3 base boards, allowing the RPMsg sample to build
and run on Espressif platforms. This enables easier testing
and validation of OpenAMP communication on these boards.