### PR TITLE
drivers: Counter: STM Support on Zephyr

### DIFF
--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
@@ -164,6 +164,8 @@
 	mux-0-dc-4-div = <4>;
 	mux-0-dc-5-div = <4>;
 	mux-0-dc-6-div = <1>;
+	mux-1-dc-0-div = <1>;
+	mux-2-dc-0-div = <1>;
 };
 
 &stm_0 {

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
@@ -165,3 +165,8 @@
 	mux-0-dc-5-div = <4>;
 	mux-0-dc-6-div = <1>;
 };
+
+&stm_0 {
+	status = "okay";
+	prescaler = <1>;
+};

--- a/drivers/clock_control/clock_control_nxp_mc_cgm.c
+++ b/drivers/clock_control/clock_control_nxp_mc_cgm.c
@@ -160,6 +160,19 @@ static int mc_cgm_clock_control_on(const struct device *dev, clock_control_subsy
 	}
 #endif /* defined(CONFIG_I2C_MCUX_LPI2C) */
 
+#if defined(CONFIG_COUNTER_MCUX_STM)
+	switch ((uint32_t)sub_system) {
+	case MCUX_STM0_CLK:
+		CLOCK_EnableClock(kCLOCK_Stm0);
+		break;
+	case MCUX_STM1_CLK:
+		CLOCK_EnableClock(kCLOCK_Stm1);
+		break;
+	default:
+		break;
+	}
+#endif /* defined(CONFIG_COUNTER_MCUX_STM) */
+
 	return 0;
 }
 
@@ -237,6 +250,15 @@ static int mc_cgm_get_subsys_rate(const struct device *dev, clock_control_subsys
 		*rate = CLOCK_GetFlexcanPeClkFreq(5);
 		break;
 #endif /* defined(CONFIG_CAN_MCUX_FLEXCAN) */
+
+#if defined(CONFIG_COUNTER_MCUX_STM)
+	case MCUX_STM0_CLK:
+		*rate = CLOCK_GetStmClkFreq(0);
+		break;
+	case MCUX_STM1_CLK:
+		*rate = CLOCK_GetStmClkFreq(1);
+		break;
+#endif /* defined(CONFIG_COUNTER_MCUX_STM) */
 	}
 	return 0;
 }
@@ -297,6 +319,14 @@ static int mc_cgm_init(const struct device *dev)
 #endif
 	CLOCK_CommonTriggerClkMux0DivUpdate();
 	CLOCK_ProgressiveClockFrequencySwitch(kPLL_PHI0_CLK_to_MUX0, &pcfs_config);
+#if defined(CONFIG_COUNTER_MCUX_STM)
+	CLOCK_SetClkDiv(kCLOCK_DivStm0Clk, NXP_PLL_MUX_1_DC_0_DIV);
+	CLOCK_AttachClk(kAIPS_PLAT_CLK_to_STM0);
+#if defined(FSL_FEATURE_SOC_STM_COUNT) && (FSL_FEATURE_SOC_STM_COUNT == 2U)
+	CLOCK_SetClkDiv(kCLOCK_DivStm1Clk, NXP_PLL_MUX_2_DC_0_DIV);
+	CLOCK_AttachClk(kAIPS_PLAT_CLK_to_STM1);
+#endif /* FSL_FEATURE_SOC_STM_COUNT == 2U */
+#endif /* defined(CONFIG_COUNTER_MCUX_STM) */
 #endif
 
 	/* Set SystemCoreClock variable. */

--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -35,6 +35,7 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_XEC                 counter_mchp_xec
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPTMR          counter_mcux_lptmr.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPIT           counter_mcux_lpit.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_FTM            counter_mcux_ftm.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_STM            counter_mcux_stm.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MAXIM_DS3231        maxim_ds3231.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NATIVE_SIM          counter_native_sim.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE                   counter_handlers.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -74,6 +74,8 @@ source "drivers/counter/Kconfig.mcux_lpit"
 
 source "drivers/counter/Kconfig.mcux_ftm"
 
+source "drivers/counter/Kconfig.mcux_stm"
+
 source "drivers/counter/Kconfig.maxim_ds3231"
 
 source "drivers/counter/Kconfig.native_sim"

--- a/drivers/counter/Kconfig.mcux_stm
+++ b/drivers/counter/Kconfig.mcux_stm
@@ -1,0 +1,12 @@
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# MCUXpresso SDK System Timer Module (STM)
+
+config COUNTER_MCUX_STM
+	bool "MCUX STM driver"
+	default y
+	depends on DT_HAS_NXP_STM_ENABLED
+	help
+	  Enable support for the MCUX System Timer Module (STM).

