### PR TITLE
sample: net: sockets: echo_service improvements

### DIFF
--- a/samples/net/sockets/echo_service/README.rst
+++ b/samples/net/sockets/echo_service/README.rst
@@ -46,6 +46,4 @@ The easiest way to connect is:
     $ telnet 192.0.2.1 4242
 
 After a connection is made, the application will echo back any line sent
-to it. The application implements a single-threaded server using blocking
-sockets, and currently is only implemented to serve only one client connection
-at time. After the current client disconnects, the next connection can proceed.
+to it.

--- a/samples/net/sockets/echo_service/prj.conf
+++ b/samples/net/sockets/echo_service/prj.conf
@@ -33,3 +33,6 @@ CONFIG_NET_BUF_TX_COUNT=64
 CONFIG_NET_CONTEXT_NET_PKT_POOL=y
 
 CONFIG_NET_SHELL=y
+
+# ZVFS_POLL_MAX is increased to serve multiple clients concurrently
+CONFIG_ZVFS_POLL_MAX=41

--- a/samples/net/sockets/echo_service/src/main.c
+++ b/samples/net/sockets/echo_service/src/main.c
@@ -25,13 +25,14 @@ LOG_MODULE_REGISTER(net_echo_server_svc_sample, LOG_LEVEL_DBG);
 BUILD_ASSERT(MAX_SERVICES > 0, "Need at least 4 poll fds, increase CONFIG_ZVFS_POLL_MAX");
 
 K_MUTEX_DEFINE(lock);
-static struct pollfd sockfd_udp[1] = {
-	[0] = { .fd = -1 }, /* UDP socket */
-};
 static struct pollfd sockfd_tcp[MAX_SERVICES];
+static int tcp_socket = -1;
+static int udp_socket = -1;
 
 static void receive_data(bool is_udp, struct net_socket_service_event *pev,
 			 char *buf, size_t buflen);
+static void tcp_accept_handler(struct net_socket_service_event *pev);
+static void restart_echo_service(void);
 
 static void tcp_service_handler(struct net_socket_service_event *pev)
 {
@@ -48,6 +49,7 @@ static void udp_service_handler(struct net_socket_service_event *pev)
 }
 
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(service_udp, udp_service_handler, 1);
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(service_accept, tcp_accept_handler, 1);
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(service_tcp, tcp_service_handler, MAX_SERVICES);
 
 static void client_list_init(void)
