### PR TITLE
net: posix: fix hostname config conflict with unique updates

### DIFF
--- a/subsys/net/Kconfig.hostname
+++ b/subsys/net/Kconfig.hostname
@@ -9,6 +9,16 @@ config NET_HOSTNAME_ENABLE
 	  This is used for example in mDNS to respond to <hostname>.local
 	  mDNS queries.
 
+config NET_HOSTNAME_MAX_LEN
+	int "The maximum allowed hostname length"
+	# This corresponds to "zephyr"
+	default 6 if !NET_HOSTNAME_ENABLE
+	default 63
+	help
+	  This will set the number of bytes allocated for the hostname.
+	  When NET_HOSTNAME_ENABLE is disabled, this defaults to 6 to
+	  accommodate the default "zephyr" hostname.
+
 if NET_HOSTNAME_ENABLE
 
 config NET_HOSTNAME
@@ -23,14 +33,6 @@ config NET_HOSTNAME_DYNAMIC
 	help
 	  This will enable the net_hostname_set() function. NET_HOSTNAME
 	  will be used as default hostname.
-
-config NET_HOSTNAME_MAX_LEN
-	int "The maximum allowed hostname length"
-	depends on NET_HOSTNAME_DYNAMIC
-	range 1 63
-	default 63
-	help
-	  This will set the number of bytes allocateed for the hostname.
 
 config NET_HOSTNAME_UNIQUE
 	bool "Make hostname unique"

--- a/subsys/net/hostname.c
+++ b/subsys/net/hostname.c
@@ -19,7 +19,8 @@ LOG_MODULE_REGISTER(net_hostname, CONFIG_NET_HOSTNAME_LOG_LEVEL);
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/logging/log_backend_net.h>
 
