### PR TITLE
MAINTAINERS: Fix some orphaned and wrongly assigned NXP files

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3327,15 +3327,16 @@ NXP Platform Drivers:
   files-regex:
     - ^drivers/.*nxp.*
     - ^drivers/.*mcux.*
+    - drivers\/.*[_\/]+lpc[_\.\d]+.*c
   files:
     - drivers/*/*imx*
-    - drivers/*/*lpc*.c
     - drivers/*/*mcux*.c
     - drivers/*/*.mcux
     - drivers/*/*.nxp
     - drivers/*/*nxp*
     - drivers/*/*/*kinetis*
     - drivers/misc/*/nxp*
+    - drivers/sensor/nxp/
     - include/zephyr/dt-bindings/*/*nxp*
     - include/zephyr/dt-bindings/*/*mcux*
     - include/zephyr/dt-bindings/inputmux/
@@ -3343,6 +3344,7 @@ NXP Platform Drivers:
     - include/zephyr/drivers/*/*nxp*
     - include/zephyr/drivers/*/*nxp*/
     - include/zephyr/drivers/*/*mcux*
+    - include/zephyr/drivers/misc/flexram/
     - arch/arm/core/mpu/nxp_mpu.c
     - dts/bindings/*/nxp*
   files-exclude:
@@ -3352,7 +3354,7 @@ NXP Platform Drivers:
   files-regex-exclude:
     - .*s32.*
   labels:
-    - "platform: NXP Drivers"
+    - "platform: NXP"
   description: NXP Drivers
 
 NXP Platform MCUX USB:
@@ -3364,7 +3366,7 @@ NXP Platform MCUX USB:
     - drivers/usb/*/*mcux*
     - boards/nxp/usb_kw24d512/
   labels:
-    - "platform: NXP Drivers"
+    - "platform: NXP"
   description: NXP MCUX USB shim drivers
 
 NXP Platform Wireless:
@@ -3390,7 +3392,7 @@ NXP Platform Wireless:
     - soc/nxp/mcx/mcxw/
     - soc/nxp/rw/
   labels:
-    - "platform: NXP Drivers"
+    - "platform: NXP"
 
 NXP Platforms (MCU):
   status: maintained
@@ -3405,6 +3407,7 @@ NXP Platforms (MCU):
   files:
     - boards/nxp/mimxrt*/
     - boards/nxp/frdm*/
+    - boards/nxp/*mcx*/
     - boards/nxp/lpcxpress*/
     - boards/nxp/twr_*/
     - boards/nxp/*rw*/
@@ -3421,9 +3424,11 @@ NXP Platforms (MCU):
     - samples/boards/nxp*/
   files-exclude:
     - dts/arm/nxp/nxp_imx*
+    - boards/nxp/frdm_imx*/
   files-regex-exclude:
     - .*s32.*
   labels:
+    - "platform: NXP MCU"
     - "platform: NXP"
   description: NXP MCU Platforms supported by MCUXpresso suite
 
@@ -3444,9 +3449,10 @@ NXP Platforms (MPU):
     - soc/nxp/layerscape/
     - boards/nxp/ls1046ardb/
   files-regex:
-    - boards/nxp/m?imx[^(rt)].*/
+    - boards/nxp/.*m?imx[^(rt)].*/
   labels:
     - "platform: NXP MPU"
+    - "platform: NXP"
   description: NXP MPU platforms
 
 NXP Platforms (Robotics Products):
@@ -3461,8 +3467,7 @@ NXP Platforms (Robotics Products):
     - boards/nxp/rddrone_fmuk66/
     - boards/nxp/mr_canhubk3/
     - boards/nxp/ucans32k1sic/
-  labels:
-    - "platform: NXP Robotics"
+    - tests/boards/vmu_rt1170/
   description: NXP Robotics Module Platform Products
 
 NXP Platforms (S32):
@@ -3488,6 +3493,7 @@ NXP Platforms (S32):
     - boards/nxp/ucans32k1sic/
   labels:
     - "platform: NXP S32"
+    - "platform: NXP"
   description: NXP S32 platforms and S32-specific drivers
 
 NXP Platforms (Xtensa):
@@ -3498,13 +3504,13 @@ NXP Platforms (Xtensa):
     - iuliana-prodan
   files:
     - soc/nxp/imx/*/adsp/
-    - soc/nxp/imxrt/imxrt5xx/f1/
-    - soc/nxp/imxrt/imxrt7xx/hifi1/
-    - soc/nxp/imxrt/*/hifi4/
+    - soc/nxp/imxrt/*/f1/
+    - soc/nxp/imxrt/*/hifi*/
     - soc/nxp/imxrt/imxrt[567]xx/CMakeLists.txt
     - soc/nxp/imxrt/imxrt[567]xx/Kconfig*
   labels:
     - "platform: NXP Xtensa"
+    - "platform: NXP"
   description: NXP Xtensa platforms
 
 Native_sim and POSIX arch:


### PR DESCRIPTION
Fix some orphaned NXP files, fix some files being assigned to wrong NXP area, and remove "NXP Drivers" label which is just confusing people, and unify all the main NXP areas under one "platform: NXP" label to make it easier for Zephyr Release Team to simply put the "platform: NXP" on NXP bugs so NXP maintainers can triage from there. Right now the  "platform: NXP" label actually was not meant to mean all NXP issues, it was a poorly named specific NXP area for only some platform, so fix to align expectations.