### PR TITLE
ztest: Add validation of zassert strings

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -76,8 +76,9 @@ static inline bool z_zexpect_(bool cond, const char *file, int line)
 
 #else /* CONFIG_ZTEST_ASSERT_VERBOSE != 0 */
 
-static inline bool z_zassert(bool cond, const char *default_msg, const char *file, int line,
-			     const char *func, const char *msg, ...)
+static inline __printf_like(6, 7) bool z_zassert(bool cond, const char *default_msg,
+						 const char *file, int line, const char *func,
+						 const char *msg, ...)
 {
 	if (cond == false) {
 		va_list vargs;
@@ -100,8 +101,9 @@ static inline bool z_zassert(bool cond, const char *default_msg, const char *fil
 	return true;
 }
 
-static inline bool z_zassume(bool cond, const char *default_msg, const char *file, int line,
-			     const char *func, const char *msg, ...)
+static inline __printf_like(6, 7) bool z_zassume(bool cond, const char *default_msg,
+						 const char *file, int line, const char *func,
+						 const char *msg, ...)
 {
 	if (cond == false) {
 		va_list vargs;
@@ -124,8 +126,9 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
 	return true;
 }
 
-static inline bool z_zexpect(bool cond, const char *default_msg, const char *file, int line,
-			     const char *func, const char *msg, ...)
+static inline __printf_like(6, 7) bool z_zexpect(bool cond, const char *default_msg,
+						 const char *file, int line, const char *func,
+						 const char *msg, ...)
 {
 	if (cond == false) {
 		va_list vargs;


### PR DESCRIPTION
Add `__printf_like` attribute to ztest assertion functions `zassert`, `zassume`, `zexpect` to validate format strings and arguments at compile time.

Re-land https://github.com/zephyrproject-rtos/zephyr/pull/96335 after it was reverted in https://github.com/zephyrproject-rtos/zephyr/pull/96910. The test failures have been fixed in individual PRs, for details, see #96968.

Fixes #96968