### PR TITLE
drivers: modem: extract common DTS bindings

### DIFF
--- a/dts/bindings/modem/nordic,nrf91-slm.yaml
+++ b/dts/bindings/modem/nordic,nrf91-slm.yaml
@@ -2,8 +2,4 @@ description: Nordic nRF91 series running the Serial LTE Modem application
 
 compatible: "nordic,nrf91-slm"
 
-include: uart-device.yaml
-
-properties:
-  mdm-power-gpios:
-    type: phandle-array
+include: zephyr,cellular-modem-device.yaml

--- a/dts/bindings/modem/quectel,bg95.yaml
+++ b/dts/bindings/modem/quectel,bg95.yaml
@@ -5,7 +5,7 @@ description: Quectel BG95 modem
 
 compatible: "quectel,bg95"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-power-gpios:

--- a/dts/bindings/modem/quectel,bg9x.yaml
+++ b/dts/bindings/modem/quectel,bg9x.yaml
@@ -5,15 +5,12 @@ description: quectel BG9x modem
 
 compatible: "quectel,bg9x"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-power-gpios:
     type: phandle-array
     required: true
-
-  mdm-reset-gpios:
-    type: phandle-array
 
   mdm-dtr-gpios:
     type: phandle-array

--- a/dts/bindings/modem/quectel,eg25-g.yaml
+++ b/dts/bindings/modem/quectel,eg25-g.yaml
@@ -2,7 +2,7 @@ description: Quectel EG25-G modem
 
 compatible: "quectel,eg25-g"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-reset-gpios:

--- a/dts/bindings/modem/quectel,eg800q.yaml
+++ b/dts/bindings/modem/quectel,eg800q.yaml
@@ -2,7 +2,7 @@ description: Quectel EG800Q modem
 
 compatible: "quectel,eg800q"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-power-gpios:

--- a/dts/bindings/modem/simcom,a76xx.yaml
+++ b/dts/bindings/modem/simcom,a76xx.yaml
@@ -5,7 +5,7 @@ description: Simcom A76XX modem
 
 compatible: "simcom,a76xx"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-power-gpios:

--- a/dts/bindings/modem/simcom,sim7080.yaml
+++ b/dts/bindings/modem/simcom,sim7080.yaml
@@ -5,7 +5,7 @@ description: Simcom Sim7080 modem
 
 compatible: "simcom,sim7080"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-power-gpios:

--- a/dts/bindings/modem/sqn,gm02s.yaml
+++ b/dts/bindings/modem/sqn,gm02s.yaml
@@ -5,12 +5,9 @@ description: Sequans Monarch 2 GM02S Modem
 
 compatible: "sqn,gm02s"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-reset-gpios:
     type: phandle-array
     required: true
-
-  mdm-wake-gpios:
-    type: phandle-array

--- a/dts/bindings/modem/swir,hl7800.yaml
+++ b/dts/bindings/modem/swir,hl7800.yaml
@@ -8,7 +8,7 @@ description: Sierra Wireless HL7800 Modem
 
 compatible: "swir,hl7800"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-wake-gpios:

--- a/dts/bindings/modem/telit,me310g1.yaml
+++ b/dts/bindings/modem/telit,me310g1.yaml
@@ -2,7 +2,7 @@ description: Telit ME310G1 Modem
 
 compatible: "telit,me310g1"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-power-gpios:

--- a/dts/bindings/modem/telit,me910g1.yaml
+++ b/dts/bindings/modem/telit,me910g1.yaml
@@ -5,7 +5,7 @@ description: Telit ME910G1 Modem
 
 compatible: "telit,me910g1"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-power-gpios:

--- a/dts/bindings/modem/u-blox,lara-r6.yaml
+++ b/dts/bindings/modem/u-blox,lara-r6.yaml
@@ -5,12 +5,9 @@ description: u-blox LARA-R6 modem
 
 compatible: "u-blox,lara-r6"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-power-gpios:
     type: phandle-array
     required: true
-
-  mdm-reset-gpios:
-    type: phandle-array

--- a/dts/bindings/modem/u-blox,sara-r4.yaml
+++ b/dts/bindings/modem/u-blox,sara-r4.yaml
@@ -5,15 +5,12 @@ description: u-blox SARA-R4 modem
 
 compatible: "u-blox,sara-r4"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-power-gpios:
     type: phandle-array
     required: true
-
-  mdm-reset-gpios:
-    type: phandle-array
 
   mdm-vint-gpios:
     type: phandle-array

--- a/dts/bindings/modem/u-blox,sara-r5.yaml
+++ b/dts/bindings/modem/u-blox,sara-r5.yaml
@@ -5,11 +5,4 @@ description: u-blox SARA-R5 modem
 
 compatible: "u-blox,sara-r5"
 
-include: uart-device.yaml
-
-properties:
-  mdm-power-gpios:
-    type: phandle-array
-
-  mdm-reset-gpios:
-    type: phandle-array
+include: zephyr,cellular-modem-device.yaml

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -5,7 +5,7 @@ description: WNC-M14A2A LTE-M modem
 
 compatible: "wnc,m14a2a"
 
-include: uart-device.yaml
+include: zephyr,cellular-modem-device.yaml
 
 properties:
   mdm-boot-mode-sel-gpios:

--- a/dts/bindings/modem/zephyr,cellular-modem-device.yaml
+++ b/dts/bindings/modem/zephyr,cellular-modem-device.yaml
@@ -1,0 +1,19 @@
+# Copyright 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Common properties for Zephyr cellular modems
+
+include: uart-device.yaml
+
+properties:
+  mdm-power-gpios:
+    type: phandle-array
+    description: GPIO for modem power control
+
+  mdm-reset-gpios:
+    type: phandle-array
+    description: GPIO for modem reset
+
+  mdm-wake-gpios:
+    type: phandle-array
+    description: GPIO for modem wake


### PR DESCRIPTION
Extract common DTS bindings to zephyr,cellular-modem-device.yaml
as these are referred in the modem_cellular.c in the
MODEM_CELLULAR_DEFINE_INSTANCE() macro.
