### PR TITLE
drivers: video: esp32: add selection api

### DIFF
--- a/drivers/video/video_esp32_dvp.c
+++ b/drivers/video/video_esp32_dvp.c
@@ -88,13 +88,13 @@ static int video_esp32_reload_dma(struct video_esp32_data *data)
 
 	ret = dma_reload(cfg->dma_dev, cfg->rx_dma_channel, 0, (uint32_t)data->active_vbuf->buffer,
 			 data->active_vbuf->bytesused);
-	if (ret) {
+	if (ret < 0) {
 		LOG_ERR("Unable to reload DMA (%d)", ret);
 		return ret;
 	}
 
 	ret = dma_start(cfg->dma_dev, cfg->rx_dma_channel);
-	if (ret) {
+	if (ret < 0) {
 		LOG_ERR("Unable to start DMA (%d)", ret);
 		return ret;
 	}
@@ -260,7 +260,7 @@ static int video_esp32_get_fmt(const struct device *dev, struct video_format *fm
 	LOG_DBG("Get format");
 
 	ret = video_get_format(cfg->source_dev, fmt);
-	if (ret) {
+	if (ret < 0) {
 		LOG_ERR("Failed to get format from source");
 		return ret;
 	}
@@ -389,6 +389,34 @@ static int video_esp32_init(const struct device *dev)
 	return 0;
 }
 
+int video_esp32_set_selection(const struct device *dev, struct video_selection *sel)
+{
+	struct video_esp32_data *data = dev->data;
+	const struct video_esp32_config *cfg = dev->config;
+	int ret;
+
+	ret = video_set_selection(cfg->source_dev, sel);
+	if (ret < 0) {
+		LOG_ERR("Failed to set selection on source device");
+		return ret;
+	}
+
+	ret = video_get_format(cfg->source_dev, &data->video_format);
+	if (ret < 0) {
+		LOG_ERR("Failed to get format from source device");
+		return ret;
+	}
+
+	return 0;
+}
+
+int video_esp32_get_selection(const struct device *dev, struct video_selection *sel)
+{
+	const struct video_esp32_config *cfg = dev->config;
+
+	return video_get_selection(cfg->source_dev, sel);
+}
+
 static DEVICE_API(video, esp32_driver_api) = {
 	/* mandatory callbacks */
 	.set_format = video_esp32_set_fmt,
@@ -399,6 +427,8 @@ static DEVICE_API(video, esp32_driver_api) = {
 	.enqueue = video_esp32_enqueue,
 	.dequeue = video_esp32_dequeue,
 	.flush = video_esp32_flush,
+	.set_selection = video_esp32_set_selection,
+	.get_selection = video_esp32_get_selection,
 #ifdef CONFIG_POLL
 	.set_signal = video_esp32_set_signal,
 #endif


### PR DESCRIPTION
Forward get/set selection to the camera source and update the driver's video_format on set so buffer sizing and streaming follow the selected region.