### PR TITLE
soc: ish: Refactor PM code

### DIFF
--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -74,17 +74,23 @@
 		zephyr,memory-region = "AON";
 	};
 
-	soc {
+	soc: soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		#interrupt-cells = <3>;
 		compatible = "simple-bus";
+		interrupt-parent = <&intc>;
+		interrupts = <
+			6 IRQ_TYPE_FIXED_LEVEL_HIGH 1
+			9 IRQ_TYPE_FIXED_LEVEL_HIGH 1
+			10 IRQ_TYPE_FIXED_LEVEL_HIGH 1
+		>;
+		interrupt-names = "reset_prep", "pcidev", "pmu2ioapic";
 		ranges;
 
 		hpet: hpet@4700000 {
 			compatible = "intel,hpet";
 			reg = <0x04700000 0x400>;
-			interrupt-parent = <&intc>;
 			interrupts = <14 IRQ_TYPE_FIXED_LEVEL_HIGH 2>;
 
 			status = "okay";
@@ -94,7 +100,6 @@
 			compatible = "intel,sedi-ipm";
 			peripheral-id = <0>;
 			reg = <0x4100000 0x1000>;
-			interrupt-parent = <&intc>;
 			interrupts = <0 IRQ_TYPE_LOWEST_LEVEL_HIGH 2>;
 
 			status = "okay";
@@ -104,7 +109,6 @@
 			compatible = "intel,sedi-uart";
 			peripheral-id = <0>;
 			reg = <0x08100000 0x1000>;
-			interrupt-parent = <&intc>;
 			interrupts = <23 IRQ_TYPE_LOWEST_EDGE_RISING 6>;
 
 			status = "okay";
@@ -115,7 +119,6 @@
 			compatible = "intel,sedi-uart";
 			peripheral-id = <1>;
 			reg = <0x08102000 0x1000>;
-			interrupt-parent = <&intc>;
 			interrupts = <24 IRQ_TYPE_LOWEST_EDGE_RISING 6>;
 
 			status = "disabled";
@@ -126,7 +129,6 @@
 			compatible = "intel,sedi-uart";
 			peripheral-id = <2>;
 			reg = <0x08104000 0x1000>;
-			interrupt-parent = <&intc>;
 			interrupts = <25 IRQ_TYPE_LOWEST_EDGE_RISING 6>;
 
 			status = "disabled";
@@ -139,7 +141,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x0 0x1000>;
-			interrupt-parent = <&intc>;
 			interrupts = <15 IRQ_TYPE_LOWEST_LEVEL_HIGH 2>;
 
 			status = "okay";
@@ -152,7 +153,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00002000 0x1000>;
-			interrupt-parent = <&intc>;
 			interrupts = <16 IRQ_TYPE_LOWEST_LEVEL_HIGH 2>;
 
 			status = "okay";
@@ -165,7 +165,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00004000 0x1000>;
-			interrupt-parent = <&intc>;
 			interrupts = <17 IRQ_TYPE_LOWEST_LEVEL_HIGH 2>;
 
 			status = "disabled";
@@ -178,7 +177,6 @@
 			#gpio-cells = <2>;
 			peripheral-id = <0>;
 			reg = <0x00100000 0x1000>;
-			interrupt-parent = <&intc>;
 			interrupts = <13 IRQ_TYPE_LOWEST_LEVEL_HIGH 2>;
 			ngpios = <32>;
 
@@ -191,7 +189,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x8000000 0x1000>;
-			interrupt-parent = <&intc>;
 			interrupts = <19 IRQ_TYPE_LOWEST_LEVEL_HIGH 2>;
 
 			status = "okay";
@@ -203,7 +200,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x8002000 0x1000>;
-			interrupt-parent = <&intc>;
 			interrupts = <20 IRQ_TYPE_LOWEST_LEVEL_HIGH 2>;
 
 			status = "disabled";
@@ -214,7 +210,6 @@
 			peripheral-id = <0>;
 			reg = <0x10100000 0x1000>;
 			interrupts = <11 IRQ_TYPE_LOWEST_LEVEL_HIGH 2>;
-			interrupt-parent = <&intc>;
 			#dma-cells = <2>;
 			dma-channels = <8>;
 			dma-buf-size-alignment = <4>;

--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -41,7 +41,7 @@
 			device_type = "cpu";
 			compatible = "intel,ish", "intel,x86";
 			reg = <0>;
-			cpu-power-states = <&d0i0 &d0i2 &d0i3>;
+			cpu-power-states = <&d0i0 &d0i2>;
 		};
 	};
 

