### PR TITLE
net: l2: openthread: Fix nat64 API compile warning

### DIFF
--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -28,6 +28,10 @@ LOG_MODULE_REGISTER(net_l2_openthread, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 
 #include "openthread_utils.h"
 
+#if defined(CONFIG_OPENTHREAD_NAT64_TRANSLATOR)
+#include <openthread/nat64.h>
+#endif /* CONFIG_OPENTHREAD_NAT64_TRANSLATOR */
+
 #if defined(CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER)
 #include "openthread_border_router.h"
 #endif /* CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER */


### PR DESCRIPTION
This PR includes OpenThread's NAT64 header file when NAT64_TRANSLATOR is enabled. This is done to avoid compile warnings when OT NAT64 API is used.