### PR TITLE
Drivers: i2c: target eeprom extra api

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -229,6 +229,12 @@ Counter
            resolution = <16>;
        };
 
+EEPROM
+======
+
+* Added :c:func:`eeprom_target_read_data()` and :c:func:`eeprom_target_write_data()` which takes an
+  offset and length and deprecated :c:func:`eeprom_target_program()` for the I2C EEPROM target driver.
+
 Ethernet
 ========
 

--- a/drivers/i2c/target/eeprom_target.c
+++ b/drivers/i2c/target/eeprom_target.c
@@ -81,34 +81,6 @@ int eeprom_target_write_data(const struct device *dev, off_t offset,
 	return 0;
 }
 
-int eeprom_target_program(const struct device *dev, const uint8_t *eeprom_data,
-			 unsigned int length)
-{
-	struct i2c_eeprom_target_data *data = dev->data;
-
-	if (length > data->buffer_size) {
-		return -EINVAL;
-	}
-
-	memcpy(data->buffer, eeprom_data, length);
-
-	return 0;
-}
-
-int eeprom_target_read(const struct device *dev, uint8_t *eeprom_data,
-		      unsigned int offset)
-{
-	struct i2c_eeprom_target_data *data = dev->data;
-
-	if (!data || offset >= data->buffer_size) {
-		return -EINVAL;
-	}
-
-	*eeprom_data = data->buffer[offset];
-
-	return 0;
-}
-
 #ifdef CONFIG_I2C_EEPROM_TARGET_RUNTIME_ADDR
 int eeprom_target_set_addr(const struct device *dev, uint8_t addr)
 {

--- a/drivers/i2c/target/eeprom_target.c
+++ b/drivers/i2c/target/eeprom_target.c
@@ -53,6 +53,34 @@ size_t eeprom_target_get_size(const struct device *dev)
 	return data->buffer_size;
 }
 
