### PR TITLE
soc: mimxrt685s/hifi4: Fix HW cycle count

### DIFF
--- a/dts/xtensa/nxp/nxp_rt685_hifi4.dtsi
+++ b/dts/xtensa/nxp/nxp_rt685_hifi4.dtsi
@@ -5,6 +5,7 @@
 
 #include <xtensa/xtensa.dtsi>
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
@@ -20,6 +21,7 @@
 		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
+			clock-frequency = <DT_FREQ_M(594)>;
 			reg = <0>;
 		};
 	};

--- a/soc/nxp/imxrt/imxrt6xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt6xx/Kconfig.defconfig
@@ -69,7 +69,7 @@ endif # SOC_MIMXRT685S_CM33
 if SOC_MIMXRT685S_HIFI4
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 198000000
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
 config MCUX_CORE_SUFFIX
 	default "_dsp"


### PR DESCRIPTION
Change hardware cycle count (`CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC)` to 594 MHz. Move that value to the SoC layer's DT.

Validated with the `amp_blinky` example - the period of the blinking LED is exactly 2 seconds, like was programmed.