### PR TITLE
drivers: udc: stm32: cleanup how PHY type and speed are determined

### DIFF
--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -9,6 +9,7 @@ config UDC_STM32
 	select USE_STM32_LL_USB
 	select USE_STM32_HAL_PCD
 	select USE_STM32_HAL_PCD_EX
+	select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT
 	select PINCTRL
 	default y
 	help


### PR DESCRIPTION
Rework how the STM32 USB driver determines the PHY type and operating speed. This approach is more solid, based on the `phys` property and `compatible` on the node itself, rather than looking at which nodes are enabled and hoping for the best. `PCD_PHY_xxx` and `PCD_SPEED_xxx` macros, which should be more portable, are also used now in place of the LL USB macros.

Commit 7ff59b5d855182b0a3e6c718f28caf39a64b0891 is cherry-picked from #89866; it is not *strictly* related to PR's contents, but HS does not work without it. Since this PR supersedes #89866, the commit could be merged as part of it; however, I don't mind #89866 being modified to only include this commit or a separate PR being opened...

This PR also partially supersedes #86100 (only a few cosmetic(?) changes are missing here).