### PR TITLE
Bluetooth: Classic: HFP: Fix fixed MTU issue

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_internal.h
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define BT_HFP_MAX_MTU       140
+#define BT_HFP_MAX_MTU       (BT_L2CAP_RX_MTU - BT_RFCOMM_HDR_MAX_SIZE - BT_RFCOMM_FCS_SIZE)
 #define BT_HF_CLIENT_MAX_PDU BT_HFP_MAX_MTU
 
 /* HFP AG Features */


### PR DESCRIPTION
The MTU of HFP HF or AG is fixed value. It cannot be configured.

Fix the issue to make the MTU of RFCOMM is consistency with the MTU of L2CAP.