### PR TITLE
drivers: gpio: renesas: Fix fail case pin_get_config

### DIFF
--- a/drivers/gpio/gpio_renesas_rz.c
+++ b/drivers/gpio/gpio_renesas_rz.c
@@ -102,14 +102,15 @@ static int gpio_rz_pin_config_get_raw(bsp_io_port_pin_t port_pin, struct gpio_rz
 	pm_value = GPIO_RZ_PM_VALUE_GET(*p_pm, pin);
 	pfc_value = GPIO_RZ_PFC_VALUE_GET(*p_pfc, pin);
 
-	if (p_value) {
-		rz_flags->gpio_flags = GPIO_OUTPUT_INIT_HIGH;
-	} else {
-		rz_flags->gpio_flags = GPIO_OUTPUT_INIT_LOW;
-	}
-
-	rz_flags->gpio_flags |= (pm_value << 16);
 	rz_flags->pfc = pfc_value;
+	rz_flags->gpio_flags = (pm_value << 16);
+	if (rz_flags->gpio_flags & GPIO_OUTPUT) {
+		if (p_value) {
+			rz_flags->gpio_flags |= GPIO_OUTPUT_INIT_HIGH;
+		} else {
+			rz_flags->gpio_flags |= GPIO_OUTPUT_INIT_LOW;
+		}
+	}
 
 	return 0;
 }

--- a/drivers/gpio/gpio_renesas_rza2m.c
+++ b/drivers/gpio/gpio_renesas_rza2m.c
@@ -368,14 +368,13 @@ static int gpio_rza2m_pin_get_config(const struct device *port_dev, gpio_pin_t p
 		*flags |= GPIO_INPUT;
 	} else if ((reg16 >> (pin * 2)) == RZA2M_PDR_OUTPUT) {
 		*flags |= GPIO_OUTPUT;
-	}
-
-	/* Get pin initial value */
-	reg8 = sys_read8(RZA2M_PODR(int_dev, port));
-	if (reg8 & BIT(pin)) {
-		*flags |= GPIO_OUTPUT_INIT_HIGH;
-	} else {
-		*flags |= GPIO_OUTPUT_INIT_LOW;
+		/* Get pin initial value */
+		reg8 = sys_read8(RZA2M_PODR(int_dev, port));
+		if (reg8 & BIT(pin)) {
+			*flags |= GPIO_OUTPUT_INIT_HIGH;
+		} else {
+			*flags |= GPIO_OUTPUT_INIT_LOW;
+		}
 	}
 
 	/* Get pin drive strength */


### PR DESCRIPTION
Due to https://github.com/zephyrproject-rtos/zephyr/pull/96093, these Renesas RZ boards failed `gpio_port.test_gpio_port` test.
This PR adds condition to check whether the pin is set as output before reading the output high or low for gpio driver of Renesas RZ.

```
SUITE FAIL -   0.00% [gpio_port]: pass = 0, fail = 1, skip = 0, total = 1 duration = 0.040 seconds
 - FAIL - [gpio_port.test_gpio_port] duration = 0.040 seconds
