### PR TITLE
scripts: Use different module IDs per runner module

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -239,8 +239,10 @@ def do_run_common(command, user_args, user_runner_args, domain_file=None):
     for module in zephyr_module.parse_modules(ZEPHYR_BASE, command.manifest):
         runners_ext = module.meta.get("runners", [])
         for runner in runners_ext:
+            module_name = module.meta.get("name", "runners_ext") + "." + Path(runner["file"]).stem
+
             import_from_path(
-                module.meta.get("name", "runners_ext"), Path(module.project) / runner["file"]
+                module_name, Path(module.project) / runner["file"]
             )
 
     build_dir = get_build_dir(user_args)


### PR DESCRIPTION
If we have multiple runners listed under a module, Each runner py file will individually overload and overwrite the prior module loaded, because it is using the same module name.