### PR TITLE
scripts: dts: fix CMake DT API helper for compatible properties

### DIFF
--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -134,10 +134,8 @@ def main():
                 cmake_prop = f'DT_PROP|{node.path}|{item}'
                 cmake_props.append(f'"{cmake_prop}" "{escape(cmake_value)}"')
 
-                if item == 'compatible':
-                    # compatibles is always an array
-                    for comp in node.props[item].val:
-                        compatible2paths[comp].append(node.path)
+        for comp in node.compats:
+            compatible2paths[comp].append(node.path)
 
         if node.regs is not None:
             cmake_props.append(f'"DT_REG|{node.path}|NUM" "{len(node.regs)}"')


### PR DESCRIPTION
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/96761

Our build system DT API has a dt_comp_path() function used to look up paths of nodes with a given compatible. This relies on the generated edt.pickle.cmake file in the build directory to look inside the concrete devicetree for the current application build.

The script gen_dts_cmake.py is responsible for generating edt.pickle.cmake. It currently generates the data needed by dt_comp_path() by looking inside each edtlib.Node object's "props" attribute. This attribute in turn is fed by the "properties:" key in the node's YAML binding. This leads to an edge case which is breaking the dt_comp_path() API.

In most cases, we don't notice this edge case because base.yaml, which is included by nearly all bindings, has a definition for "compatible" in its "properties:" map. However, bindings are not required to include base.yaml, and bindings do not have to explicitliy define a "compatible" entry in their "properties:". An example of a binding that does neither is fixed-partitions.yaml: it only has #address-cells and #size-cells in its "properties:".

Nonetheless, "compatible" is always a valid property name because it's defined in the DT spec, and we should make the CMake API robustly detect all nodes with a given compatible, regardless of whether that node's binding explicitly defines it or not.

To make this happen, rely on the edtlib.Node.compats attribute instead of edtlib.Node.props. The compats attribute is always defined even if the node's YAML binding doesn't have an explicit entry for "compatible".