### PR TITLE
libc + posix: signal.h + time.h: fix typos and avoid redeclaration warnings / errors

### DIFF
--- a/include/zephyr/posix/posix_signal.h
+++ b/include/zephyr/posix/posix_signal.h
@@ -43,11 +43,8 @@ typedef int uid_t;
 #define __uid_t_defined
 #endif
 
-#if !defined(_TIME_T_DECLARED) && !defined(__time_t_defined)
-typedef long time_t;
-#define _TIME_T_DECLARED
-#define __time_t_defined
-#endif
+/* time_t must be defined by the libc time.h */
+#include <time.h>
 
 #if !defined(_TIMESPEC_DECLARED) && !defined(__timespec_defined)
 struct timespec {

--- a/include/zephyr/posix/posix_signal.h
+++ b/include/zephyr/posix/posix_signal.h
@@ -111,7 +111,8 @@ union sigval {
 #if !defined(_SIGEVENT_DECLARED) && !defined(__sigevent_defined)
 struct sigevent {
 #if defined(_POSIX_THREADS) || defined(__DOXYGEN__)
-	pthread_attr_t *sigev_thread_attr;
+	pthread_attr_t *sigev_notify_attributes;
+	void (*sigev_notify_function)(union sigval value);
 #endif
 	union sigval sigev_value;
 	int sigev_notify;

--- a/include/zephyr/posix/posix_signal.h
+++ b/include/zephyr/posix/posix_signal.h
@@ -101,14 +101,14 @@ typedef struct {
 union sigval; /* forward declaration (to preserve spec order) */
 
 #if !defined(_SIGEVENT_DECLARED) && !defined(__sigevent_defined)
-typedef struct {
+struct sigevent {
 #if defined(_POSIX_THREADS) || defined(__DOXYGEN__)
 	pthread_attr_t *sigev_thread_attr;
 #endif
 	union sigval sigev_value;
 	int sigev_notify;
 	int sigev_signo;
-} sigevent_t;
+};
 #define _SIGEVENT_DECLARED
 #define __sigevent_defined
 #endif

--- a/include/zephyr/posix/posix_signal.h
+++ b/include/zephyr/posix/posix_signal.h
@@ -98,7 +98,15 @@ typedef struct {
 
 #if defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__)
 
-union sigval; /* forward declaration (to preserve spec order) */
+/* slightly out of order w.r.t. the specification */
+#if !defined(_SIGVAL_DECLARED) && !defined(__sigval_defined)
+union sigval {
+	int sival_int;
+	void *sival_ptr;
+};
+#define _SIGVAL_DECLARED
+#define __sigval_defined
+#endif
 
 #if !defined(_SIGEVENT_DECLARED) && !defined(__sigevent_defined)
 struct sigevent {
@@ -121,16 +129,27 @@ struct sigevent {
 
 #endif /* defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__) */
 
-#if !defined(_SIGVAL_DECLARED) && !defined(__sigval_defined)
-union sigval {
-	int sival_int;
-	void *sival_ptr;
-};
-#define _SIGVAL_DECLARED
-#define __sigval_defined
-#endif
-
 /* SIGRTMIN and SIGRTMAX defined above */
+
+#if !defined(_SIGINFO_T_DECLARED) && !defined(__siginfo_t_defined)
+typedef struct {
+	void *si_addr;
+#if defined(_XOPEN_STREAMS) || defined(__DOXYGEN__)
+	long si_band;
+#endif
+	union sigval si_value;
+	pid_t si_pid;
+	uid_t si_uid;
+	int si_signo;
+	int si_code;
+#if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+	int si_errno;
+#endif
+	int si_status;
+} siginfo_t;
+#define _SIGINFO_T_DECLARED
+#define __siginfo_t_defined
+#endif
 
 #if defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__)
 
@@ -199,26 +218,6 @@ typedef struct {
 #endif
 
 #endif /* defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__) */
-
-#if !defined(_SIGINFO_T_DECLARED) && !defined(__siginfo_t_defined)
-typedef struct {
-	void *si_addr;
-#if defined(_XOPEN_STREAMS) || defined(__DOXYGEN__)
-	long si_band;
-#endif
-	union sigval si_value;
-	pid_t si_pid;
-	uid_t si_uid;
-	int si_signo;
-	int si_code;
-#if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
-	int si_errno;
-#endif
-	int si_status;
-} siginfo_t;
-#define _SIGINFO_T_DECLARED
-#define __siginfo_t_defined
-#endif
 
 /* Siginfo codes are defined below */
 

--- a/include/zephyr/posix/posix_signal.h
+++ b/include/zephyr/posix/posix_signal.h
@@ -46,6 +46,9 @@ typedef int uid_t;
 /* time_t must be defined by the libc time.h */
 #include <time.h>
 
+#if __STDC_VERSION__ >= 201112L
+/* struct timespec must be defined in the libc time.h */
+#else
 #if !defined(_TIMESPEC_DECLARED) && !defined(__timespec_defined)
 struct timespec {
 	time_t tv_sec;
@@ -53,6 +56,7 @@ struct timespec {
 };
 #define _TIMESPEC_DECLARED
 #define __timespec_defined
+#endif
 #endif
 
 /* sig_atomic_t must be defined by the libc signal.h */

--- a/include/zephyr/posix/posix_time.h
+++ b/include/zephyr/posix/posix_time.h
@@ -61,10 +61,10 @@ struct sigevent;
 /* struct timespec must be defined in the libc time.h */
 #else
 #if !defined(_TIMESPEC_DECLARED) && !defined(__timespec_defined)
-typedef struct {
+struct timespec {
 	time_t tv_sec;
 	long tv_nsec;
-} timespec_t;
+};
 #define _TIMESPEC_DECLARED
 #define __timespec_defined
 #endif

--- a/lib/libc/arcmwdt/include/sys/timespec.h
+++ b/lib/libc/arcmwdt/include/sys/timespec.h
@@ -9,6 +9,8 @@
 
 #include <sys/_timespec.h>
 
+#define _TIMESPEC_DECLARED
+
 struct itimerspec {
 	struct timespec it_interval;  /* Timer interval */
 	struct timespec it_value;     /* Timer expiration */

--- a/lib/libc/armstdc/include/sys/_timespec.h
+++ b/lib/libc/armstdc/include/sys/_timespec.h
@@ -13,5 +13,6 @@ struct timespec {
 	time_t tv_sec;
 	long tv_nsec;
 };
+#define __timespec_defined
 
 #endif /* ZEPHYR_LIB_LIBC_ARMSTDC_INCLUDE_SYS__TIMESPEC_H_ */

--- a/lib/libc/armstdc/include/sys/_timeval.h
+++ b/lib/libc/armstdc/include/sys/_timeval.h
@@ -23,5 +23,6 @@ struct timeval {
 	time_t tv_sec;
 	suseconds_t tv_usec;
 };
+#define __timeval_defined
 
 #endif /* ZEPHYR_LIB_LIBC_ARMSTDC_INCLUDE_SYS__TIMEVAL_H_ */

--- a/lib/libc/iar/include/sys/_timeval.h
+++ b/lib/libc/iar/include/sys/_timeval.h
@@ -23,5 +23,6 @@ struct timeval {
 	time_t tv_sec;
 	suseconds_t tv_usec;
 };
+#define __timeval_defined
 
 #endif /* ZEPHYR_LIB_LIBC_IAR_INCLUDE_SYS__TIMEVAL_H_ */

--- a/lib/libc/minimal/include/sys/_timespec.h
+++ b/lib/libc/minimal/include/sys/_timespec.h
@@ -19,9 +19,13 @@ typedef _TIME_T_ time_t;
 typedef _SUSECONDS_T_ suseconds_t;
 #endif
 
+#if !defined(_TIMESPEC_DECLARED) && !defined(__timespec_defined)
 struct timespec {
 	time_t tv_sec;
 	long tv_nsec;
 };
+#define __timespec_defined
+#define _TIMESPEC_DECLARED
+#endif
 
 #endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS__TIMESPEC_H_ */

--- a/lib/libc/minimal/include/sys/_timeval.h
+++ b/lib/libc/minimal/include/sys/_timeval.h
@@ -19,9 +19,13 @@ typedef _TIME_T_ time_t;
 typedef _SUSECONDS_T_ suseconds_t;
 #endif
 
+#if !defined(_TIMEVAL_DECLARED) && !defined(__timeval_defined)
 struct timeval {
 	time_t tv_sec;
 	suseconds_t tv_usec;
 };
+#define _TIMEVAL_DECLARED
+#define __timeval_defined
+#endif
 
 #endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS__TIMEVAL_H_ */

--- a/lib/libc/newlib/include/signal.h
+++ b/lib/libc/newlib/include/signal.h
@@ -34,6 +34,11 @@
 #undef sigdelset
 #undef sigismember
 
+#if defined(_POSIX_REALTIME_SIGNALS)
+#define _SIGEVENT_DECLARED
+#define _SIGVAL_DECLARED
+#endif
+
 #endif /* defined(_POSIX_C_SOURCE) || defined(__DOXYGEN__) */
 
 #endif /* ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_SIGNAL_H_ */

--- a/lib/libc/newlib/include/sys/_timespec.h
+++ b/lib/libc/newlib/include/sys/_timespec.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_SYS__TIMESPEC_H_
+#define ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_SYS__TIMESPEC_H_
+
+#include_next <sys/_timespec.h>
+
+#define _TIMESPEC_DECLARED
+
+#endif /* ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_SYS__TIMESPEC_H_ */

--- a/lib/libc/newlib/include/sys/_timeval.h
+++ b/lib/libc/newlib/include/sys/_timeval.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_SYS__TIMEVAL_H_
+#define ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_SYS__TIMEVAL_H_
+
+#include_next <sys/_timeval.h>
+
+#define _TIMEVAL_DECLARED
+
+#endif /* ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_SYS__TIMEVAL_H_ */

--- a/lib/libc/picolibc/include/signal.h
+++ b/lib/libc/picolibc/include/signal.h
@@ -47,6 +47,11 @@ int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT 
 #undef sigdelset
 #undef sigismember
 
+#if defined(_POSIX_REALTIME_SIGNALS)
+#define _SIGEVENT_DECLARED
+#define _SIGVAL_DECLARED
+#endif
+
 #endif /* defined(_POSIX_C_SOURCE) || defined(__DOXYGEN__) */
 
 #endif /* ZEPHYR_LIB_LIBC_PICOLIBC_INCLUDE_SIGNAL_H_ */

--- a/lib/libc/picolibc/include/sys/_timespec.h
+++ b/lib/libc/picolibc/include/sys/_timespec.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_PICOLIBC_INCLUDE_SYS__TIMESPEC_H_
+#define ZEPHYR_LIB_LIBC_PICOLIBC_INCLUDE_SYS__TIMESPEC_H_
+
+#include_next <sys/_timespec.h>
+
+#define _TIMESPEC_DECLARED
+
+#endif /* ZEPHYR_LIB_LIBC_PICOLIBC_INCLUDE_SYS__TIMESPEC_H_ */

--- a/lib/libc/picolibc/include/sys/_timeval.h
+++ b/lib/libc/picolibc/include/sys/_timeval.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_PICOLIBC_INCLUDE_SYS__TIMEVAL_H_
+#define ZEPHYR_LIB_LIBC_PICOLIBC_INCLUDE_SYS__TIMEVAL_H_
+
+#include_next <sys/_timeval.h>
+
+#define _TIMEVAL_DECLARED
+
+#endif /* ZEPHYR_LIB_LIBC_PICOLIBC_INCLUDE_SYS__TIMEVAL_H_ */


### PR DESCRIPTION
This change corrects 2 typos in `posix_signal.h` and `posix_time.h` and additionally ensures that libc definitions of `struct timespec` are indicated via macro to avoid redefinition warnings / errors.

* libc: newlib + picolibc: indicate sigevent and sigval are declared
* libc: indicate timeval is defined
* libc: indicate timespec is defined
* posix: signal.h: always pull in `time_t` definition from libc
* posix: signal.h: do not define `struct timespec` when >= c11
* posix: time.h: `timepsec` is a struct not a typedef
* posix: signal.h: `sigevent` is a struct not a typedef
* posix: signal.h: reorder where `sigval` is declared 
* posix: signal.h: include `sigev_notify_function` field in `struct sigevent`

The issues do not affect CI or build status at the moment but do block changes slated for v4.3.0