### PR TITLE
tests: libc: thread: fix -Wformat errors

### DIFF
--- a/tests/lib/c_lib/thrd/src/thrd.c
+++ b/tests/lib/c_lib/thrd/src/thrd.c
@@ -79,7 +79,8 @@ ZTEST(libc_thrd, test_thrd_create_join)
 
 	zassert_equal(thrd_success, thrd_create(&thr, fun, &param));
 	zassert_equal(thrd_success, thrd_join(thr, &res));
-	zassert_equal(BIOS_FOOD, param, "expected: %d actual: %d", BIOS_FOOD, param);
+	zassert_equal(BIOS_FOOD, param, "expected: %u actual: %llu", BIOS_FOOD,
+		     (unsigned long long)param);
 	zassert_equal(FORTY_TWO, res);
 }
 


### PR DESCRIPTION
Cast `uintptr_t` to `unsigned long long` and adjust format specifier accordingly to ensure compatibility on both 32-bit and 64-bit architectures.

Fixes the following warning:
```
/home/user/west_workspace/zephyr/tests/lib/c_lib/thrd/src/thrd.c: In function 'libc_thrd_test_thrd_create_join':
/home/user/west_workspace/zephyr/tests/lib/c_lib/thrd/src/thrd.c:82:41: error: format '%d' expects argument of type 'int', but argument 8 has type 'uintptr_t' {aka 'long unsigned int'} [-Werror=format=]
   82 |         zassert_equal(BIOS_FOOD, param, "expected: %d actual: %d", BIOS_FOOD, param);
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~             ~~~~~
      |                                                                               |
      |                                                                               uintptr_t {aka long unsigned int}
```

Part of: https://github.com/zephyrproject-rtos/zephyr/issues/96968