### PR TITLE
doc: Update Zversion based on sphinx conf

### DIFF
--- a/doc/_templates/zversions.html
+++ b/doc/_templates/zversions.html
@@ -1,22 +1,26 @@
 {# Add rst-badge after rst-versions for small badge style. #}
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
-      <span class="fa fa-book"> Zephyr Project</span>
+      <span class="fa fa-book"> {{ project }}</span>
       v: {{ current_version if is_release else "latest" }}
       <span class="fa fa-caret-down"></span>
     </span>
     <div class="rst-other-versions">
+      {% if versions %}
       <dl>
         <dt>{{ _('Document Release Versions') }}</dt>
         {% for slug, url in versions %}
           <dd><a href="{{ url }}">{{ slug }}</a></dd>
         {% endfor %}
       </dl>
+      {% endif %}
+      {% if pdf %}
       <dl>
         <dt>{{ _('Downloads') }}</dt>
         {% set prefix = current_version if is_release else "latest" %}
-        <dd><a href="/{{ prefix }}/zephyr.pdf">PDF</a></dd>
+        <dd><a href="/{{ prefix }}/{{ pdf }}.pdf">PDF</a></dd>
       </dl>
+      {% endif %}
       <dl>
         <dt>{{ _('zephyrproject.org Links') }}</dt>
           <dd>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -204,6 +204,8 @@ if tags.has("publish"):  # pylint: disable=undefined-variable  # noqa: F821
 docs_title = "Docs / {}".format(version if is_release else "Latest")
 html_context = {
     "show_license": True,
+    "project": project,
+    "pdf": "zephyr",
     "docs_title": docs_title,
     "is_release": is_release,
     "current_version": version,


### PR DESCRIPTION
We would like to re-use the zephyr html templates for our own, if possible.

A) Currently `zversions.html` assumes the project to be zephyr project, but we would like to use our own project name there.
B) We currently don't have versions or PDF links, so don't display the title blocks for them if they aren't provided by the `conf.py`

[Doc Preview](https://builds.zephyrproject.io/zephyr/pr/96515/docs/)
This is what the resulting rendered HTML looks like
<img width="241" height="167" alt="Screenshot 2025-10-14 at 11 16 33 AM" src="https://github.com/user-attachments/assets/186b11f8-d79c-449a-aa2e-214f6a60b380" />
