### PR TITLE
boards: renesas: Add support USB on Renesas ek_ra8p1 and mck_ra8t2

### DIFF
--- a/boards/renesas/ek_ra8p1/ek_ra8p1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1-pinctrl.dtsi
@@ -95,6 +95,22 @@
 		};
 	};
 
+	usbhs_default: usbhs_default {
+		group1 {
+			psels = <RA_PSEL(RA_PSEL_USBHS, 4, 8)>; /* VBUS */
+			drive-strength = "high";
+		};
+	};
+
+	usbfs_default: usbfs_default {
+		group1 {
+			psels = <RA_PSEL(RA_PSEL_USBFS, 8, 15)>, /* USB_DM */
+				<RA_PSEL(RA_PSEL_USBFS, 8, 14)>, /* USB_DP */
+				<RA_PSEL(RA_PSEL_USBFS, 4, 7)>;	 /* VBUS */
+			drive-strength = "high";
+		};
+	};
+
 	sdram_default: sdram_default {
 		group1 {
 			psels = <RA_PSEL(RA_PSEL_BUS, 10, 3)>, /* SDRAM_A2 */

--- a/boards/renesas/ek_ra8p1/ek_ra8p1.dtsi
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1.dtsi
@@ -177,6 +177,22 @@
 	status = "okay";
 };
 
+&usbfs {
+	pinctrl-0 = <&usbfs_default>;
+	pinctrl-names = "default";
+	maximum-speed = "full-speed";
+};
+
+&usbhs {
+	pinctrl-0 = <&usbhs_default>;
+	pinctrl-names = "default";
+	maximum-speed = "high-speed";
+};
+
+&usbhs_phy {
+	phys-clock-src = "xtal";
+};
+
 &sdram {
 	pinctrl-0 = <&sdram_default>;
 	pinctrl-names = "default";

--- a/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.dts
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.dts
@@ -130,6 +130,17 @@
 	burst-transfer = <256>;
 };
 
+&usbhs {
+	pinctrl-0 = <&usbhs_default>;
+	interrupts = <23 12>;
+	interrupt-names = "usbhs-ir";
+	status = "okay";
+
+	zephyr_udc0: udc {
+		status = "okay";
+	};
+};
+
 zephyr_lcdif: &lcdif {};
 
 pmod_sd_shield: &sdhc0 {};

--- a/boards/renesas/mck_ra8t2/mck_ra8t2-pinctrl.dtsi
+++ b/boards/renesas/mck_ra8t2/mck_ra8t2-pinctrl.dtsi
@@ -40,6 +40,15 @@
 		};
 	};
 
+	usbfs_default: usbfs_default {
+		group1 {
+			psels = <RA_PSEL(RA_PSEL_USBFS, 8, 15)>, /* USB_DM */
+				<RA_PSEL(RA_PSEL_USBFS, 8, 14)>, /* USB_DP */
+				<RA_PSEL(RA_PSEL_USBFS, 4, 7)>;	 /* VBUS */
+			drive-strength = "high";
+		};
+	};
+
 	sdhc0_default: sdhc0_default {
 		group1 {
 			psels = <RA_PSEL(RA_PSEL_SDHI, 13, 7)>, /* SDCD */

--- a/boards/renesas/mck_ra8t2/mck_ra8t2.dtsi
+++ b/boards/renesas/mck_ra8t2/mck_ra8t2.dtsi
@@ -88,6 +88,10 @@
 	};
 };
 
+&uclk {
+	status = "okay";
+};
+
 &sciclk {
 	status = "okay";
 };
@@ -110,4 +114,10 @@
 
 &ioportb {
 	status = "okay";
+};
+
+&usbfs {
+	pinctrl-0 = <&usbfs_default>;
+	pinctrl-names = "default";
+	maximum-speed = "full-speed";
 };

--- a/boards/renesas/mck_ra8t2/mck_ra8t2_r7ka8t2lfecac_cm85.dts
+++ b/boards/renesas/mck_ra8t2/mck_ra8t2_r7ka8t2lfecac_cm85.dts
@@ -91,3 +91,14 @@
 		status = "okay";
 	};
 };
+
+&usbfs {
+	pinctrl-0 = <&usbfs_default>;
+	interrupts = <16 12>, <17 12>;
+	interrupt-names = "usbfs-i", "usbfs-r";
+	status = "okay";
+
+	zephyr_udc0: udc {
+		status = "okay";
+	};
+};

--- a/dts/arm/renesas/ra/ra8/r7ka8t2xf.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7ka8t2xf.dtsi
@@ -7,6 +7,9 @@
 #include <arm/renesas/ra/ra8/ra8x2.dtsi>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 
+/delete-node/ &usbhs;
+/delete-node/ &usbhs_phy;
+
 / {
 	clocks: clocks {
 		#address-cells = <1>;

--- a/dts/arm/renesas/ra/ra8/ra8x2.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x2.dtsi
@@ -766,6 +766,34 @@
 			status = "disabled";
 		};
 
+		usbfs: usbfs@40250000 {
+			compatible = "renesas,ra-usbfs";
+			reg = <0x40250000 0x2000>;
+			num-bidir-endpoints = <10>;
+			phys = <&usbfs_phy>;
+			phys-clock = <&uclk>;
+			status = "disabled";
+
+			udc {
+				compatible = "renesas,ra-udc";
+				status = "disabled";
+			};
+		};
+
+		usbhs: usbhs@40351000 {
+			compatible = "renesas,ra-usbhs";
+			reg = <0x40351000 0x2000>;
+			num-bidir-endpoints = <10>;
+			phys = <&usbhs_phy>;
+			phys-clock = <&uclk>, <&usb60clk>;
+			status = "disabled";
+
+			udc {
+				compatible = "renesas,ra-udc";
+				status = "disabled";
+			};
+		};
+
 		port_irq0: external-interrupt@40006000 {
 			compatible = "renesas,ra-external-interrupt";
 			reg = <0x40006000 0x1>;
@@ -1162,6 +1190,16 @@
 				status = "okay";
 			};
 		};
+	};
+
+	usbfs_phy: usbfs-phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+	};
+
+	usbhs_phy: usbhs-phy {
+		compatible = "renesas,ra-usbphyc";
+		#phy-cells = <0>;
 	};
 };
 


### PR DESCRIPTION
Add support USB on Renesas `ek_ra8p1` and `mck_ra8t2` boards