### PR TITLE
modem: chat: add `modem_chat_is_running`

### DIFF
--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -338,6 +338,14 @@ int modem_chat_init(struct modem_chat *chat, const struct modem_chat_config *con
 int modem_chat_attach(struct modem_chat *chat, struct modem_pipe *pipe);
 
 /**
+ * @brief Check if a script is running
+ * @param chat Chat instance
+ * @returns true if a script is currently running
+ * @returns false if a script is not currently running
+ */
+bool modem_chat_is_running(struct modem_chat *chat);
+
+/**
  * @brief Run script asynchronously
  * @param chat Chat instance
  * @param script Script to run

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -843,6 +843,11 @@ int modem_chat_attach(struct modem_chat *chat, struct modem_pipe *pipe)
 	return 0;
 }
 
+bool modem_chat_is_running(struct modem_chat *chat)
+{
+	return atomic_test_bit(&chat->script_state, MODEM_CHAT_SCRIPT_STATE_RUNNING_BIT);
+}
+
 int modem_chat_run_script_async(struct modem_chat *chat, const struct modem_chat_script *script)
 {
 	bool script_is_running;

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -635,8 +635,10 @@ ZTEST(modem_chat, test_script_chat_timeout_cmd)
 	int ret;
 	bool called;
 
+	zassert_false(modem_chat_is_running(&cmd));
 	zassert_ok(modem_chat_run_script_async(&cmd, &script_timeout_cmd),
 		   "Failed to start script");
+	zassert_true(modem_chat_is_running(&cmd));
 	k_msleep(100);
 
 	/*
@@ -672,6 +674,7 @@ ZTEST(modem_chat, test_script_chat_timeout_cmd)
 	 */
 	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
 	k_msleep(100);
+	zassert_false(modem_chat_is_running(&cmd));
 
 	called = atomic_test_bit(&callback_called, MODEM_CHAT_UTEST_ON_SCRIPT_CALLBACK_BIT);
 	zassert_true(called == true, "Script callback should have been called");


### PR DESCRIPTION
Add a helper function to query if the chat instance is currently running a script.

Implemented as part of another feature that didn't end up making sense, but maybe it will help someone else.