### PR TITLE
modem: cmux: Handle C/R bit from address field

### DIFF
--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -142,10 +142,11 @@ struct modem_cmux {
 
 	/* State */
 	enum modem_cmux_state state;
-	bool flow_control_on;
+	bool flow_control_on : 1;
+	bool initiator : 1;
 
 	/* Work lock */
-	bool attached;
+	bool attached : 1;
 	struct k_spinlock work_lock;
 
 	/* Receive state*/

--- a/tests/subsys/modem/modem_cmux/src/main.c
+++ b/tests/subsys/modem/modem_cmux/src/main.c
@@ -886,4 +886,22 @@ ZTEST(modem_cmux, test_modem_cmux_split_large_data)
 		     "Incorrect number of bytes transmitted %d", ret);
 }
 
+ZTEST(modem_cmux, test_modem_cmux_invalid_cr)
+{
+	uint32_t events;
+
+	/* We are initiator, so any CMD with CR set should be dropped */
+	modem_backend_mock_put(&bus_mock, cmux_frame_control_cld_cmd,
+			       sizeof(cmux_frame_control_cld_cmd));
+
+	modem_backend_mock_put(&bus_mock, cmux_frame_control_sabm_cmd,
+			       sizeof(cmux_frame_control_sabm_cmd));
+
+	events = k_event_wait_all(&cmux_event,
+				  (MODEM_CMUX_EVENT_CONNECTED | MODEM_CMUX_EVENT_DISCONNECTED),
+				  false, K_MSEC(100));
+
+	zassert_false(events, "Wrong CMD should have been ignored");
+}
+
 ZTEST_SUITE(modem_cmux, NULL, test_modem_cmux_setup, test_modem_cmux_before, NULL, NULL);


### PR DESCRIPTION
The C/R bit in the address field should be handled as explained in 5.2.1.2 in the spec (3GPP TS 127.010).

To detect if the frame is a command or a response, we need to know who was the initiator of the CMUX channel.

>    Initiator is the station that take the initiative to initialize
>    the multiplexer (i.e. sends the SABM command at DLCI 0 )

See the table from given section of the specification.

Also, on UIH frames 5.4.3.1 says
>    The frames sent by the initiating station have the C/R bit set to 1
>    and those sent by the responding station have the C/R bit set to 0.

NOTE: This is different than a C/R bit in the Type field.