### PR TITLE
tests: build_all: led_strip: split uart test case

### DIFF
--- a/drivers/led_strip/Kconfig.ws2812
+++ b/drivers/led_strip/Kconfig.ws2812
@@ -34,7 +34,6 @@ config WS2812_STRIP_UART
 	depends on DT_HAS_WORLDSEMI_WS2812_UART_ENABLED
 	select SERIAL if $(dt_compat_on_bus,$(DT_COMPAT_WORLDSEMI_WS2812_UART),uart)
 	select UART_ASYNC_API
-	select SERIAL_SUPPORT_ASYNC
 	help
 	  Enable driver for WS2812 (and compatible) LED strips using UART.
 	  This method requires a high-speed UART and carefully crafted

--- a/tests/drivers/build_all/led_strip/app.overlay
+++ b/tests/drivers/build_all/led_strip/app.overlay
@@ -84,29 +84,5 @@
 				spi-zero-frame = <2>;
 			};
 		};
-
-		test_uart: uart@55556666 {
-			compatible = "vnd,serial";
-			reg = <0x55556666 0x100>;
-			status = "okay";
-			current-speed = <2500000>;
-			data-bits = <7>;
-			tx-invert;
-
-			test_ws2812_uart: ws2812-strip {
-				compatible = "worldsemi,ws2812-uart";
-				status = "okay";
-
-				one-symbol = <6>;   /* 0b110 */
-				zero-symbol = <4>;  /* 0b100 */
-				bits-per-symbol = <3>;
-
-				chain-length = <8>;
-				reset-delay = <50>;
-				color-mapping = <LED_COLOR_ID_GREEN
-						 LED_COLOR_ID_RED
-						 LED_COLOR_ID_BLUE>;
-			};
-		};
 	};
 };

--- a/tests/drivers/build_all/led_strip/testcase.yaml
+++ b/tests/drivers/build_all/led_strip/testcase.yaml
@@ -1,13 +1,21 @@
+common:
+  build_only: true
+  min_ram: 32
+  tags:
+    - drivers
+    - led_strip
 tests:
   drivers.led_strip.build:
-    build_only: true
-    min_ram: 32
-    tags:
-      - drivers
-      - led_strip
     depends_on:
       - gpio
       - spi
+  drivers.led_strip.build.uart:
+    depends_on:
+      - gpio
+      - uart
+    filter: not CONFIG_SERIAL_SUPPORT_ASYNC
+    extra_args:
+      - DTC_OVERLAY_FILE="uart.overlay"
   drivers.led_strip.build.rpi_pico_pio:
-    build_only: true
-    platform_allow: rpi_pico
+    platform_allow:
+      - rpi_pico

--- a/tests/drivers/build_all/led_strip/uart.overlay
+++ b/tests/drivers/build_all/led_strip/uart.overlay
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, Linaro Ltd.
+ * Copyright (c) 2022, Esco Medical ApS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Application overlay for testing driver builds
+ *
+ * Names in this file should be chosen in a way that won't conflict
+ * with real-world devicetree nodes, to allow these tests to run on
+ * (and be extended to test) real hardware.
+ */
+
+#include <freq.h>
+#include <zephyr/dt-bindings/led/led.h>
+
+/ {
+	test {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		test_uart: uart@55556666 {
+			compatible = "vnd,serial";
+			reg = <0x55556666 0x100>;
+			status = "okay";
+			current-speed = <2500000>;
+			data-bits = <7>;
+			tx-invert;
+
+			test_ws2812_uart: ws2812-strip {
+				compatible = "worldsemi,ws2812-uart";
+				status = "okay";
+
+				one-symbol = <6>;   /* 0b110 */
+				zero-symbol = <4>;  /* 0b100 */
+				bits-per-symbol = <3>;
+
+				chain-length = <8>;
+				reset-delay = <50>;
+				color-mapping = <LED_COLOR_ID_GREEN
+						 LED_COLOR_ID_RED
+						 LED_COLOR_ID_BLUE>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Make sure this test filters out UART peripherals that do not support ASYNC operation.

This is needed after #95174.