### PR TITLE
manifest: update hostap module to correct time.h and signal.h paths

### DIFF
--- a/scripts/native_simulator/Makefile
+++ b/scripts/native_simulator/Makefile
@@ -65,6 +65,7 @@ NSI_OPT?=-O0
 NSI_WARNINGS?=-Wall -Wpedantic
 #  Preprocessor flags
 NSI_CPPFLAGS?=-D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED
+NSI_CPPFLAGS+=-I/usr/include/x86_64-linux-gnu
 
 NO_PIE_CO:=-fno-pie -fno-pic
 DEPENDFLAGS:=-MMD -MP

--- a/west.yml
+++ b/west.yml
@@ -286,7 +286,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 0798bf0faff40919bd577f1c8f75a2f9baae6299
+      revision: pull/105/head
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
Update the hostap module to use standard include paths for the ISO C header files time.h and signal.h

Also includes changes from https://github.com/zephyrproject-rtos/zephyr/pull/96582 to ensure that building works.

Testing done:
```shell
west build -p -b native_sim/native tests/net/wifi/configs -T wifi.build.hostapd_ap
```

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/96566