### PR TITLE
drivers: WM89xx: fix a dts prop naming issue

### DIFF
--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -671,7 +671,7 @@ static const struct audio_codec_api wm8904_driver_api = {
 #define WM8904_INIT(n)                                                                             \
 	static const struct wm8904_driver_config wm8904_device_config_##n = {                      \
 		.i2c = I2C_DT_SPEC_INST_GET(n),                                                    \
-		.clock_source = DT_INST_PROP_OR(n, clk_source, 0),                                 \
+		.clock_source = DT_INST_ENUM_IDX(n, clock_source),				   \
 		.mclk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_NAME(n, mclk)),                   \
 		.mclk_name = (clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, name)};  \
                                                                                                    \

--- a/drivers/audio/wm8962.c
+++ b/drivers/audio/wm8962.c
@@ -718,7 +718,7 @@ static const struct audio_codec_api wm8962_driver_api = {.configure = wm8962_con
 #define wm8962_INIT(n)                                                                             \
 	static const struct wm8962_driver_config wm8962_device_config_##n = {                      \
 		.i2c = I2C_DT_SPEC_INST_GET(n),                                                    \
-		.clock_source = DT_INST_PROP_OR(n, clk_source, 0),                                 \
+		.clock_source = DT_INST_ENUM_IDX(n, clock_source),                                 \
 		.mclk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_NAME(n, mclk)),                   \
 		.mclk_name = (clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, name)};  \
                                                                                                    \


### PR DESCRIPTION
1. the clock-source is wrongly typed as clk-source, which happen to pass the build and function check.
2. and should use DT_INST_ENUM_IDX for index enumrate as string.