### PR TITLE
manifest: update hostap module to correct time.h and signal.h paths

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -286,7 +286,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 0798bf0faff40919bd577f1c8f75a2f9baae6299
+      revision: pull/105/head
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
Update the hostap module to use non-prefixed paths for the ISO C time.h and signal.h headers.

Alternative to 
https://github.com/zephyrproject-rtos/zephyr/pull/96583

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/96566