### PR TITLE
sensor: mcp9600: extend driver functionality

### DIFF
--- a/drivers/sensor/microchip/mcp9600/mcp9600.c
+++ b/drivers/sensor/microchip/mcp9600/mcp9600.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025, Thomas Schmid <tom@lfence.de>
  * Copyright (c) 2022, Maxmillion McLaughlin
  * Copyright (c) 2020, SER Consulting LLC / Steven Riedl
  *
@@ -10,6 +11,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/mcp9600.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
@@ -17,9 +19,9 @@ LOG_MODULE_REGISTER(MCP9600, CONFIG_SENSOR_LOG_LEVEL);
 
 #define MCP9600_REG_TEMP_HOT 0x00
 
-#define MCP9600_REG_TEMP_DIFF 0x01
-#define MCP9600_REG_TEMP_COLD 0x02
-#define MCP9600_REG_RAW_ADC   0x03
+#define MCP9600_REG_TEMP_DELTA 0x01
+#define MCP9600_REG_TEMP_COLD  0x02
+#define MCP9600_REG_RAW_ADC    0x03
 
 #define MCP9600_REG_STATUS 0x04
 
@@ -43,12 +45,28 @@ LOG_MODULE_REGISTER(MCP9600, CONFIG_SENSOR_LOG_LEVEL);
 
 #define MCP9600_REG_ID_REVISION 0x20
 
+#define MCP9600_REG_TC_CONFIG_OFFSET_TC_TYPE            0x05
+#define MCP9600_REG_TC_CONFIG_OFFSET_FILTER_COEF        0x00
+#define MCP9600_REG_DEV_CONFIG_OFFSET_ADC_RES           0x05
+#define MCP9600_REG_DEV_CONFIG_COLD_JUNCTION_RES_OFFSET 0x07
+
 struct mcp9600_data {
-	int32_t temp;
+	int32_t temp_hot_junction;
+	int32_t temp_cold_junction;
+	int32_t temp_delta;
+	int32_t adc_raw;
+	bool temp_hot_valid;
+	bool temp_cold_valid;
+	bool temp_delta_valid;
+	bool adc_raw_valid;
 };
 
 struct mcp9600_config {
 	const struct i2c_dt_spec bus;
+	const uint8_t thermocouple_type;
+	const uint8_t filter_coefficient;
+	const uint8_t adc_resolution;
+	const uint8_t cold_junction_temp_resolution;
 };
 
 static int mcp9600_reg_read(const struct device *dev, uint8_t start, uint8_t *buf, int size)
@@ -58,29 +76,213 @@ static int mcp9600_reg_read(const struct device *dev, uint8_t start, uint8_t *bu
 	return i2c_burst_read_dt(&cfg->bus, start, buf, size);
 }
 
