### PR TITLE
doc: samples: remove manually added links to sample sources

### DIFF
--- a/samples/bluetooth/bap_broadcast_assistant/README.rst
+++ b/samples/bluetooth/bap_broadcast_assistant/README.rst
@@ -18,9 +18,6 @@ Practical use of this sample requires a sink (e.g. the BAP Broadcast Audio Sink 
 a set of BAP Broadcast capable earbuds) and a source (e.g. the BAP Broadcast Audio
 Source sample).
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/bap_broadcast_assistant` in the Zephyr tree.
-
 Check the :zephyr:code-sample-category:`bluetooth` samples for general information.
 
 Requirements

--- a/samples/bluetooth/bap_broadcast_sink/README.rst
+++ b/samples/bluetooth/bap_broadcast_sink/README.rst
@@ -11,9 +11,6 @@ Application demonstrating the BAP Broadcast Sink functionality.
 Starts by scanning for BAP Broadcast Sources and then synchronizes to
 the first found and listens to it until the source is (potentially) stopped.
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/bap_broadcast_sink` in the Zephyr tree.
-
 Check the :zephyr:code-sample-category:`bluetooth` samples for general information.
 
 Use :kconfig:option:`CONFIG_TARGET_BROADCAST_NAME` Kconfig to specify the name

--- a/samples/bluetooth/bap_broadcast_source/README.rst
+++ b/samples/bluetooth/bap_broadcast_source/README.rst
@@ -14,9 +14,6 @@ Broadcast Audio Source Endpoint (BASE) and finally the BIGinfo together with
 
 The BAP Broadcast Source will reset every 30 seconds to show the full API.
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/bap_broadcast_source` in the Zephyr tree.
-
 Check the :zephyr:code-sample-category:`bluetooth` samples for general information.
 
 Requirements

--- a/samples/bluetooth/bap_unicast_client/README.rst
+++ b/samples/bluetooth/bap_unicast_client/README.rst
@@ -10,9 +10,6 @@ Overview
 Application demonstrating the BAP Unicast Client functionality. Scans for and
 connects to a BAP Unicast Server and establishes an audio stream.
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/bap_unicast_client` in the Zephyr tree.
-
 Check the :zephyr:code-sample-category:`bluetooth` samples for general information.
 
 Requirements

--- a/samples/bluetooth/bap_unicast_server/README.rst
+++ b/samples/bluetooth/bap_unicast_server/README.rst
@@ -10,9 +10,6 @@ Overview
 Application demonstrating the BAP Unicast Server functionality.
 Starts advertising and awaits connection from a BAP Unicast Client.
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/bap_unicast_server` in the Zephyr tree.
-
 Check the :zephyr:code-sample-category:`bluetooth` samples for general information.
 
 Requirements

--- a/samples/bluetooth/beacon/README.rst
+++ b/samples/bluetooth/beacon/README.rst
@@ -19,7 +19,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/beacon` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/broadcaster/README.rst
+++ b/samples/bluetooth/broadcaster/README.rst
@@ -22,7 +22,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/broadcaster` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/broadcaster_multiple/README.rst
+++ b/samples/bluetooth/broadcaster_multiple/README.rst
@@ -27,9 +27,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/broadcaster_multiple` in the Zephyr tree.
-
 To test this sample use the Observer sample with Extended Scanning enabled,
 found under
 :zephyr_file:`samples/bluetooth/observer` in the Zephyr tree.

