### PR TITLE
samples: mcumgr: smp_svr: correct overlay-udp.conf to udp.conf

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -38,7 +38,7 @@ tests:
     integration_platforms:
       - frdm_k64f
   sample.mcumgr.smp_svr.udp.802154.subg:
-    extra_args: EXTRA_CONF_FILE="overlay-udp.conf;802154-subg.conf"
+    extra_args: EXTRA_CONF_FILE="udp.conf;802154-subg.conf"
     platform_allow: beagleconnect_freedom
   sample.mcumgr.smp_svr.cdc:
     extra_args:


### PR DESCRIPTION
The `EXTRA_CONF_FILE="overlay-udp.conf"` should have been `"udp.conf"` with a recent rename.

Fixes this
https://github.com/zephyrproject-rtos/zephyr/actions/runs/18413129079/job/52474652183

Testing Done:
```shell
west build -p -b beagleconnect_freedom/cc1352p7 samples/subsys/mgmt/mcumgr/smp_svr -T sample.mcumgr.smp_svr.udp.802154.subg
```