### PR TITLE
Fix nrf board variants flashing

### DIFF
--- a/boards/nordic/nrf54h20dk/board.yml
+++ b/boards/nordic/nrf54h20dk/board.yml
@@ -14,3 +14,43 @@ board:
     default: "0.9.0"
     revisions:
     - name: "0.9.0"
+runners:
+  run_once:
+    '--recover':
+    - runners:
+      - nrfutil
+      run: first
+      groups:
+      - boards:
+        - nrf54h20dk@0.9.0/nrf54h20/cpuapp
+        - nrf54h20dk@0.9.0/nrf54h20/cpurad
+        - nrf54h20dk@0.9.0/nrf54h20/cpuppr
+        - nrf54h20dk@0.9.0/nrf54h20/cpuppr/xip
+        - nrf54h20dk@0.9.0/nrf54h20/cpuflpr
+        - nrf54h20dk@0.9.0/nrf54h20/cpuflpr/xip
+    '--erase':
+    - runners:
+      - jlink
+      - nrfutil
+      run: first
+      groups:
+      - boards:
+        - nrf54h20dk@0.9.0/nrf54h20/cpuapp
+        - nrf54h20dk@0.9.0/nrf54h20/cpurad
+        - nrf54h20dk@0.9.0/nrf54h20/cpuppr
+        - nrf54h20dk@0.9.0/nrf54h20/cpuppr/xip
+        - nrf54h20dk@0.9.0/nrf54h20/cpuflpr
+        - nrf54h20dk@0.9.0/nrf54h20/cpuflpr/xip
+    '--reset':
+    - runners:
+      - jlink
+      - nrfutil
+      run: last
+      groups:
+      - boards:
+        - nrf54h20dk@0.9.0/nrf54h20/cpuapp
+        - nrf54h20dk@0.9.0/nrf54h20/cpurad
+        - nrf54h20dk@0.9.0/nrf54h20/cpuppr
+        - nrf54h20dk@0.9.0/nrf54h20/cpuppr/xip
+        - nrf54h20dk@0.9.0/nrf54h20/cpuflpr
+        - nrf54h20dk@0.9.0/nrf54h20/cpuflpr/xip


### PR DESCRIPTION
Fix flashing of nrf board variants:
- for nrf54h20, ppr/xip and flpr/xip were not managed by soc.yml and not possible to flash with --erase or --recover
(erasing for ppr/xip also erases app core memory).