### PR TITLE
boards: ti: am62: Fix size of DDR1 memory region

### DIFF
--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_m4-common.dtsi
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_m4-common.dtsi
@@ -48,7 +48,7 @@
 
 	ddr1: memory@9cc01000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x9cc01000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
+		reg = <0x9cc01000 (DT_SIZE_M(14) - DT_SIZE_K(4))>;
 		zephyr,memory-region = "DDR";
 	};
 

--- a/boards/phytec/phyboard_lyra/phyboard_lyra_am6234_m4.dts
+++ b/boards/phytec/phyboard_lyra/phyboard_lyra_am6234_m4.dts
@@ -45,7 +45,7 @@
 
 	ddr1: memory@9cc01000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x9cc01000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
+		reg = <0x9cc01000 (DT_SIZE_M(14) - DT_SIZE_K(4))>;
 		zephyr,memory-region = "DDR";
 	};
 

--- a/boards/ti/sk_am62/sk_am62_am6234_m4.dts
+++ b/boards/ti/sk_am62/sk_am62_am6234_m4.dts
@@ -40,7 +40,7 @@
 
 	ddr1: memory@9cc01000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x9cc01000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
+		reg = <0x9cc01000 (DT_SIZE_M(14) - DT_SIZE_K(4))>;
 		zephyr,memory-region = "DDR";
 	};
 };

--- a/boards/toradex/verdin_am62/verdin_am62_am6234_m4.dts
+++ b/boards/toradex/verdin_am62/verdin_am62_am6234_m4.dts
@@ -47,7 +47,7 @@
 
 	ddr1: memory@9cc01000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x9cc01000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
+		reg = <0x9cc01000 (DT_SIZE_M(14) - DT_SIZE_K(4))>;
 		zephyr,memory-region = "DDR";
 	};
 };


### PR DESCRIPTION
Unlike most other remote cores on most other TI K3 devices, the M4 on AM62 was only reserved 15MB of DDR vs the normal 16MB. Update the same for all AM62 boards to prevent writing into unreserved memory.