### PR TITLE
boards/nordic/nrf54h20dk: Add button/LED aliases

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -42,6 +42,8 @@
 		sw3 = &button3;
 		ipc-to-cpusys = &cpuapp_cpusys_ipc;
 		watchdog0 = &wdt010;
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 
 	buttons {

--- a/samples/boards/nordic/spis_wakeup/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/boards/nordic/spis_wakeup/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -12,6 +12,8 @@
 		/delete-property/ sw1;
 		/delete-property/ sw2;
 		/delete-property/ sw3;
+		/delete-property/ mcuboot-led0;
+		/delete-property/ mcuboot-button0;
 	};
 	/delete-node/ buttons;
 };


### PR DESCRIPTION
Added aliases so that nrf54h20dk/nrf54h20/cpuapp can use MCUboot serial recovery.