### PR TITLE
Sensor: Clock: Add Helper to simplify sensor-time retrieval

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345_stream.c
+++ b/drivers/sensor/adi/adxl345/adxl345_stream.c
@@ -369,21 +369,12 @@ void adxl345_stream_irq_handler(const struct device *dev)
 {
 	struct adxl345_dev_data *data = (struct adxl345_dev_data *) dev->data;
 	const struct adxl345_dev_config *cfg = (const struct adxl345_dev_config *) dev->config;
-	uint64_t cycles;
-	int rc;
 
 	if (data->sqe == NULL) {
 		return;
 	}
+	data->timestamp = sensor_clock_get_ns();
 
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(data->sqe, rc);
-		return;
-	}
-
-	data->timestamp = sensor_clock_cycles_to_ns(cycles);
 	struct rtio_sqe *write_status_addr = rtio_sqe_acquire(data->rtio_ctx);
 	struct rtio_sqe *read_status_reg = rtio_sqe_acquire(data->rtio_ctx);
 	struct rtio_sqe *check_status_reg = rtio_sqe_acquire(data->rtio_ctx);

--- a/drivers/sensor/adi/adxl362/adxl362_stream.c
+++ b/drivers/sensor/adi/adxl362/adxl362_stream.c
@@ -395,20 +395,11 @@ static void adxl362_process_status_cb(struct rtio *r, const struct rtio_sqe *sqe
 void adxl362_stream_irq_handler(const struct device *dev)
 {
 	struct adxl362_data *data = (struct adxl362_data *) dev->data;
-	uint64_t cycles;
-	int rc;
+
 	if (data->sqe == NULL) {
 		return;
 	}
-
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(data->sqe, rc);
-		return;
-	}
-
-	data->timestamp = sensor_clock_cycles_to_ns(cycles);
+	data->timestamp = sensor_clock_get_ns();
 
 	struct rtio_sqe *write_status_addr = rtio_sqe_acquire(data->rtio_ctx);
 	struct rtio_sqe *read_status_reg = rtio_sqe_acquire(data->rtio_ctx);

--- a/drivers/sensor/adi/adxl367/adxl367_stream.c
+++ b/drivers/sensor/adi/adxl367/adxl367_stream.c
@@ -548,20 +548,11 @@ static void adxl367_process_status_cb(struct rtio *r, const struct rtio_sqe *sqe
 void adxl367_stream_irq_handler(const struct device *dev)
 {
 	struct adxl367_data *data = (struct adxl367_data *) dev->data;
-	uint64_t cycles;
-	int rc;
+
 	if (data->sqe == NULL) {
 		return;
 	}
-
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(data->sqe, rc);
-		return;
-	}
-
-	data->timestamp = sensor_clock_cycles_to_ns(cycles);
+	data->timestamp = sensor_clock_get_ns();
 
 	struct rtio_sqe *write_status_addr = rtio_sqe_acquire(data->rtio_ctx);
 	struct rtio_sqe *read_status_reg = rtio_sqe_acquire(data->rtio_ctx);

--- a/drivers/sensor/adi/adxl372/adxl372_stream.c
+++ b/drivers/sensor/adi/adxl372/adxl372_stream.c
@@ -421,20 +421,11 @@ static void adxl372_process_status1_cb(struct rtio *r, const struct rtio_sqe *sq
 void adxl372_stream_irq_handler(const struct device *dev)
 {
 	struct adxl372_data *data = (struct adxl372_data *)dev->data;
-	uint64_t cycles;
-	int rc;
+
 	if (data->sqe == NULL) {
 		return;
 	}
-
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(data->sqe, rc);
-		return;
-	}
-
-	data->timestamp = sensor_clock_cycles_to_ns(cycles);
+	data->timestamp = sensor_clock_get_ns();
 
 	struct rtio_sqe *write_status_addr = rtio_sqe_acquire(data->rtio_ctx);
 	struct rtio_sqe *read_status_reg = rtio_sqe_acquire(data->rtio_ctx);

--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
@@ -81,18 +81,10 @@ void akm09918_after_start_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe,
 	const struct device *dev = cfg->sensor;
 	struct akm09918c_data *data = dev->data;
 	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)arg0;
-	uint64_t cycles;
 	int rc;
 
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(iodev_sqe, rc);
-		return;
-	}
-
 	/* save information for the work item */
-	data->work_ctx.timestamp = sensor_clock_cycles_to_ns(cycles);
+	data->work_ctx.timestamp = sensor_clock_get_ns();
 	data->work_ctx.iodev_sqe = iodev_sqe;
 
 	rc = akm09918c_flush_cqes(data->rtio_ctx);

--- a/drivers/sensor/bosch/bma4xx/bma4xx_rtio.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_rtio.c
@@ -55,7 +55,6 @@ static void bma4xx_submit_one_shot(const struct device *dev, struct rtio_iodev_s
 	uint8_t *buf;
 	uint32_t buf_len;
 	uint32_t min_buf_len = sizeof(struct bma4xx_encoded_data);
-	uint64_t cycles;
 	int rc;
 
 	/* Get the buffer for the frame, it may be allocated dynamically by the rtio context */
@@ -74,15 +73,7 @@ static void bma4xx_submit_one_shot(const struct device *dev, struct rtio_iodev_s
 	}
 
 	edata->header.accel_fs = bma4xx->cfg.accel_fs_range;
-
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(iodev_sqe, rc);
-		return;
-	}
-
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	edata->header.timestamp = sensor_clock_get_ns();
 
 	struct rtio_sqe *write_accel_sqe = rtio_sqe_acquire(bma4xx->r);
 	struct rtio_sqe *read_accel_sqe = rtio_sqe_acquire(bma4xx->r);

--- a/drivers/sensor/bosch/bma4xx/bma4xx_rtio_stream.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_rtio_stream.c
@@ -318,21 +318,11 @@ void bma4xx_fifo_event(const struct device *dev)
 	const struct bma4xx_config *drv_cfg = dev->config;
 	struct rtio_iodev *iodev = drv_data->iodev;
 	struct rtio *r = drv_data->r;
-	uint64_t cycles;
-	int rc;
 
 	if (drv_data->streaming_sqe == NULL) {
 		return;
 	}
-
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(drv_data->streaming_sqe, rc);
-		return;
-	}
-
-	drv_data->timestamp = sensor_clock_cycles_to_ns(cycles);
+	drv_data->timestamp = sensor_clock_get_ns();
 
 	struct rtio_sqe *write_int_reg = rtio_sqe_acquire(r);
 	struct rtio_sqe *read_int_reg = rtio_sqe_acquire(r);

