### PR TITLE
doc: net: sockets: Document mbed TLS limitation for non-blocking case

### DIFF
--- a/doc/connectivity/networking/api/sockets.rst
+++ b/doc/connectivity/networking/api/sockets.rst
@@ -173,6 +173,13 @@ CA certificate and hostname can be set:
 
 Once configured, socket can be used just like a regular TCP socket.
 
+.. note::
+
+   Due to mbed TLS internal data buffering and ``mbedtls_ssl_write()`` function
+   requirements, when a non-blocking :c:func:`zsock_send` returns ``EAGAIN``, it is
+   expected that the consecutive call to :c:func:`zsock_send` will contain the same
+   data as the original call.
+
 Several samples in Zephyr use secure sockets for communication. For a sample use
 see e.g. :zephyr:code-sample:`echo-server sample application <sockets-echo-server>` or
 :zephyr:code-sample:`HTTP GET sample application <sockets-http-get>`.


### PR DESCRIPTION
mbedtls_ssl_write() function has a limitation, that when the function returns MBEDTLS_ERR_SSL_WANT_WRITE, the consecutive call to this function have to contain the same data as the previous call. As there doesn't seem to be a viable workaround for this at the socket layer (other than dropping non-blocking support which is not an option), we need to carry this requirement for non-blocking sockets as well, therefore document this case in secure sockets documentation.