### PR TITLE
native_sim drivers: Set O_CLOEXEC for all native sim specific host descriptors by default

### DIFF
--- a/boards/native/native_sim/doc/index.rst
+++ b/boards/native/native_sim/doc/index.rst
@@ -720,7 +720,7 @@ host libC (:kconfig:option:`CONFIG_EXTERNAL_LIBC`):
      FUSE, :ref:`Host based filesystem access <native_fuse_flash>`, :kconfig:option:`CONFIG_FUSE_FS_ACCESS`, All
      GPIO, GPIO emulator, :kconfig:option:`CONFIG_GPIO_EMUL`, All
      GPIO, SDL GPIO emulator, :kconfig:option:`CONFIG_GPIO_EMUL_SDL`, All
-     HWINFO, :kconfig:option:`CONFIG_HWINFO_NATIVE`, All
+     HWINFO, HWINFO native, :kconfig:option:`CONFIG_HWINFO_NATIVE`, All
      I2C, I2C emulator, :kconfig:option:`CONFIG_I2C_EMUL`, All
      Input, Input SDL touch, :kconfig:option:`CONFIG_INPUT_SDL_TOUCH`, All
      Input, Linux evdev, :kconfig:option:`CONFIG_NATIVE_LINUX_EVDEV`, All

--- a/drivers/can/can_native_linux_adapt.c
+++ b/drivers/can/can_native_linux_adapt.c
@@ -47,7 +47,7 @@ int linux_socketcan_iface_open(const char *if_name)
 	struct ifreq ifr;
 	int fd, opt, ret = -EINVAL;
 
-	fd = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+	fd = socket(PF_CAN, SOCK_RAW | SOCK_CLOEXEC, CAN_RAW);
 	if (fd < 0) {
 		return -errno;
 	}

