### PR TITLE
boards: espressif: esp32s3_mini_n8: fix psram size

### DIFF
--- a/dts/xtensa/espressif/esp32s3/esp32s3_mini_n8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_mini_n8.dtsi
@@ -10,7 +10,3 @@
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
 };
-
-&psram0 {
-	size = <DT_SIZE_M(8)>;
-};


### PR DESCRIPTION
There is no psram on this board.

see also:
Table 1-1. ESP32-S3-MINI-1 and ESP32-S3-MINI-1U Series Comparison https://www.espressif.com/sites/default/files/documentation/esp32-s3-mini-1_mini-1u_datasheet_en.pdf