### PR TITLE
MSPM0 int_group handler (NVIC 0 and 1)

### DIFF
--- a/drivers/gpio/Kconfig.mspm0
+++ b/drivers/gpio/Kconfig.mspm0
@@ -7,6 +7,7 @@ config GPIO_MSPM0
 	bool "TI MSPM0 GPIO driver"
 	default y
 	depends on DT_HAS_TI_MSPM0_GPIO_ENABLED
+	select SOC_TI_MSPM0_INT_GROUP_1
 	select USE_MSPM0_DL_GPIO
 	help
 	  Enable the TI MSPM0 GPIO driver.

--- a/dts/arm/ti/mspm0/g/mspm0gx51x.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0gx51x.dtsi
@@ -8,6 +8,7 @@
 			compatible = "ti,mspm0-gpio";
 			reg = <0x400a4000 0x2000>;
 			interrupts = <1 0>;
+			ti,int-group-iidx = <6>;
 			status = "disabled";
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/dts/arm/ti/mspm0/g/mspm0gx51x.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0gx51x.dtsi
@@ -1,4 +1,10 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Texas Instruments
+ * Copyright (c) 2025 Linumiz
+ * Copyright (c) 2025 Bang & Olufsen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <ti/mspm0/g/mspm0g.dtsi>
 

--- a/dts/arm/ti/mspm0/l/mspm0l.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l.dtsi
@@ -12,6 +12,7 @@
 		compatible = "ti,mspm0-gpio";
 		reg = <0x400a4000 0x2000>;
 		interrupts = <1 0>;
+		ti,int-group-iidx = <6>;
 		status = "disabled";
 		gpio-controller;
 		#gpio-cells = <2>;

--- a/dts/arm/ti/mspm0/mspm0.dtsi
+++ b/dts/arm/ti/mspm0/mspm0.dtsi
@@ -172,6 +172,7 @@
 				compatible = "ti,mspm0-gpio";
 				reg = <0x400a0000 0x2000>;
 				interrupts = <1 0>;
+				ti,int-group-iidx = <0>;
 				status = "disabled";
 				gpio-controller;
 				#gpio-cells = <2>;
@@ -181,6 +182,7 @@
 				compatible = "ti,mspm0-gpio";
 				reg = <0x400a2000 0x2000>;
 				interrupts = <1 0>;
+				ti,int-group-iidx = <1>;
 				status = "disabled";
 				gpio-controller;
 				#gpio-cells = <2>;

--- a/dts/bindings/gpio/ti,mspm0-gpio.yaml
+++ b/dts/bindings/gpio/ti,mspm0-gpio.yaml
@@ -13,6 +13,12 @@ properties:
   interrupts:
     required: true
 
+  ti,int-group-iidx:
+    required: true
+    type: int
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+    description: Set the interrupt index
+
   "#gpio-cells":
     const: 2
 

--- a/soc/ti/mspm0/Kconfig
+++ b/soc/ti/mspm0/Kconfig
@@ -15,6 +15,16 @@ config MSPM0_PERIPH_STARTUP_DELAY
 	int
 	default 8
 
+# MSPM0 shares the NVIC interrupt 0 and 1 up to 8 IP blocks each,
+# called interrupt groups 0 and 1 respectively.
+# These IP blocks are not either/or but always in such group
+# so up to these blocks to select the right group they are in.
+config SOC_TI_MSPM0_INT_GROUP_0
+	bool
+
+config SOC_TI_MSPM0_INT_GROUP_1
+	bool
+
 config HWINFO
 	bool
 	default y if POWEROFF

--- a/soc/ti/mspm0/common/soc.c
+++ b/soc/ti/mspm0/common/soc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2025 Texas Instruments
  * Copyright (c) 2025 Linumiz GmbH
+ * Copyright (c) 2025 Bang & Olufsen
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,10 +9,143 @@
 #include <zephyr/init.h>
 #include <ti/driverlib/driverlib.h>
 
