### PR TITLE
drivers: usb: udc: stm32: fix FS mode on OTG_FS for STM32F4 series

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1282,6 +1282,13 @@ static int priv_clock_enable(void)
 #else /* CONFIG_SOC_SERIES_STM32F2X || CONFIG_SOC_SERIES_STM32F4X */
 	if (UDC_STM32_NODE_PHY_ITFACE(DT_DRV_INST(0)) == PCD_PHY_ULPI) {
 		LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
+	} else if (UDC_STM32_NODE_SPEED(DT_DRV_INST(0)) == PCD_SPEED_HIGH_IN_FULL) {
+		/*
+		 * Some parts of the STM32F4 series require the OTGHSULPILPEN to be
+		 * cleared if the OTG_HS is used in FS mode. Disable it on all parts
+		 * since it has no nefarious effect if performed when not required.
+		 */
+		LL_AHB1_GRP1_DisableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 	}
 #endif /* CONFIG_SOC_SERIES_* */
 #elif defined(CONFIG_SOC_SERIES_STM32H7X) && DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otgfs)


### PR DESCRIPTION
On most parts of the STM32F4 series, when the OTG_HS controller is used in FS mode, the ULIP **low-power** clock must also be disabled for proper operation. This was done properly in an old version of the driver but was lost as part of refactoring (commit e31ddec7812b68c11bd4490884e3e98b55c57469).

See Reference Manual extract:
<img width="1288" height="915" alt="image" src="https://github.com/user-attachments/assets/43490495-97b7-44dd-804f-7b96629ee3a7" />


Re-introduce ULPI low-power clock disable when OTG_HS is used in FS mode.

Fixes #97748