### PR TITLE
boards: st: address recent OpenOCD deprecation of HLA interface

### DIFF
--- a/boards/st/b_l072z_lrwan1/support/openocd.cfg
+++ b/boards/st/b_l072z_lrwan1/support/openocd.cfg
@@ -1,6 +1,14 @@
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
 
-transport select hla_swd
+# If you use an OpenOCD version higher than 0.12.0 and your target embeds
+# an ST-Link firmware earlier than v2j24, connection will not work.
+# It is recommended to upgrade the ST-Link firmware of the target,
+# however, if not possible, the 2 lines above can be replaced with the
+# following to connect successfully:
+#
+# source [find interface/stlink-hla.cfg]
+# transport select hla_swd
 
 set WORKAREASIZE 0x2000
 

--- a/boards/st/nucleo_g070rb/support/openocd.cfg
+++ b/boards/st/nucleo_g070rb/support/openocd.cfg
@@ -1,7 +1,1 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32g0x.cfg]
-
-reset_config srst_only
+source [find board/st_nucleo_g0.cfg]

--- a/boards/st/nucleo_g071rb/support/openocd.cfg
+++ b/boards/st/nucleo_g071rb/support/openocd.cfg
@@ -1,7 +1,1 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32g0x.cfg]
-
-reset_config srst_only
+source [find board/st_nucleo_g0.cfg]

--- a/boards/st/nucleo_g0b1re/support/openocd.cfg
+++ b/boards/st/nucleo_g0b1re/support/openocd.cfg
@@ -1,7 +1,1 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32g0x.cfg]
-
-reset_config srst_only
+source [find board/st_nucleo_g0.cfg]

--- a/boards/st/nucleo_g431kb/support/openocd.cfg
+++ b/boards/st/nucleo_g431kb/support/openocd.cfg
@@ -1,7 +1,1 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32g4x.cfg]
-
-reset_config srst_only
+source [find board/st_nucleo_g4.cfg]

--- a/boards/st/nucleo_g431rb/support/openocd.cfg
+++ b/boards/st/nucleo_g431rb/support/openocd.cfg
@@ -1,7 +1,1 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32g4x.cfg]
-
-reset_config srst_only
+source [find board/st_nucleo_g4.cfg]

--- a/boards/st/nucleo_g474re/support/openocd.cfg
+++ b/boards/st/nucleo_g474re/support/openocd.cfg
@@ -1,7 +1,1 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32g4x.cfg]
-
-reset_config srst_only
+source [find board/st_nucleo_g4.cfg]

--- a/boards/st/nucleo_l011k4/support/openocd.cfg
+++ b/boards/st/nucleo_l011k4/support/openocd.cfg
@@ -1,8 +1,17 @@
 # This is an ST NUCLEO-L011K4 board with single STM32L011K4 chip.
 # https://www.st.com/en/evaluation-tools/nucleo-l011k4.html
-source [find interface/stlink.cfg]
 
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+
+# If you use an OpenOCD version higher than 0.12.0 and your target embeds
+# an ST-Link firmware earlier than v2j24, connection will not work.
+# It is recommended to upgrade the ST-Link firmware of the target,
+# however, if not possible, the 2 lines above can be replaced with the
+# following to connect successfully:
+#
+# source [find interface/stlink-hla.cfg]
+# transport select hla_swd
 
 #set WORKAREASIZE 0x2000
 

--- a/boards/st/nucleo_l031k6/support/openocd.cfg
+++ b/boards/st/nucleo_l031k6/support/openocd.cfg
@@ -1,8 +1,17 @@
 # This is an ST NUCLEO-L031K6 board with single STM32L031K6 chip.
 # https://www.st.com/en/evaluation-tools/nucleo-l031k6.html
