### PR TITLE
drivers: pinctrl: microchip: update pinctrl driver for Port G1 IPs

### DIFF
--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
@@ -11,4 +11,5 @@ flash: 512
 ram: 64
 supported:
   - gpio
+  - pinctrl
 vendor: microchip

--- a/drivers/pinctrl/pinctrl_mchp_port_g1.c
+++ b/drivers/pinctrl/pinctrl_mchp_port_g1.c
@@ -27,23 +27,23 @@
 /* clang-format off */
 #define MCHP_PORT_ADDR_OR_NONE(nodelabel)                              \
 	IF_ENABLED(DT_NODE_EXISTS(DT_NODELABEL(nodelabel)),            \
-		(DT_REG_ADDR(DT_NODELABEL(nodelabel))))
-/* clang-format on */
+		(DT_REG_ADDR(DT_NODELABEL(nodelabel)),))
 
 /**
- * @brief Array of port addresses for the MCHP SAMD5x_E5x series.
+ * @brief Array of port addresses for the MCHP G1 series.
  *
  * This array contains the register addresses of the ports (PORTA, PORTB, PORTC, and PORTD)
- * for the MCHP SAMD5x_E5x series microcontrollers. The addresses are obtained using the
+ * for the MCHP G1 series port peripheral. The addresses are obtained using the
  * MCHP_PORT_ADDR_OR_NONE macro, which ensures that only existing ports are included.
- * This can be updated for other devices using conditional comiplation directives
+ * This can be updated for other devices using conditional compilation directives
  */
 static const uint32_t mchp_port_addrs[] = {
-	MCHP_PORT_ADDR_OR_NONE(porta),
-	MCHP_PORT_ADDR_OR_NONE(portb),
-	MCHP_PORT_ADDR_OR_NONE(portc),
-	MCHP_PORT_ADDR_OR_NONE(portd),
+	MCHP_PORT_ADDR_OR_NONE(porta)
+	MCHP_PORT_ADDR_OR_NONE(portb)
+	MCHP_PORT_ADDR_OR_NONE(portc)
+	MCHP_PORT_ADDR_OR_NONE(portd)
 };
