### PR TITLE
Use k3-am62-main for A53 dtsi

### DIFF
--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am62_a53-common.dtsi
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am62_a53-common.dtsi
@@ -11,8 +11,8 @@
 	compatible = "beagle,pocketbeagle_2_a53";
 
 	chosen {
-		zephyr,console = &uart6;
-		zephyr,shell-uart = &uart6;
+		zephyr,console = &main_uart6;
+		zephyr,shell-uart = &main_uart6;
 		zephyr,sram = &a53_ddr_section;
 	};
 
@@ -62,7 +62,7 @@
 	};
 };
 
-&uart6 {
+&main_uart6 {
 	pinctrl-0 = <&main_uart6_rx_default &main_uart6_tx_default>;
 	pinctrl-names = "default";
 	status = "okay";

--- a/boards/phytec/phyboard_lyra/phyboard_lyra_am6234_a53.dts
+++ b/boards/phytec/phyboard_lyra/phyboard_lyra_am6234_a53.dts
@@ -13,8 +13,8 @@
 	compatible = "phytec,phyboard-lyra-am62xx-a53", "ti,am625";
 
 	chosen {
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
+		zephyr,console = &main_uart0;
+		zephyr,shell-uart = &main_uart0;
 		zephyr,sram = &ddr0;
 	};
 
@@ -52,7 +52,7 @@
 	};
 };
 
-&uart0 {
+&main_uart0 {
 	current-speed = <115200>;
 	pinctrl-0 = <&uart0_rx_default &uart0_tx_default>;
 	pinctrl-names = "default";

--- a/boards/ti/sk_am62/sk_am62_am6234_a53.dts
+++ b/boards/ti/sk_am62/sk_am62_am6234_a53.dts
@@ -14,8 +14,8 @@
 	compatible = "ti,am62x_a53_sk";
 
 	chosen {
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
+		zephyr,console = &main_uart0;
+		zephyr,shell-uart = &main_uart0;
 		zephyr,sram = &ddr0;
 	};
 
@@ -43,7 +43,7 @@
 	};
 };
 
