### PR TITLE
tests: bluetooth: ascs: make callback expectation checks more generic

### DIFF
--- a/tests/bluetooth/audio/ascs/include/bap_unicast_server_expects.h
+++ b/tests/bluetooth/audio/ascs/include/bap_unicast_server_expects.h
@@ -13,180 +13,204 @@
 #include "bap_unicast_server.h"
 #include "expects_util.h"
 
-#define expect_bt_bap_unicast_server_cb_config_called_once(_conn, _ep, _dir, _codec)               \
-do {                                                                                               \
-	const char *func_name = "bt_bap_unicast_server_cb.config";                                 \
-												   \
-	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_config_fake.call_count);       \
-												   \
-	IF_NOT_EMPTY(_conn, (                                                                      \
-		     zassert_equal_ptr(_conn, mock_bap_unicast_server_cb_config_fake.arg0_val,     \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "conn");))                                       \
-												   \
-	IF_NOT_EMPTY(_ep, (                                                                        \
-		     zassert_equal_ptr(_ep, mock_bap_unicast_server_cb_config_fake.arg1_val,       \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "ep");))                                         \
-												   \
-	IF_NOT_EMPTY(_dir, (                                                                       \
-		     zassert_equal(_dir, mock_bap_unicast_server_cb_config_fake.arg2_val,          \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "_dir");))                                       \
-												   \
-	IF_NOT_EMPTY(_codec, (                                                                     \
-		     /* TODO */                                                                    \
-		     zassert_unreachable("Not implemented");))                                     \
-} while (0)
-
-#define expect_bt_bap_unicast_server_cb_reconfig_called_once(_stream, _dir, _codec)                \
-do {                                                                                               \
-	const char *func_name = "bt_bap_unicast_server_cb.reconfig";                               \
-												   \
-	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_reconfig_fake.call_count);     \
-												   \
-	IF_NOT_EMPTY(_stream, (                                                                    \
-		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_reconfig_fake.arg0_val, \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "stream");))                                     \
-												   \
-	IF_NOT_EMPTY(_dir, (                                                                       \
-		     zassert_equal(_dir, mock_bap_unicast_server_cb_reconfig_fake.arg1_val,        \
-				   "'%s()' was called with incorrect '%s' value",                  \
-				   func_name, "_dir");))                                           \
-												   \
-	IF_NOT_EMPTY(_codec, (                                                                     \
-		     /* TODO */                                                                    \
-		     zassert_unreachable("Not implemented");))                                     \
-} while (0)
-
-#define expect_bt_bap_unicast_server_cb_qos_called_once(_stream, _qos)                             \
-do {                                                                                               \
-	const char *func_name = "bt_bap_unicast_server_cb.qos";                                    \
-												   \
-	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_qos_fake.call_count);          \
-												   \
-	IF_NOT_EMPTY(_stream, (                                                                    \
-		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_qos_fake.arg0_val,      \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "stream");))                                     \
-												   \
-	IF_NOT_EMPTY(_qos, (                                                                       \
-		     /* TODO */                                                                    \
-		     zassert_unreachable("Not implemented");))                                     \
-} while (0)
-
-#define expect_bt_bap_unicast_server_cb_enable_called_once(_stream, _meta, _meta_len)            \
-do {                                                                                               \
-	const char *func_name = "bt_bap_unicast_server_cb.enable";                                 \
-												   \
-	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_enable_fake.call_count);       \
-												   \
-	IF_NOT_EMPTY(_stream, (                                                                    \
-		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_enable_fake.arg0_val,   \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "stream");))                                     \
-												   \
-	IF_NOT_EMPTY(_meta, (                                                                      \
-		     /* TODO */                                                                    \
-		     zassert_unreachable("Not implemented");))                                     \
-												   \
-	IF_NOT_EMPTY(_meta_len, (                                                                \
-		     /* TODO */                                                                    \
-		     zassert_unreachable("Not implemented");))                                     \
-} while (0)
-
-#define expect_bt_bap_unicast_server_cb_metadata_called_once(_stream, _meta, _meta_len)          \
-do {                                                                                               \
-	const char *func_name = "bt_bap_unicast_server_cb.enable";                                 \
-												   \
-	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_metadata_fake.call_count);     \
-												   \
-	IF_NOT_EMPTY(_stream, (                                                                    \
-		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_metadata_fake.arg0_val, \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "stream");))                                     \
-												   \
-	IF_NOT_EMPTY(_meta, (                                                                      \
-		     /* TODO */                                                                    \
-		     zassert_unreachable("Not implemented");))                                     \
-												   \
-	IF_NOT_EMPTY(_meta_len, (                                                                \
-		     /* TODO */                                                                    \
-		     zassert_unreachable("Not implemented");))                                     \
-} while (0)
-
-#define expect_bt_bap_unicast_server_cb_disable_called_once(_stream)                               \
-do {                                                                                               \
-	const char *func_name = "bt_bap_unicast_server_cb.disable";                                \
-												   \
-	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_disable_fake.call_count);      \
-												   \
-	IF_NOT_EMPTY(_stream, (                                                                    \
-		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_disable_fake.arg0_val,  \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "stream");))                                     \
-} while (0)
-
-#define expect_bt_bap_unicast_server_cb_release_called_once(_stream)                               \
-do {                                                                                               \
-	const char *func_name = "bt_bap_unicast_server_cb.release";                                \
-												   \
-	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_release_fake.call_count);      \
-												   \
-	IF_NOT_EMPTY(_stream, (                                                                    \
-		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_release_fake.arg0_val,  \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "stream");))                                     \
-} while (0)
-
-#define expect_bt_bap_unicast_server_cb_release_called_twice(_streams)                             \
-do {                                                                                               \
-	const char *func_name = "bt_bap_unicast_server_cb.release";                                \
-												   \
-	zexpect_call_count(func_name, 2, mock_bap_unicast_server_cb_release_fake.call_count);      \
-												   \
-	IF_NOT_EMPTY(_stream[0], (                                                                 \
-		     zassert_equal_ptr(_streams[0],                                                \
-				       mock_bap_unicast_server_cb_release_fake.arg0_history[0],    \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "stream[0]");))                                  \
-	IF_NOT_EMPTY(_stream[1], (                                                                 \
-		     zassert_equal_ptr(_streams[1],                                                \
-				       mock_bap_unicast_server_cb_release_fake.arg0_history[1],    \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "stream[1]");))                                  \
-} while (0)
-
-#define expect_bt_bap_unicast_server_cb_start_called_once(_stream)                                 \
-do {                                                                                               \
-	const char *func_name = "bt_bap_unicast_server_cb.start";                                  \
-												   \
-	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_start_fake.call_count);        \
-												   \
-	IF_NOT_EMPTY(_stream, (                                                                    \
-		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_start_fake.arg0_val,    \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "stream");))                                     \
-} while (0)
-
-#define expect_bt_bap_unicast_server_cb_stop_called_once(_stream)                                  \
-do {                                                                                               \
-	const char *func_name = "bt_bap_unicast_server_cb.stop";                                   \
-												   \
-	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_stop_fake.call_count);         \
-												   \
-	IF_NOT_EMPTY(_stream, (                                                                    \
-		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_stop_fake.arg0_val,     \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "stream");))                                     \
-} while (0)
-
-static inline void expect_bt_bap_unicast_server_cb_config_not_called(void)
+static inline void expect_bt_bap_unicast_server_cb_config_called(
+	unsigned int expected_count,
+	struct bt_conn *conns[],
+	struct bt_bap_ep *eps[],
+	enum bt_audio_dir dirs[],
+	void *codec[])
 {
 	const char *func_name = "bt_bap_unicast_server_cb.config";
 
-	zexpect_call_count(func_name, 0, mock_bap_unicast_server_cb_config_fake.call_count);
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_unicast_server_cb_config_fake.call_count);
+
+	for (unsigned int i = 0; i < mock_bap_unicast_server_cb_config_fake.call_count; i++) {
+		zassert_equal_ptr(conns[i],
+			mock_bap_unicast_server_cb_config_fake.arg0_history[i],
+			"'%s()' was called with incorrect 'conn[%i]' value", func_name, i);
+		if (eps) {
+			zassert_equal_ptr(eps[i],
+				mock_bap_unicast_server_cb_config_fake.arg1_history[i],
+				"'%s()' was called with incorrect 'ep[%i]' value", func_name, i);
+		}
+		zassert_equal(dirs[i],
+			mock_bap_unicast_server_cb_config_fake.arg2_history[i],
+			"'%s()' was called with incorrect 'dir[%i]' value", func_name, i);
+	}
+
+	if (codec) {
+		/* TODO */
+		zassert_unreachable("Not implemented");
+	}
+}
+
+static inline void expect_bt_bap_unicast_server_cb_reconfig_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[],
+	const enum bt_audio_dir dirs[],
+	void *codec[])
+{
+	const char *func_name = "bt_bap_unicast_server_cb.reconfig";
+
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_unicast_server_cb_reconfig_fake.call_count);
+
+	for (unsigned int i = 0; i < mock_bap_unicast_server_cb_reconfig_fake.call_count; i++) {
+		zassert_equal_ptr(streams[i],
+			mock_bap_unicast_server_cb_reconfig_fake.arg0_history[i],
+			"'%s()' was called with incorrect 'stream[%i]' value", func_name, i);
+		zassert_equal(dirs[i],
+			mock_bap_unicast_server_cb_reconfig_fake.arg1_history[i],
+			"'%s()' was called with incorrect 'dir[%i]' value", func_name, i);
+	}
+
+	if (codec) {
+		/* TODO */
+		zassert_unreachable("Not implemented");
+	}
+}
+
+static inline void expect_bt_bap_unicast_server_cb_qos_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[],
+	void *qos[])
+{
+	const char *func_name = "bt_bap_unicast_server_cb.qos";
+
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_unicast_server_cb_qos_fake.call_count);
+
+	for (unsigned int i = 0; i < mock_bap_unicast_server_cb_qos_fake.call_count; i++) {
+		zassert_equal_ptr(streams[i],
+			mock_bap_unicast_server_cb_qos_fake.arg0_history[i],
+			"'%s()' was called with incorrect 'stream[%i]' value", func_name, i);
+	}
+
+	if (qos) {
+		/* TODO */
+		zassert_unreachable("Not implemented");
+	}
+}
+
+static inline void expect_bt_bap_unicast_server_cb_enable_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[],
+	void *meta[],
+	void *meta_len[])
+{
+	const char *func_name = "bt_bap_unicast_server_cb.enable";
+
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_unicast_server_cb_enable_fake.call_count);
+
+	for (unsigned int i = 0; i < mock_bap_unicast_server_cb_enable_fake.call_count; i++) {
+		zassert_equal_ptr(streams[i],
+			mock_bap_unicast_server_cb_enable_fake.arg0_history[i],
+			"'%s()' was called with incorrect 'stream[%i]' value", func_name, i);
+	}
+
+	if (meta) {
+		/* TODO */
+		zassert_unreachable("Not implemented");
+	}
+
+	if (meta_len) {
+		/* TODO */
+		zassert_unreachable("Not implemented");
+	}
+}
+
+static inline void expect_bt_bap_unicast_server_cb_metadata_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[],
+	void *meta[],
+	void *meta_len[])
+{
+	const char *func_name = "bt_bap_unicast_server_cb.enable";
+
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_unicast_server_cb_metadata_fake.call_count);
+
+	for (unsigned int i = 0; i < mock_bap_unicast_server_cb_metadata_fake.call_count; i++) {
+		zassert_equal_ptr(streams[i],
+			mock_bap_unicast_server_cb_metadata_fake.arg0_history[i],
+			"'%s()' was called with incorrect 'stream[%i]' value", func_name, i);
+	}
+
+	if (meta) {
+		/* TODO */
+		zassert_unreachable("Not implemented");
+	}
+
+	if (meta_len) {
+		/* TODO */
+		zassert_unreachable("Not implemented");
+	}
+}
+
+static inline void expect_bt_bap_unicast_server_cb_disable_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[])
+{
+	const char *func_name = "bt_bap_unicast_server_cb.disable";
+
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_unicast_server_cb_disable_fake.call_count);
+
+	for (unsigned int i = 0; i < mock_bap_unicast_server_cb_disable_fake.call_count; i++) {
+		zassert_equal_ptr(streams[i],
+			mock_bap_unicast_server_cb_disable_fake.arg0_history[i],
+			"'%s()' was called with incorrect 'stream[%i]' value", func_name, i);
+	}
+}
+
+static inline void expect_bt_bap_unicast_server_cb_release_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[])
+{
+	const char *func_name = "bt_bap_unicast_server_cb.release";
+
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_unicast_server_cb_release_fake.call_count);
+
+	for (unsigned int i = 0; i < mock_bap_unicast_server_cb_release_fake.call_count; i++) {
+		zassert_equal_ptr(streams[i],
+			mock_bap_unicast_server_cb_release_fake.arg0_history[i],
+			"'%s()' was called with incorrect 'stream[%i]' value", func_name, i);
+	}
+}
+
+static inline void expect_bt_bap_unicast_server_cb_start_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[])
+{
+	const char *func_name = "bt_bap_unicast_server_cb.start";
+
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_unicast_server_cb_start_fake.call_count);
+
+	for (unsigned int i = 0; i < mock_bap_unicast_server_cb_start_fake.call_count; i++) {
+		zassert_equal_ptr(streams[i],
+			mock_bap_unicast_server_cb_start_fake.arg0_history[i],
+			"'%s()' was called with incorrect 'stream[%i]' value", func_name, i);
+	}
+}
+
+static inline void expect_bt_bap_unicast_server_cb_stop_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[])
+{
+	const char *func_name = "bt_bap_unicast_server_cb.stop";
+
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_unicast_server_cb_stop_fake.call_count);
+
+	for (unsigned int i = 0; i < mock_bap_unicast_server_cb_stop_fake.call_count; i++) {
+		zassert_equal_ptr(streams[i],
+			mock_bap_unicast_server_cb_stop_fake.arg0_history[i],
+			"'%s()' was called with incorrect 'stream[%i]' value", func_name, i);
+	}
 }
 
 #endif /* MOCKS_BAP_UNICAST_SERVER_EXPECTS_H_ */

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -204,8 +204,8 @@ ZTEST_F(ascs_test_suite, test_release_ase_on_callback_unregister)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Expected to notify the upper layers */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
 
 	/* Expected to notify the client */
 	expect_bt_gatt_notify_cb_called_once(conn, ase->uuid, ase, EMPTY, sizeof(*hdr));
