### PR TITLE
cc13xx_cc26xx: select required CRC with SubG driver

### DIFF
--- a/drivers/ieee802154/Kconfig.cc13xx_cc26xx
+++ b/drivers/ieee802154/Kconfig.cc13xx_cc26xx
@@ -57,6 +57,7 @@ endif # IEEE802154_CC13XX_CC26XX
 
 menuconfig IEEE802154_CC13XX_CC26XX_SUB_GHZ
 	bool "TI CC13xx / CC26xx IEEE 802.15.4g driver support"
+	select CRC
 	default y
 	depends on DT_HAS_TI_CC13XX_CC26XX_IEEE802154_SUBGHZ_ENABLED
 


### PR DESCRIPTION
This was previously only selected when the 2.4GHz driver was enabled, but SubG can be enabled without the 2.4GHz driver.

Build tested using:

```
west build -b beagleconnect_freedom -d build/bcf/ot_coap samples/net/openthread/coap
west flash -d build/bcf/ot_coap
```