### PR TITLE
scripts: kconfig: fix dt_nodelabel_int_prop crash if prop doesn't exist

### DIFF
--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -547,13 +547,7 @@ def dt_nodelabel_int_prop(kconf, _, label, prop):
     except edtlib.EDTError:
         return "0"
 
-    if not node or node.props[prop].type != "int":
-        return "0"
-
-    if not node.props[prop].val:
-        return "0"
-
-    return str(node.props[prop].val)
+    return str(_node_int_prop(node, prop))
 
 def dt_chosen_bool_prop(kconf, _, chosen, prop):
     """


### PR DESCRIPTION
`dt_nodelabel_int_prop` did not check if the property existed on the node before accessing it, which would result in a build-time crash (`KeyError` exception) and thus build error if used on a node which lacked the requested property.

Fix by using the common `_node_int_prop()` helper which handles all edge cases properly.

> NOTE: there is a tiny functional difference compared to my original idea which was
>```diff
>-    if not node or node.props[prop].type != "int":
>+    if not node:
>        return "0"
>
>+    if not prop in node.props:     # <=== this is the missing check
>+      return "0"
>+
>+    if node.props[prop].type != "int":
>+      return "0"
>
>    if not node.props[prop].val:
>        return "0"
>
>    return str(node.props[prop].val)
>```
>
> :arrow_right: `_node_int_prop()` does not check for `node.props[prop].val is not None`
>
>However, the check for `type` should be sufficient since according to `edtlib` documentation:
https://github.com/zephyrproject-rtos/zephyr/blob/8d202cb9485558b24310334ef000c171de94ff07/scripts/dts/python-devicetree/src/devicetree/edtlib.py#L682-L687