### PR TITLE
tracing: Change tracing state dynamically at runtime

### DIFF
--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -2688,6 +2688,12 @@ void sys_trace_idle_exit(void);
  */
 #define sys_trace_sys_init_exit(entry, level, result)
 
+/**
+ * @brief Enable/Disable Tracing
+ * @param state A boolean value either true or false
+ */
+#define sys_trace_set_state(state)
+
 /** @} */ /* end of subsys_tracing_apis */
 
 /** @} */ /* end of subsys_tracing */

--- a/samples/subsys/tracing/src/tracing_user.c
+++ b/samples/subsys/tracing/src/tracing_user.c
@@ -101,3 +101,8 @@ void sys_trace_gpio_pin_interrupt_configure_exit_user(const struct device *port,
 {
 	printk("port: %s, pin: %d ret: %d\n", port->name, pin, ret);
 }
+
+void sys_trace_set_state_user(bool state)
+{
+	printk("set current tracing state to %d\n", state);
+}

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -14,6 +14,9 @@
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/debug/cpu_load.h>
+#include <zephyr/sys/atomic.h>
+
+static atomic_t tracing_state = ATOMIC_INIT(0x01);
 
 static void _get_thread_name(struct k_thread *thread,
 			     ctf_bounded_string_t *name)
@@ -946,4 +949,14 @@ void sys_port_trace_gpio_fire_callbacks_enter(sys_slist_t *list, const struct de
 void sys_port_trace_gpio_fire_callback(const struct device *port, struct gpio_callback *cb)
 {
 	ctf_top_gpio_fire_callback((uint32_t)(uintptr_t)port, (uint32_t)(uintptr_t)cb);
+}
+
+void sys_trace_set_state_ctf(bool state)
+{
+	(void)atomic_set(&tracing_state, state);
+}
+
+bool ctf_trace_is_enabled(void)
+{
+	return atomic_get(&tracing_state);
 }

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -28,6 +28,8 @@
  */
 #define CTF_INTERNAL_FIELD_SIZE(x) + sizeof(x)
 
+bool ctf_trace_is_enabled(void);
+
 /*
  * Append a field to current event-packet.
  */
@@ -40,13 +42,15 @@
 /*
  * Gather fields to a contiguous event-packet, then atomically emit.
  */
-#define CTF_GATHER_FIELDS(...)                                                  \
-	{                                                                       \
-		uint8_t epacket[0 MAP(CTF_INTERNAL_FIELD_SIZE, ##__VA_ARGS__)]; \
-		uint8_t *epacket_cursor = &epacket[0];                          \
-										\
-		MAP(CTF_INTERNAL_FIELD_APPEND, ##__VA_ARGS__)                   \
-		tracing_format_raw_data(epacket, sizeof(epacket));              \
+#define CTF_GATHER_FIELDS(...)                                                                     \
+	{                                                                                          \
+		uint8_t epacket[0 MAP(CTF_INTERNAL_FIELD_SIZE, ##__VA_ARGS__)];                    \
+		uint8_t *epacket_cursor = &epacket[0];                                             \
+                                                                                                   \
+		MAP(CTF_INTERNAL_FIELD_APPEND, ##__VA_ARGS__)                                      \
+		if (ctf_trace_is_enabled()) {                                                      \
+			tracing_format_raw_data(epacket, sizeof(epacket));                         \
+		}                                                                                  \
 	}
 
 #ifdef CONFIG_TRACING_CTF_TIMESTAMP

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -448,6 +448,7 @@ void sys_trace_k_timer_status_sync_exit(struct k_timer *timer, uint32_t result);
 
 void sys_trace_k_event_init(struct k_event *event);
 
+void sys_trace_set_state_ctf(bool state);
 
 #define sys_port_trace_socket_init(sock, family, type, proto)	\
 	sys_trace_socket_init(sock, family, type, proto)
@@ -700,6 +701,8 @@ void sys_trace_gpio_fire_callback(const struct device *port, struct gpio_callbac
 #define sys_port_trace_gpio_fire_callbacks_enter(list, port, pins)                                 \
 	sys_trace_gpio_fire_callbacks_enter(list, port, pins)
 #define sys_port_trace_gpio_fire_callback(port, cb) sys_trace_gpio_fire_callback(port, cb)
+
+#define sys_trace_set_state(state) sys_trace_set_state_ctf(state)
 
 #ifdef __cplusplus
 }

--- a/subsys/tracing/user/tracing_user.c
+++ b/subsys/tracing/user/tracing_user.c
@@ -75,6 +75,9 @@ void __weak sys_trace_gpio_fire_callbacks_enter_user(sys_slist_t *list, const st
 						     gpio_pin_t pins) {}
 void __weak sys_trace_gpio_fire_callback_user(const struct device *port,
 					      struct gpio_callback *callback) {}
+void __weak sys_trace_set_state_user(bool state)
+{
+}
 
 void sys_trace_thread_create(struct k_thread *thread)
 {
@@ -313,4 +316,9 @@ void sys_trace_gpio_fire_callbacks_enter(sys_slist_t *list, const struct device 
 void sys_trace_gpio_fire_callback(const struct device *port, struct gpio_callback *callback)
 {
 	sys_trace_gpio_fire_callback_user(port, callback);
+}
+
+void _sys_trace_set_state(bool state)
+{
+	sys_trace_set_state_user(state);
 }

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -31,6 +31,7 @@ void sys_trace_isr_exit_user(void);
 void sys_trace_idle_user(void);
 void sys_trace_sys_init_enter_user(const struct init_entry *entry, int level);
 void sys_trace_sys_init_exit_user(const struct init_entry *entry, int level, int result);
+void sys_trace_set_state_user(bool state);
 
 void sys_trace_thread_create(struct k_thread *thread);
 void sys_trace_thread_abort(struct k_thread *thread);
@@ -49,6 +50,7 @@ void sys_trace_idle(void);
 void sys_trace_idle_exit(void);
 void sys_trace_sys_init_enter(const struct init_entry *entry, int level);
 void sys_trace_sys_init_exit(const struct init_entry *entry, int level, int result);
+void _sys_trace_set_state(bool state);
 
 struct gpio_callback;
 typedef uint8_t gpio_pin_t;
@@ -502,6 +504,8 @@ void sys_trace_gpio_fire_callback_user(const struct device *port, struct gpio_ca
 	sys_trace_gpio_fire_callbacks_enter_user(list, port, pins)
 #define sys_port_trace_gpio_fire_callback(port, callback) \
 	sys_trace_gpio_fire_callback_user(port, callback)
+
+#define sys_trace_set_state(state) _sys_trace_set_state(state)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This commit adds support for applications to enable/disable tracing dynamically at runtime. Current implementation only allow changing tracing state when `CONFIG_TRACING_HANDLE_HOST_CMD` is enabled. Thus application cannot enable/disable tracing to save tracing buffer after some unexpected event.