### PR TITLE
scripts: west_commands: fix typo in west sdk install help message

### DIFF
--- a/scripts/west_commands/sdk.py
+++ b/scripts/west_commands/sdk.py
@@ -138,7 +138,7 @@ class Sdk(WestCommand):
             help="SDK install destination directory. "
             "The SDK will be installed on the specified path. "
             "The directory contained in the archive will be renamed and installed for the specified directory. "
-            "For example, if you specify -b /foo/bar/baz, The archive's zephyr-sdk-<version> directory will be renamed baz and placed under /foo/bar. "
+            "For example, if you specify -d /foo/bar/baz, The archive's zephyr-sdk-<version> directory will be renamed baz and placed under /foo/bar. "
             "If this option is specified, the --install-base option is ignored. "
         )
         install_args_parser.add_argument(


### PR DESCRIPTION
The help message for the option '-d'/'--instal-dir' of 'west sdk install' incorrectly use '-b' in its help message.
Fix the typo by using '-d'.