### PR TITLE
subsys: usb: device_next: class: fix format specifier warning in debug log

### DIFF
--- a/subsys/usb/device_next/class/usbd_midi2.c
+++ b/subsys/usb/device_next/class/usbd_midi2.c
@@ -469,7 +469,7 @@ int usbd_midi_send(const struct device *dev, const struct midi_ump ump)
 	size_t buflen = 4 * words;
 	uint32_t word;
 
-	LOG_DBG("Send MT=%X group=%X", UMP_MT(ump), UMP_GROUP(ump));
+	LOG_DBG("Send MT=%X group=%lX", UMP_MT(ump), UMP_GROUP(ump));
 	if (data->altsetting != MIDI2_ALTERNATE) {
 		LOG_WRN("MIDI2.0 is not enabled");
 		return -EIO;


### PR DESCRIPTION

Corrected the format specifier in LOG_DBG to match the actual type of UMP_GROUP(ump), which returns an unsigned long. Changed '%X' to '%lX' to avoid -Wformat warnings.


To reproduce : 

`west build -p -b nucleo_g0b1re/stm32g0b1xx samples/subsys/usb/midi -T sample.usb_device_next.midi`



Log message :  

```
warning: format '%X' expects argument of type 'unsigned int', but argument 3 has type 'long unsigned int'

LOG_DBG("Send MT=%X group=%X", UMP_MT(ump), UMP_GROUP(ump));
      |                                   ~^
      |                                    |
      |                                    unsigned int
      |                                   %lX

```