### PR TITLE
dts: arm: silabs: Reformat series 2 devicetree files

### DIFF
--- a/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
@@ -79,6 +79,8 @@
 	pinctrl-names = "default";
 	status = "okay";
 
+	#address-cells = <1>;
+	#size-cells = <0>;
 	cs-gpios = <&gpioc 3 GPIO_ACTIVE_LOW>;
 
 	mx25r80: mx25r8035f@0 {

--- a/dts/arm/silabs/xg22/bgm220pc22hna.dtsi
+++ b/dts/arm/silabs/xg22/bgm220pc22hna.dtsi
@@ -38,6 +38,10 @@
 	status = "okay";
 };
 
+&prortcclk {
+	clocks = <&lfxo>;
+};
+
 &radio {
 	pa-voltage-mv = <1800>;
 };

--- a/dts/arm/silabs/xg22/bgm220sc22hna.dtsi
+++ b/dts/arm/silabs/xg22/bgm220sc22hna.dtsi
@@ -6,18 +6,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <silabs/xg22/efr32bg22.dtsi>
 #include <mem.h>
+#include <silabs/xg22/bgm22.dtsi>
 
 / {
 	soc {
-		compatible = "silabs,bgm220sc22hna", "silabs,efr32bg22", "silabs,xg22",
-			     "silabs,efr32", "simple-bus";
+		compatible = "silabs,bgm220sc22hna", "silabs,bgm22", "silabs,xg22", "silabs,efr32",
+			     "simple-bus";
 	};
 };
 
 &flash0 {
-	reg = <0x0 DT_SIZE_K(512)>;
+	reg = <0x00000000 DT_SIZE_K(512)>;
+};
+
+&hfxo {
+	ctune = <140>;
+	precision = <50>;
+	status = "okay";
+};
+
+&lfrco {
+	precision-mode;
+};
+
+&radio {
+	pa-voltage-mv = <1800>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg22/efr32bg22c222f352gm32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c222f352gm32.dtsi
@@ -5,19 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <silabs/xg22/efr32bg22.dtsi>
 #include <mem.h>
+#include <silabs/xg22/efr32bg22.dtsi>
 
 / {
 	soc {
 		compatible = "silabs,efr32bg22c222f352gm32", "silabs,efr32bg22", "silabs,xg22",
 			     "silabs,efr32", "simple-bus";
-		model = "Silicon Labs EFR32BG22C222F352GM32 SoC";
 	};
 };
 
 &flash0 {
-	reg = <0x0 DT_SIZE_K(352)>;
+	reg = <0x00000000 DT_SIZE_K(352)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg22/efr32bg22c222f352gm40.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c222f352gm40.dtsi
@@ -5,19 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <silabs/xg22/efr32bg22.dtsi>
 #include <mem.h>
+#include <silabs/xg22/efr32bg22.dtsi>
 
 / {
 	soc {
 		compatible = "silabs,efr32bg22c222f352gm40", "silabs,efr32bg22", "silabs,xg22",
 			     "silabs,efr32", "simple-bus";
-		model = "Silicon Labs EFR32BG22C222F352GM40 SoC";
 	};
 };
 
 &flash0 {
-	reg = <0x0 DT_SIZE_K(352)>;
+	reg = <0x00000000 DT_SIZE_K(352)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg22/efr32bg22c222f352gn32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c222f352gn32.dtsi
@@ -5,19 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <silabs/xg22/efr32bg22.dtsi>
 #include <mem.h>
+#include <silabs/xg22/efr32bg22.dtsi>
 
 / {
 	soc {
 		compatible = "silabs,efr32bg22c222f352gn32", "silabs,efr32bg22", "silabs,xg22",
 			     "silabs,efr32", "simple-bus";
-		model = "Silicon Labs EFR32BG22C222F352GN32 SoC";
 	};
 };
 
 &flash0 {
-	reg = <0x0 DT_SIZE_K(352)>;
+	reg = <0x00000000 DT_SIZE_K(352)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg22/efr32bg22c224f512gm32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512gm32.dtsi
@@ -5,19 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <silabs/xg22/efr32bg22.dtsi>
 #include <mem.h>
+#include <silabs/xg22/efr32bg22.dtsi>
 
 / {
 	soc {
 		compatible = "silabs,efr32bg22c224f512gm32", "silabs,efr32bg22", "silabs,xg22",
 			     "silabs,efr32", "simple-bus";
-		model = "Silicon Labs EFR32BG22C224F512GM32 SoC";
 	};
 };
 
 &flash0 {
-	reg = <0x0 DT_SIZE_K(512)>;
+	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg22/efr32bg22c224f512gm40.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512gm40.dtsi
@@ -5,19 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <silabs/xg22/efr32bg22.dtsi>
 #include <mem.h>
+#include <silabs/xg22/efr32bg22.dtsi>
 
 / {
 	soc {
 		compatible = "silabs,efr32bg22c224f512gm40", "silabs,efr32bg22", "silabs,xg22",
 			     "silabs,efr32", "simple-bus";
-		model = "Silicon Labs EFR32BG22C224F512GM40 SoC";
 	};
 };
 
 &flash0 {
-	reg = <0x0 DT_SIZE_K(512)>;
+	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg22/efr32bg22c224f512gn32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512gn32.dtsi
@@ -5,19 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <silabs/xg22/efr32bg22.dtsi>
 #include <mem.h>
+#include <silabs/xg22/efr32bg22.dtsi>
 
 / {
 	soc {
 		compatible = "silabs,efr32bg22c224f512gn32", "silabs,efr32bg22", "silabs,xg22",
 			     "silabs,efr32", "simple-bus";
-		model = "Silicon Labs EFR32BG22C224F512GN32 SoC";
 	};
 };
 
 &flash0 {
-	reg = <0x0 DT_SIZE_K(512)>;
+	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg22/efr32bg22c224f512im32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512im32.dtsi
@@ -5,19 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <silabs/xg22/efr32bg22.dtsi>
 #include <mem.h>
+#include <silabs/xg22/efr32bg22.dtsi>
 
 / {
 	soc {
 		compatible = "silabs,efr32bg22c224f512im32", "silabs,efr32bg22", "silabs,xg22",
 			     "silabs,efr32", "simple-bus";
-		model = "Silicon Labs EFR32BG22C224F512IM32 SoC";
 	};
 };
 
 &flash0 {
-	reg = <0x0 DT_SIZE_K(512)>;
+	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg22/efr32bg22c224f512im40.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512im40.dtsi
@@ -5,19 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <silabs/xg22/efr32bg22.dtsi>
 #include <mem.h>
+#include <silabs/xg22/efr32bg22.dtsi>
 
 / {
 	soc {
 		compatible = "silabs,efr32bg22c224f512im40", "silabs,efr32bg22", "silabs,xg22",
 			     "silabs,efr32", "simple-bus";
-		model = "Silicon Labs EFR32BG22C224F512IM40 SoC";
 	};
 };
 
 &flash0 {
-	reg = <0x0 DT_SIZE_K(512)>;
+	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg22/efr32mg22c224f512gn32.dtsi
+++ b/dts/arm/silabs/xg22/efr32mg22c224f512gn32.dtsi
@@ -5,19 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <silabs/xg22/efr32mg22.dtsi>
 #include <mem.h>
+#include <silabs/xg22/efr32mg22.dtsi>
 
 / {
 	soc {
 		compatible = "silabs,efr32mg22c224f512gn32", "silabs,efr32mg22", "silabs,xg22",
 			     "silabs,efr32", "simple-bus";
-		model = "Silicon Labs EFR32MG22C224F512GN32 SoC";
 	};
 };
 
 &flash0 {
-	reg = <0x0 DT_SIZE_K(512)>;
+	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg22/efr32mg22c224f512im32.dtsi
+++ b/dts/arm/silabs/xg22/efr32mg22c224f512im32.dtsi
@@ -5,19 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <silabs/xg22/efr32mg22.dtsi>
 #include <mem.h>
+#include <silabs/xg22/efr32mg22.dtsi>
 
 / {
 	soc {
 		compatible = "silabs,efr32mg22c224f512im32", "silabs,efr32mg22", "silabs,xg22",
 			     "silabs,efr32", "simple-bus";
-		model = "Silicon Labs EFR32MG22C224F512IM32 SoC";
 	};
 };
 
 &flash0 {
-	reg = <0x0 DT_SIZE_K(512)>;
+	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg22/efr32mg22c224f512im40.dtsi
+++ b/dts/arm/silabs/xg22/efr32mg22c224f512im40.dtsi
@@ -5,19 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <silabs/xg22/efr32mg22.dtsi>
 #include <mem.h>
+#include <silabs/xg22/efr32mg22.dtsi>
 
 / {
 	soc {
 		compatible = "silabs,efr32mg22c224f512im40", "silabs,efr32mg22", "silabs,xg22",
 			     "silabs,efr32", "simple-bus";
-		model = "Silicon Labs EFR32MG22C224F512IM40 SoC";
 	};
 };
 
 &flash0 {
-	reg = <0x0 DT_SIZE_K(512)>;
+	reg = <0x00000000 DT_SIZE_K(512)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg22/efr32xg22.dtsi
+++ b/dts/arm/silabs/xg22/efr32xg22.dtsi
@@ -10,16 +10,16 @@
 	soc {
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
-			reg = <0xb0000000 0x1000000>;
-			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>,
-				     <37 1>, <38 1>, <39 1>, <40 1>, <41 1>, <42 1>;
+			reg = <0xb0000000 0x01000000>;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 					  "rac_rsm", "rac_seq", "rdmailbox", "rfsense", "prortc",
 					  "synth";
+			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>, <37 1>,
+				     <38 1>, <39 1>, <40 1>, <41 1>, <42 1>;
+			pa-2p4ghz = "highest";
 			pa-initial-power-dbm = <10>;
 			pa-ramp-time-us = <2>;
 			pa-voltage-mv = <3300>;
-			pa-2p4ghz = "highest";
 
 			pti: pti {
 				compatible = "silabs,pti";

--- a/dts/arm/silabs/xg22/xg22.dtsi
+++ b/dts/arm/silabs/xg22/xg22.dtsi
@@ -6,118 +6,131 @@
  */
 
 #include <arm/armv8-m.dtsi>
+#include <freq.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/silabs/xg22-clock.h>
 #include <zephyr/dt-bindings/dma/silabs/xg22-dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
-#include <freq.h>
 
 / {
 	chosen {
-		zephyr,flash-controller = &msc;
 		zephyr,entropy = &trng;
+		zephyr,flash-controller = &msc;
 	};
 
 	clocks {
-		sysclk: sysclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfrcodpll>;
-		};
-
-		hclk: hclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&sysclk>;
-			/* Divisors 1, 2, 4, 8, 16 allowed */
-			clock-div = <1>;
-		};
-
-		pclk: pclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-			/* Divisors 1, 2 allowed */
-			clock-div = <2>;
-		};
-
-		lspclk: lspclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&pclk>;
-			/* Fixed divisor of 2 */
-			clock-div = <2>;
-		};
-
-		hclkdiv1024: hclkdiv1024 {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-			/* Fixed divisor of 1024 */
-			clock-div = <1024>;
-		};
-
-		traceclk: traceclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&sysclk>;
-			/* Divisors 1, 2, 3, 4 allowed */
-			clock-div = <1>;
-		};
-
 		em01grpaclk: em01grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hfrcodpll>;
 		};
 
 		em01grpbclk: em01grpbclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hfrcodpll>;
 		};
 
-		iadcclk: iadcclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em01grpaclk>;
-		};
-
 		em23grpaclk: em23grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
 		em4grpaclk: em4grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&lfrco>;
+		};
+
+		euart0clk: euart0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpaclk>;
+		};
+
+		hclk: hclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1>;
+			clocks = <&sysclk>;
+		};
+
+		hclkdiv1024: hclkdiv1024 {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1024>;
+			clocks = <&hclk>;
+		};
+
+		hfrcodpllrt: hfrcodpllrt {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfrcodpll>;
+		};
+
+		hfxort: hfxort {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfxo>;
+		};
+
+		iadcclk: iadcclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpaclk>;
+		};
+
+		lspclk: lspclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clocks = <&pclk>;
+		};
+
+		pclk: pclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clocks = <&hclk>;
+		};
+
+		prortcclk: prortcclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
 		rtccclk: rtccclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
-		wdog0clk: wdog0clk {
-			#clock-cells = <0>;
+		sysclk: sysclk {
 			compatible = "fixed-factor-clock";
-			clocks = <&lfrco>;
+			#clock-cells = <0>;
+			clocks = <&hfrcodpll>;
 		};
 
 		systickclk: systickclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hclk>;
 		};
 
-		euart0clk: euart0clk {
-			#clock-cells = <0>;
+		traceclk: traceclk {
 			compatible = "fixed-factor-clock";
-			clocks = <&em01grpaclk>;
+			#clock-cells = <0>;
+			clock-div = <1>;
+			clocks = <&sysclk>;
+		};
+
+		wdog0clk: wdog0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&lfrco>;
 		};
 	};
 
@@ -126,58 +139,39 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			/*
-			 * EM1 is enabled by default because it is
-			 * unconditionally safe.
-			 *
-			 * EM2/3 can be enabled by the board code if proper
-			 * timing configuration is ensured:
-			 * - for EM2, EM3: BURTC used as sys_clock
-			 * - for EM3: BURTC clocked from ULFRCO
-			 * Using BURTC as sys_clock instead of SysTick
-			 * has implications on system performance. Read
-			 * KConfig documentation entry before enabling it.
-			 *
-			 * The minimum residency and exit latency is
-			 * managed by sl_power_manager on S2 devices.
-			 */
-			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			/*
+			 * The minimum residency and exit latency is managed by sl_power_manager
+			 * on S2 devices.
+			 */
+			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
+			device_type = "cpu";
 
 			itm: itm@e0000000 {
 				compatible = "arm,armv8m-itm";
 				reg = <0xe0000000 0x1000>;
 			};
+
+			mpu: mpu@e000ed90 {
+				compatible = "arm,armv8m-mpu";
+				reg = <0xe000ed90 0x40>;
+			};
 		};
 
 		power-states {
-			/*
-			 * EM1 is a basic "CPU WFI idle", all high-freq clocks remain
-			 * enabled.
-			 */
 			pstate_em1: em1 {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";
-				/* HFXO remains active */
 			};
 
-			/*
-			 * EM2 is a deepsleep with HF clocks disabled by HW, voltages
-			 * scaled down, etc.
-			 */
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
 			};
 
-			/*
-			 * EM4 is a shutdown state where all clocks are off. The device
-			 * is reset on wakeup from EM4.
-			 */
 			pstate_em4: em4 {
 				compatible = "zephyr,power-state";
 				power-state-name = "soft-off";
@@ -186,83 +180,175 @@
 		};
 	};
 
