### PR TITLE
modem: cellular: baudrate update from devicetree

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -93,6 +93,12 @@ MISC
   the ``NRF_ETR`` symbols. Also the driver needs to be explicitly enabled via
   :kconfig:option:`DEBUG_DRIVER` as it is no longer built by default.
 
+Modem
+=====
+
+* ``CONFIG_MODEM_CELLULAR_NEW_BAUDRATE`` has been removed. Updated baudrates
+  are now specified in devicetree as the ``target-speed`` property.
+
 PWM
 ===
 

--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -63,12 +63,6 @@ config MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES
 	int "The size of the buffers used for each user pipe in bytes."
 	default 128
 
-config MODEM_CELLULAR_NEW_BAUDRATE
-	int "New baudrate to configure modem to, if supported"
-	range 9600 4000000
-	default 3000000 if DT_HAS_U_BLOX_LARA_R6_ENABLED
-	default 115200
-
 config MODEM_CELLULAR_NEW_BAUDRATE_DELAY
 	int "Time modem takes to change baudrate, in milliseconds"
 	range 0 1000

--- a/dts/bindings/modem/u-blox,lara-r6.yaml
+++ b/dts/bindings/modem/u-blox,lara-r6.yaml
@@ -11,3 +11,10 @@ properties:
   mdm-power-gpios:
     type: phandle-array
     required: true
+
+  target-speed:
+    type: int
+    default: 3000000
+    description:
+      UART baudrate which will be requested using AT commands and to which
+      UART interface will be reconfigured during initialization phase.


### PR DESCRIPTION
Move baudrate updates from a global kconfig to a devicetree property.

Implemented by extending the modem chat API to support requests to be provided from a callback instead of being statically specified.

Tested on an OOT modem using the same implementation as applied for the LARA_R6.