### PR TITLE
testsuite: Make CONFIG_COVERAGE_DUMP_PATH_EXCLUDE depend on libc support

### DIFF
--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -95,9 +95,18 @@ config COVERAGE_DUMP
 
 endchoice
 
+config HAVE_COVERAGE_DUMP_PATH_EXCLUDE
+	bool
+	default y
+	depends on COVERAGE_DUMP_PATH_EXCLUDE != ""
+	help
+	  Helper symbol that is true when COVERAGE_DUMP_PATH_EXCLUDE is a
+	  non-empty string
+
 config COVERAGE_DUMP_PATH_EXCLUDE
 	string "Exclude files matching this pattern from the coverage data"
 	default ""
+	depends on !MINIMAL_LIBC
 	help
 	  Filenames are matched against the pattern using the POSIX fnmatch
 	  function. Filenames are based on their path in the build folder, not the

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -9,7 +9,11 @@
 #include <stdint.h>
 #include <errno.h>
 #include <string.h>
+
+#ifdef CONFIG_HAVE_COVERAGE_DUMP_PATH_EXCLUDE
 #include <fnmatch.h>
+#endif /* CONFIG_HAVE_COVERAGE_DUMP_PATH_EXCLUDE */
+
 #include "coverage.h"
 
 K_HEAP_DEFINE(gcov_heap, CONFIG_COVERAGE_GCOV_HEAP_SIZE);
@@ -316,11 +320,13 @@ void gcov_coverage_dump(void)
 	}
 	printk("\nGCOV_COVERAGE_DUMP_START");
 	while (gcov_list) {
+#ifdef CONFIG_HAVE_COVERAGE_DUMP_PATH_EXCLUDE
 		if ((strlen(CONFIG_COVERAGE_DUMP_PATH_EXCLUDE) > 0) &&
 		    (fnmatch(CONFIG_COVERAGE_DUMP_PATH_EXCLUDE, gcov_list->filename, 0) == 0)) {
 			/* Don't print a note here, it would be interpreted as dump data */
 			goto file_dump_end;
 		}
+#endif /* CONFIG_HAVE_COVERAGE_DUMP_PATH_EXCLUDE */
 
 		dump_on_console_start(gcov_list->filename);
 		size = gcov_calculate_buff_size(gcov_list);
@@ -340,7 +346,7 @@ void gcov_coverage_dump(void)
 		dump_on_console_data(buffer, size);
 
 		k_heap_free(&gcov_heap, buffer);
-file_dump_end:
+goto file_dump_end; file_dump_end:
 		gcov_list = gcov_list->next;
 		if (gcov_list_first == gcov_list) {
 			goto coverage_dump_end;


### PR DESCRIPTION
PR #94029 introduced a feature to filter out certain file paths from coverage dumps using the `fnmatch` function. Unfortauntely, this function is not universally implemented among all of Zephyr's libc options, particularly minimal libc. This causes build failures when libc support for `fnmatch()` is absent.

Update Kconfig with a `depends on` clause and a helper symbol that guards the fnmatch header and function call when not enabled.