### PR TITLE
dts: bindings: sensor: ti,ina226: Removed double enum value entry

### DIFF
--- a/dts/bindings/sensor/ti,ina226.yaml
+++ b/dts/bindings/sensor/ti,ina226.yaml
@@ -47,7 +47,6 @@ properties:
       - "Shunt Voltage, Triggered"
       - "Bus Voltage, Triggered"
       - "Shunt and Bus, Triggered"
-      - "Power-Down (or Shutdown)"
       - "Shunt Voltage, Continuous"
       - "Bus Voltage, Continuous"
       - "Shunt and Bus, Continuous"


### PR DESCRIPTION
Fixes warning "compatible 'ti,ina226' in binding 'zephyr/dts/bindings/sensor/ti,ina226.yaml' has non-tokenizable enum for property 'operating-mode': 'Power-Down (or Shutdown)', 'Shunt Voltage, Triggered', 'Bus Voltage, Triggered', 'Shunt and Bus, Triggered', 'Power-Down (or Shutdown)', 'Shunt Voltage, Continuous', 'Bus Voltage, Continuous', 'Shunt and Bus, Continuous'"

when using the INA226 driver