### PR TITLE
Fix temperature value calculation for ds18s20

### DIFF
--- a/drivers/sensor/maxim/ds18b20/ds18b20.c
+++ b/drivers/sensor/maxim/ds18b20/ds18b20.c
@@ -89,7 +89,7 @@ static inline void ds18b20_temperature_from_raw(const struct device *dev,
 
 	if (cfg->chip == type_ds18s20) {
 		val->val1 = temp / 2;
-		val->val2 = (temp % 2) * 5000000;
+		val->val2 = (temp % 2) * 500000;
 	} else {
 		val->val1 = temp / 16;
 		val->val2 = (temp % 16) * 1000000 / 16;


### PR DESCRIPTION
The DS18S20 returns a 9 bit temperature value. The value is a signed integer scaled by a factor of two, for 0.5 °C resolution. The integer part was calculated correctly using integer division by two. The decimal had one zero too much in the multiplication factor, thus would either add 0 or 5 to the total value instead of 0 or 0.5.