### PR TITLE
boards: seeed: xiao_nrf54l15: fix led0 polarity

### DIFF
--- a/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_common.dtsi
+++ b/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_common.dtsi
@@ -10,7 +10,7 @@
 		compatible = "gpio-leds";
 
 		led0: led_0 {
-			gpios = <&gpio2 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
 			label = "LED 0";
 		};
 	};


### PR DESCRIPTION
led0 in this board is active low according to the [schematic](https://files.seeedstudio.com/wiki/XIAO_nRF54L15/Getting_Start/nRF54L15_Sense_Schematic.pdf).
Tested on a XIAO-nRF54L15 and a XIAO-nRF54L15 sense.