### PR TITLE
drivers: memc: siwx91x: Fix performances

### DIFF
--- a/drivers/clock_control/clock_control_silabs_siwx91x.c
+++ b/drivers/clock_control/clock_control_silabs_siwx91x.c
@@ -84,7 +84,7 @@ static int siwx91x_clock_on(const struct device *dev, clock_control_subsys_t sys
 		RSI_CLK_GspiClkConfig(M4CLK, GSPI_INTF_PLL_CLK);
 		break;
 	case SIWX91X_CLK_QSPI:
-		RSI_CLK_Qspi2ClkConfig(M4CLK, QSPI_ULPREFCLK, 0, 0, 0);
+		RSI_CLK_Qspi2ClkConfig(M4CLK, QSPI_INTFPLLCLK, 0, 0, 1);
 		break;
 	case SIWX91X_CLK_RTC:
 		/* Already done in sl_calendar_init()*/

--- a/drivers/memc/memc_silabs_siwx91x_qspi.c
+++ b/drivers/memc/memc_silabs_siwx91x_qspi.c
@@ -112,11 +112,5 @@ struct sl_psram_info_type_t PSRAM_Device = {
 	.spi_config.spi_config_1.d3d2_data         = 0x03,
 	.spi_config.spi_config_5.d7_d4_data        = 0x0f,
 };
-/* PSRAMSecureSegments is directly referenced by sl_si91x_psram_init() */
-struct PSRAMSecureSegmentType PSRAMSecureSegments[MAX_SEC_SEGMENTS] = {
-	[0].segmentEnable = 1,
-	[0].lowerBoundary = 0x00000,
-	[0].higherBoundary = 0x0ffff,
-};
 DEVICE_DT_INST_DEFINE(0, siwx91x_memc_init, NULL, NULL, &siwx91x_memc_config,
 		      PRE_KERNEL_1, CONFIG_MEMC_INIT_PRIORITY, NULL);

--- a/drivers/memc/memc_silabs_siwx91x_qspi.c
+++ b/drivers/memc/memc_silabs_siwx91x_qspi.c
@@ -30,7 +30,7 @@ static int siwx91x_memc_init(const struct device *dev)
 	/* Memory controller is automatically setup by the siwx91x bootloader,
 	 * so we have to uninitialize it before to change the configuration
 	 */
-	ret = sl_si91x_psram_uninit();
+	ret = sl_si91x_psram_device_uninit();
 	if (ret) {
 		return -EIO;
 	}
@@ -50,7 +50,7 @@ static int siwx91x_memc_init(const struct device *dev)
 		}
 	}
 
-	ret = sl_si91x_psram_init();
+	ret = sl_si91x_psram_device_init();
 	if (ret) {
 		LOG_ERR("sl_si91x_psram_init() returned %d", ret);
 		return -EIO;

--- a/west.yml
+++ b/west.yml
@@ -240,7 +240,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 5871310b8c5ebae05c457598a6eef53690ca1bad
+      revision: 971c39bee2a1bcd2a31caf78606820059a585157
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Siwx91x memory controller is currently 4 times slower than expected. Investigations point out the clock is not correct.

CC: @fimohame