### PR TITLE
net: lib: wifi: mgmt: Fix memory leaks

### DIFF
--- a/include/zephyr/toolchain.h
+++ b/include/zephyr/toolchain.h
@@ -247,6 +247,17 @@
 #endif
 
 /**
+ * @def TOOLCHAIN_WARNING_CAST_QUAL
+ * @brief Toolchain-specific warning for pointer casts removing a type qualifier.
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_CAST_QUAL
+#define TOOLCHAIN_WARNING_CAST_QUAL
+#endif
+
+/**
  * @def TOOLCHAIN_DISABLE_WARNING
  * @brief Disable the specified compiler warning for all compilers.
  */

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -721,6 +721,7 @@ do {                                                                    \
 #define TOOLCHAIN_WARNING_SHADOW                   "-Wshadow"
 #define TOOLCHAIN_WARNING_UNUSED_LABEL             "-Wunused-label"
 #define TOOLCHAIN_WARNING_UNUSED_VARIABLE          "-Wunused-variable"
+#define TOOLCHAIN_WARNING_CAST_QUAL                "-Wcast-qual"
 
 /* GCC-specific warnings that aren't in clang. */
 #if defined(__GNUC__) && !defined(__clang__)

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -678,7 +678,7 @@ void wifi_mgmt_raise_neighbor_rep_recv_event(struct net_if *iface, char *inbuf, 
 			LOG_INF("Maximum neighbors added to list, Skipping.");
 		}
 	} else {
-		LOG_INF("Failed to Parse Neighbor Report - Skipping entry\n");
+		LOG_INF("Failed to Parse Neighbor Report - Skipping entry");
 	}
 }
 #endif
@@ -1038,7 +1038,7 @@ static int wifi_set_twt(uint64_t mgmt_request, struct net_if *iface,
 	}
 #else
 	NET_WARN("Check for valid IP address been disabled. "
-		 "Device might be unreachable or might not receive traffic.\n");
+		 "Device might be unreachable or might not receive traffic.");
 #endif /* CONFIG_WIFI_MGMT_TWT_CHECK_IP */
 
 	if (info.link_mode < WIFI_6) {
@@ -1537,7 +1537,7 @@ static int __stored_creds_to_params(struct wifi_credentials_personal *creds,
 {
 	/* SSID */
 	if (creds->header.ssid_len > WIFI_SSID_MAX_LEN) {
-		LOG_ERR("SSID string truncated\n");
+		LOG_ERR("SSID string truncated");
 		return -EINVAL;
 	}
 
@@ -1557,7 +1557,7 @@ static int __stored_creds_to_params(struct wifi_credentials_personal *creds,
 	if (params->security == WIFI_SECURITY_TYPE_EAP_TLS) {
 		if (creds->header.key_passwd_length > 0) {
 			if (creds->header.key_passwd_length > WIFI_ENT_PSWD_MAX_LEN) {
-				LOG_ERR("key_passwd string truncated\n");
+				LOG_ERR("key_passwd string truncated");
 				return -EINVAL;
 			}
 			memcpy((uint8_t *)params->key_passwd, creds->header.key_passwd,


### PR DESCRIPTION
When connecting to WiFi from stored credentials, the `key_passwd` is never freed.
Additionally if the connect fails, the allocated data was never freed.