### PR TITLE
Bluetooth: Classic: AVRCP: Support vendor dependent cmd

### DIFF
--- a/include/zephyr/bluetooth/classic/avrcp.h
+++ b/include/zephyr/bluetooth/classic/avrcp.h
@@ -629,6 +629,29 @@ struct bt_avrcp_event_data {
 	};
 };
 
+/** @brief Callback for AVRCP event notifications (CHANGED only).
+ *
+ * This callback is invoked by the AVRCP Target (TG) when a registered event
+ * occurs and a "changed" notification needs to be sent to the Controller (CT).
+ *
+ * For interim and rejected error cases, the callback will trigger the
+ * `notification` function registered by the Controller
+ *
+ *  @param ct AVRCP CT connection object.
+ *
+ *  @param event_id The AVRCP event identifier. @ref bt_avrcp_event_data
+ *        This corresponds to one of the AVRCP event types such as
+ *         EVENT_PLAYBACK_STATUS_CHANGED, EVENT_TRACK_CHANGED, etc.
+ *
+ *  @param data Pointer to @ref bt_avrcp_event_data structure containing the event-specific
+ *        data. The content of the union depends on the event_id.
+ *
+ *  @note The callback implementation should not block or perform heavy operations.
+ *       If needed, defer processing to another thread or task.
+ */
+typedef void(*bt_avrcp_notify_changed_cb_t)(struct bt_avrcp_ct *ct, uint8_t event_id,
+					    struct bt_avrcp_event_data *data);
+
 struct bt_avrcp_ct_cb {
 	/** @brief An AVRCP CT connection has been established.
 	 *
@@ -735,6 +758,34 @@ struct bt_avrcp_ct_cb {
 	 *             big-endian format.
 	 */
 	void (*browsed_player_rsp)(struct bt_avrcp_ct *ct, uint8_t tid, struct net_buf *buf);
+
+	/** @brief Callback function for Event Notification response (CT).
+	 *
+	 * Called when the AVRCP Target (TG) sends a response to a previously
+	 * registered event (Register Notification). This callback reports the
+	 * event type, the response phase (e.g., Interim), and the event-specific
+	 * payload.
+	 *
+	 * @param ct       AVRCP Controller (CT) connection context.
+	 * @param tid      Transaction label that correlates this notification
+	 *                 with the original Register Notification request.
+	 * @param status   TG status/phase code (BT_AVRCP_STATUS_*). Typically
+	 *                 BT_AVRCP_STATUS_SUCCESS for an interim notification.
+	 *                 Error codes may be returned for invalid parameters or
+	 *                 unsupported events.
+	 * @param event_id The AVRCP event identifier. @ref bt_avrcp_event_data
+	 *        This corresponds to one of the AVRCP event types such as
+	 *        EVENT_PLAYBACK_STATUS_CHANGED, EVENT_TRACK_CHANGED, etc.
+	 *
+	 * @param data Pointer to @ref bt_avrcp_event_data structure containing the
+	 *         event-specific data. The content of the union depends on the event_id.
+	 *
+	 * @note This callback is only invoked for interim notifications and error
+	 *       statuses from the TG. For CHANGED event notifications, the event must
+	 *       first be registered using @ref bt_avrcp_notify_changed_cb_t.
+	 */
+	void (*notification)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status, uint8_t event_id,
+			     struct bt_avrcp_event_data *data);
 };
 
 /** @brief Connect AVRCP.
@@ -883,6 +934,23 @@ int bt_avrcp_ct_passthrough(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t opid, u
  */
 int bt_avrcp_ct_set_browsed_player(struct bt_avrcp_ct *ct, uint8_t tid, uint16_t player_id);
 
+/** @brief Register for AVRCP changed notifications with callback.
+ *
+ *  This function registers for notifications from the target device.
+ *  The notification response will be received through the provided callback function.
+ *
+ *  @param ct The AVRCP CT instance.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param event_id The event ID to register for, see @ref bt_avrcp_evt_t.
+ *  @param interval The playback interval for position changed events.
+ *         Other events will have this value set to 0 to ignore.
+ *  @param cb The callback function to handle the changed notification response.
+ *
+ *  @return 0 in case of success or error code in case of error.
+ */
+int bt_avrcp_ct_register_notification(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t event_id,
+				      uint32_t interval, bt_avrcp_notify_changed_cb_t cb);
+
 struct bt_avrcp_tg_cb {
 	/** @brief An AVRCP TG connection has been established.
 	 *
@@ -911,6 +979,19 @@ struct bt_avrcp_tg_cb {
 	 *  @param tg AVRCP TG connection object.
 	 */
 	void (*unit_info_req)(struct bt_avrcp_tg *tg, uint8_t tid);
+
+	/** @brief Register notification request callback.
+	 *
+	 *  This callback is called whenever an AVRCP register notification is requested.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param event_id The event ID that the CT wants to register for @ref bt_avrcp_evt_t.
+	 *  @param interval The playback interval for position changed event.
+	 *         other events will have this value set to 0 for ignoring.
+	 */
+	void (*register_notification)(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t event_id,
+				      uint32_t interval);
 
 	/** @brief Subunit Info Request callback.
 	 *
@@ -1022,6 +1103,33 @@ int bt_avrcp_tg_send_subunit_info_rsp(struct bt_avrcp_tg *tg, uint8_t tid);
  *  @return 0 in case of success or error code in case of error.
  */
 int bt_avrcp_tg_get_caps(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status, struct net_buf *buf);
+
+/** @brief Send notification response.
+ *
+ * This function sends a notification response from the AVRCP Target (TG) to
+ * the Controller (CT) for a previously registered event. The response can be:
+ *
+ * - **INTERIM**: Sent on the first call for the given @p event_id to indicate
+ *   that the event is being monitored.
+ * - **CHANGED**: Sent on the next call for the same @p event_id when the event
+ *   state has changed.
+ *
+ *  @param tg The AVRCP TG instance.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *  @param event_id The AVRCP event ID for which the notification is sent, @ref bt_avrcp_evt_t.
+ *  @param data Pointer to an bt_avrcp_event_data structure containing the event-specific
+ *             data. The content of the union depends on the event_id.
+ *
+ *  @return 0 in case of success or error code in case of error.
+ *
+ * @note
+ * - The first successful call for a given @p event_id sends an INTERIM response.
+ * - The next successful call for the same @p event_id sends a CHANGED response.
+ * - If @p status is not SUCCESS, a REJECTED or NOT_IMPLEMENTED response is sent.
+ */
+int bt_avrcp_tg_notification(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status, uint8_t event_id,
+			     struct bt_avrcp_event_data *data);
 
 /** @brief Send the set browsed player response.
  *

--- a/include/zephyr/bluetooth/classic/avrcp.h
+++ b/include/zephyr/bluetooth/classic/avrcp.h
@@ -257,6 +257,26 @@ typedef enum __packed {
 	 * Valid for Commands: All Register Notification commands
 	 */
 	BT_AVRCP_STATUS_ADDRESSED_PLAYER_CHANGED = 0x16,
+
+	/** In transition response.
+	 * The target is currently changing state (e.g., between play/pause).
+	 * Note: This status is not used for browsing commands.
+	 */
+	BT_AVRCP_STATUS_IN_TRANSITION = 0xfd,
+
+	/** Not implemented response.
+	 * The command/PDU is not supported by the target device.
+	 * Note: This status is not used for browsing commands.
+	 */
+	BT_AVRCP_STATUS_NOT_IMPLEMENTED = 0xfe,
+
+	/** Successful response.
+	 * The requested command or PDU was processed successfully by the target device.
+	 *
+	 * For control commands, it means the request was accepted.
+	 * For status commands, it means the state is stable and reported successfully.
+	 */
+	BT_AVRCP_STATUS_SUCCESS = BT_AVRCP_STATUS_OPERATION_COMPLETED,
 } bt_avrcp_status_t;
 
 /** @brief AVRCP CT structure */
@@ -300,7 +320,7 @@ struct bt_avrcp_passthrough_rsp {
 	struct bt_avrcp_passthrough_opvu_data data[0]; /**< opvu data */
 } __packed;
 
