### PR TITLE
riscv: linker: move XIP __rom_region_end after .text and .rodata LMA

### DIFF
--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -217,13 +217,12 @@ SECTIONS
 #include <zephyr/linker/cplusplus-rom.ld>
 	__rodata_region_end = .;
 
-	/* For non-XIP system, __rom_region_end symbol should be set to
-	 * the end of common ROMABLE_REGIONs (text and rodata) instead of
-	 * the linker script end, so it wouldn't mistakenly contain
-	 * RAMABLE_REGION in it.
-	 */
 #ifndef CONFIG_XIP
-#ifdef CONFIG_RISCV_PMP
+	/*
+	 * Include a padding section here to make sure that the LMA address
+	 * of the sections in the RAMABLE_REGION are aligned with those
+	 * section's VMA alignment requirements.
+	 */
 	SECTION_PROLOGUE(rom_mpu_padding,,)
 	{
 		MPU_ALIGN(__rodata_region_end - __rom_region_start);
@@ -237,11 +236,11 @@ SECTIONS
 		. = ALIGN(0x1000);
 #endif
 	} GROUP_LINK_IN(ROMABLE_REGION)
-#endif /* CONFIG_RISCV_PMP */
-
+#else
+	MPU_ALIGN(__rodata_region_end - __rom_region_start);
+#endif
 	__rom_region_end = .;
 	__rom_region_size = __rom_region_end - __rom_region_start;
-#endif /* CONFIG_XIP */
     GROUP_END(ROMABLE_REGION)
 
     GROUP_START(RAMABLE_REGION)
@@ -446,10 +445,6 @@ GROUP_END(DTCM)
     /* Sections generated from 'zephyr,memory-region' nodes */
     LINKER_DT_SECTIONS()
 
-/* Because ROMABLE_REGION != RAMABLE_REGION in XIP-system, it is valid
- * to set __rom_region_end symbol at the end of linker script and
- * doesn't mistakenly contain the RAMABLE_REGION in it.
- */
 #ifdef CONFIG_XIP
 /* Must be last in romable region */
 SECTION_PROLOGUE(.last_section,,)
@@ -457,16 +452,11 @@ SECTION_PROLOGUE(.last_section,,)
   /* .last_section contains a fixed word to ensure location counter and actual
    * rom region data usage match when CONFIG_LINKER_LAST_SECTION_ID=y. */
   KEEP(*(.last_section))
-  /* __rom_region_size is used when configuring the PMP entry of the ROM region.
-   * Addresses (pmpaddr) in PMP registers need to be aligned to 4. Align
-   * __rom_region_size to 4 to meet that requirement. */
-  MPU_MIN_SIZE_ALIGN
 } GROUP_LINK_IN(ROMABLE_REGION)
 
 /* To provide the image size as a const expression,
  * calculate this value here. */
-__rom_region_end = LOADADDR(.last_section) + SIZEOF(.last_section);
-__rom_region_size = __rom_region_end - __rom_region_start;
+_flash_used = LOADADDR(.last_section) + SIZEOF(.last_section) - __rom_region_start;
 #endif
 
 }

--- a/soc/ite/ec/it51xxx/linker.ld
+++ b/soc/ite/ec/it51xxx/linker.ld
@@ -233,13 +233,12 @@ SECTIONS
 #include <zephyr/linker/cplusplus-rom.ld>
 	__rodata_region_end = .;
 
-	/* For non-XIP system, __rom_region_end symbol should be set to
-	 * the end of common ROMABLE_REGIONs (text and rodata) instead of
-	 * the linker script end, so it wouldn't mistakenly contain
-	 * RAMABLE_REGION in it.
-	 */
 #ifndef CONFIG_XIP
-#ifdef CONFIG_RISCV_PMP
+	/*
+	 * Include a padding section here to make sure that the LMA address
+	 * of the sections in the RAMABLE_REGION are aligned with those
+	 * section's VMA alignment requirements.
+	 */
 	SECTION_PROLOGUE(rom_mpu_padding,,)
 	{
 		MPU_ALIGN(__rodata_region_end - __rom_region_start);
@@ -253,11 +252,11 @@ SECTIONS
 		. = ALIGN(0x1000);
 #endif
 	} GROUP_LINK_IN(ROMABLE_REGION)
