### PR TITLE
heap_listener: only use designated initializer

### DIFF
--- a/include/zephyr/sys/heap_listener.h
+++ b/include/zephyr/sys/heap_listener.h
@@ -105,10 +105,10 @@ struct heap_listener {
 	enum heap_event_types event;
 
 	union {
-		heap_listener_alloc_cb_t alloc_cb;
-		heap_listener_free_cb_t free_cb;
-		heap_listener_resize_cb_t resize_cb;
-	};
+		heap_listener_alloc_cb_t alloc;
+		heap_listener_free_cb_t free;
+		heap_listener_resize_cb_t resize;
+	} cb;
 };
 
 /**
@@ -206,7 +206,7 @@ void heap_listener_notify_resize(uintptr_t heap_id, void *old_heap_end, void *ne
 	struct heap_listener name = {                                                              \
 		.heap_id = _heap_id,                                                               \
 		.event = HEAP_ALLOC,                                                               \
-		{.alloc_cb = _alloc_cb},                                                           \
+		.cb = {.alloc = _alloc_cb},                                                        \
 	}
 
 /**
@@ -230,7 +230,7 @@ void heap_listener_notify_resize(uintptr_t heap_id, void *old_heap_end, void *ne
 	struct heap_listener name = {                                                              \
 		.heap_id = _heap_id,                                                               \
 		.event = HEAP_FREE,                                                                \
-		{.free_cb = _free_cb},                                                             \
+		.cb = {.free = _free_cb},                                                          \
 	}
 
 /**
@@ -254,7 +254,7 @@ void heap_listener_notify_resize(uintptr_t heap_id, void *old_heap_end, void *ne
 	struct heap_listener name = {                                                              \
 		.heap_id = _heap_id,                                                               \
 		.event = HEAP_RESIZE,                                                              \
-		{.resize_cb = _resize_cb},                                                         \
+		.cb = {.resize = _resize_cb},                                                      \
 	}
 
 /** @} */

