### PR TITLE
soc: nordic: common: `CONFIG_SOC_NRF_FORCE_CONSTLAT`

### DIFF
--- a/samples/boards/nordic/nrf_sys_event/sample.yaml
+++ b/samples/boards/nordic/nrf_sys_event/sample.yaml
@@ -1,30 +1,34 @@
 sample:
   name: nRF System events
+common:
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "constant latency mode disabled"
+  platform_allow:
+    - nrf52dk/nrf52810
+    - nrf52dk/nrf52832
+    - nrf52833dk/nrf52820
+    - nrf52833dk/nrf52833
+    - nrf52840dk/nrf52811
+    - nrf52840dk/nrf52840
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf5340dk/nrf5340/cpunet
+    - nrf54h20dk/nrf54h20/cpuapp
+    - nrf54h20dk/nrf54h20/cpurad
+    - nrf54l15dk/nrf54l15/cpuapp
+    - ophelia4ev/nrf54l15/cpuapp
+  integration_platforms:
+    - nrf52840dk/nrf52840
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf5340dk/nrf5340/cpunet
+    - nrf54h20dk/nrf54h20/cpuapp
+    - nrf54h20dk/nrf54h20/cpurad
+    - nrf54l15dk/nrf54l15/cpuapp
+    - ophelia4ev/nrf54l15/cpuapp
 tests:
-  sample.boards.nordic.nrf_sys_event:
-    harness: console
-    harness_config:
-      type: one_line
-      regex:
-        - "constant latency mode disabled"
-    platform_allow:
-      - nrf52dk/nrf52810
-      - nrf52dk/nrf52832
-      - nrf52833dk/nrf52820
-      - nrf52833dk/nrf52833
-      - nrf52840dk/nrf52811
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf5340dk/nrf5340/cpunet
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54h20dk/nrf54h20/cpurad
-      - nrf54l15dk/nrf54l15/cpuapp
-      - ophelia4ev/nrf54l15/cpuapp
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf5340dk/nrf5340/cpunet
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54h20dk/nrf54h20/cpurad
-      - nrf54l15dk/nrf54l15/cpuapp
-      - ophelia4ev/nrf54l15/cpuapp
+  sample.boards.nordic.nrf_sys_event: {}
+  sample.boards.nordic.nrf_sys_event.force_constlat:
+    extra_configs:
+      - CONFIG_SOC_NRF_FORCE_CONSTLAT=y

--- a/soc/nordic/common/CMakeLists.txt
+++ b/soc/nordic/common/CMakeLists.txt
@@ -39,4 +39,5 @@ if(CONFIG_TFM_PARTITION_PLATFORM)
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_NRF_SYS_EVENT nrf_sys_event.c)
+zephyr_library_sources_ifdef(CONFIG_SOC_NRF_FORCE_CONSTLAT nrf_constlat.c)
 zephyr_library_sources_ifdef(CONFIG_MRAM_LATENCY mram_latency.c)

--- a/soc/nordic/common/Kconfig
+++ b/soc/nordic/common/Kconfig
@@ -21,6 +21,15 @@ config NRF_SYS_EVENT
 	bool "nRF system event support"
 	select NRFX_POWER if !NRF_PLATFORM_HALTIUM
 
+config SOC_NRF_FORCE_CONSTLAT
+	bool "Force constant latency mode in system ON"
+	depends on NRF_SYS_EVENT && !RISCV
+	help
+	  In constant latency mode the CPU wakeup latency and the PPI task response
+	  will be constant and kept at a minimum. This is secured by forcing a set
+	  of base resources on while in sleep. The advantage of having a constant
+	  and predictable latency will be at the cost of having increased power consumption.
+
 config MRAM_LATENCY
 	bool "MRAM latency manager"
 	depends on NRFS_HAS_MRAM_SERVICE

--- a/soc/nordic/common/nrf_constlat.c
+++ b/soc/nordic/common/nrf_constlat.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Embeint Pty Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+
+#include <nrf_sys_event.h>
+
+static int nrf_const_lat(void)
+{
+	return nrf_sys_event_request_global_constlat();
+}
+
+/* Immediately after the SoC init functions */
+SYS_INIT(nrf_const_lat, PRE_KERNEL_1, 1);

--- a/soc/nordic/nrf54l/Kconfig
+++ b/soc/nordic/nrf54l/Kconfig
@@ -76,14 +76,6 @@ config SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE
 	  With this option, the glitch detector is not disabled during system initialization.
 	  The CPU runs with the default state of glitch detector.
 
-config SOC_NRF_FORCE_CONSTLAT
-	bool "Force constant-latency mode"
-	help
-	  In constant latency mode the CPU wakeup latency and the PPI task response
-	  will be constant and kept at a minimum. This is secured by forcing a set
-	  of base resources on while in sleep. The advantage of having a constant
-	  and predictable latency will be at the cost of having increased power consumption.
-
 config SOC_NRF54L_ANOMALY_56_WORKAROUND
 	bool "Apply workaround 56 for nRF54L SoCs"
 	default y

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -138,10 +138,6 @@ static inline void power_and_clock_configuration(void)
 	nrf_oscillators_hfxo_cap_set(NRF_OSCILLATORS, false, 0);
 #endif
 
-	if (IS_ENABLED(CONFIG_SOC_NRF_FORCE_CONSTLAT)) {
-		nrf_power_task_trigger(NRF_POWER, NRF_POWER_TASK_CONSTLAT);
-	}
-
 #if (DT_PROP(DT_NODELABEL(vregmain), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
 #endif

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -10,6 +10,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <soc.h>
 
+#include <nrf_sys_event.h>
 #include <nrfx_gpiote.h>
 
 #include "util/mem.h"
@@ -221,7 +222,11 @@ void radio_reset(void)
 			    RADIO_TIMING_RU_Msk;
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
+#if defined(CONFIG_NRF_SYS_EVENT)
+	(void)nrf_sys_event_request_global_constlat();
+#else /* !CONFIG_NRF_SYS_EVENT */
 	NRF_POWER->TASKS_CONSTLAT = 1U;
+#endif /* !CONFIG_NRF_SYS_EVENT */
 #endif /* CONFIG_SOC_COMPATIBLE_NRF54LX */
 
 #if defined(HAL_RADIO_GPIO_HAVE_PA_PIN) || defined(HAL_RADIO_GPIO_HAVE_LNA_PIN)
@@ -1788,7 +1793,11 @@ void radio_tmr_stop(void)
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
 #if defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
+#if defined(CONFIG_NRF_SYS_EVENT)
+	(void)nrf_sys_event_release_global_constlat();
+#else /* !CONFIG_NRF_SYS_EVENT */
 	NRF_POWER->TASKS_LOWPWR = 1U;
+#endif /* !CONFIG_NRF_SYS_EVENT */
 #endif /* CONFIG_SOC_COMPATIBLE_NRF54LX */
 }
 


### PR DESCRIPTION
Move the option to force constant latency mode outside of nRF54l, since it is an option applicable to most Nordic SoCs.

This is a quality-of-life option to prevent boards/applications from needing to implement the calls themselves.