### PR TITLE
soc: xlnx: zynqmp: fix vectors and SRAM MPU region priority order

### DIFF
--- a/soc/xlnx/zynqmp/arm_mpu_regions.c
+++ b/soc/xlnx/zynqmp/arm_mpu_regions.c
@@ -11,16 +11,6 @@ extern const uint32_t __rom_region_start;
 extern const uint32_t __rom_region_mpu_size_bits;
 
 static const struct arm_mpu_region mpu_regions[] = {
-	/*
-	 * The address of the vectors is determined by arch/arm/core/cortex_a_r/prep_c.c
-	 * -> for v7-R, there's no other option than 0x0, HIVECS always gets cleared
-	 */
-	MPU_REGION_ENTRY(
-		"vectors",
-		0x00000000,
-		REGION_64B,
-		{.rasr = P_RO_U_NA_Msk |
-			 NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE}),
 	/* Basic SRAM mapping is all data, R/W + XN */
 	MPU_REGION_ENTRY(
 		"sram",
@@ -71,6 +61,16 @@ static const struct arm_mpu_region mpu_regions[] = {
 			 STRONGLY_ORDERED_SHAREABLE |
 			 NOT_EXEC}),
 #endif
+	/*
+	 * The address of the vectors is determined by arch/arm/core/cortex_a_r/prep_c.c
+	 * -> for v7-R, there's no other option than 0x0, HIVECS always gets cleared
+	 */
+	MPU_REGION_ENTRY(
+		"vectors",
+		0x00000000,
+		REGION_64B,
+		{.rasr = P_RO_U_NA_Msk |
+			 NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE}),
 };
 
 const struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
Place the 'vectors' region configuration behind the 'sram' and 'rom_region' configurations so that the MPU region for the vectors takes precedence over the 'sram' region due to higher region index = higher priority when resolving memory properties/permissions for overlapping regions. This is required for the vectors to work properly if the SRAM base address is also at 0x0.

Fixes #96688.