### PR TITLE
tests: llext: Improve compatibility with 64-bit platforms

### DIFF
--- a/tests/subsys/llext/src/test_llext.c
+++ b/tests/subsys/llext/src/test_llext.c
@@ -523,7 +523,8 @@ ZTEST(llext, test_find_section)
 	res = llext_get_section_header(loader, ext, ".data", &shdr);
 	zassert_ok(res, "get_section_header() should succeed");
 	zassert_equal(shdr.sh_offset, section_ofs,
-		     "different section offset %zd from get_section_header", shdr.sh_offset);
+		     "different section offset %llu from get_section_header",
+		     (uint64_t)shdr.sh_offset);
 
 	uintptr_t symbol_ptr = (uintptr_t)llext_find_sym(&ext->exp_tab, "number");
 	uintptr_t section_ptr = (uintptr_t)find_section_ext + section_ofs;


### PR DESCRIPTION
Cast `elf32_off`/`elf64_off` to `uint64_t` and use `%llu` format specifier to ensure compatibility with both 32-bit and 64-bit platforms.

Part of https://github.com/zephyrproject-rtos/zephyr/issues/96968