### PR TITLE
sys: util_macro: Support macros as arguments

### DIFF
--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -388,7 +388,7 @@ extern "C" {
  *
  * @return Nth argument.
  */
-#define GET_ARG_N(N, ...) Z_GET_ARG_##N(__VA_ARGS__)
+#define GET_ARG_N(N, ...) UTIL_CAT(Z_GET_ARG_, N)(__VA_ARGS__)
 
 /**
  * @brief Strips n first arguments from the argument list.
@@ -398,7 +398,7 @@ extern "C" {
  *
  * @return argument list without N first arguments.
  */
-#define GET_ARGS_LESS_N(N, ...) Z_GET_ARGS_LESS_##N(__VA_ARGS__)
+#define GET_ARGS_LESS_N(N, ...) UTIL_CAT(Z_GET_ARGS_LESS_, N)(__VA_ARGS__)
 
 /**
  * @brief Like <tt>a || b</tt>, but does evaluation and

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -534,20 +534,25 @@ ZTEST(util, test_nested_FOR_EACH) {
 	zassert_equal(a2, 2);
 }
 
+#define TWO 2 /* to showcase that GET_ARG_N and GET_ARGS_LESS_N also work with macros */
+
 ZTEST(util, test_GET_ARG_N) {
 	int a = GET_ARG_N(1, 10, 100, 1000);
 	int b = GET_ARG_N(2, 10, 100, 1000);
 	int c = GET_ARG_N(3, 10, 100, 1000);
+	int d = GET_ARG_N(TWO, 10, 100, 1000);
 
 	zassert_equal(a, 10);
 	zassert_equal(b, 100);
 	zassert_equal(c, 1000);
+	zassert_equal(d, 100);
 }
 
 ZTEST(util, test_GET_ARGS_LESS_N) {
 	uint8_t a[] = { GET_ARGS_LESS_N(0, 1, 2, 3) };
 	uint8_t b[] = { GET_ARGS_LESS_N(1, 1, 2, 3) };
 	uint8_t c[] = { GET_ARGS_LESS_N(2, 1, 2, 3) };
+	uint8_t d[] = { GET_ARGS_LESS_N(TWO, 1, 2, 3) };
 
 	zassert_equal(sizeof(a), 3);
 
@@ -557,6 +562,9 @@ ZTEST(util, test_GET_ARGS_LESS_N) {
 
 	zassert_equal(sizeof(c), 1);
 	zassert_equal(c[0], 3);
+
+	zassert_equal(sizeof(d), 1);
+	zassert_equal(d[0], 3);
 }
 
 ZTEST(util, test_mixing_GET_ARG_and_FOR_EACH) {


### PR DESCRIPTION
I adjusted GET_ARG_N and GET_ARGS_LESS_N to use UTIL_CAT instead of simple concatenation. This allows to use a macro as the argument N instead of only literal numbers. So for example this would be possible now:

```
#define CONFIG_BAUDRATE_INDEX 3 /* from kconfig */
uint32_t baudrate = GET_ARG_N(CONFIG_BAUDRATE_INDEX, 9600, 19200, 38400, 57600);
/* baudrate == 38400 */
```


I also adjusted the unit tests to showcase this. (I can also revert this part, if it is not wished to have this in the tests.)