### PR TITLE
kernel:  Replace redundant switch_handle assignment with assertion

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -856,7 +856,10 @@ void *z_get_next_switch_handle(void *interrupted)
 
 	K_SPINLOCK(&_sched_spinlock) {
 		struct k_thread *old_thread = _current, *new_thread;
-		old_thread->switch_handle = NULL;
+
+		__ASSERT(old_thread->switch_handle == NULL,
+			"old thread handle should be null.");
+
 		new_thread = next_up();
 
 		z_sched_usage_switch(new_thread);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1213,6 +1213,10 @@ void z_dummy_thread_init(struct k_thread *dummy_thread)
 	dummy_thread->resource_pool = NULL;
 #endif /* K_HEAP_MEM_POOL_SIZE */
 
+#ifdef CONFIG_USE_SWITCH
+	dummy_thread->switch_handle = NULL;
+#endif /* CONFIG_USE_SWITCH */
+
 #ifdef CONFIG_TIMESLICE_PER_THREAD
 	dummy_thread->base.slice_ticks = 0;
 #endif /* CONFIG_TIMESLICE_PER_THREAD */


### PR DESCRIPTION
The switch_handle for the outgoing thread is expected to be NULL or dummy thread at the start of a context switch. The previous code performed a redundant assignment to NULL.

This change replaces the assignment with an __ASSERT(). This makes the code more robust by explicitly enforcing this precondition, helping to catch potential scheduler bugs earlier.