### PR TITLE
boards: nrf9280pdk: Fix LED pins for rev. 0.2.0 with IronSide

### DIFF
--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp_iron_0_2_0.overlay
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp_iron_0_2_0.overlay
@@ -5,3 +5,48 @@
  */
 
 #include "nrf9280pdk_nrf9280-pinctrl_0_2_0.dtsi"
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led2; /* Alias for compatibility with samples that use pwm-led0 */
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpio9 0 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 0";
+		};
+
+		led1: led_1 {
+			gpios = <&gpio9 1 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 1";
+		};
+
+		led2: led_2 {
+			gpios = <&gpio9 2 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 2";
+		};
+
+		led3: led_3 {
+			gpios = <&gpio9 3 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 3";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/delete-node/ pwm_led_0;
+
+		/*
+		 * There is no valid hardware configuration to pass PWM signal on pins 0 and 1.
+		 * First valid config is P9.2. This corresponds to LED 2.
+		 * Signal on PWM130's channel 0 can be passed directly on GPIO Port 9 pin 2.
+		 */
+		pwm_led2: pwm_led_2 {
+			pwms = <&pwm130 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+};


### PR DESCRIPTION
LED pins need to be set in the cpuapp/iron rev. 0.2.0 overlay.