### PR TITLE
RM3100: Add one-shot polling via int-gpio as an alternative to continuous mode when not streaming.

### DIFF
--- a/drivers/sensor/pni/rm3100/CMakeLists.txt
+++ b/drivers/sensor/pni/rm3100/CMakeLists.txt
@@ -7,6 +7,6 @@ zephyr_library_sources(
 	rm3100.c
 	rm3100_decoder.c
 )
-zephyr_library_sources_ifdef(CONFIG_RM3100_STREAM
+zephyr_library_sources_ifdef(CONFIG_RM3100_HAS_TRIGGER
 	rm3100_stream.c
 )

--- a/drivers/sensor/pni/rm3100/Kconfig
+++ b/drivers/sensor/pni/rm3100/Kconfig
@@ -6,8 +6,10 @@ config RM3100
 	bool "RM3100 3-Axis Magnetometer"
 	default y
 	depends on DT_HAS_PNI_RM3100_ENABLED
-	select I2C
-	select I2C_RTIO
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_PNI_RM3100),spi)
+	select SPI_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_PNI_RM3100),spi)
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_PNI_RM3100),i2c)
+	select I2C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_PNI_RM3100),i2c)
 	select SENSOR_ASYNC_API
 	help
 	  Enable driver for PNI RM3100 high-accuracy 3-axis magnetometer.

--- a/drivers/sensor/pni/rm3100/Kconfig
+++ b/drivers/sensor/pni/rm3100/Kconfig
@@ -14,9 +14,12 @@ config RM3100
 	help
 	  Enable driver for PNI RM3100 high-accuracy 3-axis magnetometer.
 
+config RM3100_HAS_TRIGGER
+	def_bool $(dt_compat_any_has_prop,$(DT_COMPAT_PNI_RM3100),int-gpios)
+
 config RM3100_STREAM
 	bool "RM3100 Streaming Mode"
-	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_PNI_RM3100),int-gpios)
+	depends on RM3100_HAS_TRIGGER
 	help
 	  Enable streaming mode for the RM3100 sensor.
 	  This mode allows for continuous data output at a specified rate.

--- a/drivers/sensor/pni/rm3100/rm3100.c
+++ b/drivers/sensor/pni/rm3100/rm3100.c
@@ -8,6 +8,7 @@
 #define DT_DRV_COMPAT pni_rm3100
 
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/spi.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/rtio/rtio.h>
 #include <zephyr/rtio/work.h>
@@ -102,7 +103,9 @@ static void rm3100_submit_one_shot(const struct device *dev, struct rtio_iodev_s
 			   edata->payload,
 			   sizeof(edata->payload),
 			   NULL);
