### PR TITLE
bluetooth: classic: HFP_AG: Fix early SCO connection req sending

### DIFF
--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -328,17 +328,6 @@ config BT_HFP_AG_TX_BUF_COUNT
 	  sending buf. Normally this can be left to the default value, which
 	  is equal to the number of session in the stack-internal pool.
 
-config BT_HFP_AG_THREAD_STACK_SIZE
-	int "Size of the HFP AG thread stack [EXPERIMENTAL]"
-	default 1024
-	help
-	  Stack size needed for executing thread for HFP AG.
-
-config BT_HFP_AG_THREAD_PRIO
-	# Hidden option for HFP AG thread priority
-	int
-	default 6
-
 config BT_HFP_AG_OUTGOING_TIMEOUT
 	int "Call outgoing timeout value for HFP AG [EXPERIMENTAL]"
 	default 3

--- a/subsys/bluetooth/host/classic/hfp_ag_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_ag_internal.h
@@ -138,6 +138,7 @@ enum {
 	BT_HFP_AG_VRE_R2A,       /* HF is ready to accept audio */
 	BT_HGP_AG_ONGOING_CALLS, /* Waiting ongoing calls */
 	BT_HFP_AG_SLC_CONNECTED, /* SLC connected event needs to be notified */
+	BT_HFP_AG_AT_PROCESS,    /* AT command is in processing */
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_HFP_AG_NUM_FLAGS,
@@ -256,6 +257,7 @@ struct bt_hfp_ag {
 
 	/* HFP TX pending */
 	sys_slist_t tx_pending;
+	sys_slist_t tx_submit_pending;
 
 	/* Critical locker */
 	struct k_sem lock;


### PR DESCRIPTION
When creating the audio connection, the SCO connection request will be sent before the response "OK" to AT command "AT+BCS" is issued.

It causes the issue that the HFP HF cannot response the SCO connection request with the correct codec. Then the SCO connection cannot be established properly.

Put all processing into the same context, thus avoiding non-sequential execution caused by the different priorities of different threads.

Add a flag `BT_HFP_AG_AT_PROCESS` to flag the AT command is being processed.

When the flag `BT_HFP_AG_AT_PROCESS` is set, put the pending executions into temp list `tx_submit_pending`. After the AT response `OK` or `ERROR` has been sent, move the pending executions from `tx_submit_pending` to `tx_pending`.