### PR TITLE
shell / logging: shell log backend output Kconfig

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -297,12 +297,48 @@ config SHELL_LOG_BACKEND_CUSTOM
 	  It allows to provide custom implementation of multiplexing logging messages
 	  with shell data.
 
+if SHELL_LOG_BACKEND
+
+config SHELL_LOG_OUTPUT_TIMESTAMP
+	bool "Log output timestamp"
+	default y
+	help
+	  Enable timestamp in log output.
+
 config SHELL_LOG_FORMAT_TIMESTAMP
 	bool "Format timestamp"
 	default y
-	depends on SHELL_LOG_BACKEND
 	help
 	  Enable timestamp formatting.
+
+config SHELL_LOG_OUTPUT_LEVEL
+	bool "Log output level"
+	default y
+	help
+	  Enable log level in log output.
+
+config SHELL_LOG_OUTPUT_CRLF_NONE
+	bool "Log output CRLF none"
+	help
+	  Do not modify CRLF characters in log output.
+
+config SHELL_LOG_OUTPUT_CRLF_LFONLY
+	bool "Log output CRLF LF only"
+	help
+	  Convert CRLF to LF in log output.
+
+config SHELL_LOG_OUTPUT_THREAD
+	bool "Log output thread"
+	default y
+	help
+	  Enable logging thread id or name
+
+config SHELL_LOG_OUTPUT_SKIP_SOURCE
+	bool "Log output skip source"
+	help
+	  Skip outputting source in log output.
+
+endif # SHELL_LOG_BACKEND
 
 config SHELL_AUTOSTART
 	bool "Auto-start shell at boot"

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -155,17 +155,23 @@ static bool copy_to_pbuffer(struct mpsc_pbuf_buffer *mpsc_buffer,
 	return true;
 }
 
+/* Compile-time computed shell log output flags */
+#define SHELL_LOG_BASE_FLAGS                                                                       \
+	((IS_ENABLED(CONFIG_SHELL_LOG_OUTPUT_TIMESTAMP) ? LOG_OUTPUT_FLAG_TIMESTAMP : 0) |         \
+	 (IS_ENABLED(CONFIG_SHELL_LOG_FORMAT_TIMESTAMP) ? LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP : 0) |  \
+	 (IS_ENABLED(CONFIG_SHELL_LOG_OUTPUT_LEVEL) ? LOG_OUTPUT_FLAG_LEVEL : 0) |                 \
+	 (IS_ENABLED(CONFIG_SHELL_LOG_OUTPUT_CRLF_NONE) ? LOG_OUTPUT_FLAG_CRLF_NONE : 0) |         \
+	 (IS_ENABLED(CONFIG_SHELL_LOG_OUTPUT_CRLF_LFONLY) ? LOG_OUTPUT_FLAG_CRLF_LFONLY : 0) |     \
+	 (IS_ENABLED(CONFIG_SHELL_LOG_OUTPUT_THREAD) ? LOG_OUTPUT_FLAG_THREAD : 0) |               \
+	 (IS_ENABLED(CONFIG_SHELL_LOG_OUTPUT_SKIP_SOURCE) ? LOG_OUTPUT_FLAG_SKIP_SOURCE : 0))
+
 static void process_log_msg(const struct shell *sh,
 			     const struct log_output *log_output,
 			     union log_msg_generic *msg,
 			     bool locked, bool colors)
 {
 	unsigned int key = 0;
-	uint32_t flags = LOG_OUTPUT_FLAG_LEVEL | LOG_OUTPUT_FLAG_TIMESTAMP | LOG_OUTPUT_FLAG_THREAD;
-
-	if (IS_ENABLED(CONFIG_SHELL_LOG_FORMAT_TIMESTAMP)) {
-		flags |= LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
-	}
+	uint32_t flags = SHELL_LOG_BASE_FLAGS;
 
 	if (colors) {
 		flags |= LOG_OUTPUT_FLAG_COLORS;


### PR DESCRIPTION
Gives access to all log output format flag configurations for shell backend.

shell log backend doesn't use log_backend_std_get_flags() and it's debateable if it should, so give it its own fullly configurable format set for maximum backend bandwidth control

===================================

There was a little bit of discussion in #94534 about if this should be standard or per-backend and since shell log backend doesn't currently use `log_backend_std_get_flags()`, this was the first approach to narrow the scope of change to only shell's log backend, although I believe all log backends would benefit from having full output format configurability to manage bandwidth traffic.