-	read_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	if (rtio_is_i2c(data->rtio.type)) {
+		read_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	}
 	read_sqe->flags |= RTIO_SQE_CHAINED;
 
 	rtio_sqe_prep_callback_no_cqe(complete_sqe,
@@ -139,6 +142,19 @@ static int rm3100_init(const struct device *dev)
 	struct rm3100_data *data = dev->data;
 	uint8_t val;
 	int err;
+
+#if CONFIG_SPI_RTIO
+	if (rtio_is_spi(data->rtio.type) && !spi_is_ready_iodev(data->rtio.iodev)) {
+		LOG_ERR("Bus is not ready");
+		return -ENODEV;
+	}
+#endif
+#if CONFIG_I2C_RTIO
+	if (rtio_is_i2c(data->rtio.type) && !i2c_is_ready_iodev(data->rtio.iodev)) {
+		LOG_ERR("Bus is not ready");
+		return -ENODEV;
+	}
+#endif
 
 	/* Check device ID to make sure we can talk to the sensor */
 	err = rm3100_bus_read(dev, RM3100_REG_REVID, &val, 1);
@@ -205,7 +221,15 @@ static int rm3100_init(const struct device *dev)
 #define RM3100_DEFINE(inst)									   \
 												   \
 	RTIO_DEFINE(rm3100_rtio_ctx_##inst, 8, 8);						   \
-	I2C_DT_IODEV_DEFINE(rm3100_bus_##inst, DT_DRV_INST(inst));				   \
+	COND_CODE_1(DT_INST_ON_BUS(inst, i2c),							   \
+		    (I2C_DT_IODEV_DEFINE(rm3100_bus_##inst, DT_DRV_INST(inst))),		   \
+		    ());									   \
+	COND_CODE_1(DT_INST_ON_BUS(inst, spi),							   \
+		    (SPI_DT_IODEV_DEFINE(rm3100_bus_##inst,					   \
+					 DT_DRV_INST(inst),					   \
+					 SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_TRANSFER_MSB,  \
+					 0U)),							   \
+		    ());									   \
 												   \
 	static const struct rm3100_config rm3100_cfg_##inst = {					   \
 		.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, {0}),			   \
@@ -215,6 +239,10 @@ static int rm3100_init(const struct device *dev)
 		.rtio = {									   \
 			.iodev = &rm3100_bus_##inst,						   \
 			.ctx = &rm3100_rtio_ctx_##inst,						   \
+			COND_CODE_1(DT_INST_ON_BUS(inst, i2c),					   \
+				(.type = RTIO_BUS_I2C), ())					   \
+			COND_CODE_1(DT_INST_ON_BUS(inst, spi),					   \
+				(.type = RTIO_BUS_SPI), ())					   \
 		},										   \
 		.settings = {									   \
 			.odr = DT_INST_PROP(inst, odr),						   \

--- a/drivers/sensor/pni/rm3100/rm3100.h
+++ b/drivers/sensor/pni/rm3100/rm3100.h
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/rtio/rtio.h>
+#include <zephyr/rtio/regmap.h>
 #include "rm3100_reg.h"
 
 /* RM3100 produces 3 bytes (24-bit) of data per axis */
@@ -60,6 +61,7 @@ struct rm3100_data {
 	struct {
 		struct rtio_iodev *iodev;
 		struct rtio *ctx;
+		rtio_bus_type type;
 	} rtio;
 	struct {
 		uint8_t odr;

--- a/drivers/sensor/pni/rm3100/rm3100.h
+++ b/drivers/sensor/pni/rm3100/rm3100.h
@@ -66,9 +66,9 @@ struct rm3100_data {
 	struct {
 		uint8_t odr;
 	} settings;
-#if defined(CONFIG_RM3100_STREAM)
+#if defined(CONFIG_RM3100_HAS_TRIGGER)
 	struct rm3100_stream stream;
-#endif /* CONFIG_RM3100_STREAM */
+#endif /* CONFIG_RM3100_HAS_TRIGGER */
 };
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_PNI_RM3100_H_ */

--- a/drivers/sensor/pni/rm3100/rm3100_bus.h
+++ b/drivers/sensor/pni/rm3100/rm3100_bus.h
@@ -31,10 +31,14 @@ static inline int rm3100_bus_read(const struct device *dev,
 		return -ENOMEM;
 	}
 
+	reg = reg | REG_READ_BIT;
+
 	rtio_sqe_prep_write(write_sqe, iodev, RTIO_PRIO_HIGH, &reg, 1, NULL);
 	write_sqe->flags |= RTIO_SQE_TRANSACTION;
 	rtio_sqe_prep_read(read_sqe, iodev, RTIO_PRIO_HIGH, buf, len, NULL);
-	read_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	if (rtio_is_i2c(data->rtio.type)) {
+		read_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	}
 
 	err = rtio_submit(ctx, 2);
 	if (err) {

--- a/drivers/sensor/pni/rm3100/rm3100_reg.h
+++ b/drivers/sensor/pni/rm3100/rm3100_reg.h
@@ -12,6 +12,7 @@
 #define REG_READ_BIT BIT(7)
 
 /* RM3100 register addresses */
+#define RM3100_REG_POLL        0x00 /* Polls for a Single Measurement */
 #define RM3100_REG_CMM         0x01 /* Continuous measurement mode */
 #define RM3100_REG_CCX_MSB     0x04 /* Cycle Count X LSB */
 #define RM3100_REG_CCX_LSB     0x05 /* Cycle Count X MSB */

--- a/drivers/sensor/pni/rm3100/rm3100_stream.c
+++ b/drivers/sensor/pni/rm3100/rm3100_stream.c
@@ -108,7 +108,7 @@ static void rm3100_stream_get_data(const struct device *dev)
 
 	uint8_t val;
 
-	val = RM3100_REG_STATUS;
+	val = RM3100_REG_STATUS | REG_READ_BIT;
 
 	rtio_sqe_prep_tiny_write(status_wr_sqe,
 				 data->rtio.iodev,
@@ -124,10 +124,13 @@ static void rm3100_stream_get_data(const struct device *dev)
 			   &edata->header.status,
 			   sizeof(edata->header.status),
 			   NULL);
-	status_rd_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+
+	if (rtio_is_i2c(data->rtio.type)) {
+		status_rd_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	}
 	status_rd_sqe->flags |= RTIO_SQE_CHAINED;
 
-	val = RM3100_REG_MX;
+	val = RM3100_REG_MX | REG_READ_BIT;
 
 	rtio_sqe_prep_tiny_write(write_sqe,
 				 data->rtio.iodev,
@@ -143,7 +146,9 @@ static void rm3100_stream_get_data(const struct device *dev)
 			   edata->payload,
 			   sizeof(edata->payload),
 			   NULL);
-	read_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	if (rtio_is_i2c(data->rtio.type)) {
+		read_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	}
 	read_sqe->flags |= RTIO_SQE_CHAINED;
 
 	rtio_sqe_prep_callback_no_cqe(complete_sqe,

--- a/drivers/sensor/pni/rm3100/rm3100_stream.c
+++ b/drivers/sensor/pni/rm3100/rm3100_stream.c
@@ -196,13 +196,6 @@ void rm3100_stream_submit(const struct device *dev,
 	const struct rm3100_config *cfg = dev->config;
 	int err;
 
-	if ((read_config->count != 1) ||
-	    (read_config->triggers[0].trigger != SENSOR_TRIG_DATA_READY)) {
-		LOG_ERR("Only SENSOR_TRIG_DATA_READY is supported");
-		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
-		return;
-	}
-
 	/* Store context for next submission (handled within callbacks) */
 	data->stream.iodev_sqe = iodev_sqe;
 
@@ -210,7 +203,7 @@ void rm3100_stream_submit(const struct device *dev,
 	data->stream.settings.opt.drdy = read_config->triggers[0].opt;
 
 	err = gpio_pin_interrupt_configure_dt(&cfg->int_gpio,
-						GPIO_INT_LEVEL_ACTIVE);
+					      GPIO_INT_LEVEL_ACTIVE);
 	if (err) {
 		LOG_ERR("Failed to enable interrupts");
 

--- a/dts/bindings/sensor/pni,rm3100-common.yaml
+++ b/dts/bindings/sensor/pni,rm3100-common.yaml
@@ -23,17 +23,17 @@ properties:
       The output data rate (ODR) of the sensor in Hz.
       Default is power-on setting.
     enum:
-      - 0x92 # RM33100_DT_ODR_600
-      - 0x93 # RM33100_DT_ODR_300
-      - 0x94 # RM33100_DT_ODR_150
-      - 0x95 # RM33100_DT_ODR_75
-      - 0x96 # RM33100_DT_ODR_37_5
-      - 0x97 # RM33100_DT_ODR_18
-      - 0x98 # RM33100_DT_ODR_9
-      - 0x99 # RM33100_DT_ODR_4_5
-      - 0x9A # RM33100_DT_ODR_2_3
-      - 0x9B # RM33100_DT_ODR_1_2
-      - 0x9C # RM33100_DT_ODR_0_6
-      - 0x9D # RM33100_DT_ODR_0_3
-      - 0x9E # RM33100_DT_ODR_0_015
-      - 0x9F # RM33100_DT_ODR_0_0075
+      - 0x92 # RM3100_DT_ODR_600
+      - 0x93 # RM3100_DT_ODR_300
+      - 0x94 # RM3100_DT_ODR_150
+      - 0x95 # RM3100_DT_ODR_75
+      - 0x96 # RM3100_DT_ODR_37_5
+      - 0x97 # RM3100_DT_ODR_18
+      - 0x98 # RM3100_DT_ODR_9
+      - 0x99 # RM3100_DT_ODR_4_5
+      - 0x9A # RM3100_DT_ODR_2_3
+      - 0x9B # RM3100_DT_ODR_1_2
+      - 0x9C # RM3100_DT_ODR_0_6
+      - 0x9D # RM3100_DT_ODR_0_3
+      - 0x9E # RM3100_DT_ODR_0_015
+      - 0x9F # RM3100_DT_ODR_0_0075

--- a/dts/bindings/sensor/pni,rm3100-common.yaml
+++ b/dts/bindings/sensor/pni,rm3100-common.yaml
@@ -2,28 +2,11 @@
 # Copyright (c) 2025 CogniPilot Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-    PNI RM3100 3-axis Magnetometer.
-
-    The RM3100 can use either I2C or SPI as a communication bus.
-    This driver currently supports I2C only.
-    When setting the odr property in a .dts or .dtsi file you may include rm3100.h
-    and use the macros defined there.
-
-    Example:
-    #include <zephyr/dt-bindings/sensor/rm3100.h>
-
-    &i2c0 {
-        rm3100@20 {
-            compatible = "pni,rm3100";
-            reg = <0x20>;
-            odr = <RM3100_DT_ODR_600>;
-        };
-    };
+description: PNI RM3100 3-axis Magnetometer.
 
 compatible: "pni,rm3100"
 
-include: [sensor-device.yaml, i2c-device.yaml]
+include: sensor-device.yaml
 
 properties:
   int-gpios:

--- a/dts/bindings/sensor/pni,rm3100-i2c.yaml
+++ b/dts/bindings/sensor/pni,rm3100-i2c.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2025 Anthony Williams <anthony289478@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    PNI RM3100 3-axis Magnetometer.
+
+    The RM3100 can use either I2C or SPI as a communication bus.
+    When setting the odr property in a .dts or .dtsi file you may include rm3100.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/rm3100.h>
+
+    &i2c0 {
+        rm3100@20 {
+            compatible = "pni,rm3100";
+            reg = <0x20>;
+            odr = <RM3100_DT_ODR_600>;
+        };
+    };
+
+compatible: "pni,rm3100"
+
+include: ["i2c-device.yaml", "pni,rm3100-common.yaml"]

--- a/dts/bindings/sensor/pni,rm3100-spi.yaml
+++ b/dts/bindings/sensor/pni,rm3100-spi.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) 2025 Anthony Williams <anthony289478@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    PNI RM3100 3-axis Magnetometer.
+
+    The RM3100 can use either I2C or SPI as a communication bus.
+    When using SPI, the device only supports SPI mode 0 or 3.
+    When setting the odr property in a .dts or .dtsi file you may include rm3100.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/rm3100.h>
+
+    &spi0 {
+        cs-gpios = <&arduino_header 10 GPIO_ACTIVE_LOW>;
+        rm3100@0 {
+            compatible = "pni,rm3100";
+            reg = <0x0>;
+            spi-max-frequency = <8000000>;
+
+            // Enable SPI mode 3. Remove to use mode 0.
+            spi-cpol;
+            spi-pha;
+
+            odr = <RM3100_DT_ODR_600>;
+        };
+    };
+
+compatible: "pni,rm3100"
+
+include: ["spi-device.yaml", "pni,rm3100-common.yaml"]


### PR DESCRIPTION
Additionally, when CONFIG_RM3100_TRIGGER is enabled via the presence of int-gpios but CONFIG_RM3100_STREAM is not explicitly enabled, the option to perform one-shot transfers using the POLL register becomes available instead of automatically enabling continuous mode.

As noted during the initial CMM implementation,
>7% standard deviation, which may be significant for certain applications.

By using the POLL register during one-shot rtio the host has finer control over the ODR and when exactly the sample is taken.