### PR TITLE
soc: nxp: nxp_nbu: Fix IMU IRQ enabled too early in NXP NBU driver

### DIFF
--- a/soc/nxp/common/nxp_nbu.c
+++ b/soc/nxp/common/nxp_nbu.c
@@ -42,12 +42,10 @@ void nxp_nbu_init(void)
 #if defined(CONFIG_BT) || defined(CONFIG_IEEE802154)
 	/* NBU interface Interrupt */
 	IRQ_CONNECT(NBU_RX_IRQ_N, NBU_RX_IRQ_P, nbu_handler, 0, 0);
-	irq_enable(NBU_RX_IRQ_N);
 
 #if DT_INST_IRQ_HAS_NAME(0, wakeup_int)
 	/* Wake up done interrupt */
 	IRQ_CONNECT(NBU_WAKE_UP_IRQ_N, NBU_WAKE_UP_IRQ_P, nbu_wakeup_done_handler, 0, 0);
-	irq_enable(NBU_WAKE_UP_IRQ_N);
 #endif
 #if (DT_INST_PROP(0, wakeup_source)) && CONFIG_PM
 	NXP_ENABLE_WAKEUP_SIGNAL(NBU_RX_IRQ_N);


### PR DESCRIPTION
This commit addresses an issue where the IMU interrupt is enabled too early by the nxp_nbu driver, this leads to a race condition where the interrupt can be triggered even though the IMU driver is not fully initialized.
The interrupt shall not be enabled at Zephyr level since this will be done by the low level driver in the hal_nxp when it's ready.