### PR TITLE
include: Fix C headers such that they can be included in C++ context.

### DIFF
--- a/arch/arm64/include/kernel_arch_func.h
+++ b/arch/arm64/include/kernel_arch_func.h
@@ -40,13 +40,13 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 
 static inline void arch_switch(void *switch_to, void **switched_from)
 {
-	extern void z_arm64_context_switch(struct k_thread *new,
+	extern void z_arm64_context_switch(struct k_thread *new_thread,
 					   struct k_thread *old);
-	struct k_thread *new = switch_to;
+	struct k_thread *new_thread = switch_to;
 	struct k_thread *old = CONTAINER_OF(switched_from, struct k_thread,
 					    switch_handle);
 
-	z_arm64_context_switch(new, old);
+	z_arm64_context_switch(new_thread, old);
 }
 
 extern void z_arm64_fatal_error(unsigned int reason, struct arch_esf *esf);

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -44,6 +44,10 @@ BUILD_ASSERT(K_LOWEST_APPLICATION_THREAD_PRIO
 #define LOCK_SCHED_SPINLOCK   K_SPINLOCK(&_sched_spinlock)
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern struct k_spinlock _sched_spinlock;
 
 extern struct k_thread _thread_dummy;
@@ -334,5 +338,9 @@ static inline void z_sched_usage_switch(struct k_thread *thread)
 	z_sched_usage_start(thread);
 #endif /* CONFIG_SCHED_THREAD_USAGE */
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_KSCHED_H_ */


### PR DESCRIPTION
ksched.h: Add missing extern "C" for C++.
arch/arm64/include/kernel_arch_func.h: Remove usage of reserved "new" C++ keyword.

No functional change.