### PR TITLE
soc: nordic: nrf54h: uicr: Improve deps for uicr/zephyr/zephyr.hex

### DIFF
--- a/soc/nordic/common/uicr/sysbuild.cmake
+++ b/soc/nordic/common/uicr/sysbuild.cmake
@@ -9,7 +9,23 @@ ExternalZephyrProject_Add(
 # Ensure UICR is configured and built after the default image so EDT/ELFs exist.
 sysbuild_add_dependencies(CONFIGURE uicr ${DEFAULT_IMAGE})
 
-add_dependencies(uicr ${DEFAULT_IMAGE})
-if(DEFINED image)
-  add_dependencies(uicr ${image})
-endif()
+# Add build dependencies for all images whose ELF files may be used by gen_uicr.
+# The gen_uicr/CMakeLists.txt scans all sibling build directories and adds their
+# ELF files as file dependencies. However, we also need target dependencies to
+# ensure those images are built before uicr attempts to use their ELF files.
+#
+# Use cmake_language(DEFER DIRECTORY) to ensure this runs after ALL images have
+# been added to the sysbuild_images global property, even if some module adds
+# images after the soc subdirectory is processed. We defer to the source root
+# directory to ensure we're at the top-level scope where all subdirectories have
+# completed processing.
+function(uicr_add_image_dependencies)
+  get_property(all_images GLOBAL PROPERTY sysbuild_images)
+  foreach(img ${all_images})
+    if(NOT img STREQUAL "uicr")
+      add_dependencies(uicr ${img})
+    endif()
+  endforeach()
+endfunction()
+
+cmake_language(DEFER DIRECTORY ${CMAKE_SOURCE_DIR} CALL uicr_add_image_dependencies)


### PR DESCRIPTION
uicr/zephyr/zephyr.hex needs to be built after all other zephyr images.

Instead of adding a dependency on uicr, we check the sysbuild_images property to find images.

Also, we check it as late possible by using the cmake_language(DEFER DIRECTORY feature. Which will ensure that running this code will be one of the last things that the CMake sysbuild program does at Configure time.