### PR TITLE
Enable mpu by default on MAX32xxx boards.

### DIFF
--- a/boards/adi/apard32690/apard32690_max32690_m4_defconfig
+++ b/boards/adi/apard32690/apard32690_max32690_m4_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32655evkit/max32655evkit_max32655_m4_defconfig
+++ b/boards/adi/max32655evkit/max32655evkit_max32655_m4_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2023-2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4_defconfig
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2023-2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32657evkit/max32657evkit_max32657_defconfig
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32657evkit/max32657evkit_max32657_ns_defconfig
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_ns_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32662evkit/max32662evkit_defconfig
+++ b/boards/adi/max32662evkit/max32662evkit_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32666evkit/max32666evkit_max32666_cpu0_defconfig
+++ b/boards/adi/max32666evkit/max32666evkit_max32666_cpu0_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32666fthr/max32666fthr_max32666_cpu0_defconfig
+++ b/boards/adi/max32666fthr/max32666fthr_max32666_cpu0_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2023-2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32670evkit/max32670evkit_defconfig
+++ b/boards/adi/max32670evkit/max32670evkit_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32672evkit/max32672evkit_defconfig
+++ b/boards/adi/max32672evkit/max32672evkit_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32672fthr/max32672fthr_defconfig
+++ b/boards/adi/max32672fthr/max32672fthr_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32675evkit/max32675evkit_defconfig
+++ b/boards/adi/max32675evkit/max32675evkit_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32680evkit/max32680evkit_max32680_m4_defconfig
+++ b/boards/adi/max32680evkit/max32680evkit_max32680_m4_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32690evkit/max32690evkit_max32690_m4_defconfig
+++ b/boards/adi/max32690evkit/max32690evkit_max32690_m4_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2023-2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max78002evkit/max78002evkit_max78002_m4_defconfig
+++ b/boards/adi/max78002evkit/max78002evkit_max78002_m4_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 


### PR DESCRIPTION
MPU is supported on MAX32 soc family. Enable it by default for all supported MAX32XXX boards.