### PR TITLE
lib: multi_heap: fix out-of-bounds array access

### DIFF
--- a/lib/heap/multi_heap.c
+++ b/lib/heap/multi_heap.c
@@ -75,8 +75,11 @@ const struct sys_multi_heap_rec *sys_multi_heap_get_heap(const struct sys_multi_
 
 	/* Now i stores the index of the heap after our target (even
 	 * if it's invalid and our target is the last!)
-	 * FIXME: return -ENOENT when a proper heap is not found
 	 */
+	if (i == 0) {
+		return NULL;
+	}
+
 	return &mheap->heaps[i-1];
 }
 


### PR DESCRIPTION
Add bounds check to prevent accessing heaps array with index=-1 when the address parameter is NULL or too small.

Return NULL in such cases to match the API specification.