### PR TITLE
tests: drivers: flash: Improve compatibility with 64-bit platforms

### DIFF
--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -345,8 +345,8 @@ ZTEST(flash_driver, test_supply_gpios_control)
 }
 
 struct test_cb_data_type {
-	uint32_t page_counter; /* used to count how many pages was iterated */
-	uint32_t exit_page;    /* terminate iteration when this page is reached */
+	size_t page_counter; /* used to count how many pages was iterated */
+	size_t exit_page;    /* terminate iteration when this page is reached */
 };
 
 static bool flash_callback(const struct flash_pages_info *info, void *data)
@@ -405,7 +405,7 @@ ZTEST(flash_driver, test_flash_page_layout)
 	zassert_equal(page_info_off.index, page_info_idx.index);
 
 	page_count = flash_get_page_count(flash_dev);
-	TC_PRINT("page_count=%d\n", (int)page_count);
+	TC_PRINT("page_count=%zu\n", page_count);
 	zassert_true(page_count > 0, "flash_get_page_count returned %d", rc);
 	zassert_true(page_count >= page_info_off.index);
 
@@ -413,7 +413,7 @@ ZTEST(flash_driver, test_flash_page_layout)
 	test_cb_data.exit_page = page_count + 1;
 	flash_page_foreach(flash_dev, flash_callback, &test_cb_data);
 	zassert_true(page_count == test_cb_data.page_counter,
-		     "page_count = %d not equal to pages counted with cb = %d", page_count,
+		     "page_count = %zu not equal to pages counted with cb = %zu", page_count,
 		     test_cb_data.page_counter);
 
 	/* Test that callback can cancell iteration */
@@ -421,7 +421,7 @@ ZTEST(flash_driver, test_flash_page_layout)
 	test_cb_data.exit_page = page_count >> 1;
 	flash_page_foreach(flash_dev, flash_callback, &test_cb_data);
 	zassert_true(test_cb_data.exit_page == test_cb_data.page_counter,
-		     "%d pages were iterated while it shall stop on page %d",
+		     "%zu pages were iterated while it shall stop on page %zu",
 		     test_cb_data.page_counter, test_cb_data.exit_page);
 }
 


### PR DESCRIPTION
Change variables in `test_cb_data_type` from `uint32_t` to `size_t` to match the return type of `flash_get_page_count()` and adjust format specifiers accordingly. This resolves warnings when compiling for 64-bit platforms.

```
/home/user/west_workspace/zephyr/tests/drivers/flash/common/src/main.c: In function 'flash_driver_test_flash_page_layout':
/home/user/west_workspace/zephyr/tests/drivers/flash/common/src/main.c:416:22: error: format '%d' expects argument of type 'int', but argument 7 has type 'size_t' {aka 'long unsigned int'} [-Werror=format=]
  416 |                      "page_count = %d not equal to pages counted with cb = %d", page_count,
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~
      |                                                                                 |
      |                                                                                 size_t {aka long unsigned int}
```

Part of https://github.com/zephyrproject-rtos/zephyr/issues/96968