### PR TITLE
tests: subsys: secure_storage: Erase targets when flashing the test

### DIFF
--- a/tests/subsys/secure_storage/psa/its/CMakeLists.txt
+++ b/tests/subsys/secure_storage/psa/its/CMakeLists.txt
@@ -1,4 +1,13 @@
 cmake_minimum_required(VERSION 3.20.0)
+
+macro(app_set_runner_args)
+  board_runner_args(dfu-util "--dfuse-modifiers=force:mass-erase")
+  board_runner_args(pyocd "--erase")
+  board_runner_args(jlink "--erase")
+  board_runner_args(nrfjprog "--erase")
+  board_runner_args(openocd "--erase")
+endmacro()
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(app)
 


### PR DESCRIPTION
The PSA ITS test requires previous test run data to be removed before it can be successfully run again, so tweak the app to include erase to the board runner args for common board runners.