### PR TITLE
drivers: modem: bg9x: Rollback Kconfig deprecation

### DIFF
--- a/drivers/modem/Kconfig.quectel-bg9x
+++ b/drivers/modem/Kconfig.quectel-bg9x
@@ -11,8 +11,10 @@ config MODEM_QUECTEL_BG9X
 	select MODEM_SOCKET
 	select NET_SOCKETS_OFFLOAD
 	help
-	  Choose this setting to enable quectel BG9x LTE-CatM1/NB-IoT modem
-	  driver.
+	  Quectel BG9x LTE-CatM1/NB-IoT off-load modem driver. This should be
+	  used when off-load drivers are needed. This is the preferred mode
+	  only when user needs PSM/eDRX power saving modes. Otherwise, the
+	  celullar modem is the recommended solution.
 
 if MODEM_QUECTEL_BG9X
 

--- a/drivers/modem/Kconfig.quectel-bg9x
+++ b/drivers/modem/Kconfig.quectel-bg9x
@@ -4,13 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config MODEM_QUECTEL_BG9X
-	bool "Quectel modem driver [ DEPRECATED ]"
+	bool "Quectel modem driver"
 	select MODEM_CONTEXT
 	select MODEM_CMD_HANDLER
 	select MODEM_IFACE_UART
 	select MODEM_SOCKET
 	select NET_SOCKETS_OFFLOAD
-	select DEPRECATED
 	help
 	  Choose this setting to enable quectel BG9x LTE-CatM1/NB-IoT modem
 	  driver.


### PR DESCRIPTION
Rollback the deprecation from BG9x Kconfig. The off-load driver has an important use-case that is when a device is powered by a battery, In this case, to save power, the device can activate the PSM/eDRX modes.

Those cases currently can not be achieved by PPP only implementation. The BG9x driver still require adaptation to use LPM modes but this rollback is intended to avoid driver removal before someone try to send those patches.