### PR TITLE
STM32: Change/fix memory sizes in stm32h7rs device tree files

### DIFF
--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -63,7 +63,7 @@
 
 	ext_memory: memory@70000000 {
 		compatible = "zephyr,memory-region";
-		reg = <0x70000000 DT_SIZE_M(64)>;
+		reg = <0x70000000 DT_SIZE_M(32)>;
 		zephyr,memory-region = "EXTMEM";
 		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.yaml
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-ram: 128
+ram: 456
 flash: 64
 supported:
   - gpio

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.yaml
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-ram: 128
+ram: 456
 flash: 64
 supported:
   - arduino_gpio

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.yaml
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-ram: 128
+ram: 456
 flash: 61439  # size in kB of 1 app slot minus MCUboot header size (1KB)
 sysbuild: true
 supported:

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -49,9 +49,9 @@
 		};
 	};
 
-	/* System data RAM accessible over AXI bus: AXI SRAM1 in CD domain */
+	/* System data RAM accessible over AXI bus: AXI SRAM1 to AXI SRAM4 in CD domain */
 	sram0: memory@24000000 {
-		reg = <0x24000000 DT_SIZE_K(128)>;
+		reg = <0x24000000 DT_SIZE_K(456)>;
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM0";
 	};


### PR DESCRIPTION
## Changes

1. SOC's DT: The h7rs option bytes default setting configures the AXI SRAM1-4 as one contiguous memory, sram0 can therefore be increased from 128k to 456k (3x128k + 72k).
2. Set the ram size in boards/st/nucleo_h7s3l8 and stm32h7s78_dk .yaml files to 456k. 
3. Board Nucleo_H7S3L8: Setting the correct size of ext_memory node to 32MB, as the board uses a Macronix MX25UW25645GXDI00 with 256MBits. 

## Testing status
* Access to whole 456k of sram0 checked with custom app.