### PR TITLE
west.yml: hal_stm32: update to fix compiling with clang and pin updates

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -250,7 +250,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 5d27023564c9fbd9bb3aa51b0529ac3d2cf18134
+      revision: 55e159704b02ec4e7b4f0a88735044bee92c25c2
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update hal_stm32 to include fix for compiling for STM32H5 with clang.

Fixes warning about extraneous parentheses when compiling with clang.

```
/home/user/west_workspace/modules/hal/stm32/stm32cube/stm32h5xx/drivers/src/stm32h5xx_hal_rcc_ex.c:3513:26: error: equality comparison with extraneous parentheses [-Werror,-Wparentheses-equality]
 3513 |         else if ((srcclk == RCC_USART2CLKSOURCE_PLL3Q))
      |                   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/modules/hal/stm32/stm32cube/stm32h5xx/drivers/src/stm32h5xx_hal_rcc_ex.c:3513:26: note: remove extraneous parentheses around the comparison to silence this warning
 3513 |         else if ((srcclk == RCC_USART2CLKSOURCE_PLL3Q))
      |                  ~       ^                           ~
/home/user/west_workspace/modules/hal/stm32/stm32cube/stm32h5xx/drivers/src/stm32h5xx_hal_rcc_ex.c:3513:26: note: use '=' to turn this equality comparison into an assignment
 3513 |         else if ((srcclk == RCC_USART2CLKSOURCE_PLL3Q))
      |                          ^~
      |                          =
```

EDIT (@erwango): Also introduces ALE and CLE pins for the FMC peripheral from a distinct HAL PR.
