### PR TITLE
drivers: intc: gicv3: add ARM AArch32 affinity comparison

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -673,6 +673,11 @@ static bool arm_gic_aff_matching(uint64_t gicr_aff, uint64_t aff)
 	uint64_t mask = BIT64_MASK(8);
 
 	return (gicr_aff & mask) == (aff & mask);
+#elif defined(CONFIG_ARM)
+	uint64_t mask = BIT64_MASK(24);
+
+	/* For ARM (AArch32), only compare aff2:aff1:aff0 (lower 24 bits) */
+	return (gicr_aff & mask) == (aff & mask);
 #else
 	return gicr_aff == aff;
 #endif


### PR DESCRIPTION
This commit introduces a comparison for the ARM (AArch32) architecture in the GICv3 interrupt controller.
It specifically compares the lower 24 bits of the affinity values, because there is no aff3 in AArch32 or Arm-v7.