### PR TITLE
cmake: add net_socket_service_desc to common-rom.cmake

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -234,6 +234,13 @@ if (CONFIG_NET_MGMT)
   zephyr_iterable_section(NAME net_mgmt_event_static_handler KVMA RAM_REGION GROUP RODATA_REGION)
 endif()
 
+if(CONFIG_NET_SOCKETS_SERVICE)
+  zephyr_iterable_section(NAME net_socket_service_desc
+                          KVMA RAM_REGION GROUP RODATA_REGION
+                          SUBALIGN ${CONFIG_LINKER_ITERABLE_SUBALIGN}
+  )
+endif()
+
 if(CONFIG_INPUT)
   zephyr_iterable_section(NAME input_callback KVMA RAM_REGION GROUP RODATA_REGION)
 endif()


### PR DESCRIPTION
Commit eff5d028728ccc8291f9d83a724517288e940435 added `net_socket_service_desc` to common-rom ld snippet but not to common-rom CMake linker generator equivalent.

Bring common-rom.cmake up-to-date to ensure `net_socket_service_desc` works correctly with the linker generator.