### PR TITLE
usb: device_next: cdc_acm: reschedule TX handler if data remain in fifo

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -669,6 +669,11 @@ static void cdc_acm_tx_fifo_handler(struct k_work *work)
 		net_buf_unref(buf);
 		atomic_clear_bit(&data->state, CDC_ACM_TX_FIFO_BUSY);
 	}
+
+	/* Reschedule if the TX fifo still contains data. */
+	if (!ring_buf_is_empty(data->tx_fifo.rb)) {
+		cdc_acm_work_schedule(&data->tx_fifo_work, K_MSEC(1));
+	}
 }
 
 /*


### PR DESCRIPTION
The TX handler is called at most once per UART API call.

As the tx_fifo can be larger than the cdc_acm_ep_pool buffer, the TX handler has to be rescheduled so the remaining data can be sent.

Otherwise, there is a risk of data being stuck in the tx_fifo until the next UART API write call.