### PR TITLE
mgmt: mcumgr: grp: settings_mgmt: Add capability to save setting by key

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt.h
@@ -55,6 +55,9 @@ enum settings_mgmt_ret_code_t {
 
 	/** The provided key name does not support being deleted. */
 	SETTINGS_MGMT_ERR_DELETE_NOT_SUPPORTED,
+
+	/** The provided key name does not support being saved. */
+	SETTINGS_MGMT_ERR_SAVE_NOT_SUPPORTED,
 };
 
 #ifdef __cplusplus

--- a/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt_callbacks.h
@@ -44,11 +44,11 @@ struct settings_mgmt_access {
 	enum settings_mgmt_access_types access;
 
 	/**
-	 * Key name for accesses (only set for #SETTINGS_ACCESS_READ, #SETTINGS_ACCESS_WRITE and
-	 * #SETTINGS_ACCESS_DELETE). Note that this can be changed by handlers to redirect settings
-	 * access if needed (as long as it does not exceed the maximum setting string size) if
-	 * CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_STACK is selected, of maximum size
-	 * CONFIG_MCUMGR_GRP_SETTINGS_NAME_LEN.
+	 * Key name for accesses (only set for #SETTINGS_ACCESS_READ, #SETTINGS_ACCESS_WRITE,
+	 * #SETTINGS_ACCESS_DELETE and #SETTINGS_ACCESS_SAVE). Note that this can be changed by
+	 * handlers to redirect settings access if needed (as long as it does not exceed the maximum
+	 * setting string size) if CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_STACK is selected, of
+	 * maximum size CONFIG_MCUMGR_GRP_SETTINGS_NAME_LEN.
 	 *
 	 * Note: This string *must* be NULL terminated.
 	 */
@@ -58,10 +58,15 @@ struct settings_mgmt_access {
 	char *name;
 #endif
 
-	/** Data provided by the user (only set for SETTINGS_ACCESS_WRITE) */
+	/**
+	 * Data provided by the user (only set for SETTINGS_ACCESS_WRITE and SETTINGS_ACCESS_SAVE)
+	 */
 	const uint8_t *val;
 
-	/** Length of data provided by the user (only set for SETTINGS_ACCESS_WRITE) */
+	/**
+	 * Length of data provided by the user (only set for SETTINGS_ACCESS_WRITE and
+	 * SETTINGS_ACCESS_SAVE)
+	 */
 	const size_t *val_length;
 };
 

--- a/subsys/mgmt/mcumgr/grp/settings_mgmt/src/settings_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/settings_mgmt/src/settings_mgmt.c
@@ -433,15 +433,76 @@ end:
  */
 static int settings_mgmt_save(struct smp_streamer *ctxt)
 {
+	int rc;
+	zcbor_state_t *zse = ctxt->writer->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	bool ok = true;
+	struct zcbor_string data = {0};
+	size_t decoded;
+	struct zcbor_string key = {0};
+	bool name_found = false;
+	bool val_found = false;
+	bool save_subtree = false;
+	bool save_one = false;
+
+#ifdef CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_HEAP
+	char *key_name = NULL;
+#else
+	char key_name[CONFIG_MCUMGR_GRP_SETTINGS_NAME_LEN];
+#endif
+
+	struct zcbor_map_decode_key_val settings_save_decode[] = {
+		ZCBOR_MAP_DECODE_KEY_DECODER("name", zcbor_tstr_decode, &key),
+		ZCBOR_MAP_DECODE_KEY_DECODER("val", zcbor_bstr_decode, &data),
+	};
+
+	ok = zcbor_map_decode_bulk(zsd, settings_save_decode, ARRAY_SIZE(settings_save_decode),
+				   &decoded) == 0;
+
+	if (!ok) {
+		return MGMT_ERR_EINVAL;
+	}
+
+	name_found = zcbor_map_decode_bulk_key_found(settings_save_decode,
+						     ARRAY_SIZE(settings_save_decode), "name");
+	val_found = zcbor_map_decode_bulk_key_found(settings_save_decode,
+						    ARRAY_SIZE(settings_save_decode), "val");
+
+	if ((name_found && key.len == 0) || (val_found && data.len == 0)) {
+		return MGMT_ERR_EINVAL;
+	} else if (name_found && val_found) {
+		save_one = true;
+	} else if (name_found) {
+		save_subtree = true;
+	}
+
+	if (save_one || save_subtree) {
+		if (key.len >= CONFIG_MCUMGR_GRP_SETTINGS_NAME_LEN) {
+			ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_SETTINGS,
+					     SETTINGS_MGMT_ERR_KEY_TOO_LONG);
+			goto end;
+		}
+
+#ifdef CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_HEAP
+		key_name = (char *)malloc(key.len + 1);
+
+		if (key_name == NULL) {
+			return MGMT_ERR_ENOMEM;
+		}
+#endif
+		memcpy(key_name, key.value, key.len);
+		key_name[key.len] = 0;
+	}
 
 	if (IS_ENABLED(CONFIG_MCUMGR_GRP_SETTINGS_ACCESS_HOOK)) {
 		/* Send request to application to check if access should be allowed or not */
 		struct settings_mgmt_access settings_access_data = {
 			.access = SETTINGS_ACCESS_SAVE,
+			.name = name_found ? key_name : NULL,
+			.val = val_found ? data.value : NULL,
+			.val_length = val_found ? &data.len : NULL,
 		};
 
-		zcbor_state_t *zse = ctxt->writer->zs;
 		enum mgmt_cb_return status;
 		int32_t ret_rc;
 		uint16_t ret_group;
@@ -452,6 +513,9 @@ static int settings_mgmt_save(struct smp_streamer *ctxt)
 
 		if (status != MGMT_CB_OK) {
 			if (status == MGMT_CB_ERROR_RC) {
+#ifdef CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_HEAP
+				free(key_name);
+#endif
 				return ret_rc;
 			}
 
@@ -460,9 +524,33 @@ static int settings_mgmt_save(struct smp_streamer *ctxt)
 		}
 	}
 
-	settings_save();
+	if (save_one) {
+		rc = settings_save_one(key_name, data.value, data.len);
+	} else if (save_subtree) {
+		rc = settings_save_subtree(key_name);
+	} else {
+		rc = settings_save();
+	}
+
+	if (rc != 0) {
+		switch (rc) {
+		case -ENOENT:
+		case -ENOTSUP:
+			rc = SETTINGS_MGMT_ERR_SAVE_NOT_SUPPORTED;
+			break;
+		default:
+			rc = SETTINGS_MGMT_ERR_UNKNOWN;
+			break;
+		}
+
+		ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_SETTINGS, (uint16_t)rc);
+	}
 
 end:
+#ifdef CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_HEAP
+	free(key_name);
+#endif
+
 	return MGMT_RETURN_CHECK(ok);
 }
 


### PR DESCRIPTION
Extend the save command to allow passing name/val pair to save an individual setting to persistent storage.
Resolves zephyrproject-rtos#90407
Fixes #96000