### PR TITLE
dts: bindings: sensor: ti,ina226: Added missing enum

### DIFF
--- a/dts/bindings/sensor/ti,ina226.yaml
+++ b/dts/bindings/sensor/ti,ina226.yaml
@@ -47,6 +47,7 @@ properties:
       - "Shunt Voltage, Triggered"
       - "Bus Voltage, Triggered"
       - "Shunt and Bus, Triggered"
+      - "Power-Down (or Shutdown)_2"
       - "Shunt Voltage, Continuous"
       - "Bus Voltage, Continuous"
       - "Shunt and Bus, Continuous"

--- a/dts/bindings/sensor/ti,ina226.yaml
+++ b/dts/bindings/sensor/ti,ina226.yaml
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    TI INA226 Bidirectional Current and Power Monitor.
-    The <zephyr/dt-bindings/sensor/ina226.h> file should be included in the
-    DeviceTree as it provides macros that can be used for initializing the
-    configuration registers.
+  TI INA226 Bidirectional Current and Power Monitor.
+  The <zephyr/dt-bindings/sensor/ina226.h> file should be included in the
+  DeviceTree as it provides macros that can be used for initializing the
+  configuration registers.
 
 compatible: "ti,ina226"
 


### PR DESCRIPTION
- Removal of double enum (by me) caused later enum entries to have the wrong values
  - See commit 36abe5efecbc27963189880d7c426c50760bcd58
- Added the second power down state (but with different name) 
  -> This restores the old function but still fixes the double enum issue