### PR TITLE
scripts: update the Github auth API

### DIFF
--- a/scripts/ci/check_maintainer_changes.py
+++ b/scripts/ci/check_maintainer_changes.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 import yaml
-from github import Github
+from github import Auth, Github
 
 
 def load_areas(filename: str):
@@ -25,7 +25,7 @@ def set_or_empty(d, key):
 
 def check_github_access(usernames, repo_fullname, token):
     """Check if each username has at least Triage access to the repo."""
-    gh = Github(token)
+    gh = Github(auth=Auth.Token(token))
     repo = gh.get_repo(repo_fullname)
     missing_access = set()
     for username in usernames:

--- a/scripts/ci/do_not_merge.py
+++ b/scripts/ci/do_not_merge.py
@@ -62,8 +62,8 @@ def workflow_delay(repo, pr):
 def main(argv):
     args = parse_args(argv)
 
-    token = os.environ.get('GITHUB_TOKEN', None)
-    gh = github.Github(token)
+    auth = github.Auth.Token(os.environ.get('GITHUB_TOKEN', None))
+    gh = github.Github(auth=auth)
 
     print_rate_limit(gh, args.org)
 

--- a/scripts/ci/stats/merged_prs.py
+++ b/scripts/ci/stats/merged_prs.py
@@ -8,7 +8,7 @@
 
 import sys
 import os
-from github import Github
+from github import Auth, Github
 import argparse
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk
@@ -137,7 +137,7 @@ def main():
         sys.exit('Github token not set in environment, please set the '
                  'GITHUB_TOKEN environment variable and retry.')
 
-    gh = Github(token)
+    gh = Github(auth=Auth.Token(token))
     json_list = []
     gh_repo = gh.get_repo(args.repo)
 

--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -10,7 +10,7 @@ import sys
 import time
 from collections import defaultdict
 
-from github import Github, GithubException
+from github import Auth, Github, GithubException
 from github.GithubException import UnknownObjectException
 from west.manifest import Manifest, ManifestProject
 
@@ -443,7 +443,7 @@ def main():
             'GITHUB_TOKEN environment variable and retry.'
         )
 
-    gh = Github(token)
+    gh = Github(auth=Auth.Token(token))
     maintainer_file = Maintainers(args.maintainer_file)
 
     if args.pull_request:


### PR DESCRIPTION
Fixes: /home/runner/work/zephyr/zephyr/scripts/ci/do_not_merge.py:66: DeprecationWarning: Argument login_or_token is deprecated, please use auth=github.Auth.Token(...) instead