### PR TITLE
modules: hal_infineon: updated CMakeLists.txt for whd-expansion

### DIFF
--- a/drivers/wifi/infineon/Kconfig.airoc
+++ b/drivers/wifi/infineon/Kconfig.airoc
@@ -254,6 +254,11 @@ config CYW955573M2IPA1_SM
 	bool "CYW955573M2IPA1_SM"
 	help
 	  Infineon CYW955573M2IPA1 (SM) module
+
+config CYW55513IUBG_SM
+	bool "CYW55513IUBG_SM"
+	help
+	  Infineon CYW55513IUBG (SM) module
 endchoice
 
 endif # AIROC_WIFI

--- a/modules/hal_infineon/CMakeLists.txt
+++ b/modules/hal_infineon/CMakeLists.txt
@@ -71,8 +71,8 @@ if(CONFIG_SOC_FAMILY_INFINEON_EDGE)
 endif()
 
 ## Add Wi-Fi assets for AIROC devices
-if(CONFIG_WIFI_AIROC)
-  add_subdirectory(wifi-host-driver)
+if (CONFIG_WIFI_AIROC)
+  add_subdirectory(whd-expansion)
 
   ## Add core-lib sources for CAT1 devices
   add_subdirectory_ifndef(CONFIG_SOC_FAMILY_INFINEON_CAT1 core-lib)

--- a/modules/hal_infineon/whd-expansion/CMakeLists.txt
+++ b/modules/hal_infineon/whd-expansion/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright (c) 2023 Cypress Semiconductor Corporation.
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,8 +10,8 @@ else()
 endif()
 
 set(hal_dir                  ${ZEPHYR_HAL_INFINEON_MODULE_DIR})
-set(hal_wifi_dir             ${hal_dir}/wifi-host-driver)
-set(hal_wifi_dir_resources   ${hal_dir}/wifi-host-driver/WHD/${whd_wifi_ver}/resources)
+set(hal_wifi_dir             ${hal_dir}/whd-expansion)
+set(hal_wifi_dir_resources   ${hal_dir}/whd-expansion/WHD/${whd_wifi_ver}/resources)
 
 set(hal_blobs_dir            ${hal_dir}/zephyr/blobs/img/whd/resources)
 set(blob_gen_dir             ${ZEPHYR_BINARY_DIR}/include/generated)
@@ -31,38 +32,46 @@ if(CONFIG_WHD_DISABLE_SDIO_PULLUP_DURING_SPI_SLEEP)
   zephyr_compile_definitions(WHD_DISABLE_SDIO_PULLUP_DURING_SPI_SLEEP)
 endif()
 
+zephyr_compile_definitions(WHD_ZEPHYR)
+
 # Add WHD includes
 zephyr_include_directories(${hal_wifi_dir})
 zephyr_include_directories(${hal_wifi_dir}/WHD/${whd_wifi_ver}/inc)
 zephyr_include_directories(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src)
 zephyr_include_directories(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/include)
+zephyr_include_directories(${hal_wifi_dir}/WHD/${whd_wifi_ver}/resources)
 zephyr_include_directories(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols)
 zephyr_include_directories(${hal_wifi_dir}/WHD/${whd_wifi_ver}/resources/resource_imp)
