### PR TITLE
pm: Ensure pm_device_driver_init is pinned in memory

### DIFF
--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -338,6 +338,7 @@ bool pm_device_on_power_domain(const struct device *dev)
 #endif
 }
 
+__boot_func
 bool pm_device_is_powered(const struct device *dev)
 {
 #ifdef CONFIG_PM_DEVICE_POWER_DOMAIN
@@ -355,6 +356,7 @@ bool pm_device_is_powered(const struct device *dev)
 #endif
 }
 
+__boot_func
 int pm_device_driver_init(const struct device *dev,
 			  pm_device_action_cb_t action_cb)
 {


### PR DESCRIPTION
Make pm_device_driver_init() pinned to support using it for early driver init on devices with demand paging.

Fixes issue observed on `qemu_x86_tiny` after merge of #94851 :
```
ERROR   - SeaBIOS (version zephyr-v1.16.3-2-0-gf8da0cc-zephyr)
Booting from ROM..
ASSERTION FAIL [page_frames_initialized] @ WEST_TOPDIR/zephyr/kernel/mmu.c:1625
	page fault at 0x4012c8bf happened too early
E: EAX: 0x00000008, EBX: 0x4012c8bf, ECX: 0x40115fa2, EDX: 0x40124728
E: ESI: 0x4012c8bf, EDI: 0x00001000, EBP: 0x40124750, ESP: 0x4012471c
E: EFLAGS: 0x00000097 CS: 0x0008 CR3: 0x0011e000
E: EIP: 0x4010e575
E: call trace:
E:      corrupted? (bp=0x40124750)
E: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
E: Current thread: 0x4011f5a0 (unknown)
E: Halting system
```