### PR TITLE
drivers: i2c: add i2c target support for ambiq soc

### DIFF
--- a/boards/ambiq/apollo3_evb/apollo3_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo3_evb/apollo3_evb-pinctrl.dtsi
@@ -79,6 +79,15 @@
 		};
 	};
 
+	ios_i2c0_default: ios_i2c0_default {
+		group1 {
+			pinmux = <SLSCL_P0>, <SLSDAWIR3_P1>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+
 	spid0_default: spid0_default {
 		group1 {
 			pinmux = <SLSCK_P0>, <SLMISO_P2>, <SLMOSI_P1>, <SLNCE_P3>;

--- a/boards/ambiq/apollo3_evb/apollo3_evb.yaml
+++ b/boards/ambiq/apollo3_evb/apollo3_evb.yaml
@@ -15,6 +15,7 @@ supported:
   - gpio
   - spi
   - i2c
+  - i2c_target
   - logging
 testing:
   ignore_tags:

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb-pinctrl.dtsi
@@ -79,6 +79,15 @@
 		};
 	};
 
+	ios_i2c0_default: ios_i2c0_default {
+		group1 {
+			pinmux = <SLSCL_P0>, <SLSDAWIR3_P1>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+
 	spid0_default: spid0_default {
 		group1 {
 			pinmux = <SLSCK_P0>, <SLMISO_P2>, <SLMOSI_P1>, <SLNCE_P3>;

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb.yaml
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb.yaml
@@ -15,6 +15,7 @@ supported:
   - gpio
   - spi
   - i2c
+  - i2c_target
   - mspi
   - logging
 testing:

--- a/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
@@ -87,6 +87,15 @@
 		};
 	};
 
+	ios_i2c0_default: ios_i2c0_default {
+		group1 {
+			pinmux = <SLSCL_P0>, <SLSDAWIR3_P1>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+
 	spi0_default: spi0_default {
 		group1 {
 			pinmux = <M0SCK_P5>, <M0MISO_P7>, <M0MOSI_P6>;

--- a/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.yaml
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.yaml
@@ -15,6 +15,7 @@ supported:
   - gpio
   - spi
   - i2c
+  - i2c_target
   - clock_control
   - ble
   - usbd

--- a/boards/ambiq/apollo4p_evb/apollo4p_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo4p_evb/apollo4p_evb-pinctrl.dtsi
@@ -104,6 +104,15 @@
 		};
 	};
 
+	ios_i2c0_default: ios_i2c0_default {
+		group1 {
+			pinmux = <SLSCL_P0>, <SLSDAWIR3_P1>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+
 	spi0_default: spi0_default {
 		group1 {
 			pinmux = <M0SCK_P5>, <M0MISO_P7>, <M0MOSI_P6>;

--- a/boards/ambiq/apollo4p_evb/apollo4p_evb.yaml
+++ b/boards/ambiq/apollo4p_evb/apollo4p_evb.yaml
@@ -14,6 +14,7 @@ supported:
   - gpio
   - spi
   - i2c
+  - i2c_target
   - rtc
   - adc
   - hwinfo

--- a/boards/ambiq/apollo510_evb/apollo510_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo510_evb/apollo510_evb-pinctrl.dtsi
@@ -157,6 +157,21 @@
 		};
 	};
 
+	ios_i2c0_default: ios_i2c0_default {
+		group1 {
+			pinmux = <SLSCL_P11>, <SLSDAWIR3_P52>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+
+	ios_i2c0_sleep: ios_i2c0_sleep {
+		group1 {
+			pinmux = <GPIO_P11>, <GPIO_P52>;
+		};
+	};
+
 	spid0_default: spid0_default {
 		group1 {
 			pinmux = <SLSCK_P11>, <SLMISO_P83>, <SLMOSI_P52>, <SLnCE_P13>;

--- a/boards/ambiq/apollo510_evb/apollo510_evb.yaml
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.yaml
@@ -15,6 +15,7 @@ supported:
   - gpio
   - spi
   - i2c
+  - i2c_target
   - rtc
   - hwinfo
   - clock_control

--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -22,6 +22,7 @@ add_subdirectory_ifdef(CONFIG_I2C_TARGET target)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_I2C_AMBIQ i2c_ambiq.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_AMBIQ_IOS i2c_ambiq_ios.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_ANDES_ATCIIC100 i2c_andes_atciic100.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_BEE i2c_bee.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_BFLB i2c_bflb.c)

--- a/drivers/i2c/Kconfig.ambiq
+++ b/drivers/i2c/Kconfig.ambiq
@@ -30,3 +30,12 @@ config I2C_AMBIQ_BUS_RECOVERY
 	  Enable AMBIQ driver bus recovery support via GPIO bitbanging.
 
 endif # I2C_AMBIQ
+
+config I2C_AMBIQ_IOS
+	bool "AMBIQ IOS I2C target driver"
+	default y
+	depends on DT_HAS_AMBIQ_IOS_I2C_ENABLED
+	select AMBIQ_HAL
+	select AMBIQ_HAL_USE_IOS_I2C
+	help
+	  Enable driver for Ambiq I2C in Target mode.

--- a/drivers/i2c/i2c_ambiq_ios.c
+++ b/drivers/i2c/i2c_ambiq_ios.c
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2025 Ambiq <www.ambiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ambiq_ios_i2c
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/irq.h>
+#include <soc.h>
+
+LOG_MODULE_REGISTER(i2c_ambiq_ios, CONFIG_I2C_LOG_LEVEL);
+
+#if defined(CONFIG_SOC_SERIES_APOLLO5X)
+#define IOS_ADDR_INTERVAL (IOSLAVEFD1_BASE - IOSLAVEFD0_BASE)
+#else
+#define IOS_ADDR_INTERVAL 1
+#endif
+
+#define AMBIQ_I2C_IOS_FIFO_BASE   0x78
+#define AMBIQ_I2C_IOS_FIFO_END    0x100
+#define AMBIQ_I2C_IOS_FIFO_LENGTH (AMBIQ_I2C_IOS_FIFO_END - AMBIQ_I2C_IOS_FIFO_BASE)
+
+struct ambiq_i2c_ios_config {
+	const struct pinctrl_dev_config *pcfg;
+	uint32_t inst_idx;
+	uint8_t fifo_thr;
+	void (*irq_cfg)(void);
+	void (*acc_irq_cfg)(void);
+	bool has_acc_irq;
+};
+
+struct ambiq_i2c_ios_data {
+	void *i2c_ios_handle;
+	struct i2c_target_config *tgt;
+	bool enabled;
+	uint8_t sram_buf[256];
+
+	/* read buffer-mode staging */
+	const uint8_t *rd_ptr;
+	uint32_t rd_len;
+	uint32_t rd_pos;
+};
+
+static void i2c_ambiq_ios_feed_fifo(const struct device *dev)
+{
+	struct ambiq_i2c_ios_data *data = dev->data;
+	uint32_t left = data->rd_len - data->rd_pos;
+	uint32_t wrote = 0;
+
+	if (!data->tgt || !data->rd_ptr) {
+		return;
+	}
+	if (!left) {
+		return;
+	}
+	am_hal_ios_fifo_write(data->i2c_ios_handle, (uint8_t *)&data->rd_ptr[data->rd_pos], left,
+			      &wrote);
+	data->rd_pos += wrote;
+	am_hal_ios_control(data->i2c_ios_handle, AM_HAL_IOS_REQ_FIFO_UPDATE_CTR, NULL);
+}
+
+static void i2c_ambiq_ios_isr(const struct device *dev)
+{
+	struct ambiq_i2c_ios_data *data = dev->data;
+	uint32_t status = 0;
+
+	am_hal_ios_interrupt_status_get(data->i2c_ios_handle, true, &status);
+	if (status & AM_HAL_IOS_INT_FSIZE) {
+		if (data->tgt && data->tgt->callbacks &&
+		    IS_ENABLED(CONFIG_I2C_TARGET_BUFFER_MODE) &&
+		    data->tgt->callbacks->buf_read_requested && (data->rd_pos == data->rd_len)) {
+			uint8_t *ptr = NULL;
+			uint32_t len = 0;
+
+			if (data->tgt->callbacks->buf_read_requested(data->tgt, &ptr, &len) == 0 &&
+			    ptr && len) {
+				data->rd_ptr = ptr;
+				data->rd_len = len;
+				data->rd_pos = 0;
+			}
+		}
+		i2c_ambiq_ios_feed_fifo(dev);
+		am_hal_ios_interrupt_clear(data->i2c_ios_handle, AM_HAL_IOS_INT_FSIZE);
+	}
+	am_hal_ios_interrupt_clear(data->i2c_ios_handle, status & ~AM_HAL_IOS_INT_FSIZE);
+}
+
+static void i2c_ambiq_ios_acc_isr(const struct device *dev)
+{
+	struct ambiq_i2c_ios_data *data = dev->data;
+	uint32_t acc_pend = 0;
+
+	if (am_hal_ios_control(data->i2c_ios_handle, AM_HAL_IOS_REQ_ACC_INTGET, &acc_pend) ==
+	    AM_HAL_STATUS_SUCCESS) {
+		if ((acc_pend & AM_HAL_IOS_ACCESS_INT_00) && data->tgt && data->tgt->callbacks &&
+		    IS_ENABLED(CONFIG_I2C_TARGET_BUFFER_MODE) &&
+		    data->tgt->callbacks->buf_write_received) {
+			uint8_t len = am_hal_ios_pui8LRAM[0];
+
+			if (len > 0) {
+				data->tgt->callbacks->buf_write_received(
+					data->tgt, (uint8_t *)&am_hal_ios_pui8LRAM[1],
+					(uint32_t)len);
+				am_hal_ios_pui8LRAM[0] = 0;
+			}
+		}
+		(void)am_hal_ios_control(data->i2c_ios_handle, AM_HAL_IOS_REQ_ACC_INTCLR,
+					 &acc_pend);
+	}
+}
+
+#ifdef CONFIG_PM_DEVICE
+static int i2c_ambiq_ios_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct ambiq_i2c_ios_config *cfg = dev->config;
+	struct ambiq_i2c_ios_data *data = dev->data;
+	int err;
+	am_hal_sysctrl_power_state_e status;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		/* Set pins to active state */
+		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (err < 0) {
+			return err;
+		}
+		status = AM_HAL_SYSCTRL_WAKE;
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		/* Move pins to sleep state */
+		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
+		if ((err < 0) && (err != -ENOENT)) {
+			/*
+			 * If returning -ENOENT, no pins where defined for sleep mode :
+			 * Do not output on console (might sleep already) when going to
+			 * sleep,
+			 * "I2C pinctrl sleep state not available"
+			 * and don't block PM suspend.
+			 * Else return the error.
+			 */
+			return err;
+		}
+		status = AM_HAL_SYSCTRL_DEEPSLEEP;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	err = am_hal_ios_power_ctrl(data->i2c_ios_handle, status, true);
+	if (err != AM_HAL_STATUS_SUCCESS) {
+		LOG_ERR("am_hal_ios_power_ctrl failed: %d", err);
+		return -EPERM;
+	} else {
+		return 0;
+	}
+}
+#endif /* CONFIG_PM_DEVICE */
+
+#ifdef CONFIG_I2C_TARGET
+static int i2c_ambiq_ios_target_register(const struct device *dev, struct i2c_target_config *tcfg)
+{
+	const struct ambiq_i2c_ios_config *config = dev->config;
+	struct ambiq_i2c_ios_data *data = dev->data;
+	am_hal_ios_config_t ios = {0};
+	uint32_t acc_mask = AM_HAL_IOS_ACCESS_INT_00;
+
+	if (data->tgt) {
+		return -EBUSY;
+	}
+
+	/* Disable IOS instance as it cannot be configured when enabled */
+	if (am_hal_ios_disable(data->i2c_ios_handle) != AM_HAL_STATUS_SUCCESS) {
+		return -EIO;
+	}
+
+	ios.ui32InterfaceSelect = AM_HAL_IOS_USE_I2C | AM_HAL_IOS_I2C_ADDRESS(tcfg->address << 1);
+	ios.ui32ROBase = AMBIQ_I2C_IOS_FIFO_BASE;
+	ios.ui32FIFOBase = AMBIQ_I2C_IOS_FIFO_BASE;
+	ios.ui32RAMBase = AMBIQ_I2C_IOS_FIFO_END;
+	/* FIFO Threshold - set to half the size */
+	ios.ui32FIFOThreshold = config->fifo_thr;
+	ios.pui8SRAMBuffer = data->sram_buf;
+	ios.ui32SRAMBufferCap = sizeof(data->sram_buf);
+
+	if (am_hal_ios_configure(data->i2c_ios_handle, &ios) != AM_HAL_STATUS_SUCCESS) {
+		return -EIO;
+	}
+
+	int rc = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+
+	if (rc < 0) {
+		return rc;
+	}
+
+	if (am_hal_ios_enable(data->i2c_ios_handle) != AM_HAL_STATUS_SUCCESS) {
+		return -EIO;
+	}
+
+	am_hal_ios_interrupt_clear(data->i2c_ios_handle, AM_HAL_IOS_INT_ALL);
+	am_hal_ios_interrupt_enable(data->i2c_ios_handle, AM_HAL_IOS_INT_FSIZE);
+	am_hal_ios_control(data->i2c_ios_handle, AM_HAL_IOS_REQ_ACC_INTEN, &acc_mask);
+
+	data->tgt = tcfg;
+	data->enabled = true;
+
+	if (IS_ENABLED(CONFIG_I2C_TARGET_BUFFER_MODE) && data->tgt->callbacks &&
+	    data->tgt->callbacks->buf_read_requested) {
+		uint8_t *ptr = NULL;
+		uint32_t len = 0;
+
+		if (data->tgt->callbacks->buf_read_requested(data->tgt, &ptr, &len) == 0 && ptr &&
+		    len) {
+			data->rd_ptr = ptr;
+			data->rd_len = len;
+			data->rd_pos = 0;
+			i2c_ambiq_ios_feed_fifo(dev);
+		}
+	}
+
+	return 0;
+}
+
+static int i2c_ambiq_ios_target_unregister(const struct device *dev, struct i2c_target_config *tcfg)
+{
+	const struct ambiq_i2c_ios_config *config = dev->config;
+	struct ambiq_i2c_ios_data *data = dev->data;
+	uint32_t acc_mask = AM_HAL_IOS_ACCESS_INT_ALL;
+
+	if (data->tgt != tcfg) {
+		return -EINVAL;
+	}
+
+	am_hal_ios_interrupt_disable(data->i2c_ios_handle, AM_HAL_IOS_INT_ALL);
+	am_hal_ios_control(data->i2c_ios_handle, AM_HAL_IOS_REQ_ACC_INTDIS, &acc_mask);
+	am_hal_ios_control(data->i2c_ios_handle, AM_HAL_IOS_REQ_FIFO_BUF_CLR, NULL);
+	am_hal_ios_disable(data->i2c_ios_handle);
+	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
+
+	data->tgt = NULL;
+	data->enabled = false;
+	data->rd_ptr = NULL;
+	data->rd_len = data->rd_pos = 0;
+
+	return 0;
+}
+#endif
+
+static int i2c_ambiq_ios_init(const struct device *dev)
+{
+	const struct ambiq_i2c_ios_config *config = dev->config;
+	struct ambiq_i2c_ios_data *data = dev->data;
+	uint32_t ret = am_hal_ios_initialize(config->inst_idx, &data->i2c_ios_handle);
+
+	if (ret != AM_HAL_STATUS_SUCCESS) {
+		LOG_ERR("Failed to initialize i2c target\n");
+		return -EBUSY;
+	}
+
+	ret = am_hal_ios_power_ctrl(data->i2c_ios_handle, AM_HAL_SYSCTRL_WAKE, false);
+	if (ret != AM_HAL_STATUS_SUCCESS) {
+		LOG_ERR("Failed to power up i2c target\n");
+		am_hal_ios_uninitialize(data->i2c_ios_handle);
+		return -ENXIO;
+	}
+
+	config->irq_cfg();
+	if (config->has_acc_irq && config->acc_irq_cfg) {
+		config->acc_irq_cfg();
+	}
+
+	data->enabled = false;
+	data->tgt = NULL;
+	data->rd_ptr = NULL;
+	data->rd_len = data->rd_pos = 0;
+	return 0;
+}
+
+static DEVICE_API(i2c, i2c_ambiq_ios_api) = {
+#ifdef CONFIG_I2C_TARGET
+	.target_register = i2c_ambiq_ios_target_register,
+	.target_unregister = i2c_ambiq_ios_target_unregister,
+#endif
+};
+
+#define AMBIQ_I2C_IOS_IRQ_CFG(n)                                                       \
+	static void i2c_ambiq_ios_irq_cfg_##n(void)                                        \
+	{                                                                                  \
+		IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(n)), DT_IRQ(DT_INST_PARENT(n), priority),   \
+			i2c_ambiq_ios_isr, DEVICE_DT_INST_GET(n), 0);                              \
+		irq_enable(DT_IRQN(DT_INST_PARENT(n)));                                        \
+	}
+
+#define AMBIQ_I2C_IOS_ACC_IRQ_CFG(n)                                               \
+	COND_CODE_1(DT_IRQ_HAS_IDX(DT_INST_PARENT(n), 1), (                            \
+		static void i2c_ambiq_ios_acc_irq_cfg_##n(void)                            \
+		{                                                                          \
+			IRQ_CONNECT(DT_IRQ_BY_IDX(DT_INST_PARENT(n), 1, irq),                  \
+				DT_IRQ_BY_IDX(DT_INST_PARENT(n), 1, priority),                     \
+				i2c_ambiq_ios_acc_isr, DEVICE_DT_INST_GET(n), 0);                  \
+			irq_enable(DT_IRQ_BY_IDX(DT_INST_PARENT(n), 1, irq));                  \
+		}                                                                          \
+	), (/* no acc irq */))
+
+#define AMBIQ_I2C_IOS_DEFINE(n)                                                        \
+	BUILD_ASSERT(DT_CHILD_NUM_STATUS_OKAY(DT_INST_PARENT(n)) == 1,                     \
+		     "Too many children for IOS, either SPI or I2C should be enabled!");       \
+	PINCTRL_DT_INST_DEFINE(n);                                                         \
+	AMBIQ_I2C_IOS_IRQ_CFG(n)                                                           \
+	AMBIQ_I2C_IOS_ACC_IRQ_CFG(n)                                                       \
+	static const struct ambiq_i2c_ios_config cfg_##n = {                               \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                     \
+		.inst_idx = (DT_REG_ADDR(DT_INST_PARENT(n)) - IOSLAVE_BASE) / IOS_ADDR_INTERVAL,\
+		.fifo_thr = DT_INST_PROP_OR(n, fifo_threshold, 16),                            \
+		.irq_cfg = i2c_ambiq_ios_irq_cfg_##n,                                          \
+		.acc_irq_cfg = COND_CODE_1(DT_IRQ_HAS_IDX(DT_INST_PARENT(n), 1),               \
+		     (i2c_ambiq_ios_acc_irq_cfg_##n), (NULL)),                                 \
+		.has_acc_irq = DT_IRQ_HAS_IDX(DT_INST_PARENT(n), 1),                           \
+	};                                                                                 \
+	static struct ambiq_i2c_ios_data data_##n;                                         \
+	PM_DEVICE_DT_INST_DEFINE(n, i2c_ambiq_ios_pm_action);                              \
+	DEVICE_DT_INST_DEFINE(n, i2c_ambiq_ios_init, PM_DEVICE_DT_INST_GET(n), &data_##n,  \
+			&cfg_##n, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,                           \
+			&i2c_ambiq_ios_api);
+
+DT_INST_FOREACH_STATUS_OKAY(AMBIQ_I2C_IOS_DEFINE)

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2025 Ambiq Micro Inc. */
 
 #include <arm/armv7-m.dtsi>
 #include <mem.h>
@@ -270,14 +271,24 @@
 			zephyr,pm-device-runtime-auto;
 		};
 
-		spid0: spi@50000100 {
-			compatible = "ambiq,spid";
+		ios0: ios@50000100 {
+			compatible = "ambiq,ios";
 			reg = <0x50000100 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <4 0>;
-			status = "disabled";
-			zephyr,pm-device-runtime-auto;
+			interrupts = <4 0>, <5 0>;
+
+			spi {
+				compatible = "ambiq,spid";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			i2c {
+				compatible = "ambiq,ios-i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
 		};
 
 		iom0: iom@50004000 {

--- a/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2025 Ambiq Micro Inc. */
 
 #include <arm/armv7-m.dtsi>
 #include <mem.h>
@@ -288,14 +289,24 @@
 			zephyr,pm-device-runtime-auto;
 		};
 
-		spid0: spi@50000100 {
-			compatible = "ambiq,spid";
+		ios0: ios@50000100 {
+			compatible = "ambiq,ios";
 			reg = <0x50000100 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <4 0>;
-			status = "disabled";
-			zephyr,pm-device-runtime-auto;
+			interrupts = <4 0>, <5 0>;
+
+			spi {
+				compatible = "ambiq,spid";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			i2c {
+				compatible = "ambiq,ios-i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
 		};
 
 		iom0: iom@50004000 {

--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -417,6 +417,26 @@
 			status = "disabled";
 		};
 
+		ios0: ios@40034000 {
+			compatible = "ambiq,ios";
+			reg = <0x40034000 0x1000>;
+			interrupts = <4 0>, <5 0>;
+
+			spi {
+				compatible = "ambiq,spid";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			i2c {
+				compatible = "ambiq,ios-i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
+
 		iom0: iom@40050000 {
 			compatible = "ambiq,iom";
 			reg = <0x40050000 0x1000>;

--- a/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
@@ -431,6 +431,26 @@
 			status = "disabled";
 		};
 
+		ios0: ios@40034000 {
+			compatible = "ambiq,ios";
+			reg = <0x40034000 0x1000>;
+			interrupts = <4 0>, <5 0>;
+
+			spi {
+				compatible = "ambiq,spid";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			i2c {
+				compatible = "ambiq,ios-i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
+
 		iom0: iom@40050000 {
 			compatible = "ambiq,iom";
 			reg = <0x40050000 0x1000>;

--- a/dts/arm/ambiq/ambiq_apollo510.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo510.dtsi
@@ -418,14 +418,24 @@
 			status = "disabled";
 		};
 
-		spid0: spi@IOSLAVE_BASE_NAME {
-			compatible = "ambiq,spid";
+		ios0: ios@IOSLAVE_BASE_NAME {
+			compatible = "ambiq,ios";
 			reg = <IOSLAVE_REG_BASE IOSLAVE_REG_SIZE>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <4 0>;
-			status = "disabled";
-			zephyr,pm-device-runtime-auto;
+			interrupts = <4 0>, <5 0>;
+
+			spi {
+				compatible = "ambiq,spid";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			i2c {
+				compatible = "ambiq,ios-i2c";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
 		};
 
 		iom0: iom@IOM0_BASE_NAME {

--- a/dts/bindings/i2c/ambiq,ios-i2c.yaml
+++ b/dts/bindings/i2c/ambiq,ios-i2c.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2025 Ambiq Micro Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Ambiq IOS I2C target (slave) peripheral
+
+compatible: "ambiq,ios-i2c"
+
+include: [i2c-controller.yaml, pinctrl-device.yaml]
+
+properties:
+  fifo-threshold:
+    type: int
+    required: true
+    default: 16
+    description: |
+        Set the FIFO threshold to the middle by default

--- a/dts/bindings/mfd/ambiq,ios.yaml
+++ b/dts/bindings/mfd/ambiq,ios.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 Ambiq Micro Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Ambiq IOS peripheral (SPI device or I2C target) parent node
+
+compatible: "ambiq,ios"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true

--- a/modules/hal_ambiq/Kconfig.hal
+++ b/modules/hal_ambiq/Kconfig.hal
@@ -62,6 +62,11 @@ config AMBIQ_HAL_USE_I2C
 	help
 	  Use the I2C driver from Ambiq HAL
 
+config AMBIQ_HAL_USE_IOS_I2C
+	bool
+	help
+	  Use the I2C Target driver from Ambiq HAL
+
 config AMBIQ_HAL_USE_SPIC
 	bool
 	help

--- a/samples/drivers/i2c/target_eeprom/boards/apollo510_evb.overlay
+++ b/samples/drivers/i2c/target_eeprom/boards/apollo510_evb.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Ambiq Micro Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ios0 {
+	i2c_ios0: i2c {
+		compatible = "ambiq,ios-i2c";
+		status = "okay";
+		fifo-threshold = <16>;
+		pinctrl-0 = <&ios_i2c0_default>;
+		pinctrl-names = "default";
+
+		eeprom0: eeprom@10 {
+			compatible = "zephyr,i2c-target-eeprom";
+			reg = <0x10>;
+			size = <256>;
+			status = "okay";
+		};
+	};
+};
+
+target_eeprom: &eeprom0 {};

--- a/samples/drivers/i2c/target_eeprom/sample.yaml
+++ b/samples/drivers/i2c/target_eeprom/sample.yaml
@@ -6,6 +6,7 @@ tests:
     filter: dt_nodelabel_enabled("target_eeprom")
     platform_allow:
       - lpcxpresso55s69/lpc55s69/cpu0
+      - apollo510_evb
     harness: TBD
   sample.drivers.i2c.target.kinetis:
     tags: i2c_target


### PR DESCRIPTION
Adds bingding for ambiq ios which can used as spi device or i2c target, and creates ios i2c driver.