### PR TITLE
boards: nxp: frdm_rw612: added arduino and mikrobus labels

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612-pinctrl.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612-pinctrl.dtsi
@@ -47,9 +47,14 @@
 		};
 	};
 
+	/* support CS0 (Arduino connector) and CS1 (MicroBus connector). */
 	pinmux_flexcomm1_spi: pinmux_flexcomm1_spi {
 		group0 {
 			pinmux = <IO_MUX_FC1_SPI_SS0>;
+			slew-rate = "ultra";
+		};
+		group1 {
+			pinmux = <IO_MUX_FC1_SPI_SS1>;
 			slew-rate = "ultra";
 		};
 	};

--- a/boards/nxp/frdm_rw612/frdm_rw612.yaml
+++ b/boards/nxp/frdm_rw612/frdm_rw612.yaml
@@ -16,6 +16,9 @@ flash: 65536
 supported:
   - arduino_gpio
   - gpio
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_spi
   - dma
   - spi
   - i2c

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -59,6 +59,25 @@
 			   <12 0 &hsgpio0 18 0>;  /* Pin 11, LCD touch INT */
 	};
 
+	mikrobus_header: mikrobus-connector {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &hsgpio1 29 0>,  /* AN */
+			   <1 0 &hsgpio0 19 0>,  /* RST */
+			   <2 0 &hsgpio0 10 0>,  /* CS */
+			   <3 0 &hsgpio0 7 0>,   /* SCK */
+			   <4 0 &hsgpio0 8 0>,   /* MISO */
+			   <5 0 &hsgpio0 9 0>,   /* MOSI */
+			   <6 0 &hsgpio0 1 0>,   /* PWM */
+			   <7 0 &hsgpio1 22 0>,  /* INT */
+			   <8 0 &hsgpio0 2 0>,   /* RX */
+			   <9 0 &hsgpio0 3 0>,   /* TX */
+			   <10 0 &hsgpio0 17 0>, /* SCL */
+			   <11 0 &hsgpio0 16 0>; /* SDA */
+	};
+
 	arduino_header: arduino-connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
@@ -102,6 +121,8 @@
 	pinctrl-0 = <&pinmux_flexcomm0_usart>;
 	pinctrl-names = "default";
 };
