### PR TITLE
tests native_sim reset_hw_info: Skip by now

### DIFF
--- a/tests/boards/native_sim/reset_hw_info/testcase.yaml
+++ b/tests/boards/native_sim/reset_hw_info/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   boards.native_sim.reset_hw_info:
+    skip: true
     platform_allow:
       - native_sim
       - native_sim/native/64


### PR DESCRIPTION
This tests is failing in CI and at random locally. While we understand why and how to fix it, let's disable it.