### PR TITLE
ci: Switch to CI image v0.28.5

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.4.20250818
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.5.20250930
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.4.20250818
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.5.20250930
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.4.20250818
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.5.20250930
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -14,7 +14,7 @@ jobs:
   check-errno:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.28.4
+      image: ghcr.io/zephyrproject-rtos/ci:v0.28.5
 
     steps:
       - name: Apply container owner mismatch workaround

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -28,7 +28,7 @@ jobs:
       group: zephyr-runner-v2-linux-x64-4xlarge
     if: github.repository_owner == 'zephyrproject-rtos'
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.4.20250818
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.5.20250930
       options: '--entrypoint /bin/bash'
     defaults:
       run:

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -128,7 +128,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.4.20250818
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.5.20250930
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false


### PR DESCRIPTION
This commit updates the CI workflows to use the CI image v0.28.5, which adds Node.js runtime and the TF-M Python dependencies.