### PR TITLE
drivers: spi: enhance spi shell

### DIFF
--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -90,6 +90,15 @@ config SPI_STATS
 	help
 	  Enable SPI device statistics.
 
+config SPI_SHELL_MAX_DEVICE_SLOTS
+	int "Number of empty device slots in the SPI shell"
+	depends on SPI_SHELL
+	default 16
+	help
+	  The number of empty device slots in the SPI shell. Increase it, if you
+	  are using many SPI devices and see "ERROR: not enough space" error
+	  messages when using SPI shell.
+
 module = SPI
 module-str = spi
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/spi/spi_shell.c
+++ b/drivers/spi/spi_shell.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <string.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -11,31 +12,226 @@
 #include <zephyr/drivers/spi.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/devicetree.h>
 
-#define TXRX_ARGV_BYTES     (1)
-#define CONF_ARGV_DEV       (1)
+#define TXRX_ARGV_SPI_DEV (1)
+#define TXRX_ARGV_BYTES   (2)
+
+#define CONF_ARGV_SPI_DEV   (1)
 #define CONF_ARGV_FREQUENCY (2)
 #define CONF_ARGV_SETTINGS  (3)
 
-#define CS_ARGV_GPIO_DEV    (1)
-#define CS_ARGV_GPIO_PIN    (2)
-#define CS_ARGV_GPIO_FLAGS  (3)
+#define CS_ARGV_SPI_DEV    (1)
+#define CS_ARGV_GPIO_DEV   (2)
+#define CS_ARGV_GPIO_PIN   (3)
+#define CS_ARGV_GPIO_FLAGS (4)
 
 /* Maximum bytes we can write and read at once */
 #define MAX_SPI_BYTES MIN((CONFIG_SHELL_ARGC_MAX - TXRX_ARGV_BYTES), 32)
 
