### PR TITLE
infineon: Psc3m5 counter

### DIFF
--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -46,6 +46,7 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_SMARTBOND_TIMER     counter_smartbon
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MICROCHIP_MCP7940N  rtc_mcp7940n.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_ANDES_ATCPIT100     counter_andes_atcpit100.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_INFINEON_CAT1       counter_ifx_cat1.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_INFINEON_TCPWM      counter_ifx_tcpwm.c)
 zephyr_library_sources_ifdef(CONFIG_ACE_V1X_ART_COUNTER         counter_ace_v1x_art.c)
 zephyr_library_sources_ifdef(CONFIG_ACE_V1X_RTC_COUNTER         counter_ace_v1x_rtc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NXP_S32_SYS_TIMER   counter_nxp_s32_sys_timer.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -94,6 +94,8 @@ source "drivers/counter/Kconfig.mcux_ctimer"
 
 source "drivers/counter/Kconfig.ifx_cat1"
 
+source "drivers/counter/Kconfig.ifx_tcpwm"
+
 source "drivers/counter/Kconfig.andes_atcpit100"
 
 source "drivers/counter/Kconfig.nxp_s32"

--- a/drivers/counter/Kconfig.ifx_tcpwm
+++ b/drivers/counter/Kconfig.ifx_tcpwm
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config COUNTER_INFINEON_TCPWM
+	bool "Infineon TCPWM counter driver"
+	default y
+	depends on DT_HAS_INFINEON_TCPWM_COUNTER_ENABLED
+	select USE_INFINEON_TIMER
+	help
+	  This option enables the TCPWM counter driver for Infineon devices.

--- a/drivers/counter/counter_ifx_tcpwm.c
+++ b/drivers/counter/counter_ifx_tcpwm.c
@@ -1,0 +1,495 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Counter driver for Infineon TCPWM peripheral. */
+
+#define DT_DRV_COMPAT infineon_tcpwm_counter
+
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/timer/ifx_tcpwm.h>
+#include <zephyr/dt-bindings/pinctrl/ifx_cat1-pinctrl.h>
+#include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
+#include <zephyr/irq.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(ifx_tcpwm_counter, CONFIG_COUNTER_LOG_LEVEL);
+
+#include <cy_sysclk.h>
+#include <cy_tcpwm_counter.h>
+
+struct ifx_tcpwm_counter_config {
+	struct counter_config_info counter_info;
+	TCPWM_GRP_CNT_Type *reg_base;
+	uint32_t index;
+	bool resolution_32_bits;
+	IRQn_Type irq_num;
+	cy_en_divider_types_t divider_type;
+	uint32_t divider_sel;
+	uint32_t divider_val;
+	void (*irq_enable_func)(const struct device *dev);
+};
+
+struct ifx_tcpwm_counter_data {
+	bool alarm_irq_flag;
+	cy_israddress callback;
+	/* Timer/counter comparison value */
+	uint32_t compare_value;
+	/* Default value of the timer/counter. */
+	uint32_t value;
+	struct counter_alarm_cfg alarm_cfg;
+	struct counter_top_cfg top_value_cfg_counter;
+	uint32_t guard_period;
+	struct ifx_cat1_clock clock;
+	uint8_t clock_peri_group;
+};
+
+static const cy_stc_tcpwm_counter_config_t counter_default_config = {
+	.period = 32768,
+	.clockPrescaler = CY_TCPWM_COUNTER_PRESCALER_DIVBY_1,
+	.runMode = CY_TCPWM_COUNTER_CONTINUOUS,
+	.countDirection = CY_TCPWM_COUNTER_COUNT_UP,
+	.compareOrCapture = CY_TCPWM_COUNTER_MODE_COMPARE,
+	.compare0 = 16384,
+	.compare1 = 16384,
+	.enableCompareSwap = false,
+	.interruptSources = CY_TCPWM_INT_NONE,
+	.captureInputMode = 0x3U,
+	.captureInput = CY_TCPWM_INPUT_0,
+	.reloadInputMode = 0x3U,
+	.reloadInput = CY_TCPWM_INPUT_0,
+	.startInputMode = 0x3U,
+	.startInput = CY_TCPWM_INPUT_0,
+	.stopInputMode = 0x3U,
+	.stopInput = CY_TCPWM_INPUT_0,
+	.countInputMode = 0x3U,
+	.countInput = CY_TCPWM_INPUT_1,
+};
+
+typedef enum {
+	/* No interrupt handled */
+	COUNTER_IRQ_NONE = 0,
+	/* Interrupt when terminal count is reached */
+	COUNTER_IRQ_TERMINAL_COUNT = 1 << 0,
+	/* Interrupt when Compare/Capture value is reached */
+	COUNTER_IRQ_CAPTURE_COMPARE = 1 << 1,
+	/* Interrupt on terminal count and Compare/Capture values */
+	COUNTER_IRQ_ALL = (1 << 2) - 1,
+} counter_event_t;
+
+static void counter_enable_event(const struct device *dev, counter_event_t event, bool enable)
+{
+	const struct ifx_tcpwm_counter_config *const config = dev->config;
+	uint32_t savedIntrStatus = Cy_SysLib_EnterCriticalSection();
+	uint32_t old_mask = IFX_TCPWM_GetInterruptMask(config->reg_base);
+	uint32_t new_event;
+
+	if (enable) {
+		/* Clear any newly enabled events so that old IRQs don't trigger ISRs */
+		IFX_TCPWM_ClearInterrupt(config->reg_base, ~old_mask & event);
+	}
+
+	new_event = enable ? (old_mask | event) : (old_mask & ~event);
+	IFX_TCPWM_SetInterruptMask(config->reg_base, new_event);
+
+	Cy_SysLib_ExitCriticalSection(savedIntrStatus);
+}
+
+static void counter_isr_handler(const struct device *dev)
+{
+	struct ifx_tcpwm_counter_data *const data = dev->data;
+	const struct ifx_tcpwm_counter_config *const config = dev->config;
+	uint32_t pending_int;
+
+	pending_int = IFX_TCPWM_GetInterruptStatusMasked(config->reg_base);
+	IFX_TCPWM_ClearInterrupt(config->reg_base, pending_int);
+	NVIC_ClearPendingIRQ(config->irq_num);
+
+	/* Alarm compare/capture interrupt */
+	if ((data->alarm_cfg.callback != NULL) &&
+	    (((COUNTER_IRQ_CAPTURE_COMPARE & pending_int) == COUNTER_IRQ_CAPTURE_COMPARE) ||
+	     data->alarm_irq_flag)) {
+		/* Alarm works as one-shot, so disable interrupt */
+		counter_enable_event(dev, COUNTER_IRQ_CAPTURE_COMPARE, false);
+
+		/* Call User callback for Alarm */
+		data->alarm_cfg.callback(dev, 1, IFX_TCPWM_Counter_GetCounter(config->reg_base),
+					 data->alarm_cfg.user_data);
+		data->alarm_irq_flag = false;
+	}
+
+	/* Top_value terminal count interrupt */
+	if ((data->top_value_cfg_counter.callback != NULL) &&
+	    ((COUNTER_IRQ_TERMINAL_COUNT & pending_int) == COUNTER_IRQ_TERMINAL_COUNT)) {
+
+		/* Call User callback for top value */
+		data->top_value_cfg_counter.callback(dev, data->top_value_cfg_counter.user_data);
+	}
+}
+
+static int ifx_tcpwm_counter_init(const struct device *dev)
+{
+	__ASSERT_NO_MSG(dev != NULL);
+
+	cy_rslt_t rslt;
+	struct ifx_tcpwm_counter_data *const data = dev->data;
+	const struct ifx_tcpwm_counter_config *config = dev->config;
+	uint32_t clk_connection;
+	cy_stc_tcpwm_counter_config_t counter_config = counter_default_config;
+
+	/* Calculate clock connection based on TCPWM index */
+	if (config->resolution_32_bits) {
+		clk_connection = PCLK_TCPWM0_CLOCK_COUNTER_EN0 + config->index;
+	} else {
+		clk_connection = PCLK_TCPWM0_CLOCK_COUNTER_EN256 + config->index;
+	}
+	/* Configure PWM clock */
+	Cy_SysClk_PeriPclkDisableDivider((en_clk_dst_t)clk_connection, config->divider_type,
+					 config->divider_sel);
+	Cy_SysClk_PeriPclkSetDivider((en_clk_dst_t)clk_connection, config->divider_type,
+				     config->divider_sel, config->divider_val);
+	Cy_SysClk_PeriPclkEnableDivider((en_clk_dst_t)clk_connection, config->divider_type,
+					config->divider_sel);
+
+	Cy_SysClk_PeriPclkAssignDivider(clk_connection, config->divider_type, config->divider_sel);
+
+	/* Initialize counter structure */
+	data->alarm_irq_flag = false;
+	data->top_value_cfg_counter.ticks = config->counter_info.max_top_value;
+	data->compare_value = 0;
+	data->value = 0;
+
+	/* Configure timer */
+	counter_config.period = data->top_value_cfg_counter.ticks;
+	counter_config.compare0 = data->compare_value;
+
+	/* DeInit will clear the interrupt mask; save it now and restore after we re-nit */
+	uint32_t old_mask = IFX_TCPWM_GetInterruptMask(config->reg_base);
+
+	IFX_TCPWM_Counter_DeInit(config->reg_base, &counter_config);
+
+	rslt = (cy_rslt_t)IFX_TCPWM_Counter_Init(config->reg_base, &counter_config);
+	if (rslt != CY_RSLT_SUCCESS) {
+		return -EIO;
+	}
+
+	IFX_TCPWM_Counter_Enable(config->reg_base);
+	IFX_TCPWM_SetInterruptMask(config->reg_base, old_mask);
+
+	/* This must be called after IFX_TCPWM_Counter_Init */
+	IFX_TCPWM_Counter_SetCounter(config->reg_base, data->value);
+
+	/* enable the counter interrupt */
+	config->irq_enable_func(dev);
+
+	return 0;
+}
+
+static int ifx_tcpwm_counter_start(const struct device *dev)
+{
+	__ASSERT_NO_MSG(dev != NULL);
+
+	const struct ifx_tcpwm_counter_config *config = dev->config;
+
+	IFX_TCPWM_Counter_Enable(config->reg_base);
+	IFX_TCPWM_TriggerStart_Single(config->reg_base);
+
+	return 0;
+}
+
+static int ifx_tcpwm_counter_stop(const struct device *dev)
+{
+	__ASSERT_NO_MSG(dev != NULL);
+
+	const struct ifx_tcpwm_counter_config *config = dev->config;
+
+	IFX_TCPWM_Counter_Disable(config->reg_base);
+
+	return 0;
+}
+
+static int ifx_tcpwm_counter_get_value(const struct device *dev, uint32_t *ticks)
+{
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(ticks != NULL);
+
+	const struct ifx_tcpwm_counter_config *config = dev->config;
+
+	*ticks = IFX_TCPWM_Counter_GetCounter(config->reg_base);
+
+	return 0;
+}
+
+static int ifx_tcpwm_counter_set_top_value(const struct device *dev,
+					   const struct counter_top_cfg *cfg)
+{
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(cfg != NULL);
+
+	struct ifx_tcpwm_counter_data *const data = dev->data;
+	const struct ifx_tcpwm_counter_config *const config = dev->config;
+
+	data->top_value_cfg_counter = *cfg;
+
+	/* Check new top value limit */
+	if (cfg->ticks > config->counter_info.max_top_value) {
+		return -ENOTSUP;
+	}
+
+	/* Checks if new period value is not less then old period value */
+	if (!(cfg->flags & COUNTER_TOP_CFG_DONT_RESET)) {
+		data->value = 0u;
+	} else {
+		/* timer_configure resets timer counter register to value
+		 * defined in config structure 'data->value', so update
+		 * counter value with current value of counter (read by
+		 * IFX_TCPWM_Counter_GetCounter function).
+		 */
+		data->value = IFX_TCPWM_Counter_GetCounter(config->reg_base);
+	}
+
+	IFX_TCPWM_Block_SetPeriod(config->reg_base, cfg->ticks);
+
+	/* Register an top_value terminal count event callback handler if
+	 * callback is not NULL.
+	 */
+	if (cfg->callback != NULL) {
+		counter_enable_event(dev, COUNTER_IRQ_TERMINAL_COUNT, true);
+	}
+
+	return 0;
+}
+
+static uint32_t ifx_tcpwm_counter_get_top_value(const struct device *dev)
+{
+	__ASSERT_NO_MSG(dev != NULL);
+
+	struct ifx_tcpwm_counter_data *const data = dev->data;
+
+	return data->top_value_cfg_counter.ticks;
+}
+
+static inline bool counter_is_bit_mask(uint32_t val)
+{
+	/* Return true if value equals 2^n - 1 */
+	return !(val & (val + 1U));
+}
+
+static uint32_t counter_ticks_add(uint32_t val1, uint32_t val2, uint32_t top)
+{
+	uint32_t to_top;
+
+	/* refer to https://tbrindus.ca/how-builtin-expect-works/ for 'likely' usage */
+	if (likely(counter_is_bit_mask(top))) {
+		return (val1 + val2) & top;
+	}
+
+	to_top = top - val1;
+
+	return (val2 <= to_top) ? (val1 + val2) : (val2 - to_top - 1U);
+}
+
+static uint32_t counter_ticks_sub(uint32_t val, uint32_t old, uint32_t top)
+{
+	/* refer to https://tbrindus.ca/how-builtin-expect-works/ for 'likely' usage */
+	if (likely(counter_is_bit_mask(top))) {
+		return (val - old) & top;
+	}
+
+	/* if top is not 2^n-1 */
+	return (val >= old) ? (val - old) : (val + top + 1U - old);
+}
+
+static int ifx_tcpwm_counter_set_alarm(const struct device *dev, uint8_t chan_id,
+				       const struct counter_alarm_cfg *alarm_cfg)
+{
+	ARG_UNUSED(chan_id);
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(alarm_cfg != NULL);
+
+	struct ifx_tcpwm_counter_data *const data = dev->data;
+	const struct ifx_tcpwm_counter_config *const config = dev->config;
+
+	uint32_t compare_value = alarm_cfg->ticks;
+	uint32_t top_val = ifx_tcpwm_counter_get_top_value(dev);
+	uint32_t flags = alarm_cfg->flags;
+	uint32_t max_rel_val;
+	bool absolute = ((flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) ? false : true;
+	bool irq_on_late;
+
+	data->alarm_cfg = *alarm_cfg;
+
+	/* Checks if compare value is not less then period value */
+	if (alarm_cfg->ticks > top_val) {
+		return -EINVAL;
+	}
+
+	if (absolute) {
+		max_rel_val = top_val - data->guard_period;
+		irq_on_late = ((flags & COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE) == 0) ? false : true;
+	} else {
+		/* If relative value is smaller than half of the counter range it is assumed
+		 * that there is a risk of setting value too late and late detection algorithm
+		 * must be applied. When late setting is detected, interrupt shall be
+		 * triggered for immediate expiration of the timer. Detection is performed
+		 * by limiting relative distance between CC and counter.
+		 *
+		 * Note that half of counter range is an arbitrary value.
+		 */
+		irq_on_late = compare_value < (top_val / 2U);
+
+		/* limit max to detect short relative being set too late. */
+		max_rel_val = irq_on_late ? (top_val / 2U) : top_val;
+		compare_value = counter_ticks_add(IFX_TCPWM_Counter_GetCounter(config->reg_base),
+						  compare_value, top_val);
+	}
+
+	/* Decrement value to detect the case when compare_value == counter_read(dev). Otherwise,
+	 * condition would need to include comparing diff against 0.
+	 */
+	uint32_t curr = IFX_TCPWM_Counter_GetCounter(config->reg_base);
+	uint32_t diff = counter_ticks_sub((compare_value - 1), curr, top_val);
+
+	if ((absolute && (compare_value < curr)) || (diff > max_rel_val)) {
+
+		/* Interrupt is triggered always for relative alarm and for absolute depending
+		 * on the flag.
+		 */
+		if (irq_on_late) {
+			data->alarm_irq_flag = true;
+			counter_enable_event(dev, COUNTER_IRQ_CAPTURE_COMPARE, true);
+			IFX_TCPWM_SetInterrupt(config->reg_base, COUNTER_IRQ_CAPTURE_COMPARE);
+		}
+
+		if (absolute) {
+			return -ETIME;
+		}
+	} else {
+		/* Setting new compare value
+		 *
+		 * timer_configure resets timer counter register to value
+		 * defined in config structure 'data->value', so update
+		 * counter value with current value of counter (read by
+		 * IFX_TCPWM_Counter_GetCounter function).
+		 */
+		data->value = IFX_TCPWM_Counter_GetCounter(config->reg_base);
+		data->compare_value = compare_value;
+
+		/* Reconfigure timer */
+		IFX_TCPWM_Block_SetCC0Val(config->reg_base, compare_value);
+
+		counter_enable_event(dev, COUNTER_IRQ_CAPTURE_COMPARE, true);
+	}
+
+	return 0;
+}
+
+static int ifx_tcpwm_counter_cancel_alarm(const struct device *dev, uint8_t chan_id)
+{
+	ARG_UNUSED(chan_id);
+	__ASSERT_NO_MSG(dev != NULL);
+
+	counter_enable_event(dev, COUNTER_IRQ_CAPTURE_COMPARE, false);
+	return 0;
+}
+
+static uint32_t ifx_tcpwm_counter_get_pending_int(const struct device *dev)
+{
+	__ASSERT_NO_MSG(dev != NULL);
+
+	const struct ifx_tcpwm_counter_config *const config = dev->config;
+
+	return NVIC_GetPendingIRQ(config->irq_num);
+}
+
+static uint32_t ifx_tcpwm_counter_get_guard_period(const struct device *dev, uint32_t flags)
+{
+	ARG_UNUSED(flags);
+	__ASSERT_NO_MSG(dev != NULL);
+
+	struct ifx_tcpwm_counter_data *const data = dev->data;
+
+	return data->guard_period;
+}
+
+static int ifx_tcpwm_counter_set_guard_period(const struct device *dev, uint32_t guard,
+					      uint32_t flags)
+{
+	ARG_UNUSED(flags);
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(guard < ifx_tcpwm_counter_get_top_value(dev));
+
+	struct ifx_tcpwm_counter_data *const data = dev->data;
+
+	data->guard_period = guard;
+	return 0;
+}
+
+static DEVICE_API(counter, counter_api) = {
+	.start = ifx_tcpwm_counter_start,
+	.stop = ifx_tcpwm_counter_stop,
+	.get_value = ifx_tcpwm_counter_get_value,
+	.set_alarm = ifx_tcpwm_counter_set_alarm,
+	.cancel_alarm = ifx_tcpwm_counter_cancel_alarm,
+	.set_top_value = ifx_tcpwm_counter_set_top_value,
+	.get_pending_int = ifx_tcpwm_counter_get_pending_int,
+	.get_top_value = ifx_tcpwm_counter_get_top_value,
+	.get_guard_period = ifx_tcpwm_counter_get_guard_period,
+	.set_guard_period = ifx_tcpwm_counter_set_guard_period,
+};
+
+#define DT_INST_GET_CYHAL_GPIO_OR(inst, gpios_prop, default)                                       \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, gpios_prop),                                       \
+		    (DT_GET_CYHAL_GPIO_FROM_DT_GPIOS(DT_INST(inst, DT_DRV_COMPAT), gpios_prop)),   \
+		    (default))
+
+/* Counter driver init macros */
+#define INFINEON_TCPWM_COUNTER_INIT(n)                                                             \
+                                                                                                   \
+	static void ifx_cat1_spi_irq_enable_func_##n(const struct device *dev)                     \
+	{                                                                                          \
+		IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(n)), DT_IRQ(DT_INST_PARENT(n), priority),       \
+			    counter_isr_handler, DEVICE_DT_INST_GET(n), 0);                        \
+		irq_enable(DT_IRQN(DT_INST_PARENT(n)));                                            \
+	}                                                                                          \
+                                                                                                   \
+	static struct ifx_tcpwm_counter_data ifx_tcpwm_counter##n##_data = {                       \
+		.clock =                                                                           \
+			{                                                                          \
+				.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                         \
+					DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), clk_dst, 1),    \
+					DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),             \
+				.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, div_num),            \
+			},                                                                         \
+		.clock_peri_group = DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), clk_dst, 1),        \
+	};                                                                                         \
+                                                                                                   \
+	static const struct ifx_tcpwm_counter_config ifx_tcpwm_counter##n##_config = {             \
+		.counter_info = {.max_top_value = (DT_PROP(DT_INST_PARENT(n), resolution) == 32)   \
+							  ? UINT32_MAX                             \
+							  : UINT16_MAX,                            \
+				 .freq = DT_INST_PROP(n, clock_frequency),                         \
+				 .flags = COUNTER_CONFIG_INFO_COUNT_UP,                            \
+				 .channels = 1},                                                   \
+		.reg_base = (TCPWM_GRP_CNT_Type *)DT_REG_ADDR(DT_INST_PARENT(n)),                  \
+		.index = (DT_REG_ADDR(DT_INST_PARENT(n)) -                                         \
+			  DT_REG_ADDR(DT_PARENT(DT_INST_PARENT(n)))) /                             \
+			 DT_REG_SIZE(DT_INST_PARENT(n)),                                           \
+		.irq_num = DT_IRQN(DT_INST_PARENT(n)),                                             \
+		.resolution_32_bits =                                                              \
+			(DT_PROP(DT_INST_PARENT(n), resolution) == 32) ? true : false,             \
+		.divider_type = DT_PROP(DT_INST_PARENT(n), divider_type),                          \
+		.divider_sel = DT_PROP(DT_INST_PARENT(n), divider_sel),                            \
+		.divider_val = DT_PROP(DT_INST_PARENT(n), divider_val),                            \
+		.irq_enable_func = ifx_cat1_spi_irq_enable_func_##n,                               \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, ifx_tcpwm_counter_init, NULL, &ifx_tcpwm_counter##n##_data,       \
+			      &ifx_tcpwm_counter##n##_config, PRE_KERNEL_1,                        \
+			      CONFIG_COUNTER_INIT_PRIORITY, &counter_api);
+
+DT_INST_FOREACH_STATUS_OKAY(INFINEON_TCPWM_COUNTER_INIT);

