### PR TITLE
stm32 clock mux for CK48 definition

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -186,6 +186,13 @@ int enabled_clock(uint32_t src_clk)
 		}
 		break;
 #endif /* STM32_SRC_MSI */
+#if defined(STM32_SRC_CK48)
+	case STM32_SRC_CK48:
+		if (!IS_ENABLED(STM32_CK48_ENABLED)) {
+			r = -ENOTSUP;
+		}
+		break;
+#endif /* STM32_SRC_CK48 */
 #if defined(STM32_SRC_PLLCLK)
 	case STM32_SRC_PLLCLK:
 		if (!IS_ENABLED(STM32_PLL_ENABLED)) {

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -176,6 +176,11 @@
 #define STM32_TIMG_PRESCALER	DT_PROP(DT_NODELABEL(rcc), timg_prescaler)
 #endif /* rcc node compatible st_stm32n6_rcc and okay */
 
+/** clock 48MHz node related symbols */
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk48), st_stm32_clock_mux, okay)
+#define STM32_CK48_ENABLED	1
+#endif
+
 /** PLL node related symbols */
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32f2_pll_clock, okay) || \

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/f4_sdmmc48_pll.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/f4_sdmmc48_pll.overlay
@@ -12,6 +12,28 @@
 	status = "okay";
 };
 
+/*
+ * In case the clk48 is selecting the STM32_SRC_PLL_Q with
+ * clocks = <&rcc STM32_SRC_PLL_Q CK48M_SEL(0)>;
+ * one possible PLL config to give 48MHz on the pll_q output is as follows :
+ &pll {
+	div-m = <4>;
+	mul-n = <192>;
+	div-p = <4>;
+	div-q = <8>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(96)>;
+	ahb-prescaler = <1>;
+	apb1-prescaler = <2>;
+	apb2-prescaler = <1>;
+};
+*/
+
 &plli2s {
 	div-m = <4>;
 	mul-n = <96>;


### PR DESCRIPTION
Define the STM32_CK48_ENABLED especially for the stm32F4 series

FIxes https://github.com/zephyrproject-rtos/zephyr/issues/94934