### PR TITLE
tracing: trace timer calls

### DIFF
--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -1923,6 +1923,30 @@
  */
 #define sys_port_trace_k_timer_status_sync_exit(timer, result)
 
+/**
+ * @brief Trace Timer expiry entry
+ * @param timer Timer object
+ */
+#define sys_port_trace_k_timer_expiry_enter(timer)
+
+/**
+ * @brief Trace Timer expiry exit
+ * @param timer Timer object
+ */
+#define sys_port_trace_k_timer_expiry_exit(timer)
+
+/**
+ * @brief Trace Timer stop function expiry entry
+ * @param timer Timer object
+ */
+#define sys_port_trace_k_timer_stop_fn_expiry_enter(timer)
+
+/**
+ * @brief Trace Timer stop function expiry exit
+ * @param timer Timer object
+ */
+#define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)
+
 /** @} */ /* end of subsys_tracing_apis_timer */
 
 /**

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -84,7 +84,13 @@ void z_timer_expiration_handler(struct _timeout *t)
 	if (timer->expiry_fn != NULL) {
 		/* Unlock for user handler. */
 		k_spin_unlock(&lock, key);
+
+		SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_timer, expiry, timer);
+
 		timer->expiry_fn(timer);
+
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, expiry, timer);
+
 		key = k_spin_lock(&lock);
 	}
 
@@ -207,7 +213,11 @@ void z_impl_k_timer_stop(struct k_timer *timer)
 	}
 
 	if (timer->stop_fn != NULL) {
+		SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_timer, stop_fn_expiry, timer);
+
 		timer->stop_fn(timer);
+
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, stop_fn_expiry, timer);
 	}
 
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -939,6 +939,26 @@ void sys_trace_k_timer_status_sync_exit(struct k_timer *timer, uint32_t result)
 	ctf_top_timer_status_sync_exit((uint32_t)(uintptr_t)timer, result);
 }
 
+void sys_trace_k_timer_expiry_enter(struct k_timer *timer)
+{
+	ctf_top_timer_expiry_enter((uint32_t)(uintptr_t)timer);
+}
+
+void sys_trace_k_timer_expiry_exit(struct k_timer *timer)
+{
+	ctf_top_timer_expiry_exit((uint32_t)(uintptr_t)timer);
+}
+
+void sys_trace_k_timer_stop_fn_expiry_enter(struct k_timer *timer)
+{
+	ctf_top_timer_stop_fn_expiry_enter((uint32_t)(uintptr_t)timer);
+}
+
+void sys_trace_k_timer_stop_fn_expiry_exit(struct k_timer *timer)
+{
+	ctf_top_timer_stop_fn_expiry_exit((uint32_t)(uintptr_t)timer);
+}
+
 /* Network socket */
 void sys_trace_socket_init(int sock, int family, int type, int proto)
 {

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -336,6 +336,11 @@ typedef enum {
 	CTF_EVENT_EVENT_WAIT_BLOCKING = 0xFE,
 	CTF_EVENT_EVENT_WAIT_EXIT = 0xFF,
 
+	CTF_EVENT_TIMER_EXPIRY_ENTER = 0x100,
+	CTF_EVENT_TIMER_EXPIRY_EXIT = 0x101,
+	CTF_EVENT_TIMER_STOP_FN_EXPIRY_ENTER = 0x102,
+	CTF_EVENT_TIMER_STOP_FN_EXPIRY_EXIT = 0x103,
+
 } ctf_event_t;
 
 typedef struct {
@@ -1113,6 +1118,26 @@ static inline void ctf_top_timer_status_sync_blocking(uint32_t timer, uint32_t t
 static inline void ctf_top_timer_status_sync_exit(uint32_t timer, uint32_t result)
 {
 	CTF_EVENT(CTF_LITERAL(uint8_t, CTF_EVENT_TIMER_STATUS_SYNC_EXIT), timer, result);
+}
+
+static inline void ctf_top_timer_expiry_enter(uint32_t timer)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_TIMER_EXPIRY_ENTER), timer);
+}
+
+static inline void ctf_top_timer_expiry_exit(uint32_t timer)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_TIMER_EXPIRY_EXIT), timer);
+}
+
+static inline void ctf_top_timer_stop_fn_expiry_enter(uint32_t timer)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_TIMER_STOP_FN_EXPIRY_ENTER), timer);
+}
+
+static inline void ctf_top_timer_stop_fn_expiry_exit(uint32_t timer)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_TIMER_STOP_FN_EXPIRY_EXIT), timer);
 }
 
 /* Network socket */

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -198,6 +198,12 @@ extern "C" {
 	sys_trace_k_timer_status_sync_blocking(timer, timeout)
 #define sys_port_trace_k_timer_status_sync_exit(timer, result)                                     \
 	sys_trace_k_timer_status_sync_exit(timer, result)
+#define sys_port_trace_k_timer_expiry_enter(timer)	sys_trace_k_timer_expiry_enter(timer)
+#define sys_port_trace_k_timer_expiry_exit(timer)	sys_trace_k_timer_expiry_exit(timer)
+#define sys_port_trace_k_timer_stop_fn_expiry_enter(timer)                                         \
+	sys_trace_k_timer_stop_fn_expiry_enter(timer)
+#define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)                                          \
+	sys_trace_k_timer_stop_fn_expiry_exit(timer)
 
 #define sys_port_trace_k_condvar_init(condvar, ret)    sys_trace_k_condvar_init(condvar, ret)
 #define sys_port_trace_k_condvar_signal_enter(condvar) sys_trace_k_condvar_signal_enter(condvar)
@@ -602,6 +608,10 @@ void sys_trace_k_timer_stop(struct k_timer *timer);
 void sys_trace_k_timer_status_sync_blocking(struct k_timer *timer, k_timeout_t timeout);
 void sys_trace_k_timer_status_sync_enter(struct k_timer *timer);
 void sys_trace_k_timer_status_sync_exit(struct k_timer *timer, uint32_t result);
+void sys_trace_k_timer_expiry_enter(struct k_timer *timer);
+void sys_trace_k_timer_expiry_exit(struct k_timer *timer);
+void sys_trace_k_timer_stop_fn_expiry_enter(struct k_timer *timer);
+void sys_trace_k_timer_stop_fn_expiry_exit(struct k_timer *timer);
 
 /* Mailbox */
 void sys_trace_k_mbox_init(struct k_mbox *mbox);

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -2197,3 +2197,35 @@ event {
 		int32_t ret;
 	};
 };
