### PR TITLE
soc: nordic: common: dmm: Fix allocation algorithm

### DIFF
--- a/tests/boards/nrf/dmm/src/main.c
+++ b/tests/boards/nrf/dmm/src/main.c
@@ -522,6 +522,10 @@ static void stress_allocator(void *mem_reg, bool cached)
 	int rv;
 	uint32_t curr_use;
 
+	if (mem_reg == NULL) {
+		ztest_test_skip();
+	}
+
 	memset(&ctx, 0, sizeof(ctx));
 	ctx.mem_reg = mem_reg;
 	ctx.cached = cached;


### PR DESCRIPTION
There were some corner cases and stress test could fail. Reworking tail bits handling to make the stress test pass.

Fixes  #96835.