### PR TITLE
samples: fix subsys/usb/console for mini_stm32h743

### DIFF
--- a/samples/subsys/usb/console/src/boards/mini_stm32h743.overlay
+++ b/samples/subsys/usb/console/src/boards/mini_stm32h743.overlay
@@ -1,0 +1,5 @@
+/ {
+	chosen {
+		zephyr,console = &board_cdc_acm_uart;
+	};
+};


### PR DESCRIPTION
Mini stm32H743 core board uses board_cdc_acm_uart as label for cdc acm uart instead of cdc_acm_uart0 in app overlay. This change is to correct it in the board overlay file.