### PR TITLE
drivers: hwinfo: Memoize the USN fetched on MAX32

### DIFF
--- a/boards/adi/max32655evkit/max32655evkit_max32655_m4.yaml
+++ b/boards/adi/max32655evkit/max32655evkit_max32655_m4.yaml
@@ -9,6 +9,7 @@ toolchain:
 supported:
   - gpio
   - serial
+  - hwinfo
   - trng
   - i2c
   - dma

--- a/boards/adi/max32657evkit/max32657evkit_max32657.yaml
+++ b/boards/adi/max32657evkit/max32657evkit_max32657.yaml
@@ -11,6 +11,7 @@ supported:
   - gpio
   - trng
   - watchdog
+  - hwinfo
   - dma
   - counter
   - pwm

--- a/boards/adi/max32690evkit/max32690evkit_max32690_m4.yaml
+++ b/boards/adi/max32690evkit/max32690evkit_max32690_m4.yaml
@@ -9,6 +9,7 @@ toolchain:
 supported:
   - gpio
   - serial
+  - hwinfo
   - spi
   - i2c
   - trng

--- a/boards/adi/max78002evkit/max78002evkit_max78002_m4.yaml
+++ b/boards/adi/max78002evkit/max78002evkit_max78002_m4.yaml
@@ -9,6 +9,7 @@ toolchain:
 supported:
   - gpio
   - serial
+  - hwinfo
   - trng
   - i2c
   - dma

--- a/drivers/hwinfo/hwinfo_max32.c
+++ b/drivers/hwinfo/hwinfo_max32.c
@@ -4,21 +4,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/hwinfo.h>
 #include <soc.h>
 #include <wrap_max32_sys.h>
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
 
+static struct k_spinlock device_id_lock;
+static bool initialized;
+static uint8_t usn[MXC_SYS_USN_LEN];
+
 ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
-	uint8_t usn[MXC_SYS_USN_LEN];
-	int error;
+	int ret;
+	k_spinlock_key_t key;
 
-	error = Wrap_MXC_SYS_GetUSN(usn);
-	if (error != E_NO_ERROR) {
-		/* Error reading USN */
-		return error;
+	key = k_spin_lock(&device_id_lock);
+
+	if (!initialized) {
+		ret = Wrap_MXC_SYS_GetUSN(usn);
+
+		if (ret != E_NO_ERROR) {
+			/* Error reading USN */
+			goto exit;
+		}
+
+		initialized = true;
 	}
 
 	if (length > sizeof(usn)) {
@@ -27,6 +39,9 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 
 	/* Provide device ID in big endian */
 	sys_memcpy_swap(buffer, usn, length);
+	ret = length;
 
-	return length;
+exit:
+	k_spin_unlock(&device_id_lock, key);
+	return ret;
 }


### PR DESCRIPTION
To avoid issues with multiple calls to fetch the USN returning garbage data, memoize the returned USN value and re-use it on subsequent calls.