### PR TITLE
MAINTAINERS: add entry for opamp drivers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2036,6 +2036,24 @@ Documentation Infrastructure:
   tests:
     - drivers.modem
 
+"Drivers: OPAMP":
+  status: maintained
+  maintainers:
+    - ZhaoxiangJin
+  files:
+    - include/zephyr/drivers/opamp.h
+    - include/zephyr/dt-bindings/opamp/
+    - dts/bindings/opamp/
+    - drivers/opamp/
+    - samples/drivers/opamp/
+    - tests/drivers/build_all/opamp/
+    - tests/drivers/opamp/
+    - doc/hardware/peripherals/opamp.rst
+  labels:
+    - "area: OPAMP"
+  tests:
+    - drivers.opamp
+
 "Drivers: PCI":
   status: maintained
   maintainers:


### PR DESCRIPTION
I introduced the OPAMP device driver model in Zephyr (see https://github.com/zephyrproject-rtos/zephyr/pull/94040). I volunteer to become the maintainer for this module. Thanks.