### PR TITLE
drivers: usb: udc: Fix VBUS ready timeout dependency in Kconfig.dwc2

### DIFF
--- a/drivers/usb/udc/Kconfig.dwc2
+++ b/drivers/usb/udc/Kconfig.dwc2
@@ -49,7 +49,7 @@ config UDC_DWC2_THREAD_PRIORITY
 
 config UDC_DWC2_USBHS_VBUS_READY_TIMEOUT
 	int "UDC DWC2 USBHS VBUS ready event timeout in ms"
-	depends on SOC_SERIES_NRF54HX || SOC_SERIES_NRF54LX
+	depends on SOC_SERIES_NRF54HX || SOC_SERIES_NRF54LX || SOC_SERIES_NRF92X
 	default 0
 	help
 	  UDC DWC2 USBHS VBUS ready event timeout. If the VBUS is not ready


### PR DESCRIPTION
This is a follow up to commit 4fe2c5bd5fe1d017783eb4b48ca752759a68ca02.

The UDC_DWC2_USBHS_VBUS_READY_TIMEOUT Kconfig option should be available also for nRF92 Series SoCs (as it was previously when it depended on NRFS_HAS_VBUS_DETECTOR_SERVICE), otherwise some builds will fail for such targets.