### PR TITLE
ci: compliance: treat LicenseAndCopyrightCheck warnings as ...warnings

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -92,7 +92,7 @@ jobs:
           exit 1;
         fi
 
-        warns=("ClangFormat")
+        warns=("ClangFormat" "LicenseAndCopyrightCheck")
         files=($(./scripts/ci/check_compliance.py -l))
 
         for file in "${files[@]}"; do


### PR DESCRIPTION
Warnings related to the LicenseAndCopyrightCheck should not be blocking.

i've tested the change locally