### PR TITLE
drivers:ethernet: Add promiscuous mode to the slip interface

### DIFF
--- a/drivers/ethernet/eth_slip_tap.c
+++ b/drivers/ethernet/eth_slip_tap.c
@@ -6,7 +6,7 @@
  */
 
 #define LOG_MODULE_NAME eth_slip_tap
-#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
+#define LOG_LEVEL       CONFIG_ETHERNET_LOG_LEVEL
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
@@ -22,7 +22,7 @@ static enum ethernet_hw_caps eth_capabilities(const struct device *dev)
 
 	return ETHERNET_HW_VLAN
 #if defined(CONFIG_NET_LLDP)
-		| ETHERNET_LLDP
+	       | ETHERNET_LLDP
 #endif
 		;
 }
@@ -34,7 +34,7 @@ static const struct ethernet_api slip_if_api = {
 	.send = slip_send,
 };
 
-#define _SLIP_L2_LAYER ETHERNET_L2
+#define _SLIP_L2_LAYER    ETHERNET_L2
 #define _SLIP_L2_CTX_TYPE NET_L2_GET_CTX_TYPE(ETHERNET_L2)
 
 ETH_NET_DEVICE_INIT(slip, CONFIG_SLIP_DRV_NAME,

--- a/drivers/ethernet/eth_slip_tap.c
+++ b/drivers/ethernet/eth_slip_tap.c
@@ -24,7 +24,25 @@ static enum ethernet_hw_caps eth_capabilities(const struct device *dev)
 #if defined(CONFIG_NET_LLDP)
 	       | ETHERNET_LLDP
 #endif
+#if defined(CONFIG_NET_PROMISCUOUS_MODE)
+	       | ETHERNET_PROMISC_MODE
+#endif
 		;
+}
+
+static int eth_slip_tap_set_config(const struct device *dev, enum ethernet_config_type type,
+				   const struct ethernet_config *config)
+{
+	switch (type) {
+#if defined(CONFIG_NET_PROMISCUOUS_MODE)
+	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
+		return 0;
+#endif /* CONFIG_NET_PROMISCUOUS_MODE */
+	default:
+		break;
+	}
+
+	return -ENOTSUP;
 }
 
 static const struct ethernet_api slip_if_api = {
@@ -32,6 +50,7 @@ static const struct ethernet_api slip_if_api = {
 
 	.get_capabilities = eth_capabilities,
 	.send = slip_send,
+	.set_config = eth_slip_tap_set_config,
 };
 
 #define _SLIP_L2_LAYER    ETHERNET_L2


### PR DESCRIPTION
Slip is naturally promiscuous, so this patch does nothing but acknowledge that. Promiscuous mode in slip is important to allow the interface to be added to a bridge.