### PR TITLE
driver: i2s: fix nxp i2s fifo combine values

### DIFF
--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -614,11 +614,7 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 
 		config.fifo.fifoWatermark = (uint32_t)FSL_FEATURE_SAI_FIFO_COUNTn(base) - 1;
 #if defined(FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE) && FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE
-		/*
-		 * TX FIFO combine on write. The value below has correct value and wrong name
-		 * because RX and TX definitions are different but MCUX uses the same for both.
-		 */
-		config.fifo.fifoCombine = kSAI_FifoCombineModeEnabledOnRead;
+		config.fifo.fifoCombine = kSAI_FifoCombineModeEnabledOnWrite;
 #endif
 		/* set bit clock divider */
 		SAI_TxSetConfig(base, &config);
@@ -639,7 +635,7 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 		/* For RX, DMA reads from FIFO whenever data present */
 		config.fifo.fifoWatermark = 0;
 #if defined(FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE) && FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE
-		config.fifo.fifoCombine = kSAI_FifoCombineModeEnabledOnRead;
+		config.fifo.fifoCombine = kSAI_RXFifoCombineModeEnabledOnRead;
 #endif
 
 		memcpy(&dev_data->rx.cfg, i2s_cfg, sizeof(struct i2s_config));


### PR DESCRIPTION
MCUX defined RX fifo combine names and the references need to be adjusted in the i2s driver.

Current definition: 

```c
typedef enum _sai_fifo_combine
{
    kSAI_FifoCombineDisabled               = 0U, /*!< sai TX/RX fifo combine mode disabled */
    kSAI_FifoCombineModeEnabledOnRead      = 1U, /*!< sai TX fifo combine mode enabled on FIFO reads */
    kSAI_FifoCombineModeEnabledOnWrite     = 2U, /*!< sai TX fifo combine mode enabled on FIFO write */
    kSAI_RxFifoCombineModeEnabledOnWrite   = 1U, /*!< sai RX fifo combine mode enabled on FIFO write */
    kSAI_RXFifoCombineModeEnabledOnRead    = 2U, /*!< sai RX fifo combine mode enabled on FIFO reads */
    kSAI_FifoCombineModeEnabledOnReadWrite = 3U, /*!< sai TX/RX fifo combined mode enabled on FIFO read/writes */
} sai_fifo_combine_t;
```

Past definition (used in v4.2.0):
```c
typedef enum _sai_fifo_combine
{
    kSAI_FifoCombineDisabled = 0U,          /*!< sai fifo combine mode disabled */
    kSAI_FifoCombineModeEnabledOnWrite,     /*!< sai fifo combine mode enabled on FIFO write */
    kSAI_FifoCombineModeEnabledOnRead,      /*!< sai fifo combine mode enabled on FIFO reads */
    kSAI_FifoCombineModeEnabledOnReadWrite, /*!< sai fifo combined mode enabled on FIFO read/writes */
} sai_fifo_combine_t;
#endif
```