### PR TITLE
timer: espressif: keep alarm disable support only for mcuboot

### DIFF
--- a/drivers/timer/Kconfig.esp32
+++ b/drivers/timer/Kconfig.esp32
@@ -11,7 +11,7 @@ config ESP32_SYS_TIMER
 	default y
 	select TICKLESS_CAPABLE
 	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
+	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT if MCUBOOT
 	help
 	  This option enables the system timer driver for the Espressif ESP32Cx
 	  and provides the standard "system clock driver" interface.


### PR DESCRIPTION
There is no need to disable systimer in application level as the restart procedure automatically handles it.