### PR TITLE
sensors: Add missing const to `sensor_read_async_mempool`

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1127,7 +1127,7 @@ static inline int sensor_read(struct rtio_iodev *iodev, struct rtio *ctx, uint8_
  * @return 0 on success
  * @return < 0 on error
  */
-static inline int sensor_read_async_mempool(struct rtio_iodev *iodev, struct rtio *ctx,
+static inline int sensor_read_async_mempool(const struct rtio_iodev *iodev, struct rtio *ctx,
 					    void *userdata)
 {
 	if (IS_ENABLED(CONFIG_USERSPACE)) {


### PR DESCRIPTION
Add missing const on `struct rtio_iodev *iodev`
The blocking version, sensor_read(), as well as rtio_sqe_prep_read_with_pool() which accepts `struct rtio_iodev` are both marked as const. This function should also be marked const.