### PR TITLE
drivers: dma: mcux_edma: convert address

### DIFF
--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -669,8 +669,8 @@ static int dma_mcux_edma_resume(const struct device *dev, uint32_t channel)
 static void dma_mcux_edma_update_hw_tcd(const struct device *dev, uint32_t channel, uint32_t src,
 					uint32_t dst, size_t size)
 {
-	EDMA_HW_TCD_SADDR(dev, channel) = src;
-	EDMA_HW_TCD_DADDR(dev, channel) = dst;
+	EDMA_HW_TCD_SADDR(dev, channel) = EDMA_MMAP_ADDR(src);
+	EDMA_HW_TCD_DADDR(dev, channel) = EDMA_MMAP_ADDR(dst);
 	EDMA_HW_TCD_BITER(dev, channel) = size;
 	EDMA_HW_TCD_CITER(dev, channel) = size;
 	EDMA_HW_TCD_CSR(dev, channel) |= DMA_CSR_DREQ(1U);


### PR DESCRIPTION
Convert address for dma when update tcd registers.
- This commit fixes a bug that dma reports source/destination bus errors when dma try to access the unconveted addresses. The unconverted addresses will be reserved address from dma view.