### PR TITLE
tracing: Remove superfluous inclusion of kernel.h

### DIFF
--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -6,8 +6,6 @@
 #ifndef ZEPHYR_INCLUDE_TRACING_TRACING_H_
 #define ZEPHYR_INCLUDE_TRACING_TRACING_H_
 
-#include <zephyr/kernel.h>
-
 #include "tracking.h"
 
 #if defined CONFIG_SEGGER_SYSTEMVIEW


### PR DESCRIPTION
Nothing in the tracing/tracing.h header file requires the explicit inclusion of kernel.h.

Fixes #95123