### PR TITLE
boards: st: nucleo_c071rb: Add pull-up to user button

### DIFF
--- a/boards/st/nucleo_c071rb/nucleo_c071rb.dts
+++ b/boards/st/nucleo_c071rb/nucleo_c071rb.dts
@@ -48,7 +48,7 @@
 
 		user_button: button {
 			label = "user button";
-			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			status = "okay";
 			zephyr,code = <INPUT_KEY_0>;
 		};


### PR DESCRIPTION
The NUCLEO-C071RB user manual UM3353 states that "The PC13 I/O used for the user button must be set in INPUT, pull‑up". The board does not have an external pull-up fitted.

Without the internal pull-up, the GPIO for the user button is left floating and can't be used reliably by an application.