### PR TITLE
manifest: update EDTT to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -134,7 +134,7 @@ manifest:
       groups:
         - hal
     - name: edtt
-      revision: b9ca3c7030518f07b7937dacf970d37a47865a76
+      revision: c282625e694f0b53ea53e13231ea6d2f49411768
       path: tools/edtt
       groups:
         - tools


### PR DESCRIPTION
Update the HW models module to:
c282625e694f0b53ea53e13231ea6d2f49411768

Including the following:
c282625 Fix broken link in Readme.md