### PR TITLE
SCMI add power on off states in power protocol

### DIFF
--- a/include/zephyr/drivers/firmware/scmi/power.h
+++ b/include/zephyr/drivers/firmware/scmi/power.h
@@ -17,6 +17,42 @@
 #define SCMI_POWER_STATE_SET_FLAGS_ASYNC BIT(0)
 
 /**
+ * @name SCMI power domain state parameters
+ * @{
+ */
+
+/** Power state type field bit shift */
+#define SCMI_POWER_STATE_TYPE_SHIFT	30U
+
+/** Power state ID field mask */
+#define SCMI_POWER_STATE_ID_MASK	(BIT(28) - 1)
+
+/**
+ * @brief Construct SCMI power state parameter
+ *
+ * @param type Power state type
+ * @param id   Power state ID
+ */
+#define SCMI_POWER_STATE_PARAM(type, id) \
+	((((type) & BIT(0)) << SCMI_POWER_STATE_TYPE_SHIFT) | \
+	 ((id) & SCMI_POWER_STATE_ID_MASK))
+
+/** @} */
+
+/**
+ * @name SCMI power domain generic states
+ * @{
+ */
+
+/** Power domain is in ON state */
+#define SCMI_POWER_STATE_GENERIC_ON	SCMI_POWER_STATE_PARAM(0, 0)
+
+/** Power domain is in OFF state */
+#define SCMI_POWER_STATE_GENERIC_OFF	SCMI_POWER_STATE_PARAM(1, 0)
+
+/** @} */
+
+/**
  * @struct scmi_power_state_config
  *
  * @brief Describes the parameters for the POWER_STATE_SET

--- a/soc/nxp/imx/imx9/imx943/a55/soc.c
+++ b/soc/nxp/imx/imx9/imx943/a55/soc.c
@@ -14,10 +14,6 @@
 #include <zephyr/dt-bindings/power/imx943_power.h>
 #include <soc.h>
 
-/* SCMI power domain states */
-#define POWER_DOMAIN_STATE_ON  0x00000000
-#define POWER_DOMAIN_STATE_OFF 0x40000000
-
 #if defined(CONFIG_ETH_NXP_IMX_NETC) && (DT_CHILD_NUM_STATUS_OKAY(DT_NODELABEL(netc)) != 0)
 /* The function is to reuse code for 250MHz NETC system clock and MACs clocks initialization */
 static int soc_netc_clock_init(int clk_id)
@@ -51,18 +47,18 @@ static int soc_init(void)
 
 #if defined(CONFIG_ETH_NXP_IMX_NETC) && (DT_CHILD_NUM_STATUS_OKAY(DT_NODELABEL(netc)) != 0)
 	struct scmi_power_state_config pwr_cfg = {0};
-	uint32_t power_state = POWER_DOMAIN_STATE_OFF;
+	uint32_t power_state = SCMI_POWER_STATE_GENERIC_OFF;
 
 	/* Power up NETCMIX */
 	pwr_cfg.domain_id = IMX943_PD_NETC;
-	pwr_cfg.power_state = POWER_DOMAIN_STATE_ON;
+	pwr_cfg.power_state = SCMI_POWER_STATE_GENERIC_ON;
 
 	ret = scmi_power_state_set(&pwr_cfg);
 	if (ret) {
 		return ret;
 	}
 
