### PR TITLE
samples: net: capture: avoid net_ip.h conflicts with CONFIG_NATIVE_LIBC

### DIFF
--- a/samples/net/capture/src/main.c
+++ b/samples/net/capture/src/main.c
@@ -8,7 +8,12 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_capture_sample, LOG_LEVEL_DBG);
 
+#if defined(CONFIG_NATIVE_LIBC)
+#define ARPHRD_CAN 280
+#define ARPHRD_PPP 512
+#else
 #include <zephyr/posix/net/if_arp.h>
+#endif
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/net/capture.h>


### PR DESCRIPTION
The net capture sample is likely one application that does rely on linking against the native C library rather than Picolibc, since it needs to hook into Linux's tun / tap interfaces.

However, after removing `<zephyr/posix/...h>` from the default search path, a number of conflicts appear between the native libc socket types and Zephyr's in `net_ip.h`.

Issue 97050 already captures this partially. However, there seems to be some confusion about POSIX headers and types and ISO C headers and types.

There are C libraries that do not include all of the necessary POSIX headers and types that Zephyr depends on. For example:

* minimal libc
* IAR
* newlib
* picolibc

The latter two might surprise some.

In any case, the work required to properly namespace `net_ip.h` constants and types is well out of the scope of the current release cycles, so this small workaround should suffice.

A non-exhaustive list of constants and types from `net_ip.h` that conflict with native types are

* PF_INET
* PF_INET6
* PF_PACKET
* PF_CAN
* PF_LOCAL
* SOCK_STREAM
* SOCK_DGRAM
* SOCK_RAW
* struct iovec
* struct msghdr
* struct cmsghdr
* struct sockaddr
* struct sockaddr_storage

A non-exhaustive list of errors that arise are of the form(s) below:
```shell
In file included from $HOME/../zephyr/net/ethernet.h:21,
                 from $HOME/../samples/net/capture/src/main.c:15:
../zephyr/net/net_ip.h:45: warning: "PF_INET" redefined
   45 | #define PF_INET      1     /**< IP protocol family version 4. */
      |
/usr/include/bits/socket.h:45: note: this is the location of the previous \
  definition
   45 | #define PF_INET         2       /* IP protocol family.  */
      |
In file included from /usr/include/bits/socket.h:38:
$HOME/zephyrproject/zephyr/include/zephyr/net/net_ip.h:89:9: error: \
  redeclaration of enumerator ‘SOCK_STREAM’
   89 |         SOCK_STREAM = 1,           /**< Stream socket type   */
      |         ^~~~~~~~~~~
/usr/include/bits/socket_type.h:26:3: note: previous definition of \
  ‘SOCK_STREAM’ with type ‘enum __socket_type’
   26 |   SOCK_STREAM = 1,              /* Sequenced, reliable,...
      |   ^~~~~~~~~~~
$HOME/zephyrproject/zephyr/include/zephyr/net/net_ip.h:250:8: error: \
  redefinition of ‘struct iovec’
  250 | struct iovec {
      |        ^~~~~
In file included from /usr/include/sys/socket.h:26:
/usr/include/bits/types/struct_iovec.h:26:8: note: originally defined here
   26 | struct iovec
      |        ^~~~~
```
https://github.com/zephyrproject-rtos/zephyr/actions/runs/18482839735/job/52660791882?pr=97152