### PR TITLE
samples: Use printf in pressure_polling sample

### DIFF
--- a/samples/sensor/pressure_polling/src/main.c
+++ b/samples/sensor/pressure_polling/src/main.c
@@ -49,13 +49,13 @@ int main(void)
 			sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &temperature);
 			ret = sensor_channel_get(dev, SENSOR_CHAN_ALTITUDE, &altitude);
 
-			printk("temp %.2f Cel, pressure %f kPa",
+			printf("temp %.2f Cel, pressure %f kPa",
 			       sensor_value_to_double(&temperature),
 			       sensor_value_to_double(&pressure));
 			if (ret == 0) {
-				printk(", altitude %f m", sensor_value_to_double(&altitude));
+				printf(", altitude %f m", sensor_value_to_double(&altitude));
 			}
-			printk("\n");
+			printf("\n");
 		}
 
 		k_msleep(1000);


### PR DESCRIPTION
Use printf to print the floating point numbers, instead of printk. This is how it is done in the magn_polling sample.

Otherwise the sample hangs indefinitely after printing the first time, when running the LPS22 sensor on an adafruit_feather_rp2040 board.