### PR TITLE
samples: net: capture: use EXTRA_CONF_FILE for native_sim

### DIFF
--- a/samples/net/capture/README.rst
+++ b/samples/net/capture/README.rst
@@ -31,10 +31,17 @@ Build the sample application like this:
 .. zephyr-app-commands::
    :zephyr-app: samples/net/capture
    :board: <board to use>
-   :conf: <config file to use>
    :goals: build
    :compact:
 
+Example building for :zephyr:board:`native_sim`:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/net/capture
+   :board: native_sim
+   :gen-args: -DEXTRA_CONF_FILE=overlay-tunnel.conf
+   :goals: build
+   :compact:
 
 Network Configuration
 *********************


### PR DESCRIPTION
The generated docs for building this sample suggested using `-DCONF_FILE=overlay-tunnel.conf`, but that was just an artifact of using the `:conf:` directive in the kind of generic app-command.

Without specifying `-DEXTRA_CONF_FILE=overlay-tunnel.conf`, which also pulls in `prj.conf`, there were a few build errors.

Update the docu to provide a concrete example of building for `native_sim` with `:gen-args: -DEXTRA_CONF_FILE=overlay-tunnel.conf`.