### PR TITLE
soc: nxp: imx943: fix error: iteration 15 invokes undefined behavior

### DIFF
--- a/soc/nxp/imx/imx9/imx943/pm_mcore.c
+++ b/soc/nxp/imx/imx9/imx943/pm_mcore.c
@@ -37,7 +37,9 @@ static void pm_state_before(void)
 
 	/* IRQs enabled at NVIC level become GPC wake sources */
 	for (uint32_t idx = 0; idx < nvic_iser_nb; idx++) {
-		wake_mask[idx] = ~(NVIC->ISER[idx]);
+		if (idx < GPC_CPU_CTRL_CMC_IRQ_WAKEUP_MASK_COUNT) {
+			wake_mask[idx] = ~(NVIC->ISER[idx]);
+		}
 	}
 
 	cpu_irq_mask_cfg.cpu_id = cpu_idx;


### PR DESCRIPTION
This commit fixes error:
- iteration 15 invokes undefined behavior. It is from the patch c992e1a11ea82efbb6fba93e990bcd5fe47fe571
- soc: nxp: imx943: implement basic PM flow for Cortex-M cores