### PR TITLE
net: lib: coap: Add packet pointer to client response callback data

### DIFF
--- a/doc/connectivity/networking/api/coap_client.rst
+++ b/doc/connectivity/networking/api/coap_client.rst
@@ -66,16 +66,15 @@ The following is an example of a very simple response handling function:
 
 .. code-block:: c
 
-    void response_cb(int16_t code, size_t offset, const uint8_t *payload, size_t len,
-                     bool last_block, void *user_data)
+    void response_cb(const struct coap_client_response_data *data, void *user_data)
     {
-        if (code >= 0) {
-	        LOG_INF("CoAP response from server %d", code);
-                if (last_block) {
+        if (data->result_code >= 0) {
+	        LOG_INF("CoAP response from server %d", data->result_code);
+                if (data->last_block) {
                         LOG_INF("Last packet received");
                 }
         } else {
-                LOG_ERR("Error in sending request %d", code);
+                LOG_ERR("Error in sending request %d", data->result_code);
         }
     }
 

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -181,6 +181,9 @@ Power management
 Networking
 **********
 
+* The :c:type:`coap_client_response_cb_t` signature has changed. The list of arguments
+  is passed as a :c:struct:`coap_client_response_data` pointer instead.
+
 * The HTTP server now respects the configured ``_config`` value. Check that
   you provide applicable value to :c:macro:`HTTP_SERVICE_DEFINE_EMPTY`,
   :c:macro:`HTTPS_SERVICE_DEFINE_EMPTY`, :c:macro:`HTTP_SERVICE_DEFINE` and

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -185,6 +185,10 @@ New APIs and options
 
 * Networking
 
+  * CoAP
+
+    * :c:struct:`coap_client_response_data`
+
   * Sockets
 
     * :c:func:`zsock_listen` now implements the ``backlog`` parameter support. The TCP server

--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -41,6 +41,8 @@ struct coap_client_response_data {
 	 * @ref coap_response_code for positive.
 	 */
 	int16_t result_code;
+	/** A pointer to the response CoAP packet. NULL for error result. */
+	const struct coap_packet *packet;
 	/** Payload offset from the beginning of a blockwise transfer. */
 	size_t offset;
 	/** Buffer containing the payload from the response. NULL for empty payload. */

--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -33,6 +33,25 @@ extern "C" {
 			  CONFIG_COAP_CLIENT_MESSAGE_SIZE)
 
 /**
+ * @brief Representation for CoAP client response data.
+ */
+struct coap_client_response_data {
+	/**
+	 * Result code of the response. Negative if there was a failure in send.
+	 * @ref coap_response_code for positive.
+	 */
+	int16_t result_code;
+	/** Payload offset from the beginning of a blockwise transfer. */
+	size_t offset;
+	/** Buffer containing the payload from the response. NULL for empty payload. */
+	const uint8_t *payload;
+	/** Size of the payload. */
+	size_t payload_len;
+	/** Indicates the last block of the response. */
+	bool last_block;
+};
+
+/**
  * @typedef coap_client_response_cb_t
  * @brief Callback for CoAP request.
  *
@@ -41,17 +60,11 @@ extern "C" {
  * Blockwise transfers cause this callback to be called sequentially with increasing payload offset
  * and only partial content in buffer pointed by payload parameter.
  *
- * @param result_code Result code of the response. Negative if there was a failure in send.
- *                    @ref coap_response_code for positive.
- * @param offset Payload offset from the beginning of a blockwise transfer.
- * @param payload Buffer containing the payload from the response. NULL for empty payload.
- * @param len Size of the payload.
- * @param last_block Indicates the last block of the response.
+ * @param data The CoAP response data.
  * @param user_data User provided context.
  */
-typedef void (*coap_client_response_cb_t)(int16_t result_code,
-					  size_t offset, const uint8_t *payload, size_t len,
-					  bool last_block, void *user_data);
+typedef void (*coap_client_response_cb_t)(const struct coap_client_response_data *data,
+					  void *user_data);
 
 /**
  * @brief Representation of a CoAP client request.

--- a/samples/net/sockets/coap_download/src/main.c
+++ b/samples/net/sockets/coap_download/src/main.c
@@ -31,20 +31,20 @@ static void net_event_handler(uint64_t mgmt_event, struct net_if *iface, void *i
 
 NET_MGMT_REGISTER_EVENT_HANDLER(l4_conn_handler, NET_EVENT_L4_CONNECTED, net_event_handler, NULL);
 
-static void on_coap_response(int16_t result_code, size_t offset, const uint8_t *payload, size_t len,
-			     bool last_block, void *user_data)
+static void on_coap_response(const struct coap_client_response_data *data, void *user_data)
 {
-	LOG_INF("CoAP response, result_code=%d, offset=%u, len=%u", result_code, offset, len);
+	LOG_INF("CoAP response, result_code=%d, offset=%u, len=%u", data->result_code, data->offset,
+		data->payload_len);
 
-	if ((COAP_RESPONSE_CODE_CONTENT == result_code) && last_block) {
+	if ((COAP_RESPONSE_CODE_CONTENT == data->result_code) && data->last_block) {
 		int64_t elapsed_time = k_uptime_delta(&start_time);
-		size_t total_size = offset + len;
+		size_t total_size = data->offset + data->payload_len;
 
 		LOG_INF("CoAP download done, got %u bytes in %" PRId64 " ms", total_size,
 			elapsed_time);
 		k_sem_give(&coap_done_sem);
-	} else if (COAP_RESPONSE_CODE_CONTENT != result_code) {
-		LOG_ERR("Error during CoAP download, result_code=%d", result_code);
+	} else if (COAP_RESPONSE_CODE_CONTENT != data->result_code) {
+		LOG_ERR("Error during CoAP download, result_code=%d", data->result_code);
 		k_sem_give(&coap_done_sem);
 	}
 }

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -459,9 +459,14 @@ out:
 
 static void report_callback_error(struct coap_client_internal_request *internal_req, int error_code)
 {
-	if (internal_req->coap_request.cb) {
+	if (internal_req->coap_request.cb != NULL) {
 		if (!atomic_set(&internal_req->in_callback, 1)) {
-			internal_req->coap_request.cb(error_code, 0, NULL, 0, true,
+			const struct coap_client_response_data resp_data = {
+				.result_code = error_code,
+				.last_block = true,
+			};
+
+			internal_req->coap_request.cb(&resp_data,
 						      internal_req->coap_request.user_data);
 			atomic_clear(&internal_req->in_callback);
 		} else {
@@ -947,10 +952,17 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 	}
 
 	/* Call user callback */
-	if (internal_req->coap_request.cb) {
+	if (internal_req->coap_request.cb != NULL) {
 		if (!atomic_set(&internal_req->in_callback, 1)) {
-			internal_req->coap_request.cb(response_code, internal_req->offset, payload,
-						      payload_len, last_block,
+			const struct coap_client_response_data resp_data = {
+				.result_code = response_code,
+				.offset = internal_req->offset,
+				.payload = payload,
+				.payload_len = payload_len,
+				.last_block = last_block,
+			};
+
+			internal_req->coap_request.cb(&resp_data,
 						      internal_req->coap_request.user_data);
 			atomic_clear(&internal_req->in_callback);
 		}

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -956,6 +956,7 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 		if (!atomic_set(&internal_req->in_callback, 1)) {
 			const struct coap_client_response_data resp_data = {
 				.result_code = response_code,
+				.packet = response,
 				.offset = internal_req->offset,
 				.payload = payload,
 				.payload_len = payload_len,

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -27,8 +27,7 @@ DEFINE_FFF_GLOBALS;
 #define VALID_MESSAGE_ID BIT(31)
 #define TOKEN_OFFSET          4
 
-void coap_callback(int16_t code, size_t offset, const uint8_t *payload, size_t len, bool last_block,
-		   void *user_data);
+void coap_callback(const struct coap_client_response_data *data, void *user_data);
 
 static int16_t last_response_code;
 static const char test_path[] = "test";
@@ -451,11 +450,10 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_observe(int sock, void *buf, si
 	return ret;
 }
 
-void coap_callback(int16_t code, size_t offset, const uint8_t *payload, size_t len, bool last_block,
-		   void *user_data)
+void coap_callback(const struct coap_client_response_data *data, void *user_data)
 {
-	LOG_INF("CoAP response callback, %d", code);
-	last_response_code = code;
+	LOG_INF("CoAP response callback, %d", data->result_code);
+	last_response_code = data->result_code;
 	if (user_data) {
 		k_sem_give((struct k_sem *) user_data);
 	}


### PR DESCRIPTION
- Make it easier to modify the response callback data by passing it as a struct pointer rather than a long list of arguments.
- Pass a pointer to the CoAP packet in the response data. This allows callback function to inspect for CoAP options.

Fixes #96952