### PR TITLE
drivers: gpio: intel: Enable support for new ACPI GINF method

### DIFF
--- a/dts/bindings/gpio/intel,gpio.yaml
+++ b/dts/bindings/gpio/intel,gpio.yaml
@@ -25,6 +25,33 @@ properties:
     type: int
     description: Pin offset of this GPIO entry
 
+  int-en-offset:
+    type: int
+    description: |
+      This parameter enables to add proper offset to access
+      GPIO_INT_EN register from General Purpose Events status
+      Register, as it is observed that the offset varies from
+      platform to platform. GP_EVENT_STAT register is fetched
+      from ACPI GPIO table.
+
+  int-stat-offset:
+    type: int
+    description: |
+      This parameter enables to add proper offset to access
+      GPIO_INT_STAT register from General Purpose Events status
+      Register, as it is observed that the offset varies from
+      platform to platform. GP_EVENT_STAT register is fetched
+      from ACPI GPIO table.
+
+  acpi-ginf-3-param:
+    type: boolean
+    description: |
+      This boolean will indicate the version of GINF method ACPI
+      enabled for a given platform. If the value is true, GINF
+      method which takes 3 parameters (u-id, bank-id and field-id)
+      will be used else GINF method with 2 parameters (field-id
+      and bank-id) will be used.
+
   "#gpio-cells":
     const: 2
 

--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -57,6 +57,8 @@
 			acpi-hid = "INTC1057";
 			acpi-uid = "2";
 			group-index = <0x02>;
+			int-stat-offset = <0x40>;
+			int-en-offset = <0x20>;
 			status = "okay";
 		};
 
@@ -64,6 +66,8 @@
 			acpi-hid = "INTC1057";
 			acpi-uid = "0";
 			group-index = <0x0>;
+			int-stat-offset = <0x40>;
+			int-en-offset = <0x20>;
 			status = "okay";
 		};
 
@@ -71,6 +75,8 @@
 			acpi-hid = "INTC1057";
 			acpi-uid = "0";
 			group-index = <0x0B>;
+			int-stat-offset = <0x40>;
+			int-en-offset = <0x20>;
 			status = "okay";
 		};
 
@@ -78,6 +84,8 @@
 			acpi-hid = "INTC1057";
 			acpi-uid = "0";
 			group-index = <0x8>;
+			int-stat-offset = <0x40>;
+			int-en-offset = <0x20>;
 			status = "okay";
 		};
 
@@ -85,6 +93,8 @@
 			acpi-hid = "INTC1057";
 			acpi-uid = "0";
 			group-index = <0xE>;
+			int-stat-offset = <0x40>;
+			int-en-offset = <0x20>;
 			status = "okay";
 		};
 
@@ -92,6 +102,8 @@
 			acpi-hid = "INTC1057";
 			acpi-uid = "0";
 			group-index = <0xC>;
+			int-stat-offset = <0x40>;
+			int-en-offset = <0x20>;
 			status = "okay";
 		};
 
@@ -99,6 +111,8 @@
 			acpi-hid = "INTC1057";
 			acpi-uid = "0";
 			group-index = <0x7>;
+			int-stat-offset = <0x40>;
+			int-en-offset = <0x20>;
 			status = "okay";
 		};
 
@@ -106,6 +120,8 @@
 			acpi-hid = "INTC1057";
 			acpi-uid = "0";
 			group-index = <0x9>;
+			int-stat-offset = <0x40>;
+			int-en-offset = <0x20>;
 			status = "okay";
 		};
 
@@ -113,6 +129,8 @@
 			acpi-hid = "INTC1057";
 			acpi-uid = "0";
 			group-index = <0x6>;
+			int-stat-offset = <0x40>;
+			int-en-offset = <0x20>;
 			status = "okay";
 		};
 
@@ -120,6 +138,8 @@
 			acpi-hid = "INTC1057";
 			acpi-uid = "0";
 			group-index = <0x3>;