-	sram0: memory@20000000 {
-		compatible = "mmio-sram";
+	hwinfo: hwinfo {
+		compatible = "silabs,series2-hwinfo";
+		status = "disabled";
 	};
 
 	soc {
 		cmu: clock@50008000 {
 			compatible = "silabs,series-clock";
 			reg = <0x50008000 0x4000>;
-			interrupts = <46 2>;
-			interrupt-names = "cmu";
-			status = "okay";
 			#clock-cells = <2>;
-		};
-
-		fsrco: fsrco@50018000 {
-			#clock-cells = <0>;
-			compatible = "fixed-clock";
-			reg = <0x50018000 0x4000>;
-			clock-frequency = <DT_FREQ_M(20)>;
+			interrupt-names = "cmu";
+			interrupts = <46 2>;
+			status = "okay";
 		};
 
 		clk_hfxo: hfxo: hfxo@5000c000 {
-			#clock-cells = <0>;
 			compatible = "silabs,hfxo";
 			reg = <0x5000c000 0x4000>;
+			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_K(38400)>;
-			interrupts = <44 0>;
-			interrupt-names = "hfxo";
+			clocks = <&cmu CLOCK_HFXO0 CLOCK_BRANCH_INVALID>;
 			ctune = <140>;
+			interrupt-names = "hfxo0";
+			interrupts = <44 2>;
 			precision = <50>;
 			status = "disabled";
 		};
 
-		lfxo: lfxo@50020000 {
+		hfrcodpll: hfrcodpll@50010000 {
+			compatible = "silabs,series2-hfrcodpll";
+			reg = <0x50010000 0x4000>;
 			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(19)>;
+			clocks = <&cmu CLOCK_HFRCO0 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "hfrco0";
+			interrupts = <45 2>;
+		};
+
+		fsrco: fsrco@50018000 {
+			compatible = "fixed-clock";
+			reg = <0x50018000 0x4000>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(20)>;
+			clocks = <&cmu CLOCK_FSRCO CLOCK_BRANCH_INVALID>;
+		};
+
+		lfxo: lfxo@50020000 {
 			compatible = "silabs,series2-lfxo";
 			reg = <0x50020000 0x4000>;
+			#clock-cells = <0>;
 			clock-frequency = <32768>;
+			clocks = <&cmu CLOCK_LFXO CLOCK_BRANCH_INVALID>;
 			ctune = <63>;
+			interrupt-names = "lfxo";
+			interrupts = <22 2>;
 			precision = <50>;
 			timeout = <4096>;
 			status = "disabled";
 		};
 
-		hfrcodpll: hfrcodpll@50010000 {
-			#clock-cells = <0>;
-			compatible = "silabs,series2-hfrcodpll";
-			reg = <0x50010000 0x4000>;
-			clock-frequency = <DT_FREQ_M(19)>;
-		};
-
 		lfrco: lfrco@50024000 {
-			#clock-cells = <0>;
 			compatible = "silabs,series2-lfrco";
 			reg = <0x50024000 0x4000>;
+			#clock-cells = <0>;
 			clock-frequency = <32768>;
+			clocks = <&cmu CLOCK_LFRCO CLOCK_BRANCH_INVALID>;
+			interrupt-names = "lfrco";
+			interrupts = <23 2>;
 		};
 
 		ulfrco: ulfrco@50028000 {
-			#clock-cells = <0>;
 			compatible = "fixed-clock";
 			reg = <0x50028000 0x4000>;
+			#clock-cells = <0>;
 			clock-frequency = <1000>;
+			clocks = <&cmu CLOCK_ULFRCO CLOCK_BRANCH_INVALID>;
+			interrupt-names = "ulfrco";
+			interrupts = <24 2>;
 		};
 
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
-			reg = <0x50030000 0xC69>;
-			interrupts = <49 2>;
+			reg = <0x50030000 0x4000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			clocks = <&cmu CLOCK_MSC CLOCK_BRANCH_HCLK>;
+			interrupt-names = "msc";
+			interrupts = <49 2>;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				write-block-size = <4>;
 				erase-block-size = <8192>;
+				write-block-size = <4>;
 			};
+		};
+
+		gpio: gpio@5003c000 {
+			compatible = "silabs,gpio";
+			reg = <0x5003c000 0x4000>;
+			ranges;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
+			interrupt-names = "gpio_odd", "gpio_even";
+			interrupts = <25 2>, <26 2>;
+
+			gpioa: gpio@5003c000 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c000 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <0>;
+				silabs,wakeup-pins = <5>;
+				status = "disabled";
+			};
+
+			gpiob: gpio@5003c030 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c030 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <3>, <4>;
+				silabs,wakeup-pins = <1>, <3>;
+				status = "disabled";
+			};
+
+			gpioc: gpio@5003c060 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c060 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <6>, <7>, <8>;
+				silabs,wakeup-pins = <0>, <5>, <7>;
+				status = "disabled";
+			};
+
+			gpiod: gpio@5003c090 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c090 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <9>;
+				silabs,wakeup-pins = <2>;
+				status = "disabled";
+			};
+		};
+
+		pinctrl: pin-controller@5003c440 {
+			compatible = "silabs,dbus-pinctrl";
+			reg = <0x5003c440 0x0bc0>, <0x5003c320 0x40>;
+			reg-names = "dbus", "abus";
+		};
+
+		clkin0: clkin0@5003c454 {
+			compatible = "fixed-clock";
+			reg = <0x5003c454 0x04>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(38)>;
+		};
+
+		dma0: dma@50040000 {
+			compatible = "silabs,ldma";
+			reg = <0x50040000 0x4000>;
+			#dma-cells = <1>;
+			clocks = <&cmu CLOCK_LDMA0 CLOCK_BRANCH_HCLK>;
+			dma-channels = <8>;
+			interrupt-names = "ldma";
+			interrupts = <21 2>;
+			status = "disabled";
 		};
 
 		timer0: timer@50048000 {
@@ -271,6 +357,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER0 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <32>;
+			interrupt-names = "timer0";
 			interrupts = <7 2>;
 			status = "disabled";
 
@@ -287,6 +374,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER1 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer1";
 			interrupts = <8 2>;
 			status = "disabled";
 
@@ -303,6 +391,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER2 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer2";
 			interrupts = <9 2>;
 			status = "disabled";
 
@@ -319,6 +408,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER3 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer3";
 			interrupts = <10 2>;
 			status = "disabled";
 
@@ -335,6 +425,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER4 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer4";
 			interrupts = <11 2>;
 			status = "disabled";
 
@@ -347,151 +438,60 @@
 
 		usart0: usart@5005c000 {
 			compatible = "silabs,usart-spi";
-			reg = <0x5005C000 0x400>;
-			interrupts = <13 2>, <14 2>;
-			interrupt-names = "rx", "tx";
+			reg = <0x5005c000 0x4000>;
 			clocks = <&cmu CLOCK_USART0 CLOCK_BRANCH_PCLK>;
-			#address-cells = <1>;
-			#size-cells = <0>;
+			interrupt-names = "rx", "tx";
+			interrupts = <13 2>, <14 2>;
 			status = "disabled";
 		};
 
 		usart1: usart@50060000 {
 			compatible = "silabs,usart-uart";
-			reg = <0x50060000 0x400>;
-			interrupts = <15 2>, <16 2>;
-			interrupt-names = "rx", "tx";
+			reg = <0x50060000 0x4000>;
 			clocks = <&cmu CLOCK_USART1 CLOCK_BRANCH_PCLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <15 2>, <16 2>;
 			status = "disabled";
 		};
 
 		burtc0: burtc@50064000 {
 			compatible = "silabs,gecko-burtc";
-			reg = <0x50064000 0x3034>;
-			interrupts = <18 2>;
+			reg = <0x50064000 0x4000>;
 			clocks = <&cmu CLOCK_BURTC CLOCK_BRANCH_EM4GRPACLK>;
-			status = "disabled";
-		};
-
-		rtcc0: stimer0: rtcc@58000000 {
-			compatible = "silabs,gecko-stimer";
-			reg = <0x58000000 0x3054>;
-			interrupts = <12 2>;
-			interrupt-names = "rtcc";
-			clocks = <&cmu CLOCK_RTCC CLOCK_BRANCH_RTCCCLK>;
-			clock-frequency = <32768>;
-			prescaler = <1>;
-			status = "disabled";
-		};
-
-		trng: trng@4c021000 {
-			compatible = "silabs,gecko-trng";
-			reg = <0x4C021000 0x1000>;
-			status = "disabled";
-			interrupts = <0x1 0x2>;
-		};
-
-		i2c0: i2c@5a010000 {
-			compatible = "silabs,i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			reg = <0x5a010000 0x3044>;
-			interrupts = <27 2>;
-			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
-			#address-cells = <1>;
-			#size-cells = <0>;
+			interrupt-names = "burtc";
+			interrupts = <18 2>;
 			status = "disabled";
 		};
 
 		i2c1: i2c@50068000 {
 			compatible = "silabs,i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			reg = <0x50068000 0x3044>;
-			interrupts = <28 2>;
-			clocks = <&cmu CLOCK_I2C1 CLOCK_BRANCH_PCLK>;
+			reg = <0x50068000 0x4000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			clocks = <&cmu CLOCK_I2C1 CLOCK_BRANCH_PCLK>;
+			interrupt-names = "i2c1";
+			interrupts = <28 2>;
 			status = "disabled";
 		};
 
-		gpio: gpio@5003c000 {
-			compatible = "silabs,gpio";
-			reg = <0x5003C000 0x440>;
-			ranges;
-			interrupts = <25 2>, <26 2>;
-			interrupt-names = "gpio_odd", "gpio_even";
-			clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			gpioa: gpio@5003c000 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003C000 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <0>;
-				silabs,wakeup-pins = <5>;
-				status = "disabled";
-			};
-
-			gpiob: gpio@5003c030 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003C030 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <3>, <4>;
-				silabs,wakeup-pins = <1>, <3>;
-				status = "disabled";
-			};
-
-			gpioc: gpio@5003c060 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003C060 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <6>, <7>, <8>;
-				silabs,wakeup-pins = <0>, <5>, <7>;
-				status = "disabled";
-			};
-
-			gpiod: gpio@5003c090 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003C090 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <9>;
-				silabs,wakeup-pins = <2>;
-				status = "disabled";
-			};
-		};
-
-		pinctrl: pin-controller@5003c440 {
-			compatible = "silabs,dbus-pinctrl";
-			reg = <0x5003c440 0xbc0>, <0x5003c320 0x40>;
-			reg-names = "dbus", "abus";
-		};
-
-		clkin0: clkin0@5003c454 {
-			#clock-cells = <0>;
-			compatible = "fixed-clock";
-			reg = <0x5003c454 0x4>;
-			clock-frequency = <DT_FREQ_M(38)>;
-		};
-
-		dma0: dma@40040000 {
-			compatible = "silabs,ldma";
-			reg = <0x40040000 0x4000>;
-			interrupts = <21 0>;
-			#dma-cells = <1>;
-			dma-channels = <8>;
+		dcdc: dcdc@50094000 {
+			compatible = "silabs,series2-dcdc";
+			reg = <0x50094000 0x4000>;
+			clocks = <&cmu CLOCK_DCDC CLOCK_BRANCH_INVALID>;
+			interrupt-names = "dcdc";
+			interrupts = <61 2>;
 			status = "disabled";
 		};
 
-		wdog0: wdog@4a018000 {
-			compatible = "silabs,gecko-wdog";
-			reg = <0x4A018000 0x3028>;
-			interrupts = <43 2>;
-			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
-			peripheral-id = <0>;
+		rtcc0: stimer0: rtcc@58000000 {
+			compatible = "silabs,gecko-stimer";
+			reg = <0x58000000 0x4000>;
+			clock-frequency = <32768>;
+			clocks = <&cmu CLOCK_RTCC CLOCK_BRANCH_RTCCCLK>;
+			interrupt-names = "rtcc";
+			interrupts = <12 2>;
+			prescaler = <1>;
 			status = "disabled";
 		};
 
@@ -499,6 +499,7 @@
 			compatible = "silabs,series2-letimer";
 			reg = <0x5a000000 0x4000>;
 			clocks = <&cmu CLOCK_LETIMER0 CLOCK_BRANCH_EM23GRPACLK>;
+			interrupt-names = "letimer0";
 			interrupts = <19 2>;
 			status = "disabled";
 
@@ -512,16 +513,32 @@
 		adc0: adc@5a004000 {
 			compatible = "silabs,gecko-iadc";
 			reg = <0x5a004000 0x4000>;
-			interrupts = <48 2>;
-			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
-			status = "disabled";
 			#io-channel-cells = <1>;
+			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
+			interrupt-names = "iadc";
+			interrupts = <48 2>;
+			status = "disabled";
 		};
 
-		dcdc: dcdc@50094000 {
-			compatible = "silabs,series2-dcdc";
-			reg = <0x50094000 0x4000>;
-			interrupts = <61 2>;
+		i2c0: i2c@5a010000 {
+			compatible = "silabs,i2c";
+			reg = <0x5a010000 0x4000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
+			interrupt-names = "i2c0";
+			interrupts = <27 2>;
+			status = "disabled";
+		};
+
+		wdog0: wdog@5a018000 {
+			compatible = "silabs,gecko-wdog";
+			reg = <0x5a018000 0x4000>;
+			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
+			interrupt-names = "wdog0";
+			interrupts = <43 2>;
+			peripheral-id = <0>;
 			status = "disabled";
 		};
 
@@ -529,10 +546,22 @@
 			compatible = "silabs,eusart-uart";
 			reg = <0x5a030000 0x4000>;
 			clocks = <&cmu CLOCK_EUART0 CLOCK_BRANCH_EUART0CLK>;
-			interrupt-names = "rx", "tx";
-			interrupts = <62 2>, <63 2>;
 			status = "disabled";
 		};
+
+		trng: cryptoacc@5c020000 {
+			compatible = "silabs,gecko-trng";
+			reg = <0x5c020000 0x4000>;
+			clocks = <&cmu CLOCK_CRYPTOACC CLOCK_BRANCH_INVALID>;
+			interrupt-names = "cryptoacc", "trng", "pke";
+			interrupts = <0 2>, <1 2>, <2 2>;
+			status = "disabled";
+		};
+	};
+
+	sram0: memory@20000000 {
+		compatible = "mmio-sram";
+		device_type = "memory";
 	};
 };
 

--- a/dts/arm/silabs/xg23/efm32pg23.dtsi
+++ b/dts/arm/silabs/xg23/efm32pg23.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <silabs/xg23/xg23.dtsi>

--- a/dts/arm/silabs/xg23/efm32pg23b310f512im48.dtsi
+++ b/dts/arm/silabs/xg23/efm32pg23b310f512im48.dtsi
@@ -1,19 +1,17 @@
 /*
  * Copyright (c) 2025 Christoph Jans
+ * Copyright (c) 2025 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <mem.h>
-#include <silabs/xg23/xg23.dtsi>
+#include <silabs/xg23/efm32pg23.dtsi>
 
 / {
 	soc {
-		compatible = "silabs,efm32pg23b310f512im48",
-			     "silabs,efm32pg23",
-			     "silabs,xg23",
-			     "silabs,efm32",
-			     "simple-bus";
+		compatible = "silabs,efm32pg23b310f512im48", "silabs,efm32pg23", "silabs,xg23",
+			     "silabs,efm32", "simple-bus";
 	};
 };
 

--- a/dts/arm/silabs/xg23/efr32xg23.dtsi
+++ b/dts/arm/silabs/xg23/efr32xg23.dtsi
@@ -10,16 +10,16 @@
 	soc {
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
-			reg = <0xb0000000 0x1000000>;
-			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>,
-				     <37 1>, <38 1>, <39 1>, <40 1>, <74 1>, <75 1>;
+			reg = <0xb0000000 0x01000000>;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
-					  "rac_rsm", "rac_seq", "hostmailbox", "synth",
-					  "rfeca0", "rfeca1";
+					  "rac_rsm", "rac_seq", "hostmailbox", "synth", "rfeca0",
+					  "rfeca1";
+			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>, <37 1>,
+				     <38 1>, <39 1>, <40 1>, <74 1>, <75 1>;
 			pa-initial-power-dbm = <10>;
 			pa-ramp-time-us = <10>;
-			pa-voltage-mv = <3300>;
 			pa-subghz = "highest";
+			pa-voltage-mv = <3300>;
 
 			pti: pti {
 				compatible = "silabs,pti";

--- a/dts/arm/silabs/xg23/xg23.dtsi
+++ b/dts/arm/silabs/xg23/xg23.dtsi
@@ -1,164 +1,160 @@
 /*
  * Copyright (c) 2024 Yishai Jaffe
+ * Copyright (c) 2025 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <arm/armv8-m.dtsi>
+#include <freq.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/silabs/xg23-clock.h>
 #include <zephyr/dt-bindings/dma/silabs/xg23-dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
-#include <freq.h>
 
 / {
 	chosen {
-		zephyr,flash-controller = &msc;
 		zephyr,entropy = &se;
+		zephyr,flash-controller = &msc;
 	};
 
 	clocks {
-		hfxort: hfxort {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfxo>;
-		};
-
-		hfrcodpllrt: hfrcodpllrt {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfrcodpll>;
-		};
-
-		sysclk: sysclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfrcodpll>;
-		};
-
-		hclk: hclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&sysclk>;
-			/* Divider 1, 2, 4, 8, or 16 */
-			clock-div = <1>;
-		};
-
-		pclk: pclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-			/* Divider 1 or 2 */
-			clock-div = <2>;
-		};
-
-		lspclk: lspclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&pclk>;
-			/* Fixed divider of 2 */
-			clock-div = <2>;
-		};
-
-		hclkdiv1024: hclkdiv1024 {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-			/* Fixed divider of 1024 */
-			clock-div = <1024>;
-		};
-
-		traceclk: traceclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&sysclk>;
-			/* Divider 1, 2 or 4 */
-			clock-div = <1>;
-		};
-
 		em01grpaclk: em01grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hfrcodpll>;
 		};
 
 		em01grpcclk: em01grpcclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hfrcodpll>;
 		};
 
-		iadcclk: iadcclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em01grpaclk>;
-		};
-
-		lesensehfclk: lesensehfclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&fsrco>;
-		};
-
 		em23grpaclk: em23grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
 		em4grpaclk: em4grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
