### PR TITLE
drivers: wch: Clock Control Fixes + SOC Support for CH32V307

### DIFF
--- a/drivers/clock_control/clock_control_wch_rcc.c
+++ b/drivers/clock_control/clock_control_wch_rcc.c
@@ -18,6 +18,7 @@
 
 #define WCH_RCC_CLOCK_ID_OFFSET(id) (((id) >> 5) & 0xFF)
 #define WCH_RCC_CLOCK_ID_BIT(id)    ((id) & 0x1F)
+#define WCH_RCC_PLLMUL_VAL(mul)     (((mul) << 0x12) & RCC_PLLMULL)
 #define WCH_RCC_SYSCLK              DT_PROP(DT_NODELABEL(cpu0), clock_frequency)
 
 #if DT_NODE_HAS_COMPAT(DT_INST_CLOCKS_CTLR(0), wch_ch32v00x_pll_clock) ||                          \
@@ -33,6 +34,8 @@
 #elif DT_NODE_HAS_COMPAT(DT_INST_CLOCKS_CTLR(0), wch_ch32v00x_hsi_clock)
 #define WCH_RCC_SRC_IS_HSI 1
 #endif
+
+static const uint8_t pllmul_lut[] = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18};
 
 struct clock_control_wch_rcc_config {
 	RCC_TypeDef *regs;
@@ -155,7 +158,16 @@ static int clock_control_wch_rcc_init(const struct device *dev)
 		} else if (IS_ENABLED(WCH_RCC_PLL_SRC_IS_HSI)) {
 			RCC->CFGR0 &= ~RCC_PLLSRC;
 		}
-		RCC->CFGR0 |= (config->mul == 18 ? 0xF : (config->mul - 2)) << 0x12;
+
+		uint8_t pllmul = 0x0; /* Default Reset Value */
+
+		for (size_t i = 0; i < ARRAY_SIZE(pllmul_lut); i++) {
+			if (pllmul_lut[i] == config->mul) {
+				pllmul = i;
+			}
+		}
+		RCC->CFGR0 &= ~RCC_PLLMULL;
+		RCC->CFGR0 |= WCH_RCC_PLLMUL_VAL(pllmul);
 		RCC->CTLR |= RCC_PLLON;
 		while ((RCC->CTLR & RCC_PLLRDY) == 0) {
 		}

--- a/drivers/clock_control/clock_control_wch_rcc.c
+++ b/drivers/clock_control/clock_control_wch_rcc.c
@@ -35,7 +35,14 @@
 #define WCH_RCC_SRC_IS_HSI 1
 #endif
 
+#if defined(CONFIG_SOC_CH32V307)
+/* TODO: Entry 13 is 6.5x (fractional multiple currently unsupported without
+ * changes to RCC config datatype)
+ */
+static const uint8_t pllmul_lut[] = {18, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 0, 15, 16};
+#else
 static const uint8_t pllmul_lut[] = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18};
