### PR TITLE
Fix format specifiers zassert strings

### DIFF
--- a/tests/kernel/common/src/pow2.c
+++ b/tests/kernel/common/src/pow2.c
@@ -56,11 +56,11 @@ BUILD_ASSERT(sizeof(static_array9) == 16);
 static void test_pow2_ceil_x(unsigned long test_value,
 			     unsigned long expected_result)
 {
-	volatile unsigned int x = test_value;
-	unsigned int result = Z_POW2_CEIL(x);
+	volatile unsigned long x = test_value;
+	unsigned long result = Z_POW2_CEIL(x);
 
 	zassert_equal(result, expected_result,
-		      "ZPOW2_CEIL(%lu) returned %ld, expected %lu",
+		      "ZPOW2_CEIL(%lu) returned %lu, expected %lu",
 		      test_value, result, expected_result);
 }
 

--- a/tests/kernel/obj_core/obj_core_stats/src/main.c
+++ b/tests/kernel/obj_core/obj_core_stats/src/main.c
@@ -336,7 +336,7 @@ ZTEST(obj_core_stats_thread, test_obj_core_stats_thread_test)
 	/* Disable the stats (re-using query2 and query3) */
 
 	status = k_obj_core_stats_disable(K_OBJ_CORE(test_thread));
-	zassert_equal(status, 0, "Expected 0, got %llu\n", status);
+	zassert_equal(status, 0, "Expected 0, got %d\n", status);
 
 	k_sem_give(&wake_test_thread);
 	k_sem_take(&wake_main_thread, K_FOREVER);
@@ -351,7 +351,7 @@ ZTEST(obj_core_stats_thread, test_obj_core_stats_thread_test)
 	/* Enable the stats */
 
 	status = k_obj_core_stats_enable(K_OBJ_CORE(test_thread));
-	zassert_equal(status, 0, "Expected 0, got %llu\n", status);
+	zassert_equal(status, 0, "Expected 0, got %d\n", status);
 
 	k_sem_give(&wake_test_thread);
 	k_sem_take(&wake_main_thread, K_FOREVER);
@@ -440,14 +440,14 @@ static void test_mem_block_query(const char *str,
 		      "%s: Failed to get query stats (%d)\n", str, status);
 
 	zassert_equal(query.free_bytes, expected->free_bytes,
-		      "%s: Expected %u free bytes, got %u\n",
+		      "%s: Expected %zu free bytes, got %zu\n",
 		      str, expected->free_bytes, query.free_bytes);
 #ifdef CONFIG_SYS_MEM_BLOCKS_RUNTIME_STATS
 	zassert_equal(query.allocated_bytes, expected->allocated_bytes,
-		      "%s: Expected %u allocated bytes, got %u\n",
+		      "%s: Expected %zu allocated bytes, got %zu\n",
 		      str, expected->allocated_bytes, query.allocated_bytes);
 	zassert_equal(query.max_allocated_bytes, expected->max_allocated_bytes,
-		      "%s: Expected %u max_allocated bytes, got %d\n",
+		      "%s: Expected %zu max_allocated bytes, got %zu\n",
 		      str, expected->max_allocated_bytes,
 		      query.max_allocated_bytes);
 #endif
@@ -575,7 +575,7 @@ static void test_mem_slab_raw(const char *str, struct k_mem_slab_info *expected)
 		      "%s: Expected %u blocks, got %u\n",
 		      str, expected->num_blocks, raw.num_blocks);
 	zassert_equal(raw.block_size, expected->block_size,
-		      "%s: Expected block size=%u blocks, got %u\n",
+		      "%s: Expected block size=%zu blocks, got %zu\n",
 		      str, expected->block_size, raw.block_size);
 	zassert_equal(raw.num_used, expected->num_used,
 		      "%s: Expected %u used, got %d\n",
@@ -599,13 +599,13 @@ static void test_mem_slab_query(const char *str,
 		      "%s: Failed to get query stats (%d)\n", str, status);
 
 	zassert_equal(query.free_bytes, expected->free_bytes,
-		      "%s: Expected %u free bytes, got %u\n",
+		      "%s: Expected %zu free bytes, got %zu\n",
 		      str, expected->free_bytes, query.free_bytes);
 	zassert_equal(query.allocated_bytes, expected->allocated_bytes,
-		      "%s: Expected %u allocated bytes, got %u\n",
+		      "%s: Expected %zu allocated bytes, got %zu\n",
 		      str, expected->allocated_bytes, query.allocated_bytes);
 	zassert_equal(query.max_allocated_bytes, expected->max_allocated_bytes,
-		      "%s: Expected %u max_allocated bytes, got %d\n",
+		      "%s: Expected %zu max_allocated bytes, got %zu\n",
 		      str, expected->max_allocated_bytes,
 		      query.max_allocated_bytes);
 }

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -321,10 +321,10 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		+ expected_period_drift;
 
 	zassert_true(min_us >= min_us_bound,
-		"Shortest timer period too short (off by more than expected %d%)",
+		"Shortest timer period too short (off by more than expected %d%%)",
 		CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT);
 	zassert_true(max_us <= max_us_bound,
-		"Longest timer period too long (off by more than expected %d%)",
+		"Longest timer period too long (off by more than expected %d%%)",
 		CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT);
 
 

--- a/tests/lib/c_lib/thrd/src/thrd.c
+++ b/tests/lib/c_lib/thrd/src/thrd.c
@@ -79,7 +79,7 @@ ZTEST(libc_thrd, test_thrd_create_join)
 
 	zassert_equal(thrd_success, thrd_create(&thr, fun, &param));
 	zassert_equal(thrd_success, thrd_join(thr, &res));
-	zassert_equal(BIOS_FOOD, param, "expected: %d actual: %d", BIOS_FOOD, param);
+	zassert_equal(BIOS_FOOD, param, "expected: %lu actual: %lu", BIOS_FOOD, param);
 	zassert_equal(FORTY_TWO, res);
 }
 

--- a/tests/lib/c_lib/thrd/src/thrd.h
+++ b/tests/lib/c_lib/thrd/src/thrd.h
@@ -14,7 +14,7 @@
 #include <zephyr/sys/timeutil.h>
 
 /* arbitrary magic numbers used for testing */
-#define BIOS_FOOD     0xb105f00d
+#define BIOS_FOOD     0xb105f00dUL
 #define FORTY_TWO     42
 #define SEVENTY_THREE 73
 #define DONT_CARE     0x370ca2e5

--- a/tests/net/dhcpv6/src/main.c
+++ b/tests/net/dhcpv6/src/main.c
@@ -413,13 +413,13 @@ static void verify_dhcpv6_oro_sol_max_rt(struct net_if *iface,
 	net_pkt_cursor_backup(pkt, &backup);
 
 	ret = dhcpv6_find_option(pkt, DHCPV6_OPTION_CODE_ORO, &length);
-	zassert_ok(ret, 0, "ORO option not found");
+	zassert_ok(ret, "ORO option not found");
 	zassert_true(length >= sizeof(uint16_t) && length % sizeof(uint16_t) == 0,
 		     "Invalid ORO length");
 
 	while (length >= sizeof(uint16_t)) {
 		ret = net_pkt_read_be16(pkt, &oro);
-		zassert_ok(ret, 0, "ORO read error");
+		zassert_ok(ret, "ORO read error");
 		length -= sizeof(uint16_t);
 
 		if (oro == DHCPV6_OPTION_CODE_SOL_MAX_RT) {


### PR DESCRIPTION
For details see individual commits.

Fixes errors that were found after adding validation of zassert string in https://github.com/zephyrproject-rtos/zephyr/pull/96335.