@@ -285,7 +285,7 @@ ZTEST_F(ascs_test_suite, test_release_ase_on_acl_disconnection)
 	mock_bt_conn_disconnected(conn, BT_HCI_ERR_CONN_TIMEOUT);
 
 	/* Expected to notify the upper layers */
-	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
 
 	/* Mock CIS disconnection */
 	mock_bt_iso_disconnected(chan, BT_HCI_ERR_CONN_TIMEOUT);
@@ -343,9 +343,9 @@ ZTEST_F(ascs_test_suite, test_release_ase_pair_on_acl_disconnection)
 	mock_bt_conn_disconnected(conn, BT_HCI_ERR_CONN_TIMEOUT);
 
 	/* Expected to notify the upper layers */
-	const struct bt_bap_stream *streams[2] = { &snk_stream, &src_stream };
+	const struct bt_bap_stream *streams[] = { &snk_stream, &src_stream };
 
-	expect_bt_bap_stream_ops_released_called(streams, 2);
+	expect_bt_bap_stream_ops_released_called(ARRAY_SIZE(streams), streams);
 
 	/* Mock CIS disconnection */
 	mock_bt_iso_disconnected(chan, BT_HCI_ERR_CONN_TIMEOUT);
@@ -374,7 +374,7 @@ ZTEST_F(ascs_test_suite, test_recv_in_streaming_state)
 	chan->ops->recv(chan, &info, &buf);
 
 	/* Verification */
