### PR TITLE
drivers: can: mcux: flexcan: fix loop back error when CAN FD enabled

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -482,9 +482,19 @@ static int mcux_flexcan_set_mode(const struct device *dev, can_mode_t mode)
 
 			/* Transceiver Delay Compensation must be disabled in loopback mode */
 			if ((mode & CAN_MODE_LOOPBACK) != 0) {
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG) && \
+	 FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG)
+				base->ETDC &= ~(CAN_ETDC_ETDCEN_MASK);
+#else
 				base->FDCTRL &= ~(CAN_FDCTRL_TDCEN_MASK);
+#endif
 			} else {
+#if (defined(FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG) && \
+	 FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG)
+				base->ETDC |= CAN_ETDC_ETDCEN_MASK;
+#else
 				base->FDCTRL |= CAN_FDCTRL_TDCEN_MASK;
+#endif
 			}
 		} else {
 			/* Disable CAN FD mode */


### PR DESCRIPTION
Fix mcux flexcan driver failed to transfer when both loop back mode and CAN FD mode are enabled.

Transceiver Delay Compensation feature must be disabled in loopback mode. For some platforms, both FDCTRL[TDCEN] and ETDC[ETDCEN] can enable such feature. In this case, SDK API only configure ETDC register and current driver do not clear ETDC[ETDCEN].

Fix this issue by add ETDC[ETDCEN] configuration according to SDK macro `FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG` vaule.

Test this commit on mimxrt1180_evk/mimxrt1189/cm33 and set both CAN FD mode and loop back mode.