### PR TITLE
dts: vendor: nordic: nrf54lm20a: Fix invalid reg for USB

### DIFF
--- a/dts/vendor/nordic/nrf54lm20a.dtsi
+++ b/dts/vendor/nordic/nrf54lm20a.dtsi
@@ -212,7 +212,7 @@
 
 			usbhs: usbhs@5a000 {
 				compatible = "nordic,nrf-usbhs-nrf54l", "snps,dwc2";
-				reg = <0x5a000 0x1000>, <0x50020000 0x1a000>;
+				reg = <0x5a000 0x1000>, <0x20000 0x1a000>;
 				reg-names = "wrapper", "core";
 				interrupts = <90 NRF_DEFAULT_IRQ_PRIORITY>;
 				num-in-eps = <16>;


### PR DESCRIPTION
Fixes an invalid reg value which duplicated the parents range property