### PR TITLE
tests: drivers: memc: correct buffer size to support smaller memories

### DIFF
--- a/tests/drivers/memc/ram/src/main.c
+++ b/tests/drivers/memc/ram/src/main.c
@@ -11,13 +11,11 @@
 #include <zephyr/ztest.h>
 
 /** Buffer size. */
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(psram))
-#define BUF_SIZE 524288U
-#else
-#define BUF_SIZE 64U
-#endif
+#define BUF_SIZE_PSRAM	524288U
+#define BUF_SIZE_SDRAM	64U
+#define BUF_SIZE_SRAM	64U
 
-#define BUF_DEF(label) static uint32_t buf_##label[BUF_SIZE]			\
+#define BUF_DEF(label, size) static uint32_t buf_##label[size]		\
 	Z_GENERIC_SECTION(LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(label)))
 
 /**
@@ -39,19 +37,19 @@ static void test_ram_rw(uint32_t *mem, size_t size)
 }
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sdram1))
-BUF_DEF(sdram1);
+BUF_DEF(sdram1, BUF_SIZE_SDRAM);
 #endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sdram2))
-BUF_DEF(sdram2);
+BUF_DEF(sdram2, BUF_SIZE_SDRAM);
 #endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram1))
-BUF_DEF(sram1);
+BUF_DEF(sram1, BUF_SIZE_SRAM);
 #endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram2))
-BUF_DEF(sram2);
+BUF_DEF(sram2, BUF_SIZE_SRAM);
 #endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(memc))
-BUF_DEF(psram);
+BUF_DEF(psram, BUF_SIZE_PSRAM);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ram0))
@@ -64,7 +62,7 @@ ZTEST_SUITE(test_ram, NULL, NULL, NULL, NULL, NULL);
 ZTEST(test_ram, test_sdram1)
 {
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sdram1))
-	test_ram_rw(buf_sdram1, BUF_SIZE);
+	test_ram_rw(buf_sdram1, BUF_SIZE_SDRAM);
 #else
 	ztest_test_skip();
 #endif
@@ -73,7 +71,7 @@ ZTEST(test_ram, test_sdram1)
 ZTEST(test_ram, test_ram0)
 {
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ram0))
-	test_ram_rw(buf_ram0, RAM_SIZE);
+	test_ram_rw(buf_ram0, RAM_SIZE_SRAM);
 #else
 	ztest_test_skip();
 #endif
@@ -82,7 +80,7 @@ ZTEST(test_ram, test_ram0)
 ZTEST(test_ram, test_sdram2)
 {
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sdram2))
-	test_ram_rw(buf_sdram2, BUF_SIZE);
+	test_ram_rw(buf_sdram2, BUF_SIZE_SDRAM);
 #else
 	ztest_test_skip();
 #endif
@@ -91,7 +89,7 @@ ZTEST(test_ram, test_sdram2)
 ZTEST(test_ram, test_sram1)
 {
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram1))
-	test_ram_rw(buf_sram1, BUF_SIZE);
+	test_ram_rw(buf_sram1, BUF_SIZE_SRAM);
 #else
 	ztest_test_skip();
 #endif
@@ -100,7 +98,7 @@ ZTEST(test_ram, test_sram1)
 ZTEST(test_ram, test_sram2)
 {
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram2))
-	test_ram_rw(buf_sram2, BUF_SIZE);
+	test_ram_rw(buf_sram2, BUF_SIZE_SRAM);
 #else
 	ztest_test_skip();
 #endif
@@ -109,7 +107,7 @@ ZTEST(test_ram, test_sram2)
 ZTEST(test_ram, test_psram)
 {
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(memc))
-	test_ram_rw(buf_psram, BUF_SIZE);
+	test_ram_rw(buf_psram, BUF_SIZE_PSRAM);
 #else
 	ztest_test_skip();
 #endif


### PR DESCRIPTION
Correct the buffer size to be adapted to the target memory device not enforcing a 512kB test on SRAMs/SDRAMs when a PSRAM is also tested.

Fixes build failure currently reported by CI (e.g.  #96545 [CI job 51327905850](https://github.com/zephyrproject-rtos/zephyr/actions/runs/18037343701/job/51327905850?pr=96545)).