### PR TITLE
modules: mbedtls: Fix build with address sanitizer and size opt

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -125,11 +125,11 @@ zephyr_interface_library_named(mbedTLS)
     zephyr_library_sources_ifdef(CONFIG_MBEDTLS_SHELL shell.c)
 
     zephyr_library_app_memory(k_mbedtls_partition)
-    if(CONFIG_ARCH_POSIX AND CONFIG_ASAN AND NOT CONFIG_64BIT)
+    if(CONFIG_ARCH_POSIX AND CONFIG_ASAN AND NOT CONFIG_64BIT AND NOT CONFIG_NO_OPTIMIZATIONS)
       # i386 assembly code used in MBEDTLS does not compile with size optimization
       # if address sanitizer is enabled, as such switch default optimization level
       # to speed
-      set_property(SOURCE ${ZEPHYR_CURRENT_MODULE_DIR}/mbedtls/library/bignum.c APPEND PROPERTY COMPILE_OPTIONS
+      set_property(SOURCE ${ZEPHYR_CURRENT_MODULE_DIR}/library/bignum_core.c APPEND PROPERTY COMPILE_OPTIONS
           "${COMPILER_OPTIMIZE_FOR_SPEED_FLAG}")
     endif ()
 


### PR DESCRIPTION
When building with the address sanitizer and size optimizations some of the mbedtls assembler fails to build, with an error like:
`error: ‘asm’ operand has impossible constraints or there are not enough registers`

Avoid this issue by forcing speed optimizations for this problematic file if any optimization is chosen.

A similar fix was originally introduced in the module: https://github.com/zephyrproject-rtos/mbedtls/commit/4f1e8f5a78d 
but it seems to have stopped working when the content of the file was moved.

-----

Failure can be seen in https://github.com/zephyrproject-rtos/zephyr/actions/runs/18528101219/job/52804304523?pr=97619#step:13:322
