### PR TITLE
drivers: ethernet: lan865x: enable PHY access through generic ethernet_api

### DIFF
--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -453,11 +453,19 @@ static int lan865x_port_send(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
+const struct device *lan865x_get_phy(const struct device *dev)
+{
+	const struct lan865x_config *cfg = dev->config;
+
+	return cfg->phy;
+}
+
 static const struct ethernet_api lan865x_api_func = {
 	.iface_api.init = lan865x_iface_init,
 	.get_capabilities = lan865x_port_get_capabilities,
 	.set_config = lan865x_set_config,
 	.send = lan865x_port_send,
+	.get_phy = lan865x_get_phy,
 };
 
 #define LAN865X_DEFINE(inst)                                                                       \


### PR DESCRIPTION
Enabling the lan865x internal PHY access through the generic ethernet_api is needed for accessing the PHY device through the ethernet network interface.