### PR TITLE
MAINTAINERS: Adding a new file pattern for Infineon drivers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2820,6 +2820,7 @@ Infineon Platforms:
     - boards/cypress/
     - boards/infineon/
     - drivers/*/*ifx_cat1*
+    - drivers/*/*ifx*
     - drivers/*/*xmc*
     - drivers/sensor/infineon/
     - dts/arm/infineon/


### PR DESCRIPTION
We are moving away from category based driver names. Updating the "files:" patterns to include the newer drivers as well.