### PR TITLE
modem: at_shell: extract user pipe handling

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -150,6 +150,11 @@ Networking
 
 .. zephyr-keep-sorted-stop
 
+Modem
+*****
+
+* ``CONFIG_MODEM_AT_SHELL_USER_PIPE`` has been renamed to :kconfig:option:`CONFIG_MODEM_AT_USER_PIPE`.
+
 Display
 *******
 

--- a/drivers/modem/CMakeLists.txt
+++ b/drivers/modem/CMakeLists.txt
@@ -36,4 +36,5 @@ if (CONFIG_MODEM_SIM7080)
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_MODEM_CELLULAR modem_cellular.c)
+zephyr_library_sources_ifdef(CONFIG_MODEM_AT_USER_PIPE modem_at_user_pipe.c)
 zephyr_library_sources_ifdef(CONFIG_MODEM_AT_SHELL modem_at_shell.c)

--- a/drivers/modem/Kconfig.at_shell
+++ b/drivers/modem/Kconfig.at_shell
@@ -1,21 +1,29 @@
 # Copyright (c) 2024 Trackunit Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-config MODEM_AT_SHELL
-	bool "AT command shell based on modem modules"
-	select MODEM_MODULES
+config MODEM_AT_USER_PIPE
+	bool "Modem AT command user pipe helpers"
+	depends on $(dt_alias_enabled,modem)
 	select MODEM_CHAT
 	select MODEM_PIPE
 	select MODEM_PIPELINK
+	help
+	  Utility functions for managing access to user pipes
+	  for arbitrary AT commands
+
+config MODEM_AT_USER_PIPE_IDX
+	int "User pipe number to use"
+	depends on MODEM_AT_USER_PIPE
+	default 0
+
+config MODEM_AT_SHELL
+	bool "AT command shell based on modem modules"
+	select MODEM_MODULES
+	select MODEM_AT_USER_PIPE
 	depends on !MODEM_SHELL
 	depends on !SHELL_WILDCARD
-	depends on $(dt_alias_enabled,modem)
 
 if MODEM_AT_SHELL
-
-config MODEM_AT_SHELL_USER_PIPE
-	int "User pipe number to use"
-	default 0
 
 config MODEM_AT_SHELL_RESPONSE_TIMEOUT_S
 	int "Timeout waiting for response to AT command in seconds"

--- a/drivers/modem/modem_at_shell.c
+++ b/drivers/modem/modem_at_shell.c
@@ -6,23 +6,13 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
+#include <zephyr/modem/at/user_pipe.h>
 #include <zephyr/modem/chat.h>
 #include <zephyr/modem/pipelink.h>
 #include <zephyr/sys/atomic.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(modem_at_shell, CONFIG_MODEM_LOG_LEVEL);
-
-#define AT_SHELL_MODEM_NODE DT_ALIAS(modem)
-#define AT_SHELL_PIPELINK_NAME _CONCAT(user_pipe_, CONFIG_MODEM_AT_SHELL_USER_PIPE)
-
-#define AT_SHELL_STATE_ATTACHED_BIT       0
-#define AT_SHELL_STATE_SCRIPT_RUNNING_BIT 1
-
-MODEM_PIPELINK_DT_DECLARE(AT_SHELL_MODEM_NODE, AT_SHELL_PIPELINK_NAME);
-
-static struct modem_pipelink *at_shell_pipelink =
-	MODEM_PIPELINK_DT_GET(AT_SHELL_MODEM_NODE, AT_SHELL_PIPELINK_NAME);
 
 static struct modem_chat at_shell_chat;
 static uint8_t at_shell_chat_receive_buf[CONFIG_MODEM_AT_SHELL_CHAT_RECEIVE_BUF_SIZE];
