### PR TITLE
STM32: Replace init structures for drivers that use the RTC

### DIFF
--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -8,7 +8,6 @@ menuconfig COUNTER_RTC_STM32
 	default y if !RTC
 	depends on DT_HAS_ST_STM32_RTC_ENABLED
 	depends on !SOC_SERIES_STM32WB0X
-	select USE_STM32_LL_RTC
 	help
 	  Build RTC driver for STM32 SoCs.
 	  Tested on STM32 C0, F0, F2, F3, F4, F7, G0, G4, H7, L1, L4, L5, U5 series

--- a/drivers/counter/Kconfig.stm32_timer
+++ b/drivers/counter/Kconfig.stm32_timer
@@ -5,7 +5,6 @@ config COUNTER_TIMER_STM32
 	bool "STM32 counter driver"
 	default y
 	depends on DT_HAS_ST_STM32_COUNTER_ENABLED
-	select USE_STM32_LL_TIM
 	select RESET
 	help
 	  Enable the counter driver for STM32 family of processors.

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -18,6 +18,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
 #include <soc.h>
+#include <stm32_ll_cortex.h>
 #include <stm32_ll_exti.h>
 #include <stm32_ll_pwr.h>
 #include <stm32_ll_rcc.h>
@@ -33,6 +34,14 @@
 #include <stm32_hsem.h>
 
 LOG_MODULE_REGISTER(counter_rtc_stm32, CONFIG_COUNTER_LOG_LEVEL);
+
+#if defined(CONFIG_SOC_SERIES_STM32F1X) || defined(CONFIG_SOC_SERIES_STM32F2X) || \
+	(defined(CONFIG_SOC_SERIES_STM32L1X) && !defined(RTC_SUBSECOND_SUPPORT))
+/* subsecond counting is not supported by some STM32L1x MCUs (Cat.1) & by STM32F1x/2x SoC series */
+#define HW_SUBSECOND_SUPPORT 0
+#else
+#define HW_SUBSECOND_SUPPORT 1
+#endif
 
 /* Seconds from 1970-01-01T00:00:00 to 2000-01-01T00:00:00 */
 #define T_TIME_OFFSET 946684800
@@ -82,6 +91,9 @@ LOG_MODULE_REGISTER(counter_rtc_stm32, CONFIG_COUNTER_LOG_LEVEL);
 #define RTC_ASYNCPRE (RTCCLK_FREQ - 1)
 #endif /* CONFIG_SOC_SERIES_STM32F1X */
 
+/* Timeout in microseconds used to wait for flags */
+#define RTC_TIMEOUT 1000
+
 /* Adjust the second sync prescaler to get 1Hz on ck_spre */
 #define RTC_SYNCPRE ((RTCCLK_FREQ / (1 + RTC_ASYNCPRE)) - 1)
 