-struct bt_avrcp_get_cap_rsp {
+struct bt_avrcp_get_caps_rsp {
 	uint8_t cap_id;  /**< bt_avrcp_cap_t */
 	uint8_t cap_cnt; /**< number of items contained in *cap */
 	uint8_t cap[];   /**< 1 or 3 octets each depends on cap_id */
@@ -326,6 +346,288 @@ struct bt_avrcp_set_browsed_player_rsp {
 	uint8_t folder_depth;                        /**< Folder depth */
 	struct bt_avrcp_folder_name folder_names[0]; /**< Folder names data */
 } __packed;
+
+/** @brief AVRCP Playback Status */
+typedef enum __packed {
+	BT_AVRCP_PLAYBACK_STATUS_STOPPED  = 0x00,
+	BT_AVRCP_PLAYBACK_STATUS_PLAYING  = 0x01,
+	BT_AVRCP_PLAYBACK_STATUS_PAUSED   = 0x02,
+	BT_AVRCP_PLAYBACK_STATUS_FWD_SEEK = 0x03,
+	BT_AVRCP_PLAYBACK_STATUS_REV_SEEK = 0x04,
+	BT_AVRCP_PLAYBACK_STATUS_ERROR    = 0xFF,
+} bt_avrcp_playback_status_t;
+
+/** @brief AVRCP System Status Code. */
+typedef enum __packed {
+	BT_AVRCP_SYSTEM_STATUS_POWER_ON  = 0x00,
+	BT_AVRCP_SYSTEM_STATUS_POWER_OFF = 0x01,
+	BT_AVRCP_SYSTEM_STATUS_UNPLUGGED = 0x02,
+} bt_avrcp_system_status_t;
+
+/** @brief AVRCP Battery Status Code. */
+typedef enum __packed {
+	BT_AVRCP_BATTERY_STATUS_NORMAL   = 0x00,
+	BT_AVRCP_BATTERY_STATUS_WARNING  = 0x01,
+	BT_AVRCP_BATTERY_STATUS_CRITICAL = 0x02,
+	BT_AVRCP_BATTERY_STATUS_EXTERNAL = 0x03,
+	BT_AVRCP_BATTERY_STATUS_FULL     = 0x04,
+} bt_avrcp_battery_status_t;
+
+/** AVRCP MAX absolute volume. */
+#define BT_AVRCP_MAX_ABSOLUTE_VOLUME 0x7F
+
+/** @brief AVRCP Media Attribute IDs */
+typedef enum __packed {
+	BT_AVRCP_MEDIA_ATTR_TITLE = 0x01,
+	BT_AVRCP_MEDIA_ATTR_ARTIST = 0x02,
+	BT_AVRCP_MEDIA_ATTR_ALBUM = 0x03,
+	BT_AVRCP_MEDIA_ATTR_TRACK_NUMBER = 0x04,
+	BT_AVRCP_MEDIA_ATTR_TOTAL_TRACKS = 0x05,
+	BT_AVRCP_MEDIA_ATTR_GENRE = 0x06,
+	BT_AVRCP_MEDIA_ATTR_PLAYING_TIME = 0x07,
+} bt_avrcp_media_attr_t;
+
+/** @brief GetElementAttributes command request structure */
+struct bt_avrcp_get_element_attrs_cmd {
+	uint8_t identifier[8]; /**< Element identifier (0x0 for currently playing) */
+	uint8_t num_attrs;     /**< Number of attributes requested (0 = all) */
+	uint32_t attr_ids[];   /**< Array of requested attribute IDs */
+} __packed;
+
+/** @brief AVRCP Media Attribute structure */
+struct bt_avrcp_media_attr {
+	uint32_t attr_id;    /**< Media attribute ID, see @ref bt_avrcp_media_attr_t */
+	uint16_t charset_id; /**< Character set ID, see @ref bt_avrcp_charset_t */
+	uint16_t attr_len;   /**< Length of attribute value */
+	uint8_t attr_val[];  /**< Attribute value data */
+} __packed;
+
+/** @brief GetElementAttributes response structure */
+struct bt_avrcp_get_element_attrs_rsp {
+	uint8_t num_attrs;			/**< Number of attributes in response */
+	struct bt_avrcp_media_attr attrs[];	/**< Array of media attributes */
+} __packed;
+
+/** @brief AVRCP Player Application Setting Attribute IDs */
+typedef enum __packed {
+	BT_AVRCP_PLAYER_ATTR_EQUALIZER = 0x01U,
+	BT_AVRCP_PLAYER_ATTR_REPEAT_MODE = 0x02U,
+	BT_AVRCP_PLAYER_ATTR_SHUFFLE = 0x03U,
+	BT_AVRCP_PLAYER_ATTR_SCAN = 0x04U,
+} bt_avrcp_player_attr_id_t;
+
+/** @brief AVRCP Player Application Setting Values for Equalizer */
+typedef enum __packed {
+	BT_AVRCP_EQUALIZER_OFF = 0x01U,
+	BT_AVRCP_EQUALIZER_ON = 0x02U,
+} bt_avrcp_equalizer_value_t;
+
+/** @brief AVRCP Player Application Setting Values for Repeat Mode */
+typedef enum __packed {
+	BT_AVRCP_REPEAT_MODE_OFF = 0x01U,
+	BT_AVRCP_REPEAT_MODE_SINGLE_TRACK = 0x02U,
+	BT_AVRCP_REPEAT_MODE_ALL_TRACKS = 0x03U,
+	BT_AVRCP_REPEAT_MODE_GROUP = 0x04U,
+} bt_avrcp_repeat_mode_value_t;
+
+/** @brief AVRCP Player Application Setting Values for Shuffle */
+typedef enum __packed {
+	BT_AVRCP_SHUFFLE_OFF = 0x01U,
+	BT_AVRCP_SHUFFLE_ALL_TRACKS = 0x02U,
+	BT_AVRCP_SHUFFLE_GROUP = 0x03U,
+} bt_avrcp_shuffle_value_t;
+
+/** @brief AVRCP Player Application Setting Values for Scan */
+typedef enum __packed {
+	BT_AVRCP_SCAN_OFF = 0x01U,
+	BT_AVRCP_SCAN_ALL_TRACKS = 0x02U,
+	BT_AVRCP_SCAN_GROUP = 0x03U,
+} bt_avrcp_scan_value_t;
+
+/** @brief AVRCP Scope Values
+ *  0x00 = Media Player List
+ *  0x01 = Filesystem
+ *  0x02 = Search
+ *  0x03 = Now Playing
+ */
+typedef enum __packed {
+	BT_AVRCP_SCOPE_MEDIA_PLAYER_LIST = 0x00U,
+	BT_AVRCP_SCOPE_FILESYSTEM        = 0x01U,
+	BT_AVRCP_SCOPE_SEARCH            = 0x02U,
+	BT_AVRCP_SCOPE_NOW_PLAYING       = 0x03U,
+} bt_avrcp_scope_t;
+
+/** @brief ListPlayerApplicationSettingAttributes response */
+struct bt_avrcp_list_app_setting_attr_rsp {
+	uint8_t num_attrs;       /**< Number of application setting attributes */
+	uint8_t attr_ids[];      /**< Array of attribute IDs @ref bt_avrcp_player_attr_id_t */
+} __packed;
+
+/** @brief ListPlayerApplicationSettingValues command request */
+struct bt_avrcp_list_player_app_setting_vals_cmd {
+	uint8_t attr_id;         /**< Attribute ID to query values for */
+} __packed;
+
+/** @brief ListPlayerApplicationSettingValues response */
+struct bt_avrcp_list_player_app_setting_vals_rsp {
+	uint8_t num_values;      /**< Number of values for the attribute */
+	uint8_t values[];        /**< Array of possible values */
+} __packed;
+
+/** @brief GetCurrentPlayerApplicationSettingValue command request */
+struct bt_avrcp_get_curr_player_app_setting_val_cmd {
+	uint8_t num_attrs;       /**< Number of attributes to query */
+	uint8_t attr_ids[];      /**< Array of attribute IDs */
+} __packed;
+
+/** @brief AVRCP Attribute-Value Pair */
+struct bt_avrcp_app_setting_attr_val {
+	uint8_t attr_id;   /**< Attribute ID */
+	uint8_t value_id;  /**< Value ID */
+} __packed;
+
+/** @brief GetCurrentPlayerApplicationSettingValue response */
+struct bt_avrcp_get_curr_player_app_setting_val_rsp {
+	uint8_t num_attrs;       /**< Number of attributes returned */
+	struct bt_avrcp_app_setting_attr_val attr_vals[]; /**< Array of attribute-value pairs */
+} __packed;
+
+/** @brief SetPlayerApplicationSettingValue command request */
+struct bt_avrcp_set_player_app_setting_val_cmd {
+	uint8_t num_attrs;       /**< Number of attributes to set */
+	struct bt_avrcp_app_setting_attr_val attr_vals[]; /**< Array of attribute-value pairs */
+} __packed;
+
+/** @brief GetPlayerApplicationSettingAttributeText command request */
+struct bt_avrcp_get_player_app_setting_attr_text_cmd {
+	uint8_t num_attrs;       /**< Number of attributes to get text for */
+	uint8_t attr_ids[];      /**< Array of attribute IDs */
+} __packed;
+
+/** @brief AVRCP Attribute Text Entry */
+struct bt_avrcp_app_setting_attr_text {
+	uint8_t attr_id;       /**< Attribute ID */
+	uint16_t charset_id;   /**< Charset ID */
+	uint8_t text_len;      /**< Length of text */
+	uint8_t text[];        /**< Text string */
+} __packed;
+
+/** @brief GetPlayerApplicationSettingAttributeText response */
+struct bt_avrcp_get_player_app_setting_attr_text_rsp {
+	uint8_t num_attrs;       /**< Number of attributes returned */
+	struct bt_avrcp_app_setting_attr_text attr_text[];
+} __packed;
+
+/** @brief GetPlayerApplicationSettingValueText command request */
+struct bt_avrcp_get_player_app_setting_val_text_cmd {
+	uint8_t attr_id;         /**< Attribute ID */
+	uint8_t num_values;      /**< Number of values to get text for */
+	uint8_t value_ids[];     /**< Array of value IDs */
+} __packed;
+
+/** @brief AVRCP Attribute Text Entry */
+struct bt_avrcp_app_setting_val_text {
+	uint8_t value_id;    /**< Value ID */
+	uint16_t charset_id;   /**< Charset ID */
+	uint8_t text_len;      /**< Length of text */
+	uint8_t text[];        /**< Text string */
+} __packed;
+
+/** @brief GetPlayerApplicationSettingValueText response */
+struct bt_avrcp_get_player_app_setting_val_text_rsp {
+	uint8_t num_values;      /**< Number of values returned */
+	struct bt_avrcp_app_setting_val_text value_text[];
+} __packed;
+
+/** @brief InformDisplayableCharacterSet command request */
+struct bt_avrcp_inform_displayable_char_set_cmd {
+	uint8_t num_charsets;    /**< Number of character sets supported */
+	uint16_t charset_ids[];  /**< Array of character set IDs */
+} __packed;
+
+/** @brief InformBatteryStatusOfCT command request */
+struct bt_avrcp_inform_batt_status_of_ct_cmd {
+	uint8_t battery_status;  /**< Battery status value @ref bt_avrcp_battery_status_t */
+} __packed;
+
+/** @brief GetPlayStatus response */
+struct bt_avrcp_get_play_status_rsp {
+	uint32_t song_length;    /**< Total length of the song in milliseconds */
+	uint32_t song_position;  /**< Current position in the song in milliseconds */
+	uint8_t play_status;     /**< Play status: @ref bt_avrcp_playback_status_t */
+} __packed;
+
+/** @brief RegisterNotification command request */
+struct bt_avrcp_register_notification_cmd {
+	uint8_t event_id;        /**< Event ID to register for */
+	uint32_t interval;       /**< Playback interval (used only for event_id = 0x05) */
+} __packed;
+
+/** @brief SetAbsoluteVolume command request */
+struct bt_avrcp_set_absolute_volume_cmd {
+	uint8_t absolute_volume;          /**< Volume level (0x00 to 0x7F) */
+} __packed;
+
+/** @brief SetAbsoluteVolume response */
+struct bt_avrcp_set_absolute_volume_rsp {
+	uint8_t absolute_volume;          /**< Volume level acknowledged */
+} __packed;
+
+/** @brief SetAddressedPlayer command request */
+struct bt_avrcp_set_addressed_player_cmd {
+	uint16_t player_id;      /**< Player ID to be addressed */
+} __packed;
+
+/** @brief PlayItem command request */
+struct bt_avrcp_play_item_cmd {
+	uint8_t scope;        /**< Scope: @ref bt_avrcp_scope_t */
+	uint8_t uid[8];       /**< UID of the item */
+	uint16_t uid_counter; /**< UID counter */
+} __packed;
+
+/** @brief AddToNowPlaying command request */
+struct bt_avrcp_add_to_now_playing_cmd {
+	uint8_t scope;           /**< Scope: @ref bt_avrcp_scope_t */
+	uint8_t uid[8];         /**< UID of the item */
+	uint16_t uid_counter;    /**< UID counter */
+} __packed;
+
+struct bt_avrcp_event_data {
+	union {
+		/* EVENT_PLAYBACK_STATUS_CHANGED */
+		uint8_t play_status;
+
+		/* EVENT_TRACK_CHANGED */
+		uint8_t identifier[8];
+
+		/* EVENT_PLAYBACK_POS_CHANGED */
+		uint32_t playback_pos;
+
+		/* EVENT_BATT_STATUS_CHANGED */
+		uint8_t battery_status;
+
+		/* EVENT_SYSTEM_STATUS_CHANGED */
+		uint8_t system_status;
+
+		/* EVENT_PLAYER_APPLICATION_SETTING_CHANGED */
+		struct __packed {
+			uint8_t num_of_attr;
+			struct bt_avrcp_app_setting_attr_val *attr_vals;
+		} setting_changed;
+
+		/* EVENT_ADDRESSED_PLAYER_CHANGED */
+		struct __packed {
+			uint16_t player_id;
+			uint16_t uid_counter;
+		} addressed_player_changed;
+
+		/* EVENT_UIDS_CHANGED */
+		uint16_t uid_counter;
+
+		/* EVENT_VOLUME_CHANGED */
+		uint8_t absolute_volume;
+	};
+};
 
 struct bt_avrcp_ct_cb {
 	/** @brief An AVRCP CT connection has been established.
@@ -366,16 +668,26 @@ struct bt_avrcp_ct_cb {
 	 */
 	void (*browsing_disconnected)(struct bt_avrcp_ct *ct);
 
-	/** @brief Callback function for bt_avrcp_get_cap().
+	/** @brief Callback function for bt_avrcp_get_caps().
 	 *
 	 *  Called when the get capabilities process is completed.
 	 *
 	 *  @param ct AVRCP CT connection object.
 	 *  @param tid The transaction label of the response.
-	 *  @param rsp The response for Get Capabilities command.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation, @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 *  @param buf The response buffer containing the BT_AVRCP_PDU_ID_GET_CAPS
+	 *            payload returned by the TG. The application can parse this
+	 *            payload according to the format, defined in @ref bt_avrcp_get_caps_rsp.
+	 *            If status is in the range BT_AVRCP_STATUS_INVALID_COMMAND to
+	 *            BT_AVRCP_STATUS_ADDRESSED_PLAYER_CHANGED, and is not equal to
+	 *            BT_AVRCP_STATUS_OPERATION_COMPLETED, it indicates that the AVRCP response
+	 *            code is an AV/C REJECTED response, and buf is NULL.
+	 *            Note that all multi-octet fields are encoded in big-endian format.
 	 */
-	void (*get_cap_rsp)(struct bt_avrcp_ct *ct, uint8_t tid,
-			    const struct bt_avrcp_get_cap_rsp *rsp);
+	void (*get_caps)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status, struct net_buf *buf);
 
 	/** @brief Callback function for bt_avrcp_get_unit_info().
 	 *
@@ -461,6 +773,21 @@ int bt_avrcp_disconnect(struct bt_conn *conn);
  */
 struct net_buf *bt_avrcp_create_pdu(struct net_buf_pool *pool);
 
+/**
+ * @brief Allocate a net_buf for AVRCP Vendor-Dependent PDU transmission, reserving
+ *        headroom for the Vendor PDU header in addition to AVRCP, AVCTP, L2CAP,
+ *        and ACL headers.
+ *
+ * This function allocates a buffer from the specified pool and reserves
+ * sufficient headroom for protocol headers required by AVRCP Vendor-Dependent
+ * PDUs over Bluetooth.
+ *
+ * @param pool The buffer pool to allocate from.
+ *
+ * @return A newly allocated net_buf with reserved headroom.
+ */
+struct net_buf *bt_avrcp_create_vendor_pdu(struct net_buf_pool *pool);
+
 /** @brief Connect AVRCP browsing channel.
  *
  *  This function is to be called after the AVRCP control channel is established.
@@ -502,7 +829,7 @@ int bt_avrcp_ct_register_cb(const struct bt_avrcp_ct_cb *cb);
  *
  *  @return 0 in case of success or error code in case of error.
  */
-int bt_avrcp_ct_get_cap(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t cap_id);
+int bt_avrcp_ct_get_caps(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t cap_id);
 
 /** @brief Get AVRCP Unit Info.
  *
@@ -594,6 +921,16 @@ struct bt_avrcp_tg_cb {
 	 */
 	void (*subunit_info_req)(struct bt_avrcp_tg *tg, uint8_t tid);
 
+	/** @brief Get capabilities request callback.
+	 *
+	 *  This callback is called whenever an AVRCP get capabilities command is received.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param cap_id The capability ID requested.
+	 */
+	void (*get_caps)(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t cap_id);
+
 	/** @brief An AVRCP TG browsing connection has been established.
 	 *
 	 *  This callback notifies the application of an avrcp browsing connection,
@@ -670,6 +1007,21 @@ int bt_avrcp_tg_send_unit_info_rsp(struct bt_avrcp_tg *tg, uint8_t tid,
  *  @return 0 in case of success or error code in case of error.
  */
 int bt_avrcp_tg_send_subunit_info_rsp(struct bt_avrcp_tg *tg, uint8_t tid);
+
+/** @brief Send GET_CAPABILITIES response.
+ *
+ *  This function is called by the application to send the GET_CAPABILITIES response.
+ *
+ *  @param tg The AVRCP TG instance.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *  @param buf The response buffer containing the GET_CAPS payload,
+ *            formatted as @ref bt_avrcp_get_caps_rsp.
+ *            Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 in case of success or error code in case of error.
+ */
+int bt_avrcp_tg_get_caps(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status, struct net_buf *buf);
 
 /** @brief Send the set browsed player response.
  *

--- a/include/zephyr/bluetooth/classic/avrcp.h
+++ b/include/zephyr/bluetooth/classic/avrcp.h
@@ -938,6 +938,104 @@ struct bt_avrcp_ct_cb {
 	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
 	 */
 	void (*inform_batt_status_of_ct)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status);
+
+	/** @brief Callback function for Set Absolute Volume response (CT).
+	 *
+	 *  Called when the Set Absolute Volume response is received from the TG.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the response.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation, @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 *  @param absolute_volume The absolute volume value (0x00-0x7F).
+	 */
+	void (*set_absolute_volume)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status,
+				   uint8_t absolute_volume);
+
+	/** @brief Callback for PDU ID GET_ELEMENT_ATTRS.
+	 *
+	 *  Called when the response for GET_ELEMENT_ATTRS is received.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation, @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 *  @param buf The response buffer containing the GET_ELEMENT_ATTRS payload
+	 *            returned by the TG, formatted as
+	 *            @ref bt_avrcp_get_element_attrs_rsp.
+	 *            If status is in the range BT_AVRCP_STATUS_INVALID_COMMAND to
+	 *            BT_AVRCP_STATUS_ADDRESSED_PLAYER_CHANGED, and is not equal to
+	 *            BT_AVRCP_STATUS_OPERATION_COMPLETED, it indicates that the AVRCP response
+	 *            code is an AV/C REJECTED response, and buf is NULL.
+	 *            Note that all multi-octet fields are encoded in big-endian format.
+	 */
+	void (*get_element_attrs)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status,
+				  struct net_buf *buf);
+
+	/** @brief Callback for PDU ID GET_PLAY_STATUS.
+	 *
+	 *  Called when the response for GET_PLAY_STATUS is received.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation, @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 *  @param buf The response buffer containing the GET_PLAY_STATUS payload
+	 *            returned by the TG, formatted as
+	 *            @ref bt_avrcp_get_play_status_rsp.
+	 *            If status is in the range BT_AVRCP_STATUS_INVALID_COMMAND to
+	 *            BT_AVRCP_STATUS_ADDRESSED_PLAYER_CHANGED, and is not equal to
+	 *            BT_AVRCP_STATUS_OPERATION_COMPLETED, it indicates that the AVRCP response
+	 *            code is an AV/C REJECTED response, and buf is NULL.
+	 *            Note that all multi-octet fields are encoded in big-endian format.
+	 */
+	void (*get_play_status)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status,
+				struct net_buf *buf);
+
+	/** @brief Callback for PDU ID SET_ADDRESSED_PLAYER.
+	 *
+	 *  Called when the response for SET_ADDRESSED_PLAYER is received.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation. @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 */
+	void (*set_addressed_player)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status);
+
+	/** @brief Callback for PDU ID PLAY_ITEM.
+	 *
+	 *  Called when the response for PLAY_ITEM is received.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation. @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 */
+	void (*play_item)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status);
+
+	/** @brief Callback for PDU ID ADD_TO_NOW_PLAYING.
+	 *
+	 *  Called when the response for ADD_TO_NOW_PLAYING is received.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation. @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 */
+	void (*add_to_now_playing)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status);
 };
 
 /** @brief Connect AVRCP.
@@ -1203,6 +1301,77 @@ int bt_avrcp_ct_inform_displayable_char_set(struct bt_avrcp_ct *ct, uint8_t tid,
  */
 int bt_avrcp_ct_inform_batt_status_of_ct(struct bt_avrcp_ct *ct, uint8_t tid,
 					 uint8_t battery_status);
