### PR TITLE
requirements: do not pin spsdk version

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -19,7 +19,7 @@ junit2html
 lpc_checksum
 
 # used by NXP platform to generate/flash firmware images
-spsdk == 2.6.0
+spsdk
 
 # used by scripts/build/gen_cfb_font_header.py - helper script for user
 Pillow>=10.3.0


### PR DESCRIPTION
This is very restrictive and blocking other packahges from being
installed due to old dependencies.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
