### PR TITLE
kernel: work: work timeout handler uninitialized variables fix

### DIFF
--- a/kernel/work.c
+++ b/kernel/work.c
@@ -606,8 +606,8 @@ bool k_work_cancel_sync(struct k_work *work,
 static void work_timeout_handler(struct _timeout *record)
 {
 	struct k_work_q *queue = CONTAINER_OF(record, struct k_work_q, work_timeout_record);
-	struct k_work *work;
-	k_work_handler_t handler;
+	struct k_work *work = NULL;
+	k_work_handler_t handler = NULL;
 	const char *name;
 	const char *space = " ";
 


### PR DESCRIPTION
work and handler pointers are local and not initialized. Initialize them with NULL to avoid compiler error maybe-uninitialized.

This issue was found when running twister tests on RISCV

`zephyr/include/zephyr/logging/log_core.h:221:9: error: 'work' may be used uninitialized [-Werror=maybe-uninitialized]
  221 |         z_log_minimal_printk("%c: " fmt "\n", `
`zephyr/kernel/work.c:609:24: note: 'work' was declared here
  609 |         struct k_work *work;`

