### PR TITLE
tests: kernel: fix -Wformat errors

### DIFF
--- a/tests/kernel/common/src/bitarray.c
+++ b/tests/kernel/common/src/bitarray.c
@@ -64,16 +64,16 @@ void validate_bitarray_define(sys_bitarray_t *ba, size_t num_bits)
 		      / sizeof(uint32_t);
 
 	zassert_equal(ba->num_bits, num_bits,
-		      "SYS_BITARRAY_DEFINE num_bits expected %u, got %u",
+		      "SYS_BITARRAY_DEFINE num_bits expected %zu, got %u",
 		      num_bits, ba->num_bits);
 
 	zassert_equal(ba->num_bundles, num_bundles,
-		      "SYS_BITARRAY_DEFINE num_bundles expected %u, got %u",
+		      "SYS_BITARRAY_DEFINE num_bundles expected %zu, got %u",
 		      num_bundles, ba->num_bundles);
 
 	for (i = 0; i < num_bundles; i++) {
 		zassert_equal(ba->bundles[i], FREE,
-			      "SYS_BITARRAY_DEFINE bundles[%u] not free for num_bits %u",
+			      "SYS_BITARRAY_DEFINE bundles[%u] not free for num_bits %zu",
 			      i, num_bits);
 	}
 }
@@ -149,78 +149,78 @@ ZTEST(bitarray, test_bitarray_set_clear)
 
 		ret = sys_bitarray_set_bit(&ba, bit);
 		zassert_equal(ret, 0,
-			      "sys_bitarray_set_bit failed on bit %d", bit);
+			      "sys_bitarray_set_bit failed on bit %zu", bit);
 		zassert_equal(ba.bundles[bundle_idx], BIT(bit_idx_in_bundle),
-			      "sys_bitarray_set_bit did not set bit %d\n", bit);
+			      "sys_bitarray_set_bit did not set bit %zu\n", bit);
 		zassert_not_equal(sys_bitfield_test_bit((mem_addr_t)ba.bundles, bit),
-				  0, "sys_bitarray_set_bit did not set bit %d\n", bit);
+				  0, "sys_bitarray_set_bit did not set bit %zu\n", bit);
 
 		ret = sys_bitarray_test_bit(&ba, bit, &bit_val);
 		zassert_equal(ret, 0,
-			      "sys_bitarray_test_bit failed at bit %d", bit);
+			      "sys_bitarray_test_bit failed at bit %zu", bit);
 		zassert_equal(bit_val, 1,
-			      "sys_bitarray_test_bit did not detect bit %d\n", bit);
+			      "sys_bitarray_test_bit did not detect bit %zu\n", bit);
 
 		ret = sys_bitarray_clear_bit(&ba, bit);
 		zassert_equal(ret, 0,
-			      "sys_bitarray_clear_bit failed at bit %d", bit);
+			      "sys_bitarray_clear_bit failed at bit %zu", bit);
 		zassert_equal(ba.bundles[bundle_idx], 0,
-			      "sys_bitarray_clear_bit did not clear bit %d\n", bit);
+			      "sys_bitarray_clear_bit did not clear bit %zu\n", bit);
 		zassert_equal(sys_bitfield_test_bit((mem_addr_t)ba.bundles, bit),
-			      0, "sys_bitarray_set_bit did not set bit %d\n", bit);
+			      0, "sys_bitarray_set_bit did not set bit %zu\n", bit);
 
 		ret = sys_bitarray_test_bit(&ba, bit, &bit_val);
 		zassert_equal(ret, 0,
-			      "sys_bitarray_test_bit failed at bit %d", bit);
+			      "sys_bitarray_test_bit failed at bit %zu", bit);
 		zassert_equal(bit_val, 0,
-			      "sys_bitarray_test_bit erroneously detected bit %d\n",
+			      "sys_bitarray_test_bit erroneously detected bit %zu\n",
 			      bit);
 
 		ret = sys_bitarray_test_and_set_bit(&ba, bit, &bit_val);
 		zassert_equal(ret, 0,
-			      "sys_bitarray_test_and_set_bit failed at bit %d", bit);
+			      "sys_bitarray_test_and_set_bit failed at bit %zu", bit);
 		zassert_equal(bit_val, 0,
-			      "sys_bitarray_test_and_set_bit erroneously detected bit %d\n",
+			      "sys_bitarray_test_and_set_bit erroneously detected bit %zu\n",
 			      bit);
 		zassert_equal(ba.bundles[bundle_idx], BIT(bit_idx_in_bundle),
-			      "sys_bitarray_test_and_set_bit did not set bit %d\n", bit);
+			      "sys_bitarray_test_and_set_bit did not set bit %zu\n", bit);
 		zassert_not_equal(sys_bitfield_test_bit((mem_addr_t)ba.bundles, bit),
-				  0, "sys_bitarray_set_bit did not set bit %d\n", bit);
+				  0, "sys_bitarray_set_bit did not set bit %zu\n", bit);
 
 		ret = sys_bitarray_test_and_set_bit(&ba, bit, &bit_val);
 		zassert_equal(ret, 0,
-			      "sys_bitarray_test_and_set_bit failed at bit %d", bit);
+			      "sys_bitarray_test_and_set_bit failed at bit %zu", bit);
 		zassert_equal(bit_val, 1,
-			      "sys_bitarray_test_and_set_bit did not detect bit %d\n",
+			      "sys_bitarray_test_and_set_bit did not detect bit %zu\n",
 			      bit);
 		zassert_equal(ba.bundles[bundle_idx], BIT(bit_idx_in_bundle),
-			      "sys_bitarray_test_and_set_bit cleared bit %d\n", bit);
+			      "sys_bitarray_test_and_set_bit cleared bit %zu\n", bit);
 		zassert_not_equal(sys_bitfield_test_bit((mem_addr_t)ba.bundles, bit),
-				  0, "sys_bitarray_set_bit did not set bit %d\n", bit);
+				  0, "sys_bitarray_set_bit did not set bit %zu\n", bit);
 
 		ret = sys_bitarray_test_and_clear_bit(&ba, bit, &bit_val);
 		zassert_equal(ret, 0,
-			      "sys_bitarray_test_and_clear_bit failed at bit %d", bit);
+			      "sys_bitarray_test_and_clear_bit failed at bit %zu", bit);
 		zassert_equal(bit_val, 1,
-			      "sys_bitarray_test_and_clear_bit did not detect bit %d\n",
+			      "sys_bitarray_test_and_clear_bit did not detect bit %zu\n",
 			      bit);
 		zassert_equal(ba.bundles[bundle_idx], 0,
-			      "sys_bitarray_test_and_clear_bit did not clear bit %d\n",
+			      "sys_bitarray_test_and_clear_bit did not clear bit %zu\n",
 			      bit);
 		zassert_equal(sys_bitfield_test_bit((mem_addr_t)ba.bundles, bit),
-			      0, "sys_bitarray_set_bit did not set bit %d\n", bit);
+			      0, "sys_bitarray_set_bit did not set bit %zu\n", bit);
 
 		ret = sys_bitarray_test_and_clear_bit(&ba, bit, &bit_val);
 		zassert_equal(ret, 0,
-			      "sys_bitarray_test_and_clear_bit failed at bit %d", bit);
+			      "sys_bitarray_test_and_clear_bit failed at bit %zu", bit);
 		zassert_equal(bit_val, 0,
-			      "sys_bitarray_test_and_clear_bit erroneously detected bit %d\n",
+			      "sys_bitarray_test_and_clear_bit erroneously detected bit %zu\n",
 			      bit);
 		zassert_equal(ba.bundles[bundle_idx], 0,
-			      "sys_bitarray_test_and_clear_bit set bit %d\n",
+			      "sys_bitarray_test_and_clear_bit set bit %zu\n",
 			      bit);
 		zassert_equal(sys_bitfield_test_bit((mem_addr_t)ba.bundles, bit),
-			      0, "sys_bitarray_set_bit did not set bit %d\n", bit);
+			      0, "sys_bitarray_set_bit did not set bit %zu\n", bit);
 	}
 
 	/* All this should fail because we go outside of
@@ -298,7 +298,7 @@ static void test_alloc_free_32(uint32_t mask, uint32_t mask_after, size_t num_bi
 		return;
 	}
 	zassert_equal(offset, exp_offset,
-		      "sys_bitarray_alloc() offset expected %d, got %d", exp_offset, offset);
+		      "sys_bitarray_alloc() offset expected %zu, got %zu", exp_offset, offset);
 	zassert_equal(ba_32.bundles[0], mask_after, "sys_bitarray_alloc() failed bits comparison");
 
 	ret = sys_bitarray_free(&ba_32, num_bits, offset);
@@ -340,7 +340,7 @@ void alloc_and_free_predefined(void)
 
 	ret = sys_bitarray_alloc(&ba_128, 5, &offset);
 	zassert_equal(ret, 0, "sys_bitarray_alloc() failed: %d", ret);
-	zassert_equal(offset, 11, "sys_bitarray_alloc() offset expected %d, got %d", 11, offset);
+	zassert_equal(offset, 11, "sys_bitarray_alloc() offset expected %d, got %zu", 11, offset);
 	zassert_true(cmp_u32_arrays(ba_128.bundles, ba_128_expected, ba_128.num_bundles),
 		     "sys_bitarray_alloc() failed bits comparison");
 
@@ -348,7 +348,7 @@ void alloc_and_free_predefined(void)
 	ba_128_expected[2] = 0xFF0F0F0F;
 	ba_128_expected[3] = 0x0F0F0FFF;
 	zassert_equal(ret, 0, "sys_bitarray_alloc() failed: %d", ret);
-	zassert_equal(offset, 92, "sys_bitarray_alloc() offset expected %d, got %d", 92, offset);
+	zassert_equal(offset, 92, "sys_bitarray_alloc() offset expected %d, got %zu", 92, offset);
 	zassert_true(cmp_u32_arrays(ba_128.bundles, ba_128_expected, ba_128.num_bundles),
 		     "sys_bitarray_alloc() failed bits comparison");
 
@@ -388,7 +388,7 @@ void alloc_and_free_predefined(void)
 
 	ret = sys_bitarray_alloc(&ba_128, 34, &offset);
 	zassert_equal(ret, 0, "sys_bitarray_alloc() failed: %d", ret);
-	zassert_equal(offset, 64, "sys_bitarray_alloc() offset expected %d, got %d", 64, offset);
+	zassert_equal(offset, 64, "sys_bitarray_alloc() offset expected %d, got %zu", 64, offset);
 	zassert_true(cmp_u32_arrays(ba_128.bundles, ba_128_expected, ba_128.num_bundles),
 		     "sys_bitarray_alloc() failed bits comparison");
 }
@@ -421,7 +421,7 @@ void alloc_and_free_loop(int divisor)
 	for (bit = 0U; bit < ba.num_bits; ++bit) {
 		cur_popcnt = get_bitarray_popcnt(&ba);
 		zassert_equal(cur_popcnt, expected_popcnt,
-			      "bit count expected %u, got %u (at bit %u)",
+			      "bit count expected %zu, got %zu (at bit %zu)",
 			      expected_popcnt, cur_popcnt, bit);
 
 		/* Allocate half of remaining bits */
