### PR TITLE
scripts: twister: add failure_script parameter to run after test failure

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -725,6 +725,11 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
         help="""Create individual reports for each platform.
         """)
 
+    parser.add_argument("--failure-script",
+                        help="""specify a failures script. This will be executed
+                        on test failure.
+                        """)
+
     parser.add_argument(
         "--quarantine-list",
         action="append",

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -685,6 +685,7 @@ class DeviceHandler(Handler):
 
         post_flash_script = hardware.post_flash_script
         post_script = hardware.post_script
+        failure_script = hardware.failure_script
 
         flash_timeout = hardware.flash_timeout
         if hardware.flash_with_test:
@@ -831,6 +832,13 @@ class DeviceHandler(Handler):
             if script_param:
                 timeout = script_param.get("post_script_timeout", timeout)
             self.run_custom_script(post_script, timeout)
+
+        if failure_script and self.instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
+            logger.debug(f"Running failure script: {failure_script}")
+            timeout = 30
+            if script_param:
+                timeout = script_param.get("failure_script_timeout", timeout)
+            self.run_custom_script(failure_script, timeout)
 
 
 class QEMUHandler(Handler):

--- a/scripts/pylib/twister/twisterlib/hardwaredata.py
+++ b/scripts/pylib/twister/twisterlib/hardwaredata.py
@@ -28,6 +28,7 @@ class HardwareData:
     flash_timeout: int = 60
     flash_with_test: bool = False
     flash_before: bool = False
+    failure_script: str | None = None
     fixtures: list[str] = field(default_factory=list)
     probe_id: str | None = None
     notes: str | None = None

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -168,6 +168,7 @@ class HardwareMap:
                 self.add_device(self.options.device_serial[0],
                                 self.options.platform[0],
                                 self.options.pre_script,
+                                self.options.failure_script,
                                 False,
                                 baud=self.options.device_serial_baud,
                                 flash_timeout=self.options.device_flash_timeout,
@@ -179,12 +180,14 @@ class HardwareMap:
                         self.add_device(serial,
                                         platform=None,
                                         pre_script=None,
+                                        failure_script=None,
                                         is_pty=False)
 
             elif self.options.device_serial_pty:
                 self.add_device(self.options.device_serial_pty,
                                 self.options.platform[0],
                                 self.options.pre_script,
+                                self.options.failure_script,
                                 True,
                                 flash_timeout=self.options.device_flash_timeout,
                                 flash_with_test=self.options.device_flash_with_test,
@@ -214,6 +217,7 @@ class HardwareMap:
         serial,
         platform,
         pre_script,
+        failure_script,
         is_pty,
         baud=None,
         flash_timeout=60,
@@ -224,6 +228,7 @@ class HardwareMap:
             platform=platform,
             connected=True,
             pre_script=pre_script,
+            failure_script=failure_script,
             serial_baud=baud,
             flash_timeout=flash_timeout,
             flash_with_test=flash_with_test,
@@ -268,6 +273,7 @@ class HardwareMap:
             fixtures = dut.get('fixtures', [])
             connected = dut.get('connected') and ((serial or serial_pty) is not None)
             west_flash_cmd = dut.get('west_flash_cmd', "")
+            failure_script = dut.get('failure_script')
             if not connected:
                 continue
             for plat in platforms:
@@ -287,7 +293,8 @@ class HardwareMap:
                               script_param=script_param,
                               flash_timeout=flash_timeout,
                               flash_with_test=flash_with_test,
-                              west_flash_cmd=west_flash_cmd)
+                              west_flash_cmd=west_flash_cmd,
+                              failure_script=failure_script)
                 new_dut.fixtures = fixtures
                 new_dut.counter = 0
                 self.duts.append(new_dut)

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -36,6 +36,8 @@ items:
       type: string
     pre_script:
       type: string
+    failure_script:
+      type: string
     fixtures:
       type: array
       items:
@@ -54,6 +56,8 @@ items:
         post_script_timeout:
           type: integer
         post_flash_timeout:
+          type: integer
+        failure_script_timeout:
           type: integer
       additionalProperties: false
     west_flash_cmd:

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1169,6 +1169,7 @@ def test_devicehandler_handle(
         pre_script='dummy pre script',
         post_script='dummy post script',
         post_flash_script='dummy post flash script',
+        failure_script='dummy failure script',
         flash_timeout=60,
         flash_with_test=True
     )
@@ -1225,11 +1226,18 @@ def test_devicehandler_handle(
     if raise_create_serial:
         return
 
-    handler.run_custom_script.assert_has_calls([
+    expected_calls = [
         mock.call('dummy pre script', mock.ANY),
         mock.call('dummy post flash script', mock.ANY),
-        mock.call('dummy post script', mock.ANY)
-    ])
+        mock.call('dummy post script', mock.ANY),
+    ]
+
+    if raise_popen or raise_timeout or returncode:
+        expected_calls.append(
+            mock.call('dummy failure script', mock.ANY)
+        )
+
+    handler.run_custom_script.assert_has_calls(expected_calls)
 
     if expected_reason:
         assert handler.instance.reason == expected_reason

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -53,6 +53,7 @@ TESTDATA_1 = [
             'pre_script': 'dummy pre script',
             'post_script': 'dummy post script',
             'post_flash_script': 'dummy post flash script',
+            'failure_script': 'dummy failure script',
             'runner': 'dummy runner',
             'flash_timeout': 30,
             'flash_with_test': True,
@@ -60,6 +61,7 @@ TESTDATA_1 = [
                 'pre_script_timeout' : 30,
                 'post_flash_timeout' : 30,
                 'post_script_timeout' : 30,
+                'failure_script_timeout' : 30,
                 }
         },
         {
@@ -74,6 +76,7 @@ TESTDATA_1 = [
             'pre_script': 'dummy pre script',
             'post_script': 'dummy post script',
             'post_flash_script': 'dummy post flash script',
+            'failure_script': 'dummy failure script',
             'runner': 'dummy runner',
             'flash_timeout': 30,
             'flash_with_test': True,
@@ -81,6 +84,7 @@ TESTDATA_1 = [
                 'pre_script_timeout' : 30,
                 'post_flash_timeout' : 30,
                 'post_script_timeout' : 30,
+                'failure_script_timeout' : 30,
                 }
         },
         '<dummy platform (dummy product) on dummy serial>'
@@ -248,7 +252,8 @@ def test_hardwaremap_add_device(is_pty):
     serial = 'dummy'
     platform = 'p0'
     pre_script = 'dummy pre script'
-    hm.add_device(serial, platform, pre_script, is_pty)
+    failure_script = 'dummy failure script'
+    hm.add_device(serial, platform, pre_script, failure_script, is_pty)
 
     assert len(hm.duts) == 1
     if is_pty:


### PR DESCRIPTION
Add "failure_script", a commandline or hardware map parameter that allows users to execute a custom script after a testcase fails on a DUT. This can be useful to dump device state after a test failure, especially one that did not produce any console output.