### PR TITLE
tests: secure_storage: Exclude nRF54H20 targets

### DIFF
--- a/tests/subsys/secure_storage/psa/crypto/testcase.yaml
+++ b/tests/subsys/secure_storage/psa/crypto/testcase.yaml
@@ -1,6 +1,9 @@
 common:
   tags:
     - psa.secure_storage
+  platform_exclude:
+    - nrf54h20dk/nrf54h20/cpuapp
+    - nrf54h20dk/nrf54h20/cpurad
 tests:
   secure_storage.psa.crypto.secure_storage:
     filter: CONFIG_SECURE_STORAGE and not CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_NONE

--- a/tests/subsys/secure_storage/psa/its/testcase.yaml
+++ b/tests/subsys/secure_storage/psa/its/testcase.yaml
@@ -4,6 +4,8 @@ common:
     - nrf54l15dk/nrf54l15/cpuapp
   platform_exclude:
     - qemu_cortex_m0 # settings subsystem initialization fails
+    - nrf54h20dk/nrf54h20/cpuapp
+    - nrf54h20dk/nrf54h20/cpurad
   timeout: 600
   tags:
     - psa.secure_storage


### PR DESCRIPTION
Exclude the application and radio core targets for nRF54H20 since
they use Ironside as their PSA storage provider.