### PR TITLE
stm32n6: Add I3C support

### DIFF
--- a/boards/st/stm32n6570_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32n6570_dk/arduino_r3_connector.dtsi
@@ -42,3 +42,5 @@ arduino_serial: &usart2 {};
 arduino_i2c: &i2c1 {};
 
 arduino_spi: &spi5 {};
+
+arduino_i3c: &i3c1 {};

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -173,6 +173,12 @@
 	status = "okay";
 };
 
+&ic10 {
+	pll-src = <4>;
+	ic-div = <32>;
+	status = "okay";
+};
+
 &ic11 {
 	pll-src = <1>;
 	ic-div = <3>;
@@ -311,6 +317,20 @@ csi_i2c: &i2c1 {
 		pinctrl-0 = <&tim15_ch1_pc12>;
 		pinctrl-names = "default";
 	};
+};
+
+&i3c1 {
+	pinctrl-0 = <&i3c1_scl_ph9 &i3c1_sda_pc1>;
+	pinctrl-names = "default";
+
+	clocks = <&rcc STM32_CLOCK(APB1, 24)>,
+		 <&rcc STM32_SRC_IC10 I3C1_SEL(2)>;
+
+	i2c-scl-hz = <400000>;
+	i3c-scl-hz = <6000000>;
+
+	/* Due to pin conflict with i2c1, keep it disabled  */
+	/* status = "okay"; */
 };
 
 zephyr_udc0: &usbotg_hs1 {

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -635,6 +635,32 @@
 			status = "disabled";
 		};
 
+		i3c1: i3c@50006000 {
+			compatible = "st,stm32-i3c";
+			reg = <0x50006000 0x400>;
+			interrupts = <108 0>, <109 0>;
+			interrupt-names = "event", "error";
+			#address-cells = <3>;
+			#size-cells = <0>;
+			clocks = <&rcc STM32_CLOCK(APB1, 24)>;
+			resets = <&rctl STM32_RESET(APB1L, 24)>;
+			zephyr,pm-device-runtime-auto;
+			status = "disabled";
+		};
+
+		i3c2: i3c@50006400 {
+			compatible = "st,stm32-i3c";
+			reg = <0x50006400 0x400>;
+			interrupts = <110 0>, <111 0>;
+			interrupt-names = "event", "error";
+			#address-cells = <3>;
+			#size-cells = <0>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
+			resets = <&rctl STM32_RESET(APB1L, 25)>;
+			zephyr,pm-device-runtime-auto;
+			status = "disabled";
+		};
+
 		spi1: spi@52003000 {
 			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;


### PR DESCRIPTION
Enable I3C on STM32N6 series and stm32n6570_dk board.

Tested on up coming out of tree shield sample supporting i3c