### PR TITLE
modem: cmux: debug message on DLCI open/close

### DIFF
--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -1300,6 +1300,7 @@ static void modem_cmux_dlci_open_handler(struct k_work *item)
 		.data_len = 0,
 	};
 
+	LOG_DBG("Opening: %d", dlci->dlci_address);
 	modem_cmux_transmit_cmd_frame(dlci->cmux, &frame);
 	modem_work_schedule(&dlci->open_work, MODEM_CMUX_T1_TIMEOUT);
 }
@@ -1329,6 +1330,7 @@ static void modem_cmux_dlci_close_handler(struct k_work *item)
 		.data_len = 0,
 	};
 
+	LOG_DBG("Closing: %d", dlci->dlci_address);
 	modem_cmux_transmit_cmd_frame(cmux, &frame);
 	modem_work_schedule(&dlci->close_work, MODEM_CMUX_T1_TIMEOUT);
 }


### PR DESCRIPTION
Add simple debug messages when a DLCI command opening or closing a channel is sent.