### PR TITLE
boards: nordic: nrf54h20: Add adc to supported features

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr_0_9_0.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr_0_9_0.yaml
@@ -11,6 +11,7 @@ sysbuild: true
 ram: 62
 flash: 62
 supported:
+  - adc
   - counter
   - gpio
   - i2c


### PR DESCRIPTION
Enable twister adc tests execution on nrf54h20dk/nrf54h20/cpuppr target.