### PR TITLE
drivers: xen: add DMOP hypercall wrappers

### DIFF
--- a/arch/arm64/core/xen/hypercall.S
+++ b/arch/arm64/core/xen/hypercall.S
@@ -23,6 +23,7 @@ HYPERCALL(sched_op);
 HYPERCALL(event_channel_op);
 HYPERCALL(hvm_op);
 HYPERCALL(memory_op);
+HYPERCALL(dm_op);
 
 #ifdef CONFIG_XEN_DOM0
 HYPERCALL(domctl);

--- a/drivers/xen/CMakeLists.txt
+++ b/drivers/xen/CMakeLists.txt
@@ -5,5 +5,6 @@ zephyr_sources(hvm.c)
 zephyr_sources(events.c)
 zephyr_sources_ifdef(CONFIG_XEN_GRANT_TABLE gnttab.c)
 zephyr_sources(memory.c)
+zephyr_sources_ifdef(CONFIG_XEN_DMOP dmop.c)
 
 add_subdirectory_ifdef(CONFIG_XEN_DOM0 dom0)

--- a/drivers/xen/Kconfig
+++ b/drivers/xen/Kconfig
@@ -5,6 +5,12 @@ if XEN
 
 menu "Xen drivers"
 
+config XEN_DMOP
+	bool "Xen dmop hypercall wrappers"
+	help
+	  Enable lightweight wrappers for Xen dm_op hypercalls used by
+	  Xen device backends. Disable to drop dmop.c from the build.
+
 config XEN_GRANT_TABLE
 	bool "Xen grant table driver"
 	depends on HEAP_MEM_POOL_SIZE > 0

--- a/drivers/xen/dmop.c
+++ b/drivers/xen/dmop.c
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/util.h>
+#include <zephyr/xen/dmop.h>
+#include <zephyr/arch/arm64/hypercall.h>
+
+int dmop_create_ioreq_server(domid_t domid, uint8_t handle_bufioreq, ioservid_t *id)
+{
+	struct xen_dm_op_buf bufs[1] = {0};
+	struct xen_dm_op dm_op = {0};
+	int err;
+
+	dm_op.op = XEN_DMOP_create_ioreq_server;
+	dm_op.u.create_ioreq_server.handle_bufioreq = handle_bufioreq;
+
+	set_xen_guest_handle(bufs[0].h, &dm_op);
+	bufs[0].size = sizeof(struct xen_dm_op);
+
+	err = HYPERVISOR_dm_op(domid, ARRAY_SIZE(bufs), bufs);
+	if (err) {
+		return err;
+	}
+
+	*id = dm_op.u.create_ioreq_server.id;
+
+	return 0;
+}
+
+int dmop_destroy_ioreq_server(domid_t domid, ioservid_t id)
+{
+	struct xen_dm_op_buf bufs[1] = {0};
+	struct xen_dm_op dm_op = {0};
+	int err;
+
+	dm_op.op = XEN_DMOP_destroy_ioreq_server;
+	dm_op.u.destroy_ioreq_server.id = id;
+
+	set_xen_guest_handle(bufs[0].h, &dm_op);
+	bufs[0].size = sizeof(struct xen_dm_op);
+
+	err = HYPERVISOR_dm_op(domid, ARRAY_SIZE(bufs), bufs);
+	if (err) {
+		return err;
+	}
+
+	return 0;
+}
+
+int dmop_map_io_range_to_ioreq_server(domid_t domid, ioservid_t id, uint32_t type, uint64_t start,
+				      uint64_t end)
+{
+	struct xen_dm_op_buf bufs[1] = {0};
+	struct xen_dm_op dm_op = {0};
+	int err;
+
+	dm_op.op = XEN_DMOP_map_io_range_to_ioreq_server;
+	dm_op.u.map_io_range_to_ioreq_server.id = id;
+	dm_op.u.map_io_range_to_ioreq_server.type = type;
+	dm_op.u.map_io_range_to_ioreq_server.start = start;
+	dm_op.u.map_io_range_to_ioreq_server.end = end;
+
+	set_xen_guest_handle(bufs[0].h, &dm_op);
+	bufs[0].size = sizeof(struct xen_dm_op);
+
+	err = HYPERVISOR_dm_op(domid, ARRAY_SIZE(bufs), bufs);
+	if (err < 0) {
+		return err;
+	}
+
+	return 0;
+}
+
+int dmop_unmap_io_range_from_ioreq_server(domid_t domid, ioservid_t id, uint32_t type,
+					  uint64_t start, uint64_t end)
+{
+	struct xen_dm_op_buf bufs[1] = {0};
+	struct xen_dm_op dm_op = {0};
+	int err;
+
+	dm_op.op = XEN_DMOP_unmap_io_range_from_ioreq_server;
+	dm_op.u.unmap_io_range_from_ioreq_server.id = id;
+	dm_op.u.unmap_io_range_from_ioreq_server.type = type;
+	dm_op.u.unmap_io_range_from_ioreq_server.start = start;
+	dm_op.u.unmap_io_range_from_ioreq_server.end = end;
+
+	set_xen_guest_handle(bufs[0].h, &dm_op);
+	bufs[0].size = sizeof(struct xen_dm_op);
+
+	err = HYPERVISOR_dm_op(domid, ARRAY_SIZE(bufs), bufs);
+	if (err < 0) {
+		return err;
+	}
+
+	return 0;
+}
+
+int dmop_set_ioreq_server_state(domid_t domid, ioservid_t id, uint8_t enabled)
+{
+	struct xen_dm_op_buf bufs[1] = {0};
+	struct xen_dm_op dm_op = {0};
+	int err;
+
+	dm_op.op = XEN_DMOP_set_ioreq_server_state;
+	dm_op.u.set_ioreq_server_state.id = id;
+	dm_op.u.set_ioreq_server_state.enabled = enabled;
+
+	set_xen_guest_handle(bufs[0].h, &dm_op);
+	bufs[0].size = sizeof(struct xen_dm_op);
+
+	err = HYPERVISOR_dm_op(domid, 1, bufs);
+	if (err) {
+		return err;
+	}
+
+	return 0;
+}
+
+int dmop_nr_vcpus(domid_t domid)
+{
+	struct xen_dm_op_buf bufs[1] = {0};
+	struct xen_dm_op dm_op = {0};
+	int err;
+
+	dm_op.op = XEN_DMOP_nr_vcpus;
+
+	set_xen_guest_handle(bufs[0].h, &dm_op);
+	bufs[0].size = sizeof(struct xen_dm_op);
+
+	err = HYPERVISOR_dm_op(domid, 1, bufs);
+	if (err < 0) {
+		return err;
+	}
+
+	return dm_op.u.nr_vcpus.vcpus;
+}
+
+int dmop_set_irq_level(domid_t domid, uint32_t irq, uint8_t level)
+{
+	struct xen_dm_op_buf bufs[1] = {0};
+	struct xen_dm_op dm_op = {0};
+	int err;
+
+	dm_op.op = XEN_DMOP_set_irq_level;
+	dm_op.u.set_irq_level.irq = irq;
+	dm_op.u.set_irq_level.level = level;
+
+	set_xen_guest_handle(bufs[0].h, &dm_op);
+	bufs[0].size = sizeof(struct xen_dm_op);
+
+	err = HYPERVISOR_dm_op(domid, 1, bufs);
+
+	return err;
+}

