### PR TITLE
drivers: stm32: correct wrong clock_control_subsys_t cast in clock_control calls

### DIFF
--- a/drivers/mbox/mbox_stm32_hsem.c
+++ b/drivers/mbox/mbox_stm32_hsem.c
@@ -207,7 +207,7 @@ static int mbox_stm32_clock_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (clock_control_on(clk, (clock_control_subsys_t *)&cfg->pclken) != 0) {
+	if (clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken) != 0) {
 		LOG_WRN("Failed to enable clock.");
 		return -EIO;
 	}

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1123,7 +1123,7 @@ static void priv_pcd_prepare(const struct device *dev)
 	priv->pcd.Init.phy_itface = cfg->selected_phy;
 }
 
-static const struct stm32_pclken pclken[] = STM32_DT_INST_CLOCKS(0);
+static struct stm32_pclken pclken[] = STM32_DT_INST_CLOCKS(0);
 
 static int priv_clock_enable(void)
 {
@@ -1182,14 +1182,13 @@ static int priv_clock_enable(void)
 #endif
 
 	if (DT_INST_NUM_CLOCKS(0) > 1) {
-		if (clock_control_configure(clk, (clock_control_subsys_t *)&pclken[1],
-									NULL) != 0) {
+		if (clock_control_configure(clk, &pclken[1], NULL) != 0) {
 			LOG_ERR("Could not select USB domain clock");
 			return -EIO;
 		}
 	}
 
-	if (clock_control_on(clk, (clock_control_subsys_t *)&pclken[0]) != 0) {
+	if (clock_control_on(clk, &pclken[0]) != 0) {
 		LOG_ERR("Unable to enable USB clock");
 		return -EIO;
 	}
@@ -1197,9 +1196,7 @@ static int priv_clock_enable(void)
 	if (IS_ENABLED(CONFIG_UDC_STM32_CLOCK_CHECK)) {
 		uint32_t usb_clock_rate;
 
-		if (clock_control_get_rate(clk,
-					   (clock_control_subsys_t *)&pclken[1],
-					   &usb_clock_rate) != 0) {
+		if (clock_control_get_rate(clk, &pclken[1], &usb_clock_rate) != 0) {
 			LOG_ERR("Failed to get USB domain clock rate");
 			return -EIO;
 		}
@@ -1292,7 +1289,7 @@ static int priv_clock_disable(void)
 {
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (clock_control_off(clk, (clock_control_subsys_t *)&pclken[0]) != 0) {
+	if (clock_control_off(clk, &pclken[0]) != 0) {
 		LOG_ERR("Unable to disable USB clock");
 		return -EIO;
 	}

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -180,7 +180,7 @@ static int stm32_dcmi_enable_clock(const struct device *dev)
 	}
 
 	/* Turn on DCMI peripheral clock */
-	return clock_control_on(dcmi_clock, (clock_control_subsys_t *)&config->pclken);
+	return clock_control_on(dcmi_clock, (clock_control_subsys_t)&config->pclken);
 }
 
 static int video_stm32_dcmi_set_fmt(const struct device *dev, struct video_format *fmt)

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1597,7 +1597,7 @@ static int stm32_dcmipp_enable_clock(const struct device *dev)
 		return err;
 	}
 
-	err = clock_control_on(cc_node, (clock_control_subsys_t *)&config->dcmipp_pclken);
+	err = clock_control_on(cc_node, (clock_control_subsys_t)&config->dcmipp_pclken);
 	if (err < 0) {
 		LOG_ERR("Failed to enable DCMIPP clock. Error %d", err);
 		return err;
@@ -1605,7 +1605,7 @@ static int stm32_dcmipp_enable_clock(const struct device *dev)
 
 #if defined(STM32_DCMIPP_HAS_CSI)
 	/* Turn on CSI peripheral clock */
-	err = clock_control_on(cc_node, (clock_control_subsys_t *)&config->csi_pclken);
+	err = clock_control_on(cc_node, (clock_control_subsys_t)&config->csi_pclken);
 	if (err < 0) {
 		LOG_ERR("Failed to enable CSI clock. Error %d", err);
 		return err;


### PR DESCRIPTION
This PR correct incorrects (clock_control_subsys_t *) cast done when calling some clock_control_ apis in some stm32 drivers.