### PR TITLE
boards: kincony: kincony_kc868_a32: use common partition table

### DIFF
--- a/boards/kincony/kincony_kc868_a32/kincony_kc868_a32_procpu.dts
+++ b/boards/kincony/kincony_kc868_a32/kincony_kc868_a32_procpu.dts
@@ -7,6 +7,7 @@
 
 #include <espressif/esp32/esp32_wroom_32ue_n4.dtsi>
 #include "kincony_kc868_a32-pinctrl.dtsi"
+#include <espressif/partitions_0x1000_amp.dtsi>
 
 / {
 	model = "Kincony KC868_A32 PROCPU";
@@ -164,46 +165,6 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&uart0_default>;
 	pinctrl-names = "default";
-};
-
-&flash0 {
-	status = "okay";
-
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@1000 {
-			label = "mcuboot";
-			reg = <0x00001000 0x0000F000>;
-			read-only;
-		};
-
-		/* Reserve 1024kB for the application in slot 0 */
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x00010000 0x00100000>;
-		};
-
-		/* Reserve 1024kB for the application in slot 1 */
-		slot1_partition: partition@110000 {
-			label = "image-1";
-			reg = <0x00110000 0x00100000>;
-		};
-
-		/* Reserve 256kB for the scratch partition */
-		scratch_partition: partition@210000 {
-			label = "image-scratch";
-			reg = <0x00210000 0x00040000>;
-		};
-
-		storage_partition: partition@250000 {
-			label = "storage";
-			reg = <0x00250000 0x00006000>;
-		};
-	};
 };
 
 &esp32_bt_hci {


### PR DESCRIPTION
A follow up to commit 78c1def4db53302823be34a321a2118bf08c9bd4 that probably missed this file.

Fixes CI issues observed in weekly run:
- kincony_kc868_a32/esp32/procpu:libraries.devicetree.api_ext