### PR TITLE
net: Fix mDNS and LLMNR responders

### DIFF
--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -192,23 +192,19 @@ static void setup_dns_hdr(uint8_t *buf, uint16_t answers, uint16_t dns_id)
 
 static void add_question(struct net_buf *query, enum dns_rr_type qtype)
 {
-	char *dot = query->data + DNS_MSG_HEADER_SIZE;
-	char *prev = NULL;
+	char *dot = query->data + DNS_MSG_HEADER_SIZE + 1;
+	char *prev = query->data + DNS_MSG_HEADER_SIZE;
 	uint16_t offset;
 
-	while ((dot = strchr(dot, '.'))) {
-		if (!prev) {
-			prev = dot++;
-			continue;
-		}
+	/* For the length of the first label. */
+	query->len += 1;
 
+	while ((dot = strchr(dot, '.')) != NULL) {
 		*prev = dot - prev - 1;
 		prev = dot++;
 	}
 
-	if (prev) {
-		*prev = strlen(prev) - 1;
-	}
+	*prev = strlen(prev + 1);
 
 	offset = DNS_MSG_HEADER_SIZE + query->len + 1;
 	UNALIGNED_PUT(htons(qtype), (uint16_t *)(query->data+offset));
@@ -245,14 +241,15 @@ static int create_answer(enum dns_rr_type qtype,
 	/* Prepare the response into the query buffer: move the name
 	 * query buffer has to get enough free space: dns_hdr + query + answer
 	 */
-	if ((net_buf_max_len(query) - query->len) < (DNS_MSG_HEADER_SIZE +
+	if ((net_buf_max_len(query) - query->len) < (DNS_MSG_HEADER_SIZE + 1 +
 					  (DNS_QTYPE_LEN + DNS_QCLASS_LEN) * 2 +
 					  DNS_TTL_LEN + DNS_RDLENGTH_LEN +
 					  addr_len + query->len)) {
 		return -ENOBUFS;
 	}
 
-	memmove(query->data + DNS_MSG_HEADER_SIZE, query->data, query->len);
+	/* +1 for the initial label length */
+	memmove(query->data + DNS_MSG_HEADER_SIZE + 1, query->data, query->len);
 
 	setup_dns_hdr(query->data, 1, dns_id);
 
@@ -488,8 +485,8 @@ static int dns_read(int sock,
 			result->data, ret);
 
 		/* If the query matches to our hostname, then send reply */
-		if (!strncasecmp(hostname, result->data + 1, hostname_len) &&
-		    (result->len - 1) >= hostname_len) {
+		if (!strncasecmp(hostname, result->data, hostname_len) &&
+		    (result->len) >= hostname_len) {
 			NET_DBG("%s query to our hostname %s", "LLMNR",
 				hostname);
 			ret = send_response(sock, src_addr, addrlen, result, qtype,

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -274,23 +274,19 @@ static void setup_dns_hdr(uint8_t *buf, uint16_t answers)
 static void add_answer(struct net_buf *query, enum dns_rr_type qtype,
 		       uint32_t ttl, uint16_t addr_len, uint8_t *addr)
 {
-	char *dot = query->data + DNS_MSG_HEADER_SIZE;
-	char *prev = NULL;
+	char *dot = query->data + DNS_MSG_HEADER_SIZE + 1;
+	char *prev = query->data + DNS_MSG_HEADER_SIZE;
 	uint16_t offset;
 
-	while ((dot = strchr(dot, '.'))) {
-		if (!prev) {
-			prev = dot++;
-			continue;
-		}
+	/* For the length of the first label. */
+	query->len += 1;
 
+	while ((dot = strchr(dot, '.')) != NULL) {
 		*prev = dot - prev - 1;
 		prev = dot++;
 	}
 
-	if (prev) {
-		*prev = strlen(prev) - 1;
-	}
+	*prev = strlen(prev + 1);
 
 	/* terminator byte (0x00) */
 	query->len += 1;
@@ -322,14 +318,15 @@ static int create_answer(int sock,
 	/* Prepare the response into the query buffer: move the name
 	 * query buffer has to get enough free space: dns_hdr + answer
 	 */
-	if ((net_buf_max_len(query) - query->len) < (DNS_MSG_HEADER_SIZE +
+	if ((net_buf_max_len(query) - query->len) < (DNS_MSG_HEADER_SIZE + 1 +
 					  DNS_QTYPE_LEN + DNS_QCLASS_LEN +
 					  DNS_TTL_LEN + DNS_RDLENGTH_LEN +
 					  addr_len)) {
 		return -ENOBUFS;
 	}
 
-	memmove(query->data + DNS_MSG_HEADER_SIZE, query->data, query->len);
+	/* +1 for the initial label length */
+	memmove(query->data + DNS_MSG_HEADER_SIZE + 1, query->data, query->len);
 
 	setup_dns_hdr(query->data, 1);
 
@@ -641,7 +638,7 @@ static int dns_read(int sock,
 		}
 
 		/* Handle only .local queries */
-		lquery = strrchr(result->data + 1, '.');
+		lquery = strrchr(result->data, '.');
 		if (!lquery || memcmp(lquery, (const void *){ ".local" }, 7)) {
 			continue;
 		}
@@ -654,9 +651,9 @@ static int dns_read(int sock,
 		 * We skip the first dot, and make sure there is dot after
 		 * matching hostname.
 		 */
-		if (!strncasecmp(hostname, result->data + 1, hostname_len) &&
-		    (result->len - 1) >= hostname_len &&
-		    &(result->data + 1)[hostname_len] == lquery) {
+		if (!strncasecmp(hostname, result->data, hostname_len) &&
+		    (result->len) >= hostname_len &&
+		    &result->data[hostname_len] == lquery) {
 			NET_DBG("%s %s %s to our hostname %s%s", "mDNS",
 				family == AF_INET ? "IPv4" : "IPv6", "query",
 				hostname, ".local");

--- a/tests/net/socket/getaddrinfo/src/main.c
+++ b/tests/net/socket/getaddrinfo/src/main.c
@@ -96,7 +96,7 @@ static bool check_dns_query(uint8_t *buf, int buf_len)
 	/* In this test we are just checking if the query came to us in correct
 	 * form, we are not creating a DNS server implementation here.
 	 */
-	if (strncmp(result->data + 1, QUERY_HOST,
+	if (strncmp(result->data, QUERY_HOST,
 		    sizeof(QUERY_HOST) - 1)) {
 		net_buf_unref(result);
 		return false;


### PR DESCRIPTION
Align with `dns_unpack_query()` change (skip initial dot from DNS labels) from https://github.com/zephyrproject-rtos/zephyr/commit/b60ae6fb1ac24339cde1c568a61a089517a9b3ef.

Fixes #96201