### PR TITLE
soc: ti: cc23x0: drop deprecated CONFIG_BUILD_NO_GAP_FILL option

### DIFF
--- a/soc/ti/simplelink/cc23x0/Kconfig
+++ b/soc/ti/simplelink/cc23x0/Kconfig
@@ -18,7 +18,6 @@ config SOC_SERIES_CC23X0
 	select DYNAMIC_THREAD_ALLOC
 	select THREAD_STACK_INFO
 	select BUILD_OUTPUT_HEX
-	select BUILD_NO_GAP_FILL
 
 menu "Bootloader Configuration"
 depends on SOC_SERIES_CC23X0


### PR DESCRIPTION
The CONFIG_BUILD_NO_GAP_FILL option became obsolete after commit 2e8868c16e5e and has since been deprecated.

Remove the unused Kconfig select from the CC23x0 SoC configuration.