### PR TITLE
drivers: mipi-dbi-spi: use the SPI_CS_CONTROL_INIT macro for CS

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -78,6 +78,15 @@ Comparator
   and :c:macro:`NRF_COMP_AIN_VDDH_DIV5` represents VDDH/5.
   The old ``string`` properties type is deprecated.
 
+Display
+===
+
+* The macros :c:macro:`MIPI_DBI_SPI_CONFIG_DT` :c:macro:`MIPI_DBI_SPI_CONFIG_DT_INST`,
+  :c:macro:`MIPI_DBI_CONFIG_DT`, and :c:macro:`MIPI_DBI_CONFIG_DT_INST` have been changed so that
+  they do not need to be provided a delay parameter anymore. This is because the timing parameters
+  of a SPI peripheral chip select should now be specified in DT with the
+  ``spi-cs-setup-delay-ns`` and ``spi-cs-hold-delay-ns`` properties.
+
 MFD
 ===
 

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -69,6 +69,9 @@ Deprecated APIs and options
   :c:macro:`SPI_DT_SPEC_GET`, :c:macro:`SPI_DT_SPEC_INST_GET` is deprecated. Providing a
   second argument to :c:macro:`SPI_CS_CONTROL_INIT` is deprecated. Use new DT properties
   ``spi-cs-setup-delay-ns`` and ``spi-cs-hold-delay-ns`` to specify delay instead.
+* Providing a third agument to :c:macro:`MIPI_DBI_SPI_CONFIG_DT`, :c:macro:`MIPI_DBI_SPI_CONFIG_DT_INST`,
+  :c:macro:`MIPI_DBI_CONFIG_DT`, :c:macro:`MIPI_DBI_CONFIG_DT_INST` is deprecated. Use new DT properties
+  ``spi-cs-setup-delay-ns`` and ``spi-cs-hold-delay-ns`` to specify delay instead.
 
 * :c:enum:`bt_hci_bus` was deprecated as it was not used. :c:macro:`BT_DT_HCI_BUS_GET` should be
   used instead.

--- a/drivers/display/display_gc9x01x.c
+++ b/drivers/display/display_gc9x01x.c
@@ -626,7 +626,7 @@ static DEVICE_API(display, gc9x01x_api) = {
 			.mode = MIPI_DBI_MODE_SPI_4WIRE,                                           \
 			.config = MIPI_DBI_SPI_CONFIG_DT_INST(inst,                                \
 							      SPI_OP_MODE_MASTER |                 \
-							      SPI_WORD_SET(8), 0),                 \
+							      SPI_WORD_SET(8)),                    \
 		},                                                                                 \
 		.pixel_format = DT_INST_PROP(inst, pixel_format),                                  \
 		.orientation = DT_INST_ENUM_IDX(inst, orientation),                                \

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -542,8 +542,7 @@ static const struct ili9xxx_quirks ili9488_quirks = {
 			.config = MIPI_DBI_SPI_CONFIG_DT(                      \
 						INST_DT_ILI9XXX(n, t),         \
 						SPI_OP_MODE_MASTER |           \
-						SPI_WORD_SET(8),               \
-						0),                            \
+						SPI_WORD_SET(8)),              \
 		},                                                             \
 		.pixel_format = DT_PROP(INST_DT_ILI9XXX(n, t), pixel_format),  \
 		.rotation = DT_PROP(INST_DT_ILI9XXX(n, t), rotation),          \

--- a/drivers/display/display_sh1122.c
+++ b/drivers/display/display_sh1122.c
@@ -485,7 +485,7 @@ static DEVICE_API(display, sh1122_driver_api) = {
 	static const struct sh1122_config config##node_id = {                                      \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(node_id)),                                     \
 		.dbi_config = MIPI_DBI_CONFIG_DT(                                                  \
-			node_id, SH1122_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER, 0),               \
+			node_id, SH1122_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER),                  \
 		.height = DT_PROP(node_id, height),                                                \
 		.width = DT_PROP(node_id, width),                                                  \
 		.oscillator_freq = DT_PROP(node_id, oscillator_freq),                              \

--- a/drivers/display/display_ssd1320.c
+++ b/drivers/display/display_ssd1320.c
@@ -522,7 +522,7 @@ static DEVICE_API(display, ssd1320_driver_api) = {
 	static const struct ssd1320_config config##node_id = {                                     \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(node_id)),                                     \
 		.dbi_config = MIPI_DBI_CONFIG_DT(                                                  \
-			node_id, SSD1320_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER, 0),              \
+			node_id, SSD1320_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER),                 \
 		.height = DT_PROP(node_id, height),                                                \
 		.width = DT_PROP(node_id, width),                                                  \
 		.oscillator_freq = DT_PROP(node_id, oscillator_freq),                              \