@@ -32,10 +22,6 @@ static struct modem_chat_script_chat at_shell_script_chat[1];
 static struct modem_chat_match at_shell_script_chat_matches[2];
 static uint8_t at_shell_match_buf[CONFIG_MODEM_AT_SHELL_RESPONSE_MAX_SIZE];
 static const struct shell *at_shell_active_shell;
-static struct k_work at_shell_open_pipe_work;
-static struct k_work at_shell_attach_chat_work;
-static struct k_work at_shell_release_chat_work;
-static atomic_t at_shell_state;
 
 static void at_shell_print_any_match(struct modem_chat *chat, char **argv, uint16_t argc,
 				     void *user_data)
@@ -74,7 +60,7 @@ static void at_shell_script_callback(struct modem_chat *chat,
 				     enum modem_chat_script_result result,
 				     void *user_data)
 {
-	atomic_clear_bit(&at_shell_state, AT_SHELL_STATE_SCRIPT_RUNNING_BIT);
+	modem_at_user_pipe_release();
 }
 
 MODEM_CHAT_SCRIPT_DEFINE(
@@ -84,83 +70,6 @@ MODEM_CHAT_SCRIPT_DEFINE(
 	at_shell_script_callback,
 	CONFIG_MODEM_AT_SHELL_RESPONSE_TIMEOUT_S
 );
-
-static void at_shell_pipe_callback(struct modem_pipe *pipe,
-				   enum modem_pipe_event event,
-				   void *user_data)
-{
-	ARG_UNUSED(user_data);
-
-	switch (event) {
-	case MODEM_PIPE_EVENT_OPENED:
-		LOG_INF("pipe opened");
-		k_work_submit(&at_shell_attach_chat_work);
-		break;
-
-	default:
-		break;
-	}
-}
-
-void at_shell_pipelink_callback(struct modem_pipelink *link,
-				enum modem_pipelink_event event,
-				void *user_data)
-{
-	ARG_UNUSED(user_data);
-
-	switch (event) {
-	case MODEM_PIPELINK_EVENT_CONNECTED:
-		LOG_INF("pipe connected");
-		k_work_submit(&at_shell_open_pipe_work);
-		break;
-
-	case MODEM_PIPELINK_EVENT_DISCONNECTED:
-		LOG_INF("pipe disconnected");
-		k_work_submit(&at_shell_release_chat_work);
-		break;
-
-	default:
-		break;
-	}
-}
-
-static void at_shell_open_pipe_handler(struct k_work *work)
-{
-	ARG_UNUSED(work);
-
-	LOG_INF("opening pipe");
-
-	modem_pipe_attach(modem_pipelink_get_pipe(at_shell_pipelink),
-			  at_shell_pipe_callback,
-			  NULL);
-
-	modem_pipe_open_async(modem_pipelink_get_pipe(at_shell_pipelink));
-}
-
-static void at_shell_attach_chat_handler(struct k_work *work)
-{
-	ARG_UNUSED(work);
-
-	modem_chat_attach(&at_shell_chat, modem_pipelink_get_pipe(at_shell_pipelink));
-	atomic_set_bit(&at_shell_state, AT_SHELL_STATE_ATTACHED_BIT);
-	LOG_INF("chat attached");
-}
-
-static void at_shell_release_chat_handler(struct k_work *work)
-{
-	ARG_UNUSED(work);
-
-	modem_chat_release(&at_shell_chat);
-	atomic_clear_bit(&at_shell_state, AT_SHELL_STATE_ATTACHED_BIT);
-	LOG_INF("chat released");
-}
-
-static void at_shell_init_work(void)
-{
-	k_work_init(&at_shell_open_pipe_work, at_shell_open_pipe_handler);
-	k_work_init(&at_shell_attach_chat_work, at_shell_attach_chat_handler);
-	k_work_init(&at_shell_release_chat_work, at_shell_release_chat_handler);
-}
 
 static void at_shell_init_chat(void)
 {
@@ -204,17 +113,11 @@ static void at_shell_init_script_chat(void)
 					   CONFIG_MODEM_AT_SHELL_RESPONSE_TIMEOUT_S);
 }
 
