### PR TITLE
boards: nxp: frdm_mcxa153: added arduino and mikrobus labels

### DIFF
--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153-pinctrl.dtsi
@@ -75,6 +75,18 @@
 		};
 	};
 
+	pinmux_lpspi1: pinmux_lpspi1 {
+		group0 {
+			pinmux = <LPSPI1_SDO_P2_13>,
+				 <LPSPI1_SCK_P2_12>,
+				 <LPSPI1_SDI_P2_16>,
+				 <LPSPI1_PCS1_P2_6>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+		};
+	};
+
 	pinmux_lpuart0: pinmux_lpuart0 {
 		group0 {
 			pinmux = <LPUART0_RXD_P0_2>,

--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
@@ -72,6 +72,25 @@
 		};
 	};
 
+	mikrobus_header: mikrobus-connector {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio3 30 0>,  /* AN */
+			   <1 0 &gpio3 1 0>,   /* RST */
+			   <2 0 &gpio1 3 0>,   /* CS */
+			   <3 0 &gpio1 1 0>,   /* SCK */
+			   <4 0 &gpio1 2 0>,   /* MISO */
+			   <5 0 &gpio1 0 0>,   /* MOSI */
+			   <6 0 &gpio3 12 0>,  /* PWM */
+			   <7 0 &gpio2 5 0>,   /* INT */
+			   <8 0 &gpio3 14 0>,  /* RX */
+			   <9 0 &gpio3 15 0>,  /* TX */
+			   <10 0 &gpio3 27 0>, /* GPIO, Not a SCL  */
+			   <11 0 &gpio3 28 0>; /* GPIO, Not a SDA  */
+	};
+
 	arduino_header: arduino-connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
@@ -207,6 +226,8 @@ arduino_i2c: &lpi2c0 {};
 	pinctrl-names = "default";
 };
 
+mikrobus_spi: &lpspi0 {};
+
 &lpspi1 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpspi1>;
@@ -232,6 +253,8 @@ arduino_spi: &lpspi1 {};
 	pinctrl-0 = <&pinmux_lpuart2>;
 	pinctrl-names = "default";
 };
+
+mikrobus_serial: &lpuart2 {};
 
 /*
  * Uses OS timer as the kernel timer

--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
@@ -9,6 +9,7 @@
 #include <nxp/nxp_mcxa153.dtsi>
 #include "frdm_mcxa153-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <freq.h>
 
 / {
@@ -69,6 +70,35 @@
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_1>;
 		};
+	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio2 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio3 31 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio3 30 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 4 0>,   /* GPIO, Not a RX */
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 5 0>,   /* GPIO, Not a TX */
+			   <ARDUINO_HEADER_R3_D2 0 &gpio2 4 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio3 0 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio2 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio3 12 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio3 13 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio3 1 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio3 15 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio3 14 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio2 6 0>,  /* CS */
+			   <ARDUINO_HEADER_R3_D11 0 &gpio2 13 0>, /* MOSI */
+			   <ARDUINO_HEADER_R3_D12 0 &gpio2 16 0>, /* MISO */
+			   <ARDUINO_HEADER_R3_D13 0 &gpio2 12 0>, /* SCK */
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 8 0>,  /* SDA */
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 9 0>;  /* SCL */
 	};
 };
 
@@ -169,11 +199,21 @@
 	pinctrl-names = "default";
 };
 
+arduino_i2c: &lpi2c0 {};
+
 &lpspi0 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpspi0>;
 	pinctrl-names = "default";
 };
+
+&lpspi1 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpspi1>;
+	pinctrl-names = "default";
+};
+
+arduino_spi: &lpspi1 {};
 
 &lptmr0 {
 	status = "okay";

--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153.yaml
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153.yaml
@@ -15,6 +15,9 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_spi
   - counter
   - dma
   - flash


### PR DESCRIPTION
Added `arduino_i2c`, `arduino_spi`, `arduino_header`, `mikrobus_serial`, `mikrobus_spi` and `mikrobus_header` node labels to **FRDM-MCXA153** device tree board definition, allowing compatible shield boards to be used. Also extend the board YAML file with related support tags `arduino_gpio`, `arduino_i2c` and `arduino_spi`.

