### PR TITLE
boards: shields: tcan4550evm: support for FRDM-MCXN947 and FRDM-MCXA153

### DIFF
--- a/boards/shields/tcan4550evm/boards/can_at_cs1.dtsi
+++ b/boards/shields/tcan4550evm/boards/can_at_cs1.dtsi
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Navimatix GmbH
+ * SPDX-FileCopyrightText: Copyright (c) 2025 TiaC Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	/delete-node/ can@0;
+
+	tcan4x5x_tcan4550evm: can@1 {
+		compatible = "ti,tcan4x5x";
+		reg = <1>;
+		/* reduced spi-max-frequency to accommodate flywire connections */
+		spi-max-frequency = <2000000>;
+		status = "okay";
+		clock-frequency = <40000000>;
+		device-state-gpios = <&arduino_header ARDUINO_HEADER_R3_D6 GPIO_ACTIVE_HIGH>;
+		device-wake-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_HIGH>;
+		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>;
+		bosch,mram-cfg = <0x0 15 15 7 7 0 10 10>;
+
+		can-transceiver {
+			max-bitrate = <8000000>;
+		};
+	};
+};

--- a/boards/shields/tcan4550evm/boards/frdm_mcxa153.overlay
+++ b/boards/shields/tcan4550evm/boards/frdm_mcxa153.overlay
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Navimatix GmbH
+ * SPDX-FileCopyrightText: Copyright (c) 2025 TiaC Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * FRDM-MCXA153, based on the Low Power SPI driver "nxp,lpspi"
+ * should by used with hardware controlled CS pins, due to reset
+ * issues. Moreover, the second CS1 is used on this board at the
+ * Arduino connector. This means that the CAN controller node
+ * must be completely rebuilt with the reg index 1.
+ */
+
+#include "hw_ctrl_cs.dtsi"
+#include "can_at_cs1.dtsi"

--- a/boards/shields/tcan4550evm/boards/frdm_mcxn947.dtsi
+++ b/boards/shields/tcan4550evm/boards/frdm_mcxn947.dtsi
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Navimatix GmbH
+ * SPDX-FileCopyrightText: Copyright (c) 2025 TiaC Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * FRDM-MCXN947, based on the Low Power SPI driver "nxp,lpspi"
+ * should by used with hardware controlled CS pins, among other
+ * things, due to the extremely accelerated DMA transfers.
+ */
+
+#include "hw_ctrl_cs.dtsi"

--- a/boards/shields/tcan4550evm/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/boards/shields/tcan4550evm/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Navimatix GmbH
+ * SPDX-FileCopyrightText: Copyright (c) 2025 TiaC Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "frdm_mcxn947.dtsi"

--- a/boards/shields/tcan4550evm/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
+++ b/boards/shields/tcan4550evm/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Navimatix GmbH
+ * SPDX-FileCopyrightText: Copyright (c) 2025 TiaC Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "frdm_mcxn947.dtsi"

--- a/boards/shields/tcan4550evm/boards/hw_ctrl_cs.dtsi
+++ b/boards/shields/tcan4550evm/boards/hw_ctrl_cs.dtsi
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Navimatix GmbH
+ * SPDX-FileCopyrightText: Copyright (c) 2025 TiaC Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	/delete-property/ cs-gpios;
+};


### PR DESCRIPTION
The board-specific device tree overlay for FRDM-MCXN947 and FRDM-MCXA153 has been added, which should be used, among other things, due to the extremely accelerated DMA transfers on FRDM-MCXN947 and reset issues on FRDM-MCXA153 with hardware-controlled CS pins. Moreover, on FRDM-MCXA153, the second CS1 is used on this board at the Arduino connector. This means that the CAN controller node must be completely rebuilt with the reg index 1.

Also the FRDM-RW612 were qualified and can be used without additional board-specific device tree overlay.

### Required pull requests that must be merged before

- [x] #97419 (FRDM-RW612)
- [x] #97420 (FRDM-MCXN947)
- [x] #97421 (FRDM-MCXA153)
- [x] #96654 (CAN API test thread priority issue)

### Successful examples and tests

#### Modular shell sample with CAN commands

```
west build -p -b frdm_mcxn947/mcxn947/cpu0/qspi --shield tcan4550evm zephyr/samples/subsys/shell/shell_module -- -DCONFIG_CAN=y -DCONFIG_CAN_SHELL=y
west build -p -b frdm_mcxn947/mcxn947/cpu0 --shield tcan4550evm zephyr/samples/subsys/shell/shell_module -- -DCONFIG_CAN=y -DCONFIG_CAN_SHELL=y
west build -p -b frdm_mcxa153 --shield tcan4550evm zephyr/samples/subsys/shell/shell_module -- -DCONFIG_CAN=y -DCONFIG_CAN_SHELL=y
west build -p -b frdm_rw612 --shield tcan4550evm zephyr/samples/subsys/shell/shell_module -- -DCONFIG_CAN=y -DCONFIG_CAN_SHELL=y
```

#### CAN API test

```
west build -p -b frdm_mcxn947/mcxn947/cpu0/qspi --shield tcan4550evm zephyr/tests/drivers/can/api
west build -p -b frdm_mcxn947/mcxn947/cpu0 --shield tcan4550evm zephyr/tests/drivers/can/api
west build -p -b frdm_mcxa153 --shield tcan4550evm zephyr/tests/drivers/can/api
west build -p -b frdm_rw612 --shield tcan4550evm zephyr/tests/drivers/can/api
```