### PR TITLE
Bluetooth: Classic: fix a2dp stream chan release

### DIFF
--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -683,8 +683,12 @@ struct bt_a2dp_stream_ops {
 	/**
 	 * @brief Stream release callback
 	 *
+	 * The release procedure (bt_a2dp_stream_release, release_req, release_rsp and
+	 * disconnect l2cap media channel), the abort procedure (bt_a2dp_stream_abort, abort_req,
+	 * abort_rsp and disconnect l2cap media channel) and the error procedure (for example,
+	 * the l2cap channel disconnected unexpectedly) will cause the stream to be released.
 	 * The callback is called whenever an Audio Stream has been released.
-	 * After released, the stream becomes invalid.
+	 * After released, the stream becomes invalid to control.
 	 *
 	 * @param stream Stream object that has been released.
 	 */
@@ -705,15 +709,6 @@ struct bt_a2dp_stream_ops {
 	 * @param stream Stream object that has been suspended.
 	 */
 	void (*suspended)(struct bt_a2dp_stream *stream);
-	/**
-	 * @brief Stream abort callback
-	 *
-	 * The callback is called whenever an Audio Stream has been aborted.
-	 * After aborted, the stream becomes invalid.
-	 *
-	 * @param stream Stream object that has been aborted.
-	 */
-	void (*aborted)(struct bt_a2dp_stream *stream);
 #if defined(CONFIG_BT_A2DP_SINK)
 	/** @brief the media streaming data, only for sink
 	 *

--- a/include/zephyr/bluetooth/classic/avdtp.h
+++ b/include/zephyr/bluetooth/classic/avdtp.h
@@ -144,6 +144,12 @@ struct bt_avdtp_sep {
 	struct k_sem sem_lock;
 	/** avdtp session */
 	struct bt_avdtp *session;
+	/** endpoint becomes idle */
+	int (*endpoint_released)(struct bt_avdtp_sep *sep);
+	/** delay worker for disconnecting l2cap media channel */
+	struct k_work_delayable _delay_work;
+	/** delay_work_state */
+	uint8_t _delay_work_state;
 	/** SEP state */
 	uint8_t state;
 	/* Internally used list node */

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -496,14 +496,13 @@ static int a2dp_close_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, ui
 
 static int a2dp_abort_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode)
 {
-	struct bt_a2dp_ep *ep = CONTAINER_OF(sep, struct bt_a2dp_ep, sep);
 	bt_a2dp_ctrl_req_cb req_cb;
-	bt_a2dp_ctrl_done_cb done_cb;
 
 	__ASSERT(sep, "Invalid sep");
 	req_cb = a2dp_cb != NULL ? a2dp_cb->abort_req : NULL;
-	done_cb = (ep->stream != NULL && ep->stream->ops != NULL) ? ep->stream->ops->aborted : NULL;
-	return a2dp_ctrl_ind(session, sep, errcode, req_cb, done_cb, true);
+
+	/* When stream is released, the `stream->ops->released` will be called. */
+	return a2dp_ctrl_ind(session, sep, errcode, req_cb, NULL, true);
 }
 
 static int bt_a2dp_set_config_cb(struct bt_avdtp_req *req, struct net_buf *buf)
@@ -856,12 +855,10 @@ static int bt_a2dp_close_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 
 static int bt_a2dp_abort_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 {
-	struct bt_a2dp_ep *ep = CONTAINER_OF(CTRL_REQ(req)->sep, struct bt_a2dp_ep, sep);
 	bt_a2dp_rsp_cb rsp_cb = a2dp_cb != NULL ? a2dp_cb->abort_rsp : NULL;
-	bt_a2dp_done_cb done_cb =
-		(ep->stream != NULL && ep->stream->ops != NULL) ? ep->stream->ops->aborted : NULL;
 
-	return bt_a2dp_ctrl_cb(req, rsp_cb, done_cb, true);
+	/* When stream is released, the `stream->ops->released` will be called. */
+	return bt_a2dp_ctrl_cb(req, rsp_cb, NULL, true);
 }
 
 static int bt_a2dp_stream_ctrl_pre(struct bt_a2dp_stream *stream, bt_avdtp_func_t cb)

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -152,6 +152,98 @@ static inline void bt_avdtp_clear_req(struct bt_avdtp *session)
 	avdtp_unlock(session);
 }
 
