### PR TITLE
drivers: counter: add support for Infineon PSE84 device

### DIFF
--- a/dts/bindings/counter/infineon,tcpwm-counter.yaml
+++ b/dts/bindings/counter/infineon,tcpwm-counter.yaml
@@ -10,11 +10,6 @@ compatible: "infineon,tcpwm-counter"
 include: [base.yaml, "infineon,system-interrupts.yaml"]
 
 properties:
-  clock-frequency:
-    type: int
-    description: |
-      Frequency that the counter runs
-
   external-trigger-gpios:
     type: phandle-array
     description: |

--- a/samples/drivers/counter/alarm/boards/kit_pse84_eval_common.overlay
+++ b/samples/drivers/counter/alarm/boards/kit_pse84_eval_common.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+
+&tcpwm0_1 {
+	status = "okay";
+
+	counter0_1 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_1>;
+	};
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <1>;
+	clock-div = <9600>;
+};

--- a/samples/drivers/counter/alarm/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/samples/drivers/counter/alarm/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/samples/drivers/counter/alarm/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/drivers/counter/alarm/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -54,7 +54,7 @@ struct counter_alarm_cfg alarm_cfg;
 #endif
 #define TIMER DT_CHOSEN(silabs_sleeptimer)
 #elif defined(CONFIG_COUNTER_INFINEON_CAT1) || defined(CONFIG_COUNTER_INFINEON_TCPWM)
-#define TIMER DT_NODELABEL(counter0_0)
+#define TIMER DT_NODELABEL(counter0_1)
 #elif defined(CONFIG_COUNTER_AMBIQ)
 #ifdef TIMER
 #undef TIMER


### PR DESCRIPTION
 - Update the driver to support the PSE84 device
 - Update to new peripheral clock allocation scheme
 - Add overlay files for the alarm sample