### PR TITLE
drivers: memory: aps6404l: Removed addressshift field from APS6404L d…

### DIFF
--- a/drivers/memc/memc_mcux_flexspi_aps6404l.c
+++ b/drivers/memc/memc_mcux_flexspi_aps6404l.c
@@ -222,7 +222,6 @@ static int memc_flexspi_aps6404l_init(const struct device *dev)
 		.flexspiRootClk = DT_INST_PROP(n, spi_max_frequency),	\
 		.isSck2Enabled = false,					\
 		.flashSize = DT_INST_PROP(n, size) / 8 / KB(1),		\
-		.addressShift = false,					\
 		.CSIntervalUnit =					\
 			CS_INTERVAL_UNIT(				\
 				DT_INST_PROP(n, cs_interval_unit)),	\


### PR DESCRIPTION
Memory APS6404L does not support address shift feature. Since it is being configured for different platforms that uses this memory, this is causing an error while building.

Fixes: #83244