### PR TITLE
drivers: wifi: nrf_wifi: Set device config pointer to NULL

### DIFF
--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -983,11 +983,7 @@ ETH_NET_DEVICE_DT_INST_DEFINE(0,
 		    nrf_wifi_drv_main_zep, /* init_fn */
 		    NULL, /* pm_action_cb */
 		    &rpu_drv_priv_zep.rpu_ctx_zep.vif_ctx_zep[0], /* data */
-#ifdef CONFIG_NRF70_STA_MODE
-		    &wpa_supp_ops, /* cfg */
-#else /* CONFIG_NRF70_STA_MODE */
 		    NULL, /* cfg */
-#endif /* !CONFIG_NRF70_STA_MODE */
 		    CONFIG_WIFI_INIT_PRIORITY, /* prio */
 		    &wifi_offload_ops, /* api */
 		    CONFIG_NRF_WIFI_IFACE_MTU); /*mtu */
@@ -997,11 +993,7 @@ ETH_NET_DEVICE_DT_INST_DEFINE(1,
 		    nrf_wifi_drv_main_zep, /* init_fn */
 		    NULL, /* pm_action_cb */
 		    &rpu_drv_priv_zep.rpu_ctx_zep.vif_ctx_zep[1], /* data */
-#ifdef CONFIG_NRF70_STA_MODE
-		    &wpa_supp_ops, /* cfg */
-#else /* CONFIG_NRF70_STA_MODE */
 		    NULL, /* cfg */
-#endif /* !CONFIG_NRF70_STA_MODE */
 		    CONFIG_WIFI_INIT_PRIORITY, /* prio */
 		    &wifi_offload_ops, /* api */
 		    CONFIG_NRF_WIFI_IFACE_MTU); /*mtu */


### PR DESCRIPTION
Commit https://github.com/zephyrproject-rtos/hostap/commit/2de30ff7822bb moved the driver ops from the config pointer to the API. As the config pointer isn't used, set it to NULL and allow future updates to actually add a configuration struct.