### PR TITLE
kconfig: flash: Cleanup FLASH_SIZE and FLASH_BASE_ADDRESS

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -248,8 +248,7 @@ DT_CHOSEN_Z_FLASH := zephyr,flash
 
 config FLASH_SIZE
 	int "Flash Size in kB"
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K) if (XIP && (ARM ||ARM64)) || !ARM
-	default 0 if !XIP
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 	help
 	  This option specifies the size of the flash in kB.  It is normally set by
 	  the board's defconfig file and the user should generally avoid modifying
@@ -257,8 +256,7 @@ config FLASH_SIZE
 
 config FLASH_BASE_ADDRESS
 	hex "Flash Base Address"
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)) if (XIP && (ARM || ARM64)) || !ARM
-	default 0 if !XIP
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 	help
 	  This option specifies the base address of the flash on the board. It is
 	  normally set by the board's defconfig file and the user should generally

--- a/soc/arm/fvp_aemv8a/Kconfig.defconfig
+++ b/soc/arm/fvp_aemv8a/Kconfig.defconfig
@@ -10,17 +10,4 @@ config NUM_IRQS
 	default 16384 if GIC_V3_ITS
 	default 128 if !GIC_V3_ITS
 
-if SOC_FVP_BASE_REVC_2XAEMV8A
-
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
-endif # SOC_FVP_BASE_REVC_2XAEMV8A
-
 endif # SOC_SERIES_FVP_AEMV8A

--- a/soc/arm/qemu_cortex_a53/Kconfig.defconfig
+++ b/soc/arm/qemu_cortex_a53/Kconfig.defconfig
@@ -13,13 +13,4 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 62500000
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 endif # SOC_QEMU_CORTEX_A53

--- a/soc/arm/qemu_virt_arm64/Kconfig.defconfig
+++ b/soc/arm/qemu_virt_arm64/Kconfig.defconfig
@@ -14,13 +14,4 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 1
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 endif # SOC_QEMU_VIRT_ARM64

--- a/soc/nxp/common/Kconfig.xspi_xip
+++ b/soc/nxp/common/Kconfig.xspi_xip
@@ -8,7 +8,6 @@ DT_CHOSEN_FLASH_NODE := $(dt_chosen_path,$(DT_CHOSEN_Z_FLASH))
 DT_CHOSEN_FLASH_PARENT := $(dt_node_parent,$(DT_CHOSEN_FLASH_NODE))
 
 DT_FLASH_PARENT_IS_XSPI := $(dt_node_has_compat,$(DT_CHOSEN_FLASH_PARENT),$(DT_COMPAT_XSPI))
-DT_FLASH_HAS_SIZE_PROP := $(dt_node_has_prop,$(DT_CHOSEN_FLASH_NODE),size)
 
 config FLASH_BASE_ADDRESS
 	default $(dt_node_reg_addr_hex,$(DT_CHOSEN_FLASH_PARENT),1) \

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_a53
@@ -3,15 +3,6 @@
 
 if SOC_MIMX8ML8_A53
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 # Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
 config GIC_SAFE_CONFIG
 	default y

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_a53
@@ -3,15 +3,6 @@
 
 if SOC_MIMX8MM6_A53
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 # Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
 config GIC_SAFE_CONFIG
 	default y

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mn6_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mn6_a53
@@ -3,15 +3,6 @@
 
 if SOC_MIMX8MN6_A53
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 # Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
 config GIC_SAFE_CONFIG
 	default y

--- a/soc/nxp/imx/imx9/imx91/Kconfig.defconfig.mimx91
+++ b/soc/nxp/imx/imx9/imx91/Kconfig.defconfig.mimx91
@@ -3,15 +3,6 @@
 
 if SOC_MIMX9131
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 config NUM_IRQS
 	default 300
 

--- a/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.a55
+++ b/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.a55
@@ -3,15 +3,6 @@
 
 if SOC_MIMX9352_A55
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 # Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
 config GIC_SAFE_CONFIG
 	default y

--- a/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.m33
+++ b/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.m33
@@ -3,14 +3,6 @@
 
 if SOC_MIMX9352_M33
 
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 config NUM_IRQS
 	default 268
 

--- a/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.a55
+++ b/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.a55
@@ -3,15 +3,6 @@
 
 if SOC_MIMX94398_A55
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 # Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
 config GIC_SAFE_CONFIG
 	default y

--- a/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m33
+++ b/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m33
@@ -3,14 +3,6 @@
 
 if SOC_MIMX94398_M33
 
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 config MCUX_CORE_SUFFIX
 	default "_cm33_core1" if SOC_MIMX94398_M33
 

--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.a55
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.a55
@@ -3,15 +3,6 @@
 
 if SOC_MIMX9596_A55
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 # Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
 config GIC_SAFE_CONFIG
 	default y

--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
@@ -3,14 +3,6 @@
 
 if SOC_MIMX9596_M7
 
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 # multi-level interrupts
 config MULTI_LEVEL_INTERRUPTS
 	default y

--- a/soc/renesas/rz/rza2m/Kconfig.defconfig
+++ b/soc/renesas/rz/rza2m/Kconfig.defconfig
@@ -9,12 +9,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config NUM_IRQS
 	default 512
 
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 DT_CHOSEN_Z_SRAM = zephyr,sram
 

