### PR TITLE
soc: nordic: uicr: Change how secondary images are detected

### DIFF
--- a/soc/nordic/common/uicr/Kconfig
+++ b/soc/nordic/common/uicr/Kconfig
@@ -18,3 +18,10 @@ config NRF_PERIPHCONF_GENERATE_ENTRIES
 	help
 	  Generate a C file containing PERIPHCONF entries based on the
 	  device configuration in the devicetree.
+
+config IS_IRONSIDE_SE_SECONDARY_IMAGE
+	bool "Ironside SE secondary image indicator (informative only, do not change)"
+	help
+	  This Kconfig is set by sysbuild to indicate that this image is a
+	  secondary firmware for Ironside SE. This is used by the UICR generation
+	  system to determine which PERIPHCONF partition to use.

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -23,11 +23,19 @@ project(uicr)
 function(parse_kconfig_value config_file config_name output_var)
   file(STRINGS ${config_file} config_lines ENCODING "UTF-8")
   foreach(line ${config_lines})
+    # Match quoted strings like CONFIG_FOO="value"
     if("${line}" MATCHES "^${config_name}=\"(.*)\"$")
       set(${output_var} "${CMAKE_MATCH_1}" PARENT_SCOPE)
       return()
     endif()
+    # Match unquoted values like CONFIG_FOO=y or CONFIG_FOO=n
+    if("${line}" MATCHES "^${config_name}=(.*)$")
+      set(${output_var} "${CMAKE_MATCH_1}" PARENT_SCOPE)
+      return()
+    endif()
   endforeach()
+  # If not found, return empty (including "# CONFIG_FOO is not set" case)
+  set(${output_var} "" PARENT_SCOPE)
 endfunction()
 
 # Function to compute partition absolute address and size from devicetree
@@ -131,8 +139,9 @@ if(CONFIG_GEN_UICR_GENERATE_PERIPHCONF)
       parse_kconfig_value(${_dir}/zephyr/.config CONFIG_KERNEL_BIN_NAME kernel_bin_name)
       set(kernel_elf_path ${_dir}/zephyr/${kernel_bin_name}.elf)
 
-      # Check if this is secondary firmware by looking for the marker file
-      if(EXISTS ${_dir}/is_secondary_firmware.txt)
+      # Check if this is secondary firmware by reading the Kconfig from .config
+      parse_kconfig_value(${_dir}/zephyr/.config CONFIG_IS_IRONSIDE_SE_SECONDARY_IMAGE is_secondary)
+      if(is_secondary STREQUAL "y")
         list(APPEND secondary_periphconf_elfs ${kernel_elf_path})
       else()
         list(APPEND periphconf_elfs ${kernel_elf_path})


### PR DESCRIPTION
Detect secondary images by checking a Kconfig value instead of a marker file.