### PR TITLE
boards: st: stm32h7s78_dk: add support for touch input

### DIFF
--- a/boards/st/stm32h7s78_dk/Kconfig.defconfig
+++ b/boards/st/stm32h7s78_dk/Kconfig.defconfig
@@ -31,4 +31,11 @@ config STM32_LTDC_FB_USE_SHARED_MULTI_HEAP
 	default y
 endif # DISPLAY
 
+if INPUT
+
+config INPUT_GT911_INTERRUPT
+	default y
+
+endif # INPUT
+
 endif # BOARD_STM32H7S78_DK

--- a/boards/st/stm32h7s78_dk/doc/index.rst
+++ b/boards/st/stm32h7s78_dk/doc/index.rst
@@ -179,6 +179,7 @@ Default Zephyr Peripheral Mapping:
 - ADC1 channel 6 input : PF12
 - USB OTG FS DM/DP : PM12/PM11
 - XSPI1 NCS/DQS0/DQS1/CLK/IO: PO0/PO2/PO3/PO4/PP0..15
+- I2C1 SCL/SDA: PB6/PB9
 
 System Clock
 ------------

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
@@ -21,6 +21,7 @@
 		zephyr,flash = &flash0;
 		zephyr,sram = &sram0;
 		zephyr,display = &ltdc;
+		zephyr,touch = &display_ctp;
 	};
 
 	psram: memory@90000000 {
@@ -202,6 +203,14 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	status = "okay";
+
+	display_ctp: gt911@5d {
+		compatible = "goodix,gt911";
+		reg = <0x5d>;
+		irq-gpios = <&gpioe 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+		status = "okay";
+	};
 };
 
 &xspi1 {


### PR DESCRIPTION
Add support for the touch input controller on the STM32H7S78-DK:
- Enable I2C1 on the board
- Add device tree node for the touch controller in the display panel

Tested with `samples/subsys/input/draw_touch_events`
