### PR TITLE
intel_adsp: Introduce debug slot manager

### DIFF
--- a/soc/intel/intel_adsp/Kconfig
+++ b/soc/intel/intel_adsp/Kconfig
@@ -87,6 +87,15 @@ config MEMORY_WIN_3_SIZE
 
 	  This window is used for trace.
 
+config INTEL_ADSP_DEBUG_SLOT_MANAGER
+	bool "Debug slot manager"
+	help
+	  If selected the debug slot allocation can be only done via
+	  the manager API, direct debug window access and tampering is
+	  forbidden.
+	  The API use allows dynamic slot allocation instead of static
+	  and error prone slot usage.
+
 config ADSP_CLOCK
 	bool
 	help

--- a/soc/intel/intel_adsp/Kconfig
+++ b/soc/intel/intel_adsp/Kconfig
@@ -73,11 +73,11 @@ config MEMORY_WIN_1_SIZE
 
 config MEMORY_WIN_2_SIZE
 	int "Size of memory window 2"
-	default 8192
+	default 12288
 	help
 	  Size of memory window 2.
 
-	  This window is used for debug.
+	  This window is used for debug, default size is 12288 bytes
 
 config MEMORY_WIN_3_SIZE
 	int "Size of memory window 3"

--- a/soc/intel/intel_adsp/common/CMakeLists.txt
+++ b/soc/intel/intel_adsp/common/CMakeLists.txt
@@ -25,6 +25,10 @@ zephyr_library_sources(
 
 zephyr_library_sources_ifdef(CONFIG_ADSP_CLOCK clk.c)
 
+zephyr_library_sources_ifdef(CONFIG_INTEL_ADSP_DEBUG_SLOT_MANAGER
+    debug_window.c
+    )
+
 if(CONFIG_SMP OR CONFIG_MP_MAX_NUM_CPUS GREATER 1)
   zephyr_library_sources(multiprocessing.c)
 endif()

--- a/soc/intel/intel_adsp/common/debug_window.c
+++ b/soc/intel/intel_adsp/common/debug_window.c
@@ -1,0 +1,187 @@
+/* Copyright (c) 2025 Intel Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <adsp_memory.h>
+#include <adsp_debug_window.h>
+#include <zephyr/cache.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(debug_window, CONFIG_SOC_LOG_LEVEL);
+
+struct adsp_debug_window {
+	struct adsp_dw_desc descs[ADSP_DW_DESC_COUNT];
+	uint8_t reserved[ADSP_DW_PAGE0_SLOT_OFFSET -
+			 ADSP_DW_DESC_COUNT * sizeof(struct adsp_dw_desc)];
+	uint8_t partial_page0[ADSP_DW_SLOT_SIZE - ADSP_DW_PAGE0_SLOT_OFFSET];
+	uint8_t slots[ADSP_DW_SLOT_COUNT][ADSP_DW_SLOT_SIZE];
+} __packed;
+
+#define WIN2_MBASE		DT_REG_ADDR(DT_PHANDLE(DT_NODELABEL(mem_window2), memory))
+#define WIN2_SLOTS		((HP_SRAM_WIN2_SIZE / ADSP_DW_PAGE_SIZE) - 1)
+#define ADSP_DW_FULL_SLOTS	MIN(WIN2_SLOTS, ADSP_DW_SLOT_COUNT)
+
+#define ADSP_DW ((struct adsp_debug_window *) \
+		  (sys_cache_uncached_ptr_get((__sparse_force void __sparse_cache *) \
+				     (WIN2_MBASE + WIN2_OFFSET))))
+
+static int adsp_dw_find_unused_slot(bool prefer_partial)
+{
+	int i;
+
+	if (prefer_partial) {
+		if (ADSP_DW->descs[ADSP_DW_SLOT_COUNT].type == ADSP_DW_SLOT_UNUSED) {
+			return ADSP_DW_SLOT_COUNT;
+		}
+	}
+
+	for (i = 0; i < ADSP_DW_FULL_SLOTS; i++) {
+		if (ADSP_DW->descs[i].type == ADSP_DW_SLOT_UNUSED) {
+			return i;
+		}
+	}
+
+	if (!prefer_partial) {
+		if (ADSP_DW->descs[ADSP_DW_SLOT_COUNT].type == ADSP_DW_SLOT_UNUSED) {
+			return ADSP_DW_SLOT_COUNT;
+		}
+	}
+
+	return -ENOENT;
+}
+
+static int adsp_dw_find_slot_by_type(uint32_t type)
+{
+	int i;
+
+	for (i = 0; i < ADSP_DW_FULL_SLOTS; i++) {
+		if (ADSP_DW->descs[i].type == type) {
+			return i;
+		}
+	}
+
+	if (ADSP_DW->descs[ADSP_DW_SLOT_COUNT].type == type) {
+		return ADSP_DW_SLOT_COUNT;
+	}
+
+	return -ENOENT;
+}
+
+void *adsp_dw_request_slot(struct adsp_dw_desc *dw_desc, size_t *slot_size)
+{
+	int slot_idx;
+
+	if (!dw_desc->type) {
+		return NULL;
+	}
+
+	/* Check if a slot has been allocated for this type */
+	slot_idx = adsp_dw_find_slot_by_type(dw_desc->type);
+	if (slot_idx >= 0) {
+		if (slot_size) {
+			*slot_size = ADSP_DW_SLOT_SIZE;
+		}
+
+		if (slot_idx == ADSP_DW_SLOT_COUNT) {
+			if (slot_size) {
+				*slot_size -= ADSP_DW_PAGE0_SLOT_OFFSET;
+			}
+			return ADSP_DW->partial_page0;
+		}
+
+		return ADSP_DW->slots[slot_idx];
+	}
+
+	/* Look for an empty slot */
+	slot_idx = adsp_dw_find_unused_slot(!!slot_size);
+	if (slot_idx < 0) {
+		LOG_INF("No available slot for %#x", dw_desc->type);
+		return NULL;
+	}
+
+	ADSP_DW->descs[slot_idx].resource_id = dw_desc->resource_id;
+	ADSP_DW->descs[slot_idx].type = dw_desc->type;
+	ADSP_DW->descs[slot_idx].vma = dw_desc->vma;
+
+	if (slot_size) {
+		*slot_size = ADSP_DW_SLOT_SIZE;
+	}
+
+	if (slot_idx == ADSP_DW_SLOT_COUNT) {
+		if (slot_size) {
+			*slot_size -= ADSP_DW_PAGE0_SLOT_OFFSET;
+		}
+
+		LOG_DBG("Allocating partial page0 to be used for %#x", dw_desc->type);
+
+		return ADSP_DW->partial_page0;
+	}
+
+	LOG_DBG("Allocating debug slot %d to be used for %#x", slot_idx, dw_desc->type);
+
+	return ADSP_DW->slots[slot_idx];
+}
+
+void *adsp_dw_seize_slot(uint32_t slot_index, struct adsp_dw_desc *dw_desc,
+				  size_t *slot_size)
+{
+	if ((slot_index >= ADSP_DW_FULL_SLOTS && slot_index != ADSP_DW_SLOT_COUNT) ||
+	    !dw_desc->type) {
+		return NULL;
+	}
+
+	if (slot_index < ADSP_DW_FULL_SLOTS) {
+		if (ADSP_DW->descs[slot_index].type != ADSP_DW_SLOT_UNUSED) {
+			LOG_INF("Overtaking debug slot %d, used by %#x for %#x", slot_index,
+				ADSP_DW->descs[slot_index].type, dw_desc->type);
+		}
+
+		if (slot_size) {
+			*slot_size = ADSP_DW_SLOT_SIZE;
+		}
+
+		ADSP_DW->descs[slot_index].resource_id = dw_desc->resource_id;
+		ADSP_DW->descs[slot_index].type = dw_desc->type;
+		ADSP_DW->descs[slot_index].vma = dw_desc->vma;
+
+		return ADSP_DW->slots[slot_index];
+	}
+
+	/* The caller is not prepared to handle partial debug slot */
+	if (!slot_size) {
+		return NULL;
+	}
+
+	if (ADSP_DW->descs[slot_index].type != ADSP_DW_SLOT_UNUSED) {
+		LOG_INF("Overtaking partial page0, used by %#x for %#x",
+			ADSP_DW->descs[slot_index].type, dw_desc->type);
+	}
+
+	*slot_size = ADSP_DW_SLOT_SIZE - ADSP_DW_PAGE0_SLOT_OFFSET;
+
+	ADSP_DW->descs[slot_index].resource_id = dw_desc->resource_id;
+	ADSP_DW->descs[slot_index].type = dw_desc->type;
+	ADSP_DW->descs[slot_index].vma = dw_desc->vma;
+
+	return ADSP_DW->partial_page0;
+}
+
+void adsp_dw_release_slot(uint32_t type)
+{
+	int slot_idx;
+
+	slot_idx = adsp_dw_find_slot_by_type(type);
+	if (slot_idx < 0) {
+		return;
+	}
+
+	if (slot_idx == ADSP_DW_SLOT_COUNT) {
+		LOG_DBG("Releasing partial page0 used by %#x", type);
+	} else {
+		LOG_DBG("Releasing debug slot %d used by %#x", slot_idx, type);
+	}
+
+	ADSP_DW->descs[slot_idx].resource_id = 0;
+	ADSP_DW->descs[slot_idx].type = ADSP_DW_SLOT_UNUSED;
+	ADSP_DW->descs[slot_idx].vma = 0;
+}

