### PR TITLE
boards: disco_l475_iot1 update openocd.cfg

### DIFF
--- a/boards/st/disco_l475_iot1/support/openocd.cfg
+++ b/boards/st/disco_l475_iot1/support/openocd.cfg
@@ -1,7 +1,1 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32l4x.cfg]
-
-reset_config srst_only
+source [find board/stm32l4discovery.cfg]


### PR DESCRIPTION
Latest versions of OpenOCD don't seem to work with `transport select hla_swd`, but the `board/stm32l4discovery.cfg` file should work on any version of OpenOCD that contains it (including my older version).

This should keep things forward-compatible.

Probably this will affect other stm32 boards using `hla_swd` but I have no way of testing them.