### PR TITLE
STM32: add USB support for STM32WBA6 series

### DIFF
--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -174,3 +174,17 @@ stm32_lp_tick_source: &lptim1 {
 		};
 	};
 };
+
+zephyr_udc0: &usbotg_hs {
+	clocks = <&rcc STM32_CLOCK(AHB2, 14)>,
+		 <&rcc STM32_SRC_HSE OTGHS_SEL(0)>;
+	pinctrl-0 = <&usb_otg_hs_dm_pd7 &usb_otg_hs_dp_pd6>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&otghs_phy {
+	/* OTG HS clock source is 32 MHz HSE */
+	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_32MHz";
+	status = "okay";
+};

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.yaml
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.yaml
@@ -11,6 +11,7 @@ supported:
   - spi
   - adc
   - rng
+  - usbd
   - arduino_gpio
   - arduino_i2c
   - arduino_spi

--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -58,7 +58,11 @@ config UDC_STM32_OTG_RXFIFO_BASELINE_SIZE
 
 config UDC_STM32_CLOCK_CHECK
 	bool "Runtime USB 48MHz clock check"
-	default y if !(SOC_SERIES_STM32F1X || SOC_SERIES_STM32F3X || SOC_SERIES_STM32U5X)
+	default n if SOC_SERIES_STM32F1X || \
+		     SOC_SERIES_STM32F3X || \
+		     SOC_SERIES_STM32U5X || \
+		     SOC_SERIES_STM32WBAX
+	default y
 	help
 	  Enable USB clock 48MHz configuration runtime check.
 	  In specific cases, this check might provide wrong verdict and should

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -135,7 +135,7 @@ LOG_MODULE_REGISTER(udc_stm32, CONFIG_UDC_DRIVER_LOG_LEVEL);
 #define USB_USBPHYC_CR_FSEL_24MHZ        USB_USBPHYC_CR_FSEL_1
 #endif
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs) && defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32u5_otghs_phy)
 static const int syscfg_otg_hs_phy_clk[] = {
 	SYSCFG_OTG_HS_PHY_CLK_SELECT_1,	/* 16Mhz   */
 	SYSCFG_OTG_HS_PHY_CLK_SELECT_2,	/* 19.2Mhz */
@@ -1182,6 +1182,29 @@ static int priv_clock_enable(void)
 
 	/* Enable VDDUSB */
 	LL_PWR_EnableVddUSB();
+#elif defined(CONFIG_SOC_SERIES_STM32WBAX)
+	/* Remove VDDUSB power isolation */
+	LL_PWR_EnableVddUSB();
+
+	/* Make sure that voltage scaling is Range 1 */
+	__ASSERT_NO_MSG(LL_PWR_GetRegulCurrentVOS() == LL_PWR_REGU_VOLTAGE_SCALE1);
+
+	/* Enable VDD11USB */
+	LL_PWR_EnableVdd11USB();
+
+	/* Enable USB OTG internal power */
+	LL_PWR_EnableUSBPWR();
+
+	while (!LL_PWR_IsActiveFlag_VDD11USBRDY()) {
+		/* Wait for VDD11USB supply to be ready */
+	}
+
+	/* Enable USB OTG booster */
+	LL_PWR_EnableUSBBooster();
+
+	while (!LL_PWR_IsActiveFlag_USBBOOSTRDY()) {
+		/* Wait for USB OTG booster to be ready */
+	}
 #elif defined(PWR_USBSCR_USB33SV) || defined(PWR_SVMCR_USV)
 	/*
 	 * VDDUSB independent USB supply (PWR clock is on)
@@ -1247,16 +1270,31 @@ static int priv_clock_enable(void)
 
 	/* Peripheral OTGPHY clock enable */
 	LL_AHB5_GRP1_EnableClock(LL_AHB5_GRP1_PERIPH_OTGPHY1);
-#elif defined(CONFIG_SOC_SERIES_STM32U5X)
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32u5_otghs_phy)
+	const struct stm32_pclken hsphy_clk[] = STM32_DT_CLOCKS(DT_NODELABEL(otghs_phy));
+	const uint32_t hsphy_clknum = DT_NUM_CLOCKS(DT_NODELABEL(otghs_phy));
+
 	/* Configure OTG PHY reference clock through SYSCFG */
-	LL_APB3_GRP1_EnableClock(LL_APB3_GRP1_PERIPH_SYSCFG);
+	__HAL_RCC_SYSCFG_CLK_ENABLE();
+
 	HAL_SYSCFG_SetOTGPHYReferenceClockSelection(
 		syscfg_otg_hs_phy_clk[DT_ENUM_IDX(DT_NODELABEL(otghs_phy), clock_reference)]
 	);
 
 	/* De-assert reset and enable clock of OTG PHY */
 	HAL_SYSCFG_EnableOTGPHY(SYSCFG_OTG_HS_PHY_ENABLE);
-	LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_USBPHY);
+
+	if (hsphy_clknum > 1) {
+		if (clock_control_configure(clk, (void *)&hsphy_clk[1], NULL) != 0) {
+			LOG_ERR("Failed OTGHS PHY mux configuration");
+			return -EIO;
+		}
+	}
+
+	if (clock_control_on(clk, (void *)&hsphy_clk[0]) != 0) {
+		LOG_ERR("Failed enabling OTGHS PHY clock");
+		return -EIO;
+	}
 #elif defined(CONFIG_SOC_SERIES_STM32H7X)
 	/*
 	 * If HS PHY (over ULPI) is used, enable ULPI interface clock.

--- a/dts/arm/st/wba/stm32wba65.dtsi
+++ b/dts/arm/st/wba/stm32wba65.dtsi
@@ -77,6 +77,25 @@
 				#pwm-cells = <3>;
 			};
 		};
+
+		usbotg_hs: usb@42040000 {
+			compatible = "st,stm32-otghs";
+			reg = <0x42040000 DT_SIZE_K(128)>;
+			interrupts = <76 0>;
+			interrupt-names = "otghs";
+			num-bidir-endpoints = <9>;
+			ram-size = <4096>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 14)>;
+			phys = <&otghs_phy>;
+			status = "disabled";
+		};
+	};
+
+	otghs_phy: otghs_phy {
+		compatible = "st,stm32u5-otghs-phy";
+		clocks = <&rcc STM32_CLOCK(AHB2, 15)>;
+		#phy-cells = <0>;
+		status = "disabled";
 	};
 
 	/*

--- a/include/zephyr/dt-bindings/clock/stm32wba_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wba_clock.h
@@ -70,6 +70,7 @@
 #define TIMIC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 31, CCIPR1_REG)
 /** CCIPR2 devices */
 #define RNG_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 12, CCIPR2_REG)
+#define OTGHS_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 28, CCIPR2_REG)
 /** CCIPR3 devices */
 #define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 3, 0, CCIPR3_REG)
 #define SPI3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 3, CCIPR3_REG)


### PR DESCRIPTION
Add USB support for STM32WBA6 series:
* add node in SoC DTSI
* add missing macro in DT bindings header
* add WBA6 support in UDC driver + rework how PHY is handled
* add USB node configuration to `nucleo_wba65ri` board

Tested that `samples/subsys/usb/cdc_acm` builds, runs and works as expected.

(Also tested that it still works on `nucleo_u5a5zj_q` to ensure no regression)

Fixes #96705