### PR TITLE
samples/subsys/instrumentation: add missing `sample.yaml`

### DIFF
--- a/samples/subsys/instrumentation/sample.yaml
+++ b/samples/subsys/instrumentation/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  name: Instrumentation subsystem sample
+tests:
+  sample.instrumentation:
+    platform_allow:
+      - b_u585i_iot02a
+      - mps2/an385
+    tags: instrumentation
+    build_only: true


### PR DESCRIPTION
This PR adds a missing `sample.yaml` file to the instrumentation subsystem sample.