### PR TITLE
drivers/flash: it51xxx: Add ex_op API support and refactor test  for ITE platforms

### DIFF
--- a/boards/ite/it515xx_evb/it515xx_evb.dts
+++ b/boards/ite/it515xx_evb/it515xx_evb.dts
@@ -27,7 +27,6 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &flashctrl;
-		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -59,29 +58,6 @@
 
 &ite_uart1_wrapper {
 	status = "okay";
-};
-
-&flash0 {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x00000000 DT_SIZE_K(128)>;
-		};
-
-		slot1_partition: partition@20000 {
-			label = "image-1";
-			reg = <0x00020000 DT_SIZE_K(128)>;
-		};
-
-		storage_partition: partition@40000 {
-			label = "storage";
-			reg = <0x00040000 DT_SIZE_K(256)>;
-		};
-	};
 };
 
 &kbd {

--- a/boards/ite/it82xx2_evb/it82xx2_evb.dts
+++ b/boards/ite/it82xx2_evb/it82xx2_evb.dts
@@ -28,7 +28,6 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &flashctrl;
-		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -210,27 +209,4 @@ zephyr_udc0: &usb0 {
 	pinctrl-0 = <&usb0_dm_gph5_default
 		     &usb0_dp_gph6_default>;
 	pinctrl-names = "default";
-};
-
-&flash0 {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x00000000 DT_SIZE_K(128)>;
-		};
-
-		slot1_partition: partition@20000 {
-			label = "image-1";
-			reg = <0x00020000 DT_SIZE_K(128)>;
-		};
-
-		storage_partition: partition@40000 {
-			label = "storage";
-			reg = <0x00040000 DT_SIZE_K(256)>;
-		};
-	};
 };

--- a/boards/ite/it8xxx2_evb/it8xxx2_evb.dts
+++ b/boards/ite/it8xxx2_evb/it8xxx2_evb.dts
@@ -28,7 +28,6 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &flashctrl;
-		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -203,37 +202,4 @@
 
 &sha0 {
 	status = "okay";
-};
-
-&flash0 {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0x20000>;
-		};
-
-		slot0_partition: partition@20000 {
-			label = "image-0";
-			reg = <0x00020000 0x20000>;
-		};
-
-		slot1_partition: partition@40000 {
-			label = "image-1";
-			reg = <0x00040000 0x10000>;
-		};
-
-		scratch_partition: partition@50000 {
-			label = "image-scratch";
-			reg = <0x00050000 0x10000>;
-		};
-
-		storage_partition: partition@60000 {
-			label = "storage";
-			reg = <0x00060000 0x20000>;
-		};
-	};
 };

--- a/drivers/flash/Kconfig.it51xxx_m1k
+++ b/drivers/flash/Kconfig.it51xxx_m1k
@@ -8,6 +8,7 @@ config SOC_FLASH_ITE_IT51XXX_M1K
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	select PINCTRL
+	select FLASH_HAS_EX_OP
 	help
 	  The flash M1K driver supports read (up to 1K), write (1K), and erase (4K)
 	  operations. Accessible flash regions include internal e-Flash or external

