### PR TITLE
boards: litex: add missing netif:eth to supported

### DIFF
--- a/boards/enjoydigital/litex_vexriscv/litex_vexriscv.yaml
+++ b/boards/enjoydigital/litex_vexriscv/litex_vexriscv.yaml
@@ -17,6 +17,7 @@ supported:
   - spi
   - i2s
   - i2c
+  - netif:eth
   - watchdog
 testing:
   ignore_tags:


### PR DESCRIPTION
add missing netif:eth to supported for litex board.