### PR TITLE
subsys: instrumentation: support dynamic triggers

### DIFF
--- a/include/zephyr/instrumentation/instrumentation.h
+++ b/include/zephyr/instrumentation/instrumentation.h
@@ -82,6 +82,13 @@ bool instr_tracing_supported(void);
 bool instr_profiling_supported(void);
 
 /**
+ * @brief Checks if dynamic trigger configuration feature is available.
+ *
+ * @return true if dynamic trigger is supported, false otherwise.
+ */
+bool instr_dynamic_trigger_supported(void);
+
+/**
  * @brief Checks if subsystem is ready to be initialized. Must called be before
  *        instr_init().
  */

--- a/subsys/instrumentation/Kconfig
+++ b/subsys/instrumentation/Kconfig
@@ -6,11 +6,6 @@
 config INSTRUMENTATION
 	bool "Compiler Instrumentation Support"
 	select REBOOT
-	select RETAINED_MEM
-	select RETAINED_MEM_ZEPHYR_RAM
-	select RETAINED_MEM_MUTEX_FORCE_DISABLE
-	select RETENTION
-	select RETENTION_MUTEX_FORCE_DISABLE
 	select UART_INTERRUPT_DRIVEN
 	help
 	  Enable compiler-managed runtime system instrumentation. This requires
@@ -89,16 +84,29 @@ config INSTRUMENTATION_TRIGGER_FUNCTION
 	default "main"
 	help
 	  Sets the trigger function. Instrumentation (tracing and profiling) is
-	  only turned on when the trigger function is called. The trigger
-	  function can be changed at runtime via the 'zaru' CLI tool.
+	  only turned on when the trigger function is called.
 
 config INSTRUMENTATION_STOPPER_FUNCTION
 	string "Default stopper function used to turn off instrumentation"
 	default "main"
 	help
 	  Sets the stopper function. Instrumentation (tracing and profiling) is
-	  only turned off when the trigger function returns. The stopper
-	  function can be changed at runtime via the 'zaru' CLI tool.
+	  only turned off when the stopper function returns.
+
+config INSTRUMENTATION_DYNAMIC_TRIGGER
+	bool "Dynamic trigger/stopper functions configuration"
+	select RETAINED_MEM
+	select RETAINED_MEM_ZEPHYR_RAM
+	select RETAINED_MEM_MUTEX_FORCE_DISABLE
+	select RETENTION
+	select RETENTION_MUTEX_FORCE_DISABLE
+	default y
+	help
+	  Enables configuration of trigger/stopper functions in runtime.
+	  Enabling this option requires configuration of the 'instrumentation_triggers'
+	  retained memory region in the device tree. When enabled, trigger/stopper
+	  functions can be changed at runtime via the 'zaru' CLI tool.
+
 
 config INSTRUMENTATION_EXCLUDE_FUNCTION_LIST
 	string "Exclude function list"

--- a/subsys/instrumentation/common/instr_common.c
+++ b/subsys/instrumentation/common/instr_common.c
@@ -36,8 +36,10 @@
  *
  */
 
+#if defined(CONFIG_INSTRUMENTATION_DYNAMIC_TRIGGER)
 const struct device *instrumentation_triggers =
 	DEVICE_DT_GET(DT_NODELABEL(instrumentation_triggers));
+#endif
 
 static bool _instr_initialized;
 static bool _instr_enabled;
@@ -46,6 +48,7 @@ static bool _instr_tracing_disabled;
 static bool _instr_profiling_disabled;
 static bool _instr_tracing_supported = IS_ENABLED(CONFIG_INSTRUMENTATION_MODE_CALLGRAPH);
 static bool _instr_profiling_supported = IS_ENABLED(CONFIG_INSTRUMENTATION_MODE_STATISTICAL);
+static bool _instr_dynamic_trigger_supported = IS_ENABLED(CONFIG_INSTRUMENTATION_DYNAMIC_TRIGGER);
 
 #if defined(CONFIG_INSTRUMENTATION_MODE_STATISTICAL)
 /*
@@ -100,6 +103,11 @@ bool instr_profiling_supported(void)
 	return _instr_profiling_supported;
 }
 
+bool instr_dynamic_trigger_supported(void)
+{
+	return _instr_dynamic_trigger_supported;
+}
+
 __no_instrumentation__
 int instr_init(void)
 {
@@ -116,6 +124,7 @@ int instr_init(void)
 	 */
 	_instr_initialized = 1;
 
+#if defined(CONFIG_INSTRUMENTATION_DYNAMIC_TRIGGER)
 	if (retention_is_valid(instrumentation_triggers)) {
 		/* Retained mem is already initialized, load trigger and stopper addresses */
 		retention_read(instrumentation_triggers, 0, (uint8_t *)&trigger_callee,
@@ -131,6 +140,10 @@ int instr_init(void)
 		retention_write(instrumentation_triggers, sizeof(trigger_callee),
 				(const uint8_t *)&stopper_callee, sizeof(stopper_callee));
 	}
+#else
+	trigger_callee = k_trigger_callee;
+	stopper_callee = k_stopper_callee;
+#endif
 
 #if defined(CONFIG_INSTRUMENTATION_MODE_CALLGRAPH)
 	/* Initialize ring buffer */
@@ -246,8 +259,10 @@ void instr_set_trigger_func(void *callee)
 	/* Update trigger_callee before updating retained mem */
 	trigger_callee = callee;
 
+#if defined(CONFIG_INSTRUMENTATION_DYNAMIC_TRIGGER)
 	retention_write(instrumentation_triggers, 0, (const uint8_t *)&trigger_callee,
 			sizeof(trigger_callee));
+#endif
 }
 
 __no_instrumentation__
@@ -256,8 +271,10 @@ void instr_set_stop_func(void *callee)
 	/* Update stopper_callee before updating retained mem */
 	stopper_callee = callee;
 
+#if defined(CONFIG_INSTRUMENTATION_DYNAMIC_TRIGGER)
 	retention_write(instrumentation_triggers, sizeof(trigger_callee),
 			(const uint8_t *)&stopper_callee, sizeof(stopper_callee));
+#endif
 }
 
 __no_instrumentation__

--- a/subsys/instrumentation/transport/uart.c
+++ b/subsys/instrumentation/transport/uart.c
@@ -27,7 +27,8 @@ void handle_cmd(char *cmd, uint32_t length)
 	if (strncmp("reboot", cmd, length) == 0) {
 		sys_reboot(SYS_REBOOT_COLD);
 	} else if (strncmp("status", cmd, length) == 0) {
-		printk("%d %d\n", instr_tracing_supported(), instr_profiling_supported());
+		printk("%d %d %d\n", instr_tracing_supported(), instr_profiling_supported(),
+		       instr_dynamic_trigger_supported());
 	} else if (strncmp("ping", cmd, length) == 0) {
 		printk("pong\n");
 	} else if (strncmp("dump_trace", cmd, length) == 0) {


### PR DESCRIPTION
This PR adds dynamic trigger support to the instrumentation subsystem.

This makes using instrumentation with any sample/board combination much easier, as it eliminates the need to define a custom dt overlay. Trigger/stopper functions need to be configured at build time.