### PR TITLE
drivers: wifi: siwx91x: fix client idle timeout in AP mode

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi_ap.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_ap.c
@@ -9,6 +9,8 @@
 #include "sl_rsi_utility.h"
 #include "sl_net.h"
 
+#define SIWX91X_AP_BEACON_INTERVAL_MS 100
+
 LOG_MODULE_DECLARE(siwx91x_wifi);
 
 static int siwx91x_nwp_reboot_if_required(const struct device *dev, uint8_t oper_mode)
@@ -134,13 +136,13 @@ int siwx91x_ap_enable(const struct device *dev, struct wifi_connect_req_params *
 	sl_wifi_ap_configuration_t siwx91x_ap_cfg = {
 		.credential_id       = SL_NET_DEFAULT_WIFI_AP_CREDENTIAL_ID,
 		.keepalive_type      = SL_SI91X_AP_NULL_BASED_KEEP_ALIVE,
+		.beacon_interval     = SIWX91X_AP_BEACON_INTERVAL_MS,
 		.rate_protocol       = SL_WIFI_RATE_PROTOCOL_AUTO,
 		.encryption          = SL_WIFI_DEFAULT_ENCRYPTION,
 		.channel.bandwidth   = SL_WIFI_BANDWIDTH_20MHz,
 		.maximum_clients     = sidev->max_num_sta,
 		.tdi_flags           = SL_WIFI_TDI_NONE,
 		.client_idle_timeout = 0xFF,
-		.beacon_interval     = 100,
 		.dtim_beacon_count   = 3,
 		.beacon_stop         = 0,
 		.options             = 0,
@@ -319,6 +321,8 @@ int siwx91x_ap_config_params(const struct device *dev, struct wifi_ap_config_par
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	sl_wifi_ap_configuration_t siwx91x_ap_cfg;
+	uint32_t idle_timeout;
+	uint32_t max_sec;
 
 	__ASSERT(params, "params cannot be NULL");
 
@@ -335,7 +339,19 @@ int siwx91x_ap_config_params(const struct device *dev, struct wifi_ap_config_par
 	sli_get_saved_ap_configuration(&siwx91x_ap_cfg);
 	siwx91x_ap_cfg.channel.bandwidth = SL_WIFI_BANDWIDTH_20MHz;
 	if (params->type & WIFI_AP_CONFIG_PARAM_MAX_INACTIVITY) {
-		siwx91x_ap_cfg.client_idle_timeout = params->max_inactivity * 1000;
+		/*
+		 * Firmware requires idle timeout as a count of 32-beacon intervals
+		 * The actual timeout applied by the FW will be slightly higher than requested
+		 */
+		idle_timeout = DIV_ROUND_UP(params->max_inactivity * MSEC_PER_SEC,
+					    SIWX91X_AP_BEACON_INTERVAL_MS * 32);
+		if (idle_timeout > UINT8_MAX) {
+			max_sec = (SIWX91X_AP_BEACON_INTERVAL_MS * 32 * UINT8_MAX) / 1000;
+			LOG_WRN("requested inactivity %u exceeds FW limit %u, clamping to %u",
+				params->max_inactivity, max_sec, max_sec);
+			idle_timeout = UINT8_MAX;
+		}
+		siwx91x_ap_cfg.client_idle_timeout = idle_timeout;
 	}
 
 	if (params->type & WIFI_AP_CONFIG_PARAM_MAX_NUM_STA) {


### PR DESCRIPTION
The firmware interprets the client idle timeout in units of 32 beacon intervals, not in milliseconds. This mismatch caused the applied timeout to be higher than the configured value.

Fix the driver to use the correct unit.