### PR TITLE
flash: spi_nor: Winbond output drive strength

### DIFF
--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -103,6 +103,18 @@ properties:
 
       Only supported on Macronix MX25R Ultra Low Power series.
 
+  winbond,w25q-output-driver-strength:
+    type: string
+    enum:
+      - "100%"
+      - "75%"
+      - "50%"
+      - "25%"
+    description:
+      Select to configure the output driver strength for read operations.
+
+      Only supported on Winbond W25Q series.
+
   use-4b-addr-opcodes:
     type: boolean
     description: |

--- a/tests/drivers/build_all/flash/spi.dtsi
+++ b/tests/drivers/build_all/flash/spi.dtsi
@@ -23,6 +23,8 @@ spi-nor@1 {
 	spi-max-frequency = <5000000>;
 	size = <1048576>;
 	jedec-id = [00 11 22];
+	mxicy,mx25r-power-mode = "high-performance";
+	winbond,w25q-output-driver-strength = "75%";
 };
 
 at25xv021a@2 {


### PR DESCRIPTION
Support configuring the output drive strength on Winbond W25Q series chipsets. Modelled on the Macronix MX25R performance mode implementation.

<img width="810" height="342" alt="image" src="https://github.com/user-attachments/assets/4c856874-0349-4866-a4c2-4370da5c8870" />

<img width="735" height="214" alt="image" src="https://github.com/user-attachments/assets/ba6f9a03-c5a1-4780-8a17-85494d1293e3" />
