### PR TITLE
stm32 U5: Disable UART DMA before shutdown

### DIFF
--- a/soc/st/stm32/stm32u5x/poweroff.c
+++ b/soc/st/stm32/stm32u5x/poweroff.c
@@ -12,12 +12,48 @@
 
 #include <stm32_ll_cortex.h>
 #include <stm32_ll_pwr.h>
+#include <stm32_ll_usart.h>
+#include <stm32_ll_dma.h>
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32u5_dma)
+#define DT_DRV_COMPAT st_stm32_uart
+#define TURN_OFF_UART_DMA(inst)									\
+	{											\
+		USART_TypeDef *usart = (USART_TypeDef *)DT_INST_REG_ADDR(inst);			\
+												\
+		if (DT_INST_DMAS_HAS_NAME(inst, tx)) {						\
+			while (LL_DMA_IsEnabledChannel(						\
+				(DMA_TypeDef *)DT_INST_DMAS_CTLR_BY_NAME(inst, tx),		\
+				 DT_INST_DMAS_CHANNEL_BY_NAME(inst, tx))) {			\
+					/* wait for DMA to be disabled */			\
+			}									\
+			LL_USART_DisableDMAReq_TX(usart);					\
+		}										\
+		if (DT_INST_DMAS_HAS_NAME(inst, rx)) {						\
+			while (LL_DMA_IsEnabledChannel(						\
+				(DMA_TypeDef *)DT_INST_DMAS_CTLR_BY_NAME(inst, rx),		\
+				DT_INST_DMAS_CHANNEL_BY_NAME(inst, rx))) {			\
+					/* wait for DMA to be disabled */			\
+			}									\
+			LL_USART_DisableDMAReq_RX(usart);					\
+		}										\
+	}
+#endif
 
 void z_sys_poweroff(void)
 {
 #ifdef CONFIG_STM32_WKUP_PINS
 	stm32_pwr_wkup_pin_cfg_pupd();
 #endif /* CONFIG_STM32_WKUP_PINS */
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32u5_dma)
+/*
+ * Workaround for STM32U5 Errata ES0499:
+ * uart_stm32 driver leaves DMA enabled after transfer due to hardware erratum.
+ * Explicitly disable DMA here to allow proper shutdown.
+ */
+	DT_INST_FOREACH_STATUS_OKAY(TURN_OFF_UART_DMA)
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32u5_dma) */
 
 	LL_PWR_ClearFlag_WU();
 


### PR DESCRIPTION
In z_sys_poweroff(), before entering shutdown mode, wait for all UART DMA TX/RX channels to be disabled, then clear DMAT/DMAR bits for all STM32U5 UARTs.

fixes: #63236