### PR TITLE
Enable DMA tests for MAX32675EVKIT board

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/boards/max32675evkit.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/max32675evkit.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CODE_DATA_RELOCATION=y

--- a/tests/drivers/dma/chan_blen_transfer/boards/max32675evkit.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/max32675evkit.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+test_dma0: &dma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/max32675evkit.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/max32675evkit.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+test_dma0: &dma0 { };


### PR DESCRIPTION
This PR enables 'chan_blen_transfer' and 'loop_transfer' tests for MAX32675EVKIT board.