### PR TITLE
tests: drivers: spi_loopback: Add xg29_rb4412a to SPI RTIO test

### DIFF
--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -35,6 +35,7 @@ tests:
       - robokit1
       - mimxrt1170_evk/mimxrt1176/cm7
       - bg29_rb4420a
+      - xg29_rb4412a
     integration_platforms:
       - robokit1
   drivers.spi.mcux_dspi_dma.loopback:


### PR DESCRIPTION
Included the xg29_rb4412a board in the list of tested platforms for the SPI loopback RTIO test.