+static int mcp9600_reg_write(const struct device *dev, uint8_t start, uint8_t *buf, int size)
+{
+	const struct mcp9600_config *cfg = dev->config;
+
+	return i2c_burst_write_dt(&cfg->bus, start, buf, size);
+}
+
+static int mcp9600_attr_set(const struct device *dev, enum sensor_channel chan,
+			    enum sensor_attribute attr, const struct sensor_value *value)
+{
+	__ASSERT(chan == SENSOR_CHAN_ALL, "Attribute set is only supported for SENSOR_CHAN_ALL");
+	uint8_t register_value = 0;
+	int rc = 0;
+	uint8_t register_address;
+	uint32_t attribute_id = attr;
+
+	if (attribute_id == SENSOR_ATTR_MCP9600_ADC_RES) {
+		register_address = MCP9600_REG_DEV_CONFIG;
+		rc = mcp9600_reg_read(dev, register_address, &register_value, 1);
+		if (rc != 0) {
+			return rc;
+		}
+
+		register_value &= ~(BIT_MASK(2) << MCP9600_REG_DEV_CONFIG_OFFSET_ADC_RES);
+		register_value |= (value->val1 & BIT_MASK(2))
+				  << MCP9600_REG_DEV_CONFIG_OFFSET_ADC_RES;
+	} else if (attribute_id == SENSOR_ATTR_MCP9600_COLD_JUNCTION_RESOLUTION) {
+		register_address = MCP9600_REG_DEV_CONFIG;
+		rc = mcp9600_reg_read(dev, register_address, &register_value, 1);
+		if (rc != 0) {
+			return rc;
+		}
+
+		register_value &= ~(1 << MCP9600_REG_DEV_CONFIG_COLD_JUNCTION_RES_OFFSET);
+		register_value |= (value->val1 & 1)
+				  << MCP9600_REG_DEV_CONFIG_COLD_JUNCTION_RES_OFFSET;
+	} else if (attribute_id == SENSOR_ATTR_MCP9600_FILTER_COEFFICIENT) {
+		register_address = MCP9600_REG_TC_CONFIG;
+		rc = mcp9600_reg_read(dev, register_address, &register_value, 1);
+		if (rc != 0) {
+			return rc;
+		}
+
+		register_value &= ~(BIT_MASK(3) << MCP9600_REG_TC_CONFIG_OFFSET_FILTER_COEF);
+		register_value |= (value->val1 & BIT_MASK(3))
+				  << MCP9600_REG_TC_CONFIG_OFFSET_FILTER_COEF;
+	} else if (attribute_id == SENSOR_ATTR_MCP9600_THERMOCOUPLE_TYPE) {
+		register_address = MCP9600_REG_TC_CONFIG;
+		rc = mcp9600_reg_read(dev, register_address, &register_value, 1);
+		if (rc != 0) {
+			return rc;
+		}
+
+		register_value &= ~(BIT_MASK(3) << MCP9600_REG_TC_CONFIG_OFFSET_TC_TYPE);
+		register_value |= (value->val1 & BIT_MASK(3))
+				  << MCP9600_REG_TC_CONFIG_OFFSET_TC_TYPE;
+	} else {
+		return -ENOTSUP;
+	}
+
+	rc = mcp9600_reg_write(dev, register_address, &register_value, 1);
+	return rc;
+}
+
+static int mcp9600_attr_get(const struct device *dev, enum sensor_channel chan,
+			    enum sensor_attribute attr, struct sensor_value *value)
+{
+	uint8_t register_value[2];
+	int rc = -1;
+	uint32_t attribute_id = attr;
+
+	if (attribute_id == SENSOR_ATTR_MCP9600_ADC_RES) {
+		rc = mcp9600_reg_read(dev, MCP9600_REG_DEV_CONFIG, register_value, 1);
+		if (rc != 0) {
+			return rc;
+		}
+
+		value->val1 =
+			(register_value[0] >> MCP9600_REG_DEV_CONFIG_OFFSET_ADC_RES) & BIT_MASK(2);
+	} else if (attribute_id == SENSOR_ATTR_MCP9600_COLD_JUNCTION_RESOLUTION) {
+		rc = mcp9600_reg_read(dev, MCP9600_REG_DEV_CONFIG, register_value, 1);
+		if (rc != 0) {
+			return rc;
+		}
+
+		value->val1 =
+			(register_value[0] >> MCP9600_REG_DEV_CONFIG_COLD_JUNCTION_RES_OFFSET) & 1;
+	} else if (attribute_id == SENSOR_ATTR_MCP9600_THERMOCOUPLE_TYPE) {
+		rc = mcp9600_reg_read(dev, MCP9600_REG_TC_CONFIG, register_value, 1);
+		if (rc != 0) {
+			return rc;
+		}
+
+		value->val1 =
+			(register_value[0] >> MCP9600_REG_TC_CONFIG_OFFSET_TC_TYPE) & BIT_MASK(3);
+	} else if (attribute_id == SENSOR_ATTR_MCP9600_FILTER_COEFFICIENT) {
+		rc = mcp9600_reg_read(dev, MCP9600_REG_TC_CONFIG, register_value, 1);
+		if (rc != 0) {
+			return rc;
+		}
+
+		value->val1 = (register_value[0] >> MCP9600_REG_TC_CONFIG_OFFSET_FILTER_COEF) &
+			      BIT_MASK(3);
+	} else if (attribute_id == SENSOR_ATTR_MCP9600_DEV_ID) {
+		rc = mcp9600_reg_read(dev, MCP9600_REG_ID_REVISION, register_value,
+				      sizeof(register_value));
+		if (rc != 0) {
+			return rc;
+		}
+		value->val1 = (register_value[0] << 8) | register_value[1];
+	} else {
+		return -ENOTSUP;
+	}
+
+	return rc;
+}
+
 static int mcp9600_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct mcp9600_data *data = dev->data;
