### PR TITLE
tests: arch: arm: irq_vector_table: don't printk from ISRs

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/README.txt
+++ b/tests/arch/arm/arm_irq_vector_table/README.txt
@@ -31,10 +31,20 @@ or
 
 Sample Output:
 
-tc_start() - Test Cortex-M3 IRQ installed directly in vector table
-isr0 ran!
-isr1 ran!
-isr2 ran!
-PASS - main.
+Running TESTSUITE vector_table
+===================================================================
+START - test_arm_irq_vector_table
+Test Cortex-M IRQs installed directly in the vector table
+ PASS - test_arm_irq_vector_table in 0.007 seconds
+===================================================================
+TESTSUITE vector_table succeeded
+
+------ TESTSUITE SUMMARY START ------
+
+SUITE PASS - 100.00% [vector_table]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.007 seconds
+ - PASS - [vector_table.test_arm_irq_vector_table] duration = 0.007 seconds
+
+------ TESTSUITE SUMMARY END ------
+
 ===================================================================
 PROJECT EXECUTION SUCCESSFUL

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -46,7 +46,6 @@ struct k_sem sem[3];
 
 void isr0(void)
 {
-	printk("%s ran!\n", __func__);
 	k_sem_give(&sem[0]);
 	z_arm_int_exit();
 }
@@ -59,7 +58,6 @@ void isr0(void)
 
 void isr1(void)
 {
-	printk("%s ran!\n", __func__);
 	k_sem_give(&sem[1]);
 	z_arm_int_exit();
 }
@@ -72,7 +70,6 @@ void isr1(void)
 
 void isr2(void)
 {
-	printk("%s ran!\n", __func__);
 	k_sem_give(&sem[2]);
 	z_arm_int_exit();
 }
@@ -97,7 +94,7 @@ void isr2(void)
  */
 ZTEST(vector_table, test_arm_irq_vector_table)
 {
-	printk("Test Cortex-M IRQs installed directly in the vector table\n");
+	TC_PRINT("Test Cortex-M IRQs installed directly in the vector table\n");
 
 	for (int ii = 0; ii < 3; ii++) {
 		irq_enable(_ISR_OFFSET + ii);


### PR DESCRIPTION
This rather anchient test suite calls printk from within ISRs. printk() is not declared isr safe, and printk should be avoided from ISRs due to their stack and cpu time requirements. The test suite does not use the printk() output in any case, so the printk() output is simply removed. The `README.txt` (that's right, .txt, it mentions `make`) has been updated with the actual output produced by todays test suite, sans the printk() output.