### PR TITLE
tests: smf: replace raw smf_ctx casts with SMF_CTX() macro

### DIFF
--- a/tests/lib/smf/src/test_lib_flat_smf.c
+++ b/tests/lib/smf/src/test_lib_flat_smf.c
@@ -229,10 +229,10 @@ ZTEST(smf_tests, test_smf_flat)
 
 	test_obj.transition_bits = 0;
 	test_obj.terminate = NONE;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[STATE_A]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj)) {
+		if (smf_run_state(SMF_CTX(&test_obj))) {
 			break;
 		}
 	}
@@ -246,10 +246,10 @@ ZTEST(smf_tests, test_smf_flat)
 
 	test_obj.transition_bits = 0;
 	test_obj.terminate = ENTRY;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[STATE_A]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj)) {
+		if (smf_run_state(SMF_CTX(&test_obj))) {
 			break;
 		}
 	}
@@ -263,10 +263,10 @@ ZTEST(smf_tests, test_smf_flat)
 
 	test_obj.transition_bits = 0;
 	test_obj.terminate = RUN;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[STATE_A]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj)) {
+		if (smf_run_state(SMF_CTX(&test_obj))) {
 			break;
 		}
 	}
@@ -280,10 +280,10 @@ ZTEST(smf_tests, test_smf_flat)
 
 	test_obj.transition_bits = 0;
 	test_obj.terminate = EXIT;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[STATE_A]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj)) {
+		if (smf_run_state(SMF_CTX(&test_obj))) {
 			break;
 		}
 	}

--- a/tests/lib/smf/src/test_lib_hierarchical_5_ancestor_smf.c
+++ b/tests/lib/smf/src/test_lib_hierarchical_5_ancestor_smf.c
@@ -411,10 +411,10 @@ ZTEST(smf_tests, test_smf_hierarchical_5_ancestors)
 {
 	test_obj.tv_idx = 0;
 	test_obj.transition_bits = 0;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[A]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[A]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}

--- a/tests/lib/smf/src/test_lib_hierarchical_smf.c
+++ b/tests/lib/smf/src/test_lib_hierarchical_smf.c
@@ -344,10 +344,10 @@ ZTEST(smf_tests, test_smf_hierarchical)
 
 	test_obj.transition_bits = 0;
 	test_obj.terminate = NONE;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[STATE_A]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}
@@ -360,10 +360,10 @@ ZTEST(smf_tests, test_smf_hierarchical)
 
 	test_obj.transition_bits = 0;
 	test_obj.terminate = PARENT_ENTRY;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[STATE_A]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}
@@ -377,10 +377,10 @@ ZTEST(smf_tests, test_smf_hierarchical)
 
 	test_obj.transition_bits = 0;
 	test_obj.terminate = PARENT_RUN;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[STATE_A]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}
@@ -394,10 +394,10 @@ ZTEST(smf_tests, test_smf_hierarchical)
 
 	test_obj.transition_bits = 0;
 	test_obj.terminate = PARENT_EXIT;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[STATE_A]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}
@@ -411,10 +411,10 @@ ZTEST(smf_tests, test_smf_hierarchical)
 
 	test_obj.transition_bits = 0;
 	test_obj.terminate = ENTRY;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[STATE_A]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}
@@ -428,10 +428,10 @@ ZTEST(smf_tests, test_smf_hierarchical)
 
 	test_obj.transition_bits = 0;
 	test_obj.terminate = RUN;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[STATE_A]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}
@@ -445,10 +445,10 @@ ZTEST(smf_tests, test_smf_hierarchical)
 
 	test_obj.transition_bits = 0;
 	test_obj.terminate = EXIT;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[STATE_A]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}

--- a/tests/lib/smf/src/test_lib_self_transition_smf.c
+++ b/tests/lib/smf/src/test_lib_self_transition_smf.c
@@ -469,10 +469,10 @@ ZTEST(smf_tests, test_smf_self_transition)
 	test_obj.transition_bits = 0;
 	test_obj.first_time = FIRST_TIME_BITS;
 	test_obj.terminate = NONE;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[PARENT_AB]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}
@@ -486,10 +486,10 @@ ZTEST(smf_tests, test_smf_self_transition)
 	test_obj.transition_bits = 0;
 	test_obj.first_time = FIRST_TIME_BITS;
 	test_obj.terminate = PARENT_ENTRY;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[PARENT_AB]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}
@@ -504,10 +504,10 @@ ZTEST(smf_tests, test_smf_self_transition)
 	test_obj.transition_bits = 0;
 	test_obj.first_time = FIRST_TIME_BITS;
 	test_obj.terminate = PARENT_RUN;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[PARENT_AB]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}
@@ -522,10 +522,10 @@ ZTEST(smf_tests, test_smf_self_transition)
 	test_obj.transition_bits = 0;
 	test_obj.first_time = FIRST_TIME_BITS;
 	test_obj.terminate = PARENT_EXIT;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[PARENT_AB]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}
@@ -540,10 +540,10 @@ ZTEST(smf_tests, test_smf_self_transition)
 	test_obj.transition_bits = 0;
 	test_obj.first_time = FIRST_TIME_BITS;
 	test_obj.terminate = ENTRY;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[PARENT_AB]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}
@@ -558,10 +558,10 @@ ZTEST(smf_tests, test_smf_self_transition)
 	test_obj.transition_bits = 0;
 	test_obj.first_time = FIRST_TIME_BITS;
 	test_obj.terminate = RUN;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[PARENT_AB]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}
@@ -576,10 +576,10 @@ ZTEST(smf_tests, test_smf_self_transition)
 	test_obj.transition_bits = 0;
 	test_obj.first_time = FIRST_TIME_BITS;
 	test_obj.terminate = EXIT;
-	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[PARENT_AB]);
 
 	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+		if (smf_run_state(SMF_CTX(&test_obj)) < 0) {
 			break;
 		}
 	}


### PR DESCRIPTION
Replaces explicit "(struct smf_ctx *)" casts in SMF tests with the "SMF_CTX()"
macro for clarity and consistency.

Only test files were modified, runtime behavior is unchanged.