### PR TITLE
STM32 ADC: Add new properties to simplify driver

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1722,10 +1722,7 @@ static int adc_stm32_suspend_setup(const struct device *dev)
 #if ANY_ADC_INTERNAL_REGULATOR_TYPE_IS(INTERNAL_REGULATOR_STARTUP_SW_DELAY) || \
 	ANY_ADC_INTERNAL_REGULATOR_TYPE_IS(INTERNAL_REGULATOR_STARTUP_HW_STATUS)
 	if (config->internal_regulator != INTERNAL_REGULATOR_NONE) {
-		/* Disable ADC internal voltage regulator */
 		LL_ADC_DisableInternalRegulator(adc);
-		while (LL_ADC_IsInternalRegulatorEnabled(adc) == 1U) {
-		}
 	}
 #endif /* INTERNAL_REGULATOR_STARTUP_SW_DELAY || INTERNAL_REGULATOR_STARTUP_HW_STATUS */
 

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -939,10 +939,7 @@ static int set_sequencer(const struct device *dev)
 	if (config->sequencer_type == NOT_FULLY_CONFIGURABLE) {
 		LL_ADC_REG_SetSequencerChannels(adc, channels_mask);
 
-#if !defined(CONFIG_SOC_SERIES_STM32F0X) && \
-	!defined(CONFIG_SOC_SERIES_STM32L0X) && \
-	!defined(CONFIG_SOC_SERIES_STM32U5X) && \
-	!defined(CONFIG_SOC_SERIES_STM32WBAX)
+#ifdef LL_ADC_FLAG_CCRDY
 		/*
 		 * After modifying sequencer it is mandatory to wait for the
 		 * assertion of CCRDY flag
@@ -950,7 +947,7 @@ static int set_sequencer(const struct device *dev)
 		while (LL_ADC_IsActiveFlag_CCRDY(adc) == 0) {
 		}
 		LL_ADC_ClearFlag_CCRDY(adc);
-#endif /* !CONFIG_SOC_SERIES_STM32F0X && !L0X && !U5X && !WBAX */
+#endif /* LL_ADC_FLAG_CCRDY */
 	}
 #endif /* ANY_ADC_SEQUENCER_TYPE_IS(NOT_FULLY_CONFIGURABLE) */
 

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -459,7 +459,6 @@
 			reg = <0x40012400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 20)>;
 			interrupts = <12 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -469,6 +468,8 @@
 			num-sampling-time-common-channels = <2>;
 			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			status = "disabled";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -347,7 +347,6 @@
 			reg = <0x40012400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <12 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -357,6 +356,8 @@
 			num-sampling-time-common-channels = <1>;
 			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -369,12 +369,13 @@
 			reg = <0x40012400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32F1_ADC_RES(12)>;
 			sampling-times = <2 8 14 29 42 56 72 240>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -127,8 +127,13 @@
 			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
 			/* Shares vector with ADC1 */
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32F1_ADC_RES(12)>;
+			sampling-times = <2 8 14 29 42 56 72 240>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
+			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		adc3: adc@40013c00 {
@@ -136,8 +141,13 @@
 			reg = <0x40013c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 15)>;
 			interrupts = <47 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32F1_ADC_RES(12)>;
