### PR TITLE
driver: i2c: i2c_ll_stm32: add error handling in i2c_stm32_error for I2C target mode

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -597,9 +597,11 @@ int i2c_stm32_error(const struct device *dev)
 	I2C_TypeDef *i2c = cfg->i2c;
 
 #if defined(CONFIG_I2C_TARGET)
-	if (data->slave_attached && !data->master_active) {
-		/* No need for a slave error function right now. */
-		return 0;
+	i2c_target_error_cb_t error_cb = NULL;
+
+	if (data->slave_attached && !data->master_active &&
+	    data->slave_cfg != NULL && data->slave_cfg->callbacks != NULL) {
+		error_cb = data->slave_cfg->callbacks->error;
 	}
 #endif
 
@@ -607,17 +609,42 @@ int i2c_stm32_error(const struct device *dev)
 		LL_I2C_ClearFlag_AF(i2c);
 		LL_I2C_GenerateStopCondition(i2c);
 		data->current.is_nack = 1U;
+#if defined(CONFIG_I2C_TARGET)
+		if (error_cb != NULL) {
+			error_cb(data->slave_cfg, I2C_ERROR_GENERIC);
+		}
+#endif
 		goto end;
 	}
 	if (LL_I2C_IsActiveFlag_ARLO(i2c)) {
 		LL_I2C_ClearFlag_ARLO(i2c);
 		data->current.is_arlo = 1U;
+#if defined(CONFIG_I2C_TARGET)
+		if (error_cb != NULL) {
+			error_cb(data->slave_cfg, I2C_ERROR_ARBITRATION);
+		}
+#endif
 		goto end;
 	}
 
 	if (LL_I2C_IsActiveFlag_BERR(i2c)) {
 		LL_I2C_ClearFlag_BERR(i2c);
 		data->current.is_err = 1U;
+#if defined(CONFIG_I2C_TARGET)
+		if (error_cb != NULL) {
+			error_cb(data->slave_cfg, I2C_ERROR_GENERIC);
+		}
+#endif
+		goto end;
+	}
+
+	if (LL_I2C_IsActiveFlag_OVR(i2c)) {
+		LL_I2C_ClearFlag_OVR(i2c);
+#if defined(CONFIG_I2C_TARGET)
+		if (error_cb != NULL) {
+			error_cb(data->slave_cfg, I2C_ERROR_GENERIC);
+		}
+#endif
 		goto end;
 	}
 
@@ -632,7 +659,13 @@ int i2c_stm32_error(const struct device *dev)
 #endif
 	return 0;
 end:
+#if defined(CONFIG_I2C_TARGET)
+	if (!data->slave_attached || data->master_active) {
+		i2c_stm32_master_mode_end(dev);
+	}
+#else
 	i2c_stm32_master_mode_end(dev);
+#endif
 	return -EIO;
 }
 

--- a/drivers/i2c/i2c_ll_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_ll_stm32_v1_rtio.c
@@ -452,31 +452,53 @@ int i2c_stm32_error(const struct device *dev)
 
 #if defined(CONFIG_I2C_TARGET)
 	struct i2c_stm32_data *data = dev->data;
+	i2c_target_error_cb_t error_cb = NULL;
 
-	if (data->slave_attached && !data->master_active) {
-		/* No need for a target error function right now. */
-		return 0;
+	if (data->slave_attached && !data->master_active &&
+	    data->slave_cfg != NULL && data->slave_cfg->callbacks != NULL) {
+		error_cb = data->slave_cfg->callbacks->error;
 	}
 #endif
 
 	if (LL_I2C_IsActiveFlag_AF(i2c)) {
 		LL_I2C_ClearFlag_AF(i2c);
 		LL_I2C_GenerateStopCondition(i2c);
+#if defined(CONFIG_I2C_TARGET)
+		if (error_cb != NULL) {
+			error_cb(data->slave_cfg, I2C_ERROR_GENERIC);
+		}
+#endif
 		goto error;
 	}
 	if (LL_I2C_IsActiveFlag_ARLO(i2c)) {
 		LL_I2C_ClearFlag_ARLO(i2c);
+#if defined(CONFIG_I2C_TARGET)
+		if (error_cb != NULL) {
+			error_cb(data->slave_cfg, I2C_ERROR_ARBITRATION);
+		}
+#endif
 		goto error;
 	}
 
 	if (LL_I2C_IsActiveFlag_BERR(i2c)) {
 		LL_I2C_ClearFlag_BERR(i2c);
+#if defined(CONFIG_I2C_TARGET)
+		if (error_cb != NULL) {
+			error_cb(data->slave_cfg, I2C_ERROR_GENERIC);
+		}
+#endif
 		goto error;
 	}
 
 	return 0;
 error:
+#if defined(CONFIG_I2C_TARGET)
+	if (!data->slave_attached || data->master_active) {
+		i2c_stm32_master_mode_end(dev, -EIO);
+	}
+#else
 	i2c_stm32_master_mode_end(dev, -EIO);
+#endif
 	return -EIO;
 
 }

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -414,6 +414,34 @@ typedef int (*i2c_target_buf_read_requested_cb_t)(
  */
 typedef int (*i2c_target_stop_cb_t)(struct i2c_target_config *config);
 
+/**
+ * @brief I2C error reasons.
+ *
+ * Values that correspond to events or errors responsible for stopping
+ * an I2C transfer.
+ */
+enum i2c_error_reason {
+	I2C_ERROR_TIMEOUT = 0,	/* Timeout error         */
+	I2C_ERROR_ARBITRATION,	/* Bus arbitration size  */
+	I2C_ERROR_SIZE,		/* Bad frame size        */
+	I2C_ERROR_DMA,		/* DMA transfer error    */
+	I2C_ERROR_GENERIC,	/* Any other bus error   */
+};
+
+/** @brief Function called when an error is detected on the I2C bus
+ * while acting as a target.
+ *
+ * This function is invoked by the controller when a bus error,
+ * arbitration lost, or other critical error is detected during
+ * a transaction addressed to this device.
+ *
+ * @param config the configuration structure associated with the
+ * device to which the operation is addressed.
+ * @param error_code an integer code identifying the error type.
+ */
+typedef void (*i2c_target_error_cb_t)(struct i2c_target_config *config,
+				      enum i2c_error_reason error_code);
+
 /** @brief Structure providing callbacks to be implemented for devices
  * that supports the I2C target API.
  *
@@ -430,6 +458,7 @@ struct i2c_target_callbacks {
 	i2c_target_buf_read_requested_cb_t buf_read_requested;
 #endif
 	i2c_target_stop_cb_t stop;
+	i2c_target_error_cb_t error;
 };
 
 /** @brief Structure describing a device that supports the I2C


### PR DESCRIPTION
Taking over #95984 as mentioned [here](https://github.com/zephyrproject-rtos/zephyr/pull/95984#issuecomment-3405289008)

Main differences with the first PR are:
- Branch is rebased.
- Removed the `i2c_stm32_master_mode_end` calls from `drivers/i2c/i2c_ll_stm32_v2.c` because it has been removed with this [commit](https://github.com/zephyrproject-rtos/zephyr/commit/c8b9697eb390ae88fe326aa68173741d2d479592).

Fixes #92383 