### PR TITLE
lib: hash: Fix OA/LP hmap inserts returning already removed entries

### DIFF
--- a/lib/hash/hash_map_oa_lp.c
+++ b/lib/hash/hash_map_oa_lp.c
@@ -84,23 +84,22 @@ static int sys_hashmap_oa_lp_insert_no_rehash(struct sys_hashmap *map, uint64_t 
 	__ASSERT_NO_MSG(entry != NULL);
 
 	switch (entry->state) {
-	case UNUSED:
-		++data->size;
-		ret = 1;
-		break;
 	case TOMBSTONE:
 		--data->n_tombstones;
 		++data->size;
-		ret = 0;
+		ret = 1;
 		break;
 	case USED:
-	default:
+		if (old_value != NULL) {
+			*old_value = entry->value;
+		}
 		ret = 0;
 		break;
-	}
-
-	if (old_value != NULL) {
-		*old_value = entry->value;
+	case UNUSED:
+	default:
+		++data->size;
+		ret = 1;
+		break;
 	}
 
 	entry->state = USED;

--- a/tests/lib/hash_map/src/remove.c
+++ b/tests/lib/hash_map/src/remove.c
@@ -37,3 +37,24 @@ ZTEST(hash_map, test_remove_false)
 	zassert_equal(1, sys_hashmap_insert(&map, 1, 1, NULL));
 	zassert_false(sys_hashmap_remove(&map, 42, NULL));
 }
+
+ZTEST(hash_map, test_remove_entry)
+{
+	uint64_t entry = 0xF00DF00DF00DF00DU;
+	uint64_t old_value;
+
+	/* Fill hashmap so that the rehashing condition is not always met when running the test */
+	for (size_t i = 0; i < 20; ++i) {
+		zassert_false(sys_hashmap_insert(&map, i, i, NULL) < 0);
+	}
+
+	/* Remove key 16, expecting its entry to be erased */
+	old_value = 0;
+	zassert_true(sys_hashmap_remove(&map, 16, &old_value));
+	zassert_equal(16, old_value);
+
+	/* Insert an entry at key 16, expecting no old entry to be returned */
+	old_value = 0;
+	zassert_equal(1, sys_hashmap_insert(&map, 16, entry, &old_value));
+	zassert_equal(0, old_value);
+}


### PR DESCRIPTION
According to the hashmap interface specification sys_hashmap_remove will "Erase the entry associated with key `key`, if one exists"

The added testcase succeeds on 2/3 hashmap implementations, with a differing behavior on the OA/LP hashmap.

If a rehash is performed OA/LP will return 1 and no old_value for sys_hashmap_insert.

If a rehash is NOT performed OA/LP will return 0 and a stale old_value for sys_hashmap_insert even though the user requested the entry for that key to be removed.

This patch makes OA/LP not return the value of tombstoned entries.

I am not certain this change is correct, but since I stuffed a bunch of pointers in my hashmap and I got a double free when OA/LP started returning a "dead entry" I am requesting further comments on the PR.