### PR TITLE
soc: mspm0: Allow usage of SEGGER RTT

### DIFF
--- a/soc/ti/mspm0/Kconfig.soc
+++ b/soc/ti/mspm0/Kconfig.soc
@@ -6,6 +6,7 @@
 
 config SOC_FAMILY_TI_MSPM0
 	bool
+	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 
 config SOC_FAMILY
 	default "ti_mspm0" if SOC_FAMILY_TI_MSPM0


### PR DESCRIPTION
Allow usage of SEGGER RTT with Texas Instruments MSPM0 family