### PR TITLE
boards: st: nucleo_g431kb: fix lptim1 domain clock

### DIFF
--- a/boards/st/nucleo_g431kb/nucleo_g431kb.dts
+++ b/boards/st/nucleo_g431kb/nucleo_g431kb.dts
@@ -53,7 +53,7 @@
 
 stm32_lp_tick_source: &lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
-		 <&rcc STM32_SRC_LSI LPTIM1_SEL(3)>;
+		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";
 };
 


### PR DESCRIPTION
The domain clock configuration for `lptim1` node in `boards/st/nucleo_g431kb/nucleo_g431kb.dts` has a conflict between the source and the peripheral in the domain clock. The source is specified as `STM32_SRC_LSI` - low speed internal, but `LPTIM1_SEL(3)` will actually configure the low speed external clock as the source, which the Nucleo G431KB does not have. Update this to actually use the LSI clock. See RM0440 Rev 9 page 322 - `LPTIM1SEL[1:0]` for more details.