### PR TITLE
dts: bindings: mtd: add erase-block-size property to spi-nor

### DIFF
--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -21,3 +21,7 @@ properties:
   reset-gpios:
     type: phandle-array
     description: RESETn pin
+  erase-block-size:
+    type: int
+    description: |
+      The minimum erasable block size of the device, in bytes.


### PR DESCRIPTION
Add an optional `erase-block-size` property to the `jedec,spi-nor` Devicetree binding.

This ensures that devices whose `slot1_partition` is on a SPI NOR flash device do not encounter the following warning from mcuboot.

```shell
Unable to determine size of slot1 partition, cannot calculate minimum sector usage
```