### PR TITLE
drivers: serial: silabs: bug correction on high baudrate for series 2

### DIFF
--- a/drivers/serial/uart_silabs_eusart.c
+++ b/drivers/serial/uart_silabs_eusart.c
@@ -470,9 +470,12 @@ __maybe_unused static void eusart_dma_tx_cb(const struct device *dma_dev, void *
 {
 	const struct device *uart_dev = user_data;
 	struct eusart_data *data = uart_dev->data;
+	const struct eusart_config *config = uart_dev->config;
 
 	dma_stop(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
 	data->dma_tx.enabled = false;
+
+	EUSART_IntEnable(config->eusart, EUSART_IF_TXC);
 }
 
 static int eusart_async_tx(const struct device *dev, const uint8_t *tx_data, size_t buf_size,
@@ -500,7 +503,6 @@ static int eusart_async_tx(const struct device *dev, const uint8_t *tx_data, siz
 	eusart_pm_lock_get(dev, EUSART_PM_LOCK_TX);
 
 	EUSART_IntClear(config->eusart, EUSART_IF_TXC);
-	EUSART_IntEnable(config->eusart, EUSART_IF_TXC);
 
 	ret = dma_config(data->dma_tx.dma_dev, data->dma_tx.dma_channel, &data->dma_tx.dma_cfg);
 	if (ret) {

--- a/drivers/serial/uart_silabs_usart.c
+++ b/drivers/serial/uart_silabs_usart.c
@@ -539,11 +539,12 @@ static int uart_silabs_async_tx_abort(const struct device *dev)
 	USART_IntClear(config->base, USART_IF_TXC | USART_IF_TCMP2);
 	(void)uart_silabs_pm_lock_put(dev, UART_SILABS_PM_LOCK_TX);
 
+	dma_stop(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
+
 	if (!dma_get_status(data->dma_tx.dma_dev, data->dma_tx.dma_channel, &stat)) {
 		data->dma_tx.counter = tx_buffer_length - stat.pending_length;
 	}
 
-	dma_stop(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
 	data->dma_tx.enabled = false;
 
 	async_evt_tx_abort(data);

--- a/drivers/serial/uart_silabs_usart.c
+++ b/drivers/serial/uart_silabs_usart.c
@@ -461,9 +461,12 @@ void uart_silabs_dma_tx_cb(const struct device *dma_dev, void *user_data, uint32
 {
 	const struct device *uart_dev = user_data;
 	struct uart_silabs_data *data = uart_dev->data;
+	const struct uart_silabs_config *config = uart_dev->config;
 
 	dma_stop(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
 	data->dma_tx.enabled = false;
+
+	USART_IntEnable(config->base, USART_IF_TXC);
 }
 
 static int uart_silabs_async_tx(const struct device *dev, const uint8_t *tx_data, size_t buf_size,
@@ -499,7 +502,6 @@ static int uart_silabs_async_tx(const struct device *dev, const uint8_t *tx_data
 
 	(void)uart_silabs_pm_lock_get(dev, UART_SILABS_PM_LOCK_TX);
 	USART_IntClear(config->base, USART_IF_TXC | USART_IF_TCMP2);
-	USART_IntEnable(config->base, USART_IF_TXC);
 	if (timeout >= 0) {
 		USART_IntEnable(config->base, USART_IF_TCMP2);
 	}


### PR DESCRIPTION
This PR correct a bug where the uart/eusart tx callback might be triggered before the dma complete callback at high baudrate when using async transfer. It leads to an error because you can't actually give a new buffer for the next transfer because of the unavailability of the dma channel.

It also resolved another bug where async_tx_abort function in not giving the right information since we're stopping the dma after getting the status of it. It makes the uart_async_api test failed on high baudrate.

It's a bug found by @shontal1005, can you confirm that it resolves your issue ?
