### PR TITLE
dac: mcux_gau: fix output-voltage-range mapping on RW61x (0,1,3)

### DIFF
--- a/drivers/dac/dac_mcux_gau.c
+++ b/drivers/dac/dac_mcux_gau.c
@@ -102,23 +102,23 @@ static int nxp_gau_dac_init(const struct device *dev)
 };
 
 #define _NXP_MAP_OUTPUT_RANGE(idx) \
-    ((idx) == 0 ? kDAC_RangeSmall : \
-     (idx) == 1 ? kDAC_RangeMiddle : \
-                  kDAC_RangeLarge)
+	((idx) == 0 ? kDAC_RangeSmall : \
+	(idx) == 1 ? kDAC_RangeMiddle : \
+	kDAC_RangeLarge)
 
 /* or if you prefer explicit property reuse */
 #define NXP_GAU_DAC_INIT(inst)                                            \
-    const struct nxp_gau_dac_config nxp_gau_dac_##inst##_config = {       \
-        .base = (DAC_Type *)DT_INST_REG_ADDR(inst),                       \
-        .voltage_ref = DT_INST_ENUM_IDX(inst, nxp_dac_reference),         \
-        .conversion_rate = DT_INST_ENUM_IDX(inst, nxp_conversion_rate),   \
-        .output_range = (dac_output_voltage_range_t) _NXP_MAP_OUTPUT_RANGE( \
-            DT_INST_ENUM_IDX(inst, nxp_output_voltage_range)),            \
-    };                                                                    \
-    DEVICE_DT_INST_DEFINE(inst, &nxp_gau_dac_init, NULL,                  \
-                          NULL,                                           \
-                          &nxp_gau_dac_##inst##_config,                   \
-                          POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,          \
-                          &nxp_gau_dac_driver_api);
+	const struct nxp_gau_dac_config nxp_gau_dac_##inst##_config = {       \
+		.base = (DAC_Type *)DT_INST_REG_ADDR(inst),                       \
+		.voltage_ref = DT_INST_ENUM_IDX(inst, nxp_dac_reference),         \
+		.conversion_rate = DT_INST_ENUM_IDX(inst, nxp_conversion_rate),   \
+		.output_range = (dac_output_voltage_range_t) _NXP_MAP_OUTPUT_RANGE( \
+			DT_INST_ENUM_IDX(inst, nxp_output_voltage_range)),            \
+	};                                                                    \
+	DEVICE_DT_INST_DEFINE(inst, &nxp_gau_dac_init, NULL,                  \
+		NULL,                                           \
+		&nxp_gau_dac_##inst##_config,                   \
+		POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,          \
+		&nxp_gau_dac_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(NXP_GAU_DAC_INIT)

--- a/drivers/dac/dac_mcux_gau.c
+++ b/drivers/dac/dac_mcux_gau.c
@@ -101,21 +101,24 @@ static int nxp_gau_dac_init(const struct device *dev)
 	return 0;
 };
 
-#define NXP_GAU_DAC_INIT(inst)							\
-										\
-	const struct nxp_gau_dac_config nxp_gau_dac_##inst##_config = {		\
-		.base = (DAC_Type *) DT_INST_REG_ADDR(inst),			\
-		.voltage_ref = DT_INST_ENUM_IDX(inst, nxp_dac_reference),	\
-		.conversion_rate = DT_INST_ENUM_IDX(inst, nxp_conversion_rate),	\
-		.output_range = DT_INST_ENUM_IDX(inst,				\
-						nxp_output_voltage_range),	\
-	};									\
-										\
-										\
-	DEVICE_DT_INST_DEFINE(inst, &nxp_gau_dac_init, NULL,			\
-				NULL,						\
-				&nxp_gau_dac_##inst##_config,			\
-				POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,		\
-				&nxp_gau_dac_driver_api);
+#define _NXP_MAP_OUTPUT_RANGE(idx) \
+    ((idx) == 0 ? kDAC_RangeSmall : \
+     (idx) == 1 ? kDAC_RangeMiddle : \
+                  kDAC_RangeLarge)
+
+/* or if you prefer explicit property reuse */
+#define NXP_GAU_DAC_INIT(inst)                                            \
+    const struct nxp_gau_dac_config nxp_gau_dac_##inst##_config = {       \
+        .base = (DAC_Type *)DT_INST_REG_ADDR(inst),                       \
+        .voltage_ref = DT_INST_ENUM_IDX(inst, nxp_dac_reference),         \
+        .conversion_rate = DT_INST_ENUM_IDX(inst, nxp_conversion_rate),   \
+        .output_range = (dac_output_voltage_range_t) _NXP_MAP_OUTPUT_RANGE( \
+            DT_INST_ENUM_IDX(inst, nxp_output_voltage_range)),            \
+    };                                                                    \
+    DEVICE_DT_INST_DEFINE(inst, &nxp_gau_dac_init, NULL,                  \
+                          NULL,                                           \
+                          &nxp_gau_dac_##inst##_config,                   \
+                          POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,          \
+                          &nxp_gau_dac_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(NXP_GAU_DAC_INIT)

--- a/drivers/dac/dac_mcux_gau.c
+++ b/drivers/dac/dac_mcux_gau.c
@@ -101,6 +101,7 @@ static int nxp_gau_dac_init(const struct device *dev)
 	return 0;
 };
 
