### PR TITLE
MIN/MAX rework

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -38,6 +38,9 @@ Base Libraries
   been moved from ``util.h`` to a separate
   :zephyr_file:`include/zephyr/sys/util_utf8.h` file.
 
+* ``Z_MIN``, ``Z_MAX`` and ``Z_CLAMP`` macros have been renamed to
+  :c:macro:`min` :c:macro:`max` and :c:macro:`clamp`.
+
 Boards
 ******
 

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -608,7 +608,7 @@ int usb_dc_ep_write(uint8_t ep, const uint8_t *buf, uint32_t len, uint32_t *ret_
 		return -EAGAIN;
 	}
 
-	len = Z_MIN(len, capacity);
+	len = min(len, capacity);
 
 	/* Note that this code does not use the hardware's
 	 * multi-packet and automatic zero-length packet features as

--- a/include/zephyr/dsp/utils.h
+++ b/include/zephyr/dsp/utils.h
@@ -116,7 +116,7 @@ extern "C" {
  * @return The converted Q7 fixed-point value.
  */
 #define Z_SHIFT_F32_TO_Q7(src, m)                                                                  \
-	((q7_t)Z_CLAMP((int32_t)(src * (1U << 7)) >> m, INT8_MIN, INT8_MAX))
+	((q7_t)clamp((int32_t)(src * (1U << 7)) >> m, INT8_MIN, INT8_MAX))
 
 /**
  * @brief Convert a floating-point (float32_t) value to a Q15 fixed-point value with a right shift.
@@ -126,7 +126,7 @@ extern "C" {
  * @return The converted Q15 fixed-point value.
  */
 #define Z_SHIFT_F32_TO_Q15(src, m)                                                                 \
-	((q15_t)Z_CLAMP((int32_t)(src * (1U << 15)) >> m, INT16_MIN, INT16_MAX))
+	((q15_t)clamp((int32_t)(src * (1U << 15)) >> m, INT16_MIN, INT16_MAX))
 
 /**
  * @brief Convert a floating-point (float32_t) value to a Q31 fixed-point value with a right shift.
@@ -136,7 +136,7 @@ extern "C" {
  * @return The converted Q31 fixed-point value.
  */
 #define Z_SHIFT_F32_TO_Q31(src, m)                                                                 \
-	((q31_t)Z_CLAMP((int64_t)(src * (1U << 31)) >> m, INT32_MIN, INT32_MAX))
+	((q31_t)clamp((int64_t)(src * (1U << 31)) >> m, INT32_MIN, INT32_MAX))
 
 /**
  * @brief Convert a floating-point (float64_t) value to a Q7 fixed-point value with a right shift.
@@ -146,7 +146,7 @@ extern "C" {
  * @return The converted Q7 fixed-point value.
  */
 #define Z_SHIFT_F64_TO_Q7(src, m)                                                                  \
-	((q7_t)Z_CLAMP((int32_t)(src * (1U << 7)) >> m, INT8_MIN, INT8_MAX))
+	((q7_t)clamp((int32_t)(src * (1U << 7)) >> m, INT8_MIN, INT8_MAX))
 
 /**
  * @brief Convert a floating-point (float64_t) value to a Q15 fixed-point value with a right shift.
@@ -156,7 +156,7 @@ extern "C" {
  * @return The converted Q15 fixed-point value.
  */
 #define Z_SHIFT_F64_TO_Q15(src, m)                                                                 \
-	((q15_t)Z_CLAMP((int32_t)(src * (1U << 15)) >> m, INT16_MIN, INT16_MAX))
+	((q15_t)clamp((int32_t)(src * (1U << 15)) >> m, INT16_MIN, INT16_MAX))
 
 /**
  * @brief Convert a floating-point (float64_t) value to a Q31 fixed-point value with a right shift.
@@ -166,7 +166,7 @@ extern "C" {
  * @return The converted Q31 fixed-point value.
  */
 #define Z_SHIFT_F64_TO_Q31(src, m)                                                                 \
