### PR TITLE
net: dns: DNS resolver packet forwarding

### DIFF
--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -194,6 +194,13 @@ config DNS_RESOLVER_CACHE_MAX_ENTRIES
 
 endif # DNS_RESOLVER_CACHE
 
+config DNS_RESOLVER_PACKET_FORWARDING
+	bool "Forwards received DNS packets to application"
+	depends on !DNS_RESOLVER_CACHE
+	help
+	  This allows forwarding of received packets from DNS servers
+	  to applications that register the forwarding callback.
+
 endif # DNS_RESOLVER
 
 config MDNS_RESPONDER

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -7,6 +7,7 @@
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2024 Nordic Semiconductor
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1526,6 +1527,12 @@ static int dns_read(struct dns_resolve_context *ctx,
 	    query_idx > CONFIG_DNS_NUM_CONCUR_QUERIES) {
 		goto quit;
 	}
+
+#if defined(CONFIG_DNS_RESOLVER_PACKET_FORWARDING)
+	if (ctx->pkt_fw_cb != NULL) {
+		ctx->pkt_fw_cb(dns_data, data_len, ctx->queries[query_idx].user_data);
+	}
+#endif /* CONFIG_DNS_RESOLVER_PACKET_FORWARDING */
 
 	invoke_query_callback(ret, NULL, &ctx->queries[query_idx]);
 


### PR DESCRIPTION
This aims to implement a packet forwarding mechanism between DNS resolver and applications that install a callback, letting DNS resolver know that received UDP packet is also required by an application.

Related to https://github.com/zephyrproject-rtos/zephyr/discussions/95786