+static int avdtp_media_disconnect(struct bt_avdtp_sep *sep)
+{
+	if (sep == NULL || sep->chan.chan.conn == NULL || sep->chan.chan.ops == NULL) {
+		return -EINVAL;
+	}
+
+	return bt_l2cap_chan_disconnect(&sep->chan.chan);
+}
+
+static bool avdtp_media_chan_valid(struct bt_avdtp_sep *sep)
+{
+	/* another way is checking whether the `chan` is in `conn->channels`. */
+	if ((sep->chan.state != BT_L2CAP_DISCONNECTED) &&
+	    (sep->chan.chan.conn != NULL) &&
+	    (sep->chan.chan.ops != NULL) &&
+	    (sep->state != AVDTP_IDLE)) {
+		return true;
+	}
+
+	if (((sep->chan.state != BT_L2CAP_DISCONNECTED) ||
+	     (sep->chan.chan.conn != NULL)) &&
+	    (sep->state != AVDTP_IDLE)) {
+		LOG_ERR("Media chan is disconnected, but sep state is %u", sep->state);
+	}
+
+	if (((sep->chan.state != BT_L2CAP_DISCONNECTED) ||
+	     (sep->chan.chan.conn != NULL)) &&
+	    (sep->state == AVDTP_IDLE)) {
+		LOG_ERR("Sep state is IDLE, but stream chan is not disconnected");
+	}
+
+	return false;
+}
+
+static void avdtp_endpoint_released(struct bt_avdtp_sep *sep)
+{
+	if (sep->endpoint_released != NULL) {
+		sep->endpoint_released(sep);
+	}
+}
+
+#define DELAY_WORK_RETRY 1
+#define DELAY_WORK_CHECK 2
+#define RETRY_MEDIA_DISCONNECT_TIMEOUT 100
+#define CHECK_MEDIA_DISCONNECT_TIMEOUT 3000
+
+static void avdtp_schedule_media_disconnect_work(struct bt_avdtp_sep *sep, uint8_t state)
+{
+	uint32_t timeout;
+
+	sep->_delay_work_state = state;
+
+	if (state == DELAY_WORK_RETRY) {
+		timeout = RETRY_MEDIA_DISCONNECT_TIMEOUT;
+	} else {
+		timeout = CHECK_MEDIA_DISCONNECT_TIMEOUT;
+	}
+
+	k_work_schedule(&sep->_delay_work, K_MSEC(timeout));
+}
+
+static void avdtp_cancel_media_disconnect_work(struct bt_avdtp_sep *sep)
+{
+	k_work_cancel_delayable(&sep->_delay_work);
+}
+
+static void avdtp_media_disconnect_work(struct k_work *work)
+{
+	struct bt_avdtp_sep *sep = CONTAINER_OF(work, struct bt_avdtp_sep, _delay_work.work);
+
+	if (!avdtp_media_chan_valid(sep)) {
+		if (sep->state != AVDTP_IDLE) {
+			bt_avdtp_set_state_lock(sep, AVDTP_IDLE);
+			avdtp_endpoint_released(sep);
+		}
+
+		return;
+	}
+
+	if (sep->_delay_work_state == DELAY_WORK_RETRY) {
+		int err;
+
+		err = avdtp_media_disconnect(sep);
+		if (err == 0) {
+			avdtp_schedule_media_disconnect_work(sep, DELAY_WORK_CHECK);
+			return;
+		}
+	}
+
+	/* TODO: disconnect acl or notify application? */
+}
+
 /* L2CAP Interface callbacks */
 void bt_avdtp_media_l2cap_connected(struct bt_l2cap_chan *chan)
 {
@@ -195,6 +287,8 @@ void bt_avdtp_media_l2cap_disconnected(struct bt_l2cap_chan *chan)
 
 	LOG_DBG("chan %p", chan);
 	chan->conn = NULL;
+	avdtp_cancel_media_disconnect_work(sep);
+
 	avdtp_sep_lock(sep);
 
 	if ((sep->state == AVDTP_CLOSING) && (session->req != NULL) &&
@@ -210,14 +304,13 @@ void bt_avdtp_media_l2cap_disconnected(struct bt_l2cap_chan *chan)
 		if (req->func != NULL) {
 			req->func(req, NULL);
 		}
-	} else if (sep->state > AVDTP_OPENING) {
+	} else {
 		bt_avdtp_set_state(sep, AVDTP_IDLE);
 		avdtp_sep_unlock(sep);
-		/* the l2cap is disconnected by other unexpected reasons */
-		session->ops->stream_l2cap_disconnected(session, sep);
-	} else {
-		avdtp_sep_unlock(sep);
 	}
+
+	/* the media l2cap is disconnected by other unexpected reasons */
+	avdtp_endpoint_released(sep);
 }
 
 int bt_avdtp_media_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