-	((q31_t)Z_CLAMP((int64_t)(src * (1U << 31)) >> m, INT32_MIN, INT32_MAX))
+	((q31_t)clamp((int64_t)(src * (1U << 31)) >> m, INT32_MIN, INT32_MAX))
 
 /**
  * @}

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -376,8 +376,8 @@ extern "C" {
 /**
  * @brief Obtain the maximum of two values.
  *
- * @note Arguments are evaluated twice. Use Z_MAX for a GCC-only, single
- * evaluation version
+ * @note Arguments are evaluated twice. Use @ref max for a single evaluation
+ * version.
  *
  * @param a First value.
  * @param b Second value.
@@ -387,28 +387,30 @@ extern "C" {
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #endif
 
+#ifndef __cplusplus
 /** @brief Return larger value of two provided expressions.
  *
  * Macro ensures that expressions are evaluated only once.
  *
  * @note Macro has limited usage compared to the standard macro as it cannot be
  *	 used:
- *	 - to generate constant integer, e.g. __aligned(Z_MAX(4,5))
- *	 - static variable, e.g. array like static uint8_t array[Z_MAX(...)];
+ *	 - to generate constant integer, e.g. __aligned(max(4,5))
+ *	 - static variable, e.g. array like static uint8_t array[max(...)];
  */
-#define Z_MAX(a, b) ({ \
+#define max(a, b) ({ \
 		/* random suffix to avoid naming conflict */ \
 		__typeof__(a) _value_a_ = (a); \
 		__typeof__(b) _value_b_ = (b); \
 		(_value_a_ > _value_b_) ? _value_a_ : _value_b_; \
 	})
+#endif
 
 #ifndef MIN
 /**
  * @brief Obtain the minimum of two values.
  *
- * @note Arguments are evaluated twice. Use Z_MIN for a GCC-only, single
- * evaluation version
+ * @note Arguments are evaluated twice. Use @ref min for a single evaluation
+ * version.
  *
  * @param a First value.
  * @param b Second value.
@@ -418,17 +420,19 @@ extern "C" {
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
+#ifndef __cplusplus
 /** @brief Return smaller value of two provided expressions.
  *
- * Macro ensures that expressions are evaluated only once. See @ref Z_MAX for
+ * Macro ensures that expressions are evaluated only once. See @ref max for
  * macro limitations.
  */
-#define Z_MIN(a, b) ({ \
+#define min(a, b) ({ \
 		/* random suffix to avoid naming conflict */ \
 		__typeof__(a) _value_a_ = (a); \
 		__typeof__(b) _value_b_ = (b); \
 		(_value_a_ < _value_b_) ? _value_a_ : _value_b_; \
 	})
+#endif
 
 #ifndef MAX_FROM_LIST
 /**
@@ -555,8 +559,8 @@ extern "C" {
 /**
  * @brief Clamp a value to a given range.
  *
- * @note Arguments are evaluated multiple times. Use Z_CLAMP for a GCC-only,
- * single evaluation version.
+ * @note Arguments are evaluated multiple times. Use @ref clamp for a single
+ * evaluation version.
  *
  * @param val Value to be clamped.
  * @param low Lowest allowed value (inclusive).
@@ -567,12 +571,13 @@ extern "C" {
 #define CLAMP(val, low, high) (((val) <= (low)) ? (low) : MIN(val, high))
 #endif
 
+#ifndef __cplusplus
 /** @brief Return a value clamped to a given range.
  *
- * Macro ensures that expressions are evaluated only once. See @ref Z_MAX for
+ * Macro ensures that expressions are evaluated only once. See @ref max for
  * macro limitations.
  */
-#define Z_CLAMP(val, low, high) ({                                             \
+#define clamp(val, low, high) ({                                               \
 		/* random suffix to avoid naming conflict */                   \
 		__typeof__(val) _value_val_ = (val);                           \
 		__typeof__(low) _value_low_ = (low);                           \
@@ -581,6 +586,7 @@ extern "C" {
 		(_value_val_ > _value_high_) ? _value_high_ :                  \
 					       _value_val_;                    \
 	})
+#endif
 
 /**
  * @brief Checks if a value is within range.

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -375,6 +375,9 @@ extern "C" {
 /**
  * @cond INTERNAL_HIDDEN
  */
