### PR TITLE
net: coap: Correct parameter constness in func signature

### DIFF
--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -418,7 +418,7 @@ int clear_more_flag(struct coap_packet *cpkt)
 
 int coap_well_known_core_get_len(struct coap_resource *resources,
 				 size_t resources_len,
-				 struct coap_packet *request,
+				 const struct coap_packet *request,
 				 struct coap_packet *response,
 				 uint8_t *data, uint16_t len)
 {


### PR DESCRIPTION
The request parameter of  coap_well_known_core_get_len() is declared to be a pointer-to-const, but the const is missing for one of the two function definitions, so the code did not compile In case CONFIG_COAP_WELL_KNOWN_BLOCK_WISE was enabled.