### PR TITLE
soc: nordic: nrf54h: increase default log stack size if CONFIG_PM=y

### DIFF
--- a/soc/nordic/nrf54h/Kconfig.defconfig
+++ b/soc/nordic/nrf54h/Kconfig.defconfig
@@ -40,6 +40,13 @@ if PM
 config PM_DEVICE
 	default y
 
+if LOG
+
+config LOG_PROCESS_THREAD_STACK_SIZE
+	default 1536
+
+endif # LOG
+
 endif # PM
 
 if PM_DEVICE


### PR DESCRIPTION
The default log process thread stack size on the nRFH20 SoC needs to be increased to account for the recursion into resuming power domains, which may happen within char_out for some backends like uart.