### PR TITLE
manifest: Update hal_silabs to include wiseconnect 3.5.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -240,7 +240,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 764d9153c69178bc851625d5a6a15fde237e626a
+      revision: 37f989015ee6cb178957f8b154fd14f760456b29
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
hal_silabs now includes the last version (3.5.2) of WiseConnect, the downstream SDK for Silicon Labs SiWx91x series.