-	expect_bt_bap_stream_ops_recv_called_once(stream, &info, &buf);
+	expect_bt_bap_stream_ops_recv_called(1, &stream, &info, &buf);
 }
 
 ZTEST_F(ascs_test_suite, test_recv_in_enabling_state)
@@ -405,7 +405,7 @@ ZTEST_F(ascs_test_suite, test_recv_in_enabling_state)
 	chan->ops->recv(chan, &info, &buf);
 
 	/* Verification */
-	expect_bt_bap_stream_ops_recv_not_called();
+	expect_bt_bap_stream_ops_recv_called(0, NULL, NULL, NULL);
 }
 
 ZTEST_F(ascs_test_suite, test_cis_link_loss_in_streaming_state)
@@ -439,10 +439,10 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_streaming_state)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Expected to notify the upper layers */
-	expect_bt_bap_stream_ops_qos_set_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_called_once(stream);
-	expect_bt_bap_stream_ops_released_not_called();
-	expect_bt_bap_stream_ops_disconnected_called_once(stream);
+	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(0, NULL);
+	expect_bt_bap_stream_ops_disconnected_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 static void test_cis_link_loss_in_disabling_state(struct ascs_test_suite_fixture *fixture,
@@ -475,7 +475,7 @@ static void test_cis_link_loss_in_disabling_state(struct ascs_test_suite_fixture
 
 	test_ase_control_client_disable(conn, ase_id);
 
-	expect_bt_bap_stream_ops_disabled_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 
 	test_mocks_reset();
 
@@ -485,10 +485,10 @@ static void test_cis_link_loss_in_disabling_state(struct ascs_test_suite_fixture
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Expected to notify the upper layers */
-	expect_bt_bap_stream_ops_qos_set_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
-	expect_bt_bap_stream_ops_released_not_called();
-	expect_bt_bap_stream_ops_disconnected_called_once(stream);
+	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
+	expect_bt_bap_stream_ops_released_called(0, NULL);
+	expect_bt_bap_stream_ops_disconnected_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 ZTEST_F(ascs_test_suite, test_cis_link_loss_in_disabling_state_v1)
@@ -535,9 +535,9 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Expected no change in ASE state */
-	expect_bt_bap_stream_ops_qos_set_not_called();
-	expect_bt_bap_stream_ops_released_not_called();
-	expect_bt_bap_stream_ops_disconnected_called_once(stream);
+	expect_bt_bap_stream_ops_qos_set_called(0, NULL);
+	expect_bt_bap_stream_ops_released_called(0, NULL);
+	expect_bt_bap_stream_ops_disconnected_called(1, (const struct bt_bap_stream **)&stream);
 
 	err = bt_bap_stream_disable(stream);
 	zassert_equal(0, err, "Failed to disable stream: err %d", err);
@@ -545,11 +545,11 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	if (IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK)) {
-		expect_bt_bap_stream_ops_qos_set_called_once(stream);
-		expect_bt_bap_stream_ops_disabled_called_once(stream);
+		expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+		expect_bt_bap_stream_ops_disabled_called(1, &stream);
 	} else {
 		/* Server-initiated disable operation that shall not cause transition to QoS */
-		expect_bt_bap_stream_ops_qos_set_not_called();
+		expect_bt_bap_stream_ops_qos_set_called(0, NULL);
 	}
 }
 
@@ -578,7 +578,7 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state_client_retries)
 	test_preamble_state_enabling(conn, ase_id, stream);
 	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
 	zassert_equal(0, err, "Failed to connect iso: err %d", err);
-	expect_bt_bap_stream_ops_connected_called_once(stream);
+	expect_bt_bap_stream_ops_connected_called(1, (const struct bt_bap_stream **)&stream);
 
 	/* Mock CIS disconnection */
 	mock_bt_iso_disconnected(chan, BT_HCI_ERR_CONN_FAIL_TO_ESTAB);
@@ -586,9 +586,9 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state_client_retries)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Expected to not notify the upper layers */
-	expect_bt_bap_stream_ops_qos_set_not_called();
-	expect_bt_bap_stream_ops_released_not_called();
-	expect_bt_bap_stream_ops_disconnected_called_once(stream);
+	expect_bt_bap_stream_ops_qos_set_called(0, NULL);
+	expect_bt_bap_stream_ops_released_called(0, NULL);
+	expect_bt_bap_stream_ops_disconnected_called(1, (const struct bt_bap_stream **)&stream);
 
 	/* Client retries to establish CIS */
 	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
@@ -602,8 +602,10 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state_client_retries)
 
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
-	expect_bt_bap_stream_ops_connected_called_twice(stream);
-	expect_bt_bap_stream_ops_started_called_once(stream);
+	const struct bt_bap_stream *streams[] = { stream, stream };
+
+	expect_bt_bap_stream_ops_connected_called(ARRAY_SIZE(streams), streams);
+	expect_bt_bap_stream_ops_started_called(1, &stream);
 }
 
 static struct bt_bap_stream *stream_allocated;
