### PR TITLE
include: doc: fix bad @endcond markers

### DIFF
--- a/include/zephyr/modbus/modbus.h
+++ b/include/zephyr/modbus/modbus.h
@@ -447,7 +447,7 @@ struct modbus_custom_fc {
 	uint8_t fc;
 	uint8_t excep_code;
 };
-/** @endcond INTERNAL_HIDDEN */
+/** INTERNAL_HIDDEN @endcond */
 
 /**
  * @brief Helper macro for initializing custom function code structs

--- a/include/zephyr/pmci/mctp/mctp_i2c_gpio_common.h
+++ b/include/zephyr/pmci/mctp/mctp_i2c_gpio_common.h
@@ -20,6 +20,6 @@
 /* Max packet size (pseudo registers are byte sized) */
 #define MCTP_I2C_GPIO_MAX_PKT_SIZE 255
 
-/** @endcond INTERNAL_HIDDEN */
+/** INTERNAL_HIDDEN @endcond */
 
 #endif /* ZEPHYR_MCTP_I2C_GPIO_COMMON_H_ */

--- a/include/zephyr/pmci/mctp/mctp_i2c_gpio_controller.h
+++ b/include/zephyr/pmci/mctp/mctp_i2c_gpio_controller.h
@@ -31,8 +31,7 @@ struct mctp_i2c_gpio_controller_cb {
 	uint8_t index;
 };
 
-/** @endcond INTERNAL_HIDDEN */
-
+/** INTERNAL_HIDDEN @endcond */
 
 /**
  * @brief An MCTP binding for Zephyr's I2C interface using GPIO
@@ -65,7 +64,7 @@ struct mctp_binding_i2c_gpio_controller {
 	struct mpsc rx_q;
 	struct mctp_i2c_gpio_controller_cb *inflight_rx;
 
-	/** @endcond INTERNAL_HIDDEN */
+	/** INTERNAL_HIDDEN @endcond */
 };
 
 /** @cond INTERNAL_HIDDEN */
@@ -101,7 +100,7 @@ int mctp_i2c_gpio_controller_tx(struct mctp_binding *binding, struct mctp_pktbuf
 				(,), _name)                                                        \
 	}
 
-/** @endcond INTERNAL_HIDDEN */
+/** INTERNAL_HIDDEN @endcond */
 
 /**
  * @brief Define a MCTP bus binding for I2C controller with GPIO

--- a/include/zephyr/pmci/mctp/mctp_i2c_gpio_target.h
+++ b/include/zephyr/pmci/mctp/mctp_i2c_gpio_target.h
@@ -34,14 +34,14 @@ struct mctp_binding_i2c_gpio_target {
 	struct k_sem *tx_complete;
 	uint8_t tx_idx;
 	struct mctp_pktbuf *tx_pkt;
-	/** @endcond INTERNAL_HIDDEN */
+	/** INTERNAL_HIDDEN @endcond */
 };
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct i2c_target_callbacks mctp_i2c_gpio_target_callbacks;
 int mctp_i2c_gpio_target_start(struct mctp_binding *binding);
 int mctp_i2c_gpio_target_tx(struct mctp_binding *binding, struct mctp_pktbuf *pkt);
-/** @endcond INTERNAL_HIDDEN */
+/** INTERNAL_HIDDEN @endcond */
 
 /**
  * @brief Define a MCTP bus binding for I2C target with GPIO

--- a/include/zephyr/pmci/mctp/mctp_uart.h
+++ b/include/zephyr/pmci/mctp/mctp_uart.h
@@ -44,7 +44,7 @@ struct mctp_binding_uart {
 	uint8_t tx_buf[256];
 	int tx_res;
 
-	/** @endcond INTERNAL_HIDDEN */
+	/** INTERNAL_HIDDEN @endcond */
 };
 
 /**
@@ -59,7 +59,7 @@ void mctp_uart_start_rx(struct mctp_binding_uart *uart);
 /** @cond INTERNAL_HIDDEN */
 int mctp_uart_start(struct mctp_binding *binding);
 int mctp_uart_tx(struct mctp_binding *binding, struct mctp_pktbuf *pkt);
-/** @endcond INTERNAL_HIDDEN */
+/** INTERNAL_HIDDEN @endcond */
 
 /**
  * @brief Statically define a MCTP bus binding for a UART

--- a/include/zephyr/sys/clock.h
+++ b/include/zephyr/sys/clock.h
@@ -387,7 +387,7 @@ struct timespec;
 
 /* Convert a POSIX clock (cast to int) to a sys_clock identifier */
 int sys_clock_from_clockid(int clock_id);
-/** @endcond INTERNAL_HIDDEN */
+/** INTERNAL_HIDDEN @endcond */
 
 /**
  * @brief Get the offset @ref SYS_CLOCK_REALTIME with respect to @ref SYS_CLOCK_MONOTONIC


### PR DESCRIPTION
Anything appearing after the @endcond tag is, well, not part of the conditional block anymore. This fixes "INTERNAL_HIDDEN" text appearing at odd polaces in the generated documentation.

Fixes zephyrproject-rtos/zephyr#94862