### PR TITLE
enable watchdog on imx93 A-Core

### DIFF
--- a/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.dts
+++ b/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.dts
@@ -18,6 +18,7 @@
 		led0 = &led_r;
 		led1 = &led_g;
 		sw0 = &btn_1;
+		watchdog0 = &wdog4;
 	};
 
 	chosen {
@@ -142,5 +143,9 @@
 	pinctrl-0 = <&flexcan2_default>;
 	pinctrl-names = "default";
 	phys = <&can_phy0>;
+	status = "okay";
+};
+
+&wdog4 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.yaml
+++ b/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.yaml
@@ -19,6 +19,7 @@ supported:
   - spi
   - can
   - net
+  - watchdog
 testing:
   ignore_tags:
     - bluetooth

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -36,6 +36,7 @@
 		led0 = &led_r;
 		led1 = &led_g;
 		sw0 = &btn_1;
+		watchdog0 = &wdog4;
 	};
 
 	leds {
@@ -244,4 +245,8 @@
 		disk-name = "SD";
 		status = "disabled";
 	};
+};
+
+&wdog4 {
+	status = "okay";
 };

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -19,6 +19,7 @@ supported:
   - spi
   - can
   - net
+  - watchdog
 testing:
   ignore_tags:
     - bluetooth

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (2) 2019 Vestas Wind Systems A/S
+ * Copyright 2025 NXP
  *
  * Based on wdt_mcux_wdog.c, which is:
  * Copyright (c) 2018, NXP
@@ -11,6 +12,7 @@
 
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/sys/device_mmio.h>
 #include <fsl_wdog32.h>
 
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
@@ -20,8 +22,11 @@ LOG_MODULE_REGISTER(wdt_mcux_wdog32);
 
 #define MIN_TIMEOUT 1
 
