### PR TITLE
smf: make while conditions MISRA 14.4 compliant

### DIFF
--- a/lib/smf/smf.c
+++ b/lib/smf/smf.c
@@ -242,7 +242,7 @@ void smf_set_initial(struct smf_ctx *const ctx, const struct smf_state *init_sta
 	 * The final target will be the deepest leaf state that
 	 * the target contains. Set that as the real target.
 	 */
-	while (init_state->initial) {
+	while (init_state->initial != NULL) {
 		init_state = init_state->initial;
 	}
 #endif
@@ -351,7 +351,7 @@ void smf_set_state(struct smf_ctx *const ctx, const struct smf_state *new_state)
 	 * The final target will be the deepest leaf state that
 	 * the target contains. Set that as the real target.
 	 */
-	while (new_state->initial) {
+	while (new_state->initial != NULL) {
 		new_state = new_state->initial;
 	}
 #endif


### PR DESCRIPTION
Replace pointer-as-condition checks, with explicit != NULL comparisons. 
Which satisfies MISRA-C:2012 Rule 14.4 (controlling expressions shall be 
essentially Boolean).