### PR TITLE
doc: _scripts: improve heuristics for guessing board/shield image

### DIFF
--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -88,11 +88,19 @@ def guess_file_from_patterns(directory, patterns, name, extensions):
 
 def guess_image(board_or_shield):
     img_exts = ("jpg", "jpeg", "webp", "png")
+
+    name_parts = board_or_shield.name.split('_')
+    prefix_matches = []
+    for i in range(len(name_parts) - 1, 0, -1):
+        partial_name = '_'.join(name_parts[:i])
+        prefix_matches.append(f"**/{partial_name}.{{ext}}")
+
     patterns = (
-        "**/{name}.{ext}",
+        *prefix_matches,
         "**/*{name}*.{ext}",
         "**/*.{ext}",
     )
+
     img_file = guess_file_from_patterns(
         board_or_shield.dir, patterns, board_or_shield.name, img_exts
     )

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -87,7 +87,7 @@ def guess_file_from_patterns(directory, patterns, name, extensions):
 
 
 def guess_image(board_or_shield):
-    img_exts = ("jpg", "jpeg", "webp", "png")
+    img_exts = ("webp", "png", "jpg", "jpeg")
 
     name_parts = board_or_shield.name.split('_')
     prefix_matches = []


### PR DESCRIPTION
When a board or shield is named boardfoo_is_awesome, we now explicitly look for images with a name that starts with one of the segments of the board/shield name ; i.e.: boardfoo_is_awesome.imgext, then boardfoo_is.imgext, then boardfoo.imgext.