### PR TITLE
Bluetooth: Controller: fix assertion check for ptc value

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -489,20 +489,22 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 	lll->irc = PDU_BIG_INFO_IRC_GET(bi);
 	if (lll->pto) {
 		uint8_t nse;
+		uint8_t ptc;
 
 		nse = lll->irc * lll->bn; /* 4 bits * 3 bits, total 7 bits */
 		if (nse >= lll->nse) {
 			return;
 		}
 
-		lll->ptc = lll->nse - nse;
+		ptc = lll->nse - nse;
 
 		/* FIXME: Do not remember why ptc is 4 bits, it should be 5 bits as ptc is a
 		 *        running buffer offset related to nse.
 		 *        Fix ptc and ptc_curr definitions, until then we keep an assertion check
 		 *        here.
 		 */
-		LL_ASSERT(lll->ptc <= BIT_MASK(4));
+		LL_ASSERT(ptc <= BIT_MASK(4));
+		lll->ptc = ptc;
 	} else {
 		lll->ptc = 0U;
 	}


### PR DESCRIPTION
Fix the issue reported by Coverity CID 487708. The LL_ASSERT was performed on lll->ptc, which is a 4-bit bitfield and therefore always succeeds. Instead, the computation (lll->nse - nse) should be checked to ensure it falls within the 4-bit value range before assigning it to lll->ptc.

Fixes: #84710 