### PR TITLE
DT_INST_STRING_TOKEN_BY_IDX_OR macro

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) 2020 Nordic Semiconductor
  * Copyright (c) 2020, Linaro Ltd.
+ * Copyright (c) 2025 The Zephyr Project Contributors
  *
  * Not a generated file. Feel free to modify.
  */
@@ -1321,6 +1322,18 @@
  */
 #define DT_STRING_TOKEN_BY_IDX(node_id, prop, idx) \
 	DT_CAT6(node_id, _P_, prop, _IDX_, idx, _STRING_TOKEN)
+
+/**
+ * @brief Like DT_STRING_TOKEN_BY_IDX(), but with a fallback to @p default_value
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param idx the index to get
+ * @param default_value a fallback value to expand to
+ * @return the element in @p prop at index @p idx as a token, or @p default_value
+ */
+#define DT_STRING_TOKEN_BY_IDX_OR(node_id, prop, idx, default_value) \
+	COND_CODE_1(DT_PROP_HAS_IDX(node_id, prop, idx), \
+		    (DT_STRING_TOKEN_BY_IDX(node_id, prop, idx)), (default_value))
 
 /**
  * @brief Like DT_STRING_TOKEN_BY_IDX(), but uppercased.
@@ -4417,6 +4430,17 @@
  */
 #define DT_INST_STRING_TOKEN_BY_IDX(inst, prop, idx) \
 	DT_STRING_TOKEN_BY_IDX(DT_DRV_INST(inst), prop, idx)
+
+/**
+ * @brief Like DT_INST_STRING_TOKEN_BY_IDX(), but with a fallback to @p default_value
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param idx the index to get
+ * @param default_value a fallback value to expand to
+ * @return the element in @p prop at index @p idx as a token, or @p default_value
+ */
+#define DT_INST_STRING_TOKEN_BY_IDX_OR(inst, prop, idx, default_value) \
+	DT_STRING_TOKEN_BY_IDX_OR(DT_DRV_INST(inst), prop, idx, default_value)
 
 /**
  * @brief Like DT_INST_STRING_TOKEN_BY_IDX(), but uppercased.

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -3430,7 +3430,9 @@ ZTEST(devicetree_api, test_string_token)
 #define DT_DRV_COMPAT vnd_string_array_token
 ZTEST(devicetree_api, test_string_idx_token)
 {
+	/* The enum has 7 values in total - thus invalid idx starts with 16 */
 	enum token_string_idx {
+		token_idx_default,
 		/* Tokens */
 		token_first_idx_zero,
 		token_first_idx_one,
@@ -3464,6 +3466,15 @@ ZTEST(devicetree_api, test_string_idx_token)
 			token_second_idx_two, "");
 	zassert_equal(DT_STRING_TOKEN_BY_IDX(DT_NODELABEL(test_str_array_token_1), val, 3),
 			token_second_idx_three, "");
+
+	/* Index is in range */
+	zassert_equal(DT_STRING_TOKEN_BY_IDX_OR(DT_NODELABEL(test_str_array_token_1), val, 3,
+						token_idx_default),
+		      token_second_idx_three, "");
+	/* Index is out of range */
+	zassert_equal(DT_STRING_TOKEN_BY_IDX_OR(DT_NODELABEL(test_str_array_token_1), val, 42,
+						token_idx_default),
+		      token_idx_default, "");
 
 	zassert_equal(DT_STRING_UPPER_TOKEN_BY_IDX(DT_NODELABEL(test_str_array_token_0), val, 0),
 			TOKEN_FIRST_IDX_ZERO, "");
@@ -3502,6 +3513,57 @@ ZTEST(devicetree_api, test_string_idx_token)
 			token_second_idx_one, "");
 	zassert_equal(STRING_TOKEN_BY_IDX_VAR(DT_NODELABEL(test_str_array_token_1))[2],
 			token_second_idx_two, "");
