### PR TITLE
tests: Bluetooth: BSIM: ISO: Refactor TX

### DIFF
--- a/tests/bsim/bluetooth/host/iso/bis/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/iso/bis/CMakeLists.txt
@@ -13,9 +13,13 @@ target_sources(app PRIVATE
   src/bis_broadcaster.c
   src/bis_receiver.c
   src/main.c
+
+  ${ZEPHYR_BASE}/tests/bsim/bluetooth/host/iso/common/iso_tx.c
 )
 
 zephyr_include_directories(
   ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
   ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+
+  ${ZEPHYR_BASE}/tests/bsim/bluetooth/host/iso/common
 )

--- a/tests/bsim/bluetooth/host/iso/bis/src/common.h
+++ b/tests/bsim/bluetooth/host/iso/bis/src/common.h
@@ -8,7 +8,7 @@
 
 #include <stdint.h>
 
-#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys/clock.h>
 
 #include "bs_types.h"
 
@@ -18,9 +18,3 @@ void test_init(void);
 void test_tick(bs_time_t HW_device_time);
 
 #define SDU_INTERVAL_US 10U * USEC_PER_MSEC /* 10 ms */
-
-/* Generate 1 KiB of mock data going 0x00, 0x01, ..., 0xff, 0x00, 0x01, ..., 0xff, etc */
-#define ISO_DATA_GEN(_i, _) (uint8_t)_i
-static const uint8_t mock_iso_data[] = {
-	LISTIFY(1024, ISO_DATA_GEN, (,)),
-};

--- a/tests/bsim/bluetooth/host/iso/cis/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/iso/cis/CMakeLists.txt
@@ -5,22 +5,24 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_iso_cis)
 
-add_subdirectory(${ZEPHYR_BASE}/tests/bsim/babblekit babblekit)
-target_link_libraries(app PRIVATE babblekit)
-
 target_sources(app PRIVATE
   src/common.c
   src/cis_central.c
   src/cis_peripheral.c
   src/main.c
+
+  ${ZEPHYR_BASE}/tests/bsim/bluetooth/host/iso/common/iso_tx.c
 )
 
 zephyr_include_directories(
   ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
   ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
-  )
+
+  ${ZEPHYR_BASE}/tests/bsim/bluetooth/host/iso/common
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/common/testlib testlib)
+add_subdirectory(${ZEPHYR_BASE}/tests/bsim/babblekit babblekit)
 
 target_link_libraries(app PRIVATE
   testlib

--- a/tests/bsim/bluetooth/host/iso/cis/src/cis_central.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/cis_central.c
@@ -16,84 +16,30 @@
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys_clock.h>
 #include <zephyr/toolchain.h>
 
 #include "babblekit/testcase.h"
 #include "babblekit/flags.h"
 #include "bstests.h"
 #include "common.h"
+#include "iso_tx.h"
 
-#define ENQUEUE_COUNT 2
+#define EXPECTED_TX_CNT 100U
 
 extern enum bst_result_t bst_result;
 static struct bt_iso_chan iso_chans[CONFIG_BT_ISO_MAX_CHAN];
 static struct bt_iso_chan *default_chan = &iso_chans[0];
 static struct bt_iso_cig *cig;
-static uint16_t seq_num;
-static volatile size_t enqueue_cnt;
-static uint32_t latency_ms = 10U; /* 10ms */
-static uint32_t interval_us = 10U * USEC_PER_MSEC; /* 10 ms */
-NET_BUF_POOL_FIXED_DEFINE(tx_pool, ENQUEUE_COUNT, BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
-			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
+static const uint32_t latency_ms = 10U;                  /* 10ms */
+static const uint32_t interval_us = 10U * USEC_PER_MSEC; /* 10 ms */
+static uint8_t disconnect_reason;
 
 BUILD_ASSERT(CONFIG_BT_ISO_MAX_CHAN > 1, "CONFIG_BT_ISO_MAX_CHAN shall be at least 2");
 
 DEFINE_FLAG_STATIC(flag_iso_connected);
-
-static void send_data_cb(struct k_work *work)
-{
-	static uint8_t buf_data[CONFIG_BT_ISO_TX_MTU];
-	static size_t len_to_send = 1;
-	static bool data_initialized;
-	struct net_buf *buf;
-	int ret;
-
-	if (!IS_FLAG_SET(flag_iso_connected)) {
-		/* TX has been aborted */
-		return;
-	}
-
-	if (!data_initialized) {
-		for (int i = 0; i < ARRAY_SIZE(buf_data); i++) {
-			buf_data[i] = (uint8_t)i;
-		}
-
-		data_initialized = true;
-	}
-
-	buf = net_buf_alloc(&tx_pool, K_FOREVER);
-	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
-
-	net_buf_add_mem(buf, buf_data, len_to_send);
-
-	ret = bt_iso_chan_send(default_chan, buf, seq_num++);
-	if (ret < 0) {
-		printk("Failed to send ISO data (%d)\n", ret);
-		net_buf_unref(buf);
-
-		/* Reschedule for next interval */
-		k_work_reschedule(k_work_delayable_from_work(work), K_USEC(interval_us));
-
-		return;
-	}
-
-	len_to_send++;
-	if (len_to_send > ARRAY_SIZE(buf_data)) {
-		len_to_send = 1;
-	}
-
-	enqueue_cnt--;
-	if (enqueue_cnt > 0U) {
-		/* If we have more buffers available, we reschedule the workqueue item immediately
-		 * to trigger another encode + TX, but without blocking this call for too long
-		 */
-		k_work_reschedule(k_work_delayable_from_work(work), K_NO_WAIT);
-	}
-}
-K_WORK_DELAYABLE_DEFINE(iso_send_work, send_data_cb);
 
 static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 			 struct net_buf_simple *ad)
@@ -126,18 +72,16 @@ static void iso_connected(struct bt_iso_chan *chan)
 
 	printk("ISO Channel %p connected\n", chan);
 
-	seq_num = 0U;
-	enqueue_cnt = ENQUEUE_COUNT;
+	err = bt_iso_setup_data_path(chan, BT_HCI_DATAPATH_DIR_HOST_TO_CTLR, &hci_path);
+	TEST_ASSERT(err == 0, "Failed to set ISO data path: %d", err);
 
 	if (chan == default_chan) {
-		/* Start send timer */
-		k_work_schedule(&iso_send_work, K_MSEC(0));
+		/* Register for TX to start sending */
+		err = iso_tx_register(chan);
+		TEST_ASSERT(err == 0, "Failed to register chan for TX: %d", err);
 
 		SET_FLAG(flag_iso_connected);
 	}
-
-	err = bt_iso_setup_data_path(chan, BT_HCI_DATAPATH_DIR_HOST_TO_CTLR, &hci_path);
-	TEST_ASSERT(err == 0, "Failed to set ISO data path: %d", err);
 }
 
 static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
