### PR TITLE
boards: infineon: kit_pse84_eval pwm support

### DIFF
--- a/drivers/clock_control/clock_control_infineon_peri_clock.c
+++ b/drivers/clock_control/clock_control_infineon_peri_clock.c
@@ -31,19 +31,23 @@ struct ifx_peri_clock_data {
 
 #if defined(CY_IP_MXPERI) || defined(CY_IP_M0S8PERI)
 
-#define _IFX_CAT1_PCLK_GROUP(clkdst) 0
-#define _IFX_CAT1_TCPWM0_PCLK_CLOCK0 PCLK_TCPWM0_CLOCKS0
-#define _IFX_CAT1_TCPWM1_PCLK_CLOCK0 PCLK_TCPWM1_CLOCKS0
-#define _IFX_CAT1_SCB0_PCLK_CLOCK    PCLK_SCB0_CLOCK
+#define IFX_PCLK_GROUP(clkdst) 0
+#if (CY_IP_MXTCPWM_INSTANCES > 1) || (CY_IP_M0S8TCPWM_INSTANCES > 1)
+#define IFX_TCPWM0_PCLK_CLOCK0 PCLK_TCPWM0_CLOCKS0
+#define IFX_TCPWM1_PCLK_CLOCK0 PCLK_TCPWM1_CLOCKS0
+#else
+#define IFX_TCPWM0_PCLK_CLOCK0 PCLK_TCPWM_CLOCKS0
+#endif
+#define IFX_SCB0_PCLK_CLOCK PCLK_SCB0_CLOCK
 
 #elif defined(CY_IP_MXSPERI)
 
-#define _IFX_CAT1_PCLK_GROUP(clkdst) ((uint8_t)((uint32_t)(clkdst) >> 8))
-#define _IFX_CAT1_TCPWM0_PCLK_CLOCK0 PCLK_TCPWM0_CLOCK_COUNTER_EN0
-#define _IFX_CAT1_TCPWM1_PCLK_CLOCK0 PCLK_TCPWM1_CLOCK_COUNTER_EN0
-#define _IFX_CAT1_SCB0_PCLK_CLOCK    PCLK_SCB0_CLOCK_SCB_EN
-#define _IFX_CAT1_SCB1_PCLK_CLOCK    PCLK_SCB1_CLOCK_SCB_EN
-#define _IFX_CAT1_SCB5_PCLK_CLOCK    PCLK_SCB5_CLOCK_SCB_EN
+#define IFX_PCLK_GROUP(clkdst) ((uint8_t)((uint32_t)(clkdst) >> 8))
+#define IFX_TCPWM0_PCLK_CLOCK0 PCLK_TCPWM0_CLOCK_COUNTER_EN0
+#define IFX_TCPWM1_PCLK_CLOCK0 PCLK_TCPWM0_CLOCK_COUNTER_EN256
+#define IFX_SCB0_PCLK_CLOCK    PCLK_SCB0_CLOCK_SCB_EN
+#define IFX_SCB1_PCLK_CLOCK    PCLK_SCB1_CLOCK_SCB_EN
+#define IFX_SCB5_PCLK_CLOCK    PCLK_SCB5_CLOCK_SCB_EN
 #endif
 
 en_clk_dst_t ifx_cat1_scb_get_clock_index(uint32_t block_num)
@@ -52,21 +56,45 @@ en_clk_dst_t ifx_cat1_scb_get_clock_index(uint32_t block_num)
 /* PSOC6A256K does not have SCB 3 */
 #if defined(CY_DEVICE_PSOC6A256K)
 	if (block_num < 3) {
-		clk = (en_clk_dst_t)((uint32_t)_IFX_CAT1_SCB0_PCLK_CLOCK + block_num);
+		clk = (en_clk_dst_t)((uint32_t)IFX_SCB0_PCLK_CLOCK + block_num);
 	} else {
-		clk = (en_clk_dst_t)((uint32_t)_IFX_CAT1_SCB0_PCLK_CLOCK + block_num - 1);
+		clk = (en_clk_dst_t)((uint32_t)IFX_SCB0_PCLK_CLOCK + block_num - 1);
 	}
 #elif defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
 	if (block_num == 0) {
-		clk = (en_clk_dst_t)((uint32_t)_IFX_CAT1_SCB0_PCLK_CLOCK);
+		clk = (en_clk_dst_t)((uint32_t)IFX_SCB0_PCLK_CLOCK);
 	} else if (block_num == 1) {
-		clk = (en_clk_dst_t)((uint32_t)_IFX_CAT1_SCB1_PCLK_CLOCK);
+		clk = (en_clk_dst_t)((uint32_t)IFX_SCB1_PCLK_CLOCK);
 	} else {
-		clk = (en_clk_dst_t)((uint32_t)_IFX_CAT1_SCB0_PCLK_CLOCK + block_num - 1);
+		clk = (en_clk_dst_t)((uint32_t)IFX_SCB0_PCLK_CLOCK + block_num - 1);
 	}
 #else
-	clk = (en_clk_dst_t)((uint32_t)_IFX_CAT1_SCB0_PCLK_CLOCK + block_num);
+	clk = (en_clk_dst_t)((uint32_t)IFX_SCB0_PCLK_CLOCK + block_num);
 #endif
+
+	return clk;
+}
+
+en_clk_dst_t ifx_cat1_tcpwm_get_clock_index(uint32_t block_num, uint32_t channel)
+{
+	en_clk_dst_t clk = -EINVAL;
+
+	if (block_num == 0) {
+		/* block_num 0 is 32-bit tcpwm instances */
+		clk = (en_clk_dst_t)((uint32_t)IFX_TCPWM0_PCLK_CLOCK0 + channel);
+#if (CY_IP_MXTCPWM_INSTANCES > 1) || (CY_IP_M0S8TCPWM_INSTANCES > 1) || (CY_IP_MXSPERI)
+	} else if (block_num == 1) {
+		/* block_num 1 is 16-bit tcwpm instances */
+		clk = (en_clk_dst_t)((uint32_t)IFX_TCPWM1_PCLK_CLOCK0 + channel);
+#endif
+	} else {
+		/* Current support does not account for block_num other than 0 or 1 */
+		__ASSERT(block_num == 0 || block_num == 1,
+			 "Invalid block_num used for tcpwm clock index.");
+#if (CY_IP_MXTCPWM_INSTANCES == 1) || (CY_IP_M0S8TCPWM_INSTANCES == 1) || (CY_IP_MXSPERI)
+		__ASSERT(block_num == 0, "Invalid block_num used for tcpwm clock index.");
+#endif
+	}
 
 	return clk;
 }
