### PR TITLE
driver: espi_rts5912: Set STS0 only when input buffer has data

### DIFF
--- a/drivers/espi/espi_realtek_rts5912.c
+++ b/drivers/espi/espi_realtek_rts5912.c
@@ -471,8 +471,11 @@ static void promt0_ibf_isr(const struct device *dev)
 				 .evt_details = ESPI_PERIPHERAL_EC_HOST_CMD,
 				 .evt_data = ESPI_PERIPHERAL_NODATA};
 
-	promt0_reg->STS |= ACPI_STS_STS0;
-	evt.evt_data = (uint8_t)promt0_reg->IB;
+	if (promt0_reg->STS & ACPI_STS_IBF) {
+		promt0_reg->STS |= ACPI_STS_STS0;
+		evt.evt_data = (uint8_t)promt0_reg->IB;
+	}
+
 	espi_send_callbacks(&data->callbacks, dev, evt);
 }
 


### PR DESCRIPTION
When using the eSPI peripheral channel for HOST_CMD, the STS0 bit indicates that EC is busy.
To reflect this properly,
STS0 should only be set when there is actual input data to process.

This avoids falsely signaling a busy state when there is no data.