### PR TITLE
storage: flash_map: deprecate legacy Mbed TLS crypto

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -302,6 +302,14 @@ Cellular
  * :c:enum:`cellular_access_technology` values have been redefined to align with 3GPP TS 27.007.
  * :c:enum:`cellular_registration_status` values have been extended to align with 3GPP TS 27.007.
 
+Flash Map
+=========
+
+* With the long-term goal of transitioning to PSA Crypto API as the only crypto support in Zephyr,
+  :kconfig:option:`FLASH_AREA_CHECK_INTEGRITY_MBEDTLS` is deprecated.
+  :kconfig:option:`FLASH_AREA_CHECK_INTEGRITY_PSA` is now the default choice: if TF-M is not
+  enabled or not supported by the platform, Mbed TLS will be used as PSA Crypto API provider.
+
 Logging
 =======
 

--- a/subsys/storage/flash_map/Kconfig
+++ b/subsys/storage/flash_map/Kconfig
@@ -46,19 +46,20 @@ if FLASH_AREA_CHECK_INTEGRITY
 
 choice FLASH_AREA_CHECK_INTEGRITY_BACKEND
 	prompt "Crypto backend for the flash check functions"
-	default FLASH_AREA_CHECK_INTEGRITY_PSA if BUILD_WITH_TFM
-	default FLASH_AREA_CHECK_INTEGRITY_MBEDTLS if !BUILD_WITH_TFM
+	default FLASH_AREA_CHECK_INTEGRITY_PSA
 
 config FLASH_AREA_CHECK_INTEGRITY_PSA
 	bool "Use PSA"
 	select PSA_WANT_ALG_SHA_256
+	select PSA_CRYPTO
 	help
 	  Use the PSA API to perform the integrity check.
 
 config FLASH_AREA_CHECK_INTEGRITY_MBEDTLS
-	bool "Use Mbed TLS"
+	bool "Use Mbed TLS [DEPRECATED]"
 	select MBEDTLS
 	select MBEDTLS_SHA256
+	select DEPRECATED
 	help
 	  Use the Mbed TLS library to perform the integrity check.
 


### PR DESCRIPTION
The long-term goal of the Zephyr project is to rely exclusively on PSA Crypto API for the crypto support. In parallel Mbed TLS is going to remove legacy crypto support from the next (4.0) release.

Therefore this PR deprecates CONFIG_FLASH_AREA_CHECK_INTEGRITY_MBEDTLS and it also updates the migration guide document about this change.