### PR TITLE
tests: kernel: device: add missing node in hifive board overlays

### DIFF
--- a/tests/kernel/device/boards/hifive_unmatched_fu740_s7.overlay
+++ b/tests/kernel/device/boards/hifive_unmatched_fu740_s7.overlay
@@ -63,6 +63,13 @@
 		zephyr,deferred-init;
 	};
 
+	fakedeferdriver@F9000000 {
+		compatible = "fakedeferdriver";
+		reg = <0x0 0xF9000000 0x0 0x2000>;
+		status = "okay";
+		zephyr,deferred-init;
+	};
+
 	fakedomain_0: fakedomain_0 {
 		compatible = "fakedomain";
 		status = "okay";

--- a/tests/kernel/device/boards/hifive_unmatched_fu740_u74.overlay
+++ b/tests/kernel/device/boards/hifive_unmatched_fu740_u74.overlay
@@ -63,6 +63,13 @@
 		zephyr,deferred-init;
 	};
 
+	fakedeferdriver@F9000000 {
+		compatible = "fakedeferdriver";
+		reg = <0x0 0xF9000000 0x0 0x2000>;
+		status = "okay";
+		zephyr,deferred-init;
+	};
+
 	fakedomain_0: fakedomain_0 {
 		compatible = "fakedomain";
 		status = "okay";


### PR DESCRIPTION
A follow-up to commit d6ce2f4f41dd585a40f1d60f12536a8525b33449 that introduced a new fakedeferdriver node in app.overlay, but due to how overlays are applied, the board specific overlay files also need to be updated to avoid build errors, as they override whatever app.overlay has.

Fixes a few errors caught in weekly CI

 - "hifive_unmatched/fu740/s7:kernel.device",
 - "hifive_unmatched/fu740/s7:kernel.device.minimallibc",
 - "hifive_unmatched/fu740/s7:kernel.device.pm",
 - "hifive_unmatched/fu740/u74:kernel.device",
 - "hifive_unmatched/fu740/u74:kernel.device.minimallibc",
 - "hifive_unmatched/fu740/u74:kernel.device.pm"

cc @ljd42 
