### PR TITLE
usb: device_next: cdc_acm: Process TX fifo on configuration enable

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -360,14 +360,14 @@ static void usbd_cdc_acm_enable(struct usbd_class_data *const c_data)
 		cdc_acm_irq_rx_enable(dev);
 	}
 
-	if (atomic_test_bit(&data->state, CDC_ACM_IRQ_TX_ENABLED)) {
-		if (ring_buf_space_get(data->tx_fifo.rb)) {
+	if (ring_buf_is_empty(data->tx_fifo.rb)) {
+		if (atomic_test_bit(&data->state, CDC_ACM_IRQ_TX_ENABLED)) {
 			/* Raise TX ready interrupt */
 			cdc_acm_work_submit(&data->irq_cb_work);
-		} else {
-			/* Queue pending TX data on IN endpoint */
-			cdc_acm_work_schedule(&data->tx_fifo_work, K_NO_WAIT);
 		}
+	} else {
+		/* Queue pending TX data on IN endpoint */
+		cdc_acm_work_schedule(&data->tx_fifo_work, K_NO_WAIT);
 	}
 }
 


### PR DESCRIPTION
If cdc_acm_poll_out() is called with enough data to completely fill the TX fifo while the configuration is disabled, it ends up in an infinite loop, as cdc_acm_tx_fifo_handler() simply returns immediately each time.

In order to exit this infinite loop, schedule the TX handler when the configuration is enabled if the fifo is full, so it starts emptying it.