### PR TITLE
tests: c_lib: common: remove test_time_t

### DIFF
--- a/tests/lib/c_lib/common/src/main.c
+++ b/tests/lib/c_lib/common/src/main.c
@@ -156,19 +156,6 @@ ZTEST(libc_common, test_stdint)
 #endif
 }
 
-/**
- * @brief Test time_t to make sure it is at least 64 bits
- *
- */
-ZTEST(libc_common, test_time_t)
-{
-#ifdef CONFIG_EXTERNAL_LIBC
-	ztest_test_skip();
-#else
-	zassert_true(sizeof(time_t) >= sizeof(uint64_t));
-#endif
-}
-
 /*
  * variables used during string library testing
  */


### PR DESCRIPTION
Previously, `time_t` was only checked in some C libraries to be greater than or equal to a 64-bit integer and it was skipped in other C libraries.

The C standard still does not make this guarantee, and other code within Zephyr already has been changed to accomodate both 32-bit `time_t` and 64-bit `time_t`.

There really is no point in having this test, since it is inconsistent at best.

Until Zephyr changes to a 64-bit `time_t` (e.g. `time64_t`), then there is no guarantee of safety against the Y2038 problem.