### PR TITLE
drivers: smbus: stm32: add support for pcall api

### DIFF
--- a/drivers/smbus/smbus_stm32.c
+++ b/drivers/smbus/smbus_stm32.c
@@ -447,6 +447,70 @@ static int smbus_stm32_block_read(const struct device *dev, uint16_t periph_addr
 	return 0;
 }
 
+int smbus_stm32_block_pcall(const struct device *dev, uint16_t addr, uint8_t cmd,
+			    uint8_t send_count, uint8_t *send_buf, uint8_t *recv_count,
+			    uint8_t *recv_buf)
+{
+	int ret;
+	uint8_t num_msgs;
+	uint8_t received_pec;
+	struct i2c_msg msgs[] = {
+		{
+			.buf = &cmd,
+			.len = sizeof(cmd),
+			.flags = I2C_MSG_WRITE,
+		},
+		{
+			.buf = &send_count,
+			.len = sizeof(send_count),
+			.flags = I2C_MSG_WRITE,
+		},
+		{
+			.buf = send_buf,
+			.len = send_count,
+			.flags = I2C_MSG_WRITE,
+		},
+		{
+			.buf = NULL, /* will point to next message's len field */
+			.len = 1,
+			.flags = I2C_MSG_READ | I2C_MSG_RESTART,
+		},
+		{
+			.buf = recv_buf,
+			.len = 0, /* written by previous message! */
+			.flags = I2C_MSG_READ,
+		},
+		{
+			.buf = &received_pec,
+			.len = 1,
+			.flags = I2C_MSG_READ,
+		},
+	};
+	struct smbus_stm32_data *data = dev->data;
+	const struct smbus_stm32_config *config = dev->config;
+
+	/* Count is read in msg 3 and stored in the len of msg 4.
+	 * This works because the STM I2C driver processes each message serially.
+	 * The addressing math assumes little-endian.
+	 */
+	msgs[3].buf = (uint8_t *)&msgs[4].len;
+
+	num_msgs = smbus_pec_num_msgs(data->config, ARRAY_SIZE(msgs));
+	ret = i2c_transfer(config->i2c_dev, msgs, num_msgs, addr);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = smbus_read_check_pec(data->config, addr, msgs, num_msgs);
+	if (ret < 0) {
+		return ret;
+	}
+
+	*recv_count = msgs[4].len;
+
+	return 0;
+}
+
 static DEVICE_API(smbus, smbus_stm32_api) = {
 	.configure = smbus_stm32_configure,
 	.get_config = smbus_stm32_get_config,
@@ -467,7 +531,7 @@ static DEVICE_API(smbus, smbus_stm32_api) = {
 	.smbus_smbalert_set_cb = NULL,
 	.smbus_smbalert_remove_cb = NULL,
 #endif /* CONFIG_SMBUS_STM32_SMBALERT */
-	.smbus_block_pcall = NULL,
+	.smbus_block_pcall = smbus_stm32_block_pcall,
 	.smbus_host_notify_set_cb = NULL,
 	.smbus_host_notify_remove_cb = NULL,
 };


### PR DESCRIPTION
Add SMBus Process Call / Process Call Block APIs for STM32.

This implementation also supports PEC mode (packet error checking) and is dependent on PEC support already being supported in-tree.

For more details, please see Sections 6.5.6 and 6.5.8 of the SMBus 3.1 Specification.
https://smbus.org/specs/SMBus_3_1_20180319.pdf