### PR TITLE
xtensa: memory domains: reuse page tables until changes are made

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -258,6 +258,12 @@ config XTENSA_MMU_FLUSH_AUTOREFILL_DTLBS_ON_SWAP
 	  This flushes (invalidates) all auto-refill data TLBs when page
 	  tables are swapped.
 
+config XTENSA_MMU_PAGE_TABLE_STATS
+	bool "Page table statistics"
+	help
+	  Enable this for page table statistics, including current usage and
+	  maximum number of page tables used.
+
 endif # XTENSA_MMU
 
 endif # CPU_HAS_MMU

--- a/arch/xtensa/include/xtensa_mmu_priv.h
+++ b/arch/xtensa/include/xtensa_mmu_priv.h
@@ -31,6 +31,9 @@
 /** Mask for attributes in PTE */
 #define XTENSA_MMU_PTE_ATTR_MASK		0x0000000FU
 
+/** Number of bits to shift for attributes in PTE */
+#define XTENSA_MMU_PTE_ATTR_SHIFT		0U
+
 /** Mask for cache mode in PTE */
 #define XTENSA_MMU_PTE_ATTR_CACHED_MASK		0x0000000CU
 
@@ -90,19 +93,21 @@
 	(((paddr) & XTENSA_MMU_PTE_PPN_MASK) | \
 	 (((ring) << XTENSA_MMU_PTE_RING_SHIFT) & XTENSA_MMU_PTE_RING_MASK) | \
 	 (((sw) << XTENSA_MMU_PTE_SW_SHIFT) & XTENSA_MMU_PTE_SW_MASK) | \
-	 ((attr) & XTENSA_MMU_PTE_ATTR_MASK))
+	 (((attr) << XTENSA_MMU_PTE_ATTR_SHIFT) & XTENSA_MMU_PTE_ATTR_MASK))
 
 /** Get the attributes from a PTE */
 #define XTENSA_MMU_PTE_ATTR_GET(pte) \
-	((pte) & XTENSA_MMU_PTE_ATTR_MASK)
+	(((pte) & XTENSA_MMU_PTE_ATTR_MASK) >> XTENSA_MMU_PTE_ATTR_SHIFT)
 
 /** Set the attributes in a PTE */
 #define XTENSA_MMU_PTE_ATTR_SET(pte, attr) \
-	(((pte) & ~XTENSA_MMU_PTE_ATTR_MASK) | (attr & XTENSA_MMU_PTE_ATTR_MASK))
+	(((pte) & ~XTENSA_MMU_PTE_ATTR_MASK) | \
+	 (((attr) << XTENSA_MMU_PTE_ATTR_SHIFT) & XTENSA_MMU_PTE_ATTR_MASK))
 
 /** Set the SW field in a PTE */
 #define XTENSA_MMU_PTE_SW_SET(pte, sw) \
-	(((pte) & ~XTENSA_MMU_PTE_SW_MASK) | (sw << XTENSA_MMU_PTE_SW_SHIFT))
+	(((pte) & ~XTENSA_MMU_PTE_SW_MASK) | \
+	 (((sw) << XTENSA_MMU_PTE_SW_SHIFT) & XTENSA_MMU_PTE_SW_MASK))
 
 /** Get the SW field from a PTE */
 #define XTENSA_MMU_PTE_SW_GET(pte) \
@@ -124,7 +129,7 @@
 /** Set the ring in a PTE */
 #define XTENSA_MMU_PTE_RING_SET(pte, ring) \
 	(((pte) & ~XTENSA_MMU_PTE_RING_MASK) | \
-	((ring) << XTENSA_MMU_PTE_RING_SHIFT))
+	 (((ring) << XTENSA_MMU_PTE_RING_SHIFT) & XTENSA_MMU_PTE_RING_MASK))
 
 /** Get the ring from a PTE */
 #define XTENSA_MMU_PTE_RING_GET(pte) \

--- a/arch/xtensa/include/xtensa_mmu_priv.h
+++ b/arch/xtensa/include/xtensa_mmu_priv.h
@@ -54,46 +54,30 @@
 /** Number of bits to shift for ring in PTE */
 #define XTENSA_MMU_PTE_RING_SHIFT		4U
 
