### PR TITLE
added uc8151d display controller support

### DIFF
--- a/drivers/display/Kconfig.uc81xx
+++ b/drivers/display/Kconfig.uc81xx
@@ -6,7 +6,7 @@
 config UC81XX
 	bool "UltraChip UC81xx compatible display controller driver"
 	default y
-	depends on DT_HAS_ULTRACHIP_UC8175_ENABLED || DT_HAS_ULTRACHIP_UC8176_ENABLED || DT_HAS_ULTRACHIP_UC8179_ENABLED
+	depends on DT_HAS_ULTRACHIP_UC8175_ENABLED || DT_HAS_ULTRACHIP_UC8176_ENABLED || DT_HAS_ULTRACHIP_UC8151D_ENABLED || DT_HAS_ULTRACHIP_UC8179_ENABLED
 	select MIPI_DBI
 	help
 	  Enable driver for UC81xx compatible controller.

--- a/drivers/display/uc81xx_regs.h
+++ b/drivers/display/uc81xx_regs.h
@@ -140,7 +140,48 @@ struct uc81xx_ptl16 {
 
 BUILD_ASSERT(sizeof(struct uc81xx_ptl16) == 9);
 
-#define UC81XX_PTL_FLAG_PT_SCAN			BIT(0)
+/* UC8151D-specific structures */
+#if DT_HAS_COMPAT_STATUS_OKAY(ultrachip_uc8151d)
+struct uc8151d_tres {
+	/* Horizontal resolution in pixels.
+	 * Hardware interprets as bank[7:3] | column[2:0]
+	 */
+	uint8_t hres;
+	uint16_t vres;       /* Vertical resolution (big-endian) */
+} __packed;
+
+BUILD_ASSERT(sizeof(struct uc8151d_tres) == 3);
+
+struct uc8151d_ptl {
+	uint8_t hrst;        /* Horizontal start (byte-packed) */
+	uint8_t hred;        /* Horizontal end (byte-packed) */
+	uint16_t vrst;       /* Vertical start (big-endian, 9-bit) */
+	uint16_t vred;       /* Vertical end (big-endian, 9-bit) */
+	uint8_t pt_scan;      /* PT_SCAN - Scan mode */
+} __packed;
+
+BUILD_ASSERT(sizeof(struct uc8151d_ptl) == 7);
+
+/* UC8151D CDI register bit fields */
+#define UC8151D_CDI_VBD_MASK		GENMASK(7, 6)
+#define UC8151D_CDI_DDX_MASK		GENMASK(5, 4)
+#define UC8151D_CDI_MASK			GENMASK(3, 0)
+#define UC8151D_CDI_DEFAULT			0xD7    /* Default value */
+
+/* UC8151D CDI VBD values for border control */
+#define UC8151D_CDI_VBD_FLOATING	0x00    /* Floating border */
+#define UC8151D_CDI_VBD_LUT1		0x40    /* LUT1 border */
+#define UC8151D_CDI_VBD_LUT2		0x80    /* LUT2 border */
+#define UC8151D_CDI_VBD_LUT3		0xC0    /* LUT3 border */
+
+/* UC8151D CDI DDX values for data polarity */
+#define UC8151D_CDI_DDX_DEFAULT		0x10    /* Default DDX setting */
+
+/* UC8151D CDI interval values */
+#define UC8151D_CDI_10_HSYNC		0x07    /* 10 hsync (default) */
+#endif
+
+#define UC81XX_PTL_FLAG_PT_SCAN		BIT(0)
 
 /* Time constants in ms */
 #define UC81XX_RESET_DELAY			10U

--- a/dts/bindings/display/ultrachip,uc8151d.yaml
+++ b/dts/bindings/display/ultrachip,uc8151d.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Cactus Engineering S.L
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  UltraChip UC8151D EPD controller with native 160x296 monochrome (1bpp)
+  display support.
+
+compatible: "ultrachip,uc8151d"
+
+include: ultrachip,uc81xx-common.yaml

--- a/tests/drivers/build_all/display/app.overlay
+++ b/tests/drivers/build_all/display/app.overlay
@@ -292,6 +292,27 @@
 				remap-value = <0x0>;
 				mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
 			};
+
+			test_gooddisplay_epaper_gdew029i6fd: uc8151d@17 {
+				compatible = "ultrachip,uc8151d";
+				reg = <17>;
+				mipi-max-frequency = <4000000>;
+				status = "okay";
+				width = <128>;
+				height = <296>;
+				busy-gpios = <&test_gpio 0 0>;
+
+				full {
+					/* Override CDI / VCOM for full refresh */
+					cdi = <0x17>;
+					vdcs = <0x08>;
+				};
+
+				partial {
+					/* Exercise CDI override path for partial refresh */
+					cdi = <0x17>;
+				};
+			};
 		};
 
 		test_mipi_dbi_xfr_16bit_write_only {


### PR DESCRIPTION
## Summary

  - Extended the UC81xx SPI EPD driver with UC8151D-specific handling (packed TRES/PTL payloads, CDI overrides, and the extra PON-after-BTST quirk defined in the datasheet)
  - Added the UC8151D quirk table and hook it into the DT instantiation path alongside the existing UC8175/76/79 variants
  - Documented the new controller via ultrachip,uc8151d.yaml and update Kconfig dependencies so the driver enables when the new compatible appears

  ## Testing

  - Tested using the GDEW029I6FD from Good Display and a custom nrf9151 board. 
