### PR TITLE
dts: arm: st: stm32h7rs: remove flash controller clock property

### DIFF
--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -180,7 +180,6 @@
 			compatible = "st,stm32-flash-controller", "st,stm32h7-flash-controller";
 			reg = <0x52002000 0x400>;
 			interrupts = <8 0>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 8)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;


### PR DESCRIPTION
Bit 8 of AHB3 is reserved, there is no clock-enable bit for the flash controller according to the [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0477-stm32h7rx7sx-armbased-32bit-mcus-stmicroelectronics.pdf#page=500).

<img width="728" height="281" alt="image" src="https://github.com/user-attachments/assets/8b8a8e5c-2c34-4db4-892a-c72349af8095" />

> Considering [this](https://github.com/zephyrproject-rtos/zephyr/blob/7d84a3b639526374eee405a06c773b572b74c913/drivers/flash/flash_stm32h7x.c#L932-L947) and [this](https://github.com/zephyrproject-rtos/zephyr/blob/7d84a3b639526374eee405a06c773b572b74c913/dts/arm/st/h7/stm32h7_dualcore.dtsi#L29-L31), I would say this is a copy-paste error. (@mathieuchopstm)
