### PR TITLE
Bluetooth: Controller: BIG_TERMINATE_IND reason unused

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -89,7 +89,6 @@ struct lll_adv_iso {
 
 	uint8_t term_req:1;
 	uint8_t term_ack:1;
-	uint8_t term_reason;
 
 	uint8_t  ctrl_expire;
 	uint16_t ctrl_instant;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -10,6 +10,7 @@
 #include <soc.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/bluetooth/hci_types.h>
 
 #include "hal/cpu.h"
 #include "hal/ccm.h"
@@ -604,7 +605,7 @@ static void isr_tx_common(void *param,
 		pdu->ctrl.opcode = PDU_BIG_CTRL_TYPE_TERM_IND;
 
 		term = (void *)&pdu->ctrl.term_ind;
-		term->reason = lll->term_reason;
+		term->reason_unused = BT_HCI_ERR_REMOTE_USER_TERM_CONN;
 		term->instant = lll->ctrl_instant;
 
 		/* control subevent to use bis = 0 and se_n = 1 */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -1848,7 +1848,7 @@ static void isr_rx_ctrl_recv(struct lll_sync_iso *lll, struct pdu_bis *pdu)
 			struct pdu_big_ctrl_term_ind *term;
 
 			term = (void *)&pdu->ctrl.term_ind;
-			lll->term_reason = term->reason;
+			lll->term_reason = BT_HCI_ERR_REMOTE_USER_TERM_CONN;
 			lll->ctrl_instant = term->instant;
 		}
 	} else if (opcode == PDU_BIG_CTRL_TYPE_CHAN_MAP_IND) {

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -1109,7 +1109,7 @@ struct pdu_big_ctrl_chan_map_ind {
 } __packed;
 
 struct pdu_big_ctrl_term_ind {
-	uint8_t  reason;
+	uint8_t  reason_unused;
 	uint16_t instant;
 } __packed;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -779,7 +779,6 @@ uint8_t ll_big_terminate(uint8_t big_handle, uint8_t reason)
 	}
 
 	/* Request terminate procedure */
-	lll_adv_iso->term_reason = reason;
 	lll_adv_iso->term_req = 1U;
 
 	return BT_HCI_ERR_SUCCESS;


### PR DESCRIPTION
Only Remote User Terminated Connection (0x13), MIC Failure (0x3D) and Supervision Timeout (0x08) are valid reason in the LE BIG Sync Lost event, hence, reason field in the BIG_TERMINATE_IND Control PDU is unused.