### PR TITLE
lib: open-amp: initialize the resource_table.cm_trace.da at runtime

### DIFF
--- a/lib/open-amp/resource_table.c
+++ b/lib/open-amp/resource_table.c
@@ -43,6 +43,10 @@ static struct fw_resource_table __resource resource_table = RESOURCE_TABLE_INIT;
 
 void rsc_table_get(void **table_ptr, int *length)
 {
+#if defined(CONFIG_RAM_CONSOLE)
+	resource_table.cm_trace.da = (uint32_t)(uintptr_t)ram_console_buf;
+#endif
+
 	*length = sizeof(resource_table);
 #ifdef CONFIG_OPENAMP_COPY_RSC_TABLE
 	*table_ptr = (void *)RSC_TABLE_ADDR;

--- a/lib/open-amp/resource_table.h
+++ b/lib/open-amp/resource_table.h
@@ -85,7 +85,8 @@ struct fw_resource_table {
 	#define CM_TRACE_ENTRY							\
 		.cm_trace = {							\
 			RSC_TRACE,						\
-			(uint32_t)ram_console_buf, CONFIG_RAM_CONSOLE_BUFFER_SIZE, 0,\
+			0, /* Will be initialized at runtime */			\
+			CONFIG_RAM_CONSOLE_BUFFER_SIZE, 0,			\
 			"Zephyr_log",						\
 		},
 #else


### PR DESCRIPTION
When build the openamp_rsc_table with the ram-console snippet, it will report build error: "initializer element is not constant". This patch fix it by moving the initialization of the resource_table.cm_trace.da to runtime.

build error logs:
zephyr/lib/open-amp/resource_table.c:77:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   77 |                 (uint32_t)ram_console_buf, CONFIG_RAM_CONSOLE_BUFFER_SIZE, 0,
      |                 ^
zephyr/lib/open-amp/resource_table.c:77:17: error: initializer element is not constant
zephyr/lib/open-amp/resource_table.c:77:17: note: (near initialization for 'resource_table.cm_trace.da')