### PR TITLE
modem: cellular: configurable initialisation priority

### DIFF
--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -40,6 +40,15 @@ config MODEM_CELLULAR
 
 if MODEM_CELLULAR
 
+config MODEM_CELLULAR_INIT_PRIORITY
+	int "Cellular modem driver initialization priority"
+	default 79
+	range 0 99
+	help
+	  Driver initialization priority for cellular modem drivers.
+	  Defaults to less than GNSS_INIT_PRIORITY, as LTE modems often
+	  integrate a GNSS modem.
+
 config MODEM_CELLULAR_APN
 	string "Static APN"
 	default "internet"

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -2996,8 +2996,8 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
 			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
-			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
-			      &modem_cellular_api);
+			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL,                \
+			      CONFIG_MODEM_CELLULAR_INIT_PRIORITY, &modem_cellular_api);
 
 #define MODEM_CELLULAR_DEVICE_QUECTEL_BG9X(inst)                                                   \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \


### PR DESCRIPTION
Make the initialisation priority of cellular modems configurable, and move it earlier in the sequence by default to provide room for devices to be initialised later.

The updated default value is set to one earlier than `GNSS_INIT_PRIORITY` (80), as LTE modems often embed a GNSS modem, whose driver may depend on the baseline modem driver (GNSS user pipes, etc).