### PR TITLE
soc: stm32g0 do not enable Prefetch for stm32g0B1 due to errata

### DIFF
--- a/soc/st/stm32/stm32g0x/soc.c
+++ b/soc/st/stm32/stm32g0x/soc.c
@@ -82,7 +82,14 @@ void soc_early_init_hook(void)
 {
 	/* Enable ART Accelerator I-cache and prefetch */
 	LL_FLASH_EnableInstCache();
+#ifndef CONFIG_SOC_STM32G0B1XX
+	/* See ErrataSheet ES0548 2.2.10 "Prefetch failure when branching across flash memory banks
+	 * which causes code execution corruption and may lead to HardFault interrupt"
+	 * Do not enable Prefetch for the stm32G0B1xB/C/E to prevent failing
+	 * branching instructions between memory banks
+	 */
 	LL_FLASH_EnablePrefetch();
+#endif /* CONFIG_SOC_STM32G0B1XX */
 
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 16 MHz from HSI */


### PR DESCRIPTION
Implement the errata sheet for the stm32G0B1 series  [ES0548](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/5b/85/f7/7e/5e/a1/49/c5/DM00760234/files/DM00760234.pdf/jcr:content/translations/en.DM00760234.pdf) 
_2.2.10 Prefetch failure when branching across flash memory banks_
 which do not enable prefetch for the stm32G0B1

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/95107