### PR TITLE
kernel: update platform hooks documentation and usage

### DIFF
--- a/arch/arc/core/prep_c.c
+++ b/arch/arc/core/prep_c.c
@@ -84,9 +84,7 @@ extern void arc_secureshield_init(void);
 
 FUNC_NORETURN void z_prep_c(void)
 {
-#if defined(CONFIG_SOC_PREP_HOOK)
 	soc_prep_hook();
-#endif
 
 #ifdef CONFIG_ISA_ARCV3
 	arc_cluster_scm_enable();

--- a/arch/arm/core/cortex_a_r/prep_c.c
+++ b/arch/arm/core/cortex_a_r/prep_c.c
@@ -100,9 +100,8 @@ extern FUNC_NORETURN void z_cstart(void);
  */
 FUNC_NORETURN void z_prep_c(void)
 {
-#if defined(CONFIG_SOC_PREP_HOOK)
 	soc_prep_hook();
-#endif
+
 	/* Initialize tpidruro with our struct _cpu instance address */
 	write_tpidruro((uintptr_t)&_kernel.cpus[0]);
 

--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -197,9 +197,7 @@ extern FUNC_NORETURN void z_cstart(void);
  */
 FUNC_NORETURN void z_prep_c(void)
 {
-#if defined(CONFIG_SOC_PREP_HOOK)
 	soc_prep_hook();
-#endif
 
 	relocate_vector_table();
 #if defined(CONFIG_CPU_HAS_FPU)

--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -35,9 +35,7 @@ __weak void z_arm64_mm_init(bool is_primary_core) { }
  */
 FUNC_NORETURN void z_prep_c(void)
 {
-#if defined(CONFIG_SOC_PREP_HOOK)
 	soc_prep_hook();
-#endif
 
 	/* Initialize tpidrro_el0 with our struct _cpu instance address */
 	write_tpidrro_el0((uintptr_t)&_kernel.cpus[0]);

--- a/arch/mips/core/prep_c.c
+++ b/arch/mips/core/prep_c.c
@@ -47,9 +47,8 @@ static void interrupt_init(void)
 
 FUNC_NORETURN void z_prep_c(void)
 {
-#if defined(CONFIG_SOC_PREP_HOOK)
 	soc_prep_hook();
-#endif
+
 	arch_bss_zero();
 
 	interrupt_init();

--- a/arch/riscv/core/prep_c.c
+++ b/arch/riscv/core/prep_c.c
@@ -36,9 +36,7 @@ void soc_interrupt_init(void);
 
 FUNC_NORETURN void z_prep_c(void)
 {
-#if defined(CONFIG_SOC_PREP_HOOK)
 	soc_prep_hook();
-#endif
 
 	arch_bss_zero();
 	arch_data_copy();

--- a/arch/sparc/core/prep_c.c
+++ b/arch/sparc/core/prep_c.c
@@ -22,9 +22,8 @@
 
 FUNC_NORETURN void z_prep_c(void)
 {
-#if defined(CONFIG_SOC_PREP_HOOK)
 	soc_prep_hook();
-#endif
+
 	arch_data_copy();
 #if CONFIG_ARCH_CACHE
 	arch_cache_init();

--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -36,9 +36,8 @@ FUNC_NORETURN void z_prep_c(void *arg)
 {
 	x86_boot_arg_t *cpu_arg = arg;
 
-#if defined(CONFIG_SOC_PREP_HOOK)
 	soc_prep_hook();
-#endif
+
 	_kernel.cpus[0].nested = 0;
 
 #ifdef CONFIG_MMU

--- a/arch/xtensa/core/prep_c.c
+++ b/arch/xtensa/core/prep_c.c
@@ -31,9 +31,8 @@ BUILD_ASSERT(CONFIG_DCACHE_LINE_SIZE == XCHAL_DCACHE_LINESIZE);
  */
 FUNC_NORETURN void z_prep_c(void)
 {
-#if defined(CONFIG_SOC_PREP_HOOK)
 	soc_prep_hook();
-#endif
+
 #if CONFIG_SOC_HAS_RUNTIME_NUM_CPUS
 	soc_num_cpus_init();
 #endif

--- a/include/zephyr/platform/hooks.h
+++ b/include/zephyr/platform/hooks.h
@@ -8,14 +8,14 @@
 
 /**
  * @file
- * @brief Soc and Board hooks
+ * @brief SoC and Board hooks
  *
  * This header file contains function prototypes for the interfaces between
- * zephyr architecture and initialization code and the SoC and board specific logic
+ * Zephyr's architecture and initialization code and SoC/board-specific logic
  * that resides under boards/ and soc/
  *
- * @note These are all standard soc and board interfaces that are exported from
- * soc and board specific logic to OS internal logic.  These should never be accessed
+ * @note These are all standard SoC and board interfaces that are exported from
+ * SoC/board-specific logic to OS internal logic. These should never be accessed
  * directly from application code but may be freely used within the OS.
  */
 

--- a/include/zephyr/platform/hooks.h
+++ b/include/zephyr/platform/hooks.h
@@ -19,7 +19,7 @@
  * directly from application code but may be freely used within the OS.
  */
 
-#ifdef CONFIG_SOC_EARLY_RESET_HOOK
+#if defined(CONFIG_SOC_EARLY_RESET_HOOK) || defined(__DOXYGEN__)
 /**
  * @brief SoC hook executed before data RAM initialization, at the beginning
  * of the reset vector.
@@ -33,9 +33,9 @@ void soc_early_reset_hook(void);
 #define soc_early_reset_hook() do { } while (0)
 #endif
 
-#ifdef CONFIG_SOC_RESET_HOOK
+#if defined(CONFIG_SOC_RESET_HOOK) || defined(__DOXYGEN__)
 /**
- * @brief SoC  hook executed at the beginning of the reset vector.
+ * @brief SoC hook executed at the beginning of the reset vector.
  *
  * This hook is implemented by the SoC and can be used to perform any
  * SoC-specific initialization.
@@ -45,7 +45,7 @@ void soc_reset_hook(void);
 #define soc_reset_hook() do { } while (0)
 #endif
 
-#ifdef CONFIG_SOC_PREP_HOOK
+#if defined(CONFIG_SOC_PREP_HOOK) || defined(__DOXYGEN__)
 /**
  * @brief SoC hook executed after the reset vector.
  *
@@ -57,7 +57,7 @@ void soc_prep_hook(void);
 #define soc_prep_hook() do { } while (0)
 #endif
 
-#ifdef CONFIG_SOC_EARLY_INIT_HOOK
+#if defined(CONFIG_SOC_EARLY_INIT_HOOK) || defined(__DOXYGEN__)
 /**
  * @brief SoC hook executed before the kernel and devices are initialized.
  *
@@ -69,7 +69,7 @@ void soc_early_init_hook(void);
 #define soc_early_init_hook() do { } while (0)
 #endif
 
-#ifdef CONFIG_SOC_LATE_INIT_HOOK
+#if defined(CONFIG_SOC_LATE_INIT_HOOK) || defined(__DOXYGEN__)
 /**
  * @brief SoC hook executed after the kernel and devices are initialized.
  *
@@ -81,7 +81,7 @@ void soc_late_init_hook(void);
 #define soc_late_init_hook() do { } while (0)
 #endif
 
-#ifdef CONFIG_SOC_PER_CORE_INIT_HOOK
+#if defined(CONFIG_SOC_PER_CORE_INIT_HOOK) || defined(__DOXYGEN__)
 /**
  * @brief SoC per-core initialization
  *
@@ -93,7 +93,7 @@ void soc_per_core_init_hook(void);
 #define soc_per_core_init_hook() do { } while (0)
 #endif
 
-#ifdef CONFIG_BOARD_EARLY_INIT_HOOK
+#if defined(CONFIG_BOARD_EARLY_INIT_HOOK) || defined(__DOXYGEN__)
 /**
  * @brief Board hook executed before the kernel starts.
  *
@@ -106,7 +106,7 @@ void board_early_init_hook(void);
 #define board_early_init_hook() do { } while (0)
 #endif
 
-#ifdef CONFIG_BOARD_LATE_INIT_HOOK
+#if defined(CONFIG_BOARD_LATE_INIT_HOOK) || defined(__DOXYGEN__)
 /**
  * @brief Board hook executed after the kernel starts.
  *


### PR DESCRIPTION
Update documentation related to platform hooks:
* make sure the hook functions' documentation is actually visible - currently, the dummy no-op macros are seen instead (c.f. https://docs.zephyrproject.org/latest/doxygen/html/hooks_8h.html)
* update architecture porting documentation to include a section about hooks that must be implemented in arch-specific code
  * this should reflect current practices and expectations
* clean up unnecessary `#ifdef` check in architecture files

https://builds.zephyrproject.io/zephyr/pr/97099/docs/hardware/porting/arch.html#early-boot-sequence-hooks