### PR TITLE
drivers: clock_control: stm32: hide STM32_HSE_CLOCK when HSE is off

### DIFF
--- a/boards/oct/osd32mp1_brk/Kconfig.defconfig
+++ b/boards/oct/osd32mp1_brk/Kconfig.defconfig
@@ -7,7 +7,4 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
-config CLOCK_STM32_HSE_CLOCK
-	default 24000000
-
 endif # BOARD_OSD32MP1_BRK

--- a/boards/oct/osd32mp1_brk/osd32mp1_brk.dts
+++ b/boards/oct/osd32mp1_brk/osd32mp1_brk.dts
@@ -52,6 +52,11 @@
 	};
 };
 
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(24)>;
+	status = "okay";
+};
+
 &spi4_miso_pe13 {
 	slew-rate = "very-high-speed";
 };

--- a/boards/st/stm32mp157c_dk2/Kconfig.defconfig
+++ b/boards/st/stm32mp157c_dk2/Kconfig.defconfig
@@ -9,7 +9,4 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
-config CLOCK_STM32_HSE_CLOCK
-	default 24000000
-
 endif # BOARD_STM32MP157_Dk2

--- a/boards/st/stm32mp157c_dk2/stm32mp157c_dk2.dts
+++ b/boards/st/stm32mp157c_dk2/stm32mp157c_dk2.dts
@@ -57,6 +57,11 @@
 	clock-frequency = <DT_FREQ_M(209)>;
 };
 
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(24)>;
+	status = "okay";
+};
+
 &spi4_miso_pe13 {
 	slew-rate = "very-high-speed";
 };

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -67,6 +67,14 @@ ADC
 * ``iadc_gecko.c`` driver is replaced by ``adc_silabs_iadc.c``.
   :dtcompatible:`silabs,gecko-iadc` is replaced by :dtcompatible:`silabs,iadc`.
 
+Clock Control
+=============
+
+* :kconfig:option:`CONFIG_CLOCK_STM32_HSE_CLOCK` is no longer user-configurable. Its value is now
+  always taken from the ``clock-frequency`` property of ``&clk_hse`` DT node, but only if the node
+  is enabled (otherwise, the symbol is not defined). This change should only affect STM32 MPU-based
+  platforms and aligns them with existing practice from STM32 MCU platforms.
+
 Comparator
 ==========
 

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -22,23 +22,30 @@ menuconfig CLOCK_CONTROL_STM32_CUBE
 
 if CLOCK_CONTROL_STM32_CUBE
 
-DT_STM32_HSE_CLOCK := $(dt_nodelabel_path,clk_hse)
-DT_STM32_HSE_CLOCK_FREQ := $(dt_node_int_prop_int,$(DT_STM32_HSE_CLOCK),clock-frequency)
-
 config CLOCK_STM32_HSE_CLOCK
-	int "HSE clock value"
-	default "$(DT_STM32_HSE_CLOCK_FREQ)" if "$(dt_nodelabel_enabled,clk_hse)"
-	default 8000000
+	int
+	default $(dt_nodelabel_int_prop,clk_hse,clock-frequency)
+	depends on $(dt_nodelabel_enabled,clk_hse)
 	help
-	  Value of external high-speed clock (HSE). This symbol could be optionally
-	  configured using device tree by setting "clock-frequency" value of clk_hse
-	  node. For instance:
-	  &clk_hse{
-	  status = "okay";
-	  clock-frequency = <DT_FREQ_M(25)>;
-	  };
-	  Note: Device tree configuration is overridden when current symbol is set:
-	  CONFIG_CLOCK_STM32_HSE_CLOCK=32000000
+	  Frequency of external high-speed clock (HSE).
+
+	  The value of this symbol is used to set the preprocessor
+	  definition "HSE_VALUE" notably consumed by the HAL.
+
+	  This symbol cannot be set externally: its value is directly
+	  taken from the "clock-frequency" property of the "clk_hse"
+	  Device Tree node when it is enabled.
+
+	  This node would usually looks similar to:
+
+	    &clk_hse {
+	      clock-frequency = <DT_FREQ_M(25)>;
+	      status = "okay";
+	    };
+
+	  If the "clk_hse" node does not exist or is not enabled
+	  (status != "okay"), this symbol is not defined and the
+	  HSE_VALUE preprocessor definition does not exist.
 
 config CLOCK_STM32_MUX
 	bool "STM32 clock mux driver"

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -42,6 +42,15 @@
 		reg = <0x10000000 DT_SIZE_K(320)>;
 	};
 
+	clocks {
+		/* NOTE: clocks must be enabled by Cortex-A */
+		clk_hse: clk-hse {
+			#clock-cells = <0>;
+			compatible = "st,stm32-hse-clock";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32mp157", "st,stm32mp1", "simple-bus";
 


### PR DESCRIPTION
Ensure the `CONFIG_CLOCK_STM32_HSE_CLOCK` symbol is not visible when the HSE clock is not enabled.

Depends on #97215.