### PR TITLE
soc: adi: max32: Update SoC PM handling

### DIFF
--- a/soc/adi/max32/Kconfig
+++ b/soc/adi/max32/Kconfig
@@ -64,6 +64,14 @@ config MAX32_SECONDARY_RV32
 	bool "Secondary RISC-V core enable"
 	depends on MAX32_HAS_SECONDARY_RV32
 
+config MAX32_STANDBY_DELAY
+	int "Prevent standby on boot for given ms"
+	depends on PM
+	default 1000
+	help
+	  Prevents the system from entering standby mode for a give number of ms.
+	  This is intended to prevent debug lockout when using power management.
+
 DT_CHOSEN_Z_CODE_RV32_PARTITION := zephyr,code-rv32-partition
 
 config MAX32_SECONDARY_RV32_BOOT_ADDRESS

--- a/soc/adi/max32/power.c
+++ b/soc/adi/max32/power.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -26,7 +26,7 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 	switch (state) {
 	case PM_STATE_RUNTIME_IDLE:
 		LOG_DBG("entering PM state runtime idle");
-		Wrap_MXC_LP_EnterLowPowerMode();
+		MXC_LP_EnterSleepMode();
 		break;
 	case PM_STATE_SUSPEND_TO_IDLE:
 		LOG_DBG("entering PM state suspend to idle");

--- a/soc/adi/max32/power.c
+++ b/soc/adi/max32/power.c
@@ -61,10 +61,6 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 		LOG_DBG("exited PM state suspend to idle");
 		break;
 	case PM_STATE_STANDBY:
-		/* For this state wait a little until RTC register being ready
-		 * otherwise seems previous RTC value being read
-		 */
-		k_busy_wait(100);
 		LOG_DBG("exited PM state standby");
 		break;
 	default:

--- a/soc/adi/max32/soc.c
+++ b/soc/adi/max32/soc.c
@@ -11,12 +11,23 @@
 
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/pm/policy.h>
 
 #include <wrap_max32_sys.h>
 
 #ifdef CONFIG_MAX32_SECONDARY_RV32
 #include <fcr_regs.h>
 #endif
+
+#if defined(CONFIG_MAX32_STANDBY_DELAY) && (CONFIG_MAX32_STANDBY_DELAY > 0)
+struct k_timer max32_soc_timer;
+void max32_soc_timer_callback(struct k_timer *timer_id)
+{
+	/* Allow the system to enter standby */
+	pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
+}
+#endif /* defined(MAX32_STANDBY_DELAY) && (MAX32_STANDBY_DELAY > 0) */
 
 #if defined(CONFIG_MAX32_ON_ENTER_CPU_IDLE_HOOK)
 bool z_arm_on_enter_cpu_idle(void)
@@ -35,6 +46,16 @@ void soc_early_init_hook(void)
 {
 	/* Apply device related preinit configuration */
 	max32xx_system_init();
+
+	/* Temporarily prevent  the system from entering standby to prevent debug lockout */
+#if defined(CONFIG_MAX32_STANDBY_DELAY) && (CONFIG_MAX32_STANDBY_DELAY > 0)
+	/* Prevent the system from entering standby mode */
+	pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
+
+	/* Start a one-shot timer to put the pm lock */
+	k_timer_init(&max32_soc_timer, max32_soc_timer_callback, NULL);
+	k_timer_start(&max32_soc_timer, K_MSEC(CONFIG_MAX32_STANDBY_DELAY), K_NO_WAIT);
+#endif /* defined(MAX32_STANDBY_DELAY) && (MAX32_STANDBY_DELAY > 0) */
 
 #ifdef CONFIG_MAX32_SECONDARY_RV32
 	MXC_FCR->urvbootaddr = CONFIG_MAX32_SECONDARY_RV32_BOOT_ADDRESS;

--- a/tests/subsys/pm/power_mgmt_soc/boards/max32655evkit_max32655_m4.overlay
+++ b/tests/subsys/pm/power_mgmt_soc/boards/max32655evkit_max32655_m4.overlay
@@ -1,19 +1,16 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 / {
 	chosen {
-		zephyr,cortex-m-idle-timer = &counter_wut0;
+		zephyr,cortex-m-idle-timer = &rtc_counter;
 	};
 };
 
-&wut0 {
+&rtc_counter {
 	status = "okay";
 	wakeup-source;
-	counter_wut0: counter {
-		status = "okay";
-	};
 };

--- a/tests/subsys/pm/power_mgmt_soc/boards/max32655fthr_max32655_m4.overlay
+++ b/tests/subsys/pm/power_mgmt_soc/boards/max32655fthr_max32655_m4.overlay
@@ -1,19 +1,16 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 / {
 	chosen {
-		zephyr,cortex-m-idle-timer = &counter_wut0;
+		zephyr,cortex-m-idle-timer = &rtc_counter;
 	};
 };
 
-&wut0 {
+&rtc_counter {
 	status = "okay";
 	wakeup-source;
-	counter_wut0: counter {
-		status = "okay";
-	};
 };


### PR DESCRIPTION
Add several improvements to MAX32 SoC power management.

1. When switching to `IDLE`, use sleep mode instead of Low Power Mode (LPM). LPM is similar to deep sleep, not intended to be used for general idle.
2. Delay is not needed when coming out of `STANDBY` so remove it.
3. Add standby lock to prevent debug lockout on boot when using power management.
4. Revert 41339e2dd406a7be209f3347310cbbfc65a72397. Wake-up timer fails to reliably bring the MAX32655 out of sleep states.