### PR TITLE
Bluetooth: Classic: add supervision timeout feature

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -3316,6 +3316,21 @@ int bt_conn_br_exit_sniff_mode(struct bt_conn *conn);
  */
 int bt_conn_br_get_supervision_timeout(struct bt_conn *conn, uint16_t *timeout);
 
+/** @brief Set BR/EDR supervision timeout.
+ *
+ *  Each physical link has a timer that is used for link supervision.
+ *  This timer is used to detect physical link loss caused by devices
+ *  moving out of range, or being blocked by interference, a device's
+ *  power-down, or other similar failure cases.
+ *
+ *  @param conn  Connection object.
+ *  @param timeout Link supervision timeout, Range: 0x0001 to 0xFFFF
+ *                 Time Range: 0.625 ms to 40.9 s.
+ *
+ *  @return  Zero for success, non-zero otherwise.
+ */
+int bt_conn_br_set_supervision_timeout(struct bt_conn *conn, uint16_t timeout);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -3305,6 +3305,17 @@ int bt_conn_br_enter_sniff_mode(struct bt_conn *conn, uint16_t min_interval,
 int bt_conn_br_exit_sniff_mode(struct bt_conn *conn);
 #endif /* CONFIG_BT_POWER_MODE_CONTROL */
 
+/** @brief Read BR/EDR supervision timeout.
+ *
+ *  Read the current link supervision timeout value for a BR/EDR connection.
+ *
+ *  @param conn     Connection object.
+ *  @param timeout  Pointer to store the supervision timeout value.
+ *
+ *  @return  Zero for success, non-zero otherwise.
+ */
+int bt_conn_br_get_supervision_timeout(struct bt_conn *conn, uint16_t *timeout);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -880,6 +880,16 @@ struct bt_hci_rp_read_link_supervision_timeout {
 	uint16_t timeout;
 } __packed;
 
+/** HCI opcode for Write Link Supervision Timeout. */
+#define BT_HCI_OP_WRITE_LINK_SUPERVISION_TIMEOUT    BT_OP(BT_OGF_BASEBAND, 0x0037) /* 0x0c37 */
+/** HCI command parameters for Write Link Supervision Timeout. */
+struct bt_hci_cp_write_link_supervision_timeout {
+	/** Connection handle. */
+	uint16_t handle;
+	/** Link supervision timeout. */
+	uint16_t timeout;
+} __packed;
+
 #define BT_HCI_OP_WRITE_CURRENT_IAC_LAP         BT_OP(BT_OGF_BASEBAND, 0x003a) /* 0x0c3a */
 struct bt_hci_iac_lap {
 	uint8_t iac[3];

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -863,6 +863,23 @@ struct bt_hci_cp_host_num_completed_packets {
 	struct bt_hci_handle_count h[0];
 } __packed;
 
+/** HCI opcode for Read Link Supervision Timeout. */
+#define BT_HCI_OP_READ_LINK_SUPERVISION_TIMEOUT     BT_OP(BT_OGF_BASEBAND, 0x0036) /* 0x0c36 */
+/** HCI command parameters for Read Link Supervision Timeout. */
+struct bt_hci_cp_read_link_supervision_timeout {
+	/** Connection handle. */
+	uint16_t handle;
+} __packed;
+/** HCI response parameters for Read Link Supervision Timeout. */
+struct bt_hci_rp_read_link_supervision_timeout {
+	/** Status. */
+	uint8_t  status;
+	/** Connection handle. */
+	uint16_t handle;
+	/** Link supervision timeout. */
+	uint16_t timeout;
+} __packed;
+
 #define BT_HCI_OP_WRITE_CURRENT_IAC_LAP         BT_OP(BT_OGF_BASEBAND, 0x003a) /* 0x0c3a */
 struct bt_hci_iac_lap {
 	uint8_t iac[3];

--- a/subsys/bluetooth/host/classic/conn_br.c
+++ b/subsys/bluetooth/host/classic/conn_br.c
@@ -275,3 +275,50 @@ int bt_conn_br_set_role_switch_enable(const struct bt_conn *conn, bool enable)
 	link_policy_settings ^= BT_HCI_LINK_POLICY_SETTINGS_ENABLE_ROLE_SWITCH;
 	return bt_conn_br_write_link_policy_settings(conn, link_policy_settings);
 }
+
+int bt_conn_br_get_supervision_timeout(struct bt_conn *conn, uint16_t *timeout)
+{
+	struct bt_hci_cp_read_link_supervision_timeout *cp;
+	struct bt_hci_rp_read_link_supervision_timeout *rp;
+	struct net_buf *buf, *rsp;
+	int err;
+
+	if (conn == NULL) {
+		LOG_DBG("conn is NULL");
+		return -EINVAL;
+	}
+
+	if (timeout == NULL) {
+		LOG_DBG("timeout pointer is NULL");
+		return -EINVAL;
+	}
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_BR)) {
+		LOG_DBG("Invalid connection type: %u for %p", conn->type, conn);
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_alloc(K_FOREVER);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+
+	if (net_buf_tailroom(buf) < sizeof(*cp)) {
+		net_buf_unref(buf);
+		return -ENOMEM;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_READ_LINK_SUPERVISION_TIMEOUT, buf, &rsp);
+	if (err != 0) {
+		return err;
+	}
+
+	rp = (void *)rsp->data;
+	*timeout = sys_le16_to_cpu(rp->timeout);
+	net_buf_unref(rsp);
+
+	return 0;
+}

--- a/subsys/bluetooth/host/classic/conn_br.c
+++ b/subsys/bluetooth/host/classic/conn_br.c
@@ -322,3 +322,35 @@ int bt_conn_br_get_supervision_timeout(struct bt_conn *conn, uint16_t *timeout)
 
 	return 0;
 }
+
+int bt_conn_br_set_supervision_timeout(struct bt_conn *conn, uint16_t timeout)
+{
+	struct bt_hci_cp_write_link_supervision_timeout *cp;
+	struct net_buf *buf;
+
+	if (conn == NULL) {
+		LOG_DBG("conn is NULL");
+		return -EINVAL;
+	}
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_BR)) {
+		LOG_DBG("Invalid connection type: %u for %p", conn->type, conn);
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_alloc(K_FOREVER);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+
+	if (net_buf_tailroom(buf) < sizeof(*cp)) {
+		net_buf_unref(buf);
+		return -ENOMEM;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->timeout = sys_cpu_to_le16(timeout);
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_LINK_SUPERVISION_TIMEOUT, buf, NULL);
+}


### PR DESCRIPTION
Bluetooth: Classic: add supervision timeout read/write support

This PR adds APIs to read and write the link supervision timeout for BR/EDR connections, enabling applications to monitor and configure the link supervision timer used for detecting physical link loss.

### Changes

Commit 1: add read supervision timeout feature
- Add bt_conn_br_get_supervision_timeout() API to read the current link supervision timeout value via HCI Read Link Supervision Timeout command.
- Define BT_HCI_OP_READ_LINK_SUPERVISION_TIMEOUT opcode and related HCI structs in hci_types.h.

Commit 2: add write supervision timeout feature
- Add bt_conn_br_set_supervision_timeout() API to configure the link supervision timeout via HCI Write Link Supervision Timeout command.
- Define BT_HCI_OP_WRITE_LINK_SUPERVISION_TIMEOUT opcode and related HCI structs in hci_types.h.
