### PR TITLE
Skip usermode test on MAX32657EVKIT

### DIFF
--- a/tests/subsys/logging/log_core_additional/testcase.yaml
+++ b/tests/subsys/logging/log_core_additional/testcase.yaml
@@ -22,3 +22,5 @@ tests:
       - USERSPACE_TEST=1
     integration_platforms:
       - qemu_x86
+    platform_exclude:
+      - max32657evkit/max32657


### PR DESCRIPTION
logging.log_user test requires 3 free MPU regions, however MAX32657 only has 2 free MPU regions available after boot. This PR excludes MAX32657EVKIT board for this test since it does not meet this requirement.