### PR TITLE
Bluetooth: HFP_AG: Fix SLC connected event early notify issue

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_ag_internal.h
@@ -137,6 +137,7 @@ enum {
 	BT_HFP_AG_VRE_ACTIVATE,  /* VRE is activated */
 	BT_HFP_AG_VRE_R2A,       /* HF is ready to accept audio */
 	BT_HGP_AG_ONGOING_CALLS, /* Waiting ongoing calls */
+	BT_HFP_AG_SLC_CONNECTED, /* SLC connected event needs to be notified */
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_HFP_AG_NUM_FLAGS,


### PR DESCRIPTION
In current implementation, the SLC connected event will be early notified. It causes the SLC state of AG is not aligned with the state of HF.

The SLC connected event should be notified after the procedure of HF indicators is done if the HF indicators feature is supported by both devices.

Do not notify the SLC connected event after the AG has successfully responded with information about how call hold and multiparty services are supported if the HF indicators feature is supported by both devices.

Notify the SLC connected event after the procedure of HF indicators is done.