### PR TITLE
net: socket: Change socklen_t to be 4 bytes long

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -186,6 +186,11 @@ Networking
   :c:macro:`HTTPS_SERVICE_DEFINE_EMPTY`, :c:macro:`HTTP_SERVICE_DEFINE` and
   :c:macro:`HTTPS_SERVICE_DEFINE`.
 
+* The size of socket address length type :c:type:`socklen_t` has changed. It is now defined to
+  be always 32 bit ``uint32_t`` in order to be aligned with Linux. Previously it was defined as
+  ``size_t`` which meant that the size could be either 32 bit or 64 bit depending on system
+  configuration.
+
 .. zephyr-keep-sorted-start re(^\w)
 
 .. zephyr-keep-sorted-stop

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -1419,7 +1419,7 @@ enum net_context_option {
  */
 int net_context_set_option(struct net_context *context,
 			   enum net_context_option option,
-			   const void *value, size_t len);
+			   const void *value, uint32_t len);
 
 /**
  * @brief Get connection option value for this context.
@@ -1433,7 +1433,7 @@ int net_context_set_option(struct net_context *context,
  */
 int net_context_get_option(struct net_context *context,
 			   enum net_context_option option,
-			   void *value, size_t *len);
+			   void *value, uint32_t *len);
 
 /**
  * @typedef net_context_cb_t

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -169,7 +169,7 @@ typedef unsigned short int sa_family_t;
 
 /** Length of a socket address */
 #ifndef __socklen_t_defined
-typedef size_t socklen_t;
+typedef uint32_t socklen_t;
 #define __socklen_t_defined
 #endif
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1591,7 +1591,7 @@ unlock:
 	return ret;
 }
 
-__maybe_unused static int get_bool_option(bool option, int *value, size_t *len)
+__maybe_unused static int get_bool_option(bool option, int *value, uint32_t *len)
 {
 	if (value == NULL) {
 		return -EINVAL;
@@ -1610,7 +1610,7 @@ __maybe_unused static int get_bool_option(bool option, int *value, size_t *len)
 	return 0;
 }
 
-__maybe_unused static int get_uint8_option(uint8_t option, uint8_t *value, size_t *len)
+__maybe_unused static int get_uint8_option(uint8_t option, uint8_t *value, uint32_t *len)
 {
 	if (value == NULL) {
 		return -EINVAL;
@@ -1625,7 +1625,7 @@ __maybe_unused static int get_uint8_option(uint8_t option, uint8_t *value, size_
 	return 0;
 }
 
-__maybe_unused static int get_uint16_option(uint16_t option, int *value, size_t *len)
+__maybe_unused static int get_uint16_option(uint16_t option, int *value, uint32_t *len)
 {
 	if (value == NULL) {
 		return -EINVAL;
@@ -1641,7 +1641,7 @@ __maybe_unused static int get_uint16_option(uint16_t option, int *value, size_t 
 }
 
 static int get_context_priority(struct net_context *context,
-				void *value, size_t *len)
+				void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_PRIORITY)
 	return get_uint8_option(context->options.priority,
@@ -1656,7 +1656,7 @@ static int get_context_priority(struct net_context *context,
 }
 
 static int get_context_proxy(struct net_context *context,
-			     void *value, size_t *len)
+			     void *value, uint32_t *len)
 {
 #if defined(CONFIG_SOCKS)
 	struct sockaddr *addr = (struct sockaddr *)value;
@@ -1684,7 +1684,7 @@ static int get_context_proxy(struct net_context *context,
 }
 
 static int get_context_txtime(struct net_context *context,
-			      void *value, size_t *len)
+			      void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_TXTIME)
 	return get_bool_option(context->options.txtime,
@@ -1699,7 +1699,7 @@ static int get_context_txtime(struct net_context *context,
 }
 
 static int get_context_rcvtimeo(struct net_context *context,
-				void *value, size_t *len)
+				void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_RCVTIMEO)
 	*((k_timeout_t *)value) = context->options.rcvtimeo;
@@ -1719,7 +1719,7 @@ static int get_context_rcvtimeo(struct net_context *context,
 }
 
 static int get_context_sndtimeo(struct net_context *context,
-				void *value, size_t *len)
+				void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_SNDTIMEO)
 	*((k_timeout_t *)value) = context->options.sndtimeo;
@@ -1739,7 +1739,7 @@ static int get_context_sndtimeo(struct net_context *context,
 }
 
 static int get_context_rcvbuf(struct net_context *context,
-			      void *value, size_t *len)
+			      void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_RCVBUF)
 	return get_uint16_option(context->options.rcvbuf,
@@ -1754,7 +1754,7 @@ static int get_context_rcvbuf(struct net_context *context,
 }
 
 static int get_context_sndbuf(struct net_context *context,
-				void *value, size_t *len)
+				void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_SNDBUF)
 	return get_uint16_option(context->options.sndbuf,
@@ -1769,7 +1769,7 @@ static int get_context_sndbuf(struct net_context *context,
 }
 
 static int get_context_dscp_ecn(struct net_context *context,
-				void *value, size_t *len)
+				void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_DSCP_ECN)
 	return get_uint8_option(context->options.dscp_ecn,
@@ -1784,7 +1784,7 @@ static int get_context_dscp_ecn(struct net_context *context,
 }
 
 static int get_context_ttl(struct net_context *context,
-				 void *value, size_t *len)
+				 void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_IPV4)
 	*((int *)value) = context->ipv4_ttl;
@@ -1804,7 +1804,7 @@ static int get_context_ttl(struct net_context *context,
 }
 
 static int get_context_mcast_ttl(struct net_context *context,
-				 void *value, size_t *len)
+				 void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_IPV4)
 	*((int *)value) = context->ipv4_mcast_ttl;
@@ -1824,7 +1824,7 @@ static int get_context_mcast_ttl(struct net_context *context,
 }
 
 static int get_context_ipv4_mcast_loop(struct net_context *context,
-				  void *value, size_t *len)
+				  void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_IPV4)
 	return get_bool_option(context->options.ipv4_mcast_loop, value, len);
