### PR TITLE
drivers/i2c: it8xxx2: Allow I2C target entry power saving mode

### DIFF
--- a/drivers/i2c/Kconfig.it8xxx2
+++ b/drivers/i2c/Kconfig.it8xxx2
@@ -71,4 +71,14 @@ config I2C_TARGET_IT8XXX2_MAX_BUF_SIZE
 config I2C_TARGET_BUFFER_MODE
 	default y
 
+config I2C_TARGET_ALLOW_POWER_SAVING
+	bool "Allow I2C target to enter power-saving modes [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	depends on !SOC_IT8XXX2_REG_SET_V1
+	help
+	  When enabled, the I2C target device can enter Doze/Deep doze states
+	  while the bus is idle. Ongoing transfers will block low-power entry
+	  until they are completed, ensuring correct communication while still
+	  reducing overall power consumption.
+
 endif # I2C_TARGET

--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
 #include <errno.h>
 #include <soc.h>
@@ -123,6 +124,8 @@ struct i2c_enhance_data {
 	struct k_mutex mutex;
 	struct k_sem device_sync_sem;
 	struct i2c_bitbang bitbang;
+	struct gpio_callback gpio_wui_scl_cb;
+	struct gpio_callback gpio_wui_sda_cb;
 	/* Index into output data */
 	size_t widx;
 	/* Index into input data */
@@ -1197,6 +1200,20 @@ static void i2c_enhance_isr(void *arg)
 #endif
 }
 
+#ifdef CONFIG_I2C_TARGET_ALLOW_POWER_SAVING
+void wui_scl_isr(const struct device *gpio, struct gpio_callback *cb, uint32_t pins)
+{
+	/* Disable interrupts on SCL pin to avoid repeated interrupts. */
+	(void)gpio_pin_interrupt_configure(gpio, (find_msb_set(pins) - 1), GPIO_INT_MODE_DISABLED);
+}
+
+void wui_sda_isr(const struct device *gpio, struct gpio_callback *cb, uint32_t pins)
+{
+	/* Disable interrupts on SDA pin to avoid repeated interrupts. */
+	(void)gpio_pin_interrupt_configure(gpio, (find_msb_set(pins) - 1), GPIO_INT_MODE_DISABLED);
+}
+#endif
+
 static int i2c_enhance_init(const struct device *dev)
 {
 	struct i2c_enhance_data *data = dev->data;
@@ -1286,6 +1303,31 @@ static int i2c_enhance_init(const struct device *dev)
 		return status;
 	}
 
+#ifdef CONFIG_I2C_TARGET_ALLOW_POWER_SAVING
+	if (config->target_enable) {
+		/*
+		 * Configure GPIO callbacks for SDA/SCL pins as wake-up sources.
+		 * When the device enters PM_DEVICE_ACTION_SUSPEND, the pins are
+		 * set to trigger interrupts on both edges.
+		 * Any bus activity will wake the system from Deep Doze. Enabling
+		 * lower power consumption while maintaining reliable communication.
+		 */
+		gpio_init_callback(&data->gpio_wui_scl_cb, wui_scl_isr, BIT(config->scl_gpios.pin));
+		status = gpio_add_callback(config->scl_gpios.port, &data->gpio_wui_scl_cb);
+		if (status < 0) {
+			LOG_ERR("Failed to add SCL %d wui pin callback (err %d)", config->port,
+				status);
+			return status;
+		}
+		gpio_init_callback(&data->gpio_wui_sda_cb, wui_sda_isr, BIT(config->sda_gpios.pin));
+		status = gpio_add_callback(config->sda_gpios.port, &data->gpio_wui_sda_cb);
+		if (status < 0) {
+			LOG_ERR("Failed to add SDA %d wui pin callback (err %d)", config->port,
+				status);
+			return status;
+		}
+	}
+#endif
 
 	return 0;
 }
