### PR TITLE
soc: espressif: esp32h2: remove kernel include

### DIFF
--- a/soc/espressif/esp32h2/soc.c
+++ b/soc/espressif/esp32h2/soc.c
@@ -13,7 +13,6 @@
 #include <efuse_virtual.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <zephyr/kernel_structs.h>
-#include <kernel_internal.h>
 
 extern void esp_reset_reason_init(void);
 extern FUNC_NORETURN void z_cstart(void);


### PR DESCRIPTION
Remove unnecessary include from ESP32-H2 SoC sources.