### PR TITLE
tree-wide: stm32: fix dma DTS phandle lists

### DIFF
--- a/dts/arm/st/f4/stm32f401.dtsi
+++ b/dts/arm/st/f4/stm32f401.dtsi
@@ -55,8 +55,8 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
-			dmas = <&dma1 4 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
-				&dma1 3 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
+			dmas = <&dma1 4 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
+			       <&dma1 3 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};
@@ -68,8 +68,8 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
-			dmas = <&dma1 5 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
-				&dma1 0 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
+			dmas = <&dma1 5 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
+			       <&dma1 0 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -42,8 +42,8 @@
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <35 5>;
-			dmas = <&dma2 3 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
-				&dma2 2 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
+			dmas = <&dma2 3 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
+			       <&dma2 2 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};
@@ -55,8 +55,8 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
-			dmas = <&dma1 4 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
-				&dma1 3 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
+			dmas = <&dma1 4 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
+			       <&dma1 3 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};
@@ -68,8 +68,8 @@
 			reg = <0x40015000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
 			interrupts = <85 5>;
-			dmas = <&dma2 6 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
-				&dma2 5 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
+			dmas = <&dma2 6 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
+			       <&dma2 5 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f411.dtsi
+++ b/dts/arm/st/f4/stm32f411.dtsi
@@ -35,8 +35,8 @@
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <35 5>;
-			dmas = <&dma2 3 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
-				&dma2 2 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
+			dmas = <&dma2 3 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
+			       <&dma2 2 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};
@@ -48,8 +48,8 @@
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
 			interrupts = <84 5>;
-			dmas = <&dma2 1 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
-				&dma2 0 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
+			dmas = <&dma2 1 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
+			       <&dma2 0 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};
@@ -61,8 +61,8 @@
 			reg = <0x40015000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
 			interrupts = <85 5>;
-			dmas = <&dma2 6 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
-				&dma2 5 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
+			dmas = <&dma2 6 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
+			       <&dma2 5 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -85,8 +85,8 @@
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
 			interrupts = <84 5>;
-			dmas = <&dma2 1 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
-				&dma2 0 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
+			dmas = <&dma2 1 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
+			       <&dma2 0 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -31,8 +31,8 @@
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <35 5>;
-			dmas = <&dma2 3 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
-				&dma2 2 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
+			dmas = <&dma2 3 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
+			       <&dma2 2 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -578,9 +578,9 @@
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI1_SEL(0)>;
 			dmas = <&gpdma1 0 7 (STM32_DMA_PERIPH_TX | STM32_DMA_16BITS |
-				STM32_DMA_PRIORITY_HIGH)
-				&gpdma1 1 6 (STM32_DMA_PERIPH_RX | STM32_DMA_16BITS |
-				STM32_DMA_PRIORITY_HIGH)>;
+					     STM32_DMA_PRIORITY_HIGH)>,
+			       <&gpdma1 1 6 (STM32_DMA_PERIPH_RX | STM32_DMA_16BITS |
+					     STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
 			interrupts = <55 3>;
 			status = "disabled";
@@ -594,9 +594,9 @@
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI2_SEL(0)>;
 			dmas = <&gpdma1 2 9 (STM32_DMA_PERIPH_TX | STM32_DMA_16BITS |
-				STM32_DMA_PRIORITY_HIGH)
-				&gpdma1 3 8 (STM32_DMA_PERIPH_RX | STM32_DMA_16BITS |
-				STM32_DMA_PRIORITY_HIGH)>;
+					     STM32_DMA_PRIORITY_HIGH)>,
+			       <&gpdma1 3 8 (STM32_DMA_PERIPH_RX | STM32_DMA_16BITS |
+					     STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
 			interrupts = <56 3>;
 			status = "disabled";
@@ -610,9 +610,9 @@
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI3_SEL(0)>;
 			dmas = <&gpdma1 4 11 (STM32_DMA_PERIPH_TX | STM32_DMA_16BITS |
-				STM32_DMA_PRIORITY_HIGH)
-				&gpdma1 5 10 (STM32_DMA_PERIPH_RX | STM32_DMA_16BITS |
-				STM32_DMA_PRIORITY_HIGH)>;
+					      STM32_DMA_PRIORITY_HIGH)>,
+			       <&gpdma1 5 10 (STM32_DMA_PERIPH_RX | STM32_DMA_16BITS |
+					      STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
 			interrupts = <57 3>;
 			status = "disabled";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -498,8 +498,8 @@
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
-			dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-				&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+			dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+			       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
 			interrupts = <35 3>;
 			status = "disabled";
@@ -512,8 +512,8 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
-			dmas = <&dmamux1 0 40 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-				&dmamux1 1 39 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+			dmas = <&dmamux1 0 40 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+			       <&dmamux1 1 39 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
 			interrupts = <36 0>;
 			status = "disabled";
@@ -526,8 +526,8 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
-			dmas = <&dmamux1 0 62 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-				&dmamux1 1 61 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+			dmas = <&dmamux1 0 62 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+			       <&dmamux1 1 61 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
 			interrupts = <51 0>;
 			status = "disabled";

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -87,8 +87,8 @@
 			reg = <0x58001400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB4, 5)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI6_SEL(0)>;
