### PR TITLE
drivers: serial: Fix deadlock in virtio console

### DIFF
--- a/drivers/serial/Kconfig.virtio_console
+++ b/drivers/serial/Kconfig.virtio_console
@@ -17,14 +17,6 @@ config UART_VIRTIO_CONSOLE_TX_BUFSIZE
 	int "VIRTIO console transmit buffer length"
 	default 2
 
-config UART_VIRTIO_CONSOLE_RX_CONTROL_BUFSIZE
-	int "VIRTIO console receive buffer length (for control messages)"
-	default 8
-
-config UART_VIRTIO_CONSOLE_TX_CONTROL_BUFSIZE
-	int "VIRTIO console transmit buffer length (for control messages)"
-	default 8
-
 config UART_VIRTIO_CONSOLE_F_MULTIPORT
 	bool "Support multiple VIRTIO console ports"
 	default n
@@ -33,8 +25,33 @@ config UART_VIRTIO_CONSOLE_F_MULTIPORT
 	  (up to 31 in the case of QEMU). Select to enable this feature. Otherwise
 	  only one will be used.
 
+if UART_VIRTIO_CONSOLE_F_MULTIPORT
+
+config UART_VIRTIO_CONSOLE_RX_CONTROL_BUFSIZE
+	int "VIRTIO console receive buffer length (for control messages)"
+	default 16
+	help
+	  This will set the size of the control receive buffer and its corresponding
+	  virtqueue. Keep in mind that control messages are sent in quick succession
+	  and thus some may never be received if this value is too low. Try increasing
+	  this value if you're experiencing issues with the multiport feature.
+
+config UART_VIRTIO_CONSOLE_TX_CONTROL_BUFSIZE
+	int "VIRTIO console transmit buffer length (for control messages)"
+	default 8
+	help
+	  This will set the size of the control transmit buffer and its corresponding
+	  virtqueue. Keep in mind that control messages are sent in quick succession
+	  and this buffer may fill up fast if this value is too low. Try increasing
+	  this value if you're experiencing issues with the multiport feature.
+
+endif
+
 config UART_VIRTIO_CONSOLE_NAME_BUFSIZE
 	int "VIRTIO console maximum port name length"
+	default 0 if UART_LOG_LEVEL < 3
 	default 16
+	help
+	  Ports can be assigned human-readable names, which are then printed in logs.
 
 endif

--- a/drivers/serial/uart_virtio_console.c
+++ b/drivers/serial/uart_virtio_console.c
@@ -140,10 +140,12 @@ struct virtconsole_data {
 static uint16_t virtconsole_enum_queues_cb(uint16_t q_index, uint16_t q_size_max, void *)
 {
 	switch (q_index) {
+#ifdef CONFIG_UART_VIRTIO_CONSOLE_F_MULTIPORT
 	case VIRTQ_CONTROL_RX:
 		return CONFIG_UART_VIRTIO_CONSOLE_RX_CONTROL_BUFSIZE;
 	case VIRTQ_CONTROL_TX:
 		return CONFIG_UART_VIRTIO_CONSOLE_TX_CONTROL_BUFSIZE;
+#endif
 	default:
 		return 1;
 	}


### PR DESCRIPTION
This PR fixes a deadlock occurring in some cases due to the infinite wait time in `virtq_add_buffer_chain` called from the isr callback. Its fixed by changing the timeout to `K_NO_WAIT` and delaying adding buffers to the virtqueue if no free descriptors are available