### PR TITLE
drivers: flash: nrf_mram: Add more robustness for write

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -152,3 +152,5 @@ zephyr_udc0: &usbhs {
 &lfclk {
 	status = "okay";
 };
+
+ironside_se_boot_report: &cpurad_ironside_se_boot_report {};

--- a/drivers/flash/Kconfig.nrf_mram
+++ b/drivers/flash/Kconfig.nrf_mram
@@ -8,9 +8,12 @@ config SOC_FLASH_NRF_MRAM
 	bool "Nordic Semiconductor flash driver for MRAM"
 	default y
 	depends on DT_HAS_NORDIC_MRAM_ENABLED
+	select NRFX_MRAMC
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_NO_EXPLICIT_ERASE
+	imply NRFS
+	imply MRAM_LATENCY
 	imply MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	help
 	  Enables Nordic Semiconductor flash driver for MRAM in direct write mode.

--- a/drivers/flash/Kconfig.nrf_mram
+++ b/drivers/flash/Kconfig.nrf_mram
@@ -8,7 +8,7 @@ config SOC_FLASH_NRF_MRAM
 	bool "Nordic Semiconductor flash driver for MRAM"
 	default y
 	depends on DT_HAS_NORDIC_MRAM_ENABLED
-	select NRFX_MRAMC
+	depends on HAS_NRFX
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_NO_EXPLICIT_ERASE
@@ -21,3 +21,15 @@ config SOC_FLASH_NRF_MRAM
 	  Note that MRAM words are auto-erased when written to, but writing to a
 	  pre-erased area is faster. Hence, the erase API is not required, but
 	  it can be used to amortize write performance for some use cases.
+
+config NRF_MRAM_MAX_RETRIES
+	int "Maximum number of retries for MRAM write/erase operations"
+	default 20
+	range 0 255
+	depends on SOC_FLASH_NRF_MRAM
+	help
+	  This option sets the maximum number of retry attempts for MRAM
+	  write and erase operations when verification fails. Each retry
+	  attempts to rewrite or re-erase the data to ensure reliability.
+	  Higher values increase reliability but may impact performance
+	  in case of persistent failures.

--- a/drivers/flash/soc_flash_nrf_mram.c
+++ b/drivers/flash/soc_flash_nrf_mram.c
@@ -10,7 +10,6 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/barrier.h>
 #include <zephyr/cache.h>
-#include <nrfx_mramc.h>
 #include <ironside/se/versions.h>
 #if defined(CONFIG_MRAM_LATENCY)
 #include "../soc/nordic/common/mram_latency.h"
@@ -18,6 +17,9 @@
 #if defined(CONFIG_HAS_IRONSIDE_SE)
 #include <ironside/se/boot_report.h>
 #endif
+#include <hal/nrf_cache.h>
+#include <hal/nrf_mvdma.h>
+#include <haly/nrfy_mvdma.h>
 
 LOG_MODULE_REGISTER(flash_nrf_mram, CONFIG_FLASH_LOG_LEVEL);
 
@@ -32,6 +34,13 @@ LOG_MODULE_REGISTER(flash_nrf_mram, CONFIG_FLASH_LOG_LEVEL);
 #define WRITE_BLOCK_SIZE DT_INST_PROP_OR(0, write_block_size, MRAM_WORD_SIZE)
 #define ERASE_BLOCK_SIZE DT_INST_PROP_OR(0, erase_block_size, WRITE_BLOCK_SIZE)
 
+#if (WRITE_BLOCK_SIZE & MRAM_WORD_MASK)
+#warning "write-block-size is not a multiple of 16 bytes. \
+This may lead to data corruption in corner cases where partial writes to MRAM words are needed. \
+If a partial write fails and a read-modify-write is needed for recovery, the read may return \
+corrupted data due to the previous corrupted write, which can cause the recovery to fail as well."
+#endif
+
 #define ERASE_VALUE 0xff
 
 #define SOC_NRF_MRAM_BANK_11_OFFSET  (MRAM_SIZE / 2)
@@ -43,9 +52,148 @@ BUILD_ASSERT(MRAM_START > 0, "nordic,mram: start address expected to be non-zero
 BUILD_ASSERT((ERASE_BLOCK_SIZE % WRITE_BLOCK_SIZE) == 0,
 	     "erase-block-size expected to be a multiple of write-block-size");
 
+/** MVDMA Attribute field offset. */
+#define NRF_MVDMA_ATTR_OFF 24
+
+/** MVDMA Extended attribute field offset. */
+#define NRF_MVDMA_EXT_ATTR_OFF 30
+
+/** @brief Default transfer. */
+#define NRF_MVDMA_ATTR_DEFAULT 7
+
+#define NRF_MVDMA_JOB_ATTR(_size, _attr, _ext_attr)                                                \
+	(((_size) & 0xFFFFFF) | ((_attr) << NRF_MVDMA_ATTR_OFF) |                                  \
+	 ((_ext_attr) << NRF_MVDMA_EXT_ATTR_OFF))
+
+#define NRF_MVDMA_BASIC_INIT(_src, _src_len, _src_attr, _src_ext_attr, _sink, _sink_len,           \
+			     _sink_attr, _sink_ext_attr)                                           \
+	{                                                                                          \
+		.source = (uint32_t)(_src),                                                        \
+		.source_attr_len = NRF_MVDMA_JOB_ATTR((_src_len), _src_attr, _src_ext_attr),       \
+		.source_terminate = 0,                                                             \
+		.source_padding = 0,                                                               \
+		.sink = (uint32_t)(_sink),                                                         \
+		.sink_attr_len = NRF_MVDMA_JOB_ATTR((_sink_len), _sink_attr, _sink_ext_attr),      \
+		.sink_terminate = 0,                                                               \
+		.sink_padding = 0,                                                                 \
+	}
+
+#define NRF_MVDMA_BASIC_MEMCPY_INIT(_dst, _src, _len)                                              \
+	NRF_MVDMA_BASIC_INIT(_src, _len, NRF_MVDMA_ATTR_DEFAULT, 0, _dst, _len,                    \
+			     NRF_MVDMA_ATTR_DEFAULT, 0)
+
+struct mvdma_basic_desc {
+	uint32_t source;
+	uint32_t source_attr_len;
+	uint32_t source_terminate;
+	uint32_t source_padding;
+	uint32_t sink;
+	uint32_t sink_attr_len;
+	uint32_t sink_terminate;
+	uint32_t sink_padding;
+};
+
 struct nrf_mram_data_t {
 	uint8_t ironside_se_ver;
+	struct k_mutex nrf_mram_mutex;
 };
+
+/**
+ * @brief Verify MRAM word using MVDMA read operation.
+ *
+ * Uses the MVDMA peripheral to read one MRAM_WORD_SIZE (16 bytes) from the
+ * specified address. This operation serves as a verification mechanism after
+ * write/erase operations by checking if a bus fault occurs or if the operation
+ * completes successfully.
+ *
+ * @param addr The MRAM address to read from.
+ * @return 0 on success, -EIO if a bus error is detected.
+ */
+static int nrf_mram_mvdma_read(uint32_t addr)
+{
+	uint8_t rbuf[MRAM_WORD_SIZE];
+	struct mvdma_basic_desc desc __aligned(4) =
+		NRF_MVDMA_BASIC_MEMCPY_INIT(rbuf, addr, MRAM_WORD_SIZE);
+
+	sys_cache_data_flush_range(&desc, sizeof(desc));
+	nrf_mvdma_event_clear(NRF_MVDMA, NRF_MVDMA_EVENT_COMPLETED0);
+	nrf_mvdma_source_list_ptr_set(NRF_MVDMA, (void *)&desc.source);
+	nrf_mvdma_sink_list_ptr_set(NRF_MVDMA, (void *)&desc.sink);
+	nrf_mvdma_task_trigger(NRF_MVDMA, NRF_MVDMA_TASK_START0);
+	while (!nrf_mvdma_event_check(NRF_MVDMA, NRF_MVDMA_EVENT_COMPLETED0)) {
+		/* Wait until transfer is complete */
+		if (nrf_mvdma_event_check(NRF_MVDMA, NRF_MVDMA_EVENT_SOURCEBUSERROR)) {
+			nrf_mvdma_event_clear(NRF_MVDMA, NRF_MVDMA_EVENT_SOURCEBUSERROR);
+			LOG_ERR("MVDMA source bus error");
+			nrfy_mvdma_reset(NRF_MVDMA, true);
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+static int nrf_mram_write_and_verify(uint32_t addr, const void *data, size_t len)
+{
+	uint8_t retries = CONFIG_NRF_MRAM_MAX_RETRIES;
+#if (WRITE_BLOCK_SIZE & MRAM_WORD_MASK)
+	uint8_t rbuf[MRAM_WORD_SIZE];
+
+	if (len % MRAM_WORD_SIZE) {
+		/* For partial word writes, we need to read the existing data first to avoid
+		 * overwriting the unwritten bytes in the same word.
+		 */
+		memcpy(rbuf + len, (void *)(addr + len), MRAM_WORD_SIZE - len);
+		memcpy(rbuf, data, len);
+		data = rbuf;
+		len = MRAM_WORD_SIZE;
+	}
+#endif
+
+	while (retries--) {
+		memcpy((void *)addr, data, len);
+		if (!nrf_mram_mvdma_read(addr)) {
+			return 0;
+		}
+		LOG_ERR("MRAM write verification failed at address 0x%x, retrying... (%u retries "
+			"left)",
+			addr, retries);
+	}
+
+	return -EIO;
+}
+
+static int nrf_mram_erase_and_verify(uint32_t addr, size_t len)
+{
+	uint8_t retries = CONFIG_NRF_MRAM_MAX_RETRIES;
+#if (WRITE_BLOCK_SIZE & MRAM_WORD_MASK)
+	uint8_t rbuf[MRAM_WORD_SIZE];
+
+	if (len % MRAM_WORD_SIZE) {
+		/* For partial word writes, we need to read the existing data first to avoid
+		 * overwriting the unwritten bytes in the same word.
+		 */
+		memcpy(rbuf, (void *)(addr + len), MRAM_WORD_SIZE - len);
+	}
+#endif
+
+	while (retries--) {
+		memset((void *)addr, ERASE_VALUE, len);
+#if (WRITE_BLOCK_SIZE & MRAM_WORD_MASK)
+		if (len % MRAM_WORD_SIZE) {
+			memcpy((void *)addr, rbuf, MRAM_WORD_SIZE - len);
+		}
+#endif
+		if (!nrf_mram_mvdma_read(addr)) {
+			return 0;
+		}
+		LOG_ERR("MRAM erase verification failed at address 0x%x, retrying... (%u retries "
+			"left)",
+			addr, retries);
+	}
+
+	return -EIO;
+}
 
 #ifdef CONFIG_MRAM_LATENCY
 static inline bool nrf_mram_ready(uint32_t addr, uint8_t ironside_se_ver)
@@ -55,9 +203,9 @@ static inline bool nrf_mram_ready(uint32_t addr, uint8_t ironside_se_ver)
 	}
 
 	if (addr < SOC_NRF_MRAM_BANK_11_ADDRESS) {
-		return nrf_mramc_ready_get(NRF_MRAMC110);
+		return (bool)NRF_MRAMC110->READY;
 	} else {
-		return nrf_mramc_ready_get(NRF_MRAMC111);
+		return (bool)NRF_MRAMC111->READY;
 	}
 }
 #else
@@ -86,40 +234,13 @@ static uintptr_t validate_and_map_addr(off_t offset, size_t len, bool must_align
 
 	const uintptr_t addr = MRAM_START + offset;
 
-	if (WRITE_BLOCK_SIZE > 1 && must_align &&
+	if ((WRITE_BLOCK_SIZE > 1) && must_align &&
 	    unlikely((addr % WRITE_BLOCK_SIZE) != 0 || (len % WRITE_BLOCK_SIZE) != 0)) {
 		LOG_ERR("invalid alignment: %p:%zu", (void *)addr, len);
 		return 0;
 	}
 
 	return addr;
-}
-
-/**
- * @param[in] addr_end  Last modified MRAM address (not inclusive).
- */
-static void commit_changes(uintptr_t addr_end)
-{
-	/* Barrier following our last write. */
-	barrier_dmem_fence_full();
-
-	if ((WRITE_BLOCK_SIZE & MRAM_WORD_MASK) == 0 || (addr_end & MRAM_WORD_MASK) == 0) {
-		/* Our last operation was MRAM word-aligned, so we're done.
-		 * Note: if WRITE_BLOCK_SIZE is a multiple of MRAM_WORD_SIZE,
-		 * then this was already checked in validate_and_map_addr().
-		 */
-		return;
-	}
-
-	/* Get the most significant byte (MSB) of the last MRAM word we were modifying.
-	 * Writing to this byte makes the MRAM controller commit other pending writes to that word.
-	 */
-	addr_end |= MRAM_WORD_MASK;
-
-	/* Issue a dummy write, since we didn't have anything to write here.
-	 * Doing this lets us finalize our changes before we exit the driver API.
-	 */
-	sys_write8(sys_read8(addr_end), addr_end);
 }
 
 static int nrf_mram_read(const struct device *dev, off_t offset, void *data, size_t len)
@@ -143,6 +264,7 @@ static int nrf_mram_write(const struct device *dev, off_t offset, const void *da
 {
 	struct nrf_mram_data_t *nrf_mram_data = dev->data;
 	uint8_t ironside_se_ver = nrf_mram_data->ironside_se_ver;
+	int ret = 0;
 
 	const uintptr_t addr = validate_and_map_addr(offset, len, true);
 
@@ -152,40 +274,54 @@ static int nrf_mram_write(const struct device *dev, off_t offset, const void *da
 
 	LOG_DBG("write: %p:%zu", (void *)addr, len);
 
+	k_mutex_lock(&nrf_mram_data->nrf_mram_mutex, K_FOREVER);
+
 	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
 #if defined(CONFIG_MRAM_LATENCY)
 		mram_no_latency_sync_request();
 #endif
 	}
+
 	for (uint32_t i = 0; i < (len / MRAM_WORD_SIZE); i++) {
 		while (!nrf_mram_ready(addr + (i * MRAM_WORD_SIZE), ironside_se_ver)) {
 			/* Wait until MRAM controller is ready */
 		}
-		memcpy((void *)(addr + (i * MRAM_WORD_SIZE)),
-		       (void *)((uintptr_t)data + (i * MRAM_WORD_SIZE)), MRAM_WORD_SIZE);
+		ret = nrf_mram_write_and_verify(addr + (i * MRAM_WORD_SIZE),
+						(void *)((uintptr_t)data + (i * MRAM_WORD_SIZE)),
+						MRAM_WORD_SIZE);
+		if (ret) {
+			goto unlock;
+		}
 	}
-
+#if (WRITE_BLOCK_SIZE & MRAM_WORD_MASK)
 	if (len % MRAM_WORD_SIZE) {
 		while (!nrf_mram_ready(addr + (len & ~MRAM_WORD_MASK), ironside_se_ver)) {
 			/* Wait until MRAM controller is ready */
 		}
-		memcpy((void *)(addr + (len & ~MRAM_WORD_MASK)),
-		       (void *)((uintptr_t)data + (len & ~MRAM_WORD_MASK)), len & MRAM_WORD_MASK);
+		ret = nrf_mram_write_and_verify(addr + (len & ~MRAM_WORD_MASK),
+						(void *)((uintptr_t)data + (len & ~MRAM_WORD_MASK)),
+						len & MRAM_WORD_MASK);
+		if (ret) {
+			goto unlock;
+		}
 	}
-	commit_changes(addr + len);
+#endif
 	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
 #if defined(CONFIG_MRAM_LATENCY)
 		mram_no_latency_sync_release();
 #endif
 	}
 
-	return 0;
+unlock:
+	k_mutex_unlock(&nrf_mram_data->nrf_mram_mutex);
+	return ret;
 }
 
 static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 {
 	struct nrf_mram_data_t *nrf_mram_data = dev->data;
 	uint8_t ironside_se_ver = nrf_mram_data->ironside_se_ver;
+	int ret = 0;
 
 	const uintptr_t addr = validate_and_map_addr(offset, size, true);
 
@@ -194,6 +330,8 @@ static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 	}
 
 	LOG_DBG("erase: %p:%zu", (void *)addr, size);
+
+	k_mutex_lock(&nrf_mram_data->nrf_mram_mutex, K_FOREVER);
 
 	/* Ensure that the mramc banks are powered on */
 	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
@@ -205,23 +343,34 @@ static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 		while (!nrf_mram_ready(addr + (i * MRAM_WORD_SIZE), ironside_se_ver)) {
 			/* Wait until MRAM controller is ready */
 		}
-		memset((void *)(addr + (i * MRAM_WORD_SIZE)), ERASE_VALUE, MRAM_WORD_SIZE);
+		ret = nrf_mram_erase_and_verify(addr + (i * MRAM_WORD_SIZE), MRAM_WORD_SIZE);
+		if (ret) {
+			goto unlock;
+		}
 	}
+
+#if (WRITE_BLOCK_SIZE & MRAM_WORD_MASK)
 	if (size % MRAM_WORD_SIZE) {
 		while (!nrf_mram_ready(addr + (size & ~MRAM_WORD_MASK), ironside_se_ver)) {
 			/* Wait until MRAM controller is ready */
 		}
-		memset((void *)(addr + (size & ~MRAM_WORD_MASK)), ERASE_VALUE,
-		       size & MRAM_WORD_MASK);
+		ret = nrf_mram_erase_and_verify(addr + (size & ~MRAM_WORD_MASK),
+						size & MRAM_WORD_MASK);
+		if (ret) {
+			goto unlock;
+		}
 	}
-	commit_changes(addr + size);
+#endif
+
 	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
 #if defined(CONFIG_MRAM_LATENCY)
 		mram_no_latency_sync_release();
 #endif
 	}
 
-	return 0;
+unlock:
+	k_mutex_unlock(&nrf_mram_data->nrf_mram_mutex);
+	return ret;
 }
 
 static int nrf_mram_get_size(const struct device *dev, uint64_t *size)
