### PR TITLE
drivers: sensor: tdk: icm42x70: update temperature data processing

### DIFF
--- a/drivers/sensor/tdk/icm42x70/icm42x70.c
+++ b/drivers/sensor/tdk/icm42x70/icm42x70.c
@@ -482,12 +482,17 @@ static void icm42x70_convert_accel(struct sensor_value *val, int16_t raw_val, ui
 	val->val2 = conv_val % 1000000;
 }
 
-static void icm42x70_convert_temp(struct sensor_value *val, int16_t raw_val)
+static void icm42x70_convert_temp(struct sensor_value *val, int16_t raw_val, bool hires)
 {
 	int64_t conv_val;
 
 	/* see datasheet section 15.9 for details */
-	conv_val = 25 * 1000000 + ((int64_t)raw_val * 1000000 / 2);
+	if (hires) {
+		conv_val = (25 * 1000000) + ((int64_t)raw_val * 1000000 / 128);
+	} else {
+		conv_val = (25 * 1000000) + ((int64_t)raw_val * 1000000 / 2);
+	}
+
 	val->val1 = conv_val / 1000000;
 	val->val2 = conv_val % 1000000;
 }
@@ -530,7 +535,15 @@ static int icm42x70_channel_get(const struct device *dev, enum sensor_channel ch
 		icm42670_convert_gyro(val, data->gyro_z, data->gyro_fs);
 #endif
 	} else if (chan == SENSOR_CHAN_DIE_TEMP) {
-		icm42x70_convert_temp(val, data->temp);
+		/* see datasheet section 15.9 for details */
+		if (IS_ENABLED(CONFIG_ICM42X70_TRIGGER)) {
+			icm42x70_convert_temp(val, data->temp, data->driver.fifo_highres_enabled);
+		} else {
+			/* The temperature data read in non-fifo mode is of 2-bytes;
+			 * which is same as FIFO with high resolution temp data.
+			 */
+			icm42x70_convert_temp(val, data->temp, true);
+		}
 #ifdef CONFIG_TDK_APEX
 	} else if ((enum sensor_channel_tdk_apex)chan == SENSOR_CHAN_APEX_MOTION) {
 		if (cfg->apex == TDK_APEX_PEDOMETER) {


### PR DESCRIPTION
Update the temperature data processing to
handle different data sizes based on FIFO configuration. The temperature sensor data size and conversion
formula vary depending on the FIFO mode:
1. FIFO disabled: Uses 20-bit data format
2. FIFO enabled (standard resolution): 16-bit data
3. FIFO enabled (high resolution): 20-bit data

The implementation now:
- Uses the 'fifo_highres_enabled' flag to determine the correct data size
- Applies the appropriate conversion formula based on the resolution mode
- Handles all three possible FIFO configurations
- Ensures accurate temperature readings in all modes