### PR TITLE
arch/arm: introduce the pre-stack/RAM init hook

### DIFF
--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -35,6 +35,10 @@ GTEXT(z_arm_init_arch_hw_at_boot)
 #if defined(CONFIG_PM_S2RAM)
 GTEXT(arch_pm_s2ram_resume)
 #endif
+#if defined(CONFIG_SOC_EARLY_RESET_HOOK)
+GTEXT(soc_early_reset_hook)
+#endif
+
 
 /*
  * PACBTI Mask for CONTROL register:
@@ -100,6 +104,10 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 
 #endif /* CONFIG_INIT_ARCH_HW_AT_BOOT */
 
+#if defined(CONFIG_SOC_EARLY_RESET_HOOK)
+    /* Call custom code that executes before any stack is set up or RAM memory is accessed */
+    bl soc_early_reset_hook
+#endif
 #if defined(CONFIG_PM_S2RAM)
     /*
      * Temporarily set MSP to interrupt stack so that arch_pm_s2ram_resume can

--- a/include/zephyr/platform/hooks.h
+++ b/include/zephyr/platform/hooks.h
@@ -19,6 +19,19 @@
  * directly from application code but may be freely used within the OS.
  */
 
+#ifdef CONFIG_SOC_EARLY_RESET_HOOK
+/**
+ * @brief SoC hook executed before data RAM initialization, at the beginning
+ * of the reset vector.
+ *
+ * This hook is implemented by the SoC and can be used to perform any
+ * SoC-specific initialization. Refer to :kconfig:option:`SOC_EARLY_RESET_HOOK`
+ * and relevant architecture zephyr-rtos startup implementation for more details.
+ */
+void soc_early_reset_hook(void);
+#else
+#define soc_early_reset_hook() do { } while (0)
+#endif
 
 #ifdef CONFIG_SOC_RESET_HOOK
 /**

--- a/kernel/Kconfig.init
+++ b/kernel/Kconfig.init
@@ -6,6 +6,28 @@
 
 menu "SoC and Board Hooks"
 
+config SOC_EARLY_RESET_HOOK
+	bool "Run SoC-specific early reset hook"
+	help
+	  Run a SoC-specific hook early in the reset/startup code (__start).
+	  A custom hook soc_early_reset_hook() will be executed at the beginning
+	  of the architecture-specific startup code, after hardware has been
+	  configured (as required by CONFIG_INIT_ARCH_HW_AT_BOOT) but before
+	  architecture's own resume logic.
+
+	  Returning from this hook is not mandatory: it can be used to implement
+	  special logic to resume execution in some scenarios (for example, when
+	  a bootloader is used).
+
+	  The stack pointer register should be considered as not initialized upon
+	  call to this hook. In particular, this means that the hook is NOT allowed
+	  to "push" any data using this stack pointer value. However, the hook may
+	  use an implementation-specific area as stack if desired; in such case,
+	  the original value of the stack pointer needs not to be "restored" before
+	  returning control to the hook's caller.
+
+	  Additional constraints may be imposed on the hook by the architecture.
+
 config SOC_RESET_HOOK
 	bool "Run early SoC reset hook"
 	help

--- a/kernel/Kconfig.init
+++ b/kernel/Kconfig.init
@@ -29,12 +29,17 @@ config SOC_EARLY_RESET_HOOK
 	  Additional constraints may be imposed on the hook by the architecture.
 
 config SOC_RESET_HOOK
-	bool "Run early SoC reset hook"
+	bool "Run SoC-specific reset hook"
 	help
-	  Run an early SoC reset hook.
+	  Run a SoC-specific hook in the reset/startup code (__start).
 
-	  A custom hook soc_reset_hook() is executed at the beginning of the
-	  startup code (__start). soc_reset_hook() must be implemented by the SoC.
+	  A custom hook soc_reset_hook() will be executed near the beginning
+	  of the architecture-specific startup code, after hardware has been
+	  configured (as required by CONFIG_INIT_ARCH_HW_AT_BOOT), a stack
+	  pointer has been loaded and the architecture's own resume logic
+	  has executed (if CONFIG_PM_S2RAM is enabled). Because this hook
+	  runs after the resume logic, it is not called when the system
+	  resumes from a suspend-to-RAM power state.
 
 config SOC_PREP_HOOK
 	bool "Run early SoC preparation hook"


### PR DESCRIPTION
Introduce hook for customize reset.S code even before stack is initialized or RAM is accessed. Hook can be enabled using CONFIG_SOC_EARLY_RESET_HOOK=y.
Hook implementation is by soc_start_hook() function which should be provided by custom code.

For my case this hook can be use for implementing S2RAM resume operation bridge by the zephyr-rtos based bootloader: for such case the startu code is redirected to application startup code via application's reset vector call.
In the hook proram does recognition of whether this is the regular CPU boot or the S2RAM resume boot. For regular boot the hook returns to reset.S code flow. For S2RAM resume boot the hooks performs jump to well-known (for bootloader) application reset vector.

``` TXT
              resume/reboot                                               reboot==T
[S2RAM sleep]-------------->[ boot (reset.S) ]---->[soc_early_reset_hook]---------->[ continue regular boot ]
                                                          |  
                                                          |      resume==T
                                                          '----------------------> [ s2ram resume ]
```

This PR supersede #96290 as it is more generic an SoC independent.