### PR TITLE
add ENET ethernet support on i.MX 91 FRDM board

### DIFF
--- a/boards/nxp/frdm_imx91/frdm_imx91-pinctrl.dtsi
+++ b/boards/nxp/frdm_imx91/frdm_imx91-pinctrl.dtsi
@@ -236,4 +236,40 @@
 			bias-pull-up;
 		};
 	};
+
+	pinmux_mdio: pinmux_mdio {
+		group0 {
+			pinmux = <&iomuxc1_enet2_mdc_enet_mdc_enet2_mdc>,
+				 <&iomuxc1_enet2_mdio_enet_mdio_enet2_mdio>;
+			bias-pull-down;
+			slew-rate = "slightly_fast";
+			drive-strength = "x6";
+		};
+	};
+
+	pinmux_enet: pinmux_enet {
+		group0 {
+			pinmux = <&iomuxc1_enet2_rd0_enet_rgmii_rd_enet2_rgmii_rd0>,
+				 <&iomuxc1_enet2_rd1_enet_rgmii_rd_enet2_rgmii_rd1>,
+				 <&iomuxc1_enet2_rd2_enet_rgmii_rd_enet2_rgmii_rd2>,
+				 <&iomuxc1_enet2_rd3_enet_rgmii_rd_enet2_rgmii_rd3>,
+				 <&iomuxc1_enet2_rx_ctl_enet_rgmii_rx_ctl_enet2_rgmii_rx_ctl>,
+				 <&iomuxc1_enet2_td0_enet_rgmii_td_enet2_rgmii_td0>,
+				 <&iomuxc1_enet2_td1_enet_rgmii_td_enet2_rgmii_td1>,
+				 <&iomuxc1_enet2_td2_enet_rgmii_td_enet2_rgmii_td2>,
+				 <&iomuxc1_enet2_td3_enet_rgmii_td_enet2_rgmii_td3>,
+				 <&iomuxc1_enet2_tx_ctl_enet_rgmii_tx_ctl_enet2_rgmii_tx_ctl>;
+			bias-pull-down;
+			slew-rate = "slightly_fast";
+			drive-strength = "x6";
+		};
+
+		group1 {
+			pinmux = <&iomuxc1_enet2_rxc_enet_rgmii_rxc_enet2_rgmii_rxc>,
+				 <&iomuxc1_enet2_txc_enet_rgmii_txc_enet2_rgmii_txc>;
+			bias-pull-down;
+			slew-rate = "fast";
+			drive-strength = "x6";
+		};
+	};
 };

--- a/boards/nxp/frdm_imx91/frdm_imx91_mimx9131.dts
+++ b/boards/nxp/frdm_imx91/frdm_imx91_mimx9131.dts
@@ -87,3 +87,30 @@
 		status = "disabled";
 	};
 };
+
+&enet {
+	status = "okay";
+};
+
+&enet_mac {
+	pinctrl-0 = <&pinmux_enet>;
+	pinctrl-names = "default";
+	phy-handle = <&phy>;
+	zephyr,random-mac-address;
+	phy-connection-type = "rgmii";
+	status = "okay";
+};
+
+&enet_mdio {
+	pinctrl-0 = <&pinmux_mdio>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	phy: phy@2 {
+		compatible = "motorcomm,yt8521";
+		reg = <2>;
+		status = "okay";
+		motorcomm,rx-delay-sel = <13>;
+		motorcomm,tx-delay-sel = <13>;
+	};
+};

--- a/boards/nxp/frdm_imx91/frdm_imx91_mimx9131.yaml
+++ b/boards/nxp/frdm_imx91/frdm_imx91_mimx9131.yaml
@@ -14,5 +14,6 @@ toolchain:
 ram: 1024
 supported:
   - counter
+  - net
   - uart
 vendor: nxp

--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -28,7 +28,7 @@ static int mcux_ccm_on(const struct device *dev,
 	switch (peripheral) {
 #ifdef CONFIG_ETH_NXP_ENET
 
-#ifdef CONFIG_SOC_MIMX9352
+#if defined(CONFIG_SOC_MIMX9352) || defined(CONFIG_SOC_MIMX9131)
 #define ENET1G_CLOCK	kCLOCK_Enet1
 #else
 #define ENET_CLOCK	kCLOCK_Enet
@@ -192,7 +192,7 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 #ifdef CONFIG_ETH_NXP_ENET
 	case IMX_CCM_ENET_CLK:
 	case IMX_CCM_ENET1G_CLK:
-#ifdef CONFIG_SOC_MIMX9352
+#if defined(CONFIG_SOC_MIMX9352) || defined(CONFIG_SOC_MIMX9131)
 		clock_root = kCLOCK_Root_WakeupAxi;
 #else
 		clock_root = kCLOCK_Root_Bus;

--- a/dts/arm64/nxp/nxp_mimx9131.dtsi
+++ b/dts/arm64/nxp/nxp_mimx9131.dtsi
@@ -300,6 +300,38 @@
 		status = "disabled";
 	};
 
+	enet: enet@42890000 {
+		compatible = "nxp,enet1g";
+		reg = <0x42890000 DT_SIZE_K(64)>;
+		clocks = <&ccm IMX_CCM_ENET_CLK 0 0>;
+		status = "disabled";
+
+		enet_mac: ethernet {
+			compatible = "nxp,enet-mac";
+			interrupts = <GIC_SPI 181 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "COMMON";
+			interrupt-parent = <&gic>;
+			nxp,mdio = <&enet_mdio>;
+			ptp-clock = <&enet_ptp_clock>;
+			status = "disabled";
+		};
+
+		enet_mdio: mdio {
+			compatible = "nxp,enet-mdio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		enet_ptp_clock: ptp_clock {
+			compatible = "nxp,enet-ptp-clock";
+			interrupts = <GIC_SPI 182 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-parent = <&gic>;
+			clocks = <&ccm IMX_CCM_ENET_PLL 0 0>;
+			status = "disabled";
+		};
+	};
+
 	tpm1: tpm@44310000 {
 		compatible = "nxp,tpm-timer";
 		reg = <0x44310000 DT_SIZE_K(64)>;


### PR DESCRIPTION
Depends on https://github.com/zephyrproject-rtos/hal_nxp/pull/622 (merged)
based on: https://github.com/zephyrproject-rtos/zephyr/pull/97535