### PR TITLE
net: dns: swallow packets that have no useful records in them

### DIFF
--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -195,8 +195,6 @@ int dns_unpack_response_header(struct dns_msg_t *msg, int src_id)
 {
 	uint8_t *dns_header;
 	uint16_t size;
-	int qdcount;
-	int ancount;
 	int rc;
 
 	dns_header = msg->msg;
@@ -229,16 +227,6 @@ int dns_unpack_response_header(struct dns_msg_t *msg, int src_id)
 	default:
 		return rc;
 
-	}
-
-	qdcount = dns_unpack_header_qdcount(dns_header);
-	ancount = dns_unpack_header_ancount(dns_header);
-
-	/* For mDNS (when src_id == 0) the query count is 0 so accept
-	 * the packet in that case.
-	 */
-	if ((qdcount < 1 && src_id > 0) || ancount < 1) {
-		return -EINVAL;
 	}
 
 	return 0;


### PR DESCRIPTION
There are some poorly compliant mdns responders on the network that will respond with zero counts on the answers and the additional records (in addition to the qdcount). So, this removes the checks in the unpack method since this is a "valid" DNS packet but the logic is already partially handled in the dns_read code already.

An example packet can be seen in this decode
```
  0000   33 33 00 00 00 fb 9a f8 c3 0c 07 0b 86 dd 60 07   33............`.
  0010   c4 e4 00 14 11 ff fe 80 00 00 00 00 00 00 98 f8   ................
  0020   c3 ff fe 0c 07 0b ff 02 00 00 00 00 00 00 00 00   ................
  0030   00 00 00 00 00 fb 14 e9 14 e9 00 14 f1 64 00 00   .............d..
  0040   84 00 00 00 00 00 00 00 00 00                     ..........

  User Datagram Protocol, Src Port: 5353, Dst Port: 5353
    Source Port: 5353
    Destination Port: 5353
    Length: 20
    Checksum: 0xf164 [unverified]
    [Checksum Status: Unverified]
    [Stream index: 2]
    [Stream Packet Number: 1]
    [Timestamps]
    UDP payload (12 bytes)
  Multicast Domain Name System (response)
    Transaction ID: 0x0000
    Flags: 0x8400 Standard query response, No error
        1... .... .... .... = Response: Message is a response
        .000 0... .... .... = Opcode: Standard query (0)
        .... .1.. .... .... = Authoritative: Server is an authority for domain
        .... ..0. .... .... = Truncated: Message is not truncated
        .... ...0 .... .... = Recursion desired: Don't do query recursively
        .... .... 0... .... = Recursion available: Server can't do
                              recursive queries
        .... .... .0.. .... = Z: reserved (0)
        .... .... ..0. .... = Answer authenticated: Answer/authority portion
                              was not authenticated by the server
        .... .... ...0 .... = Non-authenticated data: Unacceptable
        .... .... .... 0000 = Reply code: No error (0)
    Questions: 0
    Answer RRs: 0
    Authority RRs: 0
    Additional RRs: 0
    [Unsolicited: True]
```