### PR TITLE
drivers: display: mipi-dbi-spi: Fix the delay for gpio CS

### DIFF
--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -63,7 +63,7 @@ extern "C" {
 		.slave = DT_REG_ADDR(node_id),				\
 		.cs = {							\
 			COND_CODE_1(DT_SPI_DEV_HAS_CS_GPIOS(node_id),	\
-			(SPI_CS_CONTROL_INIT_GPIO(node_id, _delay)),	\
+			(SPI_CS_CONTROL_INIT_GPIO(node_id, delay_)),	\
 			(SPI_CS_CONTROL_INIT_NATIVE(node_id)))		\
 			.cs_is_gpio = DT_SPI_DEV_HAS_CS_GPIOS(node_id),	\
 		},							\


### PR DESCRIPTION
Fix a typo in the argument passed to SPI_CS_CONTROL_INIT_GPIO in MIPI_DBI_SPI_CONFIG_DT

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/97581