@@ -673,7 +675,7 @@ ZTEST_F(ascs_test_suite, test_ase_state_notification_retry)
 	cp->write(conn, cp, (void *)buf, sizeof(buf), 0, 0);
 
 	/* Verification */
-	expect_bt_bap_stream_ops_configured_not_called();
+	expect_bt_bap_stream_ops_configured_called(0, NULL, NULL);
 
 	mock_bt_gatt_notify_cb_fake.return_val = 0;
 
@@ -683,5 +685,5 @@ ZTEST_F(ascs_test_suite, test_ase_state_notification_retry)
 	/* Wait for ASE state notification retry */
 	k_sleep(K_USEC(info.le.interval_us));
 
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -148,9 +148,12 @@ ZTEST_F(test_sink_ase_state_transition, test_client_idle_to_codec_configured)
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_config_called_once(conn, EMPTY, BT_AUDIO_DIR_SINK, EMPTY);
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	enum bt_audio_dir dir = BT_AUDIO_DIR_SINK;
+
+	expect_bt_bap_unicast_server_cb_config_called(1, &conn, NULL, &dir, NULL);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }
+
 ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_qos_configured)
 {
 	struct bt_bap_stream *stream = &fixture->stream;
@@ -164,9 +167,9 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_qos_conf
 	test_ase_control_client_config_qos(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
-	expect_bt_bap_stream_ops_qos_set_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_qos_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_enabling)
@@ -182,8 +185,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_enabling)
 	test_ase_control_client_enable(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_enable_called_once(stream, EMPTY, EMPTY);
-	expect_bt_bap_stream_ops_enabled_called_once(stream);
+	expect_bt_bap_unicast_server_cb_enable_called(1, &stream, NULL, NULL);
+	expect_bt_bap_stream_ops_enabled_called(1, &stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_qos_configured)
@@ -199,9 +202,9 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_qos_configured)
 	test_ase_control_client_disable(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
-	expect_bt_bap_stream_ops_qos_set_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_called_once(stream);
+	expect_bt_bap_unicast_server_cb_disable_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_releasing)
@@ -217,8 +220,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_releasing)
 	test_ase_control_client_release(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_codec_configured)
@@ -234,9 +237,11 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_codec_co
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_config_not_called();
-	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SINK, EMPTY);
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	const enum bt_audio_dir dir = BT_AUDIO_DIR_SINK;
+
+	expect_bt_bap_unicast_server_cb_config_called(0, NULL, NULL, NULL, NULL);
+	expect_bt_bap_unicast_server_cb_reconfig_called(1, &stream, &dir, NULL);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_qos_configured)
@@ -252,9 +257,9 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_qos_config
 	test_ase_control_client_config_qos(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
-	expect_bt_bap_stream_ops_qos_set_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_qos_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_codec_configured)
@@ -270,8 +275,10 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_codec_conf
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SINK, EMPTY);
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	const enum bt_audio_dir dir = BT_AUDIO_DIR_SINK;
+
+	expect_bt_bap_unicast_server_cb_reconfig_called(1, &stream, &dir, NULL);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_releasing)
@@ -287,8 +294,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_releasin
 	test_ase_control_client_release(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_releasing)
@@ -304,9 +311,9 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_releasing)
 	test_ase_control_client_release(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_enabling)
@@ -322,9 +329,9 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_enabling)
 	test_ase_control_client_update_metadata(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
-	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_metadata_called(1, &stream, NULL, NULL);
+	expect_bt_bap_stream_ops_metadata_updated_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_releasing)
@@ -346,11 +353,13 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_releasing)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-	expect_bt_bap_stream_ops_released_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
-	expect_bt_bap_stream_ops_disconnected_called_once(stream);
+	const uint8_t reason = BT_HCI_ERR_REMOTE_USER_TERM_CONN;
+
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_stopped_called(1, &stream, &reason);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
+	expect_bt_bap_stream_ops_disconnected_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_streaming)
@@ -367,9 +376,9 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_streaming)
 	test_ase_control_client_update_metadata(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
-	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_metadata_called(1, &stream, NULL, NULL);
+	expect_bt_bap_stream_ops_metadata_updated_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_qos_configured)
@@ -386,10 +395,12 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_qos_configured)
 	test_ase_control_client_disable(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
-	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-	expect_bt_bap_stream_ops_qos_set_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_called_once(stream);
+	const uint8_t reason = BT_HCI_ERR_REMOTE_USER_TERM_CONN;
+
+	expect_bt_bap_unicast_server_cb_disable_called(1, &stream);
+	expect_bt_bap_stream_ops_stopped_called(1, &stream, &reason);
+	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_idle_to_codec_configured)
@@ -409,8 +420,8 @@ ZTEST_F(test_sink_ase_state_transition, test_server_idle_to_codec_configured)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_config_not_called();
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	expect_bt_bap_unicast_server_cb_config_called(0, NULL, NULL, NULL, NULL);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_codec_configured_to_codec_configured)
@@ -433,8 +444,10 @@ ZTEST_F(test_sink_ase_state_transition, test_server_codec_configured_to_codec_co
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SINK, EMPTY);
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	const enum bt_audio_dir dir = BT_AUDIO_DIR_SINK;
+
+	expect_bt_bap_unicast_server_cb_reconfig_called(1, &stream, &dir, NULL);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_codec_configured_to_releasing)
@@ -454,8 +467,8 @@ ZTEST_F(test_sink_ase_state_transition, test_server_codec_configured_to_releasin
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_qos_configured_to_codec_configured)
@@ -478,8 +491,10 @@ ZTEST_F(test_sink_ase_state_transition, test_server_qos_configured_to_codec_conf
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SINK, EMPTY);
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	const enum bt_audio_dir dir = BT_AUDIO_DIR_SINK;
+
+	expect_bt_bap_unicast_server_cb_reconfig_called(1, &stream, &dir, NULL);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_qos_configured_to_releasing)
@@ -499,8 +514,8 @@ ZTEST_F(test_sink_ase_state_transition, test_server_qos_configured_to_releasing)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_releasing)
@@ -520,9 +535,9 @@ ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_releasing)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_enabling)
@@ -546,9 +561,9 @@ ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_enabling)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
-	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_metadata_called(1, &stream, NULL, NULL);
+	expect_bt_bap_stream_ops_metadata_updated_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_qos_configured)
@@ -568,9 +583,9 @@ ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_qos_configured)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
-	expect_bt_bap_stream_ops_qos_set_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_called_once(stream);
+	expect_bt_bap_unicast_server_cb_disable_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_streaming)
@@ -594,9 +609,9 @@ ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_streaming)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_stream_ops_connected_called_once(stream);
-	expect_bt_bap_stream_ops_started_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_stream_ops_connected_called(1, (const struct bt_bap_stream **)&stream);
+	expect_bt_bap_stream_ops_started_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 	/* XXX: unicast_server_cb->start is not called for Sink ASE */
 }
 
