### PR TITLE
Add resource table section for imx8m imx9 series soc

### DIFF
--- a/soc/nxp/imx/CMakeLists.txt
+++ b/soc/nxp/imx/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(${SOC_SERIES})
@@ -9,3 +9,7 @@ zephyr_include_directories(${SOC_SERIES})
 zephyr_include_directories(${SOC_SERIES}/include)
 
 zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)
+
+if(CONFIG_CPU_CORTEX_A)
+  zephyr_linker_sources_ifdef(CONFIG_OPENAMP_RSC_TABLE SECTIONS rsc_table.ld)
+endif()

--- a/soc/nxp/imx/rsc_table.ld
+++ b/soc/nxp/imx/rsc_table.ld
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+SECTION_PROLOGUE(.resource_table,, SUBALIGN(8))
+{
+	KEEP(*(.resource_table*))
+} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)


### PR DESCRIPTION
Add .resource_table section in A-core linker scripts for imx8m and imx9 series SOCs.