### PR TITLE
doc: fs: document preconditions with fs_open & fs_opendir

### DIFF
--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -297,7 +297,7 @@ static inline void fs_dir_t_init(struct fs_dir_t *zdp)
  * @warning If @p flags are set to 0 the function will open file, if it exists
  *          and is accessible, but you will have no read/write access to it.
  *
- * @param zfp Pointer to a file object
+ * @param zfp Pointer to an @b initialized file object
  * @param file_name The name of a file to open
  * @param flags The mode flags
  *
@@ -506,7 +506,7 @@ int fs_mkdir(const char *path);
  *
  * Opens an existing directory specified by the path.
  *
- * @param zdp Pointer to the directory object
+ * @param zdp Pointer to the @b initialized directory object
  * @param path Path to the directory to open
  *
  * @retval 0 on success;


### PR DESCRIPTION
fs_open and fs_opendir rely on the structures in the first param being intialized. (The init functions are documented with the type declarations.) This simple documentation change mentions this need to initialize (and emphasizes it). (Users of similar APIs such as POSIX open and opendir do not expect this initialization need.)

Fixes #97205