### PR TITLE
boards: shields: add apollo4p_evb_disp_shield_rev2

### DIFF
--- a/boards/shields/apollo4p_evb_disp_shield_rev2/Kconfig.shield
+++ b/boards/shields/apollo4p_evb_disp_shield_rev2/Kconfig.shield
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2025, Ambiq Micro
+
+config SHIELD_AMBIQ_APOLLO4P_EVB_DISP_SHIELD_REV2
+	def_bool $(shields_list_contains,apollo4p_evb_disp_shield_rev2)

--- a/boards/shields/apollo4p_evb_disp_shield_rev2/apollo4p_evb_disp_shield_rev2.overlay
+++ b/boards/shields/apollo4p_evb_disp_shield_rev2/apollo4p_evb_disp_shield_rev2.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, Ambiq Micro Inc. <www.ambiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		accel0 = &adxl362_test;
+	};
+};
+
+&spi1 {
+	status = "okay";
+
+	adxl362_test: adxl362@0 {
+		compatible = "adi,adxl362";
+		reg = <0>;
+		spi-max-frequency = <8000000>;
+		int1-gpios = <&gpio0_31 31 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		status = "okay";
+	};
+};
+
+&gpio0_31 {
+	status = "okay";
+};

--- a/boards/shields/apollo4p_evb_disp_shield_rev2/doc/index.rst
+++ b/boards/shields/apollo4p_evb_disp_shield_rev2/doc/index.rst
@@ -1,0 +1,41 @@
+.. _apollo4p_evb_disp_shield_rev2:
+
+Apollo4 Plus EVB Display Shield Rev2
+####################################
+
+Overview
+********
+
+Support for the Apollo4 Plus EVB display shield.
+
+Apollo4 Plus EVB Display Shield
+********************************
+
+Pin Assignments of the Shield Connector
+=======================================
+
++-----------------------+--------------------+------------------+
+| Shield Connector Pin  | Function           | Apollo4 Plus Pin |
++=======================+====================+==================+
++-----------------------+--------------------+------------------+
+| J1-29                 | IOM0_SCK           | 5                |
++-----------------------+--------------------+------------------+
+| J1-31                 | IOM0_MOSI          | 6                |
++-----------------------+--------------------+------------------+
+| J1-33                 | IOM0_MISO          | 7                |
++-----------------------+--------------------+------------------+
+| J1-34                 | IOM0_CS            | 50               |
++-----------------------+--------------------+------------------+
+
+Programming
+***********
+
+Set ``--shield apollo4p_evb_disp_shield_rev2`` when you
+invoke ``west build`` or ``cmake`` in your Zephyr application.
+For example when running the :zephyr:code-sample:`accel_polling` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/accel_polling
+   :board: apollo4p_evb
+   :shield: apollo4p_evb_disp_shield_rev2
+   :goals: build

--- a/boards/shields/apollo4p_evb_disp_shield_rev2/shield.yml
+++ b/boards/shields/apollo4p_evb_disp_shield_rev2/shield.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2025, Ambiq Micro
+
+shield:
+  name: apollo4p_evb_disp_shield_rev2
+  full_name: Apollo 4P EVB Display Shield Rev 2
+  vendor: ambiq
+  supported_features:
+    - accel_polling
+    - spi


### PR DESCRIPTION
Adds a new Zephyr shield for the Apollo4P EVB Display Shield Rev 2 with device tree, Kconfig, and documentation, plus an overlay to enable the accel_polling sample via an ADXL362 sensor on SPI1.

Introduces shield metadata (YAML), Kconfig symbol, and documentation.
Provides a device tree overlay to enable ADXL362 on SPI1 and alias it as accel0 for the accel_polling sample.