-/** Number of bits to shift for SW reserved ared in PTE */
-#define XTENSA_MMU_PTE_SW_SHIFT			6U
+/** Number of bits to shift for backup attributes in PTE SW field. */
+#define XTENSA_MMU_PTE_BCKUP_ATTR_SHIFT		(XTENSA_MMU_PTE_ATTR_SHIFT + 6U)
 
-/** Mask for SW bits in PTE */
-#define XTENSA_MMU_PTE_SW_MASK			0x00000FC0U
+/** Mask for backup attributes in PTE SW field. */
+#define XTENSA_MMU_PTE_BCKUP_ATTR_MASK		(XTENSA_MMU_PTE_ATTR_MASK << 6U)
 
-/**
- * Number of bits to shift for backup attributes in PTE SW field.
- *
- * This is relative to the SW field, not the PTE entry.
- */
-#define XTENSA_MMU_PTE_SW_ATTR_SHIFT		0U
+/** Number of bits to shift for backup ring value in PTE SW field. */
+#define XTENSA_MMU_PTE_BCKUP_RING_SHIFT		(XTENSA_MMU_PTE_RING_SHIFT + 6U)
 
-/**
- * Mask for backup attributes in PTE SW field.
- *
- * This is relative to the SW field, not the PTE entry.
- */
-#define XTENSA_MMU_PTE_SW_ATTR_MASK		0x0000000FU
+/** Mask for backup ring value in PTE SW field. */
+#define XTENSA_MMU_PTE_BCKUP_RING_MASK		(XTENSA_MMU_PTE_RING_MASK << 6U)
 
-/**
- * Number of bits to shift for backup ring value in PTE SW field.
- *
- * This is relative to the SW field, not the PTE entry.
- */
-#define XTENSA_MMU_PTE_SW_RING_SHIFT		4U
-
-/**
- * Mask for backup ring value in PTE SW field.
- *
- * This is relative to the SW field, not the PTE entry.
- */
-#define XTENSA_MMU_PTE_SW_RING_MASK		0x00000030U
+/** Construct a page table entry (PTE) with specified backup attributes and ring. */
+#define XTENSA_MMU_PTE_WITH_BCKUP(paddr, ring, attr, bckup_ring, bckup_attr) \
+	(((paddr) & XTENSA_MMU_PTE_PPN_MASK) | \
+	 (((bckup_ring) << XTENSA_MMU_PTE_BCKUP_RING_SHIFT) & XTENSA_MMU_PTE_BCKUP_RING_MASK) | \
+	 (((bckup_attr) << XTENSA_MMU_PTE_BCKUP_ATTR_SHIFT) & XTENSA_MMU_PTE_BCKUP_ATTR_MASK) | \
+	 (((ring) << XTENSA_MMU_PTE_RING_SHIFT) & XTENSA_MMU_PTE_RING_MASK) | \
+	 (((attr) << XTENSA_MMU_PTE_ATTR_SHIFT) & XTENSA_MMU_PTE_ATTR_MASK))
 
 /** Construct a page table entry (PTE) */
-#define XTENSA_MMU_PTE(paddr, ring, sw, attr) \
-	(((paddr) & XTENSA_MMU_PTE_PPN_MASK) | \
-	 (((ring) << XTENSA_MMU_PTE_RING_SHIFT) & XTENSA_MMU_PTE_RING_MASK) | \
-	 (((sw) << XTENSA_MMU_PTE_SW_SHIFT) & XTENSA_MMU_PTE_SW_MASK) | \
-	 (((attr) << XTENSA_MMU_PTE_ATTR_SHIFT) & XTENSA_MMU_PTE_ATTR_MASK))
+#define XTENSA_MMU_PTE(paddr, ring, attr) \
+	XTENSA_MMU_PTE_WITH_BCKUP(paddr, ring, attr, \
+				  XTENSA_MMU_KERNEL_RING, XTENSA_MMU_PTE_ATTR_ILLEGAL)
 
 /** Get the attributes from a PTE */
 #define XTENSA_MMU_PTE_ATTR_GET(pte) \
@@ -104,27 +88,13 @@
 	(((pte) & ~XTENSA_MMU_PTE_ATTR_MASK) | \
 	 (((attr) << XTENSA_MMU_PTE_ATTR_SHIFT) & XTENSA_MMU_PTE_ATTR_MASK))
 
