### PR TITLE
boards: nrf52840_mdk_usb_dongle: disable pwmleds node

### DIFF
--- a/boards/makerdiary/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.dts
+++ b/boards/makerdiary/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.dts
@@ -43,6 +43,7 @@
 
 	pwmleds {
 		compatible = "pwm-leds";
+		status = "disabled";
 
 		red_pwm_led: pwm_led_0 {
 			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;


### PR DESCRIPTION
PWM leds for this board are not functional out-of-the-box as pwm0 needs to be configured/enabled first. Disable the pwmleds node to reflect this.

Fixes test failure  in weekly CI:
- nrf52840_mdk_usb_dongle/nrf52840:drivers.led.build