### PR TITLE
mcumgr: client: Allow specifying server address

### DIFF
--- a/include/zephyr/mgmt/mcumgr/smp/smp_client.h
+++ b/include/zephyr/mgmt/mcumgr/smp/smp_client.h
@@ -32,6 +32,8 @@ struct smp_client_object {
 	struct smp_transport *smpt;
 	/** SMP SEQ */
 	uint8_t smp_seq;
+	/** SMP transport data. Allows multiple client_object for single smp_transport. */
+	void *priv;
 };
 
 #ifdef __cplusplus
@@ -48,6 +50,27 @@ extern "C" {
  * @return	mcumgr_err_t code on failure
  */
 int smp_client_object_init(struct smp_client_object *smp_client, int smp_type);
+
+/**
+ * @brief Set private data for SMP transport.
+ *
+ * @param smp_client	The Client to set private data for.
+ * @param data		SMP transport private data.
+ */
+static inline void smp_client_object_set_data(struct smp_client_object *smp_client, void *data)
+{
+	smp_client->priv = data;
+}
+
+/**
+ * @brief Get private data for SMP transport.
+ *
+ * @param smp_client	The Client to set private data for.
+ */
+static inline void *smp_client_object_get_data(struct smp_client_object *smp_client)
+{
+	return smp_client->priv;
+}
 
 /**
  * @brief Response callback for SMP send.

--- a/include/zephyr/mgmt/mcumgr/transport/smp.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp.h
@@ -91,6 +91,16 @@ typedef void (*smp_transport_ud_free_fn)(void *ud);
  */
 typedef bool (*smp_transport_query_valid_check_fn)(struct net_buf *nb, void *arg);
 
+/** @typedef smp_transport_ud_req_init_fn
+ * @brief SMP init request buffer
+ *
+ * The supplied net_buf should be for a SMP request
+ *
+ * @param nb                    net buf for SMP request
+ * @param priv			SMP transport private data
+ */
+typedef void (*smp_transport_ud_req_init_fn)(struct net_buf *nb, void *priv);
+
 /**
  * @brief Function pointers of SMP transport functions, if a handler is NULL then it is not
  * supported/implemented.
@@ -110,6 +120,9 @@ struct smp_transport_api_t {
 
 	/** Transport's check function for if a query is valid. */
 	smp_transport_query_valid_check_fn query_valid_check;
+
+	/** Transport's request buffer init function */
+	smp_transport_ud_req_init_fn ud_init;
 };
 
 /**

--- a/include/zephyr/mgmt/mcumgr/transport/smp_udp.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp_udp.h
@@ -14,6 +14,9 @@
 #ifndef ZEPHYR_INCLUDE_MGMT_SMP_UDP_H_
 #define ZEPHYR_INCLUDE_MGMT_SMP_UDP_H_
 
+#include <zephyr/mgmt/mcumgr/smp/smp_client.h>
+#include <zephyr/net/net_ip.h>
+
 /**
  * @brief This allows to use the MCUmgr SMP protocol over UDP.
  * @defgroup mcumgr_transport_udp UDP transport
@@ -45,6 +48,18 @@ int smp_udp_open(void);
  * @return	-errno code on failure.
  */
 int smp_udp_close(void);
+
+#if defined(CONFIG_SMP_CLIENT) || defined(__DOXYGEN__)
+/**
+ * @brief	Set host address for smp_client_object
+ *
+ * @note	addr should be valid as long as obj is valid.
+ *
+ * @return	0 on success
+ * @return	-errno code on failure.
+ */
+int smp_client_udp_set_host_addr(struct smp_client_object *obj, struct sockaddr *addr);
+#endif
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/smp_client/src/client.c
+++ b/subsys/mgmt/mcumgr/smp_client/src/client.c
@@ -256,7 +256,7 @@ struct net_buf *smp_client_buf_allocation(struct smp_client_object *smp_client, 
 	struct net_buf *nb;
 	struct smp_hdr smp_header;
 
-	nb = smp_packet_alloc();
+	nb = smp_alloc_req(smp_client->smpt, smp_client_object_get_data(smp_client));
 
 	if (nb) {
 		/* Write SMP header with payload length 0 */

--- a/subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/smp_internal.h
+++ b/subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/smp_internal.h
@@ -58,6 +58,16 @@ struct k_work_q *smp_get_wq(void);
 #endif
 
 /**
+ * @brief Allocates a request buffer.
+ *
+ * @param arg		The streamer providing the callback.
+ *
+ * @return	Newly-allocated buffer on success
+ *		NULL on failure.
+ */
+struct net_buf *smp_alloc_req(void *arg, void *priv);
+
+/**
  * @brief Allocates a response buffer.
  *
  * If a source buf is provided, its user data is copied into the new buffer.

--- a/subsys/mgmt/mcumgr/transport/src/smp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp.c
@@ -54,6 +54,32 @@ void smp_packet_free(struct net_buf *nb)
 }
 
 /**
+ * @brief Allocates a request buffer.
+ *
+ * @param arg		The streamer providing the callback.
+ * @param priv		The streamer private data.
+ *
+ * @return	Newly-allocated buffer on success
+ *		NULL on failure.
+ */
+struct net_buf *smp_alloc_req(void *arg, void *priv)
+{
+	struct net_buf *req_nb;
+	struct smp_transport *smpt = arg;
+
+	req_nb = smp_packet_alloc();
+	if (req_nb == NULL) {
+		return NULL;
+	}
+
+	if (smpt->functions.ud_init) {
+		smpt->functions.ud_init(req_nb, priv);
+	}
+
+	return req_nb;
+}
+
+/**
  * @brief Allocates a response buffer.
  *
  * If a source buf is provided, its user data is copied into the new buffer.

--- a/tests/subsys/mgmt/mcumgr/smp_client/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/smp_client/src/main.c
@@ -32,7 +32,6 @@ int smp_client_res_cb(struct net_buf *nb, void *user_data)
 
 ZTEST(smp_client, test_buf_alloc)
 {
-	struct smp_client_object smp_client;
 	struct net_buf *buf[5];
 
 	/* Allocate all 4 buffer's and verify that 5th fail */


### PR DESCRIPTION
- Currently, it is not possible to use mcumgr client with smp server since there is no way to specify smp server address for requests.
- This patch series adds support for creating smp_client_object containing information regarding the host server. This design allows multiple smp_client_object to exist for the same underlying smp_udp transport, making it much easier to use the same udp socket for multiple OTAs.