### PR TITLE
test: drivers: flash: common: Add sfdp case for nrf54l15 tests.

### DIFF
--- a/samples/drivers/jesd216/sample.yaml
+++ b/samples/drivers/jesd216/sample.yaml
@@ -30,8 +30,11 @@ tests:
     platform_allow: nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
-  sample.drivers.jesd216.nrf54lm20:
+  sample.drivers.jesd216.nrf54l:
     platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf54lm20dk/nrf54lm20a/cpuapp

--- a/tests/drivers/flash/common/boards/nrf54l15dk_remove_dt_sfdp.overlay
+++ b/tests/drivers/flash/common/boards/nrf54l15dk_remove_dt_sfdp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mx25r64 {
+/delete-property/ jedec-id;
+/delete-property/ sfdp-bfp;
+/delete-property/ has-dpd;
+/delete-property/ t-enter-dpd;
+/delete-property/ t-exit-dpd;
+};

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -70,6 +70,17 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
     harness_config:
       fixture: external_flash
+  drivers.flash.common.no_explicit_erase.sfdp_runtime:
+    platform_allow:
+      - nrf54l15dk/nrf54l05/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    harness_config:
+      fixture: external_flash
+    extra_configs:
+      - CONFIG_SPI_NOR_SFDP_RUNTIME=y
+    extra_args:
+      - DTC_OVERLAY_FILE=boards/nrf54l15dk_remove_dt_sfdp.overlay
   drivers.flash.common.no_explicit_erase.nrf54h:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Add case for using flash with some parameters read with runtime sfdp instead of dt declarations.