### PR TITLE
Add generated macro and DT macro to count the number of actual peripheral on bus

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -83,6 +83,13 @@ node-macro =/ %s"DT_N" path-id %s"_P_" prop-id %s"_FOREACH_PROP_ELEM_SEP_VARGS"
 ; These are used by DT_CHILD_NUM and DT_CHILD_NUM_STATUS_OKAY macros
 node-macro =/ %s"DT_N" path-id %s"_CHILD_NUM"
 node-macro =/ %s"DT_N" path-id %s"_CHILD_NUM_STATUS_OKAY"
+; These are used by DT_DESCENDANT_NUM_ON_BUS and
+; DT_DESCENDANT_NUM_ON_BUS_STATUS_OKAY
+; macros to count descendants on a given bus under a controller node.
+; Descendants behind child bus-controller nodes are excluded.
+; dt-name in this case is something like "spi" or "i2c".
+node-macro =/ %s"DT_N" path-id %s"_DESCENDANT_NUM_ON_BUS_" dt-name
+node-macro =/ %s"DT_N" path-id %s"_DESCENDANT_NUM_ON_BUS_" dt-name %s"_STATUS_OKAY"
 ; This is used by DT_CHILD_BY_UNIT_ADDR_INT
 node-macro =/ %s"DT_N" path-id %s"_CHILD_UNIT_ADDR_INT_" DIGIT
 ; These are used internally by DT_FOREACH_CHILD, which iterates over

--- a/dts/bindings/test/vnd,controller-device-setting.yaml
+++ b/dts/bindings/test/vnd,controller-device-setting.yaml
@@ -1,0 +1,8 @@
+description: Controller to device setting in 1 to many mapping
+
+compatible: "vnd,controller-device-setting"
+
+properties:
+  val1:
+    type: int
+    required: true

--- a/dts/bindings/test/vnd,controller.yaml
+++ b/dts/bindings/test/vnd,controller.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2025, Ambiq Micro Inc. <www.ambiq.com>
+# SPDX-License-Identifier: Apache-2.0
+description: Test Generic Controller Bus
+
+compatible: "vnd,controller"
+
+include: base.yaml
+
+bus: generic
+
+properties:
+  reg:
+    required: true

--- a/dts/bindings/test/vnd,device-extender.yaml
+++ b/dts/bindings/test/vnd,device-extender.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2025, Ambiq Micro Inc. <www.ambiq.com>
+# SPDX-License-Identifier: Apache-2.0
+description: Test Generic Device extender
+
+compatible: "vnd,device-extender"
+
+include: base.yaml
+
+on-bus: generic
+
+bus: generic

--- a/dts/bindings/test/vnd,device.yaml
+++ b/dts/bindings/test/vnd,device.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Ambiq Micro Inc. <www.ambiq.com>
+# SPDX-License-Identifier: Apache-2.0
+description: Test Generic Device
+
+compatible: "vnd,device"
+
+include: base.yaml
+
+on-bus: generic

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -694,16 +694,40 @@
  */
 #define DT_CHILD_NUM(node_id) DT_CAT(node_id, _CHILD_NUM)
 
-
 /**
- * @brief Get the number of child nodes of a given node
- *        which child nodes' status are okay
+ * @brief Get the number of child nodes of a given node,
+ *        whose status is okay
  *
  * @param node_id a node identifier
  * @return Number of child nodes which status are okay
  */
 #define DT_CHILD_NUM_STATUS_OKAY(node_id) \
 	DT_CAT(node_id, _CHILD_NUM_STATUS_OKAY)
