### PR TITLE
ite: it82000: add elpm initialization support

### DIFF
--- a/dts/bindings/power/ite,it8xxx2-power-elpm.yaml
+++ b/dts/bindings/power/ite,it8xxx2-power-elpm.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2025 ITE Corporation. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+description: IT8XXX2 Extreme Low Power Controller
+
+compatible: "ite,it8xxx2-power-elpm"
+
+include: [base.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true
+
+child-binding:
+  description: XLPIN configuration
+
+  properties:
+    reg:
+      type: int
+      description: the index of XLPIN
+
+    polarity:
+      type: string
+      enum: ["default", "low-falling", "high-rising"]
+      description: |
+        Polarity setting for this XLPIN:
+          - "default" disables it
+          - "low-falling" triggers on low/falling edge
+          - "high-rising" triggers on high/rising edge

--- a/dts/riscv/ite/it82000-pinctrl-map.dts
+++ b/dts/riscv/ite/it82000-pinctrl-map.dts
@@ -27,4 +27,18 @@
 	/omit-if-no-ref/ i2c0_data_gpf3_default: i2c0_data_gpf3_default {
 		pinmuxs = <&pinctrlf 3 IT8XXX2_ALT_FUNC_1>;
 	};
+
+	/* VBAT-Power alternate function */
+	/omit-if-no-ref/ xlpin0_gpq0_default: xlpin0_gpq0_default {
+		pinmuxs = <&pinctrlq 0 IT8XXX2_ALT_FUNC_1>;
+	};
+	/omit-if-no-ref/ xlpin1_gpq1_default: xlpin1_gpq1_default {
+		pinmuxs = <&pinctrlq 1 IT8XXX2_ALT_FUNC_1>;
+	};
+	/omit-if-no-ref/ xlpin2_gpq2_default: xlpin2_gpq2_default {
+		pinmuxs = <&pinctrlq 2 IT8XXX2_ALT_FUNC_1>;
+	};
+	/omit-if-no-ref/ xlpin4_gpq4_default: xlpin4_gpq4_default {
+		pinmuxs = <&pinctrlq 4 IT8XXX2_ALT_FUNC_1>;
+	};
 };

--- a/dts/riscv/ite/it82000.dtsi
+++ b/dts/riscv/ite/it82000.dtsi
@@ -37,6 +37,31 @@
 			has-volt-sel = <0 0 0 0 0 0 0 0>;
 			#gpio-cells = <2>;
 		};
+
+		pinctrlq: pinctrl@f016e0 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f016e0 8     /* GPCR */
+			       NO_FUNC    1>;
+			func3-gcr = <NO_FUNC NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+				     NO_FUNC NO_FUNC NO_FUNC>;
+			func3-en-mask = <0 0 0 0 0 0 0 0>;
+			func4-gcr = <NO_FUNC NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+				     NO_FUNC NO_FUNC NO_FUNC>;
+			func4-en-mask = <0 0 0 0 0 0 0 0>;
+			volt-sel = <NO_FUNC NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+				    NO_FUNC NO_FUNC NO_FUNC>;
+			volt-sel-mask = <0 0 0 0 0 0 0 0>;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
+
+		power_ctrl_elpm: power-ctrl-elpm@f03e00 {
+			compatible = "ite,it8xxx2-power-elpm";
+			reg = <0x00f03e00 0xfd>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
 	};
 };
 


### PR DESCRIPTION
This pr adds elpm(extreme low power) initialization support, enabling the  elpm firmware control mode and driving xlpout high. It also introduces the `pinctrl_q` and `power_ctrl_elpm` nodes to the dts.