### PR TITLE
samples: drivers: uart: removed lpuart from an incompatible filter

### DIFF
--- a/samples/drivers/uart/async_api/sample.yaml
+++ b/samples/drivers/uart/async_api/sample.yaml
@@ -28,7 +28,8 @@ tests:
       - nucleo_g071rb/stm32g071xx
     filter: CONFIG_SERIAL and
             CONFIG_UART_ASYNC_API and
-            dt_chosen_enabled("zephyr,shell-uart")
+            dt_chosen_enabled("zephyr,shell-uart") and
+            not CONFIG_UART_MCUX_LPUART
     harness: console
     harness_config:
       type: multi_line


### PR DESCRIPTION
Removed lpuart from sample.drivers.uart.async_api.console