### PR TITLE
drivers: mfd: npm13xx: namespace TIMER_MAX to avoid conflict

### DIFF
--- a/drivers/mfd/mfd_npm13xx.c
+++ b/drivers/mfd/mfd_npm13xx.c
@@ -34,7 +34,7 @@
 #define GPIO_OFFSET_MODE 0x00U
 
 #define TIMER_PRESCALER_MS 16U
-#define TIMER_MAX          0xFFFFFFU
+#define NPM13XX_TIMER_MAX  0xFFFFFFU
 
 #define MAIN_SIZE 0x26U
 
@@ -242,7 +242,7 @@ int mfd_npm13xx_set_timer(const struct device *dev, uint32_t time_ms)
 	uint8_t buff[5] = {NPM13XX_TIME_BASE, TIME_OFFSET_TIMER};
 	uint32_t ticks = time_ms / TIMER_PRESCALER_MS;
 
-	if (ticks > TIMER_MAX) {
+	if (ticks > NPM13XX_TIMER_MAX) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
`TIMER_MAX` is part of POSIX and defined in limits.h.

To avoid conflict with the standard, namespace the local definition with a `NPM13XX_` prefix.

This fixes an issue that appeared in weekly CI:

```shell
error: "TIMER_MAX" redefined [-Werror]
```

https://github.com/zephyrproject-rtos/zephyr/actions/runs/18437938778/job/52533996345