### PR TITLE
scripts: checkpatch.pl: relax `Missing a blank line`

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -862,7 +862,7 @@ our $LvalOrFunc	= qr{((?:[\&\*]\s*)?$Lval)\s*($balanced_parens{0,1})\s*};
 our $FuncArg = qr{$Typecast{0,1}($LvalOrFunc|$Constant|$String)};
 
 our $declaration_macros = qr{(?x:
-	(?:$Storage\s+)?(?:[A-Z_][A-Z0-9]*_){0,2}(?:DEFINE|DECLARE)(?:_[A-Z0-9]+){1,6}\s*\(|
+	(?:$Storage\s+)?(?:[A-Z_][A-Z0-9]*_){0,2}(?:DEFINE|DECLARE)(?:_[A-Z0-9]+){0,6}\s*\(|
 	(?:$Storage\s+)?[HLP]?LIST_HEAD\s*\(|
 	(?:SKCIPHER_REQUEST|SHASH_DESC|AHASH_REQUEST)_ON_STACK\s*\(
 )};


### PR DESCRIPTION
Relax the `Missing a blank line after declarations` checkpatch error by loosening the requirements for a macro to be treated as one that declares a variable.

Currently the regex matches the pattern `DECLARE` or `DEFINE`, as long as there are between 1 and 6 trailing `_FOO` components to the macro name (e.g. `DECLARE_MY_TYPE()`). Zephyr however contains many macros that don't have the trailing components but still resolve to variables (e.g. `ATOMIC_DEFINE`, `K_MUTEX_DEFINE, etc`).

By changing `{1,6}` to `{0,6}`, we remove the requirement for the trailing `_FOO` component(s) while still allowing them. This stops checkpatch from erroring on patterns like this:
```
struct driver_data {
	uint16_t some_value;
	ATOMIC_DEFINE(some_atomic, 16);
};
```