### PR TITLE
video: Improve control framework

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -172,6 +172,11 @@ Display
 
 * SSD1363's properties using 'greyscale' now use 'grayscale'.
 
+Video
+*******
+
+* The :c:func:`video_init_ctrl` signature is changed.
+
 PTP Clock
 *********
 

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -58,6 +58,11 @@ Removed APIs and options
   PSA Crypto API is now the recommended cryptographic library for Zephyr.
 * The legacy pipe object API was removed. Use the new pipe API instead.
 
+* Video
+
+  * :c:func:`video_init_menu_ctrl`
+  * :c:func:`video_init_int_menu_ctrl`
+
 Deprecated APIs and options
 ===========================
 

--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -1185,26 +1185,20 @@ static int gc2145_init_controls(const struct device *dev)
 	struct gc2145_data *drv_data = dev->data;
 	struct gc2145_ctrls *ctrls = &drv_data->ctrls;
 
-	ret = video_init_ctrl(&ctrls->hflip, dev, VIDEO_CID_HFLIP,
-			      (struct video_ctrl_range){.min = 0, .max = 1, .step = 1, .def = 0});
+	ret = video_init_ctrl(&ctrls->hflip, dev);
 	if (ret) {
 		return ret;
 	}
 
-	ret = video_init_ctrl(&ctrls->vflip, dev, VIDEO_CID_VFLIP,
-			      (struct video_ctrl_range){.min = 0, .max = 1, .step = 1, .def = 0});
+	ret = video_init_ctrl(&ctrls->vflip, dev);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = video_init_int_menu_ctrl(&ctrls->linkfreq, dev, VIDEO_CID_LINK_FREQ,
-				       GC2145_640_480_LINK_FREQ_ID, gc2145_link_frequency,
-				       ARRAY_SIZE(gc2145_link_frequency));
+	ret = video_init_ctrl(&ctrls->linkfreq, dev);
 	if (ret < 0) {
 		return ret;
 	}
-
-	ctrls->linkfreq.flags |= VIDEO_CTRL_FLAG_READ_ONLY;
 
 	return 0;
 }
@@ -1293,8 +1287,29 @@ static int gc2145_init(const struct device *dev)
 #define GC2145_GET_PWDN_GPIO(n)
 #endif
 
-#define GC2145_INIT(n)										\
-	static struct gc2145_data gc2145_data_##n;						\
+#define GC2145_INIT(n)                                                                         \
+	static struct gc2145_data gc2145_data_##n = {                                           \
+		.ctrls = {                                                                      \
+			.hflip =                                                                \
+				{                                                               \
+					.id = VIDEO_CID_HFLIP,                                  \
+					.range = {.min = 0, .max = 1, .step = 1, .def = 0},     \
+				},                                                              \
+			.vflip =                                                                \
+				{                                                               \
+					.id = VIDEO_CID_VFLIP,                                  \
+					.range = {.min = 0, .max = 1, .step = 1, .def = 0},     \
+				},                                                              \
+			.link_freq =                                                            \
+				{                                                               \
+					.id = VIDEO_CID_LINK_FREQ,                              \
+					.range = {.max = ARRAY_SIZE(gc2145_link_frequency) - 1, \
+						  .def = GC2145_640_480_LINK_FREQ_ID},          \
+					.flags = VIDEO_CTRL_FLAG_READ_ONLY,                     \
+					.int_menu = gc2145_link_frequency,                      \
+				},                                                              \
+		}};                                                                             \
+                                                                                               \
 	static const struct gc2145_config gc2145_cfg_##n = {					\
 		.i2c = I2C_DT_SPEC_INST_GET(n),							\
 		GC2145_GET_PWDN_GPIO(n)								\

--- a/drivers/video/video_ctrls.c
+++ b/drivers/video/video_ctrls.c
@@ -562,6 +562,9 @@ fill_query:
 		cq->int_menu = ctrl->int_menu;
 	}
 	cq->name = video_get_ctrl_name(cq->id);
+	if (cq->name == NULL) {
+		cq->name = ctrl->name;
+	}
 
 	return 0;
 }

--- a/drivers/video/video_ctrls.c
+++ b/drivers/video/video_ctrls.c
@@ -119,6 +119,12 @@ static inline void set_type_flag(struct video_ctrl *ctrl)
 	case VIDEO_CID_LINK_FREQ:
 		ctrl->type = VIDEO_CTRL_TYPE_INTEGER_MENU;
 		break;
+	case VIDEO_CID_PAN_RELATIVE:
+	case VIDEO_CID_TILT_RELATIVE:
+	case VIDEO_CID_FOCUS_RELATIVE:
+	case VIDEO_CID_IRIS_RELATIVE:
+	case VIDEO_CID_ZOOM_RELATIVE:
+		ctrl->flags |= VIDEO_CTRL_FLAG_WRITE_ONLY | VIDEO_CTRL_FLAG_EXECUTE_ON_WRITE;
 	default:
 		if (ctrl->id < VIDEO_CID_PRIVATE_BASE) {
 			ctrl->type = VIDEO_CTRL_TYPE_INTEGER;
@@ -324,8 +330,9 @@ int video_set_ctrl(const struct device *dev, struct video_control *control)
 	}
 
 	/* No new value */
