### PR TITLE
scripts: Refactor build/runner west logging to not use deprecated APIs

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -213,7 +213,7 @@ class Build(Forceable):
 
         self.dbg(f'pristine: {pristine} auto_pristine: {self.auto_pristine}',
                 level=Verbosity.DBG_MORE)
-        if is_zephyr_build(self.build_dir):
+        if is_zephyr_build(self, self.build_dir):
             if pristine == 'always':
                 self._run_pristine()
                 self.run_cmake = True
@@ -482,7 +482,7 @@ class Build(Forceable):
         # The CMake Cache has not been loaded yet, so this is safe
 
         context = self._get_dir_fmt_context()
-        build_dir = find_build_dir(self.args.build_dir, **context)
+        build_dir = find_build_dir(self, self.args.build_dir, **context)
         if not build_dir:
             self.die('Unable to determine a default build folder. Check '
                     'your build.dir-fmt configuration option')
@@ -531,7 +531,7 @@ class Build(Forceable):
 
         srcrel = os.path.relpath(self.source_dir)
         self.check_force(
-            not is_zephyr_build(self.source_dir),
+            not is_zephyr_build(self, self.source_dir),
             f'it looks like {srcrel} is a build directory: '
             f'did you mean --build-dir {srcrel} instead?')
         self.check_force(
@@ -681,11 +681,11 @@ class Build(Forceable):
                             f'-G{config_get("generator", DEFAULT_CMAKE_GENERATOR)}']
         if cmake_opts:
             final_cmake_args.extend(cmake_opts)
-        run_cmake(final_cmake_args, dry_run=self.args.dry_run, env=cmake_env)
+        run_cmake(self, final_cmake_args, dry_run=self.args.dry_run, env=cmake_env)
 
     def _run_pristine(self):
         self._banner(f'making build dir {self.build_dir} pristine')
-        if not is_zephyr_build(self.build_dir):
+        if not is_zephyr_build(self, self.build_dir):
             self.die('Refusing to run pristine on a folder that is not a '
                      'Zephyr build system')
 
@@ -697,7 +697,7 @@ class Build(Forceable):
         cmake_args = [f'-DBINARY_DIR={app_bin_dir}',
                       f'-DSOURCE_DIR={app_src_dir}',
                       '-P', cache['ZEPHYR_BASE'] + '/cmake/pristine.cmake']
-        run_cmake(cmake_args, cwd=self.build_dir, dry_run=self.args.dry_run)
+        run_cmake(self, cmake_args, cwd=self.build_dir, dry_run=self.args.dry_run)
 
     def _run_build(self, target, domain):
         if target:
@@ -726,7 +726,7 @@ class Build(Forceable):
                 build_dir_list.append(d.build_dir)
 
         for b in build_dir_list:
