### PR TITLE
drivers: uart_mcux_lpuart: Handle multiple uart case

### DIFF
--- a/drivers/serial/Kconfig.mcux_lpuart
+++ b/drivers/serial/Kconfig.mcux_lpuart
@@ -8,15 +8,24 @@ config UART_MCUX_LPUART
 	depends on CLOCK_CONTROL
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
-	select SERIAL_SUPPORT_ASYNC if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPUART),dmas)
-	select DMA if UART_ASYNC_API
 	select PINCTRL
 	help
 	  Enable the MCUX LPUART driver.
 
+if UART_MCUX_LPUART
+
 config UART_MCUX_LPUART_ISR_SUPPORT
 	bool
-	depends on UART_MCUX_LPUART
 	default y if UART_INTERRUPT_DRIVEN || PM || UART_ASYNC_API
 	help
 	  Enable UART interrupt service routine.
+
+config UART_NXP_LPUART_ASYNC_API_SUPPORT
+	bool
+	default y if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPUART),dmas)
+	select SERIAL_SUPPORT_ASYNC
+	select DMA if UART_ASYNC_API
+	help
+	  Indicates if LPUART has async api support by having dmas enabled for it
+
+endif


### PR DESCRIPTION
Handle the case where there are multiple different kinds of UART on one platform, the other UART driver select SERIAL_SUPPORT_ASYNC but LPUART did not, causing build error in LPUART driver. Shield LPUART driver from this case by introducing driver config to indicate that in fact LPUART is the one enabling ASYNC.

Fixing CI issue for example on https://github.com/zephyrproject-rtos/zephyr/pull/96983

Might fix https://github.com/zephyrproject-rtos/zephyr/issues/97022 , not sure @hakehuang  ?