### PR TITLE
SPI: Fix deprecated API usage leftovers from #87427

### DIFF
--- a/drivers/display/display_lpm013m126.c
+++ b/drivers/display/display_lpm013m126.c
@@ -254,7 +254,7 @@ static const struct display_driver_api lpm_api = {
 	static const struct lpm013m126_config lpm_cfg_##inst = {		\
 		.bus = SPI_DT_SPEC_INST_GET(inst, SPI_OP_MODE_MASTER |		\
 					    SPI_WORD_SET(8) |			\
-					    SPI_TRANSFER_MSB, 0),		\
+					    SPI_TRANSFER_MSB),			\
 		.disp_gpio = GPIO_DT_SPEC_INST_GET(inst, disp_gpios),		\
 		.extcomin_gpio = GPIO_DT_SPEC_INST_GET(inst, extcomin_gpios),	\
 		.extcomin_freq = DT_INST_PROP(inst, extcomin_frequency),	\

--- a/drivers/gpio/gpio_pcal9722.c
+++ b/drivers/gpio/gpio_pcal9722.c
@@ -468,7 +468,7 @@ static DEVICE_API(gpio, api_table) = {
 
 #define GPIO_PCAL9722_INIT(n)                                                                      \
 	static const struct pcal9722_config pcal9722_cfg_##n = {                                   \
-		.spi = SPI_DT_SPEC_INST_GET(n, SPI_OP_MODE_MASTER | SPI_WORD_SET(8), 0),           \
+		.spi = SPI_DT_SPEC_INST_GET(n, SPI_OP_MODE_MASTER | SPI_WORD_SET(8)),              \
 		.common =                                                                          \
 			{                                                                          \
 				.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),               \

--- a/drivers/sensor/pni/rm3100/rm3100.c
+++ b/drivers/sensor/pni/rm3100/rm3100.c
@@ -230,8 +230,7 @@ static int rm3100_init(const struct device *dev)
 	COND_CODE_1(DT_INST_ON_BUS(inst, spi),							   \
 		    (SPI_DT_IODEV_DEFINE(rm3100_bus_##inst,					   \
 					 DT_DRV_INST(inst),					   \
-					 SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_TRANSFER_MSB,  \
-					 0U)),							   \
+					 SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_TRANSFER_MSB)),\
 		    ());									   \
 												   \
 	static const struct rm3100_config rm3100_cfg_##inst = {					   \

--- a/drivers/sensor/st/iis3dwb/iis3dwb.c
+++ b/drivers/sensor/st/iis3dwb/iis3dwb.c
@@ -360,8 +360,7 @@ static int iis3dwb_init(const struct device *dev)
 	{										\
 		STMEMSC_CTX_SPI(&iis3dwb_config_##inst.stmemsc_cfg),			\
 		.stmemsc_cfg = {							\
-			.spi = SPI_DT_SPEC_INST_GET(inst,				\
-				IIS3DWB_SPI_OPERATION, 0),				\
+			.spi = SPI_DT_SPEC_INST_GET(inst, IIS3DWB_SPI_OPERATION),	\
 		},									\
 											\
 		.range = DT_INST_PROP(inst, range),					\

--- a/drivers/sensor/st/iis3dwb/iis3dwb.c
+++ b/drivers/sensor/st/iis3dwb/iis3dwb.c
@@ -342,7 +342,7 @@ static int iis3dwb_init(const struct device *dev)
 
 #define IIS3DWB_SPI_RTIO_DEFINE(inst)					\
 	SPI_DT_IODEV_DEFINE(iis3dwb_iodev_##inst,			\
-		DT_DRV_INST(inst), IIS3DWB_SPI_OPERATION, 0U);		\
+		DT_DRV_INST(inst), IIS3DWB_SPI_OPERATION);		\
 	RTIO_DEFINE(iis3dwb_rtio_ctx_##inst, 8, 8);
 
 #ifdef CONFIG_IIS3DWB_TRIGGER

--- a/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001.c
+++ b/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001.c
@@ -900,7 +900,7 @@ static int isds_2536030320001_init(const struct device *dev)
 #define ISDS_2536030320001_CONFIG_SPI(inst)                                                        \
 	{.bus_cfg =                                                                                \
 		 {                                                                                 \
-			 .spi = SPI_DT_SPEC_INST_GET(inst, ISDS_2536030320001_SPI_OPERATION, 0),   \
+			 .spi = SPI_DT_SPEC_INST_GET(inst, ISDS_2536030320001_SPI_OPERATION),      \
 		 },                                                                                \
 	 ISDS_2536030320001_CONFIG_COMMON(inst)}
 

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -1361,9 +1361,9 @@ extern const struct rtio_iodev_api spi_iodev_api;
  * @param node_id Devicetree node identifier
  * @param operation_ SPI operational mode
  */
-#define SPI_DT_IODEV_DEFINE(name, node_id, operation_)				\
+#define SPI_DT_IODEV_DEFINE(name, node_id, operation_, ...)			\
 	const struct spi_dt_spec _spi_dt_spec_##name =				\
-		SPI_DT_SPEC_GET(node_id, operation_);				\
+		SPI_DT_SPEC_GET(node_id, operation_, __VA_ARGS__);		\
 	RTIO_IODEV_DEFINE(name, &spi_iodev_api, (void *)&_spi_dt_spec_##name)
 
 /**


### PR DESCRIPTION
#87427 caused some [CI failures in main](https://github.com/zephyrproject-rtos/zephyr/actions/runs/18160982496/job/51691443328) due some drivers still using the SPI macros in a deprecated way, and actually `SPI_DT_IODEV_DEFINE()` not having the deprecation warning support. This PR tries to address both issues.