### PR TITLE
STM32: add ethernet support to stm32h7rs

### DIFF
--- a/boards/st/nucleo_h7s3l8/doc/index.rst
+++ b/boards/st/nucleo_h7s3l8/doc/index.rst
@@ -162,6 +162,7 @@ and a ST morpho connector. Board is configured as follows:
 - I2C : PB8, PB9
 - SPI1 NSS/SCK/MISO/MOSI : PD14PA5/PA6/PB5 (Arduino SPI)
 - FDCAN1 RX/TX : PD0, PD1
+- ETH : A2, A7, B6, G4, G5, G6, G11, G12, G13
 
 System Clock
 ------------

--- a/boards/st/nucleo_h7s3l8/doc/index.rst
+++ b/boards/st/nucleo_h7s3l8/doc/index.rst
@@ -184,7 +184,7 @@ In order to test backup SRAM you may want to disconnect VBAT from VDD. You can
 do it by removing ``SB13`` jumper on the back side of the board.
 
 FDCAN
-=====
+-----
 
 The Nucleo H7S3L8 board does not have any onboard CAN transceiver. In order to
 use the FDCAN bus on this board, an external CAN bus transceiver must be

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -175,6 +175,31 @@
 	status = "okay";
 };
 
+&mac {
+	pinctrl-0 = <&eth_rmii_rxd0_pg4
+		     &eth_rmii_rxd1_pg5
+		     &eth_rmii_ref_clk_pb6
+		     &eth_rmii_crs_dv_pa7
+		     &eth_rmii_tx_en_pg11
+		     &eth_rmii_txd0_pg13
+		     &eth_rmii_txd1_pg12>;
+	pinctrl-names = "default";
+	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
+	status = "okay";
+};
+
+&mdio {
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pg6>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.yaml
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.yaml
@@ -15,4 +15,5 @@ supported:
   - octospi
   - can
   - canfd
+  - netif:eth
 vendor: st

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -26,7 +26,12 @@ choice ETH_STM32_HAL_API_VERSION
 
 config ETH_STM32_HAL_API_V2
 	bool "Use official STM32Cube HAL driver"
-	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32H5X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32N6X
+	depends on SOC_SERIES_STM32F4X \
+		   || SOC_SERIES_STM32F7X \
+		   || SOC_SERIES_STM32H5X \
+		   || SOC_SERIES_STM32H7X \
+		   || SOC_SERIES_STM32H7RSX \
+		   || SOC_SERIES_STM32N6X
 	select USE_STM32_HAL_ETH_EX if SOC_SERIES_STM32N6X
 	help
 	  Use the official STM32Cube HAL driver instead of the legacy one.
@@ -86,7 +91,10 @@ menuconfig PTP_CLOCK_STM32_HAL
 	default y
 	depends on PTP_CLOCK || NET_L2_PTP
 	depends on ETH_STM32_HAL_API_V2
-	depends on SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X || SOC_SERIES_STM32H5X
+	depends on SOC_SERIES_STM32F7X \
+		   || SOC_SERIES_STM32H5X \
+		   || SOC_SERIES_STM32H7X \
+		   || SOC_SERIES_STM32H7RSX
 	help
 	  Enable STM32 PTP clock support.
 

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -33,7 +33,7 @@ extern const struct device *eth_stm32_phy_dev;
 	    DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm))
 #define __eth_stm32_desc __dtcm_noinit_section
 #define __eth_stm32_buf  __dtcm_noinit_section
-#elif defined(CONFIG_SOC_SERIES_STM32H7X)
+#elif defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32H7RSX)
 #define __eth_stm32_desc __attribute__((section(".eth_stm32_desc")))
 #define __eth_stm32_buf  __attribute__((section(".eth_stm32_buf")))
 #elif defined(CONFIG_NOCACHE_MEMORY)

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -847,6 +847,29 @@
 			status = "disabled";
 		};
 
