### PR TITLE
drivers: clock_control: sf32lb_rcc: add support for DLL2

### DIFF
--- a/drivers/clock_control/clock_control_sf32lb_rcc.c
+++ b/drivers/clock_control/clock_control_sf32lb_rcc.c
@@ -23,28 +23,53 @@
 #define HPSYS_RCC_CSR    offsetof(HPSYS_RCC_TypeDef, CSR)
 #define HPSYS_RCC_CFGR   offsetof(HPSYS_RCC_TypeDef, CFGR)
 #define HPSYS_RCC_DLL1CR offsetof(HPSYS_RCC_TypeDef, DLL1CR)
+#define HPSYS_RCC_DLL2CR offsetof(HPSYS_RCC_TypeDef, DLL2CR)
 
 #define HPSYS_RCC_CSR_SEL_SYS_CLK_HXT48  FIELD_PREP(HPSYS_RCC_CSR_SEL_SYS_Msk, 1U)
 #define HPSYS_RCC_CSR_SEL_SYS_CLK_DLL1   FIELD_PREP(HPSYS_RCC_CSR_SEL_SYS_Msk, 3U)
+#define HPSYS_RCC_CSR_SEL_MPI1_CLK_DLL2  FIELD_PREP(HPSYS_RCC_CSR_SEL_MPI1_Msk, 2U)
+#define HPSYS_RCC_CSR_SEL_MPI2_CLK_DLL2  FIELD_PREP(HPSYS_RCC_CSR_SEL_MPI2_Msk, 2U)
 #define HPSYS_RCC_CSR_SEL_PERI_CLK_HXT48 FIELD_PREP(HPSYS_RCC_CSR_SEL_PERI_Msk, 1U)
 
-#define HPSYS_RCC_DLL1CR_STG_STEP 24000000UL
-
-struct clock_control_sf32lb_rcc_dll_config {
-	bool enabled;
-	uintptr_t pmuc;
-	uint32_t freq;
-};
+#define HPSYS_RCC_DLLXCR_EN          HPSYS_RCC_DLL1CR_EN
+#define HPSYS_RCC_DLLXCR_STG_Msk     HPSYS_RCC_DLL1CR_STG_Msk
+#define HPSYS_RCC_DLLXCR_STG_STEP    24000000UL
+#define HPSYS_RCC_DLLXCR_IN_DIV2_EN  HPSYS_RCC_DLL1CR_IN_DIV2_EN
+#define HPSYS_RCC_DLLXCR_OUT_DIV2_EN HPSYS_RCC_DLL1CR_OUT_DIV2_EN
+#define HPSYS_RCC_DLLXCR_READY       HPSYS_RCC_DLL1CR_READY
 
 struct clock_control_sf32lb_rcc_config {
 	uintptr_t base;
 	uintptr_t cfg;
+	uintptr_t pmuc;
 	uint8_t hdiv;
 	uint8_t pdiv1;
 	uint8_t pdiv2;
-	struct clock_control_sf32lb_rcc_dll_config dll1;
+	uint32_t dll1_freq;
+	uint32_t dll2_freq;
 	const struct device *hxt48;
 };
+
+static inline void configure_dll(const struct device *dev, uint32_t freq, uint32_t dllxcr)
+{
+	const struct clock_control_sf32lb_rcc_config *config = dev->config;
+	uint32_t val;
+
+	/* disable DLLX, clear modified fields */
+	val = sys_read32(config->base + dllxcr);
+	val &= ~HPSYS_RCC_DLLXCR_EN;
+	sys_write32(val, config->base + dllxcr);
+
+	/* configure DLLX */
+	val &= ~(HPSYS_RCC_DLLXCR_STG_Msk | HPSYS_RCC_DLLXCR_OUT_DIV2_EN);
+	val |= FIELD_PREP(HPSYS_RCC_DLLXCR_STG_Msk, (freq / HPSYS_RCC_DLLXCR_STG_STEP) - 1U) |
+	       HPSYS_RCC_DLLXCR_IN_DIV2_EN | HPSYS_RCC_DLLXCR_EN;
+	sys_write32(val, config->base + dllxcr);
+
+	do {
+		val = sys_read32(config->base + dllxcr);
+	} while ((val & HPSYS_RCC_DLLXCR_READY) == 0U);
+}
 
 static int clock_control_sf32lb_rcc_on(const struct device *dev, clock_control_subsys_t sys)
 {
@@ -108,35 +133,33 @@ static int clock_control_sf32lb_rcc_init(const struct device *dev)
 		sys_write32(val, config->base + HPSYS_RCC_CSR);
 	}
 
