### PR TITLE
soc: silabs: s2: Move RAIL interrupts installer

### DIFF
--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -11,6 +11,7 @@
 #include <sl_hci_common_transport.h>
 #include <pa_conversions_efr32.h>
 #include <rail.h>
+#include <soc_radio.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -54,36 +55,6 @@ void BTLE_LL_EventRaise(uint32_t events);
 void BTLE_LL_Process(uint32_t events);
 int16_t BTLE_LL_SetMaxPower(int16_t power);
 bool sli_pending_btctrl_events(void);
-
-#define RADIO_IRQN(name)     DT_IRQ_BY_NAME(DT_NODELABEL(radio), name, irq)
-#define RADIO_IRQ_PRIO(name) DT_IRQ_BY_NAME(DT_NODELABEL(radio), name, priority)
-
-void rail_isr_installer(void)
-{
-	IRQ_CONNECT(RADIO_IRQN(agc), RADIO_IRQ_PRIO(agc), AGC_IRQHandler, NULL, 0);
-	IRQ_CONNECT(RADIO_IRQN(bufc), RADIO_IRQ_PRIO(bufc), BUFC_IRQHandler, NULL, 0);
-	IRQ_CONNECT(RADIO_IRQN(frc_pri), RADIO_IRQ_PRIO(frc_pri), FRC_PRI_IRQHandler, NULL, 0);
-	IRQ_CONNECT(RADIO_IRQN(frc), RADIO_IRQ_PRIO(frc), FRC_IRQHandler, NULL, 0);
-	IRQ_CONNECT(RADIO_IRQN(modem), RADIO_IRQ_PRIO(modem), MODEM_IRQHandler, NULL, 0);
-	IRQ_CONNECT(RADIO_IRQN(protimer), RADIO_IRQ_PRIO(protimer), PROTIMER_IRQHandler, NULL, 0);
-	IRQ_CONNECT(RADIO_IRQN(rac_rsm), RADIO_IRQ_PRIO(rac_rsm), RAC_RSM_IRQHandler, NULL, 0);
-	IRQ_CONNECT(RADIO_IRQN(rac_seq), RADIO_IRQ_PRIO(rac_seq), RAC_SEQ_IRQHandler, NULL, 0);
-	IRQ_CONNECT(RADIO_IRQN(synth), RADIO_IRQ_PRIO(synth), SYNTH_IRQHandler, NULL, 0);
-
-	/* Depending on the chip family, either HOSTMAILBOX, RDMAILBOX or neither is present */
-	IF_ENABLED(DT_IRQ_HAS_NAME(DT_NODELABEL(radio), hostmailbox), ({
-		IRQ_CONNECT(RADIO_IRQN(hostmailbox),
-			    RADIO_IRQ_PRIO(hostmailbox),
-			    HOSTMAILBOX_IRQHandler,
-			    NULL, 0);
-	}));
-	IF_ENABLED(DT_IRQ_HAS_NAME(DT_NODELABEL(radio), rdmailbox), ({
-		IRQ_CONNECT(RADIO_IRQN(rdmailbox),
-			    RADIO_IRQ_PRIO(rdmailbox),
-			    RDMAILBOX_IRQHandler,
-			    NULL, 0);
-	}));
-}
 
 static bool slz_is_evt_discardable(const struct bt_hci_evt_hdr *hdr, const uint8_t *params,
 				   int16_t params_len)

--- a/soc/silabs/silabs_s2/CMakeLists.txt
+++ b/soc/silabs/silabs_s2/CMakeLists.txt
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources(soc.c)
+zephyr_sources_ifdef(CONFIG_SOC_GECKO_USE_RAIL soc_radio.c)
 zephyr_sources_ifdef(CONFIG_SOC_SILABS_IMAGE_PROPERTIES soc_image_properties.c)
 zephyr_linker_sources_ifdef(CONFIG_SOC_SILABS_IMAGE_PROPERTIES RODATA soc_image_properties.ld)

--- a/soc/silabs/silabs_s2/soc.c
+++ b/soc/silabs/silabs_s2/soc.c
@@ -18,6 +18,8 @@
 #include <sl_hfxo_manager.h>
 #include <sl_power_manager.h>
 
