### PR TITLE
include: zephyr: net: remove lldp.h build dependency on net_pkt.h

### DIFF
--- a/include/zephyr/net/lldp.h
+++ b/include/zephyr/net/lldp.h
@@ -116,6 +116,7 @@ extern "C" {
 
 
 struct net_if;
+struct net_pkt;
 
 /** @endcond */
 


### PR DESCRIPTION
Declare struct net_pkt in net/lldp.h to prevent build failure when net/net_pkt.h is not included before lldp.h. This is an easier alternate way compared to including net_pkt.h from lldp.h.