@@ -1837,7 +1837,7 @@ static int get_context_ipv4_mcast_loop(struct net_context *context,
 }
 
 static int get_context_mcast_hop_limit(struct net_context *context,
-				       void *value, size_t *len)
+				       void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_IPV6)
 	*((int *)value) = context->ipv6_mcast_hop_limit;
@@ -1857,7 +1857,7 @@ static int get_context_mcast_hop_limit(struct net_context *context,
 }
 
 static int get_context_unicast_hop_limit(struct net_context *context,
-					 void *value, size_t *len)
+					 void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_IPV6)
 	*((int *)value) = context->ipv6_hop_limit;
@@ -1877,7 +1877,7 @@ static int get_context_unicast_hop_limit(struct net_context *context,
 }
 
 static int get_context_reuseaddr(struct net_context *context,
-				 void *value, size_t *len)
+				 void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_REUSEADDR)
 	return get_bool_option(context->options.reuseaddr,
@@ -1892,7 +1892,7 @@ static int get_context_reuseaddr(struct net_context *context,
 }
 
 static int get_context_reuseport(struct net_context *context,
-				void *value, size_t *len)
+				void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_REUSEPORT)
 	return get_bool_option(context->options.reuseport,
@@ -1907,7 +1907,7 @@ static int get_context_reuseport(struct net_context *context,
 }
 
 static int get_context_ipv6_v6only(struct net_context *context,
-				   void *value, size_t *len)
+				   void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_IPV4_MAPPING_TO_IPV6)
 	return get_bool_option(context->options.ipv6_v6only,
@@ -1922,7 +1922,7 @@ static int get_context_ipv6_v6only(struct net_context *context,
 }
 
 static int get_context_recv_pktinfo(struct net_context *context,
-				    void *value, size_t *len)
+				    void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_RECV_PKTINFO)
 	return get_bool_option(context->options.recv_pktinfo,
@@ -1937,7 +1937,7 @@ static int get_context_recv_pktinfo(struct net_context *context,
 }
 
 static int get_context_recv_hoplimit(struct net_context *context,
-				    void *value, size_t *len)
+				    void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_RECV_HOPLIMIT)
 	return get_bool_option(context->options.recv_hoplimit,
@@ -1952,7 +1952,7 @@ static int get_context_recv_hoplimit(struct net_context *context,
 }
 
 static int get_context_addr_preferences(struct net_context *context,
-					void *value, size_t *len)
+					void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_IPV6)
 	return get_uint16_option(context->options.addr_preferences,
@@ -1967,7 +1967,7 @@ static int get_context_addr_preferences(struct net_context *context,
 }
 
 static int get_context_timestamping(struct net_context *context,
-				    void *value, size_t *len)
+				    void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_TIMESTAMPING)
 	*((uint8_t *)value) = context->options.timestamping;
