### PR TITLE
net: mqtt_sn: Implement updating will topic and message

### DIFF
--- a/doc/connectivity/networking/api/mqtt_sn.rst
+++ b/doc/connectivity/networking/api/mqtt_sn.rst
@@ -149,7 +149,6 @@ Deviations from the standard
 Certain parts of the protocol are not yet supported in the library.
 
 * QoS -1 - it's most useful with predefined topics
-* Setting the will topic and message after the initial connect
 * Forwarder Encapsulation
 
 .. _mqtt_sn_api_reference:


### PR DESCRIPTION
Since the protocol doesn't have message IDs in the responses to these update messages, there's no reliable way to know, if an update succeeded or not. I use that fact to simplify the implementation by:
- Not providing success/failure callbacks.
- Not handling updating the variables in the client struct while an update is in progess.

In addition to adding some tests, I tested this with the emqx server.