### PR TITLE
test: rtio: use TRANSACTION and test early signal

### DIFF
--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -882,14 +882,47 @@ RTIO_DEFINE(r_await1, SQE_POOL_SIZE, CQE_POOL_SIZE);
 RTIO_IODEV_TEST_DEFINE(iodev_test_await0);
 
 /**
- * @brief Test await requests
+ * @brief Test early signalling on await requests
+ *
+ * Ensures that the AWAIT operation will be skipped if rtio_seq_signal() was
+ * called before the AWAIT SQE is executed.
+ */
+void test_rtio_await_early_signal_(struct rtio *r)
+{
+	int res;
+	int32_t userdata = 0;
+	struct rtio_sqe *sqe;
+	struct rtio_cqe *cqe;
+
+	rtio_iodev_test_init(&iodev_test_await0);
+
+	TC_PRINT("Prepare await sqe\n");
+	sqe = rtio_sqe_acquire(r);
+	zassert_not_null(sqe, "Expected a valid sqe");
+	rtio_sqe_prep_await(sqe, &iodev_test_await0, RTIO_PRIO_LOW, &userdata);
+	sqe->flags = 0;
+
+	TC_PRINT("Signal await sqe prior to submission\n");
+	rtio_sqe_signal(sqe);
+
+	TC_PRINT("Submit await sqe\n");
+	res = rtio_submit(r, 0);
+	zassert_ok(res, "Submission failed");
+
+	TC_PRINT("Ensure await sqe completed\n");
+	cqe = rtio_cqe_consume_block(r);
+	zassert_not_null(cqe, "Expected a valid cqe");
+	zassert_equal(cqe->userdata, &userdata);
+	rtio_cqe_release(r, cqe);
+}
+
+/**
+ * @brief Test blocking rtio_iodev using await requests
  *
  * Ensures we can block execution of an RTIO iodev using the AWAIT operation,
- * and unblock it by calling rtio_seq_signal(), and that the AWAIT operation
- * will be skipped if rtio_seq_signal() was called before the AWAIT SQE is
- * executed.
+ * and unblock it by calling rtio_seq_signal().
  */
-void test_rtio_await_(struct rtio *rtio0, struct rtio *rtio1)
+void test_rtio_await_iodev_(struct rtio *rtio0, struct rtio *rtio1)
 {
 	int res;
 	int32_t userdata[3] = {0, 1, 2};
@@ -1040,7 +1073,8 @@ void test_rtio_await_executor_(struct rtio *rtio0, struct rtio *rtio1)
 
 ZTEST(rtio_api, test_rtio_await)
 {
-	test_rtio_await_(&r_await0, &r_await1);
+	test_rtio_await_early_signal_(&r_await0);
+	test_rtio_await_iodev_(&r_await0, &r_await1);
 	test_rtio_await_executor_(&r_await0, &r_await1);
 }
 


### PR DESCRIPTION
The main motivation behind this PR was the comment from https://github.com/zephyrproject-rtos/zephyr/pull/95050#discussion_r2336164582
However, while I was in here, I decided to also add testing of the early signalling (like what was actually hinted within the existing test, but never implemented).

Also note that the choice to _not_ update the _executor test case to use TRANSACTION instead of CHAINED is deliberate. The intention behind the _executor variant is specifically to avoid blocking other SQEs during the await operation. As such, building a TRANSACTION is actually going against the intended use case (or at the very least, the use case that differentiates the _executor variant from the _iodev variant).

Overview of the commits:

[tests: rtio: use TRANSACTION for iodev await test](https://github.com/zephyrproject-rtos/zephyr/commit/07d48d221aa156725bca7b300546f60f3e92c33b)

The intention behind using an RTIO_OP_AWAIT tied to an rtio_iodev is
to get a guarantee that an entire transaction can be handled without
interruptions or parallel work taking place on the rtio_iodev.

This guarantee can only be met when SQEs are bundled together using
RTIO_SQE_TRANSACTION as they will otherwise be considered individual
pieces of work, hence allowing some unrelated piece of work to get
scheduled in-between the rest.
When just using RTIO_SQE_CHAINED, the rtio_iodev would still block
during the entire RTIO_OP_AWAIT, but the following SQE in the chain can
be preempted by an unrelated SQE.

Modify this specific test case to use RTIO_SQE_TRANSACTION as this will
match the intention.

Signed-off-by: Emil Dahl Juhl <emil@s16s.ai>

[tests: rtio: test early signalling of RTIO_OP_AWAIT](https://github.com/zephyrproject-rtos/zephyr/commit/5873502eec723e1833d4d72969963fe189ed7766)

The brief on the existing test_rtio_await_ function mentioned testing
that an await operation would immediately complete ("be skipped") if
the SQE were signalled prior to being submitted. The function didn't
actually test this, though.

Add a new test function for testing this specific case.

Remove the misleading part of the brief around the existing test.

Rename test_rtio_await_ to be more concise on the test it performs.

Signed-off-by: Emil Dahl Juhl <emil@s16s.ai>