--- a/samples/bluetooth/bthome_sensor_template/README.rst
+++ b/samples/bluetooth/bthome_sensor_template/README.rst
@@ -18,8 +18,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/bthome_sensor_template` in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.
 
 When the sample is running, navigate to Devices & Services under settings in Home

--- a/samples/bluetooth/cap_acceptor/README.rst
+++ b/samples/bluetooth/cap_acceptor/README.rst
@@ -11,8 +11,6 @@ Application demonstrating the CAP Acceptor functionality.
 Starts by advertising for a CAP Initiator to connect and set up available streams.
 It can also be configured to start scanning for broadcast audio streams by itself.
 
-This sample can be found under :zephyr_file:`samples/bluetooth/cap_acceptor` in the Zephyr tree.
-
 Check the :zephyr:code-sample-category:`bluetooth` samples for general information.
 
 Requirements

--- a/samples/bluetooth/cap_initiator/README.rst
+++ b/samples/bluetooth/cap_initiator/README.rst
@@ -11,8 +11,6 @@ Application demonstrating the CAP Initiator functionality.
 Starts by either scanning for a CAP Acceptor and then connects to and sets up available unicast
 audio streams, sets up a broadcast audio stream, or both.
 
-This sample can be found under :zephyr_file:`samples/bluetooth/cap_initiator` in the Zephyr tree.
-
 Check the :zephyr:code-sample-category:`bluetooth` samples for general information.
 
 Requirements

--- a/samples/bluetooth/ccp_call_control_client/README.rst
+++ b/samples/bluetooth/ccp_call_control_client/README.rst
@@ -14,9 +14,6 @@ Starts by scanning for a CCP Call Control Server to connect and set up calls.
 The profile works for both GAP Central and GAP Peripheral devices, but this sample only assumes the
 GAP Central role.
 
-This sample can be found under :zephyr_file:`samples/bluetooth/ccp_call_control_client`
-in the Zephyr tree.
-
 Check the :zephyr:code-sample-category:`bluetooth` samples for general information.
 
 Requirements

--- a/samples/bluetooth/ccp_call_control_server/README.rst
+++ b/samples/bluetooth/ccp_call_control_server/README.rst
@@ -14,8 +14,6 @@ Starts by advertising for CCP Call Control Clients to connect and set up calls.
 The profile works for both GAP Central and GAP Peripheral devices, but this sample only assumes the
 GAP Peripheral role.
 
-This sample can be found under :zephyr_file:`samples/bluetooth/ccp_call_control_server` in the Zephyr tree.
-
 Check the :zephyr:code-sample-category:`bluetooth` samples for general information.
 
 Requirements

--- a/samples/bluetooth/central_gatt_write/README.rst
+++ b/samples/bluetooth/central_gatt_write/README.rst
@@ -19,7 +19,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/central_gatt_write`
-in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/central_hr/README.rst
+++ b/samples/bluetooth/central_hr/README.rst
@@ -20,7 +20,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/central_hr` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/central_ht/README.rst
+++ b/samples/bluetooth/central_ht/README.rst
@@ -20,7 +20,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/central_ht` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/central_multilink/README.rst
+++ b/samples/bluetooth/central_multilink/README.rst
@@ -19,7 +19,4 @@ Requirements
 
 Building and Running
 ********************
-This sample can be found under :zephyr_file:`samples/bluetooth/central_multilink`
-in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/central_otc/README.rst
+++ b/samples/bluetooth/central_otc/README.rst
@@ -19,7 +19,4 @@ Requirements
 
 Building and Running
 ********************
-This sample can be found under :zephyr_file:`samples/bluetooth/central_otc` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/central_past/README.rst
+++ b/samples/bluetooth/central_past/README.rst
@@ -18,9 +18,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/central_past` in
-the Zephyr tree.
-
 Use the sample found under :zephyr_file:`samples/bluetooth/periodic_adv` on
 another board that will start periodic advertising, to which this sample will
 establish periodic advertising synchronization.

--- a/samples/bluetooth/classic/handsfree/README.rst
+++ b/samples/bluetooth/classic/handsfree/README.rst
@@ -18,7 +18,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/classic/handsfree` in
-the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/classic/handsfree_ag/README.rst
+++ b/samples/bluetooth/classic/handsfree_ag/README.rst
@@ -18,7 +18,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/classic/handsfree_ag` in
-the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/direct_adv/README.rst
+++ b/samples/bluetooth/direct_adv/README.rst
@@ -27,7 +27,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/direct_adv` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/eddystone/README.rst
+++ b/samples/bluetooth/eddystone/README.rst
@@ -23,9 +23,6 @@ Requirements
 
 Building and Running
 ********************
-This sample can be found under :zephyr_file:`samples/bluetooth/eddystone` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.
 
 .. _Eddystone Configuration Service: https://github.com/google/eddystone/tree/master/configuration-service

--- a/samples/bluetooth/encrypted_advertising/README.rst
+++ b/samples/bluetooth/encrypted_advertising/README.rst
@@ -32,9 +32,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/encrypted_advertising` in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.
 
 This sample uses two applications, so two devices need to be setup.

--- a/samples/bluetooth/extended_adv/README.rst
+++ b/samples/bluetooth/extended_adv/README.rst
@@ -31,9 +31,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/extended_adv` in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.
 
 This sample uses two applications, so two devices need to be setup.

