### PR TITLE
ICM45686: Address issues coming from a sloppy rebase on #94832

### DIFF
--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -86,8 +86,7 @@ static inline bool should_read_all_fifo(const struct sensor_read_config *read_cf
 	return (trig_fifo_full && trig_fifo_full->opt == SENSOR_STREAM_DATA_INCLUDE);
 }
 
-static inline bool should_read_data(const struct sensor_read_config *read_cfg,
-				    uint8_t int_status)
+static inline bool should_read_data(const struct sensor_read_config *read_cfg)
 {
 	struct sensor_stream_trigger *trig_drdy = get_read_config_trigger(
 		read_cfg,

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -121,7 +121,7 @@ static inline void icm45686_stream_result(const struct device *dev,
 }
 
 static void icm45686_complete_handler(struct rtio *ctx,
-				      const struct rtio_sqe *sqe,
+				      const struct rtio_sqe *sqe, int result,
 				      void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
@@ -129,6 +129,12 @@ static void icm45686_complete_handler(struct rtio *ctx,
 	const struct sensor_read_config *read_cfg = data->stream.iodev_sqe->sqe.iodev->data;
 	uint8_t int_status = data->stream.data.int_status;
 	int err;
+
+	if (result < 0) {
+		LOG_ERR("Data readout failed: %d", result);
+		icm45686_stream_result(dev, result);
+		return;
+	}
 
 	data->stream.data.events.drdy = int_status & REG_INT1_STATUS0_DRDY(true);
 	data->stream.data.events.fifo_ths = int_status & REG_INT1_STATUS0_FIFO_THS(true);


### PR DESCRIPTION
While I was rebasing #94832 I missed to address a couple changes due to in-flight contributions that got in in the mean-time.
The following issues have been corrected:
1. Helper function scrubbing `should_read_data()` argument that'd require an int-status read first.
2. Completion callback having an result argument that now can be used to handle failures during read-out.