+/* clang-format on */
 
 /**
  * @brief Set pinmux registers using odd/even logic

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
@@ -38,12 +38,19 @@
 			compatible = "mmio-sram";
 		};
 
-		porta: gpio@41000000 {
-			compatible = "microchip,port-g1-gpio";
-			reg = <0x41000000 0x80>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			#microchip,pin-cells = <2>;
+		pinctrl: pinctrl@41000000 {
+			compatible = "microchip,port-g1-pinctrl";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x41000000 0x41000000 0x180>;
+
+			porta: gpio@41000000 {
+				compatible = "microchip,port-g1-gpio";
+				reg = <0x41000000 0x80>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#microchip,pin-cells = <2>;
+			};
 		};
 	};
 };

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh_100.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh_100.dtsi
@@ -8,22 +8,20 @@
 
 #include <microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi>
 
-/ {
-	soc {
-		portb: gpio@41000080 {
-			compatible = "microchip,port-g1-gpio";
-			reg = <0x41000080 0x80>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			#microchip,pin-cells = <2>;
-		};
+&pinctrl {
+	portb: gpio@41000080 {
+		compatible = "microchip,port-g1-gpio";
+		reg = <0x41000080 0x80>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#microchip,pin-cells = <2>;
+	};
 
-		portc: gpio@41000100 {
-			compatible = "microchip,port-g1-gpio";
-			reg = <0x41000100 0x80>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			#microchip,pin-cells = <2>;
-		};
+	portc: gpio@41000100 {
+		compatible = "microchip,port-g1-gpio";
+		reg = <0x41000100 0x80>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#microchip,pin-cells = <2>;
 	};
 };

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh_48.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh_48.dtsi
@@ -8,14 +8,12 @@
 
 #include <microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi>
 
-/ {
-	soc {
-		portb: gpio@41000080 {
-			compatible = "microchip,port-g1-gpio";
-			reg = <0x41000080 0x80>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			#microchip,pin-cells = <2>;
-		};
+&pinctrl {
+	portb: gpio@41000080 {
+		compatible = "microchip,port-g1-gpio";
+		reg = <0x41000080 0x80>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#microchip,pin-cells = <2>;
 	};
 };

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh_64.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh_64.dtsi
@@ -8,14 +8,12 @@
 
 #include <microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi>
 
-/ {
-	soc {
-		portb: gpio@41000080 {
-			compatible = "microchip,port-g1-gpio";
-			reg = <0x41000080 0x80>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			#microchip,pin-cells = <2>;
-		};
+&pinctrl {
+	portb: gpio@41000080 {
+		compatible = "microchip,port-g1-gpio";
+		reg = <0x41000080 0x80>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#microchip,pin-cells = <2>;
 	};
 };

--- a/dts/bindings/pinctrl/microchip,port-g1-pinctrl.yaml
+++ b/dts/bindings/pinctrl/microchip,port-g1-pinctrl.yaml
@@ -13,6 +13,7 @@ description: |
 
   Group g1 PORT PINCTRL driver supports following hardware peripherals:
     - module name="PORT" id="U2210" version="2.2.0"
+    - module name="PORT" id="U2210" version="3.1.0"
 
   The node has the 'pinctrl' node label set in your SoC's devicetree, so you can
   modify it like this:
@@ -112,7 +113,7 @@ child-binding:
         description: |
           An array of pins sharing the same group properties. The pins should
           be defined using pre-defined macros or, alternatively, using the
-          SAM_PINMUX utility macros depending on the pinmux model used by the
+          MCHP_PINMUX utility macros depending on the pinmux model used by the
           SoC series.
       drive-strength:
         enum:

--- a/soc/microchip/pic32c/pic32cm_jh/Kconfig.soc
+++ b/soc/microchip/pic32c/pic32cm_jh/Kconfig.soc
@@ -16,6 +16,12 @@ config GPIO_MCHP_PORT_U2210_3_1_0
 	help
 	  Enable PORT GPIO peripheral IP version id="U2210" version="3.1.0".
 
+config PINCTRL_MCHP_PORT_U2210_3_1_0
+	bool
+	default y
+	help
+	  Enable PORT pinctrl peripheral IP version 3.1.0 (U2210).
+
 endif # SOC_FAMILY_MICROCHIP_PIC32CM_JH
 
 rsource "*/Kconfig.soc"

