### PR TITLE
mgmt: mcumgr: transport: udp: Increase default stack size to 1KiB

### DIFF
--- a/subsys/mgmt/mcumgr/transport/Kconfig.udp
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.udp
@@ -43,7 +43,7 @@ config MCUMGR_TRANSPORT_UDP_PORT
 
 config MCUMGR_TRANSPORT_UDP_STACK_SIZE
 	int "UDP SMP stack size"
-	default 512
+	default 1024
 	help
 	  Stack size of the SMP UDP listening thread
 


### PR DESCRIPTION
Fixes an issue in a board using ethernet that faults with the default 512 byte size by doubling the default to 1KiB. The actual size of the thread depends upon the device and application configuration so needs to be fine tined for each application anyhow

Fixes: #94632