### PR TITLE
tests: mcumgr: Improve compatibility with 64-bit platforms

### DIFF
--- a/tests/subsys/mgmt/mcumgr/os_mgmt_echo/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_echo/src/main.c
@@ -56,7 +56,7 @@ ZTEST(os_mgmt_echo, test_echo)
 	smp_dummy_disable();
 
 	zassert_equal(sizeof(expected_response), nb->len,
-		      "Expected to receive %d bytes but got %d\n", sizeof(expected_response),
+		      "Expected to receive %zu bytes but got %d\n", sizeof(expected_response),
 		      nb->len);
 
 	zassert_mem_equal(expected_response, nb->data, nb->len,

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/build_date.c
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/build_date.c
@@ -124,7 +124,7 @@ ZTEST(os_mgmt_info_build_date, test_info_build_date_1_build_date)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal(strlen(test_date_time), output.len,
-		      "Expected to receive %d bytes but got %d\n",
+		      "Expected to receive %zu bytes but got %zu\n",
 		      strlen(test_date_time), output.len);
 
 	/* Check left and right sides of date which should match */
@@ -201,7 +201,7 @@ ZTEST(os_mgmt_info_build_date, test_info_build_date_2_all)
 
 	zassert_equal((strlen(test_date_time) + strlen(response_all_left) +
 		       strlen(response_all_right)), output.len,
-		      "Expected to receive %d bytes but got %d\n",
+		      "Expected to receive %zu bytes but got %zu\n",
 		      (strlen(test_date_time) + strlen(response_all_left) +
 		       strlen(response_all_right)), output.len);
 

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/limited.c
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/limited.c
@@ -89,7 +89,7 @@ ZTEST(os_mgmt_info_limited, test_info_1_kernel_name)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_kernel_name) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n",
+		      "Expected to receive %zu bytes but got %zu\n",
 		      (sizeof(response_kernel_name) - 1), output.len);
 
 	zassert_mem_equal(response_kernel_name, output.value, output.len,
@@ -160,7 +160,7 @@ ZTEST(os_mgmt_info_limited, test_info_2_all)
 
 	zassert_true(ok, "Expected decode to be successful\n");
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
-	zassert_equal(output.len, 0, "Expected to receive 0 bytes but got %d\n", output.len);
+	zassert_equal(output.len, 0, "Expected to receive 0 bytes but got %zu\n", output.len);
 	zassert_equal(rc, MGMT_ERR_EMSGSIZE, "Expected to receive EMSGSIZE error but got %d\n",
 		      rc);
 }

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/main.c
@@ -233,7 +233,7 @@ ZTEST(os_mgmt_info, test_info_1)
 	smp_dummy_disable();
 
 	zassert_equal(sizeof(expected_response), nb->len,
-		      "Expected to receive %d bytes but got %d\n", sizeof(expected_response),
+		      "Expected to receive %zu bytes but got %d\n", sizeof(expected_response),
 		      nb->len);
 
 	zassert_mem_equal(expected_response, nb->data, nb->len,
@@ -271,7 +271,7 @@ ZTEST(os_mgmt_info, test_info_1)
 	smp_dummy_disable();
 
 	zassert_equal(sizeof(expected_response), nb->len,
-		      "Expected to receive %d bytes but got %d\n", sizeof(expected_response),
+		      "Expected to receive %zu bytes but got %d\n", sizeof(expected_response),
 		      nb->len);
 
 	zassert_mem_equal(expected_response, nb->data, nb->len,
@@ -332,7 +332,7 @@ ZTEST(os_mgmt_info, test_info_2_kernel_name)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_kernel_name) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n",
+		      "Expected to receive %zu bytes but got %zu\n",
 		      (sizeof(response_kernel_name) - 1), output.len);
 
 	zassert_mem_equal(response_kernel_name, output.value, output.len,
@@ -393,7 +393,7 @@ ZTEST(os_mgmt_info, test_info_3_node_name)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_node_name) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n",
+		      "Expected to receive %zu bytes but got %zu\n",
 		      (sizeof(response_node_name) - 1), output.len);
 
 	zassert_mem_equal(response_node_name, output.value, output.len,
@@ -455,7 +455,7 @@ ZTEST(os_mgmt_info, test_info_4_kernel_release)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_kernel_release) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n",
+		      "Expected to receive %zu bytes but got %zu\n",
 		      (sizeof(response_kernel_release) - 1), output.len);
 
 	zassert_mem_equal(response_kernel_release, output.value, output.len,
@@ -517,7 +517,7 @@ ZTEST(os_mgmt_info, test_info_5_kernel_version)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_kernel_version) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n",
+		      "Expected to receive %zu bytes but got %zu\n",
 		      (sizeof(response_kernel_version) - 1), output.len);
 
 	zassert_mem_equal(response_kernel_version, output.value, output.len,
@@ -578,8 +578,8 @@ ZTEST(os_mgmt_info, test_info_6_machine)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_machine) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n", (sizeof(response_machine) - 1),
-		      output.len);
+		      "Expected to receive %zu bytes but got %zu\n",
+		      (sizeof(response_machine) - 1), output.len);
 
 	zassert_mem_equal(response_machine, output.value, output.len,
 			  "Expected received data mismatch");
@@ -639,8 +639,8 @@ ZTEST(os_mgmt_info, test_info_7_processor)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_processor) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n", (sizeof(response_processor) - 1),
-		      output.len);
+		      "Expected to receive %zu bytes but got %zu\n",
+		      (sizeof(response_processor) - 1), output.len);
 
 	zassert_mem_equal(response_processor, output.value, output.len,
 			  "Expected received data mismatch");
