### PR TITLE
native_simulator: include folder for missing <asm/errno.h>

### DIFF
--- a/scripts/native_simulator/Makefile
+++ b/scripts/native_simulator/Makefile
@@ -65,6 +65,7 @@ NSI_OPT?=-O0
 NSI_WARNINGS?=-Wall -Wpedantic
 #  Preprocessor flags
 NSI_CPPFLAGS?=-D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED
+NSI_CPPFLAGS+=-I/usr/include/x86_64-linux-gnu
 
 NO_PIE_CO:=-fno-pie -fno-pic
 DEPENDFLAGS:=-MMD -MP


### PR DESCRIPTION
On an x86_64 Ubuntu host, the following command would result in an error.

```shell
west build -p -b native_sim/native tests/net/wifi/configs -T wifi.build.hostapd_ap
...
In file included from /usr/include/bits/errno.h:26,
                 from /usr/include/errno.h:28,
                 from ~/zephyrproject/zephyr/scripts/native_simulator//common/src/nce.c:24:
/usr/include/linux/errno.h:1:10: fatal error: asm/errno.h:  No such file or directory
    1 | #include <asm/errno.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
```

Include `/usr/include/x86_64-linux-gnu` in the search path so that the build succeeds.

Fixes #96566