### PR TITLE
drivers: serial: litex: improve driver

### DIFF
--- a/drivers/serial/uart_litex.c
+++ b/drivers/serial/uart_litex.c
@@ -267,17 +267,11 @@ static void uart_litex_irq_callback_set(const struct device *dev,
 
 static void uart_litex_irq_handler(const struct device *dev)
 {
-	const struct uart_litex_device_config *config = dev->config;
 	struct uart_litex_data *data = dev->data;
 	unsigned int key = irq_lock();
 
 	if (data->callback) {
 		data->callback(dev, data->cb_data);
-	}
-
-	/* Clear RX events, TX events still needed to enqueue the next transfer */
-	if ((litex_read8(config->ev_pending_addr) & UART_EV_RX) > 0) {
-		litex_write8(UART_EV_RX, config->ev_pending_addr);
 	}
 
 	irq_unlock(key);

--- a/drivers/serial/uart_litex.c
+++ b/drivers/serial/uart_litex.c
@@ -16,6 +16,14 @@
 
 #include <soc.h>
 
+#if DT_ANY_INST_HAS_BOOL_STATUS_OKAY(rx_fifo_rx_we)
+#define USES_RX_FIFO_RX_WE 1
+#endif
+
+BUILD_ASSERT(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(rx_fifo_rx_we) ==
+		     DT_ALL_INST_HAS_BOOL_STATUS_OKAY(rx_fifo_rx_we),
+	     "rx-fifo-rx-we property must be set for all or none of the instances");
+
 #define UART_EV_TX		BIT(0)
 #define UART_EV_RX		BIT(1)
 
@@ -73,11 +81,12 @@ static int uart_litex_poll_in(const struct device *dev, unsigned char *c)
 
 	if (!litex_read8(config->rxempty_addr)) {
 		*c = litex_read8(config->rxtx_addr);
-
+#ifndef USES_RX_FIFO_RX_WE
 		/* refresh UART_RXEMPTY by writing UART_EV_RX
 		 * to UART_EV_PENDING
 		 */
 		litex_write8(UART_EV_RX, config->ev_pending_addr);
+#endif
 		return 0;
 	}
 
@@ -193,6 +202,12 @@ static int uart_litex_fifo_fill(const struct device *dev,
 		litex_write8(tx_data[i], config->rxtx_addr);
 	}
 
+#ifndef USES_RX_FIFO_RX_WE
+	/* LiteX uses EventSourceLevel for the UART since 22.09.2025,
+	 * where TX event is level triggered and pending is self-flushing,
+	 * so this is not needed anymore for new designs. When the dt property
+	 * rx-fifo-rx-we is set, we assume the design is new enough.
+	 */
 	if (litex_read8(config->txfull_addr)) {
 		/* only flush TX event if TX is really full */
 		litex_write8(UART_EV_TX, config->ev_pending_addr);
@@ -202,6 +217,7 @@ static int uart_litex_fifo_fill(const struct device *dev,
 			litex_write8(0, config->rxtx_addr);
 		}
 	}
+#endif
 
 	return i;
 }
@@ -223,11 +239,12 @@ static int uart_litex_fifo_read(const struct device *dev,
 
 	for (i = 0; i < size && !litex_read8(config->rxempty_addr); i++) {
 		rx_data[i] = litex_read8(config->rxtx_addr);
-
+#ifndef USES_RX_FIFO_RX_WE
 		/* refresh UART_RXEMPTY by writing UART_EV_RX
 		 * to UART_EV_PENDING
 		 */
 		litex_write8(UART_EV_RX, config->ev_pending_addr);
+#endif
 	}
 
 	return i;

--- a/dts/bindings/serial/litex,uart.yaml
+++ b/dts/bindings/serial/litex,uart.yaml
@@ -13,3 +13,10 @@ properties:
 
   interrupts:
     required: true
+
+  rx-fifo-rx-we:
+    type: boolean
+    description: |
+      If true, the RX FIFO read will also remove that item from the FIFO.
+      Set this property if the uart_rx_fifo_rx_we parameter in LiteX is
+      set to true.


### PR DESCRIPTION
- remove redundant clearing of rx in ev_pending in `uart_litex_irq_handler`, as it is already done in `uart_litex_fifo_read`. Also clearing it again could lead to loss of chars, if they got in after `uart_litex_fifo_read`, but before the second clearing.
- in uart_litex_fifo_fill, don't clear tx pending, if we don't fill the fifo completely
- add support for changes of https://github.com/enjoy-digital/litex/pull/2319