### PR TITLE
usb: udc: allow to use timeout Kconfig option on nRF54LM20A SoC

### DIFF
--- a/drivers/usb/udc/Kconfig.dwc2
+++ b/drivers/usb/udc/Kconfig.dwc2
@@ -12,23 +12,22 @@ config UDC_DWC2
 	help
 	  DWC2 USB device controller driver.
 
+if UDC_DWC2
+
 config UDC_DWC2_DMA
 	bool "DWC2 USB DMA support"
 	default y
-	depends on UDC_DWC2
 	help
 	  Enable Buffer DMA if DWC2 USB controller supports Internal DMA.
 
 config UDC_DWC2_HIBERNATION
 	bool "DWC2 USB Hibernation support"
 	default y
-	depends on UDC_DWC2
 	help
 	  Enable Hibernation if DWC2 USB controller supports hibernation.
 
 config UDC_DWC2_PTI
 	bool "DWC2 USB Periodic Transfer Interrupt"
-	depends on UDC_DWC2
 	help
 	  Ignore frame number when scheduling isochronous endpoints. Use this
 	  when isochronous transfers should finish only after receiving token
@@ -38,24 +37,23 @@ config UDC_DWC2_PTI
 
 config UDC_DWC2_STACK_SIZE
 	int "UDC DWC2 driver internal thread stack size"
-	depends on UDC_DWC2
 	default 512
 	help
 	  DWC2 driver internal thread stack size.
 
 config UDC_DWC2_THREAD_PRIORITY
 	int "UDC DWC2 driver thread priority"
-	depends on UDC_DWC2
 	default 8
 	help
 	  DWC2 driver thread priority.
 
 config UDC_DWC2_USBHS_VBUS_READY_TIMEOUT
 	int "UDC DWC2 USBHS VBUS ready event timeout in ms"
-	depends on UDC_DWC2
 	depends on NRFS_HAS_VBUS_DETECTOR_SERVICE
 	default 0
 	help
 	  UDC DWC2 USBHS VBUS ready event timeout. If the VBUS is not ready
 	  and the Nordic USBHS controller is used, the udc_enable() is
 	  blocked for this amount of time. Set it to zero to wait forever.
+
+endif # UDC_DWC2

--- a/drivers/usb/udc/Kconfig.dwc2
+++ b/drivers/usb/udc/Kconfig.dwc2
@@ -49,7 +49,7 @@ config UDC_DWC2_THREAD_PRIORITY
 
 config UDC_DWC2_USBHS_VBUS_READY_TIMEOUT
 	int "UDC DWC2 USBHS VBUS ready event timeout in ms"
-	depends on NRFS_HAS_VBUS_DETECTOR_SERVICE
+	depends on SOC_SERIES_NRF54HX || SOC_SERIES_NRF54LX
 	default 0
 	help
 	  UDC DWC2 USBHS VBUS ready event timeout. If the VBUS is not ready

--- a/drivers/usb/udc/udc_dwc2_vendor_quirks.h
+++ b/drivers/usb/udc/udc_dwc2_vendor_quirks.h
@@ -393,6 +393,10 @@ static inline int usbhs_enable_core(const struct device *dev)
 	k_timeout_t timeout = K_FOREVER;
 	int err;
 
+	if (CONFIG_UDC_DWC2_USBHS_VBUS_READY_TIMEOUT) {
+		timeout = K_MSEC(CONFIG_UDC_DWC2_USBHS_VBUS_READY_TIMEOUT);
+	}
+
 	if (!k_event_wait(&usbhs_events, USBHS_VBUS_READY, false, K_NO_WAIT)) {
 		LOG_WRN("VBUS is not ready, block udc_enable()");
 		if (!k_event_wait(&usbhs_events, USBHS_VBUS_READY, false, timeout)) {


### PR DESCRIPTION
Kconfig option UDC_DWC2_USBHS_VBUS_READY_TIMEOUT depends on services
exclusively available for nRF54H20, but the option can also be used for
nRF54LM20A, where there are no service dependencies, and VREG can be
accessed by the driver directly. Let depend the option on the SOC
series, as the controller can be used by the different CPUs on the SOC.