### PR TITLE
boards: nxp: fix bad SPDX-License-Identifier header

### DIFF
--- a/boards/nxp/mimxrt595_evk/flash_config/flash_config.c
+++ b/boards/nxp/mimxrt595_evk/flash_config/flash_config.c
@@ -2,7 +2,7 @@
  * Copyright 2018-2021 NXP
  * All rights reserved.
  *
- * SPDXLicense-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 #include "flash_config.h"
 

--- a/boards/nxp/mimxrt700_evk/flash_config/flash_config.c
+++ b/boards/nxp/mimxrt700_evk/flash_config/flash_config.c
@@ -1,7 +1,7 @@
 /*
  * Copyright 2023, 2025 NXP
  *
- * SPDXLicense-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
 #include "flash_config.h"
 


### PR DESCRIPTION
add a missing "-" in SPDX-License-Identifier header