### PR TITLE
soc: nordic: uicr: Fix dependency issue

### DIFF
--- a/soc/nordic/common/uicr/sysbuild.cmake
+++ b/soc/nordic/common/uicr/sysbuild.cmake
@@ -8,4 +8,8 @@ ExternalZephyrProject_Add(
 
 # Ensure UICR is configured and built after the default image so EDT/ELFs exist.
 sysbuild_add_dependencies(CONFIGURE uicr ${DEFAULT_IMAGE})
+
 add_dependencies(uicr ${DEFAULT_IMAGE})
+if(DEFINED image)
+  add_dependencies(uicr ${image})
+endif()


### PR DESCRIPTION
Although not reproducible locally, it has been observed in CI that the uicr image will not always be the last image to be run.

To ensure it is the last image to be run we have it depend on the 'image' image when defined.

The uicr image is generated based on all other images in the build and must therefore run last.