--- a/drivers/counter/counter_mcux_stm.c
+++ b/drivers/counter/counter_mcux_stm.c
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2023-2025 NXP.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_stm
+
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
+#include <zephyr/logging/log.h>
+
+#include <fsl_stm.h>
+
+LOG_MODULE_REGISTER(mcux_stm, CONFIG_COUNTER_LOG_LEVEL);
+
+struct mcux_stm_channel_data {
+	counter_alarm_callback_t alarm_callback;
+	void *alarm_user_data;
+};
+
+struct mcux_stm_config {
+	struct counter_config_info info;
+	STM_Type *base;
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
+	uint8_t prescale;
+	void (*irq_config_func)(const struct device *dev);
+};
+
+struct mcux_stm_data {
+	uint32_t freq;
+	struct mcux_stm_channel_data channels[STM_CHANNEL_COUNT];
+};
+
+static int mcux_stm_start(const struct device *dev)
+{
+	const struct mcux_stm_config *config = dev->config;
+
+	STM_StartTimer(config->base);
+
+	return 0;
+}
+
+static int mcux_stm_stop(const struct device *dev)
+{
+	const struct mcux_stm_config *config = dev->config;
+
+	STM_StopTimer(config->base);
+
+	return 0;
+}
+
+static int mcux_stm_get_value(const struct device *dev, uint32_t *ticks)
+{
+	const struct mcux_stm_config *config = dev->config;
+
+	*ticks = STM_GetTimerCount(config->base);
+
+	return 0;
+}
+
+static uint32_t mcux_stm_get_top_value(const struct device *dev)
+{
+	const struct mcux_stm_config *config = dev->config;
+
+	return config->info.max_top_value;
+}
+
+static int mcux_stm_set_top_value(const struct device *dev, const struct counter_top_cfg *cfg)
+{
+	const struct mcux_stm_config *config = dev->config;
+
+	if (cfg->ticks != config->info.max_top_value) {
+		return -ENOTSUP;
+	} else {
+		return 0;
+	}
+}
+
+static int mcux_stm_set_alarm(const struct device *dev, uint8_t chan_id,
+			      const struct counter_alarm_cfg *alarm_cfg)
+{
+	const struct mcux_stm_config *config = dev->config;
+	struct mcux_stm_data *data = dev->data;
+	uint32_t current = STM_GetTimerCount(config->base);
+	uint32_t top_value = mcux_stm_get_top_value(dev);
+	uint32_t ticks = alarm_cfg->ticks;
+
+	if (chan_id >= config->info.channels) {
+		LOG_ERR("Invalid channel id");
+		return -EINVAL;
+	}
+
+	if (data->channels[chan_id].alarm_callback != NULL) {
+		LOG_ERR("channel already in use");
+		return -EBUSY;
+	}
+
+	if (ticks > top_value) {
+		return -EINVAL;
+	}
+
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
+		if (top_value - current >= ticks) {
+			ticks += current;
+		} else {
+			ticks -= top_value - current;
+		}
+	}
+
+	data->channels[chan_id].alarm_callback = alarm_cfg->callback;
+	data->channels[chan_id].alarm_user_data = alarm_cfg->user_data;
+
+	STM_SetCompare(config->base, (stm_channel_t)chan_id, ticks);
+
+	return 0;
+}
+
+static int mcux_stm_cancel_alarm(const struct device *dev, uint8_t chan_id)
+{
+	const struct mcux_stm_config *config = dev->config;
+	struct mcux_stm_data *data = dev->data;
+
+	if (chan_id >= config->info.channels) {
+		LOG_ERR("Invalid channel id");
+		return -EINVAL;
+	}
+
+	STM_DisableCompareChannel(config->base, (stm_channel_t)chan_id);
+
+	data->channels[chan_id].alarm_callback = NULL;
+	data->channels[chan_id].alarm_user_data = NULL;
+
+	return 0;
+}
+
+void mcux_stm_isr(const struct device *dev)
+{
+	const struct mcux_stm_config *config = dev->config;
+	struct mcux_stm_data *data = dev->data;
+	uint32_t current = STM_GetTimerCount(config->base);
+	uint32_t status;
+
+	/* Check the status flags for each channel */
+	for (int chan_id = 0; chan_id < config->info.channels; chan_id++) {
+		status = STM_GetStatusFlags(config->base, (stm_channel_t)chan_id);
+
+		if ((status & STM_CIR_CIF_MASK) != 0) {
+			STM_ClearStatusFlags(config->base, (stm_channel_t)chan_id);
+		} else {
+			continue;
+		}
+
+		if (data->channels[chan_id].alarm_callback != NULL) {
+
+			counter_alarm_callback_t alarm_callback =
+				data->channels[chan_id].alarm_callback;
+			void *alarm_user_data = data->channels[chan_id].alarm_user_data;
+
+			STM_DisableCompareChannel(config->base, (stm_channel_t)chan_id);
+			data->channels[chan_id].alarm_callback = NULL;
+			data->channels[chan_id].alarm_user_data = NULL;
+
+			alarm_callback(dev, chan_id, current, alarm_user_data);
+		}
+	}
+}
+
+static uint32_t mcux_stm_get_pending_int(const struct device *dev)
+{
+	const struct mcux_stm_config *config = dev->config;
+	uint32_t pending = 0;
+
+	for (int i = 0; i < config->info.channels; i++) {
+		pending |= STM_GetStatusFlags(config->base, (stm_channel_t)i);
+	}
+
+	return pending != 0 ? 1 : 0;
+}
+
+static uint32_t mcux_stm_get_freq(const struct device *dev)
+{
+	struct mcux_stm_data *data = dev->data;
+
+	return data->freq;
+}
+
+static int mcux_stm_init(const struct device *dev)
+{
+	const struct mcux_stm_config *config = dev->config;
+	struct mcux_stm_data *data = dev->data;
+	stm_config_t stmConfig;
+	uint32_t clock_freq;
+
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
+	for (uint8_t chan = 0; chan < config->info.channels; chan++) {
+		data->channels[chan].alarm_callback = NULL;
+		data->channels[chan].alarm_user_data = NULL;
+	}
+
+	if (clock_control_get_rate(config->clock_dev, config->clock_subsys, &clock_freq)) {
+		LOG_ERR("Could not get clock frequency");
+		return -EINVAL;
+	}
+
+	data->freq = clock_freq / (config->prescale + 1);
+
+	STM_GetDefaultConfig(&stmConfig);
+	stmConfig.prescale = config->prescale;
+	STM_Init(config->base, &stmConfig);
+
+	config->irq_config_func(dev);
+
+	return 0;
+}
+
+static DEVICE_API(counter, mcux_stm_driver_api) = {
+	.start = mcux_stm_start,
+	.stop = mcux_stm_stop,
+	.get_value = mcux_stm_get_value,
+	.set_alarm = mcux_stm_set_alarm,
+	.cancel_alarm = mcux_stm_cancel_alarm,
+	.set_top_value = mcux_stm_set_top_value,
+	.get_pending_int = mcux_stm_get_pending_int,
+	.get_top_value = mcux_stm_get_top_value,
+	.get_freq = mcux_stm_get_freq,
+};
+
+#define COUNTER_MCUX_STM_DEVICE_INIT(n)     \
+	static struct mcux_stm_data mcux_stm_data_##n;      \
+	static void mcux_stm_irq_config_##n(const struct device *dev);      \
+                                                \
+	static const struct mcux_stm_config mcux_stm_config_##n = {     \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),     \
+		.clock_subsys =	(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),   \
+		.info = {	\
+			.max_top_value = UINT32_MAX,	\
+			.channels = STM_CHANNEL_COUNT,	\
+			.flags = COUNTER_CONFIG_INFO_COUNT_UP,	\
+		},	\
+		.base = (STM_Type *)DT_INST_REG_ADDR(n),	\
+		.prescale = DT_INST_PROP(n, prescaler),	\
+		.irq_config_func = mcux_stm_irq_config_##n,	\
+	};                                                                          \
+                                                                                \
+	DEVICE_DT_INST_DEFINE(n, mcux_stm_init, NULL, &mcux_stm_data_##n,	\
+						&mcux_stm_config_##n, POST_KERNEL,	\
+						CONFIG_COUNTER_INIT_PRIORITY,   \
+						&mcux_stm_driver_api);	\
+												\
+	static void mcux_stm_irq_config_##n(const struct device *dev)	\
+	{	\
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), mcux_stm_isr,	\
+					DEVICE_DT_INST_GET(n), 0);		\
+		irq_enable(DT_INST_IRQN(n));		\
+	}
+
+DT_INST_FOREACH_STATUS_OKAY(COUNTER_MCUX_STM_DEVICE_INIT)

