### PR TITLE
boards: microchip: pic32cm_jh01_cpro: Add PyOCD runner support

### DIFF
--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/board.cmake
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/board.cmake
@@ -1,6 +1,8 @@
 # Copyright (c) 2025 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(pyocd "--target=pic32cm5164jh01100" "--frequency=4000")
 board_runner_args(jlink "--device=PIC32CM5164JH" "--speed=4000")
 
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/doc/index.rst
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/doc/index.rst
@@ -42,10 +42,44 @@ Programming & Debugging
 
 .. zephyr:board-supported-runners::
 
-Flash Using J-Link
-==================
+Setting Up the Debug Interface
+==============================
 
-To flash the board using the J-Link debugger, follow the steps below:
+PyOCD Setup
+===========
+
+1. Install Device Pack
+
+   - Add support for the PIC32CM family devices using the following command:
+
+   .. code-block:: console
+
+      pyocd pack install pic32cm
+
+2. Verify Device Support
+
+   - Confirm that the target is recognized:
+
+   .. code-block:: console
+
+      pyocd list --targets
+
+   - You should see an entry similar to:
+
+   .. code-block:: text
+
+      pic32cm5164jh01100        Microchip                PIC32CM5164JH01100           PIC32CM-JH   pack
+
+
+3. Connect the Board
+
+   - Connect the DEBUG USB port on the board to your host machine.
+   - This connection **power up the board** and provides access to the **on-board Embedded Debugger (EDBG)**,
+     which enables programming and debugging of the target microcontroller through PyOCD.
+
+
+J-Link Setup
+============
 
 1. Install J-Link Software
 
@@ -59,7 +93,11 @@ To flash the board using the J-Link debugger, follow the steps below:
    - Connect the other end of the J32 Debug Probe to your **host machine (PC)** via USB.
    - Connect the DEBUG USB port on the board to your host machine to **power up the board**.
 
-3. Build the Application
+
+Building and Flashing the Application
+=====================================
+
+1. Build the Application
 
    You can build a sample Zephyr application, such as **Blinky**, using the ``west`` tool.
    Run the following commands from your Zephyr workspace:
@@ -70,7 +108,7 @@ To flash the board using the J-Link debugger, follow the steps below:
 
    This will build the Blinky application for the ``pic32cm_jh01_cpro`` board.
 
-4. Flash the Device
+2. Flash the Device
 
    Once the build completes, flash the firmware using:
 
@@ -78,9 +116,25 @@ To flash the board using the J-Link debugger, follow the steps below:
 
       west flash
 
-   This uses the default ``jlink`` runner to flash the application to the board.
+   By default, this command uses the PyOCD runner to program the device.
 
-5. Observe the Result
+   If both the J-Link probe (connected via the **CORTEX DEBUG** header) and the PyOCD supported debug
+   interface (connected through the **DEBUG USB** port) are available, you can explicitly select the desired
+   runner as shown below:
+
+   .. code-block:: console
+
+      west flash --runner jlink
+
+   or
+
+   .. code-block:: console
+
+      west flash --runner pyocd
+
+   This ensures the application is flashed using the respective connected interface.
+
+3. Observe the Result
 
    After flashing, **LED0** on the board should start **blinking**, indicating that the
    application is running successfully.


### PR DESCRIPTION
Add PyOCD runner support to enable flashing and programming the pic32cm_jh01_cpro board using the PyOCD tool.