### PR TITLE
west.yml: espressif: improvements and updates

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -169,7 +169,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: f89d5ed56649917970067e113289fa252267fa7f
+      revision: 44c5ab74101497697e73c06aab82bab20852f3aa
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
- Keep RISC-V interrupt state if placed in IRAM when
cache enable/disable is called.

- Update hal_espressif to include TX notify callback for
the following SoCS: ESP32-C2, ESP32-C6 and ESP32-H2.

- Removed Wi-Fi/BLE binary blobs that are not required.
