### PR TITLE
tests: Fix -Wformat errors

### DIFF
--- a/tests/bluetooth/controller/ctrl_feature_exchange/src/main_hci.c
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/src/main_hci.c
@@ -56,7 +56,7 @@ static void hci_setup(void *data)
 	ull_conn_init();
 
 	conn_from_pool = ll_conn_acquire();
-	zassert_not_null(conn_from_pool, "Could not allocate connection memory", NULL);
+	zassert_not_null(conn_from_pool, "Could not allocate connection memory");
 
 	test_setup(conn_from_pool);
 }

--- a/tests/bluetooth/controller/ctrl_hci/src/main.c
+++ b/tests/bluetooth/controller/ctrl_hci/src/main.c
@@ -56,7 +56,7 @@ static void hci_setup(void *data)
 	ull_conn_init();
 
 	conn_from_pool = ll_conn_acquire();
-	zassert_not_null(conn_from_pool, "Could not allocate connection memory", NULL);
+	zassert_not_null(conn_from_pool, "Could not allocate connection memory");
 
 	test_setup(conn_from_pool);
 }

--- a/tests/posix/multi_process/src/times.c
+++ b/tests/posix/multi_process/src/times.c
@@ -57,7 +57,7 @@ ZTEST(posix_multi_process, test_times)
 		clock_t t0 = *(clock_t *)((uint8_t *)&test_tms[0] + offset);
 		clock_t t1 = *(clock_t *)((uint8_t *)&test_tms[1] + offset);
 
-		zexpect_true(t1 >= t0, "time moved backward for tms_%s: t0: %d t1: %d", name, t0,
+		zexpect_true(t1 >= t0, "time moved backward for tms_%s: t0: %ld t1: %ld", name, t0,
 			     t1);
 	}
 }


### PR DESCRIPTION
Fix for the remaining `-Wformat` errors found on the latest run on main after adding validation of zassert strings in https://github.com/zephyrproject-rtos/zephyr/pull/97210.

For details, see individual commits.