### PR TITLE
logging: rtt: Add binary dictionary logging

### DIFF
--- a/subsys/logging/backends/Kconfig.rtt
+++ b/subsys/logging/backends/Kconfig.rtt
@@ -105,4 +105,12 @@ config LOG_BACKEND_RTT_FORCE_PRINTK
 	default y if LOG_BACKEND_RTT_BUFFER = 0 && RTT_CONSOLE
 	select LOG_PRINTK
 
+if LOG_BACKEND_RTT_OUTPUT_DICTIONARY
+
+config LOG_BACKEND_RTT_OUTPUT_DICTIONARY_HEX
+	bool "Whether to output the dictionary log hex encoded (y) or as a raw binary (n)"
+	default y
+
+endif # LOG_BACKEND_RTT_OUTPUT_DICTIONARY
+
 endif # LOG_BACKEND_RTT

--- a/subsys/logging/backends/log_backend_rtt.c
+++ b/subsys/logging/backends/log_backend_rtt.c
@@ -33,7 +33,7 @@
 #define CONFIG_LOG_BACKEND_RTT_RETRY_CNT 10
 #endif
 
-#if defined(CONFIG_LOG_BACKEND_RTT_OUTPUT_DICTIONARY)
+#if defined(CONFIG_LOG_BACKEND_RTT_OUTPUT_DICTIONARY_HEX)
 static const uint8_t LOG_HEX_SEP[10] = "##ZLOGV1##";
 #endif
 
@@ -259,7 +259,7 @@ static const log_output_func_t logging_func =
 
 static int data_out(uint8_t *data, size_t length, void *ctx)
 {
-#if defined(CONFIG_LOG_BACKEND_RTT_OUTPUT_DICTIONARY)
+#if defined(CONFIG_LOG_BACKEND_RTT_OUTPUT_DICTIONARY_HEX)
 	for (size_t i = 0; i < length; i++) {
 		char c[2];
 		uint8_t x[2];
@@ -294,7 +294,7 @@ static void log_backend_rtt_init(struct log_backend const *const backend)
 		log_backend_rtt_cfg();
 	}
 
-#if defined(CONFIG_LOG_BACKEND_RTT_OUTPUT_DICTIONARY)
+#if defined(CONFIG_LOG_BACKEND_RTT_OUTPUT_DICTIONARY_HEX)
 	logging_func((uint8_t *)LOG_HEX_SEP, sizeof(LOG_HEX_SEP), NULL);
 #endif
 


### PR DESCRIPTION
A previous commit (84163d3) changed the RTT backend from outputting a binary stream to a hex encoded stream when dictionary logging is enabled.

This commit adds a Kconfig option to keep the binary format, which is required for live_log_parser.py, and also for log_parser.py when the --hex argument is not used.