--- a/samples/bluetooth/hap_ha/README.rst
+++ b/samples/bluetooth/hap_ha/README.rst
@@ -19,7 +19,4 @@ Requirements
 
 Building and Running
 ********************
-This sample can be found under
-:zephyr_file:`samples/bluetooth/hap_ha` in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/hci_ipc/README.rst
+++ b/samples/bluetooth/hci_ipc/README.rst
@@ -18,9 +18,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/hci_ipc`
-in the Zephyr tree.
-
 To use this application, you need a board with a Bluetooth controller
 and IPC support.
 You can then build this application and flash it onto your board in

--- a/samples/bluetooth/hci_pwr_ctrl/README.rst
+++ b/samples/bluetooth/hci_pwr_ctrl/README.rst
@@ -32,7 +32,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/hci_pwr_ctrl`
-in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/hci_usb/README.rst
+++ b/samples/bluetooth/hci_usb/README.rst
@@ -18,7 +18,4 @@ Requirements
 
 Building and Running
 ********************
-This sample can be found under :zephyr_file:`samples/bluetooth/hci_usb` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/hci_vs_scan_req/README.rst
+++ b/samples/bluetooth/hci_vs_scan_req/README.rst
@@ -25,7 +25,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/hci_vs_scan_req`
-in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/ibeacon/README.rst
+++ b/samples/bluetooth/ibeacon/README.rst
@@ -26,9 +26,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/ibeacon` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details on how
 to run the sample inside QEMU.
 

--- a/samples/bluetooth/iso_broadcast/README.rst
+++ b/samples/bluetooth/iso_broadcast/README.rst
@@ -21,8 +21,7 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/iso_broadcast` in
-the Zephyr tree. Use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable
+Use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable
 required ISO feature support in Zephyr Bluetooth Controller on supported boards.
 The sample defaults to sequential packing of BIS subevents, add
 ``-DCONFIG_ISO_PACKING_INTERLEAVED=y`` to use interleaved packing.

--- a/samples/bluetooth/iso_broadcast_benchmark/README.rst
+++ b/samples/bluetooth/iso_broadcast_benchmark/README.rst
@@ -30,9 +30,6 @@ Requirements
 Building and running
 ********************
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/iso_broadcast_benchmark` in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.
 
 

--- a/samples/bluetooth/iso_central/README.rst
+++ b/samples/bluetooth/iso_central/README.rst
@@ -24,9 +24,6 @@ Requirements
 
 Building and Running
 ********************
-This sample can be found under :zephyr_file:`samples/bluetooth/iso_central` in
-the Zephyr tree.
-
 1. Start the application.
    In the terminal window, check that it is scanning for other devices.
 

--- a/samples/bluetooth/iso_connected_benchmark/README.rst
+++ b/samples/bluetooth/iso_connected_benchmark/README.rst
@@ -29,9 +29,6 @@ Requirements
 Building and running
 ********************
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/iso_connected_benchmark` in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.
 
 

--- a/samples/bluetooth/iso_peripheral/README.rst
+++ b/samples/bluetooth/iso_peripheral/README.rst
@@ -23,8 +23,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/iso_peripheral` in the Zephyr tree.
-
 1. Start the application.
    In the terminal window, check that it is advertising.
 

--- a/samples/bluetooth/iso_receive/README.rst
+++ b/samples/bluetooth/iso_receive/README.rst
@@ -21,8 +21,7 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/iso_receive` in
-the Zephyr tree. Use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable
+Use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable
 required ISO feature support in Zephyr Bluetooth Controller on supported boards.
 
 Use the sample found under :zephyr_file:`samples/bluetooth/iso_broadcast` on

--- a/samples/bluetooth/mesh/README.rst
+++ b/samples/bluetooth/mesh/README.rst
@@ -28,9 +28,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/mesh` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details on how
 to run the sample inside QEMU.
 

--- a/samples/bluetooth/mesh_demo/README.rst
+++ b/samples/bluetooth/mesh_demo/README.rst
@@ -39,9 +39,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/mesh_demo` in
-the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details on how
 to run the sample inside QEMU.
 

--- a/samples/bluetooth/mesh_provisioner/README.rst
+++ b/samples/bluetooth/mesh_provisioner/README.rst
@@ -37,9 +37,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/mesh_provisioner` in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details on
 how to run the sample inside QEMU.
 

