### PR TITLE
scripts: Don't use isort known-first-party

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -25,20 +25,6 @@ ignore = [
     # zephyr-keep-sorted-stop
 ]
 
-[lint.isort]
-known-first-party = [
-    # zephyr-keep-sorted-start
-    "camera_shield",
-    "domains",
-    "list_boards",
-    "scl",
-    "twister",
-    "twister_harness",
-    "twisterlib",
-    "zephyr_module" ,
-    # zephyr-keep-sorted-stop
-]
-
 [format]
 quote-style = "preserve"
 line-ending = "lf"

--- a/scripts/tests/twister/conftest.py
+++ b/scripts/tests/twister/conftest.py
@@ -8,7 +8,6 @@ import logging
 import os
 
 import pytest
-
 from twisterlib.environment import TwisterEnv, add_parse_arguments, parse_arguments
 from twisterlib.testinstance import TestInstance
 from twisterlib.testplan import TestConfiguration, TestPlan

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from twisterlib.harness import Pytest
 from twisterlib.platform import Platform
 from twisterlib.testinstance import TestInstance

--- a/scripts/tests/twister/test_cmakecache.py
+++ b/scripts/tests/twister/test_cmakecache.py
@@ -10,7 +10,6 @@ from contextlib import nullcontext
 from unittest import mock
 
 import pytest
-
 from twisterlib.cmakecache import CMakeCache, CMakeCacheEntry
 
 TESTDATA_1 = [

--- a/scripts/tests/twister/test_config_parser.py
+++ b/scripts/tests/twister/test_config_parser.py
@@ -12,7 +12,6 @@ from contextlib import nullcontext
 from unittest import mock
 
 import pytest
-
 import scl
 from twisterlib.config_parser import (
     ConfigurationError,

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -13,7 +13,6 @@ from contextlib import nullcontext
 from unittest import mock
 
 import pytest
-
 import twisterlib.environment
 
 TESTDATA_1 = [

--- a/scripts/tests/twister/test_errors.py
+++ b/scripts/tests/twister/test_errors.py
@@ -10,7 +10,6 @@ import os
 from pathlib import Path
 
 import pytest
-
 from twisterlib.error import ConfigurationError, StatusAttributeError
 from twisterlib.harness import Test
 

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -19,9 +19,8 @@ from types import SimpleNamespace
 from unittest import mock
 
 import pytest
-from serial import SerialException
-
 import twisterlib.harness
+from serial import SerialException
 from twisterlib.error import TwisterException
 from twisterlib.handlers import (
     BinaryHandler,

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from twisterlib.hardwaremap import DUT, HardwareMap
 
 

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -13,7 +13,6 @@ import textwrap
 from unittest import mock
 
 import pytest
-
 from twisterlib.harness import (
     Bsim,
     Console,

--- a/scripts/tests/twister/test_log_helper.py
+++ b/scripts/tests/twister/test_log_helper.py
@@ -11,7 +11,6 @@ from importlib import reload
 from unittest import mock
 
 import pytest
-
 import twisterlib.log_helper
 
 TESTDATA = [

--- a/scripts/tests/twister/test_platform.py
+++ b/scripts/tests/twister/test_platform.py
@@ -11,7 +11,6 @@ from unittest import mock
 
 import pytest
 from pykwalify.errors import SchemaError
-
 from twisterlib.platform import Platform, Simulator, generate_platforms
 
 TESTDATA_1 = [

--- a/scripts/tests/twister/test_quarantine.py
+++ b/scripts/tests/twister/test_quarantine.py
@@ -11,7 +11,6 @@ import textwrap
 from unittest import mock
 
 import pytest
-
 from twisterlib.quarantine import QuarantineData, QuarantineElement, QuarantineException
 
 TESTDATA_1 = [

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -20,7 +20,6 @@ from unittest import mock
 import pytest
 import yaml
 from elftools.elf.sections import SymbolTableSection
-
 from twisterlib.error import BuildError
 from twisterlib.harness import Pytest
 from twisterlib.runner import CMake, ExecutionCounter, FilterBuilder, ProjectBuilder, TwisterRunner

--- a/scripts/tests/twister/test_scl.py
+++ b/scripts/tests/twister/test_scl.py
@@ -13,10 +13,9 @@ from importlib import reload
 from unittest import mock
 
 import pytest
+import scl
 from pykwalify.errors import SchemaError
 from yaml.scanner import ScannerError
-
-import scl
 
 TESTDATA_1 = [
     (False,),

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -13,7 +13,6 @@ from unittest import mock
 
 import pytest
 from expr_parser import reserved
-
 from twisterlib.error import BuildError
 from twisterlib.handlers import QEMUHandler
 from twisterlib.platform import Simulator

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from twisterlib.error import TwisterRuntimeError
 from twisterlib.platform import Platform
 from twisterlib.quarantine import Quarantine

--- a/scripts/tests/twister/test_testsuite.py
+++ b/scripts/tests/twister/test_testsuite.py
@@ -12,7 +12,6 @@ from contextlib import nullcontext
 from unittest import mock
 
 import pytest
-
 from twisterlib.error import TwisterException, TwisterRuntimeError
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testsuite import (

--- a/scripts/tests/twister/test_twister.py
+++ b/scripts/tests/twister/test_twister.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 import scl
 from twisterlib.error import ConfigurationError
 from twisterlib.testplan import TwisterConfigParser


### PR DESCRIPTION
Partially revert 1bcc0652241af70d0b28aee155f260cd9ca0fc74

This change impacts all other scripts that import those modules, while those weren't updated.

It will be hard to maintain this list, whilst keeping the entire tree compliant.

Running the linter on the tree:

```shell
# before
$ ruff check .
Found 54 errors.
# after
$ ruff check .
All checks passed!
```