### PR TITLE
esp32h2: esp32c6: Add coex support

### DIFF
--- a/soc/espressif/common/Kconfig
+++ b/soc/espressif/common/Kconfig
@@ -50,7 +50,9 @@ config ESP32_PHY_MAX_TX_POWER
 
 config ESP32_SW_COEXIST_ENABLE
 	bool "Software controls Wi-Fi/Bluetooth coexistence"
-	default y if (BT_ESP32 && WIFI_ESP32)
+	default y if (BT_ESP32 && WIFI_ESP32) || \
+		     (WIFI_ESP32 && IEEE802154_ESP32) || \
+		     (IEEE802154_ESP32 && BT_ESP32)
 	help
 	  If enabled, Wi-Fi & Bluetooth coexistence is controlled by software rather than hardware.
 	  Recommended for heavy traffic scenarios. Both coexistence configuration options are

--- a/soc/espressif/esp32h2/default.ld
+++ b/soc/espressif/esp32h2/default.ld
@@ -422,6 +422,8 @@ SECTIONS
     *libzephyr.a:esp_cache.*(.literal .literal.* .text .text.*)
     *libzephyr.a:cache_utils.*(.literal .text .literal.* .text.*)
 
+    *libcoexist.a:(.coexiram .coexiram.* .coexsleepiram .coexsleepiram.*)
+
     *libble_app.a:(.high_perf_code_iram1 .high_perf_code_iram1.*)
     *libble_app.a:(.bt_iram_text .bt_iram_text.*)
 

--- a/west.yml
+++ b/west.yml
@@ -169,7 +169,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 78fb21d5bcd88adcc787fff9591da6975c80c5eb
+      revision: fe15fc8f515483b1aafba130129829bc2e3b7697
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Add coexistance support when enabling IEEE802.15.4 with another
radio device (BT or Wi-Fi), for ESP32-H2 and ESP32-C6.