### PR TITLE
Add i3c iface support for bmi323 driver

### DIFF
--- a/drivers/sensor/bosch/bmi323/CMakeLists.txt
+++ b/drivers/sensor/bosch/bmi323/CMakeLists.txt
@@ -5,3 +5,4 @@ zephyr_library()
 
 zephyr_library_sources(bmi323.c)
 zephyr_library_sources_ifdef(CONFIG_BMI323_BUS_SPI bmi323_spi.c)
+zephyr_library_sources_ifdef(CONFIG_BMI323_BUS_I3C bmi323_i3c.c)

--- a/drivers/sensor/bosch/bmi323/Kconfig
+++ b/drivers/sensor/bosch/bmi323/Kconfig
@@ -23,7 +23,7 @@ menuconfig BMI323
 	  the bus is initialized, the feature engine is enabled, and INT1 is
 	  initialized.
 
-	  The driver only implements the SPI bus at this time. The driver is
+	  The driver implements the SPI and I3C bus at this time. The driver is
 	  prepared to be expanded with I2C support in the future.
 
 if BMI323
@@ -34,4 +34,9 @@ config BMI323_BUS_SPI
 	depends on $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMI323),spi)
 	select SPI
 
+config BMI323_BUS_I3C
+	bool "BMI323 driver support for I3C bus"
+	default y
+	depends on $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMI323),i3c)
+	select I3C
 endif # BMI323

--- a/drivers/sensor/bosch/bmi323/bmi323.h
+++ b/drivers/sensor/bosch/bmi323/bmi323.h
@@ -10,6 +10,8 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
+#define IMU_BOSCH_BMI323_REG_CHIP_ID    (0x00)
+
 #define IMU_BOSCH_BMI323_REG_ACC_DATA_X (0x03)
 #define IMU_BOSCH_BMI323_REG_ACC_DATA_Y (0x04)
 #define IMU_BOSCH_BMI323_REG_ACC_DATA_Z (0x05)

