### PR TITLE
linker: native_sim: add __rom_region_start and __rom_region_end symbols

### DIFF
--- a/include/zephyr/arch/posix/linker.ld
+++ b/include/zephyr/arch/posix/linker.ld
@@ -27,6 +27,7 @@ SECTIONS
 
 SECTION_PROLOGUE(rom_start,,)
 {
+	__rom_region_start = ABSOLUTE(.);
 	/* Located in generated directory. This file is populated by the
 	 * zephyr_linker_sources() Cmake function.
 	 */
@@ -46,6 +47,9 @@ SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
 	 */
 	#include <snippets-rodata.ld>
 } GROUP_LINK_IN(ROMABLE_REGION)
+
+__rom_region_end  = .;
+__rom_region_size = __rom_region_end - __rom_region_start;
 
 SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
 {


### PR DESCRIPTION
Add missing `__rom_region_start` and `__rom_region_end` definitions to the native_sim linker script.

These symbols mark the ROM region boundaries and fix build errors in code that expects them.

`west build -p -b native_sim samples/sysbuild/with_mcuboot/` fails as reference.