+#if defined(CONFIG_SOC_TI_MSPM0_INT_GROUP_0) ||		\
+	defined(CONFIG_SOC_TI_MSPM0_INT_GROUP_1)
+#include <ti/driverlib/m0p/dl_interrupt.h>
+
+#include <zephyr/irq.h>
+#include <errno.h>
+
 #include <soc.h>
+
+struct mspm0_int_grp_iidx {
+	void (*isr_handler)(const struct device *dev);
+	const struct device *dev;
+};
+#endif /* CONFIG_SOC_TI_MSPM0_INT_GROUP_0 || CONFIG_SOC_TI_MSPM0_INT_GROUP_1 */
+
+#ifdef CONFIG_SOC_TI_MSPM0_INT_GROUP_0
+static struct mspm0_int_grp_iidx mspm0_int_grp0[8];
+static uint32_t mspm0_int_grp0_mask;
+#endif /* CONFIG_SOC_TI_MSPM0_INT_GROUP_0 */
+
+#ifdef CONFIG_SOC_TI_MSPM0_INT_GROUP_1
+static struct mspm0_int_grp_iidx mspm0_int_grp1[8];
+static uint32_t mspm0_int_grp1_mask;
+#endif /* CONFIG_SOC_TI_MSPM0_INT_GROUP_1 */
+
+#if defined(CONFIG_SOC_TI_MSPM0_INT_GROUP_0) ||		\
+	defined(CONFIG_SOC_TI_MSPM0_INT_GROUP_1)
+static ALWAYS_INLINE void handle_group_isr(int group, uint32_t int_grp_mask,
+					   struct mspm0_int_grp_iidx int_grp[8])
+{
+	uint32_t triggered = DL_Interrupt_getStatusGroup(group,
+							 int_grp_mask) & 0xff;
+
+	DL_Interrupt_clearGroup(group, triggered);
+
+	/* Groups are priority-ordered: the lower the index,
+	 * the higher the priority.
+	 */
+	while (triggered) {
+		if (triggered & 1) {
+			int_grp->isr_handler(int_grp->dev);
+		}
+
+		int_grp++;
+		triggered >>= 1;
+	}
+}
+
+static inline int register_group_isr(uint8_t int_idx,
+				     uint32_t *int_grp_mask,
+				     struct mspm0_int_grp_iidx int_grp[8],
+				     void (*isr_handler)(const struct device *dev),
+				     const struct device *dev)
+{
+	if (*int_grp_mask & BIT(int_idx)) {
+		return -EALREADY;
+	}
+
+	int_grp[int_idx].isr_handler = isr_handler;
+	int_grp[int_idx].dev = dev;
+
+	*int_grp_mask |= BIT(int_idx);
+
+	return 0;
+}
+#endif /* CONFIG_SOC_TI_MSPM0_INT_GROUP_0 || CONFIG_SOC_TI_MSPM0_INT_GROUP_1 */
+
+#ifdef CONFIG_SOC_TI_MSPM0_INT_GROUP_0
+static void mspm0_int_group_0_isr(const struct device *unused)
+{
+	ARG_UNUSED(unused);
+
+	handle_group_isr(0, mspm0_int_grp0_mask, mspm0_int_grp0);
+}
+#endif /* CONFIG_SOC_TI_MSPM0_INT_GROUP_0 */
+
+#ifdef CONFIG_SOC_TI_MSPM0_INT_GROUP_1
+static void mspm0_int_group_1_isr(const struct device *unused)
+{
+	ARG_UNUSED(unused);
+
+	handle_group_isr(1, mspm0_int_grp1_mask, mspm0_int_grp1);
+}
+#endif /* CONFIG_SOC_TI_MSPM0_INT_GROUP_1 */
+
+#if defined(CONFIG_SOC_TI_MSPM0_INT_GROUP_0) ||		\
+	defined(CONFIG_SOC_TI_MSPM0_INT_GROUP_1)
+int mspm0_register_int_to_group(int group, uint8_t int_idx,
+				void (*isr_handler)(const struct device *dev),
+				const struct device *dev)
+{
+	int ret;
+
+	if ((!IS_ENABLED(CONFIG_SOC_TI_MSPM0_INT_GROUP_0) && group == 0) ||
+	    (!IS_ENABLED(CONFIG_SOC_TI_MSPM0_INT_GROUP_1) && group == 1)) {
+		return -ENOTSUP;
+	}
+
+	if (int_idx > 7 || isr_handler == NULL) {
+		return -EINVAL;
+	}
+
+#ifdef CONFIG_SOC_TI_MSPM0_INT_GROUP_0
+	if (group == 0) {
+		ret = register_group_isr(int_idx, &mspm0_int_grp0_mask,
+					 mspm0_int_grp0, isr_handler, dev);
+	} else
+#endif /* CONFIG_SOC_TI_MSPM0_INT_GROUP_0 */
+#ifdef CONFIG_SOC_TI_MSPM0_INT_GROUP_1
+	if (group == 1) {
+		ret = register_group_isr(int_idx, &mspm0_int_grp1_mask,
+					 mspm0_int_grp1, isr_handler, dev);
+	} else
+#endif /* CONFIG_SOC_TI_MSPM0_INT_GROUP_1 */
+	{
+		return -EINVAL;
+	}
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	irq_enable(group);
+
+	return 0;
+}
+#endif /* CONFIG_SOC_TI_MSPM0_INT_GROUP_0 || CONFIG_SOC_TI_MSPM0_INT_GROUP_1 */
 
 void soc_early_init_hook(void)
 {
 	/* Low Power Mode is configured to be SLEEP0 */
 	DL_SYSCTL_setBORThreshold(DL_SYSCTL_BOR_THRESHOLD_LEVEL_0);
+
+#ifdef CONFIG_SOC_TI_MSPM0_INT_GROUP_0
+	IRQ_CONNECT(0, 0, mspm0_int_group_0_isr, NULL, 0);
+#endif /* CONFIG_SOC_TI_MSPM0_INT_GROUP_0 */
+#ifdef CONFIG_SOC_TI_MSPM0_INT_GROUP_1
+	IRQ_CONNECT(1, 0, mspm0_int_group_1_isr, NULL, 0);
+#endif /* CONFIG_SOC_TI_MSPM0_INT_GROUP_1 */
 }