--- a/dts/arm/infineon/cat1b/psc3/psc3.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3.dtsi
@@ -207,344 +207,402 @@
 			status = "disabled";
 		};
 
-		counter0_0: counter@42a00000 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a00000 0x100>;
-			interrupts = <76 4>;
-			resolution = <32>;
-			status = "disabled";
+		tcpwm0: tcpwm0@42a00000  {
+			reg = <0x42a00000 0x10000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tcpwm0_0: tcpwm0_0@42a00000 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a00000 0x100>;
+				interrupts = <76 4>;
+				resolution = <32>;
+				status = "disabled";
+
+				pwm0_0: pwm0_0 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter0_0: counter0_0 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm0_1: tcpwm0_1@42a00100 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a00100 0x100>;
+				interrupts = <77 4>;
+				resolution = <32>;
+				status = "disabled";
+
+				pwm0_1: pwm0_1 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter0_1: counter0_1 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm0_2: tcpwm0_2@42a00200 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a00200 0x100>;
+				interrupts = <78 4>;
+				resolution = <32>;
+				status = "disabled";
+
+				pwm0_2: pwm0_2 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter0_2: counter0_2 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm0_3: tcpwm0_3@42a000300 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a00300 0x100>;
+				interrupts = <79 4>;
+				resolution = <32>;
+				status = "disabled";
+
+				pwm0_3: pwm0_3 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter0_3: counter0_3 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 		};
 
