### PR TITLE
tests: arch: commoon: stack_unwind: disable fpv_baser_aemv8r

### DIFF
--- a/tests/arch/common/stack_unwind/testcase.yaml
+++ b/tests/arch/common/stack_unwind/testcase.yaml
@@ -66,6 +66,10 @@ tests:
       - qemu_riscv32
       - qemu_riscv64
       - qemu_cortex_a53
+    platform_exclude:
+      # these platforms disabled here since CONFIG_ARM_MMU=n by default
+      - fvp_baser_aemv8r/fvp_aemv8r_aarch64
+      - fvp_baser_aemv8r/fvp_aemv8r_aarch64/smp
     extra_configs:
       - CONFIG_FRAME_POINTER=y
       - CONFIG_SYMTAB=y


### PR DESCRIPTION
The test configuration `arch.common.stack_unwind.symtab` was failing in weekly CI for quite a long time for the following platforms because `CONFIG_ARCH_MMU=n` by default on those platforms, although they are 64-bit.

- fvp_baser_aemv8r/fvp_aemv8r_aarch64
- fvp_baser_aemv8r/fvp_aemv8r_aarch64/smp

The command below can be used to verify the workaround.

```shell
twister -p fvp_baser_aemv8r/fvp_aemv8r_aarch64 -s arch.common.stack_unwind.symtab
```