### PR TITLE
drivers: Update Renesas RA drivers to support FSP version 6.2.0

### DIFF
--- a/drivers/i2s/i2s_renesas_ra_ssie.c
+++ b/drivers/i2s/i2s_renesas_ra_ssie.c
@@ -92,13 +92,12 @@ __maybe_unused static void ssi_rt_isr(void *p_args)
 {
 	const struct device *dev = (struct device *)p_args;
 	struct renesas_ra_ssie_data *dev_data = (struct renesas_ra_ssie_data *)dev->data;
-	R_SSI0_Type *p_ssi_reg = dev_data->fsp_ctrl.p_reg;
 
-	if (p_ssi_reg->SSIFSR_b.TDE && dev_data->active_dir == I2S_DIR_TX) {
+	if (dev_data->active_dir == I2S_DIR_TX) {
 		ssi_txi_isr();
 	}
 
-	if (p_ssi_reg->SSIFSR_b.RDF && dev_data->active_dir == I2S_DIR_RX) {
+	if (dev_data->active_dir == I2S_DIR_RX) {
 		ssi_rxi_isr();
 	}
 }

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra2a1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra2a1.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm0;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra4c1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra4c1.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm4;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra4e2.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra4e2.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra4l1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra4l1.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra4m1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra4m1.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra4m2.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra4m2.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra4m3.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra4m3.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra4w1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra4w1.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra6e2.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra6e2.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra6m1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra6m1.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra6m2.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra6m2.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra6m3.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra6m3.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm0;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra6m4.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra6m4.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm0;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra6m5.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra6m5.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm0;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra8d1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra8d1.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm7;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra8m1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra8m1.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm7;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/fpb_ra4e1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/fpb_ra4e1.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/fpb_ra6e1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/fpb_ra6e1.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/fpb_ra6e2.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/fpb_ra6e2.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm1;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/mck_ra8t1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/mck_ra8t1.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwm2;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/mck_ra8t2_r7ka8t2lfecac_cm85.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/mck_ra8t2_r7ka8t2lfecac_cm85.overlay
@@ -7,6 +7,12 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/ra_pwm.h>
 
+/ {
+	aliases {
+		pwm-test = &pwm8;
+	};
+};
+
 &pinctrl {
 	pwm8_default: pwm8_default {
 		group1 {


### PR DESCRIPTION
- Update `hal_renesas` revision to get the FSP 6.2.0 migration commits
- Update conditions for continuing data transfer for `drivers/spi/spi_b_renesas_ra8.c`
- Remove redundant condition check causing transfer error for `drivers/i2s/i2s_renesas_ra_ssie.c`
- Add `pwm_test` alias for Renesas devices