### PR TITLE
drivers: Fix some Kconfig bleeds

### DIFF
--- a/drivers/adc/Kconfig.ad405x
+++ b/drivers/adc/Kconfig.ad405x
@@ -13,6 +13,6 @@ config ADC_AD405X
 
 config AD405X_TRIGGER
 	bool "AD405X interrupts"
-	default n
+	depends on ADC_AD405X
 	help
 	  Enable interrupts for ADI AD405X.

--- a/drivers/cache/Kconfig.nrf
+++ b/drivers/cache/Kconfig.nrf
@@ -11,5 +11,6 @@ config CACHE_NRF_CACHE
 config CACHE_NRF_PATCH_LINEADDR
 	bool "Patch lineaddr"
 	default y if SOC_NRF54H20
+	depends on DCACHE
 	help
 	  Manually set 28th bit in the LINEADDR in Trustzone Secure build.

--- a/drivers/cache/Kconfig.stm32
+++ b/drivers/cache/Kconfig.stm32
@@ -4,6 +4,7 @@
 menuconfig CACHE_STM32
 	bool "STM32 cache driver"
 	select CACHE_HAS_DRIVER
+	depends on SOC_FAMILY_STM32
 	depends on CACHE_MANAGEMENT
 	help
 	  Enable support for the STM32 ICACHE / DCACHE peripheral present in some STM32 chips.

--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -7,10 +7,10 @@ config NRF_RTC_TIMER
 	bool "nRF Real Time Counter (NRF_RTC1) Timer"
 	depends on CLOCK_CONTROL
 	depends on SOC_COMPATIBLE_NRF
+	depends on !DT_HAS_NORDIC_NRF_RTC_ENABLED && !DT_HAS_NORDIC_NRF_GRTC_ENABLED
 	select TICKLESS_CAPABLE
 	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
 	select NRFX_PPI if SOC_NRF52832
-	depends on !$(dt_nodelabel_enabled,rtc1)
 	help
 	  This module implements a kernel device driver for the nRF Real Time
 	  Counter NRF_RTC1 and provides the standard "system clock driver"


### PR DESCRIPTION
Fixes instances of Kconfig options appearing for completely irrelevant builds