### PR TITLE
Bluetooth: Mesh: Decouple blob_io_flash from flash

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1065,6 +1065,17 @@ config BT_MESH_BLOB_IO_FLASH_WITH_ERASE
 	  and may be disabled to reduce code size in case when no operations
 	  are intended on such type of devices.
 
+if BT_MESH_BLOB_IO_FLASH_WITH_ERASE
+
+config BT_MESH_BLOB_IO_FLASH_WRITE_BLOCK_SIZE_MAX
+	int "Maximum supported write block size"
+	default 4
+	help
+	  The BLOB IO Flash module will support flash devices with explicit erase
+	  using a write block size of at most this value.
+
+endif # BT_MESH_BLOB_IO_FLASH_WITH_ERASE
+
 endif # BT_MESH_BLOB_IO_FLASH
 
 config BT_MESH_DFU_SRV

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1038,6 +1038,7 @@ config BT_MESH_BLOB_IO_FLASH
 	default y
 	depends on BT_MESH_BLOB_SRV || BT_MESH_BLOB_CLI
 	depends on FLASH_MAP
+	depends on FLASH_PAGE_LAYOUT
 	help
 	  Enable the BLOB flash stream for reading and writing BLOBs directly to
 	  and from flash.
@@ -1045,36 +1046,28 @@ config BT_MESH_BLOB_IO_FLASH
 if BT_MESH_BLOB_IO_FLASH
 
 config BT_MESH_BLOB_IO_FLASH_WITHOUT_ERASE
-	bool "BLOB flash support for devices without erase"
-	default y if FLASH_HAS_NO_EXPLICIT_ERASE
+	bool "BLOB flash support for devices without erase [DEPRECATED]"
+	default n
 	depends on FLASH_HAS_NO_EXPLICIT_ERASE
+	select DEPRECATED
 	help
-	  Enable path supporting devices without erase. This option appears only
-	  if there are devices without explicit erase requirements in the system
-	  and may be disabled to reduce code size in case when no operations
-	  are intended on such type of devices.
+	  This option is deprecated and is no longer used by the BLOB IO Flash module.
 
 config BT_MESH_BLOB_IO_FLASH_WITH_ERASE
-	bool "BLOB flash support for devices with erase"
-	default y if FLASH_HAS_EXPLICIT_ERASE
+	bool "BLOB flash support for devices with erase [DEPRECATED]"
+	default n
 	depends on FLASH_HAS_EXPLICIT_ERASE
 	depends on FLASH_PAGE_LAYOUT
+	select DEPRECATED
 	help
-	  Enable path supporting devices with erase. This option appears only
-	  if there are devices requiring erase,  before write, in the system
-	  and may be disabled to reduce code size in case when no operations
-	  are intended on such type of devices.
-
-if BT_MESH_BLOB_IO_FLASH_WITH_ERASE
+	  This option is deprecated and is no longer used by the BLOB IO Flash module.
 
 config BT_MESH_BLOB_IO_FLASH_WRITE_BLOCK_SIZE_MAX
 	int "Maximum supported write block size"
 	default 4
 	help
 	  The BLOB IO Flash module will support flash devices with explicit erase
-	  using a write block size of at most this value.
-
-endif # BT_MESH_BLOB_IO_FLASH_WITH_ERASE
+	  when this value is set to a multiple of the device write block size.
 
 endif # BT_MESH_BLOB_IO_FLASH
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1058,6 +1058,7 @@ config BT_MESH_BLOB_IO_FLASH_WITH_ERASE
 	bool "BLOB flash support for devices with erase"
 	default y if FLASH_HAS_EXPLICIT_ERASE
 	depends on FLASH_HAS_EXPLICIT_ERASE
+	depends on FLASH_PAGE_LAYOUT
 	help
 	  Enable path supporting devices with erase. This option appears only
 	  if there are devices requiring erase,  before write, in the system

--- a/subsys/bluetooth/mesh/blob_io_flash.c
+++ b/subsys/bluetooth/mesh/blob_io_flash.c
@@ -12,13 +12,17 @@
 #include "net.h"
 #include "transport.h"
 
-#define WRITE_BLOCK_SIZE DT_PROP(DT_INST(0, soc_nv_flash), write_block_size)
+#define LOG_LEVEL CONFIG_BT_MESH_MODEL_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(bt_mesh_blob_io_flash);
 
 #define FLASH_IO(_io) CONTAINER_OF(_io, struct bt_mesh_blob_io_flash, io)
 
 static int test_flash_area(uint8_t area_id)
 {
+	const struct flash_parameters *fparam;
 	const struct flash_area *area;
+	const struct device *fdev;
 	uint8_t align;
 	int err;
 
@@ -28,9 +32,19 @@ static int test_flash_area(uint8_t area_id)
 	}
 
 	align = flash_area_align(area);
