### PR TITLE
dts: pm: Add wakeup-signal property

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -220,6 +220,7 @@ New APIs and options
    * The :kconfig:option:`PM_S2RAM_CUSTOM_MARKING` has been renamed to
      :kconfig:option:`HAS_PM_S2RAM_CUSTOM_MARKING` and refactored to be promptless. This option
      is now selected by SoCs if they need it for their "suspend-to-ram" implementations.
+   * Added devicetree property ``wakeup-signal``
 
 * Settings
 

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -122,6 +122,10 @@ static int sys_clock_driver_init(void)
 	LPTMR_SetTimerPeriod(LPTMR_BASE, CYCLES_PER_TICK);
 	LPTMR_StartTimer(LPTMR_BASE);
 
+#if (DT_INST_PROP(0, wakeup_source))
+	/* Use wakeup-signal property if specified, else use the irq number */
+	NXP_ENABLE_WAKEUP_SIGNAL(DT_INST_PROP_OR(0, wakeup_signal, DT_INST_IRQN(0)));
+#endif
 	return 0;
 }
 

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -301,6 +301,8 @@
 		prescaler = <1>;
 		resolution = <32>;
 		status = "disabled";
+		wakeup-source;
+		wakeup-signal = <0>;
 	};
 
 	lptmr1: timer@2e000 {

--- a/dts/bindings/base/pm.yaml
+++ b/dts/bindings/base/pm.yaml
@@ -16,6 +16,16 @@ properties:
       Wake up capable devices are disabled (interruptions will not wake up
       the system) by default but they can be enabled at runtime if necessary.
 
+  wakeup-signal:
+    type: int
+    description: |
+      Property to specify the wakeup signal number.
+
+      There are some SoC's where the wakeup signal can be a different signal
+      and not necessarily the interrupt number.
+
+      This property goes together with "wakeup-source" property.
+
   zephyr,pm-device-runtime-auto:
     type: boolean
     description: |


### PR DESCRIPTION
This is a new property to specify the wakeup signal number. There are some SoC's where the wakeup signal can be a different signal and not necessarily the interrupt number.
This property goes together with wakeup-source.