### PR TITLE
drivers: nrfx: introduce prescaler calculation API to audio drivers

### DIFF
--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -21,7 +21,6 @@ LOG_MODULE_REGISTER(dmic_nrfx_pdm, CONFIG_AUDIO_DMIC_LOG_LEVEL);
 
 #if CONFIG_SOC_SERIES_NRF54HX
 #define DMIC_NRFX_CLOCK_FREQ MHZ(16)
-#define DMIC_NRFX_CLOCK_FACTOR 8192
 #define DMIC_NRFX_AUDIO_CLOCK_FREQ DT_PROP_OR(NODE_AUDIOPLL, frequency, 0)
 #elif DT_NODE_HAS_STATUS_OKAY(NODE_AUDIO_AUXPLL)
 #define DMIC_NRFX_AUDIO_CLOCK_FREQ DT_PROP(NODE_AUDIO_AUXPLL, nordic_frequency)
@@ -31,7 +30,6 @@ BUILD_ASSERT((DMIC_NRFX_AUDIO_CLOCK_FREQ == NRF_AUXPLL_FREQ_DIV_AUDIO_48K) ||
 #define DMIC_NRFX_CLOCK_FREQ MHZ(32)
 #else
 #define DMIC_NRFX_CLOCK_FREQ MHZ(32)
-#define DMIC_NRFX_CLOCK_FACTOR 4096
 #define DMIC_NRFX_AUDIO_CLOCK_FREQ DT_PROP_OR(DT_NODELABEL(aclk), clock_frequency, \
 				   DT_PROP_OR(DT_NODELABEL(clock), hfclkaudio_frequency, 0))
 #endif
@@ -202,220 +200,6 @@ static void event_handler(const struct device *dev, const nrfx_pdm_evt_t *evt)
 	}
 }
 
