### PR TITLE
scripts: pylib: twister: `--runtime-artifact-cleanup none`

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -572,11 +572,12 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
                         help="Specify a file where to save logs.")
 
     parser.add_argument(
-        "-M", "--runtime-artifact-cleanup", choices=['pass', 'all'],
+        "-M", "--runtime-artifact-cleanup", choices=['pass', 'all', 'none'],
         default=None, const='pass', nargs='?',
         help="""Cleanup test artifacts. The default behavior is 'pass'
         which only removes artifacts of passing tests. If you wish to
-        remove all artificats including those of failed tests, use 'all'.""")
+        remove all artificats including those of failed tests, use 'all'.
+        To remove no artifacts, use `none`.""")
 
     parser.add_argument(
         "--keep-artifacts", action="append", default=[],

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1285,6 +1285,8 @@ class ProjectBuilder(FilterBuilder):
 
 
     def cleanup_artifacts(self, additional_keep: list[str] = None):
+        if self.options.runtime_artifact_cleanup == 'none':
+            return
         if additional_keep is None:
             additional_keep = []
         logger.debug(f"Cleaning up {self.instance.build_dir}")

--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -1122,7 +1122,7 @@ __comp_west_twister()
 		        ;;
 
 		--runtime-artifact-cleanup|-M)
-		        __set_comp "all pass"
+		        __set_comp "all pass none"
 			return
 		        ;;
 


### PR DESCRIPTION
Add an option to never cleanup any runtime artifacts after a twister testcase. This can simplify diagnosing issues on small runs, by allowing inspection of all files without needing to previously know their paths.