### PR TITLE
more Maintainerfile cleanup and coverage

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -675,7 +675,9 @@ Board/SoC configuration:
     - "57300"
   files:
     - soc/Kconfig*
+    - soc/CMakeLists.txt
     - boards/Kconfig*
+    - boards/CMakeLists.txt
   labels:
     - "area: Board/SoC configuration"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1127,8 +1127,6 @@ Documentation:
     - doc/introduction/
     - doc/project/
     - doc/releases/
-    - doc/security/
-    - doc/safety/
     - README.rst
     - doc/substitutions.txt
     - doc/images/Zephyr-Kite-in-tree.png
@@ -4418,6 +4416,16 @@ STM32 Wireless Platforms:
     STM32WB SOCs, dts files and related drivers. STM32WB development boards
     and ST bluetooth shields.
 
+Safety:
+  status: maintained
+  maintainers:
+    - tobiaskaestner
+    - parphane
+  files:
+    - doc/safety/
+  labels:
+    - "area: Safety"
+
 Samples:
   status: maintained
   maintainers:
@@ -4445,6 +4453,16 @@ Secure storage:
     - "area: Secure storage"
   tests:
     - psa.secure_storage
+
+Security:
+  status: maintained
+  maintainers:
+    - ceolin
+    - d3zd3z
+  files:
+    - doc/security/
+  labels:
+    - "area: Security"
 
 Seeed Studio Platforms:
   status: odd fixes

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4843,6 +4843,15 @@ Testing with Renode:
   labels:
     - "area: Renode"
 
+Tests:
+  status: maintained
+  maintainers:
+    - nashif
+  files:
+    - tests/
+  labels:
+    - "area: Tests"
+
 "Toolchain ARC MWDT":
   status: maintained
   maintainers:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -681,6 +681,20 @@ Board/SoC configuration:
   labels:
     - "area: Board/SoC configuration"
 
+Boards/SoCs:
+  status: odd fixes
+  files:
+    - boards/
+    - soc/
+    - dts/
+  labels:
+    - "area: Boards/SoCs"
+  description: >-
+    Grouping of all board and SoC platforms. For maintainership of
+    individual platforms, see the relevant platform section.
+    This area will have subgrouping of files for each platform with corresponding
+    collaborators.
+
 Bootloaders:
   status: odd fixes
   files:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -861,23 +861,8 @@ Coding Guidelines:
     - jfischer-no
     - simhein
   files:
-    - .checkpatch.conf
-    - .clang-format
-    - .editorconfig
-    - .gitlint
-    - .yamllint
     - doc/contribute/guidelines.rst
     - doc/contribute/coding_guidelines/
-    - scripts/checkpatch.pl
-    - scripts/checkpatch/
-    - scripts/ci/check_compliance.py
-    - scripts/ci/guideline_check.py
-    - scripts/ci/pylintrc
-    - scripts/coccicheck
-    - scripts/coccinelle/
-    - scripts/gitlint/
-    - scripts/pylint/
-    - scripts/spelling.txt
   labels:
     - "area: Coding Guidelines"
 
@@ -3064,6 +3049,43 @@ Linker Scripts:
   tests:
     - linker
 
+Linters and Static Analyzers:
+  status: maintained
+  maintainers:
+    - keith-zephyr
+  collaborators:
+    - nashif
+    - kartben
+    - pdgendt
+  files:
+    - .codechecker.yml
+    - .codecov.yml
+    - .ruff-excludes.toml
+    - .ruff.toml
+    - REUSE.toml
+    - .yamllint
+    - scripts/ruff/gen_format_exclude.py
+    - scripts/ruff/gen_lint_exclude.py
+    - cmake/sca/
+    - .checkpatch.conf
+    - .clang-format
+    - .editorconfig
+    - .gitlint
+    - .yamllint
+    - scripts/checkpatch.pl
+    - scripts/checkpatch/
+    - scripts/ci/check_compliance.py
+    - scripts/ci/guideline_check.py
+    - scripts/ci/pylintrc
+    - scripts/coccicheck
+    - scripts/coccinelle/
+    - scripts/gitlint/
+    - scripts/pylint/
+    - scripts/spelling.txt
+  labels:
+    - "area: Linters"
+  description: >-
+    Linters and Static Analyzers used in Zephyr project.
 LiteX Platforms:
   status: maintained
   maintainers:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -740,6 +740,13 @@ Build system:
     - tests/misc/test_build/
     - tests/application_development/
     - samples/application_development/
+    - arch/archs.yml
+    - version.h.in
+    - scripts/schemas/arch-schema.yaml
+    - scripts/schemas/board-schema.yaml
+    - scripts/schemas/soc-schema.yaml
+    - scripts/list_shields.py
+    - scripts/snippets.py
   labels:
     - "area: Build System"
   tests:
@@ -875,6 +882,7 @@ Common Architecture Interface:
     - nashif
   files:
     - arch/Kconfig
+    - arch/CMakeLists.txt
     - include/zephyr/arch/
     - arch/common/
     - include/zephyr/arch/common/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1187,6 +1187,8 @@ Documentation Infrastructure:
     - carlescufi
     - nashif
   files:
+    - doc/requirements.in
+    - doc/requirements.txt
     - doc/_*/
     - doc/CMakeLists.txt
     - doc/conf.py

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1054,6 +1054,7 @@ Devicetree:
     - ^dts/bindings/[^,]+$
   files:
     - scripts/dts/
+    - dts/Kconfig
     - dts/common/
     - tests/lib/devicetree/
     - doc/build/dts/
@@ -1068,6 +1069,16 @@ Devicetree:
     - "area: Devicetree"
   tests:
     - libraries.devicetree
+
+Devicetree Bindings:
+  status: odd fixes
+  files-regex:
+    - ^dts/bindings/.*zephyr.*
+  files:
+    - dts/bindings/
+    - include/zephyr/dt-bindings/
+  labels:
+    - "area: Devicetree Bindings"
 
 Disk:
   status: maintained


### PR DESCRIPTION
- **maintainers: move linters and SCA tooling into own area**
- **maintainers: split security/safety into own areas**
- **maintainers: add missing files to soc/board config area**
- **maintainers: add missing files to build system area**
- **maintainers: add a global area for tests**
- **maintainers: add an area for dts bindings**
- **maintainers: Group all boards/socs into one area**
- **maintainers: add 2 missing files into the doc area**
