### PR TITLE
Opamp adjust modes

### DIFF
--- a/drivers/opamp/opamp_mcux_opamp.c
+++ b/drivers/opamp/opamp_mcux_opamp.c
@@ -81,9 +81,9 @@ static int mcux_opamp_set_gain(const struct device *dev, enum opamp_gain gain)
 	}
 
 	switch (config->functional_mode) {
-	case OPAMP_DIFFERENTIAL_MODE:
-	case OPAMP_INVERTING_MODE:
-	case OPAMP_NON_INVERTING_MODE:
+	case OPAMP_FUNCTIONAL_MODE_DIFFERENTIAL:
+	case OPAMP_FUNCTIONAL_MODE_INVERTING:
+	case OPAMP_FUNCTIONAL_MODE_NON_INVERTING:
 		/* For differential, inverting and non-inverting mode,
 		 * set Ngain to select different gains, and set Pgain
 		 * to be the same as Ngain.
@@ -91,7 +91,7 @@ static int mcux_opamp_set_gain(const struct device *dev, enum opamp_gain gain)
 		OPAMP_DoNegGainConfig(config->base, gain_index);
 		OPAMP_DoPosGainConfig(config->base, gain_index);
 		break;
-	case OPAMP_FOLLOWER_MODE:
+	case OPAMP_FUNCTIONAL_MODE_FOLLOWER:
 		OPAMP_DoNegGainConfig(config->base, kOPAMP_NegGainBufferMode);
 		OPAMP_DoPosGainConfig(config->base, kOPAMP_PosGainNonInvert1X);
 	default:
@@ -179,11 +179,11 @@ int mcux_opamp_init(const struct device *dev)
 #endif
 
 	switch (config->functional_mode) {
-	case OPAMP_DIFFERENTIAL_MODE:
-	case OPAMP_INVERTING_MODE:
-	case OPAMP_NON_INVERTING_MODE:
+	case OPAMP_FUNCTIONAL_MODE_DIFFERENTIAL:
+	case OPAMP_FUNCTIONAL_MODE_INVERTING:
+	case OPAMP_FUNCTIONAL_MODE_NON_INVERTING:
 		break;
-	case OPAMP_FOLLOWER_MODE:
+	case OPAMP_FUNCTIONAL_MODE_FOLLOWER:
 #if defined(FSL_FEATURE_OPAMP_HAS_OPAMP_CTR_BUFEN) && FSL_FEATURE_OPAMP_HAS_OPAMP_CTR_BUFEN
 		base->OPAMP_CTR &= ~OPAMP_OPAMP_CTR_BUFEN_MASK;
 #else

--- a/dts/bindings/opamp/opamp-controller.yaml
+++ b/dts/bindings/opamp/opamp-controller.yaml
@@ -13,6 +13,7 @@ properties:
       - "inverting"
       - "non_inverting"
       - "follower"
+      - "standalone"
     description: |
       Selects opamp functional mode.
 

--- a/include/zephyr/dt-bindings/opamp/opamp.h
+++ b/include/zephyr/dt-bindings/opamp/opamp.h
@@ -19,6 +19,12 @@ enum opamp_functional_mode {
 	OPAMP_FUNCTIONAL_MODE_NON_INVERTING,
 	/** Follower mode */
 	OPAMP_FUNCTIONAL_MODE_FOLLOWER,
+	/**
+	 * @brief Standalone mode.
+	 * The gain is set by external resistors. The API call to set the gain
+	 * is ignored in this mode or has no impact.
+	 */
+	OPAMP_FUNCTIONAL_MODE_STANDALONE,
 };
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_OPAMP_OPAMP_H_ */

--- a/include/zephyr/dt-bindings/opamp/opamp.h
+++ b/include/zephyr/dt-bindings/opamp/opamp.h
@@ -12,13 +12,13 @@
  */
 enum opamp_functional_mode {
 	/** Differential amplifier mode */
-	OPAMP_DIFFERENTIAL_MODE = 0,
+	OPAMP_FUNCTIONAL_MODE_DIFFERENTIAL = 0,
 	/** Inverting amplifier mode */
-	OPAMP_INVERTING_MODE,
+	OPAMP_FUNCTIONAL_MODE_INVERTING,
 	/** Non-inverting amplifier mode */
-	OPAMP_NON_INVERTING_MODE,
+	OPAMP_FUNCTIONAL_MODE_NON_INVERTING,
 	/** Follower mode */
-	OPAMP_FOLLOWER_MODE,
+	OPAMP_FUNCTIONAL_MODE_FOLLOWER,
 };
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_OPAMP_OPAMP_H_ */


### PR DESCRIPTION
Unluckily some newly introduced OPAMP modes from [include/zephyr/dt-bindings/opamp/opamp.h](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/dt-bindings/opamp/opamp.h#L13-L22) are clashing with ST's definitions (see ST definitions [here](https://github.com/zephyrproject-rtos/hal_stm32/blob/main/stm32cube/stm32g4xx/drivers/include/stm32g4xx_hal_opamp.h#L195-L197)).

This PR is doing following stuff:

- Changing `OPAMP_*_MODE` patterns to `OPAMP_FUNCTIONAL_MODE_*` ones. Now enums have also `FUNCTIONAL` keyword in the naming, s.t. it is clear, to which kind of mode used value becomes directly by reading the code. This approach shall reduce probability for clashing in the future. An alternative may also be `Z_OPAMP_MODE_*` prefix. Let's discuss, if you wish that one.
- Adding `OPAMP_FUNCTIONAL_MODE_STANDALONE` to cover setting of the PGA by external circuitry. See corresponding comment in  [include/zephyr/dt-bindings/opamp/opamp.h](https://github.com/KozhinovAlexander/zephyr/blob/opamp_adjust_modes/include/zephyr/dt-bindings/opamp/opamp.h#L22-L27)