### PR TITLE
dts: arm: xilinx: fix zynqmp RPU IPI mailbox base addresses

### DIFF
--- a/dts/arm/xilinx/zynqmp_rpu.dtsi
+++ b/dts/arm/xilinx/zynqmp_rpu.dtsi
@@ -31,24 +31,24 @@
 				      IRQ_DEFAULT_PRIORITY>;
 			local-ipi-id = <1>;
 
-			rpu0_apu_mailbox: mailbox@ff990200 {
+			rpu0_apu_mailbox: mailbox@ff990000 {
 				remote-ipi-id = <0>;
-				reg = <0xff990200 0x20>,
-				      <0xff990220 0x20>,
-				      <0xff990040 0x20>,
-				      <0xff990060 0x20>;
+				reg = <0xff990000 0x20>,
+				      <0xff990020 0x20>,
+				      <0xff990400 0x20>,
+				      <0xff990420 0x20>;
 				reg-names = "local_request_region",
 					    "local_response_region",
 					    "remote_request_region",
 					    "remote_response_region";
 			};
 
-			rpu0_rpu1_mailbox: mailbox@ff990260 {
+			rpu0_rpu1_mailbox: mailbox@ff990040 {
 				remote-ipi-id = <2>;
-				reg = <0xff990260 0x20>,
-				      <0xff990280 0x20>,
-				      <0xff990420 0x20>,
-				      <0xff990440 0x20>;
+				reg = <0xff990040 0x20>,
+				      <0xff990060 0x20>,
+				      <0xff990200 0x20>,
+				      <0xff990220 0x20>;
 
 				reg-names = "local_request_region",
 					    "local_response_region",
@@ -70,24 +70,24 @@
 			interrupts = <GIC_SPI 34 IRQ_TYPE_LEVEL
 				      IRQ_DEFAULT_PRIORITY>;
 
-			rpu1_apu_mailbox: mailbox@ff990400 {
+			rpu1_apu_mailbox: mailbox@ff990200 {
 				remote-ipi-id = <0>;
-				reg = <0xff990400 0x20>,
-				      <0xff990420 0x20>,
-				      <0xff990080 0x20>,
-				      <0xff9900a0 0x20>;
+				reg = <0xff990200 0x20>,
+				      <0xff990220 0x20>,
+				      <0xff990440 0x20>,
+				      <0xff990460 0x20>;
 				reg-names = "local_request_region",
 					    "local_response_region",
 					    "remote_request_region",
 					    "remote_response_region";
 			};
 
-			rpu1_rpu0_mailbox: mailbox@ff990420 {
+			rpu1_rpu0_mailbox: mailbox@ff990240 {
 				remote-ipi-id = <1>;
-				reg = <0xff990420 0x20>,
-				      <0xff990440 0x20>,
+				reg = <0xff990240 0x20>,
 				      <0xff990260 0x20>,
-				      <0xff990280 0x20>;
+				      <0xff990040 0x20>,
+				      <0xff990060 0x20>;
 				reg-names = "local_request_region",
 					    "local_response_region",
 					    "remote_request_region",


### PR DESCRIPTION
The RPU0 mailbox node in `zynqmp_rpu.dtsi` used incorrect IPI message buffer base addresses. According to UG1085 (Table 13-3)[1], RPU0 should use the channel 1 message buffer region at `0xFF99_0000` for local request/response and `0xFF99_0400` for remote request/ response. The previous values pointed to the APU channel 0 buffer (`0xFF99_0200`), which does not match the hardware mapping. The same is true for rpu1.

Fix the DTS by updating the RPU0, RPU1 mailbox nodes to use the correct base addresses from the documentation.

[1] https://docs.amd.com/v/u/en-US/ug1085-zynq-ultrascale-trm