### PR TITLE
modem: modem_ppp: optimise PPP frame wrapping

### DIFF
--- a/include/zephyr/modem/ppp.h
+++ b/include/zephyr/modem/ppp.h
@@ -50,27 +50,10 @@ enum modem_ppp_receive_state {
 };
 
 enum modem_ppp_transmit_state {
-	/* Idle */
 	MODEM_PPP_TRANSMIT_STATE_IDLE = 0,
-	/* Writing header */
 	MODEM_PPP_TRANSMIT_STATE_SOF,
-	MODEM_PPP_TRANSMIT_STATE_HDR_FF,
-	MODEM_PPP_TRANSMIT_STATE_HDR_7D,
-	MODEM_PPP_TRANSMIT_STATE_HDR_23,
-	/* Writing protocol */
-	MODEM_PPP_TRANSMIT_STATE_PROTOCOL_HIGH,
-	MODEM_PPP_TRANSMIT_STATE_ESCAPING_PROTOCOL_HIGH,
-	MODEM_PPP_TRANSMIT_STATE_PROTOCOL_LOW,
-	MODEM_PPP_TRANSMIT_STATE_ESCAPING_PROTOCOL_LOW,
-	/* Writing data */
+	MODEM_PPP_TRANSMIT_STATE_PROTOCOL,
 	MODEM_PPP_TRANSMIT_STATE_DATA,
-	MODEM_PPP_TRANSMIT_STATE_ESCAPING_DATA,
-	/* Writing FCS */
-	MODEM_PPP_TRANSMIT_STATE_FCS_LOW,
-	MODEM_PPP_TRANSMIT_STATE_ESCAPING_FCS_LOW,
-	MODEM_PPP_TRANSMIT_STATE_FCS_HIGH,
-	MODEM_PPP_TRANSMIT_STATE_ESCAPING_FCS_HIGH,
-	/* Writing end of frame */
 	MODEM_PPP_TRANSMIT_STATE_EOF,
 };
 
@@ -100,8 +83,6 @@ struct modem_ppp {
 	/* Packet being sent */
 	enum modem_ppp_transmit_state transmit_state;
 	struct net_pkt *tx_pkt;
-	uint8_t tx_pkt_escaped;
-	uint16_t tx_pkt_protocol;
 	uint16_t tx_pkt_fcs;
 
 	/* Ring buffer used for transmitting partial PPP frame */


### PR DESCRIPTION
Optimise the PPP frame wrapping process by performing all work inside a single function into a contiguous buffer, instead of operating on the ring buffer one byte at a time.

On a nRF54L15 (M33 @ 128 MHz) before the change:
```
Wrapping 1062 byte packet: ~4.1 ms
Wrapping 1355 byte packet: ~5.0 ms
```
After the change:
```
Wrapping 1026 byte packet: ~2.4 ms
Wrapping 1341 byte packet: ~3.1 ms
```

The timing matters here because the frame processing by default happens on the system workqueue, blocking other users (notably Bluetooth) from running.