### PR TITLE
doc: doxygen: enable Doxygen parallel build

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -527,7 +527,7 @@ LOOKUP_CACHE_SIZE      = 9
 # DOT_NUM_THREADS setting.
 # Minimum value: 0, maximum value: 32, default value: 1.
 
-NUM_PROC_THREADS       = 1
+NUM_PROC_THREADS       = 0
 
 # If the TIMESTAMP tag is set different from NO then each generated page will
 # contain the date or date and time when the page was generated. Setting this to


### PR DESCRIPTION
Parallel build for Doxygen has been available since v1.9, and allows to claim a few seconds off the build time (only the input processing can be done in parallel, but that's still a noticeable performance improvement).

Set `NUM_PROC_THREADS` to 0 to use as many cores as available on the system (**21 seconds build-time down to 16 on my machine**)