### PR TITLE
STM32: fix USB power-up sequence on STM32N6

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -349,7 +349,7 @@ static int usb_dc_stm32_phy_specific_clock_enable(const struct device *const clk
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_otghs)
 	/* Enable Vdd USB voltage monitoring */
 	LL_PWR_EnableVddUSBMonitoring();
-	while (__HAL_PWR_GET_FLAG(PWR_FLAG_USB33RDY)) {
+	while (!__HAL_PWR_GET_FLAG(PWR_FLAG_USB33RDY)) {
 		/* Wait for VDD33USB ready */
 	}
 	/* Enable VDDUSB */

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1174,10 +1174,10 @@ static int priv_clock_enable(void)
 		}
 	#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs) */
 #elif defined(CONFIG_SOC_SERIES_STM32N6X)
-	/* Enable Vdd USB voltage monitoring */
+	/* Enable Vdd33USB voltage monitoring */
 	LL_PWR_EnableVddUSBMonitoring();
-	while (__HAL_PWR_GET_FLAG(PWR_FLAG_USB33RDY)) {
-		/* Wait FOR VDD33USB ready */
+	while (!LL_PWR_IsActiveFlag_USB33RDY()) {
+		/* Wait for Vdd33USB ready */
 	}
 
 	/* Enable VDDUSB */


### PR DESCRIPTION
Wait for Vdd33USB to be ready instead of the opposite.

Note: I have added a commit to fix the `device` driver as my understanding is that fixes are still accepted? Let me know if that commit should be dropped.

Fixes #97589 