### PR TITLE
Bluetooth: Classic: add page/inquiry scan params and cod feature

### DIFF
--- a/include/zephyr/bluetooth/assigned_numbers.h
+++ b/include/zephyr/bluetooth/assigned_numbers.h
@@ -1462,6 +1462,335 @@ enum bt_audio_location {
 
 /** @} */ /* end of @name Company Identifiers */
 
+/**
+ * @name Defined BR Class of Device (CoD) values
+ * @{
+ */
+
+#define BT_COD(major_service, major_device, minor_device)                                          \
+	(((uint32_t)major_service << 13) | ((uint32_t)major_device << 8) |                         \
+	 ((uint32_t)minor_device << 2))
+#define BT_COD_VALID(cod) ((0 == (cod[0] & (BIT(0) | BIT(1)))) ? true : false)
+#define BT_COD_MAJOR_SERVICE_CLASSES(cod)                                                          \
+	((((uint32_t)cod[2] & 0xFF) >> 5) | (((uint32_t)cod[1] & 0xD0) >> 5))
+#define BT_COD_MAJOR_DEVICE_CLASS(cod) ((((uint32_t)cod[1]) & 0x1FUL))
+#define BT_COD_MINOR_DEVICE_CLASS(cod) (((((uint32_t)cod[0]) & 0xFF) >> 2))
+
+/**
+ * @name Major Service Classes
+ * @{
+ */
+
+/** Limited Discoverable Mode service class */
+#define BT_COD_MAJOR_SVC_CLASS_LIMITED_DISCOVER BIT(13)
+/** LE Audio service class */
+#define BT_COD_MAJOR_SVC_CLASS_LE_AUDIO         BIT(14)
+/** Reserved service class */
+#define BT_COD_MAJOR_SVC_CLASS_RESERVED         BIT(15)
+/** Positioning service class */
+#define BT_COD_MAJOR_SVC_CLASS_POSITIONING      BIT(16)
+/** Networking service class */
+#define BT_COD_MAJOR_SVC_CLASS_NETWORKING       BIT(17)
+/** Rendering service class */
+#define BT_COD_MAJOR_SVC_CLASS_RENDERING        BIT(18)
+/** Capturing service class */
+#define BT_COD_MAJOR_SVC_CLASS_CAPTURING        BIT(19)
+/** Object Transfer service class */
+#define BT_COD_MAJOR_SVC_CLASS_OBJECT_TRANSFER  BIT(20)
+/** Audio service class */
+#define BT_COD_MAJOR_SVC_CLASS_AUDIO            BIT(21)
+/** Telephony service class */
+#define BT_COD_MAJOR_SVC_CLASS_TELEPHONY        BIT(22)
+/** Information service class */
+#define BT_COD_MAJOR_SVC_CLASS_INFORMATION      BIT(23)
+
+/** @} */ /* end of Major Service Classes */
+
+/**
+ * @name Major Device Class
+ * @{
+ */
+
+/** Miscellaneous major device class */
+#define BT_COD_MAJOR_DEVICE_CLASS_MISCELLANEOUS 0x00
+/** Computer major device class */
+#define BT_COD_MAJOR_DEVICE_CLASS_COMPUTER      0x01
+/** Phone major device class */
+#define BT_COD_MAJOR_DEVICE_CLASS_PHONE         0x02
+/** LAN/Network Access Point major device class */
+#define BT_COD_MAJOR_DEVICE_CLASS_LAN_NETWORK   0x03
+/** Audio/Video major device class */
+#define BT_COD_MAJOR_DEVICE_CLASS_AUDIO_VIDEO   0x04
+/** Peripheral major device class */
+#define BT_COD_MAJOR_DEVICE_CLASS_PERIPHERAL    0x05
+/** Imaging major device class */
+#define BT_COD_MAJOR_DEVICE_CLASS_IMAGING       0x06
+/** Wearable major device class */
+#define BT_COD_MAJOR_DEVICE_CLASS_WEARABLE      0x07
+/** Toy major device class */
+#define BT_COD_MAJOR_DEVICE_CLASS_TOY           0x08
+/** Health major device class */
+#define BT_COD_MAJOR_DEVICE_CLASS_HEALTH        0x09
+/** Uncategorized major device class */
+#define BT_COD_MAJOR_DEVICE_CLASS_UNCATEGORIZED 0x1F
+
+/** @} */ /* end of Major Device Class */
+
+/**
+ * @name Minor Device Class - Computer Major Class
+ * @{
+ */
+
+/** Uncategorized computer minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_COMPUTER_UNCATEGORIZED       0x00
+/** Desktop workstation computer minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_COMPUTER_DESKTOP_WORKSTATION 0x01
+/** Server-class computer minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_COMPUTER_SERVER              0x02
+/** Laptop computer minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_COMPUTER_LAPTOP              0x03
+/** Handheld PC/PDA computer minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_COMPUTER_HANDHELD_PC_PDA     0x04
+/** Palm-sized PC/PDA computer minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_COMPUTER_PALM_SIZED_PC_PDA   0x05
+/** Wearable computer minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_COMPUTER_WEARABLE_COMPUTER   0x06
+/** Tablet computer minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_COMPUTER_TABLET              0x07
+
+/** @} */ /* end of Minor Device Class - Computer Major Class */
+
+/**
+ * @name Minor Device Class - Phone Major Class
+ * @{
+ */
+
+/** Uncategorized phone minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_PHONE_UNCATEGORIZED      0x00
+/** Cellular phone minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_PHONE_CELLULAR           0x01
+/** Cordless phone minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_PHONE_CORDLESS           0x02
+/** Smartphone minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_PHONE_SMARTPHONE         0x03
+/** Wired modem or voice gateway phone minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_PHONE_WIRED_MODEM        0x04
+/** Common ISDN access phone minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_PHONE_COMMON_ISDN_ACCESS 0x05
+
+/** @} */ /* end of Minor Device Class - Phone Major Class */
+
+/**
+ * @name Minor Device Class - LAN/Network Major Class - Service Utilization
+ * @{
+ */
+
+/** LAN service utilization: fully available */
+#define BT_COD_MINOR_DEVICE_CLASS_LAN_NETWORK_SERVICE_FULLY_AVAILABLE      0x00
+/** LAN service utilization: 1-17% utilized */
+#define BT_COD_MINOR_DEVICE_CLASS_LAN_NETWORK_SERVICE_1_17_UTILIZED        0x01
+/** LAN service utilization: 17-33% utilized */
+#define BT_COD_MINOR_DEVICE_CLASS_LAN_NETWORK_SERVICE_17_33_UTILIZED       0x02
+/** LAN service utilization: 33-50% utilized */
+#define BT_COD_MINOR_DEVICE_CLASS_LAN_NETWORK_SERVICE_33_50_UTILIZED       0x03
+/** LAN service utilization: 50-67% utilized */
+#define BT_COD_MINOR_DEVICE_CLASS_LAN_NETWORK_SERVICE_50_67_UTILIZED       0x04
+/** LAN service utilization: 67-83% utilized */
+#define BT_COD_MINOR_DEVICE_CLASS_LAN_NETWORK_SERVICE_67_83_UTILIZED       0x05
+/** LAN service utilization: 83-99% utilized */
+#define BT_COD_MINOR_DEVICE_CLASS_LAN_NETWORK_SERVICE_83_99_UTILIZED       0x06
+/** LAN service utilization: no service available */
+#define BT_COD_MINOR_DEVICE_CLASS_LAN_NETWORK_SERVICE_NO_SERVICE_AVAILABLE 0x07
+
+/** @} */ /* end of Minor Device Class - LAN/Network Major Class - Service Utilization */
+
+/**
+ * @name Minor Device Class - LAN/Network Major Class - Device Type
+ * @{
+ */
+
+/** Uncategorized LAN/network device type */
+#define BT_COD_MINOR_DEVICE_CLASS_LAN_NETWORK_DEVICE_TYPE_UNCATEGORIZED 0x00
+
+/** Minor Device Class - Audio/Video Major Class */
+/** Uncategorized audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_UNCATEGORIZED             0x00
+/** Wearable headset audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_WEARABLE_HEADSET          0x01
+/** Handsfree audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_HANDSFREE                 0x02
+/** Microphone audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_MICROPHONE                0x04
+/** Loudspeaker audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_LOUDSPEAKER               0x05
+/** Headphones audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_HEADPHONES                0x06
+/** Portable audio audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_PORTABLE_AUDIO            0x07
+/** Car audio audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_CAR_AUDIO                 0x08
+/** Set-top box audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_SETTOP_BOX                0x09
+/** HiFi audio audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_HIFI_AUDIO                0x0A
+/** VCR audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_VCR                       0x0B
+/** Video camera audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_VIDEO_CAMERA              0x0C
+/** Camcorder audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_CAMCORDER                 0x0D
+/** Video monitor audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_VIDEO_MONITOR             0x0E
+/** Video display and loudspeaker audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_VIDEO_DISPLAY_LOUDSPEAKER 0x0F
+/** Video conferencing audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_VIDEO_CONFERENCING        0x10
+/** Gaming toy audio/video minor device class */
+#define BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_GAMING_TOY                0x12
+
+/** @} */ /* end of Minor Device Class - Audio/Video Major Class */
+
+/**
+ * @name Minor Device Class - Peripheral Major Class - Input Device Type
+ * @{
+ */
+
+/** Peripheral input: no keyboard, no pointing device */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_INPUT_DEVICE_TYPE_NO_KEYBOARD_NO_POINTING 0x00
+/** Peripheral input: keyboard */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_INPUT_DEVICE_TYPE_KEYBOARD                0x01
+/** Peripheral input: pointing device */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_INPUT_DEVICE_TYPE_POINTING_DEVICE         0x02
+/** Peripheral input: combo keyboard and pointing device */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_INPUT_DEVICE_TYPE_COMBO_KEYBOARD_POINTING 0x03
+
+/** @} */ /* end of Minor Device Class - Peripheral Major Class - Input Device Type */
+
+/**
+ * @name Minor Device Class - Peripheral Major Class - Device Type
+ * @{
+ */
+
+/** Uncategorized peripheral device type */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_DEVICE_TYPE_UNCATEGORIZED           0x00
+/** Joystick peripheral device type */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_DEVICE_TYPE_JOYSTICK                0x01
+/** Gamepad peripheral device type */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_DEVICE_TYPE_GAMEPAD                 0x02
+/** Remote control peripheral device type */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_DEVICE_TYPE_REMOTE_CONTROL          0x03
+/** Sensing device peripheral device type */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_DEVICE_TYPE_SENSING_DEVICE          0x04
+/** Digitizer tablet peripheral device type */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_DEVICE_TYPE_DIGITIZER_TABLET        0x05
+/** Card reader peripheral device type */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_DEVICE_TYPE_CARD_READER             0x06
+/** Digital pen peripheral device type */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_DEVICE_TYPE_DIGITAL_PEN             0x07
+/** Handheld scanner peripheral device type */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_DEVICE_TYPE_HANDHELD_SCANNER        0x08
+/** Handheld gestural input peripheral device type */
+#define BT_COD_MINOR_DEVICE_CLASS_PERIPHERAL_DEVICE_TYPE_HANDHELD_GESTURAL_INPUT 0x09
+
+/** @} */ /* end of Minor Device Class - Peripheral Major Class - Device Type */
+
+/**
+ * @name Minor Device Class - Imaging Major Class
+ * @{
+ */
+
+/** Minor Device Class - Imaging Major Class */
+#define BT_COD_MINOR_DEVICE_CLASS_IMAGING_DISPLAY 0x01
+/** Imaging camera device */
+#define BT_COD_MINOR_DEVICE_CLASS_IMAGING_CAMERA  0x02
+/** Imaging scanner device */
+#define BT_COD_MINOR_DEVICE_CLASS_IMAGING_SCANNER 0x04
+/** Imaging printer device */
+#define BT_COD_MINOR_DEVICE_CLASS_IMAGING_PRINTER 0x08
+
+/** Minor Device Class - Imaging Major Class Uncategorized */
+#define BT_COD_MINOR_DEVICE_CLASS_IMAGING_UNCATEGORIZED 0x00
+
+/** @} */ /* end of Minor Device Class - Imaging Major Class */
+
+/**
+ * @name Minor Device Class - Wearable Major Class
+ * @{
+ */
+
+/** Wearable headset device */
+#define BT_COD_MINOR_DEVICE_CLASS_WEARABLE_HEADSET 0x01
+/** Wearable pager device */
+#define BT_COD_MINOR_DEVICE_CLASS_WEARABLE_PAGER   0x02
+/** Wearable jacket device */
+#define BT_COD_MINOR_DEVICE_CLASS_WEARABLE_JACKET  0x03
+/** Wearable helmet device */
+#define BT_COD_MINOR_DEVICE_CLASS_WEARABLE_HELMET  0x04
+/** Wearable glasses device */
+#define BT_COD_MINOR_DEVICE_CLASS_WEARABLE_GLASSES 0x05
+
+/** @} */ /* end of Minor Device Class - Wearable Major Class */
+
+/**
+ * @name Minor Device Class - Toy Major Class
+ * @{
+ */
+
+/** Toy robot device */
+#define BT_COD_MINOR_DEVICE_CLASS_TOY_ROBOT      0x01
+/** Toy vehicle device */
+#define BT_COD_MINOR_DEVICE_CLASS_TOY_VEHICLE    0x02
+/** Toy doll device */
+#define BT_COD_MINOR_DEVICE_CLASS_TOY_DOLL       0x03
+/** Toy controller device */
+#define BT_COD_MINOR_DEVICE_CLASS_TOY_CONTROLLER 0x04
+/** Toy game device */
+#define BT_COD_MINOR_DEVICE_CLASS_TOY_GAME       0x05
+
+/** @} */ /* end of Minor Device Class - Toy Major Class */
+
+/**
+ * @name Minor Device Class - Health Major Class
+ * @{
+ */
+
+/** Undefined health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_UNDEFINED                 0x00
+/** Blood pressure monitor health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_BLOOD_PRESSURE_MONITOR    0x01
+/** Thermometer health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_THERMOMETER               0x02
+/** Weighing scale health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_WEIGHING_SCALE            0x03
+/** Glucose meter health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_GLUCOSE_METER             0x04
+/** Pulse oximeter health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_PULSE_OXIMETER            0x05
+/** Heart/pulse monitor health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_HEART_PULSE_MONITOR       0x06
+/** Health data display device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_HEALTH_DATA_DISPLAY       0x07
+/** Step counter health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_STEP_COUNTER              0x08
+/** Body composition analyzer health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_BODY_COMPOSITION_ANALYZER 0x09
+/** Peak flow monitor health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_PEAK_FLOW_MONITOR         0x0A
+/** Medication monitor health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_MEDICATION_MONITOR        0x0B
+/** Knee prosthesis health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_KNEE_PROSTHESIS           0x0C
+/** Ankle prosthesis health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_ANKLE_PROSTHESIS          0x0D
+/** Generic health manager device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_GENERIC_HEALTH_MANAGER    0x0E
+/** Personal mobility health device */
+#define BT_COD_MINOR_DEVICE_CLASS_HEALTH_PERSONAL_MOBILITY_DEVICE  0x0F
+
+/** @} */ /* end of Minor Device Class - Health Major Class */
+
+/** @} */ /* end of @name BR Class of Device */
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -470,6 +470,99 @@ struct bt_br_page_scan_param {
 int bt_br_page_scan_update_param(const struct bt_br_page_scan_param *param);
 
 /**
+ * @brief BR/EDR inquiry scan parameters
+ * @note These parameters are used to configure the inquiry scan behavior of the
+ *       local BR/EDR controller.
+ */
+struct bt_br_inquiry_scan_param {
+	/** Inquiry scan interval in 0.625 ms units
+	 *  Range: 0x0012 to 0x1000.
+	 *
+	 *  According to the Bluetooth Core Specification, only even values are
+	 *  used by the controller; if an odd value is provided, the controller
+	 *  may ignore the LSB or round the value. Applications should use even
+	 *  values to be compliant.
+	 */
+	uint16_t interval;
+
+	/** Inquiry scan window in 0.625 ms units
+	 *  Range: 0x0011 to 0x1000.
+	 */
+	uint16_t window;
+
+	/** Inquiry scan type. */
+	enum bt_br_scan_type type;
+};
+
+/**
+ * @name Defined BR Inquiry Scan Intervals and Windows
+ * @{
+ */
+
+/** Default inquiry scan interval (0x1000, 2.560 s, 0.625 ms units). */
+#define BT_BR_INQUIRY_SCAN_INTERVAL_DEFAULT 0x1000
+/** Default inquiry scan window (0x0012, 11.25 ms, 0.625 ms units). */
+#define BT_BR_INQUIRY_SCAN_WINDOW_DEFAULT   0x0012
+
+/**
+ * @}
+ */
+
+/**
+ * @brief Helper to declare BR/EDR inquiry scan parameters inline
+ *
+ * @param _interval Inquiry scan interval, N * 0.625 milliseconds
+ * @param _window   Inquiry scan window, N * 0.625 milliseconds
+ * @param _type     @ref BT_BR_SCAN_TYPE_STANDARD or @ref BT_BR_SCAN_TYPE_INTERLACED
+ */
+#define BT_BR_INQUIRY_SCAN_PARAM(_interval, _window, _type)                                        \
+	((const struct bt_br_inquiry_scan_param[]){BT_BR_SCAN_INIT(_interval, _window, _type)})
+
+/**
+ * @brief Default inquiry scan parameters
+ *
+ * Inquiry scan interval is set to 2.560 seconds (0x1000 in 0.625 ms units), and the
+ * inquiry scan window is set to 11.25 milliseconds (0x0012 in 0.625 ms units).
+ * The scan type is set to standard.
+ */
+#define BT_BR_INQUIRY_SCAN_PARAM_DEFAULT                                                           \
+	BT_BR_INQUIRY_SCAN_PARAM(BT_BR_INQUIRY_SCAN_INTERVAL_DEFAULT,                              \
+				 BT_BR_INQUIRY_SCAN_WINDOW_DEFAULT, BT_BR_SCAN_TYPE_STANDARD)
+
+/**
+ * @brief Update BR/EDR inquiry scan parameters.
+ *
+ * This function updates the inquiry scan parameters of the local BR/EDR controller.
+ * Inquiry scan parameters determine how the controller handles inquiry requests.
+ *
+ * The function validates the provided parameters, including the interval,
+ * window, and scan type, and sends the appropriate HCI commands to update
+ * the controller's inquiry scan activity and scan type.
+ *
+ * The user can set custom inquiry scan parameters using the helper macro
+ * @ref BT_BR_INQUIRY_SCAN_PARAM to define their own values.
+ * Alternatively, the user can use predefined standard parameters as defined
+ * in the Bluetooth specification:
+ * - @ref BT_BR_INQUIRY_SCAN_PARAM_DEFAULT Default inquiry scan parameters.
+ * These predefined parameters are designed to meet common use cases and
+ * ensure compliance with the Bluetooth specification.
+ *
+ * @param param Inquiry scan parameters, including:
+ *              - interval: Time between consecutive inquiry scans (in 0.625 ms units).
+ *                          Must be in the range [0x0012, 0x1000].
+ *              - window: Duration of a single inquiry scan (in 0.625 ms units).
+ *                        Must be in the range [0x0011, 0x1000].
+ *              - type: Inquiry scan type (e.g., standard or interlaced).
+ *
+ * @return 0 on success.
+ * @return -EINVAL if the provided parameters are invalid.
+ * @return -EAGAIN if the device is not ready.
+ * @return -ENOBUFS if memory allocation for HCI commands fails.
+ * @return Other negative error codes for internal failures.
+ */
+int bt_br_inquiry_scan_update_param(const struct bt_br_inquiry_scan_param *param);
+
+/**
  * @brief Set the Class of Device of the local BR/EDR Controller.
  *
  * This function writes the Class of Device (COD) value to the BR/EDR

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -248,6 +248,46 @@ typedef enum bt_br_conn_req_rsp (*bt_br_conn_req_func_t)(const bt_addr_t *addr, 
  */
 int bt_br_set_connectable(bool enable, bt_br_conn_req_func_t func);
 
+/**
+ * @brief Set the Class of Device of the local BR/EDR Controller.
+ *
+ * This function writes the Class of Device (COD) value to the BR/EDR
+ * controller. The COD is used by remote devices during the discovery
+ * process to identify the type of device and the services it provides.
+ *
+ * @note The limited discoverable mode bit (@ref BT_COD_MAJOR_SVC_CLASS_LIMITED_DISCOVER)
+ *       cannot be set directly through this function. Use bt_br_set_discoverable()
+ *       with the limited parameter to enable limited discoverable mode, which will
+ *       automatically set the corresponding COD bit.
+ *
+ * @param cod Class of Device value to set. This should be a combination of
+ *            Major Service Class bits (BT_COD_MAJOR_SVC_CLASS_*), Major Device
+ *            Class bits (BT_COD_MAJOR_DEVICE_CLASS_*), and Minor Device Class
+ *            bits (BT_COD_MINOR_DEVICE_CLASS_*).
+ *
+ * @retval 0 on success
+ * @retval -EAGAIN if the Bluetooth device is not ready
+ * @retval -EINVAL if the provided COD value attempts to set the limited
+ *         discoverable bit directly, which is not permitted
+ * @retval Other negative error codes from underlying HCI command failures
+ *
+ * @see bt_br_set_discoverable()
+ * @see bt_br_get_class_of_device()
+ */
+int bt_br_set_class_of_device(uint32_t cod);
+
+/**
+ * @brief Get the Class of Device of the local BR/EDR Controller.
+ *
+ * @param cod Pointer to where the current Class of Device value will be stored.
+ *
+ * @retval 0 on success
+ * @retval -EAGAIN if the Bluetooth device is not ready
+ * @retval -EINVAL if @p cod is NULL
+ * @retval Other negative error codes on failure
+ */
+int bt_br_get_class_of_device(uint32_t *cod);
+
 /** @brief Check if a Bluetooth classic device address is bonded.
  *
  *  @param addr Bluetooth classic device address.

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -248,6 +248,227 @@ typedef enum bt_br_conn_req_rsp (*bt_br_conn_req_func_t)(const bt_addr_t *addr, 
  */
 int bt_br_set_connectable(bool enable, bt_br_conn_req_func_t func);
 
+/** Minimum BR/EDR scan interval (0x0012, 11.25 ms, 0.625 ms units). */
+#define BT_BR_SCAN_INTERVAL_MIN 0x0012
+/** Maximum BR/EDR scan interval (0x1000, 2.560 s, 0.625 ms units). */
+#define BT_BR_SCAN_INTERVAL_MAX 0x1000
+
+/** Minimum BR/EDR scan window (0x0011, 10.625 ms, 0.625 ms units). */
+#define BT_BR_SCAN_WINDOW_MIN 0x0011
+/** Maximum BR/EDR scan window (0x1000, 2.560 s, 0.625 ms units). */
+#define BT_BR_SCAN_WINDOW_MAX 0x1000
+
+/**
+ * @name Defined BR/EDR Page Scan Intervals and Windows
+ * @{
+ */
+
+/** Default page scan interval (R0) (0x0800, 1.280 s, 0.625 ms units). */
+#define BT_BR_PAGE_SCAN_INTERVAL_R0 0x0800
+/** Default page scan window (R0) (0x0800, 1.280 s, 0.625 ms units). */
+#define BT_BR_PAGE_SCAN_WINDOW_R0   0x0800
+
+/** Fast page scan interval (R1) (0x00a0, 100.0 ms, 0.625 ms units). */
+#define BT_BR_PAGE_SCAN_FAST_INTERVAL_R1 0x00a0
+/** Fast page scan window (R1) (0x0011, 10.625 ms, 0.625 ms units). */
+#define BT_BR_PAGE_SCAN_FAST_WINDOW_R1   0x0011
+
+/** Medium page scan interval (R1) (0x0800, 1.280 s, 0.625 ms units). */
+#define BT_BR_PAGE_SCAN_MEDIUM_INTERVAL_R1 0x0800
+/** Medium page scan window (R1) (0x0011, 10.625 ms, 0.625 ms units). */
+#define BT_BR_PAGE_SCAN_MEDIUM_WINDOW_R1   0x0011
+
+/** Slow page scan interval (R1) (0x0800, 1.280 s, 0.625 ms units). */
+#define BT_BR_PAGE_SCAN_SLOW_INTERVAL_R1 0x0800
+/** Slow page scan window (R1) (0x0011, 10.625 ms, 0.625 ms units). */
+#define BT_BR_PAGE_SCAN_SLOW_WINDOW_R1   0x0011
+
+/** Fast page scan interval (R2) (0x1000, 2.560 s, 0.625 ms units). */
+#define BT_BR_PAGE_SCAN_FAST_INTERVAL_R2 0x1000
+/** Fast page scan window (R2) (0x0011, 10.625 ms, 0.625 ms units). */
+#define BT_BR_PAGE_SCAN_FAST_WINDOW_R2   0x0011
+
+/** Slow page scan interval (R2) (0x1000, 2.560 s, 0.625 ms units). */
+#define BT_BR_PAGE_SCAN_SLOW_INTERVAL_R2 0x1000
+/** Slow page scan window (R2) (0x0011, 10.625 ms, 0.625 ms units). */
+#define BT_BR_PAGE_SCAN_SLOW_WINDOW_R2   0x0011
+
+/**
+ * @}
+ */
+
+/** Page scan type. */
+enum bt_br_scan_type {
+	/** Standard scan (default) */
+	BT_BR_SCAN_TYPE_STANDARD = 0,
+
+	/** Interlaced scan (1.2 devices only) */
+	BT_BR_SCAN_TYPE_INTERLACED = 1,
+};
+
+/** Page scan parameters. */
+struct bt_br_page_scan_param {
+	/** Page scan interval in 0.625 ms units
+	 *  Range: 0x0012 to 0x1000.
+	 *
+	 *  According to the Bluetooth Core Specification, only even values are
+	 *  used by the controller; if an odd value is provided, the controller
+	 *  may ignore the LSB or round the value. Applications should use even
+	 *  values to be compliant.
+	 */
+	uint16_t interval;
+
+	/** Page scan window in 0.625 ms units
+	 *  Range: 0x0011 to 0x1000.
+	 */
+	uint16_t window;
+
+	/** Page scan type. */
+	enum bt_br_scan_type type;
+};
+
+/**
+ * @brief Initialize BR Scan parameters
+ *
+ * @param _interval  Scan interval
+ * @param _window    Scan window
+ * @param _type      Scan type
+ */
+
+#define BT_BR_SCAN_INIT(_interval, _window, _type) \
+{ \
+	.interval = (_interval), \
+	.window = (_window), \
+	.type = (_type) \
+}
+
+/**
+ * @brief Helper to declare BR/EDR page scan parameters inline
+ *
+ * @param _interval page scan interval, N * 0.625 milliseconds
+ * @param _window   page scan window, N * 0.625 milliseconds
+ * @param _type     @ref BT_BR_SCAN_TYPE_STANDARD or @ref BT_BR_SCAN_TYPE_INTERLACED
+ */
+
+#define BT_BR_PAGE_SCAN_PARAM(_interval, _window, _type) \
+	((const struct bt_br_page_scan_param[]) { \
+		BT_BR_SCAN_INIT(_interval, _window, _type) \
+	})
+
+/**
+ * @brief Default page scan parameters for R0
+ *
+ * Page scan interval and window are set to 1.280 seconds (0x0800 in 0.625 ms units).
+ * The scan type is set to standard.
+ */
+#define BT_BR_PAGE_SCAN_PARAM_R0 BT_BR_PAGE_SCAN_PARAM(BT_BR_PAGE_SCAN_INTERVAL_R0, \
+						       BT_BR_PAGE_SCAN_WINDOW_R0, \
+						       BT_BR_SCAN_TYPE_STANDARD)
+
+/**
+ * @brief Fast page scan parameters for R1
+ *
+ * Page scan interval is set to 100 ms (0x00A0 in 0.625 ms units), and the
+ * page scan window is set to 10.625ms (0x0011 in 0.625 ms units).
+ * The scan type is set to interlaced.
+ */
+#define BT_BR_PAGE_SCAN_PARAM_FAST_R1 \
+	BT_BR_PAGE_SCAN_PARAM(BT_BR_PAGE_SCAN_FAST_INTERVAL_R1, \
+	BT_BR_PAGE_SCAN_FAST_WINDOW_R1, \
+	BT_BR_SCAN_TYPE_INTERLACED)
+
+/**
+ * @brief Medium page scan parameters for R1
+ *
+ * Page scan interval is set to 1.280 seconds (0x0800 in 0.625 ms units), and the
+ * page scan window is set to 10.625ms (0x0011 in 0.625 ms units).
+ * The scan type is set to interlaced.
+ */
+#define BT_BR_PAGE_SCAN_PARAM_MEDIUM_R1 \
+	BT_BR_PAGE_SCAN_PARAM( \
+	BT_BR_PAGE_SCAN_MEDIUM_INTERVAL_R1, \
+	BT_BR_PAGE_SCAN_MEDIUM_WINDOW_R1, \
+	BT_BR_SCAN_TYPE_INTERLACED)
+
+/**
+ * @brief Slow page scan parameters for R1
+ *
+ * Page scan interval is set to 1.280 seconds (0x0800 in 0.625 ms units), and the
+ * page scan window is set to 10.625ms (0x0011 in 0.625 ms units).
+ * The scan type is set to standard.
+ */
+#define BT_BR_PAGE_SCAN_PARAM_SLOW_R1 \
+	BT_BR_PAGE_SCAN_PARAM( \
+	BT_BR_PAGE_SCAN_SLOW_INTERVAL_R1, \
+	BT_BR_PAGE_SCAN_SLOW_WINDOW_R1, \
+	BT_BR_SCAN_TYPE_STANDARD)
+
+/**
+ * @brief Fast page scan parameters for R2
+ *
+ * Page scan interval is set to 2.560 seconds (0x1000 in 0.625 ms units), and the
+ * page scan window is set to 10.625ms (0x0011 in 0.625 ms units).
+ * The scan type is set to interlaced.
+ */
+#define BT_BR_PAGE_SCAN_PARAM_FAST_R2 \
+	BT_BR_PAGE_SCAN_PARAM( \
+	BT_BR_PAGE_SCAN_FAST_INTERVAL_R2, \
+	BT_BR_PAGE_SCAN_FAST_WINDOW_R2, \
+	BT_BR_SCAN_TYPE_INTERLACED)
+
+/**
+ * @brief Slow page scan parameters for R2
+ *
+ * Page scan interval is set to 2.560 seconds (0x1000 in 0.625 ms units), and the
+ * page scan window is set to 10.625ms (0x0011 in 0.625 ms units).
+ * The scan type is set to standard.
+ */
+#define BT_BR_PAGE_SCAN_PARAM_SLOW_R2 \
+	BT_BR_PAGE_SCAN_PARAM( \
+	BT_BR_PAGE_SCAN_SLOW_INTERVAL_R2, \
+	BT_BR_PAGE_SCAN_SLOW_WINDOW_R2, \
+	BT_BR_SCAN_TYPE_STANDARD)
+
+/**
+ * @brief Update BR/EDR page scan parameters.
+ *
+ * This function updates the page scan parameters of the local BR/EDR controller.
+ * Page scan parameters determine how the controller listens for incoming
+ * connection requests from remote devices.
+ *
+ * The function validates the provided parameters, including the interval,
+ * window, and scan type, and sends the appropriate HCI commands to update
+ * the controller's page scan activity and scan type.
+ *
+ * The user can set custom page scan parameters using the helper macro
+ * BT_BR_PAGE_SCAN_PARAM() to define their own values.
+ * Alternatively, the user can use predefined standard parameters as defined
+ * in the Bluetooth specification:
+ * - @ref BT_BR_PAGE_SCAN_PARAM_R0 Default page scan parameters.
+ * - @ref BT_BR_PAGE_SCAN_PARAM_FAST_R1 Fast page scan parameters for R1.
+ * - @ref BT_BR_PAGE_SCAN_PARAM_MEDIUM_R1 Medium page scan parameters for R1.
+ * - @ref BT_BR_PAGE_SCAN_PARAM_SLOW_R1 Slow page scan parameters for R1.
+ * - @ref BT_BR_PAGE_SCAN_PARAM_FAST_R2 Fast page scan parameters for R2.
+ * - @ref BT_BR_PAGE_SCAN_PARAM_SLOW_R2 Slow page scan parameters for R2.
+ *
+ * These predefined parameters are designed to meet common use cases and
+ * ensure compliance with the Bluetooth specification.
+ *
+ * @param param Page scan parameters, including:
+ *              - interval: Time between consecutive page scans (in 0.625 ms units).
+ *                          Must be in the range [0x0012, 0x1000].
+ *              - window: Duration of a single page scan (in 0.625 ms units).
+ *                        Must be in the range [0x0011, 0x1000].
+ *              - type: Page scan type (e.g., standard or interlaced).
+ *
+ * @return 0 on success.
+ * @return -EINVAL if the provided parameters are invalid.
+ * @return -EAGAIN if the device is not ready.
+ * @return -ENOBUFS if memory allocation for HCI commands fails.
+ * @return Other negative error codes for internal failures.
+ */
+int bt_br_page_scan_update_param(const struct bt_br_page_scan_param *param);
+
 /**
  * @brief Set the Class of Device of the local BR/EDR Controller.
  *

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -718,66 +718,6 @@ struct bt_hci_rp_read_class_of_device {
 	uint8_t  class_of_device[3];
 } __packed;
 
-#define BT_COD(major_service, major_device, minor_device)                         \
-	(((uint32_t)major_service << 13) | ((uint32_t)major_device << 8) |            \
-	 ((uint32_t)minor_device << 2))
-#define BT_COD_VALID(cod) ((0 == (cod[0] & (BIT(0) | BIT(1)))) ? true : false)
-#define BT_COD_MAJOR_SERVICE_CLASSES(cod)                                         \
-	((((uint32_t)cod[2] & 0xFF) >> 5) | (((uint32_t)cod[1] & 0xD0) >> 5))
-#define BT_COD_MAJOR_DEVICE_CLASS(cod) ((((uint32_t)cod[1]) & 0x1FUL))
-#define BT_COD_MINOR_DEVICE_CLASS(cod) (((((uint32_t)cod[0]) & 0xFF) >> 2))
-
-#define BT_COD_MAJOR_MISC           0x00
-#define BT_COD_MAJOR_COMPUTER       0x01
-#define BT_COD_MAJOR_PHONE          0x02
-#define BT_COD_MAJOR_LAN_NETWORK_AP 0x03
-#define BT_COD_MAJOR_AUDIO_VIDEO    0x04
-#define BT_COD_MAJOR_PERIPHERAL     0x05
-#define BT_COD_MAJOR_IMAGING        0x06
-#define BT_COD_MAJOR_WEARABLE       0x07
-#define BT_COD_MAJOR_TOY            0x08
-#define BT_COD_MAJOR_HEALTH         0x09
-#define BT_COD_MAJOR_UNCATEGORIZED  0x1F
-
-/* Minor Device Class field - Computer Major Class */
-#define BT_COD_MAJOR_COMPUTER_MINOR_UNCATEGORIZED         0x00
-#define BT_COD_MAJOR_COMPUTER_MINOR_DESKTOP               0x01
-#define BT_COD_MAJOR_COMPUTER_MINOR_SERVER_CLASS_COMPUTER 0x02
-#define BT_COD_MAJOR_COMPUTER_MINOR_LAPTOP                0x03
-#define BT_COD_MAJOR_COMPUTER_MINOR_HANDHELD_PC_PDA       0x04
-#define BT_COD_MAJOR_COMPUTER_MINOR_PALM_SIZE_PC_PDA      0x05
-#define BT_COD_MAJOR_COMPUTER_MINOR_WEARABLE_COMPUTER     0x06
-#define BT_COD_MAJOR_COMPUTER_MINOR_TABLET                0x07
-
-/* Minor Device Class field - Phone Major Class */
-#define BT_COD_MAJOR_PHONE_MINOR_UNCATEGORIZED             0x00
-#define BT_COD_MAJOR_PHONE_MINOR_CELLULAR                  0x01
-#define BT_COD_MAJOR_PHONE_MINOR_CORDLESS                  0x02
-#define BT_COD_MAJOR_PHONE_MINOR_SMARTPHONE                0x03
-#define BT_COD_MAJOR_PHONE_MINOR_WIRED_MODEM_VOICE_GATEWAY 0x04
-#define BT_COD_MAJOR_PHONE_MINOR_ISDN                      0x05
-
-/* Minor Device Class field - Audio/Video Major Class */
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_UNCATEGORIZED             0x00
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_WEARABLE_HEADSET          0x01
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_HANDS_FREE                0x02
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_RFU                       0x03
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_MICROPHONE                0x04
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_LOUDSPEAKER               0x05
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_HEADPHONES                0x06
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_PORTABLE_AUDIO            0x07
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_CAR_AUDIO                 0x08
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_SET_TOP_BOX               0x09
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_HIFI_AUDIO                0x0A
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_VCR                       0x0B
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_VIDEO_CAMERA              0x0C
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_CAMCORDER                 0x0D
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_VIDEO_MONITOR             0x0E
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_VIDEO_DISPLAY_LOUDSPEAKER 0x0F
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_VIDEO_CONFERENCING        0x10
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_RFU2                      0x11
-#define BT_COD_MAJOR_AUDIO_VIDEO_MINOR_GAME_TOY                  0x12
-
 #define BT_HCI_OP_WRITE_CLASS_OF_DEVICE         BT_OP(BT_OGF_BASEBAND, 0x0024) /* 0x0c24 */
 struct bt_hci_cp_write_class_of_device {
 	uint8_t  class_of_device[3];

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -712,6 +712,16 @@ struct bt_hci_rp_write_conn_accept_timeout {
 #define BT_BREDR_SCAN_INQUIRY                   0x01
 #define BT_BREDR_SCAN_PAGE                      0x02
 
+/** HCI opcode for Write Page Scan Activity. */
+#define BT_HCI_OP_WRITE_PAGE_SCAN_ACTIVITY      BT_OP(BT_OGF_BASEBAND, 0x001c) /* 0x0c1c */
+/** HCI command parameters for Write Page Scan Activity. */
+struct bt_hci_cp_write_page_scan_activity {
+	/** Page scan interval in 0.625 ms units. */
+	uint16_t interval;
+	/** Page scan window in 0.625 ms units. */
+	uint16_t window;
+} __packed;
+
 #define BT_HCI_OP_READ_CLASS_OF_DEVICE          BT_OP(BT_OGF_BASEBAND, 0x0023) /* 0x0c23 */
 struct bt_hci_rp_read_class_of_device {
 	uint8_t  status;
@@ -856,6 +866,14 @@ struct bt_hci_cp_write_current_iac_lap {
 #define BT_HCI_OP_WRITE_INQUIRY_MODE            BT_OP(BT_OGF_BASEBAND, 0x0045) /* 0x0c45 */
 struct bt_hci_cp_write_inquiry_mode {
 	uint8_t  mode;
+} __packed;
+
+/** HCI opcode for Write Page Scan Type. */
+#define BT_HCI_OP_WRITE_PAGE_SCAN_TYPE          BT_OP(BT_OGF_BASEBAND, 0x0047) /* 0x0c47 */
+/** HCI command parameters for Write Page Scan Type. */
+struct bt_hci_cp_write_page_scan_type {
+	/** Page scan type. */
+	uint8_t type;
 } __packed;
 
 #define BT_HCI_OP_WRITE_SSP_MODE                BT_OP(BT_OGF_BASEBAND, 0x0056) /* 0x0c56 */

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -722,6 +722,16 @@ struct bt_hci_cp_write_page_scan_activity {
 	uint16_t window;
 } __packed;
 
+/** HCI opcode for Write Inquiry Scan Activity. */
+#define BT_HCI_OP_WRITE_INQUIRY_SCAN_ACTIVITY   BT_OP(BT_OGF_BASEBAND, 0x001e) /* 0x0c1e */
+/** HCI command parameters for Write Inquiry Scan Activity. */
+struct bt_hci_cp_write_inquiry_scan_activity {
+	/** Inquiry scan interval in 0.625 ms units. */
+	uint16_t interval;
+	/** Inquiry scan window in 0.625 ms units. */
+	uint16_t window;
+} __packed;
+
 #define BT_HCI_OP_READ_CLASS_OF_DEVICE          BT_OP(BT_OGF_BASEBAND, 0x0023) /* 0x0c23 */
 struct bt_hci_rp_read_class_of_device {
 	uint8_t  status;
@@ -861,6 +871,14 @@ struct bt_hci_iac_lap {
 struct bt_hci_cp_write_current_iac_lap {
 	uint8_t  num_current_iac;
 	struct bt_hci_iac_lap lap[0];
+} __packed;
+
+/** HCI opcode for Write Inquiry Scan Type. */
+#define BT_HCI_OP_WRITE_INQUIRY_SCAN_TYPE       BT_OP(BT_OGF_BASEBAND, 0x0043) /* 0x0c43 */
+/** HCI command parameters for Write Inquiry Scan Type. */
+struct bt_hci_cp_write_inquiry_scan_type {
+	/** Inquiry scan type. */
+	uint8_t type;
 } __packed;
 
 #define BT_HCI_OP_WRITE_INQUIRY_MODE            BT_OP(BT_OGF_BASEBAND, 0x0045) /* 0x0c45 */

--- a/samples/bluetooth/classic/a2dp_source/src/main.c
+++ b/samples/bluetooth/classic/a2dp_source/src/main.c
@@ -595,8 +595,8 @@ static void discovery_timeout_cb(const struct bt_br_discovery_result *results, s
 		major_device = (uint8_t)BT_COD_MAJOR_DEVICE_CLASS(results[i].cod);
 		minor_device = (uint8_t)BT_COD_MINOR_DEVICE_CLASS(results[i].cod);
 
-		if ((major_device & BT_COD_MAJOR_AUDIO_VIDEO) != 0 &&
-		    (minor_device & BT_COD_MAJOR_AUDIO_VIDEO_MINOR_WEARABLE_HEADSET) != 0) {
+		if ((major_device & BT_COD_MAJOR_DEVICE_CLASS_AUDIO_VIDEO) != 0 &&
+		    (minor_device & BT_COD_MINOR_DEVICE_CLASS_WEARABLE_HEADSET) != 0) {
 			cod_a2dp = true;
 		}
 

--- a/samples/bluetooth/classic/handsfree_ag/src/main.c
+++ b/samples/bluetooth/classic/handsfree_ag/src/main.c
@@ -345,8 +345,8 @@ static void discovery_timeout_cb(const struct bt_br_discovery_result *results, s
 		major_device = (uint8_t)BT_COD_MAJOR_DEVICE_CLASS(results[i].cod);
 		minor_device = (uint8_t)BT_COD_MINOR_DEVICE_CLASS(results[i].cod);
 
-		if ((major_device & BT_COD_MAJOR_AUDIO_VIDEO) &&
-		    (minor_device & BT_COD_MAJOR_AUDIO_VIDEO_MINOR_HANDS_FREE)) {
+		if ((major_device & BT_COD_MAJOR_DEVICE_CLASS_AUDIO_VIDEO) &&
+		    (minor_device & BT_COD_MINOR_DEVICE_CLASS_AUDIO_VIDEO_HANDSFREE)) {
 			cod_hf = true;
 		}
 

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1372,6 +1372,86 @@ int bt_br_set_discoverable(bool enable, bool limited)
 	return 0;
 }
 
+static int bt_br_write_page_scan_activity(uint16_t interval, uint16_t window)
+{
+	struct bt_hci_cp_write_page_scan_activity *cp;
+	struct net_buf *buf;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
+	if (interval < BT_BR_SCAN_INTERVAL_MIN || interval > BT_BR_SCAN_INTERVAL_MAX) {
+		return -EINVAL;
+	}
+
+	if (window < BT_BR_SCAN_WINDOW_MIN || window > BT_BR_SCAN_WINDOW_MAX) {
+		return -EINVAL;
+	}
+
+	if (interval < window) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_alloc(K_FOREVER);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->interval = sys_cpu_to_le16(interval);
+	cp->window = sys_cpu_to_le16(window);
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_PAGE_SCAN_ACTIVITY, buf, NULL);
+}
+
+static int bt_br_write_page_scan_type(uint8_t type)
+{
+	struct bt_hci_cp_write_page_scan_type *cp;
+	struct net_buf *buf;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
+	if (type != BT_BR_SCAN_TYPE_STANDARD && type != BT_BR_SCAN_TYPE_INTERLACED) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_alloc(K_FOREVER);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->type = type;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_PAGE_SCAN_TYPE, buf, NULL);
+}
+
+int bt_br_page_scan_update_param(const struct bt_br_page_scan_param *param)
+{
+	int err;
+
+	if (param == NULL) {
+		return -EINVAL;
+	}
+
+	err = bt_br_write_page_scan_activity(param->interval, param->window);
+	if (err != 0) {
+		LOG_ERR("write page scan activity failed (err %d)", err);
+		return err;
+	}
+
+	err = bt_br_write_page_scan_type(param->type);
+	if (err != 0) {
+		LOG_ERR("write page scan type failed (err %d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
 int bt_br_set_class_of_device(uint32_t cod)
 {
 	int err;

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -1781,6 +1781,38 @@ static int cmd_set_sniff_mode(const struct shell *sh, size_t argc, char *argv[])
 }
 #endif
 
+static int cmd_get_class_of_device(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	uint32_t cod;
+
+	err = bt_br_get_class_of_device(&cod);
+	if (err != 0) {
+		shell_error(sh, "fail to get cod (err %d)", err);
+		return err;
+	}
+
+	shell_print(sh, "get cod:0x%06x success", cod);
+	return 0;
+}
+
+static int cmd_set_class_of_device(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	uint32_t cod;
+
+	cod = strtoul(argv[1], NULL, 16);
+
+	err = bt_br_set_class_of_device(cod);
+	if (err != 0) {
+		shell_error(sh, "fail to set cod (err %d)", err);
+		return err;
+	}
+
+	shell_print(sh, "set cod:0x%06x success", cod);
+	return 0;
+}
+
 #if defined(CONFIG_BT_L2CAP_CONNLESS)
 static void connless_recv(struct bt_conn *conn, uint16_t psm, struct net_buf *buf)
 {
@@ -1957,6 +1989,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(br_cmds,
 		      "<value:on, off> [min_interval] [max_interval] [attempt] [timeout]",
 		      cmd_set_sniff_mode, 2, 4),
 #endif
+	SHELL_CMD_ARG(cod-get, NULL, HELP_NONE, cmd_get_class_of_device, 1, 0),
+	SHELL_CMD_ARG(cod-set, NULL, "<cod>", cmd_set_class_of_device, 2, 0),
 	SHELL_SUBCMD_SET_END
 );
 

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -869,6 +869,61 @@ static int cmd_auto_reject_conn(const struct shell *sh, size_t argc, char *argv[
 	return 0;
 }
 
+static int cmd_pscan_mode(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	const struct bt_br_page_scan_param *param;
+
+	if (!strcmp(argv[1], "r0")) {
+		param = BT_BR_PAGE_SCAN_PARAM_R0;
+	} else if (!strcmp(argv[1], "fr1")) {
+		param = BT_BR_PAGE_SCAN_PARAM_FAST_R1;
+	} else if (!strcmp(argv[1], "fr2")) {
+		param = BT_BR_PAGE_SCAN_PARAM_FAST_R2;
+	} else if (!strcmp(argv[1], "mr1")) {
+		param = BT_BR_PAGE_SCAN_PARAM_MEDIUM_R1;
+	} else if (!strcmp(argv[1], "sr1")) {
+		param = BT_BR_PAGE_SCAN_PARAM_SLOW_R1;
+	} else if (!strcmp(argv[1], "sr2")) {
+		param = BT_BR_PAGE_SCAN_PARAM_SLOW_R2;
+	} else {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	err = bt_br_page_scan_update_param(param);
+	if (err != 0) {
+		shell_error(sh, "BR/EDR update page scan mode failed (err %d)", err);
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "BR/EDR update page scan mode success");
+	return 0;
+}
+
+static int cmd_pscan_param(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	struct bt_br_page_scan_param param;
+
+	param.interval = strtoul(argv[1], NULL, 16);
+	param.window = strtoul(argv[2], NULL, 16);
+	param.type = strtoul(argv[3], NULL, 16);
+
+	err = bt_br_page_scan_update_param(&param);
+	if (err != 0) {
+		shell_error(sh, "BR/EDR update page scan param failed (err %d)", err);
+		return -ENOEXEC;
+	}
+
+	shell_print(
+		sh,
+		"BR/EDR update page scan param(interval 0x%04x, window 0x%04x, type: %u) success",
+		param.interval, param.window, param.type);
+
+	return 0;
+}
+
 static int cmd_oob(const struct shell *sh, size_t argc, char *argv[])
 {
 	char addr[BT_ADDR_STR_LEN];
@@ -1926,6 +1981,11 @@ static int cmd_default_handler(const struct shell *sh, size_t argc, char **argv)
 	"<psm> <mode: none, ret, fc, eret, stream> [hold_credit] "    \
 	"[mode_optional] [extended_control]"
 
+#define HELP_PSCAN_PARAM                                                                           \
+	"<interval: scan interval in units of 0.625 ms> "                                          \
+	"<window: window in units of 0.625 ms> "                                                   \
+	"<type: 0 for standard, 1 for interlaced>"
+
 SHELL_STATIC_SUBCMD_SET_CREATE(echo_cmds,
 	SHELL_CMD_ARG(register, NULL, HELP_NONE, cmd_l2cap_echo_reg, 1, 0),
 	SHELL_CMD_ARG(unregister, NULL, HELP_NONE, cmd_l2cap_echo_unreg, 1, 0),
@@ -1979,6 +2039,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(br_cmds,
 	SHELL_CMD_ARG(oob, NULL, NULL, cmd_oob, 1, 0),
 	SHELL_CMD_ARG(pscan, NULL, "<value: on, off> [central/peripheral]", cmd_connectable, 2, 1),
 	SHELL_CMD_ARG(auto_reject_conn, NULL, "<value: on, off>", cmd_auto_reject_conn, 2, 0),
+	SHELL_CMD_ARG(pscan-mode, NULL, "<mode: r0, fr1, mr1, sr1, fr2, sr2>",
+		      cmd_pscan_mode, 2, 0),
+	SHELL_CMD_ARG(pscan-param, NULL, HELP_PSCAN_PARAM, cmd_pscan_param, 4, 0),
 	SHELL_CMD_ARG(sdp-find, NULL, "[HFPAG, HFPHF, A2SRC, A2SNK, PNP, AVRCP_CT, AVRCP_TG]",
 		      cmd_sdp_find_record, 1, 1),
 	SHELL_CMD_ARG(switch-role, NULL, "<value: central, peripheral>", cmd_switch_role, 2, 0),

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -808,6 +808,54 @@ static enum bt_br_conn_req_rsp br_conn_req_cb(const bt_addr_t *addr, uint32_t co
 	return BT_BR_CONN_REQ_ACCEPT_PERIPHERAL;
 }
 
+static int cmd_iscan_param(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = 0;
+
+	if (argc == 1) {
+		err = bt_br_inquiry_scan_update_param(BT_BR_INQUIRY_SCAN_PARAM_DEFAULT);
+		if (err != 0) {
+			shell_error(sh, "BR/EDR set inquiry scan param (default) failed (err %d)",
+				    err);
+			return -ENOEXEC;
+		}
+
+		shell_print(sh,
+			    "BR/EDR update inquiry scan param(interval:0x%04x, window:0x%04x, "
+			    "type:%u) success",
+			    BT_BR_INQUIRY_SCAN_PARAM_DEFAULT->interval,
+			    BT_BR_INQUIRY_SCAN_PARAM_DEFAULT->window,
+			    BT_BR_INQUIRY_SCAN_PARAM_DEFAULT->type);
+		return 0;
+	}
+
+	if (argc == 4) {
+		struct bt_br_inquiry_scan_param param;
+
+		param.interval = strtoul(argv[1], NULL, 16);
+		param.window = strtoul(argv[2], NULL, 16);
+		param.type = strtoul(argv[3], NULL, 16);
+
+		err = bt_br_inquiry_scan_update_param(&param);
+		if (err != 0) {
+			shell_error(sh,
+				    "BR/EDR set inquiry scan param failed "
+				    "(interval 0x%04x, window 0x%04x, type %u, err %d)",
+				    param.interval, param.window, param.type, err);
+			return -ENOEXEC;
+		}
+
+		shell_print(sh,
+			    "BR/EDR update inquiry scan param(interval:0x%04x, window:0x%04x, "
+			    "type:%u) success",
+			    param.interval, param.window, param.type);
+		return 0;
+	}
+
+	shell_help(sh);
+	return SHELL_CMD_HELP_PRINTED;
+}
+
 static int cmd_connectable(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
@@ -1986,6 +2034,11 @@ static int cmd_default_handler(const struct shell *sh, size_t argc, char **argv)
 	"<window: window in units of 0.625 ms> "                                                   \
 	"<type: 0 for standard, 1 for interlaced>"
 
+#define HELP_ISCAN_PARAM                                                                           \
+	"[<interval: scan interval in units of 0.625 ms> "                                         \
+	"<window: window in units of 0.625 ms> "                                                   \
+	"<type: 0 for standard, 1 for interlaced>]"
+
 SHELL_STATIC_SUBCMD_SET_CREATE(echo_cmds,
 	SHELL_CMD_ARG(register, NULL, HELP_NONE, cmd_l2cap_echo_reg, 1, 0),
 	SHELL_CMD_ARG(unregister, NULL, HELP_NONE, cmd_l2cap_echo_unreg, 1, 0),
@@ -2035,6 +2088,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(br_cmds,
 		      cmd_discovery, 2, 2),
 	SHELL_CMD_ARG(iscan, NULL, "<value: on, off> [mode: limited]",
 		      cmd_discoverable, 2, 1),
+	SHELL_CMD_ARG(iscan-param, NULL, HELP_ISCAN_PARAM, cmd_iscan_param, 1, 3),
 	SHELL_CMD(l2cap, &l2cap_cmds, HELP_NONE, cmd_default_handler),
 	SHELL_CMD_ARG(oob, NULL, NULL, cmd_oob, 1, 0),
 	SHELL_CMD_ARG(pscan, NULL, "<value: on, off> [central/peripheral]", cmd_connectable, 2, 1),


### PR DESCRIPTION
This PR adds support for configuring BR/EDR page scan and inquiry scan parameters, and Class of Device (COD) features.

## Changes
1. **Page Scan Parameters**: 
   - Add `bt_br_page_scan_update_param` API to update page scan interval, window, and type (standard or interlaced).
   - Predefined parameter sets for different Bluetooth versions (R0, R1, R2) are provided.

2. **Inquiry Scan Parameters**:
   - Add `bt_br_inquiry_scan_update_param` API to update inquiry scan interval, window, and type.
   - Default parameter set is provided.

3. **Class of Device (COD)**:
   - Add APIs to set and get COD from the controller.

4. **Shell Commands**:
   - Add `pscan-param` shell command for testing page scan parameters.
   - Add `iscan-param` shell command for testing inquiry scan parameters.

## Testing
- Tested using the Bluetooth shell with various parameter sets and custom parameters.
- Verified that the page scan and inquiry scan parameters are correctly set in the controller.
- Verified COD set and get functionality.

## Notes
These features are essential for optimizing Bluetooth classic device discoverability and connectivity, and for correctly advertising the device class.