### PR TITLE
samples: fs: Enable building of STM32F7 platform

### DIFF
--- a/samples/subsys/fs/fs_sample/sample.yaml
+++ b/samples/subsys/fs/fs_sample/sample.yaml
@@ -82,3 +82,8 @@ tests:
   sample.filesystem.fat_fs.stm32h747i_disco_m7_sdmmc:
     build_only: true
     platform_allow: stm32h747i_disco/stm32h747xx/m7
+  sample.filesystem.fat_fs.stm32f746g_sdmmc_dma:
+    build_only: true
+    platform_allow: stm32f746g_disco
+    extra_args:
+      - FILE_SUFFIX=dma


### PR DESCRIPTION
Add required sample test variant to enable systematic build of stm32f7 platform using DMA configuration.