### PR TITLE
drivers: flash: flexspi_mx25um51345g: fix DDR dummy cycles and correct max speed

### DIFF
--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -400,7 +400,7 @@ zephyr_udc0: &usbhs {
 		/* MX25UM51245G is 64MB, 512MBit flash part */
 		size = <DT_SIZE_M(64 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(200)>;
+		spi-max-frequency = <DT_FREQ_M(120)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <DT_SIZE_K(4)>;

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -265,7 +265,7 @@ i2s1: &flexcomm3 {
 		/* MX25UM51245G is 64MB, 512MBit flash part */
 		size = <DT_SIZE_M(64 * 8)>;
 		reg = <2>;
-		spi-max-frequency = <DT_FREQ_M(200)>;
+		spi-max-frequency = <DT_FREQ_M(120)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <DT_SIZE_K(4)>;

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
@@ -205,7 +205,7 @@
 		/* MX25UM51245G is 64MB, 512MBit flash part */
 		size = <DT_SIZE_M(64 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(200)>;
+		spi-max-frequency = <DT_FREQ_M(120)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <DT_SIZE_K(4)>;

--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -162,7 +162,7 @@ static const uint32_t flash_flexspi_nor_lut[][4] = {
 
 	[ERASE_CHIP] = {
 		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR,		kFLEXSPI_8PAD, 0x60,
-				kFLEXSPI_Command_SDR,		kFLEXSPI_8PAD, 0x9F),
+				kFLEXSPI_Command_DDR,		kFLEXSPI_8PAD, 0x9F),
 	},
 
 	[READ] = {

--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -105,6 +105,7 @@ static const uint32_t flash_flexspi_nor_lut[][4] = {
 		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_READ_SDR,	kFLEXSPI_8PAD, 0x04,
 				kFLEXSPI_Command_STOP,		kFLEXSPI_1PAD, 0x0),
 	},
+
 	[WRITE_ENABLE_OPI] = {
 		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR,		kFLEXSPI_8PAD, 0x06,
 				kFLEXSPI_Command_SDR,		kFLEXSPI_8PAD, 0xF9),
@@ -142,7 +143,9 @@ static const uint32_t flash_flexspi_nor_lut[][4] = {
 		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR,		kFLEXSPI_8PAD, 0x05,
 				kFLEXSPI_Command_DDR,		kFLEXSPI_8PAD, 0xFA),
 		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_RADDR_DDR,	kFLEXSPI_8PAD, 0x20,
-				kFLEXSPI_Command_READ_DDR,	kFLEXSPI_8PAD, 0x4),
+				kFLEXSPI_Command_DUMMY_DDR,	kFLEXSPI_8PAD, 0x28),
+		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_READ_DDR,	kFLEXSPI_8PAD, 0x4,
+				kFLEXSPI_Command_STOP,		kFLEXSPI_1PAD, 0x0),
 	},
 
 	[WRITE_ENABLE_OPI] = {
@@ -166,7 +169,7 @@ static const uint32_t flash_flexspi_nor_lut[][4] = {
 		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DDR,		kFLEXSPI_8PAD, 0xEE,
 				kFLEXSPI_Command_DDR,		kFLEXSPI_8PAD, 0x11),
 		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_RADDR_DDR,	kFLEXSPI_8PAD, 0x20,
-				kFLEXSPI_Command_DUMMY_DDR,	kFLEXSPI_8PAD, 0x08),
+				kFLEXSPI_Command_DUMMY_DDR,	kFLEXSPI_8PAD, 0x28),
 		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_READ_DDR,	kFLEXSPI_8PAD, 0x04,
 				kFLEXSPI_Command_STOP,		kFLEXSPI_1PAD, 0x0),
 	},

--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -600,7 +600,8 @@ static DEVICE_API(flash, flash_flexspi_nor_api) = {
 
 #define FLASH_FLEXSPI_DEVICE_CONFIG(n)					\
 	{								\
-		.flexspiRootClk = MHZ(120),				\
+		.flexspiRootClk =					\
+			DT_INST_PROP_OR(n, spi_max_frequency, MHZ(200)),\
 		.flashSize = DT_INST_PROP(n, size) / 8 / KB(1),		\
 		.CSIntervalUnit =					\
 			CS_INTERVAL_UNIT(				\


### PR DESCRIPTION
In the DDR LUT, the dummy cycles were not defined for READ_STATUS_REG and had a wrong value for READ. The default amount of dummy cycles on this chip are 20 (0x14). This means the LUT should contain the value of 0x28 (0x14*2) for DDR
at these entries.

Maximum speed is 200MHz according to the mx25um51345g datasheet and is adjusted in the driver code accordingly.

Both changes were tested with an imx95 m7 connected to a mx25um51345g.

edit: Just discovered that the ERASE_CHIP DDR entry in the LUT was also incorrect. I put the fix for that in this PR as well.