### PR TITLE
doc: project_roles: Fix table of permissions wrt admin rights

### DIFF
--- a/doc/project/project_roles.rst
+++ b/doc/project/project_roles.rst
@@ -292,7 +292,7 @@ Roles / Permissions
     Supportive Roles QA/Validation                                      x                        x
         ..           DevOps                   **x**
         ..           System Admin             **x**                                      x
-        ..           Release Engineering      **x**      **x**          x
+        ..           Release Engineering                 **x**          x
 
     ================ =================== =========== ================ =========== =========== ============
 


### PR DESCRIPTION
Release engineers do not need and do not have admin rights. Let's just fix this table removing that cross.