### PR TITLE
docs: Fix board name description for FK7B0M1-VBT6

### DIFF
--- a/boards/fanke/fk7b0m1_vbt6/doc/index.rst
+++ b/boards/fanke/fk7b0m1_vbt6/doc/index.rst
@@ -30,7 +30,7 @@ Hardware
 
 FK7B0M1-VBT6 provides the following hardware components:
 
-- STM32H7B6VB in LQFP100 package
+- STM32H7B0VB in LQFP100 package
 - ARM 32-bit Cortex-M7 CPU with FPU
 - 280 MHz max CPU frequency
 - VDD from 1.62 V to 3.6 V


### PR DESCRIPTION
Fixes  https://github.com/zephyrproject-rtos/zephyr/issues/95488

**Issue:**
The documentation for the FK7B0M1-VBT6 board contains a spelling error in the “description” field. This may mislead other developers.

**Solution:**
This PR corrects the spelling error to ensure the accuracy of the documentation.

This is a minor documentation fix intended to assist other developers.