+#endif
 
 struct clock_control_wch_rcc_config {
 	RCC_TypeDef *regs;

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -598,6 +598,7 @@ sandisk	Sandisk Corporation
 satoz	Satoz International Co., Ltd
 sbs	Smart Battery System
 sc	Space Cubics Inc.
+scdz	Shenzhen Qiushi IoT Technology Co., Ltd.
 schindler	Schindler
 sciosense	Sciosense B.V.
 seagate	Seagate Technology PLC

--- a/dts/riscv/wch/ch32v307/ch32v307.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307.dtsi
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2025 Thomas Boje
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <freq.h>
+#include <mem.h>
+#include <wch/qingke-v4f.dtsi>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/ch32v20x_30x-clocks.h>
+
+/ {
+	clocks {
+		clk_hse: clk-hse {
+			#clock-cells = <0>;
+			compatible = "wch,ch32v00x-hse-clock";
+			clock-frequency = <DT_FREQ_M(8)>;
+			status = "disabled";
+		};
+
+		clk_hsi: clk-hsi {
+			#clock-cells = <0>;
+			compatible = "wch,ch32v00x-hsi-clock";
+			clock-frequency = <DT_FREQ_M(8)>;
+			status = "disabled";
+		};
+
+		clk_lsi: clk-lsi {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_K(32)>;
+			status = "disabled";
+		};
+
+		pll: pll {
+			#clock-cells = <0>;
+			compatible = "wch,ch32v20x_30x-pll-clock";
+			mul = <18>;
+			status = "disabled";
+		};
+	};
+
+	soc {
+		sram0: memory@20000000 {
+			compatible = "mmio-sram";
+			reg = <0x20000000 DT_SIZE_K(32)>;
+		};
+
+		flash: flash-controller@40022000 {
+			compatible = "wch,ch32v20x_30x-flash-controller";
+			reg = <0x40022000 0x400>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@8000000 {
+				compatible = "soc-nv-flash";
+				reg = <0x08000000 DT_SIZE_K(480)>;
+			};
+		};
+
+		pwr: pwr@40007000 {
+			compatible = "wch,pwr";
+			reg = <0x40007000 16>;
+		};
+
+		pinctrl: pin-controller@40010000 {
+			compatible = "wch,20x_30x-afio";
+			reg = <0x40010000 16>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_AFIO>;
+
+			gpioa: gpio@40010800 {
+				compatible = "wch,gpio";
+				reg = <0x40010800 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPA>;
+			};
+
+			gpiob: gpio@40010C00 {
+				compatible = "wch,gpio";
+				reg = <0x40010C00 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPB>;
+			};
+
+			gpioc: gpio@40011000 {
+				compatible = "wch,gpio";
+				reg = <0x40011000 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPC>;
+			};
+
+			gpiod: gpio@40011400 {
+				compatible = "wch,gpio";
+				reg = <0x40011400 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPD>;
+			};
+
+			gpioe: gpio@40011800 {
+				compatible = "wch,gpio";
+				reg = <0x40011800 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPE>;
+			};
+		};
+
+		usart1: uart@40013800 {
+			compatible = "wch,usart";
+			reg = <0x40013800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <53>;
+			status = "disabled";
+		};
+
+		usart2: uart@40004400 {
+			compatible = "wch,usart";
+			reg = <0x40004400 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <54>;
+			status = "disabled";
+		};
+
+		usart3: uart@40004800 {
+			compatible = "wch,usart";
+			reg = <0x40004800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			interrupt-parent = <&pfic>;
+			interrupts = <55>;
+			status = "disabled";
+		};
+
+		usart4: uart@40004c00 {
+			compatible = "wch,usart";
+			reg = <0x40004C00 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			interrupt-parent = <&pfic>;
+			interrupts = <68>;
+			status = "disabled";
+		};
+
+		usart5: uart@40005000 {
+			compatible = "wch,usart";
+			reg = <0x40005000 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
+			interrupt-parent = <&pfic>;
+			interrupts = <69>;
+			status = "disabled";
+		};
+
+		usart6: uart@40001800 {
+			compatible = "wch,usart";
+			reg = <0x40001800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART6>;
+			interrupt-parent = <&pfic>;
+			interrupts = <87>;
+			status = "disabled";
+		};
+
+		usart7: uart@40001c00 {
+			compatible = "wch,usart";
+			reg = <0x40001c00 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART7>;
+			interrupt-parent = <&pfic>;
+			interrupts = <88>;
+			status = "disabled";
+		};
+
+		usart8: uart@40002000 {
+			compatible = "wch,usart";
+			reg = <0x40002000 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
+			interrupt-parent = <&pfic>;
+			interrupts = <89>;
+			status = "disabled";
+		};
+
+		rcc: rcc@40021000 {
+			compatible = "wch,rcc";
+			reg = <0x40021000 16>;
+			#clock-cells = <1>;
+			status = "okay";
+		};
+
+		dma1: dma@40020000 {
+			compatible = "wch,wch-dma";
+			reg = <0x40020000 0x90>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_DMA1>;
+			#dma-cells = <1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <27>, <28>, <29>, <30>, <31>, <32>, <33>;
+			dma-channels = <7>;
+		};
+
+		dma2: dma@40020400 {
+			compatible = "wch,wch-dma";
+			reg = <0x40020400 0x90>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_DMA2>;
+			#dma-cells = <1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <72>, <73>, <74>, <75>, <76>, <98>, <99>, <100>,
+						 <101>, <102>, <103>;
+			dma-channels = <11>;
+		};
+	};
+};
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_M(144)>;
+};

--- a/dts/riscv/wch/ch32v307/ch32v307rc.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307rc.dtsi
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Thomas Boje
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <wch/ch32v307/ch32v307.dtsi>
+
+&gpiod {
+	gpio-reserved-ranges = <3 13>;
+};
+
+&gpioe {
+	gpio-reserved-ranges = <0 16>;
+};

--- a/dts/riscv/wch/ch32v307/ch32v307vc.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307vc.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Thomas Boje
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <wch/ch32v307/ch32v307.dtsi>

--- a/dts/riscv/wch/ch32v307/ch32v307wc.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307wc.dtsi
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Thomas Boje
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <wch/ch32v307/ch32v307.dtsi>
+
+&gpiod {
+	gpio-reserved-ranges = <3 5>, <10 6>;
+};
+
+&gpioe {
+	gpio-reserved-ranges = <1 15>;
+};

