### PR TITLE
Fix socketlen change related issues

### DIFF
--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -106,8 +106,8 @@ static int eswifi_socket_listen(void *obj, int backlog)
 	return ret;
 }
 
-void __eswifi_socket_accept_cb(struct net_context *context, struct sockaddr *addr,
-			       size_t len, int val, void *data)
+static void __eswifi_socket_accept_cb(struct net_context *context, struct sockaddr *addr,
+				      socklen_t len, int val, void *data)
 {
 	struct sockaddr *addr_target = data;
 

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -125,7 +125,7 @@ static int recv_data(struct net_socket_service_event *pev)
 	socklen_t optlen = sizeof(int);
 	struct net_buf *dns_data = NULL;
 	struct sockaddr addr;
-	size_t addrlen;
+	socklen_t addrlen;
 	int family, sock_error;
 	int ret = 0, len;
 

--- a/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
@@ -213,12 +213,14 @@ static ssize_t tp_udp_recvfrom(struct mqtt_sn_client *client, void *buffer, size
 	struct mqtt_sn_transport_udp *udp = UDP_TRANSPORT(client->transport);
 	int rc;
 	struct sockaddr *srcaddr = src_addr;
+	socklen_t addrlen_local;
 
-	rc = zsock_recvfrom(udp->sock, buffer, length, 0, src_addr, addrlen);
+	rc = zsock_recvfrom(udp->sock, buffer, length, 0, src_addr, &addrlen_local);
 	LOG_DBG("recv %d", rc);
 	if (rc < 0) {
 		return -errno;
 	}
+	*addrlen = addrlen_local;
 
 	LOG_HEXDUMP_DBG(buffer, rc, "recv");
 

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -443,7 +443,7 @@ void sys_trace_socket_accept_enter(int sock)
 }
 
 void sys_trace_socket_accept_exit(int sock, const struct sockaddr *addr,
-				  const size_t *addrlen, int ret)
+				  const uint32_t *addrlen, int ret)
 {
 	ctf_net_bounded_string_t addr_str = { "unknown" };
 	uint32_t addr_len = 0U;
@@ -463,7 +463,7 @@ void sys_trace_socket_accept_exit(int sock, const struct sockaddr *addr,
 }
 
 void sys_trace_socket_sendto_enter(int sock, int len, int flags,
-				   const struct sockaddr *dest_addr, size_t addrlen)
+				   const struct sockaddr *dest_addr, uint32_t addrlen)
 {
 	ctf_net_bounded_string_t addr_str = { "unknown" };
 
@@ -504,7 +504,7 @@ void sys_trace_socket_sendmsg_exit(int sock, int ret)
 }
 
 void sys_trace_socket_recvfrom_enter(int sock, int max_len, int flags,
-				     struct sockaddr *addr, size_t *addrlen)
+				     struct sockaddr *addr, uint32_t *addrlen)
 {
 	ctf_top_socket_recvfrom_enter(sock, max_len, flags,
 				      (uint32_t)(uintptr_t)addr,
@@ -512,7 +512,7 @@ void sys_trace_socket_recvfrom_enter(int sock, int max_len, int flags,
 }
 
 void sys_trace_socket_recvfrom_exit(int sock, const struct sockaddr *src_addr,
-				    const size_t *addrlen, int ret)
+				    const uint32_t *addrlen, int ret)
 {
 	ctf_net_bounded_string_t addr_str = { "unknown" };
 	int len = 0;
@@ -631,7 +631,7 @@ void sys_trace_socket_getpeername_enter(int sock)
 }
 
 void sys_trace_socket_getpeername_exit(int sock,  struct sockaddr *addr,
-				       const size_t *addrlen, int ret)
+				       const uint32_t *addrlen, int ret)
 {
 	ctf_net_bounded_string_t addr_str;
 
@@ -647,7 +647,7 @@ void sys_trace_socket_getsockname_enter(int sock)
 }
 
 void sys_trace_socket_getsockname_exit(int sock, const struct sockaddr *addr,
-				       const size_t *addrlen, int ret)
+				       const uint32_t *addrlen, int ret)
 {
 	ctf_net_bounded_string_t addr_str;
 

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -558,17 +558,17 @@ void sys_trace_socket_connect_exit(int sock, int ret);
 void sys_trace_socket_listen_enter(int sock, int backlog);
 void sys_trace_socket_listen_exit(int sock, int ret);
 void sys_trace_socket_accept_enter(int sock);
-void sys_trace_socket_accept_exit(int sock, const struct sockaddr *addr, const size_t *addrlen,
+void sys_trace_socket_accept_exit(int sock, const struct sockaddr *addr, const uint32_t *addrlen,
 				  int ret);
 void sys_trace_socket_sendto_enter(int sock, int len, int flags, const struct sockaddr *dest_addr,
-				   size_t addrlen);
+				   uint32_t addrlen);
 void sys_trace_socket_sendto_exit(int sock, int ret);
 void sys_trace_socket_sendmsg_enter(int sock, const struct msghdr *msg, int flags);
 void sys_trace_socket_sendmsg_exit(int sock, int ret);
 void sys_trace_socket_recvfrom_enter(int sock, int max_len, int flags, struct sockaddr *addr,
-				     size_t *addrlen);
+				     uint32_t *addrlen);
 void sys_trace_socket_recvfrom_exit(int sock, const struct sockaddr *src_addr,
-				    const size_t *addrlen, int ret);
+				    const uint32_t *addrlen, int ret);
 void sys_trace_socket_recvmsg_enter(int sock, const struct msghdr *msg, int flags);
 void sys_trace_socket_recvmsg_exit(int sock, const struct msghdr *msg, int ret);
 void sys_trace_socket_fcntl_enter(int sock, int cmd, int flags);
