### PR TITLE
west: update mipi-sys-t to lastest SHA

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -329,7 +329,7 @@ manifest:
       path: modules/debug/mipi-sys-t
       groups:
         - debug
-      revision: 33e5c23cbedda5ba12dbe50c4baefb362a791001
+      revision: 5a9d6055b62edc54566d6d0034d9daec91749b98
     - name: nanopb
       revision: 7307ce399b81ddcb3c3a5dc862c52d4754328d38
       path: modules/lib/nanopb


### PR DESCRIPTION
This updates the SHA for the mipi-sys-t module.
This brings in support for IAR compilers.