### PR TITLE
modules: simplelink: select necessary POSIX kconfig dependencies

### DIFF
--- a/modules/Kconfig.simplelink
+++ b/modules/Kconfig.simplelink
@@ -7,13 +7,16 @@ config HAS_CC3220SDK
 # SimpleLink drivers require types (stdint.h) from c library which is not
 # provided by minimal lbc
 # Selecting ERRNO lets host driver use Zephyr's __errno
-# Selecting POSIX_THREADS and POSIX_API are needed to build the host driver
+# Selecting POSIX_SEMAPHORES, POSIX_THREADS, POSIX_TIMERS, and POSIX_SYSTEM_INTERFACES which are
+# needed to build the host driver
 config SIMPLELINK_HOST_DRIVER
 	bool "Build the SimpleLink WiFi Host Driver"
 	depends on HAS_CC3220SDK
 	depends on MULTITHREADING
 	select REQUIRES_FULL_LIBC
 	select ERRNO
+	select POSIX_SYSTEM_INTERFACES
+	select POSIX_SEMAPHORES
 	select POSIX_THREADS
 	select POSIX_TIMERS
 	help

--- a/modules/Kconfig.simplelink
+++ b/modules/Kconfig.simplelink
@@ -4,8 +4,6 @@ config HAS_CC3220SDK
 	bool
 
 # Notes:
-# SimpleLink drivers require types (stdint.h) from c library which is not
-# provided by minimal lbc
 # Selecting ERRNO lets host driver use Zephyr's __errno
 # Selecting POSIX_SEMAPHORES, POSIX_THREADS, POSIX_TIMERS, and POSIX_SYSTEM_INTERFACES which are
 # needed to build the host driver
@@ -13,7 +11,6 @@ config SIMPLELINK_HOST_DRIVER
 	bool "Build the SimpleLink WiFi Host Driver"
 	depends on HAS_CC3220SDK
 	depends on MULTITHREADING
-	select REQUIRES_FULL_LIBC
 	select ERRNO
 	select POSIX_SYSTEM_INTERFACES
 	select POSIX_SEMAPHORES


### PR DESCRIPTION
* modules: simplelink: select necessary POSIX kconfig dependencies
* modules: simplelink: remove unneeded REQUIRES_FULL_LIBC

This fixes a build issue in CI
https://github.com/zephyrproject-rtos/zephyr/actions/runs/18523743005/job/52789581990