### PR TITLE
net_buf: do not assert on buffer reset when flags are set

### DIFF
--- a/lib/net_buf/buf.c
+++ b/lib/net_buf/buf.c
@@ -87,7 +87,6 @@ static inline struct net_buf *pool_get_uninit(struct net_buf_pool *pool,
 
 void net_buf_reset(struct net_buf *buf)
 {
-	__ASSERT_NO_MSG(buf->flags == 0U);
 	__ASSERT_NO_MSG(buf->frags == NULL);
 
 	net_buf_simple_reset(&buf->b);


### PR DESCRIPTION
There is only one flag, NET_BUF_EXTERNAL_DATA, used when net_buf was allocated with external data. The flag is checked in net_buf_clone() and net_buf_destroy(). net_buf with external buffer can be used for receiving and transmitting. net_buf_reset() is convenient way to reset net_buf with external data before it is re-enqueued again.