--- a/dts/arm/nxp/nxp_mcxe31x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxe31x_common.dtsi
@@ -972,6 +972,7 @@
 		compatible = "nxp,stm";
 		reg = <0x274000 0x68>;
 		interrupts = <39 0>;
+		clocks = <&mc_cgm MCUX_STM0_CLK>;
 		status = "disabled";
 	};
 
@@ -979,6 +980,7 @@
 		compatible = "nxp,stm";
 		reg = <0x474000 0x68>;
 		interrupts = <40 0>;
+		clocks = <&mc_cgm MCUX_STM1_CLK>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/clock/nxp,mc-cgm.yaml
+++ b/dts/bindings/clock/nxp,mc-cgm.yaml
@@ -57,6 +57,14 @@ properties:
     type: int
     description: MUX_0_DC_6 divider setting
 
+  mux-1-dc-0-div:
+    type: int
+    description: MUX_1_DC_0 divider setting
+
+  mux-2-dc-0-div:
+    type: int
+    description: MUX_2_DC_0 divider setting
+
   "#clock-cells":
     type: int
     const: 1

--- a/dts/bindings/counter/nxp,stm.yaml
+++ b/dts/bindings/counter/nxp,stm.yaml
@@ -1,0 +1,29 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP System Timer Module (STM)
+
+compatible: "nxp,stm"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  clocks:
+    required: true
+
+  interrupts:
+    required: true
+
+  prescaler:
+    type: int
+    default: 0
+    required: true
+    description: |
+      Selects the module clock divide value for the prescaler (1–256).
+      00h - Divide module clock by 1
+      01h - Divide module clock by 2
+      ...
+      FFh - Divide module clock by 256

