### PR TITLE
dts: arm: ti: mspm0: l110x: Add uart1

### DIFF
--- a/dts/arm/ti/mspm0/l/mspm0l110x.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l110x.dtsi
@@ -13,5 +13,15 @@
 		sram0: memory@20000000 {
 			reg = <0x20000000 DT_SIZE_K(4)>;
 		};
+
+		uart1: uart@40100000 {
+			compatible = "ti,mspm0-uart";
+			reg = <0x40100000 0x2000>;
+			interrupts = <13 0>;
+			current-speed = <115200>;
+			clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+			clk-div = <1>;
+			status = "disabled";
+		};
 	};
 };


### PR DESCRIPTION
- MSPM0L110x series SOC contain 2 UARTS. So add UART1.
- While all MSPM0L series SOC contain at least 2 UARTs, the address for UART1 seems to be different in L222x and L122x (0x4010A000).