### PR TITLE
drivers: sensor: ti: allow setting a variable SPI_WORD_SIZE

### DIFF
--- a/drivers/sensor/ti/tmag5170/Kconfig
+++ b/drivers/sensor/ti/tmag5170/Kconfig
@@ -1,6 +1,7 @@
 # Texas Instruments TMAG5170 high-precision, linear 3D Hall-effect sensor with SPI bus interface
 
 # Copyright (c) 2023 Michal Morsisko
+# Copyright (c) 2025 Christoph Jans
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig TMAG5170
@@ -47,6 +48,12 @@ config TMAG5170_CRC
 	select CRC
 	help
 	  Verify CRC of RX data and append CRC to TX data
+
+config TMAG5170_SPI_WORD_SIZE
+	int "SPI word size"
+	default 32
+	help
+	  Set the SPI word size to one of the supported values (8, 16, 32).
 
 config TMAG5170_TRIGGER
 	bool

--- a/drivers/sensor/ti/tmag5170/tmag5170.c
+++ b/drivers/sensor/ti/tmag5170/tmag5170.c
@@ -555,7 +555,7 @@ static int tmag5170_init(const struct device *dev)
 		.bus = SPI_DT_SPEC_INST_GET(_num,					   \
 					   SPI_OP_MODE_MASTER |				   \
 					   SPI_TRANSFER_MSB |				   \
-					   SPI_WORD_SET(32)),				   \
+					   SPI_WORD_SET(CONFIG_TMAG5170_SPI_WORD_SIZE)),   \
 		.magnetic_channels = DT_INST_ENUM_IDX(_num, magnetic_channels),		   \
 		.x_range = DT_INST_ENUM_IDX(_num, x_range),				   \
 		.y_range = DT_INST_ENUM_IDX(_num, y_range),				   \


### PR DESCRIPTION
Allowing to "freely" specify the SPI WORD SIZE allows to use this driver implementation with a nucleo_u5a5zj_q and other stm32 boards as stm32 does not support WORD SIZE other than 8/16 (see #95035)

in `drivers/spi/spi_ll_stm32.c`, we have

```
if ((SPI_WORD_SIZE_GET(config->operation) != 8)
	  && (SPI_WORD_SIZE_GET(config->operation) != 16)) {
return -ENOTSUP;
}
```