### PR TITLE
drivers: tdk: Define the trigger as a pointer to allow dereferencing within the trigger handler callback.

### DIFF
--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -91,7 +91,7 @@ struct icm45686_triggers {
 		const struct device *dev;
 		struct k_mutex lock;
 		struct {
-			struct sensor_trigger trigger;
+			const struct sensor_trigger *trigger;
 			sensor_trigger_handler_t handler;
 		} entry;
 #if defined(CONFIG_ICM45686_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/tdk/icm45686/icm45686_trigger.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_trigger.c
@@ -43,7 +43,7 @@ static void icm45686_thread_cb(const struct device *dev)
 	(void)k_mutex_lock(&data->triggers.lock, K_FOREVER);
 
 	if (data->triggers.entry.handler) {
-		data->triggers.entry.handler(dev, &data->triggers.entry.trigger);
+		data->triggers.entry.handler(dev, data->triggers.entry.trigger);
 	}
 
 	(void)k_mutex_unlock(&data->triggers.lock);
@@ -113,7 +113,7 @@ int icm45686_trigger_set(const struct device *dev,
 
 	switch (trig->type) {
 	case SENSOR_TRIG_DATA_READY:
-		data->triggers.entry.trigger = *trig;
+		data->triggers.entry.trigger = trig;
 		data->triggers.entry.handler = handler;
 
 		if (handler) {


### PR DESCRIPTION
This is a proposal to fix the issue with CONTAINER_OF dereferencing in the trigger handler (see the following issue: https://github.com/zephyrproject-rtos/zephyr/issues/97124).

With this fix, it is possible to define a custom-made 

```
struct sensor_device {
...
struct sensor_trigger trigger;
...
}; 
struct sensor_device sdevice;
```

and by setting `sensor_trigger_set(dev, &sdevice.trigger, handler)` while initialisation, access in `handler() `via `CONTAINER_OF `to the underlying `struct sdevice`  is granted.

fixes: https://github.com/zephyrproject-rtos/zephyr/issues/97124