### PR TITLE
tests: Bluetooth: BR: fix import error in SMP test suite.

### DIFF
--- a/tests/bluetooth/classic/smp_io_cap/pytest/test_smp.py
+++ b/tests/bluetooth/classic/smp_io_cap/pytest/test_smp.py
@@ -19,10 +19,6 @@ from bumble.device import (
     with_connection_from_address,
 )
 from bumble.hci import (
-    HCI_DISPLAY_ONLY_IO_CAPABILITY,
-    HCI_DISPLAY_YES_NO_IO_CAPABILITY,
-    HCI_KEYBOARD_ONLY_IO_CAPABILITY,
-    HCI_NO_INPUT_NO_OUTPUT_IO_CAPABILITY,
     HCI_REMOTE_USER_TERMINATED_CONNECTION_ERROR,
     Address,
     HCI_User_Confirmation_Request_Negative_Reply_Command,
@@ -201,29 +197,29 @@ class SmpDevice(Device):
 
         # See Bluetooth spec @ Vol 3, Part C 5.2.2.6
         methods = {
-            HCI_DISPLAY_ONLY_IO_CAPABILITY: {
-                HCI_DISPLAY_ONLY_IO_CAPABILITY: display_auto_confirm,
-                HCI_DISPLAY_YES_NO_IO_CAPABILITY: display_confirm,
-                HCI_KEYBOARD_ONLY_IO_CAPABILITY: na,
-                HCI_NO_INPUT_NO_OUTPUT_IO_CAPABILITY: auto_confirm,
+            SMP_DISPLAY_ONLY_IO_CAPABILITY: {
+                SMP_DISPLAY_ONLY_IO_CAPABILITY: display_auto_confirm,
+                SMP_DISPLAY_YES_NO_IO_CAPABILITY: display_confirm,
+                SMP_KEYBOARD_ONLY_IO_CAPABILITY: na,
+                SMP_NO_INPUT_NO_OUTPUT_IO_CAPABILITY: auto_confirm,
             },
-            HCI_DISPLAY_YES_NO_IO_CAPABILITY: {
-                HCI_DISPLAY_ONLY_IO_CAPABILITY: display_auto_confirm,
-                HCI_DISPLAY_YES_NO_IO_CAPABILITY: display_confirm,
-                HCI_KEYBOARD_ONLY_IO_CAPABILITY: na,
-                HCI_NO_INPUT_NO_OUTPUT_IO_CAPABILITY: auto_confirm,
+            SMP_DISPLAY_YES_NO_IO_CAPABILITY: {
+                SMP_DISPLAY_ONLY_IO_CAPABILITY: display_auto_confirm,
+                SMP_DISPLAY_YES_NO_IO_CAPABILITY: display_confirm,
+                SMP_KEYBOARD_ONLY_IO_CAPABILITY: na,
+                SMP_NO_INPUT_NO_OUTPUT_IO_CAPABILITY: auto_confirm,
             },
-            HCI_KEYBOARD_ONLY_IO_CAPABILITY: {
-                HCI_DISPLAY_ONLY_IO_CAPABILITY: na,
-                HCI_DISPLAY_YES_NO_IO_CAPABILITY: auto_confirm,
-                HCI_KEYBOARD_ONLY_IO_CAPABILITY: na,
-                HCI_NO_INPUT_NO_OUTPUT_IO_CAPABILITY: auto_confirm,
+            SMP_KEYBOARD_ONLY_IO_CAPABILITY: {
+                SMP_DISPLAY_ONLY_IO_CAPABILITY: na,
+                SMP_DISPLAY_YES_NO_IO_CAPABILITY: auto_confirm,
+                SMP_KEYBOARD_ONLY_IO_CAPABILITY: na,
+                SMP_NO_INPUT_NO_OUTPUT_IO_CAPABILITY: auto_confirm,
             },
-            HCI_NO_INPUT_NO_OUTPUT_IO_CAPABILITY: {
-                HCI_DISPLAY_ONLY_IO_CAPABILITY: confirm,
-                HCI_DISPLAY_YES_NO_IO_CAPABILITY: confirm,
-                HCI_KEYBOARD_ONLY_IO_CAPABILITY: auto_confirm,
-                HCI_NO_INPUT_NO_OUTPUT_IO_CAPABILITY: auto_confirm,
+            SMP_NO_INPUT_NO_OUTPUT_IO_CAPABILITY: {
+                SMP_DISPLAY_ONLY_IO_CAPABILITY: confirm,
+                SMP_DISPLAY_YES_NO_IO_CAPABILITY: confirm,
+                SMP_KEYBOARD_ONLY_IO_CAPABILITY: auto_confirm,
+                SMP_NO_INPUT_NO_OUTPUT_IO_CAPABILITY: auto_confirm,
             },
         }
 


### PR DESCRIPTION
Fix import error in smp_io_cap test suite because HCI_XXX_IO_CAPABILITY is removed from bumble v0.0.214.