### PR TITLE
drivers: display: ls0xx: add support for serial VCOM inversion

### DIFF
--- a/dts/bindings/display/sharp,ls0xx.yaml
+++ b/dts/bindings/display/sharp,ls0xx.yaml
@@ -45,3 +45,21 @@ properties:
       The DISPLAY pin controls if the LCD displays memory contents or
       white screen. If defined, the pin will be set high during driver
       initialization. display blanking apis can be used to control it.
+
+  serial-vcom-inversion:
+    type: boolean
+    description: Send serial VCOM inversion commands
+
+      Enable when EXTCOMIN is not configured and VCOM inversion is not
+      application-managed.
+
+  serial-vcom-interval:
+    type: int
+    default: 1000
+    description: Serial VCOM inversion interval
+
+      VCOM inversion interval in milliseconds. This value is used when
+      there is no EXTCOMIN configured and serial-vcom inversion is set.
+      If not configured, 1000ms will be used which is the minimum some
+      sources recommend, though the panel datasheet may specify a more
+      frequent interval and 1000ms will also be visible.


### PR DESCRIPTION
The ls0xx display series require continuous VCOM inversion to prevent panel damage, this commit adds support for doing so over SPI (without EXTCOMIN connected), set via a new pair of devicetree properties so that this isn't a breaking change for anyone implementing this in their application already.

I've tested this on an nRF5340-based board with the LS013B7DH05, and others have tested parts of my work with other displays in the ls0xx line and with the nRF52840 work. 

This is based on the work that was started in the stale pull request #50935 and takes the same approach, however I ran into a few issues:
- The existing VCOM inversion stack overflowed
- That pull request is a breaking change for anyone already handling this in their application code
- There is no protection between display commands and display refreshes, so it would cause occasional image artifacts

Additionally, the addition of a mutex to cover commands and updates should improve this driver for all use cases so that one can't get image artifacts sending commands to the display.

I've tested this with EXTCOMIN to confirm it sends the signal as expected still and without any VCOM-related properties (the ones for EXTCOMIN and the ones I added for serial VCOM) to help ensure this is non-breaking for existing users.

If this moves forward, I will separately PR an update to the [Sharp memory display generic shield](https://docs.zephyrproject.org/latest/boards/shields/ls0xx_generic/doc/index.html) page to document the new devicetree options and that it is no longer the case that one must manage VCOM in software if they haven't connected EXTCOMIN.

Fixes #98271 