### PR TITLE
tests: bsim: Bluetooth: Fail on advertising start error

### DIFF
--- a/tests/bsim/bluetooth/ll/conn/src/test_connect2.c
+++ b/tests/bsim/bluetooth/ll/conn/src/test_connect2.c
@@ -127,16 +127,20 @@ static int start_advertising(void)
 	int err;
 
 	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
-	if (err) {
-		printk("Advertising failed to start (err %d)\n", err);
-	}
 
 	return err;
 }
 
 static void recycled(void)
 {
-	start_advertising();
+	int err;
+
+	err = start_advertising();
+	if (err) {
+		FAIL("Advertising failed to restart (err %d)\n", err);
+	} else {
+		printk("Advertising successfully restarted\n");
+	}
 }
 
 static struct bt_conn_cb conn_callbacks = {
@@ -152,7 +156,9 @@ static void bt_ready(void)
 	printk("Peripheral Bluetooth initialized\n");
 
 	err = start_advertising();
-	if (!err) {
+	if (err) {
+		FAIL("Advertising failed to start (err %d)\n", err);
+	} else {
 		printk("Advertising successfully started\n");
 	}
 }


### PR DESCRIPTION
Add back test failure that was missed when fixing double
and redundant advertising start in
commit 7a672c05b333f3841ccadc6ffc9cab42f8b1d1eb ("Bluetooth: tests: bsim: Fix double
advertising in test_connect2").

Also, relates to commit 8cfad44852845cd30336d40f61dade69ab4357db ("Bluetooth: Deprecate
adv auto-resume").