--- a/drivers/display/display_ssd1331.c
+++ b/drivers/display/display_ssd1331.c
@@ -348,7 +348,7 @@ static DEVICE_API(display, ssd1331_driver_api) = {
 	static const struct ssd1331_config config##node_id = {                                     \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(node_id)),                                     \
 		.dbi_config = MIPI_DBI_CONFIG_DT(                                                  \
-			node_id, SSD1331_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER, 0),              \
+			node_id, SSD1331_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER),                 \
 		.height = DT_PROP(node_id, height),                                                \
 		.width = DT_PROP(node_id, width),                                                  \
 		.display_offset = DT_PROP(node_id, display_offset),                                \

--- a/drivers/display/display_ssd135x.c
+++ b/drivers/display/display_ssd135x.c
@@ -335,7 +335,7 @@ static DEVICE_API(display, ssd135x_driver_api) = {
 	static const struct ssd135x_config config##node_id = {                                     \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(node_id)),                                     \
 		.dbi_config = MIPI_DBI_CONFIG_DT(                                                  \
-			node_id, SSD135X_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER, 0),              \
+			node_id, SSD135X_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER),                 \
 		.height = DT_PROP(node_id, height),                                                \
 		.width = DT_PROP(node_id, width),                                                  \
 		.display_offset = DT_PROP(node_id, display_offset),                                \

--- a/drivers/display/display_ssd1363.c
+++ b/drivers/display/display_ssd1363.c
@@ -508,7 +508,7 @@ static DEVICE_API(display, ssd1363_driver_api) = {
 	static const struct ssd1363_config config##node_id = {                                     \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(node_id)),                                     \
 		.dbi_config = MIPI_DBI_CONFIG_DT(                                                  \
-			node_id, SSD1363_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER, 0),              \
+			node_id, SSD1363_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER),                 \
 		.height = DT_PROP(node_id, height),                                                \
 		.width = DT_PROP(node_id, width),                                                  \
 		.oscillator_freq = DT_PROP(node_id, oscillator_freq),                              \

--- a/drivers/display/display_st730x.c
+++ b/drivers/display/display_st730x.c
@@ -542,7 +542,7 @@ static const struct st730x_specific st7306_specifics = {
 	static const struct st730x_config config##node_id = {                                      \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(node_id)),                                     \
 		.dbi_config = MIPI_DBI_CONFIG_DT(                                                  \
-			node_id, ST730X_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER, 0),               \
+			node_id, ST730X_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER),                  \
 		.height = DT_PROP(node_id, height),                                                \
 		.width = DT_PROP(node_id, width),                                                  \
 		.start_line = DT_PROP(node_id, start_line),                                        \

--- a/drivers/display/display_st75256.c
+++ b/drivers/display/display_st75256.c
@@ -597,7 +597,7 @@ static DEVICE_API(display, st75256_driver_api) = {
 		.inversion_on = DT_PROP(node_id, inversion_on),                                    \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(node_id)),                                     \
 		.dbi_config = MIPI_DBI_CONFIG_DT(                                                  \
-			node_id, ST75256_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER, 0),              \
+			node_id, ST75256_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER),                 \
 		.conversion_buf = conversion_buf##node_id,                                         \
 		.conversion_buf_size = sizeof(conversion_buf##node_id),                            \
 	};                                                                                         \

