### PR TITLE
Enable missing supported peripherals for MAX32 boards

### DIFF
--- a/boards/adi/max32675evkit/max32675evkit.dts
+++ b/boards/adi/max32675evkit/max32675evkit.dts
@@ -60,6 +60,7 @@
 		led1 = &led2;
 		sw0 = &pb1;
 		sw1 = &pb2;
+		watchdog0 = &wdt0;
 	};
 };
 
@@ -102,4 +103,8 @@
 	status = "okay";
 	pinctrl-0 = <&spi1a_mosi_p0_15 &spi1a_miso_p0_14 &spi1a_sck_p0_16 &spi1a_ss0_p0_17>;
 	pinctrl-names = "default";
+};
+
+&wdt0 {
+	status = "okay";
 };

--- a/boards/adi/max32675evkit/max32675evkit.yaml
+++ b/boards/adi/max32675evkit/max32675evkit.yaml
@@ -15,5 +15,6 @@ supported:
   - spi
   - pwm
   - flash
+  - watchdog
 ram: 64
 flash: 384

--- a/boards/adi/max32680evkit/max32680evkit_max32680_m4.dts
+++ b/boards/adi/max32680evkit/max32680evkit_max32680_m4.dts
@@ -113,6 +113,13 @@
 	status = "okay";
 };
 
+/*
+ * ERTCO is required for counter RTC
+ */
+&clk_ertco {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };
@@ -173,4 +180,8 @@
 &w1 {
 	pinctrl-0 = <&owm_io_p0_6 &owm_pe_p0_7>;
 	pinctrl-names = "default";
+};
+
+&rtc_counter {
+	status = "okay";
 };

--- a/boards/adi/max32680evkit/max32680evkit_max32680_m4.yaml
+++ b/boards/adi/max32680evkit/max32680evkit_max32680_m4.yaml
@@ -18,5 +18,6 @@ supported:
   - counter
   - w1
   - flash
+  - rtc_counter
 ram: 48
 flash: 512


### PR DESCRIPTION
This PR enables missing supported peripherals for given MAX32 boards.

- RTC Counter support for MAX32680EVKIT board
- Watchdog support for MAX32675EVKIT board