### PR TITLE
Bluetooth: Mesh: Revert deprecation of blob_io_flash erase cap options

### DIFF
--- a/include/zephyr/bluetooth/mesh/blob_io_flash.h
+++ b/include/zephyr/bluetooth/mesh/blob_io_flash.h
@@ -19,6 +19,10 @@ extern "C" {
  * @{
  */
 
+#ifndef CONFIG_BT_MESH_BLOB_IO_FLASH_WRITE_BLOCK_SIZE_MAX
+#define CONFIG_BT_MESH_BLOB_IO_FLASH_WRITE_BLOCK_SIZE_MAX 1
+#endif
+
 /** BLOB flash stream. */
 struct bt_mesh_blob_io_flash {
 	/** Flash area ID to write the BLOB to. */

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1038,7 +1038,6 @@ config BT_MESH_BLOB_IO_FLASH
 	default y
 	depends on BT_MESH_BLOB_SRV || BT_MESH_BLOB_CLI
 	depends on FLASH_MAP
-	depends on FLASH_PAGE_LAYOUT
 	help
 	  Enable the BLOB flash stream for reading and writing BLOBs directly to
 	  and from flash.
@@ -1046,28 +1045,36 @@ config BT_MESH_BLOB_IO_FLASH
 if BT_MESH_BLOB_IO_FLASH
 
 config BT_MESH_BLOB_IO_FLASH_WITHOUT_ERASE
-	bool "BLOB flash support for devices without erase [DEPRECATED]"
-	default n
+	bool "BLOB flash support for devices without erase"
+	default y if FLASH_HAS_NO_EXPLICIT_ERASE
 	depends on FLASH_HAS_NO_EXPLICIT_ERASE
-	select DEPRECATED
 	help
-	  This option is deprecated and is no longer used by the BLOB IO Flash module.
+	  Enable path supporting devices without erase. This option appears only
+	  if there are devices without explicit erase requirements in the system
+	  and may be disabled to reduce code size in case when no operations
+	  are intended on such type of devices.
 
 config BT_MESH_BLOB_IO_FLASH_WITH_ERASE
-	bool "BLOB flash support for devices with erase [DEPRECATED]"
-	default n
+	bool "BLOB flash support for devices with erase"
+	default y if FLASH_HAS_EXPLICIT_ERASE
 	depends on FLASH_HAS_EXPLICIT_ERASE
 	depends on FLASH_PAGE_LAYOUT
-	select DEPRECATED
 	help
-	  This option is deprecated and is no longer used by the BLOB IO Flash module.
+	  Enable path supporting devices with erase. This option appears only
+	  if there are devices requiring erase,  before write, in the system
+	  and may be disabled to reduce code size in case when no operations
+	  are intended on such type of devices.
+
+if BT_MESH_BLOB_IO_FLASH_WITH_ERASE
 
 config BT_MESH_BLOB_IO_FLASH_WRITE_BLOCK_SIZE_MAX
 	int "Maximum supported write block size"
 	default 4
 	help
 	  The BLOB IO Flash module will support flash devices with explicit erase
-	  when this value is set to a multiple of the device write block size.
+	  using a write block size of at most this value.
+
+endif # BT_MESH_BLOB_IO_FLASH_WITH_ERASE
 
 endif # BT_MESH_BLOB_IO_FLASH
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1072,7 +1072,7 @@ config BT_MESH_BLOB_IO_FLASH_WRITE_BLOCK_SIZE_MAX
 	default 4
 	help
 	  The BLOB IO Flash module will support flash devices with explicit erase
-	  using a write block size of at most this value.
+	  when this value is set to a multiple of the device write block size.
 
 endif # BT_MESH_BLOB_IO_FLASH_WITH_ERASE
 


### PR DESCRIPTION
This reverts the deprecation of the kconfigs for conditional compilation of code paths depending on which flash erase capabilities are needed by the application. These options are useful for users on systems/applications with more than one type of flash device available, where they know that the BLOB models will only be used with one of the types and can manually disable the code supporting the other type, to save code size.

It also changes the use of #ifdef to using IS_ENABLED across this module,
and adds conditions to all code paths that are only needed if either
explicit erase flash, non-explicit erase flash, or both, is needed by
the application.