### PR TITLE
drivers: flash: stm32_qspi: Correct special behaviour for Microchip QSPI flash memories

### DIFF
--- a/drivers/flash/Kconfig.stm32
+++ b/drivers/flash/Kconfig.stm32
@@ -99,8 +99,7 @@ config USE_MICROCHIP_QSPI_FLASH_WITH_STM32
 	bool "Include patch for Microchip qspi flash when running with stm32"
 	depends on DT_HAS_ST_STM32_QSPI_NOR_ENABLED
 	help
-	  Set to use Microchip qspi flash memories which supports
-	  the Global Block Protection Unlock instruction (ULBPR - 98H),
-	  and write with SPI_NOR_CMD_PP_1_1_4 on 4 lines
+	  Set to use Microchip QSPI flash memories which use the PP_1_1_4 opcode
+	  (32H) for the PP_1_4_4 operation (usually 38H).
 
 endif # SOC_FLASH_STM32

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -282,15 +282,14 @@ static inline int qspi_prepare_quad_program(const struct device *dev,
 
 	cmd->Instruction = dev_data->qspi_write_cmd;
 #if defined(CONFIG_USE_MICROCHIP_QSPI_FLASH_WITH_STM32)
-	/* Microchip qspi-NOR flash, does not follow the standard rules */
-	if (cmd->Instruction == SPI_NOR_CMD_PP_1_1_4) {
-		cmd->AddressMode = QSPI_ADDRESS_4_LINES;
+	/* Microchip QSPI-NOR flash uses the PP_1_1_4 opcode for the PP_1_4_4 operation */
+	if (cmd->Instruction == SPI_NOR_CMD_PP_1_4_4) {
+		cmd->Instruction = SPI_NOR_CMD_PP_1_1_4;
 	}
-#else
-	cmd->AddressMode = ((cmd->Instruction == SPI_NOR_CMD_PP_1_1_4)
+#endif /* CONFIG_USE_MICROCHIP_QSPI_FLASH_WITH_STM32 */
+	cmd->AddressMode = ((dev_data->qspi_write_cmd == SPI_NOR_CMD_PP_1_1_4)
 				? QSPI_ADDRESS_1_LINE
 				: QSPI_ADDRESS_4_LINES);
-#endif /* CONFIG_USE_MICROCHIP_QSPI_FLASH_WITH_STM32 */
 	cmd->DataMode = QSPI_DATA_4_LINES;
 	cmd->DummyCycles = 0;
 


### PR DESCRIPTION
Commit [539928d ](https://github.com/zephyrproject-rtos/zephyr/pull/74534/commits/539928d23d9df1e8f3e93ae2101e153b75b55c80) introduced a special behaviour for Microchip QSPI flash memories into the STM32 QSPI flash driver, to handle the fact that these memories use the PP_1_1_4 opcode (32H) for the PP_1_4_4 operation (usually 38H).

The special behaviour is a bit backwards, as it results in a QSPI flash memory configured in 1-1-4 write mode using 4 address lines (1-4-4 operation). It should be the other way round, so that a QSPI flash memory configured in 1-4-4 mode uses 4 address lines (1-4-4 operation).

After these changes, the mode used matches the mode configured.

See commit message for more detailed explanation.

**Before/After Comparison**

Before:

Devicetree configuration requires `writeoc = "PP_1_1_4";` for successful quad write, which then uses 1-4-4 mode.

| Devicetree `writeoc` property | Write opcode used | Write mode used | Behaviour |
|--------|--------|--------|--------|
| writeoc = "PP_1_1_4"; | SPI_NOR_CMD_PP_1_1_4 | 1-4-4 | Successful write in 1-4-4 mode |
| writeoc = "PP_1_4_4"; | SPI_NOR_CMD_PP_1_4_4 | 1-4-4 | Unsuccessful write |
| (Omitted) | SPI_NOR_CMD_PP_1_4_4 | 1-4-4 | Unsuccessful write |

After:

Devicetree configuration requires `writeoc = "PP_1_4_4";` (or property omitted, defaults to 1-4-4 mode for quad mode) for successful quad write, which then uses 1-4-4 mode.

| Devicetree `writeoc` property | Write opcode used | Write mode used | Behaviour |
|--------|--------|--------|--------|
| writeoc = "PP_1_1_4"; | SPI_NOR_CMD_PP_1_1_4 | 1-1-4 | Unsuccessful write |
| writeoc = "PP_1_4_4"; | SPI_NOR_CMD_PP_1_1_4 | 1-4-4 | Successful write in 1-4-4 mode |
| (Omitted) | SPI_NOR_CMD_PP_1_1_4 | 1-4-4 | Successful write in 1-4-4 mode |

This PR also updates the Kconfig option description for `CONFIG_USE_MICROCHIP_QSPI_FLASH_WITH_STM32` to remove references to the Global Block Protection Unlock instruction - this was added at the same time as the Microchip-specific special behaviour for the 1-1-4 / 1-4-4 opcode but is distinct from this and is not affected by `CONFIG_USE_MICROCHIP_QSPI_FLASH_WITH_STM32`.