### PR TITLE
dts: arm: st: remove U suffix from "resets" arg in SoC DTSI files

### DIFF
--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -303,7 +303,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 14)>;
-			resets = <&rctl STM32_RESET(APB1H, 14U)>;
+			resets = <&rctl STM32_RESET(APB1H, 14)>;
 			interrupts = <27 0>;
 			status = "disabled";
 		};
@@ -312,7 +312,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1L, 17U)>;
+			resets = <&rctl STM32_RESET(APB1L, 17)>;
 			interrupts = <28 0>;
 			status = "disabled";
 		};
@@ -322,7 +322,7 @@
 			reg = <0x40012C00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1H, 11U)>;
+			resets = <&rctl STM32_RESET(APB1H, 11)>;
 			interrupts = <13 0>, <14 0>;
 			interrupt-names = "brk_up_trg_com", "cc";
 			st,prescaler = <0>;
@@ -345,7 +345,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
 			interrupts = <16 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -368,7 +368,7 @@
 			reg = <0x40002000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 15)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1H, 15U)>;
+			resets = <&rctl STM32_RESET(APB1H, 15)>;
 			interrupts = <19 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -391,7 +391,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1H, 17U)>;
+			resets = <&rctl STM32_RESET(APB1H, 17)>;
 			interrupts = <21 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -414,7 +414,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1H, 18U)>;
+			resets = <&rctl STM32_RESET(APB1H, 18)>;
 			interrupts = <22 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -176,7 +176,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <27 0>;
 			status = "disabled";
 		};
@@ -237,7 +237,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <13 0>, <14 0>;
 			interrupt-names = "brk_up_trg_com", "cc";
 			st,prescaler = <0>;
@@ -255,7 +255,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 1U)>;
+			resets = <&rctl STM32_RESET(APB1, 1)>;
 			interrupts = <16 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -278,7 +278,7 @@
 			reg = <0x40002000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 8)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 8U)>;
+			resets = <&rctl STM32_RESET(APB1, 8)>;
 			interrupts = <19 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -301,7 +301,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <21 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -324,7 +324,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <22 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f0/stm32f030X8.dtsi
+++ b/dts/arm/st/f0/stm32f030X8.dtsi
@@ -22,7 +22,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1, 17U)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
 			interrupts = <28 0>;
 			status = "disabled";
 		};
@@ -54,7 +54,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
 			interrupts = <17 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -66,7 +66,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <20 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f0/stm32f030Xc.dtsi
+++ b/dts/arm/st/f0/stm32f030Xc.dtsi
@@ -30,7 +30,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -39,7 +39,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -48,7 +48,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1, 20U)>;
+			resets = <&rctl STM32_RESET(APB1, 20)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -57,7 +57,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
-			resets = <&rctl STM32_RESET(APB2, 5U)>;
+			resets = <&rctl STM32_RESET(APB2, 5)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -67,7 +67,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 5U)>;
+			resets = <&rctl STM32_RESET(APB1, 5)>;
 			interrupts = <18 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f0/stm32f031.dtsi
+++ b/dts/arm/st/f0/stm32f031.dtsi
@@ -15,7 +15,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 0U)>;
+			resets = <&rctl STM32_RESET(APB1, 0)>;
 			interrupts = <15 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f0/stm32f042.dtsi
+++ b/dts/arm/st/f0/stm32f042.dtsi
@@ -23,7 +23,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1, 17U)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
 			interrupts = <28 0>;
 			status = "disabled";
 		};
@@ -51,7 +51,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <20 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f0/stm32f051.dtsi
+++ b/dts/arm/st/f0/stm32f051.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1, 17U)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
 			interrupts = <28 0>;
 			status = "disabled";
 		};
@@ -46,7 +46,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
 			interrupts = <17 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -58,7 +58,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <20 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f0/stm32f070.dtsi
+++ b/dts/arm/st/f0/stm32f070.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1, 17U)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
 			interrupts = <28 0>;
 			status = "disabled";
 		};
@@ -24,7 +24,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <20 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f0/stm32f070Xb.dtsi
+++ b/dts/arm/st/f0/stm32f070Xb.dtsi
@@ -29,7 +29,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -38,7 +38,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -70,7 +70,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
 			interrupts = <17 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -82,7 +82,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 5U)>;
+			resets = <&rctl STM32_RESET(APB1, 5)>;
 			interrupts = <18 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f0/stm32f071.dtsi
+++ b/dts/arm/st/f0/stm32f071.dtsi
@@ -45,7 +45,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -54,7 +54,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -64,7 +64,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 5U)>;
+			resets = <&rctl STM32_RESET(APB1, 5)>;
 			interrupts = <18 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f0/stm32f091.dtsi
+++ b/dts/arm/st/f0/stm32f091.dtsi
@@ -20,7 +20,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1, 20U)>;
+			resets = <&rctl STM32_RESET(APB1, 20)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -29,7 +29,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
-			resets = <&rctl STM32_RESET(APB2, 5U)>;
+			resets = <&rctl STM32_RESET(APB2, 5)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -38,7 +38,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 6)>;
-			resets = <&rctl STM32_RESET(APB2, 6U)>;
+			resets = <&rctl STM32_RESET(APB2, 6)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -47,7 +47,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 7)>;
-			resets = <&rctl STM32_RESET(APB2, 7U)>;
+			resets = <&rctl STM32_RESET(APB2, 7)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -198,7 +198,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <37 0>;
 			status = "disabled";
 		};
@@ -207,7 +207,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1, 17U)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
 			interrupts = <38 0>;
 			status = "disabled";
 		};
@@ -216,7 +216,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -274,7 +274,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -298,7 +298,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 0U)>;
+			resets = <&rctl STM32_RESET(APB1, 0)>;
 			interrupts = <28 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -327,7 +327,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 1U)>;
+			resets = <&rctl STM32_RESET(APB1, 1)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -356,7 +356,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 2U)>;
+			resets = <&rctl STM32_RESET(APB1, 2)>;
 			interrupts = <30 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -28,7 +28,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -37,7 +37,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1, 20U)>;
+			resets = <&rctl STM32_RESET(APB1, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};
@@ -47,7 +47,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 3U)>;
+			resets = <&rctl STM32_RESET(APB1, 3)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -71,7 +71,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
 			interrupts = <54 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -83,7 +83,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 5U)>;
+			resets = <&rctl STM32_RESET(APB1, 5)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -151,7 +151,7 @@
 			compatible = "st,stm32-timers";
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
-			resets = <&rctl STM32_RESET(APB2, 13U)>;
+			resets = <&rctl STM32_RESET(APB2, 13)>;
 			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;

--- a/dts/arm/st/f1/stm32f103Xg.dtsi
+++ b/dts/arm/st/f1/stm32f103Xg.dtsi
@@ -34,7 +34,7 @@
 			reg = <0x40014c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 19)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 19U)>;
+			resets = <&rctl STM32_RESET(APB2, 19)>;
 			/* Shared with TIM1_BRK */
 			interrupts = <24 0>;
 			st,prescaler = <0>;
@@ -52,7 +52,7 @@
 			reg = <0x40015000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 20)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 20U)>;
+			resets = <&rctl STM32_RESET(APB2, 20)>;
 			/* Shared with TIM1_UP */
 			interrupts = <25 0>;
 			st,prescaler = <0>;
@@ -70,7 +70,7 @@
 			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 21U)>;
+			resets = <&rctl STM32_RESET(APB2, 21)>;
 			/* Shared with TIM1_TRG_COM */
 			interrupts = <26 0>;
 			st,prescaler = <0>;
@@ -88,7 +88,7 @@
 			reg = <0x40001800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 6)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 6U)>;
+			resets = <&rctl STM32_RESET(APB1, 6)>;
 			/* Shared with TIM8_BRK */
 			interrupts = <43 0>;
 			st,prescaler = <0>;
@@ -106,7 +106,7 @@
 			reg = <0x40001c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 7)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 7U)>;
+			resets = <&rctl STM32_RESET(APB1, 7)>;
 			/* Shared with TIM8_UP */
 			interrupts = <44 0>;
 			st,prescaler = <0>;
@@ -124,7 +124,7 @@
 			reg = <0x40002000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 8)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 8U)>;
+			resets = <&rctl STM32_RESET(APB1, 8)>;
 			/* Shared with TIM8_TRG_COM */
 			interrupts = <45 0>;
 			st,prescaler = <0>;

