### PR TITLE
Bluetooth: BAP: Bap conn checks

### DIFF
--- a/subsys/bluetooth/audio/bap_iso.c
+++ b/subsys/bluetooth/audio/bap_iso.c
@@ -240,6 +240,7 @@ static bool is_unicast_client_ep(struct bt_bap_ep *ep)
 
 void bt_bap_iso_bind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep)
 {
+	const struct bt_bap_ep *paired_ep;
 	struct bt_bap_iso_dir *iso_dir;
 
 	__ASSERT_NO_MSG(ep != NULL);
@@ -255,6 +256,15 @@ void bt_bap_iso_bind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep)
 	iso_dir->ep = ep;
 
 	ep->iso = bt_bap_iso_ref(iso);
+
+	paired_ep = bt_bap_iso_get_paired_ep(ep);
+	if (paired_ep != NULL && paired_ep->stream != NULL && paired_ep->stream->conn != NULL &&
+	    ep->stream != NULL && ep->stream->conn != NULL) {
+		__ASSERT(paired_ep->stream->conn == ep->stream->conn,
+			 "Cannot bind ep %p with conn %p to iso %p with paired_ep %p with "
+			 "different conn %p",
+			 ep, ep->stream->conn, iso, paired_ep, paired_ep->stream->conn);
+	}
 }
 
 void bt_bap_iso_unbind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep)

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -631,11 +631,30 @@ int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, str
 		return -EBADMSG;
 	}
 
+	if (ep->stream != NULL) {
+		LOG_DBG("Endpoint %p already configured for stream %p", ep, stream);
+
+		return -EINVAL;
+	}
+	__ASSERT(ep->iso == NULL, "endpoint %p already bound to iso %p", ep, ep->iso);
+
 	bt_bap_stream_attach(conn, stream, ep, codec_cfg);
+
+	/* If a stream has been added to a group at this point, then it has a reference to a CIS.
+	 * and we can bind the ep to the CIS
+	 */
+	if (stream->iso != NULL) {
+		struct bt_bap_iso *bap_iso = CONTAINER_OF(stream->iso, struct bt_bap_iso, chan);
+
+		/* Not yet bound with the bap_iso */
+		bt_bap_iso_bind_ep(bap_iso, ep);
+	}
 
 	err = bt_bap_unicast_client_config(stream, codec_cfg);
 	if (err != 0) {
 		LOG_DBG("Failed to configure stream: %d", err);
+
+		bt_bap_stream_reset(stream);
 		return err;
 	}
 

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -3454,14 +3454,6 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 
 		op->num_ases++;
 
