### PR TITLE
boards: adi: Add Arduino I2C support to APARD32690

### DIFF
--- a/boards/adi/apard32690/apard32690_max32690_m4.dts
+++ b/boards/adi/apard32690/apard32690_max32690_m4.dts
@@ -170,6 +170,20 @@ arduino_serial: &uart1 {
 	current-speed = <115200>;
 };
 
+&i2c1a_scl_p2_18 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+&i2c1a_sda_p2_17 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+arduino_i2c: &i2c1 {
+	status = "okay";
+	pinctrl-0 = <&i2c1a_sda_p2_17 &i2c1a_scl_p2_18>;
+	pinctrl-names = "default";
+};
+
 &spi1a_miso_p1_28 {
 	power-source = <MAX32_VSEL_VDDIOH>;
 };

--- a/boards/adi/apard32690/apard32690_max32690_m4.yaml
+++ b/boards/adi/apard32690/apard32690_max32690_m4.yaml
@@ -10,6 +10,7 @@ supported:
   - arduino_gpio
   - arduino_serial
   - arduino_spi
+  - arduino_i2c
   - pmod_spi
   - pmod_gpio
   - gpio


### PR DESCRIPTION
Properly export a working `&arduino_i2c` node on the APARD32690 board, for use with various Uno shields.