### PR TITLE
tests: arch: arm: fix -Wformat error

### DIFF
--- a/tests/arch/arm/arm_sw_vector_relay/src/arm_sw_vector_relay.c
+++ b/tests/arch/arm/arm_sw_vector_relay/src/arm_sw_vector_relay.c
@@ -69,6 +69,6 @@ ZTEST(arm_sw_vector_relay, test_arm_sw_vector_relay)
 	 */
 	zassert_true(_vector_table_pointer == (uint32_t)_vector_start,
 		     "vector table pointer not pointing to vector start, 0x%x, 0x%x\n",
-		     _vector_table_pointer, _vector_start);
+		     _vector_table_pointer, (uint32_t)_vector_start);
 #endif
 }


### PR DESCRIPTION
Cast _vector_start to uint32_t to match format specifier.

```
/home/user/west_workspace/zephyr/tests/arch/arm/arm_sw_vector_relay/src/arm_sw_vector_relay.c: In function 'arm_sw_vector_relay_test_arm_sw_vector_relay':
/home/user/west_workspace/zephyr/tests/arch/arm/arm_sw_vector_relay/src/arm_sw_vector_relay.c:71:22: error: format '%x' expects argument of type 'unsigned int', but argument 8 has type 'char *' [-Werror=format=]
   71 |                      "vector table pointer not pointing to vector start, 0x%x, 0x%x\n",
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   72 |                      _vector_table_pointer, _vector_start);
      |                                             ~~~~~~~~~~~~~
      |                                             |
      |                                             char *
```

Part of https://github.com/zephyrproject-rtos/zephyr/issues/96968