### PR TITLE
drivers: spi: spi_esp32_spim: fix rtio include

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(esp32_spi, CONFIG_SPI_LOG_LEVEL);
 #include <soc.h>
 #include <esp_memory_utils.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/spi/rtio.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #ifdef SOC_GDMA_SUPPORTED
 #include <zephyr/drivers/dma.h>


### PR DESCRIPTION
unable to compile for "esp32s3 spi imu" because missing include in esp32 spi driver

`zephyr/drivers/spi/spi_esp32_spim.c:603:25: error: 'spi_rtio_iodev_default_submit' undeclared here (not in a function)
  603 |         .iodev_submit = spi_rtio_iodev_default_submit,`

reproduce:
https://github.com/ain101/zephyr/tree/reproduce_spi_rtio_fail
west build --pristine -b esp32s3_devkitc/esp32s3/procpu samples/sensor/sensor_shell

possible regression:
include added in all spi drivers: 64a038aca3e9ad14e9167a6f58eb7c204eb5a50d
include deleted in esp32 driver (bug introduced): 4b8dc5f3ff262bcc606c3fb320f47089059680e5