### PR TITLE
secure_storage: remove experimental status

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -282,6 +282,10 @@ Libraries / Subsystems
     via :kconfig:option:`CONFIG_LOG_RATELIMIT_FALLBACK` to either log all messages or drop them completely.
     For more details, see :ref:`logging_ratelimited`.
 
+* Secure storage
+
+  * The experimental status has been removed. (:github:`96483`)
+
 Other notable changes
 *********************
 

--- a/subsys/secure_storage/Kconfig
+++ b/subsys/secure_storage/Kconfig
@@ -5,7 +5,6 @@ menuconfig SECURE_STORAGE
 	bool "Secure storage subsystem"
 	depends on !BUILD_WITH_TFM
 	select MBEDTLS_PSA_CRYPTO_STORAGE_C if MBEDTLS_PSA_CRYPTO_C
-	select EXPERIMENTAL
 	help
 	  The secure storage subsystem provides an implementation of the PSA Secure Storage API
 	  functions on board targets that don't already have one.

--- a/subsys/secure_storage/include/psa/error.h
+++ b/subsys/secure_storage/include/psa/error.h
@@ -10,19 +10,44 @@
  */
 #include <stdint.h>
 
+/** Function return status. Either `PSA_SUCCESS` or one of the defined `PSA_ERROR_*` values. */
 typedef int32_t psa_status_t;
 
+/** The operation completed successfully. */
 #define PSA_SUCCESS ((psa_status_t)0)
 
+/** An unspecified internal failure happened. */
 #define PSA_ERROR_GENERIC_ERROR        ((psa_status_t)-132)
+
+/** An entry associated with the provided `uid` already
+ *  exists and was created with `PSA_STORAGE_FLAG_WRITE_ONCE`.
+ */
 #define PSA_ERROR_NOT_PERMITTED        ((psa_status_t)-133)
+
+/** The function is not supported or one or more of the flags
+ *  provided in `create_flags` are not supported or not valid.
+ */
 #define PSA_ERROR_NOT_SUPPORTED        ((psa_status_t)-134)
+
+/** One or more arguments other than `create_flags` are invalid. */
 #define PSA_ERROR_INVALID_ARGUMENT     ((psa_status_t)-135)
+
+/** An entry with the provided `uid` already exists. */
 #define PSA_ERROR_ALREADY_EXISTS       ((psa_status_t)-139)
+
+/** The provided `uid` was not found in the storage. */
 #define PSA_ERROR_DOES_NOT_EXIST       ((psa_status_t)-140)
+
+/** There is insufficient space on the storage medium. */
 #define PSA_ERROR_INSUFFICIENT_STORAGE ((psa_status_t)-142)
+
+/** The physical storage has failed (fatal error). */
 #define PSA_ERROR_STORAGE_FAILURE      ((psa_status_t)-146)
+
+/** The data associated with `uid` failed authentication. */
 #define PSA_ERROR_INVALID_SIGNATURE    ((psa_status_t)-149)
+
+/** The data associated with `uid` is corrupt. */
 #define PSA_ERROR_DATA_CORRUPT         ((psa_status_t)-152)
 
 /** @} */

--- a/subsys/secure_storage/include/psa/internal_trusted_storage.h
+++ b/subsys/secure_storage/include/psa/internal_trusted_storage.h
@@ -38,7 +38,7 @@
  * @retval PSA_ERROR_NOT_PERMITTED        An entry associated with the provided `uid` already
  *                                        exists and was created with `PSA_STORAGE_FLAG_WRITE_ONCE`.
  * @retval PSA_ERROR_NOT_SUPPORTED        One or more of the flags provided in `create_flags`
- *                                        are not supported or invalid.
+ *                                        are not supported or not valid.
  * @retval PSA_ERROR_INVALID_ARGUMENT     One or more arguments other than `create_flags` are
  *                                        invalid.
  * @retval PSA_ERROR_INSUFFICIENT_STORAGE There is insufficient space on the storage medium.
