### PR TITLE
modules: openthread: fix build for RCP

### DIFF
--- a/modules/openthread/openthread.c
+++ b/modules/openthread/openthread.c
@@ -166,6 +166,22 @@ static void ot_joiner_start_handler(otError error, void *context)
 	}
 }
 
+static void ot_configure_instance(void)
+{
+#ifndef CONFIG_OPENTHREAD_COPROCESSOR_RCP
+	/* Configure Child Supervision and MLE Child timeouts. */
+	otChildSupervisionSetInterval(openthread_instance,
+				      CONFIG_OPENTHREAD_CHILD_SUPERVISION_INTERVAL);
+	otChildSupervisionSetCheckTimeout(openthread_instance,
+					  CONFIG_OPENTHREAD_CHILD_SUPERVISION_CHECK_TIMEOUT);
+	otThreadSetChildTimeout(openthread_instance, CONFIG_OPENTHREAD_MLE_CHILD_TIMEOUT);
+
+	if (IS_ENABLED(CONFIG_OPENTHREAD_ROUTER_SELECTION_JITTER_OVERRIDE)) {
+		otThreadSetRouterSelectionJitter(openthread_instance, OT_ROUTER_SELECTION_JITTER);
+	}
+#endif
+}
+
 static bool ot_setup_default_configuration(void)
 {
 	otExtendedPanId xpanid = {0};
@@ -355,17 +371,7 @@ int openthread_init(void)
 		}
 	}
 
-	/* Configure Child Supervision and MLE Child timeouts. */
-	otChildSupervisionSetInterval(openthread_instance,
-				      CONFIG_OPENTHREAD_CHILD_SUPERVISION_INTERVAL);
-	otChildSupervisionSetCheckTimeout(openthread_instance,
-					  CONFIG_OPENTHREAD_CHILD_SUPERVISION_CHECK_TIMEOUT);
-	otThreadSetChildTimeout(openthread_instance, CONFIG_OPENTHREAD_MLE_CHILD_TIMEOUT);
-
-	if (IS_ENABLED(CONFIG_OPENTHREAD_ROUTER_SELECTION_JITTER_OVERRIDE)) {
-		otThreadSetRouterSelectionJitter(openthread_instance, OT_ROUTER_SELECTION_JITTER);
-	}
-
+	ot_configure_instance();
 	openthread_mutex_unlock();
 
 	(void)k_work_submit_to_queue(&openthread_work_q, &openthread_work);


### PR DESCRIPTION
In the previous PR I moved configuring the child supervision and timeout to the function that is also used in radio co-processor firmware that does not include APIs for setting these values.

Fixes #95792