@@ -1395,8 +1437,10 @@ static int i2c_enhance_target_register(const struct device *dev,
 
 	/* I2C target initial configuration of PIO mode */
 	if (config->target_pio_mode) {
+#ifndef CONFIG_I2C_TARGET_ALLOW_POWER_SAVING
 		/* Block to enter power policy. */
 		pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
+#endif
 
 		/* I2C module enable */
 		IT8XXX2_I2C_CTR1(base) = IT8XXX2_I2C_MDL_EN;
@@ -1435,6 +1479,7 @@ static int i2c_enhance_target_register(const struct device *dev,
 		IT8XXX2_I2C_BYTE_CNT_L(base) =
 			CONFIG_I2C_TARGET_IT8XXX2_MAX_BUF_SIZE & GENMASK(2, 0);
 
+#ifndef CONFIG_I2C_TARGET_ALLOW_POWER_SAVING
 		/*
 		 * The EC processor(CPU) cannot be in the k_cpu_idle() and power
 		 * policy during the transactions with the CQ mode(DMA mode).
@@ -1442,6 +1487,7 @@ static int i2c_enhance_target_register(const struct device *dev,
 		 */
 		chip_block_idle();
 		pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
+#endif
 
 		/* I2C module enable and command queue mode */
 		IT8XXX2_I2C_CTR1(base) = IT8XXX2_I2C_COMQ_EN | IT8XXX2_I2C_MDL_EN;
@@ -1465,11 +1511,13 @@ static int i2c_enhance_target_unregister(const struct device *dev,
 
 	irq_disable(config->i2c_irq_base);
 
+#ifndef CONFIG_I2C_TARGET_ALLOW_POWER_SAVING
 	/* Permit to enter power policy and idle mode. */
 	pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
 	if (!config->target_pio_mode) {
 		chip_permit_idle();
 	}
+#endif
 
 	data->target_cfg = NULL;
 	data->target_attached = false;
@@ -1478,6 +1526,59 @@ static int i2c_enhance_target_unregister(const struct device *dev,
 	return 0;
 }
 #endif
+
+#ifdef CONFIG_I2C_TARGET_ALLOW_POWER_SAVING
+static inline int i2c_enhance_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct i2c_enhance_config *const config = dev->config;
+	int ret;
+
+	if (config->target_enable) {
+		switch (action) {
+		/* Next device power state is in active. */
+		case PM_DEVICE_ACTION_RESUME:
+			/* Disable interrupts on SCL/SDA pin to avoid repeated interrupts. */
+			ret = gpio_pin_interrupt_configure_dt(&config->scl_gpios,
+							      GPIO_INT_MODE_DISABLED);
+			if (ret < 0) {
+				LOG_ERR("Failed to configure I2C%d WUI (ret %d)", config->port,
+					ret);
+				return ret;
+			}
+			ret = gpio_pin_interrupt_configure_dt(&config->sda_gpios,
+							      GPIO_INT_MODE_DISABLED);
+			if (ret < 0) {
+				LOG_ERR("Failed to configure I2C%d WUI (ret %d)", config->port,
+					ret);
+				return ret;
+			}
+			break;
+		/* Next device power state is deep doze mode */
+		case PM_DEVICE_ACTION_SUSPEND:
+			/* Configure wakeup pins as both edge tribbers */
+			ret = gpio_pin_interrupt_configure_dt(
+				&config->scl_gpios, GPIO_INT_MODE_EDGE | GPIO_INT_TRIG_BOTH);
+			if (ret < 0) {
+				LOG_ERR("Failed to configure I2C%d WUI (ret %d)", config->port,
+					ret);
+				return ret;
+			}
+			ret = gpio_pin_interrupt_configure_dt(
+				&config->sda_gpios, GPIO_INT_MODE_EDGE | GPIO_INT_TRIG_BOTH);
+			if (ret < 0) {
+				LOG_ERR("Failed to configure I2C%d WUI (ret %d)", config->port,
+					ret);
+				return ret;
+			}
+			break;
+		default:
+			return -ENOTSUP;
+		}
+	}
+
+	return 0;
+}
+#endif /* CONFIG_I2C_TARGET_ALLOW_POWER_SAVING */
 
 static DEVICE_API(i2c, i2c_enhance_driver_api) = {
 	.configure = i2c_enhance_configure,
@@ -1530,9 +1631,11 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_I2C_TARGET_BUFFER_MODE),
 	};                                                                      \
 										\
 	static struct i2c_enhance_data i2c_enhance_data_##inst;                 \
-										\
+		IF_ENABLED(CONFIG_I2C_TARGET_ALLOW_POWER_SAVING,                \
+		(PM_DEVICE_DT_INST_DEFINE(inst, i2c_enhance_pm_action);))       \
 	I2C_DEVICE_DT_INST_DEFINE(inst, i2c_enhance_init,                       \
-				  NULL,                                         \
+		COND_CODE_1(CONFIG_I2C_TARGET_ALLOW_POWER_SAVING,               \
+			    (PM_DEVICE_DT_INST_GET(inst)), (NULL)),             \
 				  &i2c_enhance_data_##inst,                     \
 				  &i2c_enhance_cfg_##inst,                      \
 				  POST_KERNEL,                                  \

--- a/soc/ite/ec/it8xxx2/chip_chipregs.h
+++ b/soc/ite/ec/it8xxx2/chip_chipregs.h
@@ -1323,6 +1323,15 @@ enum chip_pll_mode {
 #define IT8XXX2_SMB_PREDEN      BIT(7)
 #endif
 
+/* SMBus register fields */
+/*
+ * it81xx2cx/dx:
+ * bit3@0xf01c20: Gating Enable of I2C Idle to Sleep Control
+ * it82xx2:
+ * bit3@0xf01c09: Gating Enable of I2C Idle to Sleep Control
+ */
+#define IT8XXX2_SMB_GEOIITSC BIT(3)
+
 /**
  * Enhanced SMBus/I2C Interface
  * Ch_D: 0x00F03680, Ch_E: 0x00F03500, Ch_F: 0x00F03580

--- a/soc/ite/ec/it8xxx2/soc.c
+++ b/soc/ite/ec/it8xxx2/soc.c
@@ -327,6 +327,11 @@ void riscv_idle(enum chip_pll_mode mode, unsigned int key)
 	 */
 	espi_ite_ec_enable_trans_irq(ESPI_ITE_SOC_DEV, true);
 #endif
+
+#if defined(CONFIG_I2C_TARGET) && defined(CONFIG_I2C_ITE_ENHANCE)
+	/* All I2C Channel idle state will affect CPU entering sleep */
+	IT8XXX2_SMB_SMB01CHS |= IT8XXX2_SMB_GEOIITSC;
+#endif
 	/* Chip doze after wfi instruction */
 	chip_pll_ctrl(mode);
 
@@ -350,6 +355,11 @@ void riscv_idle(enum chip_pll_mode mode, unsigned int key)
 			IT8XXX2_ECPM_PFACC2R |= PLL_FREQ_AUTO_CAL_START;
 		}
 	}
+
+#if defined(CONFIG_I2C_TARGET) && defined(CONFIG_I2C_ITE_ENHANCE)
+	/* All I2C Channel idle state will not affect CPU entering sleep */
+	IT8XXX2_SMB_SMB01CHS &= ~IT8XXX2_SMB_GEOIITSC;
+#endif
 
 #ifdef CONFIG_ESPI
 	/* CPU has been woken up, the interrupt is no longer needed */


### PR DESCRIPTION
Add I2C_TARGET_ALLOW_POWER_SAVING config. Enable this config makes I2C target device can enter Doze/Deep doze states while the bus is idle. Ongoing transfers will block low-power entry until they are completed, ensuring correct communication while still reducing overall power consumption.