### PR TITLE
MAINTAINERS: drop folks inactive since at least 24 months

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3913,7 +3913,6 @@ OSDP:
   maintainers:
     - sidcha
   collaborators:
-    - adakus
     - r2r0
   files:
     - subsys/mgmt/osdp/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5696,7 +5696,6 @@ West:
   maintainers:
     - faxe1008
   collaborators:
-    - brgl
     - pdgendt
     - uLipe
   files:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4426,7 +4426,6 @@ Sensor Subsystem:
   status: maintained
   maintainers:
     - lixuzha
-    - ghu0510
     - yperess
   collaborators:
     - qianruh

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1837,7 +1837,6 @@ Documentation Infrastructure:
 "Drivers: LED":
   status: maintained
   maintainers:
-    - Mani-Sadhasivam
     - simonguinot
   collaborators:
     - jeppenodgaard
@@ -3104,7 +3103,6 @@ LoRa and LoRaWAN:
   maintainers:
     - JordanYates
   collaborators:
-    - Mani-Sadhasivam
     - martinjaeger
     - mniestroj
   files:
@@ -5688,9 +5686,7 @@ West:
     - "area: LoRa"
 
 "West project: loramac-node":
-  status: maintained
-  maintainers:
-    - Mani-Sadhasivam
+  status: odd fixes
   files:
     - modules/loramac-node/
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3857,7 +3857,6 @@ Nuvoton NPCM Platforms:
   status: maintained
   maintainers:
     - maxdog988
-    - warp5tw
   files:
     - soc/nuvoton/npcm/
     - boards/nuvoton/npcm*/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2858,7 +2858,6 @@ Intel Platforms (Agilex):
     - gdengi
   collaborators:
     - nbalabak
-    - teikheng
   files:
     - boards/intel/socfpga/
     - soc/intel/intel_socfpga/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3864,7 +3864,6 @@ Nuvoton NPCM Platforms:
   maintainers:
     - maxdog988
     - warp5tw
-    - jc849
   files:
     - soc/nuvoton/npcm/
     - boards/nuvoton/npcm*/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2963,7 +2963,6 @@ JSON Web Token:
     - d3zd3z
   collaborators:
     - mrfuchs
-    - sir-branch
   files:
     - subsys/jwt/
     - include/zephyr/data/json.h

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3876,7 +3876,6 @@ Nuvoton NPCX Platforms:
   collaborators:
     - TomChang19
     - alvsun
-    - sjg20
     - keith-zephyr
     - fabiobaltieri
   files:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2790,7 +2790,6 @@ ITE Platforms:
     - RuibinChang
     - Chenhongren
   collaborators:
-    - jackrosenthal
     - keith-zephyr
     - fabiobaltieri
   files:
@@ -3880,7 +3879,6 @@ Nuvoton NPCX Platforms:
     - alvsun
     - sjg20
     - keith-zephyr
-    - jackrosenthal
     - fabiobaltieri
   files:
     - soc/nuvoton/npcx/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1687,7 +1687,6 @@ Documentation Infrastructure:
   status: odd fixes
   collaborators:
     - henrikbrixandersen
-    - mnkp
   files:
     - doc/hardware/peripherals/gpio.rst
     - drivers/gpio/
@@ -3250,7 +3249,6 @@ Microchip SAM Platforms:
     - nandojve
   collaborators:
     - pdgendt
-    - mnkp
     - stephanosio
   files:
     - boards/atmel/
@@ -5518,7 +5516,6 @@ West:
     - jerome-pouiller
     - sateeshkotapati
     - yonsch
-    - mnkp
     - rettichschnidi
     - Martinhoff-maker
   files:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1428,7 +1428,6 @@ Documentation Infrastructure:
     - LaurentiuM1234
   collaborators:
     - lgirdwood
-    - juimonen
     - iuliana-prodan
     - dbaluta
   files:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4712,8 +4712,6 @@ TI SimpleLink Platforms:
   status: maintained
   maintainers:
     - vaishnavachath
-  collaborators:
-    - vanti
   files:
     - boards/ti/cc*/
     - boards/ti/msp*/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -223,7 +223,6 @@ ARM arch:
   collaborators:
     - MaureenHelm
     - stephanosio
-    - bbolen
     - ithinuel
   files:
     - arch/arm/


### PR DESCRIPTION
Used GH API to look at folks with zero form of activity in Zephyr over the last 24 months.