### PR TITLE
boards: nordic: nrf54lm20dk: remove support for wdt from flpr

### DIFF
--- a/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuflpr.yaml
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuflpr.yaml
@@ -13,4 +13,3 @@ flash: 96
 supported:
   - counter
   - gpio
-  - watchdog


### PR DESCRIPTION
Should not be added in first place, never working.