### PR TITLE
soc: nordic: nrf54h: Disable code relocation for MCUBOOT

### DIFF
--- a/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuapp
+++ b/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuapp
@@ -15,6 +15,6 @@ config POWER_DOMAIN
 	default y
 
 config CODE_DATA_RELOCATION
-	default y if PM || POWEROFF
+	default y if (PM || POWEROFF) && !MCUBOOT
 
 endif # SOC_NRF54H20_CPUAPP

--- a/soc/nordic/nrf54h/power.c
+++ b/soc/nordic/nrf54h/power.c
@@ -88,7 +88,12 @@ void nrf_poweroff(void)
 	CODE_UNREACHABLE;
 }
 
-static __attribute__((__used__, noinline)) void cache_retain_and_sleep(void)
+#if CONFIG_MCUBOOT
+static __ramfunc
+#else
+static __attribute__((__used__, noinline))
+#endif
+void cache_retain_and_sleep(void)
 {
 	nrf_cache_task_trigger(NRF_DCACHE, NRF_CACHE_TASK_SAVE);
 	nrf_cache_task_trigger(NRF_ICACHE, NRF_CACHE_TASK_SAVE);


### PR DESCRIPTION
MCUBOOT requires LTO to be enabled, while using code relocation forces switching it off. When `__ramfunc` is used, LTO can also be used. Then the `cache_retain_and_sleep` function will work correctly, but slightly slower.