### PR TITLE
ci: workflows: fix junitparser merge glob pattern

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Merge Test Results
         run: |
-          junitparser merge --glob 'artifacts/*/twister.xml' --glob 'artifacts/*/*/twister.xml' junit.xml
+          junitparser merge --glob 'artifacts/*/twister.xml' 'artifacts/*/*/twister.xml' junit.xml
           junit2html junit.xml junit-clang.html
 
       - name: Upload Unit Test Results in HTML

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -347,7 +347,7 @@ jobs:
 
       - name: Merge Test Results
         run: |
-          junitparser merge --glob 'artifacts/*/twister.xml' --glob 'artifacts/*/*/twister.xml' junit.xml
+          junitparser merge --glob 'artifacts/*/twister.xml' 'artifacts/*/*/twister.xml' junit.xml
           junit2html junit.xml junit.html
 
       - name: Upload Unit Test Results


### PR DESCRIPTION
only one `--glob` should be passed to `junitparser merge`