### PR TITLE
boards: adafruit: Fix ws2812 pin on Adafruit Feather RP2040.

### DIFF
--- a/boards/adafruit/feather_rp2040/adafruit_feather_rp2040-pinctrl.dtsi
+++ b/boards/adafruit/feather_rp2040/adafruit_feather_rp2040-pinctrl.dtsi
@@ -54,7 +54,7 @@
 
 	ws2812_pio1_default: ws2812_pio1_default {
 		ws2812 {
-			pinmux = <PIO1_P12>;
+			pinmux = <PIO1_P16>;
 		};
 	};
 };

--- a/boards/adafruit/feather_rp2040/adafruit_feather_rp2040.dts
+++ b/boards/adafruit/feather_rp2040/adafruit_feather_rp2040.dts
@@ -134,7 +134,7 @@ zephyr_i2c: &i2c1 {
 
 		ws2812: ws2812 {
 			status = "okay";
-			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
 			chain-length = <1>;
 			color-mapping = <LED_COLOR_ID_GREEN
 					 LED_COLOR_ID_RED


### PR DESCRIPTION
## Description

```
boards: adafruit: Fix ws2812 pin on Adafruit Feather RP2040.

As stated in [1], the ws2812 pin is on GPIO16.

[1] https://github.com/adafruit/Adafruit-Feather-RP2040-PCB/blob/main/Adafruit%20Feather%20RP2040%20pinout.pdf
```

## Tests executed

Verified on Adafruit Feather RP2040: now the `samples/drivers/led/led_strip` sample makes the Neopixel LED blink in different colors.