### PR TITLE
tests: Update smp test to support 12 CPUs

### DIFF
--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -14,12 +14,22 @@
 #error SMP test requires at least two CPUs!
 #endif
 
+/*
+ * The test is designed to work with no more than 12 CPUs.
+ * If attempting to run on a platform with more than that,
+ * create a custom board overlay file to reduce the number
+ * of CPUs to 12.
+ */
+#if CONFIG_MP_MAX_NUM_CPUS > 12
+#error "Test only supports up to 12 CPUs\nReduce CONFIG_MP_MAX_NUM_CPUS\n"
+#endif
+
 #define RUN_FACTOR (CONFIG_SMP_TEST_RUN_FACTOR / 100.0)
 
 #define T2_STACK_SIZE (2048 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #define STACK_SIZE (384 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #define DELAY_US 50000
-#define TIMEOUT 1000
+#define TIMEOUT 5000
 #define EQUAL_PRIORITY 1
 #define TIME_SLICE_MS 500
 #define THREAD_DELAY 1
@@ -372,11 +382,11 @@ ZTEST(smp, test_coop_resched_threads)
 	 * since we don't give up current CPU, last thread
 	 * will not get scheduled
 	 */
-	spawn_threads(K_PRIO_COOP(10), num_threads, !EQUAL_PRIORITY,
+	spawn_threads(K_PRIO_COOP(12), num_threads, !EQUAL_PRIORITY,
 		      &thread_entry_fn, THREAD_DELAY);
 
 	/* Wait for some time to let other core's thread run */
-	k_busy_wait(DELAY_US);
+	k_busy_wait(DELAY_US * 5);
 
 
 	/* Reassure that cooperative thread's are not preempted
@@ -413,7 +423,7 @@ ZTEST(smp, test_preempt_resched_threads)
 	 * lower priority thread should
 	 * be preempted by higher ones
 	 */
-	spawn_threads(K_PRIO_PREEMPT(10), num_threads, !EQUAL_PRIORITY,
+	spawn_threads(K_PRIO_PREEMPT(12), num_threads, !EQUAL_PRIORITY,
 		      &thread_entry_fn, THREAD_DELAY);
 
 	spin_for_threads_exit();
@@ -446,11 +456,11 @@ ZTEST(smp, test_yield_threads)
 	 * of cores, so the last thread would be
 	 * pending.
 	 */
-	spawn_threads(K_PRIO_COOP(10), num_threads, !EQUAL_PRIORITY,
+	spawn_threads(K_PRIO_COOP(12), num_threads, !EQUAL_PRIORITY,
 		      &thread_entry_fn, !THREAD_DELAY);
 
 	k_yield();
-	k_busy_wait(DELAY_US);
+	k_busy_wait(DELAY_US * 5);
 
 	for (int i = 0; i < num_threads; i++) {
 		zassert_true(tinfo[i].executed == 1,
@@ -475,7 +485,7 @@ ZTEST(smp, test_sleep_threads)
 {
 	unsigned int num_threads = arch_num_cpus();
 
-	spawn_threads(K_PRIO_COOP(10), num_threads, !EQUAL_PRIORITY,
+	spawn_threads(K_PRIO_COOP(12), num_threads, !EQUAL_PRIORITY,
 		      &thread_entry_fn, !THREAD_DELAY);
 
 	k_msleep(TIMEOUT);
@@ -533,7 +543,7 @@ static void check_wokeup_threads(int tnum)
 	/* k_wakeup() isn't synchronous, give the other CPU time to
 	 * schedule them
 	 */
-	k_busy_wait(200000);
+	k_busy_wait(300000);
 
 	for (i = 0; i < tnum; i++) {
 		if (tinfo[i].executed == 1 && threads_woke_up <= tnum) {
@@ -558,7 +568,7 @@ ZTEST(smp, test_wakeup_threads)
 	unsigned int num_threads = arch_num_cpus();
 
 	/* Spawn threads to run on all remaining cores */
-	spawn_threads(K_PRIO_COOP(10), num_threads - 1, !EQUAL_PRIORITY,
+	spawn_threads(K_PRIO_COOP(12), num_threads - 1, !EQUAL_PRIORITY,
 		      &thread_wakeup_entry, !THREAD_DELAY);
 
 	/* Check if all the threads have started, then call wakeup */


### PR DESCRIPTION
Updates the smp test to support nsim/nsim_hs5x/smp/12cores. Furthermore, if someone attempts to build the smp test for more than 12 CPUs, report an error message informing the user to reduce the number of CPUs. This reduction can be in the form of a custom overlay for the board in question.

Fixes #96339