### PR TITLE
samples: mgmt: mcumgr: smp_svr: remove "overlay-" from sample.yaml

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -38,7 +38,7 @@ tests:
     integration_platforms:
       - frdm_k64f
   sample.mcumgr.smp_svr.udp.802154.subg:
-    extra_args: EXTRA_CONF_FILE="overlay-udp.conf;802154-subg.conf"
+    extra_args: EXTRA_CONF_FILE="udp.conf;802154-subg.conf"
     platform_allow: beagleconnect_freedom
   sample.mcumgr.smp_svr.cdc:
     extra_args:


### PR DESCRIPTION
6fb782389c8cc9a10b3da7859b6f91d4b256ee43 broke this test:

```
west twister -p beagleconnect_freedom/cc1352p7 -s sample.mcumgr.smp_svr.udp.802154.subg
```

:blue_square: #96847 got opened and removed the `overlay-` prefix
:green_square: #96732 got opened and added one more test relying on an `overlay-` file
:blue_square: #96847 got merged
:green_square: #96732 got merged

So it's a race condition on the PRs, and I have no idea if it is even possible to avoid this!

Either way, here is the fix.