### PR TITLE
net: dhcpv4_server: correct DHCPv4 lock scope for lease()

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -1771,7 +1771,7 @@ int net_dhcpv4_server_foreach_lease(struct net_if *iface,
 			}
 		}
 
-		return 0;
+		goto out;
 	}
 
 	for (int i = 0; i < ARRAY_SIZE(server_ctx); i++) {


### PR DESCRIPTION
net: dhcpv4_server: correct DHCPv4 lock scope for lease()

DHCPv4 server lease should release mutex correctly

Signed-off-by: chao an <anchao.archer@bytedance.com>
