### PR TITLE
Add UICR.SECURESTORAGE configuration based on device tree partitions

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -174,5 +174,34 @@
 		secondary_periphconf_partition: partition@1c0000 {
 			reg = <0x1c0000 DT_SIZE_K(8)>;
 		};
+
+		/* NB: A gap has been left here for future partitions */
+
+		/* 0x1fd000 was chosen for secure_storage_partition such that
+		 * there is no more space after secure_storage_partition.
+		 */
+		secure_storage_partition: partition@1fd000 {
+			compatible = "fixed-subpartitions";
+			reg = <0x1fd000 DT_SIZE_K(12)>;
+			ranges = <0x0 0x1fd000 0x3000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cpuapp_crypto_partition: partition@0 {
+				reg = <0x0 DT_SIZE_K(4)>;
+			};
+
+			cpurad_crypto_partition: partition@1000 {
+				reg = <0x1000 DT_SIZE_K(4)>;
+			};
+
+			cpuapp_its_partition: partition@2000 {
+				reg = <0x2000 DT_SIZE_K(2)>;
+			};
+
+			cpurad_its_partition: partition@2800 {
+				reg = <0x2800 DT_SIZE_K(2)>;
+			};
+		};
 	};
 };

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1270,6 +1270,7 @@ flagged.
         "GEN_UICR_GENERATE_PERIPHCONF", # Used in specialized build tool, not part of main Kconfig
         "GEN_UICR_SECONDARY", # Used in specialized build tool, not part of main Kconfig
         "GEN_UICR_SECONDARY_GENERATE_PERIPHCONF", # Used in specialized build tool, not part of main Kconfig
