### PR TITLE
sensor: icm45686: Change watermark threshold irq to equals

### DIFF
--- a/drivers/sensor/tdk/icm45686/icm45686.c
+++ b/drivers/sensor/tdk/icm45686/icm45686.c
@@ -425,6 +425,7 @@ static int icm45686_init(const struct device *dev)
 				.lpf = DT_INST_PROP_OR(inst, gyro_lpf, 0),			   \
 			},									   \
 			.fifo_watermark = DT_INST_PROP_OR(inst, fifo_watermark, 0),		   \
+			.fifo_watermark_equals = DT_INST_PROP(inst, fifo_watermark_equals),	   \
 		},										   \
 		.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, {0}),			   \
 	};											   \

--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -160,6 +160,7 @@ struct icm45686_config {
 			uint8_t lpf : 3;
 		} gyro;
 		uint16_t fifo_watermark;
+		bool fifo_watermark_equals : 1;
 	} settings;
 	struct gpio_dt_spec int_gpio;
 };

--- a/dts/bindings/sensor/invensense,icm45686-common.yaml
+++ b/dts/bindings/sensor/invensense,icm45686-common.yaml
@@ -147,3 +147,12 @@ properties:
       Specify the FIFO watermark level in frame count.
       Default is power-up configuration (disabled).
       Valid range: 0 - 104
+
+  fifo-watermark-equals:
+    type: boolean
+    description: |
+      This value changes the FIFO watermark interrupt behavior by only triggering when the number
+      of samples is equal to the threshold (count = watermark).
+
+      Otherwise, it will generate interrupts when the level is greater or equals the FIFO Watermark
+      Threshold (count >= watermark).


### PR DESCRIPTION
When using the default configuration of watermark threshold interrupt greater than or equals, extra interrupts are serviced to icm45686_event_handler(). The expected behavior should be only one interrupt is generated per watermark threshold crossing, and until the host drains the fifo, no extra interrupts should be generated.

IMU dt fragment used,
```
&icm45686 {
	status = "okay";
	accel-odr = <ICM45686_DT_ACCEL_ODR_1600>;
	accel-fs = <ICM45686_DT_ACCEL_FS_16>;
	accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
	gyro-odr = <ICM45686_DT_GYRO_ODR_1600>;
	gyro-fs = <ICM45686_DT_GYRO_FS_2000>;
	gyro-pwr-mode = <ICM45686_DT_GYRO_LN>;
	fifo-watermark = <64>;
};
```
This is the observed current behavior of the interrupt pin with the default setting, per datasheet.
```
1: Write watermark interrupt generated when FIFO data count is greater
than or equal to FIFO watermark threshold
```
<img width="1750" height="964" alt="image" src="https://github.com/user-attachments/assets/58aae626-8757-4fd0-a81e-f69049e7cd67" />


\
This is the proposed expected behavior of the interrupt pin with the new setting, per datasheet.
```
0: Write watermark interrupt generated when FIFO data count is equal to
the FIFO watermark threshold
```
<img width="1753" height="964" alt="image" src="https://github.com/user-attachments/assets/5d011c57-fecf-463f-9d6d-29ae2c87bbc7" />

