### PR TITLE
soc_native: Fix missing include of stdbool.h

### DIFF
--- a/soc/native/inf_clock/posix_soc.h
+++ b/soc/native/inf_clock/posix_soc.h
@@ -7,6 +7,7 @@
 #ifndef _POSIX_POSIX_SOC_INF_CLOCK_H
 #define _POSIX_POSIX_SOC_INF_CLOCK_H
 
+#include <stdbool.h>
 #include <zephyr/arch/posix/posix_soc_if.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
The header posix_soc.h was missing include of stdbool.h as bool is used as a function parameter.