### PR TITLE
modem: optional dedicated workqueue

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -183,6 +183,10 @@ New APIs and options
 
     * :kconfig:option:`CONFIG_HAWKBIT_REBOOT_NONE`
 
+* Modem
+
+  * :kconfig:option:`CONFIG_MODEM_DEDICATED_WORKQUEUE`
+
 * Networking
 
   * Sockets

--- a/subsys/modem/CMakeLists.txt
+++ b/subsys/modem/CMakeLists.txt
@@ -5,6 +5,7 @@ if(CONFIG_MODEM_MODULES)
 
 zephyr_library()
 
+zephyr_library_sources_ifdef(CONFIG_MODEM_DEDICATED_WORKQUEUE modem_workqueue.c)
 zephyr_library_sources_ifdef(CONFIG_MODEM_CHAT modem_chat.c)
 zephyr_library_sources_ifdef(CONFIG_MODEM_CMUX modem_cmux.c)
 zephyr_library_sources_ifdef(CONFIG_MODEM_PIPE modem_pipe.c)

--- a/subsys/modem/Kconfig
+++ b/subsys/modem/Kconfig
@@ -6,6 +6,21 @@ menuconfig MODEM_MODULES
 
 if MODEM_MODULES
 
+config MODEM_DEDICATED_WORKQUEUE
+	bool "Use a dedicated workqueue for modem operations"
+
+if MODEM_DEDICATED_WORKQUEUE
+
+config MODEM_DEDICATED_WORKQUEUE_STACK_SIZE
+	int "Modem dedicated workqueue stack size"
+	default 1024
+
+config MODEM_DEDICATED_WORKQUEUE_PRIORITY
+	int "Modem dedicated workqueue priority"
+	default SYSTEM_WORKQUEUE_PRIORITY
+
+endif # MODEM_DEDICATED_WORKQUEUE
+
 config MODEM_CHAT
 	bool "Modem chat module"
 	select RING_BUFFER

--- a/subsys/modem/backends/modem_backend_uart_async_hwfc.c
+++ b/subsys/modem/backends/modem_backend_uart_async_hwfc.c
@@ -5,6 +5,7 @@
  */
 
 #include "modem_backend_uart_async.h"
+#include "../modem_workqueue.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(modem_backend_uart_async_hwfc, CONFIG_MODEM_MODULES_LOG_LEVEL);
@@ -136,7 +137,7 @@ static void modem_backend_uart_async_hwfc_event_handler(const struct device *dev
 	case UART_TX_DONE:
 		atomic_clear_bit(&backend->async.common.state,
 				 MODEM_BACKEND_UART_ASYNC_STATE_TRANSMIT_BIT);
-		k_work_submit(&backend->transmit_idle_work);
+		modem_work_submit(&backend->transmit_idle_work);
 		break;
 
 	case UART_TX_ABORTED:
@@ -145,7 +146,7 @@ static void modem_backend_uart_async_hwfc_event_handler(const struct device *dev
 		}
 		atomic_clear_bit(&backend->async.common.state,
 				 MODEM_BACKEND_UART_ASYNC_STATE_TRANSMIT_BIT);
-		k_work_submit(&backend->transmit_idle_work);
+		modem_work_submit(&backend->transmit_idle_work);
 
 		break;
 
@@ -182,7 +183,7 @@ static void modem_backend_uart_async_hwfc_event_handler(const struct device *dev
 				rx_buf_unref(&backend->async, evt->data.rx.buf);
 				break;
 			}
-			k_work_schedule(&backend->receive_ready_work, K_NO_WAIT);
+			modem_work_schedule(&backend->receive_ready_work, K_NO_WAIT);
 		}
 		break;
 
@@ -191,7 +192,7 @@ static void modem_backend_uart_async_hwfc_event_handler(const struct device *dev
 				    MODEM_BACKEND_UART_ASYNC_STATE_OPEN_BIT)) {
 			if (!atomic_test_and_set_bit(&backend->async.common.state,
 						     MODEM_BACKEND_UART_ASYNC_STATE_RECOVERY_BIT)) {
-				k_work_schedule(&backend->receive_ready_work, K_NO_WAIT);
+				modem_work_schedule(&backend->receive_ready_work, K_NO_WAIT);
 				LOG_DBG("RX recovery started");
 			}
 		}