+		};
+
+		eusart0clk: eusart0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpcclk>;
+		};
+
+		hclk: hclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1>;
+			clocks = <&sysclk>;
+		};
+
+		hclkdiv1024: hclkdiv1024 {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1024>;
+			clocks = <&hclk>;
+		};
+
+		hfrcodpllrt: hfrcodpllrt {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfrcodpll>;
+		};
+
+		hfxort: hfxort {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfxo>;
+		};
+
+		iadcclk: iadcclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpaclk>;
+		};
+
+		lcdclk: lcdclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&lfrco>;
+		};
+
+		lesensehfclk: lesensehfclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&fsrco>;
+		};
+
+		lspclk: lspclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clocks = <&pclk>;
+		};
+
+		pclk: pclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clocks = <&hclk>;
+		};
+
+		pcnt0clk: pcnt0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em23grpaclk>;
+		};
+
+		sysclk: sysclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfrcodpll>;
 		};
 
 		sysrtcclk: sysrtcclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
-		wdog0clk: wdog0clk {
-			#clock-cells = <0>;
+		systickclk: systickclk {
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hclk>;
+		};
+
+		traceclk: traceclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1>;
+			clocks = <&sysclk>;
+		};
+
+		vdac0clk: vdac0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpaclk>;
+		};
+
+		wdog0clk: wdog0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
 		wdog1clk: wdog1clk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
-		};
-
-		lcdclk: lcdclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&lfrco>;
-		};
-
-		pcnt0clk: pcnt0clk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em23grpaclk>;
-		};
-
-		eusart0clk: eusart0clk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em01grpcclk>;
-		};
-
-		systickclk: systickclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-		};
-
-		vdac0clk: vdac0clk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em01grpaclk>;
 		};
 	};
 
@@ -167,47 +163,39 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
-			/*
-			 * The minimum residency and exit latency is
-			 * managed by sl_power_manager on S2 devices.
-			 */
 			#address-cells = <1>;
 			#size-cells = <1>;
+			/*
+			 * The minimum residency and exit latency is managed by sl_power_manager
+			 * on S2 devices.
+			 */
+			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
+			device_type = "cpu";
 
 			itm: itm@e0000000 {
 				compatible = "arm,armv8m-itm";
 				reg = <0xe0000000 0x1000>;
 			};
+
+			mpu: mpu@e000ed90 {
+				compatible = "arm,armv8m-mpu";
+				reg = <0xe000ed90 0x40>;
+			};
 		};
 
 		power-states {
-			/*
-			 * EM1 is a basic "CPU WFI idle", all high-freq clocks remain
-			 * enabled.
-			 */
 			pstate_em1: em1 {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";
-				/* HFXO remains active */
 			};
 
-			/*
-			 * EM2 is a deepsleep with HF clocks disabled by HW, voltages
-			 * scaled down, etc.
-			 */
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
 			};
 
-			/*
-			 * EM4 is a shutdown state where all clocks are off. The device
-			 * is reset on wakeup from EM4.
-			 */
 			pstate_em4: em4 {
 				compatible = "zephyr,power-state";
 				power-state-name = "soft-off";
@@ -216,99 +204,162 @@
 		};
 	};
 
-	sram0: memory@20000000 {
-		device_type = "memory";
-		compatible = "mmio-sram";
+	hwinfo: hwinfo {
+		compatible = "silabs,series2-hwinfo";
+		status = "disabled";
 	};
 
 	soc {
 		cmu: clock@50008000 {
 			compatible = "silabs,series-clock";
 			reg = <0x50008000 0x4000>;
-			interrupts = <48 2>;
-			interrupt-names = "cmu";
-			status = "okay";
 			#clock-cells = <2>;
+			interrupt-names = "cmu";
+			interrupts = <48 2>;
+			status = "okay";
+		};
+
+		hfrcodpll: hfrcodpll@50010000 {
+			compatible = "silabs,series2-hfrcodpll";
+			reg = <0x50010000 0x4000>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(19)>;
+			clocks = <&cmu CLOCK_HFRCO0 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "hfrco0";
+			interrupts = <46 2>;
 		};
 
 		fsrco: fsrco@50018000 {
-			#clock-cells = <0>;
 			compatible = "fixed-clock";
 			reg = <0x50018000 0x4000>;
-			clock-frequency = <DT_FREQ_M(20)>;
-		};
-
-		clk_hfxo: hfxo: hfxo@5a004000 {
 			#clock-cells = <0>;
-			compatible = "silabs,hfxo";
-			reg = <0x5a004000 0x4000>;
-			interrupts = <45 0>;
-			interrupt-names = "hfxo";
-			clock-frequency = <DT_FREQ_M(39)>;
-			ctune = <140>;
-			precision = <50>;
-			status = "disabled";
+			clock-frequency = <DT_FREQ_M(20)>;
+			clocks = <&cmu CLOCK_FSRCO CLOCK_BRANCH_INVALID>;
 		};
 
 		lfxo: lfxo@50020000 {
-			#clock-cells = <0>;
 			compatible = "silabs,series2-lfxo";
 			reg = <0x50020000 0x4000>;
+			#clock-cells = <0>;
 			clock-frequency = <32768>;
+			clocks = <&cmu CLOCK_LFXO CLOCK_BRANCH_INVALID>;
 			ctune = <63>;
+			interrupt-names = "lfxo";
+			interrupts = <23 2>;
 			precision = <50>;
 			timeout = <4096>;
 			status = "disabled";
 		};
 
-		hfrcodpll: hfrcodpll@50010000 {
-			#clock-cells = <0>;
-			compatible = "silabs,series2-hfrcodpll";
-			reg = <0x50010000 0x4000>;
-			clock-frequency = <DT_FREQ_M(19)>;
-		};
-
-		hfrcoem23: hfrcoem23@5a000000 {
-			#clock-cells = <0>;
-			compatible = "silabs,series2-hfrcoem23";
-			reg = <0x5a000000 0x4000>;
-			clock-frequency = <DT_FREQ_M(19)>;
-		};
-
 		lfrco: lfrco@50024000 {
-			#clock-cells = <0>;
 			compatible = "silabs,series2-lfrco";
 			reg = <0x50024000 0x4000>;
+			#clock-cells = <0>;
 			clock-frequency = <32768>;
+			clocks = <&cmu CLOCK_LFRCO CLOCK_BRANCH_INVALID>;
+			interrupt-names = "lfrco";
+			interrupts = <24 2>;
 		};
 
 		ulfrco: ulfrco@50028000 {
-			#clock-cells = <0>;
 			compatible = "fixed-clock";
 			reg = <0x50028000 0x4000>;
-			clock-frequency = <1000>;
-		};
-
-		clkin0: clkin0@5003c49c {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
-			reg = <0x5003c49c 0x4>;
-			clock-frequency = <DT_FREQ_M(38)>;
+			clock-frequency = <1000>;
+			clocks = <&cmu CLOCK_ULFRCO CLOCK_BRANCH_INVALID>;
+			interrupt-names = "ulfrco";
+			interrupts = <25 2>;
 		};
 
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
-			interrupts = <51 2>;
-
 			#address-cells = <1>;
 			#size-cells = <1>;
+			clocks = <&cmu CLOCK_MSC CLOCK_BRANCH_HCLK>;
+			interrupt-names = "msc";
+			interrupts = <51 2>;
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
-				write-block-size = <4>;
 				erase-block-size = <8192>;
+				write-block-size = <4>;
 			};
+		};
+
+		gpio: gpio@5003c000 {
+			compatible = "silabs,gpio";
+			reg = <0x5003c000 0x4000>;
+			ranges;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
+			interrupt-names = "gpio_odd", "gpio_even";
+			interrupts = <26 2>, <27 2>;
+
+			gpioa: gpio@5003c030 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c030 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <0>;
+				silabs,wakeup-pins = <5>;
+				status = "disabled";
+			};
+
+			gpiob: gpio@5003c060 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c060 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <3>;
+				silabs,wakeup-pins = <1>;
+				status = "disabled";
+			};
+
+			gpioc: gpio@5003c090 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c090 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <6>, <7>;
+				silabs,wakeup-pins = <0>, <5>;
+				status = "disabled";
+			};
+
+			gpiod: gpio@5003c0c0 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c0c0 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <9>;
+				silabs,wakeup-pins = <2>;
+				status = "disabled";
+			};
+		};
+
+		pinctrl: pin-controller@5003c440 {
+			compatible = "silabs,dbus-pinctrl";
+			reg = <0x5003c440 0x0bc0>, <0x5003c320 0x40>;
+			reg-names = "dbus", "abus";
+		};
+
+		clkin0: clkin0@5003c49c {
+			compatible = "fixed-clock";
+			reg = <0x5003c49c 0x04>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(38)>;
+		};
+
+		dma0: dma@50040000 {
+			compatible = "silabs,ldma";
+			reg = <0x50040000 0x4000>;
+			#dma-cells = <1>;
+			clocks = <&cmu CLOCK_LDMA0 CLOCK_BRANCH_HCLK>;
+			dma-channels = <8>;
+			interrupt-names = "ldma";
+			interrupts = <22 2>;
+			status = "disabled";
 		};
 
 		timer0: timer@50048000 {
@@ -317,6 +368,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER0 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <32>;
+			interrupt-names = "timer0";
 			interrupts = <4 2>;
 			status = "disabled";
 
@@ -333,6 +385,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER1 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer1";
 			interrupts = <5 2>;
 			status = "disabled";
 
@@ -349,6 +402,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER2 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer2";
 			interrupts = <6 2>;
 			status = "disabled";
 
@@ -365,6 +419,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER3 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer3";
 			interrupts = <7 2>;
 			status = "disabled";
 
@@ -381,6 +436,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER4 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer4";
 			interrupts = <8 2>;
 			status = "disabled";
 
@@ -393,171 +449,69 @@
 
 		usart0: usart@5005c000 {
 			compatible = "silabs,usart-uart";
-			reg = <0x5005C000 0x4000>;
-			interrupts = <9 2>, <10 2>;
-			interrupt-names = "rx", "tx";
+			reg = <0x5005c000 0x4000>;
 			clocks = <&cmu CLOCK_USART0 CLOCK_BRANCH_PCLK>;
-			status = "disabled";
-		};
-
-		eusart0: eusart@5b010000 {
-			compatible = "silabs,eusart-spi";
-			reg = <0x5B010000 0x4000>;
-			interrupts = <11 2>, <12 2>;
 			interrupt-names = "rx", "tx";
-			clocks = <&cmu CLOCK_EUSART0 CLOCK_BRANCH_EUSART0CLK>;
-			status = "disabled";
-		};
-
-		eusart1: eusart@500a0000 {
-			compatible = "silabs,eusart-spi";
-			reg = <0x500A0000 0x4000>;
-			interrupts = <13 2>, <14 2>;
-			interrupt-names = "rx", "tx";
-			clocks = <&cmu CLOCK_EUSART1 CLOCK_BRANCH_EM01GRPCCLK>;
-			status = "disabled";
-		};
-
-		eusart2: eusart@500a4000 {
-			compatible = "silabs,eusart-spi";
-			reg = <0x500A4000 0x4000>;
-			interrupts = <15 2>, <16 2>;
-			interrupt-names = "rx", "tx";
-			clocks = <&cmu CLOCK_EUSART2 CLOCK_BRANCH_EM01GRPCCLK>;
+			interrupts = <9 2>, <10 2>;
 			status = "disabled";
 		};
 
 		burtc0: burtc@50064000 {
 			compatible = "silabs,gecko-burtc";
 			reg = <0x50064000 0x4000>;
-			interrupts = <18 2>;
 			clocks = <&cmu CLOCK_BURTC CLOCK_BRANCH_EM4GRPACLK>;
-			status = "disabled";
-		};
-
-		se: semailbox@5c000000 {
-			compatible = "silabs,gecko-semailbox";
-			reg = <0x5c000000 0x80>;
-			interrupts = <66 3>, <67 3>, <68 3>;
-			interrupt-names = "SETAMPERHOST", "SEMBRX", "SEMBTX";
-			status = "disabled";
-		};
-
-		i2c0: i2c@5b000000 {
-			compatible = "silabs,i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x5b000000 0x4000>;
-			interrupts = <28 2>;
-			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
+			interrupt-names = "burtc";
+			interrupts = <18 2>;
 			status = "disabled";
 		};
 
 		i2c1: i2c@50068000 {
 			compatible = "silabs,i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
+			reg = <0x50068000 0x4000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x50068000 0x4000>;
-			interrupts = <29 2>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			clocks = <&cmu CLOCK_I2C1 CLOCK_BRANCH_PCLK>;
+			interrupt-names = "i2c1";
+			interrupts = <29 2>;
+			status = "disabled";
+		};
+
+		dcdc: dcdc@50094000 {
+			compatible = "silabs,series2-dcdc";
+			reg = <0x50094000 0x4000>;
+			clocks = <&cmu CLOCK_DCDC CLOCK_BRANCH_INVALID>;
+			interrupt-names = "dcdc";
+			interrupts = <54 2>;
+			status = "disabled";
+		};
+
+		eusart1: eusart@500a0000 {
+			compatible = "silabs,eusart-spi";
+			reg = <0x500a0000 0x4000>;
+			clocks = <&cmu CLOCK_EUSART1 CLOCK_BRANCH_EM01GRPCCLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <13 2>, <14 2>;
+			status = "disabled";
+		};
+
+		eusart2: eusart@500a4000 {
+			compatible = "silabs,eusart-spi";
+			reg = <0x500a4000 0x4000>;
+			clocks = <&cmu CLOCK_EUSART2 CLOCK_BRANCH_EM01GRPCCLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <15 2>, <16 2>;
 			status = "disabled";
 		};
 
 		sysrtc0: stimer0: sysrtc@500a8000 {
 			compatible = "silabs,gecko-stimer";
 			reg = <0x500a8000 0x4000>;
-			interrupts = <70 2>, <71 2>;
-			interrupt-names = "sysrtc_app", "sysrtc_seq";
 			clock-frequency = <32768>;
-			prescaler = <1>;
 			clocks = <&cmu CLOCK_SYSRTC0 CLOCK_BRANCH_SYSRTCCLK>;
-			status = "disabled";
-		};
-
-		gpio: gpio@5003c000 {
-			compatible = "silabs,gpio";
-			reg = <0x5003c000 0x4000>;
-			interrupts = <27 2>, <26 2>;
-			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
-
-			ranges;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			gpioa: gpio@5003c030 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003c030 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <0>;
-				silabs,wakeup-pins = <5>;
-				status = "disabled";
-			};
-
-			gpiob: gpio@5003c060 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003c060 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <3>, <4>;
-				silabs,wakeup-pins = <1>, <3>;
-				status = "disabled";
-			};
-
-			gpioc: gpio@5003c090 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003c090 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <6>, <7>, <8>;
-				silabs,wakeup-pins = <0>, <5>, <7>;
-				status = "disabled";
-			};
-
-			gpiod: gpio@5003c0C0 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003c0C0 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <9>, <10>;
-				silabs,wakeup-pins = <2>, <5>;
-				status = "disabled";
-			};
-		};
-
-		pinctrl: pin-controller@5003c440 {
-			compatible = "silabs,dbus-pinctrl";
-			reg = <0x5003c440 0xbc0>, <0x5003c320 0x40>;
-			reg-names = "dbus", "abus";
-		};
-
-		dma0: dma@50040000 {
-			compatible = "silabs,ldma";
-			reg = <0x50040000 0x4000>;
-			interrupts = <22 0>;
-			#dma-cells = <1>;
-			dma-channels = <8>;
-			status = "disabled";
-		};
-
-		wdog0: wdog@5b004000 {
-			compatible = "silabs,gecko-wdog";
-			reg = <0x5b004000 0x4000>;
-			peripheral-id = <0>;
-			interrupts = <43 2>;
-			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
-			status = "disabled";
-		};
-
-		wdog1: wdog@5b008000 {
-			compatible = "silabs,gecko-wdog";
-			reg = <0x5b008000 0x4000>;
-			peripheral-id = <1>;
-			interrupts = <44 2>;
-			clocks = <&cmu CLOCK_WDOG1 CLOCK_BRANCH_WDOG1CLK>;
+			interrupt-names = "sysrtc_app", "sysrtc_seq";
+			interrupts = <70 2>, <71 2>;
+			prescaler = <1>;
 			status = "disabled";
 		};
 