-			dmas = <&dmamux2 0 12 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-				&dmamux2 1 11 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+			dmas = <&dmamux2 0 12 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+			       <&dmamux2 1 11 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
 			interrupts = <86 0>;
 			status = "disabled";

--- a/samples/boards/st/power_mgmt/suspend_to_ram/boards/nucleo_wba55cg.overlay
+++ b/samples/boards/st/power_mgmt/suspend_to_ram/boards/nucleo_wba55cg.overlay
@@ -52,8 +52,8 @@
 };
 
 &spi1 {
-	dmas = <&gpdma1 0 2 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&gpdma1 1 1 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&gpdma1 0 2 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&gpdma1 1 1 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	fast@0 {
 		compatible = "test-spi-loopback";

--- a/samples/boards/st/uart/circular_dma/boards/nucleo_u575zi_q.overlay
+++ b/samples/boards/st/uart/circular_dma/boards/nucleo_u575zi_q.overlay
@@ -5,8 +5,8 @@
  */
 
 &usart1 {
-	dmas = <&gpdma1 0 25 STM32_DMA_PERIPH_TX
-		&gpdma1 1 24 (STM32_DMA_MODE_CYCLIC | STM32_DMA_PERIPH_RX | STM32_DMA_MEM_8BITS)>;
+	dmas = <&gpdma1 0 25 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 24 (STM32_DMA_MODE_CYCLIC | STM32_DMA_PERIPH_RX | STM32_DMA_MEM_8BITS)>;
 	dma-names = "tx", "rx";
 	fifo-enable;
 };

--- a/samples/boards/st/uart/circular_dma/boards/nucleo_wba55cg.overlay
+++ b/samples/boards/st/uart/circular_dma/boards/nucleo_wba55cg.overlay
@@ -5,8 +5,8 @@
  */
 
 &usart1 {
-	dmas = <&gpdma1 0 12 STM32_DMA_PERIPH_TX
-		&gpdma1 1 11 (STM32_DMA_MODE_CYCLIC | STM32_DMA_PERIPH_RX | STM32_DMA_MEM_8BITS)>;
+	dmas = <&gpdma1 0 12 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 11 (STM32_DMA_MODE_CYCLIC | STM32_DMA_PERIPH_RX | STM32_DMA_MEM_8BITS)>;
 	dma-names = "tx", "rx";
 	fifo-enable;
 };

--- a/samples/drivers/spi_flash/boards/stm32h573i_dk.overlay
+++ b/samples/drivers/spi_flash/boards/stm32h573i_dk.overlay
@@ -6,8 +6,8 @@
 
 &xspi1 {
 	/* request 57 for XSPI1 */
-	dmas = <&gpdma1 4 57 STM32_DMA_PERIPH_TX
-		&gpdma1 5 57 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 4 57 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 5 57 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 

--- a/samples/net/cellular_modem/boards/b_u585i_iot02a.overlay
+++ b/samples/net/cellular_modem/boards/b_u585i_iot02a.overlay
@@ -24,8 +24,8 @@
 	current-speed = <115200>;
 	hw-flow-control;
 
-	dmas = <&gpdma1 0 27 STM32_DMA_PERIPH_TX
-		&gpdma1 1 26 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 27 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 26 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/b_u585i_iot02a.overlay
@@ -9,8 +9,8 @@
 };
 
 &spi1 {
-	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX
-		&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_c071rb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_c071rb.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 2 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 2 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f207zg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f207zg.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dma2 5 3 0x28440 0x03
-		&dma2 2 3 0x28480 0x03>;
+	dmas = <&dma2 5 3 0x28440 0x03>,
+	       <&dma2 2 3 0x28480 0x03>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f411re.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f411re.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dma2 5 3 0x28440 0x03
-		&dma2 2 3 0x28480 0x03>;
+	dmas = <&dma2 5 3 0x28440 0x03>,
+	       <&dma2 2 3 0x28480 0x03>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f429zi.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dma2 5 3 0x28440 0x03
-		&dma2 2 3 0x28480 0x03>;
+	dmas = <&dma2 5 3 0x28440 0x03>,
+	       <&dma2 2 3 0x28480 0x03>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f746zg.overlay
@@ -6,8 +6,8 @@
 
 /* Arduino Header pins: MOSI:D11, MISO:D12 */
 &spi1 {
-	dmas = <&dma2 5 3 0x28440 0x03
-		&dma2 2 3 0x28480 0x03>;
+	dmas = <&dma2 5 3 0x28440 0x03>,
+	       <&dma2 2 3 0x28480 0x03>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f767zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f767zi.overlay
@@ -6,8 +6,8 @@
 
 /* Arduino Header pins: MOSI:D11, MISO:D12 */
 &spi1 {
-	dmas = <&dma2 5 3 0x28440 0x03
-		&dma2 2 3 0x28480 0x03>;
+	dmas = <&dma2 5 3 0x28440 0x03>,
+	       <&dma2 2 3 0x28480 0x03>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_g0b1re.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_g0b1re.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 2 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 2 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_g431rb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_g431rb.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 1 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_g474re.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_g474re.overlay
@@ -14,8 +14,8 @@
 };
 
 &spi1 {
-	dmas = <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 8 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 8 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h743zi.overlay
@@ -15,8 +15,8 @@
 };
 
 &spi1 {
-	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m4.overlay
@@ -15,8 +15,8 @@
 };
 
 &spi1 {
-	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m7.overlay
@@ -15,8 +15,8 @@
 };
 
 &spi1 {
-	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
@@ -15,8 +15,8 @@
 };
 
 &spi1 {
-	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l152re.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l152re.overlay
@@ -8,8 +8,8 @@
 	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5
 		     &spi1_miso_pa6 &spi1_mosi_pa7>;
 	pinctrl-names = "default";
-	dmas = <&dma1 3 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dma1 2 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dma1 3 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dma1 2 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	status = "okay";
 	slow@0 {

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l476rg.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dma1 3 1 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dma1 2 1 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dma1 3 1 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dma1 2 1 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l4r5zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l4r5zi.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 7 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 7 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l552ze_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l552ze_q.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 0 12 STM32_DMA_PERIPH_TX
-		&dmamux1 7 11 STM32_DMA_PERIPH_RX>;
+	dmas = <&dmamux1 0 12 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 7 11 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_n657x0_q_stm32n657xx_sb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_n657x0_q_stm32n657xx_sb.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi5 {
-	dmas = <&gpdma1 0 88 STM32_DMA_PERIPH_TX
-		&gpdma1 1 87 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 88 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 87 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_u385rg_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_u385rg_q.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi3 {
-	dmas = <&gpdma1 0 11 STM32_DMA_PERIPH_TX
-		&gpdma1 1 10 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 11 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 10 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_u575zi_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_u575zi_q.overlay
@@ -9,8 +9,8 @@
 };
 
 &spi1 {
-	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX
-		&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wb55rg.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 11 7 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 1 6 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 11 7 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 6 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wba55cg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wba55cg.overlay
@@ -9,8 +9,8 @@
 };
 
 &spi1 {
-	dmas = <&gpdma1 0 2 STM32_DMA_PERIPH_TX
-		&gpdma1 1 1 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 2 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 1 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wl55jc.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 11 8 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 1 7 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 11 8 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 7 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
@@ -9,8 +9,8 @@
 };
 
 &spi2 {
-	dmas = <&gpdma1 0 9 STM32_DMA_PERIPH_TX
-		&gpdma1 1 8 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 9 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 8 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 
 	slow@0 {

--- a/tests/drivers/spi/spi_loopback/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32l562e_dk.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 0 12 STM32_DMA_PERIPH_TX
-		&dmamux1 7 11 STM32_DMA_PERIPH_RX>;
+	dmas = <&dmamux1 0 12 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 7 11 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi5 {
-	dmas = <&gpdma1 0 88 STM32_DMA_PERIPH_TX
-		&gpdma1 1 87 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 88 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 87 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/stm32u083c_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32u083c_dk.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi3 {
-	dmas = <&dmamux1 2 41 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 1 40 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 2 41 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 40 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/uart/uart_async_api/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/b_u585i_iot02a.overlay
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 dut: &usart3 {
-	dmas = <&gpdma1 0 29 STM32_DMA_PERIPH_TX
-		&gpdma1 1 28 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 29 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 28 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_n657x0_q_stm32n657xx_sb.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_n657x0_q_stm32n657xx_sb.overlay
@@ -5,8 +5,8 @@
  */
 
 dut: &usart3 {
-	dmas = <&gpdma1 0 112 STM32_DMA_PERIPH_TX
-		&gpdma1 1 111 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 112 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 111 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_u385rg_q.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_u385rg_q.overlay
@@ -5,8 +5,8 @@
  */
 
 dut: &lpuart1 {
-	dmas = <&gpdma1 0 35 STM32_DMA_PERIPH_TX
-		&gpdma1 1 34 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 35 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 34 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_u575zi_q.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_u575zi_q.overlay
@@ -5,7 +5,7 @@
  */
 
 dut: &usart2 {
-	dmas = <&gpdma1 0 27 STM32_DMA_PERIPH_TX
-		&gpdma1 1 26 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 27 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 26 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_wb55rg.overlay
@@ -6,8 +6,8 @@
 
 dut: &lpuart1 {
 	/delete-property/ hw-flow-control;
-	dmas = <&dmamux1 0 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 0 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_wba55cg.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_wba55cg.overlay
@@ -10,8 +10,8 @@
 };
 
 dut: &lpuart1 {
-	dmas = <&gpdma1 0 16 STM32_DMA_PERIPH_TX
-		&gpdma1 1 15 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 16 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 15 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	fifo-enable;
 };

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_wl55jc.overlay
@@ -5,8 +5,8 @@
  */
 
 dut: &usart1 {
-	dmas = <&dmamux1 11 18 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
-		&dmamux1 1 17 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dmas = <&dmamux1 11 18 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 17 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pb7>;
 	pinctrl-names = "default";

--- a/tests/drivers/uart/uart_async_api/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -5,8 +5,8 @@
  */
 
 dut: &usart2 {
-	dmas = <&gpdma1 0 110 STM32_DMA_PERIPH_TX
-		&gpdma1 1 109 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 110 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 109 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/subsys/modem/backends/uart/boards/b_u585i_iot02a.overlay
+++ b/tests/subsys/modem/backends/uart/boards/b_u585i_iot02a.overlay
@@ -24,8 +24,8 @@ dut: &usart3 {
 		     &usart3_rts_pd12
 		     &usart3_cts_pd11>;
 	pinctrl-names = "default";
-	dmas = <&gpdma1 0 29 STM32_DMA_PERIPH_TX
-		&gpdma1 1 28 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 29 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 28 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	hw-flow-control;
 };


### PR DESCRIPTION

Correct STM32 SoC DTSI files and samples/tests DTS overlay files where DMA lists are not split by phandle and seemed to form unique phandles. This is not an issue with existing DT parsing macros and tools but may generate build errors if tools are more strict on the DTS implementation format.

No functional changes.