@@ -206,7 +207,7 @@ static void modem_backend_uart_async_hwfc_event_handler(const struct device *dev
 	}
 
 	if (modem_backend_uart_async_hwfc_is_uart_stopped(backend)) {
-		k_work_submit(&backend->async.common.rx_disabled_work);
+		modem_work_submit(&backend->async.common.rx_disabled_work);
 	}
 }
 
@@ -335,7 +336,7 @@ static int modem_backend_uart_async_hwfc_receive(void *data, uint8_t *buf, size_
 
 	if (backend->async.rx_event.len != 0 ||
 	    k_msgq_num_used_get(&backend->async.rx_queue) != 0) {
-		k_work_schedule(&backend->receive_ready_work, K_NO_WAIT);
+		modem_work_schedule(&backend->receive_ready_work, K_NO_WAIT);
 	}
 
 	modem_backend_uart_async_hwfc_rx_recovery(backend);

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -15,6 +15,8 @@ LOG_MODULE_REGISTER(modem_chat, CONFIG_MODEM_MODULES_LOG_LEVEL);
 
 #include <zephyr/modem/chat.h>
 
+#include "modem_workqueue.h"
+
 const struct modem_chat_match modem_chat_any_match = MODEM_CHAT_MATCH("", "", NULL);
 const struct modem_chat_match modem_chat_empty_matches[0];
 const struct modem_chat_script_chat modem_chat_empty_script_chats[0];
@@ -127,7 +129,7 @@ static void modem_chat_set_script_send_state(struct modem_chat *chat,
 static void modem_chat_script_send(struct modem_chat *chat)
 {
 	modem_chat_set_script_send_state(chat, MODEM_CHAT_SCRIPT_SEND_STATE_REQUEST);
-	k_work_submit(&chat->script_send_work);
+	modem_work_submit(&chat->script_send_work);
 }
 
 static void modem_chat_script_set_response_matches(struct modem_chat *chat)
@@ -178,7 +180,7 @@ static void modem_chat_script_chat_schedule_send_timeout(struct modem_chat *chat
 {
 	uint16_t timeout = modem_chat_script_chat_get_send_timeout(chat);
 
-	k_work_schedule(&chat->script_send_timeout_work, K_MSEC(timeout));
+	modem_work_schedule(&chat->script_send_timeout_work, K_MSEC(timeout));
 }
 
 static void modem_chat_script_next(struct modem_chat *chat, bool initial)
@@ -233,7 +235,7 @@ static void modem_chat_script_start(struct modem_chat *chat, const struct modem_
 
 	/* Start timeout work if script started */
 	if (chat->script != NULL) {
-		k_work_schedule(&chat->script_timeout_work, K_SECONDS(chat->script->timeout));
+		modem_work_schedule(&chat->script_timeout_work, K_SECONDS(chat->script->timeout));
 	}
 }
 
@@ -742,7 +744,7 @@ static void modem_chat_process_handler(struct k_work *item)
 
 	/* Process data */
 	modem_chat_process_bytes(chat);
-	k_work_submit(&chat->receive_work);
+	modem_work_submit(&chat->receive_work);
 }
 
 static void modem_chat_pipe_callback(struct modem_pipe *pipe, enum modem_pipe_event event,
@@ -752,11 +754,11 @@ static void modem_chat_pipe_callback(struct modem_pipe *pipe, enum modem_pipe_ev
 
 	switch (event) {
 	case MODEM_PIPE_EVENT_RECEIVE_READY:
-		k_work_submit(&chat->receive_work);
+		modem_work_submit(&chat->receive_work);
 		break;
 
 	case MODEM_PIPE_EVENT_TRANSMIT_IDLE:
-		k_work_submit(&chat->script_send_work);
+		modem_work_submit(&chat->script_send_work);
 		break;
 
 	default:
@@ -880,7 +882,7 @@ int modem_chat_run_script_async(struct modem_chat *chat, const struct modem_chat
 	k_sem_reset(&chat->script_stopped_sem);
 
 	chat->pending_script = script;
-	k_work_submit(&chat->script_run_work);
+	modem_work_submit(&chat->script_run_work);
 	return 0;
 }
 
@@ -903,7 +905,7 @@ int modem_chat_run_script(struct modem_chat *chat, const struct modem_chat_scrip
 
 void modem_chat_script_abort(struct modem_chat *chat)
 {
-	k_work_submit(&chat->script_abort_work);
+	modem_work_submit(&chat->script_abort_work);
 }
 
 void modem_chat_release(struct modem_chat *chat)

--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -13,6 +13,8 @@ LOG_MODULE_REGISTER(modem_cmux, CONFIG_MODEM_CMUX_LOG_LEVEL);
 
 #include <string.h>
 
+#include "modem_workqueue.h"
+
 #define MODEM_CMUX_SOF				(0xF9)
 #define MODEM_CMUX_FCS_POLYNOMIAL		(0xE0)
 #define MODEM_CMUX_FCS_INIT_VALUE		(0xFF)
@@ -257,11 +259,11 @@ static void modem_cmux_bus_callback(struct modem_pipe *pipe, enum modem_pipe_eve
 
 	switch (event) {
 	case MODEM_PIPE_EVENT_RECEIVE_READY:
-		k_work_schedule(&cmux->receive_work, K_NO_WAIT);
+		modem_work_schedule(&cmux->receive_work, K_NO_WAIT);
 		break;
 
 	case MODEM_PIPE_EVENT_TRANSMIT_IDLE:
-		k_work_schedule(&cmux->transmit_work, K_NO_WAIT);
+		modem_work_schedule(&cmux->transmit_work, K_NO_WAIT);
 		break;
 
 	default:
@@ -321,7 +323,7 @@ static uint16_t modem_cmux_transmit_frame(struct modem_cmux *cmux,
 	buf[0] = fcs;
 	buf[1] = MODEM_CMUX_SOF;
 	ring_buf_put(&cmux->transmit_rb, buf, 2);
-	k_work_schedule(&cmux->transmit_work, K_NO_WAIT);
+	modem_work_schedule(&cmux->transmit_work, K_NO_WAIT);
 	return data_len;
 }
 
@@ -940,7 +942,7 @@ static void modem_cmux_receive_handler(struct k_work *item)
 	}
 
 	/* Reschedule received work */
-	k_work_schedule(&cmux->receive_work, K_NO_WAIT);
+	modem_work_schedule(&cmux->receive_work, K_NO_WAIT);
 }
 
 static void modem_cmux_dlci_notify_transmit_idle(struct modem_cmux *cmux)
@@ -1027,7 +1029,7 @@ static void modem_cmux_connect_handler(struct k_work *item)
 	};
 
 	modem_cmux_transmit_cmd_frame(cmux, &frame);
-	k_work_schedule(&cmux->connect_work, MODEM_CMUX_T1_TIMEOUT);
+	modem_work_schedule(&cmux->connect_work, MODEM_CMUX_T1_TIMEOUT);
 }
 
 static void modem_cmux_disconnect_handler(struct k_work *item)
@@ -1057,7 +1059,7 @@ static void modem_cmux_disconnect_handler(struct k_work *item)
 
 	/* Transmit close down command */
 	modem_cmux_transmit_cmd_frame(cmux, &frame);
-	k_work_schedule(&cmux->disconnect_work, MODEM_CMUX_T1_TIMEOUT);
+	modem_work_schedule(&cmux->disconnect_work, MODEM_CMUX_T1_TIMEOUT);
 }
 
 #if CONFIG_MODEM_STATS
@@ -1107,7 +1109,7 @@ static int modem_cmux_dlci_pipe_api_open(void *data)
 			K_SPINLOCK_BREAK;
 		}
 
-		k_work_schedule(&dlci->open_work, K_NO_WAIT);
+		modem_work_schedule(&dlci->open_work, K_NO_WAIT);
 	}
 
 	return ret;
@@ -1173,7 +1175,7 @@ static int modem_cmux_dlci_pipe_api_close(void *data)
 			K_SPINLOCK_BREAK;
 		}
 
