### PR TITLE
logging: backend: net: Do not bind local socket

### DIFF
--- a/subsys/logging/backends/log_backend_net.c
+++ b/subsys/logging/backends/log_backend_net.c
@@ -91,27 +91,18 @@ LOG_OUTPUT_DEFINE(log_output_net, line_out, output_buf, sizeof(output_buf));
 
 static int do_net_init(struct log_backend_net_ctx *ctx)
 {
-	struct sockaddr *local_addr = NULL;
-	struct sockaddr_in6 local_addr6 = {0};
-	struct sockaddr_in local_addr4 = {0};
-	socklen_t server_addr_len;
+	socklen_t server_addr_len = 0;
 	int ret, proto = IPPROTO_UDP, type = SOCK_DGRAM;
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && server_addr.sa_family == AF_INET) {
-		local_addr = (struct sockaddr *)&local_addr4;
 		server_addr_len = sizeof(struct sockaddr_in);
-		local_addr4.sin_family = AF_INET;
-		local_addr4.sin_port = 0U;
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) && server_addr.sa_family == AF_INET6) {
-		local_addr = (struct sockaddr *)&local_addr6;
 		server_addr_len = sizeof(struct sockaddr_in6);
-		local_addr6.sin6_family = AF_INET6;
-		local_addr6.sin6_port = 0U;
 	}
 
-	if (local_addr == NULL) {
+	if (server_addr_len == 0) {
 		DBG("Server address unknown\n");
 		return -EINVAL;
 	}
@@ -132,50 +123,6 @@ static int do_net_init(struct log_backend_net_ctx *ctx)
 
 	if (IS_ENABLED(CONFIG_NET_HOSTNAME_ENABLE)) {
 		(void)strncpy(dev_hostname, net_hostname_get(), MAX_HOSTNAME_LEN);
-
-	} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
-		   server_addr.sa_family == AF_INET6) {
-		const struct in6_addr *src;
-
-		src = net_if_ipv6_select_src_addr(
-			NULL, &net_sin6(&server_addr)->sin6_addr);
-		if (src) {
-			net_addr_ntop(AF_INET6, src, dev_hostname,
-				      MAX_HOSTNAME_LEN);
-
-			net_ipaddr_copy(&local_addr6.sin6_addr, src);
-		} else {
-			goto unknown;
-		}
-
-	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
-		   server_addr.sa_family == AF_INET) {
-		const struct in_addr *src;
-
-		src = net_if_ipv4_select_src_addr(
-				  NULL, &net_sin(&server_addr)->sin_addr);
-
-		if (src) {
-			net_addr_ntop(AF_INET, src, dev_hostname,
-				      MAX_HOSTNAME_LEN);
-
-			net_ipaddr_copy(&local_addr4.sin_addr, src);
-		} else {
-			goto unknown;
-		}
-
-	} else {
-	unknown:
-		DBG("Cannot setup local socket\n");
-		ret = -EINVAL;
-		goto err;
-	}
-
-	ret = zsock_bind(ctx->sock, local_addr, server_addr_len);
-	if (ret < 0) {
-		ret = -errno;
-		DBG("Cannot bind socket (%d)\n", ret);
-		goto err;
 	}
 
 	ret = zsock_connect(ctx->sock, &server_addr, server_addr_len);

--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -317,6 +317,8 @@ struct tcp { /* TCP connection */
 	enum tcp_state state;
 	enum tcp_data_mode data_mode;
 	uint32_t seq;
+	uint32_t isn;
+	uint32_t isn_peer;
 	uint32_t ack;
 #if defined(CONFIG_NET_TCP_KEEPALIVE)
 	uint32_t keep_idle;

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -225,11 +225,21 @@ static void zsock_received_cb(struct net_context *ctx,
 			      int status,
 			      void *user_data)
 {
+	if (sock_is_eof(ctx)) {
+		/* If receiving is not desired and socket is shutdown,
+		 * ignore all incoming data.
+		 */
+		NET_DBG("%sctx=%p, pkt=%p, st=%d, user_data=%p",
+			"DROP: ", ctx, pkt, status, user_data);
+		net_pkt_unref(pkt);
+		return;
+	}
+
 	if (ctx->cond.lock) {
 		(void)k_mutex_lock(ctx->cond.lock, K_FOREVER);
 	}
 
-	NET_DBG("ctx=%p, pkt=%p, st=%d, user_data=%p", ctx, pkt, status,
+	NET_DBG("%sctx=%p, pkt=%p, st=%d, user_data=%p", "", ctx, pkt, status,
 		user_data);
 
 	if (status < 0) {
@@ -363,12 +373,16 @@ int zsock_connect_ctx(struct net_context *ctx, const struct sockaddr *addr,
 			errno = -ret;
 			return -1;
 		}
-		ret = net_context_recv(ctx, zsock_received_cb,
-				       K_NO_WAIT, ctx->user_data);
-		if (ret < 0) {
-			errno = -ret;
-			return -1;
+
+		if (!sock_is_eof(ctx)) {
+			ret = net_context_recv(ctx, zsock_received_cb,
+					       K_NO_WAIT, ctx->user_data);
+			if (ret < 0) {
+				errno = -ret;
+				return -1;
+			}
 		}
+
 		return 0;
 	}
 #endif
@@ -416,11 +430,14 @@ int zsock_connect_ctx(struct net_context *ctx, const struct sockaddr *addr,
 			errno = -ret;
 			return -1;
 		}
-		ret = net_context_recv(ctx, zsock_received_cb,
-					K_NO_WAIT, ctx->user_data);
-		if (ret < 0) {
-			errno = -ret;
-			return -1;
+
+		if (!sock_is_eof(ctx)) {
+			ret = net_context_recv(ctx, zsock_received_cb,
+					       K_NO_WAIT, ctx->user_data);
+			if (ret < 0) {
+				errno = -ret;
+				return -1;
+			}
 		}
 	}
 
@@ -643,11 +660,13 @@ ssize_t zsock_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 	/* Register the callback before sending in order to receive the response
 	 * from the peer.
 	 */
-	status = net_context_recv(ctx, zsock_received_cb,
-				  K_NO_WAIT, ctx->user_data);
-	if (status < 0) {
-		errno = -status;
-		return -1;
+	if (!sock_is_eof(ctx)) {
+		status = net_context_recv(ctx, zsock_received_cb,
+					  K_NO_WAIT, ctx->user_data);
+		if (status < 0) {
+			errno = -status;
+			return -1;
+		}
 	}
 
 	while (1) {


### PR DESCRIPTION
The logging net backend will send syslog messages to syslog server and it is not meant to receive anything. If we bind to a local socket, it will create UDP server socket that can receive data. Unfortunately there is no one reading the data so we will eventually run out of memory in this case.