### PR TITLE
PocketBeagle 2: A53: Enable watchdog timer

### DIFF
--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am62_a53-common.dtsi
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am62_a53-common.dtsi
@@ -18,6 +18,7 @@
 
 	aliases {
 		led0 = &led1;
+		watchdog0 = &main_rti0;
 	};
 
 	ddr0: memory@80000000 {
@@ -77,5 +78,9 @@
 &main_gpio0 {
 	pinctrl-0 = <&led_pins_default>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&main_rti0 {
 	status = "okay";
 };

--- a/dts/vendor/ti/k3-am62-main.dtsi
+++ b/dts/vendor/ti/k3-am62-main.dtsi
@@ -125,4 +125,39 @@
 		ngpios = <32>;
 		status = "disabled";
 	};
+
+	main_rti0: watchdog@e000000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0x0e000000 0x100>;
+		clock-frequency = <DT_FREQ_M(25)>;
+		status = "disabled";
+	};
+
+	main_rti1: watchdog@e010000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0x0e010000 0x100>;
+		clock-frequency = <DT_FREQ_M(25)>;
+		status = "disabled";
+	};
+
+	main_rti2: watchdog@e020000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0x0e020000 0x100>;
+		clock-frequency = <DT_FREQ_M(25)>;
+		status = "disabled";
+	};
+
+	main_rti3: watchdog@e030000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0x0e030000 0x100>;
+		clock-frequency = <DT_FREQ_M(25)>;
+		status = "disabled";
+	};
+
+	main_rti15: watchdog@e0f0000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0x0e0f0000 0x100>;
+		clock-frequency = <DT_FREQ_M(25)>;
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
- Tested on PocketBeagle 2 with the samples/drivers/watchdog.