### PR TITLE
riscv: pmp: Ensure trailing PMP entries are cleared

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -520,7 +520,7 @@ void z_riscv_pmp_stackguard_enable(struct k_thread *thread)
 
 	/* Write our m-mode MPP entries */
 	write_pmp_entries(global_pmp_end_index, thread->arch.m_mode_pmp_end_index,
-			  false /* no need to clear to the end */,
+			  true,
 			  PMP_M_MODE(thread));
 
 	if (PMP_DEBUG_DUMP) {


### PR DESCRIPTION
In `z_riscv_pmp_stackguard_enable`, the call to `write_pmp_entries` has been updated to set the `clear_trailing_entries` argument to `true`.

This change ensures that any PMP entries beyond the ones being actively configured are disabled. This is particularly critical for systems transitioning between different execution stages, such as jumping from Read-Only (RO) firmware to Read-Write (RW) firmware, where each stage may define its own set of PMP entries.

Without clearing, stale configurations from the RO stage could persist after transitioning to the RW stage. While the presence of a catch-all PMP entry might render this change somewhat cosmetic in terms of security, explicitly clearing unused trailing entries ensures a cleaner PMP state. This not only helps prevent subtle functional bugs due to unexpected lingering permissions but also significantly improves clarity during visual debugging of the PMP register settings.