### PR TITLE
ci: workflows: codecov: run codecov workflow on push

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -1,8 +1,11 @@
 name: Code Coverage with codecov
 
 on:
-  schedule:
-    - cron: '25 06,18 * * *'
+  push:
+    branches:
+      - main
+      - v*-branch
+      - collab-*
 
 permissions:
   contents: read


### PR DESCRIPTION
Code coverage is currently executed and uploaded to codecov twice a day. Now that "twister on push" also uploads stuff (test results) to codecov, it is preferrable to have each push commit known to codecov to have both tests and coverage results for each push commit, since otherwise the "compare" feature that allows to see the delta between two commits might not work as expected (see [here](https://app.codecov.io/gh/zephyrproject-rtos/zephyr/commit/377926ca0d3a65e146db554fcc7321db3a0c6c74)).

<img width="745" height="138" alt="image" src="https://github.com/user-attachments/assets/01a449a2-2da8-4867-b723-042ec34a81a6" />

 Idea if that if all "push" commits have proper coverage we can get nice stats for how things improve / degraded between two merges, with file-by-file details

<img width="804" height="273" alt="image" src="https://github.com/user-attachments/assets/00e1cdf0-988b-49fa-af24-ee5b1d7dd921" />

Since we do an average of ~4 merge batches per day so overhead is pretty minimal.