### PR TITLE
openthread: platform: radio_spinel: Spinel variables on global memory

### DIFF
--- a/modules/openthread/platform/radio_spinel.cpp
+++ b/modules/openthread/platform/radio_spinel.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2021, The OpenThread Authors.
- *  Copyright (c) 2022-2024, NXP.
+ *  Copyright (c) 2022-2025, NXP.
  *
  *  All rights reserved.
  *
@@ -46,6 +46,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_OPENTHREAD_PLATFORM_LOG_LEVEL);
 #include <zephyr/kernel.h>
 #include <zephyr/net/net_pkt.h>
 #include <openthread-system.h>
+#include <stdalign.h>
+#include <common/new.hpp>
 
 enum pending_events {
 	PENDING_EVENT_FRAME_TO_SEND, /* There is a tx frame to send  */
@@ -59,6 +61,11 @@ static ot::Spinel::RadioSpinel *psRadioSpinel;
 static ot::Url::Url *psRadioUrl;
 static ot::Hdlc::HdlcInterface *pSpinelInterface;
 static ot::Spinel::SpinelDriver *psSpinelDriver;
+
+alignas(ot::Spinel::RadioSpinel) static uint8_t gRadioBuf[sizeof(ot::Spinel::RadioSpinel)];
+alignas(ot::Url::Url) static uint8_t gUrlBuf[sizeof(ot::Url::Url)];
+alignas(ot::Hdlc::HdlcInterface) static uint8_t gIfaceBuf[sizeof(ot::Hdlc::HdlcInterface)];
+alignas(ot::Spinel::SpinelDriver) static uint8_t gDriverBuf[sizeof(ot::Spinel::SpinelDriver)];
 
 static const otRadioCaps sRequiredRadioCaps =
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
@@ -527,11 +534,11 @@ extern "C" void platformRadioInit(void)
 
 	iidList[0] = 0;
 
-	psRadioSpinel = new ot::Spinel::RadioSpinel();
-	psSpinelDriver = new ot::Spinel::SpinelDriver();
+	psRadioSpinel = new(gRadioBuf) ot::Spinel::RadioSpinel();
+	psSpinelDriver = new(gDriverBuf) ot::Spinel::SpinelDriver();
 
-	psRadioUrl = new ot::Url::Url();
-	pSpinelInterface = new ot::Hdlc::HdlcInterface(*psRadioUrl);
+	psRadioUrl = new(gUrlBuf) ot::Url::Url();
+	pSpinelInterface = new(gIfaceBuf) ot::Hdlc::HdlcInterface(*psRadioUrl);
 
 	OT_UNUSED_VARIABLE(psSpinelDriver->Init(*pSpinelInterface, true /* aSoftwareReset */,
 						iidList, OT_ARRAY_LENGTH(iidList)));


### PR DESCRIPTION
This commit aims to move spinel related variables from heap to global arrays. Main reason behind this decision is that spinel variables are required for the entire lifetime of application.
In this way, HEAP_MEM_POOL_ADD_SIZE_ does not need to be defined, or updated, if any change in data structure might occur.