### PR TITLE
MAINTAINERS: Add Pete Johanson as hal_adi collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5234,6 +5234,7 @@ West:
     - ozersa
     - ttmut
     - yasinustunerg
+    - petejohanson-adi
   files: []
   labels:
     - "platform: ADI"


### PR DESCRIPTION
Adding Pete Johanson (ADI TSC member) to the collaborators for the hal_adi.