### PR TITLE
drivers: wifi: nxp: Add libcsi feature

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -806,6 +806,27 @@ config NXP_WIFI_CSI
 	help
 	  This option enable/disable channel state information collection.
 
+config NXP_LIBCSI_CM33
+	bool "Lib csi support CM33"
+	depends on NXP_WIFI_CSI_AMI
+	help
+	  Image build with lib csi support CM33.
+
+config NXP_LIBCSI_CM7_20M
+	bool "Lib csi support CM7 bandwidth 20M"
+	depends on NXP_WIFI_CSI_AMI
+	help
+	  Image build with lib csi support CM7 bandwidth 20M.
+
+config NXP_WIFI_CSI_AMI
+	bool "CSI AMI support"
+	select FPU
+	select NXP_LIBCSI_CM33 if NXP_RW610
+	select NXP_LIBCSI_CM7_20M if NXP_IW610
+	depends on NXP_WIFI_CSI
+	help
+	  This option enable/disable channel state information to calculate ambient motion index feature.
+
 config NXP_WIFI_RESET
 	bool "Wi-Fi reset"
 	default y

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 7bf6f09cc6e544d75bdc29ddde054d83208262d7
+      revision: 24eff600bd8001fe2b4813f68aa4b0f78e55c219
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
CSI feaure switch to use static library.

- Binary blob origin: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.2.2/
- Type of blob (precompiled library, firmware image): Precompiled library
- Zephyr module that the blob(s) will be referenced from: wifi_nxp 
- Brief description of what the blob(s) do: Implemented an algorithm for processing CSI information
- What other components do the blob(s) depend on, if any? Does not depend on any component
- License the blob(s) are distributed under：LA_OPT_NXP_Software_License