### PR TITLE
kernel: Add more debug info and thread checking in run queue

### DIFF
--- a/boards/arm/mps2/Kconfig.defconfig
+++ b/boards/arm/mps2/Kconfig.defconfig
@@ -14,6 +14,9 @@ endif # SERIAL
 config ZTEST_STACK_SIZE
 	default 4096 if ZTEST
 
+config ISR_STACK_SIZE
+	default 4096
+
 if COVERAGE_GCOV
 
 config MAIN_STACK_SIZE
@@ -23,9 +26,6 @@ config IDLE_STACK_SIZE
 	default 4096
 
 config PRIVILEGED_STACK_SIZE
-	default 4096
-
-config ISR_STACK_SIZE
 	default 4096
 
 config TEST_EXTRA_STACK_SIZE

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -77,6 +77,7 @@ static ALWAYS_INLINE void *curr_cpu_runq(void)
 static ALWAYS_INLINE void runq_add(struct k_thread *thread)
 {
 	__ASSERT_NO_MSG(!z_is_idle_thread_object(thread));
+	__ASSERT_NO_MSG(!is_thread_dummy(thread));
 
 	_priq_run_add(thread_runq(thread), thread);
 }
@@ -84,6 +85,7 @@ static ALWAYS_INLINE void runq_add(struct k_thread *thread)
 static ALWAYS_INLINE void runq_remove(struct k_thread *thread)
 {
 	__ASSERT_NO_MSG(!z_is_idle_thread_object(thread));
+	__ASSERT_NO_MSG(!is_thread_dummy(thread));
 
 	_priq_run_remove(thread_runq(thread), thread);
 }
@@ -755,6 +757,9 @@ void z_reschedule_irqlock(uint32_t key)
 
 void k_sched_lock(void)
 {
+	LOG_DBG("scheduler locked (%p:%d)",
+		_current, _current->base.sched_locked);
+
 	K_SPINLOCK(&_sched_spinlock) {
 		SYS_PORT_TRACING_FUNC(k_thread, sched_lock);
 


### PR DESCRIPTION
The first patch fix the mps2/an385 stack overflow issue, finding at next patch.
The second patch add some debug information to kernel.

The information before apply first patch.
```
Running TESTSUITE arm_user_stack_test
===================================================================
START - test_arm_user_stack_corruption
Call low_fn from user
Call hi_fn from user
Call attack_entry from kernel
--- ARM Core Registers Snapshot ---
R0:  0x20001454   R1:  0x0000affc
R2:  0x00000000   R3:  0x00009af5
SP:  0x20000a10
LR:  0x00000c09
PC:  0x00009472
PSR: 0x60000000
CONTROL: 0x00000002
-----------------------------------
Changed the kernel_secret so marking test as failed
 FAIL - test_arm_user_stack_corruption in 0.222 seconds
===================================================================
TESTSUITE arm_user_stack_test failed.

```