### PR TITLE
soc: stm32n6: Add userspace support

### DIFF
--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -241,6 +241,7 @@ SECTIONS
 	MPU_ALIGN(__rodata_region_end - ADDR(rom_start));
 #endif
 	__rom_region_end = __rom_region_start + . - ADDR(rom_start);
+	__rom_region_size = __rom_region_end - __rom_region_start;
 
     GROUP_END(ROMABLE_REGION)
 

--- a/soc/st/stm32/stm32n6x/CMakeLists.txt
+++ b/soc/st/stm32/stm32n6x/CMakeLists.txt
@@ -11,6 +11,11 @@ zephyr_sources_ifdef(CONFIG_STM32N6_NPU
 
 zephyr_include_directories(.)
 
+if(CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS)
+  zephyr_linker_sources(SECTIONS mpu_regions.ld)
+  zephyr_sources(mpu_regions.c)
+endif()
+
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
 
 zephyr_linker_sources_ifdef(CONFIG_BOOTLOADER_MCUBOOT SECTIONS ram_check.ld)

--- a/soc/st/stm32/stm32n6x/Kconfig
+++ b/soc/st/stm32/stm32n6x/Kconfig
@@ -20,6 +20,8 @@ config SOC_SERIES_STM32N6X
 	select SOC_EARLY_INIT_HOOK
 	select TRUSTED_EXECUTION_SECURE
 	select BUILD_OUTPUT_BIN
+	# MPU_GAP_FILLING is default when !USERSPACE, select it in the other case as well.
+	select MPU_GAP_FILLING if USERSPACE
 
 config STM32N6_BOOT_SERIAL
 	bool "Serial boot target (USB)"

--- a/soc/st/stm32/stm32n6x/Kconfig
+++ b/soc/st/stm32/stm32n6x/Kconfig
@@ -22,6 +22,7 @@ config SOC_SERIES_STM32N6X
 	select BUILD_OUTPUT_BIN
 	# MPU_GAP_FILLING is default when !USERSPACE, select it in the other case as well.
 	select MPU_GAP_FILLING if USERSPACE
+	select CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS if USERSPACE && !XIP
 
 config STM32N6_BOOT_SERIAL
 	bool "Serial boot target (USB)"

--- a/soc/st/stm32/stm32n6x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32n6x/Kconfig.defconfig
@@ -10,6 +10,15 @@ rsource "Kconfig.defconfig.stm32n6*"
 DT_STM32_CPU_CLOCK_PATH := $(dt_nodelabel_path,cpusw)
 DT_STM32_CPU_CLOCK_FREQ := $(dt_node_int_prop_int,$(DT_STM32_CPU_CLOCK_PATH),clock-frequency)
 
+DT_CHOSEN_Z_FLASH := zephyr,flash
+DT_CHOSEN_FLASH_NODE := $(dt_chosen_path,$(DT_CHOSEN_Z_FLASH))
+DT_FLASH_HAS_SIZE_PROP := $(dt_node_has_prop,$(DT_CHOSEN_FLASH_NODE),size)
+
+# When XiP in Ext Flash, get FLASH size from size property of XSPI device node
+config FLASH_SIZE
+	default $(dt_node_int_prop_int,$(DT_CHOSEN_FLASH_NODE),size,kb) \
+		if $(DT_FLASH_HAS_SIZE_PROP) && XIP
+
 # For STM32N6, override the value defined in STM32 Kconfig to use CPU clock frequency
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default "$(DT_STM32_CPU_CLOCK_FREQ)" if "$(dt_nodelabel_enabled,cpusw)"

--- a/soc/st/stm32/stm32n6x/mpu_regions.c
+++ b/soc/st/stm32/stm32n6x/mpu_regions.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/arch/arm/mpu/arm_mpu.h>
+
+extern const uint32_t __rom_region_limit[];
+extern const uint32_t __image_ram_limit[];
+
+static const struct arm_mpu_region mpu_regions[] = {
+	{
+		.base = (uint32_t)__rom_region_start,
+		.name = "SRAM_RO",
+		.attr = {
+			.rbar = RO_Msk | NON_SHAREABLE_Msk,
+			.mair_idx = MPU_MAIR_INDEX_FLASH,
+			.pxn = !PRIV_EXEC_NEVER,
+			.r_limit = (uint32_t)__rom_region_limit,
+		},
+	},
+	{
+		.base = (uint32_t)_image_ram_start,
+		.name = "SRAM_RW",
+		.attr = {
+			.rbar = NOT_EXEC | P_RW_U_NA_Msk | NON_SHAREABLE_Msk,
+			.mair_idx = MPU_MAIR_INDEX_SRAM,
+			.pxn = !PRIV_EXEC_NEVER,
+			.r_limit = (uint32_t)__image_ram_limit,
+		},
+	}
+};
+
+const struct arm_mpu_config mpu_config = {
+	.num_regions = ARRAY_SIZE(mpu_regions),
+	.mpu_regions = mpu_regions,
+};

--- a/soc/st/stm32/stm32n6x/mpu_regions.ld
+++ b/soc/st/stm32/stm32n6x/mpu_regions.ld
@@ -1,0 +1,19 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_BASE_Pos		5					/*!< MPU RBAR: BASE Position */
+#define MPU_RBAR_BASE_Msk		(0x7FFFFFF << MPU_RBAR_BASE_Pos)	/*!< MPU RBAR: BASE Mask */
+
+/** \brief MPU Region Limit Address Register Definitions */
+#define MPU_RLAR_LIMIT_Pos		5					/*!< MPU RLAR: LIMIT Position */
+#define MPU_RLAR_LIMIT_Msk		(0x7FFFFFF << MPU_RLAR_LIMIT_Pos)	/*!< MPU RLAR: LIMIT Mask */
+
+#define REGION_LIMIT_ADDR(base, size) (((base & MPU_RBAR_BASE_Msk) + size - 1) & MPU_RLAR_LIMIT_Msk)
+
+PROVIDE(__rom_region_limit = REGION_LIMIT_ADDR(__rom_region_start, __rom_region_size));
+PROVIDE(__image_ram_limit = REGION_LIMIT_ADDR(_image_ram_start, (CONFIG_SRAM_SIZE * 1024)));


### PR DESCRIPTION
Add userspace support on stm32n6 SoC.

Involves:
- As based on Cortex-M55, implies enabling MPU_GAP_FILLING on the SoC series
- In XIP mode, this requires being able to compute FLASH_SIZE from external flash properties
- In !XIP mode (which is the mode used in CI), this implies declaring RAM_RW and RAM_RO static regions, ~~which requires the ability to provide static regions in run time. This possibility is proposed as a new `MPU_STATIC_REGIONS_DYNAMIC_INIT` option.~~ done with a dedicated linker snippet.

Note: Requires https://github.com/zephyrproject-rtos/zephyr/pull/95152 to build in XIP
