### PR TITLE
dts: nxp: Fix opamp addresses

### DIFF
--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -312,27 +312,27 @@
 		clocks = <&syscon MCUX_LPADC1_CLK>;
 	};
 
-	opamp0: opamp@400b4000 {
+	opamp0: opamp@b4000 {
 		compatible = "nxp,opamp";
-		reg = <0x400b4000 0x1000>;
+		reg = <0xb4000 0x1000>;
 		status = "disabled";
 		operation-mode = "low_noise";
 		clocks = <&syscon MCUX_OPAMP0_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(3, 12)>;
 	};
 
-	opamp1: opamp@400b8000 {
+	opamp1: opamp@b8000 {
 		compatible = "nxp,opamp";
-		reg = <0x400b8000 0x1000>;
+		reg = <0xb8000 0x1000>;
 		status = "disabled";
 		operation-mode = "low_noise";
 		clocks = <&syscon MCUX_OPAMP1_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(3, 13)>;
 	};
 
-	opamp2: opamp@400bb000 {
+	opamp2: opamp@bb000 {
 		compatible = "nxp,opamp";
-		reg = <0x400bb000 0x1000>;
+		reg = <0xbb000 0x1000>;
 		status = "disabled";
 		operation-mode = "low_noise";
 		clocks = <&syscon MCUX_OPAMP2_CLK>;

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -81,15 +81,15 @@
 		#io-channel-cells = <2>;
 	};
 
-	opamp0: opamp@40110000 {
+	opamp0: opamp@110000 {
 		compatible = "nxp,opamp";
-		reg = <0x40110000 0x1000>;
+		reg = <0x110000 0x1000>;
 		status = "disabled";
 		operation-mode = "low_noise";
 		clocks = <&syscon MCUX_OPAMP0_CLK>;
 	};
 
-	opamp1: opamp@40113000 {
+	opamp1: opamp@113000 {
 		compatible = "nxp,opamp";
 		reg = <0x40113000 0x1000>;
 		status = "disabled";
@@ -97,9 +97,9 @@
 		clocks = <&syscon MCUX_OPAMP1_CLK>;
 	};
 
-	opamp2: opamp@40115000 {
+	opamp2: opamp@115000 {
 		compatible = "nxp,opamp";
-		reg = <0x40115000 0x1000>;
+		reg = <0x115000 0x1000>;
 		status = "disabled";
 		operation-mode = "low_noise";
 		clocks = <&syscon MCUX_OPAMP2_CLK>;


### PR DESCRIPTION
The opamp addresses were wrong given the ranges translations. This resulted in using the NS addresses on a S build.