### PR TITLE
Update the versalnet apu to load TF-A as APU runs at EL1 NS

### DIFF
--- a/boards/amd/versalnet_apu/board.cmake
+++ b/boards/amd/versalnet_apu/board.cmake
@@ -13,11 +13,24 @@ set(QEMU_FLAGS_${ARCH}
   -machine arm-generic-fdt
   -hw-dtb ${PROJECT_BINARY_DIR}/${BOARD}-qemu.dtb
   -device loader,addr=0xEC200300,data=0x3EE,data-len=4
-  -device loader,addr=0xEC200300,data=0x3DD,data-len=4
+  -device loader,addr=0xEC200300,data=0x3EE,data-len=4
   -nographic
   -m 2g
 )
 
+# Set TF-A platform for ARM Trusted Firmware builds
+if(CONFIG_BUILD_WITH_TFA)
+  set(TFA_PLAT "versal_net")
+  # Add Versal NET specific TF-A build parameters
+  set(TFA_EXTRA_ARGS "TFA_NO_PM=1;PRELOADED_BL33_BASE=0x0")
+  if(CONFIG_TFA_MAKE_BUILD_TYPE_DEBUG)
+    set(BUILD_FOLDER "debug")
+  else()
+    set(BUILD_FOLDER "release")
+  endif()
+endif()
+
 set(QEMU_KERNEL_OPTION
-  -device loader,cpu-num=0,file=\$<TARGET_FILE:\${logical_target_for_zephyr_elf}>
+  -device loader,cpu-num=0,file=${PROJECT_BINARY_DIR}/../tfa/versal_net/${BUILD_FOLDER}/bl31/bl31.elf
+  -device loader,file=\$<TARGET_FILE:\${logical_target_for_zephyr_elf}>
 )

--- a/boards/amd/versalnet_apu/versalnet_apu_defconfig
+++ b/boards/amd/versalnet_apu/versalnet_apu_defconfig
@@ -1,6 +1,7 @@
 # The Zephyr build from this defconfig is expected to boot from
 # Xilinx Arm Trusted Firmware (ATF).
 # Boot Flow is: Boot PDI -> TF-A -> Zephyr
+CONFIG_BUILD_WITH_TFA=y
 
 CONFIG_ARM64_VA_BITS_40=y
 CONFIG_ARM64_PA_BITS_40=y

--- a/modules/trusted-firmware-a/CMakeLists.txt
+++ b/modules/trusted-firmware-a/CMakeLists.txt
@@ -35,6 +35,11 @@ if(CONFIG_BUILD_WITH_TFA)
     set(TFA_AARCH32_REGS "")
   endif()
 
+  # Set default TF-A build parameters that can be overridden by boards
+  if(NOT DEFINED TFA_EXTRA_ARGS)
+    set(TFA_EXTRA_ARGS "")
+  endif()
+
   set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
       COMMAND make -C ${ZEPHYR_TRUSTED_FIRMWARE_A_MODULE_DIR}
             DEBUG=${TFA_BUILD_DEBUG}
@@ -42,6 +47,7 @@ if(CONFIG_BUILD_WITH_TFA)
             BUILD_BASE=${TFA_BINARY_DIR} PLAT=${TFA_PLAT}
             BL33=${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
             ${TFA_AARCH32_REGS}
+            ${TFA_EXTRA_ARGS}
             all fip
   )
 endif()


### PR DESCRIPTION
This pull request updates the versalnet_apu board support to build TF-A alongside the Zephyr application.
By default, the APU runs at EL1-Non Secure, and QEMU requires a secure OS to configure GIC-V3 and other secure settings. Integrating TF-A with the Zephyr build ensures the necessary secure initialization is performed before the Zephyr application runs.