### PR TITLE
MCXW23 Watchdog, SCTimer and MRT enablment

### DIFF
--- a/boards/nxp/frdm_mcxw23/frdm_mcxw23-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxw23/frdm_mcxw23-pinctrl.dtsi
@@ -25,4 +25,11 @@
 			power-source = "3v3";
 		};
 	};
+
+	pinmux_sctimer_default: pinmux_sctimer_default {
+		group0 {
+			pinmux = <SCT0_OUT0_PIO0_15>;
+			slew-rate = "standard";
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxw23/frdm_mcxw23.yaml
+++ b/boards/nxp/frdm_mcxw23/frdm_mcxw23.yaml
@@ -20,4 +20,6 @@ supported:
   - counter
   - flash
   - i2c
+  - watchdog
+  - pwm
 vendor: nxp

--- a/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
+++ b/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
@@ -32,6 +32,7 @@
 		accel0 = &fxls8974;
 		mcuboot-button0 = &btn_wk;
 		watchdog0 = &wwdt0;
+		pwm-0 = &sc_timer;
 	};
 
 	leds {
@@ -169,11 +170,21 @@
 	status = "okay";
 };
 
+&sc_timer {
+	status = "okay";
+	pinctrl-0 = <&pinmux_sctimer_default>;
+	pinctrl-names = "default";
+};
+
 &wwdt0 {
 	status = "okay";
 };
 
 &rtc {
+	status = "okay";
+};
+
+&mrt0_channel0 {
 	status = "okay";
 };
 

--- a/boards/nxp/mcxw23_evk/mcxw23_evk-pinctrl.dtsi
+++ b/boards/nxp/mcxw23_evk/mcxw23_evk-pinctrl.dtsi
@@ -25,4 +25,11 @@
 			power-source = "3v3";
 		};
 	};
+
+	pinmux_sctimer_default: pinmux_sctimer_default {
+		group0 {
+			pinmux = <SCT0_OUT0_PIO0_15>;
+			slew-rate = "standard";
+		};
+	};
 };

--- a/boards/nxp/mcxw23_evk/mcxw23_evk.yaml
+++ b/boards/nxp/mcxw23_evk/mcxw23_evk.yaml
@@ -20,4 +20,6 @@ supported:
   - counter
   - flash
   - i2c
+  - watchdog
+  - pwm
 vendor: nxp

--- a/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
+++ b/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
@@ -30,6 +30,7 @@
 		accel0 = &fxls8974;
 		mcuboot-button0 = &btn_wk;
 		watchdog0 = &wwdt0;
+		pwm-0 = &sc_timer;
 	};
 
 	leds {
@@ -149,11 +150,21 @@
 	status = "okay";
 };
 
+&sc_timer {
+	status = "okay";
+	pinctrl-0 = <&pinmux_sctimer_default>;
+	pinctrl-names = "default";
+};
+
 &wwdt0 {
 	status = "okay";
 };
 
 &rtc {
+	status = "okay";
+};
+
+&mrt0_channel0 {
 	status = "okay";
 };
 

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -26,7 +26,7 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 #if defined(CONFIG_COUNTER_NXP_MRT)
 	if ((uint32_t)sub_system == MCUX_MRT_CLK) {
 #if defined(CONFIG_SOC_FAMILY_LPC) || defined(CONFIG_SOC_SERIES_RW6XX) ||                          \
-	defined(CONFIG_SOC_FAMILY_MCXN)
+	defined(CONFIG_SOC_FAMILY_MCXN) || defined(CONFIG_SOC_SERIES_MCXW2XX)
 		CLOCK_EnableClock(kCLOCK_Mrt);
 #elif defined(CONFIG_SOC_FAMILY_NXP_IMXRT)
 		CLOCK_EnableClock(kCLOCK_Mrt0);

--- a/dts/arm/nxp/nxp_mcxw23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw23x_common.dtsi
@@ -221,6 +221,16 @@
 		prescale = <0>;
 	};
 
