### PR TITLE
arch/riscv: Allow overriding ROM region for PMP setup

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -432,6 +432,30 @@ config PMP_STACK_GUARD_MIN_SIZE
 	  wiggle room to accommodate the eventual overflow exception
 	  stack usage.
 
+config ROM_REGION_START
+	string "Start address or linker symbol of the ROM region"
+	depends on RISCV_PMP
+	default "__rom_region_start"
+	help
+	  The linker symbol or hexadecimal address that defines the start of the
+	  ROM region.
+	  This configuration is used to calculate the physical memory
+	  protection (PMP) region entry. The value is resolved at compile time.
+	  To override the linker's default, set this to a hexadecimal string,
+	  such as "0x80000000".
+
+config ROM_REGION_SIZE
+	string "Size or linker symbol of the ROM region"
+	depends on RISCV_PMP
+	default "__rom_region_size"
+	help
+	  The linker symbol or hexadecimal size that defines the overall byte
+	  length of the ROM region.
+	  This configuration is used to calculate the physical memory
+	  protection (PMP) region size. The value is resolved at compile time.
+	  To manually override the linker's default size, set this to a
+	  hexadecimal string, such as "0x100000".
+
 # Implement the null pointer detection using the Physical Memory Protection
 # (PMP) Unit.
 config NULL_POINTER_EXCEPTION_DETECTION_PMP


### PR DESCRIPTION
The Physical Memory Protection (PMP) setup for the ROM region currently relies on the fixed linker symbols `__rom_region_start` and `__rom_region_size`.

In environments where the firmware is loaded by a bootloader (example a two-stage boot, or jumping from a RO-image to a RW-image), the actual physical address of the executable code might change. This is especially critical when the PMP must protect the entire persistent ROM area, regardless of which stage of the firmware is executing.

This commit addresses this by:

1. Introducing `CONFIG_ROM_REGION_START` and `CONFIG_ROM_REGION_SIZE` Kconfig options, guarded by `RISCV_PMP`. These default to the standard linker symbols but allow manual override via hexadecimal strings.

2. Adding a compile-time `ADDRESS_RESOLVER` macro in `pmp.c` to parse the Kconfig string, correctly handling the conversion of either the default linker symbol or a user-provided hexadecimal address into a numerical value.

3. Updating `z_riscv_pmp_init()` to use the resolved Kconfig values, ensuring that the PMP always protects the correct, full ROM area as defined by the user or the linker.