### PR TITLE
stm32n6: avoid instabilities with XSPI attached device and re-enable the PSRAM cache

### DIFF
--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -246,7 +246,13 @@ zephyr_udc0: &usbotg_hs1 {
 
 			storage_partition: partition@3ff0000 {
 				label = "storage";
-				reg = <0x3ff0000 DT_SIZE_K(64)>;
+				/*
+				 * Prevent access to the last 32bytes of the memory-mapped device
+				 * Issue described in the STM32N6xxxx errata sheet ES0620 Rev 1:
+				 * 2.4.5 Deadlock or data corruption when DQS is enabled and the
+				 * wrap request includes the last address of the memory
+				 */
+				reg = <0x3ff0000 (DT_SIZE_K(64) - 32)>;
 			};
 		};
 	};

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -49,7 +49,7 @@
 		 */
 		reg = <0x90000000 (DT_SIZE_M(32) - 32)>;
 		zephyr,memory-region = "PSRAM";
-		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
 	};
 
 	leds: leds {

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -41,7 +41,13 @@
 
 	psram: memory@90000000 {
 		compatible = "zephyr,memory-region";
-		reg = <0x90000000 DT_SIZE_M(32)>;
+		/*
+		 * Prevent access to the last 32bytes of the memory-mapped device
+		 * Issue described in the STM32N6xxxx errata sheet ES0620 Rev 1:
+		 * 2.4.5 Deadlock or data corruption when DQS is enabled and the
+		 * wrap request includes the last address of the memory
+		 */
+		reg = <0x90000000 (DT_SIZE_M(32) - 32)>;
 		zephyr,memory-region = "PSRAM";
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 	};


### PR DESCRIPTION
This serie changes PSRAM (or other XSPI attached device) memory-mapped size to avoid reaching the last 32bytes of the memory in order to avoid instabilities when enabling the cache.
Following this, re-enable the PSRAM cache on the STM32N6-DK board.