@@ -65,8 +65,8 @@ psa_status_t psa_its_set(psa_storage_uid_t uid, size_t data_length,
  *
  * @retval PSA_SUCCESS                The operation completed successfully.
  * @retval PSA_ERROR_GENERIC_ERROR    An unspecified internal failure happened.
- * @retval PSA_ERROR_INVALID_ARGUMENT One or more of the arguments are invalid. This can also
- *                                    happen if `data_offset` is larger than the size of the data
+ * @retval PSA_ERROR_INVALID_ARGUMENT One or more arguments are invalid. This can also happen
+ *                                    if `data_offset` is larger than the size of the data
  *                                    associated with `uid`.
  * @retval PSA_ERROR_DOES_NOT_EXIST   The provided `uid` was not found in the storage.
  * @retval PSA_ERROR_STORAGE_FAILURE  The physical storage has failed (fatal error).
@@ -90,7 +90,7 @@ psa_status_t psa_its_get(psa_storage_uid_t uid, size_t data_offset,
  *
  * @retval PSA_SUCCESS                The operation completed successfully.
  * @retval PSA_ERROR_GENERIC_ERROR    An unspecified internal failure happened.
- * @retval PSA_ERROR_INVALID_ARGUMENT One or more of the arguments are invalid.
+ * @retval PSA_ERROR_INVALID_ARGUMENT `uid` is invalid.
  * @retval PSA_ERROR_DOES_NOT_EXIST   The provided `uid` was not found in the storage.
  * @retval PSA_ERROR_STORAGE_FAILURE  The physical storage has failed (fatal error).
  */

--- a/subsys/secure_storage/include/psa/internal_trusted_storage.h
+++ b/subsys/secure_storage/include/psa/internal_trusted_storage.h
@@ -34,6 +34,7 @@
  * @param create_flags Flags indicating the properties of the entry.
  *
  * @retval PSA_SUCCESS                    The operation completed successfully.
+ * @retval PSA_ERROR_GENERIC_ERROR        An unspecified internal failure happened.
  * @retval PSA_ERROR_NOT_PERMITTED        An entry associated with the provided `uid` already
  *                                        exists and was created with `PSA_STORAGE_FLAG_WRITE_ONCE`.
  * @retval PSA_ERROR_NOT_SUPPORTED        One or more of the flags provided in `create_flags`
@@ -63,6 +64,7 @@ psa_status_t psa_its_set(psa_storage_uid_t uid, size_t data_length,
  * @param[out] p_data_length On success, the number of bytes placed in `p_data`.
  *
  * @retval PSA_SUCCESS                The operation completed successfully.
+ * @retval PSA_ERROR_GENERIC_ERROR    An unspecified internal failure happened.
  * @retval PSA_ERROR_INVALID_ARGUMENT One or more of the arguments are invalid. This can also
  *                                    happen if `data_offset` is larger than the size of the data
  *                                    associated with `uid`.
@@ -87,6 +89,7 @@ psa_status_t psa_its_get(psa_storage_uid_t uid, size_t data_offset,
  *                    be populated with the metadata on success.
  *
  * @retval PSA_SUCCESS                The operation completed successfully.
+ * @retval PSA_ERROR_GENERIC_ERROR    An unspecified internal failure happened.
  * @retval PSA_ERROR_INVALID_ARGUMENT One or more of the arguments are invalid.
  * @retval PSA_ERROR_DOES_NOT_EXIST   The provided `uid` was not found in the storage.
  * @retval PSA_ERROR_STORAGE_FAILURE  The physical storage has failed (fatal error).

--- a/subsys/secure_storage/include/psa/protected_storage.h
+++ b/subsys/secure_storage/include/psa/protected_storage.h
@@ -36,7 +36,7 @@
  * @retval PSA_ERROR_NOT_PERMITTED        An entry associated with the provided `uid` already
  *                                        exists and was created with `PSA_STORAGE_FLAG_WRITE_ONCE`.
  * @retval PSA_ERROR_NOT_SUPPORTED        One or more of the flags provided in `create_flags`
- *                                        are not supported or invalid.
+ *                                        are not supported or not valid.
  * @retval PSA_ERROR_INVALID_ARGUMENT     One or more arguments other than `create_flags` are
  *                                        invalid.
  * @retval PSA_ERROR_INSUFFICIENT_STORAGE There is insufficient space on the storage medium.
@@ -67,8 +67,8 @@ psa_status_t psa_ps_set(psa_storage_uid_t uid, size_t data_length,
  *
  * @retval PSA_SUCCESS                 The operation completed successfully.
  * @retval PSA_ERROR_GENERIC_ERROR     An unspecified internal failure happened.
- * @retval PSA_ERROR_INVALID_ARGUMENT  One or more of the arguments are invalid. This can also
- *                                     happen if `data_offset` is larger than the size of the data
+ * @retval PSA_ERROR_INVALID_ARGUMENT  One or more arguments are invalid. This can also happen
+ *                                     if `data_offset` is larger than the size of the data
  *                                     associated with `uid`.
  * @retval PSA_ERROR_DOES_NOT_EXIST    The provided `uid` was not found in the storage.
  * @retval PSA_ERROR_STORAGE_FAILURE   The physical storage has failed (fatal error).
@@ -98,7 +98,7 @@ psa_status_t psa_ps_get(psa_storage_uid_t uid, size_t data_offset,
  *
  * @retval PSA_SUCCESS                 The operation completed successfully.
  * @retval PSA_ERROR_GENERIC_ERROR     An unspecified internal failure happened.
- * @retval PSA_ERROR_INVALID_ARGUMENT  One or more of the arguments are invalid.
+ * @retval PSA_ERROR_INVALID_ARGUMENT  `uid` is invalid.
  * @retval PSA_ERROR_DOES_NOT_EXIST    The provided `uid` was not found in the storage.
  * @retval PSA_ERROR_STORAGE_FAILURE   The physical storage has failed (fatal error).
  * @retval PSA_ERROR_INVALID_SIGNATURE The data associated with `uid` failed authentication.
@@ -159,8 +159,8 @@ psa_status_t psa_ps_remove(psa_storage_uid_t uid)
  * @retval PSA_SUCCESS                    The operation completed successfully.
  * @retval PSA_ERROR_GENERIC_ERROR        An unspecified internal failure happened.
  * @retval PSA_ERROR_NOT_SUPPORTED        The implementation doesn't support this function or one
- *                                        or more of the flags provided in `create_flags` are not
- *                                        supported or invalid.
+ *                                        or more of the flags provided in `create_flags`
+ *                                        are not supported or not valid.
  * @retval PSA_ERROR_INVALID_ARGUMENT     `uid` is invalid.
  * @retval PSA_ERROR_ALREADY_EXISTS       An entry with the provided `uid` already exists.
  * @retval PSA_ERROR_INSUFFICIENT_STORAGE There is insufficient space on the storage medium.
@@ -198,7 +198,7 @@ psa_status_t psa_ps_create(psa_storage_uid_t uid, size_t capacity,
  * @retval PSA_ERROR_GENERIC_ERROR     An unspecified internal failure happened.
  * @retval PSA_ERROR_NOT_PERMITTED     The entry was created with `PSA_STORAGE_FLAG_WRITE_ONCE`.
  * @retval PSA_ERROR_NOT_SUPPORTED     The implementation doesn't support this function.
- * @retval PSA_ERROR_INVALID_ARGUMENT  One or more of the arguments are invalid.
+ * @retval PSA_ERROR_INVALID_ARGUMENT  One or more arguments are invalid.
  * @retval PSA_ERROR_DOES_NOT_EXIST    The provided `uid` was not found in the storage.
  * @retval PSA_ERROR_STORAGE_FAILURE   The physical storage has failed (fatal error).
  * @retval PSA_ERROR_INVALID_SIGNATURE The data associated with `uid` failed authentication.

--- a/subsys/secure_storage/include/psa/storage_common.h
+++ b/subsys/secure_storage/include/psa/storage_common.h
@@ -6,6 +6,7 @@
 /**
  * @defgroup psa_secure_storage PSA Secure Storage API
  * @ingroup os_services
+ * @version 1.0.4
  * @details For more information on the PSA Secure Storage API, see the
  * [PSA Certified Secure Storage API](https://arm-software.github.io/psa-api/storage/1.0/)
  * specification.

--- a/subsys/secure_storage/src/its/implementation.c
+++ b/subsys/secure_storage/src/its/implementation.c
@@ -56,9 +56,8 @@ static psa_status_t get_stored_data(
 		if (ret != PSA_ERROR_DOES_NOT_EXIST) {
 			log_failed_operation("retrieve", "from", ret);
 		}
-		return ret;
 	}
-	return PSA_SUCCESS;
+	return ret;
 }
 
 static psa_status_t transform_stored_data(
@@ -73,7 +72,7 @@ static psa_status_t transform_stored_data(
 						      data_size, data, data_len, create_flags);
 	if (ret != PSA_SUCCESS) {
 		log_failed_operation("transform", "from", ret);
-		return PSA_ERROR_STORAGE_FAILURE;
+		return PSA_ERROR_GENERIC_ERROR;
 	}
 	return PSA_SUCCESS;
 }
@@ -141,7 +140,7 @@ static psa_status_t store_entry(secure_storage_its_uid_t uid, size_t data_length
 						    stored_data, &stored_data_len);
 	if (ret != PSA_SUCCESS) {
 		log_failed_operation("transform", "for", ret);
-		return PSA_ERROR_STORAGE_FAILURE;
+		return PSA_ERROR_GENERIC_ERROR;
 	}
 
 	ret = secure_storage_its_store_set(uid, stored_data_len, stored_data);
@@ -167,7 +166,7 @@ psa_status_t secure_storage_its_set(secure_storage_its_caller_id_t caller_id, ps
 	if (data_length > CONFIG_SECURE_STORAGE_ITS_MAX_DATA_SIZE) {
 		LOG_DBG("Passed data length (%zu) exceeds maximum allowed (%u).",
 			data_length, CONFIG_SECURE_STORAGE_ITS_MAX_DATA_SIZE);
-		return PSA_ERROR_INSUFFICIENT_STORAGE;
+		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 
 	if (keep_stored_entry(its_uid, data_length, p_data, create_flags, &ret)) {
@@ -258,7 +257,9 @@ psa_status_t secure_storage_its_remove(secure_storage_its_caller_id_t caller_id,
 		return PSA_ERROR_NOT_PERMITTED;
 	}
 	/* Allow overwriting corrupted entries as well to not be stuck with them forever. */
-	if (ret == PSA_SUCCESS || ret == PSA_ERROR_STORAGE_FAILURE) {
+	if (ret == PSA_SUCCESS ||
+	    ret == PSA_ERROR_STORAGE_FAILURE ||
+	    ret == PSA_ERROR_GENERIC_ERROR) {
 		ret = secure_storage_its_store_remove(its_uid);
 		if (ret != PSA_SUCCESS) {
 			log_failed_operation("remove", "from", ret);

--- a/subsys/secure_storage/src/its/implementation.c
+++ b/subsys/secure_storage/src/its/implementation.c
@@ -161,9 +161,6 @@ psa_status_t secure_storage_its_set(secure_storage_its_caller_id_t caller_id, ps
 	if (make_its_uid(caller_id, uid, &its_uid) != PSA_SUCCESS) {
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
-	if (p_data == NULL && data_length != 0) {
-		return PSA_ERROR_INVALID_ARGUMENT;
-	}
 	if (create_flags & ~SECURE_STORAGE_ALL_CREATE_FLAGS) {
 		return PSA_ERROR_NOT_SUPPORTED;
 	}
@@ -193,14 +190,10 @@ psa_status_t secure_storage_its_get(secure_storage_its_caller_id_t caller_id, ps
 	if (make_its_uid(caller_id, uid, &its_uid) != PSA_SUCCESS) {
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
-	if ((p_data == NULL && data_size != 0) || p_data_length == NULL) {
-		return PSA_ERROR_INVALID_ARGUMENT;
-	}
 	if (data_size == 0) {
 		*p_data_length = 0;
 		return PSA_SUCCESS;
 	}
-
 
 	ret = get_stored_data(its_uid, stored_data, &stored_data_len);
 	if (ret != PSA_SUCCESS) {
@@ -237,9 +230,6 @@ psa_status_t secure_storage_its_get_info(secure_storage_its_caller_id_t caller_i
 	uint8_t data[CONFIG_SECURE_STORAGE_ITS_MAX_DATA_SIZE];
 
 	if (make_its_uid(caller_id, uid, &its_uid) != PSA_SUCCESS) {
-		return PSA_ERROR_INVALID_ARGUMENT;
-	}
-	if (p_info == NULL) {
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 


### PR DESCRIPTION
The subsystem has been out for a year.
It has been taken into use by various parties and has gone through additional downstream testing.
It is considered stable and mature enough to not be experimental anymore.