+#define Z_INTERNAL_MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define Z_INTERNAL_MIN(a, b) (((a) < (b)) ? (a) : (b))
+
 #define _minmax_unique(op, a, b, ua, ub) ({ \
 		__typeof__(a) ua = (a);     \
 		__typeof__(b) ub = (b);     \
@@ -412,7 +415,7 @@ extern "C" {
  *
  * @returns Maximum value of @p a and @p b.
  */
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MAX(a, b) Z_INTERNAL_MAX(a, b)
 #endif
 
 #ifndef __cplusplus
@@ -425,7 +428,7 @@ extern "C" {
  *	 - to generate constant integer, e.g. __aligned(max(4,5))
  *	 - static variable, e.g. array like static uint8_t array[max(...)];
  */
-#define max(a, b) _minmax_cnt(MAX, a, b, __COUNTER__)
+#define max(a, b) _minmax_cnt(Z_INTERNAL_MAX, a, b, __COUNTER__)
 #endif
 
 /** @brief Return larger value of three provided expressions.
@@ -433,7 +436,7 @@ extern "C" {
  * Macro ensures that expressions are evaluated only once. See @ref max for
  * macro limitations.
  */
-#define max3(a, b, c) _minmax3_cnt(MAX, a, b, c, __COUNTER__)
+#define max3(a, b, c) _minmax3_cnt(Z_INTERNAL_MAX, a, b, c, __COUNTER__)
 
 #ifndef MIN
 /**
@@ -447,7 +450,7 @@ extern "C" {
  *
  * @returns Minimum value of @p a and @p b.
  */
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#define MIN(a, b) Z_INTERNAL_MIN(a, b)
 #endif
 
 #ifndef __cplusplus
@@ -456,7 +459,7 @@ extern "C" {
  * Macro ensures that expressions are evaluated only once. See @ref max for
  * macro limitations.
  */
-#define min(a, b) _minmax_cnt(MIN, a, b, __COUNTER__)
+#define min(a, b) _minmax_cnt(Z_INTERNAL_MIN, a, b, __COUNTER__)
 #endif
 
 /** @brief Return smaller value of three provided expressions.
@@ -464,7 +467,7 @@ extern "C" {
  * Macro ensures that expressions are evaluated only once. See @ref max for
  * macro limitations.
  */
-#define min3(a, b, c) _minmax3_cnt(MIN, a, b, c, __COUNTER__)
+#define min3(a, b, c) _minmax3_cnt(Z_INTERNAL_MIN, a, b, c, __COUNTER__)
 
 
 #ifndef MAX_FROM_LIST
@@ -601,7 +604,7 @@ extern "C" {
  *
  * @returns Clamped value.
  */
-#define CLAMP(val, low, high) (((val) <= (low)) ? (low) : MIN(val, high))
+#define CLAMP(val, low, high) (((val) <= (low)) ? (low) : Z_INTERNAL_MIN(val, high))
 #endif
 
 #ifndef __cplusplus

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -383,6 +383,19 @@ extern "C" {
 
 #define _minmax_cnt(op, a, b, cnt) \
 	_minmax_unique(op, a, b, UTIL_CAT(_value_a_, cnt), UTIL_CAT(_value_b_, cnt))
+
+#define _minmax3_unique(op, a, b, c, ua, ub, uc) ({ \
+		__typeof__(a) ua = (a);             \
+		__typeof__(b) ub = (b);             \
+		__typeof__(c) uc = (c);             \
+		op(ua, op(ub, uc));                 \
+	})
+
+#define _minmax3_cnt(op, a, b, c, cnt)            \
+	_minmax3_unique(op, a, b, c,              \
+			UTIL_CAT(_value_a_, cnt), \
+			UTIL_CAT(_value_b_, cnt), \
+			UTIL_CAT(_value_c_, cnt))
 /**
  * @endcond
  */
@@ -415,6 +428,13 @@ extern "C" {
 #define max(a, b) _minmax_cnt(MAX, a, b, __COUNTER__)
 #endif
 
+/** @brief Return larger value of three provided expressions.
+ *
+ * Macro ensures that expressions are evaluated only once. See @ref max for
+ * macro limitations.
+ */
+#define max3(a, b, c) _minmax3_cnt(MAX, a, b, c, __COUNTER__)
+
 #ifndef MIN
 /**
  * @brief Obtain the minimum of two values.
@@ -438,6 +458,14 @@ extern "C" {
  */
 #define min(a, b) _minmax_cnt(MIN, a, b, __COUNTER__)
 #endif
+
+/** @brief Return smaller value of three provided expressions.
+ *
+ * Macro ensures that expressions are evaluated only once. See @ref max for
+ * macro limitations.
+ */
+#define min3(a, b, c) _minmax3_cnt(MIN, a, b, c, __COUNTER__)
+
 
 #ifndef MAX_FROM_LIST
 /**

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -387,6 +387,22 @@ extern "C" {
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #endif
 
+/** @brief Return larger value of two provided expressions.
+ *
+ * Macro ensures that expressions are evaluated only once.
+ *
+ * @note Macro has limited usage compared to the standard macro as it cannot be
+ *	 used:
+ *	 - to generate constant integer, e.g. __aligned(Z_MAX(4,5))
+ *	 - static variable, e.g. array like static uint8_t array[Z_MAX(...)];
+ */
+#define Z_MAX(a, b) ({ \
+		/* random suffix to avoid naming conflict */ \
+		__typeof__(a) _value_a_ = (a); \
+		__typeof__(b) _value_b_ = (b); \
+		(_value_a_ > _value_b_) ? _value_a_ : _value_b_; \
+	})
+
 #ifndef MIN
 /**
  * @brief Obtain the minimum of two values.
@@ -401,6 +417,18 @@ extern "C" {
  */
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif
+
+/** @brief Return smaller value of two provided expressions.
+ *
+ * Macro ensures that expressions are evaluated only once. See @ref Z_MAX for
+ * macro limitations.
+ */
+#define Z_MIN(a, b) ({ \
+		/* random suffix to avoid naming conflict */ \
+		__typeof__(a) _value_a_ = (a); \
+		__typeof__(b) _value_b_ = (b); \
+		(_value_a_ < _value_b_) ? _value_a_ : _value_b_; \
+	})
 
 #ifndef MAX_FROM_LIST
 /**
@@ -538,6 +566,21 @@ extern "C" {
  */
 #define CLAMP(val, low, high) (((val) <= (low)) ? (low) : MIN(val, high))
 #endif
