### PR TITLE
tests: posix: signals: adjust expectations for real-time signals

### DIFF
--- a/lib/posix/options/signal.c
+++ b/lib/posix/options/signal.c
@@ -29,7 +29,8 @@ static inline bool signo_is_rt(int signo)
 
 static inline bool signo_fits(int signo)
 {
-	return ((signo > 0) && (signo <= SIGSET_NLONGS * BITS_PER_LONG));
+	/* technically, 0 is not a valid signal number, but it still fits */
+	return ((signo >= 0) && (signo < SIGSET_NLONGS * BITS_PER_LONG));
 }
 
 #undef sigemptyset


### PR DESCRIPTION
1. Fix an off-by-one error in `signo_fits()` (a utility function inside signal.c)
2. Adjust expectations (in `tests/posix/signals`) for C libraries that do not provide a `sigset_t` large enough to support `SIGRTMIN` or `SIGRAMAX`.

This fixes an issue in CI that appeared when run under ARC.
    
Testing done:
```shell
west build -p auto -b qemu_arc/qemu_arc_hs -t run tests/posix/signals
...
*** Booting Zephyr OS build v4.2.0-4846-gaca8434c8978 ***
Running TESTSUITE posix_signals
===================================================================
START - test_pthread_sigmask
 PASS - test_pthread_sigmask in 0.001 seconds
===================================================================
START - test_sigaddset
 PASS - test_sigaddset in 0.001 seconds
===================================================================
START - test_sigaddset_oor
 PASS - test_sigaddset_oor in 0.001 seconds
===================================================================
START - test_sigdelset
 PASS - test_sigdelset in 0.001 seconds
===================================================================
START - test_sigdelset_oor
 PASS - test_sigdelset_oor in 0.001 seconds
===================================================================
START - test_sigemptyset
 PASS - test_sigemptyset in 0.001 seconds
===================================================================
START - test_sigfillset
 PASS - test_sigfillset in 0.001 seconds
===================================================================
START - test_sigismember
 PASS - test_sigismember in 0.001 seconds
===================================================================
START - test_sigismember_oor
 PASS - test_sigismember_oor in 0.001 seconds
===================================================================
START - test_signal_strsignal
 PASS - test_signal_strsignal in 0.001 seconds
===================================================================
START - test_sigprocmask
 PASS - test_sigprocmask in 0.001 seconds
===================================================================
TESTSUITE posix_signals succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [posix_signals]: pass = 11, fail = 0, skip = 0, total = 11 duration = 0.011 seconds
 - PASS - [posix_signals.test_pthread_sigmask] duration = 0.001 seconds
 - PASS - [posix_signals.test_sigaddset] duration = 0.001 seconds
 - PASS - [posix_signals.test_sigaddset_oor] duration = 0.001 seconds
 - PASS - [posix_signals.test_sigdelset] duration = 0.001 seconds
 - PASS - [posix_signals.test_sigdelset_oor] duration = 0.001 seconds
 - PASS - [posix_signals.test_sigemptyset] duration = 0.001 seconds
 - PASS - [posix_signals.test_sigfillset] duration = 0.001 seconds
 - PASS - [posix_signals.test_sigismember] duration = 0.001 seconds
 - PASS - [posix_signals.test_sigismember_oor] duration = 0.001 seconds
 - PASS - [posix_signals.test_signal_strsignal] duration = 0.001 seconds
 - PASS - [posix_signals.test_sigprocmask] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL

twister -T tests/posix/signals/
INFO    - Using Ninja..
INFO    - Zephyr version: v4.2.0-4846-g48ceade441b9
INFO    - Using 'zephyr' toolchain.
INFO    - Selecting default platforms per testsuite scenario
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 32
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:   66/  66  100%  built (not run):    0, filtered:  219, failed:    0, error:    0
INFO    - 7 test scenarios (284 configurations) selected, 219 configurations filtered (218 by static filter, 1 at runtime).
INFO    - 65 of 65 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 110.25 seconds.
INFO    - 715 of 715 executed test cases passed (100.00%) on 11 out of total 1203 platforms (0.91%).
INFO    - 65 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```

https://github.com/zephyrproject-rtos/zephyr/actions/runs/18237537849/job/51933968134