### PR TITLE
scripts: west_commands: patch: Fix modules patching mechanism

### DIFF
--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -331,7 +331,7 @@ Additional tips:
 Working with patches: ``west patch``
 ************************************
 
-The ``patch`` command allows users to apply patches to Zephyr or Zephyr modules
+The ``patch`` command allows users to apply patches to Zephyr and other west projects
 in a controlled manner that makes automation and tracking easier for external applications that
 use the :ref:`T2 star topology <west-t2>`. The :ref:`patches.yml <patches-yml>` file stores
 metadata about patch files and fills-in the gaps between official Zephyr releases, so that users
@@ -364,8 +364,8 @@ workspace:
 
 In this example, the :ref:`west manifest <west-manifests>` file, ``west.yml``, would pin to a
 specific Zephyr revision (e.g. ``v4.1.0``) and apply patches against that revision of Zephyr and
-the specific revisions of other modules used in the application. However, this application needs
-two changes in order to meet requirements; one for Zephyr and another for MCUBoot.
+the specific revisions of other west projects used in the application. However, this application
+needs two changes in order to meet requirements; one for Zephyr and another for MCUBoot.
 
 .. _patches-yml:
 


### PR DESCRIPTION
The script has been using the `zephyr_module.parse_modules` method that is returning only these west project (repositories listed in west manifest) that have module YML/YAML files. Other west project were dropped from the list wast was resulting in patches being skipped for Zephyr and west projects the don't have module file.

This patch changes the used method to the one that list all west projects that are specified in the west manifest. Variables and arguments have been changed from `modules` to `projects` to be aligned with West's difinitions.

Fixes: #96927