### PR TITLE
doc: flash_debug: add macOS tab for LinkServer

### DIFF
--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -255,6 +255,12 @@ path to add is:
 
          /usr/local/LinkServer
 
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+         /Applications/LinkServer_<version>
+
    .. group-tab:: Windows
 
       .. code-block:: console


### PR DESCRIPTION
Add default path for LinkServer in macOS