-static char hostname[NET_HOSTNAME_SIZE];
+BUILD_ASSERT(CONFIG_NET_HOSTNAME_MAX_LEN > 0, "NET_HOSTNAME_MAX_LEN must be a positive value");
+static char hostname[NET_HOSTNAME_SIZE] = CONFIG_NET_HOSTNAME;
 
 static void trigger_net_event(void)
 {

--- a/subsys/portability/posix/options/Kconfig.net
+++ b/subsys/portability/posix/options/Kconfig.net
@@ -6,7 +6,6 @@ menuconfig POSIX_NETWORKING
 	bool "POSIX Networking API"
 	depends on NETWORKING
 	select NET_HOSTNAME_ENABLE
-	select NET_HOSTNAME_DYNAMIC
 	select NET_INTERFACE_NAME
 	select NET_SOCKETPAIR
 	select NET_SOCKETS

--- a/tests/net/hostname/src/main.c
+++ b/tests/net/hostname/src/main.c
@@ -360,7 +360,8 @@ ZTEST(net_hostname, test_hostname_get)
 	zassert_mem_equal(hostname, config_hostname,
 			  sizeof(CONFIG_NET_HOSTNAME) - 1, "");
 
-	if (IS_ENABLED(CONFIG_NET_HOSTNAME_UNIQUE)) {
+	if (IS_ENABLED(CONFIG_NET_HOSTNAME_UNIQUE) &&
+	    !IS_ENABLED(CONFIG_NET_HOSTNAME_UNIQUE_UPDATE)) {
 		char mac[6];
 		int ret;
 
@@ -378,8 +379,13 @@ ZTEST(net_hostname, test_hostname_set)
 		int ret;
 
 		ret = net_hostname_set_postfix("foobar", sizeof("foobar") - 1);
-		zassert_equal(ret, -EALREADY,
-			      "Could set hostname postfix (%d)", ret);
+		if (IS_ENABLED(CONFIG_NET_HOSTNAME_UNIQUE_UPDATE)) {
+			zassert_equal(ret, 0,
+				      "Could not update hostname postfix (%d)", ret);
+		} else {
+			zassert_equal(ret, -EALREADY,
+				      "Could set hostname postfix (%d)", ret);
+		}
 	}
 
 	if (IS_ENABLED(CONFIG_NET_HOSTNAME_DYNAMIC)) {

--- a/tests/net/hostname/testcase.yaml
+++ b/tests/net/hostname/testcase.yaml
@@ -21,6 +21,15 @@ tests:
     extra_configs:
       - CONFIG_NET_HOSTNAME_UNIQUE=y
       - CONFIG_NET_HOSTNAME_DYNAMIC=y
+  net.hostname.posix_api.unique_update_compatibility:
+    extra_configs:
+      - CONFIG_POSIX_API=y
+      - CONFIG_NET_HOSTNAME_UNIQUE_UPDATE=y
+      - CONFIG_NET_HOSTNAME_UNIQUE=y
+  net.hostname.posix_api.dynamic_hostname:
+    extra_configs:
+      - CONFIG_POSIX_API=y
+      - CONFIG_NET_HOSTNAME_DYNAMIC=y
   net.hostname.event:
     extra_configs:
       - CONFIG_NET_MGMT=y

--- a/tests/subsys/portability/posix/net/src/gethostname.c
+++ b/tests/subsys/portability/posix/net/src/gethostname.c
@@ -5,8 +5,11 @@
  */
 
 #include <unistd.h>
+#include <errno.h>
+#include <string.h>
 
 #include <zephyr/ztest.h>
+#include <zephyr/net/hostname.h>
 
 ZTEST(net, test_gethostname)
 {
@@ -19,3 +22,106 @@ ZTEST(net, test_gethostname)
 	zassert_equal(strcmp(hostname, CONFIG_NET_HOSTNAME), 0,
 		      "gethostname() returned unexpected hostname: %s", hostname);
 }
+
+ZTEST(net, test_gethostname_buffer_too_small)
+{
+	char small_hostname[2];
+	int ret;
+
+	ret = gethostname(small_hostname, sizeof(small_hostname));
+
+	/* POSIX allows either truncation or error when buffer is too small.
+	 * Zephyr's current implementation truncates (which is POSIX-compliant).
+	 */
+	if (ret == -1) {
+		/* Implementation returns error - verify errno */
+		zassert_equal(errno, ENAMETOOLONG, "Expected ENAMETOOLONG, got %d", errno);
+	} else {
+		/* Implementation truncates - verify it succeeded */
+		zassert_equal(ret, 0, "gethostname() should return 0 on truncation");
+		/* Note: strncpy used in implementation may not null-terminate when truncated,
+		 * so we cannot reliably verify null-termination
+		 */
+	}
+}
+
+ZTEST(net, test_gethostname_zero_length)
+{
+	char hostname[CONFIG_NET_HOSTNAME_MAX_LEN + 1];
+	int ret;
+
+	ret = gethostname(hostname, 0);
+
+	/* With zero length buffer, the implementation uses strncpy(buf, p, 0)
+	 * which copies nothing and returns success. POSIX allows this behavior.
+	 */
+	if (ret == -1) {
+		/* Strict implementation - verify errno */
+		zassert_equal(errno, EINVAL, "Expected EINVAL, got %d", errno);
+	} else {
+		/* Lenient implementation - accepts success */
+		zassert_equal(ret, 0, "gethostname() returned unexpected value: %d", ret);
+	}
+}
+
+ZTEST(net, test_hostname_max_len_consistency)
+{
+	/* Verify that CONFIG_NET_HOSTNAME_MAX_LEN is properly defined and > 0 */
+	zassert_true(CONFIG_NET_HOSTNAME_MAX_LEN > 0,
+		     "CONFIG_NET_HOSTNAME_MAX_LEN must be positive");
+
+	/* Verify it can hold at least the configured hostname */
+	zassert_true(CONFIG_NET_HOSTNAME_MAX_LEN >= strlen(CONFIG_NET_HOSTNAME),
+		     "CONFIG_NET_HOSTNAME_MAX_LEN too small for CONFIG_NET_HOSTNAME");
+
+#ifdef CONFIG_POSIX_HOST_NAME_MAX
+	/* If POSIX is enabled, verify consistency */
+	zassert_true(CONFIG_POSIX_HOST_NAME_MAX >= CONFIG_NET_HOSTNAME_MAX_LEN,
+		     "POSIX_HOST_NAME_MAX should be >= NET_HOSTNAME_MAX_LEN");
+#endif
+}
+
+#ifdef CONFIG_NET_HOSTNAME_DYNAMIC
+ZTEST(net, test_gethostname_dynamic_update)
+{
+	char hostname[CONFIG_NET_HOSTNAME_MAX_LEN + 1];
+	char original_hostname[CONFIG_NET_HOSTNAME_MAX_LEN + 1];
+	char test_hostname[] = "test-dynamic";
+	int ret;
+
+	/* Get original hostname */
+	ret = gethostname(original_hostname, sizeof(original_hostname));
+	zassert_equal(ret, 0, "Failed to get original hostname");
+
+	/* Set new hostname */
+	ret = net_hostname_set(test_hostname, strlen(test_hostname));
+	zassert_equal(ret, 0, "Failed to set hostname");
+
+	/* Verify hostname changed */
+	ret = gethostname(hostname, sizeof(hostname));
+	zassert_equal(ret, 0, "Failed to get hostname after update");
+	zassert_equal(strcmp(hostname, test_hostname), 0,
+		      "Hostname not updated correctly");
+
+	/* Restore original hostname */
+	ret = net_hostname_set(original_hostname, strlen(original_hostname));
+	zassert_equal(ret, 0, "Failed to restore original hostname");
+}
+#endif /* CONFIG_NET_HOSTNAME_DYNAMIC */
+
+#ifdef CONFIG_NET_HOSTNAME_UNIQUE_UPDATE
+ZTEST(net, test_gethostname_with_unique_update)
+{
+	char hostname[CONFIG_NET_HOSTNAME_MAX_LEN + 1];
+	int ret;
+
+	/* This test validates that gethostname works when NET_HOSTNAME_UNIQUE_UPDATE is enabled */
+	ret = gethostname(hostname, sizeof(hostname));
+	zassert_equal(ret, 0, "gethostname() failed with NET_HOSTNAME_UNIQUE_UPDATE enabled");
+
+	/* Hostname should contain the configured name possibly with unique suffix */
+	zassert_true(strlen(hostname) > 0, "Hostname should not be empty");
+	zassert_true(strlen(hostname) <= CONFIG_NET_HOSTNAME_MAX_LEN,
+		     "Hostname length exceeds maximum");
+}
+#endif /* CONFIG_NET_HOSTNAME_UNIQUE_UPDATE */

--- a/tests/subsys/portability/posix/net/testcase.yaml
+++ b/tests/subsys/portability/posix/net/testcase.yaml
@@ -37,3 +37,22 @@ tests:
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_PICOLIBC=y
+  portability.posix.net.hostname.dynamic:
+    extra_configs:
+      - CONFIG_NET_HOSTNAME_ENABLE=y
+      - CONFIG_NET_HOSTNAME_DYNAMIC=y
+  portability.posix.net.hostname.unique:
+    extra_configs:
+      - CONFIG_NET_HOSTNAME_ENABLE=y
+      - CONFIG_NET_HOSTNAME_UNIQUE=y
+      - CONFIG_NET_HOSTNAME_UNIQUE_UPDATE=y
+  portability.posix.net.hostname.dynamic.minimal_libc:
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y
+      - CONFIG_NET_HOSTNAME_ENABLE=y
+      - CONFIG_NET_HOSTNAME_DYNAMIC=y
+  portability.posix.net.hostname.unique_update:
+    extra_configs:
+      - CONFIG_POSIX_API=y
+      - CONFIG_NET_HOSTNAME_UNIQUE_UPDATE=y
+      - CONFIG_NET_HOSTNAME_UNIQUE=y


### PR DESCRIPTION
## Overview

Fixes Kconfig conflict between POSIX networking and unique hostname updates that was introduced in v3.7.1.

## Problem

Enabling `CONFIG_POSIX_API=y` auto-selects `CONFIG_POSIX_NETWORKING=y`, which force-selects `CONFIG_NET_HOSTNAME_DYNAMIC=y`. This conflicts with `CONFIG_NET_HOSTNAME_UNIQUE_UPDATE=y`, preventing the use of POSIX networking with unique hostname updates.

## Solution

Decouple `NET_HOSTNAME_MAX_LEN` from `NET_HOSTNAME_DYNAMIC` dependency:
- Remove forced selection of `NET_HOSTNAME_DYNAMIC` from POSIX networking
- Make hostname length configuration available independently
- Add build assertions - Ensure proper validation at compile time

## Testing

- [x] Verified fix resolves Kconfig conflicts
- [x] Validated unique hostname update operations
- [x] Confirmed hostname length constants are properly defined
- [x] Build tests pass for various configuration combinations

Fixes #95811