--- a/samples/bluetooth/mtu_update/README.rst
+++ b/samples/bluetooth/mtu_update/README.rst
@@ -73,9 +73,6 @@ RSSI filtering.
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/mtu_update` in
-the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.
 
 If the devices are close enough, the central should connect to the peripheral

--- a/samples/bluetooth/observer/README.rst
+++ b/samples/bluetooth/observer/README.rst
@@ -41,7 +41,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/observer` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`Bluetooth samples section <bluetooth>` for details.

--- a/samples/bluetooth/pbp_public_broadcast_sink/README.rst
+++ b/samples/bluetooth/pbp_public_broadcast_sink/README.rst
@@ -12,9 +12,6 @@ Starts by scanning for PBP Public Broadcast Sources and then synchronizes to
 the first found source which defines a Public Broadcast Announcement including
 a High Quality Public Broadcast Audio Stream configuration.
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/pbp_public_broadcast_sink` in the Zephyr tree.
-
 Check the :zephyr:code-sample-category:`bluetooth` samples for general information.
 
 Requirements

--- a/samples/bluetooth/pbp_public_broadcast_source/README.rst
+++ b/samples/bluetooth/pbp_public_broadcast_source/README.rst
@@ -12,9 +12,6 @@ Will start advertising extended advertising and includes a Broadcast Audio Annou
 The advertised broadcast audio stream quality will cycle between high and standard quality
 every 15 seconds.
 
-This sample can be found under
-:zephyr_file:`samples/bluetooth/pbp_public_broadcast_source` in the Zephyr tree.
-
 Check the :zephyr:code-sample-category:`bluetooth` samples for general information.
 
 Requirements

--- a/samples/bluetooth/periodic_adv/README.rst
+++ b/samples/bluetooth/periodic_adv/README.rst
@@ -17,9 +17,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/periodic_adv` in
-the Zephyr tree.
-
 Use the sample found under :zephyr_file:`samples/bluetooth/periodic_sync` in the
 Zephyr tree that will scan and establish a periodic advertising synchronization
 to this sample.

--- a/samples/bluetooth/periodic_adv_conn/README.rst
+++ b/samples/bluetooth/periodic_adv_conn/README.rst
@@ -24,9 +24,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/periodic_adv_conn` in
-the Zephyr tree.
-
 Use the sample found under :zephyr_file:`samples/bluetooth/periodic_sync_conn` in the
 Zephyr tree that will synchronize and respond to this sample.
 

--- a/samples/bluetooth/periodic_adv_rsp/README.rst
+++ b/samples/bluetooth/periodic_adv_rsp/README.rst
@@ -30,9 +30,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/periodic_adv_rsp` in
-the Zephyr tree.
-
 Use the sample found under :zephyr_file:`samples/bluetooth/periodic_sync_rsp` in the
 Zephyr tree that will synchronize and respond to this sample.
 

--- a/samples/bluetooth/periodic_sync/README.rst
+++ b/samples/bluetooth/periodic_sync/README.rst
@@ -18,9 +18,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/periodic_sync` in
-the Zephyr tree.
-
 Use the sample found under :zephyr_file:`samples/bluetooth/periodic_adv` on
 another board that will start periodic advertising, to which this sample will
 establish periodic advertising synchronization.

--- a/samples/bluetooth/periodic_sync_conn/README.rst
+++ b/samples/bluetooth/periodic_sync_conn/README.rst
@@ -23,9 +23,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/periodic_sync_conn` in
-the Zephyr tree.
-
 Use the sample found under :zephyr_file:`samples/bluetooth/periodic_adv_conn` on
 another board that will start periodic advertising and connect to this sample
 once synced.

--- a/samples/bluetooth/periodic_sync_rsp/README.rst
+++ b/samples/bluetooth/periodic_sync_rsp/README.rst
@@ -31,9 +31,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/periodic_sync_rsp` in
-the Zephyr tree.
-
 Use the sample found under :zephyr_file:`samples/bluetooth/periodic_adv_rsp` on
 another board that will start periodic advertising, which will connect to this
 sample and transfer the synchronization info.

--- a/samples/bluetooth/peripheral/README.rst
+++ b/samples/bluetooth/peripheral/README.rst
@@ -20,7 +20,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/peripheral_accept_list/README.rst
+++ b/samples/bluetooth/peripheral_accept_list/README.rst
@@ -28,7 +28,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_accept_list` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/peripheral_csc/README.rst
+++ b/samples/bluetooth/peripheral_csc/README.rst
@@ -21,7 +21,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_csc` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/peripheral_dis/README.rst
+++ b/samples/bluetooth/peripheral_dis/README.rst
@@ -19,7 +19,4 @@ Requirements
 
 Building and Running
 ********************
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_dis` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/peripheral_esp/README.rst
+++ b/samples/bluetooth/peripheral_esp/README.rst
@@ -20,7 +20,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_esp` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/peripheral_gatt_write/README.rst
+++ b/samples/bluetooth/peripheral_gatt_write/README.rst
@@ -20,7 +20,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_gatt_write`
-in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/peripheral_hids/README.rst
+++ b/samples/bluetooth/peripheral_hids/README.rst
@@ -26,7 +26,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_hids` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/peripheral_hr/README.rst
+++ b/samples/bluetooth/peripheral_hr/README.rst
@@ -21,9 +21,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_hr` in the
-Zephyr tree.
-
 Building a minimal variant
 --------------------------
 