@@ -565,6 +519,7 @@
 			compatible = "silabs,series2-letimer";
 			reg = <0x59000000 0x4000>;
 			clocks = <&cmu CLOCK_LETIMER0 CLOCK_BRANCH_EM23GRPACLK>;
+			interrupt-names = "letimer0";
 			interrupts = <19 2>;
 			status = "disabled";
 
@@ -578,44 +533,41 @@
 		adc0: adc@59004000 {
 			compatible = "silabs,gecko-iadc";
 			reg = <0x59004000 0x4000>;
-			interrupts = <50 2>;
-			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
-			status = "disabled";
 			#io-channel-cells = <1>;
-		};
-
-		dcdc: dcdc@50094000 {
-			compatible = "silabs,series2-dcdc";
-			reg = <0x50094000 0x4000>;
-			interrupts = <54 2>;
+			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
+			interrupt-names = "iadc";
+			interrupts = <50 2>;
 			status = "disabled";
 		};
 
 		acmp0: acmp@59008000 {
 			compatible = "silabs,acmp";
 			reg = <0x59008000 0x4000>;
+			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "acmp0";
 			interrupts = <41 2>;
-			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
 
 		acmp1: acmp@5900c000 {
 			compatible = "silabs,acmp";
 			reg = <0x5900c000 0x4000>;
+			clocks = <&cmu CLOCK_ACMP1 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "acmp1";
 			interrupts = <42 2>;
-			clocks = <&cmu CLOCK_ACMP1 CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
 
 		vdac0: vdac@59024000 {
 			compatible = "silabs,vdac";
 			reg = <0x59024000 0x4000>;
-			interrupts = <55 2>;
-			clocks = <&cmu CLOCK_VDAC0 CLOCK_BRANCH_VDAC0CLK>;
-			status = "disabled";
 			#address-cells = <1>;
-			#size-cells = <0>;
 			#io-channel-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&cmu CLOCK_VDAC0 CLOCK_BRANCH_VDAC0CLK>;
+			interrupt-names = "vdac";
+			interrupts = <55 2>;
+			status = "disabled";
 
 			channel@0 {
 				reg = <0>;
@@ -625,11 +577,83 @@
 				reg = <1>;
 			};
 		};
+
+		hfrcoem23: hfrcoem23@5a000000 {
+			compatible = "silabs,series2-hfrcoem23";
+			reg = <0x5a000000 0x4000>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(19)>;
+			clocks = <&cmu CLOCK_HFRCOEM23 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "hfrcoem23";
+			interrupts = <47 2>;
+		};
+
+		clk_hfxo: hfxo: hfxo@5a004000 {
+			compatible = "silabs,hfxo";
+			reg = <0x5a004000 0x4000>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(39)>;
+			clocks = <&cmu CLOCK_HFXO0 CLOCK_BRANCH_INVALID>;
+			ctune = <140>;
+			interrupt-names = "hfxo0";
+			interrupts = <45 2>;
+			precision = <50>;
+			status = "disabled";
+		};
+
+		i2c0: i2c@5b000000 {
+			compatible = "silabs,i2c";
+			reg = <0x5b000000 0x4000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
+			interrupt-names = "i2c0";
+			interrupts = <28 2>;
+			status = "disabled";
+		};
+
+		wdog0: wdog@5b004000 {
+			compatible = "silabs,gecko-wdog";
+			reg = <0x5b004000 0x4000>;
+			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
+			interrupt-names = "wdog0";
+			interrupts = <43 2>;
+			peripheral-id = <0>;
+			status = "disabled";
+		};
+
+		wdog1: wdog@5b008000 {
+			compatible = "silabs,gecko-wdog";
+			reg = <0x5b008000 0x4000>;
+			clocks = <&cmu CLOCK_WDOG1 CLOCK_BRANCH_WDOG1CLK>;
+			interrupt-names = "wdog1";
+			interrupts = <44 2>;
+			peripheral-id = <1>;
+			status = "disabled";
+		};
+
+		eusart0: eusart@5b010000 {
+			compatible = "silabs,eusart-spi";
+			reg = <0x5b010000 0x4000>;
+			clocks = <&cmu CLOCK_EUSART0 CLOCK_BRANCH_EUSART0CLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <11 2>, <12 2>;
+			status = "disabled";
+		};
+
+		se: semailbox@5c000000 {
+			compatible = "silabs,gecko-semailbox";
+			reg = <0x5c000000 0x4000>;
+			interrupt-names = "setamperhost", "sembrx", "sembtx";
+			interrupts = <66 2>, <67 2>, <68 2>;
+			status = "disabled";
+		};
 	};
 
-	hwinfo: hwinfo {
-		compatible = "silabs,gecko-hwinfo";
-		status = "disabled";
+	sram0: memory@20000000 {
+		compatible = "mmio-sram";
+		device_type = "memory";
 	};
 };
 

--- a/dts/arm/silabs/xg24/bgm24.dtsi
+++ b/dts/arm/silabs/xg24/bgm24.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <silabs/xg24/efr32xg24.dtsi>

--- a/dts/arm/silabs/xg24/bgm240sa22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240sa22vna.dtsi
@@ -7,17 +7,31 @@
  */
 
 #include <mem.h>
-#include <silabs/xg24/efr32bg24.dtsi>
+#include <silabs/xg24/bgm24.dtsi>
 
 / {
 	soc {
-		compatible = "silabs,bgm240sa22vna", "silabs,efr32bg24", "silabs,xg24",
-			     "silabs,efr32", "simple-bus";
+		compatible = "silabs,bgm240sa22vna", "silabs,bgm24", "silabs,xg24", "silabs,efr32",
+			     "simple-bus";
 	};
 };
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+};
+
+&hfxo {
+	ctune = <140>;
+	precision = <50>;
+	status = "okay";
+};
+
+&lfrco {
+	precision-mode;
+};
+
+&radio {
+	pa-voltage-mv = <1800>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg24/efr32xg24.dtsi
+++ b/dts/arm/silabs/xg24/efr32xg24.dtsi
@@ -10,16 +10,16 @@
 	soc {
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
-			reg = <0xb0000000 0x1000000>;
-			interrupts = <30 1>, <31 1>, <32 1>, <33 1>, <34 1>, <35 1>,
-				     <36 1>, <37 1>, <38 1>, <39 1>, <70 1>, <71 1>;
+			reg = <0xb0000000 0x01000000>;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
-					  "rac_rsm", "rac_seq", "hostmailbox", "synth",
-					  "rfeca0", "rfeca1";
+					  "rac_rsm", "rac_seq", "hostmailbox", "synth", "rfeca0",
+					  "rfeca1";
+			interrupts = <30 1>, <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>,
+				     <37 1>, <38 1>, <39 1>, <70 1>, <71 1>;
+			pa-2p4ghz = "highest";
 			pa-initial-power-dbm = <10>;
 			pa-ramp-time-us = <10>;
 			pa-voltage-mv = <3300>;
-			pa-2p4ghz = "highest";
 
 			bt_hci_silabs: bt_hci_silabs {
 				compatible = "silabs,bt-hci-efr32";

--- a/dts/arm/silabs/xg24/mgm24.dtsi
+++ b/dts/arm/silabs/xg24/mgm24.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <silabs/xg24/efr32xg24.dtsi>

--- a/dts/arm/silabs/xg24/mgm240pb32vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pb32vna.dtsi
@@ -6,12 +6,12 @@
  */
 
 #include <mem.h>
-#include <silabs/xg24/efr32mg24.dtsi>
+#include <silabs/xg24/mgm24.dtsi>
 
 / {
 	soc {
-		compatible = "silabs,mgm240pb32vna", "silabs,efr32mg24", "silabs,xg24",
-			     "silabs,efr32", "simple-bus";
+		compatible = "silabs,mgm240pb32vna", "silabs,mgm24", "silabs,xg24", "silabs,efr32",
+			     "simple-bus";
 	};
 };
 
@@ -19,8 +19,14 @@
 	reg = <0x08000000 DT_SIZE_K(1536)>;
 };
 
-&radio {
-	pa-voltage-mv = <3300>;
+&hfxo {
+	ctune = <140>;
+	precision = <50>;
+	status = "okay";
+};
+
+&lfrco {
+	precision-mode;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg24/mgm240sd22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240sd22vna.dtsi
@@ -6,17 +6,27 @@
  */
 
 #include <mem.h>
-#include <silabs/xg24/efr32mg24.dtsi>
+#include <silabs/xg24/mgm24.dtsi>
 
 / {
 	soc {
-		compatible = "silabs,mgm240sd22vna", "silabs,efr32mg24", "silabs,xg24",
-			     "silabs,efr32", "simple-bus";
+		compatible = "silabs,mgm240sd22vna", "silabs,mgm24", "silabs,xg24", "silabs,efr32",
+			     "simple-bus";
 	};
 };
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+};
+
+&hfxo {
+	ctune = <140>;
+	precision = <50>;
+	status = "okay";
+};
+
+&lfrco {
+	precision-mode;
 };
 
 &radio {

--- a/dts/arm/silabs/xg24/xg24.dtsi
+++ b/dts/arm/silabs/xg24/xg24.dtsi
@@ -1,152 +1,154 @@
 /*
  * Copyright (c) 2020 TriaGnoSys GmbH
+ * Copyright (c) 2025 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <arm/armv8-m.dtsi>
+#include <freq.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/silabs/xg24-clock.h>
 #include <zephyr/dt-bindings/dma/silabs/xg24-dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
-#include <freq.h>
 
 / {
 	chosen {
-		zephyr,flash-controller = &msc;
 		zephyr,entropy = &se;
+		zephyr,flash-controller = &msc;
 	};
 
 	clocks {
-		hfxort: hfxort {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfxo>;
-		};
-
-		hfrcodpllrt: hfrcodpllrt {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfrcodpll>;
-		};
-
-		sysclk: sysclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfrcodpll>;
-		};
-
-		hclk: hclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&sysclk>;
-			/* Divider 1, 2, 4, 8, or 16 */
-			clock-div = <1>;
-		};
-
-		pclk: pclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-			/* Divider 1 or 2 */
-			clock-div = <2>;
-		};
-
-		lspclk: lspclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&pclk>;
-			/* Fixed divider of 2 */
-			clock-div = <2>;
-		};
-
-		hclkdiv1024: hclkdiv1024 {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-			/* Fixed divider of 1024 */
-			clock-div = <1024>;
-		};
-
-		traceclk: traceclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&sysclk>;
-			/* Divider 1, 2, 3 or 4 */
-			clock-div = <1>;
-		};
-
 		em01grpaclk: em01grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hfrcodpll>;
 		};
 
 		em01grpcclk: em01grpcclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hfrcodpll>;
 		};
 
-		iadcclk: iadcclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em01grpaclk>;
-		};
-
 		em23grpaclk: em23grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
 		em4grpaclk: em4grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
+		};
+
+		eusart0clk: eusart0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpcclk>;
+		};
+
+		hclk: hclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1>;
+			clocks = <&sysclk>;
+		};
+
+		hclkdiv1024: hclkdiv1024 {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1024>;
+			clocks = <&hclk>;
+		};
+
+		hfrcodpllrt: hfrcodpllrt {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfrcodpll>;
+		};
+
+		hfxort: hfxort {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfxo>;
+		};
+
+		iadcclk: iadcclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpaclk>;
+		};
+
+		lspclk: lspclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clocks = <&pclk>;
+		};
+
+		pclk: pclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clocks = <&hclk>;
+		};
+
+		pcnt0clk: pcnt0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em23grpaclk>;
+		};
+
+		sysclk: sysclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfrcodpll>;
 		};
 
 		sysrtcclk: sysrtcclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
-		wdog0clk: wdog0clk {
-			#clock-cells = <0>;
+		systickclk: systickclk {
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hclk>;
+		};
+
+		traceclk: traceclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1>;
+			clocks = <&sysclk>;
+		};
+
+		vdac0clk: vdac0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpaclk>;
+		};
+
+		vdac1clk: vdac1clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpaclk>;
+		};
+
+		wdog0clk: wdog0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
 		wdog1clk: wdog1clk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
-		};
-
-		pcnt0clk: pcnt0clk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em23grpaclk>;
-		};
-
-		eusart0clk: eusart0clk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em01grpcclk>;
-		};
-
-		systickclk: systickclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-		};
-
-		vdac0clk: vdac0clk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em01grpaclk>;
 		};
 	};
 
@@ -155,47 +157,39 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
-			/*
-			 * The minimum residency and exit latency is
-			 * managed by sl_power_manager on S2 devices.
-			 */
 			#address-cells = <1>;
 			#size-cells = <1>;
+			/*
+			 * The minimum residency and exit latency is managed by sl_power_manager
+			 * on S2 devices.
+			 */
+			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
+			device_type = "cpu";
 
 			itm: itm@e0000000 {
 				compatible = "arm,armv8m-itm";
 				reg = <0xe0000000 0x1000>;
 			};
+
+			mpu: mpu@e000ed90 {
+				compatible = "arm,armv8m-mpu";
+				reg = <0xe000ed90 0x40>;
+			};
 		};
 
 		power-states {
-			/*
-			 * EM1 is a basic "CPU WFI idle", all high-freq clocks remain
-			 * enabled.
-			 */
 			pstate_em1: em1 {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";
-				/* HFXO remains active */
 			};
 
-			/*
-			 * EM2 is a deepsleep with HF clocks disabled by HW, voltages
-			 * scaled down, etc.
-			 */
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
 			};
 
-			/*
-			 * EM4 is a shutdown state where all clocks are off. The device
-			 * is reset on wakeup from EM4.
-			 */
 			pstate_em4: em4 {
 				compatible = "zephyr,power-state";
 				power-state-name = "soft-off";
@@ -204,99 +198,160 @@
 		};
 	};
 
