### PR TITLE
traceconfig: generate an annotated Markdown document with source refs

### DIFF
--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -191,7 +191,13 @@ set(EXTRA_KCONFIG_TARGET_COMMAND_FOR_hardenconfig
   ${ZEPHYR_BASE}/scripts/kconfig/hardenconfig.py
   )
 
-set_ifndef(KCONFIG_TARGETS menuconfig guiconfig hardenconfig)
+set(EXTRA_KCONFIG_TARGET_COMMAND_FOR_traceconfig
+  ${ZEPHYR_BASE}/scripts/kconfig/traceconfig.py
+  ${DOTCONFIG}
+  ${PROJECT_BINARY_DIR}/kconfig-trace.md
+  )
+
+set_ifndef(KCONFIG_TARGETS menuconfig guiconfig hardenconfig traceconfig)
 
 foreach(kconfig_target
     ${KCONFIG_TARGETS}

--- a/doc/build/kconfig/index.rst
+++ b/doc/build/kconfig/index.rst
@@ -25,6 +25,7 @@ tips and best practices for writing :file:`Kconfig` files.
    :maxdepth: 1
 
    menuconfig.rst
+   tracing.rst
    setting.rst
    tips.rst
    preprocessor-functions.rst

--- a/doc/build/kconfig/tips.rst
+++ b/doc/build/kconfig/tips.rst
@@ -375,6 +375,8 @@ error-prone, since it can be hard to spot that the same dependency is added
 twice.
 
 
+.. _stuck_symbols:
+
 "Stuck" symbols in menuconfig and guiconfig
 *******************************************
 

--- a/doc/build/kconfig/tracing.rst
+++ b/doc/build/kconfig/tracing.rst
@@ -1,0 +1,59 @@
+Tracing values to their source
+##############################
+
+The merged configuration saved to :file:`zephyr/.config` contains the result of
+applying the user configuration file to the whole tree of Kconfig files. This
+process can be hard to follow, especially when invisible symbols are being
+implicitly selected from anywhere in the tree. To help with this, the
+``traceconfig`` target can be used to generate a file in the build directory
+that details how each symbol got its final value.
+
+After building the Zephyr project as usual, the Kconfig trace can be generated
+with either of these commands:
+
+   .. code-block:: bash
+
+      west build -t traceconfig
+
+   .. code-block:: bash
+
+      ninja traceconfig
+
+.. note::
+   The generated information is only useful on a clean build, because otherwise
+   the ``.config`` file "pins" all settings to a specific value (as described
+   in :ref:`Stuck symbols <stuck_symbols>`). Therefore, it is recommended to
+   run a :ref:`pristine build <west-building-pristine>` before generating the
+   trace.
+
+The output will be in the :file:`zephyr/kconfig-trace.md` file in the build
+directory. This file is best viewed within IDEs to take advantage of Markdown
+elements (tables, highlighting, clickable links), but can easily be understood
+even when opened directly with any text editor.
+
+The report is divided in three sections:
+
+#. Visible symbols
+#. Invisible symbols
+#. Unset symbols
+
+For sections 1 and 2, a table is presented where each symbol is shown with its
+type, name, and current value. The fourth column details the kind of statement
+that resulted in the value being applied, and can be one of the following:
+
+ - *assigned*, when an explicit assignment, of the form ``CONFIG_xxx=y``, is
+   read from a config file;
+
+ - *default*, when there was no user assignment, but an applicable default
+   value was read from Kconfig tree;
+
+ - *selected* or *implied*, when a ``select`` or ``imply`` statement from a
+   separate symbol caused the symbol to be set.
+
+The fifth column details the location for the source statement. For the first
+two kinds of statements, the exact location (file name and line number) is
+provided; in the latter cases, it contains the expressions that resulted in the
+symbol being set.
+
+Finally, section 3 simply lists all undefined symbols. These have no additional
+information since they never received a value by any of the above means.

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -1308,7 +1308,7 @@ class Kconfig(object):
                                            "within the same choice", loc)
 
                             # Set the choice's mode
-                            sym.choice.set_value(val)
+                            sym.choice.set_value(val, loc)
 
                     elif sym.orig_type is STRING:
                         match = _conf_string_match(val)
