### PR TITLE
modules: hal_nordic: nrfx: Use name for CMake library

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named("nrfx")
 
 # The nrfx source directory can be override through the definition of the NRFX_DIR symbol
 # during the invocation of the build system


### PR DESCRIPTION
Uses a name for this as the auto generared name is long