### PR TITLE
modem: cmux: auto calculate work buffer sizes

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -183,6 +183,8 @@ Modem
 *****
 
 * ``CONFIG_MODEM_AT_SHELL_USER_PIPE`` has been renamed to :kconfig:option:`CONFIG_MODEM_AT_USER_PIPE`.
+* ``CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE`` has been updated to :kconfig:option:`CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE_EXTRA`,
+  which only takes the number of extra bytes desired over the default of (:kconfig:option:`CONFIG_MODEM_CMUX_MTU` + 7).
 
 Display
 *******

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -110,8 +110,8 @@ struct modem_cellular_data {
 
 	/* CMUX */
 	struct modem_cmux cmux;
-	uint8_t cmux_receive_buf[CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE];
-	uint8_t cmux_transmit_buf[CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE];
+	uint8_t cmux_receive_buf[MODEM_CMUX_WORK_BUFFER_SIZE];
+	uint8_t cmux_transmit_buf[MODEM_CMUX_WORK_BUFFER_SIZE];
 
 	struct modem_cmux_dlci dlci1;
 	struct modem_cmux_dlci dlci2;
@@ -119,9 +119,9 @@ struct modem_cellular_data {
 	struct modem_pipe *dlci2_pipe;
 	/* Points to dlci2_pipe or NULL. Used for shutdown script if not NULL */
 	struct modem_pipe *cmd_pipe;
-	uint8_t dlci1_receive_buf[CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE];
+	uint8_t dlci1_receive_buf[MODEM_CMUX_WORK_BUFFER_SIZE];
 	/* DLCI 2 is only used for chat scripts. */
-	uint8_t dlci2_receive_buf[CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE];
+	uint8_t dlci2_receive_buf[MODEM_CMUX_WORK_BUFFER_SIZE];
 
 	/* Modem chat */
 	struct modem_chat chat;

--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -57,6 +57,10 @@ typedef void (*modem_cmux_callback)(struct modem_cmux *cmux, enum modem_cmux_eve
  * @cond INTERNAL_HIDDEN
  */
 
+/* Total size of the CMUX work buffers */
+#define MODEM_CMUX_WORK_BUFFER_SIZE (CONFIG_MODEM_CMUX_MTU + 7 + \
+				     CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE_EXTRA)
+
 enum modem_cmux_state {
 	MODEM_CMUX_STATE_DISCONNECTED = 0,
 	MODEM_CMUX_STATE_CONNECTING,
@@ -153,7 +157,7 @@ struct modem_cmux {
 	uint16_t receive_buf_size;
 	uint16_t receive_buf_len;
 
-	uint8_t work_buf[CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE];
+	uint8_t work_buf[MODEM_CMUX_WORK_BUFFER_SIZE];
 
 	/* Transmit buffer */
 	struct ring_buf transmit_rb;

--- a/subsys/modem/Kconfig
+++ b/subsys/modem/Kconfig
@@ -42,14 +42,12 @@ config MODEM_CMUX_MTU
 	  Maximum Transmission Unit (MTU) size for the CMUX module.
 	  Linux ldattach defaults to 127 bytes, 3GPP TS 27.010 to 31.
 
-config MODEM_CMUX_WORK_BUFFER_SIZE
-	int "CMUX module work buffer size in bytes"
-	range 23 1507
-	default 134 if MODEM_CMUX_DEFAULT_MTU_127
-	default 38
+config MODEM_CMUX_WORK_BUFFER_SIZE_EXTRA
+	int "CMUX module extra work buffer size in bytes"
+	default 0
 	help
-	  Size of the work buffer used by the CMUX module.
-	  Recommended size is MODEM_CMUX_MTU + 7 (CMUX header size).
+	  Extra bytes to add to the work buffers used by the CMUX module.
+	  The default size of these buffers is MODEM_CMUX_MTU + 7 (CMUX header size).
 
 module = MODEM_CMUX
 module-str = modem_cmux


### PR DESCRIPTION
Automatically size the CMUX work buffers based on `CONFIG_MODEM_CMUX_MTU`. This eliminates a Kconfig variable that would otherwise need to manually be kept in sync. The option to extend the size of these buffers is still provided through
`CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE_EXTRA`.

It is assumed that creating buffers smaller than the recommended (MTU + 7) would lead to broken applications.