### PR TITLE
samples: ipc: openamp_rsc_table: set module logging level to INF

### DIFF
--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -24,7 +24,7 @@
 #endif
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(openamp_rsc_table);
+LOG_MODULE_REGISTER(openamp_rsc_table, LOG_LEVEL_INF);
 
 #define SHM_DEVICE_NAME	"shm"
 


### PR DESCRIPTION
Currently, the module logging level is set to the default level, in case the default logging level is set to LOG_LEVEL_NONE, then none logging content will be printed.

This patch explictly set the module logging level to LOG_LEVEL_INF, to ensure the INF/ERR loggings can be printed to the console.

Splited from PR https://github.com/zephyrproject-rtos/zephyr/pull/96399