### PR TITLE
drivers: led_strip: Don't select SERIAL_SUPPORT_ASYNC

### DIFF
--- a/drivers/led_strip/Kconfig.ws2812
+++ b/drivers/led_strip/Kconfig.ws2812
@@ -33,8 +33,7 @@ config WS2812_STRIP_UART
 	default y
 	depends on DT_HAS_WORLDSEMI_WS2812_UART_ENABLED
 	select SERIAL if $(dt_compat_on_bus,$(DT_COMPAT_WORLDSEMI_WS2812_UART),uart)
-	select UART_ASYNC_API
-	select SERIAL_SUPPORT_ASYNC
+	imply UART_ASYNC_API
 	help
 	  Enable driver for WS2812 (and compatible) LED strips using UART.
 	  This method requires a high-speed UART and carefully crafted


### PR DESCRIPTION
It is completely wrong for a uart consumer driver to be selecting "SERIAL_SUPPORT_ASYNC", this is ONLY supposed to be set by the serial driver itself to indicate if it actually supports async api. If consumer selects this then it defeats the whole point, and is causing CI issues.