### PR TITLE
drivers: ethernet: stm32: HAL return value handling

### DIFF
--- a/drivers/ethernet/eth_stm32_hal_v1.c
+++ b/drivers/ethernet/eth_stm32_hal_v1.c
@@ -216,10 +216,14 @@ int eth_stm32_hal_init(const struct device *dev)
 	k_mutex_init(&dev_data->tx_mutex);
 	k_sem_init(&dev_data->rx_int_sem, 0, K_SEM_MAX_LIMIT);
 
-	HAL_ETH_DMATxDescListInit(heth, dma_tx_desc_tab,
-		&dma_tx_buffer[0][0], ETH_TXBUFNB);
-	HAL_ETH_DMARxDescListInit(heth, dma_rx_desc_tab,
-		&dma_rx_buffer[0][0], ETH_RXBUFNB);
+	if (HAL_ETH_DMATxDescListInit(heth, dma_tx_desc_tab,
+				      &dma_tx_buffer[0][0], ETH_TXBUFNB) != HAL_OK) {
+		return -EIO;
+	}
+	if (HAL_ETH_DMARxDescListInit(heth, dma_rx_desc_tab,
+				      &dma_rx_buffer[0][0], ETH_RXBUFNB) != HAL_OK) {
+		return -EIO;
+	}
 
 	return 0;
 }

