### PR TITLE
samples: sysbuild: hello_world: verify output from both uarts

### DIFF
--- a/samples/sysbuild/hello_world/pytest/test_both_uart.py
+++ b/samples/sysbuild/hello_world/pytest/test_both_uart.py
@@ -1,0 +1,74 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import logging
+import re
+import time
+
+import pytest
+import serial
+from twister_harness import DeviceAdapter
+from twister_harness.fixtures import determine_scope
+
+logger = logging.getLogger("test_both_uart")
+logger.setLevel(logging.DEBUG)
+
+
+@pytest.fixture(scope=determine_scope)
+def dut(request: pytest.FixtureRequest, device_object: DeviceAdapter):
+    device_object.initialize_log_files(request.node.name)
+
+    device_object.second_serial = None
+    second_serial_port_name = device_object.device_config.serial
+    if "if00" in device_object.device_config.serial:
+        second_serial_port_name = device_object.device_config.serial.replace("if00", "if02")
+    elif "if02" in device_object.device_config.serial:
+        second_serial_port_name = device_object.device_config.serial.replace("if02", "if00")
+
+    if second_serial_port_name != device_object.device_config.serial:
+        device_object.second_serial = serial.Serial(
+            port=second_serial_port_name,
+            baudrate=device_object.device_config.baud,
+            timeout=1,
+            rtscts=True,
+        )
+    device_object.launch()
+    try:
+        yield device_object
+    finally:
+        device_object.close()
+        if device_object.second_serial is not None:
+            device_object.second_serial.close()
+
+
+def test_both_uart(dut: DeviceAdapter):
+    """
+    Verify logs from both uarts
+    """
+    timeout = 5
+    regex = "Hello world from .*"
+
+    # verify first port
+    dut.readlines_until(regex=regex, print_output=True, timeout=timeout)
+
+    # verify second port
+    # skip if there is no second port
+    if dut.second_serial is not None:
+        regex_compiled = re.compile(regex)
+        timeout_time: float = time.time() + timeout
+        while time.time() < timeout_time:
+            try:
+                line = dut.second_serial.readline().decode("utf-8")
+                logger.debug(f"Second serial: -{line}-")
+            except serial.SerialException:
+                logger.exception("Second serial")
+            if regex_compiled.search(line):
+                logger.debug("Second serial - found")
+                break
+        else:
+            raise AssertionError(f"Second serial - regex not found: {regex}")
+    else:
+        logger.error("Second serial - skipped")

--- a/samples/sysbuild/hello_world/sample.yaml
+++ b/samples/sysbuild/hello_world/sample.yaml
@@ -6,11 +6,10 @@ sample:
 
 common:
   sysbuild: true
-  harness: console
+  harness: pytest
   harness_config:
-    type: multi_line
-    regex:
-      - "Hello world from .*"
+    pytest_dut_scope: session
+  timeout: 20
 
 tests:
   sample.sysbuild.hello_world.nrf5340dk_cpuapp_cpunet:
@@ -19,7 +18,6 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     extra_args: SB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf
-
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpurad:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
@@ -34,7 +32,6 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-
       - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr.conf
       - hello_world_SNIPPET=nordic-ppr
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpuppr_xip:
@@ -43,7 +40,6 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-
       - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuppr_xip.conf
       - hello_world_SNIPPET=nordic-ppr-xip
   sample.sysbuild.hello_world.nrf54l15dk_nrf54l15_cpuflpr:
@@ -54,7 +50,6 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
     extra_args:
-
       - SB_CONF_FILE=sysbuild/nrf54l15dk_nrf54l15_cpuflpr.conf
       - hello_world_SNIPPET=nordic-flpr
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpuflpr:
@@ -63,7 +58,6 @@ tests:
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
-
       - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpuflpr.conf
       - hello_world_SNIPPET=nordic-flpr
   sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpuflpr_xip:


### PR DESCRIPTION
Beside main core, check output from remote core console.
Checking second console will work only for nordic boards (as the pattern to get second uart interface is known).
For other boards (with different interface naming), the test will check only provided console,
which is the same behavior as harness:console.