### PR TITLE
MAINTAINERS: Add dts/vendor/ti to TI K3 Platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4662,6 +4662,7 @@ TI K3 Platforms:
     - dts/arm/ti/am6*
     - dts/arm/ti/j7*
     - dts/bindings/*/ti,k3*
+    - dts/vendor/ti/
     - soc/ti/k3/
   labels:
     - "platform: TI K3"


### PR DESCRIPTION
This directory was added for the DT items common to both ARM (dts/arm) and ARM64 (dts/arm64) cores for TI devices.

For now the only TI devices that share DT nodes between cores of different architectures is the K3 family. If other TI devices start using this dir then we can get more granular in the MAINTAINERS entry here. Until then mark the whole directory as part of "TI K3 Platforms".