--- a/samples/bluetooth/peripheral_ht/README.rst
+++ b/samples/bluetooth/peripheral_ht/README.rst
@@ -25,7 +25,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_ht` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/peripheral_identity/README.rst
+++ b/samples/bluetooth/peripheral_identity/README.rst
@@ -19,7 +19,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_identity`
-in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/peripheral_nus/README.rst
+++ b/samples/bluetooth/peripheral_nus/README.rst
@@ -21,7 +21,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_nus` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/peripheral_ots/README.rst
+++ b/samples/bluetooth/peripheral_ots/README.rst
@@ -19,7 +19,4 @@ Requirements
 
 Building and Running
 ********************
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_ots` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/peripheral_past/README.rst
+++ b/samples/bluetooth/peripheral_past/README.rst
@@ -18,9 +18,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_past`
-in the Zephyr tree.
-
 Use the sample found under :zephyr_file:`samples/bluetooth/central_past` on
 another board that will connect to this and transfer a periodic advertisement
 sync.

--- a/samples/bluetooth/peripheral_sc_only/README.rst
+++ b/samples/bluetooth/peripheral_sc_only/README.rst
@@ -21,7 +21,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/peripheral_sc_only`
-in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/scan_adv/README.rst
+++ b/samples/bluetooth/scan_adv/README.rst
@@ -22,7 +22,4 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/scan_adv` in the
-Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/st_ble_sensor/README.rst
+++ b/samples/bluetooth/st_ble_sensor/README.rst
@@ -21,9 +21,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/bluetooth/st_ble_sensor` in the
-Zephyr tree.
-
 Open ST Bluetooth LE Sensor app and click on "CONNECT TO A DEVICE" button to scan Bluetooth LE devices.
 To connect click on the device shown in the Device List.
 After connected, tap LED image on Android to test LED service.

--- a/samples/bluetooth/tmap_bmr/README.rst
+++ b/samples/bluetooth/tmap_bmr/README.rst
@@ -17,6 +17,4 @@ Requirements
 
 Building and Running
 ********************
-This sample can be found under :zephyr_file:`samples/bluetooth/tmap_bmr` in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/tmap_bms/README.rst
+++ b/samples/bluetooth/tmap_bms/README.rst
@@ -17,6 +17,4 @@ Requirements
 
 Building and Running
 ********************
-This sample can be found under :zephyr_file:`samples/bluetooth/tmap_bms` in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/tmap_central/README.rst
+++ b/samples/bluetooth/tmap_central/README.rst
@@ -17,7 +17,4 @@ Requirements
 
 Building and Running
 ********************
-This sample can be found under
-:zephyr_file:`samples/bluetooth/tmap_central` in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/tmap_peripheral/README.rst
+++ b/samples/bluetooth/tmap_peripheral/README.rst
@@ -17,7 +17,4 @@ Requirements
 
 Building and Running
 ********************
-This sample can be found under
-:zephyr_file:`samples/bluetooth/tmap_peripheral` in the Zephyr tree.
-
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/boards/nordic/ieee802154/802154_rpmsg/README.rst
+++ b/samples/boards/nordic/ieee802154/802154_rpmsg/README.rst
@@ -18,9 +18,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/boards/nordic/ieee802154/802154_rpmsg`
-in the Zephyr tree.
-
 To use this application, you need a board with nRF53 SoC.
 You can then build this application and flash it onto your board in
 the usual way. See :ref:`boards` for board-specific building and

--- a/samples/boards/nordic/mesh/onoff-app/README.rst
+++ b/samples/boards/nordic/mesh/onoff-app/README.rst
@@ -44,9 +44,6 @@ likely also run on the nrf52dk/nrf52832 board.
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/boards/nordic/mesh/onoff-app` in the
-Zephyr tree.
-
 The following commands build the application.
 
 .. zephyr-app-commands::