--- a/drivers/sensor/bosch/bme280/bme280_async.c
+++ b/drivers/sensor/bosch/bme280/bme280_async.c
@@ -17,7 +17,6 @@ void bme280_submit_sync(struct rtio_iodev_sqe *iodev_sqe)
 {
 	uint32_t min_buf_len = sizeof(struct bme280_encoded_data);
 	int rc;
-	uint64_t cycles;
 	uint8_t *buf;
 	uint32_t buf_len;
 
@@ -33,17 +32,10 @@ void bme280_submit_sync(struct rtio_iodev_sqe *iodev_sqe)
 		return;
 	}
 
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(iodev_sqe, rc);
-		return;
-	}
-
 	struct bme280_encoded_data *edata;
 
 	edata = (struct bme280_encoded_data *)buf;
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	edata->header.timestamp = sensor_clock_get_ns();
 	edata->has_temp = 0;
 	edata->has_humidity = 0;
 	edata->has_press = 0;

--- a/drivers/sensor/bosch/bmm350/bmm350_decoder.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_decoder.c
@@ -139,8 +139,6 @@ int bmm350_encode(const struct device *dev,
 {
 	struct bmm350_encoded_data *edata = (struct bmm350_encoded_data *)buf;
 	struct bmm350_data *data = dev->data;
-	uint64_t cycles;
-	int err;
 
 	edata->header.channels = 0;
 
@@ -155,13 +153,8 @@ int bmm350_encode(const struct device *dev,
 		}
 	}
 
-	err = sensor_clock_get_cycles(&cycles);
-	if (err != 0) {
-		return err;
-	}
-
 	edata->header.events = is_trigger ? BIT(0) : 0;
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	edata->header.timestamp = sensor_clock_get_ns();
 
 	memcpy(&edata->comp, &data->mag_comp, sizeof(edata->comp));
 

--- a/drivers/sensor/bosch/bmp581/bmp581_decoder.c
+++ b/drivers/sensor/bosch/bmp581/bmp581_decoder.c
@@ -41,8 +41,6 @@ int bmp581_encode(const struct device *dev,
 {
 	struct bmp581_encoded_data *edata = (struct bmp581_encoded_data *)buf;
 	struct bmp581_data *data = dev->data;
-	uint64_t cycles;
-	int err;
 
 	edata->header.channels = 0;
 	edata->header.press_en = data->osr_odr_press_config.press_en;
@@ -59,13 +57,8 @@ int bmp581_encode(const struct device *dev,
 		}
 	}
 
-	err = sensor_clock_get_cycles(&cycles);
-	if (err != 0) {
-		return err;
-	}
-
 	edata->header.events = trigger_status;
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	edata->header.timestamp = sensor_clock_get_ns();
 
 	return 0;
 }

--- a/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
+++ b/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
@@ -103,16 +103,7 @@ static void data_ready_work_handler(struct rtio_iodev_sqe *iodev_sqe)
 		return;
 	}
 
