### PR TITLE
fix adc tests/samples run failure on NXP platforms

### DIFF
--- a/samples/drivers/adc/adc_dt/boards/frdm_k64f.overlay
+++ b/samples/drivers/adc/adc_dt/boards/frdm_k64f.overlay
@@ -18,7 +18,7 @@
 	channel@e {
 		reg = <14>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};

--- a/tests/drivers/adc/adc_accuracy_test/boards/frdm_k64f.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/frdm_k64f.overlay
@@ -25,7 +25,7 @@
 	channel@14 {
 		reg = <20>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};

--- a/tests/drivers/adc/adc_accuracy_test/boards/frdm_kl25z.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/frdm_kl25z.overlay
@@ -20,7 +20,7 @@
 	channel@12 {
 		reg = <12>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};

--- a/tests/drivers/adc/adc_api/boards/frdm_k22f.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_k22f.overlay
@@ -18,7 +18,7 @@
 	channel@e {
 		reg = <14>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <0>;
 		zephyr,resolution = <12>;

--- a/tests/drivers/adc/adc_api/boards/frdm_k64f.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_k64f.overlay
@@ -23,7 +23,7 @@
 	channel@e {
 		reg = <14>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};

--- a/tests/drivers/adc/adc_api/boards/frdm_k82f.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_k82f.overlay
@@ -23,7 +23,7 @@
 	channel@f {
 		reg = <15>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};

--- a/tests/drivers/adc/adc_api/boards/frdm_kl25z.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_kl25z.overlay
@@ -18,7 +18,7 @@
 	channel@c {
 		reg = <12>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};

--- a/tests/drivers/adc/adc_api/boards/frdm_kw41z.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_kw41z.overlay
@@ -18,7 +18,7 @@
 	channel@3 {
 		reg = <3>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};


### PR DESCRIPTION
Commit: https://github.com/zephyrproject-rtos/zephyr/commit/bf12516cb4d2c24596c9ae6d62c60ecec01c1853 added several features to the NXP MCUX ADC16 driver, such as: support for selecting the reference voltage between ADC_REF_EXTERNAL0 and ADC_REF_VDD_1. However, many NXP platforms with ADC16 previously specified ADC_REF_INTERNAL as the reference voltage in the DT. This caused these platforms to fail in ADC tests/examples.

This PR updates the reference voltage configuration for these platforms to ADC_REF_EXTERNAL0. This update is backward compatible.

Fix https://github.com/zephyrproject-rtos/zephyr/issues/96594