### PR TITLE
drivers: ieee802154: nrf5: Update nrf-802154 and remove API migration code

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -499,13 +499,9 @@ static bool nrf5_tx_immediate(struct net_pkt *pkt, uint8_t *payload, bool cca)
 		},
 	};
 
-#ifdef NRF_802154_TX_FUNCTIONS_RETURN_ERROR_CODE
 	nrf_802154_tx_error_t result = nrf_802154_transmit_raw(payload, &metadata);
 
 	return result == NRF_802154_TX_ERROR_NONE;
-#else
-	return nrf_802154_transmit_raw(payload, &metadata);
-#endif
 }
 
 #if NRF_802154_CSMA_CA_ENABLED
@@ -522,13 +518,9 @@ static bool nrf5_tx_csma_ca(struct net_pkt *pkt, uint8_t *payload)
 		},
 	};
 
-#ifdef NRF_802154_TX_FUNCTIONS_RETURN_ERROR_CODE
 	nrf_802154_tx_error_t result = nrf_802154_transmit_csma_ca_raw(payload, &metadata);
 
 	return result == NRF_802154_TX_ERROR_NONE;
-#else
-	return nrf_802154_transmit_csma_ca_raw(payload, &metadata);
-#endif
 }
 #endif
 
@@ -585,13 +577,9 @@ static bool nrf5_tx_at(struct nrf5_802154_data *nrf5_radio, struct net_pkt *pkt,
 	uint64_t tx_at = nrf_802154_timestamp_phr_to_shr_convert(
 		net_pkt_timestamp_ns(pkt) / NSEC_PER_USEC);
 
-#ifdef NRF_802154_TX_FUNCTIONS_RETURN_ERROR_CODE
 	nrf_802154_tx_error_t result = nrf_802154_transmit_raw_at(payload, tx_at, &metadata);
 
 	return result == NRF_802154_TX_ERROR_NONE;
-#else
-	return nrf_802154_transmit_raw_at(payload, tx_at, &metadata);
-#endif
 }
 #endif /* CONFIG_NET_PKT_TXTIME */
 

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 57d9fc59c9ea86465b5cd26f0fe2b9dcc520768b
+      revision: e3bf121f1ba72fb1090ef67d19a702b0d77b9f93
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
The new nrf-802154 now has the updated API signatures. The migration code is no longer needed.