### PR TITLE
boards: OpenOCD deprecation of ST-Link HLA interface

### DIFF
--- a/boards/96boards/stm32_sensor_mez/support/openocd.cfg
+++ b/boards/96boards/stm32_sensor_mez/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x2000
 

--- a/boards/adafruit/feather_stm32f405/support/openocd.cfg
+++ b/boards/adafruit/feather_stm32f405/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]
 

--- a/boards/alientek/pandora_stm32l475/support/openocd.cfg
+++ b/boards/alientek/pandora_stm32l475/support/openocd.cfg
@@ -4,9 +4,11 @@
 # an stlink-v2-1 interface.
 # This is for STM32L4 boards that are connected via stlink-v2-1.
 
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32l4x.cfg]
 

--- a/boards/arduino/giga_r1/support/openocd_arduino_giga_r1_m4.cfg
+++ b/boards/arduino/giga_r1/support/openocd_arduino_giga_r1_m4.cfg
@@ -1,7 +1,8 @@
-
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set DUAL_BANK 1
 

--- a/boards/arduino/giga_r1/support/openocd_arduino_giga_r1_m7.cfg
+++ b/boards/arduino/giga_r1/support/openocd_arduino_giga_r1_m7.cfg
@@ -1,7 +1,8 @@
-
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32h7x.cfg]
 

--- a/boards/arduino/nicla_vision/support/openocd_arduino_nicla_vision_m4.cfg
+++ b/boards/arduino/nicla_vision/support/openocd_arduino_nicla_vision_m4.cfg
@@ -1,7 +1,8 @@
-
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set DUAL_BANK 1
 

--- a/boards/arduino/nicla_vision/support/openocd_arduino_nicla_vision_m7.cfg
+++ b/boards/arduino/nicla_vision/support/openocd_arduino_nicla_vision_m7.cfg
@@ -1,7 +1,8 @@
-
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32h7x.cfg]
 

--- a/boards/arduino/opta/support/openocd_opta_stm32h747xx_m7.cfg
+++ b/boards/arduino/opta/support/openocd_opta_stm32h747xx_m7.cfg
@@ -1,7 +1,8 @@
-
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32h7x.cfg]
 

--- a/boards/blues/cygnet/support/openocd.cfg
+++ b/boards/blues/cygnet/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32l4x.cfg]
 

--- a/boards/dragino/lsn50/support/openocd.cfg
+++ b/boards/dragino/lsn50/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x2000
 

--- a/boards/dragino/nbsn95/support/openocd.cfg
+++ b/boards/dragino/nbsn95/support/openocd.cfg
@@ -2,9 +2,11 @@
 #
 # Copyright (c) 2021 Next Big Thing AG
 
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x2000
 

--- a/boards/fanke/fk723m1_zgt6/support/openocd.cfg
+++ b/boards/fanke/fk723m1_zgt6/support/openocd.cfg
@@ -7,8 +7,11 @@
 
 #debug_level 3
 
-source [find interface/stlink.cfg]
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set CHIPNAME STM32H723ZG
 set WORKAREASIZE 0x3000

--- a/boards/mikroe/mini_m4_for_stm32/support/openocd.cfg
+++ b/boards/mikroe/mini_m4_for_stm32/support/openocd.cfg
@@ -1,8 +1,10 @@
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x30000
-
-transport select hla_swd
 
 source [find target/stm32f4x.cfg]
 

--- a/boards/olimex/stm32_h103/support/openocd.cfg
+++ b/boards/olimex/stm32_h103/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find board/olimex_stm32_h103.cfg]
 

--- a/boards/olimex/stm32_h103/support/openocd_stlink.cfg
+++ b/boards/olimex/stm32_h103/support/openocd_stlink.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find board/olimex_stm32_h103.cfg]
 

--- a/boards/olimex/stm32_h405/support/openocd.cfg
+++ b/boards/olimex/stm32_h405/support/openocd.cfg
@@ -1,8 +1,10 @@
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x10000
-
-transport select hla_swd
 
 source [find target/stm32f4x.cfg]
 

--- a/boards/olimex/stm32_p405/support/openocd.cfg
+++ b/boards/olimex/stm32_p405/support/openocd.cfg
@@ -1,8 +1,10 @@
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x10000
-
-transport select hla_swd
 
 source [find target/stm32f4x.cfg]
 

--- a/boards/others/stm32f103_mini/support/openocd.cfg
+++ b/boards/others/stm32f103_mini/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f1x.cfg]
 

--- a/boards/others/stm32f401_mini/support/openocd.cfg
+++ b/boards/others/stm32f401_mini/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]
 

--- a/boards/seco/stm32f3_seco_d23/support/openocd.cfg
+++ b/boards/seco/stm32f3_seco_d23/support/openocd.cfg
@@ -2,9 +2,11 @@
 # Flashing is possible by connecting the board to an ST-Link via SWD
 # https://edge.seco.com/juno.html
 
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f3x.cfg]
 