--- a/include/zephyr/dt-bindings/clock/nxp_mc_cgm.h
+++ b/include/zephyr/dt-bindings/clock/nxp_mc_cgm.h
@@ -18,6 +18,8 @@
 #define NXP_PLL_MUX_0_DC_4_DIV DT_PROP(DT_NODELABEL(mc_cgm), mux_0_dc_4_div)
 #define NXP_PLL_MUX_0_DC_5_DIV DT_PROP(DT_NODELABEL(mc_cgm), mux_0_dc_5_div)
 #define NXP_PLL_MUX_0_DC_6_DIV DT_PROP(DT_NODELABEL(mc_cgm), mux_0_dc_6_div)
+#define NXP_PLL_MUX_1_DC_0_DIV DT_PROP(DT_NODELABEL(mc_cgm), mux_1_dc_0_div)
+#define NXP_PLL_MUX_2_DC_0_DIV DT_PROP(DT_NODELABEL(mc_cgm), mux_2_dc_0_div)
 
 /* Note- clock identifiers in this file must be unique,
  * as the driver uses them in a switch case

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -52,6 +52,7 @@ set_variable_ifdef(CONFIG_CAN_MCUX_FLEXCAN      CONFIG_MCUX_COMPONENT_driver.fle
 set_variable_ifdef(CONFIG_CAN_MCUX_FLEXCAN_FD   CONFIG_MCUX_COMPONENT_driver.flexcan)
 set_variable_ifdef(CONFIG_COUNTER_NXP_PIT       CONFIG_MCUX_COMPONENT_driver.pit)
 set_variable_ifdef(CONFIG_COUNTER_MCUX_FTM      CONFIG_MCUX_COMPONENT_driver.ftm)
+set_variable_ifdef(CONFIG_COUNTER_MCUX_STM      CONFIG_MCUX_COMPONENT_driver.stm)
 set_variable_ifdef(CONFIG_COUNTER_MCUX_RTC      CONFIG_MCUX_COMPONENT_driver.rtc)
 set_variable_ifdef(CONFIG_DAC_MCUX_DAC          CONFIG_MCUX_COMPONENT_driver.dac)
 set_variable_ifdef(CONFIG_DAC_MCUX_DAC12        CONFIG_MCUX_COMPONENT_driver.dac12)

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -132,6 +132,9 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_MCUX_FTM
 	DEVS_FOR_DT_COMPAT(nxp_ftm)
 #endif
+#ifdef CONFIG_COUNTER_MCUX_STM
+	DEVS_FOR_DT_COMPAT(nxp_stm)
+#endif
 #ifdef CONFIG_COUNTER_RENESAS_RZ_GTM
 	DEVS_FOR_DT_COMPAT(renesas_rz_gtm_counter)
 #endif


### PR DESCRIPTION
  1. Add nxp,stm.yaml dts bindings
  2. Provide counter driver based on FTM driver from mcux-sdk-ng.
  3. Update mcxe31b STM clock configuration
  4. Enable STM counter basic api test