@@ -250,15 +343,6 @@ static int avdtp_media_connect(struct bt_avdtp *session, struct bt_avdtp_sep *se
 
 	return bt_l2cap_chan_connect(session->br_chan.chan.conn, &sep->chan.chan,
 				     BT_L2CAP_PSM_AVDTP);
-}
-
-static int avdtp_media_disconnect(struct bt_avdtp_sep *sep)
-{
-	if (sep == NULL || sep->chan.chan.conn == NULL || sep->chan.chan.ops == NULL) {
-		return -EINVAL;
-	}
-
-	return bt_l2cap_chan_disconnect(&sep->chan.chan);
 }
 
 static struct net_buf *avdtp_create_pdu(uint8_t msg_type, uint8_t sig_id, uint8_t tid)
@@ -1139,11 +1223,28 @@ static void avdtp_close_cmd(struct bt_avdtp *session, struct net_buf *buf, uint8
 
 	err = avdtp_send_rsp(session, rsp_buf);
 
-	if (!err && !avdtp_err_code) {
-		bt_avdtp_set_state(sep, AVDTP_IDLE);
-	}
+	/* From AVDTP spec, endpoint state should be idle after responsing CLOSE.
+	 * But before the sep->chan is released, the sep can't be used from stack
+	 * perspective, so waiting the stream chan released.
+	 */
+	if (err == 0 && avdtp_err_code == 0) {
+		if (avdtp_media_chan_valid(sep)) {
+			avdtp_sep_unlock(sep);
 
-	avdtp_sep_unlock(sep);
+			/* TODO: If the INT does not close the transport channels within 3 seconds
+			 * the ACP device may initiate the ABORT procedure to reset the states on
+			 * both sides.
+			 */
+			avdtp_schedule_media_disconnect_work(sep, DELAY_WORK_CHECK);
+		} else {
+			bt_avdtp_set_state(sep, AVDTP_IDLE);
+			avdtp_sep_unlock(sep);
+
+			avdtp_endpoint_released(sep);
+		}
+	} else {
+		avdtp_sep_unlock(sep);
+	}
 }
 
 static void avdtp_close_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8_t msg_type)
@@ -1158,10 +1259,30 @@ static void avdtp_close_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8
 	avdtp_set_status(req, buf, msg_type);
 
 	if (req->status == BT_AVDTP_SUCCESS) {
-		bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_CLOSING);
+		struct bt_avdtp_sep *sep = CTRL_REQ(req)->sep;
 