-		k_work_schedule(&dlci->close_work, K_NO_WAIT);
+		modem_work_schedule(&dlci->close_work, K_NO_WAIT);
 	}
 
 	return ret;
@@ -1210,7 +1212,7 @@ static void modem_cmux_dlci_open_handler(struct k_work *item)
 	};
 
 	modem_cmux_transmit_cmd_frame(dlci->cmux, &frame);
-	k_work_schedule(&dlci->open_work, MODEM_CMUX_T1_TIMEOUT);
+	modem_work_schedule(&dlci->open_work, MODEM_CMUX_T1_TIMEOUT);
 }
 
 static void modem_cmux_dlci_close_handler(struct k_work *item)
@@ -1239,7 +1241,7 @@ static void modem_cmux_dlci_close_handler(struct k_work *item)
 	};
 
 	modem_cmux_transmit_cmd_frame(cmux, &frame);
-	k_work_schedule(&dlci->close_work, MODEM_CMUX_T1_TIMEOUT);
+	modem_work_schedule(&dlci->close_work, MODEM_CMUX_T1_TIMEOUT);
 }
 
 static void modem_cmux_dlci_pipes_release(struct modem_cmux *cmux)
@@ -1367,7 +1369,7 @@ int modem_cmux_connect_async(struct modem_cmux *cmux)
 		}
 
 		if (k_work_delayable_is_pending(&cmux->connect_work) == false) {
-			k_work_schedule(&cmux->connect_work, K_NO_WAIT);
+			modem_work_schedule(&cmux->connect_work, K_NO_WAIT);
 		}
 	}
 
