### PR TITLE
drivers: spi: xmc4xxx: handle error from spi_context_cs_configure_all

### DIFF
--- a/drivers/spi/spi_xmc4xxx.c
+++ b/drivers/spi/spi_xmc4xxx.c
@@ -598,7 +598,10 @@ static int spi_xmc4xxx_init(const struct device *dev)
 	}
 
 	XMC_SPI_CH_SetInputSource(config->spi, XMC_SPI_CH_INPUT_DIN0, config->miso_src);
-	spi_context_cs_configure_all(&data->ctx);
+	ret = spi_context_cs_configure_all(&data->ctx);
+	if (ret < 0) {
+		return ret;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
This fixes CI issues ("error: statement with no effect") in the project's weekly CI run, e.g.:

- "xmc45_relax_kit/xmc4500:drivers.spi.loopback",
- "xmc45_relax_kit/xmc4500:drivers.spi.loopback.internal",
- "xmc47_relax_kit/xmc4700:drivers.eeprom.build",
- "xmc47_relax_kit/xmc4700:drivers.eeprom.emul.build",
- "xmc47_relax_kit/xmc4700:drivers.gpio.build",
- "xmc47_relax_kit/xmc4700:drivers.led_strip.build",
- "xmc47_relax_kit/xmc4700:drivers.spi.dt_spec",
- "xmc47_relax_kit/xmc4700:drivers.spi.loopback",
- "xmc47_relax_kit/xmc4700:drivers.spi.loopback.internal"
