### PR TITLE
modem: modem_cellular: periodic script error detection

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -146,6 +146,10 @@ New APIs and options
 
     * :kconfig:option:`CONFIG_CPU_FREQ`
 
+* Cellular
+
+  * :c:enumerator:`CELLULAR_EVENT_MODEM_COMMS_CHECK_RESULT`
+
 * Crypto
 
   * :kconfig:option:`CONFIG_MBEDTLS_PSA_CRYPTO_BUILTIN_KEYS`

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1388,11 +1388,15 @@ static void modem_cellular_carrier_on_event_handler(struct modem_cellular_data *
 {
 	const struct modem_cellular_config *config =
 		(const struct modem_cellular_config *)data->dev->config;
+	struct cellular_evt_modem_comms_check_result result;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
+		result.success = evt == MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS;
+
 		modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
+		modem_cellular_emit_event(data, CELLULAR_EVENT_MODEM_COMMS_CHECK_RESULT, &result);
 		break;
 
 	case MODEM_CELLULAR_EVENT_TIMEOUT:

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -139,6 +139,8 @@ enum cellular_event {
 	CELLULAR_EVENT_MODEM_INFO_CHANGED = BIT(0),
 	/** Cellular network registration status changed */
 	CELLULAR_EVENT_REGISTRATION_STATUS_CHANGED = BIT(1),
+	/** Result of a communications link check to the modem */
+	CELLULAR_EVENT_MODEM_COMMS_CHECK_RESULT = BIT(2),
 };
 
 /* Opaque bit-mask large enough for all current & future events */
@@ -152,6 +154,11 @@ struct cellular_evt_modem_info {
 /** Payload for @ref CELLULAR_EVENT_REGISTRATION_STATUS_CHANGED. */
 struct cellular_evt_registration_status {
 	enum cellular_registration_status status; /**< New registration status */
+};
+
+/** Payload for @ref CELLULAR_EVENT_MODEM_COMMS_CHECK_RESULT */
+struct cellular_evt_modem_comms_check_result {
+	bool success; /**< Communications to modem checked successfully */
 };
 
 /**


### PR DESCRIPTION
Add a callback for the periodic script result so that applications have a way of detecting dead links.

The goal of this PR is to enable this pattern to recover after a dead modem link.
```
static void modem_event_cb(const struct device *dev, enum cellular_event evt, const void *payload,
			   void *user_data)
{
    if(evt == CELLULAR_EVENT_MODEM_COMMS_CHECK_RESULT) {
        const struct cellular_evt_modem_comms_check_result *mccr= payload;

        if (mccr->success == false) {
            /* Do something to shutdown the modem (Exercise for the reader).
             * Don't call `pm_device_runtime_put(dev) though, since that will block this
             * context for up to a minute.
             */
        }
    }
   if(evt == CELLULAR_EVENT_MODEM_SUSPENDED) {
       sys_reboot(SYS_REBOOT_WARM);
   }
}
```
The advantage of this over just rebooting immediately is that it gives the modem a chance to cleanly disconnect from the LTE network.