### PR TITLE
dts: nxp: Use DT_FREQ_M/K() and DT_SIZE_M/K() 

### DIFF
--- a/boards/nxp/frdm_k32l2b3/frdm_k32l2b3.dts
+++ b/boards/nxp/frdm_k32l2b3/frdm_k32l2b3.dts
@@ -63,7 +63,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <48000000>;
+	clock-frequency = <DT_FREQ_M(48)>;
 };
 
 &sim {

--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -114,7 +114,7 @@ arduino_serial: &uart3 {
 };
 
 &cpu0 {
-	clock-frequency = <120000000>;
+	clock-frequency = <DT_FREQ_M(120)>;
 };
 
 &adc0 {
@@ -173,7 +173,7 @@ arduino_spi: &spi0 {
 			disk-name = "SD";
 			status = "okay";
 		};
-		spi-max-frequency = <24000000>;
+		spi-max-frequency = <DT_FREQ_M(24)>;
 	};
 };
 

--- a/boards/nxp/frdm_k82f/frdm_k82f.dts
+++ b/boards/nxp/frdm_k82f/frdm_k82f.dts
@@ -233,7 +233,7 @@
 	mx25u32: mx25u3235f@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <104000000>;
+		spi-max-frequency = <DT_FREQ_M(104)>;
 		wp-gpios = <&gpioe 3 0>;
 		reset-gpios = <&gpioe 0 0>;
 		size = <0x2000000>;

--- a/boards/nxp/frdm_k82f/frdm_k82f.dts
+++ b/boards/nxp/frdm_k82f/frdm_k82f.dts
@@ -236,7 +236,7 @@
 		spi-max-frequency = <DT_FREQ_M(104)>;
 		wp-gpios = <&gpioe 3 0>;
 		reset-gpios = <&gpioe 0 0>;
-		size = <0x2000000>;
+		size = <DT_SIZE_M(32)>;
 		jedec-id = [c2 25 36];
 	};
 };

--- a/boards/nxp/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/nxp/frdm_kl25z/frdm_kl25z.dts
@@ -98,7 +98,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <48000000>;
+	clock-frequency = <DT_FREQ_M(48)>;
 };
 
 &adc0 {

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242.dts
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242.dts
@@ -99,7 +99,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <48000000>;
+	clock-frequency = <DT_FREQ_M(48)>;
 };
 
 &osc {

--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444.dts
@@ -99,7 +99,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <48000000>;
+	clock-frequency = <DT_FREQ_M(48)>;
 };
 
 &osc {

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -226,7 +226,7 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 		status = "disabled";
 		size = <67108864>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		jedec-id = [ef 40 17];
 		erase-block-size = <4096>;
 		write-block-size = <1>;

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -224,11 +224,11 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 	w25q64jvssiq: w25q64jvssiq@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		status = "disabled";
-		size = <67108864>;
+		size = <DT_SIZE_M(64)>;
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(133)>;
 		jedec-id = [ef 40 17];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 		cs-interval-unit = <1>;
 		cs-interval = <2>;

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -162,7 +162,7 @@
 		/* this is the default (reset) mode for this flash */
 		mxicy,mx25r-power-mode = "low-power";
 		/* 8 MHz for low power mode */
-		spi-max-frequency = <8000000>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
 };
 

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -134,7 +134,7 @@
 		jedec-id = [ef 40 20];
 		erase-block-size = <4096>;
 		write-block-size = <1>;
-		spi-max-frequency = <104000000>;
+		spi-max-frequency = <DT_FREQ_M(104)>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -172,7 +172,7 @@
 		/* APS6404L is 8MB, 64MBit pSRAM */
 		size = <DT_SIZE_M(8 * 8)>;
 		reg = <2>;
-		spi-max-frequency = <109000000>;
+		spi-max-frequency = <DT_FREQ_M(109)>;
 		/* PSRAM cannot be enabled while board is in default XIP
 		 * configuration, as it will conflict with flash chip.
 		 */