-	sram0: memory@20000000 {
-		device_type = "memory";
-		compatible = "mmio-sram";
+	hwinfo: hwinfo {
+		compatible = "silabs,series2-hwinfo";
+		status = "disabled";
 	};
 
 	soc {
 		cmu: clock@50008000 {
 			compatible = "silabs,series-clock";
 			reg = <0x50008000 0x4000>;
-			interrupts = <47 2>;
-			interrupt-names = "cmu";
-			status = "okay";
 			#clock-cells = <2>;
+			interrupt-names = "cmu";
+			interrupts = <47 2>;
+			status = "okay";
+		};
+
+		hfrcodpll: hfrcodpll@50010000 {
+			compatible = "silabs,series2-hfrcodpll";
+			reg = <0x50010000 0x4000>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(19)>;
+			clocks = <&cmu CLOCK_HFRCO0 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "hfrco0";
+			interrupts = <45 2>;
 		};
 
 		fsrco: fsrco@50018000 {
-			#clock-cells = <0>;
 			compatible = "fixed-clock";
 			reg = <0x50018000 0x4000>;
-			clock-frequency = <DT_FREQ_M(20)>;
-		};
-
-		clk_hfxo: hfxo: hfxo@5a004000 {
 			#clock-cells = <0>;
-			compatible = "silabs,hfxo";
-			reg = <0x5a004000 0x4000>;
-			interrupts = <44 0>;
-			interrupt-names = "hfxo";
-			clock-frequency = <DT_FREQ_M(39)>;
-			ctune = <140>;
-			precision = <50>;
-			status = "disabled";
+			clock-frequency = <DT_FREQ_M(20)>;
+			clocks = <&cmu CLOCK_FSRCO CLOCK_BRANCH_INVALID>;
 		};
 
 		lfxo: lfxo@50020000 {
-			#clock-cells = <0>;
 			compatible = "silabs,series2-lfxo";
 			reg = <0x50020000 0x4000>;
+			#clock-cells = <0>;
 			clock-frequency = <32768>;
+			clocks = <&cmu CLOCK_LFXO CLOCK_BRANCH_INVALID>;
 			ctune = <63>;
+			interrupt-names = "lfxo";
+			interrupts = <22 2>;
 			precision = <50>;
 			timeout = <4096>;
 			status = "disabled";
 		};
 
-		hfrcodpll: hfrcodpll@50010000 {
-			#clock-cells = <0>;
-			compatible = "silabs,series2-hfrcodpll";
-			reg = <0x50010000 0x4000>;
-			clock-frequency = <DT_FREQ_M(19)>;
-		};
-
-		hfrcoem23: hfrcoem23@5a000000 {
-			#clock-cells = <0>;
-			compatible = "silabs,series2-hfrcoem23";
-			reg = <0x5a000000 0x4000>;
-			clock-frequency = <DT_FREQ_M(19)>;
-		};
-
 		lfrco: lfrco@50024000 {
-			#clock-cells = <0>;
 			compatible = "silabs,series2-lfrco";
 			reg = <0x50024000 0x4000>;
+			#clock-cells = <0>;
 			clock-frequency = <32768>;
+			clocks = <&cmu CLOCK_LFRCO CLOCK_BRANCH_INVALID>;
 		};
 
 		ulfrco: ulfrco@50028000 {
-			#clock-cells = <0>;
 			compatible = "fixed-clock";
 			reg = <0x50028000 0x4000>;
-			clock-frequency = <1000>;
-		};
-
-		clkin0: clkin0@5003c46c {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
-			reg = <0x5003c46c 0x4>;
-			clock-frequency = <DT_FREQ_M(38)>;
+			clock-frequency = <1000>;
+			clocks = <&cmu CLOCK_ULFRCO CLOCK_BRANCH_INVALID>;
+			interrupt-names = "ulfrco";
+			interrupts = <24 2>;
 		};
 
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
-			reg = <0x50030000 0x3148>;
-			interrupts = <50 2>;
-
+			reg = <0x50030000 0x4000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			clocks = <&cmu CLOCK_MSC CLOCK_BRANCH_HCLK>;
+			interrupt-names = "msc";
+			interrupts = <50 2>;
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
-				write-block-size = <4>;
 				erase-block-size = <8192>;
+				write-block-size = <4>;
 			};
+		};
+
+		gpio: gpio@5003c000 {
+			compatible = "silabs,gpio";
+			reg = <0x5003c000 0x4000>;
+			ranges;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
+			interrupt-names = "gpio_odd", "gpio_even";
+			interrupts = <25 2>, <26 2>;
+
+			gpioa: gpio@5003c030 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c030 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <0>;
+				silabs,wakeup-pins = <5>;
+				status = "disabled";
+			};
+
+			gpiob: gpio@5003c060 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c060 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <3>, <4>;
+				silabs,wakeup-pins = <1>, <3>;
+				status = "disabled";
+			};
+
+			gpioc: gpio@5003c090 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c090 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <6>, <7>, <8>;
+				silabs,wakeup-pins = <0>, <5>, <7>;
+				status = "disabled";
+			};
+
+			gpiod: gpio@5003c0c0 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c0c0 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <10>, <9>;
+				silabs,wakeup-pins = <5>, <2>;
+				status = "disabled";
+			};
+		};
+
+		pinctrl: pin-controller@5003c440 {
+			compatible = "silabs,dbus-pinctrl";
+			reg = <0x5003c440 0x0bc0>, <0x5003c320 0x40>;
+			reg-names = "dbus", "abus";
+		};
+
+		clkin0: clkin0@5003c46c {
+			compatible = "fixed-clock";
+			reg = <0x5003c46c 0x04>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(38)>;
+		};
+
+		dma0: dma@50040000 {
+			compatible = "silabs,ldma";
+			reg = <0x50040000 0x4000>;
+			#dma-cells = <1>;
+			clocks = <&cmu CLOCK_LDMA0 CLOCK_BRANCH_HCLK>;
+			dma-channels = <8>;
+			interrupt-names = "ldma";
+			interrupts = <21 2>;
+			status = "disabled";
 		};
 
 		timer0: timer@50048000 {
@@ -305,6 +360,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER0 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <32>;
+			interrupt-names = "timer0";
 			interrupts = <4 2>;
 			status = "disabled";
 
@@ -321,6 +377,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER1 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <32>;
+			interrupt-names = "timer1";
 			interrupts = <5 2>;
 			status = "disabled";
 
@@ -337,6 +394,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER2 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer2";
 			interrupts = <6 2>;
 			status = "disabled";
 
@@ -353,6 +411,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER3 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer3";
 			interrupts = <7 2>;
 			status = "disabled";
 
@@ -369,6 +428,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER4 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer4";
 			interrupts = <8 2>;
 			status = "disabled";
 
@@ -381,151 +441,60 @@
 
 		usart0: usart@5005c000 {
 			compatible = "silabs,usart-uart";
-			reg = <0x5005C000 0x306c>;
-			interrupts = <9 2>, <10 2>;
-			interrupt-names = "rx", "tx";
+			reg = <0x5005c000 0x4000>;
 			clocks = <&cmu CLOCK_USART0 CLOCK_BRANCH_PCLK>;
-			status = "disabled";
-		};
-
-		eusart0: eusart@5b010000 {
-			compatible = "silabs,eusart-spi";
-			reg = <0x5B010000 0x4000>;
-			interrupts = <11 2>, <12 2>;
 			interrupt-names = "rx", "tx";
-			clocks = <&cmu CLOCK_EUSART0 CLOCK_BRANCH_EUSART0CLK>;
-			status = "disabled";
-		};
-
-		eusart1: eusart@500a0000 {
-			compatible = "silabs,eusart-spi";
-			reg = <0x500A0000 0x4000>;
-			interrupts = <13 2>, <14 2>;
-			interrupt-names = "rx", "tx";
-			clocks = <&cmu CLOCK_EUSART1 CLOCK_BRANCH_EM01GRPCCLK>;
+			interrupts = <9 2>, <10 2>;
 			status = "disabled";
 		};
 
 		burtc0: burtc@50064000 {
 			compatible = "silabs,gecko-burtc";
-			reg = <0x50064000 0x3034>;
-			interrupts = <17 2>;
+			reg = <0x50064000 0x4000>;
 			clocks = <&cmu CLOCK_BURTC CLOCK_BRANCH_EM4GRPACLK>;
+			interrupt-names = "burtc";
+			interrupts = <17 2>;
 			status = "disabled";
 		};
 
-		se: semailbox@5c021000 {
-			compatible = "silabs,gecko-semailbox";
-			reg = <0x5c021000 0x1000>;
-			status = "disabled";
-			interrupts = <64 3>, <65 3>, <66 3>;
-			interrupt-names = "SETAMPERHOST", "SEMBRX", "SEMBTX";
-		};
-
-		i2c0: i2c@5b000000 {
+		i2c1: i2c@50068000 {
 			compatible = "silabs,i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
+			reg = <0x50068000 0x4000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x5b000000 0x3044>;
-			interrupts = <27 2>;
-			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			clocks = <&cmu CLOCK_I2C1 CLOCK_BRANCH_PCLK>;
+			interrupt-names = "i2c1";
+			interrupts = <28 2>;
+			status = "disabled";
+		};
+
+		dcdc: dcdc@50094000 {
+			compatible = "silabs,series2-dcdc";
+			reg = <0x50094000 0x4000>;
+			clocks = <&cmu CLOCK_DCDC CLOCK_BRANCH_INVALID>;
+			interrupt-names = "dcdc";
+			interrupts = <53 2>;
+			status = "disabled";
+		};
+
+		eusart1: eusart@500a0000 {
+			compatible = "silabs,eusart-spi";
+			reg = <0x500a0000 0x4000>;
+			clocks = <&cmu CLOCK_EUSART1 CLOCK_BRANCH_EM01GRPCCLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <13 2>, <14 2>;
 			status = "disabled";
 		};
 
 		sysrtc0: stimer0: sysrtc@500a8000 {
 			compatible = "silabs,gecko-stimer";
-			reg = <0x500a8000 0x3054>;
-			interrupts = <67 2>, <68 2>;
-			interrupt-names = "sysrtc_app", "sysrtc_seq";
+			reg = <0x500a8000 0x4000>;
 			clock-frequency = <32768>;
-			prescaler = <1>;
 			clocks = <&cmu CLOCK_SYSRTC0 CLOCK_BRANCH_SYSRTCCLK>;
-			status = "disabled";
-		};
-
-		gpio: gpio@5003c000 {
-			compatible = "silabs,gpio";
-			reg = <0x5003c000 0x440>;
-			interrupts = <26 2>, <25 2>;
-			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
-
-			ranges;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			gpioa: gpio@5003c030 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003c030 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <0>;
-				silabs,wakeup-pins = <5>;
-				status = "disabled";
-			};
-
-			gpiob: gpio@5003c060 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003c060 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <3>, <4>;
-				silabs,wakeup-pins = <1>, <3>;
-				status = "disabled";
-			};
-
-			gpioc: gpio@5003c090 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003c090 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <6>, <7>, <8>;
-				silabs,wakeup-pins = <0>, <5>, <7>;
-				status = "disabled";
-			};
-
-			gpiod: gpio@5003c0C0 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003c0C0 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <9>, <10>;
-				silabs,wakeup-pins = <2>, <5>;
-				status = "disabled";
-			};
-		};
-
-		pinctrl: pin-controller@5003c440 {
-			compatible = "silabs,dbus-pinctrl";
-			reg = <0x5003c440 0xbc0>, <0x5003c320 0x40>;
-			reg-names = "dbus", "abus";
-		};
-
-		dma0: dma@40040000 {
-			compatible = "silabs,ldma";
-			reg = <0x40040000 0x4000>;
-			interrupts = <21 0>;
-			#dma-cells = <1>;
-			dma-channels = <8>;
-			status = "disabled";
-		};
-
-		wdog0: wdog@5b004000 {
-			compatible = "silabs,gecko-wdog";
-			reg = <0x5b004000 0x2C>;
-			peripheral-id = <0>;
-			interrupts = <42 2>;
-			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
-			status = "disabled";
-		};
-
-		wdog1: wdog@5b008000 {
-			compatible = "silabs,gecko-wdog";
-			reg = <0x5b008000 0x2C>;
-			peripheral-id = <1>;
-			interrupts = <43 2>;
-			clocks = <&cmu CLOCK_WDOG1 CLOCK_BRANCH_WDOG1CLK>;
+			interrupt-names = "sysrtc_app", "sysrtc_seq";
+			interrupts = <67 2>, <68 2>;
+			prescaler = <1>;
 			status = "disabled";
 		};
 
@@ -533,6 +502,7 @@
 			compatible = "silabs,series2-letimer";
 			reg = <0x59000000 0x4000>;
 			clocks = <&cmu CLOCK_LETIMER0 CLOCK_BRANCH_EM23GRPACLK>;
+			interrupt-names = "letimer0";
 			interrupts = <18 2>;
 			status = "disabled";
 
@@ -546,44 +516,41 @@
 		adc0: adc@59004000 {
 			compatible = "silabs,gecko-iadc";
 			reg = <0x59004000 0x4000>;
-			interrupts = <49 2>;
-			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
-			status = "disabled";
 			#io-channel-cells = <1>;
-		};
-
-		dcdc: dcdc@50094000 {
-			compatible = "silabs,series2-dcdc";
-			reg = <0x50094000 0x4000>;
-			interrupts = <53 2>;
+			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
+			interrupt-names = "iadc";
+			interrupts = <49 2>;
 			status = "disabled";
 		};
 
 		acmp0: acmp@59008000 {
 			compatible = "silabs,acmp";
 			reg = <0x59008000 0x4000>;
+			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "acmp0";
 			interrupts = <40 2>;
-			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
 
 		acmp1: acmp@5900c000 {
 			compatible = "silabs,acmp";
 			reg = <0x5900c000 0x4000>;
+			clocks = <&cmu CLOCK_ACMP1 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "acmp1";
 			interrupts = <41 2>;
-			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
 
 		vdac0: vdac@59024000 {
 			compatible = "silabs,vdac";
 			reg = <0x59024000 0x4000>;
-			interrupts = <72 2>;
-			clocks = <&cmu CLOCK_VDAC0 CLOCK_BRANCH_VDAC0CLK>;
-			status = "disabled";
 			#address-cells = <1>;
-			#size-cells = <0>;
 			#io-channel-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&cmu CLOCK_VDAC0 CLOCK_BRANCH_VDAC0CLK>;
+			interrupt-names = "vdac0";
+			interrupts = <72 2>;
+			status = "disabled";
 
 			channel@0 {
 				reg = <0>;
@@ -597,12 +564,13 @@
 		vdac1: vdac@59028000 {
 			compatible = "silabs,vdac";
 			reg = <0x59028000 0x4000>;
-			interrupts = <73 2>;
-			clocks = <&cmu CLOCK_VDAC1 CLOCK_BRANCH_VDAC1CLK>;
-			status = "disabled";
 			#address-cells = <1>;
-			#size-cells = <0>;
 			#io-channel-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&cmu CLOCK_VDAC1 CLOCK_BRANCH_VDAC1CLK>;
+			interrupt-names = "vdac1";
+			interrupts = <73 2>;
+			status = "disabled";
 
 			channel@0 {
 				reg = <0>;
@@ -612,13 +580,83 @@
 				reg = <1>;
 			};
 		};
-	};
-};
 
-/ {
-	hwinfo: hwinfo {
-		compatible = "silabs,gecko-hwinfo";
-		status = "disabled";
+		hfrcoem23: hfrcoem23@5a000000 {
+			compatible = "silabs,series2-hfrcoem23";
+			reg = <0x5a000000 0x4000>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(19)>;
+			clocks = <&cmu CLOCK_HFRCOEM23 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "hfrcoem23";
+			interrupts = <46 2>;
+		};
+
+		clk_hfxo: hfxo: hfxo@5a004000 {
+			compatible = "silabs,hfxo";
+			reg = <0x5a004000 0x4000>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(39)>;
+			clocks = <&cmu CLOCK_HFXO0 CLOCK_BRANCH_INVALID>;
+			ctune = <140>;
+			interrupt-names = "hfxo0";
+			interrupts = <44 2>;
+			precision = <50>;
+			status = "disabled";
+		};
+
+		i2c0: i2c@5b000000 {
+			compatible = "silabs,i2c";
+			reg = <0x5b000000 0x4000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
+			interrupt-names = "i2c0";
+			interrupts = <27 2>;
+			status = "disabled";
+		};
+
+		wdog0: wdog@5b004000 {
+			compatible = "silabs,gecko-wdog";
+			reg = <0x5b004000 0x4000>;
+			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
+			interrupt-names = "wdog0";
+			interrupts = <42 2>;
+			peripheral-id = <0>;
+			status = "disabled";
+		};
+
+		wdog1: wdog@5b008000 {
+			compatible = "silabs,gecko-wdog";
+			reg = <0x5b008000 0x4000>;
+			clocks = <&cmu CLOCK_WDOG1 CLOCK_BRANCH_WDOG1CLK>;
+			interrupt-names = "wdog1";
+			interrupts = <43 2>;
+			peripheral-id = <1>;
+			status = "disabled";
+		};
+
+		eusart0: eusart@5b010000 {
+			compatible = "silabs,eusart-spi";
+			reg = <0x5b010000 0x4000>;
+			clocks = <&cmu CLOCK_EUSART0 CLOCK_BRANCH_EUSART0CLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <11 2>, <12 2>;
+			status = "disabled";
+		};
+
+		se: semailbox@5c000000 {
+			compatible = "silabs,gecko-semailbox";
+			reg = <0x5c000000 0x4000>;
+			interrupt-names = "setamperhost", "sembrx", "sembtx";
+			interrupts = <64 2>, <65 2>, <66 2>;
+			status = "disabled";
+		};
+	};
+
+	sram0: memory@20000000 {
+		compatible = "mmio-sram";
+		device_type = "memory";
 	};
 };
 

--- a/dts/arm/silabs/xg28/efm32pg28.dtsi
+++ b/dts/arm/silabs/xg28/efm32pg28.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <silabs/xg28/xg28.dtsi>

--- a/dts/arm/silabs/xg28/efm32pg28b310f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efm32pg28b310f1024im68.dtsi
@@ -1,19 +1,17 @@
 /*
  * Copyright (c) 2025 Christoph Jans
+ * Copyright (c) 2025 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <mem.h>
-#include <silabs/xg28/xg28.dtsi>
+#include <silabs/xg28/efm32pg28.dtsi>
 
 / {
 	soc {
-		compatible = "silabs,efm32pg28b310f1024im68",
-			     "silabs,efm32pg28",
-			     "silabs,xg28",
-			     "silabs,efm32",
-			     "simple-bus";
+		compatible = "silabs,efm32pg28b310f1024im68", "silabs,efm32pg28", "silabs,xg28",
+			     "silabs,efm32", "simple-bus";
 	};
 };
 

--- a/dts/arm/silabs/xg28/efr32xg28.dtsi
+++ b/dts/arm/silabs/xg28/efr32xg28.dtsi
@@ -10,22 +10,17 @@
 	soc {
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
-			reg = <0xb0000000 0x1000000>;
-			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>,
-				     <37 1>, <38 1>, <39 1>, <40 1>, <74 1>, <75 1>;
+			reg = <0xb0000000 0x01000000>;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
-					  "rac_rsm", "rac_seq", "hostmailbox", "synth",
-					  "rfeca0", "rfeca1";
+					  "rac_rsm", "rac_seq", "hostmailbox", "synth", "rfeca0",
+					  "rfeca1";
+			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>, <37 1>,
+				     <38 1>, <39 1>, <40 1>, <74 1>, <75 1>;
+			pa-2p4ghz = "highest";
 			pa-initial-power-dbm = <10>;
 			pa-ramp-time-us = <10>;
 			pa-subghz = "highest";
 			pa-voltage-mv = <3300>;
-			pa-2p4ghz = "highest";
-
-			bt_hci_silabs: bt_hci_silabs {
-				compatible = "silabs,bt-hci-efr32";
-				status = "disabled";
-			};
 
 			pti: pti {
 				compatible = "silabs,pti";

--- a/dts/arm/silabs/xg28/efr32zg28.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28.dtsi
@@ -5,3 +5,10 @@
  */
 
 #include <silabs/xg28/efr32xg28.dtsi>
+
+&radio {
+	bt_hci_silabs: bt_hci_silabs {
+		compatible = "silabs,bt-hci-efr32";
+		status = "disabled";
+	};
+};

--- a/dts/arm/silabs/xg28/efr32zg28b322f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28b322f1024im68.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 Shontal Biton
+ * Copyright (c) 2025 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,9 +10,8 @@
 
 / {
 	soc {
-		compatible = "silabs,efr32zg28b322f1024im68",
-			     "silabs,efr32zg28", "silabs,efr32",
-			     "simple-bus";
+		compatible = "silabs,efr32zg28b322f1024im68", "silabs,efr32zg28", "silabs,xg28",
+			     "silabs,efr32", "simple-bus";
 	};
 };
 

--- a/dts/arm/silabs/xg28/xg28.dtsi
+++ b/dts/arm/silabs/xg28/xg28.dtsi
@@ -1,164 +1,160 @@
 /*
  * Copyright (c) 2025 Christoph Jans
+ * Copyright (c) 2025 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <arm/armv8-m.dtsi>
-#include <zephyr/dt-bindings/gpio/gpio.h>
-#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <freq.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/silabs/xg28-clock.h>
 #include <zephyr/dt-bindings/dma/silabs/xg28-dma.h>
-#include <freq.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	chosen {
-		zephyr,flash-controller = &msc;
 		zephyr,entropy = &se;
+		zephyr,flash-controller = &msc;
 	};
 
 	clocks {
-		hfxort: hfxort {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfxo>;
-		};
-
-		hfrcodpllrt: hfrcodpllrt {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfrcodpll>;
-		};
-
-		sysclk: sysclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfrcodpll>;
-		};
-
-		hclk: hclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&sysclk>;
-			/* Divider 1, 2, 4, 8, or 16 */
-			clock-div = <1>;
-		};
-
-		pclk: pclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-			/* Divider 1 or 2 */
-			clock-div = <2>;
-		};
-
-		lspclk: lspclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&pclk>;
-			/* Fixed divider of 2 */
-			clock-div = <2>;
-		};
-
-		hclkdiv1024: hclkdiv1024 {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-			/* Fixed divider of 1024 */
-			clock-div = <1024>;
-		};
-
-		traceclk: traceclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&sysclk>;
-			/* Divider 1, 2 or 4 */
-			clock-div = <1>;
-		};
-
 		em01grpaclk: em01grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hfrcodpll>;
 		};
 
 		em01grpcclk: em01grpcclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hfrcodpll>;
 		};
 
