### PR TITLE
Bluetooth: Remove CONFIG_BT_BUF_ACL_RX_COUNT

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -58,6 +58,7 @@ Removed APIs and options
   PSA Crypto API is now the recommended cryptographic library for Zephyr.
 * The legacy pipe object API was removed. Use the new pipe API instead.
 * ``bt_le_set_auto_conn``
+* ``CONFIG_BT_BUF_ACL_RX_COUNT``
 
 Deprecated APIs and options
 ===========================

--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -144,26 +144,19 @@ static inline enum bt_buf_type bt_buf_type_from_h4(uint8_t h4_type, enum bt_buf_
 #define BT_BUF_ACL_RX_COUNT_MAX 65535
 
 #if defined(CONFIG_BT_CONN) && defined(CONFIG_BT_HCI_HOST)
- /* The host needs more ACL buffers than maximum ACL links. This is because of
-  * the way we re-assemble ACL packets into L2CAP PDUs.
-  *
-  * We keep around the first buffer (that comes from the driver) to do
-  * re-assembly into, and if all links are re-assembling, there will be no buffer
-  * available for the HCI driver to allocate from.
-  *
-  * TODO: When CONFIG_BT_BUF_ACL_RX_COUNT is removed,
-  *       remove the MAX and only keep the 1.
-  */
+/* The host needs more ACL buffers than maximum ACL links. This is because of
+ * the way we re-assemble ACL packets into L2CAP PDUs.
+ *
+ * We keep around the first buffer (that comes from the driver) to do
+ * re-assembly into, and if all links are re-assembling, there will be no buffer
+ * available for the HCI driver to allocate from.
+ */
 #define BT_BUF_ACL_RX_COUNT_EXTRA CONFIG_BT_BUF_ACL_RX_COUNT_EXTRA
-#define BT_BUF_ACL_RX_COUNT       (MAX(CONFIG_BT_BUF_ACL_RX_COUNT, 1) + BT_BUF_ACL_RX_COUNT_EXTRA)
+#define BT_BUF_ACL_RX_COUNT       (1 + BT_BUF_ACL_RX_COUNT_EXTRA)
 #else
 #define BT_BUF_ACL_RX_COUNT_EXTRA 0
 #define BT_BUF_ACL_RX_COUNT       0
 #endif /* CONFIG_BT_CONN && CONFIG_BT_HCI_HOST */
-
-#if defined(CONFIG_BT_BUF_ACL_RX_COUNT) && CONFIG_BT_BUF_ACL_RX_COUNT > 0
-#warning "CONFIG_BT_BUF_ACL_RX_COUNT is deprecated, see Zephyr 4.1 migration guide"
-#endif /* CONFIG_BT_BUF_ACL_RX_COUNT && CONFIG_BT_BUF_ACL_RX_COUNT > 0 */
 
 BUILD_ASSERT(BT_BUF_ACL_RX_COUNT <= BT_BUF_ACL_RX_COUNT_MAX,
 	     "Maximum number of ACL RX buffer is 65535, reduce CONFIG_BT_BUF_ACL_RX_COUNT_EXTRA");

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -102,27 +102,6 @@ config BT_BUF_ACL_RX_COUNT_EXTRA
 	  connection and uses one Rx buffer across all connections to receive a
 	  fragment from the Controller.
 
-config BT_BUF_ACL_RX_COUNT
-	int "[DEPRECATED] Number of incoming ACL data buffers"
-	default 0
-	range 0 256
-	help
-	  Number or incoming ACL data buffers sent from the Controller to the
-	  Host.
-	  In a combined Host and Controller build the buffers are shared and
-	  therefore Controller to Host flow control is not needed.
-
-	  In a Host only build with Controller to Host flow control enabled
-	  the Host will inform the Controller about the maximum number of
-	  buffers by setting this value in the Host Buffer Size command.
-
-	  When Controller to Host flow control is not enabled the Controller
-	  can assume that the Host has infinite amount of buffers.
-
-	  For both configurations, there is an additional requirement that is
-	  enforced by a build-time check: BT_BUF_ACL_RX_COUNT needs to be at
-	  least one greater than BT_MAX_CONN.
-
 config BT_BUF_EVT_RX_SIZE
 	int "Maximum supported HCI Event buffer length"
 	default $(UINT8_MAX) if (BT_EXT_ADV && BT_OBSERVER) || BT_PER_ADV_SYNC || BT_DF_CONNECTION_CTE_RX || BT_CLASSIC || BT_CHANNEL_SOUNDING || BT_LE_EXTENDED_FEAT_SET


### PR DESCRIPTION
Remove the deprecated CONFIG_BT_BUF_ACL_RX_COUNT config
as it has been deprecated since 4.1