### PR TITLE
Github workflows remove ineffective branch filters for workflow_dispatch

### DIFF
--- a/.github/workflows/bug_snapshot.yaml
+++ b/.github/workflows/bug_snapshot.yaml
@@ -8,7 +8,6 @@ name: Bug Snapshot
 
 on:
   workflow_dispatch:
-    branches: [main]
   schedule:
   # Run daily at 00:05
   - cron: '5 00 * * *'
@@ -20,7 +19,7 @@ jobs:
   make_bugs_pickle:
     name: Make bugs pickle
     runs-on: ubuntu-24.04
-    if: github.repository_owner == 'zephyrproject-rtos'
+    if: github.repository_owner == 'zephyrproject-rtos' && github.ref == 'refs/heads/main'
 
     steps:
     - name: Checkout

--- a/.github/workflows/stale-workflow-queue-cleanup.yml
+++ b/.github/workflows/stale-workflow-queue-cleanup.yml
@@ -2,7 +2,6 @@ name: Stale Workflow Queue Cleanup
 
 on:
   workflow_dispatch:
-    branches: [main]
   schedule:
   # everyday at 15:00
   - cron: '0 15 * * *'
@@ -18,6 +17,7 @@ jobs:
   cleanup:
     name: Cleanup
     runs-on: ubuntu-24.04
+    if: github.ref == 'refs/heads/main'
     permissions:
       actions: write # to delete stale workflow runs
 


### PR DESCRIPTION
The branch filter is not available for this event type and has no effect.
Add an additional condition to run the steps only on main to keep the intended behaviour of the workflows.

FYI: There is also an [open issue](https://github.com/orgs/community/discussions/75933) requesting this to be added, but no response from Github yet.
