### PR TITLE
drivers: lora: sx126x: add timeout on wait on busy

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -305,7 +305,7 @@ manifest:
       revision: 9a14f6772c1d6e303bacb2d594c8063bb804b6ee
       path: modules/lib/lora-basics-modem
     - name: loramac-node
-      revision: fb00b383072518c918e2258b0916c996f2d4eebe
+      revision: c1a86534fd663b127d45f2d0eae0d88c75e26243
       path: modules/lib/loramac-node
     - name: lvgl
       revision: b03edc8e6282a963cd312cd0b409eb5ce263ea75


### PR DESCRIPTION
There are some use cases where previously the driver could enter an infinite loop if for some reason the wait on busy pin failed to complete. This could happen due hardware issues. Based on this, implement a timeout of 1 second and emit an error in this scenario rather than causing a lockup.