### PR TITLE
drivers: wm8962: Enable input PGA

### DIFF
--- a/drivers/audio/wm8962.c
+++ b/drivers/audio/wm8962.c
@@ -681,8 +681,10 @@ static void wm8962_configure_output(const struct device *dev)
 
 static void wm8962_configure_input(const struct device *dev)
 {
-	wm8962_route_input(dev, AUDIO_CHANNEL_FRONT_LEFT, kWM8962_InputPGASourceInput1);
-	wm8962_route_input(dev, AUDIO_CHANNEL_FRONT_RIGHT, kWM8962_InputPGASourceInput3);
+	wm8962_route_input(dev, AUDIO_CHANNEL_FRONT_LEFT,
+			   WM8962_INPUT_PGA_ENA | kWM8962_InputPGASourceInput1);
+	wm8962_route_input(dev, AUDIO_CHANNEL_FRONT_RIGHT,
+			   WM8962_INPUT_PGA_ENA | kWM8962_InputPGASourceInput3);
 
 	/* Input MIXER source */
 	wm8962_write_reg(dev, WM8962_REG_INPUTMIX,

--- a/drivers/audio/wm8962.h
+++ b/drivers/audio/wm8962.h
@@ -322,6 +322,8 @@ typedef enum _wm8962_protocol {
 	kWM8962_BusRightJustified = 0, /*!< Right justified mode */
 } wm8962_protocol_t;
 
+#define WM8962_INPUT_PGA_ENA BIT(4)
+
 /*! @brief wm8962 input source */
 typedef enum _wm8962_input_pga_source {
 	kWM8962_InputPGASourceInput1 = 8, /*!< Input PGA source input1 */


### PR DESCRIPTION
The left and right input PGAs are not enabled. It causes invalid audio data is captured.

Enable the left and right input PGAs by setting bit 4.