### PR TITLE
drivers: usb: udc: stm32: fixes around control endpoint/transfers

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -515,6 +515,17 @@ static void handle_msg_setup(struct udc_stm32_data *priv)
 	struct net_buf *buf;
 	int err;
 
+	/* Drop all transfers in control endpoints queue upon new SETUP */
+	buf = udc_buf_get_all(udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT));
+	if (buf != NULL) {
+		net_buf_unref(buf);
+	}
+
+	buf = udc_buf_get_all(udc_get_ep_cfg(dev, USB_CONTROL_EP_IN));
+	if (buf != NULL) {
+		net_buf_unref(buf);
+	}
+
 	buf = udc_ctrl_alloc(dev, USB_CONTROL_EP_OUT, sizeof(struct usb_setup_packet));
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate for setup");
@@ -522,8 +533,7 @@ static void handle_msg_setup(struct udc_stm32_data *priv)
 	}
 
 	udc_ep_buf_set_setup(buf);
-	memcpy(buf->data, setup, 8);
-	net_buf_add(buf, 8);
+	net_buf_add_mem(buf, setup, sizeof(struct usb_setup_packet));
 
 	udc_ctrl_update_stage(dev, buf);
 


### PR DESCRIPTION
* empty control endpoint transfer queues when SETUP is received
* properly handle OUT control transfers with Data larger than EP0 MaxPacketSize

First commit is similar to what was introduced by #94001 - in my testing, it doesn't seem necessary, but I've included it in this patchset regardless. (I allowed myself to "cherry-pick" it as @nandojve seems unavailable)

Second commit fixes the same issue as #94001 but in a different manner that is, I believe, more solid.

Full testing TBD, but preliminary results show I have same `testusb` results as with #94001.