-		counter0_1: counter@42a00100 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a00100 0x100>;
-			interrupts = <77 4>;
-			resolution = <32>;
-			status = "disabled";
+		tcpwm1: tcpwm1@42a10000  {
+			reg = <0x42a10000 0x10000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tcpwm1_0: tcpwm1_0@42a10000 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a10000 0x100>;
+				interrupts = <80 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_0: pwm1_0 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_0: counter1_0 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_1: tcpwm1_1@42a10100 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a10100 0x100>;
+				interrupts = <81 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_1: pwm1_1 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_1: counter1_1 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_2: tcpwm1_2@42a10200 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a10200 0x100>;
+				interrupts = <82 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_2: pwm1_2 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_2: counter1_2 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_3: tcpwm1_3@42a10300 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a10300 0x100>;
+				interrupts = <83 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_3: pwm1_3 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_3: counter1_3 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_4: tcpwm1_4@42a10400 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a10400 0x100>;
+				interrupts = <84 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_4: pwm1_4 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_4: counter1_4 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_5: tcpwm1_5@42a10500 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a10500 0x100>;
+				interrupts = <85 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_5: pwm1_5 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_5: counter1_5 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_6: tcpwm1_6@42a10600 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a10600 0x100>;
+				interrupts = <86 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_6: pwm1_6 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_6: counter1_6 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_7: tcpwm1_7@42a10700 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a10700 0x100>;
+				interrupts = <87 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_7: pwm1_7 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_7: counter1_7 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 		};
 
