### PR TITLE
tests: boards: nrf: hwinfo: Add latest reset causes

### DIFF
--- a/tests/boards/nrf/hwinfo/reset_cause/src/main.c
+++ b/tests/boards/nrf/hwinfo/reset_cause/src/main.c
@@ -134,6 +134,16 @@ static void print_supported_reset_cause(void)
 		} else {
 			LOG_INF("14: no support for RESET_TEMPERATURE");
 		}
+		if (supported & RESET_BOOTLOADER) {
+			LOG_INF("15: RESET_BOOTLOADER is supported");
+		} else {
+			LOG_INF("15: no support for RESET_BOOTLOADER");
+		}
+		if (supported & RESET_FLASH) {
+			LOG_INF("16: RESET_FLASH is supported");
+		} else {
+			LOG_INF("16: no support for RESET_FLASH");
+		}
 	} else if (ret == -ENOSYS) {
 		LOG_INF("hwinfo_get_supported_reset_cause() is NOT supported");
 		supported = 0;
@@ -196,6 +206,12 @@ static void print_current_reset_cause(uint32_t *cause)
 		}
 		if (*cause & RESET_TEMPERATURE) {
 			LOG_INF("14: reset due to RESET_TEMPERATURE");
+		}
+		if (*cause & RESET_BOOTLOADER) {
+			LOG_INF("15: reset due to RESET_BOOTLOADER");
+		}
+		if (*cause & RESET_FLASH) {
+			LOG_INF("16: reset due to RESET_FLASH");
 		}
 	} else if (ret == -ENOSYS) {
 		LOG_INF("hwinfo_get_reset_cause() is NOT supported");


### PR DESCRIPTION
Reset cause API was expanded with two more reset causes. These are RESET_BOOTLOADER and RESET_FLASH.

Add handling of RESET_BOOTLOADER and RESET_FLASH to reset_cause test.