### PR TITLE
STM32: drop Kconfig support for LPTIM timer clock source selection

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -60,6 +60,8 @@ Removed APIs and options
 * ``bt_le_set_auto_conn``
 * ``CONFIG_BT_BUF_ACL_RX_COUNT``
 * ``ok`` enum value has now been removed completely from ``base.yaml`` binding ``status`` property in devicetree.
+* STM32 LPTIM clock source selection through Kconfig was removed. Device Tree must now be used instead.
+  Affected Kconfig symbols: ``CONFIG_STM32_LPTIM_CLOCK_LSI`` / ``CONFIG_STM32_LPTIM_CLOCK_LSI``
 
 Deprecated APIs and options
 ===========================

--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 DT_CHOSEN_STDBY_TIMER := st,lptim-stdby-timer
+DT_STM32_LPTIM_PATH := $(dt_nodelabel_path,stm32_lp_tick_source)
 
 menuconfig STM32_LPTIM_TIMER
 	bool "STM32 Low Power Timer [EXPERIMENTAL]"
@@ -18,23 +19,18 @@ menuconfig STM32_LPTIM_TIMER
 
 if STM32_LPTIM_TIMER
 
-choice STM32_LPTIM_CLOCK
-	prompt "LPTIM clock value configuration"
-	help
-	  This option is deprecated and configuration of LPTIM domain clock
-	  using devicetree should be preferred.
-
+# Invisible symbols exposing the selected LPTIM source to Kconfig
+# NOTE: the values 2/3 correspond too STM32_SRC_LSE/STM32_SRC_LSI
+# defined in include/zephyr/dt-bindings/clock/stm32_common_clocks.h
 config STM32_LPTIM_CLOCK_LSI
-	bool "LSI"
+	def_bool "$(dt_node_ph_array_prop_int,$(DT_STM32_LPTIM_PATH),clocks,1,bus)" = 3
 	help
-	  Use LSI as LPTIM clock
+	  LSI used as LPTIM clock source
 
 config STM32_LPTIM_CLOCK_LSE
-	bool "LSE"
+	def_bool "$(dt_node_ph_array_prop_int,$(DT_STM32_LPTIM_PATH),clocks,1,bus)" = 2
 	help
-	  Use LSE as LPTIM clock
-
-endchoice
+	  LSE used as LPTIM clock source
 
 config STM32_LPTIM_CLOCK
 	int

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -28,23 +28,13 @@
 #error Only one LPTIM instance should be enabled
 #endif
 
+#if DT_INST_NUM_CLOCKS(0) <= 1
+#error "LPTIM source clock must be provided in Device Tree"
+#endif
+
 #define LPTIM (LPTIM_TypeDef *) DT_INST_REG_ADDR(0)
 
-#if DT_INST_NUM_CLOCKS(0) == 1
-#warning Kconfig for LPTIM source clock (LSI/LSE) is deprecated, use device tree.
-static const struct stm32_pclken lptim_clk[] = {
-	STM32_CLOCK_INFO(0, DT_DRV_INST(0)),
-	/* Use Kconfig to configure source clocks fields */
-	/* Fortunately, values are consistent across enabled series */
-#ifdef CONFIG_STM32_LPTIM_CLOCK_LSI
-	{.bus = STM32_SRC_LSI, .enr = LPTIM1_SEL(1)}
-#else
-	{.bus = STM32_SRC_LSE, .enr = LPTIM1_SEL(3)}
-#endif
-};
-#else
 static const struct stm32_pclken lptim_clk[] = STM32_DT_INST_CLOCKS(0);
-#endif
 
 static const struct device *const clk_ctrl = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 

--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -72,11 +72,6 @@ config SYS_CLOCK_TICKS_PER_SEC
 	default  250 if "$(dt_node_int_prop_int,$(DT_STM32_LPTIM_PATH),$(DT_ST_PRESCALER))" = 128
 	depends on STM32_LPTIM_TIMER && STM32_LPTIM_CLOCK_LSI
 
-choice STM32_LPTIM_CLOCK
-	default STM32_LPTIM_CLOCK_LSE if "$(dt_node_ph_array_prop_int,$(DT_STM32_LPTIM_PATH),clocks,1,bus)" = 2
-	default STM32_LPTIM_CLOCK_LSI if "$(dt_node_ph_array_prop_int,$(DT_STM32_LPTIM_PATH),clocks,1,bus)" = 3
-endchoice
-
 config CLOCK_CONTROL_INIT_PRIORITY
 	default 1
 	depends on CLOCK_CONTROL


### PR DESCRIPTION
Selecting LPTIM timer source through Kconfig is marked as deprecated since Zephyr 3.2

Note that the underlying symbols have not been removed but they are now promptless; attempting to set them using command line or a configuration file will result in a build error:

```
error: STM32_LPTIM_CLOCK_LSI (defined at drivers/timer/Kconfig.stm32_lptim:25) is assigned in a configuration file, but is not directly user-configurable (has no prompt).
It gets its value indirectly from other symbols.
See http://docs.zephyrproject.org/latest/kconfig.html#CONFIG_STM32_LPTIM_CLOCK_LSI and/or look up STM32_LPTIM_CLOCK_LSI in the menuconfig/guiconfig interface.
The Application Development Primer, Setting Configuration Values, and Kconfig - Tips and Best Practices sections of the manual might be helpful too.
```

A broader rework will be required to drop these symbols entirely and is out of scope of this PR.