### PR TITLE
Boards: STM32H750B-DK: Introduce App in Ext Flash variant

### DIFF
--- a/boards/st/stm32h750b_dk/Kconfig.sysbuild
+++ b/boards/st/stm32h750b_dk/Kconfig.sysbuild
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_STM32H750B_DK_STM32H750XX_EXT_FLASH_APP
+
+choice BOOTLOADER
+	default BOOTLOADER_MCUBOOT
+endchoice
+
+choice BOOT_SIGNATURE_TYPE
+	default BOOT_SIGNATURE_TYPE_NONE
+endchoice
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_SWAP_USING_OFFSET
+endchoice
+
+endif # BOARD_STM32H750B_DK_STM32H750XX_EXT_FLASH_APP

--- a/boards/st/stm32h750b_dk/board.cmake
+++ b/boards/st/stm32h750b_dk/board.cmake
@@ -1,11 +1,10 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # keep first
-if(CONFIG_STM32_MEMMAP)
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
-board_runner_args(stm32cubeprogrammer "--extload=MT25TL01G_STM32H750B-DISCO.stldr")
-else()
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw" )
+if(CONFIG_STM32_MEMMAP OR CONFIG_BOOTLOADER_MCUBOOT)
+  board_runner_args(stm32cubeprogrammer "--extload=MT25TL01G_STM32H750B-DISCO.stldr")
 endif()
 
 board_runner_args(jlink "--device=STM32H735IG" "--speed=4000")

--- a/boards/st/stm32h750b_dk/board.yml
+++ b/boards/st/stm32h750b_dk/board.yml
@@ -4,3 +4,5 @@ board:
   vendor: st
   socs:
     - name: stm32h750xx
+      variants:
+        - name: ext_flash_app

--- a/boards/st/stm32h750b_dk/doc/index.rst
+++ b/boards/st/stm32h750b_dk/doc/index.rst
@@ -72,16 +72,10 @@ Programming and Debugging
 STM32H750B Discovery kit includes an ST-LINK-V3E embedded debug tool interface.
 This probe allows flashing and debugging the board using various tools.
 
-See :ref:`build_an_application` for more information about application builds.
-
-
-Flashing
-========
-
 The board is configured to be flashed using west `STM32CubeProgrammer`_ runner,
 so its :ref:`installation <stm32cubeprog-flash-host-tools>` is required.
 
-Alternatively, OpenOCD or JLink can also be used to flash the board using
+Alternatively, OpenOCD or JLink can also be used to write app to the SoC Flash using
 the ``--runner`` (or ``-r``) option:
 
 .. code-block:: console
@@ -89,8 +83,15 @@ the ``--runner`` (or ``-r``) option:
    $ west flash --runner openocd
    $ west flash --runner jlink
 
-Flashing an application to STM32H750B_DK
-----------------------------------------
+Application in SoC Flash
+========================
+
+Here is an example for how to build and flash the :zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32h750b_dk
+   :goals: build flash
 
 Connect the STM32H750B-DK to your host computer using the ST-LINK
 USB port, then run a serial host program to connect with the board. For example:
@@ -99,23 +100,18 @@ USB port, then run a serial host program to connect with the board. For example:
 
    $ minicom -b 115200 -D /dev/ttyACM0
 
-You can then build and flash applications in the usual way.
-Here is an example for the :zephyr:code-sample:`hello_world` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: stm32h750b_dk
-   :goals: build flash
-
 You should see the following message in the serial host program:
 
 .. code-block:: console
 
    $ Hello World! stm32h750b_dk
 
+If the application size is too big to fit in SoC Flash,
+Zephyr :ref:`Code and Data Relocation <code_data_relocation>` can be used to relocate
+the non-critical and big parts of the application to external Flash.
 
 Debugging
-=========
+---------
 
 You can debug an application in the usual way.  Here is an example for the
 :zephyr:code-sample:`hello_world` application.
