### PR TITLE
LVGL rotation for mono displays

### DIFF
--- a/modules/lvgl/lvgl_display_mono.c
+++ b/modules/lvgl/lvgl_display_mono.c
@@ -9,6 +9,9 @@
 #include <string.h>
 #include "lvgl_display.h"
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(lvgl_display_mono, CONFIG_DISPLAY_LOG_LEVEL);
+
 #define COLOR_PALETTE_HEADER_SIZE (8)
 
 static uint8_t *mono_conv_buf;
@@ -49,6 +52,17 @@ static ALWAYS_INLINE void set_px_at_pos(uint8_t *dst_buf, uint32_t x, uint32_t y
 #endif
 }
 
+#define SET_BUFFER_PIXELS(X, Y, W)                                                                 \
+	for (uint32_t y = 0; y < height; y++) {                                                    \
+		for (uint32_t x = 0; x < width; x++) {                                             \
+			uint32_t bit_idx = x + y * stride;                                         \
+			uint8_t src_bit = (src_buf[bit_idx / 8] >> (7 - (bit_idx % 8))) & 1;       \
+			if (src_bit) {                                                             \
+				set_px_at_pos(mono_conv_buf, X, Y, W, caps);                       \
+			}                                                                          \
+		}                                                                                  \
+	}
+
 static void lvgl_transform_buffer(uint8_t **px_map, uint32_t width, uint32_t height,
 				  const struct display_capabilities *caps)
 {
@@ -67,19 +81,29 @@ static void lvgl_transform_buffer(uint8_t **px_map, uint32_t width, uint32_t hei
 	uint32_t stride = (width + CONFIG_LV_DRAW_BUF_STRIDE_ALIGN - 1) &
 			  ~(CONFIG_LV_DRAW_BUF_STRIDE_ALIGN - 1);
 
-	for (uint32_t y = 0; y < height; y++) {
-		for (uint32_t x = 0; x < width; x++) {
-			uint32_t bit_idx = x + y * stride;
-			uint8_t src_bit = (src_buf[bit_idx / 8] >> (7 - (bit_idx % 8))) & 1;
-
-			if (src_bit) {
-				set_px_at_pos(mono_conv_buf, x, y, width, caps);
-			}
-		}
+	uint32_t right = width - 1;
+	uint32_t bottom = height - 1;
+	switch (caps->current_orientation) {
+	default:
+		SET_BUFFER_PIXELS(x, y, width)
+		break;
+	case DISPLAY_ORIENTATION_ROTATED_180:
+		SET_BUFFER_PIXELS(right - x, bottom - y, width)
+		break;
+	case DISPLAY_ORIENTATION_ROTATED_90:
+		SET_BUFFER_PIXELS(bottom - y, x, height)
+		break;
+	case DISPLAY_ORIENTATION_ROTATED_270:
+		/* if display's height is not multiple of 8 `px_map`'s witdh could be larger */
+		right = MIN(width, caps->y_resolution) - 1;
+		SET_BUFFER_PIXELS(y, right - x, height)
+		break;
 	}
 
 	memcpy(src_buf, mono_conv_buf, mono_conv_buf_size - COLOR_PALETTE_HEADER_SIZE);
 }
+
+#undef SET_BUFFER_PIXELS
 
 void lvgl_flush_cb_mono(lv_display_t *display, const lv_area_t *area, uint8_t *px_map)
 {
@@ -89,6 +113,9 @@ void lvgl_flush_cb_mono(lv_display_t *display, const lv_area_t *area, uint8_t *p
 	const struct device *display_dev = data->display_dev;
 	const bool is_epd = data->cap.screen_info & SCREEN_INFO_EPD;
 	const bool is_last = lv_display_flush_is_last(display);
+
+	LOG_DBG("area = (%d,%d)(%d,%d), rotation = %d", area->x1, area->y1, area->x2, area->y2,
+		data->cap.current_orientation * 90);
 
 	lvgl_transform_buffer(&px_map, w, h, &data->cap);
 
@@ -103,17 +130,45 @@ void lvgl_flush_cb_mono(lv_display_t *display, const lv_area_t *area, uint8_t *p
 		data->blanking_on = true;
 	}
 
+	const bool sideways = data->cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_90 ||
+			      data->cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_270;
+
 	struct display_buffer_descriptor desc = {
 		.buf_size = (w * h) / 8U,
-		.width = w,
-		.pitch = w,
-		.height = h,
+		.width = sideways ? h : w,
+		.pitch = sideways ? h : w,
+		/*
+		 * We may have more lines in the buffer than on the display
+		 * if the display's height isn't a multiple of 8.
+		 */
+		.height = MIN(sideways ? w : h, data->cap.y_resolution),
 		.frame_incomplete = !is_last,
 	};
 
-	display_write(display_dev, area->x1, area->y1, &desc, (void *)px_map);
+	uint16_t x, y;
+	switch (data->cap.current_orientation) {
+	default:
+		x = area->x1;
+		y = area->y1;
+		break;
+	case DISPLAY_ORIENTATION_ROTATED_180:
+		x = data->cap.x_resolution - 1 - area->x2;
+		y = data->cap.y_resolution - 1 - area->y2;
+		break;
+	case DISPLAY_ORIENTATION_ROTATED_90:
+		x = data->cap.x_resolution - 1 - area->y2;
+		y = area->x1;
+		break;
+	case DISPLAY_ORIENTATION_ROTATED_270:
+		x = area->y1;
+		/* if display's height is not multiple of 8 `px_map`'s witdh could be larger */
+		y = MAX(w, data->cap.y_resolution) - 1 - area->x2;
+		break;
+	}
+
+	display_write(display_dev, x, y, &desc, (void *)px_map);
 	if (data->cap.screen_info & SCREEN_INFO_DOUBLE_BUFFER) {
-		display_write(display_dev, area->x1, area->y1, &desc, (void *)px_map);
+		display_write(display_dev, x, y, &desc, (void *)px_map);
 	}
 
 	if (is_epd && is_last && data->blanking_on) {
@@ -134,17 +189,50 @@ void lvgl_rounder_cb_mono(lv_event_t *e)
 	lv_display_t *display = lv_event_get_user_data(e);
 	struct lvgl_disp_data *data = (struct lvgl_disp_data *)lv_display_get_user_data(display);
 
-	if (data->cap.screen_info & SCREEN_INFO_X_ALIGNMENT_WIDTH) {
-		area->x1 = 0;
-		area->x2 = data->cap.x_resolution - 1;
+	/*
+	 * Should this update be done in a callback on `LV_EVENT_RESOLUTION_CHANGED`?
+	 * Or should we not change `current_orientation` at all and call `lv_display_get_rotation()`
+	 * directly here and in `lvgl_flush_cb_mono`?
+	 */
+	data->cap.current_orientation = lv_display_get_rotation(display);
+
+	LOG_DBG("area = (%d,%d)(%d,%d), rotation = %d", area->x1, area->y1, area->x2, area->y2,
+		data->cap.current_orientation * 90);
+
+	if (data->cap.current_orientation == DISPLAY_ORIENTATION_NORMAL ||
+	    data->cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_180) {
+		if (data->cap.screen_info & SCREEN_INFO_X_ALIGNMENT_WIDTH) {
+			area->x1 = 0;
+			area->x2 = data->cap.x_resolution - 1;
+		} else {
+			area->x1 &= ~0x7;
+			area->x2 |= 0x7;
+			if (data->cap.screen_info & SCREEN_INFO_MONO_VTILED) {
+				area->y1 &= ~0x7;
+				area->y2 |= 0x7;
+			}
+		}
 	} else {
-		area->x1 &= ~0x7;
-		area->x2 |= 0x7;
-		if (data->cap.screen_info & SCREEN_INFO_MONO_VTILED) {
+		/*
+		 * Display is "sideways" so X and Y axes will be swapped
+		 */
+		if (data->cap.screen_info & SCREEN_INFO_X_ALIGNMENT_WIDTH) {
+			/*
+			 * Extend LVGL area's _height_ to match display's _width_.
+			 */
+			area->y1 = 0;
+			area->y2 = data->cap.x_resolution - 1;
+		} else {
 			area->y1 &= ~0x7;
 			area->y2 |= 0x7;
+			if (data->cap.screen_info & SCREEN_INFO_MONO_VTILED) {
+				area->x1 &= ~0x7;
+				area->x2 |= 0x7;
+			}
 		}
 	}
+
+	LOG_DBG("rounded area = (%d,%d)(%d,%d)", area->x1, area->y1, area->x2, area->y2);
 }
 
 void lvgl_set_mono_conversion_buffer(uint8_t *buffer, uint32_t buffer_size)

--- a/samples/subsys/display/lvgl/Kconfig
+++ b/samples/subsys/display/lvgl/Kconfig
@@ -10,3 +10,8 @@ config RESET_COUNTER_SW0
 	depends on $(dt_alias_enabled,sw0)
 	select GPIO
 	default y
+
+config ROTATE_DISPLAY_ON_RESET_COUNTER
+	bool "Rotate LVGL display 90 degrees when counter is reset"
+	depends on RESET_COUNTER_SW0
+	default n

--- a/samples/subsys/display/lvgl/src/main.c
+++ b/samples/subsys/display/lvgl/src/main.c
@@ -144,7 +144,28 @@ int main(void)
 	lv_timer_handler();
 	display_blanking_off(display_dev);
 
+#ifdef CONFIG_ROTATE_DISPLAY_ON_RESET_COUNTER
+	lv_style_t hello_world_label_style;
+	lv_style_init(&hello_world_label_style);
+	lv_obj_add_style(hello_world_label, &hello_world_label_style, LV_PART_MAIN);
+	uint32_t resets = 0;
+#endif /* CONFIG_ROTATE_DISPLAY_ON_RESET_COUNTER */
+
 	while (1) {
+#ifdef CONFIG_ROTATE_DISPLAY_ON_RESET_COUNTER
+		if (count == 0U) {
+			if (resets > 0U) {
+				lv_display_t *display = lv_display_get_default();
+				lv_disp_set_rotation(display,
+						     (lv_display_get_rotation(display) + 1) % 4);
+				lv_style_set_max_width(
+					&hello_world_label_style,
+					lv_display_get_horizontal_resolution(display));
+			}
+			++resets;
+		}
+#endif /* CONFIG_ROTATE_DISPLAY_ON_RESET_COUNTER */
+
 		if ((count % 100) == 0U) {
 			sprintf(count_str, "%d", count/100U);
 			lv_label_set_text(count_label, count_str);


### PR DESCRIPTION
Hello, I'm new to Zephyr and I'm trying to get LVGL display rotation implemented so we can use it on tiny 1bit screens for keyboards over at ZMK.

I've extended the existing buffer copy/transformation operations in `modules/lvgl/lvgl_display_mono.c` to take `lv_display_get_rotation()` into account.

I've also extended the `subsys/display/lvgl` sample so it can (optionally, through a config variable) call `lv_display_set_rotation()` when the `sw0` button is pressed to demonstrate the effect. I'm not sure that's the best way to do it however.

Please advise on whether these changes are the right way to go about this issue.

<details>
  <summary>Videos of the result</summary>
Here's the result running on a Sharp LS011B7DH03 display (via ZMK):

https://github.com/user-attachments/assets/cb9d86ce-56dc-4dfb-8018-f723d29cf56a

and here's the modified sample running on a random `ssd1306` display (`xiao_ble` board and [a breadboarded version of] `seeed_xiao_expansion_board` shield):

https://github.com/user-attachments/assets/408772d0-5e56-4195-b56e-2d3a4691831f
</details>