### PR TITLE
tests/libs: Improve compatibility with 64-bit platforms

### DIFF
--- a/tests/lib/mem_blocks/src/main.c
+++ b/tests/lib/mem_blocks/src/main.c
@@ -158,9 +158,9 @@ static void alloc_free(sys_mem_blocks_t *mem_block,
 				      listener_mem[i], blocks[i][0]);
 			zassert_equal(listener_size[i],
 				      BIT(mem_block->info.blk_sz_shift),
-				      "Heap allocated sized: %u != %u",
+				      "Heap allocated sized: %zu != %lu",
 				      listener_size[i],
-				      (uint32_t)BIT(mem_block->info.blk_sz_shift));
+				      BIT(mem_block->info.blk_sz_shift));
 #endif
 		}
 
@@ -195,9 +195,9 @@ static void alloc_free(sys_mem_blocks_t *mem_block,
 				      listener_mem[i], blocks[i][0]);
 			zassert_equal(listener_size[i],
 				      BIT(mem_block->info.blk_sz_shift),
-				      "Heap allocated sized: %u != %u",
+				      "Heap allocated sized: %zu != %lu",
 				      listener_size[i],
-				      (uint32_t)BIT(mem_block->info.blk_sz_shift));
+				      BIT(mem_block->info.blk_sz_shift));
 #endif
 		}
 	}
@@ -387,28 +387,28 @@ ZTEST(lib_mem_block, test_mem_block_get)
 			"sys_mem_blocks_get bitmap failed, %p != %p",
 			listener_mem[0], mem_block_01.buffer);
 	zassert_equal(listener_size[0], BLK_SZ*2,
-			"sys_mem_blocks_get bitmap failed, %u != %u",
+			"sys_mem_blocks_get bitmap failed, %zu != %u",
 			listener_size[0], BLK_SZ*2);
 
 	zassert_equal(listener_mem[1], mem_block_01.buffer + BLK_SZ*3,
 			"sys_mem_blocks_get bitmap failed, %p != %p",
 			listener_mem[1], mem_block_01.buffer + BLK_SZ*2);
 	zassert_equal(listener_size[1], BLK_SZ,
-			"sys_mem_blocks_get bitmap failed, %u != %u",
+			"sys_mem_blocks_get bitmap failed, %zu != %u",
 			listener_size[1], BLK_SZ);
 
 	zassert_equal(listener_mem[2], mem_block_01.buffer + BLK_SZ*2,
 			"sys_mem_blocks_get bitmap failed, %p != %p",
 			listener_mem[2], mem_block_01.buffer + BLK_SZ);
 	zassert_equal(listener_size[2], BLK_SZ,
-			"sys_mem_blocks_get bitmap failed, %u != %u",
+			"sys_mem_blocks_get bitmap failed, %zu != %u",
 			listener_size[2], BLK_SZ);
 
 	zassert_equal(listener_mem[3], mem_block_01.buffer,
 			"sys_mem_blocks_get bitmap failed, %p != %p",
 			listener_mem[3], mem_block_01.buffer);
 	zassert_equal(listener_size[3], BLK_SZ*4,
-			"sys_mem_blocks_get bitmap failed, %u != %u",
+			"sys_mem_blocks_get bitmap failed, %zu != %u",
 			listener_size[3], BLK_SZ*4);
 
 #endif