+			sampling-times = <2 8 14 29 42 56 72 240>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
+			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		timers8: timers@40013400 {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -370,7 +370,6 @@
 			reg = <0x40012000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 8)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -380,6 +379,8 @@
 			st,adc-clock-source = "SYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -106,7 +106,6 @@
 			reg = <0x50000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 28)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -115,6 +114,9 @@
 			sampling-times = <2 3 5 8 20 62 182 602>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 	};
 

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -134,7 +134,6 @@
 			reg = <0x50000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 28)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			vref-mv = <3000>;
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
@@ -144,6 +143,9 @@
 			sampling-times = <2 3 5 8 20 62 182 602>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		adc2: adc@50000100 {
@@ -151,7 +153,6 @@
 			reg = <0x50000100 0x4c>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 28)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			vref-mv = <3000>;
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
@@ -161,6 +162,9 @@
 			sampling-times = <2 3 5 8 20 62 182 602>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 	};
 

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -74,7 +74,6 @@
 			reg = <0x50000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 28)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -83,6 +82,9 @@
 			sampling-times = <2 3 5 8 20 62 182 602>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -236,12 +236,13 @@
 			reg = <0x40012400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32F1_ADC_RES(12)>;
 			sampling-times = <2 8 14 29 42 56 72 240>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -555,7 +555,6 @@
 			reg = <0x40012000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 8)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -565,6 +564,8 @@
 			st,adc-clock-source = "SYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -256,7 +256,6 @@
 			reg = <0x40012100 0x050>;
 			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -266,6 +265,8 @@
 			st,adc-clock-source = "SYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		adc3: adc@40012200 {
@@ -273,7 +274,6 @@
 			reg = <0x40012200 0x050>;
 			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -283,6 +283,8 @@
 			st,adc-clock-source = "SYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -117,7 +117,6 @@
 			reg = <0x40012100 0x050>;
 			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -127,6 +126,8 @@
 			st,adc-clock-source = "SYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		adc3: adc@40012200 {
@@ -134,7 +135,6 @@
 			reg = <0x40012200 0x050>;
 			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -144,6 +144,8 @@
 			st,adc-clock-source = "SYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -775,7 +775,6 @@
 			reg = <0x40012000 0x50>;
 			clocks = <&rcc STM32_CLOCK(APB2, 8)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -785,6 +784,8 @@
 			st,adc-clock-source = "SYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		adc2: adc@40012100 {
@@ -792,7 +793,6 @@
 			reg = <0x40012100 0x50>;
 			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -802,6 +802,8 @@
 			st,adc-clock-source = "SYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		adc3: adc@40012200 {
