### PR TITLE
modem: cmux: Define macros for header size

### DIFF
--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -57,8 +57,15 @@ typedef void (*modem_cmux_callback)(struct modem_cmux *cmux, enum modem_cmux_eve
  * @cond INTERNAL_HIDDEN
  */
 
+#if CONFIG_MODEM_CMUX_MTU > 127
+#define MODEM_CMUX_HEADER_SIZE			7
+#else
+#define MODEM_CMUX_HEADER_SIZE			6
+#endif
+
+
 /* Total size of the CMUX work buffers */
-#define MODEM_CMUX_WORK_BUFFER_SIZE (CONFIG_MODEM_CMUX_MTU + 7 + \
+#define MODEM_CMUX_WORK_BUFFER_SIZE (CONFIG_MODEM_CMUX_MTU + MODEM_CMUX_HEADER_SIZE + \
 				     CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE_EXTRA)
 
 enum modem_cmux_state {


### PR DESCRIPTION
Define CMUX_HEADER_SIZE macro that is 6 or 7 bytes depending on
MTU.

Remove the previous CMUX_FRAME_SIZE_MAX that was a bit misleading
as it meant only the header size without data and was fixed to 7 bytes.

Redefine new macros CMUX_FRAME_SIZE_MAX and CMUX_FRAME_SIZE_MIN which
are actually frame sizes with data included.