### PR TITLE
samples: mqtt_sn_publisher: fix adding predefined gateway

### DIFF
--- a/samples/net/mqtt_sn_publisher/Kconfig
+++ b/samples/net/mqtt_sn_publisher/Kconfig
@@ -9,7 +9,7 @@ config NET_SAMPLE_MQTT_SN_STATIC_GATEWAY
 	bool "Whether to statically define the Gateway. Will use Search procedure if False."
 
 config NET_SAMPLE_MQTT_SN_GATEWAY_IP
-	string "IP of the MQTT-SN gateway. Only used if NET_SAMPLE_MQTT_SN_STATIC_GATEWAY=n."
+	string "IP of the MQTT-SN gateway"
 	depends on NET_SAMPLE_MQTT_SN_STATIC_GATEWAY
 
 config NET_SAMPLE_MQTT_SN_GATEWAY_PORT

--- a/samples/net/mqtt_sn_publisher/src/udp.c
+++ b/samples/net/mqtt_sn_publisher/src/udp.c
@@ -149,13 +149,13 @@ static void process_thread(void)
 		LOG_INF("Adding predefined Gateway");
 		struct sockaddr_in gwaddr = {0};
 
-		LOG_DBG("Parsing Broadcast IP %s", SAMPLE_GW_IP);
+		LOG_DBG("Parsing Gateway IP %s", SAMPLE_GW_IP);
 		gwaddr.sin_family = AF_INET;
 		gwaddr.sin_port = htons(CONFIG_NET_SAMPLE_MQTT_SN_GATEWAY_PORT);
 		err = zsock_inet_pton(AF_INET, SAMPLE_GW_IP, &gwaddr.sin_addr);
 		__ASSERT(err == 1, "inet_pton() failed %d", err);
-		struct mqtt_sn_data gwaddr_data = {.data = (uint8_t *)&bcaddr,
-						   .size = sizeof(struct sockaddr)};
+		struct mqtt_sn_data gwaddr_data = {.data = (uint8_t *)&gwaddr,
+						   .size = sizeof(gwaddr)};
 
 		err = mqtt_sn_add_gw(&mqtt_client, 0x1f, gwaddr_data);
 		__ASSERT(err == 0, "mqtt_sn_add_gw() failed %d", err);


### PR DESCRIPTION
Apparently, the code was copied from where the broadcast IP is parsed and not adjusted correctly. Both the log message and the source of the IP address were wrong.