### PR TITLE
Github: workflows: compliance: remove ineffective check

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -117,8 +117,3 @@ jobs:
           echo "You can run this step locally with the ./scripts/ci/check_compliance.py script."
           exit 1;
         fi
-
-        if [ "${{ steps.pr_description.outcome }}" == "failure" ]; then
-          echo "PR description cannot be empty"
-          exit 1;
-        fi


### PR DESCRIPTION
The commit 7b1e610cc7a4 ("ci: move PR body check to a different workflow") moved the step this depends on to the do_not_merge workflow, so it no longer has any effect.

This extra message was initially added to the fail step to make it easier to sport the issue. But I don't think it's necessary in the do_not_merge workflow.