### PR TITLE
west: blobs: Add git lfs http(s) fetcher

### DIFF
--- a/doc/develop/modules.rst
+++ b/doc/develop/modules.rst
@@ -1023,6 +1023,14 @@ maps, each of which has the following entries:
 - ``doc-url``: A URL pointing to the location of the official documentation for
   this blob
 
+The following entries may also be present:
+
+- ``click-through``: A boolean indicating if a click-through license must be
+  accepted to download this blob
+- ``size``: Size of the blob in bytes. May be required by some fetchers
+- ``fetcher``: The method used to download the blob. If not set, the method is
+  inferred from the URL
+
 Package manager dependencies
 ============================
 

--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -202,7 +202,7 @@ class Blobs(WestCommand):
         self.dbg(f'Found fetcher: {fetcher}')
         inst = fetcher()
         self.ensure_folder(path)
-        inst.fetch(self, url, path)
+        inst.fetch(self, blob, path)
 
     def fetch_blob(self, args, blob):
         """

--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -55,12 +55,14 @@ class Blobs(WestCommand):
             - status: short status (A: present, M: hash failure, D: not present)
             - path: blob local path from <module>/zephyr/blobs/
             - sha256: blob SHA256 hash in hex
+            - size: blob size in bytes
             - type: type of blob
             - version: version string
             - license_path: path to the license file for the blob
             - license-abspath: absolute path to the license file for the blob
             - click-through: need license click-through or not
-            - uri: URI to the remote location of the blob
+            - url: URI to the remote location of the blob
+            - fetcher: method to use to fetch the blob
             - description: blob text description
             - doc-url: URL to the documentation for this blob
             '''),
@@ -194,7 +196,7 @@ class Blobs(WestCommand):
     def download_blob(self, blob, path):
         '''Download a blob from its url to a given path.'''
         url = blob['url']
-        scheme = urlparse(url).scheme
+        scheme = blob.get('fetcher') or urlparse(url).scheme
         self.dbg(f'Fetching blob from url {url} with {scheme} to path: {path}')
         import fetchers
 

--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -202,7 +202,7 @@ class Blobs(WestCommand):
         self.dbg(f'Found fetcher: {fetcher}')
         inst = fetcher()
         self.ensure_folder(path)
-        inst.fetch(url, path)
+        inst.fetch(self, url, path)
 
     def fetch_blob(self, args, blob):
         """

--- a/scripts/west_commands/fetchers/core.py
+++ b/scripts/west_commands/fetchers/core.py
@@ -6,6 +6,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List, Type
 
+from west.commands import WestCommand
+
 class ZephyrBlobFetcher(ABC):
 
     @staticmethod
@@ -19,5 +21,5 @@ class ZephyrBlobFetcher(ABC):
         '''Return this fetcher's schemes.'''
 
     @abstractmethod
-    def fetch(self, url: str, path: Path):
+    def fetch(self, west_command: WestCommand, url: str, path: Path):
         ''' Fetch a blob and store it '''

--- a/scripts/west_commands/fetchers/core.py
+++ b/scripts/west_commands/fetchers/core.py
@@ -21,5 +21,5 @@ class ZephyrBlobFetcher(ABC):
         '''Return this fetcher's schemes.'''
 
     @abstractmethod
-    def fetch(self, west_command: WestCommand, url: str, path: Path):
+    def fetch(self, west_command: WestCommand, blob: dict, path: Path):
         ''' Fetch a blob and store it '''

