### PR TITLE
scripts: west_commands: list sdk from env variable `ZEPHYR_SDK_INSTALL_DIR`

### DIFF
--- a/scripts/west_commands/sdk.py
+++ b/scripts/west_commands/sdk.py
@@ -520,6 +520,10 @@ class Sdk(WestCommand):
         except Exception as e:
             self.die(e)
 
+        zephyr_sdk_install_dir = os.environ.get("ZEPHYR_SDK_INSTALL_DIR", None)
+        if zephyr_sdk_install_dir:
+            sdk_lines += [f'dir={zephyr_sdk_install_dir}']
+
         def parse_sdk_entry(line):
             class SdkEntry:
                 def __init__(self):


### PR DESCRIPTION
Users can specify a Zephyr SDK installation directory using the `ZEPHYR_SDK_INSTALL_DIR` environment variable. This variable must be taken into account when listing all installed SDKs, such as with the `west sdk list` command.