### PR TITLE
dts: arm: nrf54h20_cpurad: disable unsuppported s2ram state

### DIFF
--- a/dts/arm/nordic/nrf54h20_cpurad.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpurad.dtsi
@@ -28,6 +28,7 @@ wdt011: &cpurad_wdt011 {};
 /delete-node/ &cpuapp_ram0;
 /delete-node/ &cpuppr;
 /delete-node/ &cpuflpr;
+/delete-node/ &s2ram;
 
 / {
 	soc {


### PR DESCRIPTION
The s2ram power state is a "suspend-to-ram" state which is not supported by the radio core, so delete it from the overlay.

fixes: #96610