@@ -1987,7 +1987,7 @@ static int get_context_timestamping(struct net_context *context,
 }
 
 static int get_context_mtu(struct net_context *context,
-			   void *value, size_t *len)
+			   void *value, uint32_t *len)
 {
 	sa_family_t family = net_context_get_family(context);
 	struct net_if *iface = NULL;
@@ -2029,7 +2029,7 @@ out:
 }
 
 static int get_context_mcast_ifindex(struct net_context *context,
-				     void *value, size_t *len)
+				     void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_IPV6) || defined(CONFIG_NET_IPV4)
 	sa_family_t family = net_context_get_family(context);
@@ -2087,7 +2087,7 @@ static int get_context_mcast_ifindex(struct net_context *context,
 }
 
 static int get_context_local_port_range(struct net_context *context,
-					void *value, size_t *len)
+					void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_CLAMP_PORT_RANGE)
 	if (len == NULL || *len != sizeof(uint32_t)) {
@@ -2107,7 +2107,7 @@ static int get_context_local_port_range(struct net_context *context,
 }
 
 static int get_context_ipv6_mcast_loop(struct net_context *context,
-				       void *value, size_t *len)
+				       void *value, uint32_t *len)
 {
 #if defined(CONFIG_NET_IPV6)
 	return get_bool_option(context->options.ipv6_mcast_loop, value, len);
@@ -3328,7 +3328,7 @@ int net_context_update_recv_wnd(struct net_context *context,
 	return ret;
 }
 
-__maybe_unused static int set_bool_option(bool *option, const void *value, size_t len)
+__maybe_unused static int set_bool_option(bool *option, const void *value, uint32_t len)
 {
 	if (value == NULL) {
 		return -EINVAL;
@@ -3343,7 +3343,7 @@ __maybe_unused static int set_bool_option(bool *option, const void *value, size_
 	return 0;
 }
 
-__maybe_unused static int set_uint8_option(uint8_t *option, const void *value, size_t len)
+__maybe_unused static int set_uint8_option(uint8_t *option, const void *value, uint32_t len)
 {
 	if (value == NULL) {
 		return -EINVAL;
@@ -3358,7 +3358,7 @@ __maybe_unused static int set_uint8_option(uint8_t *option, const void *value, s
 	return 0;
 }
 
-__maybe_unused static int set_uint16_option(uint16_t *option, const void *value, size_t len)
+__maybe_unused static int set_uint16_option(uint16_t *option, const void *value, uint32_t len)
 {
 	int v;
 
@@ -3383,7 +3383,7 @@ __maybe_unused static int set_uint16_option(uint16_t *option, const void *value,
 }
 
 static int set_context_priority(struct net_context *context,
-				const void *value, size_t len)
+				const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_PRIORITY)
 	return set_uint8_option(&context->options.priority, value, len);
@@ -3397,7 +3397,7 @@ static int set_context_priority(struct net_context *context,
 }
 
 static int set_context_txtime(struct net_context *context,
-			      const void *value, size_t len)
+			      const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_TXTIME)
 	return set_bool_option(&context->options.txtime, value, len);
@@ -3411,7 +3411,7 @@ static int set_context_txtime(struct net_context *context,
 }
 
 static int set_context_proxy(struct net_context *context,
-			     const void *value, size_t len)
+			     const void *value, uint32_t len)
 {
 #if defined(CONFIG_SOCKS)
 	struct sockaddr *addr = (struct sockaddr *)value;
@@ -3438,7 +3438,7 @@ static int set_context_proxy(struct net_context *context,
 }
 
 static int set_context_rcvtimeo(struct net_context *context,
-				const void *value, size_t len)
+				const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_RCVTIMEO)
 	if (len != sizeof(k_timeout_t)) {
@@ -3458,7 +3458,7 @@ static int set_context_rcvtimeo(struct net_context *context,
 }
 
 static int set_context_sndtimeo(struct net_context *context,
-				const void *value, size_t len)
+				const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_SNDTIMEO)
 	if (len != sizeof(k_timeout_t)) {
@@ -3478,7 +3478,7 @@ static int set_context_sndtimeo(struct net_context *context,
 }
 
 static int set_context_rcvbuf(struct net_context *context,
-				const void *value, size_t len)
+				const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_RCVBUF)
 	return set_uint16_option(&context->options.rcvbuf, value, len);
@@ -3492,7 +3492,7 @@ static int set_context_rcvbuf(struct net_context *context,
 }
 
 static int set_context_sndbuf(struct net_context *context,
-				const void *value, size_t len)
+				const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_SNDBUF)
 	return set_uint16_option(&context->options.sndbuf, value, len);
@@ -3506,7 +3506,7 @@ static int set_context_sndbuf(struct net_context *context,
 }
 
 static int set_context_dscp_ecn(struct net_context *context,
-				const void *value, size_t len)
+				const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_DSCP_ECN)
 	return set_uint8_option(&context->options.dscp_ecn, value, len);
@@ -3520,7 +3520,7 @@ static int set_context_dscp_ecn(struct net_context *context,
 }
 
 static int set_context_ttl(struct net_context *context,
-			   const void *value, size_t len)
+			   const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_IPV4)
 	uint8_t ttl = *((int *)value);
