### PR TITLE
MAINTAINERS: Add fuel-gauge DBS06 maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1637,6 +1637,7 @@ Documentation Infrastructure:
   status: maintained
   maintainers:
     - aaronemassey
+    - DBS06
     - teburd
   collaborators:
     - DBS06


### PR DESCRIPTION
DBS06 has been consistently contributing and reviewing fuel gauge changes. Given how much additional support they have added we should add them as a maintainer.