### PR TITLE
samples: subsys: usb: midi: fix compilation error and warnings

### DIFF
--- a/lib/midi2/ump_stream_responder.h
+++ b/lib/midi2/ump_stream_responder.h
@@ -56,13 +56,31 @@ struct ump_endpoint_dt_spec {
 };
 
 /**
+ * @brief      A function to send a UMP
+ */
+typedef void (*ump_send_func)(const void *, const struct midi_ump);
+
+/**
+ * @brief      Initialize a configuration for the UMP Stream responder
+ * @param      _dev      The device to send reply packets
+ * @param      _send     The send function
+ * @param      _ep_spec  The UMP endpoint specification
+ */
+#define UMP_STREAM_RESPONDER(_dev, _send, _ep_spec)				\
+	{									\
+		.dev = _dev,							\
+		.send = (ump_send_func) _send,	\
+		.ep_spec = _ep_spec,						\
+	}
+
+/**
  * @brief      Configuration for the UMP Stream responder
  */
 struct ump_stream_responder_cfg {
 	/** The device to send reply packets */
-	void *dev;
+	const void *dev;
 	/** The function to call to send a reply packet */
-	void (*send)(void *dev, const struct midi_ump ump);
+	ump_send_func send;
 	/** The UMP endpoint specification */
 	const struct ump_endpoint_dt_spec *ep_spec;
 };

--- a/samples/net/midi2/src/main.c
+++ b/samples/net/midi2/src/main.c
@@ -76,11 +76,8 @@ static const struct ump_endpoint_dt_spec ump_ep_dt =
 static inline void handle_ump_stream(struct netmidi2_session *session,
 				     const struct midi_ump ump)
 {
-	const struct ump_stream_responder_cfg responder_cfg = {
-		.dev = session,
-		.send = (void (*)(void *, const struct midi_ump)) netmidi2_send,
-		.ep_spec = &ump_ep_dt,
-	};
+	const struct ump_stream_responder_cfg responder_cfg =
+		UMP_STREAM_RESPONDER(session, netmidi2_send, &ump_ep_dt);
 	ump_stream_respond(&responder_cfg, ump);
 }
 

--- a/samples/subsys/usb/midi/src/main.c
+++ b/samples/subsys/usb/midi/src/main.c
@@ -45,11 +45,8 @@ INPUT_CALLBACK_DEFINE(NULL, key_press, NULL);
 static const struct ump_endpoint_dt_spec ump_ep_dt =
 	UMP_ENDPOINT_DT_SPEC_GET(USB_MIDI_DT_NODE);
 
-const struct ump_stream_responder_cfg responder_cfg = {
-	.dev = midi,
-	.send = (void (*)(void *, const struct midi_ump)) usbd_midi_send,
-	.ep_spec = &ump_ep_dt,
-};
+const struct ump_stream_responder_cfg responder_cfg =
+	UMP_STREAM_RESPONDER(midi, usbd_midi_send, &ump_ep_dt);
 
 static void on_midi_packet(const struct device *dev, const struct midi_ump ump)
 {

--- a/samples/subsys/usb/midi/src/main.c
+++ b/samples/subsys/usb/midi/src/main.c
@@ -55,8 +55,8 @@ static void on_midi_packet(const struct device *dev, const struct midi_ump ump)
 	switch (UMP_MT(ump)) {
 	case UMP_MT_MIDI1_CHANNEL_VOICE:
 		/* Only send MIDI1 channel voice messages back to the host */
-		LOG_INF("Send back MIDI1 message %02X %02X %02X", UMP_MIDI_STATUS(ump),
-			UMP_MIDI1_P1(ump), UMP_MIDI1_P2(ump));
+		LOG_INF("Send back MIDI1 message %02lX %02lX %02lX",
+			UMP_MIDI_STATUS(ump), UMP_MIDI1_P1(ump), UMP_MIDI1_P2(ump));
 		usbd_midi_send(dev, ump);
 		break;
 	case UMP_MT_UMP_STREAM:


### PR DESCRIPTION
This fixes an annoying compilation error that affects all ongoing PR since the Network MIDI 2.0 PR was merged this morning (cc @butok)