--- a/soc/microchip/pic32c/pic32cm_jh/common/CMakeLists.txt
+++ b/soc/microchip/pic32c/pic32cm_jh/common/CMakeLists.txt
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources(soc.c)
+zephyr_include_directories(.)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/microchip/pic32c/pic32cm_jh/common/pinctrl_soc.h
+++ b/soc/microchip/pic32c/pic32cm_jh/common/pinctrl_soc.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/devicetree.h>
+#include <zephyr/types.h>
+#include <dt-bindings/pic32c/pic32cm_jh/common/mchp_pinctrl_pinmux_pic32c.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @brief Structure representing the pin control settings for a SOC pin.
+ *
+ * This structure is used to define the pinmux and pin configuration settings
+ * for a specific pin on the SOC. It includes information about the port, pin,
+ * function, bias, drive, and other configuration options.
+ */
+typedef struct pinctrl_soc_pin {
+	/** Pinmux settings (port, pin and function). */
+	uint16_t pinmux;
+	/** Pin configuration (bias, drive etc). */
+	uint16_t pinflag;
+} pinctrl_soc_pin_t;
+
+/**
+ * @brief Utility macro to initialize pinmux field.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name.
+ * @param idx Property entry index.
+ */
+#define Z_PINCTRL_MCHP_PINMUX_INIT(node_id, prop, idx) DT_PROP_BY_IDX(node_id, prop, idx)
+
+/**
+ * @brief Utility macro to initialize each pin flag.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name.
+ * @param idx Property entry index.
+ */
+#define Z_PINCTRL_MCHP_PINFLAG_INIT(node_id, prop, idx)                                            \
+	((DT_PROP(node_id, bias_pull_up) << MCHP_PINCTRL_PULLUP_POS) |                             \
+	 (DT_PROP(node_id, bias_pull_down) << MCHP_PINCTRL_PULLDOWN_POS) |                         \
+	 (DT_PROP(node_id, input_enable) << MCHP_PINCTRL_INPUTENABLE_POS) |                        \
+	 (DT_PROP(node_id, output_enable) << MCHP_PINCTRL_OUTPUTENABLE_POS) |                      \
+	 (DT_ENUM_IDX(node_id, drive_strength) << MCHP_PINCTRL_DRIVESTRENGTH_POS)),
+
+/**
+ * @brief Utility macro to initialize each pin.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name.
+ * @param idx Property entry index.
+ */
+#define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)                                               \
+	{.pinmux = Z_PINCTRL_MCHP_PINMUX_INIT(node_id, prop, idx),                                 \
+	 .pinflag = Z_PINCTRL_MCHP_PINFLAG_INIT(node_id, prop, idx)},
+
+/**
+ * @brief Utility macro to initialize state pins contained in a given property.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name describing state pins.
+ */
+#define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)                                                   \
+	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop), DT_FOREACH_PROP_ELEM, pinmux,           \
+				Z_PINCTRL_STATE_PIN_INIT)}
+
+/** @endcond */
+
+/**
+ * @brief Pin flags/attributes
+ * @anchor MCHP_PINFLAGS
+ *
+ * @{
+ */
+
+#define MCHP_PINCTRL_FLAGS_DEFAULT     (0U)
+#define MCHP_PINCTRL_FLAGS_POS         (0U)
+#define MCHP_PINCTRL_FLAGS_MASK        (0x3F << MCHP_PINCTRL_FLAGS_POS)
+#define MCHP_PINCTRL_FLAG_MASK         (1U)
+#define MCHP_PINCTRL_PULLUP_POS        (MCHP_PINCTRL_FLAGS_POS)
+#define MCHP_PINCTRL_PULLUP            (1U << MCHP_PINCTRL_PULLUP_POS)
+#define MCHP_PINCTRL_PULLDOWN_POS      (MCHP_PINCTRL_PULLUP_POS + 1U)
+#define MCHP_PINCTRL_PULLDOWN          (1U << MCHP_PINCTRL_PULLDOWN_POS)
+#define MCHP_PINCTRL_OPENDRAIN_POS     (MCHP_PINCTRL_PULLDOWN_POS + 1U)
+#define MCHP_PINCTRL_OPENDRAIN         (1U << MCHP_PINCTRL_OPENDRAIN_POS)
+#define MCHP_PINCTRL_INPUTENABLE_POS   (MCHP_PINCTRL_OPENDRAIN_POS + 1U)
+#define MCHP_PINCTRL_INPUTENABLE       (1U << MCHP_PINCTRL_INPUTENABLE_POS)
+#define MCHP_PINCTRL_OUTPUTENABLE_POS  (MCHP_PINCTRL_INPUTENABLE_POS + 1U)
+#define MCHP_PINCTRL_OUTPUTENABLE      (1U << MCHP_PINCTRL_OUTPUTENABLE_POS)
+#define MCHP_PINCTRL_DRIVESTRENGTH_POS (MCHP_PINCTRL_OUTPUTENABLE_POS + 1U)
+#define MCHP_PINCTRL_DRIVESTRENGTH     (1U << MCHP_PINCTRL_DRIVESTRENGTH_POS)
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif

--- a/west.yml
+++ b/west.yml
@@ -195,7 +195,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: e5fe6469afc53d7aefcc74377dd99ce20428d42b
+      revision: db50e73b20f29ab758b3a79f173db37826434936
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
This pull request adds the pinctrl devicetree node for Microchip PIC32CM JH family devices and updates the binding file for the Microchip Pinctrl Port G1 IP. It also refactors the pinctrl driver to make it more generic and fixes a few typos.

Associated hal_microchip PR: https://github.com/zephyrproject-rtos/hal_microchip/pull/42