-#endif /* CONFIG_RISCV_PMP */
-
+#else
+	MPU_ALIGN(__rodata_region_end - __rom_region_start);
+#endif
 	__rom_region_end = .;
 	__rom_region_size = __rom_region_end - __rom_region_start;
-#endif /* CONFIG_XIP */
     GROUP_END(ROMABLE_REGION)
 
     GROUP_START(RAMABLE_REGION)
@@ -505,10 +504,6 @@ GROUP_END(DTCM)
     /* Sections generated from 'zephyr,memory-region' nodes */
     LINKER_DT_SECTIONS()
 
-/* Because ROMABLE_REGION != RAMABLE_REGION in XIP-system, it is valid
- * to set __rom_region_end symbol at the end of linker script and
- * doesn't mistakenly contain the RAMABLE_REGION in it.
- */
 #ifdef CONFIG_XIP
 /* Must be last in romable region */
 SECTION_PROLOGUE(.last_section,,)
@@ -526,8 +521,7 @@ SECTION_PROLOGUE(.last_section,,)
 
 /* To provide the image size as a const expression,
  * calculate this value here. */
-__rom_region_end = LOADADDR(.last_section) + SIZEOF(.last_section);
-__rom_region_size = __rom_region_end - __rom_region_start;
+_flash_used = LOADADDR(.last_section) + SIZEOF(.last_section) - __rom_region_start;
 #endif
 
 }

--- a/soc/ite/ec/it51xxx/linker.ld
+++ b/soc/ite/ec/it51xxx/linker.ld
@@ -508,15 +508,9 @@ GROUP_END(DTCM)
 /* Must be last in romable region */
 SECTION_PROLOGUE(.last_section,,)
 {
-#ifdef CONFIG_LINKER_LAST_SECTION_ID
-  /* Fill last section with a word to ensure location counter and actual rom
-   * region data usage match. */
-  LONG(CONFIG_LINKER_LAST_SECTION_ID_PATTERN)
-  /* __rom_region_size is used when configuring the PMP entry of the ROM region.
-   * Addresses (pmpaddr) in PMP registers need to be aligned to 4. Align
-   * __rom_region_size to 4 to meet that requirement. */
-  MPU_MIN_SIZE_ALIGN
-#endif
+  /* .last_section contains a fixed word to ensure location counter and actual
+   * rom region data usage match when CONFIG_LINKER_LAST_SECTION_ID=y. */
+  KEEP(*(.last_section))
 } GROUP_LINK_IN(ROMABLE_REGION)
 
 /* To provide the image size as a const expression,

--- a/soc/ite/ec/it8xxx2/linker.ld
+++ b/soc/ite/ec/it8xxx2/linker.ld
@@ -280,13 +280,12 @@ SECTIONS
 #include <zephyr/linker/cplusplus-rom.ld>
 	__rodata_region_end = .;
 
-	/* For non-XIP system, __rom_region_end symbol should be set to
-	 * the end of common ROMABLE_REGIONs (text and rodata) instead of
-	 * the linker script end, so it wouldn't mistakenly contain
-	 * RAMABLE_REGION in it.
-	 */
 #ifndef CONFIG_XIP
-#ifdef CONFIG_RISCV_PMP
+	/*
+	 * Include a padding section here to make sure that the LMA address
+	 * of the sections in the RAMABLE_REGION are aligned with those
+	 * section's VMA alignment requirements.
+	 */
 	SECTION_PROLOGUE(rom_mpu_padding,,)
 	{
 		MPU_ALIGN(__rodata_region_end - __rom_region_start);
@@ -300,11 +299,11 @@ SECTIONS
 		. = ALIGN(0x1000);
 #endif
 	} GROUP_LINK_IN(ROMABLE_REGION)
-#endif /* CONFIG_RISCV_PMP */
-
+#else
+	MPU_ALIGN(__rodata_region_end - __rom_region_start);
+#endif
 	__rom_region_end = .;
 	__rom_region_size = __rom_region_end - __rom_region_start;
-#endif /* CONFIG_XIP */
     GROUP_END(ROMABLE_REGION)
 
     GROUP_START(RAMABLE_REGION)
@@ -486,10 +485,6 @@ SECTIONS
     /* Sections generated from 'zephyr,memory-region' nodes */
     LINKER_DT_SECTIONS()
 
