### PR TITLE
net: mqtt: Remove misleading comment

### DIFF
--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -763,9 +763,7 @@ struct mqtt_sec_config {
 	uint32_t alpn_protocol_name_count;
 #endif
 
-	/** Peer hostname for ceritificate verification.
-	 *  May be NULL to skip hostname verification.
-	 */
+	/** Peer hostname for certificate verification. */
 	const char *hostname;
 
 	/** Indicates the preference for copying certificates to the heap. */


### PR DESCRIPTION
Setting the peer hostname to NULL does not skip hostname verification. After discussion in the issue it was agreed that it's better to remove this comment than to implement skipping hostname verification.

Also fixed a typo in the remaining part of the comment.

Fixes: #96853