### PR TITLE
hostap: fix the build error of zephyr_hostapd_cli_cmd_resp and undefined wpa_s->ctrl_conn

### DIFF
--- a/modules/hostap/src/hapd_api.c
+++ b/modules/hostap/src/hapd_api.c
@@ -830,7 +830,7 @@ static int hapd_ap_wps_pin(const struct device *dev, struct wifi_wps_config_para
 	}
 
 	if (params->oper == WIFI_WPS_PIN_GET) {
-		if (zephyr_hostapd_cli_cmd_resp(get_pin_cmd, params->pin)) {
+		if (zephyr_hostapd_cli_cmd_resp(iface->ctrl_conn, get_pin_cmd, params->pin)) {
 			goto out;
 		}
 	} else if (params->oper == WIFI_WPS_PIN_SET) {
@@ -1013,9 +1013,16 @@ int hostapd_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *param
 {
 	int ret;
 	char *cmd = NULL;
+	struct hostapd_iface *iface;
 
 	if (params == NULL) {
 		return -EINVAL;
+	}
+
+	iface = get_hostapd_handle(dev);
+	if (!iface) {
+		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
+		return -ENOENT;
 	}
 
 	cmd = os_zalloc(SUPPLICANT_DPP_CMD_BUF_SIZE);
@@ -1031,7 +1038,7 @@ int hostapd_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *param
 	}
 
 	wpa_printf(MSG_DEBUG, "hostapd_cli %s", cmd);
-	if (zephyr_hostapd_cli_cmd_resp(cmd, params->resp)) {
+	if (zephyr_hostapd_cli_cmd_resp(iface->ctrl_conn, cmd, params->resp)) {
 		os_free(cmd);
 		return -ENOEXEC;
 	}

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1598,6 +1598,13 @@ int supplicant_candidate_scan(const struct device *dev, struct wifi_scan_params 
 	char *pos = cmd;
 	char *end = pos + SUPPLICANT_CANDIDATE_SCAN_CMD_BUF_SIZE;
 	int freq = 0;
+	struct wpa_supplicant *wpa_s;
+
+	wpa_s = get_wpa_s_handle(dev);
+	if (!wpa_s) {
+		wpa_printf(MSG_ERROR, "Device %s not found", dev->name);
+		return -1;
+	}
 
 	strcpy(pos, "freq=");
 	pos += 5;

--- a/tests/net/wifi/configs/testcase.yaml
+++ b/tests/net/wifi/configs/testcase.yaml
@@ -60,6 +60,22 @@ tests:
       - CONFIG_WIFI_NM_WPA_SUPPLICANT_INF_MON=n
       - CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE=y
       - CONFIG_WIFI_NM_HOSTAPD_CRYPTO_ENTERPRISE=y
+  wifi.build.hostapd_wps:
+    extra_configs:
+      - CONFIG_WIFI_NM_HOSTAPD_AP=y
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_INF_MON=n
+      - CONFIG_WIFI_NM_HOSTAPD_WPS=y
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_WPS=y
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_EAPOL=y
+  wifi.build.hostapd_dpp:
+    extra_configs:
+      - CONFIG_WIFI_NM_HOSTAPD_AP=y
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_INF_MON=n
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP=y
+  wifi.build.roaming:
+    extra_configs:
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING=y
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_SKIP_DHCP_ON_ROAMING=y
   wifi.build.dpp:
     extra_configs:
       - CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP=y


### PR DESCRIPTION
Fix the build error that wpa_s isn't defined in supplicant_candidate_scan when CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING is enabled.
Fix the build error that missing ctrl parameter in zephyr_hostapd_cli_cmd_resp by getting iface->ctrl_conn.