### PR TITLE
shell: Allow the MCUMgr shell transport to receive the full SMP frame

### DIFF
--- a/doc/services/device_mgmt/smp_transport.rst
+++ b/doc/services/device_mgmt/smp_transport.rst
@@ -25,7 +25,7 @@ If an SMP request or response is too large to fit in a single GATT command, the
 sender fragments it across several packets.  No additional framing is
 introduced when a request or response is fragmented; the payload is simply
 split among several packets. Since GATT guarantees ordered delivery of
-packets, the SMP header in the first fragment contains sufficient information
+packets, the SMP header in the first frame contains sufficient information
 for reassembly.
 
 .. _mcumgr_smp_transport_uart:

--- a/doc/services/device_mgmt/smp_transport.rst
+++ b/doc/services/device_mgmt/smp_transport.rst
@@ -36,10 +36,6 @@ UART/serial and console
 SMP protocol specification by MCUmgr subsystem of Zephyr uses basic framing
 of data to allow multiplexing of UART channel. Multiplexing requires
 prefixing each frame with two byte marker and terminating it with newline.
-Currently MCUmgr imposes a 127 byte limit on frame size, although there
-are no real protocol constraints that require that limit.
-The limit includes the prefix and the newline character, so the allowed payload
-size is actually 124 bytes.
 
 Although no such transport exists in Zephyr, it is possible to implement
 MCUmgr client/server over UART transport that does not have framing at all,

--- a/include/zephyr/mgmt/mcumgr/transport/smp_shell.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp_shell.h
@@ -26,7 +26,6 @@
 extern "C" {
 #endif
 
-#define SMP_SHELL_RX_BUF_SIZE	127
 
 /** @brief Data used by SMP shell */
 struct smp_shell_data {

--- a/subsys/mgmt/mcumgr/grp/shell_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/shell_mgmt/Kconfig
@@ -24,7 +24,7 @@ menuconfig MCUMGR_GRP_SHELL
 	  physical interfaces outside of the scope of the user.
 	  It is possible to use additional shell backends in coordination
 	  with this handler and they will not interfere.
-	  The MCUMGR_GRP_SHELL_BACKEND_DUMMY_BUF_SIZE will affect how many characters
+	  The SHELL_BACKEND_DUMMY_BUF_SIZE will affect how many characters
 	  will be returned from command output, if your output gets cut, then
 	  increase the value. Remember to set MCUMGR_TRANSPORT_NETBUF_SIZE accordingly.
 	  Note that maximum length of shell command accepted is regulated by

--- a/subsys/mgmt/mcumgr/transport/Kconfig
+++ b/subsys/mgmt/mcumgr/transport/Kconfig
@@ -45,8 +45,8 @@ config MCUMGR_TRANSPORT_NETBUF_SIZE
 	  The size, in bytes, of each mcumgr buffer.  This value must satisfy
 	  the following relation:
 	  MCUMGR_TRANSPORT_NETBUF_SIZE >= transport-specific-MTU + transport-overhead
-	  In case when MCUMGR_TRANSPORT_SHELL is enabled this value should be set to
-	  at least MCUMGR_GRP_SHELL_BACKEND_DUMMY_BUF_SIZE + 32.
+	  In case when MCUMGR_GRP_SHELL is enabled this value should be set to
+	  at least SHELL_BACKEND_DUMMY_BUF_SIZE + 32.
 
 config MCUMGR_TRANSPORT_NETBUF_MIN_USER_DATA_SIZE
 	int

--- a/subsys/mgmt/mcumgr/transport/Kconfig.shell
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.shell
@@ -32,7 +32,7 @@ config MCUMGR_TRANSPORT_SHELL_RX_BUF_COUNT
 	int "Shell SMP RX buffer count"
 	default 2
 	help
-	  Number of buffers used for receiving SMP fragments over shell.
+	  Number of buffers used for receiving SMP frames over shell.
 
 config MCUMGR_TRANSPORT_SHELL_INPUT_TIMEOUT
 	bool "Shell input expiration"

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -25,7 +25,7 @@ LOG_MODULE_REGISTER(shell_uart);
 
 #ifdef CONFIG_MCUMGR_TRANSPORT_SHELL
 NET_BUF_POOL_DEFINE(smp_shell_rx_pool, CONFIG_MCUMGR_TRANSPORT_SHELL_RX_BUF_COUNT,
-		    SMP_SHELL_RX_BUF_SIZE, 0, NULL);
+		    CONFIG_MCUMGR_TRANSPORT_SHELL_MTU, 0, NULL);
 #endif /* CONFIG_MCUMGR_TRANSPORT_SHELL */
 
 static void async_callback(const struct device *dev, struct uart_event *evt, void *user_data)


### PR DESCRIPTION
Allow the MCUMgr shell to receive the full SMP frame instead of being
limited by a completely artificial 127 byte limit.

Update documentation:

Remove documentation of the 127 byte limit for serial.
This limit does not apply to UART or serial devices, and only applied
to the shell transport until now.

Fix reference to the non-existent config for dummy shell buffer size.
The documentation about the SHELL_BACKEND_DUMMY_BUF_SIZE + 32 bytes when
shell transport is enabled makes no sense, so this has to be when the
shell management group is enabled.

Use correct terminology for SMP frames.