### PR TITLE
posix: sched: move sched_yield() to pthread.c

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -650,6 +650,7 @@ Enable this option group with :kconfig:option:`CONFIG_POSIX_THREADS`.
     pthread_setspecific(),yes
     pthread_sigmask(),yes
     pthread_testcancel(),yes
+    sched_yield(),yes
 
 .. _posix_option_group_posix_threads_ext:
 
@@ -910,7 +911,6 @@ Enable this option with :kconfig:option:`CONFIG_POSIX_PRIORITY_SCHEDULING`.
     sched_rr_get_interval(),yes :ref:`†<posix_undefined_behaviour>`
     sched_setparam(),yes :ref:`†<posix_undefined_behaviour>`
     sched_setscheduler(),yes :ref:`†<posix_undefined_behaviour>`
-    sched_yield(),yes
 
 .. _posix_option_raw_sockets:
 

--- a/include/zephyr/posix/sched.h
+++ b/include/zephyr/posix/sched.h
@@ -40,11 +40,7 @@ struct sched_param {
  *
  * See IEEE 1003.1
  */
-static inline int sched_yield(void)
-{
-	k_yield();
-	return 0;
-}
+int sched_yield(void);
 
 int sched_get_priority_min(int policy);
 int sched_get_priority_max(int policy);

--- a/lib/posix/options/Kconfig.pthread
+++ b/lib/posix/options/Kconfig.pthread
@@ -7,8 +7,23 @@
 menuconfig POSIX_THREADS
 	bool "POSIX thread support"
 	help
-	  Select 'y' here to enable POSIX threads, mutexes, condition variables, and thread-specific
-	  storage.
+	  Select 'y' here to enable POSIX threads, mutexes, condition variables, and
+	  thread-specific storage.
+
+	  This option makes the following functions available:
+	  pthread_atfork(), pthread_attr_destroy(), pthread_attr_getdetachstate(),
+	  pthread_attr_getschedparam(), pthread_attr_init(), pthread_attr_setdetachstate(),
+	  pthread_attr_setschedparam(), pthread_cancel(), pthread_cleanup_pop(),
+	  pthread_cleanup_push(), pthread_cond_broadcast(), pthread_cond_destroy(),
+	  pthread_cond_init(), pthread_cond_signal(), pthread_cond_timedwait(),
+	  pthread_cond_wait(), pthread_condattr_destroy(), pthread_condattr_init(),
+	  pthread_create(), pthread_detach(), pthread_equal(), pthread_exit(),
+	  pthread_getspecific(), pthread_join(), pthread_key_create(), pthread_key_delete(),
+	  pthread_kill(), pthread_mutex_destroy(), pthread_mutex_init(), pthread_mutex_lock(),
+	  pthread_mutex_timedlock(), pthread_mutex_trylock(), pthread_mutex_unlock(),
+	  pthread_mutexattr_destroy(), pthread_mutexattr_init(), pthread_once(), pthread_self(),
+	  pthread_setcancelstate(), pthread_setcanceltype(), pthread_setspecific(),
+	  pthread_sigmask(), pthread_testcancel(), and sched_yield().
 
 	  For more information please see
 	  https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html

--- a/lib/posix/options/pthread.c
+++ b/lib/posix/options/pthread.c
@@ -1551,3 +1551,9 @@ static int posix_thread_pool_init(void)
 	return 0;
 }
 SYS_INIT(posix_thread_pool_init, PRE_KERNEL_1, 0);
+
+int sched_yield(void)
+{
+	k_yield();
+	return 0;
+}


### PR DESCRIPTION
The `sched_yield()` function was originally included to facilitate the of `POSIX_REALTIME` and `POSIX_THREADS_EXT` Option Groups in Issue 5.

It was then marked as part of the `_POSIX_PROCESS_SCHEDULING` Option in Issue 6, and mentioned to be part of Threads in Issue 7, but then was not clearly marked as part of the `POSIX_THREADS(_BASE)` Option Group until Issue 8.

Moving it to `pthread.c` (and making it a function with regular linkage rather than inline) ensures that it will be available with the `POSIX_THREADS` Option Group.

For more information, please see `POSIX_THREADS_BASE` in https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html (Issue 7) and
https://pubs.opengroup.org/onlinepubs/9799919799/xrat/V4_subprofiles.html (Issue 8).