### PR TITLE
drivers: adc: remove '&' when assigning `adc_xxx_init`

### DIFF
--- a/drivers/adc/adc_ad4130.c
+++ b/drivers/adc/adc_ad4130.c
@@ -1064,7 +1064,7 @@ static DEVICE_API(adc, adc_ad4130_driver_api) = {
 		ADC_CONTEXT_INIT_TIMER(adc_ad4130_data_##inst, ctx),                               \
 		ADC_CONTEXT_INIT_SYNC(adc_ad4130_data_##inst, ctx),                                \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, &ad4130_init, NULL, &adc_ad4130_data_##inst,                   \
+	DEVICE_DT_INST_DEFINE(inst, ad4130_init, NULL, &adc_ad4130_data_##inst,                    \
 			      &ad4130_config_##inst, POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,        \
 			      &adc_ad4130_driver_api);
 

--- a/drivers/adc/adc_ambiq.c
+++ b/drivers/adc/adc_ambiq.c
@@ -572,7 +572,7 @@ static int adc_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 		.pin_cfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                      \
 	};                                                                                         \
 	PM_DEVICE_DT_INST_DEFINE(n, adc_ambiq_pm_action);                                          \
-	DEVICE_DT_INST_DEFINE(n, &adc_ambiq_init, PM_DEVICE_DT_INST_GET(n), &adc_ambiq_data_##n,   \
+	DEVICE_DT_INST_DEFINE(n, adc_ambiq_init, PM_DEVICE_DT_INST_GET(n), &adc_ambiq_data_##n,    \
 			      &adc_ambiq_config_##n, POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,        \
 			      &adc_ambiq_driver_api_##n);
 

--- a/drivers/adc/adc_cc13xx_cc26xx.c
+++ b/drivers/adc/adc_cc13xx_cc26xx.c
@@ -295,7 +295,7 @@ static DEVICE_API(adc, cc13xx_cc26xx_driver_api) = {
 		ADC_CONTEXT_INIT_SYNC(adc_cc13xx_cc26xx_data_##index, ctx),	 \
 	};									 \
 	DEVICE_DT_INST_DEFINE(index,						 \
-		&adc_cc13xx_cc26xx_init, NULL,					 \
+		adc_cc13xx_cc26xx_init, NULL,					 \
 		&adc_cc13xx_cc26xx_data_##index,				 \
 		&adc_cc13xx_cc26xx_cfg_##index, POST_KERNEL,			 \
 		CONFIG_ADC_INIT_PRIORITY,					 \

--- a/drivers/adc/adc_cc23x0.c
+++ b/drivers/adc/adc_cc23x0.c
@@ -622,7 +622,7 @@ static DEVICE_API(adc, adc_cc23x0_driver_api) = {
 	};									\
 										\
 	DEVICE_DT_INST_DEFINE(n,						\
-			      &adc_cc23x0_init,					\
+			      adc_cc23x0_init,					\
 			      PM_DEVICE_DT_INST_GET(n),				\
 			      &adc_cc23x0_data_##n,				\
 			      &adc_cc23x0_config_##n,				\

--- a/drivers/adc/adc_cc32xx.c
+++ b/drivers/adc/adc_cc32xx.c
@@ -312,7 +312,7 @@ static DEVICE_API(adc, cc32xx_driver_api) = {
 	};									 \
 										 \
 	DEVICE_DT_INST_DEFINE(index,						 \
-			      &adc_cc32xx_init, NULL, &adc_cc32xx_data_##index,	 \
+			      adc_cc32xx_init, NULL, &adc_cc32xx_data_##index,	 \
 			      &adc_cc32xx_cfg_##index, POST_KERNEL,		 \
 			      CONFIG_ADC_INIT_PRIORITY,				 \
 			      &cc32xx_driver_api);				 \

--- a/drivers/adc/adc_ene_kb106x.c
+++ b/drivers/adc/adc_ene_kb106x.c
@@ -258,7 +258,7 @@ static int adc_kb106x_init(const struct device *dev)
 		.adc = (struct adc_regs *)DT_INST_REG_ADDR(inst),                                  \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                      \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, &adc_kb106x_init, NULL, &adc_kb106x_data_##inst,               \
+	DEVICE_DT_INST_DEFINE(inst, adc_kb106x_init, NULL, &adc_kb106x_data_##inst,                \
 			      &adc_kb106x_config_##inst, PRE_KERNEL_1,                             \
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &adc_kb106x_api);
 

--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -773,7 +773,7 @@ static DEVICE_API(adc, api_esp32_driver_api) = {
 			},                                                                         \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, &adc_esp32_init, NULL, &adc_esp32_data_##inst,                 \
+	DEVICE_DT_INST_DEFINE(inst, adc_esp32_init, NULL, &adc_esp32_data_##inst,                  \
 			      &adc_esp32_conf_##inst, POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,       \
 			      &api_esp32_driver_api);
 

--- a/drivers/adc/adc_gd32.c
+++ b/drivers/adc/adc_gd32.c
@@ -499,7 +499,7 @@ static void adc_gd32_global_irq_cfg(void)
 		ADC_CLOCK_SOURCE(n)								\
 	};											\
 	DEVICE_DT_INST_DEFINE(n,								\
-			      &adc_gd32_init, NULL,						\
+			      adc_gd32_init, NULL,						\
 			      &adc_gd32_data_##n, &adc_gd32_config_##n,				\
 			      POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,				\
 			      &adc_gd32_driver_api);						\

--- a/drivers/adc/adc_gecko.c
+++ b/drivers/adc/adc_gecko.c
@@ -307,7 +307,7 @@ static DEVICE_API(adc, api_gecko_adc_driver_api) = {
 		irq_enable(DT_INST_IRQN(n));	\
 	}; \
 	DEVICE_DT_INST_DEFINE(n,					 \
-			      &adc_gecko_init, NULL,			 \
+			      adc_gecko_init, NULL,			 \
 			      &adc_gecko_data_##n, &adc_gecko_config_##n,\
 			      POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,	 \
 			      &api_gecko_adc_driver_api);

--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -1073,7 +1073,7 @@ static DEVICE_API(adc, lmp90xxx_adc_api) = {
 		.channels = ch, \
 	}; \
 	DEVICE_DT_DEFINE(DT_INST_LMP90XXX(n, t), \
-			 &lmp90xxx_init, NULL, \
+			 lmp90xxx_init, NULL, \
 			 &lmp##t##_data_##n, \
 			 &lmp##t##_config_##n, POST_KERNEL, \
 			 CONFIG_ADC_INIT_PRIORITY, \

--- a/drivers/adc/adc_ltc2451.c
+++ b/drivers/adc/adc_ltc2451.c
@@ -98,7 +98,7 @@ static DEVICE_API(adc, ltc2451_api) = {
 		.conversion_speed = DT_INST_PROP(index, conversion_speed), \
 	}; \
  \
-	DEVICE_DT_INST_DEFINE(index, &ltc2451_init, NULL, NULL, \
+	DEVICE_DT_INST_DEFINE(index, ltc2451_init, NULL, NULL, \
 			      &ltc2451_cfg_##index, POST_KERNEL, CONFIG_ADC_INIT_PRIORITY, \
 			      &ltc2451_api);
 

--- a/drivers/adc/adc_max32.c
+++ b/drivers/adc/adc_max32.c
@@ -620,7 +620,7 @@ static DEVICE_API(adc, adc_max32_driver_api) = {
 		ADC_CONTEXT_INIT_SYNC(max32_adc_data_##_num, ctx),                                 \
 		.resolution = DT_INST_PROP(_num, resolution),                                      \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(_num, &adc_max32_init, NULL, &max32_adc_data_##_num,                 \
+	DEVICE_DT_INST_DEFINE(_num, adc_max32_init, NULL, &max32_adc_data_##_num,                  \
 			      &max32_adc_config_##_num, POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,     \
 			      &adc_max32_driver_api);
 

--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -320,7 +320,7 @@ static DEVICE_API(adc, mcp320x_adc_api) = {
 		.channels = ch, \
 	}; \
 	DEVICE_DT_DEFINE(INST_DT_MCP320X(n, t), \
-			 &mcp320x_init, NULL, \
+			 mcp320x_init, NULL, \
 			 &mcp##t##_data_##n, \
 			 &mcp##t##_config_##n, POST_KERNEL, \
 			 CONFIG_ADC_INIT_PRIORITY, \

--- a/drivers/adc/adc_mcp356xr.c
+++ b/drivers/adc/adc_mcp356xr.c
@@ -1308,7 +1308,7 @@ static DEVICE_API(adc, adc_mcp356xr_api) = {
 		.dev = DEVICE_DT_INST_GET(index),                                                  \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(index, &adc_mcp356xr_init, NULL, &adc_mcp356xr_data_##index,         \
+	DEVICE_DT_INST_DEFINE(index, adc_mcp356xr_init, NULL, &adc_mcp356xr_data_##index,          \
 			      &adc_mcp356xr_config_##index, POST_KERNEL, CONFIG_ADC_INIT_PRIORITY, \
 			      &adc_mcp356xr_api);
 

--- a/drivers/adc/adc_mcux_12b1msps_sar.c
+++ b/drivers/adc/adc_mcux_12b1msps_sar.c
@@ -303,7 +303,7 @@ static DEVICE_API(adc, mcux_12b1msps_sar_adc_driver_api) = {
 		ADC_CONTEXT_INIT_SYNC(mcux_12b1msps_sar_adc_data_##n, ctx),	       \
 	};								       \
 									       \
-	DEVICE_DT_INST_DEFINE(n, &mcux_12b1msps_sar_adc_init, NULL,     \
+	DEVICE_DT_INST_DEFINE(n, mcux_12b1msps_sar_adc_init, NULL,     \
 			      &mcux_12b1msps_sar_adc_data_##n, &mcux_12b1msps_sar_adc_config_##n,  \
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 			      &mcux_12b1msps_sar_adc_driver_api);			       \

--- a/drivers/adc/adc_mcux_adc12.c
+++ b/drivers/adc/adc_mcux_adc12.c
@@ -305,7 +305,7 @@ static int mcux_adc12_init(const struct device *dev)
 		ADC_CONTEXT_INIT_SYNC(mcux_adc12_data_##n, ctx),	\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, &mcux_adc12_init,			\
+	DEVICE_DT_INST_DEFINE(n, mcux_adc12_init,			\
 			    NULL, &mcux_adc12_data_##n,			\
 			    &mcux_adc12_config_##n, POST_KERNEL,	\
 			    CONFIG_ADC_INIT_PRIORITY,			\

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -550,7 +550,7 @@ static DEVICE_API(adc, mcux_adc16_driver_api) = {
 		ADC16_MCUX_EDMA_DATA(n)					\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, &mcux_adc16_init,	\
+	DEVICE_DT_INST_DEFINE(n, mcux_adc16_init,	\
 			      NULL,	\
 			      &mcux_adc16_data_##n,	\
 			      &mcux_adc16_config_##n,	\

--- a/drivers/adc/adc_mcux_gau_adc.c
+++ b/drivers/adc/adc_mcux_gau_adc.c
@@ -377,7 +377,7 @@ static DEVICE_API(adc, mcux_gau_adc_driver_api) = {
 										\
 	static struct mcux_gau_adc_data mcux_gau_adc_data_##n = {0};		\
 										\
-	DEVICE_DT_INST_DEFINE(n, &mcux_gau_adc_init, NULL,			\
+	DEVICE_DT_INST_DEFINE(n, mcux_gau_adc_init, NULL,			\
 			      &mcux_gau_adc_data_##n, &mcux_gau_adc_config_##n,	\
 			      POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,		\
 			      &mcux_gau_adc_driver_api);			\

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -726,7 +726,7 @@ static DEVICE_API(adc, mcux_lpadc_driver_api) = {
 	};														\
 										\
 	DEVICE_DT_INST_DEFINE(n,						\
-		&mcux_lpadc_init, NULL, &mcux_lpadc_data_##n,			\
+		mcux_lpadc_init, NULL, &mcux_lpadc_data_##n,			\
 		&mcux_lpadc_config_##n, POST_KERNEL,				\
 		CONFIG_ADC_INIT_PRIORITY,					\
 		&mcux_lpadc_driver_api);							\

--- a/drivers/adc/adc_mcux_sar_adc.c
+++ b/drivers/adc/adc_mcux_sar_adc.c
@@ -212,7 +212,7 @@ static DEVICE_API(adc, mcux_sar_adc_driver_api) = {
 		ADC_CONTEXT_INIT_SYNC(mcux_sar_adc_data_##n, ctx),                                 \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &mcux_sar_adc_init, NULL, &mcux_sar_adc_data_##n,                 \
+	DEVICE_DT_INST_DEFINE(n, mcux_sar_adc_init, NULL, &mcux_sar_adc_data_##n,                  \
 			      &mcux_sar_adc_config_##n, POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,     \
 			      &mcux_sar_adc_driver_api);                                           \
                                                                                                    \

--- a/drivers/adc/adc_numaker.c
+++ b/drivers/adc/adc_numaker.c
@@ -397,7 +397,7 @@ done:
 		ADC_CONTEXT_INIT_SYNC(adc_numaker_data_##inst, ctx),			     \
 	};									             \
 	DEVICE_DT_INST_DEFINE(inst,                                                          \
-			      &adc_numaker_init, NULL,                                       \
+			      adc_numaker_init, NULL,                                        \
 			      &adc_numaker_data_##inst, &adc_numaker_cfg_##inst,             \
 			      POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,			     \
 			      &adc_numaker_driver_api);

--- a/drivers/adc/adc_nxp_s32_adc_sar.c
+++ b/drivers/adc/adc_nxp_s32_adc_sar.c
@@ -451,7 +451,7 @@ static void adc_nxp_s32_isr(const struct device *dev)
 				(PINCTRL_DT_INST_DEV_CONFIG_GET(n)), (NULL)),	\
 	};									\
 	DEVICE_DT_INST_DEFINE(n,						\
-			&adc_nxp_s32_init,					\
+			adc_nxp_s32_init,					\
 			NULL,							\
 			&adc_nxp_s32_data_##n,					\
 			&adc_nxp_s32_config_##n,				\

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -2009,7 +2009,7 @@ static struct adc_stm32_data adc_stm32_data_##index = {			\
 PM_DEVICE_DT_INST_DEFINE(index, adc_stm32_pm_action);			\
 									\
 DEVICE_DT_INST_DEFINE(index,						\
-		    &adc_stm32_init, PM_DEVICE_DT_INST_GET(index),	\
+		    adc_stm32_init, PM_DEVICE_DT_INST_GET(index),	\
 		    &adc_stm32_data_##index, &adc_stm32_cfg_##index,	\
 		    POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,		\
 		    &api_stm32_driver_api);

--- a/drivers/adc/adc_stm32wb0.c
+++ b/drivers/adc/adc_stm32wb0.c
@@ -1246,6 +1246,6 @@ static struct adc_stm32wb0_data adc_data = {
 
 PM_DEVICE_DT_DEFINE(ADC_NODE, adc_stm32wb0_pm_action);
 
-DEVICE_DT_DEFINE(ADC_NODE, &adc_stm32wb0_init, PM_DEVICE_DT_GET(ADC_NODE),
+DEVICE_DT_DEFINE(ADC_NODE, adc_stm32wb0_init, PM_DEVICE_DT_GET(ADC_NODE),
 	&adc_data, &adc_config, POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,
 	&api_stm32wb0_driver_api);

--- a/drivers/adc/adc_ti_am335x.c
+++ b/drivers/adc/adc_ti_am335x.c
@@ -399,7 +399,7 @@ static void ti_adc_isr(const struct device *dev)
 		.dev = DEVICE_DT_INST_GET(n),                                                      \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &ti_adc_init, NULL, &ti_adc_data_##n, &ti_adc_cfg_##n,            \
+	DEVICE_DT_INST_DEFINE(n, ti_adc_init, NULL, &ti_adc_data_##n, &ti_adc_cfg_##n,             \
 			      POST_KERNEL, CONFIG_ADC_INIT_PRIORITY, &ti_adc_driver_api_##n);
 
 DT_INST_FOREACH_STATUS_OKAY(TI_ADC_INIT)

--- a/drivers/adc/adc_tla202x.c
+++ b/drivers/adc/adc_tla202x.c
@@ -445,7 +445,7 @@ static DEVICE_API(adc, tla202x_driver_api) = {
 		IF_ENABLED(CONFIG_ADC_ASYNC,                                                       \
 			   (.acq_lock = Z_SEM_INITIALIZER(inst_##t##_##n##_data.acq_lock, 0, 1),)) \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(n, &tla202x_init, NULL, &inst_##t##_##n##_data,                      \
+	DEVICE_DT_INST_DEFINE(n, tla202x_init, NULL, &inst_##t##_##n##_data,                       \
 			      &inst_##t##_##n##_config, POST_KERNEL,                               \
 			      CONFIG_ADC_TLA202X_INIT_PRIORITY, &tla202x_driver_api);
 

--- a/drivers/adc/adc_vf610.c
+++ b/drivers/adc/adc_vf610.c
@@ -257,7 +257,7 @@ static DEVICE_API(adc, vf610_adc_driver_api) = {
 		ADC_CONTEXT_INIT_SYNC(vf610_adc_data_##n, ctx),		\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, &vf610_adc_init,			\
+	DEVICE_DT_INST_DEFINE(n, vf610_adc_init,			\
 			      NULL, &vf610_adc_data_##n,		\
 			      &vf610_adc_config_##n, POST_KERNEL,	\
 			      CONFIG_ADC_INIT_PRIORITY,			\

--- a/drivers/adc/adc_xmc4xxx.c
+++ b/drivers/adc/adc_xmc4xxx.c
@@ -334,7 +334,7 @@ static struct adc_xmc4xxx_data adc_xmc4xxx_data_##index = {			\
 };										\
 										\
 DEVICE_DT_INST_DEFINE(index,							\
-		    &adc_xmc4xxx_init, NULL,					\
+		    adc_xmc4xxx_init, NULL,					\
 		    &adc_xmc4xxx_data_##index, &adc_xmc4xxx_cfg_##index,	\
 		    POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,			\
 		    &api_xmc4xxx_driver_api);

--- a/drivers/adc/iadc_gecko.c
+++ b/drivers/adc/iadc_gecko.c
@@ -445,7 +445,7 @@ static DEVICE_API(adc, api_gecko_adc_driver_api) = {
 		irq_enable(DT_INST_IRQN(n));	\
 	}; \
 	DEVICE_DT_INST_DEFINE(n,					 \
-			      &adc_gecko_init, PM_DEVICE_DT_INST_GET(n), \
+			      adc_gecko_init, PM_DEVICE_DT_INST_GET(n),  \
 			      &adc_gecko_data_##n, &adc_gecko_config_##n,\
 			      POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,	 \
 			      &api_gecko_adc_driver_api);


### PR DESCRIPTION
Remove address-of operator ('&') when assigning `adc_xxx_init` function pointer in `DEVICE_DT_INST_DEFINE` and `DEVICE_DT_DEFINE` macro.

This change aims to maintain consistency among the drivers in `drivers/adc`, ensuring that all function pointer assignments follow the same pattern.