@@ -1406,7 +1408,7 @@ int modem_cmux_disconnect_async(struct modem_cmux *cmux)
 		}
 
 		if (k_work_delayable_is_pending(&cmux->disconnect_work) == false) {
-			k_work_schedule(&cmux->disconnect_work, K_NO_WAIT);
+			modem_work_schedule(&cmux->disconnect_work, K_NO_WAIT);
 		}
 	}
 

--- a/subsys/modem/modem_ppp.c
+++ b/subsys/modem/modem_ppp.c
@@ -10,6 +10,8 @@
 #include <zephyr/pm/device_runtime.h>
 #include <string.h>
 
+#include "modem_workqueue.h"
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(modem_ppp, CONFIG_MODEM_MODULES_LOG_LEVEL);
 
@@ -341,12 +343,12 @@ static void modem_ppp_pipe_callback(struct modem_pipe *pipe, enum modem_pipe_eve
 
 	switch (event) {
 	case MODEM_PIPE_EVENT_RECEIVE_READY:
-		k_work_submit(&ppp->process_work);
+		modem_work_submit(&ppp->process_work);
 		break;
 
 	case MODEM_PIPE_EVENT_OPENED:
 	case MODEM_PIPE_EVENT_TRANSMIT_IDLE:
-		k_work_submit(&ppp->send_work);
+		modem_work_submit(&ppp->send_work);
 		break;
 
 	default:
@@ -425,7 +427,7 @@ static void modem_ppp_process_handler(struct k_work *item)
 		modem_ppp_process_received_byte(ppp, ppp->receive_buf[i]);
 	}
 
-	k_work_submit(&ppp->process_work);
+	modem_work_submit(&ppp->process_work);
 }
 
 static void modem_ppp_ppp_api_init(struct net_if *iface)
@@ -488,7 +490,7 @@ static int modem_ppp_ppp_api_send(const struct device *dev, struct net_pkt *pkt)
 
 	net_pkt_ref(pkt);
 	k_fifo_put(&ppp->tx_pkt_fifo, pkt);
-	k_work_submit(&ppp->send_work);
+	modem_work_submit(&ppp->send_work);
 	return 0;
 }
 

--- a/subsys/modem/modem_ubx.c
+++ b/subsys/modem/modem_ubx.c
@@ -9,6 +9,8 @@
 #include <zephyr/modem/ubx.h>
 #include <zephyr/sys/check.h>
 
+#include "modem_workqueue.h"
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(modem_ubx, CONFIG_MODEM_MODULES_LOG_LEVEL);
 
