### PR TITLE
POC: MCUmgr: Forward Tree potocol

### DIFF
--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -18,9 +18,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uart_mcumgr, CONFIG_MCUMGR_TRANSPORT_LOG_LEVEL);
 
-static const struct device *const uart_mcumgr_dev =
-	DEVICE_DT_GET(DT_CHOSEN(zephyr_uart_mcumgr));
-
 /** Callback to execute when a valid fragment has been received. */
 static uart_mcumgr_recv_fn *uart_mcumgr_recv_cb;
 
@@ -43,7 +40,7 @@ uint8_t async_buffer[CONFIG_MCUMGR_TRANSPORT_UART_ASYNC_BUFS]
 static int async_current;
 #endif
 
-static struct uart_mcumgr_rx_buf *uart_mcumgr_alloc_rx_buf(void)
+static struct uart_mcumgr_rx_buf *uart_mcumgr_alloc_rx_buf(const struct device *const dev)
 {
 	struct uart_mcumgr_rx_buf *rx_buf;
 	void *block;
@@ -56,6 +53,7 @@ static struct uart_mcumgr_rx_buf *uart_mcumgr_alloc_rx_buf(void)
 
 	rx_buf = block;
 	rx_buf->length = 0;
+	rx_buf->dev = dev;
 	return rx_buf;
 }
 
@@ -71,26 +69,26 @@ void uart_mcumgr_free_rx_buf(struct uart_mcumgr_rx_buf *rx_buf)
 /**
  * Reads a chunk of received data from the UART.
  */
