### PR TITLE
sd: evaluate constants first

### DIFF
--- a/subsys/sd/sd.c
+++ b/subsys/sd/sd.c
@@ -111,8 +111,7 @@ static int sd_common_init(struct sd_card *card)
 		LOG_ERR("Card error on CMD8");
 		return ret;
 	}
-	if (card->host_props.is_spi &&
-		IS_ENABLED(CONFIG_SDHC_SUPPORTS_SPI_MODE)) {
+	if (IS_ENABLED(CONFIG_SDHC_SUPPORTS_SPI_MODE) && card->host_props.is_spi) {
 		/* Enable CRC for spi commands using CMD59 */
 		ret = sd_enable_crc(card);
 	}

--- a/subsys/sd/sdio.c
+++ b/subsys/sd/sdio.c
@@ -589,10 +589,10 @@ int sdio_card_init(struct sd_card *card)
 		 * If card and host support 1.8V, perform voltage switch sequence now.
 		 * note that we skip this switch if the UHS protocol is not enabled.
 		 */
-		if ((card->flags & SD_1800MV_FLAG) &&
-			(!card->host_props.is_spi) &&
-			(card->host_props.host_caps.vol_180_support) &&
-			IS_ENABLED(CONFIG_SD_UHS_PROTOCOL)) {
+		if (IS_ENABLED(CONFIG_SD_UHS_PROTOCOL) &&
+		    (card->flags & SD_1800MV_FLAG) &&
+		    (!card->host_props.is_spi) &&
+		    (card->host_props.host_caps.vol_180_support)) {
 			ret = sdmmc_switch_voltage(card);
 			if (ret) {
 				/* Disable host support for 1.8 V */

--- a/subsys/sd/sdmmc.c
+++ b/subsys/sd/sdmmc.c
@@ -366,8 +366,8 @@ static inline void sdmmc_select_bus_speed(struct sd_card *card)
 	 * Note that function support is defined using bitfields, but function
 	 * selection is defined using values 0x0-0xF.
 	 */
-	if ((card->flags & SD_1800MV_FLAG) && sdmmc_host_uhs(&card->host_props) &&
-	    !(card->host_props.is_spi) && IS_ENABLED(CONFIG_SD_UHS_PROTOCOL)) {
+	if (IS_ENABLED(CONFIG_SD_UHS_PROTOCOL) && (card->flags & SD_1800MV_FLAG) &&
+	    sdmmc_host_uhs(&card->host_props) && !(card->host_props.is_spi)) {
 		/* Select UHS mode timing */
 		if (card->host_props.host_caps.sdr104_support &&
 		    (card->switch_caps.bus_speed & UHS_SDR104_BUS_SPEED)) {
@@ -466,8 +466,8 @@ static int sdmmc_set_bus_speed(struct sd_card *card)
 	 * was calculated within sdmmc_read_switch(), we can safely use the
 	 * minimum between that clock and the host's highest clock supported.
 	 */
-	if ((card->flags & SD_1800MV_FLAG) && sdmmc_host_uhs(&card->host_props) &&
-	    !(card->host_props.is_spi) && IS_ENABLED(CONFIG_SD_UHS_PROTOCOL)) {
+	if (IS_ENABLED(CONFIG_SD_UHS_PROTOCOL) && (card->flags & SD_1800MV_FLAG) &&
+	    sdmmc_host_uhs(&card->host_props) && !(card->host_props.is_spi)) {
 		/* UHS mode */
 		card_clock = MIN(card->host_props.f_max, card->switch_caps.uhs_max_dtr);
 		switch (card->card_speed) {
@@ -612,7 +612,7 @@ int sdmmc_card_init(struct sd_card *card)
 	uint32_t ocr_arg = 0U;
 
 	/* First send a probing OCR */
-	if (card->host_props.is_spi && IS_ENABLED(CONFIG_SDHC_SUPPORTS_SPI_MODE)) {
+	if (IS_ENABLED(CONFIG_SDHC_SUPPORTS_SPI_MODE) && card->host_props.is_spi) {
 		/* Probe SPI card with CMD58*/
 		ret = sdmmc_spi_send_ocr(card, ocr_arg);
 	} else if (IS_ENABLED(CONFIG_SDHC_SUPPORTS_NATIVE_MODE)) {
@@ -655,7 +655,7 @@ int sdmmc_card_init(struct sd_card *card)
 		LOG_ERR("Failed to query card OCR");
 		return ret;
 	}
-	if (card->host_props.is_spi && IS_ENABLED(CONFIG_SDHC_SUPPORTS_SPI_MODE)) {
+	if (IS_ENABLED(CONFIG_SDHC_SUPPORTS_SPI_MODE) && card->host_props.is_spi) {
 		/* Send second CMD58 to get CCS bit */
 		ret = sdmmc_spi_send_ocr(card, ocr_arg);
 		if (ret) {
@@ -679,8 +679,8 @@ int sdmmc_card_init(struct sd_card *card)
 	 * switch to new signal voltage using "signal voltage switch procedure"
 	 * described in SD specification
 	 */
-	if ((card->flags & SD_1800MV_FLAG) && (card->host_props.host_caps.vol_180_support) &&
-	    (!card->host_props.is_spi) && IS_ENABLED(CONFIG_SD_UHS_PROTOCOL)) {
+	if (IS_ENABLED(CONFIG_SD_UHS_PROTOCOL) && (card->flags & SD_1800MV_FLAG) &&
+	    (card->host_props.host_caps.vol_180_support) && (!card->host_props.is_spi)) {
 		ret = sdmmc_switch_voltage(card);
 		if (ret) {
 			/* Disable host support for 1.8 V */
@@ -699,7 +699,7 @@ int sdmmc_card_init(struct sd_card *card)
 	if (ret) {
 		return ret;
 	}
-	if (!card->host_props.is_spi && IS_ENABLED(CONFIG_SDHC_SUPPORTS_NATIVE_MODE)) {
+	if (IS_ENABLED(CONFIG_SDHC_SUPPORTS_NATIVE_MODE) && !card->host_props.is_spi) {
 		/*
 		 * Request new relative card address. This moves the card from
 		 * identification mode to data transfer mode
@@ -714,7 +714,7 @@ int sdmmc_card_init(struct sd_card *card)
 	if (ret) {
 		return ret;
 	}
-	if (!card->host_props.is_spi && IS_ENABLED(CONFIG_SDHC_SUPPORTS_NATIVE_MODE)) {
+	if (IS_ENABLED(CONFIG_SDHC_SUPPORTS_NATIVE_MODE) && !card->host_props.is_spi) {
 		/* Move the card to transfer state (with CMD7) to run remaining commands */
 		ret = sdmmc_select_card(card);
 		if (ret) {
@@ -745,15 +745,15 @@ int sdmmc_card_init(struct sd_card *card)
 		return ret;
 	}
 	/* Read switch capabilities to determine what speeds card supports */
-	if (!card->host_props.is_spi && IS_ENABLED(CONFIG_SDHC_SUPPORTS_NATIVE_MODE)) {
+	if (IS_ENABLED(CONFIG_SDHC_SUPPORTS_NATIVE_MODE) && !card->host_props.is_spi) {
 		ret = sdmmc_read_switch(card);
 		if (ret) {
 			LOG_ERR("Failed to read card functions");
 			return ret;
 		}
 	}
-	if ((card->flags & SD_1800MV_FLAG) && sdmmc_host_uhs(&card->host_props) &&
-	    !(card->host_props.is_spi) && IS_ENABLED(CONFIG_SD_UHS_PROTOCOL)) {
+	if (IS_ENABLED(CONFIG_SD_UHS_PROTOCOL) && (card->flags & SD_1800MV_FLAG) &&
+	    sdmmc_host_uhs(&card->host_props) && !(card->host_props.is_spi)) {
 		ret = sdmmc_init_uhs(card);
 		if (ret) {
 			LOG_ERR("UHS card init failed");


### PR DESCRIPTION
evaluate constants first, so the
compiler can optimize it.