### PR TITLE
nxp: usb: zephyr support on imx93 frdm Cortex-A Core

### DIFF
--- a/boards/nxp/frdm_imx93/Kconfig.defconfig
+++ b/boards/nxp/frdm_imx93/Kconfig.defconfig
@@ -42,6 +42,9 @@ configdefault NET_MGMT_EVENT_STACK_SIZE
 configdefault NET_SOCKETS_SERVICE_STACK_SIZE
 	default 8192
 
+configdefault UDC_WORKQUEUE_STACK_SIZE
+	default 4096
+
 endif # BOARD_FRDM_IMX93_MIMX9352_A55
 
 if IMX_USDHC

--- a/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.dts
+++ b/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.dts
@@ -227,3 +227,7 @@
 };
 
 display_i2c: &lpi2c1 {};
+
+zephyr_udc0: &usb1 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.yaml
+++ b/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.yaml
@@ -21,6 +21,7 @@ supported:
   - can
   - net
   - watchdog
+  - usbd
 testing:
   ignore_tags:
     - bluetooth

--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -454,6 +454,12 @@ static int CCM_SET_FUNC_ATTR mcux_ccm_set_subsys_rate(const struct device *dev,
 		return 0;
 #endif
 
+#if defined(CONFIG_UDC_NXP_EHCI) && defined(CONFIG_SOC_MIMX9352_A55)
+	case IMX_CCM_USB_CLK:
+	case IMX_CCM_USB_PHY_CLK:
+		return common_clock_set_freq(clock_name, (uint32_t)clock_rate);
+#endif
+
 	default:
 		/* Silence unused variable warning */
 		ARG_UNUSED(clock_rate);

--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -36,6 +36,10 @@ LOG_MODULE_REGISTER(udc_mcux, CONFIG_UDC_DRIVER_LOG_LEVEL);
 
 #define PRV_DATA_HANDLE(_handle) CONTAINER_OF(_handle, struct udc_mcux_data, mcux_device)
 
+/* Required by DEVICE_MMIO_NAMED_* macros */
+#define DEV_CFG(_dev) ((const struct udc_mcux_config *)(_dev)->config)
+#define DEV_DATA(_dev) ((struct udc_mcux_data *)(udc_get_private(_dev)))
+
 struct udc_mcux_config {
 	const usb_device_controller_interface_struct_t *mcux_if;
 	void (*irq_enable_func)(const struct device *dev);
@@ -43,7 +47,7 @@ struct udc_mcux_config {
 	size_t num_of_eps;
 	struct udc_ep_config *ep_cfg_in;
 	struct udc_ep_config *ep_cfg_out;
-	uintptr_t base;
+	DEVICE_MMIO_NAMED_ROM(reg_base);
 	const struct pinctrl_dev_config *pincfg;
 	usb_phy_config_struct_t *phy_config;
 	const struct device *clock_dev;
@@ -55,6 +59,7 @@ struct udc_mcux_config {
 };
 
 struct udc_mcux_data {
+	DEVICE_MMIO_NAMED_RAM(reg_base);
 	const struct device *dev;
 	usb_device_struct_t mcux_device;
 	struct k_work work;
@@ -698,10 +703,13 @@ static int udc_mcux_init(const struct device *dev)
 	const usb_device_controller_interface_struct_t *mcux_if = config->mcux_if;
 	struct udc_mcux_data *priv = udc_get_private(dev);
 	usb_status_t status;
+	uintptr_t base;
 
 	if (priv->controller_id == 0xFFu) {
 		return -ENOMEM;
 	}
+
+	base = (uintptr_t)DEVICE_MMIO_NAMED_GET(dev, reg_base);
 
 #ifdef CONFIG_DT_HAS_NXP_USBPHY_ENABLED
 	if (config->phy_config != NULL) {
@@ -717,7 +725,7 @@ static int udc_mcux_init(const struct device *dev)
 	}
 
 	if (!IS_ENABLED(CONFIG_UDC_DRIVER_HIGH_SPEED_SUPPORT_ENABLED)) {
-		USBHS_Type *usbBase = (USBHS_Type *)config->base;
+		USBHS_Type *usbBase = (USBHS_Type *)base;
 
 		usbBase->PORTSC1 |= USBHS_PORTSC1_PFSC_MASK;
 	}
@@ -725,7 +733,7 @@ static int udc_mcux_init(const struct device *dev)
 	/* enable USB interrupt */
 	config->irq_enable_func(dev);
 
-	LOG_DBG("Initialized USB controller %x", (uint32_t)config->base);
+	LOG_DBG("Initialized USB controller %x", (uint32_t)base);
 
 	return 0;
 }
@@ -749,9 +757,14 @@ static int udc_mcux_shutdown(const struct device *dev)
 	return 0;
 }
 
-static inline void udc_mcux_get_hal_driver_id(struct udc_mcux_data *priv,
-			const struct udc_mcux_config *config)
+static inline void udc_mcux_get_hal_driver_id(const struct device *dev)
 {
+	struct udc_data *data = dev->data;
+	struct udc_mcux_data *priv = data->priv;
+	uintptr_t base;
+
+	base = (uintptr_t)DEVICE_MMIO_NAMED_GET(dev, reg_base);
+
 	/*
 	 * MCUX USB controller drivers use an ID to tell the HAL drivers
 	 * which controller is being used. This part of the code converts
@@ -766,7 +779,7 @@ static inline void udc_mcux_get_hal_driver_id(struct udc_mcux_data *priv,
 	/* get the right controller id */
 	priv->controller_id = 0xFFu; /* invalid value */
 	for (uint8_t i = 0; i < ARRAY_SIZE(usb_base_addrs); i++) {
-		if (usb_base_addrs[i] == config->base) {
+		if (usb_base_addrs[i] == base) {
 			priv->controller_id = kUSB_ControllerEhci0 + i;
 			break;
 		}
@@ -780,7 +793,9 @@ static int udc_mcux_driver_preinit(const struct device *dev)
 	struct udc_mcux_data *priv = data->priv;
 	int err;
 
-	udc_mcux_get_hal_driver_id(priv, config);
+	DEVICE_MMIO_NAMED_MAP(dev, reg_base, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
+
+	udc_mcux_get_hal_driver_id(dev);
 	if (priv->controller_id == 0xFFu) {
 		return -ENOMEM;
 	}
@@ -950,7 +965,7 @@ static usb_phy_config_struct_t phy_config_##n = {					\
 	PINCTRL_DT_INST_DEFINE(n);							\
 											\
 	static struct udc_mcux_config priv_config_##n = {				\
-		.base = DT_INST_REG_ADDR(n),						\
+		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)),			\
 		.irq_enable_func = udc_irq_enable_func##n,				\
 		.irq_disable_func = udc_irq_disable_func##n,				\
 		.num_of_eps = DT_INST_PROP(n, num_bidir_endpoints),			\

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -617,6 +617,32 @@
 		prescaler = <1>;
 		status = "disabled";
 	};
+
+	usb1: usbd@4c100000 {
+		compatible = "nxp,ehci";
+		reg = <0x4c100000 DT_SIZE_K(4)>;
+		interrupts = <GIC_SPI 187 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "usb_0";
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_USB_CLK 2 3>,
+			 <&ccm IMX_CCM_USB_PHY_CLK 2 8>;
+		clock-rates = <134000000 50000000>;
+		num-bidir-endpoints = <8>;
+		status = "disabled";
+	};
+
+	usb2: usbd@4c200000 {
+		compatible = "nxp,ehci";
+		reg = <0x4c200000 DT_SIZE_K(4)>;
+		interrupts = <GIC_SPI 188 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "usb_1";
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_USB_CLK 2 3>,
+			 <&ccm IMX_CCM_USB_PHY_CLK 2 8>;
+		clock-rates = <134000000 50000000>;
+		num-bidir-endpoints = <8>;
+		status = "disabled";
+	};
 };
 
 &gpio1 {

--- a/dts/bindings/usb/nxp,ehci.yaml
+++ b/dts/bindings/usb/nxp,ehci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 NXP
+# Copyright 2023,2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP EHCI USB device mode
@@ -10,3 +10,8 @@ include: "nxp,mcux-usbd.yaml"
 properties:
   phy-handle:
     type: phandle
+
+  clock-rates:
+    type: array
+    description: |
+      Optional rate given to each clock provider in the "clocks" property.

--- a/include/zephyr/dt-bindings/clock/imx_ccm_rev2.h
+++ b/include/zephyr/dt-bindings/clock/imx_ccm_rev2.h
@@ -159,6 +159,10 @@
 /* KPP */
 #define IMX_CCM_KPP_CLK                0x2400UL
 
+/* USB */
+#define IMX_CCM_USB_CLK                0x2500UL
+#define IMX_CCM_USB_PHY_CLK            0x2600UL
+
 /* QTMR */
 #define IMX_CCM_QTMR_CLK               0x6000UL
 #define IMX_CCM_QTMR1_CLK              0x6000UL

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/middleware.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/middleware.cmake
@@ -13,7 +13,7 @@ if(CONFIG_USB_DEVICE_DRIVER)
   set_variable_ifdef(CONFIG_USB_DC_NXP_LPCIP3511 CONFIG_MCUX_COMPONENT_middleware.usb.device.ip3511fs)
 
   # For soc.c build pass
-  zephyr_include_directories(.)
+  zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR})
   zephyr_include_directories(${MCUX_SDK_NG_DIR}/middleware/usb/device)
   zephyr_include_directories(${MCUX_SDK_NG_DIR}/middleware/usb/phy)
   zephyr_include_directories(${MCUX_SDK_NG_DIR}/middleware/usb/include)
@@ -30,7 +30,7 @@ if(CONFIG_UDC_DRIVER)
   set_variable_ifdef(CONFIG_UDC_NXP_IP3511 CONFIG_MCUX_COMPONENT_middleware.usb.device.ip3511fs)
 
   # For soc.c build pass
-  zephyr_include_directories(.)
+  zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR})
   zephyr_include_directories(${MCUX_SDK_NG_DIR}/middleware/usb/device)
   zephyr_include_directories(${MCUX_SDK_NG_DIR}/middleware/usb/phy)
   zephyr_include_directories(${MCUX_SDK_NG_DIR}/middleware/usb/include)
@@ -47,7 +47,7 @@ if(CONFIG_UHC_DRIVER)
   set_variable_ifdef(CONFIG_UHC_NXP_OHCI CONFIG_MCUX_COMPONENT_middleware.usb.host.ohci)
   set_variable_ifdef(CONFIG_UHC_NXP_IP3516HS CONFIG_MCUX_COMPONENT_middleware.usb.host.ip3516hs)
   # For soc.c build pass
-  zephyr_include_directories(.)
+  zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR})
   zephyr_include_directories(${MCUX_SDK_NG_DIR}/middleware/usb/phy)
   zephyr_include_directories(${MCUX_SDK_NG_DIR}/middleware/usb/include)
 endif()


### PR DESCRIPTION
nxp: add usb support on frdm-imx93

Depends on https://github.com/zephyrproject-rtos/hal_nxp/pull/615 (has been merged)