@@ -77,6 +105,13 @@ static int ifx_cat1_peri_clock_init(const struct device *dev)
 
 	if (data->hw_resource.type == IFX_RSC_SCB) {
 		en_clk_dst_t clk_idx = ifx_cat1_scb_get_clock_index(data->hw_resource.block_num);
+
+		ifx_cat1_utils_peri_pclk_set_divider(clk_idx, &data->clock, data->divider - 1);
+		ifx_cat1_utils_peri_pclk_assign_divider(clk_idx, &data->clock);
+		ifx_cat1_utils_peri_pclk_enable_divider(clk_idx, &data->clock);
+	} else if (data->hw_resource.type == IFX_RSC_TCPWM) {
+		en_clk_dst_t clk_idx = ifx_cat1_tcpwm_get_clock_index(
+			data->hw_resource.block_num, data->hw_resource.channel_num);
 
 		ifx_cat1_utils_peri_pclk_set_divider(clk_idx, &data->clock, data->divider - 1);
 		ifx_cat1_utils_peri_pclk_assign_divider(clk_idx, &data->clock);
@@ -107,10 +142,11 @@ static int ifx_cat1_peri_clock_init(const struct device *dev)
 
 #define INFINEON_CAT1_PERI_CLOCK_INIT(n)                                                           \
 	static struct ifx_peri_clock_data ifx_cat1_peri_clock##n##_data = {                        \
-		PERI_CLOCK_INIT(n).divider = DT_INST_PROP(n, clock_div),                           \
+		.divider = DT_INST_PROP(n, clock_div),                                             \
 		.hw_resource = {.type = DT_INST_PROP(n, resource_type),                            \
-				.block_num = DT_INST_PROP(n, resource_instance)},                  \
-	};                                                                                         \
+				.block_num = DT_INST_PROP(n, resource_instance),                   \
+				.channel_num = DT_INST_PROP_OR(n, resource_channel, 0)},           \
+		PERI_CLOCK_INIT(n)};                                                               \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_peri_clock_init, NULL, &ifx_cat1_peri_clock##n##_data,  \
 			      NULL, PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY, NULL);

