### PR TITLE
drivers: crypto: crypto_ataes132a fix missing count check

### DIFF
--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -110,6 +110,12 @@ static int ataes132a_send_command(const struct device *dev, uint8_t opcode,
 	burst_read_i2c(&cfg->i2c, ATAES_COMMAND_MEM_ADDR, data->command_buffer, 64);
 
 	count = data->command_buffer[0];
+	/* validate count: at least 3 bytes (1 for count, 2 for CRC) */
+	if (count < 3) {
+		LOG_ERR("invalid packet received: count=%d"
+			" , expects count>=3", count);
+		return -EINVAL;
+	}
 
 	/* Calculate and validate response CRC */
 	ataes132a_atmel_crc(data->command_buffer, count - 2, crc);
@@ -130,7 +136,11 @@ static int ataes132a_send_command(const struct device *dev, uint8_t opcode,
 		burst_read_i2c(&cfg->i2c, ATAES_COMMAND_MEM_ADDR, data->command_buffer, 64);
 
 		count = data->command_buffer[0];
-
+		if (count < 3) {
+			LOG_ERR("invalid packet received: count=%d"
+				" , expects count>=3", count);
+			return -EINVAL;
+		}
 		ataes132a_atmel_crc(data->command_buffer, count -  2, crc);
 		retry_count++;
 


### PR DESCRIPTION
Coverity reported an untrusted loop bound caused by a missing check on the count value in ataes132a_send_command() for the response received from the device.  As per datasheet section 6.1, count should be at least 3 bytes (1 byte for count, and 2 bytes for the 16 bits CRC).

While I'm expecting this condition to be very rare, it doesn't hurt to implement a proper checking and report an error if count<3.

Coverity CID: 434625

Fixes: #81951 