### PR TITLE
Bluetooth: CAP: Add ep conn check in unicast audio start

### DIFF
--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -107,6 +107,12 @@ struct bt_cap_initiator_proc_param {
 		} meta_update;
 		struct {
 			bool release;
+			/** Since releasing may end up with the ASE state going from
+			 * BT_BAP_EP_STATE_CODEC_CONFIGURED -> BT_BAP_EP_STATE_RELEASING ->
+			 * BT_BAP_EP_STATE_CODEC_CONFIGURED we cannot rely 100% on the ASE state to
+			 * determine the state of the procedure
+			 */
+			bool completed;
 		} stop;
 	};
 	bool in_progress;

--- a/tests/bluetooth/audio/cap_initiator/include/test_common.h
+++ b/tests/bluetooth/audio/cap_initiator/include/test_common.h
@@ -1,21 +1,29 @@
 /* test_common.h */
 
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2024-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stdint.h>
 
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/conn.h>
 
+#include "conn.h"
+
 void test_mocks_init(void);
 void test_mocks_cleanup(void);
 
-void test_conn_init(struct bt_conn *conn);
+void test_conn_init(struct bt_conn *conn, uint8_t index);
 
 void test_unicast_set_state(struct bt_cap_stream *cap_stream, struct bt_conn *conn,
 			    struct bt_bap_ep *ep, struct bt_bap_lc3_preset *preset,
 			    enum bt_bap_ep_state state);
+void mock_discover(
+	struct bt_conn conns[CONFIG_BT_MAX_CONN],
+	struct bt_bap_ep *snk_eps[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT],
+	struct bt_bap_ep *src_eps[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT]);

--- a/tests/bluetooth/audio/cap_initiator/src/main.c
+++ b/tests/bluetooth/audio/cap_initiator/src/main.c
@@ -43,7 +43,7 @@ struct cap_initiator_test_suite_fixture {
 static void cap_initiator_test_suite_fixture_init(struct cap_initiator_test_suite_fixture *fixture)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
-		test_conn_init(&fixture->conns[i]);
+		test_conn_init(&fixture->conns[i], i);
 	}
 }
 

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
@@ -25,6 +25,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
@@ -37,9 +38,17 @@
 #include "expects_util.h"
 #include "test_common.h"
 
