### PR TITLE
drivers: gpio: aw9523b: Fix the condition for changing Push-pull

### DIFF
--- a/drivers/gpio/gpio_aw9523b.c
+++ b/drivers/gpio/gpio_aw9523b.c
@@ -469,7 +469,7 @@ end_hw_reset:
 		return err;
 	}
 
-	if (!config->port0_push_pull) {
+	if (config->port0_push_pull) {
 		/* Configure port0 to push-pull mode */
 		err = i2c_reg_update_byte_dt(&config->i2c, AW9523B_REG_CTL, AW9523B_GPOMD, 0xFF);
 		if (err) {


### PR DESCRIPTION
The condition for setting the GPOMD bit when `port0_push_pull` is enabled was reversed.
Fix this problem.