### PR TITLE
pm: policy: Add option to lock all power states

### DIFF
--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -112,6 +112,7 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks);
  *
  * @see pm_policy_state_lock_put()
  */
+
 void pm_policy_state_lock_get(enum pm_state state, uint8_t substate_id);
 
 /**
@@ -124,6 +125,18 @@ void pm_policy_state_lock_get(enum pm_state state, uint8_t substate_id);
  * @see pm_policy_state_lock_get()
  */
 void pm_policy_state_lock_put(enum pm_state state, uint8_t substate_id);
+
+/**
+ * @brief Request to lock all power states.
+ *
+ * Requests use a reference counter.
+ */
+void pm_policy_state_all_lock_get(void);
+
+/**
+ * @brief Release locking of all power states.
+ */
+void pm_policy_state_all_lock_put(void);
 
 /**
  * @brief Apply power state constraints by locking the specified states.
@@ -274,6 +287,14 @@ static inline void pm_policy_state_lock_put(enum pm_state state, uint8_t substat
 	ARG_UNUSED(substate_id);
 }
 
+static inline void pm_policy_state_all_lock_get(void)
+{
+}
+
+static inline void pm_policy_state_all_lock_put(void)
+{
+}
+
 static inline bool pm_policy_state_lock_is_active(enum pm_state state, uint8_t substate_id)
 {
 	ARG_UNUSED(state);
@@ -344,6 +365,7 @@ static inline void pm_policy_device_power_lock_put(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 }
+
 #endif /* CONFIG_PM_POLICY_DEVICE_CONSTRAINTS */
 
 #if defined(CONFIG_PM) || defined(CONFIG_PM_POLICY_LATENCY_STANDALONE) || defined(__DOXYGEN__)

--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -112,7 +112,6 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks);
  *
  * @see pm_policy_state_lock_put()
  */
-
 void pm_policy_state_lock_get(enum pm_state state, uint8_t substate_id);
 
 /**
@@ -365,7 +364,6 @@ static inline void pm_policy_device_power_lock_put(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 }
-
 #endif /* CONFIG_PM_POLICY_DEVICE_CONSTRAINTS */
 
 #if defined(CONFIG_PM) || defined(CONFIG_PM_POLICY_LATENCY_STANDALONE) || defined(__DOXYGEN__)

--- a/subsys/pm/policy/policy_state_lock.c
+++ b/subsys/pm/policy/policy_state_lock.c
@@ -50,13 +50,17 @@ static struct k_spinlock lock;
 
 void pm_policy_state_all_lock_get(void)
 {
+#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_power_state)
 	(void)atomic_inc(&global_lock_cnt);
+#endif
 }
 
 void pm_policy_state_all_lock_put(void)
 {
+#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_power_state)
 	__ASSERT(global_lock_cnt > 0, "Unbalanced state lock get/put");
 	(void)atomic_dec(&global_lock_cnt);
+#endif
 }
 
 

--- a/subsys/pm/policy/policy_state_lock.c
+++ b/subsys/pm/policy/policy_state_lock.c
@@ -43,9 +43,22 @@ static const struct {
 static atomic_t lock_cnt[ARRAY_SIZE(substates)];
 static atomic_t latency_mask = BIT_MASK(ARRAY_SIZE(substates));
 static atomic_t unlock_mask = BIT_MASK(ARRAY_SIZE(substates));
+static atomic_t global_lock_cnt;
 static struct k_spinlock lock;
 
 #endif
+
+void pm_policy_state_all_lock_get(void)
+{
+	(void)atomic_inc(&global_lock_cnt);
+}
+
+void pm_policy_state_all_lock_put(void)
+{
+	__ASSERT(global_lock_cnt > 0, "Unbalanced state lock get/put");
+	(void)atomic_dec(&global_lock_cnt);
+}
+
 
 void pm_policy_state_lock_get(enum pm_state state, uint8_t substate_id)
 {
@@ -106,7 +119,8 @@ bool pm_policy_state_lock_is_active(enum pm_state state, uint8_t substate_id)
 	for (size_t i = 0; i < ARRAY_SIZE(substates); i++) {
 		if (substates[i].state == state &&
 		   (substates[i].substate_id == substate_id || substate_id == PM_ALL_SUBSTATES)) {
-			return atomic_get(&lock_cnt[i]) != 0;
+			return (atomic_get(&global_lock_cnt) != 0) ||
+			       (atomic_get(&lock_cnt[i]) != 0);
 		}
 	}
 #endif
@@ -117,6 +131,10 @@ bool pm_policy_state_lock_is_active(enum pm_state state, uint8_t substate_id)
 bool pm_policy_state_is_available(enum pm_state state, uint8_t substate_id)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(zephyr_power_state)
+	if (atomic_get(&global_lock_cnt) != 0) {
+		return false;
+	}
+
 	for (size_t i = 0; i < ARRAY_SIZE(substates); i++) {
 		if (substates[i].state == state &&
 		   (substates[i].substate_id == substate_id || substate_id == PM_ALL_SUBSTATES)) {
@@ -135,7 +153,8 @@ bool pm_policy_state_any_active(void)
 	/* Check if there is any power state that is not locked and not disabled due
 	 * to latency requirements.
 	 */
-	return atomic_get(&unlock_mask) & atomic_get(&latency_mask);
+	return (atomic_get(&global_lock_cnt) == 0) &&
+	       (atomic_get(&unlock_mask) & atomic_get(&latency_mask));
 #endif
 	return true;
 }


### PR DESCRIPTION
Add function for getting and putting a lock for all power states. It is much faster version of requesting 0 us latency with actual  intention to disable all power states.