--- a/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/README.rst
+++ b/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/README.rst
@@ -61,9 +61,6 @@ likely also run on the nrf52dk/nrf52832 board.
 
 Building and Running
 ********************
-This sample can be found under :zephyr_file:`samples/boards/nordic/mesh/onoff_level_lighting_vnd_app` in the
-Zephyr tree.
-
 The following commands build the application.
 
 .. zephyr-app-commands::

--- a/samples/boards/st/bluetooth/interactive_gui/README.rst
+++ b/samples/boards/st/bluetooth/interactive_gui/README.rst
@@ -30,8 +30,5 @@ The UART default settings are:
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/boards/st/bluetooth/interactive_gui` in the
-Zephyr tree.
-
 .. _BlueNRG GUI:
    https://www.st.com/en/embedded-software/stsw-bnrgui.html

--- a/samples/drivers/smbus/README.rst
+++ b/samples/drivers/smbus/README.rst
@@ -13,8 +13,6 @@ driver supported exploring the SMBus communication with peripheral devices.
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/drivers/smbus` in the
-Zephyr tree.
 The sample can be built and run as follows for the ``qemu_x86_64`` board:
 
 .. zephyr-app-commands::

--- a/samples/subsys/edac/README.rst
+++ b/samples/subsys/edac/README.rst
@@ -12,8 +12,6 @@ This sample demonstrates the :ref:`EDAC driver API <edac_api>` in a simple EDAC 
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/subsys/edac` in the
-Zephyr tree.
 The sample can be built as follows for the :ref:`intel_ehl_crb` board:
 
 .. zephyr-app-commands::

--- a/samples/subsys/fs/zms/README.rst
+++ b/samples/subsys/fs/zms/README.rst
@@ -32,8 +32,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/subsys/fs/zms` in the Zephyr tree.
-
 The sample can be built for several platforms, but for the moment it has been tested only
 on native_sim target
 

--- a/samples/subsys/logging/ble_backend/README.rst
+++ b/samples/subsys/logging/ble_backend/README.rst
@@ -23,8 +23,5 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/subsys/logging/ble_backend` in the
-Zephyr tree.
-
 The Bluetooth logger can be tested with the NRF Toolbox app or any similar app that can connect over
 Bluetooth and detect the NRF NUS UUID service.

--- a/samples/subsys/lorawan/class_a/README.rst
+++ b/samples/subsys/lorawan/class_a/README.rst
@@ -12,9 +12,6 @@ A simple application to demonstrate the :ref:`LoRaWAN subsystem <lorawan_api>` o
 Building and Running
 ********************
 
-This sample can be found under
-:zephyr_file:`samples/subsys/lorawan/class_a` in the Zephyr tree.
-
 Before building the sample, make sure to select the correct region in the
 ``prj.conf`` file.
 

--- a/samples/subsys/lorawan/fuota/README.rst
+++ b/samples/subsys/lorawan/fuota/README.rst
@@ -28,8 +28,6 @@ A LoRaWAN Application Server implementing the relevant services is required for 
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/subsys/lorawan/fuota` in the Zephyr tree.
-
 Before building the sample, make sure to select the correct region in the ``prj.conf`` file.
 
 The following commands build and flash the sample.

--- a/samples/subsys/modbus/rtu_client/README.rst
+++ b/samples/subsys/modbus/rtu_client/README.rst
@@ -34,9 +34,6 @@ Alternatively UART RX,TX signals of two boards can be connected crosswise.
 Building and Running
 ********************
 
-This sample can be found under
-:zephyr_file:`samples/subsys/modbus/rtu_client` in the Zephyr tree.
-
 The following commands build and flash RTU client sample.
 
 .. zephyr-app-commands::

--- a/samples/subsys/modbus/rtu_server/README.rst
+++ b/samples/subsys/modbus/rtu_server/README.rst
@@ -51,9 +51,6 @@ implementing custom USB class or driver.
 Building and Running
 ********************
 
-This sample can be found under
-:zephyr_file:`samples/subsys/modbus/rtu_server` in the Zephyr tree.
-
 The following commands build and flash RTU server sample.
 
 .. zephyr-app-commands::

