### PR TITLE
drivers: entropy: gecko_trng: Ensure bus clock is enabled

### DIFF
--- a/drivers/entropy/entropy_gecko_trng.c
+++ b/drivers/entropy/entropy_gecko_trng.c
@@ -80,6 +80,7 @@ static int entropy_gecko_trng_get_entropy(const struct device *dev,
 #ifndef CONFIG_CRYPTO_ACC_GECKO_TRNG
 		available = TRNG0->FIFOLEVEL * 4;
 #else
+		CMU_ClockEnable(cmuClock_CRYPTOACC, true);
 		available = S2_FIFO_LEVEL * 4;
 #endif
 		if (available == 0) {
@@ -107,6 +108,7 @@ static int entropy_gecko_trng_get_entropy_isr(const struct device *dev,
 #ifndef CONFIG_CRYPTO_ACC_GECKO_TRNG
 		size_t available = TRNG0->FIFOLEVEL * 4;
 #else
+		CMU_ClockEnable(cmuClock_CRYPTOACC, true);
 		size_t available = S2_FIFO_LEVEL * 4;
 #endif
 


### PR DESCRIPTION
Ensure bus clock is enabled before accessing TRNG FIFO on Series 2 VSE devices.

This is a minimal bugfix to work around an issue where certain HAL APIs disable the bus clock after accessing the crypto block. Long term, this driver should be rewritten to properly use clock control APIs for clock management.