### PR TITLE
libc: picolibc: full path to toolchain `picolibc.specs`

### DIFF
--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -19,12 +19,30 @@ zephyr_library_compile_options($<TARGET_PROPERTY:compiler,prohibit_lto>)
 zephyr_compile_definitions(__LINUX_ERRNO_EXTENSIONS__)
 
 if(NOT CONFIG_PICOLIBC_USE_MODULE)
+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    # Ask the compiler for the real path to `picolibc.specs`
+    # ccache always fails to cache calls without a full path with the following
+    # internal log error:
+    #   [timestamp] Trying direct lookup
+    #   [timestamp] Failed to lstat picolibc.specs: No such file or directory
+    #   [timestamp] While processing -specs=picolibc.specs: picolibc.specs is missing
+    #   [timestamp] Failed; falling back to running the real compiler
+    execute_process(
+      COMMAND ${CMAKE_C_COMPILER} -print-file-name=picolibc.specs
+      OUTPUT_VARIABLE specs_file
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    # Normalise the path for clarity
+    get_filename_component(specs_file "${specs_file}" REALPATH)
+  else()
+    set(specs_file picolibc.specs)
+  endif()
 
   # Use picolibc provided with the toolchain. This requires a new enough
   # toolchain so that the version of picolibc supports auto-detecting a
   # Zephyr build (via the __ZEPHYR__ macro) to expose the Zephyr C API
-  zephyr_compile_options(PROPERTY specs picolibc.specs)
-  zephyr_link_libraries(PROPERTY specs picolibc.specs)
+  zephyr_compile_options(PROPERTY specs ${specs_file})
+  zephyr_link_libraries(PROPERTY specs ${specs_file})
   if(CONFIG_PICOLIBC_IO_FLOAT)
     zephyr_compile_definitions(PICOLIBC_DOUBLE_PRINTF_SCANF)
     zephyr_link_libraries(-DPICOLIBC_DOUBLE_PRINTF_SCANF)


### PR DESCRIPTION
For compilers that are known to expose the `-print-file-name` argument, query the compiler for the full path to the `picolibc.spec` file that is used for the `--specs=` argument.

The use of the relative `picolibc.spec` filename in the compiler arguments causes `ccache` to immediately give up on attempting to cache the compiler call, with internal debug errors like this:
```
Trying direct lookup
Failed to lstat picolibc.specs: No such file or directory
While processing -specs=picolibc.specs: picolibc.specs is missing
Failed; falling back to running the real compiler
```

In practice, this makes ccache unavailable for any application/test that uses the Zephyr SDK picolibc module.

A more general solution than implemented in d3f9f391, which only fixes the twister CI action (and codecov/clang actions in other commits).