--- a/dts/x86/intel/intel_ish5_8.dtsi
+++ b/dts/x86/intel/intel_ish5_8.dtsi
@@ -6,6 +6,15 @@
 
 #include <intel/intel_ish5.dtsi>
 
+&soc {
+	interrupts = <
+		8 IRQ_TYPE_FIXED_LEVEL_HIGH 1
+		11 IRQ_TYPE_FIXED_LEVEL_HIGH 1
+		12 IRQ_TYPE_FIXED_LEVEL_HIGH 1
+	>;
+	interrupt-names = "reset_prep", "pcidev", "pmu2ioapic";
+};
+
 &hpet {
 	interrupts = <17 IRQ_TYPE_FIXED_LEVEL_HIGH 2>;
 

--- a/include/zephyr/arch/x86/ia32/scripts/ish_aon.ld
+++ b/include/zephyr/arch/x86/ia32/scripts/ish_aon.ld
@@ -1,32 +1,22 @@
 /*
- * Copyright (c) 2023 Intel Corporation.
+ * Copyright (c) 2023-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define AON_C_OBJECT_FILE_IN_SECT(lsect, objfile)			\
-        KEEP(*_intel_hal.a:objfile.c.obj(.##lsect))		\
-        KEEP(*_intel_hal.a:objfile.c.obj(.##lsect##.*))
-
-#define AON_S_OBJECT_FILE_IN_SECT(lsect, objfile)			\
-        KEEP(*_intel_hal.a:objfile.S.obj(.##lsect))		\
-        KEEP(*_intel_hal.a:objfile.S.obj(.##lsect##.*))
-
-#define AON_IN_SECT(lsect)						\
-        AON_C_OBJECT_FILE_IN_SECT(lsect, aon_task)			\
-        AON_C_OBJECT_FILE_IN_SECT(lsect, ish_dma)			\
-        AON_S_OBJECT_FILE_IN_SECT(lsect, ipapg)
-
-GROUP_START(AON)
+GROUP_START(ISH_AON)
 
 	SECTION_PROLOGUE(aon,,)
 	{
-		aon_start = .;
-		KEEP(*(.data.aon_share))
-		AON_IN_SECT(data)
-		AON_IN_SECT(text)
-		AON_IN_SECT(bss)
-		aon_end = .;
+		__ish_aon_region_start = .;
+
+		KEEP(*libintel_hal_aontask.a:*(.text.*))
+		KEEP(*libintel_hal_aontask.a:*(.rodata.*))
+		KEEP(*libintel_hal_aontask.a:*(.data.*))
+		KEEP(*libintel_hal_aontask.a:*(.bss.*))
+
+		. = ALIGN(4);
+		__ish_aon_region_end = .;
 	} GROUP_LINK_IN(AON)
 
-GROUP_END(AON)
+GROUP_END(ISH_AON)

--- a/soc/intel/intel_ish/intel_ish5/pm/power.c
+++ b/soc/intel/intel_ish/intel_ish5/pm/power.c
@@ -1,21 +1,13 @@
 /*
- * Copyright (c) 2023 Intel Corporation
+ * Copyright (c) 2023-2025 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/pm/pm.h>
-#include <zephyr/pm/policy.h>
-#include <zephyr/device.h>
-#include <zephyr/init.h>
-#include <zephyr/irq.h>
-#include <zephyr/logging/log_core.h>
-#include <stdio.h>
-#include <zephyr/drivers/interrupt_controller/ioapic.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(pm_service, CONFIG_PM_LOG_LEVEL);
+LOG_MODULE_REGISTER(ish_pm, CONFIG_PM_LOG_LEVEL);
 
 /* low power modes */
 #define FW_D0		0
@@ -28,8 +20,11 @@ extern void sedi_pm_enter_power_state(int state);
 
 void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
-	LOG_DBG(" -> SoC D0i%u, idle=%u ms", substate_id,
+	if (state >= PM_STATE_SUSPEND_TO_RAM) {
+		/* Avoid tedious logs for power states lower than SUSPEND_TO_RAM */
+		LOG_DBG(" -> SoC D0i%u, idle=%u ms", substate_id,
 				k_ticks_to_ms_floor32(_kernel.idle));
+	}
 
 	switch (state) {
 	case PM_STATE_RUNTIME_IDLE:
@@ -45,11 +40,13 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 		sedi_pm_enter_power_state(FW_D0i3);
 		break;
 	default:
-		LOG_DBG("Unsupported power state %u", state);
+		LOG_ERR("Unsupported power state %u", state);
 		break;
 	}
 
-	LOG_DBG("SoC D0i%u ->", substate_id);
+	if (state >= PM_STATE_SUSPEND_TO_RAM) {
+		LOG_DBG("SoC D0i%u ->", substate_id);
+	}
 }
 
 /* Handle SOC specific activity after Low Power Mode Exit */

--- a/soc/intel/intel_ish/intel_ish5/pm/power.c
+++ b/soc/intel/intel_ish/intel_ish5/pm/power.c
@@ -5,6 +5,10 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+#include <zephyr/init.h>
+
+#include "sedi_driver_pm.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ish_pm, CONFIG_PM_LOG_LEVEL);
@@ -58,11 +62,32 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 #if defined(CONFIG_REBOOT) && !defined(CONFIG_REBOOT_RST_CNT)
-extern void sedi_pm_reset(void);
-
 void sys_arch_reboot(int type)
 {
 	ARG_UNUSED(type);
 	sedi_pm_reset();
 }
 #endif
+
+#define ISH_SOC_IRQ(_node_name, _cell) DT_IRQ_BY_NAME(DT_NODELABEL(soc), _node_name, _cell)
+
+#define DO_PM_IRQ_CONNECT(node) \
+	IRQ_CONNECT(ISH_SOC_IRQ(node, irq), ISH_SOC_IRQ(node, priority), \
+			sedi_pm_isr, ISH_SOC_IRQ(node, irq), \
+			ISH_SOC_IRQ(node, sense))
+
+static int ish_soc_pm_init(void)
+{
+	sedi_pm_init();
+
+	DO_PM_IRQ_CONNECT(reset_prep);
+	DO_PM_IRQ_CONNECT(pcidev);
+	DO_PM_IRQ_CONNECT(pmu2ioapic);
+
+	irq_enable(ISH_SOC_IRQ(reset_prep, irq));
+	irq_enable(ISH_SOC_IRQ(pcidev, irq));
+
+	return 0;
+}
+
+SYS_INIT(ish_soc_pm_init, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/intel/intel_ish/intel_ish5/soc.c
+++ b/soc/intel/intel_ish/intel_ish5/soc.c
@@ -11,14 +11,9 @@
 #include "sedi_driver_hpet.h"
 #endif
 
-extern void sedi_pm_init(void);
-
 void soc_early_init_hook(void)
 {
 #if defined(CONFIG_HPET_TIMER)
 	sedi_hpet_set_min_delay(HPET_CMP_MIN_DELAY);
-#endif
-#if defined(CONFIG_PM)
-	sedi_pm_init();
 #endif
 }

--- a/west.yml
+++ b/west.yml
@@ -190,7 +190,7 @@ manifest:
       groups:
         - hal
     - name: hal_intel
-      revision: 0447cd22e74d7ca243653f21cfd6e38c016630c6
+      revision: 82a33b2de29523d9ce572b3d0110a808665cd3ff
       path: modules/hal/intel
       groups:
         - hal


### PR DESCRIPTION
It contains 5 commits to refactor ISH SoC's PM code:
- Improve ISH PM logging
- Simplify ISH AON linker script
- Move PM init into power.c and connect IRQs in it
- west.yml: hal_intel: Update to latest revision
- soc: ish: Disable D0i3 low-power state for ISH