### PR TITLE
posix: c_lib_ext: fnmatch: add support for posix character classes

### DIFF
--- a/include/zephyr/posix/fnmatch.h
+++ b/include/zephyr/posix/fnmatch.h
@@ -38,11 +38,13 @@
 
 #define FNM_NOMATCH 1 /**< Match failed */
 
-#define FNM_NOESCAPE    0x01 /**< Disable backslash escaping */
-#define FNM_PATHNAME    0x02 /**< Slash must be matched by slash */
-#define FNM_PERIOD      0x04 /**< Period must be matched by period */
-#define FNM_CASEFOLD    0x08 /**< Pattern is matched case-insensitive */
-#define FNM_LEADING_DIR 0x10 /**< Only match the initial segment of a string up to the first '/' */
+#define FNM_NOESCAPE 0x01 /**< Disable backslash escaping */
+#define FNM_PATHNAME 0x02 /**< Slash must be matched by slash */
+#define FNM_PERIOD   0x04 /**< Period must be matched by period */
+#define FNM_CASEFOLD 0x08 /**< Pattern is matched case-insensitive */
+#define FNM_LEADING_DIR                                                                            \
+	0x10 /**< Only match the initial segment of a string up to the first '/'                   \
+	      */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/posix/fnmatch.h
+++ b/include/zephyr/posix/fnmatch.h
@@ -38,11 +38,11 @@
 
 #define FNM_NOMATCH 1 /**< Match failed */
 
-#define FNM_NOESCAPE	0x01 /* Disable backslash escaping. */
-#define FNM_PATHNAME	0x02 /* Slash must be matched by slash. */
-#define FNM_PERIOD	0x04 /* Period must be matched by period. */
-#define FNM_CASEFOLD	0x08 /* Pattern is matched case-insensitive */
-#define FNM_LEADING_DIR 0x10 /* Ignore /<tail> after Imatch. */
+#define FNM_NOESCAPE    0x01 /**< Disable backslash escaping */
+#define FNM_PATHNAME    0x02 /**< Slash must be matched by slash */
+#define FNM_PERIOD      0x04 /**< Period must be matched by period */
+#define FNM_CASEFOLD    0x08 /**< Pattern is matched case-insensitive */
+#define FNM_LEADING_DIR 0x10 /**< Only match the initial segment of a string up to the first '/' */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/posix/fnmatch.h
+++ b/include/zephyr/posix/fnmatch.h
@@ -36,9 +36,7 @@
 #ifndef _FNMATCH_H_
 #define _FNMATCH_H_
 
-#define FNM_NOMATCH 1 /* Match failed. */
-#define FNM_NOSYS   2 /* Function not implemented. */
-#define FNM_NORES   3 /* Out of resources */
+#define FNM_NOMATCH 1 /**< Match failed */
 
 #define FNM_NOESCAPE	0x01 /* Disable backslash escaping. */
 #define FNM_PATHNAME	0x02 /* Slash must be matched by slash. */
@@ -50,7 +48,18 @@
 extern "C" {
 #endif
 
-int fnmatch(const char *, const char *, int);
+/**
+ * @brief Check if a filename or input string matches a shell-style matching pattern.
+ *
+ * @param pattern pattern that is matched against @param string
+ * @param string input string to match against @param pattern
+ * @param flags flags used to signal special matching conditions such as @ref FNM_NOESCAPE
+ *
+ *
+ * @retval 0 pattern found in string
+ * @retval FNM_NOMATCH pattern not found in string
+ */
+int fnmatch(const char *pattern, const char *string, int flags);
 
 #ifdef __cplusplus
 }

