### PR TITLE
samples: drivers: spi_bitbang: Enable sample on nrf54h20 PPR core

### DIFF
--- a/samples/drivers/spi_bitbang/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/samples/drivers/spi_bitbang/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Test requires loopback between P0.06 and P0.07.
+ * No other driver on SPI_CLK and SPI_CS.
+ */
+
+/ {
+	spibb0: spibb0 {
+		compatible = "zephyr,spi-bitbang";
+		status = "okay";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		clk-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
+		miso-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpiote130 {
+	status = "okay";
+	owned-channels = <7>;
+};

--- a/samples/drivers/spi_bitbang/sample.yaml
+++ b/samples/drivers/spi_bitbang/sample.yaml
@@ -9,6 +9,7 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpuppr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
     integration_platforms:


### PR DESCRIPTION
Add overlay required to run the sample on
nrf54h20dk/nrf54h20/cpuppr.