@@ -553,42 +553,42 @@ ZTEST(lib_mem_block, test_mem_block_alloc_free_contiguous)
 			"sys_mem_blocks_alloc_contiguous failed, %p != %p",
 			listener_mem[0], mem_block_01.buffer);
 	zassert_equal(listener_size[0], BLK_SZ*NUM_BLOCKS,
-			"sys_mem_blocks_alloc_contiguous failed, %u != %u",
+			"sys_mem_blocks_alloc_contiguous failed, %zu != %u",
 			listener_size[0], BLK_SZ*NUM_BLOCKS);
 
 	zassert_equal(listener_mem[1], mem_block_01.buffer,
 			"sys_mem_blocks_alloc_contiguous failed, %p != %p",
 			listener_mem[1], mem_block_01.buffer);
 	zassert_equal(listener_size[1], BLK_SZ*3,
-			"sys_mem_blocks_alloc_contiguous failed, %u != %u",
+			"sys_mem_blocks_alloc_contiguous failed, %zu != %u",
 			listener_size[1], BLK_SZ*3);
 
 	zassert_equal(listener_mem[2], mem_block_01.buffer+BLK_SZ*4,
 			"sys_mem_blocks_alloc_contiguous failed, %p != %p",
 			listener_mem[2], mem_block_01.buffer+BLK_SZ*4);
 	zassert_equal(listener_size[2], BLK_SZ*4,
-			"sys_mem_blocks_alloc_contiguous failed, %u != %u",
+			"sys_mem_blocks_alloc_contiguous failed, %zu != %u",
 			listener_size[2], BLK_SZ*4);
 
 	zassert_equal(listener_mem[3], mem_block_01.buffer,
 			"sys_mem_blocks_alloc_contiguous failed, %p != %p",
 			listener_mem[3], mem_block_01.buffer);
 	zassert_equal(listener_size[3], BLK_SZ*3,
-			"sys_mem_blocks_alloc_contiguous failed, %u != %u",
+			"sys_mem_blocks_alloc_contiguous failed, %zu != %u",
 			listener_size[3], BLK_SZ*3);
 
 	zassert_equal(listener_mem[4], mem_block_01.buffer+BLK_SZ*4,
 			"sys_mem_blocks_alloc_contiguous failed, %p != %p",
 			listener_mem[4], mem_block_01.buffer+BLK_SZ*4);
 	zassert_equal(listener_size[4], BLK_SZ*4,
-			"sys_mem_blocks_alloc_contiguous failed, %u != %u",
+			"sys_mem_blocks_alloc_contiguous failed, %zu != %u",
 			listener_size[4], BLK_SZ*4);
 
 	zassert_equal(listener_mem[5], mem_block_01.buffer,
 			"sys_mem_blocks_alloc_contiguous failed, %p != %p",
 			listener_mem[5], mem_block_01.buffer);
 	zassert_equal(listener_size[5], BLK_SZ*NUM_BLOCKS,
-			"sys_mem_blocks_alloc_contiguous failed, %u != %u",
+			"sys_mem_blocks_alloc_contiguous failed, %zu != %u",
 			listener_size[5], BLK_SZ*NUM_BLOCKS);
 #endif
 }

