### PR TITLE
ICM45686 AN-000364 FIFO Fix

### DIFF
--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -82,7 +82,7 @@ struct icm45686_encoded_data {
 	struct icm45686_encoded_header header;
 	union {
 		struct icm45686_encoded_payload payload;
-		struct icm45686_encoded_fifo_payload fifo_payload;
+		FLEXIBLE_ARRAY_DECLARE(struct icm45686_encoded_fifo_payload, fifo_payload);
 	};
 };
 

--- a/drivers/sensor/tdk/icm45686/icm45686_decoder.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_decoder.c
@@ -493,7 +493,7 @@ static int icm45686_fifo_decode(const uint8_t *buffer,
 			(fdata->header & FIFO_HEADER_ACCEL_EN(true)) &&
 			(fdata->header & FIFO_HEADER_GYRO_EN(true)) &&
 			(fdata->header & FIFO_HEADER_HIRES_EN(true)),
-			"Unsupported FIFO packet format");
+			"Unsupported FIFO packet format 0x%02x", fdata->header);
 
 		switch (chan_spec.chan_type) {
 		case SENSOR_CHAN_ACCEL_XYZ:

--- a/drivers/sensor/tdk/icm45686/icm45686_decoder.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_decoder.c
@@ -476,7 +476,7 @@ static int icm45686_fifo_decode(const uint8_t *buffer,
 				void *data_out)
 {
 	struct icm45686_encoded_data *edata = (struct icm45686_encoded_data *)buffer;
-	struct icm45686_encoded_fifo_payload *frame_begin = &edata->fifo_payload;
+	struct icm45686_encoded_fifo_payload *frame_begin = edata->fifo_payload;
 	int count = 0;
 	int err;
 

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -470,8 +470,16 @@ void icm45686_stream_submit(const struct device *dev,
 
 		if (data->stream.settings.enabled.fifo_ths ||
 		    data->stream.settings.enabled.fifo_full) {
+			/** AN-000364: When operating in FIFO streaming mode, if FIFO threshold
+			 * interrupt is triggered with M number of FIFO frames accumulated in the
+			 * FIFO buffer, the host should only read the first M-1 number of FIFO
+			 * frames.
+			 *
+			 * To avoid the case where M == 1 and M-- would be 0,
+			 * M + 1 threshold is used so M count is read.
+			 */
 			uint16_t fifo_ths = data->stream.settings.enabled.fifo_ths ?
-					    cfg->settings.fifo_watermark : 0;
+					    cfg->settings.fifo_watermark + 1 : 0;
 
 			val = REG_FIFO_CONFIG2_FIFO_WM_GT_THS(true) |
 			      REG_FIFO_CONFIG2_FIFO_FLUSH(true);


### PR DESCRIPTION
When running the icm45686 on current main for several hours, occasionally I hit this assert,
https://github.com/zephyrproject-rtos/zephyr/blob/3e7a941094b4b343345a35ab1477d87b7a49dafa/drivers/sensor/tdk/icm45686/icm45686_decoder.c#L492-L496

When inspecting the value of the header, it is 0xff which is invalid and lead me to this comment in the official TDK HAL driver.
[zephyrproject-rtos/hal_tdk/icm456xx/imu/inv_imu_driver_advanced.c](https://github.com/zephyrproject-rtos/hal_tdk/blob/f2b4a52a9d25be4fc244d3baac86c21cecde5bed/icm456xx/imu/inv_imu_driver_advanced.c#L856-L862)

Since the current icm45686 driver implementation reads the fixed watermark threshold number of frames, and in cases where the watermark is equal to 1, the workaround is the watermark threshold set to M + 1 frames and M frames are read out on each threshold trigger.