### PR TITLE
copyrights: fix copyright line

### DIFF
--- a/boards/u-blox/ubx_evk_iris_w1/CMakeLists.txt
+++ b/boards/u-blox/ubx_evk_iris_w1/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
-#Copyright 2022-2025 NXP
-#Copyright(c)2025 u-blox AG
-#SPDX-License-Identifier:Apache-2.0
+# Copyright 2022-2025 NXP
+# Copyright (c) 2025 u-blox AG
+# SPDX-License-Identifier: Apache-2.0
 #
 
 if(CONFIG_NXP_RW6XX_BOOT_HEADER)

--- a/boards/vcc-gnd/yd_stm32h750vb/Kconfig.defconfig
+++ b/boards/vcc-gnd/yd_stm32h750vb/Kconfig.defconfig
@@ -1,6 +1,6 @@
 # YD-STM32H750VB board configuration
 
-# Copyright(c) 2024 John Sanpe <sanpeqf@gmail.com>
+# Copyright (c) 2024 John Sanpe <sanpeqf@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_YD_STM32H750VB

--- a/boards/vcc-gnd/yd_stm32h750vb/Kconfig.yd_stm32h750vb
+++ b/boards/vcc-gnd/yd_stm32h750vb/Kconfig.yd_stm32h750vb
@@ -1,6 +1,6 @@
 # YD-STM32H750VB board configuration
 
-# Copyright(c) 2024 John Sanpe <sanpeqf@gmail.com>
+# Copyright (c) 2024 John Sanpe <sanpeqf@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_YD_STM32H750VB

--- a/boards/vcc-gnd/yd_stm32h750vb/yd_stm32h750vb.dts
+++ b/boards/vcc-gnd/yd_stm32h750vb/yd_stm32h750vb.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2024 John Sanpe <sanpeqf@gmail.com>
+ * Copyright (c) 2024 John Sanpe <sanpeqf@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/vcc-gnd/yd_stm32h750vb/yd_stm32h750vb_defconfig
+++ b/boards/vcc-gnd/yd_stm32h750vb/yd_stm32h750vb_defconfig
@@ -1,4 +1,4 @@
-# Copyright(c) 2024 John Sanpe <sanpeqf@gmail.com>
+# Copyright (c) 2024 John Sanpe <sanpeqf@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 # Enable the internal SMPS regulator

--- a/boards/weact/blackpill_h523ce/Kconfig.blackpill_h523ce
+++ b/boards/weact/blackpill_h523ce/Kconfig.blackpill_h523ce
@@ -1,4 +1,4 @@
-# Copyright(c) 2025 Filip Stojanovic
+# Copyright (c) 2025 Filip Stojanovic
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_BLACKPILL_H523CE

--- a/boards/weact/blackpill_h523ce/blackpill_h523ce_defconfig
+++ b/boards/weact/blackpill_h523ce/blackpill_h523ce_defconfig
@@ -1,4 +1,4 @@
-# Copyright(c) 2025 Filip Stojanovic <filipembedded@gmail.com>
+# Copyright (c) 2025 Filip Stojanovic <filipembedded@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 # Enable MPU

--- a/drivers/dac/Kconfig.samd5x
+++ b/drivers/dac/Kconfig.samd5x
@@ -1,4 +1,4 @@
-# Copyright(c) 2025 Daikin Comfort Technologies North America, Inc.
+# Copyright (c) 2025 Daikin Comfort Technologies North America, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 config DAC_SAMD5X

--- a/drivers/ethernet/Kconfig.xilinx_axienet
+++ b/drivers/ethernet/Kconfig.xilinx_axienet
@@ -1,8 +1,8 @@
 #
-#Xilinx AXI 1G / 2.5G Ethernet Subsystem
+# Xilinx AXI 1G / 2.5G Ethernet Subsystem
 #
-#Copyright(c) 2024, CISPA Helmholtz Center for Information Security
-#SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024, CISPA Helmholtz Center for Information Security
+# SPDX-License-Identifier: Apache-2.0
 #
 
 config ETH_XILINX_AXIENET

