### PR TITLE
Add Zephyr support for Mediatek MT8365 platform

### DIFF
--- a/boards/mediatek/index.rst
+++ b/boards/mediatek/index.rst
@@ -5,18 +5,20 @@ Mediatek Audio DSPs
 
 Zephyr can be built and run on the Audio DSPs included in various
 members of the Mediatek MT8xxx series of ARM SOCs used in Chromebooks
-from various manufacturers.
+from various manufacturers and Mediatek Genio evaluations kits.
 
-Two of these DSPs are in the market already, implemented via the
-MT8195 ("Kompanio 1380") and MT8186 ("Kompanio 520") SOCs.
-Development has been done on and validation performed on at least
-these devices, though more exist:
+Four of these DSPs are in the market already, implemented via the
+MT8195 ("Kompanio 1380", MT8186 ("Kompanio 520"), MT8188 ("Kompanio 838")
+and MT8365 ("Genio 350 EVK") SOCs. Development has been done on and
+validation performed on at least these devices, though more exist:
 
   ======  =============  ===================================  =================
   SOC     Product Name   Example Device                       ChromeOS Codename
   ======  =============  ===================================  =================
   MT8195  Kompanio 1380  HP Chromebook x360 13b               dojo
   MT8186  Kompanio 520   Lenovo 300e Yoga Chromebook Gen 4    steelix
+  MT8188  Kompanio 838   Lenovo Chromebook Duet 11            ciri
+  MT8365  Genio 350      Genio 350 EVK
   ======  =============  ===================================  =================
 
 Hardware
@@ -67,7 +69,7 @@ my mt8186 device named "steelix":
 
 .. code-block:: console
 
-   user@dev_host:~$ west build -b mt8186//adsp samples/hello_world
+   user@dev_host:~$ west build -b mt8186/mt8186/adsp samples/hello_world
    ...
    ... # build output
    ...
@@ -76,8 +78,8 @@ my mt8186 device named "steelix":
    user@dev_host:~$ ssh steelix
 
    root@steelix:~ # ./mtk_adsp_load.py load zephyr.img
-   *** Booting Zephyr OS build v3.6.0-5820-gd2a89b3c089e ***
-   Hello World! mt8186_adsp/mt8186_adsp
+   *** Booting Zephyr OS build v4.2.0-4743-g80fdfabcba48 ***
+   Hello World! mt8186/mt8186/adsp
 
 Debugging
 =========
@@ -93,60 +95,11 @@ but this is still unintegrated.
 Toolchains
 **********
 
-The MT8195 toolchain is already part of the Zephyr SDK, so builds for
-the ``mt8195//adsp`` board should work out of the box simply following
-the generic Zephyr build instructions in the Getting Started guide.
-
-The MT8186 toolchain is not, and given the proliferation of Xtensa
-toolchains in the SDK may not be.  The overlay files for the device
-are maintained by the SOF project, however, and building a toolchain
-yourself using crosstools-ng is not difficult or time-consuming.  This
-script should work for most users:
-
-.. code-block:: shell
-
-   #!/bin/sh
-
-   TC=mtk_mt818x_adsp
-
-   # Grab source (these are small)
-   git clone https://github.com/crosstool-ng/crosstool-ng
-   git clone https://github.com/thesofproject/xtensa-overlay
-
-   # Build ct-ng itself
-   cd crosstool-ng
-   ./bootstrap
-   ./configure --enable-local
-   make -j$(nproc)
-
-   mkdir overlays
-   (cd overlays; ln -s ../../xtensa-overlay/xtensa_mt8186.tar.gz xtensa_${TC}.tar.gz)
-
-   # Construct a .config file
-   cat >.config <<EOF
-   CT_CONFIG_VERSION="3"
-   CT_EXPERIMENTAL=y
-   CT_OVERLAY_LOCATION="overlays"
-   CT_OVERLAY_NAME="${TC}"
-   CT_ARCH_XTENSA=y
-   CT_XTENSA_CUSTOM=y
-   CT_TARGET_VENDOR="${TC}_zephyr"
-   CT_TARGET_CFLAGS="-ftls-model=local-exec"
-   CT_CC_GCC_CONFIG_TLS=n
-   CT_GDB_CROSS_EXTRA_CONFIG_ARRAY="--enable-xtensa-use-target-regnum --disable-xtensa-remote-g-packet"
-   EOF
-
-   # Build
-   ./ct-ng olddefconfig
-   ./ct-ng build.$(nproc)
-
-After this completes, you will find your toolchain in ``~/x-tools``
-and can use it to build by setting it as your Zephyr cross compiler:
-
-.. code-block:: shell
-
-   export CROSS_COMPILE=$HOME/x-tools/xtensa-mtk_mt818x_adsp_zephyr-elf/bin/xtensa-mtk_mt818x_adsp_zephyr-elf-
-   export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
+The MT8195, MT818X and MT8365 toolchains are already part of the Zephyr
+SDK, so builds for the ``mt8195/mt8195/adsp``, ``mt8186/mt8186/adsp``,
+``mt8188/mt8188/adsp`` and ``mt8365/mt8365/adsp`` board targets should
+work out of the box simply following the generic Zephyr build instructions
+in the Getting Started guide.
 
 Closed-source Tools
 ===================

--- a/boards/mediatek/mt8365/Kconfig.mt8365
+++ b/boards/mediatek/mt8365/Kconfig.mt8365
@@ -1,0 +1,5 @@
+# Copyright 2025 Mediatek
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_MT8365
+	select SOC_MT8365

--- a/boards/mediatek/mt8365/afe-mt8365.dts
+++ b/boards/mediatek/mt8365/afe-mt8365.dts
@@ -1,0 +1,111 @@
+/* Copyright 2025 Mediatek
+ * SPDX-License-Identifier: Apache-2.0
+ */
+afe_dl1: afe_dl1 {
+	compatible = "mediatek,afe";
+	afe-name = "DL1";
+	dai-id = <0>;
+	downlink;
+	base = <0x00000000 0x11220040>;
+	cur = <0x00000000 0x11220044>;
+	end = <0x00000000 0x11220048>;
+	fs = <0x11220014 0 4>;
+	mono = <0x11220014 21 1>;
+	enable = <0x11220010 1 1>;
+	hd = <0x112203d8 16 1>;
+};
+
+afe_dl2: afe_dl2 {
+	compatible = "mediatek,afe";
+	afe-name = "DL2";
+	dai-id = <1>;
+	downlink;
+	base = <0x00000000 0x11220050>;
+	cur = <0x00000000 0x11220054>;
+	end = <0x00000000 0x11220058>;
+	fs = <0x11220014 4 4>;
+	mono = <0x11220014 22 1>;
+	enable = <0x11220010 2 1>;
+	hd = <0x112203d8 18 1>;
+};
+
+afe_tdm_out: afe_tdm_out {
+	compatible = "mediatek,afe";
+	afe-name = "TDM_OUT";
+	dai-id = <4>;
+	downlink;
+	base = <0x00000000 0x11220374>;
+	cur = <0x00000000 0x11220378>;
+	end = <0x00000000 0x1122037c>;
+	enable = <0x11220370 0 1>;
+	hd = <0x112203d8 28 1>;
+};
+
+afe_awb: afe_awb {
+	compatible = "mediatek,afe";
+	afe-name = "AWB";
+	dai-id = <2>;
+	base = <0x00000000 0x11220070>;
+	cur = <0x00000000 0x1122007c>;
+	end = <0x00000000 0x11220078>;
+	fs = <0x11220014 12 4>;
+	mono = <0x11220014 24 1>;
+	enable = <0x11220010 6 1>;
+	hd = <0x112203d8 20 1>;
+	msb = <0x112200cc 17 1>;
+};
+
+afe_vul: afe_vul {
+	compatible = "mediatek,afe";
+	afe-name = "VUL";
+	dai-id = <3>;
+	base = <0x00000000 0x11220080>;
+	cur = <0x00000000 0x1122008c>;
+	end = <0x00000000 0x11220088>;
+	fs = <0x11220014 16 4>;
+	mono = <0x11220014 27 1>;
+	enable = <0x11220010 3 1>;
+	hd = <0x112203d8 22 1>;
+	msb = <0x112200cc 20 1>;
+};
+
+afe_vul2: afe_vul2 {
+	compatible = "mediatek,afe";
+	afe-name = "VUL2";
+	dai-id = <5>;
+	base = <0x00000000 0x11220350>;
+	cur = <0x00000000 0x1122035c>;
+	end = <0x00000000 0x11220358>;
+	fs = <0x11220010 20 4>;
+	mono = <0x11220010 10 1>;
+	enable = <0x11220010 9 1>;
+	hd = <0x112203d8 14 1>;
+	msb = <0x112200cc 21 1>;
+};
+
+afe_vul3: afe_vul3 {
+	compatible = "mediatek,afe";
+	afe-name = "VUL3";
+	dai-id = <6>;
+	base = <0x00000000 0x112208c0>;
+	cur = <0x00000000 0x112208c4>;
+	end = <0x00000000 0x112208c8>;
+	fs = <0x11220014 8 4>;
+	mono = <0x11220010 13 1>;
+	enable = <0x11220010 12 1>;
+	hd = <0x112203ec 10 1>;
+	msb = <0x112200cc 27 1>;
+};
+
+afe_tdm_in: afe_tdm_in {
+	compatible = "mediatek,afe";
+	afe-name = "TDM_IN";
+	dai-id = <7>;
+	base = <0x00000000 0x112209c4>;
+	cur = <0x00000000 0x112209cc>;
+	end = <0x00000000 0x112209c8>;
+	mono = <0x112209c0 1 1>;
+	enable = <0x112209c0 0 1>;
+	hd = <0x112203ec 8 1>;
+	msb = <0x112200cc 28 1>;
+};

--- a/boards/mediatek/mt8365/board.yml
+++ b/boards/mediatek/mt8365/board.yml
@@ -1,0 +1,6 @@
+boards:
+  - name: mt8365
+    full_name: MT8365 ADSP
+    vendor: mediatek
+    socs:
+      - name: mt8365

--- a/boards/mediatek/mt8365/mt8365_adsp.dts
+++ b/boards/mediatek/mt8365/mt8365_adsp.dts
@@ -1,0 +1,85 @@
+/* Copyright 2025 Mediatek
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <mem.h>
+
+/dts-v1/;
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	sram1: memory@1e000000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
+		reg = <0x1e000000 DT_SIZE_K(416)>;
+	};
+
+	/* SRAM0 is mapped to a physical DRAM region that contains
+	 * exceptions and vectors, but we keep its name to maintain
+	 * compatibility with other Mediatek platforms.
+	 */
+
+	sram0: memory@40020000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
+		reg = <0x40020000 DT_SIZE_K(256)>;
+	};
+
+	dram0: memory@60000000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
+		reg = <0x60000000 DT_SIZE_K(13824)>;
+	};
+
+	dram1: memory@60d80000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
+		reg = <0x60d80000 DT_SIZE_K(2560)>;
+	};
+
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		core_intc: core_intc@0 {
+			compatible = "cdns,xtensa-core-intc";
+			reg = <0 4>;
+			interrupt-controller;
+			#interrupt-cells = <3>;
+		};
+
+		intc1: intc@1d062130 {
+			compatible = "mediatek,adsp_intc";
+			interrupt-controller;
+			#interrupt-cells = <3>;
+			reg = <0x1d062130 4>;
+			status-reg = <0x1d062150>;
+			interrupts = <1 0 0>;
+			mask = <0x3ff>;
+			interrupt-parent = <&core_intc>;
+		};
+
+		ostimer64: ostimer64@1d060000 {
+			compatible = "mediatek,ostimer64";
+			reg = <0x1d060000 30>;
+		};
+
+		ostimer0: ostimer@1d060040 {
+			compatible = "mediatek,ostimer";
+			reg = <0x1d060040 8>;
+			interrupt-parent = <&core_intc>;
+			interrupts = <2 0 0>;
+		};
+
+		ipi: ipi@1d062114 {
+			compatible = "mediatek,ipi";
+			reg = <0x1d062114 4>;
+			interrupt-parent = <&intc1>;
+			interrupts = <9 0 0>;
+		};
+
+		/* Generated code for AFE devices */
+		#include "afe-mt8365.dts"
+	}; /* soc */
+};

