### PR TITLE
ci: set two more ccache-cache-key false flags

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -235,6 +235,7 @@ jobs:
       with:
         app-path: zephyr
         toolchains: 'arm-zephyr-eabi'
+        enable-ccache: false
 
     - name: install-pip-pkgs
       working-directory: zephyr

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -26,6 +26,7 @@ jobs:
           toolchains: 'arm-zephyr-eabi'
           west-group-filter: -hal,-tools,-bootloader,-babblesim
           west-project-filter: -nrf_hw_models
+          enable-ccache: false
 
       - name: Run errno.py
         working-directory: zephyr


### PR DESCRIPTION
These two were introduced after the previous commit, disable the cache for them as well, reduce some noise from the github caches page.