-	uint8_t buf[2];
+	uint8_t buf[9];
+	uint8_t start_register_address;
+	uint8_t register_bytes_count = 2;
+	uint8_t current_byte_index = 0;
 	int ret;
 
-	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_AMBIENT_TEMP) {
+	/* Configure I2C read and initialize runtime data. All registers containing measurement data
+	 * are located contiguously without gaps, starting with MCP9600_REG_TEMP_HOT. Configure
+	 * start register and number of bytes to read.
+	 */
+	switch ((uint32_t)chan) {
+	case SENSOR_CHAN_ALL:
+		start_register_address = MCP9600_REG_TEMP_HOT;
+		data->adc_raw_valid = false;
+		data->temp_hot_valid = false;
+		data->temp_cold_valid = false;
+		data->temp_delta_valid = false;
+		register_bytes_count = 9;
+		break;
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		/* fall through */
+	case SENSOR_CHAN_MCP9600_HOT_JUNCTION_TEMP:
+		start_register_address = MCP9600_REG_TEMP_HOT;
+		data->temp_hot_valid = false;
+		break;
+	case SENSOR_CHAN_MCP9600_COLD_JUNCTION_TEMP:
+		start_register_address = MCP9600_REG_TEMP_COLD;
+		data->temp_cold_valid = false;
+		break;
+	case SENSOR_CHAN_MCP9600_DELTA_TEMP:
+		start_register_address = MCP9600_REG_TEMP_DELTA;
+		data->temp_delta_valid = false;
+		break;
+	case SENSOR_CHAN_MCP9600_RAW_ADC:
+		start_register_address = MCP9600_REG_RAW_ADC;
+		data->adc_raw_valid = false;
+		register_bytes_count = 3;
+		break;
+	default:
 		LOG_ERR("Unsupported sensor channel");
 		return -ENOTSUP;
 	}
 
-	/* read signed 16 bit double-buffered register value */
-	ret = mcp9600_reg_read(dev, MCP9600_REG_TEMP_HOT, buf, sizeof(buf));
+	/* read selected register values*/
+	ret = mcp9600_reg_read(dev, start_register_address, buf, register_bytes_count);
 	if (ret < 0) {
-		data->temp = 1;
 		return ret;
 	}
 
-	/* device's hot junction register is a signed int */
-	data->temp = (int32_t)(int16_t)(buf[0] << 8) | buf[1];
+	/* interpret register values based on register address and bytes in the buffer */
+	while (current_byte_index < register_bytes_count) {
+		if (start_register_address == MCP9600_REG_TEMP_HOT) {
+			/* device's hot junction register is a 16 bit signed int */
+			data->temp_hot_junction = (int32_t)(int16_t)(buf[current_byte_index] << 8) |
+						  buf[current_byte_index + 1];
+			data->temp_hot_junction *= 62500;
+			data->temp_hot_valid = true;
+			current_byte_index += 2;
+		} else if (start_register_address == MCP9600_REG_TEMP_DELTA) {
+			/* device's delta temperature register is a 16 bit signed int */
+			data->temp_delta = (int32_t)(int16_t)(buf[current_byte_index] << 8) |
+					   buf[current_byte_index + 1];
+			data->temp_delta *= 62500;
+			data->temp_delta_valid = true;
+			current_byte_index += 2;
+		} else if (start_register_address == MCP9600_REG_TEMP_COLD) {
+			/* device's cold junction register is a 16 bit signed int */
+			data->temp_cold_junction =
+				(int32_t)(int16_t)(buf[current_byte_index] << 8) |
+				buf[current_byte_index + 1];
+			data->temp_cold_junction *= 62500;
+			data->temp_cold_valid = true;
+			current_byte_index += 2;
+		} else if (start_register_address == MCP9600_REG_RAW_ADC) {
+			/* device's raw adc value register is a 24 bit signed int */
+			data->adc_raw = ((int32_t)(buf[current_byte_index] << 24) |
+					 (buf[current_byte_index + 1] << 16) |
+					 (buf[current_byte_index + 2] << 8)) >>
+					8;
+			data->adc_raw_valid = true;
+			current_byte_index += 3;
+		} else {
+			return -EINVAL;
+		}
 
-	/* 0.0625C resolution per LSB */
-	data->temp *= 62500;
+		start_register_address += 1;
+	}
 
 	return 0;
 }