+		ethernet@40028000 {
+			reg = <0x40028000 0x8000>;
+			compatible = "st,stm32-ethernet-controller";
+			clock-names = "stm-eth";
+			clocks = <&rcc STM32_CLOCK(AHB1, 15)>;
+
+			mac: ethernet {
+				compatible = "st,stm32h7-ethernet", "st,stm32-ethernet";
+				interrupts = <92 0>;
+				clock-names = "mac-clk-tx", "mac-clk-rx";
+				clocks = <&rcc STM32_CLOCK(AHB1, 16)>,
+					 <&rcc STM32_CLOCK(AHB1, 17)>;
+				status = "disabled";
+			};
+
+			mdio: mdio {
+				compatible = "st,stm32-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
+
 		usbotg_fs: usb@40080000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x40080000 0x40000>;

--- a/soc/st/stm32/stm32h7rsx/CMakeLists.txt
+++ b/soc/st/stm32/stm32h7rsx/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_sources(
   )
 
 zephyr_sources(mpu_regions.c)
+zephyr_linker_sources(SECTIONS sections.ld)
 
 zephyr_include_directories(.)
 

--- a/soc/st/stm32/stm32h7rsx/mpu_regions.c
+++ b/soc/st/stm32/stm32h7rsx/mpu_regions.c
@@ -26,6 +26,20 @@ static const struct arm_mpu_region mpu_regions[] = {
 
 	/* Region 3 */
 	MPU_REGION_ENTRY("SRAM_0", CONFIG_SRAM_BASE_ADDRESS, REGION_RAM_ATTR(REGION_SRAM_SIZE)),
+
+	/* Region 4 - Ready only flash with unique device id */
+	MPU_REGION_ENTRY("ID", 0x08FFF800, REGION_FLASH_ATTR(REGION_2K)),
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mac))
+#define sram_eth_node DT_NODELABEL(sram2)
+#if DT_NODE_HAS_STATUS_OKAY(sram_eth_node)
+	/* Region 5 - Ethernet DMA buffer RAM */
+	MPU_REGION_ENTRY("SRAM_ETH_BUF", DT_REG_ADDR(sram_eth_node),
+			 REGION_RAM_NOCACHE_ATTR(REGION_16K)),
+	/* Region 6 - Ethernet DMA descriptor RAM (overlays the first 256B of SRAM_ETH_BUF)*/
+	MPU_REGION_ENTRY("SRAM_ETH_DESC", DT_REG_ADDR(sram_eth_node), REGION_PPB_ATTR(REGION_256B)),
+#endif
+#endif
 };
 
 const struct arm_mpu_config mpu_config = {

--- a/soc/st/stm32/stm32h7rsx/sections.ld
+++ b/soc/st/stm32/stm32h7rsx/sections.ld
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 Mario Jaun
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mac))
+#define sram_eth_node	DT_NODELABEL(sram2)
+#if DT_NODE_HAS_STATUS_OKAY(sram_eth_node)
+SECTION_DATA_PROLOGUE(eth_stm32,(NOLOAD),)
+{
+    . = ABSOLUTE(DT_REG_ADDR(sram_eth_node));
+    *(.eth_stm32_desc)
+    . = ABSOLUTE(DT_REG_ADDR(sram_eth_node)) + 256;
+    *(.eth_stm32_buf)
+    . = ABSOLUTE(DT_REG_ADDR(sram_eth_node)) + 16K;
+} GROUP_DATA_LINK_IN(LINKER_DT_NODE_REGION_NAME(sram_eth_node), LINKER_DT_NODE_REGION_NAME(sram_eth_node))
+#endif /* DT_NODE_HAS_STATUS_OKAY(sram_eth_node) */
+
+#endif /* DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mac)) */


### PR DESCRIPTION
This PR adds ethernet support for STM32H7RS series microcontrollers.
It's almost a 1:1 copy of h7x ethernet configuration. Only register addresses, clock sources and interrupt numbers changed in device tree and the used RAM for DMA buffer. 

## Changes:
* Add ethernet node with mac and mdio subnodes to dts similar to h7-family.
* Add `SOC_SERIES_STM32H7RSX` where appicable next to `SOC_SERIES_STM32H7X`.
* Add ethernet DMA buffer/descriptor region (sram2) and read only flash region (0x08FFF800) with unique device ID registers to MPU region list.
* Ethernet DMA buffer/descriptor memory section is added to soc linker script.
* Enable support for ethernet on nucleo_h7s3l8 board.

## Used DMA memory
As all h7rs variants have the same memory configuration, there is no need to support multiple memories as DMA buffer. `sram1` and `sram2` (AHB SRAM1 and AHB SRAM2) are identical, so I hardcoded the DMA buffer into `sram2`. 

At first I tried not defining any special memory and let the driver use the NOCACHE memory, but after reading #29915 and #30403 I decided to keep it as near as possible to the h7x implementation.

Edit: Is it possible or useful to add a Kconfig option or dts property to select the used sram node?

## 0x08FFF800 read only flash region with unique device ID registers
The controller memfaults without this region in the MPU list while trying to read the uniqe device ID registers. The PR #94019 introduced a different way of preventing speculative access in entire memory space than the one used for h7x:
`MPU_REGION_ENTRY("UNMAPPED", 0, {REGION_4G | MPU_RASR_XN_Msk | P_NA_U_NA_Msk}), `
Every accessed memory must get a MPU region after blocking access to the complete memory space with this entry.

The unique device ID is used to create a random mac address by the ethernet driver in some conditions.

## Testing Status:
* It responds to ping ;)
* Tested on NUCLEO-H7S3L8 with custom bootloader/app. As I'm not familiar with mcuboot, I didn't run tests with samples like echo_server, they are too big to fit into internal flash and need XiP.

Maybe someone more familiar with running mcuboot+samples on this board  can run some tests?