### PR TITLE
usb: device_next: cdc_acm: init uart config from default line coding

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -1126,6 +1126,8 @@ static int usbd_cdc_acm_preinit(const struct device *dev)
 	k_work_init(&data->rx_fifo_work, cdc_acm_rx_fifo_handler);
 	k_work_init(&data->irq_cb_work, cdc_acm_irq_cb_handler);
 
+	cdc_acm_update_uart_cfg(data);
+
 	return 0;
 }
 


### PR DESCRIPTION
Initialize the UART configuration from the default line coding when the CDC ACM device is started. This ensures that the UART configuration matches the default line coding until the host sets the line coding for the first time.