@@ -124,6 +120,95 @@ You can debug an application in the usual way.  Here is an example for the
    :zephyr-app: samples/hello_world
    :board: stm32h750b_dk
    :goals: debug
+
+Application in External Flash
+=============================
+
+Because of the limited amount of SoC Flash (128KB), you may want to store the application
+in external QSPI Flash instead, and run it from there. In that case, the MCUboot bootloader
+is needed to chainload the application. A dedicate board variant, ``ext_flash_app``, was created
+for this usecase.
+
+:ref:`sysbuild` makes it possible to build and flash all necessary images needed to run a user application
+from external Flash.
+
+The following example shows how to build :zephyr:code-sample:`hello_world` with Sysbuild enabled:
+
+.. zephyr-app-commands::
+   :tool: west
+   :zephyr-app: samples/hello_world
+   :board: stm32h750b_dk/stm32h750xx/ext_flash_app
+   :goals: build
+   :west-args: --sysbuild
+
+By default, Sysbuild creates MCUboot and user application images.
+
+Build directory structure created by Sysbuild is different from traditional
+Zephyr build. Output is structured by the domain subdirectories:
+
+.. code-block::
+
+  build/
+  ├── hello_world
+  |    └── zephyr
+  │       ├── zephyr.elf
+  │       ├── zephyr.hex
+  │       ├── zephyr.bin
+  │       ├── zephyr.signed.bin
+  │       └── zephyr.signed.hex
+  ├── mcuboot
+  │    └── zephyr
+  │       ├── zephyr.elf
+  │       ├── zephyr.hex
+  │       └── zephyr.bin
+  └── domains.yaml
+
+.. note::
+
+   With ``--sysbuild`` option, MCUboot will be re-built every time the pristine build is used,
+   but only needs to be flashed once if none of the MCUboot configs are changed.
+
+For more information about the system build please read the :ref:`sysbuild` documentation.
+
+Both MCUboot and user application images can be flashed by running:
+
+.. code-block:: console
+
+   $ west flash
+
+You should see the following message in the serial host program:
+
+.. code-block:: console
+
+   *** Booting MCUboot v2.2.0-173-gb192716c969a ***
+   *** Using Zephyr OS build v4.2.0-6260-ge39ba1a35bc4 ***
+   I: Starting bootloader
+   I: Image index: 0, Swap type: none
+   I: Image index: 0, Swap type: none
+   I: Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
+   I: Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
+   I: Boot source: none
+   I: Image index: 0, Swap type: none
+   I: Image index: 0, Swap type: none
+   I: Image index: 0, Swap type: none
+   I: Image index: 0, Swap type: none
+   I: Bootloader chainload address offset: 0x0
+   I: Image version: v0.0.0
+   I: Jumping to the first image slot
+   *** Booting Zephyr OS build v4.2.0-6260-ge39ba1a35bc4 ***
+   Hello World! stm32h750b_dk/stm32h750xx/ext_flash_app
+
+To only flash the user application in the subsequent builds, Use:
+
+.. code-block:: console
+
+   $ west flash --domain hello_world
+
+With the default configuration, the board uses MCUboot's Swap-using-offset mode.
+To get more information about the different MCUboot operating modes and how to
+perform application upgrade, refer to `MCUboot design`_.
+To learn more about how to secure the application images stored in external Flash,
+refer to `MCUboot Encryption`_.
 
 
 .. _STM32H750B-DK website:
@@ -140,3 +225,9 @@ You can debug an application in the usual way.  Here is an example for the
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html
+
+.. _MCUboot design:
+   https://docs.mcuboot.com/design.html
+
+.. _MCUboot Encryption:
+   https://docs.mcuboot.com/encrypted_images.html