--- a/soc/intel/intel_adsp/common/gdbstub_backend_sram.c
+++ b/soc/intel/intel_adsp/common/gdbstub_backend_sram.c
@@ -63,7 +63,7 @@ static inline int ring_have_data(const volatile struct gdb_sram_ring *ring)
 static volatile struct gdb_sram_ring *rx;
 static volatile struct gdb_sram_ring *tx;
 
-void z_gdb_backend_init(void)
+int z_gdb_backend_init(void)
 {
 	__ASSERT_NO_MSG(sizeof(ADSP_DW->descs) <= SOF_GDB_WINDOW_OFFSET);
 
@@ -71,6 +71,8 @@ void z_gdb_backend_init(void)
 	tx = sys_cache_uncached_ptr_get(TX_UNCACHED);
 	rx->head = rx->tail = 0;
 	tx->head = tx->tail = 0;
+
+	return 0;
 }
 
 void z_gdb_putchar(unsigned char c)

--- a/soc/intel/intel_adsp/common/include/adsp_debug_window.h
+++ b/soc/intel/intel_adsp/common/include/adsp_debug_window.h
@@ -35,11 +35,34 @@
  * u32 res_id;
  * u32 type;
  * u32 vma;
+ *
+ * The descriptor layout is:
+ *
+ *	--------------------
+ *	| Desc0  - slot0   |
+ *	--------------------
+ *	| Desc1  - slot1   |
+ *	--------------------
+ *	| Desc2  - slot2   |
+ *	--------------------
+ *	|       ...        |
+ *	--------------------
+ *	| Desc13  - slot13 |
+ *	--------------------
+ *	| Desc14  - slot14 |
+ *	--------------------
+ *
+ * Additional descriptor to describe the function of the partial slot at page0:
+ *
+ *	--------------------------
+ *	| Desc15  - page0 + 1024 |
+ *	--------------------------
  */
 
 #define ADSP_DW_PAGE_SIZE		0x1000
 #define ADSP_DW_SLOT_SIZE		ADSP_DW_PAGE_SIZE
 #define ADSP_DW_SLOT_COUNT		15