@@ -700,7 +700,7 @@ ZTEST(os_mgmt_info, test_info_8_platform)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_board_target) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n",
+		      "Expected to receive %zu bytes but got %zu\n",
 		      (sizeof(response_board_target) - 1), output.len);
 
 	zassert_mem_equal(response_board_target, output.value, output.len,
@@ -761,7 +761,7 @@ ZTEST(os_mgmt_info, test_info_9_os)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_os) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n", (sizeof(response_os) - 1),
+		      "Expected to receive %zu bytes but got %zu\n", (sizeof(response_os) - 1),
 		      output.len);
 
 	zassert_mem_equal(response_os, output.value, output.len,
@@ -822,7 +822,7 @@ ZTEST(os_mgmt_info, test_info_10_all)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_all) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n",
+		      "Expected to receive %zu bytes but got %zu\n",
 		      (sizeof(response_all) - 1), output.len);
 
 	zassert_mem_equal(response_all, output.value, output.len,
@@ -888,7 +888,7 @@ ZTEST(os_mgmt_info, test_info_11_multi_1)
 	/* Construct expected response to be compared against */
 	sprintf(buffer, "%s %s %s", response_kernel_release, response_processor, response_os);
 
-	zassert_equal(strlen(buffer), output.len, "Expected to receive %d bytes but got %d\n",
+	zassert_equal(strlen(buffer), output.len, "Expected to receive %zu bytes but got %zu\n",
 		      strlen(buffer), output.len);
 
 	zassert_mem_equal(buffer, output.value, output.len, "Expected received data mismatch");
@@ -955,7 +955,7 @@ ZTEST(os_mgmt_info, test_info_12_multi_2)
 	 */
 	sprintf(buffer, "%s %s", response_node_name, response_kernel_version);
 
-	zassert_equal(strlen(buffer), output.len, "Expected to receive %d bytes but got %d\n",
+	zassert_equal(strlen(buffer), output.len, "Expected to receive %zu bytes but got %zu\n",
 		      strlen(buffer), output.len);
 
 	zassert_mem_equal(buffer, output.value, output.len, "Expected received data mismatch");
@@ -1028,7 +1028,7 @@ ZTEST(os_mgmt_info, test_info_13_invalid_1)
 
 	zassert_true(ok, "Expected decode to be successful\n");
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
-	zassert_equal(output.len, 0, "Expected to receive 0 bytes but got %d\n", output.len);
+	zassert_equal(output.len, 0, "Expected to receive 0 bytes but got %zu\n", output.len);
 	zassert_equal(rc, MGMT_ERR_EINVAL, "Expected to receive EINVAL error but got %d\n", rc);
 }
 
@@ -1099,7 +1099,7 @@ ZTEST(os_mgmt_info, test_info_14_invalid_2)
 
 	zassert_true(ok, "Expected decode to be successful\n");
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
-	zassert_equal(output.len, 0, "Expected to receive 0 bytes but got %d\n", output.len);
+	zassert_equal(output.len, 0, "Expected to receive 0 bytes but got %zu\n", output.len);
 	zassert_equal(rc, MGMT_ERR_EINVAL, "Expected to receive EINVAL error but got %d\n", rc);
 }
 
@@ -1171,7 +1171,7 @@ ZTEST(os_mgmt_info_custom_os, test_info_os_custom)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_os_custom) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n",
+		      "Expected to receive %zu bytes but got %zu\n",
 		      (sizeof(response_os_custom) - 1), output.len);
 
 	zassert_mem_equal(response_os_custom, output.value, output.len,
@@ -1232,7 +1232,7 @@ ZTEST(os_mgmt_info_custom_os_disabled, test_info_os_custom_disabled)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_os) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n",
+		      "Expected to receive %zu bytes but got %zu\n",
 		      (sizeof(response_os) - 1), output.len);
 
 	zassert_mem_equal(response_os, output.value, output.len,
@@ -1305,7 +1305,7 @@ ZTEST(os_mgmt_info_custom_cmd, test_info_cmd_custom)
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
 	zassert_equal((sizeof(response_custom_cmd) - 1), output.len,
-		      "Expected to receive %d bytes but got %d\n",
+		      "Expected to receive %zu bytes but got %zu\n",
 		      (sizeof(response_custom_cmd) - 1), output.len);
 
 	zassert_mem_equal(response_custom_cmd, output.value, output.len,
@@ -1376,7 +1376,7 @@ ZTEST(os_mgmt_info_custom_cmd_disabled, test_info_cmd_custom_disabled)
 	zassert_true(ok, "Expected decode to be successful\n");
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
-	zassert_equal(output.len, 0, "Expected to receive 0 bytes but got %d\n", output.len);
+	zassert_equal(output.len, 0, "Expected to receive 0 bytes but got %zu\n", output.len);
 
 	zassert_equal(rc, MGMT_ERR_EINVAL, "Expected to receive EINVAL error but got %d\n", rc);
 }
@@ -1445,7 +1445,7 @@ ZTEST(os_mgmt_info_custom_cmd_disabled_verify, test_info_cmd_custom_disabled)
 	zassert_true(ok, "Expected decode to be successful\n");
 	zassert_equal(decoded, 1, "Expected to receive 1 decoded zcbor element\n");
 
-	zassert_equal(output.len, 0, "Expected to receive 0 bytes but got %d\n", output.len);
+	zassert_equal(output.len, 0, "Expected to receive 0 bytes but got %zu\n", output.len);
 
 	zassert_equal(rc, MGMT_ERR_EINVAL, "Expected to receive EINVAL error but got %d\n", rc);
 


### PR DESCRIPTION
Use `%zu` format specifier for `size_t` type to ensure compatibility with both 32-bit and 64-bit platforms.

Part of https://github.com/zephyrproject-rtos/zephyr/issues/96968