### PR TITLE
boards: nxp: frdm_mcxn947: added arduino and mikrobus labels

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
@@ -18,6 +18,18 @@
 		};
 	};
 
+	pinmux_flexcomm6_lpspi: pinmux_flexcomm6_lpspi {
+		group0 {
+			pinmux = <FC6_P0_PIO3_20>, /* SAI1_TXD0 */
+				 <FC6_P1_PIO3_21>, /* SAI1_RXD0 */
+				 <FC6_P2_PIO3_22>,
+				 <FC6_P3_PIO3_23>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+		};
+	};
+
 	pinmux_flexcomm2_lpi2c: pinmux_flexcomm2_lpi2c {
 		group0 {
 			pinmux = <FC2_P0_PIO4_0>,

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -61,6 +61,25 @@
 		};
 	};
 
+	mikrobus_header: mikrobus-connector {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = /* ANA_4/ADC1_A0      AN */
+			   <1 0 &gpio1 3 0>,  /* RST */
+			   <2 0 &gpio3 23 0>, /* CS */
+			   <3 0 &gpio3 21 0>, /* SCK */
+			   <4 0 &gpio3 22 0>, /* MISO */
+			   <5 0 &gpio3 20 0>, /* MOSI */
+			   <6 0 &gpio3 19 0>, /* PWM */
+			   <7 0 &gpio5 7 0>,  /* INT */
+			   <8 0 &gpio1 16 0>, /* GPIO, Not a RX */
+			   <9 0 &gpio1 17 0>, /* GPIO, Not a TX */
+			   <10 0 &gpio1 1 0>, /* SCL */
+			   <11 0 &gpio1 0 0>; /* SDA */
+	};
+
 	arduino_header: arduino-connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
@@ -118,6 +137,13 @@
 
 arduino_spi: &flexcomm1_lpspi1 {};
 
+&flexcomm6_lpspi6 {
+	pinctrl-0 = <&pinmux_flexcomm6_lpspi>;
+	pinctrl-names = "default";
+};
+
+mikrobus_spi: &flexcomm6_lpspi6 {};
+
 nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 	pinctrl-0 = <&pinmux_flexcomm2_lpi2c>;
 	pinctrl-names = "default";
@@ -125,6 +151,14 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 };
 
 arduino_i2c: &flexcomm2_lpi2c2 {};
+
+&flexcomm3_lpi2c3 {
+	pinctrl-0 = <&pinmux_flexcomm3_lpi2c>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+};
+
+mikrobus_i2c: &flexcomm3_lpi2c3 {};
 
 &flexcomm2_lpuart2 {
 	current-speed = <115200>;

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -70,8 +70,8 @@
 			   <ARDUINO_HEADER_R3_A3 0 &gpio0 22 0>,
 			   <ARDUINO_HEADER_R3_A4 0 &gpio0 15 0>,
 			   <ARDUINO_HEADER_R3_A5 0 &gpio0 23 0>,
-			   <ARDUINO_HEADER_R3_D0 0 &gpio4 3 0>,
-			   <ARDUINO_HEADER_R3_D1 0 &gpio4 2 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio4 3 0>,   /* RX */
+			   <ARDUINO_HEADER_R3_D1 0 &gpio4 2 0>,   /* TX */
 			   <ARDUINO_HEADER_R3_D2 0 &gpio0 29 0>,
 			   <ARDUINO_HEADER_R3_D3 0 &gpio1 23 0>,
 			   <ARDUINO_HEADER_R3_D4 0 &gpio0 30 0>,
@@ -80,12 +80,12 @@
 			   <ARDUINO_HEADER_R3_D7 0 &gpio0 31 0>,
 			   <ARDUINO_HEADER_R3_D8 0 &gpio0 28 0>,
 			   <ARDUINO_HEADER_R3_D9 0 &gpio0 10 0>,
-			   <ARDUINO_HEADER_R3_D10 0 &gpio0 27 0>,
-			   <ARDUINO_HEADER_R3_D11 0 &gpio0 24 0>,
-			   <ARDUINO_HEADER_R3_D12 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D13 0 &gpio0 25 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio4 0 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio4 1 0>;
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 27 0>, /* CS */
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 24 0>, /* MOSI */
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 26 0>, /* MISO */
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 25 0>, /* SCK */
+			   <ARDUINO_HEADER_R3_D14 0 &gpio4 0 0>,  /* SDA */
+			   <ARDUINO_HEADER_R3_D15 0 &gpio4 1 0>;  /* SCL */
 	};
 
 	/*
@@ -116,17 +116,23 @@
 	pinctrl-names = "default";
 };
 
+arduino_spi: &flexcomm1_lpspi1 {};
+
 nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 	pinctrl-0 = <&pinmux_flexcomm2_lpi2c>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
+arduino_i2c: &flexcomm2_lpi2c2 {};
+
 &flexcomm2_lpuart2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&pinmux_flexcomm2_lpuart>;
 	pinctrl-names = "default";
 };
+
+arduino_serial: &flexcomm2_lpuart2 {};
 
 &flexcomm4_lpuart4 {
 	current-speed = <115200>;

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
@@ -56,19 +56,33 @@
 	status = "okay";
 };
 
+/* Required on MikroBus connector. */
+&gpio5 {
+	status = "okay";
+};
+
+/* Required on Arduino connector. */
 &gpio4 {
 	status = "okay";
 };
 