-/* Because ROMABLE_REGION != RAMABLE_REGION in XIP-system, it is valid
- * to set __rom_region_end symbol at the end of linker script and
- * doesn't mistakenly contain the RAMABLE_REGION in it.
- */
 #ifdef CONFIG_XIP
 /* Must be last in romable region */
 SECTION_PROLOGUE(.last_section,(NOLOAD),)
@@ -498,8 +493,7 @@ SECTION_PROLOGUE(.last_section,(NOLOAD),)
 
 /* To provide the image size as a const expression,
  * calculate this value here. */
-__rom_region_end = LOADADDR(.last_section);
-__rom_region_size = __rom_region_end - __rom_region_start;
+_flash_used = LOADADDR(.last_section) + SIZEOF(.last_section) - __rom_region_start;
 #endif
 
 }

--- a/soc/ite/ec/it8xxx2/linker.ld
+++ b/soc/ite/ec/it8xxx2/linker.ld
@@ -487,8 +487,11 @@ SECTIONS
 
 #ifdef CONFIG_XIP
 /* Must be last in romable region */
-SECTION_PROLOGUE(.last_section,(NOLOAD),)
+SECTION_PROLOGUE(.last_section,,)
 {
+  /* .last_section contains a fixed word to ensure location counter and actual
+   * rom region data usage match when CONFIG_LINKER_LAST_SECTION_ID=y. */
+  KEEP(*(.last_section))
 } GROUP_LINK_IN(ROMABLE_REGION)
 
 /* To provide the image size as a const expression,


### PR DESCRIPTION
Previously RISC-V linker script defined `__rom_region_end` differently for non-XIP and XIP:
1. Non-XIP: at the end of .text and .rodata https://github.com/zephyrproject-rtos/zephyr/blob/1bc914a5658179d3c97f66f13b97a227421bf0e7/include/zephyr/arch/riscv/common/linker.ld#L242
2. XIP: at the end of image, including .data LMA https://github.com/zephyrproject-rtos/zephyr/blob/1bc914a5658179d3c97f66f13b97a227421bf0e7/include/zephyr/arch/riscv/common/linker.ld#L468

This PR proposes to move XIP `__rom_region_end` to the end of  .text and .rodata, so that:

- Aligns with non-XIP and no need to pad the end of image for PMP/MPU region.
- Aligns with other architectures, where `__rom_region_end`  doesn't include `RAMABLE_REGION` LMA.
  1. [include/zephyr/arch/x86/ia32](https://github.com/zephyrproject-rtos/zephyr/blob/1bc914a5658179d3c97f66f13b97a227421bf0e7/include/zephyr/arch/x86/ia32/linker.ld#L391)
  2. [include/zephyr/arch/arm/cortex_m/scripts/linker.ld](https://github.com/zephyrproject-rtos/zephyr/blob/1bc914a5658179d3c97f66f13b97a227421bf0e7/include/zephyr/arch/arm/cortex_m/scripts/linker.ld#L243)
  3. [include/zephyr/arch/arm64/scripts/linker.ld](https://github.com/zephyrproject-rtos/zephyr/blob/1bc914a5658179d3c97f66f13b97a227421bf0e7/include/zephyr/arch/arm64/scripts/linker.ld#L197)
  4. ...
- Match linker-defs.h description.
https://github.com/zephyrproject-rtos/zephyr/blob/1bc914a5658179d3c97f66f13b97a227421bf0e7/include/zephyr/linker/linker-defs.h#L151-L154

After this PR, RISC-V XIP behavior changes as follows:
1. The image size symbol is now `_flash_used` instead of `__rom_region_size`, matching the  `LINKER_LAST_SECTION_ID` [description](https://github.com/zephyrproject-rtos/zephyr/blob/1bc914a5658179d3c97f66f13b97a227421bf0e7/Kconfig.zephyr#L288-L293).
2. The PMP protected RX region is now limited to .text and .rodata (same as non-XIP) instead of  the whole image LMA. I think this still satisfy Zephyr [Memory Protection Design](https://docs.zephyrproject.org/latest/kernel/usermode/memory_domain.html#boot-time-memory-configuration).

Additional change: synchronize the last section in soc/ite with the generic RISC-V linker script.