--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -66,7 +66,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -75,7 +75,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1, 20U)>;
+			resets = <&rctl STM32_RESET(APB1, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};
@@ -105,7 +105,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 3U)>;
+			resets = <&rctl STM32_RESET(APB1, 3)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -129,7 +129,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
 			interrupts = <54 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -141,7 +141,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 5U)>;
+			resets = <&rctl STM32_RESET(APB1, 5)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -235,7 +235,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 4)>;
-			resets = <&rctl STM32_RESET(APB2, 4U)>;
+			resets = <&rctl STM32_RESET(APB2, 4)>;
 			interrupts = <37 0>;
 			status = "disabled";
 		};
@@ -244,7 +244,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1, 17U)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
 			interrupts = <38 0>;
 			status = "disabled";
 		};
@@ -253,7 +253,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -262,7 +262,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
-			resets = <&rctl STM32_RESET(APB2, 5U)>;
+			resets = <&rctl STM32_RESET(APB2, 5)>;
 			interrupts = <71 0>;
 			status = "disabled";
 		};
@@ -271,7 +271,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -280,7 +280,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1, 20U)>;
+			resets = <&rctl STM32_RESET(APB1, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};
@@ -414,7 +414,7 @@
 			reg = <0x40010000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 0U)>;
+			resets = <&rctl STM32_RESET(APB2, 0)>;
 			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -438,7 +438,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 0U)>;
+			resets = <&rctl STM32_RESET(APB1, 0)>;
 			interrupts = <28 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -462,7 +462,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 1U)>;
+			resets = <&rctl STM32_RESET(APB1, 1)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -491,7 +491,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 2U)>;
+			resets = <&rctl STM32_RESET(APB1, 2)>;
 			interrupts = <30 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -520,7 +520,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 3U)>;
+			resets = <&rctl STM32_RESET(APB1, 3)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -549,7 +549,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
 			interrupts = <54 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -566,7 +566,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 5U)>;
+			resets = <&rctl STM32_RESET(APB1, 5)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -583,7 +583,7 @@
 			reg = <0x40010400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 1U)>;
+			resets = <&rctl STM32_RESET(APB2, 1)>;
 			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -607,7 +607,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <24 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -630,7 +630,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <25 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -653,7 +653,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <26 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -676,7 +676,7 @@
 			reg = <0x40001800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 6)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 6U)>;
+			resets = <&rctl STM32_RESET(APB1, 6)>;
 			interrupts = <43 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -699,7 +699,7 @@
 			reg = <0x40001c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 7)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 7U)>;
+			resets = <&rctl STM32_RESET(APB1, 7)>;
 			interrupts = <44 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -722,7 +722,7 @@
 			reg = <0x40002000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 8)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 8U)>;
+			resets = <&rctl STM32_RESET(APB1, 8)>;
 			interrupts = <45 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -187,7 +187,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <37 0>;
 			status = "disabled";
 		};
@@ -196,7 +196,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1, 17U)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
 			interrupts = <38 0>;
 			status = "disabled";
 		};
@@ -205,7 +205,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -214,7 +214,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -271,7 +271,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 0U)>;
+			resets = <&rctl STM32_RESET(APB1, 0)>;
 			interrupts = <28 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -300,7 +300,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
 			interrupts = <54 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -317,7 +317,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <24 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -340,7 +340,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <25 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -363,7 +363,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <26 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -73,7 +73,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK2 TIM1_SEL(0)>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -57,7 +57,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1, 20U)>;
+			resets = <&rctl STM32_RESET(APB1, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};
@@ -77,7 +77,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK2 TIM1_SEL(0)>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -17,7 +17,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK2 TIM1_SEL(0)>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -100,7 +100,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 2U)>;
+			resets = <&rctl STM32_RESET(APB1, 2)>;
 			interrupts = <30 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -124,7 +124,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 3U)>;
+			resets = <&rctl STM32_RESET(APB1, 3)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -165,7 +165,7 @@
 			reg = <0x40001800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 6)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 6U)>;
+			resets = <&rctl STM32_RESET(APB1, 6)>;
 			interrupts = <43 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -183,7 +183,7 @@
 			reg = <0x40001c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 7)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 7U)>;
+			resets = <&rctl STM32_RESET(APB1, 7)>;
 			interrupts = <44 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -201,7 +201,7 @@
 			reg = <0x40002000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 8)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 8U)>;
+			resets = <&rctl STM32_RESET(APB1, 8)>;
 			interrupts = <45 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -219,7 +219,7 @@
 			reg = <0x40009c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 9)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 9U)>;
+			resets = <&rctl STM32_RESET(APB1, 9)>;
 			interrupts = <27 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -237,7 +237,7 @@
 			reg = <0x40015c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 19)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 19U)>;
+			resets = <&rctl STM32_RESET(APB2, 19)>;
 			interrupts = <78 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -241,7 +241,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 4)>;
-			resets = <&rctl STM32_RESET(APB2, 4U)>;
+			resets = <&rctl STM32_RESET(APB2, 4)>;
 			interrupts = <37 0>;
 			status = "disabled";
 		};
@@ -250,7 +250,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1, 17U)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
 			interrupts = <38 0>;
 			status = "disabled";
 		};
@@ -259,7 +259,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
-			resets = <&rctl STM32_RESET(APB2, 5U)>;
+			resets = <&rctl STM32_RESET(APB2, 5)>;
 			interrupts = <71 0>;
 			status = "disabled";
 		};
@@ -329,7 +329,7 @@
 			reg = <0x40010000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 0U)>;
+			resets = <&rctl STM32_RESET(APB2, 0)>;
 			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -353,7 +353,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 0U)>;
+			resets = <&rctl STM32_RESET(APB1, 0)>;
 			interrupts = <28 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -382,7 +382,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 1U)>;
+			resets = <&rctl STM32_RESET(APB1, 1)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -411,7 +411,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 2U)>;
+			resets = <&rctl STM32_RESET(APB1, 2)>;
 			interrupts = <30 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -440,7 +440,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 3U)>;
+			resets = <&rctl STM32_RESET(APB1, 3)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -469,7 +469,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <24 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -492,7 +492,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <25 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -515,7 +515,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <26 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -591,7 +591,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_PLL_Q NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -52,7 +52,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -61,7 +61,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -70,7 +70,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1, 20U)>;
+			resets = <&rctl STM32_RESET(APB1, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};
@@ -80,7 +80,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
 			interrupts = <54 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -97,7 +97,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 5U)>;
+			resets = <&rctl STM32_RESET(APB1, 5)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -114,7 +114,7 @@
 			reg = <0x40010400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 1U)>;
+			resets = <&rctl STM32_RESET(APB2, 1)>;
 			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -138,7 +138,7 @@
 			reg = <0x40001800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 6)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 6U)>;
+			resets = <&rctl STM32_RESET(APB1, 6)>;
 			interrupts = <43 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -161,7 +161,7 @@
 			reg = <0x40001c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 7)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 7U)>;
+			resets = <&rctl STM32_RESET(APB1, 7)>;
 			interrupts = <44 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -184,7 +184,7 @@
 			reg = <0x40002000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 8)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 8U)>;
+			resets = <&rctl STM32_RESET(APB1, 8)>;
 			interrupts = <45 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -79,7 +79,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
 			interrupts = <54 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -53,7 +53,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -96,7 +96,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 5U)>;
+			resets = <&rctl STM32_RESET(APB1, 5)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -113,7 +113,7 @@
 			reg = <0x40010400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 1U)>;
+			resets = <&rctl STM32_RESET(APB2, 1)>;
 			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -137,7 +137,7 @@
 			reg = <0x40001800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 6)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 6U)>;
+			resets = <&rctl STM32_RESET(APB1, 6)>;
 			interrupts = <43 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -160,7 +160,7 @@
 			reg = <0x40001c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 7)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 7U)>;
+			resets = <&rctl STM32_RESET(APB1, 7)>;
 			interrupts = <44 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -183,7 +183,7 @@
 			reg = <0x40002000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 8)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 8U)>;
+			resets = <&rctl STM32_RESET(APB1, 8)>;
 			interrupts = <45 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/f4/stm32f413.dtsi
+++ b/dts/arm/st/f4/stm32f413.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -23,7 +23,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1, 20U)>;
+			resets = <&rctl STM32_RESET(APB1, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};
@@ -32,7 +32,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
-			resets = <&rctl STM32_RESET(APB1, 30U)>;
+			resets = <&rctl STM32_RESET(APB1, 30)>;
 			interrupts = <82 0>;
 			status = "disabled";
 		};
