### PR TITLE
boards: native_sim: Log failed restart to stdout

### DIFF
--- a/boards/native/native_sim/reboot_bottom.c
+++ b/boards/native/native_sim/reboot_bottom.c
@@ -71,8 +71,8 @@ void maybe_reboot(void)
 
 	(void)execv("/proc/self/exe", argv);
 
-	nsi_print_error_and_exit("%s: Failed to restart process, exiting (%s)\n", module,
-				 strerror(errno));
+	nsi_print_warning("%s: Failed to restart process, exiting (%s)\n", module, strerror(errno));
+	nsi_exit(1);
 }
 
 NSI_TASK(maybe_reboot, ON_EXIT_POST, 999);


### PR DESCRIPTION
Log error message to stdout instead of stderr when execv() fails in maybe_reboot(). This avoids the error message being lost when the native_sim board is runs in CI.