--- a/boards/mediatek/mt8365/mt8365_mt8365_adsp.yaml
+++ b/boards/mediatek/mt8365/mt8365_mt8365_adsp.yaml
@@ -1,0 +1,11 @@
+identifier: mt8365/mt8365/adsp
+name: Mediatek mt8365 Audio DSP
+type: mcu
+arch: xtensa
+toolchain:
+  - zephyr
+testing:
+  only_tags:
+    - kernel
+    - sof
+vendor: mediatek

--- a/boards/mediatek/twister.yaml
+++ b/boards/mediatek/twister.yaml
@@ -16,3 +16,5 @@ variants:
     name: MediaTek MT8186 Audio DSP
   mt8196/mt8196/adsp:
     name: MediaTek MT8196 Audio DSP
+  mt8365/mt8365/adsp:
+    name: MediaTek MT8365 Audio DSP

--- a/soc/mediatek/mt8xxx/CMakeLists.txt
+++ b/soc/mediatek/mt8xxx/CMakeLists.txt
@@ -1,7 +1,10 @@
 # Copyright 2023 The ChromiumOS Authors
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_sources(soc.c irq.c mbox.c)
+zephyr_library_sources(soc.c irq.c)
+
+zephyr_library_sources_ifndef(CONFIG_SOC_SERIES_MT8365 mbox.c)
+zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_MT8365 ipi.c)
 
 zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_MT8195 ${CONFIG_SOC}/cpuclk.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_MT8188 ${CONFIG_SOC}/cpuclk.c)