+
+	/* Test instances - index is in range */
+#define STRING_TOKEN_BY_IDX_OR_VAR_IN_RANGE(node_id) _CONCAT(var_in_range_token_or_, node_id)
+#define STRING_TOKEN_BY_IDX_OR_TEST_INST_EXPANSION_IN_RANGE(inst)                                  \
+	enum token_string_idx STRING_TOKEN_BY_IDX_OR_VAR_IN_RANGE(DT_DRV_INST(inst))[] = {         \
+		DT_INST_STRING_TOKEN_BY_IDX_OR(inst, val, 0, token_idx_default),                   \
+		DT_INST_STRING_TOKEN_BY_IDX_OR(inst, val, 1, token_idx_default),                   \
+		DT_INST_STRING_TOKEN_BY_IDX_OR(inst, val, 2, token_idx_default)};
+	DT_INST_FOREACH_STATUS_OKAY(STRING_TOKEN_BY_IDX_OR_TEST_INST_EXPANSION_IN_RANGE);
+
+	zassert_equal(STRING_TOKEN_BY_IDX_OR_VAR_IN_RANGE(DT_NODELABEL(test_str_array_token_0))[0],
+		      token_first_idx_zero, "");
+	zassert_equal(STRING_TOKEN_BY_IDX_OR_VAR_IN_RANGE(DT_NODELABEL(test_str_array_token_0))[1],
+		      token_first_idx_one, "");
+	zassert_equal(STRING_TOKEN_BY_IDX_OR_VAR_IN_RANGE(DT_NODELABEL(test_str_array_token_0))[2],
+		      token_first_idx_two, "");
+	zassert_equal(STRING_TOKEN_BY_IDX_OR_VAR_IN_RANGE(DT_NODELABEL(test_str_array_token_1))[0],
+		      token_second_idx_zero, "");
+	zassert_equal(STRING_TOKEN_BY_IDX_OR_VAR_IN_RANGE(DT_NODELABEL(test_str_array_token_1))[1],
+		      token_second_idx_one, "");
+	zassert_equal(STRING_TOKEN_BY_IDX_OR_VAR_IN_RANGE(DT_NODELABEL(test_str_array_token_1))[2],
+		      token_second_idx_two, "");
+
+	/* Test instances - index is out of range */
+#define STRING_TOKEN_BY_IDX_OR_VAR_NOT_IN_RANGE(node_id)                                           \
+	_CONCAT(var_not_in_range_token_or_, node_id)
+#define STRING_TOKEN_BY_IDX_OR_TEST_INST_EXPANSION_NOT_IN_RANGE(inst)                              \
+	enum token_string_idx STRING_TOKEN_BY_IDX_OR_VAR_NOT_IN_RANGE(DT_DRV_INST(inst))[] = {     \
+		DT_INST_STRING_TOKEN_BY_IDX_OR(inst, val, 15, token_idx_default),                  \
+		DT_INST_STRING_TOKEN_BY_IDX_OR(inst, val, 16, token_idx_default),                  \
+		DT_INST_STRING_TOKEN_BY_IDX_OR(inst, val, 17, token_idx_default)};
+	DT_INST_FOREACH_STATUS_OKAY(STRING_TOKEN_BY_IDX_OR_TEST_INST_EXPANSION_NOT_IN_RANGE);
+
+	zassert_equal(
+		STRING_TOKEN_BY_IDX_OR_VAR_NOT_IN_RANGE(DT_NODELABEL(test_str_array_token_0))[0],
+		token_idx_default, "");
+	zassert_equal(
+		STRING_TOKEN_BY_IDX_OR_VAR_NOT_IN_RANGE(DT_NODELABEL(test_str_array_token_0))[1],
+		token_idx_default, "");
+	zassert_equal(
+		STRING_TOKEN_BY_IDX_OR_VAR_NOT_IN_RANGE(DT_NODELABEL(test_str_array_token_0))[2],
+		token_idx_default, "");
+	zassert_equal(
+		STRING_TOKEN_BY_IDX_OR_VAR_NOT_IN_RANGE(DT_NODELABEL(test_str_array_token_1))[0],
+		token_idx_default, "");
+	zassert_equal(
+		STRING_TOKEN_BY_IDX_OR_VAR_NOT_IN_RANGE(DT_NODELABEL(test_str_array_token_1))[1],
+		token_idx_default, "");
+	zassert_equal(
+		STRING_TOKEN_BY_IDX_OR_VAR_NOT_IN_RANGE(DT_NODELABEL(test_str_array_token_1))[2],
+		token_idx_default, "");
 
 #define STRING_UPPER_TOKEN_BY_IDX_VAR(node_id) _CONCAT(var_upper_token, node_id)
 #define STRING_UPPER_TOKEN_BY_IDX_TEST_INST_EXPANSION(inst) \


### PR DESCRIPTION
This commit introduces the DT_INST_STRING_TOKEN_BY_IDX_OR macro, which allows specifying a default value if the indexed string token is not defined.

How-To-Test:

Introduce new property in any .yml file of your choice:

```yml
my-prop:
    required: true
    type: string-array
    enum:
      - FOO
      - BAR
```

Add it to any .dts:

```dts
node {
	my-prop = "FOO", "BAR";
	status = "okay";
};
```

Try to access from .c code an existing index:

```c
#define DT_INST_GET_MY_PROP(inst) DT_INST_STRING_TOKEN_BY_IDX_OR(inst, my_prop, 0, BAZ))
```

It shall return `FOO`.

Try to access from .c code a NON-existing index:

```c
#define DT_INST_GET_MY_PROP(inst) DT_INST_STRING_TOKEN_BY_IDX_OR(inst, my_prop, 3, BAZ))
```

It shall return `BAZ`.

UPD: Added tests under `tests/lib/devicetree/api`, thnx @JarmouniA

Run Twister Tests:

```bash
west twister -T tests/lib/devicetree/api
```