### PR TITLE
sensor: icm45686: Fix one-shot missing shift value for XYZ channels

### DIFF
--- a/drivers/sensor/tdk/icm45686/icm45686_decoder.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_decoder.c
@@ -360,6 +360,14 @@ static int icm45686_one_shot_decode(const uint8_t *buffer,
 		out->header.base_timestamp_ns = edata->header.timestamp;
 		out->header.reading_count = 1;
 
+		err = icm45686_get_shift(chan_spec.chan_type,
+					 edata->header.accel_fs,
+					 edata->header.gyro_fs,
+					 &out->shift);
+		if (err != 0) {
+			return -EINVAL;
+		}
+
 		icm45686_convert_raw_to_q31(
 			edata,
 			chan_spec.chan_type - 3,


### PR DESCRIPTION
Fix missing shift values in `sensor_three_axis_data`  when performing one-shot reads on SENSOR_CHAN_ACCEL_XYZ and SENSOR_CHAN_GYRO_XYZ