### PR TITLE
host: gatt: Support deferred Read and Write Response handling.

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -62,6 +62,14 @@ New APIs and options
 
     * :c:func:`bt_gatt_cb_unregister` Added an API to unregister GATT callback handlers.
 
+    * :c:func:`bt_gatt_send_read_rsp`
+      Added an API to send deferred GATT Read Responses when an attribute
+      read handler returns ``-EINPROGRESS``.
+
+    * :c:func:`bt_gatt_send_write_rsp`
+      Added an API to send deferred GATT Write Responses when an attribute
+      write handler returns ``-EINPROGRESS``.
+
 ..
   Link to new APIs here, in a group if you think it's necessary, no need to get
   fancy just list the link, that should contain the documentation. If you feel

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -2077,7 +2077,7 @@ int bt_gatt_read(struct bt_conn *conn, struct bt_gatt_read_params *params);
  *  @param conn   Connection object.
  *  @param err    Error value created with BT_GATT_ERR() using a specific
  *                BT_ATT_ERR_* code, or 0 for success.
- *  @param attr   The attribute that's being read.
+ *  @param handle The attribute handle that's being read.
  *  @param data   Pointer to the attribute value buffer.
  *  @param length Length of the attribute value.
  *
@@ -2088,7 +2088,7 @@ int bt_gatt_read(struct bt_conn *conn, struct bt_gatt_read_params *params);
  *  @retval -ENOMEM Out of memory.
  *  @retval -ENOTSUP EATT deferred responses not supported.
  */
-int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr,
+int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, uint16_t handle,
 			      const void *data, uint16_t length);
 
 struct bt_gatt_write_params;
@@ -2153,7 +2153,7 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
  *  @param conn   Connection object.
  *  @param err    Error value created with BT_GATT_ERR() using a specific
  *                BT_ATT_ERR_* code, or 0 for success.
- *  @param attr  The attribute that's being written.
+ *  @param handle The attribute handle that's being written.
  *
  *  @retval 0 Successfully queued response.
  *
@@ -2162,7 +2162,7 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
  *  @retval -ENOMEM Out of memory.
  *  @retval -ENOTSUP EATT deferred responses not supported.
  */
-int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr);
+int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, uint16_t handle);
 
 /** @brief Write Attribute Value by handle without response with callback.
  *

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -156,6 +156,18 @@ struct bt_gatt_attr;
  *  @note The GATT server propagates the return value from this
  *  method back to the remote client.
  *
+ *  @note If this function returns ``-EINPROGRESS``, the read operation
+ *  is deferred and the application must later send the response
+ *  using @ref bt_gatt_send_read_rsp(). Deferred responses are only
+ *  supported when no EATT bearers are established for this connection.
+ *
+ *  @note The application must send the deferred response before the ATT
+ *  timeout expires, otherwise the bearer will be terminated.
+ *
+ *  @note The @p buf pointer is only valid for the duration of this call,
+ *  and must not be accessed after the function returns, even when
+ *  returning ``-EINPROGRESS``.
+ *
  *  @param conn   The connection that is requesting to read.
  *                NULL if local.
  *  @param attr   The attribute that's being read
@@ -198,6 +210,24 @@ typedef ssize_t (*bt_gatt_attr_read_func_t)(struct bt_conn *conn,
  *
  *  @note The GATT server propagates the return value from this
  *  method back to the remote client.
+ *
+ *  @note If this function returns ``-EINPROGRESS``, the write operation
+ *  is deferred and the application must later send the response using
+ *  @ref bt_gatt_send_write_rsp(). Deferred responses are only supported
+ *  for regular Write Requests; returning ``-EINPROGRESS`` is not valid
+ *  for Write Commands (@ref BT_GATT_WRITE_FLAG_CMD), Prepare Writes
+ *  (@ref BT_GATT_WRITE_FLAG_PREPARE), or Execute Writes
+ *  (@ref BT_GATT_WRITE_FLAG_EXECUTE).
+ *
+ *  @note Deferred write responses are only supported when no EATT bearers
+ *  are established for this connection.
+ *
+ *  @note The application must send the deferred response before the ATT
+ *  timeout expires, otherwise the bearer will be terminated.
+ *
+ *  @note The @p buf pointer is only valid for the duration of this call,
+ *  and must not be accessed after the function returns, even when
+ *  returning ``-EINPROGRESS``.
  *
  *  @param conn   The connection that is requesting to write
  *  @param attr   The attribute that's being written
@@ -2035,6 +2065,32 @@ struct bt_gatt_read_params {
  */
 int bt_gatt_read(struct bt_conn *conn, struct bt_gatt_read_params *params);
 