@@ -41,7 +41,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
-			resets = <&rctl STM32_RESET(APB1, 31U)>;
+			resets = <&rctl STM32_RESET(APB1, 31)>;
 			interrupts = <83 0>;
 			status = "disabled";
 		};
@@ -50,7 +50,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40011800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 6)>;
-			resets = <&rctl STM32_RESET(APB2, 6U)>;
+			resets = <&rctl STM32_RESET(APB2, 6)>;
 			interrupts = <88 0>;
 			status = "disabled";
 		};
@@ -59,7 +59,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40011c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 7)>;
-			resets = <&rctl STM32_RESET(APB2, 7U)>;
+			resets = <&rctl STM32_RESET(APB2, 7)>;
 			interrupts = <89 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f415.dtsi
+++ b/dts/arm/st/f4/stm32f415.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
-			resets = <&rctl STM32_RESET(AHB2, 4U)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f417.dtsi
+++ b/dts/arm/st/f4/stm32f417.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
-			resets = <&rctl STM32_RESET(AHB2, 4U)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f423.dtsi
+++ b/dts/arm/st/f4/stm32f423.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
-			resets = <&rctl STM32_RESET(AHB2, 4U)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -48,7 +48,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
-			resets = <&rctl STM32_RESET(APB1, 30U)>;
+			resets = <&rctl STM32_RESET(APB1, 30)>;
 			interrupts = <82 0>;
 			status = "disabled";
 		};
@@ -57,7 +57,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
-			resets = <&rctl STM32_RESET(APB1, 31U)>;
+			resets = <&rctl STM32_RESET(APB1, 31)>;
 			interrupts = <83 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f429.dtsi
+++ b/dts/arm/st/f4/stm32f429.dtsi
@@ -25,7 +25,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK(APB2, 26)>;
-			resets = <&rctl STM32_RESET(APB2, 26U)>;
+			resets = <&rctl STM32_RESET(APB2, 26)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -15,7 +15,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
-			resets = <&rctl STM32_RESET(AHB2, 4U)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f439.dtsi
+++ b/dts/arm/st/f4/stm32f439.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
-			resets = <&rctl STM32_RESET(AHB2, 4U)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -41,7 +41,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -50,7 +50,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -59,7 +59,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1, 20U)>;
+			resets = <&rctl STM32_RESET(APB1, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -263,7 +263,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 4)>;
-			resets = <&rctl STM32_RESET(APB2, 4U)>;
+			resets = <&rctl STM32_RESET(APB2, 4)>;
 			interrupts = <37 0>;
 			status = "disabled";
 		};
@@ -272,7 +272,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1, 17U)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
 			interrupts = <38 0>;
 			status = "disabled";
 		};
@@ -281,7 +281,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -290,7 +290,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -299,7 +299,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1, 20U)>;
+			resets = <&rctl STM32_RESET(APB1, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};
@@ -308,7 +308,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
-			resets = <&rctl STM32_RESET(APB2, 5U)>;
+			resets = <&rctl STM32_RESET(APB2, 5)>;
 			interrupts = <71 0>;
 			status = "disabled";
 		};
@@ -317,7 +317,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
-			resets = <&rctl STM32_RESET(APB1, 30U)>;
+			resets = <&rctl STM32_RESET(APB1, 30)>;
 			interrupts = <82 0>;
 			status = "disabled";
 		};
@@ -326,7 +326,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
-			resets = <&rctl STM32_RESET(APB1, 31U)>;
+			resets = <&rctl STM32_RESET(APB1, 31)>;
 			interrupts = <83 0>;
 			status = "disabled";
 		};
@@ -431,7 +431,7 @@
 			reg = <0x40010000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 0U)>;
+			resets = <&rctl STM32_RESET(APB2, 0)>;
 			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -455,7 +455,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 0U)>;
+			resets = <&rctl STM32_RESET(APB1, 0)>;
 			interrupts = <28 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -484,7 +484,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 1U)>;
+			resets = <&rctl STM32_RESET(APB1, 1)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -513,7 +513,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 2U)>;
+			resets = <&rctl STM32_RESET(APB1, 2)>;
 			interrupts = <30 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -542,7 +542,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 3U)>;
+			resets = <&rctl STM32_RESET(APB1, 3)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -571,7 +571,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
 			interrupts = <54 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -588,7 +588,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 5U)>;
+			resets = <&rctl STM32_RESET(APB1, 5)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -605,7 +605,7 @@
 			reg = <0x40010400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 1U)>;
+			resets = <&rctl STM32_RESET(APB2, 1)>;
 			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -629,7 +629,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <24 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -652,7 +652,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <25 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -675,7 +675,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <26 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -698,7 +698,7 @@
 			reg = <0x40001800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 6)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 6U)>;
+			resets = <&rctl STM32_RESET(APB1, 6)>;
 			interrupts = <43 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -721,7 +721,7 @@
 			reg = <0x40001c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 7)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 7U)>;
+			resets = <&rctl STM32_RESET(APB1, 7)>;
 			interrupts = <44 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -744,7 +744,7 @@
 			reg = <0x40002000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 8)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 8U)>;
+			resets = <&rctl STM32_RESET(APB1, 8)>;
 			interrupts = <45 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -899,7 +899,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_PLL_Q SDMMC1_SEL(0)>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f7/stm32f722.dtsi
+++ b/dts/arm/st/f7/stm32f722.dtsi
@@ -37,7 +37,7 @@
 			reg = <0x40011c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 7)>,
 				 <&rcc STM32_SRC_PLL_Q SDMMC2_SEL(0)>;
-			resets = <&rctl STM32_RESET(APB2, 7U)>;
+			resets = <&rctl STM32_RESET(APB2, 7)>;
 			interrupts = <103 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f7/stm32f746.dtsi
+++ b/dts/arm/st/f7/stm32f746.dtsi
@@ -17,7 +17,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_err";
 			clocks = <&rcc STM32_CLOCK(APB2, 26)>;
-			resets = <&rctl STM32_RESET(APB2, 26U)>;
+			resets = <&rctl STM32_RESET(APB2, 26)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -98,7 +98,7 @@
 			reg = <0x40011c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 7)>,
 				 <&rcc STM32_SRC_PLL_Q SDMMC2_SEL(0)>;
-			resets = <&rctl STM32_RESET(APB2, 7U)>;
+			resets = <&rctl STM32_RESET(APB2, 7)>;
 			interrupts = <103 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -18,7 +18,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_err";
 			clocks = <&rcc STM32_CLOCK(APB2, 26)>;
-			resets = <&rctl STM32_RESET(APB2, 26U)>;
+			resets = <&rctl STM32_RESET(APB2, 26)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -241,7 +241,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 14)>;
-			resets = <&rctl STM32_RESET(APB1H, 14U)>;
+			resets = <&rctl STM32_RESET(APB1H, 14)>;
 			interrupts = <27 0>;
 			status = "disabled";
 		};
@@ -250,7 +250,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1L, 17U)>;
+			resets = <&rctl STM32_RESET(APB1L, 17)>;
 			interrupts = <28 0>;
 			status = "disabled";
 		};
@@ -271,7 +271,7 @@
 			reg = <0x40012C00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1H, 11U)>;
+			resets = <&rctl STM32_RESET(APB1H, 11)>;
 			interrupts = <13 0>, <14 0>;
 			interrupt-names = "brk_up_trg_com", "cc";
 			st,prescaler = <0>;
@@ -300,7 +300,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
 			interrupts = <16 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -329,7 +329,7 @@
 			reg = <0x40002000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 15)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1H, 15U)>;
+			resets = <&rctl STM32_RESET(APB1H, 15)>;
 			interrupts = <19 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -352,7 +352,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1H, 17U)>;
+			resets = <&rctl STM32_RESET(APB1H, 17)>;
 			interrupts = <21 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -375,7 +375,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1H, 18U)>;
+			resets = <&rctl STM32_RESET(APB1H, 18)>;
 			interrupts = <22 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/g0/stm32g031.dtsi
+++ b/dts/arm/st/g0/stm32g031.dtsi
@@ -16,7 +16,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1L, 20U)>;
+			resets = <&rctl STM32_RESET(APB1L, 20)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -31,7 +31,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 0U)>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
 			interrupts = <15 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/g0/stm32g050.dtsi
