### PR TITLE
sca: add a Devicetree error diagnostics tool (DT Doctor)

### DIFF
--- a/cmake/sca/dtdoctor/sca.cmake
+++ b/cmake/sca/dtdoctor/sca.cmake
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+
+include(python)
+include(kconfig)
+
+if(NOT "${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "zephyr")
+  message(WARNING "dtdoctor has only been tested with the Zephyr SDK toolchain.")
+endif()
+
+set(dtdoctor_sca_wrapper_script ${ZEPHYR_BASE}/scripts/dts/dtdoctor_sca_wrapper.py)
+set(edt_pickle ${CMAKE_BINARY_DIR}/zephyr/edt.pickle)
+
+# Note that Kconfig settings should not be manipulated/overridden in CMake but until
+# https://github.com/zephyrproject-rtos/zephyr/issues/96199 is addressed the below has been
+# accepted since it shortens the typically long Devicetree errors that DT Doctor is helping make
+# sense of anyway.
+set(CONFIG_COMPILER_TRACK_MACRO_EXPANSION n)
+
+set(dtdoctor_wrapper_cmd
+  ${CMAKE_COMMAND} -E env
+  ${COMMON_KCONFIG_ENV_SETTINGS}
+  ${PYTHON_EXECUTABLE}
+  ${dtdoctor_sca_wrapper_script}
+  --edt-pickle ${edt_pickle}
+  --
+)
+
+set(CMAKE_C_COMPILER_LAUNCHER   ${dtdoctor_wrapper_cmd} CACHE INTERNAL "")
+set(CMAKE_CXX_COMPILER_LAUNCHER ${dtdoctor_wrapper_cmd} CACHE INTERNAL "")
+set(CMAKE_ASM_COMPILER_LAUNCHER ${dtdoctor_wrapper_cmd} CACHE INTERNAL "")
+
+set(CMAKE_C_LINKER_LAUNCHER   ${dtdoctor_wrapper_cmd} CACHE INTERNAL "")
+set(CMAKE_CXX_LINKER_LAUNCHER ${dtdoctor_wrapper_cmd} CACHE INTERNAL "")
+set(CMAKE_ASM_LINKER_LAUNCHER ${dtdoctor_wrapper_cmd} CACHE INTERNAL "")

--- a/doc/build/dts/troubleshooting.rst
+++ b/doc/build/dts/troubleshooting.rst
@@ -21,6 +21,15 @@ This is general advice which is especially applicable to debugging devicetree
 issues, because the outputs are created during the CMake configuration phase,
 and are not always regenerated when one of their inputs changes.
 
+Use Devicetree diagnostics tool (DT Doctor)
+*******************************************
+
+An optional Devicetree diagnostics tool is available to help diagnose Devicetree issues. It can
+be enabled by passing the ``-DZEPHYR_SCA_VARIANT=dtdoctor`` argument to
+:ref:`west build <west-building>`.
+
+See :ref:`dtdoctor` for more information.
+
 Make sure <devicetree.h> is included
 ************************************
 

--- a/doc/develop/sca/dtdoctor.rst
+++ b/doc/develop/sca/dtdoctor.rst
@@ -1,0 +1,21 @@
+.. _dtdoctor:
+
+Devicetree diagnostics (``dtdoctor``)
+#####################################
+
+``dtdoctor`` is a static analysis tool that helps diagnose Devicetree-related build errors.
+
+It intercepts error messages from the compiler and linker and, when they refer to unresolved
+Devicetree device symbols (e.g. ``__device_dts_ord_*``), provides detailed information about what
+might be causing the error and how to fix it.
+
+Using dtdoctor
+**************
+
+To enable ``dtdoctor``, build with ``-DZEPHYR_SCA_VARIANT=dtdoctor``.
+
+For example:
+
+.. code-block:: shell
+
+   west build -b reel_board samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=dtdoctor

--- a/doc/develop/sca/index.rst
+++ b/doc/develop/sca/index.rst
@@ -60,12 +60,6 @@ The following is a list of SCA tools natively supported by Zephyr build system.
 
 .. toctree::
    :maxdepth: 1
+   :glob:
 
-   codechecker
-   sparse
-   gcc
-   clang
-   cpptest
-   eclair
-   polyspace
-   coverity
+   *

--- a/scripts/dts/dtdoctor_analyzer.py
+++ b/scripts/dts/dtdoctor_analyzer.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+
+"""
+A script to help diagnose build errors related to Devicetree.
+
+To use this script as a standalone tool, provide the path to an edt.pickle file
+(e.g ./build/zephyr/edt.pickle) and a symbol that appeared in the build error
+message (e.g. __device_dts_ord_123).
+
+Example usage:
+
+./scripts/dts/dtdoctor_analyzer.py \\
+    --edt-pickle ./build/zephyr/edt.pickle \\
+    --symbol __device_dts_ord_123
+
+"""
+
+import argparse
+import os
+import pickle
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "python-devicetree" / "src"))
+sys.path.insert(0, str(Path(__file__).parents[1] / "kconfig"))
+
+import kconfiglib
+from devicetree import edtlib
+from tabulate import tabulate
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "--edt-pickle",
+        required=True,
+        help="path to edt.pickle file corresponding to the build to analyze",
+    )
+    parser.add_argument(
+        "--symbol", required=True, help="symbol for which to obtain troubleshooting information"
+    )
+    return parser.parse_args()
+
+
+def load_edt(path: str) -> edtlib.EDT:
+    with open(path, "rb") as f:
+        return pickle.load(f)
+
+
+def setup_kconfig() -> kconfiglib.Kconfig:
+    kconf = kconfiglib.Kconfig(os.path.join(os.environ.get("ZEPHYR_BASE"), "Kconfig"), warn=False)
+    return kconf
+
+
+def format_node(node: edtlib.Node) -> str:
+    return f"{node.labels[0]}: {node.path}" if node.labels else node.path
+
+
+def find_kconfig_deps(kconf: kconfiglib.Kconfig, dt_has_symbol: str) -> set[str]:
+    """
+    Find all Kconfig symbols that depend on the provided DT_HAS symbol.
+    """
+    prefix = os.environ.get("CONFIG_", "CONFIG_")
+    target = f"{prefix}{dt_has_symbol}"
+    deps = set()
+
+    def collect_syms(expr):
+        # Recursively collect all symbol names in the expression tree except the target
+        for item in kconfiglib.expr_items(expr):
+            if not isinstance(item, kconfiglib.Symbol):
+                continue
+            sym_name = f"{prefix}{item.name}"
+            if sym_name != target:
+                deps.add(sym_name)
+
+    for sym in getattr(kconf, "unique_defined_syms", []):
+        for node in sym.nodes:
+            # Check dependencies
+            if node.dep is None:
+                continue
+            dep_str = kconfiglib.expr_str(
+                node.dep,
+                lambda sc: f"{prefix}{sc.name}" if hasattr(sc, 'name') and sc.name else str(sc),
+            )
+            if target in dep_str:
+                collect_syms(node.dep)
+
+            # Check selects/implies
+            for attr in ["orig_selects", "orig_implies"]:
+                for value, _ in getattr(node, attr, []) or []:
+                    value_str = kconfiglib.expr_str(value, str)
+                    if target in value_str:
+                        collect_syms(value)
+
+    return deps
+
+
+def handle_enabled_node(node: edtlib.Node) -> list[str]:
+    """
+    Handle diagnosis for an enabled DT node (linker error, one or more Kconfigs might be gating
+    the device driver).
+    """
+    lines = [f"'{format_node(node)}' is enabled but no driver appears to be available for it.\n"]
+
+    compats = list(getattr(node, "compats", []))
+    if compats:
+        kconf = setup_kconfig()
+        deps = set()
+        for compat in compats:
+            dt_has = f"DT_HAS_{edtlib.str_as_token(compat.upper())}_ENABLED"
+            deps.update(find_kconfig_deps(kconf, dt_has))
+
+        if deps:
+            lines.append("Try enabling these Kconfig options:\n")
+            lines.extend(f" - {dep}=y" for dep in sorted(deps))
+    else:
+        lines.append("Could not determine compatible; check driver Kconfig manually.")
+
+    return lines
+
+
+def handle_disabled_node(node: edtlib.Node) -> list[str]:
+    """
+    Handle diagnosis for a disabled DT node.
+    """
+    edt = node.edt
+    status_prop = node._node.props.get('status')
+    lines = [f"'{format_node(node)}' is disabled in {status_prop.filename}:{status_prop.lineno}"]
+
+    # Show dependency
+    users = getattr(node, "required_by", [])
+    if users:
+        lines.append("The following nodes depend on it:")
+        lines.extend(f" - {u.path}" for u in users)
+
+    # Show chosen/alias references
+    chosen_refs = [
+        name
+        for name, n in (getattr(edt, "chosen_nodes", {}) or getattr(edt, "chosen", {})).items()
+        if n is node
+    ]
+    alias_refs = [name for name, n in getattr(edt, "aliases", {}).items() if n is node]
+
+    if chosen_refs or alias_refs:
+        lines.append("")
+
+    if chosen_refs:
+        lines.append(
+            "It is referenced as a \"chosen\" in "
+            f"""{', '.join([f"'{ref}'" for ref in sorted(chosen_refs)])}"""
+        )
+    if alias_refs:
+        lines.append(
+            "It is referenced by the following aliases: "
+            f"""{', '.join([f"'{ref}'" for ref in sorted(alias_refs)])}"""
+        )
+
+    lines.append("\nTry enabling the node by setting its 'status' property to 'okay'.")
+
+    return lines
+
+
+def main() -> int:
+    args = parse_args()
+
+    m = re.search(r"__device_dts_ord_(\d+)", args.symbol)
+    if not m:
+        return 1
+
+    # Find node by ordinal amongst all nodes
+    edt = load_edt(args.edt_pickle)
+    node = next((n for n in edt.nodes if n.dep_ordinal == int(m.group(1))), None)
+    if not node:
+        print(f"Ordinal {m.group(1)} not found in edt.pickle", file=sys.stderr)
+        return 1
+
+    if node.status == "okay":
+        lines = handle_enabled_node(node)
+    else:
+        lines = handle_disabled_node(node)
+
+    print(tabulate([["\n".join(lines)]], headers=["DT Doctor"], tablefmt="grid"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dts/dtdoctor_sca_wrapper.py
+++ b/scripts/dts/dtdoctor_sca_wrapper.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+
+"""
+Compiler launcher wrapper that captures what appears to be Devicetree-related build errors, and
+diagnoses them using diagnose_build_error.py.
+
+The tool is meant to be configured as a CMAKE_<LANG>_COMPILER_LAUNCHER or as a
+CMAKE_<LANG>_LINKER_LAUNCHER.
+
+Example usage:
+
+  ./scripts/dts/dtdoctor_sca_wrapper.py --edt-pickle <path> \\
+    -- <compiler-or-linker> <args...>
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "--edt-pickle", help="path to edt.pickle file corresponding to the build to analyze"
+    )
+
+    if "--" in sys.argv:
+        idx = sys.argv.index("--")
+        args, cmd = parser.parse_known_args(sys.argv[1:idx])[0], sys.argv[idx + 1 :]
+    else:
+        args, cmd = parser.parse_known_args(sys.argv[1:])[0], sys.argv[1:]
+
+    # Run compiler/linker command
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    sys.stdout.write(proc.stdout)
+    sys.stderr.write(proc.stderr)
+
+    # Extract __device_dts_ord_xxx symbols from errors and run diagnostics
+    if proc.returncode != 0 and args.edt_pickle:
+        patterns = [
+            r"(__device_dts_ord_\d+).*undeclared here",  # gcc
+            r"undefined reference to.*(__device_dts_ord_\d+)",  # ld
+            r"use of undeclared identifier '(__device_dts_ord_\d+)'",  # LLVM/clang (ATfE)
+            r"undefined symbol: \(__device_dts_ord_(\d+)",  # LLVM/lld (ATfE)
+        ]
+        symbols = {m for p in patterns for m in re.findall(p, proc.stderr)}
+
+        diag_script = os.path.join(os.path.dirname(__file__), "dtdoctor_analyzer.py")
+        for symbol in sorted(symbols):
+            subprocess.run(
+                [
+                    sys.executable,
+                    diag_script,
+                    "--edt-pickle",
+                    args.edt_pickle,
+                    "--symbol",
+                    symbol,
+                ]
+            )
+
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
It is no secret that Devicetree errors can be intimidating and confusing to folks diving into Zephyr for the first time. Even seasoned developers probably spend way more time than necessary tracking the root cause of DT errors (did I forget to enable a node somewhere? did I forget to enable a subsystem?).

This PR implements a solution to look at compilation errors and provide actionable diagnostic information to help developers quickly resolve devicetree-related build failures.

Note: It is implemented as an SCA for now but it might not be a bad idea to bake into the build system so that it's always available (haven't really looked at the overhead but it should be minimal... I think?)

The code still need some clean-up, but eh, if you're seeing this draft PR, you may still want to give it a try :)

https://builds.zephyrproject.io/zephyr/pr/95824/docs/develop/sca/dtdoctor.html

This spots the following classes of errors at the moment:

## A devicetree node is `disabled` but should be `okay`

```console
# forcefully disable an important Kconfig to show the tool in action 

$ west build -b wio_terminal samples/subsys/display/cfb -p auto -- -DZEPHYR_SCA_VARIANT=dtdoctor -DCONFIG_DISPLAY=n

[...]

/Users/kartben/zephyr-sdk-0.17.2/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: app/libapp.a(main.c.obj): in function `main':
/Users/kartben/zephyrproject/zephyr/samples/subsys/display/cfb/src/main.c:81: undefined reference to `__device_dts_ord_37'
collect2: error: ld returned 1 exit status
+-----------------------------------------------------------------------------------------+
| DT Doctor                                                                               |
+=========================================================================================+
| 'ili9341: /mipi_dbi/ili9341@0' is enabled but no driver appears to be available for it. |
|                                                                                         |
| Try enabling these Kconfig options:                                                     |
|                                                                                         |
|  - CONFIG_DISPLAY=y                                                                     |
+-----------------------------------------------------------------------------------------+
ninja: build stopped: subcommand failed.

$
```

## A devicetree node is properly enabled but no device driver seems available -- suggest Kconfig option(s) that might need to be enabled for the driver to kick in

This spots the linker error, and then outputs the below:

```console
# Manually disabled `porta` for wio_terminal, then ran:

$ west build -b wio_terminal samples/basic/blinky -p auto -- -DZEPHYR_SCA_VARIANT=dtdoctor

[ ... ]

/Users/kartben/zephyrproject/zephyr/samples/basic/blinky/src/main.c:21:40: error: '__device_dts_ord_12' undeclared here (not in a function); did you mean '__device_dts_ord_13'?
   21 | static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
      |                                        ^~~~~~~~~~~~~~~~
      |                                        __device_dts_ord_13
+-------------------------------------------------------------------------------------------------------------------------------+
| DT Doctor                                                                                                                     |
+===============================================================================================================================+
| 'porta: /soc/pinctrl@41008000/gpio@41008000' is disabled in /Users/kartben/zephyrproject/zephyr/dts/arm/atmel/samd5x.dtsi:273 |
| The following nodes depend on it:                                                                                             |
|  - /leds                                                                                                                      |
|  - /usb_power_5v_en                                                                                                           |
|  - /leds/led_0                                                                                                                |
|                                                                                                                               |
| Try enabling the node by setting its 'status' property to 'okay'.                                                             |
+-------------------------------------------------------------------------------------------------------------------------------+
[43/157] Building C object zephyr/arch/arch/arm/core/CMakeFiles/arch__arm__core.dir/fatal.c.obj
ninja: build stopped: subcommand failed.



# Manually disabled `uart0` for the reel_board, then ran:

$ west build -b reel_board samples/hello_world -p auto -- -DZEPHYR_SCA_VARIANT=dtdoctor

[...]

/Users/kartben/zephyrproject/zephyr/drivers/console/uart_console.c:42:9: error: '__device_dts_ord_101' undeclared here (not in a function); did you mean '__device_dts_ord_10'?
   42 |         DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
      |         ^~~~~~~~~~~~~
      |         __device_dts_ord_10
+-------------------------------------------------------------------------------------------------------------------------------------------+
| DT Doctor                                                                                                                                 |
+===========================================================================================================================================+
| 'uart0: /soc/uart@40002000' is disabled in /Users/kartben/zephyrproject/zephyr/boards/phytec/reel_board/dts/reel_board.dtsi:123           |
|                                                                                                                                           |
| It is referenced as a "chosen" in 'zephyr,bt-c2h-uart', 'zephyr,bt-mon-uart', 'zephyr,console', 'zephyr,shell-uart', 'zephyr,uart-mcumgr' |
|                                                                                                                                           |
| Try enabling the node by setting its 'status' property to 'okay'.                                                                         |
+-------------------------------------------------------------------------------------------------------------------------------------------+
[100/155] Building C object zephyr/drivers/serial/CMakeFiles/drivers__serial.dir/uart_nrfx_uarte.c.obj
ninja: build stopped: subcommand failed.

$

``` 

### TODO 
- diagnose errors involving some of the more complex macros that gen_defines spits out (e.g. `__device_dts_ord_DT_N_NODELABEL_storage_partition_PARENT_PARENT_ORD`) 
- check whether the reverse-lookup logic (i.e. find which DT node is the main "topic" of a given error line containing a `.. . __device_dts_ord_xxxx ...` mention) could be done in a smarter way, maybe by means of having gen_defines.py dump some kind of database of all the macros it's generated and what node(s?) they concern.