@@ -1349,7 +1349,7 @@ class Kconfig(object):
                 if sym._was_set:
                     self._assigned_twice(sym, val, loc)
 
-                sym.set_value(val)
+                sym.set_value(val, loc)
 
         if replace:
             # If we're replacing the configuration, unset the symbols that
@@ -4154,6 +4154,10 @@ class Symbol(object):
       most symbols. Undefined and constant symbols have an empty nodes list.
       Symbols defined in multiple locations get one node for each location.
 
+    user_loc:
+      A (filename, linenr) tuple indicating where the user value was set, or
+      None if the user hasn't set a value.
+
     choice:
       Holds the parent Choice for choice symbols, and None for non-choice
       symbols. Doubles as a flag for whether a symbol is a choice symbol.
@@ -4295,6 +4299,7 @@ class Symbol(object):
         "ranges",
         "rev_dep",
         "selects",
+        "user_loc",
         "user_value",
         "weak_rev_dep",
     )
@@ -4588,7 +4593,7 @@ class Symbol(object):
         """
         return self.name + " " + _locs(self)
 
-    def set_value(self, value):
+    def set_value(self, value, loc=None):
         """
         Sets the user value of the symbol.
 
@@ -4620,6 +4625,9 @@ class Symbol(object):
           BOOL or "0x123" for an INT) are ignored and won't be stored in
           Symbol.user_value. Kconfiglib will print a warning by default for
           invalid assignments, and set_value() will return False.
+
+        loc:
+          A (filename, linenr) tuple indicating where the value was set.
 
         Returns True if the value is valid for the type of the symbol, and
         False otherwise. This only looks at the form of the value. For BOOL and
@@ -4661,6 +4669,7 @@ class Symbol(object):
 
             return False
 
+        self.user_loc = loc
         self.user_value = value
         self._was_set = True
 
@@ -4683,6 +4692,7 @@ class Symbol(object):
         gotten a user value via Kconfig.load_config() or Symbol.set_value().
         """
         if self.user_value is not None:
+            self.user_loc = None
             self.user_value = None
             self._rec_invalidate_if_has_prompt()
 
@@ -4827,6 +4837,7 @@ class Symbol(object):
         self.implies = []
         self.ranges = []
 
+        self.user_loc = \
         self.user_value = \
         self.choice = \
         self.env_var = \
@@ -5125,6 +5136,10 @@ class Choice(object):
       WARNING: Do not assign directly to this. It will break things. Call
       sym.set_value(2) on the choice symbol to be selected instead.
 
+    user_loc:
+      A (filename, linenr) tuple indicating where the user value was set, or
+      None if the user hasn't set a value.
+
     visibility:
       See the Symbol class documentation. Acts on the value (mode).
 
@@ -5195,6 +5210,7 @@ class Choice(object):
         "nodes",
         "orig_type",
         "syms",
+        "user_loc",
         "user_selection",
         "user_value",
     )
@@ -5274,7 +5290,7 @@ class Choice(object):
             self._cached_selection = self._selection()
         return self._cached_selection
 
-    def set_value(self, value):
+    def set_value(self, value, loc=None):
         """
         Sets the user value (mode) of the choice. Like for Symbol.set_value(),
         the visibility might truncate the value. Choices without the 'optional'
@@ -5309,6 +5325,7 @@ class Choice(object):
 
             return False
 
+        self.user_loc = loc
         self.user_value = value
         self._was_set = True
         self._rec_invalidate()
