### PR TITLE
samples: video: avoid K_FOREVER wait on initial buffer allocation

### DIFF
--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -288,7 +288,7 @@ int main(void)
 		 * buffer alignment is needed in order to achieve the best performance
 		 */
 		vbuf = video_buffer_aligned_alloc(fmt.size, CONFIG_VIDEO_BUFFER_POOL_ALIGN,
-							K_FOREVER);
+							K_NO_WAIT);
 		if (vbuf == NULL) {
 			LOG_ERR("Unable to alloc video buffer");
 			return 0;

--- a/samples/drivers/video/capture_to_lvgl/src/main.c
+++ b/samples/drivers/video/capture_to_lvgl/src/main.c
@@ -133,7 +133,7 @@ int main(void)
 	/* Alloc video buffers and enqueue for capture */
 	for (i = 0; i < ARRAY_SIZE(buffers); i++) {
 		buffers[i] = video_buffer_aligned_alloc(fmt.size, CONFIG_VIDEO_BUFFER_POOL_ALIGN,
-							K_FOREVER);
+							K_NO_WAIT);
 		if (buffers[i] == NULL) {
 			LOG_ERR("Unable to alloc video buffer");
 			return 0;

--- a/samples/drivers/video/tcpserversink/src/main.c
+++ b/samples/drivers/video/tcpserversink/src/main.c
@@ -124,7 +124,7 @@ int configure_encoder(void)
 		return -1;
 	}
 
-	buffer = video_buffer_aligned_alloc(size, CONFIG_VIDEO_BUFFER_POOL_ALIGN, K_FOREVER);
+	buffer = video_buffer_aligned_alloc(size, CONFIG_VIDEO_BUFFER_POOL_ALIGN, K_NO_WAIT);
 	if (buffer == NULL) {
 		LOG_ERR("Unable to alloc compressed video buffer size=%d", size);
 		return -1;
@@ -393,7 +393,7 @@ int main(void)
 		 * buffer alignment is needed in order to achieve the best performance
 		 */
 		buffers[i] = video_buffer_aligned_alloc(fmt.size, CONFIG_VIDEO_BUFFER_POOL_ALIGN,
-							K_FOREVER);
+							K_NO_WAIT);
 		if (buffers[i] == NULL) {
 			LOG_ERR("Unable to alloc video buffer");
 			return 0;


### PR DESCRIPTION
On samples startup, video buffers are being allocated in order to hold the captured data. Currently the timeout is set to K_FOREVER, leading to having those samples waiting forever if there isn't enought memory available on the platform.
Considering that this is done at beginning of the sample and at that moment there isn't reason to having to wait for the availability of memory, the timeout is replaced by K_NO_WAIT which will allow to have the function returning with an error if the allocation is failing.