### PR TITLE
modbus: serial: use `gpio_dt_spec` pointer-based API

### DIFF
--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -509,7 +509,7 @@ static int configure_gpio(struct modbus_context *ctx)
 	struct modbus_serial_config *cfg = ctx->cfg;
 
 	if (cfg->de != NULL) {
-		if (!device_is_ready(cfg->de->port)) {
+		if (!gpio_is_ready_dt(cfg->de)) {
 			return -ENODEV;
 		}
 
@@ -520,7 +520,7 @@ static int configure_gpio(struct modbus_context *ctx)
 
 
 	if (cfg->re != NULL) {
-		if (!device_is_ready(cfg->re->port)) {
+		if (!gpio_is_ready_dt(cfg->re)) {
 			return -ENODEV;
 		}
 

--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -34,7 +34,7 @@ static void modbus_serial_tx_on(struct modbus_context *ctx)
 	struct modbus_serial_config *cfg = ctx->cfg;
 
 	if (cfg->de != NULL) {
-		gpio_pin_set(cfg->de->port, cfg->de->pin, 1);
+		gpio_pin_set_dt(cfg->de, 1);
 	}
 
 	if (IS_ENABLED(CONFIG_MODBUS_SERIAL_ASYNC_API)) {
@@ -58,7 +58,7 @@ static void modbus_serial_tx_off(struct modbus_context *ctx)
 	}
 
 	if (cfg->de != NULL) {
-		gpio_pin_set(cfg->de->port, cfg->de->pin, 0);
+		gpio_pin_set_dt(cfg->de, 0);
 	}
 }
 
@@ -78,7 +78,7 @@ static void modbus_serial_rx_on(struct modbus_context *ctx)
 	struct modbus_serial_config *cfg = ctx->cfg;
 
 	if (cfg->re != NULL) {
-		gpio_pin_set(cfg->re->port, cfg->re->pin, 1);
+		gpio_pin_set_dt(cfg->re, 1);
 	}
 
 	atomic_set_bit(&ctx->state, MODBUS_STATE_RX_ENABLED);
@@ -108,7 +108,7 @@ static void modbus_serial_rx_off(struct modbus_context *ctx)
 	atomic_clear_bit(&ctx->state, MODBUS_STATE_RX_ENABLED);
 
 	if (cfg->re != NULL) {
-		gpio_pin_set(cfg->re->port, cfg->re->pin, 0);
+		gpio_pin_set_dt(cfg->re, 0);
 	}
 }
 


### PR DESCRIPTION
Simplify code by using gpio_dt_spec pointer-based API functions (`gpio_pin_set_dt()` and `gpio_is_ready_dt()`) instead of accessing individual structure members directly.