### PR TITLE
log: output: log thread priority

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -310,11 +310,18 @@ static int ids_print(const struct log_output *output,
 	}
 
 	if (IS_ENABLED(CONFIG_LOG_THREAD_ID_PREFIX) && thread_on) {
-		if (IS_ENABLED(CONFIG_THREAD_NAME)) {
-			total += print_formatted(output, "[%s] ",
-				tid == NULL ? "irq" : k_thread_name_get(tid));
+		if (tid == NULL) {
+			total += print_formatted(output, "[irq] ");
+		} else if (IS_ENABLED(CONFIG_THREAD_NAME)) {
+			total += print_formatted(output,
+					"[%3d %s] ",
+					k_thread_priority_get(tid),
+					k_thread_name_get(tid));
 		} else {
-			total += print_formatted(output, "[%p] ", tid);
+			total += print_formatted(output,
+					"[%3d %p] ",
+					k_thread_priority_get(tid),
+					tid);
 		}
 	}
 

--- a/tests/subsys/logging/log_output/src/log_output_test.c
+++ b/tests/subsys/logging/log_output/src/log_output_test.c
@@ -246,10 +246,14 @@ ZTEST(test_log_output, test_thread_id)
 	char exp_str[256];
 	char package[256];
 
+	k_tid_t tid = k_current_get();
+	const char *name = k_thread_name_get(tid);
+	int prio = k_thread_priority_get(tid);
+
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
-		sprintf(exp_str, "<err> [%s] src: Test\r\n", k_thread_name_get(k_current_get()));
+		sprintf(exp_str, "<err> [%3d %s] src: Test\r\n", prio, name);
 	} else {
-		sprintf(exp_str, "<err> [%p] src: Test\r\n", k_current_get());
+		sprintf(exp_str, "<err> [%3d %p] src: Test\r\n", prio, tid);
 	}
 
 	uint32_t flags = LOG_OUTPUT_FLAG_LEVEL | LOG_OUTPUT_FLAG_THREAD;


### PR DESCRIPTION
When logging thread names also log their priorities.

As @tpambor pointed out. Suffers from the same limitation as the name. See https://github.com/zephyrproject-rtos/zephyr/issues/95077

Let me know, if this is not wanted or if this shoudl be under an additional configuration option.