### PR TITLE
drivers: mspi_dw|flash_mspi_nor: Add support for CONFIG_MULTITHREADING=n

### DIFF
--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -237,7 +237,9 @@ static int acquire(const struct device *dev)
 	struct flash_mspi_nor_data *dev_data = dev->data;
 	int rc;
 
+#if defined(CONFIG_MULTITHREADING)
 	k_sem_take(&dev_data->acquired, K_FOREVER);
+#endif
 
 	rc = pm_device_runtime_get(dev_config->bus);
 	if (rc < 0) {
@@ -269,21 +271,27 @@ static int acquire(const struct device *dev)
 		(void)pm_device_runtime_put(dev_config->bus);
 	}
 
+#if defined(CONFIG_MULTITHREADING)
 	k_sem_give(&dev_data->acquired);
+#endif
+
 	return rc;
 }
 
 static void release(const struct device *dev)
 {
 	const struct flash_mspi_nor_config *dev_config = dev->config;
-	struct flash_mspi_nor_data *dev_data = dev->data;
 
 	/* This releases the MSPI controller. */
 	(void)mspi_get_channel_status(dev_config->bus, 0);
 
 	(void)pm_device_runtime_put(dev_config->bus);
 
+#if defined(CONFIG_MULTITHREADING)
+	struct flash_mspi_nor_data *dev_data = dev->data;
+
 	k_sem_give(&dev_data->acquired);
+#endif
 }
 
 static inline uint32_t dev_flash_size(const struct device *dev)
@@ -1215,7 +1223,9 @@ static int drv_init(const struct device *dev)
 		}
 	}
 
+#if defined(CONFIG_MULTITHREADING)
 	k_sem_init(&dev_data->acquired, 1, K_SEM_MAX_LIMIT);
+#endif
 
 	return pm_device_driver_init(dev, dev_pm_action_cb);
 }

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -104,7 +104,9 @@ struct flash_mspi_nor_config {
 };
 
 struct flash_mspi_nor_data {
+#if defined(CONFIG_MULTITHREADING)
 	struct k_sem acquired;
+#endif
 	struct mspi_xfer_packet packet;
 	struct mspi_xfer xfer;
 	struct jesd216_erase_type erase_types[JESD216_NUM_ERASE_TYPES];

--- a/tests/drivers/mspi/flash/testcase.yaml
+++ b/tests/drivers/mspi/flash/testcase.yaml
@@ -36,3 +36,9 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_configs:
       - CONFIG_MSPI_DW_HANDLE_FIFOS_IN_SYSTEM_WORKQUEUE=y
+  drivers.mspi.flash.mspi_nor_no_multithreading:
+    filter: dt_alias_exists("mspi0") and CONFIG_FLASH_MSPI_NOR
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_configs:
+      - CONFIG_MULTITHREADING=n


### PR DESCRIPTION
Add possibility to use the mspi_dw and flash_mspi_nor drivers in configurations with disabled multithreading. It may be useful in bootloaders, for example.