### PR TITLE
net: sockets: Reserve a default heap space for getaddrinfo

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -69,6 +69,13 @@ config NET_SOCKETS_DNS_BACKOFF_INTERVAL
 	     If no reply is received, a 3rd query is done after 15 sec (5 + 5 * 2),
 	     and the timeout is set to 2 sec so that the total timeout is 17 seconds.
 
+config HEAP_MEM_POOL_ADD_SIZE_GETADDRINFO
+	# Defaults to heap memory needed for a single getaddrinfo() call in
+	# a default configuration on 64-bit platform
+	int
+	default 280
+	depends on DNS_RESOLVER
+
 config NET_SOCKET_MAX_SEND_WAIT
 	int "Max time in milliseconds waiting for a send command"
 	default 10000


### PR DESCRIPTION
Add a default heap reservation for gettaddrinfo(), enough for a single function call in a default configuration on 64-bit platform.

Resolves #94318