### PR TITLE
arch: arm: cortex_m: scb: define SHPR_REG macro

### DIFF
--- a/arch/arm/core/cortex_m/scb.c
+++ b/arch/arm/core/cortex_m/scb.c
@@ -185,7 +185,7 @@ void z_arm_save_scb_context(struct scb_context *context)
 	 * Make u32 pointer using explicit cast to allow
 	 * access on all cores without compiler warnings.
 	 */
-	volatile uint32_t *shpr = (volatile uint32_t *)SCB->SHPR;
+	volatile uint32_t *shpr = SHPR_REG;
 
 	for (int i = 0; i < SHPR_SIZE_W; i++) {
 		context->shpr[i] = shpr[i];
@@ -226,7 +226,7 @@ void z_arm_restore_scb_context(const struct scb_context *context)
 	SCB->CCR = context->ccr;
 
 	/* Restore System Handler Priority Registers */
-	volatile uint32_t *shpr = (volatile uint32_t *)SCB->SHPR;
+	volatile uint32_t *shpr = SHPR_REG;
 
 	for (int i = 0; i < SHPR_SIZE_W; i++) {
 		shpr[i] = context->shpr[i];

--- a/include/zephyr/arch/arm/cortex_m/scb.h
+++ b/include/zephyr/arch/arm/cortex_m/scb.h
@@ -23,9 +23,16 @@
 	defined(CONFIG_CPU_CORTEX_M1) || \
 	defined(CONFIG_CPU_CORTEX_M23)
 #define SHPR_SIZE_W 2
+#define SHPR_REG ((volatile uint32_t *)SCB->SHP)
 #else
 #define SHPR_SIZE_W 3
 #define CPACR_PRESENT 1
+#if defined(CONFIG_CPU_CORTEX_M3) || \
+	defined(CONFIG_CPU_CORTEX_M4)
+#define SHPR_REG ((volatile uint32_t *)SCB->SHP)
+#else
+#define SHPR_REG ((volatile uint32_t *)SCB->SHPR)
+#endif
 #endif
 
 /**


### PR DESCRIPTION
SHPR is found to have different member names in the SCB_Type struct depending on the core. The SHPR_REG macro is created for retrieving the correct member based on the core type.