### PR TITLE
dts: bindings: add DOIT vendor prefix

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -185,6 +185,7 @@ dlc	DLC Display Co., Ltd.
 dlg	Dialog Semiconductor
 dlink	D-Link Corporation
 dmo	Data Modul AG
+doit	Shenzhen Sibo Zhilian Technology Co, Ltd
 doiting	Doctors of Intelligence & Technology
 domintech	Domintech Co., Ltd.
 dongwoon	Dongwoon Anatech


### PR DESCRIPTION
Add DOIT as a vendor for upcoming ESP32 DEVKIT V1 board support.