-            run_build(b, extra_args=extra_args,
+            run_build(self, b, extra_args=extra_args,
                       dry_run=self.args.dry_run)
 
     def _append_verbose_args(self, extra_args, add_dashes):

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 
 import zcmake
-from west import log
+from west.commands import Verbosity
 from west.configuration import config
 from west.util import escapes_directory
 
@@ -37,7 +37,7 @@ build.dir-fmt configuration variable is set. The current directory is
 checked after that. If either is a Zephyr build directory, it is used.
 '''
 
-def _resolve_build_dir(fmt, guess, cwd, **kwargs):
+def _resolve_build_dir(cmd, fmt, guess, cwd, **kwargs):
     # Remove any None values, we do not want 'None' as a string
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
     # Check if source_dir is below cwd first
@@ -78,11 +78,11 @@ def _resolve_build_dir(fmt, guess, cwd, **kwargs):
                 if len(dirs) != 1:
                     return None
                 curr = dirs[0]
-                if is_zephyr_build(str(curr)):
+                if is_zephyr_build(cmd, str(curr)):
                     return str(curr)
     return str(b)
 
-def find_build_dir(dir, guess=False, **kwargs):
+def find_build_dir(cmd, dir, guess=False, **kwargs):
     '''Heuristic for finding a build directory.
     If `dir` is specified, this directory is returned as the build directory.
     Otherwise, the default build directory is determined according to the
@@ -99,20 +99,20 @@ def find_build_dir(dir, guess=False, **kwargs):
     cwd = os.getcwd()
     dir_fmt = config.get('build', 'dir-fmt', fallback=None)
     if dir_fmt:
-        log.dbg(f'config dir-fmt: {dir_fmt}', level=log.VERBOSE_EXTREME)
-        dir_fmt = _resolve_build_dir(dir_fmt, guess, cwd, **kwargs)
-    if not build_dir and is_zephyr_build(dir_fmt):
+        cmd.dbg(f'config dir-fmt: {dir_fmt}', level=Verbosity.DBG_EXTREME)
+        dir_fmt = _resolve_build_dir(cmd, dir_fmt, guess, cwd, **kwargs)
+    if not build_dir and is_zephyr_build(cmd, dir_fmt):
         build_dir = dir_fmt
-    if not build_dir and is_zephyr_build(cwd):
+    if not build_dir and is_zephyr_build(cmd, cwd):
         build_dir = cwd
     if not build_dir and dir_fmt:
         build_dir = dir_fmt
     if not build_dir:
         build_dir = DEFAULT_BUILD_DIR
-    log.dbg(f'build dir: {build_dir}', level=log.VERBOSE_EXTREME)
+    cmd.dbg(f'build dir: {build_dir}', level=Verbosity.DBG_EXTREME)
     return os.path.abspath(build_dir)
 
-def is_zephyr_build(path):
+def is_zephyr_build(cmd, path):
     '''Return true if and only if `path` appears to be a valid Zephyr
     build directory.
 
@@ -135,12 +135,12 @@ def is_zephyr_build(path):
         cache = {}
 
     if 'ZEPHYR_BASE' in cache or 'ZEPHYR_TOOLCHAIN_VARIANT' in cache:
-        log.dbg(f'{path} is a zephyr build directory',
-                level=log.VERBOSE_EXTREME)
+        cmd.dbg(f'{path} is a zephyr build directory',
+                level=Verbosity.DBG_EXTREME)
         return True
 
-    log.dbg(f'{path} is NOT a valid zephyr build directory',
-            level=log.VERBOSE_EXTREME)
+    cmd.dbg(f'{path} is NOT a valid zephyr build directory',
+            level=Verbosity.DBG_EXTREME)
     return False
 
 

--- a/scripts/west_commands/export.py
+++ b/scripts/west_commands/export.py
@@ -51,7 +51,7 @@ class ZephyrExport(WestCommand):
         # CMake status messages and instead only prints the important
         # information.
 
-        lines = run_cmake(['-P', str(path / 'zephyr_export.cmake')],
+        lines = run_cmake(self, ['-P', str(path / 'zephyr_export.cmake')],
                           capture_output=True)
         msg = [line for line in lines if not line.startswith('-- ')]
         self.inf('\n'.join(msg))

--- a/scripts/west_commands/flash.py
+++ b/scripts/west_commands/flash.py
@@ -27,6 +27,6 @@ class Flash(WestCommand):
         return add_parser_common(self, parser_adder)
 
     def do_run(self, my_args, runner_args):
-        build_dir = get_build_dir(my_args)
+        build_dir = get_build_dir(self, my_args)
         domains_file = Path(build_dir) / 'domains.yaml'
         do_run_common(self, my_args, runner_args, domain_file=domains_file)

--- a/scripts/west_commands/sdk.py
+++ b/scripts/west_commands/sdk.py
@@ -511,7 +511,7 @@ class Sdk(WestCommand):
                 str(Path(__file__).parent / "sdk" / "listsdk.cmake"),
             ]
 
-            output = zcmake.run_cmake(cmds, capture_output=True)
+            output = zcmake.run_cmake(self, cmds, capture_output=True)
             if output:
                 # remove '-- Zephyr-sdk,' leader
                 sdk_lines = [l[15:] for l in output if l.startswith("-- Zephyr-sdk,")]

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -167,10 +167,10 @@ schema (rimage "target") is not defined in board.cmake.''')
         self.args = args        # for check_force
 
         # Find the build directory and parse .config and DT.
-        build_dir = find_build_dir(args.build_dir)
+        build_dir = find_build_dir(self, args.build_dir)
         self.check_force(os.path.isdir(build_dir),
                          'no such build directory {}'.format(build_dir))
