### PR TITLE
net: if: Fix assert when checking lladdr existence

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -5736,7 +5736,7 @@ static void notify_iface_up(struct net_if *iface)
 		/* CAN does not require link address. */
 	} else {
 		if (!net_if_is_offloaded(iface)) {
-			NET_ASSERT(net_if_get_link_addr(iface)->addr != NULL);
+			NET_ASSERT(net_if_get_link_addr(iface)->len > 0);
 		}
 	}
 

--- a/tests/net/mgmt/src/mgmt.c
+++ b/tests/net/mgmt/src/mgmt.c
@@ -107,9 +107,12 @@ int fake_dev_init(const struct device *dev)
 
 static void fake_iface_init(struct net_if *iface)
 {
-	static uint8_t mac[8] = { 0x00, 0x00, 0x00, 0x00, 0x0a, 0x0b, 0x0c, 0x0d};
+	static uint8_t mac[6] = { 0x00, 0x00, 0x0a, 0x0b, 0x0c, 0x0d};
+	int ret;
 
-	net_if_set_link_addr(iface, mac, 8, NET_LINK_DUMMY);
+	ret = net_if_set_link_addr(iface, mac, 6, NET_LINK_DUMMY);
+
+	zassert_equal(ret, 0, "Setting link address failed (%d)", ret);
 }
 
 static int fake_iface_send(const struct device *dev, struct net_pkt *pkt)


### PR DESCRIPTION
As the linkaddr->addr is no longer a pointer, the original assert check is not working as it should. So use the length of the linkaddr to verify that it is > 0.