### PR TITLE
scripts: ci: use vermin 1.7.0

### DIFF
--- a/scripts/requirements-actions.txt
+++ b/scripts/requirements-actions.txt
@@ -1544,9 +1544,9 @@ urllib3==2.5.0 \
     #   elastic-transport
     #   pygithub
     #   requests
-vermin==1.6.0 \
-    --hash=sha256:6266ca02f55d1c2aa189a610017c132eb2d1934f09e72a955b1eb3820ee6d4ef \
-    --hash=sha256:f1fa9ee40f59983dc40e0477eb2b1fa8061a3df4c3b2bcf349add462a5610efb
+vermin==1.7.0 \
+    --hash=sha256:5accad5f3599e428663af9f872debe27383edb85f737406f2d20855356e6ac2f \
+    --hash=sha256:e9e3c2c901dc2ceec746d9b9e807d6639ec4233a749ad62f51bc0334fbb38707
     # via -r requirements-actions.in
 virtualenv==20.34.0 \
     --hash=sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026 \


### PR DESCRIPTION
After having released version [1.7.0](https://github.com/netromdk/vermin/releases/tag/v1.7.0) of Vermin ([PyPi](https://pypi.org/project/vermin/1.7.0/)) it would make sense to also use it for the Zephyr CI pipelines.