### PR TITLE
boards: st: nucleo_l552ze_q set stm32cubeprogrammer as default runner

### DIFF
--- a/boards/st/nucleo_l552ze_q/board.cmake
+++ b/boards/st/nucleo_l552ze_q/board.cmake
@@ -15,10 +15,6 @@ endif()
 
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
-
-set_ifndef(BOARD_DEBUG_RUNNER pyocd)
-set_ifndef(BOARD_FLASH_RUNNER pyocd)
-
 board_runner_args(pyocd "--target=stm32l552zetxq")
 
 # keep first


### PR DESCRIPTION
This change sets stm32cubeprogrammer as default runner on nucleo_l552ze_q

Before:
```
$ west flash

-- west flash: rebuilding
ninja: no work to do.
-- west flash: using runner pyocd
-- runners.pyocd: Flashing file: /home/mario/zephyrproject/zephyr/samples/hello_world/build/zephyr/zephyr.hex
0000769 C Target type stm32l552zetxq not recognized. Use 'pyocd list --targets' to see currently available target types. See <https://pyocd.io/docs/target_support.html> for how to install additional target support. [__main__]
FATAL ERROR: command exited with status 1: pyocd flash -e sector -a 0x8000000 -t stm32l552zetxq /home/mario/zephyrproject/zephyr/samples/hello_world/build/zephyr/zephyr.hex
```
After:

```
$ west flash

-- west flash: rebuilding
ninja: no work to do.
-- west flash: using runner stm32cubeprogrammer
      -------------------------------------------------------------------
                        STM32CubeProgrammer v2.20.0                  
      -------------------------------------------------------------------

ST-LINK SN  : 0671FF363355373043093150
ST-LINK FW  : V2J45M31
Board       : NUCLEO-L552ZE-Q
Voltage     : 3.26V
SWD freq    : 4000 KHz
Connect mode: Under Reset
Reset mode  : Hardware reset
Device ID   : 0x472
Revision ID : Rev Z
Device name : STM32L5xx
Flash size  : 512 KBytes
Device type : MCU
Device CPU  : Cortex-M33
BL Version  : 0x92



Opening and parsing file: zephyr.hex


Memory Programming ...
  File          : zephyr.hex
  Size          : 18.21 KB 
  Address       : 0x08000000


Erasing memory corresponding to segment 0:
Erasing internal memory sectors [0 9]
Download in Progress:
[==================================================] 100% 

File download complete
Time elapsed during download operation: 00:00:01.205

RUNNING Program ... 
  Address:      : 0x8000000
Application is running, Please Hold on...
Start operation achieved successfully
```