### PR TITLE
cmake: clang: set no_track_macro_expansion properly

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -137,6 +137,9 @@ set_compiler_property(PROPERTY linker_script -Wl,-T)
 # clang flag for colourful diagnostic messages
 set_compiler_property(PROPERTY diagnostic -fcolor-diagnostics)
 
+# clang flag to disable macro backtrace in diagnostics (can't fully disable it, so limit to 1)
+set_compiler_property(PROPERTY no_track_macro_expansion "-fmacro-backtrace-limit=1")
+
 set_compiler_property(PROPERTY no_global_merge "-mno-global-merge")
 
 set_compiler_property(PROPERTY specs)


### PR DESCRIPTION
Compiler property `no_track_macro_expansion` is controlled by `CONFIG_COMPILER_TRACK_MACRO_EXPANSION`.
When that Kconfig is set to Y, clang fails with the following error message (due to clang inheriting all properties from gcc)

```
   unknown argument: '-ftrack-macro-expansion=0'
```

This commit modifies clang/compiler_flags.cmake so that there is a proper clang compiler option for this flag.