### PR TITLE
soc: silabs: siwx91x: Transform silabs network coprocessor (NWP) SoC files into a driver.

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -184,7 +184,7 @@ config BT_SILABS_SIWX91X
 	bool "Silabs SiWx91x Bluetooth interface"
 	default y
 	depends on DT_HAS_SILABS_SIWX91X_BT_HCI_ENABLED
-	select WISECONNECT_NETWORK_STACK
+	select SILABS_SIWX91X_NWP
 	select ENTROPY_GENERATOR
 	help
 	  Use Silicon Labs Wiseconnect 3.x Bluetooth library to connect to the controller.

--- a/drivers/flash/Kconfig.siwx91x
+++ b/drivers/flash/Kconfig.siwx91x
@@ -9,7 +9,7 @@ config SOC_FLASH_SILABS_SIWX91X
 	select FLASH_HAS_EXPLICIT_ERASE
 	select FLASH_HAS_PAGE_LAYOUT
 	# Flash controller is handled by the network coprocessor
-	select WISECONNECT_NETWORK_STACK
+	select SILABS_SIWX91X_NWP
 	help
 	  Enable flash controller for flash embedded on Silicon Labs SiWx91x
 	  chips.

--- a/drivers/wifi/siwx91x/Kconfig.siwx91x
+++ b/drivers/wifi/siwx91x/Kconfig.siwx91x
@@ -6,7 +6,7 @@ config WIFI_SILABS_SIWX91X
 	default y
 	depends on DT_HAS_SILABS_SIWX91X_WIFI_ENABLED
 	depends on NETWORKING
-	select WISECONNECT_NETWORK_STACK
+	select SILABS_SIWX91X_NWP
 	select EVENTS
 	select NET_L2_WIFI_MGMT
 	help

--- a/drivers/wifi/siwx91x/siwx91x_wifi.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.h
@@ -10,6 +10,7 @@
 #include "sl_si91x_types.h"
 
 struct siwx91x_config {
+	const struct device *nwp_dev;
 	uint8_t scan_tx_power;
 	uint8_t join_tx_power;
 };

--- a/drivers/wifi/siwx91x/siwx91x_wifi_ap.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_ap.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2024-2025 Silicon Laboratories Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <nwp.h>
+#include <siwx91x_nwp.h>
 #include "siwx91x_wifi.h"
 
 #include "sl_rsi_utility.h"
