### PR TITLE
samples: Bluetooth: BT_CUSTOM based broadcaster_lite sample

### DIFF
--- a/samples/bluetooth/broadcaster_lite/CMakeLists.txt
+++ b/samples/bluetooth/broadcaster_lite/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(broadcaster_lean)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/broadcaster_lite/Kconfig
+++ b/samples/bluetooth/broadcaster_lite/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config BT_BROADCASTER
+	default y
+
+config BT_LL_SW_SPLIT
+	default y
+
+source "Kconfig.zephyr"

--- a/samples/bluetooth/broadcaster_lite/prj.conf
+++ b/samples/bluetooth/broadcaster_lite/prj.conf
@@ -1,0 +1,6 @@
+CONFIG_BT=y
+CONFIG_BT_CUSTOM=y
+
+# Use link time optimization for code size reduction
+# CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+# CONFIG_LTO=y

--- a/samples/bluetooth/broadcaster_lite/src/main.c
+++ b/samples/bluetooth/broadcaster_lite/src/main.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2012-2014 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/bluetooth/hci.h>
+
+#include "../../../subsys/bluetooth/controller/include/ll.h"
+
+#define ADV_INTERVAL       0x0020
+#define ADV_OWN_ADDR_TYPE  BT_HCI_OWN_ADDR_RANDOM
+#define ADV_PEER_ADDR_TYPE BT_HCI_OWN_ADDR_RANDOM
+#define ADV_PEER_ADDR      NULL
+#define ADV_CHAN_MAP       0x07
+#define ADV_FILTER_POLICY  0x00
+
+static const uint8_t own_addr[] = {0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+
+static const uint8_t adv_data[] = {
+	2, BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR),
+	7, BT_DATA_NAME_COMPLETE, 'Z', 'e', 'p', 'h', 'y', 'r',
+};
+
+int main(void)
+{
+	struct k_sem sem_rx;
+	uint8_t ret;
+	int err;
+
+	printf("Initialize LL on %s...", CONFIG_BOARD_TARGET);
+	err = ll_init(&sem_rx);
+	if (err) {
+		goto exit;
+	}
+	printf("success.\n");
+
+	printf("Own address set...");
+	ret = ll_addr_set(ADV_OWN_ADDR_TYPE, own_addr);
+	if (ret) {
+		goto exit;
+	}
+	printf("success.\n");
+
+	printf("AD Data set...");
+	ret = ll_adv_data_set(sizeof(adv_data), adv_data);
+	if (ret) {
+		goto exit;
+	}
+	printf("success.\n");
+
+	printf("Non-connectable advertising, parameter set...");
+	ret = ll_adv_params_set(ADV_INTERVAL, BT_HCI_ADV_NONCONN_IND,
+				ADV_OWN_ADDR_TYPE, ADV_PEER_ADDR_TYPE, ADV_PEER_ADDR,
+				ADV_CHAN_MAP, ADV_FILTER_POLICY);
+	if (ret) {
+		goto exit;
+	}
+	printf("success.\n");
+
+	printf("Enabling...");
+	ret = ll_adv_enable(1);
+	if (ret) {
+		goto exit;
+	}
+	printf("success.\n");
+
+exit:
+	return 0;
+}

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -40,6 +40,8 @@ endchoice
 config SYSTEM_WORKQUEUE_PRIORITY
 	range -256 -1
 
+rsource "common/Kconfig"
+
 if BT_HCI
 
 config BT_HCI_RAW
@@ -405,9 +407,7 @@ config BT_ISO_MAX_BIG
 endif # BT_ISO_BROADCAST
 endif # BT_ISO
 
-rsource "common/Kconfig"
 rsource "host/Kconfig"
-rsource "controller/Kconfig"
 rsource "crypto/Kconfig"
 rsource "lib/Kconfig"
 rsource "Kconfig.logging"
@@ -435,5 +435,7 @@ config BT_COMPANY_ID
 	  controlled by BT_CTLR_COMPANY_ID. The full list of Bluetooth
 	  Company Identifiers can be found here:
 	  https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers
+
+rsource "controller/Kconfig"
 
 endif # BT

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -147,7 +147,7 @@ config BT_LL_SW_SPLIT
 
 config BT_CTLR_HCI
 	bool "Host Controller Interface (HCI)"
-	default y
+	default y if BT_HCI_HOST || BT_HCI_RAW
 	depends on HAS_BT_CTLR
 	help
 	  Enable the Host Controller interface (HCI) in the Controller.


### PR DESCRIPTION
BT_CUSTOM based light-weight Broadcaster sample.

```
west build -p -d build/broadcaster_lite -b nrf54l15dk/nrf54l15/cpuapp samples/bluetooth/broadcaster_lite
```
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       45440 B      1428 KB      3.11%
             RAM:        7160 B       188 KB      3.72%
        IDT_LIST:          0 GB        32 KB      0.00%
```
Console output:
```
*** Booting Zephyr OS build v4.2.0-3290-g6f4e1e9ca3dd ***
Initialize LL on nrf54l15dk/nrf54l15/cpuapp...success.
Own address set...success.
AD Data set...success.
Non-connectable advertising, parameter set...success.
Enabling...success.
```
compared to BT_HCI_HOST based:
```
west build -p -d build/broadcaster -b nrf54l15dk/nrf54l15/cpuapp samples/bluetooth/broadcaster
```
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       60328 B      1428 KB      4.13%
             RAM:       13544 B       188 KB      7.04%
        IDT_LIST:          0 GB        32 KB      0.00%
```