### PR TITLE
DSA header inclusion fix

### DIFF
--- a/drivers/ethernet/dsa/dsa_nxp_imx_netc.c
+++ b/drivers/ethernet/dsa/dsa_nxp_imx_netc.c
@@ -7,7 +7,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dsa_netc, CONFIG_ETHERNET_LOG_LEVEL);
 
-#include <zephyr/net/ethernet.h>
+#include <zephyr/net/dsa_core.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/ethernet/nxp_imx_netc.h>
 #include <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -78,6 +78,7 @@ static int netc_eth_rx(const struct device *dev)
 	struct net_if *iface_dst = data->iface;
 #if defined(NETC_HAS_NO_SWITCH_TAG_SUPPORT)
 	struct ethernet_context *ctx = net_if_l2_data(iface_dst);
+	struct dsa_switch_context *dsa_switch_ctx = ctx->dsa_switch_ctx;
 #endif
 	netc_frame_attr_t attr = {0};
 	struct net_pkt *pkt;
@@ -111,7 +112,7 @@ static int netc_eth_rx(const struct device *dev)
 
 #if defined(NETC_HAS_NO_SWITCH_TAG_SUPPORT)
 	if (ctx->dsa_port == DSA_CONDUIT_PORT) {
-		iface_dst = ctx->dsa_switch_ctx->iface_user[attr.srcPort];
+		iface_dst = dsa_switch_ctx->iface_user[attr.srcPort];
 	}
 #endif
 	/* Copy to pkt */

--- a/include/zephyr/net/dsa_core.h
+++ b/include/zephyr/net/dsa_core.h
@@ -15,6 +15,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/phy.h>
+#include <zephyr/net/ethernet.h>
 
 /**
  * @brief Distributed Switch Architecture (DSA)
@@ -31,12 +32,6 @@
 #define DSA_PORT_MAX_COUNT CONFIG_DSA_PORT_MAX_COUNT
 #else
 #define DSA_PORT_MAX_COUNT 0
-#endif
-
-#if defined(CONFIG_DSA_TAG_SIZE)
-#define DSA_TAG_SIZE CONFIG_DSA_TAG_SIZE
-#else
-#define DSA_TAG_SIZE 0
 #endif
 
 /** @endcond */
@@ -146,14 +141,6 @@ struct dsa_port_config {
 };
 
 /** @cond INTERNAL_HIDDEN */
-
-enum dsa_port_type {
-	NON_DSA_PORT,
-	DSA_CONDUIT_PORT,
-	DSA_USER_PORT,
-	DSA_CPU_PORT,
-	DSA_PORT,
-};
 
 /*
  * DSA port init

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -699,7 +699,7 @@ struct ethernet_context {
 	enum dsa_port_type dsa_port;
 
 	/** DSA switch context pointer */
-	struct dsa_switch_context *dsa_switch_ctx;
+	void *dsa_switch_ctx;
 #endif
 
 	/** Is network carrier up */

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -28,8 +28,6 @@
 
 #if defined(CONFIG_NET_DSA_DEPRECATED)
 #include <zephyr/net/dsa.h>
-#else
-#include <zephyr/net/dsa_core.h>
 #endif
 
 #if defined(CONFIG_NET_ETHERNET_BRIDGE)
@@ -131,6 +129,12 @@ struct net_eth_addr {
 
 #define _NET_ETH_MAX_FRAME_SIZE	(NET_ETH_MTU + _NET_ETH_MAX_HDR_SIZE)
 
+#if defined(CONFIG_DSA_TAG_SIZE)
+#define DSA_TAG_SIZE CONFIG_DSA_TAG_SIZE
+#else
+#define DSA_TAG_SIZE 0
+#endif
+
 #define NET_ETH_MAX_FRAME_SIZE (_NET_ETH_MAX_FRAME_SIZE + DSA_TAG_SIZE)
 #define NET_ETH_MAX_HDR_SIZE (_NET_ETH_MAX_HDR_SIZE + DSA_TAG_SIZE)
 
@@ -205,6 +209,16 @@ enum ethernet_hw_caps {
 };
 
 /** @cond INTERNAL_HIDDEN */
+
+#if !defined(CONFIG_NET_DSA_DEPRECATED)
+enum dsa_port_type {
+	NON_DSA_PORT,
+	DSA_CONDUIT_PORT,
+	DSA_USER_PORT,
+	DSA_CPU_PORT,
+	DSA_PORT,
+};
+#endif
 
 enum ethernet_config_type {
 	ETHERNET_CONFIG_TYPE_MAC_ADDRESS,

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -32,6 +32,9 @@ LOG_MODULE_REGISTER(net_core, CONFIG_NET_CORE_LOG_LEVEL);
 #include <zephyr/net/gptp.h>
 #include <zephyr/net/websocket.h>
 #include <zephyr/net/ethernet.h>
+#if defined(CONFIG_NET_DSA) && !defined(CONFIG_NET_DSA_DEPRECATED)
+#include <zephyr/net/dsa_core.h>
+#endif
 #include <zephyr/net/capture.h>
 
 #if defined(CONFIG_NET_LLDP)

--- a/subsys/net/l2/ethernet/dsa/dsa_tag_netc.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_tag_netc.c
@@ -28,6 +28,7 @@ struct dsa_tag_netc_to_port_header {
 struct net_if *dsa_tag_netc_recv(struct net_if *iface, struct net_pkt *pkt)
 {
 	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
+	struct dsa_switch_context *dsa_switch_ctx = eth_ctx->dsa_switch_ctx;
 	uint16_t header_len = sizeof(struct dsa_tag_netc_to_host_header);
 	struct dsa_tag_netc_to_host_header *header;
 	struct net_if *iface_dst = iface;
@@ -40,7 +41,7 @@ struct net_if *dsa_tag_netc_recv(struct net_if *iface, struct net_pkt *pkt)
 
 	/* redirect to user port */
 	header = (struct dsa_tag_netc_to_host_header *)pkt->frags->data;
-	iface_dst = eth_ctx->dsa_switch_ctx->iface_user[header->tag.comTag.port];
+	iface_dst = dsa_switch_ctx->iface_user[header->tag.comTag.port];
 
 	/* drop tag */
 	ptr = net_buf_pull(pkt->frags, sizeof(netc_swt_tag_host_t));

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -13,6 +13,9 @@ LOG_MODULE_REGISTER(net_ethernet, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/ethernet_mgmt.h>
+#if defined(CONFIG_NET_DSA) && !defined(CONFIG_NET_DSA_DEPRECATED)
+#include <zephyr/net/dsa_core.h>
+#endif
 #include <zephyr/net/gptp.h>
 #include <zephyr/random/random.h>
 


### PR DESCRIPTION
    DSA is part of Ethernet and will utilize more Ethernet definitions for
    more features support. So, it's proper to let DSA header include
    Ethernet header with moving some DSA definiton from DSA header to
    Ethernet header and adding DSA header including in c files using DSA
    definition.