### PR TITLE
jwt: deprecate CONFIG_JWT_SIGN_RSA_LEGACY

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -88,6 +88,9 @@ Deprecated APIs and options
 * :c:func:`bt_ctlr_set_public_addr` is deprecated in favor of using
   :c:struct:`bt_hci_cp_vs_write_bd_addr` for setting the public Bluetooth device address.
 
+* :kconfig:option:`CONFIG_JWT_SIGN_RSA_LEGACY` is deprecated. Please switch to the
+  PSA Crypto API based alternative (i.e. :kconfig:option:`CONIFG_JWT_SIGN_RSA_PSA`).
+
 New APIs and options
 ====================
 

--- a/subsys/jwt/Kconfig
+++ b/subsys/jwt/Kconfig
@@ -17,8 +17,9 @@ choice
 	  Select which algorithm to use for signing JWT tokens.
 
 config JWT_SIGN_RSA_LEGACY
-	bool "Use RSA signature (RS-256). Use Mbed TLS as crypto library."
+	bool "Use RSA signature (RS-256). Use Mbed TLS as crypto library [DEPRECATED]"
 	depends on CSPRNG_AVAILABLE
+	select DEPRECATED
 	select MBEDTLS
 	select MBEDTLS_MD
 	select MBEDTLS_RSA_C


### PR DESCRIPTION
The long term goal is not to use legacy Mbed TLS RSA support, but to rely only on PSA API. This commits updates the JWT subsystem and related tests.