@@ -430,14 +430,14 @@ void alloc_and_free_loop(int divisor)
 		ret = sys_bitarray_alloc(&ba, num_bits, &offset);
 		if (num_bits == 0) {
 			zassert_not_equal(ret, 0,
-					  "sys_bitarray_free() should fail but not (bit %u)",
+					  "sys_bitarray_free() should fail but not (bit %zu)",
 					  bit);
 		} else {
 			zassert_equal(ret, 0,
-				      "sys_bitarray_alloc() failed (%d) at bit %u",
+				      "sys_bitarray_alloc() failed (%d) at bit %zu",
 				      ret, bit);
 			zassert_equal(offset, bit,
-				      "sys_bitarray_alloc() offset expected %d, got %d",
+				      "sys_bitarray_alloc() offset expected %zu, got %zu",
 				      bit, offset);
 
 			expected_popcnt += num_bits;
@@ -445,18 +445,18 @@ void alloc_and_free_loop(int divisor)
 
 		cur_popcnt = get_bitarray_popcnt(&ba);
 		zassert_equal(cur_popcnt, expected_popcnt,
-			      "bit count expected %u, got %u (at bit %u)",
+			      "bit count expected %zu, got %zu (at bit %zu)",
 			      expected_popcnt, cur_popcnt, bit);
 
 		/* Free all but the first bit of allocated region */
 		ret = sys_bitarray_free(&ba, (num_bits - 1), (bit + 1));
 		if ((num_bits == 0) || ((num_bits - 1) == 0)) {
 			zassert_not_equal(ret, 0,
-					  "sys_bitarray_free() should fail but not (bit %u)",
+					  "sys_bitarray_free() should fail but not (bit %zu)",
 					  bit);
 		} else {
 			zassert_equal(ret, 0,
-				      "sys_bitarray_free() failed (%d) at bit %u",
+				      "sys_bitarray_free() failed (%d) at bit %zu",
 				      ret, (bit + 1));
 
 			expected_popcnt -= num_bits - 1;
@@ -491,22 +491,22 @@ void alloc_and_free_interval(void)
 		ret = sys_bitarray_alloc(&ba, 4, &offset);
 		if (cnt == (ba.num_bits / 8)) {
 			zassert_not_equal(ret, 0,
-					  "sys_bitarray_free() should fail but not (cnt %u)",
+					  "sys_bitarray_free() should fail but not (cnt %zu)",
 					  cnt);
 		} else {
 			zassert_equal(ret, 0,
-				      "sys_bitarray_alloc() failed (%d) (cnt %u)",
+				      "sys_bitarray_alloc() failed (%d) (cnt %zu)",
 				      ret, cnt);
 
 			zassert_equal(offset, expected_offset,
-				      "offset expected %u, got %u (cnt %u)",
+				      "offset expected %zu, got %zu (cnt %zu)",
 				      expected_offset, offset, cnt);
 
 			expected_popcnt += 4;
 
 			cur_popcnt = get_bitarray_popcnt(&ba);
 			zassert_equal(cur_popcnt, expected_popcnt,
-				      "bit count expected %u, got %u (cnt %u)",
+				      "bit count expected %zu, got %zu (cnt %zu)",
 				      expected_popcnt, cur_popcnt, cnt);
 
 
@@ -565,27 +565,27 @@ ZTEST(bitarray, test_bitarray_popcount_region)
 
 	ret = sys_bitarray_popcount_region(&ba, 1, 0, &count);
 	zassert_equal(ret, 0, "sys_bitarray_popcount_region() returned unexpected value: %d", ret);
-	zassert_equal(count, 1, "sys_bitarray_popcount_region() returned unexpected count: %d",
+	zassert_equal(count, 1, "sys_bitarray_popcount_region() returned unexpected count: %zu",
 		      count);
 
 	ret = sys_bitarray_popcount_region(&ba, 1, 1, &count);
 	zassert_equal(ret, 0, "sys_bitarray_popcount_region() returned unexpected value: %d", ret);
-	zassert_equal(count, 0, "sys_bitarray_popcount_region() returned unexpected count: %d",
+	zassert_equal(count, 0, "sys_bitarray_popcount_region() returned unexpected count: %zu",
 		      count);
 
 	ret = sys_bitarray_popcount_region(&ba, 2, 0, &count);
 	zassert_equal(ret, 0, "sys_bitarray_popcount_region() returned unexpected value: %d", ret);
-	zassert_equal(count, 1, "sys_bitarray_popcount_region() returned unexpected count: %d",
+	zassert_equal(count, 1, "sys_bitarray_popcount_region() returned unexpected count: %zu",
 		      count);
 
 	ret = sys_bitarray_popcount_region(&ba, 3, 0, &count);
 	zassert_equal(ret, 0, "sys_bitarray_popcount_region() returned unexpected value: %d", ret);
-	zassert_equal(count, 2, "sys_bitarray_popcount_region() returned unexpected count: %d",
+	zassert_equal(count, 2, "sys_bitarray_popcount_region() returned unexpected count: %zu",
 		      count);
 
 	ret = sys_bitarray_popcount_region(&ba, 3, 1, &count);
 	zassert_equal(ret, 0, "sys_bitarray_popcount_region() returned unexpected value: %d", ret);
-	zassert_equal(count, 1, "sys_bitarray_popcount_region() returned unexpected count: %d",
+	zassert_equal(count, 1, "sys_bitarray_popcount_region() returned unexpected count: %zu",
 		      count);
 
 	printk("Testing bit array region popcount spanning multiple bundles\n");
@@ -600,26 +600,26 @@ ZTEST(bitarray, test_bitarray_popcount_region)
 
 	ret = sys_bitarray_popcount_region(&ba, 126, 1, &count);
 	zassert_equal(ret, 0, "sys_bitarray_popcount_region() returned unexpected value: %d", ret);
-	zassert_equal(count, 0, "sys_bitarray_popcount_region() returned unexpected count: %d",
+	zassert_equal(count, 0, "sys_bitarray_popcount_region() returned unexpected count: %zu",
 		      count);
 
 	ret = sys_bitarray_popcount_region(&ba, 126, 0, &count);
 	zassert_equal(ret, 0, "sys_bitarray_popcount_region() returned unexpected value: %d", ret);
-	zassert_equal(count, 1, "sys_bitarray_popcount_region() returned unexpected count: %d",
+	zassert_equal(count, 1, "sys_bitarray_popcount_region() returned unexpected count: %zu",
 		      count);
 
 	ret = sys_bitarray_popcount_region(&ba, 127, 1, &count);
 	zassert_equal(ret, 0, "sys_bitarray_popcount_region() returned unexpected value: %d", ret);
-	zassert_equal(count, 1, "sys_bitarray_popcount_region() returned unexpected count: %d",
+	zassert_equal(count, 1, "sys_bitarray_popcount_region() returned unexpected count: %zu",
 		      count);
 	ret = sys_bitarray_popcount_region(&ba, 1, 127, &count);
 	zassert_equal(ret, 0, "sys_bitarray_popcount_region() returned unexpected value: %d", ret);
-	zassert_equal(count, 1, "sys_bitarray_popcount_region() returned unexpected count: %d",
+	zassert_equal(count, 1, "sys_bitarray_popcount_region() returned unexpected count: %zu",
 		      count);
 
 	ret = sys_bitarray_popcount_region(&ba, 128, 0, &count);
 	zassert_equal(ret, 0, "sys_bitarray_popcount_region() returned unexpected value: %d", ret);
-	zassert_equal(count, 2, "sys_bitarray_popcount_region() returned unexpected count: %d",
+	zassert_equal(count, 2, "sys_bitarray_popcount_region() returned unexpected count: %zu",
 		      count);
 
 	printk("Testing edge/error cases\n");
@@ -805,22 +805,22 @@ ZTEST(bitarray, test_bitarray_find_nth_set)
 
 	ret = sys_bitarray_find_nth_set(&ba, 1, 1, 0, &found_at);
 	zassert_equal(ret, 0, "sys_bitarray_find_nth_set() returned unexpected value: %d", ret);
-	zassert_equal(found_at, 0, "sys_bitarray_find_nth_set() returned unexpected found_at: %d",
+	zassert_equal(found_at, 0, "sys_bitarray_find_nth_set() returned unexpected found_at: %zu",
 		      found_at);
 
 	ret = sys_bitarray_find_nth_set(&ba, 1, 32, 0, &found_at);
 	zassert_equal(ret, 0, "sys_bitarray_find_nth_set() returned unexpected value: %d", ret);
-	zassert_equal(found_at, 0, "sys_bitarray_find_nth_set() returned unexpected found_at: %d",
+	zassert_equal(found_at, 0, "sys_bitarray_find_nth_set() returned unexpected found_at: %zu",
 		      found_at);
 
 	ret = sys_bitarray_find_nth_set(&ba, 2, 32, 0, &found_at);
 	zassert_equal(ret, 0, "sys_bitarray_find_nth_set() returned unexpected value: %d", ret);
-	zassert_equal(found_at, 31, "sys_bitarray_find_nth_set() returned unexpected found_at: %d",
+	zassert_equal(found_at, 31, "sys_bitarray_find_nth_set() returned unexpected found_at: %zu",
 		      found_at);
 
 	ret = sys_bitarray_find_nth_set(&ba, 1, 31, 1, &found_at);
 	zassert_equal(ret, 0, "sys_bitarray_find_nth_set() returned unexpected value: %d", ret);
-	zassert_equal(found_at, 31, "sys_bitarray_find_nth_set() returned unexpected found_at: %d",
+	zassert_equal(found_at, 31, "sys_bitarray_find_nth_set() returned unexpected found_at: %zu",
 		      found_at);
 
 	ret = sys_bitarray_find_nth_set(&ba, 2, 31, 1, &found_at);
@@ -830,13 +830,13 @@ ZTEST(bitarray, test_bitarray_find_nth_set)
 
 	ret = sys_bitarray_find_nth_set(&ba, 1, 128, 0, &found_at);
 	zassert_equal(ret, 0, "sys_bitarray_find_nth_set() returned unexpected value: %d", ret);
-	zassert_equal(found_at, 0, "sys_bitarray_find_nth_set() returned unexpected found_at: %d",
+	zassert_equal(found_at, 0, "sys_bitarray_find_nth_set() returned unexpected found_at: %zu",
 		      found_at);
 
 	ret = sys_bitarray_find_nth_set(&ba, 8, 128, 0, &found_at);
 	zassert_equal(ret, 0, "sys_bitarray_find_nth_set() returned unexpected value: %d", ret);
-	zassert_equal(found_at, 127, "sys_bitarray_find_nth_set() returned unexpected found_at: %d",
-		      found_at);
+	zassert_equal(found_at, 127,
+		      "sys_bitarray_find_nth_set() returned unexpected found_at: %zu", found_at);
 
 	ret = sys_bitarray_find_nth_set(&ba, 8, 128, 1, &found_at);
 	zassert_equal(ret, -EINVAL, "sys_bitarray_find_nth_set() returned unexpected value: %d",
@@ -844,32 +844,32 @@ ZTEST(bitarray, test_bitarray_find_nth_set)
 
 	ret = sys_bitarray_find_nth_set(&ba, 7, 127, 1, &found_at);
 	zassert_equal(ret, 0, "sys_bitarray_find_nth_set() returned unexpected value: %d", ret);
-	zassert_equal(found_at, 127, "sys_bitarray_find_nth_set() returned unexpected found_at: %d",
-		      found_at);
+	zassert_equal(found_at, 127,
+		      "sys_bitarray_find_nth_set() returned unexpected found_at: %zu", found_at);
 
 	ret = sys_bitarray_find_nth_set(&ba, 7, 127, 0, &found_at);
 	zassert_equal(ret, 0, "sys_bitarray_find_nth_set() returned unexpected value: %d", ret);
-	zassert_equal(found_at, 96, "sys_bitarray_find_nth_set() returned unexpected found_at: %d",
+	zassert_equal(found_at, 96, "sys_bitarray_find_nth_set() returned unexpected found_at: %zu",
 		      found_at);
 
 	ret = sys_bitarray_find_nth_set(&ba, 6, 127, 1, &found_at);
 	zassert_equal(ret, 0, "sys_bitarray_find_nth_set() returned unexpected value: %d", ret);
-	zassert_equal(found_at, 96, "sys_bitarray_find_nth_set() returned unexpected found_at: %d",
+	zassert_equal(found_at, 96, "sys_bitarray_find_nth_set() returned unexpected found_at: %zu",
 		      found_at);
 
 	ret = sys_bitarray_find_nth_set(&ba, 6, 127, 1, &found_at);
 	zassert_equal(ret, 0, "sys_bitarray_find_nth_set() returned unexpected value: %d", ret);
-	zassert_equal(found_at, 96, "sys_bitarray_find_nth_set() returned unexpected found_at: %d",
+	zassert_equal(found_at, 96, "sys_bitarray_find_nth_set() returned unexpected found_at: %zu",
 		      found_at);
 
 	ret = sys_bitarray_find_nth_set(&ba, 1, 32, 48, &found_at);
 	zassert_equal(ret, 0, "sys_bitarray_find_nth_set() returned unexpected value: %d", ret);
-	zassert_equal(found_at, 63, "sys_bitarray_find_nth_set() returned unexpected found_at: %d",
+	zassert_equal(found_at, 63, "sys_bitarray_find_nth_set() returned unexpected found_at: %zu",
 		      found_at);
 
 	ret = sys_bitarray_find_nth_set(&ba, 2, 32, 48, &found_at);
 	zassert_equal(ret, 0, "sys_bitarray_find_nth_set() returned unexpected value: %d", ret);
-	zassert_equal(found_at, 64, "sys_bitarray_find_nth_set() returned unexpected found_at: %d",
+	zassert_equal(found_at, 64, "sys_bitarray_find_nth_set() returned unexpected found_at: %zu",
 		      found_at);
 
 	printk("Testing error cases\n");

--- a/tests/kernel/common/src/pow2.c
+++ b/tests/kernel/common/src/pow2.c
@@ -56,11 +56,11 @@ BUILD_ASSERT(sizeof(static_array9) == 16);
 static void test_pow2_ceil_x(unsigned long test_value,
 			     unsigned long expected_result)
 {
-	volatile unsigned int x = test_value;
-	unsigned int result = Z_POW2_CEIL(x);
+	volatile unsigned long x = test_value;
+	unsigned long result = Z_POW2_CEIL(x);
 
 	zassert_equal(result, expected_result,
-		      "ZPOW2_CEIL(%lu) returned %ld, expected %lu",
+		      "ZPOW2_CEIL(%lu) returned %lu, expected %lu",
 		      test_value, result, expected_result);
 }
 

--- a/tests/kernel/mem_protect/demand_paging/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/demand_paging/mem_map/src/main.c
@@ -131,7 +131,7 @@ static void touch_anon_pages(bool zig, bool zag)
 		size_t i = zig ? (arena_size - 1 - j) : j;
 
 		zassert_equal(arena[i], '\x00',
-			      "page not zeroed got 0x%hhx at index %d",
+			      "page not zeroed got 0x%hhx at index %zu",
 			      arena[i], i);
 	}
 
@@ -149,7 +149,7 @@ static void touch_anon_pages(bool zig, bool zag)
 		size_t i = zig ? (arena_ptr_size - 1 - j) : j;
 
 		zassert_equal(arena_ptr[i], &arena_ptr[i],
-			      "arena corrupted at index %d: got %p expected %p",
+			      "arena corrupted at index %zu: got %p expected %p",
 			      i, arena_ptr[i], &arena_ptr[i]);
 	}
 
@@ -176,7 +176,7 @@ static void touch_anon_pages(bool zig, bool zag)
 		size_t i = zag ? (arena_ptr_size - 1 - j) : j;
 
 		zassert_equal(arena_ptr[i], &arena_ptr[i],
-			      "arena corrupted at index %d: got %p expected %p",
+			      "arena corrupted at index %zu: got %p expected %p",
 			      i, arena_ptr[i], &arena_ptr[i]);
 	}
 
@@ -253,7 +253,7 @@ static void test_k_mem_page_out(void)
 	irq_unlock(key);
 
 	zassert_equal(faults, HALF_PAGES,
-		      "unexpected num pagefaults expected %lu got %d",
+		      "unexpected num pagefaults expected %d got %lu",
 		      HALF_PAGES, faults);
 
 	ret = k_mem_page_out(arena, arena_size);
@@ -284,7 +284,7 @@ ZTEST(demand_paging_api, test_k_mem_page_in)
 	faults = k_mem_num_pagefaults_get() - faults;
 	irq_unlock(key);
 
-	zassert_equal(faults, 0, "%d page faults when 0 expected",
+	zassert_equal(faults, 0, "%lu page faults when 0 expected",
 		      faults);
 }
 
@@ -309,7 +309,7 @@ ZTEST(demand_paging_api, test_k_mem_pin)
 	faults = k_mem_num_pagefaults_get() - faults;
 	irq_unlock(key);
 
-	zassert_equal(faults, 0, "%d page faults when 0 expected",
+	zassert_equal(faults, 0, "%lu page faults when 0 expected",
 		      faults);
 
 	/* Clean up */

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -89,7 +89,7 @@ ZTEST(mem_map, test_k_mem_map_phys_bare_rw)
 			k_mem_region_align(&aligned_addr, &aligned_size, (uintptr_t)mapped_rw,
 					   BUF_SIZE, CONFIG_MMU_PAGE_SIZE);
 		zassert_equal(aligned_offset, BUF_OFFSET,
-			      "unexpected mapped_rw aligned offset: %u != %u", aligned_offset,
+			      "unexpected mapped_rw aligned offset: %zu != %u", aligned_offset,
 			      BUF_OFFSET);
 		sys_cache_data_flush_and_invd_range((void *)aligned_addr, aligned_size);
 	}
@@ -471,7 +471,7 @@ ZTEST(mem_map_api, test_k_mem_map_exhaustion)
 
 	printk("Mapped %zu pages\n", cnt);
 	zassert_equal(cnt, expected_cnt,
-		      "number of pages mapped: expected %u, got %u",
+		      "number of pages mapped: expected %zu, got %zu",
 		      expected_cnt, cnt);
 
 	free_mem_now = k_mem_free_get();
@@ -491,7 +491,7 @@ ZTEST(mem_map_api, test_k_mem_map_exhaustion)
 
 	printk("Unmapped %zu pages\n", cnt);
 	zassert_equal(cnt, expected_cnt,
-		      "number of pages unmapped: expected %u, got %u",
+		      "number of pages unmapped: expected %zu, got %zu",
 		      expected_cnt, cnt);
 
 	free_mem_now = k_mem_free_get();

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -266,13 +266,13 @@ ZTEST_USER(syscalls, test_string_nlen)
 	} else {
 		zassert_equal(err, 0, "kernel string faulted in kernel mode (%d)", err);
 		zassert_equal(ret, strlen(kernel_string),
-			      "incorrect length returned (%d)", ret);
+			      "incorrect length returned (%zu)", ret);
 	}
 
 	/* Valid usage */
 	ret = string_nlen(user_string, BUF_SIZE, &err);
 	zassert_equal(err, 0, "user string faulted (%d)", err);
-	zassert_equal(ret, strlen(user_string), "incorrect length returned (%d)", ret);
+	zassert_equal(ret, strlen(user_string), "incorrect length returned (%zu)", ret);
 
 	/* Skip this scenario for nsim_sem emulated board, unfortunately
 	 * the emulator doesn't set up memory as specified in DTS and poking

--- a/tests/kernel/mem_slab/mslab_stats/src/main.c
+++ b/tests/kernel/mem_slab/mslab_stats/src/main.c
@@ -52,7 +52,7 @@ ZTEST(lib_mem_slab_stats_test, test_mem_slab_runtime_stats)
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
 
 	zassert_equal(stats.free_bytes, BLK_SZ * NUM_BLOCKS,
-		      "Expected %zu free bytes, not %zu\n",
+		      "Expected %d free bytes, not %zu\n",
 		      BLK_SZ * NUM_BLOCKS, stats.free_bytes);
 	zassert_equal(stats.allocated_bytes, 0,
 		      "Expected 0 allocated bytes, not %zu\n",
@@ -76,13 +76,13 @@ ZTEST(lib_mem_slab_stats_test, test_mem_slab_runtime_stats)
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
 
 	zassert_equal(stats.free_bytes, BLK_SZ * (NUM_BLOCKS - 3),
-		      "Expected %zu free bytes, not %zu\n",
+		      "Expected %d free bytes, not %zu\n",
 		      BLK_SZ * (NUM_BLOCKS - 3), stats.free_bytes);
 	zassert_equal(stats.allocated_bytes, 3 * BLK_SZ,
-		      "Expected %zu allocated bytes, not %zu\n",
+		      "Expected %d allocated bytes, not %zu\n",
 		      3 * BLK_SZ, stats.allocated_bytes);
 	zassert_equal(stats.max_allocated_bytes, 3 * BLK_SZ,
-		      "Expected %zu max allocated bytes, not %zu\n",
+		      "Expected %d max allocated bytes, not %zu\n",
 		      3 * BLK_SZ, stats.max_allocated_bytes);
 
 	/* Free blocks 1 and 2, and then verify the stats. */
@@ -94,13 +94,13 @@ ZTEST(lib_mem_slab_stats_test, test_mem_slab_runtime_stats)
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
 
 	zassert_equal(stats.free_bytes, BLK_SZ * (NUM_BLOCKS - 1),
-		      "Expected %zu free bytes, not %zu\n",
+		      "Expected %d free bytes, not %zu\n",
 		      BLK_SZ * (NUM_BLOCKS - 1), stats.free_bytes);
 	zassert_equal(stats.allocated_bytes, 1 * BLK_SZ,
-		      "Expected %zu allocated bytes, not %zu\n",
+		      "Expected %d allocated bytes, not %zu\n",
 		      1 * BLK_SZ, stats.allocated_bytes);
 	zassert_equal(stats.max_allocated_bytes, 3 * BLK_SZ,
-		      "Expected %zu max allocated bytes, not %zu\n",
+		      "Expected %d max allocated bytes, not %zu\n",
 		      3 * BLK_SZ, stats.max_allocated_bytes);
 
 	/* Allocate 1 block and verify the max is still at 3 */
@@ -112,13 +112,13 @@ ZTEST(lib_mem_slab_stats_test, test_mem_slab_runtime_stats)
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
 
 	zassert_equal(stats.free_bytes, BLK_SZ * (NUM_BLOCKS - 2),
-		      "Expected %zu free bytes, not %zu\n",
+		      "Expected %d free bytes, not %zu\n",
 		      BLK_SZ * (NUM_BLOCKS - 2), stats.free_bytes);
 	zassert_equal(stats.allocated_bytes, 2 * BLK_SZ,
-		      "Expected %zu allocated bytes, not %zu\n",
+		      "Expected %d allocated bytes, not %zu\n",
 		      2 * BLK_SZ, stats.allocated_bytes);
 	zassert_equal(stats.max_allocated_bytes, 3 * BLK_SZ,
-		      "Expected %zu max allocated bytes, not %zu\n",
+		      "Expected %d max allocated bytes, not %zu\n",
 		      3 * BLK_SZ, stats.max_allocated_bytes);
 
 
@@ -131,13 +131,13 @@ ZTEST(lib_mem_slab_stats_test, test_mem_slab_runtime_stats)
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
 
 	zassert_equal(stats.free_bytes, BLK_SZ * (NUM_BLOCKS - 2),
-		      "Expected %zu free bytes, not %zu\n",
+		      "Expected %d free bytes, not %zu\n",
 		      BLK_SZ * (NUM_BLOCKS - 2), stats.free_bytes);
 	zassert_equal(stats.allocated_bytes, 2 * BLK_SZ,
-		      "Expected %zu allocated bytes, not %zu\n",
+		      "Expected %d allocated bytes, not %zu\n",
 		      2 * BLK_SZ, stats.allocated_bytes);
 	zassert_equal(stats.max_allocated_bytes, 2 * BLK_SZ,
-		      "Expected %zu max allocated bytes, not %zu\n",
+		      "Expected %d max allocated bytes, not %zu\n",
 		      2 * BLK_SZ, stats.max_allocated_bytes);
 
 	/* Free the last two blocks; verify stats results */
@@ -149,13 +149,13 @@ ZTEST(lib_mem_slab_stats_test, test_mem_slab_runtime_stats)
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
 
 	zassert_equal(stats.free_bytes, BLK_SZ * NUM_BLOCKS,
-		      "Expected %zu free bytes, not %zu\n",
+		      "Expected %d free bytes, not %zu\n",
 		      BLK_SZ * NUM_BLOCKS, stats.free_bytes);
 	zassert_equal(stats.allocated_bytes, 0,
-		      "Expected %zu allocated bytes, not %zu\n",
+		      "Expected %d allocated bytes, not %zu\n",
 		      0, stats.allocated_bytes);
 	zassert_equal(stats.max_allocated_bytes, 2 * BLK_SZ,
-		      "Expected %zu max allocated bytes, not %zu\n",
+		      "Expected %d max allocated bytes, not %zu\n",
 		      2 * BLK_SZ, stats.max_allocated_bytes);
 }
 

--- a/tests/kernel/obj_core/obj_core_stats/src/main.c
+++ b/tests/kernel/obj_core/obj_core_stats/src/main.c
@@ -336,7 +336,7 @@ ZTEST(obj_core_stats_thread, test_obj_core_stats_thread_test)
 	/* Disable the stats (re-using query2 and query3) */
 
 	status = k_obj_core_stats_disable(K_OBJ_CORE(test_thread));
-	zassert_equal(status, 0, "Expected 0, got %llu\n", status);
+	zassert_equal(status, 0, "Expected 0, got %d\n", status);
 
 	k_sem_give(&wake_test_thread);
 	k_sem_take(&wake_main_thread, K_FOREVER);
@@ -351,7 +351,7 @@ ZTEST(obj_core_stats_thread, test_obj_core_stats_thread_test)
 	/* Enable the stats */
 
 	status = k_obj_core_stats_enable(K_OBJ_CORE(test_thread));
-	zassert_equal(status, 0, "Expected 0, got %llu\n", status);
+	zassert_equal(status, 0, "Expected 0, got %d\n", status);
 
 	k_sem_give(&wake_test_thread);
 	k_sem_take(&wake_main_thread, K_FOREVER);
@@ -440,14 +440,14 @@ static void test_mem_block_query(const char *str,
 		      "%s: Failed to get query stats (%d)\n", str, status);
 
 	zassert_equal(query.free_bytes, expected->free_bytes,
-		      "%s: Expected %u free bytes, got %u\n",
+		      "%s: Expected %zu free bytes, got %zu\n",
 		      str, expected->free_bytes, query.free_bytes);
 #ifdef CONFIG_SYS_MEM_BLOCKS_RUNTIME_STATS
 	zassert_equal(query.allocated_bytes, expected->allocated_bytes,
-		      "%s: Expected %u allocated bytes, got %u\n",
+		      "%s: Expected %zu allocated bytes, got %zu\n",
 		      str, expected->allocated_bytes, query.allocated_bytes);
 	zassert_equal(query.max_allocated_bytes, expected->max_allocated_bytes,
-		      "%s: Expected %u max_allocated bytes, got %d\n",
+		      "%s: Expected %zu max_allocated bytes, got %zu\n",
 		      str, expected->max_allocated_bytes,
 		      query.max_allocated_bytes);
 #endif
@@ -575,14 +575,14 @@ static void test_mem_slab_raw(const char *str, struct k_mem_slab_info *expected)
 		      "%s: Expected %u blocks, got %u\n",
 		      str, expected->num_blocks, raw.num_blocks);
 	zassert_equal(raw.block_size, expected->block_size,
-		      "%s: Expected block size=%u blocks, got %u\n",
+		      "%s: Expected block size=%zu blocks, got %zu\n",
 		      str, expected->block_size, raw.block_size);
 	zassert_equal(raw.num_used, expected->num_used,
-		      "%s: Expected %u used, got %d\n",
+		      "%s: Expected %u used, got %u\n",
 		      str, expected->num_used, raw.num_used);
 #ifdef CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION
 	zassert_equal(raw.max_used, expected->max_used,
-		      "%s: Expected max %u used, got %d\n",
+		      "%s: Expected max %u used, got %u\n",
 		      str, expected->max_used, raw.max_used);
 #endif
 }
@@ -599,13 +599,13 @@ static void test_mem_slab_query(const char *str,
 		      "%s: Failed to get query stats (%d)\n", str, status);
 
 	zassert_equal(query.free_bytes, expected->free_bytes,
-		      "%s: Expected %u free bytes, got %u\n",
+		      "%s: Expected %zu free bytes, got %zu\n",
 		      str, expected->free_bytes, query.free_bytes);
 	zassert_equal(query.allocated_bytes, expected->allocated_bytes,
-		      "%s: Expected %u allocated bytes, got %u\n",
+		      "%s: Expected %zu allocated bytes, got %zu\n",
 		      str, expected->allocated_bytes, query.allocated_bytes);
 	zassert_equal(query.max_allocated_bytes, expected->max_allocated_bytes,
-		      "%s: Expected %u max_allocated bytes, got %d\n",
+		      "%s: Expected %zu max_allocated bytes, got %zu\n",
 		      str, expected->max_allocated_bytes,
 		      query.max_allocated_bytes);
 }

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -321,10 +321,10 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		+ expected_period_drift;
 
 	zassert_true(min_us >= min_us_bound,
-		"Shortest timer period too short (off by more than expected %d%)",
+		"Shortest timer period too short (off by more than expected %d%%)",
 		CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT);
 	zassert_true(max_us <= max_us_bound,
-		"Longest timer period too long (off by more than expected %d%)",
+		"Longest timer period too long (off by more than expected %d%%)",
 		CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT);
 
 


### PR DESCRIPTION
Fix format specifiers that did not match the argument type. Use `%zu` format specifier for `size_t` type to ensure compatibility with both 32-bit and 64-bit platforms. Escape percent signs in format strings using `%%` to prevent warnings about unknown format specifiers.

Part of https://github.com/zephyrproject-rtos/zephyr/issues/96968