--- a/drivers/ethernet/dwc_xgmac/Kconfig
+++ b/drivers/ethernet/dwc_xgmac/Kconfig
@@ -1,7 +1,7 @@
 #
 # Synopsys DesignWare XGMAC configuration options
 #
-# Copyright(c) 2024, Intel Corporation
+# Copyright (c) 2024, Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/drivers/ethernet/eth_xilinx_axienet.c
+++ b/drivers/ethernet/eth_xilinx_axienet.c
@@ -1,7 +1,7 @@
 /*
  * Xilinx AXI 1G / 2.5G Ethernet Subsystem
  *
- * Copyright(c) 2024, CISPA Helmholtz Center for Information Security
+ * Copyright (c) 2024, CISPA Helmholtz Center for Information Security
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/drivers/mdio/mdio_xilinx_axienet.c
+++ b/drivers/mdio/mdio_xilinx_axienet.c
@@ -1,7 +1,7 @@
 /*
  * Xilinx AXI 1G / 2.5G Ethernet Subsystem
  *
- * Copyright(c) 2024, CISPA Helmholtz Center for Information Security
+ * Copyright (c) 2024, CISPA Helmholtz Center for Information Security
  * SPDX - License - Identifier : Apache-2.0
  */
 #include <zephyr/logging/log.h>

--- a/drivers/sensor/Kconfig.sensor_clock
+++ b/drivers/sensor/Kconfig.sensor_clock
@@ -1,5 +1,5 @@
 # Sensor clock configuration options
-# Copyright(c) 2024 Cienet
+# Copyright (c) 2024 Cienet
 # SPDX-License-Identifier: Apache-2.0
 
 config SENSOR_CLOCK

--- a/drivers/sensor/adi/adltc2990/CMakeLists.txt
+++ b/drivers/sensor/adi/adltc2990/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright(c) 2023 Carl Zeiss Meditec AG
+# Copyright (c) 2023 Carl Zeiss Meditec AG
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()

--- a/drivers/sensor/adi/adltc2990/Kconfig
+++ b/drivers/sensor/adi/adltc2990/Kconfig
@@ -1,6 +1,6 @@
 # ADLTC2990 Quad I2C Voltage, Current and Temperature sensor configuration options
 
-# Copyright(c) 2023 Carl Zeiss Meditec AG
+# Copyright (c) 2023 Carl Zeiss Meditec AG
 # SPDX-License-Identifier: Apache-2.0
 
 config ADLTC2990

--- a/drivers/sensor/apds9253/Kconfig
+++ b/drivers/sensor/apds9253/Kconfig
@@ -1,5 +1,5 @@
-# Copyright(c) 2017 Intel Corporation
-# Copyright(c) 2018 Phytec Messtechnik GmbH
+# Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2018 Phytec Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
 config APDS9253

--- a/drivers/sensor/rohm/bh1790/Kconfig
+++ b/drivers/sensor/rohm/bh1790/Kconfig
@@ -1,6 +1,6 @@
 # BH1790 BH1790 Optical Sensor for Heart Rate Monitor IC sensor configuration options
 
-# Copyright(c) 2025 Magpie Embedded
+# Copyright (c) 2025 Magpie Embedded
 # SPDX-License-Identifier: Apache-2.0
 
 config BH1790

--- a/drivers/sensor/ti/bq274xx/bq274xx.h
+++ b/drivers/sensor/ti/bq274xx/bq274xx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020 Linumiz
+ * Copyright (c) 2020 Linumiz
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/dts/bindings/ethernet/snps,dwcxgmac.yaml
+++ b/dts/bindings/ethernet/snps,dwcxgmac.yaml
@@ -1,4 +1,4 @@
-# Copyright(c) 2024 Intel Corporation.
+# Copyright (c) 2024 Intel Corporation.
 # SPDX - License - Identifier : Apache - 2.0
 
 compatible: "snps,dwcxgmac"