@@ -12,7 +15,7 @@ add_custom_target(dsp_img ALL
   DEPENDS ${ZEPHYR_FINAL_EXECUTABLE}
   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_img.py
     ${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
-    ${CMAKE_BINARY_DIR}/zephyr/zephyr.img
+    ${ZEPHYR_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.img
 )
 
 # Sign zephyr.ri using west (if the underlying rimage tool is
@@ -38,9 +41,9 @@ board_set_rimage_target(${CONFIG_SOC})
 set(RIMAGE_SIGN_KEY "otc_private_key_3k.pem" CACHE STRING "default rimage key")
 add_custom_target(zephyr.ri ALL DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri)
 add_custom_command(
-  OUTPUT ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
+  OUTPUT ${ZEPHYR_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.ri
   COMMENT "Sign with rimage..."
   COMMAND west $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose> sign
     --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR}
-  DEPENDS ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+  DEPENDS ${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
 )

--- a/soc/mediatek/mt8xxx/Kconfig.defconfig
+++ b/soc/mediatek/mt8xxx/Kconfig.defconfig
@@ -62,6 +62,7 @@ config XTENSA_CCOUNT_HZ
 	default 400000000 if SOC_MT8186
 	default 800000000 if SOC_MT8188
 	default 800000000 if SOC_MT8196
+	default 600000000 if SOC_MT8365
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,$(dt_nodelabel_path,ostimer64),freq-hz)
@@ -89,6 +90,7 @@ config SOC_TOOLCHAIN_NAME
 	default "mtk_mt8195_adsp" if SOC_SERIES_MT8195
 	default "mtk_mt818x_adsp" if SOC_SERIES_MT818X
 	default "mtk_mt8196_adsp" if SOC_SERIES_MT8196
+	default "mtk_mt8365_adsp" if SOC_SERIES_MT8365
 
 config XTENSA_RESET_VECTOR
 	default n

--- a/soc/mediatek/mt8xxx/Kconfig.soc
+++ b/soc/mediatek/mt8xxx/Kconfig.soc
@@ -22,6 +22,12 @@ config SOC_SERIES_MT8196
 	help
 	  Mediatek MT8196 Audio DSPs
 
+config SOC_SERIES_MT8365
+	bool
+	select SOC_FAMILY_MTK
+	help
+	  Mediatek MT8365 Audio DSP
+
 config SOC_MT8195
 	bool
 	select SOC_SERIES_MT8195
@@ -38,8 +44,19 @@ config SOC_MT8196
 	bool
 	select SOC_SERIES_MT8196
 
+config SOC_MT8365
+	bool
+	select SOC_SERIES_MT8365
+
+config SOC_SERIES
+	default "mt8195" if SOC_SERIES_MT8195
+	default "mt818x" if SOC_SERIES_MT818X
+	default "mt8196" if SOC_SERIES_MT8196
+	default "mt8365" if SOC_SERIES_MT8365
+
 config SOC
 	default "mt8195" if SOC_MT8195
 	default "mt8186" if SOC_MT8186
 	default "mt8188" if SOC_MT8188
 	default "mt8196" if SOC_MT8196
+	default "mt8365" if SOC_MT8365

--- a/soc/mediatek/mt8xxx/gen_img.py
+++ b/soc/mediatek/mt8xxx/gen_img.py
@@ -39,7 +39,7 @@ def sram_off(addr):
     global sram_block
     if addr < 0x40000000 or addr >= 0x50000000:
         return -1
-    block = addr & ~0xFFFFF
+    block = addr & ~0xFFFF
     assert sram_block in (0, block)
 
     sram_block = block

--- a/soc/mediatek/mt8xxx/ipi.c
+++ b/soc/mediatek/mt8xxx/ipi.c
@@ -1,0 +1,92 @@
+/* Copyright 2025 Mediatek
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/irq.h>
+#include <zephyr/devicetree.h>
+#include <soc.h>
+
+#define DT_DRV_COMPAT mediatek_ipi
+
+#define CPU2DSP_IRQ		BIT(0)
+#define DSP2CPU_IRQ		BIT(1)
+#define DSP2SPM_IRQ_B		BIT(2)
+
+struct mtk_ipi {
+	uint32_t int2cirq;
+	uint32_t int_pol;
+	uint32_t int_en;
+	uint32_t int_status;
+};
+
+struct ipi_cfg {
+	volatile struct mtk_ipi *ipi;
+};
+
+struct ipi_data {
+	mtk_adsp_ipi_handler_t handler;
+	void *handler_arg;
+};
+
+void mtk_adsp_ipi_set_handler(const struct device *ipi, uint32_t chan,
+			       mtk_adsp_ipi_handler_t handler, void *arg)
+{
+	struct ipi_data *data = ((struct device *)ipi)->data;
+
+	data->handler = handler;
+	data->handler_arg = arg;
+}
+
+void mtk_adsp_ipi_signal(const struct device *ipi, uint32_t op)
+{
+	const struct ipi_cfg *cfg = ((struct device *)ipi)->config;
+
+	/* wakeup CPU */
+	cfg->ipi->int2cirq &= ~(DSP2SPM_IRQ_B);
+	/* trigger IPI IRQ to CPU */
+	cfg->ipi->int2cirq |= DSP2CPU_IRQ;
+}
+
+#define DEF_DEVPTR(N) DEVICE_DT_INST_GET(N),
+const struct device * const ipi_dev = {
+	DEF_DEVPTR(0)
+};
+
+static void ipi_handle(const void *arg)
+{
+	const struct ipi_cfg *cfg = ((struct device *)arg)->config;
+	struct ipi_data *data = ((struct device *)arg)->data;
+
+	if (data->handler != NULL) {
+		data->handler(arg, data->handler_arg);
+	}
+	/* clear IPI IRQ from CPU */
+	cfg->ipi->int2cirq &= ~(CPU2DSP_IRQ);
+}
+
+static void ipi_isr(const void *arg)
+{
+	ipi_handle(ipi_dev);
+}
+
+#define DEF_IRQ(N)							\
+	{ IRQ_CONNECT(DT_INST_IRQN(N), 0, ipi_isr, DEVICE_DT_INST_GET(N), 0); \
+	  irq_enable(DT_INST_IRQN(N)); }
+
+static int ipi_init(void)
+{
+	DEF_IRQ(0);
+	return 0;
+}
+
+SYS_INIT(ipi_init, POST_KERNEL, 0);
+
+#define DEF_DEV(N)							\
+	static struct ipi_data dev_data##N;				\
+	static const struct ipi_cfg dev_cfg##N =			\
+		{ .ipi = (void *)DT_INST_REG_ADDR(N), };		\
+	DEVICE_DT_INST_DEFINE(N, NULL, NULL, &dev_data##N, &dev_cfg##N,	\
+			      POST_KERNEL, 0, NULL);
+
+DEF_DEV(0);

--- a/soc/mediatek/mt8xxx/mt8365/Kconfig.defconfig
+++ b/soc/mediatek/mt8xxx/mt8365/Kconfig.defconfig
@@ -1,0 +1,12 @@
+# Copyright 2025 Mediatek
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_MT8365
+
+config NUM_2ND_LEVEL_AGGREGATORS
+	default 1
+
+config 2ND_LVL_INTR_00_OFFSET
+	default 1
+
+endif # SOC_SERIES_MT8365

--- a/soc/mediatek/mt8xxx/mt8365/linker.ld
+++ b/soc/mediatek/mt8xxx/mt8365/linker.ld
@@ -1,0 +1,5 @@
+/* Copyright 2025 Mediatek
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../linker.ld"

--- a/soc/mediatek/mt8xxx/mt8365/soc.h
+++ b/soc/mediatek/mt8xxx/mt8365/soc.h
@@ -1,0 +1,10 @@
+/* Copyright 2025 Mediatek
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SOC_MT8365_SOC_H
+#define ZEPHYR_SOC_MT8365_SOC_H
+
+#include "../soc.h"
+
+#endif /* ZEPHYR_SOC_MT8365_SOC_H */

--- a/soc/mediatek/mt8xxx/soc.c
+++ b/soc/mediatek/mt8xxx/soc.c
@@ -13,6 +13,12 @@ extern char _mtk_adsp_sram_end[];
 #define SRAM_SIZE  DT_REG_SIZE(DT_NODELABEL(sram0))
 #define SRAM_END   (SRAM_START + SRAM_SIZE)
 
+#ifdef CONFIG_SOC_MT8365
+#define SRAM1_START DT_REG_ADDR(DT_NODELABEL(sram1))
+#define SRAM1_SIZE  DT_REG_SIZE(DT_NODELABEL(sram1))
+#define SRAM1_END   (SRAM1_START + SRAM1_SIZE)
+#endif
+
 extern char _mtk_adsp_dram_end[];
 
 #define DRAM_START DT_REG_ADDR(DT_NODELABEL(dram0))
@@ -195,7 +201,12 @@ static void enable_mpu(void)
 	static const uint32_t mpu[][2] = {
 		{ 0x00000000, 0x06000 },          /* inaccessible null region */
 		{ 0x10000000, 0x06f00 },          /* MMIO registers */
+#ifndef CONFIG_SOC_MT8365
 		{ 0x1d000000, 0x06000 },          /* inaccessible */
+#else
+		{ SRAM1_START, 0xf7f00 },         /* cached SRAM */
+		{ SRAM1_END,  0x06000 },          /* inaccessible */
+#endif
 		{ SRAM_START, 0xf7f00 },          /* cached SRAM */
 		{ SRAM_END,   0x06000 },          /* inaccessible */
 		{ DRAM_START, 0xf7f00 },          /* cached DRAM */

--- a/soc/mediatek/mt8xxx/soc.h
+++ b/soc/mediatek/mt8xxx/soc.h
@@ -26,4 +26,12 @@ void mtk_adsp_mbox_set_handler(const struct device *mbox, uint32_t chan,
 /* Signal an interrupt on the specified channel for the other side */
 void mtk_adsp_mbox_signal(const struct device *mbox, uint32_t chan);
 
+typedef void (*mtk_adsp_ipi_handler_t)(const struct device *ipi, void *arg);
+
+void mtk_adsp_ipi_set_handler(const struct device *ipi, uint32_t chan,
+			       mtk_adsp_ipi_handler_t handler, void *arg);
+
+/* Signal an interrupt on the specified channel for the other side */
+void mtk_adsp_ipi_signal(const struct device *ipi, uint32_t chan);
+
 #endif /* ZEPHYR_SOC_MTK_SOC_H */

--- a/soc/mediatek/mt8xxx/soc.yml
+++ b/soc/mediatek/mt8xxx/soc.yml
@@ -19,3 +19,8 @@ family:
           - name: mt8196
             cpuclusters:
               - name: adsp
+      - name: mt8365
+        socs:
+          - name: mt8365
+            cpuclusters:
+              - name: adsp

--- a/west.yml
+++ b/west.yml
@@ -280,7 +280,7 @@ manifest:
       groups:
         - hal
     - name: hal_xtensa
-      revision: 3cc9e3a9360be5c96c956dce84064b85439b6769
+      revision: 0495a1afd300b644d3ec8dd2c3bd11007e69a892
       path: modules/hal/xtensa
       groups:
         - hal


### PR DESCRIPTION
Add Zephyr support for Mediatek MT8365 platform. This MR depends on [https://github.com/zephyrproject-rtos/hal_xtensa/pull/36](https://github.com/zephyrproject-rtos/hal_xtensa/pull/36), so  `west.yml` has to be updated accordingly.