### PR TITLE
include: zephyr: drivers: sensor.h: fixed inline code format

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -513,7 +513,7 @@ struct sensor_decoder_api {
 	/**
 	 * @brief Decode up to @p max_count frames specified by @p chan_spec from the @p buffer
 	 *
-	 * Sample showing the process of decoding at most @code MAX_FRAMES for each distance
+	 * Sample showing the process of decoding at most `MAX_FRAMES` for each distance
 	 * sensor channel. The frame iterator is reset for each new channel to allow the
 	 * full history of each channel to be decoded.
 	 *


### PR DESCRIPTION
Fixed inline code format from `@ code` to backticks.

Current format looks off:

<img width="970" height="684" alt="Screenshot 2025-10-08 at 4 05 13 PM" src="https://github.com/user-attachments/assets/2c059d60-1831-48fa-acf5-9f8f20b5b851" />
