### PR TITLE
drivers: spi: siwx91x: Use GPDMA rather than UDMA

### DIFF
--- a/drivers/dma/dma_silabs_siwx91x_gpdma.c
+++ b/drivers/dma/dma_silabs_siwx91x_gpdma.c
@@ -153,7 +153,7 @@ static int siwx91x_gpdma_desc_config(struct siwx19x_gpdma_data *data,
 
 	for (int i = 0; i < config->block_count; i++) {
 		if (block_addr->block_size > max_xfer_size) {
-			LOG_ERR("Maximum xfer size should be <= %d\n", max_xfer_size);
+			LOG_ERR("Maximum xfer size should be <= %d", max_xfer_size);
 			goto free_desc;
 		}
 
@@ -227,18 +227,18 @@ static int siwx91x_gpdma_xfer_configure(const struct device *dev, const struct d
 	data->chan_info[channel].xfer_direction = config->channel_direction;
 
 	if (config->dest_data_size != config->source_data_size) {
-		LOG_ERR("Data size mismatch\n");
+		LOG_ERR("Data size mismatch");
 		return -EINVAL;
 	}
 
 	if (config->dest_burst_length != config->source_burst_length) {
-		LOG_ERR("Burst length mismatch\n");
+		LOG_ERR("Burst length mismatch");
 		return -EINVAL;
 	}
 
 	if (config->source_data_size * config->source_burst_length >= GPDMA_MAX_CHANNEL_FIFO_SIZE) {
 		LOG_ERR("FIFO overflow detected: data_size × burst_length = %d >= %d (maximum "
-			"allowed)\n",
+			"allowed)",
 			config->source_data_size * config->source_burst_length,
 			GPDMA_MAX_CHANNEL_FIFO_SIZE);
 		return -EINVAL;
@@ -307,7 +307,7 @@ static int siwx91x_gpdma_configure(const struct device *dev, uint32_t channel,
 	}
 
 	if (!siwx91x_gpdma_is_priority_valid(config->channel_priority)) {
-		LOG_ERR("Invalid priority values: (valid range: 0-3)\n");
+		LOG_ERR("Invalid priority values: (valid range: 0-3)");
 		return -EINVAL;
 	}
 	gpdma_channel_cfg.channelPrio = config->channel_priority;
@@ -358,7 +358,7 @@ static int siwx91x_gpdma_reload(const struct device *dev, uint32_t channel, uint
 	}
 
 	if (size > (GPDMA_DESC_MAX_TRANSFER_SIZE - data_size)) {
-		LOG_ERR("Maximum xfer size should be <= %d\n",
+		LOG_ERR("Maximum xfer size should be <= %d",
 			GPDMA_DESC_MAX_TRANSFER_SIZE - data_size);
 		return -EINVAL;
 	}

--- a/drivers/spi/spi_silabs_siwx91x_gspi.c
+++ b/drivers/spi/spi_silabs_siwx91x_gspi.c
@@ -674,7 +674,6 @@ static DEVICE_API(spi, gspi_siwx91x_driver_api) = {
 		.dma_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(index, dir)),                   \
 		.dma_slot = DT_DMAS_CELL_BY_NAME_OR(DT_DRV_INST(index), dir, slot, 0xFF),          \
 	},
-
 #define SPI_SILABS_SIWX91X_GSPI_DMA_CHANNEL(index, dir)                                            \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(index, dmas),                                            \
 		    (SPI_SILABS_SIWX91X_GSPI_DMA_CHANNEL_INIT(index, dir)), ())
@@ -688,9 +687,9 @@ static DEVICE_API(spi, gspi_siwx91x_driver_api) = {
 		SPI_CONTEXT_INIT_LOCK(gspi_data_##inst, ctx),                                      \
 		SPI_CONTEXT_INIT_SYNC(gspi_data_##inst, ctx),                                      \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(inst), ctx)                            \
-			SPI_SILABS_SIWX91X_GSPI_DMA_CHANNEL(inst, rx)                              \
-				SPI_SILABS_SIWX91X_GSPI_DMA_CHANNEL(inst, tx)                      \
-		};                                                                                 \
+		SPI_SILABS_SIWX91X_GSPI_DMA_CHANNEL(inst, rx)                                      \
+		SPI_SILABS_SIWX91X_GSPI_DMA_CHANNEL(inst, tx)                                      \
+	};                                                                                         \
 	static const struct gspi_siwx91x_config gspi_config_##inst = {                             \
 		.reg = (GSPI0_Type *)DT_INST_REG_ADDR(inst),                                       \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(inst)),                             \

--- a/drivers/spi/spi_silabs_siwx91x_gspi.c
+++ b/drivers/spi/spi_silabs_siwx91x_gspi.c
@@ -36,6 +36,7 @@ LOG_MODULE_REGISTER(spi_siwx91x_gspi, CONFIG_SPI_LOG_LEVEL);
 /* Structure for DMA configuration */
 struct gspi_siwx91x_dma_channel {
 	const struct device *dma_dev;
+	uint8_t dma_slot;
 	int chan_nb;
 #ifdef CONFIG_SPI_SILABS_SIWX91X_GSPI_DMA
 	struct dma_block_config dma_descriptors[CONFIG_SPI_SILABS_SIWX91X_GSPI_DMA_MAX_BLOCKS];
@@ -227,6 +228,7 @@ static int gspi_siwx91x_dma_config(const struct device *dev,
 		.dest_burst_length = dfs,
 		.block_count = block_count,
 		.head_block = channel->dma_descriptors,
+		.dma_slot = channel->dma_slot,
 		.dma_callback = !is_tx ? &gspi_siwx91x_dma_rx_callback : NULL,
 		.user_data = (void *)dev,
 	};
@@ -670,6 +672,7 @@ static DEVICE_API(spi, gspi_siwx91x_driver_api) = {
 	.dma_##dir = {                                                                             \
 		.chan_nb = DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                         \
 		.dma_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(index, dir)),                   \
+		.dma_slot = DT_DMAS_CELL_BY_NAME_OR(DT_DRV_INST(index), dir, slot, 0xFF),          \
 	},
 
 #define SPI_SILABS_SIWX91X_GSPI_DMA_CHANNEL(index, dir)                                            \

--- a/drivers/spi/spi_silabs_siwx91x_gspi.c
+++ b/drivers/spi/spi_silabs_siwx91x_gspi.c
@@ -47,7 +47,7 @@ struct gspi_siwx91x_config {
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	const struct pinctrl_dev_config *pcfg;
-	uint8_t mosi_overrun;
+	uint8_t mosi_overrun __aligned(4);
 };
 
 struct gspi_siwx91x_data {
@@ -58,7 +58,7 @@ struct gspi_siwx91x_data {
 
 #ifdef CONFIG_SPI_SILABS_SIWX91X_GSPI_DMA
 /* Placeholder buffer for unused RX data */
-static volatile uint8_t empty_buffer;
+static volatile uint8_t empty_buffer __aligned(4);
 #endif
 
 static bool spi_siwx91x_is_dma_enabled_instance(const struct device *dev)

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -300,6 +300,22 @@
 			status = "disabled";
 		};
 
+		ulpdma: dma@24078000 {
+			compatible = "silabs,siwx91x-dma";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x24078000 0x82C>;
+			interrupts = <10 0>;
+			interrupt-names = "ulpdma";
+			clocks = <&clock0 SIWX91X_CLK_ULP_DMA>;
+			silabs,sram-region = <&sram_dma1>;
+			#dma-cells = <1>;
+			dma-channels = <12>;
+			power-domains = <&siwx91x_soc_pd>;
+			zephyr,pm-device-runtime-auto;
+			status = "disabled";
+		};
+
 		dma0: dma@44030000 {
 			compatible = "silabs,siwx91x-dma";
 			#address-cells = <1>;
@@ -315,17 +331,17 @@
 			status = "disabled";
 		};
 
-		ulpdma: dma@24078000 {
-			compatible = "silabs,siwx91x-dma";
+		gpdma: gpdma@21080000 {
+			compatible = "silabs,gpdma";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x24078000 0x82C>;
-			interrupts = <10 0>;
-			interrupt-names = "ulpdma";
-			clocks = <&clock0 SIWX91X_CLK_ULP_DMA>;
-			silabs,sram-region = <&sram_dma1>;
-			#dma-cells = <1>;
-			dma-channels = <12>;
+			reg = <0x21080000 0x1720>;
+			interrupts = <31 0>;
+			interrupt-names = "gpdma";
+			clocks = <&clock0 SIWX91X_CLK_GPDMA0>;
+			silabs,channel-reg-base = <0x21081004>;
+			silabs,dma-channel-count = <8>;
+			#dma-cells = <2>;
 			power-domains = <&siwx91x_soc_pd>;
 			zephyr,pm-device-runtime-auto;
 			status = "disabled";
@@ -424,22 +440,6 @@
 			silabs,adc-sampling-rate = <100000>;
 			clocks = <&clock0 SIWX91X_ADC_CLK>;
 			#io-channel-cells = <1>;
-			status = "disabled";
-		};
-
-		gpdma0: gpdma@21080000 {
-			compatible = "silabs,gpdma";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x21080000 0x1720>;
-			interrupts = <31 0>;
-			interrupt-names = "gpdma0";
-			clocks = <&clock0 SIWX91X_CLK_GPDMA0>;
-			silabs,channel-reg-base = <0x21081004>;
-			silabs,dma-channel-count = <8>;
-			#dma-cells = <2>;
-			power-domains = <&siwx91x_soc_pd>;
-			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 	};

--- a/tests/drivers/dma/chan_blen_transfer/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/siwx917_rb4338a.overlay
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&gpdma0 {
+&gpdma {
 	status = "okay";
 };
 
-tst_dma0: &gpdma0 { };
+tst_dma0: &gpdma { };

--- a/tests/drivers/spi/spi_loopback/boards/siwx917_dk2605a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/siwx917_dk2605a.overlay
@@ -21,7 +21,7 @@
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 
-	dmas = <&dma0 11>, <&dma0 10>;
+	dmas = <&gpdma 0 11>, <&gpdma 1 10>;
 	dma-names = "tx", "rx";
 
 	slow@0 {
@@ -36,6 +36,6 @@
 	};
 };
 
-&dma0 {
+&gpdma {
 	status = "okay";
 };

--- a/tests/drivers/spi/spi_loopback/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/siwx917_rb4338a.overlay
@@ -21,7 +21,7 @@
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 
-	dmas = <&dma0 11>, <&dma0 10>;
+	dmas = <&gpdma 0 11>, <&gpdma 1 10>;
 	dma-names = "tx", "rx";
 
 	slow@0 {
@@ -36,6 +36,6 @@
 	};
 };
 
-&dma0 {
+&gpdma {
 	status = "okay";
 };

--- a/tests/drivers/spi/spi_loopback/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/siwx917_rb4338a.overlay
@@ -31,7 +31,7 @@
 	};
 	fast@1 {
 		compatible = "test-spi-loopback-fast";
-		reg = <1>;
+		reg = <0>;
 		spi-max-frequency = <10000000>;
 	};
 };


### PR DESCRIPTION
Silabs siwx91x offer two DMA hardware block: GPDMA and UDMA.

While UDMA has some benefit when running in low power modes, GPDMA offer better performances. So GDMA is probably better suited for SPI device.

Ideally, we would like to leave the ability to switch back to UDMA.
Unfortunately, UDMA and GPDMA are not configured in the same way:
 - the maximum length of the block are different (1024 or 2048 for UDMA and 4096 for GPDMA)
 - the burst length is different

So, we only support GPDMA.