-		iadcclk: iadcclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em01grpaclk>;
-		};
-
-		lesensehfclk: lesensehfclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&fsrco>;
-		};
-
 		em23grpaclk: em23grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
 		em4grpaclk: em4grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
+		};
+
+		eusart0clk: eusart0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpcclk>;
+		};
+
+		hclk: hclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1>;
+			clocks = <&sysclk>;
+		};
+
+		hclkdiv1024: hclkdiv1024 {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1024>;
+			clocks = <&hclk>;
+		};
+
+		hfrcodpllrt: hfrcodpllrt {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfrcodpll>;
+		};
+
+		hfxort: hfxort {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfxo>;
+		};
+
+		iadcclk: iadcclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpaclk>;
+		};
+
+		lcdclk: lcdclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&lfrco>;
+		};
+
+		lesensehfclk: lesensehfclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&fsrco>;
+		};
+
+		lspclk: lspclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clocks = <&pclk>;
+		};
+
+		pclk: pclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clocks = <&hclk>;
+		};
+
+		pcnt0clk: pcnt0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em23grpaclk>;
+		};
+
+		sysclk: sysclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfrcodpll>;
 		};
 
 		sysrtcclk: sysrtcclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
-		wdog0clk: wdog0clk {
-			#clock-cells = <0>;
+		systickclk: systickclk {
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hclk>;
+		};
+
+		traceclk: traceclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1>;
+			clocks = <&sysclk>;
+		};
+
+		vdac0clk: vdac0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpaclk>;
+		};
+
+		wdog0clk: wdog0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
 		wdog1clk: wdog1clk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
-		};
-
-		lcdclk: lcdclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&lfrco>;
-		};
-
-		pcnt0clk: pcnt0clk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em23grpaclk>;
-		};
-
-		eusart0clk: eusart0clk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em01grpcclk>;
-		};
-
-		systickclk: systickclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-		};
-
-		vdac0clk: vdac0clk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em01grpaclk>;
 		};
 	};
 
@@ -167,40 +163,39 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			/*
-			 * The minimum residency and exit latency is
-			 * managed by sl_power_manager on S2 devices.
+			 * The minimum residency and exit latency is managed by sl_power_manager
+			 * on S2 devices.
 			 */
+			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
+			device_type = "cpu";
+
+			itm: itm@e0000000 {
+				compatible = "arm,armv8m-itm";
+				reg = <0xe0000000 0x1000>;
+			};
+
+			mpu: mpu@e000ed90 {
+				compatible = "arm,armv8m-mpu";
+				reg = <0xe000ed90 0x40>;
+			};
 		};
 
 		power-states {
-			/*
-			 * EM1 is a basic "CPU WFI idle", all high-freq clocks remain
-			 * enabled.
-			 */
 			pstate_em1: em1 {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";
-				/* HFXO remains active */
 			};
 
-			/*
-			 * EM2 is a deepsleep with HF clocks disabled by HW, voltages
-			 * scaled down, etc.
-			 */
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
 			};
 
-			/*
-			 * EM4 is a shutdown state where all clocks are off. The device
-			 * is reset on wakeup from EM4.
-			 */
 			pstate_em4: em4 {
 				compatible = "zephyr,power-state";
 				power-state-name = "soft-off";
@@ -209,99 +204,162 @@
 		};
 	};
 
-	sram0: memory@20000000 {
-		device_type = "memory";
-		compatible = "mmio-sram";
+	hwinfo: hwinfo {
+		compatible = "silabs,series2-hwinfo";
+		status = "disabled";
 	};
 
 	soc {
 		cmu: clock@50008000 {
 			compatible = "silabs,series-clock";
 			reg = <0x50008000 0x4000>;
-			interrupts = <48 2>;
-			interrupt-names = "cmu";
-			status = "okay";
 			#clock-cells = <2>;
+			interrupt-names = "cmu";
+			interrupts = <48 2>;
+			status = "okay";
+		};
+
+		hfrcodpll: hfrcodpll@50010000 {
+			compatible = "silabs,series2-hfrcodpll";
+			reg = <0x50010000 0x4000>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(19)>;
+			clocks = <&cmu CLOCK_HFRCO0 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "hfrco0";
+			interrupts = <46 2>;
 		};
 
 		fsrco: fsrco@50018000 {
-			#clock-cells = <0>;
 			compatible = "fixed-clock";
 			reg = <0x50018000 0x4000>;
-			clock-frequency = <DT_FREQ_M(20)>;
-		};
-
-		clk_hfxo: hfxo: hfxo@5a004000 {
 			#clock-cells = <0>;
-			compatible = "silabs,hfxo";
-			reg = <0x5a004000 0x4000>;
-			interrupts = <45 2>;
-			interrupt-names = "hfxo";
-			clock-frequency = <DT_FREQ_M(39)>;
-			ctune = <140>;
-			precision = <50>;
-			status = "disabled";
+			clock-frequency = <DT_FREQ_M(20)>;
+			clocks = <&cmu CLOCK_FSRCO CLOCK_BRANCH_INVALID>;
 		};
 
 		lfxo: lfxo@50020000 {
-			#clock-cells = <0>;
 			compatible = "silabs,series2-lfxo";
 			reg = <0x50020000 0x4000>;
+			#clock-cells = <0>;
 			clock-frequency = <32768>;
+			clocks = <&cmu CLOCK_LFXO CLOCK_BRANCH_INVALID>;
 			ctune = <63>;
+			interrupt-names = "lfxo";
+			interrupts = <23 2>;
 			precision = <50>;
 			timeout = <4096>;
 			status = "disabled";
 		};
 
-		hfrcodpll: hfrcodpll@50010000 {
-			#clock-cells = <0>;
-			compatible = "silabs,series2-hfrcodpll";
-			reg = <0x50010000 0x4000>;
-			clock-frequency = <DT_FREQ_M(19)>;
-		};
-
-		hfrcoem23: hfrcoem23@5a000000 {
-			#clock-cells = <0>;
-			compatible = "silabs,series2-hfrcoem23";
-			reg = <0x5a000000 0x4000>;
-			clock-frequency = <DT_FREQ_M(19)>;
-		};
-
 		lfrco: lfrco@50024000 {
-			#clock-cells = <0>;
 			compatible = "silabs,series2-lfrco";
 			reg = <0x50024000 0x4000>;
+			#clock-cells = <0>;
 			clock-frequency = <32768>;
+			clocks = <&cmu CLOCK_LFRCO CLOCK_BRANCH_INVALID>;
+			interrupt-names = "lfrco";
+			interrupts = <24 2>;
 		};
 
 		ulfrco: ulfrco@50028000 {
-			#clock-cells = <0>;
 			compatible = "fixed-clock";
 			reg = <0x50028000 0x4000>;
-			clock-frequency = <1000>;
-		};
-
-		clkin0: clkin0@5003c49c {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
-			reg = <0x5003c49c 0x4>;
-			clock-frequency = <DT_FREQ_M(38)>;
+			clock-frequency = <1000>;
+			clocks = <&cmu CLOCK_ULFRCO CLOCK_BRANCH_INVALID>;
+			interrupt-names = "ulfrco";
+			interrupts = <25 2>;
 		};
 
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
-			interrupts = <51 2>;
-
 			#address-cells = <1>;
 			#size-cells = <1>;
+			clocks = <&cmu CLOCK_MSC CLOCK_BRANCH_HCLK>;
+			interrupt-names = "msc";
+			interrupts = <51 2>;
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
-				write-block-size = <4>;
 				erase-block-size = <8192>;
+				write-block-size = <4>;
 			};
+		};
+
+		gpio: gpio@5003c000 {
+			compatible = "silabs,gpio";
+			reg = <0x5003c000 0x4000>;
+			ranges;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
+			interrupt-names = "gpio_odd", "gpio_even";
+			interrupts = <26 2>, <27 2>;
+
+			gpioa: gpio@5003c030 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c030 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <0>;
+				silabs,wakeup-pins = <5>;
+				status = "disabled";
+			};
+
+			gpiob: gpio@5003c060 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c060 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <3>, <4>;
+				silabs,wakeup-pins = <1>, <3>;
+				status = "disabled";
+			};
+
+			gpioc: gpio@5003c090 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c090 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <6>, <7>, <8>;
+				silabs,wakeup-pins = <0>, <5>, <7>;
+				status = "disabled";
+			};
+
+			gpiod: gpio@5003c0c0 {
+				compatible = "silabs,gpio-port";
+				reg = <0x5003c0c0 0x30>;
+				#gpio-cells = <2>;
+				gpio-controller;
+				silabs,wakeup-ints = <10>, <9>;
+				silabs,wakeup-pins = <5>, <2>;
+				status = "disabled";
+			};
+		};
+
+		pinctrl: pin-controller@5003c440 {
+			compatible = "silabs,dbus-pinctrl";
+			reg = <0x5003c440 0x0bc0>, <0x5003c320 0x40>;
+			reg-names = "dbus", "abus";
+		};
+
+		clkin0: clkin0@5003c49c {
+			compatible = "fixed-clock";
+			reg = <0x5003c49c 0x04>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(38)>;
+		};
+
+		dma0: dma@50040000 {
+			compatible = "silabs,ldma";
+			reg = <0x50040000 0x4000>;
+			#dma-cells = <1>;
+			clocks = <&cmu CLOCK_LDMA0 CLOCK_BRANCH_HCLK>;
+			dma-channels = <8>;
+			interrupt-names = "ldma";
+			interrupts = <22 2>;
+			status = "disabled";
 		};
 
 		timer0: timer@50048000 {
@@ -310,6 +368,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER0 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <32>;
+			interrupt-names = "timer0";
 			interrupts = <4 2>;
 			status = "disabled";
 
@@ -326,6 +385,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER1 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer1";
 			interrupts = <5 2>;
 			status = "disabled";
 
@@ -342,6 +402,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER2 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer2";
 			interrupts = <6 2>;
 			status = "disabled";
 
@@ -358,6 +419,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER3 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer3";
 			interrupts = <7 2>;
 			status = "disabled";
 
@@ -374,6 +436,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER4 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer4";
 			interrupts = <8 2>;
 			status = "disabled";
 
@@ -386,171 +449,69 @@
 
 		usart0: usart@5005c000 {
 			compatible = "silabs,usart-uart";
-			reg = <0x5005C000 0x4000>;
-			interrupts = <9 2>, <10 2>;
-			interrupt-names = "rx", "tx";
+			reg = <0x5005c000 0x4000>;
 			clocks = <&cmu CLOCK_USART0 CLOCK_BRANCH_PCLK>;
-			status = "disabled";
-		};
-
-		eusart0: eusart@5b010000 {
-			compatible = "silabs,eusart-spi";
-			reg = <0x5B010000 0x4000>;
-			interrupts = <11 2>, <12 2>;
 			interrupt-names = "rx", "tx";
-			clocks = <&cmu CLOCK_EUSART0 CLOCK_BRANCH_EUSART0CLK>;
-			status = "disabled";
-		};
-
-		eusart1: eusart@500a0000 {
-			compatible = "silabs,eusart-spi";
-			reg = <0x500A0000 0x4000>;
-			interrupts = <13 2>, <14 2>;
-			interrupt-names = "rx", "tx";
-			clocks = <&cmu CLOCK_EUSART1 CLOCK_BRANCH_EM01GRPCCLK>;
-			status = "disabled";
-		};
-
-		eusart2: eusart@500a4000 {
-			compatible = "silabs,eusart-spi";
-			reg = <0x500A4000 0x4000>;
-			interrupts = <15 2>, <16 2>;
-			interrupt-names = "rx", "tx";
-			clocks = <&cmu CLOCK_EUSART2 CLOCK_BRANCH_EM01GRPCCLK>;
+			interrupts = <9 2>, <10 2>;
 			status = "disabled";
 		};
 
 		burtc0: burtc@50064000 {
 			compatible = "silabs,gecko-burtc";
 			reg = <0x50064000 0x4000>;
-			interrupts = <18 2>;
 			clocks = <&cmu CLOCK_BURTC CLOCK_BRANCH_EM4GRPACLK>;
-			status = "disabled";
-		};
-
-		se: semailbox@5c000000 {
-			compatible = "silabs,gecko-semailbox";
-			reg = <0x5c000000 0x80>;
-			interrupts = <66 3>, <67 3>, <68 3>;
-			interrupt-names = "SETAMPERHOST", "SEMBRX", "SEMBTX";
-			status = "disabled";
-		};
-
-		i2c0: i2c@5b000000 {
-			compatible = "silabs,i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x5b000000 0x4000>;
-			interrupts = <28 2>;
-			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
+			interrupt-names = "burtc";
+			interrupts = <18 2>;
 			status = "disabled";
 		};
 
 		i2c1: i2c@50068000 {
 			compatible = "silabs,i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
+			reg = <0x50068000 0x4000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x50068000 0x4000>;
-			interrupts = <29 2>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			clocks = <&cmu CLOCK_I2C1 CLOCK_BRANCH_PCLK>;
+			interrupt-names = "i2c1";
+			interrupts = <29 2>;
+			status = "disabled";
+		};
+
+		dcdc: dcdc@50094000 {
+			compatible = "silabs,series2-dcdc";
+			reg = <0x50094000 0x4000>;
+			clocks = <&cmu CLOCK_DCDC CLOCK_BRANCH_INVALID>;
+			interrupt-names = "dcdc";
+			interrupts = <54 2>;
+			status = "disabled";
+		};
+
+		eusart1: eusart@500a0000 {
+			compatible = "silabs,eusart-spi";
+			reg = <0x500a0000 0x4000>;
+			clocks = <&cmu CLOCK_EUSART1 CLOCK_BRANCH_EM01GRPCCLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <13 2>, <14 2>;
+			status = "disabled";
+		};
+
+		eusart2: eusart@500a4000 {
+			compatible = "silabs,eusart-spi";
+			reg = <0x500a4000 0x4000>;
+			clocks = <&cmu CLOCK_EUSART2 CLOCK_BRANCH_EM01GRPCCLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <15 2>, <16 2>;
 			status = "disabled";
 		};
 
 		sysrtc0: stimer0: sysrtc@500a8000 {
 			compatible = "silabs,gecko-stimer";
 			reg = <0x500a8000 0x4000>;
-			interrupts = <70 2>, <71 2>;
-			interrupt-names = "sysrtc_app", "sysrtc_seq";
 			clock-frequency = <32768>;
-			prescaler = <1>;
 			clocks = <&cmu CLOCK_SYSRTC0 CLOCK_BRANCH_SYSRTCCLK>;
-			status = "disabled";
-		};
-
-		gpio: gpio@5003c000 {
-			compatible = "silabs,gpio";
-			reg = <0x5003c000 0x4000>;
-			interrupts = <27 2>, <26 2>;
-			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
-
-			ranges;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			gpioa: gpio@5003c030 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003c030 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <0>;
-				silabs,wakeup-pins = <5>;
-				status = "disabled";
-			};
-
-			gpiob: gpio@5003c060 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003c060 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <3>, <4>;
-				silabs,wakeup-pins = <1>, <3>;
-				status = "disabled";
-			};
-
-			gpioc: gpio@5003c090 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003c090 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <6>, <7>, <8>;
-				silabs,wakeup-pins = <0>, <5>, <7>;
-				status = "disabled";
-			};
-
-			gpiod: gpio@5003c0c0 {
-				compatible = "silabs,gpio-port";
-				reg = <0x5003c0c0 0x30>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				silabs,wakeup-ints = <9>, <10>;
-				silabs,wakeup-pins = <2>, <5>;
-				status = "disabled";
-			};
-		};
-
-		pinctrl: pin-controller@5003c440 {
-			compatible = "silabs,dbus-pinctrl";
-			reg = <0x5003c440 0xbc0>, <0x5003c320 0x40>;
-			reg-names = "dbus", "abus";
-		};
-
-		dma0: dma@50040000 {
-			compatible = "silabs,ldma";
-			reg = <0x50040000 0x4000>;
-			interrupts = <22 2>;
-			#dma-cells = <1>;
-			dma-channels = <8>;
-			status = "disabled";
-		};
-
-		wdog0: wdog@5b004000 {
-			compatible = "silabs,gecko-wdog";
-			reg = <0x5b004000 0x4000>;
-			peripheral-id = <0>;
-			interrupts = <43 2>;
-			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
-			status = "disabled";
-		};
-
-		wdog1: wdog@5b008000 {
-			compatible = "silabs,gecko-wdog";
-			reg = <0x5b008000 0x4000>;
-			peripheral-id = <1>;
-			interrupts = <44 2>;
-			clocks = <&cmu CLOCK_WDOG1 CLOCK_BRANCH_WDOG1CLK>;
+			interrupt-names = "sysrtc_app", "sysrtc_seq";
+			interrupts = <70 2>, <71 2>;
+			prescaler = <1>;
 			status = "disabled";
 		};
 