-		if (!avdtp_media_disconnect(CTRL_REQ(req)->sep)) {
-			return;
+		/* release stream */
+		avdtp_sep_lock(sep);
+		if (avdtp_media_chan_valid(sep)) {
+			int err;
+			uint8_t work_state;
+
+			bt_avdtp_set_state(sep, AVDTP_CLOSING);
+			avdtp_sep_unlock(sep);
+
+			err = avdtp_media_disconnect(sep);
+			if (err != 0) {
+				work_state = DELAY_WORK_RETRY;
+			} else {
+				work_state = DELAY_WORK_CHECK;
+			}
+
+			avdtp_schedule_media_disconnect_work(sep, work_state);
+		} else {
+			bt_avdtp_set_state(sep, AVDTP_IDLE);
+			avdtp_sep_unlock(sep);
+
+			avdtp_endpoint_released(sep);
 		}
 	}
 
@@ -1281,15 +1402,20 @@ static void avdtp_abort_cmd(struct bt_avdtp *session, struct net_buf *buf, uint8
 	err = avdtp_send_rsp(session, rsp_buf);
 
 	if (!err && !avdtp_err_code) {
-		if ((sep->state & (AVDTP_OPEN | AVDTP_STREAMING)) &&
-		    (sep->chan.state == BT_L2CAP_CONNECTED)) {
+		if (avdtp_media_chan_valid(sep)) {
 			bt_avdtp_set_state(sep, AVDTP_ABORTING);
+			avdtp_sep_unlock(sep);
+
+			avdtp_schedule_media_disconnect_work(sep, DELAY_WORK_CHECK);
 		} else {
 			bt_avdtp_set_state(sep, AVDTP_IDLE);
-		}
-	}
+			avdtp_sep_unlock(sep);
 
-	avdtp_sep_unlock(sep);
+			avdtp_endpoint_released(sep);
+		}
+	} else {
+		avdtp_sep_unlock(sep);
+	}
 }
 
 static void avdtp_abort_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8_t msg_type)
@@ -1303,25 +1429,36 @@ static void avdtp_abort_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8
 	k_work_cancel_delayable(&session->timeout_work);
 
 	if (msg_type == BT_AVDTP_ACCEPT) {
-		uint8_t pre_state = CTRL_REQ(req)->sep->state;
+		struct bt_avdtp_sep *sep = CTRL_REQ(req)->sep;
 
-		bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_ABORTING);
+		req->status = BT_AVDTP_SUCCESS;
 
 		/* release stream */
-		if (pre_state & (AVDTP_OPEN | AVDTP_STREAMING)) {
-			avdtp_media_disconnect(CTRL_REQ(req)->sep);
+		avdtp_sep_lock(sep);
+		if (avdtp_media_chan_valid(sep)) {
+			int err;
+			uint8_t work_state;
+
+			bt_avdtp_set_state(sep, AVDTP_ABORTING);
+			avdtp_sep_unlock(sep);
+
+			err = avdtp_media_disconnect(sep);
+			if (err != 0) {
+				work_state = DELAY_WORK_RETRY;
+			} else {
+				work_state = DELAY_WORK_CHECK;
+			}
+
+			avdtp_schedule_media_disconnect_work(sep, work_state);
+		} else {
+			bt_avdtp_set_state(sep, AVDTP_IDLE);
+			avdtp_sep_unlock(sep);
+
+			avdtp_endpoint_released(sep);
 		}
-
-		/* For abort, make sure the state revert to IDLE state after
-		 * releasing l2cap channel.
-		 */
-		bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_IDLE);
-	} else if (msg_type == BT_AVDTP_REJECT) {
-		avdtp_handle_reject(buf, req);
-	}
-
-	if (req->status == BT_AVDTP_SUCCESS) {
-		avdtp_set_status(req, buf, msg_type);
+	} else {
+		/* Spec only allows accept, spec doesn't define the packet format of reject. */
+		req->status = BT_AVDTP_BAD_STATE;
 	}
 
 	bt_avdtp_clear_req(session);
@@ -1412,6 +1549,34 @@ void bt_avdtp_l2cap_connected(struct bt_l2cap_chan *chan)
 	session->ops->connected(session);
 }
 
