### PR TITLE
MAINTAINERS: Add tpambor as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3623,6 +3623,8 @@ Native_sim and POSIX arch:
   status: maintained
   maintainers:
     - aescolar
+  collaborators:
+    - tpambor
   files:
     - arch/posix/
     - boards/native/common/


### PR DESCRIPTION
Add myself as collaborator to native_sim area.

I would like to continue participating actively in the native_sim area. I also used native_sim together with sanitizers like UBSan to improve overall code quality, e.g. in network area see https://github.com/zephyrproject-rtos/zephyr/issues/90882.

Some evidence:
- https://github.com/zephyrproject-rtos/zephyr/pull/95603
- https://github.com/zephyrproject-rtos/zephyr/pull/94478
- https://github.com/zephyrproject-rtos/zephyr/pull/95229
- https://github.com/zephyrproject-rtos/zephyr/pull/95437
- https://github.com/zephyrproject-rtos/zephyr/pull/96208
- https://github.com/zephyrproject-rtos/zephyr/pull/96765
- https://github.com/zephyrproject-rtos/zephyr/pull/96812
- https://github.com/zephyrproject-rtos/zephyr/pull/96869
-https://github.com/zephyrproject-rtos/zephyr/issues/96809