### PR TITLE
include: linker: Set eh_frame size to 0 when C++ exceptions are disabled

### DIFF
--- a/include/zephyr/linker/cplusplus-rom.ld
+++ b/include/zephyr/linker/cplusplus-rom.ld
@@ -30,5 +30,9 @@
 #endif /* CONFIG_CPP */
 
 #if !defined(CONFIG_CPP_EXCEPTIONS)
+	PROVIDE(__eh_frame_start = 0);
+	PROVIDE(__eh_frame_end = 0);
+	PROVIDE(__eh_frame_hdr_start = 0);
+	PROVIDE(__eh_frame_hdr_end = 0);
 	/DISCARD/ : { *(.eh_frame) }
 #endif


### PR DESCRIPTION
When building Zephyr with CONFIG_CPP_EXCEPTIONS=n and linking against a
libc++ built with support for exceptions, lld complains that the
eh_frame-related symbols are missing:

ld.lld: error: undefined symbol: __eh_frame_start
ld.lld: error: undefined symbol: __eh_frame_end
ld.lld: error: undefined symbol: __eh_frame_hdr_start
ld.lld: error: undefined symbol: __eh_frame_hdr_end

libunwind handles the zero size:

https://github.com/llvm/llvm-project/blob/76e71e05d2687f602695931b2fbf25e4e262dcc4/libunwind/src/AddressSpace.hpp#L520-L526
https://github.com/llvm/llvm-project/blob/76e71e05d2687f602695931b2fbf25e4e262dcc4/libunwind/src/EHHeaderParser.hpp#L61-L64