### PR TITLE
soc: rockchip: update rk3588 NUM_IRQS

### DIFF
--- a/soc/rockchip/rk35/rk3588/Kconfig.defconfig.rk3588
+++ b/soc/rockchip/rk35/rk3588/Kconfig.defconfig.rk3588
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Syswonder
 # SPDX-License-Identifier: Apache-2.0
+# Copyright The Zephyr Project Contributors
 
 if SOC_RK3588
 
@@ -10,7 +11,7 @@ config FLASH_BASE_ADDRESS
 	default 0
 
 config NUM_IRQS
-	default 370
+	default 508
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)


### PR DESCRIPTION
This pull request updates the default configuration for the RK3588 SoC in Zephyr. The main changes are an increase in the default number of IRQs and the addition of a copyright notice.

Configuration updates:

* Increased the default value of `NUM_IRQS` from 370 to 508 in `rk3588/Kconfig.defconfig.rk3588`, reflecting support for more interrupt sources.

Documentation and licensing:

* Added a copyright notice for The Zephyr Project Contributors at the top of `rk3588/Kconfig.defconfig.rk3588`.Update NUM_IRQS value according to chip manual

ref: https://wiki.friendlyelec.com/wiki/images/e/ee/Rockchip_RK3588_Datasheet_V1.6-20231016.pdf