### PR TITLE
drivers: sensor: explorir_m: fix variable mix-up

### DIFF
--- a/drivers/sensor/explorir_m/explorir_m.c
+++ b/drivers/sensor/explorir_m/explorir_m.c
@@ -135,11 +135,11 @@ static int explorir_m_buffer_process(struct explorir_m_data *data, char type,
 		break;
 
 	case EXPLORIR_M_CO2_FILTERED_CHAR:
-		data->scaling = strtol(&data->read_buffer[EXPLORIR_M_VALUE_INDEX], NULL, 10);
+		data->filtered = strtol(&data->read_buffer[EXPLORIR_M_VALUE_INDEX], NULL, 10);
 		break;
 
 	case EXPLORIR_M_SCALING_CHAR:
-		data->filtered = strtol(&data->read_buffer[EXPLORIR_M_VALUE_INDEX], NULL, 10);
+		data->scaling = strtol(&data->read_buffer[EXPLORIR_M_VALUE_INDEX], NULL, 10);
 		break;
 
 	case EXPLORIR_M_GET_FILTER_CHAR:
@@ -282,7 +282,7 @@ static int explorir_m_calibrate(const struct device *dev, struct sensor_value *v
 	rc = explorir_m_uart_transceive(dev, EXPLORIR_M_SET_FILTER_CHAR, &tmp,
 					EXPLORIR_M_SET_VAL_ONE);
 	if (rc == 0) {
-		tmp.val1 = val->val1 / data->filtered;
+		tmp.val1 = val->val1 / data->scaling;
 		rc = explorir_m_uart_transceive(dev, EXPLORIR_M_ZERO_POINT_KNOWN_CHAR, &tmp,
 						EXPLORIR_M_SET_VAL_ONE);
 	}


### PR DESCRIPTION
Fix the mix‑up between `filtered` and `scaling` in `explorir_m_buffer_process()`.