### PR TITLE
drivers: usb: udc: stm32: driver cleanup and EP MPS fixes

### DIFF
--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -36,6 +36,26 @@ config UDC_STM32_MAX_QMESSAGES
 	help
 	  Maximum number of messages for handling of STM32 USBD ISR events.
 
+config UDC_STM32_OTG_RXFIFO_BASELINE_SIZE
+	int "Baseline RxFIFO size (in bytes)"
+	default 600
+	depends on DT_HAS_ST_STM32_OTGFS_ENABLED \
+		|| DT_HAS_ST_STM32_OTGHS_ENABLED
+	help
+	  Baseline value for RXFIFO size computation
+
+	  The OTG_FS and OTG_HS USB controllers use a single "RxFIFO" to hold
+	  data received by all OUT endpoints. The RxFIFO's size is influenced
+	  by various parameters: the optimal value depends on the exact USB
+	  configuration that will be used, which the driver does not know by
+	  the time it has to configure the RxFIFO size.
+
+	  The total RxFIFO size will be equal to the value of this option
+	  plus a fixed overhead that the driver can derive from the hardware
+	  configuration (e.g., number of endpoints implemented).
+
+	  Refer to STM32 Reference Manuals for more details about the RxFIFO.
+
 config UDC_STM32_CLOCK_CHECK
 	bool "Runtime USB 48MHz clock check"
 	default y if !(SOC_SERIES_STM32F1X || SOC_SERIES_STM32F3X || SOC_SERIES_STM32U5X)

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -121,6 +121,16 @@ LOG_MODULE_REGISTER(udc_stm32, CONFIG_UDC_DRIVER_LOG_LEVEL);
 		(PCD_SPEED_HIGH_IN_FULL),				\
 		(PCD_SPEED_HIGH))))
 
+/*
+ * Returns max packet size allowed for endpoints of 'usb_node'
+ *
+ * Hardware always supports the maximal value allowed
+ * by the USB Specification at a given operating speed:
+ * 1024 bytes in High-Speed, 1023 bytes in Full-Speed
+ */
+#define UDC_STM32_NODE_EP_MPS(node_id)					\
+	((UDC_STM32_NODE_SPEED(node_id) == PCD_SPEED_HIGH) ? 1024U : 1023U)
+
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_otghs)
 #define USB_USBPHYC_CR_FSEL_24MHZ        USB_USBPHYC_CR_FSEL_1
 #endif
@@ -158,11 +168,12 @@ struct udc_stm32_data  {
 struct udc_stm32_config {
 	uint32_t num_endpoints;
 	uint32_t dram_size;
-	uint16_t ep_mps;
 	/* PHY selected for use by instance */
 	uint32_t selected_phy;
 	/* Speed selected for use by instance */
 	uint32_t selected_speed;
+	/* Maximal packet size allowed for endpoints */
+	uint16_t ep_mps;
 };
 
 enum udc_stm32_msg_type {
@@ -1070,18 +1081,7 @@ static const struct udc_api udc_stm32_api = {
  * Kconfig system.
  */
 #define USB_NUM_BIDIR_ENDPOINTS	DT_INST_PROP(0, num_bidir_endpoints)
-
-#if defined(USB) || defined(USB_DRD_FS)
-#define EP_MPS 64U
-#define USB_RAM_SIZE	DT_INST_PROP(0, ram_size)
-#else /* USB_OTG_FS */
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)
-#define EP_MPS USB_OTG_HS_MAX_PACKET_SIZE
-#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otgfs) || DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb)
-#define EP_MPS USB_OTG_FS_MAX_PACKET_SIZE
-#endif
-#define USB_RAM_SIZE	DT_INST_PROP(0, ram_size)
-#endif /* USB */
+#define USB_RAM_SIZE		DT_INST_PROP(0, ram_size)
 
 static struct udc_stm32_data udc0_priv;
 
@@ -1093,7 +1093,7 @@ static struct udc_data udc0_data = {
 static const struct udc_stm32_config udc0_cfg  = {
 	.num_endpoints = USB_NUM_BIDIR_ENDPOINTS,
 	.dram_size = USB_RAM_SIZE,
-	.ep_mps = EP_MPS,
+	.ep_mps = UDC_STM32_NODE_EP_MPS(DT_DRV_INST(0)),
 	.selected_phy = UDC_STM32_NODE_PHY_ITFACE(DT_DRV_INST(0)),
 	.selected_speed = UDC_STM32_NODE_SPEED(DT_DRV_INST(0)),
 };

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -157,7 +157,6 @@ struct udc_stm32_data  {
 
 struct udc_stm32_config {
 	uint32_t num_endpoints;
-	uint32_t pma_offset;
 	uint32_t dram_size;
 	uint16_t ep_mps;
 	/* PHY selected for use by instance */
@@ -608,7 +607,12 @@ static inline void udc_stm32_mem_init(const struct device *dev)
 	struct udc_stm32_data *priv = udc_get_private(dev);
 	const struct udc_stm32_config *cfg = dev->config;
 
-	priv->occupied_mem = cfg->pma_offset;
+	/**
+	 * Endpoint configuration table is placed at the
+	 * beginning of Private Memory Area and consumes
+	 * 8 bytes for each endpoint.
+	 */
+	priv->occupied_mem = 8 * cfg->num_endpoints;
 }
 
 static int udc_stm32_ep_mem_config(const struct device *dev,
@@ -1074,7 +1078,6 @@ static const struct udc_api udc_stm32_api = {
 
 #if defined(USB) || defined(USB_DRD_FS)
 #define EP_MPS 64U
-#define USB_BTABLE_SIZE  (8 * USB_NUM_BIDIR_ENDPOINTS)
 #define USB_RAM_SIZE	DT_INST_PROP(0, ram_size)
 #else /* USB_OTG_FS */
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)
@@ -1083,7 +1086,6 @@ static const struct udc_api udc_stm32_api = {
 #define EP_MPS USB_OTG_FS_MAX_PACKET_SIZE
 #endif
 #define USB_RAM_SIZE	DT_INST_PROP(0, ram_size)
-#define USB_BTABLE_SIZE 0
 #endif /* USB */
 
 static struct udc_stm32_data udc0_priv;
@@ -1096,7 +1098,6 @@ static struct udc_data udc0_data = {
 static const struct udc_stm32_config udc0_cfg  = {
 	.num_endpoints = USB_NUM_BIDIR_ENDPOINTS,
 	.dram_size = USB_RAM_SIZE,
-	.pma_offset = USB_BTABLE_SIZE,
 	.ep_mps = EP_MPS,
 	.selected_phy = UDC_STM32_NODE_PHY_ITFACE(DT_DRV_INST(0)),
 	.selected_speed = UDC_STM32_NODE_SPEED(DT_DRV_INST(0)),


### PR DESCRIPTION
Cleans up various parts of the STM32 UDC shim driver while also fixing issues related to endpoint sizes.
