### PR TITLE
[DTS]: Update vendor-prefixes.txt to fix Raspberry Pi entry

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -564,7 +564,7 @@ raidsonic	RaidSonic Technology GmbH
 rakwireless	RAKwireless Technology Limited
 ralink	Mediatek/Ralink Technology Corp.
 ramtron	Ramtron International
-raspberrypi	Raspberry Pi Foundation
+raspberrypi	Raspberry Pi
 raydium	Raydium Semiconductor Corp.
 raytac	Raytac Corporation
 rda	Unisoc Communications, Inc.


### PR DESCRIPTION
Removed Foundation from the vendor prefix. The Foundation have nothing to do with Raspberry Pi HW or SW development.