### PR TITLE
twister: remove not needed try..except

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -23,7 +23,6 @@ from pathlib import Path
 import zephyr_module
 from twisterlib.constants import SUPPORTED_SIMS
 from twisterlib.coverage import supported_coverage_formats
-from twisterlib.error import TwisterRuntimeError
 from twisterlib.log_helper import log_command
 
 logger = logging.getLogger('twister')
@@ -1192,11 +1191,8 @@ class TwisterEnv:
         toolchain_script = Path(ZEPHYR_BASE) / Path('cmake/verify-toolchain.cmake')
         result = self.run_cmake_script([toolchain_script, "FORMAT=json"])
 
-        try:
-            if result['returncode']:
-                raise TwisterRuntimeError(f"E: {result['returnmsg']}")
-        except Exception as e:
-            print(str(e))
+        if result['returncode'] != 0:
+            print(f"E: {result['returnmsg']}")
             sys.exit(2)
         self.toolchain = json.loads(result['stdout'])['ZEPHYR_TOOLCHAIN_VARIANT']
         logger.info(f"Using '{self.toolchain}' toolchain.")

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -7,15 +7,14 @@
 Tests for environment.py classes' methods
 """
 
-from unittest import mock
 import os
-import pytest
 import shutil
-
 from contextlib import nullcontext
+from unittest import mock
+
+import pytest
 
 import twisterlib.environment
-
 
 TESTDATA_1 = [
     (
@@ -538,7 +537,7 @@ TESTDATA_6 = [
         'Using \'dummy toolchain\' toolchain.'
     ),
     (
-        {'returncode': 1},
+        {'returncode': 1, "returnmsg": "something went wrong"},
         2,
         None
     ),
@@ -572,7 +571,7 @@ def test_get_toolchain(caplog, script_result, exit_value, expected_log):
             twisterlib.environment.TwisterEnv,
             'run_cmake_script',
             mock.Mock(return_value=script_result)), \
-         pytest.raises(SystemExit) \
+         pytest.raises(SystemExit, match='2') \
             if exit_value is not None else nullcontext() as exit_info:
         twister_env.get_toolchain()
 


### PR DESCRIPTION
Removed redundant try..except around the code
and fixed a test for that code which was false positive.

With this change twister will print an error message without 
a stacktrace from twister code, which is more user friendly.
Example:
```sh
Renaming previous output directory to /home/workspace/repos/zephyr/twister-out.10
INFO    - Using Ninja..
INFO    - Zephyr version: v4.2.0-5355-ga9be24ce627f
ERROR   - CMake script failure: /home/workspace/repos/zephyr/cmake/verify-toolchain.cmake
E: CMake Error at cmake/modules/FindZephyr-sdk.cmake:159 (find_package):
  Could not find a package configuration file provided by "Zephyr-sdk"
  (requested version 0.16) with any of the following names:

    Zephyr-sdkConfig.cmake
    zephyr-sdk-config.cmake

  Add the installation prefix of "Zephyr-sdk" to CMAKE_PREFIX_PATH or set
  "Zephyr-sdk_DIR" to a directory containing one of the above files.  If
  "Zephyr-sdk" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  cmake/modules/FindHostTools.cmake:51 (find_package)
  cmake/verify-toolchain.cmake:30 (find_package)
```