-		counter0_2: counter@42a00200 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a00200 0x100>;
-			interrupts = <78 4>;
-			resolution = <32>;
-			status = "disabled";
-		};
+		tcpwm2: tcpwm2@42a20000  {
+			reg = <0x42a20000 0x10000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-		counter0_3: counter@42a00300 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a00300 0x100>;
-			interrupts = <79 4>;
-			resolution = <32>;
-			status = "disabled";
-		};
+			tcpwm2_0: tcpwm2_0@42a20000 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a20000 0x100>;
+				interrupts = <88 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		counter1_0: counter@42a10000 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a10000 0x100>;
-			interrupts = <80 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				pwm2_0: pwm2_0 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		counter1_1: counter@42a10100 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a10100 0x100>;
-			interrupts = <81 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				counter2_0: counter2_0 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		counter1_2: counter@42a10200 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a10200 0x100>;
-			interrupts = <82 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+			tcpwm2_1: tcpwm2_1@42a20100 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a20100 0x100>;
+				interrupts = <89 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		counter1_3: counter@42a10300 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a10300 0x100>;
-			interrupts = <83 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				pwm2_1: pwm2_1 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		counter1_4: counter@42a10400 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a10400 0x100>;
-			interrupts = <84 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				counter2_1: counter2_1 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		counter1_5: counter@42a10500 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a10500 0x100>;
-			interrupts = <85 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+			tcpwm2_2: tcpwm2_2@42a20200 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a20200 0x100>;
+				interrupts = <90 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		counter1_6: counter@42a10600 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a10600 0x100>;
-			interrupts = <86 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				pwm2_2: pwm2_2 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		counter1_7: counter@42a10700 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a10700 0x100>;
-			interrupts = <87 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				counter2_2: counter2_2 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		counter2_0: counter@42a20000 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a20000 0x100>;
-			interrupts = <88 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+			tcpwm2_3: tcpwm2_3@42a20300 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a20300 0x100>;
+				interrupts = <91 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		counter2_1: counter@42a20100 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a20100 0x100>;
-			interrupts = <89 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				pwm2_3: pwm2_3 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		counter2_2: counter@42a20200 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a20200 0x100>;
-			interrupts = <90 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				counter2_3: counter2_3 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		counter2_3: counter@42a20300 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a20300 0x100>;
-			interrupts = <91 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+			tcpwm2_4: tcpwm2_4@42a20400 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a20400 0x100>;
+				interrupts = <92 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		counter2_4: counter@42a20400 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a20400 0x100>;
-			interrupts = <92 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				pwm2_4: pwm2_4 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		counter2_5: counter@42a20500 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a20500 0x100>;
-			interrupts = <93 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				counter2_4: counter2_4 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		counter2_6: counter@42a20600 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a20600 0x100>;
-			interrupts = <94 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+			tcpwm2_5: tcpwm2_5@42a20500 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a20500 0x100>;
+				interrupts = <93 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		counter2_7: counter@42a20700 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x42a20700 0x100>;
-			interrupts = <95 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				pwm2_5: pwm2_5 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		pwm0_0: pwm@42a00000 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a00000 0x100>;
-			interrupts = <76 4>;
-			resolution = <32>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
+				counter2_5: counter2_5 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		pwm0_1: pwm@42a00100 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a00100 0x100>;
-			interrupts = <77 4>;
-			resolution = <32>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
+			tcpwm2_6: tcpwm2_6@42a20600 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a20600 0x100>;
+				interrupts = <94 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		pwm0_2: pwm@42a00200 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a00200 0x100>;
-			interrupts = <78 4>;
-			resolution = <32>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
+				pwm2_6: pwm2_6 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		pwm0_3: pwm@42a00300 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a00300 0x100>;
-			interrupts = <79 4>;
-			resolution = <32>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
+				counter2_6: counter2_6 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		pwm1_0: pwm@42a10000 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a10000 0x100>;
-			interrupts = <80 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
+			tcpwm2_7: tcpwm2_7@42a20700 {
+				compatible = "infineon,tcpwm";
+				reg = <0x42a20700 0x100>;
+				interrupts = <95 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		pwm1_1: pwm@42a10100 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a10100 0x100>;
-			interrupts = <81 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
+				pwm2_7: pwm2_7 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		pwm1_2: pwm@42a10200 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a10200 0x100>;
-			interrupts = <82 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm1_3: pwm@42a10300 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a10300 0x100>;
-			interrupts = <83 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm1_4: pwm@42a10400 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a10400 0x100>;
-			interrupts = <84 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm1_5: pwm@42a10500 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a10500 0x100>;
-			interrupts = <85 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm1_6: pwm@42a10600 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a10600 0x100>;
-			interrupts = <86 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm1_7: pwm@42a10700 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a10700 0x100>;
-			interrupts = <87 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_0: pwm@42a20000 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a20000 0x100>;
-			interrupts = <88 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_1: pwm@42a20100 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a20100 0x100>;
-			interrupts = <89 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_2: pwm@42a20200 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a20200 0x100>;
-			interrupts = <90 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_3: pwm@42a20300 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a20300 0x100>;
-			interrupts = <91 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_4: pwm@42a20400 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a20400 0x100>;
-			interrupts = <92 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_5: pwm@42a20500 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a20500 0x100>;
-			interrupts = <93 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_6: pwm@42a20600 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a20600 0x100>;
-			interrupts = <94 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_7: pwm@42a20700 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x42a20700 0x100>;
-			interrupts = <95 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
+				counter2_7: counter2_7 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 		};
 
 		dma0: dw@42180000 {

--- a/dts/arm/infineon/cat1b/psc3/psc3_partition.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3_partition.dtsi
@@ -31,11 +31,11 @@
 		#size-cells = <1>;
 
 		slot0_partition: partition@12000000 {
-			reg = <0x12000000 DT_SIZE_K(63)>;
+			reg = <0x12000000 DT_SIZE_K(128)>;
 		};
 
 		slot0_ns_partition: partition@2010000 {
-			reg = <0x02010000 0x30000>;
+			reg = <0x02010000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/dts/arm/infineon/cat1b/psc3/psc3_s.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3_s.dtsi
@@ -207,344 +207,402 @@
 			status = "disabled";
 		};
 
-		counter0_0: counter@52a00000 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a00000 0x100>;
-			interrupts = <76 4>;
-			resolution = <32>;
-			status = "disabled";
+		tcpwm0: tcpwm0@52a00000  {
+			reg = <0x52a00000 0x10000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tcpwm0_0: tcpwm0_0@52a00000 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a00000 0x100>;
+				interrupts = <76 4>;
+				resolution = <32>;
+				status = "disabled";
+
+				pwm0_0: pwm0_0 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter0_0: counter0_0 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm0_1: tcpwm0_1@52a00100 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a00100 0x100>;
+				interrupts = <77 4>;
+				resolution = <32>;
+				status = "disabled";
+
+				pwm0_1: pwm0_1 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter0_1: counter0_1 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm0_2: tcpwm0_2@52a00200 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a00200 0x100>;
+				interrupts = <78 4>;
+				resolution = <32>;
+				status = "disabled";
+
+				pwm0_2: pwm0_2 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter0_2: counter0_2 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm0_3: tcpwm0_3@52a00300 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a00300 0x100>;
+				interrupts = <79 4>;
+				resolution = <32>;
+				status = "disabled";
+
+				pwm0_3: pwm0_3 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter0_3: counter0_3 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 		};
 
-		counter0_1: counter@52a00100 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a00100 0x100>;
-			interrupts = <77 4>;
-			resolution = <32>;
-			status = "disabled";
+		tcpwm1: tcpwm1@52a10000  {
+			reg = <0x52a10000 0x10000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			tcpwm1_0: tcpwm1_0@52a10000 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a10000 0x100>;
+				interrupts = <80 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_0: pwm1_0 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_0: counter1_0 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_1: tcpwm1_1@52a10100 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a10100 0x100>;
+				interrupts = <81 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_1: pwm1_1 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_1: counter1_1 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_2: tcpwm1_2@52a10200 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a10200 0x100>;
+				interrupts = <82 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_2: pwm1_2 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_2: counter1_2 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_3: tcpwm1_3@52a10300 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a10300 0x100>;
+				interrupts = <83 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_3: pwm1_3 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_3: counter1_3 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_4: tcpwm1_4@52a10400 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a10400 0x100>;
+				interrupts = <84 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_4: pwm1_4 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_4: counter1_4 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_5: tcpwm1_5@52a10500 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a10500 0x100>;
+				interrupts = <85 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_5: pwm1_5 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_5: counter1_5 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_6: tcpwm1_6@52a10600 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a10600 0x100>;
+				interrupts = <86 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_6: pwm1_6 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_6: counter1_6 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
+
+			tcpwm1_7: tcpwm1_7@52a10700 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a10700 0x100>;
+				interrupts = <87 4>;
+				resolution = <16>;
+				status = "disabled";
+
+				pwm1_7: pwm1_7 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
+
+				counter1_7: counter1_7 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 		};
 
-		counter0_2: counter@52a00200 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a00200 0x100>;
-			interrupts = <78 4>;
-			resolution = <32>;
-			status = "disabled";
-		};
+		tcpwm2: tcpwm2@52a20000  {
+			reg = <0x52a20000 0x10000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-		counter0_3: counter@52a00300 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a00300 0x100>;
-			interrupts = <79 4>;
-			resolution = <32>;
-			status = "disabled";
-		};
+			tcpwm2_0: tcpwm2_0@52a20000 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a20000 0x100>;
+				interrupts = <88 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		counter1_0: counter@52a10000 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a10000 0x100>;
-			interrupts = <80 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				pwm2_0: pwm2_0 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		counter1_1: counter@52a10100 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a10100 0x100>;
-			interrupts = <81 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				counter2_0: counter2_0 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		counter1_2: counter@52a10200 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a10200 0x100>;
-			interrupts = <82 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+			tcpwm2_1: tcpwm2_1@52a20100 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a20100 0x100>;
+				interrupts = <89 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		counter1_3: counter@52a10300 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a10300 0x100>;
-			interrupts = <83 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				pwm2_1: pwm2_1 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		counter1_4: counter@52a10400 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a10400 0x100>;
-			interrupts = <84 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				counter2_1: counter2_1 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		counter1_5: counter@52a10500 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a10500 0x100>;
-			interrupts = <85 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+			tcpwm2_2: tcpwm2_2@52a20200 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a20200 0x100>;
+				interrupts = <90 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		counter1_6: counter@52a10600 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a10600 0x100>;
-			interrupts = <86 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				pwm2_2: pwm2_2 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		counter1_7: counter@52a10700 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a10700 0x100>;
-			interrupts = <87 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				counter2_2: counter2_2 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		counter2_0: counter@52a20000 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a20000 0x100>;
-			interrupts = <88 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+			tcpwm2_3: tcpwm2_3@52a20300 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a20300 0x100>;
+				interrupts = <91 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		counter2_1: counter@52a20100 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a20100 0x100>;
-			interrupts = <89 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				pwm2_3: pwm2_3 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		counter2_2: counter@52a20200 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a20200 0x100>;
-			interrupts = <90 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				counter2_3: counter2_3 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		counter2_3: counter@52a20300 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a20300 0x100>;
-			interrupts = <91 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+			tcpwm2_4: tcpwm2_4@52a20400 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a20400 0x100>;
+				interrupts = <92 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		counter2_4: counter@52a20400 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a20400 0x100>;
-			interrupts = <92 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				pwm2_4: pwm2_4 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		counter2_5: counter@52a20500 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a20500 0x100>;
-			interrupts = <93 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				counter2_4: counter2_4 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		counter2_6: counter@52a20600 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a20600 0x100>;
-			interrupts = <94 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+			tcpwm2_5: tcpwm2_5@52a20500 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a20500 0x100>;
+				interrupts = <93 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		counter2_7: counter@52a20700 {
-			compatible = "infineon,cat1-counter";
-			reg = <0x52a20700 0x100>;
-			interrupts = <95 4>;
-			resolution = <16>;
-			status = "disabled";
-		};
+				pwm2_5: pwm2_5 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		pwm0_0: pwm@52a00000 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a00000 0x100>;
-			interrupts = <76 4>;
-			resolution = <32>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
+				counter2_5: counter2_5 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		pwm0_1: pwm@52a00100 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a00100 0x100>;
-			interrupts = <77 4>;
-			resolution = <32>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
+			tcpwm2_6: tcpwm2_6@52a20600 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a20600 0x100>;
+				interrupts = <94 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		pwm0_2: pwm@52a00200 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a00200 0x100>;
-			interrupts = <78 4>;
-			resolution = <32>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
+				pwm2_6: pwm2_6 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		pwm0_3: pwm@52a00300 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a00300 0x100>;
-			interrupts = <79 4>;
-			resolution = <32>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
+				counter2_6: counter2_6 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 
-		pwm1_0: pwm@52a10000 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a10000 0x100>;
-			interrupts = <80 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
+			tcpwm2_7: tcpwm2_7@52a20700 {
+				compatible = "infineon,tcpwm";
+				reg = <0x52a20700 0x100>;
+				interrupts = <95 4>;
+				resolution = <16>;
+				status = "disabled";
 
-		pwm1_1: pwm@52a10100 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a10100 0x100>;
-			interrupts = <81 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
+				pwm2_7: pwm2_7 {
+					compatible = "infineon,tcpwm-pwm";
+					#pwm-cells = <3>;
+					status = "disabled";
+				};
 
-		pwm1_2: pwm@52a10200 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a10200 0x100>;
-			interrupts = <82 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm1_3: pwm@52a10300 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a10300 0x100>;
-			interrupts = <83 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm1_4: pwm@52a10400 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a10400 0x100>;
-			interrupts = <84 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm1_5: pwm@52a10500 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a10500 0x100>;
-			interrupts = <85 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm1_6: pwm@52a10600 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a10600 0x100>;
-			interrupts = <86 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm1_7: pwm@52a10700 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a10700 0x100>;
-			interrupts = <87 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_0: pwm@52a20000 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a20000 0x100>;
-			interrupts = <88 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_1: pwm@52a20100 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a20100 0x100>;
-			interrupts = <89 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_2: pwm@52a20200 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a20200 0x100>;
-			interrupts = <90 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_3: pwm@52a20300 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a20300 0x100>;
-			interrupts = <91 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_4: pwm@52a20400 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a20400 0x100>;
-			interrupts = <92 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_5: pwm@52a20500 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a20500 0x100>;
-			interrupts = <93 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_6: pwm@52a20600 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a20600 0x100>;
-			interrupts = <94 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
-		};
-
-		pwm2_7: pwm@52a20700 {
-			compatible = "infineon,cat1-pwm";
-			reg = <0x52a20700 0x100>;
-			interrupts = <95 4>;
-			resolution = <16>;
-			status = "disabled";
-			#pwm-cells = <3>;
+				counter2_7: counter2_7 {
+					compatible = "infineon,tcpwm-counter";
+					status = "disabled";
+				};
+			};
 		};
 
 		dma0: dw@52180000 {

--- a/dts/bindings/counter/infineon,tcpwm-counter.yaml
+++ b/dts/bindings/counter/infineon,tcpwm-counter.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Infineon TCPWM counter
+
+compatible: "infineon,tcpwm-counter"
+
+include: [base.yaml, "infineon,system-interrupts.yaml"]
+
+properties:
+  clock-frequency:
+    type: int
+    description: |
+      Frequency that the counter runs
+
+  external-trigger-gpios:
+    type: phandle-array
+    description: |
+      External trigger that runs counter
+
+  interrupts:
+    description: Required for non-cat1c devices
+
+  system-interrupts:
+    description: Required for cat1c devices

--- a/dts/bindings/timer/infineon,tcpwm.yaml
+++ b/dts/bindings/timer/infineon,tcpwm.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: Infineon CAT1 TCPWM (Timer/Counter/PWM) node
+description: Infineon TCPWM Timer
 
 compatible: "infineon,tcpwm"
 

--- a/include/zephyr/drivers/timer/ifx_tcpwm.h
+++ b/include/zephyr/drivers/timer/ifx_tcpwm.h
@@ -13,30 +13,23 @@
  * is always 0.
  */
 
-#if !defined(IFX_TCPWM_H)
-#define IFX_TCPWM_H
+#if !defined(ZEPHYR_INCLUDE_DRIVERS_TIMER_IFX_TCPWM_TIMER_H)
+#define ZEPHYR_INCLUDE_DRIVERS_TIMER_IFX_TCPWM_TIMER_H
 
 #include <stdint.h>
 #include "cy_tcpwm.h"
 
-#define IFX_TCPWM_GetTrigPinLevel(ADDRESS, TRIGGERSELECT)                                          \
-	Cy_TCPWM_GetTrigPinLevel((TCPWM_Type *)ADDRESS, 0, TRIGGERSELECT)
-#define IFX_TCPWM_SetDebugFreeze(ADDRESS, ENABLE)                                                  \
-	Cy_TCPWM_SetDebugFreeze((TCPWM_Type *)ADDRESS, 0, ENABLE)
+/** @cond INTERNAL_HIDDEN */
+#define IFX_TCPWM_Block_EnableCompare0Swap(ADDRESS, ENABLE)                                        \
+	Cy_TCPWM_Block_EnableCompare0Swap((TCPWM_Type *)ADDRESS, 0, ENABLE)
+#define IFX_TCPWM_Block_EnableCompare1Swap(ADDRESS, ENABLE)                                        \
+	Cy_TCPWM_Block_EnableCompare1Swap((TCPWM_Type *)ADDRESS, 0, ENABLE)
 #define IFX_TCPWM_Block_GetCC0BufVal(ADDRESS) Cy_TCPWM_Block_GetCC0BufVal((TCPWM_Type *)ADDRESS, 0)
 #define IFX_TCPWM_Block_GetCC0Val(ADDRESS)    Cy_TCPWM_Block_GetCC0Val((TCPWM_Type *)ADDRESS, 0)
 #define IFX_TCPWM_Block_GetCC1BufVal(ADDRESS) Cy_TCPWM_Block_GetCC1BufVal((TCPWM_Type *)ADDRESS, 0)
 #define IFX_TCPWM_Block_GetCC1Val(ADDRESS)    Cy_TCPWM_Block_GetCC1Val((TCPWM_Type *)ADDRESS, 0)
 #define IFX_TCPWM_Block_GetCounter(ADDRESS)   Cy_TCPWM_Block_GetCounter((TCPWM_Type *)ADDRESS, 0)
 #define IFX_TCPWM_Block_GetPeriod(ADDRESS)    Cy_TCPWM_Block_GetPeriod((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_GetInterruptMask(ADDRESS)   Cy_TCPWM_GetInterruptMask((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_GetInterruptStatus(ADDRESS) Cy_TCPWM_GetInterruptStatus((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_GetInterruptStatusMasked(ADDRESS)                                                \
-	Cy_TCPWM_GetInterruptStatusMasked((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_Block_EnableCompare0Swap(ADDRESS, ENABLE)                                        \
-	Cy_TCPWM_Block_EnableCompare0Swap((TCPWM_Type *)ADDRESS, 0, ENABLE)
-#define IFX_TCPWM_Block_EnableCompare1Swap(ADDRESS, ENABLE)                                        \
-	Cy_TCPWM_Block_EnableCompare1Swap((TCPWM_Type *)ADDRESS, 0, ENABLE)
 #define IFX_TCPWM_Block_SetCC0BufVal(ADDRESS, COMPARE1)                                            \
 	Cy_TCPWM_Block_SetCC0BufVal((TCPWM_Type *)ADDRESS, 0, COMPARE1)
 #define IFX_TCPWM_Block_SetCC0Val(ADDRESS, COMPARE0)                                               \
@@ -51,8 +44,16 @@
 	Cy_TCPWM_Block_SetPeriod((TCPWM_Type *)ADDRESS, 0, PERIOD)
 #define IFX_TCPWM_ClearInterrupt(ADDRESS, SOURCE)                                                  \
 	Cy_TCPWM_ClearInterrupt((TCPWM_Type *)ADDRESS, 0, SOURCE)
-#define IFX_TCPWM_Disable_Single(ADDRESS) Cy_TCPWM_Disable_Single((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_Enable_Single(ADDRESS)  Cy_TCPWM_Enable_Single((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_Disable_Single(ADDRESS)     Cy_TCPWM_Disable_Single((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_Enable_Single(ADDRESS)      Cy_TCPWM_Enable_Single((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_GetInterruptMask(ADDRESS)   Cy_TCPWM_GetInterruptMask((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_GetInterruptStatus(ADDRESS) Cy_TCPWM_GetInterruptStatus((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_GetInterruptStatusMasked(ADDRESS)                                                \
+	Cy_TCPWM_GetInterruptStatusMasked((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_GetTrigPinLevel(ADDRESS, TRIGGERSELECT)                                          \
+	Cy_TCPWM_GetTrigPinLevel((TCPWM_Type *)ADDRESS, 0, TRIGGERSELECT)
+#define IFX_TCPWM_SetDebugFreeze(ADDRESS, ENABLE)                                                  \
+	Cy_TCPWM_SetDebugFreeze((TCPWM_Type *)ADDRESS, 0, ENABLE)
 #define IFX_TCPWM_SetInterrupt(ADDRESS, SOURCE)                                                    \
 	Cy_TCPWM_SetInterrupt((TCPWM_Type *)ADDRESS, 0, SOURCE)
 #define IFX_TCPWM_SetInterruptMask(ADDRESS, MASK)                                                  \
@@ -64,6 +65,16 @@
 #define IFX_TCPWM_TriggerStopOrKill_Single(ADDRESS)                                                \
 	Cy_TCPWM_TriggerStopOrKill_Single((TCPWM_Type *)ADDRESS, 0)
 
+#define IFX_TCPWM_Counter_DeInit(ADDRESS, CONFIG)                                                  \
+	Cy_TCPWM_Counter_DeInit((TCPWM_Type *)ADDRESS, 0, CONFIG)
+#define IFX_TCPWM_Counter_Disable(ADDRESS) Cy_TCPWM_Counter_Disable((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_Counter_Enable(ADDRESS)  Cy_TCPWM_Counter_Enable((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_Counter_EnableCompare0Swap(ADDRESS, ENABLE)                                      \
+	Cy_TCPWM_Counter_EnableCompare0Swap((TCPWM_Type *)ADDRESS, 0, ENABLE)
+#define IFX_TCPWM_Counter_EnableCompare1Swap(ADDRESS, ENABLE)                                      \
+	Cy_TCPWM_Counter_EnableCompare1Swap((TCPWM_Type *)ADDRESS, 0, ENABLE)
+#define IFX_TCPWM_Counter_EnableSwap(ADDRESS, ENABLE)                                              \
+	Cy_TCPWM_Counter_EnableSwap((TCPWM_Type *)ADDRESS, 0, ENABLE)
 #define IFX_TCPWM_Counter_GetCapture0BufVal(ADDRESS)                                               \
 	Cy_TCPWM_Counter_GetCapture0BufVal((TCPWM_Type *)ADDRESS, 0)
 #define IFX_TCPWM_Counter_GetCapture0Val(ADDRESS)                                                  \
@@ -83,14 +94,8 @@
 #define IFX_TCPWM_Counter_GetCounter(ADDRESS) Cy_TCPWM_Counter_GetCounter((TCPWM_Type *)ADDRESS, 0)
 #define IFX_TCPWM_Counter_GetPeriod(ADDRESS)  Cy_TCPWM_Counter_GetPeriod((TCPWM_Type *)ADDRESS, 0)
 #define IFX_TCPWM_Counter_GetStatus(ADDRESS)  Cy_TCPWM_Counter_GetStatus((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_Counter_Disable(ADDRESS)    Cy_TCPWM_Counter_Disable((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_Counter_Enable(ADDRESS)     Cy_TCPWM_Counter_Enable((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_Counter_EnableCompare0Swap(ADDRESS, ENABLE)                                      \
-	Cy_TCPWM_Counter_EnableCompare0Swap((TCPWM_Type *)ADDRESS, 0, ENABLE)
-#define IFX_TCPWM_Counter_EnableCompare1Swap(ADDRESS, ENABLE)                                      \
-	Cy_TCPWM_Counter_EnableCompare1Swap((TCPWM_Type *)ADDRESS, 0, ENABLE)
-#define IFX_TCPWM_Counter_EnableSwap(ADDRESS, ENABLE)                                              \
-	Cy_TCPWM_Counter_EnableSwap((TCPWM_Type *)ADDRESS, 0, ENABLE)
+#define IFX_TCPWM_Counter_Init(ADDRESS, CONFIG)                                                    \
+	Cy_TCPWM_Counter_Init((TCPWM_Type *)ADDRESS, 0, CONFIG)
 #define IFX_TCPWM_Counter_SetCompare0BufVal(ADDRESS, COMPARE1)                                     \
 	Cy_TCPWM_Counter_SetCompare0BufVal((TCPWM_Type *)ADDRESS, 0, COMPARE1)
 #define IFX_TCPWM_Counter_SetCompare0Val(ADDRESS, COMPARE0)                                        \
@@ -106,16 +111,8 @@
 #define IFX_TCPWM_Counter_SetPeriod(ADDRESS, PERIOD)                                               \
 	Cy_TCPWM_Counter_SetPeriod((TCPWM_Type *)ADDRESS, 0, PERIOD)
 
-#define IFX_TCPWM_PWM_GetCompare0BufVal(ADDRESS)                                                   \
-	Cy_TCPWM_PWM_GetCompare0BufVal((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_PWM_GetCompare0Val(ADDRESS) Cy_TCPWM_PWM_GetCompare0Val((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_PWM_GetCounter(ADDRESS)     Cy_TCPWM_PWM_GetCounter((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_PWM_GetDtCounter(ADDRESS)   Cy_TCPWM_PWM_GetDtCounter((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_PWM_GetPeriod0(ADDRESS)     Cy_TCPWM_PWM_GetPeriod0((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_PWM_GetPeriod1(ADDRESS)     Cy_TCPWM_PWM_GetPeriod1((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_PWM_GetStatus(ADDRESS)      Cy_TCPWM_PWM_GetStatus((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_PWM_Disable(ADDRESS)        Cy_TCPWM_PWM_Disable((TCPWM_Type *)ADDRESS, 0)
-#define IFX_TCPWM_PWM_Enable(ADDRESS)         Cy_TCPWM_PWM_Enable((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_PWM_Disable(ADDRESS) Cy_TCPWM_PWM_Disable((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_PWM_Enable(ADDRESS)  Cy_TCPWM_PWM_Enable((TCPWM_Type *)ADDRESS, 0)
 #define IFX_TCPWM_PWM_EnableCompare0Swap(ADDRESS, ENABLE)                                          \
 	Cy_TCPWM_PWM_EnableCompare0Swap((TCPWM_Type *)ADDRESS, 0, ENABLE)
 #define IFX_TCPWM_PWM_EnableLineSelectSwap(ADDRESS, ENABLE)                                        \
@@ -124,7 +121,15 @@
 	Cy_TCPWM_PWM_EnablePeriodSwap((TCPWM_Type *)ADDRESS, 0, ENABLE)
 #define IFX_TCPWM_PWM_EnableSwap(ADDRESS, ENABLE)                                                  \
 	Cy_TCPWM_PWM_EnableSwap((TCPWM_Type *)ADDRESS, 0, ENABLE)
-#define IFX_TCPWM_PWM_Init(ADDRESS, CONFIG) Cy_TCPWM_PWM_Init((TCPWM_Type *)ADDRESS, 0, CONFIG)
+#define IFX_TCPWM_PWM_GetCompare0BufVal(ADDRESS)                                                   \
+	Cy_TCPWM_PWM_GetCompare0BufVal((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_PWM_GetCompare0Val(ADDRESS) Cy_TCPWM_PWM_GetCompare0Val((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_PWM_GetCounter(ADDRESS)     Cy_TCPWM_PWM_GetCounter((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_PWM_GetDtCounter(ADDRESS)   Cy_TCPWM_PWM_GetDtCounter((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_PWM_GetPeriod0(ADDRESS)     Cy_TCPWM_PWM_GetPeriod0((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_PWM_GetPeriod1(ADDRESS)     Cy_TCPWM_PWM_GetPeriod1((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_PWM_GetStatus(ADDRESS)      Cy_TCPWM_PWM_GetStatus((TCPWM_Type *)ADDRESS, 0)
+#define IFX_TCPWM_PWM_Init(ADDRESS, CONFIG)   Cy_TCPWM_PWM_Init((TCPWM_Type *)ADDRESS, 0, CONFIG)
 #define IFX_TCPWM_PWM_PWMDeadTime(ADDRESS, DEADTIME)                                               \
 	Cy_TCPWM_PWM_PWMDeadTime((TCPWM_Type *)ADDRESS, 0, DEADTIME)
 #define IFX_TCPWM_PWM_PWMDeadTimeBuff(ADDRESS, DEADTIME)                                           \
@@ -147,9 +152,10 @@
 	Cy_TCPWM_PWM_SetPeriod0((TCPWM_Type *)ADDRESS, 0, PERIOD0)
 #define IFX_TCPWM_PWM_SetPeriod1(ADDRESS, PERIOD1)                                                 \
 	Cy_TCPWM_PWM_SetPeriod1((TCPWM_Type *)ADDRESS, 0, PERIOD1)
+#define IFX_TCPWM_TriggerCaptureOrSwap_Single(ADDRESS)                                             \
+	Cy_TCPWM_TriggerCaptureOrSwap_Single((TCPWM_Type *)ADDRESS, 0)
 #define IFX_en_tcpwm_status_t(ADDRESS, MODE, PERIOD, DUTY, LIMITER)                                \
 	cy_en_tcpwm_status_t Cy_TCPWM_PWM_Configure_Dithering((TCPWM_Type *)ADDRESS, 0, MODE,      \
 							      PERIOD, DUTY, LIMITER)
-#define IFX_TCPWM_TriggerCaptureOrSwap_Single(ADDRESS)                                             \
-	Cy_TCPWM_TriggerCaptureOrSwap_Single((TCPWM_Type *)ADDRESS, 0)
-#endif /* CY_TCPWM_H */
+/** @endcond */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_TIMER_IFX_TCPWM_TIMER_H */

--- a/samples/drivers/counter/alarm/boards/kit_psc3m5_evk.overlay
+++ b/samples/drivers/counter/alarm/boards/kit_psc3m5_evk.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+
+&tcpwm0_0 {
+	status = "okay";
+	divider-type = <PWM_IFX_SYSCLK_DIV_16_BIT>;
+	divider-sel = <0>;
+	divider-val = <2399>;
+
+	counter0_0 {
+		status = "okay";
+		clocks = <&peri0_group4_16bit_0>;
+		clock-frequency = <20000>;
+	};
+};
+
+&peri0_group4_16bit_0 {
+	status = "okay";
+	scb-block = <0>;
+	div-value = <109>;
+};

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -49,7 +49,7 @@ struct counter_alarm_cfg alarm_cfg;
 #define TIMER DT_NODELABEL(rtcc0)
 #elif defined(CONFIG_COUNTER_GECKO_STIMER)
 #define TIMER DT_NODELABEL(stimer0)
-#elif defined(CONFIG_COUNTER_INFINEON_CAT1)
+#elif defined(CONFIG_COUNTER_INFINEON_CAT1) || defined(CONFIG_COUNTER_INFINEON_TCPWM)
 #define TIMER DT_NODELABEL(counter0_0)
 #elif defined(CONFIG_COUNTER_AMBIQ)
 #ifdef TIMER

--- a/tests/drivers/counter/counter_basic_api/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/kit_psc3m5_evk.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+
+&tcpwm0_0 {
+	status = "okay";
+	divider-type = <PWM_IFX_SYSCLK_DIV_16_BIT>;
+	divider-sel = <0>;
+	divider-val = <2399>;
+
+	counter0_0 {
+		status = "okay";
+		clocks = <&peri0_group4_16bit_0>;
+		clock-frequency = <20000>;
+	};
+};
+
+&peri0_group4_16bit_0 {
+	status = "okay";
+	scb-block = <0>;
+	div-value = <109>;
+};

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -147,6 +147,9 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_RENESAS_RZ_CMTW
 	DEVS_FOR_DT_COMPAT(renesas_rz_cmtw_counter)
 #endif
+#ifdef CONFIG_COUNTER_INFINEON_TCPWM
+	DEVS_FOR_DT_COMPAT(infineon_tcpwm_counter)
+#endif
 };
 
 static const struct device *const period_devs[] = {


### PR DESCRIPTION
Add psc3m5 counter driver:

- Add a new counter driver implementation based on the PDL for
  Infineon CAT1B devices. This enables support for hardware
  counters on the PSC3M5 platform.
- Add IFX_TCPWM_Counter_DeInit and IFX_TCPWM_Counter_Init
  macros to include/zephyr/drivers/timer/ifx_tcpwm.h
  and sort all of the macros in that file
- Enable the alarm sample for the kit_psc3m5_evk
