### PR TITLE
drivers: i2c: cdns: add broken hold bit workaround for Zynq-7000

### DIFF
--- a/drivers/i2c/Kconfig.cdns
+++ b/drivers/i2c/Kconfig.cdns
@@ -9,3 +9,15 @@ config I2C_CADENCE
 	select EVENTS
 	help
 	  Enable Cadence I2C driver.
+
+if I2C_CADENCE
+
+config I2C_CADENCE_BROKEN_HOLD_BIT
+	bool "Workaround for errata condition found on the Zynq-7000"
+	default n
+	help
+	  Disallows message transfers with a repeated start condition following a read operation. Also
+	  disables interrupts between the address register write and control register write during
+	  message reception, to prevent transfer size register rollover.
+
+endif # I2C_CADENCE


### PR DESCRIPTION
The Xilinx Zynq 7000 I2C controller has the following bugs:
- completion indication is not given to the driver at the end of a read/receive transfer with HOLD bit set.
- Invalid read transaction are generated on the bus when HW timeout condition occurs with HOLD bit set.
- If the delay between address register write and control register write in cdns_i2c_mrecv function is more, the xfer size register rolls over and controller is stuck.

As a result of the above, this patch disallows message transfers with a repeated start condition following a read operation. Also disables interrupts between the address register write and control register write during message reception, to prevent transfer size register rollover.