-static struct device *spi_device;
-static struct spi_config config = {.frequency = 1000000,
-				   .operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(8)};
+/* Runs the given fn only if the node_id belongs to a spi device, which is on an okay spi bus. */
+#define RUN_FN_ON_SPI_DEVICE(node_id, fn)                                                          \
+	COND_CODE_1(DT_ON_BUS(node_id, spi), \
+	(COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(DT_BUS(node_id)), \
+	(fn), ())), ())
+
+/* Create specified number of empty structs, separated by ',' */
+#define _EMPTY_STRUCT_INST(idx, list) {0}
+#define CREATE_NUM_EMPTY_STRUCTS(num) LISTIFY(num, _EMPTY_STRUCT_INST, (,))
+
+/* Struct representing either a spi bus or a spi device. */
+struct spi_shell_device {
+	/* Device name. Either a spi bus or a spi device. */
+	const char *name;
+	struct spi_dt_spec spec;
+};
+
+/* Struct used to map a label to a name of the associated spi_shell_device. */
+struct map {
+	/* Either nodelabel or device name of either spi bus or spi device. */
+	const char *label;
+	/* Device name. This is the same as the name of the associated spi_shell_device struct. */
+	const char *name;
+};
+
+#define INST_SPI_SHELL_DEVICE_AS_SPI_DEV(node_id)                                                  \
+	{                                                                                          \
+		.name = DEVICE_DT_NAME(node_id),                                                   \
+		.spec = SPI_DT_SPEC_GET(node_id, 0, 0),                                            \
+	},
+
+#define INST_SPI_SHELL_DEVICE_AS_SPI_DEV_AS_SPI_BUS(dev)                                           \
+	(struct spi_shell_device)                                                                  \
+	{                                                                                          \
+		.name = dev->name,                                                                 \
+		.spec = {                                                                          \
+			.bus = dev,                                                                \
+			.config =                                                                  \
+				{                                                                  \
+					.frequency = 1000000,                                      \
+					.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(8),         \
+				},                                                                 \
+		},                                                                                 \
+	}
+
+#define INST_MAP(nodelabel, node_id)                                                               \
+	{.label = STRINGIFY(nodelabel), .name = DEVICE_DT_NAME(node_id)},
+
+#define INST_MAP_FROM_NODE_ID(node_id)                                                             \
+	{.label = DEVICE_DT_NAME(node_id), .name = DEVICE_DT_NAME(node_id)},
+
+/* Instantiate spi_shell_device struct from node_id, if node_id is a spi device. */
+#define INST_ALL_SPI_DEVICES_AS_SPI_SHELL_DEVICES(node_id)                                         \
+	RUN_FN_ON_SPI_DEVICE(node_id, INST_SPI_SHELL_DEVICE_AS_SPI_DEV(node_id))
+
+/* List of spi shell devices. At compile time we instantiate structs for all spi devices.
+ * Additional empty space is reserved for the spi buses, which are added in spi_buses_init at
+ * runtime.
+ */
+static struct spi_shell_device spi_shell_devices[] = {
+	DT_FOREACH_STATUS_OKAY_NODE(INST_ALL_SPI_DEVICES_AS_SPI_SHELL_DEVICES)
+		CREATE_NUM_EMPTY_STRUCTS(CONFIG_SPI_SHELL_MAX_DEVICE_SLOTS)};
+static size_t num_spi_shell_devices =
+	ARRAY_SIZE(spi_shell_devices) - CONFIG_SPI_SHELL_MAX_DEVICE_SLOTS;
+
+#define INST_MAPS_FROM_SPI_DEVICE_NODELABELS(node_id)                                              \
+	RUN_FN_ON_SPI_DEVICE(node_id, DT_FOREACH_NODELABEL_VARGS(node_id, INST_MAP, node_id))
+
+#define INST_MAPS_FROM_SPI_DEVICE_NODE_ID(node_id)                                                 \
+	RUN_FN_ON_SPI_DEVICE(node_id, INST_MAP_FROM_NODE_ID(node_id))
+
+/* A list of maps. At compile time we create maps for all nodelabels and node_ids of spi devices.
+ * Additional empty space is reserved for the spi buses, which are added in spi_buses_init at
+ * runtime.
+ */
+static struct map maps[] = {
+	DT_FOREACH_STATUS_OKAY_NODE(INST_MAPS_FROM_SPI_DEVICE_NODELABELS)
+		DT_FOREACH_STATUS_OKAY_NODE(INST_MAPS_FROM_SPI_DEVICE_NODE_ID)
+			CREATE_NUM_EMPTY_STRUCTS(CONFIG_SPI_SHELL_MAX_DEVICE_SLOTS)};
+static size_t num_maps = ARRAY_SIZE(maps) - CONFIG_SPI_SHELL_MAX_DEVICE_SLOTS;
 
 static bool device_is_spi(const struct device *dev)
 {
 	return DEVICE_API_IS(spi, dev);
 }
 
