### PR TITLE
include: arch: arm: cortex_m: Move ITCM before .text

### DIFF
--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -141,6 +141,28 @@ SECTIONS
 
 #endif /* CONFIG_CODE_DATA_RELOCATION */
 
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_itcm), okay)
+GROUP_START(ITCM)
+
+	SECTION_PROLOGUE(_ITCM_SECTION_NAME,,SUBALIGN(4))
+	{
+		__itcm_start = .;
+		*(.itcm)
+		*(".itcm.*")
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function. */
+#include <snippets-itcm-section.ld>
+
+		__itcm_end = .;
+	} GROUP_LINK_IN(ITCM AT> ROMABLE_REGION)
+
+	__itcm_size = __itcm_end - __itcm_start;
+	__itcm_load_start = LOADADDR(_ITCM_SECTION_NAME);
+
+GROUP_END(ITCM)
+#endif
+
     SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
 	__text_region_start = .;
@@ -320,28 +342,6 @@ SECTIONS
 #include <snippets-data-sections.ld>
 
     __data_region_end = .;
-
-#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_itcm), okay)
-GROUP_START(ITCM)
-
-	SECTION_PROLOGUE(_ITCM_SECTION_NAME,,SUBALIGN(4))
-	{
-		__itcm_start = .;
-		*(.itcm)
-		*(".itcm.*")
-
-/* Located in generated directory. This file is populated by the
- * zephyr_linker_sources() Cmake function. */
-#include <snippets-itcm-section.ld>
-
-		__itcm_end = .;
-	} GROUP_LINK_IN(ITCM AT> ROMABLE_REGION)
-
-	__itcm_size = __itcm_end - __itcm_start;
-	__itcm_load_start = LOADADDR(_ITCM_SECTION_NAME);
-
-GROUP_END(ITCM)
-#endif
 
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
 GROUP_START(DTCM)


### PR DESCRIPTION
When using `zephyr_linker_sources(ITCM_SECTION link.ld)`, functions matched by `*(.text.*)` are typically absorbed into the ROM section early, making it impossible to relocate them to ITCM without modifying source code.

This change reorders the ITCM section in `linker.ld` to appear before the ROM section in the linker script. It enables relocating individual functions to ITCM using patterns like *(.text.<function_name>) without requiring file-level hints or annotations.

While Zephyr supports [code relocation](https://docs.zephyrproject.org/latest/kernel/code-relocation.html), it operates at the file level. This patch allows function-level relocation without altering existing code.

Open to discussion if there’s a better way to achieve this.