### PR TITLE
dts: arm: renesas: ra: Remove unneeded container nodes for OFS registers

### DIFF
--- a/dts/arm/renesas/ra/ra2/ra2l1.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2l1.dtsi
@@ -524,42 +524,29 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-in-rom@400 {
-			reg = <0x00000400 0x3c>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			option_setting_ofs0: option-setting-ofs0@400 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000400 0x4>;
-				status = "okay";
-			};
-
-			option_setting_ofs1: option-setting-ofs1@404 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000404 0x4>;
-				status = "okay";
-			};
-
-			option_setting_secmpu: option-setting-secmpu@408 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000408 0x34>;
-				status = "okay";
-			};
+		option_setting_ofs0: option-setting-ofs0@400 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000400 0x4>;
+			status = "okay";
 		};
 
-		option-setting-ofs-conf@1010010 {
-			reg = <0x01010010 0x24>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs1: option-setting-ofs1@404 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000404 0x4>;
 			status = "okay";
+		};
 
-			option_setting_osis: option-setting-osis@1010018 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OSIS_MEMORY";
-				reg = <0x01010018 0x1c>;
-				status = "okay";
-			};
+		option_setting_secmpu: option-setting-secmpu@408 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000408 0x34>;
+			status = "okay";
+		};
+
+		option_setting_osis: option-setting-osis@1010018 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OSIS_MEMORY";
+			reg = <0x01010018 0x1c>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra2/ra2xx.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2xx.dtsi
@@ -393,42 +393,29 @@
 			};
 		};
 
-		option-setting-ofs-in-rom@400 {
-			reg = <0x00000400 0x3c>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			option_setting_ofs0: option-setting-ofs0@400 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000400 0x4>;
-				status = "okay";
-			};
-
-			option_setting_ofs1: option-setting-ofs1@404 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000404 0x4>;
-				status = "okay";
-			};
-
-			option_setting_secmpu: option-setting-secmpu@408 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000408 0x34>;
-				status = "okay";
-			};
+		option_setting_ofs0: option-setting-ofs0@400 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000400 0x4>;
+			status = "okay";
 		};
 
-		option-setting-ofs-conf@1010008 {
-			reg = <0x01010008 0x2c>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs1: option-setting-ofs1@404 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000404 0x4>;
 			status = "okay";
+		};
 
-			option_setting_osis: option-setting-osis@1010018 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OSIS_MEMORY";
-				reg = <0x01010018 0x1c>;
-				status = "okay";
-			};
+		option_setting_secmpu: option-setting-secmpu@408 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000408 0x34>;
+			status = "okay";
+		};
+
+		option_setting_osis: option-setting-osis@1010018 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OSIS_MEMORY";
+			reg = <0x01010018 0x1c>;
+			status = "okay";
 		};
 	};
 };

--- a/dts/arm/renesas/ra/ra4/r7fa4c1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4c1bx.dtsi
@@ -535,74 +535,67 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-conf@100a100 {
-			reg = <0x0100a100 0x200>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs0: option-setting-ofs0@100a100 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS0_MEMORY";
+			reg = <0x0100a100 0x4>;
 			status = "okay";
+		};
 
-			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS0_MEMORY";
-				reg = <0x0100a100 0x4>;
-				status = "okay";
-			};
+		option_setting_dualsel: option-setting-dualsel@100a110 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_DUALSEL_MEMORY";
+			reg = <0x0100a110 0x4>;
+			status = "okay";
+		};
 
-			option_setting_dualsel: option-setting-dualsel@100a110 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_DUALSEL_MEMORY";
-				reg = <0x0100a110 0x4>;
-				status = "okay";
-			};
+		option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
+			reg = <0x0100a200 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
-				reg = <0x0100a200 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
+			reg = <0x0100a210 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
-				reg = <0x0100a210 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sec: option-setting-bps-sec@100a240 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
+			reg = <0x0100a240 0xc>;
+			status = "okay";
+		};
 
-			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
-				reg = <0x0100a240 0xc>;
-				status = "okay";
-			};
+		option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
+			reg = <0x0100a260 0xc>;
+			status = "okay";
+		};
 
