### PR TITLE
cmake: use zephyr_file_copy(...) instead of file(COPY_FILE ...)

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -4720,7 +4720,7 @@ function(zephyr_dt_import)
       COMMAND_ERROR_IS_FATAL ANY
     )
 
-    file(COPY_FILE ${gen_dts_cmake_temp} ${gen_dts_cmake_output} ONLY_IF_DIFFERENT)
+    zephyr_file_copy(${gen_dts_cmake_temp} ${gen_dts_cmake_output} ONLY_IF_DIFFERENT)
   endif()
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${gen_dts_cmake_script})
 


### PR DESCRIPTION
`file(COPY_FILE ...)` is from CMake 3.21.
Zephyr still supports CMake 3.20, so use zephyr_file_copy(...) instead of `file(COPY_FILE ...)`.