### PR TITLE
boards: nxp: mcx_n9xx_evk: deactivate eth phy on cpu1

### DIFF
--- a/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk.dtsi
+++ b/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk.dtsi
@@ -209,7 +209,7 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 	phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0>;
-		status = "okay";
+		status = "disabled";
 	};
 };
 

--- a/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk_mcxn947_cpu0.dtsi
+++ b/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk_mcxn947_cpu0.dtsi
@@ -167,6 +167,10 @@
 	status = "okay";
 };
 
+&phy {
+	status = "okay";
+};
+
 &wwdt0 {
 	status = "okay";
 };


### PR DESCRIPTION
deactivate eth phy on cpu1, because mdio is also only activated on cpu0.

basically the same fix as #95122, just for a different board

Fixes CI issues in weekly run:
- mcx_n9xx_evk/mcxn947/cpu1:sample.net.sockets.dumb_http_server,
- mcx_n9xx_evk/mcxn947/cpu1:sample.posix.gettimeofday