+int eeprom_target_read_data(const struct device *dev, off_t offset,
+			    void *data, size_t len)
+{
+	struct i2c_eeprom_target_data *drv_data = dev->data;
+
+	if ((offset + len) > drv_data->buffer_size) {
+		LOG_WRN("attempt to read past device boundary");
+		return -EINVAL;
+	}
+
+	memcpy(data, drv_data->buffer + offset, len);
+	return 0;
+}
+
+int eeprom_target_write_data(const struct device *dev, off_t offset,
+			     const void *data, size_t len)
+{
+	struct i2c_eeprom_target_data *drv_data = dev->data;
+
+	if ((offset + len) > drv_data->buffer_size) {
+		LOG_WRN("attempt to write past device boundary");
+		return -EINVAL;
+	}
+
+	memcpy(drv_data->buffer + offset, data, len);
+	return 0;
+}
+
 int eeprom_target_program(const struct device *dev, const uint8_t *eeprom_data,
 			 unsigned int length)
 {

--- a/drivers/i2c/target/eeprom_target.c
+++ b/drivers/i2c/target/eeprom_target.c
@@ -46,6 +46,13 @@ void eeprom_target_set_changed_callback(const struct device *dev,
 	data->changed_handler_data = user_data;
 }
 
+size_t eeprom_target_get_size(const struct device *dev)
+{
+	struct i2c_eeprom_target_data *data = dev->data;
+
+	return data->buffer_size;
+}
+
 int eeprom_target_program(const struct device *dev, const uint8_t *eeprom_data,
 			 unsigned int length)
 {

--- a/include/zephyr/drivers/i2c/target/eeprom.h
+++ b/include/zephyr/drivers/i2c/target/eeprom.h
@@ -12,6 +12,8 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_I2C_TARGET_EEPROM_H_
 #define ZEPHYR_INCLUDE_DRIVERS_I2C_TARGET_EEPROM_H_
 
+#include <stddef.h>
+
 /**
  * @brief Interfaces for I2C EEPROM target devices.
  * @defgroup i2c_eeprom_target_api I2C EEPROM Target
@@ -40,6 +42,15 @@ typedef void (*eeprom_target_changed_handler_t)(const struct device *dev, void *
 void eeprom_target_set_changed_callback(const struct device *dev,
 					eeprom_target_changed_handler_t handler,
 					void *user_data);
+
+/**
+ * @brief Get size of the virtual EEPROM
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @return Size of EEPROM in bytes
+ */
+size_t eeprom_target_get_size(const struct device *dev);
 
 /**
  * @brief Program memory of the virtual EEPROM

--- a/include/zephyr/drivers/i2c/target/eeprom.h
+++ b/include/zephyr/drivers/i2c/target/eeprom.h
@@ -91,8 +91,12 @@ int eeprom_target_write_data(const struct device *dev, off_t offset,
  * @retval 0 If successful.
  * @retval -EINVAL Invalid data size
  */
-__deprecated int eeprom_target_program(const struct device *dev, const uint8_t *eeprom_data,
-				       unsigned int length);
+static inline __deprecated int eeprom_target_program(const struct device *dev,
+						     const uint8_t *eeprom_data,
+						     unsigned int length)
+{
+	return eeprom_target_write_data(dev, 0, eeprom_data, length);
+}
 
 /**
  * @brief Read single byte of virtual EEPROM memory
@@ -104,8 +108,11 @@ __deprecated int eeprom_target_program(const struct device *dev, const uint8_t *
  * @retval 0 If successful.
  * @retval -EINVAL Invalid data pointer or offset
  */
-int eeprom_target_read(const struct device *dev, uint8_t *eeprom_data,
-		      unsigned int offset);
+static inline int eeprom_target_read(const struct device *dev, uint8_t *eeprom_data,
+				     unsigned int offset)
+{
+	return eeprom_target_read_data(dev, offset, eeprom_data, 1);
+}
 
 /**
  * @brief Change the address of eeprom target at runtime

--- a/include/zephyr/drivers/i2c/target/eeprom.h
+++ b/include/zephyr/drivers/i2c/target/eeprom.h
@@ -82,6 +82,8 @@ int eeprom_target_write_data(const struct device *dev, off_t offset,
 /**
  * @brief Program memory of the virtual EEPROM
  *
+ * @deprecated Use @ref eeprom_target_write_data instead.
+ *
  * @param dev Pointer to the device structure for the driver instance.
  * @param eeprom_data Pointer of data to program into the virtual eeprom memory
  * @param length Length of data to program into the virtual eeprom memory
@@ -89,8 +91,8 @@ int eeprom_target_write_data(const struct device *dev, off_t offset,
  * @retval 0 If successful.
  * @retval -EINVAL Invalid data size
  */
-int eeprom_target_program(const struct device *dev, const uint8_t *eeprom_data,
-			 unsigned int length);
+__deprecated int eeprom_target_program(const struct device *dev, const uint8_t *eeprom_data,
+				       unsigned int length);
 
 /**
  * @brief Read single byte of virtual EEPROM memory

--- a/include/zephyr/drivers/i2c/target/eeprom.h
+++ b/include/zephyr/drivers/i2c/target/eeprom.h
@@ -22,6 +22,26 @@
  */
 
 /**
+ * @typedef eeprom_target_changed_handler_t
+ * @brief Define the application callback handler function signature
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param user_data Optional user data provided when callback is set.
+ */
+typedef void (*eeprom_target_changed_handler_t)(const struct device *dev, void *user_data);
+
+/**
+ * @brief Set the EEPROM changed callback handler
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param handler Handler to call on EEPROM changes
+ * @param user_data Optional user data passed to callback
+ */
+void eeprom_target_set_changed_callback(const struct device *dev,
+					eeprom_target_changed_handler_t handler,
+					void *user_data);
+
+/**
  * @brief Program memory of the virtual EEPROM
  *
  * @param dev Pointer to the device structure for the driver instance.

--- a/include/zephyr/drivers/i2c/target/eeprom.h
+++ b/include/zephyr/drivers/i2c/target/eeprom.h
@@ -13,6 +13,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_I2C_TARGET_EEPROM_H_
 
 #include <stddef.h>
+#include <sys/types.h>
 
 /**
  * @brief Interfaces for I2C EEPROM target devices.
@@ -51,6 +52,32 @@ void eeprom_target_set_changed_callback(const struct device *dev,
  * @return Size of EEPROM in bytes
  */
 size_t eeprom_target_get_size(const struct device *dev);
+
+/**
+ * @brief Read data from the virtual EEPROM
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param offset Address offset to read from.
+ * @param data Buffer to store read data.
+ * @param len Number of bytes to read.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int eeprom_target_read_data(const struct device *dev, off_t offset,
+			    void *data, size_t len);
+
+/**
+ * @brief Write data to the virtual EEPROM
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param offset Address offset to write data to.
+ * @param data Buffer with data to write.
+ * @param len Number of bytes to write.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int eeprom_target_write_data(const struct device *dev, off_t offset,
+			     const void *data, size_t len);
 
 /**
  * @brief Program memory of the virtual EEPROM

--- a/samples/drivers/i2c/target_eeprom/src/main.c
+++ b/samples/drivers/i2c/target_eeprom/src/main.c
@@ -27,14 +27,5 @@ int main(void)
 
 	printk("i2c target driver registered\n");
 
-	k_msleep(1000);
-
-	if (i2c_target_driver_unregister(eeprom) < 0) {
-		printk("Failed to unregister i2c target driver\n");
-		return 0;
-	}
-
-	printk("i2c target driver unregistered\n");
-
 	return 0;
 }

--- a/samples/drivers/i2c/target_eeprom/src/main.c
+++ b/samples/drivers/i2c/target_eeprom/src/main.c
@@ -11,6 +11,24 @@
 
 static const struct device *eeprom = DEVICE_DT_GET(DT_NODELABEL(eeprom0));
 
+static void on_changed(const struct device *dev, void *user_data)
+{
+	unsigned int size;
+
+	size = eeprom_target_get_size(dev);
+
+	printk("Eeprom changed, now contains:\n");
+	for (unsigned int i = 0; i < size; i++) {
+		uint8_t data;
+		char sep = i % 16 == 15 ? '\n' : ' ';
+
+		eeprom_target_read_data(dev, i, &data, sizeof(data));
+
+		printk("%02x%c", data, sep);
+	}
+	printk("\n");
+}
+
 int main(void)
 {
 	printk("i2c target sample\n");
@@ -19,6 +37,8 @@ int main(void)
 		printk("eeprom device not ready\n");
 		return 0;
 	}
+
+	eeprom_target_set_changed_callback(eeprom, on_changed, NULL);
 
 	if (i2c_target_driver_register(eeprom) < 0) {
 		printk("Failed to register i2c target driver\n");

--- a/tests/drivers/i2c/i2c_target_api/src/main.c
+++ b/tests/drivers/i2c/i2c_target_api/src/main.c
@@ -273,11 +273,11 @@ ZTEST(i2c_eeprom_target, test_eeprom_target)
 	/* Program differentiable data into the two devices through a back door
 	 * that doesn't use I2C.
 	 */
-	ret = eeprom_target_program(eeprom_0, eeprom_0_data, TEST_DATA_SIZE);
+	ret = eeprom_target_write_data(eeprom_0, 0, eeprom_0_data, TEST_DATA_SIZE);
 	zassert_equal(ret, 0, "Failed to program EEPROM 0");
 	if (IS_ENABLED(CONFIG_APP_DUAL_ROLE_I2C)) {
-		ret = eeprom_target_program(eeprom_1, eeprom_1_data,
-					   TEST_DATA_SIZE);
+		ret = eeprom_target_write_data(eeprom_1, 0, eeprom_1_data,
+					       TEST_DATA_SIZE);
 		zassert_equal(ret, 0, "Failed to program EEPROM 1");
 	}
 


### PR DESCRIPTION
For some use cases it can be interesting to know when the eeprom has been written to by the I2C host (E.G.  once a stop has been received after a write transaction), so add a "changed" callback.

The existing API for accessing the EEPROM data is not ideal, so add getters for the size and data instead and update the sample the use the new APIs