--- a/boards/seeed/lora_e5_dev_board/support/openocd.cfg
+++ b/boards/seeed/lora_e5_dev_board/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32wlx.cfg]
 

--- a/boards/seeed/lora_e5_mini/support/openocd.cfg
+++ b/boards/seeed/lora_e5_mini/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32wlx.cfg]
 

--- a/boards/st/b_l072z_lrwan1/support/openocd.cfg
+++ b/boards/st/b_l072z_lrwan1/support/openocd.cfg
@@ -1,14 +1,8 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
-
-# If you use an OpenOCD version higher than 0.12.0 and your target embeds
-# an ST-Link firmware earlier than v2j24, connection will not work.
-# It is recommended to upgrade the ST-Link firmware of the target,
-# however, if not possible, the 2 lines above can be replaced with the
-# following to connect successfully:
-#
-# source [find interface/stlink-hla.cfg]
-# transport select hla_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x2000
 

--- a/boards/st/nucleo_l011k4/support/openocd.cfg
+++ b/boards/st/nucleo_l011k4/support/openocd.cfg
@@ -3,15 +3,9 @@
 
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
-
-# If you use an OpenOCD version higher than 0.12.0 and your target embeds
-# an ST-Link firmware earlier than v2j24, connection will not work.
-# It is recommended to upgrade the ST-Link firmware of the target,
-# however, if not possible, the 2 lines above can be replaced with the
-# following to connect successfully:
-#
-# source [find interface/stlink-hla.cfg]
-# transport select hla_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 #set WORKAREASIZE 0x2000
 

--- a/boards/st/nucleo_l031k6/support/openocd.cfg
+++ b/boards/st/nucleo_l031k6/support/openocd.cfg
@@ -3,15 +3,9 @@
 
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
-
-# If you use an OpenOCD version higher than 0.12.0 and your target embeds
-# an ST-Link firmware earlier than v2j24, connection will not work.
-# It is recommended to upgrade the ST-Link firmware of the target,
-# however, if not possible, the 2 lines above can be replaced with the
-# following to connect successfully:
-#
-# source [find interface/stlink-hla.cfg]
-# transport select hla_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32l0.cfg]
 

--- a/boards/st/nucleo_l053r8/support/openocd.cfg
+++ b/boards/st/nucleo_l053r8/support/openocd.cfg
@@ -3,15 +3,9 @@
 
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
-
-# If you use an OpenOCD version higher than 0.12.0 and your target embeds
-# an ST-Link firmware earlier than v2j24, connection will not work.
-# It is recommended to upgrade the ST-Link firmware of the target,
-# however, if not possible, the 2 lines above can be replaced with the
-# following to connect successfully:
-#
-# source [find interface/stlink-hla.cfg]
-# transport select hla_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x2000
 

--- a/boards/st/st25dv_mb1283_disco/support/openocd.cfg
+++ b/boards/st/st25dv_mb1283_disco/support/openocd.cfg
@@ -1,14 +1,8 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
-
-# If you use an OpenOCD version higher than 0.12.0 and your target embeds
-# an ST-Link firmware earlier than v2j24, connection will not work.
-# It is recommended to upgrade the ST-Link firmware of the target,
-# however, if not possible, the 2 lines above can be replaced with the
-# following to connect successfully:
-#
-# source [find interface/stlink-hla.cfg]
-# transport select hla_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]
 

--- a/boards/st/steval_fcu001v1/support/openocd.cfg
+++ b/boards/st/steval_fcu001v1/support/openocd.cfg
@@ -1,14 +1,8 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
-
-# If you use an OpenOCD version higher than 0.12.0 and your target embeds
-# an ST-Link firmware earlier than v2j24, connection will not work.
-# It is recommended to upgrade the ST-Link firmware of the target,
-# however, if not possible, the 2 lines above can be replaced with the
-# following to connect successfully:
-#
-# source [find interface/stlink-hla.cfg]
-# transport select hla_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x10000
 

--- a/boards/steelseries/apex_pro_mini/support/openocd.cfg
+++ b/boards/steelseries/apex_pro_mini/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32l4x.cfg]
 

--- a/boards/weact/blackpill_f401cc/support/openocd.cfg
+++ b/boards/weact/blackpill_f401cc/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]
 

--- a/boards/weact/blackpill_f401ce/support/openocd.cfg
+++ b/boards/weact/blackpill_f401ce/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]
 

--- a/boards/weact/blackpill_f411ce/support/openocd.cfg
+++ b/boards/weact/blackpill_f411ce/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]
 

--- a/boards/weact/stm32f405_core/support/openocd.cfg
+++ b/boards/weact/stm32f405_core/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]
 

--- a/boards/weact/stm32f446_core/support/openocd.cfg
+++ b/boards/weact/stm32f446_core/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]
 

