### PR TITLE
boards: lpcxpresso55s69: support jlink when CONFIG_SECOND_CORE_MCUX

### DIFF
--- a/boards/nxp/lpcxpresso55s69/board.cmake
+++ b/boards/nxp/lpcxpresso55s69/board.cmake
@@ -12,6 +12,7 @@ board_runner_args(linkserver  "--device=LPC55S69:LPCXpresso55S69")
 
 if(CONFIG_SECOND_CORE_MCUX)
   board_runner_args(linkserver  "--core=all")
+  board_runner_args(jlink "--device=LPC55S69_M33_0")
 elseif(CONFIG_BOARD_LPCXPRESSO55S69_LPC55S69_CPU0 OR
    CONFIG_BOARD_LPCXPRESSO55S69_LPC55S69_CPU0_NS)
   board_runner_args(jlink "--device=LPC55S69_M33_0")


### PR DESCRIPTION
when config CONFIG_SECOND_CORE_MCUX we can use cpu0 to flash all test for mbox cases.