### PR TITLE
drivers: i3c: i3c_max32: Init bus only if known devices exist

### DIFF
--- a/drivers/i3c/i3c_max32.c
+++ b/drivers/i3c/i3c_max32.c
@@ -1729,9 +1729,14 @@ static int max32_i3c_init(const struct device *dev)
 
 	cfg->irq_config_func(dev);
 
-	ret = i3c_bus_init(dev, &cfg->common.dev_list);
+	if (cfg->common.dev_list.num_i3c > 0) {
+		ret = i3c_bus_init(dev, &cfg->common.dev_list);
+		if (ret) {
+			LOG_ERR("Failed to do i3c bus init, err=%d", ret);
+		}
+	}
 
-	return ret;
+	return 0;
 }
 
 static int max32_i3c_i2c_api_configure(const struct device *dev, uint32_t dev_config)


### PR DESCRIPTION
CCC operation fails when no known devices exist, causing whole bus initialization procedure to fail when no I3C devices are defined in devicetree. Do not initialize the bus if no known devices exist. Other I3C drivers follow this logic as well.

Fixes the regression introduced in https://github.com/zephyrproject-rtos/zephyr/commit/69e31d87be4187d193a65da0f4b50a1fcde591dd

Tested `sensor/accel_polling` example on MAX32657EVKIT which has an on-board ADXL367 I2C sensor.

> *** Booting Zephyr OS build v4.2.0-4886-g9f11967c3ae0 ***
> adxl367@530000000000000000 [m/s^2]:    (   -0.274512,     0.166668,     9.507429)
> adxl367@530000000000000000 [m/s^2]:    (   -0.191178,     0.171570,     9.478017)
> adxl367@530000000000000000 [m/s^2]:    (   -0.220590,     0.110295,     9.424095)
> adxl367@530000000000000000 [m/s^2]:    (   -0.227943,     0.149511,     9.507429)
> adxl367@530000000000000000 [m/s^2]:    (   -0.223041,     0.117648,     9.507429)
> adxl367@530000000000000000 [m/s^2]:    (   -0.193629,     0.129903,     9.519684)
> adxl367@530000000000000000 [m/s^2]:    (   -0.240198,     0.154413,     9.497625)
> adxl367@530000000000000000 [m/s^2]:    (   -0.208335,     0.125001,     9.514782)