### PR TITLE
Fix off-by-one error during virtiofs initialization and overallocation in virtio_pci_init_virtqueues

### DIFF
--- a/drivers/virtio/virtio_pci.c
+++ b/drivers/virtio/virtio_pci.c
@@ -267,18 +267,18 @@ static int virtio_pci_init_virtqueues(
 		return -EINVAL;
 	}
 
-	data->virtqueues = k_malloc(queue_count * sizeof(struct virtq));
+	data->virtqueues = k_malloc(num_queues * sizeof(struct virtq));
 	if (!data->virtqueues) {
 		LOG_ERR("failed to allocate virtqueue array");
 		return -ENOMEM;
 	}
-	data->virtqueue_count = queue_count;
+	data->virtqueue_count = num_queues;
 
 	int ret = 0;
 	int created_queues = 0;
 	int activated_queues = 0;
 
-	for (int i = 0; i < queue_count; i++) {
+	for (int i = 0; i < num_queues; i++) {
 		data->common_cfg->queue_select = sys_cpu_to_le16(i);
 		barrier_dmem_fence_full();
 

--- a/subsys/fs/virtiofs/virtiofs.c
+++ b/subsys/fs/virtiofs/virtiofs.c
@@ -31,6 +31,12 @@ LOG_MODULE_REGISTER(virtiofs, CONFIG_VIRTIOFS_LOG_LEVEL);
 #define REQUEST_QUEUE 2
 #endif
 
+/*
+ * Currently we are using only one request queue, so we don't have to initialize queues
+ * after that one
+ */
+#define QUEUE_COUNT (REQUEST_QUEUE + 1)
+
 
 struct virtio_fs_config {
 	char tag[36];
@@ -132,7 +138,7 @@ int virtiofs_init(const struct device *dev, struct fuse_init_out *response)
 		return ret;
 	}
 
-	ret = virtio_init_virtqueues(dev, REQUEST_QUEUE, virtiofs_queue_enum_cb, NULL);
+	ret = virtio_init_virtqueues(dev, QUEUE_COUNT, virtiofs_queue_enum_cb, NULL);
 	if (ret != 0) {
 		LOG_ERR("failed to initialize fs virtqueues");
 		return ret;


### PR DESCRIPTION
This PR fixes off-by-one error in `virtio_init_virtqueues` call in virtiofs that went unnoticed due to overallocation in `virtio_pci_init_virtqueues` that this PR also addresses