### PR TITLE
arch: common: nocache.ld: One nocache MPU region

### DIFF
--- a/arch/common/nocache.ld
+++ b/arch/common/nocache.ld
@@ -14,7 +14,7 @@ SECTION_DATA_PROLOGUE(_NOCACHE_SECTION_NAME,(NOLOAD),)
 #if defined(CONFIG_MMU)
 	MMU_ALIGN;
 #else
-	MPU_ALIGN(_nocache_noload_ram_size);
+	MPU_ALIGN(_nocache_ram_size);
 #endif
 	_nocache_ram_start = .;
 	_nocache_noload_ram_start = .;
@@ -23,11 +23,6 @@ SECTION_DATA_PROLOGUE(_NOCACHE_SECTION_NAME,(NOLOAD),)
 
 #include <snippets-nocache-section.ld>
 
-#if defined(CONFIG_MMU)
-	MMU_ALIGN;
-#else
-	MPU_ALIGN(_nocache_noload_ram_size);
-#endif
 	_nocache_noload_ram_end = .;
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 _nocache_noload_ram_size = _nocache_noload_ram_end - _nocache_noload_ram_start;
@@ -35,11 +30,6 @@ _nocache_noload_ram_size = _nocache_noload_ram_end - _nocache_noload_ram_start;
 /* Non-cached loadable region of RAM and ROM */
 SECTION_DATA_PROLOGUE(_NOCACHE_LOAD_SECTION_NAME,,)
 {
-#if defined(CONFIG_MMU)
-	MMU_ALIGN;
-#else
-	MPU_ALIGN(_nocache_load_ram_size);
-#endif
 	_nocache_load_ram_start = .;
 	*(.nocache_load)
 	*(".nocache_load.*")
@@ -47,7 +37,7 @@ SECTION_DATA_PROLOGUE(_NOCACHE_LOAD_SECTION_NAME,,)
 #if defined(CONFIG_MMU)
 	MMU_ALIGN;
 #else
-	MPU_ALIGN(_nocache_load_ram_size);
+	MPU_ALIGN(_nocache_ram_size);
 #endif
 	_nocache_load_ram_end = .;
 	_nocache_ram_end = .;


### PR DESCRIPTION
Combine the load and noload cache regions for a single MPU aligned block. This is required to have an MPU region with a size that is a power of 2.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/95530
Alternative to https://github.com/zephyrproject-rtos/zephyr/pull/95533