+	fdev = flash_area_get_device(area);
+	fparam = flash_get_parameters(fdev);
+
 	flash_area_close(area);
 
-	if (align > WRITE_BLOCK_SIZE) {
+	if (!fdev) {
+		return -ENODEV;
+	}
+
+	if ((flash_params_get_erase_cap(fparam) & FLASH_ERASE_C_EXPLICIT) &&
+	    CONFIG_BT_MESH_BLOB_IO_FLASH_WRITE_BLOCK_SIZE_MAX % align) {
+		LOG_ERR("CONFIG_BT_MESH_BLOB_IO_FLASH_WRITE_BLOCK_SIZE_MAX must be set to a\n"
+			"multiple of the write block size for the flash deviced used.");
 		return -EINVAL;
 	}
 
@@ -126,30 +140,49 @@ static int wr_chunk(const struct bt_mesh_blob_io *io,
 		    const struct bt_mesh_blob_chunk *chunk)
 {
 	struct bt_mesh_blob_io_flash *flash = FLASH_IO(io);
+	const struct device *fdev = flash_area_get_device(flash->area);
 
-	if (IS_ENABLED(CONFIG_SOC_FLASH_NRF_RRAM)) {
+	if (!fdev) {
+		return -ENODEV;
+	}
+
+	const struct flash_parameters *fparam = flash_get_parameters(fdev);
+
+	/*
+	 * If device has no erase requirement then write directly.
+	 * This is required since trick with padding using the erase value will
+	 * not work in this case.
+	 */
+	if (!(flash_params_get_erase_cap(fparam) & FLASH_ERASE_C_EXPLICIT)) {
 		return flash_area_write(flash->area,
 					flash->offset + block->offset + chunk->offset,
 					chunk->data, chunk->size);
 	}
 
-	uint8_t buf[ROUND_UP(BLOB_RX_CHUNK_SIZE, WRITE_BLOCK_SIZE)];
+	/*
+	 * Allocate one additional write block for the case where a chunk will need
+	 * an extra write block on both sides to fit.
+	 */
+	uint8_t buf[ROUND_UP(BLOB_RX_CHUNK_SIZE, CONFIG_BT_MESH_BLOB_IO_FLASH_WRITE_BLOCK_SIZE_MAX)
+		    + CONFIG_BT_MESH_BLOB_IO_FLASH_WRITE_BLOCK_SIZE_MAX];
+	uint32_t write_block_size = flash_area_align(flash->area);
 	off_t area_offset = flash->offset + block->offset + chunk->offset;
-	int i = 0;
+	int start_pad = area_offset % write_block_size;
 
-	/* Write block align the chunk data */
-	memset(&buf[i], 0xff, area_offset % WRITE_BLOCK_SIZE);
-	i += area_offset % WRITE_BLOCK_SIZE;
+	/*
+	 * Fill buffer with erase value, to make sure only the part of the
+	 * buffer with chunk data will overwrite flash.
+	 * (Because chunks can arrive in random order, this is required unless
+	 *  the entire block is cached in RAM).
+	 */
+	memset(buf, fparam->erase_value, sizeof(buf));
 
-	memcpy(&buf[i], chunk->data, chunk->size);
-	i += chunk->size;
-
-	memset(&buf[i], 0xff, ROUND_UP(i, WRITE_BLOCK_SIZE) - i);
-	i = ROUND_UP(i, WRITE_BLOCK_SIZE);
+	memcpy(&buf[start_pad], chunk->data, chunk->size);
 
 	return flash_area_write(flash->area,
-				ROUND_DOWN(area_offset, WRITE_BLOCK_SIZE),
-				buf, i);
+				ROUND_DOWN(area_offset, write_block_size),
+				buf,
+				ROUND_UP(start_pad + chunk->size, write_block_size));
 }
 
 int bt_mesh_blob_io_flash_init(struct bt_mesh_blob_io_flash *flash,

--- a/subsys/bluetooth/mesh/blob_io_flash.c
+++ b/subsys/bluetooth/mesh/blob_io_flash.c
@@ -70,8 +70,6 @@ static void io_close(const struct bt_mesh_blob_io *io,
 	flash_area_close(flash->area);
 }
 
-/* Erasure code not needed if no flash in the system requires explicit erase */
-#ifdef CONFIG_BT_MESH_BLOB_IO_FLASH_WITH_ERASE
 static inline int erase_device_block(const struct flash_area *fa, off_t start, size_t size)
 {
 	const struct device *fdev = flash_area_get_device(fa);
@@ -82,15 +80,12 @@ static inline int erase_device_block(const struct flash_area *fa, off_t start, s
 		return -ENODEV;
 	}
 
-#ifdef CONFIG_BT_MESH_BLOB_IO_FLASH_WITHOUT_ERASE
-	/* We have a mix of devices in system */
 	const struct flash_parameters *fparam = flash_get_parameters(fdev);
 
 	/* If device has no erase requirement then do nothing */
 	if (!(flash_params_get_erase_cap(fparam) & FLASH_ERASE_C_EXPLICIT)) {
 		return 0;
 	}
-#endif /* CONFIG_BT_MESH_BLOB_IO_FLASH_WITHOUT_ERASE */
 
 	err = flash_get_page_info_by_offs(fdev, start, &page);
 	if (err) {
@@ -120,7 +115,6 @@ static int block_start(const struct bt_mesh_blob_io *io,
 
 	return erase_device_block(flash->area, flash->offset + block->offset, block->size);
 }
-#endif /* CONFIG_BT_MESH_BLOB_IO_FLASH_WITH_ERASE */
 
 static int rd_chunk(const struct bt_mesh_blob_io *io,
 		    const struct bt_mesh_blob_xfer *xfer,
@@ -199,11 +193,7 @@ int bt_mesh_blob_io_flash_init(struct bt_mesh_blob_io_flash *flash,
 	flash->offset = offset;
 	flash->io.open = io_open;
 	flash->io.close = io_close;
-#ifdef CONFIG_BT_MESH_BLOB_IO_FLASH_WITH_ERASE
 	flash->io.block_start = block_start;
-#else
-	flash->io.block_start = NULL;
-#endif
 	flash->io.block_end = NULL;
 	flash->io.rd = rd_chunk;
 	flash->io.wr = wr_chunk;

--- a/subsys/bluetooth/mesh/blob_io_flash.c
+++ b/subsys/bluetooth/mesh/blob_io_flash.c
@@ -83,9 +83,13 @@ static inline int erase_device_block(const struct flash_area *fa, off_t start, s
 		return err;
 	}
 
+	if (start != page.start_offset) {
+		/* Only need to erase when starting the first block on the page. */
+		return 0;
+	}
+
 	/* Align to page boundary. */
 	size = page.size * DIV_ROUND_UP(size, page.size);
-	start = page.start_offset;
 
 	return flash_area_erase(fa, start, size);
 }


### PR DESCRIPTION
This fully decouples blob_io_flash from flash configuration details, by removing remaining direct references to CONFIG_FLASH_* options and hard-coded write block size, instead pulling this from the actual flash device used.

It also requires the use of FLASH_PAGE_LAYOUT APIs when enabling the module for use with flash with explicit erase. This was already a silent requirement, since the existing code does not work for such use cases except for the case when a BLOB has a size which is a multiple of the page size (since, without it, trying to erase flash space for the final block, which is of variable size, will fail).

Additionally, the erasure logic has been changed slightly to only erase a page when starting the first block on that page. This fixes a bug where, if the block size is smaller than the page size, the entire page would be erased upon start of each block when writing, meaning only the final block on each page would be retained. This works because blocks are always received in order.

(Note: we might need to add some code to ensure that the area and offset passed to the init function lies on a page boundary. I suggest to defer that to a separate PR, as it is an existing problem already and not introduced by my changes)

The block write routine has been updated to be more generic and fix a few bugs:

  * The write buffer is now sized based on a KConfig option instead of basing it off the device tree - this makes the module usable with any flash device, not just the internal memory. The configured value is checked during initialization, to ensure that the configured size will fit the write block size required by the device passed to the init function.
  * The erase value used to fill the buffer when using a device with explicit erase is now pulled from the flash parameters instead of being hard-coded to `0xff`.
  * An additional write block sized piece of buffer is allocated - the previous buffer sizing with rounding up only worked if `BLOB_RX_CHUNK_SIZE % WRITE_BLOCK_SIZE` was 0 or 1 (which coincidentally worked in all testing because the chunk size defaults to 161, and for internal flash w/write block size of 4, `161 % 4 == 1`).
  * The choice of whether to just write the chunk as-is or to write-block align it is now based on the erase cap pulled from the flash parameters, instead of checking the type of memory in the SOC. This means the module dos _not_ currently support the case where memory has to be written write-block aligned, but the memory does _not_ use explicit erase. It uses a trick of filling the write buffer with the erase value to avoid overwriting existing chunks, which will not work in this case. This trick is required to support random ordered chunks while still writing write-block aligned.
  * The code has been cleaned up a bit in general.