--- a/drivers/pwm/pwm_infineon_tcpwm.c
+++ b/drivers/pwm/pwm_infineon_tcpwm.c
@@ -13,8 +13,11 @@
 
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/drivers/pinctrl.h>
+
+#include <infineon_kconfig.h>
 #include <zephyr/drivers/timer/ifx_tcpwm.h>
 #include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+#include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
 
 #include <cy_tcpwm_pwm.h>
 #include <cy_gpio.h>
@@ -27,10 +30,12 @@ struct ifx_tcpwm_pwm_config {
 	TCPWM_GRP_CNT_Type *reg_base;
 	const struct pinctrl_dev_config *pcfg;
 	bool resolution_32_bits;
-	cy_en_divider_types_t divider_type;
-	uint32_t divider_sel;
-	uint32_t divider_val;
 	uint32_t tcpwm_index;
+	uint32_t index;
+};
+
+struct ifx_tcpwm_pwm_data {
+	struct ifx_cat1_clock clock;
 };
 
 static int ifx_tcpwm_pwm_init(const struct device *dev)
@@ -38,7 +43,6 @@ static int ifx_tcpwm_pwm_init(const struct device *dev)
 	const struct ifx_tcpwm_pwm_config *config = dev->config;
 	cy_en_tcpwm_status_t status;
 	int ret;
-	uint32_t clk_connection;
 
 	const cy_stc_tcpwm_pwm_config_t pwm_config = {
 		.pwmMode = CY_TCPWM_PWM_MODE_PWM,
@@ -50,20 +54,6 @@ static int ifx_tcpwm_pwm_init(const struct device *dev)
 		.enableCompareSwap = true,
 		.enablePeriodSwap = true,
 	};
-
-	/* Configure PWM clock */
-	Cy_SysClk_PeriphDisableDivider(config->divider_type, config->divider_sel);
-	Cy_SysClk_PeriphSetDivider(config->divider_type, config->divider_sel, config->divider_val);
-	Cy_SysClk_PeriphEnableDivider(config->divider_type, config->divider_sel);
-
-	/* Calculate clock connection based on TCPWM index */
-	if (config->resolution_32_bits) {
-		clk_connection = PCLK_TCPWM0_CLOCK_COUNTER_EN0 + config->tcpwm_index;
-	} else {
-		clk_connection = PCLK_TCPWM0_CLOCK_COUNTER_EN256 + config->tcpwm_index;
-	}
-
-	Cy_SysClk_PeriphAssignDivider(clk_connection, config->divider_type, config->divider_sel);
 
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
@@ -157,9 +147,18 @@ static int ifx_tcpwm_pwm_get_cycles_per_sec(const struct device *dev, uint32_t c
 {
 	ARG_UNUSED(channel);
 
+	struct ifx_tcpwm_pwm_data *const data = dev->data;
 	const struct ifx_tcpwm_pwm_config *config = dev->config;
+	en_clk_dst_t clk_connection;
 
-	*cycles = Cy_SysClk_PeriphGetFrequency(config->divider_type, config->divider_sel);
+	/* Determine tcpwm block number based on its resolution */
+	uint32_t tcpwm_block = config->resolution_32_bits ? 0 : 1;
+
+	/* Calculate clock connection based on TCPWM index */
+	clk_connection = ifx_cat1_tcpwm_get_clock_index(tcpwm_block, config->index);
+
+	*cycles = ifx_cat1_utils_peri_pclk_get_frequency(clk_connection,
+							 &data->clock);
 
 	return 0;
 }
@@ -169,8 +168,32 @@ static DEVICE_API(pwm, ifx_tcpwm_pwm_api) = {
 	.get_cycles_per_sec = ifx_tcpwm_pwm_get_cycles_per_sec,
 };
 
+#if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#define PWM_PERI_CLOCK_INIT(n)                                                                     \
+	.clock =                                                                                   \
+		{                                                                                  \
+			.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                 \
+				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 0),         \
+				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),         \
+				DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                     \
+			.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                    \
+		}
+#else
+#define PWM_PERI_CLOCK_INIT(n)                                                                     \
+	.clock =                                                                                   \
+		{                                                                                  \
+			.block = IFX_CAT1_PERIPHERAL_GROUP_ADJUST(                                 \
+				DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),         \
+				DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                     \
+			.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                    \
+		}
+#endif
+
 #define INFINEON_TCPWM_PWM_INIT(n)                                                                 \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
