### PR TITLE
MAINTAINERS: remove tomi-font from modem collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3387,8 +3387,6 @@ Modem:
   status: maintained
   maintainers:
     - bjarki-andreasen
-  collaborators:
-    - tomi-font
   files:
     - subsys/modem/
     - include/zephyr/modem/


### PR DESCRIPTION
Remove myself from this area. I'm not working with this anymore and I don't really have the bandwidth to properly review significant changes.