### PR TITLE
boards: infineon: kit_pse84_eval: cmake fix

### DIFF
--- a/boards/infineon/kit_pse84_eval/board.cmake
+++ b/boards/infineon/kit_pse84_eval/board.cmake
@@ -17,5 +17,5 @@ include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 
 if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)
   set_property(TARGET runners_yaml_props_target
-    PROPERTY hex_file ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME}.signed.hex)
+    PROPERTY hex_file ${KERNEL_NAME}.signed.hex)
 endif()


### PR DESCRIPTION
Fix to the .hex file path.  This was breaking
twister runs.