-static void at_shell_init_pipelink(void)
-{
-	modem_pipelink_attach(at_shell_pipelink, at_shell_pipelink_callback, NULL);
-}
-
 static int at_shell_init(void)
 {
-	at_shell_init_work();
 	at_shell_init_chat();
 	at_shell_init_script_chat();
-	at_shell_init_pipelink();
+	modem_at_user_pipe_init(&at_shell_chat);
 	return 0;
 }
 
@@ -228,14 +131,19 @@ static int at_shell_cmd_handler(const struct shell *sh, size_t argc, char **argv
 		return -EINVAL;
 	}
 
-	if (!atomic_test_bit(&at_shell_state, AT_SHELL_STATE_ATTACHED_BIT)) {
-		shell_error(sh, "modem is not ready");
-		return -EPERM;
-	}
-
-	if (atomic_test_and_set_bit(&at_shell_state, AT_SHELL_STATE_SCRIPT_RUNNING_BIT)) {
-		shell_error(sh, "script is already running");
-		return -EBUSY;
+	ret = modem_at_user_pipe_claim();
+	if (ret < 0) {
+		switch (ret) {
+		case -EPERM:
+			shell_error(sh, "modem is not ready");
+			break;
+		case -EBUSY:
+			shell_error(sh, "script is already running");
+			break;
+		default:
+			shell_error(sh, "unknown");
+		}
+		return ret;
 	}
 
 	strncpy(at_shell_request_buf, argv[1], sizeof(at_shell_request_buf) - 1);
@@ -260,7 +168,7 @@ static int at_shell_cmd_handler(const struct shell *sh, size_t argc, char **argv
 	ret = modem_chat_run_script_async(&at_shell_chat, &at_shell_script);
 	if (ret < 0) {
 		shell_error(sh, "failed to start script");
-		atomic_clear_bit(&at_shell_state, AT_SHELL_STATE_SCRIPT_RUNNING_BIT);
+		modem_at_user_pipe_release();
 	}
 
 	return ret;

--- a/drivers/modem/modem_at_user_pipe.c
+++ b/drivers/modem/modem_at_user_pipe.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025 Embeint Holdings Pty Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/modem/at/user_pipe.h>
+#include <zephyr/modem/pipelink.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/logging/log.h>
+
+#define AT_UTIL_MODEM_NODE    DT_ALIAS(modem)
+#define AT_UTIL_PIPELINK_NAME _CONCAT(user_pipe_, CONFIG_MODEM_AT_USER_PIPE_IDX)
+
+#define AT_UTIL_STATE_ATTACHED_BIT       0
+#define AT_UTIL_STATE_SCRIPT_RUNNING_BIT 1
+
+MODEM_PIPELINK_DT_DECLARE(AT_UTIL_MODEM_NODE, AT_UTIL_PIPELINK_NAME);
+
+static struct modem_pipelink *at_util_pipelink =
+	MODEM_PIPELINK_DT_GET(AT_UTIL_MODEM_NODE, AT_UTIL_PIPELINK_NAME);
+
+static struct k_work at_util_open_pipe_work;
+static struct k_work at_util_attach_chat_work;
+static struct k_work at_util_release_chat_work;
+static struct modem_chat *at_util_chat;
+static atomic_t at_util_state;
+
+LOG_MODULE_REGISTER(modem_at_user_pipe, CONFIG_MODEM_LOG_LEVEL);
+
+static void at_util_pipe_callback(struct modem_pipe *pipe, enum modem_pipe_event event,
+				  void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	switch (event) {
+	case MODEM_PIPE_EVENT_OPENED:
+		LOG_INF("pipe opened");
+		k_work_submit(&at_util_attach_chat_work);
+		break;
+
+	default:
+		break;
+	}
+}
+
+void at_util_pipelink_callback(struct modem_pipelink *link, enum modem_pipelink_event event,
+			       void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	switch (event) {
+	case MODEM_PIPELINK_EVENT_CONNECTED:
+		LOG_INF("pipe connected");
+		k_work_submit(&at_util_open_pipe_work);
+		break;
+
+	case MODEM_PIPELINK_EVENT_DISCONNECTED:
+		LOG_INF("pipe disconnected");
+		k_work_submit(&at_util_release_chat_work);
+		break;
+
+	default:
+		break;
+	}
+}
+
+static void at_util_open_pipe_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	LOG_INF("opening pipe");
+
+	modem_pipe_attach(modem_pipelink_get_pipe(at_util_pipelink), at_util_pipe_callback, NULL);
+
+	modem_pipe_open_async(modem_pipelink_get_pipe(at_util_pipelink));
+}
+
+static void at_util_attach_chat_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	modem_chat_attach(at_util_chat, modem_pipelink_get_pipe(at_util_pipelink));
+	atomic_set_bit(&at_util_state, AT_UTIL_STATE_ATTACHED_BIT);
+	LOG_INF("chat attached");
+}
+
+static void at_util_release_chat_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	modem_chat_release(at_util_chat);
+	atomic_clear_bit(&at_util_state, AT_UTIL_STATE_ATTACHED_BIT);
+	LOG_INF("chat released");
+}
+
+void modem_at_user_pipe_init(struct modem_chat *chat)
+{
+	at_util_chat = chat;
+	/* Initialise workers and setup callbacks */
+	k_work_init(&at_util_open_pipe_work, at_util_open_pipe_handler);
+	k_work_init(&at_util_attach_chat_work, at_util_attach_chat_handler);
+	k_work_init(&at_util_release_chat_work, at_util_release_chat_handler);
+	modem_pipelink_attach(at_util_pipelink, at_util_pipelink_callback, NULL);
+}
+
+int modem_at_user_pipe_claim(void)
+{
+	if (!atomic_test_bit(&at_util_state, AT_UTIL_STATE_ATTACHED_BIT)) {
+		return -EPERM;
+	}
+
+	if (atomic_test_and_set_bit(&at_util_state, AT_UTIL_STATE_SCRIPT_RUNNING_BIT)) {
+		return -EBUSY;
+	}
+
+	return 0;
+}
+
+void modem_at_user_pipe_release(void)
+{
+	atomic_clear_bit(&at_util_state, AT_UTIL_STATE_SCRIPT_RUNNING_BIT);
+}

