### PR TITLE
boards: nxp: convert enum members to upper case.

### DIFF
--- a/boards/madmachine/mm_feather/flexspi_nor_config.c
+++ b/boards/madmachine/mm_feather/flexspi_nor_config.c
@@ -16,11 +16,11 @@ const struct flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_100mhz,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_100MHZ,
 		.sflash_a1_size = 8u * 1024u * 1024u,
 		.lookup_table = {
 			FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD,

--- a/boards/madmachine/mm_swiftio/flexspi_nor_config.c
+++ b/boards/madmachine/mm_swiftio/flexspi_nor_config.c
@@ -16,11 +16,11 @@ const struct flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_100mhz,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_100MHZ,
 		.sflash_a1_size = 8u * 1024u * 1024u,
 		.lookup_table = {
 			FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD,

--- a/boards/nxp/frdm_mcxn947/xip/mcxn_flexspi_nor_config.c
+++ b/boards/nxp/frdm_mcxn947/xip/mcxn_flexspi_nor_config.c
@@ -74,16 +74,16 @@ const flexspi_nor_image_config image_config = {
 			.tag = FLEXSPI_CFG_BLK_TAG,
 			.version = FLEXSPI_CFG_BLK_VERSION,
 			.read_sample_clk_src =
-				flexspi_read_sample_clk_loopback_from_dqs_pad,
+					FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 			.cs_hold_time = 3u,
 			.cs_setup_time = 3u,
 			/* Enable DDR mode, Wordaddassable, Safe */
 			/* configuration, Differential clock */
 			.controller_misc_option =
-			(1u << flexspi_misc_offset_safe_config_freq_enable),
-			.device_type = flexspi_device_type_serial_nor,
-			.sflash_pad_type = serial_flash_4_pads,
-			.serial_clk_freq = flexspi_serial_clk_75mhz,
+			(1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE),
+			.device_type = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+			.sflash_pad_type = SERIAL_FLASH_4_PADS,
+			.serial_clk_freq = FLEXSPI_SERIAL_CLK_75MHZ,
 			.sflash_a1_size = 8u * 1024u * 1024u,
 			.lookup_table = {
 				/* Read LUTs */

--- a/boards/nxp/frdm_mcxn947/xip/mcxn_flexspi_nor_config.h
+++ b/boards/nxp/frdm_mcxn947/xip/mcxn_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __MCXN_FLEXSPI_NOR_CONFIG__
-#define __MCXN_FLEXSPI_NOR_CONFIG__
+#ifndef MCXN_FLEXSPI_NOR_CONFIG_
+#define MCXN_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -72,71 +72,71 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_100mhz = 5,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_100MHZ = 5,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR,
 	 * A2 is Serial NAND
 	 */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR,
 	 * A2 is Serial RAMs
 	 */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -151,17 +151,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -380,4 +380,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* __MCXN_FLEXSPI_NOR_CONFIG__ */
+#endif /* MCXN_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mcx_nx4x_evk/xip/mcxn_flexspi_nor_config.c
+++ b/boards/nxp/mcx_nx4x_evk/xip/mcxn_flexspi_nor_config.c
@@ -74,16 +74,16 @@ const flexspi_nor_image_config image_config = {
 			.tag = FLEXSPI_CFG_BLK_TAG,
 			.version = FLEXSPI_CFG_BLK_VERSION,
 			.read_sample_clk_src =
-				flexspi_read_sample_clk_loopback_from_dqs_pad,
+					FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 			.cs_hold_time = 3u,
 			.cs_setup_time = 3u,
 			/* Enable DDR mode, Wordaddassable, Safe */
 			/* configuration, Differential clock */
 			.controller_misc_option =
-			(1u << flexspi_misc_offset_safe_config_freq_enable),
-			.device_type = flexspi_device_type_serial_nor,
-			.sflash_pad_type = serial_flash_4_pads,
-			.serial_clk_freq = flexspi_serial_clk_75mhz,
+			(1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE),
+			.device_type = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+			.sflash_pad_type = SERIAL_FLASH_4_PADS,
+			.serial_clk_freq = FLEXSPI_SERIAL_CLK_75MHZ,
 			.sflash_a1_size = 8u * 1024u * 1024u,
 			.lookup_table = {
 				/* Read LUTs */

--- a/boards/nxp/mcx_nx4x_evk/xip/mcxn_flexspi_nor_config.h
+++ b/boards/nxp/mcx_nx4x_evk/xip/mcxn_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __MCXN_FLEXSPI_NOR_CONFIG__
-#define __MCXN_FLEXSPI_NOR_CONFIG__
+#ifndef MCXN_FLEXSPI_NOR_CONFIG_
+#define MCXN_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -72,71 +72,71 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_100mhz = 5,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_100MHZ = 5,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR,
 	 * A2 is Serial NAND
 	 */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR,
 	 * A2 is Serial RAMs
 	 */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -151,17 +151,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -380,4 +380,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* __MCXN_FLEXSPI_NOR_CONFIG__ */
+#endif /* MCXN_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt1010_evk/xip/evkmimxrt1010_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1010_evk/xip/evkmimxrt1010_flexspi_nor_config.c
@@ -15,12 +15,12 @@ const flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
-		.device_type = flexspi_device_type_serial_nor,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_120mhz,
+	.device_type = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+	.sflash_pad_type = SERIAL_FLASH_4_PADS,
+	.serial_clk_freq = FLEXSPI_SERIAL_CLK_120MHZ,
 		.sflash_a1_size = 16u * 1024u * 1024u,
 		.lookup_table = {
 			/* Read LUTs */

--- a/boards/nxp/mimxrt1010_evk/xip/evkmimxrt1010_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1010_evk/xip/evkmimxrt1010_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKMIMXRT1011_FLEXSPI_NOR_CONFIG__
-#define __EVKMIMXRT1011_FLEXSPI_NOR_CONFIG__
+#ifndef EVKMIMXRT1011_FLEXSPI_NOR_CONFIG_
+#define EVKMIMXRT1011_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -72,70 +72,70 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_120mhz = 7,
-	flexspi_serial_clk_133mhz = 8,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_120MHZ = 7,
+	FLEXSPI_SERIAL_CLK_133MHZ = 8,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial RAMs */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -150,17 +150,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -367,4 +367,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* __EVKMIMXRT1011_FLEXSPI_NOR_CONFIG__ */
+#endif /* EVKMIMXRT1011_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt1015_evk/xip/evkmimxrt1015_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1015_evk/xip/evkmimxrt1015_flexspi_nor_config.c
@@ -15,14 +15,14 @@ const flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
 		.controller_misc_option =
-			(1u << flexspi_misc_offset_safe_config_freq_enable),
-		.device_type = flexspi_device_type_serial_nor,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_133mhz,
+			(1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE),
+		.device_type = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_133MHZ,
 		.sflash_a1_size = 16u * 1024u * 1024u,
 		.lookup_table = {
 			/* Read LUTs */

--- a/boards/nxp/mimxrt1015_evk/xip/evkmimxrt1015_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1015_evk/xip/evkmimxrt1015_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKMIMXRT1015_FLEXSPI_NOR_CONFIG__
-#define __EVKMIMXRT1015_FLEXSPI_NOR_CONFIG__
+#ifndef EVKMIMXRT1015_FLEXSPI_NOR_CONFIG_
+#define EVKMIMXRT1015_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -72,69 +72,69 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial RAMs */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -149,17 +149,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -366,4 +366,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* #ifndef __EVKMIMXRT1015_FLEXSPI_NOR_CONFIG__ */
+#endif /* #ifndef EVKMIMXRT1015_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt1020_evk/dcd/dcd.h
+++ b/boards/nxp/mimxrt1020_evk/dcd/dcd.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __DCD__
-#define __DCD__
+#ifndef DCD_
+#define DCD_
 
 #include <stdint.h>
 
@@ -15,4 +15,4 @@
 #define DCD_TAG_HEADER_SHIFT (24)
 #define DCD_ARRAY_SIZE       1
 
-#endif /* __DCD__ */
+#endif /* DCD_ */

--- a/boards/nxp/mimxrt1020_evk/xip/evkmimxrt1020_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1020_evk/xip/evkmimxrt1020_flexspi_nor_config.c
@@ -17,18 +17,18 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.mem_config = {
 		.tag                  = FLEXSPI_CFG_BLK_TAG,
 		.version              = FLEXSPI_CFG_BLK_VERSION,
-		.read_sample_clk_src     = flexspi_read_sample_clk_loopback_from_dqs_pad,
+		.read_sample_clk_src     = FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time           = 3u,
 		.cs_setup_time          = 3u,
 		.controller_misc_option =
-			(1u << flexspi_misc_offset_safe_config_freq_enable),
-		.device_type            = flexspi_device_type_serial_nor,
-		.sflash_pad_type        = serial_flash_4_pads,
-		.serial_clk_freq        = flexspi_serial_clk_133mhz,
+			(1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE),
+		.device_type            = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type        = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq        = FLEXSPI_SERIAL_CLK_133MHZ,
 		.sflash_a1_size         = 8u * 1024u * 1024u,
 		/* Enable flash configuration feature */
 		.config_cmd_enable   = 1u,
-		.config_mode_type[0] = device_config_cmd_type_generic,
+		.config_mode_type[0] = DEVICE_CONFIG_CMD_TYPE_GENERIC,
 		/* Set configuration command sequences */
 		.config_cmd_seqs[0] = {
 			.seq_num   = 1,

--- a/boards/nxp/mimxrt1020_evk/xip/evkmimxrt1020_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1020_evk/xip/evkmimxrt1020_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKMIMXRT1020_FLEXSPI_NOR_CONFIG__
-#define __EVKMIMXRT1020_FLEXSPI_NOR_CONFIG__
+#ifndef EVKMIMXRT1020_FLEXSPI_NOR_CONFIG_
+#define EVKMIMXRT1020_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -72,73 +72,73 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR,
 	 * A2 is Serial NAND
 	 */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR,
 	 * A2 is Serial RAMs
 	 */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -153,17 +153,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -370,4 +370,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* #ifndef __EVKMIMXRT1020_FLEXSPI_NOR_CONFIG__ */
+#endif /* #ifndef EVKMIMXRT1020_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt1024_evk/dcd/dcd.h
+++ b/boards/nxp/mimxrt1024_evk/dcd/dcd.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __DCD__
-#define __DCD__
+#ifndef DCD_
+#define DCD_
 
 #include <stdint.h>
 
@@ -15,4 +15,4 @@
 #define DCD_TAG_HEADER_SHIFT (24)
 #define DCD_ARRAY_SIZE       1
 
-#endif /* __DCD__ */
+#endif /* DCD_ */

--- a/boards/nxp/mimxrt1024_evk/xip/evkmimxrt1024_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1024_evk/xip/evkmimxrt1024_flexspi_nor_config.c
@@ -15,14 +15,14 @@ const flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_internally,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
 		.controller_misc_option =
-			(1u << flexspi_misc_offset_safe_config_freq_enable),
-		.device_type = flexspi_device_type_serial_nor,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_60mhz,
+			(1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE),
+		.device_type = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_60MHZ,
 		.sflash_a1_size = 4u * 1024u * 1024u,
 		.lookup_table = {
 			/* Read LUTs */

--- a/boards/nxp/mimxrt1024_evk/xip/evkmimxrt1024_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1024_evk/xip/evkmimxrt1024_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKMIMXRT1024_FLEXSPI_NOR_CONFIG__
-#define __EVKMIMXRT1024_FLEXSPI_NOR_CONFIG__
+#ifndef EVKMIMXRT1024_FLEXSPI_NOR_CONFIG_
+#define EVKMIMXRT1024_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -72,69 +72,69 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum _FlashReadSampleClkSource {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial RAMs */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pad = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -149,17 +149,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -366,4 +366,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* #ifndef __EVKMIMXRT1024_FLEXSPI_NOR_CONFIG__ */
+#endif /* #ifndef EVKMIMXRT1024_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt1040_evk/dcd/dcd.h
+++ b/boards/nxp/mimxrt1040_evk/dcd/dcd.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __DCD__
-#define __DCD__
+#ifndef DCD_
+#define DCD_
 
 #include <stdint.h>
 
@@ -15,4 +15,4 @@
 #define DCD_TAG_HEADER_SHIFT (24)
 #define DCD_ARRAY_SIZE       1
 
-#endif /* __DCD__ */
+#endif /* DCD_ */

--- a/boards/nxp/mimxrt1040_evk/xip/evkmimxrt1040_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1040_evk/xip/evkmimxrt1040_flexspi_nor_config.c
@@ -14,11 +14,11 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.mem_config = {
 		.tag		  = FLEXSPI_CFG_BLK_TAG,
 		.version          = FLEXSPI_CFG_BLK_VERSION,
-		.read_sample_clk_src = flexspi_read_sample_clk_loopback_from_dqs_pad,
+		.read_sample_clk_src = FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time       = 3u,
 		.cs_setup_time      = 3u,
-		.sflash_pad_type    = serial_flash_4_pads,
-		.serial_clk_freq    = flexspi_serial_clk_100mhz,
+		.sflash_pad_type    = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq    = FLEXSPI_SERIAL_CLK_100MHZ,
 		.sflash_a1_size     = 8u * 1024u * 1024u,
 		.lookup_table = {
 			/* Read LUTs */

--- a/boards/nxp/mimxrt1040_evk/xip/evkmimxrt1040_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1040_evk/xip/evkmimxrt1040_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKMIMXRT1040_FLEXSPI_NOR_CONFIG__
-#define __EVKMIMXRT1040_FLEXSPI_NOR_CONFIG__
+#ifndef EVKMIMXRT1040_FLEXSPI_NOR_CONFIG_
+#define EVKMIMXRT1040_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -72,71 +72,71 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_120mhz = 7,
-	flexspi_serial_clk_133mhz = 8,
-	flexspi_serial_clk_166mhz = 9,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_120MHZ = 7,
+	FLEXSPI_SERIAL_CLK_133MHZ = 8,
+	FLEXSPI_SERIAL_CLK_166MHZ = 9,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial RAMs */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -151,17 +151,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -368,4 +368,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* #ifndef __EVKMIMXRT1040_FLEXSPI_NOR_CONFIG__ */
+#endif /* #ifndef EVKMIMXRT1040_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt1050_evk/dcd/dcd.h
+++ b/boards/nxp/mimxrt1050_evk/dcd/dcd.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __DCD__
-#define __DCD__
+#ifndef DCD_
+#define DCD_
 
 #include <stdint.h>
 
@@ -15,4 +15,4 @@
 #define DCD_TAG_HEADER_SHIFT (24)
 #define DCD_ARRAY_SIZE       1
 
-#endif /* __DCD__ */
+#endif /* DCD_ */

--- a/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_config.c
@@ -15,7 +15,7 @@ const flexspi_nor_config_t hyperflash_config = {
 		.tag                = FLEXSPI_CFG_BLK_TAG,
 		.version            = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src
-			= flexspi_read_sample_clk_external_input_from_dqs_pad,
+			= FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD,
 		.cs_hold_time         = 3u,
 		.cs_setup_time        = 3u,
 		.column_address_width = 3u,
@@ -23,13 +23,13 @@ const flexspi_nor_config_t hyperflash_config = {
 		 * Safe configuration, Differential clock
 		 */
 		.controller_misc_option =
-			(1u << flexspi_misc_offset_ddr_mode_enable) |
-			(1u << flexspi_misc_offset_word_addressable_enable) |
-			(1u << flexspi_misc_offset_safe_config_freq_enable) |
-			(1u << flexspi_misc_offset_diff_clk_enable),
-		.device_type         = flexspi_device_type_serial_nor,
-		.sflash_pad_type      = serial_flash_8_pads,
-		.serial_clk_freq      = flexspi_serial_clk_133mhz,
+			(1u << FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE) |
+			(1u << FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE) |
+			(1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE) |
+			(1u << FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE),
+		.device_type         = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type      = SERIAL_FLASH_8_PADS,
+		.serial_clk_freq      = FLEXSPI_SERIAL_CLK_133MHZ,
 		.lut_custom_seq_enable = 0x1,
 		.sflash_a1_size       = 64u * 1024u * 1024u,
 		.data_valid_time      = {15u, 0u},

--- a/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKBMIMXRT1050_FLEXSPI_NOR_CONFIG__
-#define __EVKBMIMXRT1050_FLEXSPI_NOR_CONFIG__
+#ifndef EVKBMIMXRT1050_FLEXSPI_NOR_CONFIG_
+#define EVKBMIMXRT1050_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -72,70 +72,70 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
-	flexspi_serial_clk_166mhz = 8,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
+	FLEXSPI_SERIAL_CLK_166MHZ = 8,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum _FlashReadSampleClkSource {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial RAMs */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pad = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PAD = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -150,17 +150,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -367,4 +367,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* #ifndef __EVKBMIMXRT1050_FLEXSPI_NOR_CONFIG__ */
+#endif /* #ifndef EVKBMIMXRT1050_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_qspi_config.c
+++ b/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_qspi_config.c
@@ -15,11 +15,11 @@ const flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src
-			= flexspi_read_sample_clk_loopback_from_dqs_pad,
+			= FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_100mhz,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_100MHZ,
 		.sflash_a1_size = 8u * 1024u * 1024u,
 		.lookup_table = {
 			/* Read LUTs */

--- a/boards/nxp/mimxrt1060_evk/dcd/dcd.h
+++ b/boards/nxp/mimxrt1060_evk/dcd/dcd.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __DCD__
-#define __DCD__
+#ifndef DCD_
+#define DCD_
 
 #include <stdint.h>
 
@@ -15,4 +15,4 @@
 #define DCD_TAG_HEADER_SHIFT (24)
 #define DCD_ARRAY_SIZE       1
 
-#endif /* __DCD__ */
+#endif /* DCD_ */

--- a/boards/nxp/mimxrt1060_evk/xip/evkbmimxrt1060_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1060_evk/xip/evkbmimxrt1060_flexspi_nor_config.c
@@ -15,14 +15,14 @@ const flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
 		.controller_misc_option =
-			(1u << flexspi_misc_offset_safe_config_freq_enable),
-		.device_type = flexspi_device_type_serial_nor,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_120mhz,
+			(1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE),
+		.device_type = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_120MHZ,
 		.sflash_a1_size = 8u * 1024u * 1024u,
 		.lookup_table = {
 			/* Read LUTs */

--- a/boards/nxp/mimxrt1060_evk/xip/evkbmimxrt1060_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1060_evk/xip/evkbmimxrt1060_flexspi_nor_config.h
@@ -72,71 +72,71 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_120mhz = 7,
-	flexspi_serial_clk_133mhz = 8,
-	flexspi_serial_clk_166mhz = 9,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_120MHZ = 7,
+	FLEXSPI_SERIAL_CLK_133MHZ = 8,
+	FLEXSPI_SERIAL_CLK_166MHZ = 9,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial RAMs */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -151,17 +151,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */

--- a/boards/nxp/mimxrt1060_evk/xip/evkmimxrt1060_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1060_evk/xip/evkmimxrt1060_flexspi_nor_config.c
@@ -15,14 +15,14 @@ const flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
 		.controller_misc_option =
-			(1u << flexspi_misc_offset_safe_config_freq_enable),
-		.device_type = flexspi_device_type_serial_nor,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_120mhz,
+			(1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE),
+		.device_type = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_120MHZ,
 		.sflash_a1_size = 8u * 1024u * 1024u,
 		.lookup_table = {
 			/* Read LUTs */

--- a/boards/nxp/mimxrt1060_evk/xip/evkmimxrt1060_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1060_evk/xip/evkmimxrt1060_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKMIMXRT1060_FLEXSPI_NOR_CONFIG__
-#define __EVKMIMXRT1060_FLEXSPI_NOR_CONFIG__
+#ifndef EVKMIMXRT1060_FLEXSPI_NOR_CONFIG_
+#define EVKMIMXRT1060_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -72,71 +72,71 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_120mhz = 7,
-	flexspi_serial_clk_133mhz = 8,
-	flexspi_serial_clk_166mhz = 9,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_120MHZ = 7,
+	FLEXSPI_SERIAL_CLK_133MHZ = 8,
+	FLEXSPI_SERIAL_CLK_166MHZ = 9,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial RAMs */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -151,17 +151,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -368,4 +368,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* #ifndef __EVKMIMXRT1060_FLEXSPI_NOR_CONFIG__ */
+#endif /* #ifndef EVKMIMXRT1060_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt1064_evk/dcd/dcd.h
+++ b/boards/nxp/mimxrt1064_evk/dcd/dcd.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __DCD__
-#define __DCD__
+#ifndef DCD_
+#define DCD_
 
 #include <stdint.h>
 
@@ -15,4 +15,4 @@
 #define DCD_TAG_HEADER_SHIFT (24)
 #define DCD_ARRAY_SIZE       1
 
-#endif /* __DCD__ */
+#endif /* DCD_ */

--- a/boards/nxp/mimxrt1064_evk/xip/evkmimxrt1064_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1064_evk/xip/evkmimxrt1064_flexspi_nor_config.c
@@ -15,14 +15,14 @@ const flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
 		.controller_misc_option =
-			(1u << flexspi_misc_offset_safe_config_freq_enable),
-		.device_type = flexspi_device_type_serial_nor,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_120mhz,
+			(1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE),
+		.device_type = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_120MHZ,
 		.sflash_a1_size = 4u * 1024u * 1024u,
 		.lookup_table = {
 			/* Read LUTs */

--- a/boards/nxp/mimxrt1064_evk/xip/evkmimxrt1064_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1064_evk/xip/evkmimxrt1064_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKMIMXRT1064_FLEXSPI_NOR_CONFIG__
-#define __EVKMIMXRT1064_FLEXSPI_NOR_CONFIG__
+#ifndef EVKMIMXRT1064_FLEXSPI_NOR_CONFIG_
+#define EVKMIMXRT1064_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -72,71 +72,71 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_120mhz = 7,
-	flexspi_serial_clk_133mhz = 8,
-	flexspi_serial_clk_166mhz = 9,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_120MHZ = 7,
+	FLEXSPI_SERIAL_CLK_133MHZ = 8,
+	FLEXSPI_SERIAL_CLK_166MHZ = 9,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum _FlashReadSampleClkSource {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial RAMs */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -151,17 +151,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -366,4 +366,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* #ifndef __EVKMIMXRT1064_FLEXSPI_NOR_CONFIG__ */
+#endif /* #ifndef EVKMIMXRT1064_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt1160_evk/dcd/dcd.h
+++ b/boards/nxp/mimxrt1160_evk/dcd/dcd.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __DCD__
-#define __DCD__
+#ifndef DCD_
+#define DCD_
 
 #include <stdint.h>
 
@@ -15,4 +15,4 @@
 #define DCD_TAG_HEADER_SHIFT (24)
 #define DCD_ARRAY_SIZE       1
 
-#endif /* __DCD__ */
+#endif /* DCD_ */

--- a/boards/nxp/mimxrt1160_evk/xip/evkmimxrt1160_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1160_evk/xip/evkmimxrt1160_flexspi_nor_config.c
@@ -18,20 +18,20 @@ const flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
 		/* Enable DDR mode, Wordaddassable, Safe configuration,
 		 * Differential clock
 		 */
 		.controller_misc_option = 0x10,
-		.device_type = flexspi_device_type_serial_nor,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_133mhz,
+		.device_type = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_133MHZ,
 		.sflash_a1_size = 16u * 1024u * 1024u,
 		/* Enable flash configuration feature */
 		.config_cmd_enable = 1u,
-		.config_mode_type[0] = device_config_cmd_type_generic,
+		.config_mode_type[0] = DEVICE_CONFIG_CMD_TYPE_GENERIC,
 		/* Set configuration command sequences */
 		.config_cmd_seqs[0] = {
 			.seq_num = 1,

--- a/boards/nxp/mimxrt1160_evk/xip/evkmimxrt1160_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1160_evk/xip/evkmimxrt1160_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKMIMXRT1160_FLEXSPI_NOR_CONFIG__
-#define __EVKMIMXRT1160_FLEXSPI_NOR_CONFIG__
+#ifndef EVKMIMXRT1160_FLEXSPI_NOR_CONFIG_
+#define EVKMIMXRT1160_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -71,75 +71,75 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_80mhz = 4,
-	flexspi_serial_clk_100mhz = 5,
-	flexspi_serial_clk_120mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
-	flexspi_serial_clk_166mhz = 8,
-	flexspi_serial_clk_200mhz = 9,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_80MHZ = 4,
+	FLEXSPI_SERIAL_CLK_100MHZ = 5,
+	FLEXSPI_SERIAL_CLK_120MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
+	FLEXSPI_SERIAL_CLK_166MHZ = 8,
+	FLEXSPI_SERIAL_CLK_200MHZ = 9,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum _FlashReadSampleClkSource {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR,
 	 * A2 is Serial NAND
 	 */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR,
 	 * A2 is Serial RAMs
 	 */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -154,17 +154,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -375,4 +375,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* #ifndef __EVKMIMXRT1160_FLEXSPI_NOR_CONFIG__ */
+#endif /* #ifndef EVKMIMXRT1160_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt1170_evk/dcd/dcd.h
+++ b/boards/nxp/mimxrt1170_evk/dcd/dcd.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __DCD__
-#define __DCD__
+#ifndef DCD_
+#define DCD_
 
 #include <stdint.h>
 
@@ -15,4 +15,4 @@
 #define DCD_TAG_HEADER_SHIFT (24)
 #define DCD_ARRAY_SIZE       1
 
-#endif /* __DCD__ */
+#endif /* DCD_ */

--- a/boards/nxp/mimxrt1170_evk/xip/evkbmimxrt1170_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1170_evk/xip/evkbmimxrt1170_flexspi_nor_config.c
@@ -18,20 +18,20 @@ const flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
 		/* Enable DDR mode, Wordaddassable, Safe configuration,
 		 * Differential clock
 		 */
 		.controller_misc_option = 0x10,
-		.device_type = flexspi_device_type_serial_nor,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_133mhz,
+		.device_type = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_133MHZ,
 		.sflash_a1_size = 64u * 1024u * 1024u,
 		/* Enable flash configuration feature */
 		.config_cmd_enable = 1u,
-		.config_mode_type[0] = device_config_cmd_type_generic,
+		.config_mode_type[0] = DEVICE_CONFIG_CMD_TYPE_GENERIC,
 		/* Set configuration command sequences */
 		.config_cmd_seqs[0] = {
 			.seq_num = 1,

--- a/boards/nxp/mimxrt1170_evk/xip/evkbmimxrt1170_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1170_evk/xip/evkbmimxrt1170_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKMIMXRT1170_FLEXSPI_NOR_CONFIG__
-#define __EVKMIMXRT1170_FLEXSPI_NOR_CONFIG__
+#ifndef EVKMIMXRT1170_FLEXSPI_NOR_CONFIG_
+#define EVKMIMXRT1170_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -71,75 +71,75 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_80mhz = 4,
-	flexspi_serial_clk_100mhz = 5,
-	flexspi_serial_clk_120mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
-	flexspi_serial_clk_166mhz = 8,
-	flexspi_serial_clk_200mhz = 9,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_80MHZ = 4,
+	FLEXSPI_SERIAL_CLK_100MHZ = 5,
+	FLEXSPI_SERIAL_CLK_120MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
+	FLEXSPI_SERIAL_CLK_166MHZ = 8,
+	FLEXSPI_SERIAL_CLK_200MHZ = 9,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR,
 	 * A2 is Serial NAND
 	 */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR,
 	 * A2 is Serial RAMs
 	 */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -154,17 +154,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -375,4 +375,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* #ifndef __EVKMIMXRT1170_FLEXSPI_NOR_CONFIG__ */
+#endif /* #ifndef EVKMIMXRT1170_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt1170_evk/xip/evkmimxrt1170_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1170_evk/xip/evkmimxrt1170_flexspi_nor_config.c
@@ -18,18 +18,18 @@ const flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
 		/* Enable DDR mode, Wordaddassable, Safe configuration, Differential clock */
 		.controller_misc_option = 0x10,
-		.device_type = flexspi_device_type_serial_nor,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_133mhz,
+		.device_type = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_133MHZ,
 		.sflash_a1_size = 16u * 1024u * 1024u,
 		/* Enable flash configuration feature */
 		.config_cmd_enable = 1u,
-		.config_mode_type[0] = device_config_cmd_type_generic,
+		.config_mode_type[0] = DEVICE_CONFIG_CMD_TYPE_GENERIC,
 		/* Set configuration command sequences */
 		.config_cmd_seqs[0] = {
 			.seq_num = 1,

--- a/boards/nxp/mimxrt1170_evk/xip/evkmimxrt1170_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1170_evk/xip/evkmimxrt1170_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKMIMXRT1170_FLEXSPI_NOR_CONFIG__
-#define __EVKMIMXRT1170_FLEXSPI_NOR_CONFIG__
+#ifndef EVKMIMXRT1170_FLEXSPI_NOR_CONFIG_
+#define EVKMIMXRT1170_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -72,71 +72,71 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_80mhz = 4,
-	flexspi_serial_clk_100mhz = 5,
-	flexspi_serial_clk_120mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
-	flexspi_serial_clk_166mhz = 8,
-	flexspi_serial_clk_200mhz = 9,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_80MHZ = 4,
+	FLEXSPI_SERIAL_CLK_100MHZ = 5,
+	FLEXSPI_SERIAL_CLK_120MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
+	FLEXSPI_SERIAL_CLK_166MHZ = 8,
+	FLEXSPI_SERIAL_CLK_200MHZ = 9,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial RAMs */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -151,17 +151,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -372,4 +372,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* #ifndef __EVKMIMXRT1170_FLEXSPI_NOR_CONFIG__ */
+#endif /* #ifndef EVKMIMXRT1170_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt1170_evk/xmcd/xmcd.h
+++ b/boards/nxp/mimxrt1170_evk/xmcd/xmcd.h
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __XMCD__
-#define __XMCD__
+#ifndef XMCD_
+#define XMCD_
 
 #include <stdint.h>
 
-#endif /* __XMCD__ */
+#endif /* XMCD_ */

--- a/boards/nxp/mimxrt1180_evk/xip/evkmimxrt1180_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1180_evk/xip/evkmimxrt1180_flexspi_nor_config.c
@@ -52,19 +52,19 @@ const flexspi_nor_config_t qspi_flash_nor_config = {
 	.mem_config = {
 		.tag		  = FLEXSPI_CFG_BLK_TAG,
 		.version          = FLEXSPI_CFG_BLK_VERSION,
-		.read_sample_clk_src = flexspi_read_sample_clk_loopback_from_dqs_pad,
+		.read_sample_clk_src = FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time       = 3u,
 		.cs_setup_time      = 3u,
 		/* Enable DDR mode, Wordaddassable, Safe configuration,
 		 * Differential clock
 		 */
 		.controller_misc_option = 0x10,
-		.device_type           = flexspi_device_type_serial_nor,
-		.sflash_pad_type        = serial_flash_4_pads,
-		.serial_clk_freq        = flexspi_serial_clk_133mhz,
+		.device_type           = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type        = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq        = FLEXSPI_SERIAL_CLK_133MHZ,
 		.sflash_a1_size         = 16u * 1024u * 1024u,
 
-		.config_mode_type[0] = device_config_cmd_type_generic,
+		.config_mode_type[0] = DEVICE_CONFIG_CMD_TYPE_GENERIC,
 
 		.lookup_table = {
 			/* Read LUTs */

--- a/boards/nxp/mimxrt1180_evk/xip/evkmimxrt1180_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1180_evk/xip/evkmimxrt1180_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKMIMXRT1180_FLEXSPI_NOR_CONFIG__
-#define __EVKMIMXRT1180_FLEXSPI_NOR_CONFIG__
+#ifndef EVKMIMXRT1180_FLEXSPI_NOR_CONFIG_
+#define EVKMIMXRT1180_FLEXSPI_NOR_CONFIG_
 
 #include "fsl_common.h"
 
@@ -54,40 +54,40 @@
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_reversed = 2,
-	flexspi_read_sample_clk_flash_provided_dqs = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_REVERSED = 2,
+	FLEXSPI_READ_SAMPLE_CLK_FLASH_PROVIDED_DQS = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_80mhz = 4,
-	flexspi_serial_clk_100mhz = 5,
-	flexspi_serial_clk_120mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
-	flexspi_serial_clk_166mhz = 8,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_80MHZ = 4,
+	FLEXSPI_SERIAL_CLK_100MHZ = 5,
+	FLEXSPI_SERIAL_CLK_120MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
+	FLEXSPI_SERIAL_CLK_166MHZ = 8,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief Flash Configuration Command Type */
@@ -95,17 +95,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -266,4 +266,4 @@ typedef struct _flexspi_nor_config {
 	uint32_t reserve1[10];
 } flexspi_nor_config_t;
 
-#endif /* __EVKMIMXRT1180_FLEXSPI_NOR_CONFIG__ */
+#endif /* EVKMIMXRT1180_FLEXSPI_NOR_CONFIG_ */

--- a/boards/nxp/mimxrt595_evk/flash_config/flash_config.c
+++ b/boards/nxp/mimxrt595_evk/flash_config/flash_config.c
@@ -14,7 +14,7 @@ const flexspi_nor_config_t flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.readSampleClkSrc =
-			flexspi_read_sample_clk_external_input_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD,
 		.csHoldTime = 3,
 		.csSetupTime = 3,
 		.deviceModeCfgEnable = 1,
@@ -29,11 +29,11 @@ const flexspi_nor_config_t flash_config = {
 		/* Enable OPI DDR mode */
 		.deviceModeArg = 2,
 		.controllerMiscOption =
-			(1u << flexspi_misc_offset_safe_config_freq_enable) |
-			(1u << flexspi_misc_offset_ddr_mode_enable),
+			(1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE) |
+			(1u << FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE),
 		.deviceType = kFlexSpiDeviceType_SerialNOR,
 		.sflashPadType = kSerialFlash_8Pads,
-		.serialClkFreq = flexspi_serial_clk_60mhz,
+	.serialClkFreq = FLEXSPI_SERIAL_CLK_60MHZ,
 		.sflashA1Size = 64ul * 1024u * 1024u,
 		.busyOffset = 0u,
 		.busyBitPolarity = 0u,

--- a/boards/nxp/mimxrt595_evk/flash_config/flash_config.h
+++ b/boards/nxp/mimxrt595_evk/flash_config/flash_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  */
-#ifndef __FLASH_CONFIG_H__
-#define __FLASH_CONFIG_H__
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
 
 #include <stdint.h>
 #include "fsl_iap.h"
@@ -17,15 +17,15 @@
 
 /*! @brief FLEXSPI clock configuration - When clock source is PLL */
 enum {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_80mhz = 4,
-	flexspi_serial_clk_100mhz = 5,
-	flexspi_serial_clk_120mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
-	flexspi_serial_clk_166mhz = 8,
-	flexspi_serial_clk_200mhz = 9,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_80MHZ = 4,
+	FLEXSPI_SERIAL_CLK_100MHZ = 5,
+	FLEXSPI_SERIAL_CLK_120MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
+	FLEXSPI_SERIAL_CLK_166MHZ = 8,
+	FLEXSPI_SERIAL_CLK_200MHZ = 9,
 };
 
 /*! @brief LUT instructions supported by FLEXSPI */
@@ -70,28 +70,28 @@ enum {
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 	/* Bit for DLLCR settings under all modes */
-	flexspi_misc_offset_use_valid_time_for_all_freq = 7,
+	FLEXSPI_MISC_OFFSET_USE_VALID_TIME_FOR_ALL_FREQ = 7,
 };
 
-#endif
+#endif /* FLASH_CONFIG_H_ */

--- a/boards/nxp/mimxrt685_evk/flash_config/flash_config.c
+++ b/boards/nxp/mimxrt685_evk/flash_config/flash_config.c
@@ -16,7 +16,7 @@ const flexspi_nor_config_t flexspi_config = {
 		.cs_hold_time = 3,
 		.cs_setup_time = 3,
 		.device_mode_cfg_enable = 1,
-		.device_mode_type = device_config_cmd_type_generic,
+		.device_mode_type = DEVICE_CONFIG_CMD_TYPE_GENERIC,
 		.wait_time_cfg_commands = 1,
 		.device_mode_seq = {
 			.seq_num = 1,
@@ -26,9 +26,9 @@ const flexspi_nor_config_t flexspi_config = {
 		},
 		.device_mode_arg = 0,
 		.config_cmd_enable = 1,
-		.config_mode_type = {device_config_cmd_type_generic,
-					device_config_cmd_type_spi2xpi,
-					device_config_cmd_type_generic},
+		.config_mode_type = {DEVICE_CONFIG_CMD_TYPE_GENERIC,
+					DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
+					DEVICE_CONFIG_CMD_TYPE_GENERIC},
 		.config_cmd_seqs = {
 			{
 				.seq_num = 1,
@@ -43,10 +43,10 @@ const flexspi_nor_config_t flexspi_config = {
 		},
 		.config_cmd_args = {0x2, 0x1},
 		.controller_misc_option =
-			1u << flexspi_misc_offset_safe_config_freq_enable,
+			1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE,
 		.device_type = 0x1,
-		.sflash_pad_type = serial_flash_8_pads,
-		.serial_clk_freq = flexspi_serial_clk_sdr_48mhz,
+		.sflash_pad_type = SERIAL_FLASH_8_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_SDR_48MHZ,
 		.sflash_a1_size = 0,
 		.sflash_a2_size = 0,
 		.sflash_b1_size = 0x4000000U,

--- a/boards/nxp/mimxrt685_evk/flash_config/flash_config.h
+++ b/boards/nxp/mimxrt685_evk/flash_config/flash_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __FLASH_CONFIG__
-#define __FLASH_CONFIG__
+#ifndef FLASH_CONFIG_
+#define FLASH_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -57,46 +57,46 @@
 
 /*! @brief Data pad used in Read command */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PADS = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FLEXSPI clock configuration - In High speed boot mode */
 enum {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_80mhz = 4,
-	flexspi_serial_clk_100mhz = 5,
-	flexspi_serial_clk_120mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
-	flexspi_serial_clk_166mhz = 8,
-	flexspi_serial_clk_200mhz = 9,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_80MHZ = 4,
+	FLEXSPI_SERIAL_CLK_100MHZ = 5,
+	FLEXSPI_SERIAL_CLK_120MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
+	FLEXSPI_SERIAL_CLK_166MHZ = 8,
+	FLEXSPI_SERIAL_CLK_200MHZ = 9,
 };
 
 /*! @brief FLEXSPI clock configuration - In Normal boot SDR mode */
 enum {
-	flexspi_serial_clk_sdr_24mhz = 1,
-	flexspi_serial_clk_sdr_48mhz = 2,
+	FLEXSPI_SERIAL_CLK_SDR_24MHZ = 1,
+	FLEXSPI_SERIAL_CLK_SDR_48MHZ = 2,
 };
 
 /*! @brief FLEXSPI clock configuration - In Normal boot DDR mode */
 enum {
-	flexspi_serial_clk_ddr_48mhz = 1,
+	FLEXSPI_SERIAL_CLK_DDR_48MHZ = 1,
 };
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Configuration Command Type */
@@ -104,17 +104,17 @@ enum {
 	/* !< Generic command, for example:
 	 * configure dummy cycles, drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* !< Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* !< Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* !< Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* !< Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* !< Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 typedef struct {
@@ -292,4 +292,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* __FLASH_CONFIG__ */
+#endif /* FLASH_CONFIG_ */

--- a/boards/nxp/mimxrt700_evk/flash_config/flash_config.c
+++ b/boards/nxp/mimxrt700_evk/flash_config/flash_config.c
@@ -14,7 +14,7 @@ const fc_static_platform_config_t flash_config = {
 			.tag = FC_XSPI_CFG_BLK_TAG,
 			.version = FC_XSPI_CFG_BLK_VERSION,
 			.read_sample_clk_src =
-				fc_xspi_read_sample_clk_external_input_from_dqs_pad,
+				FC_XSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD,
 			.cs_hold_time = 3,
 			.cs_setup_time = 3,
 			.device_mode_cfg_enable = 1,
@@ -28,11 +28,11 @@ const fc_static_platform_config_t flash_config = {
 			},
 			.device_mode_arg = 2, /* Enable OPI DDR mode */
 			.controller_misc_option =
-			(1u << fc_xspi_misc_offset_safe_config_freq_enable) |
-			(1u << fc_xspi_misc_offset_ddr_mode_enable),
+			(1u << FC_XSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE) |
+			(1u << FC_XSPI_MISC_OFFSET_DDR_MODE_ENABLE),
 			.device_type = 1,
 			.sflash_pad_type = 8,
-			.serial_clk_freq = fc_xspi_serial_clk_200mhz,
+			.serial_clk_freq = FC_XSPI_SERIAL_CLK_200MHZ,
 			.sflash_a1_size = 64ul * 1024u * 1024u,
 			.busy_offset = 0u,
 			.busy_bit_polarity = 0u,

--- a/boards/nxp/mimxrt700_evk/flash_config/flash_config.h
+++ b/boards/nxp/mimxrt700_evk/flash_config/flash_config.h
@@ -19,15 +19,15 @@
 
 /*! @brief XSPI clock configuration - When clock source is PLL */
 typedef enum fc_xspi_serial_clock_freq {
-	fc_xspi_serial_clk_30mhz = 1,
-	fc_xspi_serial_clk_50mhz = 2,
-	fc_xspi_serial_clk_60mhz = 3,
-	fc_xspi_serial_clk_80mhz = 4,
-	fc_xspi_serial_clk_100mhz = 5,
-	fc_xspi_serial_clk_120mhz = 6,
-	fc_xspi_serial_clk_133mhz = 7,
-	fc_xspi_serial_clk_166mhz = 8,
-	fc_xspi_serial_clk_200mhz = 9,
+	FC_XSPI_SERIAL_CLK_30MHZ = 1,
+	FC_XSPI_SERIAL_CLK_50MHZ = 2,
+	FC_XSPI_SERIAL_CLK_60MHZ = 3,
+	FC_XSPI_SERIAL_CLK_80MHZ = 4,
+	FC_XSPI_SERIAL_CLK_100MHZ = 5,
+	FC_XSPI_SERIAL_CLK_120MHZ = 6,
+	FC_XSPI_SERIAL_CLK_133MHZ = 7,
+	FC_XSPI_SERIAL_CLK_166MHZ = 8,
+	FC_XSPI_SERIAL_CLK_200MHZ = 9,
 } fc_xspi_serial_clk_freq_t;
 
 /*! @brief LUT instructions supported by XSPI */
@@ -87,21 +87,21 @@ typedef enum fc_xspi_serial_clock_freq {
 
 /* !@brief XSPI Read Sample Clock Source definition */
 typedef enum fc_xspi_read_sample_clk_source {
-	fc_xspi_read_sample_clk_loopback_internally = 0,
-	fc_xspi_read_sample_clk_loopback_from_dqs_pad = 2,
-	fc_xspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FC_XSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FC_XSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 2,
+	FC_XSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } fc_xspi_read_sample_clk_t;
 
 /* !@brief Misc feature bit definitions */
 enum {
 	/* !< Bit for Differential clock enable */
-	fc_xspi_misc_offset_diff_clk_enable = 0,
+	FC_XSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* !< Bit for Word Addressable enable */
-	fc_xspi_misc_offset_word_addressable_enable = 3,
+	FC_XSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* !< Bit for Safe Configuration Frequency enable */
-	fc_xspi_misc_offset_safe_config_freq_enable = 4,
+	FC_XSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* !< Bit for DDR clock confiuration indication. */
-	fc_xspi_misc_offset_ddr_mode_enable = 6,
+	FC_XSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 typedef struct {

--- a/boards/nxp/vmu_rt1170/flexspi_nor_config.c
+++ b/boards/nxp/vmu_rt1170/flexspi_nor_config.c
@@ -43,11 +43,11 @@ const struct flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_internally,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY,
 		.cs_hold_time = 1u,
 		.cs_setup_time = 1u,
-		.sflash_pad_type = serial_flash_1_pad,
-		.serial_clk_freq = flexspi_serial_clk_80mhz,
+		.sflash_pad_type = SERIAL_FLASH_1_PAD,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_80MHZ,
 		.sflash_a1_size = 64u * 1024u * 1024u,
 		.lookup_table = {
 			FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD,
@@ -70,11 +70,11 @@ const struct flexspi_nor_config_t g_flash_fast_config = {
 	.mem_config = {
 		.tag                 = FLEXSPI_CFG_BLK_TAG,
 		.version             = FLEXSPI_CFG_BLK_VERSION,
-		.read_sample_clk_src    = flexspi_read_sample_clk_external_input_from_dqs_pad,
+		.read_sample_clk_src    = FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD,
 		.cs_hold_time          = 1,
 		.cs_setup_time         = 1,
 		.device_mode_cfg_enable = 1,
-		.device_mode_type      = device_config_cmd_type_spi2xpi,
+		.device_mode_type      = DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 		.wait_time_cfg_commands = 1,
 		.device_mode_seq = {
 			.seq_num   = 1,
@@ -83,11 +83,11 @@ const struct flexspi_nor_config_t g_flash_fast_config = {
 		},
 		.device_mode_arg = 2, /* Enable OPI DDR mode */
 		.controller_misc_option =
-		(1u << flexspi_misc_offset_safe_config_freq_enable)
-			| (1u << flexspi_misc_offset_ddr_mode_enable),
-		.device_type    = flexspi_device_type_serial_nor,
-		.sflash_pad_type = serial_flash_8_pads,
-		.serial_clk_freq = flexspi_serial_clk_200mhz,
+		(1u << FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE)
+			| (1u << FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE),
+		.device_type    = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type = SERIAL_FLASH_8_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_200MHZ,
 		.sflash_a1_size  = 64ul * 1024u * 1024u,
 		.busy_offset      = 0u,
 		.busy_bit_polarity = 0u,

--- a/boards/nxp/vmu_rt1170/xip/evkmimxrt1170_flexspi_nor_config.c
+++ b/boards/nxp/vmu_rt1170/xip/evkmimxrt1170_flexspi_nor_config.c
@@ -18,20 +18,20 @@ const flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
 		/* Enable DDR mode, Wordaddassable, Safe configuration,
 		 * Differential clock
 		 */
 		.controller_misc_option = 0x10,
-		.device_type = flexspi_device_type_serial_nor,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_133mhz,
+		.device_type = FLEXSPI_DEVICE_TYPE_SERIAL_NOR,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_133MHZ,
 		.sflash_a1_size = 16u * 1024u * 1024u,
 		/* Enable flash configuration feature */
 		.config_cmd_enable = 1u,
-		.config_mode_type[0] = device_config_cmd_type_generic,
+		.config_mode_type[0] = DEVICE_CONFIG_CMD_TYPE_GENERIC,
 		/* Set configuration command sequences */
 		.config_cmd_seqs[0] = {
 			.seq_num = 1,

--- a/boards/nxp/vmu_rt1170/xip/evkmimxrt1170_flexspi_nor_config.h
+++ b/boards/nxp/vmu_rt1170/xip/evkmimxrt1170_flexspi_nor_config.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __EVKMIMXRT1170_FLEXSPI_NOR_CONFIG__
-#define __EVKMIMXRT1170_FLEXSPI_NOR_CONFIG__
+#ifndef EVKMIMXRT1170_FLEXSPI_NOR_CONFIG_
+#define EVKMIMXRT1170_FLEXSPI_NOR_CONFIG_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -72,71 +72,71 @@
 
 /*! @brief Definitions for FlexSPI Serial Clock Frequency */
 typedef enum flexspi_serial_clock_freq {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_80mhz = 4,
-	flexspi_serial_clk_100mhz = 5,
-	flexspi_serial_clk_120mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
-	flexspi_serial_clk_166mhz = 8,
-	flexspi_serial_clk_200mhz = 9,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_80MHZ = 4,
+	FLEXSPI_SERIAL_CLK_100MHZ = 5,
+	FLEXSPI_SERIAL_CLK_120MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
+	FLEXSPI_SERIAL_CLK_166MHZ = 8,
+	FLEXSPI_SERIAL_CLK_200MHZ = 9,
 } flexspi_serial_clk_freq_t;
 
 /*! @brief FlexSPI clock configuration type */
 enum {
 	/* Clock configure for SDR mode */
-	flexspi_clk_sdr,
+	FLEXSPI_CLK_SDR,
 	/* Clock configurat for DDR mode */
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_DDR,
 };
 
 /*! @brief FlexSPI Read Sample Clock Source definition */
 typedef enum flexspi_read_sample_clk_source {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 } flexspi_read_sample_clk_t;
 
 /*! @brief Misc feature bit definitions */
 enum {
 	/* Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* Bit for DDR clock confiuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /*! @brief Flash Type Definition */
 enum {
 	/* Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* Flash device is MCP device, A1 is Serial NOR, A2 is Serial RAMs */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /*! @brief Flash Pad Definitions */
 enum {
-	serial_flash_1_pads = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PAD = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 /*! @brief FlexSPI LUT Sequence structure */
@@ -151,17 +151,17 @@ enum {
 	/* Generic command, for example: configure dummy cycles,
 	 * drive strength, etc
 	 */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 /*! @brief FlexSPI Memory Configuration Block */
@@ -372,4 +372,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* #ifndef __EVKMIMXRT1170_FLEXSPI_NOR_CONFIG__ */
+#endif /* #ifndef EVKMIMXRT1170_FLEXSPI_NOR_CONFIG_ */

--- a/boards/pjrc/teensy4/flexspi_nor_config.c
+++ b/boards/pjrc/teensy4/flexspi_nor_config.c
@@ -17,11 +17,11 @@ const struct flexspi_nor_config_t qspi_flash_config = {
 		.tag = FLEXSPI_CFG_BLK_TAG,
 		.version = FLEXSPI_CFG_BLK_VERSION,
 		.read_sample_clk_src =
-			flexspi_read_sample_clk_loopback_from_dqs_pad,
+			FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD,
 		.cs_hold_time = 3u,
 		.cs_setup_time = 3u,
-		.sflash_pad_type = serial_flash_4_pads,
-		.serial_clk_freq = flexspi_serial_clk_100mhz,
+		.sflash_pad_type = SERIAL_FLASH_4_PADS,
+		.serial_clk_freq = FLEXSPI_SERIAL_CLK_100MHZ,
 		.sflash_a1_size = 8u * 1024u * 1024u,
 		.lookup_table = {
 			FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD,

--- a/soc/nxp/imxrt/flexspi_nor_config.h
+++ b/soc/nxp/imxrt/flexspi_nor_config.h
@@ -6,8 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __FLEXSPI_NOR_CONFIG__
-#define __FLEXSPI_NOR_CONFIG__
+#ifndef FLEXSPI_NOR_CONFIG_
+#define FLEXSPI_NOR_CONFIG_
 
 #include <zephyr/types.h>
 #include "fsl_common.h"
@@ -69,49 +69,49 @@
 /* For flexspi_mem_config.serial_clk_freq */
 #if defined(CONFIG_SOC_MIMXRT1011)
 enum {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_120mhz = 7,
-	flexspi_serial_clk_133mhz = 8,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_120MHZ = 7,
+	FLEXSPI_SERIAL_CLK_133MHZ = 8,
 };
 #elif defined(CONFIG_SOC_MIMXRT1015) || defined(CONFIG_SOC_MIMXRT1021) ||                          \
 	defined(CONFIG_SOC_MIMXRT1024)
 enum {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
 };
 #elif defined(CONFIG_SOC_MIMXRT1052) || defined(CONFIG_SOC_SERIES_IMXRT11XX)
 enum {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_133mhz = 7,
-	flexspi_serial_clk_166mhz = 8,
-	flexspi_serial_clk_200mhz = 9,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_133MHZ = 7,
+	FLEXSPI_SERIAL_CLK_166MHZ = 8,
+	FLEXSPI_SERIAL_CLK_200MHZ = 9,
 };
 #elif defined(CONFIG_SOC_MIMXRT1062) || defined(CONFIG_SOC_MIMXRT1064)
 enum {
-	flexspi_serial_clk_30mhz = 1,
-	flexspi_serial_clk_50mhz = 2,
-	flexspi_serial_clk_60mhz = 3,
-	flexspi_serial_clk_75mhz = 4,
-	flexspi_serial_clk_80mhz = 5,
-	flexspi_serial_clk_100mhz = 6,
-	flexspi_serial_clk_120mhz = 7,
-	flexspi_serial_clk_133mhz = 8,
-	flexspi_serial_clk_166mhz = 9,
+	FLEXSPI_SERIAL_CLK_30MHZ = 1,
+	FLEXSPI_SERIAL_CLK_50MHZ = 2,
+	FLEXSPI_SERIAL_CLK_60MHZ = 3,
+	FLEXSPI_SERIAL_CLK_75MHZ = 4,
+	FLEXSPI_SERIAL_CLK_80MHZ = 5,
+	FLEXSPI_SERIAL_CLK_100MHZ = 6,
+	FLEXSPI_SERIAL_CLK_120MHZ = 7,
+	FLEXSPI_SERIAL_CLK_133MHZ = 8,
+	FLEXSPI_SERIAL_CLK_166MHZ = 9,
 };
 #else
 #error "kFlexSpiSerialClk is not defined for this SoC"
@@ -119,71 +119,71 @@ enum {
 
 /* For flexspi_mem_config.controller_misc_option */
 enum {
-	flexspi_clk_sdr,
-	flexspi_clk_ddr,
+	FLEXSPI_CLK_SDR,
+	FLEXSPI_CLK_DDR,
 };
 
 /* For flexspi_mem_config.read_sample_clk_src */
 enum {
-	flexspi_read_sample_clk_loopback_internally = 0,
-	flexspi_read_sample_clk_loopback_from_dqs_pad = 1,
-	flexspi_read_sample_clk_loopback_from_sck_pad = 2,
-	flexspi_read_sample_clk_external_input_from_dqs_pad = 3,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY = 0,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD = 1,
+	FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD = 2,
+	FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 3,
 };
 
 /* For flexspi_mem_config.controller_misc_option */
 enum {
 	/* !< Bit for Differential clock enable */
-	flexspi_misc_offset_diff_clk_enable = 0,
+	FLEXSPI_MISC_OFFSET_DIFF_CLK_ENABLE = 0,
 	/* !< Bit for CK2 enable */
-	flexspi_misc_offset_ck2_enable = 1,
+	FLEXSPI_MISC_OFFSET_CK2_ENABLE = 1,
 	/* !< Bit for Parallel mode enable */
-	flexspi_misc_offset_parallel_enable = 2,
+	FLEXSPI_MISC_OFFSET_PARALLEL_ENABLE = 2,
 	/* !< Bit for Word Addressable enable */
-	flexspi_misc_offset_word_addressable_enable = 3,
+	FLEXSPI_MISC_OFFSET_WORD_ADDRESSABLE_ENABLE = 3,
 	/* !< Bit for Safe Configuration Frequency enable */
-	flexspi_misc_offset_safe_config_freq_enable = 4,
+	FLEXSPI_MISC_OFFSET_SAFE_CONFIG_FREQ_ENABLE = 4,
 	/* !< Bit for Pad setting override enable */
-	flexspi_misc_offset_pad_setting_override_enable = 5,
+	FLEXSPI_MISC_OFFSET_PAD_SETTING_OVERRIDE_ENABLE = 5,
 	/* !< Bit for DDR clock configuration indication. */
-	flexspi_misc_offset_ddr_mode_enable = 6,
+	FLEXSPI_MISC_OFFSET_DDR_MODE_ENABLE = 6,
 };
 
 /* For flexspi_mem_config.device_type */
 enum {
 	/* !< Flash devices are Serial NOR */
-	flexspi_device_type_serial_nor = 1,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NOR = 1,
 	/* !< Flash devices are Serial NAND */
-	flexspi_device_type_serial_nand = 2,
+	FLEXSPI_DEVICE_TYPE_SERIAL_NAND = 2,
 	/* !< Flash devices are Serial RAM/HyperFLASH */
-	flexspi_device_type_serial_ram = 3,
+	FLEXSPI_DEVICE_TYPE_SERIAL_RAM = 3,
 	/* !< Flash device is MCP device, A1 is Serial NOR, A2 is Serial NAND */
-	flexspi_device_type_mcp_nor_nand = 0x12,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_NAND = 0x12,
 	/* !< Flash device is MCP device, A1 is Serial NOR, A2 is Serial RAMs */
-	flexspi_device_type_mcp_nor_ram = 0x13,
+	FLEXSPI_DEVICE_TYPE_MCP_NOR_RAM = 0x13,
 };
 
 /* For flexspi_mem_config.sflash_pad_type */
 enum {
-	serial_flash_1_pad = 1,
-	serial_flash_2_pads = 2,
-	serial_flash_4_pads = 4,
-	serial_flash_8_pads = 8,
+	SERIAL_FLASH_1_PAD = 1,
+	SERIAL_FLASH_2_PADS = 2,
+	SERIAL_FLASH_4_PADS = 4,
+	SERIAL_FLASH_8_PADS = 8,
 };
 
 enum {
 	/* !< Generic command, for example: configure dummy cycles, drive strength, etc */
-	device_config_cmd_type_generic,
+	DEVICE_CONFIG_CMD_TYPE_GENERIC,
 	/* !< Quad Enable command */
-	device_config_cmd_type_quad_enable,
+	DEVICE_CONFIG_CMD_TYPE_QUAD_ENABLE,
 	/* !< Switch from SPI to DPI/QPI/OPI mode */
-	device_config_cmd_type_spi2xpi,
+	DEVICE_CONFIG_CMD_TYPE_SPI2XPI,
 	/* !< Switch from DPI/QPI/OPI to SPI mode */
-	device_config_cmd_type_xpi2spi,
+	DEVICE_CONFIG_CMD_TYPE_XPI2SPI,
 	/* !< Switch to 0-4-4/0-8-8 mode */
-	device_config_cmd_type_spi2nocmd,
+	DEVICE_CONFIG_CMD_TYPE_SPI2NOCMD,
 	/* !< Reset device command */
-	device_config_cmd_type_reset,
+	DEVICE_CONFIG_CMD_TYPE_RESET,
 };
 
 struct flexspi_lut_seq_t {
@@ -338,7 +338,7 @@ struct flexspi_nor_config_t {
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* FLEXSPI_NOR_CONFIG_ */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
In PR https://github.com/zephyrproject-rtos/zephyr/pull/96120, i didn't noticed that the enum members should be uppercase, changes in this PR are: 
1. Convert enum members to upper case
2. Remove extra underscores from header names to align with zephyr style.