### PR TITLE
posix: net: use regular linkage with gethostname() instead of static inline

### DIFF
--- a/include/zephyr/net/hostname.h
+++ b/include/zephyr/net/hostname.h
@@ -11,6 +11,11 @@
 #ifndef ZEPHYR_INCLUDE_NET_HOSTNAME_H_
 #define ZEPHYR_INCLUDE_NET_HOSTNAME_H_
 
+#include <errno.h>
+
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/posix/unistd.h
+++ b/include/zephyr/posix/unistd.h
@@ -11,11 +11,6 @@
 #ifdef CONFIG_POSIX_API
 #include <zephyr/fs/fs.h>
 #endif
-#ifdef CONFIG_NETWORKING
-/* For zsock_gethostname() */
-#include <zephyr/net/socket.h>
-#include <zephyr/net/hostname.h>
-#endif
 #include <zephyr/posix/sys/confstr.h>
 #include <zephyr/posix/sys/stat.h>
 #include <zephyr/posix/sys/sysconf.h>
@@ -48,12 +43,7 @@ int rmdir(const char *path);
 
 FUNC_NORETURN void _exit(int status);
 
-#ifdef CONFIG_NETWORKING
-static inline int gethostname(char *buf, size_t len)
-{
-	return zsock_gethostname(buf, len);
-}
-#endif /* CONFIG_NETWORKING */
+int gethostname(char *buf, size_t len);
 
 #endif /* CONFIG_POSIX_API */
 

--- a/lib/posix/options/net.c
+++ b/lib/posix/options/net.c
@@ -9,7 +9,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <zephyr/net/hostname.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/socket.h>
 #include <zephyr/posix/arpa/inet.h>
 #include <zephyr/posix/netinet/in.h>
 #include <zephyr/posix/net/if.h>
@@ -322,6 +324,11 @@ int bind(int sock, const struct sockaddr *addr, socklen_t addrlen)
 int connect(int sock, const struct sockaddr *addr, socklen_t addrlen)
 {
 	return zsock_connect(sock, addr, addrlen);
+}
+
+int gethostname(char *name, size_t namelen)
+{
+	return zsock_gethostname(name, namelen);
 }
 
 int getsockname(int sock, struct sockaddr *addr, socklen_t *addrlen)

--- a/tests/posix/net/src/gethostname.c
+++ b/tests/posix/net/src/gethostname.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <unistd.h>
+
+#include <zephyr/ztest.h>
+
+ZTEST(net, test_gethostname)
+{
+	char hostname[CONFIG_NET_HOSTNAME_MAX_LEN + 1];
+	int ret;
+
+	ret = gethostname(hostname, sizeof(hostname));
+	zassert_equal(ret, 0, "gethostname() failed: %d", ret);
+
+	zassert_equal(strcmp(hostname, CONFIG_NET_HOSTNAME), 0,
+		      "gethostname() returned unexpected hostname: %s", hostname);
+}

--- a/west.yml
+++ b/west.yml
@@ -260,7 +260,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: d0628446c830c25522bd1999234a77b4841016fa
+      revision: cc049020152585c4e968b83c084d230234b6d852
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
Convert `gethostname()` from a static inline wrapper to a normal function with regular linkage and add some minimal test coverage for it.

Depends on
- [x] #95962
- [x] zephyrproject-rtos/hal_ti#70