--- a/include/zephyr/modem/at/user_pipe.h
+++ b/include/zephyr/modem/at/user_pipe.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Embeint Holdings Pty Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_MODEM_AT_USER_PIPE_
+#define ZEPHYR_MODEM_AT_USER_PIPE_
+
+#include <zephyr/modem/chat.h>
+
+/**
+ * @brief Initialise the AT command user pipe
+ *
+ * @param chat Chat instance that will be used with the user pipe
+ */
+void modem_at_user_pipe_init(struct modem_chat *chat);
+
+/**
+ * @brief Claim the AT command user pipe to run commands
+ *
+ *
+ * @retval 0 On success
+ * @retval -EPERM Modem is not ready
+ * @retval -EBUSY User pipe already claimed
+ */
+int modem_at_user_pipe_claim(void);
+
+/**
+ * @brief Release the AT command user pipe to other users
+ *
+ * Must be called after @ref modem_at_user_pipe_claim when pipe is no longer
+ * in use.
+ */
+void modem_at_user_pipe_release(void);
+
+#endif /* ZEPHYR_MODEM_AT_USER_PIPE_ */


### PR DESCRIPTION
Extract the user pipe setup and claim/release logic so that it can be re-used by other software modules, if the AT shell is not used. Ideally the chat instance would live within the `modem_at_user_pipe.c` and be handed out by `modem_at_user_pipe_claim`, but the current chat API doesn't make this possible.