### PR TITLE
nordic: nrf54h: bicr: allow for custom bicr.json in application

### DIFF
--- a/soc/nordic/nrf54h/bicr/CMakeLists.txt
+++ b/soc/nordic/nrf54h/bicr/CMakeLists.txt
@@ -1,8 +1,14 @@
 if(CONFIG_SOC_NRF54H20_GENERATE_BICR)
-  set(bicr_json_file ${BOARD_DIR}/bicr.json)
+  set(bicr_json_file ${BOARD_DIR}/${CONFIG_SOC_NRF54H20_BICR_NAME})
   set(bicr_hex_file ${PROJECT_BINARY_DIR}/bicr.hex)
   set(svd_file ${ZEPHYR_HAL_NORDIC_MODULE_DIR}/nrfx/mdk/nrf54h20_application.svd)
 
+  set(app_bicr_json_file ${APPLICATION_SOURCE_DIR}/${CONFIG_SOC_NRF54H20_BICR_NAME})
+  if(EXISTS ${app_bicr_json_file})
+    set(bicr_json_file ${app_bicr_json_file})
+  endif()
+
+  message(STATUS "Found BICR: ${bicr_json_file}")
   if(EXISTS ${bicr_json_file})
     set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${bicr_json_file})
 

--- a/soc/nordic/nrf54h/bicr/Kconfig
+++ b/soc/nordic/nrf54h/bicr/Kconfig
@@ -8,3 +8,12 @@ config SOC_NRF54H20_GENERATE_BICR
 	help
 	  This option generates a BICR file for the board being used. Board
 	  directory must contain a "bicr.json" file for this option to work.
+
+config SOC_NRF54H20_BICR_NAME
+	string "Name of nRF54H20 BICR file to use"
+	depends on SOC_NRF54H20_GENERATE_BICR
+	default "bicr.json"
+	help
+	  The file will be searched for in application folder first, then
+	  board folder if not found. The application can select a bicr by
+	  setting CONFIG_SOC_NRF54H20_BICR_NAME="some_bicr.json"


### PR DESCRIPTION
Allow placing a custom bicr.json file in the application source
folder which will be used instead of the default one in the
boards folder. Also allows setting a custom name to use for the
file so multiple files can be placed in either boards or app dirs
and selected with Kconfig (prj.conf or <board>.conf)

The following will take precedence over the bicr.json file in the
board folder:

- <app>/bicr.json
- <app>/bicr_foo.json + CONFIG_SOC_NRF54H20_BICR_NAME="bicr_foo.json"