### PR TITLE
Update compiler_flags.cmake

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -42,8 +42,6 @@ check_set_compiler_property(PROPERTY warning_base
 # C implicit promotion rules will want to make floats into doubles very easily
 check_set_compiler_property(APPEND PROPERTY warning_base -Wdouble-promotion)
 
-check_set_compiler_property(APPEND PROPERTY warning_base -Wno-pointer-sign)
-
 # Prohibit void pointer arithmetic. Illegal in C99
 check_set_compiler_property(APPEND PROPERTY warning_base -Wpointer-arith)
 


### PR DESCRIPTION
posix: fnmatch: fix known bugs #55186
The two fixes—the fnmatch() bug and the compiler warning change—are linked in the description because they were solved and verified as part of the same development task or branch.

When committing code changes:

Atomic Commits: It is standard practice in development to group logically related changes into a single "atomic" commit. Since you fixed a user-reported bug (fnmatch()) and addressed a related compiler environment cleanup (-Wpointer-sign) in one session, submitting them together keeps the project history clean and manageable.

Context: Linking them provides reviewers with the complete context of the changes you made in this particular feature branch or project.