### PR TITLE
Revert "shell: Add user data argument to shell_set_bypass"

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -323,9 +323,6 @@ Shell
   compatibility.
   (:github:`92677`).
 
-* The :c:func:`shell_set_bypass` now requires a user data pointer to be passed. And accordingly the
-  :c:type:`shell_bypass_cb_t` now has a user data argument.
-
 .. zephyr-keep-sorted-stop
 
 Modules

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -74,13 +74,11 @@ static bool can_device_check(const struct device *dev)
 }
 
 #ifdef CONFIG_CAN_SHELL_SCRIPTING_FRIENDLY
-static void can_shell_dummy_bypass_cb(const struct shell *sh, uint8_t *data, size_t len,
-				      void *user_data)
+static void can_shell_dummy_bypass_cb(const struct shell *sh, uint8_t *data, size_t len)
 {
 	ARG_UNUSED(sh);
 	ARG_UNUSED(data);
 	ARG_UNUSED(len);
-	ARG_UNUSED(user_data);
 }
 #endif /* CONFIG_CAN_SHELL_SCRIPTING_FRIENDLY */
 
@@ -92,7 +90,7 @@ static void can_shell_print_frame(const struct shell *sh, const struct device *d
 
 #ifdef CONFIG_CAN_SHELL_SCRIPTING_FRIENDLY
 	/* Bypass the shell to avoid breaking up the line containing the frame */
-	shell_set_bypass(sh, can_shell_dummy_bypass_cb, NULL);
+	shell_set_bypass(sh, can_shell_dummy_bypass_cb);
 #endif /* CONFIG_CAN_SHELL_SCRIPTING_FRIENDLY */
 
 #ifdef CONFIG_CAN_RX_TIMESTAMP
@@ -134,7 +132,7 @@ static void can_shell_print_frame(const struct shell *sh, const struct device *d
 	shell_fprintf_normal(sh, "\n");
 
 #ifdef CONFIG_CAN_SHELL_SCRIPTING_FRIENDLY
-	shell_set_bypass(sh, NULL, NULL);
+	shell_set_bypass(sh, NULL);
 #endif /* CONFIG_CAN_SHELL_SCRIPTING_FRIENDLY */
 }
 

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -587,18 +587,16 @@ static int set_bypass(const struct shell *sh, shell_bypass_cb_t bypass)
 		shell_print(sh, "Loading...");
 	}
 
-	shell_set_bypass(sh, bypass, NULL);
+	shell_set_bypass(sh, bypass);
 
 	return 0;
 }
 
