### PR TITLE
ci: doc-build.yml: do not tweak manifest.project-filter unnecessarily

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -112,7 +112,6 @@ jobs:
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
         west init -l . || true
-        west config manifest.group-filter -- +ci,+optional
         west config --global update.narrow true
         west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
         west forall -c 'git reset --hard HEAD'


### PR DESCRIPTION
The documentation build shouldn't need to pull in anything beyond what's active by default in the west.yml manifest. In fact, due to the way the manifest_projects_table.py script currently works, it is important that have a local west config that's "vanilla" so that the table of active/inactive projects is correct.