+
+/**
+ * @brief Get the number of descendant nodes of a given node
+ *        that are on the given bus,
+ *        whose binding defines the given bus as their on-bus key
+ *
+ * @param node_id a node identifier
+ * @param bus bus type string
+ * @return Number of descendant nodes
+ */
+#define DT_DESCENDANT_NUM_ON_BUS(node_id, bus) \
+	DT_CAT3(node_id, _DESCENDANT_NUM_ON_BUS_, bus)
+
+/**
+ * @brief Get the number of descendant nodes of a given node
+ *        that are on the given bus,
+ *        whose binding defines the given bus as their on-bus key,
+ *        and whose status is okay
+ *
+ * @param node_id a node identifier
+ * @param bus bus type string
+ * @return Number of descendant nodes
+ */
+#define DT_DESCENDANT_NUM_ON_BUS_STATUS_OKAY(node_id, bus) \
+	DT_CAT4(node_id, _DESCENDANT_NUM_ON_BUS_, bus, _STATUS_OKAY)
 
 /**
  * @brief Do @p node_id1 and @p node_id2 refer to the same node?
@@ -4278,7 +4302,8 @@
 #define DT_INST_CHILD_NUM(inst) DT_CHILD_NUM(DT_DRV_INST(inst))
 
 /**
- * @brief Get the number of child nodes of a given node
+ * @brief Get the number of child nodes of a given node,
+ *        whose status is okay
  *
  * This is equivalent to @see
  * <tt>DT_CHILD_NUM_STATUS_OKAY(DT_DRV_INST(inst))</tt>.
@@ -4288,6 +4313,37 @@
  */
 #define DT_INST_CHILD_NUM_STATUS_OKAY(inst) \
 	DT_CHILD_NUM_STATUS_OKAY(DT_DRV_INST(inst))