+/* Map output range enum index to mcux dac_output_voltage_range_t */ /
 #define _NXP_MAP_OUTPUT_RANGE(idx)	\
 	((idx) == 0 ? kDAC_RangeSmall :	\
 	(idx) == 1 ? kDAC_RangeMiddle :	\

--- a/drivers/dac/dac_mcux_gau.c
+++ b/drivers/dac/dac_mcux_gau.c
@@ -101,7 +101,7 @@ static int nxp_gau_dac_init(const struct device *dev)
 	return 0;
 };
 
-#define _NXP_MAP_OUTPUT_RANGE(idx) \
+#define _NXP_MAP_OUTPUT_RANGE(idx)  \
 	((idx) == 0 ? kDAC_RangeSmall : \
 	(idx) == 1 ? kDAC_RangeMiddle : \
 	kDAC_RangeLarge)
@@ -116,9 +116,9 @@ static int nxp_gau_dac_init(const struct device *dev)
 			DT_INST_ENUM_IDX(inst, nxp_output_voltage_range)),            \
 	};                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, &nxp_gau_dac_init, NULL,                  \
-		NULL,                                           \
-		&nxp_gau_dac_##inst##_config,                   \
-		POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,          \
+		NULL,                                           				  \
+		&nxp_gau_dac_##inst##_config,                   				  \
+		POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,          				  \
 		&nxp_gau_dac_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(NXP_GAU_DAC_INIT)

--- a/drivers/dac/dac_mcux_gau.c
+++ b/drivers/dac/dac_mcux_gau.c
@@ -107,18 +107,18 @@ static int nxp_gau_dac_init(const struct device *dev)
 	kDAC_RangeLarge)
 
 /* or if you prefer explicit property reuse */
-#define NXP_GAU_DAC_INIT(inst)												\
-	const struct nxp_gau_dac_config nxp_gau_dac_##inst##_config = {			\
-		.base = (DAC_Type *)DT_INST_REG_ADDR(inst),							\
-		.voltage_ref = DT_INST_ENUM_IDX(inst, nxp_dac_reference),			\
-		.conversion_rate = DT_INST_ENUM_IDX(inst, nxp_conversion_rate),		\
+#define NXP_GAU_DAC_INIT(inst)							\
+	const struct nxp_gau_dac_config nxp_gau_dac_##inst##_config = {		\
+		.base = (DAC_Type *)DT_INST_REG_ADDR(inst),			\
+		.voltage_ref = DT_INST_ENUM_IDX(inst, nxp_dac_reference),	\
+		.conversion_rate = DT_INST_ENUM_IDX(inst, nxp_conversion_rate),	\
 		.output_range = (dac_output_voltage_range_t) _NXP_MAP_OUTPUT_RANGE( \
-			DT_INST_ENUM_IDX(inst, nxp_output_voltage_range)),				\
-	};																		\
-	DEVICE_DT_INST_DEFINE(inst, &nxp_gau_dac_init, NULL,					\
-		NULL,																\
-		&nxp_gau_dac_##inst##_config,										\
-		POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,								\
+			DT_INST_ENUM_IDX(inst, nxp_output_voltage_range)),	\
+	};									\
+	DEVICE_DT_INST_DEFINE(inst, &nxp_gau_dac_init, NULL,			\
+		NULL,								\
+		&nxp_gau_dac_##inst##_config,					\
+		POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,				\
 		&nxp_gau_dac_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(NXP_GAU_DAC_INIT)

--- a/drivers/dac/dac_mcux_gau.c
+++ b/drivers/dac/dac_mcux_gau.c
@@ -101,24 +101,24 @@ static int nxp_gau_dac_init(const struct device *dev)
 	return 0;
 };
 