+#define DEV_CFG(_dev) ((const struct mcux_wdog32_config *)(_dev)->config)
+#define DEV_DATA(_dev) ((struct mcux_wdog32_data *)(_dev)->data)
+
 struct mcux_wdog32_config {
-	WDOG_Type *base;
+	DEVICE_MMIO_NAMED_ROM(reg);
 #if DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency)
 	uint32_t clock_frequency;
 #else /* !DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency) */
@@ -34,16 +39,21 @@ struct mcux_wdog32_config {
 };
 
 struct mcux_wdog32_data {
+	DEVICE_MMIO_NAMED_RAM(reg);
 	wdt_callback_t callback;
 	wdog32_config_t wdog_config;
 	bool timeout_valid;
 };
 
+static inline WDOG_Type *get_base_address(const struct device *dev)
+{
+	return (WDOG_Type *)DEVICE_MMIO_NAMED_GET(dev, reg);
+}
+
 static int mcux_wdog32_setup(const struct device *dev, uint8_t options)
 {
-	const struct mcux_wdog32_config *config = dev->config;
 	struct mcux_wdog32_data *data = dev->data;
-	WDOG_Type *base = config->base;
+	WDOG_Type *base = get_base_address(dev);
 
 	if (!data->timeout_valid) {
 		LOG_ERR("No valid timeouts installed");
@@ -64,9 +74,8 @@ static int mcux_wdog32_setup(const struct device *dev, uint8_t options)
 
 static int mcux_wdog32_disable(const struct device *dev)
 {
-	const struct mcux_wdog32_config *config = dev->config;
 	struct mcux_wdog32_data *data = dev->data;
-	WDOG_Type *base = config->base;
+	WDOG_Type *base = get_base_address(dev);
 
 	WDOG32_Deinit(base);
 	data->timeout_valid = false;
@@ -140,8 +149,7 @@ static int mcux_wdog32_install_timeout(const struct device *dev,
 
 static int mcux_wdog32_feed(const struct device *dev, int channel_id)
 {
-	const struct mcux_wdog32_config *config = dev->config;
-	WDOG_Type *base = config->base;
+	WDOG_Type *base = get_base_address(dev);
 
 	if (channel_id != 0) {
 		LOG_ERR("Invalid channel id");
@@ -156,9 +164,8 @@ static int mcux_wdog32_feed(const struct device *dev, int channel_id)
 
 static void mcux_wdog32_isr(const struct device *dev)
 {
-	const struct mcux_wdog32_config *config = dev->config;
 	struct mcux_wdog32_data *data = dev->data;
-	WDOG_Type *base = config->base;
+	WDOG_Type *base = get_base_address(dev);
 	uint32_t flags;
 
 	flags = WDOG32_GetStatusFlags(base);
@@ -172,6 +179,9 @@ static void mcux_wdog32_isr(const struct device *dev)
 static int mcux_wdog32_init(const struct device *dev)
 {
 	const struct mcux_wdog32_config *config = dev->config;
+
+	/* Map the named MMIO region */
+	DEVICE_MMIO_NAMED_MAP(dev, reg, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
 
 	config->irq_config_func(dev);
 
@@ -191,7 +201,7 @@ static DEVICE_API(wdt, mcux_wdog32_api) = {
 static void mcux_wdog32_config_func_0(const struct device *dev);
 
 static const struct mcux_wdog32_config mcux_wdog32_config_0 = {
-	.base = (WDOG_Type *) DT_INST_REG_ADDR(0),
+	DEVICE_MMIO_NAMED_ROM_INIT(reg, DT_DRV_INST(0)),
 #if DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency)
 	.clock_frequency = DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency),
 #else /* !DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency) */

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -165,11 +165,13 @@ static int mcux_wdog32_feed(const struct device *dev, int channel_id)
 static void mcux_wdog32_isr(const struct device *dev)
 {
 	struct mcux_wdog32_data *data = dev->data;
+#ifndef CONFIG_SOC_MIMX9352
 	WDOG_Type *base = get_base_address(dev);
 	uint32_t flags;
 
 	flags = WDOG32_GetStatusFlags(base);
 	WDOG32_ClearStatusFlags(base, flags);
+#endif
 
 	if (data->callback) {
 		data->callback(dev, 0);

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022,2024 NXP
+ * Copyright 2022, 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -80,6 +80,58 @@
 		compatible = "nxp,imx-ccm-rev2";
 		reg = <0x44450000 DT_SIZE_K(64)>;
 		#clock-cells = <3>;
+
+		ext_clk: ext24m {
+			/* WDOG ext clock: 24MHz */
+			compatible = "fixed-clock";
+			clock-frequency = <24000000>;
+			#clock-cells = <0>;
+		};
+
+		lpo_clk: lpo32k {
+			/* WDOG LPO clock: 32KHz */
+			compatible = "fixed-clock";
+			clock-frequency = <32000>;
+			#clock-cells = <0>;
+		};
+
+		int_clk: int133m {
+			/* WDOG int clock: 133MHz */
+			compatible = "fixed-clock";
+			clock-frequency = <133000000>;
+			#clock-cells = <0>;
+		};
+
+		ipg_clk: ipg133m {
+			/* WDOG ipg clock: 133MHz */
+			compatible = "fixed-clock";
+			clock-frequency = <133000000>;
+			#clock-cells = <0>;
+		};
+	};
+
+	wdog3: watchdog@42490000 {
+		compatible = "nxp,wdog32";
+		reg = <0x42490000 0x1000>;
+		interrupts = <GIC_SPI 79 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		/* clk-source and clocks must aligned: 0-ipg_clk, 1-lpo_clk, 2-int_clk, 3-ext_clk */
+		clocks = <&lpo_clk>;
+		clk-source = <1>;
+		clk-divider = <256>;
+		status = "disabled";
+	};
+
+	wdog4: watchdog@424a0000 {
+		compatible = "nxp,wdog32";
+		reg = <0x424a0000 0x1000>;
+		interrupts = <GIC_SPI 80 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		/* clk-source and clocks must aligned: 0-ipg_clk, 1-lpo_clk, 2-int_clk, 3-ext_clk */
+		clocks = <&lpo_clk>;
+		clk-source = <1>;
+		clk-divider = <256>;
+		status = "disabled";
 	};
 
 	gpio1: gpio@47400000 {

--- a/modules/hal_nxp/mcux/CMakeLists.txt
+++ b/modules/hal_nxp/mcux/CMakeLists.txt
@@ -107,6 +107,8 @@ zephyr_compile_definitions_ifdef(
   I2C_RETRY_TIMES=40000
   )
 
+zephyr_compile_definitions(FSL_SDK_DRIVER_QUICK_ACCESS_DISABLE)
+
 # note: if FSL_IRQSTEER_ENABLE_MASTER_INT is not
 # defined then it will automatically be defined
 # and set to 1 via fsl_irqsteer.h

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 59cf3dc87b41a0e89974d215174a1ca2ab6d4ac5
+      revision: 54f8ccc592f499f63fedc39485be363df8a90c35
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Enable watchdog on i.MX 93 EVK and FRDM board.
Depend on https://github.com/zephyrproject-rtos/hal_nxp/pull/605