### PR TITLE
include: zephyr: net: coap: Fix doxygen for coap_packet.user_data

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -316,10 +316,10 @@ struct coap_packet {
 	uint8_t hdr_len;  /**< CoAP header length */
 	uint16_t opt_len; /**< Total options length (delta + len + value) */
 	uint16_t delta;   /**< Used for delta calculation in CoAP packet */
-#if defined(CONFIG_COAP_KEEP_USER_DATA) || defined(DOXYGEN)
+#if defined(CONFIG_COAP_KEEP_USER_DATA) || defined(__DOXYGEN__)
 	/**
 	 * Application specific user data.
-	 * Only available when @kconfig{CONFIG_COAP_KEEP_USER_DATA} is enabled.
+	 * @kconfig_dep{CONFIG_COAP_KEEP_USER_DATA}
 	 */
 	void *user_data;
 #endif


### PR DESCRIPTION
Fix the expansion guard for `__DOXYGEN__` and improve the Kconfig dependency reference.