### PR TITLE
ci: assigner: checkout merged west manifest

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -42,7 +42,7 @@ jobs:
       if: >
         github.event_name == 'pull_request_target'
       run: |
-        git fetch origin pull/${{ github.event.pull_request.number }}/head
+        git fetch origin pull/${{ github.event.pull_request.number }}/merge
         git show FETCH_HEAD:west.yml > pr_west.yml
 
     - name: west setup


### PR DESCRIPTION
When a pull request is based off an old commit in the base branch (usually
`main`), the manifest file from the `pull/NUMBER/head` ref may contain
out-of-date changes, and running diff between it and the manifest file
from the latest base branch may return more changes than what is actually
made in the pull request.

This commit updates the workflow to check out the manifest file from the
`pull/NUMBER/merge` ref, which is a temporary ref created by GitHub with
the pull request commits merged into the base branch.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
