### PR TITLE
bluetooth: classic: a2dp: fix spelling error of STEREO

### DIFF
--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -66,7 +66,7 @@ extern "C" {
  *  @param _freq sbc codec frequency.
  *               for example: A2DP_SBC_SAMP_FREQ_44100 | A2DP_SBC_SAMP_FREQ_48000
  *  @param _ch_mode sbc codec channel mode.
- *               for example: A2DP_SBC_CH_MODE_MONO | A2DP_SBC_CH_MODE_STREO
+ *               for example: A2DP_SBC_CH_MODE_MONO | A2DP_SBC_CH_MODE_STEREO
  *  @param _blk_len sbc codec block length.
  *               for example: A2DP_SBC_BLK_LEN_16
  *  @param _subband sbc codec subband.
@@ -96,7 +96,7 @@ extern "C" {
  *  @param _freq sbc codec frequency.
  *               for example: A2DP_SBC_SAMP_FREQ_44100 | A2DP_SBC_SAMP_FREQ_48000
  *  @param _ch_mode sbc codec channel mode.
- *               for example: A2DP_SBC_CH_MODE_MONO | A2DP_SBC_CH_MODE_STREO
+ *               for example: A2DP_SBC_CH_MODE_MONO | A2DP_SBC_CH_MODE_STEREO
  *  @param _blk_len sbc codec block length.
  *               for example: A2DP_SBC_BLK_LEN_16
  *  @param _subband sbc codec subband.
@@ -127,7 +127,7 @@ extern "C" {
 	static struct bt_a2dp_codec_ie bt_a2dp_ep_cap_ie##_name = {                                \
 		.len = BT_A2DP_SBC_IE_LENGTH,                                                      \
 		.codec_ie = {A2DP_SBC_SAMP_FREQ_44100 | A2DP_SBC_SAMP_FREQ_48000 |                 \
-				     A2DP_SBC_CH_MODE_MONO | A2DP_SBC_CH_MODE_STREO |              \
+				     A2DP_SBC_CH_MODE_MONO | A2DP_SBC_CH_MODE_STEREO |             \
 				     A2DP_SBC_CH_MODE_JOINT,                                       \
 			     A2DP_SBC_BLK_LEN_16 | A2DP_SBC_SUBBAND_8 |                            \
 				     A2DP_SBC_ALLOC_MTHD_LOUDNESS,                                 \
@@ -147,7 +147,7 @@ extern "C" {
 	static struct bt_a2dp_codec_ie bt_a2dp_ep_cap_ie##_name = {                                \
 		.len = BT_A2DP_SBC_IE_LENGTH,                                                      \
 		.codec_ie = {A2DP_SBC_SAMP_FREQ_44100 | A2DP_SBC_SAMP_FREQ_48000 |                 \
-				     A2DP_SBC_CH_MODE_MONO | A2DP_SBC_CH_MODE_STREO |              \
+				     A2DP_SBC_CH_MODE_MONO | A2DP_SBC_CH_MODE_STEREO |             \
 				     A2DP_SBC_CH_MODE_JOINT,                                       \
 			     A2DP_SBC_BLK_LEN_16 | A2DP_SBC_SUBBAND_8 |                            \
 				     A2DP_SBC_ALLOC_MTHD_LOUDNESS,                                 \

--- a/include/zephyr/bluetooth/classic/a2dp_codec_sbc.h
+++ b/include/zephyr/bluetooth/classic/a2dp_codec_sbc.h
@@ -32,10 +32,10 @@ extern "C" {
 #define A2DP_SBC_SAMP_FREQ_48000 BIT(4)
 
 /* Channel Mode */
-#define A2DP_SBC_CH_MODE_MONO  BIT(3)
-#define A2DP_SBC_CH_MODE_DUAL  BIT(2)
-#define A2DP_SBC_CH_MODE_STREO BIT(1)
-#define A2DP_SBC_CH_MODE_JOINT BIT(0)
+#define A2DP_SBC_CH_MODE_MONO   BIT(3)
+#define A2DP_SBC_CH_MODE_DUAL   BIT(2)
+#define A2DP_SBC_CH_MODE_STEREO BIT(1)
+#define A2DP_SBC_CH_MODE_JOINT  BIT(0)
 
 /* Block Length */
 #define A2DP_SBC_BLK_LEN_4  BIT(7)

--- a/subsys/bluetooth/host/classic/a2dp_codec_sbc.c
+++ b/subsys/bluetooth/host/classic/a2dp_codec_sbc.c
@@ -24,7 +24,7 @@ uint8_t bt_a2dp_sbc_get_channel_num(struct bt_a2dp_codec_sbc_params *sbc_codec)
 		return 1U;
 	} else if (sbc_codec->config[0] & A2DP_SBC_CH_MODE_DUAL) {
 		return 2U;
-	} else if (sbc_codec->config[0] & A2DP_SBC_CH_MODE_STREO) {
+	} else if (sbc_codec->config[0] & A2DP_SBC_CH_MODE_STEREO) {
 		return 2U;
 	} else if (sbc_codec->config[0] & A2DP_SBC_CH_MODE_JOINT) {
 		return 2U;

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -240,7 +240,7 @@ static void shell_a2dp_print_capabilities(struct bt_a2dp_ep_info *ep_info)
 		if (0U != (codec_ie[0U] & A2DP_SBC_CH_MODE_DUAL)) {
 			bt_shell_print("	Dual ");
 		}
-		if (0U != (codec_ie[0U] & A2DP_SBC_CH_MODE_STREO)) {
+		if (0U != (codec_ie[0U] & A2DP_SBC_CH_MODE_STEREO)) {
 			bt_shell_print("	Stereo ");
 		}
 		if (0U != (codec_ie[0U] & A2DP_SBC_CH_MODE_JOINT)) {


### PR DESCRIPTION
change A2DP_SBC_CH_MODE_STREO as A2DP_SBC_CH_MODE_STEREO