### PR TITLE
samples: net: wpan_serial: Excluding nucleo_wba65ri platform

### DIFF
--- a/samples/net/wpan_serial/sample.yaml
+++ b/samples/net/wpan_serial/sample.yaml
@@ -15,6 +15,7 @@ tests:
       - thingy53/nrf5340/cpuapp/ns
       - raytac_mdbt53_db_40/nrf5340/cpuapp/ns
       - raytac_mdbt53_db_40/nrf5340/cpuapp
+      - nucleo_wba65ri
     integration_platforms:
       - usb_kw24d512
   sample.net.wpan_serial.frdm_cr20a:


### PR DESCRIPTION
As CONFIG_BUILD_ONLY_NO_BLOBS feature is not implemented for stm32wbax socs, 
we have temporarily excluded nucleo_wba65ri platform from CI build tests.

Issue https://github.com/zephyrproject-rtos/zephyr/issues/95495 will be updated accordingly