### PR TITLE
boards: Add secondary_app_partition alias

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -18,7 +18,7 @@
 
 	chosen {
 		zephyr,console = &uart136;
-		zephyr,code-partition = &slot0_partition;
+		zephyr,code-partition = &cpuapp_slot0_partition;
 		zephyr,flash = &mram1x;
 		zephyr,sram = &cpuapp_data;
 		zephyr,shell-uart = &uart136;
@@ -187,6 +187,8 @@ boot_partition: &cpuapp_boot_partition {
 slot0_partition: &cpuapp_slot0_partition {
 	label = "image-0";
 };
+
+secondary_app_partition: &cpuapp_slot1_partition {};
 
 slot1_partition: &cpuapp_slot1_partition {
 	label = "image-1";

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -85,6 +85,8 @@ slot0_partition: &cpurad_slot0_partition {
 	label = "image-0";
 };
 
+secondary_app_partition: &cpurad_slot1_partition {};
+
 slot1_partition: &cpurad_slot1_partition {
 	label = "image-1";
 };


### PR DESCRIPTION
Add secondary_app_partition aliases.
Those aliases can be used to configure the code partition for the second copy of the FW in the Direct XIP update scenarios.