--- a/boards/st/stm32h750b_dk/stm32h750b_dk-common.dtsi
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk-common.dtsi
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2023-2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/h7/stm32h750Xb.dtsi>
+#include <st/h7/stm32h750xbhx-pinctrl.dtsi>
+#include "arduino_r3_connector.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	chosen {
+		zephyr,console = &usart3;
+		zephyr,shell-uart = &usart3;
+		zephyr,sram = &sram0;
+		zephyr,display = &ltdc;
+	};
+
+	sdram2: sdram@d0000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		device_type = "memory";
+		reg = <0xd0000000 DT_SIZE_M(16)>; /* 128Mbit */
+		zephyr,memory-region = "SDRAM2";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
+	};
+
+	ext_flash_mem: memory@90000000 {
+		compatible = "zephyr,memory-region";
+		reg = <0x90000000 DT_SIZE_M(128)>; /* 128MB */
+		zephyr,memory-region = "EXT_FLASH";
+		zephyr,memory-attr = <DT_MEM_ARM_MPU_FLASH>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		red_led: led_1 {
+			gpios = <&gpioi 13 GPIO_ACTIVE_LOW>;
+			label = "USER1 LD6";
+		};
+
+		green_led: led_2 {
+			gpios = <&gpioj 2 GPIO_ACTIVE_LOW>;
+			label = "USER2 LD7";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+
+		user_button: button {
+			label = "User";
+			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+
+	aliases {
+		led0 = &green_led;
+		led1 = &red_led;
+		sw0 = &user_button;
+		die-temp0 = &die_temp;
+	};
+};
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(25)>;
+	hse-bypass;
+	status = "okay";
+};
+
+&clk_lse {
+	status = "okay";
+};
+
+&flash0 {
+	status = "okay";
+};
+
+&ltdc {
+	pinctrl-0 = <&ltdc_r0_pi15 &ltdc_r1_pj0 &ltdc_r2_pj1 &ltdc_r3_ph9
+		     &ltdc_r4_pj3 &ltdc_r5_pj4 &ltdc_r6_pj5 &ltdc_r7_pj6
+		     &ltdc_g0_pj7 &ltdc_g1_pj8 &ltdc_g2_pj9 &ltdc_g3_pj10
+		     &ltdc_g4_pj11 &ltdc_g5_pi0 &ltdc_g6_pi1 &ltdc_g7_pk2
+		     &ltdc_b0_pj12 &ltdc_b1_pj13 &ltdc_b2_pj14 &ltdc_b3_pj15
+		     &ltdc_b4_pk3 &ltdc_b5_pk4 &ltdc_b6_pk5 &ltdc_b7_pk6
+		     &ltdc_de_pk7 &ltdc_clk_pi14 &ltdc_hsync_pi12 &ltdc_vsync_pi9>;
+	pinctrl-names = "default";
+
+	disp-on-gpios = <&gpiod 7 GPIO_ACTIVE_HIGH>;
+
+	ext-sdram = <&sdram2>;
+	status = "okay";
+
+	clocks = <&rcc STM32_CLOCK(APB3, 3)>,
+		 <&rcc STM32_SRC_PLL3_R NO_SEL>;
+
+	width = <480>;
+	height = <272>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+
+	display-timings {
+		compatible = "zephyr,panel-timing";
+		de-active = <1>;
+		pixelclk-active = <0>;
+		hsync-active = <0>;
+		vsync-active = <0>;
+		hsync-len = <1>;
+		vsync-len = <10>;
+		hback-porch = <43>;
+		vback-porch = <12>;
+		hfront-porch = <8>;
+		vfront-porch = <4>;
+	};
+
+	def-back-color-red = <0xFF>;
+	def-back-color-green = <0xFF>;
+	def-back-color-blue = <0xFF>;
+};
+
+&pll {
+	div-m = <5>;
+	mul-n = <192>;
+	div-p = <2>;
+	div-q = <4>;
+	div-r = <4>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&pll3 {
+	div-m = <5>;
+	mul-n = <192>;
+	div-p = <2>;
+	div-q = <20>;
+	div-r = <99>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(480)>;
+	d1cpre = <1>;
+	hpre = <2>;
+	d1ppre = <2>;
+	d2ppre1 = <2>;
+	d2ppre2 = <2>;
+	d3ppre = <2>;
+};
+
+&usart3 {
+	pinctrl-0 = <&usart3_tx_pb10 &usart3_rx_pb11>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&quadspi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&quadspi_clk_pf10 &quadspi_bk1_ncs_pg6
+		     &quadspi_bk1_io0_pd11 &quadspi_bk1_io1_pf9
+		     &quadspi_bk1_io2_pf7 &quadspi_bk1_io3_pf6
+		     &quadspi_bk2_io0_ph2 &quadspi_bk2_io1_ph3
+		     &quadspi_bk2_io2_pg9 &quadspi_bk2_io3_pg14>;
+	/*
+	 * Two MT25QL512AB NOR Flash chips connected to QSPI in parallel
+	 * and accessed simultaneously, 4bits sent to/received from each.
+	 */
+	dual-flash;
+	status = "okay";
+
+	ext_flash_ctrl: qspi-flash-controller@0 {
+		compatible = "st,stm32-qspi-nor";
+		reg = <0>;
+		size = <DT_SIZE_M(512)>; /* 64MB for each Flash */
+		qspi-max-frequency = <72000000>;
+		cs-high-time = <4>; /* >= 50 ns */
+		spi-bus-width = <4>;
+		reset-cmd;
+		status = "okay";
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x90000000 DT_SIZE_M(128)>; /* Ext Flash mem-mapped to 0x90000000 */
+
+		/* Sector erase 64KB uniform granularity for each Flash */
+		/* Subsector erase 4KB, 32KB granularity for each Flash */
+		ext_flash: mt25ql512ab: ext-flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(128)>; /* 128MB total in dual-flash mode */
+			write-block-size = <1>; /* 1byte=4bits*2 in dual-flash mode */
+			erase-block-size = <DT_SIZE_K(8)>; /* 4KB*2 in dual-flash mode */
+
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+			};
+		};
+	};
+};
+
+&fmc {
+	pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1
+		     &fmc_sdclk_pg8 &fmc_sdnwe_ph5 &fmc_sdcke1_ph7
+		     &fmc_sdne1_ph6 &fmc_sdnras_pf11 &fmc_sdncas_pg15
+		     &fmc_a0_pf0 &fmc_a1_pf1 &fmc_a2_pf2 &fmc_a3_pf3 &fmc_a4_pf4
+		     &fmc_a5_pf5 &fmc_a6_pf12 &fmc_a7_pf13 &fmc_a8_pf14
+		     &fmc_a9_pf15 &fmc_a10_pg0 &fmc_a11_pg1
+		     &fmc_a14_pg4 &fmc_a15_pg5 &fmc_d0_pd14 &fmc_d1_pd15
+		     &fmc_d2_pd0 &fmc_d3_pd1 &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9
+		     &fmc_d7_pe10 &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13
+		     &fmc_d11_pe14 &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9
+		     &fmc_d15_pd10>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	sdram {
+		status = "okay";
+		power-up-delay = <100>;
+		num-auto-refresh = <8>;
+		mode-register = <0x230>;
+		refresh-rate = <0x603>;
+
+		bank@1 {
+			reg = <1>;
+			st,sdram-control = <STM32_FMC_SDRAM_NC_8
+					    STM32_FMC_SDRAM_NR_12
+					    STM32_FMC_SDRAM_MWID_16
+					    STM32_FMC_SDRAM_NB_4
+					    STM32_FMC_SDRAM_CAS_3
+					    STM32_FMC_SDRAM_SDCLK_PERIOD_2
+					    STM32_FMC_SDRAM_RBURST_ENABLE
+					    STM32_FMC_SDRAM_RPIPE_1>;
+			st,sdram-timing = <2 7 4 7 2 2 2>;
+		};
+	};
+};
+
+&rtc {
+	clocks = <&rcc STM32_CLOCK(APB4, 16)>,
+		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
+	status = "okay";
+};
+
+&die_temp {
+	status = "okay";
+};
+
+&adc3 {
+	st,adc-clock-source = "SYNC";
+	st,adc-prescaler = <4>;
+	status = "okay";
+};
+
+/* Arduino Header pins: Tx:D1, Rx:D0 */
+/* LPUART1 can also be used with this pins */
+&usart1 {
+	dma-names = "tx", "rx";
+	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pb7>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -5,288 +5,29 @@
  */
 
 /dts-v1/;
-#include <st/h7/stm32h750Xb.dtsi>
-#include <st/h7/stm32h750xbhx-pinctrl.dtsi>
-#include "arduino_r3_connector.dtsi"
-#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include "stm32h750b_dk-common.dtsi"
 
 / {
 	model = "STMicroelectronics STM32H750B DISCOVERY KIT";
 	compatible = "st,stm32h750b-dk";
 
 	chosen {
-		zephyr,console = &usart3;
-		zephyr,shell-uart = &usart3;
-		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,flash-controller = &mt25ql512ab1;
-		zephyr,display = &ltdc;
-		zephyr,code-partition = &slot0_partition;
-	};
-
-	sdram2: sdram@d0000000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		device_type = "memory";
-		reg = <0xd0000000 DT_SIZE_M(16)>; /* 128Mbit */
-		zephyr,memory-region = "SDRAM2";
-		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
-	};
-
-	ext_memory: memory@90000000 {
-		compatible = "zephyr,memory-region";
-		reg = <0x90000000 DT_SIZE_M(256)>; /* max addressable area */
-		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
-		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		red_led: led_1 {
-			gpios = <&gpioi 13 GPIO_ACTIVE_LOW>;
-			label = "USER1 LD6";
-		};
-
-		green_led: led_2 {
-			gpios = <&gpioj 2 GPIO_ACTIVE_LOW>;
-			label = "USER2 LD7";
-		};
-	};
-
-	gpio_keys {
-		compatible = "gpio-keys";
-
-		user_button: button {
-			label = "User";
-			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
-			zephyr,code = <INPUT_KEY_0>;
-		};
-	};
-
-	aliases {
-		led0 = &green_led;
-		led1 = &red_led;
-		sw0 = &user_button;
-		die-temp0 = &die_temp;
+		zephyr,flash-controller = &flash;
 	};
 };
 
