### PR TITLE
Disable SDHC on MAX32666FTHR board

### DIFF
--- a/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.dts
+++ b/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.dts
@@ -184,11 +184,3 @@
 	power-source = <MAX32_VSEL_VDDIOH>;
 	drive-strength = <1>;
 };
-
-&sdhc0 {
-	status = "okay";
-
-	mmc {
-		status = "okay";
-	};
-};

--- a/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.yaml
+++ b/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.yaml
@@ -20,6 +20,5 @@ supported:
   - pwm
   - w1
   - flash
-  - sdhc
 ram: 128
 flash: 1024


### PR DESCRIPTION
Some SDHC related tests began failing after the Zephyr v4.1 release. This PR disables the SDHC and removes it from the feature list on the MAX32666FTHR board until the issue is resolved.