### PR TITLE
drivers: serial: pl011: only declare ambiq pm action when used

### DIFF
--- a/drivers/serial/uart_pl011_ambiq.h
+++ b/drivers/serial/uart_pl011_ambiq.h
@@ -62,7 +62,7 @@ static inline int clk_enable_ambiq_uart(const struct device *dev, uint32_t clk)
 	return pl011_ambiq_clk_set(dev, clk);
 }
 
-#if !defined(CONFIG_SOC_SERIES_APOLLO2X)
+#if defined(CONFIG_SOC_SERIES_APOLLO3X) || defined(CONFIG_SOC_SERIES_APOLLO5X)
 #ifdef CONFIG_PM_DEVICE
 
 /* Register status record.


### PR DESCRIPTION
The conditions needed to declare `uart_ambiq_pm_action()` in `uart_pl011_ambiq.h` and the conditions needed to use it in `uart_pl011.c` differed, which would result in a warning promoted to error during weekly CI runs.

Ensure that the conditions match to remove the warning / error.

```cpp
if defined(CONFIG_SOC_SERIES_APOLLO3X) || \
  defined(CONFIG_SOC_SERIES_APOLLO5X)
```

https://github.com/zephyrproject-rtos/zephyr/actions/runs/18068117603/job/51413729488

Testing Done:
```shell
west build -p -b apollo4p_blue_kxr_evb/apollo4p_blue tests/lib/cpp/cxx -T cpp.main.newlib_nano
```