### PR TITLE
doc: develop: gsg: Update windows installation steps

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -171,7 +171,7 @@ The current minimum required version for the main dependencies are:
 
          .. code-block:: bat
 
-            winget install Kitware.CMake Ninja-build.Ninja oss-winget.gperf python Git.Git oss-winget.dtc wget 7zip.7zip
+            winget install Kitware.CMake Ninja-build.Ninja oss-winget.gperf Python.Python.3.12 Git.Git oss-winget.dtc wget 7zip.7zip
 
       #. Close the terminal window.
 
@@ -336,6 +336,15 @@ chosen. You'll also install Zephyr's additional Python dependencies in a
                python -m venv zephyrproject\.venv
 
       #. Activate the virtual environment:
+
+         .. note::
+
+            Python's virtual environment activation in PowerShell requires
+            running a script itself, which needs to be allowed.
+
+            .. code-block:: powershell
+
+               Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
          .. tabs::
 


### PR DESCRIPTION
The Python version installed with winget defaults to 3.8, make a more recent version the default.
Also add a note on the execution policy for activating the Python virtual environment.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/97393