### PR TITLE
drivers: udc_dwc2: add Espressif pre-enable and shutdown hooks

### DIFF
--- a/drivers/usb/udc/Kconfig.dwc2
+++ b/drivers/usb/udc/Kconfig.dwc2
@@ -37,6 +37,7 @@ config UDC_DWC2_PTI
 
 config UDC_DWC2_STACK_SIZE
 	int "UDC DWC2 driver internal thread stack size"
+	default 1024 if SOC_SERIES_ESP32S3
 	default 512
 	help
 	  DWC2 driver internal thread stack size.


### PR DESCRIPTION
Ensure the USB clock is enabled before initializing the controller by invoking the pre_enable hook. This avoids initialization failures when the HAL has not yet configured the clock.

Fixes #96679