### PR TITLE
Bluetooth: BAP: Add bt_bap_unicast_client_unregister_cb

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -118,6 +118,7 @@ New APIs and options
     * :c:struct:`bt_bap_stream` now contains an ``iso`` field as a reference to the ISO channel
     * :c:func:`bt_bap_unicast_group_get_info`
     * :c:func:`bt_cap_unicast_group_get_info`
+    * :c:func:`bt_bap_unicast_client_unregister_cb`
 
   * Host
 

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1967,16 +1967,23 @@ struct bt_bap_unicast_client_cb {
 /**
  * @brief Register unicast client callbacks.
  *
- * Only one callback structure can be registered, and attempting to
- * registering more than one will result in an error.
- *
- * @param cb  Unicast client callback structure.
+ * @param cb  Unicast client callback structure to register.
  *
  * @retval 0 Success
  * @retval -EINVAL @p cb is NULL.
  * @retval -EEXIST @p cb is already registered.
  */
 int bt_bap_unicast_client_register_cb(struct bt_bap_unicast_client_cb *cb);
+
+/**
+ * @brief Unregister unicast client callbacks.
+ *
+ * @param cb  Unicast client callback structure to unregister.
+ *
+ * @retval 0 Success
+ * @retval -EINVAL @p cb is NULL or @p cb was not registered
+ */
+int bt_bap_unicast_client_unregister_cb(struct bt_bap_unicast_client_cb *cb);
 
 /**
  * @brief Discover remote capabilities and endpoints

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -4684,3 +4684,18 @@ int bt_bap_unicast_client_register_cb(struct bt_bap_unicast_client_cb *cb)
 
 	return 0;
 }
+
+int bt_bap_unicast_client_unregister_cb(struct bt_bap_unicast_client_cb *cb)
+{
+	if (cb == NULL) {
+		LOG_DBG("cb was NULL");
+		return -EINVAL;
+	}
+
+	if (!sys_slist_find_and_remove(&unicast_client_cbs, &cb->_node)) {
+		LOG_DBG("cb was not registered");
+		return -EALREADY;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Add bt_bap_unicast_client_unregister_cb to unregister BAP
unicast client callbacks. This is required for unittests
to clean up between runs.

The function isn't used or tested anywhere yet, but will be part of the CAP unittests