### PR TITLE
Bluetooth: Controller: Add support for nRF54L15DK debug pins

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -1449,7 +1449,14 @@ config BT_CTLR_PROFILE_ISR
 
 config BT_CTLR_DEBUG_PINS
 	bool "Bluetooth Controller Debug Pins"
-	depends on BOARD_NRF51DK_NRF51822 || BOARD_NRF52DK_NRF52832 || BOARD_NRF52DK_NRF52810 || BOARD_NRF52840DK_NRF52840 || BOARD_NRF52833DK_NRF52833 || BOARD_NRF5340DK_NRF5340_CPUNET || BOARD_RV32M1_VEGA
+	depends on BOARD_NRF51DK_NRF51822 || \
+		   BOARD_NRF52DK_NRF52832 || \
+		   BOARD_NRF52DK_NRF52810 || \
+		   BOARD_NRF52840DK_NRF52840 || \
+		   BOARD_NRF52833DK_NRF52833 || \
+		   BOARD_NRF5340DK_NRF5340_CPUNET || \
+		   BOARD_NRF54L15DK_NRF54L15_CPUAPP || \
+		   BOARD_RV32M1_VEGA
 	help
 	  Turn on debug GPIO toggling for the Bluetooth LE Controller. This is useful
 	  when debugging with a logic analyzer or profiling certain sections of

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h
@@ -9,16 +9,16 @@
 	defined(CONFIG_BT_CTLR_DEBUG_PINS_CPUAPP)
 #if defined(CONFIG_BOARD_NRF54L15DK_NRF54L15_CPUAPP)
 #define DEBUG_PORT       NRF_P1 /* Pin header/connector labeled "PORT P1" or "P1" on DK */
-#define DEBUG_PIN0       BIT(4) /* overlaps TXD1 but disabled by default in DTS for DK, ok to use */
-#define DEBUG_PIN1       BIT(5) /* overlaps RXD1 but disabled by default in DTS for DK, ok to use */
-#define DEBUG_PIN2       BIT(6) /* overlaps RTS1 but disabled by default in DTS for DK, ok to use */
-#define DEBUG_PIN3       BIT(7) /* overlaps CTS1 but disabled by default in DTS for DK, ok to use */
-#define DEBUG_PIN4       BIT(8)
-#define DEBUG_PIN5       BIT(9)
-#define DEBUG_PIN6       BIT(10)
-#define DEBUG_PIN7       BIT(11)
-#define DEBUG_PIN8       BIT(12)
-#define DEBUG_PIN9       BIT(13)
+#define DEBUG_PIN0       BIT(7) /* overlaps CTS1, FIXME */
+#define DEBUG_PIN1       BIT(8)
+#define DEBUG_PIN2       BIT(9)
+#define DEBUG_PIN3       BIT(10)
+#define DEBUG_PIN4       BIT(10)
+#define DEBUG_PIN5       BIT(11)
+#define DEBUG_PIN6       BIT(11)
+#define DEBUG_PIN7       BIT(12)
+#define DEBUG_PIN8       BIT(13)
+#define DEBUG_PIN9       BIT(14)
 #elif defined(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP) || \
 	defined(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP_NS) || \
 	defined(CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2025 Nordic Semiconductor ASA
  * Copyright (c) 2016 Vinayak Kariappa Chettimada
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -7,7 +7,21 @@
 
 #if defined(CONFIG_BT_CTLR_DEBUG_PINS) || \
 	defined(CONFIG_BT_CTLR_DEBUG_PINS_CPUAPP)
-#if defined(CONFIG_BOARD_NRF5340DK)
+#if defined(CONFIG_BOARD_NRF54L15DK_NRF54L15_CPUAPP)
+#define DEBUG_PORT       NRF_P1 /* Pin header/connector labeled "PORT P1" or "P1" on DK */
+#define DEBUG_PIN0       BIT(4) /* overlaps TXD1 but disabled by default in DTS for DK, ok to use */
+#define DEBUG_PIN1       BIT(5) /* overlaps RXD1 but disabled by default in DTS for DK, ok to use */
+#define DEBUG_PIN2       BIT(6) /* overlaps RTS1 but disabled by default in DTS for DK, ok to use */
+#define DEBUG_PIN3       BIT(7) /* overlaps CTS1 but disabled by default in DTS for DK, ok to use */
+#define DEBUG_PIN4       BIT(8)
+#define DEBUG_PIN5       BIT(9)
+#define DEBUG_PIN6       BIT(10)
+#define DEBUG_PIN7       BIT(11)
+#define DEBUG_PIN8       BIT(12)
+#define DEBUG_PIN9       BIT(13)
+#elif defined(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP) || \
+	defined(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP_NS) || \
+	defined(CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET)
 #define DEBUG_PORT       NRF_P1
 #define DEBUG_PIN_IDX0   0
 #define DEBUG_PIN_IDX1   1


### PR DESCRIPTION
Add support for GPIO debug pins for nRF54L15DK.

Relates to #93199.