### PR TITLE
MAINTAINERS: Add one collaborator for Bluetooth Classic

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -458,6 +458,7 @@ Bluetooth Classic:
     - MarkWangChinese
     - gzh-terry
     - makeshi
+    - chengkai15
   files:
     - doc/connectivity/bluetooth/shell/classic/a2dp.rst
     - subsys/bluetooth/common/


### PR DESCRIPTION
Add chengkai15 as collaborator for Bluetooth Classic.

The nomination is here: [96420](https://github.com/zephyrproject-rtos/zephyr/issues/96420)