--- a/lib/posix/c_lib_ext/fnmatch.c
+++ b/lib/posix/c_lib_ext/fnmatch.c
@@ -303,7 +303,7 @@ static int fnmatchx(const char *pattern, const char *string, int flags, size_t r
 	}
 
 	if (recursion-- == 0) {
-		return FNM_NORES;
+		return FNM_NOMATCH;
 	}
 
 	for (stringstart = string;;) {

--- a/lib/posix/c_lib_ext/fnmatch.c
+++ b/lib/posix/c_lib_ext/fnmatch.c
@@ -48,11 +48,13 @@
 
 #define EOS '\0'
 
-#define MATCH_CLASS6(p,a,b,c,d,e,f,g) \
-	((p)[0]==(a) && (p)[1]==(b) && (p)[2]==(c) && (p)[3]==(d) && (p)[4]==(e) && (p)[5]==(f) && (p)[6]==(g))
+#define MATCH_CLASS6(p, a, b, c, d, e, f, g)                                                       \
+	((p)[0] == (a) && (p)[1] == (b) && (p)[2] == (c) && (p)[3] == (d) && (p)[4] == (e) &&      \
+	 (p)[5] == (f) && (p)[6] == (g))
 
-#define MATCH_CLASS7(p,a,b,c,d,e,f,g,h) \
-	((p)[0]==(a) && (p)[1]==(b) && (p)[2]==(c) && (p)[3]==(d) && (p)[4]==(e) && (p)[5]==(f) && (p)[6]==(g) && (p)[7]==(h))
+#define MATCH_CLASS7(p, a, b, c, d, e, f, g, h)                                                    \
+	((p)[0] == (a) && (p)[1] == (b) && (p)[2] == (c) && (p)[3] == (d) && (p)[4] == (e) &&      \
+	 (p)[5] == (f) && (p)[6] == (g) && (p)[7] == (h))
 
 enum fnm_char_class {
 	FNM_CC_ALNUM,
@@ -76,84 +78,84 @@ static bool fnm_cc_is_valid(const char *pattern, size_t psize, enum fnm_char_cla
 		return false;
 	}
 
-	pattern++;  /* skip ':' */
+	pattern++; /* skip ':' */
 	psize--;
 
 	/* Each class name ends with ":]" */
 	switch (pattern[0]) {
 	case 'a':
-		if (MATCH_CLASS6(pattern,'a','l','n','u','m',':',']')) {
+		if (MATCH_CLASS6(pattern, 'a', 'l', 'n', 'u', 'm', ':', ']')) {
 			*cc = FNM_CC_ALNUM;
 			return true;
 		}
-		if (MATCH_CLASS6(pattern,'a','l','p','h','a',':',']')) {
+		if (MATCH_CLASS6(pattern, 'a', 'l', 'p', 'h', 'a', ':', ']')) {
 			*cc = FNM_CC_ALPHA;
 			return true;
 		}
 		break;
-	
+
 	case 'b':
-		if (MATCH_CLASS6(pattern,'b','l','a','n','k',':',']')) {
+		if (MATCH_CLASS6(pattern, 'b', 'l', 'a', 'n', 'k', ':', ']')) {
 			*cc = FNM_CC_BLANK;
 			return true;
 		}
 		break;
 
 	case 'c':
-		if (MATCH_CLASS6(pattern,'c','n','t','r','l',':',']')) {
+		if (MATCH_CLASS6(pattern, 'c', 'n', 't', 'r', 'l', ':', ']')) {
 			*cc = FNM_CC_CNTRL;
 			return true;
 		}
 		break;
 
 	case 'd':
-		if (MATCH_CLASS6(pattern,'d','i','g','i','t',':',']')) {
+		if (MATCH_CLASS6(pattern, 'd', 'i', 'g', 'i', 't', ':', ']')) {
 			*cc = FNM_CC_DIGIT;
 			return true;
 		}
 		break;
 
 	case 'g':
-		if (MATCH_CLASS6(pattern,'g','r','a','p','h',':',']')) {
+		if (MATCH_CLASS6(pattern, 'g', 'r', 'a', 'p', 'h', ':', ']')) {
 			*cc = FNM_CC_GRAPH;
 			return true;
 		}
 		break;
 
 	case 'l':
-		if (MATCH_CLASS6(pattern,'l','o','w','e','r',':',']')) {
+		if (MATCH_CLASS6(pattern, 'l', 'o', 'w', 'e', 'r', ':', ']')) {
 			*cc = FNM_CC_LOWER;
 			return true;
 		}
 		break;
 
 	case 'p':
-		if (MATCH_CLASS6(pattern,'p','r','i','n','t',':',']')) {
+		if (MATCH_CLASS6(pattern, 'p', 'r', 'i', 'n', 't', ':', ']')) {
 			*cc = FNM_CC_PRINT;
 			return true;
 		}
-		if (MATCH_CLASS6(pattern,'p','u','n','c','t',':',']')) {
+		if (MATCH_CLASS6(pattern, 'p', 'u', 'n', 'c', 't', ':', ']')) {
 			*cc = FNM_CC_PUNCT;
 			return true;
 		}
 		break;
 
 	case 's':
-		if (MATCH_CLASS6(pattern,'s','p','a','c','e',':',']')) {
+		if (MATCH_CLASS6(pattern, 's', 'p', 'a', 'c', 'e', ':', ']')) {
 			*cc = FNM_CC_SPACE;
 			return true;
 		}
 		break;
 
 	case 'u':
-		if (MATCH_CLASS6(pattern,'u','p','p','e','r',':',']')) {
+		if (MATCH_CLASS6(pattern, 'u', 'p', 'p', 'e', 'r', ':', ']')) {
 			*cc = FNM_CC_UPPER;
 			return true;
 		}
 		break;
 
 	case 'x':
-		if (MATCH_CLASS7(pattern,'x','d','i','g','i','t',':',']')) {
+		if (MATCH_CLASS7(pattern, 'x', 'd', 'i', 'g', 'i', 't', ':', ']')) {
 			*cc = FNM_CC_XDIGIT;
 			return true;
 		}
@@ -169,18 +171,30 @@ static bool fnm_cc_is_valid(const char *pattern, size_t psize, enum fnm_char_cla
 static inline int fnm_cc_match(int c, enum fnm_char_class cc)
 {
 	switch (cc) {
-	case FNM_CC_ALNUM:  return isalnum(c);
-	case FNM_CC_ALPHA:  return isalpha(c);
-	case FNM_CC_BLANK:  return isblank(c);
-	case FNM_CC_CNTRL:  return iscntrl(c);
-	case FNM_CC_DIGIT:  return isdigit(c);
-	case FNM_CC_GRAPH:  return isgraph(c);
-	case FNM_CC_LOWER:  return islower(c);
-	case FNM_CC_PRINT:  return isprint(c);
-	case FNM_CC_PUNCT:  return ispunct(c);
-	case FNM_CC_SPACE:  return isspace(c);
-	case FNM_CC_UPPER:  return isupper(c);
-	case FNM_CC_XDIGIT: return isxdigit(c);
+	case FNM_CC_ALNUM:
+		return isalnum(c);
+	case FNM_CC_ALPHA:
+		return isalpha(c);
+	case FNM_CC_BLANK:
+		return isblank(c);
+	case FNM_CC_CNTRL:
+		return iscntrl(c);
+	case FNM_CC_DIGIT:
+		return isdigit(c);
+	case FNM_CC_GRAPH:
+		return isgraph(c);
+	case FNM_CC_LOWER:
+		return islower(c);
+	case FNM_CC_PRINT:
+		return isprint(c);
+	case FNM_CC_PUNCT:
+		return ispunct(c);
+	case FNM_CC_SPACE:
+		return isspace(c);
+	case FNM_CC_UPPER:
+		return isupper(c);
+	case FNM_CC_XDIGIT:
+		return isxdigit(c);
 	default:
 		break;
 	}
@@ -213,6 +227,7 @@ static bool match_posix_class(const char **pattern, int test)
 
 	/* move pattern pointer past ":]" */
 	const char *end = strstr(p, ":]");
+
 	if (end) {
 		*pattern = end + 2;
 	}

--- a/lib/posix/c_lib_ext/fnmatch.c
+++ b/lib/posix/c_lib_ext/fnmatch.c
@@ -72,8 +72,9 @@ enum fnm_char_class {
 
 static bool fnm_cc_is_valid(const char *pattern, size_t psize, enum fnm_char_class *cc)
 {
-	if (psize < 4 || *pattern != ':')
+	if (psize < 4 || *pattern != ':') {
 		return false;
+	}
 
 	pattern++;  /* skip ':' */
 	psize--;
@@ -187,7 +188,6 @@ static inline int fnm_cc_match(int c, enum fnm_char_class cc)
 	return 0;
 }
 
-
 static inline int foldcase(int ch, int flags)
 {
 
@@ -207,13 +207,15 @@ static bool match_posix_class(const char **pattern, int test)
 	const char *p = *pattern;
 	size_t remaining = strlen(p);
 
-	if (!fnm_cc_is_valid(p, remaining, &cc))
+	if (!fnm_cc_is_valid(p, remaining, &cc)) {
 		return false;
+	}
 
 	/* move pattern pointer past ":]" */
 	const char *end = strstr(p, ":]");
-	if (end)
+	if (end) {
 		*pattern = end + 2;
+	}
 
 	return fnm_cc_match(test, cc);
 }
@@ -262,9 +264,14 @@ static const char *rangematch(const char *pattern, int test, int flags)
 				ok = true;
 				continue;
 			} else {
-				// skip over class if unrecognized
-				while (*pattern && !(*pattern == ':' && *(pattern+1) == ']')) pattern++;
-				if (*pattern) pattern += 2;
+				/* skip over class if unrecognized */
+				while (*pattern && !(*pattern == ':' && *(pattern + 1) == ']')) {
+					pattern++;
+				}
+
+				if (*pattern) {
+					pattern += 2;
+				}
 				continue;
 			}
 		}

--- a/lib/posix/c_lib_ext/fnmatch.c
+++ b/lib/posix/c_lib_ext/fnmatch.c
@@ -48,6 +48,146 @@
 
 #define EOS '\0'
 
+#define MATCH_CLASS6(p,a,b,c,d,e,f,g) \
+	((p)[0]==(a) && (p)[1]==(b) && (p)[2]==(c) && (p)[3]==(d) && (p)[4]==(e) && (p)[5]==(f) && (p)[6]==(g))
+
+#define MATCH_CLASS7(p,a,b,c,d,e,f,g,h) \
+	((p)[0]==(a) && (p)[1]==(b) && (p)[2]==(c) && (p)[3]==(d) && (p)[4]==(e) && (p)[5]==(f) && (p)[6]==(g) && (p)[7]==(h))
+
+enum fnm_char_class {
+	FNM_CC_ALNUM,
+	FNM_CC_ALPHA,
+	FNM_CC_BLANK,
+	FNM_CC_CNTRL,
+	FNM_CC_DIGIT,
+	FNM_CC_GRAPH,
+	FNM_CC_LOWER,
+	FNM_CC_PRINT,
+	FNM_CC_PUNCT,
+	FNM_CC_SPACE,
+	FNM_CC_UPPER,
+	FNM_CC_XDIGIT,
+	FNM_CC_INVALID,
+};
+
+static bool fnm_cc_is_valid(const char *pattern, size_t psize, enum fnm_char_class *cc)
+{
+	if (psize < 4 || *pattern != ':')
+		return false;
+
+	pattern++;  /* skip ':' */
+	psize--;
+
+	/* Each class name ends with ":]" */
+	switch (pattern[0]) {
+	case 'a':
+		if (MATCH_CLASS6(pattern,'a','l','n','u','m',':',']')) {
+			*cc = FNM_CC_ALNUM;
+			return true;
+		}
+		if (MATCH_CLASS6(pattern,'a','l','p','h','a',':',']')) {
+			*cc = FNM_CC_ALPHA;
+			return true;
+		}
+		break;
+	
+	case 'b':
+		if (MATCH_CLASS6(pattern,'b','l','a','n','k',':',']')) {
+			*cc = FNM_CC_BLANK;
+			return true;
+		}
+		break;
+
+	case 'c':
+		if (MATCH_CLASS6(pattern,'c','n','t','r','l',':',']')) {
+			*cc = FNM_CC_CNTRL;
+			return true;
+		}
+		break;
+
+	case 'd':
+		if (MATCH_CLASS6(pattern,'d','i','g','i','t',':',']')) {
+			*cc = FNM_CC_DIGIT;
+			return true;
+		}
+		break;
+
+	case 'g':
+		if (MATCH_CLASS6(pattern,'g','r','a','p','h',':',']')) {
+			*cc = FNM_CC_GRAPH;
+			return true;
+		}
+		break;
+
+	case 'l':
+		if (MATCH_CLASS6(pattern,'l','o','w','e','r',':',']')) {
+			*cc = FNM_CC_LOWER;
+			return true;
+		}
+		break;
+
+	case 'p':
+		if (MATCH_CLASS6(pattern,'p','r','i','n','t',':',']')) {
+			*cc = FNM_CC_PRINT;
+			return true;
+		}
+		if (MATCH_CLASS6(pattern,'p','u','n','c','t',':',']')) {
+			*cc = FNM_CC_PUNCT;
+			return true;
+		}
+		break;
+
+	case 's':
+		if (MATCH_CLASS6(pattern,'s','p','a','c','e',':',']')) {
+			*cc = FNM_CC_SPACE;
+			return true;
+		}
+		break;
+
+	case 'u':
+		if (MATCH_CLASS6(pattern,'u','p','p','e','r',':',']')) {
+			*cc = FNM_CC_UPPER;
+			return true;
+		}
+		break;
+
+	case 'x':
+		if (MATCH_CLASS7(pattern,'x','d','i','g','i','t',':',']')) {
+			*cc = FNM_CC_XDIGIT;
+			return true;
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	return false;
+}
+
+static inline int fnm_cc_match(int c, enum fnm_char_class cc)
+{
+	switch (cc) {
+	case FNM_CC_ALNUM:  return isalnum(c);
+	case FNM_CC_ALPHA:  return isalpha(c);
+	case FNM_CC_BLANK:  return isblank(c);
+	case FNM_CC_CNTRL:  return iscntrl(c);
+	case FNM_CC_DIGIT:  return isdigit(c);
+	case FNM_CC_GRAPH:  return isgraph(c);
+	case FNM_CC_LOWER:  return islower(c);
+	case FNM_CC_PRINT:  return isprint(c);
+	case FNM_CC_PUNCT:  return ispunct(c);
+	case FNM_CC_SPACE:  return isspace(c);
+	case FNM_CC_UPPER:  return isupper(c);
+	case FNM_CC_XDIGIT: return isxdigit(c);
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+
 static inline int foldcase(int ch, int flags)
 {
 
@@ -59,6 +199,24 @@ static inline int foldcase(int ch, int flags)
 }
 
 #define FOLDCASE(ch, flags) foldcase((unsigned char)(ch), (flags))
+
+static bool match_posix_class(const char **pattern, int test)
+{
+	enum fnm_char_class cc;
+
+	const char *p = *pattern;
+	size_t remaining = strlen(p);
+
+	if (!fnm_cc_is_valid(p, remaining, &cc))
+		return false;
+
+	/* move pattern pointer past ":]" */
+	const char *end = strstr(p, ":]");
+	if (end)
+		*pattern = end + 2;
+
+	return fnm_cc_match(test, cc);
+}
 
 static const char *rangematch(const char *pattern, int test, int flags)
 {
@@ -97,6 +255,18 @@ static const char *rangematch(const char *pattern, int test, int flags)
 
 		if (c == EOS) {
 			return NULL;
+		}
+
+		if (c == '[' && *pattern == ':') {
+			if (match_posix_class(&pattern, test)) {
+				ok = true;
+				continue;
+			} else {
+				// skip over class if unrecognized
+				while (*pattern && !(*pattern == ':' && *(pattern+1) == ']')) pattern++;
+				if (*pattern) pattern += 2;
+				continue;
+			}
 		}
 
 		if (*pattern == '-') {

--- a/tests/posix/c_lib_ext/src/fnmatch.c
+++ b/tests/posix/c_lib_ext/src/fnmatch.c
@@ -13,8 +13,6 @@
  */
 ZTEST(posix_c_lib_ext, test_fnmatch)
 {
-	/* Note: commented out lines indicate known problems to be addressed in #55186 */
-
 	zassert_ok(fnmatch("*.c", "foo.c", 0));
 	zassert_ok(fnmatch("*.c", ".c", 0));
 	zassert_equal(fnmatch("*.a", "foo.c", 0), FNM_NOMATCH);
@@ -73,7 +71,7 @@ ZTEST(posix_c_lib_ext, test_fnmatch)
 	zassert_equal(fnmatch("*/*", "a/.b", FNM_PATHNAME | FNM_PERIOD), FNM_NOMATCH);
 	zassert_ok(fnmatch("*?*/*", "a/.b", FNM_PERIOD));
 	zassert_ok(fnmatch("*[.]/b", "a./b", FNM_PATHNAME | FNM_PERIOD));
-	/* zassert_ok(fnmatch("*[[:alpha:]]/""*[[:alnum:]]", "a/b", FNM_PATHNAME)); */
+	zassert_ok(fnmatch("*[[:alpha:]]/""*[[:alnum:]]", "a/b", FNM_PATHNAME));
 	zassert_not_equal(fnmatch("*[![:digit:]]*/[![:d-d]", "a/b", FNM_PATHNAME), 0);
 	zassert_not_equal(fnmatch("*[![:digit:]]*/[[:d-d]", "a/[", FNM_PATHNAME), 0);
 	zassert_not_equal(fnmatch("*[![:digit:]]*/[![:d-d]", "a/[", FNM_PATHNAME), 0);


### PR DESCRIPTION
Fixed failling tests in fnmatch.c test file.
Removed duplicated code and added simplicfications.
Added new test cases.

Stepts to test run:  `west build -p -b qemu_cortex_a53 -t run tests/posix/c_lib_ext/` 
in the shell and you shall get the next result:
`- PASS - [posix_c_lib_ext.test_fnmatch] duration = 0.001 seconds`

Fixes #55186