### PR TITLE
drivers: pwm: stm32: Add trigger output configuration

### DIFF
--- a/dts/bindings/timer/st,stm32-lptim.yaml
+++ b/dts/bindings/timer/st,stm32-lptim.yaml
@@ -11,6 +11,7 @@ include:
     property-blocklist:
       - st,prescaler
       - st,countermode
+      - st,mastermode
 
 properties:
   st,prescaler:

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -62,3 +62,32 @@ properties:
       STM32L0/STM32L1 have no instance supporting this feature).
 
       Valid range [0 ... 255].
+
+  st,mastermode:
+    type: string
+    default: RESET
+    enum:
+      - RESET
+      - ENABLE
+      - UPDATE
+      - CC1IF
+      - OC1REF
+      - OC2REF
+      - OC3REF
+      - OC4REF
+    description: |
+      Selects master mode (trigger output TRGO source selection)
+      of the timer instance. Only available for timer instances
+      with master function - property is ignored otherwise.
+
+      For details, refer to your device's Reference Manual.
+
+      * RESET   - The UG bit from the TIMx_EGR register is used
+                  as TRGO.
+      * ENABLE  - The Counter enable signal, CNT_EN, is used as TRGO.
+      * UPDATE  - The update event is used as TRGO.
+      * CC1IF   - The CC1IF set event is used as TRGO.
+      * OC1REF - OC1REF signal is used as TRGO.
+      * OC2REF - OC2REF signal is used as TRGO.
+      * OC3REF - OC3REF signal is used as TRGO.
+      * OC4REF - OC4REF signal is used as TRGO.

--- a/samples/boards/st/pwm/index.rst
+++ b/samples/boards/st/pwm/index.rst
@@ -1,0 +1,5 @@
+.. zephyr:code-sample-category:: stm32_pwm
+   :name: PWM
+   :show-listing:
+
+   Samples that demonstrate the use of PWM on STM32 boards.

--- a/samples/boards/st/pwm/mastermode/CMakeLists.txt
+++ b/samples/boards/st/pwm/mastermode/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(mastermode)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/boards/st/pwm/mastermode/Kconfig
+++ b/samples/boards/st/pwm/mastermode/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Matthias Plöger <matze.ploeger@gmx.de>
+# SPDX-License-Identifier: Apache-2.0
+
+menu "Zephyr"
+source "Kconfig.zephyr"
+endmenu
+
+module = MAIN
+module-str = MAIN
+source "subsys/logging/Kconfig.template.log_config"

--- a/samples/boards/st/pwm/mastermode/README.rst
+++ b/samples/boards/st/pwm/mastermode/README.rst
@@ -1,0 +1,27 @@
+.. zephyr:code-sample:: stm32_pwm_mastermode
+   :name: STM32 pwm mastermode
+   :relevant-api: pwm_interface
+
+   Devicetree configuration for generation of timer events.
+
+Overview
+********
+
+Devicetree configuration for event generation on the interconnect
+matrix by the timer module (master mode selection / trigger output
+TRGO) of an STM32 device.
+The :ref:`PWM API <pwm_api>` is used to configure the PWM signal.
+
+Requirements
+************
+
+This sample requires the support of a Master Mode-compatible timer block.
+
+Building and Running
+********************
+
+ .. zephyr-app-commands::
+   :zephyr-app: samples/boards/st/pwm/mastermode
+   :board: nucleo_g070rb
+   :goals: build
+   :compact:

--- a/samples/boards/st/pwm/mastermode/boards/nucleo_g070rb.overlay
+++ b/samples/boards/st/pwm/mastermode/boards/nucleo_g070rb.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Matthias Plöger <matze.ploeger@gmx.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "dt-bindings/timer/stm32-timer.h"
+
+&timers3 {
+	/**
+	 * Configure the TRGO output and counter mode of the timer instance.
+	 * TRGO event is generated at timer update event.
+	 * --> Will cause the TRGO event during mid of high AND low time
+	 *     of PWM period.
+	 * The TRGO can be used on other peripherals according to the
+	 * `Interconnect matrix` of the SoC.
+	 */
+	st,countermode = <STM32_TIM_COUNTERMODE_CENTER_UP>;
+	st,mastermode = "UPDATE";
+};