-			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
-				reg = <0x0100a260 0xc>;
-				status = "okay";
-			};
+		option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
+			reg = <0x0100a280 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
-				reg = <0x0100a280 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
+			reg = <0x0100a290 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
-				reg = <0x0100a290 0x4>;
-				status = "okay";
-			};
-
-			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
-				reg = <0x0100a2c0 0xc>;
-				status = "okay";
-			};
+		option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
+			reg = <0x0100a2c0 0xc>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e10x.dtsi
@@ -69,53 +69,46 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-conf@100a100 {
-			reg = <0x0100a100 0x200>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs0: option-setting-ofs0@100a100 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS0_MEMORY";
+			reg = <0x0100a100 0x4>;
 			status = "okay";
+		};
 
-			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS0_MEMORY";
-				reg = <0x0100a100 0x4>;
-				status = "okay";
-			};
+		option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
+			reg = <0x0100a200 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
-				reg = <0x0100a200 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sec: option-setting-bps-sec@100a240 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
+			reg = <0x0100a240 0x4>;
+			status = "okay";
+		};
 
-			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
-				reg = <0x0100a240 0x4>;
-				status = "okay";
-			};
+		option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
+			reg = <0x0100a260 0x4>;
+			status = "okay";
+		};
 
-			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
-				reg = <0x0100a260 0x4>;
-				status = "okay";
-			};
+		option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
+			reg = <0x0100a280 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
-				reg = <0x0100a280 0x4>;
-				status = "okay";
-			};
-
-			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
-				reg = <0x0100a2c0 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
+			reg = <0x0100a2c0 0x4>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
@@ -122,46 +122,39 @@
 			};
 		};
 
-		option-setting-ofs-conf@100a100 {
-			reg = <0x0100a100 0x200>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs0: option-setting-ofs0@100a100 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS0_MEMORY";
+			reg = <0x0100a100 0x4>;
 			status = "okay";
+		};
 
-			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS0_MEMORY";
-				reg = <0x0100a100 0x4>;
-				status = "okay";
-			};
+		option_setting_osis: option-setting-osis@100a120 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OSIS_MEMORY";
+			reg = <0x0100a120 0x10>;
+			status = "okay";
+		};
 
-			option_setting_osis: option-setting-osis@100a120 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OSIS_MEMORY";
-				reg = <0x0100a120 0x10>;
-				status = "okay";
-			};
+		option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
+			reg = <0x0100a200 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
-				reg = <0x0100a200 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sec: option-setting-bps-sec@100a240 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
+			reg = <0x0100a240 0x4>;
+			status = "okay";
+		};
 
-			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
-				reg = <0x0100a240 0x4>;
-				status = "okay";
-			};
-
-			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
-				reg = <0x0100a260 0x4>;
-				status = "okay";
-			};
+		option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
+			reg = <0x0100a260 0x4>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
@@ -576,75 +576,67 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-conf@100a100 {
-			compatible = "renesas,ofs-memory";
-			reg = <0x0100a100 0x200>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs0: option-setting-ofs0@100a100 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS0_MEMORY";
+			reg = <0x0100a100 0x4>;
 			status = "okay";
+		};
 
-			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS0_MEMORY";
-				reg = <0x0100a100 0x4>;
-				status = "okay";
-			};
+		option_setting_dualsel: option-setting-dualsel@100a110 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_DUALSEL_MEMORY";
+			reg = <0x0100a110 0x4>;
+			status = "okay";
+		};
 
-			option_setting_dualsel: option-setting-dualsel@100a110 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_DUALSEL_MEMORY";
-				reg = <0x0100a110 0x4>;
-				status = "okay";
-			};
+		option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
+			reg = <0x0100a200 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
-				reg = <0x0100a200 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
+			reg = <0x0100a210 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
-				reg = <0x0100a210 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sec: option-setting-bps-sec@100a240 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
+			reg = <0x0100a240 0xc>;
+			status = "okay";
+		};
 
-			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
-				reg = <0x0100a240 0xc>;
-				status = "okay";
-			};
+		option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
+			reg = <0x0100a260 0xc>;
+			status = "okay";
+		};
 
-			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
-				reg = <0x0100a260 0xc>;
-				status = "okay";
-			};
+		option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
+			reg = <0x0100a280 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
-				reg = <0x0100a280 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
+			reg = <0x0100a290 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
-				reg = <0x0100a290 0x4>;
-				status = "okay";
-			};
-
-			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
-				reg = <0x0100a2c0 0xc>;
-				status = "okay";
-			};
+		option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
+			reg = <0x0100a2c0 0xc>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
@@ -157,53 +157,46 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-conf@100a100 {
-			reg = <0x0100a100 0x200>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs0: option-setting-ofs0@100a100 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS0_MEMORY";
+			reg = <0x0100a100 0x4>;
 			status = "okay";
+		};
 
