### PR TITLE
tests: drivers: gpio: add nrf54h20dk_nrf54h20_cpuppr

### DIFF
--- a/samples/basic/blinky/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/samples/basic/blinky/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	aliases {
+		led0 = &led0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio9 0 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 0";
+		};
+	};
+};
+
+&gpiote130 {
+	status = "okay";
+};
+
+&gpio9 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_get_direction/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/gpio/gpio_get_direction/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	aliases {
+		led0 = &led0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio9 0 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 0";
+		};
+	};
+};
+
+&gpiote130 {
+	status = "okay";
+};
+
+&gpio9 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_hogs/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	zephyr,user {
+		output-high-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		output-low-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+		input-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gpio0 {
+	status = "okay";
+	hog1 {
+		gpio-hog;
+		gpios = <3 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+
+	hog2 {
+		gpio-hog;
+		gpios = <4 GPIO_ACTIVE_HIGH>;
+		output-low;
+	};
+
+	hog3 {
+		gpio-hog;
+		gpios = <1 GPIO_ACTIVE_LOW>;
+		input;
+	};
+};
+
+&gpiote130 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_hogs/testcase.yaml
+++ b/tests/drivers/gpio/gpio_hogs/testcase.yaml
@@ -11,6 +11,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpuppr
       - nucleo_g474re
       - nrf52_bsim
       - nrf5340bsim/nrf5340/cpuapp

--- a/tests/drivers/gpio/gpio_nrf/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/gpio/gpio_nrf/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	aliases {
+		led0 = &led0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio9 0 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 0";
+		};
+	};
+};
+
+&gpiote130 {
+	status = "okay";
+};
+
+&gpio9 {
+	status = "okay";
+};


### PR DESCRIPTION
Enable GPIO tests on nRF54H20 CPUPPR.