### PR TITLE
drivers: Update Renesas RA drivers to support FSP version 6.1.0

### DIFF
--- a/drivers/pwm/pwm_renesas_ra.c
+++ b/drivers/pwm/pwm_renesas_ra.c
@@ -604,6 +604,8 @@ static int pwm_renesas_ra_init(const struct device *dev)
 		.capture_filter_gtiocb = GPT_CAPTURE_FILTER_NONE,                                  \
 		.p_pwm_cfg = NULL,                                                                 \
 		.gtior_setting.gtior = (0x0U),                                                     \
+		.gtioca_polarity = GPT_GTIOC_POLARITY_NORMAL,                                      \
+		.gtiocb_polarity = GPT_GTIOC_POLARITY_NORMAL,                                      \
 	};                                                                                         \
 	static struct pwm_renesas_ra_data pwm_renesas_ra_data_##index = {                          \
 		.fsp_cfg =                                                                         \

--- a/soc/renesas/ra/ra4c1/soc.c
+++ b/soc/renesas/ra/ra4c1/soc.c
@@ -35,7 +35,7 @@ void soc_early_init_hook(void)
 {
 	extern volatile uint16_t g_protect_counters[];
 
-	for (uint32_t i = 0; i < 4; i++) {
+	for (uint32_t i = 0; i < 5; i++) {
 		g_protect_counters[i] = 0;
 	}
 

--- a/soc/renesas/ra/ra4e1/soc.c
+++ b/soc/renesas/ra/ra4e1/soc.c
@@ -40,7 +40,7 @@ void soc_early_init_hook(void)
 {
 	extern volatile uint16_t g_protect_counters[];
 
-	for (uint32_t i = 0; i < 4; i++) {
+	for (uint32_t i = 0; i < 5; i++) {
 		g_protect_counters[i] = 0;
 	}
 

--- a/soc/renesas/ra/ra4e2/soc.c
+++ b/soc/renesas/ra/ra4e2/soc.c
@@ -40,7 +40,7 @@ void soc_early_init_hook(void)
 {
 	extern volatile uint16_t g_protect_counters[];
 
-	for (uint32_t i = 0; i < 4; i++) {
+	for (uint32_t i = 0; i < 5; i++) {
 		g_protect_counters[i] = 0;
 	}
 

--- a/soc/renesas/ra/ra4l1/soc.c
+++ b/soc/renesas/ra/ra4l1/soc.c
@@ -40,7 +40,7 @@ void soc_early_init_hook(void)
 {
 	extern volatile uint16_t g_protect_counters[];
 
-	for (uint32_t i = 0; i < 4; i++) {
+	for (uint32_t i = 0; i < 5; i++) {
 		g_protect_counters[i] = 0;
 	}
 

--- a/soc/renesas/ra/ra4m2/soc.c
+++ b/soc/renesas/ra/ra4m2/soc.c
@@ -40,7 +40,7 @@ void soc_early_init_hook(void)
 {
 	extern volatile uint16_t g_protect_counters[];
 
-	for (uint32_t i = 0; i < 4; i++) {
+	for (uint32_t i = 0; i < 5; i++) {
 		g_protect_counters[i] = 0;
 	}
 

--- a/soc/renesas/ra/ra4m3/soc.c
+++ b/soc/renesas/ra/ra4m3/soc.c
@@ -40,7 +40,7 @@ void soc_early_init_hook(void)
 {
 	extern volatile uint16_t g_protect_counters[];
 
-	for (uint32_t i = 0; i < 4; i++) {
+	for (uint32_t i = 0; i < 5; i++) {
 		g_protect_counters[i] = 0;
 	}
 

--- a/soc/renesas/ra/ra6e1/soc.c
+++ b/soc/renesas/ra/ra6e1/soc.c
@@ -41,7 +41,7 @@ void soc_early_init_hook(void)
 
 	extern volatile uint16_t g_protect_counters[];
 
-	for (uint32_t i = 0; i < 4; i++) {
+	for (uint32_t i = 0; i < 5; i++) {
 		g_protect_counters[i] = 0;
 	}
 

--- a/soc/renesas/ra/ra6e2/soc.c
+++ b/soc/renesas/ra/ra6e2/soc.c
@@ -43,7 +43,7 @@ void soc_early_init_hook(void)
 
 	extern volatile uint16_t g_protect_counters[];
 
-	for (uint32_t i = 0; i < 4; i++) {
+	for (uint32_t i = 0; i < 5; i++) {
 		g_protect_counters[i] = 0;
 	}
 

--- a/soc/renesas/ra/ra6m4/soc.c
+++ b/soc/renesas/ra/ra6m4/soc.c
@@ -43,7 +43,7 @@ void soc_early_init_hook(void)
 
 	extern volatile uint16_t g_protect_counters[];
 
-	for (uint32_t i = 0; i < 4; i++) {
+	for (uint32_t i = 0; i < 5; i++) {
 		g_protect_counters[i] = 0;
 	}
 

--- a/soc/renesas/ra/ra6m5/soc.c
+++ b/soc/renesas/ra/ra6m5/soc.c
@@ -43,7 +43,7 @@ void soc_early_init_hook(void)
 
 	extern volatile uint16_t g_protect_counters[];
 
-	for (uint32_t i = 0; i < 4; i++) {
+	for (uint32_t i = 0; i < 5; i++) {
 		g_protect_counters[i] = 0;
 	}
 

--- a/soc/renesas/ra/ra8p1/soc.c
+++ b/soc/renesas/ra/ra8p1/soc.c
@@ -40,7 +40,7 @@ void soc_early_init_hook(void)
 
 	extern volatile uint16_t g_protect_counters[];
 
-	for (uint32_t i = 0; i < 4; i++) {
+	for (uint32_t i = 0; i < 5; i++) {
 		g_protect_counters[i] = 0;
 	}
 

--- a/tests/subsys/pm/power_mgmt_soc/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt_soc/testcase.yaml
@@ -21,6 +21,10 @@ tests:
       - max32657evkit/max32657
       - max32657evkit/max32657/ns
       - imx95_evk/mimx9596/m7
+      - ek_ra8m1
+      - ek_ra8d1
+      - mck_ra8t1
+      - ek_ra8p1/r7ka8p1kflcac/cm85
     tags: pm
     integration_platforms:
       - mec15xxevb_assy6853

--- a/west.yml
+++ b/west.yml
@@ -226,7 +226,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: 6ff5c0662bc9ad4a126be28eab0addcb2454fe69
+      revision: f0b78440ba8f0b4a07cdd657031ac9ec1cc4c126
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
- Update counter value of `g_protect_counters` to `5`
- Add initial polarity value for Renesas RA PWM driver