-source [find interface/stlink.cfg]
 
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+
+# If you use an OpenOCD version higher than 0.12.0 and your target embeds
+# an ST-Link firmware earlier than v2j24, connection will not work.
+# It is recommended to upgrade the ST-Link firmware of the target,
+# however, if not possible, the 2 lines above can be replaced with the
+# following to connect successfully:
+#
+# source [find interface/stlink-hla.cfg]
+# transport select hla_swd
 
 source [find target/stm32l0.cfg]
 

--- a/boards/st/nucleo_l053r8/support/openocd.cfg
+++ b/boards/st/nucleo_l053r8/support/openocd.cfg
@@ -1,8 +1,17 @@
 # This is an ST NUCLEO-L053R8 board with single STM32L053R8 chip.
 # https://www.st.com/en/evaluation-tools/nucleo-l053r8.html
-source [find interface/stlink.cfg]
 
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+
+# If you use an OpenOCD version higher than 0.12.0 and your target embeds
+# an ST-Link firmware earlier than v2j24, connection will not work.
+# It is recommended to upgrade the ST-Link firmware of the target,
+# however, if not possible, the 2 lines above can be replaced with the
+# following to connect successfully:
+#
+# source [find interface/stlink-hla.cfg]
+# transport select hla_swd
 
 set WORKAREASIZE 0x2000
 

--- a/boards/st/nucleo_l073rz/support/openocd.cfg
+++ b/boards/st/nucleo_l073rz/support/openocd.cfg
@@ -1,19 +1,6 @@
 # This is an ST NUCLEO-L073RZ board with single STM32L073RZ chip.
 # https://www.st.com/en/evaluation-tools/nucleo-l073rz.html
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-set WORKAREASIZE 0x2000
-
-source [find target/stm32l0.cfg]
-
-# Add the second flash bank.
-set _FLASHNAME $_CHIPNAME.flash1
-flash bank $_FLASHNAME stm32lx 0 0 0 0 $_TARGETNAME
-
-# There is only system reset line and JTAG/SWD command can be issued when SRST
-reset_config srst_only
+source [find board/st_nucleo_l073rz.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
         echo "Debugger attaching: halting execution"

--- a/boards/st/nucleo_l152re/support/openocd.cfg
+++ b/boards/st/nucleo_l152re/support/openocd.cfg
@@ -1,15 +1,5 @@
-# TODO: Once official openOCD fix merged and available in zephyr:
-#       http://openocd.zylin.com/#/c/5829/
-#       revert to board/st_nucleo_l1.cfg
-# source [find board/st_nucleo_l1.cfg]
-
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32l1x_dual_bank.cfg]
-
-reset_config srst_only
+# http://openocd.zylin.com/#/c/5829/ was merged in 2020
+source [find board/st_nucleo_l1.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
         echo "Debugger attaching: halting execution"

--- a/boards/st/nucleo_l412rb_p/support/openocd.cfg
+++ b/boards/st/nucleo_l412rb_p/support/openocd.cfg
@@ -1,7 +1,1 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32l4x.cfg]
-
-reset_config srst_only
+source [find board/st_nucleo_l4.cfg]

--- a/boards/st/nucleo_l432kc/support/openocd.cfg
+++ b/boards/st/nucleo_l432kc/support/openocd.cfg
@@ -1,7 +1,1 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32l4x.cfg]
-
-reset_config srst_only
+source [find board/st_nucleo_l4.cfg]

--- a/boards/st/nucleo_l433rc_p/support/openocd.cfg
+++ b/boards/st/nucleo_l433rc_p/support/openocd.cfg
@@ -1,7 +1,1 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32l4x.cfg]
-
-reset_config srst_only
+source [find board/st_nucleo_l4.cfg]

--- a/boards/st/nucleo_l452re/support/openocd.cfg
+++ b/boards/st/nucleo_l452re/support/openocd.cfg
@@ -1,7 +1,1 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32l4x.cfg]
-
-reset_config srst_only
+source [find board/st_nucleo_l4.cfg]

