### PR TITLE
Fix some slip Kconfig initialization issues

### DIFF
--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -376,6 +376,7 @@ void slip_iface_init(struct net_if *iface)
 {
 	struct slip_context *slip = net_if_get_device(iface)->data;
 	struct net_linkaddr *ll_addr;
+	int err;
 
 #if defined(CONFIG_SLIP_TAP) && defined(CONFIG_NET_L2_ETHERNET)
 	ethernet_init(iface);
@@ -410,6 +411,11 @@ use_random_mac:
 	ll_addr = slip_get_mac(slip);
 	net_if_set_link_addr(iface, ll_addr->addr, ll_addr->len,
 			     NET_LINK_ETHERNET);
+
+	err = net_if_set_name(iface, CONFIG_SLIP_DRV_NAME);
+	if (err < 0) {
+		LOG_ERR("Could not set the interface name: %d", err);
+	}
 }
 
 

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -389,8 +389,6 @@ void slip_iface_init(struct net_if *iface)
 		return;
 	}
 
-	ll_addr = slip_get_mac(slip);
-
 	slip->init_done = true;
 	slip->iface = iface;
 
@@ -409,6 +407,7 @@ use_random_mac:
 		slip->mac_addr[4] = 0x53;
 		slip->mac_addr[5] = sys_rand8_get();
 	}
+	ll_addr = slip_get_mac(slip);
 	net_if_set_link_addr(iface, ll_addr->addr, ll_addr->len,
 			     NET_LINK_ETHERNET);
 }


### PR DESCRIPTION
These two patches fix two Kconfig initialization issues on the slip interface:

- The MAC address set in Kconfig was not being set;
- The interface name in Kconfig was not being set.
