### PR TITLE
boards: espressif: fix rtc_timer compatible string

### DIFF
--- a/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
@@ -101,7 +101,7 @@
 
 		rtc_timer: rtc_timer@60008004 {
 			reg = <0x60008004 0xC>;
-			compatible = "espressif,esp32-rtc_timer";
+			compatible = "espressif,esp32-rtc-timer";
 			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -128,7 +128,7 @@
 
 		rtc_timer: rtc_timer@60008004 {
 			reg = <0x60008004 0xC>;
-			compatible = "espressif,esp32-rtc_timer";
+			compatible = "espressif,esp32-rtc-timer";
 			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;

--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -173,7 +173,7 @@
 		};
 
 		rtc_timer: rtc_timer@600b0c00 {
-			compatible = "espressif,esp32-rtc_timer";
+			compatible = "espressif,esp32-rtc-timer";
 			reg = <0x600B0C00 DT_SIZE_K(1)>;
 			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <LP_RTC_TIMER_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;

--- a/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
@@ -142,7 +142,7 @@
 
 		rtc_timer: rtc_timer@3f408004 {
 			reg = <0x3f408004 0xC>;
-			compatible = "espressif,esp32-rtc_timer";
+			compatible = "espressif,esp32-rtc-timer";
 			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -181,7 +181,7 @@
 
 		rtc_timer: rtc_timer@60008004 {
 			reg = <0x60008004 0xC>;
-			compatible = "espressif,esp32-rtc_timer";
+			compatible = "espressif,esp32-rtc-timer";
 			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;


### PR DESCRIPTION
Take correct compatible string from: espressif,esp32-rtc-timer.yaml
Fixes a regression caused by: e0a915a17880806412871a81ca01a579f96c2c50

tested with esp32s3 board