### PR TITLE
tests: logging: Improve compatibility with 64-bit platforms

### DIFF
--- a/tests/subsys/logging/log_backend_uart/src/main.c
+++ b/tests/subsys/logging/log_backend_uart/src/main.c
@@ -68,7 +68,7 @@ ZTEST_F(log_backend_uart, test_log_backend_uart_multi_instance)
 
 		tx_len = uart_emul_get_tx_data(fixture->dev[i], tx_content, sizeof(tx_content));
 		zassert_equal(tx_len, strlen(TEST_DATA),
-			      "%d: TX buffer length does not match. Expected %d, got %d",
+			      "%zu: TX buffer length does not match. Expected %zu, got %zu",
 			      i, strlen(TEST_DATA), tx_len);
 		zassert_mem_equal(tx_content, TEST_DATA, strlen(TEST_DATA));
 	}

--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -300,7 +300,7 @@ ZTEST(test_log_core_additional, test_log_early_logging)
 		}
 
 		zassert_equal(backend1_cb.total_logs, backend1_cb.counter,
-			      "Unexpected amount of messages received. %d",
+			      "Unexpected amount of messages received. %zu",
 			      backend1_cb.counter);
 	}
 }


### PR DESCRIPTION
Use `%zu` format specifier for `size_t` type to ensure compatibility with both 32-bit and 64-bit platforms.

This fixes warnings when using zassert string validation, e.g.
```
/home/user/west_workspace/zephyr/tests/subsys/logging/log_backend_uart/src/main.c: In function 'log_backend_uart_test_log_backend_uart_multi_instance':
/home/user/west_workspace/zephyr/tests/subsys/logging/log_backend_uart/src/main.c:71:31: error: format '%d' expects argument of type 'int', but argument 7 has type 'size_t' {aka 'long unsigned int'} [-Werror=format=]
   71 |                               "%d: TX buffer length does not match. Expected %d, got %d",
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   72 |                               i, strlen(TEST_DATA), tx_len);
      |                               ~
      |                               |
      |                               size_t {aka long unsigned int}
```

Part of https://github.com/zephyrproject-rtos/zephyr/issues/96968