### PR TITLE
tests: ram_context_for_isr: pick an available IRQ for nxp_k32l2b3 soc

### DIFF
--- a/tests/application_development/ram_context_for_isr/Kconfig
+++ b/tests/application_development/ram_context_for_isr/Kconfig
@@ -11,6 +11,7 @@ config TEST_IRQ_NUM
 	default 22 if SOC_SERIES_DA1469X
 	default 18 if SOC_SERIES_STM32C0X
 	default 1 if (SOC_SERIES_NPCX9 || SOC_SERIES_NPCX7 || SOC_SERIES_NPCK3)
+	default 29 if SOC_K32L2B31A
 	default 0
 	help
 	  IRQ number to use for testing purposes. This should be an
@@ -22,6 +23,7 @@ config TEST_IRQ_NUM
 	  - DA1469X series: 22 (available test IRQ)
 	  - STM32C0X series: 18 (available test IRQ)
 	  - NPCX9, NPCX7, NPCK3 series: 1 (unused IRQ not mapped to MIWU groups)
+	  - K32L2B31A: 29 (available test IRQ)
 	  - Other platforms: 0 (magic config value to select the last IRQ: NUM_IRQS - 1)
 
 config TEST_IRQ_PRIO


### PR DESCRIPTION
(NUM_IRQS-1) IRQ is taken on this soc, so set CONFIG_TEST_IRQ_NUM to a different available IRQ to avoid test failure.

Fixes the following test failure in weekly CI:
- frdm_k32l2b3/k32l2b31a:application_development.ram_context_for_isr