### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: d5b0dcb9aaee397fc105ae2228e8030038c3d871
+      revision: 48b0f6da9af8d009eb8eafba023998a7d85320a1
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  48b0f6da9af8d009eb8eafba023998a7d85320a1

Brings following Zephyr relevant fixes:

  - 48b0f6da imgtool: support producing images in test mode
  - 2b9f2a2f boot: zephyr: fix getting base address for certain boards
  - 028d80c3 bootutil: Move boot_enc_init in boot_swap_image
  - 15d43f20 zephyr: Deprecate MCUBOOT_VERIFY_IMG_ADDRESS
  - fd2c1428 zephyr: Added MCUBOOT_CHECK_HEADER_LOAD_ADDRESS Kconfig
  - 1035cc01 bootutil: Add MCUBOOT_CHECK_HEADER_LOAD_ADDRESS
  - 17a6ecd2 boot: bootutil: fix image_index definition
  - cc985298 boot: zephyr: Fix IO-based entrance method
  - 9ca08817 bootutil: Fix minor issues
  - 8a07053d bootutil: Fix log module registration
  - 5e1be19f boot: bootutil: write_sz fix
  - aed3fb95 docs: Add release note entry for MCUBOOT_BOOT_MAX_ALIGN Zephyr change

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.