### PR TITLE
[Backport v4.2-branch] modules: lvgl: Fix stdlib usage

### DIFF
--- a/modules/lvgl/CMakeLists.txt
+++ b/modules/lvgl/CMakeLists.txt
@@ -16,6 +16,7 @@ zephyr_include_directories(${LVGL_DIR}/src/)
 zephyr_include_directories(include)
 
 zephyr_compile_definitions(LV_CONF_INCLUDE_SIMPLE=1)
+zephyr_library_compile_definitions(_POSIX_C_SOURCE=200809L)
 zephyr_compile_definitions(LV_CONF_PATH="${CMAKE_CURRENT_SOURCE_DIR}/include/lv_conf.h")
 
 zephyr_library_sources(
@@ -309,6 +310,8 @@ zephyr_library_sources(
     ${LVGL_DIR}/src/stdlib/builtin/lv_sprintf_builtin.c
     ${LVGL_DIR}/src/stdlib/builtin/lv_string_builtin.c
     ${LVGL_DIR}/src/stdlib/builtin/lv_tlsf.c
+    ${LVGL_DIR}/src/stdlib/clib/lv_string_clib.c
+    ${LVGL_DIR}/src/stdlib/clib/lv_sprintf_clib.c
 
     ${LVGL_DIR}/src/stdlib/clib/lv_mem_core_clib.c
     ${LVGL_DIR}/src/stdlib/clib/lv_sprintf_clib.c

--- a/modules/lvgl/include/lv_conf.h
+++ b/modules/lvgl/include/lv_conf.h
@@ -12,7 +12,9 @@
 
 /* Memory manager settings */
 
-#define LV_USE_STDLIB_MALLOC LV_STDLIB_CUSTOM
+#define LV_USE_STDLIB_MALLOC  LV_STDLIB_CUSTOM
+#define LV_USE_STDLIB_STRING  LV_STDLIB_CLIB
+#define LV_USE_STDLIB_SPRINTF LV_STDLIB_CLIB
 
 #if defined(CONFIG_LV_Z_MEM_POOL_HEAP_LIB_C)
 #define LV_STDLIB_INCLUDE "stdlib.h"
@@ -26,9 +28,6 @@
 #define lv_free_core      lvgl_free
 #endif
 
-/* Misc settings */
-#define lv_snprintf               snprintf
-#define lv_vsnprintf              vsnprintf
 #define LV_ASSERT_HANDLER         __ASSERT_NO_MSG(false);
 #define LV_ASSERT_HANDLER_INCLUDE "zephyr/sys/__assert.h"
 


### PR DESCRIPTION
LVGL already provides an implementation wrapping a C standard library into its own lv_* functions. Add them to the CMakeLists and set the appropriate defines for them.

Fixes #93986
Fixes #93943


(cherry picked from commit 076994f49225779ff8ccdc9d3be13663d4096405)