@@ -622,9 +637,9 @@ ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_streaming)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
-	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_metadata_called(1, &stream, NULL, NULL);
+	expect_bt_bap_stream_ops_metadata_updated_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_qos_configured)
@@ -645,10 +660,12 @@ ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_qos_configured)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
-	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
-	expect_bt_bap_stream_ops_qos_set_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_called_once(stream);
+	const uint8_t reason = BT_HCI_ERR_LOCALHOST_TERM_CONN;
+
+	expect_bt_bap_unicast_server_cb_disable_called(1, &stream);
+	expect_bt_bap_stream_ops_stopped_called(1, &stream, &reason);
+	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_releasing)
@@ -674,11 +691,13 @@ ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_releasing)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
-	expect_bt_bap_stream_ops_released_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
-	expect_bt_bap_stream_ops_disconnected_called_once(stream);
+	const uint8_t reason = BT_HCI_ERR_LOCALHOST_TERM_CONN;
+
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_stopped_called(1, &stream, &reason);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
+	expect_bt_bap_stream_ops_disconnected_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 static void *test_source_ase_state_transition_setup(void)
@@ -713,8 +732,10 @@ ZTEST_F(test_source_ase_state_transition, test_client_idle_to_codec_configured)
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_config_called_once(conn, EMPTY, BT_AUDIO_DIR_SOURCE, EMPTY);
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	enum bt_audio_dir dir = BT_AUDIO_DIR_SOURCE;
+
+	expect_bt_bap_unicast_server_cb_config_called(1, &conn, NULL, &dir, NULL);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_qos_configured)
@@ -730,9 +751,9 @@ ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_qos_co
 	test_ase_control_client_config_qos(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
-	expect_bt_bap_stream_ops_qos_set_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_qos_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_enabling)
@@ -748,8 +769,8 @@ ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_enabling
 	test_ase_control_client_enable(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_enable_called_once(stream, EMPTY, EMPTY);
-	expect_bt_bap_stream_ops_enabled_called_once(stream);
+	expect_bt_bap_unicast_server_cb_enable_called(1, &stream, NULL, NULL);
+	expect_bt_bap_stream_ops_enabled_called(1, &stream);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_disabling)
@@ -765,8 +786,8 @@ ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_disabling)
 	test_ase_control_client_disable(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_called_once(stream);
+	expect_bt_bap_unicast_server_cb_disable_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_releasing)
@@ -782,8 +803,8 @@ ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_releasin
 	test_ase_control_client_release(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_streaming)
@@ -804,10 +825,10 @@ ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_streaming)
 	test_ase_control_client_receiver_start_ready(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_start_called_once(stream);
-	expect_bt_bap_stream_ops_connected_called_once(stream);
-	expect_bt_bap_stream_ops_started_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_start_called(1, &stream);
+	expect_bt_bap_stream_ops_connected_called(1, (const struct bt_bap_stream **)&stream);
+	expect_bt_bap_stream_ops_started_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_codec_configured)
@@ -823,8 +844,10 @@ ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_codec_
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SOURCE, EMPTY);
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	const enum bt_audio_dir dir = BT_AUDIO_DIR_SOURCE;
+
+	expect_bt_bap_unicast_server_cb_reconfig_called(1, &stream, &dir, NULL);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_qos_configured)
@@ -840,9 +863,9 @@ ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_qos_conf
 	test_ase_control_client_config_qos(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
-	expect_bt_bap_stream_ops_qos_set_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_qos_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_codec_configured)
@@ -858,8 +881,10 @@ ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_codec_co
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SOURCE, EMPTY);
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	const enum bt_audio_dir dir = BT_AUDIO_DIR_SOURCE;
+
+	expect_bt_bap_unicast_server_cb_reconfig_called(1, &stream, &dir, NULL);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_releasing)
@@ -875,8 +900,8 @@ ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_releas
 	test_ase_control_client_release(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_releasing)
@@ -892,9 +917,9 @@ ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_releasing)
 	test_ase_control_client_release(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_enabling)
@@ -910,9 +935,9 @@ ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_enabling)
 	test_ase_control_client_update_metadata(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
-	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_metadata_called(1, &stream, NULL, NULL);
+	expect_bt_bap_stream_ops_metadata_updated_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_releasing)
@@ -934,11 +959,13 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_releasing)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-	expect_bt_bap_stream_ops_released_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
-	expect_bt_bap_stream_ops_disconnected_called_once(stream);
+	const uint8_t reason = BT_HCI_ERR_REMOTE_USER_TERM_CONN;
+
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_stopped_called(1, &stream, &reason);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
+	expect_bt_bap_stream_ops_disconnected_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_streaming)
@@ -955,9 +982,9 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_streaming)
 	test_ase_control_client_update_metadata(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
-	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_metadata_called(1, &stream, NULL, NULL);
+	expect_bt_bap_stream_ops_metadata_updated_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling)
@@ -974,9 +1001,11 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling)
 	test_ase_control_client_disable(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
-	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-	expect_bt_bap_stream_ops_disabled_called_once(stream);
+	const uint8_t reason = BT_HCI_ERR_REMOTE_USER_TERM_CONN;
+
+	expect_bt_bap_unicast_server_cb_disable_called(1, &stream);
+	expect_bt_bap_stream_ops_stopped_called(1, &stream, &reason);
+	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_disabling_to_qos_configured)
@@ -989,16 +1018,16 @@ ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_disabling_to_q
 
 	test_preamble_state_enabling(conn, ase_id, stream);
 	test_ase_control_client_disable(conn, ase_id);
-	expect_bt_bap_stream_ops_disabled_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 
 	test_mocks_reset();
 
 	test_ase_control_client_receiver_stop_ready(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_stop_called_once(stream);
-	expect_bt_bap_stream_ops_qos_set_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_stop_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling_to_qos_configured)
@@ -1014,8 +1043,10 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling_to_
 	test_ase_control_client_disable(conn, ase_id);
 
 	/* Verify that stopped callback was called by disable */
-	expect_bt_bap_stream_ops_disabled_called_once(stream);
-	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	const uint8_t reason = BT_HCI_ERR_REMOTE_USER_TERM_CONN;
+
+	expect_bt_bap_stream_ops_disabled_called(1, &stream);
+	expect_bt_bap_stream_ops_stopped_called(1, &stream, &reason);
 
 
 	test_mocks_reset();
