### PR TITLE
drivers: uart: npcx: support additional capabilities

### DIFF
--- a/dts/bindings/serial/nuvoton,npcx-uart.yaml
+++ b/dts/bindings/serial/nuvoton,npcx-uart.yaml
@@ -5,7 +5,7 @@ description: Nuvoton, NPCX-UART node
 
 compatible: "nuvoton,npcx-uart"
 
-include: [uart-controller.yaml, pinctrl-device.yaml]
+include: [uart-controller.yaml, uart-controller-pin-inversion.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
@@ -24,3 +24,7 @@ properties:
 
         For example the WUI mapping on NPCX7 UART1 would be
            uart-rx = <&wui_cr_sin1>;
+  data-bits:
+    description: |
+      Sets the number of data bits. Defaults to standard of 8 if not specified.
+    default: 8

--- a/soc/nuvoton/npcx/common/npckn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npckn/include/reg_def.h
@@ -309,6 +309,9 @@ struct uart_reg {
 #define NPCX_UMDSL_ETD                        4
 #define NPCX_UMDSL_ERD                        5
 
+#define NPCX_UFRS_CHAR_DATA_BIT_8 0
+#define NPCX_UFRS_CHAR_DATA_BIT_7 1
+
 #define NPCX_UFTSTS_TEMPTY_LVL                FIELD(0, 5)
 #define NPCX_UFTSTS_TEMPTY_LVL_STS            5
 #define NPCX_UFTSTS_TFIFO_EMPTY_STS           6

--- a/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
@@ -328,6 +328,9 @@ struct uart_reg {
 	volatile uint8_t reserved11;
 	/* 0x026: FIFO Mode Receive Control */
 	volatile uint8_t UFRCTL;
+	volatile uint8_t reserved12[5];
+	/* 0x02C: Common Mode Operation Control */
+	volatile uint8_t UCNTL;
 };
 
 /* UART register fields */
@@ -352,6 +355,9 @@ struct uart_reg {
 #define NPCX_UMDSL_ETD       4
 #define NPCX_UMDSL_ERD       5
 
+#define NPCX_UFRS_CHAR_DATA_BIT_8 0
+#define NPCX_UFRS_CHAR_DATA_BIT_7 1
+
 #define NPCX_UFTSTS_TEMPTY_LVL       FIELD(0, 5)
 #define NPCX_UFTSTS_TEMPTY_LVL_STS   5
 #define NPCX_UFTSTS_TFIFO_EMPTY_STS  6
@@ -367,6 +373,8 @@ struct uart_reg {
 #define NPCX_UFRCTL_RFULL_LVL_EN     5
 #define NPCX_UFRCTL_RNEMPTY_EN       6
 #define NPCX_UFRCTL_ERR_EN           7
+#define NPCX_UCNTL_CR_SIN_INV        0
+#define NPCX_UCNTL_CR_SOUT_INV       1
 
 /* Macro functions for MIWU multi-registers */
 #define NPCX_WKEDG(base, group)  (*(volatile uint8_t *)(base + NPCX_WKEDG_OFFSET(group)))

--- a/soc/nuvoton/npcx/common/npcxn/registers.c
+++ b/soc/nuvoton/npcx/common/npcxn/registers.c
@@ -35,7 +35,7 @@ NPCX_REG_OFFSET_CHECK(glue_reg, SMB_SEL, 0x021);
 NPCX_REG_OFFSET_CHECK(glue_reg, PSL_CTS, 0x027);
 
 /* UART register structure check */
-NPCX_REG_SIZE_CHECK(uart_reg, 0x027);
+NPCX_REG_SIZE_CHECK(uart_reg, 0x02d);
 NPCX_REG_OFFSET_CHECK(uart_reg, UPSR, 0x00e);
 NPCX_REG_OFFSET_CHECK(uart_reg, UFTSTS, 0x020);
 NPCX_REG_OFFSET_CHECK(uart_reg, UFRCTL, 0x026);


### PR DESCRIPTION
This commit adds the following functionality support:
1. More baudrate setting.
2. 7 bit data moded.
3. Tx (CR_SOUT) and Rx (CR_SIN) signal's polarity invert.