### PR TITLE
Bluetooth: Classic: HFP_HF: Fix `AT+CLCC` can not be sent issue

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_hf_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_hf_internal.h
@@ -143,6 +143,8 @@ enum {
 	BT_HFP_HF_FLAG_CLCC_PENDING,  /* HFP HF CLCC is pending */
 	BT_HFP_HF_FLAG_VRE_ACTIVATE,  /* VRE is activated */
 	BT_HFP_HF_FLAG_BINP,          /* +BINP result code is received */
+	BT_HFP_HF_FLAG_INITIATING,    /* HF is in initiating state */
+	BT_HFP_HF_FLAG_QUERY_CALLS,   /* Require to query list of current calls */
 	/* Total number of flags - must be at the end of the enum */
 	BT_HFP_HF_NUM_FLAGS,
 };


### PR DESCRIPTION
Due to the flag `BT_HFP_HF_FLAG_CLCC_PENDING` is set when receiving the +CIEV or +CIND notification, the command `AT+CLCC` will be pending due to the flag is not cleared.

Add a flag `BT_HFP_HF_FLAG_INITIATING` to indicate the HF initialization is ongoing.

Add a flag `BT_HFP_HF_FLAG_QUERY_CALLS` to indicate the current calls list needs to be queried.

Set the flag `BT_HFP_HF_FLAG_INITIATING` at the beginning of the HF initialization. Set the flag `BT_HFP_HF_FLAG_QUERY_CALLS` instead of setting the flag `BT_HFP_HF_FLAG_CLCC_PENDING` if the current calls list needs to be queried and the flag `BT_HFP_HF_FLAG_INITIATING` is set.

After the HF initialization is done, query list of the current calls by calling the function `hf_query_current_calls()` if the flag `BT_HFP_HF_FLAG_QUERY_CALLS` is set.

Set the flag `BT_HFP_HF_FLAG_CLCC_PENDING` if it is not set in the function `hf_query_current_calls()`.