### PR TITLE
doc: services: logging: add limitation when using logging thread name

### DIFF
--- a/doc/services/logging/index.rst
+++ b/doc/services/logging/index.rst
@@ -882,6 +882,26 @@ There are following limitations:
 
 * Logging does not support string format specifier with width (e.g., ``%.*s`` or ``%8s``). That
   is because format string content is not used to build a log message, only argument types.
+* If deferred logging is used and log messages are prefixed with the thread name
+  (Kconfig option ``CONFIG_LOG_THREAD_ID_PREFIX=y`` and ``CONFIG_THREAD_NAME=y``), it is assumed that
+  the corresponding :c:struct:`k_thread` structure is still valid when the log message is
+  formatted. This can be an issue when that structure is allocated dynamically, using :c:func:`k_malloc` or
+  :c:func:`malloc` for instance. In this case, if the thread logs some messages and then gets
+  stopped and its ``struct k_thread`` is freed, the log system will still try to access that
+  structure when handling the message later. This creates a use-after-free scenario.
+  To avoid this, a solution consists in calling :c:func:`log_flush` before freeing the structure.
+
+.. code-block:: c
+
+   struct k_thread *thread = k_malloc(sizeof(*thread)); /* struct allocated dynamically */
+   k_thread_create(thread, ...);
+   k_thread_name_set(thread, "foobar");
+
+   /* Thread calls LOG_*(...) */
+
+   k_thread_join(thread, K_FOREVER);
+   log_flush();  /* flush log buffer before freeing the struct k_thread */
+   k_free(thread); /* avoid a potential use-after-free scenario if deferred logging is used */
 
 Benchmark
 *********


### PR DESCRIPTION
Add a note about a limitation when using deferred logging + thread name together with dynamically allocated struct k_thread. This limitation has been raised in issue #95077.