### PR TITLE
ztest: Add validation of zassert strings

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -76,8 +76,9 @@ static inline bool z_zexpect_(bool cond, const char *file, int line)
 
 #else /* CONFIG_ZTEST_ASSERT_VERBOSE != 0 */
 
-static inline bool z_zassert(bool cond, const char *default_msg, const char *file, int line,
-			     const char *func, const char *msg, ...)
+static inline __printf_like(6, 7) bool z_zassert(bool cond, const char *default_msg,
+						 const char *file, int line, const char *func,
+						 const char *msg, ...)
 {
 	if (cond == false) {
 		va_list vargs;
@@ -100,8 +101,9 @@ static inline bool z_zassert(bool cond, const char *default_msg, const char *fil
 	return true;
 }
 
-static inline bool z_zassume(bool cond, const char *default_msg, const char *file, int line,
-			     const char *func, const char *msg, ...)
+static inline __printf_like(6, 7) bool z_zassume(bool cond, const char *default_msg,
+						 const char *file, int line, const char *func,
+						 const char *msg, ...)
 {
 	if (cond == false) {
 		va_list vargs;
@@ -124,8 +126,9 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
 	return true;
 }
 
-static inline bool z_zexpect(bool cond, const char *default_msg, const char *file, int line,
-			     const char *func, const char *msg, ...)
+static inline __printf_like(6, 7) bool z_zexpect(bool cond, const char *default_msg,
+						 const char *file, int line, const char *func,
+						 const char *msg, ...)
 {
 	if (cond == false) {
 		va_list vargs;

--- a/tests/application_development/ram_context_for_isr/src/main.c
+++ b/tests/application_development/ram_context_for_isr/src/main.c
@@ -39,16 +39,16 @@ static void test_irq_callback(const struct device *dev, void *user_data)
 	/* Check that the function and its call stack are in RAM */
 	zassert_true(func_addr >= CONFIG_SRAM_BASE_ADDRESS &&
 			     func_addr <= CONFIG_SRAM_BASE_ADDRESS + CONFIG_SRAM_SIZE * 1024,
-		     "%s is not in RAM! Address: 0x%x", __func__, func_addr);
+		     "%s is not in RAM! Address: 0x%lx", __func__, func_addr);
 
 	zassert_true(driver_isr_addr >= CONFIG_SRAM_BASE_ADDRESS &&
 			     driver_isr_addr <= CONFIG_SRAM_BASE_ADDRESS + CONFIG_SRAM_SIZE * 1024,
-		     "fake_driver_isr is not in RAM! Address: 0x%x", driver_isr_addr);
+		     "fake_driver_isr is not in RAM! Address: 0x%lx", driver_isr_addr);
 
 	zassert_true(arch_isr_wrapper_addr >= CONFIG_SRAM_BASE_ADDRESS &&
 			     arch_isr_wrapper_addr <=
 				     CONFIG_SRAM_BASE_ADDRESS + CONFIG_SRAM_SIZE * 1024,
-		     "arch_isr_wrapper_addr is not in RAM! Address: 0x%x", arch_isr_wrapper_addr);
+		     "arch_isr_wrapper_addr is not in RAM! Address: 0x%lx", arch_isr_wrapper_addr);
 
 	TC_PRINT("Callback function address: 0x%lx\n", func_addr);
 	TC_PRINT("Driver ISR address: 0x%lx\n", driver_isr_addr);
@@ -63,7 +63,7 @@ ZTEST(ram_context_for_isr, test_fake_driver_in_ram)
 
 	zassert_true(dev_addr >= CONFIG_SRAM_BASE_ADDRESS &&
 			     dev_addr <= CONFIG_SRAM_BASE_ADDRESS + CONFIG_SRAM_SIZE * 1024,
-		     "fake driver device is not in RAM! Address: 0x%x", dev_addr);
+		     "fake driver device is not in RAM! Address: 0x%lx", dev_addr);
 
 	TC_PRINT("Fake driver device address: 0x%lx\n", dev_addr);
 

--- a/tests/subsys/dsp/print_format/src/main.c
+++ b/tests/subsys/dsp/print_format/src/main.c
@@ -9,7 +9,7 @@
 #define float_multiplier(type) ((INT64_C(1) << (8 * sizeof(type) - 1)) - 1)
 
 #define assert_strings(expected, actual)                                                           \
-	zexpect_equal(strlen(expected), strlen(actual), "Expected %d(%s), got %d(%s)",             \
+	zexpect_equal(strlen(expected), strlen(actual), "Expected %zu(%s), got %zu(%s)",           \
 		      strlen(expected), expected, strlen(actual), actual);                         \
 	zexpect_mem_equal(expected, actual, MIN(strlen(expected), strlen(actual)),                 \
 			  "Expected '%s', got '%s'", expected, actual)


### PR DESCRIPTION
Add `__printf_like` attribute to ztest assertion functions `zassert`, `zassume`, `zexpect` to validate format strings and arguments at compile time.

This also fixes the following warnings when compiling with clang (found while testing new zephyr sdk 0.18.0-alpha4):
```
zephyr/subsys/testsuite/ztest/include/zephyr/ztest_assert.h:88:11: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
   88 |                 vprintk(msg, vargs);
      |                         ^~~
zephyr/subsys/testsuite/ztest/include/zephyr/ztest_assert.h:112:11: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
  112 |                 vprintk(msg, vargs);
      |                         ^~~
zephyr/subsys/testsuite/ztest/include/zephyr/ztest_assert.h:136:11: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
  136 |                 vprintk(msg, vargs);
      |                         ^~~
```