@@ -584,11 +584,11 @@ void sys_trace_socket_setsockopt_enter(int sock, int level, int optname, const v
 				       size_t optlen);
 void sys_trace_socket_setsockopt_exit(int sock, int ret);
 void sys_trace_socket_getpeername_enter(int sock);
-void sys_trace_socket_getpeername_exit(int sock,  struct sockaddr *addr, const size_t *addrlen,
+void sys_trace_socket_getpeername_exit(int sock, struct sockaddr *addr, const uint32_t *addrlen,
 				       int ret);
 void sys_trace_socket_getsockname_enter(int sock);
-void sys_trace_socket_getsockname_exit(int sock, const struct sockaddr *addr, const size_t *addrlen,
-				       int ret);
+void sys_trace_socket_getsockname_exit(int sock, const struct sockaddr *addr,
+				       const uint32_t *addrlen, int ret);
 void sys_trace_socket_socketpair_enter(int family, int type, int proto, int *sv);
 void sys_trace_socket_socketpair_exit(int sock_A, int sock_B, int ret);
 

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -2492,7 +2492,7 @@ static void check_ipv6_address_preferences(struct net_if *iface,
 					   const struct in6_addr *dest)
 {
 	const struct in6_addr *selected;
-	size_t optlen;
+	socklen_t optlen;
 	int optval;
 	int sock;
 	int ret;
@@ -2573,8 +2573,8 @@ ZTEST(net_socket_udp, test_38_ipv6_multicast_ifindex)
 	struct net_if_mcast_addr *ifmaddr;
 	struct net_if_addr *ifaddr;
 	int server_sock;
-	size_t addrlen;
-	size_t optlen;
+	socklen_t addrlen;
+	socklen_t optlen;
 	int ifindex;
 	int optval;
 	int sock;
@@ -2718,8 +2718,8 @@ ZTEST(net_socket_udp, test_39_ipv4_multicast_ifindex)
 	struct ip_mreq mreq;
 	struct net_if *iface;
 	int server_sock;
-	size_t addrlen;
-	size_t optlen;
+	socklen_t addrlen;
+	socklen_t optlen;
 	int ifindex;
 	int sock;
 	int ret;
@@ -2964,8 +2964,8 @@ static void check_port_range(struct sockaddr *my_addr,
 {
 	sa_family_t family = AF_UNSPEC;
 	uint32_t optval;
-	size_t addr_len;
-	size_t optlen;
+	socklen_t addr_len;
+	socklen_t optlen;
 	int sock;
 	int ret, err;
 


### PR DESCRIPTION
Zephyr's socklen_t was changed in
c546c1cad1f86977dbf3fb3354469db9cda926aa
to be uint32_t instea of size_t.
Let's fix accordingly the prototypes which expect it.

Related to:
* https://github.com/zephyrproject-rtos/zephyr/pull/96903