--- a/drivers/display/display_st7567.c
+++ b/drivers/display/display_st7567.c
@@ -532,7 +532,7 @@ static DEVICE_API(display, st7567_driver_api) = {
 
 #define ST7567_CONFIG_DBI(node_id)                                                                 \
 	.bus = {.dbi.dbi_config = MIPI_DBI_CONFIG_DT(                                              \
-			node_id, ST7567_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER, 0),               \
+			node_id, ST7567_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER),                  \
 		.dbi.mipi_dev = DEVICE_DT_GET(DT_PARENT(node_id)),},                               \
 	.bus_ready = st7567_bus_ready_dbi,                                                         \
 	.write_cmd_bus = st7567_write_cmd_bus_dbi, .write_pixels_bus = st7567_write_pixels_bus_dbi,\

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -497,7 +497,7 @@ static DEVICE_API(display, st7735r_api) = {
 				((DT_INST_STRING_UPPER_TOKEN(inst, mipi_mode) == \
 				 MIPI_DBI_MODE_SPI_4WIRE) ? SPI_WORD_SET(8) :	\
 				 SPI_WORD_SET(9)) |				\
-				SPI_HOLD_ON_CS | SPI_LOCK_ON, 0),		\
+				SPI_HOLD_ON_CS | SPI_LOCK_ON),			\
 		.width = DT_INST_PROP(inst, width),				\
 		.height = DT_INST_PROP(inst, height),				\
 		.madctl = DT_INST_PROP(inst, madctl),				\

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -478,7 +478,7 @@ static DEVICE_API(display, st7789v_api) = {
 		.mipi_dbi = DEVICE_DT_GET(DT_INST_PARENT(inst)),                        \
 		.dbi_config = MIPI_DBI_CONFIG_DT_INST(inst,                             \
 						      ST7789V_WORD_SIZE(inst) |         \
-						      SPI_OP_MODE_MASTER, 0),           \
+						      SPI_OP_MODE_MASTER),              \
 		.vcom = DT_INST_PROP(inst, vcom),					\
 		.gctrl = DT_INST_PROP(inst, gctrl),					\
 		.vdv_vrh_enable = (DT_INST_NODE_HAS_PROP(inst, vrhs)			\

--- a/drivers/display/display_st7796s.c
+++ b/drivers/display/display_st7796s.c
@@ -377,8 +377,7 @@ static DEVICE_API(display, st7796s_api) = {
 			.config = MIPI_DBI_SPI_CONFIG_DT(			\
 						DT_DRV_INST(n),			\
 						SPI_OP_MODE_MASTER |		\
-						SPI_WORD_SET(8),		\
-						0),				\
+						SPI_WORD_SET(8)),		\
 			.mode = DT_INST_STRING_UPPER_TOKEN_OR(n, mipi_mode,     \
 						MIPI_DBI_MODE_SPI_4WIRE),	\
 		},								\

--- a/drivers/display/ssd1322.c
+++ b/drivers/display/ssd1322.c
@@ -518,7 +518,7 @@ static DEVICE_API(display, ssd1322_driver_api) = {
 		.color_inversion = DT_PROP(node_id, inversion_on),                                 \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(node_id)),                                     \
 		.dbi_config = MIPI_DBI_CONFIG_DT(                                                  \
-			node_id, SSD1322_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER, 0),              \
+			node_id, SSD1322_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER),                 \
 		.conversion_buf = conversion_buf##node_id,                                         \
 		.conversion_buf_size = sizeof(conversion_buf##node_id),                            \
 	};                                                                                         \

--- a/drivers/display/ssd1327.c
+++ b/drivers/display/ssd1327.c
@@ -504,7 +504,7 @@ static DEVICE_API(display, ssd1327_driver_api) = {
 	static const struct ssd1327_config config##node_id = {                                     \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(node_id)),                                     \
 		.dbi_config = MIPI_DBI_CONFIG_DT(                                                  \
-			node_id, SSD1327_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER, 0),              \
+			node_id, SSD1327_WORD_SIZE(node_id) | SPI_OP_MODE_MASTER),                 \
 		.height = DT_PROP(node_id, height),                                                \
 		.width = DT_PROP(node_id, width),                                                  \
 		.oscillator_freq = DT_PROP(node_id, oscillator_freq),                              \

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -1065,7 +1065,7 @@ static struct ssd16xx_quirks quirks_solomon_ssd1681 = {
 			.mode = MIPI_DBI_MODE_SPI_4WIRE,                \
 			.config = MIPI_DBI_SPI_CONFIG_DT(n,             \
 				SPI_OP_MODE_MASTER | SPI_WORD_SET(8) |  \
-				SPI_HOLD_ON_CS | SPI_LOCK_ON, 0),       \
+				SPI_HOLD_ON_CS | SPI_LOCK_ON),          \
 		},                                                      \
 		.busy_gpio = GPIO_DT_SPEC_GET(n, busy_gpios),		\
 		.quirks = quirks_ptr,					\

--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -879,8 +879,7 @@ static DEVICE_API(display, uc81xx_driver_api) = {
 			.mode = MIPI_DBI_MODE_SPI_4WIRE,                \
 			.config = MIPI_DBI_SPI_CONFIG_DT(n,             \
 					SPI_OP_MODE_MASTER |            \
-					SPI_LOCK_ON | SPI_WORD_SET(8),  \
-					0),                             \
+					SPI_LOCK_ON | SPI_WORD_SET(8)), \
 		},                                                      \
 		.busy_gpio = GPIO_DT_SPEC_GET(n, busy_gpios),		\
 									\

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -26,7 +26,7 @@
  * @brief Interfaces for MIPI-DBI (Display Bus Interface).
  * @defgroup mipi_dbi_interface MIPI-DBI
  * @since 3.6
