### PR TITLE
boards: add the zephyr_i2c to adafruit_feather_esp32

### DIFF
--- a/boards/adafruit/feather_esp32/adafruit_feather_esp32_procpu.dts
+++ b/boards/adafruit/feather_esp32/adafruit_feather_esp32_procpu.dts
@@ -81,7 +81,7 @@
 	status = "okay";
 };
 
-&i2c0 {
+zephyr_i2c: &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	pinctrl-0 = <&i2c0_default>;


### PR DESCRIPTION
Match the behavior of other Adafruit boards by including the zephyr_i2c label to allow the use of JST SH I2C shields.