### PR TITLE
drivers: nrfx: add conditional ISR safety

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -285,7 +285,7 @@ static DEVICE_API(i2c, i2c_nrfx_twim_driver_api) = {
 				DT_PROP(I2C(idx), easydma_maxcnt_bits)),       \
 	};								       \
 	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action,                     \
-			PM_DEVICE_ISR_SAFE);                                   \
+			I2C_PM_ISR_SAFE(idx));                                 \
 	I2C_DEVICE_DT_DEINIT_DEFINE(I2C(idx),				       \
 		      i2c_nrfx_twim_init,				       \
 		      i2c_nrfx_twim_deinit,				       \

--- a/drivers/i2c/i2c_nrfx_twim_common.h
+++ b/drivers/i2c/i2c_nrfx_twim_common.h
@@ -31,6 +31,26 @@ extern "C" {
 #define I2C_FREQUENCY(idx)      I2C_NRFX_TWIM_FREQUENCY(DT_PROP_OR(I2C(idx), clock_frequency,      \
 								   I2C_BITRATE_STANDARD))
 
+/* Macro determines PM actions interrupt safety level.
+ *
+ * Requesting/releasing TWIM device may be ISR safe, but it cannot be reliably known whether
+ * managing its power domain is. It is then assumed that if power domains are used, device is
+ * no longer ISR safe. This macro let's us check if we will be requesting/releasing
+ * power domains and determines PM device ISR safety value.
+ */
+#define I2C_PM_ISR_SAFE(idx)									\
+	COND_CODE_1(										\
+		UTIL_AND(									\
+			IS_ENABLED(CONFIG_PM_DEVICE_POWER_DOMAIN),				\
+			UTIL_AND(								\
+				DT_NODE_HAS_PROP(I2C(idx), power_domains),			\
+				DT_NODE_HAS_STATUS_OKAY(DT_PHANDLE(I2C(idx), power_domains))	\
+			)									\
+		),										\
+		(0),										\
+		(PM_DEVICE_ISR_SAFE)								\
+	)
+
 struct i2c_nrfx_twim_common_config {
 	nrfx_twim_t twim;
 	nrfx_twim_config_t twim_config;

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -287,7 +287,7 @@ static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
 			},                                                                         \
 		.ctx = &_i2c##idx##_twim_rtio,                                                     \
 	};                                                                                         \
-	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action, PM_DEVICE_ISR_SAFE);                    \
+	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action, I2C_PM_ISR_SAFE(idx));                  \
 	I2C_DEVICE_DT_DEINIT_DEFINE(I2C(idx), i2c_nrfx_twim_rtio_init, i2c_nrfx_twim_rtio_deinit,  \
 			     PM_DEVICE_DT_GET(I2C(idx)), &twim_##idx##z_data,                      \
 			     &twim_##idx##z_config, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,         \


### PR DESCRIPTION
Requesting/releasing driver device may be ISR safe, but it cannot be reliably known whether managing its power domain is. Is is then assumed that if power domains are used, device is no longer ISR safe. This macro let's us check if we will be requesting/releasing power domains and determines PM device ISR safety value.