### PR TITLE
tests: lib: cpp: cxx: Add test to verify C++ compilation

### DIFF
--- a/tests/lib/cpp/cxx/testcase.yaml
+++ b/tests/lib/cpp/cxx/testcase.yaml
@@ -78,3 +78,14 @@ tests:
     build_only: true
     extra_configs:
       - CONFIG_STD_CPP23=y
+  # Verify struct _cpu_arch struct _thread_arch are compatible with C++ when
+  # specific configs are enabled.
+  cpp.main.empty_struct_size:
+    build_only: true
+    integration_platforms:
+      - qemu_riscv32
+      - qemu_riscv64
+    extra_configs:
+      - CONFIG_USERSPACE=n
+      - CONFIG_SMP=n
+      - CONFIG_FPU_SHARING=n


### PR DESCRIPTION
When using clang to build for RISC-V with these configs:

```
CONFIG_CPP=y
CONFIG_USERSPACE=n
CONFIG_SMP=n
CONFIG_FPU_SHARING=n
```

we get the following warnings:

```
include/zephyr/arch/riscv/structs.h:11:1: error: empty struct has size 0
in C, size 1 in C++ [-Werror,-Wextern-c-compat]
11 | struct _cpu_arch {
| ^

include/zephyr/arch/riscv/thread.h:68:1: error: empty struct has size 0
in C, size 1 in C++ [-Werror,-Wextern-c-compat]
68 | struct _thread_arch {
| ^
```

This commit adds a test with those configs to verify compilation
succeeds. Although gcc doesn't emit these warnings, we can test with gcc
as well with a `BUILD_ASSERT` in `include/zephyr/arch/riscv/thread.h` and
`include/zephyr/arch/riscv/structs.h` that was added in https://github.com/zephyrproject-rtos/zephyr/pull/96943.