### PR TITLE
drivers: ethernet: eth_w5500: Remove config dependency from ETH_PHY_DRIVER

### DIFF
--- a/drivers/ethernet/Kconfig.w5500
+++ b/drivers/ethernet/Kconfig.w5500
@@ -37,3 +37,12 @@ config ETH_W5500_TIMEOUT
 	  Given timeout in milliseconds. Maximum amount of time
 	  that the driver will wait from the IP stack to get
 	  a memory buffer before the Ethernet frame is dropped.
+
+config ETH_W5500_MONITOR_PERIOD
+	int "Monitor task execution period"
+	depends on ETH_W5500
+	default 500
+	help
+	  Monitor task execution period in milliseconds. The monitor task is
+	  periodically executed to detect and report any changes in the
+	  link status to the operating system.

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -311,7 +311,7 @@ static void w5500_thread(void *p1, void *p2, void *p3)
 	const struct w5500_config *config = dev->config;
 
 	while (true) {
-		res = k_sem_take(&ctx->int_sem, K_MSEC(CONFIG_PHY_MONITOR_PERIOD));
+		res = k_sem_take(&ctx->int_sem, K_MSEC(CONFIG_ETH_W5500_MONITOR_PERIOD));
 
 		if (res == 0) {
 			/* semaphore taken, update link status and receive packets */


### PR DESCRIPTION
Fixes zephyrproject-rtos/zephyr#97217

Added new MONITOR_PERIOD config for W5500 driver
to remove dependency from ETH_PHY_DRIVER.

Signed-off-by: Siddhant Modi <siddhant.modi@gmail.com>