### PR TITLE
.github: workflows: clang: install python packages

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -86,6 +86,10 @@ jobs:
           gcc --version
           ls -la
 
+      - name: Install Python packages
+        run: |
+          pip install -r scripts/requirements-actions.txt --require-hashes
+
       - name: Set up ccache
         run: |
           mkdir -p ${CCACHE_DIR}


### PR DESCRIPTION
Always install current python dependencies required for CI as part of setting up the workflow, since the ones pulled in the docker image may be out of date.

Related to https://github.com/zephyrproject-rtos/zephyr/pull/96403