### PR TITLE
drivers: spi: spi_ll_stm32: add support for IO swap

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -692,6 +692,12 @@ static int spi_stm32_configure(const struct device *dev,
 	LL_SPI_Disable(spi);
 	LL_SPI_SetBaudRatePrescaler(spi, scaler[br - 1]);
 
+#if defined(SPI_CFG2_IOSWP)
+	if (cfg->ioswp) {
+		LL_SPI_EnableIOSwap(cfg->spi);
+	}
+#endif
+
 	if (SPI_MODE_GET(config->operation) & SPI_MODE_CPOL) {
 		LL_SPI_SetClockPolarity(spi, LL_SPI_POLARITY_HIGH);
 	} else {
@@ -1595,6 +1601,7 @@ static const struct spi_stm32_config spi_stm32_cfg_##id = {		\
 	.pclk_len = DT_INST_NUM_CLOCKS(id),				\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),			\
 	.fifo_enabled = SPI_FIFO_ENABLED(id),				\
+	.ioswp = DT_INST_PROP(id, ioswp),				\
 	STM32_SPI_IRQ_HANDLER_FUNC(id)					\
 	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz),	\
 		(.use_subghzspi_nss =					\

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -37,7 +37,8 @@ struct spi_stm32_config {
 #endif
 	size_t pclk_len;
 	const struct stm32_pclken *pclken;
-	bool fifo_enabled;
+	bool fifo_enabled: 1;
+	bool ioswp: 1;
 };
 
 #ifdef CONFIG_SPI_STM32_DMA

--- a/dts/bindings/spi/st,stm32-spi-common.yaml
+++ b/dts/bindings/spi/st,stm32-spi-common.yaml
@@ -17,3 +17,7 @@ properties:
 
   pinctrl-names:
     required: true
+
+  ioswp:
+    type: boolean
+    description: Swap SPI MOSI and MISO pins


### PR DESCRIPTION
This commit adds a new property in the device-tree bindings for swapping the MISO and MOSI pins of the SPI/I2S peripheral for STM32 microcontrollers that support it.

For example, the STM32H7RS has it : https://www.st.com/resource/en/reference_manual/rm0477-stm32h7rx7sx-armbased-32bit-mcus-stmicroelectronics.pdf#page=2614

I've also opened a PR for I2S : https://github.com/zephyrproject-rtos/zephyr/pull/96463