-&uart0 {
+&main_uart0 {
 	current-speed = <115200>;
 	pinctrl-0 = <&uart0_rx_default &uart0_tx_default>;
 	pinctrl-names = "default";

--- a/dts/arm64/ti/ti_am62x_a53.dtsi
+++ b/dts/arm64/ti/ti_am62x_a53.dtsi
@@ -75,50 +75,6 @@
 		#mbox-cells = <1>;
 	};
 
-	main_i2c0: i2c@20000000 {
-		compatible = "ti,omap-i2c";
-		reg = <0x20000000 0x100>;
-		interrupts = <GIC_SPI 161 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		clock-frequency = <100000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		status = "disabled";
-	};
-
-	main_i2c1: i2c@20010000 {
-		compatible = "ti,omap-i2c";
-		reg = <0x20010000 0x100>;
-		interrupts = <GIC_SPI 162 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		clock-frequency = <100000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		status = "disabled";
-	};
-
-	main_i2c2: i2c@20020000 {
-		compatible = "ti,omap-i2c";
-		reg = <0x20020000 0x100>;
-		interrupts = <GIC_SPI 163 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		clock-frequency = <100000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		status = "disabled";
-	};
-
-	main_i2c3: i2c@20030000 {
-		compatible = "ti,omap-i2c";
-		reg = <0x20030000 0x100>;
-		interrupts = <GIC_SPI 164 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		clock-frequency = <100000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		status = "disabled";
-	};
-
 	main_gpio0: gpio@600000 {
 		compatible = "ti,davinci-gpio";
 		reg = <0x00600000 0x100>;
@@ -172,5 +128,25 @@
 
 &main_uart6 {
 	interrupts = <GIC_SPI 184 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_i2c0 {
+	interrupts = <GIC_SPI 161 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_i2c1 {
+	interrupts = <GIC_SPI 162 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_i2c2 {
+	interrupts = <GIC_SPI 163 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_i2c3 {
+	interrupts = <GIC_SPI 164 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&gic>;
 };

--- a/dts/arm64/ti/ti_am62x_a53.dtsi
+++ b/dts/arm64/ti/ti_am62x_a53.dtsi
@@ -74,26 +74,6 @@
 		usr-id = <0>;
 		#mbox-cells = <1>;
 	};
-
-	main_gpio0: gpio@600000 {
-		compatible = "ti,davinci-gpio";
-		reg = <0x00600000 0x100>;
-		gpio-controller;
-		#gpio-cells = <2>;
-		/* FIXME: Enable all 92 GPIOs */
-		ngpios = <32>;
-		status = "disabled";
-	};
-
-	main_gpio1: gpio@601000 {
-		compatible = "ti,davinci-gpio";
-		reg = <0x00601000 0x100>;
-		gpio-controller;
-		#gpio-cells = <2>;
-		/* FIXME: Enable all 52 GPIOs */
-		ngpios = <32>;
-		status = "disabled";
-	};
 };
 
 &main_uart0 {

--- a/dts/arm64/ti/ti_am62x_a53.dtsi
+++ b/dts/arm64/ti/ti_am62x_a53.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/pinctrl/ti-k3-pinctrl.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <ti/k3-am62-main.dtsi>
 
 / {
 	#address-cells = <1>;
@@ -63,83 +64,6 @@
 		compatible = "ti,k3-pinctrl";
 		reg = <0x000f4000 0x2ac>;
 		status = "okay";
-	};
-
-	uart0: serial@2800000 {
-		compatible = "ns16550";
-		reg = <0x02800000 0x100>;
-		interrupts = <GIC_SPI 178 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		clock-frequency = <48000000>;
-		current-speed = <115200>;
-		reg-shift = <2>;
-		status = "disabled";
-	};
-
-	uart1: serial@2810000 {
-		compatible = "ns16550";
-		reg = <0x02810000 0x100>;
-		interrupts = <GIC_SPI 179 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		clock-frequency = <48000000>;
-		current-speed = <115200>;
-		reg-shift = <2>;
-		status = "disabled";
-	};
-
-	uart2: serial@2820000 {
-		compatible = "ns16550";
-		reg = <0x02820000 0x100>;
-		interrupts = <GIC_SPI 180 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		clock-frequency = <48000000>;
-		current-speed = <115200>;
-		reg-shift = <2>;
-		status = "disabled";
-	};
-
-	uart3: serial@2830000 {
-		compatible = "ns16550";
-		reg = <0x02830000 0x100>;
-		interrupts = <GIC_SPI 181 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		clock-frequency = <48000000>;
-		current-speed = <115200>;
-		reg-shift = <2>;
-		status = "disabled";
-	};
-
-	uart4: serial@2840000 {
-		compatible = "ns16550";
-		reg = <0x02840000 0x100>;
-		interrupts = <GIC_SPI 182 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		clock-frequency = <48000000>;
-		current-speed = <115200>;
-		reg-shift = <2>;
-		status = "disabled";
-	};
-
-	uart5: serial@2850000 {
-		compatible = "ns16550";
-		reg = <0x02850000 0x100>;
-		interrupts = <GIC_SPI 183 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		clock-frequency = <48000000>;
-		current-speed = <115200>;
-		reg-shift = <2>;
-		status = "disabled";
-	};
-
-	uart6: serial@2860000 {
-		compatible = "ns16550";
-		reg = <0x02860000 0x100>;
-		interrupts = <GIC_SPI 184 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		clock-frequency = <48000000>;
-		current-speed = <115200>;
-		reg-shift = <2>;
-		status = "disabled";
 	};
 
 	mbox0: mailbox0@29000000 {
@@ -214,4 +138,39 @@
 		ngpios = <32>;
 		status = "disabled";
 	};
+};
+
+&main_uart0 {
+	interrupts = <GIC_SPI 178 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_uart1 {
+	interrupts = <GIC_SPI 179 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_uart2 {
+	interrupts = <GIC_SPI 180 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_uart3 {
+	interrupts = <GIC_SPI 181 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_uart4 {
+	interrupts = <GIC_SPI 182 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_uart5 {
+	interrupts = <GIC_SPI 183 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_uart6 {
+	interrupts = <GIC_SPI 184 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
 };

--- a/dts/vendor/ti/k3-am62-main.dtsi
+++ b/dts/vendor/ti/k3-am62-main.dtsi
@@ -69,4 +69,40 @@
 		reg-shift = <2>;
 		status = "disabled";
 	};
+
+	main_i2c0: i2c@20000000 {
+		compatible = "ti,omap-i2c";
+		reg = <0x20000000 0x100>;
+		clock-frequency = <100000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	main_i2c1: i2c@20010000 {
+		compatible = "ti,omap-i2c";
+		reg = <0x20010000 0x100>;
+		clock-frequency = <100000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	main_i2c2: i2c@20020000 {
+		compatible = "ti,omap-i2c";
+		reg = <0x20020000 0x100>;
+		clock-frequency = <100000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	main_i2c3: i2c@20030000 {
+		compatible = "ti,omap-i2c";
+		reg = <0x20030000 0x100>;
+		clock-frequency = <100000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
 };

--- a/dts/vendor/ti/k3-am62-main.dtsi
+++ b/dts/vendor/ti/k3-am62-main.dtsi
@@ -105,4 +105,24 @@
 		#size-cells = <0>;
 		status = "disabled";
 	};
+
+	main_gpio0: gpio@600000 {
+		compatible = "ti,davinci-gpio";
+		reg = <0x00600000 0x100>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		/* FIXME: Enable all 92 GPIOs */
+		ngpios = <32>;
+		status = "disabled";
+	};
+
+	main_gpio1: gpio@601000 {
+		compatible = "ti,davinci-gpio";
+		reg = <0x00601000 0x100>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		/* FIXME: Enable all 52 GPIOs */
+		ngpios = <32>;
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
- Since the same file is also used by m4 cores, do not add interrupt
  properties, since they are different between m4 and a53