### PR TITLE
drivers: ptp clock: ptp_clock_nxp_enet: extended pulse width of 1 PPS signal

### DIFF
--- a/drivers/ptp_clock/ptp_clock_nxp_enet.c
+++ b/drivers/ptp_clock/ptp_clock_nxp_enet.c
@@ -179,6 +179,16 @@ void nxp_enet_ptp_clock_callback(const struct device *dev,
 
 		ENET_Ptp1588SetChannelMode(data->base, kENET_PtpTimerChannel3,
 				kENET_PtpChannelPulseHighonCompare, true);
+
+		/* Set 1PPS pulse width to 32 clock cycles of PTP clock.
+		 * At 25 MHz clock frequency, this amounts to a pulse width of 1.28 us.
+		 * Note that this is still orders of magnitude shorter than the 1PPS
+		 * pulse width of many devices, which are often in the range of milliseconds.
+		 * However, 32 clock cycles is the upper limit.
+		 */
+		ENET_Ptp1588SetChannelOutputPulseWidth(data->base, kENET_PtpTimerChannel3, false,
+						       31, true);
+
 		ENET_Ptp1588StartTimer(data->base, ptp_config.ptp1588ClockSrc_Hz);
 		ENET_EnableInterrupts(data->base, ENET_TS_INTERRUPT);
 	}


### PR DESCRIPTION
The pulse width of the 1 PPS output signal on NXP boards (ENET driver) is only one cycle of the PTP clock. For instance, at 25 MHz clock rate, the pulse width is only 40 ns. Other devices typically have orders of mangitude longer pulses in the range of milliseconds (e.g., 100 ms for many GPS devices or even 500 ms for the Intel i210 NIC).

This PR extends the 1 PPS pulse to its maximum width of 32 clock cycles (1.28 us). This is still very short compared to other devices, but better than the 1 clock cycle (40 ns) default value.

The following figure shows the resulting 1 PPS pulse from an i.MX RT1062 width the PR applied:

![1pps](https://github.com/user-attachments/assets/1cfce904-d471-4e7d-84eb-15c7e61d1994)
