### PR TITLE
drivers: spi: spi_max32: Fix race condition on dma_stat

### DIFF
--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -645,12 +645,12 @@ static int transceive_dma(const struct device *dev, const struct spi_config *con
 		spi->dma |= ADI_MAX32_SPI_DMA_TX_DMA_EN;
 		MXC_SPI_SetTXThreshold(spi, 2);
 
+		data->dma_stat = 0;
 		ret = spi_max32_tx_dma_load(dev, ctx->tx_buf, len, dfs_shift);
 		if (ret < 0) {
 			goto unlock;
 		}
 
-		data->dma_stat = 0;
 		MXC_SPI_StartTransmission(spi);
 		ret = spi_context_wait_for_completion(ctx);
 	} while (!ret && (spi_context_tx_on(ctx) || spi_context_rx_on(ctx)));


### PR DESCRIPTION
A race condition occurs when the TX DMA callback is triggered before the `dma_stat` variable is initialized to zero. This leads to `dma_stat` being reset after the DMA TX done flag is already set.

To prevent this, move the initialization of `dma_stat` before starting the DMA load operation.