### PR TITLE
ci: workflows: fix glob pattern syntax for junitparser

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Merge Test Results
         run: |
-          junitparser merge --glob artifacts/**/twister.xml junit.xml
+          junitparser merge --glob 'artifacts/*/twister.xml' --glob 'artifacts/*/*/twister.xml' junit.xml
           junit2html junit.xml junit-clang.html
 
       - name: Upload Unit Test Results in HTML

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -347,7 +347,7 @@ jobs:
 
       - name: Merge Test Results
         run: |
-          junitparser merge --glob artifacts/**/twister.xml junit.xml
+          junitparser merge --glob 'artifacts/*/twister.xml' --glob 'artifacts/*/*/twister.xml' junit.xml
           junit2html junit.xml junit.html
 
       - name: Upload Unit Test Results


### PR DESCRIPTION
The lack of double quotes causes junitparser to not find any files due to spaces in folder names (e.g.  `... Artifact Unit Test Results (Subset 4) ...`)

I can't really reproduce the issue locally though, but one thing that's for sure is that something is off

<img width="1118" height="414" alt="image" src="https://github.com/user-attachments/assets/8c9a99c8-bd46-457b-a660-fbbb966c61c9" />

Based on https://github.com/zephyrproject-rtos/zephyr/actions/runs/17729508707/job/50385474568, the artifacts are properly downloaded and are definitely not "empty" (size is >100KB) so at least things _seem_ to point at the merge not happening correctly...