### PR TITLE
BOARD: fix typo in imx8mm and imx8mp board doc

### DIFF
--- a/boards/nxp/imx8mm_evk/doc/index.rst
+++ b/boards/nxp/imx8mm_evk/doc/index.rst
@@ -159,7 +159,7 @@ Or use "cpu" command to boot from secondary Core, for example Core1:
 Option 3. Boot Zephyr by Using Remoteproc under Linux
 =====================================================
 
-When running Linux on the A55 core, it can use the remoteproc framework to load and boot Zephyr,
+When running Linux on the A53 cores, it can use the remoteproc framework to load and boot Zephyr,
 refer to Real-Time Edge user guide for more details. Pre-build images and user guide can be found
 at `Real-Time Edge Software`_.
 

--- a/boards/nxp/imx8mp_evk/doc/index.rst
+++ b/boards/nxp/imx8mp_evk/doc/index.rst
@@ -155,7 +155,7 @@ Or use "cpu" command to boot from secondary Core, for example Core1:
 Option 3. Boot Zephyr by Using Remoteproc under Linux
 =====================================================
 
-When running Linux on the A55 core, it can use the remoteproc framework to load and boot Zephyr,
+When running Linux on the A53 cores, it can use the remoteproc framework to load and boot Zephyr,
 refer to Real-Time Edge user guide for more details. Pre-build images and user guide can be found
 at `Real-Time Edge Software`_.
 


### PR DESCRIPTION
A53 cores miswritten as A55. Fix it for accuracy.