### PR TITLE
drivers: udc_dwc2: Optimize Completer/DMA mode check

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -132,18 +132,65 @@ static void dwc2_wait_for_bit(const struct device *dev,
 	}
 }
 
+#define DWC2_SUPPORTS_DMA(node, operator)					\
+	(usb_dwc2_get_ghwcfg2_otgarch(DT_PROP(node, ghwcfg2)) ==		\
+	 USB_DWC2_GHWCFG2_OTGARCH_INTERNALDMA) operator
+
+#define ALL_INSTANCES_SUPPORT_BUFFER_DMA					\
+	(DT_FOREACH_STATUS_OKAY_VARGS(DT_DRV_COMPAT, DWC2_SUPPORTS_DMA, &&) 1)
+
+#define ANY_INSTANCE_SUPPORTS_BUFFER_DMA					\
+	(DT_FOREACH_STATUS_OKAY_VARGS(DT_DRV_COMPAT, DWC2_SUPPORTS_DMA, ||) 0)
+
+#define DWC2_DRIVER_SUPPORTS_COMPLETER_MODE					\
+	(!IS_ENABLED(CONFIG_UDC_DWC2_DMA) || !ALL_INSTANCES_SUPPORT_BUFFER_DMA)
+
 static inline bool dwc2_in_completer_mode(const struct device *dev)
 {
 	struct udc_dwc2_data *const priv = udc_get_private(dev);
 
-	return !IS_ENABLED(CONFIG_UDC_DWC2_DMA) || !priv->bufferdma;
+	if (!IS_ENABLED(CONFIG_UDC_DWC2_DMA)) {
+		/* Completer mode is the only supported mode */
+		return true;
+	}
+
+	if (ALL_INSTANCES_SUPPORT_BUFFER_DMA) {
+		/* All instances support Buffer DMA and it is compiled, which
+		 * means that compiler can optimize away Completer mode support.
+		 */
+		return false;
+	}
+
+	if (!ANY_INSTANCE_SUPPORTS_BUFFER_DMA) {
+		/* DMA Kconfig was enabled, but there is no instance that can
+		 * use it. Completer mode will be used on all instances.
+		 */
+		return true;
+	}
+
+	return !priv->bufferdma;
 }
 
 static inline bool dwc2_in_buffer_dma_mode(const struct device *dev)
 {
 	struct udc_dwc2_data *const priv = udc_get_private(dev);
 
-	return IS_ENABLED(CONFIG_UDC_DWC2_DMA) && priv->bufferdma;
+	if (!IS_ENABLED(CONFIG_UDC_DWC2_DMA)) {
+		/* Buffer DMA support not compiled */
+		return false;
+	}
+
+	if (ALL_INSTANCES_SUPPORT_BUFFER_DMA) {
+		/* Buffer DMA is used by all instances */
+		return true;
+	}
+
+	if (!ANY_INSTANCE_SUPPORTS_BUFFER_DMA) {
+		/* Buffer DMA is not supported by any instance */
+		return false;
+	}
+
+	return priv->bufferdma;
 }
 
 /* Get DOEPCTLn or DIEPCTLn register address */
@@ -2928,7 +2975,8 @@ static void udc_dwc2_isr_handler(const struct device *dev)
 			dwc2_handle_iepint(dev);
 		}
 
