### PR TITLE
soc: st: Add missing definition for STM32H742xx

### DIFF
--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -125,6 +125,7 @@ family:
     - name: stm32h725xx
     - name: stm32h730xx
     - name: stm32h735xx
+    - name: stm32h742xx
     - name: stm32h743xx
     - name: stm32h745xx
       cpuclusters:


### PR DESCRIPTION
Adds stm32h742xx to stm32h7x family in soc/st/stm32/soc.yml