--- a/drivers/eeprom/eeprom_simulator_native.c
+++ b/drivers/eeprom/eeprom_simulator_native.c
@@ -46,7 +46,7 @@ int eeprom_mock_init_native(bool eeprom_in_ram, char **mock_eeprom, unsigned int
 			return -1;
 		}
 	} else {
-		*eeprom_fd = open(eeprom_file_path, O_RDWR | O_CREAT, (mode_t)0600);
+		*eeprom_fd = open(eeprom_file_path, O_RDWR | O_CREAT | O_CLOEXEC, (mode_t)0600);
 		if (*eeprom_fd == -1) {
 			nsi_print_warning("Failed to open EEPROM device file %s: %s\n",
 					  eeprom_file_path, strerror(errno));

--- a/drivers/ethernet/eth_native_tap_adapt.c
+++ b/drivers/ethernet/eth_native_tap_adapt.c
@@ -44,7 +44,7 @@ int eth_iface_create(const char *dev_name, const char *if_name, bool tun_only)
 	struct ifreq ifr;
 	int fd, ret = -EINVAL;
 
-	fd = open(dev_name, O_RDWR);
+	fd = open(dev_name, O_RDWR | O_CLOEXEC);
 	if (fd < 0) {
 		return -errno;
 	}

--- a/drivers/flash/flash_simulator_native.c
+++ b/drivers/flash/flash_simulator_native.c
@@ -50,7 +50,7 @@ int flash_mock_init_native(bool flash_in_ram, uint8_t **mock_flash, unsigned int
 			return -1;
 		}
 	} else {
-		*flash_fd = open(flash_file_path, O_RDWR | O_CREAT, (mode_t)0600);
+		*flash_fd = open(flash_file_path, O_RDWR | O_CREAT | O_CLOEXEC, (mode_t)0600);
 		if (*flash_fd == -1) {
 			nsi_print_warning("Failed to open flash device file "
 					"%s: %s\n",

--- a/drivers/input/linux_evdev_bottom.c
+++ b/drivers/input/linux_evdev_bottom.c
@@ -42,7 +42,7 @@ int linux_evdev_open(const char *path)
 {
 	int fd;
 
-	fd = open(path, O_RDONLY | O_NONBLOCK);
+	fd = open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
 	if (fd < 0) {
 		nsi_print_error_and_exit(
 				"Failed to open the evdev device %s: %s\n",

--- a/drivers/net/nsos_adapt.c
+++ b/drivers/net/nsos_adapt.c
@@ -269,7 +269,7 @@ int nsos_adapt_socket(int family_mid, int type_mid, int proto_mid)
 		return ret;
 	}
 
-	ret = socket(family, type, proto);
+	ret = socket(family, type | SOCK_CLOEXEC, proto);
 	if (ret < 0) {
 		return -nsi_errno_to_mid(errno);
 	}

--- a/drivers/serial/uart_native_pty_bottom.c
+++ b/drivers/serial/uart_native_pty_bottom.c
@@ -139,7 +139,7 @@ int np_uart_open_pty(const char *uart_name, const char *auto_attach_cmd,
 	int ret;
 	int flags;
 
-	master_pty = posix_openpt(O_RDWR | O_NOCTTY);
+	master_pty = posix_openpt(O_RDWR | O_NOCTTY | O_CLOEXEC);
 	if (master_pty == -1) {
 		ERROR("Could not open a new PTY for the UART\n");
 	}
@@ -214,7 +214,7 @@ int np_uart_open_pty(const char *uart_name, const char *auto_attach_cmd,
 		 * The connection of the client would cause the HUP flag to be
 		 * cleared, and in turn set again at disconnect.
 		 */
-		ret = open(slave_pty_name, O_RDWR | O_NOCTTY);
+		ret = open(slave_pty_name, O_RDWR | O_NOCTTY | O_CLOEXEC);
 		if (ret == -1) {
 			err_nbr = errno;
 			ERROR("%s: Could not open terminal from the slave side (%i,%s)\n",

--- a/drivers/serial/uart_native_tty_bottom.c
+++ b/drivers/serial/uart_native_tty_bottom.c
@@ -267,7 +267,7 @@ int native_tty_poll_bottom(int fd)
 
 int native_tty_open_tty_bottom(const char *pathname)
 {
-	int fd = open(pathname, O_RDWR | O_NOCTTY);
+	int fd = open(pathname, O_RDWR | O_NOCTTY | O_CLOEXEC);
 
 	if (fd < 0) {
 		ERROR("Failed to open serial port %s, errno: %i\n", pathname, errno);

--- a/subsys/tracing/tracing_backend_posix_bottom.c
+++ b/subsys/tracing/tracing_backend_posix_bottom.c
@@ -12,7 +12,12 @@ void *tracing_backend_posix_init_bottom(const char *file_name)
 {
 	FILE *f;
 
+#if defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 7)
+	f = fopen(file_name, "wbe"); /* Set O_CLOEXEC flag which is supported in glibc >= 2.7 */
+#else
 	f = fopen(file_name, "wb");
+#endif
+
 	if (f == NULL) {
 		nsi_print_error_and_exit("%s: Could not open CTF backend file %s\n",
 					 __func__, file_name);


### PR DESCRIPTION
If the process does an exec() (or fork, or..) all descriptors are kept
open by default and inherited by the child/replacement process, 
unless O_CLOEXEC is set when opening them.
This is useful for stdin/out/err so that new process is connected to
them, but it is very rare for it to be useful for any other descriptor.

In general this leads to descriptors being kept open unnecessarily,
which either will block other process from connecting to the respective resource
(for example if the child survives the parent but it does something else).
Or for a "leak" which unnecessarily uses descriptors and memory in the
child process.

Let's ensure we do not leak it for all these components as we do not need it.

& as a freebie, fix driver table entry in native_sim docs

Note: If any of the reviewers would like the change to their area in a separate PR please just tell.
Otherwise I would still like to have an approval from each respective maintainer before merging.