### PR TITLE
logging: fix dictionary message corruption

### DIFF
--- a/subsys/logging/log_output_dict.c
+++ b/subsys/logging/log_output_dict.c
@@ -28,19 +28,23 @@ void log_dict_output_msg_process(const struct log_output *output,
 
 	output_hdr.source = (source != NULL) ? log_source_id(source) : 0U;
 
-	log_output_write(output->func, (uint8_t *)&output_hdr, sizeof(output_hdr),
-			 (void *)output->control_block->ctx);
+	// TODO: what do we do if all of this doesn't fit into output-buf?
+
+	memcpy(&output->buf[output->control_block->offset], &output_hdr, sizeof(output_hdr));
+	output->control_block->offset += sizeof(output_hdr);
 
 	size_t len;
 	uint8_t *data = log_msg_get_package(msg, &len);
 
 	if (len > 0U) {
-		log_output_write(output->func, data, len, (void *)output->control_block->ctx);
+		memcpy(&output->buf[output->control_block->offset], data, len);
+		output->control_block->offset += len;
 	}
 
 	data = log_msg_get_data(msg, &len);
 	if (len > 0U) {
-		log_output_write(output->func, data, len, (void *)output->control_block->ctx);
+		memcpy(&output->buf[output->control_block->offset], data, len);
+		output->control_block->offset += len;
 	}
 
 	log_output_flush(output);


### PR DESCRIPTION
This is a demonstration of my idea for fixing #94781

Replace the series of log_output_write calls with copying data to the backend's buffer. The log_output_flush call will perform a single log_output_write to dump all the data at once. This fixes the bug where filling up the RTT buffer causes only parts of the message to be transferred, causing the resulting data stream to be undecodable.

log_output.c does something similar, where it puts characters in the buffer and flushes when it's full. We could do the same here as well.
