### PR TITLE
AMP rpmsg samples fix

### DIFF
--- a/samples/subsys/ipc/rpmsg_service/CMakeLists.txt
+++ b/samples/subsys/ipc/rpmsg_service/CMakeLists.txt
@@ -15,9 +15,4 @@ message(STATUS "${BOARD} compile as Master in this sample")
 
 enable_language(C ASM)
 
-if("${BOARD}" STREQUAL "esp32_devkitc" OR "${BOARD}" STREQUAL "esp32s3_devkitm")
-  set_source_files_properties(${REMOTE_ZEPHYR_DIR}/esp32_net_firmware.c PROPERTIES GENERATED TRUE)
-  target_sources(app PRIVATE src/main.c ${REMOTE_ZEPHYR_DIR}/esp32_net_firmware.c)
-else()
-  target_sources(app PRIVATE src/main.c)
-endif()
+target_sources(app PRIVATE src/main.c)

--- a/samples/subsys/ipc/rpmsg_service/Kconfig
+++ b/samples/subsys/ipc/rpmsg_service/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config RPMSG_SERVICE_DEMO_CYCLES
+	int "Number of demo message cycles"
+	default 1000
+	range 10 10000
+
+config MAIN_APP_TASK_STACK_SIZE
+	int "Main application task size"
+	default 1024

--- a/samples/subsys/ipc/rpmsg_service/Kconfig.sysbuild
+++ b/samples/subsys/ipc/rpmsg_service/Kconfig.sysbuild
@@ -9,3 +9,5 @@ config RPMSG_REMOTE_BOARD
 	default "mps2/an521/cpu1" if $(BOARD) = "mps2"
 	default "v2m_musca_b1/musca_b1/ns" if $(BOARD) = "v2m_musca_b1"
 	default "stm32h747i_disco/stm32h747xx/m4" if $(BOARD) = "stm32h747i_disco"
+	default "esp32_devkitc/esp32/appcpu" if $(BOARD) = "esp32_devkitc"
+	default "esp32s3_devkitc/esp32s3/appcpu" if $(BOARD) = "esp32s3_devkitc"

--- a/samples/subsys/ipc/rpmsg_service/remote/Kconfig
+++ b/samples/subsys/ipc/rpmsg_service/remote/Kconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+source "samples/subsys/ipc/rpmsg_service/Kconfig"
+
+config APP_REMOTE_TASK_STACK_SIZE
+	int "Remote application task size"
+	default 2048 if SOC_SERIES_ESP32
+	default 1024

--- a/samples/subsys/ipc/rpmsg_service/remote/socs/esp32_procpu.overlay
+++ b/samples/subsys/ipc/rpmsg_service/remote/socs/esp32_procpu.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ipc_shm = &shm0;
+		zephyr,ipc = &ipm0;
+	};
+};
+
+&ipm0 {
+	status = "okay";
+};

--- a/samples/subsys/ipc/rpmsg_service/remote/socs/esp32s3_procpu.overlay
+++ b/samples/subsys/ipc/rpmsg_service/remote/socs/esp32s3_procpu.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ipc_shm = &shm0;
+		zephyr,ipc = &ipm0;
+	};
+};
+
+&ipm0 {
+	status = "okay";
+};

--- a/samples/subsys/ipc/rpmsg_service/sample.yaml
+++ b/samples/subsys/ipc/rpmsg_service/sample.yaml
@@ -5,6 +5,8 @@ tests:
     platform_allow:
       - mps2/an521/cpu0
       - v2m_musca_b1/musca_b1
+      - esp32_devkitc/esp32/procpu
+      - esp32s3_devkitc/esp32s3/procpu
     integration_platforms:
       - mps2/an521/cpu0
       - v2m_musca_b1/musca_b1

--- a/samples/subsys/ipc/rpmsg_service/socs/esp32_procpu.overlay
+++ b/samples/subsys/ipc/rpmsg_service/socs/esp32_procpu.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ipc_shm = &shm0;
+		zephyr,ipc = &ipm0;
+	};
+};
+
+&ipm0 {
+	status = "okay";
+};

--- a/samples/subsys/ipc/rpmsg_service/socs/esp32s3_procpu.overlay
+++ b/samples/subsys/ipc/rpmsg_service/socs/esp32s3_procpu.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ipc_shm = &shm0;
+		zephyr,ipc = &ipm0;
+	};
+};
+
+&ipm0 {
+	status = "okay";
+};

--- a/samples/subsys/ipc/rpmsg_service/src/main.c
+++ b/samples/subsys/ipc/rpmsg_service/src/main.c
@@ -17,18 +17,16 @@
 
 #include <zephyr/ipc/rpmsg_service.h>
 
-#define APP_TASK_STACK_SIZE (1024)
-K_THREAD_STACK_DEFINE(thread_stack, APP_TASK_STACK_SIZE);
+K_THREAD_STACK_DEFINE(thread_stack, CONFIG_MAIN_APP_TASK_STACK_SIZE);
 static struct k_thread thread_data;
 
 static volatile unsigned int received_data;
 
 static K_SEM_DEFINE(data_rx_sem, 0, 1);
 
-int endpoint_cb(struct rpmsg_endpoint *ept, void *data,
-		size_t len, uint32_t src, void *priv)
+int endpoint_cb(struct rpmsg_endpoint *ept, void *data, size_t len, uint32_t src, void *priv)
 {
-	received_data = *((unsigned int *) data);
+	received_data = *((unsigned int *)data);
 
 	k_sem_give(&data_rx_sem);
 
@@ -68,11 +66,10 @@ void app_task(void *arg1, void *arg2, void *arg3)
 		k_sleep(K_MSEC(1));
 	}
 
-	while (message < 100) {
+	while (message < CONFIG_RPMSG_SERVICE_DEMO_CYCLES) {
 		status = send_message(message);
 		if (status < 0) {
-			printk("send_message(%d) failed with status %d\n",
-			       message, status);
+			printk("send_message(%d) failed with status %d\n", message, status);
 			break;
 		}
 
@@ -88,12 +85,10 @@ void app_task(void *arg1, void *arg2, void *arg3)
 int main(void)
 {
 	printk("Starting application thread!\n");
-	k_thread_create(&thread_data, thread_stack, APP_TASK_STACK_SIZE,
-			app_task,
+	k_thread_create(&thread_data, thread_stack, CONFIG_MAIN_APP_TASK_STACK_SIZE, app_task,
 			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
 
-#if defined(CONFIG_SOC_MPS2_AN521) || \
-	defined(CONFIG_SOC_V2M_MUSCA_B1)
+#if defined(CONFIG_SOC_MPS2_AN521) || defined(CONFIG_SOC_V2M_MUSCA_B1)
 	wakeup_cpu1();
 	k_msleep(500);
 #endif /* #if defined(CONFIG_SOC_MPS2_AN521) */

--- a/samples/subsys/ipc/rpmsg_service/sysbuild.cmake
+++ b/samples/subsys/ipc/rpmsg_service/sysbuild.cmake
@@ -13,3 +13,9 @@ ExternalZephyrProject_Add(
   )
 
 add_dependencies(${DEFAULT_IMAGE} rpmsg_service_remote)
+sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} rpmsg_service_remote)
+
+if(SB_CONFIG_BOOTLOADER_MCUBOOT)
+  # Make sure MCUboot is flashed first
+  sysbuild_add_dependencies(FLASH rpmsg_service_remote mcuboot)
+endif()


### PR DESCRIPTION
Fix the Espressif targets with the IPC sample.