@@ -284,6 +433,8 @@ static int nrf_mram_init(const struct device *dev)
 	nrf_mram_data->ironside_se_ver = 0;
 #endif
 	LOG_DBG("Ironside SE version: %u", nrf_mram_data->ironside_se_ver);
+
+	k_mutex_init(&nrf_mram_data->nrf_mram_mutex);
 
 	return 0;
 }

--- a/drivers/flash/soc_flash_nrf_mram.c
+++ b/drivers/flash/soc_flash_nrf_mram.c
@@ -9,6 +9,15 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/barrier.h>
+#include <zephyr/cache.h>
+#include <nrfx_mramc.h>
+#include <ironside/se/versions.h>
+#if defined(CONFIG_MRAM_LATENCY)
+#include "../soc/nordic/common/mram_latency.h"
+#endif
+#if defined(CONFIG_HAS_IRONSIDE_SE)
+#include <ironside/se/boot_report.h>
+#endif
 
 LOG_MODULE_REGISTER(flash_nrf_mram, CONFIG_FLASH_LOG_LEVEL);
 
@@ -25,9 +34,40 @@ LOG_MODULE_REGISTER(flash_nrf_mram, CONFIG_FLASH_LOG_LEVEL);
 
 #define ERASE_VALUE 0xff
 
