### PR TITLE
scripts: west_commands: correct f-string in board mismatch error message

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -589,7 +589,7 @@ class Build(Forceable):
         self.check_force(
             not boards_mismatched or self.auto_pristine,
             f'Build directory {self.build_dir} targets board {cached_board}, '
-            'but board {self.args.board} was specified. '
+            f'but board {self.args.board} was specified. '
             '(Clean the directory, use --pristine, or use --build-dir to '
             'specify a different one.)')
 


### PR DESCRIPTION
The board mismatch error message in `scripts/west_commands/build.py` was partially missing f-string formatting. This caused `{self.args.board}` to be printed literally instead of being replaced with the actual board value.

Fix the f-string.


On another note, the string being splitted on multiple line prevent efficient greping of the error message, and the coding guidelines says that this should be avoided (https://kernel.org/doc/html/latest/process/coding-style.html#breaking-long-lines-and-strings), should this be fixed ?