### PR TITLE
drivers: usb: udc: sam0: do not select CONFIG_SYS_MEM_BLOCKS

### DIFF
--- a/drivers/usb/udc/Kconfig.sam0
+++ b/drivers/usb/udc/Kconfig.sam0
@@ -6,7 +6,6 @@ config UDC_SAM0
 	default y
 	depends on DT_HAS_ATMEL_SAM0_USB_ENABLED
 	select PINCTRL
-	select SYS_MEM_BLOCKS
 	select EVENTS
 	help
 	  Driver for SAM0 family USB device controller.


### PR DESCRIPTION
Do not select `CONFIG_SYS_MEM_BLOCKS` when enabling the Atmel SAM0 USB device controller driver as the implementation does not use the system memory blocks allocator.