### PR TITLE
Bluetooth: CAP: Add missing failed_conn for reception_start

### DIFF
--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -364,6 +364,9 @@ int cap_commander_broadcast_reception_start(
 	if (err != 0) {
 		LOG_DBG("Failed to start broadcast reception for conn %p: %d", (void *)conn, err);
 
+		active_proc->err = err;
+		active_proc->failed_conn = conn;
+
 		return -ENOEXEC;
 	}
 

--- a/subsys/bluetooth/audio/cap_handover.c
+++ b/subsys/bluetooth/audio/cap_handover.c
@@ -261,8 +261,6 @@ void bt_cap_handover_unicast_to_broadcast_reception_start(void)
 	err = cap_commander_broadcast_reception_start(&param);
 	if (err != 0) {
 		LOG_DBG("Failed to start reception start: %d", err);
-		active_proc->err = err;
-		active_proc->failed_conn = NULL;
 
 		bt_cap_handover_complete();
 	}


### PR DESCRIPTION
When cap_commander_broadcast_reception_start is called during the handover, the failed_conn was not correctly.
It is now being set by cap_commander_broadcast_reception_start and if that is called via handover, it will be correctly set. If it is called via bt_cap_commander_broadcast_reception_start then it will be cleared in case of error.