### PR TITLE
drivers: uart: microchip/g1: Add support to interrupts

### DIFF
--- a/drivers/serial/Kconfig.mchp
+++ b/drivers/serial/Kconfig.mchp
@@ -6,6 +6,7 @@ config UART_MCHP_SERCOM_G1
 	default y
 	depends on DT_HAS_MICROCHIP_SERCOM_G1_UART_ENABLED
 	select SERIAL_HAS_DRIVER
+	select SERIAL_SUPPORT_INTERRUPT
 	select PINCTRL
 	help
 	  This option enables UART driver for group (g1) of SERCOM peripherals.

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51n19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51n19a.dtsi
@@ -7,3 +7,4 @@
 #include <mem.h>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51n20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51n20a.dtsi
@@ -7,3 +7,4 @@
 #include <mem.h>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51p19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51p19a.dtsi
@@ -7,3 +7,4 @@
 #include <mem.h>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_p.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51p20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51p20a.dtsi
@@ -7,3 +7,4 @@
 #include <mem.h>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_p.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51n19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51n19a.dtsi
@@ -7,3 +7,4 @@
 #include <mem.h>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51n20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51n20a.dtsi
@@ -7,3 +7,4 @@
 #include <mem.h>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53n19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53n19a.dtsi
@@ -7,3 +7,4 @@
 #include <mem.h>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53n20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53n20a.dtsi
@@ -7,3 +7,4 @@
 #include <mem.h>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54n19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54n19a.dtsi
@@ -7,3 +7,4 @@
 #include <mem.h>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54n20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54n20a.dtsi
@@ -7,3 +7,4 @@
 #include <mem.h>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54p19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54p19a.dtsi
@@ -7,3 +7,4 @@
 #include <mem.h>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_p.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54p20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54p20a.dtsi
@@ -7,3 +7,4 @@
 #include <mem.h>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_p.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	soc {
+		sercom6: sercom@43000800 {
+			compatible = "microchip,sercom-g1";
+			status = "disabled";
+			reg = <0x43000800 0x31>;
+			interrupts = <70 0>, <71 0>, <72 0>, <73 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_SERCOM6>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM6_CORE>;
+			clock-names = "mclk", "gclk";
+		};
+
+		sercom7: sercom@43000c00 {
+			compatible = "microchip,sercom-g1-i2c";
+			status = "disabled";
+			reg = <0x43000c00 0x31>;
+			interrupts = <74 0>, <75 0>, <76 0>, <77 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_SERCOM7>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM7_CORE>;
+			clock-names = "mclk", "gclk";
+		};
+	};
+};

--- a/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_p.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_p.dtsi
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	soc {
+		sercom6: sercom@43000800 {
+			compatible = "microchip,sercom-g1";
+			status = "disabled";
+			reg = <0x43000800 0x31>;
+			interrupts = <70 0>, <71 0>, <72 0>, <73 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_SERCOM6>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM6_CORE>;
+			clock-names = "mclk", "gclk";
+		};
+
+		sercom7: sercom@43000c00 {
+			compatible = "microchip,sercom-g1-i2c";
+			status = "disabled";
+			reg = <0x43000c00 0x31>;
+			interrupts = <74 0>, <75 0>, <76 0>, <77 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_SERCOM7>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM7_CORE>;
+			clock-names = "mclk", "gclk";
+		};
+	};
+};

--- a/dts/bindings/serial/microchip,sercom-g1-uart.yaml
+++ b/dts/bindings/serial/microchip,sercom-g1-uart.yaml
@@ -78,3 +78,18 @@ properties:
     type: boolean
     description: |
       Enable collision detection for half-duplex mode.
+
+  run-in-standby-en:
+    type: int
+    enum:
+      - 0
+      - 1
+    default: 1
+    description: |
+      This property defines the functionality in standby sleep mode.
+
+      0: Generic clock is disabled when ongoing transfer is finished. The device
+         will not wake up on Transfer Complete interrupt unless the appropriate
+         ONDEMAND bits are set in the clocking chain.
+      1: Wake on Receive Complete interrupt. Generic clock is enabled in all sleep modes.
+         Any interrupt can wake up the device.


### PR DESCRIPTION
This update introduces more functionality to UART G1 driver, including implementation of interrupt API.
Additionally, Device Tree bindings are added to support SERCOM modules in both 'n' and 'p' SoC variants. 