### PR TITLE
drivers: gpio: fix SN74HC595 reset GPIO prop name

### DIFF
--- a/drivers/gpio/gpio_sn74hc595.c
+++ b/drivers/gpio/gpio_sn74hc595.c
@@ -226,7 +226,7 @@ static int gpio_sn74hc595_init(const struct device *dev)
 				.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),               \
 			},                                                                         \
 		.bus = SPI_DT_SPEC_INST_GET(n, SN74HC595_SPI_OPERATION),                           \
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpio, {0}),                        \
+		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),                       \
 		.enable_gpio = GPIO_DT_SPEC_INST_GET_OR(n, enable_gpios, {0}),                     \
 		.num_registers = DT_INST_PROP(n, ngpios) / BITS_PER_BYTE,                          \
 	};                                                                                         \


### PR DESCRIPTION
The reset GPIO for the SN74HC595 driver was not working anymore since c407fbc. That commit made it optional among other changes but accidently removed the s from reset_gpios property name causing the driver not being able to retrieve the specified reset-gpios property from the devicetree anymore. Add the missing s back to fix this.