+                                                                                                   \
+	static struct ifx_tcpwm_pwm_data ifx_tcpwm_pwm##n##_data =                                 \
+		{PWM_PERI_CLOCK_INIT(n)};                                                          \
                                                                                                    \
 	static const struct ifx_tcpwm_pwm_config pwm_tcpwm_config_##n = {                          \
 		.reg_base = (TCPWM_GRP_CNT_Type *)DT_REG_ADDR(DT_INST_PARENT(n)),                  \
@@ -180,12 +203,13 @@ static DEVICE_API(pwm, ifx_tcpwm_pwm_api) = {
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		.resolution_32_bits =                                                              \
 			(DT_PROP(DT_INST_PARENT(n), resolution) == 32) ? true : false,             \
-		.divider_type = DT_PROP(DT_INST_PARENT(n), divider_type),                          \
-		.divider_sel = DT_PROP(DT_INST_PARENT(n), divider_sel),                            \
-		.divider_val = DT_PROP(DT_INST_PARENT(n), divider_val),                            \
+		.index = (DT_REG_ADDR(DT_INST_PARENT(n)) -                                         \
+			  DT_REG_ADDR(DT_PARENT(DT_INST_PARENT(n)))) /                             \
+			 DT_REG_SIZE(DT_INST_PARENT(n)),                                           \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, ifx_tcpwm_pwm_init, NULL, NULL, &pwm_tcpwm_config_##n,            \
-			      POST_KERNEL, CONFIG_PWM_INIT_PRIORITY, &ifx_tcpwm_pwm_api);
+	DEVICE_DT_INST_DEFINE(n, ifx_tcpwm_pwm_init, NULL, &ifx_tcpwm_pwm##n##_data,               \
+			      &pwm_tcpwm_config_##n, POST_KERNEL, CONFIG_PWM_INIT_PRIORITY,        \
+			      &ifx_tcpwm_pwm_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_TCPWM_PWM_INIT)

