### PR TITLE
MAINTAINERS.yml: Remove nandojve as BouffaloLab maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -690,7 +690,6 @@ Bootloaders:
 Bouffalolab Platforms:
   status: maintained
   maintainers:
-    - nandojve
     - VynDragon
   files:
     - boards/bflb/
@@ -5265,7 +5264,6 @@ West:
 "West project: hal_bouffalolab":
   status: maintained
   maintainers:
-    - nandojve
     - VynDragon
   files:
     - modules/hal_bouffalolab/


### PR DESCRIPTION
The Bouffalo Lab has been evolved since it was introduced. It can now grow in the hands of community. The platform is not isolated and there is an active maintainer which is active working.