### PR TITLE
scripts: west_commands: fix ZEPHYR_BASE env check

### DIFF
--- a/scripts/west_commands/sdk.py
+++ b/scripts/west_commands/sdk.py
@@ -210,10 +210,11 @@ class Sdk(WestCommand):
         if args.version:
             version = args.version
         else:
-            if os.environ["ZEPHYR_BASE"]:
-                zephyr_base = Path(os.environ["ZEPHYR_BASE"])
+            zephyr_base_env = os.environ.get("ZEPHYR_BASE")
+            if zephyr_base_env:
+                zephyr_base = Path(zephyr_base_env)
             else:
-                zephyr_base = Path(__file__).parents[2]
+                zephyr_base = Path(__file__).resolve().parents[2]
 
             sdk_version_file = zephyr_base / "SDK_VERSION"
 


### PR DESCRIPTION
`detect_version()` in the sdk west command used `os.environ["ZEPHYR_BASE"]`, which raises a `KeyError` when the variable is absent, preventing the fallback path from running. Switch to `os.environ.get("ZEPHYR_BASE")` and use `Path(__file__).resolve()` for the fallback so the path is absolute/canonical.

(@tdewey-rpi @will-v-pi)