### PR TITLE
zms: Move FLASH_MAP dependency to the Settings backend

### DIFF
--- a/subsys/fs/zms/Kconfig
+++ b/subsys/fs/zms/Kconfig
@@ -7,7 +7,6 @@
 
 config ZMS
 	bool "Zephyr Memory Storage"
-	depends on FLASH_MAP
 	select CRC
 	help
 	  Enable Zephyr Memory Storage, which is a key-value storage system designed to work with

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -52,6 +52,7 @@ choice SETTINGS_BACKEND
 config SETTINGS_ZMS
 	bool "ZMS (Zephyr Memory Storage)"
 	depends on ZMS
+	depends on FLASH_MAP
 	select SYS_HASH_FUNC32
 	help
 	  Use ZMS as settings storage backend.


### PR DESCRIPTION
Add the missing Kconfig dependency to `SETTINGS_ZMS`, then revert the patch that added it to `ZMS` by mistake.