+
+/**
+ * @brief Get the number of descendant nodes of a given node
+ *        that are on the given bus,
+ *        whose binding defines the given bus as their on-bus key
+ *
+ * This is equivalent to @see
+ * <tt>DT_DESCENDANT_NUM_ON_BUS(DT_DRV_INST(inst), bus)</tt>.
+ *
+ * @param inst Devicetree instance number
+ * @param bus bus type string
+ * @return Number of descendant nodes
+ */
+#define DT_INST_DESCENDANT_NUM_ON_BUS(inst, bus) \
+	DT_DESCENDANT_NUM_ON_BUS(DT_DRV_INST(inst), bus)
+
+/**
+ * @brief Get the number of descendant nodes of a given node
+ *        that are on the given bus,
+ *        whose binding defines the given bus as their on-bus key,
+ *        and whose status is okay
+ *
+ * This is equivalent to @see
+ * <tt>DT_DESCENDANT_NUM_ON_BUS_STATUS_OKAY(DT_DRV_INST(inst), bus)</tt>.
+ *
+ * @param inst Devicetree instance number
+ * @param bus bus type string
+ * @return Number of descendant nodes
+ */
+#define DT_INST_DESCENDANT_NUM_ON_BUS_STATUS_OKAY(inst, bus) \
+	DT_DESCENDANT_NUM_ON_BUS_STATUS_OKAY(DT_DRV_INST(inst), bus)
 
 /**
  * @brief Get a string array of DT_DRV_INST(inst)'s node labels

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -1120,6 +1120,44 @@ def write_global_macros(edt: edtlib.EDT):
             out_define(
                 f"DT_COMPAT_{str2ident(compat)}_BUS_{str2ident(bus)}", 1)
 
+    bus_by_id = {}
+    for node in edt.nodes:
+        if node.bus_node is not None:
+            bus_by_id[node.bus_node.z_path_id] = node.bus_node
+
+    def _iter_descendants(node):
+        # Iterate descendants but stop recursion at bus nodes (i.e. nodes that
+        # themselves expose a bus). This allows counting devices nested below
+        # helper/container nodes while not traversing into sub-buses.
+        for child in node.children.values():
+            yield child
+            if not child.buses:
+                yield from _iter_descendants(child)
+
+    # For each bus controller and each bus type it exposes, count descendant
+    # nodes whose resolved on-bus matches that bus.
+    for bus_id, bus_node in bus_by_id.items():
+
+        for bus in bus_node.buses:
+            bus_ident = str2ident(bus)
+
+            count = 0
+            count_ok = 0
+            for descendant in _iter_descendants(bus_node):
+                # Count nodes that are on this bus, including nodes that are
+                # themselves bus nodes. Recursion into bus-node subtrees is
+                # prevented by _iter_descendants, so we won't double-count
+                # devices behind sub-buses.
+                if descendant.on_bus == bus:
+                    count += 1
+                    if descendant.status == "okay":
+                        count_ok += 1
+
+            out_comment(f"Bus info (controller: '{bus_node.path}', bus: '{bus_ident}')")
+            out_comment("Includes descendants on this bus, excludes devices behind child buses")
+            out_dt_define(f"{bus_id}_DESCENDANT_NUM_ON_BUS_{bus_ident}", count)
+            out_dt_define(f"{bus_id}_DESCENDANT_NUM_ON_BUS_{bus_ident}_STATUS_OKAY", count_ok)
+
 
 def str2ident(s: str) -> str:
     # Converts 's' to a form suitable for (part of) an identifier

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1111,6 +1111,11 @@ class Node:
       returning the value of the first 'bus:' key found. If none of the node's
       parents has a 'bus:' key, this attribute is an empty list.
 
+    on_bus:
+      Resolved bus type for this node, or None if the node is not on a bus.
+      If the binding sets 'on-bus', that value is validated against the parent
+      bus controller's bus types and used only when it matches.
+
     bus_node:
       Like on_bus, but contains the Node for the bus controller, or None if the
       node is not on a bus.
@@ -1326,6 +1331,18 @@ class Node:
         "See the class docstring"
         bus_node = self.bus_node
         return bus_node.buses if bus_node else []
+
+    @property
+    def on_bus(self) -> Optional[str]:
+        "See the class docstring"
+        if self._binding and self._binding.on_bus is not None:
+            bus_node = self.bus_node
+            if bus_node and self._binding.on_bus in bus_node.buses:
+                return self._binding.on_bus
+            else:
+                return None
+        else:
+            return None
 
     @property
     def flash_controller(self) -> 'Node':

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -735,6 +735,98 @@
 			};
 		};
 
+		test_children_on_bus: controller@ccccdddd {
+			compatible = "vnd,controller";
+			reg = <0xccccdddd 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* Child number 1 of the controller */
+			test_child_on_bus_a: test-child-a@0 {
+				compatible = "vnd,device";
+				reg = <0x0 0x100>;
+				status = "okay";
+			};
+
+			/* Child number 2 of the controller */
+			test_child_on_bus_b: test-child-b@100 {
+				compatible = "vnd,device";
+				reg = <0x100 0x100>;
+				status = "okay";
+			};
+
+			/* Child number 3 of the controller */
+			test_child_on_bus_c: test-child-c@200 {
+				compatible = "vnd,device";
+				reg = <0x200 0x100>;
+				status = "disabled";
+			};
+
+			/*
+			 * Structural container only (no compatible/on-bus): descendants
+			 * below this node are still counted for the controller bus.
+			 */
+			test_child_on_bus_d: test-child-on-bus-d {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
+
+				/* Child number 4 of the controller */
+				test_child_dd: test-child-dd@300 {
+					compatible = "vnd,device";
+					reg = <0x300 0x100>;
+					status = "okay";
+				};
+
+				/* Child number 5 of the controller */
+				test_child_ee: test-child-ee@400 {
+					compatible = "vnd,device";
+					reg = <0x400 0x100>;
+					status = "disabled";
+				};
+			};
+
+			/*
+			 * Child number 6 of the controller.
+			 * Also acts as a child bus controller, so it is counted for the
+			 * parent bus, while descendants behind this node are counted only
+			 * when querying this node itself.
+			 */
+			test_child_on_bus_ext: test-child-on-bus-ext@500 {
+				compatible = "vnd,device-extender";
+				reg = <0x500 0x300>;
+				ranges = <0x0 0x600 0x200>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				/* Child number 1 of the extender */
+				test_child_a_on_ext: test-child-a-on-ext@0 {
+					compatible = "vnd,device";
+					reg = <0x0 0x100>;
+					status = "okay";
+				};
+
+				/* Child number 2 of the extender */
+				test_child_b_on_ext: test-child-b-on-ext@100 {
+					compatible = "vnd,device";
+					reg = <0x100 0x100>;
+					status = "disabled";
+				};
+			};
+
+			/* Not a physical child node of the controller bus */
+			controller_dev_setting_a: setting-a {
+				compatible = "vnd,controller-device-setting";
+				val1 = <1>;
+			};
+
+			/* Not a physical child node of the controller bus */
+			controller_dev_setting_b: setting-b {
+				compatible = "vnd,controller-device-setting";
+				val1 = <2>;
+			};
+		};
+
 		test-ranges {
 			#address-cells = <2>;
 			#size-cells = <1>;

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -77,6 +77,9 @@
 #define TEST_DMA_CTLR_1 DT_NODELABEL(test_dma1)
 #define TEST_DMA_CTLR_2 DT_NODELABEL(test_dma2)
 
+#define TEST_CONTROLLER DT_NODELABEL(test_children_on_bus)
+#define TEST_BUS_EXT    DT_NODELABEL(test_child_on_bus_ext)
+
 #define TEST_VIDEO2           DT_NODELABEL(test_video2)
 #define TEST_VIDEO2_PORT0     DT_NODELABEL(test_video2_port0)
 #define TEST_VIDEO2_PORT0_IN0 DT_NODELABEL(test_video2_port0_in0)
@@ -2817,6 +2820,18 @@ ZTEST(devicetree_api, test_child_nodes_number)
 ZTEST(devicetree_api, test_great_grandchild)
 {
 	zassert_equal(DT_PROP(DT_NODELABEL(test_ggc), ggc_prop), 42, "");
+}
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_controller
+ZTEST(devicetree_api, test_descendant_on_bus_nodes_number)
+{
+	zassert_equal(DT_DESCENDANT_NUM_ON_BUS(TEST_CONTROLLER, generic), 6, "");
+	zassert_equal(DT_INST_DESCENDANT_NUM_ON_BUS(0, generic), 6, "");
+	zassert_equal(DT_DESCENDANT_NUM_ON_BUS_STATUS_OKAY(TEST_CONTROLLER, generic), 4, "");
+	zassert_equal(DT_INST_DESCENDANT_NUM_ON_BUS_STATUS_OKAY(0, generic), 4, "");
+	zassert_equal(DT_DESCENDANT_NUM_ON_BUS(TEST_BUS_EXT, generic), 2, "");
+	zassert_equal(DT_DESCENDANT_NUM_ON_BUS_STATUS_OKAY(TEST_BUS_EXT, generic), 1, "");
 }
 
 #undef DT_DRV_COMPAT


### PR DESCRIPTION
## Summary
This PR adds generic devicetree support to count bus-connected device descendants under a controller node, without introducing controller-specific special handling in edtlib.

## Problem
For hierarchical devicetree layouts, direct-child counting is not enough. Real peripheral nodes may be nested under structural/container nodes, and some child nodes may themselves be bus controllers.

Using only direct children can undercount real devices and overfit logic to specific controller implementations.
Take the following device tree as an example. It has 6 peripherals, but with normal child counting, there is 7, not to mention some of them aren't actual peripherals but fake/intermediate nodes. 

```
		test_children_on_bus: controller@ccccdddd {
			compatible = "vnd,controller";
			reg = <0xccccdddd 0x1000>;
			#address-cells = <1>;
			#size-cells = <1>;

			/* Child number 1 of the controller */
			test_child_on_bus_a: test-child-a@0 {
				compatible = "vnd,device";
				reg = <0x0 0x100>;
				status = "okay";
			};

			/* Child number 2 of the controller */
			test_child_on_bus_b: test-child-b@100 {
				compatible = "vnd,device";
				reg = <0x100 0x100>;
				status = "okay";
			};

			/* Child number 3 of the controller */
			test_child_on_bus_c: test-child-c@200 {
				compatible = "vnd,device";
				reg = <0x200 0x100>;
				status = "disabled";
			};

			test_child_on_bus_d: test-child-on-bus-d {
				#address-cells = <1>;
				#size-cells = <1>;
				ranges;

				/* Child number 4 of the controller */
				test_child_dd: test-child-dd@300 {
					compatible = "vnd,device";
					reg = <0x300 0x100>;
					status = "okay";
				};

				/* Child number 5 of the controller */
				test_child_ee: test-child-ee@400 {
					compatible = "vnd,device";
					reg = <0x400 0x100>;
					status = "disabled";
				};
			};

			/* Child number 6 of the controller */
			test_child_on_bus_ext: test-child-on-bus-ext@500 {
				compatible = "vnd,device-extender";
				reg = <0x500 0x300>;
				ranges = <0x0 0x600 0x200>;
				#address-cells = <1>;
				#size-cells = <1>;

				/* Child number 1 of the extender */
				test_child_a_on_ext: test-child-a-on-ext@0 {
					compatible = "vnd,device";
					reg = <0x0 0x100>;
					status = "okay";
				};

				/* Child number 2 of the extender */
				test_child_b_on_ext: test-child-b-on-ext@100 {
					compatible = "vnd,device";
					reg = <0x100 0x100>;
					status = "disabled";
				};
			};

			/* Not a phyiscal child node of the controller */
			controller_dev_setting_a: setting-a {
				compatible = "vnd,controller-device-setting";
				val1 = <1>;
			};

			/* Not a phyiscal child node of the controller */
			controller_dev_setting_b: setting-b {
				compatible = "vnd,controller-device-setting";
				val1 = <2>;
			};
		};
``` 

## Solution
Adds resolved Node.on_bus usage for generation logic, validating binding on-bus against the parent controller’s bus types.
Generates descendant-on-bus count macros in [gen_defines.py](https://file+.vscode-resource.vscode-cdn.net/Users/swift/.vscode/extensions/openai.chatgpt-0.4.71-darwin-x64/webview/#).
Exposes new public macros:
DT_DESCENDANT_NUM_ON_BUS(node_id, bus)
DT_DESCENDANT_NUM_ON_BUS_STATUS_OKAY(node_id, bus)
DT_INST_DESCENDANT_NUM_ON_BUS(inst, bus)
DT_INST_DESCENDANT_NUM_ON_BUS_STATUS_OKAY(inst, bus)
Updates docs and tests accordingly.

### Counting Semantics
Counts nodes whose resolved on_bus matches the queried bus.
Walks descendants (not only direct children).
Stops recursion at child bus-controller nodes.
A child bus-controller node can be counted for the parent bus (if it is on that bus), but devices behind that child bus are excluded from the parent’s count.
_STATUS_OKAY variants apply status filtering.

### Test Coverage
The new devicetree API test topology validates:

Nested devices under non-bus container nodes are counted.
Child bus-controller nodes are counted on the parent bus when applicable.
Devices behind child buses are excluded from parent-bus totals.
Status-okay counts are correct.
Example validated totals:

Parent controller on generic: total 6, status-okay 4
Extender node on generic: total 2, status-okay 1

## Practical Use Cases
Useful for SPI/MSPI and similar multi-peripheral controllers where DTS may include:

Structural/grouping nodes (not actual peripherals),
Stacked-die or wrapper nodes,
Vendor-specific timing/config nodes.
This keeps hierarchy flexible while preserving generic, predictable bus-device counting.

Note that the example is to show one of the possible ways that the DTS could be written without putting specific restrictions in python scripts. 
A few things to note:
- The `ambiq,timing` nodes do not represent an actual peripheral device that are on mspi bus as they are just "grouped" controller specific timing properties by the actual peripheral device i.e. psram and flash. Again, it is one of the possible ways to write down vendor specific controller properties that varies based on the connected peripheral device.
- The actual device nodes in this example have a reg property and its value only represents the sequence as DT allows non consecutive increment. The devices are : S70KL1282_1, S70KL1282_2, is25wx064
- S70KL1282 is a stacked die device which has two spi interfaces to the mspi controller. The node is not on the mspi bus but only its two direct children. **Whether or not they are on mspi bus, it shall be represented by the on_bus key in their compatible bindings**. Again, it is one of the possible ways to represent a stacked die device, but I feel it has the correct hierarchy one would expect. Additionally, there could be some device specific properties such as reset-gpio that are not part of the spi device properties. In this case, the parent holds all the common properties of the its children via additional-property: true, but the example could be written in a way such that every children repeats everything that the parent currently has.
```
&mspi0 {
	pinctrl-0 = <&mspi0_default>;
	pinctrl-1 = <&mspi0_sleep>;
	pinctrl-2 = <&mspi0_psram>;
	pinctrl-3 = <&mspi0_flash>;
	pinctrl-names = "default","sleep","psram","flash";
	status = "okay";
	zephyr,pm-device-runtime-auto;

	cmdq-buffer-location = "SRAM_NO_CACHE";
	cmdq-buffer-size = <256>;

	ambiq,hyperram;

	dqs-support;

	psram_timing: ambiq_timing1 {
		compatible = "ambiq,timing";
		ambiq,timing-config-mask = <0x62>;
		ambiq,timing-config = <8 7 1 0 0 3 10>;
	}

	flash_timing: ambiq_timing2 {
		compatible = "ambiq,timing";
		ambiq,timing-config-mask = <0x62>;
		ambiq,timing-config = <0 16 1 0 0 5 20>;
	}

	S70KL1282: S70KL1282 {
		compatible = "mspi-s70kl1282";
		status = "okay";
		mspi-io-mode = "MSPI_IO_MODE_OCTAL";
		mspi-data-rate = "MSPI_DATA_RATE_S_D_D";
		mspi-max-frequency = <125000000>;
		mspi-dqs-enable;
		read-command = <0x20>;
		write-command = <0xA0>;
		command-length = "INSTR_1_BYTE";
		address-length = "ADDR_4_BYTE";
		rx-dummy = <7>;
		tx-dummy = <8>;
		S70KL1282_1: S70KL1282_1@0 {
			compatible = "mspi-s70kl1282-child",
			size = <DT_SIZE_M(64)>;
			reg = <0>;
			status = "okay";
			mspi-hardware-ce-num = <0>;
			xip-config = <1 0 DT_SIZE_M(8) 0>;
		};
		S70KL1282_2: S70KL1282_2@1 {
			compatible = "mspi-s70kl1282-child",
			size = <DT_SIZE_M(64)>;
			reg = <0>;
			status = "okay";
			mspi-hardware-ce-num = <1>;
			xip-config = <1 DT_SIZE_M(8) DT_SIZE_M(8) 0>;
		};
	};
	is25wx064: is25wx064@2 {
		compatible = "mspi-is25xX0xx", "ambiq,mspi-device";
		size = <DT_SIZE_M(64)>;
		reg = <2>;
		status = "okay";
		mspi-max-frequency = <96000000>;
		mspi-io-mode = "MSPI_IO_MODE_OCTAL_1_8_8";
		mspi-data-rate = "MSPI_DATA_RATE_SINGLE";
		mspi-dqs-enable;
		mspi-hardware-ce-num = <2>;
		read-command = <0xCC>;
		write-command = <0x8E>;
		command-length = "INSTR_1_BYTE";
		address-length = "ADDR_4_BYTE"; 
		rx-dummy = <16>;
		tx-dummy = <0>;
		xip-config = <1 0 DT_SIZE_M(8) 0>;
		ce-break-config = <0 0>;
	};
};
```
The controller may use the actual child number to validate against the maximum allowed number of child devices.

