### PR TITLE
tests: pm: Fix for power management test

### DIFF
--- a/scripts/pylib/power-twister-harness/stm32l562e_dk/PowerShield.py
+++ b/scripts/pylib/power-twister-harness/stm32l562e_dk/PowerShield.py
@@ -1,4 +1,5 @@
-# Copyright: (c)  2025, Intel Corporation
+# Copyright (c) 2025, Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 # Author: Arkadiusz Cholewinski <arkadiuszx.cholewinski@intel.com>
 
 import csv
@@ -303,7 +304,7 @@ class PowerShield(PowerMonitor):
         while True:
             # Read the first byte
             first_byte = self.handler.read_bytes(1)
-            if len(first_byte) < 1 or self.acqComplete:  # Exit conditions
+            if len(first_byte) < 1 or self.acqComplete:
                 logging.info("Stopping data acquisition...")
                 return
 
@@ -408,7 +409,6 @@ class PowerShield(PowerMonitor):
         :return: None
         """
         command = "start"
-        self.acqComplete = False
         self.__send_command(command)
 
         raw_to_file_Thread = threading.Thread(
@@ -420,11 +420,10 @@ class PowerShield(PowerMonitor):
         raw_to_file_Thread.join()
 
     def __raw_to_file(self, outputFilePath: str):
-        # Open a CSV file for writing
         with open(outputFilePath, 'w', newline='') as outputFile:
             writer = csv.writer(outputFile)
             while True:
-                if self.dataQueue.empty() and bool(self.acqComplete):
+                if self.dataQueue.empty() and self.acqComplete:
                     outputFile.close()
                     break
                 if not self.dataQueue.empty():
@@ -457,7 +456,6 @@ class PowerShield(PowerMonitor):
 
     def get_data(self, unit: str = PowerShieldConf.MeasureUnit.RAW_DATA):
         if self.acqComplete:
-            # Open the CSV file
             with open(self.power_shield_conf.output_file) as file:
                 csv_reader = csv.reader(file)
                 for row in csv_reader:

--- a/tests/subsys/pm/power_states/testcase.yaml
+++ b/tests/subsys/pm/power_states/testcase.yaml
@@ -13,7 +13,7 @@ common:
       peak_padding: 40
       measurement_duration: 6
       num_of_transitions: 4
-      expected_rms_values: [5.6, 0.4, 0.14, 0.026, 14]
+      expected_rms_values: [5.6, 0.4, 0.12, 0.026, 14]
       tolerance_percentage: 20
     record:
       regex:

--- a/tests/subsys/pm/power_states/testcase.yaml
+++ b/tests/subsys/pm/power_states/testcase.yaml
@@ -17,7 +17,7 @@ common:
       tolerance_percentage: 20
     record:
       regex:
-        - "RECORD:(?P<metrics>.*)"
+        - "^INFO: RECORD:(?P<metrics>.*)"
       as_json: ['metrics']
 
 tests:


### PR DESCRIPTION
Fix for collecting and presenting measured data.
During verify measured values, the test skipped all results after the first incorrect one.
Furthermore, it duplicated already collected data on the output list. 
So in this case the result list include wrong data.
The result after fail:
```
[{'expected_rms_ua': 5.6}, {'tolerance_ua': 1.12}, {'measured_rms_ua': 5.65}]
[{'expected_rms_ua': 0.4}, {'tolerance_ua': 0.08}, {'measured_rms_ua': 0.39}]
[{'expected_rms_ua': 0.14}, {'tolerance_ua': 0.03}, {'measured_rms_ua': 0.11}] <-- this measured value trigger a fail, but we don't see because accuracy is too low
[{'expected_rms_ua': 5.6}, {'tolerance_ua': 1.12}, {'measured_rms_ua': 5.65}]
[{'expected_rms_ua': 0.4}, {'tolerance_ua': 0.08}, {'measured_rms_ua': 0.39}]
[{'expected_rms_ua': 0.14}, {'tolerance_ua': 0.03}, {'measured_rms_ua': 0.11}]
```
It should looks like:
```
"[{'expected_rms_ua': 5.6}, {'tolerance_ua': 1.12}, {'measured_rms_ua': 5.647}]"
"[{'expected_rms_ua': 0.4}, {'tolerance_ua': 0.08}, {'measured_rms_ua': 0.388}]"
"[{'expected_rms_ua': 0.14}, {'tolerance_ua': 0.03}, {'measured_rms_ua': 0.109}]" <-- this measured value trigger a fail
"[{'expected_rms_ua': 0.03}, {'tolerance_ua': 0.01}, {'measured_rms_ua': 0.027}]"
"[{'expected_rms_ua': 14.0}, {'tolerance_ua': 2.8}, {'measured_rms_ua': 13.606}]"
```
The part of twister log:
```
INFO: Stopping data acquisition...
DEBUG: Measured RMS values in mA: [np.float64(5.654448390178646), np.float64(0.37803122099654946), np.float64(0.10985806520053602), np.float64(0.02664327621459961), np.float64(13.615673289676113)]
DEBUG: Expected RMS: 5.60 mA
DEBUG: Tolerance: 1.12 mA
DEBUG: Measured  RMS: 5.65 mA
INFO: RECORD: [{"expected_rms_ua": 5.60},{"tolerance_ua": 1.12},{"measured_rms_ua": 5.65}]
DEBUG: Expected RMS: 0.40 mA
DEBUG: Tolerance: 0.08 mA
DEBUG: Measured  RMS: 0.38 mA
INFO: RECORD: [{"expected_rms_ua": 0.40},{"tolerance_ua": 0.08},{"measured_rms_ua": 0.38}]
DEBUG: Expected RMS: 0.14 mA
DEBUG: Tolerance: 0.03 mA
DEBUG: Measured  RMS: 0.11 mA
INFO: RECORD: [{"expected_rms_ua": 0.14},{"tolerance_ua": 0.03},{"measured_rms_ua": 0.11}]
FAILED
```
It is confused because the measured value: 0.11 should not trigger fail but real value is 0.109858....