### PR TITLE
twister: Remove redundant code and sort imports with ruff

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -721,23 +721,14 @@
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
 ]
-"./scripts/tests/twister/conftest.py" = [
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
-"./scripts/tests/twister/pytest_integration/test_harness_pytest.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/tests/twister/test_cmakecache.py" = [
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
 "./scripts/tests/twister/test_config_parser.py" = [
     "B017",     # https://docs.astral.sh/ruff/rules/assert-raises-exception
     "B033",     # https://docs.astral.sh/ruff/rules/duplicate-value
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM117",   # https://docs.astral.sh/ruff/rules/multiple-with-statements
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
@@ -745,23 +736,16 @@
     "B011",     # https://docs.astral.sh/ruff/rules/assert-false
 ]
 "./scripts/tests/twister/test_environment.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM117",   # https://docs.astral.sh/ruff/rules/multiple-with-statements
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
-"./scripts/tests/twister/test_errors.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/tests/twister/test_handlers.py" = [
     "B011",     # https://docs.astral.sh/ruff/rules/assert-false
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP012",    # https://docs.astral.sh/ruff/rules/unnecessary-encode-utf8
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
 "./scripts/tests/twister/test_hardwaremap.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
@@ -769,71 +753,53 @@
     "B017",     # https://docs.astral.sh/ruff/rules/assert-raises-exception
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "E713",     # https://docs.astral.sh/ruff/rules/not-in-test
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
 "./scripts/tests/twister/test_jobserver.py" = [
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
 "./scripts/tests/twister/test_log_helper.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
 "./scripts/tests/twister/test_platform.py" = [
     "B011",     # https://docs.astral.sh/ruff/rules/assert-false
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
 "./scripts/tests/twister/test_quarantine.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
 "./scripts/tests/twister/test_runner.py" = [
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
 ]
 "./scripts/tests/twister/test_scl.py" = [
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM117",   # https://docs.astral.sh/ruff/rules/multiple-with-statements
     "UP025",    # https://docs.astral.sh/ruff/rules/unicode-kind-prefix
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
 "./scripts/tests/twister/test_testinstance.py" = [
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
 "./scripts/tests/twister/test_testplan.py" = [
     "B905",     # https://docs.astral.sh/ruff/rules/zip-without-explicit-strict
     "E101",     # https://docs.astral.sh/ruff/rules/mixed-spaces-and-tabs
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM118",   # https://docs.astral.sh/ruff/rules/in-dict-keys
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
     "W191",     # https://docs.astral.sh/ruff/rules/tab-indentation
 ]
 "./scripts/tests/twister/test_testsuite.py" = [
     "B011",     # https://docs.astral.sh/ruff/rules/assert-false
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
 "./scripts/tests/twister/test_twister.py" = [
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP026",    # https://docs.astral.sh/ruff/rules/deprecated-mock-import
 ]
 "./scripts/tests/twister_blackbox/conftest.py" = [

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -25,6 +25,20 @@ ignore = [
     # zephyr-keep-sorted-stop
 ]
 
+[lint.isort]
+known-first-party = [
+    # zephyr-keep-sorted-start
+    "camera_shield",
+    "domains",
+    "list_boards",
+    "scl",
+    "twister",
+    "twister_harness",
+    "twisterlib",
+    "zephyr_module" ,
+    # zephyr-keep-sorted-stop
+]
+
 [format]
 quote-style = "preserve"
 line-ending = "lf"

--- a/scripts/tests/twister/__init__.py
+++ b/scripts/tests/twister/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+from pathlib import Path
+
+ZEPHYR_BASE = os.getenv("ZEPHYR_BASE", str(Path(__file__).parents[3]))
+
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts"))

--- a/scripts/tests/twister/conftest.py
+++ b/scripts/tests/twister/conftest.py
@@ -6,23 +6,25 @@
 '''Common fixtures for use in testing the twister tool.'''
 import logging
 import os
-import sys
+
 import pytest
 
+from twisterlib.environment import TwisterEnv, add_parse_arguments, parse_arguments
+from twisterlib.testinstance import TestInstance
+from twisterlib.testplan import TestConfiguration, TestPlan
+
+from . import ZEPHYR_BASE
+
 pytest_plugins = ["pytester"]
+
 logging.getLogger("twister").setLevel(logging.DEBUG)  # requires for testing twister
 
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts"))
-from twisterlib.testplan import TestPlan, TestConfiguration
-from twisterlib.testinstance import TestInstance
-from twisterlib.environment import TwisterEnv, add_parse_arguments, parse_arguments
 
 def new_get_toolchain(*args, **kwargs):
     return 'zephyr'
 
 TestPlan.get_toolchain = new_get_toolchain
+
 
 @pytest.fixture(name='test_data')
 def _test_data():
@@ -30,14 +32,17 @@ def _test_data():
     data = ZEPHYR_BASE + "/scripts/tests/twister/test_data/"
     return data
 
+
 @pytest.fixture(name='zephyr_base')
 def zephyr_base_directory():
     return ZEPHYR_BASE
+
 
 @pytest.fixture(name='testsuites_dir')
 def testsuites_directory():
     """ Pytest fixture to load the test data directory"""
     return ZEPHYR_BASE + "/scripts/tests/twister/test_data/testsuites"
+
 
 @pytest.fixture(name='class_env')
 def tesenv_obj(test_data, testsuites_dir, tmpdir_factory):
@@ -63,6 +68,7 @@ def testplan_obj(class_env):
     plan.options.outdir = env.outdir
     return plan
 
+
 @pytest.fixture(name='all_testsuites_dict')
 def testsuites_dict(class_testplan):
     """ Pytest fixture to call add_testcase function of
@@ -71,6 +77,7 @@ def testsuites_dict(class_testplan):
     class_testplan.TESTSUITE_FILENAME = 'test_data.yaml'
     class_testplan.add_testsuites()
     return class_testplan.testsuites
+
 
 @pytest.fixture(name='platforms_list')
 def all_platforms_list(test_data, class_testplan):
@@ -81,6 +88,7 @@ def all_platforms_list(test_data, class_testplan):
     plan.test_config = TestConfiguration(config_file=class_testplan.env.test_config)
     plan.add_configurations()
     return plan.platforms
+
 
 @pytest.fixture
 def instances_fixture(class_testplan, platforms_list, all_testsuites_dict):

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import pytest
 import textwrap
-
-from unittest import mock
 from pathlib import Path
+from unittest import mock
+
+import pytest
 
 from twisterlib.harness import Pytest
-from twisterlib.testsuite import TestSuite
-from twisterlib.testinstance import TestInstance
 from twisterlib.platform import Platform
+from twisterlib.testinstance import TestInstance
+from twisterlib.testsuite import TestSuite
 
 
 @pytest.fixture

--- a/scripts/tests/twister/test_cmakecache.py
+++ b/scripts/tests/twister/test_cmakecache.py
@@ -6,13 +6,12 @@
 Tests for cmakecache.py classes' methods
 """
 
+from contextlib import nullcontext
 from unittest import mock
+
 import pytest
 
-from contextlib import nullcontext
-
-from twisterlib.cmakecache import CMakeCacheEntry, CMakeCache
-
+from twisterlib.cmakecache import CMakeCache, CMakeCacheEntry
 
 TESTDATA_1 = [
     ('ON', True),

--- a/scripts/tests/twister/test_config_parser.py
+++ b/scripts/tests/twister/test_config_parser.py
@@ -8,12 +8,18 @@ Tests for config_parser.py
 """
 
 import os
-import pytest
-from unittest import mock
-import scl
-
-from twisterlib.config_parser import TwisterConfigParser, extract_fields_from_arg_list, ConfigurationError
 from contextlib import nullcontext
+from unittest import mock
+
+import pytest
+
+import scl
+from twisterlib.config_parser import (
+    ConfigurationError,
+    TwisterConfigParser,
+    extract_fields_from_arg_list,
+)
+
 
 def test_extract_single_field_from_string_argument():
     target_fields = {"FIELD1"}

--- a/scripts/tests/twister/test_errors.py
+++ b/scripts/tests/twister/test_errors.py
@@ -7,11 +7,11 @@ Tests for the error classes
 """
 
 import os
+from pathlib import Path
+
 import pytest
 
-from pathlib import Path
-from twisterlib.error import StatusAttributeError
-from twisterlib.error import ConfigurationError
+from twisterlib.error import ConfigurationError, StatusAttributeError
 from twisterlib.harness import Test
 
 

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -8,35 +8,33 @@ Tests for handlers.py classes' methods
 """
 
 import itertools
-from unittest import mock
 import os
-import pytest
 import signal
 import subprocess
 import sys
-
 from contextlib import nullcontext
 from importlib import reload
-from serial import SerialException
 from subprocess import CalledProcessError, TimeoutExpired
 from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from serial import SerialException
 
 import twisterlib.harness
-
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-
 from twisterlib.error import TwisterException
-from twisterlib.statuses import TwisterStatus
 from twisterlib.handlers import (
-    Handler,
     BinaryHandler,
     DeviceHandler,
+    Handler,
     QEMUHandler,
-    SimulationHandler
+    SimulationHandler,
 )
-from twisterlib.hardwaremap import (
-    DUT
-)
+from twisterlib.hardwaremap import DUT
+from twisterlib.statuses import TwisterStatus
+
+from . import ZEPHYR_BASE
+
 
 @pytest.fixture
 def mocked_instance(tmp_path):

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -6,16 +6,13 @@
 Tests for hardwaremap.py classes' methods
 """
 
-from unittest import mock
-import pytest
 import sys
-
 from pathlib import Path
+from unittest import mock
 
-from twisterlib.hardwaremap import(
-    DUT,
-    HardwareMap
-)
+import pytest
+
+from twisterlib.hardwaremap import DUT, HardwareMap
 
 
 @pytest.fixture

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -6,18 +6,13 @@
 """
 This test file contains testsuites for the Harness classes of twister
 """
-from unittest import mock
-import sys
-import os
-import pytest
-import re
 import logging as logger
+import os
+import re
 import textwrap
+from unittest import mock
 
-# ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-from conftest import ZEPHYR_BASE
-
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
+import pytest
 
 from twisterlib.harness import (
     Bsim,
@@ -31,8 +26,8 @@ from twisterlib.harness import (
     Test,
 )
 from twisterlib.statuses import TwisterStatus
-from twisterlib.testsuite import TestSuite, TestCase
 from twisterlib.testinstance import TestInstance
+from twisterlib.testsuite import TestCase, TestSuite
 
 GTEST_START_STATE = " RUN      "
 GTEST_PASS_STATE = "       OK "

--- a/scripts/tests/twister/test_jobserver.py
+++ b/scripts/tests/twister/test_jobserver.py
@@ -7,20 +7,21 @@ Tests for jobserver.py classes' methods
 """
 
 import functools
-from unittest import mock
 import os
-import pytest
 import sys
-
 from contextlib import nullcontext
 from errno import ENOENT
 from selectors import EVENT_READ
+from unittest import mock
+
+import pytest
 
 # Job server only works on Linux for now.
 pytestmark = pytest.mark.skipif(sys.platform != 'linux', reason='JobServer only works on Linux.')
 if sys.platform == 'linux':
-    from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient, JobHandle
     from fcntl import F_GETFL
+
+    from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient, JobHandle
 
 
 def test_jobhandle(capfd):

--- a/scripts/tests/twister/test_log_helper.py
+++ b/scripts/tests/twister/test_log_helper.py
@@ -7,13 +7,12 @@ Tests for log_helper.py functions
 """
 
 import logging
+from importlib import reload
 from unittest import mock
+
 import pytest
 
-from importlib import reload
-
 import twisterlib.log_helper
-
 
 TESTDATA = [
     ('Windows', 'dummy message: [\'dummy\', \'command\', \'-flag\']'),

--- a/scripts/tests/twister/test_platform.py
+++ b/scripts/tests/twister/test_platform.py
@@ -6,19 +6,13 @@
 '''
 This test file contains tests for platform.py module of twister
 '''
-import sys
-import os
-from unittest import mock
-import pytest
-
 from contextlib import nullcontext
+from unittest import mock
+
+import pytest
 from pykwalify.errors import SchemaError
 
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
-
 from twisterlib.platform import Platform, Simulator, generate_platforms
-
 
 TESTDATA_1 = [
     (

--- a/scripts/tests/twister/test_quarantine.py
+++ b/scripts/tests/twister/test_quarantine.py
@@ -6,15 +6,13 @@
 Tests for quarantine.py classes' methods
 """
 
-from unittest import mock
 import os
-import pytest
 import textwrap
+from unittest import mock
 
-from twisterlib.quarantine import QuarantineException, \
-                                  QuarantineElement, \
-                                  QuarantineData
+import pytest
 
+from twisterlib.quarantine import QuarantineData, QuarantineElement, QuarantineException
 
 TESTDATA_1 = [
     (

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -7,34 +7,27 @@ Tests for runner.py classes
 """
 
 import errno
-from unittest import mock
 import os
 import pathlib
-import pytest
 import re
 import subprocess
 import sys
-import yaml
-
 from collections import deque
 from contextlib import nullcontext
-from elftools.elf.sections import SymbolTableSection
 from typing import List
+from unittest import mock
 
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
+import pytest
+import yaml
+from elftools.elf.sections import SymbolTableSection
 
-from twisterlib.statuses import TwisterStatus
 from twisterlib.error import BuildError
 from twisterlib.harness import Pytest
+from twisterlib.runner import CMake, ExecutionCounter, FilterBuilder, ProjectBuilder, TwisterRunner
+from twisterlib.statuses import TwisterStatus
 
-from twisterlib.runner import (
-    CMake,
-    ExecutionCounter,
-    FilterBuilder,
-    ProjectBuilder,
-    TwisterRunner
-)
+from . import ZEPHYR_BASE
+
 
 @pytest.fixture
 def mocked_instance(tmp_path):

--- a/scripts/tests/twister/test_scl.py
+++ b/scripts/tests/twister/test_scl.py
@@ -7,25 +7,20 @@ Tests for scl.py functions
 """
 
 import logging
-from unittest import mock
-import os
-import pytest
 import sys
-
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
-
-import scl
-
 from contextlib import nullcontext
 from importlib import reload
+from unittest import mock
+
+import pytest
 from pykwalify.errors import SchemaError
 from yaml.scanner import ScannerError
 
+import scl
 
 TESTDATA_1 = [
-    (False),
-    (True),
+    (False,),
+    (True,),
 ]
 
 @pytest.mark.parametrize(

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -7,23 +7,19 @@
 Tests for testinstance class
 """
 
-from contextlib import nullcontext
 import os
-import sys
-import pytest
+from contextlib import nullcontext
 from unittest import mock
 
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
-
-from pylib.twister.twisterlib.platform import Simulator
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testinstance import TestInstance
-from twisterlib.error import BuildError
-from twisterlib.runner import TwisterRunner
-from twisterlib.handlers import QEMUHandler
+import pytest
 from expr_parser import reserved
 
+from twisterlib.error import BuildError
+from twisterlib.handlers import QEMUHandler
+from twisterlib.platform import Simulator
+from twisterlib.runner import TwisterRunner
+from twisterlib.statuses import TwisterStatus
+from twisterlib.testinstance import TestInstance
 
 TESTDATA_PART_1 = [
     (False, False, "console", None, "qemu", False, [], (False, True)),

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -6,24 +6,21 @@
 '''
 This test file contains testsuites for testsuite.py module of twister
 '''
-import sys
 import os
-from unittest import mock
-import pytest
-
+import sys
 from contextlib import nullcontext
 from pathlib import Path
+from unittest import mock
 
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
+import pytest
 
-from twisterlib.statuses import TwisterStatus
-from twisterlib.testplan import TestPlan, TestConfiguration, change_skip_to_error_if_integration
-from twisterlib.testinstance import TestInstance
-from twisterlib.testsuite import TestSuite
+from twisterlib.error import TwisterRuntimeError
 from twisterlib.platform import Platform
 from twisterlib.quarantine import Quarantine
-from twisterlib.error import TwisterRuntimeError
+from twisterlib.statuses import TwisterStatus
+from twisterlib.testinstance import TestInstance
+from twisterlib.testplan import TestConfiguration, TestPlan, change_skip_to_error_if_integration
+from twisterlib.testsuite import TestSuite
 
 
 def test_testplan_add_testsuites_short(class_testplan):

--- a/scripts/tests/twister/test_testsuite.py
+++ b/scripts/tests/twister/test_testsuite.py
@@ -7,29 +7,26 @@ Tests for testinstance class
 """
 
 import mmap
-from unittest import mock
 import os
-import pytest
-import sys
-
 from contextlib import nullcontext
+from unittest import mock
 
-ZEPHYR_BASE = os.getenv('ZEPHYR_BASE')
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, 'scripts', 'pylib', 'twister'))
+import pytest
 
+from twisterlib.error import TwisterException, TwisterRuntimeError
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testsuite import (
+    ScanPathResult,
+    TestCase,
+    TestSuite,
     _find_src_dir_path,
     _get_search_area_boundary,
     find_c_files_in,
     scan_file,
     scan_testsuite_path,
-    ScanPathResult,
-    TestCase,
-    TestSuite
 )
-from twisterlib.error import TwisterException, TwisterRuntimeError
 
+from . import ZEPHYR_BASE
 
 TESTDATA_1 = [
     (

--- a/scripts/tests/twister/test_twister.py
+++ b/scripts/tests/twister/test_twister.py
@@ -7,19 +7,17 @@
 This test file contains foundational testcases for Twister tool
 """
 
-import os
-import sys
-from unittest import mock
-import pytest
-
 from pathlib import Path
+from unittest import mock
 
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
+import pytest
 
 import scl
 from twisterlib.error import ConfigurationError
 from twisterlib.testplan import TwisterConfigParser
+
+from . import ZEPHYR_BASE
+
 
 def test_yamlload():
     """ Test to check if loading the non-existent files raises the errors """


### PR DESCRIPTION
- Removed redundant `sys.path.insert`
- Fixed imports order to follow PEP8 style