### PR TITLE
doc: clarify gcc-multilib instructions for AArch64

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -84,7 +84,7 @@ The current minimum required version for the main dependencies are:
          .. note::
 
             Due to the unavailability of ``gcc-multilib`` and ``g++-multilib`` on AArch64
-            (ARM64) systems, you may need to remove them from the list of packages to install.
+            (ARM64) systems, you may need to omit them from the list of packages to install.
 
       #. Verify the versions of the main dependencies installed on your system by entering:
 


### PR DESCRIPTION
Changed 'remove' to 'omit' to clarify package instructions for
AArch64 systems. This improves clarity for users following
the Zephyr SDK setup guide.

Supersedes PR #96298. The previous branch was closed to
clean up the commit history and ensure a single, clear commit.

