### PR TITLE
modules: hal_nordic: nrf_802154: remove setting of deprecated macro

### DIFF
--- a/modules/hal_nordic/nrf_802154/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/CMakeLists.txt
@@ -44,8 +44,6 @@ target_compile_definitions(zephyr-802154-interface
     # Number of buffers in receive queue.
     NRF_802154_RX_BUFFERS=${CONFIG_NRF_802154_RX_BUFFERS}
 
-    NRF_802154_TX_STARTED_NOTIFY_ENABLED=1
-
     # ACK timeout
     NRF_802154_ACK_TIMEOUT_ENABLED=1
 


### PR DESCRIPTION
The macro `NRF_802154_TX_STARTED_NOTIFY_ENABLED` has been removed from the nRF 802.15.4 Radio Driver.
Setting it in CMakeLists.txt became pointless and is removed.