### PR TITLE
driver: sensor: tsl2591: fix unintended sign extension

### DIFF
--- a/drivers/sensor/ams/tsl2591/tsl2591.c
+++ b/drivers/sensor/ams/tsl2591/tsl2591.c
@@ -192,7 +192,7 @@ static int tsl2591_set_threshold(const struct device *dev, enum sensor_attribute
 	int ret;
 
 	/* Convert from relative strength of visible light to raw value */
-	cpl = data->atime * data->again;
+	cpl = (uint32_t)data->atime * (uint32_t)data->again;
 	raw = ((val->val1 * cpl) / TSL2591_LUX_DF) +
 	      ((val->val2 * cpl) / (1000000U * TSL2591_LUX_DF));
 


### PR DESCRIPTION
There is a unintended sign extension in the 195 line of tsl2591.c If the result of multiplication is greater than 0x7fffffff, the high bits of cpl would be all 1
Signed-off-by: weijunzhou <20044439@163.com>