### PR TITLE
tests: flash: Fix disable_spi_nor filtering

### DIFF
--- a/tests/drivers/flash/common/Kconfig
+++ b/tests/drivers/flash/common/Kconfig
@@ -16,4 +16,12 @@ config TEST_DRIVER_FLASH_SIZE
 	  support the get_size() API, leave this set as -1 to skip the test.
 	  For the STM32 devices, the flash size is directly given by the soc DTSI.
 
+config TEST_FORCE_STORAGE_PARTITION
+	bool "Force testing the storage partition area"
+	default n
+	help
+	  This test prioritizes testing spi nor flash over
+	  the storage area by default. Set this config to priorize
+	  testing the storage partition instead.
+
 source "Kconfig.zephyr"

--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -10,7 +10,9 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/storage/flash_map.h>
 
-#if defined(CONFIG_NORDIC_QSPI_NOR)
+#if defined(CONFIG_TEST_FORCE_STORAGE_PARTITION)
+#define TEST_AREA	storage_partition
+#elif defined(CONFIG_NORDIC_QSPI_NOR)
 #define TEST_AREA_DEV_NODE	DT_INST(0, nordic_qspi_nor)
 #elif defined(SOC_SERIES_STM32N6X)
 #define TEST_AREA_DEV_NODE	DT_INST(0, st_stm32_xspi_nor)

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -155,12 +155,12 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-  drivers.flash.common.disable_spi_nor:
-    filter: dt_compat_enabled("soc-nv-flash") and dt_compat_enabled("jedec,spi-nor")
+  drivers.flash.common.test_storage_partition:
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     platform_exclude:
       - beagleconnect_freedom/cc1352p7
     extra_args:
-      - CONFIG_SPI_NOR=n
+      - CONFIG_TEST_FORCE_STORAGE_PARTITION=y
   drivers.flash.common.ra_ospi_b_nor:
     platform_allow:
       - ek_ra8m1


### PR DESCRIPTION
Require platform has a "storage partition" to run the "disable spi nor" case, due to this is what the test code expects.

Fixes #96682