### PR TITLE
scripts: ci: check_compliance: fix misleading error message when Signed-off-by check fails

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1744,6 +1744,7 @@ class Identity(ComplianceTest):
                 auth_name, auth_email, body = commit_info
             else:
                 self.failure(f'Unable to parse commit message for {shaidx}')
+                continue
 
             match_signoff = re.search(r"signed-off-by:\s(.*)", body,
                                       re.IGNORECASE)


### PR DESCRIPTION
Commit https://github.com/zephyrproject-rtos/zephyr/commit/e4650bc3491e6fa2a6dde9c109f490174a9ebc03 modified `check_compliance` to avoid false negatives when a commit has multiple signoff lines and the author's signoff line isn't the first one. To avoid this, a signoff line which matches exactly the author's name and email is searched instead of matching any line with the proper syntax and checking the fields.

While this solved the original issue, this also introduced a new issue: the old script distinguished *a properly formed signoff line with the wrong author* from *a malformed signoff line*, but the new method perfoms both the syntax and the author name/email checks at the same time. As such, if any of these fail, the script will report `signoff line does not follow the syntax` even though the signoff line **DOES** follow the syntax in the latter case. This makes the error message nothing but a misleading red herring, which is quite unfortunate considering this situation is much more likely to occur than the "malformed syntax" one.

Example here: https://github.com/zephyrproject-rtos/zephyr/actions/runs/16752997174/job/47427937294?pr=93699#step:10:47

Fix this issue - and improve the check - by *actually verifying every signoff line* in a commit's message body. Invalid syntax on any line is reported as a `does not follow syntax` failure, whereas inability to find the commit author is reported as a separate `no signoff entry matches commit author` failure as it should always have...

\+ tiny commit to fix a potential issue reported by VS Code's linter that would occur if `git show` failed (this has presumably never happened since the bug is still here :slightly_smiling_face:)