### PR TITLE
posix: Reintroduce legacy time.h and signal.h headers with warnings

### DIFF
--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Space Cubics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_POSIX_SIGNAL_H_
+#define ZEPHYR_INCLUDE_POSIX_SIGNAL_H_
+
+# warning "Since Zephyr v4.3, don't use <zephyr/posix/signal.h> directly; include <signal.h> instead."
+#include_next <signal.h>
+
+#endif /* ZEPHYR_INCLUDE_POSIX_SIGNAL_H_ */

--- a/include/zephyr/posix/time.h
+++ b/include/zephyr/posix/time.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Space Cubics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_POSIX_TIME_H_
+#define ZEPHYR_INCLUDE_POSIX_TIME_H_
+
+# warning "Since Zephyr v4.3, don't use <zephyr/posix/time.h> directly; include <time.h> instead."
+#include_next <time.h>
+
+#endif /* ZEPHYR_INCLUDE_POSIX_TIME_H_ */


### PR DESCRIPTION
Commit 5cbb2a421d95 ("posix: switch to using posix_time.h and posix_signal.h") removed `<zephyr/posix/time.h>` and `<zephyr/posix/signal.h>` in favor of standard `<time.h>` and `<signal.h>`.  However, this was a hard cut-over. Users including the old headers now encounter build errors without guidance on how to resolve them.

Reintroduce `<zephyr/posix/time.h>` and `<zephyr/posix/signal.h>` as stubs that emit compile-time warnings and include their corresponding standard headers. This helps users migrate smoothly by providing actionable diagnostics.

ref)
- #95226
- #96911