--- a/dts/arm/infineon/cat1b/cyw20829/system_clocks.dtsi
+++ b/dts/arm/infineon/cat1b/cyw20829/system_clocks.dtsi
@@ -5,7 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "clock_source_def.h"
+#define DIV_8_BIT    00
+#define DIV_16_BIT	 01
+#define DIV_16_5_BIT 02
+#define DIV_24_5_BIT 03
+
+#include <dt-bindings/clock/ifx_clock_source_common.h>
 
 / {
 	srss_power: srss_power {
@@ -140,6 +145,167 @@
 			compatible = "fixed-factor-clock";
 			clocks = <&clk_pilo>;
 			status = "okay";
+		};
+	};
+
+	peri0: peri0 {
+		/* Peripheral 0, Clock Group 0 */
+		/* 24.5-bit */
+		peri0_group0_24_5bit_0: peri0_group0_24_5bit_0 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 00]; /* inst#, group# */
+			div-type = <DIV_24_5_BIT>;
+			channel = <0>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		/* Peripheral 0, Clock Group 1 */
+		/* 8-bit */
+		peri0_group1_8bit_0: peri0_group1_8bit_0 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 01]; /* inst#, group# */
+			div-type = <DIV_8_BIT>;
+			channel = <0>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		peri0_group1_8bit_1: peri0_group1_8bit_1 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 01]; /* inst#, group# */
+			div-type = <DIV_8_BIT>;
+			channel = <1>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		peri0_group1_8bit_2: peri0_group1_8bit_2 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 01]; /* inst#, group# */
+			div-type = <DIV_8_BIT>;
+			channel = <2>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		peri0_group1_8bit_3: peri0_group1_8bit_3 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 01]; /* inst#, group# */
+			div-type = <DIV_8_BIT>;
+			channel = <3>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		peri0_group1_8bit_4: peri0_group1_8bit_4 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 01]; /* inst#, group# */
+			div-type = <DIV_8_BIT>;
+			channel = <4>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		/* 16-bit */
+		peri0_group1_16bit_0: peri0_group1_16bit_0 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 01]; /* inst#, group# */
+			div-type = <DIV_16_BIT>;
+			channel = <0>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		peri0_group1_16bit_1: peri0_group1_16bit_1 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 01]; /* inst#, group# */
+			div-type = <DIV_16_BIT>;
+			channel = <1>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		peri0_group1_16bit_2: peri0_group1_16bit_2 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 01]; /* inst#, group# */
+			div-type = <DIV_16_BIT>;
+			channel = <2>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		peri0_group1_16bit_3: peri0_group1_16bit_3 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 01]; /* inst#, group# */
+			div-type = <DIV_16_BIT>;
+			channel = <3>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		/* 16.5-bit */
+		peri0_group1_16_5bit_0: peri0_group1_16_5bit_0 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 01]; /* inst#, group# */
+			div-type = <DIV_16_5_BIT>;
+			channel = <0>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		peri0_group1_16_5bit_1: peri0_group1_16_5bit_1 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 01]; /* inst#, group# */
+			div-type = <DIV_16_5_BIT>;
+			channel = <1>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		/* 24.5-bit */
+		peri0_group1_24_5bit_0: peri0_group1_24_5bit_0 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 01]; /* inst#, group# */
+			div-type = <DIV_24_5_BIT>;
+			channel = <0>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		/* Peripheral 0, Clock Group 3 */
+		/* 16.5-bit */
+		peri0_group3_16_5bit_0: peri0_group3_16_5bit_0 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 03]; /* inst#, group# */
+			div-type = <DIV_16_5_BIT>;
+			channel = <0>;
+			clock-div = <1>;
+			status = "disabled";
+		};
+
+		peri0_group3_16_5bit_1: peri0_group3_16_5bit_1 {
+			#clock-cells = <0>;
+			compatible = "infineon,peri-div";
+			peri-group = [00 03]; /* inst#, group# */
+			div-type = <DIV_16_5_BIT>;
+			channel = <1>;
+			clock-div = <1>;
+			status = "disabled";
 		};
 	};
 };

--- a/dts/bindings/clock/infineon,peri-div.yaml
+++ b/dts/bindings/clock/infineon,peri-div.yaml
@@ -63,3 +63,12 @@ properties:
       &scb0 : resource-instance = <0>
       &scb3 : resource-instance = <3>
       &scb5 : resource-instance = <5>
+      &tcpwm0_3: resource-instance = <0>
+
+  resource-channel:
+    type: int
+    description: |
+      Resource instance's channel that the peripheral clock is assigned to:
+      &tcpwm0_0 : resource-channel = <0>
+      &tcpwm0_4 : resource-channel = <4>
+      &tcpwm1_2 : resource-channel = <2>

