### PR TITLE
modules: hal_rpi_pico: Add `pico_platform_common` to include path

### DIFF
--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -84,6 +84,7 @@ if(CONFIG_HAS_RPI_PICO)
     ${rp2_common_dir}/hardware_sync_spin_lock/include
     ${rp2_common_dir}/pico_bootrom/include
     ${rp2_common_dir}/pico_flash/include
+    ${rp2_common_dir}/pico_platform_common/include
     ${rp2_common_dir}/pico_platform_compiler/include
     ${rp2_common_dir}/pico_platform_sections/include
     ${rp2_common_dir}/pico_platform_panic/include

--- a/modules/hal_rpi_pico/bootloader/CMakeLists.txt
+++ b/modules/hal_rpi_pico/bootloader/CMakeLists.txt
@@ -37,6 +37,7 @@ target_include_directories(boot_stage2 PUBLIC
   ${rp2040_dir}/pico_platform/include
   ${rp2040_dir}/hardware_regs/include
   ${common_dir}/pico_base_headers/include
+  ${rp2_common_dir}/pico_platform_common/include
   ${rp2_common_dir}/pico_platform_compiler/include
   ${rp2_common_dir}/pico_platform_sections/include
   ${rp2_common_dir}/pico_platform_panic/include


### PR DESCRIPTION
By the recent SDK update, compilation will fail if `pico_platform_common` is not added to the include path, so that we fix this.