### PR TITLE
net: context: Fix IPv4-to-IPv6 mapped sendto() 

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2415,15 +2415,16 @@ static int context_sendto(struct net_context *context,
 	 */
 	if (IS_ENABLED(CONFIG_NET_IPV4_MAPPING_TO_IPV6) &&
 	    IS_ENABLED(CONFIG_NET_IPV6) &&
-	    net_context_get_family(context) == AF_INET6 &&
-	    dst_addr != NULL &&
-	    dst_addr->sa_family == AF_INET) {
-		family = AF_INET;
-	} else if (IS_ENABLED(CONFIG_NET_IPV4_MAPPING_TO_IPV6) &&
-		   IS_ENABLED(CONFIG_NET_IPV6) && msghdr != NULL) {
-		const struct sockaddr_in6 *addr6 = msghdr->msg_name;
+	    net_context_get_family(context) == AF_INET6) {
+		const struct sockaddr_in6 *addr6 = NULL;
 
-		if (net_ipv6_addr_is_v4_mapped(&addr6->sin6_addr)) {
+		if (dst_addr != NULL) {
+			addr6 = (const struct sockaddr_in6 *)dst_addr;
+		} else if (msghdr != NULL) {
+			addr6 = msghdr->msg_name;
+		}
+
+		if (addr6 != NULL && net_ipv6_addr_is_v4_mapped(&addr6->sin6_addr)) {
 			family = AF_INET;
 		} else {
 			family = net_context_get_family(context);

--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -45,3 +45,6 @@ tests:
       - CONFIG_TRACING_BACKEND_POSIX=y
       - CONFIG_TRACING_PACKET_MAX_SIZE=256
       - CONFIG_TRACING_SYNC=y
+  net.socket.udp.v4_mapping_to_v6_enabled:
+    extra_configs:
+      - CONFIG_NET_IPV4_MAPPING_TO_IPV6=y


### PR DESCRIPTION
Commit https://github.com/zephyrproject-rtos/zephyr/commit/48897a9090db3e144235f02b8ed543f51a107e35 fixed the address mapping for dual-stack sockets when sendmsg() was used, however the same similar issue appears (cannot check for AF_INET family for mapped addresses as those are AF_INET6) for regular sendto() calls.

Therefore, for the sendto() case, where dst_addr is specified, check if the address is mapped with net_ipv6_addr_is_v4_mapped() function as well.

This also fixes another bug in sendmsg() case, where `msghdr->msg_name` could've been dereferenced even if it was NULL (for example in case of a connected socket).