### PR TITLE
Bluetooth: Controller: Deprecate bt_ctlr_set_public_addr

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -125,6 +125,9 @@ Bluetooth Controller
     * :kconfig:option:`CONFIG_BT_CTRL_ADV_ADI_IN_SCAN_RSP` to
       :kconfig:option:`CONFIG_BT_CTLR_ADV_ADI_IN_SCAN_RSP`
 
+   * :c:func:`bt_ctlr_set_public_addr` is deprecated. To set the public Bluetooth device address,
+     sending a vendor specific HCI command with :c:struct:`bt_hci_cp_vs_write_bd_addr` can be used.
+
 .. zephyr-keep-sorted-start re(^\w)
 
 Bluetooth Audio

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -74,6 +74,9 @@ Deprecated APIs and options
 
 * :kconfig:option:`CONFIG_POSIX_READER_WRITER_LOCKS` is deprecated. Use :kconfig:option:`CONFIG_POSIX_RW_LOCKS` instead.
 
+* :c:func:`bt_ctlr_set_public_addr` is deprecated in favor of using
+  :c:struct:`bt_hci_cp_vs_write_bd_addr` for setting the public Bluetooth device address.
+
 New APIs and options
 ====================
 

--- a/include/zephyr/bluetooth/controller.h
+++ b/include/zephyr/bluetooth/controller.h
@@ -29,7 +29,7 @@ extern "C" {
  *
  *  @param addr Public address
  */
-void bt_ctlr_set_public_addr(const uint8_t *addr);
+__deprecated void bt_ctlr_set_public_addr(const uint8_t *addr);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Deprecate the bt_ctlr_set_public_addr function.
It is unused in the tree, and there is a vendor specific HCI
command that can be used for the same purpose.
The function does not have any tests and is basically
unmaintained.
Additionally it is the only function in the public
controller API, and removing it would allow us to
remove that part completely as unused.