### PR TITLE
correct mcxn23x and mcxnx4x edma properties information

### DIFF
--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -498,7 +498,7 @@
 		compatible = "nxp,mcux-edma";
 		nxp,version = <4>;
 		dma-channels = <16>;
-		dma-requests = <120>;
+		dma-requests = <94>;
 
 		reg = <0x80000 0x1000>;
 		interrupts = <1 0>, <2 0>, <3 0>, <4 0>,
@@ -513,14 +513,12 @@
 		#dma-cells = <2>;
 		compatible = "nxp,mcux-edma";
 		nxp,version = <4>;
-		dma-channels = <16>;
-		dma-requests = <120>;
+		dma-channels = <8>;
+		dma-requests = <94>;
 
 		reg = <0xa0000 0x1000>;
 		interrupts = <77 0>, <78 0>, <79 0>, <80 0>,
-			     <81 0>, <82 0>, <83 0>, <84 0>,
-			     <85 0>, <86 0>, <87 0>, <88 0>,
-			     <89 0>, <90 0>, <91 0>, <92 0>;
+			     <81 0>, <82 0>, <83 0>, <84 0>;
 		no-error-irq;
 		status = "disabled";
 	};

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -595,7 +595,7 @@
 		compatible = "nxp,mcux-edma";
 		nxp,version = <4>;
 		dma-channels = <16>;
-		dma-requests = <120>;
+		dma-requests = <117>;
 
 		reg = <0x80000 0x1000>;
 		interrupts = <1 0>, <2 0>, <3 0>, <4 0>,
@@ -611,7 +611,7 @@
 		compatible = "nxp,mcux-edma";
 		nxp,version = <4>;
 		dma-channels = <16>;
-		dma-requests = <120>;
+		dma-requests = <117>;
 
 		reg = <0xa0000 0x1000>;
 		interrupts = <77 0>, <78 0>, <79 0>, <80 0>,


### PR DESCRIPTION
The EDMA1 controller on MCXN236 SoCs has 8 channels not 16.
see:https://github.com/zephyrproject-rtos/hal_nxp/blob/master/mcux/mcux-sdk-ng/devices/MCX/MCXN/MCXN236/MCXN236_COMMON.h#L162
85-92 are resolved