### PR TITLE
Bluetooth: ISO: Fix issue with CIG being terminated

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -500,8 +500,7 @@ static void bt_iso_chan_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 
 			is_chan_connected = false;
 			SYS_SLIST_FOR_EACH_CONTAINER(&cig->cis_channels, cis_chan, node) {
-				if (cis_chan->state == BT_ISO_STATE_CONNECTED ||
-				    cis_chan->state == BT_ISO_STATE_CONNECTING) {
+				if (cis_chan->state != BT_ISO_STATE_DISCONNECTED) {
 					is_chan_connected = true;
 					break;
 				}


### PR DESCRIPTION
In the case of a CIG having multiple CIS, and all CIS has been requested to being disconnected (i.e. they all enter the BT_ISO_STATE_DISCONNECTING state), then when the first disconnect complete is handled in bt_iso_chan_disconnected, then the cig->state was prematurely set to BT_ISO_CIG_STATE_INACTIVE. This meant that if the application called bt_iso_cig_terminate when the 2nd CIS entered bt_iso_chan_disconnected and called chan->ops->disconnected(chan, reason) then the CIG would be removed. When the CIS then entered bt_iso_cleanup_acl, it would access removed data from cleanup_cig.

Change bt_iso_chan_disconnected to not allow the termination of the CIG until all CIS have entered the BT_ISO_STATE_DISCONNECTED state.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/96155