### PR TITLE
Add description for nxp,mcux-edma 'dma-requests' and 'dma-channels'

### DIFF
--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -498,7 +498,7 @@
 		compatible = "nxp,mcux-edma";
 		nxp,version = <4>;
 		dma-channels = <16>;
-		dma-requests = <94>;
+		dma-requests = <119>;
 
 		reg = <0x80000 0x1000>;
 		interrupts = <1 0>, <2 0>, <3 0>, <4 0>,
@@ -514,7 +514,7 @@
 		compatible = "nxp,mcux-edma";
 		nxp,version = <4>;
 		dma-channels = <8>;
-		dma-requests = <94>;
+		dma-requests = <119>;
 
 		reg = <0xa0000 0x1000>;
 		interrupts = <77 0>, <78 0>, <79 0>, <80 0>,

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -595,7 +595,7 @@
 		compatible = "nxp,mcux-edma";
 		nxp,version = <4>;
 		dma-channels = <16>;
-		dma-requests = <117>;
+		dma-requests = <121>;
 
 		reg = <0x80000 0x1000>;
 		interrupts = <1 0>, <2 0>, <3 0>, <4 0>,
@@ -611,7 +611,7 @@
 		compatible = "nxp,mcux-edma";
 		nxp,version = <4>;
 		dma-channels = <16>;
-		dma-requests = <117>;
+		dma-requests = <121>;
 
 		reg = <0xa0000 0x1000>;
 		interrupts = <77 0>, <78 0>, <79 0>, <80 0>,

--- a/dts/bindings/dma/nxp,mcux-edma.yaml
+++ b/dts/bindings/dma/nxp,mcux-edma.yaml
@@ -19,9 +19,17 @@ properties:
 
   dma-channels:
     required: true
+    description: |
+      Specifies the number of DMA channels supported by the controller.
+      This value is used to validate the channel number provided in the
+      DMA specifier.
 
   dma-requests:
     required: true
+    description: |
+      Indicates the maximum value of the DMA request sources (slots) index supported by
+      DMAMUX. This value is used to validate the request source index provided in the
+      DMA specifier.
 
   dmamux-reg-offset:
     type: int


### PR DESCRIPTION
1. Added description for dma-requests and dma-channels in dts/bindings/dma/nxp,mcux-edma.yaml.

2. Fixed dma-requests value in dts/arm/nxp/nxp_mcxn23x_common.dtsi and dts/arm/nxp/nxp_mcxnx4x_common.dtsi. The 'dma-requests' indicates the maximum value of the DMA request sources (slots) index supported by DMAMUX rather than the number of request sources.