### PR TITLE
dts: bindings: serial: st,stm32-uart: Fix description of dts property

### DIFF
--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -86,7 +86,7 @@ properties:
     type: int
     default: 0
     description: |
-      Defines the time between the activation of the DE signal and the beginning of the start bit.
+      Defines the time between the end of the stop bit and the deactivation of the DE signal.
       It is expressed in 16th of a bit time.
       Valid range: 0 - 31
 


### PR DESCRIPTION
Fix dts property description of `de-deassert-time` for `stm32-uart` driver. Old text was copy'n'pasted from `de-assert-time`.

Cite from the H7RSx reference manual:
**Driver Enable deassertion time**
This 5-bit value defines the time between the end of the last stop bit, in a transmitted
message, and the de-activation of the DE (Driver Enable) signal. It is expressed in sample
time units (1/8 or 1/16 bit time, depending on the oversampling rate).
If the USART_TDR register is written during the DEDT time, the new data is transmitted only
when the DEDT and DEAT times have both elapsed.
This bitfield can only be written when the USART is disabled (UE = 0).