### PR TITLE
RFC: MSPI CE control rework and CE timing support

### DIFF
--- a/boards/ambiq/apollo510_evb/apollo510_evb.dts
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.dts
@@ -180,7 +180,9 @@
 		rx-dummy = <7>;
 		tx-dummy = <8>;
 		xip-config = <1 0 DT_SIZE_M(64) 0>;
-		ce-break-config = <1024 4>;
+		memory-boundary = <1024>;
+		mspi-ce-max-active = <4>;
+		mspi-ce-setup = <3>;
 		ambiq,timing-config-mask = <0x62>;
 		ambiq,timing-config = <8 7 1 0 0 3 10>;
 		zephyr,pm-device-runtime-auto;
@@ -219,7 +221,6 @@
 		rx-dummy = <16>;
 		tx-dummy = <0>;
 		xip-config = <1 0 DT_SIZE_M(8) 0>;
-		ce-break-config = <0 0>;
 		ambiq,timing-config-mask = <0x62>;
 		ambiq,timing-config = <0 16 1 0 0 5 20>;
 	};

--- a/drivers/flash/flash_mspi_atxp032.c
+++ b/drivers/flash/flash_mspi_atxp032.c
@@ -800,13 +800,12 @@ static DEVICE_API(flash, flash_mspi_atxp032_api) = {
 
 #define MSPI_DEVICE_CONFIG_SERIAL(n)                                                              \
 	{                                                                                         \
-		.ce_num             = DT_INST_PROP(n, mspi_hardware_ce_num),                      \
+		.ce                 = MSPI_DEVICE_CE_DT_INST(n),                                  \
 		.freq               = 12000000,                                                   \
 		.io_mode            = MSPI_IO_MODE_SINGLE,                                        \
 		.data_rate          = MSPI_DATA_RATE_SINGLE,                                      \
 		.cpp                = MSPI_CPP_MODE_0,                                            \
 		.endian             = MSPI_XFER_LITTLE_ENDIAN,                                    \
-		.ce_polarity        = MSPI_CE_ACTIVE_LOW,                                         \
 		.dqs_enable         = false,                                                      \
 		.rx_dummy           = 8,                                                          \
 		.tx_dummy           = 0,                                                          \
@@ -815,7 +814,7 @@ static DEVICE_API(flash, flash_mspi_atxp032_api) = {
 		.cmd_length         = 1,                                                          \
 		.addr_length        = 4,                                                          \
 		.mem_boundary       = 0,                                                          \
-		.time_to_break      = 0,                                                          \
+		.ce_timing          = MSPI_DEVICE_CE_TIMING_DT_INST(n),                           \
 	}
 
 #define MSPI_TIMING_CONFIG(n)                                                                     \

--- a/drivers/flash/flash_mspi_is25xX0xx.c
+++ b/drivers/flash/flash_mspi_is25xX0xx.c
@@ -951,7 +951,10 @@ static int flash_mspi_is25xX0xx_read_jedec_id(const struct device *flash, uint8_
 {
 	struct flash_mspi_is25xX0xx_data *data = flash->data;
 
-	id = &data->id;
+	if (id == NULL) {
+		return -EINVAL;
+	}
+	memcpy(id, data->id, MIN(3, sizeof(data->id)));
 	return 0;
 }
 #endif /* CONFIG_FLASH_JESD216_API */
@@ -972,13 +975,12 @@ static DEVICE_API(flash, flash_mspi_is25xX0xx_api) = {
 
 #define MSPI_DEVICE_CONFIG_SERIAL(n)                                                              \
 	{                                                                                         \
-		.ce_num             = DT_INST_PROP(n, mspi_hardware_ce_num),                      \
+		.ce                 = MSPI_DEVICE_CE_DT_INST(n),                                  \
 		.freq               = 12000000,                                                   \
 		.io_mode            = MSPI_IO_MODE_SINGLE,                                        \
 		.data_rate          = MSPI_DATA_RATE_SINGLE,                                      \
 		.cpp                = MSPI_CPP_MODE_0,                                            \
 		.endian             = MSPI_XFER_LITTLE_ENDIAN,                                    \
-		.ce_polarity        = MSPI_CE_ACTIVE_LOW,                                         \
 		.dqs_enable         = false,                                                      \
 		.rx_dummy           = 8,                                                          \
 		.tx_dummy           = 0,                                                          \
@@ -987,7 +989,7 @@ static DEVICE_API(flash, flash_mspi_is25xX0xx_api) = {
 		.cmd_length         = 1,                                                          \
 		.addr_length        = 3,                                                          \
 		.mem_boundary       = 0,                                                          \
-		.time_to_break      = 0,                                                          \
+		.ce_timing          = MSPI_DEVICE_CE_TIMING_DT_INST(n),                           \
 	}
 
 #define MSPI_TIMING_CONFIG(n)                                                                     \

--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -1237,14 +1237,14 @@ static DEVICE_API(flash, drv_api) = {
 
 #define FLASH_INITIAL_CONFIG(inst)					\
 {									\
-	.ce_num = DT_INST_PROP_OR(inst, mspi_hardware_ce_num, 0),	\
+	.ce = MSPI_DEVICE_CE_DT_INST(inst),				\
 	.freq = MIN(DT_INST_PROP(inst, mspi_max_frequency), MHZ(50)),	\
 	.io_mode = MSPI_IO_MODE_SINGLE,					\
 	.data_rate = MSPI_DATA_RATE_SINGLE,				\
 	.cpp = MSPI_CPP_MODE_0,						\
 	.endian = MSPI_XFER_BIG_ENDIAN,					\
-	.ce_polarity = MSPI_CE_ACTIVE_LOW,				\
 	.dqs_enable = false,						\
+	.ce_timing = MSPI_DEVICE_CE_TIMING_DT_INST(inst),		\
 }
 
 #define FLASH_QUIRKS(inst) FLASH_MSPI_QUIRKS_GET(DT_DRV_INST(inst))

--- a/drivers/memc/memc_mspi_aps6404l.c
+++ b/drivers/memc/memc_mspi_aps6404l.c
@@ -381,13 +381,12 @@ static int memc_mspi_aps6404l_init(const struct device *psram)
 
 #define MSPI_DEVICE_CONFIG_SERIAL(n)                                                              \
 	{                                                                                         \
-		.ce_num             = DT_INST_PROP(n, mspi_hardware_ce_num),                      \
+		.ce                 = MSPI_DEVICE_CE_DT_INST(n),                                  \
 		.freq               = 12000000,                                                   \
 		.io_mode            = MSPI_IO_MODE_SINGLE,                                        \
 		.data_rate          = MSPI_DATA_RATE_SINGLE,                                      \
 		.cpp                = MSPI_CPP_MODE_0,                                            \
 		.endian             = MSPI_XFER_LITTLE_ENDIAN,                                    \
-		.ce_polarity        = MSPI_CE_ACTIVE_LOW,                                         \
 		.dqs_enable         = false,                                                      \
 		.rx_dummy           = 8,                                                          \
 		.tx_dummy           = 0,                                                          \
@@ -396,18 +395,17 @@ static int memc_mspi_aps6404l_init(const struct device *psram)
 		.cmd_length         = 1,                                                          \
 		.addr_length        = 3,                                                          \
 		.mem_boundary       = 1024,                                                       \
-		.time_to_break      = 8,                                                          \
+		.ce_timing          = MSPI_DEVICE_CE_TIMING_DT_INST(n),                           \
 	}
 
 #define MSPI_DEVICE_CONFIG_QUAD(n)                                                                \
 	{                                                                                         \
-		.ce_num             = DT_INST_PROP(n, mspi_hardware_ce_num),                      \
+		.ce                 = MSPI_DEVICE_CE_DT_INST(n),                                  \
 		.freq               = 24000000,                                                   \
 		.io_mode            = MSPI_IO_MODE_SINGLE,                                        \
 		.data_rate          = MSPI_DATA_RATE_SINGLE,                                      \
 		.cpp                = MSPI_CPP_MODE_0,                                            \
 		.endian             = MSPI_XFER_LITTLE_ENDIAN,                                    \
-		.ce_polarity        = MSPI_CE_ACTIVE_LOW,                                         \
 		.dqs_enable         = false,                                                      \
 		.rx_dummy           = 6,                                                          \
 		.tx_dummy           = 0,                                                          \
@@ -416,7 +414,7 @@ static int memc_mspi_aps6404l_init(const struct device *psram)
 		.cmd_length         = 1,                                                          \
 		.addr_length        = 3,                                                          \
 		.mem_boundary       = 1024,                                                       \
-		.time_to_break      = 4,                                                          \
+		.ce_timing          = MSPI_DEVICE_CE_TIMING_DT_INST(n),                           \
 	}
 
 #define MSPI_TIMING_CONFIG(n)                                                                     \

--- a/drivers/memc/memc_mspi_aps_z8.c
+++ b/drivers/memc/memc_mspi_aps_z8.c
@@ -553,13 +553,12 @@ static int memc_mspi_aps_z8_init(const struct device *psram)
 
 #define MSPI_DEVICE_CONFIG_OCTAL(n)                                                               \
 	{                                                                                         \
-		.ce_num             = DT_INST_PROP(n, mspi_hardware_ce_num),                      \
+		.ce                 = MSPI_DEVICE_CE_DT_INST(n),                                  \
 		.freq               = 24000000,                                                   \
 		.io_mode            = MSPI_IO_MODE_OCTAL,                                         \
 		.data_rate          = MSPI_DATA_RATE_S_D_D,                                       \
 		.cpp                = MSPI_CPP_MODE_0,                                            \
 		.endian             = MSPI_XFER_LITTLE_ENDIAN,                                    \
-		.ce_polarity        = MSPI_CE_ACTIVE_LOW,                                         \
 		.dqs_enable         = DT_INST_PROP(n, mspi_dqs_enable),                           \
 		.rx_dummy           = MEMC_MSPI_APS_Z8_RX_DUMMY_DEFAULT,                          \
 		.tx_dummy           = MEMC_MSPI_APS_Z8_TX_DUMMY_DEFAULT,                          \
@@ -568,7 +567,7 @@ static int memc_mspi_aps_z8_init(const struct device *psram)
 		.cmd_length         = MEMC_MSPI_APS_Z8_CMD_LENGTH_DEFAULT,                        \
 		.addr_length        = MEMC_MSPI_APS_Z8_ADDR_LENGTH_DEFAULT,                       \
 		.mem_boundary       = 1024,                                                       \
-		.time_to_break      = 4,                                                          \
+		.ce_timing          = MSPI_DEVICE_CE_TIMING_DT_INST(n),                           \
 	}
 #define MSPI_TIMING_CONFIG(n)                                                                     \
 	COND_CODE_1(CONFIG_SOC_FAMILY_AMBIQ,                                                      \

--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -599,9 +599,9 @@ static int _api_dev_config(const struct device *dev,
 		}
 	}
 
-	if (param_mask & MSPI_DEVICE_CONFIG_CE_POL) {
-		if (cfg->ce_polarity != MSPI_CE_ACTIVE_LOW) {
-			LOG_ERR("Only active low CE is supported.");
+	if (param_mask & MSPI_DEVICE_CONFIG_CE) {
+		if (cfg->ce.ce_mode != MSPI_CE_MODE_GPIO) {
+			LOG_ERR("Only GPIO CE is supported.");
 			return -ENOTSUP;
 		}
 	}
@@ -613,11 +613,12 @@ static int _api_dev_config(const struct device *dev,
 		}
 	}
 
-	if (param_mask & MSPI_DEVICE_CONFIG_BREAK_TIME) {
-		if (cfg->time_to_break) {
+	if (param_mask & MSPI_DEVICE_CONFIG_CE_TIMING) {
+		if (cfg->ce_timing.t_ce_max_act) {
 			LOG_ERR("Auto CE break is not supported.");
 			return -ENOTSUP;
 		}
+		LOG_WRN("CE timing configuration is ignored.");
 	}
 
 	if (param_mask & MSPI_DEVICE_CONFIG_IO_MODE) {

--- a/drivers/mspi/mspi_emul.c
+++ b/drivers/mspi/mspi_emul.c
@@ -209,8 +209,8 @@ static inline int mspi_dev_cfg_check_save(const struct device *controller,
 {
 	struct mspi_emul_data *data = controller->data;
 
-	if (param_mask & MSPI_DEVICE_CONFIG_CE_NUM) {
-		data->dev_cfg.ce_num = dev_cfg->ce_num;
+	if (param_mask & MSPI_DEVICE_CONFIG_CE) {
+		data->dev_cfg.ce = dev_cfg->ce;
 	}
 
 	if (param_mask & MSPI_DEVICE_CONFIG_FREQUENCY) {
@@ -253,13 +253,6 @@ static inline int mspi_dev_cfg_check_save(const struct device *controller,
 		data->dev_cfg.endian = dev_cfg->endian;
 	}
 
-	if (param_mask & MSPI_DEVICE_CONFIG_CE_POL) {
-		if (dev_cfg->ce_polarity > MSPI_CE_ACTIVE_HIGH) {
-			LOG_ERR("%u, Invalid ce_polarity.", __LINE__);
-			return -EINVAL;
-		}
-		data->dev_cfg.ce_polarity = dev_cfg->ce_polarity;
-	}
 
 	if (param_mask & MSPI_DEVICE_CONFIG_DQS) {
 		if (dev_cfg->dqs_enable && !data->mspicfg.dqs_support) {
@@ -297,8 +290,8 @@ static inline int mspi_dev_cfg_check_save(const struct device *controller,
 		data->dev_cfg.mem_boundary = dev_cfg->mem_boundary;
 	}
 
-	if (param_mask & MSPI_DEVICE_CONFIG_BREAK_TIME) {
-		data->dev_cfg.time_to_break = dev_cfg->time_to_break;
+	if (param_mask & MSPI_DEVICE_CONFIG_CE_TIMING) {
+		data->dev_cfg.ce_timing = dev_cfg->ce_timing;
 	}
 
 	return 0;
@@ -886,16 +879,8 @@ static struct emul_mspi_driver_api emul_mspi_driver_api = {
 		.mspicfg.num_ce_gpios  = ARRAY_SIZE(ce_gpios##n),                                 \
 		.mspicfg.num_periph    = DT_INST_CHILD_NUM(n),                                    \
 		.mspicfg.re_init       = false,                                                   \
-		.dev_id                = 0,                                                       \
 		.lock                  = Z_MUTEX_INITIALIZER(mspi_emul_data_##n.lock),            \
-		.dev_cfg               = {0},                                                     \
-		.xip_cfg               = {0},                                                     \
-		.scramble_cfg          = {0},                                                     \
-		.cbs                   = {0},                                                     \
-		.cb_ctxs               = {0},                                                     \
 		.ctx.lock              = Z_SEM_INITIALIZER(mspi_emul_data_##n.ctx.lock, 0, 1),    \
-		.ctx.callback          = 0,                                                       \
-		.ctx.callback_ctx      = 0,                                                       \
 	};                                                                                        \
 	DEVICE_DT_INST_DEFINE(n,                                                                  \
 			      &mspi_emul_init,                                                    \

--- a/dts/bindings/mspi/mspi-device.yaml
+++ b/dts/bindings/mspi/mspi-device.yaml
@@ -193,20 +193,30 @@ properties:
         .size           = 0;
       >
 
-  ce-break-config:
-    type: array
+  memory-boundary:
+    type: int
     description: |
-      Array of parameters to configure the auto CE break feature.
-      mem_boundary: Memory boundary in bytes of a device that a transfer
-                    should't cross.
-      time_to_break: The maximum time of a transfer should't exceed for
-                     a device in micro seconds(us).
+      The Device memory boundary in bytes. This can be used for controller to
+      determine when to automatically break a transfer in to two.
 
-      This is typically used with devices that has memory boundaries or
-      requires periodic internal refresh. e.g. psram
+  mspi-ce-max-active:
+    type: int
+    description: |
+      The maximum CE active time, previously was time_to_break.
+      The maximum time of a transfer should't exceed for a device
+      in micro seconds(us).
 
-      default =
-      <
-        .mem_boundary    = 0;
-        .time_to_break   = 0;
-      >
+  mspi-ce-setup:
+    type: int
+    description: |
+      The minimum CE active time before the first CLK active edge in nano seconds(ns).
+
+  mspi-ce-hold:
+    type: int
+    description: |
+      The minimum CE active time after the last CLK active edge nano seconds(ns).
+
+  mspi-ce-min-inactive:
+    type: int
+    description: |
+      The minimum CE inactive time between transfers in nano seconds(ns).

--- a/dts/bindings/mspi/zephyr,mspi-emul-device.yaml
+++ b/dts/bindings/mspi/zephyr,mspi-emul-device.yaml
@@ -16,6 +16,3 @@ properties:
 
   scramble-config:
     default: [0, 0, 0]
-
-  ce-break-config:
-    default: [0, 0]

--- a/include/zephyr/drivers/mspi/devicetree.h
+++ b/include/zephyr/drivers/mspi/devicetree.h
@@ -21,6 +21,65 @@ extern "C" {
 #endif
 
 /**
+ * @brief Structure initializer for <tt>struct mspi_ce</tt> from devicetree
+ *
+ * This helper macro expands to a static initializer for a <tt>struct
+ * mspi_ce</tt> by reading the relevant data from the devicetree.
+ *
+ * @param mspi_dev Devicetree node identifier for the MSPI device whose
+ *                 struct mspi_ce to create an initializer for
+ */
+#define MSPI_DEVICE_CE_DT(mspi_dev)                                                               \
+	COND_CODE_1(DT_NODE_HAS_PROP(mspi_dev, mspi_hardware_ce_num),                             \
+		({                                                                                \
+			.ce_num      = DT_PROP(mspi_dev, mspi_hardware_ce_num),                   \
+			.ce_polarity = DT_ENUM_IDX_OR(mspi_dev, mspi_ce_polarity,                 \
+							MSPI_CE_ACTIVE_LOW),                      \
+			.ce_mode     = MSPI_CE_MODE_HARDWARE,                                     \
+		}),                                                                               \
+		({                                                                                \
+			.gpio        = MSPI_DEV_CE_GPIOS_DT_SPEC_GET(mspi_dev),                   \
+			.ce_mode     = MSPI_CE_MODE_GPIO,                                         \
+		}))
+
+/**
+ * @brief Structure initializer for <tt>struct mspi_ce</tt> from devicetree instance
+ *
+ * This is equivalent to
+ * <tt>MSPI_DEVICE_CE_DT(DT_DRV_INST(inst))</tt>.
+ *
+ * @param inst Devicetree instance number
+ */
+#define MSPI_DEVICE_CE_DT_INST(inst) MSPI_DEVICE_CE_DT(DT_DRV_INST(inst))
+
+/**
+ * @brief Structure initializer for <tt>struct mspi_ce_timing</tt> from devicetree
+ *
+ * This helper macro expands to a static initializer for a <tt>struct
+ * ce_timing</tt> by reading the relevant data from the devicetree.
+ *
+ * @param mspi_dev Devicetree node identifier for the MSPI device whose
+ *                 struct mspi_ce_timing to create an initializer for
+ */
+#define MSPI_DEVICE_CE_TIMING_DT(mspi_dev)                                                        \
+	{                                                                                         \
+		.t_ce_max_act   = DT_PROP_OR(mspi_dev, mspi_ce_max_active, 0),                    \
+		.t_ce_setup     = DT_PROP_OR(mspi_dev, mspi_ce_setup, 0),                         \
+		.t_ce_hold      = DT_PROP_OR(mspi_dev, mspi_ce_hold, 0),                          \
+		.t_ce_min_inact = DT_PROP_OR(mspi_dev, mspi_ce_min_inactive, 0),                  \
+	}
+
+/**
+ * @brief Structure initializer for <tt>struct ce_timing</tt> from devicetree instance
+ *
+ * This is equivalent to
+ * <tt>MSPI_DEVICE_CE_TIMING_DT(DT_DRV_INST(inst))</tt>.
+ *
+ * @param inst Devicetree instance number
+ */
+#define MSPI_DEVICE_CE_TIMING_DT_INST(inst) MSPI_DEVICE_CE_TIMING_DT(DT_DRV_INST(inst))
+
+/**
  * @brief Structure initializer for <tt>struct mspi_dev_cfg</tt> from devicetree
  *
  * This helper macro expands to a static initializer for a <tt>struct
@@ -31,7 +90,7 @@ extern "C" {
  */
 #define MSPI_DEVICE_CONFIG_DT(mspi_dev)                                                           \
 	{                                                                                         \
-		.ce_num               = DT_PROP_OR(mspi_dev, mspi_hardware_ce_num, 0),            \
+		.ce                   = MSPI_DEVICE_CE_DT(mspi_dev),                              \
 		.freq                 = DT_PROP(mspi_dev, mspi_max_frequency),                    \
 		.io_mode              = DT_ENUM_IDX_OR(mspi_dev, mspi_io_mode,                    \
 						MSPI_IO_MODE_SINGLE),                             \
@@ -40,8 +99,6 @@ extern "C" {
 		.cpp                  = DT_ENUM_IDX_OR(mspi_dev, mspi_cpp_mode, MSPI_CPP_MODE_0), \
 		.endian               = DT_ENUM_IDX_OR(mspi_dev, mspi_endian,                     \
 						MSPI_XFER_LITTLE_ENDIAN),                         \
-		.ce_polarity          = DT_ENUM_IDX_OR(mspi_dev, mspi_ce_polarity,                \
-						MSPI_CE_ACTIVE_LOW),                              \
 		.dqs_enable           = DT_PROP(mspi_dev, mspi_dqs_enable),                       \
 		.rx_dummy             = DT_PROP_OR(mspi_dev, rx_dummy, 0),                        \
 		.tx_dummy             = DT_PROP_OR(mspi_dev, tx_dummy, 0),                        \
@@ -49,12 +106,8 @@ extern "C" {
 		.write_cmd            = DT_PROP_OR(mspi_dev, write_command, 0),                   \
 		.cmd_length           = DT_ENUM_IDX_OR(mspi_dev, command_length, 0),              \
 		.addr_length          = DT_ENUM_IDX_OR(mspi_dev, address_length, 0),              \
-		.mem_boundary         = COND_CODE_1(DT_NODE_HAS_PROP(mspi_dev, ce_break_config),  \
-						(DT_PROP_BY_IDX(mspi_dev, ce_break_config, 0)),   \
-						(0)),                                             \
-		.time_to_break        = COND_CODE_1(DT_NODE_HAS_PROP(mspi_dev, ce_break_config),  \
-						(DT_PROP_BY_IDX(mspi_dev, ce_break_config, 1)),   \
-						(0)),                                             \
+		.mem_boundary         = DT_PROP_OR(mspi_dev, memory_boundary, 0),                 \
+		.ce_timing            = MSPI_DEVICE_CE_TIMING_DT(mspi_dev),                       \
 	}
 
 /**
@@ -256,64 +309,6 @@ extern "C" {
  */
 #define MSPI_CE_GPIOS_DT_SPEC_INST_GET(inst)                                                      \
 		MSPI_CE_GPIOS_DT_SPEC_GET(DT_DRV_INST(inst))
-
-/**
- * @brief Initialize and get a pointer to a @p mspi_ce_control from a
- *        devicetree node identifier
- *
- * This helper is useful for initializing a device on a MSPI bus. It
- * initializes a struct mspi_ce_control and returns a pointer to it.
- * Here, @p node_id is a node identifier for a MSPI device, not a MSPI
- * controller.
- *
- * Example devicetree fragment:
- *
- * @code{.devicetree}
- *     mspi@abcd0001 {
- *             ce-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
- *             mspidev: mspi-device@0 { ... };
- *     };
- * @endcode
- *
- * Example usage:
- *
- * @code{.c}
- *     struct mspi_ce_control ctrl =
- *             MSPI_CE_CONTROL_INIT(DT_NODELABEL(mspidev), 2);
- * @endcode
- *
- * This example is equivalent to:
- *
- * @code{.c}
- *     struct mspi_ce_control ctrl = {
- *             .gpio = MSPI_DEV_CE_GPIOS_DT_SPEC_GET(DT_NODELABEL(mspidev)),
- *             .delay = 2,
- *     };
- * @endcode
- *
- * @param node_id Devicetree node identifier for a device on a MSPI bus
- * @param delay_ The @p delay field to set in the @p mspi_ce_control
- * @return a pointer to the @p mspi_ce_control structure
- */
-#define MSPI_CE_CONTROL_INIT(node_id, delay_)                                                     \
-	{                                                                                         \
-		.gpio = MSPI_DEV_CE_GPIOS_DT_SPEC_GET(node_id), .delay = (delay_),                \
-	}
-
-/**
- * @brief Get a pointer to a @p mspi_ce_control from a devicetree node
- *
- * This is equivalent to
- * <tt>MSPI_CE_CONTROL_INIT(DT_DRV_INST(inst), delay)</tt>.
- *
- * Therefore, @p DT_DRV_COMPAT must already be defined before using
- * this macro.
- *
- * @param inst Devicetree node instance number
- * @param delay_ The @p delay field to set in the @p mspi_ce_control
- * @return a pointer to the @p mspi_ce_control structure
- */
-#define MSPI_CE_CONTROL_INIT_INST(inst, delay_) MSPI_CE_CONTROL_INIT(DT_DRV_INST(inst), delay_)
 
 #ifdef __cplusplus
 }

--- a/samples/drivers/memc/boards/apollo3p_evb.overlay
+++ b/samples/drivers/memc/boards/apollo3p_evb.overlay
@@ -48,7 +48,8 @@
 		rx-dummy = <6>;
 		tx-dummy = <0>;
 		xip-config = <1 0 0 0>;
-		ce-break-config = <1024 3>;
+		memory-boundary = <1024>;
+		mspi-ce-max-active = <3>;
 		ambiq,timing-config-mask = <3>;
 		ambiq,timing-config = <0 6 0 0 0 0 0 0>;
 	};

--- a/samples/drivers/mspi/mspi_async/boards/apollo3p_evb.overlay
+++ b/samples/drivers/mspi/mspi_async/boards/apollo3p_evb.overlay
@@ -48,7 +48,8 @@
 		rx-dummy = <6>;
 		tx-dummy = <0>;
 		xip-config = <1 0 0 0>;
-		ce-break-config = <1024 3>;
+		memory-boundary = <1024>;
+		mspi-ce-max-active = <3>;
 		ambiq,timing-config-mask = <3>;
 		ambiq,timing-config = <0 6 0 0 0 0 0 0>;
 	};

--- a/samples/drivers/mspi/mspi_flash/boards/apollo3p_evb.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/apollo3p_evb.overlay
@@ -49,7 +49,8 @@
 		rx-dummy = <6>;
 		tx-dummy = <0>;
 		xip-config = <1 0 0 0>;
-		ce-break-config = <1024 3>;
+		memory-boundary = <1024>;
+		mspi-ce-max-active = <3>;
 		ambiq,timing-config-mask = <3>;
 		ambiq,timing-config = <0 6 0 0 0 0 0 0>;
 	};
@@ -70,7 +71,6 @@
 		rx-dummy = <8>;
 		tx-dummy = <0>;
 		xip-config = <1 0 0 0>;
-		ce-break-config = <0 0>;
 		ambiq,timing-config-mask = <3>;
 		ambiq,timing-config = <0 8 0 0 0 0 0 0>;
 	};

--- a/tests/drivers/mspi/api/boards/native_sim.overlay
+++ b/tests/drivers/mspi/api/boards/native_sim.overlay
@@ -16,5 +16,9 @@
 		compatible = "zephyr,mspi-emul-device";
 		reg = <0x0>;
 		mspi-max-frequency = <48000000>;
+		mspi-ce-max-active = <10>;
+		mspi-ce-setup = <2>;
+		mspi-ce-hold = <2>;
+		mspi-ce-min-inactive = <2>;
 	};
 };

--- a/tests/drivers/mspi/flash/boards/apollo3p_evb.overlay
+++ b/tests/drivers/mspi/flash/boards/apollo3p_evb.overlay
@@ -43,7 +43,8 @@
 		rx-dummy = <8>;
 		tx-dummy = <0>;
 		xip-config = <1 0 0 0>;
-		ce-break-config = <0 0>;
+		memory-boundary = <1024>;
+		mspi-ce-max-active = <3>;
 		ambiq,timing-config-mask = <3>;
 		ambiq,timing-config = <0 8 0 0 0 0 0 0>;
 	};

--- a/tests/drivers/mspi/flash/boards/native_sim.overlay
+++ b/tests/drivers/mspi/flash/boards/native_sim.overlay
@@ -26,12 +26,14 @@
 		mspi-io-mode = "MSPI_IO_MODE_QUAD";
 		mspi-data-rate = "MSPI_DATA_RATE_SINGLE";
 		mspi-hardware-ce-num = <0>;
+		mspi-ce-polarity = "MSPI_CE_ACTIVE_HIGH";
 		read-command = <0x0B>;
 		write-command = <0x02>;
 		command-length = "INSTR_1_BYTE";
 		address-length = "ADDR_4_BYTE";
 		rx-dummy = <8>;
 		tx-dummy = <0>;
+		memory-boundary = <0>;
 	};
 
 	flash_dummy1: flash_dummy1@1 {
@@ -43,6 +45,11 @@
 		mspi-io-mode = "MSPI_IO_MODE_OCTAL";
 		mspi-data-rate = "MSPI_DATA_RATE_DUAL";
 		mspi-hardware-ce-num = <1>;
+		mspi-ce-polarity = "MSPI_CE_ACTIVE_LOW";
+		mspi-ce-max-active = <10>;
+		mspi-ce-setup = <2>;
+		mspi-ce-hold = <2>;
+		mspi-ce-min-inactive = <2>;
 		mspi-dqs-enable;
 		read-command = <0x20>;
 		write-command = <0xAA>;
@@ -51,6 +58,6 @@
 		rx-dummy = <6>;
 		tx-dummy = <5>;
 		xip-config = <1 0 0 0>;
-		ce-break-config = <1024 4>;
+		memory-boundary = <1024>;
 	};
 };


### PR DESCRIPTION
### Introduction
This RFC proposes a breaking update to the MSPI subsystem to make Chip Enable (CE) behavior explicit and portable across controllers, and to provide device-specific CE timing configuration. The MSPI API is bumped to 0.2.0.

### Problem Description
- CE control was implicit, leading to inconsistent behavior across controllers, fragile multi-device support, and difficulty expressing controller limitations (GPIO vs HW CE).
- There was no standardized way to set CE timing (setup, hold, inactive, max-active)
- The `struct mspi_ce_control` model copied from `struct spi_ce_control` is no longer sufficient.

### Proposed change
Please checkout the detail here : d2f0da3edd6209eea8504715c78636b2ff0e858e
- Add explicit CE description in `struct mspi_ce` which will include gpio or hardware ce property that includes removed ce_num and ce_polarity in `struct mspi_dev_cfg`
- Add `struct mspi_ce_timing` in `struct mspi_dev_cfg` as these are device specific and can be found on device datasheets.
- Remove `struct mspi_ce_control`

### Concerns and Unresolved Questions
- Not sure about out of trees useage of MSPI API at this point.
- Should probably find better way to validate child and child number than using ce-gpios. Changes to `struct mspi_dev_id` seems necessary as it has a duplicated gpio_dt_spec with this addition.

The effect of this breaking change should be minimal.