### PR TITLE
net: mqtt_sn: Add support for publishing with QOS=-1

### DIFF
--- a/doc/connectivity/networking/api/mqtt_sn.rst
+++ b/doc/connectivity/networking/api/mqtt_sn.rst
@@ -148,7 +148,6 @@ Deviations from the standard
 
 Certain parts of the protocol are not yet supported in the library.
 
-* QoS -1 - it's most useful with predefined topics
 * Forwarder Encapsulation
 
 .. _mqtt_sn_api_reference:

--- a/include/zephyr/net/mqtt_sn.h
+++ b/include/zephyr/net/mqtt_sn.h
@@ -502,6 +502,18 @@ int mqtt_sn_predefine_topic(struct mqtt_sn_client *client, uint16_t topic_id,
 			    struct mqtt_sn_data *topic_name);
 
 /**
+ * @brief Define a short topic.
+ *
+ * Can be called before mqtt_sn_connect, because short topics are never cleared.
+ *
+ * @param[in] client The MQTT-SN client to define the topic on.
+ * @param[in] topic_name The name of the topic. Must be exactly 2 bytes long.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_sn_define_short_topic(struct mqtt_sn_client *client, struct mqtt_sn_data *topic_name);
+
+/**
  * @brief Send a will topic update to the server.
  *
  * Call this to send the will topic stored in client->will_topic to the server.

--- a/include/zephyr/net/mqtt_sn.h
+++ b/include/zephyr/net/mqtt_sn.h
@@ -487,10 +487,10 @@ int mqtt_sn_get_topic_name(struct mqtt_sn_client *client, uint16_t id,
 /**
  * @brief Predefine topic.
  *
- * Has to be called after mqtt_sn_connect, if a clear session is started. Otherwise, the clearing
- * will also remove all predefined topics. Additionally, it has to be called before calling
- * mqtt_sn_input for the first time after the connect, to prevent race conditions where incoming
- * publications use predefined topics which were not defined, yet.
+ * Can be called before mqtt_sn_connect, because predefined topics are never cleared. If you call it
+ * afterwards, it has to be called before calling mqtt_sn_input for the first time after the
+ * connect, to prevent race conditions where incoming publications use predefined topics which were
+ * not defined, yet.
  *
  * @param[in] client The MQTT-SN client to define the topic on.
  * @param[in] topic_id Topic identifier.

--- a/subsys/net/lib/mqtt_sn/mqtt_sn.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn.c
@@ -562,8 +562,8 @@ static void mqtt_sn_do_publish(struct mqtt_sn_client *client, struct mqtt_sn_pub
 		return;
 	}
 
-	if (client->state != MQTT_SN_CLIENT_ACTIVE) {
-		LOG_ERR("Cannot subscribe: not connected");
+	if (pub->qos != MQTT_SN_QOS_M1 && client->state != MQTT_SN_CLIENT_ACTIVE) {
+		LOG_ERR("Cannot publish: not connected");
 		return;
 	}
 
@@ -773,7 +773,7 @@ static int process_will_message_update(struct mqtt_sn_client *client, int64_t *n
 }
 
 /**
- * @brief Process all publish tasks in the queue.
+ * @brief Process all publish tasks in the queue, except ones with QOS=-1.
  *
  * @param client
  * @param next_cycle will be set to the time when the next action is required
@@ -789,6 +789,10 @@ static int process_pubs(struct mqtt_sn_client *client, int64_t *next_cycle)
 	bool dup; /* dup flag if message is resent */
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&client->publish, pub, pubs, next) {
+		if (pub->qos == MQTT_SN_QOS_M1) {
+			continue;
+		}
+
 		LOG_HEXDUMP_DBG(pub->topic->name, pub->topic->namelen,
 				"Processing publish for topic");
 		LOG_HEXDUMP_DBG(pub->pubdata, pub->datalen, "Processing publish data");
@@ -839,6 +843,29 @@ static int process_pubs(struct mqtt_sn_client *client, int64_t *next_cycle)
 	LOG_DBG("next_cycle: %lld", *next_cycle);
 
 	return 0;
+}
+
+/**
+ * @brief Process all QOS=-1 publish tasks in the queue.
+ *
+ * @param client
+ */
+static void process_pubs_qos_m1(struct mqtt_sn_client *client)
+{
+	struct mqtt_sn_publish *pub, *pubs;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&client->publish, pub, pubs, next) {
+		if (pub->qos != MQTT_SN_QOS_M1) {
+			continue;
+		}
+
+		LOG_HEXDUMP_DBG(pub->topic->name, pub->topic->namelen,
+				"Processing publish for topic");
+		LOG_HEXDUMP_DBG(pub->pubdata, pub->datalen, "Processing publish data");
+
+		mqtt_sn_do_publish(client, pub, false);
+		mqtt_sn_publish_destroy(client, pub);
+	}
 }
 
 /**
@@ -1125,6 +1152,8 @@ static void process_work(struct k_work *wrk)
 		return;
 	}
 
+	process_pubs_qos_m1(client);
+
 	if (client->state == MQTT_SN_CLIENT_ACTIVE) {
 		err = process_will_topic_update(client, &next_cycle);
 		if (err) {
@@ -1380,6 +1409,43 @@ int mqtt_sn_unsubscribe(struct mqtt_sn_client *client, enum mqtt_sn_qos qos,
 	return 0;
 }
 
+static int mqtt_sn_publish_m1(struct mqtt_sn_client *client, struct mqtt_sn_data *topic_name,
+			      bool retain, struct mqtt_sn_data *data)
+{
+	struct mqtt_sn_publish *pub;
+	struct mqtt_sn_topic *topic;
+	int err;
+
+	topic = mqtt_sn_topic_find_by_name(client, topic_name);
+	if (!topic) {
+		LOG_ERR("Topic not found");
+		return -EINVAL;
+	}
+	if (topic->type != MQTT_SN_TOPIC_TYPE_PREDEF && topic->type != MQTT_SN_TOPIC_TYPE_SHORT) {
+		LOG_ERR("Topic must be predefined or short");
+		return -EINVAL;
+	}
+
+	pub = mqtt_sn_publish_create(client, data);
+	if (!pub) {
+		k_work_reschedule(&client->process_work, K_NO_WAIT);
+		return -ENOMEM;
+	}
+
+	pub->qos = MQTT_SN_QOS_M1;
+	pub->retain = retain;
+	pub->topic = topic;
+
+	sys_slist_append(&client->publish, &pub->next);
+
+	err = k_work_reschedule(&client->process_work, K_NO_WAIT);
+	if (err < 0) {
+		return err;
+	}
+
+	return 0;
+}
+
 int mqtt_sn_publish(struct mqtt_sn_client *client, enum mqtt_sn_qos qos,
 		    struct mqtt_sn_data *topic_name, bool retain, struct mqtt_sn_data *data)
 {
@@ -1392,8 +1458,7 @@ int mqtt_sn_publish(struct mqtt_sn_client *client, enum mqtt_sn_qos qos,
 	}
 
 	if (qos == MQTT_SN_QOS_M1) {
-		LOG_ERR("QoS -1 not supported");
-		return -ENOTSUP;
+		return mqtt_sn_publish_m1(client, topic_name, retain, data);
 	}
 
 	if (client->state != MQTT_SN_CLIENT_ACTIVE) {

--- a/subsys/net/lib/mqtt_sn/mqtt_sn.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn.c
@@ -331,6 +331,12 @@ static void mqtt_sn_topic_destroy_all(struct mqtt_sn_client *client)
 			mqtt_sn_publish_destroy(client, pub);
 		}
 
+		/* Keep these around since they are valid without a connection */
+		if (topic->type == MQTT_SN_TOPIC_TYPE_PREDEF ||
+		    topic->type == MQTT_SN_TOPIC_TYPE_SHORT) {
+			continue;
+		}
+
 		k_mem_slab_free(&topics, (void *)topic);
 	}
 }


### PR DESCRIPTION
QOS=-1 is used to publish messages without an active connection. This PR adds support for that. I tested this with both predefined topics and short topics with the emqx server.