### PR TITLE
mqtt_sn: process_ping: fix infinite loop

### DIFF
--- a/subsys/net/lib/mqtt_sn/mqtt_sn.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn.c
@@ -854,7 +854,7 @@ static int process_ping(struct mqtt_sn_client *client, int64_t *next_cycle)
 		next_ping = client->last_ping + T_RETRY_MSEC;
 	}
 
-	if (next_ping < now) {
+	if (next_ping <= now) {
 		if (!client->ping_retries--) {
 			LOG_WRN("Ping ran out of retries");
 			mqtt_sn_disconnect_internal(client);


### PR DESCRIPTION
When next_ping == now, the code scheduled the workqueue for the current time. On native_sim, this meant that the system workqueue thread was stuck in an infinite loop because it kept processing the MQTT work over and over again and the current timestamp could not advance anymore.

I didn't investigate why the yield inside the workqueue didn't help or why native_sim can't advance time when one of the threads is stuck, but changing the condition to >= inside mqtt_sn solves this issue.

I discovered this while running zephyr.exe through strace for up to 60 minutes. I guess that the performance overhead makes it more likely for the workqueue handler to be run while next_ping == now, but I didn't verify that, because it takes a long time to trigger the bug.