### PR TITLE
bluetooth: BAP: fix select bug

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.bap
+++ b/subsys/bluetooth/audio/Kconfig.bap
@@ -16,8 +16,8 @@ config BT_BAP_UNICAST_SERVER
 	depends on BT_ISO_PERIPHERAL
 	depends on BT_ASCS
 	depends on BT_BONDABLE
-	select BT_PAC_SRC if BT_ASCS_ASE_SNK
-	select BT_PAC_SNK if BT_ASCS_ASE_SRC
+	select BT_PAC_SNK if BT_ASCS_ASE_SNK
+	select BT_PAC_SRC if BT_ASCS_ASE_SRC
 	help
 	  This option enables support for Bluetooth Unicast Audio Server
 	  using Isochronous channels.


### PR DESCRIPTION
Change 4c86a5cc8d59618c97173dc225571f31e5ebc4fa moved a select from Kconfig.asc to Kconfig.bap (amongst some other changes from select to depends), but inverted the PAC_{SRC,SNK} from ASCS_ASE_{SRC,SNK} condition.