--- a/dts/bindings/pwm/infineon,tcpwm-pwm.yaml
+++ b/dts/bindings/pwm/infineon,tcpwm-pwm.yaml
@@ -7,7 +7,7 @@ description: Infineon TCPWM PWM
 
 compatible: "infineon,tcpwm-pwm"
 
-include: [pwm-controller.yaml, pinctrl-device.yaml, "infineon,system-interrupts.yaml"]
+include: [base.yaml, pwm-controller.yaml, pinctrl-device.yaml, "infineon,system-interrupts.yaml"]
 
 properties:
   "#pwm-cells":

--- a/dts/bindings/timer/infineon,tcpwm.yaml
+++ b/dts/bindings/timer/infineon,tcpwm.yaml
@@ -19,26 +19,6 @@ properties:
     type: array
     description: Interrupt mapping for TCPWM instance
 
-  divider-type:
-    type: int
-    description: |
-      Specifies which type of divider to use.
-      Defined by cy_en_divider_types_t in cy_sysclk.h.
-    required: true
-
-  divider-sel:
-    type: int
-    description: |
-      Specifies which divider of the selected type to configure.
-    required: true
-
-  divider-val:
-    type: int
-    description: |
-      Causes integer division of (divider value + 1), or division by 1 to 256
-      (8-bit divider) or 1 to 65536 (16-bit divider).
-    required: true
-
   resolution:
     type: int
     required: true

--- a/include/zephyr/drivers/clock_control/clock_control_ifx_cat1.h
+++ b/include/zephyr/drivers/clock_control/clock_control_ifx_cat1.h
@@ -401,6 +401,21 @@ struct ifx_cat1_resource_inst {
 int ifx_cat1_clock_control_get_frequency(uint32_t dt_ord, uint32_t *frequency);
 
 en_clk_dst_t ifx_cat1_scb_get_clock_index(uint32_t block_num);
+en_clk_dst_t ifx_cat1_tcpwm_get_clock_index(uint32_t block_num, uint32_t channel);
+
+static inline uint32_t ifx_cat1_utils_peri_pclk_get_frequency(en_clk_dst_t clk_dest,
+							      const struct ifx_cat1_clock *_clock)
+{
+#if defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) || defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+	return Cy_SysClk_PeriPclkGetFrequency(
+		clk_dest, IFX_CAT1_PERIPHERAL_GROUP_GET_DIVIDER_TYPE(_clock->block),
+		_clock->channel);
+#else
+	CY_UNUSED_PARAMETER(clk_dest);
+	return Cy_SysClk_PeriphGetFrequency(
+		IFX_CAT1_PERIPHERAL_GROUP_GET_DIVIDER_TYPE(_clock->block), _clock->channel);
+#endif
+}
 
 static inline cy_rslt_t ifx_cat1_utils_peri_pclk_enable_divider(en_clk_dst_t clk_dest,
 								const struct ifx_cat1_clock *_clock)

--- a/samples/basic/blinky_pwm/boards/cyw920829m2evk_02_common.overlay
+++ b/samples/basic/blinky_pwm/boards/cyw920829m2evk_02_common.overlay
@@ -25,15 +25,21 @@
 
 &tcpwm0_0 {
 	status = "okay";
-	divider-type = <PWM_IFX_SYSCLK_DIV_16_BIT>;
-	divider-sel = <1>;
-	divider-val = <9599>;
 
 	pwm0_0: pwm0_0 {
 		status = "okay";
+		clocks = <&peri0_group1_16bit_0>;
 		pinctrl-0 = <&p1_1_pwm0_0>;
 		pinctrl-names = "default";
 	};
+};
+
+&peri0_group1_16bit_0 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <0>;
+	clock-div = <9600>;
 };
 
 &pinctrl {

--- a/samples/basic/blinky_pwm/boards/kit_pse84_eval_common.overlay
+++ b/samples/basic/blinky_pwm/boards/kit_pse84_eval_common.overlay
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0_7 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "PWM LED";
+		};
+
+		status = "okay";
+	};
+};
+
+&tcpwm0_7 {
+	status = "okay";
+
+	pwm0_7: pwm0_7 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_1>;
+		pinctrl-0 = <&p16_7_pwm0_7>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <7>;
+	clock-div = <9600>;
+};
+
+&pinctrl {
+	p16_7_pwm0_7: p16_7_pwm0_7 {
+		drive-push-pull;
+	};
+};