-	while (power_state != POWER_DOMAIN_STATE_ON) {
+	while (power_state != SCMI_POWER_STATE_GENERIC_ON) {
 		ret = scmi_power_state_get(IMX943_PD_NETC, &power_state);
 		if (ret) {
 			return ret;

--- a/soc/nxp/imx/imx9/imx943/m33/soc.c
+++ b/soc/nxp/imx/imx9/imx943/m33/soc.c
@@ -15,10 +15,6 @@
 #include <zephyr/dt-bindings/power/imx943_power.h>
 #include <soc.h>
 
-/* SCMI power domain states */
-#define POWER_DOMAIN_STATE_ON  0x00000000
-#define POWER_DOMAIN_STATE_OFF 0x40000000
-
 void soc_early_init_hook(void)
 {
 #ifdef CONFIG_CACHE_MANAGEMENT
@@ -60,18 +56,18 @@ static int soc_init(void)
 
 #if defined(CONFIG_ETH_NXP_IMX_NETC) && (DT_CHILD_NUM_STATUS_OKAY(DT_NODELABEL(netc)) != 0)
 	struct scmi_power_state_config pwr_cfg = {0};
-	uint32_t power_state = POWER_DOMAIN_STATE_OFF;
+	uint32_t power_state = SCMI_POWER_STATE_GENERIC_OFF;
 
 	/* Power up NETCMIX */
 	pwr_cfg.domain_id = IMX943_PD_NETC;
-	pwr_cfg.power_state = POWER_DOMAIN_STATE_ON;
+	pwr_cfg.power_state = SCMI_POWER_STATE_GENERIC_ON;
 
 	ret = scmi_power_state_set(&pwr_cfg);
 	if (ret) {
 		return ret;
 	}
 
-	while (power_state != POWER_DOMAIN_STATE_ON) {
+	while (power_state != SCMI_POWER_STATE_GENERIC_ON) {
 		ret = scmi_power_state_get(IMX943_PD_NETC, &power_state);
 		if (ret) {
 			return ret;

--- a/soc/nxp/imx/imx9/imx95/a55/soc.c
+++ b/soc/nxp/imx/imx9/imx95/a55/soc.c
@@ -16,10 +16,6 @@
 
 #define FREQ_24M_HZ 24000000 /* 24 MHz */
 
-/* SCMI power domain states */
-#define POWER_DOMAIN_STATE_ON  0x00000000
-#define POWER_DOMAIN_STATE_OFF 0x40000000
-
 static int lpuart_clk_init(void)
 {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpuart1), okay) ||                                             \
@@ -70,20 +66,20 @@ static int netc_init(void)
 	struct scmi_protocol *proto = clk_dev->data;
 	struct scmi_clock_rate_config clk_cfg = {0};
 	struct scmi_power_state_config pwr_cfg = {0};
-	uint32_t power_state = POWER_DOMAIN_STATE_OFF;
+	uint32_t power_state = SCMI_POWER_STATE_GENERIC_OFF;
 	uint64_t enetref_clk = 250000000; /* 250 MHz*/
 	int ret;
 
 	/* Power up NETCMIX */
 	pwr_cfg.domain_id = IMX95_PD_NETC;
-	pwr_cfg.power_state = POWER_DOMAIN_STATE_ON;
+	pwr_cfg.power_state = SCMI_POWER_STATE_GENERIC_ON;
 
 	ret = scmi_power_state_set(&pwr_cfg);
 	if (ret) {
 		return ret;
 	}
 
-	while (power_state != POWER_DOMAIN_STATE_ON) {
+	while (power_state != SCMI_POWER_STATE_GENERIC_ON) {
 		ret = scmi_power_state_get(IMX95_PD_NETC, &power_state);
 		if (ret) {
 			return ret;

--- a/soc/nxp/imx/imx9/imx95/m7/soc.c
+++ b/soc/nxp/imx/imx9/imx95/m7/soc.c
@@ -15,10 +15,6 @@
 #include <zephyr/dt-bindings/power/imx95_power.h>
 #include <soc.h>
 
-/* SCMI power domain states */
-#define POWER_DOMAIN_STATE_ON  0x00000000
-#define POWER_DOMAIN_STATE_OFF 0x40000000
-
 void soc_early_init_hook(void)
 {
 #ifdef CONFIG_CACHE_MANAGEMENT
@@ -39,19 +35,19 @@ static int soc_init(void)
 	struct scmi_protocol *proto = clk_dev->data;
 	struct scmi_clock_rate_config clk_cfg = {0};
 	struct scmi_power_state_config pwr_cfg = {0};
-	uint32_t power_state = POWER_DOMAIN_STATE_OFF;
+	uint32_t power_state = SCMI_POWER_STATE_GENERIC_OFF;
 	uint64_t enetref_clk = 250000000; /* 250 MHz*/
 
 	/* Power up NETCMIX */
 	pwr_cfg.domain_id = IMX95_PD_NETC;
-	pwr_cfg.power_state = POWER_DOMAIN_STATE_ON;
+	pwr_cfg.power_state = SCMI_POWER_STATE_GENERIC_ON;
 
 	ret = scmi_power_state_set(&pwr_cfg);
 	if (ret) {
 		return ret;
 	}
 
-	while (power_state != POWER_DOMAIN_STATE_ON) {
+	while (power_state != SCMI_POWER_STATE_GENERIC_ON) {
 		ret = scmi_power_state_get(IMX95_PD_NETC, &power_state);
 		if (ret) {
 			return ret;


### PR DESCRIPTION
add generic power domain on/off states in scmi power.h file, the states should be defined in scmi protocol rather than soc level