### PR TITLE
kconfig: Load Kconfig env file better

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 source "Kconfig.constants"
-source "$(KCONFIG_ENV_FILE)"
 
 osource "$(APPLICATION_SOURCE_DIR)/VERSION"
 

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -132,10 +132,13 @@ endif()
 # APP_DIR: Path to the main image (sysbuild) or synonym for APPLICATION_SOURCE_DIR (non-sysbuild)
 zephyr_get(APP_DIR VAR APP_DIR APPLICATION_SOURCE_DIR)
 
+# Load the module Kconfig file into CMake
+include("${KCONFIG_BINARY_DIR}/kconfig_module_dirs.cmake")
+
 set(COMMON_KCONFIG_ENV_SETTINGS
   PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
-  KCONFIG_ENV_FILE=${KCONFIG_BINARY_DIR}/kconfig_module_dirs.env
   srctree=${ZEPHYR_BASE}
+  ${kconfig_env_dirs}
   KERNELVERSION=${KERNELVERSION}
   APPVERSION=${APP_VERSION_STRING}
   APP_VERSION_EXTENDED_STRING=${APP_VERSION_EXTENDED_STRING}

--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -44,6 +44,7 @@ from tempfile import TemporaryDirectory
 from typing import Any
 
 from docutils import nodes
+from dotenv import load_dotenv
 from sphinx.addnodes import pending_xref
 from sphinx.application import Sphinx
 from sphinx.builders import Builder
@@ -81,7 +82,8 @@ def kconfig_load(app: Sphinx) -> tuple[kconfiglib.Kconfig, kconfiglib.Kconfig, d
         sysbuild_kconfig = ""
         for module in modules:
             kconfig_module_dirs += zephyr_module.process_kconfig_module_dir(module.project,
-                                                                            module.meta)
+                                                                            module.meta,
+                                                                            False)
             kconfig += zephyr_module.process_kconfig(module.project, module.meta)
             sysbuild_kconfig += zephyr_module.process_sysbuildkconfig(module.project, module.meta)
 
@@ -155,7 +157,7 @@ def kconfig_load(app: Sphinx) -> tuple[kconfiglib.Kconfig, kconfiglib.Kconfig, d
 
         os.environ["BOARD"] = "boards"
         os.environ["KCONFIG_BOARD_DIR"] = str(Path(td) / "boards")
-        os.environ["KCONFIG_ENV_FILE"] = str(Path(td) / "kconfig_module_dirs.env")
+        load_dotenv(str(Path(td) / "kconfig_module_dirs.env"))
 
         # Sysbuild runs first
         os.environ["CONFIG_"] = "SB_CONFIG_"

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -23,6 +23,8 @@ import textwrap
 import unidiff
 import yaml
 
+from dotenv import load_dotenv
+
 from yamllint import config, linter
 
 from junitparser import TestCase, TestSuite, JUnitXml, Skipped, Error, Failure
@@ -700,14 +702,14 @@ class KconfigCheck(ComplianceTest):
         os.environ["KCONFIG_BINARY_DIR"] = kconfiglib_dir
         os.environ['DEVICETREE_CONF'] = "dummy"
         os.environ['TOOLCHAIN_HAS_NEWLIB'] = "y"
-        os.environ['KCONFIG_ENV_FILE'] = os.path.join(kconfiglib_dir, "kconfig_module_dirs.env")
+        kconfig_env_file = os.path.join(kconfiglib_dir, "kconfig_module_dirs.env")
 
         # Older name for DEVICETREE_CONF, for compatibility with older Zephyr
         # versions that don't have the renaming
         os.environ["GENERATED_DTS_BOARD_CONF"] = "dummy"
 
         # For multi repo support
-        self.get_modules(os.environ['KCONFIG_ENV_FILE'],
+        self.get_modules(kconfig_env_file,
                          os.path.join(kconfiglib_dir, "Kconfig.modules"),
                          os.path.join(kconfiglib_dir, "Kconfig.sysbuild.modules"),
                          os.path.join(kconfiglib_dir, "settings_file.txt"))
@@ -720,6 +722,8 @@ class KconfigCheck(ComplianceTest):
         # Tells Kconfiglib to generate warnings for all references to undefined
         # symbols within Kconfig files
         os.environ["KCONFIG_WARN_UNDEF"] = "y"
+
+        load_dotenv(kconfig_env_file)
 
         try:
             # Note this will both print warnings to stderr _and_ return

--- a/scripts/requirements-actions.in
+++ b/scripts/requirements-actions.in
@@ -22,6 +22,7 @@ pykwalify
 pylint>=3
 pyserial
 pytest
+python-dotenv
 python-magic-bin; sys_platform == "win32"
 python-magic; sys_platform != "win32"
 pyyaml

--- a/scripts/requirements-actions.txt
+++ b/scripts/requirements-actions.txt
@@ -880,6 +880,10 @@ python-debian==1.0.1 \
     --hash=sha256:3ada9b83a3d671b58081782c0969cffa0102f6ce433fbbc7cf21275b8b5cc771 \
     --hash=sha256:8f137c230c1d9279c2ac892b35915068b2aca090c9fd3da5671ff87af32af12c
     # via reuse
+python-dotenv==1.1.1 \
+    --hash=sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc \
+    --hash=sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab
+    # via -r requirements-actions.in
 python-magic==0.4.27 ; sys_platform != 'win32' \
     --hash=sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b \
     --hash=sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3

--- a/scripts/requirements-build-test.txt
+++ b/scripts/requirements-build-test.txt
@@ -19,3 +19,5 @@ mypy
 
 # used for JUnit XML parsing in CTest harness
 junitparser>=3.0.0
+
+python-dotenv

--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -8,6 +8,7 @@ junitparser>=4.0.1
 lxml>=5.3.0
 pykwalify
 pylint>=3
+python-dotenv
 python-magic-bin; sys_platform == "win32"
 python-magic; sys_platform != "win32"
 ruff==0.11.11

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -386,10 +386,13 @@ def kconfig_snippet(meta, path, kconfig_file=None, blobs=False, taint_blobs=Fals
     return '\n'.join(snippet)
 
 
-def process_kconfig_module_dir(module, meta):
+def process_kconfig_module_dir(module, meta, cmake_output):
     module_path = PurePath(module)
     name_sanitized = meta['name-sanitized']
-    return f'ZEPHYR_{name_sanitized.upper()}_MODULE_DIR={module_path.as_posix()}\n'
+
+    if cmake_output is False:
+        return f'ZEPHYR_{name_sanitized.upper()}_MODULE_DIR={module_path.as_posix()}\n'
+    return f'list(APPEND kconfig_env_dirs ZEPHYR_{name_sanitized.upper()}_MODULE_DIR={module_path.as_posix()})\n'
 
 
 def process_kconfig(module, meta):
@@ -870,6 +873,7 @@ def main():
     args = parser.parse_args()
 
     kconfig_module_dirs = ""
+    kconfig_module_dirs_cmake = "set(kconfig_env_dirs)\n"
     kconfig = ""
     cmake = ""
     sysbuild_kconfig = ""
@@ -882,7 +886,8 @@ def main():
                             args.modules, args.extra_modules)
 
     for module in modules:
-        kconfig_module_dirs += process_kconfig_module_dir(module.project, module.meta)
+        kconfig_module_dirs += process_kconfig_module_dir(module.project, module.meta, False)
+        kconfig_module_dirs_cmake += process_kconfig_module_dir(module.project, module.meta, True)
         kconfig += process_kconfig(module.project, module.meta)
         cmake += process_cmake(module.project, module.meta)
         sysbuild_kconfig += process_sysbuildkconfig(
@@ -894,12 +899,19 @@ def main():
     if args.kconfig_out or args.sysbuild_kconfig_out:
         if args.kconfig_out:
             kconfig_module_dirs_out = PurePath(args.kconfig_out).parent / 'kconfig_module_dirs.env'
+            kconfig_module_dirs_cmake_out = PurePath(args.kconfig_out).parent / \
+                                            'kconfig_module_dirs.cmake'
         elif args.sysbuild_kconfig_out:
             kconfig_module_dirs_out = PurePath(args.sysbuild_kconfig_out).parent / \
                                       'kconfig_module_dirs.env'
+            kconfig_module_dirs_cmake_out = PurePath(args.sysbuild_kconfig_out).parent / \
+                                      'kconfig_module_dirs.cmake'
 
         with open(kconfig_module_dirs_out, 'w', encoding="utf-8") as fp:
             fp.write(kconfig_module_dirs)
+
+        with open(kconfig_module_dirs_cmake_out, 'w', encoding="utf-8") as fp:
+            fp.write(kconfig_module_dirs_cmake)
 
     if args.kconfig_out:
         with open(args.kconfig_out, 'w', encoding="utf-8") as fp:

--- a/share/sysbuild/Kconfig
+++ b/share/sysbuild/Kconfig
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-source "$(KCONFIG_ENV_FILE)"
-
 config BOARD
 	string
 	default "$(BOARD)"


### PR DESCRIPTION
Loads this file in a better way that means samples and modules should not have to source the file before referencing Kconfig module path variables