### PR TITLE
boards: scobc_a1: Fix typo in OpenOCD config comment

### DIFF
--- a/boards/sc/scobc_a1/support/scobc-a1.cfg
+++ b/boards/sc/scobc_a1/support/scobc-a1.cfg
@@ -3,7 +3,7 @@
 if {[info exists env(OPENOCD_INTERFACE)]} {
     set _INTERFACE $env(OPENOCD_INTERFACE)
 } else {
-    # Default CMIS-DAP
+    # Default CMSIS-DAP
     set _INTERFACE "CMSIS-DAP"
 }
 


### PR DESCRIPTION
The board support file `scobc-a1.cfg` contained a typo in the default interface comment.

"Default CMIS-DAP" → "Default CMSIS-DAP"

This fixes the spelling of CMSIS-DAP to match the actual debug interface.