### PR TITLE
Devicetree: remove deprecated ok state

### DIFF
--- a/boards/arduino/portenta_c33/arduino_portenta_c33.dts
+++ b/boards/arduino/portenta_c33/arduino_portenta_c33.dts
@@ -162,7 +162,7 @@
 		   <&ioport1 4 GPIO_ACTIVE_LOW>;
 
 	esp_hosted@1 {
-		status = "ok";
+		status = "okay";
 		compatible = "espressif,esp-hosted";
 		reg = <0x1>;
 		spi-max-frequency = <DT_FREQ_M(5)>;

--- a/boards/shields/adafruit_winc1500/adafruit_winc1500.overlay
+++ b/boards/shields/adafruit_winc1500/adafruit_winc1500.overlay
@@ -11,7 +11,7 @@
 	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 0>;
 
 	winc1500_adafruit_winc1500: winc1500@0 {
-		status = "ok";
+		status = "okay";
 		compatible = "atmel,winc1500";
 		reg = <0x0>;
 		spi-max-frequency = <4000000>;

--- a/doc/build/dts/intro-syntax-structure.rst
+++ b/doc/build/dts/intro-syntax-structure.rst
@@ -282,9 +282,7 @@ status
 
     A node is considered enabled if its status property is either ``"okay"`` or
     not defined (i.e. does not exist in the devicetree source). Nodes with
-    status ``"disabled"`` are explicitly disabled. (For backwards
-    compatibility, the value ``"ok"`` is treated the same as ``"okay"``, but
-    this usage is deprecated.) Devicetree nodes which correspond to physical
+    status ``"disabled"`` are explicitly disabled. Devicetree nodes which correspond to physical
     devices must be enabled for the corresponding ``struct device`` in the
     Zephyr driver model to be allocated and initialized.
 

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -59,6 +59,7 @@ Removed APIs and options
 * The legacy pipe object API was removed. Use the new pipe API instead.
 * ``bt_le_set_auto_conn``
 * ``CONFIG_BT_BUF_ACL_RX_COUNT``
+* ``ok`` enum value has now been removed completely from ``base.yaml`` binding ``status`` property in devicetree.
 
 Deprecated APIs and options
 ===========================

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -93,7 +93,7 @@
 		reg = <0x34000 0x1000>;
 		#address-cells = <1>;
 		#size-cells = <1>;
-		status = "ok";
+		status = "okay";
 
 		flash0: flash@0 {
 			compatible = "soc-nv-flash";

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -16,7 +16,6 @@ properties:
 
       For details, see "2.3.4 status" in Devicetree Specification v0.4.
     enum:
-      - "ok" # Deprecated form
       - "okay"
       - "disabled"
       - "reserved"

--- a/samples/drivers/fuel_gauge/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/fuel_gauge/boards/nrf52840dk_nrf52840.overlay
@@ -18,7 +18,7 @@
 	pinctrl-names = "default", "sleep";
 	max17048: max17048@36 {
 		compatible = "maxim,max17048";
-		status = "ok";
+		status = "okay";
 		reg = <0x36>;
 	};
 };

--- a/samples/net/gptp/boards/frdm_k64f.overlay
+++ b/samples/net/gptp/boards/frdm_k64f.overlay
@@ -7,6 +7,6 @@
 &enet {
 
 	ptp {
-		status = "ok";
+		status = "okay";
 	};
 };

--- a/samples/net/wifi/shell/boards/reel_board.overlay
+++ b/samples/net/wifi/shell/boards/reel_board.overlay
@@ -24,14 +24,14 @@
 };
 
 &spi3 {
-	status = "ok";
+	status = "okay";
 	cs-gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&spi3_default_alt>;
 	pinctrl-1 = <&spi3_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 
 	winc1500@0 {
-		status = "ok";
+		status = "okay";
 		compatible = "atmel,winc1500";
 		reg = <0x0>;
 		spi-max-frequency = <4000000>;

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -972,8 +972,7 @@ class Node:
 
     status:
       The node's status property value, as a string, or "okay" if the node
-      has no status property set. If the node's status property is "ok",
-      it is converted to "okay" for consistency.
+      has no status property set.
 
     read_only:
       True if the node has a 'read-only' property, and False otherwise
@@ -1198,9 +1197,6 @@ class Node:
             as_string = "okay"
         else:
             as_string = status.to_string()
-
-        if as_string == "ok":
-            as_string = "okay"
 
         return as_string
 
@@ -3312,8 +3308,7 @@ def _check_dt(dt: DT) -> None:
 
     # Check that 'status' has one of the values given in the devicetree spec.
 
-    # Accept "ok" for backwards compatibility
-    ok_status = {"ok", "okay", "disabled", "reserved", "fail", "fail-sss"}
+    ok_status = {"okay", "disabled", "reserved", "fail", "fail-sss"}
 
     for node in dt.node_iter():
         if "status" in node.props:


### PR DESCRIPTION
The `ok` state is deprecated and very few files are using this. The DTS spec also does not have this value.

This PR removes this value once and for all.