### PR TITLE
shell_uart: Stop polling if buffer is full

### DIFF
--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -265,7 +265,8 @@ static void polling_rx_timeout_handler(struct k_timer *timer)
 	uint8_t c;
 	struct shell_uart_polling *sh_uart = k_timer_user_data_get(timer);
 
-	while (uart_poll_in(sh_uart->common.dev, &c) == 0) {
+	while ((ring_buf_space_get(&sh_uart->rx_ringbuf) > 0) &&
+	       (uart_poll_in(sh_uart->common.dev, &c) == 0)) {
 		if (ring_buf_put(&sh_uart->rx_ringbuf, &c, 1) == 0U) {
 			/* ring buffer full. */
 			LOG_WRN("RX ring buffer full.");

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -267,10 +267,7 @@ static void polling_rx_timeout_handler(struct k_timer *timer)
 
 	while ((ring_buf_space_get(&sh_uart->rx_ringbuf) > 0) &&
 	       (uart_poll_in(sh_uart->common.dev, &c) == 0)) {
-		if (ring_buf_put(&sh_uart->rx_ringbuf, &c, 1) == 0U) {
-			/* ring buffer full. */
-			LOG_WRN("RX ring buffer full.");
-		}
+		ring_buf_put(&sh_uart->rx_ringbuf, &c, 1);
 		sh_uart->common.handler(SHELL_TRANSPORT_EVT_RX_RDY, sh_uart->common.context);
 	}
 }


### PR DESCRIPTION
Before calling `uart_poll_in`, check we have space to store the character in the ring buffer beforehand.  If we do, *then* poll for the character.

That way we don't miss out on serial traffic when our ring buffer is full unless we fill our hardware ring buffer too.

Fixes issue #97235.