### PR TITLE
stm32: tests: drivers : fix mpu faults by enabling SRAM clocks and configuring MPU regions on stm32h7rsx

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -1040,6 +1040,14 @@ int stm32_clock_control_init(const struct device *dev)
 #endif
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
+#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram1))
+	LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_AHBSRAM1);
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram2))
+	LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_AHBSRAM2);
+#endif
+#endif
 	/* Set up individual enabled clocks */
 	set_up_fixed_clock_sources();
 

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -60,6 +60,7 @@
 		reg = <0x30000000 DT_SIZE_K(16)>;
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM1";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM2 in D2 domain */
@@ -67,6 +68,11 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30004000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM2";
+		/* Disable SRAM2 by default to avoid unintended access.
+		 * To enable it, explicitly define zephyr,memory-attr
+		 * to configure MPU attributes.
+		 */
+		status = "disabled";
 	};
 
 	dtcm: memory@20000000 {

--- a/tests/drivers/memc/ram/boards/stm32h7s78_dk.overlay
+++ b/tests/drivers/memc/ram/boards/stm32h7s78_dk.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sram2 {
+	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
+	status = "okay";
+};


### PR DESCRIPTION
This pull request addresses multiple MPU-related faults observed during runtime tests on the `STM32H7RSX` 
series by introducing the following changes:

- Enable MPU regions for SRAM1 and SRAM2 access 
- Enables AHB2 peripheral clocks for SRAM1 and SRAM2