+#include <soc_radio.h>
+
 #if defined(CONFIG_PRINTK) || defined(CONFIG_LOG)
 #define PR_EXC(...) LOG_ERR(__VA_ARGS__)
 #else
@@ -107,5 +109,9 @@ void soc_prep_hook(void)
 
 	IRQ_DIRECT_CONNECT(SMU_SECURE_IRQn, 0, smu_fault, 0);
 	irq_enable(SMU_SECURE_IRQn);
+
+	if (IS_ENABLED(CONFIG_SOC_GECKO_USE_RAIL)) {
+		rail_isr_installer();
+	}
 #endif
 }

--- a/soc/silabs/silabs_s2/soc_radio.c
+++ b/soc/silabs/silabs_s2/soc_radio.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Radio initialization for Silicon Labs Series 2 products
+ */
+
+#include <zephyr/kernel.h>
+#include <rail.h>
+
+#include <soc_radio.h>
+
+#define RADIO_IRQN(name)     DT_IRQ_BY_NAME(DT_NODELABEL(radio), name, irq)
+#define RADIO_IRQ_PRIO(name) DT_IRQ_BY_NAME(DT_NODELABEL(radio), name, priority)
+
+void rail_isr_installer(void)
+{
+	IRQ_CONNECT(RADIO_IRQN(agc), RADIO_IRQ_PRIO(agc), AGC_IRQHandler, NULL, 0);
+	IRQ_CONNECT(RADIO_IRQN(bufc), RADIO_IRQ_PRIO(bufc), BUFC_IRQHandler, NULL, 0);
+	IRQ_CONNECT(RADIO_IRQN(frc_pri), RADIO_IRQ_PRIO(frc_pri), FRC_PRI_IRQHandler, NULL, 0);
+	IRQ_CONNECT(RADIO_IRQN(frc), RADIO_IRQ_PRIO(frc), FRC_IRQHandler, NULL, 0);
+	IRQ_CONNECT(RADIO_IRQN(modem), RADIO_IRQ_PRIO(modem), MODEM_IRQHandler, NULL, 0);
+	IRQ_CONNECT(RADIO_IRQN(protimer), RADIO_IRQ_PRIO(protimer), PROTIMER_IRQHandler, NULL, 0);
+	IRQ_CONNECT(RADIO_IRQN(rac_rsm), RADIO_IRQ_PRIO(rac_rsm), RAC_RSM_IRQHandler, NULL, 0);
+	IRQ_CONNECT(RADIO_IRQN(rac_seq), RADIO_IRQ_PRIO(rac_seq), RAC_SEQ_IRQHandler, NULL, 0);
+	IRQ_CONNECT(RADIO_IRQN(synth), RADIO_IRQ_PRIO(synth), SYNTH_IRQHandler, NULL, 0);
+
+	/* Depending on the chip family, either HOSTMAILBOX, RDMAILBOX or neither is present */
+	IF_ENABLED(DT_IRQ_HAS_NAME(DT_NODELABEL(radio), hostmailbox), ({
+		IRQ_CONNECT(RADIO_IRQN(hostmailbox),
+			    RADIO_IRQ_PRIO(hostmailbox),
+			    HOSTMAILBOX_IRQHandler,
+			    NULL, 0);
+	}));
+	IF_ENABLED(DT_IRQ_HAS_NAME(DT_NODELABEL(radio), rdmailbox), ({
+		IRQ_CONNECT(RADIO_IRQN(rdmailbox),
+			    RADIO_IRQ_PRIO(rdmailbox),
+			    RDMAILBOX_IRQHandler,
+			    NULL, 0);
+	}));
+}

--- a/soc/silabs/silabs_s2/soc_radio.h
+++ b/soc/silabs/silabs_s2/soc_radio.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Declare radio functions for Silicon Labs Series 2 products
+ *
+ */
+
+void rail_isr_installer(void);


### PR DESCRIPTION
Move the RAIL interrupts installer from the Bluetooth HCI driver to the SoC layer so that it can be used by other subsystems as well.