### PR TITLE
soc: nuvoton: numicro: Disable m48x SPIM cache

### DIFF
--- a/soc/nuvoton/numicro/m48x/soc.c
+++ b/soc/nuvoton/numicro/m48x/soc.c
@@ -12,6 +12,11 @@ void soc_reset_hook(void)
 {
 	SYS_UnlockReg();
 
+	/* Disable SPIM cache to relocate 32 KB to SRAM */
+	CLK->AHBCLK |= CLK_AHBCLK_SPIMCKEN_Msk;
+	SPIM->CTL1 |= SPIM_CTL1_CACHEOFF_Msk;
+	SPIM->CTL1 |= SPIM_CTL1_CCMEN_Msk;
+
 	/* system clock init */
 	SystemInit();
 


### PR DESCRIPTION
This PR is to disable m48x SPIM cache by default, the SRAM size could be 160 KB.
It could fix heap init failure in blinky or hello_world sample on numaker_pfm_m487.