### PR TITLE
tests: gpio: enable gpio_basic_api on arduino for frdm_rw612

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612.yaml
+++ b/boards/nxp/frdm_rw612/frdm_rw612.yaml
@@ -14,6 +14,7 @@ toolchain:
 ram: 960
 flash: 65536
 supported:
+  - arduino_gpio
   - gpio
   - dma
   - spi

--- a/tests/drivers/gpio/gpio_basic_api/boards/frdm_rw612_hsgpio.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/frdm_rw612_hsgpio.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright NXP 2025
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&hsgpio0 18 GPIO_ACTIVE_HIGH>; /* gpio18 J7-2 */
+		in-gpios = <&hsgpio1 12 GPIO_ACTIVE_HIGH>; /* gpio44  J7-4 */
+	};
+};
+
+&hsgpio0 {
+	status = "okay";
+};
+
+&hsgpio1 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -130,3 +130,11 @@ tests:
       - nrf54h20dk/nrf54h20/cpurad
     extra_args:
       - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpurad_gpiote0.overlay"
+  drivers.gpio.2pin_hsgpio:
+    min_flash: 34
+    filter: dt_compat_enabled("test-gpio-basic-api")
+    platform_allow:
+      - frdm_rw612
+    extra_args: "DTC_OVERLAY_FILE=boards/frdm_rw612_hsgpio.overlay"
+    harness_config:
+      fixture: hsgpio_loopback


### PR DESCRIPTION
enable gpio test on frdm_rw612 board