### PR TITLE
lib: smf: remove unreachable case in get_lca_of()

### DIFF
--- a/lib/smf/smf.c
+++ b/lib/smf/smf.c
@@ -57,7 +57,8 @@ static const struct smf_state *get_last_of(const struct smf_state *states)
 }
 
 /**
- * @brief Find the Least Common Ancestor (LCA) of two states
+ * @brief Find the Least Common Ancestor (LCA) of two states,
+ *	  that are not ancestors of one another.
  *
  * @param source transition source
  * @param dest transition destination
@@ -68,9 +69,8 @@ static const struct smf_state *get_lca_of(const struct smf_state *source,
 {
 	for (const struct smf_state *ancestor = source->parent; ancestor != NULL;
 	     ancestor = ancestor->parent) {
-		if (ancestor == dest) {
-			return ancestor->parent;
-		} else if (share_parent(dest, ancestor)) {
+		/* First common ancestor */
+		if (share_parent(dest, ancestor)) {
 			return ancestor;
 		}
 	}


### PR DESCRIPTION
Summery:
smf_set_state() excludes ancestor/descendant relations before calling get_lca_of(). The function now walks from source->parent and returns the first ancestor that contains dest. The 'ancestor == dest' case was unreachable and is removed.

Testing: 
- Twister (hsm_psicc2 sample):
 
```
./scripts/twister -T samples/subsys/smf/hsm_psicc2/ \
    -p native_sim -p qemu_cortex_m3 -p qemu_cortex_m0 \
    -p qemu_x86 -p qemu_riscv32 -v --inline-logs -j"$(nproc)"
```

Got a PASS on above platforms.

Ref: RFC #95952