### PR TITLE
drivers: counter: max32: Fix prescaler configuration

### DIFF
--- a/drivers/counter/counter_max32_timer.c
+++ b/drivers/counter/counter_max32_timer.c
@@ -246,12 +246,7 @@ static int max32_counter_init(const struct device *dev)
 	int prescaler_index;
 
 	prescaler_index = LOG2(cfg->prescaler);
-	if (prescaler_index == 0) {
-		tmr_cfg.pres = TMR_PRES_1; /* TMR_PRES_1 is 0 */
-	} else {
-		/* TMR_PRES_2 is  1<<X */
-		tmr_cfg.pres = TMR_PRES_2 + (prescaler_index - 1);
-	}
+	tmr_cfg.pres = prescaler_index * TMR_PRES_2;
 	tmr_cfg.mode = TMR_MODE_COMPARE;
 	tmr_cfg.cmp_cnt = cfg->info.max_top_value;
 	tmr_cfg.bitMode = 0; /* Timer Mode 32 bit */

--- a/drivers/pwm/pwm_max32.c
+++ b/drivers/pwm/pwm_max32.c
@@ -40,14 +40,9 @@ static int api_set_cycles(const struct device *dev, uint32_t channel, uint32_t p
 	mxc_tmr_regs_t *regs = cfg->regs;
 	wrap_mxc_tmr_cfg_t pwm_cfg;
 	int prescaler_index;
-	mxc_tmr_pres_t tmr_prescaler_lut[] = {
-		TMR_PRES_1,    TMR_PRES_2,    TMR_PRES_4,   TMR_PRES_8,   TMR_PRES_16,
-		TMR_PRES_32,   TMR_PRES_64,   TMR_PRES_128, TMR_PRES_256, TMR_PRES_512,
-		TMR_PRES_1024, TMR_PRES_2048, TMR_PRES_4096};
 
 	prescaler_index = LOG2(cfg->prescaler);
-	pwm_cfg.pres = tmr_prescaler_lut[prescaler_index];
-
+	pwm_cfg.pres = prescaler_index * TMR_PRES_2;
 	pwm_cfg.mode = TMR_MODE_PWM;
 	pwm_cfg.cmp_cnt = period_cycles;
 	pwm_cfg.bitMode = 0; /* Timer Mode 32 bit */


### PR DESCRIPTION
Fixes a bug in the prescaler configuration formula. Prescaler enumerations are not consecutive numbers, so the existing formula does not work as expected. <s>Add prescaler enums into a lookup table and set counter prescaler from this array using prescaler_index parameter.</s>

<s>This is the same fix introduced in https://github.com/zephyrproject-rtos/zephyr/pull/95409, but for the counter driver.</s>