### PR TITLE
test: kernel: fix warnings in kernel.no-mt

### DIFF
--- a/tests/kernel/fatal/no-multithreading/src/main.c
+++ b/tests/kernel/fatal/no-multithreading/src/main.c
@@ -22,7 +22,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
 		TC_PRINT("Unexpected reason (exp: %d)\n", expected_reason);
 		rv = TC_FAIL;
 	}
-	TC_END_RESULT_CUSTOM(rv, "test_fatal");
+	TC_END_RESULT_CUSTOM(rv, "test_fatal_no_mt");
 	TC_END_REPORT(rv);
 	arch_system_halt(reason);
 }


### PR DESCRIPTION
Align expected test name in kernel fatal error handler