### PR TITLE
drivers: sai: Fix compile time error with clang

### DIFF
--- a/drivers/dai/nxp/sai/sai.c
+++ b/drivers/dai/nxp/sai/sai.c
@@ -886,6 +886,21 @@ static int sai_init(const struct device *dev)
 
 	device_map(&data->regmap, cfg->regmap_phys, cfg->regmap_size, K_MEM_CACHE_NONE);
 
+	if (SAI_DLINE_COUNT(cfg->regmap_phys) == -1) {
+		LOG_ERR("bad or unsupported SAI instance");
+		return -EINVAL;
+	}
+
+	if (cfg->tx_dline >= SAI_DLINE_COUNT(cfg->regmap_phys)) {
+		LOG_ERR("invalid TX data line index");
+		return -EINVAL;
+	}
+
+	if (cfg->rx_dline >= SAI_DLINE_COUNT(cfg->regmap_phys)) {
+		LOG_ERR("invalid RX data line index");
+		return -EINVAL;
+	}
+
 #ifndef CONFIG_PM_DEVICE_RUNTIME
 	ret = sai_clks_enable_disable(dev, true);
 	if (ret < 0) {
@@ -934,17 +949,6 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_SAI_HAS_MCLK_CONFIG_OPTION) ||			\
 BUILD_ASSERT(SAI_TX_SYNC_MODE(inst) != SAI_RX_SYNC_MODE(inst) ||		\
 	     SAI_TX_SYNC_MODE(inst) != kSAI_ModeSync,				\
 	     "transmitter and receiver can't be both SYNC with each other");	\
-										\
-BUILD_ASSERT(SAI_DLINE_COUNT(inst) != -1,					\
-	     "bad or unsupported SAI instance. Is the base address correct?");	\
-										\
-BUILD_ASSERT(SAI_TX_DLINE_INDEX(inst) >= 0 &&					\
-	     (SAI_TX_DLINE_INDEX(inst) < SAI_DLINE_COUNT(inst)),		\
-	     "invalid TX data line index");					\
-										\
-BUILD_ASSERT(SAI_RX_DLINE_INDEX(inst) >= 0 &&					\
-	     (SAI_RX_DLINE_INDEX(inst) < SAI_DLINE_COUNT(inst)),		\
-	     "invalid RX data line index");					\
 										\
 static const struct dai_properties sai_tx_props_##inst = {			\
 	.fifo_address = SAI_TX_FIFO_BASE(inst, SAI_TX_DLINE_INDEX(inst)),	\

--- a/drivers/dai/nxp/sai/sai.h
+++ b/drivers/dai/nxp/sai/sai.h
@@ -148,8 +148,8 @@ LOG_MODULE_REGISTER(nxp_dai_sai);
 	 ((DT_INST_DMAS_CELL_BY_NAME(inst, dir, mux) << 8) & GENMASK(15, 8)))
 
 /* used to retrieve the number of supported transmission/receive lines */
-#define SAI_DLINE_COUNT(inst)\
-	FSL_FEATURE_SAI_CHANNEL_COUNTn(UINT_TO_I2S(DT_INST_REG_ADDR(inst)))
+#define SAI_DLINE_COUNT(base)\
+	FSL_FEATURE_SAI_CHANNEL_COUNTn(UINT_TO_I2S(base))
 
 /* used to retrieve the index of the transmission line */
 #define SAI_TX_DLINE_INDEX(inst) DT_INST_PROP_OR(inst, tx_dataline, 0)


### PR DESCRIPTION
After commit 524b72ce40530 ("toolchain: llvm: Provide working BUILD_ASSERT macro") when compiling with clang we have actual checks and a real assert check using _Static_assert.

Now, when compiling with clang (used by Xtensa internal toolchain) we get the following error.

$ zephyr/drivers/dai/nxp/sai/sai.c:968:29: error: static_assert expression
 is not an integral constant expression

We get this in asserts like this:

BUILD_ASSERT(SAI_DLINE_COUNT(inst) != -1, "...").

This expands to (reduced the macro to easier understand the context):

_Static_assert(((((((I2S_Type *)(uintptr_t)(1493499904U))) == ((I2S_Type *)(0x59040000u)))

... and clang complains that this is not a constant expression.

So, in order to fix the compile time error remove the compile time asserts and replace them with runtime checks.


Fixes: commit 524b72ce40530 ("toolchain: llvm: Provide working BUILD_ASSERT macro")