### PR TITLE
soc: renesas: Enable secure security attribution for DMA module

### DIFF
--- a/soc/renesas/ra/ra4c1/soc.c
+++ b/soc/renesas/ra/ra4c1/soc.c
@@ -49,6 +49,7 @@ void soc_early_init_hook(void)
 	R_PSCU->PSARD = 0;
 	R_PSCU->PSARE = 0;
 
+	R_CPSCU->ICUSARC = 0;
 	R_CPSCU->ICUSARG = 0;
 	R_CPSCU->ICUSARH = 0;
 

--- a/soc/renesas/ra/ra4e1/soc.c
+++ b/soc/renesas/ra/ra4e1/soc.c
@@ -54,6 +54,7 @@ void soc_early_init_hook(void)
 	R_PSCU->PSARD = 0;
 	R_PSCU->PSARE = 0;
 
+	R_CPSCU->ICUSARC = 0;
 	R_CPSCU->ICUSARG = 0;
 	R_CPSCU->ICUSARH = 0;
 	R_CPSCU->ICUSARI = 0;

--- a/soc/renesas/ra/ra4e2/soc.c
+++ b/soc/renesas/ra/ra4e2/soc.c
@@ -54,6 +54,7 @@ void soc_early_init_hook(void)
 	R_PSCU->PSARD = 0;
 	R_PSCU->PSARE = 0;
 
+	R_CPSCU->ICUSARC = 0;
 	R_CPSCU->ICUSARG = 0;
 	R_CPSCU->ICUSARH = 0;
 	R_CPSCU->ICUSARI = 0;

--- a/soc/renesas/ra/ra4l1/soc.c
+++ b/soc/renesas/ra/ra4l1/soc.c
@@ -54,6 +54,7 @@ void soc_early_init_hook(void)
 	R_PSCU->PSARD = 0;
 	R_PSCU->PSARE = 0;
 
+	R_CPSCU->ICUSARC = 0;
 	R_CPSCU->ICUSARG = 0;
 	R_CPSCU->ICUSARH = 0;
 	R_CPSCU->ICUSARI = 0;

--- a/soc/renesas/ra/ra4m2/soc.c
+++ b/soc/renesas/ra/ra4m2/soc.c
@@ -54,6 +54,7 @@ void soc_early_init_hook(void)
 	R_PSCU->PSARD = 0;
 	R_PSCU->PSARE = 0;
 
+	R_CPSCU->ICUSARC = 0;
 	R_CPSCU->ICUSARG = 0;
 	R_CPSCU->ICUSARH = 0;
 	R_CPSCU->ICUSARI = 0;

--- a/soc/renesas/ra/ra4m3/soc.c
+++ b/soc/renesas/ra/ra4m3/soc.c
@@ -54,6 +54,7 @@ void soc_early_init_hook(void)
 	R_PSCU->PSARD = 0;
 	R_PSCU->PSARE = 0;
 
+	R_CPSCU->ICUSARC = 0;
 	R_CPSCU->ICUSARG = 0;
 	R_CPSCU->ICUSARH = 0;
 	R_CPSCU->ICUSARI = 0;

--- a/soc/renesas/ra/ra6e1/soc.c
+++ b/soc/renesas/ra/ra6e1/soc.c
@@ -55,6 +55,7 @@ void soc_early_init_hook(void)
 	R_PSCU->PSARD = 0;
 	R_PSCU->PSARE = 0;
 
+	R_CPSCU->ICUSARC = 0;
 	R_CPSCU->ICUSARG = 0;
 	R_CPSCU->ICUSARH = 0;
 	R_CPSCU->ICUSARI = 0;

--- a/soc/renesas/ra/ra6e2/soc.c
+++ b/soc/renesas/ra/ra6e2/soc.c
@@ -57,6 +57,7 @@ void soc_early_init_hook(void)
 	R_PSCU->PSARD = 0;
 	R_PSCU->PSARE = 0;
 
+	R_CPSCU->ICUSARC = 0;
 	R_CPSCU->ICUSARG = 0;
 	R_CPSCU->ICUSARH = 0;
 	R_CPSCU->ICUSARI = 0;

--- a/soc/renesas/ra/ra6m4/soc.c
+++ b/soc/renesas/ra/ra6m4/soc.c
@@ -57,6 +57,7 @@ void soc_early_init_hook(void)
 	R_PSCU->PSARD = 0;
 	R_PSCU->PSARE = 0;
 
+	R_CPSCU->ICUSARC = 0;
 	R_CPSCU->ICUSARG = 0;
 	R_CPSCU->ICUSARH = 0;
 	R_CPSCU->ICUSARI = 0;

--- a/soc/renesas/ra/ra6m5/soc.c
+++ b/soc/renesas/ra/ra6m5/soc.c
@@ -56,6 +56,7 @@ void soc_early_init_hook(void)
 	R_PSCU->PSARC = 0;
 	R_PSCU->PSARD = 0;
 	R_PSCU->PSARE = 0;
+	R_CPSCU->ICUSARC = 0;
 
 	/* The secure Attribute managed within the ARM CPU NVIC must match the
 	 * security attribution of IELSEn registers (Reference section 13.2.9


### PR DESCRIPTION
Currently, the DMA on several Renesas boards is failing due to the security attribution of DMA

As a solution: Enable secure security attribution for DMA module for:
- RA6: `ra6e1`, `ra6e2`, `ra6m4`, `ra6m5`
- RA4: `ra4c1`, `ra4e1`, `ra4e2`, `ra4l1`, `ra4m2`, `ra4m3`