--- a/boards/st/nucleo_l552ze_q/support/openocd.cfg
+++ b/boards/st/nucleo_l552ze_q/support/openocd.cfg
@@ -1,11 +1,4 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32l5x.cfg]
-
-# use hardware reset
-reset_config srst_only srst_nogate
+source [find board/st_nucleo_l5.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
         echo "Debugger attaching: halting execution"

--- a/boards/st/nucleo_wb55rg/support/openocd.cfg
+++ b/boards/st/nucleo_wb55rg/support/openocd.cfg
@@ -1,7 +1,1 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32wbx.cfg]
-
-reset_config srst_only
+source [find board/st_nucleo_wb55rg]

--- a/boards/st/nucleo_wl55jc/support/openocd.cfg
+++ b/boards/st/nucleo_wl55jc/support/openocd.cfg
@@ -1,6 +1,6 @@
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
 
-transport select hla_swd
+transport select dapdirect_swd
 
 source [find target/stm32wlx.cfg]
 

--- a/boards/st/st25dv_mb1283_disco/support/openocd.cfg
+++ b/boards/st/st25dv_mb1283_disco/support/openocd.cfg
@@ -1,6 +1,14 @@
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
 
-transport select hla_swd
+# If you use an OpenOCD version higher than 0.12.0 and your target embeds
+# an ST-Link firmware earlier than v2j24, connection will not work.
+# It is recommended to upgrade the ST-Link firmware of the target,
+# however, if not possible, the 2 lines above can be replaced with the
+# following to connect successfully:
+#
+# source [find interface/stlink-hla.cfg]
+# transport select hla_swd
 
 source [find target/stm32f4x.cfg]
 

--- a/boards/st/steval_fcu001v1/support/openocd.cfg
+++ b/boards/st/steval_fcu001v1/support/openocd.cfg
@@ -1,6 +1,14 @@
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
 
-transport select hla_swd
+# If you use an OpenOCD version higher than 0.12.0 and your target embeds
+# an ST-Link firmware earlier than v2j24, connection will not work.
+# It is recommended to upgrade the ST-Link firmware of the target,
+# however, if not possible, the 2 lines above can be replaced with the
+# following to connect successfully:
+#
+# source [find interface/stlink-hla.cfg]
+# transport select hla_swd
 
 set WORKAREASIZE 0x10000
 

--- a/boards/st/stm32g0316_disco/support/openocd.cfg
+++ b/boards/st/stm32g0316_disco/support/openocd.cfg
@@ -1,5 +1,5 @@
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
 
-transport select hla_swd
+transport select dapdirect_swd
 
 source [find target/stm32g0x.cfg]

--- a/boards/st/stm32h747i_disco/support/openocd_stm32h747i_disco_m4.cfg
+++ b/boards/st/stm32h747i_disco/support/openocd_stm32h747i_disco_m4.cfg
@@ -1,7 +1,7 @@
 
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
 
-transport select hla_swd
+transport select dapdirect_swd
 
 set DUAL_BANK 1
 

--- a/boards/st/stm32h747i_disco/support/openocd_stm32h747i_disco_m7.cfg
+++ b/boards/st/stm32h747i_disco/support/openocd_stm32h747i_disco_m7.cfg
@@ -1,7 +1,7 @@
 
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
 
-transport select hla_swd
+transport select dapdirect_swd
 
 source [find target/stm32h7x.cfg]
 

--- a/boards/st/stm32h757i_eval/support/openocd_stm32h757i_eval_m4.cfg
+++ b/boards/st/stm32h757i_eval/support/openocd_stm32h757i_eval_m4.cfg
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 Foss Analytical A/S
 
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
 
-transport select hla_swd
+transport select dapdirect_swd
 
 set DUAL_BANK 1
 

--- a/boards/st/stm32h757i_eval/support/openocd_stm32h757i_eval_m7.cfg
+++ b/boards/st/stm32h757i_eval/support/openocd_stm32h757i_eval_m7.cfg
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 Foss Analytical A/S
 
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
 
-transport select hla_swd
+transport select dapdirect_swd
 
 source [find target/stm32h7x.cfg]
 