--- a/samples/basic/blinky_pwm/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/samples/basic/blinky_pwm/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/samples/basic/blinky_pwm/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/basic/blinky_pwm/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/samples/basic/fade_led/boards/cyw920829m2evk_02_common.overlay
+++ b/samples/basic/fade_led/boards/cyw920829m2evk_02_common.overlay
@@ -31,28 +31,40 @@
 
 &tcpwm0_0 {
 	status = "okay";
-	divider-type = <PWM_IFX_SYSCLK_DIV_16_BIT>;
-	divider-sel = <1>;
-	divider-val = <9599>;
 
 	pwm0_0: pwm0_0 {
 		status = "okay";
+		clocks = <&peri0_group1_16bit_0>;
 		pinctrl-0 = <&p1_1_pwm0_0>;
 		pinctrl-names = "default";
 	};
 };
 
+&peri0_group1_16bit_0 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <0>;
+	clock-div = <9600>;
+};
+
 &tcpwm1_5 {
 	status = "okay";
-	divider-type = <PWM_IFX_SYSCLK_DIV_16_BIT>;
-	divider-sel = <1>;
-	divider-val = <9599>;
 
 	pwm1_5: pwm1_5 {
 		status = "okay";
+		clocks = <&peri0_group1_16bit_1>;
 		pinctrl-0 = <&p5_2_pwm1_5>;
 		pinctrl-names = "default";
 	};
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <1>;
+	resource-channel = <5>;
+	clock-div = <9600>;
 };
 
 &pinctrl {

--- a/samples/basic/fade_led/boards/kit_pse84_eval_common.overlay
+++ b/samples/basic/fade_led/boards/kit_pse84_eval_common.overlay
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0_7 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "PWM LED";
+		};
+
+		status = "okay";
+	};
+};
+
+&tcpwm0_7 {
+	status = "okay";
+
+	pwm0_7: pwm0_7 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_1>;
+		pinctrl-0 = <&p16_7_pwm0_7>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <7>;
+	clock-div = <9600>;
+};
+
+&pinctrl {
+	p16_7_pwm0_7: p16_7_pwm0_7 {
+		drive-push-pull;
+	};
+};

