### PR TITLE
dts: arm: nordic: nrf5340: Add missing ranges property for QSPI

### DIFF
--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -60,7 +60,8 @@
 			reg = <0x50000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x50000000 0x10000000>;
+			ranges = <0x0 0x50000000 0x10000000>,
+				 <0x10000000 0x10000000 0x10000000>;
 
 			/* Common nRF5340 Application MCU
 			 * peripheral description


### PR DESCRIPTION
This was missing the XIP region