+static void avdtp_release_work(struct k_work *work)
+{
+	struct bt_avdtp_sep *sep, *next;
+	struct bt_avdtp *session = CONTAINER_OF(work, struct bt_avdtp, _release_work);
+	int err;
+	uint8_t work_state;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&seps, sep, next, _node) {
+		if (sep->session != session || sep->state == AVDTP_IDLE) {
+			continue;
+		}
+
+		if (avdtp_media_chan_valid(sep)) {
+			err = avdtp_media_disconnect(sep);
+			if (err != 0) {
+				work_state = DELAY_WORK_RETRY;
+			} else {
+				work_state = DELAY_WORK_CHECK;
+			}
+
+			avdtp_schedule_media_disconnect_work(sep, work_state);
+		} else {
+			bt_avdtp_set_state_lock(sep, AVDTP_IDLE);
+			avdtp_endpoint_released(sep);
+		}
+	}
+}
+
 void bt_avdtp_clear_tx(struct bt_avdtp *session)
 {
 	struct net_buf *buf, *next;
@@ -1456,6 +1621,8 @@ void bt_avdtp_l2cap_disconnected(struct bt_l2cap_chan *chan)
 
 	/* notify a2dp disconnect */
 	session->ops->disconnected(session);
+
+	k_work_submit(&session->_release_work);
 }
 
 void (*cmd_handler[])(struct bt_avdtp *session, struct net_buf *buf, uint8_t tid) = {
@@ -1768,6 +1935,7 @@ int bt_avdtp_connect(struct bt_conn *conn, struct bt_avdtp *session)
 
 	/* Locking semaphore initialized to 1 (unlocked) */
 	k_sem_init(&session->sem_lock, 1, 1);
+	k_work_init(&session->_release_work, avdtp_release_work);
 	session->br_chan.rx.mtu = BT_L2CAP_RX_MTU;
 	session->br_chan.chan.ops = &signal_chan_ops;
 	session->br_chan.required_sec_level = BT_SECURITY_L2;
@@ -1777,11 +1945,28 @@ int bt_avdtp_connect(struct bt_conn *conn, struct bt_avdtp *session)
 
 int bt_avdtp_disconnect(struct bt_avdtp *session)
 {
+	struct bt_avdtp_sep *sep, *next;
+	int err;
+
 	if (!session) {
 		return -EINVAL;
 	}
 
 	LOG_DBG("session %p", session);
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&seps, sep, next, _node) {
+		if ((sep->session != session) || (!avdtp_media_chan_valid(sep))) {
+			continue;
+		}
+
+		err = avdtp_media_disconnect(sep);
+		if (err != 0) {
+			LOG_ERR("fail to disconnect media connection");
+			return err;
+		}
+
+		avdtp_schedule_media_disconnect_work(sep, DELAY_WORK_CHECK);
+	}
 
 	return bt_l2cap_chan_disconnect(&session->br_chan.chan);
 }
@@ -1812,6 +1997,7 @@ int bt_avdtp_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 		k_sem_give(&avdtp_sem_lock);
 		/* Locking semaphore initialized to 1 (unlocked) */
 		k_sem_init(&session->sem_lock, 1, 1);
+		k_work_init(&session->_release_work, avdtp_release_work);
 		session->br_chan.chan.ops = &signal_chan_ops;
 		session->br_chan.rx.mtu = BT_L2CAP_RX_MTU;
 		*chan = &session->br_chan.chan;
