### PR TITLE
tests: kernel: fatal: Add ARC-specific stack protection test

### DIFF
--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -415,17 +415,11 @@ ZTEST(fatal_exception, test_fatal)
 
 #ifdef CONFIG_USERSPACE
 
-	/* on arc, this fails with an MPU error instead of a stack
-	 * overflow because the priv stack is merged into the defined
-	 * stack.
-	 */
-#if !defined(CONFIG_ARC)
 	TC_PRINT("test stack HW-based overflow - user 1\n");
 	check_stack_overflow(stack_hw_overflow, K_USER);
 
 	TC_PRINT("test stack HW-based overflow - user 2\n");
 	check_stack_overflow(stack_hw_overflow, K_USER);
-#endif
 
 	TC_PRINT("test stack HW-based overflow - user priv stack 1\n");
 	check_stack_overflow(user_priv_stack_hw_overflow, K_USER);

--- a/tests/kernel/fatal/exception/testcase.yaml
+++ b/tests/kernel/fatal/exception/testcase.yaml
@@ -9,6 +9,17 @@ tests:
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION
     arch_exclude:
       - posix
+      - arc
+    tags:
+      - kernel
+      - userspace
+  kernel.common.stack_protection.arc:
+    extra_args: CONF_FILE=prj.conf
+    filter: CONFIG_ARCH_HAS_STACK_PROTECTION
+    arch_allow: arc
+    extra_configs:
+      - CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT=y
+      - CONFIG_OMIT_FRAME_POINTER=y
     tags:
       - kernel
       - userspace


### PR DESCRIPTION
Add ARC-specific variant of kernel.common.stack_protection test that omits frame pointers to work around GNU toolchain code generation issue.

The GNU toolchain generates FP-relative memory accesses (st r0,[fp,-8]) for local variables when frame pointers are enabled as described here https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/643, which bypasses ARC hardware stack checking that only monitors SP-based instructions. This causes the test to fail with MPU violations instead of stack check violations.

Reverts: https://github.com/zephyrproject-rtos/zephyr/pull/95901
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/68682