### PR TITLE
drivers: xen: add SCHEDOP hypercall wrapper

### DIFF
--- a/drivers/xen/CMakeLists.txt
+++ b/drivers/xen/CMakeLists.txt
@@ -5,5 +5,6 @@ zephyr_sources(hvm.c)
 zephyr_sources(events.c)
 zephyr_sources_ifdef(CONFIG_XEN_GRANT_TABLE gnttab.c)
 zephyr_sources(memory.c)
+zephyr_sources_ifdef(CONFIG_XEN_SCHED sched.c)
 
 add_subdirectory_ifdef(CONFIG_XEN_DOM0 dom0)

--- a/drivers/xen/Kconfig
+++ b/drivers/xen/Kconfig
@@ -29,6 +29,12 @@ config NR_GRANT_FRAMES
 	  grant table driver in runtime. This value should be <= max_grant_frames
 	  configured for domain in Xen hypervisor.
 
+config XEN_SCHED
+	bool "Xen scheduler helpers"
+	default y
+	help
+	  Enable Xen scheduler helper functions
+
 endmenu
 
 endif # XEN

--- a/drivers/xen/sched.c
+++ b/drivers/xen/sched.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/arm64/hypercall.h>
+#include <zephyr/xen/sched.h>
+
+int xen_sched_poll(evtchn_port_t *ports, unsigned int nr_ports, uint64_t timeout)
+{
+	struct sched_poll poll = {
+		.ports.p = ports,
+		.nr_ports = 1,
+		.timeout = timeout,
+	};
+
+	return HYPERVISOR_sched_op(SCHEDOP_poll, &poll);
+}

--- a/include/zephyr/xen/sched.h
+++ b/include/zephyr/xen/sched.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_XEN_SCHED_H_
+#define ZEPHYR_XEN_SCHED_H_
+
+#include <zephyr/xen/public/sched.h>
+
+/**
+ * @brief Poll one or more Xen event channels for activity.
+ *
+ * Issues the SCHEDOP_poll hypercall to wait for events on the specified ports.
+ *
+ * @param ports      Array of event channel ports to poll.
+ * @param nr_ports   Number of ports in the array.
+ * @param timeout    Timeout in microseconds to wait for an event.
+ * @return           0 if an event occurred, -EAGAIN on timeout, or negative errno on error.
+ */
+int xen_sched_poll(evtchn_port_t *ports, unsigned int nr_ports, uint64_t timeout);
+
+#endif /* ZEPHYR_XEN_SCHED_H_ */


### PR DESCRIPTION
Add SCHEDOP_poll wrapper used by Xen backends to wait on event channels efficiently.

- sched
  - sched_poll: HYPERVISOR_sched_op(SCHEDOP_poll)
  
---
Note: This PR extracted from #91605