+#define ADSP_DW_PAGE0_SLOT_OFFSET	1024
 #define ADSP_DW_DESC_COUNT		(ADSP_DW_SLOT_COUNT + 1)
 
 /* debug window slots usage, mutually exclusive options can reuse slots */
@@ -73,7 +96,9 @@ struct adsp_dw_desc {
 
 struct adsp_debug_window {
 	struct adsp_dw_desc descs[ADSP_DW_DESC_COUNT];
-	uint8_t reserved[ADSP_DW_SLOT_SIZE - ADSP_DW_DESC_COUNT * sizeof(struct adsp_dw_desc)];
+	uint8_t reserved[ADSP_DW_PAGE0_SLOT_OFFSET -
+			 ADSP_DW_DESC_COUNT * sizeof(struct adsp_dw_desc)];
+	uint8_t partial_page0[ADSP_DW_SLOT_SIZE - ADSP_DW_PAGE0_SLOT_OFFSET];
 	uint8_t slots[ADSP_DW_SLOT_COUNT][ADSP_DW_SLOT_SIZE];
 } __packed;
 


### PR DESCRIPTION
Currently the debug slots are 'allocated' in wild-west style, no real rules enforced, one has to know exactly which module uses what slots (in hard-wired fashion mostly) which can lead to races and bugs that slots have multiple users and at the same time we still have empty, unused slot(s).

The debug slot manager provides a way for drivers to request a debug slot for their use, or (in case of panic handler) forcibly overtake a given slot.

The debug slot manager can be enabled with a Kconfig change to avoid breakage in compilation - SOF also have modules which tampers with the descriptor page and slots directly.
