### PR TITLE
riscv: pmp: Rename PMP stackguard functions to kernelmode

### DIFF
--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -229,7 +229,7 @@ void z_riscv_fault(struct arch_esf *esf)
 		 * Remove the thread's PMP setting to prevent triggering a stack
 		 * overflow error again due to the previous configuration.
 		 */
-		z_riscv_pmp_stackguard_disable();
+		z_riscv_pmp_kernelmode_disable();
 #endif /* CONFIG_PMP_STACK_GUARD */
 		reason = K_ERR_STACK_CHK_FAIL;
 	}

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -376,7 +376,7 @@ no_fp:	/* increment _current->arch.exception_depth */
 	and t0, t0, t1
 	bnez t0, 1f
 	lr a0, ___cpu_t_current_OFFSET(s0)
-	call z_riscv_pmp_stackguard_enable
+	call z_riscv_pmp_kernelmode_enable
 1:
 #endif /* CONFIG_PMP_STACK_GUARD */
 
@@ -524,7 +524,7 @@ is_user_syscall:
 	 * PMP for kernel mode stack guard.
 	 */
 	lr a0, ___cpu_t_current_OFFSET(s0)
-	call z_riscv_pmp_stackguard_enable
+	call z_riscv_pmp_kernelmode_enable
 #endif
 
 	/* It is safe to re-enable IRQs now */
@@ -599,7 +599,7 @@ is_interrupt:
 	and t0, t0, t1
 	bnez t0, 1f
 	lr a0, ___cpu_t_current_OFFSET(s0)
-	call z_riscv_pmp_stackguard_enable
+	call z_riscv_pmp_kernelmode_enable
 	j 2f
 #endif /* CONFIG_USERSPACE */
 1:	/* Re-activate PMP for m-mode */

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -408,7 +408,7 @@ void z_riscv_pmp_init(void)
 	 * This early, the kernel init code uses the IRQ stack and we want to
 	 * safeguard it as soon as possible. But we need a temporary default
 	 * "catch all" PMP entry for MPRV to work. Later on, this entry will
-	 * be set for each thread by z_riscv_pmp_stackguard_prepare().
+	 * be set for each thread by z_riscv_pmp_kernelmode_prepare().
 	 */
 	set_pmp_mprv_catchall(&index, pmp_addr, pmp_cfg, ARRAY_SIZE(pmp_addr));
 
@@ -501,7 +501,7 @@ static inline unsigned int z_riscv_pmp_thread_init(unsigned long *pmp_addr,
  *
  * This is called once during new thread creation.
  */
-void z_riscv_pmp_stackguard_prepare(struct k_thread *thread)
+void z_riscv_pmp_kernelmode_prepare(struct k_thread *thread)
 {
 	unsigned int index = z_riscv_pmp_thread_init(PMP_M_MODE(thread));
 	uintptr_t stack_bottom;
@@ -529,7 +529,7 @@ void z_riscv_pmp_stackguard_prepare(struct k_thread *thread)
  *
  * This is called on every context switch.
  */
-void z_riscv_pmp_stackguard_enable(struct k_thread *thread)
+void z_riscv_pmp_kernelmode_enable(struct k_thread *thread)
 {
 	LOG_DBG("pmp_stackguard_enable for thread %p", thread);
 
@@ -558,7 +558,7 @@ void z_riscv_pmp_stackguard_enable(struct k_thread *thread)
 /**
  * @brief Remove PMP stackguard content to actual PMP registers
  */
-void z_riscv_pmp_stackguard_disable(void)
+void z_riscv_pmp_kernelmode_disable(void)
 {
 
 	unsigned long pmp_addr[CONFIG_PMP_SLOTS];

--- a/arch/riscv/core/switch.S
+++ b/arch/riscv/core/switch.S
@@ -64,7 +64,7 @@ SECTION_FUNC(TEXT, z_riscv_switch)
 #if defined(CONFIG_PMP_STACK_GUARD)
 	/* Stack guard has priority over user space for PMP usage. */
 	mv s0, a0
-	call z_riscv_pmp_stackguard_enable
+	call z_riscv_pmp_kernelmode_enable
 	mv a0, s0
 #elif defined(CONFIG_USERSPACE)
 	/*

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -99,7 +99,7 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 
 #if defined(CONFIG_PMP_STACK_GUARD)
 	/* Setup PMP regions of PMP stack guard of thread. */
-	z_riscv_pmp_stackguard_prepare(thread);
+	z_riscv_pmp_kernelmode_prepare(thread);
 #endif /* CONFIG_PMP_STACK_GUARD */
 
 #ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
@@ -178,7 +178,7 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 
 #ifdef CONFIG_PMP_STACK_GUARD
 	/* reconfigure as the kernel mode stack will be different */
-	z_riscv_pmp_stackguard_prepare(_current);
+	z_riscv_pmp_kernelmode_prepare(_current);
 #endif
 
 	/* Set up Physical Memory Protection */

--- a/arch/riscv/include/pmp.h
+++ b/arch/riscv/include/pmp.h
@@ -8,9 +8,9 @@
 #define PMP_H_
 
 void z_riscv_pmp_init(void);
-void z_riscv_pmp_stackguard_prepare(struct k_thread *thread);
-void z_riscv_pmp_stackguard_enable(struct k_thread *thread);
-void z_riscv_pmp_stackguard_disable(void);
+void z_riscv_pmp_kernelmode_prepare(struct k_thread *thread);
+void z_riscv_pmp_kernelmode_enable(struct k_thread *thread);
+void z_riscv_pmp_kernelmode_disable(void);
 void z_riscv_pmp_usermode_init(struct k_thread *thread);
 void z_riscv_pmp_usermode_prepare(struct k_thread *thread);
 void z_riscv_pmp_usermode_enable(struct k_thread *thread);


### PR DESCRIPTION
Rename the `z_riscv_pmp_stackguard_*` functions to `z_riscv_pmp_kernelmode_*`. This change better reflects that these functions are used for general kernel mode PMP configuration, not strictly limited to stack guard purposes.

Call sites in fatal.c, isr.S, and switch.S have been updated accordingly.