### PR TITLE
drv: ft8xx: refactor coprocessor driver

### DIFF
--- a/drivers/misc/ft8xx/ft8xx_copro.c
+++ b/drivers/misc/ft8xx/ft8xx_copro.c
@@ -57,18 +57,62 @@ static void increase_reg_cmd_write(const struct device *dev, uint16_t value)
 	data->reg_cmd_write = (data->reg_cmd_write + value) % FT800_RAM_CMD_SIZE;
 }
 
-void ft8xx_copro_cmd(const struct device *dev, uint32_t cmd)
+static uint32_t ram_cmd_wr_address(const struct device *dev)
 {
 	struct ft8xx_data *data = dev->data;
 
-	while (ram_cmd_freespace(dev) < sizeof(cmd)) {
+	return FT800_RAM_CMD + data->reg_cmd_write;
+}
+
+static size_t ram_cmd_wr16(const struct device *dev, uint16_t data)
+{
+	ft8xx_wr16(dev, ram_cmd_wr_address(dev), data);
+	increase_reg_cmd_write(dev, sizeof(data));
+
+	return sizeof(data);
+}
+
+static size_t ram_cmd_wr32(const struct device *dev, uint32_t data)
+{
+	ft8xx_wr32(dev, ram_cmd_wr_address(dev), data);
+	increase_reg_cmd_write(dev, sizeof(data));
+
+	return sizeof(data);
+}
+
+static size_t ram_cmd_wr_var(const struct device *dev, const uint8_t *data, size_t data_size,
+			   size_t padding_size)
+{
+	(void)ft8xx_drv_write(dev, ram_cmd_wr_address(dev), data, data_size);
+	increase_reg_cmd_write(dev, data_size + padding_size);
+
+	return data_size + padding_size;
+}
+
+static void cmd_beginning(const struct device *dev, size_t cmd_size)
+{
+	while (ram_cmd_freespace(dev) < cmd_size) {
 		refresh_reg_cmd_read(dev);
 	}
+}
 
-	ft8xx_wr32(dev, FT800_RAM_CMD + data->reg_cmd_write, cmd);
-	increase_reg_cmd_write(dev, sizeof(cmd));
-
+static void cmd_ending(const struct device *dev, size_t cmd_size, size_t written_bytes)
+{
+	__ASSERT(written_bytes == cmd_size, "Written %zu bytes, expected %zu", written_bytes,
+		 cmd_size);
+	(void)written_bytes;
+	(void)cmd_size;
 	flush_reg_cmd_write(dev);
+}
+
+void ft8xx_copro_cmd(const struct device *dev, uint32_t cmd)
+{
+	const size_t cmd_size = sizeof(cmd);
+	size_t written_bytes = 0;
+
+	cmd_beginning(dev, cmd_size);
+	written_bytes += ram_cmd_wr32(dev, cmd);
+	cmd_ending(dev, cmd_size, written_bytes);
 }
 
 void ft8xx_copro_cmd_dlstart(const struct device *dev)
@@ -88,42 +132,25 @@ void ft8xx_copro_cmd_text(const struct device *dev,
 			   uint16_t options,
 			   const char *string)
 {
-	struct ft8xx_data *data = dev->data;
-
 	const uint16_t str_bytes = strlen(string) + 1;
 	const uint16_t padding_bytes = (4 - (str_bytes % 4)) % 4;
-	const uint16_t cmd_size = sizeof(CMD_TEXT) +
-				   sizeof(x) +
-				   sizeof(y) +
-				   sizeof(font) +
-				   sizeof(options) +
-				   str_bytes +
-				   padding_bytes;
+	const size_t cmd_size = sizeof(CMD_TEXT) +
+				sizeof(x) +
+				sizeof(y) +
+				sizeof(font) +
+				sizeof(options) +
+				str_bytes +
+				padding_bytes;
+	size_t written_bytes = 0;
 
-	while (ram_cmd_freespace(dev) < cmd_size) {
-		refresh_reg_cmd_read(dev);
-	}
-
-	ft8xx_wr32(dev, FT800_RAM_CMD + data->reg_cmd_write, CMD_TEXT);
-	increase_reg_cmd_write(dev, sizeof(CMD_TEXT));
-
-	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, x);
-	increase_reg_cmd_write(dev, sizeof(x));
-
-	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, y);
-	increase_reg_cmd_write(dev, sizeof(y));
-
-	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, font);
-	increase_reg_cmd_write(dev, sizeof(font));
-
-	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, options);
-	increase_reg_cmd_write(dev, sizeof(options));
-
-	(void)ft8xx_drv_write(dev, FT800_RAM_CMD + data->reg_cmd_write, (uint8_t *)string,
-			      str_bytes);
-	increase_reg_cmd_write(dev, str_bytes + padding_bytes);
-
-	flush_reg_cmd_write(dev);
+	cmd_beginning(dev, cmd_size);
+	written_bytes += ram_cmd_wr32(dev, CMD_TEXT);
+	written_bytes += ram_cmd_wr16(dev, x);
+	written_bytes += ram_cmd_wr16(dev, y);
+	written_bytes += ram_cmd_wr16(dev, font);
+	written_bytes += ram_cmd_wr16(dev, options);
+	written_bytes += ram_cmd_wr_var(dev, (const uint8_t *)string, str_bytes, padding_bytes);
+	cmd_ending(dev, cmd_size, written_bytes);
 }
 
 void ft8xx_copro_cmd_number(const struct device *dev,
@@ -133,59 +160,37 @@ void ft8xx_copro_cmd_number(const struct device *dev,
 			     uint16_t options,
 			     int32_t number)
 {
-	struct ft8xx_data *data = dev->data;
+	const size_t cmd_size = sizeof(CMD_NUMBER) +
+				sizeof(x) +
+				sizeof(y) +
+				sizeof(font) +
+				sizeof(options) +
+				sizeof(number);
+	size_t written_bytes = 0;
 
-	const uint16_t cmd_size = sizeof(CMD_NUMBER) +
-				   sizeof(x) +
-				   sizeof(y) +
-				   sizeof(font) +
-				   sizeof(options) +
-				   sizeof(number);
-
-	while (ram_cmd_freespace(dev) < cmd_size) {
-		refresh_reg_cmd_read(dev);
-	}
-
-	ft8xx_wr32(dev, FT800_RAM_CMD + data->reg_cmd_write, CMD_NUMBER);
-	increase_reg_cmd_write(dev, sizeof(CMD_NUMBER));
-
-	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, x);
-	increase_reg_cmd_write(dev, sizeof(x));
-
-	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, y);
-	increase_reg_cmd_write(dev, sizeof(y));
-
-	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, font);
-	increase_reg_cmd_write(dev, sizeof(font));
-
-	ft8xx_wr16(dev, FT800_RAM_CMD + data->reg_cmd_write, options);
-	increase_reg_cmd_write(dev, sizeof(options));
-
-	ft8xx_wr32(dev, FT800_RAM_CMD + data->reg_cmd_write, number);
-	increase_reg_cmd_write(dev, sizeof(number));
-
-	flush_reg_cmd_write(dev);
+	cmd_beginning(dev, cmd_size);
+	written_bytes += ram_cmd_wr32(dev, CMD_NUMBER);
+	written_bytes += ram_cmd_wr16(dev, x);
+	written_bytes += ram_cmd_wr16(dev, y);
+	written_bytes += ram_cmd_wr16(dev, font);
+	written_bytes += ram_cmd_wr16(dev, options);
+	written_bytes += ram_cmd_wr32(dev, number);
+	cmd_ending(dev, cmd_size, written_bytes);
 }
 
 void ft8xx_copro_cmd_calibrate(const struct device *dev, uint32_t *result)
 {
-	struct ft8xx_data *data = dev->data;
-
-	const uint16_t cmd_size = sizeof(CMD_CALIBRATE) + sizeof(uint32_t);
 	uint32_t result_address;
 
-	while (ram_cmd_freespace(dev) < cmd_size) {
-		refresh_reg_cmd_read(dev);
-	}
+	const size_t cmd_size = sizeof(CMD_CALIBRATE) +
+				sizeof(uint32_t);
+	size_t written_bytes = 0;
 
-	ft8xx_wr32(dev, FT800_RAM_CMD + data->reg_cmd_write, CMD_CALIBRATE);
-	increase_reg_cmd_write(dev, sizeof(CMD_CALIBRATE));
-
-	result_address = FT800_RAM_CMD + data->reg_cmd_write;
-	ft8xx_wr32(dev, result_address, 1UL);
-	increase_reg_cmd_write(dev, sizeof(uint32_t));
-
-	flush_reg_cmd_write(dev);
+	cmd_beginning(dev, cmd_size);
+	written_bytes += ram_cmd_wr32(dev, CMD_CALIBRATE);
+	result_address = ram_cmd_wr_address(dev);
+	written_bytes += ram_cmd_wr32(dev, 1UL);
+	cmd_ending(dev, cmd_size, written_bytes);
 
 	/* Wait until calibration is finished. */
 	while (ram_cmd_fullness(dev) > 0) {


### PR DESCRIPTION
Refactor the driver of FT8xx coprocessor by moving code common to coprocessor commands to common functions.