### PR TITLE
drivers: scmi: nxp: fix build warning

### DIFF
--- a/drivers/firmware/scmi/nxp/CMakeLists.txt
+++ b/drivers/firmware/scmi/nxp/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
+zephyr_library_property(ALLOW_EMPTY TRUE)
+
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_NXP_VENDOR_EXTENSIONS shmem.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS cpu.c)


### PR DESCRIPTION
When none of the configs is enabled, it will reports the following build warning:

CMake Warning at zephyr/CMakeLists.txt:1096 (message):
  No SOURCES given to Zephyr library: drivers__firmware__scmi__nxp

  Excluding target from build.