### PR TITLE
Handle RDNSS ICMPV6 option lifetime

### DIFF
--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -679,6 +679,23 @@ int dns_resolve_remove_source(struct dns_resolve_context *ctx, int if_index,
 			      enum dns_server_source source);
 
 /**
+ * @brief Remove servers from the DNS resolving context that have a specific IP address.
+ *
+ * @param ctx DNS context
+ * @param servers_sa DNS server addresses as struct sockaddr. The array
+ *        is NULL terminated. Port numbers are optional in struct sockaddr, the
+ *        default will be used if set to 0.
+ * @param interfaces Network interfaces to which the DNS servers are bound.
+ *        This is an array of network interface indices. The array must be
+ *        the same length as the servers_sa array.
+ *
+ * @return 0 if ok, <0 if error.
+ */
+int dns_resolve_remove_server_addresses(struct dns_resolve_context *ctx,
+					const struct sockaddr *servers_sa[],
+					int interfaces[]);
+
+/**
  * @brief Cancel a pending DNS query.
  *
  * @details This releases DNS resources used by a pending query.

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -464,9 +464,9 @@ static bool is_server_name_found(struct dns_resolve_context *ctx,
 	return false;
 }
 
-static bool is_server_addr_found(struct dns_resolve_context *ctx,
-				 const struct sockaddr *addr,
-				 int if_index)
+static int idx_of_server_addr(struct dns_resolve_context *ctx,
+			      const struct sockaddr *addr,
+			      int if_index)
 {
 	ARRAY_FOR_EACH(ctx->servers, i) {
 		if (ctx->servers[i].dns_server.sa_family == addr->sa_family &&
@@ -478,11 +478,11 @@ static bool is_server_addr_found(struct dns_resolve_context *ctx,
 				continue;
 			}
 
-			return true;
+			return i;
 		}
 	}
 
-	return false;
+	return -1;
 }
 
 static int get_free_slot(struct dns_resolve_context *ctx)
@@ -670,11 +670,11 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 
 	for (i = 0; servers_sa != NULL && idx < SERVER_COUNT && servers_sa[i] != NULL; i++) {
 		char iface_str[IFNAMSIZ] = { 0 };
-		bool found;
+		int found_idx;
 
-		found = is_server_addr_found(ctx, servers_sa[i],
-					     interfaces == NULL ? 0 : interfaces[i]);
-		if (found) {
+		found_idx = idx_of_server_addr(ctx, servers_sa[i],
+					       interfaces == NULL ? 0 : interfaces[i]);
+		if (found_idx != -1) {
 			NET_DBG("Server %s already exists",
 				net_sprint_addr(ctx->servers[i].dns_server.sa_family,
 						&net_sin(&ctx->servers[i].dns_server)->sin_addr));
@@ -2510,6 +2510,38 @@ int dns_resolve_remove_source(struct dns_resolve_context *ctx, int if_index,
 			      enum dns_server_source source)
 {
 	return dns_resolve_remove_and_check_source(ctx, if_index, true, source);
+}
+
+int dns_resolve_remove_server_addresses(struct dns_resolve_context *ctx,
+					const struct sockaddr *servers_sa[],
+					int interfaces[])
+{
+	int ret = -ENOENT;
+	int i = 0;
+	int server_idx = -1;
+
+	if (ctx == NULL || servers_sa == NULL) {
+		return -ENOENT;
+	}
+
+	k_mutex_lock(&ctx->lock, K_FOREVER);
+
+	do {
+		server_idx = idx_of_server_addr(ctx, servers_sa[i],
+						interfaces == NULL ? 0 : interfaces[i]);
+		if (server_idx != -1) {
+			ctx->servers[server_idx].if_index = 0;
+
+			k_mutex_unlock(&ctx->lock);
+			ret = dns_server_close(ctx, server_idx);
+			k_mutex_lock(&ctx->lock, K_FOREVER);
+		}
+		i++;
+	} while (servers_sa[i] != NULL);
+
+	k_mutex_unlock(&ctx->lock);
+
+	return ret;
 }
 
 struct dns_resolve_context *dns_resolve_get_default(void)


### PR DESCRIPTION
When an IPV6 message that contains an RDNSS ICMPV6 option with a lifetime equal to 0 is received, proceed to delete the indicated recursive DNS servers listed in that option.