@@ -1023,9 +1054,9 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling_to_
 	test_ase_control_client_receiver_stop_ready(conn, ase_id);
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_stop_called_once(stream);
-	expect_bt_bap_stream_ops_qos_set_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_stop_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_idle_to_codec_configured)
@@ -1045,8 +1076,8 @@ ZTEST_F(test_source_ase_state_transition, test_server_idle_to_codec_configured)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_config_not_called();
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	expect_bt_bap_unicast_server_cb_config_called(0, NULL, NULL, NULL, NULL);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_codec_configured_to_codec_configured)
@@ -1069,8 +1100,10 @@ ZTEST_F(test_source_ase_state_transition, test_server_codec_configured_to_codec_
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SOURCE, EMPTY);
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	const enum bt_audio_dir dir = BT_AUDIO_DIR_SOURCE;
+
+	expect_bt_bap_unicast_server_cb_reconfig_called(1, &stream, &dir, NULL);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_codec_configured_to_releasing)
@@ -1090,8 +1123,8 @@ ZTEST_F(test_source_ase_state_transition, test_server_codec_configured_to_releas
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_qos_configured_to_codec_configured)
@@ -1114,8 +1147,10 @@ ZTEST_F(test_source_ase_state_transition, test_server_qos_configured_to_codec_co
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SOURCE, EMPTY);
-	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+	const enum bt_audio_dir dir = BT_AUDIO_DIR_SOURCE;
+
+	expect_bt_bap_unicast_server_cb_reconfig_called(1, &stream, &dir, NULL);
+	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_qos_configured_to_releasing)
@@ -1135,8 +1170,8 @@ ZTEST_F(test_source_ase_state_transition, test_server_qos_configured_to_releasin
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_releasing)
@@ -1156,9 +1191,9 @@ ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_releasing)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_released_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_enabling)
@@ -1182,9 +1217,9 @@ ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_enabling)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
-	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_metadata_called(1, &stream, NULL, NULL);
+	expect_bt_bap_stream_ops_metadata_updated_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_disabling)
@@ -1204,8 +1239,8 @@ ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_disabling)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_called_once(stream);
+	expect_bt_bap_unicast_server_cb_disable_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_streaming)
@@ -1230,9 +1265,9 @@ ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_streaming)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
-	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
+	expect_bt_bap_unicast_server_cb_metadata_called(1, &stream, NULL, NULL);
+	expect_bt_bap_stream_ops_metadata_updated_called(1, &stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_disabling)
@@ -1253,9 +1288,11 @@ ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_disabling)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
-	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
-	expect_bt_bap_stream_ops_disabled_called_once(stream);
+	const uint8_t reason = BT_HCI_ERR_LOCALHOST_TERM_CONN;
+
+	expect_bt_bap_unicast_server_cb_disable_called(1, &stream);
+	expect_bt_bap_stream_ops_stopped_called(1, &stream, &reason);
+	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_releasing)
@@ -1281,9 +1318,11 @@ ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_releasing)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Verification */
-	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
-	expect_bt_bap_stream_ops_released_called_once(stream);
-	expect_bt_bap_stream_ops_disabled_not_called();
-	expect_bt_bap_stream_ops_disconnected_called_once(stream);
+	const uint8_t reason = BT_HCI_ERR_LOCALHOST_TERM_CONN;
+
+	expect_bt_bap_unicast_server_cb_release_called(1, &stream);
+	expect_bt_bap_stream_ops_stopped_called(1, &stream, &reason);
+	expect_bt_bap_stream_ops_released_called(1, (const struct bt_bap_stream **)&stream);
+	expect_bt_bap_stream_ops_disabled_called(0, NULL);
+	expect_bt_bap_stream_ops_disconnected_called(1, (const struct bt_bap_stream **)&stream);
 }

--- a/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
@@ -17,116 +17,100 @@
 #include "bap_stream.h"
 #include "expects_util.h"
 
-#define expect_bt_bap_stream_ops_configured_called_once(_stream, _pref)                            \
-do {                                                                                               \
-	const char *func_name = "bt_bap_stream_ops.configured";                                    \
-												   \
-	zexpect_call_count(func_name, 1, mock_bap_stream_configured_cb_fake.call_count);           \
-												   \
-	if (mock_bap_stream_configured_cb_fake.call_count > 0) {                                   \
-		IF_NOT_EMPTY(_stream, (                                                            \
-			zexpect_equal_ptr(_stream, mock_bap_stream_configured_cb_fake.arg0_val,    \
-					  "'%s()' was called with incorrect '%s' value",           \
-					  func_name, "stream");))                                  \
-												   \
-		IF_NOT_EMPTY(_pref, (                                                              \
-			/* TODO */                                                                 \
-			zassert_unreachable("Not implemented");))                                  \
-	}                                                                                          \
-} while (0)
-
-static inline void expect_bt_bap_stream_ops_configured_not_called(void)
+static inline void expect_bt_bap_stream_ops_configured_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[],
+	void *pref[])
 {
 	const char *func_name = "bt_bap_stream_ops.configured";
 
-	zexpect_call_count(func_name, 0, mock_bap_stream_configured_cb_fake.call_count);
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_stream_configured_cb_fake.call_count);
+
+	for (unsigned int i = 0; i < mock_bap_stream_configured_cb_fake.call_count; i++) {
+		zexpect_equal_ptr(streams[i],
+			mock_bap_stream_configured_cb_fake.arg0_history[i],
+			"'%s()' was called with incorrect 'stream[%i]' value",
+			func_name, i);
+	}
+
+	if (pref) {
+		/* TODO */
+		zassert_unreachable("Not implemented");
+	}
 }
 
-static inline void expect_bt_bap_stream_ops_qos_set_called_once(struct bt_bap_stream *stream)
+static inline void expect_bt_bap_stream_ops_qos_set_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[])
 {
 	const char *func_name = "bt_bap_stream_ops.qos_set";
 
-	zexpect_call_count(func_name, 1, mock_bap_stream_qos_set_cb_fake.call_count);
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_stream_qos_set_cb_fake.call_count);
 
