### PR TITLE
Fixes #96880 - unneccessary log file deletion

### DIFF
--- a/subsys/logging/backends/log_backend_fs.c
+++ b/subsys/logging/backends/log_backend_fs.c
@@ -367,7 +367,7 @@ static int allocate_new_file(struct fs_file_t *file)
 	 * is not exceeded.
 	 */
 	while ((file_ctr >= CONFIG_LOG_BACKEND_FS_FILES_LIMIT) ||
-	       ((stat.f_bfree * stat.f_frsize) <=
+	       ((stat.f_bfree * stat.f_frsize) <
 		CONFIG_LOG_BACKEND_FS_FILE_SIZE)) {
 
 		if (IS_ENABLED(CONFIG_LOG_BACKEND_FS_OVERWRITE)) {


### PR DESCRIPTION
This specific test made the function delete the oldest log to free space even if there is exactly the needed amount of data

Now only deletes old logs if more data is needed than is available.

Fixes #96880.