### PR TITLE
tests: posix: fix -Wformat errors

### DIFF
--- a/tests/posix/common/src/pthread_attr.c
+++ b/tests/posix/common/src/pthread_attr.c
@@ -527,9 +527,9 @@ ZTEST(pthread_attr, test_pthread_attr_policy_and_priority_limits)
 			 *
 			 * Note: we relax this requirement
 			 */
-			zassert_true(pmax > pmin, "pmax (%d) <= pmin (%d)", pmax, pmin,
-				     "%s min/max inconsistency: pmin: %d pmax: %d",
-				     policy_names[policy], pmin, pmax);
+			zassert_true(pmax > pmin,
+				     "%s min/max inconsistency, pmax (%d) <= pmin (%d)",
+				     policy_names[policy], pmax, pmin);
 
 			/*
 			 * Getting into the weeds a bit (i.e. whitebox testing), Zephyr

--- a/tests/posix/eventfd/src/blocking.c
+++ b/tests/posix/eventfd/src/blocking.c
@@ -19,7 +19,7 @@ ZTEST_F(eventfd, test_write_then_read)
 
 	ret = eventfd_read(fixture->fd, &val);
 	zassert_true(ret == 0, "read ret %d", ret);
-	zassert_true(val == 5, "val == %d", val);
+	zassert_true(val == 5, "val == %lld", val);
 
 	/* Test EFD_SEMAPHORE */
 	reopen(&fixture->fd, 0, EFD_SEMAPHORE);
@@ -32,7 +32,7 @@ ZTEST_F(eventfd, test_write_then_read)
 
 	ret = eventfd_read(fixture->fd, &val);
 	zassert_true(ret == 0, "read ret %d", ret);
-	zassert_true(val == 1, "val == %d", val);
+	zassert_true(val == 1, "val == %lld", val);
 }
 
 ZTEST_F(eventfd, test_zero_shall_not_unblock)

--- a/tests/posix/eventfd/src/ioctl.c
+++ b/tests/posix/eventfd/src/ioctl.c
@@ -32,7 +32,7 @@ ZTEST_F(eventfd, test_set_flags)
 
 	ret = eventfd_read(fixture->fd, &val);
 	zassert_ok(ret);
-	zassert_equal(val, 3, "val == %d", val);
+	zassert_equal(val, 3, "val == %lld", val);
 
 
 	/* Set nonblocking without reopening. */
@@ -53,7 +53,7 @@ ZTEST_F(eventfd, test_set_flags)
 
 	ret = eventfd_read(fixture->fd, &val);
 	zassert_ok(ret);
-	zassert_equal(val, 19, "val == %d", val);
+	zassert_equal(val, 19, "val == %lld", val);
 
 
 	/* Set back to blocking. */
@@ -74,7 +74,7 @@ ZTEST_F(eventfd, test_set_flags)
 
 	ret = eventfd_read(fixture->fd, &val);
 	zassert_ok(ret);
-	zassert_equal(val, 10, "val == %d", val);
+	zassert_equal(val, 10, "val == %lld", val);
 
 
 	/* Test setting internal in-use-flag. Should fail. */
@@ -88,5 +88,5 @@ ZTEST_F(eventfd, test_set_flags)
 
 	ret = eventfd_read(fixture->fd, &val);
 	zassert_ok(ret);
-	zassert_equal(val, 97, "val == %d", val);
+	zassert_equal(val, 97, "val == %lld", val);
 }

--- a/tests/posix/eventfd/src/nonblocking.c
+++ b/tests/posix/eventfd/src/nonblocking.c
@@ -22,10 +22,10 @@ ZTEST_F(eventfd, test_read_nonblock)
 
 	ret = eventfd_read(fixture->fd, &val);
 	zassert_true(ret == 0, "read set ret %d", ret);
-	zassert_true(val == TESTVAL, "red set val %d", val);
+	zassert_true(val == TESTVAL, "red set val %lld", val);
 
 	ret = eventfd_read(fixture->fd, &val);
-	zassert_true(ret == -1, "read subsequent ret %d val %d", ret, val);
+	zassert_true(ret == -1, "read subsequent ret %d val %lld", ret, val);
 	zassert_true(errno == EAGAIN, "errno %d", errno);
 }
 

