### PR TITLE
sd: sdmmc: only with to 4 bit, if supported by host

### DIFF
--- a/subsys/sd/sdmmc.c
+++ b/subsys/sd/sdmmc.c
@@ -591,7 +591,7 @@ static int sdmmc_init_hs(struct sd_card *card)
 		LOG_ERR("Failed to switch card to HS mode");
 		return ret;
 	}
-	if (card->flags & SD_4BITS_WIDTH) {
+	if (card->host_props.host_caps.bus_4_bit_support && (card->flags & SD_4BITS_WIDTH)) {
 		/* Raise bus width to 4 bits */
 		ret = sdmmc_set_bus_width(card, SDHC_BUS_WIDTH4BIT);
 		if (ret) {


### PR DESCRIPTION
only switch to 4 bit mode, if it is supported
by the host. for MMC it is already checked,
but not for the sd card.