### PR TITLE
doc: west: remove old west 0.6 and 0.7 related troubleshooting entries

### DIFF
--- a/doc/develop/west/troubleshooting.rst
+++ b/doc/develop/west/troubleshooting.rst
@@ -83,47 +83,6 @@ Then:
 #. Close your ``cmd.exe`` window and open a new one. You should be able to run
    ``west``.
 
-"Error: unexpected keyword argument 'requires_workspace'"
-*********************************************************
-
-This error occurs on some Linux distributions after upgrading to west 0.7.0 or
-later from 0.6.x. For example:
-
-.. code-block:: none
-
-   $ west update
-   [... stack trace ...]
-   TypeError: __init__() got an unexpected keyword argument 'requires_workspace'
-
-This appears to be a problem with the distribution's pip; see `this comment in
-west issue 373`_ for details. Some versions of **Ubuntu** and **Linux Mint** are known to
-have this problem. Some users report issues on Fedora as well.
-
-Neither macOS nor Windows users have reported this issue. There have been no
-reports of this issue on other Linux distributions, like Arch Linux, either.
-
-.. _this comment in west issue 373:
-   https://github.com/zephyrproject-rtos/west/issues/373#issuecomment-583489272
-
-**Workaround 1**: remove the old version, then upgrade:
-
-.. code-block:: none
-
-   $ pip3 show west | grep Location: | cut -f 2 -d ' '
-   /home/foo/.local/lib/python3.6/site-packages
-   $ rm -r /home/foo/.local/lib/python3.6/site-packages/west
-   $ pip3 install --user west==0.7.0
-
-**Workaround 2**: install west in a Python virtual environment
-
-One option is to use the `venv module`_ that's part of the Python 3 standard
-library. Some distributions remove this module from their base Python 3
-packages, so you may need to do some additional work to get it installed on
-your system.
-
-.. _venv module:
-   https://docs.python.org/3/library/venv.html
-
 "invalid choice: 'build'" (or 'flash', etc.)
 ********************************************
 
@@ -203,21 +162,3 @@ The easiest way to resolve this issue is to upgrade west and retry as follows:
    you will get the "already in a workspace" error message discussed next).
 
 #. Run ``west init`` again.
-
-"already in an installation"
-****************************
-
-You may see this error when running ``west init`` with west 0.6:
-
-.. code-block:: none
-
-   FATAL ERROR: already in an installation (<some directory>), aborting
-
-If this is unexpected and you're really trying to create a new west workspace,
-then it's likely that west is using the :envvar:`ZEPHYR_BASE` :ref:`environment
-variable <env_vars>` to locate a workspace elsewhere on your system.
-
-This is intentional; it allows you to put your Zephyr applications in
-any directory and still use west to build, flash, and debug them, for example.
-
-To resolve this issue, unset :envvar:`ZEPHYR_BASE` and try again.


### PR DESCRIPTION
west 0.6.0 and 0.7.0 were released in 2019 and 2020 ; keeping troubleshooting information for these versions is not needed anymore (there isn't even a currently maintained LTS that would remotely be concerned by this).