@@ -147,35 +91,16 @@ static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 	printk("ISO Channel %p disconnected (reason 0x%02x)\n", chan, reason);
 
 	if (chan == default_chan) {
-		k_work_cancel_delayable(&iso_send_work);
+		err = iso_tx_unregister(chan);
+		TEST_ASSERT(err == 0, "Failed to unregister chan for TX: %d", err);
+
+		disconnect_reason = reason;
 
 		UNSET_FLAG(flag_iso_connected);
 	}
 
 	err = bt_iso_remove_data_path(chan, BT_HCI_DATAPATH_DIR_HOST_TO_CTLR);
 	TEST_ASSERT(err == 0, "Failed to remove ISO data path: %d", err);
-
-	if (seq_num < 100) {
-		printk("Channel disconnected early, bumping seq_num to 1000 to end test\n");
-		seq_num = 1000;
-	}
-}
-
-static void sdu_sent_cb(struct bt_iso_chan *chan)
-{
-	int err;
-
-	enqueue_cnt++;
-
-	if (!IS_FLAG_SET(flag_iso_connected)) {
-		/* TX has been aborted */
-		return;
-	}
-
-	err = k_work_schedule(&iso_send_work, K_NO_WAIT);
-	if (err < 0) {
-		TEST_FAIL("Failed to schedule TX for chan %p: %d", chan, err);
-	}
 }
 
 static void init(void)
@@ -183,7 +108,7 @@ static void init(void)
 	static struct bt_iso_chan_ops iso_ops = {
 		.connected = iso_connected,
 		.disconnected = iso_disconnected,
-		.sent = sdu_sent_cb,
+		.sent = iso_tx_sent_cb,
 	};
 	static struct bt_iso_chan_io_qos iso_tx = {
 		.sdu = CONFIG_BT_ISO_TX_MTU,
@@ -207,6 +132,8 @@ static void init(void)
 		iso_chans[i].ops = &iso_ops;
 		iso_chans[i].qos = &iso_qos;
 	}