+#define SOC_NRF_MRAM_BANK_11_OFFSET  (MRAM_SIZE / 2)
+#define SOC_NRF_MRAM_BANK_11_ADDRESS (MRAM_START + SOC_NRF_MRAM_BANK_11_OFFSET)
+
+#define IRONSIDE_SE_SUPPORT_READY_VER IRONSIDE_SE_V23_1_2_21
+
 BUILD_ASSERT(MRAM_START > 0, "nordic,mram: start address expected to be non-zero");
 BUILD_ASSERT((ERASE_BLOCK_SIZE % WRITE_BLOCK_SIZE) == 0,
 	     "erase-block-size expected to be a multiple of write-block-size");
+
+struct nrf_mram_data_t {
+	uint8_t ironside_se_ver;
+};
+
+#ifdef CONFIG_MRAM_LATENCY
+static inline bool nrf_mram_ready(uint32_t addr, uint8_t ironside_se_ver)
+{
+	if (ironside_se_ver < IRONSIDE_SE_SUPPORT_READY_VER) {
+		return true;
+	}
+
+	if (addr < SOC_NRF_MRAM_BANK_11_ADDRESS) {
+		return nrf_mramc_ready_get(NRF_MRAMC110);
+	} else {
+		return nrf_mramc_ready_get(NRF_MRAMC111);
+	}
+}
+#else
+static inline bool nrf_mram_ready(uint32_t addr, uint8_t ironside_se_ver)
+{
+	ARG_UNUSED(addr);
+	ARG_UNUSED(ironside_se_ver);
+	return true;
+}
+#endif
 
 /**
  * @param[in,out] offset      Relative offset into memory, from the driver API.
@@ -101,7 +141,8 @@ static int nrf_mram_read(const struct device *dev, off_t offset, void *data, siz
 
 static int nrf_mram_write(const struct device *dev, off_t offset, const void *data, size_t len)
 {
-	ARG_UNUSED(dev);
+	struct nrf_mram_data_t *nrf_mram_data = dev->data;
+	uint8_t ironside_se_ver = nrf_mram_data->ironside_se_ver;
 
 	const uintptr_t addr = validate_and_map_addr(offset, len, true);
 
@@ -111,15 +152,40 @@ static int nrf_mram_write(const struct device *dev, off_t offset, const void *da
 
 	LOG_DBG("write: %p:%zu", (void *)addr, len);
 
-	memcpy((void *)addr, data, len);
+	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
+#if defined(CONFIG_MRAM_LATENCY)
+		mram_no_latency_sync_request();
+#endif
+	}
+	for (uint32_t i = 0; i < (len / MRAM_WORD_SIZE); i++) {
+		while (!nrf_mram_ready(addr + (i * MRAM_WORD_SIZE), ironside_se_ver)) {
+			/* Wait until MRAM controller is ready */
+		}
+		memcpy((void *)(addr + (i * MRAM_WORD_SIZE)),
+		       (void *)((uintptr_t)data + (i * MRAM_WORD_SIZE)), MRAM_WORD_SIZE);
+	}
+
+	if (len % MRAM_WORD_SIZE) {
+		while (!nrf_mram_ready(addr + (len & ~MRAM_WORD_MASK), ironside_se_ver)) {
+			/* Wait until MRAM controller is ready */
+		}
+		memcpy((void *)(addr + (len & ~MRAM_WORD_MASK)),
+		       (void *)((uintptr_t)data + (len & ~MRAM_WORD_MASK)), len & MRAM_WORD_MASK);
+	}
 	commit_changes(addr + len);
