### PR TITLE
drivers: sensor: iim4623x: add driver for iim4623x

### DIFF
--- a/drivers/sensor/tdk/CMakeLists.txt
+++ b/drivers/sensor/tdk/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory_ifdef(CONFIG_ICM42X70 icm42x70)
 add_subdirectory_ifdef(CONFIG_ICM45686 icm45686)
 add_subdirectory_ifdef(CONFIG_ICP101XX icp101xx)
 add_subdirectory_ifdef(CONFIG_ICP201XX icp201xx)
+add_subdirectory_ifdef(CONFIG_IIM4623X iim4623x)
 add_subdirectory_ifdef(CONFIG_MPU6050 mpu6050)
 add_subdirectory_ifdef(CONFIG_MPU9250 mpu9250)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/tdk/Kconfig
+++ b/drivers/sensor/tdk/Kconfig
@@ -9,6 +9,7 @@ source "drivers/sensor/tdk/icm42x70/Kconfig"
 source "drivers/sensor/tdk/icm45686/Kconfig"
 source "drivers/sensor/tdk/icp101xx/Kconfig"
 source "drivers/sensor/tdk/icp201xx/Kconfig"
+source "drivers/sensor/tdk/iim4623x/Kconfig"
 source "drivers/sensor/tdk/mpu6050/Kconfig"
 source "drivers/sensor/tdk/mpu9250/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/tdk/iim4623x/CMakeLists.txt
+++ b/drivers/sensor/tdk/iim4623x/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Sentry Technologies ApS
+#
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(
+  iim4623x.c
+  iim4623x_bus.c
+)

--- a/drivers/sensor/tdk/iim4623x/CMakeLists.txt
+++ b/drivers/sensor/tdk/iim4623x/CMakeLists.txt
@@ -8,3 +8,7 @@ zephyr_library_sources(
   iim4623x.c
   iim4623x_bus.c
 )
+
+zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API
+  iim4623x_decoder.c
+)

--- a/drivers/sensor/tdk/iim4623x/CMakeLists.txt
+++ b/drivers/sensor/tdk/iim4623x/CMakeLists.txt
@@ -12,3 +12,7 @@ zephyr_library_sources(
 zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API
   iim4623x_decoder.c
 )
+
+zephyr_library_sources_ifdef(CONFIG_IIM4623X_STREAM
+  iim4623x_stream.c
+)

--- a/drivers/sensor/tdk/iim4623x/Kconfig
+++ b/drivers/sensor/tdk/iim4623x/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Sentry Technologies ApS
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config IIM4623X
+	bool "TDK Invensense IIM4623x IMU sensor family"
+	default y
+	depends on DT_HAS_INVENSENSE_IIM46234_ENABLED || \
+		   DT_HAS_INVENSENSE_IIM46230_ENABLED
+	select SPI
+	select SPI_RTIO
+	help
+	  Enable TDK Invensense IIM46234 IMU sensor family support.

--- a/drivers/sensor/tdk/iim4623x/Kconfig
+++ b/drivers/sensor/tdk/iim4623x/Kconfig
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-config IIM4623X
+menuconfig IIM4623X
 	bool "TDK Invensense IIM4623x IMU sensor family"
 	default y
 	depends on DT_HAS_INVENSENSE_IIM46234_ENABLED || \
@@ -11,3 +11,13 @@ config IIM4623X
 	select SPI_RTIO
 	help
 	  Enable TDK Invensense IIM46234 IMU sensor family support.
+
+if IIM4623X
+
+config IIM4623X_STREAM
+	bool "Streaming mode"
+	select SENSOR_ASYNC_API
+	help
+	  Enable streaming of sensor data.
+
+endif # IIM4623X

