### PR TITLE
drivers: power_domain: intel_adsp: Refactor power management initialization

### DIFF
--- a/drivers/power_domain/power_domain_intel_adsp.c
+++ b/drivers/power_domain/power_domain_intel_adsp.c
@@ -83,12 +83,30 @@ static int pd_intel_adsp_pm_action(const struct device *dev, enum pm_device_acti
 
 	return ret;
 }
+
+#else /* !CONFIG_PM_DEVICE */
+
+static int pd_intel_adsp_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	ARG_UNUSED(dev);
+
+	/* When PM is disabled, accept TURN_ON and RESUME but do nothing.
+	 * Power domains remain in their hardware default state.
+	 */
+	switch (action) {
+	case PM_DEVICE_ACTION_TURN_ON:
+	case PM_DEVICE_ACTION_RESUME:
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
 #endif /* CONFIG_PM_DEVICE */
 
 static int pd_intel_adsp_init(const struct device *dev)
 {
-	pm_device_init_suspended(dev);
-	return pm_device_runtime_enable(dev);
+	return pm_device_driver_init(dev, pd_intel_adsp_pm_action);
 }
 
 #define DT_DRV_COMPAT intel_adsp_power_domain

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -398,54 +398,63 @@
 				compatible = "intel,adsp-power-domain";
 				bit-position = <15>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			ml1_domain: ml1_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <13>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			ml0_domain: ml0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <12>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			io3_domain: io3_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <11>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			io2_domain: io2_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <10>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			io1_domain: io1_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <9>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			io0_domain: io0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <8>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			hub_hp_domain: hub_hp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <6>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			hst_domain: hst_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <4>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 		};
 

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -330,36 +330,42 @@
 				compatible = "intel,adsp-power-domain";
 				bit-position = <15>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			ml0_domain: ml0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <12>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			io1_domain: io1_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <9>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			io0_domain: io0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <8>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			hub_hp_domain: hub_hp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <6>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			hst_domain: hst_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <5>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 		};
 

--- a/dts/xtensa/intel/intel_adsp_ace30.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30.dtsi
@@ -483,36 +483,42 @@
 				compatible = "intel,adsp-power-domain";
 				bit-position = <15>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			ml0_domain: ml0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <12>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			io1_domain: io1_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <9>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			io0_domain: io0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <8>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			hub_hp_domain: hub_hpp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <6>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			hst_domain: hst_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <5>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 		};
 

--- a/dts/xtensa/intel/intel_adsp_ace40.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace40.dtsi
@@ -468,36 +468,42 @@
 				compatible = "intel,adsp-power-domain";
 				bit-position = <15>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			ml0_domain: ml0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <12>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			io1_domain: io1_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <9>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			io0_domain: io0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <8>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			hub_hp_domain: hub_hpp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <6>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			hst_domain: hst_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <5>;
 				#power-domain-cells = <0>;
+				zephyr,pm-device-runtime-auto;
 			};
 		};
 


### PR DESCRIPTION
This patch refactors the power management initialization for the Intel ADSP power domain driver to align with the recommended practices outlined in the documentation. The changes include:

1. Replacing the manual power management initialization sequence (`pm_device_init_suspended` + `pm_device_runtime_enable`) with a call to `pm_device_driver_init` in the `pd_intel_adsp_init` function.
2. Adding the `zephyr,pm-device-runtime-auto` property to the power domain nodes in the device tree files for ACE15, ACE20, ACE30, and ACE40.

These changes ensure that the power domain driver is initialized with the appropriate power management state and that runtime power management is automatically enabled based on the device tree configuration. The functionality of the power management state remains unchanged, ensuring consistent behavior.