--- a/tests/lib/mem_blocks_stats/src/main.c
+++ b/tests/lib/mem_blocks_stats/src/main.c
@@ -56,7 +56,7 @@ ZTEST(lib_mem_blocks_stats_test, test_mem_blocks_runtime_stats)
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
 
 	zassert_equal(stats.free_bytes, BLK_SZ * NUM_BLOCKS,
-		      "Expected %zu free bytes, not %zu\n",
+		      "Expected %u free bytes, not %zu\n",
 		      BLK_SZ * NUM_BLOCKS, stats.free_bytes);
 	zassert_equal(stats.allocated_bytes, 0,
 		      "Expected 0 allocated bytes, not %zu\n",
@@ -74,13 +74,13 @@ ZTEST(lib_mem_blocks_stats_test, test_mem_blocks_runtime_stats)
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
 
 	zassert_equal(stats.free_bytes, BLK_SZ * (NUM_BLOCKS - 3),
-		      "Expected %zu free bytes, not %zu\n",
+		      "Expected %u free bytes, not %zu\n",
 		      BLK_SZ * (NUM_BLOCKS - 3), stats.free_bytes);
 	zassert_equal(stats.allocated_bytes, 3 * BLK_SZ,
-		      "Expected %zu allocated bytes, not %zu\n",
+		      "Expected %u allocated bytes, not %zu\n",
 		      3 * BLK_SZ, stats.allocated_bytes);
 	zassert_equal(stats.max_allocated_bytes, 3 * BLK_SZ,
-		      "Expected %zu max allocated bytes, not %zu\n",
+		      "Expected %u max allocated bytes, not %zu\n",
 		      3 * BLK_SZ, stats.max_allocated_bytes);
 
 	/* Free blocks 1 and 2, and then verify the stats. */
@@ -92,13 +92,13 @@ ZTEST(lib_mem_blocks_stats_test, test_mem_blocks_runtime_stats)
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
 
 	zassert_equal(stats.free_bytes, BLK_SZ * (NUM_BLOCKS - 1),
-		      "Expected %zu free bytes, not %zu\n",
+		      "Expected %u free bytes, not %zu\n",
 		      BLK_SZ * (NUM_BLOCKS - 1), stats.free_bytes);
 	zassert_equal(stats.allocated_bytes, 1 * BLK_SZ,
-		      "Expected %zu allocated bytes, not %zu\n",
+		      "Expected %u allocated bytes, not %zu\n",
 		      1 * BLK_SZ, stats.allocated_bytes);
 	zassert_equal(stats.max_allocated_bytes, 3 * BLK_SZ,
-		      "Expected %zu max allocated bytes, not %zu\n",
+		      "Expected %u max allocated bytes, not %zu\n",
 		      3 * BLK_SZ, stats.max_allocated_bytes);
 
 	/* Allocate 1 block and verify the max is still at 3 */
@@ -110,13 +110,13 @@ ZTEST(lib_mem_blocks_stats_test, test_mem_blocks_runtime_stats)
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
 
 	zassert_equal(stats.free_bytes, BLK_SZ * (NUM_BLOCKS - 2),
-		      "Expected %zu free bytes, not %zu\n",
+		      "Expected %u free bytes, not %zu\n",
 		      BLK_SZ * (NUM_BLOCKS - 2), stats.free_bytes);
 	zassert_equal(stats.allocated_bytes, 2 * BLK_SZ,
-		      "Expected %zu allocated bytes, not %zu\n",
+		      "Expected %u allocated bytes, not %zu\n",
 		      2 * BLK_SZ, stats.allocated_bytes);
 	zassert_equal(stats.max_allocated_bytes, 3 * BLK_SZ,
-		      "Expected %zu max allocated bytes, not %zu\n",
+		      "Expected %u max allocated bytes, not %zu\n",
 		      3 * BLK_SZ, stats.max_allocated_bytes);
 
 
@@ -129,13 +129,13 @@ ZTEST(lib_mem_blocks_stats_test, test_mem_blocks_runtime_stats)
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
 
 	zassert_equal(stats.free_bytes, BLK_SZ * (NUM_BLOCKS - 2),
-		      "Expected %zu free bytes, not %zu\n",
+		      "Expected %u free bytes, not %zu\n",
 		      BLK_SZ * (NUM_BLOCKS - 2), stats.free_bytes);
 	zassert_equal(stats.allocated_bytes, 2 * BLK_SZ,
-		      "Expected %zu allocated bytes, not %zu\n",
+		      "Expected %u allocated bytes, not %zu\n",
 		      2 * BLK_SZ, stats.allocated_bytes);
 	zassert_equal(stats.max_allocated_bytes, 2 * BLK_SZ,
-		      "Expected %zu max allocated bytes, not %zu\n",
+		      "Expected %u max allocated bytes, not %zu\n",
 		      2 * BLK_SZ, stats.max_allocated_bytes);
 
 	/* Free the last two blocks; verify stats results */
@@ -147,13 +147,13 @@ ZTEST(lib_mem_blocks_stats_test, test_mem_blocks_runtime_stats)
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
 
 	zassert_equal(stats.free_bytes, BLK_SZ * NUM_BLOCKS,
-		      "Expected %zu free bytes, not %zu\n",
+		      "Expected %u free bytes, not %zu\n",
 		      BLK_SZ * NUM_BLOCKS, stats.free_bytes);
 	zassert_equal(stats.allocated_bytes, 0,
-		      "Expected %zu allocated bytes, not %zu\n",
+		      "Expected %u allocated bytes, not %zu\n",
 		      0, stats.allocated_bytes);
 	zassert_equal(stats.max_allocated_bytes, 2 * BLK_SZ,
-		      "Expected %zu max allocated bytes, not %zu\n",
+		      "Expected %u max allocated bytes, not %zu\n",
 		      2 * BLK_SZ, stats.max_allocated_bytes);
 }
 

--- a/tests/lib/sprintf/src/main.c
+++ b/tests/lib/sprintf/src/main.c
@@ -282,7 +282,7 @@ ZTEST(sprintf, test_sprintf_double)
 	var.d = 0x1p800;
 	sprintf(buffer, "%.140f", var.d);
 	zassert_true((strlen(buffer) == 382),
-		     "sprintf(<large output>) - incorrect length %d\n",
+		     "sprintf(<large output>) - incorrect length %zu\n",
 		     strlen(buffer));
 	buffer[10] = 0;  /* log facility doesn't support %.10s */
 	zassert_true((strcmp(buffer, "6668014432") == 0),
@@ -297,7 +297,7 @@ ZTEST(sprintf, test_sprintf_double)
 	/* 3.872E-121 expressed as " 0.0...387" */
 	sprintf(buffer, "% .380f", var.d);
 	zassert_true((strlen(buffer) == 383),
-		     "sprintf(<large output>) - incorrect length %d\n",
+		     "sprintf(<large output>) - incorrect length %zu\n",
 		     strlen(buffer));
 	zassert_equal(strncmp(&buffer[119], "00003872", 8), 0,
 		      "sprintf(<large output>) - misplaced value\n");


### PR DESCRIPTION
Use `%zu` format specifier for `size_t` type (return type of `strlen`) to ensure compatibility with both 32-bit and 64-bit platforms.

Part of: https://github.com/zephyrproject-rtos/zephyr/issues/96968