### PR TITLE
tests: boot: Fix bootloader.mcuboot boot loop for nrf platforms

### DIFF
--- a/tests/boot/test_mcuboot/sysbuild.cmake
+++ b/tests/boot/test_mcuboot/sysbuild.cmake
@@ -14,6 +14,12 @@ ExternalZephyrProject_Add(
   SOURCE_DIR ${APP_DIR}/swapped_app
 )
 
+# This section ensures that sysbuild-related configurations, such as the MCUBOOT swap type,
+# are passed down to the swapped_app image.
+set_target_properties(swapped_app PROPERTIES
+  IMAGE_CONF_SCRIPT ${ZEPHYR_BASE}/share/sysbuild/image_configurations/MAIN_image_default.cmake
+)
+
 # Add the swapped app to the list of images to flash
 # Ensure the flashing order of images is as follows:
 # - mcuboot


### PR DESCRIPTION
The swapped_app image, added via ExternalZephyrProject_Add, wasn't receiving the swap method configuration from sysbuild. If trying to build the test with a different configuration that SWAP_USING_OFFSET (for example SWAP_USING_MOVE) this resulted in a boot loop due to configuration mismatch between swapped_image and mcuboot.

This fix ensures proper configuration propagation and prevents similar mismatches in future scenarios.