+
+/** @brief Send Set Absolute Volume command (CT).
+ *
+ *  This function sends the Set Absolute Volume command to the TG.
+ *
+ *  @param ct The AVRCP CT instance.
+ *  @param tid The transaction label of the command, valid from 0 to 15.
+ *  @param absolute_volume The absolute volume value (0x00-0x7F).
+ *
+ * @return 0 in case of success or error code in case of error.
+ */
+int bt_avrcp_ct_set_absolute_volume(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t absolute_volume);
+
+/** @brief Send AVRCP vendor dependent command for GET_ELEMENT_ATTRS.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param buf The command buffer containing the GET_ELEMENT_ATTRS
+ *            request payload, formatted as
+ *            @ref bt_avrcp_get_element_attrs_cmd.
+ *            Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_get_element_attrs(struct bt_avrcp_ct *ct, uint8_t tid, struct net_buf *buf);
+
+/** @brief Send AVRCP vendor dependent command for GET_PLAY_STATUS.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_get_play_status(struct bt_avrcp_ct *ct, uint8_t tid);
+
+/** @brief Send AVRCP vendor dependent command for SET_ADDRESSED_PLAYER.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param player_id The player ID to be set as addressed player.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_set_addressed_player(struct bt_avrcp_ct *ct, uint8_t tid, uint16_t player_id);
+
+/** @brief Send AVRCP vendor dependent command for PLAY_ITEM.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param buf The command buffer containing the PLAY_ITEM
+ *            request payload, formatted as
+ *            @ref bt_avrcp_play_item_cmd.
+ *            Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_play_item(struct bt_avrcp_ct *ct, uint8_t tid, struct net_buf *buf);
+
+/** @brief Send AVRCP vendor dependent command for ADD_TO_NOW_PLAYING.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param buf The command buffer containing the ADD_TO_NOW_PLAYING
+ *            request payload, formatted as
+ *            @ref bt_avrcp_add_to_now_playing_cmd.
+ *            Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_add_to_now_playing(struct bt_avrcp_ct *ct, uint8_t tid, struct net_buf *buf);
+
 struct bt_avrcp_tg_cb {
 	/** @brief An AVRCP TG connection has been established.
 	 *
@@ -1413,6 +1582,59 @@ struct bt_avrcp_tg_cb {
 	 *            The application should parse fields in big-endian order.
 	 */
 	void (*get_element_attrs)(struct bt_avrcp_tg *tg, uint8_t tid, struct net_buf *buf);
+
+	/** @brief Callback function for Set Absolute Volume command (TG).
+	 *
+	 *  Called when the Set Absolute Volume command is received from the CT.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 *  @param absolute_volume The absolute volume value (0x00-0x7F).
+	 */
+	void (*set_absolute_volume)(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t absolute_volume);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_GET_PLAY_STATUS.
+	 *
+	 *  Called when the TG receives a vendor dependent command for GET_PLAY_STATUS.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 */
+	void (*get_play_status)(struct bt_avrcp_tg *tg, uint8_t tid);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_SET_ADDRESSED_PLAYER.
+	 *
+	 *  Called when the TG receives a vendor dependent command for SET_ADDRESSED_PLAYER.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 *  @param player_id The player ID to be set as addressed player.
+	 */
+	void (*set_addressed_player)(struct bt_avrcp_tg *tg, uint8_t tid, uint16_t player_id);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_PLAY_ITEM.
+	 *
+	 *  Called when the TG receives a vendor dependent command for PLAY_ITEM.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 *  @param buf The buffer containing the PLAY_ITEM command payload,
+	 *            formatted as @ref bt_avrcp_play_item_cmd.
+	 *            The application should parse fields in big-endian order.
+	 */
+	void (*play_item)(struct bt_avrcp_tg *tg, uint8_t tid, struct net_buf *buf);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_ADD_TO_NOW_PLAYING.
+	 *
+	 *  Called when the TG receives a vendor dependent command for ADD_TO_NOW_PLAYING.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 *  @param buf The buffer containing the ADD_TO_NOW_PLAYING command payload,
+	 *            formatted as @ref bt_avrcp_add_to_now_playing_cmd.
+	 *            The application should parse fields in big-endian order.
+	 */
+	void (*add_to_now_playing)(struct bt_avrcp_tg *tg, uint8_t tid, struct net_buf *buf);
 };
 
 /** @brief Register callback.
@@ -1486,7 +1708,8 @@ int bt_avrcp_tg_get_caps(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status, st
  * @note
  * - The first successful call for a given @p event_id sends an INTERIM response.
  * - The next successful call for the same @p event_id sends a CHANGED response.
- * - If @p status is not SUCCESS, a REJECTED or NOT_IMPLEMENTED response is sent.
+ * - If @p status is BT_AVRCP_STATUS_NOT_IMPLEMENTED, a NOT_IMPLEMENTED response is sent.
+ * - If @p status is any other non-SUCCESS value, a REJECTED response is sent.
  */
 int bt_avrcp_tg_notification(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status, uint8_t event_id,
 			     struct bt_avrcp_event_data *data);
@@ -1621,6 +1844,78 @@ int bt_avrcp_tg_inform_displayable_char_set(struct bt_avrcp_tg *tg, uint8_t tid,
  *  @return 0 on success or error code.
  */
 int bt_avrcp_tg_inform_batt_status_of_ct(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status);
+
+/** @brief Send Set Absolute Volume response (TG).
+ *
+ *  This function sends the Set Absolute Volume response to the CT.
+ *
+ *  @param tg The AVRCP TG instance.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *  @param absolute_volume The absolute volume value (0x00-0x7F).
+ *
+ *  @return 0 in case of success or error code in case of error.
+ */
+int bt_avrcp_tg_absolute_volume(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status,
+				uint8_t absolute_volume);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_GET_ELEMENT_ATTRS.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *  @param buf The response buffer containing the GET_ELEMENT_ATTRS payload,
+ *            formatted as @ref bt_avrcp_get_element_attrs_rsp.
+ *            Note that all multi-octet fields are encoded in big-endian format.
+ *
+ * @return 0 on success or error code.
+ */
+int bt_avrcp_tg_get_element_attrs(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status,
+				  struct net_buf *buf);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_GET_PLAY_STATUS.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *  @param buf The response buffer containing the GET_PLAY_STATUS payload,
+ *            formatted as @ref bt_avrcp_get_play_status_rsp.
+ *            Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_tg_get_play_status(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status,
+				struct net_buf *buf);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_SET_ADDRESSED_PLAYER.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_tg_set_addressed_player(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_PLAY_ITEM.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_tg_play_item(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_ADD_TO_NOW_PLAYING.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_tg_add_to_now_playing(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status);
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/bluetooth/classic/avrcp.h
+++ b/include/zephyr/bluetooth/classic/avrcp.h
@@ -786,6 +786,158 @@ struct bt_avrcp_ct_cb {
 	 */
 	void (*notification)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status, uint8_t event_id,
 			     struct bt_avrcp_event_data *data);
+
+	/** @brief Callback for PDU ID LIST_PLAYER_APP_SETTING_ATTRS.
+	 *
+	 *  Called when the response for LIST_PLAYER_APP_SETTING_ATTRS is received.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation, @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 *  @param buf The response buffer containing the LIST_PLAYER_APP_SETTING_ATTRS
+	 *            payload returned by the TG.
+	 *            The application can parse this payload according to the format
+	 *            defined in @ref bt_avrcp_list_app_setting_attr_rsp.
+	 *            If status is in the range BT_AVRCP_STATUS_INVALID_COMMAND to
+	 *            BT_AVRCP_STATUS_ADDRESSED_PLAYER_CHANGED, and is not equal to
+	 *            BT_AVRCP_STATUS_OPERATION_COMPLETED, it indicates that the AVRCP response
+	 *            code is an AV/C REJECTED response, and buf is NULL.
+	 *            Note that all multi-octet fields are encoded in big-endian format.
+	 */
+	void (*list_player_app_setting_attrs)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status,
+					      struct net_buf *buf);
+
+	/** @brief Callback for PDU ID LIST_PLAYER_APP_SETTING_VALS.
+	 *
+	 *  Called when the response for LIST_PLAYER_APP_SETTING_VALS is received.`
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation, @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 *  @param buf The response buffer containing the LIST_PLAYER_APP_SETTING_VALS
+	 *            payload returned by the TG.
+	 *            The application can parse this payload according to the format
+	 *            defined in @ref bt_avrcp_list_player_app_setting_vals_rsp.
+	 *            If status is in the range BT_AVRCP_STATUS_INVALID_COMMAND to
+	 *            BT_AVRCP_STATUS_ADDRESSED_PLAYER_CHANGED, and is not equal to
+	 *            BT_AVRCP_STATUS_OPERATION_COMPLETED, it indicates that the AVRCP response
+	 *            code is an AV/C REJECTED response, and buf is NULL.
+	 *            Note that all multi-octet fields are encoded in big-endian format.
+	 */
+	void (*list_player_app_setting_vals)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status,
+					     struct net_buf *buf);
+
+	/** @brief Callback for PDU ID GET_CURR_PLAYER_APP_SETTING_VAL.
+	 *
+	 *  Called when the response for GET_CURR_PLAYER_APP_SETTING_VAL is received.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation, @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 *  @param buf The response buffer containing the GET_CURR_PLAYER_APP_SETTING_VAL
+	 *            payload returned by the TG.
+	 *            The application can parse this payload according to the format
+	 *            defined in @ref bt_avrcp_get_curr_player_app_setting_val_rsp.
+	 *            If status is in the range BT_AVRCP_STATUS_INVALID_COMMAND to
+	 *            BT_AVRCP_STATUS_ADDRESSED_PLAYER_CHANGED, and is not equal to
+	 *            BT_AVRCP_STATUS_OPERATION_COMPLETED, it indicates that the AVRCP response
+	 *            code is an AV/C REJECTED response, and buf is NULL.
+	 *            Note that all multi-octet fields are encoded in big-endian format.
+	 */
+	void (*get_curr_player_app_setting_val)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status,
+						struct net_buf *buf);
+
+	/** @brief Callback for PDU ID SET_PLAYER_APP_SETTING_VAL.
+	 *
+	 *  Called when the response for SET_PLAYER_APP_SETTING_VAL is received.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation, @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 */
+	void (*set_player_app_setting_val)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status);
+
+	/** @brief Callback for PDU ID GET_PLAYER_APP_SETTING_ATTR_TEXT.
+	 *
+	 *  Called when the response for GET_PLAYER_APP_SETTING_ATTR_TEXT is received.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation, @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 *  @param buf The response buffer containing the GET_PLAYER_APP_SETTING_ATTR_TEXT
+	 *            payload returned by the TG, formatted as
+	 *            @ref bt_avrcp_get_player_app_setting_attr_text_rsp.
+	 *            If status is in the range BT_AVRCP_STATUS_INVALID_COMMAND to
+	 *            BT_AVRCP_STATUS_ADDRESSED_PLAYER_CHANGED, and is not equal to
+	 *            BT_AVRCP_STATUS_OPERATION_COMPLETED, it indicates that the AVRCP response
+	 *            code is an AV/C REJECTED response, and buf is NULL.
+	 *            Note that all multi-octet fields are encoded in big-endian format.
+	 */
+	void (*get_player_app_setting_attr_text)(struct bt_avrcp_ct *ct, uint8_t tid,
+						 uint8_t status, struct net_buf *buf);
+
+	/** @brief Callback for PDU ID GET_PLAYER_APP_SETTING_VAL_TEXT.
+	 *
+	 *  Called when the response for GET_PLAYER_APP_SETTING_VAL_TEXT is received.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation, @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 *  @param buf The response buffer containing the GET_PLAYER_APP_SETTING_VAL_TEXT
+	 *            payload returned by the TG, formatted as
+	 *            @ref bt_avrcp_get_player_app_setting_val_text_rsp.
+	 *            If status is in the range BT_AVRCP_STATUS_INVALID_COMMAND to
+	 *            BT_AVRCP_STATUS_ADDRESSED_PLAYER_CHANGED, and is not equal to
+	 *            BT_AVRCP_STATUS_OPERATION_COMPLETED, it indicates that the AVRCP response
+	 *            code is an AV/C REJECTED response, and buf is NULL.
+	 *            Note that all multi-octet fields are encoded in big-endian format.
+	 */
+	void (*get_player_app_setting_val_text)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status,
+						struct net_buf *buf);
+
+	/** @brief Callback for PDU ID INFORM_DISPLAYABLE_CHAR_SET.
+	 *
+	 *  Called when the response for INFORM_DISPLAYABLE_CHAR_SET is received.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation, @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 */
+	void (*inform_displayable_char_set)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status);
+
+	/** @brief Callback for PDU ID INFORM_BATT_STATUS_OF_CT.
+	 *
+	 *  Called when the response for INFORM_BATT_STATUS_OF_CT is received.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param status The status code returned by the TG, indicating the result of the
+	 *               operation, @ref bt_avrcp_status_t. Typically corresponds to
+	 *               BT_AVRCP_STATUS_* values such as BT_AVRCP_STATUS_SUCCESS
+	 *               or BT_AVRCP_STATUS_INVALID_PARAMETER.
+	 */
+	void (*inform_batt_status_of_ct)(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status);
 };
 
 /** @brief Connect AVRCP.
@@ -951,6 +1103,106 @@ int bt_avrcp_ct_set_browsed_player(struct bt_avrcp_ct *ct, uint8_t tid, uint16_t
 int bt_avrcp_ct_register_notification(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t event_id,
 				      uint32_t interval, bt_avrcp_notify_changed_cb_t cb);
 
+/** @brief Send AVRCP vendor dependent command for LIST_PLAYER_APP_SETTING_ATTRS.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_list_player_app_setting_attrs(struct bt_avrcp_ct *ct, uint8_t tid);
+
+/** @brief Send AVRCP vendor dependent command for LIST_PLAYER_APP_SETTING_VALS.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param attr_id Player application setting attribute ID for which the possible
+ *        values should be listed (e.g., Equalizer, Repeat Mode, Shuffle, Scan).
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_list_player_app_setting_vals(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t attr_id);
+
+/** @brief Send AVRCP vendor dependent command for GET_CURR_PLAYER_APP_SETTING_VAL.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param buf The command buffer containing the GET_CURR_PLAYER_APP_SETTING_VAL
+ *          request payload, formatted as
+ *          @ref bt_avrcp_get_curr_player_app_setting_val_cmd.
+ *          Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_get_curr_player_app_setting_val(struct bt_avrcp_ct *ct, uint8_t tid,
+						struct net_buf *buf);
+
+/** @brief Send AVRCP vendor dependent command for SET_PLAYER_APP_SETTING_VAL.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param buf The command buffer containing the SET_PLAYER_APP_SETTING_VAL
+ *            request payload, formatted as
+ *            @ref bt_avrcp_set_player_app_setting_val_cmd.
+ *            Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_set_player_app_setting_val(struct bt_avrcp_ct *ct, uint8_t tid,
+					   struct net_buf *buf);
+
+/** @brief Send AVRCP vendor dependent command for GET_PLAYER_APP_SETTING_ATTR_TEXT.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param buf The command buffer containing the GET_PLAYER_APP_SETTING_ATTR_TEXT
+ *            request payload, formatted as
+ *            @ref bt_avrcp_get_player_app_setting_attr_text_cmd.
+ *            Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_get_player_app_setting_attr_text(struct bt_avrcp_ct *ct, uint8_t tid,
+						 struct net_buf *buf);
+
+/** @brief Send AVRCP vendor dependent command for GET_PLAYER_APP_SETTING_VAL_TEXT.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param buf The command buffer containing the GET_PLAYER_APP_SETTING_VAL_TEXT
+ *            request payload, formatted as
+ *            @ref bt_avrcp_get_player_app_setting_val_text_cmd.
+ *            Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_get_player_app_setting_val_text(struct bt_avrcp_ct *ct, uint8_t tid,
+						struct net_buf *buf);
+
+/** @brief Send AVRCP vendor dependent command for INFORM_DISPLAYABLE_CHAR_SET.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param buf The command buffer containing the INFORM_DISPLAYABLE_CHAR_SET
+ *            request payload, formatted as
+ *            @ref bt_avrcp_inform_displayable_char_set_cmd.
+ *            Note that all multi-octet fields are encoded in big-endian format
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_inform_displayable_char_set(struct bt_avrcp_ct *ct, uint8_t tid,
+					    struct net_buf *buf);
+
+/** @brief Send AVRCP vendor dependent command for INFORM_BATT_STATUS_OF_CT.
+ *
+ *  @param ct AVRCP CT connection object.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param battery_status Battery status value @ref bt_avrcp_battery_status_t
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_ct_inform_batt_status_of_ct(struct bt_avrcp_ct *ct, uint8_t tid,
+					 uint8_t battery_status);
 struct bt_avrcp_tg_cb {
 	/** @brief An AVRCP TG connection has been established.
 	 *
@@ -1053,6 +1305,114 @@ struct bt_avrcp_tg_cb {
 	 *             in big-endian format.
 	 */
 	void (*passthrough_req)(struct bt_avrcp_tg *tg, uint8_t tid, struct net_buf *buf);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_LIST_PLAYER_APP_SETTING_ATTRS.
