### PR TITLE
boards: nxp: mimxrt1180_evk: suppress spi_bus_bridge warning

### DIFF
--- a/dts/arm/nxp/nxp_rt118x_cm33.dtsi
+++ b/dts/arm/nxp/nxp_rt118x_cm33.dtsi
@@ -37,11 +37,11 @@
 			ranges = <0x0 0x50000000 0x10000000>;
 		};
 
-		flexspi: memory-controller@525e0000 {
+		flexspi: spi@525e0000 {
 			reg = <0x525e0000 0x4000>, <0x38000000 DT_SIZE_M(128)>;
 		};
 
-		flexspi2: memory-controller@545e0000 {
+		flexspi2: spi@545e0000 {
 			reg = <0x545e0000 0x4000>, <0x14000000 DT_SIZE_M(64)>;
 		};
 	};

--- a/dts/arm/nxp/nxp_rt118x_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt118x_cm7.dtsi
@@ -30,11 +30,11 @@
 			ranges = <0x0 0x40000000 0x10000000>;
 		};
 
-		flexspi: memory-controller@425e0000 {
+		flexspi: spi@425e0000 {
 			reg = <0x425e0000 0x4000>, <0x28000000 DT_SIZE_M(128)>;
 		};
 
-		flexspi2: memory-controller@445e0000 {
+		flexspi2: spi@445e0000 {
 			reg = <0x445e0000 0x4000>, <0x04000000 DT_SIZE_M(64)>;
 		};
 	};

--- a/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
@@ -55,11 +55,11 @@
 	};
 
 	soc {
-		xspi0: memory-controller@50184000 {
+		xspi0: spi@50184000 {
 			reg = <0x50184000 0x1000>, <0x38000000 DT_SIZE_M(128)>;
 		};
 
-		xspi1: memory-controller@50185000 {
+		xspi1: spi@50185000 {
 			reg = <0x50185000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
 		};
 	};

--- a/dts/arm/nxp/nxp_rt7xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_common.dtsi
@@ -24,7 +24,7 @@
 			ranges = <0x0 0x50000000 0x10000000>;
 		};
 
-		xspi2: memory-controller@50411000 {
+		xspi2: spi@50411000 {
 			reg = <0x50411000 0x1000>, <0x70000000 DT_SIZE_M(128)>;
 		};
 	};


### PR DESCRIPTION
Suppress "spi_bus_bridge" warning, as the flexspi is used as memory controller, the node name isn't spi@...