### PR TITLE
drivers: dma: stm32: avoid clear TE in case of hal_override

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -129,7 +129,12 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		}
 		stream->dma_callback(dev, stream->user_data, callback_arg, DMA_STATUS_COMPLETE);
 	} else if (stm32_dma_is_unexpected_irq_happened(dma, id)) {
-		LOG_ERR("Unexpected irq happened.");
+		/* Let HAL DMA handle flags on its own */
+		if (!stream->hal_override) {
+			LOG_ERR("Unexpected irq happened.");
+			stm32_dma_dump_stream_irq(dma, id);
+			stm32_dma_clear_stream_irq(dma, id);
+		}
 		stream->dma_callback(dev, stream->user_data,
 				     callback_arg, -EIO);
 	} else {

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -133,10 +133,13 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		stream->dma_callback(dev, stream->user_data,
 				     callback_arg, -EIO);
 	} else {
-		LOG_ERR("Transfer Error.");
-		stream->busy = false;
-		dma_stm32_dump_stream_irq(dev, id);
-		dma_stm32_clear_stream_irq(dev, id);
+		/* Let HAL DMA handle flags on its own */
+		if (!stream->hal_override) {
+			LOG_ERR("Transfer Error.");
+			stream->busy = false;
+			dma_stm32_dump_stream_irq(dev, id);
+			dma_stm32_clear_stream_irq(dev, id);
+		}
 		stream->dma_callback(dev, stream->user_data,
 				     callback_arg, -EIO);
 	}

--- a/drivers/dma/dma_stm32_v1.c
+++ b/drivers/dma/dma_stm32_v1.c
@@ -306,9 +306,6 @@ bool stm32_dma_is_unexpected_irq_happened(DMA_TypeDef *dma, uint32_t id)
 	if (LL_DMA_IsEnabledIT_FE(dma, dma_stm32_id_to_stream(id)) &&
 	    dma_stm32_is_fe_active(dma, id)) {
 		LOG_ERR("FiFo error.");
-		stm32_dma_dump_stream_irq(dma, id);
-		stm32_dma_clear_stream_irq(dma, id);
-
 		return true;
 	}
 


### PR DESCRIPTION
If hal_override is set, avoid reporting an error and clear the transfer error (TE) bit so that HAL code can properly handle it.