### PR TITLE
soc: ite: linker: Make h2ram_pool behind the CONFIG_ESPI_IT8XXX2 option

### DIFF
--- a/soc/ite/ec/it51xxx/linker.ld
+++ b/soc/ite/ec/it51xxx/linker.ld
@@ -377,6 +377,7 @@ SECTIONS
 
     __data_region_end = .;
 
+#ifdef CONFIG_ESPI_IT8XXX2
 	SECTION_DATA_PROLOGUE(.h2ram_pool,(NOLOAD),)
 	{
 		/*
@@ -389,6 +390,7 @@ SECTIONS
 		_h2ram_pool_end = .;
 	}  GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 	_h2ram_pool_size = ABSOLUTE(_h2ram_pool_end - _h2ram_pool_start);
+#endif
 
 	__kernel_ram_end = .;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;

--- a/soc/ite/ec/it8xxx2/linker.ld
+++ b/soc/ite/ec/it8xxx2/linker.ld
@@ -441,6 +441,7 @@ SECTIONS
 
     __data_region_end = .;
 
+#ifdef CONFIG_ESPI_IT8XXX2
 	SECTION_DATA_PROLOGUE(.h2ram_pool,(NOLOAD),)
 	{
 		/*
@@ -456,6 +457,7 @@ SECTIONS
 		_h2ram_pool_end = .;
 	}  GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 	_h2ram_pool_size = ABSOLUTE(_h2ram_pool_end - _h2ram_pool_start);
+#endif
 
 	__kernel_ram_end = .;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;


### PR DESCRIPTION
The .h2ram_pool linker section was previously always included, even on platforms that do not enable eSPI. This caused unnecessary memory reservation in the `RAMABLE_REGION` for non-eSPI configurations.
Add a `CONFIG_ESPI_IT8XXX2` guard around the `.h2ram_pool` section definition so that it is only included when eSPI support is enabled.

Apply the same `CONFIG_ESPI_IT8XXX2` guard to the `.h2ram_pool` section in the IT51XXX linker script, since the eSPI driver is compatible with IT8XXX2.