--- a/samples/boards/st/pwm/mastermode/boards/nucleo_g071rb.overlay
+++ b/samples/boards/st/pwm/mastermode/boards/nucleo_g071rb.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Matthias Plöger <matze.ploeger@gmx.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "dt-bindings/timer/stm32-timer.h"
+
+&timers3 {
+	/**
+	 * Configure the TRGO output and counter mode of the timer instance.
+	 * TRGO event is generated at timer update event.
+	 * --> Will cause the TRGO event during mid of high AND low time
+	 *     of PWM period.
+	 * The TRGO can be used on other peripherals according to the
+	 * `Interconnect matrix` of the SoC.
+	 */
+	st,countermode = <STM32_TIM_COUNTERMODE_CENTER_UP>;
+	st,mastermode = "UPDATE";
+};

--- a/samples/boards/st/pwm/mastermode/prj.conf
+++ b/samples/boards/st/pwm/mastermode/prj.conf
@@ -1,0 +1,2 @@
+CONFIG_LOG=y
+CONFIG_PWM=y

--- a/samples/boards/st/pwm/mastermode/sample.yaml
+++ b/samples/boards/st/pwm/mastermode/sample.yaml
@@ -1,0 +1,17 @@
+sample:
+  name: STM32 pwm mastermode
+tests:
+  sample.boards.stm32.pwm.mastermode:
+    depends_on: pwm
+    tags:
+      - drivers
+      - pwm
+    filter: dt_compat_enabled("st,stm32-timers")
+    platform_allow:
+      - nucleo_g070rb
+      - nucleo_g071rb
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "TRGO event will be generated every.*"

--- a/samples/boards/st/pwm/mastermode/src/main.c
+++ b/samples/boards/st/pwm/mastermode/src/main.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Matthias Plöger <matze.ploeger@gmx.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/kernel.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(main, CONFIG_MAIN_LOG_LEVEL);
+
+#define PWM_PERIOD_US     200 /* PWM period duration */
+#define PWM_PULSE_TIME_US 100 /* PWM on/pulse/high time*/
+
+static const struct device *pwm = DEVICE_DT_GET(DT_NODELABEL(pwm3));
+
+int main(void)
+{
+	int ret;
+
+	if (!device_is_ready(pwm)) {
+		LOG_ERR("%s: pwm device not ready", pwm->name);
+		return 0;
+	}
+
+	LOG_INF("Configuring PWM to generate signal on channel 1.");
+	LOG_INF("TRGO event will be generated twice per given period.");
+	ret = pwm_set(pwm, 1, PWM_USEC(PWM_PERIOD_US), PWM_USEC(PWM_PULSE_TIME_US),
+		      PWM_POLARITY_NORMAL);
+	if (ret < 0) {
+		LOG_ERR("pwm_set() failed");
+		return 0;
+	}
+
+	LOG_INF("TRGO event will be generated every 100us.");
+
+	while (true) {
+		k_sleep(K_MSEC(2000));
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## Summary

This push request enables trigger output (TRGO) configuration for ST pwm instances via devictree.
Therefore the usage of the STM32 interconnect matrix is possible for pwm instances.
API remains unchanged.

## What is changed
- Add new dts-binding to configure source of TRGO signal.
- Add predefined constants for configuration
- Add TRGO configuation during instance init.

## Alternatives

As described in https://github.com/zephyrproject-rtos/zephyr/issues/70097 an interconnect subsystem would solve the problem as well.

In comparison to a new subsystem this solution is more lightweight on code size and most init time. 
Drawback is the hardware dependency to ST devices (but you have to know the hardware interconnect capabilities of your SoC in both cases to archive maximal performance).