### PR TITLE
Bluetooth: Host: Invoke tx callbacks when channel is deleted

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -267,7 +267,30 @@ struct bt_l2cap_le_chan {
 	 * L2CAP_LE_CREDIT_BASED_CONNECTION_REQ/RSP or L2CAP_CONFIGURATION_REQ.
 	 */
 	struct bt_l2cap_le_endpoint	tx;
-	/** Channel Transmission queue (for SDUs) */
+	/** Channel Transmission queue
+	 *
+	 * Internal
+	 *
+	 * SDUs/PDUs given to @ref bt_l2cap_chan_send and @c bt_l2cap_send_pdu
+	 * are stored here until they are sent to the Controller.
+	 *
+	 * The SDU header is prepended to SDUs before they are stored here. The
+	 * head of this list (the next data to be sent) may be just the
+	 * remaining part of an already partially transmitted SDU/PDU due to
+	 * L2CAP segmentation and fragmentation.
+	 *
+	 * This is the outbox for a single channel. Channels may be serviced in
+	 * any order. The transmission order does not follow the sequence of
+	 * @ref bt_l2cap_chan_send calls across channels.
+	 *
+	 * There may be more data here than the channel currently has credits
+	 * for. The transmission will wait until credits are available.
+	 *
+	 * Callbacks given to @ref bt_l2cap_chan_send are stored in the
+	 * user_data of the buffer. These callbacks must be invoked when the
+	 * Controller gives a Number of Buffers Complete Event for the last
+	 * L2CAP PDU of the buffer or when the channel is disconnected.
+	 */
 	struct k_fifo                   tx_queue;
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	/** Segment SDU packet from upper layer */

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -283,7 +283,12 @@ struct bt_conn {
 	 * Details about the returned net_buf when it is not NULL:
 	 *   - If the net_buf->len <= *length, then the net_buf has been removed
 	 *     from the tx_queue of the connection and the caller is now the
-	 *     owner of the only reference to the net_buf.
+	 *     owner of the only reference to the net_buf. The caller now has to
+	 *     invoke get_and_clear_cb to get the callback and user-data for the
+	 *     net_buf and is responsible for invoking the callback eventually
+	 *     after the Controller gives a Number of Completed Packets Event
+	 *     for this PDU or when the connection is disconnected, in which
+	 *     case the callback must be invoked with the error code -ESHUTDOWN.
 	 *   - Otherwise, the net_buf is still on the tx_queue of the connection,
 	 *     and the callback has incremented the reference count to account
 	 *     for it having a reference still.

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -278,6 +278,14 @@ static void l2cap_chan_del(struct bt_l2cap_chan *chan)
 	 * `l2cap_chan_destroy()` as it is not called for fixed channels.
 	 */
 	while ((buf = k_fifo_get(&le_chan->tx_queue, K_NO_WAIT))) {
+		bt_conn_tx_cb_t cb = closure_cb(buf->user_data);
+
+		if (cb != NULL) {
+			void *user_data = closure_data(buf->user_data);
+
+			cb(chan->conn, user_data, -ESHUTDOWN);
+		}
+
 		net_buf_unref(buf);
 	}
 

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -190,6 +190,12 @@ struct net_buf *bt_l2cap_create_pdu_timeout(struct net_buf_pool *pool,
 /* Send L2CAP PDU over a connection
  *
  * Buffer ownership is transferred to stack in case of success.
+ *
+ * The callback will always be invoked exactly once: After the
+ * Controller gives a Number of Completed Packets Event for the
+ * last L2CAP PDU of the buffer or after the channel is
+ * disconnected and the buffer may or may not have been sent in
+ * full, in which case the error code will be -ESHUTDOWN.
  */
 int bt_l2cap_send_pdu(struct bt_l2cap_le_chan *le_chan, struct net_buf *pdu,
 		      bt_conn_tx_cb_t cb, void *user_data);


### PR DESCRIPTION
When bt_l2cap_send_pdu() succeeds, it transfers buffer ownership to the stack, which must eventually invoke the provided callback. This contract is honored in all paths where transmission becomes impossible:

- Normal transmission: callback invoked with err=0 after HCI Number of Completed Packets event (tx_notify_process)
- Send errors (after tx allocated): callback invoked with err=-ESHUTDOWN via conn_tx_destroy
- Send errors (before tx allocated): callback invoked with the specific error code in send_buf error_return path
- Connection disconnect: callbacks invoked with err=-ESHUTDOWN via process_unack_tx -> conn_tx_destroy for all PDUs in tx_pending

However, when a channel is deleted (l2cap_chan_del), PDUs remaining in the tx_queue are dropped without invoking their callbacks, violating the ownership contract.

Fix this by extracting and invoking any non-NULL callbacks from the closure stored in buf->user_data before releasing the buffers. The callback is invoked with err=-ESHUTDOWN, making this path analogous to process_unack_tx: both drain queues of unsent PDUs when transmission becomes impossible due to external events (channel deletion vs connection disconnect). The only difference is the buffer lifecycle stage - in l2cap_chan_del, PDUs are still in tx_queue (closure in buf->user_data), while in process_unack_tx, they've progressed to tx_pending (callback in bt_conn_tx struct).

Note: conn_tx_destroy() cannot be used here because no bt_conn_tx struct has been allocated yet - the closure is still in buf->user_data.