-	uint64_t cycles;
-
-	err = sensor_clock_get_cycles(&cycles);
-	CHECKIF(err != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		handle_error_on_result(data, -EIO);
-		return;
-	}
-
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	edata->header.timestamp = sensor_clock_get_ns();
 	edata->header.channels = afbr_s50_encode_channel(SENSOR_CHAN_DISTANCE) |
 				 afbr_s50_encode_channel(SENSOR_CHAN_AFBR_S50_PIXELS);
 	edata->header.events = cfg->is_streaming ? afbr_s50_encode_event(SENSOR_TRIG_DATA_READY) :

--- a/drivers/sensor/default_rtio_sensor.c
+++ b/drivers/sensor/default_rtio_sensor.c
@@ -122,15 +122,7 @@ static void sensor_submit_fallback_sync(struct rtio_iodev_sqe *iodev_sqe)
 	uint32_t min_buf_len = compute_min_buf_len(num_output_samples);
 	uint64_t cycles;
 	int rc;
-
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(iodev_sqe, rc);
-		return;
-	}
-
-	uint64_t timestamp_ns = sensor_clock_cycles_to_ns(cycles);
+	uint64_t timestamp_ns = sensor_clock_get_ns();
 	uint8_t *buf;
 	uint32_t buf_len;
 

--- a/drivers/sensor/melexis/mlx90394/mlx90394_async.c
+++ b/drivers/sensor/melexis/mlx90394/mlx90394_async.c
@@ -96,10 +96,8 @@ void mlx90394_async_fetch(struct k_work *work)
 
 void mlx90394_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
-	int rc;
 	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
 	struct mlx90394_data *data = dev->data;
-	uint64_t cycles;
 
 	rc = mlx90394_trigger_measurement_internal(dev, cfg->channels->chan_type);
 	if (rc != 0) {
@@ -108,15 +106,8 @@ void mlx90394_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 		return;
 	}
 
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(iodev_sqe, rc);
-		return;
-	}
-
 	/* save information for the work item */
