### PR TITLE
drivers: ethernet: phy: Fix missing configurations

### DIFF
--- a/dts/bindings/ethernet/phy/ti,dp83867.yaml
+++ b/dts/bindings/ethernet/phy/ti,dp83867.yaml
@@ -36,3 +36,9 @@ properties:
   default-speeds:
     default: ["10BASE Half-Duplex", "10BASE Full-Duplex", "100BASE Half-Duplex",
               "100BASE Full-Duplex", "1000BASE Half-Duplex", "1000BASE Full-Duplex"]
+  ti,dp83867-rxctrl-strap-quirk:
+    type: boolean
+    description:
+      This denotes the fact that the board has RX_DV/RX_CTRL pin strapped in
+      mode 1 or 2. To ensure PHY operation, there are specific actions that
+      software needs to take when this pin is strapped in these modes.


### PR DESCRIPTION
Add indirect read/write method for accessing extended register set beyond 0x1F. Implement configuration for strap quirk, reset and restart ensures reliable PHY initialization and operation.

@michalsimek 