-	if (config->dll1.enabled) {
-		val = sys_read32(config->dll1.pmuc + PMUC_HXT_CR1);
+	if (config->dll1_freq != 0U || config->dll2_freq != 0U) {
+		val = sys_read32(config->pmuc + PMUC_HXT_CR1);
 		val |= PMUC_HXT_CR1_BUF_DLL_EN;
-		sys_write32(val, config->dll1.pmuc + PMUC_HXT_CR1);
+		sys_write32(val, config->pmuc + PMUC_HXT_CR1);
 
 		val = sys_read32(config->cfg + HPSYS_CFG_CAU2_CR);
 		val |= HPSYS_CFG_CAU2_CR_HPBG_EN | HPSYS_CFG_CAU2_CR_HPBG_VDDPSW_EN;
 		sys_write32(val, config->cfg + HPSYS_CFG_CAU2_CR);
 
-		/* disable DLL1, clear modified fields */
-		val = sys_read32(config->base + HPSYS_RCC_DLL1CR);
-		val &= ~HPSYS_RCC_DLL1CR_EN;
-		sys_write32(val, config->base + HPSYS_RCC_DLL1CR);
-
-		/* configure DLL1 */
-		val &= ~(HPSYS_RCC_DLL1CR_STG_Msk | HPSYS_RCC_DLL1CR_OUT_DIV2_EN);
-		val |= FIELD_PREP(HPSYS_RCC_DLL1CR_STG_Msk,
-				  (config->dll1.freq / HPSYS_RCC_DLL1CR_STG_STEP) - 1U) |
-		       HPSYS_RCC_DLL1CR_IN_DIV2_EN | HPSYS_RCC_DLL1CR_EN;
-		sys_write32(val, config->base + HPSYS_RCC_DLL1CR);
-
-		do {
-			val = sys_read32(config->base + HPSYS_RCC_DLL1CR);
-		} while ((val & HPSYS_RCC_DLL1CR_READY) == 0U);
-
-		/* TODO: make this configurable */
 		val = sys_read32(config->base + HPSYS_RCC_CSR);
-		val &= ~HPSYS_RCC_CSR_SEL_SYS_Msk;
-		val |= HPSYS_RCC_CSR_SEL_SYS_CLK_DLL1;
+
+		if (config->dll1_freq != 0U) {
+			configure_dll(dev, config->dll1_freq, HPSYS_RCC_DLL1CR);
+
+			/* TODO: make this configurable */
+			val &= ~HPSYS_RCC_CSR_SEL_SYS_Msk;
+			val |= HPSYS_RCC_CSR_SEL_SYS_CLK_DLL1;
+		}
+
+		if (config->dll2_freq != 0U) {
+			configure_dll(dev, config->dll2_freq, HPSYS_RCC_DLL2CR);
+
+			/* TODO: make this configurable */
+			val &= ~(HPSYS_RCC_CSR_SEL_MPI1_Msk | HPSYS_RCC_CSR_SEL_MPI2_Msk);
+			val |= HPSYS_RCC_CSR_SEL_MPI1_CLK_DLL2 | HPSYS_RCC_CSR_SEL_MPI2_CLK_DLL2;
+		}
+
 		sys_write32(val, config->base + HPSYS_RCC_CSR);
 	}
 
@@ -151,35 +174,45 @@ static int clock_control_sf32lb_rcc_init(const struct device *dev)
 	return 0;
 }
 