-&clk_hse {
-	clock-frequency = <DT_FREQ_M(25)>;
-	hse-bypass;
+&ext_flash {
 	status = "okay";
-};
 
-&clk_lse {
-	status = "okay";
-};
-
-&flash0 {
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Flash has 128KB sector size */
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(128)>;
+		storage_partition: partition@0 {
+			label = "storage";
+			reg = <0x00000000 DT_SIZE_M(128)>; /* 128MB */
 		};
 	};
-};
-
-&ltdc {
-	pinctrl-0 = <&ltdc_r0_pi15 &ltdc_r1_pj0 &ltdc_r2_pj1 &ltdc_r3_ph9
-		     &ltdc_r4_pj3 &ltdc_r5_pj4 &ltdc_r6_pj5 &ltdc_r7_pj6
-		     &ltdc_g0_pj7 &ltdc_g1_pj8 &ltdc_g2_pj9 &ltdc_g3_pj10
-		     &ltdc_g4_pj11 &ltdc_g5_pi0 &ltdc_g6_pi1 &ltdc_g7_pk2
-		     &ltdc_b0_pj12 &ltdc_b1_pj13 &ltdc_b2_pj14 &ltdc_b3_pj15
-		     &ltdc_b4_pk3 &ltdc_b5_pk4 &ltdc_b6_pk5 &ltdc_b7_pk6
-		     &ltdc_de_pk7 &ltdc_clk_pi14 &ltdc_hsync_pi12 &ltdc_vsync_pi9>;
-	pinctrl-names = "default";
-
-	disp-on-gpios = <&gpiod 7 GPIO_ACTIVE_HIGH>;
-
-	ext-sdram = <&sdram2>;
-	status = "okay";
-
-	clocks = <&rcc STM32_CLOCK(APB3, 3)>,
-		 <&rcc STM32_SRC_PLL3_R NO_SEL>;
-
-	width = <480>;
-	height = <272>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
-
-	display-timings {
-		compatible = "zephyr,panel-timing";
-		de-active = <1>;
-		pixelclk-active = <0>;
-		hsync-active = <0>;
-		vsync-active = <0>;
-		hsync-len = <1>;
-		vsync-len = <10>;
-		hback-porch = <43>;
-		vback-porch = <12>;
-		hfront-porch = <8>;
-		vfront-porch = <4>;
-	};
-
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
-};
-
-&pll {
-	div-m = <5>;
-	mul-n = <192>;
-	div-p = <2>;
-	div-q = <4>;
-	div-r = <4>;
-	clocks = <&clk_hse>;
-	status = "okay";
-};
-
-&pll3 {
-	div-m = <5>;
-	mul-n = <192>;
-	div-p = <2>;
-	div-q = <20>;
-	div-r = <99>;
-	clocks = <&clk_hse>;
-	status = "okay";
-};
-
-&rcc {
-	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(480)>;
-	d1cpre = <1>;
-	hpre = <2>;
-	d1ppre = <2>;
-	d2ppre1 = <2>;
-	d2ppre2 = <2>;
-	d3ppre = <2>;
-};
-
-&usart3 {
-	pinctrl-0 = <&usart3_tx_pb10 &usart3_rx_pb11>;
-	pinctrl-names = "default";
-	current-speed = <115200>;
-	status = "okay";
-};
-
-&quadspi {
-	pinctrl-names = "default";
-	pinctrl-0 = <&quadspi_clk_pf10 &quadspi_bk1_ncs_pg6
-		     &quadspi_bk1_io0_pd11 &quadspi_bk1_io1_pf9
-		     &quadspi_bk1_io2_pf7 &quadspi_bk1_io3_pf6
-		     &quadspi_bk2_io0_ph2 &quadspi_bk2_io1_ph3
-		     &quadspi_bk2_io2_pg9 &quadspi_bk2_io3_pg14>;
-	dual-flash;
-	status = "okay";
-
-	/* Sector erase 64KB uniform granularity */
-	/* Subsector erase 4KB, 32KB granularity */
-	mt25ql512ab1: qspi-nor-flash-1@0 {
-		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
-		size = <DT_SIZE_M(512)>; /* 512 Mbits */
-		qspi-max-frequency = <72000000>;
-		cs-high-time = <4>; /* >= 50 ns */
-		spi-bus-width = <4>;
-		reset-cmd;
-		status = "okay";
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			slot0_partition: partition@0 {
-				label = "image-0";
-				reg = <0x00000000 DT_SIZE_K(2048)>;
-			};
-
-			slot1_partition: partition@200000 {
-				label = "image-1";
-				reg = <0x00200000 DT_SIZE_K(2048)>;
-			};
-
-			storage_partition: partition@400000 {
-				label = "storage";
-				reg = <0x00400000 DT_SIZE_K(128)>;
-			};
-		};
-	};
-
-	mt25ql512ab2: qspi-nor-flash-2@0 {
-		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
-		size = <DT_SIZE_M(512)>; /* 512 Mbits */
-		qspi-max-frequency = <72000000>;
-		status = "okay";
-	};
-};
-
-&fmc {
-	pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1
-		     &fmc_sdclk_pg8 &fmc_sdnwe_ph5 &fmc_sdcke1_ph7
-		     &fmc_sdne1_ph6 &fmc_sdnras_pf11 &fmc_sdncas_pg15
-		     &fmc_a0_pf0 &fmc_a1_pf1 &fmc_a2_pf2 &fmc_a3_pf3 &fmc_a4_pf4
-		     &fmc_a5_pf5 &fmc_a6_pf12 &fmc_a7_pf13 &fmc_a8_pf14
-		     &fmc_a9_pf15 &fmc_a10_pg0 &fmc_a11_pg1
-		     &fmc_a14_pg4 &fmc_a15_pg5 &fmc_d0_pd14 &fmc_d1_pd15
-		     &fmc_d2_pd0 &fmc_d3_pd1 &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9
-		     &fmc_d7_pe10 &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13
-		     &fmc_d11_pe14 &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9
-		     &fmc_d15_pd10>;
-	pinctrl-names = "default";
-	status = "okay";
-
-	sdram {
-		status = "okay";
-		power-up-delay = <100>;
-		num-auto-refresh = <8>;
-		mode-register = <0x230>;
-		refresh-rate = <0x603>;
-
-		bank@1 {
-			reg = <1>;
-			st,sdram-control = <STM32_FMC_SDRAM_NC_8
-					    STM32_FMC_SDRAM_NR_12
-					    STM32_FMC_SDRAM_MWID_16
-					    STM32_FMC_SDRAM_NB_4
-					    STM32_FMC_SDRAM_CAS_3
-					    STM32_FMC_SDRAM_SDCLK_PERIOD_2
-					    STM32_FMC_SDRAM_RBURST_ENABLE
-					    STM32_FMC_SDRAM_RPIPE_1>;
-			st,sdram-timing = <2 7 4 7 2 2 2>;
-		};
-	};
-};
-
-&rtc {
-	clocks = <&rcc STM32_CLOCK(APB4, 16)>,
-		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
-	status = "okay";
-};
-
-&die_temp {
-	status = "okay";
-};
-
-&adc3 {
-	st,adc-clock-source = "SYNC";
-	st,adc-prescaler = <4>;
-	status = "okay";
-};
-
-/* Arduino Header pins: Tx:D1, Rx:D0 */
-/* LPUART1 can also be used with this pins */
-&usart1 {
-	dma-names = "tx", "rx";
-	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pb7>;
-	pinctrl-names = "default";
-	current-speed = <115200>;
-	status = "okay";
 };

