### PR TITLE
dts: doc: add binding type for CRC device driver

### DIFF
--- a/dts/bindings/binding-types.txt
+++ b/dts/bindings/binding-types.txt
@@ -32,6 +32,7 @@ comparator	Comparator
 coredump	Core dump
 counter	Counter
 cpu	CPU (Central Processing Unit)
+crc	CRC (Cyclic Redundancy Check)
 crypto	Cryptographic accelerator
 dac	DAC (Digital to Analog Converter)
 dai	DAI (Digital Audio Interface)


### PR DESCRIPTION
Add CRC binding type for supported device doc generator

Signed-off-by: The Nguyen <the.nguyen.yf@renesas.com>