### PR TITLE
soc: litex: split litex_vexriscv

### DIFF
--- a/soc/litex/CMakeLists.txt
+++ b/soc/litex/CMakeLists.txt
@@ -1,9 +1,5 @@
 # SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_LITEX_VEXRISCV
-
-config NUM_IRQS
-	default 12
-
-endif # SOC_LITEX_VEXRISCV
+add_subdirectory(common)
+add_subdirectory(${SOC_SERIES})

--- a/soc/litex/Kconfig
+++ b/soc/litex/Kconfig
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_FAMILY_LITEX
+
+rsource "*/Kconfig"
+
+config LITEX_CSR_DATA_WIDTH
+	int "Select Control/Status register width"
+	default 32
+
+config LITEX_CSR_DATA_WIDTH_DEPRECATED
+	def_bool y
+	depends on LITEX_CSR_DATA_WIDTH != 32
+	select DEPRECATED
+	help
+	  This option is there to select DEPRECATED, when LITEX_CSR_DATA_WIDTH is
+	  set to a value other than 32. It will be removed in future releases.
+
+choice LITEX_CSR_ORDERING
+	prompt "Select Control/Status register ordering"
+	default LITEX_CSR_ORDERING_BIG
+
+config LITEX_CSR_ORDERING_BIG
+	bool "Big-endian ordering"
+	help
+	  Use big-endian ordering for CSR accesses
+
+config LITEX_CSR_ORDERING_LITTLE
+	bool "Little-endian ordering"
+	help
+	  Use little-endian ordering for CSR accesses
+endchoice
+
+endif # SOC_FAMILY_LITEX

--- a/soc/litex/Kconfig.defconfig
+++ b/soc/litex/Kconfig.defconfig
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_FAMILY_LITEX
+
+rsource "*/Kconfig.defconfig"
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+
+config REBOOT
+	depends on DT_HAS_LITEX_SOC_CONTROLLER_ENABLED
+	default y
+
+endif # SOC_FAMILY_LITEX

--- a/soc/litex/Kconfig.soc
+++ b/soc/litex/Kconfig.soc
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_LITEX_VEXRISCV
+config SOC_FAMILY_LITEX
+	bool
 
-config NUM_IRQS
-	default 12
+config SOC_FAMILY
+	default "litex" if SOC_FAMILY_LITEX
 
-endif # SOC_LITEX_VEXRISCV
+rsource "*/Kconfig.soc"

--- a/soc/litex/common/CMakeLists.txt
+++ b/soc/litex/common/CMakeLists.txt
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_LITEX_VEXRISCV
+zephyr_sources_ifdef(CONFIG_REBOOT reboot.c)
 
-config NUM_IRQS
-	default 12
-
-endif # SOC_LITEX_VEXRISCV
+zephyr_include_directories(.)

--- a/soc/litex/common/reboot.c
+++ b/soc/litex/common/reboot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Vogl Electronic GmbH
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Vogl Electronic GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/soc/litex/common/soc.h
+++ b/soc/litex/common/soc.h
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __RISCV32_LITEX_VEXRISCV_SOC_H_
-#define __RISCV32_LITEX_VEXRISCV_SOC_H_
+#ifndef __RISCV32_LITEX_COMMON_SOC_H_
+#define __RISCV32_LITEX_COMMON_SOC_H_
 
 #include <zephyr/devicetree.h>
 #include <zephyr/arch/riscv/sys_io.h>
@@ -236,4 +237,4 @@ static inline void litex_read32_array(mem_addr_t addr, uint32_t *buf, size_t cnt
 
 #endif /* _ASMLANGUAGE */
 
-#endif /* __RISCV32_LITEX_VEXRISCV_SOC_H_ */
+#endif /* __RISCV32_LITEX_COMMON_SOC_H_ */

--- a/soc/litex/litex_vexriscv/CMakeLists.txt
+++ b/soc/litex/litex_vexriscv/CMakeLists.txt
@@ -1,5 +1,5 @@
-#
-# Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -8,8 +8,6 @@ zephyr_sources(
     ${ZEPHYR_BASE}/soc/common/riscv-privileged/soc_irq.S
     ${ZEPHYR_BASE}/soc/common/riscv-privileged/vector.S
 )
-
-zephyr_sources_ifdef(CONFIG_REBOOT reboot.c)
 
 zephyr_include_directories(.)
 

--- a/soc/litex/litex_vexriscv/Kconfig
+++ b/soc/litex/litex_vexriscv/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
+# SPDX-FileCopyrightText: Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_LITEX_VEXRISCV
@@ -7,34 +7,3 @@ config SOC_LITEX_VEXRISCV
 	# There are varriants of the Vexriscv without cache, be able to set it
 	select CPU_HAS_ICACHE if $(dt_node_int_prop_int,/cpus/cpu@0,i-cache-line-size) > 0
 	select CPU_HAS_DCACHE if $(dt_node_int_prop_int,/cpus/cpu@0,d-cache-line-size) > 0
-
-if SOC_LITEX_VEXRISCV
-
-config LITEX_CSR_DATA_WIDTH
-	int "Select Control/Status register width"
-	default 32
-
-config LITEX_CSR_DATA_WIDTH_DEPRECATED
-	def_bool y
-	depends on LITEX_CSR_DATA_WIDTH != 32
-	select DEPRECATED
-	help
-	  This option is there to select DEPRECATED, when LITEX_CSR_DATA_WIDTH is
-	  set to a value other than 32. It will be removed in future releases.
-
-choice LITEX_CSR_ORDERING
-	prompt "Select Control/Status register ordering"
-	default LITEX_CSR_ORDERING_BIG
-
-config LITEX_CSR_ORDERING_BIG
-	bool "Big-endian ordering"
-	help
-	  Use big-endian ordering for CSR accesses
-
-config LITEX_CSR_ORDERING_LITTLE
-	bool "Little-endian ordering"
-	help
-	  Use little-endian ordering for CSR accesses
-endchoice
-
-endif # SOC_LITEX_VEXRISCV

--- a/soc/litex/litex_vexriscv/Kconfig.soc
+++ b/soc/litex/litex_vexriscv/Kconfig.soc
@@ -1,10 +1,16 @@
-# Copyright (c) 2018 - 2019 Antmicro <www.antmicro.com>
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES
+	default "litex_vexriscv" if SOC_SERIES_LITEX_VEXRISCV
+
+config SOC_SERIES_LITEX_VEXRISCV
+	bool
+	select SOC_FAMILY_LITEX
 
 config SOC_LITEX_VEXRISCV
 	bool
-	help
-	  LiteX VexRiscv system implementation
+	select SOC_SERIES_LITEX_VEXRISCV
 
 config SOC
 	default "litex_vexriscv" if SOC_LITEX_VEXRISCV

--- a/soc/litex/litex_vexriscv/soc.yml
+++ b/soc/litex/litex_vexriscv/soc.yml
@@ -1,2 +1,0 @@
-socs:
-- name: litex_vexriscv

--- a/soc/litex/soc.yml
+++ b/soc/litex/soc.yml
@@ -1,0 +1,6 @@
+family:
+- name: litex
+  series:
+  - name: litex_vexriscv
+    socs:
+    - name: litex_vexriscv


### PR DESCRIPTION
- split litex_vexriscv into a family and a soc
- ~~add a litex_vexiiriscv soc (uses a plic irq)~~ now in  #106609