### PR TITLE
dts: arm: nordic: Fix SRAM partitioning

### DIFF
--- a/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
@@ -16,7 +16,6 @@
 
 	/* We need to remove aliases to nodes we delete */
 	aliases {
-		/delete-property/ sram-0;
 		/delete-property/ i2c-0;
 		/delete-property/ spi-0;
 		/delete-property/ i2c-1;
@@ -48,8 +47,6 @@
 	};
 
 	soc {
-		/delete-node/ memory@20000000;
-
 		peripheral@50000000 {
 			/delete-node/ dcnf@0;
 			/delete-node/ oscillator@4000;
@@ -108,6 +105,11 @@
 			reg = <0x00000000 DT_SIZE_K(1024)>;
 		};
 	};
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(512)>;
 };
 
 &gpiote {

--- a/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpunet.dts
+++ b/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpunet.dts
@@ -16,7 +16,6 @@
 
 	/* We need to remove aliases to nodes we delete */
 	aliases {
-		/delete-property/ sram-0;
 		/delete-property/ sram-1;
 		/delete-property/ wdt-0;
 		/delete-property/ i2c-0;
@@ -33,7 +32,6 @@
 	};
 
 	soc {
-		/delete-node/ memory@20000000;
 		/delete-node/ memory@21000000;
 		/delete-node/ watchdog@4100b000;
 		/delete-node/ i2c@41013000;
@@ -68,6 +66,11 @@
 			reg = <0x00000000 DT_SIZE_K(256)>;
 		};
 	};
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(512)>;
 };
 
 &gpiote {

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -47,6 +47,8 @@
 
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		power: power@40000000 {

--- a/dts/arm/nordic/nrf51822_qfaa.dtsi
+++ b/dts/arm/nordic/nrf51822_qfaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(16)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(16)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf51822_qfab.dtsi
+++ b/dts/arm/nordic/nrf51822_qfab.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(16)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(16)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf51822_qfac.dtsi
+++ b/dts/arm/nordic/nrf51822_qfac.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(32)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -52,6 +52,8 @@
 
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		clock: clock@40000000 {

--- a/dts/arm/nordic/nrf52805_caaa.dtsi
+++ b/dts/arm/nordic/nrf52805_caaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(24)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(24)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -56,6 +56,8 @@
 
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		clock: clock@40000000 {

--- a/dts/arm/nordic/nrf52810_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52810_qfaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(24)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(24)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -60,6 +60,8 @@
 
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		clock: clock@40000000 {

--- a/dts/arm/nordic/nrf52811_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52811_qfaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(24)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(24)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -59,6 +59,8 @@
 
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		clock: clock@40000000 {

--- a/dts/arm/nordic/nrf52820_qdaa.dtsi
+++ b/dts/arm/nordic/nrf52820_qdaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(32)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -56,6 +56,8 @@
 
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		clock: clock@40000000 {

--- a/dts/arm/nordic/nrf52832_ciaa.dtsi
+++ b/dts/arm/nordic/nrf52832_ciaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(64)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf52832_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52832_qfaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(64)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(64)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf52832_qfab.dtsi
+++ b/dts/arm/nordic/nrf52832_qfab.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(32)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(32)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -60,6 +60,8 @@
 
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		clock: clock@40000000 {

--- a/dts/arm/nordic/nrf52833_qdaa.dtsi
+++ b/dts/arm/nordic/nrf52833_qdaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(128)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf52833_qiaa.dtsi
+++ b/dts/arm/nordic/nrf52833_qiaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(128)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(128)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -56,6 +56,8 @@
 
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		clock: clock@40000000 {

--- a/dts/arm/nordic/nrf52840_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52840_qfaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf52840_qiaa.dtsi
+++ b/dts/arm/nordic/nrf52840_qiaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };
 
 &power {

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -54,6 +54,8 @@
 
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		peripheral@50000000 {

--- a/dts/arm/nordic/nrf5340_cpuapp_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_qkaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(512)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -37,6 +37,8 @@
 	soc {
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		peripheral@40000000 {

--- a/dts/arm/nordic/nrf5340_cpuappns_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns_qkaa.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(512)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -48,11 +48,15 @@
 
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		sram1: memory@21000000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
 			zephyr,memory-region = "SRAM1";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		clock: clock@41005000 {

--- a/dts/arm/nordic/nrf5340_cpunet_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet_qkaa.dtsi
@@ -13,10 +13,12 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(512)>;
 };
 
 &sram1 {
 	reg = <0x21000000 DT_SIZE_K(64)>;
+	ranges = <0x0 0x21000000 DT_SIZE_K(64)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf91.dtsi
+++ b/dts/arm/nordic/nrf91.dtsi
@@ -34,6 +34,8 @@
 	soc {
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		peripheral@50000000 {

--- a/dts/arm/nordic/nrf9131_laca.dtsi
+++ b/dts/arm/nordic/nrf9131_laca.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf9131ns_laca.dtsi
+++ b/dts/arm/nordic/nrf9131ns_laca.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf9151_laca.dtsi
+++ b/dts/arm/nordic/nrf9151_laca.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf9151ns_laca.dtsi
+++ b/dts/arm/nordic/nrf9151ns_laca.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf9160_sica.dtsi
+++ b/dts/arm/nordic/nrf9160_sica.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf9160ns_sica.dtsi
+++ b/dts/arm/nordic/nrf9160ns_sica.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf9161_laca.dtsi
+++ b/dts/arm/nordic/nrf9161_laca.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf9161ns_laca.dtsi
+++ b/dts/arm/nordic/nrf9161ns_laca.dtsi
@@ -13,6 +13,7 @@
 
 &sram0 {
 	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(256)>;
 };
 
 / {

--- a/dts/arm/nordic/nrf91ns.dtsi
+++ b/dts/arm/nordic/nrf91ns.dtsi
@@ -35,6 +35,8 @@
 	soc {
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		peripheral@40000000 {

--- a/dts/vendor/nordic/nrf5340_shared_sram_partition.dtsi
+++ b/dts/vendor/nordic/nrf5340_shared_sram_partition.dtsi
@@ -21,15 +21,11 @@
 	chosen {
 		zephyr,ipc_shm = &sram0_shared;
 	};
+};
 
-	reserved-memory {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges;
-
-		sram0_shared: memory@20070000 {
-			/* Last 64 kB of sram0 */
-			reg = <0x20070000 0x10000>;
-		};
+&sram0 {
+	sram0_shared: sram@70000 {
+		/* Last 64 kB of sram0 */
+		reg = <0x70000 0x10000>;
 	};
 };

--- a/dts/vendor/nordic/nrf5340_sram_partition.dtsi
+++ b/dts/vendor/nordic/nrf5340_sram_partition.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
+&sram0 {
 	/* Default SRAM planning when building for nRF5340 with ARM TF-M support
 	 * - Lowest 256 kB SRAM allocated to Secure image (sram0_s)
 	 * - Upper 256 kB allocated to Non-Secure image (sram0_ns)
@@ -13,29 +13,26 @@
 	 * - 64 kB allocated to shared memory (sram0_shared).
 	 *   (See nrf5340_shared_sram_partition.dtsi)
 	 */
-	reserved-memory {
+	sram0_image: sram@0 {
+		/* Zephyr image(s) memory */
+		reg = <0x20000000 DT_SIZE_K(448)>;
+	};
+
+	sram0_s: sram@20000000 {
+		/* Secure image memory */
+		reg = <0x20000000 0x40000>;
+	};
+
+	sram0_ns: sram@20040000 {
+		/* Non-Secure image memory */
+		reg = <0x20040000 0x40000>;
+		ranges = <0x0 0x20040000 0x40000>;
 		#address-cells = <1>;
 		#size-cells = <1>;
-		ranges;
 
-		sram0_image: image@20000000 {
-			/* Zephyr image(s) memory */
-			reg = <0x20000000 DT_SIZE_K(448)>;
-		};
-
-		sram0_s: image_s@20000000 {
-			/* Secure image memory */
-			reg = <0x20000000 0x40000>;
-		};
-
-		sram0_ns: image_ns@20040000 {
+		sram0_ns_app: sram@0 {
 			/* Non-Secure image memory */
-			reg = <0x20040000 0x40000>;
-		};
-
-		sram0_ns_app: image_ns_app@20040000 {
-			/* Non-Secure image memory */
-			reg = <0x20040000 0x30000>;
+			reg = <0x0 0x30000>;
 		};
 	};
 };

--- a/dts/vendor/nordic/nrf91xx_partition.dtsi
+++ b/dts/vendor/nordic/nrf91xx_partition.dtsi
@@ -94,7 +94,7 @@
 	};
 };
 
-/ {
+&sram0 {
 	/*
 	 * Default SRAM planning when building for nRF91xx with
 	 * ARM TrustZone-M support
@@ -104,29 +104,26 @@
 	 * - 40 kB SRAM reserved for and used by the modem library (sram0_ns_modem).
 	 * - 128 kB allocated to the application (sram0_ns_app).
 	 */
-	reserved-memory {
+	sram0_s: sram@0 {
+		/* Secure image memory */
+		reg = <0x0 DT_SIZE_K(88)>;
+	};
+
+	sram0_ns: sram@16000 {
+		/* Non-Secure image memory */
+		reg = <0x16000 DT_SIZE_K(168)>;
 		#address-cells = <1>;
 		#size-cells = <1>;
-		ranges;
+		ranges = <0x0 0x16000 DT_SIZE_K(168)>;
 
-		sram0_s: image_s@20000000 {
-			/* Secure image memory */
-			reg = <0x20000000 DT_SIZE_K(88)>;
-		};
-
-		sram0_ns: image_ns@20016000 {
-			/* Non-Secure image memory */
-			reg = <0x20016000 DT_SIZE_K(168)>;
-		};
-
-		sram0_ns_modem: image_ns_modem@20016000 {
+		sram0_ns_modem: sram@0 {
 			/* Modem (shared) memory */
-			reg = <0x20016000 DT_SIZE_K(40)>;
+			reg = <0x0 DT_SIZE_K(40)>;
 		};
 
-		sram0_ns_app: image_ns_app@20020000 {
+		sram0_ns_app: sram@a000 {
 			/* Non-Secure application memory */
-			reg = <0x20020000 DT_SIZE_K(128)>;
+			reg = <0xa000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/samples/subsys/ipc/ipc_service/icmsg/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,13 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/delete-node/ &sram0_shared;
+
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
 	};
 
 	reserved-memory {
-		/delete-node/ memory@20070000;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		sram_tx: memory@20070000 {
 			reg = <0x20070000 0x0800>;

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -4,13 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/delete-node/ &sram0_shared;
+
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
 	};
 
 	reserved-memory {
-		/delete-node/ memory@20070000;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		sram_rx: memory@20070000 {
 			reg = <0x20070000 0x0800>;

--- a/samples/subsys/ipc/ipc_service/multi_endpoint/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,13 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/delete-node/ &sram0_shared;
+
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
 	};
 
 	reserved-memory {
-		/delete-node/ memory@20070000;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		sram_ipc0_tx: memory@20070000 {
 			reg = <0x20070000 0x4000>;

--- a/samples/subsys/ipc/ipc_service/multi_endpoint/boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay
@@ -4,13 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/delete-node/ &sram0_shared;
+
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
 	};
 
 	reserved-memory {
-		/delete-node/ memory@20070000;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		sram_ipc0_tx: memory@20070000 {
 			reg = <0x20070000 0x4000>;

--- a/samples/subsys/ipc/ipc_service/multi_endpoint/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -4,13 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/delete-node/ &sram0_shared;
+
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
 	};
 
 	reserved-memory {
-		/delete-node/ memory@20070000;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		sram_ipc0_rx: memory@20070000 {
 			reg = <0x20070000 0x4000>;

--- a/samples/subsys/ipc/ipc_service/multi_endpoint/remote/boards/nrf5340dk_nrf5340_cpunet_icbmsg.overlay
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/remote/boards/nrf5340dk_nrf5340_cpunet_icbmsg.overlay
@@ -4,13 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/delete-node/ &sram0_shared;
+
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
 	};
 
 	reserved-memory {
-		/delete-node/ memory@20070000;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		sram_ipc0_rx: memory@20070000 {
 			reg = <0x20070000 0x4000>;

--- a/samples/subsys/ipc/ipc_service/static_vrings/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -6,13 +6,16 @@
 
 #include <zephyr/dt-bindings/ipc_service/static_vrings.h>
 
+/delete-node/ &sram0_shared;
+
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
 	};
 
 	reserved-memory {
-		/delete-node/ memory@20070000;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		sram_ipc0: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -6,13 +6,16 @@
 
 #include <zephyr/dt-bindings/ipc_service/static_vrings.h>
 
+/delete-node/ &sram0_shared;
+
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
 	};
 
 	reserved-memory {
-		/delete-node/ memory@20070000;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		sram_ipc0: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/subsys/logging/multidomain/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/subsys/logging/multidomain/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -6,6 +6,8 @@
 
 #include <zephyr/dt-bindings/ipc_service/static_vrings.h>
 
+/delete-node/ &sram0_shared;
+
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
@@ -13,7 +15,8 @@
 	};
 
 	reserved-memory {
-		/delete-node/ memory@20070000;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		sram_ipc0: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/samples/subsys/logging/multidomain/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/subsys/logging/multidomain/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -6,6 +6,8 @@
 
 #include <zephyr/dt-bindings/ipc_service/static_vrings.h>
 
+/delete-node/ &sram0_shared;
+
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
@@ -13,7 +15,8 @@
 	};
 
 	reserved-memory {
-		/delete-node/ memory@20070000;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		sram_ipc0: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/tests/subsys/ipc/ipc_sessions/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/subsys/ipc/ipc_sessions/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -5,6 +5,7 @@
  */
 
 /delete-node/ &ipc0;
+/delete-node/ &sram0_shared;
 
 / {
 	chosen {
@@ -13,7 +14,8 @@
 	};
 
 	reserved-memory {
-		/delete-node/ memory@20070000;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		sram_tx: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/tests/subsys/ipc/ipc_sessions/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/tests/subsys/ipc/ipc_sessions/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -5,6 +5,7 @@
  */
 
 /delete-node/ &ipc0;
+/delete-node/ &sram0_shared;
 
 / {
 	chosen {
@@ -12,7 +13,8 @@
 	};
 
 	reserved-memory {
-		/delete-node/ memory@20070000;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		sram_rx: memory@20070000 {
 			reg = <0x20070000 0x8000>;

--- a/tests/subsys/ipc/ipc_sessions/testcase.yaml
+++ b/tests/subsys/ipc/ipc_sessions/testcase.yaml
@@ -8,12 +8,12 @@ common:
   harness: ztest
 
 tests:
-  sample.ipc.ipc_sessions.nrf5340dk:
+  test.ipc.ipc_sessions.nrf5340dk:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-  sample.ipc.ipc_sessions.nrf54h20dk_cpuapp_cpurad:
+  test.ipc.ipc_sessions.nrf54h20dk_cpuapp_cpurad:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -21,7 +21,7 @@ tests:
     extra_args:
       - CONFIG_IPC_TEST_SKIP_CORE_RESET=y
       - CONFIG_SOC_NRF54H20_CPURAD_ENABLE=y
-  sample.ipc.ipc_sessions.nrf54h20dk_cpuapp_cpuppr:
+  test.ipc.ipc_sessions.nrf54h20dk_cpuapp_cpuppr:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -29,7 +29,7 @@ tests:
     extra_args:
       - FILE_SUFFIX=cpuppr
       - ipc_sessions_SNIPPET=nordic-ppr
-  sample.ipc.ipc_sessions.nrf54h20dk_cpuapp_no_unbound_cpuppr:
+  test.ipc.ipc_sessions.nrf54h20dk_cpuapp_no_unbound_cpuppr:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
@@ -39,7 +39,7 @@ tests:
       - ipc_sessions_SNIPPET=nordic-ppr
       - CONFIG_IPC_TEST_SKIP_UNBOUND=y
       - CONFIG_IPC_SERVICE_BACKEND_ICMSG_V1=y
-  sample.ipc.ipc_sessions.nrf54h20dk_cpuapp_cpuppr_no_unbound:
+  test.ipc.ipc_sessions.nrf54h20dk_cpuapp_cpuppr_no_unbound:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:


### PR DESCRIPTION
Uses the correct way to partition memory as per the linux binding, also fixes names which were not compliant with the zephyr devicetree guidelines