### PR TITLE
treewide: Default to C17 as the minimum required C standard

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -357,18 +357,19 @@ menu "Compiler Options"
 
 config REQUIRES_STD_C99
 	bool
+	select DEPRECATED
 	help
 	  Hidden option to select compiler support C99 standard or higher.
 
 config REQUIRES_STD_C11
 	bool
+	select DEPRECATED
 	select REQUIRES_STD_C99
 	help
 	  Hidden option to select compiler support C11 standard or higher.
 
 config REQUIRES_STD_C17
 	bool
-	select REQUIRES_STD_C11
 	help
 	  Hidden option to select compiler support C17 standard or higher.
 
@@ -381,27 +382,28 @@ config REQUIRES_STD_C23
 choice STD_C
 	prompt "C Standard"
 	default STD_C23 if REQUIRES_STD_C23
-	default STD_C17 if REQUIRES_STD_C17
-	default STD_C11 if REQUIRES_STD_C11
-	default STD_C99
+	default STD_C17
 	help
 	  C Standards.
 
 config STD_C90
-	bool "C90"
+	bool "C90 [DEPRECATED]"
+	select DEPRECATED
 	depends on !REQUIRES_STD_C99
 	help
 	  1989 C standard as completed in 1989 and ratified by ISO/IEC
 	  as ISO/IEC 9899:1990. This version is known as "ANSI C".
 
 config STD_C99
-	bool "C99"
+	bool "C99 [DEPRECATED]"
+	select DEPRECATED
 	depends on !REQUIRES_STD_C11
 	help
 	  1999 C standard.
 
 config STD_C11
-	bool "C11"
+	bool "C11 [DEPRECATED]"
+	select DEPRECATED
 	depends on !REQUIRES_STD_C17
 	help
 	  2011 C standard.

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -153,12 +153,6 @@ config ARCH_POSIX
 	select BARRIER_OPERATIONS_BUILTIN
 	# POSIX arch based targets get their memory cleared on entry by the host OS
 	select SKIP_BSS_CLEAR
-	# Override the C standard used for compilation to C 2011
-	# This is due to some tests using _Static_assert which is a 2011 feature, but
-	# otherwise relying on compilers supporting it also when set to C99.
-	# This was in general ok, but with some host compilers and C library versions
-	# it led to problems. So we override it to 2011 for the native targets.
-	select REQUIRES_STD_C11
 	help
 	  POSIX (native) architecture
 

--- a/doc/develop/languages/c/index.rst
+++ b/doc/develop/languages/c/index.rst
@@ -35,16 +35,14 @@ toolchain that supports the C99 standard and above:
 * variadic macros
 * ``restrict`` qualification
 
-Some Zephyr components make use of the features newly introduced in the 2011
-release of the ISO C standard (ISO/IEC 9899:2011, hereinafter referred to as
-C11) such as the type-generic expressions using the ``_Generic`` keyword. For
-example, the :c:func:`cbprintf` component, used as the default formatted output
-processor for Zephyr, makes use of the C11 type-generic expressions, and this
-effectively requires most Zephyr applications to be compiled using a compiler
-toolchain that supports the C11 standard and above.
+Additionally, some components or parts of them make use of features introduced in the
+C11 and C17 versions of the standard (ISO/IEC 9899:2011 and 9899:2018 respectively):
+
+* _Generic keyword
+* _Static_assert keyword
 
 In summary, it is recommended to use a compiler toolchain that supports at
-least the C11 standard for developing with Zephyr. It is, however, important to
+least the C17 standard for developing with Zephyr. It is, however, important to
 note that some optional Zephyr components and external modules may make use of
 the C language features that have been introduced in more recent versions of
 the standards, in which case it will be necessary to use a more up-to-date

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -23,6 +23,11 @@ the :ref:`release notes<zephyr_4.4>`.
 Build System
 ************
 
+* Zephyr now officially defaults to C17 (ISO/IEC 9899:2018) as its minimum required
+  C standard version.  If your toolchain does not support this standard you will
+  need to use one of the existing and now deprecated options:
+  :kconfig:option:`CONFIG_STD_C99` or :kconfig:option:`CONFIG_STD_C11`.
+
 Kernel
 ******
 

--- a/modules/nanopb/Kconfig
+++ b/modules/nanopb/Kconfig
@@ -6,8 +6,6 @@ config ZEPHYR_NANOPB_MODULE
 
 menuconfig NANOPB
 	bool "Nanopb Support"
-	# Nanopb requires c_std_11 compiler features like _Static_assert
-	select REQUIRES_STD_C11
 	help
 	  This option enables the Nanopb library and generator.
 

--- a/tests/subsys/bindesc/definition/testcase.yaml
+++ b/tests/subsys/bindesc/definition/testcase.yaml
@@ -19,23 +19,9 @@ tests:
       - qemu_riscv32
       - qemu_riscv32e
       - qemu_riscv64
-  bindesc.define.c99:
-    extra_configs:
-      - CONFIG_STD_C99=y
-  bindesc.define.c11:
-    extra_configs:
-      - CONFIG_STD_C11=y
   bindesc.define.c17:
     extra_configs:
       - CONFIG_STD_C17=y
-  bindesc.define.gnu99:
-    extra_configs:
-      - CONFIG_STD_C99=y
-      - CONFIG_GNU_C_EXTENSIONS=y
-  bindesc.define.gnu11:
-    extra_configs:
-      - CONFIG_STD_C11=y
-      - CONFIG_GNU_C_EXTENSIONS=y
   bindesc.define.gnu17:
     extra_configs:
       - CONFIG_STD_C17=y

--- a/tests/subsys/bindesc/reading/testcase.yaml
+++ b/tests/subsys/bindesc/reading/testcase.yaml
@@ -8,23 +8,9 @@ tests:
   bindesc.read:
     platform_allow:
       - native_sim
-  bindesc.read.c99:
-    extra_configs:
-      - CONFIG_STD_C99=y
-  bindesc.read.c11:
-    extra_configs:
-      - CONFIG_STD_C11=y
   bindesc.read.c17:
     extra_configs:
       - CONFIG_STD_C17=y
-  bindesc.read.gnu99:
-    extra_configs:
-      - CONFIG_STD_C99=y
-      - CONFIG_GNU_C_EXTENSIONS=y
-  bindesc.read.gnu11:
-    extra_configs:
-      - CONFIG_STD_C11=y
-      - CONFIG_GNU_C_EXTENSIONS=y
   bindesc.read.gnu17:
     extra_configs:
       - CONFIG_STD_C17=y


### PR DESCRIPTION
C99 has been the minimum required C standard version for Zephyr since its inception. After multiple attempts and discussions, a decision has been made to upgrade to C17 going forward.
This commits replaces the default C standard from C99 to C17 in the configuration and build system, and deprecates support for the older standards.


Closes #97061