+	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
+#if defined(CONFIG_MRAM_LATENCY)
+		mram_no_latency_sync_release();
+#endif
+	}
 
 	return 0;
 }
 
 static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 {
-	ARG_UNUSED(dev);
+	struct nrf_mram_data_t *nrf_mram_data = dev->data;
+	uint8_t ironside_se_ver = nrf_mram_data->ironside_se_ver;
 
 	const uintptr_t addr = validate_and_map_addr(offset, size, true);
 
@@ -129,8 +195,31 @@ static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 
 	LOG_DBG("erase: %p:%zu", (void *)addr, size);
 
-	memset((void *)addr, ERASE_VALUE, size);
+	/* Ensure that the mramc banks are powered on */
+	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
+#if defined(CONFIG_MRAM_LATENCY)
+		mram_no_latency_sync_request();
+#endif
+	}
+	for (uint32_t i = 0; i < (size / MRAM_WORD_SIZE); i++) {
+		while (!nrf_mram_ready(addr + (i * MRAM_WORD_SIZE), ironside_se_ver)) {
+			/* Wait until MRAM controller is ready */
+		}
+		memset((void *)(addr + (i * MRAM_WORD_SIZE)), ERASE_VALUE, MRAM_WORD_SIZE);
+	}
+	if (size % MRAM_WORD_SIZE) {
+		while (!nrf_mram_ready(addr + (size & ~MRAM_WORD_MASK), ironside_se_ver)) {
+			/* Wait until MRAM controller is ready */
+		}
+		memset((void *)(addr + (size & ~MRAM_WORD_MASK)), ERASE_VALUE,
+		       size & MRAM_WORD_MASK);
+	}
 	commit_changes(addr + size);
