### PR TITLE
drivers: sensor: voltage-divider: Add skip-calibration property

### DIFF
--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -20,6 +20,7 @@ struct voltage_config {
 	struct voltage_divider_dt_spec voltage;
 	struct gpio_dt_spec gpio_power;
 	uint32_t sample_delay_us;
+	bool skip_calibration;
 };
 
 struct voltage_data {
@@ -191,7 +192,7 @@ static int voltage_init(const struct device *dev)
 
 	data->sequence.buffer = &data->raw;
 	data->sequence.buffer_size = sizeof(data->raw);
-	data->sequence.calibrate = true;
+	data->sequence.calibrate = !config->skip_calibration;
 
 	return pm_device_driver_init(dev, pm_action);
 }
@@ -203,6 +204,7 @@ static int voltage_init(const struct device *dev)
 		.voltage = VOLTAGE_DIVIDER_DT_SPEC_GET(DT_DRV_INST(inst)),                         \
 		.gpio_power = GPIO_DT_SPEC_INST_GET_OR(inst, power_gpios, {0}),                    \
 		.sample_delay_us = DT_INST_PROP(inst, power_on_sample_delay_us),                   \
+		.skip_calibration = DT_INST_PROP(inst, skip_calibration),                          \
 	};                                                                                         \
                                                                                                    \
 	PM_DEVICE_DT_INST_DEFINE(inst, pm_action);                                                 \

--- a/dts/bindings/iio/afe/voltage-divider.yaml
+++ b/dts/bindings/iio/afe/voltage-divider.yaml
@@ -45,3 +45,8 @@ properties:
       `power-gpios`. In most cases the switched voltage rail will
       require some non-zero time to settle to its final value. The
       default value of 100us should be sufficient in most situations.
+
+  skip-calibration:
+    type: boolean
+    description: |
+      Skip ADC calibration before taking a measurement.


### PR DESCRIPTION
Adds a calibrate property to the voltage divider sensor, which can be disabled, in case the underlying ADC driver does not support calibration.

Encountered this issue while using the esp32,adc
https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/adc/adc_esp32.c#L407