### PR TITLE
riscv: Source flash geometry from Kconfig

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -525,6 +525,23 @@ config RISCV_NO_MTVAL_ON_FP_TRAP
 	  to contain the faulting FP instruction, requiring alternative methods
 	  to handle FP exceptions.
 
+# Workaround for not being able to have commas in macro arguments.
+DT_CHOSEN_Z_FLASH := zephyr,flash
+DT_COMPAT_JEDEC_SPI_NOR := jedec,spi-nor
+DT_COMPAT_LITEX_SPI_LITESPI := litex,spi-litespi
+DT_CHOSEN_FLASH_NODE := $(dt_chosen_path,$(DT_CHOSEN_Z_FLASH))
+DT_CHOSEN_FLASH_PARENT := $(dt_node_parent,$(DT_CHOSEN_FLASH_NODE))
+
+config FLASH_SIZE
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K) if (XIP && $(dt_chosen_has_compat,$(DT_CHOSEN_Z_FLASH),soc-nv-flash))
+	default $(dt_node_reg_size_int,$(DT_CHOSEN_FLASH_PARENT),9,K) if (XIP && $(dt_node_has_compat,$(DT_CHOSEN_FLASH_PARENT),$(DT_COMPAT_LITEX_SPI_LITESPI)))
+	default $(dt_node_reg_size_int,$(DT_CHOSEN_FLASH_PARENT),1,K) if (XIP && $(dt_chosen_has_compat,$(DT_CHOSEN_Z_FLASH),$(DT_COMPAT_JEDEC_SPI_NOR)))
+
+config FLASH_BASE_ADDRESS
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)) if (XIP && $(dt_chosen_has_compat,$(DT_CHOSEN_Z_FLASH),soc-nv-flash))
+	default $(dt_node_reg_addr_hex,$(DT_CHOSEN_FLASH_PARENT),9) if (XIP && $(dt_node_has_compat,$(DT_CHOSEN_FLASH_PARENT),$(DT_COMPAT_LITEX_SPI_LITESPI)))
+	default $(dt_node_reg_addr_hex,$(DT_CHOSEN_FLASH_PARENT),1) if (XIP && $(dt_chosen_has_compat,$(DT_CHOSEN_Z_FLASH),$(DT_COMPAT_JEDEC_SPI_NOR)))
+
 rsource "Kconfig.isa"
 rsource "core/Kconfig"
 

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -47,35 +47,10 @@
 #define ROM_SIZE (CONFIG_FLASH_LOAD_SIZE - ROM_END_OFFSET)
 #endif
 
-#if DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_flash), soc_nv_flash, okay)
-#define ROM_BASE (DT_REG_ADDR(DT_CHOSEN(zephyr_flash)) + FLASH_LOAD_OFFSET)
-#ifndef ROM_SIZE
-#define ROM_SIZE (DT_REG_SIZE(DT_CHOSEN(zephyr_flash)) - ROM_END_OFFSET)
-#endif
-
-#elif DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_flash), jedec_spi_nor)
-/* For jedec,spi-nor we expect the spi controller to memory map the flash
- * and for that mapping to be on the register with the name flash_mmap and if a register with that
- * name doesn't exists, we expect it to be in the second register property of the spi controller.
- */
-#define SPI_CTRL DT_PARENT(DT_CHOSEN(zephyr_flash))
-#define FLASH_MMAP_NAME flash_mmap
-#define ROM_BASE                                                                                   \
-	(DT_REG_ADDR_BY_NAME_OR(SPI_CTRL, FLASH_MMAP_NAME, DT_REG_ADDR_BY_IDX(SPI_CTRL, 1)) +      \
-	 FLASH_LOAD_OFFSET)
-#ifndef ROM_SIZE
-#define ROM_SIZE                                                                                   \
-	(DT_REG_SIZE_BY_NAME_OR(SPI_CTRL, FLASH_MMAP_NAME, DT_REG_SIZE_BY_IDX(SPI_CTRL, 1)) -      \
-	 ROM_END_OFFSET)
-#endif
-
-#else /* Use Kconfig to cover the remaining cases */
 #define ROM_BASE (CONFIG_FLASH_BASE_ADDRESS + FLASH_LOAD_OFFSET)
 #ifndef ROM_SIZE
 #define ROM_SIZE (CONFIG_FLASH_SIZE * 1024 - FLASH_LOAD_OFFSET - ROM_END_OFFSET)
-#endif
-
-#endif /* DT_NODE_HAS_COMPAT_STATUS */
+#endif /* ROM_SIZE*/
 
 #else /* CONFIG_XIP */
 #define ROM_BASE CONFIG_SRAM_BASE_ADDRESS


### PR DESCRIPTION
Move the logic for determining flash base address and size from the RISC-V common linker script to Kconfig.

The new Kconfig options CONFIG_FLASH_BASE_ADDRESS and CONFIG_FLASH_SIZE are now the source of truth for the linker script. These options are given default values derived from the devicetree, supporting both "soc-nv-flash" and "jedec,spi-nor" flash types.

SoC-specific defaults for litex_vexriscv with JEDEC SPI NOR flash have also been added.

This change simplifies the linker script and consolidates the flash geometry configuration within the Kconfig system.