### PR TITLE
drivers: i2c: stm32: Fix STM32 I2C hang on read

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -343,13 +343,14 @@ static void i2c_stm32_slave_event(const struct device *dev)
 	slave_cb = slave_cfg->callbacks;
 
 	if (LL_I2C_IsActiveFlag_TXIS(i2c)) {
-		uint8_t val;
+		uint8_t val = 0x00;
 
 		if (slave_cb->read_processed(slave_cfg, &val) < 0) {
 			LOG_ERR("Error continuing reading");
-		} else {
-			LL_I2C_TransmitData8(i2c, val);
 		}
+
+		LL_I2C_TransmitData8(i2c, val);
+
 		return;
 	}
 


### PR DESCRIPTION
ensure LL_I2C_TransmitData8() is always called when TXIS is set, even if read_processed() returns an error. This prevents the peripheral from clock-stretching indefinitely and blocking the I2C bus when the master reads from the slave.

fixes: #95762