### PR TITLE
usb: device_next: use k_event instead of msg_q 

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -303,6 +303,12 @@ struct usbd_context {
 	void *fs_desc;
 	/** Pointer to High-Speed device descriptor */
 	void *hs_desc;
+	/** Thread structure */
+	struct k_thread *const thread_data;
+	/** Thread stack */
+	k_thread_stack_t *const thread_stack;
+	/** Thread stack size */
+	const size_t stack_size;
 };
 
 /**
@@ -504,6 +510,11 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
 		.bNumConfigurations = 0,				\
 	};								\
 	))								\
+									\
+	static K_KERNEL_STACK_DEFINE(thread_stack_##device_name,	\
+				     CONFIG_USBD_THREAD_STACK_SIZE);	\
+	static struct k_thread thread_data_##device_name;		\
+									\
 	static STRUCT_SECTION_ITERABLE(usbd_context, device_name) = {	\
 		.name = STRINGIFY(device_name),				\
 		.dev = udc_dev,						\
@@ -511,6 +522,10 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
 		IF_ENABLED(USBD_SUPPORTS_HIGH_SPEED, (			\
 		.hs_desc = &hs_desc_##device_name,			\
 		))							\
+		.thread_data = &thread_data_##device_name,		\
+		.thread_stack = thread_stack_##device_name,		\
+		.stack_size = K_KERNEL_STACK_SIZEOF(			\
+				thread_stack_##device_name),		\
 	}
 
 /**

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -287,6 +287,12 @@ struct usbd_context {
 	const struct device *dev;
 	/** Notification message recipient callback */
 	usbd_msg_cb_t msg_cb;
+	/** UDC driver events */
+	struct k_event events;
+	/** slist to keep endpoint events */
+	sys_slist_t ep_events;
+	/** Endpoint event list spinlock */
+	struct k_spinlock ep_event_lock;
 	/** Middle layer runtime data */
 	struct usbd_ch9_data ch9_data;
 	/** slist to manage descriptors like string, BOS */

--- a/subsys/usb/device_next/Kconfig
+++ b/subsys/usb/device_next/Kconfig
@@ -5,6 +5,7 @@
 menuconfig USB_DEVICE_STACK_NEXT
 	bool "New USB device stack"
 	select UDC_DRIVER
+	select EVENTS
 	imply HWINFO
 	help
 	  New USB device stack.
@@ -66,12 +67,6 @@ config USBD_THREAD_STACK_SIZE
 	default 1024
 	help
 	  USB device stack thread stack size in bytes.
-
-config USBD_MAX_UDC_MSG
-	int "Maximum number of UDC events"
-	default 10
-	help
-	  Maximum number of USB device controller events that can be queued.
 
 config USBD_MSG_DEFERRED_MODE
 	bool "Execute message callback from system workqueue"


### PR DESCRIPTION
USBD_MAX_UDC_MSG configures the number of events coming from the UDC
driver that the stack can keep. This can be filled very quickly on high
speed devices, and subsequent events would be dropped. It seems that
only endpoint events, which are net_bufs, need to be queued, and we can
use single linked lists for that. Then, we can replace msg_q with
k_event. Likely, some work is needed to filter bus events, as now the
stack may see them simultaneously.

The first commit introduces some drawbacks in regards to memory usage for use cases like samples/subsys/usb/dfu.