### PR TITLE
doc: use commit range as argument, not upstream/main

### DIFF
--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -607,7 +607,7 @@ before opening a new Pull Request:
 
 .. code-block:: bash
 
-   ./scripts/ci/check_compliance.py -c upstream/main..
+   ./scripts/ci/check_compliance.py -c <commit range>
 
 .. note::
    On Windows if the .pl extension has not yet been associated with an


### PR DESCRIPTION
upstream/main depends on how you checked out the repo, it can be
anything and user might have a different remote. Use <commit range>
instead to make it more general.

Fixes zephyrproject-rtos/zephyr#96121

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
