### PR TITLE
mgmt: mcumgr: grp: os_mgmt: Use board target for hardware platform

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -227,6 +227,15 @@ Logging
   used. The new script supports the same functionality (and more), but requires different command
   line arguments when invoked.
 
+MCUmgr
+======
+
+* The :ref:`OS mgmt<mcumgr_smp_group_0>` :ref:`mcumgr_os_application_info` command's response for
+  hardware platform has been updated to output the board target instead of the board and board
+  revision, which now includes the SoC and board variant. The old behaviour has been deprecated,
+  but can still be used by enabling
+  :kconfig:option:`CONFIG_MCUMGR_GRP_OS_INFO_HARDWARE_INFO_SHORT_HARDWARE_PLATFORM`.
+
 RTIO
 ====
 

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
@@ -183,6 +183,14 @@ config MCUMGR_GRP_OS_INFO_MAX_RESPONSE_SIZE
 	  size to store the data in. If the output response is too big then the output will not be
 	  present in the response, which will just contain the result code (rc) of memory error.
 
+config MCUMGR_GRP_OS_INFO_HARDWARE_INFO_SHORT_HARDWARE_PLATFORM
+	bool "Use short hardware platform (board name) [DEPRECATED]"
+	select DEPRECATED
+	help
+	  Will use the board name and board revision without the SoC or variant information if
+	  enabled which is the Zephyr 4.2 and earlier behaviour, otherwise will output the full
+	  board target for the hardware platform.
+
 config MCUMGR_GRP_OS_INFO_CUSTOM_HOOKS
 	bool "Custom info hooks"
 	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -831,9 +831,13 @@ static int os_mgmt_info(struct smp_streamer *ctxt)
 
 	if (format_bitmask & OS_MGMT_INFO_FORMAT_HARDWARE_PLATFORM) {
 		rc = snprintf(&output[output_length], (sizeof(output) - output_length),
+#ifdef CONFIG_MCUMGR_GRP_OS_INFO_HARDWARE_INFO_SHORT_HARDWARE_PLATFORM
 			      (prior_output == true ? " %s%s%s" : "%s%s%s"), CONFIG_BOARD,
 			      (sizeof(CONFIG_BOARD_REVISION) > 1 ? "@" : ""),
 			      CONFIG_BOARD_REVISION);
+#else
+			      (prior_output == true ? " %s" : "%s"), CONFIG_BOARD_TARGET);
+#endif
 
 		if (rc < 0 || rc >= (sizeof(output) - output_length)) {
 			goto fail;

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/build_date.c
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/build_date.c
@@ -31,15 +31,10 @@ static struct net_buf *nb;
 
 /* Responses to commands */
 extern uint8_t *test_date_time;
-const uint8_t response_all_board_revision_left[] = "Zephyr unknown " STRINGIFY(BUILD_VERSION) " "
-						   KERNEL_VERSION_STRING " ";
-const uint8_t response_all_board_revision_right[] = " " CONFIG_ARCH " " PROCESSOR_NAME " "
-						   CONFIG_BOARD "@" CONFIG_BOARD_REVISION
-						   " Zephyr";
 const uint8_t response_all_left[] = "Zephyr unknown " STRINGIFY(BUILD_VERSION) " "
 				    KERNEL_VERSION_STRING " ";
-const uint8_t response_all_right[] = " " CONFIG_ARCH " " PROCESSOR_NAME " " CONFIG_BOARD " Zephyr";
-
+const uint8_t response_all_right[] = " " CONFIG_ARCH " " PROCESSOR_NAME " " CONFIG_BOARD_TARGET
+				     " Zephyr";
 const uint8_t query_build_date[] = "b";
 const uint8_t query_all[] = "a";
 
@@ -204,36 +199,17 @@ ZTEST(os_mgmt_info_build_date, test_info_build_date_2_all)
 	zassert_true(ok, "Expected decode to be successful\n");
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
-	if (sizeof(CONFIG_BOARD_REVISION) > 1) {
-		/* Check with board revision */
-		zassert_equal((strlen(test_date_time) + strlen(response_all_board_revision_left) +
-			       strlen(response_all_board_revision_right)), output.len,
-			      "Expected to receive %d bytes but got %d\n",
-			      (strlen(test_date_time) + strlen(response_all_board_revision_left) +
-			       strlen(response_all_board_revision_right)), output.len);
+	zassert_equal((strlen(test_date_time) + strlen(response_all_left) +
+		       strlen(response_all_right)), output.len,
+		      "Expected to receive %d bytes but got %d\n",
+		      (strlen(test_date_time) + strlen(response_all_left) +
+		       strlen(response_all_right)), output.len);
 
-		zassert_mem_equal(response_all_board_revision_left, output.value,
-				  strlen(response_all_board_revision_left),
-				  "Expected received data mismatch");
-		zassert_mem_equal(response_all_board_revision_right,
-				  &output.value[strlen(response_all_board_revision_left) +
-				  strlen(test_date_time)],
-				  strlen(response_all_board_revision_right),
-				  "Expected received data mismatch");
-	} else {
-		/* Check without board revision */
-		zassert_equal((strlen(test_date_time) + strlen(response_all_left) +
-			       strlen(response_all_right)), output.len,
-			      "Expected to receive %d bytes but got %d\n",
-			      (strlen(test_date_time) + strlen(response_all_left) +
-			       strlen(response_all_right)), output.len);
-
-		zassert_mem_equal(response_all_left, output.value, strlen(response_all_left),
-				  "Expected received data mismatch");
-		zassert_mem_equal(response_all_right, &output.value[strlen(response_all_left) +
-				  strlen(test_date_time)], strlen(response_all_right),
-				  "Expected received data mismatch");
-	}
+	zassert_mem_equal(response_all_left, output.value, strlen(response_all_left),
+			  "Expected received data mismatch");
+	zassert_mem_equal(response_all_right, &output.value[strlen(response_all_left) +
+			  strlen(test_date_time)], strlen(response_all_right),
+			  "Expected received data mismatch");
 
 	/* Extract time strings into timestamps */
 	expected_time_seconds = time_string_to_seconds(&test_date_time[TIME_CHECK_HH_START_CHAR]);

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/main.c
@@ -82,24 +82,10 @@ const uint8_t response_kernel_release[] = STRINGIFY(BUILD_VERSION);
 const uint8_t response_kernel_version[] = KERNEL_VERSION_STRING;
 const uint8_t response_machine[] = CONFIG_ARCH;
 const uint8_t response_processor[] = PROCESSOR_NAME;
-const uint8_t response_board_revision[] = CONFIG_BOARD "@" CONFIG_BOARD_REVISION;
-const uint8_t response_board[] = CONFIG_BOARD;
+const uint8_t response_board_target[] = CONFIG_BOARD_TARGET;
 const uint8_t response_os[] = "Zephyr";
 const uint8_t response_custom_cmd[] = "Magic Output for Test";
 const uint8_t response_os_custom[] = CONFIG_CUSTOM_OS_NAME_VALUE;
-
-const uint8_t response_all_board_revision[] = "Zephyr "
-#if defined(CONFIG_BT)
-					      CONFIG_BT_DEVICE_NAME
-#elif defined(CONFIG_NET_HOSTNAME_ENABLE)
-					      CONFIG_NET_HOSTNAME
-#else
-					      "unknown"
-#endif
-					      " " STRINGIFY(BUILD_VERSION) " "
-					      KERNEL_VERSION_STRING " " CONFIG_ARCH " "
-					      PROCESSOR_NAME " " CONFIG_BOARD "@"
-					      CONFIG_BOARD_REVISION " Zephyr";
 
 const uint8_t response_all[] = "Zephyr "
 #if defined(CONFIG_BT)
@@ -110,7 +96,7 @@ const uint8_t response_all[] = "Zephyr "
 			       "unknown"
 #endif
 			       " " STRINGIFY(BUILD_VERSION) " " KERNEL_VERSION_STRING " "
-			       CONFIG_ARCH " " PROCESSOR_NAME " " CONFIG_BOARD " Zephyr";
+			       CONFIG_ARCH " " PROCESSOR_NAME " " CONFIG_BOARD_TARGET " Zephyr";
 
 const uint8_t query_kernel_name[] = "s";
 const uint8_t query_node_name[] = "n";
@@ -713,23 +699,12 @@ ZTEST(os_mgmt_info, test_info_8_platform)
 	zassert_true(ok, "Expected decode to be successful\n");
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
-	if (sizeof(CONFIG_BOARD_REVISION) > 1) {
-		/* Check with board revision */
-		zassert_equal((sizeof(response_board_revision) - 1), output.len,
-			      "Expected to receive %d bytes but got %d\n",
-			      (sizeof(response_board_revision) - 1), output.len);
+	zassert_equal((sizeof(response_board_target) - 1), output.len,
+		      "Expected to receive %d bytes but got %d\n",
+		      (sizeof(response_board_target) - 1), output.len);
 
-		zassert_mem_equal(response_board_revision, output.value, output.len,
-				  "Expected received data mismatch");
-	} else {
-		/* Check without board revision */
-		zassert_equal((sizeof(response_board) - 1), output.len,
-			      "Expected to receive %d bytes but got %d\n",
-			      (sizeof(response_board) - 1), output.len);
-
-		zassert_mem_equal(response_board, output.value, output.len,
-				  "Expected received data mismatch");
-	}
+	zassert_mem_equal(response_board_target, output.value, output.len,
+			  "Expected received data mismatch");
 }
 
 ZTEST(os_mgmt_info, test_info_9_os)
