### PR TITLE
mgmt: hawkbit: Add options to not confirm or erase at init

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -171,6 +171,8 @@ New APIs and options
   * hawkBit
 
     * :kconfig:option:`CONFIG_HAWKBIT_REBOOT_NONE`
+    * :kconfig:option:`CONFIG_HAWKBIT_CONFIRM_IMG_ON_INIT`
+    * :kconfig:option:`CONFIG_HAWKBIT_ERASE_SECOND_SLOT_ON_CONFIRM`
 
 * Networking
 

--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -258,6 +258,21 @@ config HAWKBIT_SAVE_PROGRESS_INTERVAL
 	  Set the interval (in percent) that the hawkBit update download progress will be saved.
 	  0 means that the progress will be saved every time a new chunk is downloaded.
 
+config HAWKBIT_CONFIRM_IMG_ON_INIT
+	bool "Confirm boot image at hawkBit init"
+	default y
+	help
+	  Automatically confirm current boot image at hawkBit initialization.
+	  Application shall handle image confirmation when set to false.
+
+config HAWKBIT_ERASE_SECOND_SLOT_ON_CONFIRM
+	bool "Erase second slot after confirming boot image"
+	default y
+	depends on HAWKBIT_CONFIRM_IMG_ON_INIT
+	help
+	  Erase the second image slot partition contents after confirming current boot image
+	  at hawkBit init.
+
 module = HAWKBIT
 module-str = Log Level for hawkbit
 module-help = Enables logging for hawkBit code.

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -910,7 +910,8 @@ int hawkbit_init(void)
 
 	image_ok = boot_is_img_confirmed();
 	LOG_INF("Current image is%s confirmed", image_ok ? "" : " not");
-	if (!image_ok) {
+
+	if (IS_ENABLED(CONFIG_HAWKBIT_CONFIRM_IMG_ON_INIT) && !image_ok) {
 		ret = boot_write_img_confirmed();
 		if (ret < 0) {
 			LOG_ERR("Failed to confirm current image: %d", ret);
@@ -918,10 +919,13 @@ int hawkbit_init(void)
 		}
 
 		LOG_DBG("Marked current image as OK");
-		ret = boot_erase_img_bank(flash_img_get_upload_slot());
-		if (ret < 0) {
-			LOG_ERR("Failed to erase second slot: %d", ret);
-			return ret;
+
+		if (IS_ENABLED(CONFIG_HAWKBIT_ERASE_SECOND_SLOT_ON_CONFIRM)) {
+			ret = boot_erase_img_bank(flash_img_get_upload_slot());
+			if (ret < 0) {
+				LOG_ERR("Failed to erase second slot: %d", ret);
+				return ret;
+			}
 		}
 
 		hawkbit_event_raise(HAWKBIT_EVENT_CONFIRMED_CURRENT_IMAGE);


### PR DESCRIPTION
Current implementation forces confirmation of current boot image and second slot erase at hawkbit_init() and it is impossible to communicate with hawkBit server without running it.
This makes impossible to notify update failures to server (#71750)

Add option HAWKBIT_CONFIRM_IMG_ON_INIT to allow disabling the auto image confirmation and HAWKBIT_ERASE_SECOND_SLOT_ON_CONFIRM to select if the second partition slot shall be erased or not.

Disable those to handle of these behaviors on application code.