### PR TITLE
arch: riscv: core: vector_table: Fix local ISR generation

### DIFF
--- a/arch/riscv/core/vector_table.ld
+++ b/arch/riscv/core/vector_table.ld
@@ -5,8 +5,8 @@
  */
 
 #if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
-INCLUDE isr_tables_vt.ld
 KEEP(*(.vectors.__start))
+INCLUDE isr_tables_vt.ld
 #else
 KEEP(*(.vectors.*))
 #endif


### PR DESCRIPTION
Fixes local ISR generation so that devices actually boot, also allows enabling LTO for these builds (tested working on nrf54l15 flpr device)

Fixes #97846