### PR TITLE
Update snvs rtc for generic rtc driver and enable it for RT10xx boards

### DIFF
--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
@@ -1,3 +1,9 @@
+#
+# Copyright 2018, 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 identifier: frdm_mcxw71
 name: NXP FRDM_MCXW71
 type: mcu
@@ -22,4 +28,5 @@ supported:
   - uart
   - watchdog
   - netif:openthread
+  - rtc
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.yaml
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2019, 2024 NXP
+# Copyright 2019, 2024, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -28,4 +28,5 @@ supported:
   - sdhc
   - usb_device
   - watchdog
+  - rtc
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.yaml
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2019, 2024 NXP
+# Copyright 2019, 2024, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -21,4 +21,5 @@ supported:
   - gpio
   - spi
   - watchdog
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023 TiaC Systems
- * Copyright 2019,2023-2024 NXP
+ * Copyright 2019, 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,6 +20,7 @@
 		led0 = &green_led;
 		sw0 = &user_button;
 		mcuboot-button0 = &user_button;
+		rtc = &counter_rtc;
 	};
 
 	chosen {
@@ -192,5 +193,9 @@ zephyr_udc0: &usb1 {
 };
 
 &pit0 {
+	status = "okay";
+};
+
+&counter_rtc {
 	status = "okay";
 };

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.yaml
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.yaml
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2023 TiaC Systems
-# Copyright (c) 2019, NXP
+# Copyright 2019, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -27,4 +27,5 @@ supported:
   - i2c
   - spi
   - usb_device
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019,2023 NXP
+ * Copyright 2019, 2023, 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,6 +19,7 @@
 		led0 = &green_led;
 		sw0 = &user_button;
 		mcuboot-button0 = &user_button;
+		rtc = &counter_rtc;
 	};
 
 	chosen {
@@ -185,5 +186,9 @@ zephyr_udc0: &usb1 {
 };
 
 &systick {
+	status = "okay";
+};
+
+&counter_rtc {
 	status = "okay";
 };

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.yaml
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NXP
+# Copyright 2019, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -24,4 +24,5 @@ supported:
   - i2c
   - spi
   - usb_device
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NXP
+ * Copyright 2018, 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,6 +20,7 @@
 		sw0 = &user_button;
 		sdhc0 = &usdhc1;
 		mcuboot-button0 = &user_button;
+		rtc = &counter_rtc;
 	};
 
 	chosen {
@@ -246,5 +247,9 @@ zephyr_udc0: &usb1 {
 };
 
 &systick {
+	status = "okay";
+};
+
+&counter_rtc {
 	status = "okay";
 };

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.yaml
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, NXP
+# Copyright 2018, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -26,4 +26,5 @@ supported:
   - sdhc
   - spi
   - usb_device
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NXP
+ * Copyright 2020, 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,6 +23,7 @@
 		accel0 = &fxos8700;
 		sdhc0 = &usdhc1;
 		mcuboot-button0 = &user_button;
+		rtc = &counter_rtc;
 	};
 
 	chosen {
@@ -255,4 +256,8 @@ zephyr_udc0: &usb1 {
 		disk-name = "SD";
 		status = "okay";
 	};
+};
+
+&counter_rtc {
+	status = "okay";
 };

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.yaml
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, NXP
+# Copyright 2020, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -28,4 +28,5 @@ supported:
   - spi
   - usb_device
   - watchdog
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023, 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,6 +21,7 @@
 		pwm-0 = &flexpwm1_pwm3;
 		accel0 = &fxls8974;
 		mcuboot-button0 = &user_button;