@@ -5321,6 +5338,7 @@ class Choice(object):
         the user had never touched the mode or any of the choice symbols.
         """
         if self.user_value is not None or self.user_selection:
+            self.user_loc = None
             self.user_value = self.user_selection = None
             self._rec_invalidate()
 

--- a/scripts/kconfig/traceconfig.py
+++ b/scripts/kconfig/traceconfig.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 Arduino SA
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+import pickle
+
+from tabulate import tabulate
+
+KIND_TO_COL = {
+    "unset": "not set",
+    "default": "default",
+    "assign": "assigned",
+    "select": "selected",
+    "imply": "implied",
+}
+
+
+def source_link(refpath, fn, ln):
+    if refpath:
+        fn = os.path.relpath(fn, refpath)
+
+    link_fn = fn
+    disp_fn = os.path.normpath(fn).replace("../", "").replace("_", "\\_")
+
+    return f"[{disp_fn}:{ln}](<{link_fn}#L{ln}>)"
+
+
+def write_markdown(trace_data, output):
+    sections = {"user": [], "hidden": [], "unset": []}
+
+    if os.name == "nt":
+        # relative paths on Windows can't span drives, so don't use them
+        # generated links will be absolute
+        refpath = None
+    else:
+        refpath = os.path.dirname(os.path.abspath(output))
+
+    for sym in trace_data:
+        sym_name, sym_vis, sym_type, sym_value, sym_src, sym_loc = sym
+        if sym_vis == "n":
+            section = "hidden"
+        elif sym_src == "unset":
+            section = "unset"
+        else:
+            section = "user"
+
+        if section == "user":
+            sym_name = f"`{sym_name}`"
+        elif section == "hidden":
+            sym_name = f"`{sym_name}` (h)"
+
+        if sym_type == "string" and sym_value is not None:
+            sym_value = f'"{sym_value}"'.replace("_", "\\_")
+
+        if isinstance(sym_loc, tuple):
+            sym_loc = source_link(refpath, *sym_loc)
+        elif isinstance(sym_loc, list):
+            sym_loc = " || <br> ".join(f"`{loc}`" for loc in sym_loc)
+            sym_loc = sym_loc.replace("|", "\\|")
+        elif sym_loc is None and sym_src == "default":
+            sym_loc = "_(implicit)_"
+
+        sym_src = KIND_TO_COL[sym_src]
+
+        sections[section].append((sym_type, sym_name, sym_value, sym_src, sym_loc))
+
+    lines = []
+    add = lines.append
+
+    headers = ["Type", "Name", "Value", "Source", "Location"]
+    colaligns = ["right", "left", "right", "center", "left"]
+
+    add("\n## Visible symbols\n\n")
+    add(
+        tabulate(
+            sorted(sections["user"], key=lambda x: x[1]),
+            headers=headers,
+            tablefmt='pipe',
+            colalign=colaligns,
+        )
+    )
+
+    add("\n\n## Invisible symbols\n\n")
+    add(
+        tabulate(
+            sorted(sections["hidden"], key=lambda x: x[1]),
+            headers=headers,
+            tablefmt='pipe',
+            colalign=colaligns,
+        )
+    )
+
+    add("\n\n## Unset symbols\n\n")
+    for sym_name in sorted(x[1] for x in sections["unset"]):
+        add(f"    # {sym_name} is not set\n")
+
+    with open(output, "w") as f:
+        f.writelines(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    parser.add_argument("dotconfig_file", help="Input merged .config file")
+    parser.add_argument("output_file", help="Output Markdown file")
+    parser.add_argument("kconfig_file", help="Top-level Kconfig file", nargs="?")
+
+    args = parser.parse_args()
+
+    with open(args.dotconfig_file + '-trace.pickle', 'rb') as f:
+        trace_data = pickle.load(f)
+    write_markdown(trace_data, args.output_file)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/kconfig/tracing/CMakeLists.txt
+++ b/tests/kconfig/tracing/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright 2025 Arduino SA
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+# will never be created so the check runs every time
+set(output_file ${PROJECT_BINARY_DIR}/validate_tracing_output.txt)
+
+add_custom_command(
+  COMMENT "Testing Kconfig value origin traces"
+  OUTPUT ${output_file}
+  DEPENDS
+    ${logical_target_for_zephyr_elf}
+    $<$<TARGET_EXISTS:native_runner_executable>:native_runner_executable>
+  COMMAND ${PYTHON_EXECUTABLE} ${APPLICATION_SOURCE_DIR}/validate_tracing.py ${DOTCONFIG}
+  COMMAND ${WEST} build -t traceconfig
+)
+
+add_custom_target(validate_traces ALL DEPENDS ${output_file})
+
+project(check_tracing)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/kconfig/tracing/Kconfig
+++ b/tests/kconfig/tracing/Kconfig
@@ -1,0 +1,34 @@
+# Copyright 2025 Arduino SA
+# SPDX-License-Identifier: Apache-2.0
+
+# Note that line numbers in this file are important for test scripts. Ensure
+# these match the expectations in validate_srcrefs.py.
+
+source "Kconfig.zephyr"
+
+config MAIN_FLAG
+	bool
+
+config MAIN_FLAG_DEPENDENCY
+	bool "Main Feature Dependency"
+	default y
+	depends on MAIN_FLAG
+
+config MAIN_FLAG_SELECT
+	bool "Main Feature Dependent"
+	select MAIN_FLAG
+
+choice MULTIPLE_CHOICES
+	prompt "Multiple Choice Option"
+
+config FIRST_CHOICE
+	bool "First Choice Option"
+	depends on !MAIN_FLAG
+
+config SECOND_CHOICE
+	bool "Second Choice Option"
+
+endchoice
+
+config UNSET_FLAG
+	bool "Disabled Feature"

--- a/tests/kconfig/tracing/prj.conf
+++ b/tests/kconfig/tracing/prj.conf
@@ -1,0 +1,7 @@
+# Copyright 2025 Arduino SA
+# SPDX-License-Identifier: Apache-2.0
+
+# Note that line numbers in this file are important for test scripts. Ensure
+# these match the expectations in validate_srcrefs.py.
+
+CONFIG_MAIN_FLAG_SELECT=y

--- a/tests/kconfig/tracing/src/main.c
+++ b/tests/kconfig/tracing/src/main.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025 Arduino SA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+int main(void)
+{
+	return 0;
+}

--- a/tests/kconfig/tracing/testcase.yaml
+++ b/tests/kconfig/tracing/testcase.yaml
@@ -1,0 +1,11 @@
+# Copyright 2025 Arduino SA
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  kconfig.tracing:
+    build_only: true
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim

--- a/tests/kconfig/tracing/validate_tracing.py
+++ b/tests/kconfig/tracing/validate_tracing.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2025 Arduino SA
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import pickle
+import sys
+
+# fmt: off
+
+# Indices for the fields in the trace entries
+# Keep these in sync with the generation code in scripts/kconfig/kconfig.py!
+(
+    SYM_NAME,
+    SYM_VIS,
+    SYM_TYPE,
+    SYM_VALUE,
+    SYM_KIND,
+    SYM_LOC
+) = range(6)
+
+EXPECTED_TRACES = [
+    [
+        "CONFIG_BOARD",
+        "n",
+        "string",
+        "native_sim",
+        "default",
+        [ "zephyr/boards/Kconfig", None ] # only test the file name
+    ],
+    [
+        "CONFIG_MAIN_FLAG",
+        "n",
+        "bool",
+        "y",
+        "select",
+        [ "MAIN_FLAG_SELECT" ]
+    ],
+    [
+        "CONFIG_MAIN_FLAG_DEPENDENCY",
+        "y",
+        "bool",
+        "y",
+        "default",
+        [ "tests/kconfig/tracing/Kconfig", 14 ]
+    ],
+    [
+        "CONFIG_MAIN_FLAG_SELECT",
+        "y",
+        "bool",
+        "y",
+        "assign",
+        [ "tests/kconfig/tracing/prj.conf", 7 ]
+    ],
+    [
+        "CONFIG_SECOND_CHOICE",
+        "y",
+        "bool",
+        "y",
+        "default",
+        None
+    ],
+    [
+        "CONFIG_UNSET_FLAG",
+        "y",
+        "bool",
+        None,
+        "unset",
+        None
+    ],
+]
+
+# fmt: on
+
+
+def compare_entry(actual, expected):
+    for field in SYM_NAME, SYM_VIS, SYM_TYPE, SYM_VALUE, SYM_KIND:
+        if actual[field] != expected[field]:
+            return False
+
+    if expected[SYM_KIND] in ("imply", "select") or expected[SYM_LOC] is None:
+        # list of strings or None, compare directly
+        if actual[SYM_LOC] != expected[SYM_LOC]:
+            return False
+    else:
+        # file reference, trim input path
+        if not isinstance(actual[SYM_LOC], list | tuple) or len(actual[SYM_LOC]) != 2:
+            return False
+
+        expected_path, expected_line = expected[SYM_LOC]
+        actual_path, actual_line = actual[SYM_LOC]
+
+        if not os.path.normpath(actual_path).endswith(expected_path):
+            return False
+
+        if expected_line is not None and expected_line != actual_line:
+            return False
+
+    return True
+
+
+def compare_traces(source, actual_list, expected_list):
+    result = True
+    for expected in expected_list:
+        actual = next((sr for sr in actual_list if sr[0] == expected[0]), None)
+        if not actual:
+            print(f"Missing value traces for {expected[0]}")
+            result = False
+            continue
+
+        if not compare_entry(actual, expected):
+            print(f"{source}: ERROR: value traces mismatch for {expected[0]}:")
+            print("  expected:", expected)
+            print("    actual:", actual)
+            result = False
+            continue
+
+    if result:
+        print(f"{source}: value traces match expected values.")
+    else:
+        print(f"{source}: ERROR: Validation failed.")
+        sys.exit(1)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: validate_traces.py <dotconfig>")
+        sys.exit(1)
+
+    dotconfig = sys.argv[1]
+
+    with open(dotconfig + "-trace.json") as f:
+        traces = json.load(f)
+        compare_traces("json", traces, EXPECTED_TRACES)
+
+    with open(dotconfig + "-trace.pickle", 'rb') as f:
+        traces = pickle.load(f)
+        compare_traces("pickle", traces, EXPECTED_TRACES)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds a new `traceconfig` build target to generate Markdown documentation for Kconfig symbols that details the reason a value was chosen for each symbol in the configuration. The list of symbols is split in three sorted groups:

* **Visible symbols**: parameters that have a value and are user-configurable
* **Invisible symbols**: parameters that have a value which are hidden by default (often target of `select`s or implicit `default`s).
* **Unset symbols**: parameters that do not have a value assigned

Symbols that have a value include a readable and clickable (if the viewer supports it) link to the location of the statement that resulted in that value being applied, be it an explicit assignment or a `default`. For the symbols that are `select`-ed or `imply`-ed by multiple sources, the set of matching requirements are printed.

[Documentation](https://builds.zephyrproject.io/zephyr/pr/95808/docs/build/kconfig/tracing.html) for the new feature is available and a [test suite](https://github.com/zephyrproject-rtos/zephyr/actions/runs/17795626467/job/50582879272#step:13:414) has been added to validate Kconfig source reference functionality.

## Sample generated documentation

The new target generates a `zephyr/kconfig-trace.md` file in the project's build folder. [This](https://github.com/user-attachments/files/22383650/kconfig-trace.md) is an example of a full generated documentation for the `sample/drivers/spi_flash` project running on the `arduino_opta//m7` board. 

The objective is for the generated document to be easily readable by humans with a simple editor. The entries are rendered like this:

### As a raw source

```
| Type | Name                             |      Value |  Source  | Location                                                                                                                                  |
|-----:|:---------------------------------|-----------:|:--------:|:------------------------------------------------------------------------------------------------------------------------------------------|
| bool | `CONFIG_SERIAL`                  |          y | user set | [boards/arduino/opta/arduino\_opta\_stm32h747xx\_m7\_defconfig:27](<../../boards/arduino/opta/arduino_opta_stm32h747xx_m7_defconfig#L27>) |
| bool | `CONFIG_SIZE_OPTIMIZATIONS`      |          y | default  | [Kconfig.zephyr:485](<../../Kconfig.zephyr#L485>)                                                                                         |
| bool | `CONFIG_SOC_EARLY_INIT_HOOK`     |          y | selected | `SOC_SERIES_STM32H7X && SOC_FAMILY_STM32`                                                                                                 |
| bool | `CONFIG_SOC_FLASH_STM32`         |          y | default  | [drivers/flash/Kconfig.stm32:22](<../../drivers/flash/Kconfig.stm32#L22>)                                                                 |
|  hex | `CONFIG_SRAM_BASE_ADDRESS`       | 0x24000000 | default  | [arch/Kconfig:228](<../../arch/Kconfig#L228>)                                                                                             |
| bool | `CONFIG_SRAM_REGION_PERMISSIONS` |          y | selected | `ARM_MPU && CPU_HAS_MPU`                                                                                                                  |
|  int | `CONFIG_SRAM_SIZE`               |        512 | default  | [arch/Kconfig:220](<../../arch/Kconfig#L220>)                                                                                             |
| bool | `CONFIG_STACK_ALIGN_DOUBLE_WORD` |          y | default  | [arch/arm/core/Kconfig:152](<../../arch/arm/core/Kconfig#L152>)                                                                           |
| bool | `CONFIG_STDOUT_CONSOLE`          |          y | user set | [samples/drivers/spi\_flash/prj.conf:1](<../../samples/drivers/spi_flash/prj.conf#L1>)                                                    |
```

### As a Github table

Note: links here have been edited to refer to the upstream used in the PR generation. They are usually relative to where the file was generated.

| Type | Name | Value | Source | Location |
|-------:|:----------------------------------------------------|--------------------------:|:--------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| bool | `CONFIG_SERIAL`                  |          y | user set | [boards/arduino/opta/arduino\_opta\_stm32h747xx\_m7\_defconfig:27](<../../zephyr/blob/7d84a3b639526374eee405a06c773b572b74c913/boards/arduino/opta/arduino_opta_stm32h747xx_m7_defconfig#L27>) |
| bool | `CONFIG_SIZE_OPTIMIZATIONS`      |          y | default  | [Kconfig.zephyr:485](<../../zephyr/blob/7d84a3b639526374eee405a06c773b572b74c913/Kconfig.zephyr#L485>)                                                                                         |
| bool | `CONFIG_SOC_EARLY_INIT_HOOK`     |          y | selected | `SOC_SERIES_STM32H7X && SOC_FAMILY_STM32`                                                                                                 |
| bool | `CONFIG_SOC_FLASH_STM32`         |          y | default  | [drivers/flash/Kconfig.stm32:22](<../../zephyr/blob/7d84a3b639526374eee405a06c773b572b74c913/drivers/flash/Kconfig.stm32#L22>)                                                                 |
|  hex | `CONFIG_SRAM_BASE_ADDRESS`       | 0x24000000 | default  | [arch/Kconfig:228](<../../zephyr/blob/7d84a3b639526374eee405a06c773b572b74c913/arch/Kconfig#L228>)                                                                                             |
| bool | `CONFIG_SRAM_REGION_PERMISSIONS` |          y | selected | `ARM_MPU && CPU_HAS_MPU`                                                                                                                  |
|  int | `CONFIG_SRAM_SIZE`               |        512 | default  | [arch/Kconfig:220](<../../zephyr/blob/7d84a3b639526374eee405a06c773b572b74c913/arch/Kconfig#L220>)                                                                                             |
| bool | `CONFIG_STACK_ALIGN_DOUBLE_WORD` |          y | default  | [arch/arm/core/Kconfig:152](<../../zephyr/blob/7d84a3b639526374eee405a06c773b572b74c913/arch/arm/core/Kconfig#L152>)                                                                           |
| bool | `CONFIG_STDOUT_CONSOLE`          |          y | user set | [samples/drivers/spi\_flash/prj.conf:1](<../../zephyr/blob/7d84a3b639526374eee405a06c773b572b74c913/samples/drivers/spi_flash/prj.conf#L1>)                                                    |

### Rendered in VSCode:

<img width="1257" height="384" alt="image" src="https://github.com/user-attachments/assets/42219de5-5a4e-4389-96f9-9c3a5cc8d95d" />

## Review notes

* Kconfiglib already used `loc`s (a tuple of filename and line number) in a few specific places to store line information. 
* A refactor was first applied to expand the usage to all statements modifying the value, with the same `loc` element  shared with multiple entities. 
* The *source reference* concept is then added to `Symbols` to collapse this information in a common form, which is exported for later usage by external tools. 
* A processor that reads this information and writes the user-visible Markdown document is then added, along with a test suite for the functionality. 