### PR TITLE
ci: workflows: upload doxygen coverage to codecov together w/ unittests

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -112,6 +112,24 @@ jobs:
             -T tests --coverage-tool gcovr -xCONFIG_TEST_EXTRA_STACK_SIZE=4096 -e nano \
             --timeout-multiplier 2
 
+      - name: Build Doxygen Coverage
+        if: matrix.platform == 'unit_testing'
+        run: |
+          pip install -r doc/requirements.txt --require-hashes
+          sudo apt-get update
+          sudo apt-get install -y graphviz # dot is needed but currently missing from the Docker image
+          cmake -B doc/_build -S doc
+          cmake --build doc/_build --target doxygen-coverage
+
+      - name: Upload Doxygen Coverage Results
+        if: matrix.platform == 'unit_testing'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: doxygen-coverage-results
+          path: |
+            doc/_build/new.info
+            doc/_build/coverage-report
+
       - name: Print ccache stats
         if: always()
         run: |
@@ -230,7 +248,7 @@ jobs:
             coverage/reports/coverage-report-${{ steps.run_date.outputs.run_date_short }}.json
             coverage/reports/coverage-report-${{ steps.run_date.outputs.run_date_short }}.xlsx
 
-      - name: Upload coverage to Codecov
+      - name: Upload test coverage to Codecov
         if: always()
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
@@ -240,3 +258,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/reports/merged.xml
           flags: unittests-coverage
+
+      - name: Upload Doxygen coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        with:
+          env_vars: OS,PYTHON
+          fail_ci_if_error: false
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/reports/doxygen-coverage-results/new.info
+          disable_search: true
+          flags: doxygen-coverage

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -164,18 +164,6 @@ jobs:
         name: api-coverage
         path: zephyr/api-coverage.tar.xz
 
-    - name: Upload Doxygen coverage to Codecov
-      if: github.event_name == 'schedule'
-      uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
-      with:
-        env_vars: OS,PYTHON
-        fail_ci_if_error: false
-        verbose: true
-        token: ${{ secrets.CODECOV_TOKEN }}
-        working-directory: zephyr
-        files: new.info
-        disable_search: true
-        flags: doxygen-coverage
 
     - name: process-pr
       if: github.event_name == 'pull_request'

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -119,6 +119,27 @@ set_target_properties(
 )
 
 #-------------------------------------------------------------------------------
+# Doxygen Coverage
+
+add_custom_target(
+  doxygen-coverage
+  COMMAND ${PYTHON_EXECUTABLE} -m coverxygen
+    --xml-dir ${CMAKE_CURRENT_BINARY_DIR}/doxygen/xml/
+    --src-dir ${ZEPHYR_BASE}/include/
+    --output ${CMAKE_CURRENT_BINARY_DIR}/doc-coverage.info
+  COMMAND lcov
+    --remove ${CMAKE_CURRENT_BINARY_DIR}/doc-coverage.info "*/deprecated"
+    > ${CMAKE_CURRENT_BINARY_DIR}/new.info
+  COMMAND genhtml
+    --no-function-coverage
+    --no-branch-coverage
+    ${CMAKE_CURRENT_BINARY_DIR}/new.info
+    -o ${CMAKE_CURRENT_BINARY_DIR}/coverage-report
+  DEPENDS doxygen
+  COMMENT "Generating Doxygen coverage info and HTML report..."
+)
+
+#-------------------------------------------------------------------------------
 # devicetree
 
 set(GEN_DEVICETREE_REST_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/_scripts/gen_devicetree_rest.py)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,7 +14,7 @@ HW_FEATURES_VENDOR_FILTER ?=
 # ------------------------------------------------------------------------------
 # Documentation targets
 
-.PHONY: configure clean html html-fast html-live html-live-fast latex pdf doxygen
+.PHONY: configure clean html html-fast html-live html-live-fast latex pdf doxygen doxygen-coverage
 
 html-fast:
 	${MAKE} html DT_TURBO_MODE=1 HW_FEATURES_TURBO_MODE=1
@@ -22,7 +22,7 @@ html-fast:
 html-live-fast:
 	${MAKE} html-live DT_TURBO_MODE=1 HW_FEATURES_TURBO_MODE=1
 
-html html-live latex pdf linkcheck doxygen: configure
+html html-live latex pdf linkcheck doxygen doxygen-coverage: configure
 	cmake --build ${BUILDDIR} --target $@
 
 configure:


### PR DESCRIPTION
Remove codecov upload from doc build workflow and instead ensure both test and doxygen coverage is uploaded in the same codecov.yml workflow, this way codecov report will accurately show the consolidated coverage for each "push" commit.