### PR TITLE
kernel: events: add conditional guards for timeout operations

### DIFF
--- a/kernel/events.c
+++ b/kernel/events.c
@@ -136,7 +136,9 @@ static int event_walk_op(struct k_thread *thread, void *data)
 		 * have been processed.
 		 */
 		thread->no_wake_on_timeout = true;
+#ifdef CONFIG_SYS_CLOCK_EXISTS
 		z_abort_timeout(&thread->base.timeout);
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 	}
 
 	return 0;


### PR DESCRIPTION
Add conditional compilation guards around timeout operations in `kernel/events.c` to ensure compatibility with timer-less configurations.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/96018