### PR TITLE
samples: mctp: Add sample.yaml's to samples

### DIFF
--- a/samples/subsys/pmci/mctp/endpoint/sample.yaml
+++ b/samples/subsys/pmci/mctp/endpoint/sample.yaml
@@ -1,0 +1,16 @@
+sample:
+  name: MCTP Uart Endpoint
+common:
+  tags:
+    - pmci
+    - mctp
+tests:
+  sample.pmci.mctp.uart_endpoint:
+    platform_allow:
+      - nrf52840dk/nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "(.*)MCTP Endpoint EID: (.*) on (.*)"
+        - "got mctp message (.*) for eid (.*)"

--- a/samples/subsys/pmci/mctp/host/sample.yaml
+++ b/samples/subsys/pmci/mctp/host/sample.yaml
@@ -1,0 +1,16 @@
+sample:
+  name: MCTP Uart Host Endpoint
+common:
+  tags:
+    - pmci
+    - mctp
+tests:
+  sample.pmci.mctp.uart_host:
+    platform_allow:
+      - nrf52840dk/nrf52840
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "(.*)MCTP Host EID: (.*) on (.*)"
+        - "received message (.*) for endpoint (.*)"

--- a/samples/subsys/pmci/mctp/i2c_gpio_bus_endpoint/sample.yaml
+++ b/samples/subsys/pmci/mctp/i2c_gpio_bus_endpoint/sample.yaml
@@ -1,0 +1,16 @@
+sample:
+  name: MCTP I2C+GPIO Bus Endpoint
+common:
+  tags:
+    - pmci
+    - mctp
+tests:
+  sample.pmci.mctp.i2c_gpio_bus_endpoint:
+    platform_allow:
+      - frdm_mcxn947/mcxn947/cpu0
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "(.*)MCTP Host EID: (.*) on (.*)"
+        - "(.*)received message (.*) from endpoint (.*)"

--- a/samples/subsys/pmci/mctp/i2c_gpio_bus_owner/sample.yaml
+++ b/samples/subsys/pmci/mctp/i2c_gpio_bus_owner/sample.yaml
@@ -1,0 +1,16 @@
+sample:
+  name: MCTP I2C+GPIO Bus Owner
+common:
+  tags:
+    - pmci
+    - mctp
+tests:
+  sample.pmci.mctp.i2c_gpio_bus_owner:
+    platform_allow:
+      - frdm_mcxn947/mcxn947/cpu0
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "(.*)MCTP Host EID: (.*) on (.*)"
+        - "(.*)received message (.*) from endpoint (.*)"

--- a/subsys/pmci/mctp/mctp_i2c_gpio_controller.c
+++ b/subsys/pmci/mctp/mctp_i2c_gpio_controller.c
@@ -21,8 +21,10 @@ LOG_MODULE_REGISTER(mctp_i2c_gpio_controller, CONFIG_MCTP_LOG_LEVEL);
 static void mctp_start_rx(struct mctp_binding_i2c_gpio_controller *b,
 			  bool chained_rx);
 
-static void rx_completion(struct rtio *r, const struct rtio_sqe *sqe, void *arg0)
+static void rx_completion(struct rtio *r, const struct rtio_sqe *sqe, int result, void *arg0)
 {
+	ARG_UNUSED(result);
+
 	struct mctp_binding_i2c_gpio_controller *b = arg0;
 	struct rtio_cqe *cqe;
 
@@ -48,8 +50,10 @@ static void rx_completion(struct rtio *r, const struct rtio_sqe *sqe, void *arg0
 }
 
 
-static void rx_len_completion(struct rtio *r, const struct rtio_sqe *sqe, void *arg0)
+static void rx_len_completion(struct rtio *r, const struct rtio_sqe *sqe, int result, void *arg0)
 {
+	ARG_UNUSED(result);
+
 	const uint8_t mctp_tx_msg_addr = MCTP_I2C_GPIO_TX_MSG_ADDR;
 
 	struct mctp_binding_i2c_gpio_controller *b = arg0;


### PR DESCRIPTION
Adds the missing sample.yaml's for building these in CI and with twister.

Fixes a build issue that came up along the way.