### PR TITLE
arch/posix: Workaround race condition in glibc

### DIFF
--- a/boards/native/native_sim/CMakeLists.txt
+++ b/boards/native/native_sim/CMakeLists.txt
@@ -16,6 +16,10 @@ zephyr_library_sources(
 if(CONFIG_NATIVE_SIM_REBOOT)
   zephyr_library_sources(reboot.c)
   target_sources(native_simulator INTERFACE reboot_bottom.c)
+
+  # Explicitly link with libgcc_s to work around a race condition in glibc when
+  # dynamically loading libgcc_s in multiple threads.
+  target_link_options(native_simulator INTERFACE "-lgcc_s")
 endif()
 
 zephyr_include_directories(

--- a/tests/boards/native_sim/reset_hw_info/testcase.yaml
+++ b/tests/boards/native_sim/reset_hw_info/testcase.yaml
@@ -1,6 +1,5 @@
 tests:
   boards.native_sim.reset_hw_info:
-    skip: true
     platform_allow:
       - native_sim
       - native_sim/native/64


### PR DESCRIPTION
Explicitly link with libgcc_s to work around a race condition in glibc when dynamically loading libgcc_s in multiple threads.

The race condition was observed in the past in https://github.com/zephyrproject-rtos/zephyr/pull/87987#issuecomment-2778378878 when running native_sim with `CONFIG_REBOOT=y` and `CONFIG_NATIVE_SIM_REBOOT=y` and rebooting quickly
from `main()`. As well as in the new `boards.native_sim.reset_hw_info` test that was temporarily disabled in https://github.com/zephyrproject-rtos/zephyr/pull/96765.

Most likely, this is caused by `pthread_exit()` and `vprintf` loading `libgcc_s` in two threads at the same time. The program then crashes with
```
libgcc_s.so.1 must be installed for pthread_exit to work
Aborted (core dumped)
```

With this PR, no crashes were observed for the following example (without sleeping) based on https://github.com/zephyrproject-rtos/zephyr/pull/87987#issuecomment-2778378878:
```
diff --git a/samples/hello_world/prj.conf b/samples/hello_world/prj.conf
index b2a4ba59104..36d8008a72b 100644
--- a/samples/hello_world/prj.conf
+++ b/samples/hello_world/prj.conf
@@ -1 +1,3 @@
 # nothing here
+CONFIG_REBOOT=y
+CONFIG_NATIVE_SIM_REBOOT=y
\ No newline at end of file
diff --git a/samples/hello_world/src/main.c b/samples/hello_world/src/main.c
index c550ab461cb..4c3b037d42e 100644
--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -5,10 +5,14 @@
  */
 
 #include <stdio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/reboot.h>
 
 int main(void)
 {
        printf("Hello World! %s\n", CONFIG_BOARD_TARGET);
 
+       sys_reboot(SYS_REBOOT_WARM);
+
        return 0;
 }
```