### PR TITLE
libc: minimal: sys/types.h: move mem_word_t to string.c

### DIFF
--- a/lib/libc/minimal/include/sys/types.h
+++ b/lib/libc/minimal/include/sys/types.h
@@ -46,18 +46,4 @@ typedef _TIME_T_ time_t;
 typedef _SUSECONDS_T_ suseconds_t;
 #endif
 
-#if !defined(__mem_word_t_defined)
-#define __mem_word_t_defined
-
-/*
- * The mem_word_t should match the optimal memory access word width
- * on the target platform. Here we defaults it to uintptr_t.
- */
-
-typedef uintptr_t mem_word_t;
-
-#define Z_MEM_WORD_T_WIDTH __INTPTR_WIDTH__
-
-#endif
-
 #endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_TYPES_H_ */

--- a/lib/libc/minimal/source/string/string.c
+++ b/lib/libc/minimal/source/string/string.c
@@ -10,6 +10,20 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#if !defined(__mem_word_t_defined)
+#define __mem_word_t_defined
+
+/*
+ * The mem_word_t should match the optimal memory access word width
+ * on the target platform. Here we default it to uintptr_t.
+ */
+
+typedef uintptr_t mem_word_t;
+
+#define Z_MEM_WORD_T_WIDTH __INTPTR_WIDTH__
+
+#endif
+
 /**
  *
  * @brief Copy a string


### PR DESCRIPTION
The `sys/types.h` header is part of POSIX, which is optional in Zephyr and is mostly unimplemented by Zephyr's minimal C library.

Additionally, the only reason `sys/types.h` is included in `string.c` (in the minimal libc) is because of the non-standard `mem_word_t` type.

`mem_word_t` is not used anywhere else in-tree or in modules hosted by the Zephyr project. It is only used in `string.c` in the minimal c library.

It's definitely not specified here https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html and so does not really belong in `sys/types.h`.

Move `mem_word_t` into the minimal libc's `string.c`. If needed, it can be removed at a later date and switched for `uintptr_t`.