### PR TITLE
stm32: test: drivers: memc: ram: fix a specific SRAM memory overflow issue during the build process

### DIFF
--- a/tests/drivers/memc/ram/boards/stm32h7s78_dk.overlay
+++ b/tests/drivers/memc/ram/boards/stm32h7s78_dk.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&memc {
+
+	status = "disabled";
+};
+
+&psram {
+	status = "disabled";
+};

--- a/tests/drivers/memc/ram/boards/stm32h7s78_psram.overlay
+++ b/tests/drivers/memc/ram/boards/stm32h7s78_psram.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sram1 {
+	status = "disabled";
+};
+
+&sram2 {
+	status = "disabled";
+};

--- a/tests/drivers/memc/ram/testcase.yaml
+++ b/tests/drivers/memc/ram/testcase.yaml
@@ -11,3 +11,9 @@ tests:
     extra_args:
       - platform:da1469x_dk_pro/da14699:EXTRA_DTC_OVERLAY_FILE="da1469x_dk_pro_psram.overlay"
       - platform:da14695_dk_usb/da14695:EXTRA_DTC_OVERLAY_FILE="da14695_dk_usb_psram.overlay"
+  drivers.memc.stm32_psram:
+    depends_on: memc
+    integration_platforms:
+      - stm32h7s78_dk
+    extra_args:
+      - platform:stm32h7s78_dk/stm32h7s7xx:DTC_OVERLAY_FILE="boards/stm32h7s78_psram.overlay"


### PR DESCRIPTION
This commit  https://github.com/zephyrproject-rtos/zephyr/commit/23ebd62d1ea0132383fffcd3190ec9e4e8b3cf04 adds changes to update the buffer size to the full PSRAM size when the PSRAM node is available.
Now, on a board like stm32h7s78_dk, where both internal and external flash nodes are enabled, the test runs into SRAM overflow with the following errors: ...

```
...zephyr/zephyr_pre0.elf section `SRAM1' will not fit in region `SRAM1' 
...zephyr/zephyr_pre0.elf section `SRAM2' will not fit in region `SRAM2' 
...
...region `SRAM1' overflowed by 2080768 bytes 
...region `SRAM2' overflowed by 2080768 bytes 
```
To run tests successfully, mutual exclusion between SRAM and PSRAM needs to be implemented, so the correct buffer size is chosen for the correct peripheral.



To reproduce : 

`west build -p -b stm32h7s78_dk/stm32h7s7xx tests/drivers/memc/ram -T drivers.memc`
