### PR TITLE
include: net: lldp.h: Include required headers

### DIFF
--- a/include/zephyr/net/lldp.h
+++ b/include/zephyr/net/lldp.h
@@ -22,6 +22,9 @@
  * @{
  */
 
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_pkt.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
net_if.h and net_pkt.h are 2 headers required by lldp.h as it needs to know net_if and net_pkt structs.

Fixes #96294