--- a/include/zephyr/drivers/flash/it51xxx_flash_api_ex.h
+++ b/include/zephyr/drivers/flash/it51xxx_flash_api_ex.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for IT51XXX extended operations.
+ * @ingroup it51xxx_flash_ex_op
+ */
+
+#ifndef __ZEPHYR_INCLUDE_DRIVERS_IT51XXX_FLASH_API_EX_H__
+#define __ZEPHYR_INCLUDE_DRIVERS_IT51XXX_FLASH_API_EX_H__
+
+/**
+ * @brief Extended operations for IT51XXX flash controllers.
+ * @defgroup it51xxx_flash_ex_op IT51XXX
+ * @ingroup flash_ex_op
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/drivers/flash.h>
+
+/**
+ * @enum flash_it51xxx_ex_op
+ * @brief Enumeration for IT51XXX flash extended operations.
+ *
+ * Defines which flash device is accessed by IT51XXX flash controller,
+ * and the addressing mode for IT51XXX flash operations.
+ */
+enum flash_it51xxx_ex_op {
+	/**
+	 * Access the internal SPI e-flash.
+	 *
+	 * This operation targets the on-chip embedded SPI flash integrated
+	 * inside the IT51XXX SoC.
+	 */
+	FLASH_IT51XXX_INTERNAL,
+	/**
+	 * Access the external SPI flash connected to FSPI CS0#.
+	 *
+	 * This operation targets an external flash device connected to the
+	 * IT51XXX FSPI controller chip select 0.
+	 */
+	FLASH_IT51XXX_EXTERNAL_FSPI_CS0,
+	/**
+	 * Access the external SPI flash connected to FSPI CS1#.
+	 *
+	 * This operation targets an external flash device connected to the
+	 * IT51XXX FSPI controller chip select 1.
+	 */
+	FLASH_IT51XXX_EXTERNAL_FSPI_CS1,
+	/**
+	 * 3-byte (24-bit) addressing mode.
+	 *
+	 * This mode supports flash devices up to 16MB capacity, using
+	 * 24-bit address cycles.
+	 */
+	FLASH_IT51XXX_ADDR_3B,
+	/**
+	 * 4-byte (32-bit) addressing mode.
+	 *
+	 * This mode supports larger flash devices (>16MB capacity),
+	 * requiring 32-bit address cycles.
+	 */
+	FLASH_IT51XXX_ADDR_4B,
+};
+
+/**
+ * @}
+ */
+
+#endif /* __ZEPHYR_INCLUDE_DRIVERS_IT51XXX_FLASH_API_EX_H__ */

--- a/tests/drivers/flash/common/boards/it515xx_m1k.overlay
+++ b/tests/drivers/flash/common/boards/it515xx_m1k.overlay
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,flash = &flash_m1k0;
+		zephyr,flash-controller = &manual_flash_1k;
+	};
+};
+
+&manual_flash_1k {
+	status = "okay";
+
+	m1k-sel-access-flash = "external-fspi-cs1";
+
+	pinctrl-0 = <&fspi_fsce1_gpg6_default
+		     &fspi_fdio2_gph5_default
+		     &fspi_fdio3_gph6_default
+		     &fspi_fsck_gpg7_default>;
+	pinctrl-names = "default";
+
+	flash_m1k0: flash_m1k0@0 {
+		compatible = "soc-nv-flash";
+		reg = <0 DT_SIZE_M(1)>;
+		erase-block-size = <4096>;
+		write-block-size = <1>;
+	};
+};
+
+&flash_m1k0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		storage_partition: partition@40000 {
+			label = "storage";
+			reg = <0x00040000 DT_SIZE_K(256)>;
+		};
+	};
+};

--- a/tests/drivers/flash/common/boards/it8xxx2_indirect.overlay
+++ b/tests/drivers/flash/common/boards/it8xxx2_indirect.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		storage_partition: partition@40000 {
+			label = "storage";
+			reg = <0x00040000 DT_SIZE_K(256)>;
+		};
+	};
+};

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -216,3 +216,9 @@ tests:
       - it515xx_evb
     extra_args:
       - DTC_OVERLAY_FILE="./boards/it8xxx2_indirect.overlay"
+  drivers.flash.common.it515xx_m1k:
+    build_only: true
+    platform_allow:
+      - it515xx_evb
+    extra_args:
+      - DTC_OVERLAY_FILE="./boards/it515xx_m1k.overlay"

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -208,3 +208,11 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE=boards/mx25uw63_low_freq.overlay
     harness_config:
       fixture: gpio_loopback
+  drivers.flash.common.it8xxx2_indirect:
+    build_only: true
+    platform_allow:
+      - it8xxx2_evb
+      - it82xx2_evb
+      - it515xx_evb
+    extra_args:
+      - DTC_OVERLAY_FILE="./boards/it8xxx2_indirect.overlay"


### PR DESCRIPTION
This PR includes three commits:
Add flash extended operation (ex_op) API to the IT51XXX M1K flash controller driver. This enables runtime selection of both the flash target (internal/external) and addressing mode (3-byte/4-byte).

Move the flash0 node definition into dedicated test-specific overlays under `tests/drivers/flash/common/boards`. This removes duplication from board DTS files and makes the setup more flexible.