@@ -93,7 +105,10 @@ typedef uint64_t tick_t;
 
 struct rtc_stm32_config {
 	struct counter_config_info counter_info;
-	LL_RTC_InitTypeDef ll_rtc_config;
+	uint32_t async_prescaler;
+#if !defined(CONFIG_SOC_SERIES_STM32F1X)
+	uint32_t sync_prescaler;
+#endif  /* !CONFIG_SOC_SERIES_STM32F1X */
 	const struct stm32_pclken *pclken;
 #if DT_INST_CLOCKS_CELL_BY_IDX(0, 1, bus) == STM32_SRC_HSE
 	uint32_t hse_prescaler;
@@ -108,16 +123,6 @@ struct rtc_stm32_data {
 	bool irq_on_late;
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 };
-
-static inline ErrorStatus ll_func_init_alarm(RTC_TypeDef *rtc, uint32_t format,
-					     LL_RTC_AlarmTypeDef *alarmStruct)
-{
-#if defined(CONFIG_SOC_SERIES_STM32F1X)
-	return LL_RTC_ALARM_Init(rtc, format, alarmStruct);
-#else
-	return LL_RTC_ALMA_Init(rtc, format, alarmStruct);
-#endif
-}
 
 static inline void ll_func_clear_alarm_flag(RTC_TypeDef *rtc)
 {
@@ -186,6 +191,169 @@ static inline void ll_func_disable_alarm(RTC_TypeDef *rtc)
 
 static void rtc_stm32_irq_config(const struct device *dev);
 
+/* When no error occurs, this function disables the RTC write protection and should be balanced
+ * with a call to rtc_stm32_exit_init_mode (which enables RTC write protection).
+ * In case of error, the write protection is enabled when leaving this function, so nothing more
+ * needs to be made.
+ */
+static int rtc_stm32_enter_init_mode(void)
+{
+#if defined(CONFIG_SOC_SERIES_STM32F1X)
+	/* Wait for RTC to be ready */
+	if (!WAIT_FOR(LL_RTC_IsActiveFlag_RTOF(RTC), RTC_TIMEOUT, NULL)) {
+		return -ETIMEDOUT;
+	}
+
+	LL_RTC_DisableWriteProtection(RTC);
+#else
+	LL_RTC_DisableWriteProtection(RTC);
+
+	/* Check if the Initialization mode is set */
+	if (LL_RTC_IsActiveFlag_INIT(RTC) == 0U) {
+		/* Set the Initialization mode */
+		LL_RTC_EnableInitMode(RTC);
+		if (!WAIT_FOR(LL_RTC_IsActiveFlag_INIT(RTC), RTC_TIMEOUT, NULL)) {
+			LL_RTC_DisableInitMode(RTC);
+			LL_RTC_EnableWriteProtection(RTC);
+			return -ETIMEDOUT;
+		}
+	}
+#endif
+
+	return 0;
+}
+
+static int rtc_stm32_exit_init_mode(void)
+{
+	int status = 0;
+
+#if defined(CONFIG_SOC_SERIES_STM32F1X)
+	LL_RTC_EnableWriteProtection(RTC);
+
+	/* Wait for RTC to be ready */
+	if (!WAIT_FOR(LL_RTC_IsActiveFlag_RTOF(RTC), RTC_TIMEOUT, NULL)) {
+		status = -ETIMEDOUT;
+	}
+#else
+	LL_RTC_DisableInitMode(RTC);
+
+	LL_RTC_EnableWriteProtection(RTC);
+#endif
+
+	return status;
+}
+
+#if !defined(CONFIG_COUNTER_RTC_STM32_SAVE_VALUE_BETWEEN_RESETS)
+static int rtc_stm32_wait_for_synchro(void)
+{
+	int status = 0;
+
+	/* Clear RSF flag */
+	LL_RTC_ClearFlag_RS(RTC);
+
+	if (!WAIT_FOR(LL_RTC_IsActiveFlag_RS(RTC), RTC_TIMEOUT, NULL)) {
+		status = -ETIMEDOUT;
+	}
+
+	return status;
+}
+
+static int rtc_stm32_deinit(void)
+{
+	int ret;
+
+	/* Set Initialization mode */
+	ret = rtc_stm32_enter_init_mode();
+	if (ret < 0) {
+		LOG_ERR("Failed to enter RTC init mode");
+		return ret;
+	}
+
+#if defined(CONFIG_SOC_SERIES_STM32F1X)
+	WRITE_REG(RTC->CNTL, 0U);
+	WRITE_REG(RTC->CNTH, 0U);
+	WRITE_REG(RTC->PRLH, 0U);
+	WRITE_REG(RTC->PRLL, 0x8000U);
+	WRITE_REG(RTC->CRH, 0U);
+	WRITE_REG(RTC->CRL, 0x20U);
+#else /* CONFIG_SOC_SERIES_STM32F1X */
+	WRITE_REG(RTC->CR, 0U);
+	WRITE_REG(RTC->TR, 0U);
+#ifdef RTC_WUTR_WUT
+	WRITE_REG(RTC->WUTR, RTC_WUTR_WUT);
+#endif /* RTC_WUTR_WUT */
+	WRITE_REG(RTC->DR, RTC_DR_WDU_0 | RTC_DR_MU_0 | RTC_DR_DU_0);
+	WRITE_REG(RTC->PRER, RTC_PRER_PREDIV_A | 0xFFU);
+	WRITE_REG(RTC->ALRMAR, 0U);
+#ifdef RTC_CR_ALRBE
+	WRITE_REG(RTC->ALRMBR, 0U);
+#endif /* RTC_CR_ALRBE */
+
+#if HW_SUBSECOND_SUPPORT
+	WRITE_REG(RTC->CALR, 0U);
+	WRITE_REG(RTC->SHIFTR, 0U);
+	WRITE_REG(RTC->ALRMASSR, 0U);
+#ifdef RTC_CR_ALRBE
+	WRITE_REG(RTC->ALRMBSSR, 0U);
+#endif /* RTC_CR_ALRBE */
+#endif /* HW_SUBSECOND_SUPPORT */
+
+#if defined(RTC_PRIVCFGR_PRIV)
+	WRITE_REG(RTC->PRIVCFGR, 0U);
+#endif /* RTC_PRIVCFGR_PRIV */
+#if defined(__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+	WRITE_REG(RTC->SECCFGR,  0U);
+#endif /* (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+	/* Reset I(C)SR register and exit initialization mode */
+#ifdef RTC_ICSR_INIT
+	WRITE_REG(RTC->ICSR, 0U);
+#else
+	WRITE_REG(RTC->ISR, 0U);
+#endif
+
+#endif /* CONFIG_SOC_SERIES_STM32F1X */
+
+	/* Exit Initialization mode */
+	ret = rtc_stm32_exit_init_mode();
+	if (ret < 0) {
+		LOG_ERR("Failed to exit RTC init mode");
+		return ret;
+	}
+
+	return rtc_stm32_wait_for_synchro();
+}
+#endif
+
+static int rtc_stm32_configure(const struct device *dev)
+{
+	const struct rtc_stm32_config *cfg = dev->config;
+	int ret;
+
+	/* Set Initialization mode */
+	ret = rtc_stm32_enter_init_mode();
+	if (ret < 0) {
+		LOG_ERR("Failed to enter RTC init mode");
+		return ret;
+	}
+
+#if defined(CONFIG_SOC_SERIES_STM32F1X)
+	LL_RTC_SetAsynchPrescaler(RTC, cfg->async_prescaler);
+	LL_RTC_SetOutputSource(BKP, LL_RTC_CALIB_OUTPUT_NONE);
+#else
+	LL_RTC_SetHourFormat(RTC, LL_RTC_HOURFORMAT_24HOUR);
+	LL_RTC_SetAsynchPrescaler(RTC, cfg->async_prescaler);
+	LL_RTC_SetSynchPrescaler(RTC, cfg->sync_prescaler);
+#endif
+
+	/* Exit Initialization mode */
+	ret = rtc_stm32_exit_init_mode();
+	if (ret < 0) {
+		LOG_ERR("Failed to exit RTC init mode");
+	}
+
+	return ret;
+}
 
 static int rtc_stm32_start(const struct device *dev)
 {
@@ -195,7 +363,7 @@ static int rtc_stm32_start(const struct device *dev)
 
 	/* Enable RTC bus clock */
 	if (clock_control_on(clk, (clock_control_subsys_t) &cfg->pclken[0]) != 0) {
-		LOG_ERR("RTC clock enabling failed\n");
+		LOG_ERR("RTC clock enabling failed");
 		return -EIO;
 	}
 #else
@@ -220,7 +388,7 @@ static int rtc_stm32_stop(const struct device *dev)
 
 	/* Disable RTC bus clock */
 	if (clock_control_off(clk, (clock_control_subsys_t) &cfg->pclken[0]) != 0) {
-		LOG_ERR("RTC clock disabling failed\n");
+		LOG_ERR("RTC clock disabling failed");
 		return -EIO;
 	}
 #else
@@ -342,14 +510,14 @@ static int rtc_stm32_set_alarm(const struct device *dev, uint8_t chan_id,
 #else
 	uint32_t remain;
 #endif
-	LL_RTC_AlarmTypeDef rtc_alarm;
 	struct rtc_stm32_data *data = dev->data;
+	int ret = 0;
 
 	tick_t now = rtc_stm32_read(dev);
 	tick_t ticks = alarm_cfg->ticks;
 
 	if (data->callback != NULL) {
-		LOG_DBG("Alarm busy\n");
+		LOG_DBG("Alarm busy");
 		return -EBUSY;
 	}
 
@@ -369,8 +537,14 @@ static int rtc_stm32_set_alarm(const struct device *dev, uint8_t chan_id,
 	} else {
 		alarm_val_s = (time_t)(ticks / counter_get_frequency(dev));
 	}
+
+	gmtime_r(&alarm_val_s, &alarm_tm);
+
 #ifdef CONFIG_COUNTER_RTC_STM32_SUBSECONDS
 	alarm_val_ss = ticks % counter_get_frequency(dev);
+	LOG_DBG("Set Alarm: %llu", ticks);
+#else /* !CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
+	LOG_DBG("Set Alarm: %d", ticks);
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 
 #else
@@ -386,54 +560,57 @@ static int rtc_stm32_set_alarm(const struct device *dev, uint8_t chan_id,
 	remain--;
 #endif
 
-#if !defined(COUNTER_NO_DATE)
-#ifndef CONFIG_COUNTER_RTC_STM32_SUBSECONDS
-	LOG_DBG("Set Alarm: %d\n", ticks);
-#else /* !CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
-	LOG_DBG("Set Alarm: %llu\n", ticks);
-#endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
-
-	gmtime_r(&alarm_val_s, &alarm_tm);
-
-	/* Apply ALARM_A */
-	rtc_alarm.AlarmTime.TimeFormat = LL_RTC_TIME_FORMAT_AM_OR_24;
-	rtc_alarm.AlarmTime.Hours = alarm_tm.tm_hour;
-	rtc_alarm.AlarmTime.Minutes = alarm_tm.tm_min;
-	rtc_alarm.AlarmTime.Seconds = alarm_tm.tm_sec;
-
-	rtc_alarm.AlarmMask = LL_RTC_ALMA_MASK_NONE;
-	rtc_alarm.AlarmDateWeekDaySel = LL_RTC_ALMA_DATEWEEKDAYSEL_DATE;
-	rtc_alarm.AlarmDateWeekDay = alarm_tm.tm_mday;
-#else
-	rtc_alarm.AlarmTime.Hours = remain / 3600;
-	remain -= rtc_alarm.AlarmTime.Hours * 3600;
-	rtc_alarm.AlarmTime.Minutes = remain / 60;
-	remain -= rtc_alarm.AlarmTime.Minutes * 60;
-	rtc_alarm.AlarmTime.Seconds = remain;
-#endif
-
 	stm32_backup_domain_enable_access();
 
+#if !defined(COUNTER_NO_DATE)
 	LL_RTC_DisableWriteProtection(RTC);
-	ll_func_disable_alarm(RTC);
-	LL_RTC_EnableWriteProtection(RTC);
 
-	if (ll_func_init_alarm(RTC, LL_RTC_FORMAT_BIN, &rtc_alarm) != SUCCESS) {
-		stm32_backup_domain_disable_access();
-		return -EIO;
+	ll_func_disable_alarm(RTC);
+
+	/* Configure the Alarm registers */
+	LL_RTC_ALMA_DisableWeekday(RTC);
+	LL_RTC_ALMA_SetDay(RTC, __LL_RTC_CONVERT_BIN2BCD(alarm_tm.tm_mday));
+	LL_RTC_ALMA_ConfigTime(RTC, LL_RTC_TIME_FORMAT_AM_OR_24,
+				__LL_RTC_CONVERT_BIN2BCD(alarm_tm.tm_hour),
+				__LL_RTC_CONVERT_BIN2BCD(alarm_tm.tm_min),
+				__LL_RTC_CONVERT_BIN2BCD(alarm_tm.tm_sec));
+	LL_RTC_ALMA_SetMask(RTC, LL_RTC_ALMA_MASK_NONE);
+
+	LL_RTC_EnableWriteProtection(RTC);
+#else
+	/* Set Initialization mode */
+	ret = rtc_stm32_enter_init_mode();
+	if (ret < 0) {
+		goto out_disable_bkup_access;
 	}
 
+	/* Set the alarm */
+	LL_RTC_ALARM_Set(RTC, remain);
+
+	ret = rtc_stm32_exit_init_mode();
+	if (ret < 0) {
+		goto out_disable_bkup_access;
+	}
+#endif
+
 	LL_RTC_DisableWriteProtection(RTC);
+#if HW_SUBSECOND_SUPPORT
 #ifdef CONFIG_COUNTER_RTC_STM32_SUBSECONDS
 	/* Care about all bits of the subsecond register */
 	LL_RTC_ALMA_SetSubSecondMask(RTC, 0xF);
 	LL_RTC_ALMA_SetSubSecond(RTC, RTC_SYNCPRE - alarm_val_ss);
+#else
+	LL_RTC_ALMA_SetSubSecondMask(RTC, 0);
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
+#endif /* HW_SUBSECOND_SUPPORT */
 	ll_func_enable_alarm(RTC);
 	ll_func_clear_alarm_flag(RTC);
 	ll_func_enable_interrupt_alarm(RTC);
 	LL_RTC_EnableWriteProtection(RTC);
 
+#if defined(COUNTER_NO_DATE)
+out_disable_bkup_access:
+#endif
 	stm32_backup_domain_disable_access();
 
 #ifdef CONFIG_COUNTER_RTC_STM32_SUBSECONDS
@@ -454,7 +631,7 @@ static int rtc_stm32_set_alarm(const struct device *dev, uint8_t chan_id,
 	}
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 
-	return 0;
+	return ret;
 }
 
 
@@ -566,7 +743,7 @@ static int rtc_stm32_init(const struct device *dev)
 
 	/* Enable RTC bus clock */
 	if (clock_control_on(clk, (clock_control_subsys_t) &cfg->pclken[0]) != 0) {
-		LOG_ERR("clock op failed\n");
+		LOG_ERR("clock op failed");
 		return -EIO;
 	}
 
@@ -575,11 +752,16 @@ static int rtc_stm32_init(const struct device *dev)
 
 	stm32_backup_domain_enable_access();
 
+#if DT_INST_CLOCKS_CELL_BY_IDX(0, 1, bus) == STM32_SRC_HSE
+	/* Must be configured before selecting the RTC clock source */
+	LL_RCC_SetRTC_HSEPrescaler(cfg->hse_prescaler);
+#endif
+
 	/* Enable RTC clock source */
 	if (clock_control_configure(clk,
 				    (clock_control_subsys_t) &cfg->pclken[1],
 				    NULL) != 0) {
-		LOG_ERR("clock configure failed\n");
+		LOG_ERR("clock configure failed");
 		goto out_disable_bkup_access;
 	}
 
@@ -590,30 +772,16 @@ static int rtc_stm32_init(const struct device *dev)
 	z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 
 #if !defined(CONFIG_COUNTER_RTC_STM32_SAVE_VALUE_BETWEEN_RESETS)
-
-/* STM32C0 LL driver does not clear the CR register in LL_RTC_DeInit so it will loop forever waiting
- * for a flag that will never be set when shadow registers are bypassed (BYPSHAD enabled).
- */
-#if defined(RTC_CR_BYPSHAD) && defined(CONFIG_SOC_SERIES_STM32C0X)
-	if (LL_RTC_IsShadowRegBypassEnabled(RTC)) {
-		LL_RTC_DisableWriteProtection(RTC);
-		LL_RTC_DisableShadowRegBypass(RTC);
-		LL_RTC_EnableWriteProtection(RTC);
-	}
-#endif /* defined(RTC_CR_BYPSHAD) && defined(CONFIG_SOC_SERIES_STM32C0X) */
-
-	if (LL_RTC_DeInit(RTC) != SUCCESS) {
+	ret = rtc_stm32_deinit();
+	if (ret < 0) {
+		LOG_ERR("Failed to deinit RTC");
 		goto out_disable_bkup_access;
 	}
 #endif
 
-#if DT_INST_CLOCKS_CELL_BY_IDX(0, 1, bus) == STM32_SRC_HSE
-	/* Must be configured before selecting the RTC clock source */
-	LL_RCC_SetRTC_HSEPrescaler(cfg->hse_prescaler);
-#endif
-
-	if (LL_RTC_Init(RTC, ((LL_RTC_InitTypeDef *)
-			      &cfg->ll_rtc_config)) != SUCCESS) {
+	ret = rtc_stm32_configure(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to init RTC");
 		goto out_disable_bkup_access;
 	}
 
@@ -632,8 +800,6 @@ static int rtc_stm32_init(const struct device *dev)
 	LL_EXTI_EnableIT_0_31(RTC_EXTI_LINE);
 	LL_EXTI_EnableRisingTrig_0_31(RTC_EXTI_LINE);
 #endif
-
-	ret = 0;
 
 out_disable_bkup_access:
 	stm32_backup_domain_disable_access();
@@ -680,30 +846,20 @@ static const struct rtc_stm32_config rtc_config = {
 		.flags = COUNTER_CONFIG_INFO_COUNT_UP,
 		.channels = 1,
 	},
-	.ll_rtc_config = {
 #if DT_INST_CLOCKS_CELL_BY_IDX(0, 1, bus) == STM32_SRC_LSI ||                                      \
 	DT_INST_CLOCKS_CELL_BY_IDX(0, 1, bus) == STM32_SRC_LSE
-		.AsynchPrescaler = DT_INST_PROP_OR(0, async_prescaler, RTC_ASYNCPRE),
+	.async_prescaler = DT_INST_PROP_OR(0, async_prescaler, RTC_ASYNCPRE),
 #if !defined(CONFIG_SOC_SERIES_STM32F1X)
-		.HourFormat = LL_RTC_HOURFORMAT_24HOUR,
-		.SynchPrescaler = DT_INST_PROP_OR(0, sync_prescaler, RTC_SYNCPRE),
-#else  /* !CONFIG_SOC_SERIES_STM32F1X */
-		.OutPutSource = LL_RTC_CALIB_OUTPUT_NONE,
+	.sync_prescaler = DT_INST_PROP_OR(0, sync_prescaler, RTC_SYNCPRE),
 #endif /* !CONFIG_SOC_SERIES_STM32F1X */
 #elif DT_INST_CLOCKS_CELL_BY_IDX(0, 1, bus) == STM32_SRC_HSE
-		.AsynchPrescaler =
-			DT_INST_PROP_OR(0, async_prescaler, _HSE_ASYNC_PRESCALER - 1),
+	.async_prescaler = DT_INST_PROP_OR(0, async_prescaler, _HSE_ASYNC_PRESCALER - 1),
 #if !defined(CONFIG_SOC_SERIES_STM32F1X)
-		.HourFormat = LL_RTC_HOURFORMAT_24HOUR,
-		.SynchPrescaler =
-			DT_INST_PROP_OR(0, hse_prescaler, RTC_HSE_SYNC_PRESCALER - 1),
-#else  /* CONFIG_SOC_SERIES_STM32F1X */
-		.OutPutSource = LL_RTC_CALIB_OUTPUT_NONE,
+	.sync_prescaler = DT_INST_PROP_OR(0, hse_prescaler, RTC_HSE_SYNC_PRESCALER - 1),
 #endif /* !CONFIG_SOC_SERIES_STM32F1X */
 #else
 #error Invalid RTC SRC
 #endif
-	},
 	.pclken = rtc_clk,
 #if DT_INST_CLOCKS_CELL_BY_IDX(0, 1, bus) == STM32_SRC_HSE
 	.hse_prescaler = DT_INST_PROP_OR(0, hse_prescaler, RTC_HSE_PRESCALER),
@@ -721,7 +877,7 @@ static int rtc_stm32_pm_action(const struct device *dev,
 	case PM_DEVICE_ACTION_RESUME:
 		/* Enable RTC bus clock */
 		if (clock_control_on(clk, (clock_control_subsys_t) &cfg->pclken[0]) != 0) {
-			LOG_ERR("clock op failed\n");
+			LOG_ERR("clock op failed");
 			return -EIO;
 		}
 		break;

--- a/drivers/pwm/Kconfig.stm32
+++ b/drivers/pwm/Kconfig.stm32
@@ -7,8 +7,6 @@ config PWM_STM32
 	bool "STM32 MCU PWM driver"
 	default y
 	depends on DT_HAS_ST_STM32_PWM_ENABLED
-	select USE_STM32_LL_TIM
-	select USE_STM32_LL_RCC if SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
 	select RESET
 	select PINCTRL
 	help

--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -21,6 +21,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/util.h>
 #include <soc.h>
+#include <stm32_ll_cortex.h>
 #include <stm32_ll_pwr.h>
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_rtc.h>
@@ -46,9 +47,9 @@ LOG_MODULE_REGISTER(rtc_stm32, CONFIG_RTC_LOG_LEVEL);
 #if (defined(CONFIG_SOC_SERIES_STM32L1X) && !defined(RTC_SUBSECOND_SUPPORT)) \
 	|| defined(CONFIG_SOC_SERIES_STM32F2X)
 /* subsecond counting is not supported by some STM32L1x MCUs (Cat.1) & by STM32F2x SoC series */
-#define HW_SUBSECOND_SUPPORT (0)
+#define HW_SUBSECOND_SUPPORT 0
 #else
-#define HW_SUBSECOND_SUPPORT (1)
+#define HW_SUBSECOND_SUPPORT 1
 #endif
 
 /* RTC start time: 1st, Jan, 2000 */
@@ -80,7 +81,7 @@ LOG_MODULE_REGISTER(rtc_stm32, CONFIG_RTC_LOG_LEVEL);
 #define MIN_PPB -NB_PULSES_TO_PPB(MAX_CALM)
 
 /* Timeout in microseconds used to wait for flags */
-#define RTC_TIMEOUT 1000000
+#define RTC_TIMEOUT 1000
 
 #ifdef STM32_RTC_ALARM_ENABLED
 #define RTC_STM32_ALARMS_COUNT	DT_INST_PROP(0, alarms_count)
@@ -112,9 +113,6 @@ struct rtc_stm32_config {
 
 #ifdef STM32_RTC_ALARM_ENABLED
 struct rtc_stm32_alrm {
-	LL_RTC_AlarmTypeDef ll_rtc_alrm;
-	/* user-defined alarm mask, values from RTC_ALARM_TIME_MASK */
-	uint16_t user_mask;
 	rtc_alarm_callback user_callback;
 	void *user_data;
 	bool is_pending;
@@ -158,6 +156,21 @@ static inline void exti_clear_rtc_alarm_flag(uint32_t line_num)
 
 #endif /* STM32_RTC_ALARM_ENABLED */
 
+static int rtc_stm32_enter_init_mode(void)
+{
+	int status = 0;
+
+	/* Check if the Initialization mode is set */
+	if (LL_RTC_IsActiveFlag_INIT(RTC) == 0U) {
+		/* Set the Initialization mode */
+		LL_RTC_EnableInitMode(RTC);
+		if (!WAIT_FOR(LL_RTC_IsActiveFlag_INIT(RTC), RTC_TIMEOUT, NULL)) {
+			status = -ETIMEDOUT;
+		}
+	}
+	return status;
+}
+
 static int rtc_stm32_configure(const struct device *dev)
 {
 	const struct rtc_stm32_config *cfg = dev->config;
@@ -176,14 +189,12 @@ static int rtc_stm32_configure(const struct device *dev)
 	if ((hour_format != LL_RTC_HOURFORMAT_24HOUR) ||
 	    (sync_prescaler != cfg->sync_prescaler) ||
 	    (async_prescaler != cfg->async_prescaler)) {
-		ErrorStatus status = LL_RTC_EnterInitMode(RTC);
+		err = rtc_stm32_enter_init_mode();
 
-		if (status == SUCCESS) {
+		if (err == 0) {
 			LL_RTC_SetHourFormat(RTC, LL_RTC_HOURFORMAT_24HOUR);
 			LL_RTC_SetSynchPrescaler(RTC, cfg->sync_prescaler);
 			LL_RTC_SetAsynchPrescaler(RTC, cfg->async_prescaler);
-		} else {
-			err = -EIO;
 		}
 
 		LL_RTC_DisableInitMode(RTC);
@@ -205,24 +216,103 @@ static int rtc_stm32_configure(const struct device *dev)
 }
 
 #ifdef STM32_RTC_ALARM_ENABLED
-static inline ErrorStatus rtc_stm32_init_alarm(RTC_TypeDef *rtc, uint32_t format,
-					LL_RTC_AlarmTypeDef *ll_alarm_struct, uint16_t id)
+static void rtc_stm32_init_alarm(const struct rtc_time *timeptr, uint16_t id, uint16_t mask)
 {
-	ll_alarm_struct->AlarmDateWeekDaySel = RTC_STM32_ALRM_DATEWEEKDAYSEL_DATE;
+	uint32_t seconds = 0;
+	uint32_t minutes = 0;
+	uint32_t hours = 0;
+	uint32_t day_weekday = LL_RTC_WEEKDAY_SUNDAY;
+	uint32_t day_weekday_sel = RTC_STM32_ALRM_DATEWEEKDAYSEL_DATE;
+	uint32_t ll_mask = RTC_STM32_ALRM_MASK_ALL;
+
 	/*
-	 * RTC write protection is disabled & enabled again inside LL_RTC_ALMx_Init functions
-	 * The LL_RTC_ALMx_Init does convert bin2bcd by itself
+	 * STM32 RTC Alarm LL mask should be set for all fields beyond the broadest one
+	 * that's being matched with RTC calendar to trigger alarm periodically,
+	 * the opposite of Zephyr RTC Alarm mask which is set for active fields.
 	 */
+	if (mask & RTC_ALARM_TIME_MASK_SECOND) {
+		ll_mask &= ~RTC_STM32_ALRM_MASK_SECONDS;
+		seconds = bin2bcd(timeptr->tm_sec);
+	}
+
+	if (mask & RTC_ALARM_TIME_MASK_MINUTE) {
+		ll_mask &= ~RTC_STM32_ALRM_MASK_MINUTES;
+		minutes = bin2bcd(timeptr->tm_min);
+	}
+
+	if (mask & RTC_ALARM_TIME_MASK_HOUR) {
+		ll_mask &= ~RTC_STM32_ALRM_MASK_HOURS;
+		hours = bin2bcd(timeptr->tm_hour);
+	}
+
+	if (mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
+		/* the Alarm Mask field compares with the day of the week */
+		ll_mask &= ~RTC_STM32_ALRM_MASK_DATEWEEKDAY;
+		day_weekday_sel = RTC_STM32_ALRM_DATEWEEKDAYSEL_WEEKDAY;
+
+		if (timeptr->tm_wday == 0) {
+			/* sunday (tm_wday = 0) is not represented by the same value in hardware */
+			day_weekday = LL_RTC_WEEKDAY_SUNDAY;
+		} else {
+			/* all the other values are consistent with what is expected by hardware */
+			day_weekday = bin2bcd(timeptr->tm_wday);
+		}
+
+	} else if (mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
+		/* the Alarm compares with the day number & ignores the day of the week */
+		ll_mask &= ~RTC_STM32_ALRM_MASK_DATEWEEKDAY;
+		day_weekday_sel = RTC_STM32_ALRM_DATEWEEKDAYSEL_DATE;
+		day_weekday = bin2bcd(timeptr->tm_mday);
+	}
+
+	/* Disable the write protection for RTC registers */
+	LL_RTC_DisableWriteProtection(RTC);
+
 	if (id == RTC_STM32_ALRM_A) {
-		return LL_RTC_ALMA_Init(rtc, format, ll_alarm_struct);
+		if (day_weekday_sel == RTC_STM32_ALRM_DATEWEEKDAYSEL_DATE) {
+			/* Set the date for ALARM */
+			LL_RTC_ALMA_DisableWeekday(RTC);
+			LL_RTC_ALMA_SetDay(RTC, day_weekday);
+		} else {
+			/* Set the week day for ALARM */
+			LL_RTC_ALMA_EnableWeekday(RTC);
+			LL_RTC_ALMA_SetWeekDay(RTC, day_weekday);
+		}
+
+		/* Configure the Alarm register */
+		LL_RTC_ALMA_ConfigTime(RTC, LL_RTC_TIME_FORMAT_AM_OR_24, hours, minutes, seconds);
+
+		/* Set ALARM mask */
+		LL_RTC_ALMA_SetMask(RTC, ll_mask);
+#if HW_SUBSECOND_SUPPORT
+		LL_RTC_ALMA_SetSubSecondMask(RTC, 0);
+#endif
 	}
 #if RTC_STM32_ALARMS_COUNT > 1
 	if (id == RTC_STM32_ALRM_B) {
-		return LL_RTC_ALMB_Init(rtc, format, ll_alarm_struct);
+		if (day_weekday_sel == RTC_STM32_ALRM_DATEWEEKDAYSEL_DATE) {
+			/* Set the date for ALARM */
+			LL_RTC_ALMB_DisableWeekday(RTC);
+			LL_RTC_ALMB_SetDay(RTC, day_weekday);
+		} else {
+			/* Set the week day for ALARM */
+			LL_RTC_ALMB_EnableWeekday(RTC);
+			LL_RTC_ALMB_SetWeekDay(RTC, day_weekday);
+		}
+
+		/* Configure the Alarm register */
+		LL_RTC_ALMB_ConfigTime(RTC, LL_RTC_TIME_FORMAT_AM_OR_24, hours, minutes, seconds);
+
+		/* Set ALARM mask */
+		LL_RTC_ALMB_SetMask(RTC, ll_mask);
+#if HW_SUBSECOND_SUPPORT
+		LL_RTC_ALMB_SetSubSecondMask(RTC, 0);
+#endif
 	}
 #endif /* RTC_STM32_ALARMS_COUNT > 1 */
 
-	return 0;
+	/* Enable the write protection for RTC registers */
+	LL_RTC_EnableWriteProtection(RTC);
 }
 
 static inline void rtc_stm32_clear_alarm_flag(RTC_TypeDef *rtc, uint16_t id)
@@ -445,9 +535,8 @@ static int rtc_stm32_init(const struct device *dev)
 static int rtc_stm32_set_time(const struct device *dev, const struct rtc_time *timeptr)
 {
 	struct rtc_stm32_data *data = dev->data;
-	LL_RTC_TimeTypeDef rtc_time;
-	LL_RTC_DateTypeDef rtc_date;
 	uint32_t real_year = timeptr->tm_year + TM_YEAR_REF;
+	int err;
 
 	if (real_year < RTC_YEAR_REF) {
 		/* RTC does not support years before 2000 */
@@ -460,15 +549,15 @@ static int rtc_stm32_set_time(const struct device *dev, const struct rtc_time *t
 	}
 
 	/* Enter Init mode inside the LL_RTC_Time and Date Init functions */
-	rtc_time.Hours = bin2bcd(timeptr->tm_hour);
-	rtc_time.Minutes = bin2bcd(timeptr->tm_min);
-	rtc_time.Seconds = bin2bcd(timeptr->tm_sec);
+	uint32_t hours = bin2bcd(timeptr->tm_hour);
+	uint32_t minutes = bin2bcd(timeptr->tm_min);
+	uint32_t seconds = bin2bcd(timeptr->tm_sec);
 
 	/* Set Date after Time to be sure the DR is correctly updated on stm32F2 serie. */
-	rtc_date.Year = bin2bcd((real_year - RTC_YEAR_REF));
-	rtc_date.Month = bin2bcd((timeptr->tm_mon + 1));
-	rtc_date.Day = bin2bcd(timeptr->tm_mday);
-	rtc_date.WeekDay = ((timeptr->tm_wday == 0) ? (LL_RTC_WEEKDAY_SUNDAY) : (timeptr->tm_wday));
+	uint32_t year = bin2bcd((real_year - RTC_YEAR_REF));
+	uint32_t month = bin2bcd((timeptr->tm_mon + 1));
+	uint32_t day = bin2bcd(timeptr->tm_mday);
+	uint32_t weekDay = ((timeptr->tm_wday == 0) ? (LL_RTC_WEEKDAY_SUNDAY) : (timeptr->tm_wday));
 	/* WeekDay sunday (tm_wday = 0) is not represented by the same value in hardware,
 	 * all the other values are consistent with what is expected by hardware.
 	 */
@@ -479,8 +568,23 @@ static int rtc_stm32_set_time(const struct device *dev, const struct rtc_time *t
 
 	stm32_backup_domain_enable_access();
 
-	LL_RTC_TIME_Init(RTC, LL_RTC_FORMAT_BCD, &rtc_time);
-	LL_RTC_DATE_Init(RTC, LL_RTC_FORMAT_BCD, &rtc_date);
+	/* Disable the write protection for RTC registers */
+	LL_RTC_DisableWriteProtection(RTC);
+
+	/* Set Initialization mode */
+	err = rtc_stm32_enter_init_mode();
+
+	if (err == 0) {
+		/* Set time and date */
+		LL_RTC_TIME_Config(RTC, LL_RTC_TIME_FORMAT_AM_OR_24, hours, minutes, seconds);
+		LL_RTC_DATE_Config(RTC, weekDay, day, month, year);
+	}
+
+	/* Exit Initialization mode */
+	LL_RTC_DisableInitMode(RTC);
+
+	/* Enable the write protection for RTC registers */
+	LL_RTC_EnableWriteProtection(RTC);
 
 	stm32_backup_domain_disable_access();
 
@@ -505,7 +609,7 @@ static int rtc_stm32_set_time(const struct device *dev, const struct rtc_time *t
 
 	k_spin_unlock(&data->lock, key);
 
-	return 0;
+	return err;
 }
 
 static int rtc_stm32_get_time(const struct device *dev, struct rtc_time *timeptr)
@@ -597,60 +701,7 @@ static int rtc_stm32_get_time(const struct device *dev, struct rtc_time *timeptr
 }
 
 #ifdef STM32_RTC_ALARM_ENABLED
-static void rtc_stm32_init_ll_alrm_struct(LL_RTC_AlarmTypeDef *p_rtc_alarm,
-					const struct rtc_time *timeptr, uint16_t mask)
-{
-	LL_RTC_TimeTypeDef *p_rtc_alrm_time = &(p_rtc_alarm->AlarmTime);
-	uint32_t ll_mask = 0;
-
-	/*
-	 * STM32 RTC Alarm LL mask should be set for all fields beyond the broadest one
-	 * that's being matched with RTC calendar to trigger alarm periodically,
-	 * the opposite of Zephyr RTC Alarm mask which is set for active fields.
-	 */
-	ll_mask = RTC_STM32_ALRM_MASK_ALL;
-
-	if (mask & RTC_ALARM_TIME_MASK_SECOND) {
-		ll_mask &= ~RTC_STM32_ALRM_MASK_SECONDS;
-		p_rtc_alrm_time->Seconds = bin2bcd(timeptr->tm_sec);
-	}
-
-	if (mask & RTC_ALARM_TIME_MASK_MINUTE) {
-		ll_mask &= ~RTC_STM32_ALRM_MASK_MINUTES;
-		p_rtc_alrm_time->Minutes = bin2bcd(timeptr->tm_min);
-	}
-
-	if (mask & RTC_ALARM_TIME_MASK_HOUR) {
-		ll_mask &= ~RTC_STM32_ALRM_MASK_HOURS;
-		p_rtc_alrm_time->Hours = bin2bcd(timeptr->tm_hour);
-	}
-
-	if (mask & RTC_ALARM_TIME_MASK_WEEKDAY) {
-		/* the Alarm Mask field compares with the day of the week */
-		ll_mask &= ~RTC_STM32_ALRM_MASK_DATEWEEKDAY;
-		p_rtc_alarm->AlarmDateWeekDaySel = RTC_STM32_ALRM_DATEWEEKDAYSEL_WEEKDAY;
-
-		if (timeptr->tm_wday == 0) {
-			/* sunday (tm_wday = 0) is not represented by the same value in hardware */
-			p_rtc_alarm->AlarmDateWeekDay = LL_RTC_WEEKDAY_SUNDAY;
-		} else {
-			/* all the other values are consistent with what is expected by hardware */
-			p_rtc_alarm->AlarmDateWeekDay = bin2bcd(timeptr->tm_wday);
-		}
-
-	} else if (mask & RTC_ALARM_TIME_MASK_MONTHDAY) {
-		/* the Alarm compares with the day number & ignores the day of the week */
-		ll_mask &= ~RTC_STM32_ALRM_MASK_DATEWEEKDAY;
-		p_rtc_alarm->AlarmDateWeekDaySel = RTC_STM32_ALRM_DATEWEEKDAYSEL_DATE;
-		p_rtc_alarm->AlarmDateWeekDay = bin2bcd(timeptr->tm_mday);
-	}
-
-	p_rtc_alrm_time->TimeFormat = LL_RTC_TIME_FORMAT_AM_OR_24;
-
-	p_rtc_alarm->AlarmMask = ll_mask;
-}
-
-static inline void rtc_stm32_get_ll_alrm_time(uint16_t id, struct rtc_time *timeptr)
+static void rtc_stm32_alarm_get_alrm_time(uint16_t id, struct rtc_time *timeptr)
 {
 	if (id == RTC_STM32_ALRM_A) {
 		timeptr->tm_sec = bcd2bin(LL_RTC_ALMA_GetSecond(RTC));
@@ -671,7 +722,7 @@ static inline void rtc_stm32_get_ll_alrm_time(uint16_t id, struct rtc_time *time
 #endif /* RTC_STM32_ALARMS_COUNT > 1 */
 }
 
-static inline uint16_t rtc_stm32_get_ll_alrm_mask(uint16_t id)
+static inline uint16_t rtc_stm32_alarm_get_alrm_mask(uint16_t id)
 {
 	uint32_t ll_alarm_mask = 0;
 	uint16_t zephyr_alarm_mask = 0;
@@ -743,9 +794,6 @@ static int rtc_stm32_alarm_get_time(const struct device *dev, uint16_t id, uint1
 			struct rtc_time *timeptr)
 {
 	struct rtc_stm32_data *data = dev->data;
-	struct rtc_stm32_alrm *p_rtc_alrm;
-	LL_RTC_AlarmTypeDef *p_ll_rtc_alarm;
-	LL_RTC_TimeTypeDef *p_ll_rtc_alrm_time;
 	int err = 0;
 
 	if ((mask == NULL) || (timeptr == NULL)) {
@@ -755,26 +803,16 @@ static int rtc_stm32_alarm_get_time(const struct device *dev, uint16_t id, uint1
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	if (id == RTC_STM32_ALRM_A) {
-		p_rtc_alrm = &(data->rtc_alrm_a);
-	} else if (id == RTC_STM32_ALRM_B) {
-		p_rtc_alrm = &(data->rtc_alrm_b);
-	} else {
+	if ((id != RTC_STM32_ALRM_A) &&
+	    ((RTC_STM32_ALARMS_COUNT == 1) || (id != RTC_STM32_ALRM_B))) {
 		LOG_ERR("invalid alarm ID %d", id);
 		err = -EINVAL;
 		goto unlock;
 	}
 
-	p_ll_rtc_alarm = &(p_rtc_alrm->ll_rtc_alrm);
-	p_ll_rtc_alrm_time = &(p_ll_rtc_alarm->AlarmTime);
-
 	memset(timeptr, -1, sizeof(struct rtc_time));
-
-	rtc_stm32_get_ll_alrm_time(id, timeptr);
-
-	p_rtc_alrm->user_mask = rtc_stm32_get_ll_alrm_mask(id);
-
-	*mask = p_rtc_alrm->user_mask;
+	rtc_stm32_alarm_get_alrm_time(id, timeptr);
+	*mask = rtc_stm32_alarm_get_alrm_mask(id);
 
 	LOG_DBG("get alarm: mday = %d, wday = %d, hour = %d, min = %d, sec = %d, "
 		"mask = 0x%04x", timeptr->tm_mday, timeptr->tm_wday, timeptr->tm_hour,
@@ -791,8 +829,6 @@ static int rtc_stm32_alarm_set_time(const struct device *dev, uint16_t id, uint1
 {
 	struct rtc_stm32_data *data = dev->data;
 	struct rtc_stm32_alrm *p_rtc_alrm;
-	LL_RTC_AlarmTypeDef *p_ll_rtc_alarm;
-	LL_RTC_TimeTypeDef *p_ll_rtc_alrm_time;
 	int err = 0;
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
@@ -808,7 +844,6 @@ static int rtc_stm32_alarm_set_time(const struct device *dev, uint16_t id, uint1
 	}
 
 	if ((mask == 0) && (timeptr == NULL)) {
-		memset(&(p_rtc_alrm->ll_rtc_alrm), 0, sizeof(LL_RTC_AlarmTypeDef));
 		p_rtc_alrm->user_callback = NULL;
 		p_rtc_alrm->user_data = NULL;
 		p_rtc_alrm->is_pending = false;
@@ -843,14 +878,6 @@ static int rtc_stm32_alarm_set_time(const struct device *dev, uint16_t id, uint1
 		goto unlock;
 	}
 
-	p_ll_rtc_alarm = &(p_rtc_alrm->ll_rtc_alrm);
-	p_ll_rtc_alrm_time = &(p_ll_rtc_alarm->AlarmTime);
-
-	memset(p_ll_rtc_alrm_time, 0, sizeof(LL_RTC_TimeTypeDef));
-	rtc_stm32_init_ll_alrm_struct(p_ll_rtc_alarm, timeptr, mask);
-
-	p_rtc_alrm->user_mask = mask;
-
 	LOG_DBG("set alarm %d : second = %d, min = %d, hour = %d,"
 			" wday = %d, mday = %d, mask = 0x%04x",
 			id, timeptr->tm_sec, timeptr->tm_min, timeptr->tm_hour,
@@ -884,12 +911,7 @@ static int rtc_stm32_alarm_set_time(const struct device *dev, uint16_t id, uint1
 #endif /* RTC_ISR_ALRBWF */
 
 	/* init Alarm */
-	/* write protection is disabled & enabled again inside the LL_RTC_ALMx_Init function */
-	if (rtc_stm32_init_alarm(RTC, LL_RTC_FORMAT_BCD, p_ll_rtc_alarm, id) != SUCCESS) {
-		LOG_ERR("Could not initialize Alarm %d", id);
-		err = -ECANCELED;
-		goto disable_bkup_access;
-	}
+	rtc_stm32_init_alarm(timeptr, id, mask);
 
 	/* Disable the write protection for RTC registers */
 	LL_RTC_DisableWriteProtection(RTC);


### PR DESCRIPTION
This PR applies changes to the STM32 RTC and Counter-RTC drivers.
It removes the usage of the various initialization structures functions that are located in the source files of the LL. They are replaced by several calls to simple static inline functions from the LL header file.

It is similar to PR #96156 that did the same thing for the STM32 timers.