### PR TITLE
boards: phytec: phyboard_nash: doc: fix core name

### DIFF
--- a/boards/phytec/phyboard_nash/doc/index.rst
+++ b/boards/phytec/phyboard_nash/doc/index.rst
@@ -161,8 +161,8 @@ display the following console output:
     *** Booting Zephyr OS build v3.7.0-848-gb4d99b124c6d ***
     Hello World! phyboard_nash/mimx9352/m33
 
-Starting the M7-Core from U-Boot and Linux
-==========================================
+Starting the M33-Core from U-Boot and Linux
+===========================================
 
 Loading binaries and starting the M33-Core is supported from Linux via
 remoteproc. Please check the `phyCORE-i.MX93 BSP Manual`_ for more information.


### PR DESCRIPTION
It's M33 rather than M7.