### PR TITLE
samples: usb: mitigate race between resume and report transfer

### DIFF
--- a/subsys/usb/device/class/hid/core.c
+++ b/subsys/usb/device/class/hid/core.c
@@ -699,7 +699,7 @@ int hid_int_ep_write(const struct device *dev, const uint8_t *data, uint32_t dat
 		return usb_write(cfg->endpoint[HID_INT_IN_EP_IDX].ep_addr, data,
 			 data_len, bytes_ret);
 	} else {
-		LOG_WRN("Device is not configured");
+		LOG_WRN("Device is not configured or is suspended");
 		return -EAGAIN;
 	}
 


### PR DESCRIPTION
After remote wakeup is signaled, the device may still be in the
suspended state, and attempting to transfer a report may fail. If remote
wakeup is enabled, wait until the device is resumed.

Fixes: #95919