### PR TITLE
cmake: mcuboot: Add dependency to keys

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -73,6 +73,9 @@ function(zephyr_mcuboot_tasks)
                             "APPLICATION_CONFIG_DIR=\"${APPLICATION_CONFIG_DIR}\" "
                             "and WEST_TOPDIR=\"${WEST_TOPDIR}\")")
       endif()
+
+      # Add key file as CMake dependency so a file change will rerun the build
+      set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${${file}})
     endforeach()
   endif()
 


### PR DESCRIPTION
Adds a dependency that causes CMake to re-configure if the input key files for MCUboot signing/encryption have changed

Fixes #95850