--- a/include/zephyr/arch/arm64/hypercall.h
+++ b/include/zephyr/arch/arm64/hypercall.h
@@ -6,6 +6,8 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM64_HYPERCALL_H_
 #define ZEPHYR_INCLUDE_ARCH_ARM64_HYPERCALL_H_
 
+#include <zephyr/xen/dmop.h>
+
 /* defined in hypercall.S by HYPERCALL(hypercall) */
 int HYPERVISOR_console_io(int op, int cnt, char *str);
 int HYPERVISOR_sched_op(int op, void *param);
@@ -13,6 +15,7 @@ int HYPERVISOR_event_channel_op(int op, void *param);
 int HYPERVISOR_hvm_op(int op, void *param);
 int HYPERVISOR_memory_op(int op, void *param);
 int HYPERVISOR_grant_table_op(int op, void *uop, unsigned int count);
+int HYPERVISOR_dm_op(domid_t domid, unsigned int nr_bufs, struct xen_dm_op_buf *bufs);
 
 #ifdef CONFIG_XEN_DOM0
 int HYPERVISOR_domctl(void *param);

--- a/include/zephyr/xen/dmop.h
+++ b/include/zephyr/xen/dmop.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_XEN_DMOP_H_
+#define ZEPHYR_XEN_DMOP_H_
+
+#include <zephyr/xen/public/hvm/dm_op.h>
+
+/**
+ * @brief Create an I/O request server in the given Xen domain.
+ *
+ * This function issues the XEN_DMOP_create_ioreq_server hypercall to create
+ * a server that handles I/O requests on behalf of the guest domain.
+ *
+ * @param domid        Xen domain identifier where the server is created.
+ * @param handle_bufioreq  Flag indicating whether buffered I/O requests should be handled.
+ *                        Set to non-zero to enable buffered handling.
+ * @param id           Output pointer to receive the newly created server ID.
+ *
+ * @retval 0      On success
+ * @retval -errno Negative errno code on failure.
+ */
+int dmop_create_ioreq_server(domid_t domid, uint8_t handle_bufioreq, ioservid_t *id);
+
+/**
+ * @brief Destroy a previously created I/O request server.
+ *
+ * Issues the XEN_DMOP_destroy_ioreq_server hypercall to tear down the
+ * specified I/O request server.
+ *
+ * @param domid Xen domain identifier where the server exists.
+ * @param id    I/O request server ID returned by dmop_create_ioreq_server().
+ *
+ * @retval 0      On success
+ * @retval -errno Negative errno code on failure.
+ */
+int dmop_destroy_ioreq_server(domid_t domid, ioservid_t id);
+
+/**
+ * @brief Map a specified I/O address range to an existing I/O request server.
+ *
+ * This function issues the XEN_DMOP_map_io_range_to_ioreq_server hypercall to grant
+ * access to the given I/O address range for the specified server.
+ *
+ * @param domid  Xen domain identifier where the mapping is applied.
+ * @param id     I/O request server ID returned by dmop_create_ioreq_server().
+ * @param type   Type identifier for the I/O range (e.g., MMIO, port I/O).
+ * @param start  Start physical address of the I/O range.
+ * @param end    End physical address (inclusive) of the I/O range.
+ *
+ * @retval 0      On success
+ * @retval -errno Negative errno code on failure.
+ */
+int dmop_map_io_range_to_ioreq_server(domid_t domid, ioservid_t id, uint32_t type, uint64_t start,
+				      uint64_t end);
+
+/**
+ * @brief Unmap an I/O address range from an I/O request server.
+ *
+ * Issues the XEN_DMOP_unmap_io_range_from_ioreq_server hypercall to revoke
+ * access to a previously mapped I/O address range.
+ *
+ * @param domid Xen domain identifier where the unmapping is applied.
+ * @param id    I/O request server ID returned by dmop_create_ioreq_server().
+ * @param type  Type identifier for the I/O range (e.g., MMIO, port I/O).
+ * @param start Start physical address of the I/O range.
+ * @param end   End physical address (inclusive) of the I/O range.
+ *
+ * @retval 0      On success
+ * @retval -errno Negative errno code on failure.
+ */
+int dmop_unmap_io_range_from_ioreq_server(domid_t domid, ioservid_t id, uint32_t type,
+					  uint64_t start, uint64_t end);
+
+/**
+ * @brief Enable or disable an existing I/O request server.
+ *
+ * This function issues the XEN_DMOP_set_ioreq_server_state hypercall to change
+ * the operational state of the specified I/O request server.
+ *
+ * @param domid    Xen domain identifier.
+ * @param id       I/O request server ID to modify.
+ * @param enabled  Non-zero to enable the server, zero to disable it.
+ *
+ * @retval 0      On success
+ * @retval -errno Negative errno code on failure.
+ */
+int dmop_set_ioreq_server_state(domid_t domid, ioservid_t id, uint8_t enabled);
+
+/**
+ * @brief Query the number of virtual CPUs in a Xen domain.
+ *
+ * This function issues the XEN_DMOP_nr_vcpus hypercall to retrieve
+ * the current vCPU count for the specified domain.
+ *
+ * @param domid  Xen domain identifier to query.
+ *
+ * @retval num_vcpus The number of vCPUs on success.
+ * @retval -errno    Negative errno code on failure.
+ */
+int dmop_nr_vcpus(domid_t domid);
+
+/**
+ * @brief Set the interrupt level for a specific IRQ in a Xen domain.
+ *
+ * This function issues the XEN_DMOP_set_irq_level hypercall to adjust
+ * the signal level (assert or deassert) for the given IRQ line.
+ *
+ * @param domid  Xen domain identifier.
+ * @param irq    IRQ number whose level is to be set.
+ * @param level  Non-zero to assert (raise) the IRQ, zero to deassert (lower) it.
+ *
+ * @retval 0      On success
+ * @retval -errno Negative errno code on failure.
+ */
+int dmop_set_irq_level(domid_t domid, uint32_t irq, uint8_t level);
+
+#endif /* ZEPHYR_XEN_DMOP_H_ */

