### PR TITLE
drivers: stepper: Kconfig: fix bleeding Kconfigs

### DIFF
--- a/drivers/stepper/CMakeLists.txt
+++ b/drivers/stepper/CMakeLists.txt
@@ -4,10 +4,13 @@
 zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/stepper.h)
 
 # zephyr-keep-sorted-start
-add_subdirectory_ifdef(CONFIG_STEPPER_ADI_TMC adi_tmc)
-add_subdirectory_ifdef(CONFIG_STEPPER_ALLEGRO allegro)
-add_subdirectory_ifdef(CONFIG_STEPPER_TI ti)
-add_subdirectory_ifdef(CONFIG_STEP_DIR_STEPPER step_dir)
+add_subdirectory(adi_tmc)
+add_subdirectory(allegro)
+add_subdirectory(ti)
+# zephyr-keep-sorted-stop
+
+# zephyr-keep-sorted-start
+add_subdirectory(step_dir)
 # zephyr-keep-sorted-stop
 
 zephyr_library()

--- a/drivers/stepper/adi_tmc/CMakeLists.txt
+++ b/drivers/stepper/adi_tmc/CMakeLists.txt
@@ -8,4 +8,4 @@ zephyr_library_sources_ifdef(CONFIG_STEPPER_ADI_TMC2209 tmc22xx.c)
 zephyr_library_sources_ifdef(CONFIG_STEPPER_ADI_TMC50XX tmc50xx.c)
 add_subdirectory_ifdef(CONFIG_STEPPER_ADI_TMC51XX tmc51xx)
 
-add_subdirectory_ifdef(CONFIG_STEPPER_ADI_TMC bus)
+add_subdirectory(bus)

--- a/drivers/stepper/adi_tmc/Kconfig
+++ b/drivers/stepper/adi_tmc/Kconfig
@@ -1,33 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 Carl Zeiss Meditec AG
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig STEPPER_ADI_TMC
-	bool "Trinamic Stepper Controller"
-	depends on STEPPER
-	default y
-	help
-	  Enable trinamic stepper controller
+comment "ADI Trinamic Stepper Drivers"
 
-if STEPPER_ADI_TMC
-
-config STEPPER_ADI_TMC_SPI
-	bool "Use Trinamic Stepper Controller with SPI"
-	depends on STEPPER_ADI_TMC
-	select SPI
-	help
-	  A Trinamic Stepper Controller with SPI is enabled
-
-config STEPPER_ADI_TMC_UART
-	bool "Use Trinamic Stepper Controller with single wire UART"
-	depends on STEPPER_ADI_TMC
-	select UART
-	help
-	  A Trinamic Stepper Controller with single wire UART is enabled
-
-comment "Trinamic Stepper Drivers"
+rsource "bus/Kconfig"
 
 rsource "Kconfig.tmc22xx"
 rsource "Kconfig.tmc50xx"
-rsource "Kconfig.tmc51xx"
-
-endif # STEPPER_ADI_TMC
+rsource "tmc51xx/Kconfig.tmc51xx"

--- a/drivers/stepper/adi_tmc/Kconfig.tmc50xx
+++ b/drivers/stepper/adi_tmc/Kconfig.tmc50xx
@@ -4,10 +4,14 @@
 
 config STEPPER_ADI_TMC50XX
 	bool "Activate trinamic tmc50xx stepper driver"
-	depends on DT_HAS_ADI_TMC50XX_ENABLED && STEPPER_ADI_TMC
+	depends on DT_HAS_ADI_TMC50XX_ENABLED
 	select STEPPER_ADI_TMC_SPI
 	default y
+
+if STEPPER_ADI_TMC50XX
 
 module = TMC50XX
 module-str = tmc50xx
 rsource "Kconfig.tmc_rampgen_template"
+
+endif # STEPPER_ADI_TMC51XX

