### PR TITLE
doc: release process: Update the timeline for the release announcement

### DIFF
--- a/doc/project/release_process.rst
+++ b/doc/project/release_process.rst
@@ -167,9 +167,13 @@ Release Milestones
      - Review target milestones
      - Finalize target milestones for features in flight.
      - Release Engineering
-   * - T-4W
+   * - T-5W
      - Release Announcement
      - Release owner announces feature freeze and timeline for release.
+     - Release Manager
+   * - T-4W
+     - Release Timeline reminder
+     - Release owner sends a reminder of the feature freeze and timeline for release.
      - Release Manager
    * - T-3W
      - Feature Freeze (RC1)


### PR DESCRIPTION
Update the timeline so that the release timeline announcement goes out two weeks prior to rc1. This way developers have more time to ensure that their features will make it to the next release. Also add a reminder of the release timeline one week prior to rc1.