+			int-stat-offset = <0x40>;
+			int-en-offset = <0x20>;
 			status = "okay";
 		};
 
@@ -127,6 +147,8 @@
 			acpi-hid = "INTC1057";
 			acpi-uid = "0";
 			group-index = <0x1>;
+			int-stat-offset = <0x40>;
+			int-en-offset = <0x20>;
 			status = "okay";
 		};
 
@@ -134,6 +156,8 @@
 			acpi-hid = "INTC1057";
 			acpi-uid = "0";
 			group-index = <0xA>;
+			int-stat-offset = <0x40>;
+			int-en-offset = <0x20>;
 			status = "okay";
 		};
 	};

--- a/dts/x86/intel/gpio_common.dtsi
+++ b/dts/x86/intel/gpio_common.dtsi
@@ -145,6 +145,15 @@
 			status = "disabled";
 		};
 
+		gpio_v: gpio_v {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
 		vgpio: vgpio {
 			compatible = "intel,gpio";
 			interrupt-parent = <&intc>;

--- a/dts/x86/intel/panther_lake_h.dtsi
+++ b/dts/x86/intel/panther_lake_h.dtsi
@@ -7,6 +7,8 @@
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include "gpio_common.dtsi"
 
 / {
 	cpus {
@@ -47,6 +49,98 @@
 		interrupt-controller;
 		#interrupt-cells = <3>;
 		#address-cells = <1>;
+	};
+
+	acpi {
+		gpio_a: gpio_a {
+			acpi-hid = "INTC10BC";
+			acpi-uid = "3";
+			group-index = <0x02>;
+			acpi-ginf-3-param;
+			int-stat-offset = <0x30>;
+			int-en-offset = <0x20>;
+			status = "disabled";
+		};
+
+		gpio_b: gpio_b {
+			acpi-hid = "INTC10BC";
+			acpi-uid = "5";
+			group-index = <0x00>;
+			acpi-ginf-3-param;
+			int-stat-offset = <0x30>;
+			int-en-offset = <0x20>;
+			status = "disabled";
+		};
+
+		gpio_c: gpio_c {
+			acpi-hid = "INTC10BC";
+			acpi-uid = "0";
+			group-index = <0x01>;
+			acpi-ginf-3-param;
+			int-stat-offset = <0x30>;
+			int-en-offset = <0x20>;
+			status = "disabled";
+		};
+
+		gpio_d: gpio_d {
+			acpi-hid = "INTC10BC";
+			acpi-uid = "5";
+			group-index = <0x01>;
+			acpi-ginf-3-param;
+			int-stat-offset = <0x30>;
+			int-en-offset = <0x20>;
+			status = "disabled";
+		};
+
+		gpio_e: gpio_e {
+			acpi-hid = "INTC10BC";
+			acpi-uid = "1";
+			group-index = <0x01>;
+			acpi-ginf-3-param;
+			int-stat-offset = <0x30>;
+			int-en-offset = <0x20>;
+			status = "disabled";
+		};
+
+		gpio_f: gpio_f {
+			acpi-hid = "INTC10BC";
+			acpi-uid = "1";
+			group-index = <0x00>;
+			acpi-ginf-3-param;
+			int-stat-offset = <0x30>;
+			int-en-offset = <0x20>;
+			status = "disabled";
+		};
+
+		gpio_h: gpio_h {
+			acpi-hid = "INTC10BC";
+			acpi-uid = "3";
+			group-index = <0x01>;
+			acpi-ginf-3-param;
+			int-stat-offset = <0x30>;
+			int-en-offset = <0x20>;
+			status = "disabled";
+		};
+
+		gpio_s: gpio_s {
+			acpi-hid = "INTC10BC";
+			acpi-uid = "4";
+			group-index = <0x00>;
+			acpi-ginf-3-param;
+			int-stat-offset = <0x30>;
+			int-en-offset = <0x20>;
+			status = "disabled";
+		};
+
+		gpio_v: gpio_v {
+			acpi-hid = "INTC10BC";
+			acpi-uid = "0";
+			group-index = <0x00>;
+			acpi-ginf-3-param;
+			int-stat-offset = <0x30>;
+			int-en-offset = <0x20>;
+			status = "disabled";
+		};
 	};
 
 	pcie0: pcie0 {
@@ -178,6 +272,7 @@
 			pw,cs-mode = <0>;
 			pw,cs-output = <0>;
 			pw,fifo-depth = <64>;
+			cs-gpios = <&gpio_e 17 GPIO_ACTIVE_LOW>;
 			clock-frequency = <100000000>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -193,6 +288,7 @@
 			pw,cs-mode = <0>;
 			pw,cs-output = <0>;
 			pw,fifo-depth = <64>;
+			cs-gpios = <&gpio_f 17 GPIO_ACTIVE_LOW>;
 			clock-frequency = <100000000>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -208,6 +304,7 @@
 			pw,cs-mode = <0>;
 			pw,cs-output = <0>;
 			pw,fifo-depth = <64>;
+			cs-gpios = <&gpio_f 18 GPIO_ACTIVE_LOW>;
 			clock-frequency = <100000000>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;

--- a/lib/acpi/acpi.c
+++ b/lib/acpi/acpi.c
@@ -544,6 +544,11 @@ int acpi_device_mmio_get(struct acpi_dev *child_dev, struct acpi_mmio_resource *
 			reg_base[mmio_cnt].mmio = (uintptr_t)res->Data.FixedMemory32.Address;
 			reg_base[mmio_cnt++].length = res->Data.FixedMemory32.AddressLength;
 			break;
+		case ACPI_RESOURCE_TYPE_ADDRESS64:
+			reg_base[mmio_cnt].type = ACPI_RES_TYPE_MEM;
+			reg_base[mmio_cnt].mmio = (uintptr_t)res->Data.Address64.Address.Minimum;
+			reg_base[mmio_cnt++].length = res->Data.Address64.Address.AddressLength;
+			break;
 		}
 
 		res = ACPI_NEXT_RESOURCE(res);

--- a/soc/intel/alder_lake/CMakeLists.txt
+++ b/soc/intel/alder_lake/CMakeLists.txt
@@ -8,7 +8,7 @@ zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_cc_option(-march=goldmont)
 
 zephyr_library_sources(cpu.c)
-zephyr_library_sources(../common/soc_gpio.c)
+zephyr_library_sources_ifdef(CONFIG_GPIO ../common/soc_gpio.c)
 
 zephyr_library_sources_ifdef(CONFIG_POWEROFF ../common/power.c)
 

--- a/soc/intel/common/soc_gpio.c
+++ b/soc/intel/common/soc_gpio.c
@@ -8,6 +8,9 @@
 #include <zephyr/acpi/acpi.h>
 #include "soc.h"
 #include "soc_gpio.h"
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(soc_gpio, CONFIG_SOC_LOG_LEVEL);
 
 #define GET_GPIO_BASE_NUM ("\\_SB.GINF")
 
@@ -72,7 +75,7 @@ int soc_acpi_gpio_resource_get(int bank_idx, char *hid, char *uid, struct gpio_a
 
 	acpi_child = acpi_device_get(hid, uid);
 	if (!acpi_child) {
-		printk("acpi_device_get failed\n");
+		LOG_ERR("acpi_device_get failed");
 		return -EIO;
 	}
 
@@ -80,7 +83,7 @@ int soc_acpi_gpio_resource_get(int bank_idx, char *hid, char *uid, struct gpio_a
 	mmio_res.reg_base = reg_base;
 	ret = acpi_device_mmio_get(acpi_child, &mmio_res);
 	if (ret) {
-		printk("acpi_device_mmio_get failed\n");
+		LOG_ERR("acpi_device_mmio_get failed");
 		return ret;
 	}
 
@@ -88,7 +91,7 @@ int soc_acpi_gpio_resource_get(int bank_idx, char *hid, char *uid, struct gpio_a
 	irq_res.irqs = irqs;
 	ret = acpi_device_irq_get(acpi_child, &irq_res);
 	if (ret) {
-		printk("acpi_device_irq_get failed\n");
+		LOG_ERR("acpi_device_irq_get failed");
 		return ret;
 	}
 
@@ -105,7 +108,7 @@ int soc_acpi_gpio_resource_get(int bank_idx, char *hid, char *uid, struct gpio_a
 		for (int i = 0; i < num_fields; i++) {
 			ret = gpio_info_acpi_get(uid_int, bank_idx, i, &field_val[i], ginf);
 			if (ret) {
-				printk("gpio_info_acpi_get failed\n");
+				LOG_ERR("gpio_info_acpi_get failed");
 				return ret;
 			}
 		}
@@ -139,7 +142,7 @@ int soc_acpi_gpio_resource_get(int bank_idx, char *hid, char *uid, struct gpio_a
 			res->base_num = field_val[6];
 		}
 	} else {
-		printk("ACPI_RES_TYPE_MEM failed\n");
+		LOG_ERR("ACPI_RES_TYPE_MEM failed");
 		return -ENODEV;
 	}
 

--- a/soc/intel/common/soc_gpio.c
+++ b/soc/intel/common/soc_gpio.c
@@ -11,21 +11,40 @@
 
 #define GET_GPIO_BASE_NUM ("\\_SB.GINF")
 
-static int gpio_info_acpi_get(uint32_t bank_idx, uint32_t field_idx, uint32_t *ret_val)
+static int gpio_info_acpi_get(uint8_t uid, uint32_t bank_idx, uint32_t field_idx,
+			      uint32_t *ret_val, bool ginf)
 {
 	int status;
-	ACPI_OBJECT args[2];
+	ACPI_OBJECT args[3];
 	ACPI_OBJECT_LIST arg_list;
 	ACPI_OBJECT gpio_obj;
 
-	arg_list.Count = ARRAY_SIZE(args);
 	arg_list.Pointer = args;
 
-	args[0].Type = ACPI_TYPE_INTEGER;
-	args[0].Integer.Value = bank_idx;
+	if (ginf) {
+		arg_list.Count = 3;
+		args[0].Type = ACPI_TYPE_INTEGER;
+		/* u-id is used to indicate the order of communities in ACPI table,
+		 * in GINF method with u-id parameter community 2 is not existing
+		 * but ACPI table stores community 3 group values in uid index 2
+		 * and same for communities 4 and 5. So following logic is used
+		 * while sending u-id to GINF.
+		 */
+		args[0].Integer.Value = (uid > GINF_MISSING_UID) ? (--uid) : uid;
 
-	args[1].Type = ACPI_TYPE_INTEGER;
-	args[1].Integer.Value = field_idx;
+		args[1].Type = ACPI_TYPE_INTEGER;
+		args[1].Integer.Value = bank_idx;
+
+		args[2].Type = ACPI_TYPE_INTEGER;
+		args[2].Integer.Value = field_idx;
+	} else {
+		arg_list.Count = 2;
+		args[0].Type = ACPI_TYPE_INTEGER;
+		args[0].Integer.Value = bank_idx;
+
+		args[1].Type = ACPI_TYPE_INTEGER;
+		args[1].Integer.Value = field_idx;
+	}
 
 	status = acpi_invoke_method(GET_GPIO_BASE_NUM, &arg_list, &gpio_obj);
 	if (status) {
@@ -39,15 +58,17 @@ static int gpio_info_acpi_get(uint32_t bank_idx, uint32_t field_idx, uint32_t *r
 	return status;
 }
 
-int soc_acpi_gpio_resource_get(int bank_idx, char *hid, char *uid, struct gpio_acpi_res *res)
+int soc_acpi_gpio_resource_get(int bank_idx, char *hid, char *uid, struct gpio_acpi_res *res,
+			       bool ginf)
 {
 	int ret;
 	struct acpi_dev *acpi_child;
 	struct acpi_irq_resource irq_res;
 	struct acpi_mmio_resource mmio_res;
-	uint32_t field_val[7];
+	uint32_t field_val[8] = {0};
 	uint16_t irqs[CONFIG_ACPI_IRQ_VECTOR_MAX];
 	struct acpi_reg_base reg_base[CONFIG_ACPI_MMIO_ENTRIES_MAX];
+	uint8_t uid_int = 0;
 
 	acpi_child = acpi_device_get(hid, uid);
 	if (!acpi_child) {
@@ -75,23 +96,48 @@ int soc_acpi_gpio_resource_get(int bank_idx, char *hid, char *uid, struct gpio_a
 	res->irq_flags = irq_res.flags;
 
 	if (ACPI_RESOURCE_TYPE_GET(&mmio_res) == ACPI_RES_TYPE_MEM) {
-		for (int i = 0; i < ARRAY_SIZE(field_val); i++) {
-			ret = gpio_info_acpi_get(bank_idx, i, &field_val[i]);
+		int num_fields = ARRAY_SIZE(field_val);
+
+		if (uid) {
+			uid_int = atoi(uid);
+		}
+
+		for (int i = 0; i < num_fields; i++) {
+			ret = gpio_info_acpi_get(uid_int, bank_idx, i, &field_val[i], ginf);
 			if (ret) {
 				printk("gpio_info_acpi_get failed\n");
 				return ret;
 			}
 		}
 
-		res->reg_base = ACPI_MMIO_GET(&mmio_res) & (~0x0FFFFFF);
-		res->reg_base += field_val[0];
-		res->len = ACPI_RESOURCE_SIZE_GET(&mmio_res);
-		res->num_pins = field_val[1];
-		res->pad_base = field_val[2];
-		res->host_owner_reg = field_val[3];
-		res->pad_owner_reg = field_val[4];
-		res->intr_stat_reg = field_val[5] - 0x40;
-		res->base_num = field_val[6];
+		if (ginf) {
+			/* GINF method used to fetch GPIO data from ACPI table requires 3
+			 * parameters for each GPIO group.
+			 * In this method Reg_base stores 64-bit physical address of the GPIO group.
+			 */
+			res->reg_base = ACPI_MMIO_GET(&mmio_res);
+			res->len = ACPI_RESOURCE_SIZE_GET(&mmio_res);
+			res->num_pins = field_val[0];
+			res->pad_base = field_val[1];
+			res->host_owner_reg = field_val[2];
+			res->pad_owner_reg = field_val[3];
+			res->gp_evt_stat_reg = field_val[4];
+			res->base_num = field_val[7];
+		} else {
+			/* GINF method used to fetch GPIO data from ACPI table requires 2
+			 * parameters for each GPIO group.
+			 * In this method reg_base stores 32-bit physical address of the GPIO group
+			 */
+			res->reg_base = ACPI_MMIO_GET(&mmio_res) & (~0x0FFFFFF);
+			res->reg_base += field_val[0];
+			res->len = ACPI_RESOURCE_SIZE_GET(&mmio_res);
+			res->num_pins = field_val[1];
+			res->pad_base = field_val[2];
+			res->host_owner_reg = field_val[3];
+			res->pad_owner_reg = field_val[4];
+			res->gp_evt_stat_reg = field_val[5];
+			res->base_num = field_val[6];
+		}
 	} else {
 		printk("ACPI_RES_TYPE_MEM failed\n");
 		return -ENODEV;

--- a/soc/intel/common/soc_gpio.h
+++ b/soc/intel/common/soc_gpio.h
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define GINF_MISSING_UID 2 /* Missing community in GPIO communities */
+
 struct gpio_acpi_res {
 	uintptr_t reg_base;
 	uint32_t len;
@@ -11,7 +13,7 @@ struct gpio_acpi_res {
 	uint8_t num_pins;
 	uint32_t host_owner_reg;
 	uint32_t pad_owner_reg;
-	uint32_t intr_stat_reg;
+	uint32_t gp_evt_stat_reg;
 	uint16_t base_num;
 	uint16_t irq;
 	uint32_t irq_flags;
@@ -24,6 +26,8 @@ struct gpio_acpi_res {
  * @param hid the hardware id of the acpi device
  * @param uid the unique id of the acpi device
  * @param res the pointer to resource struct on which data return
+ * @param ginf bool to indicate ginf method
  * @return return 0 on success or error code
  */
-int soc_acpi_gpio_resource_get(int bank_idx, char *hid, char *uid, struct gpio_acpi_res *res);
+int soc_acpi_gpio_resource_get(int bank_idx, char *hid, char *uid, struct gpio_acpi_res *res,
+			       bool ginf);

--- a/soc/intel/panther_lake/CMakeLists.txt
+++ b/soc/intel/panther_lake/CMakeLists.txt
@@ -4,4 +4,6 @@ zephyr_include_directories(.)
 
 zephyr_cc_option(-march=goldmont)
 
+zephyr_library_sources_ifdef(CONFIG_GPIO ../common/soc_gpio.c)
+
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/intel/panther_lake/soc.h
+++ b/soc/intel/panther_lake/soc.h
@@ -21,6 +21,14 @@
 #include <zephyr/random/random.h>
 #endif
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(acpi_hid)
+#include "../common/soc_gpio.h"
+#endif
+
+#ifdef CONFIG_GPIO_INTEL
+#include "soc_gpio.h"
+#endif
+
 #if DT_ON_BUS(DT_CHOSEN(zephyr_console), pcie)
 #include <zephyr/drivers/pcie/pcie.h>
 #define X86_SOC_EARLY_SERIAL_PCIDEV DT_REG_ADDR(DT_CHOSEN(zephyr_console))

--- a/soc/intel/panther_lake/soc_gpio.h
+++ b/soc/intel/panther_lake/soc_gpio.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025, Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief GPIO macros for the Panther Lake SoC
+ *
+ * This header file is used to specify the GPIO macros for
+ * the Panther Lake SoC.
+ */
+
+#ifndef __SOC_GPIO_H_
+#define __SOC_GPIO_H_
+
+#define GPIO_OWNERSHIP_BIT(raw_pin)	(0x0)
+#define GPIO_RAW_PIN(pin, pin_offset)	pin
+#define PAD_CFG0_PMODE_MASK		(0x07 << 10)
+#define PIN_OFFSET			(0x10)
+
+#endif /* __SOC_GPIO_H_ */

--- a/soc/intel/raptor_lake/CMakeLists.txt
+++ b/soc/intel/raptor_lake/CMakeLists.txt
@@ -3,6 +3,5 @@
 zephyr_include_directories(.)
 
 zephyr_cc_option(-march=goldmont)
-zephyr_library_sources(../common/soc_gpio.c)
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/tests/drivers/gpio/gpio_basic_api/boards/intel_ptl_h_crb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/intel_ptl_h_crb.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Connect loopback between GPP_B_22 and GPP_B_23.
+ * BIOS settings to mark these two pins as GPIO
+ * Under Intel Advanced Menu > PCH-IO Configuration
+ * Enable Timed GPIO0 > Disable
+ * Enable Timed GPIO1 > Disable
+ * ISH Configuration > GP_5 > Unchecked [ ]
+ * ISH Configuration > GP_6 > Unchecked [ ]
+ */
+
+&gpio_b {
+	status = "okay";
+};
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+
+		out-gpios = <&gpio_b 22 0>;
+		in-gpios  = <&gpio_b 23 0>;
+	};
+};


### PR DESCRIPTION
This PR adds GPIO support for Intel Panther Lake H SoC, implementing a new ACPI GINF method for GPIO resource enumeration and adding corresponding device tree definitions.

Adds GPIO device tree definitions for Panther Lake H with new ACPI GINF method support
Implements enhanced ACPI GPIO resource enumeration with support for both old and new GINF methods
Adds GPIO configuration overlay for test board intel_ptl_h_crb