### PR TITLE
MAINTAINERS: Add boards/intel/btl to Intel Platforms (x86)

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2899,6 +2899,7 @@ Intel Platforms (X86):
     - ceolin
   files:
     - boards/intel/adl/
+    - boards/intel/btl/
     - boards/intel/ehl/
     - boards/intel/rpl/
     - dts/x86/intel/


### PR DESCRIPTION
It helps bots to find reviewers for PRs.