### PR TITLE
boards: Enable Neopixel LED on Adafruit Feather RP2040

### DIFF
--- a/boards/adafruit/feather_rp2040/adafruit_feather_rp2040-pinctrl.dtsi
+++ b/boards/adafruit/feather_rp2040/adafruit_feather_rp2040-pinctrl.dtsi
@@ -52,9 +52,9 @@
 		};
 	};
 
-	ws2812_pio1_default: ws2812_pio1_default {
+	ws2812_pio0_default: ws2812_pio0_default {
 		ws2812 {
-			pinmux = <PIO1_P12>;
+			pinmux = <PIO0_P16>;
 		};
 	};
 };

--- a/boards/adafruit/feather_rp2040/adafruit_feather_rp2040.dts
+++ b/boards/adafruit/feather_rp2040/adafruit_feather_rp2040.dts
@@ -116,25 +116,18 @@ zephyr_i2c: &i2c1 {
 
 &pio0 {
 	status = "okay";
-};
 
-&pio1 {
-	status = "okay";
-
-	/*
-	 * Need to put this on PIO1 as having this on PIO0 causes the GPIO hog to
-	 * not work.
-	 */
 	pio-ws2812 {
 		compatible = "worldsemi,ws2812-rpi_pico-pio";
 		status = "okay";
-		pinctrl-0 = <&ws2812_pio1_default>;
+		pinctrl-0 = <&ws2812_pio0_default>;
 		pinctrl-names = "default";
 		bit-waveform = <3>, <3>, <4>;
 
+		/* RGB LED (Neopixel) */
 		ws2812: ws2812 {
 			status = "okay";
-			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
 			chain-length = <1>;
 			color-mapping = <LED_COLOR_ID_GREEN
 					 LED_COLOR_ID_RED


### PR DESCRIPTION
The Neopixel is connected to pin P16, not P12. In order to make it work I had to change to PIO0, like the other Adafruit Feather boards with Neopixel.

The original devicetree entry seems to be from
boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts That board powers the Neopixel from a GPIO pin, why that GPIO line had to be hogged.

This board powers the Neopixel from +3.3 Volt, why no GPIO hogging is necessary. See https://learn.adafruit.com/adafruit-feather-rp2040-pico/downloads for schematic.

Tested with
west build -b adafruit_feather_rp2040 samples/drivers/led/led_strip/