### PR TITLE
arch: riscv: Add function to clear all unlocked PMP entries

### DIFF
--- a/arch/riscv/include/pmp.h
+++ b/arch/riscv/include/pmp.h
@@ -15,4 +15,15 @@ void z_riscv_pmp_usermode_init(struct k_thread *thread);
 void z_riscv_pmp_usermode_prepare(struct k_thread *thread);
 void z_riscv_pmp_usermode_enable(struct k_thread *thread);
 
+/**
+ * @brief Resets all unlocked PMP entries to OFF mode (Null Region).
+ *
+ * This function is used to securely clear the PMP configuration. It first
+ * ensures the execution context is M-mode by setting MSTATUS_MPRV=0 and
+ * MSTATUS_MPP=M-mode. It then reads all pmpcfgX CSRs, iterates through
+ * the configuration bytes, and clears the Address Matching Mode bits (PMP_A)
+ * for any entry that is not locked (PMP_L is clear), effectively disabling the region.
+ */
+void riscv_pmp_clear_all(void);
+
 #endif /* PMP_H_ */


### PR DESCRIPTION
Introduce the new function `riscv_pmp_clear_all()` to securely reset the Physical Memory Protection (PMP) configuration.

This function iterates through all configured PMP slots. For each entry, it checks if the Lock (L) bit is set. If the entry is not locked, it clears the Address Matching Mode (A) bits, effectively setting the region type to OFF (Null Region), disabling the entry.

The function ensures it operates in default Machine Status Registers (CSRs) with `MSTATUS.MPRV = 0` and `MSTATUS.MPP = 11`.

This provides a mechanism to clear all non-locked PMP regions, returning them to a default disabled state. The function is exposed in the pmp.h header file.