--- a/include/zephyr/sys/heap_listener.h
+++ b/include/zephyr/sys/heap_listener.h
@@ -48,8 +48,7 @@ enum heap_event_types {
  * @param old_heap_end Pointer to end of heap before resize
  * @param new_heap_end Pointer to end of heap after resize
  */
-typedef void (*heap_listener_resize_cb_t)(uintptr_t heap_id,
-					  void *old_heap_end,
+typedef void (*heap_listener_resize_cb_t)(uintptr_t heap_id, void *old_heap_end,
 					  void *new_heap_end);
 
 /**
@@ -68,8 +67,7 @@ typedef void (*heap_listener_resize_cb_t)(uintptr_t heap_id,
  * @param mem Pointer to the allocated memory
  * @param bytes Size of allocated memory
  */
-typedef void (*heap_listener_alloc_cb_t)(uintptr_t heap_id,
-					 void *mem, size_t bytes);
+typedef void (*heap_listener_alloc_cb_t)(uintptr_t heap_id, void *mem, size_t bytes);
 
 /**
  * @typedef heap_listener_free_cb_t
@@ -87,8 +85,7 @@ typedef void (*heap_listener_alloc_cb_t)(uintptr_t heap_id,
  * @param mem Pointer to the freed memory
  * @param bytes Size of freed memory
  */
-typedef void (*heap_listener_free_cb_t)(uintptr_t heap_id,
-					void *mem, size_t bytes);
+typedef void (*heap_listener_free_cb_t)(uintptr_t heap_id, void *mem, size_t bytes);
 
 struct heap_listener {
 	/** Singly linked list node */
@@ -205,13 +202,11 @@ void heap_listener_notify_resize(uintptr_t heap_id, void *old_heap_end, void *ne
  * @param _heap_id	Identifier of the heap to be listened
  * @param _alloc_cb	Function to be called for allocation event
  */
-#define HEAP_LISTENER_ALLOC_DEFINE(name, _heap_id, _alloc_cb) \
-	struct heap_listener name = { \
-		.heap_id = _heap_id, \
-		.event = HEAP_ALLOC, \
-		{ \
-			.alloc_cb = _alloc_cb \
-		}, \
+#define HEAP_LISTENER_ALLOC_DEFINE(name, _heap_id, _alloc_cb)                                      \
+	struct heap_listener name = {                                                              \
+		.heap_id = _heap_id,                                                               \
+		.event = HEAP_ALLOC,                                                               \
+		{.alloc_cb = _alloc_cb},                                                           \
 	}
 
 /**
@@ -231,13 +226,11 @@ void heap_listener_notify_resize(uintptr_t heap_id, void *old_heap_end, void *ne
  * @param _heap_id	Identifier of the heap to be listened
  * @param _free_cb	Function to be called for free event
  */
-#define HEAP_LISTENER_FREE_DEFINE(name, _heap_id, _free_cb) \
-	struct heap_listener name = { \
-		.heap_id = _heap_id, \
-		.event = HEAP_FREE, \
-		{ \
-			.free_cb = _free_cb \
-		}, \
+#define HEAP_LISTENER_FREE_DEFINE(name, _heap_id, _free_cb)                                        \
+	struct heap_listener name = {                                                              \
+		.heap_id = _heap_id,                                                               \
+		.event = HEAP_FREE,                                                                \
+		{.free_cb = _free_cb},                                                             \
 	}
 
 /**
@@ -257,13 +250,11 @@ void heap_listener_notify_resize(uintptr_t heap_id, void *old_heap_end, void *ne
  * @param _heap_id	Identifier of the heap to be listened
  * @param _resize_cb	Function to be called when the listened heap is resized
  */
-#define HEAP_LISTENER_RESIZE_DEFINE(name, _heap_id, _resize_cb) \
-	struct heap_listener name = { \
-		.heap_id = _heap_id, \
-		.event = HEAP_RESIZE, \
-		{ \
-			.resize_cb = _resize_cb \
-		}, \
+#define HEAP_LISTENER_RESIZE_DEFINE(name, _heap_id, _resize_cb)                                    \
+	struct heap_listener name = {                                                              \
+		.heap_id = _heap_id,                                                               \
+		.event = HEAP_RESIZE,                                                              \
+		{.resize_cb = _resize_cb},                                                         \
 	}
 
 /** @} */

--- a/lib/heap/heap_listener.c
+++ b/lib/heap/heap_listener.c
@@ -34,9 +34,9 @@ void heap_listener_notify_alloc(uintptr_t heap_id, void *mem, size_t bytes)
 	k_spinlock_key_t key = k_spin_lock(&heap_listener_lock);
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&heap_listener_list, listener, node) {
-		if (listener->heap_id == heap_id && listener->alloc_cb != NULL &&
+		if (listener->heap_id == heap_id && listener->cb.alloc != NULL &&
 		    listener->event == HEAP_ALLOC) {
-			listener->alloc_cb(heap_id, mem, bytes);
+			listener->cb.alloc(heap_id, mem, bytes);
 		}
 	}
 
@@ -49,9 +49,9 @@ void heap_listener_notify_free(uintptr_t heap_id, void *mem, size_t bytes)
 	k_spinlock_key_t key = k_spin_lock(&heap_listener_lock);
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&heap_listener_list, listener, node) {
-		if (listener->heap_id == heap_id && listener->free_cb != NULL &&
+		if (listener->heap_id == heap_id && listener->cb.free != NULL &&
 		    listener->event == HEAP_FREE) {
-			listener->free_cb(heap_id, mem, bytes);
+			listener->cb.free(heap_id, mem, bytes);
 		}
 	}
 
@@ -64,9 +64,9 @@ void heap_listener_notify_resize(uintptr_t heap_id, void *old_heap_end, void *ne
 	k_spinlock_key_t key = k_spin_lock(&heap_listener_lock);
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&heap_listener_list, listener, node) {
-		if (listener->heap_id == heap_id && listener->resize_cb != NULL &&
+		if (listener->heap_id == heap_id && listener->cb.resize != NULL &&
 		    listener->event == HEAP_RESIZE) {
-			listener->resize_cb(heap_id, old_heap_end, new_heap_end);
+			listener->cb.resize(heap_id, old_heap_end, new_heap_end);
 		}
 	}
 

--- a/lib/heap/heap_listener.c
+++ b/lib/heap/heap_listener.c
@@ -34,9 +34,8 @@ void heap_listener_notify_alloc(uintptr_t heap_id, void *mem, size_t bytes)
 	k_spinlock_key_t key = k_spin_lock(&heap_listener_lock);
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&heap_listener_list, listener, node) {
-		if (listener->heap_id == heap_id
-		    && listener->alloc_cb != NULL
-		    && listener->event == HEAP_ALLOC) {
+		if (listener->heap_id == heap_id && listener->alloc_cb != NULL &&
+		    listener->event == HEAP_ALLOC) {
 			listener->alloc_cb(heap_id, mem, bytes);
 		}
 	}
@@ -50,9 +49,8 @@ void heap_listener_notify_free(uintptr_t heap_id, void *mem, size_t bytes)
 	k_spinlock_key_t key = k_spin_lock(&heap_listener_lock);
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&heap_listener_list, listener, node) {
-		if (listener->heap_id == heap_id
-		    && listener->free_cb != NULL
-		    && listener->event == HEAP_FREE) {
+		if (listener->heap_id == heap_id && listener->free_cb != NULL &&
+		    listener->event == HEAP_FREE) {
 			listener->free_cb(heap_id, mem, bytes);
 		}
 	}
@@ -66,9 +64,8 @@ void heap_listener_notify_resize(uintptr_t heap_id, void *old_heap_end, void *ne
 	k_spinlock_key_t key = k_spin_lock(&heap_listener_lock);
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&heap_listener_list, listener, node) {
-		if (listener->heap_id == heap_id
-		    && listener->resize_cb != NULL
-		    && listener->event == HEAP_RESIZE) {
+		if (listener->heap_id == heap_id && listener->resize_cb != NULL &&
+		    listener->event == HEAP_RESIZE) {
 			listener->resize_cb(heap_id, old_heap_end, new_heap_end);
 		}
 	}


### PR DESCRIPTION
C++20 require that either all initializer clauses should be designated or
none of them should be.

