### PR TITLE
soc: nxp: mcxw: Fix MCXW71 BLE warning during init

### DIFF
--- a/soc/nxp/mcx/mcxw/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/Kconfig.defconfig
@@ -31,7 +31,8 @@ config BT_BUF_EVT_RX_COUNT
 	default 16
 
 config BT_BUF_ACL_TX_COUNT
-	default 12
+	default 12 if SOC_MCXW727C
+	default 8 if SOC_MCXW716C
 
 if SHELL
 


### PR DESCRIPTION
SOC_MCXW716C is using a different ACL_TX_COUNT compared to SOC_MCXW727C