### PR TITLE
retention: remove unused API struct

### DIFF
--- a/include/zephyr/retention/retention.h
+++ b/include/zephyr/retention/retention.h
@@ -32,22 +32,6 @@ extern "C" {
  * @{
  */
 
-typedef ssize_t (*retention_size_api)(const struct device *dev);
-typedef int (*retention_is_valid_api)(const struct device *dev);
-typedef int (*retention_read_api)(const struct device *dev, off_t offset, uint8_t *buffer,
-				  size_t size);
-typedef int (*retention_write_api)(const struct device *dev, off_t offset,
-				   const uint8_t *buffer, size_t size);
-typedef int (*retention_clear_api)(const struct device *dev);
-
-struct retention_api {
-	retention_size_api size;
-	retention_is_valid_api is_valid;
-	retention_read_api read;
-	retention_write_api write;
-	retention_clear_api clear;
-};
-
 /**
  * @brief		Returns the size of the retention area.
  *

--- a/subsys/retention/retention.c
+++ b/subsys/retention/retention.c
@@ -392,14 +392,6 @@ finish:
 	return rc;
 }
 
-static const struct retention_api retention_api = {
-	.size = retention_size,
-	.is_valid = retention_is_valid,
-	.read = retention_read,
-	.write = retention_write,
-	.clear = retention_clear,
-};
-
 #define RETENTION_DEVICE(inst)									\
 	static struct retention_data								\
 		retention_data_##inst = {							\
@@ -425,6 +417,6 @@ static const struct retention_api retention_api = {
 			      &retention_config_##inst,						\
 			      POST_KERNEL,							\
 			      CONFIG_RETENTION_INIT_PRIORITY,					\
-			      &retention_api);
+			      NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(RETENTION_DEVICE)


### PR DESCRIPTION
Remove the unused/unnecessary retention subsystem API struct.