### PR TITLE
boards: infineon: xmc4x_relax_kit: pwmleds should be disabled initially

### DIFF
--- a/boards/infineon/xmc45_relax_kit/xmc45_relax_kit.dts
+++ b/boards/infineon/xmc45_relax_kit/xmc45_relax_kit.dts
@@ -39,8 +39,9 @@
 		};
 	};
 
-	pwmleds {
+	pwmleds: pwmleds {
 		compatible = "pwm-leds";
+		status = "disabled";
 
 		pwm_led1: pwm_led1 {
 			pwms = <&pwm_ccu40 2 PWM_SEC(1) PWM_POLARITY_NORMAL>;

--- a/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.dts
+++ b/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.dts
@@ -38,8 +38,9 @@
 		};
 	};
 
-	pwmleds {
+	pwmleds: pwmleds {
 		compatible = "pwm-leds";
+		status = "disabled";
 
 		pwm_led1: pwm_led1 {
 			pwms = <&pwm_ccu80 4 PWM_SEC(1) PWM_POLARITY_NORMAL>;

--- a/samples/basic/blinky_pwm/boards/xmc45_relax_kit.overlay
+++ b/samples/basic/blinky_pwm/boards/xmc45_relax_kit.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&pwm_led1 {
+&pwmleds {
 	status = "okay";
 };
 

--- a/samples/basic/blinky_pwm/boards/xmc47_relax_kit.overlay
+++ b/samples/basic/blinky_pwm/boards/xmc47_relax_kit.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&pwm_led1 {
+&pwmleds {
 	status = "okay";
 };
 


### PR DESCRIPTION
The pwmleds node for `xmc45_relax_kit` and `xmc47_relax_kit` should be disabled initially due to the PWM controller the pwmleds node use not being enabled by default.

Fixes a bunch of CI failures in weekly CI test runs:
- xmc47_relax_kit/xmc4700:sample.net.sockets.http.server
- xmc47_relax_kit/xmc4700:sample.net.sockets.https.server
- xmc45_relax_kit/xmc4500:drivers.led.build
- xmc47_relax_kit/xmc4700:drivers.led.build