### PR TITLE
arch: arm64: core: include kernel_arch_func.h to mitigate warning

### DIFF
--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -14,6 +14,8 @@
  * initialization is performed.
  */
 
+#include "kernel_arch_func.h"
+
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/platform/hooks.h>
 #include <zephyr/arch/cache.h>


### PR DESCRIPTION
A warning was promoted to error in twister runs due to implicit declaration of the function `z_arm64_safe_exception_stack_init()`.

Include `kernel_arch_func.h` in `prep_c.c` to mitigate the warning.

This should fix 685 failures in the weekly twister run, as well as most builds targeting `fvp_baser_aemv8r/fvp_aemv8r_aarch64` or similar platforms.

Testing Done:
```shell
west build -p auto -b fvp_baser_aemv8r/fvp_aemv8r_aarch64 -t run tests/posix/rwlocks -T portability.posix.rwlocks.minimal
```