### PR TITLE
drivers: dma: stm32: add null callback checking

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -117,7 +117,10 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		if (!stream->hal_override) {
 			dma_stm32_clear_ht(dma, id);
 		}
-		stream->dma_callback(dev, stream->user_data, callback_arg, DMA_STATUS_BLOCK);
+		if (stream->dma_callback != NULL) {
+			stream->dma_callback(dev, stream->user_data, callback_arg,
+					     DMA_STATUS_BLOCK);
+		}
 	} else if (stm32_dma_is_tc_irq_active(dma, id)) {
 		/* Circular buffer never stops receiving as long as peripheral is enabled */
 		if (!stream->cyclic) {
@@ -127,7 +130,10 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		if (!stream->hal_override) {
 			dma_stm32_clear_tc(dma, id);
 		}
-		stream->dma_callback(dev, stream->user_data, callback_arg, DMA_STATUS_COMPLETE);
+		if (stream->dma_callback != NULL) {
+			stream->dma_callback(dev, stream->user_data, callback_arg,
+					     DMA_STATUS_COMPLETE);
+		}
 	} else if (stm32_dma_is_unexpected_irq_happened(dma, id)) {
 		/* Let HAL DMA handle flags on its own */
 		if (!stream->hal_override) {
@@ -135,8 +141,9 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 			stm32_dma_dump_stream_irq(dma, id);
 			stm32_dma_clear_stream_irq(dma, id);
 		}
-		stream->dma_callback(dev, stream->user_data,
-				     callback_arg, -EIO);
+		if (stream->dma_callback != NULL) {
+			stream->dma_callback(dev, stream->user_data, callback_arg, -EIO);
+		}
 	} else {
 		/* Let HAL DMA handle flags on its own */
 		if (!stream->hal_override) {
@@ -145,8 +152,9 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 			dma_stm32_dump_stream_irq(dev, id);
 			dma_stm32_clear_stream_irq(dev, id);
 		}
-		stream->dma_callback(dev, stream->user_data,
-				     callback_arg, -EIO);
+		if (stream->dma_callback != NULL) {
+			stream->dma_callback(dev, stream->user_data, callback_arg, -EIO);
+		}
 	}
 }
 


### PR DESCRIPTION
drivers: dma: stm32: check for null dma_callback before enabling irqs

The STM32 DMA driver did not check if the optional dma_callback was set in dma_stm32_configure(). This could lead to a hard fault when an interrupt occurs and the callback is NULL, even though the API allows the callback to be omitted.

This patch modifies dma_stm32_configure() to enable transfer and half-transfer interrupts only if a valid dma_callback is supplied in config. This prevents NULL-function pointer dereference if callbacks are not used.

Fixes #97454