-/** Set the SW field in a PTE */
-#define XTENSA_MMU_PTE_SW_SET(pte, sw) \
-	(((pte) & ~XTENSA_MMU_PTE_SW_MASK) | \
-	 (((sw) << XTENSA_MMU_PTE_SW_SHIFT) & XTENSA_MMU_PTE_SW_MASK))
-
-/** Get the SW field from a PTE */
-#define XTENSA_MMU_PTE_SW_GET(pte) \
-	(((pte) & XTENSA_MMU_PTE_SW_MASK) >> XTENSA_MMU_PTE_SW_SHIFT)
-
-/** Construct a PTE SW field to be used for backing up PTE ring and attributes. */
-#define XTENSA_MMU_PTE_SW(ring, attr) \
-	((((ring) << XTENSA_MMU_PTE_SW_RING_SHIFT) & XTENSA_MMU_PTE_SW_RING_MASK) | \
-	 (((attr) << XTENSA_MMU_PTE_SW_ATTR_SHIFT) & XTENSA_MMU_PTE_SW_ATTR_MASK))
-
 /** Get the backed up attributes from the PTE SW field. */
-#define XTENSA_MMU_PTE_SW_ATTR_GET(sw) \
-	(((sw) & XTENSA_MMU_PTE_SW_ATTR_MASK) >> XTENSA_MMU_PTE_SW_ATTR_SHIFT)
+#define XTENSA_MMU_PTE_BCKUP_ATTR_GET(pte) \
+	(((pte) & XTENSA_MMU_PTE_BCKUP_ATTR_MASK) >> XTENSA_MMU_PTE_BCKUP_ATTR_SHIFT)
 
 /** Get the backed up ring value from the PTE SW field. */
-#define XTENSA_MMU_PTE_SW_RING_GET(sw) \
-	(((sw) & XTENSA_MMU_PTE_SW_RING_MASK) >> XTENSA_MMU_PTE_SW_RING_SHIFT)
+#define XTENSA_MMU_PTE_BCKUP_RING_GET(pte) \
+	(((pte) & XTENSA_MMU_PTE_BCKUP_RING_MASK) >> XTENSA_MMU_PTE_BCKUP_RING_SHIFT)
 
 /** Set the ring in a PTE */
 #define XTENSA_MMU_PTE_RING_SET(pte, ring) \
@@ -191,14 +161,12 @@
 #define XTENSA_MMU_PTE_ATTR_ILLEGAL		(BIT(3) | BIT(2))
 
 /** Illegal PTE entry for Level 1 page tables */
-#define XTENSA_MMU_PTE_L1_ILLEGAL		XTENSA_MMU_PTE_ATTR_ILLEGAL
+#define XTENSA_MMU_PTE_L1_ILLEGAL \
+	XTENSA_MMU_PTE(0, XTENSA_MMU_KERNEL_RING, XTENSA_MMU_PTE_ATTR_ILLEGAL)
 
 /** Illegal PTE entry for Level 2 page tables */
 #define XTENSA_MMU_PTE_L2_ILLEGAL \
-	XTENSA_MMU_PTE(0, XTENSA_MMU_KERNEL_RING, \
-		       XTENSA_MMU_PTE_SW(XTENSA_MMU_KERNEL_RING, \
-					 XTENSA_MMU_PTE_ATTR_ILLEGAL), \
-		       XTENSA_MMU_PTE_ATTR_ILLEGAL)
+	XTENSA_MMU_PTE(0, XTENSA_MMU_KERNEL_RING, XTENSA_MMU_PTE_ATTR_ILLEGAL)
 
 /**
  * PITLB HIT bit.

--- a/arch/xtensa/include/xtensa_mmu_priv.h
+++ b/arch/xtensa/include/xtensa_mmu_priv.h
@@ -28,15 +28,6 @@
 /** Mask for PPN in PTE */
 #define XTENSA_MMU_PTE_PPN_MASK			0xFFFFF000U
 
-/** Mask for attributes in PTE */
-#define XTENSA_MMU_PTE_ATTR_MASK		0x0000000FU
-
-/** Number of bits to shift for attributes in PTE */
-#define XTENSA_MMU_PTE_ATTR_SHIFT		0U
-
-/** Mask for cache mode in PTE */
-#define XTENSA_MMU_PTE_ATTR_CACHED_MASK		0x0000000CU
-
 /** Mask used to figure out which L1 page table to use */
 #define XTENSA_MMU_L1_MASK			0x3FF00000U
 
@@ -47,68 +38,6 @@
 
 /** Number of bits to shift for PPN in PTE */
 #define XTENSA_MMU_PTE_PPN_SHIFT		12U
