### PR TITLE
dts: ra8: fix syntax error in r7fa8XXXX.dtsi files

### DIFF
--- a/dts/arm/renesas/ra/ra8/r7fa8d1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8d1xh.dtsi
@@ -77,6 +77,7 @@
 
 		pll: pll {
 			compatible = "renesas,ra-cgc-pll";
+			status = "disabled";
 			#clock-cells = <0>;
 
 			/* PLL */
@@ -107,11 +108,11 @@
 				status = "disabled";
 				#clock-cells = <0>;
 			};
-			status = "disabled";
 		};
 
 		pll2: pll2 {
 			compatible = "renesas,ra-cgc-pll";
+			status = "disabled";
 			#clock-cells = <0>;
 
 			/* PLL2 */
@@ -141,7 +142,6 @@
 				status = "disabled";
 				#clock-cells = <0>;
 			};
-			status = "disabled";
 		};
 
 		pclkblock: pclkblock@40203000 {

--- a/dts/arm/renesas/ra/ra8/r7fa8m1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8m1xh.dtsi
@@ -47,6 +47,7 @@
 
 		pll: pll {
 			compatible = "renesas,ra-cgc-pll";
+			status = "disabled";
 			#clock-cells = <0>;
 
 			/* PLL */
@@ -77,11 +78,11 @@
 				status = "disabled";
 				#clock-cells = <0>;
 			};
-			status = "disabled";
 		};
 
 		pll2: pll2 {
 			compatible = "renesas,ra-cgc-pll";
+			status = "disabled";
 			#clock-cells = <0>;
 
 			/* PLL2 */
@@ -111,7 +112,6 @@
 				status = "disabled";
 				#clock-cells = <0>;
 			};
-			status = "disabled";
 		};
 
 		pclkblock: pclkblock@40203000 {

--- a/dts/arm/renesas/ra/ra8/r7fa8t1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8t1xh.dtsi
@@ -50,6 +50,7 @@
 
 		pll: pll {
 			compatible = "renesas,ra-cgc-pll";
+			status = "disabled";
 			#clock-cells = <0>;
 			clocks = <&xtal>;
 			div = <2>;
@@ -78,11 +79,11 @@
 				status = "disabled";
 				#clock-cells = <0>;
 			};
-			status = "disabled";
 		};
 
 		pll2: pll2 {
 			compatible = "renesas,ra-cgc-pll";
+			status = "disabled";
 			#clock-cells = <0>;
 
 			div = <2>;
@@ -111,7 +112,6 @@
 				status = "disabled";
 				#clock-cells = <0>;
 			};
-			status = "disabled";
 		};
 
 		pclkblock: pclkblock@40203000 {


### PR DESCRIPTION
The "status" property was defined after the pllX subnodes in pll node, which violates the Devicetree Specification v0.4, section 6.3:

"Nodes may contain property definitions and/or child node definitions. If both are present, properties shall come before child nodes."

This caused the Device Tree Compiler error: "Properties must precede subnodes. Unable to parse input tree"

This commit moves the "status" property to precede all pll subnodes, fixing the syntax error and ensuring compliance with the Devicetree Specification.