### PR TITLE
samples: capture: fix a double promotion warning

### DIFF
--- a/samples/drivers/pwm/capture/src/main.c
+++ b/samples/drivers/pwm/capture/src/main.c
@@ -47,8 +47,8 @@ int main(void)
 			width);
 
 		printk("{period: %f Hz duty: %f}\n",
-			(float)tim_clk_cycles / (float)period,
-			(float)(width * 100) / (float)period);
+			(double)tim_clk_cycles / (double)period,
+			(double)(width * 100) / (double)period);
 	}
 
 	return 0;


### PR DESCRIPTION
Fixes

samples/drivers/pwm/capture/src/main.c:50:47: warning: implicit conversion from 'floa' to 'double' when passing argument to function [-Wdouble-promotion]
   50 |                         (float)tim_clk_cycles / (float)period,
      |                         ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
samples/drivers/pwm/capture/src/main.c:51:46: warning: implicit
conversion from 'floa' to 'double' when passing argument to function
[-Wdouble-promotion]
   51 |                         (float)(width * 100) / (float)period);
      |                         ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~