--- a/modules/hal_wch/hal_ch32fun.h
+++ b/modules/hal_wch/hal_ch32fun.h
@@ -2,6 +2,10 @@
  * Copyright (c) 2024 Dhiru Kholia
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * NOTE: See this table for IC family reference,
+ * in conjunction with Page 5 of the reference manual:
+ * https://www.wch-ic.com/products/productsCenter/mcuInterface?categoryId=70
  */
 
 #ifndef _CH32FUN_H
@@ -10,33 +14,32 @@
 #if defined(CONFIG_SOC_CH32V003)
 #define CH32V003 1
 #include <ch32fun.h>
-#endif
+#endif /* defined(CONFIG_SOC_CH32V003) */
 
 #if defined(CONFIG_SOC_SERIES_CH32V00X)
 #define CH32V00x 1
 #include <ch32fun.h>
-#endif
+#endif /* defined(CONFIG_SOC_SERIES_CH32V00X) */
 
 #if defined(CONFIG_SOC_SERIES_QINGKE_V4B)
-#define CH32V20x 1
+#define CH32V20x    1
+#define CH32V20x_D6 1
 #include <ch32fun.h>
-#endif
+#endif /* defined(CONFIG_SOC_SERIES_QINGKE_V4B) */
 
 #if defined(CONFIG_SOC_SERIES_QINGKE_V4C)
+#define CH32V20x 1
 #if defined(CONFIG_SOC_CH32V208)
 #define CH32V20x_D8W 1
 #endif
-#define CH32V20x 1
 #include <ch32fun.h>
-#endif
+#endif /* defined(CONFIG_SOC_SERIES_QINGKE_V4C) */
 
 #if defined(CONFIG_SOC_SERIES_QINGKE_V4F)
 #define CH32V30x 1
 #if defined(CONFIG_SOC_CH32V303)
 #define CH32V30x_D8 1
-#endif
-
 #include <ch32fun.h>
-#endif
+#endif /* defined(CONFIG_SOC_SERIES_QINGKE_V4F) */
 
 #endif

--- a/modules/hal_wch/hal_ch32fun.h
+++ b/modules/hal_wch/hal_ch32fun.h
@@ -39,6 +39,9 @@
 #define CH32V30x 1
 #if defined(CONFIG_SOC_CH32V303)
 #define CH32V30x_D8 1
+#elif defined(CONFIG_SOC_CH32V307)
+#define CH32V30x_D8C 1
+#endif
 #include <ch32fun.h>
 #endif /* defined(CONFIG_SOC_SERIES_QINGKE_V4F) */
 

--- a/soc/wch/ch32v/qingke_v4f/Kconfig.defconfig.ch32v307
+++ b/soc/wch/ch32v/qingke_v4f/Kconfig.defconfig.ch32v307
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Thomas Boje
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_CH32V307
+
+config VECTOR_TABLE_SIZE
+	default 103
+
+config NUM_IRQS
+	default 128
+
+endif # SOC_CH32V307

--- a/soc/wch/ch32v/qingke_v4f/Kconfig.soc.ch32v307
+++ b/soc/wch/ch32v/qingke_v4f/Kconfig.soc.ch32v307
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Thomas Boje
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_CH32V307
+	bool
+	select SOC_SERIES_QINGKE_V4F
+
+config SOC
+	default "ch32v307" if SOC_CH32V307

--- a/soc/wch/ch32v/soc.yml
+++ b/soc/wch/ch32v/soc.yml
@@ -1,4 +1,5 @@
 # Copyright (c) 2024 Michael Hope
+# Copyright (c) 2025 Thomas Boje
 # SPDX-License-Identifier: Apache-2.0
 
 family:
@@ -19,3 +20,4 @@ family:
   - name: qingke-v4f
     socs:
     - name: ch32v303
+    - name: ch32v307


### PR DESCRIPTION
This PR is intended to complement PR [#93030](https://github.com/zephyrproject-rtos/zephyr/pull/93030).

The changes address issues around the incorrect clock being selected due to different register values being required for certain WCH chip variants.
<img width="689" height="502" alt="image" src="https://github.com/user-attachments/assets/1d4f60b8-2afb-4463-bfde-2bbdad86821b" />
<img width="742" height="579" alt="image" src="https://github.com/user-attachments/assets/801649a4-9573-4f76-a8a5-65038194fe64" />

The PR also fixes some macro initialisations for the `ch32fun` module by defining the relevant WCH package suffix.

I have only been able to test this on the `CH32V307` SOC, but the PLL settings have been checked for a SYSCLK of 128 MHz and 144 MHz. Both work as expected.
