### PR TITLE
drivers: i2c_dw: Avoid spamming NACK error messages

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -128,7 +128,7 @@ static int i2c_dw_error_chk(const struct device *dev)
 		/* check 7bit NACK Tx Abort */
 		if (ic_txabrt_src.bits.ADDR7BNACK) {
 			dw->state |= I2C_DW_NACK;
-			LOG_ERR("NACK on %s", dev->name);
+			LOG_ERR_RATELIMIT("NACK on %s", dev->name);
 		}
 		/* check SDA stuck low Tx abort, need to do bus recover */
 		if (ic_txabrt_src.bits.SDASTUCKLOW) {
@@ -147,7 +147,7 @@ static int i2c_dw_error_chk(const struct device *dev)
 #if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
 		dw->need_setup = true;
 #endif
-		LOG_ERR("IO Fail on %s", dev->name);
+		LOG_ERR_RATELIMIT("IO Fail on %s", dev->name);
 		return -EIO;
 	}
 	return 0;


### PR DESCRIPTION
NACK message are now logged with LOG_DBG instead of LOG_ERR to reduce log noise.

When scanning I2C device,
receiving a NACK is expected behavior and not necessarily an error. Logging it at LOG_ERR causes unnecessary clutter in the logs.

Therefore, the log level is reduced to LOG_DBG for NACK cases.