### PR TITLE
doc: naming: Refine the statement about public APIs and prefixes

### DIFF
--- a/doc/contribute/style/naming.rst
+++ b/doc/contribute/style/naming.rst
@@ -15,7 +15,7 @@ as stated in each individual sub-section.
 Public symbol prefixes
 ======================
 
-All :term:`public APIs <public API>` in Zephyr must be prefixed according
+All :term:`public APIs <public API>` introduced to Zephyr must be prefixed according
 to the area or subsystem they belong to. Examples of area or subsystem prefixes
 are provided below for reference.
 


### PR DESCRIPTION
Clarify that the rule applies to APIs being introduced to Zephyr, and it is not necessarily retroactive to apply to existing APIs.