+/* Required on MikroBus connector. */
+&gpio3 {
+	status = "okay";
+};
+
+/* Required on SD card. */
+&gpio2 {
+	status = "okay";
+};
+
+/* Required on Arduino and MikroBus connector. */
 &gpio1 {
 	status = "okay";
 };
 
+/* Required on Arduino connector. */
 &gpio0 {
-	status = "okay";
-};
-
-&gpio2 {
 	status = "okay";
 };
 
@@ -92,23 +106,35 @@
 	status = "okay";
 };
 
+/* Required on Arduino connector. */
 &flexcomm1_lpspi1 {
 	status = "okay";
 };
 
+/*
+ * LPFLEXCOMM supports UART and I2C on the same instance, enable this for
+ * LPLEXCOMM2 with LPUART2 and LPI2C2.
+ */
 &flexcomm2 {
 	status = "okay";
 };
 
+/* Required on Arduino and FlexIO LCD (touch panel) connector. */
 &flexcomm2_lpi2c2 {
 	status = "okay";
 };
 
-/*
- *LPFLEXCOMM supports UART and I2C on the same instance, enable this for
- * LFLEXCOMM2
- */
+/* Required on Arduino connector. */
 &flexcomm2_lpuart2 {
+	status = "okay";
+};
+
+&flexcomm3 {
+	status = "okay";
+};
+
+/* Required on MikroBus connector. */
+&flexcomm3_lpi2c3 {
 	status = "okay";
 };
 
@@ -116,7 +142,19 @@
 	status = "okay";
 };
 
+/* Required for serial console and on Camera connector. */
 &flexcomm4_lpuart4 {
+	status = "okay";
+};
+
+/*
+ * LPFLEXCOMM6 supports SPI for MikroBus. Enable this for LPSPI6 but let
+ * LPSPI6 disabled as long as it is not needed because of two shared signals
+ * with SAI1 (P3_20 for SAI1_TXD0 and FC6_SPI_MOSI and P3_21 for SAI1_RXD0
+ * and FC6_SPI_SCK). There is also an additional MikroBus signal shared
+ * with SAI1 (P3_19 for SAI1_RX_FS and MikroBus:PWM).
+ */
+&flexcomm6 {
 	status = "okay";
 };
 
@@ -124,6 +162,7 @@
 	status = "okay";
 };
 
+/* Required on Camera connector. */
 &flexcomm7_lpi2c7 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -15,6 +15,10 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - can
   - counter
   - dac

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
@@ -15,6 +15,10 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - can
   - counter
   - dac


### PR DESCRIPTION
Added `arduino_serial`, `arduino_i2c`, `arduino_spi`, `arduino_header`, `mikrobus_i2c`, `mikrobus_spi` and `mikrobus_header` node labels to **FRDM-MCXN947** device tree board definition, allowing compatible shield boards to be used. Also extend the board YAML file with related support tags `arduino_gpio`, `arduino_i2c`, `arduino_serial` and `arduino_spi`.

### Pull requests that depend on this and should be merged afterwards

- [ ] #97437