### PR TITLE
drivers: i2c: make STM32 transfer timeout configurable

### DIFF
--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -65,4 +65,12 @@ config I2C_STM32_V2_DMA
 	help
 	  Enable DMA support for the STM32 I2C driver.
 
+config I2C_STM32_TRANSFER_TIMEOUT_MSEC
+	int "STM32 I2C transfer timeout (ms)"
+	range 1 $(UINT32_MAX)
+	default 500
+	help
+	  Time in milliseconds to wait for an I2C transfer to complete before
+	  considering it timed out.
+
 endif # I2C_STM32

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -24,8 +24,6 @@ LOG_MODULE_REGISTER(i2c_ll_stm32_v1);
 #include "i2c_ll_stm32.h"
 #include "i2c-priv.h"
 
-#define I2C_STM32_TRANSFER_TIMEOUT_MSEC  500
-
 #define I2C_STM32_TIMEOUT_USEC  1000
 #define I2C_REQUEST_WRITE       0x00
 #define I2C_REQUEST_READ        0x01
@@ -648,7 +646,7 @@ static int32_t i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg
 	i2c_stm32_enable_transfer_interrupts(dev);
 
 	if (k_sem_take(&data->device_sync_sem,
-			K_MSEC(I2C_STM32_TRANSFER_TIMEOUT_MSEC)) != 0) {
+		       K_MSEC(CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC)) != 0) {
 		LOG_DBG("%s: WRITE timeout", __func__);
 		i2c_stm32_reset(dev);
 		return -EIO;
@@ -670,7 +668,7 @@ static int32_t i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 	LL_I2C_EnableIT_RX(i2c);
 
 	if (k_sem_take(&data->device_sync_sem,
-			K_MSEC(I2C_STM32_TRANSFER_TIMEOUT_MSEC)) != 0) {
+		       K_MSEC(CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC)) != 0) {
 		LOG_DBG("%s: READ timeout", __func__);
 		i2c_stm32_reset(dev);
 		return -EIO;

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -33,8 +33,6 @@ LOG_MODULE_REGISTER(i2c_ll_stm32_v2);
 #include "i2c_ll_stm32.h"
 #include "i2c-priv.h"
 
-#define I2C_STM32_TRANSFER_TIMEOUT_MSEC  500
-
 #ifdef CONFIG_I2C_STM32_V2_TIMING
 /* Use the algorithm to calcuate the I2C timing */
 #ifndef I2C_STM32_VALID_TIMING_NBR
@@ -691,7 +689,7 @@ static int i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg,
 	LL_I2C_EnableIT_TX(i2c);
 
 	if (k_sem_take(&data->device_sync_sem,
-		       K_MSEC(I2C_STM32_TRANSFER_TIMEOUT_MSEC)) != 0) {
+		       K_MSEC(CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC)) != 0) {
 		i2c_stm32_master_mode_end(dev);
 		k_sem_take(&data->device_sync_sem, K_FOREVER);
 		is_timeout = true;
@@ -750,7 +748,7 @@ static int i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 	LL_I2C_EnableIT_RX(i2c);
 
 	if (k_sem_take(&data->device_sync_sem,
-		       K_MSEC(I2C_STM32_TRANSFER_TIMEOUT_MSEC)) != 0) {
+		       K_MSEC(CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC)) != 0) {
 		i2c_stm32_master_mode_end(dev);
 		k_sem_take(&data->device_sync_sem, K_FOREVER);
 		is_timeout = true;
@@ -845,7 +843,7 @@ static inline int msg_done(const struct device *dev,
 			return -EIO;
 		}
 		if ((k_uptime_get() - start_time) >
-		    I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
+		    CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
 			return -ETIMEDOUT;
 		}
 	}
@@ -854,7 +852,7 @@ static inline int msg_done(const struct device *dev,
 		LL_I2C_GenerateStopCondition(i2c);
 		while (!LL_I2C_IsActiveFlag_STOP(i2c)) {
 			if ((k_uptime_get() - start_time) >
-			    I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
+			    CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
 				return -ETIMEDOUT;
 			}
 		}
@@ -889,7 +887,7 @@ static int i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg,
 			}
 
 			if ((k_uptime_get() - start_time) >
-			    I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
+			    CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
 				return -ETIMEDOUT;
 			}
 		}
@@ -920,7 +918,7 @@ static int i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 				return -EIO;
 			}
 			if ((k_uptime_get() - start_time) >
-			    I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
+			    CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
 				return -ETIMEDOUT;
 			}
 		}


### PR DESCRIPTION
Make the STM32 I2C transfer timeout configurable via Kconfig.

* Add `CONFIG_I2C_STM32_TRANSFER_TIMEOUT` Kconfig symbol.
* Keep default behavior (500 ms) to preserve compatibility.
* Replace the hard-coded 500 ms timeout in `i2c_ll_stm32_v1.c` and `i2c_ll_stm32_v2.c` with new Kconfig symbol.

Previously the STM32 I2C driver used a macro with a hardcoded 500 ms timeout which could cause unacceptable blocking in some real-time applications. This change exposes the timeout to applications so it can be customized.

Fixes: #95819