### PR TITLE
mcux: wifi_nxp: Enable IMU IRQ after event initialized

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -2024,9 +2024,7 @@ static int nxp_wifi_dev_init(const struct device *dev)
 
 #ifdef CONFIG_NXP_RW610
 	IRQ_CONNECT(IMU_IRQ_N, IMU_IRQ_P, WL_MCI_WAKEUP0_DriverIRQHandler, 0, 0);
-	irq_enable(IMU_IRQ_N);
 	IRQ_CONNECT(IMU_WAKEUP_IRQ_N, IMU_WAKEUP_IRQ_P, WL_MCI_WAKEUP_DONE0_DriverIRQHandler, 0, 0);
-	irq_enable(IMU_WAKEUP_IRQ_N);
 #if (DT_INST_PROP(0, wakeup_source))
 	NXP_ENABLE_WAKEUP_SIGNAL(IMU_IRQ_N);
 #endif /* DT_INST_PROP */

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: aa3d275aa690dd364503d83ecf730da367297af9
+      revision: 97eecad81142a5f28b8c3e5177ecef521dc05b7a
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION

After running 'kernel reboot' cmd on coex application, zephyr os clean bss section, IMU13 IRQ event data set as 0, then CPU3 receive IMU13 IRQ from CPU1, need access IMU13 IRQ event, cause hang.
Put enable IMU13 IRQ operation after related task and event created to fix this issue.