### PR TITLE
boards: imx7-based boards: doc: use board-supported-hw directive

### DIFF
--- a/boards/96boards/meerkat96/doc/index.rst
+++ b/boards/96boards/meerkat96/doc/index.rst
@@ -1,4 +1,4 @@
-.. _96b_meerkat96:
+.. zephyr:board:: 96b_meerkat96
 
 96Boards Meerkat96
 ##################
@@ -34,10 +34,6 @@ Zephyr OS is ported to run on the Cortex®-M4 core.
     - 4x Green user LEDs
     - 1x Blue Bluetooth LED
     - 1x Yellow WiFi LED
-
-.. image:: img/96b_meerkat96.jpg
-   :align: center
-   :alt: 96Boards Meerkat96
 
 More information about the board can be found at the
 `96Boards website`_.
@@ -91,27 +87,7 @@ More information about the i.MX7 SoC can be found here:
 Supported Features
 ==================
 
-The Zephyr 96b_meerkat96 board configuration supports the following hardware
-features:
-
-+-----------+------------+-------------------------------------+
-| Interface | Controller | Driver/Component                    |
-+===========+============+=====================================+
-| NVIC      | on-chip    | nested vector interrupt controller  |
-+-----------+------------+-------------------------------------+
-| SYSTICK   | on-chip    | systick                             |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
-+-----------+------------+-------------------------------------+
-| UART      | on-chip    | serial port-polling;                |
-|           |            | serial port-interrupt               |
-+-----------+------------+-------------------------------------+
-
-The default configuration can be found in the defconfig file:
-
-	:zephyr_file:`boards/96boards/meerkat96/96b_meerkat96_mcimx7d_m4_defconfig`
-
-Other hardware features are not currently supported by the port.
+.. zephyr:board-supported-hw::
 
 Connections and IOs
 ===================

--- a/boards/technexion/pico_pi/doc/index.rst
+++ b/boards/technexion/pico_pi/doc/index.rst
@@ -44,28 +44,7 @@ For more information about the i.MX7 SoC and Pico-Pi i.MX7D, see these reference
 Supported Features
 ==================
 
-The Pico-Pi i.MX7D configuration supports the following hardware features on the
-Cortex M4 Core:
-
-+-----------+------------+-------------------------------------+
-| Interface | Controller | Driver/Component                    |
-+===========+============+=====================================+
-| NVIC      | on-chip    | nested vector interrupt controller  |
-+-----------+------------+-------------------------------------+
-| SYSTICK   | on-chip    | systick                             |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
-+-----------+------------+-------------------------------------+
-| I2C       | on-chip    | i2c                                 |
-+-----------+------------+-------------------------------------+
-| UART      | on-chip    | serial port-polling;                |
-|           |            | serial port-interrupt               |
-+-----------+------------+-------------------------------------+
-
-The default configuration can be found in the defconfig file:
-:zephyr_file:`boards/technexion/pico_pi/pico_pi_mcimx7d_m4_defconfig`
-
-Other hardware features are not currently supported by the port.
+.. zephyr:board-supported-hw::
 
 Connections and IOs
 ===================

--- a/boards/toradex/colibri_imx7d/doc/index.rst
+++ b/boards/toradex/colibri_imx7d/doc/index.rst
@@ -61,31 +61,7 @@ and Colibri Evaluation Board, see these references:
 Supported Features
 ==================
 
-The Colibri iMX7D Computer on Module with Colibri Evaluation Board configuration
-supports the following hardware features on the Cortex M4 Core:
-
-+-----------+------------+-------------------------------------+
-| Interface | Controller | Driver/Component                    |
-+===========+============+=====================================+
-| NVIC      | on-chip    | nested vector interrupt controller  |
-+-----------+------------+-------------------------------------+
-| SYSTICK   | on-chip    | systick                             |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
-+-----------+------------+-------------------------------------+
-| I2C       | on-chip    | i2c                                 |
-+-----------+------------+-------------------------------------+
-| PWM       | on-chip    | pwm                                 |
-+-----------+------------+-------------------------------------+
-| UART      | on-chip    | serial port-polling;                |
-|           |            | serial port-interrupt               |
-+-----------+------------+-------------------------------------+
-
-The default configuration can be found in the defconfig file:
-
-	:zephyr_file:`boards/toradex/colibri_imx7d/colibri_imx7d_mcimx7d_m4_defconfig`
-
-Other hardware features are not currently supported by the port.
+.. zephyr:board-supported-hw::
 
 Connections and IOs
 ===================


### PR DESCRIPTION
Use the zephyr:board-supported-hw directive for the documentation of every imx7-based which board which didn't use it yet.

I didn't add the zephyr:board-supported-runners directive because it looked like none of them have any runner defined. Not sure what the policy is in that case. Should we still add the directive even if it shows up empty? If so, let me know and I can update the PR.

Thanks.