### PR TITLE
drivers: video: stm32: HAL return value handling

### DIFF
--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -65,8 +65,10 @@ void HAL_DCMI_FrameEventCallback(DCMI_HandleTypeDef *hdcmi)
 	struct video_stm32_dcmi_data *dev_data =
 			CONTAINER_OF(hdcmi, struct video_stm32_dcmi_data, hdcmi);
 	struct video_buffer *vbuf;
+	HAL_StatusTypeDef __maybe_unused hal_ret;
 
-	HAL_DCMI_Suspend(hdcmi);
+	hal_ret = HAL_DCMI_Suspend(hdcmi);
+	__ASSERT_NO_MSG(hal_ret == HAL_OK);
 
 	vbuf = k_fifo_get(&dev_data->fifo_in, K_NO_WAIT);
 
@@ -81,7 +83,8 @@ void HAL_DCMI_FrameEventCallback(DCMI_HandleTypeDef *hdcmi)
 	k_fifo_put(&dev_data->fifo_out, vbuf);
 
 resume:
-	HAL_DCMI_Resume(hdcmi);
+	hal_ret = HAL_DCMI_Resume(hdcmi);
+	__ASSERT_NO_MSG(hal_ret == HAL_OK);
 }
 
 static void stm32_dcmi_isr(const struct device *dev)

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -231,6 +231,7 @@ static int video_stm32_dcmi_set_stream(const struct device *dev, bool enable,
 {
 	struct video_stm32_dcmi_data *data = dev->data;
 	const struct video_stm32_dcmi_config *config = dev->config;
+	HAL_StatusTypeDef hal_ret;
 	int err;
 
 	if (!enable) {
@@ -239,8 +240,8 @@ static int video_stm32_dcmi_set_stream(const struct device *dev, bool enable,
 			return err;
 		}
 
-		err = HAL_DCMI_Stop(&data->hdcmi);
-		if (err != HAL_OK) {
+		hal_ret = HAL_DCMI_Stop(&data->hdcmi);
+		if (hal_ret != HAL_OK) {
 			LOG_ERR("Failed to stop DCMI");
 			return -EIO;
 		}
@@ -262,9 +263,9 @@ static int video_stm32_dcmi_set_stream(const struct device *dev, bool enable,
 	data->hdcmi.Instance->CR &= ~(DCMI_CR_FCRC_0 | DCMI_CR_FCRC_1);
 	data->hdcmi.Instance->CR |= STM32_DCMI_GET_CAPTURE_RATE(data->capture_rate);
 
-	err = HAL_DCMI_Start_DMA(&data->hdcmi, DCMI_MODE_CONTINUOUS,
-			(uint32_t)data->vbuf->buffer, data->vbuf->bytesused / 4);
-	if (err != HAL_OK) {
+	hal_ret = HAL_DCMI_Start_DMA(&data->hdcmi, DCMI_MODE_CONTINUOUS,
+				     (uint32_t)data->vbuf->buffer, data->vbuf->bytesused / 4);
+	if (hal_ret != HAL_OK) {
 		LOG_ERR("Failed to start DCMI DMA");
 		return -EIO;
 	}
@@ -543,8 +544,7 @@ static int video_stm32_dcmi_init(const struct device *dev)
 	config->irq_config(dev);
 
 	/* Initialize DCMI peripheral */
-	err = HAL_DCMI_Init(&data->hdcmi);
-	if (err != HAL_OK) {
+	if (HAL_DCMI_Init(&data->hdcmi) != HAL_OK) {
 		LOG_ERR("DCMI initialization failed.");
 		return -EIO;
 	}

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1202,12 +1202,18 @@ static int stm32_dcmipp_stream_enable(const struct device *dev)
 		if (ret < 0) {
 			LOG_ERR("Failed to start the source");
 			if (config->bus_type == VIDEO_BUS_TYPE_PARALLEL) {
-				HAL_DCMIPP_PIPE_Stop(&dcmipp->hdcmipp, pipe->id);
+				if (HAL_DCMIPP_PIPE_Stop(&dcmipp->hdcmipp, pipe->id) != HAL_OK) {
+					ret = -EIO;
+					goto out;
+				}
 			}
 #if defined(STM32_DCMIPP_HAS_CSI)
 			else if (config->bus_type == VIDEO_BUS_TYPE_CSI2_DPHY) {
-				HAL_DCMIPP_CSI_PIPE_Stop(&dcmipp->hdcmipp, pipe->id,
-							 DCMIPP_VIRTUAL_CHANNEL0);
+				if (HAL_DCMIPP_CSI_PIPE_Stop(&dcmipp->hdcmipp, pipe->id,
+							     DCMIPP_VIRTUAL_CHANNEL0) != HAL_OK) {
+					ret = -EIO;
+					goto out;
+				}
 			}
 #endif
 			else {


### PR DESCRIPTION
Add missing test of some HAL functions return value in STM32 DCMI and DCMIPP drivers.

Clarify HAL return value is of type `HAL_StatusTypeDef` and not an `int` in STM32 DCMI and DCMIPP drivers.
