### PR TITLE
intel_adsp: various test configuration changes for simulator runs

### DIFF
--- a/tests/benchmarks/latency_measure/boards/intel_adsp_ace40_nvl_sim.conf
+++ b/tests/benchmarks/latency_measure/boards/intel_adsp_ace40_nvl_sim.conf
@@ -1,0 +1,6 @@
+# Due to addition of busy threads running on other cores,
+# and the simulator runs in single thread bouncing through
+# all cores, we are wasting quite a bit of time just busy
+# waiting. This makes each simulator run too long for CI.
+# So limit CPU number to 1.
+CONFIG_MP_MAX_NUM_CPUS=1

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -15,6 +15,9 @@
 
 #if defined(CONFIG_BOARD_FVP_BASE_REVC_2XAEMV8A)
 #define SLEEP_MS_LONG	30000
+#elif defined(CONFIG_BOARD_INTEL_ADSP_ACE30_PTL_SIM) ||                                            \
+	defined(CONFIG_BOARD_INTEL_ADSP_ACE40_NVL_SIM)
+#define SLEEP_MS_LONG	300
 #else
 #define SLEEP_MS_LONG	15000
 #endif

--- a/tests/kernel/smp/boards/intel_adsp_ace15_mtpm_sim.conf
+++ b/tests/kernel/smp/boards/intel_adsp_ace15_mtpm_sim.conf
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SMP_TEST_RUN_FACTOR=0

--- a/tests/kernel/smp/boards/intel_adsp_ace20_lnl_sim.conf
+++ b/tests/kernel/smp/boards/intel_adsp_ace20_lnl_sim.conf
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SMP_TEST_RUN_FACTOR=0

--- a/tests/kernel/smp/boards/intel_adsp_ace30_ptl_sim.conf
+++ b/tests/kernel/smp/boards/intel_adsp_ace30_ptl_sim.conf
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SMP_TEST_RUN_FACTOR=0

--- a/tests/kernel/smp/boards/intel_adsp_ace40_nvl_sim.conf
+++ b/tests/kernel/smp/boards/intel_adsp_ace40_nvl_sim.conf
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SMP_TEST_RUN_FACTOR=0


### PR DESCRIPTION
There are various config changes to run these tests on simulator in a reasonable time without timing out. Most of the issue is simply due to the simulator running as a single thread. So under SMP, each simulated CPU runs sequentially. This results in those tests timing out.