### PR TITLE
include: hooks.h: Add mocks

### DIFF
--- a/include/zephyr/platform/hooks.h
+++ b/include/zephyr/platform/hooks.h
@@ -20,6 +20,7 @@
  */
 
 
+#ifdef CONFIG_SOC_RESET_HOOK
 /**
  * @brief SoC  hook executed at the beginning of the reset vector.
  *
@@ -27,7 +28,11 @@
  * SoC-specific initialization.
  */
 void soc_reset_hook(void);
+#else
+#define soc_reset_hook() do { } while (0)
+#endif
 
+#ifdef CONFIG_SOC_PREP_HOOK
 /**
  * @brief SoC hook executed after the reset vector.
  *
@@ -35,7 +40,11 @@ void soc_reset_hook(void);
  * SoC-specific initialization.
  */
 void soc_prep_hook(void);
+#else
+#define soc_prep_hook() do { } while (0)
+#endif
 
+#ifdef CONFIG_SOC_EARLY_INIT_HOOK
 /**
  * @brief SoC hook executed before the kernel and devices are initialized.
  *
@@ -43,7 +52,11 @@ void soc_prep_hook(void);
  * SoC-specific initialization.
  */
 void soc_early_init_hook(void);
+#else
+#define soc_early_init_hook() do { } while (0)
+#endif
 
+#ifdef CONFIG_SOC_LATE_INIT_HOOK
 /**
  * @brief SoC hook executed after the kernel and devices are initialized.
  *
@@ -51,7 +64,11 @@ void soc_early_init_hook(void);
  * SoC-specific initialization.
  */
 void soc_late_init_hook(void);
+#else
+#define soc_late_init_hook() do { } while (0)
+#endif
 
+#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
 /**
  * @brief SoC per-core initialization
  *
@@ -59,7 +76,11 @@ void soc_late_init_hook(void);
  * SoC-specific per-core initialization
  */
 void soc_per_core_init_hook(void);
+#else
+#define soc_per_core_init_hook() do { } while (0)
+#endif
 
+#ifdef CONFIG_BOARD_EARLY_INIT_HOOK
 /**
  * @brief Board hook executed before the kernel starts.
  *
@@ -68,7 +89,11 @@ void soc_per_core_init_hook(void);
  * initialization.
  */
 void board_early_init_hook(void);
+#else
+#define board_early_init_hook() do { } while (0)
+#endif
 
+#ifdef CONFIG_BOARD_LATE_INIT_HOOK
 /**
  * @brief Board hook executed after the kernel starts.
  *
@@ -77,5 +102,8 @@ void board_early_init_hook(void);
  * any board-specific initialization.
  */
 void board_late_init_hook(void);
+#else
+#define board_late_init_hook() do { } while (0)
+#endif
 
 #endif

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -300,12 +300,10 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	arch_irq_offload_init();
 #endif
 	z_sys_init_run_level(INIT_LEVEL_POST_KERNEL);
-#if CONFIG_SOC_LATE_INIT_HOOK
+
 	soc_late_init_hook();
-#endif
-#if CONFIG_BOARD_LATE_INIT_HOOK
+
 	board_late_init_hook();
-#endif
 
 #if defined(CONFIG_STACK_POINTER_RANDOM) && (CONFIG_STACK_POINTER_RANDOM != 0)
 	z_stack_adjust_initialized = 1;
@@ -554,12 +552,10 @@ FUNC_NORETURN void z_cstart(void)
 	/* do any necessary initialization of static devices */
 	z_device_state_init();
 
-#if CONFIG_SOC_EARLY_INIT_HOOK
 	soc_early_init_hook();
-#endif
-#if CONFIG_BOARD_EARLY_INIT_HOOK
+
 	board_early_init_hook();
-#endif
+
 	/* perform basic hardware initialization */
 	z_sys_init_run_level(INIT_LEVEL_PRE_KERNEL_1);
 #if defined(CONFIG_SMP)


### PR DESCRIPTION
Add mocks of platform hooks so that #ifdef are not needed around calls to these functions.