### PR TITLE
scripts: west_commands: zspdx: fix log reference to meta file

### DIFF
--- a/scripts/west_commands/zspdx/walker.py
+++ b/scripts/west_commands/zspdx/walker.py
@@ -385,7 +385,7 @@ class Walker:
                 if not self.setupZephyrDocument(content["zephyr"], content["modules"]):
                     return False
         except (FileNotFoundError, yaml.YAMLError):
-            log.err("cannot find a valid zephyr_meta.yml required for SPDX generation; bailing")
+            log.err("cannot find a valid zephyr.meta required for SPDX generation; bailing")
             return False
 
         self.setupAppDocument()


### PR DESCRIPTION
The build output meta data is written to the zephyr.meta file not a zephyr_meta.yml file.
This name is defined by KERNEL_META_NAME in cmake/modules/kernel.cmake.