### PR TITLE
build: Track all syscall deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -805,6 +805,33 @@ if(NOT (${CMAKE_HOST_SYSTEM_NAME} STREQUAL Windows))
 endif()
 
 # When running CMake it must be ensured that all dependencies are correctly acquired.
+# Gather syscall dependencies
+list(APPEND SYSCALL_SCAN_DIRS ${ZEPHYR_BASE}/include ${ZEPHYR_BASE}/drivers ${ZEPHYR_BASE}/subsys/net)
+
+if(CONFIG_APPLICATION_DEFINED_SYSCALL)
+  list(APPEND SYSCALL_INCLUDE_DIRS ${APPLICATION_SOURCE_DIR})
+endif()
+
+if(CONFIG_ZTEST)
+  list(APPEND SYSCALL_INCLUDE_DIRS ${ZEPHYR_BASE}/subsys/testsuite/ztest/include)
+
+  if(CONFIG_NO_OPTIMIZATIONS AND CONFIG_ZTEST_WARN_NO_OPTIMIZATIONS)
+    message(WARNING "Running tests with CONFIG_NO_OPTIMIZATIONS is generally "
+    "not supported and known to break in many cases due to stack overflow or "
+    "other problems. Please do not file issues about it unless the test is "
+    "specifically tuned to run in this configuration. To disable this warning "
+    "set CONFIG_ZTEST_WARN_NO_OPTIMIZATIONS=n.")
+  endif()
+endif()
+
+get_property(
+  syscalls_include_list
+  TARGET syscalls_interface
+  PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+)
+list(APPEND SYSCALL_INCLUDE_DIRS ${syscalls_include_list})
+
+# Walk dependencies to find all subfolders
 execute_process(
   COMMAND
   ${PYTHON_EXECUTABLE}
@@ -817,7 +844,12 @@ execute_process(
 file(STRINGS ${syscalls_subdirs_txt} PARSE_SYSCALLS_PATHS_DEPENDS ENCODING UTF-8)
 
 # Each header file must be monitored as file modifications are not reflected on directory level.
-file(GLOB_RECURSE PARSE_SYSCALLS_HEADER_DEPENDS ${ZEPHYR_BASE}/include/*.h)
+foreach(d IN LISTS SYSCALL_SCAN_DIRS SYSCALL_INCLUDE_DIRS)
+  list(APPEND glob_syscalls_headers
+    ${d}/*.h
+    )
+endforeach()
+file(GLOB_RECURSE PARSE_SYSCALLS_HEADER_DEPENDS ${glob_syscalls_headers})
 
 if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Windows)
   # On windows only adding/removing files or folders will be reflected in depends.
@@ -860,30 +892,12 @@ else()
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${syscalls_subdirs_txt})
 endif()
 
-# syscall declarations are searched for in the SYSCALL_INCLUDE_DIRS
-if(CONFIG_APPLICATION_DEFINED_SYSCALL)
-  list(APPEND SYSCALL_INCLUDE_DIRS ${APPLICATION_SOURCE_DIR})
-endif()
-
-if(CONFIG_ZTEST)
-  list(APPEND SYSCALL_INCLUDE_DIRS ${ZEPHYR_BASE}/subsys/testsuite/ztest/include)
-
-  if(CONFIG_NO_OPTIMIZATIONS AND CONFIG_ZTEST_WARN_NO_OPTIMIZATIONS)
-    message(WARNING "Running tests with CONFIG_NO_OPTIMIZATIONS is generally "
-    "not supported and known to break in many cases due to stack overflow or "
-    "other problems. Please do not file issues about it unless the test is "
-    "specifically tuned to run in this configuration. To disable this warning "
-    "set CONFIG_ZTEST_WARN_NO_OPTIMIZATIONS=n.")
-  endif()
-
-endif()
-
-get_property(
-  syscalls_include_list
-  TARGET syscalls_interface
-  PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-)
-list(APPEND SYSCALL_INCLUDE_DIRS ${syscalls_include_list})
+# syscall declarations are searched for in the SYSCALL_SCAN_DIRS and SYSCALL_INCLUDE_DIRS
+foreach(d ${SYSCALL_SCAN_DIRS})
+  list(APPEND parse_syscalls_scan_args
+    --scan ${d}
+    )
+endforeach()
 
 foreach(d ${SYSCALL_INCLUDE_DIRS})
   list(APPEND parse_syscalls_include_args
@@ -898,9 +912,7 @@ add_custom_command(
   COMMAND
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/scripts/build/parse_syscalls.py
-  --scan             ${ZEPHYR_BASE}/include         # Read files from this dir
-  --scan             ${ZEPHYR_BASE}/drivers         # For net sockets
-  --scan             ${ZEPHYR_BASE}/subsys/net      # More net sockets
+  ${parse_syscalls_scan_args}                       # Search for syscall declarations in these dirs
   ${parse_syscalls_include_args}                    # Read files from these dirs also
   --json-file        ${syscalls_json}               # Write this file
   --tag-struct-file  ${struct_tags_json}            # Write subsystem list to this file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -832,11 +832,17 @@ get_property(
 list(APPEND SYSCALL_INCLUDE_DIRS ${syscalls_include_list})
 
 # Walk dependencies to find all subfolders
+foreach(d IN LISTS SYSCALL_SCAN_DIRS SYSCALL_INCLUDE_DIRS)
+  list(APPEND syscalls_subfolders
+    --directory ${d}
+    )
+endforeach()
+
 execute_process(
   COMMAND
   ${PYTHON_EXECUTABLE}
   ${ZEPHYR_BASE}/scripts/build/subfolder_list.py
-  --directory        ${ZEPHYR_BASE}/include      # Walk this directory
+  ${syscalls_subfolders}                         # Walk these directories
   --out-file         ${syscalls_subdirs_txt}     # Write file with discovered folder
   --trigger-file     ${syscalls_subdirs_trigger} # Trigger file that is used for json generation
   ${syscalls_links}                              # If defined, create symlinks for dependencies
@@ -873,7 +879,7 @@ else()
     COMMAND
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/build/subfolder_list.py
-    --directory        ${ZEPHYR_BASE}/include      # Walk this directory
+    ${syscalls_subfolders}                         # Walk these directories
     --out-file         ${syscalls_subdirs_txt}     # Write file with discovered folder
     --trigger-file     ${syscalls_subdirs_trigger} # Trigger file that is used for json generation
     ${syscalls_links}                              # If defined, create symlinks for dependencies

--- a/scripts/build/subfolder_list.py
+++ b/scripts/build/subfolder_list.py
@@ -26,7 +26,11 @@ def parse_args():
     )
 
     parser.add_argument(
-        '-d', '--directory', required=True, help='Directory to walk for sub-directory discovery'
+        '-d',
+        '--directory',
+        required=True,
+        action='append',
+        help='Directory to walk for sub-directory discovery (can be specified multiple times)',
     )
     parser.add_argument(
         '-c',
@@ -49,34 +53,54 @@ def parse_args():
     return args
 
 
-def get_subfolder_list(directory, create_links=None):
-    """Return subfolder list of a directory"""
+def get_subfolder_list(directories, create_links=None):
+    """Return subfolder list of directories"""
     dirlist = []
+    used_link_names = set()
 
-    if create_links is not None:
-        if not os.path.exists(create_links):
-            os.makedirs(create_links)
-        symbase = os.path.basename(directory)
-        symlink = create_links + os.path.sep + symbase
-        if not os.path.exists(symlink):
-            os.symlink(directory, symlink)
-        dirlist.append(symlink)
-    else:
-        dirlist.append(directory)
+    for directory in directories:
+        if create_links is not None:
+            if not os.path.exists(create_links):
+                os.makedirs(create_links)
+            symbase = os.path.basename(directory)
 
-    for root, dirs, _ in os.walk(directory, topdown=True):
-        dirs.sort()
-        for subdir in dirs:
-            if create_links is not None:
-                targetdirectory = os.path.join(root, subdir)
-                reldir = os.path.relpath(targetdirectory, directory)
-                linkname = symbase + '_' + reldir.replace(os.path.sep, '_')
-                symlink = create_links + os.path.sep + linkname
-                if not os.path.exists(symlink):
-                    os.symlink(targetdirectory, symlink)
-                dirlist.append(symlink)
-            else:
-                dirlist.append(os.path.join(root, subdir))
+            # Ensure unique link name for the base directory
+            linkname = symbase
+            counter = 1
+            while linkname in used_link_names:
+                linkname = f'{symbase}_{counter}'
+                counter += 1
+            used_link_names.add(linkname)
+
+            symlink = create_links + os.path.sep + linkname
+            if not os.path.exists(symlink):
+                os.symlink(directory, symlink)
+            dirlist.append(symlink)
+        else:
+            dirlist.append(directory)
+
+        for root, dirs, _ in os.walk(directory, topdown=True):
+            dirs.sort()
+            for subdir in dirs:
+                if create_links is not None:
+                    targetdirectory = os.path.join(root, subdir)
+                    reldir = os.path.relpath(targetdirectory, directory)
+                    base_linkname = symbase + '_' + reldir.replace(os.path.sep, '_')
+
+                    # Ensure unique link name for subdirectories
+                    linkname = base_linkname
+                    counter = 1
+                    while linkname in used_link_names:
+                        linkname = f'{base_linkname}_{counter}'
+                        counter += 1
+                    used_link_names.add(linkname)
+
+                    symlink = create_links + os.path.sep + linkname
+                    if not os.path.exists(symlink):
+                        os.symlink(targetdirectory, symlink)
+                    dirlist.append(symlink)
+                else:
+                    dirlist.append(os.path.join(root, subdir))
 
     return dirlist
 
@@ -120,7 +144,8 @@ def main():
     """Parse command line arguments and take respective actions"""
     args = parse_args()
 
-    dirs = get_subfolder_list(args.directory, args.create_links)
+    directories = sorted(set(args.directory))
+    dirs = get_subfolder_list(directories, args.create_links)
     gen_out_file(args.out_file, dirs)
 
     # Always touch trigger file to ensure json files are updated


### PR DESCRIPTION
When working on https://github.com/zephyrproject-rtos/zephyr/pull/96892 I noticed that in some places cmake is only tracking syscall deps for those under ${ZEPHYR_BASE}/include when in reality syscalls can come from a number of places including those defined by users.

This PR updates cmake dependencies to track all inputs used in syscall generation.

I was able to verify the issue by creating an external zephyr module driver. Repo steps are somewhat complicated, as mentioned in https://github.com/zephyrproject-rtos/zephyr/pull/96892 and https://github.com/zephyrproject-rtos/zephyr/issues/96881, git is funny and will do full file delete/adds when modifying a few lines.
# Repo
## Part A: Setup external module
1. `git clone https://github.com/mark-inderhees/zephyr-module`
2. Stage changes to the driver syscall, save this patch as module.patch
```
diff --git a/include/hello_driver.h b/include/hello_driver.h
index 781b033..d3836b0 100644
--- a/include/hello_driver.h
+++ b/include/hello_driver.h
@@ -29,7 +29,7 @@ extern "C" {
  * @retval 0 On success
  * @retval -ENODEV Device not found or not ready
  */
-typedef int (*hello_driver_print_message_t)(const struct device *dev);
+typedef int (*hello_driver_print_message_t)(const struct device *dev, uint32_t foo);
 
 /**
  * @brief Hello driver API structure
@@ -47,9 +47,9 @@ struct hello_driver_api {
  * @retval -ENODEV Device not found or not ready
  * @retval -ENOSYS API not implemented
  */
-__syscall int hello_driver_print_message(const struct device *dev);
+__syscall int hello_driver_print_message(const struct device *dev, uint32_t foo);
 
-static inline int z_impl_hello_driver_print_message(const struct device *dev)
+static inline int z_impl_hello_driver_print_message(const struct device *dev, uint32_t foo)
 {
     const struct hello_driver_api *api = 
         (const struct hello_driver_api *)dev->api;
@@ -58,7 +58,7 @@ static inline int z_impl_hello_driver_print_message(const struct device *dev)
         return -ENOSYS;
     }
 
-    return api->print_message(dev);
+    return api->print_message(dev, foo);
 }
 
 /**
diff --git a/src/hello_driver.c b/src/hello_driver.c
index 2ae1dfe..d65a95e 100644
--- a/src/hello_driver.c
+++ b/src/hello_driver.c
@@ -16,8 +16,9 @@ struct hello_driver_config {
 };
 
 // Driver API implementation: print message
-static int hello_driver_api_print_message(const struct device *dev)
+static int hello_driver_api_print_message(const struct device *dev, uint32_t foo)
 {
+    (void)foo;
     if (!device_is_ready(dev)) {
         return -ENODEV;
     }
```
3. Apply patch with `git apply module.patch`
4. Cache those changes
```
cp include/hello_driver.h /tmp/hello_driver.h
cp src/hello_driver.c /tmp/hello_driver.c
```
5. Revert state with
```
git restore include/hello_driver.h
git restore src/hello_driver.c
```

## Part B: Setup repo
1. Clone my fork of blinky to use my test module, based of zephyr main
```
git clone https://github.com/mark-inderhees/zephyr
git checkout test-module-broke
```
2. Stage patch to use the updated syscall, save this patch as zephyr.patch
```
diff --git a/samples/basic/blinky/src/main.c b/samples/basic/blinky/src/main.c
index 263592497ef..870ff487026 100644
--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -41,7 +41,7 @@ int main(void)
 
 	LOG_INF("Hello from the app, retrieved from device: %p", hello_driver_dev);
 
-	ret = hello_driver_print_message(hello_driver_dev);
+	ret = hello_driver_print_message(hello_driver_dev, 1);
 	if (ret != 0) {
 		LOG_ERR("Failed to print message from hello driver: %d", ret);
 	}
```
3. Apply patch with `git apply zephyr.patch`
4. Cache the patch with `cp samples/basic/blinky/src/main.c /tmp/main.c`
5. Restore the repo with `git restore samples/basic/blinky/src/main.c`
6. Export the external module from Part A with `export ZEPHYR_EXTRA_MODULES=<your_path>/zephyr-module`
7. Do a pristine build with `west build -b nrf5340dk/nrf5340/cpuapp samples/basic/blinky -p always`
8. Apply the zephyr change to blinky with `cp /tmp/main.c samples/basic/blinky/src/main.c`
9. In the external module repository, apply the staged syscall changes
```
cp /tmp/hello_driver.h include/hello_driver.h
cp /tmp/hello_driver.c src/hello_driver.c
```
10. Back in the zephyr repository, do an incremental build and see the build failure `west build -b nrf5340dk/nrf5340/cpuapp samples/basic/blinky`

I verified the fix by replacing Part B step 1, checking out my branch `git checkout test-module`. This cherry-picks the blinky external driver integration on top of this PR's fix.