### PR TITLE
Add support System Timer for Renesas RZ/V2L, RZ/A3UL

### DIFF
--- a/dts/arm/renesas/rz/rzv/r9a07g054.dtsi
+++ b/dts/arm/renesas/rz/rzv/r9a07g054.dtsi
@@ -883,6 +883,48 @@
 			#mbox-cells = <1>;
 			status = "disabled";
 		};
+
+		gtm0: gtm@42801000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42801000 0x400>;
+			channel = <0>;
+			interrupts = <46 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			os_timer {
+				compatible = "renesas,rz-gtm-os-timer";
+				status = "disabled";
+			};
+		};
+
+		gtm1: gtm@42801400 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42801400 0x400>;
+			channel = <1>;
+			interrupts = <47 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			os_timer {
+				compatible = "renesas,rz-gtm-os-timer";
+				status = "disabled";
+			};
+		};
+
+		gtm2: gtm@42801800 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42801800 0x400>;
+			channel = <2>;
+			interrupts = <48 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			os_timer {
+				compatible = "renesas,rz-gtm-os-timer";
+				status = "disabled";
+			};
+		};
 	};
 };
 

--- a/dts/arm64/renesas/rz/rza/r9a07g063.dtsi
+++ b/dts/arm64/renesas/rz/rza/r9a07g063.dtsi
@@ -646,5 +646,47 @@
 			interrupt-names = "rxi", "txi", "tei", "naki", "spi", "sti", "ali", "tmoi";
 			status = "disabled";
 		};
+
+		gtm0: gtm@12801000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x12801000 0x400>;
+			channel = <0>;
+			interrupts = <GIC_SPI 46 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			os_timer {
+				compatible = "renesas,rz-gtm-os-timer";
+				status = "disabled";
+			};
+		};
+
+		gtm1: gtm@12801400 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x12801400 0x400>;
+			channel = <1>;
+			interrupts = <GIC_SPI 47 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			os_timer {
+				compatible = "renesas,rz-gtm-os-timer";
+				status = "disabled";
+			};
+		};
+
+		gtm2: gtm@12801800 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x12801800 0x400>;
+			channel = <2>;
+			interrupts = <GIC_SPI 48 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			os_timer {
+				compatible = "renesas,rz-gtm-os-timer";
+				status = "disabled";
+			};
+		};
 	};
 };

--- a/soc/renesas/rz/rza3ul/Kconfig
+++ b/soc/renesas/rz/rza3ul/Kconfig
@@ -4,6 +4,6 @@
 config SOC_SERIES_RZA3UL
 	select ARM64
 	select CPU_CORTEX_A55
-	select ARM_ARCH_TIMER
+	select ARM_ARCH_TIMER if !RZ_OS_TIMER
 	select HAS_RENESAS_RZ_FSP
 	select SOC_EARLY_INIT_HOOK

--- a/tests/kernel/tickless/tickless_concept/boards/rza3ul_smarc.overlay
+++ b/tests/kernel/tickless/tickless_concept/boards/rza3ul_smarc.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	os_timer {
+		status = "okay";
+	};
+};

--- a/tests/kernel/tickless/tickless_concept/boards/rzv2l_smarc_r9a07g054l23gbg_cm33.overlay
+++ b/tests/kernel/tickless/tickless_concept/boards/rzv2l_smarc_r9a07g054l23gbg_cm33.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	os_timer {
+		status = "okay";
+	};
+};
+
+&systick {
+	status = "disabled";
+};


### PR DESCRIPTION
Add support system timer for Renesas RZ/V2L, RZ/A3UL:
- Update `drivers/counter/renesas_rz_gtm_timer.c` to using common source code for Renesas RZ devices
- Add device tree for Renesas RZ/V2L, A3UL
- Test: support `tests/kernel/tickles/tickless_concept` test

Need: https://github.com/zephyrproject-rtos/hal_renesas/pull/130