### PR TITLE
Enable watchdog sample support on SF32LB boards

### DIFF
--- a/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.dts
+++ b/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.dts
@@ -52,6 +52,7 @@
 		led0 = &led0;
 		sw0 = &key1;
 		sw1 = &key2;
+		watchdog0 = &wdt;
 	};
 };
 
@@ -118,4 +119,8 @@
 	current-speed = <1000000>;
 	pinctrl-0 = <&usart1_default>;
 	pinctrl-names = "default";
+};
+
+&wdt {
+	status = "okay";
 };

--- a/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.yaml
+++ b/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.yaml
@@ -12,4 +12,5 @@ toolchain:
 supported:
   - uart
   - gpio
+  - watchdog
 vendor: sifli

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -45,6 +45,9 @@
 #elif DT_HAS_COMPAT_STATUS_OKAY(wch_iwdg)
 #define WDT_ALLOW_CALLBACK 0
 #define WDT_OPT            0
+#elif DT_HAS_COMPAT_STATUS_OKAY(sifli_sf32lb_wdt)
+#define WDT_ALLOW_CALLBACK 0
+#define WDT_OPT            0
 #endif
 
 #ifndef WDT_ALLOW_CALLBACK


### PR DESCRIPTION
So sample can be used by SF32LB based boards.