### PR TITLE
drivers: serial: Fix build on NXP LPUART when ASYNCH is enabled

### DIFF
--- a/drivers/serial/Kconfig.mcux_lpuart
+++ b/drivers/serial/Kconfig.mcux_lpuart
@@ -1,6 +1,4 @@
-# MCUXpresso SDK LPUART
-
-# Copyright (c) 2017, NXP
+# Copyright 2017, 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config UART_MCUX_LPUART
@@ -10,7 +8,7 @@ config UART_MCUX_LPUART
 	depends on CLOCK_CONTROL
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
-	select SERIAL_SUPPORT_ASYNC
+	select SERIAL_SUPPORT_ASYNC if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPUART),dmas)
 	select DMA if UART_ASYNC_API
 	select PINCTRL
 	help


### PR DESCRIPTION
ASYNCH implementation in the NXP LPUART driver requires DMA. Add a conditional check to enable this feature only when DMA is neabled.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/96158