### PR TITLE
boards: st: n6_dk: fix active state for cd gpio

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -266,7 +266,7 @@ csi_i2c: &i2c1 {
 		     &sdmmc2_ck_pc2 &sdmmc2_cmd_pc3>;
 	pinctrl-names = "default";
 	bus-width = <4>;
-	cd-gpios = <&gpion 12 GPIO_ACTIVE_HIGH>;
+	cd-gpios = <&gpion 12 GPIO_ACTIVE_LOW>;
 	pwr-gpios = <&gpioq 7 GPIO_ACTIVE_HIGH>;
 	disk-name = "SD";
 };


### PR DESCRIPTION
CD pin of the SDMMC on the STM32N6570-DK board was incorrectly set as active high, but is actually active low:
<img width="501" height="279" alt="image" src="https://github.com/user-attachments/assets/3661b528-1504-4db8-a1c0-111d49fdd903" />
