### PR TITLE
net: lwm2m: add cache filtering

### DIFF
--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -532,9 +532,9 @@ Read and Write operations
 Full content of data cache is written into a payload when any READ, SEND or NOTIFY operation
 internally reads the content of a given resource. This has a side effect that any read callbacks
 registered for a that resource are ignored when cache is enabled.
-Data is written into a cache when any of the ``lwm2m_set_*`` functions are called. To filter
-the data entering the cache, application may register a validation callback using
-:c:func:`lwm2m_register_validate_callback`.
+Data is written into a cache when any of the ``lwm2m_set_*`` functions are called. Applications can
+register a cache filter callback with :c:func:`lwm2m_set_cache_filter` to drop otherwise valid samples
+based on application-specific rules.
 
 Limitations
 ===========

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -349,6 +349,20 @@ struct lwm2m_time_series_elem {
 };
 
 /**
+ * @typedef lwm2m_cache_filter_cb_t
+ * @brief Callback type for filtering cached time series samples.
+ *
+ * Returning false skips storing the provided sample in the LwM2M cache.
+ *
+ * @param path    Object path of the cached resource.
+ * @param element Sample produced by the engine for the cache.
+ *
+ * @return true to keep the sample, false to discard it.
+ */
+typedef bool (*lwm2m_cache_filter_cb_t)(const struct lwm2m_obj_path *path,
+					const struct lwm2m_time_series_elem *element);
+
+/**
  * @brief Asynchronous callback to get a resource buffer and length.
  *
  * Prior to accessing the data buffer of a resource, the engine can
@@ -1589,6 +1603,21 @@ struct lwm2m_ctx *lwm2m_rd_client_ctx(void);
  */
 int lwm2m_enable_cache(const struct lwm2m_obj_path *path, struct lwm2m_time_series_elem *data_cache,
 		       size_t cache_len);
+
+/**
+ * @brief Register a filtering callback for cached resource samples.
+ *
+ * The callback is invoked whenever the LwM2M engine attempts to append a new
+ * sample to the resource cache. Returning false prevents the sample from being
+ * stored. Passing a NULL callback removes any previously registered filter.
+ *
+ * @param path      LwM2M path to the cached resource.
+ * @param filter_cb Callback used to decide whether samples should be cached.
+ *
+ * @return 0 for success or a negative errno code in case of error.
+ */
+int lwm2m_set_cache_filter(const struct lwm2m_obj_path *path,
+			   lwm2m_cache_filter_cb_t filter_cb);
 
 /**
  * @brief Security modes as defined in LwM2M Security object.

--- a/subsys/net/lib/lwm2m/lwm2m_registry.h
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.h
@@ -209,6 +209,8 @@ struct lwm2m_time_series_resource {
 	sys_snode_t node;
 	/* Resource Path url */
 	struct lwm2m_obj_path path;
+	/* Optional filter for cached samples */
+	lwm2m_cache_filter_cb_t filter_cb;
 	/* Ring buffer */
 	struct ring_buf rb;
 };

--- a/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
+++ b/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
@@ -628,6 +628,7 @@ ZTEST(lwm2m_registry, test_resource_cache)
 	/* Resource cache is turned off */
 	zassert_is_null(lwm2m_cache_entry_get_by_object(&path));
 	zassert_equal(lwm2m_enable_cache(&path, &e, 1), -ENOTSUP);
+	zassert_equal(lwm2m_set_cache_filter(&path, NULL), -ENOTSUP);
 	zassert_false(lwm2m_cache_write(NULL, NULL));
 	zassert_false(lwm2m_cache_read(NULL, NULL));
 	zassert_equal(lwm2m_cache_size(NULL), 0);


### PR DESCRIPTION
Introduce `lwm2m_set_cache_filter()` so applications can drop cached samples before they reach the LwM2M SEND path.

Fixes #91590