--- a/drivers/stepper/adi_tmc/bus/Kconfig
+++ b/drivers/stepper/adi_tmc/bus/Kconfig
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Jilay Sandeep Pandya
+# SPDX-License-Identifier: Apache-2.0
+
+config STEPPER_ADI_TMC_SPI
+	bool "Use Trinamic Stepper Controller with SPI"
+	select SPI
+	help
+	  A Trinamic Stepper Controller with SPI is enabled
+
+config STEPPER_ADI_TMC_UART
+	bool "Use Trinamic Stepper Controller with single wire UART"
+	select UART
+	help
+	  A Trinamic Stepper Controller with single wire UART is enabled

--- a/drivers/stepper/adi_tmc/tmc51xx/Kconfig.tmc51xx
+++ b/drivers/stepper/adi_tmc/tmc51xx/Kconfig.tmc51xx
@@ -3,11 +3,15 @@
 
 config STEPPER_ADI_TMC51XX
 	bool "Activate trinamic tmc51xx stepper driver"
-	depends on DT_HAS_ADI_TMC51XX_ENABLED && STEPPER_ADI_TMC
+	depends on DT_HAS_ADI_TMC51XX_ENABLED
 	select STEPPER_ADI_TMC_UART if $(dt_compat_on_bus,$(DT_COMPAT_ADI_TMC51XX),uart)
 	select STEPPER_ADI_TMC_SPI if $(dt_compat_on_bus,$(DT_COMPAT_ADI_TMC51XX),spi)
 	default y
 
+if STEPPER_ADI_TMC51XX
+
 module = TMC51XX
 module-str = tmc51xx
-rsource "Kconfig.tmc_rampgen_template"
+rsource "../Kconfig.tmc_rampgen_template"
+
+endif # STEPPER_ADI_TMC51XX

--- a/drivers/stepper/allegro/Kconfig
+++ b/drivers/stepper/allegro/Kconfig
@@ -1,19 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Carl Zeiss Meditec AG
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig STEPPER_ALLEGRO
-	bool "Allegro Stepper Controller"
-	depends on STEPPER
-	default y
-	help
-	  Enable allegro stepper controller
-
-if STEPPER_ALLEGRO
-
 comment "Allegro Stepper Drivers"
 
 # zephyr-keep-sorted-start
 rsource "Kconfig.a4979"
 # zephyr-keep-sorted-stop
-
-endif # STEPPER_ALLEGRO

--- a/drivers/stepper/ti/Kconfig
+++ b/drivers/stepper/ti/Kconfig
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 Navimatix GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-config STEPPER_TI
-	bool
-	depends on STEPPER
+comment "TI Stepper Drivers"
 
 rsource "Kconfig.drv84xx"

--- a/drivers/stepper/ti/Kconfig.drv84xx
+++ b/drivers/stepper/ti/Kconfig.drv84xx
@@ -5,7 +5,6 @@ config DRV84XX
 	bool "TI DRV84XX stepper motor driver"
 	default y
 	depends on DT_HAS_TI_DRV84XX_ENABLED
-	select STEPPER_TI
 	select STEP_DIR_STEPPER
 	select STEPPER_STEP_DIR_GENERATE_ISR_SAFE_EVENTS
 	help


### PR DESCRIPTION
- currently Kconfigs in stepper area are not uniformly organized, some vendor folders follow menuconfig while the others config.

Also without activating drivers explicitly following Kconfigs appear in autoconf.h with CONFIG_STEPPER=y

CONFIG_STEPPER_ADI_TMC 1
CONFIG_STEPPER_ADI_TMC50XX_RAMPSTAT_POLL_INTERVAL_IN_MSEC 100
CONFIG_STEPPER_ADI_TMC51XX_RAMPSTAT_POLL_INTERVAL_IN_MSEC 100
CONFIG_STEPPER_ALLEGRO 1

- refactor Kconfig.tmc51xx to tmc51xx folder
- refactor adi_tmc bus related Kconfigs in adi_tmc/bus