### PR TITLE
drivers: crypto: ataes132a: fix integer overflow (CID 487700)

### DIFF
--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -636,9 +636,9 @@ int ataes132a_aes_ecb_block(const struct device *dev,
 	param_buffer[1] = key_id;
 	param_buffer[2] = 0x0;
 	memcpy(param_buffer + 3, pkt->in_buf, buf_len);
-	/* If buf_len is less than 16,
-         * zero-pad the payload in param_buffer to a 16-byte block.
-         */
+	/* If buf_len is less than 16 bytes,
+	 * zero-pad the payload in param_buffer to a 16-byte block.
+	 */
 	if (buf_len < 16U) {
 		(void)memset(param_buffer + 3 + buf_len, 0x0, 16U - buf_len);
 	}


### PR DESCRIPTION
Use a wider type for buf_len and add bounds checks so the computed count cannot overflow. This addresses Coverity finding in ataes132a_aes_ecb_block (CWE-190).

Fixes: #84717
CID: 487700
Signed-off-by: Phonlakrit Tiraratn <phonlakrit.tiraratn@gmail.com>