-			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS0_MEMORY";
-				reg = <0x0100a100 0x4>;
-				status = "okay";
-			};
+		option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
+			reg = <0x0100a200 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
-				reg = <0x0100a200 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sec: option-setting-bps-sec@100a240 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
+			reg = <0x0100a240 0x4>;
+			status = "okay";
+		};
 
-			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
-				reg = <0x0100a240 0x4>;
-				status = "okay";
-			};
+		option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
+			reg = <0x0100a260 0x4>;
+			status = "okay";
+		};
 
-			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
-				reg = <0x0100a260 0x4>;
-				status = "okay";
-			};
+		option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
+			reg = <0x0100a280 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
-				reg = <0x0100a280 0x4>;
-				status = "okay";
-			};
-
-			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
-				reg = <0x0100a2c0 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
+			reg = <0x0100a2c0 0x4>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
@@ -170,67 +170,60 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-conf@100a100 {
-			reg = <0x0100a100 0x200>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs0: option-setting-ofs0@100a100 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS0_MEMORY";
+			reg = <0x0100a100 0x4>;
 			status = "okay";
+		};
 
-			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS0_MEMORY";
-				reg = <0x0100a100 0x4>;
-				status = "okay";
-			};
+		option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
+			reg = <0x0100a200 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
-				reg = <0x0100a200 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
+			reg = <0x0100a210 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
-				reg = <0x0100a210 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sec: option-setting-bps-sec@100a240 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
+			reg = <0x0100a240 0x8>;
+			status = "okay";
+		};
 
-			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
-				reg = <0x0100a240 0x8>;
-				status = "okay";
-			};
+		option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
+			reg = <0x0100a260 0x8>;
+			status = "okay";
+		};
 
-			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
-				reg = <0x0100a260 0x8>;
-				status = "okay";
-			};
+		option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
+			reg = <0x0100a280 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
-				reg = <0x0100a280 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
+			reg = <0x0100a290 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
-				reg = <0x0100a290 0x4>;
-				status = "okay";
-			};
-
-			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
-				reg = <0x0100a2c0 0x8>;
-				status = "okay";
-			};
+		option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
+			reg = <0x0100a2c0 0x8>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -463,42 +463,29 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-in-rom@400 {
-			reg = <0x00000400 0x3c>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			option_setting_ofs0: option-setting-ofs0@400 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000400 0x4>;
-				status = "okay";
-			};
-
-			option_setting_ofs1: option-setting-ofs1@404 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000404 0x4>;
-				status = "okay";
-			};
-
-			option_setting_secmpu: option-setting-secmpu@408 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000408 0x34>;
-				status = "okay";
-			};
+		option_setting_ofs0: option-setting-ofs0@400 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000400 0x4>;
+			status = "okay";
 		};
 
-		option-setting-ofs-conf@1010008 {
-			reg = <0x01010008 0x2c>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs1: option-setting-ofs1@404 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000404 0x4>;
 			status = "okay";
+		};
 
-			option_setting_osis: option-setting-osis@1010018 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OSIS_MEMORY";
-				reg = <0x01010018 0x1c>;
-				status = "okay";
-			};
+		option_setting_secmpu: option-setting-secmpu@408 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000408 0x34>;
+			status = "okay";
+		};
+
+		option_setting_osis: option-setting-osis@1010018 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OSIS_MEMORY";
+			reg = <0x01010018 0x1c>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
@@ -128,74 +128,67 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-conf@100a100 {
-			reg = <0x0100a100 0x200>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs0: option-setting-ofs0@100a100 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS0_MEMORY";
+			reg = <0x0100a100 0x4>;
 			status = "okay";
+		};
 
-			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS0_MEMORY";
-				reg = <0x0100a100 0x4>;
-				status = "okay";
-			};
+		option_setting_dualsel: option-setting-dualsel@100a110 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_DUALSEL_MEMORY";
+			reg = <0x0100a110 0x4>;
+			status = "okay";
+		};
 
-			option_setting_dualsel: option-setting-dualsel@100a110 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_DUALSEL_MEMORY";
-				reg = <0x0100a110 0x4>;
-				status = "okay";
-			};
+		option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
+			reg = <0x0100a200 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
-				reg = <0x0100a200 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
+			reg = <0x0100a210 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
-				reg = <0x0100a210 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sec: option-setting-bps-sec@100a240 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
+			reg = <0x0100a240 0xc>;
+			status = "okay";
+		};
 
