### PR TITLE
linker: nxp: imxrt6xx: hifi4: add missing include

### DIFF
--- a/soc/nxp/imxrt/imxrt6xx/hifi4/linker.ld
+++ b/soc/nxp/imxrt/imxrt6xx/hifi4/linker.ld
@@ -463,4 +463,6 @@ SECTIONS
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <zephyr/linker/intlist.ld>
 #endif
+
+#include <snippets-sections.ld>
 }


### PR DESCRIPTION
Add the #include <snippets-sections.ld> directive to include a linker file automatically.
This file defines additional linker sections that are dynamically added during the build process.

It is placed at the very end of the SECTIONS block, ensuring that any sections it defines appear after all standard sections.