### PR TITLE
Allow device-tree compiler know SoC and CPU used

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -248,6 +248,17 @@ if(DEFINED CMAKE_DTS_PREPROCESSOR)
 else()
   set(dts_preprocessor ${CMAKE_C_COMPILER})
 endif()
+if(BOARD_QUALIFIERS MATCHES ".+/.+")
+  string(REPLACE "/" ";" BOARD_QUALIFIERS_LIST "${BOARD_QUALIFIERS}")
+  list(GET BOARD_QUALIFIERS_LIST 1 SOC_NAME)
+  list(GET BOARD_QUALIFIERS_LIST 2 CPU_NAME)
+  string(TOUPPER "${SOC_NAME}" SOC_NAME)
+  string(TOUPPER "${CPU_NAME}" CPU_NAME)
+  list(APPEND DTS_EXTRA_CPPFLAGS
+    "-DDTS_SOC_${SOC_NAME}"
+    "-DDTS_CPU_${CPU_NAME}"
+  )
+endif()
 zephyr_dt_preprocess(
   CPP ${dts_preprocessor}
   SOURCE_FILES ${dts_files}


### PR DESCRIPTION
This pull request introduces logic to automatically extract and use board qualifiers from the `BOARD_QUALIFIERS` variable in CMake. If `BOARD_QUALIFIERS` matches a specific pattern, it splits the value and sets preprocessor flags for the SOC and CPU, making the build process more dynamic and configurable.

Enhancements to board qualifier handling:

* Added logic to detect if `BOARD_QUALIFIERS` contains both SOC and CPU information (in the format `SOC/CPU`), splits them, converts them to uppercase, and appends corresponding preprocessor flags to `DTS_EXTRA_CPPFLAGS`.Allow device-tree compiler know SoC and CPU used.

With this change device-tree compiler will become information about SoC variant and CPU being used during generation of defines from device-tree.
This change is advantageous, because it shall allow usage of C-preprocessor directives within .dts/.dtsi files s.t. following form of includes becomes possible:

```c
#if defined(DTS_CPU_M7)
#include <a/path/to/file/with/cortex_m7_defines>
#endif

// or

#if defined(DTS_SOC_STM32H745XX)
#include <a/path/to/file/with/stm32h745xx_defines>
#elif defined(DTS_SOC_STM32G4XX)
#include <a/path/to/file/with/stm32g4xx_defines>
#endif
```

Testing could be done with similiar patch:


```c
diff --git a/dts/arm/st/h7/stm32h745Xi_m7.dtsi b/dts/arm/st/h7/stm32h745Xi_m7.dtsi
index 0e79c0150f3..bc554307bba 100644
--- a/dts/arm/st/h7/stm32h745Xi_m7.dtsi
+++ b/dts/arm/st/h7/stm32h745Xi_m7.dtsi
@@ -7,6 +7,14 @@
 #include <mem.h>
 #include <st/h7/stm32h745.dtsi>
 
+#if defined(DTS_CPU_M7)
+#warning "Defined DTS_CPU_M7"
+#endif
+
+#if defined(DTS_SOC_STM32H745XX)
+#warning "Defined DTS_SOC_STM32H745XX"
+#endif
+
 /delete-node/ &flash1;
 
 / {
```