### PR TITLE
Bluetooth: Host: Change WRN->DBG for not connect for TX

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1051,7 +1051,7 @@ void bt_conn_tx_processor(void)
 	LOG_DBG("processing conn %p", conn);
 
 	if (conn->state != BT_CONN_CONNECTED) {
-		LOG_WRN("conn %p: not connected", conn);
+		LOG_DBG("conn %p: not connected: state %d", conn, conn->state);
 		goto raise_and_exit;
 	}
 


### PR DESCRIPTION
The bt_conn_tx_processor logged connections not in the connected state as LOG_WRN, but this is a case that is handled and could occur during regular behavior.
For this reason the log statement was changed to LOG_DBG, as the developer/user does not need to worry about it.