@@ -558,6 +519,7 @@
 			compatible = "silabs,series2-letimer";
 			reg = <0x59000000 0x4000>;
 			clocks = <&cmu CLOCK_LETIMER0 CLOCK_BRANCH_EM23GRPACLK>;
+			interrupt-names = "letimer0";
 			interrupts = <19 2>;
 			status = "disabled";
 
@@ -571,39 +533,127 @@
 		adc0: adc@59004000 {
 			compatible = "silabs,gecko-iadc";
 			reg = <0x59004000 0x4000>;
-			interrupts = <50 2>;
-			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
-			status = "disabled";
 			#io-channel-cells = <1>;
-		};
-
-		dcdc: dcdc@50094000 {
-			compatible = "silabs,series2-dcdc";
-			reg = <0x50094000 0x4000>;
-			interrupts = <54 2>;
+			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
+			interrupt-names = "iadc";
+			interrupts = <50 2>;
 			status = "disabled";
 		};
 
 		acmp0: acmp@59008000 {
 			compatible = "silabs,acmp";
 			reg = <0x59008000 0x4000>;
+			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "acmp0";
 			interrupts = <41 2>;
-			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
 
 		acmp1: acmp@5900c000 {
 			compatible = "silabs,acmp";
 			reg = <0x5900c000 0x4000>;
+			clocks = <&cmu CLOCK_ACMP1 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "acmp1";
 			interrupts = <42 2>;
-			clocks = <&cmu CLOCK_ACMP1 CLOCK_BRANCH_EM01GRPACLK>;
+			status = "disabled";
+		};
+
+		vdac0: vdac@59024000 {
+			compatible = "silabs,vdac";
+			reg = <0x59024000 0x4000>;
+			#address-cells = <1>;
+			#io-channel-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&cmu CLOCK_VDAC0 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "vdac0";
+			interrupts = <55 2>;
+			status = "disabled";
+
+			channel@0 {
+				reg = <0>;
+			};
+
+			channel@1 {
+				reg = <1>;
+			};
+		};
+
+		hfrcoem23: hfrcoem23@5a000000 {
+			compatible = "silabs,series2-hfrcoem23";
+			reg = <0x5a000000 0x4000>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(19)>;
+			clocks = <&cmu CLOCK_HFRCOEM23 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "hfrcoem23";
+			interrupts = <47 2>;
+		};
+
+		clk_hfxo: hfxo: hfxo@5a004000 {
+			compatible = "silabs,hfxo";
+			reg = <0x5a004000 0x4000>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(39)>;
+			clocks = <&cmu CLOCK_HFXO0 CLOCK_BRANCH_INVALID>;
+			ctune = <140>;
+			interrupt-names = "hfxo0";
+			interrupts = <45 2>;
+			precision = <50>;
+			status = "disabled";
+		};
+
+		i2c0: i2c@5b000000 {
+			compatible = "silabs,i2c";
+			reg = <0x5b000000 0x4000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
+			interrupt-names = "i2c0";
+			interrupts = <28 2>;
+			status = "disabled";
+		};
+
+		wdog0: wdog@5b004000 {
+			compatible = "silabs,gecko-wdog";
+			reg = <0x5b004000 0x4000>;
+			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
+			interrupt-names = "wdog0";
+			interrupts = <43 2>;
+			peripheral-id = <0>;
+			status = "disabled";
+		};
+
+		wdog1: wdog@5b008000 {
+			compatible = "silabs,gecko-wdog";
+			reg = <0x5b008000 0x4000>;
+			clocks = <&cmu CLOCK_WDOG1 CLOCK_BRANCH_WDOG1CLK>;
+			interrupt-names = "wdog1";
+			interrupts = <44 2>;
+			peripheral-id = <1>;
+			status = "disabled";
+		};
+
+		eusart0: eusart@5b010000 {
+			compatible = "silabs,eusart-spi";
+			reg = <0x5b010000 0x4000>;
+			clocks = <&cmu CLOCK_EUSART0 CLOCK_BRANCH_EUSART0CLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <11 2>, <12 2>;
+			status = "disabled";
+		};
+
+		se: semailbox@5c000000 {
+			compatible = "silabs,gecko-semailbox";
+			reg = <0x5c000000 0x4000>;
+			interrupt-names = "setamperhost", "sembrx", "sembtx";
+			interrupts = <66 2>, <67 2>, <68 2>;
 			status = "disabled";
 		};
 	};
 
-	hwinfo: hwinfo {
-		compatible = "silabs,gecko-hwinfo";
-		status = "disabled";
+	sram0: memory@20000000 {
+		compatible = "mmio-sram";
+		device_type = "memory";
 	};
 };
 

--- a/dts/arm/silabs/xg29/efr32bg29b140f1024im40.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b140f1024im40.dtsi
@@ -14,10 +14,10 @@
 	};
 };
 
-&sram0 {
-	reg = <0x20000000 DT_SIZE_K(256)>;
-};
-
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32bg29b220f1024cj45.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b220f1024cj45.dtsi
@@ -15,17 +15,17 @@
 	};
 };
 
-&sram0 {
-	reg = <0x20000000 DT_SIZE_K(256)>;
+&dcdc {
+	regulator-boot-on;
+	regulator-init-microvolt = <1800000>;
+	regulator-initial-mode = <SILABS_DCDC_MODE_BOOST>;
+	status = "okay";
 };
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
-&dcdc {
-	regulator-boot-on;
-	regulator-initial-mode = <SILABS_DCDC_MODE_BOOST>;
-	regulator-init-microvolt = <1800000>;
-	status = "okay";
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32bg29b221f1024cj45.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b221f1024cj45.dtsi
@@ -15,17 +15,17 @@
 	};
 };
 
-&sram0 {
-	reg = <0x20000000 DT_SIZE_K(192)>;
+&dcdc {
+	regulator-boot-on;
+	regulator-init-microvolt = <1800000>;
+	regulator-initial-mode = <SILABS_DCDC_MODE_BOOST>;
+	status = "okay";
 };
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
-&dcdc {
-	regulator-boot-on;
-	regulator-initial-mode = <SILABS_DCDC_MODE_BOOST>;
-	regulator-init-microvolt = <1800000>;
-	status = "okay";
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(192)>;
 };

--- a/dts/arm/silabs/xg29/efr32bg29b230f1024cm40.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b230f1024cm40.dtsi
@@ -15,17 +15,17 @@
 	};
 };
 
-&sram0 {
-	reg = <0x20000000 DT_SIZE_K(256)>;
+&dcdc {
+	regulator-boot-on;
+	regulator-init-microvolt = <1800000>;
+	regulator-initial-mode = <SILABS_DCDC_MODE_BOOST>;
+	status = "okay";
 };
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
-&dcdc {
-	regulator-boot-on;
-	regulator-initial-mode = <SILABS_DCDC_MODE_BOOST>;
-	regulator-init-microvolt = <1800000>;
-	status = "okay";
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32mg29b140f1024im40.dtsi
+++ b/dts/arm/silabs/xg29/efr32mg29b140f1024im40.dtsi
@@ -14,10 +14,10 @@
 	};
 };
 
-&sram0 {
-	reg = <0x20000000 DT_SIZE_K(256)>;
-};
-
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32mg29b230f1024cm40.dtsi
+++ b/dts/arm/silabs/xg29/efr32mg29b230f1024cm40.dtsi
@@ -15,17 +15,17 @@
 	};
 };
 
-&sram0 {
-	reg = <0x20000000 DT_SIZE_K(256)>;
+&dcdc {
+	regulator-boot-on;
+	regulator-init-microvolt = <1800000>;
+	regulator-initial-mode = <SILABS_DCDC_MODE_BOOST>;
+	status = "okay";
 };
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
 };
 
-&dcdc {
-	regulator-boot-on;
-	regulator-initial-mode = <SILABS_DCDC_MODE_BOOST>;
-	regulator-init-microvolt = <1800000>;
-	status = "okay";
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg29/efr32xg29.dtsi
+++ b/dts/arm/silabs/xg29/efr32xg29.dtsi
@@ -10,16 +10,16 @@
 	soc {
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
-			reg = <0xb0000000 0x1000000>;
-			interrupts = <36 1>, <37 1>, <38 1>, <39 1>, <40 1>, <41 1>,
-				     <42 1>, <43 1>, <44 1>, <45 1>, <46 1>, <47 1>;
+			reg = <0xb0000000 0x01000000>;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 					  "rac_rsm", "rac_seq", "rdmailbox", "rfsense", "synth",
 					  "prortc";
+			interrupts = <36 1>, <37 1>, <38 1>, <39 1>, <40 1>, <41 1>, <42 1>,
+				     <43 1>, <44 1>, <45 1>, <46 1>, <47 1>;
+			pa-2p4ghz = "highest";
 			pa-initial-power-dbm = <10>;
 			pa-ramp-time-us = <2>;
 			pa-voltage-mv = <3300>;
-			pa-2p4ghz = "highest";
 
 			bt_hci_silabs: bt_hci_silabs {
 				compatible = "silabs,bt-hci-efr32";

--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -5,136 +5,137 @@
  */
 
 #include <arm/armv8-m.dtsi>
+#include <freq.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/silabs/xg29-clock.h>
 #include <zephyr/dt-bindings/dma/silabs/xg29-dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
-#include <freq.h>
 
 / {
 	chosen {
-		zephyr,flash-controller = &msc;
 		zephyr,entropy = &se;
+		zephyr,flash-controller = &msc;
 	};
 
 	clocks {
-		hfxort: hfxort {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfxo>;
-		};
-
-		hfrcodpllrt: hfrcodpllrt {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfrcodpll>;
-		};
-
-		sysclk: sysclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hfrcodpll>;
-		};
-
-		hclk: hclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&sysclk>;
-			/* Divisors 1, 2, 4, 8, 16 allowed */
-			clock-div = <1>;
-		};
-
-		pclk: pclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-			/* Divisors 1, 2 allowed */
-			clock-div = <2>;
-		};
-
-		lspclk: lspclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&pclk>;
-			/* Fixed divisor of 2 */
-			clock-div = <2>;
-		};
-
-		hclkdiv1024: hclkdiv1024 {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&hclk>;
-			/* Fixed divisor of 1024 */
-			clock-div = <1024>;
-		};
-
-		traceclk: traceclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&sysclk>;
-			/* Divisors 1, 2, 3, 4 allowed */
-			clock-div = <1>;
-		};
-
 		em01grpaclk: em01grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hfrcodpll>;
 		};
 
 		em01grpbclk: em01grpbclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hfrcodpll>;
 		};
 
 		em01grpcclk: em01grpcclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hfrcodpll>;
 		};
 
-		iadcclk: iadcclk {
-			#clock-cells = <0>;
-			compatible = "fixed-factor-clock";
-			clocks = <&em01grpaclk>;
-		};
-
 		em23grpaclk: em23grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
 		em4grpaclk: em4grpaclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&lfrco>;
+		};
+
+		eusart0clk: eusart0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpaclk>;
+		};
+
+		hclk: hclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1>;
+			clocks = <&sysclk>;
+		};
+
+		hclkdiv1024: hclkdiv1024 {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <1024>;
+			clocks = <&hclk>;
+		};
+
+		hfrcodpllrt: hfrcodpllrt {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfrcodpll>;
+		};
+
+		hfxort: hfxort {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&hfxo>;
+		};
+
+		iadcclk: iadcclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&em01grpaclk>;
+		};
+
+		lspclk: lspclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clocks = <&pclk>;
+		};
+
+		pclk: pclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clocks = <&hclk>;
+		};
+
+		prortcclk: prortcclk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
 		rtccclk: rtccclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&lfrco>;
 		};
 
-		wdog0clk: wdog0clk {
-			#clock-cells = <0>;
+		sysclk: sysclk {
 			compatible = "fixed-factor-clock";
-			clocks = <&lfrco>;
+			#clock-cells = <0>;
+			clocks = <&hfrcodpll>;
 		};
 
 		systickclk: systickclk {
-			#clock-cells = <0>;
 			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
 			clocks = <&hclk>;
 		};
 
-		eusart0clk: eusart0clk {
-			#clock-cells = <0>;
+		traceclk: traceclk {
 			compatible = "fixed-factor-clock";
-			clocks = <&em01grpaclk>;
+			#clock-cells = <0>;
+			clock-div = <1>;
+			clocks = <&sysclk>;
+		};
+
+		wdog0clk: wdog0clk {
+			compatible = "fixed-factor-clock";
+			#clock-cells = <0>;
+			clocks = <&lfrco>;
 		};
 	};
 
@@ -143,47 +144,39 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
-			/*
-			 * The minimum residency and exit latency is
-			 * managed by sl_power_manager on S2 devices.
-			 */
 			#address-cells = <1>;
 			#size-cells = <1>;
+			/*
+			 * The minimum residency and exit latency is managed by sl_power_manager
+			 * on S2 devices.
+			 */
+			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em4>;
+			device_type = "cpu";
 
 			itm: itm@e0000000 {
 				compatible = "arm,armv8m-itm";
 				reg = <0xe0000000 0x1000>;
 			};
+
+			mpu: mpu@e000ed90 {
+				compatible = "arm,armv8m-mpu";
+				reg = <0xe000ed90 0x40>;
+			};
 		};
 
 		power-states {
-			/*
-			 * EM1 is a basic "CPU WFI idle", all high-freq clocks remain
-			 * enabled.
-			 */
 			pstate_em1: em1 {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";
-				/* HFXO remains active */
 			};
 
-			/*
-			 * EM2 is a deepsleep with HF clocks disabled by HW, voltages
-			 * scaled down, etc.
-			 */
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
 			};
 
