### PR TITLE
boards: rt1180: fix lpspi with dma

### DIFF
--- a/boards/nxp/mimxrt1180_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1180_evk/Kconfig.defconfig
@@ -39,4 +39,12 @@ if !CM7_BOOT_FROM_FLASH
 		$(dt_node_reg_addr_hex,/soc/itcm@0)"
 endif # !CM7_BOOT_FROM_FLASH
 endif # SECOND_CORE_MCUX && BOARD_MIMXRT1180_EVK_MIMXRT1189_CM7
+
+if DMA
+
+config NOCACHE_MEMORY
+	default y
+
+endif # DMA
+
 endif # BOARD_MIMXRT1180_EVK

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -6,12 +6,6 @@
 
 /* To test this sample, connect J44.8 <-> J44.10 */
 
-/ {
-	chosen {
-		zephyr,sram = &dtcm;
-	};
-};
-
 &lpspi3 {
 	slow@0 {
 		compatible = "test-spi-loopback-slow";


### PR DESCRIPTION
Since this board is by default having hyperram as SRAM, need to set NOCACHE_MEMORY when using dma to make sure the memory for the tcd pools is not cached.

The previous approach to set zephyr,sram to dtcm just caused an error because zephyr,dtcm was also set to dtcm, and the default logic of the driver is put the tcdpools in dtcm, so what happened was these buffer got linked over the rest of the app causing massive failing of the image to work at all.

So instead of doing that we need to just keep running from hyperram but set CONFIG_NOCACHE_MEMORY to have a place to put the tcd pools that wont be cached.

Fixes #95074