### PR TITLE
mgmt/mcumgr: add missing designator to ZCBOR_MAP_DECODE_KEY_DECODER

### DIFF
--- a/subsys/mgmt/mcumgr/util/include/mgmt/mcumgr/util/zcbor_bulk.h
+++ b/subsys/mgmt/mcumgr/util/include/mgmt/mcumgr/util/zcbor_bulk.h
@@ -34,7 +34,7 @@ struct zcbor_map_decode_key_val {
  */
 #define ZCBOR_MAP_DECODE_KEY_DECODER(k, dec, vp)		\
 	{							\
-		{						\
+		.key = {					\
 			.value = k,				\
 			.len = sizeof(k) - 1,			\
 		},						\


### PR DESCRIPTION
Add missing `.key` designator.

This also fixes a compile error:
> error: either all initializer clauses should be designated or none of them
should be