@@ -13,11 +13,13 @@ LOG_MODULE_DECLARE(siwx91x_wifi);
 
 static int siwx91x_nwp_reboot_if_required(const struct device *dev, uint8_t oper_mode)
 {
+	const struct siwx91x_config *siwx91x_cfg = dev->config;
 	struct siwx91x_dev *sidev = dev->data;
 	int ret;
 
 	if (sidev->reboot_needed) {
-		ret = siwx91x_nwp_mode_switch(oper_mode, sidev->hidden_ssid, sidev->max_num_sta);
+		ret = siwx91x_nwp_mode_switch(siwx91x_cfg->nwp_dev, oper_mode, sidev->hidden_ssid,
+					      sidev->max_num_sta);
 		if (ret < 0) {
 			LOG_ERR("Failed to reboot the device: %d", ret);
 			return ret;

--- a/drivers/wifi/siwx91x/siwx91x_wifi_ps.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_ps.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/sys/util.h>
-#include <nwp.h>
+#include <siwx91x_nwp.h>
 #include "siwx91x_wifi.h"
 #include "siwx91x_wifi_ps.h"
 

--- a/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
@@ -5,7 +5,7 @@
  */
 #include <zephyr/logging/log.h>
 
-#include <nwp.h>
+#include <siwx91x_nwp.h>
 #include "siwx91x_wifi.h"
 #include "siwx91x_wifi_scan.h"
 

--- a/drivers/wifi/siwx91x/siwx91x_wifi_sta.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_sta.c
@@ -5,7 +5,7 @@
  */
 #include <zephyr/logging/log.h>
 
-#include <nwp.h>
+#include <siwx91x_nwp.h>
 #include "siwx91x_wifi.h"
 #include "siwx91x_wifi_socket.h"
 #include "siwx91x_wifi_ps.h"

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -76,6 +76,11 @@
 	nwp: nwp {
 		compatible = "silabs,siwx91x-nwp";
 		power-profile = "high-performance";
+		stack-size = <10240>;
+		interrupt-parent = <&nvic>;
+		interrupts = <30 0>, <74 0>;
+		interrupt-names = "nwp_stack", "nwp_irq";
+		status = "okay";
 
 		bt_hci0: bt_hci {
 			compatible = "silabs,siwx91x-bt-hci";

--- a/dts/bindings/net/wireless/silabs,siwx91x-nwp.yaml
+++ b/dts/bindings/net/wireless/silabs,siwx91x-nwp.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-title: Silicon Labs SiWx91x NWP (Network Wireless Processor)
+title: Silicon Labs SiWx91x NWP (Network Wireless Coprocessor)
 
 description: |
   The Network Wireless Processor (NWP) manages Wi-Fi and Bluetooth connectivity on SiWx91x devices,
@@ -10,7 +10,17 @@ description: |
 
 compatible: "silabs,siwx91x-nwp"
 
+include: base.yaml
+
 properties:
+  interrupts:
+    required: true
+
+  stack-size:
+    type: int
+    description: Stack size for the NWP in bytes
+    required: true
+
   power-profile:
     type: string
     description: Power/performance profile

--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -154,7 +154,7 @@ if(CONFIG_BT_SILABS_SIWX91X)
   )
 endif() # CONFIG_BT_SILABS_SIWX91X
 
-if(CONFIG_WISECONNECT_NETWORK_STACK)
+if(CONFIG_SILABS_SIWX91X_NWP)
   zephyr_compile_definitions(
     SLI_SI91X_ENABLE_OS
     SL_SI91X_SI917_RAM_MEM_CONFIG=2
@@ -198,7 +198,7 @@ if(CONFIG_WISECONNECT_NETWORK_STACK)
     ${WISECONNECT_DIR}/components/device/silabs/si91x/wireless/firmware_upgrade/firmware_upgradation.c
   )
   zephyr_include_directories(.)
-endif() # CONFIG_WISECONNECT_NETWORK_STACK
+endif() # CONFIG_SILABS_SIWX91X_NWP
 
 if(CONFIG_SOC_SILABS_SLEEPTIMER)
   zephyr_include_directories(

--- a/soc/silabs/silabs_siwx91x/Kconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig
@@ -20,9 +20,22 @@ config SOC_SILABS_SLEEPTIMER
 	help
 	  The Sleeptimer HAL module is used for SIWX91X.
 
+config SILABS_SIWX91X_NWP
+	bool "Silabs Network Coprocessor"
+	depends on DT_HAS_SILABS_SIWX91X_NWP_ENABLED
+	select CMSIS_RTOS_V2
+	select POLL
+	select DYNAMIC_THREAD
+	select THREAD_NAME
+	select THREAD_STACK_INFO
+	select THREAD_MONITOR
+	select INIT_STACKS
+	help
+	  Add support for Network Coprocessor (also named NWP) presents on SiWx91x parts.
+
 config SOC_SIWX91X_PM_BACKEND_PMGR
 	bool
-	select WISECONNECT_NETWORK_STACK
+	select SILABS_SIWX91X_NWP
 	select SILABS_SLEEPTIMER_TIMER
 	select SRAM_VECTOR_TABLE
 	select CODE_DATA_RELOCATION_SRAM
@@ -64,7 +77,7 @@ config SIWX91X_ENCRYPT
 
 config SIWX91X_FIRMWARE_UPGRADE
 	bool "Support for firmware upgrade"
-	select WISECONNECT_NETWORK_STACK
+	select SILABS_SIWX91X_NWP
 	help
 	  The firmware upgrade process for SiWx91x devices involves coordinated
 	  communication with both the Network Co-Processor (NCP) and the ROM

--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -13,17 +13,7 @@ configdefault SYS_CLOCK_TICKS_PER_SEC
 configdefault UART_NS16550_DW8250_DW_APB
 	default y
 
-config WISECONNECT_NETWORK_STACK
-	bool
-	select CMSIS_RTOS_V2
-	select POLL
-	select DYNAMIC_THREAD
-	select THREAD_NAME
-	select THREAD_STACK_INFO
-	select THREAD_MONITOR
-	select INIT_STACKS
-
-if WISECONNECT_NETWORK_STACK
+if SILABS_SIWX91X_NWP
 
 # WiseConnect create threads with realtime priority. Default (10kHz) clock tick
 # prevent proper use of the system with these threads.
@@ -42,7 +32,7 @@ config CMSIS_V2_THREAD_DYNAMIC_STACK_SIZE
 config CMSIS_V2_THREAD_MAX_STACK_SIZE
 	default 2048
 
-endif # WISECONNECT_NETWORK_STACK
+endif
 
 rsource "*/Kconfig.defconfig"
 

--- a/soc/silabs/silabs_siwx91x/siwg917/CMakeLists.txt
+++ b/soc/silabs/silabs_siwx91x/siwg917/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources_ifdef(CONFIG_SOC_SERIES_SIWG917 soc.c)
-zephyr_sources_ifdef(CONFIG_WISECONNECT_NETWORK_STACK nwp.c)
+zephyr_sources_ifdef(CONFIG_SILABS_SIWX91X_NWP siwx91x_nwp.c)
 zephyr_sources_ifdef(CONFIG_SOC_SIWX91X_PM_BACKEND_PMGR soc_siwx91x_power_pmgr.c)
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.h
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.h
@@ -2,13 +2,14 @@
  * Copyright (c) 2025 Silicon Laboratories Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef SIWG917_NWP_H
-#define SIWG917_NWP_H
+#ifndef SIWX91X_NWP_H
+#define SIWX91X_NWP_H
 
+#include <zephyr/device.h>
 #include "sl_wifi.h"
 
 #define SIWX91X_INTERFACE_MASK (0x03)
-#define DEFAULT_COUNTRY_CODE	"00"
+#define DEFAULT_COUNTRY_CODE   "00"
 
 /**
  * @brief Switch the Wi-Fi operating mode.
@@ -17,13 +18,15 @@
  * operating mode based on the provided features. It performs a soft reboot
  * of the NWP to apply the new mode along with the updated features.
  *
+ * @param[in] dev           NWP device.
  * @param[in] oper_mode     Wi-Fi operating mode to switch to.
  * @param[in] hidden_ssid   SSID and its length (used only in WIFI_AP_MODE).
  * @param[in] max_num_sta   Maximum number of supported stations (only for WIFI_AP_MODE).
  *
  * @return 0 on success, negative error code on failure.
  */
-int siwx91x_nwp_mode_switch(uint8_t oper_mode, bool hidden_ssid, uint8_t max_num_sta);
+int siwx91x_nwp_mode_switch(const struct device *dev, uint8_t oper_mode, bool hidden_ssid,
+			    uint8_t max_num_sta);
 
 /**
  * @brief Map an ISO/IEC 3166-1 alpha-2 country code to a Wi-Fi region code.
@@ -55,9 +58,10 @@ const sli_si91x_set_region_ap_request_t *siwx91x_find_sdk_region_table(uint8_t r
  *
  * This function saves the provided country code to a static internal buffer.
  *
+ * @param[in] dev           NWP device.
  * @param[in] country_code  Pointer to a 2-character ISO country code.
  */
-int siwx91x_store_country_code(const char *country_code);
+int siwx91x_store_country_code(const struct device *dev, const char *country_code);
 
 /**
  * @brief Retrieve the currently stored country code.
@@ -65,8 +69,10 @@ int siwx91x_store_country_code(const char *country_code);
  * This function returns a pointer to the internally stored 2-character
  * country code set by store_country_code().
  *
+ * @param[in] dev           NWP device.
+ *
  * @return Pointer to the stored country code string.
  */
-const char *siwx91x_get_country_code(void);
+const char *siwx91x_get_country_code(const struct device *dev);
 
 #endif

--- a/soc/silabs/silabs_siwx91x/siwg917/soc_siwx91x_power_pmgr.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/soc_siwx91x_power_pmgr.c
@@ -42,7 +42,7 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 			LOG_ERR("Failed to configure clocks for sleep mode");
 			goto out;
 		}
-		if (IS_ENABLED(CONFIG_WISECONNECT_NETWORK_STACK)) {
+		if (IS_ENABLED(CONFIG_SILABS_SIWX91X_NWP)) {
 			if (!(M4_ULP_SLP_STATUS_REG & ULP_MODE_SWITCHED_NPSS)) {
 				if (!sl_si91x_is_device_initialized()) {
 					LOG_ERR("Device is not initialized");


### PR DESCRIPTION
The goal of this PR is to transform the SoC files for the NWP (Network coprocessor) into a driver.

The node for the NWP already exists, but declaring it as a driver allows us to have a device and check device health during initialization and when other components (like WiFi or Bluetooth) need it.
I also renamed the Kconfig option from "CONFIG_WISECONNECT_NETWORK_STACK" to "CONFIG_SILABS_SIWX91X_NWP" to make it more explicit.

Currently, we don't have "default=y" for the Kconfig option because we don't want to boot up the NWP if no component will use it. Components that need it must select this option.

The first commit is quite large, but I couldn't find a way to split it while maintaining successful compilation between individual commits. Any suggestions are welcome.

I will do some cleanup of the siwx91x  SoC folder on an upcoming PR.