### PR TITLE
riscv: pmp: Add helper to write PMP configuration CSRs

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -136,6 +136,40 @@ static inline void z_riscv_pmp_read_config(unsigned long *pmp_cfg, size_t pmp_cf
 #endif
 }
 
+/**
+ * @brief Writes the PMP configuration CSRs (pmpcfgX) based on architecture and slot count.
+ *
+ * This helper function abstracts the logic required to write the correct Control and Status
+ * Registers (CSRs)—pmpcfg0, pmpcfg1, etc.—by accounting for whether the system is 32-bit or
+ * 64-bit and the total number of PMP slots configured. It handles the different register
+ * packing schemes between RV32 and RV64.
+ *
+ * @param pmp_cfg Pointer to the array containing the PMP configuration values to be written
+ * to the CSRs.
+ * @param pmp_cfg_size The size of the pmp_cfg array, measured in unsigned long entries.
+ */
+static inline void z_riscv_pmp_write_config(unsigned long *pmp_cfg, size_t pmp_cfg_size)
+{
+	__ASSERT(pmp_cfg_size == (size_t)(CONFIG_PMP_SLOTS / PMPCFG_STRIDE),
+		 "Invalid PMP config array size");
+
+#ifdef CONFIG_64BIT
+	/* RV64: pmpcfg0 holds entries 0-7; pmpcfg2 holds entries 8-15. */
+	csr_write(pmpcfg0, pmp_cfg[0]);
+#if CONFIG_PMP_SLOTS > 8
+	csr_write(pmpcfg2, pmp_cfg[1]);
+#endif
+#else
+	/* RV32: Each pmpcfg register holds 4 entries. */
+	csr_write(pmpcfg0, pmp_cfg[0]);
+	csr_write(pmpcfg1, pmp_cfg[1]);
+#if CONFIG_PMP_SLOTS > 8
+	csr_write(pmpcfg2, pmp_cfg[2]);
+	csr_write(pmpcfg3, pmp_cfg[3]);
+#endif
+#endif
+}
+
 static void dump_pmp_regs(const char *banner)
 {
 	unsigned long pmp_addr[CONFIG_PMP_SLOTS];


### PR DESCRIPTION
Introduce `z_riscv_pmp_write_config` to abstract writing to pmpcfg registers. This function handles the differing register layouts and slot counts between RV32 and RV64 architectures, writing to the appropriate pmpcfg0, pmpcfg1, pmpcfg2, or pmpcfg3 CSRs as needed based on CONFIG_PMP_SLOTS.