+
+# common/inc
+zephyr_include_directories(${hal_wifi_dir}/WHD/COMMON/inc)
+
+# common/src
+zephyr_library_sources(${hal_wifi_dir}/WHD/COMMON/src/whd_bus_common.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/COMMON/src/whd_cdc_bdc.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/COMMON/src/whd_clm.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/COMMON/src/whd_sdpcm.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/COMMON/src/whd_utils.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/COMMON/src/whd_wifi.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/COMMON/src/whd_logging.c)
+zephyr_library_sources(${hal_wifi_dir}/WHD/COMMON/src/whd_debug.c)
 
 # src
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_ap.c)
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_buffer_api.c)
-zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_cdc_bdc.c)
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_chip.c)
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_chip_constants.c)
-zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_clm.c)
-zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_debug.c)
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_events.c)
-zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_logging.c)
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_management.c)
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_network_if.c)
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_proto.c)
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_resource_if.c)
-zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_sdpcm.c)
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_thread.c)
-zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_utils.c)
-zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_wifi.c)
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_wifi_api.c)
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_wifi_p2p.c)
 
 # src/bus_protocols
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus.c)
-zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus_common.c)
 zephyr_library_sources_ifdef(CONFIG_AIROC_WIFI_BUS_SDIO  ${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus_sdio_protocol.c)
 zephyr_library_sources_ifdef(CONFIG_AIROC_WIFI_BUS_SPI  ${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus_spi_protocol.c)
 
@@ -82,64 +91,55 @@ endif()
 
 # CYW43012 firmware
 if(CONFIG_CYW43012 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  # firmware
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43012/43012C0-mfgtest_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_43012/43012C0-mfgtest.bin)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43012/43012C0_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_43012/43012C0.bin)
   endif()
 endif()
 
 # CYW43022 firmware
 if(CONFIG_CYW43022 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  # firmware
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43022/COMPONENT_SM/43022C1-mfgtest_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_43022/COMPONENT_SM/43022C1-mfgtest.trxs)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43022/COMPONENT_SM/43022C1_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_43022/COMPONENT_SM/43022C1.trxs)
   endif()
 endif()
 
 # CYW4343W firmware
 if(CONFIG_CYW4343W AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  # firmware
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_4343W/4343WA1-mfgtest_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_4343W/4343WA1-mfgtest.bin)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_4343W/4343WA1_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_4343W/4343WA1.bin)
   endif()
 endif()
 
-# CYW43438 firmware/clm
+# CYW43438 firmware
 if(CONFIG_CYW43438 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  # firmware/clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43438/43438A1-mfgtest_bin.c)
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43438/43438A1-mfgtest_clm_blob.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_43438/43438A1-mfgtest.bin)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43438/43438A1_bin.c)
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43438/43438A1_clm_blob.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_43438/43438A1.bin)
   endif()
-
 endif()
 
 # CYW43439 firmware
 if(CONFIG_CYW43439 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  # firmware
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43439/43439A0-mfgtest_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_43439/43439A0-mfgtest.bin)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_43439/43439a0_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_43439/43439A0.bin)
   endif()
 endif()
 
 # CYW4373 firmware
 if(CONFIG_CYW4373 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  # firmware
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_4373/4373A0-mfgtest_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_4373/4373A0-mfgtest.bin)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_4373/4373A0_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_4373/4373A0.bin)
   endif()
 endif()
 
@@ -147,104 +147,96 @@ endif()
 if(CONFIG_CYW43012_MURATA_1LV AND NOT CONFIG_AIROC_WIFI_CUSTOM)
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43012/43012C0-mfgtest_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_43012/COMPONENT_MURATA-1LV/43012C0-mfgtest.clm_blob)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43012/43012C0_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_43012/COMPONENT_MURATA-1LV/43012C0.clm_blob)
   endif()
-
   # nvram
-  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_43012/COMPONENT_MURATA-1LV)
+  set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_43012/COMPONENT_MURATA-1LV/cyw9cy8ckit_062S2_43012.txt)
 endif()
 
 # CYW43022CUB clm/nvram
 if(CONFIG_CYW43022CUB AND NOT CONFIG_AIROC_WIFI_CUSTOM)
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43022/43022C1-mfgtest_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_43022/COMPONENT_CYW43022CUB/43022C1-mfgtest.clm_blob)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43022/43022C1_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_43022/COMPONENT_CYW43022CUB/43022C1.clm_blob)
   endif()
-
   # nvram
-  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_43022/COMPONENT_CYW43022CUB)
+  set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_43022/COMPONENT_CYW43022CUB/cyw943022sdm2wlipa_rev3.1.txt)
 endif()
 
 # CYW4343W_MURATA_1DX clm/nvram
 if(CONFIG_CYW4343W_MURATA_1DX AND NOT CONFIG_AIROC_WIFI_CUSTOM)
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4343W/4343WA1-mfgtest_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_4343W/COMPONENT_MURATA-1DX/4343WA1-mfgtest.clm_blob)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4343W/4343WA1_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_4343W/COMPONENT_MURATA-1DX/4343WA1.clm_blob)
   endif()
