### PR TITLE
DNM // TEST // ci: workflows: fix glob pattern syntax for junitparser

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Merge Test Results
         run: |
-          junitparser merge --glob artifacts/**/twister.xml junit.xml
+          junitparser merge --glob "artifacts/**/twister.xml" junit.xml
           junit2html junit.xml junit-clang.html
 
       - name: Upload Unit Test Results in HTML

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -347,7 +347,7 @@ jobs:
 
       - name: Merge Test Results
         run: |
-          junitparser merge --glob artifacts/**/twister.xml junit.xml
+          junitparser merge --glob "artifacts/**/twister.xml" junit.xml
           junit2html junit.xml junit.html
 
       - name: Upload Unit Test Results

--- a/boards/seeed/wio_terminal/wio_terminal.dts
+++ b/boards/seeed/wio_terminal/wio_terminal.dts
@@ -1,4 +1,5 @@
 /*
+ * foo
  * Copyright (c) 2023 Joel Guittet
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
The lack of double quotes causes junitparser to not find any files due
to spaces in folder names (e.g.  `... Artifact Unit Test Results (Subset
4) ...`)

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>