### PR TITLE
Bluetooth: Host: bt_iso_reset before bt_conn_cleanup_all

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4650,6 +4650,10 @@ int bt_disable(void)
 	bt_periodic_sync_disable();
 #endif /* CONFIG_BT_PER_ADV_SYNC */
 
+	if (IS_ENABLED(CONFIG_BT_ISO)) {
+		bt_iso_reset();
+	}
+
 #if defined(CONFIG_BT_CONN)
 	if (IS_ENABLED(CONFIG_BT_SMP)) {
 		bt_pub_key_hci_disrupted();
@@ -4703,10 +4707,6 @@ int bt_disable(void)
 
 	/* If random address was set up - clear it */
 	bt_addr_le_copy(&bt_dev.random_addr, BT_ADDR_LE_ANY);
-
-	if (IS_ENABLED(CONFIG_BT_ISO)) {
-		bt_iso_reset();
-	}
 
 	bt_monitor_send(BT_MONITOR_CLOSE_INDEX, NULL, 0);
 


### PR DESCRIPTION
Move the call to bt_iso_reset to before bt_conn_cleanup_all. The reason for this is that bt_conn_cleanup_all will disconnect all the ACL connections, which will put the CIS in a disconnecting state, without finalizing them.
This means that if we get a num_completed_packet event between the call to bt_conn_cleanup_all and before the BT_HCI_OP_RESET request has been completed, we will trigger an assert in the hci_num_completed_packets function as the CIS still exists, but where we would already have cleaned up the pending TX without telling the controller.

Moving the call to bt_iso_reset means that the CIS will have been fully terminated at this point, which will prevent the assert from happening. Since CIS depends on ACLs, this is also the logical order for resetting them.