### PR TITLE
boards: mimxrt700_evk: Make linkserver the default runner

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.cmake
+++ b/boards/nxp/mimxrt700_evk/board.cmake
@@ -17,5 +17,5 @@ elseif(CONFIG_SOC_MIMXRT798S_HIFI4)
   board_runner_args(jlink "--device=MIMXRT798S_HiFi4")
 endif()
 
-include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Linkeserver should be the default runner because that's actually what comes on the board out of box, which is already indicated in the documentation of the board.