### PR TITLE
kernel: dynamic: correct storage size for pool of dynamic thread stacks

### DIFF
--- a/kernel/dynamic.c
+++ b/kernel/dynamic.c
@@ -28,7 +28,7 @@ struct dyn_cb_data {
 };
 
 static K_THREAD_STACK_ARRAY_DEFINE(dynamic_stack, CONFIG_DYNAMIC_THREAD_POOL_SIZE,
-				   CONFIG_DYNAMIC_THREAD_STACK_SIZE);
+				   K_THREAD_STACK_LEN(CONFIG_DYNAMIC_THREAD_STACK_SIZE));
 SYS_BITARRAY_DEFINE_STATIC(dynamic_ba, BA_SIZE);
 
 static k_thread_stack_t *z_thread_stack_alloc_pool(size_t size, int flags)
@@ -36,11 +36,10 @@ static k_thread_stack_t *z_thread_stack_alloc_pool(size_t size, int flags)
 	int rv;
 	size_t offset;
 	k_thread_stack_t *stack;
-	const size_t max_size = ((flags & K_USER) != 0) ? K_THREAD_STACK_SIZEOF(dynamic_stack[0]) :
-							  K_KERNEL_STACK_SIZEOF(dynamic_stack[0]);
 
-	if (size > max_size) {
-		LOG_DBG("stack size %zu is > pool stack size %zu", size, max_size);
+	if (size > CONFIG_DYNAMIC_THREAD_STACK_SIZE) {
+		LOG_DBG("stack size %zu is > pool stack size %zu", size,
+			(size_t)CONFIG_DYNAMIC_THREAD_STACK_SIZE);
 		return NULL;
 	}
 

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -70,9 +70,6 @@ tests:
       - CONFIG_THREAD_STACK_INFO=n
   portability.posix.common.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    # Excluded while #96602 is in review
-    platform_exclude:
-      - mps2/an385
     tags:
       - userspace
     extra_configs:


### PR DESCRIPTION
Commit 5c5e17f introduced a subtle regression when userspace was configured on architectures requiring guard pages.

Prior to 5c5e17f, the assumption was that guard pages would be included in `CONFIG_DYNAMIC_THREAD_STACK_SIZE`, and that was something that the caller of `k_thread_stack_alloc()` would need to be aware of, although it was not documented at all, unfortunately.

It seems that 5c5e17f intended to remove the need for that assumption, but the necessary conditions for doing so had not been met.

Update pool storage size to account for guard pages, which ensures that users can access every byte of `CONFIG_DYNAMIC_THREAD_STACK_SIZE` rather than needing to be aware that guard pages would be included in the requested size.

The compromise is a more intuitive API at the cost of more storage space for the pool of thread stacks when userspace is enabled.

Fixes #96383 (without requiring a revert).

Testing Done:
```shell
twister -c -p mps2/an385 -s  portability.posix.common.userspace
Deleting output directory /home/cfriedt/zephyrproject/zephyr/twister-out
INFO    - Using Ninja..
INFO    - Zephyr version: v4.2.0-4826-g534e808d4051
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 32
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    1/   1  100%  built (not run):    0, filtered:    0, failed:    0, error:    0
INFO    - 1 test scenarios (1 configurations) selected, 0 configurations filtered (0 by static filter, 0 at runtime).
INFO    - 1 of 1 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 44.54 seconds.
INFO    - 44 of 44 executed test cases passed (100.00%) on 1 out of total 1203 platforms (0.08%).
INFO    - 2 selected test cases not executed: 2 skipped.
INFO    - 1 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```