### PR TITLE
kernel: essential work queue should not stop

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -3932,6 +3932,7 @@ int k_work_queue_unplug(struct k_work_q *queue);
  * @retval -EALREADY if the work queue was not started (or already stopped)
  * @retval -EBUSY if the work queue is actively processing work items
  * @retval -ETIMEDOUT if the work queue did not stop within the stipulated timeout
+ * @retval -ENOSUP if the work queue is essential
  */
 int k_work_queue_stop(struct k_work_q *queue, k_timeout_t timeout);
 

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -920,6 +920,11 @@ int k_work_queue_stop(struct k_work_q *queue, k_timeout_t timeout)
 	__ASSERT_NO_MSG(queue);
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work_queue, stop, queue, timeout);
+
+	if (z_is_thread_essential(&queue->thread)) {
+		return -ENOTSUP;
+	}
+
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	if (!flag_test(&queue->flags, K_WORK_QUEUE_STARTED_BIT)) {

--- a/tests/kernel/workq/work_queue/src/start_stop.c
+++ b/tests/kernel/workq/work_queue/src/start_stop.c
@@ -56,6 +56,23 @@ ZTEST(workqueue_api, test_k_work_queue_start_stop)
 		      "Succeeded to submit work item to non-initialized work queue");
 }
 
+ZTEST(workqueue_api, test_k_work_queue_stop_sys_thread)
+{
+	struct k_work_q work_q = {0};
+	struct k_work_queue_config cfg = {
+		.name = "test_work_q",
+		.no_yield = true,
+		.essential = true,
+	};
+
+	k_work_queue_start(&work_q, work_q_stack, K_THREAD_STACK_SIZEOF(work_q_stack),
+			   K_PRIO_PREEMPT(4), &cfg);
+
+	zassert_true(k_work_queue_drain(&work_q, true) >= 0, "Failed to drain & plug work queue");
+	zassert_equal(-ENOTSUP, k_work_queue_stop(&work_q, K_FOREVER), "Failed to stop work queue");
+}
+
+
 #define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
 
 static K_THREAD_STACK_DEFINE(run_stack, STACK_SIZE);


### PR DESCRIPTION
First patch avoid stop essential thread from work queue.
The second patch increases mps2/an385 ISR stack duo to QEMU issue.
The third patch add debug info and we should only add additional check to run queue.