### PR TITLE
drivers: mfd: axp192 fix EXTEN switch control  value

### DIFF
--- a/drivers/mfd/mfd_axp192.c
+++ b/drivers/mfd/mfd_axp192.c
@@ -100,7 +100,7 @@ struct mfd_axp192_config {
 
 #define AXP192_GPIO5_OUTPUT_MASK  0x04U
 #define AXP192_GPIO5_OUTPUT_VAL   0x04U
-#define AXP192_GPIO5_OUTPUT_SHIFT 3U
+#define AXP192_GPIO5_OUTPUT_SHIFT 2U
 
 struct mfd_axp192_data {
 	const struct device *gpio_mask_used[AXP192_GPIO_MAX_NUM];


### PR DESCRIPTION
Currently, EXTEN switch control (mapped to GPIO5) is always 0, due to a bug in the shift value. This has been reported in Coverity CID 353647.

Following the AXP192-X Datasheet, the EXTEN switch control status is given by bit 2 of the register 10h. If "GPIO5" corresponds to EXTEN Switch control (AXP192_GPIO5_OUTPUT_MASK is 0x04U), then the shift AXP192_GPIO5_OUTPUT_SHIFT should be 2, not 3.

fixes #74751 