-/* DLL1 requires HXT48 */
-IF_ENABLED(DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll1), okay), (
-	   BUILD_ASSERT(
+/* DLL1/2 requires HXT48 */
+IF_ENABLED(UTIL_OR(
+		DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll1), okay),
+		DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll2), okay)),
+	   (BUILD_ASSERT(
 		(DT_NODE_HAS_STATUS(DT_INST_CLOCKS_CTLR_BY_NAME(0, hxt48), okay)),
-		"DLL1 requires HXT48 to be enabled"
-	   );))
+		"DLL1/2 require HXT48 to be enabled");))
 
-/* DLL1 frequency must be a multiple of step size */
+/* DLL1/2 frequency must be a multiple of step size */
 IF_ENABLED(DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll1), okay), (
 	   BUILD_ASSERT(
 		((DT_PROP(DT_INST_CHILD(0, dll1), clock_frequency) != 0) &&
 		 ((DT_PROP(DT_INST_CHILD(0, dll1), clock_frequency) %
-		   HPSYS_RCC_DLL1CR_STG_STEP) == 0)),
+		   HPSYS_RCC_DLLXCR_STG_STEP) == 0)),
 		"DLL1 frequency must be a non-zero multiple of "
-		STRINGIFY(HPSYS_RCC_DLL1CR_STG_STEP)
+		STRINGIFY(HPSYS_RCC_DLLXCR_STG_STEP)
+	   );))
+
+IF_ENABLED(DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll2), okay), (
+	   BUILD_ASSERT(
+		((DT_PROP(DT_INST_CHILD(0, dll2), clock_frequency) != 0) &&
+		 ((DT_PROP(DT_INST_CHILD(0, dll2), clock_frequency) %
+		   HPSYS_RCC_DLLXCR_STG_STEP) == 0)),
+		"DLL2 frequency must be a non-zero multiple of "
+		STRINGIFY(HPSYS_RCC_DLLXCR_STG_STEP)
 	   );))
 
 static const struct clock_control_sf32lb_rcc_config config = {
 	.base = DT_REG_ADDR(DT_INST_PARENT(0)),
 	.cfg = DT_REG_ADDR(DT_INST_PHANDLE(0, sifli_cfg)),
+	.pmuc = DT_REG_ADDR(DT_INST_PHANDLE(0, sifli_pmuc)),
 	.hxt48 = DEVICE_DT_GET_OR_NULL(DT_INST_CLOCKS_CTLR_BY_NAME(0, hxt48)),
 	.hdiv = DT_INST_PROP(0, sifli_hdiv),
 	.pdiv1 = DT_INST_PROP(0, sifli_pdiv1),
 	.pdiv2 = DT_INST_PROP(0, sifli_pdiv2),
-	.dll1 = {
-		.enabled = DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll1), okay),
-		.pmuc = DT_REG_ADDR(DT_INST_PHANDLE(0, sifli_pmuc)),
-		.freq = DT_PROP(DT_INST_CHILD(0, dll1), clock_frequency),
-	},
+	.dll1_freq = COND_CODE_1(DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll1), okay),
+				 (DT_PROP(DT_INST_CHILD(0, dll1), clock_frequency)), (0U)),
+	.dll2_freq = COND_CODE_1(DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll2), okay),
+				 (DT_PROP(DT_INST_CHILD(0, dll2), clock_frequency)), (0U)),
 };
 
 DEVICE_DT_INST_DEFINE(0, clock_control_sf32lb_rcc_init, NULL, NULL, &config, PRE_KERNEL_1,

--- a/dts/arm/sifli/sf32lb52x.dtsi
+++ b/dts/arm/sifli/sf32lb52x.dtsi
@@ -80,6 +80,11 @@
 					compatible = "sifli,sf32lb-dll";
 					status = "disabled";
 				};
+
+				dll2: dll2 {
+					compatible = "sifli,sf32lb-dll";
+					status = "disabled";
+				};
 			};
 		};
 


### PR DESCRIPTION
Add support for configuring and enabling DLL2. A few things have been
simplified (common PMUC, just store frequency, etc.).