### PR TITLE
logging: backend: swo: Fix SWO clock divider check

### DIFF
--- a/subsys/logging/backends/log_backend_swo.c
+++ b/subsys/logging/backends/log_backend_swo.c
@@ -50,8 +50,8 @@ PINCTRL_DT_DEFINE(DT_NODELABEL(itm));
 	((CONFIG_LOG_BACKEND_SWO_REF_FREQ_HZ + (CONFIG_LOG_BACKEND_SWO_FREQ_HZ / 2)) / \
 		CONFIG_LOG_BACKEND_SWO_FREQ_HZ)
 
-#if SWO_FREQ_DIV > 0xFFFF
-#error CONFIG_LOG_BACKEND_SWO_FREQ_HZ is too low. SWO clock divider is 16-bit. \
+#if SWO_FREQ_DIV > 0x1FFF
+#error CONFIG_LOG_BACKEND_SWO_FREQ_HZ is too low. SWO clock divider is 13-bit. \
 	Minimum supported SWO clock frequency is \
 	[Reference Clock Frequency]/2^16.
 #endif


### PR DESCRIPTION
The TPIU->ACPR register is only 13 bits wide, so the maximum allowed SWO clock divider is 0x1FFF. Update the validation to use 0x1FFF instead of 0xFFFF