### PR TITLE
drivers: adc: ad599x: Fix async logic error

### DIFF
--- a/drivers/adc/adc_ad559x.c
+++ b/drivers/adc/adc_ad559x.c
@@ -222,8 +222,12 @@ static int adc_ad559x_read_async(const struct device *dev, const struct adc_sequ
 {
 	struct adc_ad559x_data *data = dev->data;
 	int ret;
-
-	adc_context_lock(&data->ctx, async ? true : false, async);
+	/*
+	 * Check if either async or callback is set for asynchronous operation
+	 */
+	bool asynchronous = (async != NULL) ||
+		(sequence->options && sequence->options->callback);
+	adc_context_lock(&data->ctx, asynchronous, async);
 	ret = adc_ad559x_start_read(dev, sequence);
 	adc_context_release(&data->ctx, ret);
 


### PR DESCRIPTION
The general ADC documentation states, that it is possible to use the adc_read_async function with third parameter (k_poll_signal *async) set to NULL, in which case the callback is called when all channels have been converted. This change fixes this issue as it now also checks if a callback has been set.