### PR TITLE
Add lv_arclabel.c to LVGL Zephyr build

### DIFF
--- a/modules/lvgl/CMakeLists.txt
+++ b/modules/lvgl/CMakeLists.txt
@@ -324,6 +324,7 @@ zephyr_library_sources(
     ${LVGL_DIR}/src/widgets/3dtexture/lv_3dtexture.c
     ${LVGL_DIR}/src/widgets/animimage/lv_animimage.c
     ${LVGL_DIR}/src/widgets/arc/lv_arc.c
+    ${LVGL_DIR}/src/widgets/arclabel/lv_arclabel.c
     ${LVGL_DIR}/src/widgets/bar/lv_bar.c
     ${LVGL_DIR}/src/widgets/button/lv_button.c
     ${LVGL_DIR}/src/widgets/buttonmatrix/lv_buttonmatrix.c


### PR DESCRIPTION
This patch updates the `modules/lvgl/CMakeLists.txt` to include the `lv_arclabel.c` source file in the Zephyr build.

Without this change, the arclabel widget from LVGL was not compiled into Zephyr projects, making it unavailable for use. Adding this file ensures that arclabel functionality is included and usable.

Change:
* Added `${LVGL_DIR}/src/widgets/arclabel/lv_arclabel.c` to `zephyr_library_sources`.