+++ b/dts/arm/st/g0/stm32g050.dtsi
@@ -15,7 +15,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 4U)>;
+			resets = <&rctl STM32_RESET(APB1L, 4)>;
 			interrupts = <17 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -27,7 +27,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 5U)>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
 			interrupts = <18 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/g0/stm32g051.dtsi
+++ b/dts/arm/st/g0/stm32g051.dtsi
@@ -15,7 +15,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 4U)>;
+			resets = <&rctl STM32_RESET(APB1L, 4)>;
 			interrupts = <17 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -31,7 +31,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 5U)>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
 			interrupts = <18 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -48,7 +48,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK1 TIM15_SEL(0)>;
-			resets = <&rctl STM32_RESET(APB1H, 16U)>;
+			resets = <&rctl STM32_RESET(APB1H, 16)>;
 			interrupts = <20 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/g0/stm32g070.dtsi
+++ b/dts/arm/st/g0/stm32g070.dtsi
@@ -15,7 +15,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -24,7 +24,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1L, 19U)>;
+			resets = <&rctl STM32_RESET(APB1L, 19)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -34,7 +34,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1H, 16U)>;
+			resets = <&rctl STM32_RESET(APB1H, 16)>;
 			interrupts = <20 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/g0/stm32g071.dtsi
+++ b/dts/arm/st/g0/stm32g071.dtsi
@@ -16,7 +16,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -25,7 +25,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1L, 19U)>;
+			resets = <&rctl STM32_RESET(APB1L, 19)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g0/stm32g0_crypt.dtsi
+++ b/dts/arm/st/g0/stm32g0_crypt.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x40026000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 16)>;
-			resets = <&rctl STM32_RESET(AHB1, 16U)>;
+			resets = <&rctl STM32_RESET(AHB1, 16)>;
 			interrupts = <31 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g0/stm32g0b0.dtsi
+++ b/dts/arm/st/g0/stm32g0b0.dtsi
@@ -25,7 +25,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 8)>;
-			resets = <&rctl STM32_RESET(APB1L, 8U)>;
+			resets = <&rctl STM32_RESET(APB1L, 8)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -34,7 +34,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 9)>;
-			resets = <&rctl STM32_RESET(APB1L, 9U)>;
+			resets = <&rctl STM32_RESET(APB1L, 9)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -44,7 +44,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 2U)>;
+			resets = <&rctl STM32_RESET(APB1L, 2)>;
 			interrupts = <16 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -58,7 +58,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 8)>;
-			resets = <&rctl STM32_RESET(APB1L, 8U)>;
+			resets = <&rctl STM32_RESET(APB1L, 8)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -67,7 +67,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 9)>;
-			resets = <&rctl STM32_RESET(APB1L, 9U)>;
+			resets = <&rctl STM32_RESET(APB1L, 9)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -76,7 +76,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 7)>;
-			resets = <&rctl STM32_RESET(APB1L, 7U)>;
+			resets = <&rctl STM32_RESET(APB1L, 7)>;
 			interrupts = <28 0>;
 			status = "disabled";
 		};
@@ -86,7 +86,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 2U)>;
+			resets = <&rctl STM32_RESET(APB1L, 2)>;
 			interrupts = <16 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -269,7 +269,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <37 0>;
 			status = "disabled";
 		};
@@ -278,7 +278,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1L, 17U)>;
+			resets = <&rctl STM32_RESET(APB1L, 17)>;
 			interrupts = <38 0>;
 			status = "disabled";
 		};
@@ -287,7 +287,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -296,7 +296,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1L, 19U)>;
+			resets = <&rctl STM32_RESET(APB1L, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -305,7 +305,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
-			resets = <&rctl STM32_RESET(APB1H, 0U)>;
+			resets = <&rctl STM32_RESET(APB1H, 0)>;
 			interrupts = <91 0>;
 			status = "disabled";
 		};
@@ -417,7 +417,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -441,7 +441,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 0U)>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
 			interrupts = <28 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -470,7 +470,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -499,7 +499,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 2U)>;
+			resets = <&rctl STM32_RESET(APB1L, 2)>;
 			interrupts = <30 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -528,7 +528,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 4U)>;
+			resets = <&rctl STM32_RESET(APB1L, 4)>;
 			interrupts = <54 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -540,7 +540,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 5U)>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -552,7 +552,7 @@
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 13U)>;
+			resets = <&rctl STM32_RESET(APB2, 13)>;
 			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -576,7 +576,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <24 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -599,7 +599,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <25 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -622,7 +622,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <26 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -16,7 +16,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 3U)>;
+			resets = <&rctl STM32_RESET(APB1L, 3)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -27,7 +27,7 @@
 			reg = <0x40015000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 20)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 20U)>;
+			resets = <&rctl STM32_RESET(APB2, 20)>;
 			interrupts = <77 0>, <78 0>, <79 0>, <80 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -81,7 +81,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1L, 20U)>;
+			resets = <&rctl STM32_RESET(APB1L, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -253,7 +253,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <58 0>;
 			status = "disabled";
 		};
@@ -262,7 +262,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1L, 17U)>;
+			resets = <&rctl STM32_RESET(APB1L, 17)>;
 			interrupts = <59 0>;
 			status = "disabled";
 		};
@@ -271,7 +271,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <60 0>;
 			status = "disabled";
 		};
@@ -280,7 +280,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x44002400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB3, 6)>;
-			resets = <&rctl STM32_RESET(APB3, 6U)>;
+			resets = <&rctl STM32_RESET(APB3, 6)>;
 			interrupts = <63 0>;
 			status = "disabled";
 		};
@@ -340,7 +340,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <41 0>, <42 0>, <43 0>, <44 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			status = "disabled";
@@ -357,7 +357,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 0U)>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
 			interrupts = <45 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -379,7 +379,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
 			interrupts = <46 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -401,7 +401,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 4U)>;
+			resets = <&rctl STM32_RESET(APB1L, 4)>;
 			interrupts = <49 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -423,7 +423,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 5U)>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -472,7 +472,7 @@
 			#address-cells = <3>;
 			#size-cells = <0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
-			resets = <&rctl STM32_RESET(APB1L, 23U)>;
+			resets = <&rctl STM32_RESET(APB1L, 23)>;
 			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
@@ -485,7 +485,7 @@
 			#address-cells = <3>;
 			#size-cells = <0>;
 			clocks = <&rcc STM32_CLOCK(APB3, 9)>;
-			resets = <&rctl STM32_RESET(APB3, 9U)>;
+			resets = <&rctl STM32_RESET(APB3, 9)>;
 			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -151,7 +151,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1L, 19U)>;
+			resets = <&rctl STM32_RESET(APB1L, 19)>;
 			interrupts = <61 0>;
 			status = "disabled";
 		};
@@ -160,7 +160,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1L, 20U)>;
+			resets = <&rctl STM32_RESET(APB1L, 20)>;
 			interrupts = <62 0>;
 			status = "disabled";
 		};
@@ -169,7 +169,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
-			resets = <&rctl STM32_RESET(APB1L, 30U)>;
+			resets = <&rctl STM32_RESET(APB1L, 30)>;
 			interrupts = <98 0>;
 			status = "disabled";
 		};
@@ -178,7 +178,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
-			resets = <&rctl STM32_RESET(APB1L, 31U)>;
+			resets = <&rctl STM32_RESET(APB1L, 31)>;
 			interrupts = <99 0>;
 			status = "disabled";
 		};
@@ -187,7 +187,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40008000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
-			resets = <&rctl STM32_RESET(APB1H, 0U)>;
+			resets = <&rctl STM32_RESET(APB1H, 0)>;
 			interrupts = <100 0>;
 			status = "disabled";
 		};
@@ -196,7 +196,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40006400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
-			resets = <&rctl STM32_RESET(APB1L, 25U)>;
+			resets = <&rctl STM32_RESET(APB1L, 25)>;
 			interrupts = <85 0>;
 			status = "disabled";
 		};
@@ -205,7 +205,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40006800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 26)>;
-			resets = <&rctl STM32_RESET(APB1L, 26U)>;
+			resets = <&rctl STM32_RESET(APB1L, 26)>;
 			interrupts = <86 0>;
 			status = "disabled";
 		};
