### PR TITLE
shields: support for ssd1306 shield on nrf5340dk

### DIFF
--- a/boards/shields/ssd1306/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/boards/shields/ssd1306/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Sebastian Viviani
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+&arduino_i2c {
+	zephyr,concat-buf-size = <4096>;
+};

--- a/boards/shields/ssd1306/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/boards/shields/ssd1306/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Sebastian Viviani
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+&arduino_i2c {
+	zephyr,concat-buf-size = <4096>;
+};


### PR DESCRIPTION
The ssd1396 shield uses an I2C interface, and the nrf5340dk board overlay needs a bigger buffer size by default to work. It also needs to enable a default theme if using LVGL and display is monochrome (1 bit depth)

Signed-off-by: Sebastian Viviani <sebastian.viviani@nordicsemi.no