+
+mikrobus_serial: &flexcomm0 {};
 
 &hsgpio0 {
 	status = "okay";
@@ -301,6 +322,8 @@ zephyr_udc0: &usb_otg {
 
 arduino_spi: &flexcomm1 {};
 
+mikrobus_spi: &flexcomm1 {};
+
 &flexcomm2 {
 	compatible = "nxp,lpc-i2c";
 	status = "okay";
@@ -318,6 +341,8 @@ arduino_spi: &flexcomm1 {};
 };
 
 arduino_i2c: &flexcomm2 {};
+
+mikrobus_i2c: &flexcomm2 {};
 
 zephyr_mipi_dbi_spi: &lcdic {
 	status = "okay";

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -67,8 +67,8 @@
 		gpio-map = <ARDUINO_HEADER_R3_A0 0 &hsgpio1 10 0>,
 			   <ARDUINO_HEADER_R3_A1 0 &hsgpio1 11 0>,
 			   <ARDUINO_HEADER_R3_A2 0 &hsgpio1 13 0>,
-			   <ARDUINO_HEADER_R3_D0 0 &hsgpio0 9 0>,
-			   <ARDUINO_HEADER_R3_D1 0 &hsgpio0 8 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &hsgpio0 9 0>,   /* GPIO(D11), Not a RX */
+			   <ARDUINO_HEADER_R3_D1 0 &hsgpio0 8 0>,   /* GPIO(D12), Not a TX */
 			   <ARDUINO_HEADER_R3_D2 0 &hsgpio0 11 0>,
 			   <ARDUINO_HEADER_R3_D3 0 &hsgpio0 15 0>,
 			   <ARDUINO_HEADER_R3_D4 0 &hsgpio0 18 0>,
@@ -77,12 +77,12 @@
 			   <ARDUINO_HEADER_R3_D7 0 &hsgpio0 20 0>,
 			   <ARDUINO_HEADER_R3_D8 0 &hsgpio1 18 0>,
 			   <ARDUINO_HEADER_R3_D9 0 &hsgpio1 20 0>,
-			   <ARDUINO_HEADER_R3_D10 0 &hsgpio0 6 0>,
-			   <ARDUINO_HEADER_R3_D11 0 &hsgpio0 9 0>,
-			   <ARDUINO_HEADER_R3_D12 0 &hsgpio0 8 0>,
-			   <ARDUINO_HEADER_R3_D13 0 &hsgpio0 7 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &hsgpio0 16 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &hsgpio0 17 0>;
+			   <ARDUINO_HEADER_R3_D10 0 &hsgpio0 6 0>,  /* CS */
+			   <ARDUINO_HEADER_R3_D11 0 &hsgpio0 9 0>,  /* MOSI */
+			   <ARDUINO_HEADER_R3_D12 0 &hsgpio0 8 0>,  /* MISO */
+			   <ARDUINO_HEADER_R3_D13 0 &hsgpio0 7 0>,  /* SCK */
+			   <ARDUINO_HEADER_R3_D14 0 &hsgpio0 16 0>, /* SDA */
+			   <ARDUINO_HEADER_R3_D15 0 &hsgpio0 17 0>; /* SCL */
 	};
 };
 
@@ -299,7 +299,9 @@ zephyr_udc0: &usb_otg {
 	#size-cells = <0>;
 };
 
-arduino_i2c: &flexcomm2 {
+arduino_spi: &flexcomm1 {};
+
+&flexcomm2 {
 	compatible = "nxp,lpc-i2c";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
@@ -314,6 +316,8 @@ arduino_i2c: &flexcomm2 {
 		status = "okay";
 	};
 };
+
+arduino_i2c: &flexcomm2 {};
 
 zephyr_mipi_dbi_spi: &lcdic {
 	status = "okay";

--- a/samples/shields/x_nucleo_iks01a1/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a1/sample.yaml
@@ -4,6 +4,7 @@ tests:
   sample.shields.x_nucleo_iks01a1:
     platform_exclude:
       - disco_l475_iot1
+      - frdm_rw612
       - pan1781_evb
       - pan1782_evb
     harness: shield

--- a/samples/shields/x_nucleo_iks01a2/standard/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a2/standard/sample.yaml
@@ -9,6 +9,7 @@ tests:
       - arduino_gpio
     platform_exclude:
       - disco_l475_iot1
+      - frdm_rw612
       - lpcxpresso55s16
       - stm32mp157c_dk2
       - mimxrt1010_evk

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/sample.yaml
@@ -9,5 +9,6 @@ tests:
       - arduino_gpio
     platform_exclude:
       - disco_l475_iot1
+      - frdm_rw612
       - lpcxpresso55s16
       - mimxrt1010_evk

--- a/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
+++ b/samples/shields/x_nucleo_iks01a3/standard/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - arduino_gpio
     platform_exclude:
       - disco_l475_iot1
+      - frdm_rw612
       - lpcxpresso55s16
       - pan1781_evb
       - pan1782_evb

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/sample.yaml
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/sample.yaml
@@ -9,6 +9,7 @@ tests:
       - arduino_gpio
     platform_exclude:
       - disco_l475_iot1
+      - frdm_rw612
       - lpcxpresso55s16
       - stm32mp157c_dk2
       - pan1781_evb

--- a/samples/shields/x_nucleo_iks02a1/standard/sample.yaml
+++ b/samples/shields/x_nucleo_iks02a1/standard/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - arduino_gpio
     platform_exclude:
       - disco_l475_iot1
+      - frdm_rw612
       - lpcxpresso55s16
       - stm32mp157c_dk2
       - pan1781_evb

--- a/samples/shields/x_nucleo_iks4a1/sensorhub2/sample.yaml
+++ b/samples/shields/x_nucleo_iks4a1/sensorhub2/sample.yaml
@@ -9,6 +9,7 @@ tests:
       - arduino_gpio
     platform_exclude:
       - disco_l475_iot1
+      - frdm_rw612
       - lpcxpresso55s16
       - pan1781_evb
       - pan1782_evb

--- a/samples/shields/x_nucleo_iks4a1/standard/sample.yaml
+++ b/samples/shields/x_nucleo_iks4a1/standard/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - arduino_gpio
     platform_exclude:
       - disco_l475_iot1
+      - frdm_rw612
       - lpcxpresso55s16
       - mimxrt1010_evk
       - pan1781_evb


### PR DESCRIPTION
Added `arduino_spi`, `mikrobus_serial`, `mikrobus_i2c`, `mikrobus_spi` and `mikrobus_header` node labels to **FRDM-RW612** device tree board definition, allowing compatible shield boards to be used. Also extend the board YAML file with related support tags `arduino_gpio`, `arduino_i2c` and `arduino_spi`.

### Pull requests that depend on this and should be merged afterwards

- [ ] #97437