### PR TITLE
submanifests: optional: update rust commit to fix blinky build error

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -54,7 +54,7 @@ manifest:
       groups:
         - optional
     - name: zephyr-lang-rust
-      revision: dd73abc242e995784da62352fe8c70d9a6c7ac2e
+      revision: 7e5f345d7e5f5d8a93573c4528237181603dbebf
       path: modules/lang/rust
       remote: upstream
       groups:


### PR DESCRIPTION
The Rust blinky sample was failing to build in weekly CI, so bump the revision of the rust module so that it includes the fix that already exists.

https://github.com/zephyrproject-rtos/zephyr/actions/runs/18068117603/job/51413729478

Testing done:
```shell
west build -p auto -b nrf52840dk/nrf52840 ../modules/lang/rust/samples/blinky -T sample.rust.basic.blinky
```