--- a/scripts/west_commands/fetchers/git_lfs.py
+++ b/scripts/west_commands/fetchers/git_lfs.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2025 Silicon Laboratories Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+import requests
+
+from fetchers.core import ZephyrBlobFetcher
+
+
+class GitLFSFetcher(ZephyrBlobFetcher):
+    """
+    Fetcher for Git LFS (Large File Storage) objects.
+
+    Sends a request to a Git LFS endpoint to get the URL of the requested blob before downloading
+    the blob itself. The ``sha256`` and ``size`` fields from the blob metadata are used for the
+    ``oid`` and ``size`` parameters of the LFS API, and the ``url`` field is used as the LFS API
+    URL.
+    """
+
+    @classmethod
+    def schemes(cls):
+        return ['lfs']
+
+    def fetch(self, west_command, blob, path):
+        url = blob["url"]
+        oid = blob["sha256"]
+
+        if "size" in blob:
+            size = blob["size"]
+        else:
+            west_command.err(f"'size' field missing for blob {path}, unable to fetch")
+            sys.exit(os.EX_USAGE)
+
+        west_command.dbg(f'GitLFSFetcher fetching {oid} from {url}')
+
+        # Perform a batch request to get the download URL of the LFS object
+        # see https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md#requests
+        headers = {
+            "Accept": "application/vnd.git-lfs+json",
+            "Content-Type": "application/vnd.git-lfs+json",
+        }
+
+        request = {
+            "operation": "download",
+            "transfers": ["basic"],
+            "objects": [
+                {
+                    "oid": oid,
+                    "size": size,
+                }
+            ],
+        }
+
+        try:
+            resp = requests.post(url + "/objects/batch", json=request, headers=headers)
+            resp.raise_for_status()  # Raises an HTTPError for bad status codes (4xx or 5xx)
+        except requests.exceptions.HTTPError as e:
+            west_command.err(f'HTTP error occurred: {e}')
+            sys.exit(os.EX_DATAERR)
+        except requests.exceptions.RequestException as e:
+            west_command.err(f'An error occurred: {e}')
+            sys.exit(os.EX_DATAERR)
+
+        # Download the LFS object
+        # see https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md#successful-responses
+        for obj in resp.json().get("objects", []):
+            if obj["oid"] == oid:
+                if "error" in obj:
+                    west_command.err(f'Failed to download LFS object {oid}: {obj["error"]}')
+                    sys.exit(os.EX_DATAERR)
+
+                try:
+                    download = obj["actions"]["download"]
+                except KeyError:
+                    west_command.err(f'Unexpected response from LFS server: {obj}')
+                    sys.exit(os.EX_DATAERR)
+
+                west_command.dbg(f'GitLFSFetcher fetching {download["href"]} to {path}')
+                try:
+                    resp = requests.get(download["href"], headers=download.get("header", {}))
+                    resp.raise_for_status()  # Raises an HTTPError for bad status codes (4xx or 5xx)
+                except requests.exceptions.HTTPError as e:
+                    west_command.err(f'HTTP error occurred: {e}')
+                    sys.exit(os.EX_DATAERR)
+                except requests.exceptions.RequestException as e:
+                    west_command.err(f'An error occurred: {e}')
+                    sys.exit(os.EX_DATAERR)
+                with open(path, "wb") as f:
+                    f.write(resp.content)
+                break
+        else:
+            west_command.err(f'Failed to download LFS object {oid}')
+            sys.exit(os.EX_DATAERR)

--- a/scripts/west_commands/fetchers/http.py
+++ b/scripts/west_commands/fetchers/http.py
@@ -6,8 +6,6 @@ import os
 import requests
 import sys
 
-from west import log
-
 from fetchers.core import ZephyrBlobFetcher
 
 class HTTPFetcher(ZephyrBlobFetcher):
@@ -16,16 +14,16 @@ class HTTPFetcher(ZephyrBlobFetcher):
     def schemes(cls):
         return ['http', 'https']
 
-    def fetch(self, url, path):
-        log.dbg(f'HTTPFetcher fetching {url} to {path}')
+    def fetch(self, west_command, url, path):
+        west_command.dbg(f'HTTPFetcher fetching {url} to {path}')
         try:
             resp = requests.get(url)
             resp.raise_for_status()  # Raises an HTTPError for bad status codes (4xx or 5xx)
         except requests.exceptions.HTTPError as e:
-            log.err(f'HTTP error occurred: {e}')
+            west_command.err(f'HTTP error occurred: {e}')
             sys.exit(os.EX_NOHOST)
         except requests.exceptions.RequestException as e:
-            log.err(f'An error occurred: {e}')
+            west_command.err(f'An error occurred: {e}')
             sys.exit(os.EX_DATAERR)
         with open(path, "wb") as f:
             f.write(resp.content)

--- a/scripts/west_commands/fetchers/http.py
+++ b/scripts/west_commands/fetchers/http.py
@@ -14,7 +14,8 @@ class HTTPFetcher(ZephyrBlobFetcher):
     def schemes(cls):
         return ['http', 'https']
 
-    def fetch(self, west_command, url, path):
+    def fetch(self, west_command, blob, path):
+        url = blob['url']
         west_command.dbg(f'HTTPFetcher fetching {url} to {path}')
         try:
             resp = requests.get(url)

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -119,6 +119,10 @@ properties:
           type: string
         doc-url:
           type: string
+        fetcher:
+          type: string
+        size:
+          type: integer
       required:
         - path
         - sha256


### PR DESCRIPTION
Add support for fetching blobs from (unauthenticated) Git LFS HTTP(s) servers using the LFS API to discover the blob URL.

Pass the entire blob context to the fetcher instead of only the URL to allow for fetchers that require more context than a single URL, and implement fetching from LFS servers using the `sha256` and `size` fields in the blob metadata to perform an API request to the LFS API in `url` to get the download URL for the blob.