### PR TITLE
tests: can: api: changing the test thread priority

### DIFF
--- a/tests/drivers/can/api/prj.conf
+++ b/tests/drivers/can/api/prj.conf
@@ -5,5 +5,13 @@ CONFIG_STATS=y
 CONFIG_CAN_STATS=y
 CONFIG_TEST_USERSPACE=y
 CONFIG_ZTEST=y
+# Global default settings assign both the ZTest thread and the
+# system worker queue to the same cooperative priority. Relying
+# solely on the system worker queue for concurrency management
+# can lead to unwanted interference between the two threads,
+# causing the test to report its expected sequence of system
+# events as an error. This situation will be avoided by moving
+# the ZTest thread to the highest priority preemptive thread.
+CONFIG_ZTEST_THREAD_PRIORITY=0
 # The canfd test suite may be skipped
 CONFIG_ZTEST_VERIFY_RUN_ALL=n


### PR DESCRIPTION
The test thread and the system workqueue have the same priority, mostly some specific CAN driver threads a lower preemptive priority, so it is a bit arbitrary whether the workqueue cleans up the send context before the next send.

Fixes #96650