### PR TITLE
include: bluetooth: fix Doxygen \retval & \return commands usage

### DIFF
--- a/include/zephyr/bluetooth/addr.h
+++ b/include/zephyr/bluetooth/addr.h
@@ -75,7 +75,9 @@ extern const bt_addr_le_t bt_addr_le_none;
  *  @param a First Bluetooth device address to compare
  *  @param b Second Bluetooth device address to compare
  *
- *  @return negative value if @a a < @a b, 0 if @a a == @a b, else positive
+ *  @retval <0 negative value if @a a < @a b
+ *  @retval 0 if @a a == @a b
+ *  @retval >0 else positive
  */
 static inline int bt_addr_cmp(const bt_addr_t *a, const bt_addr_t *b)
 {
@@ -84,8 +86,8 @@ static inline int bt_addr_cmp(const bt_addr_t *a, const bt_addr_t *b)
 
 /** @brief Determine equality of two Bluetooth device addresses.
  *
- *  @retval #true if the two addresses are equal
- *  @retval #false otherwise
+ *  @retval true if the two addresses are equal
+ *  @retval false otherwise
  */
 static inline bool bt_addr_eq(const bt_addr_t *a, const bt_addr_t *b)
 {
@@ -97,7 +99,9 @@ static inline bool bt_addr_eq(const bt_addr_t *a, const bt_addr_t *b)
  *  @param a First Bluetooth LE device address to compare
  *  @param b Second Bluetooth LE device address to compare
  *
- *  @return negative value if @a a < @a b, 0 if @a a == @a b, else positive
+ *  @retval <0 negative value if @a a < @a b
+ *  @retval 0 if @a a == @a b
+ *  @retval >0 else positive
  *
  *  @sa bt_addr_le_eq
  */
@@ -111,8 +115,8 @@ static inline int bt_addr_le_cmp(const bt_addr_le_t *a, const bt_addr_le_t *b)
  *  The Bluetooth LE addresses are equal if and only if both the types and
  *  the 48-bit addresses are numerically equal.
  *
- *  @retval #true if the two addresses are equal
- *  @retval #false otherwise
+ *  @retval true if the two addresses are equal
+ *  @retval false otherwise
  */
 static inline bool bt_addr_le_eq(const bt_addr_le_t *a, const bt_addr_le_t *b)
 {

--- a/include/zephyr/bluetooth/att.h
+++ b/include/zephyr/bluetooth/att.h
@@ -152,10 +152,10 @@ int bt_eatt_reconfigure(struct bt_conn *conn, uint16_t mtu);
  * @param num_channels The number of Enhanced ATT bearers to request.
  * Must be in the range 1 - @kconfig{CONFIG_BT_EATT_MAX}, inclusive.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative value in case of error.
  * @retval -EINVAL if @p num_channels is not in the allowed range or @p conn is NULL.
  * @retval -ENOMEM if less than @p num_channels are allocated.
- * @retval 0 in case of success
  */
 int bt_eatt_connect(struct bt_conn *conn, size_t num_channels);
 

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -259,8 +259,8 @@ struct bt_le_ext_adv_cb {
 	 *
 	 * @param adv  The advertising set object.
 	 *
-	 * @return true to rotate the current RPA, or false to use it for the
-	 *         next rotation period.
+	 * @retval true to rotate the current RPA,
+	 * @retval false to use it for the next rotation period.
 	 */
 	bool (*rpa_expired)(struct bt_le_ext_adv *adv);
 #endif /* defined(CONFIG_BT_PRIVACY) */
@@ -345,7 +345,8 @@ int bt_disable(void);
 /**
  * @brief Check if Bluetooth is ready
  *
- * @return true when Bluetooth is ready, false otherwise
+ * @retval true when Bluetooth is ready
+ * @retval false otherwise
  */
 bool bt_is_ready(void);
 
@@ -511,7 +512,8 @@ int bt_id_reset(uint8_t id, bt_addr_le_t *addr, uint8_t *irk);
  *
  * @param id   Existing identity handle.
  *
- * @return 0 in case of success, or a negative error code on failure.
+ * @retval 0 in case of success
+ * @retval <0 a negative error code on failure.
  */
 int bt_id_delete(uint8_t id);
 
@@ -1287,9 +1289,9 @@ struct bt_le_per_adv_param {
  * @param sd_len Number of elements in sd
  *
  * @return Zero on success or (negative) error code otherwise.
- * @return -ENOMEM No free connection objects available for connectable
+ * @retval -ENOMEM No free connection objects available for connectable
  *                 advertiser.
- * @return -ECONNREFUSED When connectable advertising is requested and there
+ * @retval -ECONNREFUSED When connectable advertising is requested and there
  *                       is already maximum number of connections established
  *                       in the controller.
  *                       This error code is only guaranteed when using Zephyr
@@ -2602,7 +2604,8 @@ BUILD_ASSERT(BT_GAP_SCAN_FAST_WINDOW == BT_GAP_SCAN_FAST_INTERVAL_MIN,
  * @param cb Callback to notify scan results. May be NULL if callback
  *           registration through @ref bt_le_scan_cb_register is preferred.
  *
- * @return Zero on success or error code otherwise, positive in case of
+ * @retval 0 on success
+ * @retval err error code otherwise, positive in case of
  *         protocol error or negative (POSIX) in case of stack internal error.
  * @retval -EBUSY if the scanner is already being started in a different thread.
  */
@@ -2613,7 +2616,8 @@ int bt_le_scan_start(const struct bt_le_scan_param *param, bt_le_scan_cb_t cb);
  *
  * Stops ongoing LE scanning.
  *
- * @return Zero on success or error code otherwise, positive in case of
+ * @retval 0 on success
+ * @retval err error code otherwise, positive in case of
  *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_scan_stop(void);
@@ -2653,7 +2657,8 @@ void bt_le_scan_cb_unregister(struct bt_le_scan_cb *cb);
  *
  * @param addr Bluetooth LE identity address.
  *
- * @return Zero on success or error code otherwise, positive in case of
+ * @retval 0 on success
+ * @retval err error code otherwise, positive in case of
  *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_filter_accept_list_add(const bt_addr_le_t *addr);
@@ -2669,7 +2674,8 @@ int bt_le_filter_accept_list_add(const bt_addr_le_t *addr);
  *
  * @param addr Bluetooth LE identity address.
  *
- * @return Zero on success or error code otherwise, positive in case of
+ * @retval 0 on success
+ * @retval err error code otherwise, positive in case of
  *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_filter_accept_list_remove(const bt_addr_le_t *addr);
@@ -2683,7 +2689,8 @@ int bt_le_filter_accept_list_remove(const bt_addr_le_t *addr);
  * the filter accept list, i.e advertiser or scanner using a filter accept
  * list or automatic connecting to devices using filter accept list.
  *
- * @return Zero on success or error code otherwise, positive in case of
+ * @retval 0 on success
+ * @retval err error code otherwise, positive in case of
  *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_filter_accept_list_clear(void);
@@ -2700,7 +2707,8 @@ int bt_le_filter_accept_list_clear(void);
  * @param chan_map Channel map. 5 octets where each bit represents a channel. Only the lower 37 bits
  *        are valid.
  *
- * @return Zero on success or error code otherwise, positive in case of
+ * @retval 0 on success
+ * @retval err error code otherwise, positive in case of
  *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_set_chan_map(uint8_t chan_map[5]);
@@ -2792,7 +2800,8 @@ struct bt_le_oob {
  *                 address this function will be called for.
  * @param[out] oob LE OOB information
  *
- * @return Zero on success or error code otherwise, positive in case of
+ * @retval 0 on success
+ * @retval err error code otherwise, positive in case of
  *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob);
@@ -2818,7 +2827,8 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob);
  * @param[in]  adv The advertising set object
  * @param[out] oob LE OOB information
  *
- * @return Zero on success or error code otherwise, positive in case
+ * @retval 0 on success
+ * @retval err error code otherwise, positive in case
  * of protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_ext_adv_oob_get_local(struct bt_le_ext_adv *adv,
@@ -2832,7 +2842,8 @@ int bt_le_ext_adv_oob_get_local(struct bt_le_ext_adv *adv,
  * @param addr  Remote address, NULL or BT_ADDR_LE_ANY to clear all remote
  *              devices.
  *
- * @return 0 on success or negative error value on failure.
+ * @retval 0 on success
+ * @retval <0 negative error value on failure.
  */
 int bt_unpair(uint8_t id, const bt_addr_le_t *addr);
 
@@ -2867,7 +2878,8 @@ void bt_foreach_bond(uint8_t id, void (*func)(const struct bt_bond_info *info,
  * @param vs_config_len  Length of additional vendor specific configuration data
  * @param vs_config      Pointer to additional vendor specific configuration data
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative value in case of error.
  */
 int bt_configure_data_path(uint8_t dir, uint8_t id, uint8_t vs_config_len,
 			   const uint8_t *vs_config);
@@ -2974,7 +2986,7 @@ int bt_le_per_adv_set_response_data(struct bt_le_per_adv_sync *per_adv_sync,
  *             address this function will be called for.
  * @param addr Bluetooth LE device address.
  *
- * @return true if @p addr is bonded with local @p id
+ * @retval true if @p addr is bonded with local @p id
  */
 bool bt_le_bond_exists(uint8_t id, const bt_addr_le_t *addr);
 

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1185,7 +1185,8 @@ enum bt_conn_auth_keypress {
  *  @param conn Connection object.
  *  @param info Connection info object.
  *
- *  @return Zero on success or (negative) error code on failure.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
  */
 int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info);
 
@@ -1212,9 +1213,10 @@ bool bt_conn_is_type(const struct bt_conn *conn, enum bt_conn_type type);
  *  been established. The application can be notified about when the remote
  *  information is available through the remote_info_available callback.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -EBUSY The remote information is not yet available.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
+ *  @retval -EBUSY The remote information is not yet available.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection.
  */
 int bt_conn_get_remote_info(const struct bt_conn *conn, struct bt_conn_remote_info *remote_info);
 
@@ -1223,9 +1225,10 @@ int bt_conn_get_remote_info(const struct bt_conn *conn, struct bt_conn_remote_in
  *  @param conn           @ref BT_CONN_TYPE_LE connection object.
  *  @param tx_power_level Transmit power level descriptor.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -ENOBUFS HCI command buffer is not available.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
+ *  @retval -ENOBUFS HCI command buffer is not available.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
 				  struct bt_conn_le_tx_power *tx_power_level);
@@ -1235,9 +1238,10 @@ int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
  *  @param conn           @ref BT_CONN_TYPE_LE connection object.
  *  @param tx_power       Transmit power level descriptor.
  *
- *  @return Zero on success or (negative) error code on failure.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
  *  @retval -ENOBUFS HCI command buffer is not available.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_conn_le_enhanced_get_tx_power_level(struct bt_conn *conn,
 					   struct bt_conn_le_tx_power *tx_power);
@@ -1247,9 +1251,10 @@ int bt_conn_le_enhanced_get_tx_power_level(struct bt_conn *conn,
  *  @param conn           @ref BT_CONN_TYPE_LE connection object.
  *  @param phy            PHY information.
  *
- *  @return Zero on success or (negative) error code on failure.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
  *  @retval -ENOBUFS HCI command buffer is not available.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_conn_le_get_remote_tx_power_level(struct bt_conn *conn,
 					 enum bt_conn_le_tx_power_phy phy);
@@ -1260,9 +1265,10 @@ int bt_conn_le_get_remote_tx_power_level(struct bt_conn *conn,
  *  @param local_enable   Enable/disable reporting for local.
  *  @param remote_enable  Enable/disable reporting for remote.
  *
- *  @return Zero on success or (negative) error code on failure.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
  *  @retval -ENOBUFS HCI command buffer is not available.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_conn_le_set_tx_power_report_enable(struct bt_conn *conn,
 					  bool local_enable,
@@ -1277,8 +1283,9 @@ int bt_conn_le_set_tx_power_report_enable(struct bt_conn *conn,
  *  @param conn  @ref BT_CONN_TYPE_LE connection object.
  *  @param param Path Loss Monitoring parameters
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_conn_le_set_path_loss_mon_param(struct bt_conn *conn,
 				       const struct bt_conn_le_path_loss_reporting_param *param);
@@ -1293,8 +1300,9 @@ int bt_conn_le_set_path_loss_mon_param(struct bt_conn *conn,
  * @param conn  @ref BT_CONN_TYPE_LE connection object.
  * @param enable Enable/disable path loss reporting.
  *
- * @return Zero on success or (negative) error code on failure.
- * @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ * @retval 0 on success
+ * @retval <0 negative error code on failure.
+ * @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_conn_le_set_path_loss_mon_enable(struct bt_conn *conn, bool enable);
 
@@ -1310,7 +1318,8 @@ int bt_conn_le_set_path_loss_mon_enable(struct bt_conn *conn, bool enable);
  *
  *  @param params Subrating parameters.
  *
- *  @return Zero on success or (negative) error code on failure.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
  */
 int bt_conn_le_subrate_set_defaults(const struct bt_conn_le_subrate_param *params);
 
@@ -1323,8 +1332,9 @@ int bt_conn_le_subrate_set_defaults(const struct bt_conn_le_subrate_param *param
  *  @param conn   @ref BT_CONN_TYPE_LE connection object.
  *  @param params Subrating parameters.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_conn_le_subrate_request(struct bt_conn *conn,
 			       const struct bt_conn_le_subrate_param *params);
@@ -1342,8 +1352,9 @@ int bt_conn_le_subrate_request(struct bt_conn *conn,
  *  @param pages_requested Number of feature pages to be requested from peer.
  *                         There is a maximum of 10 pages.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_conn_le_read_all_remote_features(struct bt_conn *conn, uint8_t pages_requested);
 
@@ -1358,8 +1369,9 @@ int bt_conn_le_read_all_remote_features(struct bt_conn *conn, uint8_t pages_requ
  *  @param conn   @ref BT_CONN_TYPE_LE connection object.
  *  @param params Frame Space Update parameters.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_conn_le_frame_space_update(struct bt_conn *conn,
 				  const struct bt_conn_le_frame_space_update_param *params);
@@ -1373,8 +1385,9 @@ int bt_conn_le_frame_space_update(struct bt_conn *conn,
  *  @param conn  @ref BT_CONN_TYPE_LE connection object.
  *  @param param Updated connection parameters.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_conn_le_param_update(struct bt_conn *conn,
 			    const struct bt_le_conn_param *param);
@@ -1384,8 +1397,9 @@ int bt_conn_le_param_update(struct bt_conn *conn,
  *  @param conn  @ref BT_CONN_TYPE_LE connection object.
  *  @param param Updated data length parameters.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_conn_le_data_len_update(struct bt_conn *conn,
 			       const struct bt_conn_le_data_len_param *param);
@@ -1398,8 +1412,9 @@ int bt_conn_le_data_len_update(struct bt_conn *conn,
  *  @param conn  @ref BT_CONN_TYPE_LE connection object.
  *  @param param Updated connection parameters.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_conn_le_phy_update(struct bt_conn *conn,
 			  const struct bt_conn_le_phy_param *param);
@@ -1414,7 +1429,8 @@ int bt_conn_le_phy_update(struct bt_conn *conn,
  *  @param pref_tx_phy  Preferred transmitter phy prarameters.
  *  @param pref_rx_phy  Preferred receiver phy prameters.
  *
- *  @return Zero on success or (negative) error code on failure.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
  */
 int bt_conn_le_set_default_phy(uint8_t pref_tx_phy, uint8_t pref_rx_phy);
 
@@ -1438,7 +1454,8 @@ int bt_conn_le_set_default_phy(uint8_t pref_tx_phy, uint8_t pref_rx_phy);
  *  @param conn Connection to disconnect.
  *  @param reason Reason code for the disconnection.
  *
- *  @return Zero on success or (negative) error code on failure.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
  */
 int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason);
 
@@ -1572,7 +1589,8 @@ struct bt_conn_le_create_param {
  *  @param[in]  conn_param   Initial connection parameters.
  *  @param[out] conn         Valid connection object on success.
  *
- *  @return Zero on success or (negative) error code on failure.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
  */
 int bt_conn_le_create(const bt_addr_le_t *peer,
 		      const struct bt_conn_le_create_param *create_param,
@@ -1609,7 +1627,8 @@ struct bt_conn_le_create_synced_param {
  *  @param[in]  conn_param   Initial connection parameters.
  *  @param[out] conn         Valid connection object on success.
  *
- *  @return Zero on success or (negative) error code on failure.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
  */
 int bt_conn_le_create_synced(const struct bt_le_ext_adv *adv,
 			     const struct bt_conn_le_create_synced_param *synced_param,
@@ -1627,15 +1646,17 @@ int bt_conn_le_create_synced(const struct bt_le_ext_adv *adv,
  *  @param create_param Create connection parameters
  *  @param conn_param   Initial connection parameters.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -ENOMEM No free connection object available.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
+ *  @retval -ENOMEM No free connection object available.
  */
 int bt_conn_le_create_auto(const struct bt_conn_le_create_param *create_param,
 			   const struct bt_le_conn_param *conn_param);
 
 /** @brief Stop automatic connect creation.
  *
- *  @return Zero on success or (negative) error code on failure.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
  */
 int bt_conn_create_auto_stop(void);
 
@@ -1673,8 +1694,9 @@ int bt_conn_create_auto_stop(void);
  *  @param conn @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection object.
  *  @param sec Requested minimum security level.
  *
- *  @return 0 on success or negative error
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection.
+ *  @retval 0 on success
+ *  @retval <0 negative error
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection.
  */
 int bt_conn_set_security(struct bt_conn *conn, bt_security_t sec);
 
@@ -1697,7 +1719,7 @@ bt_security_t bt_conn_get_security(const struct bt_conn *conn);
  *  @param conn @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection object.
  *
  *  @return Encryption key size.
- *  @return 0 @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection.
+ *  @retval 0 @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection.
  */
 uint8_t bt_conn_enc_key_size(const struct bt_conn *conn);
 
@@ -2300,8 +2322,8 @@ bool bt_get_bondable(void);
  *
  *  @retval 0 Success
  *  @retval -EALREADY Already in the requested state
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection
- *  @return -EINVAL @p conn is a valid @ref BT_CONN_TYPE_LE but could not get SMP context
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection
+ *  @retval -EINVAL @p conn is a valid @ref BT_CONN_TYPE_LE but could not get SMP context
  */
 int bt_conn_set_bondable(struct bt_conn *conn, bool enable);
 
@@ -2331,8 +2353,8 @@ void bt_le_oob_set_legacy_flag(bool enable);
  *  @param tk Pointer to 16 byte long TK array
  *
  *  @retval 0 Success
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
- *  @return -EINVAL @p tk is NULL.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval -EINVAL @p tk is NULL.
  */
 int bt_le_oob_set_legacy_tk(struct bt_conn *conn, const uint8_t *tk);
 
@@ -2351,9 +2373,10 @@ int bt_le_oob_set_legacy_tk(struct bt_conn *conn, const uint8_t *tk);
  *  @param oobd_local Local OOB data or NULL if not present
  *  @param oobd_remote Remote OOB data or NULL if not present
  *
- *  @return Zero on success or error code otherwise, positive in case of
+ *  @retval 0 on success
+ * @retval err error code otherwise, positive in case of
  *          protocol error or negative (POSIX) in case of stack internal error.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_le_oob_set_sc_data(struct bt_conn *conn,
 			  const struct bt_le_oob_sc_data *oobd_local,
@@ -2371,9 +2394,10 @@ int bt_le_oob_set_sc_data(struct bt_conn *conn,
  *  @param oobd_local Local OOB data or NULL if not set
  *  @param oobd_remote Remote OOB data or NULL if not set
  *
- *  @return Zero on success or error code otherwise, positive in case of
+ *  @retval 0 on success
+ * @retval err error code otherwise, positive in case of
  *          protocol error or negative (POSIX) in case of stack internal error.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.
  */
 int bt_le_oob_get_sc_data(struct bt_conn *conn,
 			  const struct bt_le_oob_sc_data **oobd_local,
@@ -2718,7 +2742,8 @@ struct bt_conn_auth_info_cb {
  *
  *  @param cb Callback struct.
  *
- *  @return Zero on success or negative error code otherwise
+ *  @return 0 on success
+ *  @retval <0 negative error code otherwise
  */
 int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb);
 
@@ -2734,8 +2759,9 @@ int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb);
  *  @param conn @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection object.
  *  @param cb	Callback struct.
  *
- *  @return Zero on success or negative error code otherwise
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection
+ *  @return 0 on success
+ *  @retval <0 negative error code otherwise
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection
  */
 int bt_conn_auth_cb_overlay(struct bt_conn *conn, const struct bt_conn_auth_cb *cb);
 
@@ -2746,7 +2772,8 @@ int bt_conn_auth_cb_overlay(struct bt_conn *conn, const struct bt_conn_auth_cb *
  *
  *  @param cb Callback struct.
  *
- *  @return Zero on success or negative error code otherwise
+ *  @return 0 on success
+ *  @retval <0 negative error code otherwise
  */
 int bt_conn_auth_info_cb_register(struct bt_conn_auth_info_cb *cb);
 
@@ -2756,7 +2783,8 @@ int bt_conn_auth_info_cb_register(struct bt_conn_auth_info_cb *cb);
  *
  *  @param cb Callback struct.
  *
- *  @return Zero on success or negative error code otherwise
+ *  @return 0 on success
+ *  @retval <0 negative error code otherwise
  */
 int bt_conn_auth_info_cb_unregister(struct bt_conn_auth_info_cb *cb);
 
@@ -2768,8 +2796,9 @@ int bt_conn_auth_info_cb_unregister(struct bt_conn_auth_info_cb *cb);
  *  @param conn @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection object.
  *  @param passkey Entered passkey.
  *
- *  @return Zero on success or negative error code otherwise
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection
+ *  @return 0 on success
+ *  @retval <0 negative error code otherwise
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection
  */
 int bt_conn_auth_passkey_entry(struct bt_conn *conn, unsigned int passkey);
 
@@ -2787,7 +2816,7 @@ int bt_conn_auth_passkey_entry(struct bt_conn *conn, unsigned int passkey);
  *  @retval -EINVAL Improper use of the API.
  *  @retval -ENOMEM Failed to allocate.
  *  @retval -ENOBUFS Failed to allocate.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection
  */
 int bt_conn_auth_keypress_notify(struct bt_conn *conn, enum bt_conn_auth_keypress type);
 
@@ -2797,8 +2826,9 @@ int bt_conn_auth_keypress_notify(struct bt_conn *conn, enum bt_conn_auth_keypres
  *
  *  @param conn @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection object.
  *
- *  @return Zero on success or negative error code otherwise
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection
+ *  @return 0 on success
+ *  @retval <0 negative error code otherwise
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection
  */
 int bt_conn_auth_cancel(struct bt_conn *conn);
 
@@ -2809,8 +2839,9 @@ int bt_conn_auth_cancel(struct bt_conn *conn);
  *
  *  @param conn @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection object.
  *
- *  @return Zero on success or negative error code otherwise
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection
+ *  @return 0 on success
+ *  @retval <0 negative error code otherwise
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection
  */
 int bt_conn_auth_passkey_confirm(struct bt_conn *conn);
 
@@ -2821,8 +2852,9 @@ int bt_conn_auth_passkey_confirm(struct bt_conn *conn);
  *
  *  @param conn @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection object.
  *
- *  @return Zero on success or negative error code otherwise
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection
+ *  @return 0 on success
+ *  @retval <0 negative error code otherwise
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE or @ref BT_CONN_TYPE_BR connection
  */
 int bt_conn_auth_pairing_confirm(struct bt_conn *conn);
 
@@ -2834,8 +2866,9 @@ int bt_conn_auth_pairing_confirm(struct bt_conn *conn);
  *  @param conn @ref BT_CONN_TYPE_BR connection object.
  *  @param pin Entered PIN code.
  *
- *  @return Zero on success or negative error code otherwise
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_BR connection
+ *  @return 0 on success
+ *  @retval <0 negative error code otherwise
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_BR connection
  */
 int bt_conn_auth_pincode_entry(struct bt_conn *conn, const char *pin);
 
@@ -2910,9 +2943,10 @@ const bt_addr_t *bt_conn_get_dst_br(const struct bt_conn *conn);
  *  @param role The role that want to switch as, the value is @ref BT_HCI_ROLE_CENTRAL and
  *              @ref BT_HCI_ROLE_PERIPHERAL from hci_types.h.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -ENOBUFS HCI command buffer is not available.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_BR connection
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
+ *  @retval -ENOBUFS HCI command buffer is not available.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_BR connection
  */
 int bt_conn_br_switch_role(const struct bt_conn *conn, uint8_t role);
 
@@ -2921,9 +2955,10 @@ int bt_conn_br_switch_role(const struct bt_conn *conn, uint8_t role);
  *  @param conn Connection object.
  *  @param enable Value enable/disable role switch of controller.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -ENOBUFS HCI command buffer is not available.
- *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_BR connection.
+ *  @retval 0 on success
+ *  @retval <0 negative error code on failure.
+ *  @retval -ENOBUFS HCI command buffer is not available.
+ *  @retval -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_BR connection.
  */
 int bt_conn_br_set_role_switch_enable(const struct bt_conn *conn, bool enable);
 

--- a/include/zephyr/bluetooth/crypto.h
+++ b/include/zephyr/bluetooth/crypto.h
@@ -34,7 +34,8 @@ extern "C" {
  *  @param buf Buffer to insert the random data
  *  @param len Length of random data to generate
  *
- *  @return Zero on success or error code otherwise, positive in case
+ *  @retval 0 on success
+ * @retval err error code otherwise, positive in case
  *  of protocol error or negative (POSIX) in case of stack internal error
  */
 int bt_rand(void *buf, size_t len);
@@ -49,7 +50,8 @@ int bt_rand(void *buf, size_t len);
  *  @param plaintext 128 bit LS byte first plaintext data block to be encrypted
  *  @param enc_data 128 bit LS byte first encrypted data block
  *
- *  @return Zero on success or error code otherwise.
+ *  @retval 0 on success
+ * @retval err error code otherwise.
  */
 int bt_encrypt_le(const uint8_t key[16], const uint8_t plaintext[16],
 		  uint8_t enc_data[16]);
@@ -64,7 +66,8 @@ int bt_encrypt_le(const uint8_t key[16], const uint8_t plaintext[16],
  *  @param plaintext 128 bit MS byte first plaintext data block to be encrypted
  *  @param enc_data 128 bit MS byte first encrypted data block
  *
- *  @return Zero on success or error code otherwise.
+ *  @retval 0 on success
+ * @retval err error code otherwise.
  */
 int bt_encrypt_be(const uint8_t key[16], const uint8_t plaintext[16],
 		  uint8_t enc_data[16]);

--- a/include/zephyr/bluetooth/cs.h
+++ b/include/zephyr/bluetooth/cs.h
@@ -575,7 +575,8 @@ void bt_le_cs_set_valid_chmap_bits(uint8_t channel_map[10]);
  *
  * @param conn   Connection Object.
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_read_remote_supported_capabilities(struct bt_conn *conn);
 
@@ -589,7 +590,8 @@ int bt_le_cs_read_remote_supported_capabilities(struct bt_conn *conn);
  * @param conn   Connection Object.
  * @param params Channel sounding default settings parameters.
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_set_default_settings(struct bt_conn *conn,
 				  const struct bt_le_cs_set_default_settings_param *params);
@@ -609,7 +611,8 @@ int bt_le_cs_set_default_settings(struct bt_conn *conn,
  *
  * @param conn   Connection Object.
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_read_remote_fae_table(struct bt_conn *conn);
 
@@ -622,7 +625,8 @@ int bt_le_cs_read_remote_fae_table(struct bt_conn *conn);
  *
  * @param cs_test_cb Set of callbacks to be used with CS Test
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_test_cb_register(struct bt_le_cs_test_cb cs_test_cb);
 
@@ -644,7 +648,8 @@ int bt_le_cs_test_cb_register(struct bt_le_cs_test_cb cs_test_cb);
  *
  * @param params CS Test parameters
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_start_test(const struct bt_le_cs_test_param *params);
 
@@ -660,7 +665,8 @@ int bt_le_cs_start_test(const struct bt_le_cs_test_param *params);
  * @param context Controls whether the configuration is written to the local controller or
  *                both the local and the remote controller
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_create_config(struct bt_conn *conn, struct bt_le_cs_create_config_params *params,
 			   enum bt_le_cs_create_config_context context);
@@ -675,7 +681,8 @@ int bt_le_cs_create_config(struct bt_conn *conn, struct bt_le_cs_create_config_p
  * @param conn      Connection Object.
  * @param config_id CS Config ID
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_remove_config(struct bt_conn *conn, uint8_t config_id);
 
@@ -688,7 +695,8 @@ int bt_le_cs_remove_config(struct bt_conn *conn, uint8_t config_id);
  *
  * @note To use this API @kconfig{CONFIG_BT_CHANNEL_SOUNDING_TEST} must be set.
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_stop_test(void);
 
@@ -720,7 +728,8 @@ void bt_le_cs_step_data_parse(struct net_buf_simple *step_data_buf,
  *
  * @param conn   Connection Object.
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_security_enable(struct bt_conn *conn);
 
@@ -740,7 +749,8 @@ struct bt_le_cs_procedure_enable_param {
  * @param conn   Connection Object.
  * @param params Parameters for the CS Procedure Enable command.
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_procedure_enable(struct bt_conn *conn,
 			      const struct bt_le_cs_procedure_enable_param *params);
@@ -813,7 +823,8 @@ struct bt_le_cs_set_procedure_parameters_param {
  * @param conn Connection Object.
  * @param params Parameters for the CS Set Procedure Parameters command.
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_set_procedure_parameters(struct bt_conn *conn,
 				      const struct bt_le_cs_set_procedure_parameters_param *params);
@@ -835,7 +846,8 @@ int bt_le_cs_set_procedure_parameters(struct bt_conn *conn,
  *
  * @param channel_classification Bit fields
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_set_channel_classification(uint8_t channel_classification[10]);
 
@@ -848,7 +860,8 @@ int bt_le_cs_set_channel_classification(uint8_t channel_classification[10]);
  *
  * @param ret Return values for the CS Procedure Enable command.
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_read_local_supported_capabilities(struct bt_conn_le_cs_capabilities *ret);
 
@@ -863,7 +876,8 @@ int bt_le_cs_read_local_supported_capabilities(struct bt_conn_le_cs_capabilities
  * @param conn   Connection Object.
  * @param params Parameters for the CS Write Cached Remote Supported Capabilities command.
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_write_cached_remote_supported_capabilities(
 	struct bt_conn *conn, const struct bt_conn_le_cs_capabilities *params);
@@ -883,7 +897,8 @@ int bt_le_cs_write_cached_remote_supported_capabilities(
  * @param conn   Connection Object.
  * @param remote_fae_table Per-channel mode-0 FAE table of the local Controller
  *
- * @return Zero on success or (negative) error code on failure.
+ * @return 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_le_cs_write_cached_remote_fae_table(struct bt_conn *conn, int8_t remote_fae_table[72]);
 
@@ -902,7 +917,7 @@ int bt_le_cs_write_cached_remote_fae_table(struct bt_conn *conn, int8_t remote_f
  *					 tone_index = n_ap corresponds to extension slot.
  *
  * @return Antenna path used to exchange CS tones, range: [0, 3].
- * @return -EINVAL if arguments are invalid.
+ * @retval -EINVAL if arguments are invalid.
  */
 int bt_le_cs_get_antenna_path(uint8_t n_ap,
 			      uint8_t antenna_path_permutation_index,

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -94,7 +94,8 @@ struct net_buf *bt_hci_cmd_alloc(k_timeout_t timeout);
   * @param opcode Command OpCode.
   * @param buf    Command buffer or NULL (if no parameters).
   *
-  * @return 0 on success or negative error value on failure.
+  * @retval 0 on success
+  * @retval <0 negative error value on failure.
   */
 int bt_hci_cmd_send(uint16_t opcode, struct net_buf *buf);
 
@@ -119,7 +120,8 @@ int bt_hci_cmd_send(uint16_t opcode, struct net_buf *buf);
   *               for calling net_buf_unref() on the buffer when done parsing
   *               it.
   *
-  * @return 0 on success or negative error value on failure.
+  * @retval 0 on success
+  * @retval <0 negative error value on failure.
   */
 int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 			 struct net_buf **rsp);
@@ -129,7 +131,8 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
  * @param conn Connection object.
  * @param conn_handle Place to store the Connection handle.
  *
- * @return 0 on success or negative error value on failure.
+ * @retval 0 on success
+ * @retval <0 negative error value on failure.
  */
 int bt_hci_get_conn_handle(const struct bt_conn *conn, uint16_t *conn_handle);
 
@@ -141,7 +144,7 @@ int bt_hci_get_conn_handle(const struct bt_conn *conn, uint16_t *conn_handle);
  * @param handle The connection handle
  *
  * @returns The corresponding connection object on success.
- *          NULL if it does not exist.
+ * @retval NULL if it does not exist.
  */
 struct bt_conn *bt_hci_conn_lookup_handle(uint16_t handle);
 
@@ -150,7 +153,8 @@ struct bt_conn *bt_hci_conn_lookup_handle(uint16_t handle);
  * @param adv Advertising set.
  * @param adv_handle Place to store the advertising handle.
  *
- * @return 0 on success or negative error value on failure.
+ * @retval 0 on success
+ * @retval <0 negative error value on failure.
  */
 int bt_hci_get_adv_handle(const struct bt_le_ext_adv *adv, uint8_t *adv_handle);
 
@@ -159,7 +163,7 @@ int bt_hci_get_adv_handle(const struct bt_le_ext_adv *adv, uint8_t *adv_handle);
  * @param handle The advertising handle
  *
  * @returns The corresponding advertising set on success,
- *          NULL if it does not exist.
+ * @retval NULL if it does not exist.
  */
 struct bt_le_ext_adv *bt_hci_adv_lookup_handle(uint8_t handle);
 
@@ -168,7 +172,8 @@ struct bt_le_ext_adv *bt_hci_adv_lookup_handle(uint8_t handle);
  * @param sync Periodic advertising sync set.
  * @param sync_handle Place to store the periodic advertising sync handle.
  *
- * @return 0 on success or negative error value on failure.
+ * @retval 0 on success
+ * @retval <0 negative error value on failure.
  */
 int bt_hci_get_adv_sync_handle(const struct bt_le_per_adv_sync *sync, uint16_t *sync_handle);
 
@@ -176,8 +181,8 @@ int bt_hci_get_adv_sync_handle(const struct bt_le_per_adv_sync *sync, uint16_t *
  *
  * @param handle The periodic sync set handle
  *
- * @retval The corresponding periodic advertising sync set object on success,
- *         NULL if it does not exist.
+ * @return The corresponding periodic advertising sync set object on success
+ * @retval NULL if it does not exist.
  */
 struct bt_le_per_adv_sync *bt_hci_per_adv_sync_lookup_handle(uint16_t handle);
 
@@ -202,8 +207,8 @@ const char *bt_hci_get_ver_str(uint8_t core_version);
   *
   * @param buf Buffer containing event parameters.
   *
-  * @return true if the function handles the event or false to defer the
-  *         handling of this event back to the stack.
+  * @retval true if the function handles the event
+  * @retval false to defer the handling of this event back to the stack.
   */
 typedef bool bt_hci_vnd_evt_cb_t(struct net_buf_simple *buf);
 
@@ -212,7 +217,8 @@ typedef bool bt_hci_vnd_evt_cb_t(struct net_buf_simple *buf);
   * @param cb Callback to be called when the stack receives a
   *           HCI Vendor-Specific Event.
   *
-  * @return 0 on success or negative error value on failure.
+  * @retval 0 on success
+  * @retval <0 negative error value on failure.
   */
 int bt_hci_register_vnd_evt_cb(bt_hci_vnd_evt_cb_t cb);
 
@@ -227,7 +233,8 @@ int bt_hci_register_vnd_evt_cb(bt_hci_vnd_evt_cb_t cb);
  * @param buffer Buffer to fill with random bytes.
  * @param len Length of the buffer in bytes.
  *
- * @return 0 on success or negative error value on failure.
+ * @retval 0 on success
+ * @retval <0 negative error value on failure.
  */
 int bt_hci_le_rand(void *buffer, size_t len);
 

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -50,19 +50,19 @@ static inline const char *bt_hci_err_to_str(uint8_t hci_err)
 #endif
 
 /** Allocate a HCI command buffer.
-  *
-  * This function allocates a new buffer for a HCI command. It is given
-  * the OpCode (encoded e.g. using the BT_OP macro) and the total length
-  * of the parameters. Upon successful return the buffer is ready to have
-  * the parameters encoded into it.
-  *
-  * @deprecated Use bt_hci_cmd_alloc() instead.
-  *
-  * @param opcode     Command OpCode.
-  * @param param_len  Length of command parameters.
-  *
-  * @return Newly allocated buffer.
-  */
+ *
+ * This function allocates a new buffer for a HCI command. It is given
+ * the OpCode (encoded e.g. using the BT_OP macro) and the total length
+ * of the parameters. Upon successful return the buffer is ready to have
+ * the parameters encoded into it.
+ *
+ * @deprecated Use bt_hci_cmd_alloc() instead.
+ *
+ * @param opcode     Command OpCode.
+ * @param param_len  Length of command parameters.
+ *
+ * @return Newly allocated buffer.
+ */
 __deprecated struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len);
 
 /** Allocate an HCI command buffer.
@@ -80,49 +80,49 @@ __deprecated struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_le
 struct net_buf *bt_hci_cmd_alloc(k_timeout_t timeout);
 
 /** Send a HCI command asynchronously.
-  *
-  * This function is used for sending a HCI command asynchronously. It can
-  * either be called for a buffer created using bt_hci_cmd_alloc(), or
-  * if the command has no parameters a NULL can be passed instead. The
-  * sending of the command will happen asynchronously, i.e. upon successful
-  * return from this function the caller only knows that it was queued
-  * successfully.
-  *
-  * If synchronous behavior, and retrieval of the Command Complete parameters
-  * is desired, the bt_hci_cmd_send_sync() API should be used instead.
-  *
-  * @param opcode Command OpCode.
-  * @param buf    Command buffer or NULL (if no parameters).
-  *
-  * @retval 0 on success
-  * @retval <0 negative error value on failure.
-  */
+ *
+ * This function is used for sending a HCI command asynchronously. It can
+ * either be called for a buffer created using bt_hci_cmd_alloc(), or
+ * if the command has no parameters a NULL can be passed instead. The
+ * sending of the command will happen asynchronously, i.e. upon successful
+ * return from this function the caller only knows that it was queued
+ * successfully.
+ *
+ * If synchronous behavior, and retrieval of the Command Complete parameters
+ * is desired, the bt_hci_cmd_send_sync() API should be used instead.
+ *
+ * @param opcode Command OpCode.
+ * @param buf    Command buffer or NULL (if no parameters).
+ *
+ * @retval 0 on success
+ * @retval <0 negative error value on failure.
+ */
 int bt_hci_cmd_send(uint16_t opcode, struct net_buf *buf);
 
 /** Send a HCI command synchronously.
-  *
-  * This function is used for sending a HCI command synchronously. It can
-  * either be called for a buffer created using bt_hci_cmd_alloc(), or
-  * if the command has no parameters a NULL can be passed instead.
-  *
-  * The function will block until a Command Status or a Command Complete
-  * event is returned. If either of these have a non-zero status the function
-  * will return a negative error code and the response reference will not
-  * be set. If the command completed successfully and a non-NULL rsp parameter
-  * was given, this parameter will be set to point to a buffer containing
-  * the response parameters.
-  *
-  * @param opcode Command OpCode.
-  * @param buf    Command buffer or NULL (if no parameters).
-  * @param rsp    Place to store a reference to the command response. May
-  *               be NULL if the caller is not interested in the response
-  *               parameters. If non-NULL is passed the caller is responsible
-  *               for calling net_buf_unref() on the buffer when done parsing
-  *               it.
-  *
-  * @retval 0 on success
-  * @retval <0 negative error value on failure.
-  */
+ *
+ * This function is used for sending a HCI command synchronously. It can
+ * either be called for a buffer created using bt_hci_cmd_alloc(), or
+ * if the command has no parameters a NULL can be passed instead.
+ *
+ * The function will block until a Command Status or a Command Complete
+ * event is returned. If either of these have a non-zero status the function
+ * will return a negative error code and the response reference will not
+ * be set. If the command completed successfully and a non-NULL rsp parameter
+ * was given, this parameter will be set to point to a buffer containing
+ * the response parameters.
+ *
+ * @param opcode Command OpCode.
+ * @param buf    Command buffer or NULL (if no parameters).
+ * @param rsp    Place to store a reference to the command response. May
+ *               be NULL if the caller is not interested in the response
+ *               parameters. If non-NULL is passed the caller is responsible
+ *               for calling net_buf_unref() on the buffer when done parsing
+ *               it.
+ *
+ * @retval 0 on success
+ * @retval <0 negative error value on failure.
+ */
 int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 			 struct net_buf **rsp);
 
@@ -200,26 +200,26 @@ struct bt_le_per_adv_sync *bt_hci_per_adv_sync_lookup_handle(uint16_t handle);
 const char *bt_hci_get_ver_str(uint8_t core_version);
 
 /** @typedef bt_hci_vnd_evt_cb_t
-  * @brief Callback type for vendor handling of HCI Vendor-Specific Events.
-  *
-  * A function of this type is registered with bt_hci_register_vnd_evt_cb()
-  * and will be called for any HCI Vendor-Specific Event.
-  *
-  * @param buf Buffer containing event parameters.
-  *
-  * @retval true if the function handles the event
-  * @retval false to defer the handling of this event back to the stack.
-  */
+ * @brief Callback type for vendor handling of HCI Vendor-Specific Events.
+ *
+ * A function of this type is registered with bt_hci_register_vnd_evt_cb()
+ * and will be called for any HCI Vendor-Specific Event.
+ *
+ * @param buf Buffer containing event parameters.
+ *
+ * @retval true if the function handles the event
+ * @retval false to defer the handling of this event back to the stack.
+ */
 typedef bool bt_hci_vnd_evt_cb_t(struct net_buf_simple *buf);
 
 /** Register user callback for HCI Vendor-Specific Events
-  *
-  * @param cb Callback to be called when the stack receives a
-  *           HCI Vendor-Specific Event.
-  *
-  * @retval 0 on success
-  * @retval <0 negative error value on failure.
-  */
+ *
+ * @param cb Callback to be called when the stack receives a
+ *           HCI Vendor-Specific Event.
+ *
+ * @retval 0 on success
+ * @retval <0 negative error value on failure.
+ */
 int bt_hci_register_vnd_evt_cb(bt_hci_vnd_evt_cb_t cb);
 
 /** @brief Get Random bytes from the LE Controller.

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -812,7 +812,8 @@ struct bt_iso_server {
 	 * @param info The ISO accept information structure
 	 * @param chan Pointer to receive the allocated channel
 	 *
-	 * @return 0 in case of success or negative value in case of error.
+	 * @retval 0 in case of success
+	 * @retval <0 negative value in case of error.
 	 */
 	int (*accept)(const struct bt_iso_accept_info *info, struct bt_iso_chan **chan);
 };
@@ -826,7 +827,8 @@ struct bt_iso_server {
  *
  * @param server Server structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative value in case of error.
  */
 int bt_iso_server_register(struct bt_iso_server *server);
 
@@ -837,7 +839,8 @@ int bt_iso_server_register(struct bt_iso_server *server);
  *
  * @param server Server structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative value in case of error.
  */
 int bt_iso_server_unregister(struct bt_iso_server *server);
 
@@ -853,7 +856,8 @@ int bt_iso_server_unregister(struct bt_iso_server *server);
  * @param[in]  param    The parameters used to create and enable the CIG.
  * @param[out] out_cig  Connected Isochronous Group object on success.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative value in case of error.
  */
 int bt_iso_cig_create(const struct bt_iso_cig_param *param, struct bt_iso_cig **out_cig);
 
@@ -875,7 +879,8 @@ int bt_iso_cig_create(const struct bt_iso_cig_param *param, struct bt_iso_cig **
  * @param cig       Connected Isochronous Group object.
  * @param param     The parameters used to reconfigure the CIG.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative value in case of error.
  */
 int bt_iso_cig_reconfigure(struct bt_iso_cig *cig, const struct bt_iso_cig_param *param);
 
@@ -886,7 +891,8 @@ int bt_iso_cig_reconfigure(struct bt_iso_cig *cig, const struct bt_iso_cig_param
  *
  * @param cig    Pointer to the CIG structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative value in case of error.
  */
 int bt_iso_cig_terminate(struct bt_iso_cig *cig);
 
@@ -946,7 +952,8 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count);
  *
  * @param chan Channel object.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative value in case of error.
  */
 int bt_iso_chan_disconnect(struct bt_iso_chan *chan);
 
@@ -967,7 +974,8 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan);
  *                 each call to this function and at least once per SDU
  *                 interval for a specific channel.
  *
- * @return Number of octets sent in case of success or negative value in case of error.
+ * @return Number of octets sent in case of success
+ * @retval <0 negative value in case of error.
  */
 int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq_num);
 
@@ -991,7 +999,8 @@ int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq
  *                 This value can be used to transmit multiple
  *                 SDUs in the same SDU interval in a CIG or BIG.
  *
- * @return Number of octets sent in case of success or negative value in case of error.
+ * @return Number of octets sent in case of success
+ * @retval <0 negative value in case of error.
  */
 int bt_iso_chan_send_ts(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq_num,
 			uint32_t ts);
@@ -1239,7 +1248,8 @@ struct bt_iso_info {
  * @param chan Channel object.
  * @param info Channel info object.
  *
- * @return Zero on success or (negative) error code on failure.
+ * @retval 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_iso_chan_get_info(const struct bt_iso_chan *chan, struct bt_iso_info *info);
 
@@ -1256,7 +1266,8 @@ int bt_iso_chan_get_info(const struct bt_iso_chan *chan, struct bt_iso_info *inf
  * @param[in]  chan Channel object.
  * @param[out] info Transmit info object.
  *
- * @return Zero on success or (negative) error code on failure.
+ * @retval 0 on success
+ * @retval <0 negative error code on failure.
  */
 int bt_iso_chan_get_tx_sync(const struct bt_iso_chan *chan, struct bt_iso_tx_info *info);
 
@@ -1305,7 +1316,8 @@ int bt_iso_big_register_cb(struct bt_iso_big_cb *cb);
  *                      parameter.
  * @param[out] out_big  Broadcast Isochronous Group object on success.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative value in case of error.
  */
 int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param *param,
 		      struct bt_iso_big **out_big);
@@ -1318,7 +1330,8 @@ int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param
  *
  * @param big    Pointer to the BIG structure.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative value in case of error.
  */
 int bt_iso_big_terminate(struct bt_iso_big *big);
 
@@ -1329,7 +1342,8 @@ int bt_iso_big_terminate(struct bt_iso_big *big);
  * @param[in] param    The parameters used to create and enable the BIG sync.
  * @param[out] out_big Broadcast Isochronous Group object on success.
  *
- * @return 0 in case of success or negative value in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative value in case of error.
  */
 int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_param *param,
 		    struct bt_iso_big **out_big);

--- a/include/zephyr/bluetooth/uuid.h
+++ b/include/zephyr/bluetooth/uuid.h
@@ -5220,7 +5220,9 @@ struct bt_uuid_128 {
  *  @param u1 First Bluetooth UUID to compare
  *  @param u2 Second Bluetooth UUID to compare
  *
- *  @return negative value if @a u1 < @a u2, 0 if @a u1 == @a u2, else positive
+ *  @retval <0 negative value if @a u1 < @a u2
+ *  @retval 0 if @a u1 == @a u2
+ *  @retval >0 else positive
  */
 int bt_uuid_cmp(const struct bt_uuid *u1, const struct bt_uuid *u2);
 
@@ -5234,7 +5236,7 @@ int bt_uuid_cmp(const struct bt_uuid *u1, const struct bt_uuid *u2);
  *  @param data pointer to UUID stored in little-endian data buffer
  *  @param data_len length of the UUID in the data buffer
  *
- *  @return true if the data was valid and the UUID was successfully created.
+ *  @retval true if the data was valid and the UUID was successfully created.
  */
 bool bt_uuid_create(struct bt_uuid *uuid, const uint8_t *data, uint8_t data_len);
 


### PR DESCRIPTION
Fix how Doxygen special commands \retval and \return are used in Bluetooth API doc text.

From Doxygen documentation:
"\retval: Starts a description for a function's return value with name <return value>.
\return: Starts a return value description for a function."

See https://www.doxygen.nl/manual/commands.html#cmdreturn
https://www.doxygen.nl/manual/commands.html#cmdretval