### PR TITLE
llext: only build fs_loader.c if file-systems are enabled

### DIFF
--- a/subsys/llext/CMakeLists.txt
+++ b/subsys/llext/CMakeLists.txt
@@ -14,8 +14,8 @@ if(CONFIG_LLEXT)
 		llext_export.c
 		llext_handlers.c
 		buf_loader.c
-    fs_loader.c
 	)
+  zephyr_library_sources_ifdef(CONFIG_FILE_SYSTEM fs_loader.c)
   zephyr_library_sources_ifdef(CONFIG_LLEXT_SHELL shell.c)
   zephyr_library_sources_ifdef(CONFIG_LLEXT_EXPERIMENTAL llext_experimental.c)
 


### PR DESCRIPTION
No need to build fs_loader.c if CONFIG_FILE_SYSTEM=n.