### PR TITLE
soc: rockchip: replace MT_NS with MT_DEFAULT_SECURE_STATE for rk3588

### DIFF
--- a/soc/rockchip/rk35/rk3588/mmu_regions.c
+++ b/soc/rockchip/rk35/rk3588/mmu_regions.c
@@ -2,6 +2,8 @@
  * Copyright (c) 2025 Syswonder
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright The Zephyr Project Contributors
  */
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
@@ -11,15 +13,15 @@ static const struct arm_mmu_region mmu_regions[] = {
 
 	MMU_REGION_FLAT_ENTRY("GIC", DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 0),
 			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 0),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
 
 	MMU_REGION_FLAT_ENTRY("GIC", DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 1),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
 
 };
 
 const struct arm_mmu_config mmu_config = {
 	.num_regions = ARRAY_SIZE(mmu_regions),
-	.mmu_regions = mmu_regions,
+.mmu_regions = mmu_regions,
 };


### PR DESCRIPTION
This pull request makes minor updates to the `rk3588/mmu_regions.c` file, including a copyright notice addition and a change to the MMU region security attribute for GIC regions.

- **Copyright and Licensing**
  * Added a copyright line for "The Zephyr Project Contributors" to the file header.

- **MMU Region Security Attribute Update**
  * Updated the MMU region entries for the GIC device to use `MT_DEFAULT_SECURE_STATE` instead of `MT_NS`, aligning the security attribute with the default secure state macro.