### PR TITLE
boards: st: stm32n6570_dk: correct touchscreen reset line

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -97,7 +97,7 @@
 	gt911: gt911@5d {
 		compatible = "goodix,gt911";
 		reg = <0x5d>;
-		reset-gpios = <&gpioe 4 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&gpioe 1 GPIO_ACTIVE_LOW>;
 		irq-gpios = <&gpioq 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 	};
 };


### PR DESCRIPTION
Correct GT911 touchscreen reset line that is connected to GPIO E1, not E4, on stm32n6570_dk boards. Note that GPIO E4 in connected to SDcard data bus line D3 on that board.