--- a/tests/posix/signals/src/main.c
+++ b/tests/posix/signals/src/main.c
@@ -74,7 +74,7 @@ ZTEST(posix_signals, test_sigaddset)
 	for (int i = 0; i < SIGSET_NLONGS; i++) {
 		zassert_equal(_set[i], _target[i],
 			      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-			      SIGSET_NLONGS - 1, _set[i], _target[i]);
+			      (int)(SIGSET_NLONGS - 1), _set[i], _target[i]);
 	}
 
 	signo = SIGSYS;
@@ -83,7 +83,7 @@ ZTEST(posix_signals, test_sigaddset)
 	for (int i = 0; i < SIGSET_NLONGS; i++) {
 		zassert_equal(_set[i], _target[i],
 			      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-			      SIGSET_NLONGS - 1, _set[i], _target[i]);
+			      (int)(SIGSET_NLONGS - 1), _set[i], _target[i]);
 	}
 
 	/* TODO: move rt signal tests to realtime_signals testsuite */
@@ -108,7 +108,7 @@ ZTEST(posix_signals, test_sigaddset)
 		for (int i = 0; i < SIGSET_NLONGS; i++) {
 			zassert_equal(_set[i], _target[i],
 				      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-				      SIGSET_NLONGS - 1, _set[i], _target[i]);
+				      (int)(SIGSET_NLONGS - 1), _set[i], _target[i]);
 		}
 	}
 }
@@ -144,7 +144,7 @@ ZTEST(posix_signals, test_sigdelset)
 	for (int i = 0; i < SIGSET_NLONGS; i++) {
 		zassert_equal(_set[i], _target[i],
 			      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-			      SIGSET_NLONGS - 1, _set[i], _target[i]);
+			      (int)(SIGSET_NLONGS - 1), _set[i], _target[i]);
 	}
 
 	signo = SIGSYS;
@@ -153,7 +153,7 @@ ZTEST(posix_signals, test_sigdelset)
 	for (int i = 0; i < SIGSET_NLONGS; i++) {
 		zassert_equal(_set[i], _target[i],
 			      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-			      SIGSET_NLONGS - 1, _set[i], _target[i]);
+			      (int)(SIGSET_NLONGS - 1), _set[i], _target[i]);
 	}
 
 	/* TODO: move rt signal tests to realtime_signals testsuite */
@@ -178,7 +178,7 @@ ZTEST(posix_signals, test_sigdelset)
 		for (int i = 0; i < SIGSET_NLONGS; i++) {
 			zassert_equal(_set[i], _target[i],
 				      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-				      SIGSET_NLONGS - 1, _set[i], _target[i]);
+				      (int)(SIGSET_NLONGS - 1), _set[i], _target[i]);
 		}
 	}
 }

--- a/tests/posix/timers/src/nanosleep_common.c
+++ b/tests/posix/timers/src/nanosleep_common.c
@@ -66,10 +66,10 @@ void common_lower_bound_check(int selection, clockid_t clock_id, int flags, cons
 
 	zassert_equal(r, 0, "actual: %d expected: %d", r, 0);
 	zassert_equal(errno, 0, "actual: %d expected: %d", errno, 0);
-	zassert_equal(req.tv_sec, s, "actual: %d expected: %d", req.tv_sec, s);
-	zassert_equal(req.tv_nsec, ns, "actual: %d expected: %d", req.tv_nsec, ns);
-	zassert_equal(rem.tv_sec, 0, "actual: %d expected: %d", rem.tv_sec, 0);
-	zassert_equal(rem.tv_nsec, 0, "actual: %d expected: %d", rem.tv_nsec, 0);
+	zassert_equal(req.tv_sec, s, "actual: %lld expected: %d", (long long)req.tv_sec, s);
+	zassert_equal(req.tv_nsec, ns, "actual: %lld expected: %d", (long long)req.tv_nsec, ns);
+	zassert_equal(rem.tv_sec, 0, "actual: %lld expected: %d", (long long)rem.tv_sec, 0);
+	zassert_equal(rem.tv_nsec, 0, "actual: %lld expected: %d", (long long)rem.tv_nsec, 0);
 
 	switch (selection) {
 	case SELECT_NANOSLEEP:


### PR DESCRIPTION
Use `%lld` format specifier for variables of type `eventfd_t`. Cast variables of type `time_t` to `long long` and use `%lld` format specifier to ensure compatibility with 32-bit and 64-bit `time_t`.

Part of https://github.com/zephyrproject-rtos/zephyr/issues/96968