### PR TITLE
scripts: gen_boards_catalog.py: add verbose flag to Twister

### DIFF
--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -207,6 +207,7 @@ def run_twister_cmake_only(outdir, vendor_filter):
         *[arg for path in EDT_PICKLE_PATHS for arg in ('--keep-artifacts', path)],
         *[arg for path in RUNNERS_YAML_PATHS for arg in ('--keep-artifacts', path)],
         "--cmake-only",
+        "-v",
         "--outdir",
         str(outdir),
     ]


### PR DESCRIPTION
Pass verbose flag to Twister to get better insights into what boards are being built and see progress.