### PR TITLE
tests: sd: sdmmc: remove mimxrt700_evk/mimxrt798s/cm33_cpu0

### DIFF
--- a/tests/subsys/sd/sdmmc/testcase.yaml
+++ b/tests/subsys/sd/sdmmc/testcase.yaml
@@ -8,7 +8,7 @@ tests:
     harness: ztest
     harness_config:
       fixture: fixture_sdhc
-    filter: dt_alias_exists("sdhc0")
+    filter: dt_compat_enabled("zephyr,sdmmc-disk")
     tags: sdhc
     min_ram: 32
     integration_platforms:


### PR DESCRIPTION
What RT700 EVK enables now is eMMC on USDHC0. So, remove the SD card test case.