### PR TITLE
soc: stm32g0: Add configurable FLASH prefetch option for G0B0/G0B1/G0C1

### DIFF
--- a/soc/st/stm32/stm32g0x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32g0x/Kconfig.defconfig
@@ -49,4 +49,12 @@ config SHARED_INTERRUPTS
 
 endif # UART_STM32
 
+# Default enable flash prefetch for all G0xx SoCs but G0Bx, G0Cx since ErrataSheet
+# ES0548/ES0549, section "Prefetch failure when branching across flash memory banks
+# which causes code execution corruption and may lead to HardFault interrupt"
+# Project may override this configuration if sure no cross-bank prefetch access is
+# awaited.
+config STM32_FLASH_PREFETCH
+	default y if !SOC_STM32G0B0XX && !SOC_STM32G0B1XX && !SOC_STM32G0C1XX
+
 endif # SOC_SERIES_STM32G0X

--- a/soc/st/stm32/stm32g0x/soc.c
+++ b/soc/st/stm32/stm32g0x/soc.c
@@ -82,7 +82,11 @@ void soc_early_init_hook(void)
 {
 	/* Enable ART Accelerator I-cache and prefetch */
 	LL_FLASH_EnableInstCache();
+
+/* Working around ErrataSheets ES0548/ES0549 section 2.2.10 may prevent enabling flash prefetch */
+#if defined(CONFIG_STM32_FLASH_PREFETCH)
 	LL_FLASH_EnablePrefetch();
+#endif
 
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 16 MHz from HSI */


### PR DESCRIPTION
Add a Kconfig option SOC_FLASH_PREFETCH_ENABLE to control the enabling of
FLASH prefetch on STM32G0B0, G0B1, and G0C1 series. 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/95107