### PR TITLE
STM32: clean up inclusion of `mem.h` in SoC DTSI files

### DIFF
--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -69,6 +69,7 @@
 #include <zephyr/dt-bindings/reset/stm32c0_reset.h>
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/c0/stm32c011X6.dtsi
+++ b/dts/arm/st/c0/stm32c011X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/c0/stm32c011.dtsi>
 
 / {

--- a/dts/arm/st/c0/stm32c031X6.dtsi
+++ b/dts/arm/st/c0/stm32c031X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/c0/stm32c031.dtsi>
 
 / {

--- a/dts/arm/st/c0/stm32c051X6.dtsi
+++ b/dts/arm/st/c0/stm32c051X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/c0/stm32c051.dtsi>
 
 / {

--- a/dts/arm/st/c0/stm32c051X8.dtsi
+++ b/dts/arm/st/c0/stm32c051X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/c0/stm32c051.dtsi>
 
 / {

--- a/dts/arm/st/c0/stm32c071X8.dtsi
+++ b/dts/arm/st/c0/stm32c071X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/c0/stm32c071.dtsi>
 
 / {

--- a/dts/arm/st/c0/stm32c071Xb.dtsi
+++ b/dts/arm/st/c0/stm32c071Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/c0/stm32c071.dtsi>
 
 / {

--- a/dts/arm/st/c0/stm32c091Xb.dtsi
+++ b/dts/arm/st/c0/stm32c091Xb.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/c0/stm32c091.dtsi>
 
 / {

--- a/dts/arm/st/c0/stm32c091Xc.dtsi
+++ b/dts/arm/st/c0/stm32c091Xc.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/c0/stm32c091.dtsi>
 
 / {

--- a/dts/arm/st/c0/stm32c092Xb.dtsi
+++ b/dts/arm/st/c0/stm32c092Xb.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/c0/stm32c092.dtsi>
 
 / {

--- a/dts/arm/st/c0/stm32c092Xc.dtsi
+++ b/dts/arm/st/c0/stm32c092Xc.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/c0/stm32c092.dtsi>
 
 / {

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -17,6 +17,7 @@
 #include <zephyr/dt-bindings/reset/stm32f0_1_3_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/f0/stm32f030X4.dtsi
+++ b/dts/arm/st/f0/stm32f030X4.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f0/stm32f030.dtsi>
 
 / {

--- a/dts/arm/st/f0/stm32f030X6.dtsi
+++ b/dts/arm/st/f0/stm32f030X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f0/stm32f030.dtsi>
 
 / {
@@ -20,4 +19,3 @@
 		};
 	};
 };
-

--- a/dts/arm/st/f0/stm32f030X8.dtsi
+++ b/dts/arm/st/f0/stm32f030X8.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/f0/stm32f030.dtsi>
 
 / {

--- a/dts/arm/st/f0/stm32f030Xc.dtsi
+++ b/dts/arm/st/f0/stm32f030Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f0/stm32f030X8.dtsi>
 
 / {

--- a/dts/arm/st/f0/stm32f031X6.dtsi
+++ b/dts/arm/st/f0/stm32f031X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f0/stm32f031.dtsi>
 
 / {

--- a/dts/arm/st/f0/stm32f042X6.dtsi
+++ b/dts/arm/st/f0/stm32f042X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f0/stm32f042.dtsi>
 
 / {

--- a/dts/arm/st/f0/stm32f051X8.dtsi
+++ b/dts/arm/st/f0/stm32f051X8.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/f0/stm32f051.dtsi>
 
 / {

--- a/dts/arm/st/f0/stm32f070Xb.dtsi
+++ b/dts/arm/st/f0/stm32f070Xb.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/f0/stm32f070.dtsi>
 
 / {

--- a/dts/arm/st/f0/stm32f072X8.dtsi
+++ b/dts/arm/st/f0/stm32f072X8.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/f0/stm32f072.dtsi>
 
 / {

--- a/dts/arm/st/f0/stm32f072Xb.dtsi
+++ b/dts/arm/st/f0/stm32f072Xb.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/f0/stm32f072.dtsi>
 
 / {

--- a/dts/arm/st/f0/stm32f091Xc.dtsi
+++ b/dts/arm/st/f0/stm32f091Xc.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/f0/stm32f091.dtsi>
 
 / {

--- a/dts/arm/st/f0/stm32f098Xc.dtsi
+++ b/dts/arm/st/f0/stm32f098Xc.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/f0/stm32f091.dtsi>
 
 / {

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -18,6 +18,7 @@
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/f1/stm32f100Xb.dtsi
+++ b/dts/arm/st/f1/stm32f100Xb.dtsi
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f1/stm32f1.dtsi>
 
 / {

--- a/dts/arm/st/f1/stm32f100Xe.dtsi
+++ b/dts/arm/st/f1/stm32f100Xe.dtsi
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f1/stm32f100Xb.dtsi>
 
 / {

--- a/dts/arm/st/f1/stm32f103X8.dtsi
+++ b/dts/arm/st/f1/stm32f103X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f1/stm32f1.dtsi>
 
 / {

--- a/dts/arm/st/f1/stm32f103Xb.dtsi
+++ b/dts/arm/st/f1/stm32f103Xb.dtsi
@@ -7,7 +7,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f1/stm32f103X8.dtsi>
 
 / {

--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -7,7 +7,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f1/stm32f103Xb.dtsi>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 

--- a/dts/arm/st/f1/stm32f103Xd.dtsi
+++ b/dts/arm/st/f1/stm32f103Xd.dtsi
@@ -7,7 +7,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f1/stm32f103Xc.dtsi>
 
 / {

--- a/dts/arm/st/f1/stm32f103Xe.dtsi
+++ b/dts/arm/st/f1/stm32f103Xe.dtsi
@@ -7,7 +7,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f1/stm32f103Xd.dtsi>
 
 / {

--- a/dts/arm/st/f1/stm32f103Xg.dtsi
+++ b/dts/arm/st/f1/stm32f103Xg.dtsi
@@ -6,7 +6,6 @@
  * where 'x' is replaced for specific SoCs like {R,V,Z}
  */
 
-#include <mem.h>
 #include <st/f1/stm32f103Xe.dtsi>
 
 / {

--- a/dts/arm/st/f1/stm32f105Xb.dtsi
+++ b/dts/arm/st/f1/stm32f105Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f1/stm32f105.dtsi>
 
 / {

--- a/dts/arm/st/f1/stm32f105Xc.dtsi
+++ b/dts/arm/st/f1/stm32f105Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f1/stm32f105.dtsi>
 
 / {

--- a/dts/arm/st/f1/stm32f107Xc.dtsi
+++ b/dts/arm/st/f1/stm32f107Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f1/stm32f107.dtsi>
 
 / {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -18,6 +18,7 @@
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/f2/stm32f205Xe.dtsi
+++ b/dts/arm/st/f2/stm32f205Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f2/stm32f2.dtsi>
 
 / {

--- a/dts/arm/st/f2/stm32f207Xg.dtsi
+++ b/dts/arm/st/f2/stm32f207Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f2/stm32f207.dtsi>
 
 / {

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -17,6 +17,7 @@
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/f3/stm32f302X8.dtsi
+++ b/dts/arm/st/f3/stm32f302X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f3/stm32f302.dtsi>
 
 / {

--- a/dts/arm/st/f3/stm32f302Xc.dtsi
+++ b/dts/arm/st/f3/stm32f302Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f3/stm32f302.dtsi>
 #include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 

--- a/dts/arm/st/f3/stm32f303X8.dtsi
+++ b/dts/arm/st/f3/stm32f303X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f3/stm32f303.dtsi>
 
 / {

--- a/dts/arm/st/f3/stm32f303Xb.dtsi
+++ b/dts/arm/st/f3/stm32f303Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f3/stm32f303.dtsi>
 #include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 

--- a/dts/arm/st/f3/stm32f303Xc.dtsi
+++ b/dts/arm/st/f3/stm32f303Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f3/stm32f303Xb.dtsi>
 
 &sram0 {

--- a/dts/arm/st/f3/stm32f303Xe.dtsi
+++ b/dts/arm/st/f3/stm32f303Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f3/stm32f303.dtsi>
 #include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 

--- a/dts/arm/st/f3/stm32f334X8.dtsi
+++ b/dts/arm/st/f3/stm32f334X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f3/stm32f334.dtsi>
 
 / {

--- a/dts/arm/st/f3/stm32f373Xc.dtsi
+++ b/dts/arm/st/f3/stm32f373Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f3/stm32f373.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -20,6 +20,7 @@
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/f4/stm32f401Xc.dtsi
+++ b/dts/arm/st/f4/stm32f401Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f401.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f401Xd.dtsi
+++ b/dts/arm/st/f4/stm32f401Xd.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f401.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f401Xe.dtsi
+++ b/dts/arm/st/f4/stm32f401Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f401.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f405Xg.dtsi
+++ b/dts/arm/st/f4/stm32f405Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f405.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f407Xe.dtsi
+++ b/dts/arm/st/f4/stm32f407Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f407.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f407Xg.dtsi
+++ b/dts/arm/st/f4/stm32f407Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f407.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f410Xb.dtsi
+++ b/dts/arm/st/f4/stm32f410Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f410.dtsi>
 
 /delete-node/ &sdmmc1;

--- a/dts/arm/st/f4/stm32f411Xe.dtsi
+++ b/dts/arm/st/f4/stm32f411Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f411.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f412Xe.dtsi
+++ b/dts/arm/st/f4/stm32f412Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f412.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f412Xg.dtsi
+++ b/dts/arm/st/f4/stm32f412Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f412.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f413Xg.dtsi
+++ b/dts/arm/st/f4/stm32f413Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f413.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f413Xh.dtsi
+++ b/dts/arm/st/f4/stm32f413Xh.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f413.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f415Rg.dtsi
+++ b/dts/arm/st/f4/stm32f415Rg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f415.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f417Xe.dtsi
+++ b/dts/arm/st/f4/stm32f417Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f417.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f417Xg.dtsi
+++ b/dts/arm/st/f4/stm32f417Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f417.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f423Xg.dtsi
+++ b/dts/arm/st/f4/stm32f423Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f423.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f423Xh.dtsi
+++ b/dts/arm/st/f4/stm32f423Xh.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f423.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f427Xi.dtsi
+++ b/dts/arm/st/f4/stm32f427Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f427.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f427vi.dtsi
+++ b/dts/arm/st/f4/stm32f427vi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f427vX.dtsi>
 
 / {
@@ -26,4 +25,3 @@
 		};
 	};
 };
-

--- a/dts/arm/st/f4/stm32f429Xi.dtsi
+++ b/dts/arm/st/f4/stm32f429Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f429.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f429vi.dtsi
+++ b/dts/arm/st/f4/stm32f429vi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f429vX.dtsi>
 
 / {
@@ -26,4 +25,3 @@
 		};
 	};
 };
-

--- a/dts/arm/st/f4/stm32f437Xi.dtsi
+++ b/dts/arm/st/f4/stm32f437Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f437.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f439Xi.dtsi
+++ b/dts/arm/st/f4/stm32f439Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f439.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f439vi.dtsi
+++ b/dts/arm/st/f4/stm32f439vi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f439vX.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f446Xe.dtsi
+++ b/dts/arm/st/f4/stm32f446Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f446.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f469Xi.dtsi
+++ b/dts/arm/st/f4/stm32f469Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f469.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f479Xi.dtsi
+++ b/dts/arm/st/f4/stm32f479Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f4/stm32f479.dtsi>
 
 / {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -21,6 +21,7 @@
 #include <zephyr/dt-bindings/memory-attr/memory-attr.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/f7/stm32f722Xe.dtsi
+++ b/dts/arm/st/f7/stm32f722Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f7/stm32f722.dtsi>
 
 / {

--- a/dts/arm/st/f7/stm32f723Xe.dtsi
+++ b/dts/arm/st/f7/stm32f723Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f7/stm32f723.dtsi>
 
 / {

--- a/dts/arm/st/f7/stm32f745Xe.dtsi
+++ b/dts/arm/st/f7/stm32f745Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f7/stm32f745.dtsi>
 
 / {

--- a/dts/arm/st/f7/stm32f745Xg.dtsi
+++ b/dts/arm/st/f7/stm32f745Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f7/stm32f745.dtsi>
 
 / {

--- a/dts/arm/st/f7/stm32f746Xg.dtsi
+++ b/dts/arm/st/f7/stm32f746Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f7/stm32f746.dtsi>
 
 / {

--- a/dts/arm/st/f7/stm32f750X8.dtsi
+++ b/dts/arm/st/f7/stm32f750X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f7/stm32f750.dtsi>
 
 / {

--- a/dts/arm/st/f7/stm32f756Xg.dtsi
+++ b/dts/arm/st/f7/stm32f756Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f7/stm32f756.dtsi>
 
 / {

--- a/dts/arm/st/f7/stm32f765Xg.dtsi
+++ b/dts/arm/st/f7/stm32f765Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f7/stm32f765.dtsi>
 
 / {

--- a/dts/arm/st/f7/stm32f765Xi.dtsi
+++ b/dts/arm/st/f7/stm32f765Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f7/stm32f765.dtsi>
 
 / {

--- a/dts/arm/st/f7/stm32f767Xi.dtsi
+++ b/dts/arm/st/f7/stm32f767Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f7/stm32f767.dtsi>
 
 / {

--- a/dts/arm/st/f7/stm32f769Xi.dtsi
+++ b/dts/arm/st/f7/stm32f769Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/f7/stm32f769.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -21,6 +21,7 @@
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <zephyr/dt-bindings/reset/stm32g0_reset.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/g0/stm32g030X6.dtsi
+++ b/dts/arm/st/g0/stm32g030X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g030.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g030X8.dtsi
+++ b/dts/arm/st/g0/stm32g030X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g030.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g031X4.dtsi
+++ b/dts/arm/st/g0/stm32g031X4.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g031.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g031X6.dtsi
+++ b/dts/arm/st/g0/stm32g031X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g031.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g031X8.dtsi
+++ b/dts/arm/st/g0/stm32g031X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g031.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g041X6.dtsi
+++ b/dts/arm/st/g0/stm32g041X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g041.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g041X8.dtsi
+++ b/dts/arm/st/g0/stm32g041X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g041.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g050X6.dtsi
+++ b/dts/arm/st/g0/stm32g050X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g050.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g050X8.dtsi
+++ b/dts/arm/st/g0/stm32g050X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g050.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g051X6.dtsi
+++ b/dts/arm/st/g0/stm32g051X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g051.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g051X8.dtsi
+++ b/dts/arm/st/g0/stm32g051X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g051.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g061X6.dtsi
+++ b/dts/arm/st/g0/stm32g061X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g061.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g061X8.dtsi
+++ b/dts/arm/st/g0/stm32g061X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g061.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g070Xb.dtsi
+++ b/dts/arm/st/g0/stm32g070Xb.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g070.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g071X8.dtsi
+++ b/dts/arm/st/g0/stm32g071X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g071.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g071Xb.dtsi
+++ b/dts/arm/st/g0/stm32g071Xb.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g071.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g081Xb.dtsi
+++ b/dts/arm/st/g0/stm32g081Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g081.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g0b0Xe.dtsi
+++ b/dts/arm/st/g0/stm32g0b0Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g0b0.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g0b1Xb.dtsi
+++ b/dts/arm/st/g0/stm32g0b1Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g0b1.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g0b1Xc.dtsi
+++ b/dts/arm/st/g0/stm32g0b1Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g0b1.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g0b1Xe.dtsi
+++ b/dts/arm/st/g0/stm32g0b1Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g0b1.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g0c1Xc.dtsi
+++ b/dts/arm/st/g0/stm32g0c1Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g0c1.dtsi>
 
 / {

--- a/dts/arm/st/g0/stm32g0c1Xe.dtsi
+++ b/dts/arm/st/g0/stm32g0c1Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g0/stm32g0c1.dtsi>
 
 / {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -20,6 +20,7 @@
 #include <zephyr/dt-bindings/reset/stm32g4_l4_5_reset.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/g4/stm32g431X6.dtsi
+++ b/dts/arm/st/g4/stm32g431X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g431.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g431X8.dtsi
+++ b/dts/arm/st/g4/stm32g431X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g431.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g431Xb.dtsi
+++ b/dts/arm/st/g4/stm32g431Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g431.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g441Xb.dtsi
+++ b/dts/arm/st/g4/stm32g441Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g441.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g473Xb.dtsi
+++ b/dts/arm/st/g4/stm32g473Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g473.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g473Xc.dtsi
+++ b/dts/arm/st/g4/stm32g473Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g473.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g473Xe.dtsi
+++ b/dts/arm/st/g4/stm32g473Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g473.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g474Xb.dtsi
+++ b/dts/arm/st/g4/stm32g474Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g474.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g474Xc.dtsi
+++ b/dts/arm/st/g4/stm32g474Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g474.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g474Xe.dtsi
+++ b/dts/arm/st/g4/stm32g474Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g474.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g483Xe.dtsi
+++ b/dts/arm/st/g4/stm32g483Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g483.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g484Xe.dtsi
+++ b/dts/arm/st/g4/stm32g484Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g484.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g491Xc.dtsi
+++ b/dts/arm/st/g4/stm32g491Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g491.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g491Xe.dtsi
+++ b/dts/arm/st/g4/stm32g491Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g491.dtsi>
 
 &sram0 {

--- a/dts/arm/st/g4/stm32g4a1Xe.dtsi
+++ b/dts/arm/st/g4/stm32g4a1Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/g4/stm32g4a1.dtsi>
 
 &sram0 {

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/h5/stm32h503Xb.dtsi
+++ b/dts/arm/st/h5/stm32h503Xb.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/h5/stm32h503.dtsi>
 
 / {

--- a/dts/arm/st/h5/stm32h523Xe.dtsi
+++ b/dts/arm/st/h5/stm32h523Xe.dtsi
@@ -4,7 +4,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/h5/stm32h523.dtsi>
 
 / {

--- a/dts/arm/st/h5/stm32h533Xe.dtsi
+++ b/dts/arm/st/h5/stm32h533Xe.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/h5/stm32h533.dtsi>
 
 / {

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -8,7 +8,6 @@
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
 /* keep both header files for compatibility */
 #include <zephyr/dt-bindings/flash_controller/xspi.h>
-#include <mem.h>
 
 / {
 	clocks {

--- a/dts/arm/st/h5/stm32h562Xg.dtsi
+++ b/dts/arm/st/h5/stm32h562Xg.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/h5/stm32h562.dtsi>
 
 / {

--- a/dts/arm/st/h5/stm32h563Xi.dtsi
+++ b/dts/arm/st/h5/stm32h563Xi.dtsi
@@ -4,7 +4,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/h5/stm32h563.dtsi>
 
 / {

--- a/dts/arm/st/h5/stm32h573Xi.dtsi
+++ b/dts/arm/st/h5/stm32h573Xi.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/h5/stm32h573.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -23,6 +23,7 @@
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h7.dtsi>
 #include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>

--- a/dts/arm/st/h7/stm32h723Xe.dtsi
+++ b/dts/arm/st/h7/stm32h723Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h723.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h723Xg.dtsi
+++ b/dts/arm/st/h7/stm32h723Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h723.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h725Xe.dtsi
+++ b/dts/arm/st/h7/stm32h725Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h725.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h725Xg.dtsi
+++ b/dts/arm/st/h7/stm32h725Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h725.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h730Xb.dtsi
+++ b/dts/arm/st/h7/stm32h730Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h730.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h735Xg.dtsi
+++ b/dts/arm/st/h7/stm32h735Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h735.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h742Xg.dtsi
+++ b/dts/arm/st/h7/stm32h742Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h742.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h742Xi.dtsi
+++ b/dts/arm/st/h7/stm32h742Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h742.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h743Xg.dtsi
+++ b/dts/arm/st/h7/stm32h743Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h743.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h743Xi.dtsi
+++ b/dts/arm/st/h7/stm32h743Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h743.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h745Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h745Xi_m4.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h745.dtsi>
 
 /delete-node/ &flash0;

--- a/dts/arm/st/h7/stm32h745Xi_m7.dtsi
+++ b/dts/arm/st/h7/stm32h745Xi_m7.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h745.dtsi>
 
 /delete-node/ &flash1;

--- a/dts/arm/st/h7/stm32h747Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h747Xi_m4.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h747.dtsi>
 
 /delete-node/ &flash0;

--- a/dts/arm/st/h7/stm32h747Xi_m7.dtsi
+++ b/dts/arm/st/h7/stm32h747Xi_m7.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h747.dtsi>
 
 /delete-node/ &flash1;

--- a/dts/arm/st/h7/stm32h750Xb.dtsi
+++ b/dts/arm/st/h7/stm32h750Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h750.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h753Xi.dtsi
+++ b/dts/arm/st/h7/stm32h753Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h753.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h755Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h755Xi_m4.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h755.dtsi>
 
 /delete-node/ &flash0;

--- a/dts/arm/st/h7/stm32h755Xi_m7.dtsi
+++ b/dts/arm/st/h7/stm32h755Xi_m7.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h755.dtsi>
 
 /delete-node/ &flash1;

--- a/dts/arm/st/h7/stm32h757Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h757Xi_m4.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h757.dtsi>
 
 /delete-node/ &flash0;

--- a/dts/arm/st/h7/stm32h757Xi_m7.dtsi
+++ b/dts/arm/st/h7/stm32h757Xi_m7.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h757.dtsi>
 
 /delete-node/ &flash1;

--- a/dts/arm/st/h7/stm32h7a3Xi.dtsi
+++ b/dts/arm/st/h7/stm32h7a3Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h7a3.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h7b0.dtsi
+++ b/dts/arm/st/h7/stm32h7b0.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h7a3.dtsi>
 
 /*

--- a/dts/arm/st/h7/stm32h7b0Xb.dtsi
+++ b/dts/arm/st/h7/stm32h7b0Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h7b0.dtsi>
 
 / {

--- a/dts/arm/st/h7/stm32h7b3.dtsi
+++ b/dts/arm/st/h7/stm32h7b3.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h7b0.dtsi>
 
 /*

--- a/dts/arm/st/h7/stm32h7b3Xi.dtsi
+++ b/dts/arm/st/h7/stm32h7b3Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7/stm32h7b3.dtsi>
 
 / {

--- a/dts/arm/st/h7rs/stm32h7r3.dtsi
+++ b/dts/arm/st/h7rs/stm32h7r3.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7rs/stm32h7rs.dtsi>
 
 / {

--- a/dts/arm/st/h7rs/stm32h7r3X8.dtsi
+++ b/dts/arm/st/h7rs/stm32h7r3X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7rs/stm32h7r3.dtsi>
 
 / {

--- a/dts/arm/st/h7rs/stm32h7r7.dtsi
+++ b/dts/arm/st/h7rs/stm32h7r7.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7rs/stm32h7r3.dtsi>
 
 /*

--- a/dts/arm/st/h7rs/stm32h7r7X8.dtsi
+++ b/dts/arm/st/h7rs/stm32h7r7X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7rs/stm32h7r7.dtsi>
 
 / {

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -19,6 +19,7 @@
 #include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <freq.h>
+#include <mem.h>
 
 /*
  * STM32H7RS line contains has many common peripherals with STM32H7.

--- a/dts/arm/st/h7rs/stm32h7s3.dtsi
+++ b/dts/arm/st/h7rs/stm32h7s3.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7rs/stm32h7r3.dtsi>
 
 /*

--- a/dts/arm/st/h7rs/stm32h7s3X8.dtsi
+++ b/dts/arm/st/h7rs/stm32h7s3X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7rs/stm32h7s3.dtsi>
 
 / {

--- a/dts/arm/st/h7rs/stm32h7s7.dtsi
+++ b/dts/arm/st/h7rs/stm32h7s7.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7rs/stm32h7r7.dtsi>
 
 /*

--- a/dts/arm/st/h7rs/stm32h7s7X8.dtsi
+++ b/dts/arm/st/h7rs/stm32h7s7X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/h7rs/stm32h7s7.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -17,6 +17,7 @@
 #include <zephyr/dt-bindings/reset/stm32l0_reset.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/l0/stm32l010X4.dtsi
+++ b/dts/arm/st/l0/stm32l010X4.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l010.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l010X6.dtsi
+++ b/dts/arm/st/l0/stm32l010X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l010.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l010X8.dtsi
+++ b/dts/arm/st/l0/stm32l010X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l010.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l010Xb.dtsi
+++ b/dts/arm/st/l0/stm32l010Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l010.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l011X4.dtsi
+++ b/dts/arm/st/l0/stm32l011X4.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l010.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l031X6.dtsi
+++ b/dts/arm/st/l0/stm32l031X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l031.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l051X6.dtsi
+++ b/dts/arm/st/l0/stm32l051X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l051.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l051X8.dtsi
+++ b/dts/arm/st/l0/stm32l051X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l051.dtsi>
 
 / {
@@ -20,4 +19,3 @@
 		};
 	};
 };
-

--- a/dts/arm/st/l0/stm32l053X8.dtsi
+++ b/dts/arm/st/l0/stm32l053X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l053.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l071X8.dtsi
+++ b/dts/arm/st/l0/stm32l071X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l071.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l071Xb.dtsi
+++ b/dts/arm/st/l0/stm32l071Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l071.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l071Xz.dtsi
+++ b/dts/arm/st/l0/stm32l071Xz.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l071.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l072Xz.dtsi
+++ b/dts/arm/st/l0/stm32l072Xz.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l072.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l073Xz.dtsi
+++ b/dts/arm/st/l0/stm32l073Xz.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l073.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l081Xz.dtsi
+++ b/dts/arm/st/l0/stm32l081Xz.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l081.dtsi>
 
 / {

--- a/dts/arm/st/l0/stm32l083Xz.dtsi
+++ b/dts/arm/st/l0/stm32l083Xz.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l0/stm32l083.dtsi>
 
 / {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -19,6 +19,7 @@
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/l1/stm32l100Xb.dtsi
+++ b/dts/arm/st/l1/stm32l100Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l1/stm32l100.dtsi>
 
 / {

--- a/dts/arm/st/l1/stm32l151X8-a.dtsi
+++ b/dts/arm/st/l1/stm32l151X8-a.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l1/stm32l151.dtsi>
 
 / {

--- a/dts/arm/st/l1/stm32l151Xb-a.dtsi
+++ b/dts/arm/st/l1/stm32l151Xb-a.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l1/stm32l151.dtsi>
 
 / {

--- a/dts/arm/st/l1/stm32l151Xb.dtsi
+++ b/dts/arm/st/l1/stm32l151Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l1/stm32l151.dtsi>
 
 / {

--- a/dts/arm/st/l1/stm32l151Xc.dtsi
+++ b/dts/arm/st/l1/stm32l151Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l1/stm32l151.dtsi>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 

--- a/dts/arm/st/l1/stm32l152Xc.dtsi
+++ b/dts/arm/st/l1/stm32l152Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l1/stm32l152.dtsi>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 

--- a/dts/arm/st/l1/stm32l152Xe.dtsi
+++ b/dts/arm/st/l1/stm32l152Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l1/stm32l152.dtsi>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -20,6 +20,7 @@
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/l4/stm32l412X8.dtsi
+++ b/dts/arm/st/l4/stm32l412X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l412.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l412XB.dtsi
+++ b/dts/arm/st/l4/stm32l412XB.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l412.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l422Xb.dtsi
+++ b/dts/arm/st/l4/stm32l422Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l422.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l431Xb.dtsi
+++ b/dts/arm/st/l4/stm32l431Xb.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l431.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l431Xc.dtsi
+++ b/dts/arm/st/l4/stm32l431Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l431.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l432Xc.dtsi
+++ b/dts/arm/st/l4/stm32l432Xc.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/l4/stm32l432.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l433Xb.dtsi
+++ b/dts/arm/st/l4/stm32l433Xb.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/l4/stm32l433.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l433Xc.dtsi
+++ b/dts/arm/st/l4/stm32l433Xc.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/l4/stm32l433.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l451Xc.dtsi
+++ b/dts/arm/st/l4/stm32l451Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l451.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l451Xe.dtsi
+++ b/dts/arm/st/l4/stm32l451Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l451.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l452Xc.dtsi
+++ b/dts/arm/st/l4/stm32l452Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l452.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l452Xe.dtsi
+++ b/dts/arm/st/l4/stm32l452Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l452.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l462Xe.dtsi
+++ b/dts/arm/st/l4/stm32l462Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l462.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l471Xg.dtsi
+++ b/dts/arm/st/l4/stm32l471Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l471.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l475Xe.dtsi
+++ b/dts/arm/st/l4/stm32l475Xe.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/l4/stm32l475.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l475Xg.dtsi
+++ b/dts/arm/st/l4/stm32l475Xg.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/l4/stm32l475.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l476Xg.dtsi
+++ b/dts/arm/st/l4/stm32l476Xg.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/l4/stm32l476.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l486Xg.dtsi
+++ b/dts/arm/st/l4/stm32l486Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l486.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l496Xe.dtsi
+++ b/dts/arm/st/l4/stm32l496Xe.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/l4/stm32l496.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l496Xg.dtsi
+++ b/dts/arm/st/l4/stm32l496Xg.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/l4/stm32l496.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l4a6Xg.dtsi
+++ b/dts/arm/st/l4/stm32l4a6Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l4a6.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l4.dtsi>
 #include <zephyr/dt-bindings/clock/stm32l4plus_clock.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>

--- a/dts/arm/st/l4/stm32l4p5Xi.dtsi
+++ b/dts/arm/st/l4/stm32l4p5Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l4p5.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l4p5.dtsi>
 
 /delete-node/ &sdmmc2;

--- a/dts/arm/st/l4/stm32l4r5Xi.dtsi
+++ b/dts/arm/st/l4/stm32l4r5Xi.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l4r5.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l4r9.dtsi
+++ b/dts/arm/st/l4/stm32l4r9.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l4r5.dtsi>
 #include <zephyr/dt-bindings/display/panel.h>
 

--- a/dts/arm/st/l4/stm32l4r9Xi.dtsi
+++ b/dts/arm/st/l4/stm32l4r9Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l4r9.dtsi>
 
 / {

--- a/dts/arm/st/l4/stm32l4s5Xi.dtsi
+++ b/dts/arm/st/l4/stm32l4s5Xi.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/l4/stm32l4s5.dtsi>
 
 / {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -20,6 +20,7 @@
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/l5/stm32l552Xc.dtsi
+++ b/dts/arm/st/l5/stm32l552Xc.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/l5/stm32l552.dtsi>
 
 / {

--- a/dts/arm/st/l5/stm32l552Xe.dtsi
+++ b/dts/arm/st/l5/stm32l552Xe.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/l5/stm32l552.dtsi>
 
 / {

--- a/dts/arm/st/l5/stm32l562Xe.dtsi
+++ b/dts/arm/st/l5/stm32l562Xe.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/l5/stm32l562.dtsi>
 
 / {

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -18,6 +18,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/video/video-interfaces.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	cpus {

--- a/dts/arm/st/n6/stm32n657X0.dtsi
+++ b/dts/arm/st/n6/stm32n657X0.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/n6/stm32n657.dtsi>
 
 / {

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -15,6 +15,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/reset/stm32u0_reset.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/u0/stm32u031X4.dtsi
+++ b/dts/arm/st/u0/stm32u031X4.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/u0/stm32u031.dtsi>
 
 / {

--- a/dts/arm/st/u0/stm32u031X6.dtsi
+++ b/dts/arm/st/u0/stm32u031X6.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/u0/stm32u031.dtsi>
 
 / {

--- a/dts/arm/st/u0/stm32u031X8.dtsi
+++ b/dts/arm/st/u0/stm32u031X8.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/u0/stm32u031.dtsi>
 
 / {

--- a/dts/arm/st/u0/stm32u073X8.dtsi
+++ b/dts/arm/st/u0/stm32u073X8.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/u0/stm32u073.dtsi>
 
 / {

--- a/dts/arm/st/u0/stm32u073Xb.dtsi
+++ b/dts/arm/st/u0/stm32u073Xb.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/u0/stm32u073.dtsi>
 
 / {

--- a/dts/arm/st/u0/stm32u073Xc.dtsi
+++ b/dts/arm/st/u0/stm32u073Xc.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/u0/stm32u073.dtsi>
 
 / {

--- a/dts/arm/st/u0/stm32u083Xc.dtsi
+++ b/dts/arm/st/u0/stm32u083Xc.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/u0/stm32u083.dtsi>
 
 / {

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/reset/stm32u3_reset.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/u3/stm32u385Xg.dtsi
+++ b/dts/arm/st/u3/stm32u385Xg.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/u3/stm32u385.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -21,6 +21,7 @@
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/u5/stm32u535Xb.dtsi
+++ b/dts/arm/st/u5/stm32u535Xb.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/u5/stm32u535.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u535Xc.dtsi
+++ b/dts/arm/st/u5/stm32u535Xc.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/u5/stm32u535.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u535Xe.dtsi
+++ b/dts/arm/st/u5/stm32u535Xe.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/u5/stm32u535.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u545Xe.dtsi
+++ b/dts/arm/st/u5/stm32u545Xe.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/u5/stm32u545.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u575Xg.dtsi
+++ b/dts/arm/st/u5/stm32u575Xg.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/u5/stm32u575.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u575Xi.dtsi
+++ b/dts/arm/st/u5/stm32u575Xi.dtsi
@@ -4,7 +4,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/u5/stm32u575.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u585Xi.dtsi
+++ b/dts/arm/st/u5/stm32u585Xi.dtsi
@@ -4,7 +4,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/u5/stm32u585.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u595Xi.dtsi
+++ b/dts/arm/st/u5/stm32u595Xi.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/u5/stm32u595.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u595Xj.dtsi
+++ b/dts/arm/st/u5/stm32u595Xj.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/u5/stm32u595.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u599.dtsi
+++ b/dts/arm/st/u5/stm32u599.dtsi
@@ -10,7 +10,6 @@
 #include <zephyr/dt-bindings/memory-attr/memory-attr.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/flash_controller/xspi.h>
-#include <mem.h>
 
 / {
 	soc {

--- a/dts/arm/st/u5/stm32u599Xi.dtsi
+++ b/dts/arm/st/u5/stm32u599Xi.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/u5/stm32u599.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u599Xj.dtsi
+++ b/dts/arm/st/u5/stm32u599Xj.dtsi
@@ -4,7 +4,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/u5/stm32u599.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u5a5Xj.dtsi
+++ b/dts/arm/st/u5/stm32u5a5Xj.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/u5/stm32u5a5.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u5a9Xj.dtsi
+++ b/dts/arm/st/u5/stm32u5a9Xj.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/u5/stm32u5a9.dtsi>
 
 / {

--- a/dts/arm/st/u5/stm32u5g9Xj.dtsi
+++ b/dts/arm/st/u5/stm32u5g9Xj.dtsi
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mem.h>
 #include <st/u5/stm32u5g9.dtsi>
 
 / {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -18,6 +18,7 @@
 #include <zephyr/dt-bindings/reset/stm32wb_l_reset.h>
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/wb/stm32wb55Xg.dtsi
+++ b/dts/arm/st/wb/stm32wb55Xg.dtsi
@@ -4,7 +4,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/wb/stm32wb55.dtsi>
 
 / {

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -16,6 +16,7 @@
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/wba/stm32wba52Xg.dtsi
+++ b/dts/arm/st/wba/stm32wba52Xg.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/wba/stm32wba52.dtsi>
 
 / {

--- a/dts/arm/st/wba/stm32wba55Xg.dtsi
+++ b/dts/arm/st/wba/stm32wba55Xg.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/wba/stm32wba55.dtsi>
 
 / {

--- a/dts/arm/st/wba/stm32wba65Xi.dtsi
+++ b/dts/arm/st/wba/stm32wba65Xi.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/wba/stm32wba65.dtsi>
 
 / {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -17,6 +17,7 @@
 #include <zephyr/dt-bindings/reset/stm32wb_l_reset.h>
 #include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <freq.h>
+#include <mem.h>
 
 / {
 	chosen {

--- a/dts/arm/st/wl/stm32wl54Xc.dtsi
+++ b/dts/arm/st/wl/stm32wl54Xc.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/wl/stm32wl55.dtsi>
 
 / {

--- a/dts/arm/st/wl/stm32wl55Xc.dtsi
+++ b/dts/arm/st/wl/stm32wl55Xc.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/wl/stm32wl55.dtsi>
 
 / {

--- a/dts/arm/st/wl/stm32wle4X8.dtsi
+++ b/dts/arm/st/wl/stm32wle4X8.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/wl/stm32wle5.dtsi>
 
 / {

--- a/dts/arm/st/wl/stm32wle4Xb.dtsi
+++ b/dts/arm/st/wl/stm32wle4Xb.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/wl/stm32wle5.dtsi>
 
 / {

--- a/dts/arm/st/wl/stm32wle4Xc.dtsi
+++ b/dts/arm/st/wl/stm32wle4Xc.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/wl/stm32wle5.dtsi>
 
 / {

--- a/dts/arm/st/wl/stm32wle5X8.dtsi
+++ b/dts/arm/st/wl/stm32wle5X8.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/wl/stm32wle5.dtsi>
 
 / {

--- a/dts/arm/st/wl/stm32wle5Xb.dtsi
+++ b/dts/arm/st/wl/stm32wle5Xb.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/wl/stm32wle5.dtsi>
 
 / {

--- a/dts/arm/st/wl/stm32wle5Xc.dtsi
+++ b/dts/arm/st/wl/stm32wle5Xc.dtsi
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <mem.h>
 #include <st/wl/stm32wle5.dtsi>
 
 / {


### PR DESCRIPTION
Include `<mem.h>` from the root DTSI in all series and remove it from other levels of the DTSI inclusion hierarchy. This cleans up some duplicate inclusions and is just more maintainable in the long term (especially since new series copy the existing bad pattern).

STM32WB0, STM32MP1, STM32MP13 and STM32MP2 are not modified because they already include `<mem.h>` from root. 