--- a/drivers/ethernet/eth_stm32_hal_v1.c
+++ b/drivers/ethernet/eth_stm32_hal_v1.c
@@ -233,6 +233,7 @@ void eth_stm32_set_mac_config(const struct device *dev, struct phy_link_state *s
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 	ETH_HandleTypeDef *heth = &dev_data->heth;
 	HAL_StatusTypeDef hal_ret = HAL_OK;
+
 	heth->Init.DuplexMode =
 		PHY_LINK_IS_FULL_DUPLEX(state->speed) ? ETH_MODE_FULLDUPLEX : ETH_MODE_HALFDUPLEX;
 

--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -134,10 +134,13 @@ static inline struct eth_stm32_tx_context *allocate_tx_context(struct net_pkt *p
 
 void eth_stm32_setup_mac_filter(ETH_HandleTypeDef *heth)
 {
-	__ASSERT_NO_MSG(heth != NULL);
 	ETH_MACFilterConfigTypeDef MACFilterConf;
+	HAL_StatusTypeDef __maybe_unused hal_ret;
 
-	HAL_ETH_GetMACFilterConfig(heth, &MACFilterConf);
+	__ASSERT_NO_MSG(heth != NULL);
+
+	hal_ret = HAL_ETH_GetMACFilterConfig(heth, &MACFilterConf);
+	__ASSERT_NO_MSG(hal_ret == HAL_OK);
 
 	MACFilterConf.HashMulticast =
 		IS_ENABLED(CONFIG_ETH_STM32_MULTICAST_FILTER) ? ENABLE : DISABLE;
@@ -145,7 +148,8 @@ void eth_stm32_setup_mac_filter(ETH_HandleTypeDef *heth)
 		IS_ENABLED(CONFIG_ETH_STM32_MULTICAST_FILTER) ? DISABLE : ENABLE;
 	MACFilterConf.HachOrPerfectFilter = DISABLE;
 
-	HAL_ETH_SetMACFilterConfig(heth, &MACFilterConf);
+	hal_ret = HAL_ETH_SetMACFilterConfig(heth, &MACFilterConf);
+	__ASSERT_NO_MSG(hal_ret == HAL_OK);
 
 	k_sleep(K_MSEC(1));
 }
@@ -183,7 +187,9 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 			    net_pkt_is_tx_timestamping(pkt);
 	if (timestamped_frame) {
 		/* Enable transmit timestamp */
-		HAL_ETH_PTP_InsertTxTimestamp(heth);
+		if (HAL_ETH_PTP_InsertTxTimestamp(heth) != HAL_OK) {
+			return -EIO;
+		}
 	}
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
@@ -276,7 +282,9 @@ error:
 
 	if (!ctx) {
 		/* The HAL owns the tx context */
-		HAL_ETH_ReleaseTxPacket(heth);
+		if (HAL_ETH_ReleaseTxPacket(heth) != HAL_OK) {
+			return -EIO;
+		}
 	} else {
 		/* We need to release the tx context and its buffers */
 		HAL_ETH_TxFreeCallback((uint32_t *)ctx);
@@ -529,7 +537,12 @@ void eth_stm32_set_mac_config(const struct device *dev, struct phy_link_state *s
 	HAL_StatusTypeDef hal_ret = HAL_OK;
 	ETH_MACConfigTypeDef mac_config = {0};
 
-	HAL_ETH_GetMACConfig(heth, &mac_config);
+	hal_ret = HAL_ETH_GetMACConfig(heth, &mac_config);
+	if (hal_ret != HAL_OK) {
+		LOG_ERR("HAL_ETH_GetMACConfig failed: %d", hal_ret);
+		__ASSERT_NO_MSG(0);
+		return;
+	}
 
 	mac_config.DuplexMode =
 		PHY_LINK_IS_FULL_DUPLEX(state->speed) ? ETH_FULLDUPLEX_MODE : ETH_HALFDUPLEX_MODE;
@@ -541,7 +554,8 @@ void eth_stm32_set_mac_config(const struct device *dev, struct phy_link_state *s
 
 	hal_ret = HAL_ETH_SetMACConfig(heth, &mac_config);
 	if (hal_ret != HAL_OK) {
-		LOG_ERR("HAL_ETH_SetMACConfig: failed: %d", hal_ret);
+		LOG_ERR("HAL_ETH_SetMACConfig failed: %d", hal_ret);
+		__ASSERT_NO_MSG(0);
 	}
 }
 
@@ -604,11 +618,15 @@ int eth_stm32_hal_set_config(const struct device *dev,
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
 		ETH_MACFilterConfigTypeDef MACFilterConf;
 
-		HAL_ETH_GetMACFilterConfig(heth, &MACFilterConf);
+		if (HAL_ETH_GetMACFilterConfig(heth, &MACFilterConf) != HAL_OK) {
+			return -EIO;
+		}
 
 		MACFilterConf.PromiscuousMode = config->promisc_mode ? ENABLE : DISABLE;
 
-		HAL_ETH_SetMACFilterConfig(heth, &MACFilterConf);
+		if (HAL_ETH_SetMACFilterConfig(heth, &MACFilterConf) != HAL_OK) {
+			return -EIO;
+		}
 		return 0;
 #endif /* CONFIG_NET_PROMISCUOUS_MODE */
 #if defined(CONFIG_ETH_STM32_MULTICAST_FILTER)

--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -257,7 +257,7 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 		}
 
 		/* Check for DMA errors */
-		if (HAL_ETH_GetDMAError(heth)) {
+		if (HAL_ETH_GetDMAError(heth) != 0U) {
 			LOG_ERR("%s: ETH DMA error: dmaerror:%x",
 				__func__,
 				HAL_ETH_GetDMAError(heth));
@@ -266,7 +266,7 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 		}
 
 		/* Check for MAC errors */
-		if (HAL_ETH_GetMACError(heth)) {
+		if (HAL_ETH_GetMACError(heth) != 0U) {
 			LOG_ERR("%s: ETH MAC error: macerror:%x",
 				__func__,
 				HAL_ETH_GetMACError(heth));

--- a/drivers/mdio/mdio_stm32_hal.c
+++ b/drivers/mdio/mdio_stm32_hal.c
@@ -38,8 +38,8 @@ static int mdio_stm32_read(const struct device *dev, uint8_t prtad,
 {
 	struct mdio_stm32_data *const dev_data = dev->data;
 	ETH_HandleTypeDef *heth = &dev_data->heth;
+	HAL_StatusTypeDef ret;
 	uint32_t read;
-	int ret;
 
 	k_sem_take(&dev_data->sem, K_FOREVER);
 
@@ -59,7 +59,7 @@ static int mdio_stm32_read(const struct device *dev, uint8_t prtad,
 
 	*data = read & ADIN1100_REG_VALUE_MASK;
 
-	return ret;
+	return 0;
 }
 
 static int mdio_stm32_write(const struct device *dev, uint8_t prtad,
@@ -67,7 +67,7 @@ static int mdio_stm32_write(const struct device *dev, uint8_t prtad,
 {
 	struct mdio_stm32_data *const dev_data = dev->data;
 	ETH_HandleTypeDef *heth = &dev_data->heth;
-	int ret;
+	HAL_StatusTypeDef ret;
 
 	k_sem_take(&dev_data->sem, K_FOREVER);
 
@@ -85,7 +85,7 @@ static int mdio_stm32_write(const struct device *dev, uint8_t prtad,
 		return -EIO;
 	}
 
-	return ret;
+	return 0;
 }
 
 #ifdef CONFIG_ETH_STM32_HAL_API_V1


### PR DESCRIPTION
Add missing test of some HAL functions return value in stm32 ethernet drivers.

Correct `mdio_stm32_read()` and `mdio_stm32_write()` to return a valid _errno_ instead of mixing HAL return values and `errno` return values.

Plus some minor coding style issues fixes.


