### PR TITLE
kernel: Consolidate thread state checking functions

### DIFF
--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -98,6 +98,25 @@ static inline bool z_is_thread_pending(struct k_thread *thread)
 	return (thread->base.thread_state & _THREAD_PENDING) != 0U;
 }
 
+static inline bool z_is_thread_dead(struct k_thread *thread)
+{
+	return (thread->base.thread_state & _THREAD_DEAD) != 0U;
+}
+
+/* Return true if the thread is aborting, else false */
+static inline bool z_is_thread_aborting(struct k_thread *thread)
+{
+	return (thread->base.thread_state & _THREAD_ABORTING) != 0U;
+}
+
+/* Return true if the thread is aborting or suspending, else false */
+static inline bool z_is_thread_halting(struct k_thread *thread)
+{
+	return (thread->base.thread_state &
+		(_THREAD_ABORTING | _THREAD_SUSPENDING)) != 0U;
+}
+
+
 static inline bool z_is_thread_prevented_from_running(struct k_thread *thread)
 {
 	uint8_t state = thread->base.thread_state;


### PR DESCRIPTION
This series of two patches performs minor cleanup and refactoring within the scheduler code.

The first patch improves code consistency and readability by:

1. Consolidating thread state functions into a shared header file.

2. Replacing a direct bitwise check with a new, more descriptive helper function.

The second patch simplifies logic by:

1. Replacing a negative condition (!z_is_thread_prevented_from_running()) with a more readable positive check (z_is_thread_ready()).

2. Removing a redundant CONFIG_SMP conditional check.

3. Add the missing #endif directive.