### PR TITLE
Fix SPI even modes testing on MCXW and remove old LPSPI timing params from NXP board DTS

### DIFF
--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -142,9 +142,6 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpspi1>;
 	pinctrl-names = "default";
-	pcs-sck-delay = <5>;
-	sck-pcs-delay = <5>;
-	transfer-delay = <125>;
 
 	mx25r6435fm2il0: flash@0 {
 		compatible = "jedec,spi-nor";
@@ -163,6 +160,9 @@
 		mxicy,mx25r-power-mode = "low-power";
 		/* 8 MHz for low power mode */
 		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-cs-setup-delay-ns = <5>;
+		spi-cs-hold-delay-ns = <5>;
+		spi-interframe-delay-ns = <125>;
 	};
 };
 

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -255,15 +255,15 @@
 
 &lpspi1 {
 	status = "okay";
-	pcs-sck-delay = <50>;
-	sck-pcs-delay = <50>;
-	transfer-delay = <50>;
 
 	icm42686_0: icm42686p0@0 {
 		compatible = "invensense,icm42686", "invensense,icm4268x";
 		reg = <0>;
 		int-gpios = <&gpio3 19 GPIO_ACTIVE_HIGH>;
 		spi-max-frequency = <DT_FREQ_M(24)>;
+		spi-cs-setup-delay-ns = <50>;
+		spi-cs-hold-delay-ns = <50>;
+		spi-interframe-delay-ns = <50>;
 		accel-pwr-mode = <ICM42686_DT_ACCEL_LN>;
 		accel-odr = <ICM42686_DT_ACCEL_ODR_1000>;
 		accel-fs = <ICM42686_DT_ACCEL_FS_16>;
@@ -283,15 +283,15 @@
 
 &lpspi2 {
 	status = "okay";
-	pcs-sck-delay = <50>;
-	sck-pcs-delay = <50>;
-	transfer-delay = <50>;
 
 	icm42688_0: icm42688p0@0 {
 		compatible = "invensense,icm42688", "invensense,icm4268x";
 		reg = <0>;
 		int-gpios = <&gpio2 7 GPIO_ACTIVE_HIGH>;
 		spi-max-frequency = <DT_FREQ_M(24)>;
+		spi-cs-setup-delay-ns = <50>;
+		spi-cs-hold-delay-ns = <50>;
+		spi-interframe-delay-ns = <50>;
 		accel-pwr-mode = <ICM42688_DT_ACCEL_LN>;
 		accel-odr = <ICM42688_DT_ACCEL_ODR_1000>;
 		accel-fs = <ICM42688_DT_ACCEL_FS_16>;

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxw71.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxw71.overlay
@@ -9,10 +9,17 @@
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;
 		spi-max-frequency = <500000>;
+		spi-cs-setup-delay-ns = <1000>;
+		spi-cs-hold-delay-ns = <1000>;
+		spi-interframe-delay-ns = <1000>;
 	};
 	fast@0 {
 		compatible = "test-spi-loopback-fast";
 		reg = <0>;
 		spi-max-frequency = <16000000>;
+		spi-cs-setup-delay-ns = <200>;
+		spi-cs-hold-delay-ns = <200>;
+		spi-interframe-delay-ns = <100>;
 	};
+
 };

--- a/tests/drivers/spi/spi_loopback/boards/mcxw72_evk_mcxw727c_cpu0.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mcxw72_evk_mcxw727c_cpu0.overlay
@@ -9,10 +9,16 @@
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;
 		spi-max-frequency = <500000>;
+		spi-cs-setup-delay-ns = <1000>;
+		spi-cs-hold-delay-ns = <1000>;
+		spi-interframe-delay-ns = <1000>;
 	};
 	fast@0 {
 		compatible = "test-spi-loopback-fast";
 		reg = <0>;
 		spi-max-frequency = <16000000>;
+		spi-cs-setup-delay-ns = <200>;
+		spi-cs-hold-delay-ns = <200>;
+		spi-interframe-delay-ns = <100>;
 	};
 };


### PR DESCRIPTION
Fix SPI even modes testing on MCXW and remove old LPSPI timing params from NXP board DTS

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/96708