### PR TITLE
samples: adc_dt: adding silabs xg24_dk2601b

### DIFF
--- a/samples/drivers/adc/adc_dt/boards/xg24_dk2601b.overlay
+++ b/samples/drivers/adc/adc_dt/boards/xg24_dk2601b.overlay
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ */
+
+#include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
+#include <dt-bindings/adc/silabs-adc.h>
+
+/*
+ * ch0: VDD: does not need analog bus
+ * ch1: button0 on GPIO port B2 pin: requires even analog bus
+ * ch2: button1 on GPIO port B3 pin: requires odd analog bus
+ * ch3: U.FL connector on AIN0 pin: does not need analog bus
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 1>, <&adc0 2>, <&adc0 3>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_BODD0_IADC0>, <ABUS_BEVEN0_IADC0>;
+		};
+	};
+};
+
+&adc0 {
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_AVDD>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_PB2>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_PB3>;
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_AIN0>;
+	};
+
+};

--- a/samples/drivers/adc/adc_dt/sample.yaml
+++ b/samples/drivers/adc/adc_dt/sample.yaml
@@ -37,6 +37,7 @@ tests:
       - mcx_n9xx_evk/mcxn947/cpu0
       - frdm_mcxc242
       - ucans32k1sic
+      - xg24_dk2601b
       - xg24_rb4187c
       - xg29_rb4412a
       - raytac_an54l15q_db/nrf54l15/cpuapp


### PR DESCRIPTION
This pull request adds support for xg24_dk2601b to the adc_dt sample app.
Measuring four channels:

- ch0: AVDD
- ch1: button0 on GPIO port B2 pin
- ch2: button1 on GPIO port B3 pin
- ch3: U.FL connector on AIN0 pin