### PR TITLE
subsys: display: cfb: Fix tile drawing processing

### DIFF
--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -450,23 +450,23 @@ int cfb_invert_area(const struct device *dev, uint16_t x, uint16_t y,
 		return -EINVAL;
 	}
 
+	if (x > fb->x_res) {
+		x = fb->x_res;
+	}
+
+	if (y > fb->y_res) {
+		y = fb->y_res;
+	}
+
+	if (x + width > fb->x_res) {
+		width = fb->x_res - x;
+	}
+
+	if (y + height > fb->y_res) {
+		height = fb->y_res - y;
+	}
+
 	if ((fb->screen_info & SCREEN_INFO_MONO_VTILED)) {
-		if (x > fb->x_res) {
-			x = fb->x_res;
-		}
-
-		if (y > fb->y_res) {
-			y = fb->y_res;
-		}
-
-		if (x + width > fb->x_res) {
-			width = fb->x_res - x;
-		}
-
-		if (y + height > fb->y_res) {
-			height = fb->y_res - y;
-		}
-
 		for (size_t i = x; i < x + width; i++) {
 			for (size_t j = y; j < (y + height); j++) {
 				/*
@@ -517,12 +517,37 @@ int cfb_invert_area(const struct device *dev, uint16_t x, uint16_t y,
 				}
 			}
 		}
+	} else {
+		const size_t bytes_per_row = fb->x_res / 8U;
 
-		return 0;
+		for (uint16_t j = y; j < (y + height); j++) {
+			const uint16_t start_byte = x / 8U;
+			const uint16_t end_byte = (x + width - 1U) / 8U;
+
+			for (uint16_t b = start_byte; b <= end_byte; b++) {
+				const size_t index = j * bytes_per_row + b;
+				const uint8_t bit_start = (b == start_byte) ? (x % 8U) : 0U;
+				const uint8_t bit_end =
+					(b == end_byte) ? ((x + width - 1U) % 8U) : 7U;
+				uint8_t m;
+
+				if (bit_end >= bit_start) {
+					m = BIT_MASK(bit_end - bit_start + 1U) << bit_start;
+				} else {
+					m = 0U;
+				}
+
+				if (need_reverse) {
+					m = byte_reverse(m);
+				}
+
+				/* invert byte with computed mask */
+				fb->buf[index] ^= m;
+			}
+		}
 	}
 
-	LOG_ERR("Unsupported framebuffer configuration");
-	return -EINVAL;
+	return 0;
 }
 
 static int cfb_invert(const struct char_framebuffer *fb)

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -251,7 +251,6 @@ static uint8_t draw_char_htmono(const struct char_framebuffer *fb,
 			uint8_t pixel_value;
 
 			if (fb_x < 0 || fb->x_res <= fb_x || fb_y < 0 || fb->y_res <= fb_y) {
-				g_y++;
 				continue;
 			}
 

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -604,7 +604,7 @@ int cfb_framebuffer_finalize(const struct device *dev)
 		.pitch = fb->x_res,
 	};
 
-	if ((fb->pixel_format == PIXEL_FORMAT_MONO10) == fb->inverted) {
+	if ((fb->pixel_format == PIXEL_FORMAT_MONO10) != fb->inverted) {
 		cfb_invert(fb);
 		err = api->write(dev, 0, 0, &desc, fb->buf);
 		cfb_invert(fb);

--- a/tests/subsys/display/cfb/basic/src/utils.c
+++ b/tests/subsys/display/cfb/basic/src/utils.c
@@ -30,16 +30,22 @@ inline uint32_t mono_pixel_order(uint32_t order)
 
 uint32_t display_pixel(int x, int y)
 {
-	const uint8_t *ptr = read_buffer + (display_width * (y / 8) + x);
 	struct display_capabilities display_caps;
+	bool pixel_on;
 
 	display_get_capabilities(dev, &display_caps);
 
-	if (display_caps.current_pixel_format == PIXEL_FORMAT_MONO10) {
-		return !(*ptr & mono_pixel_order(y % 8));
+	if (IS_ENABLED(CONFIG_SDL_DISPLAY_MONO_VTILED)) {
+		const uint8_t *ptr = read_buffer + (display_width * (y / 8)) + x;
+
+		pixel_on = !!(*ptr & mono_pixel_order(y % 8));
+	} else {
+		const uint8_t *ptr = read_buffer + (y * (display_width / 8)) + (x / 8);
+
+		pixel_on = !!(*ptr & mono_pixel_order(x % 8));
 	}
 
-	return !!(*ptr & mono_pixel_order(y % 8));
+	return (display_caps.current_pixel_format == PIXEL_FORMAT_MONO10) ? !pixel_on : pixel_on;
 }
 
 uint32_t image_pixel(const uint32_t *img, size_t width, int x, int y)

--- a/tests/subsys/display/cfb/basic/testcase.yaml
+++ b/tests/subsys/display/cfb/basic/testcase.yaml
@@ -6,7 +6,9 @@ common:
     - display
     - drivers
     - cfb
-  harness: display
+  harness: ztest
+  harness_config:
+    fixture: display
   platform_allow:
     - native_sim
 tests:

--- a/tests/subsys/display/cfb/basic/testcase.yaml
+++ b/tests/subsys/display/cfb/basic/testcase.yaml
@@ -11,6 +11,7 @@ common:
     fixture: display
   platform_allow:
     - native_sim
+    - native_sim/native/64
 tests:
   display.cfb.basic.mono01.vtiled.msbfirst.lsbfirst_font:
     extra_configs:


### PR DESCRIPTION
There is a bug in the CFB tile drawing process, so we will fix it.

We will also modify testcase.yaml to make it easier to perform testing using twister.

Fix #92860
But still fail circle drawing tests.

#96313 is required to be merged prior.