### PR TITLE
drivers: video: shell: fix control name lookup

### DIFF
--- a/drivers/video/video_shell.c
+++ b/drivers/video/video_shell.c
@@ -651,7 +651,7 @@ static int video_shell_get_ctrl_by_name(struct video_ctrl_query *cq, char const 
 			return -ENOENT;
 		}
 
-		video_shell_convert_ctrl_name(name, ctrl_name, sizeof(ctrl_name));
+		video_shell_convert_ctrl_name(cq->name, ctrl_name, sizeof(ctrl_name));
 		if (strcmp(ctrl_name, name) == 0) {
 			break;
 		}


### PR DESCRIPTION
video_shell_get_ctrl_by_name() normalized the search string (`name`) instead of the control's actual name (`cq->name`). This made the comparison always succeed on the first control, causing incorrect lookups at runtime.

Update the code to normalize `cq->name` before comparison so that each control name is correctly checked against the search string.