--- a/samples/subsys/modbus/tcp_gateway/README.rst
+++ b/samples/subsys/modbus/tcp_gateway/README.rst
@@ -30,9 +30,6 @@ Alternatively UART RX,TX signals of two boards can be connected crosswise.
 Building and Running
 ********************
 
-This sample can be found under
-:zephyr_file:`samples/subsys/modbus/tcp_gateway` in the Zephyr tree.
-
 The following commands build and flash gateway sample.
 
 .. zephyr-app-commands::

--- a/samples/subsys/modbus/tcp_server/README.rst
+++ b/samples/subsys/modbus/tcp_server/README.rst
@@ -26,9 +26,6 @@ The user can of course try out other client implementations with this sample.
 Building and Running
 ********************
 
-This sample can be found under
-:zephyr_file:`samples/subsys/modbus/tcp_server` in the Zephyr tree.
-
 The following commands build and flash TCP server sample.
 
 .. zephyr-app-commands::

--- a/samples/subsys/nvs/README.rst
+++ b/samples/subsys/nvs/README.rst
@@ -20,8 +20,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/subsys/nvs` in the Zephyr tree.
-
 The sample can be built for several platforms, the following commands build the
 application for the nrf51dk/nrf51822 board.
 

--- a/samples/subsys/rtio/sensor_batch_processing/README.rst
+++ b/samples/subsys/rtio/sensor_batch_processing/README.rst
@@ -20,8 +20,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/subsys/rtio` in the Zephyr tree.
-
 The sample can be built for most platforms, the following commands build the
 application for the native_sim target.
 

