### PR TITLE
posix: Add guards to prevent macro redefinition

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -179,6 +179,10 @@ New APIs and options
     * :c:func:`zsock_listen` now implements the ``backlog`` parameter support. The TCP server
       socket will limit the number of pending incoming connections to that value.
 
+* Newlib
+
+  * :kconfig:option:`CONFIG_NEWLIB_LIBC_USE_POSIX_LIMITS_H`
+
 * Power management
 
    * :c:func:`pm_device_driver_deinit`

--- a/lib/libc/newlib/Kconfig
+++ b/lib/libc/newlib/Kconfig
@@ -70,4 +70,14 @@ config NEWLIB_LIBC_CUSTOM_SBRK
 	  Allow user to define custom version of the _sbrk function. Some application
 	  may need to use the remaining RAM for also other purposes than heap.
 
+config NEWLIB_LIBC_USE_POSIX_LIMITS_H
+	bool "Use Zephyr's posix_limits.h header"
+	default y
+	help
+	  The newlib provided by the Zephyr SDK does not include all mandatory POSIX limits.
+	  However, some external newlib-based toolchains do.
+
+	  Disable this option if your toolchain's newlib already includes all mandatory POSIX
+	  limits.
+
 endif # NEWLIB_LIBC

--- a/lib/libc/newlib/include/limits.h
+++ b/lib/libc/newlib/include/limits.h
@@ -8,6 +8,8 @@
 #define ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_LIMITS_H_
 
 #include_next <limits.h>
+#ifdef CONFIG_NEWLIB_LIBC_USE_POSIX_LIMITS_H
 #include <zephyr/posix/posix_limits.h>
+#endif
 
 #endif /* ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_LIMITS_H_ */


### PR DESCRIPTION
Add guards to prevent macro redefinition, as downstream toolchains may provide these macros.