### PR TITLE
lib: os: cbprintf: fix conditional initializer being inconsistent

### DIFF
--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -760,7 +760,7 @@ do { \
  * initial value to hush the compiler when compiling
  * with C++.
  */
-#if defined(CONFIG_XTENSA) && defined(__cplusplus)
+#if defined(CONFIG_XTENSA)
 #define Z_CBPRINTF_XTENSA_PKG_DESC_PADDING_INITIALIZER .xtensa_padding = { },
 #else
 #define Z_CBPRINTF_XTENSA_PKG_DESC_PADDING_INITIALIZER


### PR DESCRIPTION
In 7d56d6a this conditional initializer was added with different requirements as what is used for the definition of `xtensa_padding` in `struct cbprintf_package_desc`. There was edge cases where the initializer was added when the field does not exist which was caught by clang-tidy. This commit ensures it uses the same conditions to add the padding initializer.

---

I could verify this by changing the `struct cbprintf_package_desc` which would cause a build error. Proving that the previous change would add the initialzier when the field didn't exist due to mismatching `#if`
```C
// include/zephyr/sys/cbprintf.h

#ifdef __xtensa__

#if !defined(__cplusplus)
// This causes a build failure
#error "__xtensa__ is defined but __cplusplus is not set"
#endif


	/*
	 * On Xtensa, the first argument needs to be aligned to 8-byte.
	 * With 32-bit pointers, we need another 4 bytes padding so
	 * that whole struct cbprintf_package_hdr_ext is of multiple of
	 * 8 bytes.
	 */
	uint32_t xtensa_padding[Z_PKG_DESC_XTENSA_PADDING];
#endif
```