@@ -846,23 +821,12 @@ ZTEST(os_mgmt_info, test_info_10_all)
 	zassert_true(ok, "Expected decode to be successful\n");
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
-	if (sizeof(CONFIG_BOARD_REVISION) > 1) {
-		/* Check with board revision */
-		zassert_equal((sizeof(response_all_board_revision) - 1), output.len,
-			      "Expected to receive %d bytes but got %d\n",
-			      (sizeof(response_all_board_revision) - 1), output.len);
+	zassert_equal((sizeof(response_all) - 1), output.len,
+		      "Expected to receive %d bytes but got %d\n",
+		      (sizeof(response_all) - 1), output.len);
 
-		zassert_mem_equal(response_all_board_revision, output.value, output.len,
-				  "Expected received data mismatch");
-	} else {
-		/* Check without board revision */
-		zassert_equal((sizeof(response_all) - 1), output.len,
-			      "Expected to receive %d bytes but got %d\n",
-			      (sizeof(response_all) - 1), output.len);
-
-		zassert_mem_equal(response_all, output.value, output.len,
-				  "Expected received data mismatch");
-	}
+	zassert_mem_equal(response_all, output.value, output.len,
+			  "Expected received data mismatch");
 }
 
 ZTEST(os_mgmt_info, test_info_11_multi_1)


### PR DESCRIPTION
    Uses the full hwmv2 board target for the hardware platform output,
    seemingly this was missed in the hwmv2 migration and it was using
    the board name only. Adds a deprecated Kconfig to restore to the
    previous behaviour

Fixes #96487