### PR TITLE
subsys: usb: Fixed build warning

### DIFF
--- a/subsys/usb/device_next/class/usbd_midi2.c
+++ b/subsys/usb/device_next/class/usbd_midi2.c
@@ -469,7 +469,7 @@ int usbd_midi_send(const struct device *dev, const struct midi_ump ump)
 	size_t buflen = 4 * words;
 	uint32_t word;
 
-	LOG_DBG("Send MT=%X group=%X", UMP_MT(ump), UMP_GROUP(ump));
+	LOG_DBG("Send MT=%x group=%x", (unsigned int)UMP_MT(ump), (unsigned int)UMP_GROUP(ump));
 	if (data->altsetting != MIDI2_ALTERNATE) {
 		LOG_WRN("MIDI2.0 is not enabled");
 		return -EIO;


### PR DESCRIPTION
need to explicitly convert UMP_MT(ump) and UMP_GROUP(ump) to unsigned int, otherwise the compiler will report an warning.