### PR TITLE
tests: posix: temporarily exclude two platforms failing in CI

### DIFF
--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -70,6 +70,9 @@ tests:
       - CONFIG_THREAD_STACK_INFO=n
   portability.posix.common.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    # Excluded while #96602 is in review
+    platform_exclude:
+      - mps2/an385
     tags:
       - userspace
     extra_configs:

--- a/tests/posix/signals/testcase.yaml
+++ b/tests/posix/signals/testcase.yaml
@@ -9,6 +9,12 @@ common:
     - simulation
   min_flash: 64
   min_ram: 32
+  # Exclude qemu_arc/qemu_arc_hs5x for now because of qemu_arc issue
+  # qemu-system-arc: /usr/src/debug/nativesdk-qemu-arc/git/target/arc/decoder-v2.c:266:
+  #   arc_find_format_v2: Assertion `mcount != 0' failed.
+  # Aborted (core dumped)
+  platform_exclude:
+    - qemu_arc/qemu_arc_hs5x
 tests:
   portability.posix.signals:
     integration_platforms:


### PR DESCRIPTION
Two platforms are failing posix tests. One is a known issue with a fix in review (mps2/an385 userspace), and the other is an issue with qemu_arc/qemu_arc_hs5x encountering an invalid instruction and crashing.

Testing done:
```shell
twister -c -p qemu_arc/qemu_arc_hs5x -T tests/posix/signals
INFO    - Using Ninja..
INFO    - Zephyr version: v4.2.0-4825-gea75b2a82611
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 32
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue

INFO    - 7 test scenarios (8 configurations) selected, 8 configurations filtered (8 by static filter, 0 at runtime).
INFO    - 0 of 0 executed test configurations passed (0.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 4.21 seconds.
INFO    - 0 of 0 executed test cases passed (0.00%) on 0 out of total 1203 platforms (0.00%).
INFO    - 0 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```

```shell
twister -c -p mps2/an385 -s  portability.posix.common.userspace
...
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 32
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue

INFO    - 1 test scenarios (1 configurations) selected, 1 configurations filtered (1 by static filter, 0 at runtime).
INFO    - 0 of 0 executed test configurations passed (0.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 5.67 seconds.
INFO    - 0 of 0 executed test cases passed (0.00%) on 0 out of total 1203 platforms (0.00%).
INFO    - 0 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```