+
+/** @brief Return a value clamped to a given range.
+ *
+ * Macro ensures that expressions are evaluated only once. See @ref Z_MAX for
+ * macro limitations.
+ */
+#define Z_CLAMP(val, low, high) ({                                             \
+		/* random suffix to avoid naming conflict */                   \
+		__typeof__(val) _value_val_ = (val);                           \
+		__typeof__(low) _value_low_ = (low);                           \
+		__typeof__(high) _value_high_ = (high);                        \
+		(_value_val_ < _value_low_)  ? _value_low_ :                   \
+		(_value_val_ > _value_high_) ? _value_high_ :                  \
+					       _value_val_;                    \
+	})
 
 /**
  * @brief Checks if a value is within range.

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -372,6 +372,21 @@ extern "C" {
 		 ? ((n) - ((d) / 2)) / (d)                                                         \
 		 : ((n) + ((d) / 2)) / (d))
 
+/**
+ * @cond INTERNAL_HIDDEN
+ */
+#define _minmax_unique(op, a, b, ua, ub) ({ \
+		__typeof__(a) ua = (a);     \
+		__typeof__(b) ub = (b);     \
+		op(ua, ub);                 \
+	})
+
+#define _minmax_cnt(op, a, b, cnt) \
+	_minmax_unique(op, a, b, UTIL_CAT(_value_a_, cnt), UTIL_CAT(_value_b_, cnt))
+/**
+ * @endcond
+ */
+
 #ifndef MAX
 /**
  * @brief Obtain the maximum of two values.
@@ -397,12 +412,7 @@ extern "C" {
  *	 - to generate constant integer, e.g. __aligned(max(4,5))
  *	 - static variable, e.g. array like static uint8_t array[max(...)];
  */
