### PR TITLE
MAINTAINERS.yml: Remove aaillet as Renesas R-Car maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4206,7 +4206,6 @@ Release Notes:
 Renesas R-Car Platforms:
   status: maintained
   maintainers:
-    - aaillet
     - lorc
   collaborators:
     - xakep-amatop


### PR DESCRIPTION
Due to a change in my work situation, I will no longer have the time to fulfill my obligations as a maintainer. The Renesas R-Car area will still have a maintainer and a collaborator, which is enough given the workload involved.

