### PR TITLE
drivers: flash_mspi_nor: Assign quirks based on flash DT node property

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -269,9 +269,10 @@ slot3_partition: &cpurad_slot1_partition {
 	status = "disabled";
 
 	mx25uw63: mx25uw6345g@0 {
-		compatible = "mxicy,mx25u", "jedec,mspi-nor";
+		compatible = "jedec,mspi-nor";
 		status = "disabled";
 		reg = <0>;
+		chip-family = "mxicy,mx25uw";
 		jedec-id = [c2 84 37];
 		sfdp-bfp = [e5 20 8a ff ff ff ff 03 00 ff 00 ff 00 ff 00 ff
 			    ee ff ff ff ff ff 00 ff ff ff 00 ff 0c 20 10 d8

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
@@ -248,9 +248,10 @@ ipc0: &cpuapp_cpurad_ipc {
 	status = "okay";
 
 	mx25uw63: mx25uw6345g@0 {
-		compatible = "mxicy,mx25u", "jedec,mspi-nor";
+		compatible = "jedec,mspi-nor";
 		status = "disabled";
 		reg = <0>;
+		chip-family = "mxicy,mx25uw";
 		jedec-id = [c2 84 37];
 		sfdp-bfp = [e5 20 8a ff ff ff ff 03 00 ff 00 ff 00 ff 00 ff
 			    ee ff ff ff ff ff 00 ff ff ff 00 ff 0c 20 10 d8

--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -1257,8 +1257,6 @@ static DEVICE_API(flash, drv_api) = {
 	.dqs_enable = false,						\
 }
 
-#define FLASH_QUIRKS(inst) FLASH_MSPI_QUIRKS_GET(DT_DRV_INST(inst))
-
 #define IO_MODE_FLAGS(io_mode) \
 	.multi_io_cmd = (io_mode == MSPI_IO_MODE_DUAL || \
 			 io_mode == MSPI_IO_MODE_QUAD || \

--- a/drivers/flash/flash_mspi_nor_quirks.h
+++ b/drivers/flash/flash_mspi_nor_quirks.h
@@ -21,14 +21,17 @@ struct flash_mspi_nor_quirks {
 };
 
 /* Extend this macro when adding new flash chip with quirks */
-#define FLASH_MSPI_QUIRKS_GET(node)						\
-	COND_CODE_1(DT_NODE_HAS_COMPAT_STATUS(node, mxicy_mx25r, okay),		\
-		    (&flash_quirks_mxicy_mx25r),				\
-	(COND_CODE_1(DT_NODE_HAS_COMPAT_STATUS(node, mxicy_mx25u, okay),	\
-		    (&flash_quirks_mxicy_mx25u),				\
-		    (NULL))))
+#define FLASH_QUIRKS(inst) \
+	DT_INST_ENUM_HAS_VALUE(inst, chip_family, mxicy_mx25r) ? \
+		&flash_quirks_mxicy_mx25r : \
+	DT_INST_ENUM_HAS_VALUE(inst, chip_family, mxicy_mx25um) || \
+	DT_INST_ENUM_HAS_VALUE(inst, chip_family, mxicy_mx25uw) || \
+	DT_INST_ENUM_HAS_VALUE(inst, chip_family, mxicy_mx66um) || \
+	DT_INST_ENUM_HAS_VALUE(inst, chip_family, mxicy_mx66uw) ? \
+		&flash_quirks_mxicy_mx25um : \
+	NULL
 
-#if DT_HAS_COMPAT_STATUS_OKAY(mxicy_mx25r)
+/* ---- Macronix MX25R ---- */
 
 #define MXICY_MX25R_LH_MASK BIT(1)
 #define MXICY_MX25R_QE_MASK BIT(6)
@@ -115,15 +118,13 @@ static inline int mxicy_mx25r_post_switch_mode(const struct device *dev)
 	return 0;
 }
 
-struct flash_mspi_nor_quirks flash_quirks_mxicy_mx25r = {
+__unused struct flash_mspi_nor_quirks flash_quirks_mxicy_mx25r = {
 	.post_switch_mode = mxicy_mx25r_post_switch_mode,
 };
 
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(mxicy_mx25r) */
+/* ---- Macronix MX25UM, MX25UW, MX66UM, MX66UW ---- */
 
-#if DT_HAS_COMPAT_STATUS_OKAY(mxicy_mx25u)
-
-static inline int mxicy_mx25u_post_switch_mode(const struct device *dev)
+static inline int mxicy_mx25um_post_switch_mode(const struct device *dev)
 {
 	const struct flash_mspi_nor_config *dev_config = dev->config;
 	struct flash_mspi_nor_data *dev_data = dev->data;
@@ -162,7 +163,7 @@ static inline int mxicy_mx25u_post_switch_mode(const struct device *dev)
 	return perform_xfer(dev, SPI_NOR_CMD_WR_CFGREG2, false);
 }
 
-static int mxicy_mx25u_pre_init(const struct device *dev)
+static int mxicy_mx25um_pre_init(const struct device *dev)
 {
 	const struct flash_mspi_nor_config *dev_config = dev->config;
 	struct flash_mspi_nor_data *dev_data = dev->data;
@@ -204,11 +205,9 @@ static int mxicy_mx25u_pre_init(const struct device *dev)
 	return 0;
 }
 
-struct flash_mspi_nor_quirks flash_quirks_mxicy_mx25u = {
-	.pre_init = mxicy_mx25u_pre_init,
-	.post_switch_mode = mxicy_mx25u_post_switch_mode,
+__unused struct flash_mspi_nor_quirks flash_quirks_mxicy_mx25um = {
+	.pre_init = mxicy_mx25um_pre_init,
+	.post_switch_mode = mxicy_mx25um_post_switch_mode,
 };
-
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(mxicy_mx25u) */
 
 #endif /*__FLASH_MSPI_NOR_QUIRKS_H__*/

--- a/dts/bindings/mtd/jedec,mspi-nor.yaml
+++ b/dts/bindings/mtd/jedec,mspi-nor.yaml
@@ -21,6 +21,20 @@ include:
       - t-exit-dpd
 
 properties:
+  chip-family:
+    type: string
+    description: |
+      Some flash chips need special handling in certain aspects, for example,
+      to be configured properly at initialization. This property determines
+      what specific routines need to be used for the flash chip. If not set,
+      only generic handling is used.
+    enum:
+      - "mxicy,mx25r"
+      - "mxicy,mx25um"
+      - "mxicy,mx25uw"
+      - "mxicy,mx66um"
+      - "mxicy,mx66uw"
+
   reset-gpios:
     type: phandle-array
     description: |


### PR DESCRIPTION
Introduce "chip-family" enum property in the "jedec,mspi-nor" binding as a way of specifying what special routines need to be use for a given flash chip. This has the advantage over an additional compatible string that users can see the possibilities in the binding documentation and do not need to look into the driver code to find out those. Also any typos in the enum value will be caught by the DT compiler, while for the compatible string such typos would cause it to be silently ignored.

Addresses #93135.