### PR TITLE
drivers: serial: opentitan: remove bogus depends on clause

### DIFF
--- a/drivers/serial/Kconfig.opentitan
+++ b/drivers/serial/Kconfig.opentitan
@@ -5,7 +5,6 @@ config UART_OPENTITAN
 	bool "OpenTitan UART"
 	default y
 	depends on DT_HAS_LOWRISC_OPENTITAN_UART_ENABLED
-	depends on !SERIAL_SUPPORT_INTERRUPT
 	select SERIAL_HAS_DRIVER
 	help
 	  Enable OpenTitan UART serial driver


### PR DESCRIPTION
CONFIG_SERIAL_SUPPORT_INTERRUPT is a Kconfig option that is supposed to be _selected_ by serial drivers that support interrupts. This commit removes a bogus "depends on !SERIAL_SUPPORT_INTERRUPT" which does not make sense and causes some tests to fail.

Fixes test failures in weekly CI:
- opentitan_earlgrey/opentitan:logging.backend.uart.multi
- opentitan_earlgrey/opentitan:logging.backend.uart.single