@@ -214,7 +214,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40006c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 27)>;
-			resets = <&rctl STM32_RESET(APB1L, 27U)>;
+			resets = <&rctl STM32_RESET(APB1L, 27)>;
 			interrupts = <87 0>;
 			status = "disabled";
 		};
@@ -223,7 +223,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40008400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 1)>;
-			resets = <&rctl STM32_RESET(APB1H, 1U)>;
+			resets = <&rctl STM32_RESET(APB1H, 1)>;
 			interrupts = <101 0>;
 			status = "disabled";
 		};
@@ -316,7 +316,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 2U)>;
+			resets = <&rctl STM32_RESET(APB1L, 2)>;
 			interrupts = <47 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -338,7 +338,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 3U)>;
+			resets = <&rctl STM32_RESET(APB1L, 3)>;
 			interrupts = <48 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -377,7 +377,7 @@
 			reg = <0x40001800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 6)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 6U)>;
+			resets = <&rctl STM32_RESET(APB1L, 6)>;
 			interrupts = <120 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -399,7 +399,7 @@
 			reg = <0x40001c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 7)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 7U)>;
+			resets = <&rctl STM32_RESET(APB1L, 7)>;
 			interrupts = <121 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -421,7 +421,7 @@
 			reg = <0x40002000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 8)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 8U)>;
+			resets = <&rctl STM32_RESET(APB1L, 8)>;
 			interrupts = <122 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -443,7 +443,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <71 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -465,7 +465,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <72 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -487,7 +487,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <73 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -508,7 +508,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
 			interrupts = <116 0>;
 			status = "disabled";
 		};
@@ -518,7 +518,7 @@
 			reg = <0x46008000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB4, 11)>,
 				 <&rcc STM32_SRC_PLL1_Q SDMMC1_SEL(0)>;
-			resets = <&rctl STM32_RESET(AHB4, 11U)>;
+			resets = <&rctl STM32_RESET(AHB4, 11)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -15,7 +15,7 @@
 			reg = <0x46008c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB4, 12)>,
 				 <&rcc STM32_SRC_PLL1_Q SDMMC2_SEL(0)>;
-			resets = <&rctl STM32_RESET(AHB4, 12U)>;
+			resets = <&rctl STM32_RESET(AHB4, 12)>;
 			interrupts = <102 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -292,7 +292,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 4)>;
-			resets = <&rctl STM32_RESET(APB2, 4U)>;
+			resets = <&rctl STM32_RESET(APB2, 4)>;
 			interrupts = <37 0>;
 			status = "disabled";
 		};
@@ -301,7 +301,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1L, 17U)>;
+			resets = <&rctl STM32_RESET(APB1L, 17)>;
 			interrupts = <38 0>;
 			status = "disabled";
 		};
@@ -310,7 +310,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -319,7 +319,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1L, 19U)>;
+			resets = <&rctl STM32_RESET(APB1L, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -328,7 +328,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1L, 20U)>;
+			resets = <&rctl STM32_RESET(APB1L, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};
@@ -337,7 +337,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
-			resets = <&rctl STM32_RESET(APB2, 5U)>;
+			resets = <&rctl STM32_RESET(APB2, 5)>;
 			interrupts = <71 0>;
 			status = "disabled";
 		};
@@ -346,7 +346,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
-			resets = <&rctl STM32_RESET(APB1L, 30U)>;
+			resets = <&rctl STM32_RESET(APB1L, 30)>;
 			interrupts = <82 0>;
 			status = "disabled";
 		};
@@ -355,7 +355,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
-			resets = <&rctl STM32_RESET(APB1L, 31U)>;
+			resets = <&rctl STM32_RESET(APB1L, 31)>;
 			interrupts = <83 0>;
 			status = "disabled";
 		};
@@ -364,7 +364,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x58000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB4, 3)>;
-			resets = <&rctl STM32_RESET(APB4, 3U)>;
+			resets = <&rctl STM32_RESET(APB4, 3)>;
 			interrupts = <142 0>;
 			status = "disabled";
 		};
@@ -560,7 +560,7 @@
 			reg = <0x40010000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 0U)>;
+			resets = <&rctl STM32_RESET(APB2, 0)>;
 			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -584,7 +584,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 0U)>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
 			interrupts = <28 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -613,7 +613,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -642,7 +642,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 2U)>;
+			resets = <&rctl STM32_RESET(APB1L, 2)>;
 			interrupts = <30 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -671,7 +671,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 3U)>;
+			resets = <&rctl STM32_RESET(APB1L, 3)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -700,7 +700,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 4U)>;
+			resets = <&rctl STM32_RESET(APB1L, 4)>;
 			interrupts = <54 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -717,7 +717,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 5U)>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -734,7 +734,7 @@
 			reg = <0x40010400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 1U)>;
+			resets = <&rctl STM32_RESET(APB2, 1)>;
 			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -758,7 +758,7 @@
 			reg = <0x40001800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 6)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 6U)>;
+			resets = <&rctl STM32_RESET(APB1L, 6)>;
 			interrupts = <43 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -781,7 +781,7 @@
 			reg = <0x40001c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 7)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 7U)>;
+			resets = <&rctl STM32_RESET(APB1L, 7)>;
 			interrupts = <44 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -804,7 +804,7 @@
 			reg = <0x40002000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 8)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 8U)>;
+			resets = <&rctl STM32_RESET(APB1L, 8)>;
 			interrupts = <45 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -827,7 +827,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <116 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -850,7 +850,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <117 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -873,7 +873,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <118 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -1070,7 +1070,7 @@
 			reg = <0x52007000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB3, 16)>,
 				 <&rcc STM32_SRC_PLL1_Q SDMMC_SEL(0)>;
-			resets = <&rctl STM32_RESET(AHB3, 16U)>;
+			resets = <&rctl STM32_RESET(AHB3, 16)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};
@@ -1080,7 +1080,7 @@
 			reg = <0x48022400 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 9)>,
 				 <&rcc STM32_SRC_PLL1_Q SDMMC_SEL(0)>;
-			resets = <&rctl STM32_RESET(AHB2, 9U)>;
+			resets = <&rctl STM32_RESET(AHB2, 9)>;
 			interrupts = <124 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -29,7 +29,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40011800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 6)>;
-			resets = <&rctl STM32_RESET(APB2, 6U)>;
+			resets = <&rctl STM32_RESET(APB2, 6)>;
 			interrupts = <155 0>;
 			status = "disabled";
 		};
@@ -38,7 +38,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 7)>;
-			resets = <&rctl STM32_RESET(APB2, 7U)>;
+			resets = <&rctl STM32_RESET(APB2, 7)>;
 			interrupts = <156 0>;
 			status = "disabled";
 		};
@@ -90,7 +90,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK(APB3, 3)>;
-			resets = <&rctl STM32_RESET(APB3, 3U)>;
+			resets = <&rctl STM32_RESET(APB3, 3)>;
 			status = "disabled";
 		};
 
@@ -142,7 +142,7 @@
 			reg = <0x4000e000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 24)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1H, 24U)>;
+			resets = <&rctl STM32_RESET(APB1H, 24)>;
 			interrupts = <161 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -171,7 +171,7 @@
 			reg = <0x4000e400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 25)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1H, 25U)>;
+			resets = <&rctl STM32_RESET(APB1H, 25)>;
 			interrupts = <162 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/h7/stm32h730.dtsi
+++ b/dts/arm/st/h7/stm32h730.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
-			resets = <&rctl STM32_RESET(AHB2, 4U)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -43,7 +43,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK(APB3, 3)>;
-			resets = <&rctl STM32_RESET(APB3, 3U)>;
+			resets = <&rctl STM32_RESET(APB3, 3)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h747.dtsi
+++ b/dts/arm/st/h7/stm32h747.dtsi
@@ -20,7 +20,7 @@
 			clocks = <&rcc STM32_CLOCK(APB3, 4)>,
 				 <&rcc STM32_SRC_HSE NO_SEL>,
 				 <&rcc STM32_SRC_PLL3_R NO_SEL>;
-			resets = <&rctl STM32_RESET(APB3, 4U)>;
+			resets = <&rctl STM32_RESET(APB3, 4)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -52,7 +52,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK(APB3, 3)>;
-			resets = <&rctl STM32_RESET(APB3, 3U)>;
+			resets = <&rctl STM32_RESET(APB3, 3)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h7b0.dtsi
+++ b/dts/arm/st/h7/stm32h7b0.dtsi
@@ -19,7 +19,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
-			resets = <&rctl STM32_RESET(AHB2, 4U)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
 			interrupts = <79 0>;
 			interrupt-names = "cryp";
 			status = "disabled";

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -335,7 +335,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x42001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 4)>;
-			resets = <&rctl STM32_RESET(APB2, 4U)>;
+			resets = <&rctl STM32_RESET(APB2, 4)>;
 			interrupts = <82 0>;
 			status = "disabled";
 		};