--- a/include/zephyr/xen/public/hvm/dm_op.h
+++ b/include/zephyr/xen/public/hvm/dm_op.h
@@ -1,0 +1,503 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Copyright (c) 2016, Citrix Systems Inc
+ *
+ */
+
+#ifndef __XEN_PUBLIC_HVM_DM_OP_H__
+#define __XEN_PUBLIC_HVM_DM_OP_H__
+
+#include "../xen.h"
+#include "../event_channel.h"
+
+#ifndef uint64_aligned_t
+#define uint64_aligned_t uint64_t
+#endif
+
+/*
+ * IOREQ Servers
+ *
+ * The interface between an I/O emulator an Xen is called an IOREQ Server.
+ * A domain supports a single 'legacy' IOREQ Server which is instantiated if
+ * parameter...
+ *
+ * HVM_PARAM_IOREQ_PFN is read (to get the gfn containing the synchronous
+ * ioreq structures), or...
+ * HVM_PARAM_BUFIOREQ_PFN is read (to get the gfn containing the buffered
+ * ioreq ring), or...
+ * HVM_PARAM_BUFIOREQ_EVTCHN is read (to get the event channel that Xen uses
+ * to request buffered I/O emulation).
+ *
+ * The following hypercalls facilitate the creation of IOREQ Servers for
+ * 'secondary' emulators which are invoked to implement port I/O, memory, or
+ * PCI config space ranges which they explicitly register.
+ */
+
+typedef uint16_t ioservid_t;
+
+/*
+ * XEN_DMOP_create_ioreq_server: Instantiate a new IOREQ Server for a
+ *                               secondary emulator.
+ *
+ * The <id> handed back is unique for target domain. The valur of
+ * <handle_bufioreq> should be one of HVM_IOREQSRV_BUFIOREQ_* defined in
+ * hvm_op.h. If the value is HVM_IOREQSRV_BUFIOREQ_OFF then  the buffered
+ * ioreq ring will not be allocated and hence all emulation requests to
+ * this server will be synchronous.
+ */
+#define XEN_DMOP_create_ioreq_server 1
+
+struct xen_dm_op_create_ioreq_server {
+	/* IN - should server handle buffered ioreqs */
+	uint8_t handle_bufioreq;
+	uint8_t pad[3];
+	/* OUT - server id */
+	ioservid_t id;
+};
+typedef struct xen_dm_op_create_ioreq_server xen_dm_op_create_ioreq_server_t;
+
+/*
+ * XEN_DMOP_get_ioreq_server_info: Get all the information necessary to
+ *                                 access IOREQ Server <id>.
+ *
+ * If the IOREQ Server is handling buffered emulation requests, the
+ * emulator needs to bind to event channel <bufioreq_port> to listen for
+ * them. (The event channels used for synchronous emulation requests are
+ * specified in the per-CPU ioreq structures).
+ * In addition, if the XENMEM_acquire_resource memory op cannot be used,
+ * the emulator will need to map the synchronous ioreq structures and
+ * buffered ioreq ring (if it exists) from guest memory. If <flags> does
+ * not contain XEN_DMOP_no_gfns then these pages will be made available and
+ * the frame numbers passed back in gfns <ioreq_gfn> and <bufioreq_gfn>
+ * respectively. (If the IOREQ Server is not handling buffered emulation
+ * only <ioreq_gfn> will be valid).
+ *
+ * NOTE: To access the synchronous ioreq structures and buffered ioreq
+ *       ring, it is preferable to use the XENMEM_acquire_resource memory
+ *       op specifying resource type XENMEM_resource_ioreq_server.
+ */
+#define XEN_DMOP_get_ioreq_server_info 2
+
+struct xen_dm_op_get_ioreq_server_info {
+	/* IN - server id */
+	ioservid_t id;
+	/* IN - flags */
+	uint16_t flags;
+
+#define _XEN_DMOP_no_gfns 0
+#define XEN_DMOP_no_gfns  (1u << _XEN_DMOP_no_gfns)
+
+	/* OUT - buffered ioreq port */
+	evtchn_port_t bufioreq_port;
+	/* OUT - sync ioreq gfn (see block comment above) */
+	uint64_aligned_t ioreq_gfn;
+	/* OUT - buffered ioreq gfn (see block comment above)*/
+	uint64_aligned_t bufioreq_gfn;
+};
+typedef struct xen_dm_op_get_ioreq_server_info xen_dm_op_get_ioreq_server_info_t;
+
+/*
+ * XEN_DMOP_map_io_range_to_ioreq_server: Register an I/O range for
+ *                                        emulation by the client of
+ *                                        IOREQ Server <id>.
+ * XEN_DMOP_unmap_io_range_from_ioreq_server: Deregister an I/O range
+ *                                            previously registered for
+ *                                            emulation by the client of
+ *                                            IOREQ Server <id>.
+ *
+ * There are three types of I/O that can be emulated: port I/O, memory
+ * accesses and PCI config space accesses. The <type> field denotes which
+ * type of range* the <start> and <end> (inclusive) fields are specifying.
+ * PCI config space ranges are specified by segment/bus/device/function
+ * values which should be encoded using the DMOP_PCI_SBDF helper macro
+ * below.
+ *
+ * NOTE: unless an emulation request falls entirely within a range mapped
+ * by a secondary emulator, it will not be passed to that emulator.
+ */
+#define XEN_DMOP_map_io_range_to_ioreq_server     3
+#define XEN_DMOP_unmap_io_range_from_ioreq_server 4
+
+struct xen_dm_op_ioreq_server_range {
+	/* IN - server id */
+	ioservid_t id;
+	uint16_t pad;
+	/* IN - type of range */
+	uint32_t type;
+#define XEN_DMOP_IO_RANGE_PORT   0 /* I/O port range */
+#define XEN_DMOP_IO_RANGE_MEMORY 1 /* MMIO range */
+#define XEN_DMOP_IO_RANGE_PCI    2 /* PCI segment/bus/dev/func range */
+	/* IN - inclusive start and end of range */
+	uint64_aligned_t start, end;
+};
+typedef struct xen_dm_op_ioreq_server_range xen_dm_op_ioreq_server_range_t;
+
+#define XEN_DMOP_PCI_SBDF(s, b, d, f)                                                              \
+	((((s) & 0xffff) << 16) | (((b) & 0xff) << 8) | (((d) & 0x1f) << 3) | ((f) & 0x07))
+
+/*
+ * XEN_DMOP_set_ioreq_server_state: Enable or disable the IOREQ Server <id>
+ *
+ * The IOREQ Server will not be passed any emulation requests until it is
+ * in the enabled state.
+ * Note that the contents of the ioreq_gfn and bufioreq_gfn (see
+ * XEN_DMOP_get_ioreq_server_info) are not meaningful until the IOREQ Server
+ * is in the enabled state.
+ */
+#define XEN_DMOP_set_ioreq_server_state 5
+
+struct xen_dm_op_set_ioreq_server_state {
+	/* IN - server id */
+	ioservid_t id;
+	/* IN - enabled? */
+	uint8_t enabled;
+	uint8_t pad;
+};
+typedef struct xen_dm_op_set_ioreq_server_state xen_dm_op_set_ioreq_server_state_t;
+
+/*
+ * XEN_DMOP_destroy_ioreq_server: Destroy the IOREQ Server <id>.
+ *
+ * Any registered I/O ranges will be automatically deregistered.
+ */
+#define XEN_DMOP_destroy_ioreq_server 6
+
+struct xen_dm_op_destroy_ioreq_server {
+	/* IN - server id */
+	ioservid_t id;
+	uint16_t pad;
+};
+typedef struct xen_dm_op_destroy_ioreq_server xen_dm_op_destroy_ioreq_server_t;
+
+/*
+ * XEN_DMOP_track_dirty_vram: Track modifications to the specified pfn
+ *                            range.
+ *
+ * NOTE: The bitmap passed back to the caller is passed in a
+ *       secondary buffer.
+ */
+#define XEN_DMOP_track_dirty_vram 7
+
+struct xen_dm_op_track_dirty_vram {
+	/* IN - number of pages to be tracked */
+	uint32_t nr;
+	uint32_t pad;
+	/* IN - first pfn to track */
+	uint64_aligned_t first_pfn;
+};
+typedef struct xen_dm_op_track_dirty_vram xen_dm_op_track_dirty_vram_t;
+
+/*
+ * XEN_DMOP_set_pci_intx_level: Set the logical level of one of a domain's
+ *                              PCI INTx pins.
+ */
+#define XEN_DMOP_set_pci_intx_level 8
+
+struct xen_dm_op_set_pci_intx_level {
+	/* IN - PCI INTx identification (domain:bus:device:intx) */
+	uint16_t domain;
+	uint8_t bus, device, intx;
+	/* IN - Level: 0 -> deasserted, 1 -> asserted */
+	uint8_t level;
+};
+typedef struct xen_dm_op_set_pci_intx_level xen_dm_op_set_pci_intx_level_t;
+
+/*
+ * XEN_DMOP_set_isa_irq_level: Set the logical level of a one of a domain's
+ *                             ISA IRQ lines.
+ */
+#define XEN_DMOP_set_isa_irq_level 9
+
+struct xen_dm_op_set_isa_irq_level {
+	/* IN - ISA IRQ (0-15) */
+	uint8_t isa_irq;
+	/* IN - Level: 0 -> deasserted, 1 -> asserted */
+	uint8_t level;
+};
+typedef struct xen_dm_op_set_isa_irq_level xen_dm_op_set_isa_irq_level_t;
+
+/*
+ * XEN_DMOP_set_pci_link_route: Map a PCI INTx line to an IRQ line.
+ */
+#define XEN_DMOP_set_pci_link_route 10
+
+struct xen_dm_op_set_pci_link_route {
+	/* PCI INTx line (0-3) */
+	uint8_t link;
+	/* ISA IRQ (1-15) or 0 -> disable link */
+	uint8_t isa_irq;
+};
+typedef struct xen_dm_op_set_pci_link_route xen_dm_op_set_pci_link_route_t;
+
+/*
+ * XEN_DMOP_modified_memory: Notify that a set of pages were modified by
+ *                           an emulator.
+ *
+ * DMOP buf 1 contains an array of xen_dm_op_modified_memory_extent with
+ * @nr_extents entries.
+ *
+ * On error, @nr_extents will contain the index+1 of the extent that
+ * had the error.  It is not defined if or which pages may have been
+ * marked as dirty, in this event.
+ */
+#define XEN_DMOP_modified_memory 11
+
+struct xen_dm_op_modified_memory {
+	/*
+	 * IN - Number of extents to be processed
+	 * OUT -returns n+1 for failing extent
+	 */
+	uint32_t nr_extents;
+	/* IN/OUT - Must be set to 0 */
+	uint32_t opaque;
+};
+typedef struct xen_dm_op_modified_memory xen_dm_op_modified_memory_t;
+
+struct xen_dm_op_modified_memory_extent {
+	/* IN - number of contiguous pages modified */
+	uint32_t nr;
+	uint32_t pad;
+	/* IN - first pfn modified */
+	uint64_aligned_t first_pfn;
+};
+
+/*
+ * XEN_DMOP_set_mem_type: Notify that a region of memory is to be treated
+ *                        in a specific way. (See definition of
+ *                        hvmmem_type_t).
+ *
+ * NOTE: In the event of a continuation (return code -ERESTART), the
+ *       @first_pfn is set to the value of the pfn of the remaining
+ *       region and @nr reduced to the size of the remaining region.
+ */
+#define XEN_DMOP_set_mem_type 12
+
+struct xen_dm_op_set_mem_type {
+	/* IN - number of contiguous pages */
+	uint32_t nr;
+	/* IN - new hvmmem_type_t of region */
+	uint16_t mem_type;
+	uint16_t pad;
+	/* IN - first pfn in region */
+	uint64_aligned_t first_pfn;
+};
+typedef struct xen_dm_op_set_mem_type xen_dm_op_set_mem_type_t;
+
+/*
+ * XEN_DMOP_inject_event: Inject an event into a VCPU, which will
+ *                        get taken up when it is next scheduled.
+ *
+ * Note that the caller should know enough of the state of the CPU before
+ * injecting, to know what the effect of injecting the event will be.
+ */
+#define XEN_DMOP_inject_event 13
+
+struct xen_dm_op_inject_event {
+	/* IN - index of vCPU */
+	uint32_t vcpuid;
+	/* IN - interrupt vector */
+	uint8_t vector;
+	/* IN - event type (DMOP_EVENT_* ) */
+	uint8_t type;
+/* NB. This enumeration precisely matches hvm.h:X86_EVENTTYPE_* */
+#define XEN_DMOP_EVENT_ext_int    0 /* external interrupt */
+#define XEN_DMOP_EVENT_nmi        2 /* nmi */
+#define XEN_DMOP_EVENT_hw_exc     3 /* hardware exception */
+#define XEN_DMOP_EVENT_sw_int     4 /* software interrupt (CD nn) */
+#define XEN_DMOP_EVENT_pri_sw_exc 5 /* ICEBP (F1) */
+#define XEN_DMOP_EVENT_sw_exc     6 /* INT3 (CC), INTO (CE) */
+	/* IN - instruction length */
+	uint8_t insn_len;
+	uint8_t pad0;
+	/* IN - error code (or ~0 to skip) */
+	uint32_t error_code;
+	uint32_t pad1;
+	/* IN - type-specific extra data (%cr2 for #PF, pending_dbg for #DB) */
+	uint64_aligned_t cr2;
+};
+typedef struct xen_dm_op_inject_event xen_dm_op_inject_event_t;
+
+/*
+ * XEN_DMOP_inject_msi: Inject an MSI for an emulated device.
+ */
+#define XEN_DMOP_inject_msi 14
+
+struct xen_dm_op_inject_msi {
+	/* IN - MSI data (lower 32 bits) */
+	uint32_t data;
+	uint32_t pad;
+	/* IN - MSI address (0xfeexxxxx) */
+	uint64_aligned_t addr;
+};
+typedef struct xen_dm_op_inject_msi xen_dm_op_inject_msi_t;
+
+/*
+ * XEN_DMOP_map_mem_type_to_ioreq_server : map or unmap the IOREQ Server <id>
+ *                                      to specific memory type <type>
+ *                                      for specific accesses <flags>
+ *
+ * For now, flags only accept the value of XEN_DMOP_IOREQ_MEM_ACCESS_WRITE,
+ * which means only write operations are to be forwarded to an ioreq server.
+ * Support for the emulation of read operations can be added when an ioreq
+ * server has such requirement in future.
+ */
+#define XEN_DMOP_map_mem_type_to_ioreq_server 15
+
+struct xen_dm_op_map_mem_type_to_ioreq_server {
+	ioservid_t id;  /* IN - ioreq server id */
+	uint16_t type;  /* IN - memory type */
+	uint32_t flags; /* IN - types of accesses to be forwarded to the */
+			/* ioreq server. flags with 0 means to unmap the */
+			/* ioreq server */
+
+#define XEN_DMOP_IOREQ_MEM_ACCESS_READ  (1u << 0)
+#define XEN_DMOP_IOREQ_MEM_ACCESS_WRITE (1u << 1)
+
+	uint64_t opaque; /* IN/OUT - only used for hypercall continuation, */
+			 /* has to be set to zero by the caller */
+};
+typedef struct xen_dm_op_map_mem_type_to_ioreq_server xen_dm_op_map_mem_type_to_ioreq_server_t;
+
+/*
+ * XEN_DMOP_remote_shutdown : Declare a shutdown for another domain
+ *                            Identical to SCHEDOP_remote_shutdown
+ */
+#define XEN_DMOP_remote_shutdown 16
+
+struct xen_dm_op_remote_shutdown {
+	uint32_t reason; /* SHUTDOWN_* => enum sched_shutdown_reason */
+			 /* (Other reason values are not blocked) */
+};
+typedef struct xen_dm_op_remote_shutdown xen_dm_op_remote_shutdown_t;
+
+/*
+ * XEN_DMOP_relocate_memory : Relocate GFNs for the specified guest.
+ *                            Identical to XENMEM_add_to_physmap with
+ *                            space == XENMAPSPACE_gmfn_range.
+ */
+#define XEN_DMOP_relocate_memory 17
+
+struct xen_dm_op_relocate_memory {
+	/* All fields are IN/OUT, with their OUT state undefined. */
+	/* Number of GFNs to process. */
+	uint32_t size;
+	uint32_t pad;
+	/* Starting GFN to relocate. */
+	uint64_aligned_t src_gfn;
+	/* Starting GFN where GFNs should be relocated. */
+	uint64_aligned_t dst_gfn;
+};
+typedef struct xen_dm_op_relocate_memory xen_dm_op_relocate_memory_t;
+
+/*
+ * XEN_DMOP_pin_memory_cacheattr : Pin caching type of RAM space.
+ *                                 Identical to XEN_DOMCTL_pin_mem_cacheattr.
+ */
+#define XEN_DMOP_pin_memory_cacheattr 18
+
+struct xen_dm_op_pin_memory_cacheattr {
+	uint64_aligned_t start; /* Start gfn. */
+	uint64_aligned_t end;   /* End gfn. */
+/* Caching types: these happen to be the same as x86 MTRR/PAT type codes. */
+#define XEN_DMOP_MEM_CACHEATTR_UC     0
+#define XEN_DMOP_MEM_CACHEATTR_WC     1
+#define XEN_DMOP_MEM_CACHEATTR_WT     4
+#define XEN_DMOP_MEM_CACHEATTR_WP     5
+#define XEN_DMOP_MEM_CACHEATTR_WB     6
+#define XEN_DMOP_MEM_CACHEATTR_UCM    7
+#define XEN_DMOP_DELETE_MEM_CACHEATTR (~(uint32_t)0)
+	uint32_t type; /* XEN_DMOP_MEM_CACHEATTR_* */
+	uint32_t pad;
+};
+typedef struct xen_dm_op_pin_memory_cacheattr xen_dm_op_pin_memory_cacheattr_t;
+
+/*
+ * XEN_DMOP_set_irq_level: Set the logical level of a one of a domain's
+ *                         IRQ lines (currently Arm only).
+ * Only SPIs are supported.
+ */
+#define XEN_DMOP_set_irq_level 19
+
+struct xen_dm_op_set_irq_level {
+	uint32_t irq;
+	/* IN - Level: 0 -> deasserted, 1 -> asserted */
+	uint8_t level;
+	uint8_t pad[3];
+};
+typedef struct xen_dm_op_set_irq_level xen_dm_op_set_irq_level_t;
+
+/*
+ * XEN_DMOP_nr_vcpus: Query the number of vCPUs a domain has.
+ *
+ * This is the number of vcpu objects allocated in Xen for the domain, and is
+ * fixed from creation time.  This bound is applicable to e.g. the vcpuid
+ * parameter of XEN_DMOP_inject_event, or number of struct ioreq objects
+ * mapped via XENMEM_acquire_resource.
+ */
+#define XEN_DMOP_nr_vcpus 20
+
+struct xen_dm_op_nr_vcpus {
+	uint32_t vcpus; /* OUT */
+};
+typedef struct xen_dm_op_nr_vcpus xen_dm_op_nr_vcpus_t;
+
+struct xen_dm_op {
+	uint32_t op;
+	uint32_t pad;
+	union {
+		xen_dm_op_create_ioreq_server_t create_ioreq_server;
+		xen_dm_op_get_ioreq_server_info_t get_ioreq_server_info;
+		xen_dm_op_ioreq_server_range_t map_io_range_to_ioreq_server;
+		xen_dm_op_ioreq_server_range_t unmap_io_range_from_ioreq_server;
+		xen_dm_op_set_ioreq_server_state_t set_ioreq_server_state;
+		xen_dm_op_destroy_ioreq_server_t destroy_ioreq_server;
+		xen_dm_op_track_dirty_vram_t track_dirty_vram;
+		xen_dm_op_set_pci_intx_level_t set_pci_intx_level;
+		xen_dm_op_set_isa_irq_level_t set_isa_irq_level;
+		xen_dm_op_set_irq_level_t set_irq_level;
+		xen_dm_op_set_pci_link_route_t set_pci_link_route;
+		xen_dm_op_modified_memory_t modified_memory;
+		xen_dm_op_set_mem_type_t set_mem_type;
+		xen_dm_op_inject_event_t inject_event;
+		xen_dm_op_inject_msi_t inject_msi;
+		xen_dm_op_map_mem_type_to_ioreq_server_t map_mem_type_to_ioreq_server;
+		xen_dm_op_remote_shutdown_t remote_shutdown;
+		xen_dm_op_relocate_memory_t relocate_memory;
+		xen_dm_op_pin_memory_cacheattr_t pin_memory_cacheattr;
+		xen_dm_op_nr_vcpus_t nr_vcpus;
+	} u;
+};
+
+struct xen_dm_op_buf {
+	XEN_GUEST_HANDLE(void) h;
+	xen_ulong_t size;
+};
+typedef struct xen_dm_op_buf xen_dm_op_buf_t;
+DEFINE_XEN_GUEST_HANDLE(xen_dm_op_buf_t);
+
+/* ` enum neg_errnoval
+ * ` HYPERVISOR_dm_op(domid_t domid,
+ * `                  unsigned int nr_bufs,
+ * `                  xen_dm_op_buf_t bufs[])
+ * `
+ *
+ * @domid is the domain the hypercall operates on.
+ * @nr_bufs is the number of buffers in the @bufs array.
+ * @bufs points to an array of buffers where @bufs[0] contains a struct
+ * xen_dm_op, describing the specific device model operation and its
+ * parameters.
+ * @bufs[1..] may be referenced in the parameters for the purposes of
+ * passing extra information to or from the domain.
+ */
+
+#endif /* __XEN_PUBLIC_HVM_DM_OP_H__ */
+
+/*
+ * Local variables:
+ * mode: C
+ * c-file-style: "BSD"
+ * c-basic-offset: 4
+ * tab-width: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/include/zephyr/xen/public/hvm/hvm_op.h
+++ b/include/zephyr/xen/public/hvm/hvm_op.h
@@ -39,4 +39,17 @@ struct xen_hvm_param {
 typedef struct xen_hvm_param xen_hvm_param_t;
 DEFINE_XEN_GUEST_HANDLE(xen_hvm_param_t);
 
+/*
+ * Definitions relating to DMOP_create_ioreq_server. (Defined here for
+ * backwards compatibility).
+ */
+
+#define HVM_IOREQSRV_BUFIOREQ_OFF    0
+#define HVM_IOREQSRV_BUFIOREQ_LEGACY 1
+/*
+ * Use this when read_pointer gets updated atomically and
+ * the pointer pair gets read atomically:
+ */
+#define HVM_IOREQSRV_BUFIOREQ_ATOMIC 2
+
 #endif /* __XEN_PUBLIC_HVM_HVM_OP_H__ */