-
   # nvram
-  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_4343W/COMPONENT_MURATA-1DX)
+  set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_4343W/COMPONENT_MURATA-1DX/cyw94343cy8cmod.txt)
 endif()
 
-# CYW43439_MURATA_1YN
+# CYW43439_MURATA_1YN clm/nvram
 if(CONFIG_CYW43439_MURATA_1YN AND NOT CONFIG_AIROC_WIFI_CUSTOM)
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43439/43439A0-mfgtest_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_43439/COMPONENT_MURATA-1YN/43439A0-mfgtest.clm_blob)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43439/43439A0_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_43439/COMPONENT_MURATA-1YN/43439A0.clm_blob)
   endif()
-
   # nvram
-  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_43439/COMPONENT_MURATA-1YN)
+  set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_43439/COMPONENT_MURATA-1YN/cyfmac43439-1YN.txt)
 endif()
 
 # CYW43439_STERLING_LWBPLUS
 if(CONFIG_CYW43439_STERLING_LWBPLUS AND NOT CONFIG_AIROC_WIFI_CUSTOM)
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43439/43439A0-mfgtest_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_43439/COMPONENT_STERLING-LWBplus/43439A0-mfgtest.clm_blob)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_43439/43439A0_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_43439/COMPONENT_STERLING-LWBplus/43439A0.clm_blob)
   endif()
-
   # nvram
-  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_43439/COMPONENT_STERLING-LWBplus)
+  set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_43439/COMPONENT_STERLING-LWBplus/cyfmac43439-1YN.txt)
 endif()
 
 # CYW4373_STERLING_LWB5PLUS
 if(CONFIG_CYW4373_STERLING_LWB5PLUS AND NOT CONFIG_AIROC_WIFI_CUSTOM)
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_STERLING-LWB5plus/4373A0-mfgtest_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_STERLING-LWB5plus/4373A0-mfgtest.clm_blob)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_STERLING-LWB5plus/4373A0_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_STERLING-LWB5plus/4373A0.clm_blob)
   endif()
-
   # nvram
-  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_4373/COMPONENT_STERLING-LWB5plus)
+  set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_4373/COMPONENT_STERLING-LWB5plus/cyfmac4373-2AE.txt)
 endif()
 
 # CYW4373_MURATA-2AE
 if(CONFIG_CYW4373_MURATA_2AE AND NOT CONFIG_AIROC_WIFI_CUSTOM)
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_MURATA-2AE/4373A0-mfgtest_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_MURATA-2AE/4373A0-mfgtest.clm_blob)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_MURATA-2AE/4373A0_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_MURATA-2AE/4373A0.clm_blob)
   endif()
-
   # nvram
-  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_4373/COMPONENT_MURATA-2AE)
+  set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_4373/COMPONENT_MURATA-2AE/cyfmac4373-2AE.txt)
 endif()
 
 # CYW4373_MURATA-2BC
 if(CONFIG_CYW4373_MURATA_2BC AND NOT CONFIG_AIROC_WIFI_CUSTOM)
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_MURATA-2BC/4373A0-mfgtest_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_MURATA-2BC/4373A0-mfgtest.clm_blob)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_MURATA-2BC/4373A0_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_4373/COMPONENT_MURATA-2BC/4373A0.clm_blob)
   endif()
-
   # nvram
-  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_4373/COMPONENT_MURATA-2BC)
+  set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_4373/COMPONENT_MURATA-2BC/cyfmac4373-2BC.txt)
 endif()
 
 ############################################################################################################
@@ -258,52 +250,73 @@ endif()
 
 # CYW55500 firmware
 if(CONFIG_CYW55500 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  # firmware
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_55500/COMPONENT_SM/55500A1-mfgtest_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_55500/COMPONENT_SM/55500A1-mfgtest.trxcse)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_55500/COMPONENT_SM/55500A1_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_55500/COMPONENT_SM/55500A1.trxcse)
   endif()
 endif()
 
 # CYW55572 firmware
 if(CONFIG_CYW55572 AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-  # firmware
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_55572/COMPONENT_SM/55572A1-mfgtest_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_55572/COMPONENT_SM/55572A1-mfgtest.trxse)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/firmware/COMPONENT_55572/COMPONENT_SM/55572A1_bin.c)
+    set(FW_IMAGE_NAME ${hal_blobs_dir}/firmware/COMPONENT_55572/COMPONENT_SM/55572A1-mfgtest.trxse)
   endif()
 endif()
 
