### PR TITLE
MAINTAINERS: move TF-A to odd fixes

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6098,10 +6098,7 @@ West:
     - thrift
 
 "West project: trusted-firmware-a":
-  status: maintained
-  maintainers:
-    - povergoing
-    - sgrrzhf
+  status: odd fixes
   collaborators:
     - wearyzen
     - ithinuel


### PR DESCRIPTION
Former maintainers @povergoing  and @SgrrZhf have not been active for several releases despite attempts to contact them. Instead of keeping PRs and releases gating on having them respond, remove them from the maintainers list until they can return.

Unfortunately this moves TF-A from maintained to odd fixes.