### PR TITLE
net: lwm2m: finalize CBOR output on -ENOMEM instead of aborting

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -3304,6 +3304,10 @@ int lwm2m_perform_composite_read_op(struct lwm2m_message *msg, uint16_t content_
 
 		ret = lwm2m_perform_read_object_instance(msg, obj_inst, &num_read);
 		if (ret == -ENOMEM) {
+			if (num_read > 0) {
+				/* Return what we have read so far */
+				goto put_end;
+			}
 			return ret;
 		}
 	}
@@ -3312,6 +3316,7 @@ int lwm2m_perform_composite_read_op(struct lwm2m_message *msg, uint16_t content_
 		return -ENOENT;
 	}
 
+put_end:
 	/* Add object end mark */
 	if (engine_put_end(&msg->out, &msg->path) < 0) {
 		return -ENOMEM;


### PR DESCRIPTION
**Description**
When encoding cached LwM2M 1.1 resources into SenML CBOR, the encoder currently aborts with -ENOMEM once the number of records written (plus CBOR control elements such as start, delimiter, end) exceeds CONFIG_LWM2M_RW_SENML_CBOR_RECORDS. In this case all previously serialized data is discarded, no payload is sent, the client gets stuck, caches keep filling up, and only a reboot will clear the state – all cached data is lost.

**Fix**
If the output writer runs out of internal resources during serialization (-ENOMEM with num_read > 0), the CBOR output is now finalized (end marker added) and success is returned to the higher layer. There lwm2m_send_cb() sends the finalized message. After checking for more cached data, the cycle repeats until everything is sent.

If the output writer has made no progress (num_read == 0), -ENOMEM is still propagated so the existing retry logic can apply. This way useful data is delivered and upper layers can continue until all data is sent.

**Impact**

- Guarantees forward progress instead of canceling the message
- Prevents client lock-up and data loss
- Keeps API and success-path behavior unchanged
- Complements the existing limited retry mechanism (still used when zero progress is possible)

**Testing**
Verified on NCS 3.0.2 / 3.1.0 nrf/lwm2m_client with large local caches. Partial uploads succeed, the system recovers as expected, and clients behave reliably again in field use.

**Notes**
A more detailed explanation of the broken and fixed behavior is given in my review comment:
https://github.com/zephyrproject-rtos/zephyr/pull/95842#issuecomment-3281668934

Fixes #95839