+	sc_timer: pwm@85000 {
+		compatible = "nxp,sctimer-pwm";
+		reg = <0x85000 0x1000>;
+		interrupts = <12 1>;
+		status = "disabled";
+		clocks = <&syscon MCUX_SCTIMER_CLK>;
+		prescaler = <2>;
+		#pwm-cells = <3>;
+	};
+
 	flexcomm0: flexcomm@86000 {
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x86000 0x1000>;
@@ -289,6 +299,42 @@
 		compatible = "nxp,nbu";
 		interrupts = <22 0>;
 		interrupt-names = "nbu_rx_int";
+	};
+
+	mrt0: mrt@d000 {
+		compatible = "nxp,mrt";
+		reg = <0xd000 0x100>;
+		interrupts = <9 1>;
+		num-channels = <4>;
+		num-bits = <24>;
+		clocks = <&syscon MCUX_MRT_CLK>;
+		resets = <&reset NXP_SYSCON_RESET(1, 0)>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		mrt0_channel0: mrt0_channel@0 {
+			compatible = "nxp,mrt-channel";
+			reg = <0>;
+			status = "disabled";
+		};
+
+		mrt0_channel1: mrt0_channel@1 {
+			compatible = "nxp,mrt-channel";
+			reg = <1>;
+			status = "disabled";
+		};
+
+		mrt0_channel2: mrt0_channel@2 {
+			compatible = "nxp,mrt-channel";
+			reg = <2>;
+			status = "disabled";
+		};
+
+		mrt0_channel3: mrt0_channel@3 {
+			compatible = "nxp,mrt-channel";
+			reg = <3>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/soc/nxp/mcx/mcxw/mcxw2xx/soc.c
+++ b/soc/nxp/mcx/mcxw/mcxw2xx/soc.c
@@ -88,6 +88,10 @@ __weak void clock_init(void)
 	CLOCK_AttachClk(kFRO_HF_DIV_to_FLEXCOMM2);
 #endif
 
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(wwdt0), nxp_lpc_wwdt, okay)
+	CLOCK_Enable1MFRO(true);
+#endif
+
 	DT_FOREACH_STATUS_OKAY(nxp_lpc_ctimer, CTIMER_CLOCK_SETUP)
 	DT_FOREACH_STATUS_OKAY(nxp_ctimer_pwm, CTIMER_CLOCK_SETUP)
 

--- a/tests/drivers/pwm/pwm_api/boards/frdm_mcxw23.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/frdm_mcxw23.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &sc_timer;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/mcxw23_evk.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/mcxw23_evk.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &sc_timer;
+	};
+};

--- a/tests/drivers/watchdog/wdt_basic_reset_none/boards/frdm_mcxw23.conf
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/boards/frdm_mcxw23.conf
@@ -1,0 +1,6 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier Apache-2.0
+#
+CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG=512

--- a/tests/drivers/watchdog/wdt_basic_reset_none/boards/mcxw23_evk.conf
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/boards/mcxw23_evk.conf
@@ -1,0 +1,6 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier Apache-2.0
+#
+CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG=512


### PR DESCRIPTION
Add support for MCXW23 watchdog, SCTimer and MRT.
Verfied the functionality with the commands below:
Watchdog:
_west build -p auto -b frdm_mcxw23 tests/drivers/watchdog/wdt_basic_reset_none/
west build -p auto -b mcxw23_evk tests/drivers/watchdog/wdt_basic_reset_none/_

SCTimer (PWM output on J5-1 on FRDM board, J18-3 on EVK board):
_west build -p auto -b frdm_mcxw23 tests/drivers/pwm/pwm_api/
west build -p auto -b mcxw23_evk tests/drivers/pwm/pwm_api/_

MRT:
_west build -p auto -b frdm_mcxw23 tests/drivers/counter/counter_basic_api/
west build -p auto -b mcxw23_evk tests/drivers/counter/counter_basic_api/_