@@ -3538,7 +3538,7 @@ static int set_context_ttl(struct net_context *context,
 }
 
 static int set_context_mcast_ttl(struct net_context *context,
-				 const void *value, size_t len)
+				 const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_IPV4)
 	uint8_t mcast_ttl = *((int *)value);
@@ -3556,7 +3556,7 @@ static int set_context_mcast_ttl(struct net_context *context,
 }
 
 static int set_context_ipv4_mcast_loop(struct net_context *context,
-				       const void *value, size_t len)
+				       const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_IPV4)
 	return set_bool_option(&context->options.ipv4_mcast_loop, value, len);
@@ -3570,7 +3570,7 @@ static int set_context_ipv4_mcast_loop(struct net_context *context,
 }
 
 static int set_context_mcast_hop_limit(struct net_context *context,
-				       const void *value, size_t len)
+				       const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_IPV6)
 	int mcast_hop_limit = *((int *)value);
@@ -3606,7 +3606,7 @@ static int set_context_mcast_hop_limit(struct net_context *context,
 }
 
 static int set_context_unicast_hop_limit(struct net_context *context,
-					 const void *value, size_t len)
+					 const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_IPV6)
 	uint8_t unicast_hop_limit = *((int *)value);
@@ -3625,7 +3625,7 @@ static int set_context_unicast_hop_limit(struct net_context *context,
 }
 
 static int set_context_ipv6_mcast_loop(struct net_context *context,
-				       const void *value, size_t len)
+				       const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_IPV6)
 	return set_bool_option(&context->options.ipv6_mcast_loop, value, len);
@@ -3639,7 +3639,7 @@ static int set_context_ipv6_mcast_loop(struct net_context *context,
 }
 
 static int set_context_reuseaddr(struct net_context *context,
-				 const void *value, size_t len)
+				 const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_REUSEADDR)
 	return set_bool_option(&context->options.reuseaddr, value, len);
@@ -3653,7 +3653,7 @@ static int set_context_reuseaddr(struct net_context *context,
 }
 
 static int set_context_reuseport(struct net_context *context,
-				 const void *value, size_t len)
+				 const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_REUSEPORT)
 	return set_bool_option(&context->options.reuseport, value, len);
