### PR TITLE
Fix twister build for mcxw71/72 boards

### DIFF
--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
@@ -21,3 +21,5 @@ supported:
   - spi
   - uart
   - watchdog
+  - netif:openthread
+vendor: nxp

--- a/boards/nxp/frdm_mcxw72/doc/index.rst
+++ b/boards/nxp/frdm_mcxw72/doc/index.rst
@@ -100,11 +100,13 @@ Openthread applications
    :zephyr-app: samples/net/sockets/echo_server
    :board: frdm_mcxw72/mcxw727c/cpu0
    :goals: build
+   :gen-args: -DEXTRA_CONF_FILE=overlay-ot.conf
 
 .. zephyr-app-commands::
    :zephyr-app: samples/net/sockets/echo_client
    :board: frdm_mcxw72/mcxw727c/cpu0
    :goals: build
+   :gen-args: -DEXTRA_CONF_FILE=overlay-ot.conf
 
 Application Flashing
 ====================

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.yaml
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.yaml
@@ -19,3 +19,5 @@ supported:
   - spi
   - uart
   - watchdog
+  - netif:openthread
+vendor: nxp

--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -83,7 +83,7 @@ tests:
     tags:
       - net
       - usb
-  sample.net.sockets.echo_server.nrf_openthread:
+  sample.net.sockets.echo_server.openthread:
     extra_args: EXTRA_CONF_FILE="overlay-ot.conf"
     slow: true
     tags:

--- a/soc/nxp/mcx/mcxw/mcxw7xx/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/CMakeLists.txt
@@ -15,5 +15,5 @@ zephyr_include_directories(./)
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")
 
 if(CONFIG_BT OR CONFIG_IEEE802154)
-  zephyr_linker_sources(RAM_SECTIONS /sections.ld)
+  zephyr_linker_sources(RAM_SECTIONS sections.ld)
 endif()


### PR DESCRIPTION
Updated supported features list for frdm_mcxw71/72 boards so CI can be successfully built for echo_server/client app with OpenThread support.
Updated frdm_mcx72 documentation.