### PR TITLE
testsuite: ztest: disable `ZTEST_NO_YIELD` for `COVERAGE_DUMP`

### DIFF
--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -101,6 +101,7 @@ config ZTEST_ASSERT_HOOK
 
 config ZTEST_NO_YIELD
 	bool "Do not yield to the idle thread after tests complete"
+	default n if COVERAGE_DUMP
 	default y if (PM || PM_DEVICE || PM_DEVICE_RUNTIME)
 	help
 	  When the tests complete, do not yield to the idle thread and instead


### PR DESCRIPTION
Don't enable `ZTEST_NO_YIELD` when `COVERAGE_DUMP` is enabled, since this option spins forever at the end of `main`, while `COVERAGE_DUMP` occurs after `main` returns into `bg_thread_main`.
https://github.com/zephyrproject-rtos/zephyr/blob/73ea9419c354526edf175607c5f0713f892a5196/subsys/testsuite/ztest/src/ztest.c#L1192-L1208
https://github.com/zephyrproject-rtos/zephyr/blob/73ea9419c354526edf175607c5f0713f892a5196/kernel/init.c#L349-L358
Originally introduced in #92822.