### PR TITLE
MAINTAINERS: Switch Xilinx platforms to maintained state

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6022,11 +6022,12 @@ Xen Platform:
     - "area: Xen Platform"
 
 Xilinx Platforms:
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - michalsimek
   collaborators:
     - henrikbrixandersen
     - ibirnbaum
-    - michalsimek
   files:
     - boards/amd/
     - drivers/*/*xilinx*


### PR DESCRIPTION
Move Xilinx platform to maintained state to properly reflect current support status.