### PR TITLE
`Zephyr,power-state` clarify min-residency-us and remove incoherent "consistency" check which was not consistent

### DIFF
--- a/dts/bindings/power/zephyr,power-state.yaml
+++ b/dts/bindings/power/zephyr,power-state.yaml
@@ -1,7 +1,9 @@
 # Copyright (c) 2020, Intel Corporation
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: Properties for power management state
+description: |
+  Properties for power management idle states.
 
 compatible: "zephyr,power-state"
 
@@ -24,9 +26,13 @@ properties:
   min-residency-us:
     type: int
     description: |
-        Minimum residency duration in microseconds. It is the minimum time for a
-        given idle state to be worthwhile energywise. It includes the time to enter
-        in this state.
+      Minimum residency duration in microseconds.
+
+      How much time the residency in a given idle state must last for state entry
+      to be worthwhile energywise. It includes the time to enter into this state
+      and represents the "break-even" time to justify the time and power spent
+      on the work needed for entering and exiting the state based on how much actual energy
+      is saved once in the state, compared to choosing the next shallowest state.
   exit-latency-us:
     type: int
     description: |

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -11,34 +11,6 @@
 BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
 	     "cpus node not defined in Devicetree");
 
-/**
- * Check CPU power state consistency.
- *
- * @param i Power state index.
- * @param node_id CPU node identifier.
- */
-#define CHECK_POWER_STATE_CONSISTENCY(i, node_id)			       \
-	BUILD_ASSERT(							       \
-		DT_PROP_BY_PHANDLE_IDX_OR(node_id, cpu_power_states, i,	       \
-					  min_residency_us, 0U) >=	       \
-		DT_PROP_BY_PHANDLE_IDX_OR(node_id, cpu_power_states, i,	       \
-					  exit_latency_us, 0U),		       \
-		"Found CPU power state with min_residency < exit_latency")
-
-/**
- * @brief Check CPU power states consistency
- *
- * All states should have a minimum residency >= than the exit latency.
- *
- * @param node_id A CPU node identifier.
- */
-#define CHECK_POWER_STATES_CONSISTENCY(node_id)				       \
-	LISTIFY(DT_PROP_LEN_OR(node_id, cpu_power_states, 0),		       \
-		CHECK_POWER_STATE_CONSISTENCY, (;), node_id);		       \
-
-/* Check that all power states are consistent */
-DT_FOREACH_CHILD(DT_PATH(cpus), CHECK_POWER_STATES_CONSISTENCY)
-
 #define DEFINE_CPU_STATES(n) \
 	static const struct pm_state_info pmstates_##n[] \
 		= PM_STATE_INFO_LIST_FROM_DT_CPU(n);


### PR DESCRIPTION
There is some incoherency about the meaning of the timing properties in the power-state binding. Improve the documentation and also fill out the binding to finish matching linux https://www.kernel.org/doc/Documentation/devicetree/bindings/cpu/idle-states.yaml as it was currently an incomplete match. More importantly, remove the check for "power state consistency" as it was in disagreement (inconsistent if you will) with the actual code of the default policy manager. The check considered min-residency-us as including exit-latency-us whereas the zephyr code and linux binding consider them as totally separate values.