### PR TITLE
doc: hardware: fix cache/guide.rst appearing in two different toctrees

### DIFF
--- a/doc/hardware/index.rst
+++ b/doc/hardware/index.rst
@@ -8,7 +8,6 @@ Hardware Support
 
    arch/index.rst
    barriers/index.rst
-   cache/guide.rst
    cache/index.rst
    emulator/index.rst
    emulator/bus_emulators.rst


### PR DESCRIPTION
The "Caching Basics" page is already included in the toctree of cache/index.rst, so it should not be included again at this level.