### PR TITLE
MAINTAINERS: Add cc23xx and collaborator for TI SimpleLink Platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4881,10 +4881,13 @@ TI SimpleLink Platforms:
   status: maintained
   maintainers:
     - vaishnavachath
+  collaborators:
+    - bogdanovs
   files:
     - boards/ti/cc*/
     - boards/ti/msp*/
     - drivers/*/*cc13*
+    - drivers/*/*cc23*
     - drivers/*/*cc25*
     - drivers/*/*cc26*
     - drivers/*/*cc32*


### PR DESCRIPTION
- Add cc23xx SoCs to files in TI SimpleLink
- Add bogdanovs as colaborator for TI SimpleLink