+/** @brief Send a deferred Read Response
+ *
+ *  Used when an attribute read request was deferred (attr->read returned
+ *  -EINPROGRESS). The application later completes the read operation
+ *  by providing either a value (success) or error code via this API.
+ *
+ *  Deferred responses are only supported when no EATT bearers are
+ *  established for this connection.
+ *
+ *  @param conn   Connection object.
+ *  @param err    Error value created with BT_GATT_ERR() using a specific
+ *                BT_ATT_ERR_* code, or 0 for success.
+ *  @param attr   The attribute that's being read.
+ *  @param data   Pointer to the attribute value buffer.
+ *  @param length Length of the attribute value.
+ *
+ *  @retval 0 Successfully queued response.
+ *
+ *  @retval -ENOTCONN The connection is not established.
+ *  @retval -EINVAL Invalid parameters.
+ *  @retval -ENOMEM Out of memory.
+ *  @retval -ENOTSUP EATT deferred responses not supported.
+ */
+int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr,
+			      const void *data, uint16_t length);
+
 struct bt_gatt_write_params;
 
 /** @typedef bt_gatt_write_func_t
@@ -2083,6 +2139,30 @@ struct bt_gatt_write_params {
  *  by @kconfig{CONFIG_BT_ATT_TX_COUNT}.
  */
 int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
+
+/**
+ *  @brief Send a deferred Write Response
+ *
+ *  Used when an attribute write request was deferred (attr->write returned
+ *  -EINPROGRESS). The application later completes the write operation
+ *  by providing either a success response or an error code via this API.
+ *
+ *  Deferred responses are only supported when no EATT bearers are
+ *  established for this connection.
+ *
+ *  @param conn   Connection object.
+ *  @param err    Error value created with BT_GATT_ERR() using a specific
+ *                BT_ATT_ERR_* code, or 0 for success.
+ *  @param attr  The attribute that's being written.
+ *
+ *  @retval 0 Successfully queued response.
+ *
+ *  @retval -ENOTCONN The connection is not established.
+ *  @retval -EINVAL Invalid parameters.
+ *  @retval -ENOMEM Out of memory.
+ *  @retval -ENOTSUP EATT deferred responses not supported.
+ */
+int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr);
 
 /** @brief Write Attribute Value by handle without response with callback.
  *

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1401,6 +1401,11 @@ static ssize_t att_chan_read(struct bt_att_chan *chan,
 
 		read = attr->read(conn, attr, frag->data + frag->len, len,
 				  offset);
+
+		if (read == -EINPROGRESS) {
+			return -EINPROGRESS;
+		}
+
 		if (read < 0) {
 			if (total) {
 				return total;
@@ -1586,6 +1591,7 @@ struct read_data {
 	uint16_t offset;
 	struct net_buf *buf;
 	uint8_t err;
+	bool async;
 };
 
 static uint8_t read_cb(const struct bt_gatt_attr *attr, uint16_t handle,
@@ -1618,6 +1624,12 @@ static uint8_t read_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 
 	/* Read attribute value and store in the buffer */
 	ret = att_chan_read(chan, attr, data->buf, data->offset, NULL, NULL);