-static int uart_mcumgr_read_chunk(void *buf, int capacity)
+static int uart_mcumgr_read_chunk(const struct device *const dev, void *buf, int capacity)
 {
-	if (!uart_irq_rx_ready(uart_mcumgr_dev)) {
+	if (!uart_irq_rx_ready(dev)) {
 		return 0;
 	}
 
-	return uart_fifo_read(uart_mcumgr_dev, buf, capacity);
+	return uart_fifo_read(dev, buf, capacity);
 }
 #endif
 
 /**
  * Processes a single incoming byte.
  */
-static struct uart_mcumgr_rx_buf *uart_mcumgr_rx_byte(uint8_t byte)
+static struct uart_mcumgr_rx_buf *uart_mcumgr_rx_byte(const struct device *const dev, uint8_t byte)
 {
 	struct uart_mcumgr_rx_buf *rx_buf;
 
 	if (!uart_mcumgr_ignoring) {
 		if (uart_mcumgr_cur_buf == NULL) {
-			uart_mcumgr_cur_buf = uart_mcumgr_alloc_rx_buf();
+			uart_mcumgr_cur_buf = uart_mcumgr_alloc_rx_buf(dev);
 			if (uart_mcumgr_cur_buf == NULL) {
 				LOG_WRN("Insufficient buffers, fragment dropped");
 				uart_mcumgr_ignoring = true;
@@ -124,7 +122,7 @@ static struct uart_mcumgr_rx_buf *uart_mcumgr_rx_byte(uint8_t byte)
 }
 
 #if defined(CONFIG_MCUMGR_TRANSPORT_UART_ASYNC)
-static void uart_mcumgr_async(const struct device *dev, struct uart_event *evt, void *user_data)
+static void uart_mcumgr_async(const struct device *const dev, struct uart_event *evt, void *user_data)
 {
 	struct uart_mcumgr_rx_buf *rx_buf;
 	uint8_t *p;
@@ -141,7 +139,7 @@ static void uart_mcumgr_async(const struct device *dev, struct uart_event *evt, 
 		p = &evt->data.rx.buf[evt->data.rx.offset];
 
 		for (int i = 0; i < len; i++) {
-			rx_buf = uart_mcumgr_rx_byte(p[i]);
+			rx_buf = uart_mcumgr_rx_byte(dev, p[i]);
 			if (rx_buf != NULL) {
 				uart_mcumgr_recv_cb(rx_buf);
 			}
@@ -172,26 +170,25 @@ static void uart_mcumgr_async(const struct device *dev, struct uart_event *evt, 
 /**
  * ISR that is called when UART bytes are received.
  */
-static void uart_mcumgr_isr(const struct device *unused, void *user_data)
+static void uart_mcumgr_isr(const struct device *const dev, void *user_data)
 {
 	struct uart_mcumgr_rx_buf *rx_buf;
 	uint8_t buf[32];
 	int chunk_len;
 	int i;
 
-	ARG_UNUSED(unused);
 	ARG_UNUSED(user_data);
 
-	while (uart_irq_update(uart_mcumgr_dev) &&
-	       uart_irq_is_pending(uart_mcumgr_dev)) {
+	while (uart_irq_update(dev) &&
+	       uart_irq_is_pending(dev)) {
 
-		chunk_len = uart_mcumgr_read_chunk(buf, sizeof(buf));
+		chunk_len = uart_mcumgr_read_chunk(dev, buf, sizeof(buf));
 		if (chunk_len == 0) {
 			continue;
 		}
 
 		for (i = 0; i < chunk_len; i++) {
-			rx_buf = uart_mcumgr_rx_byte(buf[i]);
+			rx_buf = uart_mcumgr_rx_byte(dev, buf[i]);
 			if (rx_buf != NULL) {
 				uart_mcumgr_recv_cb(rx_buf);
 			}
@@ -203,48 +200,48 @@ static void uart_mcumgr_isr(const struct device *unused, void *user_data)
 /**
  * Sends raw data over the UART.
  */
-static int uart_mcumgr_send_raw(const void *data, int len)
+static int uart_mcumgr_send_raw(const struct device *const dev, const void *data, int len)
 {
 	const uint8_t *u8p;
 
 	u8p = data;
 	while (len--) {
-		uart_poll_out(uart_mcumgr_dev, *u8p++);
+		uart_poll_out(dev, *u8p++);
 	}
 
 	return 0;
 }
 
-int uart_mcumgr_send(const uint8_t *data, int len)
+int uart_mcumgr_send(const struct device *const dev, const uint8_t *data, int len)
 {
-	return mcumgr_serial_tx_pkt(data, len, uart_mcumgr_send_raw);
+	return mcumgr_serial_tx_pkt(dev, data, len, uart_mcumgr_send_raw);
 }
 
 
 #if defined(CONFIG_MCUMGR_TRANSPORT_UART_ASYNC)
-static void uart_mcumgr_setup(const struct device *uart)
+static void uart_mcumgr_setup(const struct device *const dev)
 {
-	uart_callback_set(uart, uart_mcumgr_async, NULL);
+	uart_callback_set(dev, uart_mcumgr_async, NULL);
 
-	uart_rx_enable(uart, async_buffer[0], sizeof(async_buffer[0]), 0);
+	uart_rx_enable(dev, async_buffer[0], sizeof(async_buffer[0]), 0);
 }
 #else
-static void uart_mcumgr_setup(const struct device *uart)
+static void uart_mcumgr_setup(const struct device *const dev)
 {
-	uart_irq_rx_disable(uart);
-	uart_irq_tx_disable(uart);
+	uart_irq_rx_disable(dev);
+	uart_irq_tx_disable(dev);
 
-	uart_irq_callback_set(uart, uart_mcumgr_isr);
+	uart_irq_callback_set(dev, uart_mcumgr_isr);
 
-	uart_irq_rx_enable(uart);
+	uart_irq_rx_enable(dev);
 }
 #endif
 
-void uart_mcumgr_register(uart_mcumgr_recv_fn *cb)
+void uart_mcumgr_register(const struct device *const dev, uart_mcumgr_recv_fn *cb)
 {
 	uart_mcumgr_recv_cb = cb;
 
-	if (device_is_ready(uart_mcumgr_dev)) {
-		uart_mcumgr_setup(uart_mcumgr_dev);
+	if (device_is_ready(dev)) {
+		uart_mcumgr_setup(dev);
 	}
 }

--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -53,7 +53,9 @@ static struct uart_mcumgr_rx_buf *uart_mcumgr_alloc_rx_buf(const struct device *
 
 	rx_buf = block;
 	rx_buf->length = 0;
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
 	rx_buf->dev = dev;
+#endif
 	return rx_buf;
 }
 

--- a/dts/bindings/misc/zephyr,smpmgr-forward.yaml
+++ b/dts/bindings/misc/zephyr,smpmgr-forward.yaml
@@ -1,0 +1,83 @@
+# Copyright (c) 2025 Freedom Veiculos Eletricos
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  The SMP MCUmgr Mux is a software defined muxer to route SMP requests between
+  nodes in the hardware. It is composed from one upstream port and a finite
+  number of downstream ports.
+
+  The zephyr,smpmgr-forward node should be added in the zephyr,uart-mcumgr chosen
+  node. The zephyr,smpmgr-forward router uses a counter in the protocol to know
+  when it should stop to forward the data downstream. In this case, the data
+  is sent to the local device in the zephyr,uart-mcumgr interface.
+
+  In the below snip it is possible to see the definition of my_muxer. The
+  my_muxer is composed by three node: 'the_upstream', 'down1' and 'down2'. In
+  this case the 'down1' node is the 'index 0' and 'down2' is the 'index 1'.
+
+    / {
+      chosen {
+        zephyr,uart-mcumgr = &my_muxer;
+      };
+
+      the_upstream: the_upstream{
+        compatible = "zephyr,smpmgr-transport";
+        status = "okay";
+
+        transport = <&cdc_acm_uart0>;
+        type = "serial";
+      };
+
+      down1: down1{
+        compatible = "zephyr,smpmgr-transport";
+        status = "okay";
+
+        transport = <&uart1>;
+        type = "serial";
+      };
+
+      down2: down2{
+        compatible = "zephyr,smpmgr-transport";
+        status = "okay";
+
+        transport = <&uart0>;
+        type = "ble";
+      };
+
+      my_muxer: my_muxer {
+        compatible = "zephyr,smpmgr-forward";
+        status = "okay";
+
+        upstream = <&the_upstream>;
+        downstream = <&down1>, <&down2>;
+      };
+    };
+
+  In the above example when the protocol mux counter is 0 the content is
+  pushed to zephyr,uart-mcumgr. In any other case the system will forward to
+  the respective downstream port. An error is returned if the index is out of
+  range.
+
+  The content that came from the local or a downstream port is forward to the
+  upstream interface.
+
+compatible: "zephyr,smpmgr-forward"
+
+include:
+  - name: base.yaml
+
+properties:
+  upstream:
+    type: phandle
+    required: true
+    description: |
+      phandle to the upstream node. This should be a zephyr,smpmgr-transport
+      node.
+
+  downstream:
+    type: phandles
+    required: true
+    description: |
+      list of the phandle to all downstream nodes. These should be a
+      zephyr,smpmgr-transport node. The order of the nodes define the interface
+      number.

--- a/dts/bindings/misc/zephyr,smpmgr-transport.yaml
+++ b/dts/bindings/misc/zephyr,smpmgr-transport.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 Freedom Veiculos Eletricos
+# SPDX-License-Identifier: Apache-2.0
+
+description: SMP MCUmgr Interface
+
+compatible: "zephyr,smpmgr-transport"
+
+include:
+  - name: base.yaml
+
+properties:
+  transport:
+    type: phandle
+    required: true
+    description: phandle to the transport node.
+
+  type:
+    type: string
+    required: true
+    enum:
+      - "serial"
+      - "ble"
+    description: define the transport type.

--- a/include/zephyr/drivers/console/uart_mcumgr.h
+++ b/include/zephyr/drivers/console/uart_mcumgr.h
@@ -27,7 +27,9 @@ struct uart_mcumgr_rx_buf {
 	void *fifo_reserved;   /* 1st word reserved for use by fifo */
 	uint8_t data[CONFIG_UART_MCUMGR_RX_BUF_SIZE];
 	int length;
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
 	const struct device *dev;
+#endif
 };
 
 /** @typedef uart_mcumgr_recv_fn

--- a/include/zephyr/drivers/console/uart_mcumgr.h
+++ b/include/zephyr/drivers/console/uart_mcumgr.h
@@ -27,6 +27,7 @@ struct uart_mcumgr_rx_buf {
 	void *fifo_reserved;   /* 1st word reserved for use by fifo */
 	uint8_t data[CONFIG_UART_MCUMGR_RX_BUF_SIZE];
 	int length;
+	const struct device *dev;
 };
 
 /** @typedef uart_mcumgr_recv_fn
@@ -43,12 +44,13 @@ typedef void uart_mcumgr_recv_fn(struct uart_mcumgr_rx_buf *rx_buf);
 /**
  * @brief Sends an mcumgr packet over UART.
  *
+ * @param dev                   Device instance
  * @param data                  Buffer containing the mcumgr packet to send.
  * @param len                   The length of the buffer, in bytes.
  *
  * @return                      0 on success; negative error code on failure.
  */
-int uart_mcumgr_send(const uint8_t *data, int len);
+int uart_mcumgr_send(const struct device *const dev, const uint8_t *data, int len);
 
 /**
  * @brief Frees the supplied receive buffer.
@@ -63,10 +65,11 @@ void uart_mcumgr_free_rx_buf(struct uart_mcumgr_rx_buf *rx_buf);
  * Configures the mcumgr UART driver to call the specified function when an
  * mcumgr request packet is received.
  *
+ * @param dev                   Device instance
  * @param cb                    The callback to execute when an mcumgr request
  *                                  packet is received.
  */
-void uart_mcumgr_register(uart_mcumgr_recv_fn *cb);
+void uart_mcumgr_register(const struct device *const dev, uart_mcumgr_recv_fn *cb);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/mgmt/mcumgr/smp/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp/smp.h
@@ -106,6 +106,10 @@ struct smp_streamer {
  */
 int smp_process_request_packet(struct smp_streamer *streamer, void *req);
 
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+int smp_ft_process_request_packet(struct smp_streamer *streamer, void *vreq);
+#endif
+
 /**
  * @brief Appends an "err" response
  *

--- a/include/zephyr/mgmt/mcumgr/transport/serial.h
+++ b/include/zephyr/mgmt/mcumgr/transport/serial.h
@@ -52,12 +52,13 @@ struct mcumgr_serial_rx_ctxt {
 /** @typedef mcumgr_serial_tx_cb
  * @brief Transmits a chunk of raw response data.
  *
+ * @param dev                   Device instance
  * @param data                  The data to transmit.
  * @param len                   The number of bytes to transmit.
  *
  * @return                      0 on success; negative error code on failure.
  */
-typedef int (*mcumgr_serial_tx_cb)(const void *data, int len);
+typedef int (*mcumgr_serial_tx_cb)(const struct device *const dev, const void *data, int len);
 
 /**
  * @brief Processes an mcumgr request fragment received over a serial
@@ -85,13 +86,15 @@ struct net_buf *mcumgr_serial_process_frag(
 /**
  * @brief Encodes and transmits an mcumgr packet over serial.
  *
+ * @param dev                   Device instance
  * @param data                  The mcumgr packet data to send.
  * @param len                   The length of the unencoded mcumgr packet.
  * @param cb                    A callback used to transmit raw bytes.
  *
  * @return                      0 on success; negative error code on failure.
  */
-int mcumgr_serial_tx_pkt(const uint8_t *data, int len, mcumgr_serial_tx_cb cb);
+int mcumgr_serial_tx_pkt(const struct device *const dev, const uint8_t *data,
+			 int len, mcumgr_serial_tx_cb cb);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/mgmt/mcumgr/transport/smp.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp.h
@@ -140,6 +140,7 @@ struct smp_transport {
 
 #ifdef CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE
 	const struct device *const dev;
+	uint8_t user_data[64];
 #endif
 };
 

--- a/include/zephyr/mgmt/mcumgr/transport/smp.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp.h
@@ -30,11 +30,16 @@ struct net_buf;
  *
  * The supplied net_buf is always consumed, regardless of return code.
  *
+ * @param dev                   Device instance
  * @param nb                    The net_buf to transmit.
  *
  * @return                      0 on success, #mcumgr_err_t code on failure.
  */
+#ifdef CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE
+typedef int (*smp_transport_out_fn)(const struct device *const dev, struct net_buf *nb);
+#else
 typedef int (*smp_transport_out_fn)(struct net_buf *nb);
+#endif
 
 /** @typedef smp_transport_get_mtu_fn
  * @brief SMP MTU query callback for transport
@@ -132,6 +137,10 @@ struct smp_transport {
 		uint16_t expected;		/* expected bytes to come */
 	} __reassembly;
 #endif
+
+#ifdef CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE
+	const struct device *const dev;
+#endif
 };
 
 /**
@@ -208,6 +217,10 @@ void smp_client_transport_register(struct smp_client_transport_entry *entry);
  * @return		Pointer to registered object. Unknown type return NULL.
  */
 struct smp_transport *smp_client_transport_get(int smpt_type);
+
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+struct smp_transport *smp_get_smpt(const struct device *const dev);
+#endif
 
 /**
  * @}

--- a/subsys/mgmt/mcumgr/smp/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/smp/CMakeLists.txt
@@ -7,3 +7,6 @@
 # Protocol API is only exposed to MCUmgr internals.
 zephyr_library()
 zephyr_library_sources(src/smp.c)
+zephyr_library_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE
+  src/forward_tree.c
+)

--- a/subsys/mgmt/mcumgr/smp/src/forward_tree.c
+++ b/subsys/mgmt/mcumgr/smp/src/forward_tree.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** SMP Forward Tree - Simple Management Protocol Forward Tree. */
+
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
+#include <zephyr/mgmt/mcumgr/smp/smp.h>
+#include <zephyr/mgmt/mcumgr/smp/smp_client.h>
+#include <zephyr/mgmt/mcumgr/transport/smp.h>
+#include <assert.h>
+#include <string.h>
+
+#include <zcbor_common.h>
+#include <zcbor_decode.h>
+#include <zcbor_encode.h>
+
+#include <mgmt/mcumgr/transport/smp_internal.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(mcumgr_forward, 4);
+
+#define SMP_FORWARD_TREE_PORT_MASK 0x0f
+#define SMP_FORWARD_TREE_PORT_BITS 0x04
+#define SMP_FORWARD_TREE_MAX_PORTS 0x10
+
+#define DT_SMP_FORWARD_INST		DT_INST(0, zephyr_smpmgr_forward)
+#define DT_SMP_UPSTREAM			DT_PHANDLE(DT_SMP_FORWARD_INST, upstream)
+#define DT_SMP_UPSTREAM_TRANSPORT 	DT_PHANDLE(DT_SMP_UPSTREAM, transport)
+
+struct smp_forward_tree_transport upstream_transport = {
+	.dev = DEVICE_DT_GET(DT_SMP_UPSTREAM_TRANSPORT),
+	.type = DT_ENUM_IDX(DT_SMP_UPSTREAM, type),
+};
+
+#define INST_DOWN_TRANSPORTS_ENTRY(node_id)					\
+{										\
+	.dev = DEVICE_DT_GET(DT_PHANDLE(node_id, transport)),			\
+	.type = DT_ENUM_IDX(node_id, type),					\
+},
+
+#define INST_DOWN_TRANSPORTS(node_id, prop, idx)				\
+	INST_DOWN_TRANSPORTS_ENTRY(DT_PHANDLE_BY_IDX(node_id, prop, idx))
+
+struct smp_forward_tree_transport downstream_transport[] = {
+	DT_FOREACH_PROP_ELEM(DT_SMP_FORWARD_INST, downstream, INST_DOWN_TRANSPORTS)
+};
+
+static int smp_read_hdr(const struct net_buf_simple *nb, struct smp_hdr *dst_hdr)
+{
+	if (nb->len < sizeof(*dst_hdr)) {
+		return MGMT_ERR_EINVAL;
+	}
+
+	memcpy(dst_hdr, nb->data, sizeof(*dst_hdr));
+	dst_hdr->nh_len = sys_be16_to_cpu(dst_hdr->nh_len);
+	dst_hdr->nh_group = sys_be16_to_cpu(dst_hdr->nh_group);
+
+	return 0;
+}
+
+static int smp_ft_read_fwd(const struct net_buf_simple *nb,
+			   struct smp_forward_tree *dst_fwd)
+{
+	uint64_t tmp_ft;
+
+	if (nb->len < sizeof(struct smp_forward_tree)) {
+		return MGMT_ERR_EINVAL;
+	}
+
+	memcpy(&tmp_ft, nb->data + (nb->len - sizeof(uint64_t)), sizeof(uint64_t));
+	tmp_ft = sys_be64_to_cpu(tmp_ft);
+	memcpy(dst_fwd, &tmp_ft, sizeof(uint64_t));
+
+	return 0;
+}
+
+int smp_ft_forward_downstream(struct smp_forward_tree *req_fwd, void *vreq)
+{
+	uint32_t shift = (req_fwd->hop - 1) * SMP_FORWARD_TREE_PORT_BITS;
+	uint8_t port = (req_fwd->port >> shift) & SMP_FORWARD_TREE_PORT_MASK;
+	struct smp_transport *smpt = NULL;
+
+	LOG_DBG("port: %d", port);
+
+	if (port >= SMP_FORWARD_TREE_MAX_PORTS
+	||  port > ARRAY_SIZE(downstream_transport)) {
+		LOG_ERR("Invalid transport index [%d]", port);
+		return MGMT_ERR_EINVAL;
+	}
+
+	smpt = smp_get_smpt(downstream_transport[port].dev);
+	if (smpt == NULL) {
+		LOG_ERR("Transport index [%d] not recognized", port);
+		for (int i = 0; i < ARRAY_SIZE(downstream_transport); ++i) {
+			LOG_DBG("transport[%d]: %s", i, downstream_transport[i].dev->name);
+		}
+
+		return MGMT_ERR_EINVAL;
+	}
+
+	--req_fwd->hop;
+
+	return smpt->functions.output(smpt->dev, vreq);
+}
+
+/**
+ * Intercept all SMP requests in an incoming packet. Each intercepted requests
+ * is evaluated sequentially looking in the header to detect the forward tree
+ * bit. When the Forward Tree bit is set the data length contains 8 additional
+ * bytes at end of the package. The Forward Tree evaluate the protocol counter
+ * to detected if the value is 0. When the value is zero the package is send to
+ * the mgmt/smp.c to process the content locally (final destination). If the
+ * counter is greater the zero the content is forwarded to the correspondent
+ * port number. If the port does not exists the package is dropped and an error
+ * is returned.
+ *
+ * If a request elicits an error response, processing of the packet is aborted.
+ * This function consumes the supplied request buffer regardless of the outcome.
+ *
+ * The function will return MGMT_ERR_EOK (0) when given an empty input stream,
+ * and will also release the buffer from the stream; it does not return
+ * MTMT_ERR_ECORRUPT, or any other MGMT error, because there was no error while
+ * processing of the input stream, it is callers fault that an empty stream has
+ * been passed to the function.
+ *
+ * @param streamer	The streamer to use for reading, writing, and transmitting.
+ * @param req		A buffer containing the request packet.
+ *
+ * @return 0 on success or when input stream is empty;
+ *         MGMT_ERR_ECORRUPT if buffer starts with non SMP data header or there
+ *         is not enough bytes to process header, or other MGMT_ERR_[...] code on
+ *         failure.
+ */
+int smp_ft_process_request_packet(struct smp_streamer *streamer, void *vreq)
+{
+	struct smp_hdr req_hdr = { 0 };
+	struct net_buf_simple clone = { 0 };
+	struct smp_forward_tree req_fwd = { 0 };
+	struct net_buf *req = vreq;
+	struct smp_transport *smpt;
+	int rc = 0;
+
+	LOG_DBG("incomming forward request...");
+
+	/*
+	 * This clone will copy the size and max length. The pointers will
+	 * reference the real data. This means that any change in the data in
+	 * the cloned data will change the real data.
+	 */
+	net_buf_simple_clone(&req->b, &clone);
+
+	do {
+		/* Read the management header. */
+		rc = smp_read_hdr(&clone, &req_hdr);
+		if (rc != 0) {
+			rc = MGMT_ERR_ECORRUPT;
+			LOG_ERR("Corrupted 1");
+			break;
+		}
+
+		LOG_DBG("Group ID: %04x", req_hdr.nh_group);
+		LOG_DBG("Seq Num:  %02x", req_hdr.nh_seq);
+		LOG_DBG("CMD ID:   %02x", req_hdr.nh_id);
+		LOG_DBG("OP:       %02x", req_hdr.nh_op);
+		LOG_DBG("Flags:    %02x", req_hdr.nh_flags);
+		LOG_DBG("Len:      %04x", req_hdr.nh_len);
+
+		/* Does buffer contain only one message and it is complete? */
+		net_buf_simple_pull(&clone, sizeof(struct smp_hdr));
+
+		if (clone.len != req_hdr.nh_len) {
+			rc = MGMT_ERR_ECORRUPT;
+			LOG_ERR("Corrupted 2");
+			break;
+		}
+
+		if (req_hdr.nh_flags & SMP_HDR_FLAG_FORWARD_TREE) {
+			LOG_DBG("Processing Forward Tree Protocol");
+			if (smp_ft_read_fwd(&clone, &req_fwd)) {
+				rc = MGMT_ERR_ECORRUPT;
+				LOG_ERR("Corrupted 3");
+				break;
+			}
+
+			LOG_DBG("hops: %02x", req_fwd.hop);
+			for (int i = req_fwd.hop - 1; i >= 0; --i) {
+				uint8_t port = ((req_fwd.port >> (i * SMP_FORWARD_TREE_PORT_BITS))
+						& SMP_FORWARD_TREE_PORT_MASK);
+				LOG_DBG("fwd[%02d]: %02x", i + 1, port);
+			}
+
+			if (req_fwd.hop > 0) {
+				LOG_ERR("forward downstream");
+				rc = smp_ft_forward_downstream(&req_fwd, vreq);
+				break;
+			}
+
+			// Drop forward tree content from payload
+			net_buf_simple_remove_mem(&clone, sizeof(struct smp_forward_tree));
+
+			// Adjust Header
+			req_hdr.nh_flags &= ~SMP_HDR_FLAG_FORWARD_TREE;
+			req_hdr.nh_len -= sizeof(struct smp_forward_tree);
+
+			// Replace Header
+			net_buf_simple_push_mem(&clone, &req_hdr, sizeof(struct smp_hdr));
+		}
+
+		if (streamer->smpt->dev == upstream_transport.dev) {
+			LOG_DBG("local port: %s", streamer->smpt->dev->name);
+			rc = smp_process_request_packet(streamer, vreq);
+		} else {
+			smpt = smp_get_smpt(upstream_transport.dev);
+			if (smpt == NULL) {
+				rc = MGMT_ERR_ECORRUPT;
+				LOG_ERR("Corrupted 4");
+				break;
+			}
+
+			LOG_DBG("forward upstream: %s", smpt->dev->name);
+			rc = smpt->functions.output(smpt->dev, vreq);
+		}
+	} while (0);
+
+	LOG_DBG("finish forward request...");
+
+	smp_free_buf(req, streamer->smpt);
+
+	return rc;
+}

--- a/subsys/mgmt/mcumgr/transport/Kconfig
+++ b/subsys/mgmt/mcumgr/transport/Kconfig
@@ -70,6 +70,12 @@ config MCUMGR_TRANSPORT_NETBUF_USER_DATA_SIZE
 	  is sufficient for Bluetooth. For UDP, the userdata must be large
 	  enough to hold IPv4/IPv6 addresses.
 
+config MCUMGR_TRANSPORT_FORWARD_TREE
+	bool "MCUmgr transport with support to forward tree"
+	help
+	  Allow the host to forward requests to multiple devices in a board.
+	  This feature do not allow the devices to communicate between then.
+
 module = MCUMGR_TRANSPORT
 module-str = mcumgr_transport
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/smp_internal.h
+++ b/subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/smp_internal.h
@@ -39,6 +39,27 @@ struct smp_hdr {
 struct smp_transport;
 struct zephyr_smp_transport;
 
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+enum smp_hdr_flag {
+	SMP_HDR_FLAG_FORWARD_TREE = 0x80,
+} __packed;
+
+struct smp_forward_tree {
+#ifdef CONFIG_LITTLE_ENDIAN
+	uint64_t port:60;
+	uint64_t hop:4;
+#else
+	uint64_t hop:4;
+	uint64_t port:60;
+#endif
+} __packed;
+
+struct smp_forward_tree_transport {
+	const struct device *const dev;
+	enum smp_transport_type type;
+};
+#endif
+
 /**
  * @brief Enqueues an incoming SMP request packet for processing.
  *

--- a/subsys/mgmt/mcumgr/transport/src/smp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp.c
@@ -16,7 +16,8 @@
 #include <mgmt/mcumgr/transport/smp_reassembly.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(mcumgr_smp, CONFIG_MCUMGR_TRANSPORT_LOG_LEVEL);
+//LOG_MODULE_REGISTER(mcumgr_smp, CONFIG_MCUMGR_TRANSPORT_LOG_LEVEL);
+LOG_MODULE_REGISTER(mcumgr_smp, 4);
 
 /* To be able to unit test some callers some functions need to be
  * demoted to allow overriding them.
@@ -42,6 +43,13 @@ static const struct k_work_queue_config smp_work_queue_config = {
 NET_BUF_POOL_DEFINE(pkt_pool, CONFIG_MCUMGR_TRANSPORT_NETBUF_COUNT,
 		    CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE,
 		    CONFIG_MCUMGR_TRANSPORT_NETBUF_USER_DATA_SIZE, NULL);
+
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+
+#define NUM_SMP_TRANSPORTS DT_NUM_INST_STATUS_OKAY(zephyr_smpmgr_transport)
+struct smp_transport *smpt_instances[NUM_SMP_TRANSPORTS] = { NULL };
+
+#endif
 
 struct net_buf *smp_packet_alloc(void)
 {
@@ -120,7 +128,12 @@ smp_process_packet(struct smp_transport *smpt, struct net_buf *nb)
 		.smpt = smpt,
 	};
 
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+	LOG_DBG("Process transport: %s", smpt->dev->name);
+	rc = smp_ft_process_request_packet(&streamer, nb);
+#else
 	rc = smp_process_request_packet(&streamer, nb);
+#endif
 	return rc;
 }
 
@@ -143,6 +156,10 @@ smp_handle_reqs(struct k_work *work)
 
 int smp_transport_init(struct smp_transport *smpt)
 {
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+	int counter;
+#endif
+
 	__ASSERT((smpt->functions.output != NULL),
 		 "Required transport output function pointer cannot be NULL");
 
@@ -157,8 +174,32 @@ int smp_transport_init(struct smp_transport *smpt)
 	k_work_init(&smpt->work, smp_handle_reqs);
 	k_fifo_init(&smpt->fifo);
 
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+	for (counter = 0; counter < NUM_SMP_TRANSPORTS; ++counter) {
+		if (smpt_instances[counter] == NULL) {
+			smpt_instances[counter] = smpt;
+			break;
+		}
+	}
+#endif
+
 	return 0;
 }
+
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+struct smp_transport *smp_get_smpt(const struct device *const dev)
+{
+	int counter;
+
+	for (counter = 0; counter < NUM_SMP_TRANSPORTS; ++counter) {
+		if (smpt_instances[counter]->dev == dev) {
+			return smpt_instances[counter];
+		}
+	}
+
+	return NULL;
+}
+#endif
 
 #ifdef CONFIG_SMP_CLIENT
 struct smp_transport *smp_client_transport_get(int smpt_type)

--- a/subsys/mgmt/mcumgr/transport/src/smp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp.c
@@ -240,6 +240,10 @@ void smp_client_transport_register(struct smp_client_transport_entry *entry)
 WEAK void
 smp_rx_req(struct smp_transport *smpt, struct net_buf *nb)
 {
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+	memcpy(smpt->user_data, net_buf_user_data((void *)nb), nb->user_data_size);
+#endif
+
 	k_fifo_put(&smpt->fifo, nb);
 	k_work_submit_to_queue(&smp_work_queue, &smpt->work);
 }

--- a/subsys/mgmt/mcumgr/transport/src/smp_bt.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_bt.c
@@ -25,7 +25,7 @@
 #include <mgmt/mcumgr/transport/smp_reassembly.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(mcumgr_smp, CONFIG_MCUMGR_TRANSPORT_LOG_LEVEL);
+LOG_MODULE_DECLARE(mcumgr_smp, 4);
 
 #define RESTORE_TIME COND_CODE_1(CONFIG_MCUMGR_TRANSPORT_BT_CONN_PARAM_CONTROL, \
 				 (CONFIG_MCUMGR_TRANSPORT_BT_CONN_PARAM_CONTROL_RESTORE_TIME), \
@@ -106,7 +106,26 @@ struct conn_param_data {
 };
 
 static uint8_t next_id;
-static struct smp_transport smp_bt_transport;
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+#define DT_DRV_COMPAT zephyr_smpmgr_transport
+
+#define ENTRY_BT_TRANSPORTS(inst)						\
+{										\
+	.dev = DEVICE_DT_GET(DT_INST_PHANDLE(inst, transport)),			\
+},
+
+#define INST_BT_TRANSPORTS(inst)						\
+	COND_CODE_1(DT_INST_ENUM_HAS_VALUE(inst, type, ble),			\
+	(ENTRY_BT_TRANSPORTS(inst)), ())
+
+static struct smp_transport smp_bt_transport[] = {
+	DT_INST_FOREACH_STATUS_OKAY(INST_BT_TRANSPORTS)
+};
+#else
+static struct smp_transport smp_bt_transport[1] = {};
+static const struct device *const bt_mcumgr_dev =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_hci));
+#endif
 static struct conn_param_data conn_data[CONFIG_BT_MAX_CONN];
 
 static void connected(struct bt_conn *conn, uint8_t err);
@@ -257,12 +276,12 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_INSUFFICIENT_RESOURCES);
 	}
 
-	started = (smp_reassembly_expected(&smp_bt_transport) >= 0);
+	started = (smp_reassembly_expected(smp_bt_transport) >= 0);
 
 	LOG_DBG("started = %s, buf len = %d", started ? "true" : "false", len);
 	LOG_HEXDUMP_DBG(buf, len, "buf = ");
 
-	ret = smp_reassembly_collect(&smp_bt_transport, buf, len);
+	ret = smp_reassembly_collect(smp_bt_transport, buf, len);
 	LOG_DBG("collect = %d", ret);
 
 	/*
@@ -277,14 +296,14 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 		 * error.
 		 */
 		struct smp_bt_user_data *ud =
-			(struct smp_bt_user_data *)smp_reassembly_get_ud(&smp_bt_transport);
+			(struct smp_bt_user_data *)smp_reassembly_get_ud(smp_bt_transport);
 
 		if (ud != NULL) {
 			ud->conn = NULL;
 			ud->id = 0;
 		}
 
-		smp_reassembly_drop(&smp_bt_transport);
+		smp_reassembly_drop(smp_bt_transport);
 		return BT_GATT_ERR(BT_ATT_ERR_VALUE_NOT_ALLOWED);
 	}
 
@@ -293,7 +312,7 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 		 * Transport context is attached to the buffer after first fragment
 		 * has been collected.
 		 */
-		struct smp_bt_user_data *ud = smp_reassembly_get_ud(&smp_bt_transport);
+		struct smp_bt_user_data *ud = smp_reassembly_get_ud(smp_bt_transport);
 
 		if (IS_ENABLED(CONFIG_MCUMGR_TRANSPORT_BT_CONN_PARAM_CONTROL)) {
 			conn_param_smp_enable(conn);
@@ -305,7 +324,7 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 
 	/* No more bytes are expected for this packet */
 	if (ret == 0) {
-		smp_reassembly_complete(&smp_bt_transport, false);
+		smp_reassembly_complete(smp_bt_transport, false);
 	}
 
 	/* BT expects entire len to be consumed */
@@ -342,7 +361,7 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 		conn_param_smp_enable(conn);
 	}
 
-	smp_rx_req(&smp_bt_transport, nb);
+	smp_rx_req(smp_bt_transport, nb);
 
 	return len;
 #endif
@@ -351,13 +370,13 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 static void smp_bt_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT_REASSEMBLY
-	if (smp_reassembly_expected(&smp_bt_transport) >= 0 && value == 0) {
-		struct smp_bt_user_data *ud = smp_reassembly_get_ud(&smp_bt_transport);
+	if (smp_reassembly_expected(smp_bt_transport) >= 0 && value == 0) {
+		struct smp_bt_user_data *ud = smp_reassembly_get_ud(smp_bt_transport);
 
 		ud->conn = NULL;
 		ud->id = 0;
 
-		smp_reassembly_drop(&smp_bt_transport);
+		smp_reassembly_drop(smp_bt_transport);
 	}
 #endif
 }
@@ -391,6 +410,20 @@ int smp_bt_notify(struct bt_conn *conn, const void *data, uint16_t len)
 static struct bt_conn *smp_bt_conn_from_pkt(const struct net_buf *nb)
 {
 	struct smp_bt_user_data *ud = net_buf_user_data(nb);
+
+	if (!ud->conn) {
+		return NULL;
+	}
+
+	return ud->conn;
+}
+
+/**
+ * Extracts the Bluetooth connection from a transport user data.
+ */
+static struct bt_conn *smp_bt_conn_from_smpt(void)
+{
+	struct smp_bt_user_data *ud = (struct smp_bt_user_data *) &smp_bt_transport[0].user_data;
 
 	if (!ud->conn) {
 		return NULL;
@@ -445,12 +478,16 @@ static int smp_bt_ud_copy(struct net_buf *dst, const struct net_buf *src)
 /**
  * Transmits the specified SMP response.
  */
-static int smp_bt_tx_pkt(struct net_buf *nb)
+static int smp_bt_tx_pkt(
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+	const struct device *dev,
+#endif
+	struct net_buf *nb)
 {
 	struct bt_conn *conn;
 	int rc = MGMT_ERR_EOK;
 	uint16_t off = 0;
-	uint16_t mtu_size;
+	uint16_t mtu_size = 0;
 	struct bt_gatt_notify_params notify_param = {
 		.attr = attr_smp_bt_svc + 2,
 		.func = smp_notify_finished,
@@ -461,8 +498,15 @@ static int smp_bt_tx_pkt(struct net_buf *nb)
 	struct conn_param_data *cpd;
 	struct smp_bt_user_data *ud;
 
+	LOG_DBG("");
+
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+	conn = smp_bt_conn_from_smpt();
+#else
 	conn = smp_bt_conn_from_pkt(nb);
+#endif
 	if (conn == NULL) {
+		LOG_DBG("smp_bt_conn_from_pkt is NULL");
 		rc = MGMT_ERR_ENOENT;
 		goto cleanup;
 	}
@@ -474,27 +518,42 @@ static int smp_bt_tx_pkt(struct net_buf *nb)
 	 * dropped, this avoids waiting for a semaphore that will never be given which would
 	 * otherwise cause a deadlock.
 	 */
+
 	rc = bt_conn_get_info(conn, &info);
 
 	if (rc != 0 || info.state != BT_CONN_STATE_CONNECTED) {
+		LOG_DBG("bt_conn_get_info device is deconnected");
+
 		/* Remote device has disconnected */
 		rc = MGMT_ERR_ENOENT;
 		goto cleanup;
 	}
 
 	/* Send data in chunks of the MTU size */
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+	if (conn) {
+		mtu_size = bt_gatt_get_mtu(conn) - 3;
+	}
+#else
 	mtu_size = smp_bt_get_mtu(nb);
+#endif
 
 	if (mtu_size == 0U) {
+		LOG_DBG("smp_bt_get_mtu transport cannot support a transmission right now");
 		/* The transport cannot support a transmission right now. */
 		rc = MGMT_ERR_EUNKNOWN;
 		goto cleanup;
 	}
 
 	cpd = conn_param_data_get(conn);
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+	ud = (struct smp_bt_user_data *) &smp_bt_transport[0].user_data;
+#else
 	ud = net_buf_user_data(nb);
+#endif
 
 	if (cpd == NULL || cpd->id == 0 || cpd->id != ud->id) {
+		LOG_DBG("The device that sent this packet has disconnected or is not the same active connection, drop the outgoing data");
 		/* The device that sent this packet has disconnected or is not the same active
 		 * connection, drop the outgoing data
 		 */
@@ -504,11 +563,14 @@ static int smp_bt_tx_pkt(struct net_buf *nb)
 
 	k_sem_reset(&cpd->smp_notify_sem);
 
+	LOG_DBG("Start to send data");
+
 	while (off < nb->len) {
 		if (cpd->id == 0 || cpd->id != ud->id) {
 			/* The device that sent this packet has disconnected or is not the same
 			 * active connection, drop the outgoing data
 			 */
+			LOG_DBG("The device that sent this packet has disconnected or is not the same active connection, drop the outgoing data");
 			rc = MGMT_ERR_ENOENT;
 			goto cleanup;
 		}
@@ -532,6 +594,7 @@ static int smp_bt_tx_pkt(struct net_buf *nb)
 					/* If unable to send a 20 byte message, something is
 					 * amiss, no point in continuing
 					 */
+					LOG_DBG("If unable to send a 20 byte message, something is amiss, no point in continuing");
 					rc = MGMT_ERR_ENOMEM;
 					break;
 				}
@@ -555,12 +618,18 @@ static int smp_bt_tx_pkt(struct net_buf *nb)
 			k_sem_take(&cpd->smp_notify_sem, K_FOREVER);
 		} else {
 			/* No connection, cannot continue */
+			LOG_DBG("No connection, cannot continue");
 			rc = MGMT_ERR_EUNKNOWN;
 			break;
 		}
 	}
 
+	LOG_DBG("Finished to send data");
+
 cleanup:
+	LOG_DBG("cleanup");
+
+	memset(smp_bt_transport[0].user_data, 0, sizeof(smp_bt_transport[0].user_data));
 	smp_bt_ud_free(net_buf_user_data(nb));
 	smp_packet_free(nb);
 
@@ -595,7 +664,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	/* Remove all pending requests from this device which have yet to be processed from the
 	 * FIFO (for this specific connection).
 	 */
-	smp_rx_remove_invalid(&smp_bt_transport, (void *)conn);
+	smp_rx_remove_invalid(smp_bt_transport, (void *)conn);
 
 	/* Force giving the notification semaphore here, this is only needed if there is a pending
 	 * outgoing packet when the device has disconnected, as in this case the notification
@@ -664,13 +733,13 @@ static void smp_bt_setup(void)
 		++i;
 	}
 
-	smp_bt_transport.functions.output = smp_bt_tx_pkt;
-	smp_bt_transport.functions.get_mtu = smp_bt_get_mtu;
-	smp_bt_transport.functions.ud_copy = smp_bt_ud_copy;
-	smp_bt_transport.functions.ud_free = smp_bt_ud_free;
-	smp_bt_transport.functions.query_valid_check = smp_bt_query_valid_check;
+	smp_bt_transport[0].functions.output = smp_bt_tx_pkt;
+	smp_bt_transport[0].functions.get_mtu = smp_bt_get_mtu;
+	smp_bt_transport[0].functions.ud_copy = smp_bt_ud_copy;
+	smp_bt_transport[0].functions.ud_free = smp_bt_ud_free;
+	smp_bt_transport[0].functions.query_valid_check = smp_bt_query_valid_check;
 
-	rc = smp_transport_init(&smp_bt_transport);
+	rc = smp_transport_init(smp_bt_transport);
 
 	if (IS_ENABLED(CONFIG_MCUMGR_TRANSPORT_BT_DYNAMIC_SVC_REGISTRATION) && rc == 0) {
 		rc = smp_bt_register();
@@ -678,7 +747,7 @@ static void smp_bt_setup(void)
 
 #ifdef CONFIG_SMP_CLIENT
 	if (rc == 0) {
-		smp_client_transport.smpt = &smp_bt_transport;
+		smp_client_transport.smpt = smp_bt_transport;
 		smp_client_transport.smpt_type = SMP_BLUETOOTH_TRANSPORT;
 		smp_client_transport_register(&smp_client_transport);
 	}

--- a/subsys/mgmt/mcumgr/transport/src/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_shell.c
@@ -228,7 +228,7 @@ static int smp_shell_tx_pkt(struct net_buf *nb)
 	int rc;
 
 	shell_uart = (struct shell_uart_common *)shell_backend_uart_get_ptr()->iface->ctx;
-	rc = mcumgr_serial_tx_pkt(nb->data, nb->len, smp_shell_tx_raw);
+	rc = mcumgr_serial_tx_pkt(shell_uart->dev, nb->data, nb->len, smp_shell_tx_raw);
 	smp_packet_free(nb);
 
 	return rc;

--- a/subsys/mgmt/mcumgr/transport/src/smp_uart.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_uart.c
@@ -20,10 +20,31 @@
 
 #include <mgmt/mcumgr/transport/smp_internal.h>
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(smp_uart, 4);
+
 BUILD_ASSERT(CONFIG_MCUMGR_TRANSPORT_UART_MTU != 0, "CONFIG_MCUMGR_TRANSPORT_UART_MTU must be > 0");
 
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+#define DT_DRV_COMPAT zephyr_smpmgr_transport
+
+#define ENTRY_SERIAL_TRANSPORTS(inst)						\
+{										\
+	.dev = DEVICE_DT_GET(DT_INST_PHANDLE(inst, transport)),			\
+},
+
+#define INST_SERIAL_TRANSPORTS(inst)						\
+	COND_CODE_1(DT_INST_ENUM_HAS_VALUE(inst, type, serial),			\
+	(ENTRY_SERIAL_TRANSPORTS(inst)), ())
+
+static struct smp_transport smp_uart_transport[] = {
+	DT_INST_FOREACH_STATUS_OKAY(INST_SERIAL_TRANSPORTS)
+};
+#else
+static struct smp_transport smp_uart_transport[1] = {};
 static const struct device *const uart_mcumgr_dev =
 	DEVICE_DT_GET(DT_CHOSEN(zephyr_uart_mcumgr));
+#endif
 
 struct device;
 
@@ -33,7 +54,6 @@ K_FIFO_DEFINE(smp_uart_rx_fifo);
 K_WORK_DEFINE(smp_uart_work, smp_uart_process_rx_queue);
 
 static struct mcumgr_serial_rx_ctxt smp_uart_rx_ctxt;
-static struct smp_transport smp_uart_transport;
 #ifdef CONFIG_SMP_CLIENT
 static struct smp_client_transport_entry smp_client_transport;
 #endif
@@ -44,6 +64,14 @@ static struct smp_client_transport_entry smp_client_transport;
 static void smp_uart_process_frag(struct uart_mcumgr_rx_buf *rx_buf)
 {
 	struct net_buf *nb;
+
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+	struct smp_transport *transport = NULL;
+	int inst;
+
+	LOG_DBG("RX from %s", rx_buf->dev->name);
+#endif
+	LOG_HEXDUMP_DBG(rx_buf->data, rx_buf->length, "RX");
 
 	/* Decode the fragment and write the result to the global receive
 	 * context.
@@ -58,7 +86,21 @@ static void smp_uart_process_frag(struct uart_mcumgr_rx_buf *rx_buf)
 	 * processing.
 	 */
 	if (nb != NULL) {
-		smp_rx_req(&smp_uart_transport, nb);
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+		for (inst = 0; inst < ARRAY_SIZE(smp_uart_transport); ++inst)
+		{
+			if (smp_uart_transport[inst].dev == rx_buf->dev) {
+				transport = &smp_uart_transport[inst];
+				break;
+			}
+		}
+
+		if (transport) {
+			smp_rx_req(transport, nb);
+		}
+#else
+		smp_rx_req(smp_uart_transport, nb);
+#endif
 	}
 }
 
@@ -86,11 +128,24 @@ static uint16_t smp_uart_get_mtu(const struct net_buf *nb)
 	return CONFIG_MCUMGR_TRANSPORT_UART_MTU;
 }
 
-static int smp_uart_tx_pkt(struct net_buf *nb)
+static int smp_uart_tx_pkt(
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+	const struct device *dev,
+#endif
+	struct net_buf *nb)
 {
 	int rc;
 
-	rc = uart_mcumgr_send(uart_mcumgr_dev, nb->data, nb->len);
+	LOG_HEXDUMP_DBG(nb->data, nb->len, "TX");
+
+	rc = uart_mcumgr_send(
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+		dev,
+#else
+		uart_mcumgr_dev,
+#endif
+		nb->data, nb->len);
+
 	smp_packet_free(nb);
 
 	return rc;
@@ -99,22 +154,35 @@ static int smp_uart_tx_pkt(struct net_buf *nb)
 static int smp_uart_init(void)
 {
 	int rc;
+	int inst;
 
-	smp_uart_transport.functions.output = smp_uart_tx_pkt;
-	smp_uart_transport.functions.get_mtu = smp_uart_get_mtu;
+	for (inst = 0; inst < ARRAY_SIZE(smp_uart_transport); ++inst)
+	{
+		smp_uart_transport[inst].functions.output = smp_uart_tx_pkt;
+		smp_uart_transport[inst].functions.get_mtu = smp_uart_get_mtu;
 
-	rc = smp_transport_init(&smp_uart_transport);
+		rc = smp_transport_init(&smp_uart_transport[inst]);
 
-	if (rc == 0) {
+		if (rc) {
+			return rc;
+		}
+
+#if defined(CONFIG_MCUMGR_TRANSPORT_FORWARD_TREE)
+		LOG_DBG("uart dev[%d]: %s", inst, smp_uart_transport[inst].dev->name);
+		uart_mcumgr_register(smp_uart_transport[inst].dev, smp_uart_rx_frag);
+#else
+		LOG_DBG("uart dev: %s", uart_mcumgr_dev->name);
 		uart_mcumgr_register(uart_mcumgr_dev, smp_uart_rx_frag);
-#ifdef CONFIG_SMP_CLIENT
-		smp_client_transport.smpt = &smp_uart_transport;
-		smp_client_transport.smpt_type = SMP_SERIAL_TRANSPORT;
-		smp_client_transport_register(&smp_client_transport);
 #endif
 	}
 
-	return rc;
+#ifdef CONFIG_SMP_CLIENT
+	smp_client_transport.smpt = &smp_uart_transport;
+	smp_client_transport.smpt_type = SMP_SERIAL_TRANSPORT;
+	smp_client_transport_register(&smp_client_transport);
+#endif
+
+	return 0;
 }
 
 SYS_INIT(smp_uart_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/subsys/mgmt/mcumgr/transport/src/smp_uart.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_uart.c
@@ -22,6 +22,9 @@
 
 BUILD_ASSERT(CONFIG_MCUMGR_TRANSPORT_UART_MTU != 0, "CONFIG_MCUMGR_TRANSPORT_UART_MTU must be > 0");
 
+static const struct device *const uart_mcumgr_dev =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_uart_mcumgr));
+
 struct device;
 
 static void smp_uart_process_rx_queue(struct k_work *work);
@@ -87,7 +90,7 @@ static int smp_uart_tx_pkt(struct net_buf *nb)
 {
 	int rc;
 
-	rc = uart_mcumgr_send(nb->data, nb->len);
+	rc = uart_mcumgr_send(uart_mcumgr_dev, nb->data, nb->len);
 	smp_packet_free(nb);
 
 	return rc;
@@ -103,7 +106,7 @@ static int smp_uart_init(void)
 	rc = smp_transport_init(&smp_uart_transport);
 
 	if (rc == 0) {
-		uart_mcumgr_register(smp_uart_rx_frag);
+		uart_mcumgr_register(uart_mcumgr_dev, smp_uart_rx_frag);
 #ifdef CONFIG_SMP_CLIENT
 		smp_client_transport.smpt = &smp_uart_transport;
 		smp_client_transport.smpt_type = SMP_SERIAL_TRANSPORT;


### PR DESCRIPTION
smp: Add forward tree protocol

Introduce the Forward Tree protocol (FT). The FT route data downstream in a tree of MCUmgr devices. This solution target a system composed by multiple units that are physically interconnected and have a single point of external communication. Some example of possible scenarios:

* SoM (System on Module) composed by multiple MCUs
* Wheel chair
* autonomous vehicles (ROS) [ cars, boats, planes, drones etc)

The Flag 0x80 was selected to indicate that the data payload contains additionally the FT 8 bytes. This 8 bytes are placed at end of regular group payload. The FT payload is composed by 16 nimbles. The first nimble is the number of hops down in the tree, which in total can handle 15. The remaining nimbles identify the downstream port index.

The FT is a generic downstream route protocol mechanism and it is not designed to create network were a downstream device can send communication upstream or downstream.
    
```
    FT example:
                              host
                               |
                               D1
                              /|\
                         ----- | -----
                        /      D3     \
                       D2      |      D4
                              / \
                      D5------   ------D6
```
    
The host is the controller which sends SMP requests. This means that data flows from host to devices in the downstream direction. A response from a device to host is the upstream direction.

In this scenario, all upstream messages are processed as a transparent forward response to the host or without any changes the content.

A downstream message needs to be inspected when the FORWARD_TREE flag bit (0x80) is set. The FT payload format is compose by 16 nimbles. The most left nimble is the hops counter. All the other nimbles are port indexes.
    
```
           ---- Nimble 15       ---- Nimble 1
          /                    /
      0xH0'00'00'00'00'00'00'0N
        \
         --- hops
```
    
Assuming that the host wants to send data to D4 device:

1- set the hops property to 1
2- add the FT port[0] nimble as 2

The correspondent FT big endian data payload in the wire will be:
    
```
                                ---- Nimble 1
                               /
      0x10'00'00'00'00'00'00'02
        \
         --- hops
```
    
In this case, when host send the data to D1 the device will inspect the
content and forward downstream in the D1 port[2], where D4 is connected.

In the same way, when host wants to send a request to D6:

1- set the hops property to 2
2- set the FT port[1] nimble to 1 and port[0] nimble to 1
    
```
                                ---- Ninble 2
                               /---- Nimble 1
                              //
      0x20'00'00'00'00'00'00'11
        \
         --- hops
```
    
This means that each time a device must inspect the FT payload and forward downstream the hops count should be reduced by 1 and when hops is evaluated to 0 the device must consume the package.

The system will use the hops value to index the correspondent FT port nimble. In summary, the FT lower port index represents the route closer to the destine and the high port index represents the node closer to the device that start the request.

Forward Tree Protocol proposal:
<img width="578" height="255" alt="image" src="https://github.com/user-attachments/assets/d87bd377-3c41-4c66-b726-95b1479c3da0" />

Devicetree example

```
/ {
	chosen {
		/* Compatibility mode - MCUmgr forward is disabled */
		zephyr,uart-mcumgr = &cdc_acm_uart0;
	};

	mcumgr_upstream: upstream {
		compatible = "zephyr,smpmgr-transport";
		status = "okay";

		transport = <&cdc_acm_uart0>;
	};

	mcumgr_downstream0: downstream0 {
		compatible = "zephyr,smpmgr-transport";
		status = "okay";

		transport = <&uart0>;
	};

	mcumgr_downstream1: downstream1 {
		compatible = "zephyr,smpmgr-transport";
		status = "okay";

		transport = <&uart1>;
	};

	mcumgr_forward: mcumgr_forward {
		compatible = "zephyr,smpmgr-forward";
		status = "okay";

		upstream = <&mcumgr_upstream>;
		downstream = <&mcumgr_downstream0>, <&mcumgr_downstream1>;
	};
};

&zephyr_udc0 {
	cdc_acm_uart0: cdc_acm_uart0 {
		compatible = "zephyr,cdc-acm-uart";
		label = "Zephyr USB CDC-ACM";
	};
};
```

Python Client:
https://github.com/JPHutchins/smp/pull/49
https://github.com/intercreate/smpmgr/pull/62

Example of command line for the 2 examples in the comments:

```
smpmgr --port /dev/ttyACMx --forward-tree "[1, 2]" os echo test
```

```
smpmgr --port /dev/ttyACMx --forward-tree "[2, 1, 1]" os echo test
```

Pros:
1- Add a capability to update a complex scenario with multiple devices interconnected
2- No changes in the protocol allowing compatibility
3- Very small implementation to inspect and forward
4- Support 15 levels of interconnection and 16 ports per level

Cons:
1- Require some reworking in the transports to better handle in/out and store transports more efficient
2- Overhead of 8 bytes in downstream direction

Notes:
1- This still a proposal and it is open to comments
2- There is no intention to create a network and make devices to talk between then

CC: @otavio 