### PR TITLE
drivers: smbus: stm32: send block write byte count

### DIFF
--- a/drivers/smbus/smbus_stm32.c
+++ b/drivers/smbus/smbus_stm32.c
@@ -235,13 +235,18 @@ static int smbus_stm32_block_write(const struct device *dev, uint16_t periph_add
 		{
 			.buf = &command,
 			.len = sizeof(command),
-			.flags = 0,
+			.flags = I2C_MSG_WRITE,
+		},
+		{
+			.buf = &count,
+			.len = sizeof(count),
+			.flags = I2C_MSG_WRITE,
 		},
 		{
 			.buf = buf,
 			.len = count,
-			.flags = 0,
-		},
+			.flags = I2C_MSG_WRITE,
+		}
 	};
 
 	return i2c_transfer(config->i2c_dev, messages, ARRAY_SIZE(messages), periph_addr);


### PR DESCRIPTION
Send "count" byte. The SMBus block write protocol requires this byte.

Use I2C_MSG_WRITE named flag instead of 0.

For reference, please see section 6.5.7
https://smbus.org/specs/SMBus_3_1_20180319.pdf
<img width="681" height="138" alt="Screenshot 2025-09-24 at 2 50 16 PM" src="https://github.com/user-attachments/assets/3a4a8e86-067f-444b-b2be-7a7e93bebac3" />