+		rtc = &counter_rtc;
 	};
 
 	chosen {
@@ -245,3 +246,7 @@ lpi2c3: &lpi2c3 {
 m2_hci_bt_uart: &lpuart3 {};
 
 m2_wifi_sdio: &usdhc1 {};
+
+&counter_rtc {
+	status = "okay";
+};

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 NXP
+# Copyright 2023, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -22,4 +22,5 @@ supported:
   - i2c
   - pwm
   - spi
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NXP
+ * Copyright 2017, 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,6 +23,7 @@
 		accel0 = &fxos8700;
 		sdhc0 = &usdhc1;
 		mcuboot-button0 = &user_button;
+		rtc = &counter_rtc;
 	};
 
 	chosen {
@@ -277,5 +278,9 @@ zephyr_uhc1: &usbh2 {
 };
 
 &systick {
+	status = "okay";
+};
+
+&counter_rtc {
 	status = "okay";
 };

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, NXP
+# Copyright 2017, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -29,4 +29,5 @@ supported:
   - usb_device
   - usbd
   - watchdog
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, NXP
+# Copyright 2017, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -29,4 +29,5 @@ supported:
   - usb_device
   - usbd
   - watchdog
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018,2024-2025 NXP
+ * Copyright 2018, 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,6 +22,7 @@
 		watchdog0 = &wdog0;
 		sdhc0 = &usdhc1;
 		mcuboot-button0 = &user_button;
+		rtc = &counter_rtc;
 	};
 
 	chosen {
@@ -342,3 +343,7 @@ dvp_fpc24_interface: &csi {};
 m2_hci_bt_uart: &lpuart3 {};
 
 m2_wifi_sdio: &usdhc1 {};
+
+&counter_rtc {
+	status = "okay";
+};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, NXP
+# Copyright 2018, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -31,4 +31,5 @@ supported:
   - usb_device
   - usbd
   - watchdog
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, NXP
+# Copyright 2018, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -33,4 +33,5 @@ supported:
   - usb_device
   - usbd
   - watchdog
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_B.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_B.yaml
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2022, Whisper.ai
+# Copyright 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -30,4 +31,5 @@ supported:
   - spi
   - usbd
   - watchdog
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2022, Whisper.ai
+# Copyright 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -31,4 +32,5 @@ supported:
   - spi
   - usbd
   - watchdog
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -1,7 +1,7 @@
 /*
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2023, 2025 NXP
  *
- * Copyright 2023 NXP
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /dts-v1/;
@@ -23,6 +23,7 @@
 		gps1 = &lpuart2;
 		telem1 = &lpuart3;
 		telem4-gps2 = &lpuart5;
+		rtc = &counter_rtc;
 	};
 
 	chosen {
@@ -467,4 +468,8 @@ zephyr_udc0: &usb1 {
 &itm {
 	pinctrl-0 = <&pinmux_swo>;
 	pinctrl-names = "default";
+};
+
+&counter_rtc {
+	status = "okay";
 };

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.yaml
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.yaml
@@ -1,7 +1,7 @@
 #
-# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023, 2025 NXP
 #
-# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
 #
 
 identifier: mimxrt1062_fmurt6
@@ -28,4 +28,5 @@ supported:
   - uart
   - usb_device
   - watchdog
+  - rtc
 vendor: nxp

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NXP
+ * Copyright 2018, 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,6 +22,7 @@
 		watchdog0 = &wdog0;
 		sdhc0 = &usdhc1;
 		mcuboot-button0 = &user_button;
+		rtc = &counter_rtc;
 	};
 
 	chosen {
@@ -363,3 +364,7 @@ zephyr_udc0: &usb1 {
 dvp_fpc24_i2c: &lpi2c1 {};
 
 dvp_fpc24_interface: &csi {};
+
+&counter_rtc {
+	status = "okay";
+};

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, NXP
+# Copyright 2018, 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -32,4 +32,5 @@ supported:
   - usb_device
   - video
   - watchdog
+  - rtc
 vendor: nxp

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017,2023,2024 NXP
+ * Copyright 2017, 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -345,6 +345,12 @@
 				compatible = "nxp,imx-snvs-rtc";
 				interrupts = <46 0>;
 				wakeup-source;
+
+				counter_rtc: counter_rtc {
+					compatible = "zephyr,rtc-counter";
+					alarms-count = <2>;
+					status = "disabled";
+				};
 			};
 		};
 

--- a/samples/drivers/rtc/boards/mimxrt1010_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1010_evk.conf
@@ -1,0 +1,8 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1015_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1015_evk.conf
@@ -1,0 +1,8 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1020_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1020_evk.conf
@@ -1,0 +1,8 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1024_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1024_evk.conf
@@ -1,0 +1,8 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1040_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1040_evk.conf
@@ -1,0 +1,8 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1050_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1050_evk.conf
@@ -1,0 +1,8 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1060_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1060_evk.conf
@@ -1,0 +1,8 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1062_fmurt6.conf
+++ b/samples/drivers/rtc/boards/mimxrt1062_fmurt6.conf
@@ -1,0 +1,8 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_INIT_PRIORITY=70

--- a/samples/drivers/rtc/boards/mimxrt1064_evk.conf
+++ b/samples/drivers/rtc/boards/mimxrt1064_evk.conf
@@ -1,0 +1,8 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_INIT_PRIORITY=70

--- a/tests/drivers/rtc/rtc_api/boards/frdm_mcxw71.conf
+++ b/tests/drivers/rtc/rtc_api/boards/frdm_mcxw71.conf
@@ -1,9 +1,0 @@
-#
-# Copyright 2025 NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-
-CONFIG_RTC_ALARM=y
-CONFIG_RTC_INIT_PRIORITY=70
-CONFIG_TEST_RTC_ALARM_TIME_MASK=255

--- a/tests/drivers/rtc/rtc_api/boards/lpcxpresso55s69_lpc55s69_cpu0.conf
+++ b/tests/drivers/rtc/rtc_api/boards/lpcxpresso55s69_lpc55s69_cpu0.conf
@@ -1,9 +1,0 @@
-#
-# Copyright 2025 NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-
-CONFIG_RTC_ALARM=y
-CONFIG_RTC_INIT_PRIORITY=70
-CONFIG_TEST_RTC_ALARM_TIME_MASK=255

--- a/tests/drivers/rtc/rtc_api/testcase.yaml
+++ b/tests/drivers/rtc/rtc_api/testcase.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2022 Bjarki Arge Andreasen
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 tests:
@@ -7,8 +8,21 @@ tests:
       - drivers
       - rtc
       - api
-    filter: dt_alias_exists("rtc")
+    filter: dt_alias_exists("rtc") and not dt_compat_enabled("zephyr,rtc-counter")
     depends_on: rtc
     timeout: 100
     platform_exclude:
       - qemu_x86_64
+
+  drivers.rtc.rtc_api.rtc_counter:
+    tags:
+      - drivers
+      - rtc
+      - api
+    filter: dt_alias_exists("rtc") and dt_compat_enabled("zephyr,rtc-counter")
+    depends_on: rtc
+    timeout: 100
+    extra_configs:
+      - CONFIG_RTC_ALARM=y
+      - CONFIG_RTC_INIT_PRIORITY=70
+      - CONFIG_TEST_RTC_ALARM_TIME_MASK=255

--- a/tests/drivers/rtc/rtc_api_helpers/testcase.yaml
+++ b/tests/drivers/rtc/rtc_api_helpers/testcase.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2022 Bjarki Arge Andreasen
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 tests:
@@ -8,4 +9,5 @@ tests:
       - rtc
       - api
       - helpers
+    filter: not dt_compat_enabled("zephyr,rtc-counter")
     depends_on: rtc

--- a/tests/drivers/rtc/rtc_utils/testcase.yaml
+++ b/tests/drivers/rtc/rtc_utils/testcase.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2024 Andrew Featherstone
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 tests:
@@ -6,4 +7,5 @@ tests:
     tags:
       - drivers
       - rtc
+    filter: not dt_compat_enabled("zephyr,rtc-counter")
     depends_on: rtc

--- a/tests/drivers/rtc/shell/testcase.yaml
+++ b/tests/drivers/rtc/shell/testcase.yaml
@@ -7,5 +7,5 @@ tests:
       - drivers
       - rtc
       - shell
-    filter: dt_alias_exists("rtc")
+    filter: dt_alias_exists("rtc") and not dt_compat_enabled("zephyr,rtc-counter")
     depends_on: rtc


### PR DESCRIPTION
Update snvs rtc for generic rtc driver.
Enable it for RT10xx boards: samples and tests.