--- a/samples/subsys/settings/README.rst
+++ b/samples/subsys/settings/README.rst
@@ -23,9 +23,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/subsys/settings` in
-the Zephyr tree.
-
 The sample can be built for several platforms, the following commands build the
 application for the qemu_x86.
 

--- a/samples/subsys/shell/shell_module/README.rst
+++ b/samples/subsys/shell/shell_module/README.rst
@@ -43,9 +43,6 @@ Requirements
 Building and Running
 ********************
 
-This sample can be found under :zephyr_file:`samples/subsys/shell/shell_module`
-in the Zephyr tree.
-
 The sample can be built for several platforms.
 
 Emulation Targets

--- a/samples/subsys/usb/cdc_acm/README.rst
+++ b/samples/subsys/usb/cdc_acm/README.rst
@@ -11,8 +11,6 @@ This sample app demonstrates use of a USB Communication Device Class (CDC)
 Abstract Control Model (ACM) driver provided by the Zephyr project.
 Received data from the serial port is echoed back to the same port
 provided by this driver.
-This sample can be found under :zephyr_file:`samples/subsys/usb/cdc_acm` in the
-Zephyr project tree.
 
 Requirements
 ************

--- a/samples/subsys/usb/cdc_acm_bridge/README.rst
+++ b/samples/subsys/usb/cdc_acm_bridge/README.rst
@@ -9,8 +9,6 @@ Overview
 
 This sample app demonstrates use of a USB CDC-ACM to bridge a standard hardware
 UART on a supported board.
-This sample can be found under :zephyr_file:`samples/subsys/usb/cdc_acm_bridge` in the
-Zephyr project tree.
 
 Requirements
 ************

--- a/samples/subsys/usb/hid-mouse/README.rst
+++ b/samples/subsys/usb/hid-mouse/README.rst
@@ -14,8 +14,6 @@ the number of buttons on the board) a right mouse button, X-axis movement,
 and Y-axis movement.
 If the USB peripheral driver supports remote wakeup feature, wakeup request
 will be performed on every button click if the bus is in suspended state.
-This sample can be found under :zephyr_file:`samples/subsys/usb/hid-mouse` in the
-Zephyr project tree.
 
 Requirements
 ************

--- a/samples/subsys/usb/legacy/audio_headphones_microphone/README.rst
+++ b/samples/subsys/usb/legacy/audio_headphones_microphone/README.rst
@@ -37,6 +37,3 @@ Steps to test the sample:
 - Start streaming audio (for example by playing an audio file on the HOST).
 - Start recording audio stream (for example using Audacity).
 - Verify the recorded audio stream.
-
-This sample can be found under
-:zephyr_file:`samples/subsys/usb/legacy/audio_headphones_microphone` in the Zephyr project tree.

--- a/samples/subsys/usb/legacy/audio_headset/README.rst
+++ b/samples/subsys/usb/legacy/audio_headset/README.rst
@@ -36,6 +36,3 @@ Steps to test the sample:
 - Start streaming audio (for example by playing an audio file on the HOST).
 - Start recording audio stream (for example using Audacity).
 - Verify the recorded audio stream.
-
-This sample can be found under
-:zephyr_file:`samples/subsys/usb/legacy/audio_headset` in the Zephyr project tree.

--- a/samples/subsys/usb/legacy/cdc_acm/README.rst
+++ b/samples/subsys/usb/legacy/cdc_acm/README.rst
@@ -15,9 +15,6 @@ provided by this driver.
 .. note::
    This samples demonstrate deprecated :ref:`usb_device_stack`.
 
-This sample can be found under :zephyr_file:`samples/subsys/usb/legacy/cdc_acm` in the
-Zephyr project tree.
-
 Requirements
 ************
 

--- a/samples/subsys/usb/legacy/hid-mouse/README.rst
+++ b/samples/subsys/usb/legacy/hid-mouse/README.rst
@@ -14,8 +14,6 @@ the number of buttons on the board) a right mouse button, X-axis movement,
 and Y-axis movement.
 If the USB peripheral driver supports remote wakeup feature, wakeup request
 will be performed on every button click if the bus is in suspended state.
-This sample can be found under :zephyr_file:`samples/subsys/usb/legacy/hid-mouse` in the
-Zephyr project tree.
 
 .. note::
    This samples demonstrate deprecated :ref:`usb_device_stack`.

--- a/samples/subsys/usb/legacy/mass/README.rst
+++ b/samples/subsys/usb/legacy/mass/README.rst
@@ -9,8 +9,7 @@ Overview
 
 This sample app demonstrates use of a USB Mass Storage driver by the Zephyr
 project. This very simple driver enumerates a board with RAM disk into an USB
-disk. This sample can be found under
-:zephyr_file:`samples/subsys/usb/legacy/mass` in the Zephyr project tree.
+disk.
 
 .. note::
    This samples demonstrate deprecated :ref:`usb_device_stack`.

--- a/samples/subsys/usb/legacy/netusb/README.rst
+++ b/samples/subsys/usb/legacy/netusb/README.rst
@@ -13,9 +13,6 @@ connection to a device running the Zephyr RTOS.
 .. note::
    This samples demonstrate deprecated :ref:`usb_device_stack`.
 
-This sample can be found under :zephyr_file:`samples/subsys/usb/legacy/netusb` in the
-Zephyr project tree.
-
 Requirements
 ************
 

--- a/samples/subsys/usb/legacy/webusb/README.rst
+++ b/samples/subsys/usb/legacy/webusb/README.rst
@@ -18,8 +18,6 @@ This application receives the data and echoes back to the WebUSB
 based web application (web page) running in the browser at host.
 This application is intended for testing purposes only. For running
 real usecase, implement applications based on the WebUSB API.
-This sample can be found under :zephyr_file:`samples/subsys/usb/legacy/webusb` in the
-Zephyr project tree.
 
 .. note::
    This samples demonstrate deprecated :ref:`usb_device_stack`.

--- a/samples/subsys/usb/mass/README.rst
+++ b/samples/subsys/usb/mass/README.rst
@@ -9,8 +9,7 @@ Overview
 
 This sample app demonstrates use of a USB Mass Storage driver by the Zephyr
 project. This very simple driver enumerates a board with either RAM or FLASH
-into an USB disk.  This sample can be found under
-:zephyr_file:`samples/subsys/usb/mass` in the Zephyr project tree.
+into an USB disk.
 
 Requirements
 ************

--- a/samples/subsys/usb/webusb/README.rst
+++ b/samples/subsys/usb/webusb/README.rst
@@ -11,8 +11,6 @@ This sample demonstrates how to use the Binary Device Object Store (BOS),
 Microsoft OS 2.0 descriptors, and WebUSB descriptors to implement a WebUSB
 sample application. The sample USB function receives the data and echoes back
 to the WebUSB API based application running in the browser on your local host.
-This sample can be found at :zephyr_file:`samples/subsys/usb/webusb` in the
-Zephyr project tree.
 
 Requirements
 ************


### PR DESCRIPTION
The `zephyr:code-sample` directive automatically adds a link to the sample source code on GitHub -- remove all manually added links that are just redundant and subject to bitrot / copy-paste errors.