### PR TITLE
boards: qemu: cortex_r5: declare 192KB tcm_ram area at board level

### DIFF
--- a/boards/qemu/cortex_r5/qemu_cortex_r5.dts
+++ b/boards/qemu/cortex_r5/qemu_cortex_r5.dts
@@ -12,6 +12,11 @@
 	model = "QEMU Cortex-R5";
 	compatible = "xlnx,zynqmp-qemu";
 
+	tcm_ram: memory@0 {
+		compatible = "mmio-sram";
+		reg = <0x0 DT_SIZE_K(192)>;
+	};
+
 	sram0: memory@4000000 {
 		compatible = "mmio-sram";
 		reg = <0x4000000 DT_SIZE_M(64)>;


### PR DESCRIPTION
This commit harmonizes the definition of `tcm_ram` memory between Zephyr’s board description and the fdt-single_arch-zcu102-arm.dts file, which is required because this target relocates the vector table to 0x0 at runtime.