### PR TITLE
drivers: serial: silabs: Update ISR to check for DMA device presence and change poll_out to blocking mode

### DIFF
--- a/drivers/serial/uart_silabs_eusart.c
+++ b/drivers/serial/uart_silabs_eusart.c
@@ -778,7 +778,9 @@ static void eusart_isr(const struct device *dev)
 	}
 #endif
 #ifdef CONFIG_UART_SILABS_EUSART_ASYNC
-
+	if (!data->dma_tx.dma_dev) {
+		return;
+	}
 	if (flags & EUSART_IF_RXTO) {
 		if (data->dma_rx.timeout == 0) {
 			eusart_dma_rx_flush(data);

--- a/drivers/serial/uart_silabs_eusart.c
+++ b/drivers/serial/uart_silabs_eusart.c
@@ -47,7 +47,6 @@ struct eusart_config {
 
 enum eusart_pm_lock {
 	EUSART_PM_LOCK_TX,
-	EUSART_PM_LOCK_TX_POLL,
 	EUSART_PM_LOCK_RX,
 	EUSART_PM_LOCK_COUNT,
 };
@@ -82,7 +81,7 @@ static int eusart_pm_action(const struct device *dev, enum pm_device_action acti
  *
  * @return true if lock was taken, false otherwise
  */
-static bool eusart_pm_lock_get(const struct device *dev, enum eusart_pm_lock lock)
+static __maybe_unused bool eusart_pm_lock_get(const struct device *dev, enum eusart_pm_lock lock)
 {
 #ifdef CONFIG_PM
 	struct eusart_data *data = dev->data;
@@ -108,7 +107,7 @@ static bool eusart_pm_lock_get(const struct device *dev, enum eusart_pm_lock loc
  *
  * @return true if lock was released, false otherwise
  */
-static bool eusart_pm_lock_put(const struct device *dev, enum eusart_pm_lock lock)
+static __maybe_unused bool eusart_pm_lock_put(const struct device *dev, enum eusart_pm_lock lock)
 {
 #ifdef CONFIG_PM
 	struct eusart_data *data = dev->data;
@@ -142,13 +141,13 @@ static void eusart_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct eusart_config *config = dev->config;
 
-	if (eusart_pm_lock_get(dev, EUSART_PM_LOCK_TX_POLL)) {
-		EUSART_IntEnable(config->eusart, EUSART_IF_TXC);
-	}
 	/* EUSART_Tx function already waits for the transmit buffer being empty
 	 * and waits for the bus to be free to transmit.
 	 */
 	EUSART_Tx(config->eusart, c);
+
+	while (!(config->eusart->STATUS & EUSART_STATUS_TXC)) {
+	}
 }
 
 static int eusart_err_check(const struct device *dev)
@@ -761,17 +760,12 @@ static int eusart_async_init(const struct device *dev)
 static void eusart_isr(const struct device *dev)
 {
 	__maybe_unused struct eusart_data *data = dev->data;
+#ifdef CONFIG_UART_SILABS_EUSART_ASYNC
 	const struct eusart_config *config = dev->config;
 	EUSART_TypeDef *eusart = config->eusart;
 	uint32_t flags = EUSART_IntGet(eusart);
-	__maybe_unused struct dma_status stat;
-
-	if (flags & EUSART_IF_TXC) {
-		if (eusart_pm_lock_put(dev, EUSART_PM_LOCK_TX_POLL)) {
-			EUSART_IntDisable(eusart, EUSART_IEN_TXC);
-			EUSART_IntClear(eusart, EUSART_IF_TXC);
-		}
-	}
+	struct dma_status stat;
+#endif
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	if (data->callback) {
 		data->callback(dev, data->cb_data);

--- a/drivers/serial/uart_silabs_usart.c
+++ b/drivers/serial/uart_silabs_usart.c
@@ -53,7 +53,6 @@ struct uart_silabs_config {
 
 enum uart_silabs_pm_lock {
 	UART_SILABS_PM_LOCK_TX,
-	UART_SILABS_PM_LOCK_TX_POLL,
 	UART_SILABS_PM_LOCK_RX,
 	UART_SILABS_PM_LOCK_COUNT,
 };
@@ -88,7 +87,8 @@ static int uart_silabs_pm_action(const struct device *dev, enum pm_device_action
  *
  * @return true if lock was taken, false otherwise
  */
-static bool uart_silabs_pm_lock_get(const struct device *dev, enum uart_silabs_pm_lock lock)
+static __maybe_unused bool uart_silabs_pm_lock_get(const struct device *dev,
+						   enum uart_silabs_pm_lock lock)
 {
 #ifdef CONFIG_PM
 	struct uart_silabs_data *data = dev->data;
@@ -114,7 +114,8 @@ static bool uart_silabs_pm_lock_get(const struct device *dev, enum uart_silabs_p
  *
  * @return true if lock was released, false otherwise
  */
-static bool uart_silabs_pm_lock_put(const struct device *dev, enum uart_silabs_pm_lock lock)
+static __maybe_unused bool uart_silabs_pm_lock_put(const struct device *dev,
+						   enum uart_silabs_pm_lock lock)
 {
 #ifdef CONFIG_PM
 	struct uart_silabs_data *data = dev->data;
@@ -149,11 +150,13 @@ static void uart_silabs_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_silabs_config *config = dev->config;
 
-	if (uart_silabs_pm_lock_get(dev, UART_SILABS_PM_LOCK_TX_POLL)) {
-		USART_IntEnable(config->base, USART_IF_TXC);
-	}
-
+	/* USART_Tx function already waits for the transmit buffer being empty
+	 * and waits for the bus to be free to transmit.
+	 */
 	USART_Tx(config->base, c);
+
+	while (!(config->base->STATUS & USART_STATUS_TXC)) {
+	}
 }
 
 static int uart_silabs_err_check(const struct device *dev)
@@ -746,19 +749,12 @@ static int uart_silabs_async_init(const struct device *dev)
 static void uart_silabs_isr(const struct device *dev)
 {
 	__maybe_unused struct uart_silabs_data *data = dev->data;
+#ifdef CONFIG_UART_SILABS_USART_ASYNC
 	const struct uart_silabs_config *config = dev->config;
 	USART_TypeDef *usart = config->base;
 	uint32_t flags = USART_IntGet(usart);
-#ifdef CONFIG_UART_SILABS_USART_ASYNC
 	struct dma_status stat;
 #endif
-
-	if (flags & USART_IF_TXC) {
-		if (uart_silabs_pm_lock_put(dev, UART_SILABS_PM_LOCK_TX_POLL)) {
-			USART_IntDisable(usart, USART_IEN_TXC);
-			USART_IntClear(usart, USART_IF_TXC);
-		}
-	}
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	if (data->callback) {
 		data->callback(dev, data->cb_data);

--- a/drivers/serial/uart_silabs_usart.c
+++ b/drivers/serial/uart_silabs_usart.c
@@ -765,6 +765,9 @@ static void uart_silabs_isr(const struct device *dev)
 	}
 #endif
 #ifdef CONFIG_UART_SILABS_USART_ASYNC
+	if (!data->dma_tx.dma_dev) {
+		return;
+	}
 	if (flags & USART_IF_TCMP1) {
 
 		data->dma_rx.timeout_cnt++;


### PR DESCRIPTION
Since the symbol `CONFIG_UART_ASYNC_API` is shared between EUSART and USART drivers, it creates a scenario where EUSART can have `CONFIG_UART_SILABS_EUSART_ASYNC=y` but with no DMA device declared for it in the DTS (because we only want async API for the USART driver).

We handled this case by disabling async transfer when the DMA device is null, but when we activate `CONFIG_PM=y`, we have a hard fault due to null pointer dereference in the ISR.

This bug was only discovered today when trying to enable CONFIG_PM over the uart_async_api test, which led to a hard fault in the ISR. This occurs because we only enable interrupts while PM is enabled in the "poll_out" function to put the PM lock back.

I also take care to change the poll_out function to blocking mode as described in UART API.