### PR TITLE
ci: doc-build: build full docs on push, drop cron, increase timeout

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -60,7 +60,7 @@ jobs:
     container:
       image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.6.20251003
       options: '--entrypoint /bin/bash'
-    timeout-minutes: 20
+    timeout-minutes: 60
     concurrency:
       group: doc-build-html-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -4,11 +4,10 @@
 name: Documentation Build
 
 on:
-  schedule:
-  - cron: '0 */3 * * *'
   push:
     tags:
     - v*
+    - main
   pull_request:
 
 permissions:


### PR DESCRIPTION
Building the full docs every 3 hours is not really the best approach given we end up building "for nothing" when things are quiet, and on the other hand introduce a 3-hours-at-most delay for changes to be reflected on the public docs after a merge/push.
Therefore, drop cron and do the full build on every push to main

Also increase timeout to 60 minutes for full HTML build as it appears to hit the 20-minute timeout currently :|