-		if (stream->ep->iso == NULL) {
-			struct bt_bap_iso *bap_iso =
-				CONTAINER_OF(stream->iso, struct bt_bap_iso, chan);
-
-			/* Not yet bound with the bap_iso */
-			bt_bap_iso_bind_ep(bap_iso, stream->ep);
-		}
-
 		err = bt_bap_unicast_client_ep_qos(stream->ep, buf, stream->qos);
 		if (err != 0) {
 			audio_stream_qos_cleanup(conn, group);

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -3356,6 +3356,8 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 	sink_pd = group->sink_pd;
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
+		const struct bt_bap_ep *paired_ep;
+
 		if (stream->conn != conn) {
 			/* Channel not part of this ACL, skip */
 			continue;
@@ -3364,6 +3366,17 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 		ep = stream->ep;
 		if (ep == NULL) {
 			LOG_DBG("stream->ep is NULL");
+			return -EINVAL;
+		}
+
+		paired_ep = bt_bap_iso_get_paired_ep(ep);
+		if (paired_ep != NULL && paired_ep->stream != NULL &&
+		    paired_ep->stream->conn != NULL && paired_ep->stream->conn != stream->conn) {
+			LOG_DBG("Misconfigured group %p: Stream %p has endpoint %p for conn %p "
+				"paired with endpoint %p for conn %p",
+				group, stream, ep, stream->conn, paired_ep,
+				paired_ep->stream->conn);
+
 			return -EINVAL;
 		}
 

--- a/tests/bluetooth/audio/cap_initiator/src/test_common.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_common.c
@@ -48,6 +48,7 @@ void test_unicast_set_state(struct bt_cap_stream *cap_stream, struct bt_conn *co
 			    enum bt_bap_ep_state state)
 {
 	struct bt_bap_stream *bap_stream = &cap_stream->bap_stream;
+	int err;
 
 	printk("Setting stream %p to state %d\n", bap_stream, state);
 
@@ -59,6 +60,9 @@ void test_unicast_set_state(struct bt_cap_stream *cap_stream, struct bt_conn *co
 	zassert_not_null(conn);
 	zassert_not_null(ep);
 	zassert_not_null(preset);
+
+	err = bt_bap_stream_config(conn, &cap_stream->bap_stream, ep, &preset->codec_cfg);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	bap_stream->conn = conn;
 	bap_stream->ep = ep;

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
@@ -7,17 +7,22 @@
  */
 
 #include <errno.h>
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
 #include <zephyr/fff.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <sys/errno.h>
@@ -34,8 +39,10 @@
 struct cap_initiator_test_unicast_start_fixture {
 	struct bt_cap_stream cap_streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
 	struct bt_bap_ep eps[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
-	struct bt_bap_iso bap_iso[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
-	struct bt_bap_unicast_group unicast_group;
+	struct bt_cap_unicast_audio_start_stream_param
+		audio_start_stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
+	struct bt_cap_unicast_audio_start_param audio_start_param;
+	struct bt_cap_unicast_group *unicast_group;
 	struct bt_conn conns[CONFIG_BT_MAX_CONN];
 	struct bt_bap_lc3_preset preset;
 };
@@ -43,6 +50,15 @@ struct cap_initiator_test_unicast_start_fixture {
 static void cap_initiator_test_unicast_start_fixture_init(
 	struct cap_initiator_test_unicast_start_fixture *fixture)
 {
+	struct bt_cap_unicast_group_stream_pair_param
+		pair_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
+	struct bt_cap_unicast_group_stream_param
+		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
+	struct bt_cap_unicast_group_param group_param = {0};
+	size_t stream_cnt = 0U;
+	size_t pair_cnt = 0U;
+	int err;
+
 	fixture->preset = (struct bt_bap_lc3_preset)BT_BAP_LC3_UNICAST_PRESET_16_2_1(
 		BT_AUDIO_LOCATION_MONO_AUDIO, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
 
@@ -50,17 +66,53 @@ static void cap_initiator_test_unicast_start_fixture_init(
 		test_conn_init(&fixture->conns[i]);
 	}
 
-	for (size_t i = 0U; i < ARRAY_SIZE(fixture->cap_streams); i++) {
-		struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-
-		sys_slist_append(&fixture->unicast_group.streams, &bap_stream->_node);
-		bap_stream->group = &fixture->unicast_group;
-	}
-
 	for (size_t i = 0U; i < ARRAY_SIZE(fixture->eps); i++) {
-		fixture->eps[i].dir = (i & 1) + 1; /* Makes it either 1 or 2 (sink or source)*/
-		fixture->eps[i].iso = &fixture->bap_iso[i];
+		const uint8_t dir = (i & 1) + 1; /* Makes it either 1 or 2 (sink or source)*/
+
+		fixture->eps[i].dir = dir;
 	}
+
+	while (stream_cnt < ARRAY_SIZE(stream_params)) {
+		stream_params[stream_cnt].stream = &fixture->cap_streams[stream_cnt];
+		stream_params[stream_cnt].qos_cfg = &fixture->preset.qos;
+
+		/* Switch between sink and source depending on index*/
+		if ((stream_cnt & 1) == 0) {
+			pair_params[pair_cnt].tx_param = &stream_params[stream_cnt];
+		} else {
+			pair_params[pair_cnt].rx_param = &stream_params[stream_cnt];
+		}
+
+		pair_cnt = DIV_ROUND_UP(stream_cnt, 2U);
+		stream_cnt++;
+	}
+
+	group_param.packing = BT_ISO_PACKING_SEQUENTIAL;
+	group_param.params_count = pair_cnt;
+	group_param.params = pair_params;
+
+	err = bt_cap_unicast_group_create(&group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	/* Setup default params */
+	ARRAY_FOR_EACH(fixture->audio_start_stream_params, i) {
+		struct bt_cap_unicast_audio_start_stream_param *stream_param =
+			&fixture->audio_start_stream_params[i];
+		/* We pair 2 streams, so only increase conn_index every 2nd stream and otherwise
+		 * round robin on all conns
+		 */
+		const size_t conn_index = (i / 2) % ARRAY_SIZE(fixture->conns);
+
+		stream_param->stream = &fixture->cap_streams[i];
+		stream_param->codec_cfg = &fixture->preset.codec_cfg;
+		/* Distribute the streams equally among the connections */
+		stream_param->member.member = &fixture->conns[conn_index];
+		stream_param->ep = &fixture->eps[i];
+	}
+
+	fixture->audio_start_param.type = BT_CAP_SET_TYPE_AD_HOC;
+	fixture->audio_start_param.count = CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT;
+	fixture->audio_start_param.stream_params = fixture->audio_start_stream_params;
 }
 
 static void *cap_initiator_test_unicast_start_setup(void)
@@ -75,9 +127,10 @@ static void *cap_initiator_test_unicast_start_setup(void)
 
 static void cap_initiator_test_unicast_start_before(void *f)
 {
+	struct cap_initiator_test_unicast_start_fixture *fixture = f;
 	int err;
 
-	memset(f, 0, sizeof(struct cap_initiator_test_unicast_start_fixture));
+	(void)memset(fixture, 0, sizeof(*fixture));
 	cap_initiator_test_unicast_start_fixture_init(f);
 
 	err = bt_cap_initiator_register_cb(&mock_cap_initiator_cb);
@@ -96,6 +149,24 @@ static void cap_initiator_test_unicast_start_after(void *f)
 
 	/* In the case of a test failing, we cancel the procedure so that subsequent won't fail */
 	bt_cap_initiator_unicast_audio_cancel();
+
+	if (fixture->unicast_group != NULL) {
+		struct bt_cap_stream
+			*cap_stream_ptrs[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
+		const struct bt_cap_unicast_audio_stop_param param = {
+			.type = BT_CAP_SET_TYPE_AD_HOC,
+			.count = ARRAY_SIZE(fixture->cap_streams),
+			.streams = cap_stream_ptrs,
+			.release = true,
+		};
+
+		ARRAY_FOR_EACH(cap_stream_ptrs, idx) {
+			cap_stream_ptrs[idx] = &fixture->cap_streams[idx];
+		}
+
+		(void)bt_cap_initiator_unicast_audio_stop(&param);
+		(void)bt_cap_unicast_group_delete(fixture->unicast_group);
+	}
 }
 
 static void cap_initiator_test_unicast_start_teardown(void *f)
@@ -109,24 +180,9 @@ ZTEST_SUITE(cap_initiator_test_unicast_start, NULL, cap_initiator_test_unicast_s
 
 static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start)
 {
-	struct bt_cap_unicast_audio_start_stream_param
-		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(stream_params),
-		.stream_params = stream_params,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
-		stream_params[i].stream = &fixture->cap_streams[i];
-		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
-		/* Distribute the streams equally among the connections */
-		stream_params[i].member.member = &fixture->conns[i % ARRAY_SIZE(fixture->conns)];
-		stream_params[i].ep = &fixture->eps[i];
-	}
-
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
@@ -137,7 +193,7 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start)
 	zassert_equal_ptr(NULL, mock_cap_initiator_unicast_start_complete_cb_fake.arg1_history[0],
 			  "%p", mock_cap_initiator_unicast_start_complete_cb_fake.arg1_history[0]);
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
@@ -160,14 +216,11 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_in
 static ZTEST_F(cap_initiator_test_unicast_start,
 	       test_initiator_unicast_start_inval_param_null_param)
 {
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT,
-		.stream_params = NULL,
-	};
 	int err;
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	fixture->audio_start_param.stream_params = NULL;
+
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 0,
@@ -177,22 +230,11 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 static ZTEST_F(cap_initiator_test_unicast_start,
 	       test_initiator_unicast_start_inval_param_null_member)
 {
-	struct bt_cap_unicast_audio_start_stream_param
-		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(stream_params),
-		.stream_params = stream_params,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
-		stream_params[i].stream = &fixture->cap_streams[i];
-		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
-		stream_params[i].ep = &fixture->eps[i];
-	}
+	fixture->audio_start_stream_params[0].member.member = NULL;
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 0,
@@ -201,23 +243,11 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 
 static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_inval_missing_cas)
 {
-	struct bt_cap_unicast_audio_start_stream_param
-		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_CSIP, /* CSIP requires CAS */
-		.count = ARRAY_SIZE(stream_params),
-		.stream_params = stream_params,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
-		stream_params[i].stream = &fixture->cap_streams[i];
-		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
-		stream_params[i].member.member = &fixture->conns[i % ARRAY_SIZE(fixture->conns)];
-		stream_params[i].ep = &fixture->eps[i];
-	}
+	fixture->audio_start_param.type = BT_CAP_SET_TYPE_CSIP; /* CSIP requires CAS */
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 0,
@@ -227,23 +257,11 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_in
 static ZTEST_F(cap_initiator_test_unicast_start,
 	       test_initiator_unicast_start_inval_param_zero_count)
 {
-	struct bt_cap_unicast_audio_start_stream_param
-		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = 0U,
-		.stream_params = stream_params,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
-		stream_params[i].stream = &fixture->cap_streams[i];
-		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
-		stream_params[i].member.member = &fixture->conns[i % ARRAY_SIZE(fixture->conns)];
-		stream_params[i].ep = &fixture->eps[i];
-	}
+	fixture->audio_start_param.count = 0U;
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 0,
@@ -253,23 +271,11 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 static ZTEST_F(cap_initiator_test_unicast_start,
 	       test_initiator_unicast_start_inval_param_inval_count)
 {
-	struct bt_cap_unicast_audio_start_stream_param
-		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT + 1U,
-		.stream_params = stream_params,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
-		stream_params[i].stream = &fixture->cap_streams[i];
-		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
-		stream_params[i].member.member = &fixture->conns[i % ARRAY_SIZE(fixture->conns)];
-		stream_params[i].ep = &fixture->eps[i];
-	}
+	fixture->audio_start_param.count = CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT + 1U;
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 0,
@@ -279,20 +285,11 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 static ZTEST_F(cap_initiator_test_unicast_start,
 	       test_initiator_unicast_start_inval_param_inval_stream_param_null_stream)
 {
-	struct bt_cap_unicast_audio_start_stream_param stream_param = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = 1,
-		.stream_params = &stream_param,
-	};
 	int err;
 
-	stream_param.stream = NULL;
-	stream_param.codec_cfg = &fixture->preset.codec_cfg;
-	stream_param.member.member = &fixture->conns[0];
-	stream_param.ep = &fixture->eps[0];
+	fixture->audio_start_stream_params[0].stream = NULL;
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 0,
@@ -302,20 +299,11 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 static ZTEST_F(cap_initiator_test_unicast_start,
 	       test_initiator_unicast_start_inval_param_inval_stream_param_null_codec_cfg)
 {
-	struct bt_cap_unicast_audio_start_stream_param stream_param = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = 1,
-		.stream_params = &stream_param,
-	};
 	int err;
 
-	stream_param.stream = &fixture->cap_streams[0];
-	stream_param.codec_cfg = NULL;
-	stream_param.member.member = &fixture->conns[0];
-	stream_param.ep = &fixture->eps[0];
+	fixture->audio_start_stream_params[0].codec_cfg = NULL;
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 0,
@@ -325,20 +313,11 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 static ZTEST_F(cap_initiator_test_unicast_start,
 	       test_initiator_unicast_start_inval_param_inval_stream_param_null_member)
 {
-	struct bt_cap_unicast_audio_start_stream_param stream_param = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = 1,
-		.stream_params = &stream_param,
-	};
 	int err;
 
-	stream_param.stream = &fixture->cap_streams[0];
-	stream_param.codec_cfg = &fixture->preset.codec_cfg;
-	stream_param.member.member = NULL;
-	stream_param.ep = &fixture->eps[0];
+	fixture->audio_start_stream_params[0].member.member = NULL;
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 0,
@@ -348,20 +327,11 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 static ZTEST_F(cap_initiator_test_unicast_start,
 	       test_initiator_unicast_start_inval_param_inval_stream_param_null_ep)
 {
-	struct bt_cap_unicast_audio_start_stream_param stream_param = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = 1,
-		.stream_params = &stream_param,
-	};
 	int err;
 
-	stream_param.stream = &fixture->cap_streams[0];
-	stream_param.codec_cfg = &fixture->preset.codec_cfg;
-	stream_param.member.member = &fixture->conns[0];
-	stream_param.ep = NULL;
+	fixture->audio_start_stream_params[0].ep = NULL;
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 0,
@@ -371,24 +341,14 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 static ZTEST_F(cap_initiator_test_unicast_start,
 	       test_initiator_unicast_start_inval_param_inval_stream_param_invalid_meta)
 {
-	struct bt_cap_unicast_audio_start_stream_param stream_param = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = 1,
-		.stream_params = &stream_param,
-	};
 	int err;
 
-	stream_param.stream = &fixture->cap_streams[0];
-	stream_param.codec_cfg = &fixture->preset.codec_cfg;
-	stream_param.member.member = &fixture->conns[0];
-	stream_param.ep = &fixture->eps[0];
-
 	/* CAP requires stream context - Let's remove it */
-	memset(stream_param.codec_cfg->meta, 0, sizeof(stream_param.codec_cfg->meta));
-	stream_param.codec_cfg->meta_len = 0U;
+	(void)memset(fixture->audio_start_stream_params[0].codec_cfg->meta, 0,
+		     sizeof(fixture->audio_start_stream_params[0].codec_cfg->meta));
+	fixture->audio_start_stream_params[0].codec_cfg->meta_len = 0U;
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 0,
@@ -398,27 +358,15 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 static ZTEST_F(cap_initiator_test_unicast_start,
 	       test_initiator_unicast_start_state_codec_configured)
 {
-	struct bt_cap_unicast_audio_start_stream_param
-		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(stream_params),
-		.stream_params = stream_params,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
-		stream_params[i].stream = &fixture->cap_streams[i];
-		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
-		stream_params[i].member.member = &fixture->conns[i % ARRAY_SIZE(fixture->conns)];
-		stream_params[i].ep = &fixture->eps[i];
-
-		test_unicast_set_state(stream_params[i].stream, stream_params[i].member.member,
-				       stream_params[i].ep, &fixture->preset,
+	ARRAY_FOR_EACH_PTR(fixture->audio_start_stream_params, stream_param) {
+		test_unicast_set_state(stream_param->stream, stream_param->member.member,
+				       stream_param->ep, &fixture->preset,
 				       BT_BAP_EP_STATE_CODEC_CONFIGURED);
 	}
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
@@ -428,7 +376,7 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 	zassert_equal_ptr(NULL, mock_cap_initiator_unicast_start_complete_cb_fake.arg1_history[0],
 			  "%p", mock_cap_initiator_unicast_start_complete_cb_fake.arg1_history[0]);
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
@@ -439,27 +387,15 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 
 static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_state_qos_configured)
 {
-	struct bt_cap_unicast_audio_start_stream_param
-		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(stream_params),
-		.stream_params = stream_params,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
-		stream_params[i].stream = &fixture->cap_streams[i];
-		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
-		stream_params[i].member.member = &fixture->conns[i % ARRAY_SIZE(fixture->conns)];
-		stream_params[i].ep = &fixture->eps[i];
-
-		test_unicast_set_state(stream_params[i].stream, stream_params[i].member.member,
-				       stream_params[i].ep, &fixture->preset,
+	ARRAY_FOR_EACH_PTR(fixture->audio_start_stream_params, stream_param) {
+		test_unicast_set_state(stream_param->stream, stream_param->member.member,
+				       stream_param->ep, &fixture->preset,
 				       BT_BAP_EP_STATE_QOS_CONFIGURED);
 	}
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
@@ -469,7 +405,7 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 	zassert_equal_ptr(NULL, mock_cap_initiator_unicast_start_complete_cb_fake.arg1_history[0],
 			  "%p", mock_cap_initiator_unicast_start_complete_cb_fake.arg1_history[0]);
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
@@ -480,27 +416,15 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 
 static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_state_enabling)
 {
-	struct bt_cap_unicast_audio_start_stream_param
-		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(stream_params),
-		.stream_params = stream_params,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
-		stream_params[i].stream = &fixture->cap_streams[i];
-		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
-		stream_params[i].member.member = &fixture->conns[i % ARRAY_SIZE(fixture->conns)];
-		stream_params[i].ep = &fixture->eps[i];
-
-		test_unicast_set_state(stream_params[i].stream, stream_params[i].member.member,
-				       stream_params[i].ep, &fixture->preset,
+	ARRAY_FOR_EACH_PTR(fixture->audio_start_stream_params, stream_param) {
+		test_unicast_set_state(stream_param->stream, stream_param->member.member,
+				       stream_param->ep, &fixture->preset,
 				       BT_BAP_EP_STATE_ENABLING);
 	}
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
@@ -510,7 +434,7 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 	zassert_equal_ptr(NULL, mock_cap_initiator_unicast_start_complete_cb_fake.arg1_history[0],
 			  "%p", mock_cap_initiator_unicast_start_complete_cb_fake.arg1_history[0]);
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
@@ -521,33 +445,21 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 
 static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_state_streaming)
 {
-	struct bt_cap_unicast_audio_start_stream_param
-		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_start_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(stream_params),
-		.stream_params = stream_params,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
-		stream_params[i].stream = &fixture->cap_streams[i];
-		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
-		stream_params[i].member.member = &fixture->conns[i % ARRAY_SIZE(fixture->conns)];
-		stream_params[i].ep = &fixture->eps[i];
-
-		test_unicast_set_state(stream_params[i].stream, stream_params[i].member.member,
-				       stream_params[i].ep, &fixture->preset,
+	ARRAY_FOR_EACH_PTR(fixture->audio_start_stream_params, stream_param) {
+		test_unicast_set_state(stream_param->stream, stream_param->member.member,
+				       stream_param->ep, &fixture->preset,
 				       BT_BAP_EP_STATE_STREAMING);
 	}
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&fixture->audio_start_param);
 	zassert_equal(err, -EALREADY, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 0,
 			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);
 
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
 

--- a/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
@@ -15,8 +15,10 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/iso.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/ztest_assert.h>
 #include <sys/errno.h>
 
@@ -369,6 +371,168 @@ int bt_bap_unicast_client_register_cb(struct bt_bap_unicast_client_cb *cb)
 	return 0;
 }
 
+struct bt_bap_iso *bt_bap_unicast_client_new_audio_iso(void)
+{
+	static struct bt_iso_chan_ops unicast_client_iso_ops;
+	struct bt_bap_iso *bap_iso;
+
+	bap_iso = bt_bap_iso_new();
+	if (bap_iso == NULL) {
+		return NULL;
+	}
+
+	bt_bap_iso_init(bap_iso, &unicast_client_iso_ops);
+
+	return bap_iso;
+}
+
+static int unicast_group_add_iso(struct bt_bap_unicast_group *group, struct bt_bap_iso *iso)
+{
+	struct bt_iso_chan **chan_slot = NULL;
+
+	__ASSERT_NO_MSG(group != NULL);
+	__ASSERT_NO_MSG(iso != NULL);
+
+	/* Append iso channel to the group->cis array */
+	for (size_t i = 0U; i < ARRAY_SIZE(group->cis); i++) {
+		/* Return if already there */
+		if (group->cis[i] == &iso->chan) {
+			return 0;
+		}
+
+		if (chan_slot == NULL && group->cis[i] == NULL) {
+			chan_slot = &group->cis[i];
+		}
+	}
+
+	if (chan_slot == NULL) {
+		return -ENOMEM;
+	}
+
+	*chan_slot = &iso->chan;
+
+	return 0;
+}
+
+static void unicast_client_qos_cfg_to_iso_qos(struct bt_bap_iso *iso,
+					      const struct bt_bap_qos_cfg *qos,
+					      enum bt_audio_dir dir)
+{
+	struct bt_iso_chan_io_qos *io_qos;
+	struct bt_iso_chan_io_qos *other_io_qos;
+
+	if (dir == BT_AUDIO_DIR_SINK) {
+		/* If the endpoint is a sink, then we need to
+		 * configure our TX parameters
+		 */
+		io_qos = iso->chan.qos->tx;
+		if (bt_bap_iso_get_ep(true, iso, BT_AUDIO_DIR_SOURCE) == NULL) {
+			other_io_qos = iso->chan.qos->rx;
+		} else {
+			other_io_qos = NULL;
+		}
+	} else {
+		/* If the endpoint is a source, then we need to
+		 * configure our RX parameters
+		 */
+		io_qos = iso->chan.qos->rx;
+		if (bt_bap_iso_get_ep(true, iso, BT_AUDIO_DIR_SINK) == NULL) {
+			other_io_qos = iso->chan.qos->tx;
+		} else {
+			other_io_qos = NULL;
+		}
+	}
+
+	bt_bap_qos_cfg_to_iso_qos(io_qos, qos);
+#if defined(CONFIG_BT_ISO_TEST_PARAMS)
+	iso->chan.qos->num_subevents = qos->num_subevents;
+#endif /* CONFIG_BT_ISO_TEST_PARAMS */
+
+	if (other_io_qos != NULL) {
+		/* If the opposing ASE of the CIS is not yet configured, we
+		 * still need to set the PHY value when creating the CIG.
+		 */
+		other_io_qos->phy = io_qos->phy;
+	}
+}
+
+static void unicast_group_set_iso_stream_param(struct bt_bap_unicast_group *group,
+					       struct bt_bap_iso *iso, struct bt_bap_qos_cfg *qos,
+					       enum bt_audio_dir dir)
+{
+	/* Store the stream Codec QoS in the bap_iso */
+	unicast_client_qos_cfg_to_iso_qos(iso, qos, dir);
+
+	/* Store the group Codec QoS in the group - This assumes thats the parameters have been
+	 * verified first
+	 */
+	group->cig_param.framing = qos->framing;
+	if (dir == BT_AUDIO_DIR_SOURCE) {
+		group->cig_param.p_to_c_interval = qos->interval;
+		group->cig_param.p_to_c_latency = qos->latency;
+	} else {
+		group->cig_param.c_to_p_interval = qos->interval;
+		group->cig_param.c_to_p_latency = qos->latency;
+	}
+}
+
+static void unicast_group_add_stream(struct bt_bap_unicast_group *group,
+				     struct bt_bap_unicast_group_stream_param *param,
+				     struct bt_bap_iso *iso, enum bt_audio_dir dir)
+{
+	struct bt_bap_stream *stream = param->stream;
+	struct bt_bap_qos_cfg *qos = param->qos;
+
+	__ASSERT_NO_MSG(stream->ep == NULL || (stream->ep != NULL && stream->ep->iso == NULL));
+
+	stream->qos = qos;
+	stream->group = group;
+
+	/* iso initialized already */
+	bt_bap_iso_bind_stream(iso, stream, dir);
+	if (stream->ep != NULL) {
+		bt_bap_iso_bind_ep(iso, stream->ep);
+	}
+
+	unicast_group_set_iso_stream_param(group, iso, qos, dir);
+
+	sys_slist_append(&group->streams, &stream->_node);
+}
+
+static int unicast_group_add_stream_pair(struct bt_bap_unicast_group *group,
+					 struct bt_bap_unicast_group_stream_pair_param *param)
+{
+	struct bt_bap_iso *iso;
+	int err;
+
+	__ASSERT_NO_MSG(group != NULL);
+	__ASSERT_NO_MSG(param != NULL);
+	__ASSERT_NO_MSG(param->rx_param != NULL || param->tx_param != NULL);
+
+	iso = bt_bap_unicast_client_new_audio_iso();
+	if (iso == NULL) {
+		return -ENOMEM;
+	}
+
+	err = unicast_group_add_iso(group, iso);
+	if (err < 0) {
+		bt_bap_iso_unref(iso);
+		return err;
+	}
+
+	if (param->rx_param != NULL) {
+		unicast_group_add_stream(group, param->rx_param, iso, BT_AUDIO_DIR_SOURCE);
+	}
+
+	if (param->tx_param != NULL) {
+		unicast_group_add_stream(group, param->tx_param, iso, BT_AUDIO_DIR_SINK);
+	}
+
+	bt_bap_iso_unref(iso);
+
+	return 0;
+}
+
 int bt_bap_unicast_group_create(struct bt_bap_unicast_group_param *param,
 				struct bt_bap_unicast_group **unicast_group)
 {
@@ -381,25 +545,13 @@ int bt_bap_unicast_group_create(struct bt_bap_unicast_group_param *param,
 
 	sys_slist_init(&bap_unicast_group.streams);
 	for (size_t i = 0U; i < param->params_count; i++) {
-		if (param->params[i].rx_param != NULL) {
-			sys_slist_append(&bap_unicast_group.streams,
-					 &param->params[i].rx_param->stream->_node);
-		}
+		struct bt_bap_unicast_group_stream_pair_param *stream_param;
+		int err;
 
-		if (param->params[i].tx_param != NULL) {
-			sys_slist_append(&bap_unicast_group.streams,
-					 &param->params[i].tx_param->stream->_node);
-		}
-	}
+		stream_param = &param->params[i];
 
-	return 0;
-}
-
-int bt_bap_unicast_group_reconfig(struct bt_bap_unicast_group *unicast_group,
-				  const struct bt_bap_unicast_group_param *param)
-{
-	if (unicast_group == NULL || param == NULL) {
-		return -EINVAL;
+		err = unicast_group_add_stream_pair(*unicast_group, stream_param);
+		__ASSERT(err == 0, "%d", err);
 	}
 
 	return 0;
@@ -428,19 +580,54 @@ int bt_bap_unicast_group_add_streams(struct bt_bap_unicast_group *unicast_group,
 	return 0;
 }
 
-int bt_bap_unicast_group_delete(struct bt_bap_unicast_group *unicast_group)
+int bt_bap_unicast_group_reconfig(struct bt_bap_unicast_group *unicast_group,
+				  const struct bt_bap_unicast_group_param *param)
+{
+	if (unicast_group == NULL || param == NULL) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static void unicast_group_free(struct bt_bap_unicast_group *group)
 {
 	struct bt_bap_stream *stream, *next;
 
+	__ASSERT_NO_MSG(group != NULL);
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&group->streams, stream, next, _node) {
+		struct bt_bap_iso *bap_iso = CONTAINER_OF(stream->iso, struct bt_bap_iso, chan);
+		struct bt_bap_ep *ep = stream->ep;
+
+		stream->group = NULL;
+		if (bap_iso != NULL) {
+			if (bap_iso->rx.stream == stream) {
+				bt_bap_iso_unbind_stream(stream, BT_AUDIO_DIR_SOURCE);
+			} else if (bap_iso->tx.stream == stream) {
+				bt_bap_iso_unbind_stream(stream, BT_AUDIO_DIR_SINK);
+			} else {
+				__ASSERT_PRINT("stream %p has invalid bap_iso %p", stream, bap_iso);
+			}
+		}
+
+		if (ep != NULL && ep->iso != NULL) {
+			bt_bap_iso_unbind_ep(ep->iso, ep);
+		}
+
+		sys_slist_remove(&group->streams, NULL, &stream->_node);
+	}
+
+	group->allocated = false;
+}
+
+int bt_bap_unicast_group_delete(struct bt_bap_unicast_group *unicast_group)
+{
 	if (unicast_group == NULL) {
 		return -EINVAL;
 	}
 
-	unicast_group->allocated = false;
-
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&unicast_group->streams, stream, next, _node) {
-		sys_slist_remove(&unicast_group->streams, NULL, &stream->_node);
-	}
+	unicast_group_free(unicast_group);
 
 	return 0;
 }


### PR DESCRIPTION
Add additional checks to ensure that 2 endpoints sharing the same CIS also share the same connection (the CIS does not yet have a connection at this point, so the stream->conn is used for this). 