### PR TITLE
boards: st: nucleo_n657x0_q: fix boot pins information

### DIFF
--- a/boards/st/nucleo_n657x0_q/doc/index.rst
+++ b/boards/st/nucleo_n657x0_q/doc/index.rst
@@ -176,7 +176,7 @@ To program the board, there are two options:
   and executed from there.
 - Optionally, it can also be taken advantage from the serial boot interface provided
   by the boot ROM. In that case, firmware is directly loaded in RAM and executed from
-  there. It is not retained.
+  there. It is not retained in persistent memory.
 
 Programming an application to NUCLEO-N657X0-Q
 ---------------------------------------------
@@ -199,33 +199,38 @@ First, connect the NUCLEO-N657X0-Q to your host computer using the ST-Link USB p
          .. note::
             For flashing, before powering the board, set the boot pins in the following configuration:
 
-            * BOOT0: 0
-            * BOOT1: 1
+            * BOOT0: 0 (jumper JP1 in position 1, printed on PCB)
+            * BOOT1: 1 (jumper JP2 in position 2, not-printed on PCB)
 
             After flashing, to run the application, set the boot pins in the following configuration:
 
-            * BOOT1: 0
+            * BOOT0: 0 (jumper JP1 in position 1, printed on PCB)
+            * BOOT1: 0 (jumper JP2 in position 1, printed on PCB)
 
-	    Power off and on the board again.
+            Power off and on the board again.
 
       .. group-tab:: Serial Boot Loader (USB)
 
-         Additionally, connect the NUCLEO-N657X0-Q to your host computer using the USB port.
-         In this configuration, ST-Link is used to power the board and for serial communication
-         over the Virtual COM Port.
+         Additionally to the USB/ST-Link, connect the NUCLEO-N657X0-Q to your
+         host computer using the USB port (USB/CN8).
+
+         In this configuration, ST-Link (USB connector CN10) is used to power
+         the board and for serial communication over the Virtual COM Port,
+         while USB/CN8 is used to send the Zephyr image to Boot ROM for loading
+         it in RAM and executing it.
 
          .. note::
             Before powering the board, set the boot pins in the following configuration:
 
-            * BOOT0: 1
-            * BOOT1: 0
+            * BOOT0: 1 (jumper JP1 in position 2, not-printed on PCB)
+            * BOOT1: 0 (jumper JP2 in position 1, printed on PCB)
 
          Build and load an application using ``nucleo_n657x0_q/stm32n657xx/sb`` target (you
          can also use the shortened form: ``nucleo_n657x0_q//sb``)
 
          .. zephyr-app-commands::
             :zephyr-app: samples/hello_world
-            :board: nucleo_n657x0_q
+            :board: nucleo_n657x0_q//sb
             :goals: build flash
 
 

--- a/boards/st/stm32n6570_dk/doc/index.rst
+++ b/boards/st/stm32n6570_dk/doc/index.rst
@@ -227,7 +227,7 @@ To program the board, there are two options:
   and executed from there.
 - Optionally, it can also be taken advantage from the serial boot interface provided
   by the boot ROM. In that case, firmware is directly loaded in RAM and executed from
-  there. It is not retained.
+  there. It is not retained in persistent memory.
 
 Programming an application to STM32N6570_DK
 -------------------------------------------
@@ -258,6 +258,19 @@ First, connect the STM32N6570_DK to your host computer using the ST-Link USB por
                          :west-args: --sysbuild -- -DCONFIG_XIP=n -DSB_CONFIG_MCUBOOT_MODE_RAM_LOAD=y
                          :goals: build flash
 
+         .. note::
+            For flashing, before powering the board, set the boot pins in the following configuration:
+
+            * BOOT0: 0 (switch SW2 in position L)
+            * BOOT1: 1 (switch SW1 in position H)
+
+            After flashing, to run the application, set the boot pins in the following configuration:
+
+            * BOOT0: 0 (switch SW2 in position L)
+            * BOOT1: 0 (switch SW1 in position L)
+
+            Power off and on the board again.
+
       .. group-tab:: FSBL - ST-Link
 
          Build and flash an application using ``stm32n6570_dk/stm32n657xx/fsbl`` target.
@@ -270,26 +283,31 @@ First, connect the STM32N6570_DK to your host computer using the ST-Link USB por
          .. note::
             For flashing, before powering the board, set the boot pins in the following configuration:
 
-            * BOOT0: 0
-            * BOOT1: 1
+            * BOOT0: 0 (switch SW2 in position L)
+            * BOOT1: 1 (switch SW1 in position H)
 
             After flashing, to run the application, set the boot pins in the following configuration:
 
-            * BOOT1: 0
+            * BOOT0: 0 (switch SW2 in position L)
+            * BOOT1: 0 (switch SW1 in position L)
 
-	    Power off and on the board again.
+            Power off and on the board again.
 
       .. group-tab:: FSBL - Serial Boot Loader (USB)
 
-         Additionally, connect the STM32N6570_DK to your host computer using the USB port.
-         In this configuration, ST-Link is used to power the board and for serial communication
-         over the Virtual COM Port.
+         Additionally to the USB/ST-Link, connect the STM32N6570_DK to your
+         host computer using USB1 port (CN18).
+
+         In this configuration, ST-Link (USB/CN6) is used to power the board
+         and for serial communication over the Virtual COM Port, while
+         USB1/CN18 is used to send the Zephyr image to Boot ROM for loading it
+         in RAM and executing it.
 
          .. note::
             Before powering the board, set the boot pins in the following configuration:
 
-            * BOOT0: 1
-            * BOOT1: 0
+            * BOOT0: 1 (switch SW2 in position H)
+            * BOOT1: 0 (switch SW1 in position L)
 
          Build and load an application using ``stm32n6570_dk/stm32n657xx/sb`` target (you
          can also use the shortened form: ``stm32n6570_dk//sb``)


### PR DESCRIPTION
Correct the BOOT0/BOOT1 configuration needed to program the flash memory or load the image straight in RAM (serial boot variant 'sb').

Fix the build directive when 'sb' variant is to be used.

Mention that even with 'sb' variant, the USB connector CN10 is still used to evacuate Zephyr UART console, despite STLink is to be connected to USB CN8 for RAM programming.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/96265