### PR TITLE
tests: kernel: fix issue with stack overflow detection

### DIFF
--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -415,11 +415,17 @@ ZTEST(fatal_exception, test_fatal)
 
 #ifdef CONFIG_USERSPACE
 
+	/* on arc, this fails with an MPU error instead of a stack
+	 * overflow because the priv stack is merged into the defined
+	 * stack.
+	 */
+#if !defined(CONFIG_ARC)
 	TC_PRINT("test stack HW-based overflow - user 1\n");
 	check_stack_overflow(stack_hw_overflow, K_USER);
 
 	TC_PRINT("test stack HW-based overflow - user 2\n");
 	check_stack_overflow(stack_hw_overflow, K_USER);
+#endif
 
 	TC_PRINT("test stack HW-based overflow - user priv stack 1\n");
 	check_stack_overflow(user_priv_stack_hw_overflow, K_USER);


### PR DESCRIPTION
on arc, the test fails with an MPU error instead of a stack
overflow because the priv stack is merged into the defined
stack.

Fixes #68682

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
