### PR TITLE
arch: riscv: Remove early MPRV catch-all in pmp_init

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -383,22 +383,8 @@ void z_riscv_pmp_init(void)
 		      Z_RISCV_STACK_GUARD_SIZE,
 		      pmp_addr, pmp_cfg, ARRAY_SIZE(pmp_addr));
 
-	/*
-	 * This early, the kernel init code uses the IRQ stack and we want to
-	 * safeguard it as soon as possible. But we need a temporary default
-	 * "catch all" PMP entry for MPRV to work. Later on, this entry will
-	 * be set for each thread by z_riscv_pmp_stackguard_prepare().
-	 */
-	set_pmp_mprv_catchall(&index, pmp_addr, pmp_cfg, ARRAY_SIZE(pmp_addr));
-
 	 /* Write those entries to PMP regs. */
 	write_pmp_entries(0, index, true, pmp_addr, pmp_cfg, ARRAY_SIZE(pmp_addr));
-
-	/* Activate our non-locked PMP entries for m-mode */
-	csr_set(mstatus, MSTATUS_MPRV);
-
-	/* And forget about that last entry as we won't need it later */
-	index--;
 #else
 	/* Without multithreading setup stack guards for IRQ and main stacks */
 	set_pmp_entry(&index, PMP_NONE | PMP_L,


### PR DESCRIPTION
Remove the temporary PMP entry for MPRV catch-all and the setting of MSTATUS_MPRV from the early `z_riscv_pmp_init` function.

This early, broad catch-all setup is not strictly necessary. The required MPRV catch-all configuration for stack protection in multithreading scenarios is already handled within the `z_riscv_pmp_stackguard_prepare` function. This function is called during thread creation, providing a more localized and appropriate context for setting up thread-specific stack guard PMP entries, including the MPRV catch-all.

This change consolidates the stack guard related PMP setup logic within the thread creation path.