@@ -3667,7 +3667,7 @@ static int set_context_reuseport(struct net_context *context,
 }
 
 static int set_context_ipv6_mtu(struct net_context *context,
-				const void *value, size_t len)
+				const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_IPV6)
 	struct net_if *iface;
@@ -3716,7 +3716,7 @@ static int set_context_ipv6_mtu(struct net_context *context,
 }
 
 static int set_context_ipv6_v6only(struct net_context *context,
-				   const void *value, size_t len)
+				   const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_IPV4_MAPPING_TO_IPV6)
 	return set_bool_option(&context->options.ipv6_v6only, value, len);
@@ -3730,7 +3730,7 @@ static int set_context_ipv6_v6only(struct net_context *context,
 }
 
 static int set_context_recv_pktinfo(struct net_context *context,
-				    const void *value, size_t len)
+				    const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_RECV_PKTINFO)
 	return set_bool_option(&context->options.recv_pktinfo, value, len);
@@ -3744,7 +3744,7 @@ static int set_context_recv_pktinfo(struct net_context *context,
 }
 
 static int set_context_recv_hoplimit(struct net_context *context,
-				    const void *value, size_t len)
+				    const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_RECV_HOPLIMIT)
 	if (net_context_get_type(context) == SOCK_DGRAM) {
@@ -3762,7 +3762,7 @@ static int set_context_recv_hoplimit(struct net_context *context,
 }
 
 static int set_context_addr_preferences(struct net_context *context,
-					const void *value, size_t len)
+					const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_IPV6)
 	return set_uint16_option(&context->options.addr_preferences,
@@ -3777,7 +3777,7 @@ static int set_context_addr_preferences(struct net_context *context,
 }
 
 static int set_context_timestamping(struct net_context *context,
-				    const void *value, size_t len)
+				    const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_TIMESTAMPING)
 	uint8_t timestamping_flags = *((uint8_t *)value);
@@ -3794,7 +3794,7 @@ static int set_context_timestamping(struct net_context *context,
 }
 
 static int set_context_mcast_ifindex(struct net_context *context,
-				     const void *value, size_t len)
+				     const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_IPV6) || defined(CONFIG_NET_IPV4)
 	sa_family_t family = net_context_get_family(context);
@@ -3855,7 +3855,7 @@ static int set_context_mcast_ifindex(struct net_context *context,
 }
 
 static int set_context_local_port_range(struct net_context *context,
-					const void *value, size_t len)
+					const void *value, uint32_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_CLAMP_PORT_RANGE)
 	uint16_t lower_range, upper_range;
