### PR TITLE
debug: thread_analyzer: replace #if IS_ENABLED

### DIFF
--- a/subsys/debug/thread_analyzer/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer/thread_analyzer.c
@@ -171,7 +171,7 @@ static void thread_analyze_cb(const struct k_thread *cthread, void *user_data)
 
 	cb(&info);
 
-#if IS_ENABLED(CONFIG_THREAD_ANALYZER_LONG_FRAME_PER_INTERVAL)
+#ifdef CONFIG_THREAD_ANALYZER_LONG_FRAME_PER_INTERVAL
 	k_thread_runtime_stats_longest_frame_reset(thread);
 #endif
 
@@ -257,7 +257,7 @@ void thread_analyzer_auto(void *a, void *b, void *c)
 	}
 }
 
-#if IS_ENABLED(CONFIG_THREAD_ANALYZER_AUTO_SEPARATE_CORES)
+#ifdef CONFIG_THREAD_ANALYZER_AUTO_SEPARATE_CORES
 
 static K_THREAD_STACK_ARRAY_DEFINE(analyzer_thread_stacks, CONFIG_MP_MAX_NUM_CPUS,
 				   CONFIG_THREAD_ANALYZER_AUTO_STACK_SIZE);


### PR DESCRIPTION
Use of IS_ENABLED in a #if statement is discouraged. Replace with #ifdef.