### PR TITLE
Debugging: Fix GDB packet parsing for ARM Cortex M

### DIFF
--- a/scripts/coredump/gdbstubs/arch/arm_cortex_m.py
+++ b/scripts/coredump/gdbstubs/arch/arm_cortex_m.py
@@ -115,8 +115,13 @@ class GdbStub_ARM_CortexM(GdbStub):
 
     def handle_register_single_write_packet(self, pkt):
         pkt_str = pkt.decode("ascii")
-        reg = int(pkt_str[1:pkt_str.index('=')], 16)
-        self.registers[reg] = int.from_bytes(binascii.unhexlify(pkt[3:]), byteorder = 'little')
+        separator_index = pkt_str.index('=')
+
+        if separator_index < 0:
+            raise ValueError(f"Malformed register write packet: {pkt_str}")
+
+        reg = int(pkt_str[1:separator_index], 16)
+        self.registers[reg] = int.from_bytes(binascii.unhexlify(pkt[(separator_index + 1):]), byteorder = 'little')
         self.put_gdb_packet(b'+')
 
     def arch_supports_thread_operations(self):


### PR DESCRIPTION
When analyzing Zephyr coredumps from ARM Cortex M, sometimes the GDB server fails with the following error:

```
Traceback (most recent call last):
  File "/opt/zephyr/scripts/coredump/coredump_gdbserver.py", line 155, in <module>
    main()
  File "/opt/zephyr/scripts/coredump/coredump_gdbserver.py", line 142, in main
    gdbstub.run(conn)
  File "/opt/zephyr/scripts/coredump/gdbstubs/gdbstub.py", line 335, in run
    self.handle_register_single_write_packet(pkt)
  File "/opt/zephyr/scripts/coredump/gdbstubs/arch/arm_cortex_m.py", line 120, in handle_register_single_write_packet
    self.registers[reg] = int.from_bytes(binascii.unhexlify(pkt[(3):]), byteorder = 'little')
binascii.Error: Odd-length string
```

I traced the error to the [scripts/coredump/gdbstubs/arch/arm_cortex_m.py](https://github.com/zephyrproject-rtos/zephyr/blob/fa61e87f1f2b28e7460c90613ed5518dc19623a4/scripts/coredump/gdbstubs/arch/arm_cortex_m.py#L119) file, more specifically to `handle_register_single_write_packet` function.

This functions parses the incoming GDB packet, expecting [specific format](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Packets.html) like this:

* `Pe=314c0400`
* `P0=0c000000`
* `Pd=f8ffffff`
* `Pf=38560400`

However, if the registry identifier (the string segment after `P` and before `=`) has more then two digits/letters, the error is thrown because the parsing logic is hardcoded in way it expects only a single digit. Therefore, parsing of the following packet fails:

* `P19=3f000001`

I fixed the error by properly parsing the `key=value` structure.