-			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
-				reg = <0x0100a240 0xc>;
-				status = "okay";
-			};
+		option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
+			reg = <0x0100a260 0xc>;
+			status = "okay";
+		};
 
-			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
-				reg = <0x0100a260 0xc>;
-				status = "okay";
-			};
+		option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
+			reg = <0x0100a280 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
-				reg = <0x0100a280 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
+			reg = <0x0100a290 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
-				reg = <0x0100a290 0x4>;
-				status = "okay";
-			};
-
-			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
-				reg = <0x0100a2c0 0xc>;
-				status = "okay";
-			};
+		option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
+			reg = <0x0100a2c0 0xc>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -118,46 +118,39 @@
 			};
 		};
 
-		option-setting-ofs-conf@100a100 {
-			reg = <0x0100a100 0x200>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs0: option-setting-ofs0@100a100 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS0_MEMORY";
+			reg = <0x0100a100 0x4>;
 			status = "okay";
+		};
 
-			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS0_MEMORY";
-				reg = <0x0100a100 0x4>;
-				status = "okay";
-			};
+		option_setting_osis: option-setting-osis@100a120 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OSIS_MEMORY";
+			reg = <0x0100a120 0x10>;
+			status = "okay";
+		};
 
-			option_setting_osis: option-setting-osis@100a120 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OSIS_MEMORY";
-				reg = <0x0100a120 0x10>;
-				status = "okay";
-			};
+		option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
+			reg = <0x0100a200 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
-				reg = <0x0100a200 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sec: option-setting-bps-sec@100a240 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
+			reg = <0x0100a240 0x4>;
+			status = "okay";
+		};
 
-			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
-				reg = <0x0100a240 0x4>;
-				status = "okay";
-			};
-
-			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
-				reg = <0x0100a260 0x4>;
-				status = "okay";
-			};
+		option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
+			reg = <0x0100a260 0x4>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
@@ -55,42 +55,29 @@
 			channel-available-mask = <0x300e7>;
 		};
 
-		option-setting-ofs-in-rom@400 {
-			reg = <0x00000400 0x3c>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			option_setting_ofs0: option-setting-ofs0@400 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000400 0x4>;
-				status = "okay";
-			};
-
-			option_setting_ofs1: option-setting-ofs1@404 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000404 0x4>;
-				status = "okay";
-			};
-
-			option_setting_secmpu: option-setting-secmpu@408 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000408 0x34>;
-				status = "okay";
-			};
+		option_setting_ofs0: option-setting-ofs0@400 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000400 0x4>;
+			status = "okay";
 		};
 
-		option-setting-ofs-conf@100a150 {
-			reg = <0x0100a150 0x18>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs1: option-setting-ofs1@404 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000404 0x4>;
 			status = "okay";
+		};
 
-			option_setting_osis: option-setting-osis@100a150 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OSIS_MEMORY";
-				reg = <0x0100a150 0x10>;
-				status = "okay";
-			};
+		option_setting_secmpu: option-setting-secmpu@408 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000408 0x34>;
+			status = "okay";
+		};
+
+		option_setting_osis: option-setting-osis@100a150 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OSIS_MEMORY";
+			reg = <0x0100a150 0x10>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
@@ -86,42 +86,29 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-in-rom@400 {
-			reg = <0x00000400 0x3c>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			option_setting_ofs0: option-setting-ofs0@400 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000400 0x4>;
-				status = "okay";
-			};
-
-			option_setting_ofs1: option-setting-ofs1@404 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000404 0x4>;
-				status = "okay";
-			};
-
-			option_setting_secmpu: option-setting-secmpu@408 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000408 0x34>;
-				status = "okay";
-			};
+		option_setting_ofs0: option-setting-ofs0@400 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000400 0x4>;
+			status = "okay";
 		};
 
-		option-setting-ofs-conf@100a150 {
-			reg = <0x0100a150 0x18>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs1: option-setting-ofs1@404 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000404 0x4>;
 			status = "okay";
+		};
 
