### PR TITLE
tests: interrupt: Fix nested_irq test for Arm's GIC in Non-Secure state

### DIFF
--- a/tests/arch/common/interrupt/src/nested_irq.c
+++ b/tests/arch/common/interrupt/src/nested_irq.c
@@ -45,11 +45,13 @@
 #endif
 #elif defined(CONFIG_GIC)
 /*
- * For the platforms that use the ARM GIC, use the SGI (software generated
- * interrupt) lines 14 and 15 for testing.
+ * For platforms that use Arm's GIC, use the SGI (software generated
+ * interrupt) lines 6 and 7 for testing.
+ * SGI 0-2 are used by Zephyr for SMP IPIs.
+ * SGI 8-15 are unaccessible from Non-Secure state.
  */
-#define IRQ0_LINE	14
-#define IRQ1_LINE	15
+#define IRQ0_LINE	6
+#define IRQ1_LINE	7
 
 /*
  * Choose lower prio for IRQ0 and higher priority for IRQ1


### PR DESCRIPTION
Change SGI interrupt lines from 14-15 to 6-7 for nested interrupt
testing. SGI 8-15 are unaccessible from Non-Secure state (e.g., when
running with TF-A), causing test failures. SGI 0-2 are reserved for
Zephyr SMP IPIs, so use SGI 6-7 which work in both Secure and
Non-Secure configurations.

Fixes test failure: "isr0 did not execute" assertion at line 184.
