### PR TITLE
tests: boards: espressif: add missing psram0 node

### DIFF
--- a/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_appcpu.dts
+++ b/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_appcpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_wroom_n8r8.dtsi>
+#include <espressif/esp32s3/esp32s3_wroom_n8.dtsi>
 #include <espressif/partitions_0x0_amp.dtsi>
 #include "esp32s3_devkitc-pinctrl.dtsi"
 

--- a/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_procpu.dts
+++ b/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_procpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include <espressif/esp32s3/esp32s3_wroom_n8r8.dtsi>
+#include <espressif/esp32s3/esp32s3_wroom_n8.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
 #include <espressif/partitions_0x0_amp.dtsi>

--- a/samples/boards/espressif/spiram_test/app.overlay
+++ b/samples/boards/espressif/spiram_test/app.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Using the smallest available PSRAM size of 2MB */
+&psram0 {
+	size = <DT_SIZE_M(2)>;
+};

--- a/tests/boards/espressif/cache_coex/app.overlay
+++ b/tests/boards/espressif/cache_coex/app.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Using the smallest available PSRAM size of 2MB */
+&psram0 {
+	size = <DT_SIZE_M(2)>;
+};


### PR DESCRIPTION
Add missing psram0 node which is used to determine the memory size.