### PR TITLE
Create art_pi.overlay

### DIFF
--- a/samples/sysbuild/with_mcuboot/boards/art_pi.overlay
+++ b/samples/sysbuild/with_mcuboot/boards/art_pi.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Dejiang He <hedejiang9@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Define the device, controller and partition to be the external memory
+ * for running the application in external NOR from MCUboot
+ */
+/ {
+	chosen {
+		zephyr,flash = &w25q64_qspi;
+		zephyr,flash-controller = &w25q64_qspi;
+		zephyr,code-partition = &slot0_partition;
+	};
+};


### PR DESCRIPTION
support art_pi   

mcuboot  pr :
https://github.com/zephyrproject-rtos/mcuboot/pull/136

art_pi pr  :
https://github.com/zephyrproject-rtos/zephyr/pull/96139


building cmd

```
west build -p always -b art_pi samples/sysbuild/with_mcuboot \
--sysbuild -- \
-DSB_CONFIG_BOOTLOADER_MCUBOOT=y

```

building 

```
-- Zephyr version: 4.2.99 (/home/hdj/zephyrproject/zephyr), build: v4.2.0-3810-g9fe29f98ae2d
[286/286] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       43024 B       128 KB     32.82%
             RAM:       87296 B       512 KB     16.65%
          EXTMEM:          0 GB        64 MB      0.00%
           SRAM1:          0 GB       128 KB      0.00%
           SRAM2:          0 GB       128 KB      0.00%
           SRAM4:          0 GB        64 KB      0.00%
            DTCM:          0 GB       128 KB      0.00%
            ITCM:          0 GB        64 KB      0.00%
           SRAM3:          0 GB        32 KB      0.00%
          SDRAM1:          0 GB         6 MB      0.00%
        IDT_LIST:          0 GB        32 KB      0.00%
Generating files from /home/hdj/zephyrproject/zephyr/build/mcuboot/zephyr/zephyr.elf for board: art_pi
[11/16] Performing build step for 'with_mcuboot'
[1/148] Preparing syscall dependency handling

[2/148] Generating include/generated/zephyr/version.h
-- Zephyr version: 4.2.99 (/home/hdj/zephyrproject/zephyr), build: v4.2.0-3810-g9fe29f98ae2d
[148/148] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       20048 B    2096768 B      0.96%
             RAM:        4608 B       512 KB      0.88%
          EXTMEM:          0 GB        64 MB      0.00%
           SRAM1:          0 GB       128 KB      0.00%
           SRAM2:          0 GB       128 KB      0.00%
           SRAM4:          0 GB        64 KB      0.00%
            DTCM:          0 GB       128 KB      0.00%
            ITCM:          0 GB        64 KB      0.00%
           SRAM3:          0 GB        32 KB      0.00%
          SDRAM1:          0 GB         6 MB      0.00%
        IDT_LIST:          0 GB        32 KB      0.00%
Generating files from /home/hdj/zephyrproject/zephyr/build/with_mcuboot/zephyr/zephyr.elf for board: art_pi
image.py: sign the payload
image.py: sign the payload
[16/16] Completed 'with_mcuboot'

```

download

```
hdj@hdj-virtual-machine:~/zephyrproject/zephyr$ west flash
-- west flash: rebuilding
[0/6] Performing build step for 'with_mcuboot'
ninja: no work to do.
[1/6] Performing build step for 'mcuboot'
ninja: no work to do.
[6/6] Completed 'mcuboot'
-- west flash: using runner stm32cubeprogrammer
      -------------------------------------------------------------------
                        STM32CubeProgrammer v2.20.0                  
      -------------------------------------------------------------------

ST-LINK SN  : 0669FF505750888667051238
ST-LINK FW  : V2J43M28
Board       : --
Voltage     : 3.25V
SWD freq    : 4000 KHz
Connect mode: Under Reset
Reset mode  : Hardware reset
Device ID   : 0x450
Revision ID : Rev V
Device name : STM32H7xx
Flash size  : 128 KBytes
Device type : MCU
Device CPU  : Cortex-M7
BL Version  : 0x90



Opening and parsing file: zephyr.hex


Memory Programming ...
  File          : zephyr.hex
  Size          : 42.02 KB 
  Address       : 0x08000000


Erasing memory corresponding to segment 0:
Download in Progress:
[==================================================] 100% 

File download complete
Time elapsed during download operation: 00:00:09.268

RUNNING Program ... 
  Address:      : 0x8000000
Application is running, Please Hold on...
Start operation achieved successfully
-- west flash: using runner stm32cubeprogrammer
      -------------------------------------------------------------------
                        STM32CubeProgrammer v2.20.0                  
      -------------------------------------------------------------------

ST-LINK SN  : 0669FF505750888667051238
ST-LINK FW  : V2J43M28
Board       : --
Voltage     : 3.25V
SWD freq    : 4000 KHz
Connect mode: Under Reset
Reset mode  : Hardware reset
Device ID   : 0x450
Revision ID : Rev V
Device name : STM32H7xx
Flash size  : 128 KBytes
Device type : MCU
Device CPU  : Cortex-M7
BL Version  : 0x90



Opening and parsing file: zephyr.signed.hex


Memory Programming ...
  File          : zephyr.signed.hex
  Size          : 19.91 KB 
  Address       : 0x90000000


Erasing memory corresponding to segment 0:
Erasing external memory sectors [0 4]
Download in Progress:
[==================================================] 100% 

File download complete
Time elapsed during download operation: 00:00:01.051

RUNNING Program ... 
  Address:      : 0x8000000
Application is running, Please Hold on...
Start operation achieved successfully

```

log

```
*** Booting MCUboot v2.2.0-118-gaa4fa2b6e173 ***
*** Using Zephyr OS build v4.2.0-3810-g9fe29f98ae2d ***
*** Booting Zephyr OS build v4.2.0-3810-g9fe29f98ae2d ***
Address of sample 0x90000000
Hello sysbuild with mcuboot! art_pi
```