### PR TITLE
stm32: drivers: clock_control:  replace pllsai1m with pllsaim

### DIFF
--- a/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
+++ b/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
@@ -151,7 +151,7 @@ void config_pllsai1(void)
 #endif
 #if STM32_PLLSAI1_P_ENABLED
 	LL_RCC_PLLSAI1_ConfigDomain_SAI(get_pllsai1_source(),
-					pllsai1m(STM32_PLLSAI1_M_DIVISOR),
+					pllsaim(STM32_PLLSAI1_M_DIVISOR),
 					STM32_PLLSAI1_N_MULTIPLIER,
 					pllsai1p(STM32_PLLSAI1_P_DIVISOR));
 
@@ -160,7 +160,7 @@ void config_pllsai1(void)
 
 #if STM32_PLLSAI1_Q_ENABLED
 	LL_RCC_PLLSAI1_ConfigDomain_48M(get_pllsai1_source(),
-					pllsai1m(STM32_PLLSAI1_M_DIVISOR),
+					pllsaim(STM32_PLLSAI1_M_DIVISOR),
 					STM32_PLLSAI1_N_MULTIPLIER,
 					pllsai1q(STM32_PLLSAI1_Q_DIVISOR));
 
@@ -169,7 +169,7 @@ void config_pllsai1(void)
 
 #if STM32_PLLSAI1_R_ENABLED
 	LL_RCC_PLLSAI1_ConfigDomain_ADC(get_pllsai1_source(),
-					pllsai1m(STM32_PLLSAI1_M_DIVISOR),
+					pllsaim(STM32_PLLSAI1_M_DIVISOR),
 					STM32_PLLSAI1_N_MULTIPLIER,
 					pllsai1r(STM32_PLLSAI1_R_DIVISOR));
 


### PR DESCRIPTION
This commit https://github.com/zephyrproject-rtos/zephyr/commit/63367b5cb403e4f52b85289b6f12d4fa5be72423 updates the function name from  `pllsai1m` was to `pllsaim`. 


This missing change is updated in the `clock_stm32l4_l5_wb_wl.c` driver.


To reproduce: 
` west build -p -b nucleo_l432kc/stm32l432xx samples/drivers/i2s/output -T sample.drivers.i2s.output
`