### PR TITLE
lib: os: clock: Fix possibly unitialized variable warning

### DIFF
--- a/lib/os/clock.c
+++ b/lib/os/clock.c
@@ -158,7 +158,7 @@ int z_impl_sys_clock_nanosleep(int clock_id, int flags, const struct timespec *r
 {
 	k_timepoint_t end;
 	k_timeout_t timeout;
-	struct timespec duration;
+	struct timespec duration = {0, 0};
 	const bool update_rmtp = rmtp != NULL;
 	const bool abstime = (flags & SYS_TIMER_ABSTIME) != 0;
 


### PR DESCRIPTION
When building with high optimization level, the compiler thinks duration may be used uninitialized and warns as much.

Let's initialize this variable always to ensure it does not happen and with it pacify the compiler.

To repro:
`build$ cmake -GNinja -DBOARD=nrf54l15dk/nrf54l15/cpuapp ../samples/hello_world/ '-DCONFIG_COMPILER_OPT="-O3"' && ninja`
w SDK 0.17.4

And the warning without this fix:
```
    inlined from 'z_impl_sys_clock_nanosleep' at zephyr/lib/os/clock.c:176:9:
zephyr/include/zephyr/sys/timeutil.h:564:12: warning: 'duration.tv_sec' may be used uninitialized [-Wmaybe-uninitialized]
  564 |         if (ts->tv_sec == SYS_TIME_T_MIN) {
      |            ^
zephyr/lib/os/clock.c: In function 'z_impl_sys_clock_nanosleep':
zephyr/lib/os/clock.c:161:25: note: 'duration.tv_sec' was declared here
  161 |         struct timespec duration;
      |                         ^~~~~~~~
In function 'timespec_add',
    inlined from 'z_impl_sys_clock_nanosleep' at zephyr/lib/os/clock.c:177:9:
zephyr/include/zephyr/sys/timeutil.h:534:20: warning: 'duration.tv_nsec' may be used uninitialized [-Wmaybe-uninitialized]
  534 |         a->tv_nsec += b->tv_nsec;
      |                    ^~
zephyr/lib/os/clock.c: In function 'z_impl_sys_clock_nanosleep':
zephyr/lib/os/clock.c:161:25: note: 'duration.tv_nsec' was declared here
  161 |         struct timespec duration;
      |                         ^~~~~~~~
```
