### PR TITLE
logging: rtt: remove cast to void to used function arguments, use ARG_UNUSED for those unused arguments

### DIFF
--- a/subsys/logging/backends/log_backend_rtt.c
+++ b/subsys/logging/backends/log_backend_rtt.c
@@ -90,7 +90,6 @@ static inline bool is_panic_mode(void)
 
 static int data_out_drop_mode(uint8_t *data, size_t length, void *ctx)
 {
-	(void) ctx;
 	uint8_t *pos;
 
 	if (is_sync_mode()) {

--- a/subsys/logging/backends/log_backend_rtt.c
+++ b/subsys/logging/backends/log_backend_rtt.c
@@ -207,6 +207,8 @@ static void on_write(int retry_cnt)
 
 static int data_out_block_mode(uint8_t *data, size_t length, void *ctx)
 {
+	ARG_UNUSED(ctx);
+
 	int ret = 0;
 	/* This function is also called in drop mode for synchronous operation
 	 * in that case retry is undesired */
@@ -238,6 +240,8 @@ static int data_out_block_mode(uint8_t *data, size_t length, void *ctx)
 
 static int data_out_overwrite_mode(uint8_t *data, size_t length, void *ctx)
 {
+	ARG_UNUSED(ctx);
+
 	if (!is_sync_mode()) {
 		RTT_LOCK();
 		SEGGER_RTT_WriteWithOverwriteNoLock(CONFIG_LOG_BACKEND_RTT_BUFFER,
@@ -304,6 +308,8 @@ static void log_backend_rtt_init(struct log_backend const *const backend)
 
 static void panic(struct log_backend const *const backend)
 {
+	ARG_UNUSED(backend);
+
 	panic_mode = true;
 	log_backend_std_panic(&log_output_rtt);
 }
@@ -322,6 +328,8 @@ static void dropped(const struct log_backend *const backend, uint32_t cnt)
 static void process(const struct log_backend *const backend,
 		union log_msg_generic *msg)
 {
+	ARG_UNUSED(backend);
+
 	uint32_t flags = log_backend_std_get_flags();
 
 	log_format_func_t log_output_func = log_format_func_t_get(log_format_current);
@@ -331,6 +339,8 @@ static void process(const struct log_backend *const backend,
 
 static int format_set(const struct log_backend *const backend, uint32_t log_type)
 {
+	ARG_UNUSED(backend);
+
 	log_format_current = log_type;
 	return 0;
 }


### PR DESCRIPTION
- remove cast to void to used function arguments
- Add missing ARG_UNUSED() to mark unused function arguments.
