### PR TITLE
ws2812_gpio: Fix prematurely overwrite of pixel input

### DIFF
--- a/drivers/led_strip/Kconfig.ws2812
+++ b/drivers/led_strip/Kconfig.ws2812
@@ -46,7 +46,6 @@ config WS2812_STRIP_GPIO
 	default y
 	depends on DT_HAS_WORLDSEMI_WS2812_GPIO_ENABLED
 	depends on (SOC_SERIES_NRF91X || SOC_SERIES_NRF51X || SOC_SERIES_NRF52X || SOC_SERIES_NRF53X)
-	select LED_STRIP_RGB_SCRATCH
 	help
 	  Enable driver for WS2812 (and compatibles) LED strip directly
 	  controlling with GPIO. The GPIO driver does bit-banging with inline

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -225,6 +225,10 @@ static const uint8_t ws2812_gpio_##idx##_color_mapping[] =		\
 		return gpio_pin_configure_dt(&cfg->gpio, GPIO_OUTPUT);	\
 	}								\
 									\
+	BUILD_ASSERT(WS2812_NUM_COLORS(idx) <= sizeof(struct led_rgb),  \
+		"Too many channels in color-mapping; "			\
+		"currently not supported by the ws2812_gpio driver");	\
+									\
 	WS2812_COLOR_MAPPING(idx);					\
 									\
 	static const struct ws2812_gpio_cfg ws2812_gpio_##idx##_cfg = { \

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -140,6 +140,7 @@ static int ws2812_gpio_update_rgb(const struct device *dev,
 	/* Convert from RGB to on-wire format (e.g. GRB, GRBW, RGB, etc) */
 	for (i = 0; i < num_pixels; i++) {
 		uint8_t j;
+		const struct led_rgb current_pixel = pixels[i];
 
 		for (j = 0; j < config->num_colors; j++) {
 			switch (config->color_mapping[j]) {
@@ -148,13 +149,13 @@ static int ws2812_gpio_update_rgb(const struct device *dev,
 				*ptr++ = 0;
 				break;
 			case LED_COLOR_ID_RED:
-				*ptr++ = pixels[i].r;
+				*ptr++ = current_pixel.r;
 				break;
 			case LED_COLOR_ID_GREEN:
-				*ptr++ = pixels[i].g;
+				*ptr++ = current_pixel.g;
 				break;
 			case LED_COLOR_ID_BLUE:
-				*ptr++ = pixels[i].b;
+				*ptr++ = current_pixel.b;
 				break;
 			default:
 				return -EINVAL;


### PR DESCRIPTION
This PR fixes too early overwriting of the input led buffer during iteration, and statically assures that no overflow happens.

While the API allows modification of the led input, the ws2812_gpio driver modified the input already due to the ptr alias, while it still reads in the next inner loop. This leads to reading already modified values, making the LED strip showing other colors than expected.

I also noticed that the code could technically overflow when there are more color mappings than the struct led. But as I am unsure if this is a realistic problem, I went for a BUILD_ASSERT so in case one has an LED strip, it does not break during runtime but earlier to fix if necessary, as a new buffer would need additional memory. 

Fixes #96099