### PR TITLE
net: if: Remove net_if_oper_state build assert

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -912,7 +912,6 @@ static inline enum net_if_oper_state net_if_oper_state_set(
 		return NET_IF_OPER_UNKNOWN;
 	}
 
-	BUILD_ASSERT((enum net_if_oper_state)(-1) > 0 && NET_IF_OPER_UNKNOWN == 0);
 	if (oper_state <= NET_IF_OPER_UP) {
 		iface->if_dev->oper_state = oper_state;
 	}


### PR DESCRIPTION
Remove the build assert checking if net_if_oper_state is of unsigned type. It's generating warnings with clang, and in fact isn't very useful.

Fixes #95755