### PR TITLE
MAINTAINERS: add missing TF-M collaborators to all repositories

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5812,6 +5812,8 @@ West:
   collaborators:
     - Vge0rge
     - wearyzen
+    - valeriosetti
+    - tomi-font
     - ithinuel
   files: []
   labels:
@@ -5847,6 +5849,8 @@ West:
   collaborators:
     - Vge0rge
     - wearyzen
+    - valeriosetti
+    - tomi-font
     - ithinuel
   files: []
   labels:


### PR DESCRIPTION
Add all the `West project: trusted-firmware-m` collaborators to `tf-m-tests` and `psa-arch-tests`. They are repositories highly related to TF-M.