### PR TITLE
boards: ti: sk_am62: Add IPC mailbox support

### DIFF
--- a/boards/ti/sk_am62/sk_am62_am6234_m4.dts
+++ b/boards/ti/sk_am62/sk_am62_am6234_m4.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,ipc = &ipc0;
 		zephyr,ipc_shm = &ddr0;
 		zephyr,sram1 = &ddr1;
 	};
@@ -42,6 +43,12 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x9cc01000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
 		zephyr,memory-region = "DDR";
+	};
+
+	ipc0: ipc {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox0 0>, <&mbox0 1>;
+		mbox-names = "tx", "rx";
 	};
 };
 


### PR DESCRIPTION
Add IPC mailbox chosen property. The mailbox channels used are as expected by Linux.