+
+event {
+	name = timer_expiry_enter;
+	id = 0x100;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = timer_expiry_exit;
+	id = 0x101;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = timer_stop_fn_expiry_enter;
+	id = 0x102;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = timer_stop_fn_expiry_exit;
+	id = 0x103;
+	fields := struct {
+		uint32_t id;
+	};
+};

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -733,6 +733,18 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_timer_status_sync_exit(timer, result)                                     \
 	SEGGER_SYSVIEW_RecordEndCallU32(TID_TIMER_STATUS_SYNC, (uint32_t)result)
 
+#define sys_port_trace_k_timer_expiry_enter(timer)                                                 \
+	SEGGER_SYSVIEW_RecordU32(TID_TIMER_EXPIRY, (uint32_t)(uintptr_t)timer)
+
+#define sys_port_trace_k_timer_expiry_exit(timer)                                                  \
+	SEGGER_SYSVIEW_RecordEndCall(TID_TIMER_EXPIRY)
+
+#define sys_port_trace_k_timer_stop_fn_expiry_enter(timer)                                         \
+	SEGGER_SYSVIEW_RecordU32(TID_TIMER_STOP_EXPIRY, (uint32_t)(uintptr_t)timer)
+
+#define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)                                          \
+	SEGGER_SYSVIEW_RecordEndCall(TID_TIMER_STOP_EXPIRY)
+
 #define sys_port_trace_syscall_enter(id, name, ...)                                                \
 	SEGGER_SYSVIEW_RecordString(TID_SYSCALL, (const char *)#name)
 

--- a/subsys/tracing/sysview/tracing_sysview_ids.h
+++ b/subsys/tracing/sysview/tracing_sysview_ids.h
@@ -163,7 +163,10 @@ extern "C" {
 #define TID_EVENT_POST (133u + TID_OFFSET)
 #define TID_EVENT_WAIT (134u + TID_OFFSET)
 
-/* latest ID is 134 */
+#define TID_TIMER_EXPIRY (135u + TID_OFFSET)
+#define TID_TIMER_STOP_EXPIRY (136u + TID_OFFSET)
+
+/* latest ID is 136 */
 
 #ifdef __cplusplus
 }

--- a/subsys/tracing/test/tracing_string_format_test.c
+++ b/subsys/tracing/test/tracing_string_format_test.c
@@ -348,6 +348,25 @@ void sys_trace_k_timer_status_sync_exit(struct k_timer *timer, uint32_t result)
 	TRACING_STRING("%s: %p\n", __func__, timer);
 }
 