- * @version 0.8.0
+ * @version 0.9.0
  * @ingroup display_interface
  * @{
  */
@@ -49,10 +49,8 @@ extern "C" {
  * @param node_id Devicetree node identifier for the MIPI DBI device whose
  *                struct spi_config to create an initializer for
  * @param operation_ the desired operation field in the struct spi_config
- * @param delay_ the desired delay field in the struct spi_config's
- *               spi_cs_control, if there is one
  */
-#define MIPI_DBI_SPI_CONFIG_DT(node_id, operation_, delay_)		\
+#define MIPI_DBI_SPI_CONFIG_DT(node_id, operation_)			\
 	{								\
 		.frequency = DT_PROP(node_id, mipi_max_frequency),	\
 		.operation = (operation_) |				\
@@ -61,12 +59,7 @@ extern "C" {
 			COND_CODE_1(DT_PROP(node_id, mipi_cpha), SPI_MODE_CPHA, (0)) |	\
 			COND_CODE_1(DT_PROP(node_id, mipi_hold_cs), SPI_HOLD_ON_CS, (0)),	\
 		.slave = DT_REG_ADDR(node_id),				\
-		.cs = {							\
-			COND_CODE_1(DT_SPI_DEV_HAS_CS_GPIOS(node_id),	\
-			(SPI_CS_CONTROL_INIT_GPIO(node_id, _delay)),	\
-			(SPI_CS_CONTROL_INIT_NATIVE(node_id)))		\
-			.cs_is_gpio = DT_SPI_DEV_HAS_CS_GPIOS(node_id),	\
-		},							\
+		.cs = SPI_CS_CONTROL_INIT(node_id),			\
 	}
 
 /**
@@ -76,11 +69,9 @@ extern "C" {
  * instance. It is equivalent to MIPI_DBI_SPI_CONFIG_DT(DT_DRV_INST(inst))
  * @param inst Instance number to initialize configuration from
  * @param operation_ the desired operation field in the struct spi_config
- * @param delay_ the desired delay field in the struct spi_config's
- *               spi_cs_control, if there is one
  */
-#define MIPI_DBI_SPI_CONFIG_DT_INST(inst, operation_, delay_)		\
-	MIPI_DBI_SPI_CONFIG_DT(DT_DRV_INST(inst), operation_, delay_)
+#define MIPI_DBI_SPI_CONFIG_DT_INST(inst, operation_)			\
+	MIPI_DBI_SPI_CONFIG_DT(DT_DRV_INST(inst), operation_)
 
 /**
  * @brief Initialize a MIPI DBI configuration from devicetree
@@ -91,26 +82,22 @@ extern "C" {
  * @param node_id Devicetree node identifier for the MIPI DBI device to
  *                initialize
  * @param operation_ the desired operation field in the struct spi_config
- * @param delay_ the desired delay field in the struct spi_config's
- *               spi_cs_control, if there is one
  */
-#define MIPI_DBI_CONFIG_DT(node_id, operation_, delay_)			\
+#define MIPI_DBI_CONFIG_DT(node_id, operation_)				\
 	{								\
 		.mode = DT_STRING_UPPER_TOKEN(node_id, mipi_mode),	\
-		.config = MIPI_DBI_SPI_CONFIG_DT(node_id, operation_, delay_), \
+		.config = MIPI_DBI_SPI_CONFIG_DT(node_id, operation_),	\
 	}
 
 /**
  * @brief Initialize a MIPI DBI configuration from device instance
  *
- * Equivalent to MIPI_DBI_CONFIG_DT(DT_DRV_INST(inst), operation_, delay_)
+ * Equivalent to MIPI_DBI_CONFIG_DT(DT_DRV_INST(inst), operation_)
  * @param inst Instance of the device to initialize a MIPI DBI configuration for
  * @param operation_ the desired operation field in the struct spi_config
- * @param delay_ the desired delay field in the struct spi_config's
- *               spi_cs_control, if there is one
  */
-#define MIPI_DBI_CONFIG_DT_INST(inst, operation_, delay_)		\
-	MIPI_DBI_CONFIG_DT(DT_DRV_INST(inst), operation_, delay_)
+#define MIPI_DBI_CONFIG_DT_INST(inst, operation_)			\
+	MIPI_DBI_CONFIG_DT(DT_DRV_INST(inst), operation_)
 
 /**
  * @brief Get the MIPI DBI TE mode from devicetree


### PR DESCRIPTION
Remove the delay parameter from the MIPI_DBI_SPI_CONFIG macros and use the SPI_CS_CONTROL_INIT macro to create the SPI CS, which will pull the values for delay from the devicetree

See RFC https://github.com/zephyrproject-rtos/zephyr/issues/97348