### PR TITLE
Ckhardin/fix inet ntop buffer size

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -286,7 +286,7 @@ struct xmodem_packet {
 #define MAX_PROFILE_LINE_LENGTH                                                \
 	MAX(sizeof(PROFILE_LINE_1), sizeof(PROFILE_LINE_2))
 
-#define IPV6_ADDR_FORMAT "####:####:####:####:####:####:####:####"
+#define IPV6_ADDR_FORMAT "####:####:####:####:####:####:xxx.xxx.xxx.xxx"
 #define HL7800_IPV6_ADDR_LEN                                                                       \
 	sizeof("a01.a02.a03.a04.a05.a06.a07.a08.a09.a10.a11.a12.a13.a14.a15.a16")
 

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -692,7 +692,7 @@ static int offload_connect(void *obj, const struct sockaddr *addr,
 	char		    *protocol = "TCP";
 	struct modem_cmd    cmd[]     = { MODEM_CMD("+QIOPEN: ", on_cmd_atcmdinfo_sockopen, 2U, ",") };
 	char		    buf[sizeof("AT+QIOPEN=#,#,'###','###',"
-				       "####.####.####.####.####.####.####.####,######,"
+				       "####:####:####:####:####:####:xxx.xxx.xxx.xxx,######,"
 				       "0,0")] = {0};
 	int		    ret;
 	char		    ip_str[NET_IPV6_ADDR_LEN];

--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -135,7 +135,8 @@ static int offload_connect(void *obj, const struct sockaddr *addr, socklen_t add
 	uint16_t dst_port = 0;
 	char *protocol;
 	struct modem_cmd cmd[] = { MODEM_CMD("+CAOPEN: ", on_cmd_caopen, 2U, ",") };
-	char buf[sizeof("AT+CAOPEN: #,#,#####,#xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx#,####")];
+	char buf[sizeof("AT+CAOPEN: #,#,#####,"
+			"#xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxx.xxx.xxx.xxx#,####")];
 	char ip_str[NET_IPV6_ADDR_LEN];
 	int ret;
 

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -292,7 +292,7 @@ static ssize_t send_socket_data(void *obj,
 {
 	int ret;
 	char send_buf[sizeof("AT+USO**=###,"
-			     "!####.####.####.####.####.####.####.####!,"
+			     "!####:####:####:####:####:####:xxx.xxx.xxx.xxx!,"
 			     "#####,#########\r\n")];
 	uint16_t dst_port = 0U;
 	struct modem_socket *sock = (struct modem_socket *)obj;
@@ -1530,7 +1530,8 @@ static int offload_connect(void *obj, const struct sockaddr *addr,
 {
 	struct modem_socket *sock = (struct modem_socket *)obj;
 	int ret;
-	char buf[sizeof("AT+USOCO=###,!####.####.####.####.####.####.####.####!,#####,#\r")];
+	char buf[sizeof("AT+USOCO=###,"
+			"!####:####:####:####:####:####:xxx.xxx.xxx.xxx!,#####,#\r")];
 	uint16_t dst_port = 0U;
 	char ip_str[NET_IPV6_ADDR_LEN];
 

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -479,7 +479,7 @@ extern const struct in6_addr in6addr_loopback;
 /** @cond INTERNAL_HIDDEN */
 
 /* These are for internal usage of the stack */
-#define NET_IPV6_ADDR_LEN sizeof("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx")
+#define NET_IPV6_ADDR_LEN sizeof("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxx.xxx.xxx.xxx")
 #define NET_IPV4_ADDR_LEN sizeof("xxx.xxx.xxx.xxx")
 
 /** @endcond */

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -174,7 +174,13 @@ char *z_impl_net_addr_ntop(sa_family_t family, const void *src,
 	bool needcolon = false;
 	bool mapped = false;
 
-	if (family == AF_INET6) {
+	switch (family) {
+	case AF_INET6:
+		if (size < INET6_ADDRSTRLEN) {
+			/* POSIX definition is the size - includes nil */
+			return NULL;
+		}
+
 		net_ipv6_addr_copy_raw(addr6.s6_addr, src);
 		w = (uint16_t *)addr6.s6_addr16;
 		len = 8;
@@ -203,12 +209,20 @@ char *z_impl_net_addr_ntop(sa_family_t family, const void *src,
 		if (longest == 1U) {
 			pos = -1;
 		}
+		break;
 
-	} else if (family == AF_INET) {
+	case AF_INET:
+		if (size < INET_ADDRSTRLEN) {
+			/* POSIX definition is the size - includes nil */
+			return NULL;
+		}
+
 		net_ipv4_addr_copy_raw(addr.s4_addr, src);
 		len = 4;
 		delim = '.';
-	} else {
+		break;
+
+	default:
 		return NULL;
 	}
 
@@ -279,10 +293,6 @@ print_mapped:
 		}
 
 		needcolon = true;
-	}
-
-	if (!(ptr - dst)) {
-		return NULL;
 	}
 
 	if (family == AF_INET) {

--- a/subsys/net/lib/shell/dns.c
+++ b/subsys/net/lib/shell/dns.c
@@ -38,13 +38,13 @@ static void dns_result_cb(enum dns_resolve_status status,
 		case AF_INET:
 			net_addr_ntop(AF_INET,
 				      &net_sin(&info->ai_addr)->sin_addr,
-				      str, NET_IPV4_ADDR_LEN);
+				      str, sizeof(str));
 			break;
 
 		case AF_INET6:
 			net_addr_ntop(AF_INET6,
 				      &net_sin6(&info->ai_addr)->sin6_addr,
-				      str, NET_IPV6_ADDR_LEN);
+				      str, sizeof(str));
 			break;
 
 		case AF_LOCAL:


### PR DESCRIPTION
Deal with some issues found during a misconfiguration of the DNS resolver that ended up leading into a problem in the base inet_ntop implementation not checking the bounds of the passed in buffer and overwriting the passed in dst.