### PR TITLE
modules: mcuboot: Add Kconfig option for BOOT_MAX_ALIGN

### DIFF
--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -430,4 +430,14 @@ config MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP
 	  when bootloader is in DirectXIP-revert mode.
 endif
 
+DT_CHOSEN_ZEPHYR_FLASH := zephyr,flash
+
+config MCUBOOT_BOOT_MAX_ALIGN
+	int "Override programmable flash block alignment"
+	default $(dt_node_int_prop_int,$(DT_CHOSEN_ZEPHYR_FLASH),write-block-size)
+	help
+	  Allow to override the programmable flash block alignment size.
+	  By default it's set to the maximum of the write block size of
+	  the chosen zephyr,flash node and 8.
+
 endif # MCUBOOT_BOOTUTIL_LIB

--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: aa4fa2b6e17361dd3ce16a60883059778fd147a9
+      revision: d5b0dcb9aaee397fc105ae2228e8030038c3d871
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Add a configuration option to override the default BOOT_MAX_ALIGN value in `mcuboot`.

This can be used when image slots are on different flash devices.