### PR TITLE
script: logging: fix formatting of dropped messages

### DIFF
--- a/scripts/logging/dictionary/dictionary_parser/log_parser_v1.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_parser_v1.py
@@ -366,7 +366,7 @@ class LogParserV1(LogParser):
                 return False, offset
             offset += struct.calcsize(self.fmt_msg_type)
 
-            num_dropped = struct.unpack_from(self.fmt_dropped_cnt, logdata, offset)
+            num_dropped = struct.unpack_from(self.fmt_dropped_cnt, logdata, offset)[0]
             offset += struct.calcsize(self.fmt_dropped_cnt)
 
             print(f"--- {num_dropped} messages dropped ---")

--- a/scripts/logging/dictionary/dictionary_parser/log_parser_v3.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_parser_v3.py
@@ -378,7 +378,7 @@ class LogParserV3(LogParser):
 
             offset += struct.calcsize(self.fmt_msg_type)
 
-            num_dropped = struct.unpack_from(self.fmt_dropped_cnt, logdata, offset)
+            num_dropped = struct.unpack_from(self.fmt_dropped_cnt, logdata, offset)[0]
             offset += struct.calcsize(self.fmt_dropped_cnt)
 
             print(f"--- {num_dropped} messages dropped ---")


### PR DESCRIPTION
Before: `--- (2,) messages dropped ---`
After: `--- 2 messages dropped ---`

struct.unpack_from always returns a tuple, even if there's a single element. Print the value instead of the tuple.

