### PR TITLE
tests: drivers: build_all: gpio: Fix license

### DIFF
--- a/tests/drivers/build_all/gpio/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/tests/drivers/build_all/gpio/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2025 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 &cpuflpr_rram {


### PR DESCRIPTION
This overlay was mistakenly submitted using a Nordic-specific license. Switch to the standard Apache 2.0.