### PR TITLE
dts: nrf54h20: Add zephyr,pm-device-runtime-auto; to uart instances

### DIFF
--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -733,6 +733,7 @@
 				power-domains = <&gdpwr_fast_active_1>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi121: spi@8e7000 {
@@ -1141,6 +1142,7 @@
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			i2c131: i2c@9a6000 {
@@ -1276,6 +1278,7 @@
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			i2c133: i2c@9b6000 {
@@ -1322,6 +1325,7 @@
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			dppic135: dppic@9c1000 {
@@ -1410,6 +1414,7 @@
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			i2c135: i2c@9c6000 {
@@ -1456,6 +1461,7 @@
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			dppic136: dppic@9d1000 {
@@ -1591,6 +1597,7 @@
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			tdm130: tdm@992000 {


### PR DESCRIPTION
The uart driver for nRF54h20 doesn't call pm_device_runtime_enable(). During an uart driver init `pm_device_driver_init()` return early, because the `pm_device_is_powered()` returns `false`. Power domains, where uarts are instantiated, are disabled: `pm->domain->pm_base->state` is not equal to `PM_DEVICE_STATE_ACTIVE`.

At the end of the day, an uart instance is left disabled.

This is a workaround to make the uart usable when CONFIG_PM, CONFIG_PM_DEVICE and CONFIG_PM_DEVICE_RUNTIME are enabled.