@@ -3895,7 +3895,7 @@ static int set_context_local_port_range(struct net_context *context,
 
 int net_context_set_option(struct net_context *context,
 			   enum net_context_option option,
-			   const void *value, size_t len)
+			   const void *value, uint32_t len)
 {
 	int ret = 0;
 
@@ -3997,7 +3997,7 @@ int net_context_set_option(struct net_context *context,
 
 int net_context_get_option(struct net_context *context,
 			    enum net_context_option option,
-			    void *value, size_t *len)
+			    void *value, uint32_t *len)
 {
 	int ret = 0;
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -726,7 +726,7 @@ static int set_tcp_keep_cnt(struct tcp *conn, const void *value, size_t len)
 	return 0;
 }
 
-static int get_tcp_keep_alive(struct tcp *conn, void *value, size_t *len)
+static int get_tcp_keep_alive(struct tcp *conn, void *value, uint32_t *len)
 {
 	if (conn == NULL || value == NULL || len == NULL ||
 	    *len != sizeof(int)) {
@@ -738,7 +738,7 @@ static int get_tcp_keep_alive(struct tcp *conn, void *value, size_t *len)
 	return 0;
 }
 
-static int get_tcp_keep_idle(struct tcp *conn, void *value, size_t *len)
+static int get_tcp_keep_idle(struct tcp *conn, void *value, uint32_t *len)
 {
 	if (conn == NULL || value == NULL || len == NULL ||
 	    *len != sizeof(int)) {
@@ -750,7 +750,7 @@ static int get_tcp_keep_idle(struct tcp *conn, void *value, size_t *len)
 	return 0;
 }
 
-static int get_tcp_keep_intvl(struct tcp *conn, void *value, size_t *len)
+static int get_tcp_keep_intvl(struct tcp *conn, void *value, uint32_t *len)
 {
 	if (conn == NULL || value == NULL || len == NULL ||
 	    *len != sizeof(int)) {
@@ -762,7 +762,7 @@ static int get_tcp_keep_intvl(struct tcp *conn, void *value, size_t *len)
 	return 0;
 }
 
-static int get_tcp_keep_cnt(struct tcp *conn, void *value, size_t *len)
+static int get_tcp_keep_cnt(struct tcp *conn, void *value, uint32_t *len)
 {
 	if (conn == NULL || value == NULL || len == NULL ||
 	    *len != sizeof(int)) {
@@ -1394,7 +1394,7 @@ static int ip_header_add(struct tcp *conn, struct net_pkt *pkt)
 	return -EINVAL;
 }
 
-static int set_tcp_nodelay(struct tcp *conn, const void *value, size_t len)
+static int set_tcp_nodelay(struct tcp *conn, const void *value, uint32_t len)
 {
 	int no_delay_int;
 
@@ -1413,7 +1413,7 @@ static int set_tcp_nodelay(struct tcp *conn, const void *value, size_t len)
 	return 0;
 }
 
-static int get_tcp_nodelay(struct tcp *conn, void *value, size_t *len)
+static int get_tcp_nodelay(struct tcp *conn, void *value, uint32_t *len)
 {
 	int no_delay_int = (int)conn->tcp_nodelay;
 
@@ -4643,7 +4643,7 @@ uint16_t net_tcp_get_mtu(struct sockaddr *dst)
 
 int net_tcp_set_option(struct net_context *context,
 		       enum tcp_conn_option option,
-		       const void *value, size_t len)
+		       const void *value, uint32_t len)
 {
 	int ret = 0;
 
@@ -4680,7 +4680,7 @@ int net_tcp_set_option(struct net_context *context,
 
 int net_tcp_get_option(struct net_context *context,
 		       enum tcp_conn_option option,
-		       void *value, size_t *len)
+		       void *value, uint32_t *len)
 {
 	int ret = 0;
 

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -386,11 +386,11 @@ void net_tcp_init(void);
 #if defined(CONFIG_NET_NATIVE_TCP)
 int net_tcp_set_option(struct net_context *context,
 		       enum tcp_conn_option option,
-		       const void *value, size_t len);
+		       const void *value, uint32_t len);
 #else
 static inline int net_tcp_set_option(struct net_context *context,
 				     enum tcp_conn_option option,
-				     const void *value, size_t len)
+				     const void *value, uint32_t len)
 {
 	ARG_UNUSED(context);
 	ARG_UNUSED(option);
@@ -412,11 +412,11 @@ static inline int net_tcp_set_option(struct net_context *context,
 #if defined(CONFIG_NET_NATIVE_TCP)
 int net_tcp_get_option(struct net_context *context,
 		       enum tcp_conn_option option,
-		       void *value, size_t *len);
+		       void *value, uint32_t *len);
 #else
 static inline int net_tcp_get_option(struct net_context *context,
 				     enum tcp_conn_option option,
-				     void *value, size_t *len)
+				     void *value, uint32_t *len)
 {
 	ARG_UNUSED(context);
 	ARG_UNUSED(option);

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -41,6 +41,9 @@ LOG_MODULE_DECLARE(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 BUILD_ASSERT(IPPROTO_IP == 0, "Wildcard IPPROTO_IP must equal 0.");
 #endif
 
+BUILD_ASSERT(sizeof(socklen_t) == sizeof(uint32_t),
+	     "socklen_t must be 32-bit wide");
+
 const struct socket_op_vtable sock_fd_op_vtable;
 
 static void zsock_received_cb(struct net_context *ctx,
@@ -1710,7 +1713,7 @@ static int ipv4_multicast_if(struct net_context *ctx, const void *optval,
 
 	if (do_get) {
 		struct net_if_addr *ifaddr;
-		size_t len = sizeof(ifindex);
+		uint32_t len = sizeof(ifindex);
 
 		if (optval == NULL || (optlen != sizeof(struct in_addr))) {
 			errno = EINVAL;

--- a/tests/net/dhcpv6/src/main.c
+++ b/tests/net/dhcpv6/src/main.c
@@ -413,13 +413,13 @@ static void verify_dhcpv6_oro_sol_max_rt(struct net_if *iface,
 	net_pkt_cursor_backup(pkt, &backup);
 
 	ret = dhcpv6_find_option(pkt, DHCPV6_OPTION_CODE_ORO, &length);
-	zassert_ok(ret, 0, "ORO option not found");
+	zassert_ok(ret, "ORO option not found");
 	zassert_true(length >= sizeof(uint16_t) && length % sizeof(uint16_t) == 0,
 		     "Invalid ORO length");
 
 	while (length >= sizeof(uint16_t)) {
 		ret = net_pkt_read_be16(pkt, &oro);
-		zassert_ok(ret, 0, "ORO read error");
+		zassert_ok(ret, "ORO read error");
 		length -= sizeof(uint16_t);
 
 		if (oro == DHCPV6_OPTION_CODE_SOL_MAX_RT) {

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -848,7 +848,7 @@ ZTEST(net_ipv6, test_send_neighbor_discovery)
 		      k_mem_slab_num_free_get(tx), avail_pkt_count);
 
 	zassert_equal(atomic_get(&tx_data->avail_count), avail_buf_count,
-		      "Unexpected tx data pool available count (%d vs %d)",
+		      "Unexpected tx data pool available count (%ld vs %d)",
 		      atomic_get(&tx_data->avail_count), avail_buf_count);
 }
 

--- a/tests/net/socket/socketpair/src/nonblock.c
+++ b/tests/net/socket/socketpair/src/nonblock.c
@@ -20,10 +20,10 @@ ZTEST_USER_F(net_socketpair, test_write_nonblock)
 
 		/* then set the O_NONBLOCK flag */
 		res = zsock_fcntl(fixture->sv[i], F_GETFL, 0);
-		zassert_not_equal(res, -1, "fcntl() failed: %d", i, errno);
+		zassert_not_equal(res, -1, "fcntl() %d failed: %d", i, errno);
 
 		res = zsock_fcntl(fixture->sv[i], F_SETFL, res | O_NONBLOCK);
-		zassert_not_equal(res, -1, "fcntl() failed: %d", i, errno);
+		zassert_not_equal(res, -1, "fcntl() %d failed: %d", i, errno);
 
 		/* then, try to write one more byte */
 		res = zsock_send(fixture->sv[i], "x", 1, 0);
@@ -41,10 +41,10 @@ ZTEST_USER_F(net_socketpair, test_read_nonblock)
 	for (size_t i = 0; i < 2; ++i) {
 		/* set the O_NONBLOCK flag */
 		res = zsock_fcntl(fixture->sv[i], F_GETFL, 0);
-		zassert_not_equal(res, -1, "fcntl() failed: %d", i, errno);
+		zassert_not_equal(res, -1, "fcntl() %d failed: %d", i, errno);
 
 		res = zsock_fcntl(fixture->sv[i], F_SETFL, res | O_NONBLOCK);
-		zassert_not_equal(res, -1, "fcntl() failed: %d", i, errno);
+		zassert_not_equal(res, -1, "fcntl() %d failed: %d", i, errno);
 
 		/* then, try to read one byte */
 		res = zsock_recv(fixture->sv[i], &c, 1, 0);


### PR DESCRIPTION
There is an issue when zephyr is compiled with native_sim_64 where size_t is 8 bytes. The socklen_t in specified as 4 bytes in Linux even for 64 bit builds so we have a conflict between Linux and Zephyr. To make things work properly, define socklen_t as uint32_t in order to align with Linux. Four bytes is enough for socket address length anyway.