### PR TITLE
drivers: timer: nrf_rtc: Kconfig clean up

### DIFF
--- a/boards/native/nrf_bsim/Kconfig
+++ b/boards/native/nrf_bsim/Kconfig
@@ -5,7 +5,6 @@ config BOARD_NRF52_BSIM
 	bool
 	select SOC_SERIES_BSIM_NRF52X
 	select SOC_COMPATIBLE_NRF52833
-	select NRF_RTC_TIMER
 	select CLOCK_CONTROL
 	help
 	  NRF52 simulation model
@@ -16,7 +15,6 @@ config BOARD_NRF5340BSIM_NRF5340_CPUNET
 	bool
 	select SOC_SERIES_BSIM_NRF53X
 	select SOC_COMPATIBLE_NRF5340_CPUNET
-	select NRF_RTC_TIMER
 	select CLOCK_CONTROL
 	help
 	  Simulated NRF53 Network core
@@ -27,7 +25,6 @@ config BOARD_NRF5340BSIM_NRF5340_CPUAPP
 	bool
 	select SOC_SERIES_BSIM_NRF53X
 	select SOC_COMPATIBLE_NRF5340_CPUAPP
-	select NRF_RTC_TIMER
 	select CLOCK_CONTROL
 	help
 	  Simulated NRF53 Application core

--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -11,6 +11,7 @@ config NRF_RTC_TIMER
 	select TICKLESS_CAPABLE
 	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
 	select NRFX_PPI if SOC_NRF52832
+	default y if SYS_CLOCK_EXISTS
 	help
 	  This module implements a kernel device driver for the nRF Real Time
 	  Counter NRF_RTC1 and provides the standard "system clock driver"

--- a/soc/nordic/nrf51/Kconfig.defconfig
+++ b/soc/nordic/nrf51/Kconfig.defconfig
@@ -9,10 +9,6 @@ if SOC_SERIES_NRF51X
 config NUM_IRQS
 	default 26
 
-# If the kernel has timer support, enable the timer
-config NRF_RTC_TIMER
-	default y if SYS_CLOCK_EXISTS
-
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_nodelabel_int_prop,rtc1,clock-frequency)
 

--- a/soc/nordic/nrf52/Kconfig.defconfig
+++ b/soc/nordic/nrf52/Kconfig.defconfig
@@ -7,10 +7,6 @@ if SOC_SERIES_NRF52X
 
 rsource "Kconfig.defconfig.nrf52*"
 
-# If the kernel has timer support, enable the timer
-config NRF_RTC_TIMER
-	default y if SYS_CLOCK_EXISTS
-
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_nodelabel_int_prop,rtc1,clock-frequency)
 

--- a/soc/nordic/nrf53/Kconfig.defconfig
+++ b/soc/nordic/nrf53/Kconfig.defconfig
@@ -7,10 +7,6 @@ if SOC_SERIES_NRF53X
 
 rsource "Kconfig.defconfig.nrf53*"
 
-# If the kernel has timer support, enable the timer
-config NRF_RTC_TIMER
-	default y if SYS_CLOCK_EXISTS
-
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_nodelabel_int_prop,rtc1,clock-frequency)
 

--- a/soc/nordic/nrf91/Kconfig.defconfig
+++ b/soc/nordic/nrf91/Kconfig.defconfig
@@ -7,10 +7,6 @@ if SOC_SERIES_NRF91X
 
 rsource "Kconfig.defconfig.nrf91*"
 
-# If the kernel has timer support, enable the timer
-config NRF_RTC_TIMER
-	default y if SYS_CLOCK_EXISTS
-
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_nodelabel_int_prop,rtc1,clock-frequency)
 


### PR DESCRIPTION
Remove redundant enabling of NRF_RTC_TIMER in SoC specific files and replace it with default y in the NRF_RTC_TIMER definition.