### PR TITLE
Ifx e84 pwm

### DIFF
--- a/dts/bindings/pwm/infineon,tcpwm-pwm.yaml
+++ b/dts/bindings/pwm/infineon,tcpwm-pwm.yaml
@@ -7,7 +7,7 @@ description: Infineon TCPWM PWM
 
 compatible: "infineon,tcpwm-pwm"
 
-include: [pwm-controller.yaml, pinctrl-device.yaml, "infineon,system-interrupts.yaml"]
+include: [base.yaml, pwm-controller.yaml, pinctrl-device.yaml, "infineon,system-interrupts.yaml"]
 
 properties:
   "#pwm-cells":

--- a/samples/basic/blinky_pwm/boards/kit_pse84_eval_common.overlay
+++ b/samples/basic/blinky_pwm/boards/kit_pse84_eval_common.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0_7 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "PWM LED";
+		};
+		status = "okay";
+	};
+};
+
+&tcpwm0_7 {
+	status = "okay";
+
+	pwm0_7: pwm0_7 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_1>;
+		pinctrl-0 = <&p16_7_pwm0_7>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <7>;
+	clock-div = <9600>;
+};
+
+&pinctrl {
+	p16_7_pwm0_7: p16_7_pwm0_7 {
+		drive-push-pull;
+	};
+};

--- a/samples/basic/blinky_pwm/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/samples/basic/blinky_pwm/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/samples/basic/blinky_pwm/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/basic/blinky_pwm/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/samples/basic/fade_led/boards/kit_pse84_eval_common.overlay
+++ b/samples/basic/fade_led/boards/kit_pse84_eval_common.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0_7 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "PWM LED";
+		};
+		status = "okay";
+	};
+};
+
+&tcpwm0_7 {
+	status = "okay";
+
+	pwm0_7: pwm0_7 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_1>;
+		pinctrl-0 = <&p16_7_pwm0_7>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <7>;
+	clock-div = <9600>;
+};
+
+&pinctrl {
+	p16_7_pwm0_7: p16_7_pwm0_7 {
+		drive-push-pull;
+	};
+};

--- a/samples/basic/fade_led/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/samples/basic/fade_led/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/samples/basic/fade_led/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/basic/fade_led/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_common.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+
+/ {
+	aliases {
+		pwm-test = &pwm0_7;
+	};
+};
+
+&tcpwm0_7 {
+	status = "okay";
+
+	pwm0_7: pwm0_7 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_1>;
+		pinctrl-0 = <&p16_7_pwm0_7>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <7>;
+	clock-div = <9600>;
+};
+
+&pinctrl {
+	p16_7_pwm0_7: p16_7_pwm0_7 {
+		drive-push-pull;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_common.overlay
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+
+/ {
+	zephyr,user {
+		pwms = <&pwm0_1 0 PWM_MSEC(20) (PWM_POLARITY_NORMAL | PWM_IFX_TCPWM_OUTPUT_HIGHZ)>,
+		       <&pwm1_19 1 PWM_MSEC(20) (PWM_POLARITY_NORMAL | PWM_IFX_TCPWM_OUTPUT_HIGHZ)>;
+		gpios = <&gpio_prt16 2 GPIO_ACTIVE_HIGH>,
+			<&gpio_prt15 3 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&tcpwm0_1 {
+	status = "okay";
+
+	pwm0_1: pwm0_1 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_1>;
+		pinctrl-0 = <&p16_1_pwm0_1>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <1>;
+	clock-div = <9600>;
+};
+
+&tcpwm1_19 {
+	status = "okay";
+
+	pwm1_19: pwm1_19 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_2>;
+		pinctrl-0 = <&p15_2_pwm1_19>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group1_16bit_2 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <1>;
+	resource-channel = <19>;
+	clock-div = <9600>;
+};
+
+&pinctrl {
+	p15_2_pwm1_19: p15_2_pwm1_19 {
+		drive-push-pull;
+	};
+
+	p16_1_pwm0_1: p16_1_pwm0_1 {
+		drive-push-pull;
+	};
+};
+
+/* gpio_prt16 is already enabled in boards\infineon\kit_pse84_eval\kit_pse84_eval_common.dtsi */
+&gpio_prt15 {
+	status = "okay";
+};

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/tests/drivers/pwm/pwm_gpio_loopback/testcase.yaml
+++ b/tests/drivers/pwm/pwm_gpio_loopback/testcase.yaml
@@ -31,3 +31,5 @@ tests:
   drivers.pwm.gpio_loopback.ifx:
     platform_allow:
       - cyw920829m2evk_02
+      - kit_pse84_eval/pse846gps2dbzc4a/m33
+      - kit_pse84_eval/pse846gps2dbzc4a/m55


### PR DESCRIPTION
- Update the driver to support the PSE84 device
- Update to new peripheral clock allocation scheme
- Add overlay files for the blinky_pwm and fade_led samples
- Add overlay files for the pwm_api and pwm_gpio_loopback tests
- Update platform_allow for pwm_gpio_loopback