### PR TITLE
arch: riscv: Use CONFIG_PMP_SLOTS for M-mode stack guard arrays

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -539,8 +539,8 @@ void z_riscv_pmp_stackguard_enable(struct k_thread *thread)
 void z_riscv_pmp_stackguard_disable(void)
 {
 
-	unsigned long pmp_addr[PMP_M_MODE_SLOTS];
-	unsigned long pmp_cfg[PMP_M_MODE_SLOTS / sizeof(unsigned long)];
+	unsigned long pmp_addr[CONFIG_PMP_SLOTS];
+	unsigned long pmp_cfg[CONFIG_PMP_SLOTS / sizeof(unsigned long)];
 	unsigned int index = global_pmp_end_index;
 
 	/* Retrieve the pmpaddr value matching the last global PMP slot. */

--- a/include/zephyr/arch/riscv/thread.h
+++ b/include/zephyr/arch/riscv/thread.h
@@ -63,8 +63,6 @@ struct z_riscv_fp_context {
 };
 typedef struct z_riscv_fp_context z_riscv_fp_context_t;
 
-#define PMP_M_MODE_SLOTS 8	/* 8 is plenty enough for m-mode */
-
 struct _thread_arch {
 #ifdef CONFIG_FPU_SHARING
 	struct z_riscv_fp_context saved_fp_context;
@@ -81,8 +79,8 @@ struct _thread_arch {
 #endif
 #ifdef CONFIG_PMP_STACK_GUARD
 	unsigned int m_mode_pmp_end_index;
-	unsigned long m_mode_pmpaddr_regs[PMP_M_MODE_SLOTS];
-	unsigned long m_mode_pmpcfg_regs[PMP_M_MODE_SLOTS / sizeof(unsigned long)];
+	unsigned long m_mode_pmpaddr_regs[CONFIG_PMP_SLOTS];
+	unsigned long m_mode_pmpcfg_regs[CONFIG_PMP_SLOTS / sizeof(unsigned long)];
 #endif
 };
 


### PR DESCRIPTION
The arrays used for M-mode Physical Memory Protection (PMP), specifically for the stack guard feature (`CONFIG_PMP_STACK_GUARD`), were previously sized using the hardcoded `PMP_M_MODE_SLOTS` macro, defined as 8. This affected arrays in both the `_thread_arch` struct (`m_mode_pmpaddr_regs`, `m_mode_pmpcfg_regs`) and local variables within the `z_riscv_pmp_stackguard_disable` function.

This commit changes the array sizing to use the Kconfig option `CONFIG_PMP_SLOTS`. This option reflects the total number of PMP slots available and configured for the target hardware.

Using `CONFIG_PMP_SLOTS` ensures these arrays are dimensioned according to the system's actual capabilities, providing better flexibility and correctness over a fixed size.

The `PMP_M_MODE_SLOTS` macro definition has been removed from thread.h as it is no longer used.