### PR TITLE
drivers: i2s: i2s_ll_stm32: add support for IO swap

### DIFF
--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -710,6 +710,12 @@ static int i2s_stm32_initialize(const struct device *dev)
 		return -EIO;
 	}
 
+#if defined(SPI_CFG2_IOSWP)
+	if (cfg->ioswp) {
+		LL_SPI_EnableIOSwap(cfg->i2s);
+	}
+#endif
+
 	/* Configure dt provided device signals when available */
 	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
@@ -950,7 +956,8 @@ static const struct i2s_stm32_cfg i2s_stm32_config_##index = {		\
 	.pclk_len = DT_INST_NUM_CLOCKS(index),				\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
 	.irq_config = i2s_stm32_irq_config_func_##index,		\
-	.master_clk_sel = DT_INST_PROP(index, mck_enabled)		\
+	.master_clk_sel = DT_INST_PROP(index, mck_enabled),		\
+	.ioswp = DT_INST_PROP(index, ioswp),				\
 };									\
 									\
 K_MSGQ_DEFINE(rx_##index##_queue, sizeof(struct queue_item), CONFIG_I2S_STM32_RX_BLOCK_COUNT, 4);\

--- a/drivers/i2s/i2s_ll_stm32.h
+++ b/drivers/i2s/i2s_ll_stm32.h
@@ -19,7 +19,8 @@ struct i2s_stm32_cfg {
 	size_t pclk_len;
 	const struct pinctrl_dev_config *pcfg;
 	void (*irq_config)(const struct device *dev);
-	bool master_clk_sel;
+	bool master_clk_sel: 1;
+	bool ioswp: 1;
 };
 
 struct stream {

--- a/dts/bindings/i2s/st,stm32-i2s-common.yaml
+++ b/dts/bindings/i2s/st,stm32-i2s-common.yaml
@@ -29,3 +29,7 @@ properties:
     description: |
       Master Clock Output function.
       An mck pin must be listed within pinctrl-0 when enabling this property.
+
+  ioswp:
+    type: boolean
+    description: Swap I2S data input and output pins


### PR DESCRIPTION
This PR adds a new property in the device-tree bindings for swapping the serial data input and output pins of the SPI/I2S peripheral for STM32 microcontrollers that support it.

For example, the STM32H7RS has it : https://www.st.com/resource/en/reference_manual/rm0477-stm32h7rx7sx-armbased-32bit-mcus-stmicroelectronics.pdf#page=2614

I've also opened a PR for SPI : https://github.com/zephyrproject-rtos/zephyr/pull/96464