### PR TITLE
dts: arm: st: stm32h5: fix line feature avail. and can dflt clock

### DIFF
--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -529,7 +529,8 @@
 			reg-names = "m_can", "message_ram";
 			interrupts = <39 0>, <40 0>;
 			interrupt-names = "int0", "int1";
-			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>,
+				 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -544,28 +544,6 @@
 			status = "disabled";
 		};
 
-		ethernet@40028000 {
-			reg = <0x40028000 0x8000>;
-			compatible = "st,stm32-ethernet-controller";
-			clock-names = "stm-eth";
-			clocks = <&rcc STM32_CLOCK(AHB1, 19)>;
-
-			mac: ethernet {
-				compatible = "st,stm32h7-ethernet", "st,stm32-ethernet";
-				interrupts = <106 0>;
-				clock-names = "mac-clk-tx", "mac-clk-rx";
-				clocks = <&rcc STM32_CLOCK(AHB1, 20)>,
-					 <&rcc STM32_CLOCK(AHB1, 21)>;
-				status = "disabled";
-			};
-
-			mdio: mdio {
-				compatible = "st,stm32-mdio";
-				#address-cells = <1>;
-				#size-cells = <0>;
-				status = "disabled";
-			};
-		};
 
 		gpdma1: dma@40020000 {
 			compatible = "st,stm32u5-dma";
@@ -636,30 +614,6 @@
 				STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
 			interrupts = <57 3>;
-			status = "disabled";
-		};
-
-		sai1_a: sai1@40015404 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015404 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
-				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
-			dmas = <&gpdma1 1 53 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-				STM32_DMA_16BITS)>;
-			status = "disabled";
-		};
-
-		sai1_b: sai1@40015424 {
-			compatible = "st,stm32-sai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015424 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
-				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
-			dmas = <&gpdma1 0 54 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
-				STM32_DMA_16BITS)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h523.dtsi
+++ b/dts/arm/st/h5/stm32h523.dtsi
@@ -32,7 +32,8 @@
 			interrupts = <109 0>, <110 0>;
 			interrupt-names = "int0", "int1";
 			/* common clock FDCAN 1 & 2 */
-			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>,
+				 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h5/stm32h523.dtsi
+++ b/dts/arm/st/h5/stm32h523.dtsi
@@ -24,5 +24,17 @@
 			clocks = <&rcc STM32_CLOCK(AHB4, 16)>;
 			status = "disabled";
 		};
+
+		fdcan2: can@4000a800 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a800 0x400>, <0x4000ac00 0x6a0>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <109 0>, <110 0>;
+			interrupt-names = "int0", "int1";
+			/* common clock FDCAN 1 & 2 */
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -123,6 +123,30 @@
 			status = "disabled";
 		};
 
+		sai1_a: sai1@40015404 {
+			compatible = "st,stm32-sai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40015404 0x20>;
+			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
+				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
+			dmas = <&gpdma1 1 53 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
+				STM32_DMA_16BITS)>;
+			status = "disabled";
+		};
+
+		sai1_b: sai1@40015424 {
+			compatible = "st,stm32-sai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40015424 0x20>;
+			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
+				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
+			dmas = <&gpdma1 0 54 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
+				STM32_DMA_16BITS)>;
+			status = "disabled";
+		};
+
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
@@ -486,18 +510,6 @@
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
 			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <116 0>;
-			status = "disabled";
-		};
-
-		fdcan2: can@4000a800 {
-			compatible = "st,stm32-fdcan";
-			reg = <0x4000a800 0x400>, <0x4000ac00 0x6a0>;
-			reg-names = "m_can", "message_ram";
-			interrupts = <109 0>, <110 0>;
-			interrupt-names = "int0", "int1";
-			/* common clock FDCAN 1 & 2 */
-			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
-			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -19,5 +19,40 @@
 			interrupts = <102 0>;
 			status = "disabled";
 		};
+
+		ethernet@40028000 {
+			reg = <0x40028000 0x8000>;
+			compatible = "st,stm32-ethernet-controller";
+			clock-names = "stm-eth";
+			clocks = <&rcc STM32_CLOCK(AHB1, 19)>;
+
+			mac: ethernet {
+				compatible = "st,stm32h7-ethernet", "st,stm32-ethernet";
+				interrupts = <106 0>;
+				clock-names = "mac-clk-tx", "mac-clk-rx";
+				clocks = <&rcc STM32_CLOCK(AHB1, 20)>,
+					 <&rcc STM32_CLOCK(AHB1, 21)>;
+				status = "disabled";
+			};
+
+			mdio: mdio {
+				compatible = "st,stm32-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
+
+		fdcan2: can@4000a800 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a800 0x400>, <0x4000ac00 0x6a0>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <109 0>, <110 0>;
+			interrupt-names = "int0", "int1";
+			/* common clock FDCAN 1 & 2 */
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -50,7 +50,8 @@
 			interrupts = <109 0>, <110 0>;
 			interrupt-names = "int0", "int1";
 			/* common clock FDCAN 1 & 2 */
-			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>,
+				 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};


### PR DESCRIPTION
Fix peripheral availability per STM32H5 line and set the default clock source for FDCAN.

Some peripherals are not available on the entry level lines of the stm32h5 series:
- FDCAN2 only on SoCs >= H523, but not on h562
- SAI only on >= H562
- Ethernet only on >= H563

Fixes #96152