@@ -1876,6 +2062,7 @@ int bt_avdtp_register_sep(uint8_t media_type, uint8_t sep_type, struct bt_avdtp_
 	sep->sep_info.tsep = sep_type;
 	/* Locking semaphore initialized to 1 (unlocked) */
 	k_sem_init(&sep->sem_lock, 1, 1);
+	k_work_init_delayable(&sep->_delay_work, avdtp_media_disconnect_work);
 	bt_avdtp_set_state_lock(sep, AVDTP_IDLE);
 
 	sys_slist_append(&seps, &sep->_node);
@@ -2161,9 +2348,12 @@ int bt_avdtp_suspend(struct bt_avdtp *session, struct bt_avdtp_ctrl_params *para
 
 int bt_avdtp_abort(struct bt_avdtp *session, struct bt_avdtp_ctrl_params *param)
 {
+	/* from ACP and INT point of views, when the state is CONFIGURED, OPEN, STREAMING or
+	 * CLOSING. However, AVDTP_ABORT_CMD can be sent or received in IDLE state.
+	 */
 	return bt_avdtp_ctrl(session, param, BT_AVDTP_ABORT,
-			     AVDTP_CONFIGURED | AVDTP_OPENING | AVDTP_OPEN | AVDTP_STREAMING |
-				     AVDTP_CLOSING);
+			     AVDTP_IDLE | AVDTP_CONFIGURED | AVDTP_OPENING | AVDTP_OPEN |
+			     AVDTP_STREAMING | AVDTP_CLOSING);
 }
 
 int bt_avdtp_send_media_data(struct bt_avdtp_sep *sep, struct net_buf *buf)

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -954,6 +954,7 @@ static void avdtp_process_configuration_cmd(struct bt_avdtp *session, struct net
 	err = avdtp_send_rsp(session, rsp_buf);
 
 	if (!reconfig && !err && !avdtp_err_code) {
+		sep->session = session;
 		bt_avdtp_set_state(sep, AVDTP_CONFIGURED);
 	}
 
@@ -987,6 +988,10 @@ static void avdtp_process_configuration_rsp(struct bt_avdtp *session, struct net
 
 	if (req->status == BT_AVDTP_SUCCESS) {
 		avdtp_set_status(req, buf, msg_type);
+	}
+
+	if (req->status == BT_AVDTP_SUCCESS) {
+		SET_CONF_REQ(req)->sep->session = session;
 	}
 
 	bt_avdtp_clear_req(session);

--- a/subsys/bluetooth/host/classic/avdtp_internal.h
+++ b/subsys/bluetooth/host/classic/avdtp_internal.h
@@ -259,9 +259,6 @@ struct bt_avdtp_ops_cb {
 	int (*suspend_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode);
 
 	int (*abort_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode);
-
-	/* stream l2cap is closed */
-	int (*stream_l2cap_disconnected)(struct bt_avdtp *session, struct bt_avdtp_sep *sep);
 };
 
 /** @brief Global AVDTP session structure. */
@@ -271,6 +268,7 @@ struct bt_avdtp {
 	const struct bt_avdtp_ops_cb *ops;
 	struct bt_avdtp_sep *current_sep;
 	struct k_work_delayable timeout_work;
+	struct k_work _release_work;
 	/* semaphore for lock/unlock */
 	struct k_sem sem_lock;
 	struct net_buf *reasm_buf;

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -433,11 +433,6 @@ void stream_suspended(struct bt_a2dp_stream *stream)
 	bt_shell_print("stream suspended");
 }
 
-void stream_aborted(struct bt_a2dp_stream *stream)
-{
-	bt_shell_print("stream aborted");
-}
-
 void sink_sbc_streamer_data(struct bt_a2dp_stream *stream, struct net_buf *buf,
 			uint16_t seq_num, uint32_t ts)
 {
@@ -595,7 +590,6 @@ static struct bt_a2dp_stream_ops stream_ops = {
 	.released = stream_released,
 	.started = stream_started,
 	.suspended = stream_suspended,
-	.aborted = stream_aborted,
 #if defined(CONFIG_BT_A2DP_SINK)
 	.recv = stream_recv,
 #endif


### PR DESCRIPTION
When signal l2cap is disconnected, use `release_work` to release the
related stream l2cap connections. When releasing the sep's stream l2cap,
use `delay_work` to check the stream l2cap disconnecting result.