### PR TITLE
drivers: modem: cellular: Close down CMUX before shut down

### DIFF
--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -545,6 +545,19 @@ static void modem_cmux_on_control_frame_uih(struct modem_cmux *cmux)
 
 	modem_cmux_log_received_command(command);
 
+	if (!command->type.cr) {
+		LOG_DBG("Received response command");
+		switch (command->type.value) {
+		case MODEM_CMUX_COMMAND_CLD:
+			modem_cmux_on_cld_command(cmux, command);
+			break;
+		default:
+			/* Responses to other commands are ignored */
+			break;
+		}
+		return;
+	}
+
 	switch (command->type.value) {
 	case MODEM_CMUX_COMMAND_CLD:
 		modem_cmux_on_cld_command(cmux, command);
@@ -631,8 +644,7 @@ static void modem_cmux_on_control_frame(struct modem_cmux *cmux)
 	modem_cmux_log_received_frame(&cmux->frame);
 
 	if (is_connected(cmux) && cmux->frame.cr == cmux->initiator) {
-		LOG_DBG("Received a response frame, dropping");
-		return;
+		LOG_DBG("Received a response frame");
 	}
 
 	switch (cmux->frame.type) {

--- a/tests/subsys/modem/modem_cmux_pair/src/main.c
+++ b/tests/subsys/modem/modem_cmux_pair/src/main.c
@@ -507,9 +507,10 @@ ZTEST(modem_cmux_pair, test_modem_cmux_disconnect_connect)
 	modem_backend_mock_reset(&bus_mock_dte);
 	zassert_true(modem_cmux_disconnect_async(&cmux_dte) == 0, "Failed to disconnect CMUX");
 
-	k_msleep(100);
+	events = k_event_wait_all(&cmux_event_dte, (EVENT_CMUX_DISCONNECTED), false, K_MSEC(660));
+	zassert_true((events & EVENT_CMUX_DISCONNECTED), "Failed to disconnect CMUX");
 
-	events = k_event_wait_all(&cmux_event_dte, (EVENT_CMUX_DISCONNECTED), false, K_MSEC(100));
+	events = k_event_wait_all(&cmux_event_dce, (EVENT_CMUX_DISCONNECTED), false, K_MSEC(660));
 	zassert_true((events & EVENT_CMUX_DISCONNECTED), "Failed to disconnect CMUX");
 
 	/* Reconnect CMUX */
@@ -554,6 +555,9 @@ ZTEST(modem_cmux_pair, test_modem_cmux_disconnect_connect_sync)
 	zassert_true(modem_cmux_disconnect(&cmux_dte) == 0, "Failed to disconnect CMUX");
 	zassert_true(modem_cmux_disconnect(&cmux_dte) == -EALREADY,
 		     "Should already be disconnected");
+
+	events = k_event_wait_all(&cmux_event_dce, (EVENT_CMUX_DISCONNECTED), false, K_MSEC(660));
+	zassert_true((events & EVENT_CMUX_DISCONNECTED), "Failed to disconnect CMUX");
 	zassert_true(modem_cmux_disconnect(&cmux_dce) == -EALREADY,
 		     "Should already be disconnected");
 


### PR DESCRIPTION
drivers: modem: cellular: Close down CMUX before shut down

Properly close down the CMUX channel before shutting down
the modem.

The CMUX Close-Down command should indicate the remote end
to clean up, even if we don't have shutdown script or power-key GPIO.


Requires also minor fix to CMUX so we send disconnect event only after responding to CLD (Multiplexer Close Down).

If we immediately send disconnected event when CLD is received,
we might close the UART pipe before the response is actually send.

Contains changes from PR #97570
