### PR TITLE
Enable i2s for imx943

### DIFF
--- a/boards/nxp/imx943_evk/Kconfig.defconfig
+++ b/boards/nxp/imx943_evk/Kconfig.defconfig
@@ -81,3 +81,13 @@ config NET_GPTP_MONITOR_SYNC_STATUS
 	default y
 
 endif # NET_GPTP
+
+if I2S_MCUX_SAI
+
+config I2C_TCA954X_CHANNEL_INIT_PRIO
+	default 51
+
+config I2S_HAS_PLL_SETTING
+	default n
+
+endif # I2S_MCUX_SAI

--- a/boards/nxp/imx943_evk/imx943_evk-pinctrl.dtsi
+++ b/boards/nxp/imx943_evk/imx943_evk-pinctrl.dtsi
@@ -121,6 +121,17 @@
 		};
 	};
 
+	lpi2c3_default: lpi2c3_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_io16_lpi2c_sda_lpi2c3_sda>,
+				 <&iomuxc_gpio_io17_lpi2c_scl_lpi2c3_scl>;
+			drive-open-drain;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+			input-enable;
+		};
+	};
+
 	lpi2c6_default: lpi2c6_default {
 		group0 {
 			pinmux = <&iomuxc_gpio_io28_lpi2c_scl_lpi2c6_scl>,
@@ -176,6 +187,19 @@
 		group0 {
 			pinmux = <&iomuxc_gpio_io27_lpuart_rx_lpuart12_rx>,
 				 <&iomuxc_gpio_io26_lpuart_tx_lpuart12_tx>;
+			bias-pull-up;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+		};
+	};
+
+	sai1_default: sai1_default {
+		group0 {
+			pinmux = <&iomuxc_sai1_txc_sai_tx_bclk_sai1_tx_bclk>,
+				 <&iomuxc_i2c2_sda_sai_mclk_sai1_mclk>,
+				 <&iomuxc_sai1_rxd0_sai_rx_data_sai1_rx_data0>,
+				 <&iomuxc_sai1_txd0_sai_tx_data_sai1_tx_data0>,
+				 <&iomuxc_sai1_txfs_sai_tx_sync_sai1_tx_sync>;
 			bias-pull-up;
 			slew-rate = "slightly_fast";
 			drive-strength = "x4";

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_cm.dtsi
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_cm.dtsi
@@ -63,3 +63,129 @@
 	phy-connection-type = "rgmii";
 	status = "disabled";
 };
+
+&lpi2c3 {
+	pinctrl-0 = <&lpi2c3_default>;
+	pinctrl-names = "default";
+	status = "disabled";
+
+	mux_pca9548a: pca9548a@77 {
+		compatible = "ti,tca9548a";
+		reg = <0x77>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+
+		mux_i2c@0 {
+			compatible = "ti,tca9548a-channel";
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		mux_i2c@1 {
+			compatible = "ti,tca9548a-channel";
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		mux_i2c@2 {
+			compatible = "ti,tca9548a-channel";
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		mux_i2c@3 {
+			compatible = "ti,tca9548a-channel";
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		mux_i2c@4 {
+			compatible = "ti,tca9548a-channel";
+			reg = <4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			audio_codec: wm8962@1a {
+				compatible = "wolfson,wm8962";
+				reg = <0x1a>;
+				clock-source = "MCLK";
+				clocks = <&scmi_clk IMX943_CLK_SAI1>;
+				clock-names = "mclk";
+				status = "disabled";
+			};
+		};
+
+		mux_i2c@5 {
+			compatible = "ti,tca9548a-channel";
+			reg = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		mux_i2c@6 {
+			compatible = "ti,tca9548a-channel";
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		mux_i2c@7 {
+			compatible = "ti,tca9548a-channel";
+			reg = <7>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
+&lpi2c6 {
+	pinctrl-0 = <&lpi2c6_default>;
+	pinctrl-names = "default";
+	status = "disabled";
+
+	mux_pca9544a: pca9544a@77 {
+		compatible = "ti,tca9544a";
+		reg = <0x77>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+
+		mux_i2c@0 {
+			compatible = "ti,tca9544a-channel";
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		mux_i2c@1 {
+			compatible = "ti,tca9544a-channel";
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		mux_i2c@2 {
+			compatible = "ti,tca9544a-channel";
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		mux_i2c@3 {
+			compatible = "ti,tca9544a-channel";
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
+&i2s1 {
+	pinctrl-0 = <&sai1_default>;
+	pinctrl-names = "default";
+};

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.dts
@@ -21,6 +21,11 @@
 		zephyr,console = &lpuart8;
 		zephyr,shell-uart = &lpuart8;
 	};
+
+	aliases {
+		i2s-codec-tx = &i2s1;
+		i2s-tx = &i2s1;
+	};
 };
 
 &flexio1 {
@@ -95,5 +100,14 @@
 };
 
 &edma4 {
+	status = "okay";
+};
+
+&i2s1 {
+	mclk-output;
+	status = "okay";
+};
+
+&edma1 {
 	status = "okay";
 };

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.yaml
@@ -19,4 +19,5 @@ supported:
   - gpio
   - pwm
   - i2c
+  - i2s
 vendor: nxp

--- a/dts/arm/nxp/imx/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx94x.dtsi
@@ -423,19 +423,63 @@
 			status = "disabled";
 		};
 
-		flexio3: flexio@4d100000 {
-			compatible = "nxp,flexio";
-			reg = <0x4d100000 DT_SIZE_K(4)>;
-			interrupts = <50 0>;
-			clocks = <&scmi_clk IMX943_CLK_FLEXIO3>;
+		i2s2: i2s@4265000 {
+			compatible = "nxp,mcux-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x42650000 DT_SIZE_K(64)>;
+			clocks = <&scmi_clk IMX943_CLK_SAI2>;
+			interrupts = <101 0>;
+			nxp,tx-channel = <1>;
 			status = "disabled";
 		};
 
-		flexio4: flexio@4d110000 {
-			compatible = "nxp,flexio";
-			reg = <0x4d110000 DT_SIZE_K(4)>;
-			interrupts = <51 0>;
-			clocks = <&scmi_clk IMX943_CLK_FLEXIO4>;
+		i2s3: i2s@4266000 {
+			compatible = "nxp,mcux-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x42660000 DT_SIZE_K(64)>;
+			clocks = <&scmi_clk IMX943_CLK_SAI3>;
+			interrupts = <102 0>;
+			nxp,tx-channel = <1>;
+			status = "disabled";
+		};
+
+		i2s4: i2s@4267000 {
+			compatible = "nxp,mcux-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x42670000 DT_SIZE_K(64)>;
+			clocks = <&scmi_clk IMX943_CLK_SAI4>;
+			interrupts = <103 0>;
+			nxp,tx-channel = <1>;
+			status = "disabled";
+		};
+
+		edma1: dma@44000000 {
+			compatible = "nxp,mcux-edma";
+			reg = <0x44000000 0x210000>;
+			interrupts = <230 0>, <231 0>,
+				     <232 0>, <233 0>,
+				     <234 0>, <235 0>,
+				     <236 0>, <237 0>,
+				     <238 0>, <239 0>,
+				     <240 0>, <241 0>,
+				     <242 0>, <243 0>,
+				     <244 0>, <245 0>,
+				     <246 0>, <247 0>,
+				     <248 0>, <249 0>,
+				     <250 0>, <251 0>,
+				     <252 0>, <253 0>,
+				     <254 0>, <255 0>,
+				     <256 0>, <257 0>,
+				     <258 0>, <259 0>,
+				     <260 0>, <261 0>;
+			#dma-cells = <2>;
+			nxp,version = <4>;
+			dma-channels = <32>;
+			dma-requests = <32>;
+			no-error-irq;
 			status = "disabled";
 		};
 
@@ -537,6 +581,21 @@
 			reg = <0x44390000 DT_SIZE_K(64)>;
 			interrupts = <22 3>;
 			clocks = <&scmi_clk IMX943_CLK_LPUART2>;
+			status = "disabled";
+		};
+
+		i2s1: i2s@443b0000 {
+			compatible = "nxp,mcux-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x443b0000 DT_SIZE_K(64)>;
+			clocks = <&scmi_clk IMX943_CLK_SAI1>;
+			interrupts = <38 0>;
+			nxp,tx-channel = <1>;
+			dmas = <&edma1 24 24>, <&edma1 25 25>;
+			dma-names = "tx", "rx";
+			nxp,tx-dma-channel = <24>;
+			nxp,rx-dma-channel = <25>;
 			status = "disabled";
 		};
 
@@ -722,6 +781,22 @@
 					status = "disabled";
 				};
 			};
+		};
+
+		flexio3: flexio@4d100000 {
+			compatible = "nxp,flexio";
+			reg = <0x4d100000 DT_SIZE_K(4)>;
+			interrupts = <50 0>;
+			clocks = <&scmi_clk IMX943_CLK_FLEXIO3>;
+			status = "disabled";
+		};
+
+		flexio4: flexio@4d110000 {
+			compatible = "nxp,flexio";
+			reg = <0x4d110000 DT_SIZE_K(4)>;
+			interrupts = <51 0>;
+			clocks = <&scmi_clk IMX943_CLK_FLEXIO4>;
+			status = "disabled";
 		};
 
 		mu_m33s_secure_m71_for_m71: mbox@4d120000 {


### PR DESCRIPTION
Enable i2s for imx943
- sample: i2s_output
- build command: west build -p -b imx943_evk/mimx94398/m33 samples/drivers/i2s/output -d ./build_i2s_output_imx943_evk_m33