### PR TITLE
driver: flash_mspi_nor: Allow specific read/write IO modes and frequencies

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -64,6 +64,10 @@ New APIs and options
 
 .. zephyr-keep-sorted-start re(^\* \w)
 
+* Flash
+
+  * :dtcompatible:`jedec,mspi-nor` now allows MSPI configuration of read, write and
+    control commands separately via devicetree.
 
 .. zephyr-keep-sorted-stop
 

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -75,7 +75,7 @@ struct flash_mspi_nor_config {
 	uint16_t page_size;
 	struct mspi_dev_id mspi_id;
 	struct mspi_dev_cfg mspi_nor_cfg;
-	struct mspi_dev_cfg mspi_nor_init_cfg;
+	struct mspi_dev_cfg mspi_control_cfg;
 #if defined(CONFIG_MSPI_XIP)
 	struct mspi_xip_cfg xip_cfg;
 #endif
@@ -115,6 +115,7 @@ struct flash_mspi_nor_data {
 	struct flash_mspi_nor_switch_info switch_info;
 	bool in_target_io_mode;
 	const struct mspi_dev_cfg *last_applied_cfg;
+	bool chip_initialized;
 };
 
 #ifdef __cplusplus

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -96,6 +96,10 @@ struct flash_mspi_nor_config {
 	const struct jesd216_erase_type *default_erase_types;
 	struct flash_mspi_nor_cmd_info default_cmd_info;
 	struct flash_mspi_nor_switch_info default_switch_info;
+	uint32_t read_freq;
+	enum mspi_io_mode read_io_mode;
+	uint32_t write_freq;
+	enum mspi_io_mode write_io_mode;
 	bool jedec_id_specified  : 1;
 	bool rx_dummy_specified  : 1;
 	bool multiperipheral_bus : 1;
@@ -115,6 +119,10 @@ struct flash_mspi_nor_data {
 	struct flash_mspi_nor_switch_info switch_info;
 	const struct mspi_dev_cfg *last_applied_cfg;
 	bool chip_initialized;
+	const struct mspi_dev_cfg *read_cfg;
+	struct mspi_dev_cfg mspi_dev_read_cfg;
+	const struct mspi_dev_cfg *write_cfg;
+	struct mspi_dev_cfg mspi_dev_write_cfg;
 };
 
 #ifdef __cplusplus

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -114,6 +114,7 @@ struct flash_mspi_nor_data {
 	struct flash_mspi_nor_cmd_info cmd_info;
 	struct flash_mspi_nor_switch_info switch_info;
 	bool in_target_io_mode;
+	const struct mspi_dev_cfg *last_applied_cfg;
 };
 
 #ifdef __cplusplus

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -113,7 +113,6 @@ struct flash_mspi_nor_data {
 	struct jesd216_erase_type erase_types[JESD216_NUM_ERASE_TYPES];
 	struct flash_mspi_nor_cmd_info cmd_info;
 	struct flash_mspi_nor_switch_info switch_info;
-	bool in_target_io_mode;
 	const struct mspi_dev_cfg *last_applied_cfg;
 	bool chip_initialized;
 };

--- a/drivers/flash/flash_mspi_nor_quirks.h
+++ b/drivers/flash/flash_mspi_nor_quirks.h
@@ -80,7 +80,7 @@ static inline int mxicy_mx25r_post_switch_mode(const struct device *dev)
 	set_up_xfer(dev, MSPI_TX);
 	dev_data->packet.data_buf  = mxicy_mx25r_hp_payload;
 	dev_data->packet.num_bytes = sizeof(mxicy_mx25r_hp_payload);
-	rc = perform_xfer(dev, SPI_NOR_CMD_WRSR, false);
+	rc = perform_xfer(dev, SPI_NOR_CMD_WRSR);
 	if (rc < 0) {
 		return rc;
 	}
@@ -101,7 +101,7 @@ static inline int mxicy_mx25r_post_switch_mode(const struct device *dev)
 	set_up_xfer(dev, MSPI_RX);
 	dev_data->packet.num_bytes = sizeof(config);
 	dev_data->packet.data_buf  = config;
-	rc = perform_xfer(dev, SPI_NOR_CMD_RDCR, false);
+	rc = perform_xfer(dev, SPI_NOR_CMD_RDCR);
 	if (rc < 0) {
 		return rc;
 	}
@@ -159,7 +159,7 @@ static inline int mxicy_mx25u_post_switch_mode(const struct device *dev)
 	dev_data->packet.address   = 0;
 	dev_data->packet.data_buf  = &opi_enable;
 	dev_data->packet.num_bytes = sizeof(opi_enable);
-	return perform_xfer(dev, SPI_NOR_CMD_WR_CFGREG2, false);
+	return perform_xfer(dev, SPI_NOR_CMD_WR_CFGREG2);
 }
 
 static int mxicy_mx25u_pre_init(const struct device *dev)
@@ -192,7 +192,7 @@ static int mxicy_mx25u_pre_init(const struct device *dev)
 	dev_data->packet.address   = 0x300;
 	dev_data->packet.data_buf  = &cfg_reg;
 	dev_data->packet.num_bytes = sizeof(cfg_reg);
-	rc = perform_xfer(dev, SPI_NOR_CMD_RD_CFGREG2, false);
+	rc = perform_xfer(dev, SPI_NOR_CMD_RD_CFGREG2);
 	if (rc < 0) {
 		LOG_ERR("Failed to read Dummy Cycle from CFGREG2");
 		return rc;

--- a/dts/bindings/mtd/jedec,mspi-nor.yaml
+++ b/dts/bindings/mtd/jedec,mspi-nor.yaml
@@ -21,6 +21,62 @@ include:
       - t-exit-dpd
 
 properties:
+  read-frequency:
+    type: int
+    description: |
+      Clock frequency of device to configure in Hz for read
+      command, when reads are desired to be in a different
+      frequency than the rest of the commands.
+
+  read-io-mode:
+    type: string
+    enum:
+      - "MSPI_IO_MODE_SINGLE"
+      - "MSPI_IO_MODE_DUAL"
+      - "MSPI_IO_MODE_DUAL_1_1_2"
+      - "MSPI_IO_MODE_DUAL_1_2_2"
+      - "MSPI_IO_MODE_QUAD"
+      - "MSPI_IO_MODE_QUAD_1_1_4"
+      - "MSPI_IO_MODE_QUAD_1_4_4"
+      - "MSPI_IO_MODE_OCTAL"
+      - "MSPI_IO_MODE_OCTAL_1_1_8"
+      - "MSPI_IO_MODE_OCTAL_1_8_8"
+      - "MSPI_IO_MODE_HEX"
+      - "MSPI_IO_MODE_HEX_8_8_16"
+      - "MSPI_IO_MODE_HEX_8_16_16"
+    description: |
+      MSPI I/O mode setting for read command when desired to
+      be different from base device `mspi-io-mode` for the rest
+      of the commands.
+
+  write-frequency:
+    type: int
+    description: |
+      Clock frequency of device to configure in Hz for write
+      command, when write are desired to be in a different
+      frequency than the rest of the commands.
+
+  write-io-mode:
+    type: string
+    enum:
+      - "MSPI_IO_MODE_SINGLE"
+      - "MSPI_IO_MODE_DUAL"
+      - "MSPI_IO_MODE_DUAL_1_1_2"
+      - "MSPI_IO_MODE_DUAL_1_2_2"
+      - "MSPI_IO_MODE_QUAD"
+      - "MSPI_IO_MODE_QUAD_1_1_4"
+      - "MSPI_IO_MODE_QUAD_1_4_4"
+      - "MSPI_IO_MODE_OCTAL"
+      - "MSPI_IO_MODE_OCTAL_1_1_8"
+      - "MSPI_IO_MODE_OCTAL_1_8_8"
+      - "MSPI_IO_MODE_HEX"
+      - "MSPI_IO_MODE_HEX_8_8_16"
+      - "MSPI_IO_MODE_HEX_8_16_16"
+    description: |
+      MSPI I/O mode setting for write command when desired to
+      be different from base device `mspi-io-mode` for the rest
+      of the commands.
+
   reset-gpios:
     type: phandle-array
     description: |


### PR DESCRIPTION
Consider these MSPI flash parts: [Gigadevice GD25LE64E](https://www.mouser.com/datasheet/2/870/gd25le64e_rev1_3_20220426-2581248.pdf?srsltid=AfmBOorNVcnYnluZdrfwc0T8omPY6eENgh54MhcyPPMGnzULMow4bohG), [Macronix MX25U6432F](https://www.mxic.com.tw/Lists/Datasheet/Attachments/9025/MX25U6432F,%201.8V,%2064Mb,%20v1.1.pdf), [Winbond W25Q64JW](https://www.mouser.com/datasheet/2/949/W25Q64JW_RevB_11042019-1760399.pdf?srsltid=AfmBOoqU8en17EXwRIWMS5knHo8qgqum1mYZ11-1KLpk4Y5CnxYXuwyQ). If only D0 and D1 lines are connected to these flash parts, then Dual IO 1-1-2 `DREAD 0x3B` and Single IO `PP 0x02` are the best read and write commands available to use. Notice that neither Dual IO `PP_1_1_2 0xA2` command is supported in any of these flash parts, and neither these flash parts support Dual Peripheral Interface (like QPI, OPI), so all general commands need to be in Single IO.

The driver currently provides no way to use Dual IO Read and Single IO for the rest of the commands currently, and would erroneously use Single IO PP command in Dual IO mode. This PR fixes and adds support for that.

## Target Board
nRF54H20 MSPI and flash driver to support [Gigadevice GD25LE64E](https://www.mouser.com/datasheet/2/870/gd25le64e_rev1_3_20220426-2581248.pdf?srsltid=AfmBOorNVcnYnluZdrfwc0T8omPY6eENgh54MhcyPPMGnzULMow4bohG), [Macronix MX25U6432F](https://www.mxic.com.tw/Lists/Datasheet/Attachments/9025/MX25U6432F,%201.8V,%2064Mb,%20v1.1.pdf) and [Winbond W25Q64JW](https://www.mouser.com/datasheet/2/949/W25Q64JW_RevB_11042019-1760399.pdf?srsltid=AfmBOoqU8en17EXwRIWMS5knHo8qgqum1mYZ11-1KLpk4Y5CnxYXuwyQ).

## Modifications
*  JEDEC standard specifies different commands for read/writes in different MSPI IO modes. Driver should let device tree specify which IO mode and frequency to use for read and writes, defaulting to the overall IO mode and frequency when not specified.
* With different IO modes using different number of lines, one `mspi-max-frequency` is not the highest possible frequency to use for all modes. Allow read/write frequency to be granularly specified.

## Testing
The following modes for flash driver worked in local testing:
* Single IO for everything
```
mspi-io-mode = "MSPI_IO_MODE_SINGLE";
mspi-max-frequency = <DT_FREQ_M(66)>;
```
* Single IO general and write, Dual IO reads
```
mspi-io-mode = "MSPI_IO_MODE_SINGLE";
mspi-max-frequency = <DT_FREQ_M(66)>;
read-command = <0x3B>; // DREAD Dual IO 1-1-2
read-io-mode = "MSPI_IO_MODE_DUAL_1_1_2";
read-frequency = <DT_FREQ_M(40)>;
```
* Quad IO for writes and Dual IO for reads because why not.
```
mspi-max-frequency = <DT_FREQ_M(60)>;
mspi-io-mode = "MSPI_IO_MODE_SINGLE";
read-frequency = <DT_FREQ_M(30)>;
read-io-mode = "MSPI_IO_MODE_DUAL_1_1_2";
read-command = <0x3B>;
write-frequency = <DT_FREQ_M(40)>;
write-io-mode = "MSPI_IO_MODE_QUAD_1_4_4";
write-command = <0x38>;
```