+BUILD_ASSERT(CONFIG_BT_MAX_CONN * (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT +
+				   CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT) >=
+	     CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT);
+
+/* Either BT_AUDIO_DIR_SINK or BT_AUDIO_DIR_SOURCE */
+#define INDEX_TO_DIR(_idx) (((_idx) & 1U) + 1U)
+
 struct cap_initiator_test_unicast_start_fixture {
 	struct bt_cap_stream cap_streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
-	struct bt_bap_ep eps[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
+	struct bt_bap_ep *snk_eps[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
+	struct bt_bap_ep *src_eps[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
 	struct bt_cap_unicast_audio_start_stream_param
 		audio_start_stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
 	struct bt_cap_unicast_audio_start_param audio_start_param;
@@ -52,68 +61,45 @@ static void cap_initiator_test_unicast_start_fixture_init(
 	struct cap_initiator_test_unicast_start_fixture *fixture)
 {
 	struct bt_cap_unicast_group_stream_pair_param
-		pair_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
+		group_pair_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
 	struct bt_cap_unicast_group_stream_param
-		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
+		group_stream_param[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
 	struct bt_cap_unicast_group_param group_param = {0};
 	size_t stream_cnt = 0U;
-	size_t pair_cnt = 0U;
+	size_t pair_idx = 0U;
 	int err;
 
 	fixture->preset = (struct bt_bap_lc3_preset)BT_BAP_LC3_UNICAST_PRESET_16_2_1(
 		BT_AUDIO_LOCATION_MONO_AUDIO, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
 
 	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
-		test_conn_init(&fixture->conns[i]);
+		test_conn_init(&fixture->conns[i], i);
 	}
 
-	for (size_t i = 0U; i < ARRAY_SIZE(fixture->eps); i++) {
-		const uint8_t dir = (i & 1) + 1; /* Makes it either 1 or 2 (sink or source)*/
+	while (stream_cnt < ARRAY_SIZE(group_stream_param)) {
+		const enum bt_audio_dir dir = INDEX_TO_DIR(stream_cnt);
 
-		fixture->eps[i].dir = dir;
-	}
+		pair_idx = stream_cnt / 2U;
 
-	while (stream_cnt < ARRAY_SIZE(stream_params)) {
-		stream_params[stream_cnt].stream = &fixture->cap_streams[stream_cnt];
-		stream_params[stream_cnt].qos_cfg = &fixture->preset.qos;
+		group_stream_param[stream_cnt].stream = &fixture->cap_streams[stream_cnt];
+		group_stream_param[stream_cnt].qos_cfg = &fixture->preset.qos;
 
 		/* Switch between sink and source depending on index*/
-		if ((stream_cnt & 1) == 0) {
-			pair_params[pair_cnt].tx_param = &stream_params[stream_cnt];
+		if (dir == BT_AUDIO_DIR_SINK) {
+			group_pair_params[pair_idx].tx_param = &group_stream_param[stream_cnt];
 		} else {
-			pair_params[pair_cnt].rx_param = &stream_params[stream_cnt];
+			group_pair_params[pair_idx].rx_param = &group_stream_param[stream_cnt];
 		}
 
-		pair_cnt = DIV_ROUND_UP(stream_cnt, 2U);
 		stream_cnt++;
 	}
 
 	group_param.packing = BT_ISO_PACKING_SEQUENTIAL;
-	group_param.params_count = pair_cnt;
-	group_param.params = pair_params;
+	group_param.params_count = pair_idx + 1U;
+	group_param.params = group_pair_params;
 
 	err = bt_cap_unicast_group_create(&group_param, &fixture->unicast_group);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
-
-	/* Setup default params */
-	ARRAY_FOR_EACH(fixture->audio_start_stream_params, i) {
-		struct bt_cap_unicast_audio_start_stream_param *stream_param =
-			&fixture->audio_start_stream_params[i];
-		/* We pair 2 streams, so only increase conn_index every 2nd stream and otherwise
-		 * round robin on all conns
-		 */
-		const size_t conn_index = (i / 2) % ARRAY_SIZE(fixture->conns);
-
-		stream_param->stream = &fixture->cap_streams[i];
-		stream_param->codec_cfg = &fixture->preset.codec_cfg;
-		/* Distribute the streams equally among the connections */
-		stream_param->member.member = &fixture->conns[conn_index];
-		stream_param->ep = &fixture->eps[i];
-	}
-
-	fixture->audio_start_param.type = BT_CAP_SET_TYPE_AD_HOC;
-	fixture->audio_start_param.count = CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT;
-	fixture->audio_start_param.stream_params = fixture->audio_start_stream_params;
 }
 
 static void *cap_initiator_test_unicast_start_setup(void)
@@ -126,6 +112,46 @@ static void *cap_initiator_test_unicast_start_setup(void)
 	return fixture;
 }
 
+static void init_default_params(struct cap_initiator_test_unicast_start_fixture *fixture)
+{
+	/* Setup default params */
+	ARRAY_FOR_EACH(fixture->audio_start_stream_params, i) {
+		struct bt_cap_unicast_audio_start_stream_param *stream_param =
+			&fixture->audio_start_stream_params[i];
+
+		/* We pair 2 streams, so only increase conn_index every 2nd stream and otherwise
+		 * round robin on all conns
+		 */
+		const size_t conn_index = (i / 2U) % ARRAY_SIZE(fixture->conns);
+		const size_t ep_index = i / (ARRAY_SIZE(fixture->conns) * 2U);
+		const enum bt_audio_dir dir = INDEX_TO_DIR(i);
+
+		stream_param->stream = &fixture->cap_streams[i];
+		stream_param->codec_cfg = &fixture->preset.codec_cfg;
+
+		/* Distribute the streams like
+		 * [0]: conn[0] snk[0]
+		 * [1]: conn[0] src[0]
+		 * [2]: conn[1] snk[0]
+		 * [3]: conn[1] src[0]
+		 * [4]: conn[0] snk[1]
+		 * [5]: conn[0] src[1]
+		 * [6]: conn[1] snk[1]
+		 * [7]: conn[1] src[1]
+		 */
+		stream_param->member.member = &fixture->conns[conn_index];
+		if (dir == BT_AUDIO_DIR_SINK) {
+			stream_param->ep = fixture->snk_eps[conn_index][ep_index];
+		} else {
+			stream_param->ep = fixture->src_eps[conn_index][ep_index];
+		}
+	}
+
+	fixture->audio_start_param.type = BT_CAP_SET_TYPE_AD_HOC;
+	fixture->audio_start_param.count = CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT;
+	fixture->audio_start_param.stream_params = fixture->audio_start_stream_params;
+}
+
 static void cap_initiator_test_unicast_start_before(void *f)
 {
 	struct cap_initiator_test_unicast_start_fixture *fixture = f;
@@ -136,6 +162,9 @@ static void cap_initiator_test_unicast_start_before(void *f)
 
 	err = bt_cap_initiator_register_cb(&mock_cap_initiator_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	mock_discover(fixture->conns, fixture->snk_eps, fixture->src_eps);
+	init_default_params(fixture);
 }
 
 static void cap_initiator_test_unicast_start_after(void *f)

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
@@ -13,14 +13,17 @@
 #include <string.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
 #include <zephyr/fff.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
@@ -32,10 +35,20 @@
 #include "expects_util.h"
 #include "test_common.h"
 
+BUILD_ASSERT(CONFIG_BT_MAX_CONN * (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT +
+				   CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT) >=
+	     CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT);
+
+/* Either BT_AUDIO_DIR_SINK or BT_AUDIO_DIR_SOURCE */
+#define INDEX_TO_DIR(_idx) (((_idx) & 1U) + 1U)
+
 struct cap_initiator_test_unicast_stop_fixture {
+	struct bt_bap_ep *snk_eps[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
+	struct bt_bap_ep *src_eps[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
+	struct bt_cap_stream *audio_stop_streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
 	struct bt_cap_stream cap_streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
-	struct bt_bap_ep eps[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT];
-	struct bt_bap_unicast_group unicast_group;
+	struct bt_cap_unicast_audio_stop_param audio_stop_param;
+	struct bt_cap_unicast_group *unicast_group;
 	struct bt_conn conns[CONFIG_BT_MAX_CONN];
 	struct bt_bap_lc3_preset preset;
 };
@@ -43,24 +56,93 @@ struct cap_initiator_test_unicast_stop_fixture {
 static void cap_initiator_test_unicast_stop_fixture_init(
 	struct cap_initiator_test_unicast_stop_fixture *fixture)
 {
+	struct bt_cap_unicast_group_stream_pair_param
+		group_pair_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
+	struct bt_cap_unicast_group_stream_param
+		group_stream_param[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
+	struct bt_cap_unicast_group_param group_param = {0};
+	size_t stream_cnt = 0U;
+	size_t pair_idx = 0U;
+	int err;
+
 	fixture->preset = (struct bt_bap_lc3_preset)BT_BAP_LC3_UNICAST_PRESET_16_2_1(
 		BT_AUDIO_LOCATION_MONO_AUDIO, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
 
 	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
-		test_conn_init(&fixture->conns[i]);
+		test_conn_init(&fixture->conns[i], i);
 	}
 
-	for (size_t i = 0U; i < ARRAY_SIZE(fixture->eps); i++) {
-		fixture->eps[i].dir = (i & 1) + 1; /* Makes it either 1 or 2 (sink or source)*/
+	while (stream_cnt < ARRAY_SIZE(group_stream_param)) {
+		const enum bt_audio_dir dir = INDEX_TO_DIR(stream_cnt);
+
+		pair_idx = stream_cnt / 2U;
+
+		group_stream_param[stream_cnt].stream = &fixture->cap_streams[stream_cnt];
+		group_stream_param[stream_cnt].qos_cfg = &fixture->preset.qos;
+
+		/* Switch between sink and source depending on index*/
+		if (dir == BT_AUDIO_DIR_SINK) {
+			group_pair_params[pair_idx].tx_param = &group_stream_param[stream_cnt];
+		} else {
+			group_pair_params[pair_idx].rx_param = &group_stream_param[stream_cnt];
+		}
+
+		stream_cnt++;
 	}
 
-	for (size_t i = 0U; i < ARRAY_SIZE(fixture->cap_streams); i++) {
-		struct bt_cap_stream *cap_stream = &fixture->cap_streams[i];
-		struct bt_bap_stream *bap_stream = &cap_stream->bap_stream;
+	group_param.packing = BT_ISO_PACKING_SEQUENTIAL;
+	group_param.params_count = pair_idx + 1U;
+	group_param.params = group_pair_params;
 
-		sys_slist_append(&fixture->unicast_group.streams, &bap_stream->_node);
-		bap_stream->group = &fixture->unicast_group;
+	err = bt_cap_unicast_group_create(&group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+}
+
+static struct bt_conn *get_conn_from_index(struct cap_initiator_test_unicast_stop_fixture *fixture,
+					   size_t index)
+{
+	const size_t conn_index = (index / 2U) % ARRAY_SIZE(fixture->conns);
+
+	return &fixture->conns[conn_index];
+}
+
+static struct bt_bap_ep *get_ep_from_index(struct cap_initiator_test_unicast_stop_fixture *fixture,
+					   size_t index)
+{
+	const size_t conn_index = (index / 2U) % ARRAY_SIZE(fixture->conns);
+	const size_t ep_index = index / (ARRAY_SIZE(fixture->conns) * 2U);
+	const enum bt_audio_dir dir = INDEX_TO_DIR(index);
+	struct bt_bap_ep *ep;
+
+	/* Distribute the streams like
+	 * [0]: conn[0] snk[0]
+	 * [1]: conn[0] src[0]
+	 * [2]: conn[1] snk[0]
+	 * [3]: conn[1] src[0]
+	 * [4]: conn[0] snk[1]
+	 * [5]: conn[0] src[1]
+	 * [6]: conn[1] snk[1]
+	 * [7]: conn[1] src[1]
+	 */
+	if (dir == BT_AUDIO_DIR_SINK) {
+		ep = fixture->snk_eps[conn_index][ep_index];
+	} else {
+		ep = fixture->src_eps[conn_index][ep_index];
 	}
+
+	return ep;
+}
+
+static void init_default_params(struct cap_initiator_test_unicast_stop_fixture *fixture)
+{
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
+		fixture->audio_stop_streams[i] = &fixture->cap_streams[i];
+	}
+
+	fixture->audio_stop_param.type = BT_CAP_SET_TYPE_AD_HOC;
+	fixture->audio_stop_param.count = ARRAY_SIZE(fixture->cap_streams);
+	fixture->audio_stop_param.streams = fixture->audio_stop_streams;
+	fixture->audio_stop_param.release = false;
 }
 
 static void *cap_initiator_test_unicast_stop_setup(void)
@@ -75,13 +157,17 @@ static void *cap_initiator_test_unicast_stop_setup(void)
 
 static void cap_initiator_test_unicast_stop_before(void *f)
 {
+	struct cap_initiator_test_unicast_stop_fixture *fixture = f;
 	int err;
 
-	memset(f, 0, sizeof(struct cap_initiator_test_unicast_stop_fixture));
+	memset(fixture, 0, sizeof(*fixture));
 	cap_initiator_test_unicast_stop_fixture_init(f);
 
 	err = bt_cap_initiator_register_cb(&mock_cap_initiator_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	mock_discover(fixture->conns, fixture->snk_eps, fixture->src_eps);
+	init_default_params(fixture);
 }
 
 static void cap_initiator_test_unicast_stop_after(void *f)
@@ -96,6 +182,18 @@ static void cap_initiator_test_unicast_stop_after(void *f)
 
 	/* In the case of a test failing, we cancel the procedure so that subsequent won't fail */
 	bt_cap_initiator_unicast_audio_cancel();
+
+	if (fixture->unicast_group != NULL) {
+		const struct bt_cap_unicast_audio_stop_param param = {
+			.type = BT_CAP_SET_TYPE_AD_HOC,
+			.count = ARRAY_SIZE(fixture->cap_streams),
+			.streams = fixture->audio_stop_streams,
+			.release = true,
+		};
+
+		(void)bt_cap_initiator_unicast_audio_stop(&param);
+		(void)bt_cap_unicast_group_delete(fixture->unicast_group);
+	}
 }
 
 static void cap_initiator_test_unicast_stop_teardown(void *f)
@@ -110,30 +208,21 @@ ZTEST_SUITE(cap_initiator_test_unicast_stop, NULL, cap_initiator_test_unicast_st
 static ZTEST_F(cap_initiator_test_unicast_stop,
 	       test_initiator_unicast_stop_disable_state_codec_configured)
 {
-	struct bt_cap_stream *streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_stop_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(streams),
-		.streams = streams,
-		.release = false,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		streams[i] = &fixture->cap_streams[i];
-
-		test_unicast_set_state(streams[i], &fixture->conns[i % ARRAY_SIZE(fixture->conns)],
-				       &fixture->eps[i], &fixture->preset,
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
+		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
+				       get_ep_from_index(fixture, i), &fixture->preset,
 				       BT_BAP_EP_STATE_CODEC_CONFIGURED);
 	}
 
-	err = bt_cap_initiator_unicast_audio_stop(&param);
+	err = bt_cap_initiator_unicast_audio_stop(&fixture->audio_stop_param);
 	zassert_equal(err, -EALREADY, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 0,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
@@ -145,30 +234,21 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 static ZTEST_F(cap_initiator_test_unicast_stop,
 	       test_initiator_unicast_stop_disable_state_qos_configured)
 {
-	struct bt_cap_stream *streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_stop_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(streams),
-		.streams = streams,
-		.release = false,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		streams[i] = &fixture->cap_streams[i];
-
-		test_unicast_set_state(streams[i], &fixture->conns[i % ARRAY_SIZE(fixture->conns)],
-				       &fixture->eps[i], &fixture->preset,
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
+		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
+				       get_ep_from_index(fixture, i), &fixture->preset,
 				       BT_BAP_EP_STATE_QOS_CONFIGURED);
 	}
 
-	err = bt_cap_initiator_unicast_audio_stop(&param);
+	err = bt_cap_initiator_unicast_audio_stop(&fixture->audio_stop_param);
 	zassert_equal(err, -EALREADY, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 0,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
@@ -179,30 +259,21 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 
 static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_disable_state_enabling)
 {
-	struct bt_cap_stream *streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_stop_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(streams),
-		.streams = streams,
-		.release = false,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		streams[i] = &fixture->cap_streams[i];
-
-		test_unicast_set_state(streams[i], &fixture->conns[i % ARRAY_SIZE(fixture->conns)],
-				       &fixture->eps[i], &fixture->preset,
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
+		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
+				       get_ep_from_index(fixture, i), &fixture->preset,
 				       BT_BAP_EP_STATE_ENABLING);
 	}
 
-	err = bt_cap_initiator_unicast_audio_stop(&param);
+	err = bt_cap_initiator_unicast_audio_stop(&fixture->audio_stop_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
@@ -213,30 +284,21 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_disa
 
 static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_disable_state_streaming)
 {
-	struct bt_cap_stream *streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_stop_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(streams),
-		.streams = streams,
-		.release = false,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		streams[i] = &fixture->cap_streams[i];
-
-		test_unicast_set_state(streams[i], &fixture->conns[i % ARRAY_SIZE(fixture->conns)],
-				       &fixture->eps[i], &fixture->preset,
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
+		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
+				       get_ep_from_index(fixture, i), &fixture->preset,
 				       BT_BAP_EP_STATE_STREAMING);
 	}
 
-	err = bt_cap_initiator_unicast_audio_stop(&param);
+	err = bt_cap_initiator_unicast_audio_stop(&fixture->audio_stop_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
-	for (size_t i = 0U; i < ARRAY_SIZE(fixture->cap_streams); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
 		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
@@ -248,138 +310,105 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_disa
 static ZTEST_F(cap_initiator_test_unicast_stop,
 	       test_initiator_unicast_stop_release_state_codec_configured)
 {
-	struct bt_cap_stream *streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_stop_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(streams),
-		.streams = streams,
-		.release = true,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		streams[i] = &fixture->cap_streams[i];
-
-		test_unicast_set_state(streams[i], &fixture->conns[i % ARRAY_SIZE(fixture->conns)],
-				       &fixture->eps[i], &fixture->preset,
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
+		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
+				       get_ep_from_index(fixture, i), &fixture->preset,
 				       BT_BAP_EP_STATE_CODEC_CONFIGURED);
 	}
 
-	err = bt_cap_initiator_unicast_audio_stop(&param);
-	zassert_equal(err, -EALREADY, "Unexpected return value %d", err);
+	fixture->audio_stop_param.release = true;
 
-	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 0,
+	err = bt_cap_initiator_unicast_audio_stop(&fixture->audio_stop_param);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
-		zassert_equal(state, BT_BAP_EP_STATE_CODEC_CONFIGURED,
-			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
+		zassert_equal(bap_stream->ep, NULL, "[%zu]: Stream %p not released (%p)", i,
+			      bap_stream, bap_stream->ep);
 	}
 }
 
 static ZTEST_F(cap_initiator_test_unicast_stop,
 	       test_initiator_unicast_stop_release_state_qos_configured)
 {
-	struct bt_cap_stream *streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_stop_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(streams),
-		.streams = streams,
-		.release = true,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		streams[i] = &fixture->cap_streams[i];
-
-		test_unicast_set_state(streams[i], &fixture->conns[i % ARRAY_SIZE(fixture->conns)],
-				       &fixture->eps[i], &fixture->preset,
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
+		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
+				       get_ep_from_index(fixture, i), &fixture->preset,
 				       BT_BAP_EP_STATE_QOS_CONFIGURED);
 	}
 
-	err = bt_cap_initiator_unicast_audio_stop(&param);
+	fixture->audio_stop_param.release = true;
+
+	err = bt_cap_initiator_unicast_audio_stop(&fixture->audio_stop_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = fixture->eps[i].state;
 
-		zassert_equal(state, BT_BAP_EP_STATE_IDLE, "[%zu]: Stream %p unexpected state: %d",
-			      i, bap_stream, state);
+		zassert_equal(bap_stream->ep, NULL, "[%zu]: Stream %p not released (%p)", i,
+			      bap_stream, bap_stream->ep);
 	}
 }
 
 static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_release_state_enabling)
 {
-	struct bt_cap_stream *streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_stop_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(streams),
-		.streams = streams,
-		.release = true,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		streams[i] = &fixture->cap_streams[i];
-
-		test_unicast_set_state(streams[i], &fixture->conns[i % ARRAY_SIZE(fixture->conns)],
-				       &fixture->eps[i], &fixture->preset,
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
+		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
+				       get_ep_from_index(fixture, i), &fixture->preset,
 				       BT_BAP_EP_STATE_ENABLING);
 	}
 
-	err = bt_cap_initiator_unicast_audio_stop(&param);
+	fixture->audio_stop_param.release = true;
+
+	err = bt_cap_initiator_unicast_audio_stop(&fixture->audio_stop_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = fixture->eps[i].state;
 
-		zassert_equal(state, BT_BAP_EP_STATE_IDLE, "[%zu]: Stream %p unexpected state: %d",
-			      i, bap_stream, state);
+		zassert_equal(bap_stream->ep, NULL, "[%zu]: Stream %p not released (%p)", i,
+			      bap_stream, bap_stream->ep);
 	}
 }
 
 static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_release_state_streaming)
 {
-	struct bt_cap_stream *streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_stop_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = ARRAY_SIZE(streams),
-		.streams = streams,
-		.release = true,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		streams[i] = &fixture->cap_streams[i];
-
-		test_unicast_set_state(streams[i], &fixture->conns[i % ARRAY_SIZE(fixture->conns)],
-				       &fixture->eps[i], &fixture->preset,
-				       BT_BAP_EP_STATE_ENABLING);
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
+		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
+				       get_ep_from_index(fixture, i), &fixture->preset,
+				       BT_BAP_EP_STATE_STREAMING);
 	}
 
-	err = bt_cap_initiator_unicast_audio_stop(&param);
+	fixture->audio_stop_param.release = true;
+
+	err = bt_cap_initiator_unicast_audio_stop(&fixture->audio_stop_param);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 1,
 			   mock_cap_initiator_unicast_stop_complete_cb_fake.call_count);
-
-	for (size_t i = 0U; i < ARRAY_SIZE(fixture->cap_streams); i++) {
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = fixture->eps[i].state;
 
-		zassert_equal(state, BT_BAP_EP_STATE_IDLE, "[%zu]: Stream %p unexpected state: %d",
-			      i, bap_stream, state);
+		zassert_equal(bap_stream->ep, NULL, "[%zu]: Stream %p not released (%p)", i,
+			      bap_stream, bap_stream->ep);
 	}
 }
 
@@ -397,15 +426,11 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_inva
 static ZTEST_F(cap_initiator_test_unicast_stop,
 	       test_initiator_unicast_stop_inval_param_null_streams)
 {
-	const struct bt_cap_unicast_audio_stop_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT,
-		.streams = NULL,
-		.release = true,
-	};
 	int err;
 
-	err = bt_cap_initiator_unicast_audio_stop(&param);
+	fixture->audio_stop_param.streams = NULL;
+
+	err = bt_cap_initiator_unicast_audio_stop(&fixture->audio_stop_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 0,
@@ -414,24 +439,17 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 
 static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_inval_missing_cas)
 {
-	struct bt_cap_stream *streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_stop_param param = {
-		.type = BT_CAP_SET_TYPE_CSIP, /* CSIP requires CAS */
-		.count = ARRAY_SIZE(streams),
-		.streams = streams,
-		.release = true,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		streams[i] = &fixture->cap_streams[i];
+	fixture->audio_stop_param.type = BT_CAP_SET_TYPE_CSIP;
 
-		test_unicast_set_state(streams[i], &fixture->conns[i % ARRAY_SIZE(fixture->conns)],
-				       &fixture->eps[i], &fixture->preset,
+	ARRAY_FOR_EACH(fixture->cap_streams, i) {
+		test_unicast_set_state(&fixture->cap_streams[i], get_conn_from_index(fixture, i),
+				       get_ep_from_index(fixture, i), &fixture->preset,
 				       BT_BAP_EP_STATE_STREAMING);
 	}
 
-	err = bt_cap_initiator_unicast_audio_stop(&param);
+	err = bt_cap_initiator_unicast_audio_stop(&fixture->audio_stop_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 0,
@@ -440,20 +458,11 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_inva
 
 static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_inval_param_zero_count)
 {
-	struct bt_cap_stream *streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_stop_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = 0U,
-		.streams = streams,
-		.release = true,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		streams[i] = &fixture->cap_streams[i];
-	}
+	fixture->audio_stop_param.count = 0U;
 
-	err = bt_cap_initiator_unicast_audio_stop(&param);
+	err = bt_cap_initiator_unicast_audio_stop(&fixture->audio_stop_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 0,
@@ -462,20 +471,11 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_inva
 
 static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_inval_param_inval_count)
 {
-	struct bt_cap_stream *streams[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
-	const struct bt_cap_unicast_audio_stop_param param = {
-		.type = BT_CAP_SET_TYPE_AD_HOC,
-		.count = CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT + 1U,
-		.streams = streams,
-		.release = true,
-	};
 	int err;
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		streams[i] = &fixture->cap_streams[i];
-	}
+	fixture->audio_stop_param.count = CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT + 1U;
 
-	err = bt_cap_initiator_unicast_audio_stop(&param);
+	err = bt_cap_initiator_unicast_audio_stop(&fixture->audio_stop_param);
 	zassert_equal(err, -EINVAL, "Unexpected return value %d", err);
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_stop_complete_cb", 0,


### PR DESCRIPTION
Add check in valid_unicast_audio_start_param to verify that the ep connection matches the member_conn.