+	 *
+	 *  Called when the TG receives a vendor dependent command LIST_PLAYER_APP_SETTING_ATTRS.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 */
+	void (*list_player_app_setting_attrs)(struct bt_avrcp_tg *tg, uint8_t tid);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_LIST_PLAYER_APP_SETTING_VALS.
+	 *
+	 *  Called when the TG receives a vendor dependent command for LIST_PLAYER_APP_SETTING_VALS.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 *  @param attr_id Player application setting attribute ID for which the possible
+	 *                 values should be listed (e.g., Equalizer, Repeat Mode, Shuffle, Scan).
+	 */
+	void (*list_player_app_setting_vals)(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t attr_id);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_GET_CURR_PLAYER_APP_SETTING_VAL.
+	 *
+	 *  Called when the TG receives a vendor dependent command GET_CURR_PLAYER_APP_SETTING_VAL.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 *  @param buf The buffer containing the GET_CURR_PLAYER_APP_SETTING_VAL command payload,
+	 *             formatted as @ref bt_avrcp_get_curr_player_app_setting_val_cmd.
+	 *             The application should parse fields in big-endian order.
+	 */
+	void (*get_curr_player_app_setting_val)(struct bt_avrcp_tg *tg, uint8_t tid,
+						struct net_buf *buf);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_SET_PLAYER_APP_SETTING_VAL.
+	 *
+	 *  Called when the TG receives a vendor dependent command for SET_PLAYER_APP_SETTING_VAL.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 *  @param buf The buffer containing the SET_PLAYER_APP_SETTING_VAL command payload,
+	 *             formatted as @ref bt_avrcp_set_player_app_setting_val_cmd.
+	 *             The application should parse fields in big-endian order.
+	 */
+	void (*set_player_app_setting_val)(struct bt_avrcp_tg *tg, uint8_t tid,
+					   struct net_buf *buf);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_GET_PLAYER_APP_SETTING_ATTR_TEXT.
+	 *
+	 *  Called when the TG receives a vendor dependent command GET_PLAYER_APP_SETTING_ATTR_TEXT.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 *  @param buf The buffer containing the GET_PLAYER_APP_SETTING_VAL_TEXT command payload,
+	 *            formatted as @ref bt_avrcp_get_player_app_setting_val_text_cmd.
+	 *            The application should parse fields in big-endian order.
+	 */
+	void (*get_player_app_setting_attr_text)(struct bt_avrcp_tg *tg, uint8_t tid,
+						 struct net_buf *buf);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_GET_PLAYER_APP_SETTING_VAL_TEXT.
+	 *
+	 *  Called when the TG receives a vendor dependent command GET_PLAYER_APP_SETTING_VAL_TEXT.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 *  @param buf The buffer containing the GET_PLAYER_APP_SETTING_VAL_TEXT command payload,
+	 *            formatted as @ref bt_avrcp_get_player_app_setting_val_text_cmd.
+	 *            The application should parse fields in big-endian order.
+	 */
+	void (*get_player_app_setting_val_text)(struct bt_avrcp_tg *tg, uint8_t tid,
+						struct net_buf *buf);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_INFORM_DISPLAYABLE_CHAR_SET.
+	 *
+	 *  Called when the TG receives a vendor dependent command for INFORM_DISPLAYABLE_CHAR_SET.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 *  @param buf The buffer containing the INFORM_DISPLAYABLE_CHAR_SET command payload,
+	 *            formatted as @ref bt_avrcp_inform_displayable_char_set_cmd.
+	 *            The application should parse fields in big-endian order.
+	 */
+	void (*inform_displayable_char_set)(struct bt_avrcp_tg *tg, uint8_t tid,
+					    struct net_buf *buf);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_INFORM_BATT_STATUS_OF_CT.
+	 *
+	 *  Called when the TG receives a vendor dependent command for INFORM_BATT_STATUS_OF_CT.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 *  @param battery_status Battery status value @ref bt_avrcp_battery_status_t
+	 */
+	void (*inform_batt_status_of_ct)(struct bt_avrcp_tg *tg, uint8_t tid,
+					 uint8_t battery_status);
+
+	/** @brief Callback for PDU ID BT_AVRCP_PDU_ID_GET_ELEMENT_ATTRS.
+	 *
+	 *  Called when the TG receives a vendor dependent command for GET_ELEMENT_ATTRS.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the command.
+	 *  @param buf The buffer containing the GET_ELEMENT_ATTRS command payload,
+	 *            formatted as @ref bt_avrcp_get_element_attrs_cmd.
+	 *            The application should parse fields in big-endian order.
+	 */
+	void (*get_element_attrs)(struct bt_avrcp_tg *tg, uint8_t tid, struct net_buf *buf);
 };
 
 /** @brief Register callback.
@@ -1161,6 +1521,106 @@ int bt_avrcp_tg_send_set_browsed_player_rsp(struct bt_avrcp_tg *tg, uint8_t tid,
  */
 int bt_avrcp_tg_send_passthrough_rsp(struct bt_avrcp_tg *tg, uint8_t tid, bt_avrcp_rsp_t result,
 				     struct net_buf *buf);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_LIST_PLAYER_APP_SETTING_ATTRS.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *  @param buf The response buffer containing the LIST_PLAYER_APP_SETTING_ATTRS payload,
+ *            formatted as @ref bt_avrcp_list_app_setting_attr_rsp.
+ *            Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_tg_list_player_app_setting_attrs(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status,
+					      struct net_buf *buf);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_LIST_PLAYER_APP_SETTING_VALS.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *  @param buf The response buffer containing the LIST_PLAYER_APP_SETTING_VALS payload,
+ *             formatted as @ref bt_avrcp_list_player_app_setting_vals_rsp.
+ *             Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_tg_list_player_app_setting_vals(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status,
+					     struct net_buf *buf);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_GET_CURR_PLAYER_APP_SETTING_VAL.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *  @param buf The response buffer containing the GET_CURR_PLAYER_APP_SETTING_VAL payload,
+ *             formatted as @ref bt_avrcp_get_curr_player_app_setting_val_rsp.
+ *             Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_tg_get_curr_player_app_setting_val(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status,
+						struct net_buf *buf);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_SET_PLAYER_APP_SETTING_VAL.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_tg_set_player_app_setting_val(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_GET_PLAYER_APP_SETTING_ATTR_TEXT.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *  @param buf The response buffer containing the GET_PLAYER_APP_SETTING_ATTR_TEXT payload,
+ *             formatted as @ref bt_avrcp_get_player_app_setting_attr_text_rsp.
+ *             Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_tg_get_player_app_setting_attr_text(struct bt_avrcp_tg *tg, uint8_t tid,
+						 uint8_t status, struct net_buf *buf);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_GET_PLAYER_APP_SETTING_VAL_TEXT.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *  @param buf The response buffer containing the GET_PLAYER_APP_SETTING_VAL_TEXT payload,
+ *            formatted as @ref bt_avrcp_get_player_app_setting_val_text_rsp.
+ *            Note that all multi-octet fields are encoded in big-endian format.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_tg_get_player_app_setting_val_text(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status,
+						struct net_buf *buf);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_INFORM_DISPLAYABLE_CHAR_SET.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_tg_inform_displayable_char_set(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status);
+
+/** @brief Send response for PDU ID BT_AVRCP_PDU_ID_INFORM_BATT_STATUS_OF_CT.
+ *
+ *  @param tg AVRCP TG connection object.
+ *  @param tid The transaction label of the request.
+ *  @param status Status code of the operation @ref bt_avrcp_status_t.
+ *
+ *  @return 0 on success or error code.
+ */
+int bt_avrcp_tg_inform_batt_status_of_ct(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status);
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -505,6 +505,17 @@ config BT_AVRCP_CONTROLLER
 	help
 	  This option enables the AVRCP profile controller function
 
+config BT_AVRCP_VD_RX_SIZE
+	int "AVRCP Vendor Dependent RX data buffer Size"
+	default 1024
+	range 512 $(INT16_MAX)
+	help
+	  Size of the AVRCP Vendor Dependent RX data buffer in bytes.
+	  This buffer is used for reassembling fragmented AVRCP Vendor Dependent
+	  commands and responses received from the CT device. If the remote CT
+	  sends large Vendor-specific PDUs or frequent fragmentation occurs,
+	  consider increasing this value to avoid incomplete message handling.
+
 config BT_AVRCP_BROWSING
 	bool "Bluetooth AVRCP Browsing channel support [EXPERIMENTAL]"
 	select EXPERIMENTAL

--- a/subsys/bluetooth/host/classic/avctp.c
+++ b/subsys/bluetooth/host/classic/avctp.c
@@ -330,10 +330,6 @@ static void avctp_tx_processor(struct k_work *item)
 		goto failed;
 	}
 
-	if (net_buf_tailroom(buf) < chunk_size) {
-		LOG_WRN("Not enough tailroom for AVCTP payload (len: %d)", chunk_size);
-		goto failed;
-	}
 	net_buf_pull_mem(buf, chunk_size);
 
 	user_data->sent_len += chunk_size;

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -1284,6 +1284,146 @@ notify_callback:
 	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
 }
 