--- a/dts/bindings/mdio/snps,dwcxgmac-mdio.yaml
+++ b/dts/bindings/mdio/snps,dwcxgmac-mdio.yaml
@@ -1,4 +1,4 @@
-# Copyright(c) 2024 Intel Corporation.
+# Copyright (c) 2024 Intel Corporation.
 # SPDX - License - Identifier : Apache - 2.0
 
 description: Synopsys DWC XGMAC MDIO SMA Driver node

--- a/dts/bindings/modem/sqn,gm02s.yaml
+++ b/dts/bindings/modem/sqn,gm02s.yaml
@@ -1,4 +1,4 @@
-# Copyright(c) 2024 DPTechnics bv
+# Copyright (c) 2024 DPTechnics bv
 # SPDX-License-Identifier: Apache-2.0
 
 description: Sequans Monarch 2 GM02S Modem

--- a/dts/bindings/modem/telit,me910g1.yaml
+++ b/dts/bindings/modem/telit,me910g1.yaml
@@ -1,4 +1,4 @@
-# Copyright(c) 2023 Jeff Welder (Ellenby Technologies, Inc.)
+# Copyright (c) 2023 Jeff Welder (Ellenby Technologies, Inc.)
 # SPDX-License-Identifier: Apache-2.0
 
 description: Telit ME910G1 Modem

--- a/dts/bindings/sensor/avago,apds9253.yaml
+++ b/dts/bindings/sensor/avago,apds9253.yaml
@@ -1,4 +1,4 @@
-# Copyright(c) 2018, Phytec Messtechnik GmbH
+# Copyright (c) 2018, Phytec Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
 description: APDS9253 ambient light, RGB

