### PR TITLE
doc: releases: Remove double backticks in Audio mig guide

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -114,7 +114,7 @@ Bluetooth Audio
   :c:enumerator:`BT_AUDIO_CODEC_CFG_TARGET_LATENCY_BALANCED` and ``target_phy`` to
   :c:enumerator:`BT_AUDIO_CODEC_CFG_TARGET_PHY_2M`.
   The :c:macro:`BT_AUDIO_CODEC_CFG` macro defaults to these values.
-  (:github:`93825``)
+  (:github:`93825`)
 * Setting the BGS role for GMAP now requires also supporting and implementing the
   :kconfig:option:`CONFIG_BT_BAP_BROADCAST_ASSISTANT`.
   See the :zephyr:code-sample:`bluetooth_bap_broadcast_assistant` sample as a reference.
@@ -122,7 +122,7 @@ Bluetooth Audio
   :c:func:`bt_bap_scan_delegator_set_pa_state` must be used to update the state. If the
   BAP Scan Delegator is used together with the BAP Broadcast Sink, then the PA state of the
   receive state of a  :c:struct:`bt_bap_broadcast_sink` will still be automatically updated when the
-  PA state changes. (:github:`95453``)
+  PA state changes. (:github:`95453`)
 
 
 .. zephyr-keep-sorted-stop


### PR DESCRIPTION
Some references to GH PRs had an additional backtick.