### PR TITLE
soc: rockchip: fix rk3588 mistake

### DIFF
--- a/soc/rockchip/rk35/rk3588/Kconfig.defconfig.rk3588
+++ b/soc/rockchip/rk35/rk3588/Kconfig.defconfig.rk3588
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Syswonder
 # SPDX-License-Identifier: Apache-2.0
+# Copyright The Zephyr Project Contributors
 
 if SOC_RK3588
 
@@ -10,7 +11,7 @@ config FLASH_BASE_ADDRESS
 	default 0
 
 config NUM_IRQS
-	default 370
+	default 508
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)

--- a/soc/rockchip/rk35/rk3588/mmu_regions.c
+++ b/soc/rockchip/rk35/rk3588/mmu_regions.c
@@ -1,21 +1,22 @@
 /*
  * Copyright (c) 2025 Syswonder
- *
  * SPDX-License-Identifier: Apache-2.0
+ * Copyright The Zephyr Project Contributors
  */
+
+#include <zephyr/arch/arm64/arm_mmu.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/arch/arm64/arm_mmu.h>
 
 static const struct arm_mmu_region mmu_regions[] = {
 
 	MMU_REGION_FLAT_ENTRY("GIC", DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 0),
 			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 0),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
 
 	MMU_REGION_FLAT_ENTRY("GIC", DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 1),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
 
 };
 


### PR DESCRIPTION
This pull request updates the Rockchip RK3588 SoC support files with changes to licensing, interrupt configuration, and MMU region attributes. The most significant updates include an increase in the default number of IRQs and improvements to the MMU region security configuration.

**Licensing and Copyright:**
* Added "The Zephyr Project Contributors" to the copyright notices in both `Kconfig.defconfig.rk3588` and `mmu_regions.c` to ensure proper attribution.

**Platform Configuration:**
* Increased the default value of `NUM_IRQS` from 370 to 508 in `Kconfig.defconfig.rk3588` to support more interrupt sources.

**MMU Region Configuration:**
* Changed the MMU region attributes for GIC regions from `MT_NS` (Non-secure) to `MT_DEFAULT_SECURE_STATE` for more flexible and secure memory attribute configuration in `mmu_regions.c`.

ref: https://wiki.friendlyelec.com/wiki/images/e/ee/Rockchip_RK3588_Datasheet_V1.6-20231016.pdf