+void sys_trace_k_timer_expiry_enter(struct k_timer *timer)
+{
+	TRACING_STRING("%s: %p\n", __func__, timer);
+}
+
+void sys_trace_k_timer_expiry_exit(struct k_timer *timer)
+{
+	TRACING_STRING("%s: %p\n", __func__, timer);
+}
+
+void sys_trace_k_timer_stop_fn_expiry_enter(struct k_timer *timer)
+{
+	TRACING_STRING("%s: %p\n", __func__, timer);
+}
+
+void sys_trace_k_timer_stop_fn_expiry_exit(struct k_timer *timer)
+{
+	TRACING_STRING("%s: %p\n", __func__, timer);
+}
 
 void sys_trace_k_heap_init(struct k_heap *h, void *mem, size_t bytes)
 {

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -429,6 +429,14 @@
 	sys_trace_k_timer_status_sync_blocking(timer)
 #define sys_port_trace_k_timer_status_sync_exit(timer, result)                                     \
 	sys_trace_k_timer_status_sync_exit(timer, result)
+#define sys_port_trace_k_timer_expiry_enter(timer)                                                 \
+	sys_trace_k_timer_expiry_enter(timer)
+#define sys_port_trace_k_timer_expiry_exit(timer)                                                  \
+	sys_trace_k_timer_expiry_exit(timer)
+#define sys_port_trace_k_timer_stop_fn_expiry_enter(timer)					   \
+	sys_trace_k_timer_stop_fn_expiry_enter(timer)
+#define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)					   \
+	sys_trace_k_timer_stop_fn_expiry_exit(timer)
 
 #define sys_port_trace_k_event_init(event) sys_trace_k_event_init(event)
 #define sys_port_trace_k_event_post_enter(event, events, events_mask)   \
@@ -694,6 +702,10 @@ void sys_trace_k_timer_start(struct k_timer *timer, k_timeout_t duration, k_time
 void sys_trace_k_timer_stop(struct k_timer *timer);
 void sys_trace_k_timer_status_sync_blocking(struct k_timer *timer);
 void sys_trace_k_timer_status_sync_exit(struct k_timer *timer, uint32_t result);
+void sys_trace_k_timer_expiry_enter(struct k_timer *timer);
+void sys_trace_k_timer_expiry_exit(struct k_timer *timer);
+void sys_trace_k_timer_stop_fn_expiry_enter(struct k_timer *timer);
+void sys_trace_k_timer_stop_fn_expiry_exit(struct k_timer *timer);
 
 void sys_trace_k_event_init(struct k_event *event);
 void sys_trace_k_event_post_enter(struct k_event *event, uint32_t events, uint32_t events_mask);

--- a/subsys/tracing/user/tracing_user.c
+++ b/subsys/tracing/user/tracing_user.c
@@ -75,6 +75,19 @@ void __weak sys_trace_gpio_fire_callbacks_enter_user(sys_slist_t *list, const st
 						     gpio_pin_t pins) {}
 void __weak sys_trace_gpio_fire_callback_user(const struct device *port,
 					      struct gpio_callback *callback) {}
+void __weak sys_trace_timer_init_user(struct k_timer *timer) {}
+void __weak sys_trace_timer_start_user(struct k_timer *timer, k_timeout_t duration,
+							    k_timeout_t period)
+{}
+void __weak sys_trace_timer_stop_user(struct k_timer *timer) {}
+void __weak sys_trace_timer_status_sync_enter_user(struct k_timer *timer) {}
+void __weak sys_trace_timer_status_sync_blocking_user(struct k_timer *timer, k_timeout_t timeout)
+{}
+void __weak sys_trace_timer_status_sync_exit_user(struct k_timer *timer, uint32_t result) {}
+void __weak sys_trace_timer_expiry_enter_user(struct k_timer *timer) {}
+void __weak sys_trace_timer_expiry_exit_user(struct k_timer *timer) {}
+void __weak sys_trace_timer_stop_fn_expiry_enter_user(struct k_timer *timer) {}
+void __weak sys_trace_timer_stop_fn_expiry_exit_user(struct k_timer *timer) {}
 
 void __weak sys_trace_rtio_submit_enter_user(const struct rtio *r, uint32_t wait_count)
 {
@@ -462,4 +475,54 @@ void sys_trace_rtio_chain_next_enter(const struct rtio *r, const struct rtio_iod
 void sys_trace_rtio_chain_next_exit(const struct rtio *r, const struct rtio_iodev_sqe *iodev_sqe)
 {
 	sys_trace_rtio_chain_next_exit_user(r, iodev_sqe);
+}
+
+void sys_trace_timer_init(struct k_timer *timer)
+{
+	sys_trace_timer_init_user(timer);
+}
+
+void sys_trace_timer_start(struct k_timer *timer, k_timeout_t duration, k_timeout_t period)
+{
+	sys_trace_timer_start_user(timer, duration, period);
+}
+
+void sys_trace_timer_stop(struct k_timer *timer)
+{
+	sys_trace_timer_stop_user(timer);
+}
+
+void sys_trace_timer_status_sync_enter(struct k_timer *timer)
+{
+	sys_trace_timer_status_sync_enter_user(timer);
+}
+
+void sys_trace_timer_status_sync_blocking(struct k_timer *timer, k_timeout_t timeout)
+{
+	sys_trace_timer_status_sync_blocking_user(timer, timeout);
+}
+
+void sys_trace_timer_status_sync_exit(struct k_timer *timer, uint32_t result)
+{
+	sys_trace_timer_status_sync_exit_user(timer, result);
+}
+
+void sys_trace_timer_expiry_enter(struct k_timer *timer)
+{
+	sys_trace_timer_expiry_enter_user(timer);
+}
+
+void sys_trace_timer_expiry_exit(struct k_timer *timer)
+{
+	sys_trace_timer_expiry_exit_user(timer);
+}
+
+void sys_trace_timer_stop_fn_expiry_enter(struct k_timer *timer)
+{
+	sys_trace_timer_stop_fn_expiry_enter_user(timer);
+}
+
+void sys_trace_timer_stop_fn_expiry_exit(struct k_timer *timer)
+{
+	sys_trace_timer_stop_fn_expiry_exit_user(timer);
 }

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -49,6 +49,16 @@ void sys_trace_idle(void);
 void sys_trace_idle_exit(void);
 void sys_trace_sys_init_enter(const struct init_entry *entry, int level);
 void sys_trace_sys_init_exit(const struct init_entry *entry, int level, int result);
+void sys_trace_timer_init(struct k_timer *timer);
+void sys_trace_timer_start(struct k_timer *timer, k_timeout_t duration, k_timeout_t period);
+void sys_trace_timer_stop(struct k_timer *timer);
+void sys_trace_timer_status_sync_enter(struct k_timer *timer);
+void sys_trace_timer_status_sync_blocking(struct k_timer *timer, k_timeout_t timeout);
+void sys_trace_timer_status_sync_exit(struct k_timer *timer, uint32_t result);
+void sys_trace_timer_expiry_enter(struct k_timer *timer);
+void sys_trace_timer_expiry_exit(struct k_timer *timer);
+void sys_trace_timer_stop_fn_expiry_enter(struct k_timer *timer);
+void sys_trace_timer_stop_fn_expiry_exit(struct k_timer *timer);
 
 struct rtio;
 struct rtio_sqe;
@@ -388,12 +398,26 @@ void sys_trace_rtio_chain_next_exit(const struct rtio *r, const struct rtio_iode
 #define sys_port_trace_k_mem_slab_free_enter(slab)
 #define sys_port_trace_k_mem_slab_free_exit(slab)
 
-#define sys_port_trace_k_timer_init(timer)
-#define sys_port_trace_k_timer_start(timer, duration, period)
-#define sys_port_trace_k_timer_stop(timer)
-#define sys_port_trace_k_timer_status_sync_enter(timer)
-#define sys_port_trace_k_timer_status_sync_blocking(timer, timeout)
-#define sys_port_trace_k_timer_status_sync_exit(timer, result)
+#define sys_port_trace_k_timer_init(timer)					\
+					sys_trace_timer_init(timer)
+#define sys_port_trace_k_timer_start(timer, duration, period)			\
+					sys_trace_timer_start(timer, duration, period)
+#define sys_port_trace_k_timer_stop(timer)					\
+					sys_trace_timer_stop(timer)
+#define sys_port_trace_k_timer_status_sync_enter(timer)				\
+					sys_trace_timer_status_sync_enter(timer)
+#define sys_port_trace_k_timer_status_sync_blocking(timer, timeout)		\
+					sys_trace_timer_status_sync_blocking(timer, timeout)
+#define sys_port_trace_k_timer_status_sync_exit(timer, result)			\
+					sys_trace_timer_status_sync_exit(timer, result)
+#define sys_port_trace_k_timer_expiry_enter(timer)				\
+					sys_trace_timer_expiry_enter(timer)
+#define sys_port_trace_k_timer_expiry_exit(timer)				\
+					sys_trace_timer_expiry_exit(timer)
+#define sys_port_trace_k_timer_stop_fn_expiry_enter(timer)			\
+					sys_trace_timer_stop_fn_expiry_enter(timer)
+#define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)			\
+					sys_trace_timer_stop_fn_expiry_exit(timer)
 
 #define sys_port_trace_k_event_init(event)
 #define sys_port_trace_k_event_post_enter(event, events, events_mask)


### PR DESCRIPTION
Add tracing support for timer expiry and stop function callbacks, enabling measurement of callback execution duration and facilitating debugging of cases where callbacks take longer than expected.