### PR TITLE
boards: beagle: pocketbeagle_2: mspm0l1105: Test UART

### DIFF
--- a/boards/beagle/pocketbeagle_2/doc/index.rst
+++ b/boards/beagle/pocketbeagle_2/doc/index.rst
@@ -160,6 +160,9 @@ MSPM0L1105
    Flashing new firmware will also clear the EEPROM contents. So please make backup of EEPROM data
    before attempting to flash firmware to MSPM0L1105.
 
+.. note::
+   Zephyr by default uses P1.19 and P1.21 as UART RX and TX respectively.
+
 To test the A53 cores, we build the :zephyr:code-sample:`minimal` sample with the following command.
 
 .. zephyr-app-commands::

--- a/boards/beagle/pocketbeagle_2/doc/index.rst
+++ b/boards/beagle/pocketbeagle_2/doc/index.rst
@@ -163,7 +163,7 @@ MSPM0L1105
 .. note::
    Zephyr by default uses P1.19 and P1.21 as UART RX and TX respectively.
 
-To test the A53 cores, we build the :zephyr:code-sample:`minimal` sample with the following command.
+To test the MSPM0L1105, we build the :zephyr:code-sample:`minimal` sample with the following command.
 
 .. zephyr-app-commands::
    :board: pocketbeagle_2/mspm0l1105

--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_mspm0l1105.dts
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_mspm0l1105.dts
@@ -2,11 +2,25 @@
  * Copyright (c) 2025 Ayush Singh, BeagleBoard.org Foundation
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * Here is a table of pins in PocketBeagle 2 header which can be driven by MSPM0L1105
+ *
+ * | MSPM0L1105 Pin | Header Pin |
+ * |++++++++++++++++|++++++++++++|
+ * | PA15           | P2.36      |
+ * | PA16           | P1.02      |
+ * | PA20           | P2.35      |
+ * | PA21           | P1.27      |
+ * | PA22           | P1.25      |
+ * | PA24           | P1.23      |
+ * | PA25           | P1.21      |
+ * | PA26           | P1.19      |
  */
 
 /dts-v1/;
 
 #include <ti/mspm0/l/mspm0l1105.dtsi>
+#include <ti/mspm0/l/mspm0l110x-pinctrl.dtsi>
 
 / {
 	model = "BeagleBoard.org PocketBeagle 2";

--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_mspm0l1105.dts
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_mspm0l1105.dts
@@ -29,6 +29,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,console = &uart0;
 	};
 };
 
@@ -38,4 +39,10 @@
 
 &pinctrl {
 	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_rx_pa26 &uart0_tx_pa25>;
 };

--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_mspm0l1105_defconfig
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_mspm0l1105_defconfig
@@ -5,3 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_CLOCK_CONTROL=y
+
+# Enable Console
+CONFIG_SERIAL=y
+CONFIG_UART_CONSOLE=y


### PR DESCRIPTION
- Add overlay conf in hello_world example.
- Normally, these pins operate as Analog inputs, so UART should not be  enabled by default. However, it can be useful during development, or if  someone wants to create some special purpose firmware.
