### PR TITLE
boards: nxp: mimxrt1170: Remove SYSBUILD in board.cmake

### DIFF
--- a/boards/nxp/mimxrt1170_evk/board.cmake
+++ b/boards/nxp/mimxrt1170_evk/board.cmake
@@ -5,8 +5,10 @@
 #
 
 if(CONFIG_SOC_MIMXRT1176_CM7 OR CONFIG_SECOND_CORE_MCUX)
+ board_runner_args(linkserver "--no-reset")
  board_runner_args(pyocd "--target=mimxrt1170_cm7")
  board_runner_args(jlink "--device=MIMXRT1176xxxA_M7")
+ board_runner_args(jlink "--no-reset")
 
  if(${BOARD_REVISION} STREQUAL "A")
   board_runner_args(linkserver  "--device=MIMXRT1176xxxxx:MIMXRT1170-EVK")
@@ -27,10 +29,6 @@ elseif(CONFIG_SOC_MIMXRT1176_CM4)
  board_runner_args(linkserver "--core=cm4")
 endif()
 
-if(NOT SYSBUILD)
-  board_runner_args(jlink "--no-reset")
-  board_runner_args(linkserver "--no-reset")
-endif()
 
 include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Removed the dependency of config sysbuild from
the mimxrt1170_evk board.cmake.