### PR TITLE
UVC Video encoder (zephyr,videoenc) + H264 support + STM32 STM32N6 conf files

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -534,10 +534,10 @@ csi_interface: &dcmipp {
 	};
 };
 
-&venc {
+zephyr_h264enc: &venc {
 	status = "okay";
 };
 
-&jpeg {
+zephyr_jpegenc: &jpeg {
 	status = "okay";
 };

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -324,6 +324,7 @@ New APIs and options
 
   * :c:member:`video_format.size` field
   * :c:func:`video_estimate_fmt_size`
+  * :c:func:`video_transfer_buffer`
 
 .. zephyr-keep-sorted-stop
 

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -489,3 +489,20 @@ int video_set_compose_format(const struct device *dev, struct video_format *fmt)
 
 	return video_set_format(dev, fmt);
 }
+
+int video_transfer_buffer(const struct device *src, const struct device *sink,
+			  enum video_buf_type src_type, enum video_buf_type sink_type,
+			  k_timeout_t timeout)
+{
+	struct video_buffer *buf = &(struct video_buffer){.type = src_type};
+	int ret;
+
+	ret = video_dequeue(src, &buf, timeout);
+	if (ret < 0) {
+		return ret;
+	}
+
+	buf->type = sink_type;
+
+	return video_enqueue(sink, buf);
+}

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -452,6 +452,7 @@ int video_estimate_fmt_size(struct video_format *fmt)
 
 	switch (fmt->pixelformat) {
 	case VIDEO_PIX_FMT_JPEG:
+	case VIDEO_PIX_FMT_H264:
 		/* Rough estimate for the worst case (quality = 100) */
 		fmt->pitch = 0;
 		fmt->size = fmt->width * fmt->height * 2;

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -1004,6 +1004,24 @@ int video_estimate_fmt_size(struct video_format *fmt);
 int video_set_compose_format(const struct device *dev, struct video_format *fmt);
 
 /**
+ * @brief Transfer a buffer between 2 video device
+ *
+ * Helper function which dequeues a buffer from a source device and enqueues it into a
+ * sink device, changing its buffer type between the two.
+ *
+ * @param src		Video device from where buffer is dequeued (source)
+ * @param sink		Video device into which the buffer is queued (sink)
+ * @param src_type	Video buffer type on the source device
+ * @param sink_type	Video buffer type on the sink device
+ * @param timeout	Timeout to be applied on dequeue
+ *
+ * @return 0 on success, otherwise a negative errno code
+ */
+int video_transfer_buffer(const struct device *src, const struct device *sink,
+			  enum video_buf_type src_type, enum video_buf_type sink_type,
+			  k_timeout_t timeout);
+
+/**
  * @defgroup video_pixel_formats Video pixel formats
  * The '|' characters separate the pixels or logical blocks, and spaces separate the bytes.
  * The uppercase letter represents the most significant bit.

--- a/samples/subsys/usb/uvc/app_h264enc.overlay
+++ b/samples/subsys/usb/uvc/app_h264enc.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "app.overlay"
+
+/ {
+	chosen {
+		zephyr,videoenc = &zephyr_h264enc;
+	};
+};

--- a/samples/subsys/usb/uvc/app_jpegenc.overlay
+++ b/samples/subsys/usb/uvc/app_jpegenc.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "app.overlay"
+
+/ {
+	chosen {
+		zephyr,videoenc = &zephyr_jpegenc;
+	};
+};

--- a/samples/subsys/usb/uvc/sample.yaml
+++ b/samples/subsys/usb/uvc/sample.yaml
@@ -27,3 +27,27 @@ tests:
     filter: dt_chosen_enabled("zephyr,camera")
     integration_platforms:
       - arduino_nicla_vision/stm32h747xx/m7
+  sample.subsys.usb.uvc.encoder.h264:
+    depends_on:
+      - usbd
+    tags: usb video
+    extra_configs:
+      - CONFIG_VIDEO_ENCODER_H264=y
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="app_h264enc.overlay"
+      - SHIELD=st_b_cams_imx_mb1854
+    filter: dt_chosen_enabled("zephyr,camera")
+    integration_platforms:
+      - stm32n6570_dk/stm32n657xx/sb
+  sample.subsys.usb.uvc.encoder.jpeg:
+    depends_on:
+      - usbd
+    tags: usb video
+    extra_configs:
+      - CONFIG_VIDEO_ENCODER_JPEG=y
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="app_jpegenc.overlay"
+      - SHIELD=st_b_cams_imx_mb1854
+    filter: dt_chosen_enabled("zephyr,camera")
+    integration_platforms:
+      - stm32n6570_dk/stm32n657xx/sb

--- a/samples/subsys/usb/uvc/src/main.c
+++ b/samples/subsys/usb/uvc/src/main.c
@@ -57,7 +57,8 @@ static bool app_is_supported_format(uint32_t pixfmt)
 {
 	return pixfmt == VIDEO_PIX_FMT_JPEG ||
 	       pixfmt == VIDEO_PIX_FMT_YUYV ||
-	       pixfmt == VIDEO_PIX_FMT_NV12;
+	       pixfmt == VIDEO_PIX_FMT_NV12 ||
+	       pixfmt == VIDEO_PIX_FMT_H264;
 }
 
 static bool app_has_supported_format(void)

--- a/subsys/usb/device_next/class/usbd_uvc.h
+++ b/subsys/usb/device_next/class/usbd_uvc.h
@@ -385,10 +385,7 @@ struct uvc_frame_descriptor {
 	uint16_t wHeight;
 	uint32_t dwMinBitRate;
 	uint32_t dwMaxBitRate;
-	uint32_t dwMaxVideoFrameBufferSize;
-	uint32_t dwDefaultFrameInterval;
-	uint8_t bFrameIntervalType;
-	/* Other fields depending on bFrameIntervalType value */
+	/* Other fields depending on bDescriptorSubtype value */
 } __packed;
 
 struct uvc_frame_continuous_descriptor {

--- a/subsys/usb/device_next/class/usbd_uvc.h
+++ b/subsys/usb/device_next/class/usbd_uvc.h
@@ -375,6 +375,22 @@ struct uvc_format_mjpeg_descriptor {
 	uint8_t bCopyProtect;
 } __packed;
 
+struct uvc_format_frame_based_descriptor {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t bDescriptorSubtype;
+	uint8_t bFormatIndex;
+	uint8_t bNumFrameDescriptors;
+	uint8_t guidFormat[16];
+	uint8_t bBitsPerPixel;
+	uint8_t bDefaultFrameIndex;
+	uint8_t bAspectRatioX;
+	uint8_t bAspectRatioY;
+	uint8_t bmInterlaceFlags;
+	uint8_t bCopyProtect;
+	uint8_t bVariableSize;
+} __packed;
+
 struct uvc_frame_descriptor {
 	uint8_t bLength;
 	uint8_t bDescriptorType;
@@ -417,6 +433,38 @@ struct uvc_frame_discrete_descriptor {
 	uint32_t dwMinBitRate;
 	uint32_t dwMaxBitRate;
 	uint32_t dwMaxVideoFrameBufferSize;
+	uint32_t dwDefaultFrameInterval;
+	uint8_t bFrameIntervalType;
+	uint32_t dwFrameInterval[CONFIG_USBD_VIDEO_MAX_FRMIVAL];
+} __packed;
+
+struct uvc_frame_based_continuous_descriptor {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t bDescriptorSubtype;
+	uint8_t bFrameIndex;
+	uint8_t bmCapabilities;
+	uint16_t wWidth;
+	uint16_t wHeight;
+	uint32_t dwMinBitRate;
+	uint32_t dwMaxBitRate;
+	uint32_t dwDefaultFrameInterval;
+	uint8_t bFrameIntervalType;
+	uint32_t dwMinFrameInterval;
+	uint32_t dwMaxFrameInterval;
+	uint32_t dwFrameIntervalStep;
+} __packed;
+
+struct uvc_frame_based_discrete_descriptor {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t bDescriptorSubtype;
+	uint8_t bFrameIndex;
+	uint8_t bmCapabilities;
+	uint16_t wWidth;
+	uint16_t wHeight;
+	uint32_t dwMinBitRate;
+	uint32_t dwMaxBitRate;
 	uint32_t dwDefaultFrameInterval;
 	uint8_t bFrameIntervalType;
 	uint32_t dwFrameInterval[CONFIG_USBD_VIDEO_MAX_FRMIVAL];


### PR DESCRIPTION
Allow creating a pipeline as follow
       camera receiver -> encoder -> uvc

I post this PR while there are still some points to improve (cf hardcoded stuff detailed below) in order to get some first feedbacks. Since this depends on the UVC PR (PR #93192) and DCMIPP UVC PR (PR #94562), there are lots of commits in this PR. However **only the LAST 8 COMMITS is relevant for this PR.**

If the chosen zephyr,videoenc is available, the sample will pipe the camera receiver to the encoder and then the UVC device instead of directly the camera receiver to the UVC.

In order to making the change as simple as possible, the source device of the UVC device is renamed uvc_src_dev instead of video_dev previously since, depending on the configuration, the UVC source might be either the video_dev or the encoder_dev.

Current implementation has several points hardcoded for the time being:
    1. intermediate pixel format between the camera receiver and encoder
       is set to NV12. This is temporary until proper analysis of video_dev
       caps and encoder caps is done, allowing to select the common
       format of the two devices.
    2. it is considered that encoder device do NOT perform any resolution
       change and that encoder output resolution is directly based on the
       camera receiver resolution.  Thanks to this, UVC exposed formats
       are thus the encoder output pixel format & camera receiver
       resolutions.
    
This has been tested using the STM32N6-DK and the JPEG codec, leading to the following pipe:
    IMX335 -> CSI/DCMIPP -> JPEG -> UVC

compiled via:

```
west build -p -b stm32n6570_dk//sb --shield st_b_cams_imx_mb1854 samples/subsys/usb/uvc/ -DCONFIG_USE_STM32_MW_ISP=y -DFILE_SUFFIX=jpeg
```
And also VENC codec, leading to the following pipe:
     IMX335 -> CSI/DCMIPP -> VENC -> UVC
     
compiled via:

```
west build -p -b stm32n6570_dk//sb --shield st_b_cams_imx_mb1854 samples/subsys/usb/uvc/ -DCONFIG_USE_STM32_MW_ISP=y -DFILE_SUFFIX=venc
```
     
     and can be displayed on linux machine via gst-launch command:

```
gst-launch-1.0 v4l2src device=/dev/videoXX ! 'video/x-h264,width=1920,height=1080' ! h264parse ! avdec_h264 ! videoconvert ! autovideosink
```