### PR TITLE
[RFC] Implement sys_io_test[*]_bit() to return 0 or 1, proposal to deprecate sys_test[*]_bit()

### DIFF
--- a/drivers/clock_control/clock_control_gd32.c
+++ b/drivers/clock_control/clock_control_gd32.c
@@ -190,8 +190,8 @@ clock_control_gd32_get_status(const struct device *dev,
 	const struct clock_control_gd32_config *config = dev->config;
 	uint16_t id = *(uint16_t *)sys;
 
-	if (sys_test_bit(config->base + GD32_CLOCK_ID_OFFSET(id),
-			 GD32_CLOCK_ID_BIT(id)) != 0) {
+	if (sys_io_test_bit(config->base + GD32_CLOCK_ID_OFFSET(id),
+			    GD32_CLOCK_ID_BIT(id))) {
 		return CLOCK_CONTROL_STATUS_ON;
 	}
 

--- a/drivers/clock_control/clock_control_npcm.c
+++ b/drivers/clock_control/clock_control_npcm.c
@@ -343,7 +343,7 @@ static int npcm_clock_control_init(const struct device *dev)
 		/* Load M and N values into the frequency multiplier */
 		priv->hfcgctrl |= BIT(NPCM_HFCGCTRL_LOAD);
 		/* Wait for stable */
-		while (sys_test_bit(priv->hfcgctrl, NPCM_HFCGCTRL_CLK_CHNG)) {
+		while (sys_io_test_bit(priv->hfcgctrl, NPCM_HFCGCTRL_CLK_CHNG)) {
 		}
 	}
 

--- a/drivers/clock_control/clock_control_sf32lb_hxt48.c
+++ b/drivers/clock_control/clock_control_sf32lb_hxt48.c
@@ -32,7 +32,7 @@ static int clock_control_sf32lb_hxt48_on(const struct device *dev, clock_control
 	val |= HPSYS_AON_ACR_HXT48_REQ;
 	sys_write32(val, config->aon + HPSYS_AON_ACR);
 
-	while (sys_test_bit(config->aon + HPSYS_AON_ACR, HPSYS_AON_ACR_HXT48_RDY_Pos) == 0U) {
+	while (sys_io_test_bit(config->aon + HPSYS_AON_ACR, HPSYS_AON_ACR_HXT48_RDY_Pos) == 0) {
 	}
 
 	return 0;
@@ -59,7 +59,7 @@ static enum clock_control_status clock_control_sf32lb_hxt48_get_status(const str
 
 	ARG_UNUSED(sys);
 
-	if (sys_test_bit(config->aon + HPSYS_AON_ACR, HPSYS_AON_ACR_HXT48_RDY_Pos) != 0U) {
+	if (sys_io_test_bit(config->aon + HPSYS_AON_ACR, HPSYS_AON_ACR_HXT48_RDY_Pos) != 0) {
 		return CLOCK_CONTROL_STATUS_ON;
 	}
 

--- a/drivers/clock_control/clock_control_sf32lb_rcc.c
+++ b/drivers/clock_control/clock_control_sf32lb_rcc.c
@@ -99,8 +99,8 @@ static enum clock_control_status clock_control_sf32lb_rcc_get_status(const struc
 	const struct clock_control_sf32lb_rcc_config *config = dev->config;
 	uint16_t id = *(uint16_t *)sys;
 
-	if (sys_test_bit(config->base + FIELD_GET(SF32LB_CLOCK_OFFSET_MSK, id),
-			 FIELD_GET(SF32LB_CLOCK_BIT_MSK, id)) != 0) {
+	if (sys_io_test_bit(config->base + FIELD_GET(SF32LB_CLOCK_OFFSET_MSK, id),
+			    FIELD_GET(SF32LB_CLOCK_BIT_MSK, id)) != 0) {
 		return CLOCK_CONTROL_STATUS_ON;
 	}
 

--- a/drivers/dma/dma_silabs_ldma.c
+++ b/drivers/dma/dma_silabs_ldma.c
@@ -566,7 +566,7 @@ int silabs_ldma_append_block(const struct device *dev, uint32_t channel, struct 
 	}
 
 	/* A link is already set by a previous call to the function */
-	if (sys_test_bit((mem_addr_t)&LDMA->CH[channel].LINK, _LDMA_CH_LINK_LINK_SHIFT)) {
+	if (sys_io_test_bit((mem_addr_t)&LDMA->CH[channel].LINK, _LDMA_CH_LINK_LINK_SHIFT)) {
 		return -EINVAL;
 	}
 

--- a/drivers/dma/dma_silabs_siwx91x.c
+++ b/drivers/dma/dma_silabs_siwx91x.c
@@ -531,7 +531,7 @@ static int siwx91x_dma_get_status(const struct device *dev, uint32_t channel,
 	}
 
 	/* Read the channel status register */
-	stat->busy = sys_test_bit((mem_addr_t)&cfg->reg->CHANNEL_STATUS_REG, channel);
+	stat->busy = sys_io_test_bit((mem_addr_t)&cfg->reg->CHANNEL_STATUS_REG, channel);
 
 	/* Obtain the transfer direction from channel descriptors */
 	if (udma_table[channel].vsUDMAChaConfigData1.srcInc == UDMA_SRC_INC_NONE) {

--- a/drivers/dma/dma_silabs_siwx91x_gpdma.c
+++ b/drivers/dma/dma_silabs_siwx91x_gpdma.c
@@ -289,7 +289,7 @@ static int siwx91x_gpdma_configure(const struct device *dev, uint32_t channel,
 		return -ENOTSUP;
 	}
 
-	if (sys_test_bit((mem_addr_t)&cfg->reg->GLOBAL.DMA_CHNL_ENABLE_REG, channel)) {
+	if (sys_io_test_bit((mem_addr_t)&cfg->reg->GLOBAL.DMA_CHNL_ENABLE_REG, channel)) {
 		/* Transfer in progress */
 		return -EIO;
 	}
@@ -336,7 +336,7 @@ static int siwx91x_gpdma_reload(const struct device *dev, uint32_t channel, uint
 		return -ENOTSUP;
 	}
 
-	if (sys_test_bit((mem_addr_t)&cfg->reg->GLOBAL.DMA_CHNL_ENABLE_REG, channel)) {
+	if (sys_io_test_bit((mem_addr_t)&cfg->reg->GLOBAL.DMA_CHNL_ENABLE_REG, channel)) {
 		/* Transfer in progress */
 		return -EIO;
 	}
@@ -407,7 +407,7 @@ static int siwx91x_gpdma_get_status(const struct device *dev, uint32_t channel,
 		return -EINVAL;
 	}
 
-	stat->busy = sys_test_bit((mem_addr_t)&cfg->reg->GLOBAL.DMA_CHNL_ENABLE_REG, channel);
+	stat->busy = sys_io_test_bit((mem_addr_t)&cfg->reg->GLOBAL.DMA_CHNL_ENABLE_REG, channel);
 	stat->dir = data->chan_info[channel].xfer_direction;
 
 	return 0;

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -79,7 +79,7 @@ static int gpio_stellaris_configure(const struct device *dev,
 	}
 
 	/* Check for pin availability */
-	if (!sys_test_bit((uint32_t)&port_map, pin)) {
+	if (!sys_io_test_bit((uint32_t)&port_map, pin)) {
 		return -EINVAL;
 	}
 
@@ -117,12 +117,12 @@ static int gpio_stellaris_get_config(const struct device *dev,
 	gpio_flags_t flags = 0;
 	mm_reg_t mask_addr;
 
-	if (sys_test_bit(GPIO_REG_ADDR(base, GPIO_DEN_OFFSET), pin) == 0) {
+	if (!sys_io_test_bit(GPIO_REG_ADDR(base, GPIO_DEN_OFFSET), pin)) {
 		flags = GPIO_DISCONNECTED;
-	} else if (sys_test_bit(GPIO_REG_ADDR(base, GPIO_DIR_OFFSET), pin)) {
+	} else if (sys_io_test_bit(GPIO_REG_ADDR(base, GPIO_DIR_OFFSET), pin)) {
 		mask_addr = GPIO_RW_MASK_ADDR(base, GPIO_DATA_OFFSET, BIT(pin));
 
-		if (sys_test_bit(mask_addr, pin)) {
+		if (sys_io_test_bit(mask_addr, pin)) {
 			flags |= GPIO_OUTPUT_HIGH;
 		} else {
 			flags |= GPIO_OUTPUT_LOW;

--- a/drivers/input/input_tsc_keys.c
+++ b/drivers/input/input_tsc_keys.c
@@ -117,7 +117,7 @@ static int stm32_tsc_handle_incoming_data(const struct device *dev)
 {
 	const struct stm32_tsc_config *config = dev->config;
 
-	if (sys_test_bit((mem_addr_t)&config->tsc->ISR, TSC_ISR_MCEF_Pos)) {
+	if (sys_io_test_bit((mem_addr_t)&config->tsc->ISR, TSC_ISR_MCEF_Pos)) {
 		/* clear max count error flag */
 		sys_set_bit((mem_addr_t)&config->tsc->ICR, TSC_ICR_MCEIC_Pos);
 		LOG_ERR("%s: max count error", dev->name);
@@ -125,7 +125,7 @@ static int stm32_tsc_handle_incoming_data(const struct device *dev)
 		return -EIO;
 	}
 
-	if (sys_test_bit((mem_addr_t)&config->tsc->ISR, TSC_ISR_EOAF_Pos)) {
+	if (sys_io_test_bit((mem_addr_t)&config->tsc->ISR, TSC_ISR_EOAF_Pos)) {
 		/* clear end of acquisition flag */
 		sys_set_bit((mem_addr_t)&config->tsc->ICR, TSC_ICR_EOAIC_Pos);
 

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -573,7 +573,7 @@ static void gicv3_dist_init(void)
 	 * Make sure GICD_CTRL_NS is 1.
 	 */
 	sys_set_bit(GICD_CTLR, GICD_CTRL_NS);
-	__ASSERT(sys_test_bit(GICD_CTLR, GICD_CTRL_NS),
+	__ASSERT(sys_io_test_bit(GICD_CTLR, GICD_CTRL_NS),
 		 "Current GIC does not support single security state");
 #endif
 

--- a/drivers/interrupt_controller/intc_intel_vtd.c
+++ b/drivers/interrupt_controller/intc_intel_vtd.c
@@ -74,8 +74,8 @@ static void vtd_send_cmd(const struct device *dev,
 
 	vtd_write_reg32(dev, VTD_GCMD_REG, value);
 
-	while (!sys_test_bit((base_address + VTD_GSTS_REG),
-			     status_bit)) {
+	while (!sys_io_test_bit(base_address + VTD_GSTS_REG,
+				status_bit)) {
 		/* Do nothing */
 	}
 }

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -247,22 +247,22 @@ uint32_t restore_flags(unsigned int irq)
 	uint32_t flags = 0U;
 
 	if (sys_bitfield_test_bit((mem_addr_t) ioapic_suspend_buf,
-		BIT_POS_FOR_IRQ_OPTION(irq, IOAPIC_BITFIELD_HI_LO))) {
+		BIT_POS_FOR_IRQ_OPTION(irq, IOAPIC_BITFIELD_HI_LO)) != 0) {
 		flags |= IOAPIC_LOW;
 	}
 
 	if (sys_bitfield_test_bit((mem_addr_t) ioapic_suspend_buf,
-		BIT_POS_FOR_IRQ_OPTION(irq, IOAPIC_BITFIELD_LVL_EDGE))) {
+		BIT_POS_FOR_IRQ_OPTION(irq, IOAPIC_BITFIELD_LVL_EDGE)) != 0) {
 		flags |= IOAPIC_LEVEL;
 	}
 
 	if (sys_bitfield_test_bit((mem_addr_t) ioapic_suspend_buf,
-		BIT_POS_FOR_IRQ_OPTION(irq, IOAPIC_BITFIELD_ENBL_DSBL))) {
+		BIT_POS_FOR_IRQ_OPTION(irq, IOAPIC_BITFIELD_ENBL_DSBL)) != 0) {
 		flags |= IOAPIC_INT_MASK;
 	}
 
 	if (sys_bitfield_test_bit((mem_addr_t) ioapic_suspend_buf,
-		BIT_POS_FOR_IRQ_OPTION(irq, IOAPIC_BITFIELD_DELIV_MODE))) {
+		BIT_POS_FOR_IRQ_OPTION(irq, IOAPIC_BITFIELD_DELIV_MODE)) != 0) {
 		flags |= IOAPIC_LOWEST;
 	}
 

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -378,7 +378,7 @@ int loapic_resume(const struct device *port)
 							 loapic_irq]);
 
 			if (sys_bitfield_test_bit((mem_addr_t) loapic_suspend_buf,
-							loapic_irq)) {
+							loapic_irq) != 0) {
 				z_loapic_irq_enable(loapic_irq);
 			}
 		}

--- a/drivers/ipm/ipm_xlnx_ipi.c
+++ b/drivers/ipm/ipm_xlnx_ipi.c
@@ -94,7 +94,7 @@ static void xlnx_mailbox_rx_isr(const struct device *dev)
 		}
 
 		remote_ipi_ch_bit = cdev_conf->remote_ipi_ch_bit;
-		if (!sys_test_bit(config->host_ipi_reg + IPI_ISR, remote_ipi_ch_bit)) {
+		if (!sys_io_test_bit(config->host_ipi_reg + IPI_ISR, remote_ipi_ch_bit)) {
 			continue;
 		}
 
@@ -138,7 +138,8 @@ static int xlnx_ipi_send(const struct device *ipmdev, int wait, uint32_t id, con
 
 	obs_bit = 0;
 	do {
-		obs_bit = sys_test_bit(config->host_ipi_reg + IPI_OBS, config->remote_ipi_ch_bit);
+		obs_bit = sys_io_test_bit(config->host_ipi_reg + IPI_OBS,
+					  config->remote_ipi_ch_bit);
 	} while (obs_bit && wait);
 
 	return 0;
@@ -175,7 +176,7 @@ static int xlnx_ipi_set_enabled(const struct device *ipmdev, int enable)
 	}
 
 	/* If IPI channel bit in IPI Mask Register is not set, then interrupt is enabled */
-	if (!sys_test_bit(config->host_ipi_reg + IPI_IMR, config->remote_ipi_ch_bit)) {
+	if (!sys_io_test_bit(config->host_ipi_reg + IPI_IMR, config->remote_ipi_ch_bit)) {
 		data->enabled = enable;
 		return 0;
 	}

--- a/drivers/mbox/mbox_mhuv3.c
+++ b/drivers/mbox/mbox_mhuv3.c
@@ -490,7 +490,7 @@ static int mbox_mhuv3_doorbell_last_tx_done(const struct device *dev,
 		return -EINVAL;
 	}
 
-	bool done = !(sys_test_bit((mem_addr_t)&cfg->pbx->dbcw[chan->ch_idx].st, chan->doorbell));
+	bool done = !sys_io_test_bit((mem_addr_t)&cfg->pbx->dbcw[chan->ch_idx].st, chan->doorbell);
 
 	if (done) {
 		struct mbox_mhuv3_data *data = dev->data;
@@ -538,7 +538,7 @@ static int mbox_mhuv3_doorbell_send_data(const struct device *dev,
 	}
 
 	K_SPINLOCK(&ext->pending_lock) {
-		if (sys_test_bit((mem_addr_t)&ext->pending_db[chan->ch_idx], chan->doorbell)) {
+		if (sys_io_test_bit((mem_addr_t)&ext->pending_db[chan->ch_idx], chan->doorbell)) {
 			ret = -EBUSY;
 		} else {
 			sys_set_bit((mem_addr_t)&ext->pending_db[chan->ch_idx], chan->doorbell);

--- a/drivers/pcie/endpoint/pcie_ep_iproc_msi.c
+++ b/drivers/pcie/endpoint/pcie_ep_iproc_msi.c
@@ -132,7 +132,7 @@ static bool is_msix_vector_mask(const int msix_num)
 /* Below function will be called from interrupt context */
 static int generate_pending_msix(const struct device *dev, const int msix_num)
 {
-	int is_msix_pending;
+	bool is_msix_pending;
 	struct iproc_pcie_ep_ctx *ctx = dev->data;
 	k_spinlock_key_t key;
 
@@ -144,8 +144,8 @@ static int generate_pending_msix(const struct device *dev, const int msix_num)
 
 	key = k_spin_lock(&ctx->pba_lock);
 
-	is_msix_pending = sys_test_bit(PBA_OFFSET(msix_num),
-				       PENDING_BIT(msix_num));
+	is_msix_pending = sys_io_test_bit(PBA_OFFSET(msix_num),
+					  PENDING_BIT(msix_num));
 
 	/* check if vector mask bit is cleared for pending msix */
 	if (is_msix_pending && !(is_msix_vector_mask(msix_num))) {
@@ -193,8 +193,8 @@ void iproc_pcie_func_mask_isr(void *arg)
 void iproc_pcie_vector_mask_isr(void *arg)
 {
 	const struct device *dev = arg;
-	int msix_table_update = sys_test_bit(PMON_LITE_PCIE_INTERRUPT_STATUS,
-					     WR_ADDR_CHK_INTR_EN);
+	bool msix_table_update = sys_io_test_bit(PMON_LITE_PCIE_INTERRUPT_STATUS,
+						 WR_ADDR_CHK_INTR_EN);
 
 	LOG_DBG("%s: %x\n", __func__,
 		sys_read32(PMON_LITE_PCIE_INTERRUPT_STATUS));

--- a/drivers/reset/reset_gd32.c
+++ b/drivers/reset/reset_gd32.c
@@ -25,8 +25,8 @@ static int reset_gd32_status(const struct device *dev, uint32_t id,
 {
 	const struct reset_gd32_config *config = dev->config;
 
-	*status = !!sys_test_bit(config->base + GD32_RESET_ID_OFFSET(id),
-				 GD32_RESET_ID_BIT(id));
+	*status = sys_io_test_bit(config->base + GD32_RESET_ID_OFFSET(id),
+				  GD32_RESET_ID_BIT(id));
 
 	return 0;
 }

--- a/drivers/reset/reset_mchp_mss.c
+++ b/drivers/reset/reset_mchp_mss.c
@@ -28,8 +28,8 @@ static int reset_mss_status(const struct device *dev, uint32_t id, uint8_t *stat
 	const struct reset_mss_config *config = dev->config;
 
 	/* Device is in reset if the clock is turned off or held in soft reset */
-	*status = sys_test_bit(config->base + SUBBLK_CLOCK_CR_OFFSET, RESET_MSS_REG_BIT(id)) == 0 ||
-		  sys_test_bit(config->base + SOFT_RESET_CR_OFFSET, RESET_MSS_REG_BIT(id) != 0);
+	*status = !sys_io_test_bit(config->base + SUBBLK_CLOCK_CR_OFFSET, RESET_MSS_REG_BIT(id)) ||
+		  sys_io_test_bit(config->base + SOFT_RESET_CR_OFFSET, RESET_MSS_REG_BIT(id);
 
 	return 0;
 }

--- a/drivers/reset/reset_numaker.c
+++ b/drivers/reset/reset_numaker.c
@@ -30,8 +30,8 @@ static int reset_numaker_status(const struct device *dev, uint32_t id, uint8_t *
 {
 	const struct reset_numaker_config *config = dev->config;
 
-	*status = !!sys_test_bit(config->base + NUMAKER_RESET_IP_OFFSET(id),
-				 NUMAKER_RESET_IP_BIT(id));
+	*status = sys_io_test_bit(config->base + NUMAKER_RESET_IP_OFFSET(id),
+				  NUMAKER_RESET_IP_BIT(id));
 
 	return 0;
 }

--- a/drivers/reset/reset_stm32.c
+++ b/drivers/reset/reset_stm32.c
@@ -24,8 +24,8 @@ static int reset_stm32_status(const struct device *dev, uint32_t id,
 {
 	const struct reset_stm32_config *config = dev->config;
 
-	*status = !!sys_test_bit(config->base + STM32_RESET_SET_OFFSET(id),
-				 STM32_RESET_REG_BIT(id));
+	*status = sys_io_test_bit(config->base + STM32_RESET_SET_OFFSET(id),
+				  STM32_RESET_REG_BIT(id));
 
 	return 0;
 }

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -159,7 +159,7 @@ static inline uint32_t timer_count(void)
 {
 	uint32_t ccr = sys_read32(TIMER_BASE + TIMER_CNT_OFS);
 
-	if ((ccr == 0) && sys_test_bit(TIMER_BASE + TIMER_CR_OFS, TIMER_CR_START_POS)) {
+	if ((ccr == 0) && sys_io_test_bit(TIMER_BASE + TIMER_CR_OFS, TIMER_CR_START_POS)) {
 		ccr = cached_icr;
 	}
 

--- a/include/zephyr/arch/common/sys_bitops.h
+++ b/include/zephyr/arch/common/sys_bitops.h
@@ -121,6 +121,36 @@ static ALWAYS_INLINE
 	return ret;
 }
 
+/* Archtectures X86 and ARC v2 implement their own sys_io_test_bit() function */
+#if !(defined(CONFIG_X86) && !defined(CONFIG_X86_64)) && !defined(CONFIG_ISA_ARCV2)
+static ALWAYS_INLINE int sys_io_test_bit(mem_addr_t addr, unsigned int bit)
+{
+	uint32_t temp = *(volatile uint32_t *)addr;
+
+	return (int)((temp >> bit) & 1U);
+}
+
+static ALWAYS_INLINE int sys_io_test_and_set_bit(mem_addr_t addr, unsigned int bit)
+{
+	uint32_t temp = *(volatile uint32_t *)addr;
+	int ret = (int)((temp >> bit) & 1U);
+
+	*(volatile uint32_t *)addr = temp | (1U << bit);
+
+	return ret;
+}
+
+static ALWAYS_INLINE int sys_io_test_and_clear_bit(mem_addr_t addr, unsigned int bit)
+{
+	uint32_t temp = *(volatile uint32_t *)addr;
+	int ret = (int)((temp >> bit) & 1U);
+
+	*(volatile uint32_t *)addr = temp & ~(1U << bit);
+
+	return ret;
+}
+#endif /*  !(CONFIG_X86 && !CONFIG_X86_64) && !CONFIG_ISA_ARCV2 */
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/sys/sys_io.h
+++ b/include/zephyr/sys/sys_io.h
@@ -285,7 +285,8 @@ typedef uintptr_t mem_addr_t;
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to test (from 0 to 31)
  *
- * @return 1 if it is set, 0 otherwise
+ * @return the bitwise AND result of @p addr content and (1 << @p bit).
+ * Result is 0 only if the bit is cleared otherwise result is a non-0 value.
  */
 
 /**
@@ -298,7 +299,8 @@ typedef uintptr_t mem_addr_t;
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to test and set (from 0 to 31)
  *
- * @return 1 if it was set, 0 otherwise
+ * @return the bitwise AND result of @p addr content and (1 << @p bit) before target bit
+ * is set. Result is 0 only if the bit was cleared otherwise result is a non-0 value.
  */
 
 /**
@@ -311,7 +313,8 @@ typedef uintptr_t mem_addr_t;
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to test and clear (from 0 to 31)
  *
- * @return 0 if it was clear, 1 otherwise
+ * @return the bitwise AND result of @p addr content and (1 << @p bit) before target bit
+ * is cleared. Result is 0 only if the bit was cleared otherwise result is a non-0 value.
  */
 
 /**
@@ -344,7 +347,8 @@ typedef uintptr_t mem_addr_t;
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to test (arbitrary
  *
- * @return 1 if it is set, 0 otherwise
+ * @return the bitwise AND result of @p addr content and (1 << @p bit). Result is 0
+ * only if the bit is cleared otherwise result is a non-0 value.
  */
 
 /**
@@ -357,7 +361,8 @@ typedef uintptr_t mem_addr_t;
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to test and set (arbitrary)
  *
- * @return 1 if it was set, 0 otherwise
+ * @return the bitwise AND result of @p addr content and (1 << @p bit) before target bit
+ * is set. Result is 0 only if the bit was cleared otherwise result is a non-0 value.
  */
 
 /**
@@ -370,7 +375,8 @@ typedef uintptr_t mem_addr_t;
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to test and clear (arbitrary)
  *
- * @return 0 if it was clear, 1 otherwise
+ * @return the bitwise AND result of @p addr content and (1 << @p bit) before target bit
+ * is cleared. Result is 0 only if the bit was cleared otherwise result is a non-0 value.
  */
 
 

--- a/include/zephyr/sys/sys_io.h
+++ b/include/zephyr/sys/sys_io.h
@@ -282,6 +282,9 @@ typedef uintptr_t mem_addr_t;
  * This functions takes the designated bit starting from addr and tests its
  * current setting. It will return the current setting.
  *
+ * This function is deprecated and one should consider using sys_io_test_bit()
+ * instead is order to get an essentially boolean value instead of a bit mask.
+ *
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to test (from 0 to 31)
  *
@@ -296,6 +299,9 @@ typedef uintptr_t mem_addr_t;
  * This functions takes the designated bit starting from addr, tests its
  * current setting and sets it. It will return the previous setting.
  *
+ * This function is deprecated and one should consider using sys_io_test_and_set_bit()
+ * instead is order to get an essentially boolean value instead of a bit mask.
+ *
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to test and set (from 0 to 31)
  *
@@ -309,6 +315,9 @@ typedef uintptr_t mem_addr_t;
  *
  * This functions takes the designated bit starting from addr, test its
  * current setting and clears it. It will return the previous setting.
+ *
+ * This function is deprecated and one should consider using sys_io_test_and_clear_bit()
+ * instead is order to get an essentially boolean value instead of a bit mask.
  *
  * @param addr the memory address from where to look for the bit
  * @param bit the designated bit to test and clear (from 0 to 31)

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -614,7 +614,7 @@ static void wordlist_cb(struct k_object *ko, void *ctx_ptr)
 {
 	struct perm_ctx *ctx = (struct perm_ctx *)ctx_ptr;
 
-	if (sys_bitfield_test_bit((mem_addr_t)&ko->perms, ctx->parent_id) &&
+	if ((sys_bitfield_test_bit((mem_addr_t)&ko->perms, ctx->parent_id) != 0) &&
 				  ((struct k_thread *)ko->name != ctx->parent)) {
 		sys_bitfield_set_bit((mem_addr_t)&ko->perms, ctx->child_id);
 	}

--- a/tests/kernel/common/src/bitfield.c
+++ b/tests/kernel/common/src/bitfield.c
@@ -54,13 +54,13 @@ ZTEST(bitfield, test_bitfield)
 		zassert_equal(b1, (1 << bit),
 			      "sys_set_bit failed on bit %d\n", bit);
 
-		zassert_true(sys_test_bit((mem_addr_t)&b1, bit),
+		zassert_true(sys_test_bit((mem_addr_t)&b1, bit) != 0,
 			     "sys_test_bit did not detect bit %d\n", bit);
 
 		sys_clear_bit((mem_addr_t)&b1, bit);
 		zassert_equal(b1, 0, "sys_clear_bit failed for bit %d\n", bit);
 
-		zassert_false(sys_test_bit((mem_addr_t)&b1, bit),
+		zassert_false(sys_test_bit((mem_addr_t)&b1, bit) != 0,
 			      "sys_test_bit erroneously detected bit %d\n",
 			      bit);
 
@@ -93,7 +93,7 @@ ZTEST(bitfield, test_bitfield)
 		zassert_equal(b2[BIT_INDEX(bit)], BIT_VAL(bit),
 			      "sys_bitfield_set_bit failed for bit %d\n",
 			      bit);
-		zassert_true(sys_bitfield_test_bit((mem_addr_t)b2, bit),
+		zassert_true(sys_bitfield_test_bit((mem_addr_t)b2, bit) != 0,
 			     "sys_bitfield_test_bit did not detect bit %d\n",
 			     bit);
 
@@ -101,33 +101,32 @@ ZTEST(bitfield, test_bitfield)
 		zassert_equal(b2[BIT_INDEX(bit)], 0,
 			      "sys_bitfield_clear_bit failed for bit %d\n",
 			      bit);
-		zassert_false(sys_bitfield_test_bit((mem_addr_t)b2, bit),
+		zassert_false(sys_bitfield_test_bit((mem_addr_t)b2, bit) != 0,
 			      "sys_bitfield_test_bit erroneously detected"
 			      " bit %d\n", bit);
 
 		ret = sys_bitfield_test_and_set_bit((mem_addr_t)b2, bit);
-		zassert_false(ret, "sys_bitfield_test_and_set_bit erroneously"
+		zassert_false(ret != 0, "sys_bitfield_test_and_set_bit erroneously"
 			      " detected bit %d\n", bit);
 
 		zassert_equal(b2[BIT_INDEX(bit)], BIT_VAL(bit),
 			      "sys_bitfield_test_and_set_bit did not set"
 			      " bit %d\n", bit);
-		zassert_true(sys_bitfield_test_and_set_bit((mem_addr_t)b2, bit),
+		zassert_true(sys_bitfield_test_and_set_bit((mem_addr_t)b2, bit) != 0,
 			     "sys_bitfield_test_and_set_bit did not detect bit"
 			     " %d\n", bit);
 		zassert_equal(b2[BIT_INDEX(bit)], BIT_VAL(bit),
 			      "sys_bitfield_test_and_set_bit cleared bit %d\n",
 			      bit);
 
-		zassert_true(sys_bitfield_test_and_clear_bit((mem_addr_t)b2,
-							     bit), "sys_bitfield_test_and_clear_bit did not"
+		zassert_true(sys_bitfield_test_and_clear_bit((mem_addr_t)b2, bit) != 0,
+			     "sys_bitfield_test_and_clear_bit did not"
 			     " detect bit %d\n", bit);
 		zassert_equal(b2[BIT_INDEX(bit)], 0,
 			      "sys_bitfield_test_and_clear_bit did not"
 			      " clear bit %d\n", bit);
-		zassert_false(sys_bitfield_test_and_clear_bit((mem_addr_t)b2,
-							      bit), "sys_bitfield_test_and_clear_bit"
-			      " erroneously detected bit %d\n", bit);
+		zassert_false(sys_bitfield_test_and_clear_bit((mem_addr_t)b2, bit) != 0,
+			      "sys_bitfield_test_and_clear_bit erroneously detected bit %d\n", bit);
 		zassert_equal(b2[BIT_INDEX(bit)], 0,
 			      "sys_bitfield_test_and_clear_bit set bit %d\n",
 			      bit);

--- a/tests/kernel/common/src/bitfield.c
+++ b/tests/kernel/common/src/bitfield.c
@@ -54,8 +54,12 @@ ZTEST(bitfield, test_bitfield)
 		zassert_equal(b1, (1 << bit),
 			      "sys_set_bit failed on bit %d\n", bit);
 
+		/* Test sys_test_bit() and sys_io_test_bit() */
 		zassert_true(sys_test_bit((mem_addr_t)&b1, bit) != 0,
 			     "sys_test_bit did not detect bit %d\n", bit);
+
+		zassert_true(sys_io_test_bit((mem_addr_t)&b1, bit),
+			     "sys_io_test_bit did not detect bit %d\n", bit);
 
 		sys_clear_bit((mem_addr_t)&b1, bit);
 		zassert_equal(b1, 0, "sys_clear_bit failed for bit %d\n", bit);
@@ -64,6 +68,11 @@ ZTEST(bitfield, test_bitfield)
 			      "sys_test_bit erroneously detected bit %d\n",
 			      bit);
 
+		zassert_false(sys_io_test_bit((mem_addr_t)&b1, bit),
+			      "sys_io_test_bit erroneously detected bit %d\n",
+			      bit);
+
+		/* Test sys_test_and_set_bit() and sys_test_and_clear_bit() */
 		zassert_false(sys_test_and_set_bit((mem_addr_t)&b1, bit),
 			      "sys_test_and_set_bit erroneously"
 			      " detected bit %d\n", bit);
@@ -85,6 +94,30 @@ ZTEST(bitfield, test_bitfield)
 			      "sys_test_and_clear_bit erroneously detected"
 			      " bit %d\n", bit);
 		zassert_equal(b1, 0, "sys_test_and_clear_bit set bit %d\n",
+			      bit);
+
+		/* Test sys_io_test_and_set_bit() and sys_io_test_and_clear_bit() */
+		zassert_false(sys_io_test_and_set_bit((mem_addr_t)&b1, bit),
+			      "sys_io_test_and_set_bit erroneously"
+			      " detected bit %d\n", bit);
+		zassert_equal(b1, (1 << bit),
+			      "sys_io_test_and_set_bit did not set bit %d\n",
+			      bit);
+		zassert_true(sys_io_test_and_set_bit((mem_addr_t)&b1, bit),
+			     "sys_io_test_and_set_bit did not detect bit %d\n",
+			     bit);
+		zassert_equal(b1, (1 << bit),
+			      "sys_io_test_and_set_bit cleared bit %d\n", bit);
+
+		zassert_true(sys_io_test_and_clear_bit((mem_addr_t)&b1, bit),
+			     "sys_io_test_and_clear_bit did not detect bit %d\n",
+			     bit);
+		zassert_equal(b1, 0, "sys_io_test_and_clear_bit did not clear bit %d\n",
+			      bit);
+		zassert_false(sys_io_test_and_clear_bit((mem_addr_t)&b1, bit),
+			      "sys_io_test_and_clear_bit erroneously detected bit %d\n",
+			      bit);
+		zassert_equal(b1, 0, "sys_io_test_and_clear_bit set bit %d\n",
 			      bit);
 	}
 


### PR DESCRIPTION
This is an RFC.
The 1st commit of the series already is under review in #97487.

Following https://github.com/zephyrproject-rtos/zephyr/pull/97487, this RFC proposes to implement `sys_io_test_bit()`, `sys_io_test_and_set_bit()` and `sys_io_test_and_clear_bit()` helper functions that were implemented only on 32bit X86 and ARC V2 architectures. The proposed implementation ensures these function return a essentially boolean value that can be used in boolean operations.

I would propose to deprecate the former implementation. Overkilling?

This P-R adds tests for these functions and moves all use of the former helper function to use the `sys_io_test*()` variant instead (aside the tests samples that still test the former functions to ensure non-regression of their support).