### PR TITLE
riscv: pmp: Use XLEN-derived PMPCFG_STRIDE for array sizing

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -48,8 +48,6 @@ LOG_MODULE_REGISTER(mpu);
 #define PMP_NA4_SUPPORTED	!IS_ENABLED(CONFIG_PMP_NO_NA4)
 #define PMP_NAPOT_SUPPORTED	!IS_ENABLED(CONFIG_PMP_NO_NAPOT)
 
-#define PMPCFG_STRIDE sizeof(unsigned long)
-
 #define PMP_ADDR(addr)			((addr) >> 2)
 #define NAPOT_RANGE(size)		(((size) - 1) >> 1)
 #define PMP_ADDR_NAPOT(addr, size)	PMP_ADDR(addr | NAPOT_RANGE(size))
@@ -562,7 +560,7 @@ void z_riscv_pmp_stackguard_disable(void)
 {
 
 	unsigned long pmp_addr[CONFIG_PMP_SLOTS];
-	unsigned long pmp_cfg[CONFIG_PMP_SLOTS / sizeof(unsigned long)];
+	unsigned long pmp_cfg[CONFIG_PMP_SLOTS / PMPCFG_STRIDE];
 	unsigned int index = global_pmp_end_index;
 
 	/* Retrieve the pmpaddr value matching the last global PMP slot. */

--- a/arch/riscv/include/pmp.h
+++ b/arch/riscv/include/pmp.h
@@ -7,6 +7,8 @@
 #ifndef PMP_H_
 #define PMP_H_
 
+#define PMPCFG_STRIDE (__riscv_xlen / 8)
+
 void z_riscv_pmp_init(void);
 void z_riscv_pmp_stackguard_prepare(struct k_thread *thread);
 void z_riscv_pmp_stackguard_enable(struct k_thread *thread);

--- a/include/zephyr/arch/riscv/thread.h
+++ b/include/zephyr/arch/riscv/thread.h
@@ -72,7 +72,7 @@ struct _thread_arch {
 #ifdef CONFIG_USERSPACE
 	unsigned long priv_stack_start;
 	unsigned long u_mode_pmpaddr_regs[CONFIG_PMP_SLOTS];
-	unsigned long u_mode_pmpcfg_regs[CONFIG_PMP_SLOTS / sizeof(unsigned long)];
+	unsigned long u_mode_pmpcfg_regs[CONFIG_PMP_SLOTS / (__riscv_xlen / 8)];
 	unsigned int u_mode_pmp_domain_offset;
 	unsigned int u_mode_pmp_end_index;
 	unsigned int u_mode_pmp_update_nr;
@@ -80,7 +80,7 @@ struct _thread_arch {
 #ifdef CONFIG_PMP_STACK_GUARD
 	unsigned int m_mode_pmp_end_index;
 	unsigned long m_mode_pmpaddr_regs[CONFIG_PMP_SLOTS];
-	unsigned long m_mode_pmpcfg_regs[CONFIG_PMP_SLOTS / sizeof(unsigned long)];
+	unsigned long m_mode_pmpcfg_regs[CONFIG_PMP_SLOTS / (__riscv_xlen / 8)];
 #endif
 };
 


### PR DESCRIPTION
Replace `sizeof(unsigned long)` with `PMPCFG_STRIDE` (defined as `__riscv_xlen / 8`) for dimensioning PMP configuration register arrays (`pmpcfg_regs`).

The size of PMP configuration registers should be derived directly from the target architecture's XLEN. Using `sizeof(unsigned long)` can cause size mismatches, particularly with static analysis tools like SonarQube. These tools might assume a host-specific size for `unsigned long`, leading to spurious out-of-bounds access warnings when analyzing code for different RISCV base architectures (e.g., RV32 vs. RV64).

This change ensures the array sizing is correctly and consistently tied to the target's register width (XLEN).