-		if (int_status & USB_DWC2_GINTSTS_RXFLVL) {
+		if (DWC2_DRIVER_SUPPORTS_COMPLETER_MODE &&
+		    int_status & USB_DWC2_GINTSTS_RXFLVL) {
 			/* Handle RxFIFO Non-Empty interrupt */
 			dwc2_handle_rxflvl(dev);
 		}

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -791,6 +791,7 @@ static int dwc2_handle_evt_din(const struct device *dev,
 
 static void dwc2_backup_registers(const struct device *dev)
 {
+	const struct udc_dwc2_config *const config = dev->config;
 	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
 	struct udc_dwc2_data *const priv = udc_get_private(dev);
 	struct dwc2_reg_backup *backup = &priv->backup;
@@ -816,7 +817,7 @@ static void dwc2_backup_registers(const struct device *dev)
 	backup->daintmsk = sys_read32((mem_addr_t)&base->daintmsk);
 
 	for (uint8_t i = 0U; i < 16; i++) {
-		uint32_t epdir = usb_dwc2_get_ghwcfg1_epdir(priv->ghwcfg1, i);
+		uint32_t epdir = usb_dwc2_get_ghwcfg1_epdir(config->ghwcfg1, i);
 
 		if (epdir == USB_DWC2_GHWCFG1_EPDIR_IN || epdir == USB_DWC2_GHWCFG1_EPDIR_BDIR) {
 			backup->diepctl[i] = sys_read32((mem_addr_t)&base->in_ep[i].diepctl);
@@ -901,6 +902,7 @@ static void dwc2_restore_essential_registers(const struct device *dev,
 
 static void dwc2_restore_device_registers(const struct device *dev, bool rwup)
 {
+	const struct udc_dwc2_config *const config = dev->config;
 	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
 	struct udc_dwc2_data *const priv = udc_get_private(dev);
 	struct dwc2_reg_backup *backup = &priv->backup;
@@ -926,7 +928,7 @@ static void dwc2_restore_device_registers(const struct device *dev, bool rwup)
 	sys_write32(backup->daintmsk, (mem_addr_t)&base->daintmsk);
 
 	for (uint8_t i = 0U; i < 16; i++) {
-		uint32_t epdir = usb_dwc2_get_ghwcfg1_epdir(priv->ghwcfg1, i);
+		uint32_t epdir = usb_dwc2_get_ghwcfg1_epdir(config->ghwcfg1, i);
 
 		if (epdir == USB_DWC2_GHWCFG1_EPDIR_IN || epdir == USB_DWC2_GHWCFG1_EPDIR_BDIR) {
 			sys_write32(backup->dieptsiz[i], (mem_addr_t)&base->in_ep[i].dieptsiz);
@@ -1722,6 +1724,7 @@ static int dwc2_core_soft_reset(const struct device *dev)
 
 static int udc_dwc2_init_controller(const struct device *dev)
 {
+	const struct udc_dwc2_config *const config = dev->config;
 	struct udc_dwc2_data *const priv = udc_get_private(dev);
 	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
 	mem_addr_t grxfsiz_reg = (mem_addr_t)&base->grxfsiz;
@@ -1735,9 +1738,7 @@ static int udc_dwc2_init_controller(const struct device *dev)
 	uint32_t gusbcfg;
 	uint32_t gahbcfg;
 	uint32_t gintmsk;
-	uint32_t ghwcfg2;
 	uint32_t ghwcfg3;
-	uint32_t ghwcfg4;
 	uint32_t val;
 	int ret;
 	bool hs_phy;
@@ -1751,12 +1752,22 @@ static int udc_dwc2_init_controller(const struct device *dev)
 	gsnpsid = sys_read32((mem_addr_t)&base->gsnpsid);
 	priv->wa_essregrestored = gsnpsid < USB_DWC2_GSNPSID_REV_5_00A;
 
-	priv->ghwcfg1 = sys_read32((mem_addr_t)&base->ghwcfg1);
-	ghwcfg2 = sys_read32((mem_addr_t)&base->ghwcfg2);
 	ghwcfg3 = sys_read32((mem_addr_t)&base->ghwcfg3);
-	ghwcfg4 = sys_read32((mem_addr_t)&base->ghwcfg4);
 
-	if (!(ghwcfg4 & USB_DWC2_GHWCFG4_DEDFIFOMODE)) {
+	__ASSERT_EVAL(, val = sys_read32((mem_addr_t)&base->ghwcfg1),
+		      val == config->ghwcfg1,
+		      "DT GHWCFG1 value 0x%08x does not match hardware 0x%08x",
+		      config->ghwcfg2, val);
+	__ASSERT_EVAL(, val = sys_read32((mem_addr_t)&base->ghwcfg2),
+		      val == config->ghwcfg2,
+		      "DT GHWCFG2 value 0x%08x does not match hardware 0x%08x",
+		      config->ghwcfg2, val);
+	__ASSERT_EVAL(, val = sys_read32((mem_addr_t)&base->ghwcfg4),
+		      val == config->ghwcfg4,
+		      "DT GHWCFG4 value 0x%08x does not match hardware 0x%08x",
+		      config->ghwcfg4, val);
+
+	if (!(config->ghwcfg4 & USB_DWC2_GHWCFG4_DEDFIFOMODE)) {
 		LOG_ERR("Only dedicated TX FIFO mode is supported");
 		return -ENOTSUP;
 	}
@@ -1772,7 +1783,7 @@ static int udc_dwc2_init_controller(const struct device *dev)
 	/* Buffer DMA is always supported in Internal DMA mode.
 	 * TODO: check and support descriptor DMA if available
 	 */
-	priv->bufferdma = (usb_dwc2_get_ghwcfg2_otgarch(ghwcfg2) ==
+	priv->bufferdma = (usb_dwc2_get_ghwcfg2_otgarch(config->ghwcfg2) ==
 			   USB_DWC2_GHWCFG2_OTGARCH_INTERNALDMA);
 
 	if (!IS_ENABLED(CONFIG_UDC_DWC2_DMA)) {
@@ -1781,13 +1792,13 @@ static int udc_dwc2_init_controller(const struct device *dev)
 		LOG_WRN("Experimental DMA enabled");
 	}
 
-	if (ghwcfg2 & USB_DWC2_GHWCFG2_DYNFIFOSIZING) {
+	if (config->ghwcfg2 & USB_DWC2_GHWCFG2_DYNFIFOSIZING) {
 		LOG_DBG("Dynamic FIFO Sizing is enabled");
 		priv->dynfifosizing = true;
 	}
 
 	if (IS_ENABLED(CONFIG_UDC_DWC2_HIBERNATION) &&
-	    ghwcfg4 & USB_DWC2_GHWCFG4_HIBERNATION) {
+	    config->ghwcfg4 & USB_DWC2_GHWCFG4_HIBERNATION) {
 		LOG_INF("Hibernation enabled");
 		priv->suspend_type = DWC2_SUSPEND_HIBERNATION;
 	} else {
@@ -1795,19 +1806,19 @@ static int udc_dwc2_init_controller(const struct device *dev)
 	}
 
 	/* Get the number or endpoints and IN endpoints we can use later */
-	priv->numdeveps = usb_dwc2_get_ghwcfg2_numdeveps(ghwcfg2) + 1U;
-	priv->ineps = usb_dwc2_get_ghwcfg4_ineps(ghwcfg4) + 1U;
+	priv->numdeveps = usb_dwc2_get_ghwcfg2_numdeveps(config->ghwcfg2) + 1U;
+	priv->ineps = usb_dwc2_get_ghwcfg4_ineps(config->ghwcfg4) + 1U;
 	LOG_DBG("Number of endpoints (NUMDEVEPS + 1) %u", priv->numdeveps);
 	LOG_DBG("Number of IN endpoints (INEPS + 1) %u", priv->ineps);
 
 	LOG_DBG("Number of periodic IN endpoints (NUMDEVPERIOEPS) %u",
-		usb_dwc2_get_ghwcfg4_numdevperioeps(ghwcfg4));
+		usb_dwc2_get_ghwcfg4_numdevperioeps(config->ghwcfg4));
 	LOG_DBG("Number of additional control endpoints (NUMCTLEPS) %u",
-		usb_dwc2_get_ghwcfg4_numctleps(ghwcfg4));
+		usb_dwc2_get_ghwcfg4_numctleps(config->ghwcfg4));
 
 	LOG_DBG("OTG architecture (OTGARCH) %u, mode (OTGMODE) %u",
-		usb_dwc2_get_ghwcfg2_otgarch(ghwcfg2),
-		usb_dwc2_get_ghwcfg2_otgmode(ghwcfg2));
+		usb_dwc2_get_ghwcfg2_otgarch(config->ghwcfg2),
+		usb_dwc2_get_ghwcfg2_otgmode(config->ghwcfg2));
 
 	priv->dfifodepth = usb_dwc2_get_ghwcfg3_dfifodepth(ghwcfg3);
 	LOG_DBG("DFIFO depth (DFIFODEPTH) %u bytes", priv->dfifodepth * 4);
@@ -1821,9 +1832,9 @@ static int udc_dwc2_init_controller(const struct device *dev)
 		(ghwcfg3 & USB_DWC2_GHWCFG3_VNDCTLSUPT) ? "true" : "false");
 
 	LOG_DBG("PHY interface type: FSPHYTYPE %u, HSPHYTYPE %u, DATAWIDTH %u",
-		usb_dwc2_get_ghwcfg2_fsphytype(ghwcfg2),
-		usb_dwc2_get_ghwcfg2_hsphytype(ghwcfg2),
-		usb_dwc2_get_ghwcfg4_phydatawidth(ghwcfg4));
+		usb_dwc2_get_ghwcfg2_fsphytype(config->ghwcfg2),
+		usb_dwc2_get_ghwcfg2_hsphytype(config->ghwcfg2),
+		usb_dwc2_get_ghwcfg4_phydatawidth(config->ghwcfg4));
 
 	LOG_DBG("LPM mode is %s",
 		(ghwcfg3 & USB_DWC2_GHWCFG3_LPMMODE) ? "enabled" : "disabled");
@@ -1849,7 +1860,7 @@ static int udc_dwc2_init_controller(const struct device *dev)
 
 	/* Configure PHY and device speed */
 	dcfg &= ~USB_DWC2_DCFG_DEVSPD_MASK;
-	switch (usb_dwc2_get_ghwcfg2_hsphytype(ghwcfg2)) {
+	switch (usb_dwc2_get_ghwcfg2_hsphytype(config->ghwcfg2)) {
 	case USB_DWC2_GHWCFG2_HSPHYTYPE_UTMIPLUSULPI:
 		__fallthrough;
 	case USB_DWC2_GHWCFG2_HSPHYTYPE_ULPI:
@@ -1875,7 +1886,7 @@ static int udc_dwc2_init_controller(const struct device *dev)
 	case USB_DWC2_GHWCFG2_HSPHYTYPE_NO_HS:
 		__fallthrough;
 	default:
-		if (usb_dwc2_get_ghwcfg2_fsphytype(ghwcfg2) !=
+		if (usb_dwc2_get_ghwcfg2_fsphytype(config->ghwcfg2) !=
 		    USB_DWC2_GHWCFG2_FSPHYTYPE_NO_FS) {
 			gusbcfg |= USB_DWC2_GUSBCFG_PHYSEL_USB11;
 		}
@@ -1884,7 +1895,7 @@ static int udc_dwc2_init_controller(const struct device *dev)
 		hs_phy = false;
 	}
 
-	if (usb_dwc2_get_ghwcfg4_phydatawidth(ghwcfg4)) {
+	if (usb_dwc2_get_ghwcfg4_phydatawidth(config->ghwcfg4)) {
 		gusbcfg |= USB_DWC2_GUSBCFG_PHYIF_16_BIT;
 	}
 
@@ -1901,7 +1912,7 @@ static int udc_dwc2_init_controller(const struct device *dev)
 
 	priv->outeps = 0U;
 	for (uint8_t i = 0U; i < priv->numdeveps; i++) {
-		uint32_t epdir = usb_dwc2_get_ghwcfg1_epdir(priv->ghwcfg1, i);
+		uint32_t epdir = usb_dwc2_get_ghwcfg1_epdir(config->ghwcfg1, i);
 
 		if (epdir == USB_DWC2_GHWCFG1_EPDIR_OUT ||
 		    epdir == USB_DWC2_GHWCFG1_EPDIR_BDIR) {
@@ -2256,6 +2267,7 @@ static void udc_dwc2_unlock(const struct device *dev)
 
 static void dwc2_on_bus_reset(const struct device *dev)
 {
+	const struct udc_dwc2_config *config = dev->config;
 	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
 	struct udc_dwc2_data *const priv = udc_get_private(dev);
 	uint32_t doepmsk;
@@ -2263,7 +2275,7 @@ static void dwc2_on_bus_reset(const struct device *dev)
 
 	/* Set the NAK bit for all OUT endpoints */
 	for (uint8_t i = 0U; i < priv->numdeveps; i++) {
-		uint32_t epdir = usb_dwc2_get_ghwcfg1_epdir(priv->ghwcfg1, i);
+		uint32_t epdir = usb_dwc2_get_ghwcfg1_epdir(config->ghwcfg1, i);
 		mem_addr_t doepctl_reg;
 
 		LOG_DBG("ep 0x%02x EPDIR %u", i, epdir);

--- a/drivers/usb/udc/udc_dwc2.h
+++ b/drivers/usb/udc/udc_dwc2.h
@@ -88,7 +88,6 @@ struct udc_dwc2_data {
 	/* Finished transactions (IN on bits 0-15, OUT on bits 16-31) */
 	atomic_t xfer_finished;
 	struct dwc2_reg_backup backup;
-	uint32_t ghwcfg1;
 	uint32_t max_xfersize;
 	uint32_t max_pktcnt;
 	uint32_t tx_len[16];


### PR DESCRIPTION
Allow compiler to optimize away Completer and/or Buffer DMA mode check when all instances are known to use one of the modes. The optimization depends on devicetree ghwcfg2 value being valid, so add assert to verify ghwcfg2 devicetree value against hardware.