### PR TITLE
scripts: twisterlib: more efficient coverage merging

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -396,7 +396,6 @@ class TestInstance:
             for cp in coverage_platform:
                 if cp in platform.aliases:
                     content = content + "\nCONFIG_COVERAGE=y"
-                    content = content + "\nCONFIG_COVERAGE_DUMP=y"
 
         if platform.type == "native":
             if enable_asan:

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -96,13 +96,13 @@ def test_check_build_or_run(
 
 TESTDATA_PART_2 = [
     (True, True, True, ["demo_board_2/unit_testing"], "native",
-     None, '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y\nCONFIG_ASAN=y\nCONFIG_UBSAN=y'),
+     None, '\nCONFIG_COVERAGE=y\nCONFIG_ASAN=y\nCONFIG_UBSAN=y'),
     (True, False, True, ["demo_board_2/unit_testing"], "native",
-     None, '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y\nCONFIG_ASAN=y'),
+     None, '\nCONFIG_COVERAGE=y\nCONFIG_ASAN=y'),
     (False, False, True, ["demo_board_2/unit_testing"], 'native',
-     None, '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y'),
+     None, '\nCONFIG_COVERAGE=y'),
     (True, False, True, ["demo_board_2/unit_testing"], 'mcu',
-     None, '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y'),
+     None, '\nCONFIG_COVERAGE=y'),
     (False, False, False, ["demo_board_2/unit_testing"], 'native', None, ''),
     (False, False, True, ['demo_board_1'], 'native', None, ''),
     (True, False, False, ["demo_board_2"], 'native', None, '\nCONFIG_ASAN=y'),

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -72,6 +72,8 @@ config COVERAGE_GCOV
 
 endchoice
 
+if COVERAGE_GCOV
+
 config COVERAGE_GCOV_HEAP_SIZE
 	int "Size of heap allocated for gcov coverage data dump"
 	depends on COVERAGE_GCOV
@@ -82,11 +84,18 @@ config COVERAGE_GCOV_HEAP_SIZE
 	  data to be dumped over serial. If the value is 0, no buffer will be used,
 	  data will be dumped directly over serial.
 
+choice COVERAGE_DUMP_METHOD
+	prompt "Method to dump coverage data"
+	default COVERAGE_DUMP
+
 config COVERAGE_DUMP
-	bool "Dump coverage data on exit"
-	depends on COVERAGE_GCOV
+	bool "Dump coverage data to console on exit"
 	help
 	  Dump collected coverage information to console on exit.
+
+endchoice
+
+endif # COVERAGE_GCOV
 
 config FORCE_COVERAGE
 	bool "Force coverage"


### PR DESCRIPTION
Use `collections.defaultdict` to simplify code, and use the `bytes` type internally rather than hex strings.