-        self.check_force(is_zephyr_build(build_dir),
+        self.check_force(is_zephyr_build(self, build_dir),
                          "build directory {} doesn't look like a Zephyr build "
                          'directory'.format(build_dir))
         build_conf = BuildConfiguration(build_dir)

--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -104,7 +104,7 @@ def build_instance(monkeypatch):
     # mock os.makedirs to avoid filesystem operations during test
     monkeypatch.setattr("os.makedirs", lambda *a, **kw: None)
     # mock is_zephyr_build to always return False
-    monkeypatch.setattr("build_helpers.is_zephyr_build", lambda path: False)
+    monkeypatch.setattr("build_helpers.is_zephyr_build", lambda cmd, path: False)
     # mock os.environ to make tests independent from environment variables
     monkeypatch.setattr("os.environ", {})
 
@@ -151,7 +151,7 @@ def test_dir_fmt_preferred_over_others(monkeypatch, build_instance):
     # mock the config and is_zephyr_build
     mock_dir_fmt_config(monkeypatch, dir_fmt)
     mock_is_zephyr_build(monkeypatch,
-        lambda path: path in [dir_fmt, cwd, DEFAULT_BUILD_DIR])
+        lambda cmd, path: path in [dir_fmt, cwd, DEFAULT_BUILD_DIR])
 
     b._setup_build_dir()
     assert Path(b.build_dir) == cwd / dir_fmt
@@ -164,7 +164,7 @@ def test_non_existent_dir_fmt_preferred_over_others(monkeypatch, build_instance)
     # mock the config and is_zephyr_build
     mock_dir_fmt_config(monkeypatch, dir_fmt)
     mock_is_zephyr_build(monkeypatch,
-        lambda path: path in [cwd, DEFAULT_BUILD_DIR])
+        lambda cmd, path: path in [cwd, DEFAULT_BUILD_DIR])
 
     b._setup_build_dir()
     assert Path(b.build_dir) == cwd / dir_fmt
@@ -176,7 +176,7 @@ def test_cwd_preferred_over_default_build_dir(monkeypatch, build_instance):
 
     # mock is_zephyr_build
     mock_is_zephyr_build(monkeypatch,
-        lambda path: path in [str(cwd), DEFAULT_BUILD_DIR])
+        lambda cmd, path: path in [str(cwd), DEFAULT_BUILD_DIR])
 
     b._setup_build_dir()
     assert Path(b.build_dir) == cwd
@@ -189,7 +189,7 @@ def test_cwd_preferred_over_non_resolvable_dir_fmt(monkeypatch, build_instance, 
     # mock the config and is_zephyr_build
     mock_dir_fmt_config(monkeypatch, dir_fmt)
     mock_is_zephyr_build(monkeypatch,
-        lambda path: path in [str(cwd)])
+        lambda cmd, path: path in [str(cwd)])
 
     b._setup_build_dir()
     assert Path(b.build_dir) == cwd
@@ -203,7 +203,7 @@ def test_cwd_preferred_over_non_existent_dir_fmt(monkeypatch, build_instance, te
     # mock the config and is_zephyr_build
     mock_dir_fmt_config(monkeypatch, dir_fmt)
     mock_is_zephyr_build(monkeypatch,
-        lambda path: path in [str(cwd)])
+        lambda cmd, path: path in [str(cwd)])
 
     b._setup_build_dir()
     assert Path(b.build_dir) == cwd

--- a/scripts/west_commands/tests/west_build/test_dir_fmt.py
+++ b/scripts/west_commands/tests/west_build/test_dir_fmt.py
@@ -9,6 +9,7 @@ from argparse import Namespace
 from pathlib import Path
 
 import pytest
+
 from build import Build
 
 ROOT = Path(Path.cwd().anchor)

--- a/scripts/west_commands/tests/west_build/test_resolve_build_dir.py
+++ b/scripts/west_commands/tests/west_build/test_resolve_build_dir.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import pytest
 from build_helpers import _resolve_build_dir
 
+from build import Build
+
 cwd = Path.cwd()
 root = Path(cwd.anchor)
 TEST_CWD = root / 'path' / 'to' / 'my' / 'current' / 'cwd'
@@ -33,8 +35,9 @@ TEST_CASES_RESOLVE_BUILD_DIR = [
 @pytest.mark.parametrize('test_case', TEST_CASES_RESOLVE_BUILD_DIR)
 def test_resolve_build_dir(test_case):
     fmt, kwargs, expected = test_case
+    b = Build()
 
     # test both guess=True and guess=False
     for guess in [True, False]:
-        actual = _resolve_build_dir(cwd=TEST_CWD, guess=guess, fmt=fmt, **kwargs)
+        actual = _resolve_build_dir(b, cwd=TEST_CWD, guess=guess, fmt=fmt, **kwargs)
         assert actual == expected


### PR DESCRIPTION
Refactor build/runner scripts to not use the deprecated west logging API to stop the dozens of python warnings that happen when running west build and west flash or west whatever.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/92475

This all has to be one commit because of all the coupling of dependencies across these scripts, it would not be bisectable any other way.