--- a/include/zephyr/usb/class/usb_dfu.h
+++ b/include/zephyr/usb/class/usb_dfu.h
@@ -2,8 +2,8 @@
 
 /***************************************************************************
  *
- * Copyright(c) 2015,2016 Intel Corporation.
- * Copyright(c) 2017 PHYTEC Messtechnik GmbH
+ * Copyright (c) 2015,2016 Intel Corporation.
+ * Copyright (c) 2017 PHYTEC Messtechnik GmbH
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/scripts/net/enumerate_http_status.py
+++ b/scripts/net/enumerate_http_status.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright(c) 2022 Meta
+# Copyright (c) 2022 Meta
 # SPDX-License-Identifier: Apache-2.0
 
 """Format HTTP Status codes for use in a C header

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright(c) 2023 Google LLC
+# Copyright (c) 2023 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/soc/amd/acp_6_0/adsp/memory.h
+++ b/soc/amd/acp_6_0/adsp/memory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2022 AMD
+ * Copyright (c) 2022 AMD
  * SPDX-License-Identifier: Apache-2.0
  *
  * Author:      Basavaraj Hiregoudar <basavaraj.hiregoudar@amd.com>

--- a/soc/intel/intel_adsp/ace/boot.c
+++ b/soc/intel/intel_adsp/ace/boot.c
@@ -1,4 +1,4 @@
-/* Copyright(c) 2021 Intel Corporation. All rights reserved.
+/* Copyright (c) 2021 Intel Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/soc/intel/intel_adsp/ace/sram.c
+++ b/soc/intel/intel_adsp/ace/sram.c
@@ -1,4 +1,4 @@
-/* Copyright(c) 2021 Intel Corporation. All rights reserved.
+/* Copyright (c) 2021 Intel Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/soc/intel/intel_adsp/cavs/sram.c
+++ b/soc/intel/intel_adsp/cavs/sram.c
@@ -1,4 +1,4 @@
-/* Copyright(c) 2021 Intel Corporation. All rights reserved.
+/* Copyright (c) 2021 Intel Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/soc/intel/intel_adsp/common/boot.c
+++ b/soc/intel/intel_adsp/common/boot.c
@@ -1,4 +1,4 @@
-/* Copyright(c) 2021 Intel Corporation. All rights reserved.
+/* Copyright (c) 2021 Intel Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/soc/intel/intel_adsp/common/boot_complete.c
+++ b/soc/intel/intel_adsp/common/boot_complete.c
@@ -1,4 +1,4 @@
-/* Copyright(c) 2022 Intel Corporation. All rights reserved.
+/* Copyright (c) 2022 Intel Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/soc/intel/intel_adsp/common/include/manifest.h
+++ b/soc/intel/intel_adsp/common/include/manifest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2017 Intel Corporation. All rights reserved.
+ * Copyright (c) 2017 Intel Corporation. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/soc/intel/intel_adsp/common/mem_window.c
+++ b/soc/intel/intel_adsp/common/mem_window.c
@@ -1,4 +1,4 @@
-/* Copyright(c) 2022 Intel Corporation. All rights reserved.
+/* Copyright (c) 2022 Intel Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/soc/intel/intel_adsp/tools/acetool.py
+++ b/soc/intel/intel_adsp/tools/acetool.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright(c) 2022 Intel Corporation. All rights reserved.
+# Copyright (c) 2022 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio

--- a/soc/intel/intel_adsp/tools/cavstool.py
+++ b/soc/intel/intel_adsp/tools/cavstool.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright(c) 2022 Intel Corporation. All rights reserved.
+# Copyright (c) 2022 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import os
 import sys

--- a/soc/intel/intel_adsp/tools/cavstool_client.py
+++ b/soc/intel/intel_adsp/tools/cavstool_client.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright(c) 2022 Intel Corporation. All rights reserved.
+# Copyright (c) 2022 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import os
 import sys

--- a/soc/intel/intel_adsp/tools/remote-fw-service.py
+++ b/soc/intel/intel_adsp/tools/remote-fw-service.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright(c) 2022 Intel Corporation. All rights reserved.
+# Copyright (c) 2022 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import os
 import sys

--- a/soc/openhwgroup/cva6/cva6.h
+++ b/soc/openhwgroup/cva6/cva6.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2024, CISPA Helmholtz Center for Information Security
+ * Copyright (c) 2024, CISPA Helmholtz Center for Information Security
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/soc/openhwgroup/cva6/soc_cache_management.c
+++ b/soc/openhwgroup/cva6/soc_cache_management.c
@@ -1,7 +1,7 @@
 /*
  * Non-standard CVA6 cache management operations.
  *
- * Copyright(c) 2024, CISPA Helmholtz Center for Information Security
+ * Copyright (c) 2024, CISPA Helmholtz Center for Information Security
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stddef.h>

--- a/subsys/net/lib/prometheus/CMakeLists.txt
+++ b/subsys/net/lib/prometheus/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright(c) 2024 Sparse Technology, Mustafa Abdullah Kus
+# Copyright (c) 2024 Sparse Technology, Mustafa Abdullah Kus
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_include_directories(.)

--- a/subsys/net/lib/prometheus/Kconfig
+++ b/subsys/net/lib/prometheus/Kconfig
@@ -1,4 +1,4 @@
-# Copyright(c) 2024 Sparse Technology, Mustafa Abdullah Kus
+# Copyright (c) 2024 Sparse Technology, Mustafa Abdullah Kus
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig PROMETHEUS

--- a/subsys/testsuite/include/zephyr/fff_extensions.h
+++ b/subsys/testsuite/include/zephyr/fff_extensions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2023 Legrand North America, LLC.
+ * Copyright (c) 2023 Legrand North America, LLC.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *
- * Copyright(c) 2015-2019 Intel Corporation.
+ * Copyright (c) 2015-2019 Intel Corporation.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/subsys/usb/device/class/dfu/usb_dfu.c
+++ b/subsys/usb/device/class/dfu/usb_dfu.c
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *
- * Copyright(c) 2015,2016 Intel Corporation.
- * Copyright(c) 2017 PHYTEC Messtechnik GmbH
+ * Copyright (c) 2015,2016 Intel Corporation.
+ * Copyright (c) 2017 PHYTEC Messtechnik GmbH
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
Add space before (c) to allow correct parsing by linters.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
