### PR TITLE
shell: User data support

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -258,6 +258,10 @@ New APIs and options
       * :kconfig:option:`CONFIG_SHELL_MQTT_WORK_DELAY_MS`
       * :kconfig:option:`CONFIG_SHELL_MQTT_LISTEN_TIMEOUT_MS`
 
+   * :c:func:`shell_user_data_get`
+   * :c:func:`shell_user_data_set`
+   * :kconfig:option:`CONFIG_SHELL_USER_DATA`
+
 * State Machine Framework
 
   * :c:func:`smf_get_current_leaf_state`

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -1024,6 +1024,11 @@ struct shell_ctx {
 	struct k_sem lock_sem;
 	k_tid_t tid;
 	int ret_val;
+
+#if defined(CONFIG_SHELL_USER_DATA) || defined(__DOXYGEN__)
+	/** Free field for user data */
+	void *user_data;
+#endif
 };
 
 extern const struct log_backend_api log_backend_shell_api;
@@ -1464,6 +1469,29 @@ int shell_mode_delete_set(const struct shell *sh, bool val);
  * @retval return value of previous command
  */
 int shell_get_return_value(const struct shell *sh);
+
+#if defined(CONFIG_SHELL_USER_DATA) || defined(__DOXYGEN__)
+
+/** @brief Set user data.
+ *
+ * @kconfig_dep{CONFIG_SHELL_USER_DATA}
+ *
+ * @param[in] sh	Pointer to the shell instance.
+ * @param[in] user_data	Opaque pointer for custom user data.
+ */
+void shell_user_data_set(const struct shell *sh, void *user_data);
+
+/** @brief Get user data.
+ *
+ * @kconfig_dep{CONFIG_SHELL_USER_DATA}
+ *
+ * @param[in] sh	Pointer to the shell instance.
+ *
+ * @return opaque pointer to custom user data.
+ */
+void *shell_user_data_get(const struct shell *sh);
+
+#endif
 
 /**
  * @}

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -336,6 +336,12 @@ config SHELL_TX_TIMEOUT_MS
 	  When using the shell log backend, the timeout should be longer to avoid
 	  timeouts due to log processing. A value of 0 means no timeout.
 
+config SHELL_USER_DATA
+	bool "Shell user data support"
+	help
+	  This will add an extra field to the struct shell_ctx that will allow a user
+	  to get/set an opaque user_data pointer.
+
 source "subsys/shell/modules/Kconfig"
 
 endif # SHELL

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1836,6 +1836,22 @@ bool shell_ready(const struct shell *sh)
 	return state_get(sh) ==	SHELL_STATE_ACTIVE;
 }
 
+#if defined(CONFIG_SHELL_USER_DATA)
+void shell_user_data_set(const struct shell *sh, void *user_data)
+{
+	__ASSERT_NO_MSG(sh != NULL);
+
+	sh->ctx->user_data = user_data;
+}
+
+void *shell_user_data_get(const struct shell *sh)
+{
+	__ASSERT_NO_MSG(sh != NULL);
+
+	return sh->ctx->user_data;
+}
+#endif
+
 static int cmd_help(const struct shell *sh, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);


### PR DESCRIPTION
Add an optional opaque user data pointer to be set/get on a shell instance.

As an alternative to https://github.com/zephyrproject-rtos/zephyr/pull/97187