-	if (ctrl->type == VIDEO_CTRL_TYPE_INTEGER64 ? ctrl->val64 == control->val64
-						    : ctrl->val == control->val) {
+	bool no_changed = ctrl->type == VIDEO_CTRL_TYPE_INTEGER64 ? ctrl->val64 == control->val64
+							       : ctrl->val == control->val;
+	if (no_changed && !(ctrl->flags & VIDEO_CTRL_FLAG_EXECUTE_ON_WRITE)) {
 		return 0;
 	}
 

--- a/drivers/video/video_ctrls.c
+++ b/drivers/video/video_ctrls.c
@@ -131,6 +131,10 @@ static inline void set_type_flag(struct video_ctrl *ctrl)
 		}
 		break;
 	}
+
+	if (ctrl->type == VIDEO_CTRL_TYPE_BUTTON) {
+		ctrl->flags |= VIDEO_CTRL_FLAG_WRITE_ONLY | VIDEO_CTRL_FLAG_EXECUTE_ON_WRITE;
+	}
 }
 
 int video_init_ctrl(struct video_ctrl *ctrl, const struct device *const dev)

--- a/drivers/video/video_ctrls.h
+++ b/drivers/video/video_ctrls.h
@@ -19,6 +19,11 @@
 #define VIDEO_CTRL_FLAG_INACTIVE   BIT(3)
 /** Control that affects other controls, e.g. the primary control of a cluster */
 #define VIDEO_CTRL_FLAG_UPDATE     BIT(4)
+/**
+ * Control is executed immediately when set, and driver callback is invoked even if the value
+ * hasn't changed
+ */
+#define VIDEO_CTRL_FLAG_EXECUTE_ON_WRITE BIT(5)
 
 enum video_ctrl_type {
 	/** Boolean type */

--- a/drivers/video/video_ctrls.h
+++ b/drivers/video/video_ctrls.h
@@ -61,6 +61,7 @@ struct video_ctrl {
 		const char *const *menu;
 		const int64_t *int_menu;
 	};
+	const char *name;
 
 	/* Fields should not be touched by drivers */
 	const struct video_device *vdev;

--- a/drivers/video/video_ctrls.h
+++ b/drivers/video/video_ctrls.h
@@ -41,13 +41,7 @@ struct video_device;
  * @see video_control for the struct used in public API
  */
 struct video_ctrl {
-	/* Fields should not touched by drivers, used only for the 1st control of a cluster */
-	struct video_ctrl *cluster;
-	uint8_t cluster_sz;
-	bool is_auto;
-	bool has_volatiles;
-
-	const struct video_device *vdev;
+	/* Fields could be set directly by drivers if needed */
 	uint32_t id;
 	enum video_ctrl_type type;
 	unsigned long flags;
@@ -60,17 +54,17 @@ struct video_ctrl {
 		const char *const *menu;
 		const int64_t *int_menu;
 	};
+
+	/* Fields should not be touched by drivers */
+	const struct video_device *vdev;
+	struct video_ctrl *cluster;
+	uint8_t cluster_sz;
+	bool is_auto;
+	bool has_volatiles;
 	sys_dnode_t node;
 };
 
-int video_init_ctrl(struct video_ctrl *ctrl, const struct device *dev, uint32_t id,
-		    struct video_ctrl_range range);
-
-int video_init_menu_ctrl(struct video_ctrl *ctrl, const struct device *dev, uint32_t id,
-			 uint8_t def, const char *const menu[]);
-
-int video_init_int_menu_ctrl(struct video_ctrl *ctrl, const struct device *dev, uint32_t id,
-			     uint8_t def, const int64_t menu[], size_t menu_len);
+int video_init_ctrl(struct video_ctrl *ctrl, const struct device *const dev);
 
 void video_cluster_ctrl(struct video_ctrl *ctrls, uint8_t sz);
 

--- a/drivers/video/video_ctrls.h
+++ b/drivers/video/video_ctrls.h
@@ -38,6 +38,8 @@ enum video_ctrl_type {
 	VIDEO_CTRL_TYPE_STRING = 5,
 	/** Menu integer type, standard or driver-defined menu */
 	VIDEO_CTRL_TYPE_INTEGER_MENU = 6,
+	/** Command-like type, triggers an action when written, without storing a value */
+	VIDEO_CTRL_TYPE_BUTTON = 7,
 };
 
 struct video_device;


### PR DESCRIPTION
- Currently, control initialization is done in an unconsistent way, i.e. drivers need to pass some field values to video_init_ctrl() but still needs to set some other fields directly (type, flags, name, etc.). Refactor video_init_ctrl() to make it more consistent, i.e. initializing all kinds of control (standard, menu, integer menu, custom) is now done by setting directly the video_ctrl's fields and using the same API.
- Add VIDEO_CTRL_FLAG_EXECUTE_ON_WRITE
- Add VIDEO_CTRL_TYPE_BUTTON
- Add  name field to video_ctrl struct

Changes are for now applied on ov5640 and gc2145.
TODO: Apply changes on other camera sensor drivers