### PR TITLE
boards: espressif: change default esp32s3_devkit regarding SPIRAM

### DIFF
--- a/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_appcpu.dts
+++ b/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_appcpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_wroom_n8.dtsi>
+#include <espressif/esp32s3/esp32s3_wroom_n8r8.dtsi>
 #include <espressif/partitions_0x0_amp.dtsi>
 #include "esp32s3_devkitc-pinctrl.dtsi"
 

--- a/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_procpu.dts
+++ b/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_procpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_wroom_n8.dtsi>
+#include <espressif/esp32s3/esp32s3_wroom_n8r8.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
 #include <espressif/partitions_0x0_amp.dtsi>

--- a/samples/boards/espressif/spiram_test/README.rst
+++ b/samples/boards/espressif/spiram_test/README.rst
@@ -27,7 +27,7 @@ Make sure you have your board connected over USB port.
 
 .. code-block:: console
 
-   west build -b esp32s3_devkitm/esp32s3/procpu samples/boards/espressif/spiram_test
+   west build -b esp32s3_devkitc/esp32s3/procpu samples/boards/espressif/spiram_test
    west flash
 
 If using another supported Espressif board, replace the argument in the above

--- a/tests/boards/espressif/cache_coex/README.rst
+++ b/tests/boards/espressif/cache_coex/README.rst
@@ -16,7 +16,7 @@ Supported Boards
 ****************
 - esp32_devkitc
 - esp32s2_saola
-- esp32s3_devkitm
+- esp32s3_devkitc
 
 Building and Running
 ********************

--- a/tests/boards/espressif/cache_coex/testcase.yaml
+++ b/tests/boards/espressif/cache_coex/testcase.yaml
@@ -3,7 +3,7 @@ tests:
     platform_allow:
       - esp32_devkitc/esp32/procpu
       - esp32s2_saola
-      - esp32s3_devkitm/esp32s3/procpu
+      - esp32s3_devkitc/esp32s3/procpu
     tags:
       - spiram
       - spiflash


### PR DESCRIPTION
Make sure `esp32s3_devkitc` is used in tests/samples that require SPIRAM.
`esp32s3_devkitm` uses `esp32s3_mini` SoC, which does not have SPIRAM. However, `esp32s3_devkitm` has SPIRAM.