+	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
+#if defined(CONFIG_MRAM_LATENCY)
+		mram_no_latency_sync_release();
+#endif
+	}
 
 	return 0;
 }
@@ -186,5 +275,20 @@ static DEVICE_API(flash, nrf_mram_api) = {
 #endif
 };
 
-DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY,
-		      &nrf_mram_api);
+static int nrf_mram_init(const struct device *dev)
+{
+	struct nrf_mram_data_t *nrf_mram_data = dev->data;
+#if defined(CONFIG_HAS_IRONSIDE_SE) && defined(IRONSIDE_SE_BOOT_REPORT)
+	nrf_mram_data->ironside_se_ver = IRONSIDE_SE_BOOT_REPORT->ironside_se_version_int;
+#else
+	nrf_mram_data->ironside_se_ver = 0;
+#endif
+	LOG_DBG("Ironside SE version: %u", nrf_mram_data->ironside_se_ver);
+
+	return 0;
+}
+
+static struct nrf_mram_data_t nrf_mram_data;
+
+DEVICE_DT_INST_DEFINE(0, nrf_mram_init, NULL, &nrf_mram_data, NULL, POST_KERNEL,
+		      CONFIG_FLASH_INIT_PRIORITY, &nrf_mram_api);

--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -162,7 +162,7 @@ config NRFX_LPCOMP
 
 config NRFX_MRAMC
 	bool "MRAMC driver"
-	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_MRAMC))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_MRAMC)) || $(dt_has_compat,$(DT_COMPAT_NORDIC_MRAM))
 
 config NRFX_NFCT
 	bool "NFCT driver"


### PR DESCRIPTION
When writes are issued to the mram controller without verifying that it is ready, it can cause the reads to be stalled until all writes finish. Fix this by adding a wait busy loop before any MRAM_WORD aligned write.
Moreover when writing to weak words, it can cause a Bus Fault. Avoid this by using the MVDMA to capture the fault and recover from it.