### PR TITLE
dts: nxp: fix write-block-size for MCXA platforms

### DIFF
--- a/dts/arm/nxp/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/nxp_mcxa153.dtsi
@@ -136,7 +136,7 @@
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_K(128)>;
 				erase-block-size = <DT_SIZE_K(8)>;
-				write-block-size = <128>;
+				write-block-size = <16>;
 			};
 
 			uuid: uuid@1100800 {

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -167,7 +167,7 @@
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_M(1)>;
 				erase-block-size = <DT_SIZE_K(8)>;
-				write-block-size = <128>;
+				write-block-size = <16>;
 			};
 
 			uuid: uuid@1100800 {

--- a/dts/arm/nxp/nxp_mcxa266.dtsi
+++ b/dts/arm/nxp/nxp_mcxa266.dtsi
@@ -274,7 +274,7 @@
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_M(1)>;
 				erase-block-size = <DT_SIZE_K(8)>;
-				write-block-size = <128>;
+				write-block-size = <16>;
 			};
 
 			uuid: uuid@1100800 {

--- a/dts/arm/nxp/nxp_mcxa346.dtsi
+++ b/dts/arm/nxp/nxp_mcxa346.dtsi
@@ -274,7 +274,7 @@
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_M(1)>;
 				erase-block-size = <DT_SIZE_K(8)>;
-				write-block-size = <128>;
+				write-block-size = <16>;
 			};
 
 			uuid: uuid@1100800 {


### PR DESCRIPTION
Fixes the on-chip flash write-block-size for MCXA platforms to 16 Bytes.
It was set to 128 Bytes, but the MCXA Flash ROM-API supports 16-byte writes.