-#define _NXP_MAP_OUTPUT_RANGE(idx)  \
-	((idx) == 0 ? kDAC_RangeSmall : \
-	(idx) == 1 ? kDAC_RangeMiddle : \
+#define _NXP_MAP_OUTPUT_RANGE(idx)	\
+	((idx) == 0 ? kDAC_RangeSmall :	\
+	(idx) == 1 ? kDAC_RangeMiddle :	\
 	kDAC_RangeLarge)
 
 /* or if you prefer explicit property reuse */
-#define NXP_GAU_DAC_INIT(inst)                                            \
-	const struct nxp_gau_dac_config nxp_gau_dac_##inst##_config = {       \
-		.base = (DAC_Type *)DT_INST_REG_ADDR(inst),                       \
-		.voltage_ref = DT_INST_ENUM_IDX(inst, nxp_dac_reference),         \
-		.conversion_rate = DT_INST_ENUM_IDX(inst, nxp_conversion_rate),   \
+#define NXP_GAU_DAC_INIT(inst)												\
+	const struct nxp_gau_dac_config nxp_gau_dac_##inst##_config = {			\
+		.base = (DAC_Type *)DT_INST_REG_ADDR(inst),							\
+		.voltage_ref = DT_INST_ENUM_IDX(inst, nxp_dac_reference),			\
+		.conversion_rate = DT_INST_ENUM_IDX(inst, nxp_conversion_rate),		\
 		.output_range = (dac_output_voltage_range_t) _NXP_MAP_OUTPUT_RANGE( \
-			DT_INST_ENUM_IDX(inst, nxp_output_voltage_range)),            \
-	};                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, &nxp_gau_dac_init, NULL,                  \
-		NULL,                                           				  \
-		&nxp_gau_dac_##inst##_config,                   				  \
-		POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,          				  \
+			DT_INST_ENUM_IDX(inst, nxp_output_voltage_range)),				\
+	};																		\
+	DEVICE_DT_INST_DEFINE(inst, &nxp_gau_dac_init, NULL,					\
+		NULL,																\
+		&nxp_gau_dac_##inst##_config,										\
+		POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,								\
 		&nxp_gau_dac_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(NXP_GAU_DAC_INIT)

--- a/dts/bindings/dac/nxp,gau-dac.yaml
+++ b/dts/bindings/dac/nxp,gau-dac.yaml
@@ -24,7 +24,8 @@ properties:
       - "small"
       - "medium"
       - "large"
-    default: "large"
+      - "large2"
+    default: "large2"
     description: |
       See specific platform Reference Manual for equations describing the options.
       Default is large because that is the reset value.

--- a/dts/bindings/dac/nxp,gau-dac.yaml
+++ b/dts/bindings/dac/nxp,gau-dac.yaml
@@ -24,8 +24,7 @@ properties:
       - "small"
       - "medium"
       - "large"
-      - "large2"
-    default: "large2"
+    default: "large"
     description: |
       See specific platform Reference Manual for equations describing the options.
       Default is large because that is the reset value.


### PR DESCRIPTION
The devicetree binding `nxp,gau-dac` exposes "small|medium|large" with DT enum indices 0..2,
but the RW61x MCUX SDK enum is sparse: {0,1,3} (kDAC_RangeLarge = 3). The driver previously
passed the DT index straight through, so "large" wrote 2 instead of 3 and the highest range
could not be selected.

This maps the DT indices {0,1,2} to the SDK values {0,1,3}.

Boards/SoC: RW612 (e.g., FRDM-RW612)

Signed-off-by: Alexander Steen Sparre Bille assb@foss.dk