### PR TITLE
tests: Bluetooth: Audio: Fix uninitalized value

### DIFF
--- a/tests/bluetooth/audio/mocks/src/gatt.c
+++ b/tests/bluetooth/audio/mocks/src/gatt.c
@@ -150,6 +150,7 @@ static struct bt_uuid *uuid_deep_copy(const struct bt_uuid *uuid)
 		memcpy(copy, uuid, sizeof(struct bt_uuid_128));
 		break;
 	default:
+		copy = NULL;
 		zassert_unreachable("Unexpected uuid->type 0x%02x", uuid->type);
 	}
 


### PR DESCRIPTION
copy may be uninitialzed in the default case, which causes some compiler warnings/errors when returned and used.