### PR TITLE
HSE Trimming setting operation integration on stm32wbax

### DIFF
--- a/boards/st/nucleo_wba55cg/CMakeLists.txt
+++ b/boards/st/nucleo_wba55cg/CMakeLists.txt
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(board.c)

--- a/boards/st/nucleo_wba55cg/Kconfig
+++ b/boards/st/nucleo_wba55cg/Kconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_NUCLEO_WBA55CG
+	select BOARD_LATE_INIT_HOOK

--- a/boards/st/nucleo_wba55cg/board.c
+++ b/boards/st/nucleo_wba55cg/board.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+#include <stm32_ll_rcc.h>
+#include <stddef.h>
+#include <errno.h>
+
+typedef __PACKED_STRUCT
+{
+	uint8_t additional_data[8];	/*!< 64 bits of data to fill OTP slot Ex: MB184510 */
+	uint8_t bd_address[6];		/*!< Bluetooth Device Address*/
+	uint8_t hsetune;		/*!< Load capacitance to be applied on HSE pad */
+	uint8_t index;			/*!< Structure index */
+} OTP_Data_s;
+
+#define DEFAULT_OTP_IDX     0
+
+static HAL_StatusTypeDef OTP_Read(uint8_t index, OTP_Data_s **otp_ptr);
+
+
+void board_late_init_hook(void)
+{
+	HAL_StatusTypeDef status;
+	OTP_Data_s *otp_ptr = NULL;
+
+	status = OTP_Read(DEFAULT_OTP_IDX, &otp_ptr);
+	if (status != HAL_OK) {
+		/* OTP no present in flash, apply default gain */
+		LL_RCC_HSE_SetClockTrimming(0x0C);
+	} else {
+		LL_RCC_HSE_SetClockTrimming(otp_ptr->hsetune);
+	}
+}
+
+static HAL_StatusTypeDef OTP_Read(uint8_t index, OTP_Data_s **otp_ptr)
+{
+	*otp_ptr = (OTP_Data_s *) (FLASH_OTP_BASE + FLASH_OTP_SIZE - 16);
+
+	while (((*otp_ptr)->index != index) && ((*otp_ptr) != (OTP_Data_s *) FLASH_OTP_BASE)) {
+		(*otp_ptr) -= 1;
+	}
+
+	if ((*otp_ptr)->index != index) {
+		return HAL_ERROR;
+	}
+
+	return HAL_OK;
+}

--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -96,6 +96,12 @@
 
 &clk_hse {
 	status = "okay";
+
+	/*
+	 * Disable HSE trim applied by Clock Control.
+	 * Board-specific init will apply trim from OTP.
+	 */
+	/delete-property/ hse-trimming;
 };
 
 &clk_hsi {

--- a/boards/st/nucleo_wba65ri/CMakeLists.txt
+++ b/boards/st/nucleo_wba65ri/CMakeLists.txt
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(board.c)

--- a/boards/st/nucleo_wba65ri/Kconfig
+++ b/boards/st/nucleo_wba65ri/Kconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_NUCLEO_WBA65RI
+	select BOARD_LATE_INIT_HOOK

--- a/boards/st/nucleo_wba65ri/board.c
+++ b/boards/st/nucleo_wba65ri/board.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+#include <stm32_ll_rcc.h>
+#include <stddef.h>
+#include <errno.h>
+
+typedef __PACKED_STRUCT
+{
+	uint8_t additional_data[8];	/*!< 64 bits of data to fill OTP slot Ex: MB184510 */
+	uint8_t bd_address[6];		/*!< Bluetooth Device Address*/
+	uint8_t hsetune;		/*!< Load capacitance to be applied on HSE pad */
+	uint8_t index;			/*!< Structure index */
+} OTP_Data_s;
+
+#define DEFAULT_OTP_IDX     0
+
+static HAL_StatusTypeDef OTP_Read(uint8_t index, OTP_Data_s **otp_ptr);
+
+
+void board_late_init_hook(void)
+{
+	HAL_StatusTypeDef status;
+	OTP_Data_s *otp_ptr = NULL;
+
+	status = OTP_Read(DEFAULT_OTP_IDX, &otp_ptr);
+	if (status != HAL_OK) {
+		/* OTP no present in flash, apply default gain */
+		LL_RCC_HSE_SetClockTrimming(0x0C);
+	} else {
+		LL_RCC_HSE_SetClockTrimming(otp_ptr->hsetune);
+	}
+}
+
+static HAL_StatusTypeDef OTP_Read(uint8_t index, OTP_Data_s **otp_ptr)
+{
+	*otp_ptr = (OTP_Data_s *) (FLASH_OTP_BASE + FLASH_OTP_SIZE - 16);
+
+	while (((*otp_ptr)->index != index) && ((*otp_ptr) != (OTP_Data_s *) FLASH_OTP_BASE)) {
+		(*otp_ptr) -= 1;
+	}
+
+	if ((*otp_ptr)->index != index) {
+		return HAL_ERROR;
+	}
+
+	return HAL_OK;
+}

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -86,6 +86,12 @@
 
 &clk_hse {
 	status = "okay";
+
+	/*
+	 * Disable HSE trim applied by Clock Control.
+	 * Board-specific init will apply trim from OTP.
+	 */
+	/delete-property/ hse-trimming;
 };
 
 &clk_hsi {

--- a/drivers/clock_control/clock_stm32_ll_wba.c
+++ b/drivers/clock_control/clock_stm32_ll_wba.c
@@ -525,6 +525,13 @@ int stm32_clock_control_init(const struct device *dev)
 
 	ARG_UNUSED(dev);
 
+	if (IS_ENABLED(STM32_SYSCLK_SRC_HSE)) {
+#if DT_NODE_HAS_PROP(DT_NODELABEL(clk_hse), hse_trimming)
+		/* Set the HSE Trimming value specified in the device tree */
+		LL_RCC_HSE_SetClockTrimming(DT_PROP(DT_NODELABEL(clk_hse), hse_trimming));
+#endif
+	}
+
 	if (IS_ENABLED(STM32_SYSCLK_SRC_PLL) &&
 			(LL_RCC_GetSysClkSource() == LL_RCC_SYS_CLKSOURCE_STATUS_PLL1R)) {
 		/* In case of chainloaded application, it may happen that PLL

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -128,6 +128,7 @@
 			#clock-cells = <0>;
 			compatible = "st,stm32wba-hse-clock";
 			clock-frequency = <DT_FREQ_M(32)>;
+			hse-trimming = <0x0c>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/clock/st,stm32wba-hse-clock.yaml
+++ b/dts/bindings/clock/st,stm32wba-hse-clock.yaml
@@ -13,3 +13,9 @@ properties:
     description: |
       When set HSE output clock is divided by 2.
       Otherwise, no prescaler is used.
+
+  hse-trimming:
+    type: int
+    description: |
+        HSE clock trimming
+        Valid range: 0 - 63


### PR DESCRIPTION
Integration of the HSE Trimming setting operation on STM32WBAx (NUCLEO-WBA55CG and NUCLEO-WBA65RI).
HSE tuning value is getting from OTP.
This PR is in draft in order to validate the way and the changes done to integrate the HSE Trimming operation.