### PR TITLE
tests: lib: lockfree: Fix MPSC test consumer node return logic

### DIFF
--- a/tests/lib/lockfree/boards/qemu_cortex_a53_qemu_cortex_a53_smp.conf
+++ b/tests/lib/lockfree/boards/qemu_cortex_a53_qemu_cortex_a53_smp.conf
@@ -1,0 +1,2 @@
+# Configuration overlay for 4-CPU testing on QEMU Cortex-A53
+CONFIG_MP_MAX_NUM_CPUS=4

--- a/tests/lib/lockfree/boards/qemu_cortex_a53_qemu_cortex_a53_smp.overlay
+++ b/tests/lib/lockfree/boards/qemu_cortex_a53_qemu_cortex_a53_smp.overlay
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Device tree overlay to add 2 more CPUs to QEMU Cortex-A53 SMP
+ * for testing 4-CPU configurations
+ */
+
+/ {
+	cpus {
+		cpu@2 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <2>;
+		};
+
+		cpu@3 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <3>;
+		};
+	};
+};

--- a/tests/lib/lockfree/src/test_mpsc.c
+++ b/tests/lib/lockfree/src/test_mpsc.c
@@ -127,7 +127,10 @@ static void mpsc_consumer(void *p1, void *p2, void *p3)
 
 		nn = CONTAINER_OF(n, struct test_mpsc_node, n);
 
-		spsc_acquire(node_q[nn->id]);
+		/* Return node to producer's free queue - must retry if queue is full */
+		while (spsc_acquire(node_q[nn->id]) == NULL) {
+			k_yield();
+		}
 		spsc_produce(node_q[nn->id]);
 	}
 }


### PR DESCRIPTION
The MPSC test consumer was incorrectly handling node returns to
producer free queues. It called spsc_acquire() without checking the
return value, then unconditionally called spsc_produce(). When the
SPSC free queue was full, spsc_acquire() would return NULL and not
increment the acquire counter, causing spsc_produce() to silently do
nothing (it only produces if acquire > 0). This resulted in lost nodes.

At least on QEMU, a 4-CPU configuration is needed for this bug to manifest.
Producers put all nodes in flight simultaneously with the single consumer
unable to keep up, causing frequent SPSC queue full conditions.

The Fix: Loop on spsc_acquire() until it succeeds before calling
spsc_produce(). This ensures nodes are always successfully returned to
producer queues.

Added board overlay for qemu_cortex_a53/smp to enable 4-CPU testing,
which reproduces the issue and validates the fix.

Fixes #98353
