### PR TITLE
scripts: west_commands: add `build.symlinks` and extend `build.dir-fmt`

### DIFF
--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -400,6 +400,13 @@ You can :ref:`configure <west-config-cmd>` ``west build`` using these options.
            to the source directory. If the current working directory is inside
            the source directory this will be set to an empty string.
          - ``app``: The name of the source directory.
+         - ``source_dir_common``: The relative path from the west topdir to the
+           source directory (without leadiing ``..``)
+   * - ``build.symlinks``
+     - String. The symlinks format string contains one or more symlink paths,
+       with multiple paths separated by colons (``:``). Each symlink is created
+       during build process and points to the actual build directory. The
+       available arguments are the same as for ``dir-fmt``.
    * - ``build.generator``
      - String, default ``Ninja``. The `CMake Generator`_ to use to create a
        build system. (To set a generator for a single build, see the


### PR DESCRIPTION
Users might want to keep multiple build folders at the same time without removing old builds, so they use `build.dir-fmt`.
If `board` or `app` arguments are used in the `dir-fmt` string, the build directory cannot be determined automatically anymore by subsequent west commands (e.g. `west flash`). Also IDEs or user scripts might want a fix path in the filesystem, which points to the actual build directory.

As a solution a new config `build.symlinks` is added which can be used to create one or more symlinks to the actual build directory.

In addition `build.dir-fmt` format string arguments are extended with `source_dir_common`, which is the relative path of the source directory to the west workspace (without leading ..).