### PR TITLE
boards: nuvoton: numaker_pfm_m467: Guide VS Code pack

### DIFF
--- a/boards/nuvoton/numaker_pfm_m467/doc/index.rst
+++ b/boards/nuvoton/numaker_pfm_m467/doc/index.rst
@@ -69,6 +69,17 @@ Here is an example for the :zephyr:code-sample:`hello_world` application.
 
 Step through the application in your debugger.
 
+VS Code Support
+===============
+
+Here is to go through VS Code instead of command line.
+
+Please install Nuvoton NuMicro Cortex-M Pack and follow getting start guide of this pack.
+This pack is a complete development toolkit for Nuvoton’s NuMicro Cortex-M microcontrollers
+in Visual Studio Code.
+URL of this pack is
+https://marketplace.visualstudio.com/items?itemName=Nuvoton.nuvoton-numicro-cortex-m-pack
+
 References
 **********
 


### PR DESCRIPTION
This PR is to modify index.rst to guide IDE support through Nuvoton NuMicro Cortex-M Pack of Visual Studio Code.