### PR TITLE
drivers: clock: stm32: Move the MSI init after the LSE init

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -924,37 +924,6 @@ static void set_up_fixed_clock_sources(void)
 #endif
 	}
 
-#if defined(STM32_MSI_ENABLED)
-	if (IS_ENABLED(STM32_MSI_ENABLED)) {
-		/* Set MSI Range */
-#if defined(RCC_CR_MSIRGSEL)
-		LL_RCC_MSI_EnableRangeSelection();
-#endif /* RCC_CR_MSIRGSEL */
-
-#if defined(CONFIG_SOC_SERIES_STM32L0X) || defined(CONFIG_SOC_SERIES_STM32L1X)
-		LL_RCC_MSI_SetRange(STM32_MSI_RANGE << RCC_ICSCR_MSIRANGE_Pos);
-#else
-		LL_RCC_MSI_SetRange(STM32_MSI_RANGE << RCC_CR_MSIRANGE_Pos);
-#endif /* CONFIG_SOC_SERIES_STM32L0X || CONFIG_SOC_SERIES_STM32L1X */
-
-#if STM32_MSI_PLL_MODE
-		/* Enable MSI hardware auto calibration */
-		LL_RCC_MSI_EnablePLLMode();
-#endif
-
-		LL_RCC_MSI_SetCalibTrimming(0);
-
-		/* Enable MSI if not enabled */
-		if (LL_RCC_MSI_IsReady() != 1) {
-			/* Enable MSI */
-			LL_RCC_MSI_Enable();
-			while (LL_RCC_MSI_IsReady() != 1) {
-				/* Wait for MSI ready */
-			}
-		}
-	}
-#endif /* STM32_MSI_ENABLED */
-
 	if (IS_ENABLED(STM32_LSI_ENABLED)) {
 #if defined(CONFIG_SOC_SERIES_STM32WBX)
 		LL_RCC_LSI1_Enable();
@@ -1001,6 +970,37 @@ static void set_up_fixed_clock_sources(void)
 
 		z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 	}
+
+#if defined(STM32_MSI_ENABLED)
+	if (IS_ENABLED(STM32_MSI_ENABLED)) {
+		/* Set MSI Range */
+#if defined(RCC_CR_MSIRGSEL)
+		LL_RCC_MSI_EnableRangeSelection();
+#endif /* RCC_CR_MSIRGSEL */
+
+#if defined(CONFIG_SOC_SERIES_STM32L0X) || defined(CONFIG_SOC_SERIES_STM32L1X)
+		LL_RCC_MSI_SetRange(STM32_MSI_RANGE << RCC_ICSCR_MSIRANGE_Pos);
+#else
+		LL_RCC_MSI_SetRange(STM32_MSI_RANGE << RCC_CR_MSIRANGE_Pos);
+#endif /* CONFIG_SOC_SERIES_STM32L0X || CONFIG_SOC_SERIES_STM32L1X */
+
+#if STM32_MSI_PLL_MODE
+		/* Enable MSI hardware auto calibration */
+		LL_RCC_MSI_EnablePLLMode();
+#endif
+
+		LL_RCC_MSI_SetCalibTrimming(0);
+
+		/* Enable MSI if not enabled */
+		if (LL_RCC_MSI_IsReady() != 1) {
+			/* Enable MSI */
+			LL_RCC_MSI_Enable();
+			while (LL_RCC_MSI_IsReady() != 1) {
+				/* Wait for MSI ready */
+			}
+		}
+	}
+#endif /* STM32_MSI_ENABLED */
 
 #if defined(STM32_HSI14_ENABLED)
 	/* For all series with HSI 14 clock support */

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -569,6 +569,10 @@
 #define STM32_MSI_PLL_MODE	DT_PROP(DT_NODELABEL(clk_msi), msi_pll_mode)
 #endif
 
+#if defined(CONFIG_SOC_SERIES_STM32L4X) && STM32_MSI_PLL_MODE && !STM32_LSE_ENABLED
+#error "On STM32L4 series, MSI PLL mode requires LSE to be enabled"
+#endif
+
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_msis), st_stm32u5_msi_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_msis), st_stm32u3_msi_clock, okay)
 #define STM32_MSIS_ENABLED	1


### PR DESCRIPTION
Moved the MSI init after the LSE init to respect the initialization flow of the MSI PLL mode that need LSE to be enabled and ready
see the [RM0394 - STM32L41xxx/42xxx/43xxx/44xxx/45xxx/46xxx advanced Arm®-based 32-bit MCUs](https://www.st.com/resource/en/reference_manual/rm0394-stm32l41xxx42xxx43xxx44xxx45xxx46xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)
>Bit 2 MSIPLLEN: MSI clock PLL enable
Set and cleared by software to enable/ disable the PLL part of the MSI clock source.
MSIPLLEN must be enabled after LSE is enabled (LSEON enabled) and ready (LSERDY set
by hardware).There is a hardware protection to avoid enabling MSIPLLEN if LSE is not
ready.
This bit is cleared by hardware when LSE is disabled (LSEON = 0) or when the Clock
Security System on LSE detects a LSE failure (refer to RCC_CSR register).
0: MSI PLL OFF
1: MSI PLL ON

Also added a check before enabling PLL Mode for MSI by making sure LSE is ready.

Fixes #96849 