@@ -344,7 +344,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1L, 17U)>;
+			resets = <&rctl STM32_RESET(APB1L, 17)>;
 			interrupts = <83 0>;
 			status = "disabled";
 		};
@@ -353,7 +353,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <84 0>;
 			status = "disabled";
 		};
@@ -362,7 +362,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1L, 19U)>;
+			resets = <&rctl STM32_RESET(APB1L, 19)>;
 			interrupts = <85 0>;
 			status = "disabled";
 		};
@@ -371,7 +371,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1L, 20U)>;
+			resets = <&rctl STM32_RESET(APB1L, 20)>;
 			interrupts = <86 0>;
 			status = "disabled";
 		};
@@ -380,7 +380,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
-			resets = <&rctl STM32_RESET(APB1L, 30U)>;
+			resets = <&rctl STM32_RESET(APB1L, 30)>;
 			interrupts = <87 0>;
 			status = "disabled";
 		};
@@ -389,7 +389,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
-			resets = <&rctl STM32_RESET(APB1L, 31U)>;
+			resets = <&rctl STM32_RESET(APB1L, 31)>;
 			interrupts = <88 0>;
 			status = "disabled";
 		};
@@ -398,7 +398,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x58000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB4, 3)>;
-			resets = <&rctl STM32_RESET(APB4, 3U)>;
+			resets = <&rctl STM32_RESET(APB4, 3)>;
 			interrupts = <131 0>;
 			status = "disabled";
 		};
@@ -571,7 +571,7 @@
 			reg = <0x42000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 0U)>;
+			resets = <&rctl STM32_RESET(APB2, 0)>;
 			interrupts = <47 0>, <48 0>, <49 0>, <50 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -589,7 +589,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 0U)>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
 			interrupts = <51 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -612,7 +612,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
 			interrupts = <52 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -635,7 +635,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 2U)>;
+			resets = <&rctl STM32_RESET(APB1L, 2)>;
 			interrupts = <53 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -658,7 +658,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 3U)>;
+			resets = <&rctl STM32_RESET(APB1L, 3)>;
 			interrupts = <54 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -681,7 +681,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 4U)>;
+			resets = <&rctl STM32_RESET(APB1L, 4)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -698,7 +698,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 5U)>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
 			interrupts = <56 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -715,7 +715,7 @@
 			reg = <0x42004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 19)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 19U)>;
+			resets = <&rctl STM32_RESET(APB2, 19)>;
 			interrupts = <57 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -732,7 +732,7 @@
 			reg = <0x42004000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <116 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -755,7 +755,7 @@
 			reg = <0x42004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <117 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -778,7 +778,7 @@
 			reg = <0x42004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <118 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -218,7 +218,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1, 17U)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
 			interrupts = <28 0>;
 			status = "disabled";
 		};
@@ -227,7 +227,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -259,7 +259,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 0U)>;
+			resets = <&rctl STM32_RESET(APB1, 0)>;
 			interrupts = <15 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -288,7 +288,7 @@
 			reg = <0x40010800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 2U)>;
+			resets = <&rctl STM32_RESET(APB2, 2)>;
 			interrupts = <20 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/l0/stm32l010Xb.dtsi
+++ b/dts/arm/st/l0/stm32l010Xb.dtsi
@@ -28,7 +28,7 @@
 			reg = <0x40011400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 5U)>;
+			resets = <&rctl STM32_RESET(APB2, 5)>;
 			interrupts = <22 0>;
 			interrupt-names = "global";
 			status = "disabled";

--- a/dts/arm/st/l0/stm32l031.dtsi
+++ b/dts/arm/st/l0/stm32l031.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-timers";
 			reg = <0x40011400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
-			resets = <&rctl STM32_RESET(APB2, 5U)>;
+			resets = <&rctl STM32_RESET(APB2, 5)>;
 			interrupts = <22 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/l0/stm32l051.dtsi
+++ b/dts/arm/st/l0/stm32l051.dtsi
@@ -36,7 +36,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <27 0>;
 			status = "disabled";
 		};
@@ -46,7 +46,7 @@
 			reg = <0x40011400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 5U)>;
+			resets = <&rctl STM32_RESET(APB2, 5)>;
 			interrupts = <22 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -64,7 +64,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
 			interrupts = <17 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/l0/stm32l071.dtsi
+++ b/dts/arm/st/l0/stm32l071.dtsi
@@ -59,7 +59,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 1U)>;
+			resets = <&rctl STM32_RESET(APB1, 1)>;
 			interrupts = <16 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -88,7 +88,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
 			interrupts = <17 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -105,7 +105,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 5U)>;
+			resets = <&rctl STM32_RESET(APB1, 5)>;
 			interrupts = <18 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -122,7 +122,7 @@
 			reg = <0x40011400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 5U)>;
+			resets = <&rctl STM32_RESET(APB2, 5)>;
 			interrupts = <22 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -144,7 +144,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <27 0>;
 			status = "disabled";
 		};
@@ -153,7 +153,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <14 0>;
 			status = "disabled";
 		};
@@ -162,7 +162,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1, 20U)>;
+			resets = <&rctl STM32_RESET(APB1, 20)>;
 			interrupts = <14 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -148,7 +148,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1, 17U)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
 			interrupts = <38 0>;
 			status = "disabled";
 		};
@@ -157,7 +157,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -166,7 +166,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <48 0>;
 			status = "disabled";
 		};
@@ -175,7 +175,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1, 20U)>;
+			resets = <&rctl STM32_RESET(APB1, 20)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};
@@ -254,7 +254,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <37 0>;
 			status = "disabled";
 		};
@@ -306,7 +306,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 0U)>;
+			resets = <&rctl STM32_RESET(APB1, 0)>;
 			interrupts = <28 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -335,7 +335,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 1U)>;
+			resets = <&rctl STM32_RESET(APB1, 1)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -364,7 +364,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 2U)>;
+			resets = <&rctl STM32_RESET(APB1, 2)>;
 			interrupts = <30 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -393,7 +393,7 @@
 			reg = <0x40010800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 2U)>;
+			resets = <&rctl STM32_RESET(APB2, 2)>;
 			interrupts = <25 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -416,7 +416,7 @@
 			reg = <0x40010c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 3U)>;
+			resets = <&rctl STM32_RESET(APB2, 3)>;
 			interrupts = <26 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -439,7 +439,7 @@
 			reg = <0x40011000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 4U)>;
+			resets = <&rctl STM32_RESET(APB2, 4)>;
 			interrupts = <27 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/l1/stm32l151Xc.dtsi
+++ b/dts/arm/st/l1/stm32l151Xc.dtsi
@@ -25,7 +25,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 3U)>;
+			resets = <&rctl STM32_RESET(APB1, 3)>;
 			interrupts = <45 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/l1/stm32l152Xc.dtsi
+++ b/dts/arm/st/l1/stm32l152Xc.dtsi
@@ -25,7 +25,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 3U)>;
+			resets = <&rctl STM32_RESET(APB1, 3)>;
 			interrupts = <45 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/l1/stm32l152Xe.dtsi
+++ b/dts/arm/st/l1/stm32l152Xe.dtsi
@@ -25,7 +25,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 3U)>;
+			resets = <&rctl STM32_RESET(APB1, 3)>;
 			interrupts = <45 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -227,7 +227,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <37 0>;
 			status = "disabled";
 		};
@@ -236,7 +236,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1L, 17U)>;
+			resets = <&rctl STM32_RESET(APB1L, 17)>;
 			interrupts = <38 0>;
 			status = "disabled";
 		};
@@ -245,7 +245,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
-			resets = <&rctl STM32_RESET(APB1H, 0U)>;
+			resets = <&rctl STM32_RESET(APB1H, 0)>;
 			interrupts = <70 0>;
 			status = "disabled";
 		};
@@ -299,7 +299,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -323,7 +323,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 0U)>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
 			interrupts = <28 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -352,7 +352,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 4U)>;
