### PR TITLE
samples: bluetooth: peripheral_ht: Use dht0 temperature sensor

### DIFF
--- a/samples/bluetooth/peripheral_ht/Kconfig
+++ b/samples/bluetooth/peripheral_ht/Kconfig
@@ -3,10 +3,10 @@
 
 mainmenu "Bluetooth: Peripheral HT"
 
-if HAS_HW_NRF_TEMP
-
 config SENSOR
-	default y
+	default y if HAS_HW_NRF_TEMP || $(dt_alias_enabled,dht0)
+
+if HAS_HW_NRF_TEMP
 
 config TEMP_NRF5
 	default y

--- a/samples/bluetooth/peripheral_ht/README.rst
+++ b/samples/bluetooth/peripheral_ht/README.rst
@@ -10,9 +10,10 @@ Overview
 Similar to the :zephyr:code-sample:`ble_peripheral` sample, except that this
 application specifically exposes the HT (Health Thermometer) GATT Service.
 
-On Nordic nRF devices, this sample uses the built-in TEMP peripheral to return
-die temperature values. On other boards, it will generate dummy temperature
-values.
+On boards with a ``dht0`` Devicetree alias node, this sample uses this sensor to
+return ambient temperature values. On Nordic nRF devices, it uses the built-in
+TEMP peripheral to return die temperature values.  On other boards, it will
+generate dummy temperature values.
 
 
 Requirements

--- a/samples/bluetooth/peripheral_ht/src/hts.c
+++ b/samples/bluetooth/peripheral_ht/src/hts.c
@@ -27,8 +27,13 @@
 
 #ifdef CONFIG_TEMP_NRF5
 static const struct device *temp_dev = DEVICE_DT_GET_ANY(nordic_nrf_temp);
+#define TEMP_SENSOR_CHAN SENSOR_CHAN_DIE_TEMP
+#elif DT_HAS_ALIAS(dht0)
+static const struct device *temp_dev = DEVICE_DT_GET(DT_ALIAS(dht0));
+#define TEMP_SENSOR_CHAN SENSOR_CHAN_AMBIENT_TEMP
 #else
 static const struct device *temp_dev;
+#define TEMP_SENSOR_CHAN SENSOR_CHAN_AMBIENT_TEMP
 #endif
 
 static uint8_t simulate_htm;
@@ -104,8 +109,7 @@ void hts_indicate(void)
 			printk("sensor_sample_fetch failed return: %d\n", r);
 		}
 
-		r = sensor_channel_get(temp_dev, SENSOR_CHAN_DIE_TEMP,
-				       &temp_value);
+		r = sensor_channel_get(temp_dev, TEMP_SENSOR_CHAN, &temp_value);
 		if (r) {
 			printk("sensor_channel_get failed return: %d\n", r);
 		}


### PR DESCRIPTION
Use the temperature sensor with a `dht0` alias if available in the Bluetooth Health Thermometer sample. This alias is already used by the sensor/dht_polling sample app for temperature measurement, and is supported by several boards in the tree.