+static int process_list_player_app_setting_attrs_rsp(struct bt_avrcp *avrcp, uint8_t tid,
+						     uint8_t rsp_code, struct net_buf *buf)
+{
+	uint8_t status = BT_AVRCP_STATUS_INTERNAL_ERROR;
+	int err;
+
+	if ((avrcp_ct_cb == NULL) || (avrcp_ct_cb->list_player_app_setting_attrs == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	err = bt_avrcp_rsp_to_status(rsp_code, buf, &status);
+	if ((err < 0) || (status != BT_AVRCP_STATUS_SUCCESS)) {
+		buf = NULL;
+	}
+
+	avrcp_ct_cb->list_player_app_setting_attrs(get_avrcp_ct(avrcp), tid, status, buf);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_list_player_app_setting_vals_rsp(struct bt_avrcp *avrcp, uint8_t tid,
+						    uint8_t rsp_code, struct net_buf *buf)
+{
+	uint8_t status = BT_AVRCP_STATUS_INTERNAL_ERROR;
+	int err;
+
+	if ((avrcp_ct_cb == NULL) || (avrcp_ct_cb->list_player_app_setting_vals == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	err = bt_avrcp_rsp_to_status(rsp_code, buf, &status);
+	if ((err < 0) || (status != BT_AVRCP_STATUS_SUCCESS)) {
+		buf = NULL;
+	}
+
+	avrcp_ct_cb->list_player_app_setting_vals(get_avrcp_ct(avrcp), tid, status, buf);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_get_curr_player_app_setting_val_rsp(struct bt_avrcp *avrcp, uint8_t tid,
+						       uint8_t rsp_code, struct net_buf *buf)
+{
+	uint8_t status = BT_AVRCP_STATUS_INTERNAL_ERROR;
+	int err;
+
+	if ((avrcp_ct_cb == NULL) || (avrcp_ct_cb->get_curr_player_app_setting_val == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	err = bt_avrcp_rsp_to_status(rsp_code, buf, &status);
+	if ((err < 0) || (status != BT_AVRCP_STATUS_SUCCESS)) {
+		buf = NULL;
+	}
+
+	avrcp_ct_cb->get_curr_player_app_setting_val(get_avrcp_ct(avrcp), tid, status, buf);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_set_player_app_setting_val_rsp(struct bt_avrcp *avrcp, uint8_t tid,
+						  uint8_t rsp_code, struct net_buf *buf)
+{
+	uint8_t status = BT_AVRCP_STATUS_INTERNAL_ERROR;
+
+	if ((avrcp_ct_cb == NULL) || (avrcp_ct_cb->set_player_app_setting_val == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	bt_avrcp_rsp_to_status(rsp_code, buf, &status);
+
+	avrcp_ct_cb->set_player_app_setting_val(get_avrcp_ct(avrcp), tid, status);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_get_player_app_setting_attr_text_rsp(struct bt_avrcp *avrcp, uint8_t tid,
+							uint8_t rsp_code, struct net_buf *buf)
+{
+	uint8_t status = BT_AVRCP_STATUS_INTERNAL_ERROR;
+	int err;
+
+	if ((avrcp_ct_cb == NULL) || (avrcp_ct_cb->get_player_app_setting_attr_text == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	err = bt_avrcp_rsp_to_status(rsp_code, buf, &status);
+	if ((err < 0) || (status != BT_AVRCP_STATUS_SUCCESS)) {
+		buf = NULL;
+	}
+
+	avrcp_ct_cb->get_player_app_setting_attr_text(get_avrcp_ct(avrcp), tid, status, buf);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_get_player_app_setting_val_text_rsp(struct bt_avrcp *avrcp, uint8_t tid,
+						       uint8_t rsp_code, struct net_buf *buf)
+{
+	uint8_t status = BT_AVRCP_STATUS_INTERNAL_ERROR;
+	int err;
+
+	if ((avrcp_ct_cb == NULL) || (avrcp_ct_cb->get_player_app_setting_val_text == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	err = bt_avrcp_rsp_to_status(rsp_code, buf, &status);
+	if ((err < 0) || (status != BT_AVRCP_STATUS_SUCCESS)) {
+		buf = NULL;
+	}
+
+	avrcp_ct_cb->get_player_app_setting_val_text(get_avrcp_ct(avrcp), tid, status, buf);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_inform_displayable_char_set_rsp(struct bt_avrcp *avrcp, uint8_t tid,
+						   uint8_t rsp_code, struct net_buf *buf)
+{
+	uint8_t status = BT_AVRCP_STATUS_INTERNAL_ERROR;
+
+	if ((avrcp_ct_cb == NULL) || (avrcp_ct_cb->inform_displayable_char_set == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	bt_avrcp_rsp_to_status(rsp_code, buf, &status);
+
+	avrcp_ct_cb->inform_displayable_char_set(get_avrcp_ct(avrcp), tid, status);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_inform_batt_status_of_ct_rsp(struct bt_avrcp *avrcp, uint8_t tid,
+						uint8_t rsp_code, struct net_buf *buf)
+{
+	uint8_t status = BT_AVRCP_STATUS_INTERNAL_ERROR;
+
+	if ((avrcp_ct_cb == NULL) || (avrcp_ct_cb->inform_batt_status_of_ct == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	bt_avrcp_rsp_to_status(rsp_code, buf, &status);
+
+	avrcp_ct_cb->inform_batt_status_of_ct(get_avrcp_ct(avrcp), tid, status);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
 /** Response vendor handlers table.
  * Note: The min_len field specifies the minimum payload/parameter length,
  * not including status/error codes. For REJECTED responses, only 1 byte
@@ -1298,6 +1438,27 @@ static const struct avrcp_pdu_vendor_handler rsp_vendor_handlers[] = {
 	  process_get_caps_rsp },
 	{ BT_AVRCP_PDU_ID_REGISTER_NOTIFICATION, sizeof(uint8_t), BT_AVRCP_CTYPE_NOTIFY,
 	  process_register_notification_rsp },
+	{ BT_AVRCP_PDU_ID_LIST_PLAYER_APP_SETTING_ATTRS,
+	  sizeof(struct bt_avrcp_list_app_setting_attr_rsp),
+	  BT_AVRCP_CTYPE_STATUS, process_list_player_app_setting_attrs_rsp },
+	{ BT_AVRCP_PDU_ID_LIST_PLAYER_APP_SETTING_VALS,
+	  sizeof(struct bt_avrcp_list_player_app_setting_vals_rsp),
+	  BT_AVRCP_CTYPE_STATUS, process_list_player_app_setting_vals_rsp },
+	{ BT_AVRCP_PDU_ID_GET_CURR_PLAYER_APP_SETTING_VAL,
+	  sizeof(struct bt_avrcp_get_curr_player_app_setting_val_rsp),
+	  BT_AVRCP_CTYPE_STATUS, process_get_curr_player_app_setting_val_rsp },
+	{ BT_AVRCP_PDU_ID_SET_PLAYER_APP_SETTING_VAL, 0, BT_AVRCP_CTYPE_CONTROL,
+	  process_set_player_app_setting_val_rsp },
+	{ BT_AVRCP_PDU_ID_GET_PLAYER_APP_SETTING_ATTR_TEXT,
+	  sizeof(struct bt_avrcp_get_player_app_setting_attr_text_rsp),
+	  BT_AVRCP_CTYPE_STATUS, process_get_player_app_setting_attr_text_rsp },
+	{ BT_AVRCP_PDU_ID_GET_PLAYER_APP_SETTING_VAL_TEXT,
+	  sizeof(struct bt_avrcp_get_player_app_setting_val_text_rsp),
+	  BT_AVRCP_CTYPE_STATUS, process_get_player_app_setting_val_text_rsp },
+	{ BT_AVRCP_PDU_ID_INFORM_DISPLAYABLE_CHAR_SET, 0, BT_AVRCP_CTYPE_CONTROL,
+	  process_inform_displayable_char_set_rsp },
+	{ BT_AVRCP_PDU_ID_INFORM_BATT_STATUS_OF_CT, 0, BT_AVRCP_CTYPE_CONTROL,
+	  process_inform_batt_status_of_ct_rsp },
 };
 
 static inline uint8_t get_cmd_type_by_pdu(uint8_t pdu_id)
@@ -1760,6 +1921,110 @@ static int handle_avrcp_abort_continuing_rsp(struct bt_avrcp *avrcp, uint8_t tid
 	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
 }
 
+static int process_list_player_app_setting_attrs_cmd(struct bt_avrcp *avrcp, uint8_t tid,
+						     uint8_t ctype_or_rsp, struct net_buf *buf)
+{
+	if ((avrcp_tg_cb == NULL) || (avrcp_tg_cb->list_player_app_setting_attrs == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	avrcp_tg_cb->list_player_app_setting_attrs(get_avrcp_tg(avrcp), tid);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_list_player_app_setting_vals_cmd(struct bt_avrcp *avrcp, uint8_t tid,
+						    uint8_t ctype_or_rsp, struct net_buf *buf)
+{
+	uint8_t attr_id;
+
+	if ((avrcp_tg_cb == NULL) || (avrcp_tg_cb->list_player_app_setting_vals == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	attr_id = net_buf_pull_u8(buf);
+	if (attr_id > BT_AVRCP_PLAYER_ATTR_SCAN) {
+		LOG_ERR("Invalid attr_id: %d", attr_id);
+		return BT_AVRCP_STATUS_INVALID_PARAMETER;
+	}
+
+	avrcp_tg_cb->list_player_app_setting_vals(get_avrcp_tg(avrcp), tid, attr_id);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_get_curr_player_app_setting_val_cmd(struct bt_avrcp *avrcp, uint8_t tid,
+						       uint8_t ctype_or_rsp, struct net_buf *buf)
+{
+	if ((avrcp_tg_cb == NULL) || (avrcp_tg_cb->get_curr_player_app_setting_val == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	avrcp_tg_cb->get_curr_player_app_setting_val(get_avrcp_tg(avrcp), tid, buf);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_set_player_app_setting_val_cmd(struct bt_avrcp *avrcp, uint8_t tid,
+						  uint8_t ctype_or_rsp, struct net_buf *buf)
+{
+	if ((avrcp_tg_cb == NULL) || (avrcp_tg_cb->set_player_app_setting_val == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	avrcp_tg_cb->set_player_app_setting_val(get_avrcp_tg(avrcp), tid, buf);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_get_player_app_setting_attr_text_cmd(struct bt_avrcp *avrcp, uint8_t tid,
+							uint8_t ctype_or_rsp, struct net_buf *buf)
+{
+	if ((avrcp_tg_cb == NULL) || (avrcp_tg_cb->get_player_app_setting_attr_text == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	avrcp_tg_cb->get_player_app_setting_attr_text(get_avrcp_tg(avrcp), tid, buf);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_get_player_app_setting_val_text_cmd(struct bt_avrcp *avrcp, uint8_t tid,
+						       uint8_t ctype_or_rsp, struct net_buf *buf)
+{
+	if ((avrcp_tg_cb == NULL) || (avrcp_tg_cb->get_player_app_setting_val_text == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	avrcp_tg_cb->get_player_app_setting_val_text(get_avrcp_tg(avrcp), tid, buf);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_inform_displayable_char_set_cmd(struct bt_avrcp *avrcp, uint8_t tid,
+						   uint8_t ctype_or_rsp, struct net_buf *buf)
+{
+	if ((avrcp_tg_cb == NULL) || (avrcp_tg_cb->inform_displayable_char_set == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	avrcp_tg_cb->inform_displayable_char_set(get_avrcp_tg(avrcp), tid, buf);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
+static int process_inform_batt_status_of_ct_cmd(struct bt_avrcp *avrcp, uint8_t tid,
+						uint8_t ctype_or_rsp, struct net_buf *buf)
+{
+	uint8_t battery_status;
+
+	if ((avrcp_tg_cb == NULL) || (avrcp_tg_cb->inform_batt_status_of_ct == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	battery_status = net_buf_pull_u8(buf);
+	if (battery_status > BT_AVRCP_BATTERY_STATUS_FULL) {
+		LOG_ERR("Invalid battery_status: %d", battery_status);
+		return BT_AVRCP_STATUS_INVALID_PARAMETER;
+	}
+
+	avrcp_tg_cb->inform_batt_status_of_ct(get_avrcp_tg(avrcp), tid, battery_status);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
 static const struct avrcp_pdu_vendor_handler cmd_vendor_handlers[] = {
 	{ BT_AVRCP_PDU_ID_REQ_CONTINUING_RSP, sizeof(uint8_t), BT_AVRCP_CTYPE_CONTROL,
 	  handle_avrcp_continuing_rsp },
@@ -1768,6 +2033,29 @@ static const struct avrcp_pdu_vendor_handler cmd_vendor_handlers[] = {
 	{ BT_AVRCP_PDU_ID_GET_CAPS, sizeof(uint8_t), BT_AVRCP_CTYPE_STATUS, process_get_caps_cmd },
 	{ BT_AVRCP_PDU_ID_REGISTER_NOTIFICATION, sizeof(struct bt_avrcp_register_notification_cmd),
 	  BT_AVRCP_CTYPE_NOTIFY, avrcp_register_notification_cmd_handler },
+	{ BT_AVRCP_PDU_ID_LIST_PLAYER_APP_SETTING_ATTRS, 0, BT_AVRCP_CTYPE_STATUS,
+	  process_list_player_app_setting_attrs_cmd },
+	{ BT_AVRCP_PDU_ID_LIST_PLAYER_APP_SETTING_VALS,
+	  sizeof(struct bt_avrcp_list_player_app_setting_vals_cmd), BT_AVRCP_CTYPE_STATUS,
+	  process_list_player_app_setting_vals_cmd },
+	{ BT_AVRCP_PDU_ID_GET_CURR_PLAYER_APP_SETTING_VAL,
+	  sizeof(struct bt_avrcp_get_curr_player_app_setting_val_cmd), BT_AVRCP_CTYPE_STATUS,
+	  process_get_curr_player_app_setting_val_cmd },
+	{ BT_AVRCP_PDU_ID_SET_PLAYER_APP_SETTING_VAL,
+	  sizeof(struct bt_avrcp_set_player_app_setting_val_cmd), BT_AVRCP_CTYPE_CONTROL,
+	  process_set_player_app_setting_val_cmd },
+	{ BT_AVRCP_PDU_ID_GET_PLAYER_APP_SETTING_ATTR_TEXT,
+	  sizeof(struct bt_avrcp_get_player_app_setting_attr_text_cmd), BT_AVRCP_CTYPE_STATUS,
+	  process_get_player_app_setting_attr_text_cmd },
+	{ BT_AVRCP_PDU_ID_GET_PLAYER_APP_SETTING_VAL_TEXT,
+	  sizeof(struct bt_avrcp_get_player_app_setting_val_text_cmd), BT_AVRCP_CTYPE_STATUS,
+	  process_get_player_app_setting_val_text_cmd },
+	{ BT_AVRCP_PDU_ID_INFORM_DISPLAYABLE_CHAR_SET,
+	  sizeof(struct bt_avrcp_inform_displayable_char_set_cmd), BT_AVRCP_CTYPE_CONTROL,
+	  process_inform_displayable_char_set_cmd },
+	{ BT_AVRCP_PDU_ID_INFORM_BATT_STATUS_OF_CT,
+	  sizeof(struct bt_avrcp_inform_batt_status_of_ct_cmd), BT_AVRCP_CTYPE_CONTROL,
+	  process_inform_batt_status_of_ct_cmd },
 };
 
 static inline uint8_t get_cmd_min_len_by_pdu(uint8_t pdu_id)
@@ -2692,6 +2980,253 @@ int bt_avrcp_ct_get_caps(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t cap_id)
 	return err;
 }
 
+int bt_avrcp_ct_list_player_app_setting_attrs(struct bt_avrcp_ct *ct, uint8_t tid)
+{
+	struct net_buf *buf;
+	int err;
+
+	if ((ct == NULL) || (ct->avrcp == NULL)) {
+		return -EINVAL;
+	}
+
+	if (!IS_CT_ROLE_SUPPORTED()) {
+		return -ENOTSUP;
+	}
+
+	if (avrcp_ct_cb->list_player_app_setting_attrs == NULL) {
+		LOG_WRN("Rsp callback not registered");
+		return -EOPNOTSUPP;
+	}
+
+	buf = bt_avrcp_create_vendor_pdu(&avrcp_vd_tx_pool);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+
+	err = bt_avrcp_ct_vendor_dependent(ct, tid, BT_AVRCP_PDU_ID_LIST_PLAYER_APP_SETTING_ATTRS,
+					   buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send AVRCP PDU (err: %d)", err);
+		net_buf_unref(buf);
+	}
+	return err;
+}
+
+int bt_avrcp_ct_list_player_app_setting_vals(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t attr_id)
+{
+	int err;
+	struct net_buf *buf;
+
+	if ((ct == NULL) || (ct->avrcp == NULL)) {
+		return -EINVAL;
+	}
+
+	if (!IS_CT_ROLE_SUPPORTED()) {
+		return -ENOTSUP;
+	}
+
+	if (avrcp_ct_cb->list_player_app_setting_vals == NULL) {
+		LOG_WRN("Rsp callback not registered");
+		return -EOPNOTSUPP;
+	}
+
+	buf = bt_avrcp_create_vendor_pdu(&avrcp_vd_tx_pool);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+
+	if (net_buf_tailroom(buf) < sizeof(attr_id)) {
+		LOG_WRN("Not enough tailroom: for attr_id");
+		net_buf_unref(buf);
+		return -ENOMEM;
+	}
+
+	net_buf_add_u8(buf, attr_id);
+
+	err = bt_avrcp_ct_vendor_dependent(ct, tid, BT_AVRCP_PDU_ID_LIST_PLAYER_APP_SETTING_VALS,
+					   buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send AVRCP PDU (err: %d)", err);
+		net_buf_unref(buf);
+	}
+	return err;
+}
+
+int bt_avrcp_ct_get_curr_player_app_setting_val(struct bt_avrcp_ct *ct, uint8_t tid,
+						struct net_buf *buf)
+{
+	int err;
+
+	if ((ct == NULL) || (ct->avrcp == NULL) || (buf == NULL)) {
+		return -EINVAL;
+	}
+
+	if (!IS_CT_ROLE_SUPPORTED()) {
+		return -ENOTSUP;
+	}
+
+	if (avrcp_ct_cb->get_curr_player_app_setting_val == NULL) {
+		LOG_WRN("Rsp callback not registered");
+		return -EOPNOTSUPP;
+	}
+
+	err = bt_avrcp_ct_vendor_dependent(ct, tid, BT_AVRCP_PDU_ID_GET_CURR_PLAYER_APP_SETTING_VAL,
+					   buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send AVRCP PDU (err: %d)", err);
+		net_buf_unref(buf);
+	}
+	return err;
+}
+
+int bt_avrcp_ct_set_player_app_setting_val(struct bt_avrcp_ct *ct, uint8_t tid, struct net_buf *buf)
+{
+	int err;
+
+	if ((ct == NULL) || (ct->avrcp == NULL) || (buf == NULL)) {
+		return -EINVAL;
+	}
+
+	if (!IS_CT_ROLE_SUPPORTED()) {
+		return -ENOTSUP;
+	}
+
+	if (avrcp_ct_cb->set_player_app_setting_val == NULL) {
+		LOG_WRN("Rsp callback not registered");
+		return -EOPNOTSUPP;
+	}
+
+	err = bt_avrcp_ct_vendor_dependent(ct, tid, BT_AVRCP_PDU_ID_SET_PLAYER_APP_SETTING_VAL,
+					   buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send AVRCP PDU (err: %d)", err);
+	}
+	return err;
+}
+
+int bt_avrcp_ct_get_player_app_setting_attr_text(struct bt_avrcp_ct *ct, uint8_t tid,
+						 struct net_buf *buf)
+{
+	int err;
+
+	if ((ct == NULL) || (ct->avrcp == NULL) || (buf == NULL)) {
+		return -EINVAL;
+	}
+
+	if (!IS_CT_ROLE_SUPPORTED()) {
+		return -ENOTSUP;
+	}
+
+	if (avrcp_ct_cb->get_player_app_setting_attr_text == NULL) {
+		LOG_WRN("Rsp callback not registered");
+		return -EOPNOTSUPP;
+	}
+
+	err = bt_avrcp_ct_vendor_dependent(ct, tid,
+					   BT_AVRCP_PDU_ID_GET_PLAYER_APP_SETTING_ATTR_TEXT, buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send AVRCP PDU (err: %d)", err);
+	}
+	return err;
+}
+
+int bt_avrcp_ct_get_player_app_setting_val_text(struct bt_avrcp_ct *ct, uint8_t tid,
+						struct net_buf *buf)
+{
+	int err;
+
+	if ((ct == NULL) || (ct->avrcp == NULL) || (buf == NULL)) {
+		return -EINVAL;
+	}
+
+	if (!IS_CT_ROLE_SUPPORTED()) {
+		return -ENOTSUP;
+	}
+
+	if (avrcp_ct_cb->get_player_app_setting_val_text == NULL) {
+		LOG_WRN("Rsp callback not registered");
+		return -EOPNOTSUPP;
+	}
+
+	err = bt_avrcp_ct_vendor_dependent(ct, tid, BT_AVRCP_PDU_ID_GET_PLAYER_APP_SETTING_VAL_TEXT,
+					   buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send AVRCP PDU (err: %d)", err);
+	}
+	return err;
+}
+
+int bt_avrcp_ct_inform_displayable_char_set(struct bt_avrcp_ct *ct, uint8_t tid,
+					    struct net_buf *buf)
+{
+	int err;
+
+	if ((ct == NULL) || (ct->avrcp == NULL) || (buf == NULL)) {
+		return -EINVAL;
+	}
+
+	if (!IS_CT_ROLE_SUPPORTED()) {
+		return -ENOTSUP;
+	}
+
+	if (avrcp_ct_cb->inform_displayable_char_set == NULL) {
+		LOG_WRN("Rsp callback not registered");
+		return -EOPNOTSUPP;
+	}
+
+	err = bt_avrcp_ct_vendor_dependent(ct, tid, BT_AVRCP_PDU_ID_INFORM_DISPLAYABLE_CHAR_SET,
+					   buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send AVRCP PDU (err: %d)", err);
+	}
+	return err;
+}
+
+int bt_avrcp_ct_inform_batt_status_of_ct(struct bt_avrcp_ct *ct, uint8_t tid,
+					 uint8_t battery_status)
+{
+	int err;
+	struct net_buf *buf;
+
+	if ((ct == NULL) || (ct->avrcp == NULL)) {
+		return -EINVAL;
+	}
+
+	if (!IS_CT_ROLE_SUPPORTED()) {
+		return -ENOTSUP;
+	}
+
+	if (avrcp_ct_cb->inform_batt_status_of_ct == NULL) {
+		LOG_WRN("Rsp callback not registered");
+		return -EOPNOTSUPP;
+	}
+
+	if (battery_status > BT_AVRCP_BATTERY_STATUS_FULL) {
+		LOG_ERR("Invalid battery status: %d", battery_status);
+		return -EINVAL;
+	}
+
+	buf = bt_avrcp_create_vendor_pdu(&avrcp_vd_tx_pool);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+
+	if (net_buf_tailroom(buf) < sizeof(battery_status)) {
+		LOG_WRN("Not enough tailroom: for battery_status");
+		net_buf_unref(buf);
+		return -ENOMEM;
+	}
+
+	net_buf_add_u8(buf, battery_status);
+
+	err = bt_avrcp_ct_vendor_dependent(ct, tid, BT_AVRCP_PDU_ID_INFORM_BATT_STATUS_OF_CT,
+					   buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send AVRCP PDU (err: %d)", err);
+	}
+	return err;
+}
+
 int bt_avrcp_ct_register_cb(const struct bt_avrcp_ct_cb *cb)
 {
 	if (!cb) {
@@ -3119,6 +3654,110 @@ int bt_avrcp_tg_get_caps(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status, st
 						    buf);
 	if (err < 0) {
 		LOG_ERR("Failed to send Get Capabilities response (err: %d)", err);
+	}
+	return err;
+}
+
+int bt_avrcp_tg_list_player_app_setting_attrs(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status,
+					      struct net_buf *buf)
+{
+
+	return bt_avrcp_tg_send_vendor_dependent_rsp(tg, tid,
+						     BT_AVRCP_PDU_ID_LIST_PLAYER_APP_SETTING_ATTRS,
+						     status, buf);
+}
+
+int bt_avrcp_tg_list_player_app_setting_vals(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status,
+					     struct net_buf *buf)
+{
+	return bt_avrcp_tg_send_vendor_dependent_rsp(tg, tid,
+						     BT_AVRCP_PDU_ID_LIST_PLAYER_APP_SETTING_VALS,
+						     status, buf);
+}
+
+int bt_avrcp_tg_get_curr_player_app_setting_val(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status,
+						struct net_buf *buf)
+{
+	return bt_avrcp_tg_send_vendor_dependent_rsp(tg, tid,
+						     BT_AVRCP_PDU_ID_GET_CURR_PLAYER_APP_SETTING_VAL
+						     , status, buf);
+}
+
+int bt_avrcp_tg_set_player_app_setting_val(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status)
+{
+	struct net_buf *buf;
+	int err;
+
+	buf = bt_avrcp_create_vendor_pdu(&avrcp_vd_tx_pool);
+	if (buf == NULL) {
+		LOG_ERR("Failed to allocate buffer");
+		return -ENOBUFS;
+	}
+
+	err = bt_avrcp_tg_send_vendor_dependent_rsp(tg, tid,
+						    BT_AVRCP_PDU_ID_SET_PLAYER_APP_SETTING_VAL,
+						    status, buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send vendor dependent (err: %d)", err);
+		net_buf_unref(buf);
+	}
+	return err;
+}
+
+int bt_avrcp_tg_get_player_app_setting_attr_text(struct bt_avrcp_tg *tg, uint8_t tid,
+						 uint8_t status, struct net_buf *buf)
+{
+	uint8_t pdu_id = BT_AVRCP_PDU_ID_GET_PLAYER_APP_SETTING_ATTR_TEXT;
+
+	return bt_avrcp_tg_send_vendor_dependent_rsp(tg, tid, pdu_id, status, buf);
+}
+
+int bt_avrcp_tg_get_player_app_setting_val_text(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status,
+						struct net_buf *buf)
+{
+	uint8_t pdu_id = BT_AVRCP_PDU_ID_GET_PLAYER_APP_SETTING_VAL_TEXT;
+
+	return bt_avrcp_tg_send_vendor_dependent_rsp(tg, tid, pdu_id, status, buf);
+}
+
+int bt_avrcp_tg_inform_displayable_char_set(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status)
+{
+	struct net_buf *buf;
+	int err;
+
+	buf = bt_avrcp_create_vendor_pdu(&avrcp_vd_tx_pool);
+	if (buf == NULL) {
+		LOG_ERR("Failed to allocate buffer");
+		return -ENOBUFS;
+	}
+
+	err = bt_avrcp_tg_send_vendor_dependent_rsp(tg, tid,
+						    BT_AVRCP_PDU_ID_INFORM_DISPLAYABLE_CHAR_SET,
+						    status, buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send vendor dependent (err: %d)", err);
+		net_buf_unref(buf);
+	}
+	return err;
+}
+
+int bt_avrcp_tg_inform_batt_status_of_ct(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status)
+{
+	struct net_buf *buf;
+	int err;
+
+	buf = bt_avrcp_create_vendor_pdu(&avrcp_vd_tx_pool);
+	if (buf == NULL) {
+		LOG_ERR("Failed to allocate buffer");
+		return -ENOBUFS;
+	}
+
+	err = bt_avrcp_tg_send_vendor_dependent_rsp(tg, tid,
+						    BT_AVRCP_PDU_ID_INFORM_BATT_STATUS_OF_CT,
+						    status, buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send vendor dependent (err: %d)", err);
+		net_buf_unref(buf);
 	}
 	return err;
 }

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -43,6 +43,8 @@ struct bt_avrcp_ct {
 	struct bt_avrcp *avrcp;
 
 	struct net_buf *reassembly_buf;	/**< Buffer for reassembling fragments */
+
+	struct bt_avrcp_ct_notify_registration ct_notify[BT_AVRCP_EVT_VOLUME_CHANGED + 1];
 };
 
 struct bt_avrcp_tg {
@@ -56,6 +58,8 @@ struct bt_avrcp_tg {
 
 	/* AVRCP vendor dependent response TX work */
 	struct k_work_delayable vd_rsp_tx_work;
+
+	struct bt_avrcp_tg_notify_state tg_notify[BT_AVRCP_EVT_VOLUME_CHANGED + 1];
 };
 
 struct avrcp_handler {
@@ -1091,6 +1095,195 @@ static int process_get_caps_rsp(struct bt_avrcp *avrcp, uint8_t tid, uint8_t rsp
 	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
 }
 
+static int process_register_notification_rsp(struct bt_avrcp *avrcp, uint8_t tid,
+					     uint8_t rsp_code, struct net_buf *buf)
+{
+	struct bt_avrcp_event_data *event_data;
+	uint8_t event_id;
+	uint8_t status = BT_AVRCP_STATUS_INTERNAL_ERROR;
+	uint16_t expected_len;
+	struct bt_avrcp_ct *ct = get_avrcp_ct(avrcp);
+
+	if ((avrcp_ct_cb == NULL) || (avrcp_ct_cb->notification == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	if (rsp_code == BT_AVRCP_RSP_REJECTED) {
+		if (buf->len < sizeof(status)) {
+			LOG_ERR("Invalid notification status response length");
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+
+		status = net_buf_pull_u8(buf);
+		goto notify_callback;
+	}
+
+	if (rsp_code == BT_AVRCP_RSP_NOT_IMPLEMENTED) {
+		status = BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+		goto notify_callback;
+	}
+
+	/* The first byte is the event_id */
+	if (buf->len < sizeof(event_id)) {
+		LOG_ERR("Invalid notification response length");
+		return BT_AVRCP_STATUS_INVALID_PARAMETER;
+	}
+
+	event_id = net_buf_pull_u8(buf);
+	if (event_id >= ARRAY_SIZE(ct->ct_notify)) {
+		LOG_ERR("Invalid event_id");
+		return BT_AVRCP_STATUS_INVALID_PARAMETER;
+	}
+
+	event_data = (struct bt_avrcp_event_data *)buf->data;
+
+	/* Parse event-specific data */
+	switch (event_id) {
+	case BT_AVRCP_EVT_PLAYBACK_STATUS_CHANGED:
+		if (buf->len < sizeof(event_data->play_status)) {
+			LOG_ERR("Invalid PLAYBACK_STATUS_CHANGED response length");
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+
+		if (event_data->play_status > BT_AVRCP_PLAYBACK_STATUS_REV_SEEK &&
+			event_data->play_status != BT_AVRCP_PLAYBACK_STATUS_ERROR) {
+			LOG_ERR("Invalid playback status: %d", event_data->play_status);
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+		break;
+	case BT_AVRCP_EVT_TRACK_CHANGED:
+		if (buf->len < sizeof(event_data->identifier)) {
+			LOG_ERR("Invalid TRACK_CHANGED response length");
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+		uint64_t identifier = sys_get_be64((const uint8_t *)event_data->identifier);
+
+		memcpy(event_data->identifier, &identifier, sizeof(uint64_t));
+		break;
+	case BT_AVRCP_EVT_PLAYBACK_POS_CHANGED:
+		if (buf->len < sizeof(event_data->playback_pos)) {
+			LOG_ERR("Invalid PLAYBACK_POS_CHANGED response length");
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+		event_data->playback_pos = sys_be32_to_cpu(event_data->playback_pos);
+		break;
+	case BT_AVRCP_EVT_BATT_STATUS_CHANGED:
+		if (buf->len < sizeof(event_data->battery_status)) {
+			LOG_ERR("Invalid BATT_STATUS_CHANGED response length");
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+		break;
+	case BT_AVRCP_EVT_SYSTEM_STATUS_CHANGED:
+		if (buf->len < sizeof(event_data->system_status)) {
+			LOG_ERR("Invalid SYSTEM_STATUS_CHANGED response length");
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+		if (event_data->system_status > BT_AVRCP_SYSTEM_STATUS_UNPLUGGED) {
+			LOG_ERR("Invalid system status: %d", event_data->system_status);
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+		break;
+	case BT_AVRCP_EVT_PLAYER_APP_SETTING_CHANGED:
+		expected_len = sizeof(event_data->setting_changed.num_of_attr) +
+			       event_data->setting_changed.num_of_attr *
+			       sizeof(struct bt_avrcp_app_setting_attr_val);
+		if (buf->len < expected_len) {
+			LOG_ERR("Invalid PLAYER_APP_SETTING_CHANGED attribute length");
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+		break;
+	case BT_AVRCP_EVT_ADDRESSED_PLAYER_CHANGED:
+		if (buf->len < sizeof(event_data->addressed_player_changed)) {
+			LOG_ERR("Invalid ADDRESSED_PLAYER_CHANGED response length");
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+		event_data->addressed_player_changed.player_id =
+		sys_be16_to_cpu(event_data->addressed_player_changed.player_id);
+		event_data->addressed_player_changed.uid_counter =
+		sys_be16_to_cpu(event_data->addressed_player_changed.uid_counter);
+		break;
+	case BT_AVRCP_EVT_UIDS_CHANGED:
+		if (buf->len < sizeof(event_data->uid_counter)) {
+			LOG_ERR("Invalid UIDS_CHANGED response length");
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+		event_data->uid_counter = sys_be16_to_cpu(event_data->uid_counter);
+		break;
+	case BT_AVRCP_EVT_VOLUME_CHANGED:
+		if (buf->len < sizeof(event_data->absolute_volume)) {
+			LOG_ERR("Invalid VOLUME_CHANGED response length");
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+
+		if (event_data->absolute_volume > BT_AVRCP_MAX_ABSOLUTE_VOLUME) {
+			LOG_ERR("Invalid absolute volume: %d", event_data->absolute_volume);
+			return BT_AVRCP_STATUS_INVALID_PARAMETER;
+		}
+		break;
+	case BT_AVRCP_EVT_TRACK_REACHED_END:
+	case BT_AVRCP_EVT_TRACK_REACHED_START:
+	case BT_AVRCP_EVT_AVAILABLE_PLAYERS_CHANGED:
+	case BT_AVRCP_EVT_NOW_PLAYING_CONTENT_CHANGED:
+		if (buf->len != 0) {
+			LOG_WRN("Zero-parameter event (0x%02X) with %u trailing bytes",
+				event_id, buf->len);
+		}
+		event_data = NULL;
+		break;
+	default:
+		LOG_WRN("Unknown notification event_id: 0x%02X", event_id);
+		return BT_AVRCP_STATUS_INVALID_PARAMETER;
+	}
+
+	if (tid != ct->ct_notify[event_id].tid) {
+		LOG_WRN("Mismatched transaction ID: received %u, expected %u", tid,
+			ct->ct_notify[event_id].tid);
+	}
+
+	if (rsp_code != BT_AVRCP_RSP_INTERIM && rsp_code != BT_AVRCP_RSP_CHANGED) {
+		LOG_WRN("Unexpected rsp_code: 0x%02X", rsp_code);
+	}
+
+	if ((rsp_code == BT_AVRCP_RSP_INTERIM) && (ct->ct_notify[event_id].interim_received == 0)) {
+		/* Mark as interim_received flag on interim response */
+		ct->ct_notify[event_id].interim_received = 1;
+		avrcp_ct_cb->notification(get_avrcp_ct(avrcp), tid, BT_AVRCP_STATUS_SUCCESS,
+					  event_id, (struct bt_avrcp_event_data *)event_data);
+		return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+
+	}
+
+	if ((ct->ct_notify[event_id].interim_received == 1) && (rsp_code == BT_AVRCP_RSP_CHANGED)) {
+		ct->ct_notify[event_id].interim_received = 0;
+		if (ct->ct_notify[event_id].cb != NULL) {
+			bt_avrcp_notify_changed_cb_t cb;
+
+			cb = ct->ct_notify[event_id].cb;
+			ct->ct_notify[event_id].cb = NULL;
+			cb(ct, event_id, (struct bt_avrcp_event_data *)event_data);
+		}
+	}
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+notify_callback:
+	/* Find the event registered with this TID and clear ONLY that one */
+	uint8_t failed_evt = 0;
+	bool found = false;
+
+	ARRAY_FOR_EACH(ct->ct_notify, i) {
+		if (ct->ct_notify[i].tid == tid && ct->ct_notify[i].cb != NULL) {
+			failed_evt = i;
+			ct->ct_notify[i].cb = NULL;
+			ct->ct_notify[i].interim_received = 0;
+			found = true;
+			break;
+		}
+	}
+
+	avrcp_ct_cb->notification(get_avrcp_ct(avrcp), tid, status, found ? failed_evt : 0, NULL);
+
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
 /** Response vendor handlers table.
  * Note: The min_len field specifies the minimum payload/parameter length,
  * not including status/error codes. For REJECTED responses, only 1 byte
@@ -1103,6 +1296,8 @@ static const struct avrcp_pdu_vendor_handler rsp_vendor_handlers[] = {
 	  NULL },
 	{ BT_AVRCP_PDU_ID_GET_CAPS, sizeof(struct bt_avrcp_get_caps_rsp), BT_AVRCP_CTYPE_STATUS,
 	  process_get_caps_rsp },
+	{ BT_AVRCP_PDU_ID_REGISTER_NOTIFICATION, sizeof(uint8_t), BT_AVRCP_CTYPE_NOTIFY,
+	  process_register_notification_rsp },
 };
 
 static inline uint8_t get_cmd_type_by_pdu(uint8_t pdu_id)
@@ -1526,8 +1721,29 @@ static int process_get_caps_cmd(struct bt_avrcp *avrcp, uint8_t tid, uint8_t cty
 	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
 }
 
+static int avrcp_register_notification_cmd_handler(struct bt_avrcp *avrcp, uint8_t tid,
+						   uint8_t ctype_or_rsp, struct net_buf *buf)
+{
+	struct bt_avrcp_register_notification_cmd *cmd;
+
+	if ((avrcp_tg_cb == NULL) || (avrcp_tg_cb->register_notification == NULL)) {
+		return BT_AVRCP_STATUS_NOT_IMPLEMENTED;
+	}
+
+	cmd = net_buf_pull_mem(buf, sizeof(*cmd));
+	if (cmd->event_id >= ARRAY_SIZE(get_avrcp_tg(avrcp)->tg_notify)) {
+		LOG_ERR("Invalid event_id");
+		return BT_AVRCP_STATUS_INVALID_PARAMETER;
+	}
+
+	get_avrcp_tg(avrcp)->tg_notify[cmd->event_id].registered = true;
+	get_avrcp_tg(avrcp)->tg_notify[cmd->event_id].interim_sent = false;
+	avrcp_tg_cb->register_notification(get_avrcp_tg(avrcp), tid, cmd->event_id, cmd->interval);
+	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
+}
+
 static int handle_avrcp_continuing_rsp(struct bt_avrcp *avrcp, uint8_t tid, uint8_t ctype_or_rsp,
-					struct net_buf *buf)
+				       struct net_buf *buf)
 {
 	LOG_DBG("Received Continuing Response");
 	bt_avrcp_tg_process_continuing_cmd(get_avrcp_tg(avrcp), false, tid, buf);
@@ -1550,6 +1766,8 @@ static const struct avrcp_pdu_vendor_handler cmd_vendor_handlers[] = {
 	{ BT_AVRCP_PDU_ID_ABORT_CONTINUING_RSP, sizeof(uint8_t), BT_AVRCP_CTYPE_CONTROL,
 	  handle_avrcp_abort_continuing_rsp },
 	{ BT_AVRCP_PDU_ID_GET_CAPS, sizeof(uint8_t), BT_AVRCP_CTYPE_STATUS, process_get_caps_cmd },
+	{ BT_AVRCP_PDU_ID_REGISTER_NOTIFICATION, sizeof(struct bt_avrcp_register_notification_cmd),
+	  BT_AVRCP_CTYPE_NOTIFY, avrcp_register_notification_cmd_handler },
 };
 
 static inline uint8_t get_cmd_min_len_by_pdu(uint8_t pdu_id)
@@ -2057,6 +2275,10 @@ int bt_avrcp_init(void)
 		sys_slist_init(&bt_avrcp_tg_pool[i].vd_rsp_tx_pending);
 
 		k_sem_init(&bt_avrcp_tg_pool[i].lock, 1, 1);
+
+		memset(bt_avrcp_ct_pool[i].ct_notify, 0, sizeof(bt_avrcp_ct_pool[i].ct_notify));
+
+		memset(bt_avrcp_tg_pool[i].tg_notify, 0, sizeof(bt_avrcp_tg_pool[i].tg_notify));
 	}
 	LOG_DBG("AVRCP Initialized successfully.");
 	return 0;
@@ -2327,6 +2549,59 @@ int bt_avrcp_ct_set_browsed_player(struct bt_avrcp_ct *ct, uint8_t tid, uint16_t
 }
 #endif /* CONFIG_BT_AVRCP_BROWSING */
 
+int bt_avrcp_ct_register_notification(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t event_id,
+				      uint32_t interval, bt_avrcp_notify_changed_cb_t cb)
+{
+	struct net_buf *buf;
+	uint16_t param_len = sizeof(event_id) + sizeof(interval);
+	int err;
+
+	if ((ct == NULL) || (ct->avrcp == NULL)) {
+		return -EINVAL;
+	}
+
+	if (!IS_CT_ROLE_SUPPORTED()) {
+		return -ENOTSUP;
+	}
+
+	if (avrcp_ct_cb->notification == NULL) {
+		LOG_WRN("Rsp callback not registered");
+		return -EOPNOTSUPP;
+	}
+
+	if (event_id >= ARRAY_SIZE(ct->ct_notify)) {
+		return -EINVAL;
+	}
+
+	if (ct->ct_notify[event_id].cb != NULL) {
+		return -EBUSY;
+	}
+	ct->ct_notify[event_id].cb = cb;
+	ct->ct_notify[event_id].interim_received = 0;
+	ct->ct_notify[event_id].tid = tid;
+
+	buf = avrcp_prepare_vendor_pdu(ct->avrcp, BT_AVRCP_PKT_TYPE_SINGLE, BT_AVRCP_CTYPE_NOTIFY,
+				       BT_AVRCP_PDU_ID_REGISTER_NOTIFICATION, param_len);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+	/* Add event ID */
+	net_buf_add_u8(buf, event_id);
+
+	/* Add playback interval */
+	net_buf_add_be32(buf, interval);
+
+	err = avrcp_send(ct->avrcp, buf, BT_AVCTP_CMD, ct->ct_notify[event_id].tid);
+	if (err < 0) {
+		LOG_ERR("Failed to send AVRCP PDU (err: %d)", err);
+		net_buf_unref(buf);
+		/* Roll back state so the app can retry */
+		ct->ct_notify[event_id].cb = NULL;
+		ct->ct_notify[event_id].interim_received = 0;
+	}
+	return err;
+}
+
 static int bt_avrcp_ct_vendor_dependent(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t pdu_id,
 					struct net_buf *buf)
 {
@@ -2536,6 +2811,206 @@ int bt_avrcp_tg_send_set_browsed_player_rsp(struct bt_avrcp_tg *tg, uint8_t tid,
 	return err;
 }
 #endif /* CONFIG_BT_AVRCP_BROWSING */
+
+static int build_notification_rsp_data(uint8_t event_id, struct bt_avrcp_event_data *data,
+				       struct net_buf *buf)
+{
+	uint16_t param_len = sizeof(event_id);
+
+	/* Calculate parameter length based on event type */
+	switch (event_id) {
+	case BT_AVRCP_EVT_PLAYBACK_STATUS_CHANGED:
+		param_len += sizeof(data->play_status);
+		break;
+	case BT_AVRCP_EVT_TRACK_CHANGED:
+		param_len += sizeof(data->identifier);
+		break;
+	case BT_AVRCP_EVT_PLAYBACK_POS_CHANGED:
+		param_len += sizeof(data->playback_pos);
+		break;
+	case BT_AVRCP_EVT_BATT_STATUS_CHANGED:
+		param_len += sizeof(data->battery_status);
+		break;
+	case BT_AVRCP_EVT_SYSTEM_STATUS_CHANGED:
+		param_len += sizeof(data->system_status);
+		break;
+	case BT_AVRCP_EVT_PLAYER_APP_SETTING_CHANGED:
+		param_len += sizeof(data->setting_changed.num_of_attr) +
+		data->setting_changed.num_of_attr * sizeof(struct bt_avrcp_app_setting_attr_val);
+		break;
+	case BT_AVRCP_EVT_ADDRESSED_PLAYER_CHANGED:
+		param_len += sizeof(data->addressed_player_changed);
+		break;
+	case BT_AVRCP_EVT_UIDS_CHANGED:
+		param_len += sizeof(data->uid_counter);
+		break;
+	case BT_AVRCP_EVT_VOLUME_CHANGED:
+		param_len += sizeof(data->absolute_volume);
+		break;
+	case BT_AVRCP_EVT_TRACK_REACHED_END:
+	case BT_AVRCP_EVT_TRACK_REACHED_START:
+	case BT_AVRCP_EVT_AVAILABLE_PLAYERS_CHANGED:
+	case BT_AVRCP_EVT_NOW_PLAYING_CONTENT_CHANGED:
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (net_buf_tailroom(buf) < param_len) {
+		LOG_ERR("Not enough space in net_buf");
+		return -ENOMEM;
+	}
+
+	net_buf_add_u8(buf, event_id);
+	switch (event_id) {
+	case BT_AVRCP_EVT_PLAYBACK_STATUS_CHANGED:
+		if (data->play_status > BT_AVRCP_PLAYBACK_STATUS_REV_SEEK &&
+		    data->play_status != BT_AVRCP_PLAYBACK_STATUS_ERROR) {
+			LOG_ERR("Invalid playback status: %d", data->play_status);
+			return -EINVAL;
+		}
+		net_buf_add_u8(buf, data->play_status);
+		break;
+	case BT_AVRCP_EVT_TRACK_CHANGED:
+		uint64_t identifier = sys_get_be64(data->identifier);
+
+		net_buf_add_be64(buf, identifier);
+		break;
+	case BT_AVRCP_EVT_PLAYBACK_POS_CHANGED:
+		net_buf_add_be32(buf, data->playback_pos);
+		break;
+	case BT_AVRCP_EVT_BATT_STATUS_CHANGED:
+		if (data->battery_status > BT_AVRCP_BATTERY_STATUS_FULL) {
+			LOG_ERR("Invalid battery status: %d", data->battery_status);
+			return -EINVAL;
+		}
+		net_buf_add_u8(buf, data->battery_status);
+		break;
+	case BT_AVRCP_EVT_SYSTEM_STATUS_CHANGED:
+		if (data->system_status > BT_AVRCP_SYSTEM_STATUS_UNPLUGGED) {
+			LOG_ERR("Invalid system status: %d", data->system_status);
+			return -EINVAL;
+		}
+		net_buf_add_u8(buf, data->system_status);
+		break;
+	case BT_AVRCP_EVT_PLAYER_APP_SETTING_CHANGED:
+		net_buf_add_u8(buf, data->setting_changed.num_of_attr);
+		net_buf_add_mem(buf, data->setting_changed.attr_vals,
+		data->setting_changed.num_of_attr * sizeof(struct bt_avrcp_app_setting_attr_val));
+		break;
+	case BT_AVRCP_EVT_ADDRESSED_PLAYER_CHANGED:
+		net_buf_add_be16(buf, data->addressed_player_changed.player_id);
+		net_buf_add_be16(buf, data->addressed_player_changed.uid_counter);
+		break;
+	case BT_AVRCP_EVT_UIDS_CHANGED:
+		net_buf_add_be16(buf, data->uid_counter);
+		break;
+	case BT_AVRCP_EVT_VOLUME_CHANGED:
+		if (data->absolute_volume > BT_AVRCP_MAX_ABSOLUTE_VOLUME) {
+			LOG_ERR("Invalid absolute volume: %d", data->absolute_volume);
+			return -EINVAL;
+		}
+		net_buf_add_u8(buf, data->absolute_volume);
+		break;
+	case BT_AVRCP_EVT_TRACK_REACHED_END:
+	case BT_AVRCP_EVT_TRACK_REACHED_START:
+	case BT_AVRCP_EVT_AVAILABLE_PLAYERS_CHANGED:
+	case BT_AVRCP_EVT_NOW_PLAYING_CONTENT_CHANGED:
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int bt_avrcp_tg_notification(struct bt_avrcp_tg *tg, uint8_t tid, uint8_t status, uint8_t event_id,
+			     struct bt_avrcp_event_data *data)
+{
+	uint8_t rsp_code = BT_AVRCP_RSP_INTERIM;
+	struct net_buf *buf;
+	int err;
+
+	if ((tg == NULL) || (tg->avrcp == NULL)) {
+		return -EINVAL;
+	}
+
+	if (!IS_TG_ROLE_SUPPORTED()) {
+		return -ENOTSUP;
+	}
+
+	if (event_id >= ARRAY_SIZE(tg->tg_notify)) {
+		LOG_ERR("Invalid event_id");
+		return -EINVAL;
+	}
+
+	if (tg->tg_notify[event_id].registered == false) {
+		LOG_ERR("Notification response failed: event not registered");
+		return -ENOENT;
+	}
+
+	switch (status) {
+	case BT_AVRCP_STATUS_SUCCESS:
+		if (tg->tg_notify[event_id].interim_sent == false) {
+			rsp_code = BT_AVRCP_RSP_INTERIM;
+		} else {
+			rsp_code = BT_AVRCP_RSP_CHANGED;
+		}
+		break;
+	case BT_AVRCP_STATUS_NOT_IMPLEMENTED:
+		if (tg->tg_notify[event_id].interim_sent == true) {
+			LOG_ERR("Not support INTERIM has been responded");
+			return -EINVAL;
+		}
+		rsp_code = BT_AVRCP_RSP_NOT_IMPLEMENTED;
+		break;
+	case BT_AVRCP_STATUS_IN_TRANSITION:
+		LOG_ERR("Not support IN_TRANSITION");
+		return -EINVAL;
+
+	default:
+		rsp_code = BT_AVRCP_RSP_REJECTED;
+		break;
+	}
+
+	buf = bt_avrcp_create_vendor_pdu(NULL);
+	if (buf == NULL) {
+		LOG_ERR("Failed to allocate buffer");
+		return -ENOBUFS;
+	}
+
+	if (rsp_code == BT_AVRCP_RSP_REJECTED) {
+		if (net_buf_tailroom(buf) < sizeof(status)) {
+			LOG_ERR("Not enough space in net_buf");
+			net_buf_unref(buf);
+			return -ENOMEM;
+		}
+		net_buf_add_u8(buf, status);
+	} else {
+		err = build_notification_rsp_data(event_id, data, buf);
+		if (err < 0) {
+			net_buf_unref(buf);
+			return err;
+		}
+	}
+
+	err =  bt_avrcp_tg_send_vendor_rsp(tg, tid, BT_AVRCP_PDU_ID_REGISTER_NOTIFICATION,
+					   rsp_code, buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send notification response (err: %d)", err);
+		net_buf_unref(buf);
+		return err;
+	}
+
+	if (rsp_code == BT_AVRCP_RSP_INTERIM) {
+		tg->tg_notify[event_id].interim_sent = true;
+	} else {
+		tg->tg_notify[event_id].registered = false;
+		tg->tg_notify[event_id].interim_sent = false;
+	}
+
+	return err;
+}
 
 int bt_avrcp_tg_send_passthrough_rsp(struct bt_avrcp_tg *tg, uint8_t tid, bt_avrcp_rsp_t result,
 				     struct net_buf *buf)

--- a/subsys/bluetooth/host/classic/avrcp_internal.h
+++ b/subsys/bluetooth/host/classic/avrcp_internal.h
@@ -151,6 +151,17 @@ struct bt_avrcp_tg_vd_rsp_tx {
 	ATOMIC_DEFINE(flags, BT_AVRCP_TG_NUM_FLAGS);
 };
 
+struct bt_avrcp_ct_notify_registration {
+	uint8_t tid;
+	bool interim_received;
+	bt_avrcp_notify_changed_cb_t cb;
+};
+
+struct bt_avrcp_tg_notify_state {
+	bool registered;   /* CT has an active registration for this event */
+	bool interim_sent; /* we have already sent INTERIM */
+};
+
 struct bt_avrcp_req {
 	uint8_t tid;
 	uint8_t subunit;

--- a/subsys/bluetooth/host/classic/shell/avrcp.c
+++ b/subsys/bluetooth/host/classic/shell/avrcp.c
@@ -157,6 +157,94 @@ static void avrcp_passthrough_rsp(struct bt_avrcp_ct *ct, uint8_t tid, bt_avrcp_
 	}
 }
 
+static void print_notification_event(uint8_t event_id, struct bt_avrcp_event_data *data,
+				     bool is_interim)
+{
+	const char *type_str = is_interim ? "INTERIM" : "CHANGED";
+
+	bt_shell_print(" Notification type: %s", type_str);
+
+	switch (event_id) {
+	case BT_AVRCP_EVT_PLAYBACK_STATUS_CHANGED:
+		bt_shell_print(" PLAYBACK_STATUS_CHANGED: status=0x%02x", data->play_status);
+		break;
+	case BT_AVRCP_EVT_TRACK_CHANGED:
+		uint64_t identifier;
+
+		memcpy(&identifier, data->identifier, sizeof(identifier));
+		bt_shell_print(" TRACK_CHANGED: identifier value: %llx", identifier);
+		break;
+	case BT_AVRCP_EVT_PLAYBACK_POS_CHANGED:
+		bt_shell_print(" PLAYBACK_POS_CHANGED: pos=%u", data->playback_pos);
+		break;
+	case BT_AVRCP_EVT_BATT_STATUS_CHANGED:
+		bt_shell_print(" BATT_STATUS_CHANGED: battery_status=0x%02x", data->battery_status);
+		break;
+	case BT_AVRCP_EVT_SYSTEM_STATUS_CHANGED:
+		bt_shell_print(" SYSTEM_STATUS_CHANGED: system_status=0x%02x", data->system_status);
+		break;
+	case BT_AVRCP_EVT_PLAYER_APP_SETTING_CHANGED:
+		bt_shell_print(" PLAYER_APP_SETTING_CHANGED: num_of_attr=%u",
+			       data->setting_changed.num_of_attr);
+		break;
+	case BT_AVRCP_EVT_ADDRESSED_PLAYER_CHANGED:
+		bt_shell_print(" ADDRESSED_PLAYER_CHANGED: player_id=0x%04x, uid_counter=0x%04x",
+			       data->addressed_player_changed.player_id,
+			       data->addressed_player_changed.uid_counter);
+		break;
+	case BT_AVRCP_EVT_UIDS_CHANGED:
+		bt_shell_print(" UIDS_CHANGED: uid_counter=0x%04x", data->uid_counter);
+		break;
+	case BT_AVRCP_EVT_VOLUME_CHANGED:
+		bt_shell_print(" VOLUME_CHANGED: absolute_volume=0x%02x", data->absolute_volume);
+		break;
+	case BT_AVRCP_EVT_TRACK_REACHED_END:
+		bt_shell_print(" TRACK_REACHED_END");
+		break;
+	case BT_AVRCP_EVT_TRACK_REACHED_START:
+		bt_shell_print(" TRACK_REACHED_START");
+		break;
+	case BT_AVRCP_EVT_AVAILABLE_PLAYERS_CHANGED:
+		bt_shell_print(" AVAILABLE_PLAYERS_CHANGED");
+		break;
+	case BT_AVRCP_EVT_NOW_PLAYING_CONTENT_CHANGED:
+		bt_shell_print(" NOW_PLAYING_CONTENT_CHANGED");
+		break;
+	default:
+		bt_shell_print(" Unknown event_id: 0x%02x", event_id);
+		break;
+	}
+}
+
+static void avrcp_notify_changed_cb_rsp(struct bt_avrcp_ct *ct, uint8_t event_id,
+					struct bt_avrcp_event_data *data)
+{
+	bt_shell_print("AVRCP notify_changed_cb received: event_id=0x%02x", event_id);
+
+	/* For callback notifications, these are typically CHANGED events */
+	print_notification_event(event_id, data, false);
+}
+
+static void avrcp_register_notification_req(struct bt_avrcp_tg *tg, uint8_t tid,
+					    bt_avrcp_evt_t event_id,
+					    uint32_t interval)
+{
+	tg_tid = tid;
+	bt_shell_print("AVRCP register_notification_req: tid=0x%02x, event_id=0x%02x, interval=%u",
+		       tid, event_id, interval);
+}
+
+static void avrcp_notification_rsp(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t status,
+				   uint8_t event_id, struct bt_avrcp_event_data *data)
+{
+	bt_shell_print("AVRCP notification rsp: tid=0x%02x, status=0x%02x, event_id=0x%02x",
+		       tid, status, event_id);
+
+	if (status == BT_AVRCP_STATUS_SUCCESS) {
+		print_notification_event(event_id, data, true);
+	}
+}
+
 static void avrcp_browsed_player_rsp(struct bt_avrcp_ct *ct, uint8_t tid,
 				     struct net_buf *buf)
 {
@@ -221,6 +309,7 @@ static struct bt_avrcp_ct_cb app_avrcp_ct_cb = {
 	.subunit_info_rsp = avrcp_subunit_info_rsp,
 	.passthrough_rsp = avrcp_passthrough_rsp,
 	.browsed_player_rsp = avrcp_browsed_player_rsp,
+	.notification = avrcp_notification_rsp,
 };
 
 static void avrcp_tg_connected(struct bt_conn *conn, struct bt_avrcp_tg *tg)
@@ -338,6 +427,7 @@ static struct bt_avrcp_tg_cb app_avrcp_tg_cb = {
 	.subunit_info_req = avrcp_subunit_info_req,
 	.get_caps = avrcp_get_caps_req,
 	.set_browsed_player_req = avrcp_set_browsed_player_req,
+	.register_notification = avrcp_register_notification_req,
 	.passthrough_req = avrcp_passthrough_req,
 };
 
@@ -808,6 +898,161 @@ static int cmd_get_caps(const struct shell *sh, int32_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_ct_register_notification(const struct shell *sh, int argc, char *argv[])
+{
+	uint8_t event_id;
+	uint32_t interval = 0U;
+	int err;
+
+	if (!avrcp_ct_registered && register_ct_cb(sh) != 0) {
+		return -ENOEXEC;
+	}
+
+	if (default_ct == NULL) {
+		shell_error(sh, "AVRCP CT is not connected");
+		return -ENOEXEC;
+	}
+
+	event_id = (uint8_t)strtoul(argv[1], NULL, 0);
+	if (argc > 2) {
+		interval = (uint32_t)strtoul(argv[2], NULL, 0);
+	}
+
+	err = bt_avrcp_ct_register_notification(default_ct, get_next_tid(), event_id,
+						interval, avrcp_notify_changed_cb_rsp);
+	if (err < 0) {
+		shell_error(sh, "Failed to send register_notification: %d", err);
+	} else {
+		shell_print(sh, "Sent register notification event_id=0x%02x", event_id);
+	}
+	return err;
+}
+
+static int cmd_tg_send_notification_rsp(const struct shell *sh, int argc, char *argv[])
+{
+	struct bt_avrcp_event_data data;
+	bool interim = false;
+	struct bt_avrcp_app_setting_attr_val attr_vals[1];
+	uint8_t event_id = (uint8_t)strtoul(argv[1], NULL, 0);
+	bt_avrcp_status_t status;
+	uint64_t identifier;
+	char *endptr;
+	int err;
+
+	if (!avrcp_tg_registered && register_tg_cb(sh) != 0) {
+		return -ENOEXEC;
+	}
+
+	if (default_tg == NULL) {
+		shell_error(sh, "AVRCP TG is not connected");
+		return -ENOEXEC;
+	}
+
+	memset(&data, 0, sizeof(data));
+
+	if (strcmp(argv[2], "changed") == 0) {
+		status = BT_AVRCP_STATUS_SUCCESS;
+	} else if (strcmp(argv[2], "interim") == 0) {
+		status = BT_AVRCP_STATUS_SUCCESS;
+		interim = true;
+	} else {
+		shell_error(sh, "Invalid type: %s (expected: changed|interim)", argv[2]);
+		status = BT_AVRCP_STATUS_INVALID_PARAMETER;
+		goto done;
+	}
+
+	switch (event_id) {
+	case BT_AVRCP_EVT_PLAYBACK_STATUS_CHANGED:
+		if (argc < 4) {
+			data.play_status = BT_AVRCP_PLAYBACK_STATUS_PLAYING;
+		} else {
+			data.play_status = (uint8_t)strtoul(argv[3], NULL, 0);
+		}
+		break;
+	case BT_AVRCP_EVT_TRACK_CHANGED:
+		if (argc < 4) {
+			identifier = interim ? 0x111111 : 1;
+			sys_put_be64(identifier, data.identifier);
+		} else {
+			identifier = strtoull(argv[3], &endptr, 16);
+			if (*endptr != '\0') {
+				shell_error(sh, "Invalid identifier: %s", argv[3]);
+			}
+			sys_put_be64(identifier, data.identifier);
+		}
+		break;
+	case BT_AVRCP_EVT_PLAYBACK_POS_CHANGED:
+		if (argc < 4) {
+			data.playback_pos = 1000;
+		} else {
+			data.playback_pos = (uint32_t)strtoul(argv[3], NULL, 0);
+		}
+		break;
+	case BT_AVRCP_EVT_BATT_STATUS_CHANGED:
+		if (argc < 4) {
+			data.battery_status = BT_AVRCP_BATTERY_STATUS_NORMAL;
+		} else {
+			data.battery_status = (uint8_t)strtoul(argv[3], NULL, 0);
+		}
+		break;
+	case BT_AVRCP_EVT_SYSTEM_STATUS_CHANGED:
+		if (argc < 4) {
+			data.system_status = BT_AVRCP_SYSTEM_STATUS_POWER_ON;
+		} else {
+			data.system_status = (uint8_t)strtoul(argv[3], NULL, 0);
+		}
+		break;
+	case BT_AVRCP_EVT_PLAYER_APP_SETTING_CHANGED:
+		data.setting_changed.num_of_attr           = 1;
+		data.setting_changed.attr_vals = &attr_vals[0];
+		data.setting_changed.attr_vals[0].attr_id  = 1;
+		data.setting_changed.attr_vals[0].value_id = 1;
+		break;
+	case BT_AVRCP_EVT_ADDRESSED_PLAYER_CHANGED:
+		if (argc < 5) {
+			data.addressed_player_changed.player_id = 0x0001; /* Default player ID */
+			data.addressed_player_changed.uid_counter = 0x0001; /* Default UID counter*/
+		} else {
+			data.addressed_player_changed.player_id = strtoul(argv[3], NULL, 0);
+			data.addressed_player_changed.uid_counter = strtoul(argv[4], NULL, 0);
+		}
+		break;
+	case BT_AVRCP_EVT_UIDS_CHANGED:
+		if (argc < 4) {
+			data.uid_counter = 1;
+		} else {
+			data.uid_counter = (uint16_t)strtoul(argv[3], NULL, 0);
+		}
+		break;
+	case BT_AVRCP_EVT_VOLUME_CHANGED:
+		if (argc < 4) {
+			data.absolute_volume = 10;
+		} else {
+			data.absolute_volume = (uint8_t)strtoul(argv[3], NULL, 0);
+		}
+		break;
+	case BT_AVRCP_EVT_TRACK_REACHED_END:
+	case BT_AVRCP_EVT_TRACK_REACHED_START:
+	case BT_AVRCP_EVT_AVAILABLE_PLAYERS_CHANGED:
+	case BT_AVRCP_EVT_NOW_PLAYING_CONTENT_CHANGED:
+		break;
+	default:
+		shell_error(sh, "Unknown event_id: 0x%02x", event_id);
+		status = BT_AVRCP_STATUS_INVALID_PARAMETER;
+		goto done;
+	}
+
+done:
+	err = bt_avrcp_tg_notification(default_tg, tg_tid, status, event_id, &data);
+	if (err < 0) {
+		shell_error(sh, "Failed to send notification rsp: %d", err);
+	} else {
+		shell_print(sh, "Sent notification rsp event_id=0x%02x type=%s",
+			    event_id, (interim) ? "interim" : "changed");
+	}
+	return err;
+}
+
 static int cmd_set_browsed_player(const struct shell *sh, int32_t argc, char *argv[])
 {
 	uint16_t player_id;
@@ -957,6 +1202,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      2, 0),
 	SHELL_CMD_ARG(play, NULL, "request a play at the remote player", cmd_play, 1, 0),
 	SHELL_CMD_ARG(pause, NULL, "request a pause at the remote player", cmd_pause, 1, 0),
+	SHELL_CMD_ARG(register_notification, NULL, "register notify <event_id> [playback_interval]",
+		      cmd_ct_register_notification, 2, 1),
 	SHELL_CMD_ARG(set_browsed_player, NULL, "set browsed player <player_id>",
 		      cmd_set_browsed_player, 2, 0),
 	SHELL_SUBCMD_SET_END);
@@ -968,6 +1215,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(send_subunit_rsp, NULL, HELP_NONE, cmd_send_subunit_info_rsp, 1, 0),
 	SHELL_CMD_ARG(send_get_caps_rsp, NULL, "send get capabilities response [status]",
 		      cmd_send_get_caps_rsp, 1, 1),
+	SHELL_CMD_ARG(send_notification_rsp, NULL, "send notify rsp <event_id> <type> [value...]",
+		      cmd_tg_send_notification_rsp, 3, 2),
 	SHELL_CMD_ARG(send_browsed_player_rsp, NULL, HELP_BROWSED_PLAYER_RSP,
 		      cmd_send_set_browsed_player_rsp, 1, 5),
 	SHELL_CMD_ARG(send_passthrough_rsp, NULL, HELP_PASSTHROUGH_RSP, cmd_send_passthrough_rsp,


### PR DESCRIPTION
This patch introduces support for AVRCP vendor-dependent commands and responses, including full handling of fragmented messages.