### PR TITLE
net: http_server: Fix crash when cb refuses new websocket connection

### DIFF
--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -383,9 +383,11 @@ static void close_client_connection(struct http_client_ctx *client)
 {
 	int fd = client->fd;
 
-	http_server_release_client(client);
+	if (fd >= 0) {
+		http_server_release_client(client);
 
-	(void)zsock_close(fd);
+		(void)zsock_close(fd);
+	}
 }
 
 static void client_timeout(struct k_work *work)


### PR DESCRIPTION
Zephyr crashes when a new websocket connection is refused by the user supplied callback function. This is caused by multiple calls of close_client_connection(). After the first call the file handle and the client->service pointer are invalid.

This fix checks if the file handle is valid.