### PR TITLE
Clean wdt testing l15 lm20

### DIFF
--- a/samples/drivers/watchdog/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/samples/drivers/watchdog/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -1,8 +1,0 @@
-/*
- * Copyright 2024 Nordic Semiconductor ASA
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wdt31 {
-	status = "okay";
-};

--- a/samples/drivers/watchdog/boards/nrf54l15dk_nrf54l15_cpuflpr_xip.overlay
+++ b/samples/drivers/watchdog/boards/nrf54l15dk_nrf54l15_cpuflpr_xip.overlay
@@ -1,8 +1,0 @@
-/*
- * Copyright 2024 Nordic Semiconductor ASA
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wdt31 {
-	status = "okay";
-};

--- a/samples/drivers/watchdog/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
+++ b/samples/drivers/watchdog/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
@@ -1,8 +1,0 @@
-/*
- * Copyright 2025 Nordic Semiconductor ASA
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wdt31 {
-	status = "okay";
-};

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -1,8 +1,0 @@
-/*
- * Copyright 2024 Nordic Semiconductor ASA
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wdt31 {
-	status = "okay";
-};

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l15_cpuflpr_xip.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l15_cpuflpr_xip.overlay
@@ -1,8 +1,0 @@
-/*
- * Copyright 2024 Nordic Semiconductor ASA
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wdt31 {
-	status = "okay";
-};

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2025 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wdt31 {
-	status = "okay";
-};

--- a/tests/drivers/watchdog/wdt_variables/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
+++ b/tests/drivers/watchdog/wdt_variables/boards/nrf54lm20dk_nrf54lm20a_cpuflpr.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2025 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wdt31 {
-	status = "okay";
-};

--- a/tests/drivers/watchdog/wdt_variables/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_variables/testcase.yaml
@@ -16,7 +16,6 @@ tests:
       - nrf54h20dk/nrf54h20/cpuppr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuflpr
       - ophelia4ev/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Remove obsolete overlays - WDT at L15 and LM20 for FLPR core is not enabled.