### PR TITLE
Bluetooth: ISO: rm extra log statements in chan_send 

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -967,7 +967,6 @@ int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq
 
 	iso_conn = chan->iso;
 
-	BT_ISO_DATA_DBG("send-iso (no ts)");
 	return conn_iso_send(iso_conn, buf, BT_ISO_TS_ABSENT);
 }
 
@@ -983,7 +982,7 @@ int bt_iso_chan_send_ts(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t 
 		return err;
 	}
 
-	BT_ISO_DATA_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
+	BT_ISO_DATA_DBG("chan %p len %zu ts %u", chan, net_buf_frags_len(buf), ts);
 
 	hdr = net_buf_push(buf, sizeof(*hdr));
 	hdr->ts = sys_cpu_to_le32(ts);
@@ -993,7 +992,6 @@ int bt_iso_chan_send_ts(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t 
 
 	iso_conn = chan->iso;
 
-	LOG_DBG("send-iso (ts)");
 	return conn_iso_send(iso_conn, buf, BT_ISO_TS_PRESENT);
 }
 


### PR DESCRIPTION
bt_iso_chan_send and bt_iso_chan_send_ts would log
twice for each TX, which is unncessary. LOG_DBG statements
include the function name by default, so the 2nd log
statement was unncessary, and were removed.

Added logging of the ts in bt_iso_chan_send_ts which
would still make it possible to tell the 2 apart,
even if CONFIG_LOG_FUNC_NAME_PREFIX_DBG=n.