### PR TITLE
ci: maintainer_check: Check out "merged" MAINTAINERS.yml

### DIFF
--- a/.github/workflows/maintainer_check.yml
+++ b/.github/workflows/maintainer_check.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Fetch MAINTAINERS.yml from pull request
         run: |
-          git fetch origin pull/${{ github.event.pull_request.number }}/head
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge
           git show FETCH_HEAD:MAINTAINERS.yml > pr_MAINTAINERS.yml
 
       - name: Check maintainer file changes


### PR DESCRIPTION
When a pull request is based off an old commit in the base branch (usually `main`), the MAINTAINERS file from the `pull/NUMBER/head` ref may contain out-of-date changes, and running diff between it and the MAINTAINERS file from the latest base branch may return more changes than what is actually made in the pull request.

This commit updates the workflow to check out the MAINTAINERS file from the `pull/NUMBER/merge` ref, which is a temporary ref created by GitHub with the pull request commits merged into the base branch.

---

Tested in https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/17689205771/job/50279801532?pr=372