### PR TITLE
Bluetooth: Audio: Add test for ASSERT=n

### DIFF
--- a/subsys/bluetooth/audio/cap_handover.c
+++ b/subsys/bluetooth/audio/cap_handover.c
@@ -23,6 +23,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "bap_endpoint.h"
 #include "cap_internal.h"
@@ -146,7 +147,7 @@ void bt_cap_handover_broadcast_source_stopped(uint8_t reason)
 	if (proc_param->is_unicast_to_broadcast) {
 		LOG_DBG("Unexpected broadcast source stop with reason 0x%02x", reason);
 
-		const int err = bt_cap_initiator_broadcast_audio_delete(
+		__maybe_unused const int err = bt_cap_initiator_broadcast_audio_delete(
 			proc_param->unicast_to_broadcast.broadcast_source);
 
 		__ASSERT_NO_MSG(err == 0);

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -445,3 +445,9 @@ tests:
     extra_configs:
       - CONFIG_BT_CCP_CALL_CONTROL_SERVER=n
     tags: bluetooth
+  bluetooth.shell.audio.no_assert:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    extra_configs:
+      - CONFIG_ASSERT=n
+    tags: bluetooth


### PR DESCRIPTION
Add a test in the BT shell with audio that disables asserts.
Fixed a warning found by this. 