--- a/include/zephyr/xen/public/hvm/ioreq.h
+++ b/include/zephyr/xen/public/hvm/ioreq.h
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * ioreq.h: I/O request definitions for device models
+ * Copyright (c) 2004, Intel Corporation.
+ */
+
+#ifndef _IOREQ_H_
+#define _IOREQ_H_
+
+#define IOREQ_READ  1
+#define IOREQ_WRITE 0
+
+#define STATE_IOREQ_NONE      0
+#define STATE_IOREQ_READY     1
+#define STATE_IOREQ_INPROCESS 2
+#define STATE_IORESP_READY    3
+
+#define IOREQ_TYPE_PIO        0 /* pio */
+#define IOREQ_TYPE_COPY       1 /* mmio ops */
+#define IOREQ_TYPE_PCI_CONFIG 2
+#define IOREQ_TYPE_TIMEOFFSET 7
+#define IOREQ_TYPE_INVALIDATE 8 /* mapcache */
+
+/*
+ * VMExit dispatcher should cooperate with instruction decoder to
+ * prepare this structure and notify service OS and DM by sending
+ * virq.
+ *
+ * For I/O type IOREQ_TYPE_PCI_CONFIG, the physical address is formatted
+ * as follows:
+ *
+ * 63....48|47..40|39..35|34..32|31........0
+ * SEGMENT |BUS   |DEV   |FN    |OFFSET
+ */
+struct ioreq {
+	uint64_t addr;     /* physical address */
+	uint64_t data;     /* data (or paddr of data) */
+	uint32_t count;    /* for rep prefixes */
+	uint32_t size;     /* size in bytes */
+	uint32_t vp_eport; /* evtchn for notifications to/from device model */
+	uint16_t _pad0;
+	uint8_t state: 4;
+	uint8_t data_is_ptr: 1; /* if 1, data above is the guest paddr */
+				/* of the real data to use. */
+	uint8_t dir: 1;         /* 1=read, 0=write */
+	uint8_t df: 1;
+	uint8_t _pad1: 1;
+	uint8_t type; /* I/O type */
+};
+typedef struct ioreq ioreq_t;
+
+struct shared_iopage {
+	struct ioreq vcpu_ioreq[1];
+};
+typedef struct shared_iopage shared_iopage_t;
+
+struct buf_ioreq {
+	uint8_t type; /* I/O type                    */
+	uint8_t pad: 1;
+	uint8_t dir: 1;    /* 1=read, 0=write             */
+	uint8_t size: 2;   /* 0=>1, 1=>2, 2=>4, 3=>8. If 8, use two buf_ioreqs */
+	uint32_t addr: 20; /* physical address            */
+	uint32_t data;     /* data                        */
+};
+typedef struct buf_ioreq buf_ioreq_t;
+
+#define IOREQ_BUFFER_SLOT_NUM 511 /* 8 bytes each, plus 2 4-byte indexes */
+struct buffered_iopage {
+#ifdef __XEN__
+	union bufioreq_pointers {
+		struct {
+#endif
+			uint32_t read_pointer;
+			uint32_t write_pointer;
+#ifdef __XEN__
+		};
+		uint64_t full;
+	} ptrs;
+#endif
+	buf_ioreq_t buf_ioreq[IOREQ_BUFFER_SLOT_NUM];
+}; /* NB. Size of this structure must be no greater than one page. */
+typedef struct buffered_iopage buffered_iopage_t;
+
+/*
+ * ACPI Control/Event register locations. Location is controlled by a
+ * version number in HVM_PARAM_ACPI_IOPORTS_LOCATION.
+ */
+
+/*
+ * Version 0 (default): Traditional (obsolete) Xen locations.
+ *
+ * These are now only used for compatibility with VMs migrated
+ * from older Xen versions.
+ */
+#define ACPI_PM1A_EVT_BLK_ADDRESS_V0 0x1f40
+#define ACPI_PM1A_CNT_BLK_ADDRESS_V0 (ACPI_PM1A_EVT_BLK_ADDRESS_V0 + 0x04)
+#define ACPI_PM_TMR_BLK_ADDRESS_V0   (ACPI_PM1A_EVT_BLK_ADDRESS_V0 + 0x08)
+#define ACPI_GPE0_BLK_ADDRESS_V0     (ACPI_PM_TMR_BLK_ADDRESS_V0 + 0x20)
+#define ACPI_GPE0_BLK_LEN_V0         0x08
+
+/* Version 1: Locations preferred by modern Qemu (including Qemu-trad). */
+#define ACPI_PM1A_EVT_BLK_ADDRESS_V1 0xb000
+#define ACPI_PM1A_CNT_BLK_ADDRESS_V1 (ACPI_PM1A_EVT_BLK_ADDRESS_V1 + 0x04)
+#define ACPI_PM_TMR_BLK_ADDRESS_V1   (ACPI_PM1A_EVT_BLK_ADDRESS_V1 + 0x08)
+#define ACPI_GPE0_BLK_ADDRESS_V1     0xafe0
+#define ACPI_GPE0_BLK_LEN_V1         0x04
+
+/* Compatibility definitions for the default location (version 0). */
+#define ACPI_PM1A_EVT_BLK_ADDRESS ACPI_PM1A_EVT_BLK_ADDRESS_V0
+#define ACPI_PM1A_CNT_BLK_ADDRESS ACPI_PM1A_CNT_BLK_ADDRESS_V0
+#define ACPI_PM_TMR_BLK_ADDRESS   ACPI_PM_TMR_BLK_ADDRESS_V0
+#define ACPI_GPE0_BLK_ADDRESS     ACPI_GPE0_BLK_ADDRESS_V0
+#define ACPI_GPE0_BLK_LEN         ACPI_GPE0_BLK_LEN_V0
+
+#endif /* _IOREQ_H_ */
+
+/*
+ * Local variables:
+ * mode: C
+ * c-file-style: "BSD"
+ * c-basic-offset: 4
+ * tab-width: 4
+ * indent-tabs-mode: nil
+ * End:
+ */


### PR DESCRIPTION
Add wrappers for following XEN_DMOP_* hypercalls.
These enables Xen device model control path:
dm_op provides operations to create/manage the ioreq server
so guest MMIO accesses are trapped and handled by the hypervisor.
These are guarded by CONFIG_XEN_DMOP.

- dmop
  - dmop_create_ioreq_server
    XEN_DMOP_create_ioreq_server
  - dmop_map_io_range_to_ioreq_server
    XEN_DMOP_map_io_range_to_ioreq_server
  - dmop_set_ioreq_server_state
    XEN_DMOP_set_ioreq_server_state
  - dmop_nr_vcpus
    XEN_DMOP_nr_vcpus
  - dmop_set_irq_level:
    XEN_DMOP_set_irq_level
    
---

Since this is an addition of the MIT license, a warning is displayed in CI, but I think there is no problem because the source is from the same origin as approved in #37239.

---

I accidentally raised it to Architecture Review.
The license should have been a matter for TSC consideration, so I re-added it.