### PR TITLE
soc: silabs: siwx91x: Add firmware version check of NWP

### DIFF
--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -197,6 +197,7 @@ if(CONFIG_WISECONNECT_NETWORK_STACK)
   zephyr_library_sources_ifdef(CONFIG_SIWX91X_FIRMWARE_UPGRADE
     ${WISECONNECT_DIR}/components/device/silabs/si91x/wireless/firmware_upgrade/firmware_upgradation.c
   )
+  zephyr_include_directories(.)
 endif() # CONFIG_WISECONNECT_NETWORK_STACK
 
 if(CONFIG_SOC_SILABS_SLEEPTIMER)

--- a/modules/hal_silabs/wiseconnect/nwp_fw_version.h
+++ b/modules/hal_silabs/wiseconnect/nwp_fw_version.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* This value needs to be updated when the Wiseconnect SDK (hal_silabs/wiseconnect) is updated
+ * Actually mapped to Wiseconnect SDK 3.5.0
+ */
+#define SIWX91X_NWP_FW_EXPECTED_VERSION "B.2.14.5.2.0.7"


### PR DESCRIPTION
This commit introduces a new function to verify the firmware version of the SiWX917 network coprocessor. It checks the expected version (updated manually after each bump of Wiseconnect SDK in hal_silabs) against the actual version retrieved from the device.

It's actually not a "panic" if the version is not the expected one so it will not break anything but It will start advertising users about the problem.