### PR TITLE
net: socket: tls: Fix type of pointer

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1796,13 +1796,16 @@ static int tls_opt_dtls_peer_connection_id_value_get(struct tls_context *context
 #if defined(CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID)
 	int enabled = false;
 	int ret;
+	size_t optlen_local;
 
 	if (!context->is_initialized) {
 		return -ENOTCONN;
 	}
 
-	ret = mbedtls_ssl_get_peer_cid(&context->ssl, &enabled, optval, optlen);
-	if (!enabled) {
+	ret = mbedtls_ssl_get_peer_cid(&context->ssl, &enabled, optval, &optlen_local);
+	if (enabled) {
+		*optlen = optlen_local;
+	} else {
 		*optlen = 0;
 	}
 	return ret;


### PR DESCRIPTION
mbedtls_ssl_get_peer_cid takes size_t, not socklen_t. c546c1cad1f86977dbf3fb3354469db9cda926aa
changed the type of socklen_t to something that is incompatible with native offloaded sockets, which caused a compiler error.