+
+	if (ret == -EINPROGRESS) {
+		data->async = true;
+		return BT_GATT_ITER_STOP;
+	}
+
 	if (ret < 0) {
 		data->err = err_to_att(ret);
 		return BT_GATT_ITER_STOP;
@@ -1663,6 +1675,12 @@ static uint8_t att_read_rsp(struct bt_att_chan *chan, uint8_t op, uint8_t rsp,
 		net_buf_unref(data.buf);
 		/* Respond here since handle is set */
 		send_err_rsp(chan, op, handle, data.err);
+		return 0;
+	}
+
+	if (data.async) {
+		net_buf_unref(data.buf);
+		/* Async read: release buffer, app send response later */
 		return 0;
 	}
 
@@ -2029,6 +2047,7 @@ struct write_data {
 	uint16_t len;
 	uint16_t offset;
 	uint8_t err;
+	bool async;
 };
 
 static uint8_t write_cb(const struct bt_gatt_attr *attr, uint16_t handle,
@@ -2063,6 +2082,12 @@ static uint8_t write_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 	/* Write attribute value */
 	write = attr->write(data->conn, attr, data->value, data->len,
 			    data->offset, flags);
+
+	if (write == -EINPROGRESS) {
+		data->async = true;
+		return BT_GATT_ITER_STOP;
+	}
+
 	if (write < 0 || write != data->len) {
 		data->err = err_to_att(write);
 		return BT_GATT_ITER_STOP;
@@ -2119,6 +2144,12 @@ static uint8_t att_write_rsp(struct bt_att_chan *chan, uint8_t req, uint8_t rsp,
 			send_err_rsp(chan, req, handle, data.err);
 		}
 		return req == BT_ATT_OP_EXEC_WRITE_REQ ? data.err : 0;
+	}
+
+	if (data.async) {
+		net_buf_unref(data.buf);
+		/* Async write: release buffer, app send response later */
+		return 0;
 	}
 
 	if (data.buf) {

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -5168,7 +5168,7 @@ int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle,
 	return bt_att_send(conn, buf);
 }
 
-int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr,
+int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, uint16_t handle,
 			      const void *data, uint16_t length)
 {
 	struct net_buf *buf;
@@ -5179,7 +5179,6 @@ int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_at
 		sizeof(uint8_t);    /* ATT error code    */
 
 	__ASSERT(conn, "invalid connection\n");
-	__ASSERT(attr, "invalid parameter\n");
 	__ASSERT(err <= 0, "invalid error code\n");
 
 	if (conn->state != BT_CONN_CONNECTED) {
@@ -5202,11 +5201,11 @@ int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_at
 		}
 
 		net_buf_add_u8(buf, BT_ATT_OP_READ_REQ);
-		net_buf_add_le16(buf, attr->handle);
+		net_buf_add_le16(buf, handle);
 		net_buf_add_u8(buf, att_err);
 
 		LOG_DBG("conn %p error 0x%02x, handle 0x%04x",
-				conn, att_err, attr->handle);
+				conn, att_err, handle);
 
 		return bt_att_send(conn, buf);
 	}
@@ -5220,12 +5219,12 @@ int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_at
 		net_buf_add_mem(buf, data, length);
 	}
 
-	LOG_DBG("conn %p len %u, handle 0x%04x", conn, length, attr->handle);
+	LOG_DBG("conn %p len %u, handle 0x%04x", conn, length, handle);
 
 	return bt_att_send(conn, buf);
 }
 
-int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr)
+int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, uint16_t handle)
 {
 	struct net_buf *buf;
 	__maybe_unused uint8_t att_err;
@@ -5235,7 +5234,6 @@ int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_a
 		sizeof(uint8_t);    /* ATT error code    */
 
 	__ASSERT(conn, "invalid connection\n");
-	__ASSERT(attr, "invalid parameter\n");
 	__ASSERT(err <= 0, "invalid error code\n");
 
 	if (conn->state != BT_CONN_CONNECTED) {
@@ -5258,11 +5256,11 @@ int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_a
 		}
 
 		net_buf_add_u8(buf, BT_ATT_OP_WRITE_REQ);
-		net_buf_add_le16(buf, attr->handle);
+		net_buf_add_le16(buf, handle);
 		net_buf_add_u8(buf, att_err);
 
 		LOG_DBG("conn %p write err 0x%02x, handle 0x%04x",
-				conn, att_err, attr->handle);
+				conn, att_err, handle);
 
 		return bt_att_send(conn, buf);
 	}
@@ -5272,7 +5270,7 @@ int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_a
 		return -ENOMEM;
 	}
 
-	LOG_DBG("conn %p, handle 0x%04x", conn, attr->handle);
+	LOG_DBG("conn %p, handle 0x%04x", conn, handle);
 
 	return bt_att_send(conn, buf);
 }


### PR DESCRIPTION
Now stack handles read_request with a sync callback. It needs value and length to be returned right away.

This patch enhances the GATT server implementation to support deferred response handling for both Read and Write operations. It enables applications to perform long-running or context-dependent attribute operations without blocking the protocol layer.

Signed-off-by: Zhijie Zhong <zhongzhijie1@xiaomi.com>