### PR TITLE
drv: ft8xx: new coprocessor commands

### DIFF
--- a/drivers/misc/ft8xx/ft8xx.c
+++ b/drivers/misc/ft8xx/ft8xx.c
@@ -15,8 +15,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
-#include <zephyr/drivers/misc/ft8xx/ft8xx_copro.h>
 #include <zephyr/drivers/misc/ft8xx/ft8xx_common.h>
+#include <zephyr/drivers/misc/ft8xx/ft8xx_copro.h>
 #include <zephyr/drivers/misc/ft8xx/ft8xx_dl.h>
 #include <zephyr/drivers/misc/ft8xx/ft8xx_memory.h>
 
@@ -150,6 +150,11 @@ int ft8xx_get_touch_tag(const struct device *dev)
 	(void)ft8xx_rd8(dev, FT800_REG_INT_FLAGS);
 
 	return (int)ft8xx_rd8(dev, FT800_REG_TOUCH_TAG);
+}
+
+uint32_t ft8xx_get_tracker_value(const struct device *dev)
+{
+	return ft8xx_rd32(dev, FT800_REG_TRACKER);
 }
 
 void ft8xx_drv_irq_triggered(const struct device *gpio_port, struct gpio_callback *cb,

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx.h
@@ -93,6 +93,19 @@ void ft8xx_touch_transform_set(const struct device *dev,
 int ft8xx_get_touch_tag(const struct device *dev);
 
 /**
+ * @brief Get the tag and the tracking value of the tracked object.
+ *
+ * The reported tag and the tracking value apply to an object tracked by the
+ * coprocessor with the ft8xx_copro_cmd_track() function.
+ *
+ * @param dev Pointer to the device structure for the driver instance
+ *
+ * @return Track register content where 2 MS bytes (0xffff0000 mask) indicate
+ *         the track value and 2 LS bytes (0x0000ffff mask) indicate the tag.
+ */
+uint32_t ft8xx_get_tracker_value(const struct device *dev);
+
+/**
  * @brief Set callback executed when FT8xx triggers interrupt
  *
  * This function configures FT8xx to trigger interrupt when touch event changes

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx_copro.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx_copro.h
@@ -86,6 +86,137 @@ void ft8xx_copro_cmd_dlstart(const struct device *dev);
 void ft8xx_copro_cmd_swap(const struct device *dev);
 
 /**
+ * @brief Set the foreground color
+ *
+ * New foreground color, as a 24-bit RGB number. Red is the most significant 8
+ * bits, blue is the least. So 0xff0000 is bright red. Foreground color is
+ * applicable for things that the user can move such as handles and buttons
+ * ("affordances").
+ *
+ * @param dev Device structure
+ * @param color Color to set
+ */
+void ft8xx_copro_cmd_fgcolor(const struct device *dev, uint32_t color);
+
+/**
+ * @brief Set the background color
+ *
+ * New background color, as a 24-bit RGB number. Red is the most significant 8
+ * bits, blue is the least. So 0xff0000 is bright red.
+ * Background color is applicable for things that the user cannot move. Example
+ * behind gauges and sliders etc.
+ *
+ * @param dev Device structure
+ * @param color Color to set
+ */
+void ft8xx_copro_cmd_bgcolor(const struct device *dev, uint32_t color);
+
+/**
+ * @brief Draw a slider
+ *
+ * If width is greater than height, the scroll bar is drawn horizontally.
+ * If height is greater than width, the scroll bar is drawn vertically.
+ *
+ * By default the slider is drawn with a 3D effect. @ref FT8XX_OPT_FLAT removes
+ * the 3D effect.
+ *
+ * @param dev Device structure
+ * @param x x-coordinate of slider top-left, in pixels
+ * @param y y-coordinate of slider top-left, in pixels
+ * @param width Width of slider, in pixels
+ * @param height Height of slider, in pixels
+ * @param options Options to apply
+ * @param val Displayed value of slider, between 0 and range inclusive
+ * @param range Maximum value
+ */
+void ft8xx_copro_cmd_slider(const struct device *dev,
+			    int16_t x,
+			    int16_t y,
+			    int16_t width,
+			    int16_t height,
+			    uint16_t options,
+			    uint16_t val,
+			    uint16_t range);
+
+/**
+ * @brief Draw a toggle switch
+ *
+ * By default the toggle is drawn with a 3D effect and the value option is zero.
+ * @ref FT8XX_OPT_FLAT removes the 3D effect and its value is 256.
+ *
+ * In @p string, a character value of 255 (it can be written as @c \\xff )
+ * separates the off and on labels.
+ *
+ * @param dev Device structure
+ * @param x x-coordinate of top-left of toggle, in pixels
+ * @param y y-coordinate of top-left of toggle, in pixels
+ * @param width Width of toggle, in pixels
+ * @param font Font to use for text, 0-31. 16-31 are ROM fonts
+ * @param options Options to apply
+ * @param state State of the toggle: 0 is off, 65535 is on
+ * @param string String label for toggle
+ */
+void ft8xx_copro_cmd_toggle(const struct device *dev,
+			    int16_t x,
+			    int16_t y,
+			    int16_t width,
+			    int16_t font,
+			    uint16_t options,
+			    uint16_t state,
+			    const char *string);
+
+/**
+ * @brief Track touches for a graphics object
+ *
+ * This command will enable co-processor engine to track the touch on the
+ * particular graphics object with one valid tag value assigned. Then,
+ * co-processor engine will update the REG_TRACKER periodically with the frame
+ * rate of LCD display panel.
+ *
+ * Co-processor engine tracks the graphics object in rotary tracker mode and
+ * linear tracker mode:
+ *
+ * - Rotary tracker mode
+ *   Track the angle between the touching point and the center of graphics
+ *   object specified by @p tag value. The value is in units of 1/65536 of a
+ *   circle. 0 means that the angle is straight down, 0x4000 left, 0x8000 up,
+ *   and 0xC000 right from the center.
+ * - Linear tracker mode
+ *   If @p width is greater than @p height, track the relative distance of
+ *   touching point to the width of graphics object specified by @p tag value.
+ *   If @p width is not greater than @p height, track the relative distance of
+ *   touching point to the height of graphics object specified by @p tag value.
+ *   The value is in units of 1/65536 of the width or height of graphics object.
+ *   The distance of touching point refers to the distance from the top left
+ *   pixel of graphics object to the coordinate of touching point.
+ *
+ * For linear tracker functionality, @p x represents x-coordinate of track area
+ * top-left and @p y represents y-coordinate of track area top-left. Both
+ * parameters are in pixels.
+ *
+ * For rotary tracker functionality, @p x represents x-coordinate of track area
+ * center and @p y represents y-coordinate of track area center. Both
+ * parameters are in pixels.
+ *
+ * @note A @p width and @p height of (1,1) means that the tracker is rotary,
+ *       and reports an angle value in REG_TRACKER. A @p width and @p height
+ *       of (0,0) disables the track functionality of co-processor engine.
+ *
+ * @param dev Device structure
+ * @param x x-coordinate
+ * @param y y-coordinate
+ * @param width Width of track area, in pixels.
+ * @param height Height of track area, in pixels.
+ * @param tag Tag of the graphics object to be tracked, 1-255
+ */
+void ft8xx_copro_cmd_track(const struct device *dev,
+			   int16_t x,
+			   int16_t y,
+			   int16_t width,
+			   int16_t height,
+			   int16_t tag);
+
+/**
  * @brief Draw text
  *
  * By default (@p x, @p y) is the top-left pixel of the text and the value of

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx_reference_api.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx_reference_api.h
@@ -172,6 +172,146 @@ static inline void cmd_swap(void)
 }
 
 /**
+ * @brief Set the foreground color
+ *
+ * New foreground color, as a 24-bit RGB number. Red is the most significant 8
+ * bits, blue is the least. So 0xff0000 is bright red. Foreground color is
+ * applicable for things that the user can move such as handles and buttons
+ * ("affordances").
+ *
+ * @param c Color to set
+ */
+static inline void cmd_fgcolor(uint32_t c)
+{
+	ft8xx_copro_cmd_fgcolor(DEVICE_DT_GET_ONE(ftdi_ft800), c);
+}
+
+/**
+ * @brief Set the background color
+ *
+ * New background color, as a 24-bit RGB number. Red is the most significant 8
+ * bits, blue is the least. So 0xff0000 is bright red.
+ * Background color is applicable for things that the user cannot move. Example
+ * behind gauges and sliders etc.
+ *
+ * @param c Color to set
+ */
+static inline void cmd_bgcolor(uint32_t c)
+{
+	ft8xx_copro_cmd_bgcolor(DEVICE_DT_GET_ONE(ftdi_ft800), c);
+}
+
+/**
+ * @brief Draw a slider
+ *
+ * If width is greater than height, the scroll bar is drawn horizontally.
+ * If height is greater than width, the scroll bar is drawn vertically.
+ *
+ * By default the slider is drawn with a 3D effect. @ref FT8XX_OPT_FLAT removes
+ * the 3D effect.
+ *
+ * @param x x-coordinate of slider top-left, in pixels
+ * @param y y-coordinate of slider top-left, in pixels
+ * @param w Width of slider, in pixels
+ * @param h Height of slider, in pixels
+ * @param options Options to apply
+ * @param val Displayed value of slider, between 0 and range inclusive
+ * @param range Maximum value
+ */
+static inline void cmd_slider(int16_t x,
+			      int16_t y,
+			      int16_t w,
+			      int16_t h,
+			      uint16_t options,
+			      uint16_t val,
+			      uint16_t range)
+{
+	ft8xx_copro_cmd_slider(DEVICE_DT_GET_ONE(ftdi_ft800), x, y, w, h, options, val,
+			       range);
+}
+
+/**
+ * @brief Draw a toggle switch
+ *
+ * By default the toggle is drawn with a 3D effect and the value option is zero.
+ * @ref FT8XX_OPT_FLAT removes the 3D effect and its value is 256.
+ *
+ * In @p s, a character value of 255 (it can be written as @c \\xff ) separates
+ * the off and on labels.
+ *
+ * @param x x-coordinate of top-left of toggle, in pixels
+ * @param y y-coordinate of top-left of toggle, in pixels
+ * @param w Width of toggle, in pixels
+ * @param font Font to use for text, 0-31. 16-31 are ROM fonts
+ * @param options Options to apply
+ * @param state State of the toggle: 0 is off, 65535 is on
+ * @param s String label for toggle
+ */
+static inline void cmd_toggle(int16_t x,
+			      int16_t y,
+			      int16_t w,
+			      int16_t font,
+			      uint16_t options,
+			      uint16_t state,
+			      const char *s)
+{
+	ft8xx_copro_cmd_toggle(DEVICE_DT_GET_ONE(ftdi_ft800), x, y, w, font, options,
+			       state, s);
+}
+
+/**
+ * @brief Track touches for a graphics object
+ *
+ * This command will enable co-processor engine to track the touch on the
+ * particular graphics object with one valid tag value assigned. Then,
+ * co-processor engine will update the REG_TRACKER periodically with the frame
+ * rate of LCD display panel.
+ *
+ * Co-processor engine tracks the graphics object in rotary tracker mode and
+ * linear tracker mode:
+ *
+ * - Rotary tracker mode
+ *   Track the angle between the touching point and the center of graphics
+ *   object specified by @p tag value. The value is in units of 1/65536 of a
+ *   circle. 0 means that the angle is straight down, 0x4000 left, 0x8000 up,
+ *   and 0xC000 right from the center.
+ * - Linear tracker mode
+ *   If @p w is greater than @p h, track the relative distance of touching point
+ *   to the width of graphics object specified by @p tag value. If @p w is not
+ *   greater than @p h, track the relative distance of touching point to the
+ *   height of graphics object specified by @p tag value. The value is in units
+ *   of 1/65536 of the width or height of graphics object. The distance of
+ *   touching point refers to the distance from the top left pixel of graphics
+ *   object to the coordinate of touching point.
+ *
+ * For linear tracker functionality, @p x represents x-coordinate of track area
+ * top-left and @p y represents y-coordinate of track area top-left. Both
+ * parameters are in pixels.
+ *
+ * For rotary tracker functionality, @p x represents x-coordinate of track area
+ * center and @p y represents y-coordinate of track area center. Both
+ * parameters are in pixels.
+ *
+ * @note A @p w and @p h of (1,1) means that the tracker is rotary, and reports
+ *       an angle value in REG_TRACKER. A @p w and @p h of (0,0) disables the
+ *       track functionality of co-processor engine.
+ *
+ * @param x x-coordinate
+ * @param y y-coordinate
+ * @param w Width of track area, in pixels.
+ * @param h Height of track area, in pixels.
+ * @param tag Tag of the graphics object to be tracked, 1-255
+ */
+static inline void cmd_track(int16_t x,
+			     int16_t y,
+			     int16_t w,
+			     int16_t h,
+			     int16_t tag)
+{
+	ft8xx_copro_cmd_track(DEVICE_DT_GET_ONE(ftdi_ft800), x, y, w, h, tag);
+}
+
+/**
  * @brief Draw text
  *
  * By default (x,y) is the top-left pixel of the text and the value of


### PR DESCRIPTION
Implement more co-processor commands in the FT8xx display driver. The list of the new implemented commands consists of:

* CMD_FGCOLOR
* CMD_BGCOLOR
* CMD_SLIDER
* CMD_TOGGLE
* CMD_TRACK
* 