### PR TITLE
dts: soc: nxp lpc55xxx: Add SWO support

### DIFF
--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -38,6 +38,11 @@
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
 			};
+
+			itm: itm@e0000000 {
+				compatible = "arm,armv8m-itm";
+				reg = <0xe0000000 0x1000>;
+			};
 		};
 	};
 };

--- a/soc/nxp/lpc/lpc55xxx/Kconfig
+++ b/soc/nxp/lpc/lpc55xxx/Kconfig
@@ -3,6 +3,7 @@
 
 config SOC_SERIES_LPC55XXX
 	select HAS_MCUX
+	select HAS_SWO
 	select CPU_CORTEX_M_HAS_SYSTICK
 	select CPU_CORTEX_M_HAS_DWT
 	select SOC_RESET_HOOK

--- a/soc/nxp/lpc/lpc55xxx/soc.c
+++ b/soc/nxp/lpc/lpc55xxx/soc.c
@@ -433,6 +433,12 @@ DT_FOREACH_STATUS_OKAY(nxp_ctimer_pwm, CTIMER_CLOCK_SETUP)
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(opamp2))
 	POWER_DisablePD(kPDRUNCFG_PD_OPAMP2);
 #endif
+
+#ifdef CONFIG_LOG_BACKEND_SWO
+	CLOCK_AttachClk(kTRACE_DIV_to_TRACE);
+	CLOCK_SetClkDiv(kCLOCK_DivArmTrClkDiv, 1U, true);
+#endif
+
 }
 
 /**


### PR DESCRIPTION
Add ARMv8 ITM to lpc55S2x common device tree and set the clock config when using SWO as a logging backend.