### PR TITLE
dts: st: h7: fix dma stream

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1102,7 +1102,7 @@
 			interrupts = <78 0>;
 			interrupt-names = "dcmi";
 			clocks = <&rcc STM32_CLOCK(AHB2, 0)>;
-			dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
+			dmas = <&dma1 1 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
 				STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
 				STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
 			status = "disabled";
@@ -1115,7 +1115,7 @@
 			reg = <0x40015804 0x20>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(1)>;
-			dmas = <&dma1 1 87 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
+			dmas = <&dma1 2 87 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
 				STM32_DMA_16BITS) 0>;
 			status = "disabled";
 		};
@@ -1127,7 +1127,7 @@
 			reg = <0x40015824 0x20>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(1)>;
-			dmas = <&dma1 0 88 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
+			dmas = <&dma1 3 88 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
 				STM32_DMA_16BITS) 0>;
 			status = "disabled";
 		};


### PR DESCRIPTION
Workaround for drivers that use HAL_OVERRIDE hack and skips Zephyr API. https://github.com/zephyrproject-rtos/zephyr/pull/93480#discussion_r2388527851

This change fixes DMA stream ID for H7xx series for the following peripherals:

1. dcmi
2. sai1_a
3. sai1_b

DMA stream ID should be in range 1..N

`samples/drivers/i2s/output`

Before:
```
I2S device not ready
[00:00:00.000,000] <dbg> i2s_stm32_sai: stm32_sai_enable_clock: Clock Control Device: <OK>
[00:00:00.000,000] <dbg> i2s_stm32_sai: stm32_sai_enable_clock: I2S clock Enable: <OK>
[00:00:00.000,000] <dbg> i2s_stm32_sai: stm32_sai_enable_clock: I2S domain clock configuration: <OK>
[00:00:00.000,000] <err> dma_stm32: cannot configure the dma stream -1.
[00:00:00.000,000] <err> i2s_stm32_sai: Failed to configure DMA channel 0
[00:00:00.000,000] <err> i2s_stm32_sai: i2s_stm32_sai_dma_init(): <FAILED>
*** Booting Zephyr OS build v4.2.0-3327-g599d0053b7de ***
```

After:

```
[00:00:00.000,000] <dbg> i2s_stm32_sai: stm32_sai_enable_clock: Clock Control Device: <OK>
[00:00:00.000,000] <dbg> i2s_stm32_sai: stm32_sai_enable_clock: I2S clock Enable: <OK>
[00:00:00.000,000] <dbg> i2s_stm32_sai: stm32_sai_eAll I2S blocks written
nable_clock: I2S domain clock configuration: <OK>
[00:00:00.000,000] <inf> i2s_stm32_sai: sai1@40015824 inited
*** Booting Zephyr OS build v4.2.0-3327-g599d0053b7de ***
[00:00:00.000,000] <dbg> i2s_stm32_sai: i2s_stm32_sai_configure: SAI_STEREOMODE
[00:00:00.000,000] <dbg> i2s_stm32_sai: i2s_stm32_sai_trigger: I2S_TRIGGER_START
[00:00:00.021,000] <dbg> i2s_stm32_sai: i2s_stm32_sai_trigger: I2S_TRIGGER_DRAIN
[00:00:00.029,000] <dbg> i2s_stm32_sai: HAL_SAI_TxCpltCallback: Exit TX callback, no more data in the queue
```