### PR TITLE
scripts: ci: do_not_merge.py: labels starting with 'block:' mean DNM

### DIFF
--- a/scripts/ci/do_not_merge.py
+++ b/scripts/ci/do_not_merge.py
@@ -79,7 +79,7 @@ def main(argv):
     for label in pr.get_labels():
         print(f"label: {label.name}")
 
-        if label.name in DNM_LABELS:
+        if label.name in DNM_LABELS or label.name.startswith("block:"):
             print(f"Pull request is labeled as \"{label.name}\".")
             fail = True
 


### PR DESCRIPTION
When checking for "do not merge" labels on a pull request, also consider any label that starts with "block:" as a DNM label (e.g "block: HW Test").