### PR TITLE
drivers timer nrf_rtc: Fix dependency

### DIFF
--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -7,7 +7,7 @@ config NRF_RTC_TIMER
 	bool "nRF Real Time Counter (NRF_RTC1) Timer"
 	depends on CLOCK_CONTROL
 	depends on SOC_COMPATIBLE_NRF
-	depends on !DT_HAS_NORDIC_NRF_RTC_ENABLED && !DT_HAS_NORDIC_NRF_GRTC_ENABLED
+	depends on !$(dt_nodelabel_enabled,rtc1) && !DT_HAS_NORDIC_NRF_GRTC_ENABLED
 	select TICKLESS_CAPABLE
 	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
 	select NRFX_PPI if SOC_NRF52832


### PR DESCRIPTION
8498c39e13845076668aaf42513c1904a969fbb6 seems to have introduce an incorrect dependency which prevents the RTC timer from been built if any of the RTC's are enabled.
It should only depend on the rtc1.

This was first pinpointed by @anangl here: https://github.com/zephyrproject-rtos/zephyr/pull/97441#pullrequestreview-3330679586

Note this is currently failing in main:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/18593829491/job/53015430226?pr=97785
and can be repro'd w
`cmake -GNinja -DBOARD=nrf52_bsim ../tests/drivers/counter/counter_basic_api/ && ninja`

Note that for real HW targets, as their SOC kconfig files currently redefine the option to set the default,
https://github.com/zephyrproject-rtos/zephyr/blob/main/soc/nordic/nrf52/Kconfig.defconfig#L11
all depends are OR'ed with SOC_SERIES_NRF5XX(=y) && SOC_FAMILY_NORDIC_NRF(=y), so the ones from this file are effectively ignored.
But for the simulated targets we do not override the dependencies in this way.
Once this is fixed in #97441 for real targets, these real targets fail also.