### PR TITLE
tests: drivers: flash: common: remove disable_spi_nor test config

### DIFF
--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -155,12 +155,6 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-  drivers.flash.common.disable_spi_nor:
-    filter: dt_compat_enabled("soc-nv-flash") and dt_compat_enabled("jedec,spi-nor")
-    platform_exclude:
-      - beagleconnect_freedom/cc1352p7
-    extra_args:
-      - CONFIG_SPI_NOR=n
   drivers.flash.common.ra_ospi_b_nor:
     platform_allow:
       - ek_ra8m1


### PR DESCRIPTION
Remove the `drivers.flash.common.disable_spi_nor` test configuration since it has resulted in numerous CI failures for several weeks / months.

Workaround for #96682