### PR TITLE
MAINTAINERS: add dkalowsk as MCTP collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5813,6 +5813,7 @@ West:
   collaborators:
     - nashif
     - inteljiangwe1
+    - dkalowsk
   files: []
   labels:
     - "area: MCTP"


### PR DESCRIPTION
Add dkalowsk as a collaborator to the MCTP sections as discussed with @teburd 