### PR TITLE
doc: conf.py: fix pdf build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -119,6 +119,7 @@ else:
 # multiple toctrees.
 if tags.has("convertimages"):  # pylint: disable=undefined-variable  # noqa: F821
     exclude_patterns.append("index.rst")
+    root_doc = "index-tex"
 else:
     exclude_patterns.append("index-tex.rst")
 


### PR DESCRIPTION
An earlier fix (0871c7e) meant to remove warnings due to index and index-tex defining overlapping table of contents actually broke the PDF build. Fix it by making sure index-tex is set as root_doc when building for LaTeX/PDF.