@@ -61,12 +63,7 @@ static void client_list_init(void)
 
 static void client_list_deinit(void)
 {
-	int ret;
-
-	ret = net_socket_service_unregister(&service_tcp);
-	if (ret < 0) {
-		LOG_ERR("Cannot unregister socket service handler (%d)", ret);
-	}
+	(void)net_socket_service_unregister(&service_tcp);
 
 	k_mutex_lock(&lock, K_FOREVER);
 	ARRAY_FOR_EACH_PTR(sockfd_tcp, sockfd) {
@@ -88,9 +85,12 @@ static void client_list_try_add(int sock)
 			sockfd->fd = sock;
 			sockfd->events = POLLIN;
 
-			ret = net_socket_service_register(&service_tcp, sockfd_tcp, ARRAY_SIZE(sockfd_tcp), NULL);
+			ret = net_socket_service_register(&service_tcp, sockfd_tcp,
+							  ARRAY_SIZE(sockfd_tcp), NULL);
 			if (ret < 0) {
-				LOG_ERR("Cannot register socket service handler (%d)", ret);
+				LOG_ERR("Cannot register socket service handler (%d). "
+					"Attempting to restart service.", ret);
+				restart_echo_service();
 			}
 			k_mutex_unlock(&lock);
 			return;
@@ -110,9 +110,12 @@ static void client_list_remove(int client)
 		if (sockfd->fd == client) {
 			close(client);
 			sockfd->fd = -1;
-			ret = net_socket_service_register(&service_tcp, sockfd_tcp, ARRAY_SIZE(sockfd_tcp), NULL);
+			ret = net_socket_service_register(&service_tcp, sockfd_tcp,
+							  ARRAY_SIZE(sockfd_tcp), NULL);
 			if (ret < 0) {
-				LOG_ERR("Cannot register socket service handler (%d)", ret);
+				LOG_ERR("Cannot register socket service handler (%d). "
+					"Attempting to restart service.", ret);
+				restart_echo_service();
 			}
 			break;
 		}
@@ -164,6 +167,27 @@ static void receive_data(bool is_udp, struct net_socket_service_event *pev,
 	} while (len);
 }
 
+static void tcp_accept_handler(struct net_socket_service_event *pev)
+{
+	int client;
+	int sock = pev->event.fd;
+	char addr_str[INET6_ADDRSTRLEN];
+	struct sockaddr_in6 client_addr;
+	socklen_t client_addr_len = sizeof(client_addr);
+
+	client = accept(sock, (struct sockaddr *)&client_addr, &client_addr_len);
+	if (client < 0) {
+		LOG_ERR("accept: %d. Restarting service.", -errno);
+		restart_echo_service();
+		return;
+	}
+
+	inet_ntop(client_addr.sin6_family, &client_addr.sin6_addr, addr_str, sizeof(addr_str));
+	LOG_INF("Connection from %s (%d)", addr_str, client);
+
+	client_list_try_add(client);
+}
+
 static int setup_tcp_socket(struct sockaddr_in6 *addr)
 {
 	socklen_t optlen = sizeof(int);
@@ -190,11 +214,13 @@ static int setup_tcp_socket(struct sockaddr_in6 *addr)
 
 	if (bind(sock, (struct sockaddr *)addr, sizeof(*addr)) < 0) {
 		LOG_ERR("bind: %d", -errno);
+		close(sock);
 		return -errno;
 	}
 
 	if (listen(sock, 5) < 0) {
 		LOG_ERR("listen: %d", -errno);
+		close(sock);
 		return -errno;
 	}
 
@@ -227,73 +253,96 @@ static int setup_udp_socket(struct sockaddr_in6 *addr)
 
 	if (bind(sock, (struct sockaddr *)addr, sizeof(*addr)) < 0) {
 		LOG_ERR("bind: %d", -errno);
+		close(sock);
 		return -errno;
 	}
 
 	return sock;
 }
 
-int main(void)
+static int start_echo_service(void)
 {
+	struct pollfd sockfd_accept, sockfd_udp;
 	int tcp_sock, udp_sock, ret;
-	char addr_str[INET6_ADDRSTRLEN];
 	struct sockaddr_in6 addr = {
 		.sin6_family = AF_INET6,
 		.sin6_addr = IN6ADDR_ANY_INIT,
 		.sin6_port = htons(MY_PORT),
 	};
-	static int counter;
 
 	client_list_init();
 
 	tcp_sock = setup_tcp_socket(&addr);
 	if (tcp_sock < 0) {
+		LOG_ERR("Failed to setup tcp listening socket");
 		return tcp_sock;
 	}
 
 	udp_sock = setup_udp_socket(&addr);
 	if (udp_sock < 0) {
-		return udp_sock;
+		LOG_ERR("Failed to setup udp socket");
+		ret = udp_sock;
+		goto cleanup_tcp;
 	}
 
-	sockfd_udp[0].fd = udp_sock;
-	sockfd_udp[0].events = POLLIN;
-
-	/* Register UDP socket to service handler */
-	ret = net_socket_service_register(&service_udp, sockfd_udp,
-					  ARRAY_SIZE(sockfd_udp), NULL);
+	/* Register TCP listening socket to service handler */
+	sockfd_accept = (struct pollfd){ .fd = tcp_sock, .events = POLLIN };
+	ret = net_socket_service_register(&service_accept, &sockfd_accept, 1, NULL);
 	if (ret < 0) {
 		LOG_ERR("Cannot register socket service handler (%d)", ret);
+		goto cleanup_sockets;
 	}
+
+	/* Register UDP socket to service handler */
+	sockfd_udp = (struct pollfd){ .fd = udp_sock, .events = POLLIN };
+	ret = net_socket_service_register(&service_udp, &sockfd_udp, 1, NULL);
+	if (ret < 0) {
+		LOG_ERR("Cannot register socket service handler (%d)", ret);
+		goto cleanup_sockets;
+	}
+
+	k_mutex_lock(&lock, K_FOREVER);
+	tcp_socket = tcp_sock;
+	udp_socket = udp_sock;
+	k_mutex_unlock(&lock);
 
 	LOG_INF("Single-threaded TCP/UDP echo server waits "
 		"for a connection on port %d", MY_PORT);
 
-	while (1) {
-		struct sockaddr_in6 client_addr;
-		socklen_t client_addr_len = sizeof(client_addr);
-		int client;
+	return 0;
 
-		client = accept(tcp_sock, (struct sockaddr *)&client_addr,
-				&client_addr_len);
-		if (client < 0) {
-			LOG_ERR("accept: %d", -errno);
-			continue;
-		}
+cleanup_sockets:
+	close(udp_sock);
+cleanup_tcp:
+	close(tcp_sock);
+	return -1;
 
-		inet_ntop(client_addr.sin6_family, &client_addr.sin6_addr,
-			  addr_str, sizeof(addr_str));
-		LOG_INF("Connection #%d from %s (%d)", counter++, addr_str, client);
+}
 
-		client_list_try_add(client);
-
-	}
-
+static int stop_echo_service(void)
+{
 	client_list_deinit();
 	(void)net_socket_service_unregister(&service_udp);
+	(void)net_socket_service_unregister(&service_accept);
 
-	close(tcp_sock);
-	close(udp_sock);
+	k_mutex_lock(&lock, K_FOREVER);
+	if (tcp_socket >= 0) {
+		close(tcp_socket);
+		tcp_socket = -1;
+	}
+	if (udp_socket >= 0) {
+		close(udp_socket);
+		udp_socket = -1;
+	}
+	k_mutex_unlock(&lock);
 
 	return 0;
 }
+
+static void restart_echo_service(void)
+{
+	stop_echo_service();
+	start_echo_service();
+}
+
+SYS_INIT(start_echo_service, APPLICATION, 99);


### PR DESCRIPTION
Build on the echo service sample and improve it in some ways:
- No need for an thread for `accepting`. Instead do it as a socket service. This makes the intention of the socket service clearer in saving threads.
- Handle many connections concurrently

Question:
- <del>Should this be integrated into the original example?
- Maybe in the future: <del>Currently we need to track the open sockets even though the socket service has a copy of the entire list. For two reasons. We need to be able to add/remove sockets, but the api only lets one renew the entire list and if the service is taken down, all the open sockets need to be closed. This could be fixed by modifying the API (for example: `net_socket_service_add`, `net_socket_service_remove`, and some way to close the sockets, when `net_socket_service_unregister` maybe via callback).