-	data->work_ctx.timestamp = sensor_clock_cycles_to_ns(cycles);
+	data->work_ctx.timestamp = sensor_clock_get_ns();
 	data->work_ctx.iodev_sqe = iodev_sqe;
 	data->work_ctx.config_val = data->config_val;
 

--- a/drivers/sensor/memsic/mmc56x3/mmc56x3_async.c
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3_async.c
@@ -17,7 +17,6 @@ void mmc56x3_submit_sync(struct rtio_iodev_sqe *iodev_sqe)
 	int rc;
 	uint8_t *buf;
 	uint32_t buf_len;
-	uint64_t cycles;
 
 	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
 	const struct device *dev = cfg->sensor;
@@ -31,17 +30,10 @@ void mmc56x3_submit_sync(struct rtio_iodev_sqe *iodev_sqe)
 		return;
 	}
 
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(iodev_sqe, rc);
-		return;
-	}
-
 	struct mmc56x3_encoded_data *edata;
 
 	edata = (struct mmc56x3_encoded_data *)buf;
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	edata->header.timestamp = sensor_clock_get_ns();
 	edata->has_temp = 0;
 	edata->has_magn_x = 0;
 	edata->has_magn_y = 0;

--- a/drivers/sensor/pixart/paa3905/paa3905_decoder.c
+++ b/drivers/sensor/pixart/paa3905/paa3905_decoder.c
@@ -230,23 +230,15 @@ int paa3905_encode(const struct device *dev,
 		   uint8_t *buf)
 {
 	struct paa3905_encoded_data *edata = (struct paa3905_encoded_data *)buf;
-	uint64_t cycles;
-	int err;
 
 	edata->header.channels = 0;
 	edata->header.events.drdy = false;
 	edata->header.events.motion = false;
+	edata->header.timestamp = sensor_clock_get_ns();
 
 	for (size_t i = 0 ; i < num_channels; i++) {
 		edata->header.channels |= paa3905_encode_channel(channels[i].chan_type);
 	}
-
-	err = sensor_clock_get_cycles(&cycles);
-	if (err != 0) {
-		return err;
-	}
-
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
 
 	return 0;
 }