-static bool is_in_freq_range(uint32_t freq, const struct dmic_cfg *pdm_cfg)
-{
-	return freq >= pdm_cfg->io.min_pdm_clk_freq && freq <= pdm_cfg->io.max_pdm_clk_freq;
-}
-
-static bool is_better(uint32_t freq,
-		      uint8_t ratio,
-		      uint32_t req_rate,
-		      uint32_t *best_diff,
-		      uint32_t *best_rate,
-		      uint32_t *best_freq)
-{
-	uint32_t act_rate = freq / ratio;
-	uint32_t diff = act_rate >= req_rate ? (act_rate - req_rate)
-					     : (req_rate - act_rate);
-
-	LOG_DBG("Freq %u, ratio %u, act_rate %u", freq, ratio, act_rate);
-
-	if (diff < *best_diff) {
-		*best_diff = diff;
-		*best_rate = act_rate;
-		*best_freq = freq;
-		return true;
-	}
-
-	return false;
-}
-
-static bool check_pdm_frequencies(const struct dmic_nrfx_pdm_drv_cfg *drv_cfg,
-				  nrfx_pdm_config_t *config,
-				  const struct dmic_cfg *pdm_cfg,
-				  uint8_t ratio,
-				  uint32_t *best_diff,
-				  uint32_t *best_rate,
-				  uint32_t *best_freq)
-{
-	uint32_t req_rate = pdm_cfg->streams[0].pcm_rate;
-	bool better_found = false;
-	const uint32_t src_freq =
-		(NRF_PDM_HAS_SELECTABLE_CLOCK && drv_cfg->clk_src == ACLK)
-		? DMIC_NRFX_AUDIO_CLOCK_FREQ
-		: DMIC_NRFX_CLOCK_FREQ;
-#if NRF_PDM_HAS_PRESCALER
-	uint32_t req_freq = req_rate * ratio;
-	uint32_t prescaler = src_freq / req_freq;
-	uint32_t act_freq = src_freq / prescaler;
-
-	if (is_in_freq_range(act_freq, pdm_cfg) &&
-	    is_better(act_freq, ratio, req_rate, best_diff, best_rate, best_freq)) {
-		config->prescaler = prescaler;
-
-		better_found = true;
-	}
-
-	/* Stop if an exact rate match is found. */
-	if (*best_diff == 0) {
-		return true;
-	}
-
-	/* Prescaler value is rounded down by default,
-	 * thus value rounded up should be checked as well.
-	 */
-	prescaler += 1;
-	act_freq  = src_freq / prescaler;
-
-	if (is_in_freq_range(act_freq, pdm_cfg) &&
-	    is_better(act_freq, ratio, req_rate, best_diff, best_rate, best_freq)) {
-		config->prescaler = prescaler;
-
-		better_found = true;
-	}
-#else
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NRF53X) || IS_ENABLED(CONFIG_SOC_SERIES_NRF54HX)) {
-		uint32_t req_freq = req_rate * ratio;
-		/* As specified in the nRF5340 PS:
-		 *
-		 * PDMCLKCTRL = 4096 * floor(f_pdm * 1048576 /
-		 *                           (f_source + f_pdm / 2))
-		 * f_actual = f_source / floor(1048576 * 4096 / PDMCLKCTRL)
-		 */
-		uint32_t clk_factor = (uint32_t)((req_freq * 1048576ULL) /
-						 (src_freq + req_freq / 2));
-		uint32_t act_freq = src_freq / (1048576 / clk_factor);
-
-		if (is_in_freq_range(act_freq, pdm_cfg) &&
-		    is_better(act_freq, ratio, req_rate, best_diff, best_rate, best_freq)) {
-			config->clock_freq = clk_factor * DMIC_NRFX_CLOCK_FACTOR;
-
-			better_found = true;
-		}
-	} else { /* -> !IS_ENABLED(CONFIG_SOC_SERIES_NRF53X)) */
-		static const struct {
-			uint32_t       freq_val;
-			nrf_pdm_freq_t freq_enum;
-		} freqs[] = {
-			{ 1000000, NRF_PDM_FREQ_1000K },
-			{ 1032000, NRF_PDM_FREQ_1032K },
-			{ 1067000, NRF_PDM_FREQ_1067K },
-#if defined(PDM_PDMCLKCTRL_FREQ_1231K)
-			{ 1231000, NRF_PDM_FREQ_1231K },
-#endif
-#if defined(PDM_PDMCLKCTRL_FREQ_1280K)
-			{ 1280000, NRF_PDM_FREQ_1280K },
-#endif
-#if defined(PDM_PDMCLKCTRL_FREQ_1333K)
-			{ 1333000, NRF_PDM_FREQ_1333K }
-#endif
-		};
-
-		for (int i = 0; i < ARRAY_SIZE(freqs); ++i) {
-			uint32_t freq_val = freqs[i].freq_val;
-
-			if (freq_val < pdm_cfg->io.min_pdm_clk_freq) {
-				continue;
-			}
-			if (freq_val > pdm_cfg->io.max_pdm_clk_freq) {
-				break;
-			}
-
-			if (is_better(freq_val, ratio, req_rate,
-				      best_diff, best_rate, best_freq)) {
-				config->clock_freq = freqs[i].freq_enum;
-
-				/* Stop if an exact rate match is found. */
-				if (*best_diff == 0) {
-					return true;
-				}
-
-				better_found = true;
-			}
-
-			/* Since frequencies are in ascending order, stop
-			 * checking next ones for the current ratio after
-			 * resulting PCM rate goes above the one requested.
-			 */
-			if ((freq_val / ratio) > req_rate) {
-				break;
-			}
-		}
-	}
-#endif /* NRF_PDM_HAS_PRESCALER */
-
-	return better_found;
-}
-
-/* Finds clock settings that give the PCM output rate closest to that requested,
- * taking into account the hardware limitations.
- */
-static bool find_suitable_clock(const struct dmic_nrfx_pdm_drv_cfg *drv_cfg,
-				nrfx_pdm_config_t *config,
-				const struct dmic_cfg *pdm_cfg)
-{
-	uint32_t best_diff = UINT32_MAX;
-	uint32_t best_rate;
-	uint32_t best_freq;
-
-#if NRF_PDM_HAS_RATIO_CONFIG
-	static const struct {
-		uint8_t         ratio_val;
-		nrf_pdm_ratio_t ratio_enum;
-	} ratios[] = {
-#if defined(PDM_RATIO_RATIO_Ratio32)
-		{ 32, NRF_PDM_RATIO_32X },
-#endif
-#if defined(PDM_RATIO_RATIO_Ratio48)
-		{ 48, NRF_PDM_RATIO_48X },
-#endif
-#if defined(PDM_RATIO_RATIO_Ratio50)
-		{ 50, NRF_PDM_RATIO_50X },
-#endif
-		{ 64, NRF_PDM_RATIO_64X },
-		{ 80, NRF_PDM_RATIO_80X },
-#if defined(PDM_RATIO_RATIO_Ratio96)
-		{ 96, NRF_PDM_RATIO_96X },
-#endif
-#if defined(PDM_RATIO_RATIO_Ratio100)
-		{ 100, NRF_PDM_RATIO_100X },
-#endif
-#if defined(PDM_RATIO_RATIO_Ratio128)
-		{ 128, NRF_PDM_RATIO_128X }
-#endif
-	};
-
-	for (int r = 0; best_diff != 0 && r < ARRAY_SIZE(ratios); ++r) {
-		uint8_t ratio = ratios[r].ratio_val;
-
-		if (check_pdm_frequencies(drv_cfg, config, pdm_cfg, ratio,
-					  &best_diff, &best_rate, &best_freq)) {
-			config->ratio = ratios[r].ratio_enum;
-
-			/* Look no further if a configuration giving the exact
-			 * PCM rate is found.
-			 */
-			if (best_diff == 0) {
-				break;
-			}
-		}
-	}
-#else
-	uint8_t ratio = 64;
-
-	(void)check_pdm_frequencies(drv_cfg, config, pdm_cfg, ratio,
-				    &best_diff, &best_rate, &best_freq);
-#endif
-
-	if (best_diff == UINT32_MAX) {
-		return false;
-	}
-
-	LOG_INF("PDM clock frequency: %u, actual PCM rate: %u",
-		best_freq, best_rate);
-	return true;
-}
-
 static int dmic_nrfx_pdm_configure(const struct device *dev,
 				   struct dmic_cfg *config)
 {
@@ -499,7 +283,16 @@ static int dmic_nrfx_pdm_configure(const struct device *dev,
 			 ? NRF_PDM_MCLKSRC_ACLK
 			 : NRF_PDM_MCLKSRC_PCLK32M;
 #endif
-	if (!find_suitable_clock(drv_cfg, &nrfx_cfg, config)) {
+	nrfx_pdm_output_t output_config = {
+		.base_clock_freq = (NRF_PDM_HAS_SELECTABLE_CLOCK && drv_cfg->clk_src == ACLK)
+					? DMIC_NRFX_AUDIO_CLOCK_FREQ
+					: DMIC_NRFX_CLOCK_FREQ,
+		.sampling_rate = config->streams[0].pcm_rate,
+		.output_freq_min = config->io.min_pdm_clk_freq,
+		.output_freq_max = config->io.max_pdm_clk_freq
+	};
+
+	if (nrfx_pdm_prescalers_calc(&output_config, &nrfx_cfg.prescalers) != NRFX_SUCCESS) {
 		LOG_ERR("Cannot find suitable PDM clock configuration.");
 		return -EINVAL;
 	}

--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -64,148 +64,26 @@ static void find_suitable_clock(const struct i2s_nrfx_drv_cfg *drv_cfg,
 				nrfx_i2s_config_t *config,
 				const struct i2s_config *i2s_cfg)
 {
-	static const struct {
-		uint16_t        ratio_val;
-		nrf_i2s_ratio_t ratio_enum;
-	} ratios[] = {
-		{  32, NRF_I2S_RATIO_32X },
-		{  48, NRF_I2S_RATIO_48X },
-		{  64, NRF_I2S_RATIO_64X },
-		{  96, NRF_I2S_RATIO_96X },
-		{ 128, NRF_I2S_RATIO_128X },
-		{ 192, NRF_I2S_RATIO_192X },
-		{ 256, NRF_I2S_RATIO_256X },
-		{ 384, NRF_I2S_RATIO_384X },
-		{ 512, NRF_I2S_RATIO_512X }
+	const nrfx_i2s_clk_params_t clk_params = {
+		.base_clock_freq =
+			(NRF_I2S_HAS_CLKCONFIG && drv_cfg->clk_src == ACLK)
+			/* The I2S_NRFX_DEVICE() macro contains build assertions that
+			* make sure that the ACLK clock source is only used when it is
+			* available and only with the "hfclkaudio-frequency" property
+			* defined, but the default value of 0 here needs to be used to
+			* prevent compilation errors when the property is not defined
+			* (this expression will be eventually optimized away then).
+			*/
+			? DT_PROP_OR(DT_NODELABEL(clock), hfclkaudio_frequency, 0)
+			: 32*1000*1000UL,
+		.transfer_rate = i2s_cfg->frame_clk_freq,
+		.swidth = config->sample_width,
+		.allow_bypass = IS_ENABLED(CONFIG_I2S_NRFX_ALLOW_MCK_BYPASS),
 	};
-	const uint32_t src_freq =
-		(NRF_I2S_HAS_CLKCONFIG && drv_cfg->clk_src == ACLK)
-		/* The I2S_NRFX_DEVICE() macro contains build assertions that
-		 * make sure that the ACLK clock source is only used when it is
-		 * available and only with the "hfclkaudio-frequency" property
-		 * defined, but the default value of 0 here needs to be used to
-		 * prevent compilation errors when the property is not defined
-		 * (this expression will be eventually optimized away then).
-		 */
-		? DT_PROP_OR(DT_NODELABEL(clock), hfclkaudio_frequency, 0)
-		: 32*1000*1000UL;
-	uint32_t bits_per_frame = 2 * i2s_cfg->word_size;
-	uint32_t best_diff = UINT32_MAX;
-	uint8_t r, best_r = 0;
-	nrf_i2s_mck_t best_mck_cfg = 0;
-	uint32_t best_mck = 0;
 
-#if defined(CONFIG_I2S_NRFX_ALLOW_MCK_BYPASS) && NRF_I2S_HAS_CLKCONFIG
-	/* Check for bypass before calculating f_MCK */
-	for (r = 0; r < ARRAY_SIZE(ratios); ++r) {
-		if (i2s_cfg->frame_clk_freq * ratios[r].ratio_val == src_freq) {
-			LOG_INF("MCK bypass calculated");
-			best_r = r;
-			best_mck = src_freq;
-			best_diff = 0;
-
-			/* Set CONFIG.MCKFREQ register to non-zero reset value to
-			 * ensure peripheral functionality
-			 */
-			best_mck_cfg = NRF_I2S_MCK_32MDIV8;
-
-			config->enable_bypass = true;
-			break;
-		}
+	if (nrfx_i2s_prescalers_calc(&clk_params, &config->prescalers) != NRFX_SUCCESS) {
+		LOG_ERR("Failed to find suitable I2S clock configuration.");
 	}
-#endif
-
-	for (r = 0; (best_diff != 0) && (r < ARRAY_SIZE(ratios)); ++r) {
-		/* Only multiples of the frame width can be used as ratios. */
-		if ((ratios[r].ratio_val % bits_per_frame) != 0) {
-			continue;
-		}
-
-		if (IS_ENABLED(CONFIG_SOC_SERIES_NRF53X) || IS_ENABLED(CONFIG_SOC_SERIES_NRF54LX)) {
-			uint32_t requested_mck =
-				i2s_cfg->frame_clk_freq * ratios[r].ratio_val;
-			/* As specified in the nRF5340 PS:
-			 *
-			 * MCKFREQ = 4096 * floor(f_MCK * 1048576 /
-			 *                        (f_source + f_MCK / 2))
-			 * f_actual = f_source /
-			 *            floor(1048576 * 4096 / MCKFREQ)
-			 */
-			enum { MCKCONST = 1048576 };
-			uint32_t mck_factor =
-				(uint32_t)(((uint64_t)requested_mck * MCKCONST) /
-					   (src_freq + requested_mck / 2));
-
-			/* skip cases when mck_factor is too big for dividing */
-			if (mck_factor > MCKCONST) {
-				continue;
-			}
-			uint32_t actual_mck = src_freq / (MCKCONST / mck_factor);
-
-			uint32_t lrck_freq = actual_mck / ratios[r].ratio_val;
-			uint32_t diff = lrck_freq >= i2s_cfg->frame_clk_freq
-					? (lrck_freq - i2s_cfg->frame_clk_freq)
-					: (i2s_cfg->frame_clk_freq - lrck_freq);
-
-			if (diff < best_diff) {
-				best_mck_cfg = mck_factor * 4096;
-				best_mck = actual_mck;
-				best_r = r;
-				best_diff = diff;
-			}
-		} else {
-			static const struct {
-				uint8_t       divider_val;
-				nrf_i2s_mck_t divider_enum;
-			} dividers[] = {
-				{   8, NRF_I2S_MCK_32MDIV8 },
-				{  10, NRF_I2S_MCK_32MDIV10 },
-				{  11, NRF_I2S_MCK_32MDIV11 },
-				{  15, NRF_I2S_MCK_32MDIV15 },
-				{  16, NRF_I2S_MCK_32MDIV16 },
-				{  21, NRF_I2S_MCK_32MDIV21 },
-				{  23, NRF_I2S_MCK_32MDIV23 },
-				{  30, NRF_I2S_MCK_32MDIV30 },
-				{  31, NRF_I2S_MCK_32MDIV31 },
-				{  32, NRF_I2S_MCK_32MDIV32 },
-				{  42, NRF_I2S_MCK_32MDIV42 },
-				{  63, NRF_I2S_MCK_32MDIV63 },
-				{ 125, NRF_I2S_MCK_32MDIV125 }
-			};
-
-			for (uint8_t d = 0; (best_diff != 0) && (d < ARRAY_SIZE(dividers)); ++d) {
-				uint32_t mck_freq =
-					src_freq / dividers[d].divider_val;
-				uint32_t lrck_freq =
-					mck_freq / ratios[r].ratio_val;
-				uint32_t diff =
-					lrck_freq >= i2s_cfg->frame_clk_freq
-					? (lrck_freq - i2s_cfg->frame_clk_freq)
-					: (i2s_cfg->frame_clk_freq - lrck_freq);
-
-				if (diff < best_diff) {
-					best_mck_cfg = dividers[d].divider_enum;
-					best_mck = mck_freq;
-					best_r = r;
-					best_diff = diff;
-				}
-
-				/* Since dividers are in ascending order, stop
-				 * checking next ones for the current ratio
-				 * after resulting LRCK frequency falls below
-				 * the one requested.
-				 */
-				if (lrck_freq < i2s_cfg->frame_clk_freq) {
-					break;
-				}
-			}
-		}
-	}
-
-	config->mck_setup = best_mck_cfg;
-	config->ratio = ratios[best_r].ratio_enum;
-	LOG_INF("I2S MCK frequency: %u, actual PCM rate: %u",
-		best_mck, best_mck / ratios[best_r].ratio_val);
 }
 
 static bool get_next_tx_buffer(struct i2s_nrfx_drv_data *drv_data,
@@ -551,7 +429,7 @@ static int i2s_nrfx_configure(const struct device *dev, enum i2s_dir dir,
 		 */
 		drv_data->request_clock = (drv_cfg->clk_src != PCLK32M);
 	} else {
-		nrfx_cfg.mck_setup = NRF_I2S_MCK_DISABLED;
+		nrfx_cfg.prescalers.mck_setup = NRF_I2S_MCK_DISABLED;
 		drv_data->request_clock = false;
 	}
 
@@ -780,7 +658,7 @@ static int trigger_start(const struct device *dev)
 	nrf_i2s_clk_configure(drv_cfg->i2s.p_reg,
 			      drv_cfg->clk_src == ACLK ? NRF_I2S_CLKSRC_ACLK
 						       : NRF_I2S_CLKSRC_PCLK32M,
-			      nrfx_cfg->enable_bypass);
+			      nrfx_cfg->prescalers.enable_bypass);
 #endif
 
 	/* If it is required to use certain HF clock, request it to be running


### PR DESCRIPTION
Moved clock prescaling algorithms from Zephyr drivers to nrfx drivers.