-			option_setting_osis: option-setting-osis@100a150 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OSIS_MEMORY";
-				reg = <0x0100a150 0x10>;
-				status = "okay";
-			};
+		option_setting_secmpu: option-setting-secmpu@408 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000408 0x34>;
+			status = "okay";
+		};
+
+		option_setting_osis: option-setting-osis@100a150 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OSIS_MEMORY";
+			reg = <0x0100a150 0x10>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
@@ -142,42 +142,29 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-in-rom@400 {
-			reg = <0x00000400 0x3c>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			option_setting_ofs0: option-setting-ofs0@400 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000400 0x4>;
-				status = "okay";
-			};
-
-			option_setting_ofs1: option-setting-ofs1@404 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000404 0x4>;
-				status = "okay";
-			};
-
-			option_setting_secmpu: option-setting-secmpu@408 {
-				compatible = "renesas,ofs-memory";
-				reg = <0x00000408 0x34>;
-				status = "okay";
-			};
+		option_setting_ofs0: option-setting-ofs0@400 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000400 0x4>;
+			status = "okay";
 		};
 
-		option-setting-ofs-conf@100a150 {
-			reg = <0x0100a150 0x18>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs1: option-setting-ofs1@404 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000404 0x4>;
 			status = "okay";
+		};
 
-			option_setting_osis: option-setting-osis@100a150 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OSIS_MEMORY";
-				reg = <0x0100a150 0x10>;
-				status = "okay";
-			};
+		option_setting_secmpu: option-setting-secmpu@408 {
+			compatible = "renesas,ofs-memory";
+			reg = <0x00000408 0x34>;
+			status = "okay";
+		};
+
+		option_setting_osis: option-setting-osis@100a150 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OSIS_MEMORY";
+			reg = <0x0100a150 0x10>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
@@ -239,74 +239,67 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-conf@100a100 {
-			reg = <0x0100a100 0x200>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs0: option-setting-ofs0@100a100 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS0_MEMORY";
+			reg = <0x0100a100 0x4>;
 			status = "okay";
+		};
 
-			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS0_MEMORY";
-				reg = <0x0100a100 0x4>;
-				status = "okay";
-			};
+		option_setting_dualsel: option-setting-dualsel@100a110 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_DUALSEL_MEMORY";
+			reg = <0x0100a110 0x4>;
+			status = "okay";
+		};
 
-			option_setting_dualsel: option-setting-dualsel@100a110 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_DUALSEL_MEMORY";
-				reg = <0x0100a110 0x4>;
-				status = "okay";
-			};
+		option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
+			reg = <0x0100a200 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
-				reg = <0x0100a200 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
+			reg = <0x0100a210 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
-				reg = <0x0100a210 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sec: option-setting-bps-sec@100a240 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
+			reg = <0x0100a240 0x10>;
+			status = "okay";
+		};
 
-			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
-				reg = <0x0100a240 0x10>;
-				status = "okay";
-			};
+		option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
+			reg = <0x0100a260 0x10>;
+			status = "okay";
+		};
 
-			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
-				reg = <0x0100a260 0x10>;
-				status = "okay";
-			};
+		option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
+			reg = <0x0100a280 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
-				reg = <0x0100a280 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
+			reg = <0x0100a290 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
-				reg = <0x0100a290 0x4>;
-				status = "okay";
-			};
-
-			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
-				reg = <0x0100a2c0 0x10>;
-				status = "okay";
-			};
+		option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
+			reg = <0x0100a2c0 0x10>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -292,74 +292,67 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-conf@100a100 {
-			reg = <0x0100a100 0x200>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs0: option-setting-ofs0@100a100 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS0_MEMORY";
+			reg = <0x0100a100 0x4>;
 			status = "okay";
+		};
 
-			option_setting_ofs0: option-setting-ofs0@100a100 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS0_MEMORY";
-				reg = <0x0100a100 0x4>;
-				status = "okay";
-			};
+		option_setting_dualsel: option-setting-dualsel@100a110 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_DUALSEL_MEMORY";
+			reg = <0x0100a110 0x4>;
+			status = "okay";
+		};
 
-			option_setting_dualsel: option-setting-dualsel@100a110 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_DUALSEL_MEMORY";
-				reg = <0x0100a110 0x4>;
-				status = "okay";
-			};
+		option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
+			reg = <0x0100a200 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sec: option-setting-ofs1-sec@100a200 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
-				reg = <0x0100a200 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
+			reg = <0x0100a210 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sec: option-setting-banksel-sec@100a210 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
-				reg = <0x0100a210 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sec: option-setting-bps-sec@100a240 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
+			reg = <0x0100a240 0x10>;
+			status = "okay";
+		};
 
-			option_setting_bps_sec: option-setting-bps-sec@100a240 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
-				reg = <0x0100a240 0x10>;
-				status = "okay";
-			};
+		option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
+			reg = <0x0100a260 0x10>;
+			status = "okay";
+		};
 