--- a/drivers/sensor/pixart/paa3905/paa3905_stream.c
+++ b/drivers/sensor/pixart/paa3905/paa3905_stream.c
@@ -115,7 +115,6 @@ static void paa3905_complete_result(struct rtio *ctx,
 static void paa3905_stream_get_data(const struct device *dev)
 {
 	struct paa3905_data *data = dev->data;
-	uint64_t cycles;
 	int err;
 
 	CHECKIF(!data->stream.iodev_sqe) {
@@ -149,13 +148,7 @@ static void paa3905_stream_get_data(const struct device *dev)
 	struct rtio_sqe *cb_sqe = rtio_sqe_acquire(data->rtio.ctx);
 	uint8_t val;
 
-	err = sensor_clock_get_cycles(&cycles);
-	CHECKIF(err) {
-		LOG_ERR("Failed to get timestamp: %d", err);
-		handle_result_on_error(dev, err);
-		return;
-	}
-	buf->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	buf->header.timestamp = sensor_clock_get_ns();
 
 	CHECKIF(!write_sqe || !read_sqe || !cb_sqe) {
 		LOG_ERR("Failed to acquire RTIO SQE's");

--- a/drivers/sensor/pixart/pat9136/pat9136_decoder.c
+++ b/drivers/sensor/pixart/pat9136/pat9136_decoder.c
@@ -327,23 +327,15 @@ int pat9136_encode(const struct device *dev,
 		   uint8_t *buf)
 {
 	struct pat9136_encoded_data *edata = (struct pat9136_encoded_data *)buf;
-	uint64_t cycles;
-	int err;
 
 	edata->header.channels = 0;
 	edata->header.events.drdy = 0;
 	edata->header.events.motion = 0;
+	edata->header.timestamp = sensor_clock_get_ns();
 
 	for (size_t i = 0 ; i < num_channels; i++) {
 		edata->header.channels |= pat9136_encode_channel(channels[i].chan_type);
 	}
-
-	err = sensor_clock_get_cycles(&cycles);
-	if (err != 0) {
-		return err;
-	}
-
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
 
 	return 0;
 }

--- a/drivers/sensor/pixart/pat9136/pat9136_stream.c
+++ b/drivers/sensor/pixart/pat9136/pat9136_stream.c
@@ -87,7 +87,6 @@ static void pat9136_complete_result(struct rtio *ctx,
 static void pat9136_stream_get_data(const struct device *dev)
 {
 	struct pat9136_data *data = dev->data;
-	uint64_t cycles;
 	int err;
 
 	CHECKIF(!data->stream.iodev_sqe) {
@@ -141,17 +140,7 @@ static void pat9136_stream_get_data(const struct device *dev)
 	struct rtio_sqe *cb_sqe = rtio_sqe_acquire(data->rtio.ctx);
 	uint8_t val;
 
-	err = sensor_clock_get_cycles(&cycles);
-	CHECKIF(err) {
-		struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
-
-		LOG_ERR("Failed to get timestamp: %d", err);
-
-		data->stream.iodev_sqe = NULL;
-		rtio_iodev_sqe_err(iodev_sqe, err);
-		return;
-	}
-	buf->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	buf->header.timestamp = sensor_clock_get_ns();
 
 	CHECKIF(!write_res_x_sqe || !read_res_x_sqe ||
 		!write_res_y_sqe || !read_res_y_sqe ||

--- a/drivers/sensor/pni/rm3100/rm3100_decoder.c
+++ b/drivers/sensor/pni/rm3100/rm3100_decoder.c
@@ -36,10 +36,9 @@ int rm3100_encode(const struct device *dev,
 {
 	const struct rm3100_data *data = dev->data;
 	struct rm3100_encoded_data *edata = (struct rm3100_encoded_data *)buf;
-	uint64_t cycles;
-	int err;
 
 	edata->header.channels = 0;
+	edata->header.timestamp = sensor_clock_get_ns();
 
 	if (data->settings.odr == RM3100_DT_ODR_600) {
 		edata->header.cycle_count = RM3100_CYCLE_COUNT_HIGH_ODR;
@@ -50,13 +49,6 @@ int rm3100_encode(const struct device *dev,
 	for (size_t i = 0; i < num_channels; i++) {
 		edata->header.channels |= rm3100_encode_channel(channels[i].chan_type);
 	}
-
-	err = sensor_clock_get_cycles(&cycles);
-	if (err != 0) {
-		return err;
-	}
-
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
 
 	return 0;
 }

--- a/drivers/sensor/pni/rm3100/rm3100_stream.c
+++ b/drivers/sensor/pni/rm3100/rm3100_stream.c
@@ -56,7 +56,6 @@ static void rm3100_complete_result(struct rtio *ctx, const struct rtio_sqe *sqe,
 static void rm3100_stream_get_data(const struct device *dev)
 {
 	struct rm3100_data *data = dev->data;
-	uint64_t cycles;
 	int err;
 
 	CHECKIF(!data->stream.iodev_sqe) {
@@ -81,15 +80,7 @@ static void rm3100_stream_get_data(const struct device *dev)
 
 	edata = (struct rm3100_encoded_data *)buf;
 
-	err = sensor_clock_get_cycles(&cycles);
-	CHECKIF(err) {
-		LOG_ERR("Failed to get timestamp: %d", err);
-
-		data->stream.iodev_sqe = NULL;
-		rtio_iodev_sqe_err(iodev_sqe, err);
-		return;
-	}
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	edata->header.timestamp = sensor_clock_get_ns();
 
 	struct rtio_sqe *status_wr_sqe = rtio_sqe_acquire(data->rtio.ctx);
 	struct rtio_sqe *status_rd_sqe = rtio_sqe_acquire(data->rtio.ctx);

--- a/drivers/sensor/st/iis3dwb/iis3dwb.c
+++ b/drivers/sensor/st/iis3dwb/iis3dwb.c
@@ -137,7 +137,6 @@ static void iis3dwb_submit_one_shot(const struct device *dev, struct rtio_iodev_
 	const struct sensor_chan_spec *const channels = cfg->channels;
 	const size_t num_channels = cfg->count;
 	uint32_t min_buf_len = sizeof(struct iis3dwb_rtio_data);
-	uint64_t cycles;
 	int rc = 0;
 	uint8_t *buf;
 	uint32_t buf_len;
@@ -156,17 +155,9 @@ static void iis3dwb_submit_one_shot(const struct device *dev, struct rtio_iodev_
 
 	edata->has_accel = 0;
 	edata->has_temp = 0;
-
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(iodev_sqe, rc);
-		return;
-	}
-
 	edata->header.is_fifo = false;
 	edata->header.range = data->range;
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	edata->header.timestamp = sensor_clock_get_ns();
 
 	for (int i = 0; i < num_channels; i++) {
 		switch (channels[i].chan_type) {

--- a/drivers/sensor/st/iis3dwb/iis3dwb_stream.c
+++ b/drivers/sensor/st/iis3dwb/iis3dwb_stream.c
@@ -482,22 +482,14 @@ static void iis3dwb_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe, i
 void iis3dwb_stream_irq_handler(const struct device *dev)
 {
 	struct iis3dwb_data *iis3dwb = dev->data;
-	uint64_t cycles;
 	int rc;
 
 	if (iis3dwb->streaming_sqe == NULL) {
 		return;
 	}
 
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(iis3dwb->streaming_sqe, rc);
-		return;
-	}
-
 	/* get timestamp as soon as the irq is served */
-	iis3dwb->timestamp = sensor_clock_cycles_to_ns(cycles);
+	iis3dwb->timestamp = sensor_clock_get_ns();
 
 	/* handle FIFO triggers */
 	if (iis3dwb->trig_cfg.int_fifo_th || iis3dwb->trig_cfg.int_fifo_full) {

--- a/drivers/sensor/st/lis2dux12/lis2dux12_rtio.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_rtio.c
@@ -22,7 +22,6 @@ static void lis2dux12_submit_sample(const struct device *dev, struct rtio_iodev_
 	const struct sensor_chan_spec *const channels = cfg->channels;
 	const size_t num_channels = cfg->count;
 	uint32_t min_buf_len = sizeof(struct lis2dux12_rtio_data);
-	uint64_t cycles;
 	int rc = 0;
 	uint8_t *buf;
 	uint32_t buf_len;
@@ -93,16 +92,9 @@ static void lis2dux12_submit_sample(const struct device *dev, struct rtio_iodev_
 		}
 	}
 
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(iodev_sqe, rc);
-		goto err;
-	}
-
 	edata->header.is_fifo = false;
 	edata->header.range = data->range;
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	edata->header.timestamp = sensor_clock_get_ns();
 
 	rtio_iodev_sqe_ok(iodev_sqe, 0);
 

--- a/drivers/sensor/st/lis2dux12/lis2dux12_rtio_stream.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_rtio_stream.c
@@ -432,22 +432,13 @@ static void lis2dux12_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe,
 void lis2dux12_stream_irq_handler(const struct device *dev)
 {
 	struct lis2dux12_data *lis2dux12 = dev->data;
-	uint64_t cycles;
-	int rc;
 
 	if (lis2dux12->streaming_sqe == NULL) {
 		return;
 	}
 
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(lis2dux12->streaming_sqe, rc);
-		return;
-	}
-
 	/* get timestamp as soon as the irq is served */
-	lis2dux12->timestamp = sensor_clock_cycles_to_ns(cycles);
+	lis2dux12->timestamp = sensor_clock_get_ns();
 
 	/* handle FIFO triggers */
 	if (lis2dux12->trig_cfg.int_fifo_th || lis2dux12->trig_cfg.int_fifo_full) {

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio.c
@@ -22,7 +22,6 @@ static void lsm6dsv16x_submit_sample(const struct device *dev, struct rtio_iodev
 	const struct sensor_chan_spec *const channels = cfg->channels;
 	const size_t num_channels = cfg->count;
 	uint32_t min_buf_len = sizeof(struct lsm6dsv16x_rtio_data);
-	uint64_t cycles;
 	int rc = 0;
 	uint8_t *buf;
 	uint32_t buf_len;
@@ -114,18 +113,11 @@ static void lsm6dsv16x_submit_sample(const struct device *dev, struct rtio_iodev
 		}
 	}
 
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(iodev_sqe, rc);
-		goto err;
-	}
-
 	edata->header.is_fifo = false;
 	edata->header.accel_fs_idx =
 		LSM6DSV16X_ACCEL_FS_VAL_TO_FS_IDX(config->accel_fs_map[data->accel_fs]);
 	edata->header.gyro_fs = data->gyro_fs;
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	edata->header.timestamp = sensor_clock_get_ns();
 
 	rtio_iodev_sqe_ok(iodev_sqe, 0);
 

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
@@ -650,22 +650,14 @@ void lsm6dsv16x_stream_irq_handler(const struct device *dev)
 	const struct lsm6dsv16x_config *config = dev->config;
 	struct rtio *rtio = lsm6dsv16x->rtio_ctx;
 #endif
-	uint64_t cycles;
 	int rc;
 
 	if (lsm6dsv16x->streaming_sqe == NULL) {
 		return;
 	}
 
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(lsm6dsv16x->streaming_sqe, rc);
-		return;
-	}
-
 	/* get timestamp as soon as the irq is served */
-	lsm6dsv16x->timestamp = sensor_clock_cycles_to_ns(cycles);
+	lsm6dsv16x->timestamp = sensor_clock_get_ns();
 
 	/* handle FIFO triggers */
 	if (lsm6dsv16x->trig_cfg.int_fifo_th || lsm6dsv16x->trig_cfg.int_fifo_full) {

--- a/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
@@ -195,18 +195,11 @@ int icm4268x_encode(const struct device *dev, const struct sensor_chan_spec *con
 {
 	struct icm4268x_dev_data *data = dev->data;
 	struct icm4268x_encoded_data *edata = (struct icm4268x_encoded_data *)buf;
-	uint64_t cycles;
-	int rc;
 
 	edata->channels = 0;
 
 	for (int i = 0; i < num_channels; i++) {
 		edata->channels |= icm4268x_encode_channel(channels[i].chan_type);
-	}
-
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		return rc;
 	}
 
 	edata->header.is_fifo = false;
@@ -216,7 +209,7 @@ int icm4268x_encode(const struct device *dev, const struct sensor_chan_spec *con
 	edata->header.axis_align[0] = data->cfg.axis_align[0];
 	edata->header.axis_align[1] = data->cfg.axis_align[1];
 	edata->header.axis_align[2] = data->cfg.axis_align[2];
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	edata->header.timestamp = sensor_clock_get_ns();
 
 	return 0;
 }

--- a/drivers/sensor/tdk/icm4268x/icm4268x_rtio_stream.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_rtio_stream.c
@@ -327,21 +327,12 @@ void icm4268x_fifo_event(const struct device *dev)
 	struct icm4268x_dev_data *drv_data = dev->data;
 	struct rtio_iodev *spi_iodev = drv_data->spi_iodev;
 	struct rtio *r = drv_data->r;
-	uint64_t cycles;
-	int rc;
 
 	if (drv_data->streaming_sqe == NULL) {
 		return;
 	}
 
-	rc = sensor_clock_get_cycles(&cycles);
-	if (rc != 0) {
-		LOG_ERR("Failed to get sensor clock cycles");
-		rtio_iodev_sqe_err(drv_data->streaming_sqe, rc);
-		return;
-	}
-
-	drv_data->timestamp = sensor_clock_cycles_to_ns(cycles);
+	drv_data->timestamp = sensor_clock_get_ns();
 
 	/*
 	 * Setup rtio chain of ops with inline calls to make decisions

--- a/drivers/sensor/tdk/icm45686/icm45686_decoder.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_decoder.c
@@ -196,8 +196,6 @@ int icm45686_encode(const struct device *dev,
 {
 	struct icm45686_encoded_data *edata = (struct icm45686_encoded_data *)buf;
 	const struct icm45686_config *dev_config = dev->config;
-	uint64_t cycles;
-	int err;
 
 	edata->header.channels = 0;
 
@@ -205,15 +203,10 @@ int icm45686_encode(const struct device *dev,
 		edata->header.channels |= icm45686_encode_channel(channels[i].chan_type);
 	}
 
-	err = sensor_clock_get_cycles(&cycles);
-	if (err != 0) {
-		return err;
-	}
-
 	edata->header.events = 0;
 	edata->header.accel_fs = dev_config->settings.accel.fs;
 	edata->header.gyro_fs = dev_config->settings.gyro.fs;
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+	edata->header.timestamp = sensor_clock_get_ns();
 
 	return 0;
 }

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -193,7 +193,6 @@ static void icm45686_event_handler(const struct device *dev)
 	const struct icm45686_config *cfg = dev->config;
 	const struct sensor_read_config *read_cfg = data->stream.iodev_sqe->sqe.iodev->data;
 	uint8_t val = 0;
-	uint64_t cycles;
 	int err;
 
 	if (!data->stream.iodev_sqe ||
@@ -222,14 +221,7 @@ static void icm45686_event_handler(const struct device *dev)
 		return;
 	}
 
-	err = sensor_clock_get_cycles(&cycles);
-	if (err) {
-		LOG_ERR("Failed to get timestamp: %d", err);
-		icm45686_stream_result(dev, err);
-		return;
-	}
-
-	data->stream.data.timestamp = sensor_clock_cycles_to_ns(cycles);
+	data->stream.data.timestamp = sensor_clock_get_ns();
 
 	/** Prepare an asynchronous read of the INT status register */
 	struct rtio_sqe *read_sqe;

--- a/include/zephyr/drivers/sensor_clock.h
+++ b/include/zephyr/drivers/sensor_clock.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2024 Cienet
+ * Copyright (c) 2025 Croxel Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -37,6 +39,25 @@ int sensor_clock_get_cycles(uint64_t *cycles);
  * @return Time in nanoseconds.
  */
 uint64_t sensor_clock_cycles_to_ns(uint64_t cycles);
+
+/**
+ * @brief Get Current sensor clock in nanoseconds.
+ *
+ * This helper function performs the acquisition of sensor time in cycles
+ * and converts it directly in nanoseconds, instead of having to do it in
+ * a two-step process.
+ *
+ * @return nanoseconds on succes, zero on failure.
+ */
+static inline uint64_t sensor_clock_get_ns(void)
+{
+	uint64_t cycles;
+
+	if (sensor_clock_get_cycles(&cycles) != 0) {
+		return 0;
+	}
+	return sensor_clock_cycles_to_ns(cycles);
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Basic helper to reduce code-duplication.

> [!NOTE]
> I'm aware this removes error-handling of failing to obtain the timestamp.
> 
> my impression was that even without timestamp, some-data (and the time at which it is received) is better than no data with an error. In both cases, the error can still be detected (e.g: timestamp = 0) and handled accordingly
> 
>  Although that's my preference, I'm willing to add it back. Feel free to chime in with your thoughts.