### PR TITLE
add netc and flexcan pinctrl on imx95

### DIFF
--- a/boards/nxp/imx95_evk/imx95_evk-pinctrl.dtsi
+++ b/boards/nxp/imx95_evk/imx95_evk-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -134,6 +134,16 @@
 				 <&iomuxc_gpio_io21_sai_tx_data_bit_sai3_tx_data_bit0>,
 				 <&iomuxc_gpio_io26_sai_tx_sync_sai3_tx_sync>;
 			bias-pull-up;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+		};
+	};
+
+	flexcan2_default: flexcan2_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_io27_can_rx_can2_rx>,
+				<&iomuxc_gpio_io25_can_tx_can2_tx>;
+			bias-pull-down;
 			slew-rate = "slightly_fast";
 			drive-strength = "x4";
 		};

--- a/boards/nxp/imx95_evk_15x15/imx95_evk_15x15-pinctrl.dtsi
+++ b/boards/nxp/imx95_evk_15x15/imx95_evk_15x15-pinctrl.dtsi
@@ -50,4 +50,14 @@
 			drive-strength = "x4";
 		};
 	};
+
+	flexcan2_default: flexcan2_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_io27_can_rx_can2_rx>,
+				<&iomuxc_gpio_io25_can_tx_can2_tx>;
+			bias-pull-down;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+		};
+	};
 };

--- a/boards/nxp/imx95_evk_15x15/imx95_evk_15x15-pinctrl.dtsi
+++ b/boards/nxp/imx95_evk_15x15/imx95_evk_15x15-pinctrl.dtsi
@@ -6,6 +6,31 @@
 #include <nxp/nxp_imx/mimx9596cvtxn-pinctrl.dtsi>
 
 &pinctrl {
+	eth0_default: eth0_default {
+		group1 {
+			pinmux = <&iomuxc_enet1_rx_ctl_eth_rgmii_rx_ctl_eth0_rgmii_rx_ctl>,
+				<&iomuxc_enet1_rd0_eth_rgmii_rd_eth0_rgmii_rd0>,
+				<&iomuxc_enet1_rd1_eth_rgmii_rd_eth0_rgmii_rd1>,
+				<&iomuxc_enet1_rd2_eth_rgmii_rd_eth0_rgmii_rd2>,
+				<&iomuxc_enet1_rd3_eth_rgmii_rd_eth0_rgmii_rd3>,
+				<&iomuxc_enet1_tx_ctl_eth_rgmii_tx_ctl_eth0_rgmii_tx_ctl>,
+				<&iomuxc_enet1_td0_eth_rgmii_td_eth0_rgmii_td0>,
+				<&iomuxc_enet1_td1_eth_rgmii_td_eth0_rgmii_td1>,
+				<&iomuxc_enet1_td2_eth_rgmii_td_eth0_rgmii_td2>,
+				<&iomuxc_enet1_td3_eth_rgmii_td_eth0_rgmii_td3>;
+			bias-pull-down;
+			slew-rate = "slightly_fast";
+			drive-strength = "x6";
+		};
+		group2 {
+			pinmux = <&iomuxc_enet1_rxc_eth_rgmii_rx_clk_eth0_rgmii_rx_clk>,
+				<&iomuxc_enet1_txc_eth_rgmii_tx_clk_eth0_rgmii_tx_clk>;
+			bias-pull-down;
+			slew-rate = "fast";
+			drive-strength = "x6";
+		};
+	};
+
 	lpuart1_default: lpuart1_default {
 		group0 {
 			pinmux = <&iomuxc_uart1_rxd_lpuart_rx_lpuart1_rx>,


### PR DESCRIPTION
Added NETC and flexcan pinctrl node on imx95_evk and imx95_evk_15x15 boards.