### PR TITLE
maintainers: Clarify area status definitions

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -10,11 +10,11 @@
 #         One of the following:
 #
 #         * maintained:
-#             The area has a Maintainer (approved by the TSC) who
-#             looks after the area.
+#             The area has a Maintainer (approved by the TSC) and/or collaborators
+#             who looks after the area.
 #
 #         * odd fixes:
-#            The area gets odd fixes and may have collaborators.
+#            The area gets odd fixes from the community.
 #
 #         * obsolete:
 #             Old code. Something being marked obsolete generally means it has


### PR DESCRIPTION
Clarify the area status definitions for maintained and odd fixes.

Primary change is to acknowledge that a "maintained" area may not have a Maintainer but can have active collaborators that support it.

The "odd fixes" status has general support from the community and the level of effort is not great enough to consider requiring official Maintainer/Collaborators.