### PR TITLE
Bluetooth: Mesh: Provisioner closes link on failed

### DIFF
--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -685,7 +685,7 @@ static void prov_confirm(const uint8_t *data)
 static void prov_failed(const uint8_t *data)
 {
 	LOG_WRN("Error: 0x%02x", data[0]);
-	reset_state();
+	prov_link_close(PROV_BEARER_LINK_STATUS_FAIL);
 }
 
 static void local_input_complete(void)

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -577,10 +577,9 @@ static void prov_complete(const uint8_t *data)
 		bt_hex(&provisionee.new_dev_key, 16), node->net_idx,
 		node->num_elem, node->addr);
 
-	bt_mesh_prov_link.expect = PROV_NO_PDU;
 	atomic_set_bit(bt_mesh_prov_link.flags, COMPLETE);
 
-	bt_mesh_prov_link.bearer->link_close(PROV_BEARER_LINK_STATUS_SUCCESS);
+	prov_link_close(PROV_BEARER_LINK_STATUS_SUCCESS);
 }
 
 static void prov_node_add(void)


### PR DESCRIPTION
According to MshPrt 5.4.4, The Provisioner, upon receiving the Provisioning Failed PDU, shall assume that the provisioning failed and immediately disconnect the provisioning bearer.

Also changes the link close upon to success to use the prov_link_close helper function instead of doing it manually, as minor cleanup.