### PR TITLE
drivers: misc: ethos_u: add fast-memory-region support

### DIFF
--- a/drivers/misc/ethos_u/ethos_u_common.h
+++ b/drivers/misc/ethos_u/ethos_u_common.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright 2021-2022, 2024 Arm Limited and/or its
+ * SPDX-FileCopyrightText: <text>Copyright 2021-2022, 2024-2025 Arm Limited and/or its
  * affiliates <open-source-office@arm.com></text>
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,7 @@
 #define ZEPHYR_DRIVERS_MISC_ETHOS_U_ETHOS_U_COMMON_H_
 
 #include <ethosu_driver.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,6 +19,8 @@ struct ethosu_dts_info {
 	bool secure_enable;
 	bool privilege_enable;
 	void (*irq_config)(void);
+	const void *fast_mem_base;
+	size_t fast_mem_size;
 };
 
 struct ethosu_data {

--- a/dts/bindings/arm/arm,ethos-u.yaml
+++ b/dts/bindings/arm/arm,ethos-u.yaml
@@ -1,5 +1,5 @@
-# Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
-#
+# SPDX-FileCopyrightText: <text>Copyright 2022, 2025 Arm Limited and/or
+# its affiliates <open-source-office@arm.com></text>
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -30,3 +30,13 @@ properties:
   privilege-enable:
     type: boolean
     description: Configure Ethos-U NPU to operate in privileged- or non-privileged mode
+
+  fast-memory-region:
+    type: phandle
+    description: |
+      Phandle to a node compatible with "zephyr,memory-region" that represents
+      a dedicated fast SRAM region used by the Ethos-U driver as scratch
+      memory (spill cache). This is used by Ethos-U65/Ethos-U85 when the model has
+      been compiled in Dedicated SRAM mode with Vela.
+      If omitted, the driver passes NULL/0 to ethosu_init() and no fast
+      scratch area is used.


### PR DESCRIPTION
Add optional fast-memory-region property to the Ethos-U driver. When present in the devicetree, the driver passes the region base and size to ethosu_init(), allowing platforms to use dedicated SRAM for improved NPU performance.

If the property is not specified, the driver falls back to using NULL/0, keeping existing behavior unchanged.