+			resets = <&rctl STM32_RESET(APB1L, 4)>;
 			interrupts = <54 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -369,7 +369,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <24 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -392,7 +392,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <25 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -64,7 +64,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l422.dtsi
+++ b/dts/arm/st/l4/stm32l422.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -78,7 +78,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -88,7 +88,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 5U)>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -114,7 +114,7 @@
 			reg = <0x40012800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 10)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
-			resets = <&rctl STM32_RESET(APB2, 10U)>;
+			resets = <&rctl STM32_RESET(APB2, 10)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -39,7 +39,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 5U)>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/l4/stm32l433.dtsi
+++ b/dts/arm/st/l4/stm32l433.dtsi
@@ -54,7 +54,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -91,7 +91,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -100,7 +100,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1L, 19U)>;
+			resets = <&rctl STM32_RESET(APB1L, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -110,7 +110,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -156,7 +156,7 @@
 			reg = <0x40012800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 10)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
-			resets = <&rctl STM32_RESET(APB2, 10U)>;
+			resets = <&rctl STM32_RESET(APB2, 10)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l462.dtsi
+++ b/dts/arm/st/l4/stm32l462.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -62,7 +62,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -71,7 +71,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1L, 19U)>;
+			resets = <&rctl STM32_RESET(APB1L, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -80,7 +80,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1L, 20U)>;
+			resets = <&rctl STM32_RESET(APB1L, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};
@@ -122,7 +122,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -151,7 +151,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 2U)>;
+			resets = <&rctl STM32_RESET(APB1L, 2)>;
 			interrupts = <30 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -180,7 +180,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 3U)>;
+			resets = <&rctl STM32_RESET(APB1L, 3)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -209,7 +209,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 5U)>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -226,7 +226,7 @@
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 13U)>;
+			resets = <&rctl STM32_RESET(APB2, 13)>;
 			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -250,7 +250,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <26 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -282,7 +282,7 @@
 			reg = <0x40012800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 10)>,
 				 <&rcc STM32_SRC_MSI CLK48_SEL(3)>;
-			resets = <&rctl STM32_RESET(APB2, 10U)>;
+			resets = <&rctl STM32_RESET(APB2, 10)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l486.dtsi
+++ b/dts/arm/st/l4/stm32l486.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l4a6.dtsi
+++ b/dts/arm/st/l4/stm32l4a6.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -111,7 +111,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -120,7 +120,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1L, 19U)>;
+			resets = <&rctl STM32_RESET(APB1L, 19)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -129,7 +129,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1L, 20U)>;
+			resets = <&rctl STM32_RESET(APB1L, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};
@@ -183,7 +183,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -212,7 +212,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 2U)>;
+			resets = <&rctl STM32_RESET(APB1L, 2)>;
 			interrupts = <30 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -241,7 +241,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 3U)>;
+			resets = <&rctl STM32_RESET(APB1L, 3)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -270,7 +270,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 5U)>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
 			interrupts = <55 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -293,7 +293,7 @@
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 13U)>;
+			resets = <&rctl STM32_RESET(APB2, 13)>;
 			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -317,7 +317,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <26 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -395,7 +395,7 @@
 			reg = <0x50062400 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 22)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
-			resets = <&rctl STM32_RESET(AHB2, 22U)>;
+			resets = <&rctl STM32_RESET(AHB2, 22)>;
 			interrupts = <49 0>;
 			idma;
 			status = "disabled";
@@ -406,7 +406,7 @@
 			reg = <0x50062800 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 23)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
-			resets = <&rctl STM32_RESET(AHB2, 23U)>;
+			resets = <&rctl STM32_RESET(AHB2, 23)>;
 			interrupts = <47 0>;
 			idma;
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l4q5.dtsi
+++ b/dts/arm/st/l4/stm32l4q5.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l4r9.dtsi
+++ b/dts/arm/st/l4/stm32l4r9.dtsi
@@ -18,7 +18,7 @@
 			interrupts = <91 0>, <92 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK(APB2, 26)>;
-			resets = <&rctl STM32_RESET(APB2, 26U)>;
+			resets = <&rctl STM32_RESET(APB2, 26)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/l4/stm32l4s5.dtsi
+++ b/dts/arm/st/l4/stm32l4s5.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";
 			status = "disabled";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -276,7 +276,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <61 0>;
 			status = "disabled";
 		};
@@ -285,7 +285,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1L, 17U)>;
+			resets = <&rctl STM32_RESET(APB1L, 17)>;
 			interrupts = <62 0>;
 			status = "disabled";
 		};
@@ -294,7 +294,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <63 0>;
 			status = "disabled";
 		};
@@ -303,7 +303,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1L, 19U)>;
+			resets = <&rctl STM32_RESET(APB1L, 19)>;
 			interrupts = <64 0>;
 			status = "disabled";
 		};
@@ -312,7 +312,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1L, 20U)>;
+			resets = <&rctl STM32_RESET(APB1L, 20)>;
 			interrupts = <65 0>;
 			status = "disabled";
 		};
@@ -321,7 +321,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
-			resets = <&rctl STM32_RESET(APB1H, 0U)>;
+			resets = <&rctl STM32_RESET(APB1H, 0)>;
 			interrupts = <66 0>;
 			status = "disabled";
 		};
@@ -410,7 +410,7 @@
 			reg = <0x420c8000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 22)>,
 				 <&rcc STM32_SRC_HSI48 SDMMC_SEL(0)>;
-			resets = <&rctl STM32_RESET(AHB2, 22U)>;
+			resets = <&rctl STM32_RESET(AHB2, 22)>;
 			interrupts = <78 0>;
 			status = "disabled";
 		};
@@ -482,7 +482,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <41 0>, <42 0>, <43 0>, <44 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -506,7 +506,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 0U)>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
 			interrupts = <45 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -535,7 +535,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
 			interrupts = <46 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -564,7 +564,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 2U)>;
+			resets = <&rctl STM32_RESET(APB1L, 2)>;
 			interrupts = <47 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -593,7 +593,7 @@
 			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 3U)>;
+			resets = <&rctl STM32_RESET(APB1L, 3)>;
 			interrupts = <48 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -622,7 +622,7 @@
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 13U)>;
+			resets = <&rctl STM32_RESET(APB2, 13)>;
 			interrupts = <51 0>, <52 0>, <53 0>, <54 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -646,7 +646,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
 			interrupts = <69 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -669,7 +669,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <70 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -692,7 +692,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <71 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/l5/stm32l562.dtsi
+++ b/dts/arm/st/l5/stm32l562.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
 			interrupts = <93 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -270,7 +270,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x4000e000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			resets = <&rctl STM32_RESET(APB1, 14U)>;
+			resets = <&rctl STM32_RESET(APB1, 14)>;
 			interrupts = <38 0>;
 			status = "disabled";
 		};
@@ -279,7 +279,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x4000f000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			resets = <&rctl STM32_RESET(APB1, 15U)>;
+			resets = <&rctl STM32_RESET(APB1, 15)>;
 			interrupts = <39 0>;
 			status = "disabled";
 		};
@@ -288,7 +288,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40010000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 16)>;
-			resets = <&rctl STM32_RESET(APB1, 16U)>;
+			resets = <&rctl STM32_RESET(APB1, 16)>;
 			interrupts = <52 0>;
 			status = "disabled";
 		};
@@ -297,7 +297,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40011000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1, 17U)>;
+			resets = <&rctl STM32_RESET(APB1, 17)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};
@@ -306,7 +306,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x44003000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
-			resets = <&rctl STM32_RESET(APB2, 13U)>;
+			resets = <&rctl STM32_RESET(APB2, 13)>;
 			interrupts = <71 0>;
 			status = "disabled";
 		};
@@ -315,7 +315,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40018000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18U)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
 			interrupts = <82 0>;
 			status = "disabled";
 		};
@@ -324,7 +324,7 @@
 			compatible = "st,stm32-uart";
 			reg = <0x40019000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1, 19U)>;
+			resets = <&rctl STM32_RESET(APB1, 19)>;
 			interrupts = <83 0>;
 			status = "disabled";
 		};
@@ -345,7 +345,7 @@
 			compatible = "st,stm32-timers";
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>;
-			resets = <&rctl STM32_RESET(APB1, 1U)>;
+			resets = <&rctl STM32_RESET(APB1, 1)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -367,7 +367,7 @@
 			compatible = "st,stm32-timers";
 			reg = <0x40003000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 3)>;
