### PR TITLE
drivers: memc_mcux_flexspi: force applying OVRDVAL

### DIFF
--- a/drivers/memc/Kconfig.mcux
+++ b/drivers/memc/Kconfig.mcux
@@ -56,6 +56,29 @@ config MEMC_MCUX_FLEXSPI_INIT_XIP
 	  used for the FLEXSPI are compatible with those needed for XIP from
 	  the flash device.
 
+config FLASH_MCUX_FLEXSPI_FORCE_USING_OVRDVAL
+	bool "Force using the FLEXSPI Target Clock Delay Line Override Value"
+	help
+	  Enable this setting to force using a specific raw value for the OVRDVAL
+	  field in the DLLCR registers.
+
+	  This option gives more granularity than the 'data-valid-time' field in
+	  the dts. The unit of 'data-valid-time' is nanoseconds while the unit of
+	  OVRDVAL are raw delay cells.
+
+	  Normally the 'data-valid-time' on any 'nxp,imx-flexspi-device' device
+	  will set the OVRDVAL and OVRDEN fields in the DLLCR register
+	  but works only when the 'rx-clock-source' is configured to '#0 External
+	  input from DQS pad' and the frequency <= 100MHz.
+
+config FLASH_MCUX_FLEXSPI_OVRDVAL
+	int "FLEXSPI Target Clock Delay Line Override Value"
+	range 0 63
+	default 27
+	depends on FLASH_MCUX_FLEXSPI_FORCE_USING_OVRDVAL
+	help
+	  Raw value to be stored in the DDLCR->OVRDVAL field.
+
 config MEMC_MCUX_FLEXSPI
 	bool
 	select PINCTRL

--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -233,6 +233,12 @@ int memc_flexspi_set_device_config(const struct device *dev,
 	/* Lock IRQs before reconfiguring FlexSPI, to prevent XIP */
 	key = irq_lock();
 	FLEXSPI_SetFlashConfig(data->base, &tmp_config, port);
+
+#if (CONFIG_FLASH_MCUX_FLEXSPI_FORCE_USING_OVRDVAL == 1)
+	data->base->DLLCR[port >> 1U] = FLEXSPI_DLLCR_OVRDEN(1) |
+					FLEXSPI_DLLCR_OVRDVAL(CONFIG_FLASH_MCUX_FLEXSPI_OVRDVAL);
+#endif
+
 	FLEXSPI_UpdateLUT(data->base, data->port_luts[port].lut_offset,
 			  lut_ptr, lut_count);
 	irq_unlock(key);


### PR DESCRIPTION
Enable this kconfig setting to force using a specific raw value for the OVRDVAL field in the DLLCR registers.

This option gives more granularity than the 'data-valid-time' field in the dts. The unit of 'data-valid-time' is nanoseconds while the unit of OVRDVAL are raw delay cells.

Normally the 'data-valid-time' on any 'nxp,imx-flexspi-device' device will set the OVRDVAL and OVRDEN fields in the DLLCR register but works only when the 'rx-clock-source' is configured to '# 3 External input from DQS pad' and the frequency <= 100MHz.

This option allows this OVRDVAL value being set under all circumstances.