### PR TITLE
modules: hal_silabs: wiseconnect: Import firmware upgrade support files

### DIFF
--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -194,6 +194,9 @@ if(CONFIG_WISECONNECT_NETWORK_STACK)
     ${WISECONNECT_DIR}/components/sli_si91x_wifi_event_handler/src/sli_si91x_wifi_event_handler.c
     ${WISECONNECT_DIR}/components/sli_wifi_command_engine/src/sli_wifi_command_engine.c
   )
+  zephyr_library_sources_ifdef(CONFIG_SIWX91X_FIRMWARE_UPGRADE
+    ${WISECONNECT_DIR}/components/device/silabs/si91x/wireless/firmware_upgrade/firmware_upgradation.c
+  )
 endif() # CONFIG_WISECONNECT_NETWORK_STACK
 
 if(CONFIG_SOC_SILABS_SLEEPTIMER)

--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -48,6 +48,7 @@ zephyr_include_directories(
   ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/cmsis_driver/config
   ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/cmsis_driver
   ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/cmsis_driver/CMSIS/Driver/Include
+  ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/hal/inc
   ${WISECONNECT_DIR}/components/device/silabs/si91x/wireless/ahb_interface/inc
   ${WISECONNECT_DIR}/components/device/silabs/si91x/wireless/firmware_upgrade
 )
@@ -73,6 +74,7 @@ zephyr_library_sources(
   ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_driver_gpio.c
   ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_pwm.c
   ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/unified_peripheral_drivers/src/sl_si91x_peripheral_gpio.c
+  ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/hal/src/sl_si91x_hal_soc_soft_reset.c
   ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/core/chip/src/iPMU_prog/iPMU_dotc/ipmu_apis.c
   ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/core/chip/src/iPMU_prog/iPMU_dotc/rsi_system_config_917.c
 )

--- a/soc/silabs/silabs_siwx91x/Kconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig
@@ -62,4 +62,22 @@ config SIWX91X_ENCRYPT
 	  The key used is the value of CONFIG_SIWX91X_MIC_KEY. This value is
 	  passed as-is to the command "commander rps convert".
 
+config SIWX91X_FIRMWARE_UPGRADE
+	bool "Support for firmware upgrade"
+	select WISECONNECT_NETWORK_STACK
+	help
+	  The firmware upgrade process for SiWx91x devices involves coordinated
+	  communication with both the Network Co-Processor (NCP) and the ROM
+	  bootloader. The NCP is responsible for writing the firmware image to
+	  flash memory, while the ROM bootloader handles the A/B upgrade logic
+	  to ensure reliable firmware switching.
+	  This option provides the necessary APIs to perform these upgrade tasks
+	  and is agnostic to the underlying transport protocol. It does not handle
+	  firmware retrieval directly; instead, the application layer is responsible
+	  for acquiring the firmware image (e.g., via an HTTP client or other means)
+	  and invoking the appropriate APIs to initiate and complete the upgrade
+	  process.
+	  For more information, visit:
+	  https://docs.silabs.com/wiseconnect/latest/wiseconnect-api-reference-guide-si91x-driver/si91-x-firmware-update-from-host-functions#sl-si91x-fwup-load
+
 endif # SOC_FAMILY_SILABS_SIWX91X

--- a/soc/silabs/silabs_siwx91x/siwg917/soc.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/soc.c
@@ -12,6 +12,7 @@
 #include "em_device.h"
 #include "sli_siwx917_soc.h"
 #include "sl_si91x_power_manager.h"
+#include "sl_si91x_hal_soc_soft_reset.h"
 
 void soc_early_init_hook(void)
 {
@@ -31,6 +32,13 @@ void soc_early_init_hook(void)
 		sl_si91x_power_manager_add_ps_requirement(SL_SI91X_POWER_MANAGER_PS4);
 		sl_si91x_power_manager_set_clock_scaling(SL_SI91X_POWER_MANAGER_PERFORMANCE);
 	}
+}
+
+void sys_arch_reboot(int type)
+{
+	ARG_UNUSED(type);
+
+	sl_si91x_soc_nvic_reset();
 }
 
 /* SiWx917's bootloader requires IRQn 32 to hold payload's entry point address. */

--- a/west.yml
+++ b/west.yml
@@ -240,7 +240,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: ae1afd84a2acb0cdca2b691047d81a61ce3f9356
+      revision: 764d9153c69178bc851625d5a6a15fde237e626a
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Imported firmware upgrade files from the SDK driver. Adding firmware upgrade source files to demonstrate OTA functionality in Zephyr