-	if (mock_bap_stream_qos_set_cb_fake.call_count > 0) {
-		zexpect_equal_ptr(stream, mock_bap_stream_qos_set_cb_fake.arg0_val,
-				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	for (unsigned int i = 0; i < mock_bap_stream_qos_set_cb_fake.call_count; i++) {
+		zexpect_equal_ptr(streams[i],
+			mock_bap_stream_qos_set_cb_fake.arg0_history[i],
+			"'%s()' was called with incorrect '%s[%i]'", func_name, "stream", i);
 	}
 }
 
-static inline void expect_bt_bap_stream_ops_qos_set_not_called(void)
-{
-	const char *func_name = "bt_bap_stream_ops.qos_set";
-
-	zexpect_call_count(func_name, 0, mock_bap_stream_qos_set_cb_fake.call_count);
-}
-
-static inline void expect_bt_bap_stream_ops_enabled_called_once(struct bt_bap_stream *stream)
+static inline void expect_bt_bap_stream_ops_enabled_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[])
 {
 	const char *func_name = "bt_bap_stream_ops.enabled";
 
-	zexpect_call_count(func_name, 1, mock_bap_stream_enabled_cb_fake.call_count);
+	zexpect_call_count(func_name, expected_count, mock_bap_stream_enabled_cb_fake.call_count);
 
-	if (mock_bap_stream_enabled_cb_fake.call_count > 0) {
-		zexpect_equal_ptr(stream, mock_bap_stream_enabled_cb_fake.arg0_val,
-				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	for (unsigned int i = 0; i < mock_bap_stream_enabled_cb_fake.call_count; i++) {
+		zexpect_equal_ptr(streams[i],
+			mock_bap_stream_enabled_cb_fake.arg0_history[i],
+			"'%s()' was called with incorrect '%s[%i]'", func_name, "stream", i);
 	}
 }
 
-static inline void expect_bt_bap_stream_ops_enabled_not_called(void)
-{
-	const char *func_name = "bt_bap_stream_ops.enabled";
-
-	zexpect_call_count(func_name, 0, mock_bap_stream_enabled_cb_fake.call_count);
-}
-
-static inline void expect_bt_bap_stream_ops_metadata_updated_called_once(
-								struct bt_bap_stream *stream)
+static inline void expect_bt_bap_stream_ops_metadata_updated_called(
+	int expected_count,
+	struct bt_bap_stream *streams[])
 {
 	const char *func_name = "bt_bap_stream_ops.metadata_updated";
 
-	zexpect_call_count(func_name, 1, mock_bap_stream_metadata_updated_cb_fake.call_count);
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_stream_metadata_updated_cb_fake.call_count);
 
-	if (mock_bap_stream_metadata_updated_cb_fake.call_count > 0) {
-		zexpect_equal_ptr(stream, mock_bap_stream_metadata_updated_cb_fake.arg0_val,
-				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	for (unsigned int i = 0; i < mock_bap_stream_metadata_updated_cb_fake.call_count; i++) {
+		zexpect_equal_ptr(streams[i],
+			mock_bap_stream_metadata_updated_cb_fake.arg0_history[i],
+			"'%s()' was called with incorrect '%s[%i]'", func_name, "stream", i);
 	}
 }
 
-static inline void expect_bt_bap_stream_ops_metadata_updated_not_called(void)
-{
-	const char *func_name = "bt_bap_stream_ops.metadata_updated";
-
-	zexpect_call_count(func_name, 0, mock_bap_stream_metadata_updated_cb_fake.call_count);
-}
-
-static inline void expect_bt_bap_stream_ops_disabled_called_once(struct bt_bap_stream *stream)
+static inline void expect_bt_bap_stream_ops_disabled_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[])
 {
 	const char *func_name = "bt_bap_stream_ops.disabled";
 
-	zexpect_call_count(func_name, 1, mock_bap_stream_disabled_cb_fake.call_count);
+	zexpect_call_count(func_name, expected_count, mock_bap_stream_disabled_cb_fake.call_count);
 
-	if (mock_bap_stream_disabled_cb_fake.call_count > 0) {
-		zexpect_equal_ptr(stream, mock_bap_stream_disabled_cb_fake.arg0_val,
-				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	for (unsigned int i = 0; i < mock_bap_stream_disabled_cb_fake.call_count; i++) {
+		zexpect_equal_ptr(streams[i],
+			mock_bap_stream_disabled_cb_fake.arg0_history[i],
+			"'%s()' was called with incorrect '%s[%i]'", func_name, "stream", i);
 	}
 }
 
-static inline void expect_bt_bap_stream_ops_disabled_not_called(void)
-{
-	const char *func_name = "bt_bap_stream_ops.disabled";
-
-	zexpect_call_count(func_name, 0, mock_bap_stream_disabled_cb_fake.call_count);
-}
-
-static inline void expect_bt_bap_stream_ops_released_called(const struct bt_bap_stream *streams[],
-							    unsigned int count)
+static inline void expect_bt_bap_stream_ops_released_called(
+	unsigned int expected_count,
+	const struct bt_bap_stream *streams[])
 {
 	const char *func_name = "bt_bap_stream_ops.released";
 
-	zexpect_call_count(func_name, count, mock_bap_stream_released_cb_fake.call_count);
+	zexpect_call_count(func_name, expected_count, mock_bap_stream_released_cb_fake.call_count);
 
-	for (unsigned int i = 0; i < count; i++) {
+	for (unsigned int i = 0; i < expected_count; i++) {
 		bool found = false;
 
 		for (unsigned int j = 0; j < mock_bap_stream_released_cb_fake.call_count; j++) {
@@ -140,143 +124,107 @@ static inline void expect_bt_bap_stream_ops_released_called(const struct bt_bap_
 	}
 }
 
-static inline void expect_bt_bap_stream_ops_released_called_once(const struct bt_bap_stream *stream)
-{
-	expect_bt_bap_stream_ops_released_called(&stream, 1);
-}
-
-static inline void expect_bt_bap_stream_ops_released_not_called(void)
-{
-	const char *func_name = "bt_bap_stream_ops.released";
-
-	zexpect_equal(0, mock_bap_stream_released_cb_fake.call_count,
-		      "'%s()' was called unexpectedly", func_name);
-}
-
-static inline void expect_bt_bap_stream_ops_started_called_once(struct bt_bap_stream *stream)
+static inline void expect_bt_bap_stream_ops_started_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[])
 {
 	const char *func_name = "bt_bap_stream_ops.started";
 
-	zexpect_call_count(func_name, 1, mock_bap_stream_started_cb_fake.call_count);
+	zexpect_call_count(func_name, expected_count, mock_bap_stream_started_cb_fake.call_count);
 
-	if (mock_bap_stream_started_cb_fake.call_count > 0) {
-		zexpect_equal_ptr(stream, mock_bap_stream_started_cb_fake.arg0_val,
-				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	for (unsigned int i = 0; i < mock_bap_stream_started_cb_fake.call_count; i++) {
+		zexpect_equal_ptr(streams[i],
+			mock_bap_stream_started_cb_fake.arg0_history[i],
+			"'%s()' was called with incorrect '%s[%i]'", func_name, "stream", i);
 	}
 }
 
-static inline void expect_bt_bap_stream_ops_started_not_called(void)
-{
-	const char *func_name = "bt_bap_stream_ops.started";
-
-	zexpect_call_count(func_name, 0, mock_bap_stream_started_cb_fake.call_count);
-}
-
-#define expect_bt_bap_stream_ops_stopped_called_once(_stream, _reason)                             \
-do {                                                                                               \
-	const char *func_name = "bt_bap_stream_ops.stopped";                                       \
-												   \
-	zexpect_call_count(func_name, 1, mock_bap_stream_stopped_cb_fake.call_count);              \
-												   \
-	if (mock_bap_stream_stopped_cb_fake.call_count > 0) {                                      \
-		IF_NOT_EMPTY(_stream, (                                                            \
-			zexpect_equal_ptr(_stream, mock_bap_stream_stopped_cb_fake.arg0_val,       \
-					  "'%s()' was called with incorrect '%s' value",           \
-					  func_name, "stream");))                                  \
-												   \
-		IF_NOT_EMPTY(_reason, (                                                            \
-			zexpect_equal(_reason, mock_bap_stream_stopped_cb_fake.arg1_val,           \
-				      "'%s()' was called with incorrect '%s' value",               \
-				      func_name, "reason");))                                      \
-	}                                                                                          \
-} while (0)
-
-static inline void expect_bt_bap_stream_ops_stopped_not_called(void)
+static inline void expect_bt_bap_stream_ops_stopped_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[],
+	const uint8_t reasons[])
 {
 	const char *func_name = "bt_bap_stream_ops.stopped";
 
-	zexpect_call_count(func_name, 0, mock_bap_stream_stopped_cb_fake.call_count);
-}
+	zexpect_call_count(func_name, expected_count, mock_bap_stream_stopped_cb_fake.call_count);
 
-static inline void
-expect_bt_bap_stream_ops_connected_called_once(const struct bt_bap_stream *stream)
-{
-	const char *func_name = "bt_bap_stream_ops.connected";
-
-	zexpect_call_count(func_name, 1, mock_bap_stream_connected_cb_fake.call_count);
-
-	if (mock_bap_stream_connected_cb_fake.call_count > 0) {
-		zexpect_equal_ptr(stream, mock_bap_stream_connected_cb_fake.arg0_val,
-				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	for (unsigned int i = 0; i < mock_bap_stream_stopped_cb_fake.call_count; i++) {
+		zexpect_equal_ptr(streams[i],
+			mock_bap_stream_stopped_cb_fake.arg0_history[i],
+			"'%s()' was called with incorrect '%s[%i]' value", func_name, "stream", i);
+		zexpect_equal(reasons[i],
+			mock_bap_stream_stopped_cb_fake.arg1_history[i],
+			"'%s()' was called with incorrect '%s[%i]' value", func_name, "reason", i);
 	}
 }
 
 static inline void
-expect_bt_bap_stream_ops_connected_called_twice(const struct bt_bap_stream *stream)
+expect_bt_bap_stream_ops_connected_called(
+	unsigned int expected_count,
+	const struct bt_bap_stream *streams[])
 {
 	const char *func_name = "bt_bap_stream_ops.connected";
 
-	zexpect_call_count(func_name, 2, mock_bap_stream_connected_cb_fake.call_count);
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_stream_connected_cb_fake.call_count);
 
-	if (mock_bap_stream_connected_cb_fake.call_count > 0) {
-		zexpect_equal_ptr(stream, mock_bap_stream_connected_cb_fake.arg0_val,
-				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	for (unsigned int i = 0; i < mock_bap_stream_connected_cb_fake.call_count; i++) {
+		zexpect_equal_ptr(streams[i],
+			mock_bap_stream_connected_cb_fake.arg0_history[i],
+			"'%s()' was called with incorrect '%s[%i]'", func_name, "stream", i);
 	}
 }
 
 static inline void
-expect_bt_bap_stream_ops_disconnected_called_once(const struct bt_bap_stream *stream)
+expect_bt_bap_stream_ops_disconnected_called(
+	unsigned int expected_count,
+	const struct bt_bap_stream *streams[])
 {
 	const char *func_name = "bt_bap_stream_ops.disconnected";
 
-	zexpect_call_count(func_name, 1, mock_bap_stream_disconnected_cb_fake.call_count);
+	zexpect_call_count(func_name,
+		expected_count, mock_bap_stream_disconnected_cb_fake.call_count);
 
-	if (mock_bap_stream_disconnected_cb_fake.call_count > 0) {
-		zexpect_equal_ptr(stream, mock_bap_stream_disconnected_cb_fake.arg0_val,
-				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	for (unsigned int i = 0; i < mock_bap_stream_disconnected_cb_fake.call_count; i++) {
+		zexpect_equal_ptr(streams[i],
+			mock_bap_stream_disconnected_cb_fake.arg0_history[i],
+			"'%s()' was called with incorrect '%s[%i]'", func_name, "stream", i);
 	}
 }
 
-static inline void expect_bt_bap_stream_ops_recv_called_once(struct bt_bap_stream *stream,
-							     const struct bt_iso_recv_info *info,
-							     struct net_buf *buf)
+static inline void
+expect_bt_bap_stream_ops_recv_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[],
+	const struct bt_iso_recv_info *info,
+	struct net_buf *buf)
 {
 	const char *func_name = "bt_bap_stream_ops.recv";
 
-	zexpect_call_count(func_name, 1, mock_bap_stream_recv_cb_fake.call_count);
+	zexpect_call_count(func_name, expected_count, mock_bap_stream_recv_cb_fake.call_count);
 
-	if (mock_bap_stream_recv_cb_fake.call_count > 0) {
-		zexpect_equal_ptr(stream, mock_bap_stream_recv_cb_fake.arg0_val,
-				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	for (unsigned int i = 0; i < mock_bap_stream_recv_cb_fake.call_count; i++) {
+		zexpect_equal_ptr(streams[i],
+			mock_bap_stream_recv_cb_fake.arg0_history[i],
+			"'%s()' was called with incorrect '%s[%i]'", func_name, "stream", i);
 	}
 
 	/* TODO: validate info && buf */
 }
 
-static inline void expect_bt_bap_stream_ops_recv_not_called(void)
-{
-	const char *func_name = "bt_bap_stream_ops.recv";
-
-	zexpect_call_count(func_name, 0, mock_bap_stream_recv_cb_fake.call_count);
-}
-
-static inline void expect_bt_bap_stream_ops_sent_called_once(struct bt_bap_stream *stream)
+static inline void expect_bt_bap_stream_ops_sent_called(
+	unsigned int expected_count,
+	struct bt_bap_stream *streams[])
 {
 	const char *func_name = "bt_bap_stream_ops.sent";
 
-	zexpect_call_count(func_name, 1, mock_bap_stream_sent_cb_fake.call_count);
+	zexpect_call_count(func_name, expected_count, mock_bap_stream_sent_cb_fake.call_count);
 
-	if (mock_bap_stream_sent_cb_fake.call_count > 0) {
-		zexpect_equal_ptr(stream, mock_bap_stream_sent_cb_fake.arg0_val,
-				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	for (unsigned int i = 0; i < mock_bap_stream_sent_cb_fake.call_count; i++) {
+		zexpect_equal_ptr(streams[i],
+			mock_bap_stream_sent_cb_fake.arg0_history[i],
+			"'%s()' was called with incorrect '%s[%i]'", func_name, "stream", i);
 	}
-}
-
-static inline void expect_bt_bap_stream_ops_sent_not_called(void)
-{
-	const char *func_name = "bt_bap_stream_ops.sent";
-
-	zexpect_call_count(func_name, 0, mock_bap_stream_sent_cb_fake.call_count);
 }
 
 #endif /* MOCKS_BAP_STREAM_EXPECTS_H_ */


### PR DESCRIPTION
The existing ASCS test callback verification functions scale poorly and are not easily reusable across different cases.

This change introduces a more generic approach to expectation checks by adding `expect_bt_bap_unicast_server_cb_release_called(_expected_count, _streams)` and similar functions, improving readability and maintainability of ASCS unit tests.

Fixes #58034