+        "GEN_UICR_SECURESTORAGE", # Used in specialized build tool, not part of main Kconfig
         "HEAP_MEM_POOL_ADD_SIZE_", # Used as an option matching prefix
         "HUGETLBFS",          # Linux, in boards/xtensa/intel_adsp_cavs25/doc
         "IAR_BUFFERED_WRITE",

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -44,6 +44,25 @@ function(compute_partition_address_and_size partition_nodelabel output_address_v
   set(${output_size_var} ${partition_size} PARENT_SCOPE)
 endfunction()
 
+# Function to compute optional partition address and size from devicetree
+# If partition doesn't exist, sets both address and size to 0
+function(compute_optional_partition_address_and_size partition_nodelabel output_address_var output_size_var)
+  # Initialize with default values
+  set(${output_address_var} 0 PARENT_SCOPE)
+  set(${output_size_var} 0 PARENT_SCOPE)
+
+  # Check if partition exists
+  dt_nodelabel(partition_path NODELABEL ${partition_nodelabel} QUIET)
+  if(partition_path)
+    # Call nested function with different variable names to avoid naming conflicts
+    compute_partition_address_and_size(${partition_nodelabel} temp_addr temp_size)
+
+    # Copy the results to the output variables in parent scope
+    set(${output_address_var} ${temp_addr} PARENT_SCOPE)
+    set(${output_size_var} ${temp_size} PARENT_SCOPE)
+  endif()
+endfunction()
+
 # Use CMAKE_VERBOSE_MAKEFILE to silence an unused-variable warning.
 if(CMAKE_VERBOSE_MAKEFILE)
 endif()
@@ -59,6 +78,32 @@ set(secondary_periphconf_hex_file ${APPLICATION_BINARY_DIR}/zephyr/secondary_per
 # Get UICR absolute address from this image's devicetree
 dt_nodelabel(uicr_path NODELABEL "uicr" REQUIRED)
 dt_reg_addr(UICR_ADDRESS PATH ${uicr_path} REQUIRED)
+
+# Handle secure storage configuration
+set(securestorage_args)
+if(CONFIG_GEN_UICR_SECURESTORAGE)
+  list(APPEND securestorage_args --securestorage)
+
+  # Extract secure storage partition information (required)
+  compute_partition_address_and_size("secure_storage_partition" SECURE_STORAGE_ADDRESS SECURE_STORAGE_SIZE)
+  list(APPEND securestorage_args --securestorage-address ${SECURE_STORAGE_ADDRESS})
+  list(APPEND securestorage_args --securestorage-size ${SECURE_STORAGE_SIZE})
+
+  # Extract individual partition information for validation (optional partitions)
+  compute_optional_partition_address_and_size("cpuapp_crypto_partition" CPUAPP_CRYPTO_ADDRESS CPUAPP_CRYPTO_SIZE)
+  compute_optional_partition_address_and_size("cpurad_crypto_partition" CPURAD_CRYPTO_ADDRESS CPURAD_CRYPTO_SIZE)
+  compute_optional_partition_address_and_size("cpuapp_its_partition" CPUAPP_ITS_ADDRESS CPUAPP_ITS_SIZE)
+  compute_optional_partition_address_and_size("cpurad_its_partition" CPURAD_ITS_ADDRESS CPURAD_ITS_SIZE)
+
+  list(APPEND securestorage_args --cpuapp-crypto-address ${CPUAPP_CRYPTO_ADDRESS})
+  list(APPEND securestorage_args --cpuapp-crypto-size ${CPUAPP_CRYPTO_SIZE})
+  list(APPEND securestorage_args --cpurad-crypto-address ${CPURAD_CRYPTO_ADDRESS})
+  list(APPEND securestorage_args --cpurad-crypto-size ${CPURAD_CRYPTO_SIZE})
+  list(APPEND securestorage_args --cpuapp-its-address ${CPUAPP_ITS_ADDRESS})
+  list(APPEND securestorage_args --cpuapp-its-size ${CPUAPP_ITS_SIZE})
+  list(APPEND securestorage_args --cpurad-its-address ${CPURAD_ITS_ADDRESS})
+  list(APPEND securestorage_args --cpurad-its-size ${CPURAD_ITS_SIZE})
+endif(CONFIG_GEN_UICR_SECURESTORAGE)
 
 if(CONFIG_GEN_UICR_GENERATE_PERIPHCONF)
   # gen_uicr.py parses all zephyr.elf files. To find these files (which
@@ -134,6 +179,7 @@ add_custom_command(
           --out-merged-hex ${merged_hex_file}
           --out-uicr-hex ${uicr_hex_file}
           ${periphconf_args}
+          ${securestorage_args}
           ${secondary_args}
   DEPENDS ${periphconf_elfs} ${secondary_periphconf_elfs}
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}

--- a/soc/nordic/common/uicr/gen_uicr/Kconfig
+++ b/soc/nordic/common/uicr/gen_uicr/Kconfig
@@ -21,6 +21,28 @@ config GEN_UICR_SECONDARY_GENERATE_PERIPHCONF
 	  When enabled, the UICR generator will populate the
 	  secondary_periphconf_partition partition.
 
+config GEN_UICR_SECURESTORAGE
+	bool "Enable UICR.SECURESTORAGE"
+	default y
+	depends on $(dt_nodelabel_enabled,secure_storage_partition)
+	help
+	  When enabled, the UICR generator will configure the
+	  secure storage region based on device tree partitions.
+
+	  The following device tree partitions are used:
+	  - secure_storage_partition: Main secure storage partition (required)
+	  - cpuapp_crypto_partition: Application processor crypto storage (optional)
+	  - cpurad_crypto_partition: Radio core crypto storage (optional)
+	  - cpuapp_its_partition: Application processor internal trusted storage (optional)
+	  - cpurad_its_partition: Radio core internal trusted storage (optional)
+
+	  Requirements:
+	  - The secure_storage_partition address and size must be aligned to 4KB
+	  - All subpartitions must be multiples of 1KB and laid out contiguously
+	      without gaps
+	  - At least one subpartition must be defined
+	  - Combined subpartition sizes must equal secure_storage_partition size
+
 endmenu
 
 source "Kconfig.zephyr"


### PR DESCRIPTION
Add UICR.SECURESTORAGE configuration based on device tree partitions.
Validates partition layout and populates size fields in 1KB units.
Handles missing partitions gracefully.

Update the default memory map to include a `secure_storage_partition`,
which is divided into at most four subpartitions. These will be used to
configure UICR.SECURESTORAGE, if enabled.