### PR TITLE
kernel: assert if k_current_get is called pre-kernel

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -667,6 +667,33 @@ __attribute_const__
 __syscall k_tid_t k_sched_current_thread_query(void);
 
 /**
+ * @brief Test whether startup is in the before-main-task phase.
+ *
+ * This routine allows the caller to customize its actions, depending on
+ * whether it being invoked before the kernel is fully active.
+ *
+ * @funcprops \isr_ok
+ *
+ * @return true if invoked before post-kernel initialization
+ * @return false if invoked during/after post-kernel initialization
+ */
+static inline bool k_is_pre_kernel(void)
+{
+	extern bool z_sys_post_kernel; /* in init.c */
+
+	/*
+	 * If called from userspace, it must be post kernel.
+	 * This guard is necessary because z_sys_post_kernel memory
+	 * is not accessible to user threads.
+	 */
+	if (k_is_user_context()) {
+		return false;
+	}
+
+	return !z_sys_post_kernel;
+}
+
+/**
  * @brief Get thread ID of the current thread.
  *
  * @return ID of current thread.
@@ -675,6 +702,8 @@ __syscall k_tid_t k_sched_current_thread_query(void);
 __attribute_const__
 static inline k_tid_t k_current_get(void)
 {
+	__ASSERT(!k_is_pre_kernel(), "k_current_get called pre-kernel");
+
 #ifdef CONFIG_CURRENT_THREAD_USE_TLS
 
 	/* Thread-local cache of current thread ID, set in z_thread_entry() */
@@ -1252,33 +1281,6 @@ bool k_is_in_isr(void);
  * @return Non-zero if invoked by a preemptible thread.
  */
 __syscall int k_is_preempt_thread(void);
-
-/**
- * @brief Test whether startup is in the before-main-task phase.
- *
- * This routine allows the caller to customize its actions, depending on
- * whether it being invoked before the kernel is fully active.
- *
- * @funcprops \isr_ok
- *
- * @return true if invoked before post-kernel initialization
- * @return false if invoked during/after post-kernel initialization
- */
-static inline bool k_is_pre_kernel(void)
-{
-	extern bool z_sys_post_kernel; /* in init.c */
-
-	/*
-	 * If called from user mode, it must already be post kernel.
-	 * This guard is necessary because z_sys_post_kernel memory
-	 * is not accessible to user threads.
-	 */
-	if (k_is_user_context()) {
-		return false;
-	}
-
-	return !z_sys_post_kernel;
-}
 
 /**
  * @}

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1268,6 +1268,15 @@ static inline bool k_is_pre_kernel(void)
 {
 	extern bool z_sys_post_kernel; /* in init.c */
 
+	/*
+	 * If called from user mode, it must already be post kernel.
+	 * This guard is necessary because z_sys_post_kernel memory
+	 * is not accessible to user threads.
+	 */
+	if (k_is_user_context()) {
+		return false;
+	}
+
 	return !z_sys_post_kernel;
 }
 

--- a/subsys/tracing/test/tracing_string_format_test.c
+++ b/subsys/tracing/test/tracing_string_format_test.c
@@ -15,7 +15,7 @@ void sys_trace_k_thread_switched_out(void)
 {
 	struct k_thread *thread;
 
-	thread = k_current_get();
+	thread = k_sched_current_thread_query();
 	TRACING_STRING("%s: %p\n", __func__, thread);
 }
 
@@ -23,7 +23,7 @@ void sys_trace_k_thread_switched_in(void)
 {
 	struct k_thread *thread;
 
-	thread = k_current_get();
+	thread = k_sched_current_thread_query();
 	TRACING_STRING("%s: %p\n", __func__, thread);
 }
 

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -111,6 +111,18 @@ ZTEST_USER(userspace, test_is_usermode)
 }
 
 /**
+ * @brief Test to check if k_is_pre_kernel works from user mode
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+ZTEST_USER(userspace, test_is_post_kernel)
+{
+	clear_fault();
+
+	zassert_false(k_is_pre_kernel(), "still pre-kernel in user mode");
+}
+
+/**
  * @brief Test to write to a control register
  *
  * @ingroup kernel_memprotect_tests


### PR DESCRIPTION
k_current_get is not valid pre-kernel. It will return an invalid dummy thread or invalid memory. 
The invalid memory case can occur when CURRENT_THREAD_USE_TLS is enabled.

Assert in k_current_get when called pre-kernel so offending code may be identified.

k_is_pre_kernel is moved up in kernel.h to avoid needing a prototype for k_is_pre_kernel.