--- a/boards/st/stm32h750b_dk/stm32h750b_dk_stm32h750xx_ext_flash_app.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk_stm32h750xx_ext_flash_app.dts
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include "stm32h750b_dk-common.dtsi"
+
+/ {
+	model = "STMicroelectronics STM32H750B DISCOVERY KIT";
+	compatible = "st,stm32h750b-dk";
+
+	chosen {
+		zephyr,flash = &ext_flash;
+		zephyr,flash-controller = &ext_flash_ctrl;
+		zephyr,code-partition = &slot0_partition;
+	};
+};
+
+&flash0 {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Flash has 128KB sector size */
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(128)>;
+		};
+	};
+};
+
+&ext_flash {
+	status = "okay";
+
+	partitions {
+		slot0_partition: partition@0 {
+			label = "image-0";
+			reg = <0x0 DT_SIZE_M(60)>; /* 60MB */
+		};
+
+		slot1_partition: partition@3c00000 {
+			label = "image-1";
+			reg = <0x3c00000 DT_SIZE_M(60)>;
+		};
+
+		storage_partition: partition@7800000 {
+			label = "storage";
+			reg = <0x7800000 DT_SIZE_M(8)>;
+		};
+	};
+};

--- a/boards/st/stm32h750b_dk/stm32h750b_dk_stm32h750xx_ext_flash_app.yaml
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk_stm32h750xx_ext_flash_app.yaml
@@ -1,0 +1,19 @@
+identifier: stm32h750b_dk/stm32h750xx/ext_flash_app
+name: ST STM32H750B Discovery Kit with App in Ext Flash
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+sysbuild: true
+ram: 1024
+flash: 61439  # size in kB of 1 app slot minus MCUboot header size (1KB)
+supported:
+  - arduino_gpio
+  - gpio
+  - dma
+  - flash
+  - rtc
+  - memc
+  - display
+  - spi
+vendor: st

