### PR TITLE
tests: posix: xsi_single_process: reduce min ram to 16 kiB

### DIFF
--- a/tests/posix/xsi_single_process/testcase.yaml
+++ b/tests/posix/xsi_single_process/testcase.yaml
@@ -10,6 +10,7 @@ common:
     - simulation
   integration_platforms:
     - qemu_cortex_m0
+  min_ram: 16
 tests:
   portability.xsi.single_process:
     extra_configs:
@@ -31,7 +32,6 @@ tests:
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE=256
-    min_ram: 24
   portability.xsi.single_process.picolibc:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED


### PR DESCRIPTION
The `qemu_cortex_m0/nrf51822` platform only has 16 kiB of RAM. However, `qemu_cortex_m0` is listed as one of the integration platforms for this testsuite and the `newlib` test configuration listed a `min_ram` of 24.

This causes twister to fail to generate a test plan.
```shell
INFO: Error found: portability.xsi.single_process.newlib on qemu_cortex_m0/nrf51822 (Not enough RAM but is one of the integration platforms)
```

Decrease the minimum ram for that platform (universally) down to 16 kiB so that all of the test configurations can run, thus avoiding the false positive error condition in twister.

The failure can be reproduced in `main` as of 1bccaeea96c1086949f7c0a5a6e178d3a5a79466 and also fixes failures in pull requests. E.g. https://github.com/zephyrproject-rtos/zephyr/actions/runs/17711543186/job/50330875396?pr=95939

Testing Done:
```shell
twister -c -p qemu_cortex_m0/nrf51822 -T tests/posix/xsi_single_process
Deleting output directory /Users/cfriedt/zephyrproject/zephyr/twister-out
INFO    - Using Ninja..
INFO    - Zephyr version: v4.2.0-3606-g8e1c995cf03b
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /Users/cfriedt/zephyrproject/zephyr/twister-out/testplan.json
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    4/   4  100%  built (not run):    0, filtered:    2, failed:    0, error:    0
INFO    - 6 test scenarios (6 configurations) selected, 2 configurations filtered (2 by static filter, 0 at runtime).
INFO    - 4 of 4 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 36.82 seconds.
INFO    - 12 of 12 executed test cases passed (100.00%) on 1 out of total 1175 platforms (0.09%).
INFO    - 4 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /Users/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /Users/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /Users/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```