-			option_setting_pbps_sec: option-setting-pbps-sec@100a260 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
-				reg = <0x0100a260 0x10>;
-				status = "okay";
-			};
+		option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
+			reg = <0x0100a280 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sel: option-setting-ofs1-sel@100a280 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
-				reg = <0x0100a280 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
+			reg = <0x0100a290 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sel: option-setting-banksel-sel@100a290 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
-				reg = <0x0100a290 0x4>;
-				status = "okay";
-			};
-
-			option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
-				reg = <0x0100a2c0 0x10>;
-				status = "okay";
-			};
+		option_setting_bps_sel: option-setting-bps-sel@100a2c0 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
+			reg = <0x0100a2c0 0x10>;
+			status = "okay";
 		};
 	};
 

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -952,81 +952,74 @@
 			status = "disabled";
 		};
 
-		option-setting-ofs-cf-sec@300a100 {
-			reg = <0x0300a100 0x200>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		option_setting_ofs0: option-setting-ofs0@300a100 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS0_MEMORY";
+			reg = <0x0300a100 0x4>;
 			status = "okay";
+		};
 
-			option_setting_ofs0: option-setting-ofs0@300a100 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS0_MEMORY";
-				reg = <0x0300a100 0x4>;
-				status = "okay";
-			};
+		option_setting_ofs2: option-setting-ofs2@300a104 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS2_MEMORY";
+			reg = <0x0300a104 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs2: option-setting-ofs2@300a104 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS2_MEMORY";
-				reg = <0x0300a104 0x4>;
-				status = "okay";
-			};
+		option_setting_dualsel: option-setting-dualsel@300a110 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_DUALSEL_MEMORY";
+			reg = <0x0300a110 0x4>;
+			status = "okay";
+		};
 
-			option_setting_dualsel: option-setting-dualsel@300a110 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_DUALSEL_MEMORY";
-				reg = <0x0300a110 0x4>;
-				status = "okay";
-			};
+		option_setting_ofs1_sec: option-setting-ofs1-sec@300a200 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
+			reg = <0x0300a200 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sec: option-setting-ofs1-sec@300a200 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEC_MEMORY";
-				reg = <0x0300a200 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sec: option-setting-banksel-sec@300a210 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
+			reg = <0x0300a210 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sec: option-setting-banksel-sec@300a210 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEC_MEMORY";
-				reg = <0x0300a210 0x4>;
-				status = "okay";
-			};
+		option_setting_bps_sec: option-setting-bps-sec@300a240 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
+			reg = <0x0300a240 0x10>;
+			status = "okay";
+		};
 
-			option_setting_bps_sec: option-setting-bps-sec@300a240 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEC_MEMORY";
-				reg = <0x0300a240 0x10>;
-				status = "okay";
-			};
+		option_setting_pbps_sec: option-setting-pbps-sec@300a260 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
+			reg = <0x0300a260 0x10>;
+			status = "okay";
+		};
 
-			option_setting_pbps_sec: option-setting-pbps-sec@300a260 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_PBPS_SEC_MEMORY";
-				reg = <0x0300a260 0x10>;
-				status = "okay";
-			};
+		option_setting_ofs1_sel: option-setting-ofs1-sel@300a280 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
+			reg = <0x0300a280 0x4>;
+			status = "okay";
+		};
 
-			option_setting_ofs1_sel: option-setting-ofs1-sel@300a280 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_OFS1_SEL_MEMORY";
-				reg = <0x0300a280 0x4>;
-				status = "okay";
-			};
+		option_setting_banksel_sel: option-setting-banksel-sel@300a290 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
+			reg = <0x0300a290 0x4>;
+			status = "okay";
+		};
 
-			option_setting_banksel_sel: option-setting-banksel-sel@300a290 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BANKSEL_SEL_MEMORY";
-				reg = <0x0300a290 0x4>;
-				status = "okay";
-			};
-
-			option_setting_bps_sel: option-setting-bps-sel@300a2c0 {
-				compatible = "zephyr,memory-region";
-				zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
-				reg = <0x0300a2c0 0x10>;
-				status = "okay";
-			};
+		option_setting_bps_sel: option-setting-bps-sel@300a2c0 {
+			compatible = "zephyr,memory-region";
+			zephyr,memory-region = "OFS_BPS_SEL_MEMORY";
+			reg = <0x0300a2c0 0x10>;
+			status = "okay";
 		};
 	};
 


### PR DESCRIPTION
The OFS container node is not necessary, just put all the child nodes in the soc node