-			resets = <&rctl STM32_RESET(APB1, 3U)>;
+			resets = <&rctl STM32_RESET(APB1, 3)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -400,7 +400,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK(APB4, 0)>;
-			resets = <&rctl STM32_RESET(APB4, 26U)>;
+			resets = <&rctl STM32_RESET(APB4, 26)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -216,7 +216,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 14)>;
-			resets = <&rctl STM32_RESET(APB1H, 14U)>;
+			resets = <&rctl STM32_RESET(APB1H, 14)>;
 			interrupts = <27 0>;
 			status = "disabled";
 		};
@@ -225,7 +225,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1L, 17U)>;
+			resets = <&rctl STM32_RESET(APB1L, 17)>;
 			interrupts = <28 0>;
 			status = "disabled";
 		};
@@ -234,7 +234,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -243,7 +243,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
-			resets = <&rctl STM32_RESET(APB1L, 19U)>;
+			resets = <&rctl STM32_RESET(APB1L, 19)>;
 			interrupts = <30 0>;
 			status = "disabled";
 		};
@@ -252,7 +252,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
-			resets = <&rctl STM32_RESET(APB1L, 20U)>;
+			resets = <&rctl STM32_RESET(APB1L, 20)>;
 			interrupts = <29 0>;
 			status = "disabled";
 		};
@@ -261,7 +261,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 7)>;
-			resets = <&rctl STM32_RESET(APB1L, 7U)>;
+			resets = <&rctl STM32_RESET(APB1L, 7)>;
 			interrupts = <28 0>;
 			status = "disabled";
 		};
@@ -405,7 +405,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x40026000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 16)>;
-			resets = <&rctl STM32_RESET(AHB1, 16U)>;
+			resets = <&rctl STM32_RESET(AHB1, 16)>;
 			interrupts = <31 0>;
 			interrupt-names = "aes";
 			status = "disabled";
@@ -427,7 +427,7 @@
 			reg = <0x40012C00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 11)>,
 				 <&rcc STM32_SRC_PCLK TIM1_SEL(0)>;
-			resets = <&rctl STM32_RESET(APB1H, 11U)>;
+			resets = <&rctl STM32_RESET(APB1H, 11)>;
 			interrupts = <13 0>, <14 0>;
 			interrupt-names = "brk_up_trg_com", "cc";
 			st,prescaler = <0>;
@@ -450,7 +450,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_PCLK NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 0U)>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
 			interrupts = <15 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -473,7 +473,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_PCLK NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
 			interrupts = <16 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -496,7 +496,7 @@
 			reg = <0x40001000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
 				 <&rcc STM32_SRC_PCLK NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 4U)>;
+			resets = <&rctl STM32_RESET(APB1L, 4)>;
 			interrupts = <17 0>;
 			interrupt-names = "combined";
 			st,prescaler = <0>;
@@ -508,7 +508,7 @@
 			reg = <0x40001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
 				 <&rcc STM32_SRC_PCLK NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 5U)>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
 			interrupts = <18 0>;
 			interrupt-names = "combined";
 			st,prescaler = <0>;
@@ -520,7 +520,7 @@
 			reg = <0x40014000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 16)>,
 				 <&rcc STM32_SRC_PCLK TIM15_SEL(0)>;
-			resets = <&rctl STM32_RESET(APB1H, 16U)>;
+			resets = <&rctl STM32_RESET(APB1H, 16)>;
 			interrupts = <19 0>;
 			interrupt-names = "combined";
 			st,prescaler = <0>;
@@ -543,7 +543,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 17)>,
 				 <&rcc STM32_SRC_PCLK NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1H, 17U)>;
+			resets = <&rctl STM32_RESET(APB1H, 17)>;
 			interrupts = <20 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -587,7 +587,7 @@
 			compatible = "st,stm32-tsc";
 			reg = <0x40024000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 24)>;
-			resets = <&rctl STM32_RESET(AHB1, 24U)>;
+			resets = <&rctl STM32_RESET(AHB1, 24)>;
 			interrupts = <21 0>;
 			interrupt-names = "global";
 			status = "disabled";

--- a/dts/arm/st/u0/stm32u083.dtsi
+++ b/dts/arm/st/u0/stm32u083.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 12)>;
-			resets = <&rctl STM32_RESET(APB1L, 12U)>;
+			resets = <&rctl STM32_RESET(APB1L, 12)>;
 			interrupts = <30 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -258,7 +258,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <36 0>;
 			status = "disabled";
 		};
@@ -328,7 +328,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
-			resets = <&rctl STM32_RESET(APB1H, 0U)>;
+			resets = <&rctl STM32_RESET(APB1H, 0)>;
 			interrupts = <37 0>;
 			status = "disabled";
 		};
@@ -338,7 +338,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -356,7 +356,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 0U)>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
 			interrupts = <28 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -379,7 +379,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <25 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -402,7 +402,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <26 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -523,7 +523,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
 			interrupts = <51 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -308,7 +308,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <46 0>;
 			status = "disabled";
 		};
@@ -317,7 +317,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1L, 17U)>;
+			resets = <&rctl STM32_RESET(APB1L, 17)>;
 			interrupts = <47 0>;
 			status = "disabled";
 		};
@@ -326,7 +326,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x46002400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB7, 6)>;
-			resets = <&rctl STM32_RESET(APB7, 6U)>;
+			resets = <&rctl STM32_RESET(APB7, 6)>;
 			interrupts = <48 0>;
 			status = "disabled";
 		};
@@ -380,7 +380,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <37 0>, <38 0>, <39 0>, <40 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -403,7 +403,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 0U)>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
 			interrupts = <41 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -426,7 +426,7 @@
 			reg = <0x40000400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
 			interrupts = <42 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -449,7 +449,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <51 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -471,7 +471,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <52 0>;
 			interrupt-names = "global";
 			status = "disabled";

--- a/dts/arm/st/wba/stm32wba65.dtsi
+++ b/dts/arm/st/wba/stm32wba65.dtsi
@@ -40,7 +40,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			resets = <&rctl STM32_RESET(APB1L, 18)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};
@@ -60,7 +60,7 @@
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 2U)>;
+			resets = <&rctl STM32_RESET(APB1L, 2)>;
 			interrupts = <72 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -253,7 +253,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
-			resets = <&rctl STM32_RESET(APB2, 14U)>;
+			resets = <&rctl STM32_RESET(APB2, 14)>;
 			interrupts = <36 0>;
 			status = "disabled";
 		};
@@ -262,7 +262,7 @@
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
-			resets = <&rctl STM32_RESET(APB1L, 17U)>;
+			resets = <&rctl STM32_RESET(APB1L, 17)>;
 			interrupts = <37 0>;
 			status = "disabled";
 		};
@@ -271,7 +271,7 @@
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
-			resets = <&rctl STM32_RESET(APB1H, 0U)>;
+			resets = <&rctl STM32_RESET(APB1H, 0)>;
 			interrupts = <38 0>;
 			wakeup-line = <28>;
 			status = "disabled";
@@ -382,7 +382,7 @@
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 11U)>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
 			interrupts = <23 0>, <24 0>, <25 0>, <26 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
 			st,prescaler = <0>;
@@ -400,7 +400,7 @@
 			reg = <0x40000000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 0U)>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
 			interrupts = <27 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -423,7 +423,7 @@
 			reg = <0x40014400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
 			interrupts = <28 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -446,7 +446,7 @@
 			reg = <0x40014800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
 				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;
@@ -468,7 +468,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x58001800 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB3, 17)>;
-			resets = <&rctl STM32_RESET(AHB3, 16U)>;
+			resets = <&rctl STM32_RESET(AHB3, 16)>;
 			interrupts = <51 0>;
 			status = "disabled";
 		};

--- a/dts/bindings/reset/st,stm32-rcc-rctl.yaml
+++ b/dts/bindings/reset/st,stm32-rcc-rctl.yaml
@@ -13,7 +13,7 @@ description: |
     usart1: serial@xxx {
         ...
         /* Cell contains information about RCU register offset and bit */
-        resets = <&rctl STM32_RESET(ABP2, 4U)>;
+        resets = <&rctl STM32_RESET(ABP2, 4)>;
         ...
     };
 


### PR DESCRIPTION
STM32 reset controller position argument provided to STM32_RESET() macro sometime uses an unnecessary U suffix. Remove these useless suffixes for consistency among STM32 SoCs DTSI files.

No functional change.