--- a/boards/nxp/hexiwear/hexiwear_mk64f12.dts
+++ b/boards/nxp/hexiwear/hexiwear_mk64f12.dts
@@ -95,7 +95,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <120000000>;
+	clock-frequency = <DT_FREQ_M(120)>;
 };
 
 &adc0 {

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -179,7 +179,7 @@
 
 &lpspi3 {
 	status = "disabled";
-	clock-frequency = <1000000>;
+	clock-frequency = <DT_FREQ_M(1)>;
 	pinctrl-0 = <&spi3_default>;
 	pinctrl-names = "default";
 };

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -60,7 +60,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(1024)>;
 		reg = <0>;
-		spi-max-frequency = <200000000>;
+		spi-max-frequency = <DT_FREQ_M(200)>;
 		status = "okay";
 		jedec-id = [2c 5b 1b];
 		erase-block-size = <4096>;

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -63,7 +63,7 @@
 		spi-max-frequency = <DT_FREQ_M(200)>;
 		status = "okay";
 		jedec-id = [2c 5b 1b];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <2>;
 
 		partitions {

--- a/boards/nxp/lpcxpresso11u68/lpcxpresso11u68.dts
+++ b/boards/nxp/lpcxpresso11u68/lpcxpresso11u68.dts
@@ -119,7 +119,7 @@ arduino_i2c: &i2c0 {
 };
 
 &cpu0 {
-	clock-frequency = <48000000>;
+	clock-frequency = <DT_FREQ_M(48)>;
 };
 
 &gpio0 {

--- a/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m0.dts
+++ b/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m0.dts
@@ -23,7 +23,7 @@
 };
 
 &cpu1 {
-	clock-frequency = <48000000>;
+	clock-frequency = <DT_FREQ_M(48)>;
 };
 
 &mailbox0 {

--- a/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m4.dts
+++ b/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m4.dts
@@ -64,7 +64,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <48000000>;
+	clock-frequency = <DT_FREQ_M(48)>;
 };
 
 &mailbox0 {

--- a/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk.dtsi
+++ b/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk.dtsi
@@ -171,7 +171,7 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 		status = "disabled";
 		size = <67108864>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		jedec-id = [ef 40 17];
 		erase-block-size = <4096>;
 		write-block-size = <1>;

--- a/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk.dtsi
+++ b/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk.dtsi
@@ -169,11 +169,11 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 	w25q64jwtbjq: w25q64jwtbjq@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		status = "disabled";
-		size = <67108864>;
+		size = <DT_SIZE_M(64)>;
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(133)>;
 		jedec-id = [ef 40 17];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 		cs-interval-unit = <1>;
 		cs-interval = <2>;

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -99,7 +99,7 @@ arduino_serial: &lpuart1 {};
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(16 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [1f 89 01];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -102,7 +102,7 @@ arduino_serial: &lpuart1 {};
 		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [1f 89 01];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -96,7 +96,7 @@ arduino_serial: &lpuart4 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(16 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [1f 89 01];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -99,7 +99,7 @@ arduino_serial: &lpuart4 {
 		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [1f 89 01];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -103,7 +103,7 @@ arduino_serial: &lpuart2 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(8*8)>;
 		reg = <0>;
-		spi-max-frequency = <104000000>;
+		spi-max-frequency = <DT_FREQ_M(104)>;
 		status = "okay";
 		jedec-id = [9d 60 17];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -106,7 +106,7 @@ arduino_serial: &lpuart2 {
 		spi-max-frequency = <DT_FREQ_M(104)>;
 		status = "okay";
 		jedec-id = [9d 60 17];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -129,7 +129,7 @@
 		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 40 17];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -126,7 +126,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <(DT_SIZE_M(8) * 8)>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 40 17];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.dts
@@ -31,7 +31,7 @@
 		compatible = "nxp,imx-flexspi-hyperflash";
 		size = <DT_SIZE_M(64*8)>;
 		reg = <0>;
-		spi-max-frequency = <166000000>;
+		spi-max-frequency = <DT_FREQ_M(166)>;
 		word-addressable;
 		cs-interval-unit = <1>;
 		cs-interval = <2>;

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.dts
@@ -25,7 +25,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(8 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <104000000>;
+		spi-max-frequency = <DT_FREQ_M(104)>;
 		status = "okay";
 		jedec-id = [9d 70 17];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.dts
@@ -28,7 +28,7 @@
 		spi-max-frequency = <DT_FREQ_M(104)>;
 		status = "okay";
 		jedec-id = [9d 70 17];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.dts
@@ -29,7 +29,7 @@
 		compatible = "nxp,imx-flexspi-hyperflash";
 		size = <DT_SIZE_M(64*8)>;
 		reg = <0>;
-		spi-max-frequency = <166000000>;
+		spi-max-frequency = <DT_FREQ_M(166)>;
 		word-addressable;
 		cs-interval-unit = <1>;
 		cs-interval = <2>;

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.dts
@@ -27,7 +27,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(8 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <104000000>;
+		spi-max-frequency = <DT_FREQ_M(104)>;
 		status = "okay";
 		jedec-id = [9d 70 17];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.dts
@@ -30,7 +30,7 @@
 		spi-max-frequency = <DT_FREQ_M(104)>;
 		status = "okay";
 		jedec-id = [9d 70 17];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -59,7 +59,7 @@
 		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 60 18];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -56,7 +56,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(16*8)>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 60 18];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -195,7 +195,7 @@
 		compatible = "nxp,imx-flexspi-hyperflash";
 		size = <DT_SIZE_M(64*8)>;
 		reg = <0>;
-		spi-max-frequency = <166000000>;
+		spi-max-frequency = <DT_FREQ_M(166)>;
 		word-addressable;
 		cs-interval-unit = <1>;
 		cs-interval = <2>;
@@ -320,7 +320,7 @@
 	ism330dhcx: ism330dhcx@0 {
 		compatible = "st,ism330dhcx";
 		status = "disabled";
-		spi-max-frequency = <1000000>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
 		reg = <0>;
 	};
 };

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -171,7 +171,7 @@ nxp_parallel_i2c: &lpi2c1 {};
 		spi-max-frequency = <DT_FREQ_M(104)>;
 		status = "okay";
 		jedec-id = [9d 70 17];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -168,7 +168,7 @@ nxp_parallel_i2c: &lpi2c1 {};
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(8 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <104000000>;
+		spi-max-frequency = <DT_FREQ_M(104)>;
 		status = "okay";
 		jedec-id = [9d 70 17];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -98,7 +98,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(16*8)>;
 		reg = <0>;
-		spi-max-frequency = <104000000>;
+		spi-max-frequency = <DT_FREQ_M(104)>;
 		status = "okay";
 		jedec-id = [9d 70 18];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.dts
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.dts
@@ -146,7 +146,7 @@ nxp_csi: &csi {};
 zephyr_lcdif: &lcdif {};
 
 zephyr_mipi_dsi: &mipi_dsi {
-	dphy-ref-frequency = <24000000>;
+	dphy-ref-frequency = <DT_FREQ_M(24)>;
 };
 
 nxp_mipi_i2c: &lpi2c5 {

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -266,7 +266,7 @@ arduino_spi: &lpspi1 {
 		spi-max-frequency = <DT_FREQ_M(104)>;
 		status = "okay";
 		jedec-id = [9d 70 18];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -263,7 +263,7 @@ arduino_spi: &lpspi1 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(16*8)>;
 		reg = <0>;
-		spi-max-frequency = <104000000>;
+		spi-max-frequency = <DT_FREQ_M(104)>;
 		status = "okay";
 		jedec-id = [9d 70 18];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -29,7 +29,7 @@
 		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 60 20];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -26,7 +26,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(64*8)>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 60 20];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
@@ -90,7 +90,7 @@
 zephyr_lcdif: &lcdif {};
 
 zephyr_mipi_dsi: &mipi_dsi {
-	dphy-ref-frequency = <24000000>;
+	dphy-ref-frequency = <DT_FREQ_M(24)>;
 };
 
 &lpuart1 {

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -30,7 +30,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(64*8)>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 60 20];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -33,7 +33,7 @@
 		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 60 20];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk.dtsi
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk.dtsi
@@ -191,7 +191,7 @@
 		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 60 18];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk.dtsi
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk.dtsi
@@ -188,7 +188,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(16*8)>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 60 18];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -403,7 +403,7 @@ zephyr_udc0: &usbhs {
 		spi-max-frequency = <DT_FREQ_M(200)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <2>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR set */
 
 		partitions {

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -400,7 +400,7 @@ zephyr_udc0: &usbhs {
 		/* MX25UM51245G is 64MB, 512MBit flash part */
 		size = <DT_SIZE_M(64 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <200000000>;
+		spi-max-frequency = <DT_FREQ_M(200)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <4096>;
@@ -453,7 +453,7 @@ zephyr_udc0: &usbhs {
 		/* APS6408L is 8MB, 64MBit pSRAM */
 		size = <DT_SIZE_M(8 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <198000000>;
+		spi-max-frequency = <DT_FREQ_M(198)>;
 		status = "okay";
 		cs-interval-unit = <1>;
 		cs-interval = <5>;

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -268,7 +268,7 @@ i2s1: &flexcomm3 {
 		spi-max-frequency = <DT_FREQ_M(200)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_STR set */
 
 		partitions {

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -265,7 +265,7 @@ i2s1: &flexcomm3 {
 		/* MX25UM51245G is 64MB, 512MBit flash part */
 		size = <DT_SIZE_M(64 * 8)>;
 		reg = <2>;
-		spi-max-frequency = <200000000>;
+		spi-max-frequency = <DT_FREQ_M(200)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <4096>;

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -334,7 +334,7 @@ zephyr_lcdif: &lcdif {};
 		spi-max-frequency = <DT_FREQ_M(200)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <2>;
 	};
 };

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -331,7 +331,7 @@ zephyr_lcdif: &lcdif {};
 		/* MX25UM51245G is 64MB, 512MBit flash part */
 		size = <DT_SIZE_M(64 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <200000000>;
+		spi-max-frequency = <DT_FREQ_M(200)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <4096>;

--- a/boards/nxp/rd_rw612_bga/dts/goworld_16880_lcm.overlay
+++ b/boards/nxp/rd_rw612_bga/dts/goworld_16880_lcm.overlay
@@ -47,7 +47,7 @@
 		compatible = "sitronix,st7796s";
 		status = "okay";
 		reg = <0>;
-		mipi-max-frequency = <23000000>;
+		mipi-max-frequency = <DT_FREQ_M(23)>;
 		duplex = <SPI_HALF_DUPLEX>;
 		height = <320>;
 		width = <480>;

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -147,7 +147,7 @@ arduino_i2c: &flexcomm2 {
 		size = <DT_SIZE_M(64 * 8)>;
 		status = "okay";
 		jedec-id = [c2 25 3a];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -141,7 +141,7 @@ arduino_i2c: &flexcomm2 {
 
 	mx25u51245g: mx25u51245g@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		reg = <0>;
 		/* MX25UM51245G is 64MB, 512MBit flash part */
 		size = <DT_SIZE_M(64 * 8)>;
@@ -186,7 +186,7 @@ arduino_i2c: &flexcomm2 {
 		/* IS66WVQ8M4 is 4MB, 32MBit pSRAM */
 		size = <DT_SIZE_M(32)>;
 		reg = <2>;
-		spi-max-frequency = <256000000>;
+		spi-max-frequency = <DT_FREQ_M(256)>;
 		/* PSRAM cannot be enabled while board is in default XIP
 		 * configuration, as it will conflict with flash chip.
 		 */

--- a/boards/nxp/s32k148_evb/s32k148_evb.dts
+++ b/boards/nxp/s32k148_evb/s32k148_evb.dts
@@ -95,7 +95,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <80000000>;
+	clock-frequency = <DT_FREQ_M(80)>;
 };
 
 &gpioa {

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
@@ -27,7 +27,7 @@
 	local-mac-address = [00 00 00 01 02 00];
 	pinctrl-0 = <&eth0_default>;
 	pinctrl-names = "default";
-	clock-frequency = <300000000>;
+	clock-frequency = <DT_FREQ_M(300)>;
 	phy-handle = <&phy0>;
 	status = "okay";
 };

--- a/boards/nxp/twr_ke18f/twr_ke18f.dts
+++ b/boards/nxp/twr_ke18f/twr_ke18f.dts
@@ -151,7 +151,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <120000000>;
+	clock-frequency = <DT_FREQ_M(120)>;
 };
 
 &idle {
@@ -173,7 +173,7 @@
 
 	sosc_clk {
 		status = "okay";
-		clock-frequency = <8000000>;
+		clock-frequency = <DT_FREQ_M(8)>;
 	};
 
 	pll {

--- a/boards/nxp/ucans32k1sic/ucans32k1sic.dts
+++ b/boards/nxp/ucans32k1sic/ucans32k1sic.dts
@@ -103,7 +103,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <80000000>;
+	clock-frequency = <DT_FREQ_M(80)>;
 };
 
 &gpioa {

--- a/boards/nxp/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/nxp/usb_kw24d512/usb_kw24d512.dts
@@ -56,7 +56,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <48000000>;
+	clock-frequency = <DT_FREQ_M(48)>;
 };
 
 &adc0 {

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
@@ -208,7 +208,7 @@
 		spi-max-frequency = <DT_FREQ_M(200)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <2>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR set */
 
 		partitions {

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
@@ -205,7 +205,7 @@
 		/* MX25UM51245G is 64MB, 512MBit flash part */
 		size = <DT_SIZE_M(64 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <200000000>;
+		spi-max-frequency = <DT_FREQ_M(200)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <4096>;

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -261,7 +261,7 @@
 		compatible = "invensense,icm42686", "invensense,icm4268x";
 		reg = <0>;
 		int-gpios = <&gpio3 19 GPIO_ACTIVE_HIGH>;
-		spi-max-frequency = <24000000>;
+		spi-max-frequency = <DT_FREQ_M(24)>;
 		accel-pwr-mode = <ICM42686_DT_ACCEL_LN>;
 		accel-odr = <ICM42686_DT_ACCEL_ODR_1000>;
 		accel-fs = <ICM42686_DT_ACCEL_FS_16>;
@@ -287,7 +287,7 @@
 		compatible = "invensense,icm42688", "invensense,icm4268x";
 		reg = <0>;
 		int-gpios = <&gpio2 7 GPIO_ACTIVE_HIGH>;
-		spi-max-frequency = <24000000>;
+		spi-max-frequency = <DT_FREQ_M(24)>;
 		accel-pwr-mode = <ICM42688_DT_ACCEL_LN>;
 		accel-odr = <ICM42688_DT_ACCEL_ODR_1000>;
 		accel-fs = <ICM42688_DT_ACCEL_FS_16>;
@@ -311,7 +311,7 @@
 		compatible = "bosch,bmi08x-accel";
 		reg = <0>;
 		int-gpios = <&gpio3 20 GPIO_ACTIVE_HIGH>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <DT_FREQ_M(10)>;
 		int1-map-io = <0x01>;
 		int2-map-io = <0x00>;
 		int1-conf-io = <0x04>;
@@ -324,7 +324,7 @@
 		compatible = "bosch,bmi08x-gyro";
 		reg = <1>;
 		int-gpios = <&gpio2 28 GPIO_ACTIVE_HIGH>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <DT_FREQ_M(10)>;
 		int3-4-map-io = <0x01>;
 		int3-4-conf-io = <0x02>;
 		gyro-hz = "1000_116";

--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/rdc/imx_rdc.h>

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/arm/nxp/nxp_imx8m_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx8m_m4.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/rdc/imx_rdc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
+#include <freq.h>
 
 / {
 	cpus {

--- a/dts/arm/nxp/nxp_imx8ml_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx8ml_m7.dtsi
@@ -8,6 +8,7 @@
 #include <zephyr/dt-bindings/clock/imx_ccm.h>
 #include <zephyr/dt-bindings/rdc/imx_rdc.h>
 #include <mem.h>
+#include <freq.h>
 
 / {
 	cpus {

--- a/dts/arm/nxp/nxp_imx93_m33.dtsi
+++ b/dts/arm/nxp/nxp_imx93_m33.dtsi
@@ -8,6 +8,7 @@
 #include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
+#include <freq.h>
 
 / {
 	cpus {

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -9,6 +9,7 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
+#include <freq.h>
 
 / {
 	cpus {
@@ -512,7 +513,7 @@
 			reg = <0x424d0000 DT_SIZE_K(4)>;
 			interrupts = <63 0>;
 			clocks = <&scmi_clk IMX95_CLK_LPTMR2>;
-			clock-frequency = <32000>;
+			clock-frequency = <DT_FREQ_K(32)>;
 			clk-source = <2>;
 			prescaler = <1>;
 			resolution = <32>;

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -128,7 +128,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_M(1)>;
-				erase-block-size = <2048>;
+				erase-block-size = <DT_SIZE_K(2)>;
 				write-block-size = <8>;
 			};
 		};

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -6,6 +6,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>

--- a/dts/arm/nxp/nxp_k32l2b3.dtsi
+++ b/dts/arm/nxp/nxp_k32l2b3.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv6-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>
@@ -281,7 +282,7 @@
 			compatible = "nxp,lptmr";
 			reg = <0x40040000 0x1000>;
 			interrupts = <28 0>;
-			clock-frequency = <1000>;
+			clock-frequency = <DT_FREQ_K(1)>;
 			prescaler = <1>;
 			prescale-glitch-filter = <1>;
 			clk-source = <1>;

--- a/dts/arm/nxp/nxp_k32l2b3.dtsi
+++ b/dts/arm/nxp/nxp_k32l2b3.dtsi
@@ -74,7 +74,7 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				erase-block-size = <1024>;
+				erase-block-size = <DT_SIZE_K(1)>;
 				write-block-size = <4>;
 			};
 		};

--- a/dts/arm/nxp/nxp_k66.dtsi
+++ b/dts/arm/nxp/nxp_k66.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <nxp/nxp_k6x.dtsi>
 
 &flash0 {

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -155,7 +155,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_M(1)>;
-				erase-block-size = <4096>;
+				erase-block-size = <DT_SIZE_K(4)>;
 				write-block-size = <8>;
 			};
 		};

--- a/dts/arm/nxp/nxp_k8xfn256vxx15.dtsi
+++ b/dts/arm/nxp/nxp_k8xfn256vxx15.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <nxp/nxp_k8x.dtsi>
 
 / {

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -137,13 +137,13 @@
 
 			sirc_clk: sirc_clk {
 				compatible = "fixed-clock";
-				clock-frequency = <8000000>;
+				clock-frequency = <DT_FREQ_M(8)>;
 				#clock-cells = <0>;
 			};
 
 			firc_clk: firc_clk {
 				compatible = "fixed-clock";
-				clock-frequency = <48000000>;
+				clock-frequency = <DT_FREQ_M(48)>;
 				#clock-cells = <0>;
 			};
 
@@ -253,7 +253,7 @@
 			lpo: lpo128k {
 				/* LPO clock */
 				compatible = "fixed-clock";
-				clock-frequency = <128000>;
+				clock-frequency = <DT_FREQ_K(128)>;
 				#clock-cells = <0>;
 			};
 		};
@@ -288,7 +288,7 @@
 			compatible = "nxp,lptmr";
 			reg = <0x40040000 0x1000>;
 			interrupts = <58 0>;
-			clock-frequency = <128000>;
+			clock-frequency = <DT_FREQ_K(128)>;
 			prescaler = <1>;
 			clk-source = <1>;
 			resolution = <16>;

--- a/dts/arm/nxp/nxp_ke1xf256vlx16.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf256vlx16.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <nxp/nxp_ke1xf.dtsi>
 
 / {

--- a/dts/arm/nxp/nxp_ke1xf512vlx16.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf512vlx16.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <nxp/nxp_ke1xf.dtsi>
 
 / {

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include "armv6-m.dtsi"
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_pcc.h>
@@ -23,7 +24,7 @@
 
 		cpu0: cpu@0 {
 			compatible = "arm,cortex-m0+";
-			clock-frequency = <48000000>;
+			clock-frequency = <DT_FREQ_M(48)>;
 			reg = <0>;
 			cpu-power-states = <&idle &stop &pstop1 &pstop2>;
 		};
@@ -79,13 +80,13 @@
 
 			sirc_clk: sirc_clk {
 				compatible = "fixed-clock";
-				clock-frequency = <8000000>;
+				clock-frequency = <DT_FREQ_M(8)>;
 				#clock-cells = <0>;
 			};
 
 			firc_clk: firc_clk {
 				compatible = "fixed-clock";
-				clock-frequency = <48000000>;
+				clock-frequency = <DT_FREQ_M(48)>;
 				#clock-cells = <0>;
 			};
 
@@ -188,7 +189,7 @@
 			compatible = "nxp,lptmr";
 			reg = <0x40040000 0x1000>;
 			interrupts = <29 0>;
-			clock-frequency = <128000>;
+			clock-frequency = <DT_FREQ_K(128)>;
 			prescaler = <1>;
 			clk-source = <1>;
 			resolution = <16>;
@@ -229,7 +230,7 @@
 
 			lpo: lpo128k {
 				compatible = "fixed-clock";
-				clock-frequency = <128000>;
+				clock-frequency = <DT_FREQ_K(128)>;
 				#clock-cells = <0>;
 			};
 		};

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -49,7 +49,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_K(128)>;
-				erase-block-size = <1024>;
+				erase-block-size = <DT_SIZE_K(1)>;
 				write-block-size = <4>;
 			};
 		};

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <mem.h>
+#include <freq.h>
 #include "armv6-m.dtsi"
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>

--- a/dts/arm/nxp/nxp_kv5xf1m0vlx24.dtsi
+++ b/dts/arm/nxp/nxp_kv5xf1m0vlx24.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <nxp/nxp_kv5x.dtsi>
 
 / {

--- a/dts/arm/nxp/nxp_kv5xf512vlx24.dtsi
+++ b/dts/arm/nxp/nxp_kv5xf512vlx24.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <nxp/nxp_kv5x.dtsi>
 
 / {

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -119,7 +119,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_K(512)>;
-				erase-block-size = <2048>;
+				erase-block-size = <DT_SIZE_K(2)>;
 				write-block-size = <4>;
 			};
 		};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <mem.h>
+#include <freq.h>
 #include "armv6-m.dtsi"
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -88,7 +88,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_K(512)>;
-				erase-block-size = <1024>;
+				erase-block-size = <DT_SIZE_K(1)>;
 				write-block-size = <4>;
 			};
 		};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -95,7 +95,7 @@
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_K(512)>;
-				erase-block-size = <2048>;
+				erase-block-size = <DT_SIZE_K(2)>;
 				write-block-size = <4>;
 			};
 		};

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv6-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>

--- a/dts/arm/nxp/nxp_lpc11u6x.dtsi
+++ b/dts/arm/nxp/nxp_lpc11u6x.dtsi
@@ -7,6 +7,7 @@
 #include <zephyr/dt-bindings/clock/lpc11u6x_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
+#include <freq.h>
 
 / {
 	cpus {

--- a/dts/arm/nxp/nxp_lpc51u68.dtsi
+++ b/dts/arm/nxp/nxp_lpc51u68.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 
 / {

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -5,10 +5,10 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
-#include <mem.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 
 / {

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -8,6 +8,7 @@
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 
 / {

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 
 / {

--- a/dts/arm/nxp/nxp_lpc55S2x.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 
 / {

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/inputmux/inputmux_trigger_ports.h>
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 
 / {

--- a/dts/arm/nxp/nxp_lpc55S6x.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -6,6 +6,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/nxp_mcxa153.dtsi
@@ -135,7 +135,7 @@
 			flash: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_K(128)>;
-				erase-block-size = <8192>;
+				erase-block-size = <DT_SIZE_K(8)>;
 				write-block-size = <128>;
 			};
 

--- a/dts/arm/nxp/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/nxp_mcxa153.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -166,7 +166,7 @@
 			flash: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_M(1)>;
-				erase-block-size = <8192>;
+				erase-block-size = <DT_SIZE_K(8)>;
 				write-block-size = <128>;
 			};
 

--- a/dts/arm/nxp/nxp_mcxa266.dtsi
+++ b/dts/arm/nxp/nxp_mcxa266.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_mcxa266.dtsi
+++ b/dts/arm/nxp/nxp_mcxa266.dtsi
@@ -273,7 +273,7 @@
 			flash: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_M(1)>;
-				erase-block-size = <8192>;
+				erase-block-size = <DT_SIZE_K(8)>;
 				write-block-size = <128>;
 			};
 

--- a/dts/arm/nxp/nxp_mcxa346.dtsi
+++ b/dts/arm/nxp/nxp_mcxa346.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_mcxa346.dtsi
+++ b/dts/arm/nxp/nxp_mcxa346.dtsi
@@ -273,7 +273,7 @@
 			flash: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_M(1)>;
-				erase-block-size = <8192>;
+				erase-block-size = <DT_SIZE_K(8)>;
 				write-block-size = <128>;
 			};
 

--- a/dts/arm/nxp/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxc_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv6-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>

--- a/dts/arm/nxp/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxc_common.dtsi
@@ -74,7 +74,7 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				erase-block-size = <1024>;
+				erase-block-size = <DT_SIZE_K(1)>;
 				write-block-size = <4>;
 			};
 		};

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
@@ -871,7 +872,7 @@
 		compatible = "nxp,lptmr";
 		reg = <0x4a000 0x1000>;
 		interrupts = <143 0>;
-		clock-frequency = <16000>;
+		clock-frequency = <DT_FREQ_K(16)>;
 		prescaler = <1>;
 		clk-source = <1>;
 		resolution = <32>;
@@ -881,7 +882,7 @@
 		compatible = "nxp,lptmr";
 		reg = <0x4b000 0x1000>;
 		interrupts = <144 0>;
-		clock-frequency = <16000>;
+		clock-frequency = <DT_FREQ_K(16)>;
 		prescaler = <1>;
 		clk-source = <1>;
 		resolution = <32>;

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -537,7 +537,7 @@
 		flash: flash@0 {
 			compatible = "soc-nv-flash";
 			reg = <0 DT_SIZE_M(1)>;
-			erase-block-size = <8192>;
+			erase-block-size = <DT_SIZE_K(8)>;
 			/* MCXN23x ROM Flash API supports writing of 128B pages. */
 			write-block-size = <128>;
 		};

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
@@ -831,8 +832,8 @@
 		interrupts = <61 0>;
 		status = "disabled";
 		clocks = <&syscon MCUX_USDHC1_CLK>;
-		max-bus-freq = <52000000>;
-		min-bus-freq = <400000>;
+		max-bus-freq = <DT_FREQ_M(52)>;
+		min-bus-freq = <DT_FREQ_K(400)>;
 	};
 
 	vref: vref@111000 {
@@ -934,7 +935,7 @@
 		compatible = "nxp,lptmr";
 		reg = <0x4a000 0x1000>;
 		interrupts = <143 0>;
-		clock-frequency = <16000>;
+		clock-frequency = <DT_FREQ_K(16)>;
 		prescaler = <1>;
 		clk-source = <1>;
 		resolution = <32>;
@@ -944,7 +945,7 @@
 		compatible = "nxp,lptmr";
 		reg = <0x4b000 0x1000>;
 		interrupts = <144 0>;
-		clock-frequency = <16000>;
+		clock-frequency = <DT_FREQ_K(16)>;
 		prescaler = <1>;
 		clk-source = <1>;
 		resolution = <32>;

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -634,7 +634,7 @@
 		flash: flash@0 {
 			compatible = "soc-nv-flash";
 			reg = <0 DT_SIZE_M(2)>;
-			erase-block-size = <8192>;
+			erase-block-size = <DT_SIZE_K(8)>;
 			write-block-size = <16>;
 		};
 

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -54,7 +54,7 @@
 			flash: flash@0 {
 				compatible = "soc-nv-flash";
 				write-block-size = <16>;
-				erase-block-size = <8192>;
+				erase-block-size = <DT_SIZE_K(8)>;
 			};
 		};
 

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/scg_k4.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
@@ -295,7 +296,7 @@
 		compatible = "nxp,lptmr";
 		reg = <0x2d000 0x10>;
 		interrupts = <34 0>;
-		clock-frequency = <32000>;
+		clock-frequency = <DT_FREQ_K(32)>;
 		clk-source = <2>;
 		prescaler = <1>;
 		resolution = <32>;
@@ -306,7 +307,7 @@
 		compatible = "nxp,lptmr";
 		reg = <0x2e000 0x10>;
 		interrupts = <35 0>;
-		clock-frequency = <32000>;
+		clock-frequency = <DT_FREQ_K(32)>;
 		clk-source = <2>;
 		prescaler = <1>;
 		resolution = <32>;

--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -11,7 +11,7 @@
 };
 
 &sysclk {
-	clock-frequency = <500000000>;
+	clock-frequency = <DT_FREQ_M(500)>;
 };
 
 &itcm {
@@ -48,7 +48,7 @@
 
 &gpt2 {
 	interrupts = <31 0>;
-	gptfreq = <12500000>;
+	gptfreq = <DT_FREQ_K(12500)>;
 };
 
 &edma0 {

--- a/dts/arm/nxp/nxp_rt1015.dtsi
+++ b/dts/arm/nxp/nxp_rt1015.dtsi
@@ -15,7 +15,7 @@
 };
 
 &sysclk {
-	clock-frequency = <500000000>;
+	clock-frequency = <DT_FREQ_M(500)>;
 };
 
 &itcm {
@@ -37,7 +37,7 @@
 };
 
 &gpt2 {
-	gptfreq = <12500000>;
+	gptfreq = <DT_FREQ_K(12500)>;
 };
 
 /* RT1015 only has two LPSPI blocks */

--- a/dts/arm/nxp/nxp_rt1020.dtsi
+++ b/dts/arm/nxp/nxp_rt1020.dtsi
@@ -12,7 +12,7 @@
 };
 
 &sysclk {
-	clock-frequency = <500000000>;
+	clock-frequency = <DT_FREQ_M(500)>;
 };
 
 &itcm {
@@ -34,7 +34,7 @@
 };
 
 &gpt2 {
-	gptfreq = <12500000>;
+	gptfreq = <DT_FREQ_K(12500)>;
 };
 
 / {

--- a/dts/arm/nxp/nxp_rt1024.dtsi
+++ b/dts/arm/nxp/nxp_rt1024.dtsi
@@ -12,7 +12,7 @@
 };
 
 &sysclk {
-	clock-frequency = <500000000>;
+	clock-frequency = <DT_FREQ_M(500)>;
 };
 
 /* i.MX rt1024 default FlexRAM partition:
@@ -47,7 +47,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <DT_SIZE_M(4 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 40 16];
 		erase-block-size = <DT_SIZE_K(4)>;

--- a/dts/arm/nxp/nxp_rt1040.dtsi
+++ b/dts/arm/nxp/nxp_rt1040.dtsi
@@ -11,7 +11,7 @@
 };
 
 &sysclk {
-	clock-frequency = <528000000>;
+	clock-frequency = <DT_FREQ_M(528)>;
 };
 
 &ccm {
@@ -25,7 +25,7 @@
 };
 
 &gpt2 {
-	gptfreq = <33000000>;
+	gptfreq = <DT_FREQ_M(33)>;
 };
 
 / {

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -24,7 +24,7 @@
 		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 40 16];
-		erase-block-size = <4096>;
+		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 	};
 };

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -21,7 +21,7 @@
 		compatible = "nxp,imx-flexspi-nor";
 		size = <33554432>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 40 16];
 		erase-block-size = <4096>;

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/imx_ccm.h>
@@ -43,7 +44,7 @@
 			itm: itm@e0000000 {
 				compatible = "arm,armv7m-itm";
 				reg = <0xe0000000 0x1000>;
-				swo-ref-frequency = <132000000>;
+				swo-ref-frequency = <DT_FREQ_M(132)>;
 			};
 		};
 
@@ -73,13 +74,13 @@
 
 	sysclk: system-clock {
 		compatible = "fixed-clock";
-		clock-frequency = <600000000>;
+		clock-frequency = <DT_FREQ_M(600)>;
 		#clock-cells = <0>;
 	};
 
 	xtal: clock-xtal {
 		compatible = "fixed-clock";
-		clock-frequency = <24000000>;
+		clock-frequency = <DT_FREQ_M(24)>;
 		#clock-cells = <0>;
 	};
 
@@ -92,7 +93,7 @@
 	/* USB PLL (selected to be FLEXSPI clock source) will be left unchanged */
 	usbclk: usbpll-clock {
 		compatible = "fixed-clock";
-		clock-frequency = <480000000>;
+		clock-frequency = <DT_FREQ_M(480)>;
 		#clock-cells = <0>;
 	};
 
@@ -172,7 +173,7 @@
 			compatible = "nxp,imx-gpt";
 			reg = <0x401f0000 0x4000>;
 			interrupts = <101 0>;
-			gptfreq = <25000000>;
+			gptfreq = <DT_FREQ_M(25)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x68 24>;
 		};
 
@@ -914,8 +915,8 @@
 			clocks = <&ccm IMX_CCM_USDHC1_CLK 0 0>;
 			max-current-330 = <1020>;
 			max-current-180 = <1020>;
-			max-bus-freq = <208000000>;
-			min-bus-freq = <400000>;
+			max-bus-freq = <DT_FREQ_M(208)>;
+			min-bus-freq = <DT_FREQ_K(400)>;
 		};
 
 		usdhc2: usdhc@402c4000 {
@@ -926,8 +927,8 @@
 			clocks = <&ccm IMX_CCM_USDHC2_CLK 0 0>;
 			max-current-330 = <120>;
 			max-current-180 = <45>;
-			max-bus-freq = <198000000>;
-			min-bus-freq = <400000>;
+			max-bus-freq = <DT_FREQ_M(198)>;
+			min-bus-freq = <DT_FREQ_K(400)>;
 		};
 
 		csi: csi@402bc000 {

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -54,7 +54,7 @@
 	/* USB PLL */
 	usbclk: usbpll-clock {
 		compatible = "fixed-clock";
-		clock-frequency = <24000000>;
+		clock-frequency = <DT_FREQ_M(24)>;
 		#clock-cells = <0>;
 	};
 };
@@ -92,7 +92,7 @@
 
 		lpo: lpo32k {
 			compatible = "fixed-clock";
-			clock-frequency = <32000>;
+			clock-frequency = <DT_FREQ_K(32)>;
 			#clock-cells = <0>;
 		};
 	};
@@ -335,7 +335,7 @@
 		compatible = "nxp,imx-gpt";
 		reg = <0x46c0000 0x4000>;
 		interrupts = <209 0>;
-		gptfreq = <240000000>;
+		gptfreq = <DT_FREQ_M(240)>;
 		clocks = <&ccm IMX_CCM_GPT1_CLK 0x41 0>;
 		status = "disabled";
 	};
@@ -344,7 +344,7 @@
 		compatible = "nxp,imx-gpt";
 		reg = <0x2ec0000 0x4000>;
 		interrupts = <210 0>;
-		gptfreq = <240000000>;
+		gptfreq = <DT_FREQ_M(240)>;
 		clocks = <&ccm IMX_CCM_GPT2_CLK 0x41 0>;
 	};
 
@@ -885,7 +885,7 @@
 		compatible = "nxp,lptmr";
 		reg = <0x4300000 0x1000>;
 		interrupts = <18 0>;
-		clock-frequency = <80000000>;
+		clock-frequency = <DT_FREQ_M(80)>;
 		prescaler = <1>;
 		clk-source = <0>;
 		resolution = <32>;
@@ -896,7 +896,7 @@
 		compatible = "nxp,lptmr";
 		reg = <0x24d0000 0x1000>;
 		interrupts = <67 0>;
-		clock-frequency = <80000000>;
+		clock-frequency = <DT_FREQ_M(80)>;
 		prescaler = <1>;
 		clk-source = <0>;
 		resolution = <32>;
@@ -907,7 +907,7 @@
 		compatible = "nxp,lptmr";
 		reg = <0x2cd0000 0x1000>;
 		interrupts = <150 0>;
-		clock-frequency = <80000000>;
+		clock-frequency = <DT_FREQ_M(80)>;
 		prescaler = <1>;
 		clk-source = <0>;
 		resolution = <32>;
@@ -1208,8 +1208,8 @@
 		clocks = <&ccm IMX_CCM_USDHC1_CLK 0 0>;
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
-		max-bus-freq = <208000000>;
-		min-bus-freq = <400000>;
+		max-bus-freq = <DT_FREQ_M(208)>;
+		min-bus-freq = <DT_FREQ_K(400)>;
 	};
 
 	usdhc2: memory-controller@2860000 {
@@ -1220,8 +1220,8 @@
 		clocks = <&ccm IMX_CCM_USDHC2_CLK 0 0>;
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
-		max-bus-freq = <208000000>;
-		min-bus-freq = <400000>;
+		max-bus-freq = <DT_FREQ_M(208)>;
+		min-bus-freq = <DT_FREQ_K(400)>;
 	};
 
 	edma3: dma-controller@4000000 {

--- a/dts/arm/nxp/nxp_rt118x_cm33.dtsi
+++ b/dts/arm/nxp/nxp_rt118x_cm33.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv8-m.dtsi>
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
 / {

--- a/dts/arm/nxp/nxp_rt118x_cm33_ns.dtsi
+++ b/dts/arm/nxp/nxp_rt118x_cm33_ns.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv8-m.dtsi>
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
 / {

--- a/dts/arm/nxp/nxp_rt118x_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt118x_cm7.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <mem.h>
+#include <freq.h>
 
 / {
 	soc {

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
@@ -51,7 +52,7 @@
 
 	xtal: xtal-osc {
 		compatible = "fixed-clock";
-		clock-frequency = <24000000>;
+		clock-frequency = <DT_FREQ_M(24)>;
 		#clock-cells = <0>;
 	};
 
@@ -105,7 +106,7 @@
 			compatible = "nxp,imx-gpt";
 			reg = <0x400f0000 0x4000>;
 			interrupts = <120 0>;
-			gptfreq = <24000000>;
+			gptfreq = <DT_FREQ_M(24)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x41 0>;
 		};
 
@@ -113,7 +114,7 @@
 			compatible = "nxp,imx-gpt";
 			reg = <0x400f4000 0x4000>;
 			interrupts = <121 0>;
-			gptfreq = <24000000>;
+			gptfreq = <DT_FREQ_M(24)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x42 0>;
 		};
 
@@ -121,7 +122,7 @@
 			compatible = "nxp,imx-gpt";
 			reg = <0x400f8000 0x4000>;
 			interrupts = <122 0>;
-			gptfreq = <24000000>;
+			gptfreq = <DT_FREQ_M(24)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x43 0>;
 		};
 
@@ -129,7 +130,7 @@
 			compatible = "nxp,imx-gpt";
 			reg = <0x400fc000 0x4000>;
 			interrupts = <123 0>;
-			gptfreq = <24000000>;
+			gptfreq = <DT_FREQ_M(24)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x44 0>;
 		};
 
@@ -137,7 +138,7 @@
 			compatible = "nxp,imx-gpt";
 			reg = <0x40100000 0x4000>;
 			interrupts = <124 0>;
-			gptfreq = <24000000>;
+			gptfreq = <DT_FREQ_M(24)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x45 0>;
 		};
 
@@ -854,8 +855,8 @@
 			clocks = <&ccm IMX_CCM_USDHC1_CLK 0 0>;
 			max-current-330 = <1020>;
 			max-current-180 = <1020>;
-			max-bus-freq = <208000000>;
-			min-bus-freq = <400000>;
+			max-bus-freq = <DT_FREQ_M(208)>;
+			min-bus-freq = <DT_FREQ_K(400)>;
 		};
 
 		usdhc2: usdhc@4041c000 {
@@ -866,8 +867,8 @@
 			clocks = <&ccm IMX_CCM_USDHC2_CLK 0 0>;
 			max-current-330 = <1020>;
 			max-current-180 = <1020>;
-			max-bus-freq = <208000000>;
-			min-bus-freq = <400000>;
+			max-bus-freq = <DT_FREQ_M(208)>;
+			min-bus-freq = <DT_FREQ_K(400)>;
 		};
 
 		csi: csi@40800000 {

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
@@ -549,8 +550,8 @@
 		clocks = <&clkctl1 MCUX_USDHC1_CLK>;
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
-		max-bus-freq = <208000000>;
-		min-bus-freq = <400000>;
+		max-bus-freq = <DT_FREQ_M(208)>;
+		min-bus-freq = <DT_FREQ_K(400)>;
 	};
 
 	usdhc1: usdhc@137000 {
@@ -561,8 +562,8 @@
 		clocks = <&clkctl1 MCUX_USDHC2_CLK>;
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
-		max-bus-freq = <208000000>;
-		min-bus-freq = <400000>;
+		max-bus-freq = <DT_FREQ_M(208)>;
+		min-bus-freq = <DT_FREQ_K(400)>;
 	};
 
 	lpadc0: adc@13a000 {

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
@@ -493,8 +494,8 @@
 		clocks = <&clkctl1 MCUX_USDHC1_CLK>;
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
-		max-bus-freq = <208000000>;
-		min-bus-freq = <400000>;
+		max-bus-freq = <DT_FREQ_M(208)>;
+		min-bus-freq = <DT_FREQ_K(400)>;
 	};
 
 	usdhc1: usdhc@137000 {
@@ -505,8 +506,8 @@
 		clocks = <&clkctl1 MCUX_USDHC2_CLK>;
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
-		max-bus-freq = <208000000>;
-		min-bus-freq = <400000>;
+		max-bus-freq = <DT_FREQ_M(208)>;
+		min-bus-freq = <DT_FREQ_K(400)>;
 	};
 
 	lpadc0: adc@13a000 {

--- a/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
@@ -90,7 +91,7 @@
 	/* USB PLL */
 	usbclk: usbpll-clock {
 		compatible = "fixed-clock";
-		clock-frequency = <24000000>;
+		clock-frequency = <DT_FREQ_M(24)>;
 		#clock-cells = <0>;
 	};
 };
@@ -1055,8 +1056,8 @@
 		clocks = <&clkctl4 MCUX_USDHC1_CLK>;
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
-		max-bus-freq = <208000000>;
-		min-bus-freq = <400000>;
+		max-bus-freq = <DT_FREQ_M(208)>;
+		min-bus-freq = <DT_FREQ_K(400)>;
 	};
 
 	usdhc1: memory-controller@413000 {
@@ -1067,8 +1068,8 @@
 		clocks = <&clkctl4 MCUX_USDHC2_CLK>;
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
-		max-bus-freq = <208000000>;
-		min-bus-freq = <400000>;
+		max-bus-freq = <DT_FREQ_M(208)>;
+		min-bus-freq = <DT_FREQ_K(400)>;
 	};
 
 	mrt0: timer@2d000 {

--- a/dts/arm/nxp/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_cm33_cpu1.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>

--- a/dts/arm/nxp/nxp_rw6xx.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 
 / {

--- a/dts/arm/nxp/nxp_rw6xx_ns.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_ns.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-m.dtsi>
 
 / {

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
@@ -329,7 +330,7 @@
 			reg = <0x4003d000 0x1000>;
 			interrupts = <46 0>, <47 0>;
 			interrupt-names = "alarm", "seconds";
-			clock-frequency = <32000>;
+			clock-frequency = <DT_FREQ_K(32)>;
 			prescaler = <32000>;
 		};
 

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <mem.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/clock/nxp_s32k344_clock.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <arm/armv8-r.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/clock/nxp_s32z2_clock.h>


### PR DESCRIPTION
- Use DT_FREQ_M() and DT_FREQ_K() for DTS frequency property.
- Use DT_SIZE_M() and DT_SIZE_K() for DTS size property.
- For better readability.
