### PR TITLE
dts: stm32u5: disable otghs-phy by default

### DIFF
--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
@@ -85,4 +85,5 @@ zephyr_udc0: &usbotg_hs {
 
 &otghs_phy {
 	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";
+	status = "okay";
 };

--- a/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
+++ b/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
@@ -259,6 +259,7 @@ zephyr_udc0: &usbotg_hs {
 
 &otghs_phy {
 	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
+++ b/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
@@ -259,6 +259,7 @@ zephyr_udc0: &usbotg_hs {
 
 &otghs_phy {
 	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
+++ b/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
@@ -298,6 +298,7 @@ zephyr_udc0: &usbotg_hs {
 
 &otghs_phy {
 	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";
+	status = "okay";
 };
 
 &flash0 {

--- a/dts/arm/st/u5/stm32u5_usbotg_hs.dtsi
+++ b/dts/arm/st/u5/stm32u5_usbotg_hs.dtsi
@@ -28,5 +28,6 @@
 		clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
 			 <&rcc STM32_SRC_HSE OTGHS_SEL(0)>;
 		#phy-cells = <0>;
+		status = "disabled";
 	};
 };


### PR DESCRIPTION
The clock-reference property is marked as required in the bindings file. Without these changes creating new boards based on stm32u5 either requires explicitly disabling otghs_phy or setting the clock-reference -property. The in-tree boards all use the same value for it, which is probably a sensible default.