### PR TITLE
drivers: flash_mspi_nor: Take into account MSPI controller packet limit 

### DIFF
--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -70,6 +70,7 @@ struct flash_mspi_nor_switch_info {
 
 struct flash_mspi_nor_config {
 	const struct device *bus;
+	uint32_t packet_data_limit;
 	uint32_t flash_size;
 	uint16_t page_size;
 	struct mspi_dev_id mspi_id;

--- a/dts/bindings/mspi/mspi-controller.yaml
+++ b/dts/bindings/mspi/mspi-controller.yaml
@@ -92,3 +92,11 @@ properties:
       Regardless of whether the CE pin may need software control or MSPI
       controller has dedicated CE pin, this field should be defined to
       help manage multiple devices on the same MSPI controller.
+
+  packet-data-limit:
+    type: int
+    description: |
+      Specifies the maximum length of data that the controller can transfer
+      in a single packet. Transceive requests made to the controller must be
+      split into multiple packets if a single one would exceed this value.
+      If not specified, no limit is imposed.

--- a/dts/bindings/mspi/snps,designware-ssi.yaml
+++ b/dts/bindings/mspi/snps,designware-ssi.yaml
@@ -14,6 +14,10 @@ properties:
   interrupts:
     required: true
 
+  packet-data-limit:
+    required: true
+    const: 65536
+
   aux-reg-enable:
     type: boolean
     description: |

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -651,6 +651,7 @@
 				interrupts = <149 NRF_DEFAULT_IRQ_PRIORITY>;
 				power-domains = <&gdpwr_fast_active_0>;
 				clock-frequency = <DT_FREQ_M(400)>;
+				packet-data-limit = <65536>;
 				fifo-depth = <32>;
 				status = "disabled";
 			};

--- a/dts/vendor/nordic/nrf9280.dtsi
+++ b/dts/vendor/nordic/nrf9280.dtsi
@@ -385,6 +385,7 @@
 				reg-names = "wrapper", "core";
 				interrupts = <149 NRF_DEFAULT_IRQ_PRIORITY>;
 				clock-frequency = <DT_FREQ_M(400)>;
+				packet-data-limit = <65536>;
 				fifo-depth = <32>;
 				status = "disabled";
 			};


### PR DESCRIPTION
Add a property with which MSPI controllers can indicate their limits on the maximum amount of data they can transfer in one packet. Use the property for the SSI controller, for which the clock stretching feature requires the use of the NDF field of the CTRLR1 register, which is 16-bit wide, hence the data length limit is 64 kB.

Take the new property into account in the mspi_flash_nor driver and split requested transfers if necessary.