-#define max(a, b) ({ \
-		/* random suffix to avoid naming conflict */ \
-		__typeof__(a) _value_a_ = (a); \
-		__typeof__(b) _value_b_ = (b); \
-		(_value_a_ > _value_b_) ? _value_a_ : _value_b_; \
-	})
+#define max(a, b) _minmax_cnt(MAX, a, b, __COUNTER__)
 #endif
 
 #ifndef MIN
@@ -426,12 +436,7 @@ extern "C" {
  * Macro ensures that expressions are evaluated only once. See @ref max for
  * macro limitations.
  */
-#define min(a, b) ({ \
-		/* random suffix to avoid naming conflict */ \
-		__typeof__(a) _value_a_ = (a); \
-		__typeof__(b) _value_b_ = (b); \
-		(_value_a_ < _value_b_) ? _value_a_ : _value_b_; \
-	})
+#define min(a, b) _minmax_cnt(MIN, a, b, __COUNTER__)
 #endif
 
 #ifndef MAX_FROM_LIST

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -626,49 +626,6 @@ do {                                                                    \
 	__asm__ __volatile__ ("" ::: "memory"); \
 } while (false)
 
-/** @brief Return larger value of two provided expressions.
- *
- * Macro ensures that expressions are evaluated only once.
- *
- * @note Macro has limited usage compared to the standard macro as it cannot be
- *	 used:
- *	 - to generate constant integer, e.g. __aligned(Z_MAX(4,5))
- *	 - static variable, e.g. array like static uint8_t array[Z_MAX(...)];
- */
-#define Z_MAX(a, b) ({ \
-		/* random suffix to avoid naming conflict */ \
-		__typeof__(a) _value_a_ = (a); \
-		__typeof__(b) _value_b_ = (b); \
-		(_value_a_ > _value_b_) ? _value_a_ : _value_b_; \
-	})
-
-/** @brief Return smaller value of two provided expressions.
- *
- * Macro ensures that expressions are evaluated only once. See @ref Z_MAX for
- * macro limitations.
- */
-#define Z_MIN(a, b) ({ \
-		/* random suffix to avoid naming conflict */ \
-		__typeof__(a) _value_a_ = (a); \
-		__typeof__(b) _value_b_ = (b); \
-		(_value_a_ < _value_b_) ? _value_a_ : _value_b_; \
-	})
-
-/** @brief Return a value clamped to a given range.
- *
- * Macro ensures that expressions are evaluated only once. See @ref Z_MAX for
- * macro limitations.
- */
-#define Z_CLAMP(val, low, high) ({                                             \
-		/* random suffix to avoid naming conflict */                   \
-		__typeof__(val) _value_val_ = (val);                           \
-		__typeof__(low) _value_low_ = (low);                           \
-		__typeof__(high) _value_high_ = (high);                        \
-		(_value_val_ < _value_low_)  ? _value_low_ :                   \
-		(_value_val_ > _value_high_) ? _value_high_ :                  \
-					       _value_val_;                    \
-	})
-
 /**
  * @brief Calculate power of two ceiling for some nonzero value
  *

--- a/include/zephyr/toolchain/iar/iccarm.h
+++ b/include/zephyr/toolchain/iar/iccarm.h
@@ -320,49 +320,6 @@ do {                                                                    \
 	__asm volatile("" ::: "memory"); \
 } while (false)
 
-/** @brief Return larger value of two provided expressions.
- *
- * Macro ensures that expressions are evaluated only once.
- *
- * @note Macro has limited usage compared to the standard macro as it cannot be
- *	 used:
- *	 - to generate constant integer, e.g. __aligned(Z_MAX(4,5))
- *	 - static variable, e.g. array like static uint8_t array[Z_MAX(...)];
- */
-#define Z_MAX(a, b) ({ \
-		/* random suffix to avoid naming conflict */ \
-		__typeof__(a) _value_a_ = (a); \
-		__typeof__(b) _value_b_ = (b); \
-		_value_a_ > _value_b_ ? _value_a_ : _value_b_; \
-	})
-
-/** @brief Return smaller value of two provided expressions.
- *
- * Macro ensures that expressions are evaluated only once. See @ref Z_MAX for
- * macro limitations.
- */
-#define Z_MIN(a, b) ({ \
-		/* random suffix to avoid naming conflict */ \
-		__typeof__(a) _value_a_ = (a); \
-		__typeof__(b) _value_b_ = (b); \
-		_value_a_ < _value_b_ ? _value_a_ : _value_b_; \
-	})
-
-/** @brief Return a value clamped to a given range.
- *
- * Macro ensures that expressions are evaluated only once. See @ref Z_MAX for
- * macro limitations.
- */
-#define Z_CLAMP(val, low, high) ({                                             \
-		/* random suffix to avoid naming conflict */                   \
-		__typeof__(val) _value_val_ = (val);                           \
-		__typeof__(low) _value_low_ = (low);                           \
-		__typeof__(high) _value_high_ = (high);                        \
-		(_value_val_ < _value_low_)  ? _value_low_ :                   \
-		(_value_val_ > _value_high_) ? _value_high_ :                  \
-					       _value_val_;                    \
-	})
-
 /**
  * @brief Calculate power of two ceiling for some nonzero value
  *

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1176,7 +1176,7 @@ static int64_t next_rx_off(void)
 /** Return timestamp to next even whether it is RX_OFF or update event */
 static int64_t calc_next_event(void)
 {
-	return Z_MIN(next_update(), next_rx_off());
+	return min(next_update(), next_rx_off());
 }
 
 static void sm_registration_done(void)

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -346,7 +346,7 @@ static void find_completion_candidates(const struct shell *sh,
 		is_candidate = is_completion_candidate(candidate->syntax,
 						incompl_cmd, incompl_cmd_len);
 		if (is_candidate) {
-			*longest = Z_MAX(strlen(candidate->syntax), *longest);
+			*longest = max(strlen(candidate->syntax), *longest);
 			if (*cnt == 0) {
 				*first_idx = idx;
 			}

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -187,7 +187,7 @@ void z_shell_help_subcmd_print(const struct shell *sh,
 
 	/* Searching for the longest subcommand to print. */
 	while ((entry = z_shell_cmd_get(parent, idx++, &dloc)) != NULL) {
-		longest = Z_MAX(longest, z_shell_strlen(entry->syntax));
+		longest = max(longest, z_shell_strlen(entry->syntax));
 	}
 
 	/* No help to print */

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -279,6 +279,26 @@ ZTEST(util, test_max_min_clamp) {
 #endif
 }
 
+ZTEST(util, test_max3_min3) {
+	/* check for single call */
+	zassert_equal(max3(inc_func(true), 0, 0), 1, "Unexpected macro result");
+	zassert_equal(inc_func(false), 2, "Unexpected return value");
+
+	zassert_equal(min3(inc_func(false), 9, 10), 3, "Unexpected macro result");
+	zassert_equal(inc_func(false), 4, "Unexpected return value");
+
+	/* test the general functionality */
+	zassert_equal(max3(1, 2, 3), 3, "Unexpected macro result");
+	zassert_equal(max3(3, 1, 2), 3, "Unexpected macro result");
+	zassert_equal(max3(2, 3, 1), 3, "Unexpected macro result");
+	zassert_equal(max3(-1, 0, 1), 1, "Unexpected macro result");
+
+	zassert_equal(min3(1, 2, 3), 1, "Unexpected macro result");
+	zassert_equal(min3(3, 1, 2), 1, "Unexpected macro result");
+	zassert_equal(min3(2, 3, 1), 1, "Unexpected macro result");
+	zassert_equal(min3(-1, 0, 1), -1, "Unexpected macro result");
+}
+
 ZTEST(util, test_max_from_list_macro) {
 	/* Test with one argument */
 	zassert_equal(MAX_FROM_LIST(10), 10, "Should return the single value.");

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -269,6 +269,13 @@ ZTEST(util, test_max_min_clamp) {
 		      "Unexpected macro result");
 	/* clamp should have call inc_func only once */
 	zassert_equal(inc_func(false), 8, "Unexpected return value");
+
+	/* Nested calls do not generate build warnings */
+	zassert_equal(max(inc_func(false),
+			  max(inc_func(false),
+			      min(inc_func(false),
+				  inc_func(false)))), 11, "Unexpected macro result");
+	zassert_equal(inc_func(false), 13, "Unexpected return value");
 #endif
 }
 

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -245,26 +245,31 @@ static int inc_func(bool cleanup)
 	return a++;
 }
 
-/* Test checks if @ref Z_MAX, @ref Z_MIN and @ref Z_CLAMP return correct result
+/* Test checks if @ref max, @ref min and @ref clamp return correct result
  * and perform single evaluation of input arguments.
  */
-ZTEST(util, test_z_max_z_min_z_clamp) {
-	zassert_equal(Z_MAX(inc_func(true), 0), 1, "Unexpected macro result");
-	/* Z_MAX should have call inc_func only once */
+ZTEST(util, test_max_min_clamp) {
+#ifdef __cplusplus
+	/* C++ has its own std::min() and std::max(), min and max are not available. */
+	ztest_test_skip();
+#else
+	zassert_equal(max(inc_func(true), 0), 1, "Unexpected macro result");
+	/* max should have call inc_func only once */
 	zassert_equal(inc_func(false), 2, "Unexpected return value");
 
-	zassert_equal(Z_MIN(inc_func(false), 2), 2, "Unexpected macro result");
-	/* Z_MIN should have call inc_func only once */
+	zassert_equal(min(inc_func(false), 2), 2, "Unexpected macro result");
+	/* min should have call inc_func only once */
 	zassert_equal(inc_func(false), 4, "Unexpected return value");
 
-	zassert_equal(Z_CLAMP(inc_func(false), 1, 3), 3, "Unexpected macro result");
-	/* Z_CLAMP should have call inc_func only once */
+	zassert_equal(clamp(inc_func(false), 1, 3), 3, "Unexpected macro result");
+	/* clamp should have call inc_func only once */
 	zassert_equal(inc_func(false), 6, "Unexpected return value");
 
-	zassert_equal(Z_CLAMP(inc_func(false), 10, 15), 10,
+	zassert_equal(clamp(inc_func(false), 10, 15), 10,
 		      "Unexpected macro result");
-	/* Z_CLAMP should have call inc_func only once */
+	/* clamp should have call inc_func only once */
 	zassert_equal(inc_func(false), 8, "Unexpected return value");
+#endif
 }
 
 ZTEST(util, test_max_from_list_macro) {

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 979a58d0829108b57f10e90b6c3fc35ab6206e4b
+      revision: 2c0fd06a98bb9b89ac234b75b2c217742f0df1ba
       path: modules/hal/nordic
       groups:
         - hal
@@ -226,7 +226,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: d8ee5f18e95b9f4616a481be65e2c9ee0af1779f
+      revision: 740a944351300664ea17fb7913f0036a5263f008
       groups:
         - hal
     - name: hal_rpi_pico
@@ -342,7 +342,7 @@ manifest:
       revision: 40403f5f2805cca210d2a47c8717d89c4e816cda
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: acb24fe26f479df9dba3c4bd97ea653ad3086ee7
+      revision: 53500666a59195b44e2e5a939c111effbf23db7b
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: c30a6d8b92fcebdb797fc1a7698e8729e250f637


### PR DESCRIPTION
Few initial rework after binning https://github.com/zephyrproject-rtos/zephyr/pull/96132:

- optimistically move the compiler specific single evaluation implementations back to util.h
- rename them to min/max (because Linux)
- make them nestable
- add three argument variables
- add shadow MIN/MAX definitions so MIN and MAX can be redefined locally

Unit test patches also in:
- https://github.com/zephyrproject-rtos/zephyr/pull/96499

Module deps:
- https://github.com/zephyrproject-rtos/hal_nordic/pull/321
- https://github.com/zephyrproject-rtos/hal_renesas/pull/144
- https://github.com/zephyrproject-rtos/nrf_wifi/pull/76

Going to undraft and get these ^^ merged once I'm reasonably sure that there's conseus on the naming, trying to avoid more unnecessary work on the modules.

After this: go through the code base and start using these where appropriate.