@@ -19,7 +21,7 @@ static void modem_ubx_pipe_callback(struct modem_pipe *pipe,
 	struct modem_ubx *ubx = (struct modem_ubx *)user_data;
 
 	if (event == MODEM_PIPE_EVENT_RECEIVE_READY) {
-		k_work_submit(&ubx->process_work);
+		modem_work_submit(&ubx->process_work);
 	}
 }
 

--- a/subsys/modem/modem_workqueue.c
+++ b/subsys/modem/modem_workqueue.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Embeint Pty Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+
+#include "modem_workqueue.h"
+
+static struct k_work_q modem_work_q;
+static K_THREAD_STACK_DEFINE(modem_stack_area, CONFIG_MODEM_DEDICATED_WORKQUEUE_STACK_SIZE);
+
+int modem_work_submit(struct k_work *work)
+{
+	return k_work_submit_to_queue(&modem_work_q, work);
+}
+
+int modem_work_schedule(struct k_work_delayable *dwork, k_timeout_t delay)
+{
+	return k_work_schedule_for_queue(&modem_work_q, dwork, delay);
+}
+
+int modem_work_reschedule(struct k_work_delayable *dwork, k_timeout_t delay)
+{
+	return k_work_reschedule_for_queue(&modem_work_q, dwork, delay);
+}
+
+static int modem_work_q_init(void)
+{
+	/* Boot the dedicated workqueue */
+	k_work_queue_init(&modem_work_q);
+	k_work_queue_start(&modem_work_q, modem_stack_area, K_THREAD_STACK_SIZEOF(modem_stack_area),
+			   CONFIG_MODEM_DEDICATED_WORKQUEUE_PRIORITY, NULL);
+	k_thread_name_set(k_work_queue_thread_get(&modem_work_q), "modem_workq");
+	return 0;
+}
+
+SYS_INIT(modem_work_q_init, POST_KERNEL, 0);

--- a/subsys/modem/modem_workqueue.h
+++ b/subsys/modem/modem_workqueue.h
@@ -1,0 +1,49 @@
+/** @file
+ * @brief Modem workqueue header file.
+ */
+
+/*
+ * Copyright (c) 2025 Embeint Pty Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_MODEM_WORKQUEUE_H_
+#define ZEPHYR_INCLUDE_MODEM_WORKQUEUE_H_
+
+#include <zephyr/kernel.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef CONFIG_MODEM_DEDICATED_WORKQUEUE
+
+int modem_work_submit(struct k_work *work);
+int modem_work_schedule(struct k_work_delayable *dwork, k_timeout_t delay);
+int modem_work_reschedule(struct k_work_delayable *dwork, k_timeout_t delay);
+
+#else
+
+static inline int modem_work_submit(struct k_work *work)
+{
+	return k_work_submit(work);
+}
+
+static inline int modem_work_schedule(struct k_work_delayable *dwork, k_timeout_t delay)
+{
+	return k_work_schedule(dwork, delay);
+}
+
+static inline int modem_work_reschedule(struct k_work_delayable *dwork, k_timeout_t delay)
+{
+	return k_work_reschedule(dwork, delay);
+}
+
+#endif /* CONFIG_MODEM_DEDICATED_WORKQUEUE */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_MODEM_WORKQUEUE_H_ */

--- a/tests/subsys/modem/modem_chat/testcase.yaml
+++ b/tests/subsys/modem/modem_chat/testcase.yaml
@@ -1,11 +1,15 @@
 # Copyright (c) 2023 Trackunit Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+common:
+  tags: modem_chat
+  harness: ztest
+  platform_allow:
+    - native_sim
+  integration_platforms:
+    - native_sim
 tests:
-  modem.modem_chat:
-    tags: modem_chat
-    harness: ztest
-    platform_allow:
-      - native_sim
-    integration_platforms:
-      - native_sim
+  modem.modem_chat: {}
+  modem.modem_chat.workq:
+    extra_configs:
+      - CONFIG_MODEM_DEDICATED_WORKQUEUE=y


### PR DESCRIPTION
Add the option to use a dedicated workqueue for the modem backends.