-static void bypass_cb(const struct shell *sh, uint8_t *recv, size_t len, void *user_data)
+static void bypass_cb(const struct shell *sh, uint8_t *recv, size_t len)
 {
 	uint32_t left_to_read = flash_load_total - flash_load_written - flash_load_boff;
 	uint32_t to_copy = MIN(len, left_to_read);
 	uint32_t copied = 0;
-
-	ARG_UNUSED(user_data);
 
 	while (copied < to_copy) {
 

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -789,8 +789,7 @@ typedef void (*shell_uninit_cb_t)(const struct shell *sh, int res);
  */
 typedef void (*shell_bypass_cb_t)(const struct shell *sh,
 				  uint8_t *data,
-				  size_t len,
-				  void *user_data);
+				  size_t len);
 
 struct shell_transport;
 
@@ -990,9 +989,6 @@ struct shell_ctx {
 
 	/** When bypass is set, all incoming data is passed to the callback. */
 	shell_bypass_cb_t bypass;
-
-	/** When bypass is set, this user data pointer is passed to the callback. */
-	void *bypass_user_data;
 
 	/*!< Logging level for a backend. */
 	uint32_t log_level;
@@ -1368,9 +1364,8 @@ int shell_set_root_cmd(const char *cmd);
  *
  * @param[in] sh	Pointer to the shell instance.
  * @param[in] bypass	Bypass callback or null to disable.
- * @param[in] user_data	Bypass callback user data.
  */
-void shell_set_bypass(const struct shell *sh, shell_bypass_cb_t bypass, void *user_data);
+void shell_set_bypass(const struct shell *sh, shell_bypass_cb_t bypass);
 
 /** @brief Get shell readiness to execute commands.
  *

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -255,7 +255,7 @@ static int set_bypass(const struct shell *sh, shell_bypass_cb_t bypass)
 		in_use = true;
 	}
 
-	shell_set_bypass(sh, bypass, NULL);
+	shell_set_bypass(sh, bypass);
 
 	return 0;
 }
@@ -263,12 +263,10 @@ static int set_bypass(const struct shell *sh, shell_bypass_cb_t bypass)
 #define CHAR_1 0x18
 #define CHAR_2 0x11
 
-static void bypass_cb(const struct shell *sh, uint8_t *data, size_t len, void *user_data)
+static void bypass_cb(const struct shell *sh, uint8_t *data, size_t len)
 {
 	static uint8_t tail;
 	bool escape = false;
-
-	ARG_UNUSED(user_data);
 
 	/* Check if escape criteria is met. */
 	if (tail == CHAR_1 && data[0] == CHAR_2) {

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -231,7 +231,7 @@ static int parse_arg(size_t *i, size_t argc, char *argv[])
 static void ping_cleanup(struct ping_context *ctx)
 {
 	(void)net_icmp_cleanup_ctx(&ctx->icmp);
-	shell_set_bypass(ctx->sh, NULL, NULL);
+	shell_set_bypass(ctx->sh, NULL);
 }
 
 static void ping_done(struct ping_context *ctx)
@@ -286,10 +286,9 @@ static void ping_work(struct k_work *work)
 
 #define ASCII_CTRL_C 0x03
 
-static void ping_bypass(const struct shell *sh, uint8_t *data, size_t len, void *user_data)
+static void ping_bypass(const struct shell *sh, uint8_t *data, size_t len)
 {
 	ARG_UNUSED(sh);
-	ARG_UNUSED(user_data);
 
 	for (size_t i = 0; i < len; i++) {
 		if (data[i] == ASCII_CTRL_C) {
@@ -482,7 +481,7 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 
 	PR("PING %s\n", host);
 
-	shell_set_bypass(sh, ping_bypass, NULL);
+	shell_set_bypass(sh, ping_bypass);
 	k_work_reschedule(&ping_ctx.work, K_NO_WAIT);
 
 	return 0;

--- a/subsys/net/lib/tls_credentials/tls_credentials_shell.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_shell.c
@@ -517,14 +517,11 @@ cleanup:
 
 #define ASCII_CTRL_C 0x03
 
-static void tls_cred_cmd_load_bypass(const struct shell *sh, uint8_t *data, size_t len,
-				     void *user_data)
+static void tls_cred_cmd_load_bypass(const struct shell *sh, uint8_t *data, size_t len)
 {
 	bool terminate = false;
 	int res;
 	size_t write_len = len;
-
-	ARG_UNUSED(user_data);
 
 	for (size_t i = 0; i < len; i++) {
 		if (data[i] == ASCII_CTRL_C) {
@@ -536,7 +533,7 @@ static void tls_cred_cmd_load_bypass(const struct shell *sh, uint8_t *data, size
 
 	res = cred_buf_write(data, write_len);
 	if (res == -ENOMEM) {
-		shell_set_bypass(sh, NULL, NULL);
+		shell_set_bypass(sh, NULL);
 		shell_fprintf(sh, SHELL_ERROR, "Not enough room in credential buffer for "
 					       "provided data. Increase "
 					       "CONFIG_TLS_CREDENTIALS_SHELL_CRED_BUF_SIZE.\n");
@@ -545,7 +542,7 @@ static void tls_cred_cmd_load_bypass(const struct shell *sh, uint8_t *data, size
 	}
 
 	if (terminate) {
-		shell_set_bypass(sh, NULL, NULL);
+		shell_set_bypass(sh, NULL);
 		shell_fprintf(sh, SHELL_NORMAL, "Stored %d bytes.\n", cred_written);
 	}
 }
@@ -564,7 +561,7 @@ static int tls_cred_cmd_buf_load(const struct shell *sh, size_t argc, char *argv
 	shell_clear_cred_buf(sh);
 
 	shell_fprintf(sh, SHELL_NORMAL, "Input credential, finish with CTRL+C.\n");
-	shell_set_bypass(sh, tls_cred_cmd_load_bypass, NULL);
+	shell_set_bypass(sh, tls_cred_cmd_load_bypass);
 	return 0;
 }
 

--- a/subsys/shell/modules/devmem_service.c
+++ b/subsys/shell/modules/devmem_service.c
@@ -164,18 +164,16 @@ static int set_bypass(const struct shell *sh, shell_bypass_cb_t bypass)
 		in_use = true;
 	}
 
-	shell_set_bypass(sh, bypass, NULL);
+	shell_set_bypass(sh, bypass);
 
 	return 0;
 }
 
-static void bypass_cb(const struct shell *sh, uint8_t *recv, size_t len, void *user_data)
+static void bypass_cb(const struct shell *sh, uint8_t *recv, size_t len)
 {
 	bool escape = false;
 	static uint8_t tail;
 	uint8_t byte;
-
-	ARG_UNUSED(user_data);
 
 	for (size_t i = 0; i < len; i++) {
 		if (tail == CHAR_CAN && recv[i] == CHAR_DC1) {

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -996,7 +996,6 @@ static void state_collect(const struct shell *sh)
 
 	while (true) {
 		shell_bypass_cb_t bypass = sh->ctx->bypass;
-		void *bypass_user_data = sh->ctx->bypass_user_data;
 
 		if (bypass) {
 #if defined(CONFIG_SHELL_BACKEND_RTT) && defined(CONFIG_SEGGER_RTT_BUFFER_SIZE_DOWN)
@@ -1009,7 +1008,7 @@ static void state_collect(const struct shell *sh)
 							sizeof(buf), &count);
 			if (count) {
 				z_flag_cmd_ctx_set(sh, true);
-				bypass(sh, buf, count, bypass_user_data);
+				bypass(sh, buf, count);
 				z_flag_cmd_ctx_set(sh, false);
 				/* Check if bypass mode ended. */
 				if (!(volatile shell_bypass_cb_t *)sh->ctx->bypass) {
@@ -1817,12 +1816,11 @@ int shell_mode_delete_set(const struct shell *sh, bool val)
 	return (int)z_flag_mode_delete_set(sh, val);
 }
 
-void shell_set_bypass(const struct shell *sh, shell_bypass_cb_t bypass, void *user_data)
+void shell_set_bypass(const struct shell *sh, shell_bypass_cb_t bypass)
 {
 	__ASSERT_NO_MSG(sh);
 
 	sh->ctx->bypass = bypass;
-	sh->ctx->bypass_user_data = user_data;
 
 	if (bypass == NULL) {
 		cmd_buffer_clear(sh);


### PR DESCRIPTION
Revert PR https://github.com/zephyrproject-rtos/zephyr/pull/97187 as this broke a stable API.

See https://github.com/zephyrproject-rtos/zephyr/pull/97467 for an alternative approach.