--- a/soc/ti/mspm0/common/soc.h
+++ b/soc/ti/mspm0/common/soc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2025 Texas Instruments
  * Copyright (c) 2025 Linumiz GmbH
+ * Copyright (c) 2025 Bang & Olufsen
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,5 +11,28 @@
 
 #include <ti/devices/msp/msp.h>
 #include <ti/driverlib/m0p/dl_core.h>
+
+#if defined(CONFIG_SOC_TI_MSPM0_INT_GROUP_0) ||		\
+	defined(CONFIG_SOC_TI_MSPM0_INT_GROUP_1)
+/**
+ * @brief Register an isr_handler into an interrupt group
+ *
+ * @param group The targeted interrupt group (i.e. the NVIC interrupt).
+ * @param int_idx The interrupt group index (aka IIDX).
+ * @param isr_handler  Pointer to the ISR function for the device.
+ * @param dev Pointer to the device that will service the interrupt.
+ *
+ * @return 0 on success, a negative errno otherwise: -ENOTSUP if the given group
+ *         was not enabled, -EINVAL if one of the parameter is invalid and
+ *         -EALREADY if the given int_idx has already been registered.
+ */
+int mspm0_register_int_to_group(int group, uint8_t int_idx,
+				void (*isr_handler)(const struct device *dev),
+				const struct device *dev);
+#else
+
+#define mspm0_register_int_to_group(...) (-ENOTSUP)
+
+#endif /* CONFIG_SOC_TI_MSPM0_INT_GROUP_0 || CONFIG_SOC_TI_MSPM0_INT_GROUP_1 */
 
 #endif /* _MSPM0_SOC_H */


### PR DESCRIPTION
Various peripheral interrupts are routed through what's being called "interrupt group". There are 2 of these groups, which routes gpio, comparator, watchdog, trng and other few interrupts.

These 2 groups go through NVIC interrupt line 0 and 1. So the isr handler of these lines should be managed differently as they are now. 