### PR TITLE
soc: rw612: Reinitialize the GDET sensor and Voltage rails

### DIFF
--- a/boards/nxp/frdm_rw612/init.c
+++ b/boards/nxp/frdm_rw612/init.c
@@ -36,6 +36,13 @@ void board_early_init_hook(void)
 {
 	frdm_rw612_power_init_config();
 
+	/* If this is a wakeup from PM3 then return after configuring
+	 * the power supplies.
+	 */
+	if (PMU->PWR_MODE_STATUS == 2U) {
+		return;
+	}
+
 #if CONFIG_PM
 	static struct pm_notifier frdm_rw612_pm_notifier = {
 		.state_exit = frdm_rw612_pm_state_exit,

--- a/boards/nxp/rd_rw612_bga/init.c
+++ b/boards/nxp/rd_rw612_bga/init.c
@@ -36,6 +36,13 @@ void board_early_init_hook(void)
 {
 	rdrw61x_power_init_config();
 
+	/* If this is a wakeup from PM3 then return after configuring
+	 * the power supplies.
+	 */
+	if (PMU->PWR_MODE_STATUS == 2U) {
+		return;
+	}
+
 #if CONFIG_PM
 	static struct pm_notifier rdrw61x_pm_notifier = {
 		.state_exit = rdrw61x_pm_state_exit,


### PR DESCRIPTION
Before re-entering Power Mode 3, we should disable the GET sensor and reinitialize the power rails.