### PR TITLE
timeutil: timespec: mitigate warnings when -Wtype-limits is used

### DIFF
--- a/include/zephyr/sys/timeutil.h
+++ b/include/zephyr/sys/timeutil.h
@@ -415,51 +415,7 @@ static inline bool timespec_is_valid(const struct timespec *ts)
  *
  * @return `true` if the operation completes successfully, otherwise `false`.
  */
-static inline bool timespec_normalize(struct timespec *ts)
-{
-	__ASSERT_NO_MSG(ts != NULL);
-
-	long sec;
-
-	if (ts->tv_nsec >= (long)NSEC_PER_SEC) {
-		sec = ts->tv_nsec / (long)NSEC_PER_SEC;
-	} else if (ts->tv_nsec < 0) {
-		sec = DIV_ROUND_UP((unsigned long)-ts->tv_nsec, NSEC_PER_SEC);
-	} else {
-		sec = 0;
-	}
-
-	if ((ts->tv_nsec < 0) && (ts->tv_sec < 0) && (ts->tv_sec - SYS_TIME_T_MIN < sec)) {
-		/*
-		 * When `tv_nsec` is negative and `tv_sec` is already most negative,
-		 * further subtraction would cause integer overflow.
-		 */
-		return false;
-	}
-
-	if ((ts->tv_nsec >= (long)NSEC_PER_SEC) && (ts->tv_sec > 0) &&
-	    (SYS_TIME_T_MAX - ts->tv_sec < sec)) {
-		/*
-		 * When `tv_nsec` is >= `NSEC_PER_SEC` and `tv_sec` is already most
-		 * positive, further addition would cause integer overflow.
-		 */
-		return false;
-	}
-
-	if (ts->tv_nsec >= (long)NSEC_PER_SEC) {
-		ts->tv_sec += sec;
-		ts->tv_nsec -= sec * (long)NSEC_PER_SEC;
-	} else if (ts->tv_nsec < 0) {
-		ts->tv_sec -= sec;
-		ts->tv_nsec += sec * (long)NSEC_PER_SEC;
-	} else {
-		/* no change: SonarQube was complaining */
-	}
-
-	__ASSERT_NO_MSG(timespec_is_valid(ts));
-
-	return true;
-}
+bool timespec_normalize(struct timespec *ts);
 
 /**
  * @brief Add one timespec to another


### PR DESCRIPTION
Previously, warnings could be promoted to errors in timeutil.h. Those warnings were of the form below.

```shell
warning: comparison is always true due to limited range of data type
warning: comparison is always false due to limited range of data type
```

Specifically, in the speed-optimized version of `timespec_normalize()` and in the macro `SYS_TICKS_TO_NSECS()`.

The speed-optimized version of `timespec_normalize()`, which used the `__builtin_add_overflow()` function, was mainly intended to be branchless. However, many targets generate branching instructions regardless.

The speed optimized version is less valuable in that case, so remove it.

Additionally, `SYS_TICKS_TO_NSECS()` does not generate the above warnings when `k_ticks_to_ns_floor64()` is used instead of `k_ticks_to_ns_floor32()`, so use the former.

Fixes #96261

Used modified versions of `samples/hello_world` and `tests/lib/timespec_util` to test.