### PR TITLE
twister: Add missing failure reason in Robot test runner

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -243,6 +243,7 @@ class Robot(Harness):
                     f"Robot test failure: {handler.sourcedir} for {self.instance.platform.name}"
                 )
                 self.instance.status = TwisterStatus.FAIL
+                self.instance.reason = f"Exited with {renode_test_proc.returncode}"
                 self.instance.testcases[0].status = TwisterStatus.FAIL
 
             if out:


### PR DESCRIPTION
When twister tests are executed using Renode and Robot framework and the Renode process fails, the python script also fails and no further tests are executed.

Error:
```
ERROR   - Robot test failure: _ for _
ERROR   - General exception: can only concatenate str (not "NoneType") to str
Traceback (most recent call last):
  File "/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 2060, in pipeline_mgr
    return self.process_tasks(processing_queue, processing_ready, lock, results)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 2043, in process_tasks
    pb.process(processing_queue, processing_ready, task, lock, results)
  File "/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 1161, in process
    self.report_out(results)
  File "/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 1553, in report_out
    status += " " + instance.reason
              ~~~~^~~~~~~~~~~~~~~~~
TypeError: can only concatenate str (not "NoneType") to str

ERROR   - Process 1541 failed, aborting execution
```

This PR fixes this behavior by simply adding failure reason when executed Renode process fails.

Output with the fix:
```
INFO    - 1/8 _  _              FAILED Exited with 1 (renode 3.159s <zephyr>)
ERROR   - see: /_/handler.log
... further tests are executed
```