### PR TITLE
tests: ram_context_for_isr: pick an available IRQ for Nuvoton platforms

### DIFF
--- a/tests/application_development/ram_context_for_isr/Kconfig
+++ b/tests/application_development/ram_context_for_isr/Kconfig
@@ -10,6 +10,7 @@ config TEST_IRQ_NUM
 	default 14 if GIC
 	default 22 if SOC_SERIES_DA1469X
 	default 18 if SOC_SERIES_STM32C0X
+	default 1 if (SOC_SERIES_NPCX9 || SOC_SERIES_NPCX7 || SOC_SERIES_NPCK3)
 	default 0
 	help
 	  IRQ number to use for testing purposes. This should be an
@@ -20,6 +21,7 @@ config TEST_IRQ_NUM
 	  - GIC platforms: 14 (available test SGI - Software Generated Interrupt)
 	  - DA1469X series: 22 (available test IRQ)
 	  - STM32C0X series: 18 (available test IRQ)
+	  - NPCX9, NPCX7, NPCK3 series: 1 (unused IRQ not mapped to MIWU groups)
 	  - Other platforms: 0 (magic config value to select the last IRQ: NUM_IRQS - 1)
 
 config TEST_IRQ_PRIO


### PR DESCRIPTION
NPCX7, NPCX9, and NPCK3 platforms have their `(NUM_IRQS-1)` IRQ taken, so set CONFIG_TEST_IRQ_NUM to a different available IRQ.

Fixes following test failures in weekly CI:

- "google_quincy/npcx9mfp:application_development.ram_context_for_isr",
- "npck3m8k_evb/npck3m8k:application_development.ram_context_for_isr",
- "npck3m8k_evb/npck3m8k:application_development.ram_context_for_isr",
- "npcx7m6fb_evb/npcx7m6fb:application_development.ram_context_for_isr",
- "npcx9m6f_evb/npcx9m6f:application_development.ram_context_for_isr"