-static void device_name_get(size_t idx, struct shell_static_entry *entry)
+static bool device_is_gpio(const struct device *dev)
 {
-	const struct device *dev = shell_device_filter(idx, device_is_spi);
+	return DEVICE_API_IS(gpio, dev);
+}
+
+/**
+ * @brief Initialize spi buses at runtime.
+ *
+ * Since Zephyr currently doesn't support getting a device for all spi buses at compile time in a
+ * generic way, we do it at runtime.
+ *
+ * For each spi bus device we:
+ * - add an entry to spi_shell_devices array
+ * - add an entry to maps array by its name
+ * - add an entry to maps array for each it's nodelabel
+ */
+static int spi_buses_init(void)
+{
+	int idx = 0;
+
+	while (1) {
+		const struct device *dev = shell_device_filter(idx, device_is_spi);
+
+		idx++;
+
+		if (dev == NULL) {
+			break;
+		}
+
+		if (num_spi_shell_devices == ARRAY_SIZE(spi_shell_devices)) {
+			printk("ERROR: not enough space in spi_shell_devices array\n");
+			printk("Increase CONFIG_SPI_SHELL_MAX_DEVICE_SLOTS.\n");
+			break;
+		}
+
+		spi_shell_devices[num_spi_shell_devices++] =
+			INST_SPI_SHELL_DEVICE_AS_SPI_DEV_AS_SPI_BUS(dev);
+
+		maps[num_maps++] = (struct map){
+			.label = dev->name,
+			.name = dev->name,
+		};
+
+#ifdef CONFIG_DEVICE_DT_METADATA
+		const struct device_dt_nodelabels *nl = device_get_dt_nodelabels(dev);
+
+		if (nl == NULL) {
+			/* No nodelabel for this device, so we can skip the rest. */
+			continue;
+		}
+
+		if (num_maps + nl->num_nodelabels > ARRAY_SIZE(maps)) {
+			printk("ERROR: not enough space in maps array\n");
+			printk("Increase CONFIG_SPI_SHELL_MAX_DEVICE_SLOTS.\n");
+			break;
+		}
+
+		for (size_t i = 0; i < nl->num_nodelabels; i++) {
+			maps[num_maps++] = (struct map){
+				.label = nl->nodelabels[i],
+				.name = dev->name,
+			};
+		}
+#endif
+	}
+
+	if (num_spi_shell_devices == 0) {
+		printk("ERROR: no spi devices or spi buses are enabled, check devicetree.\n");
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Find spi_dt_spec by label (either nodelabel or nodename).
+ *
+ * The label can belong to either a spi bus or a spi device. We first look up the name
+ * associated with the given label in the maps array. If the name is found, we then search
+ * the spi_shell_devices array for a matching name and return the corresponding spi_dt_spec.
+ *
+ * @param[in] label
+ *
+ * @return Pointer to spi_dt_spec if found, NULL otherwise.
+ */
+static struct spi_dt_spec *find_spec_by_label(const char *label)
+{
+	const char *name = NULL;
+	static bool initialized;
+
+	if (!initialized) {
+		spi_buses_init();
+		initialized = true;
+	}
+
+	for (size_t i = 0; i < num_maps; i++) {
+		if (strcmp(label, maps[i].label) == 0) {
+			name = maps[i].name;
+			break;
+		}
+	}
+
+	if (name == NULL) {
+		return NULL;
+	}
+
+	for (size_t i = 0; i < num_spi_shell_devices; i++) {
+		if (strcmp(name, spi_shell_devices[i].name) == 0) {
+			return &spi_shell_devices[i].spec;
+		}
+	}
+
+	return NULL;
+}
+
+static void get_gpio_device_name(size_t idx, struct shell_static_entry *entry)
+{
+	const struct device *dev = shell_device_filter(idx, device_is_gpio);
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;
@@ -43,15 +239,49 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 	entry->subcmd = NULL;
 }
 
-SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
+SHELL_DYNAMIC_CMD_CREATE(dsub_get_gpio_device_name, get_gpio_device_name);
+
+static void get_spi_shell_device_name_and_set_gpio_dsub(size_t idx,
+							struct shell_static_entry *entry)
+{
+	if (idx >= num_maps) {
+		entry->syntax = NULL;
+		return;
+	}
+
+	entry->syntax = maps[idx].label;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = &dsub_get_gpio_device_name;
+}
+
+SHELL_DYNAMIC_CMD_CREATE(dsub_get_spi_shell_device_name_and_set_gpio_dsub,
+			 get_spi_shell_device_name_and_set_gpio_dsub);
+
+static void get_spi_shell_device_name(size_t idx, struct shell_static_entry *entry)
+{
+	if (idx >= num_maps) {
+		entry->syntax = NULL;
+		return;
+	}
+
+	entry->syntax = maps[idx].label;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+}
+
+SHELL_DYNAMIC_CMD_CREATE(dsub_get_spi_shell_device_name, get_spi_shell_device_name);
 
 static int cmd_spi_transceive(const struct shell *ctx, size_t argc, char **argv)
 {
 	uint8_t rx_buffer[MAX_SPI_BYTES] = {0};
 	uint8_t tx_buffer[MAX_SPI_BYTES] = {0};
 
-	if (spi_device == NULL) {
-		shell_error(ctx, "SPI device isn't configured. Use `spi conf`");
+	struct spi_dt_spec *spec = find_spec_by_label(argv[TXRX_ARGV_SPI_DEV]);
+
+	if (spec == NULL) {
+		shell_error(ctx, "device %s not found.", argv[TXRX_ARGV_SPI_DEV]);
 		return -ENODEV;
 	}
 
@@ -67,7 +297,7 @@ static int cmd_spi_transceive(const struct shell *ctx, size_t argc, char **argv)
 	const struct spi_buf_set tx_buf_set = {.buffers = &tx_buffers, .count = 1};
 	const struct spi_buf_set rx_buf_set = {.buffers = &rx_buffers, .count = 1};
 
-	int ret = spi_transceive(spi_device, &config, &tx_buf_set, &rx_buf_set);
+	int ret = spi_transceive_dt(spec, &tx_buf_set, &rx_buf_set);
 
 	if (ret < 0) {
 		shell_error(ctx, "spi_transceive returned %d", ret);
@@ -87,12 +317,10 @@ static int cmd_spi_conf(const struct shell *ctx, size_t argc, char **argv)
 {
 	spi_operation_t operation = SPI_WORD_SET(8) | SPI_OP_MODE_MASTER;
 
-	/* warning: initialization discards 'const' qualifier from pointer */
-	/* target type */
-	struct device *dev = (struct device *)shell_device_get_binding(argv[CONF_ARGV_DEV]);
+	struct spi_dt_spec *spec = find_spec_by_label(argv[CONF_ARGV_SPI_DEV]);
 
-	if (dev == NULL) {
-		shell_error(ctx, "device %s not found.", argv[CONF_ARGV_DEV]);
+	if (spec == NULL) {
+		shell_error(ctx, "device %s not found.", argv[CONF_ARGV_SPI_DEV]);
 		return -ENODEV;
 	}
 
@@ -137,15 +365,21 @@ static int cmd_spi_conf(const struct shell *ctx, size_t argc, char **argv)
 	}
 
 out:
-	config.frequency = frequency;
-	config.operation = operation;
-	spi_device = dev;
+	spec->config.frequency = frequency;
+	spec->config.operation = operation;
 
 	return 0;
 }
 
 static int cmd_spi_conf_cs(const struct shell *ctx, size_t argc, char **argv)
 {
+	struct spi_dt_spec *spec = find_spec_by_label(argv[CS_ARGV_SPI_DEV]);
+
+	if (spec == NULL) {
+		shell_error(ctx, "device %s not found.", argv[CS_ARGV_SPI_DEV]);
+		return -ENODEV;
+	}
+
 	struct device *dev = (struct device *)shell_device_get_binding(argv[CS_ARGV_GPIO_DEV]);
 	char *endptr = NULL;
 
@@ -161,8 +395,8 @@ static int cmd_spi_conf_cs(const struct shell *ctx, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	config.cs.gpio.port = dev;
-	config.cs.gpio.pin = pin;
+	spec->config.cs.gpio.port = dev;
+	spec->config.cs.gpio.pin = pin;
 
 	/* Include flags if provided */
 	if (argc == (CS_ARGV_GPIO_FLAGS + 1)) {
@@ -173,32 +407,34 @@ static int cmd_spi_conf_cs(const struct shell *ctx, size_t argc, char **argv)
 			return -EINVAL;
 		}
 
-		config.cs.gpio.dt_flags = flags;
+		spec->config.cs.gpio.dt_flags = flags;
 	}
 
 	return 0;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_spi_cmds,
-			       SHELL_CMD_ARG(conf, &dsub_device_name,
-					     "Configure SPI\n"
-					     "Usage: spi conf <device> <frequency> [<settings>]\n"
-					     "<settings> - any sequence of letters:\n"
-					     "o - SPI_MODE_CPOL\n"
-					     "h - SPI_MODE_CPHA\n"
-					     "l - SPI_TRANSFER_LSB\n"
-					     "T - SPI_FRAME_FORMAT_TI\n"
-					     "example: spi conf spi1 1000000 ol",
-					     cmd_spi_conf, 3, 1),
-			       SHELL_CMD_ARG(cs, &dsub_device_name,
-					     "Assign CS GPIO to SPI device\n"
-					     "Usage: spi cs <gpio-device> <pin> [<gpio flags>]"
-					     "example: spi cs gpio1 3 0x01",
-					     cmd_spi_conf_cs, 3, 1),
-			       SHELL_CMD_ARG(transceive, NULL,
-					     "Transceive data to and from an SPI device\n"
-					     "Usage: spi transceive <TX byte 1> [<TX byte 2> ...]",
-					     cmd_spi_transceive, 2, MAX_SPI_BYTES - 1),
-			       SHELL_SUBCMD_SET_END);
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_spi_cmds,
+	SHELL_CMD_ARG(conf, &dsub_get_spi_shell_device_name,
+		      "Configure SPI\n"
+		      "Usage: spi conf <spi-device> <frequency> [<settings>]\n"
+		      "<settings> - any sequence of letters:\n"
+		      "o - SPI_MODE_CPOL\n"
+		      "h - SPI_MODE_CPHA\n"
+		      "l - SPI_TRANSFER_LSB\n"
+		      "T - SPI_FRAME_FORMAT_TI\n"
+		      "example: spi conf spi1 1000000 ol",
+		      cmd_spi_conf, 3, 1),
+	SHELL_CMD_ARG(cs, &dsub_get_spi_shell_device_name_and_set_gpio_dsub,
+		      "Assign CS GPIO to SPI device\n"
+		      "Usage: spi cs <spi-device> <gpio-device> <pin> [<gpio flags>]\n"
+		      "example: spi cs spi1 gpio1 3 0x01",
+		      cmd_spi_conf_cs, 4, 1),
+	SHELL_CMD_ARG(transceive, &dsub_get_spi_shell_device_name,
+		      "Transceive data to and from an SPI device\n"
+		      "Usage: spi transceive <spi-device> <TX byte 1> [<TX byte 2> ...]\n"
+		      "example: spi transceive spi1 0x00 0x01",
+		      cmd_spi_transceive, 3, MAX_SPI_BYTES - 1),
+	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(spi, &sub_spi_cmds, "SPI commands", NULL);


### PR DESCRIPTION
# Description

This PR enhances the SPI shell in a number of different ways:
- Previously only spi buses could be specified in the shell. Now both spi buses and spi devices (physical device on the spi bus, not the device struct) can be specified.
- Both spi buses and spi devices can be specified by their node name or by any of their node labels.
- Instead of having a single instance of a `spi config struct`, each spi bus/device has it's own dedicated config. This means that users only have to configure spi config once for each device and use them freely, without needing to reconfigure them every time after switching between different spi buses/devices.
- Spi devices get their spi configs automatically from the devicetree at compile time. This means that once a good working configuration is found for a spi device, that can be specified as a "default" in the devicetree.
- Spi devices don't need to have their `status` set to `"okay"` or be initialized by their driver to be accessible from the spi shell. As long as the spi bus that they are on has `status="okay"`, they can be accessed.
- When changing a cs pin with `spi cs` command, the spi device/bus needs to first be specified before specifying the gpio device. The nested dynamic subcommands enable users to autocomplete both of the arguments.

## Implementation details

- It was possible to gather all the information about the spi devices from the devicetree at the compile time, but not for the spi buses. For the spi devices we have a way to get spi device nodes that are on an okay spi bus with a devicetree macros and extract data from those nodes. For the spi buses that is not possible, since there is no macro to get all spi bus nodes at once.
- So, for the spi buses this discovery step has to be done at the runtime, with the help of `SYS_INIT` macro and `shell_device_filter` function.
- Since we now allow users to either specify a spi bus or a spi device by their node label or their node name, we needed to have a way to map those strings to the correct spi config struct, so we can later pass it to the spi API functions or do some configuration on it. That is made possibly by the `find_spec_by_label` and the two arrays, `spi_things` and `maps`.