--- a/soc/renesas/rz/rza3ul/Kconfig.defconfig
+++ b/soc/renesas/rz/rza3ul/Kconfig.defconfig
@@ -12,12 +12,6 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 24000000
 
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 DT_CHOSEN_SRAM_ZEPHYR = zephyr,sram
 

--- a/soc/renesas/rz/rzg2l/Kconfig.defconfig
+++ b/soc/renesas/rz/rzg2l/Kconfig.defconfig
@@ -9,12 +9,6 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 config SYS_CLOCK_EXISTS
 	default y
 

--- a/soc/renesas/rz/rzg2ul/Kconfig.defconfig
+++ b/soc/renesas/rz/rzg2ul/Kconfig.defconfig
@@ -9,12 +9,6 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 config SYS_CLOCK_EXISTS
 	default y
 

--- a/soc/renesas/rz/rzg3s/Kconfig.defconfig
+++ b/soc/renesas/rz/rzg3s/Kconfig.defconfig
@@ -10,12 +10,6 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 config SYS_CLOCK_EXISTS
 	default y
 

--- a/soc/renesas/rz/rzn2l/Kconfig.defconfig
+++ b/soc/renesas/rz/rzn2l/Kconfig.defconfig
@@ -12,12 +12,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config FPU
 	default y
 
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 
 config BUILD_OUTPUT_ADJUST_LMA

--- a/soc/renesas/rz/rzt2l/Kconfig.defconfig
+++ b/soc/renesas/rz/rzt2l/Kconfig.defconfig
@@ -12,12 +12,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config FPU
 	default y
 
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 
 config BUILD_OUTPUT_ADJUST_LMA

--- a/soc/renesas/rz/rzt2m/Kconfig.defconfig
+++ b/soc/renesas/rz/rzt2m/Kconfig.defconfig
@@ -13,12 +13,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config FPU
 	default y
 
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 
 config BUILD_OUTPUT_ADJUST_LMA

--- a/soc/renesas/rz/rzv2h/Kconfig.defconfig.rzv2h_cm33
+++ b/soc/renesas/rz/rzv2h/Kconfig.defconfig.rzv2h_cm33
@@ -9,12 +9,6 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 config SYS_CLOCK_EXISTS
 	default y
 

--- a/soc/renesas/rz/rzv2h/Kconfig.defconfig.rzv2h_cr8
+++ b/soc/renesas/rz/rzv2h/Kconfig.defconfig.rzv2h_cr8
@@ -12,12 +12,6 @@ config FPU
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(div,$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency),4)
 
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 config SYS_CLOCK_EXISTS
 	default y
 

--- a/soc/renesas/rz/rzv2l/Kconfig.defconfig
+++ b/soc/renesas/rz/rzv2l/Kconfig.defconfig
@@ -9,12 +9,6 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 config SYS_CLOCK_EXISTS
 	default y
 

--- a/soc/renesas/rz/rzv2n/Kconfig.defconfig
+++ b/soc/renesas/rz/rzv2n/Kconfig.defconfig
@@ -9,12 +9,6 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default	$(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 config SYS_CLOCK_EXISTS
 	default y
 

--- a/soc/renode/cortex_r8_virtual/Kconfig.defconfig
+++ b/soc/renode/cortex_r8_virtual/Kconfig.defconfig
@@ -9,12 +9,4 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 5000000
 
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 endif # SOC_CORTEX_R8_VIRTUAL

--- a/soc/ti/k3/am6x/Kconfig.defconfig
+++ b/soc/ti/k3/am6x/Kconfig.defconfig
@@ -6,15 +6,6 @@ if SOC_SERIES_AM6X
 config KERNEL_ENTRY
 	default "_vector_table" if SOC_SERIES_AM6X_R5
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 config NUM_IRQS
 	default 64 if SOC_SERIES_AM6X_M4
 	default 280 if SOC_SERIES_AM6X_A53

--- a/soc/ti/mspm0/Kconfig.defconfig
+++ b/soc/ti/mspm0/Kconfig.defconfig
@@ -6,14 +6,6 @@ if SOC_FAMILY_TI_MSPM0
 
 rsource "*/Kconfig.defconfig"
 
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 DT_MSPM0_MCLK_PATH := $(dt_nodelabel_path,mclk)
 DT_MSPM0_MCLK_CPU_FREQ := $(dt_node_int_prop_int,$(DT_MSPM0_MCLK_PATH),clock-frequency)
 

--- a/soc/xlnx/zynq7000/Kconfig.defconfig
+++ b/soc/xlnx/zynq7000/Kconfig.defconfig
@@ -11,15 +11,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 96
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 config SOC_RESET_HOOK
 	default y
 

--- a/soc/xlnx/zynqmp/Kconfig.defconfig
+++ b/soc/xlnx/zynqmp/Kconfig.defconfig
@@ -16,13 +16,4 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 
 endif # SOC_XILINX_ZYNQMP_RPU
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_SIZE
-	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 endif # SOC_XILINX_ZYNQMP


### PR DESCRIPTION
Symbols `FLASH_SIZE` and `FLASH_BASE_ADDRESS` were unnecessarily duplicated over SoCs configuration.