### PR TITLE
nRF NFCT align to SoC variations

### DIFF
--- a/dts/bindings/net/wireless/nordic,nrf-nfct-nrf54h.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf-nfct-nrf54h.yaml
@@ -3,7 +3,7 @@
 
 description: Nordic nRF family NFCT (Near Field Communication Tag)
 
-compatible: "nordic,nrf-nfct-v2"
+compatible: "nordic,nrf54h-nfct"
 
 include: nordic,nrf-nfct.yaml
 

--- a/dts/bindings/net/wireless/nordic,nrf-nfct-nrf54l.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf-nfct-nrf54l.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nordic nRF family NFCT (Near Field Communication Tag)
+
+compatible: "nordic,nrf54l-nfct"
+
+include: nordic,nrf-nfct.yaml
+
+properties:
+  nfct-pins-as-gpios:
+    type: boolean
+    description: |
+      When enabled this property will configure pins dedicated to NFCT
+      peripheral as regular GPIOs.
+
+      NFC pins in nRF54L series: P1.02 and P1.03

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -1006,7 +1006,7 @@
 			};
 
 			nfct: nfct@985000 {
-				compatible = "nordic,nrf-nfct-v2";
+				compatible = "nordic,nrf54h-nfct";
 				reg = <0x985000 0x1000>;
 				status = "disabled";
 				interrupts = <389 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -516,7 +516,7 @@
 			};
 
 			nfct: nfct@d6000 {
-				compatible = "nordic,nrf-nfct";
+				compatible = "nordic,nrf54l-nfct";
 				reg = <0xd6000 0x1000>;
 				interrupts = <214 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";

--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -168,17 +168,27 @@ endif()
 
 dt_nodelabel(uicr_path NODELABEL "uicr")
 if(DEFINED uicr_path)
-  dt_prop(nfct_pins_as_gpios PATH ${uicr_path} PROPERTY "nfct-pins-as-gpios")
-  if(${nfct_pins_as_gpios})
-    zephyr_library_compile_definitions(
-      NRF_CONFIG_NFCT_PINS_AS_GPIOS
-    )
+  dt_prop(uicr_nfct_pins_as_gpios PATH ${uicr_path} PROPERTY "nfct-pins-as-gpios")
+  if(${uicr_nfct_pins_as_gpios})
+    set(nfct_pins_as_gpios True)
   endif()
-
   dt_prop(gpio_as_nreset PATH ${uicr_path} PROPERTY "gpio-as-nreset")
-  if(${gpio_as_nreset})
-    zephyr_library_compile_definitions(CONFIG_GPIO_AS_PINRESET)
+endif()
+
+dt_nodelabel(nfct_path NODELABEL "nfct")
+if(DEFINED nfct_path)
+  dt_prop(nfct_nfct_pins_as_gpios PATH ${nfct_path} PROPERTY "nfct-pins-as-gpios")
+  if(${nfct_nfct_pins_as_gpios})
+    set(nfct_pins_as_gpios True)
   endif()
+endif()
+
+if(${nfct_pins_as_gpios})
+  zephyr_library_compile_definitions(NRF_CONFIG_NFCT_PINS_AS_GPIOS)
+endif()
+
+if(${gpio_as_nreset})
+  zephyr_library_compile_definitions(CONFIG_GPIO_AS_PINRESET)
 endif()
 
 if(CONFIG_SOC_NRF54L_CPUAPP_COMMON)


### PR DESCRIPTION
the NFCT HW varies slightly between nRF SoC series, update devicetree bindings and nordic HAL to reflect this. Previously this was handled with a -v2 in one binding, now there are three bindings, one common, one for nrf54l, one for nrf54h