### PR TITLE
bluetooth: mesh: Fix build without settings under asan

### DIFF
--- a/subsys/bluetooth/mesh/app_keys.c
+++ b/subsys/bluetooth/mesh/app_keys.c
@@ -666,6 +666,10 @@ static int app_key_set(const char *name, size_t len_rd,
 	uint16_t app_idx;
 	int err;
 
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
 	if (!name) {
 		LOG_ERR("Insufficient number of arguments");
 		return -ENOENT;

--- a/subsys/bluetooth/mesh/brg_cfg.c
+++ b/subsys/bluetooth/mesh/brg_cfg.c
@@ -52,6 +52,10 @@ static int brg_en_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 {
 	int err;
 
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
 	if (len_rd == 0) {
 		brg_enabled = 0;
 		LOG_DBG("Cleared bridge enable state");

--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -180,6 +180,10 @@ static int cdb_net_set(const char *name, size_t len_rd,
 	struct net_val net;
 	int err;
 
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
 	if (len_rd == 0) {
 		LOG_DBG("val (null)");
 		return 0;
@@ -218,6 +222,10 @@ static int cdb_node_set(const char *name, size_t len_rd,
 	struct bt_mesh_key tmp;
 	uint16_t addr;
 	int err;
+
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
 
 	if (!name) {
 		LOG_ERR("Insufficient number of arguments");
@@ -280,6 +288,10 @@ static int cdb_subnet_set(const char *name, size_t len_rd,
 	struct bt_mesh_key tmp[2];
 	uint16_t net_idx;
 	int err;
+
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
 
 	if (!name) {
 		LOG_ERR("Insufficient number of arguments");
@@ -346,6 +358,10 @@ static int cdb_app_key_set(const char *name, size_t len_rd,
 	struct bt_mesh_key tmp[2];
 	uint16_t app_idx;
 	int err;
+
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
 
 	if (!name) {
 		LOG_ERR("Insufficient number of arguments");

--- a/subsys/bluetooth/mesh/cfg.c
+++ b/subsys/bluetooth/mesh/cfg.c
@@ -429,6 +429,10 @@ static int cfg_set(const char *name, size_t len_rd,
 	struct cfg_val cfg;
 	int err;
 
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
 	if (len_rd == 0) {
 		LOG_DBG("Cleared configuration state");
 		return 0;

--- a/subsys/bluetooth/mesh/heartbeat.c
+++ b/subsys/bluetooth/mesh/heartbeat.c
@@ -416,6 +416,10 @@ static int hb_pub_set(const char *name, size_t len_rd,
 	struct hb_pub_val hb_val;
 	int err;
 
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
 	err = bt_mesh_settings_set(read_cb, cb_arg, &hb_val, sizeof(hb_val));
 	if (err) {
 		LOG_ERR("Failed to set \'hb_val\'");

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -1005,6 +1005,10 @@ static int net_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	struct bt_mesh_key key;
 	int err;
 
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
 	if (len_rd == 0) {
 		LOG_DBG("val (null)");
 
@@ -1042,6 +1046,10 @@ static int iv_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	struct iv_val iv;
 	int err;
 
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
 	if (len_rd == 0) {
 		LOG_DBG("IV deleted");
 
@@ -1073,6 +1081,10 @@ static int seq_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 {
 	struct seq_val seq;
 	int err;
+
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
 
 	if (len_rd == 0) {
 		LOG_DBG("val (null)");
@@ -1112,6 +1124,10 @@ static int dev_key_cand_set(const char *name, size_t len_rd, settings_read_cb re
 {
 	int err;
 	struct bt_mesh_key key;
+
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
 
 	if (len_rd == 0) {
 		LOG_DBG("val (null)");

--- a/subsys/bluetooth/mesh/rpl.c
+++ b/subsys/bluetooth/mesh/rpl.c
@@ -272,6 +272,10 @@ static int rpl_set(const char *name, size_t len_rd,
 	int err;
 	uint16_t src;
 
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
 	if (!name) {
 		LOG_ERR("Insufficient number of arguments");
 		return -ENOENT;

--- a/subsys/bluetooth/mesh/solicitation.c
+++ b/subsys/bluetooth/mesh/solicitation.c
@@ -120,6 +120,10 @@ static int sseq_set(const char *name, size_t len_rd,
 {
 	int err;
 
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
 	err = bt_mesh_settings_set(read_cb, cb_arg, &sseq_out, sizeof(sseq_out));
 	if (err) {
 		LOG_ERR("Failed to set \'sseq\'");
@@ -363,6 +367,10 @@ static int srpl_set(const char *name, size_t len_rd,
 			LOG_ERR("Unable to allocate SRPL entry for 0x%04x", ssrc);
 			return -ENOMEM;
 		}
+	}
+
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
 	}
 
 	err = bt_mesh_settings_set(read_cb, cb_arg, &sseq, sizeof(sseq));

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -971,6 +971,10 @@ static int net_key_set(const char *name, size_t len_rd,
 	int err;
 	uint16_t net_idx;
 
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
 	if (!name) {
 		LOG_ERR("Insufficient number of arguments");
 		return -ENOENT;

--- a/subsys/bluetooth/mesh/va.c
+++ b/subsys/bluetooth/mesh/va.c
@@ -219,6 +219,10 @@ static int va_set(const char *name, size_t len_rd,
 	uint16_t index;
 	int err;
 
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
 	if (!name) {
 		LOG_ERR("Insufficient number of arguments");
 		return -ENOENT;


### PR DESCRIPTION
When Mesh is built without CONFIG_BT_SETTINGS and with CONFIG_ASAN (and CONFIG_NO_OPTIMIZATION), the call to bt_mesh_settings_set is not optimized out. Since settings.c isn’t compiled when CONFIG_BT_SETTINGS is disabled, the linker reports an undefined reference.

Guard the call with !IS_ENABLED(CONFIG_BT_SETTINGS) so the call and the subsequent code is compiled out when settings are disabled.