### PR TITLE
boards: remove supported feature 'usb'

### DIFF
--- a/boards/adafruit/trinkey_qt2040/adafruit_trinkey_qt2040.yaml
+++ b/boards/adafruit/trinkey_qt2040/adafruit_trinkey_qt2040.yaml
@@ -15,6 +15,5 @@ supported:
   - gpio
   - hwinfo
   - i2c
-  - usb
   - watchdog
   - zephyr_i2c

--- a/boards/egis/egis_et171/egis_et171.yaml
+++ b/boards/egis/egis_et171/egis_et171.yaml
@@ -15,4 +15,3 @@ testing:
   ignore_tags:
     - bluetooth
     - spi
-    - usb

--- a/boards/others/canbardo/canbardo.yaml
+++ b/boards/others/canbardo/canbardo.yaml
@@ -13,6 +13,5 @@ ram: 384
 supported:
   - can
   - gpio
-  - usb
   - usb_device
 vendor: others

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.yaml
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.yaml
@@ -19,6 +19,5 @@ supported:
   - rtc
   - spi
   - usart
-  - usb
 ram: 40
 flash: 256


### PR DESCRIPTION
Suppoted feature 'usb' is not required or used in any of the USB samples or tests. The only valid feature for USB is `usbd`, or `usb_device` for the legacy samples and tests.