### PR TITLE
soc: nordic: nrf54h: bicr: fix incorrect scaling of lfrccal props

### DIFF
--- a/soc/nordic/nrf54h/bicr/bicrgen.py
+++ b/soc/nordic/nrf54h/bicr/bicrgen.py
@@ -391,8 +391,8 @@ class LFRCCalibrationConfig:
         if calibration_enabled:
             return cls(
                 calibration_enabled=calibration_enabled,
-                temp_meas_interval_seconds=lfosc_lfrcautocalconfig["TEMPINTERVAL"],
-                temp_delta_calibration_trigger_celsius=lfosc_lfrcautocalconfig["TEMPDELTA"],
+                temp_meas_interval_seconds=lfosc_lfrcautocalconfig["TEMPINTERVAL"] * 0.25,
+                temp_delta_calibration_trigger_celsius=lfosc_lfrcautocalconfig["TEMPDELTA"] * 0.25,
                 max_meas_interval_between_calibrations=lfosc_lfrcautocalconfig["INTERVALMAXNO"],
             )
         else:
@@ -431,8 +431,10 @@ class LFRCCalibrationConfig:
             "ENABLE", "Enabled" if self.calibration_enabled else "Disabled"
         )
         if self.calibration_enabled:
-            lfosc_lfrcautocalconfig["TEMPINTERVAL"] = self.temp_meas_interval_seconds
-            lfosc_lfrcautocalconfig["TEMPDELTA"] = self.temp_delta_calibration_trigger_celsius
+            lfosc_lfrcautocalconfig["TEMPINTERVAL"] = int(self.temp_meas_interval_seconds / 0.25)
+            lfosc_lfrcautocalconfig["TEMPDELTA"] = int(
+                self.temp_delta_calibration_trigger_celsius / 0.25
+            )
             lfosc_lfrcautocalconfig["INTERVALMAXNO"] = self.max_meas_interval_between_calibrations
 
     def to_json(self, buf: dict):


### PR DESCRIPTION
The lfrccal takes the two properties tempMeasIntervalSeconds and tempDeltaCalibrationTriggerCelsius which are in steps of 0.25. The bicrgen.py script incorrectly treated these values as steps of 1, so the actual values written to (and read from) bicr where scaled incorrectly.

This commit fixes the scaling for those two props, and aligns the existing hfxo LOADCAP prop to use the same syntax for scaling.

This commit was verified with this bicr config
```
{
  "power": {
    "scheme": "VDDH_2V1_5V5"
  },
  "ioPortPower": {
    "p1Supply": "EXTERNAL_1V8",
    "p2Supply": "EXTERNAL_1V8",
    "p6Supply": "EXTERNAL_1V8",
    "p7Supply": "EXTERNAL_1V8",
    "p9Supply": "EXTERNAL_FULL"
  },
  "ioPortImpedance": {
    "p6ImpedanceOhms": 50,
    "p7ImpedanceOhms": 50
  },
  "lfosc": {
     "source": "LFRC",
     "lfrccal": {
       "calibrationEnabled": true,
       "tempMeasIntervalSeconds": 5,
       "tempDeltaCalibrationTriggerCelsius": 10,
       "maxMeasIntervalBetweenCalibrations": 3
     }
  },
  "hfxo": {
    "mode": "CRYSTAL",
    "startupTimeUs": 850,
    "builtInLoadCapacitors": true,
    "builtInLoadCapacitancePf": 14
  }
}
```

which now produces:
```
:020000040FFFEC
:1087B00081F0FF7F2FF2FF224FFFFFFFFFFFFF221D
:1087C000FFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFC9
:1087D00094E8E37FFF88F3FF52030000FFFFFFFFF1
:0C87E000FFFFFFFFFFFFFFFFFFFFFFFF99
:00000001FF
```