### PR TITLE
modules: nanopb: Release decoded message

### DIFF
--- a/samples/modules/nanopb/src/main.c
+++ b/samples/modules/nanopb/src/main.c
@@ -73,6 +73,7 @@ bool decode_message(uint8_t *buffer, size_t message_length)
 #ifdef CONFIG_SAMPLE_UNLUCKY_NUMBER
 		printk("Your unlucky number was %d!\n", (int)message.unlucky_number);
 #endif
+		pb_release(SimpleMessage_fields, &message);
 	} else {
 		printk("Decoding failed: %s\n", PB_GET_ERROR(&stream));
 	}

--- a/tests/modules/nanopb/src/main.c
+++ b/tests/modules/nanopb/src/main.c
@@ -41,6 +41,8 @@ ZTEST(nanopb_tests, test_nanopb_simple)
 	for (size_t i = 0; i < sizeof(msg.buffer); ++i) {
 		zassert_equal(msg.buffer[i], i);
 	}
+
+	pb_release(SimpleMessage_fields, &msg);
 }
 
 ZTEST(nanopb_tests, test_nanopb_nested)
@@ -68,6 +70,8 @@ ZTEST(nanopb_tests, test_nanopb_nested)
 	zassert_equal(42, msg.nested.id);
 	zassert_true(msg.has_nested);
 	zassert_str_equal(msg.nested.name, "Test name");
+
+	pb_release(ComplexMessage_fields, &msg);
 }
 
 ZTEST(nanopb_tests, test_nanopb_lib)


### PR DESCRIPTION
If `CONFIG_NANOPB_ENABLE_MALLOC` is enabled, any successfully decoded message should be released.

It the option isn't enabled, this is a no-op.
