### PR TITLE
doc: release notes: add LVGL zephyr regions options

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -145,6 +145,13 @@ New APIs and options
   * :c:macro:`K_THREAD_HW_SHADOW_STACK_ATTACH`
   * :c:macro:`k_thread_hw_shadow_stack_attach`
 
+* LVGL (Light and Versatile Graphics Library)
+
+  * :kconfig:option:`CONFIG_LV_Z_MEMORY_POOL_ZEPHYR_REGION`
+  * :kconfig:option:`CONFIG_LV_Z_MEMORY_POOL_ZEPHYR_REGION_NAME`
+  * :kconfig:option:`CONFIG_LV_Z_VDB_ZEPHYR_REGION`
+  * :kconfig:option:`CONFIG_LV_Z_VDB_ZEPHYR_REGION_NAME`
+
 * Logging:
 
   * Added rate-limited logging macros to prevent log flooding when messages are generated frequently.


### PR DESCRIPTION
Add description of new LVGL Kconfig options to specify the zephyr regions used by LVGL.

Small addition to describe new options introduced in the PR #96322 already merged.