### PR TITLE
tests: bluetooth: tester: Print backtrace on crash in native-sim build

### DIFF
--- a/tests/bluetooth/tester/src/main.c
+++ b/tests/bluetooth/tester/src/main.c
@@ -2,9 +2,19 @@
 
 /*
  * Copyright (c) 2015-2016 Intel Corporation
+ * Copyright (c) 2025 Codecoup
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#if defined(CONFIG_BOARD_NATIVE_SIM)
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <execinfo.h>
+#endif
 
 #include <zephyr/autoconf.h>
 #include <zephyr/logging/log.h>
@@ -14,8 +24,42 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 
 #include "btp/btp.h"
 
+#if defined(CONFIG_BOARD_NATIVE_SIM)
+#define BACKTRACE_BUF_SIZE 100
+
+static void sigaction_segfault(int signal, siginfo_t *si, void *arg)
+{
+	void *buffer[BACKTRACE_BUF_SIZE];
+	int nptrs;
+
+	LOG_ERR("SEGMENTATION FAULT (address %p)", si->si_addr);
+	nptrs = backtrace(buffer, BACKTRACE_BUF_SIZE);
+	LOG_ERR("Backtrace%s:", nptrs == BACKTRACE_BUF_SIZE ? " (possibly truncated)" : "");
+	backtrace_symbols_fd(buffer, nptrs, STDERR_FILENO);
+
+	exit(EXIT_FAILURE);
+}
+
+static void sigaction_register(void)
+{
+	struct sigaction sa = {};
+
+	sa.sa_sigaction = sigaction_segfault;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = SA_SIGINFO;
+
+	if (sigaction(SIGSEGV, &sa, NULL) < 0) {
+		LOG_WRN("Failed to register sigaction (errno %d)", errno);
+	}
+}
+#endif
+
 int main(void)
 {
+#if defined(CONFIG_BOARD_NATIVE_SIM)
+	sigaction_register();
+#endif
+
 	tester_init();
 	return 0;
 }


### PR DESCRIPTION
If Zephyr process was terminated due to segmentation fault print note and backtrace for debugging purposes.

```
*** Booting Zephyr OS build v4.2.0-5260-g9a778a6beff7 ***
[00:00:00.000,000] <dbg> bttester: tester_init: Initializing tester
[00:00:00.000,000] <err> bttester_main: SEGMENTATION FAULT (address (nil))
zephyr/build/zephyr/zephyr.exe() [0x8049987]
linux-gate.so.1(__kernel_rt_sigreturn+0x0) [0xf7f695b0]
zephyr/build/zephyr/zephyr.exe() [0x804a8dc]
zephyr/build/zephyr/zephyr.exe() [0x8049fc5]
zephyr/build/zephyr/zephyr.exe() [0x80499fb]
zephyr/build/zephyr/zephyr.exe() [0x80b2c24]
zephyr/build/zephyr/zephyr.exe() [0x8060166]
zephyr/build/zephyr/zephyr.exe() [0x80658ea]
zephyr/build/zephyr/zephyr.exe() [0x80b9a45]
/lib/libc.so.6(+0x72b20) [0xf7cd2b20]
/lib/libc.so.6(+0xf8c58) [0xf7d58c58]
```