-
-/** Mask for ring in PTE */
-#define XTENSA_MMU_PTE_RING_MASK		0x00000030U
-
-/** Number of bits to shift for ring in PTE */
-#define XTENSA_MMU_PTE_RING_SHIFT		4U
-
-/** Number of bits to shift for backup attributes in PTE SW field. */
-#define XTENSA_MMU_PTE_BCKUP_ATTR_SHIFT		(XTENSA_MMU_PTE_ATTR_SHIFT + 6U)
-
-/** Mask for backup attributes in PTE SW field. */
-#define XTENSA_MMU_PTE_BCKUP_ATTR_MASK		(XTENSA_MMU_PTE_ATTR_MASK << 6U)
-
-/** Number of bits to shift for backup ring value in PTE SW field. */
-#define XTENSA_MMU_PTE_BCKUP_RING_SHIFT		(XTENSA_MMU_PTE_RING_SHIFT + 6U)
-
-/** Mask for backup ring value in PTE SW field. */
-#define XTENSA_MMU_PTE_BCKUP_RING_MASK		(XTENSA_MMU_PTE_RING_MASK << 6U)
-
-/** Construct a page table entry (PTE) with specified backup attributes and ring. */
-#define XTENSA_MMU_PTE_WITH_BCKUP(paddr, ring, attr, bckup_ring, bckup_attr) \
-	(((paddr) & XTENSA_MMU_PTE_PPN_MASK) | \
-	 (((bckup_ring) << XTENSA_MMU_PTE_BCKUP_RING_SHIFT) & XTENSA_MMU_PTE_BCKUP_RING_MASK) | \
-	 (((bckup_attr) << XTENSA_MMU_PTE_BCKUP_ATTR_SHIFT) & XTENSA_MMU_PTE_BCKUP_ATTR_MASK) | \
-	 (((ring) << XTENSA_MMU_PTE_RING_SHIFT) & XTENSA_MMU_PTE_RING_MASK) | \
-	 (((attr) << XTENSA_MMU_PTE_ATTR_SHIFT) & XTENSA_MMU_PTE_ATTR_MASK))
-
-/** Construct a page table entry (PTE) */
-#define XTENSA_MMU_PTE(paddr, ring, attr) \
-	XTENSA_MMU_PTE_WITH_BCKUP(paddr, ring, attr, \
-				  XTENSA_MMU_KERNEL_RING, XTENSA_MMU_PTE_ATTR_ILLEGAL)
-
-/** Get the attributes from a PTE */
-#define XTENSA_MMU_PTE_ATTR_GET(pte) \
-	(((pte) & XTENSA_MMU_PTE_ATTR_MASK) >> XTENSA_MMU_PTE_ATTR_SHIFT)
-
-/** Set the attributes in a PTE */
-#define XTENSA_MMU_PTE_ATTR_SET(pte, attr) \
-	(((pte) & ~XTENSA_MMU_PTE_ATTR_MASK) | \
-	 (((attr) << XTENSA_MMU_PTE_ATTR_SHIFT) & XTENSA_MMU_PTE_ATTR_MASK))
-
-/** Get the backed up attributes from the PTE SW field. */
-#define XTENSA_MMU_PTE_BCKUP_ATTR_GET(pte) \
-	(((pte) & XTENSA_MMU_PTE_BCKUP_ATTR_MASK) >> XTENSA_MMU_PTE_BCKUP_ATTR_SHIFT)
-
-/** Get the backed up ring value from the PTE SW field. */
-#define XTENSA_MMU_PTE_BCKUP_RING_GET(pte) \
-	(((pte) & XTENSA_MMU_PTE_BCKUP_RING_MASK) >> XTENSA_MMU_PTE_BCKUP_RING_SHIFT)
-
-/** Set the ring in a PTE */
-#define XTENSA_MMU_PTE_RING_SET(pte, ring) \
-	(((pte) & ~XTENSA_MMU_PTE_RING_MASK) | \
-	 (((ring) << XTENSA_MMU_PTE_RING_SHIFT) & XTENSA_MMU_PTE_RING_MASK))
-
-/** Get the ring from a PTE */
-#define XTENSA_MMU_PTE_RING_GET(pte) \
-	(((pte) & XTENSA_MMU_PTE_RING_MASK) >> XTENSA_MMU_PTE_RING_SHIFT)
-
-/** Get the ASID from the RASID register corresponding to the ring in a PTE */
-#define XTENSA_MMU_PTE_ASID_GET(pte, rasid) \
-	(((rasid) >> ((((pte) & XTENSA_MMU_PTE_RING_MASK) \
-		       >> XTENSA_MMU_PTE_RING_SHIFT) * 8)) & 0xFF)
 
 /** Calculate the L2 page table position from a virtual address */
 #define XTENSA_MMU_L2_POS(vaddr) \
