### PR TITLE
riscv: Make static ROM PMP entry conditional on MEM_ATTR

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -432,6 +432,16 @@ config PMP_STACK_GUARD_MIN_SIZE
 	  wiggle room to accommodate the eventual overflow exception
 	  stack usage.
 
+config ENABLE_DEFAULT_ROM_PMP
+	bool "Set static PMP entry for ROM region"
+	depends on RISCV_PMP
+	default n if MEM_ATTR
+	default y
+	help
+	  Controls the static PMP entry for the ROM region. It is enabled by
+	  default but automatically disabled when CONFIG_MEM_ATTR is set,
+	  to allow the memory attributes subsystem to manage the PMP region.
+
 # Implement the null pointer detection using the Physical Memory Protection
 # (PMP) Unit.
 config NULL_POINTER_EXCEPTION_DETECTION_PMP

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -409,11 +409,13 @@ void z_riscv_pmp_init(void)
 	unsigned long pmp_cfg[CONFIG_PMP_SLOTS / PMPCFG_STRIDE];
 	unsigned int index = 0;
 
+#ifdef CONFIG_ENABLE_DEFAULT_ROM_PMP
 	/* The read-only area is always there for every mode */
 	set_pmp_entry(&index, PMP_R | PMP_X | PMP_L,
 		      (uintptr_t)__rom_region_start,
 		      (size_t)__rom_region_size,
 		      pmp_addr, pmp_cfg, ARRAY_SIZE(pmp_addr));
+#endif /* CONFIG_ENABLE_DEFAULT_ROM_PMP */
 
 #ifdef CONFIG_NULL_POINTER_EXCEPTION_DETECTION_PMP
 	/*


### PR DESCRIPTION
The static ROM PMP entry is redundant when `CONFIG_MEM_ATTR` is enabled, as the memory attributes subsystem manages PMP regions dynamically via Device Tree.

Add `CONFIG_ENABLE_DEFAULT_ROM_PMP` to disable the entry in this case, preventing potential conflicts.