### PR TITLE
drivers: nrf: Add missing SoC header includes to adc and i2s

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -15,6 +15,7 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <dmm.h>
+#include <soc.h>
 
 LOG_MODULE_REGISTER(adc_nrfx_saadc, CONFIG_ADC_LOG_LEVEL);
 

--- a/drivers/i2s/i2s_nrf_tdm.c
+++ b/drivers/i2s/i2s_nrf_tdm.c
@@ -16,6 +16,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <dmm.h>
+#include <soc.h>
 #include <stdlib.h>
 
 LOG_MODULE_REGISTER(tdm_nrf, CONFIG_I2S_LOG_LEVEL);


### PR DESCRIPTION
Add missing SoC header include required by memory region assertion to adc_nrfx_saadc and i2s_nrf_tdm shims.