### PR TITLE
subsys: usbd_msc: fix the issues that occur when the user calls usbd_disable.

### DIFF
--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -317,6 +317,7 @@ int usbd_disable(struct usbd_context *const uds_ctx)
 		return -EALREADY;
 	}
 
+	k_sched_lock();
 	usbd_device_lock(uds_ctx);
 
 	ret = usbd_config_set(uds_ctx, 0);
@@ -332,6 +333,7 @@ int usbd_disable(struct usbd_context *const uds_ctx)
 	uds_ctx->status.enabled = false;
 
 	usbd_device_unlock(uds_ctx);
+	k_sched_unlock();
 
 	return ret;
 }

--- a/subsys/usb/device_next/usbd_endpoint.c
+++ b/subsys/usb/device_next/usbd_endpoint.c
@@ -50,8 +50,6 @@ int usbd_ep_disable(const struct device *dev,
 		return ret;
 	}
 
-	k_yield();
-
 	return ret;
 }
 


### PR DESCRIPTION
When ECONNABORTED is received, clear MSC_CLASS_ENABLED to prevent issuing an OUT request after a soft disconnect at the application layer. Otherwise, during a subsequent soft connect, MSC_BULK_OUT_QUEUED would not be cleared, causing the OUT transfer to fail and leading to enumeration failure.