### PR TITLE
samples: onoff_level_lighting_vnd_app: Remove redundant code

### DIFF
--- a/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/app_gpio.c
+++ b/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/app_gpio.c
@@ -68,9 +68,6 @@ void app_gpio_init(void)
 	}
 
 	/* Buttons configuration & setting */
-
-	k_work_init(&button_work, publish);
-
 	for (i = 0; i < ARRAY_SIZE(button_device); i++) {
 		if (!gpio_is_ready_dt(&button_device[i])) {
 			return;


### PR DESCRIPTION
button_work is statically initialized and there is not need to initialize it again in app_gpio_init().