### PR TITLE
doc: contributor: Add paragraph about reaching common understanding

### DIFF
--- a/doc/contribute/contributor_expectations.rst
+++ b/doc/contribute/contributor_expectations.rst
@@ -269,6 +269,15 @@ defines the following escalation process for resolving technical disagreements.
 
 Before escalation of technical disagreements, follow the steps below:
 
+- First, and most importantly, the contributor and person providing feedback should try to reach a
+  common understanding.
+
+  - Remember that written communication, especially in public forums, can be easily misunderstood.
+  - Consider contacting one another directly on Discord. A direct chat, or even better a one on one
+    call usually helps clarify the feedback and any constraints or considerations around the issue.
+  - Be kind to one another, and remember that, workload, time differences, and other circumstances
+    are likely complicating communication.
+
 - Resolve in the PR among assignee, maintainers and reviewer.
 
   - Assignee to act as moderator if applicable.


### PR DESCRIPTION
Add a paragraph before any other step of the escalation path about trying to reach a common understanding between the contributor and the person providing feedback.
Many issues could be avoided with this.

Note this PR purposefully does not change anything in the next steps.
This PR is meant as a incremental improvement, trying to not get bogged down in fixing at the same time the issue around not having dev_reviews anymore, and the discussions that would go around how we fix that.