### PR TITLE
boards: renesas: disable unused button on ek_ra8p1

### DIFF
--- a/boards/renesas/ek_ra8p1/ek_ra8p1.dtsi
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1.dtsi
@@ -36,12 +36,14 @@
 			gpios = <&ioport0 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button switch 1";
 			zephyr,code = <INPUT_KEY_0>;
+			status = "disabled";
 		};
 
 		button1: s2 {
 			gpios = <&ioport0 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button switch 2";
 			zephyr,code = <INPUT_KEY_1>;
+			status = "disabled";
 		};
 	};
 

--- a/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm33.dts
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm33.dts
@@ -25,6 +25,10 @@
 	};
 };
 
+&button1 {
+	status = "okay";
+};
+
 &sci9 {
 	pinctrl-0 = <&sci9_default>;
 	pinctrl-names = "default";

--- a/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.dts
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.dts
@@ -25,6 +25,10 @@
 	};
 };
 
+&button0 {
+	status = "okay";
+};
+
 &sci8 {
 	pinctrl-0 = <&sci8_default>;
 	pinctrl-names = "default";


### PR DESCRIPTION
Set the button to disabled by default if not in use on each ek_ra8p1 cluster

Fix issue when build with `subsys/input` enabled that some interrupt line required for button0 and button1 is not enabled by default.

Error log when build `samples/subsys/input/input_dump`
```
E: interrupt configuration failed: -11
E: Pin 1 interrupt configuration failed: -11
*** Booting Zephyr OS build v4.2.0-3686-g73ea9419c354 ***
Input sample started
```