### PR TITLE
Enable NXP LPUART pin internal pullup resistor

### DIFF
--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,6 +23,7 @@
 			slew-rate = "fast";
 			drive-strength = "low";
 			input-enable;
+			bias-pull-up;
 		};
 	};
 
@@ -57,6 +58,7 @@
 			slew-rate = "fast";
 			drive-strength = "low";
 			input-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -61,6 +61,7 @@
 			slew-rate = "fast";
 			drive-strength = "low";
 			input-enable;
+			bias-pull-up;
 		};
 	};
 
@@ -71,6 +72,7 @@
 			slew-rate = "fast";
 			drive-strength = "low";
 			input-enable;
+			bias-pull-up;
 		};
 	};
 


### PR DESCRIPTION
This commit enables MCXN236, MCXN947 LPUART pin internal pullup resistor. For MCXN947 and MCXN236, during LPUAR initialization, the RX pin is pulled down internally and STAT[RAF] is set to one. In this state, attempting to enter low power mode will trigger LPACK reset and therefore cannot truly enter low power mode. The correct setting should be to enable LPUART pin internal pullup resistor.