### PR TITLE
.github: workflows: bsim-tests: install python packages

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -97,6 +97,10 @@ jobs:
 
           echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
 
+      - name: Install Python packages
+        run: |
+          pip install -r scripts/requirements-actions.txt --require-hashes
+
       - name: Check common triggering files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         id: check-common-files


### PR DESCRIPTION
A bit confused as to how this worked before, maybe the docker image had pykwalify pre-installed or something, but we do need python dependencies properly installed to run CI - here this commit is specifically fixing an issue with jsonschema not being found.