### PR TITLE
stm32: tests: drivers: flash: prevent failures in subsequent tests by disabling flash write protection after test execution

### DIFF
--- a/tests/drivers/flash/stm32/src/main.c
+++ b/tests/drivers/flash/stm32/src/main.c
@@ -116,6 +116,27 @@ static void *flash_stm32_setup(void)
 	return NULL;
 }
 
+static void flash_stm32_teardown(void *fixture)
+{
+/* disable write protection to prevent subsequent tests from failing
+ * if write protection was not disabled during test execution.
+ */
+#if defined(CONFIG_FLASH_STM32_WRITE_PROTECT)
+	struct flash_stm32_ex_op_sector_wp_in wp_request;
+	int rc;
+
+	wp_request.disable_mask = sector_mask;
+	wp_request.enable_mask = 0;
+
+	rc = flash_ex_op(flash_dev, FLASH_STM32_EX_OP_SECTOR_WP, (uintptr_t)&wp_request, NULL);
+	if (rc != 0) {
+		TC_PRINT(" Failed to disable write protection .\n");
+	} else {
+		TC_PRINT(" Successfully disabled write protection.\n");
+	}
+#endif
+}
+
 #if defined(CONFIG_FLASH_STM32_WRITE_PROTECT)
 ZTEST(flash_stm32, test_stm32_write_protection)
 {
@@ -283,4 +304,4 @@ ZTEST(flash_stm32, test_stm32_block_registers)
 }
 #endif
 
-ZTEST_SUITE(flash_stm32, NULL, flash_stm32_setup, NULL, NULL, NULL);
+ZTEST_SUITE(flash_stm32, NULL, flash_stm32_setup, NULL, NULL, flash_stm32_teardown);


### PR DESCRIPTION
This commit   https://github.com/zephyrproject-rtos/zephyr/commit/d5ead50fc69daa682e18cfe89d4ea22d0fcd6445 enables cache management by default on the STM32H7 series with Cortex-M7.   

However, this modification introduces a regression in the `tests/drivers/flash/stm32` test, particularly in the “test_stm32_write_protection” test case. After running this test, write protection is enabled but never disabled afterward, causing subsequent tests to fail.   

Add a teardown function to ensure that write protection is disabled after test execution.