### PR TITLE
editorconfig: Trailing spaces are meaningful in patches

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -86,6 +86,10 @@ indent_size = 8
 [COMMIT_EDITMSG]
 max_line_length = 75
 
+# Patches
+[{*.patch,*.diff}]
+trim_trailing_whitespace = false
+
 # Kconfig
 [Kconfig*]
 indent_style = tab


### PR DESCRIPTION
My editor (nvim) started to automatically source .editorconfig. This new feature broke my git workflow when I edit my staging changes (yes, I edit patches and they still apply).

It took me a bit of time to understand my editor striped the trailing space (which are meaningful patches) because of .editorconfig.