### PR TITLE
boards: arm: Rename WeAct STM32U585

### DIFF
--- a/boards/weact/blackpill_u585ci/board.yml
+++ b/boards/weact/blackpill_u585ci/board.yml
@@ -1,6 +1,6 @@
 board:
   name: blackpill_u585ci
-  full_name: WeAct Studio Black Pill STM32U585 Core Board
+  full_name: Black Pill STM32U585
   vendor: weact
   socs:
     - name: stm32u585xx


### PR DESCRIPTION
Update board.yml for naming consistency throughout the weact family