--- a/drivers/sensor/bosch/bmi323/bmi323_i3c.c
+++ b/drivers/sensor/bosch/bmi323/bmi323_i3c.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bmi323.h"
+#include <zephyr/device.h>
+#include <zephyr/drivers/i3c.h>
+
+#define IMU_BOSCH_BMI323_REG_I3C_DUMMY_OFFSET 0x2
+
+static int bosch_bmi323_i3c_read_words(const void *context, uint8_t offset, uint16_t *words,
+				       uint16_t words_count)
+{
+	const struct i3c_dt_spec *i3c = (const struct i3c_dt_spec *)context;
+	uint8_t dbuf[(words_count * 2) + IMU_BOSCH_BMI323_REG_I3C_DUMMY_OFFSET];
+	int ret;
+
+	ret = i3c_read_dt(i3c, offset, dbuf, sizeof(dbuf));
+	if (!ret) {
+		/* Copy actual data except first 2 bytes of dummy data */
+		memcpy(words, &dbuf[IMU_BOSCH_BMI323_REG_I3C_DUMMY_OFFSET], (words_count * 2));
+	}
+	k_usleep(2);
+
+	return ret;
+}
+
+static int bosch_bmi323_i3c_write_words(const void *context, uint8_t offset, uint16_t *words,
+					uint16_t words_count)
+{
+	const struct i3c_dt_spec *i3c = (const struct i3c_dt_spec *)context;
+	uint8_t dbuf[(words_count * 2) + sizeof(offset)];
+	int ret;
+
+	/* Prepare buffer with offset and data */
+	dbuf[0] = offset;
+	memcpy(&dbuf[sizeof(offset)], words, (words_count * 2));
+
+	ret = i3c_write_dt(i3c, dbuf, sizeof(dbuf));
+	k_usleep(2);
+
+	return ret;
+}
+
+static int bosch_bmi323_i3c_init(const void *context)
+{
+	const struct i3c_dt_spec *i3c = (const struct i3c_dt_spec *)context;
+	uint16_t sensor_id[2];
+	int ret;
+
+	if (i3c_is_ready_dt(i3c) == false) {
+		return -ENODEV;
+	}
+
+	ret = i3c_read_dt(i3c, IMU_BOSCH_BMI323_REG_CHIP_ID, (uint8_t *)sensor_id,
+			(IMU_BOSCH_BMI323_REG_I3C_DUMMY_OFFSET * 2));
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+const struct bosch_bmi323_bus_api bosch_bmi323_i3c_bus_api = {
+	.read_words = bosch_bmi323_i3c_read_words,
+	.write_words = bosch_bmi323_i3c_write_words,
+	.init = bosch_bmi323_i3c_init
+};

--- a/drivers/sensor/bosch/bmi323/bmi323_i3c.h
+++ b/drivers/sensor/bosch/bmi323/bmi323_i3c.h
@@ -1,0 +1,23 @@
+/*
+ *Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_BMI323_BMI323_I3C_H_
+#define ZEPHYR_DRIVERS_SENSOR_BMI323_BMI323_I3C_H_
+
+#include "bmi323.h"
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/i3c.h>
+
+#define BMI323_DEVICE_I3C_BUS(inst)                                                                \
+	extern const struct bosch_bmi323_bus_api bosch_bmi323_i3c_bus_api;                         \
+                                                                                                   \
+	static const struct i3c_dt_spec i3c_spec##inst =                                           \
+		I3C_DT_SPEC_INST_GET(inst);                                                        \
+                                                                                                   \
+	static const struct bosch_bmi323_bus bosch_bmi323_bus_api##inst = {                        \
+		.context = &i3c_spec##inst, .api = &bosch_bmi323_i3c_bus_api}
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_BMI323_BMI323_I3C_H_ */

--- a/dts/bindings/sensor/bosch,bmi323-i3c.yaml
+++ b/dts/bindings/sensor/bosch,bmi323-i3c.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Alif Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "bosch,bmi323"
+
+include: ["i3c-device.yaml", "bosch,bmi323.yaml"]

--- a/dts/bindings/sensor/bosch,bmi323-spi.yaml
+++ b/dts/bindings/sensor/bosch,bmi323-spi.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 Trackunit Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "bosch,bmi323"
+
+include: ["spi-device.yaml", "bosch,bmi323.yaml"]

--- a/dts/bindings/sensor/bosch,bmi323.yaml
+++ b/dts/bindings/sensor/bosch,bmi323.yaml
@@ -1,9 +1,7 @@
 # Copyright (c) 2023 Trackunit Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-compatible: "bosch,bmi323"
-
-include: ["spi-device.yaml", "sensor-device.yaml"]
+description: BMI323 motion tracking device
 
 properties:
   int-gpios:


### PR DESCRIPTION
Add I3C interface support for the BMI323 sensor driver, complementing the existing SPI interface.

At i3c.h, introduce device tree helpers for I3C device configuration:
- Add i3c_dt_spec structure to hold DT bus and address info
- Add I3C_DT_SPEC_GET and I3C_DT_SPEC_INST_GET macros
- Add i3c_is_ready_dt() for bus readiness check
- Add i3c_write_dt() and i3c_read_dt() for DT-based I3C operations

At sensor: i3c interface:
- Added new Kconfig option BMI323_BUS_I3C for I3C bus support
- Created bmi323_i3c.c for I3C-specific implementation
- Updated CMakeLists.txt to include the new I3C source file
- Added device tree bindings for I3C interface (bosch,bmi323-i3c.yaml)
- Modified main driver to handle both SPI and I3C bus types
- Note: Soft reset is disabled for I3C mode as it causes the target
  to revert to I2C mode, making it unreachable via I3C addressing
- Added chip ID register definition for I3C compatibility

The driver now supports both SPI and I3C interfaces through device tree configuration, making it more versatile for different hardware designs.