@@ -139,15 +68,6 @@
 /** Fixed data TLB way to map the vecbase */
 #define XTENSA_MMU_VECBASE_WAY			8
 
-/** Kernel specific ASID. Ring field in the PTE */
-#define XTENSA_MMU_KERNEL_RING			0
-
-/** User specific ASID. Ring field in the PTE */
-#define XTENSA_MMU_USER_RING			2
-
-/** Ring value for MMU_SHARED_ASID */
-#define XTENSA_MMU_SHARED_RING			3
-
 /** Number of data TLB ways [0-9] */
 #define XTENSA_MMU_NUM_DTLB_WAYS		10
 
@@ -156,17 +76,6 @@
 
 /** Number of auto-refill ways */
 #define XTENSA_MMU_NUM_TLB_AUTOREFILL_WAYS	4
-
-/** Attribute indicating PTE is illegal. */
-#define XTENSA_MMU_PTE_ATTR_ILLEGAL		(BIT(3) | BIT(2))
-
-/** Illegal PTE entry for Level 1 page tables */
-#define XTENSA_MMU_PTE_L1_ILLEGAL \
-	XTENSA_MMU_PTE(0, XTENSA_MMU_KERNEL_RING, XTENSA_MMU_PTE_ATTR_ILLEGAL)
-
-/** Illegal PTE entry for Level 2 page tables */
-#define XTENSA_MMU_PTE_L2_ILLEGAL \
-	XTENSA_MMU_PTE(0, XTENSA_MMU_KERNEL_RING, XTENSA_MMU_PTE_ATTR_ILLEGAL)
 
 /**
  * PITLB HIT bit.

--- a/include/zephyr/arch/xtensa/xtensa_mmu.h
+++ b/include/zephyr/arch/xtensa/xtensa_mmu.h
@@ -155,6 +155,32 @@ void xtensa_mmu_tlb_ipi(void);
  */
 void xtensa_mmu_tlb_shootdown(void);
 
+#ifdef CONFIG_XTENSA_MMU_PAGE_TABLE_STATS
+/**
+ * Struct for reporting page table statistics.
+ */
+struct xtensa_mmu_page_table_stats {
+	/** Current number of L1 page tables allocated. */
+	uint32_t cur_num_l1_alloced;
+
+	/** Current number of L2 page tables allocated. */
+	uint32_t cur_num_l2_alloced;
+
+	/** Maximum number of L1 page tables allocated. */
+	uint32_t max_num_l1_alloced;
+
+	/** Maximum number of L2 page tables allocated. */
+	uint32_t max_num_l2_alloced;
+};
+
+/**
+ * @brief Get page table statistics.
+ *
+ * @param[out] Pointer to statistics struct to write into.
+ */
+void xtensa_mmu_page_table_stats_get(struct xtensa_mmu_page_table_stats *stats);
+#endif /* CONFIG_XTENSA_MMU_PAGE_TABLE_STATS */
+
 /**
  * @}
  */

--- a/soc/cdns/dc233c/include/xtensa-dc233c.ld
+++ b/soc/cdns/dc233c/include/xtensa-dc233c.ld
@@ -211,6 +211,8 @@ SECTIONS
     KEEP(*(.fini))
     *(.gnu.version)
 
+    #include <snippets-text-sections.ld>
+
     #include <zephyr/linker/kobject-text.ld>
 
     MMU_PAGE_ALIGN


### PR DESCRIPTION
This changes the page table duplication to be COW (copy-on-write) to conserve memory space. When a new memory domain is created, the old mechanism was to duplicate all currently being used kernel page tables. The newly duplicated tables would then be modified to accommodate the new memory domain and its memory partitions. This wastes quite a bit of memory space as some tables remain unchanged, for example, page table for hardware register access and kernel only pages. The changes here modifies this mechanism to reuse existing kernel page tables until modifications are needed. Then it makes a copy of the table, and changes applied to the duplicated table.