### PR TITLE
boards: shields: rpi_pico_uno_flexypin: Fix conflicting connector node

### DIFF
--- a/boards/shields/rpi_pico_uno_flexypin/rpi_pico_uno_flexypin.overlay
+++ b/boards/shields/rpi_pico_uno_flexypin/rpi_pico_uno_flexypin.overlay
@@ -7,7 +7,7 @@
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
-	arduino_header: connector {
+	arduino_header: arduino_connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;


### PR DESCRIPTION
The `/connector` node conflicts with
`boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi` definition.

Renaming it to `connector_arduino` to avoid conflict with that.

Fix #97505