--- a/samples/basic/fade_led/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/samples/basic/fade_led/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/samples/basic/fade_led/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/basic/fade_led/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/tests/drivers/pwm/pwm_api/boards/cyw920829m2evk_02_common.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/cyw920829m2evk_02_common.overlay
@@ -16,15 +16,21 @@
 
 &tcpwm0_0 {
 	status = "okay";
-	divider-type = <PWM_IFX_SYSCLK_DIV_16_BIT>;
-	divider-sel = <1>;
-	divider-val = <9599>;
 
 	pwm0_0: pwm0_0 {
 		status = "okay";
+		clocks = <&peri0_group1_16bit_0>;
 		pinctrl-0 = <&p3_4_pwm0_0>;
 		pinctrl-names = "default";
 	};
+};
+
+&peri0_group1_16bit_0 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <0>;
+	clock-div = <9600>;
 };
 
 &pinctrl {

--- a/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_common.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+
+/ {
+	aliases {
+		pwm-test = &pwm0_7;
+	};
+};
+
+&tcpwm0_7 {
+	status = "okay";
+
+	pwm0_7: pwm0_7 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_1>;
+		pinctrl-0 = <&p16_7_pwm0_7>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <7>;
+	clock-div = <9600>;
+};
+
+&pinctrl {
+	p16_7_pwm0_7: p16_7_pwm0_7 {
+		drive-push-pull;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/cyw920829m2evk_02_common.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/cyw920829m2evk_02_common.overlay
@@ -19,28 +19,40 @@
 
 &tcpwm0_1 {
 	status = "okay";
-	divider-type = <PWM_IFX_SYSCLK_DIV_16_BIT>;
-	divider-sel = <1>;
-	divider-val = <9599>;
 
 	pwm0_1: pwm0_1 {
 		status = "okay";
+		clocks = <&peri0_group1_16bit_0>;
 		pinctrl-0 = <&p3_6_pwm0_1>;
 		pinctrl-names = "default";
 	};
 };
 
+&peri0_group1_16bit_0 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <1>;
+	clock-div = <9600>;
+};
+
 &tcpwm1_0 {
 	status = "okay";
-	divider-type = <PWM_IFX_SYSCLK_DIV_16_BIT>;
-	divider-sel = <1>;
-	divider-val = <9599>;
 
 	pwm1_0: pwm1_0 {
 		status = "okay";
+		clocks = <&peri0_group1_16bit_1>;
 		pinctrl-0 = <&p0_1_pwm1_0>;
 		pinctrl-names = "default";
 	};
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <1>;
+	resource-channel = <0>;
+	clock-div = <9600>;
 };
 
 &pinctrl {

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_common.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_common.overlay
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm_ifx_tcpwm.h>
+
+/ {
+	zephyr,user {
+		pwms = <&pwm0_1 0 PWM_MSEC(20) (PWM_POLARITY_NORMAL | PWM_IFX_TCPWM_OUTPUT_HIGHZ)>,
+		       <&pwm1_19 1 PWM_MSEC(20) (PWM_POLARITY_NORMAL | PWM_IFX_TCPWM_OUTPUT_HIGHZ)>;
+		gpios = <&gpio_prt16 2 GPIO_ACTIVE_HIGH>,
+			<&gpio_prt15 3 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&tcpwm0_1 {
+	status = "okay";
+
+	pwm0_1: pwm0_1 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_1>;
+		pinctrl-0 = <&p16_1_pwm0_1>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <0>;
+	resource-channel = <1>;
+	clock-div = <9600>;
+};
+
+&tcpwm1_19 {
+	status = "okay";
+
+	pwm1_19: pwm1_19 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_2>;
+		pinctrl-0 = <&p15_2_pwm1_19>;
+		pinctrl-names = "default";
+	};
+};
+
+&peri0_group1_16bit_2 {
+	status = "okay";
+	resource-type = <IFX_RSC_TCPWM>;
+	resource-instance = <1>;
+	resource-channel = <19>;
+	clock-div = <9600>;
+};
+
+&pinctrl {
+	p15_2_pwm1_19: p15_2_pwm1_19 {
+		drive-push-pull;
+	};
+
+	p16_1_pwm0_1: p16_1_pwm0_1 {
+		drive-push-pull;
+	};
+};
+
+/* gpio_prt16 is already enabled in boards\infineon\kit_pse84_eval\kit_pse84_eval_common.dtsi */
+&gpio_prt15 {
+	status = "okay";
+};

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"

--- a/tests/drivers/pwm/pwm_gpio_loopback/testcase.yaml
+++ b/tests/drivers/pwm/pwm_gpio_loopback/testcase.yaml
@@ -34,6 +34,8 @@ tests:
       - cyw920829m2evk_02/cyw20829b1340
       - cyw920829m2evk_02/cyw20829b1010
       - cyw920829m2evk_02/cyw20829b0lkml
+      - kit_pse84_eval/pse846gps2dbzc4a/m33
+      - kit_pse84_eval/pse846gps2dbzc4a/m55
   drivers.pwm.gpio_loopback_tc0.mchp:
     extra_args: DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tc0.overlay"
     platform_allow:


### PR DESCRIPTION
- Update the driver to support the kit_pse84_eval board
- Update to new peripheral clock allocation scheme
- Add overlay files for the blinky_pwm and fade_led samples
- Add overlay files for the pwm_api and pwm_gpio_loopback tests
- Update platform_allow for pwm_gpio_loopback
- Updates for cyw920829m2evk_02 to align with new clock scheme for pwm support