-
-# CYW955513SDM2WLIPA_SM
+# CYW955513SDM2WLIPA_SM clm, nvram
 if(CONFIG_CYW955513SDM2WLIPA_SM AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_55500/55500A1-mfgtest_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_55500/COMPONENT_CYW955513SDM2WLIPA/55500A1-mfgtest.clm_blob)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_55500/55500A1_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_55500/COMPONENT_CYW955513SDM2WLIPA/55500A1.clm_blob)
   endif()
-
   # nvram
-  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_55500/COMPONENT_CYW955513SDM2WLIPA)
+  set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_55500/COMPONENT_CYW955513SDM2WLIPA/cyw955513sdm2wlipa.txt)
+endif()
+
+# CYW55513IUBG_SM clm, nvram
+if(CONFIG_CYW55513IUBG_SM AND NOT CONFIG_AIROC_WIFI_CUSTOM)
+  # clm
+  if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_55500/COMPONENT_CYW55513IUBG/55500A1-mfgtest.clm_blob)
+  else()
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_55500/COMPONENT_CYW55513IUBG/55500A1.clm_blob)
+  endif()
+  # nvram
+  set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_55500/COMPONENT_CYW55513IUBG/cyw955513wlipa_rev103.txt)
 endif()
 
 # CYW955573M2IPA1_SM
 if(CONFIG_CYW955573M2IPA1_SM AND NOT CONFIG_AIROC_WIFI_CUSTOM)
-
   # clm
   if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_55572/55572A1-mfgtest_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_55572/COMPONENT_CYW955573M2IPA1/55572A1-mfgtest.clm_blob)
   else()
-    zephyr_library_sources(${hal_blobs_dir}/clm/COMPONENT_55572/55572A1_clm_blob.c)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_55572/COMPONENT_CYW955573M2IPA1/55572A1.clm_blob)
   endif()
 
   # nvram
-  zephyr_include_directories(${hal_wifi_dir_resources}/nvram/COMPONENT_55572/COMPONENT_CYW955573M2IPA1)
+  set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_55572/COMPONENT_CYW955573M2IPA1/cyw955573m2ipa1_rev1.01.txt)
 endif()
+
+# set fw size
+file(SIZE ${FW_IMAGE_NAME} FW_IMAGE_SIZE)
+zephyr_compile_definitions(FW_IMAGE_NAME="${FW_IMAGE_NAME}")
+zephyr_compile_definitions(FW_IMAGE_SIZE=${FW_IMAGE_SIZE})
+
+# set clm size
+file(SIZE ${CLM_IMAGE_NAME} CLM_IMAGE_SIZE)
+zephyr_compile_definitions(CLM_IMAGE_NAME="${CLM_IMAGE_NAME}")
+zephyr_compile_definitions(CLM_IMAGE_SIZE=${CLM_IMAGE_SIZE})
+
+# set nvram size
+file(SIZE ${NVRAM_IMAGE_NAME} NVRAM_IMAGE_SIZE)
+zephyr_compile_definitions(NVRAM_IMAGE_NAME="${NVRAM_IMAGE_NAME}")
+zephyr_compile_definitions(NVRAM_IMAGE_SIZE=${NVRAM_IMAGE_SIZE})
 
 # generate FW inc_blob from fw_bin
 if(EXISTS ${airoc_wifi_fw_bin})

--- a/west.yml
+++ b/west.yml
@@ -185,7 +185,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: 3ef39bda93a67cf2ef735f1679aee5a103f92275
+      revision: 58ce131beba8ad94e58837b7d0f5e31a7894790a
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
Updated the CMakeLists.txt to use bins directly instead of C files with whd-expansion.
Depends on: https://github.com/zephyrproject-rtos/hal_infineon/pull/31

Signed-off-by: Chaitanya Gaikwad ChaitanyaSandeep.Gaikwad@infineon.com