### PR TITLE
RISCV: PMP: Use correct pmpcfg index for multi-register configurations

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -335,11 +335,13 @@ static void write_pmp_entries(unsigned int start, unsigned int end,
 	ARRAY_SIZE(thread->arch.u_mode_pmpaddr_regs)
 
 /*
- * This is used to seed thread PMP copies with global m-mode cfg entries
- * sharing the same cfg register. Locked entries aren't modifiable but
+ * Stores the initial values of the pmpcfg CSRs, covering all global
+ * m-mode PMP entries. This array is sized to hold all pmpcfg registers
+ * necessary for CONFIG_PMP_SLOTS. It is used to seed the per-thread
+ * PMP configuration copies. Locked entries aren't modifiable but
  * we could have non-locked entries here too.
  */
-static unsigned long global_pmp_cfg[1];
+static unsigned long global_pmp_cfg[CONFIG_PMP_SLOTS / PMPCFG_STRIDE];
 static unsigned long global_pmp_last_addr;
 
 /* End of global PMP entry range */
@@ -432,12 +434,13 @@ void z_riscv_pmp_init(void)
 	/* Make sure secondary CPUs produced the same values */
 	if (global_pmp_end_index != 0) {
 		__ASSERT(global_pmp_end_index == index, "");
-		__ASSERT(global_pmp_cfg[0] == pmp_cfg[0], "");
+		__ASSERT(global_pmp_cfg[index / PMPCFG_STRIDE] == pmp_cfg[index / PMPCFG_STRIDE],
+			 "");
 		__ASSERT(global_pmp_last_addr == pmp_addr[index - 1], "");
 	}
 #endif
 
-	global_pmp_cfg[0] = pmp_cfg[0];
+	memcpy(global_pmp_cfg, pmp_cfg, sizeof(pmp_cfg));
 	global_pmp_last_addr = pmp_addr[index - 1];
 	global_pmp_end_index = index;
 
@@ -457,9 +460,9 @@ static inline unsigned int z_riscv_pmp_thread_init(unsigned long *pmp_addr,
 	ARG_UNUSED(index_limit);
 
 	/*
-	 * Retrieve pmpcfg0 partial content from global entries.
+	 * Retrieve the pmpcfg register with partial content from global entries.
 	 */
-	pmp_cfg[0] = global_pmp_cfg[0];
+	memcpy(pmp_cfg, global_pmp_cfg, sizeof(global_pmp_cfg));
 
 	/*
 	 * Retrieve the pmpaddr value matching the last global PMP slot.


### PR DESCRIPTION
The PMP initialization and thread seeding logic in `arch/riscv/core/pmp.c` did not correctly handle scenarios where the global PMP entries span across multiple `pmpcfg` hardware registers.

The `global_pmp_cfg` array, intended to store the hardware register values, was hardcoded to size 1. This is only sufficient if all global PMP entries fall within the range covered by the first `pmpcfg` register (e.g., pmpcfg0). When more global entries are used, their configurations reside in subsequent `pmpcfg` registers (pmpcfg1, pmpcfg2, etc.).

The code was only saving/restoring and checking `global_pmp_cfg[0]`, leading to loss of configuration for entries mapped to higher `pmpcfg` registers.

This patch fixes this by:

1.  Resizing the `global_pmp_cfg` array to `CONFIG_PMP_SLOTS / PMPCFG_STRIDE` to correctly accommodate values from all potentially used `pmpcfg` CSRs.
2.  In `z_riscv_pmp_init`, using `memcpy` to save the entire contents of the local `pmp_cfg` array (derived from initial setup) into the `global_pmp_cfg` array.
3.  In `z_riscv_pmp_thread_init`, using `memcpy` to restore the entire saved global configuration from `global_pmp_cfg` into a thread's `pmp_cfg` array.
4.  Updating the SMP consistency assertion in `z_riscv_pmp_init` to compare the contents of the array element @ `index / PMPCFG_STRIDE` of the `pmp_cfg` arrays.

These changes ensure that the configurations from all relevant `pmpcfg` registers are preserved and correctly propagated to thread contexts.