### PR TITLE
tests: shell: Improve compatibility with 64-bit platforms

### DIFF
--- a/tests/subsys/shell/shell/src/main.c
+++ b/tests/subsys/shell/shell/src/main.c
@@ -333,7 +333,7 @@ ZTEST(sh, test_shell_fprintf)
 	shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, "testing %d %s %c",
 		      1, "2", '3');
 	buf = shell_backend_dummy_get_output(sh, &size);
-	zassert_true(size >= sizeof(expect), "Expected size > %u, got %d",
+	zassert_true(size >= sizeof(expect), "Expected size > %zu, got %zu",
 		     sizeof(expect), size);
 
 	/*

--- a/tests/subsys/shell/shell_custom_header/src/main.c
+++ b/tests/subsys/shell/shell_custom_header/src/main.c
@@ -44,7 +44,7 @@ ZTEST(sh, test_shell_fprintf)
 	shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, "testing %d %s %c",
 		      1, "2", '3');
 	buf = shell_backend_dummy_get_output(sh, &size);
-	zassert_true(size >= sizeof(expect), "Expected size > %u, got %d",
+	zassert_true(size >= sizeof(expect), "Expected size > %zu, got %zu",
 		     sizeof(expect), size);
 
 	/*


### PR DESCRIPTION
Use `%zu` format specifier for `size_t` type to ensure compatibility with both 32-bit and 64-bit platforms.

Part of https://github.com/zephyrproject-rtos/zephyr/issues/96968