+
+	iso_tx_init();
 }
 
 static void set_cig_defaults(struct bt_iso_cig_param *param)
@@ -443,6 +370,7 @@ static void reset_bluetooth(void)
 
 	/* After a disable, all CIGs and BIGs are removed */
 	cig = NULL;
+	disconnect_reason = 0U;
 
 	err = bt_enable(NULL);
 	if (err != 0) {
@@ -452,6 +380,27 @@ static void reset_bluetooth(void)
 	}
 }
 
+static void wait_tx_complete(void)
+{
+	size_t tx_cnt;
+
+	do {
+		tx_cnt = iso_tx_get_sent_cnt(default_chan);
+		k_sleep(K_USEC(interval_us));
+
+		if (!IS_FLAG_SET(flag_iso_connected)) {
+			/* We don't expect all TX to be complete in the test where the peripheral
+			 * actively disconnects
+			 */
+			if (disconnect_reason != BT_HCI_ERR_REMOTE_USER_TERM_CONN) {
+				TEST_FAIL("Did not send expected amount before disconnection");
+			}
+
+			return;
+		}
+	} while (tx_cnt < EXPECTED_TX_CNT);
+}
+
 static void test_main(void)
 {
 	init();
@@ -459,21 +408,14 @@ static void test_main(void)
 	reconfigure_cig();
 	connect_acl();
 	connect_cis();
-
-	while (seq_num < 100U) {
-		k_sleep(K_USEC(interval_us));
-	}
-
-	if (seq_num == 100) {
+	wait_tx_complete();
+	if (IS_FLAG_SET(flag_iso_connected)) {
 		disconnect_cis();
-		disconnect_acl();
-		terminate_cig();
 	}
-
-	/* check that all buffers returned to pool */
-	TEST_ASSERT(atomic_get(&tx_pool.avail_count) == ENQUEUE_COUNT,
-		    "tx_pool has non returned buffers, should be %u but is %u",
-		    ENQUEUE_COUNT, atomic_get(&tx_pool.avail_count));
+	if (IS_FLAG_SET(flag_connected)) {
+		disconnect_acl();
+	}
+	terminate_cig();
 
 	TEST_PASS("Test passed");
 }
@@ -494,13 +436,13 @@ static void test_main_disable(void)
 	create_cig(ARRAY_SIZE(iso_chans));
 	connect_acl();
 	connect_cis();
-
-	while (seq_num < 100U) {
-		k_sleep(K_USEC(interval_us));
+	wait_tx_complete();
+	if (IS_FLAG_SET(flag_iso_connected)) {
+		disconnect_cis();
 	}
-
-	disconnect_cis();
-	disconnect_acl();
+	if (IS_FLAG_SET(flag_connected)) {
+		disconnect_acl();
+	}
 	terminate_cig();
 
 	TEST_PASS("Disable test passed");

--- a/tests/bsim/bluetooth/host/iso/cis/src/cis_peripheral.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/cis_peripheral.c
@@ -87,7 +87,7 @@ static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *in
 {
 	iso_recv_cnt++;
 	if (info->flags & BT_ISO_FLAGS_VALID) {
-		printk("Incoming data channel %p len %u\n", chan, buf->len);
+		printk("[%zu]: Incoming data channel %p len %u\n", iso_recv_cnt, chan, buf->len);
 		iso_print_data(buf->data, buf->len);
 		SET_FLAG(flag_data_received);
 	}
@@ -188,6 +188,9 @@ static void test_main(void)
 {
 	init();
 
+	/* This is being used for the disable test as well, so we may need to handle multiple
+	 * connection attempts before reaching flag_data_received
+	 */
 	while (true) {
 		adv_connect();
 		bt_testlib_conn_wait_free();
@@ -204,13 +207,11 @@ static void test_main_early_disconnect(void)
 
 	disconnect_after_recv_cnt = 10;
 
-	while (true) {
-		adv_connect();
-		bt_testlib_conn_wait_free();
+	adv_connect();
+	bt_testlib_conn_wait_free();
 
-		if (IS_FLAG_SET(flag_data_received)) {
-			TEST_PASS("Test passed");
-		}
+	if (IS_FLAG_SET(flag_data_received)) {
+		TEST_PASS("Test passed");
 	}
 }
 

--- a/tests/bsim/bluetooth/host/iso/common/iso_tx.c
+++ b/tests/bsim/bluetooth/host/iso/common/iso_tx.c
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel/thread_stack.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_core.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/atomic_types.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/types.h>
+
+#include "babblekit/testcase.h"
+
+#include "iso_tx.h"
+
+/** Enqueue at least 2 per channel, but otherwise equal distribution based on the buf count */
+#define ENQUEUE_CNT MAX(2, (CONFIG_BT_ISO_TX_BUF_COUNT / CONFIG_BT_ISO_MAX_CHAN))
+
+/** Mutex to prevent race conditions as the values are accessed by multiple threads */
+#define TX_MUTEX_TIMEOUT K_MSEC(1000)
+
+LOG_MODULE_REGISTER(iso_tx, LOG_LEVEL_INF);
+
+struct tx_stream {
+	struct bt_iso_chan *iso_chan;
+	struct k_mutex mutex;
+	uint16_t seq_num;
+	size_t tx_cnt;
+	atomic_t enqueued;
+};
+
+static struct tx_stream tx_streams[CONFIG_BT_ISO_MAX_CHAN];
+
+static void tx_thread_func(void *arg1, void *arg2, void *arg3)
+{
+	/* We set the SDU size to 3 x CONFIG_BT_ISO_TX_MTU to support the fragmentation tests */
+	NET_BUF_POOL_FIXED_DEFINE(tx_pool, CONFIG_BT_ISO_TX_BUF_COUNT,
+				  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU * 3),
+				  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
+
+	/* This loop will attempt to send on all streams in the streaming state in a round robin
+	 * fashion.
+	 * The TX is controlled by the number of buffers configured, and increasing
+	 * CONFIG_BT_ISO_TX_BUF_COUNT will allow for more streams in parallel, or to submit more
+	 * buffers per stream.
+	 * Once a buffer has been freed by the stack, it triggers the next TX.
+	 */
+	while (true) {
+		bool delay_and_retry = true;
+
+		ARRAY_FOR_EACH_PTR(tx_streams, tx_stream) {
+			struct bt_iso_chan *iso_chan;
+			int err;
+
+			err = k_mutex_lock(&tx_stream->mutex, K_NO_WAIT);
+			if (err != 0) {
+				continue;
+			}
+
+			iso_chan = tx_stream->iso_chan;
+			if (iso_chan != NULL && iso_chan->state == BT_ISO_STATE_CONNECTED &&
+			    atomic_get(&tx_stream->enqueued) < ENQUEUE_CNT) {
+				/* Send between 1 and sdu number of octets */
+				const size_t sdu = iso_chan->qos->tx->sdu;
+				const size_t len_to_send = 1 + (tx_stream->tx_cnt % sdu);
+				struct net_buf *buf;
+
+				buf = net_buf_alloc(&tx_pool, TX_MUTEX_TIMEOUT);
+				TEST_ASSERT(buf != NULL, "Failed to allocate buffer");
+
+				net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
+
+				TEST_ASSERT(len_to_send <= sizeof(mock_iso_data),
+					    "Invalid len_to_send: %zu", len_to_send);
+				net_buf_add_mem(buf, mock_iso_data, len_to_send);
+
+				err = bt_iso_chan_send(iso_chan, buf, tx_stream->seq_num);
+				if (err == 0) {
+					tx_stream->seq_num++;
+					atomic_inc(&tx_stream->enqueued);
+					delay_and_retry = false;
+				} else {
+					if (err == -ENOTCONN) {
+						/* Can happen if we disconnected while waiting for a
+						 * buffer - Ignore
+						 */
+					} else {
+						TEST_FAIL("Unable to send: %d", err);
+					}
+
+					net_buf_unref(buf);
+				}
+			} /* No-op if stream is not streaming */
+
+			err = k_mutex_unlock(&tx_stream->mutex);
+			TEST_ASSERT(err == 0, "Failed to unlock mutex: %d", err);
+		}
+
+		if (delay_and_retry) {
+			/* In case of any errors or nothing sent, retry with a delay */
+			k_sleep(K_MSEC(5));
+		}
+	}
+}
+
+int iso_tx_register(struct bt_iso_chan *iso_chan)
+{
+	int err;
+
+	if (iso_chan == NULL) {
+		return -EINVAL;
+	}
+
+	if (!iso_tx_can_send(iso_chan)) {
+		return -EINVAL;
+	}
+
+	ARRAY_FOR_EACH_PTR(tx_streams, tx_stream) {
+		if (tx_stream->iso_chan == iso_chan) {
+			return -EALREADY;
+		}
+	}
+
+	err = -ENOMEM;
+	ARRAY_FOR_EACH_PTR(tx_streams, tx_stream) {
+		int mutex_err;
+
+		mutex_err = k_mutex_lock(&tx_stream->mutex, TX_MUTEX_TIMEOUT);
+		if (mutex_err != 0) {
+			continue;
+		}
+
+		if (tx_stream->iso_chan == NULL) {
+			tx_stream->iso_chan = iso_chan;
+			tx_stream->seq_num = 0U;
+			tx_stream->tx_cnt = 0U;
+			atomic_set(&tx_stream->enqueued, 0);
+
+			LOG_INF("Registered %p for TX", iso_chan);
+
+			err = 0;
+		}
+
+		mutex_err = k_mutex_unlock(&tx_stream->mutex);
+		TEST_ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+		if (err == 0) {
+			break;
+		}
+	}
+
+	return err;
+}
+
+int iso_tx_unregister(struct bt_iso_chan *iso_chan)
+{
+	int err;
+
+	if (iso_chan == NULL) {
+		return -EINVAL;
+	}
+
+	err = -ENODATA;
+	ARRAY_FOR_EACH_PTR(tx_streams, tx_stream) {
+		bool pending_tx = true;
+		int mutex_err;
+
+		while (pending_tx) {
+			mutex_err = k_mutex_lock(&tx_stream->mutex, TX_MUTEX_TIMEOUT);
+			if (mutex_err != 0) {
+				continue;
+			}
+
+			if (tx_stream->iso_chan != iso_chan) {
+				mutex_err = k_mutex_unlock(&tx_stream->mutex);
+				TEST_ASSERT(mutex_err == 0, "Failed to unlock mutex: %d",
+					    mutex_err);
+				break; /* check next tx_stream */
+			}
+
+			if (atomic_get(&tx_stream->enqueued) == 0U) {
+				tx_stream->iso_chan = NULL;
+				pending_tx = false;
+				err = 0;
+
+				LOG_INF("Unregistered %p for TX", iso_chan);
+			}
+
+			mutex_err = k_mutex_unlock(&tx_stream->mutex);
+			TEST_ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+			k_sleep(K_MSEC(100));
+		}
+	}
+
+	return err;
+}
+
+void iso_tx_init(void)
+{
+	static bool thread_started;
+
+	if (!thread_started) {
+		static K_KERNEL_STACK_DEFINE(tx_thread_stack, 1024U);
+		const int tx_thread_prio = K_PRIO_PREEMPT(5);
+		static struct k_thread tx_thread;
+
+		ARRAY_FOR_EACH_PTR(tx_streams, tx_stream) {
+			const int err = k_mutex_init(&tx_stream->mutex);
+
+			TEST_ASSERT(err == 0);
+		}
+
+		k_thread_create(&tx_thread, tx_thread_stack, K_KERNEL_STACK_SIZEOF(tx_thread_stack),
+				tx_thread_func, NULL, NULL, NULL, tx_thread_prio, 0, K_NO_WAIT);
+		k_thread_name_set(&tx_thread, "TX thread");
+		thread_started = true;
+	}
+}
+
+bool iso_tx_can_send(const struct bt_iso_chan *iso_chan)
+{
+	struct bt_iso_info info;
+	int err;
+
+	if (iso_chan == NULL || iso_chan->iso == NULL) {
+		return false;
+	}
+
+	err = bt_iso_chan_get_info(iso_chan, &info);
+	if (err != 0) {
+		return false;
+	}
+
+	return info.can_send;
+}
+
+void iso_tx_sent_cb(struct bt_iso_chan *iso_chan)
+{
+	ARRAY_FOR_EACH_PTR(tx_streams, tx_stream) {
+		int mutex_err;
+
+		mutex_err = k_mutex_lock(&tx_stream->mutex, K_FOREVER);
+		TEST_ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+		if (tx_stream->iso_chan == iso_chan) {
+			const atomic_val_t old = atomic_dec(&tx_stream->enqueued);
+
+			TEST_ASSERT(old != 0, "Old enqueue count was 0");
+
+			tx_stream->tx_cnt++;
+			if ((tx_stream->tx_cnt % 100U) == 0U) {
+				LOG_INF("Channel %p sent %zu SDUs", iso_chan, tx_stream->tx_cnt);
+			}
+
+			mutex_err = k_mutex_unlock(&tx_stream->mutex);
+			TEST_ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+			return;
+		}
+
+		mutex_err = k_mutex_unlock(&tx_stream->mutex);
+		TEST_ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+	}
+}
+
+size_t iso_tx_get_sent_cnt(const struct bt_iso_chan *iso_chan)
+{
+	if (iso_chan == NULL) {
+		return 0U;
+	}
+
+	ARRAY_FOR_EACH_PTR(tx_streams, tx_stream) {
+		int mutex_err;
+
+		mutex_err = k_mutex_lock(&tx_stream->mutex, K_FOREVER);
+		TEST_ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+		if (tx_stream->iso_chan == iso_chan) {
+			const size_t tx_cnt = tx_stream->tx_cnt;
+
+			mutex_err = k_mutex_unlock(&tx_stream->mutex);
+			TEST_ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+			return tx_cnt;
+		}
+
+		mutex_err = k_mutex_unlock(&tx_stream->mutex);
+		TEST_ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+	}
+
+	return 0U;
+}

--- a/tests/bsim/bluetooth/host/iso/common/iso_tx.h
+++ b/tests/bsim/bluetooth/host/iso/common/iso_tx.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ISO_TX_H
+#define ISO_TX_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/types.h>
+
+/**
+ * @brief Initialize TX
+ *
+ * This will initialize TX if not already initialized. This creates and starts a thread that
+ * will attempt to send data on all streams registered with iso_tx_register().
+ */
+void iso_tx_init(void);
+
+/**
+ * @brief Register a stream for TX
+ *
+ * This will add it to the list of streams the TX thread will attempt to send on.
+ *
+ * @param iso_chan The channel to register
+ *
+ * @retval 0 on success
+ * @retval -EINVAL @p iso_chan is NULL or @p iso_chan is not configured for TX
+ * @retval -ENOMEM No more streams can be registered
+ * @retval -EALREADY @p iso_chan is already registered
+ */
+int iso_tx_register(struct bt_iso_chan *iso_chan);
+
+/**
+ * @brief Unregister a stream for TX
+ *
+ * This will remove from the list of streams the TX thread will attempt to send on.
+ *
+ * @param iso_chan The channel to unregister
+ *
+ * @retval 0 on success
+ * @retval -EINVAL @p iso_chan is NULL
+ * @retval -EINVAL @p iso_chan is not configured for TX
+ * @retval -ENODATA @p iso_chan is currently not registered
+ */
+int iso_tx_unregister(struct bt_iso_chan *iso_chan);
+
+/**
+ * @brief Test if the provided stream has been configured for TX
+ *
+ * @param iso_chan The channel to test for TX support
+ *
+ * @retval true if it has been configured for TX, and false if not
+ */
+bool iso_tx_can_send(const struct bt_iso_chan *iso_chan);
+
+/**
+ * @brief Callback to indicate a TX complete
+ *
+ * @param iso_chan The channel that completed TX
+ */
+void iso_tx_sent_cb(struct bt_iso_chan *iso_chan);
+
+/**
+ * @brief Get the number of sent SDUs for an ISO channel
+ *
+ * Counter will be unavailable after iso_tx_unregister()
+ *
+ * @param iso_chan The ISO channel
+ *
+ * @return The number of sent SDUs
+ */
+size_t iso_tx_get_sent_cnt(const struct bt_iso_chan *iso_chan);
+
+/* Generate 1 KiB of mock data going 0x00, 0x01, ..., 0xff, 0x00, 0x01, ..., 0xff, etc */
+#define ISO_DATA_GEN(_i, _) (uint8_t)_i
+static const uint8_t mock_iso_data[] = {
+	LISTIFY(1024, ISO_DATA_GEN, (,)),
+};
+#endif /* ISO_TX_H */


### PR DESCRIPTION
Refactor the TX for the ISO host BSIM tests to use a separate thread, instead of a timer.
This is the recommended way to handle TX, and is what the LE Audio BSIM tests and samples use.

The TX will send 1->sdu number of octets, increasing, to verify that any size can be sent (and to keep the check for this in the bis_receiver).