### PR TITLE
samples: tracing: fix missing k_event funcs for UART test

### DIFF
--- a/subsys/tracing/test/tracing_string_format_test.c
+++ b/subsys/tracing/test/tracing_string_format_test.c
@@ -553,3 +553,35 @@ void sys_trace_k_thread_foreach_unlocked_exit(k_thread_user_cb_t user_cb, void *
 {
 	TRACING_STRING("%s: %p (%p) exit\n", __func__, user_cb, data);
 }
+
+void sys_trace_k_event_init(struct k_event *event)
+{
+	TRACING_STRING("%s: %p init\n", __func__, event);
+}
+
+void sys_trace_k_event_post_enter(struct k_event *event, uint32_t events, uint32_t events_mask)
+{
+	TRACING_STRING("%s: %p post enter\n", __func__, event);
+}
+
+void sys_trace_k_event_post_exit(struct k_event *event, uint32_t events, uint32_t events_mask)
+{
+	TRACING_STRING("%s: %p post exit\n", __func__, event);
+}
+
+void sys_trace_k_event_wait_enter(struct k_event *event, uint32_t events, unsigned int options,
+				  k_timeout_t timeout)
+{
+	TRACING_STRING("%s: %p wait enter\n", __func__, event);
+}
+
+void sys_trace_k_event_wait_blocking(struct k_event *event, uint32_t events, unsigned int options,
+				     k_timeout_t timeout)
+{
+	TRACING_STRING("%s: %p wait blocking\n", __func__, event);
+}
+
+void sys_trace_k_event_wait_exit(struct k_event *event, uint32_t events, uint32_t ret)
+{
+	TRACING_STRING("%s: %p wait exit\n", __func__, event);
+}

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -745,6 +745,13 @@ void sys_trace_k_timer_status_sync_blocking(struct k_timer *timer);
 void sys_trace_k_timer_status_sync_exit(struct k_timer *timer, uint32_t result);
 
 void sys_trace_k_event_init(struct k_event *event);
+void sys_trace_k_event_post_enter(struct k_event *event, uint32_t events, uint32_t events_mask);
+void sys_trace_k_event_post_exit(struct k_event *event, uint32_t events, uint32_t events_mask);
+void sys_trace_k_event_wait_enter(struct k_event *event, uint32_t events, unsigned int options,
+				  k_timeout_t timeout);
+void sys_trace_k_event_wait_blocking(struct k_event *event, uint32_t events, unsigned int options,
+				     k_timeout_t timeout);
+void sys_trace_k_event_wait_exit(struct k_event *event, uint32_t events, uint32_t ret);
 
 #define sys_port_trace_socket_init(sock, family, type, proto)
 #define sys_port_trace_socket_close_enter(sock)


### PR DESCRIPTION
With the UART transport test (sample.tracing.transport.uart), it would fail on qemu_x86_64 complaining about missing k_event tracing functions. So add them to fix the compilation error.

Fixes #96818