### PR TITLE
scripts: set_assignee: add tests as a meta area

### DIFF
--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -125,8 +125,8 @@ def process_pr(gh, maintainer_file, number):
         log(f"Too many files changed ({len(fn)}), skipping....")
         return
 
-    # areas where assignment happens if only area is affected
-    meta_areas = ['Release Notes', 'Documentation', 'Samples']
+    # areas where assignment happens if only said areas are affected
+    meta_areas = ['Release Notes', 'Documentation', 'Samples', 'Tests']
 
     for changed_file in fn:
         num_files += 1


### PR DESCRIPTION
Add tests to be a meta area, similar to samples and documentation.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