--- a/boards/st/stm32h750b_dk/stm32h750b_dk_stm32h750xx_ext_flash_app_defconfig
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk_stm32h750xx_ext_flash_app_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 STMicroelectronics
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # Enable the internal SMPS regulator

--- a/samples/subsys/fs/littlefs/boards/stm32h750b_dk.overlay
+++ b/samples/subsys/fs/littlefs/boards/stm32h750b_dk.overlay
@@ -20,7 +20,7 @@
 	};
 };
 
-&mt25ql512ab1 {
+&mt25ql512ab {
 	partitions {
 		fs_partition: partition@0 {
 			reg = <0x0 DT_SIZE_M(64)>;

--- a/samples/subsys/mgmt/hawkbit/sample.yaml
+++ b/samples/subsys/mgmt/hawkbit/sample.yaml
@@ -7,6 +7,7 @@ common:
   platform_allow:
     - frdm_k64f
     - stm32h573i_dk
+    - stm32h750b_dk/stm32h750xx/ext_flash_app
   integration_platforms:
     - frdm_k64f
     - stm32h573i_dk

--- a/samples/sysbuild/with_mcuboot/sample.yaml
+++ b/samples/sysbuild/with_mcuboot/sample.yaml
@@ -18,6 +18,7 @@ tests:
       - nucleo_u385rg_q
       - stm32h7s78_dk
       - stm32h573i_dk
+      - stm32h750b_dk/stm32h750xx/ext_flash_app
     integration_platforms:
       - nrf52840dk/nrf52840
       - esp32_devkitc/esp32/procpu

--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -54,12 +54,14 @@ tests:
       - esp32c3_devkitm
       - esp32c6_devkitc/esp32c6/hpcore
       - esp8684_devkitm
+      - stm32h750b_dk/stm32h750xx/ext_flash_app
     integration_platforms:
       - frdm_k64f
       - nrf52840dk/nrf52840
   bootloader.mcuboot.assert:
     platform_allow:
       - b_u585i_iot02a
+      - stm32h750b_dk/stm32h750xx/ext_flash_app
     extra_configs:
       - CONFIG_ASSERT=y
   bootloader.mcuboot.swap_using_move:
@@ -68,6 +70,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf52840dk/nrf52840
       - nucleo_wba55cg
+      - stm32h750b_dk/stm32h750xx/ext_flash_app
     integration_platforms:
       - frdm_k64f
       - nrf5340dk/nrf5340/cpuapp


### PR DESCRIPTION
Introduce a board variant for storing an app in external QSPI NOR Flash and chainloading it with MCUboot (which is placed in internal Flash) to be executed in place (XiP).

The ext Flash memory partition also allows for using the Swap-using-offset & swap-using-move MCUboot image upgrade algorithms, eventhough it's not optimal as it has same-sized slots.

The new variant requires a board DT overlay on the MCUboot side (https://github.com/mcu-tools/mcuboot/pull/2479) to set the internal Flash & Flash controller as the chosen 'zephyr,flash' & 'zephyr,flash-controller'. This way, no overlay will be needed at the Zephyr user app level.

```
west build -p always -b stm32h750b_dk/stm32h750xx/ext_flash_app samples/modules/lvgl/demos --sysbuild
```

Board doc preview https://builds.zephyrproject.io/zephyr/pr/97037/docs/boards/st/stm32h750b_dk/doc/index.html