--- a/boards/weact/stm32g030_core/support/openocd.cfg
+++ b/boards/weact/stm32g030_core/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32g0x.cfg]
 

--- a/boards/weact/stm32g431_core/support/openocd.cfg
+++ b/boards/weact/stm32g431_core/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32g4x.cfg]
 

--- a/boards/weact/stm32wb55_core/support/openocd.cfg
+++ b/boards/weact/stm32wb55_core/support/openocd.cfg
@@ -1,6 +1,8 @@
-source [find interface/stlink.cfg]
-
-transport select hla_swd
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
+# If your ST-Link adapter embedded firmware dates prior version v2j24
+# DAP transport/intereface is not supported. In this case, refer to
+# https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32wbx.cfg]
 

--- a/doc/develop/flash_debug/probes.rst
+++ b/doc/develop/flash_debug/probes.rst
@@ -457,6 +457,8 @@ Flash and debug with ST-Link
         with the RTT one if they are enabled by default in the particular sample or
         application you are running, such as disable UART_CONSOLE in menuconfig
 
+.. _stlink-adapter-firmware-update:
+
 Updating or restoring ST-Link firmware
 ======================================
 
@@ -474,6 +476,33 @@ following command
 Where board_uid can be obtained using twister's generate-hardware-map
 option. For more information about twister and available options, see
 :ref:`twister_script`.
+
+OpenOCD Deprecates HLA ST-Link Interface
+========================================
+
+OpenOCD has deprecated the legacy HLA interface used by ST-Link firmware in favor to the
+generic DAP interface in Januray 2024 (see `OpenOCD deprecates ST-Link HLA Interface`_)
+in favor of the generic DAP interface. DAP interface is supported by ST-Link firmware
+since 2015 (from version v2j24).
+
+Since OpenOCD deprecation, one using a recent OpenOCD tool (after release tag v0.12.0)
+may experience communication issues when the ST-Link adapter embeds a firmware prior version
+v2j24. In such case, it is recommended to update the ST-Link firmware (refer to
+`ST-LINK firmware update <#_stlink-adapter-firmware-update>`_).
+If it is not possible to update the firmware, one may still use the old HLA interface
+by modifying its OpenOCD configuration script replacing (if applicable) the 2 below lines:
+
+  .. code-block::
+
+    source [find interface/stlink-dap.cfg]
+    transport select dapdirect_swd
+
+with the 2 following lines:
+
+  .. code-block::
+
+    source [find interface/stlink-hla.cfg]
+    transport select hla_swd
 
 .. _nxp-s32-debug-probe:
 
@@ -528,6 +557,9 @@ See `Black Magic Debug supported hardware`_.
 
 .. _STM32CubeProgrammer Tool:
     https://www.st.com/en/development-tools/stm32cubeprog.html
+
+.. _OpenOCD deprecates ST-Link HLA Interface:
+    https://sourceforge.net/p/openocd/code/ci/34ec5536c0ba3315bc5a841244bbf70141ccfbb4
 
 .. _MCUXpresso Installer:
 	https://www.nxp.com/lgfiles/updates/mcuxpresso/MCUXpressoInstaller.exe


### PR DESCRIPTION
This change aims to address a compatibility issue with recent OpenOCD pre-release and what is planned in OpenOCD v1.0.0 planned end of 2025. OpenOCD commit 34ec5536c0ba ("stlink: deprecate HLA support") [1] was merged in December 2024 after release tag 0.12.0 and before coming release v1.0.0. It deprecates the legacy HLA driver interface (also called transport) in favor to the generic DAP interface that is supported by ST-Link firmware v2.1 and later.

Since the referred commit, OpenOCD config script must source a new config file (interface/stlink-hla.cfg) in order to select hla_swd transport. This change breaks many ST-Link based OpenOCD config files of Zephyr. Alternatively, already existing interface/stlink-dap.cfg can be used with dapdirect_swd interface to use direct DAP/SWD interface.

To overcome the issue and support older and newer OpenOCD releases, change the OpenCOD configuration files for non-ST boards that use ST-Link to interface target debug and/or flash programming support. Use the already existing are still maintained interface/stlink-dap.cfg config script file together with dapdirect_swd transport interface.

One may potentially face connection issues if using both a recent OpenOCD firmware and using a ST-Link adapter that embeds a ST-Link firmware v1.x. This may happen with old ST-Link adapter devices. ST-Link firmware v1.0 do not support DAP direct SWD interface. In such a case, either upgrade the ST-Link firmware (refer to STM32CubeProgrammer guide), or revert the change made here to explicitly use hla_swd transport based on stlink-hla.cfg.

Link: https://sourceforge.net/p/openocd/code/ci/34ec5536c0ba3315bc5a841244bbf70141ccfbb4/ [1]

**Note:** This P-R addresses board from other vendors than ST. ST boards are addressed through https://github.com/zephyrproject-rtos/zephyr/pull/97638 that also adds an entry in the migration guide.