-			/*
-			 * EM4 is a shutdown state where all clocks are off. The device
-			 * is reset on wakeup from EM4.
-			 */
 			pstate_em4: em4 {
 				compatible = "zephyr,power-state";
 				power-state-name = "soft-off";
@@ -192,117 +185,117 @@
 		};
 	};
 
-	sram0: memory@20000000 {
-		device_type = "memory";
-		compatible = "mmio-sram";
+	hwinfo: hwinfo {
+		compatible = "silabs,series2-hwinfo";
+		status = "disabled";
 	};
 
 	soc {
 		cmu: clock@50008000 {
 			compatible = "silabs,series-clock";
 			reg = <0x50008000 0x4000>;
-			interrupts = <52 2>;
-			interrupt-names = "cmu";
-			status = "okay";
 			#clock-cells = <2>;
+			interrupt-names = "cmu";
+			interrupts = <52 2>;
+			status = "okay";
 		};
 
-		hfxo: hfxo@5000c000 {
-			#clock-cells = <0>;
+		clk_hfxo: hfxo: hfxo@5000c000 {
 			compatible = "silabs,hfxo";
 			reg = <0x5000c000 0x4000>;
-			interrupts = <50 0>;
-			interrupt-names = "hfxo0";
+			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_K(38400)>;
+			clocks = <&cmu CLOCK_HFXO0 CLOCK_BRANCH_INVALID>;
 			ctune = <140>;
+			interrupt-names = "hfxo0";
+			interrupts = <50 2>;
 			precision = <50>;
 			status = "disabled";
 		};
 
 		hfrcodpll: hfrcodpll@50010000 {
-			#clock-cells = <0>;
 			compatible = "silabs,series2-hfrcodpll";
 			reg = <0x50010000 0x4000>;
-			interrupts = <51 0>, <56 0>;
-			interrupt-names = "hfrco0", "dpll0";
+			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(19)>;
+			clocks = <&cmu CLOCK_HFRCO0 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "hfrco0";
+			interrupts = <51 2>;
 		};
 
 		fsrco: fsrco@50018000 {
-			#clock-cells = <0>;
 			compatible = "fixed-clock";
 			reg = <0x50018000 0x4000>;
+			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(20)>;
+			clocks = <&cmu CLOCK_FSRCO CLOCK_BRANCH_INVALID>;
 		};
 
 		lfxo: lfxo@50020000 {
-			#clock-cells = <0>;
 			compatible = "silabs,series2-lfxo";
 			reg = <0x50020000 0x4000>;
-			interrupts = <27 2>;
-			interrupt-names = "lfxo";
+			#clock-cells = <0>;
 			clock-frequency = <32768>;
+			clocks = <&cmu CLOCK_LFXO CLOCK_BRANCH_INVALID>;
 			ctune = <63>;
+			interrupt-names = "lfxo";
+			interrupts = <27 2>;
 			precision = <50>;
 			timeout = <4096>;
 			status = "disabled";
 		};
 
 		lfrco: lfrco@50024000 {
-			#clock-cells = <0>;
 			compatible = "silabs,series2-lfrco";
 			reg = <0x50024000 0x4000>;
-			interrupts = <28 2>;
-			interrupt-names = "lfrco";
+			#clock-cells = <0>;
 			clock-frequency = <32768>;
+			clocks = <&cmu CLOCK_LFRCO CLOCK_BRANCH_INVALID>;
+			interrupt-names = "lfrco";
+			interrupts = <28 2>;
 		};
 
 		ulfrco: ulfrco@50028000 {
-			#clock-cells = <0>;
 			compatible = "fixed-clock";
 			reg = <0x50028000 0x4000>;
-			interrupts = <29 2>;
-			interrupt-names = "ulfrco";
-			clock-frequency = <1000>;
-		};
-
-		clkin0: clkin0@5003c460 {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
-			reg = <0x5003c460 0x4>;
-			clock-frequency = <DT_FREQ_M(38)>;
+			clock-frequency = <1000>;
+			clocks = <&cmu CLOCK_ULFRCO CLOCK_BRANCH_INVALID>;
+			interrupt-names = "ulfrco";
+			interrupts = <29 2>;
 		};
 
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
-			interrupts = <55 2>;
-			interrupt-names = "msc";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			clocks = <&cmu CLOCK_MSC CLOCK_BRANCH_HCLK>;
+			interrupt-names = "msc";
+			interrupts = <55 2>;
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
-				write-block-size = <4>;
 				erase-block-size = <8192>;
+				write-block-size = <4>;
 			};
 		};
 
 		gpio: gpio@5003c000 {
 			compatible = "silabs,gpio";
-			reg = <0x5003C000 0x440>;
-			interrupts = <31 2>, <30 2>;
-			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
+			reg = <0x5003c000 0x4000>;
 			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
+			interrupt-names = "gpio_odd", "gpio_even";
+			interrupts = <30 2>, <31 2>;
 
 			gpioa: gpio@5003c030 {
 				compatible = "silabs,gpio-port";
-				reg = <0x5003C030 0x30>;
-				gpio-controller;
+				reg = <0x5003c030 0x30>;
 				#gpio-cells = <2>;
+				gpio-controller;
 				silabs,wakeup-ints = <0>;
 				silabs,wakeup-pins = <5>;
 				status = "disabled";
@@ -310,9 +303,9 @@
 
 			gpiob: gpio@5003c060 {
 				compatible = "silabs,gpio-port";
-				reg = <0x5003C060 0x30>;
-				gpio-controller;
+				reg = <0x5003c060 0x30>;
 				#gpio-cells = <2>;
+				gpio-controller;
 				silabs,wakeup-ints = <3>, <4>;
 				silabs,wakeup-pins = <1>, <3>;
 				status = "disabled";
@@ -320,9 +313,9 @@
 
 			gpioc: gpio@5003c090 {
 				compatible = "silabs,gpio-port";
-				reg = <0x5003C090 0x30>;
-				gpio-controller;
+				reg = <0x5003c090 0x30>;
 				#gpio-cells = <2>;
+				gpio-controller;
 				silabs,wakeup-ints = <6>, <7>, <8>;
 				silabs,wakeup-pins = <0>, <5>, <7>;
 				status = "disabled";
@@ -330,9 +323,9 @@
 
 			gpiod: gpio@5003c0c0 {
 				compatible = "silabs,gpio-port";
-				reg = <0x5003C0C0 0x30>;
-				gpio-controller;
+				reg = <0x5003c0c0 0x30>;
 				#gpio-cells = <2>;
+				gpio-controller;
 				silabs,wakeup-ints = <9>;
 				silabs,wakeup-pins = <2>;
 				status = "disabled";
@@ -341,17 +334,25 @@
 
 		pinctrl: pin-controller@5003c440 {
 			compatible = "silabs,dbus-pinctrl";
-			reg = <0x5003c440 0xbc0>, <0x5003c320 0x40>;
+			reg = <0x5003c440 0x0bc0>, <0x5003c320 0x40>;
 			reg-names = "dbus", "abus";
 		};
 
-		dma0: dma@40040000 {
+		clkin0: clkin0@5003c460 {
+			compatible = "fixed-clock";
+			reg = <0x5003c460 0x04>;
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(38)>;
+		};
+
+		dma0: dma@50040000 {
 			compatible = "silabs,ldma";
-			reg = <0x40040000 0x4000>;
-			interrupts = <26 0>;
-			interrupt-names = "ldma";
+			reg = <0x50040000 0x4000>;
 			#dma-cells = <1>;
+			clocks = <&cmu CLOCK_LDMA0 CLOCK_BRANCH_HCLK>;
 			dma-channels = <8>;
+			interrupt-names = "ldma";
+			interrupts = <26 2>;
 			status = "disabled";
 		};
 
@@ -361,6 +362,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER0 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <32>;
+			interrupt-names = "timer0";
 			interrupts = <10 2>;
 			status = "disabled";
 
@@ -377,6 +379,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER1 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <32>;
+			interrupt-names = "timer1";
 			interrupts = <11 2>;
 			status = "disabled";
 
@@ -393,6 +396,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER2 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer2";
 			interrupts = <12 2>;
 			status = "disabled";
 
@@ -409,6 +413,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER3 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer3";
 			interrupts = <13 2>;
 			status = "disabled";
 
@@ -425,6 +430,7 @@
 			channels = <3>;
 			clocks = <&cmu CLOCK_TIMER4 CLOCK_BRANCH_EM01GRPACLK>;
 			counter-size = <16>;
+			interrupt-names = "timer4";
 			interrupts = <14 2>;
 			status = "disabled";
 
@@ -437,88 +443,68 @@
 
 		usart0: usart@5005c000 {
 			compatible = "silabs,usart-uart";
-			reg = <0x5005C000 0x400>;
-			interrupts = <16 2>, <17 2>;
-			interrupt-names = "rx", "tx";
+			reg = <0x5005c000 0x4000>;
 			clocks = <&cmu CLOCK_USART0 CLOCK_BRANCH_PCLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <16 2>, <17 2>;
 			status = "disabled";
 		};
 
 		usart1: usart@50060000 {
 			compatible = "silabs,usart-uart";
-			reg = <0x50060000 0x400>;
-			interrupts = <18 2>, <19 2>;
-			interrupt-names = "rx", "tx";
+			reg = <0x50060000 0x4000>;
 			clocks = <&cmu CLOCK_USART1 CLOCK_BRANCH_PCLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <18 2>, <19 2>;
 			status = "disabled";
 		};
 
 		burtc0: burtc@50064000 {
 			compatible = "silabs,gecko-burtc";
 			reg = <0x50064000 0x4000>;
-			interrupts = <23 2>;
-			interrupt-names = "burtc";
 			clocks = <&cmu CLOCK_BURTC CLOCK_BRANCH_EM4GRPACLK>;
-			status = "disabled";
-		};
-
-		i2c0: i2c@5a010000 {
-			compatible = "silabs,i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			reg = <0x5a010000 0x4000>;
-			interrupts = <32 2>;
-			interrupt-names = "i2c0";
-			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
-			#address-cells = <1>;
-			#size-cells = <0>;
+			interrupt-names = "burtc";
+			interrupts = <23 2>;
 			status = "disabled";
 		};
 
 		i2c1: i2c@50068000 {
 			compatible = "silabs,i2c";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x50068000 0x4000>;
-			interrupts = <33 2>;
-			interrupt-names = "i2c1";
-			clocks = <&cmu CLOCK_I2C1 CLOCK_BRANCH_PCLK>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			clocks = <&cmu CLOCK_I2C1 CLOCK_BRANCH_PCLK>;
+			interrupt-names = "i2c1";
+			interrupts = <33 2>;
 			status = "disabled";
 		};
 
 		dcdc: dcdc@50094000 {
 			compatible = "silabs,series2-dcdc";
 			reg = <0x50094000 0x4000>;
-			interrupts = <8 2>;
+			clocks = <&cmu CLOCK_DCDC CLOCK_BRANCH_INVALID>;
 			interrupt-names = "dcdc";
-			status = "disabled";
-		};
-
-		eusart0: eusart@5a040000 {
-			compatible = "silabs,eusart-spi";
-			reg = <0x5A040000 0x4000>;
-			interrupts = <20 2>, <21 2>;
-			interrupt-names = "rx", "tx";
-			clocks = <&cmu CLOCK_EUSART0 CLOCK_BRANCH_EUSART0CLK>;
+			interrupts = <8 2>;
 			status = "disabled";
 		};
 
 		eusart1: eusart@500b4000 {
 			compatible = "silabs,eusart-spi";
-			reg = <0x500B4000 0x4000>;
-			interrupts = <68 2>, <69 2>;
-			interrupt-names = "rx", "tx";
+			reg = <0x500b4000 0x4000>;
 			clocks = <&cmu CLOCK_EUSART1 CLOCK_BRANCH_EM01GRPCCLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <68 2>, <69 2>;
 			status = "disabled";
 		};
 
-		rtcc0: rtcc@58000000 {
+		rtcc0: stimer0: rtcc@58000000 {
 			compatible = "silabs,gecko-stimer";
 			reg = <0x58000000 0x4000>;
-			interrupts = <15 2>;
-			interrupt-names = "rtcc";
-			clocks = <&cmu CLOCK_RTCC CLOCK_BRANCH_RTCCCLK>;
 			clock-frequency = <32768>;
+			clocks = <&cmu CLOCK_RTCC CLOCK_BRANCH_RTCCCLK>;
+			interrupt-names = "rtcc";
+			interrupts = <15 2>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -526,10 +512,10 @@
 		wdog0: wdog@58018000 {
 			compatible = "silabs,gecko-wdog";
 			reg = <0x58018000 0x4000>;
-			peripheral-id = <0>;
-			interrupts = <49 2>;
-			interrupt-names = "wdog0";
 			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
+			interrupt-names = "wdog0";
+			interrupts = <49 2>;
+			peripheral-id = <0>;
 			status = "disabled";
 		};
 
@@ -537,6 +523,7 @@
 			compatible = "silabs,series2-letimer";
 			reg = <0x5a000000 0x4000>;
 			clocks = <&cmu CLOCK_LETIMER0 CLOCK_BRANCH_EM23GRPACLK>;
+			interrupt-names = "letimer0";
 			interrupts = <24 2>;
 			status = "disabled";
 
@@ -550,33 +537,55 @@
 		adc0: adc@5a004000 {
 			compatible = "silabs,gecko-iadc";
 			reg = <0x5a004000 0x4000>;
-			interrupts = <54 2>;
-			interrupt-names = "iadc0";
-			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
-			status = "disabled";
 			#io-channel-cells = <1>;
+			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
+			interrupt-names = "iadc";
+			interrupts = <54 2>;
+			status = "disabled";
 		};
 
 		acmp0: acmp@5a008000 {
 			compatible = "silabs,acmp";
 			reg = <0x5a008000 0x4000>;
+			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_INVALID>;
+			interrupt-names = "acmp0";
 			interrupts = <48 2>;
-			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
 
-		se: semailbox@4c000000 {
+		i2c0: i2c@5a010000 {
+			compatible = "silabs,i2c";
+			reg = <0x5a010000 0x4000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
+			interrupt-names = "i2c0";
+			interrupts = <32 2>;
+			status = "disabled";
+		};
+
+		eusart0: eusart@5a040000 {
+			compatible = "silabs,eusart-spi";
+			reg = <0x5a040000 0x4000>;
+			clocks = <&cmu CLOCK_EUSART0 CLOCK_BRANCH_EUSART0CLK>;
+			interrupt-names = "rx", "tx";
+			interrupts = <20 2>, <21 2>;
+			status = "disabled";
+		};
+
+		se: semailbox@5c000000 {
 			compatible = "silabs,gecko-semailbox";
-			reg = <0x4c000000 0x1000>;
-			interrupts = <0 3>, <1 3>, <2 3>;
-			interrupt-names = "SETAMPERHOST", "SEMBRX", "SEMBTX";
+			reg = <0x5c000000 0x4000>;
+			interrupt-names = "setamperhost", "sembrx", "sembtx";
+			interrupts = <0 2>, <1 2>, <2 2>;
 			status = "disabled";
 		};
 	};
 
-	hwinfo: hwinfo {
-		compatible = "silabs,series2-hwinfo";
-		status = "disabled";
+	sram0: memory@20000000 {
+		compatible = "mmio-sram";
+		device_type = "memory";
 	};
 };
 


### PR DESCRIPTION
Reformat devicetree files according to <https://docs.zephyrproject.org/latest/contribute/style/devicetree.html> and <https://docs.kernel.org/devicetree/bindings/dts-coding-style.html>:

 * Sort nodes by unit address or name
 * Sort properties by category and name

Add a couple of missing nodes with existing drivers (MPU, clocks, I2C1 on xg24, VDAC0 on xg28).
There should be no changes to existing functionality.