### PR TITLE
Allow configuring SF32LB52 boot ROM flash delays

### DIFF
--- a/dts/arm/sifli/sf32lb52x.dtsi
+++ b/dts/arm/sifli/sf32lb52x.dtsi
@@ -177,8 +177,17 @@
 		rtc: rtc@500cb000 {
 			compatible = "sifli,sf32lb-rtc";
 			reg = <0x500cb000 0x1000>;
+			ranges = <0x0 0x500cb000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			interrupts = <49 0>;
 			status = "disabled";
+
+			backup-registers@30 {
+				compatible = "sifli,sf32lb-rtc-backup";
+				reg = <0x30 0x28>;
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/sifli/sf32lb52x.dtsi
+++ b/dts/arm/sifli/sf32lb52x.dtsi
@@ -173,6 +173,13 @@
 			compatible = "sifli,sf32lb-pmuc", "syscon";
 			reg = <0x500ca000 0x1000>;
 		};
+
+		rtc: rtc@500cb000 {
+			compatible = "sifli,sf32lb-rtc";
+			reg = <0x500cb000 0x1000>;
+			interrupts = <49 0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/bindings/retained_mem/sifli,sf32lb-rtc-backup.yaml
+++ b/dts/bindings/retained_mem/sifli,sf32lb-rtc-backup.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+description: SiFli SF32LB RTC backed retained memory area.
+
+compatible: "sifli,sf32lb-rtc-backup"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/bindings/rtc/sifli,sf32lb-rtc.yaml
+++ b/dts/bindings/rtc/sifli,sf32lb-rtc.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 Core Devices LLC
+# SPDX-License-Identifier: Apache-2.0
+
+description: SiFli SF32LB RTC
+
+compatible: "sifli,sf32lb-rtc"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true

--- a/soc/sifli/sf32/sf32lb52x/Kconfig
+++ b/soc/sifli/sf32/sf32lb52x/Kconfig
@@ -11,3 +11,28 @@ config SOC_SERIES_SF32LB52X
 	select CPU_HAS_ICACHE
 	select CPU_HAS_DCACHE
 	select SOC_EARLY_INIT_HOOK
+
+if SOC_SERIES_SF32LB52X
+
+config SF32LB52X_BOOTROM_FLASH_ON_DELAY_MS
+	int "Boot ROM flash on delay (ms)"
+	default 0
+	range 0 4095
+	help
+	  Configure boot ROM flash on delay (PA21) in milliseconds. Boot ROM
+	  will by default set on/off delays to 0ms before jumping to firmware.
+	  Enabling this option allows to configure the on/off delays to non-zero
+	  values. A flash power cycle guarantees to put the external flash into
+	  a known state before executing code from it. This is required if using
+	  4-byte address mode in the external flash, as the boot ROM will always
+	  use 3-byte address mode when reading from external flash.
+
+config SF32LB52X_BOOTROM_FLASH_OFF_DELAY_MS
+	int "Boot ROM flash off delay (ms)"
+	default 0
+	range 0 255
+	help
+	  Configure boot ROM flash off delay (PA21) in milliseconds. See
+	  SF32LB52X_BOOTROM_FLASH_ON_DELAY_MS help for more details.
+
+endif # SOC_SERIES_SF32LB52X

--- a/soc/sifli/sf32/sf32lb52x/soc.c
+++ b/soc/sifli/sf32/sf32lb52x/soc.c
@@ -3,10 +3,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/cache.h>
+#include <zephyr/sys/util.h>
+
+#define BOOTROM_BKP_REG             DT_REG_ADDR(DT_INST(0, sifli_sf32lb_rtc_backup))
+#define BOOTROM_FLASH_OFF_DELAY_MSK GENMASK(11U, 4U)
+#define BOOTROM_FLASH_ON_DELAY_MSK  GENMASK(23U, 12U)
 
 void soc_early_init_hook(void)
 {
 	sys_cache_instr_enable();
 	sys_cache_data_enable();
+
+#if CONFIG_SF32LB52X_BOOTROM_FLASH_ON_DELAY_MS > 0 ||                                              \
+	CONFIG_SF32LB52X_BOOTROM_FLASH_OFF_DELAY_MS > 0
+	uint32_t val;
+
+	val = sys_read32(BOOTROM_BKP_REG);
+	val &= ~(BOOTROM_FLASH_OFF_DELAY_MSK | BOOTROM_FLASH_ON_DELAY_MSK);
+	val |= FIELD_PREP(BOOTROM_FLASH_OFF_DELAY_MSK,
+			  CONFIG_SF32LB52X_BOOTROM_FLASH_OFF_DELAY_MS) |
+	       FIELD_PREP(BOOTROM_FLASH_ON_DELAY_MSK, CONFIG_SF32LB52X_BOOTROM_FLASH_ON_DELAY_MS);
+	sys_write32(val, BOOTROM_BKP_REG);
+#endif
 }


### PR DESCRIPTION
Boot ROM will by default set on/off delays to 0ms before jumping to
firmware. This patch adds an option to configure the on/off delays to
non-zero values. A flash power cycle guarantees to put the external
flash into a known state before executing code from it. This is required
if using 4-byte address mode in the external flash, as the boot ROM will
always use 3-byte address mode when reading from external flash, causing
a potential deadlock situation requiring a power-cycle (known errata).