### PR TITLE
ARMV7 MMU : support of the NORMAL and memory-ordered memory type

### DIFF
--- a/arch/arm/core/mmu/arm_mmu.c
+++ b/arch/arm/core/mmu/arm_mmu.c
@@ -890,6 +890,9 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 
 	switch (flags & K_MEM_CACHE_MASK) {
 
+	case K_MEM_ARM_NORMAL_NC:
+		conv_flags |= MT_NORMAL;
+		break;
 	case K_MEM_CACHE_NONE:
 	default:
 		conv_flags |= MT_DEVICE;

--- a/include/zephyr/arch/arm/mmu/arm_mem.h
+++ b/include/zephyr/arch/arm/mmu/arm_mem.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_ARM_MEM_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_ARM_MEM_H_
+
+/*
+ * Define ARM specific memory flags used by k_mem_map_phys_bare()
+ * followed public definitions in include/kernel/mm.h.
+ */
+
+/** ARM Specific flags: normal memory with Non-cacheable */
+#define K_MEM_ARM_NORMAL_NC	5
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_ARM_MEM_H_ */

--- a/include/zephyr/kernel/mm.h
+++ b/include/zephyr/kernel/mm.h
@@ -11,6 +11,8 @@
 #include <zephyr/toolchain.h>
 #if defined(CONFIG_ARM_MMU) && defined(CONFIG_ARM64)
 #include <zephyr/arch/arm64/arm_mem.h>
+#elif defined(CONFIG_ARM_AARCH32_MMU)
+#include <zephyr/arch/arm/mmu/arm_mem.h>
 #endif /* CONFIG_ARM_MMU && CONFIG_ARM64 */
 
 #include <zephyr/kernel/internal/mm.h>


### PR DESCRIPTION
This PR fixes an `Alignment fault `issue encountered when running the `/sample/net/zperf` example
on an STM32MP135F-DK board that embeds a Cortex-A7.


```
uart:~$ 
*** Booting Zephyr OS build v4.2.0-4059-g7a2552dfaa6b ***
[00:00:02.335,000] <inf> net_config: Initializing network
[00:00:02.335,000] <inf> net_config: Waiting interface 1 (0xd00017e0) to be up...
[00:00:02.381,000] <inf> microchip_lan8742: PHY (0) Link speed 100 Mb, full duplex
[00:00:02.381,000] <inf> net_config: Interface 1 (0xd00017e0) coming up
[00:00:02.381,000] <inf> net_config: IPv4 address: 192.0.2.1
[00:00:02.381,000] <err> os: ***** DATA ABORT *****
[00:00:02.381,000] <err> os: Alignment Fault @ 0x2ffe000e
[00:00:02.381,000] <err> os: r0/a1:  0x2ffe000e  r1/a2:  0xd00658a0  r2/a3:  0x00000030
[00:00:02.381,000] <err> os: r3/a4:  0x00000060 r12/ip:  0x2ffe003e r14/lr:  0xc002b374
[00:00:02.381,000] <err> os:  xpsr:  0x8000011f
[00:00:02.381,000] <err> os: Faulting instruction address (r15/pc): 0xc000103c
[00:00:02.381,000] <err> os: >>> ZEPHYR FATAL ERROR 46: Unknown error on CPU 0
[00:00:02.381,000] <err> os: Current thread: 0xd00195d8 (tx_q[0])
[00:00:02.517,000] <err> os: Halting system
uart:~$ 
```

On this board, a memory region is defined and mapped in the MMU to store Ethernet descriptors and buffers. This memory must be non-cacheable because it is accessed by both the network library and the Ethernet peripheral DMA.

```dts
eth_ram: sram@30000000 {
    compatible = "zephyr,memory-region", "mmio-sram";
    reg = <0x2FFE0000 DT_SIZE_K(16)>;
    #memory-region-cells = <0>;
    zephyr,memory-region = "ETH_SRAM";
};
```
The issue occurs in `net_pkt_cursor_operate()`, where `pkt_cursor_advance()` returns 0xE,
resulting in a memcpy to address 0xd800000e, which is not aligned on a 32-bit word boundary.

The root cause is that the MMU sets the memory type to device if `K_MEM_CACHE_NONE` is set.
In this use case, I would need  to register a normal, non-cacheable memory region since this region corresponds to RAM.

This pull request introduces the ability to select the memory type for MMU attributes.

Memory can then be registered using syntax like this:

```c
/* Map memory region for DMA descriptor and buffer as non-cacheable */
k_mem_map_phys_bare(&desc_uncached_addr,
                    DT_REG_ADDR(ETH_DMA_REGION),
                    DT_REG_SIZE(ETH_DMA_REGION),
                    K_MEM_PERM_RW | K_MEM_DIRECT_MAP | K_MEM_CACHE_NONE |
                    K_MEM_CACHE_NONE_NORMAL);
```
