### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 48b0f6da9af8d009eb8eafba023998a7d85320a1
+      revision: b192716c969ad358bb3a1db60c898212f3275c55
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  b192716c969ad358bb3a1db60c898212f3275c55

Brings following Zephyr relevant fixes:

  - b192716c Revert "loader: Allow to specify slot number in version"
  - 5b7bccf9 boot: bootutil: swap_offset: Fix not including unprotected TLVs
  - ee9efe01 bootutil: Replace boot_write_enc_key with boot_write_enc_keys
  - 80a39c64 bootutil: Replace literal slot indexes with identifiers

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.