--- a/drivers/sensor/tdk/iim4623x/iim4623x.c
+++ b/drivers/sensor/tdk/iim4623x/iim4623x.c
@@ -1,0 +1,534 @@
+/*
+ * Copyright (c) 2025 Sentry Technologies ApS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+
+#include "iim4623x.h"
+#include "iim4623x_reg.h"
+#include "iim4623x_bus.h"
+#include <zephyr/dt-bindings/sensor/iim4623x.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/util.h>
+
+LOG_MODULE_REGISTER(iim4623x, CONFIG_SENSOR_LOG_LEVEL);
+
+/* Calculate the checksum given a pointer to the preamble of a packet in a contigous buffer */
+static uint16_t iim4623x_calc_checksum(const uint8_t *packet)
+{
+	const uint8_t *head = &((struct iim4623x_pck_preamble *)packet)->type;
+	const uint8_t *end = (uint8_t *)IIM4623X_GET_POSTAMBLE(packet);
+	uint16_t sum = 0;
+
+	for (; head < end; head++) {
+		sum += *head;
+	}
+
+	return sum;
+}
+
+static int iim4623x_prepare_cmd(const struct device *dev, uint8_t cmd_type, uint8_t *payload,
+				size_t payload_len)
+{
+	struct iim4623x_data *data = dev->data;
+	size_t out_buf_len = ARRAY_SIZE(data->trx_buf);
+	uint8_t *out_buf = data->trx_buf;
+	uint8_t *out_buf_head = out_buf;
+	struct iim4623x_pck_preamble preamble = {
+		.header = sys_cpu_to_be16(IIM4623X_PCK_HEADER_TX),
+		.length = IIM4623X_PACKET_LEN(payload_len),
+		.type = cmd_type,
+	};
+	struct iim4623x_pck_postamble postamble = {
+		.checksum = 0x00,
+		.footer = sys_cpu_to_be16(IIM4623X_PCK_FOOTER),
+	};
+
+	/* Check for undersized buffer */
+	if (out_buf_len < IIM4623X_TX_LEN(payload_len)) {
+		return -ENOMEM;
+	}
+
+	/* Copy preamble to buffer */
+	memcpy(out_buf_head, &preamble, sizeof(preamble));
+	out_buf_head += sizeof(preamble);
+
+	/* Copy payload to buffer, if provided */
+	if (payload) {
+		memcpy(out_buf_head, payload, payload_len);
+		out_buf_head += payload_len;
+	}
+
+	/* Calculate checksum and correct endianness for the wire */
+	postamble.checksum = sys_cpu_to_be16(iim4623x_calc_checksum(out_buf));
+
+	/* Copy postamble to buffer */
+	memcpy(out_buf_head, &postamble, sizeof(postamble));
+	out_buf_head += sizeof(postamble);
+
+	/* Zero pad to adhere to minimum tx length if necessary */
+	if (preamble.length < IIM4623X_MIN_TX_LEN) {
+		memset(out_buf_head, 0x00, IIM4623X_MIN_TX_LEN - preamble.length);
+		out_buf_head += (IIM4623X_MIN_TX_LEN - preamble.length);
+	}
+
+	return (out_buf_head - out_buf);
+}
+
+static int iim4623x_check_ack(uint8_t *buf)
+{
+	struct iim4623x_pck_resp *packet = (struct iim4623x_pck_resp *)buf;
+	struct iim4623x_pck_postamble *postamble;
+	uint16_t checksum;
+
+	if (packet->preamble.header != sys_cpu_to_be16(IIM4623X_PCK_HEADER_RX)) {
+		LOG_ERR("Invalid packet header: 0x%04X", sys_be16_to_cpu(packet->preamble.header));
+		return -EIO;
+	}
+
+	if (packet->preamble.length != IIM4623X_PCK_ACK_LEN) {
+		LOG_ERR("Invalid packet length: %d", packet->preamble.length);
+		return -EIO;
+	}
+
+	if (packet->ack.error_code != IIM4623X_EC_ACK) {
+		LOG_ERR("ACK error code: 0x%02X", packet->ack.error_code);
+		return -EIO;
+	}
+
+	postamble = IIM4623X_GET_POSTAMBLE(buf);
+	checksum = iim4623x_calc_checksum(buf);
+	if (checksum != sys_be16_to_cpu(postamble->checksum)) {
+		LOG_ERR("Bad checksum, exp: 0x%.4x, got: 0x%.4x", checksum,
+			sys_be16_to_cpu(postamble->checksum));
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int iim4623x_read_reg(const struct device *dev, uint8_t page, uint8_t reg, uint8_t *buf,
+			     size_t len)
+{
+	struct iim4623x_data *data = dev->data;
+	struct iim4623x_pck_resp *packet;
+	struct iim4623x_pck_postamble *reply_postamble;
+	uint8_t cmd[] = {
+		0x00 /* reserved */,
+		len,
+		reg,
+		page,
+	};
+	uint16_t checksum;
+	int ret;
+
+	ret = iim4623x_prepare_cmd(dev, IIM4623X_CMD_READ_USER_REGISTER, cmd, ARRAY_SIZE(cmd));
+	if (ret < 0) {
+		LOG_ERR("Preparing cmd, ret: %d", ret);
+		return ret;
+	}
+
+	ret = iim4623x_bus_write_then_read(dev, data->trx_buf, ret, data->trx_buf,
+					   IIM4623X_READ_REG_RESP_LEN(len));
+	if (ret) {
+		LOG_ERR("Sending read user register command, ret: %d", ret);
+		return ret;
+	}
+
+	/* Parse reply */
+	packet = (struct iim4623x_pck_resp *)data->trx_buf;
+
+	if (sys_be16_to_cpu(packet->preamble.header) != IIM4623X_PCK_HEADER_RX) {
+		LOG_ERR("Bad reply header");
+		return -ENODEV;
+	}
+
+	if (packet->preamble.type != IIM4623X_CMD_READ_USER_REGISTER) {
+		LOG_ERR("Bad reply cmd type, exp: 0x%.2x, got: 0x%.2x",
+			IIM4623X_CMD_READ_USER_REGISTER, packet->preamble.type);
+		return -EIO;
+	}
+
+	if ((packet->read_user_reg.error_code & packet->read_user_reg.error_mask) !=
+	    IIM4623X_EC_ACK) {
+		LOG_ERR("Reply with error, code: 0x%.2x",
+			packet->read_user_reg.error_code & packet->read_user_reg.error_mask);
+		return -EIO;
+	}
+
+	if (packet->read_user_reg.addr != reg) {
+		LOG_ERR("Addr mismatch, reply_addr: 0x%.2x, reg: 0x%.2x",
+			packet->read_user_reg.addr, reg);
+		return -EIO;
+	}
+
+	if (packet->read_user_reg.read_len != len) {
+		LOG_ERR("Length mismatch, read_led: 0x%.2x, len: 0x%.2x",
+			packet->read_user_reg.read_len, len);
+		return -EIO;
+	}
+
+	/* Locate postamble by advancing past the reply reg_val buffer */
+	reply_postamble = (struct iim4623x_pck_postamble *)(packet->read_user_reg.reg_val + len);
+
+	/* Verify checksum */
+	checksum = iim4623x_calc_checksum((uint8_t *)packet);
+	if (checksum != sys_be16_to_cpu(reply_postamble->checksum)) {
+		LOG_ERR("Bad checksum, exp: 0x%.4x, got: 0x%.4x", checksum,
+			sys_be16_to_cpu(reply_postamble->checksum));
+		return -EIO;
+	}
+
+	/* Copy register contents */
+	(void)memcpy(buf, packet->read_user_reg.reg_val, len);
+
+	return 0;
+}
+
+static int iim4623x_read_cfg_reg(const struct device *dev, uint8_t reg, uint8_t *buf, size_t len)
+{
+	return iim4623x_read_reg(dev, IIM4623X_PAGE_CFG, reg, buf, len);
+}
+
+static int iim4623x_read_data_reg(const struct device *dev, uint8_t reg, uint8_t *buf, size_t len)
+{
+	return iim4623x_read_reg(dev, IIM4623X_PAGE_SENSOR_DATA, reg, buf, len);
+}
+
+static int iim4623x_write_reg(const struct device *dev, uint8_t reg, const uint8_t *buf, size_t len)
+{
+	struct iim4623x_data *data = dev->data;
+	/* Allocate for maximum write size */
+	uint8_t cmd[12] = {
+		0x00 /* reserved */,
+		len,
+		reg,
+		IIM4623X_PAGE_CFG /* All regs in IIM4623X_PAGE_SENSOR_DATA are read-only */,
+	};
+	int ret;
+
+	if (len > 8) {
+		LOG_ERR("Write length too big");
+		return -EINVAL;
+	}
+
+	/* Add the user data to the cmd */
+	(void)memcpy(&cmd[4], buf, len);
+
+	ret = iim4623x_prepare_cmd(dev, IIM4623X_CMD_WRITE_USER_REGISTER, cmd, len + 4);
+	if (ret < 0) {
+		LOG_ERR("Preparing write user register command, ret: %d", ret);
+		return ret;
+	}
+
+	ret = iim4623x_bus_write_then_read(dev, data->trx_buf, ret, data->trx_buf,
+					   IIM4623X_PCK_ACK_LEN);
+	if (ret) {
+		LOG_ERR("Sending write user register command, ret: %d", ret);
+		return ret;
+	}
+
+	ret = iim4623x_check_ack(data->trx_buf);
+	if (ret) {
+		LOG_ERR("Checking ack, ret: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static void iim4623x_irq_handler(const struct device *port, struct gpio_callback *cb,
+				 gpio_port_pins_t pins)
+{
+	struct iim4623x_data *data = CONTAINER_OF(cb, struct iim4623x_data, int_cb);
+
+	ARG_UNUSED(port);
+	ARG_UNUSED(pins);
+
+	if (data->await_sqe) {
+		rtio_sqe_signal(data->await_sqe);
+		data->await_sqe = NULL;
+	} else {
+		LOG_ERR("Spurious interrupt");
+	}
+}
+
+static void iim4623x_payload_be_to_cpu(struct iim4623x_pck_strm_payload *payload)
+{
+	/* Perform byteswaps for all relevant values within the payload */
+	sys_be_to_cpu(&payload->timestamp, 8);
+	sys_be_to_cpu(&payload->accel.buf.x, 4);
+	sys_be_to_cpu(&payload->accel.buf.y, 4);
+	sys_be_to_cpu(&payload->accel.buf.z, 4);
+	sys_be_to_cpu(&payload->gyro.buf.x, 4);
+	sys_be_to_cpu(&payload->gyro.buf.y, 4);
+	sys_be_to_cpu(&payload->gyro.buf.z, 4);
+	sys_be_to_cpu(&payload->temp.buf, 4);
+}
+
+static int iim4623x_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct iim4623x_data *data = dev->data;
+	int ret;
+
+	switch (chan) {
+	case SENSOR_CHAN_ALL:
+	case SENSOR_CHAN_ACCEL_XYZ:
+	case SENSOR_CHAN_ACCEL_X:
+	case SENSOR_CHAN_ACCEL_Y:
+	case SENSOR_CHAN_ACCEL_Z:
+	case SENSOR_CHAN_GYRO_XYZ:
+	case SENSOR_CHAN_GYRO_X:
+	case SENSOR_CHAN_GYRO_Y:
+	case SENSOR_CHAN_GYRO_Z:
+	case SENSOR_CHAN_DIE_TEMP:
+		break;
+	default:
+		return -ENOTSUP;
+	};
+
+	ret = iim4623x_read_data_reg(dev, IIM4623X_REG_SENSOR_STATUS,
+				     (uint8_t *)&data->edata.payload,
+				     sizeof(struct iim4623x_pck_strm_payload));
+	if (ret) {
+		LOG_ERR("Fetching sample, ret: %d", ret);
+		return ret;
+	}
+
+	/* Convert wire endianness to cpu */
+	iim4623x_payload_be_to_cpu(&data->edata.payload);
+
+	return 0;
+}
+
+static inline void iim4623x_accel_ms(float in, struct sensor_value *out)
+{
+	sensor_ug_to_ms2((in * 1000000), out);
+}
+
+static inline void iim4623x_gyro_rads(float in, struct sensor_value *out)
+{
+	sensor_10udegrees_to_rad((in * 100000), out);
+}
+
+static int iim4623x_channel_get(const struct device *dev, enum sensor_channel chan,
+				struct sensor_value *val)
+{
+	struct iim4623x_data *data = dev->data;
+	int ret = 0;
+
+	switch (chan) {
+	case SENSOR_CHAN_ACCEL_X:
+		iim4623x_accel_ms(data->edata.payload.accel.x, val);
+		break;
+	case SENSOR_CHAN_ACCEL_Y:
+		iim4623x_accel_ms(data->edata.payload.accel.y, val);
+		break;
+	case SENSOR_CHAN_ACCEL_Z:
+		iim4623x_accel_ms(data->edata.payload.accel.z, val);
+		break;
+	case SENSOR_CHAN_GYRO_X:
+		iim4623x_gyro_rads(data->edata.payload.gyro.x, val);
+		break;
+	case SENSOR_CHAN_GYRO_Y:
+		iim4623x_gyro_rads(data->edata.payload.gyro.y, val);
+		break;
+	case SENSOR_CHAN_GYRO_Z:
+		iim4623x_gyro_rads(data->edata.payload.gyro.z, val);
+		break;
+	case SENSOR_CHAN_DIE_TEMP:
+		ret = sensor_value_from_float(val, data->edata.payload.temp.val);
+		break;
+	case SENSOR_CHAN_ACCEL_XYZ:
+		iim4623x_accel_ms(data->edata.payload.accel.x, &val[0]);
+		iim4623x_accel_ms(data->edata.payload.accel.y, &val[1]);
+		iim4623x_accel_ms(data->edata.payload.accel.z, &val[2]);
+		break;
+	case SENSOR_CHAN_GYRO_XYZ:
+		iim4623x_gyro_rads(data->edata.payload.gyro.x, &val[0]);
+		iim4623x_gyro_rads(data->edata.payload.gyro.y, &val[1]);
+		iim4623x_gyro_rads(data->edata.payload.gyro.z, &val[2]);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return ret;
+}
+
+static DEVICE_API(sensor, iim4623x_api) = {
+	.sample_fetch = iim4623x_sample_fetch,
+	.channel_get = iim4623x_channel_get,
+};
+
+static int iim4623x_init(const struct device *dev)
+{
+	const struct iim4623x_config *config = dev->config;
+	struct iim4623x_data *data = dev->data;
+	uint8_t chip_id = 0;
+	uint8_t tmp;
+	int ret;
+
+	data->dev = dev;
+
+	if (!spi_is_ready_iodev(data->rtio.iodev)) {
+		LOG_ERR("Spi iodev not ready");
+		return -ENODEV;
+	}
+
+	if (!gpio_is_ready_dt(&config->reset_gpio)) {
+		LOG_ERR("Reset GPIO not ready");
+		return -ENODEV;
+	}
+
+	if (!gpio_is_ready_dt(&config->int_gpio)) {
+		LOG_ERR("Interrupt GPIO not ready");
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(&config->int_gpio, GPIO_INPUT);
+	if (ret) {
+		LOG_ERR("Configuring interrupt GPIO, ret: %d", ret);
+		return ret;
+	}
+
+	gpio_init_callback(&data->int_cb, iim4623x_irq_handler, BIT(config->int_gpio.pin));
+
+	ret = gpio_add_callback(config->int_gpio.port, &data->int_cb);
+	if (ret) {
+		LOG_ERR("Adding interrupt callback, ret: %d", ret);
+		return ret;
+	}
+
+	/**
+	 * Datasheet has a vague mention of reset pulse width down to 1us but specifies that the
+	 * value is based off simulations. In addition it mentions some power-on reset conditions at
+	 * 10ms which may be tied to supply ramping.
+	 *
+	 * Just assert reset for 10ms to be on the safe side in cases where the supplies are still
+	 * ramping up.
+	 */
+	ret = gpio_pin_configure_dt(&config->reset_gpio, GPIO_OUTPUT_ACTIVE);
+	if (ret) {
+		LOG_ERR("Configuring reset GPIO, ret: %d", ret);
+		return ret;
+	}
+
+	k_msleep(10);
+
+	ret = gpio_pin_set_dt(&config->reset_gpio, 0);
+	if (ret) {
+		LOG_ERR("Deasserting reset, ret: %d", ret);
+		return ret;
+	}
+
+	/* Wait for device registers to be available, datasheet specifies up to 200ms */
+	k_msleep(200);
+
+	ret = gpio_pin_interrupt_configure_dt(&config->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret) {
+		LOG_ERR("Configuring interrupt, ret: %d", ret);
+		return ret;
+	}
+
+	/* Check chip identifier */
+	ret = iim4623x_read_cfg_reg(dev, IIM4623X_REG_WHO_AM_I, &chip_id, 1);
+	switch (chip_id) {
+	case IIM4623X_WHO_AM_I_46230:
+	case IIM4623X_WHO_AM_I_46234:
+		break;
+	default:
+		LOG_ERR("Failed to identify iim4623x, ret: %d", ret);
+		return -ENODEV;
+	}
+
+	/* Synchronize DT configuration to the chip */
+
+	/* Write LSB of the ODR divider register */
+	ret = iim4623x_write_reg(dev, IIM4623X_REG_SAMPLE_RATE_DIV + 1, &config->odr_div, 1);
+	if (ret) {
+		LOG_ERR("Failed to set ODR, ret: %d", ret);
+		return ret;
+	};
+
+	/* Write accelerometer and gyroscope full-scale selection */
+	tmp = data->edata.header.accel_fs << IIM4623X_ACCEL_CFG_SHIFT;
+	ret = iim4623x_write_reg(dev, IIM4623X_REG_ACCEL_CFG, &tmp, 1);
+	if (ret) {
+		LOG_ERR("Failed to set accel_fs, ret: %d", ret);
+		return ret;
+	};
+
+	tmp = data->edata.header.gyro_fs << IIM4623X_GYRO_CFG_SHIFT;
+	ret = iim4623x_write_reg(dev, IIM4623X_REG_GYRO_CFG, &tmp, 1);
+	if (ret) {
+		LOG_ERR("Failed to set gyro_fs, ret: %d", ret);
+		return ret;
+	};
+
+	/* Write accelerometer and gyroscope bandwidth selection */
+	tmp = IIM4623X_BW_CFG_PACK(data->edata.header.accel_bw, data->edata.header.gyro_bw);
+	ret = iim4623x_write_reg(dev, IIM4623X_REG_BW_CFG, &tmp, 1);
+	if (ret) {
+		LOG_ERR("Failed to set accel_fs, ret: %d", ret);
+		return ret;
+	};
+
+	return 0;
+}
+
+/* Helper macros to convert the human readable full-scale settings into bit masks */
+#define IIM4623X_DT_ACCEL_FS(inst)                                                                 \
+	CONCAT(IIM4623X_ACCEL_CFG_FS_, DT_INST_PROP_OR(inst, accel_fs, 8))
+
+#define IIM4623X_DT_GYRO_FS(inst) CONCAT(IIM4623X_GYRO_CFG_FS_, DT_INST_PROP_OR(inst, gyro_fs, 480))
+
+/* Device init macro */
+#define IIM4623X_INIT(inst)                                                                        \
+	RTIO_DEFINE(iim4623x_rtio_ctx_##inst, 8, 8);                                               \
+	SPI_DT_IODEV_DEFINE(iim4623x_bus_##inst, DT_DRV_INST(inst),                                \
+			    SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_TRANSFER_MSB, 0U);          \
+                                                                                                   \
+	static const struct iim4623x_config iim4623x_cfg_##inst = {                                \
+		.reset_gpio = GPIO_DT_SPEC_GET(DT_DRV_INST(inst), reset_gpios),                    \
+		.int_gpio = GPIO_DT_SPEC_GET(DT_DRV_INST(inst), int_gpios),                        \
+		.odr_div = (1000 / DT_INST_PROP_OR(inst, odr, 1000)),                              \
+	};                                                                                         \
+                                                                                                   \
+	static struct iim4623x_data iim4623x_data_##inst = {                                       \
+		.rtio =                                                                            \
+			{                                                                          \
+				.iodev = &iim4623x_bus_##inst,                                     \
+				.ctx = &iim4623x_rtio_ctx_##inst,                                  \
+			},                                                                         \
+		.trx_buf = {0},                                                                    \
+		.edata.header =                                                                    \
+			{                                                                          \
+				.accel_fs = IIM4623X_DT_ACCEL_FS(inst),                            \
+				.gyro_fs = IIM4623X_DT_GYRO_FS(inst),                              \
+				.accel_bw = DT_INST_PROP_OR(inst, accel_bw, 0),                    \
+				.gyro_bw = DT_INST_PROP_OR(inst, gyro_bw, 0),                      \
+				.chans = {.gyro = 1, .accel = 1, .temp = 1},                       \
+			},                                                                         \
+	};                                                                                         \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, iim4623x_init, NULL, &iim4623x_data_##inst,             \
+				     &iim4623x_cfg_##inst, POST_KERNEL,                            \
+				     CONFIG_SENSOR_INIT_PRIORITY, &iim4623x_api);
+
+/* Run initialization for all compatible strings */
+#define DT_DRV_COMPAT invensense_iim46234
+DT_INST_FOREACH_STATUS_OKAY(IIM4623X_INIT)
+#undef DT_DRV_COMPAT
+
+#define DT_DRV_COMPAT invensense_iim46230
+DT_INST_FOREACH_STATUS_OKAY(IIM4623X_INIT)
+#undef DT_DRV_COMPAT

--- a/drivers/sensor/tdk/iim4623x/iim4623x.h
+++ b/drivers/sensor/tdk/iim4623x/iim4623x.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025 Sentry Technologies ApS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_H
+#define ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_H
+
+#include "iim4623x_reg.h"
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/atomic.h>
+
+/* Metadata used for parsing the encoded payload */
+union iim4623x_encoded_channels {
+	uint8_t msk;
+	struct {
+		uint8_t accel: 1;
+		uint8_t gyro: 1;
+		uint8_t temp: 1;
+		uint8_t delta_angle: 1;
+		uint8_t delta_vel: 1;
+		uint8_t _reserved: 3;
+	} __packed;
+};
+
+struct iim4623x_encoded_header {
+	uint8_t accel_fs: 2; /* See IIM4623X_ACCEL_CFG_FS_* macros */
+	uint8_t gyro_fs: 2;  /* See IIM4623X_GYRO_CFG_FS_* macros */
+	uint8_t accel_bw: 2; /* See IIM4623X_DT_ACCEL_BW_* macros */
+	uint8_t gyro_bw: 2;  /* See IIM4623X_DT_GYRO_BW_* macros */
+	/* TODO: Consider support for custom gravity setting */
+	union iim4623x_encoded_channels chans; /* Enabled data output mask */
+	uint64_t timestamp;
+	uint8_t data_ready;
+};
+
+struct iim4623x_encoded_data {
+	struct iim4623x_encoded_header header;
+	struct iim4623x_pck_strm_payload payload;
+};
+
+struct iim4623x_config {
+	struct gpio_dt_spec reset_gpio;
+	struct gpio_dt_spec int_gpio;
+	uint8_t odr_div;
+};
+
+struct iim4623x_data {
+	struct {
+		struct rtio_iodev *iodev;
+		struct rtio *ctx;
+	} rtio;
+	const struct device *dev;
+	struct gpio_callback int_cb;
+
+	/* Buffer for commands and responses, sized for max packet sizes */
+	uint8_t trx_buf[IIM4623X_PACKET_LEN(72)];
+
+	/* State */
+	struct rtio_sqe *await_sqe;
+	atomic_t busy;
+
+	/* Encoded data instance to support fetch/get API */
+	struct iim4623x_encoded_data edata;
+};
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_H */

--- a/drivers/sensor/tdk/iim4623x/iim4623x_bus.c
+++ b/drivers/sensor/tdk/iim4623x/iim4623x_bus.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2025 Sentry Technologies ApS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "iim4623x.h"
+#include "iim4623x_bus.h"
+#include "zephyr/sys/atomic.h"
+
+#include <zephyr/device.h>
+#include <zephyr/rtio/rtio.h>
+
+static int iim4623x_rtio_submit_flush(struct rtio *ctx, int n_sqe)
+{
+	int ret;
+
+	ret = rtio_submit(ctx, n_sqe);
+	if (ret) {
+		return ret;
+	}
+
+	return rtio_flush_completion_queue(ctx);
+}
+
+int iim4623x_bus_write(const struct device *dev, const uint8_t *buf, size_t len)
+{
+	struct iim4623x_data *data = dev->data;
+	struct rtio *ctx = data->rtio.ctx;
+	struct rtio_iodev *iodev = data->rtio.iodev;
+	int ret;
+
+	if (!atomic_cas(&data->busy, 0, 1)) {
+		return -EBUSY;
+	}
+
+	struct rtio_sqe *wr_sqe = rtio_sqe_acquire(ctx);
+
+	if (!wr_sqe) {
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	rtio_sqe_prep_write(wr_sqe, iodev, RTIO_PRIO_HIGH, buf, len, NULL);
+
+	ret = iim4623x_rtio_submit_flush(ctx, 1);
+
+out:
+	atomic_cas(&data->busy, 1, 0);
+	return ret;
+}
+
+int iim4623x_bus_read(const struct device *dev, uint8_t *buf, size_t len)
+{
+	struct iim4623x_data *data = dev->data;
+	struct rtio *ctx = data->rtio.ctx;
+	struct rtio_iodev *iodev = data->rtio.iodev;
+	int ret;
+
+	if (!atomic_cas(&data->busy, 0, 1)) {
+		return -EBUSY;
+	}
+
+	struct rtio_sqe *re_sqe = rtio_sqe_acquire(ctx);
+
+	if (!re_sqe) {
+		rtio_sqe_drop_all(ctx);
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	rtio_sqe_prep_read(re_sqe, iodev, RTIO_PRIO_HIGH, buf, len, NULL);
+
+	ret = iim4623x_rtio_submit_flush(ctx, 1);
+
+out:
+	atomic_cas(&data->busy, 1, 0);
+	return ret;
+}
+
+int iim4623x_bus_write_then_read(const struct device *dev, const uint8_t *wbuf, size_t wlen,
+				 uint8_t *rbuf, size_t rlen)
+{
+	struct iim4623x_data *data = dev->data;
+	struct rtio *ctx = data->rtio.ctx;
+	struct rtio_iodev *iodev = data->rtio.iodev;
+	int ret;
+
+	if (!atomic_cas(&data->busy, 0, 1)) {
+		return -EBUSY;
+	}
+
+	__ASSERT(data->await_sqe == NULL, "Already awaiting completion");
+
+	/* Acquisition order matters */
+	struct rtio_sqe *wr_sqe = rtio_sqe_acquire(ctx);
+
+	data->await_sqe = rtio_sqe_acquire(ctx);
+
+	struct rtio_sqe *re_sqe = rtio_sqe_acquire(ctx);
+
+	struct rtio_sqe *de_sqe = rtio_sqe_acquire(ctx);
+
+	if (!wr_sqe || !re_sqe || !de_sqe || !data->await_sqe) {
+		rtio_sqe_drop_all(ctx);
+		data->await_sqe = NULL;
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	/* Write */
+	rtio_sqe_prep_write(wr_sqe, iodev, RTIO_PRIO_HIGH, wbuf, wlen, NULL);
+	wr_sqe->flags |= RTIO_SQE_CHAINED;
+
+	/* Await data-ready interrupt */
+	rtio_sqe_prep_await(data->await_sqe, NULL, RTIO_PRIO_HIGH, data);
+	data->await_sqe->flags |= RTIO_SQE_CHAINED;
+
+	/* Read */
+	rtio_sqe_prep_read(re_sqe, iodev, RTIO_PRIO_HIGH, rbuf, rlen, NULL);
+	re_sqe->flags |= RTIO_SQE_CHAINED;
+
+	/**
+	 * Allow iim46234 to be ready for a new command
+	 * Refer to datasheet 5.3.1.4 which states 0.3ms after DRDY deasserts. It seems that it
+	 * takes ~3.1us from CS deassert until DRDY deasserts, so just use a single delay of >300us
+	 */
+	/**
+	 * TODO: it would be great if the delay could be scheduled to block the rtio context from
+	 * executing SQEs without also having to block the current thread
+	 */
+	rtio_sqe_prep_delay(de_sqe, K_USEC(400), NULL);
+
+	ret = iim4623x_rtio_submit_flush(ctx, 4);
+
+out:
+	atomic_cas(&data->busy, 1, 0);
+	return ret;
+}

--- a/drivers/sensor/tdk/iim4623x/iim4623x_bus.h
+++ b/drivers/sensor/tdk/iim4623x/iim4623x_bus.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Sentry Technologies ApS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_BUS_H
+#define ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_BUS_H
+
+#include <zephyr/device.h>
+
+/* Synchronously write to the iim4623x */
+int iim4623x_bus_write(const struct device *dev, const uint8_t *buf, size_t len);
+
+/* Synchronously read from the iim4623x */
+int iim4623x_bus_read(const struct device *dev, uint8_t *buf, size_t len);
+
+/* Synchronously write to then read from the iim4623x */
+int iim4623x_bus_write_then_read(const struct device *dev, const uint8_t *wbuf, size_t wlen,
+				 uint8_t *rbuf, size_t rlen);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_BUS_H */

--- a/drivers/sensor/tdk/iim4623x/iim4623x_bus.h
+++ b/drivers/sensor/tdk/iim4623x/iim4623x_bus.h
@@ -8,12 +8,19 @@
 #define ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_BUS_H
 
 #include <zephyr/device.h>
+#include <zephyr/rtio/rtio.h>
 
-/* Synchronously write to the iim4623x */
-int iim4623x_bus_write(const struct device *dev, const uint8_t *buf, size_t len);
+/* Prepare an rtio sqe chain to write to the iim4623x */
+int iim4623x_bus_prep_write(const struct device *dev, const uint8_t *buf, size_t len,
+			    struct rtio_sqe **cb_sqe);
 
-/* Synchronously read from the iim4623x */
-int iim4623x_bus_read(const struct device *dev, uint8_t *buf, size_t len);
+/* Prepare an rtio sqe chain to read from the iim4623x */
+int iim4623x_bus_prep_read(const struct device *dev, uint8_t *buf, size_t len,
+			   struct rtio_sqe **cb_sqe);
+
+/* Prepare an rtio sqe chain to write and then read from the iim4623x */
+int iim4623x_bus_prep_write_read(const struct device *dev, const uint8_t *wbuf, size_t wlen,
+				 uint8_t *rbuf, size_t rlen, struct rtio_sqe **cb_sqe);
 
 /* Synchronously write to then read from the iim4623x */
 int iim4623x_bus_write_then_read(const struct device *dev, const uint8_t *wbuf, size_t wlen,

--- a/drivers/sensor/tdk/iim4623x/iim4623x_decoder.c
+++ b/drivers/sensor/tdk/iim4623x/iim4623x_decoder.c
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2025 Sentry Technologies ApS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "iim4623x.h"
+#include "iim4623x_reg.h"
+#include "iim4623x_decoder.h"
+
+#include <zephyr/dsp/utils.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor_clock.h>
+
+LOG_MODULE_REGISTER(iim4623x_decoder, CONFIG_SENSOR_LOG_LEVEL);
+
+#define DT_DRV_COMPAT invensense_iim4623x
+
+static union iim4623x_encoded_channels iim4623x_encode_channel(enum sensor_channel chan)
+{
+	union iim4623x_encoded_channels enc_chan = {.msk = 0};
+
+	switch (chan) {
+	case SENSOR_CHAN_DIE_TEMP:
+		enc_chan.temp = 1;
+		break;
+	case SENSOR_CHAN_ACCEL_XYZ:
+	case SENSOR_CHAN_ACCEL_X:
+	case SENSOR_CHAN_ACCEL_Y:
+	case SENSOR_CHAN_ACCEL_Z:
+		enc_chan.accel = 1;
+		break;
+	case SENSOR_CHAN_GYRO_XYZ:
+	case SENSOR_CHAN_GYRO_X:
+	case SENSOR_CHAN_GYRO_Y:
+	case SENSOR_CHAN_GYRO_Z:
+		enc_chan.gyro = 1;
+		break;
+	default:
+		break;
+	};
+
+	return enc_chan;
+}
+
+static int iim4623x_decoder_get_frame_count(const uint8_t *buffer,
+					    struct sensor_chan_spec chan_spec,
+					    uint16_t *frame_count)
+{
+	struct iim4623x_encoded_data *edata = (struct iim4623x_encoded_data *)buffer;
+	union iim4623x_encoded_channels chan_req = iim4623x_encode_channel(chan_spec.chan_type);
+
+	if (chan_spec.chan_idx != 0) {
+		return -ENOTSUP;
+	}
+
+	if (!(edata->header.chans.msk & chan_req.msk)) {
+		return -ENODATA;
+	}
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_DIE_TEMP:
+	case SENSOR_CHAN_ACCEL_X:
+	case SENSOR_CHAN_ACCEL_Y:
+	case SENSOR_CHAN_ACCEL_Z:
+	case SENSOR_CHAN_GYRO_X:
+	case SENSOR_CHAN_GYRO_Y:
+	case SENSOR_CHAN_GYRO_Z:
+	case SENSOR_CHAN_ACCEL_XYZ:
+	case SENSOR_CHAN_GYRO_XYZ:
+		*frame_count = 1;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int iim4623x_decoder_get_size_info(struct sensor_chan_spec chan_spec, size_t *base_size,
+					  size_t *frame_size)
+{
+	if (chan_spec.chan_idx != 0) {
+		return -ENOTSUP;
+	}
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_DIE_TEMP:
+	case SENSOR_CHAN_ACCEL_X:
+	case SENSOR_CHAN_ACCEL_Y:
+	case SENSOR_CHAN_ACCEL_Z:
+	case SENSOR_CHAN_GYRO_X:
+	case SENSOR_CHAN_GYRO_Y:
+	case SENSOR_CHAN_GYRO_Z:
+		*base_size = sizeof(struct sensor_q31_data);
+		*frame_size = sizeof(struct sensor_q31_sample_data);
+		break;
+	case SENSOR_CHAN_ACCEL_XYZ:
+	case SENSOR_CHAN_GYRO_XYZ:
+		*base_size = sizeof(struct sensor_three_axis_data);
+		*frame_size = sizeof(struct sensor_three_axis_sample_data);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static uint8_t iim4623x_gyro_shift(uint8_t gyro_fs)
+{
+	/* Prefer supporting the full-scale range over the greatest precision */
+	switch (gyro_fs) {
+	case IIM4623X_GYRO_CFG_FS_2000:
+		return 11;
+	case IIM4623X_GYRO_CFG_FS_1000:
+		return 10;
+	case IIM4623X_GYRO_CFG_FS_480:
+		return 9;
+	case IIM4623X_GYRO_CFG_FS_250:
+		return 8;
+	default:
+		break;
+	}
+
+	/* Default to greatest precision, should never be reached */
+	return 8;
+}
+
+static int iim4623x_decode_chan(const struct iim4623x_encoded_data *edata, enum sensor_channel chan,
+				struct sensor_q31_data *out)
+{
+	struct sensor_three_axis_sample_data *tri_axis = (void *)&out->readings[0];
+	struct sensor_q31_sample_data *smpl_data = &out->readings[0];
+
+	switch (chan) {
+	case SENSOR_CHAN_DIE_TEMP:
+		/*
+		 * Use shift=7 to gain an effective range of +/- 128 degrees with a resolution of
+		 * < 0.001 degrees.
+		 * The datasheet specifies a resolution of 126.8 LSB per degree when using the fixed
+		 * point output format. Assuming the same resolution applies to the floating point
+		 * format, the sensor can only produce a resolution of ~0.0079 degrees.
+		 */
+		out->shift = 7;
+		smpl_data->value = Z_SHIFT_F32_TO_Q31(edata->payload.temp.val, out->shift);
+		break;
+	case SENSOR_CHAN_ACCEL_X:
+		/* Allow representing +/- 16g */
+		out->shift = 4;
+		smpl_data->value = Z_SHIFT_F32_TO_Q31(edata->payload.accel.x, out->shift);
+		break;
+	case SENSOR_CHAN_ACCEL_Y:
+		out->shift = 4;
+		smpl_data->value = Z_SHIFT_F32_TO_Q31(edata->payload.accel.y, out->shift);
+		break;
+	case SENSOR_CHAN_ACCEL_Z:
+		out->shift = 4;
+		smpl_data->value = Z_SHIFT_F32_TO_Q31(edata->payload.accel.z, out->shift);
+		break;
+	case SENSOR_CHAN_ACCEL_XYZ:
+		out->shift = 4;
+		tri_axis->x = Z_SHIFT_F32_TO_Q31(edata->payload.accel.x, out->shift);
+		tri_axis->y = Z_SHIFT_F32_TO_Q31(edata->payload.accel.y, out->shift);
+		tri_axis->z = Z_SHIFT_F32_TO_Q31(edata->payload.accel.z, out->shift);
+		break;
+	case SENSOR_CHAN_GYRO_X:
+		out->shift = iim4623x_gyro_shift(edata->header.gyro_fs);
+		smpl_data->value = Z_SHIFT_F32_TO_Q31(edata->payload.gyro.x, out->shift);
+		break;
+	case SENSOR_CHAN_GYRO_Y:
+		out->shift = iim4623x_gyro_shift(edata->header.gyro_fs);
+		smpl_data->value = Z_SHIFT_F32_TO_Q31(edata->payload.gyro.y, out->shift);
+		break;
+	case SENSOR_CHAN_GYRO_Z:
+		out->shift = iim4623x_gyro_shift(edata->header.gyro_fs);
+		smpl_data->value = Z_SHIFT_F32_TO_Q31(edata->payload.gyro.z, out->shift);
+		break;
+	case SENSOR_CHAN_GYRO_XYZ:
+		out->shift = iim4623x_gyro_shift(edata->header.gyro_fs);
+		tri_axis->x = Z_SHIFT_F32_TO_Q31(edata->payload.gyro.x, out->shift);
+		tri_axis->y = Z_SHIFT_F32_TO_Q31(edata->payload.gyro.y, out->shift);
+		tri_axis->z = Z_SHIFT_F32_TO_Q31(edata->payload.gyro.z, out->shift);
+		break;
+	default:
+		return -EINVAL;
+	};
+
+	return 0;
+}
+
+static int iim4623x_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
+				   uint32_t *fit, uint16_t max_count, void *data_out)
+{
+	struct iim4623x_encoded_data *edata = (struct iim4623x_encoded_data *)buffer;
+	union iim4623x_encoded_channels chan_req = iim4623x_encode_channel(chan_spec.chan_type);
+	struct sensor_q31_data *out = data_out;
+
+	if (chan_spec.chan_idx != 0) {
+		return -ENOTSUP;
+	}
+
+	if (max_count == 0 || *fit != 0) {
+		return -EINVAL;
+	}
+
+	if (!(chan_req.msk & edata->header.chans.msk)) {
+		return -ENODATA;
+	}
+
+	/* Convert timestamp from us to ns */
+	out->header.base_timestamp_ns = edata->header.timestamp;
+	/**
+	 * TODO: it should be possible to support more readings, but the internal FIFO of the
+	 * iim4623x seems a bit rough to work with for this purpose. For now just support a single
+	 * reading.
+	 */
+	out->header.reading_count = 1;
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_ACCEL_X:
+	case SENSOR_CHAN_ACCEL_Y:
+	case SENSOR_CHAN_ACCEL_Z:
+	case SENSOR_CHAN_GYRO_X:
+	case SENSOR_CHAN_GYRO_Y:
+	case SENSOR_CHAN_GYRO_Z:
+	case SENSOR_CHAN_DIE_TEMP:
+	case SENSOR_CHAN_ACCEL_XYZ:
+	case SENSOR_CHAN_GYRO_XYZ:
+		iim4623x_decode_chan(edata, chan_spec.chan_type, out);
+		break;
+	default:
+		return -EINVAL;
+	};
+
+	*fit = 1;
+	return 1;
+}
+
+static bool iim4623x_decoder_has_trigger(const uint8_t *buffer, enum sensor_trigger_type trigger)
+{
+	struct iim4623x_encoded_data *edata = (struct iim4623x_encoded_data *)buffer;
+
+	switch (trigger) {
+	case SENSOR_TRIG_DATA_READY:
+		return edata->header.data_ready;
+	default:
+		break;
+	}
+
+	return false;
+}
+
+SENSOR_DECODER_API_DT_DEFINE() = {
+	.get_frame_count = iim4623x_decoder_get_frame_count,
+	.get_size_info = iim4623x_decoder_get_size_info,
+	.decode = iim4623x_decoder_decode,
+	.has_trigger = iim4623x_decoder_has_trigger,
+};
+
+int iim4623x_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder)
+{
+	ARG_UNUSED(dev);
+	*decoder = &SENSOR_DECODER_NAME();
+
+	return 0;
+}
+
+int iim4623x_encode(const struct device *dev, struct iim4623x_encoded_data *edata)
+{
+	const struct iim4623x_data *data = dev->data;
+	uint64_t cycles;
+	int ret;
+
+	edata->header = data->edata.header;
+
+	ret = sensor_clock_get_cycles(&cycles);
+	if (ret) {
+		LOG_ERR_RATELIMIT("Failed getting sensor clock cycles, ret: %d", ret);
+		return ret;
+	}
+
+	/**
+	 * TODO: the sensor includes a micro second timestamp, if it can be converted to "system
+	 * time" then this would be more accurate and the header field could be dropped
+	 */
+	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+
+	return 0;
+}

--- a/drivers/sensor/tdk/iim4623x/iim4623x_decoder.h
+++ b/drivers/sensor/tdk/iim4623x/iim4623x_decoder.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Sentry Technologies ApS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_IIM4623X_DECODER_H_
+#define ZEPHYR_DRIVERS_SENSOR_IIM4623X_DECODER_H_
+
+#include <zephyr/drivers/sensor.h>
+#include "iim4623x.h"
+
+int iim4623x_encode(const struct device *dev, struct iim4623x_encoded_data *edata);
+
+int iim4623x_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_IIM4623X_DECODER_H_ */

--- a/drivers/sensor/tdk/iim4623x/iim4623x_reg.h
+++ b/drivers/sensor/tdk/iim4623x/iim4623x_reg.h
@@ -203,6 +203,9 @@ enum iim4623x_cmd_error_code {
 #define IIM4623X_CMD_ENABLE_SENSORFT            0x2E
 #define IIM4623X_CMD_DISABLE_SENSORFT           0x2F
 
+/* The type field value of streaming mode data packets */
+#define IIM4623X_STRM_PCK_TYPE 0xAB
+
 /**
  * Describe the register map of the iim4623x.
  *

--- a/drivers/sensor/tdk/iim4623x/iim4623x_reg.h
+++ b/drivers/sensor/tdk/iim4623x/iim4623x_reg.h
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2025 Sentry Technologies ApS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_REG_H
+#define ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_REG_H
+
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/byteorder.h>
+
+/* Structures used for the iim4623x protocol packets */
+
+/**
+ * Every packet contains a preamble with a header, message length, and type.
+ *
+ * The header value is a magical number depending on the packet direction (TX being
+ * host-to-iim4623x).
+ */
+#define IIM4623X_PCK_HEADER_TX 0x2424
+#define IIM4623X_PCK_HEADER_RX 0x2323
+
+struct iim4623x_pck_preamble {
+	uint16_t header;
+	uint8_t length;
+	uint8_t type;
+} __packed;
+
+/**
+ * Every packet contains a postamble with a checksum and a footer.
+ *
+ * The checksum is a simple sum-of-all-bytes comprising of packet type and payload.
+ * The footer is a magical number: 0x0D0A.
+ */
+#define IIM4623X_PCK_FOOTER 0x0D0A
+
+struct iim4623x_pck_postamble {
+	uint16_t checksum;
+	uint16_t footer;
+} __packed;
+
+/* Structure to describe the version command response */
+struct iim4623x_pck_resp_version {
+	uint8_t maj;
+	uint8_t min;
+	uint8_t _reserved[8];
+} __packed;
+
+/* Structure to describe the read-user-register command response */
+struct iim4623x_pck_resp_read_user_reg {
+	uint8_t _reserved;
+	uint8_t addr;
+	uint8_t page;
+	uint8_t read_len;
+	uint8_t error_code;
+	uint8_t error_mask;
+	uint8_t reg_val[72]; /* Varying size based off `read_len`, 72 is the max */
+} __packed;
+
+/* Structure to generically describe response packets from the iim4623x */
+struct iim4623x_pck_resp {
+	struct iim4623x_pck_preamble preamble;
+	/**
+	 * The acknowledgment packet is a special case wherein the packet number represents
+	 * an error_code instead
+	 */
+	union {
+		uint16_t pck_num;
+		struct {
+			uint8_t error_code;
+			uint8_t _reserved;
+		} ack;
+	};
+	/* Describe the payload which varies based off which command the response is tied to */
+	union {
+		/* Get Version */
+		struct iim4623x_pck_resp_version version;
+		/* Get Serial Number */
+		uint8_t serial_number[16];
+		/* Read User Registers */
+		struct iim4623x_pck_resp_read_user_reg read_user_reg;
+		/* IMU Self-Test */
+		uint8_t self_test[6];
+		/**
+		 * The following commands get basic acknowledgment packets:
+		 *  - Write User Register
+		 *  - Select Streaming Interface
+		 *  - Set UTC Time (no response in streaming mode)
+		 *  - Enable SensorFT (no response in streaming mode)
+		 *  - Disable SensorFT (no response in streaming mode)
+		 *
+		 * The following commands never get replies:
+		 *  - Start Streaming
+		 *  - Stop Streaming
+		 */
+	};
+	/* The postamble is described using a VLA since the payload itself varies in length */
+	uint8_t postamble_buf[];
+} __packed;
+
+/* Retrieve a pointer to the postamble of an iim4623x packet via. a pointer to the packet */
+#define IIM4623X_GET_POSTAMBLE(pck_ptr)                                                            \
+	(struct iim4623x_pck_postamble *)((uint8_t *)pck_ptr +                                     \
+					  (((struct iim4623x_pck_preamble *)pck_ptr)->length -     \
+					   sizeof(struct iim4623x_pck_postamble)))
+
+/* Structures used for streaming mode data packets */
+
+/* Conveniently wrap the collection of XYZ values from the iim4623x */
+union iim4623x_xyz_values {
+	struct {
+		uint8_t x[4];
+		uint8_t y[4];
+		uint8_t z[4];
+	} __packed buf;
+
+	struct {
+		float x;
+		float y;
+		float z;
+	} __packed;
+};
+
+/* Describe the iim4623x wire format for the payload of streaming mode data packets */
+struct iim4623x_pck_strm_payload {
+	union {
+		struct {
+			uint8_t gyro: 5;
+			uint8_t accel: 3;
+		} __packed;
+		uint8_t buf;
+	} status;
+	uint8_t sample_counter;
+	uint64_t timestamp;
+	union iim4623x_xyz_values accel;
+	union iim4623x_xyz_values gyro;
+	union {
+		uint8_t buf[4];
+		float val;
+	} temp;
+	union iim4623x_xyz_values delta_vel;   /* delta_vel output is disabled by default */
+	union iim4623x_xyz_values delta_angle; /* delta_angle output is disabled by default */
+} __packed;
+
+/* Describe the complete iim4623x streaming mode data packet */
+struct iim4623x_pck_strm {
+	struct iim4623x_pck_preamble preamble;
+	struct iim4623x_pck_strm_payload payload;
+	struct iim4623x_pck_postamble postamble;
+} __packed;
+
+/* Acknowledgment packet error codes */
+enum iim4623x_cmd_error_code {
+	IIM4623X_EC_ACK = 0x00,
+	IIM4623X_EC_NACK = 0x01,
+	IIM4623X_EC_WRITE = 0x02,
+	IIM4623X_EC_READ = 0x03,
+	IIM4623X_EC_INVAL = 0x04,
+	/* Reserved */
+	IIM4623X_EC_WRITE_FLASH = 0x06,
+	IIM4623X_EC_READ_FLASH = 0x07,
+	/* Reserved */
+	/* Reserved */
+	IIM4623X_EC_WRITE_USER = 0x0a,
+	IIM4623X_EC_READ_USER = 0x0b,
+	IIM4623X_EC_FLASH_ENDURANCE = 0x0c,
+	/* Reserved ... */
+};
+
+/**
+ * The protocol requires a minimum amount of bytes to be transferred. Any smaller packets must be
+ * zero padded after the postamble
+ */
+#define IIM4623X_MIN_TX_LEN 20
+
+/* Calculate packet length given a payload length */
+#define IIM4623X_PACKET_LEN(payload_len)                                                           \
+	(sizeof(struct iim4623x_pck_preamble) + payload_len + sizeof(struct iim4623x_pck_postamble))
+
+/* Calculate the packet length to a READ_USER_REGISTER command given the amount of bytes read */
+#define IIM4623X_READ_REG_RESP_LEN(payload_len)                                                    \
+	(sizeof(struct iim4623x_pck_preamble) + 2 +                                                \
+	 sizeof(struct iim4623x_pck_resp_read_user_reg) - 72 + payload_len +                       \
+	 sizeof(struct iim4623x_pck_postamble))
+
+/* Obtain total amount of bytes to transfer (incl. zero padding) given a payload len */
+#define IIM4623X_TX_LEN(payload_len) MAX(IIM4623X_PACKET_LEN(payload_len), IIM4623X_MIN_TX_LEN)
+
+/* For convenience, explicitly define the length of an acknowledgment packet */
+#define IIM4623X_PCK_ACK_LEN 10
+
+/* Define all command types */
+#define IIM4623X_CMD_GET_VERSION                0x20
+#define IIM4623X_CMD_GET_SERIAL_NUMBER          0x26
+#define IIM4623X_CMD_READ_USER_REGISTER         0x11
+#define IIM4623X_CMD_WRITE_USER_REGISTER        0x12
+#define IIM4623X_CMD_IMU_SELF_TEST              0x2B
+#define IIM4623X_CMD_SET_UTC_TIME               0x2D
+#define IIM4623X_CMD_SELECT_STREAMING_INTERFACE 0x30
+#define IIM4623X_CMD_START_STREAMING            0x27
+#define IIM4623X_CMD_STOP_STREAMING             0x28
+#define IIM4623X_CMD_ENABLE_SENSORFT            0x2E
+#define IIM4623X_CMD_DISABLE_SENSORFT           0x2F
+
+/**
+ * Describe the register map of the iim4623x.
+ *
+ * The register map consist of two pages, one for configuration (incl. some user data) and one for
+ * sensor data output.
+ */
+
+#define IIM4623X_PAGE_CFG         0x00
+#define IIM4623X_PAGE_SENSOR_DATA 0x01
+
+/* Registers in page 0 - the configuration page */
+
+#define IIM4623X_REG_WHO_AM_I   0x00
+#define IIM4623X_WHO_AM_I_46234 0xEA
+#define IIM4623X_WHO_AM_I_46230 0xE6
+
+#define IIM4623X_REG_SN     0x01
+#define IIM4623X_REG_SN_LEN 16
+
+#define IIM4623X_REG_FW_REV     0x11
+#define IIM4623X_REG_FW_REV_LEN 2
+
+#define IIM4623X_REG_FLASH_ENDURANCE     0x15
+#define IIM4623X_REG_FLASH_ENDURANCE_LEN 4
+
+#define IIM4623X_REG_DATA_FMT     0x19
+#define IIM4623X_DATA_FMT_FLOAT   0x00 /* IEEE-754 float */
+#define IIM4623X_DATA_FMT_QFORMAT 0x01 /* integer in two's complement */
+
+#define IIM4623X_REG_SAMPLE_RATE_DIV     0x1A
+#define IIM4623X_REG_SAMPLE_RATE_DIV_LEN 2
+
+#define IIM4623X_REG_SEL_OUT_DATA     0x1C
+#define IIM4623X_SEL_OUT_DATA_ACCEL   BIT(0)
+#define IIM4623X_SEL_OUT_DATA_GYRO    BIT(1)
+#define IIM4623X_SEL_OUT_DATA_TEMP    BIT(2)
+#define IIM4623X_SEL_OUT_DATA_D_ANGLE BIT(3)
+#define IIM4623X_SEL_OUT_DATA_D_VEL   BIT(4)
+
+#define IIM4623X_REG_UART_IF_CFG 0x1D
+
+#define IIM4623X_REG_SYNC_CFG 0x1E
+
+#define IIM4623X_REG_USR_SCRATCH1    0x1F
+#define IIM4623X_REG_USR_SCRATCH2    0x27
+#define IIM4623X_REG_USR_SCRATCH_LEN 8
+
+#define IIM4623X_REG_SAVE_ALL_CFG 0x2F
+
+#define IIM4623X_REG_BW_CFG               0x30
+#define IIM4623X_BW_CFG_PACK(accel, gyro) ((accel << 4) | gyro | 0x44)
+
+#define IIM4623X_REG_ACCEL_CFG   0x33
+#define IIM4623X_ACCEL_CFG_SHIFT 5 /* lower 5 bits are reserved */
+#define IIM4623X_ACCEL_CFG_FS_16 0x0
+#define IIM4623X_ACCEL_CFG_FS_8  0x1
+#define IIM4623X_ACCEL_CFG_FS_4  0x2
+#define IIM4623X_ACCEL_CFG_FS_2  0x3
+
+#define IIM4623X_REG_GYRO_CFG     0x34
+#define IIM4623X_GYRO_CFG_SHIFT   5 /* lower 5 bits are reserved */
+#define IIM4623X_GYRO_CFG_FS_2000 0x0
+#define IIM4623X_GYRO_CFG_FS_1000 0x1
+#define IIM4623X_GYRO_CFG_FS_480  0x2
+#define IIM4623X_GYRO_CFG_FS_250  0x3
+
+#define IIM4623X_REG_EXT_CALIB_CFG 0x3F
+
+#define IIM4623X_REG_EXT_ACCEL_X_BIAS   0x40
+#define IIM4623X_REG_EXT_ACCEL_Y_BIAS   0x44
+#define IIM4623X_REG_EXT_ACCEL_Z_BIAS   0x48
+#define IIM4623X_REG_EXT_ACCEL_BIAS_LEN 4
+
+#define IIM4623X_REG_EXT_GYRO_X_BIAS   0x4C
+#define IIM4623X_REG_EXT_GYRO_Y_BIAS   0x50
+#define IIM4623X_REG_EXT_GYRO_Z_BIAS   0x54
+#define IIM4623X_REG_EXT_GYRO_BIAS_LEN 4
+
+#define IIM4623X_REG_EXT_ACCEL_SENS_MAT11   0x58
+#define IIM4623X_REG_EXT_ACCEL_SENS_MAT12   0x5C
+#define IIM4623X_REG_EXT_ACCEL_SENS_MAT13   0x60
+#define IIM4623X_REG_EXT_ACCEL_SENS_MAT21   0x64
+#define IIM4623X_REG_EXT_ACCEL_SENS_MAT22   0x68
+#define IIM4623X_REG_EXT_ACCEL_SENS_MAT23   0x6C
+#define IIM4623X_REG_EXT_ACCEL_SENS_MAT31   0x70
+#define IIM4623X_REG_EXT_ACCEL_SENS_MAT32   0x74
+#define IIM4623X_REG_EXT_ACCEL_SENS_MAT33   0x78
+#define IIM4623X_REG_EXT_ACCEL_SENS_MAT_LEN 4
+
+#define IIM4623X_REG_EXT_GYRO_SENS_MAT11   0x7C
+#define IIM4623X_REG_EXT_GYRO_SENS_MAT12   0x80
+#define IIM4623X_REG_EXT_GYRO_SENS_MAT13   0x84
+#define IIM4623X_REG_EXT_GYRO_SENS_MAT21   0x88
+#define IIM4623X_REG_EXT_GYRO_SENS_MAT22   0x8C
+#define IIM4623X_REG_EXT_GYRO_SENS_MAT23   0x90
+#define IIM4623X_REG_EXT_GYRO_SENS_MAT31   0x94
+#define IIM4623X_REG_EXT_GYRO_SENS_MAT32   0x98
+#define IIM4623X_REG_EXT_GYRO_SENS_MAT33   0x9C
+#define IIM4623X_REG_EXT_GYRO_SENS_MAT_LEN 4
+
+#define IIM4623X_REG_CUSTOM_GRAVITY     0xA4
+#define IIM4623X_REG_CUSTOM_GRAVITY_LEN 4
+
+#define IIM4623X_REG_RESET_ALL_CFG 0xA8
+
+/* Registers in page 1 - the sensor output data page */
+
+#define IIM4623X_REG_SAMPLE_STATUS 0x00
+
+#define IIM4623X_REG_SENSOR_STATUS 0x01
+
+#define IIM4623X_REG_SAMPLE_COUNTER 0x02
+
+#define IIM4623X_REG_TIMESTAMP     0x03
+#define IIM4623X_REG_TIMESTAMP_LEN 8
+
+#define IIM4623X_REG_ACCEL_X   0x0B
+#define IIM4623X_REG_ACCEL_Y   0x0F
+#define IIM4623X_REG_ACCEL_Z   0x13
+#define IIM4623X_REG_ACCEL_LEN 4
+
+#define IIM4623X_REG_GYRO_X   0x17
+#define IIM4623X_REG_GYRO_Y   0x1B
+#define IIM4623X_REG_GYRO_Z   0x1F
+#define IIM4623X_REG_GYRO_LEN 4
+
+#define IIM4623X_REG_TEMP     0x23
+#define IIM4623X_REG_TEMP_LEN 4
+
+#define IIM4623X_REG_DELTA_VEL_X   0x27
+#define IIM4623X_REG_DELTA_VEL_Y   0x2B
+#define IIM4623X_REG_DELTA_VEL_Z   0x2F
+#define IIM4623X_REG_DELTA_VEL_LEN 4
+
+#define IIM4623X_REG_DELTA_ANGLE_X   0x33
+#define IIM4623X_REG_DELTA_ANGLE_Y   0x37
+#define IIM4623X_REG_DELTA_ANGLE_Z   0x3B
+#define IIM4623X_REG_DELTA_ANGLE_LEN 4
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_REG_H */

--- a/drivers/sensor/tdk/iim4623x/iim4623x_stream.c
+++ b/drivers/sensor/tdk/iim4623x/iim4623x_stream.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2025 Sentry Technologies ApS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "iim4623x.h"
+#include "iim4623x_bus.h"
+#include "iim4623x_decoder.h"
+#include "iim4623x_stream.h"
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(iim4623x_stream, CONFIG_SENSOR_LOG_LEVEL);
+
+/* Get the packet size of a streaming data packet given the enabled channels */
+#define IIM4623X_STRM_PCK_LEN(chans)                                                               \
+	(sizeof(struct iim4623x_pck_strm) - (chans.temp ? 0 : 4) - (chans.accel ? 0 : 12) -        \
+	 (chans.gyro ? 0 : 12) - (chans.delta_vel ? 0 : 12) - (chans.delta_angle ? 0 : 12))
+
+static void iim4623x_stream_event_complete(struct rtio *ctx, const struct rtio_sqe *sqe, void *arg)
+{
+	const struct device *dev = arg;
+	struct iim4623x_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+	struct iim4623x_encoded_data *edata = sqe->userdata;
+	int ret;
+
+	if (data->stream.data_opt == SENSOR_STREAM_DATA_DROP) {
+		/* Data has been consumed from the iim4623x but should just be dropped */
+		/**
+		 * TODO: it seems undocumented, but other sensor drivers still provide timestamp and
+		 * event type (e.g. data-ready) so let's do the same for now
+		 */
+		edata->header.chans.msk = 0x00;
+		(void)memset(&edata->payload, 0, sizeof(struct iim4623x_pck_strm_payload));
+
+		goto out;
+	};
+
+	/* Parse/check reply */
+	struct iim4623x_pck_strm *packet = (struct iim4623x_pck_strm *)data->trx_buf;
+	struct iim4623x_pck_postamble *postamble;
+	uint16_t checksum;
+
+	if (sys_be16_to_cpu(packet->preamble.header) != IIM4623X_PCK_HEADER_RX) {
+		LOG_ERR("Bad reply header");
+		ret = -EIO;
+		goto out;
+	}
+
+	if (packet->preamble.type != IIM4623X_STRM_PCK_TYPE) {
+		LOG_ERR("Bad reply type");
+		ret = -EIO;
+		goto out;
+	}
+
+	/* Locate postamble by advancing past the reply reg_val buffer */
+	postamble = IIM4623X_GET_POSTAMBLE(packet);
+
+	/* Verify checksum */
+	checksum = iim4623x_calc_checksum((uint8_t *)packet);
+	if (checksum != sys_be16_to_cpu(postamble->checksum)) {
+		LOG_ERR("Bad checksum, exp: 0x%.4x, got: 0x%.4x", checksum,
+			sys_be16_to_cpu(postamble->checksum));
+		ret = -EIO;
+		goto out;
+	}
+
+	/* Copy register contents */
+	(void)memcpy(&edata->payload, &packet->payload, sizeof(struct iim4623x_pck_strm_payload));
+
+	/* Convert wire endianness to cpu */
+	iim4623x_payload_be_to_cpu(&edata->payload);
+
+	edata->header.data_ready = true;
+
+out:
+	ret = rtio_flush_completion_queue(ctx);
+	if (ret) {
+		rtio_iodev_sqe_err(iodev_sqe, ret);
+	} else {
+		rtio_iodev_sqe_ok(iodev_sqe, 0);
+	}
+}
+
+static void iim4623x_stream_stop_complete(struct rtio *ctx, const struct rtio_sqe *sqe, void *arg)
+{
+	const struct device *dev = arg;
+	struct iim4623x_data *data = dev->data;
+	int ret;
+
+	data->stream.iodev_sqe = NULL;
+
+	/**
+	 * Note that there is no good way to check that the stop-streaming cmd was received. The
+	 * datasheet specifically mentions:
+	 *
+	 * > A ‘no’ response for more than ODR rate is a good indicator that the STOP sequence
+	 * > is obtained
+	 *
+	 */
+	atomic_cas(&data->busy, 1, 0);
+
+	ret = rtio_flush_completion_queue(ctx);
+	if (ret) {
+		LOG_ERR("Failed completing stream-stop, ret: %d", ret);
+	}
+}
+
+static void iim4623x_stream_stop(const struct device *dev, size_t read_len)
+{
+	struct iim4623x_data *data = dev->data;
+	struct rtio_sqe *comp_sqe;
+	int ret;
+
+	/**
+	 * iim4623x requires the stop_streaming cmd to arrive while data is ready. It also
+	 * requires all of the available data to be read otherwise it becomes unresponsive.
+	 */
+	(void)memset(data->trx_buf, 0, read_len);
+	ret = iim4623x_prepare_cmd(dev, IIM4623X_CMD_STOP_STREAMING, NULL, 0);
+	if (ret < 0) {
+		LOG_ERR("Failed preparing stop streaming");
+		return;
+	}
+
+	ret = iim4623x_bus_prep_write(dev, data->trx_buf, read_len, &comp_sqe);
+	if (ret < 0) {
+		LOG_ERR("Failed preparing to send stop streaming");
+		return;
+	}
+
+	rtio_sqe_prep_callback_no_cqe(comp_sqe, iim4623x_stream_stop_complete, (void *)dev, NULL);
+
+	rtio_submit(data->rtio.ctx, 0);
+}
+
+void iim4623x_stream_event(const struct device *dev)
+{
+	struct iim4623x_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+	uint32_t min_buf_len = sizeof(struct iim4623x_encoded_data);
+	struct iim4623x_encoded_data *edata;
+	struct rtio_sqe *comp_sqe;
+	size_t read_len = IIM4623X_STRM_PCK_LEN(data->edata.header.chans);
+	uint32_t buf_len;
+	uint8_t *buf;
+	int ret;
+
+	if (!iodev_sqe || FIELD_GET(RTIO_SQE_CANCELED, iodev_sqe->sqe.flags)) {
+		/* No active stream sqe, leave streaming mode */
+		iim4623x_stream_stop(dev, read_len);
+		return;
+	}
+
+	/* Fetch data async and complete iodev_sqe within completion callback */
+	ret = rtio_sqe_rx_buf(iodev_sqe, min_buf_len, min_buf_len, &buf, &buf_len);
+	if (ret || !buf || buf_len < min_buf_len) {
+		LOG_ERR("Failed to get a read buffer of size %u bytes", min_buf_len);
+		goto err_out;
+	}
+
+	edata = (struct iim4623x_encoded_data *)buf;
+
+	ret = iim4623x_encode(dev, edata);
+	if (ret) {
+		LOG_ERR("Failed to encode");
+		goto err_out;
+	}
+
+	ret = iim4623x_bus_prep_read(dev, data->trx_buf, read_len, &comp_sqe);
+	if (ret < 0) {
+		LOG_ERR("Prepping read, ret: %d", ret);
+		goto err_out;
+	}
+
+	rtio_sqe_prep_callback_no_cqe(comp_sqe, iim4623x_stream_event_complete, (void *)dev, buf);
+
+	rtio_submit(data->rtio.ctx, 0);
+	return;
+
+err_out:
+	rtio_iodev_sqe_err(iodev_sqe, ret);
+}
+
+static void iim4623x_stream_submit_complete(struct rtio *ctx, const struct rtio_sqe *sqe, void *arg)
+{
+	rtio_flush_completion_queue(ctx);
+}
+
+void iim4623x_stream_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *read_cfg = iodev_sqe->sqe.iodev->data;
+	struct iim4623x_data *data = dev->data;
+	struct rtio_sqe *comp_sqe;
+	int ret;
+
+	if ((read_cfg->count != 1) || (read_cfg->triggers[0].trigger != SENSOR_TRIG_DATA_READY) ||
+	    (read_cfg->triggers[0].opt == SENSOR_STREAM_DATA_NOP)) {
+		LOG_ERR("Unsupported read config");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+		return;
+	}
+
+	if (!data->stream.iodev_sqe) {
+		/* Can't start streaming if device is busy */
+		if (!atomic_cas(&data->busy, 0, 1)) {
+			rtio_iodev_sqe_err(iodev_sqe, -EBUSY);
+			return;
+		}
+
+		data->stream.iodev_sqe = iodev_sqe;
+		data->stream.drdy_en = true;
+		data->stream.data_opt = read_cfg->triggers[0].opt;
+
+		/* Kick off streaming */
+		ret = iim4623x_prepare_cmd(dev, IIM4623X_CMD_START_STREAMING, NULL, 0);
+		if (ret < 0) {
+			LOG_ERR("Failed to start streaming");
+			rtio_iodev_sqe_err(iodev_sqe, ret);
+			return;
+		}
+
+		ret = iim4623x_bus_prep_write(dev, data->trx_buf, ret, &comp_sqe);
+		if (ret < 0) {
+			LOG_ERR("Failed to prep write");
+			rtio_iodev_sqe_err(iodev_sqe, ret);
+		}
+
+		/* TODO: consider using SQE flags instead of callback to flush CQEs */
+		rtio_sqe_prep_callback_no_cqe(comp_sqe, iim4623x_stream_submit_complete, NULL,
+					      NULL);
+
+		rtio_submit(data->rtio.ctx, 0);
+	}
+}

--- a/drivers/sensor/tdk/iim4623x/iim4623x_stream.h
+++ b/drivers/sensor/tdk/iim4623x/iim4623x_stream.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Sentry Technologies ApS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_STREAM_H
+#define ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_STREAM_H
+
+#include <zephyr/device.h>
+#include <zephyr/rtio/rtio.h>
+
+void iim4623x_stream_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+
+void iim4623x_stream_event(const struct device *dev);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_TDK_IIM4623X_STREAM_H */

--- a/dts/bindings/sensor/invensense,iim46230.yaml
+++ b/dts/bindings/sensor/invensense,iim46230.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) 2025 Sentry Technologies ApS
+#
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "invensense,iim46230"
+
+include: invensense,iim4623x.yaml
+
+properties:
+  accel-fs:
+    type: int
+    default: 1
+    description: |
+      Specify the accelerometer range in g.
+      Default to the power-up default.
+    enum:
+      - 2
+      - 4
+      - 8
+      - 16
+
+  gyro-fs:
+    type: int
+    default: 2
+    description: |
+      Specify the gyroscope range in degrees per second.
+      Default to the power-up default.
+    enum:
+      - 250
+      - 480
+      - 1000
+      - 2000

--- a/dts/bindings/sensor/invensense,iim46234.yaml
+++ b/dts/bindings/sensor/invensense,iim46234.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2025 Sentry Technologies ApS
+#
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "invensense,iim46234"
+
+include: invensense,iim4623x.yaml
+
+properties:
+  accel-fs:
+    type: int
+    default: 1
+    description: |
+      Specify the accelerometer range in g.
+      Default to the power-up default.
+    enum:
+      - 2
+      - 4
+      - 8
+
+  gyro-fs:
+    type: int
+    default: 2
+    description: |
+      Specify the gyroscope range in degrees per second.
+      Default to the power-up default.
+    enum:
+      - 250
+      - 480

--- a/dts/bindings/sensor/invensense,iim4623x.yaml
+++ b/dts/bindings/sensor/invensense,iim4623x.yaml
@@ -1,0 +1,89 @@
+# Copyright (c) 2025 Sentry Technologies ApS
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  IIM-4623x family of 6-axis motion tracking devices. They combine multiple
+  3-axis gyroscopes and 3-axis accelerometers packaged in a small module.
+
+  The sensors can connect on either UART or SPI, but currently only SPI is
+  supported. It is worth noting that the device datasheet specifies a range
+  for the SPI clock frequency: 4 MHz <= f_sclk <= 12 MHz.
+  Additionally the device datasheet specifies operation using SPI mode 3:
+  CPOL=1, CPHA=1.
+
+  When setting the accel-bw and gyro-bw properties in a .dts or .dtsi file
+  you may include iim4623x.h and use the macros defined there.
+
+  Example:
+  #include <zephyr/dt-bindings/sensor/iim4623x.h>
+
+  &spi0 {
+    ...
+
+    iim4623x@0 {
+      ...
+
+      accel-bw = <IIM4623X_DT_ACCEL_BW_4>;
+      gyro-bw = <IIM4623X_DT_GYRO_BW_4>;
+    };
+  };
+
+include: [spi-device.yaml, sensor-device.yaml]
+
+properties:
+  int-gpios:
+    type: phandle-array
+    required: true
+    description: Interrupt gpio
+
+  reset-gpios:
+    type: phandle-array
+    required: true
+    description: Reset gpio
+
+  odr:
+    type: int
+    default: 1000
+    description: |
+      Specify the IMU output data rate in Hz.
+      Default to the power-up default.
+    enum:
+      - 1000
+      - 500
+      - 250
+      - 200
+      - 125
+      - 100
+      - 50
+      - 25
+      - 20
+      - 10
+
+  accel-bw:
+    type: int
+    default: 0
+    description: |
+      Specify the accelerometer bandwidth setting.
+      Consult the datasheet for figures regarding 3dB bandwidth,
+      noise bandwidth, and RMS noise.
+      Default to the power-up default.
+    enum:
+      - 0 # IIM4623X_DT_ACCEL_BW_4
+      - 1 # IIM4623X_DT_ACCEL_BW_5
+      - 2 # IIM4623X_DT_ACCEL_BW_6
+      - 3 # IIM4623X_DT_ACCEL_BW_7
+
+  gyro-bw:
+    type: int
+    default: 0
+    description: |
+      Specify the gyroscope bandwidth setting.
+      Consult the datasheet for figures regarding 3dB bandwidth,
+      noise bandwidth, and RMS noise.
+      Default to the power-up default.
+    enum:
+      - 0 # IIM4623X_DT_GYRO_BW_4
+      - 1 # IIM4623X_DT_GYRO_BW_5
+      - 2 # IIM4623X_DT_GYRO_BW_6
+      - 3 # IIM4623X_DT_GYRO_BW_7

--- a/include/zephyr/dt-bindings/sensor/iim4623x.h
+++ b/include/zephyr/dt-bindings/sensor/iim4623x.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Sentry Technologies ApS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_TDK_IIM4623X_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_TDK_IIM4623X_H_
+
+/**
+ * @defgroup IIM4623x Invensense (TDK) IIM4623x DT Options
+ * @ingroup sensor_interface
+ * @{
+ */
+
+/**
+ * @defgroup IIM46234_GYRO_BW Gyroscope Bandwidth options
+ * @{
+ */
+#define IIM4623X_DT_GYRO_BW_4 0
+#define IIM4623X_DT_GYRO_BW_5 1
+#define IIM4623X_DT_GYRO_BW_6 2
+#define IIM4623X_DT_GYRO_BW_7 3
+/** @} */
+
+/**
+ * @defgroup IIM46234_ACCEL_BW Accelerometer Bandwidth options
+ * @{
+ */
+#define IIM4623X_DT_ACCEL_BW_4 0
+#define IIM4623X_DT_ACCEL_BW_5 1
+#define IIM4623X_DT_ACCEL_BW_6 2
+#define IIM4623X_DT_ACCEL_BW_7 3
+/** @} */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_TDK_IIM4623X_H_ */

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -467,3 +467,29 @@ test_spi_icm42686: icm42686@38 {
 	spi-max-frequency = <24000000>;
 	int-gpios = <&test_gpio 0 0>;
 };
+
+test_spi_iim46230: iim46230@39 {
+	compatible = "invensense,iim46230";
+	reg = <0x39>;
+	spi-max-frequency = <12000000>;
+	int-gpios = <&test_gpio 0 GPIO_ACTIVE_HIGH>;
+	reset-gpios = <&test_gpio 1 GPIO_ACTIVE_LOW>;
+	odr = <1000>;
+	accel-fs = <8>;
+	gyro-fs = <480>;
+	accel-bw = <0>;
+	gyro-bw = <0>;
+};
+
+test_spi_iim46234: iim46234@3a {
+	compatible = "invensense,iim46234";
+	reg = <0x3a>;
+	spi-max-frequency = <12000000>;
+	int-gpios = <&test_gpio 0 GPIO_ACTIVE_HIGH>;
+	reset-gpios = <&test_gpio 1 GPIO_ACTIVE_LOW>;
+	odr = <1000>;
+	accel-fs = <8>;
+	gyro-fs = <480>;
+	accel-bw = <0>;
+	gyro-bw = <0>;
+};


### PR DESCRIPTION
The TDK Invensense IIM46230 and IIM46234 are 6-axis IMUs with gyroscope and accelerometers. This pull-request adds support for either model using a shared driver: iim4623x.

I'll try to do an overview in this comment, but please also see the individual commit messages for details and explanations. For the curious, the datasheet for the devices is available [from the TDK website, linked for convenience](https://invensense.tdk.com/wp-content/uploads/2022/10/DS-000300-IIM-46234-and-IIM-46230-v1.3.pdf).

Overview of the features that are implemented:
 - Devicetree properties for ODR, full-scale values, filter bandwidth options
 - Mandatory Fetch/Get API
 - Async API (Read/Decode API)
 - Stream support (triggers: `data-ready`, data-opts: `include, drop`)

List of some relevant features that are not implemented:
 - Sensor Trigger API
   * reasoning: the stream API seems to make the trigger redundant
 - Stream support with FIFO triggers
   * reasoning: the iim4623x technically has 40 sample FIFOs which are used when the device is in "streaming mode", but there are no handles for it. All that can be done is just read back samples until the device has none left. Combined with data-ready interrupt timeouts, it seems like a cumbersome task to support some kind of FIFO trigger. I also haven't explored how the FIFO is filled when interrupts are ignored for some time and similar situations
 - Channel selection on the hardware level. The default enabled channels will always be enabled in the hardware.
   * reasoning: adding the option to reconfigure the channels on the device clutters the rest of the logic and I believe there will be minimal gains from doing so. Since there is no generic channel enumerations for the default-disabled channels (`delta velocity` and `delta angle`) there is also no reason to enable these. As such, the channel selection is not implemented.
 - Support for device timestamps
   * reasoning: the device can generate timestamps with us precision, but these would need to be sync'ed/converted to the zephyr domain. If the PPS signal feature on the device is implemented, this may not be as difficult. But as-is the added complexity seem to outweigh the value added. For now the measurement timestamps are generated within the interrupt handler of the host processor.
 - Support for additional device commands such as external calibration and compensation values
   * reasoning: the devices are calibrated from factory. The datasheet says: "Factory calibration over temperature range for
bias, sensitivity, misalignment, G-sensitivity", so hopefully these parameters should be unnecessary for regular use cases.

Implementation wise I've tried to use `RTIO` everywhere for the driver to reap benefits whenever specific SPI controllers support `RTIO` optimised for their hardware.
For chip configuration, the driver fires SQEs and waits for them in a synchronous fashion for simplicity.
For data gathering, the driver fires SQEs that include completion callbacks so they get handled asynchronously (that is the intention at least).

Be aware that as-is, this pull request depends on two additional changes. These have been submitted in the following pull-requests:

https://github.com/zephyrproject-rtos/zephyr/pull/95740
https://github.com/zephyrproject-rtos/zephyr/pull/95050

Without these the driver won't work or build properly, so if they are accepted, this pull-request will be rebased. If they are not accepted, the driver implementation has to be changed.