### PR TITLE
wifi: esp32: simplify DHCP4 auto-negotiation Kconfig

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -51,7 +51,7 @@ config NET_MGMT_EVENT_STACK_SIZE
 
 config ESP32_WIFI_STA_AUTO_DHCPV4
 	bool "Automatically starts DHCP4 negotiation"
-	depends on NET_DHCPV4
+	default y if NET_DHCPV4
 	depends on NET_IPV4
 	help
 	  WiFi driver will automatically initiate DHCPV4 negotiation when connected.


### PR DESCRIPTION
Remove redundant NET_DHCPV4 dependency and add default behavior.

ESP32_WIFI_STA_AUTO_DHCPV4 now defaults to enabled when NET_DHCPV4 is selected, removing the need for explicit configuration.