### PR TITLE
boards: ti: lp_mspm0g3507: add button to devicetree

### DIFF
--- a/boards/ti/lp_mspm0g3507/lp_mspm0g3507.dts
+++ b/boards/ti/lp_mspm0g3507/lp_mspm0g3507.dts
@@ -20,6 +20,7 @@
 	aliases {
 		led0 = &led0;
 		pwm-led0 = &pwm_led0;
+		sw0 = &button0;
 	};
 
 	chosen {
@@ -44,6 +45,16 @@
 
 		pwm_led0: pwm_led0 {
 			pwms = <&pwma0 0 PWM_MSEC(100) PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+
+		button0: button_0 {
+			gpios = <&gpiob 21 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			label = "Side button";
+			zephyr,code = <INPUT_KEY_0>;
 		};
 	};
 };


### PR DESCRIPTION
Adding the button as `sw0` to the dts file to support `samples/basic/button` for the lp_mspm0g3507 board. Tested with the mspm0g3507 eval board.