@@ -90,16 +292,41 @@ static int mcp9600_channel_get(const struct device *dev, enum sensor_channel cha
 {
 	struct mcp9600_data *data = dev->data;
 
-	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
+	switch ((uint32_t)chan) {
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		/* fall through */
+	case SENSOR_CHAN_MCP9600_HOT_JUNCTION_TEMP:
+		if (!data->temp_hot_valid) {
+			return -EINVAL;
+		}
+		val->val1 = data->temp_hot_junction / 1000000;
+		val->val2 = data->temp_hot_junction % 1000000;
+		break;
+	case SENSOR_CHAN_MCP9600_COLD_JUNCTION_TEMP:
+		if (!data->temp_cold_valid) {
+			return -EINVAL;
+		}
+		val->val1 = data->temp_cold_junction / 1000000;
+		val->val2 = data->temp_cold_junction % 1000000;
+		break;
+	case SENSOR_CHAN_MCP9600_DELTA_TEMP:
+		if (!data->temp_delta_valid) {
+			return -EINVAL;
+		}
+		val->val1 = data->temp_delta / 1000000;
+		val->val2 = data->temp_delta % 1000000;
+		break;
+	case SENSOR_CHAN_MCP9600_RAW_ADC:
+		if (!data->adc_raw_valid) {
+			return -EINVAL;
+		}
+		val->val1 = data->adc_raw;
+		val->val2 = 0;
+		break;
+	default:
+		LOG_ERR("Unsupported sensor channel");
 		return -ENOTSUP;
 	}
-
-	if (data->temp == 1) {
-		return -EINVAL;
-	}
-
-	val->val1 = data->temp / 1000000;
-	val->val2 = data->temp % 1000000;
 
 	return 0;
 }
@@ -107,12 +334,16 @@ static int mcp9600_channel_get(const struct device *dev, enum sensor_channel cha
 static DEVICE_API(sensor, mcp9600_api) = {
 	.sample_fetch = mcp9600_sample_fetch,
 	.channel_get = mcp9600_channel_get,
+	.attr_set = mcp9600_attr_set,
+	.attr_get = mcp9600_attr_get,
 };
 
 static int mcp9600_init(const struct device *dev)
 {
 	const struct mcp9600_config *cfg = dev->config;
 	uint8_t buf[2];
+	uint8_t thermocouple_config_reg_value;
+	uint8_t device_config_reg_value;
 	int ret;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
@@ -122,6 +353,40 @@ static int mcp9600_init(const struct device *dev)
 
 	ret = mcp9600_reg_read(dev, MCP9600_REG_ID_REVISION, buf, sizeof(buf));
 	LOG_DBG("id: 0x%02x version: 0x%02x", buf[0], buf[1]);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Start from reset state, which is 0 according to the datasheet */
+	thermocouple_config_reg_value = 0;
+	device_config_reg_value = 0;
+
+	/* Configure device for thermocouple type and filter coefficient */
+	thermocouple_config_reg_value |=
+		((cfg->thermocouple_type & BIT_MASK(3)) << MCP9600_REG_TC_CONFIG_OFFSET_TC_TYPE) |
+		((cfg->filter_coefficient & BIT_MASK(3))
+		 << MCP9600_REG_TC_CONFIG_OFFSET_FILTER_COEF);
+	ret = mcp9600_reg_write(dev, MCP9600_REG_TC_CONFIG, &thermocouple_config_reg_value, 1);
+
+	if (ret != 0) {
+		LOG_ERR("Unable to write tc config register. Error %d", ret);
+		return ret;
+	}
+	LOG_DBG("set tc config register: 0x%02x", thermocouple_config_reg_value);
+
+	/* Configure adc resolution and cold junction temperature resolution*/
+	device_config_reg_value |=
+		((cfg->adc_resolution & BIT_MASK(2)) << MCP9600_REG_DEV_CONFIG_OFFSET_ADC_RES) |
+		((cfg->cold_junction_temp_resolution & 1)
+		 << MCP9600_REG_DEV_CONFIG_COLD_JUNCTION_RES_OFFSET);
+	ret = mcp9600_reg_write(dev, MCP9600_REG_DEV_CONFIG, &device_config_reg_value, 1);
+
+	if (ret != 0) {
+		LOG_ERR("Unable to write dev config register. Error %d", ret);
+		return ret;
+	}
+
+	LOG_DBG("set dev config register: 0x%02x", device_config_reg_value);
 
 	return ret;
 }
@@ -131,7 +396,10 @@ static int mcp9600_init(const struct device *dev)
                                                                                                    \
 	static const struct mcp9600_config mcp9600_config_##id = {                                 \
 		.bus = I2C_DT_SPEC_INST_GET(id),                                                   \
-	};                                                                                         \
+		.thermocouple_type = DT_INST_PROP(id, thermocouple_type),                          \
+		.filter_coefficient = DT_INST_PROP(id, filter_coefficient),                        \
+		.adc_resolution = DT_INST_PROP(id, adc_resolution),                                \
+		.cold_junction_temp_resolution = DT_INST_PROP(id, cold_junction_temp_resolution)}; \
                                                                                                    \
 	SENSOR_DEVICE_DT_INST_DEFINE(id, mcp9600_init, NULL, &mcp9600_data_##id,                   \
 				     &mcp9600_config_##id, POST_KERNEL,                            \

--- a/dts/bindings/sensor/microchip,mcp9600.yaml
+++ b/dts/bindings/sensor/microchip,mcp9600.yaml
@@ -1,3 +1,4 @@
+# Copyright (c) 2025, Thomas Schmid <tom@lfence.de>
 # Copyright (c) 2022, Maxmillion McLaughlin
 # Copyright (c) 2020, SER Consulting LLC / Steven Riedl
 #
@@ -7,6 +8,88 @@ description: |
   Microchip MCP9600 I2C Thermocouple EMF to Temperature Converter. See
   https://www.microchip.com/wwwproducts/en/MCP9600.
 
+  When setting the DTS properties, make sure to include
+  mcp9600.h and use the macros defined there.
+
+  Example:
+  #include <zephyr/dt-bindings/sensor/mcp9600.h>
+
+  mcp9600: mcp9600@60 {
+    ...
+
+    thermocouple-type = <MCP9600_DT_TYPE_K>;
+    adc-resolution = <MCP9600_DT_ADC_RES_18BIT>;
+    filter-coefficient = <0>;
+    cold-junction-temp-resolution: <MCP9600_DT_COLD_JUNC_TMP_RES_0_0625C>;
+  };
+
 compatible: "microchip,mcp9600"
 
 include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  thermocouple-type:
+    type: int
+    default: 0
+    description: |
+      Thermocouple type. Use MCP9600_DT_TYPE macros for setting the value.
+      The default value corresponds to the reset state of the chip.
+    enum:
+      - 0 # MCP9600_DT_TYPE_K
+      - 1 # MCP9600_DT_TYPE_J
+      - 2 # MCP9600_DT_TYPE_T
+      - 3 # MCP9600_DT_TYPE_N
+      - 4 # MCP9600_DT_TYPE_S
+      - 5 # MCP9600_DT_TYPE_E
+      - 6 # MCP9600_DT_TYPE_B
+      - 7 # MCP9600_DT_TYPE_R
+
+  adc-resolution:
+    type: int
+    default: 0
+    description: |
+      ADC resolution in bits. Use MCP9600_DT_ADC_RES macros for setting the value.
+      The default value corresponds to the reset state of the chip.
+    enum:
+      - 0 # MCP9600_DT_ADC_RES_18BIT
+      - 1 # MCP9600_DT_ADC_RES_16BIT
+      - 2 # MCP9600_DT_ADC_RES_14BIT
+      - 3 # MCP9600_DT_ADC_RES_12BIT
+
+  filter-coefficient:
+    type: int
+    default: 0
+    description: |
+      Filter coefficient:
+      - 0: Filter off
+      - 1: Minimum filter
+      - 2:
+      - 3:
+      - 4: Mid filter
+      - 5:
+      - 6:
+      - 7: Maximum filter
+      The default value corresponds to the reset state of the chip.
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+
+  cold-junction-temp-resolution:
+    description: |
+      Resolution of the cold junction temperature measurement.
+      Select from:
+      - 0: 0.0625 °C
+      - 1: 0.25 °C
+      or use MCP9600_DT_COLD_JUNC_TMP_RES_0_0625C or MCP9600_DT_COLD_JUNC_TMP_RES_0_25C Macros.
+      The default value corresponds to the reset state of the chip.
+    type: int
+    default: 0
+    enum:
+      - 0 # MCP9600_DT_COLD_JUNC_TMP_RES_0_0625C
+      - 1 # MCP9600_DT_COLD_JUNC_TMP_RES_0_25C

--- a/include/zephyr/drivers/sensor/mcp9600.h
+++ b/include/zephyr/drivers/sensor/mcp9600.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025 Thomas Schmid <tom@lfence.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for extended sensor API of MCP9600 sensor
+ * @ingroup mcp9600_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_MCP9600H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_MCP9600H_
+
+/**
+ * @brief Microchip MCP9600 Thermocouple Electromotive Force (EMF) to °C Converter
+ * @defgroup mcp9600_interface MCP9600
+ * @ingroup sensor_interface_ext
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <zephyr/drivers/sensor.h>
+
+/**
+ * @brief Custom sensor channels for MCP9600
+ */
+enum sensor_channel_mcp9600 {
+	SENSOR_CHAN_MCP9600_COLD_JUNCTION_TEMP = SENSOR_CHAN_PRIV_START,
+	SENSOR_CHAN_MCP9600_HOT_JUNCTION_TEMP,
+	SENSOR_CHAN_MCP9600_DELTA_TEMP,
+	SENSOR_CHAN_MCP9600_RAW_ADC,
+};
+
+/**
+ * @brief Custom sensor attributes for MCP9600
+ */
+enum sensor_attribute_mcp9600 {
+	SENSOR_ATTR_MCP9600_ADC_RES = SENSOR_ATTR_PRIV_START,
+	SENSOR_ATTR_MCP9600_FILTER_COEFFICIENT,
+	SENSOR_ATTR_MCP9600_THERMOCOUPLE_TYPE,
+	SENSOR_ATTR_MCP9600_COLD_JUNCTION_RESOLUTION,
+	SENSOR_ATTR_MCP9600_DEV_ID, /** @brief read only */
+};
+
+/**
+ * @name Thermocouple type selection
+ * @brief Values for attribute SENSOR_CHAN_MCP9600_THERMOCOUPLE_TYPE
+ * @{
+ */
+#define MCP9600_ATTR_VALUE_TYPE_K 0x0
+#define MCP9600_ATTR_VALUE_TYPE_J 0x1
+#define MCP9600_ATTR_VALUE_TYPE_T 0x2
+#define MCP9600_ATTR_VALUE_TYPE_N 0x3
+#define MCP9600_ATTR_VALUE_TYPE_S 0x4
+#define MCP9600_ATTR_VALUE_TYPE_E 0x5
+#define MCP9600_ATTR_VALUE_TYPE_B 0x6
+#define MCP9600_ATTR_VALUE_TYPE_R 0x7
+/** @} */
+
+
+/**
+ * @name ADC resolution
+ * @brief MCP9600 values for attribute SENSOR_ATTR_MCP9600_ADC_RES
+ * @{
+ */
+#define MCP9600_ATTR_VALUE_ADC_RES_18BIT 0x0
+#define MCP9600_ATTR_VALUE_ADC_RES_16BIT 0x1
+#define MCP9600_ATTR_VALUE_ADC_RES_14BIT 0x2
+#define MCP9600_ATTR_VALUE_ADC_RES_12BIT 0x3
+/**
+ * @}
+ */
+
+
+/**
+ * @name Cold junction temperature resolution
+ * @brief MCP9600 values for attribute SENSOR_ATTR_MCP9600_COLD_JUNCTION_RESOLUTION
+ * @{
+ */
+#define MCP9600_ATTR_VALUE_COLD_JUNC_TMP_RES_0_0625C 0x0
+#define MCP9600_ATTR_VALUE_COLD_JUNC_TMP_RES_0_25C   0x1
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_MCP9600H_ */

--- a/include/zephyr/dt-bindings/sensor/mcp9600.h
+++ b/include/zephyr/dt-bindings/sensor/mcp9600.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Thomas Schmid <tom@lfence.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MICRO_MCP9600_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_MICRO_MCP9600_H_
+
+/**
+ * @defgroup mcp9600 MCP9600 DT Options
+ * @ingroup sensor_interface
+ * @{
+ */
+
+/**
+ * @defgroup mcp9600_thermocouple_type Thermocouple type selection
+ * @{
+ */
+#define MCP9600_DT_TYPE_K 0x0
+#define MCP9600_DT_TYPE_J 0x1
+#define MCP9600_DT_TYPE_T 0x2
+#define MCP9600_DT_TYPE_N 0x3
+#define MCP9600_DT_TYPE_S 0x4
+#define MCP9600_DT_TYPE_E 0x5
+#define MCP9600_DT_TYPE_B 0x6
+#define MCP9600_DT_TYPE_R 0x7
+/** @} */
+
+/**
+ * @defgroup mcp9600_adc_resolution ADC resolution
+ * @{
+ */
+#define MCP9600_DT_ADC_RES_18BIT 0x0
+#define MCP9600_DT_ADC_RES_16BIT 0x1
+#define MCP9600_DT_ADC_RES_14BIT 0x2
+#define MCP9600_DT_ADC_RES_12BIT 0x3
+/** @} */
+
+/**
+ * @defgroup mcp9600_cold_junction_temp_resolution Cold junction temperature resultion
+ * @{
+ */
+#define MCP9600_DT_COLD_JUNC_TMP_RES_0_0625C 0x0
+#define MCP9600_DT_COLD_JUNC_TMP_RES_0_25C   0x1
+/** @} */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MICRO_MCP9600_H_ */


### PR DESCRIPTION
This pull request adds support for runtime and devicetree configuration for the mcp9600 thermocouple EMF to temperature converter. ([Datasheet](https://ww1.microchip.com/downloads/aemDocuments/documents/MSLD/ProductDocuments/DataSheets/MCP960X-L0X-RL0X-Thermocouple-EMF-to-Temperature-Converter-plus-minus-1-5-degrees-Celcius-Maximum-Accuracy-DS20005426.pdf))

The driver now supports runtime configuration via sensor attributes and initial configuration via device tree properties:

- **Thermocouple type** - K, J, T, N, S, E, B, R type
- **ADC resolution** - 18-bit, 16-bit, 14-bit, or 12-bit conversion resolution  
- **Filter coefficient** - Digital filter settings (0=off to 7=maximum filtering)
- **Cold junction temperature resolution** - 0.0625°C or 0.25°C precision
- **Chip ID** - Device identification register (read-only)

This patch also adds some device specific sensor channels while maintaining backward compatibility with the previous state of the driver.
- `SENSOR_CHAN_MCP9600_HOT_JUNCTION_TEMP` - Thermocouple temperature (same as `SENSOR_CHAN_AMBIENT_TEMP`)
- `SENSOR_CHAN_MCP9600_COLD_JUNCTION_TEMP` - Reference junction temperature
- `SENSOR_CHAN_MCP9600_DELTA_TEMP` - Temperature difference (hot - cold junction)
- `SENSOR_CHAN_MCP9600_RAW_ADC` - Raw 24-bit ADC value

All new devicetree properties are optional and defaults align with the previous state of the driver.