### PR TITLE
MAINTAINERS: Add NhMchp as hal microchip maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5367,6 +5367,7 @@ West:
     - AzharMCHP
     - scottwcpg
     - nandojve
+    - NhMchp
   collaborators:
     - VenkatKotakonda
     - albertofloyd


### PR DESCRIPTION
Add NhMchp to the list of hal_microchip maintainers.