### PR TITLE
lwm2m: Add missing offset param to write_package_cb calls for SWMGMT

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
@@ -411,7 +411,8 @@ static int handle_event(struct lwm2m_swmgmt_data *instance, uint8_t event)
 			/* Inform the instance of DOWNLOAD_FAILED by calling
 			 * write_package_cb with a bunch of NULL parameters
 			 */
-			instance->write_package_cb(instance->obj_inst_id, 0, 0, NULL, 0, false, 0);
+			instance->write_package_cb(instance->obj_inst_id, 0, 0, NULL, 0,
+					 false, 0, 0);
 			break;
 		default:
 			ret = -EINVAL;
@@ -576,7 +577,7 @@ static int package_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 	}
 
 	ret = instance->write_package_cb(obj_inst_id, res_id, res_inst_id, data, data_len,
-					 last_block, total_size);
+					 last_block, total_size, offset);
 
 	if (ret < 0) {
 		handle_event(instance, EVENT_DOWNLOAD_FAILED);


### PR DESCRIPTION
In https://github.com/zephyrproject-rtos/zephyr/pull/72590 the new `offset` parameter was added to the signature for the type used by the `write_package_cb` however it seems like 2 calls in the LWM2M OBJ 9 (SWMGMT) was missed and thus prevents compilation.

```
lwm2m_engine_set_data_cb_t write_package_cb;
```
Here is the type definition for it

```
typedef int (*lwm2m_engine_set_data_cb_t)(uint16_t obj_inst_id,
					  uint16_t res_id, uint16_t res_inst_id,
					  uint8_t *data, uint16_t data_len,
					  bool last_block, size_t total_size, size_t offset);
```

This fix simply adds the missing parameter to the appropriate calls.