@@ -809,7 +811,6 @@
 			reg = <0x40012200 0x50>;
 			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -819,6 +820,8 @@
 			st,adc-clock-source = "SYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -429,7 +429,6 @@
 			reg = <0x40012400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 20)>;
 			interrupts = <12 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -445,6 +444,8 @@
 			num-sampling-time-common-channels = <2>;
 			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			status = "disabled";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -111,7 +111,6 @@
 			reg = <0x50000000 0x100>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -120,6 +119,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		adc2: adc@50000100 {
@@ -127,7 +130,6 @@
 			reg = <0x50000100 0x100>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -136,6 +138,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		dac1: dac@50000800 {

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -33,7 +33,6 @@
 			reg = <0x50000500 0x100>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 14)>;
 			interrupts = <61 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -42,6 +41,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		adc5: adc@50000600 {
@@ -49,7 +52,6 @@
 			reg = <0x50000600 0x100>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 14)>;
 			interrupts = <62 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -58,6 +60,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		spi4: spi@40013c00 {

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -59,7 +59,6 @@
 			reg = <0x50000400 0x100>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 14)>;
 			interrupts = <47 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -68,6 +67,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		uart5: serial@40005000 {

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -312,7 +312,6 @@
 			reg = <0x42028000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 10)>;
 			interrupts = <37 0>;
-			status = "disabled";
 			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
@@ -322,6 +321,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		rtc: rtc@44007800 {

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -299,7 +299,6 @@
 			reg = <0x42028100 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 10)>;
 			interrupts = <69 0>;
-			status = "disabled";
 			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
@@ -309,6 +308,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		timers4: timers@40000800 {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -877,7 +877,6 @@
 			reg = <0x40022000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(16, 0x00)
 				       STM32_ADC_RES(14, 0x05)
@@ -887,6 +886,11 @@
 			sampling-times = <2 3 9 17 33 65 388 811>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+			st,adc-internal-regulator = "startup-hw-status";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		adc2: adc@40022100 {
@@ -894,7 +898,6 @@
 			reg = <0x40022100 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(16, 0x00)
 				       STM32_ADC_RES(14, 0x05)
@@ -904,6 +907,11 @@
 			sampling-times = <2 3 9 17 33 65 388 811>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+			st,adc-internal-regulator = "startup-hw-status";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		/* dual mode: adc1 and adc2 coupled */
@@ -912,7 +920,6 @@
 			reg = <0x40022300 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(16, 0x00)
 				       STM32_ADC_RES(14, 0x05)
@@ -922,6 +929,11 @@
 			sampling-times = <2 3 9 17 33 65 388 811>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+			st,adc-internal-regulator = "startup-hw-status";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		adc3: adc@58026000 {
@@ -929,7 +941,6 @@
 			reg = <0x58026000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB4, 24)>;
 			interrupts = <127 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(16, 0x00)
 				       STM32_ADC_RES(14, 0x05)
@@ -939,6 +950,11 @@
 			sampling-times = <2 3 9 17 33 65 388 811>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+			st,adc-internal-regulator = "startup-hw-status";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -52,8 +52,8 @@
 				       STM32H72X_ADC3_RES(8, 0x02)
 				       STM32H72X_ADC3_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
-			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
 		};
 
 		dmamux1: dmamux@40020800 {

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -812,7 +812,6 @@
 			reg = <0x40022000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			interrupts = <38 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -821,6 +820,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		adc2: adc@40022100 {
@@ -828,7 +831,6 @@
 			reg = <0x40022100 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			interrupts = <38 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -837,6 +839,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		rng: rng@48020000 {

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -315,7 +315,6 @@
 			reg = <0x40012400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <12 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -325,6 +324,8 @@
 			num-sampling-time-common-channels = <1>;
 			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			status = "disabled";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -264,7 +264,6 @@
 			clocks = <&rcc STM32_CLOCK(APB2, 9)>,
 				 <&rcc STM32_SRC_HSI NO_SEL>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -274,6 +273,8 @@
 			st,adc-clock-source = "ASYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_NONE";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -413,7 +413,6 @@
 			reg = <0x50040000 0x100>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -422,6 +421,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		adc2: adc@50040100 {
@@ -429,7 +432,6 @@
 			reg = <0x50040100 0x100>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -438,6 +440,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -275,8 +275,18 @@
 			reg = <0x50040200 0x100>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <47 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
+			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -671,7 +671,6 @@
 			reg = <0x42028000 0x100>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <37 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -680,6 +679,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		adc2: adc@42028100 {
@@ -687,7 +690,6 @@
 			reg = <0x42028100 0x100>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <37 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -696,6 +698,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		fdcan1: can@4000a400 {

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -437,7 +437,6 @@
 			reg = <0x50022000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			interrupts = <46 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -446,6 +445,10 @@
 			sampling-times = <2 3 7 12 14 47 247 1500>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+			st,adc-internal-regulator = "none";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
+			status = "disabled";
 		};
 
 		adc2: adc@50022100 {
@@ -453,7 +456,6 @@
 			reg = <0x50022100 0x300>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			interrupts = <46 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -462,6 +464,7 @@
 			sampling-times = <2 3 7 12 14 47 247 1500>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+			status = "disabled";
 		};
 
 		fdcan1: can@5000a000 {

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -285,7 +285,6 @@
 			reg = <0x40012400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 20)>;
 			interrupts = <12 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -295,6 +294,8 @@
 			num-sampling-time-common-channels = <2>;
 			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			status = "disabled";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -253,6 +253,9 @@
 			sampling-times = <2 3 7 12 24 47 247 1500>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+			st,adc-internal-regulator = "startup-hw-status";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
 			status = "disabled";
 		};
 
@@ -269,6 +272,9 @@
 			sampling-times = <2 3 7 12 24 47 247 1500>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+			st,adc-internal-regulator = "startup-hw-status";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -779,7 +779,6 @@
 			clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
 				 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
 			interrupts = <37 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(14, 0x00)
 				       STM32_ADC_RES(12, 0x01)
@@ -789,6 +788,11 @@
 			st,adc-clock-source = "ASYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+			st,adc-internal-regulator = "startup-hw-status";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		adc4: adc@46021000 {
@@ -797,7 +801,6 @@
 			clocks = <&rcc STM32_CLOCK(AHB3, 5)>,
 				 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
 			interrupts = <113 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -808,6 +811,8 @@
 			st,adc-clock-source = "ASYNC";
 			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-hw-status";
+			status = "disabled";
 		};
 
 		fdcan1: can@4000a400 {

--- a/dts/arm/st/u5/stm32u595.dtsi
+++ b/dts/arm/st/u5/stm32u595.dtsi
@@ -77,7 +77,6 @@
 			clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
 				 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
 			interrupts = <37 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(14, 0x00)
 				       STM32_ADC_RES(12, 0x01)
@@ -87,6 +86,11 @@
 			st,adc-clock-source = "ASYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+			st,adc-internal-regulator = "startup-hw-status";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 
 		/*
@@ -98,7 +102,6 @@
 			reg = <0x42028300 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 10)>;
 			interrupts = <37 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(14, 0x00)
 				       STM32_ADC_RES(12, 0x01)
@@ -108,6 +111,11 @@
 			st,adc-clock-source = "ASYNC";
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+			st,adc-internal-regulator = "startup-hw-status";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
+			st,adc-has-differential-support;
+			status = "disabled";
 		};
 	};
 

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -425,7 +425,6 @@
 			reg = <0x50040000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -434,6 +433,10 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-sequencer = "FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-differential-support;
+			st,adc-has-deep-powerdown;
+			status = "disabled";
 		};
 
 		iwdg: watchdog@40003000 {

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -494,7 +494,6 @@
 			clocks = <&rcc STM32_CLOCK(AHB4, 5)>,
 				 <&rcc STM32_SRC_HCLK1 ADC_SEL(0)>;
 			interrupts = <65 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -505,6 +504,8 @@
 			st,adc-clock-source = "ASYNC";
 			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-hw-status";
+			status = "disabled";
 		};
 
 		lptim1: timers@46004400 {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -357,7 +357,6 @@
 			reg = <0x40012400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <18 0>;
-			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32_ADC_RES(12, 0x00)
 				       STM32_ADC_RES(10, 0x01)
@@ -367,6 +366,8 @@
 			num-sampling-time-common-channels = <2>;
 			st,adc-sequencer = "NOT_FULLY_CONFIGURABLE";
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
+			st,adc-internal-regulator = "startup-sw-delay";
+			status = "disabled";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -117,5 +117,35 @@ properties:
       - "OVERSAMPLER_MINIMAL": Oversampler with 8 possible oversampling values (2, 4, 8, ..., 256)
       - "OVERSAMPLER_EXTENDED": Oversampler with 1024 possible oversampling values (1..1024)
 
+  st,adc-internal-regulator:
+    type: string
+    required: true
+    enum:
+      - "none"
+      - "startup-sw-delay"
+      - "startup-hw-status"
+    description: |
+      Presence and type of ADC internal regulator if any.
+      - "none": No internal regulator.
+      - "startup-sw-delay": Internal regulator is present and its startup time is checked with a
+        software delay.
+      - "startup-hw-status": Internal regulator is present and its startup time is checked with a
+        status flag in a register.
+
+  st,adc-has-deep-powerdown:
+    type: boolean
+    description: |
+      If present, it indicates that the ADC instance has a deep power down feature.
+
+  st,adc-has-channel-preselection:
+    type: boolean
+    description: |
+      If present, it indicates that the ADC instance has a channel preselection register.
+
+  st,adc-has-differential-support:
+    type: boolean
+    description: |
+      If present, it indicates that the ADC instance supports differential channel inputs.
+
 io-channel-cells:
   - input


### PR DESCRIPTION
Add a set of new properties to the STM32 ADC binding to simplify the driver. These properties describes the HW characteristics of the ADCs (which can sometimes be different for 2 distinct ADCs on the same SoC). This allows the driver to rely on these properties to execute the appropriate functions, instead of discriminating by series/SoC. 

This change improve code readability, and should simplify the addition of new series as there should be less modifications to do inside the driver.