### PR TITLE
tests: ram_context_for_isr: add default IRQ number for NPCKn variant

### DIFF
--- a/tests/application_development/ram_context_for_isr/Kconfig
+++ b/tests/application_development/ram_context_for_isr/Kconfig
@@ -10,6 +10,7 @@ config TEST_IRQ_NUM
 	default 14 if GIC
 	default 22 if SOC_SERIES_DA1469X
 	default 18 if SOC_SERIES_STM32C0X
+	default 1 if NPCX_SOC_VARIANT_NPCKN
 	default 0
 	help
 	  IRQ number to use for testing purposes. This should be an


### PR DESCRIPTION
Add a default IRQ number for the NPCKn variant in the npcx series.