--- a/boards/st/stm32l562e_dk/support/openocd.cfg
+++ b/boards/st/stm32l562e_dk/support/openocd.cfg
@@ -1,11 +1,4 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32l5x.cfg]
-
-# use hardware reset
-reset_config srst_only srst_nogate
+source [find board/st_nucleo_l5.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
         echo "Debugger attaching: halting execution"

--- a/boards/st/stm32wb5mm_dk/support/openocd.cfg
+++ b/boards/st/stm32wb5mm_dk/support/openocd.cfg
@@ -1,7 +1,2 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32wbx.cfg]
-
-reset_config srst_only
+# OpenOCD st_nucleo_wb55rg.cfg matches stm32wb55mm_dk support
+source [find board/st_nucleo_wb55rg.cfg]

--- a/boards/st/stm32wb5mmg/support/openocd.cfg
+++ b/boards/st/stm32wb5mmg/support/openocd.cfg
@@ -1,7 +1,2 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
-
-source [find target/stm32wbx.cfg]
-
-reset_config srst_only
+# OpenOCD st_nucleo_wb55rg.cfg matches stm32wb55mmg support
+source [find board/st_nucleo_wb55k.cfg]

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -56,6 +56,16 @@ Boards
 
 * Panasonic ``panb511evb`` is renamed to ``panb611evb``.
 
+* STM32 boards OpenOCD configuration files have been changed to support latest OpenOCD versions
+  (> v0.12.0) in which the HLA/SWD transport has been deprecated (see
+  https://review.openocd.org/c/openocd/+/8523 and commit
+  https://sourceforge.net/p/openocd/code/ci/34ec5536c0ba3315bc5a841244bbf70141ccfbb4/).
+  Issues may be encountered when connecting to an ST-Link adapter running firmware prior
+  v2j24 which do not support the new transport. In this case, the ST-Link firmware should
+  be upgraded or, if not possible, the OpenOCD configuration script should be changed to
+  source "interface/stlink-hla.cfg" and select the "hla_swd" interface explicitly.
+  Backward compatibility with OpenOCD v0.12.0 or older is maintained.
+
 Device Drivers and Devicetree
 *****************************
 


### PR DESCRIPTION
This change aims to address a compatibility issue with recent OpenOCD pre-release and what is planned in OpenOCD v1.0.0 planned end of 2025. OpenOCD commit 34ec5536c0ba ("stlink: deprecate HLA support") [1] was merged in December 2024 after release tag 0.12.0 and before coming release v1.0.0. It deprecates the legacy HLA driver interface (also called transport) in favor to the generic DAP interface that is supported by ST-Link firmware v2.1 and later.

Since the referred commit, OpenOCD config script must source a new config file (**interface/stlink-hla.cfg**) in order to select **hla_swd** transport. This change breaks many ST-Link based OpenOCD config files of Zephyr. Alternatively, already existing **interface/stlink-dap.cfg** can be used with **dapdirect_swd** interface to use direct DAP/SWD interface.

To overcome the issue and support older and newer OpenOCD releases, this change uses OpenOCD native board config script files when available or if none, we select the **dapdirect_swd** transport ID that is supported since a long time and still maintained thank to OpenOCD native **interface/stlink-dap.cfg** config script file.

One may potentially face connection issues if using both a recent OpenOCD tool and an ST-Link adapter that embeds a old ST-Link firmware v1.x. This ST-Link firmware only supports HLA interface. This situation may happen with old STM32 L0/L1/L4/F4 Nucleo/Discovery boards or with old ST-Link adapter devices. ST-Link firmware v1.0 do not support DAP direct SWD interface. In such a case, either upgrade the ST-Link firmware (see **STM32CubeProgrammer** guide), or revert the change made here to explicitly use **hla_swd** transport based on **stlink-hla.cfg**. Alternatively, use an older OpenOCD release which may not be desired.

Link: https://sourceforge.net/p/openocd/code/ci/34ec5536c0ba3315bc5a841244bbf70141ccfbb4/ [1]
