### PR TITLE
soc: xlnx: zynqmp: enable RPU MPU by default

### DIFF
--- a/soc/xlnx/zynqmp/Kconfig
+++ b/soc/xlnx/zynqmp/Kconfig
@@ -8,4 +8,5 @@ config SOC_XILINX_ZYNQMP_RPU
 	select SOC_RESET_HOOK
 	select SOC_EARLY_INIT_HOOK
 	select CPU_HAS_ARM_MPU
+	select ARM_MPU
 	select VFP_DP_D16


### PR DESCRIPTION
Enable the ARM MPU by default if the current target SoC is the ZynqMP RPU.

This is one snippet from the previous PR relating to nocache memory support (#95360) that is not implemented yet, the other one being the RPU MPU region re-ordering.

Setting this config option at the SoC level is in sync with the Versal2 and Versalnet RPUs.