### PR TITLE
Fix Arduino typo

### DIFF
--- a/boards/adafruit/metro_rp2350/adafruit_metro_rp2350_rp2350b_m33.dts
+++ b/boards/adafruit/metro_rp2350/adafruit_metro_rp2350_rp2350b_m33.dts
@@ -162,7 +162,7 @@ zephyr_udc0: &usbd {
 &pio0 {
 	status = "okay";
 
-	arduion_spi: pio0_spi0 {
+	arduino_spi: pio0_spi0 {
 		compatible = "raspberrypi,pico-spi-pio";
 		clocks = <&clocks RPI_PICO_CLKID_CLK_SYS>;
 		#address-cells = <1>;

--- a/samples/sensor/qdec/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/sensor/qdec/boards/nrf52840dk_nrf52840.overlay
@@ -26,7 +26,7 @@
 &pinctrl {
 	qdec_pinctrl: qdec_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 1, 1)>,   /* Ardiuno D0 */
+			psels = <NRF_PSEL(QDEC_A, 1, 1)>,   /* Arduino D0 */
 				<NRF_PSEL(QDEC_B, 1, 3)>;   /* Arduino D2 */
 		};
 	};

--- a/samples/sensor/qdec/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/sensor/qdec/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -26,7 +26,7 @@
 &pinctrl {
 	qdec_pinctrl: qdec_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 0, 4)>,   /* Ardiuno A0 */
+			psels = <NRF_PSEL(QDEC_A, 0, 4)>,   /* Arduino A0 */
 				<NRF_PSEL(QDEC_B, 0, 6)>;   /* Arduino A2 */
 		};
 	};

--- a/tests/boards/nrf/qdec/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/boards/nrf/qdec/boards/nrf52840dk_nrf52840.overlay
@@ -26,14 +26,14 @@
 &pinctrl {
 	qdec_pinctrl: qdec_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 1, 1)>,   /* Ardiuno D0 */
+			psels = <NRF_PSEL(QDEC_A, 1, 1)>,   /* Arduino D0 */
 				<NRF_PSEL(QDEC_B, 1, 3)>;   /* Arduino D2 */
 		};
 	};
 
 	qdec_sleep_pinctrl: qdec_sleep_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 1, 1)>,   /* Ardiuno D0 */
+			psels = <NRF_PSEL(QDEC_A, 1, 1)>,   /* Arduino D0 */
 				<NRF_PSEL(QDEC_B, 1, 3)>;   /* Arduino D2 */
 			low-power-enable;
 		};

--- a/tests/boards/nrf/qdec/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/boards/nrf/qdec/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -26,7 +26,7 @@
 &pinctrl {
 	qdec_pinctrl: qdec_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 0, 4)>,   /* Ardiuno A0 */
+			psels = <NRF_PSEL(QDEC_A, 0, 4)>,   /* Arduino A0 */
 				<NRF_PSEL(QDEC_B, 0, 6)>;   /* Arduino A2 */
 		};
 	};


### PR DESCRIPTION
Fixes zephyrproject-rtos/zephyr#95804.

Found few other typos and fixed them.