### PR TITLE
drivers: bluetooth: hci spi: Add missing semicolon

### DIFF
--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -86,7 +86,7 @@ static K_KERNEL_STACK_DEFINE(spi_rx_stack, CONFIG_BT_DRV_RX_STACK_SIZE);
 static struct k_thread spi_rx_thread_data;
 
 static const struct spi_dt_spec bus = SPI_DT_SPEC_INST_GET(
-	0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8))
+	0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8));
 
 static struct spi_buf spi_tx_buf;
 static struct spi_buf spi_rx_buf;


### PR DESCRIPTION
Adds a missing semicolon.