### PR TITLE
include: devicetree: fix Doxygen \retval & \return commands usage

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -238,7 +238,8 @@
 /**
  * @brief Test if the devicetree has a given alias
  * @param alias_name lowercase-and-underscores devicetree alias name
- * @return 1 if the alias exists and refers to a node, 0 otherwise
+ * @retval 1 if the alias exists and refers to a node
+ * @retval 0 otherwise
  */
 #define DT_HAS_ALIAS(alias_name) DT_NODE_EXISTS(DT_ALIAS(alias_name))
 
@@ -1039,7 +1040,8 @@
  * @param prop lowercase-and-underscores property name
  * @param idx the index to get
  * @param value lowercase-and-underscores enumeration value
- * @return 1 if the node property has the value @a value, 0 otherwise.
+ * @retval 1 if the node property has the value @a value
+ * @retval 0 otherwise.
  */
 #define DT_ENUM_HAS_VALUE_BY_IDX(node_id, prop, idx, value) \
 	IS_ENABLED(DT_CAT8(node_id, _P_, prop, _IDX_, idx, _ENUM_VAL_, value, _EXISTS))
@@ -1049,7 +1051,8 @@
  * @param node_id node identifier
  * @param prop lowercase-and-underscores property name
  * @param value lowercase-and-underscores enumeration value
- * @return 1 if the node property has the value @a value, 0 otherwise.
+ * @retval 1 if the node property has the value @a value
+ * @retval 0 otherwise.
  */
 #define DT_ENUM_HAS_VALUE(node_id, prop, value) \
 	IS_ENABLED(DT_CAT6(node_id, _P_, prop, _ENUM_VAL_, value, _EXISTS))
@@ -1895,8 +1898,8 @@
  *
  * @param node_id node identifier
  * @param idx index to check
- * @return 1 if @p idx is a valid register block index,
- *         0 otherwise.
+ * @retval 1 if @p idx is a valid register block index,
+ * @retval 0 otherwise.
  */
 #define DT_RANGES_HAS_IDX(node_id, idx) \
 	IS_ENABLED(DT_CAT4(node_id, _RANGES_IDX_, idx, _EXISTS))
@@ -1950,8 +1953,8 @@
  *
  * @param node_id node identifier
  * @param idx logical index into the ranges array
- * @return 1 if @p idx is a valid child bus flags index,
- *         0 otherwise.
+ * @retval 1 if @p idx is a valid child bus flags index,
+ * @retval 0 otherwise.
  */
 #define DT_RANGES_HAS_CHILD_BUS_FLAGS_AT_IDX(node_id, idx) \
 	IS_ENABLED(DT_CAT4(node_id, _RANGES_IDX_, idx, _VAL_CHILD_BUS_FLAGS_EXISTS))
@@ -1991,7 +1994,7 @@
  *
  * @param node_id node identifier
  * @param idx logical index into the ranges array
- * @returns range child bus flags field at idx
+ * @return range child bus flags field at idx
  */
 #define DT_RANGES_CHILD_BUS_FLAGS_BY_IDX(node_id, idx) \
 	DT_CAT4(node_id, _RANGES_IDX_, idx, _VAL_CHILD_BUS_FLAGS)
@@ -2040,7 +2043,7 @@
  *
  * @param node_id node identifier
  * @param idx logical index into the ranges array
- * @returns range child bus address field at idx
+ * @return range child bus address field at idx
  */
 #define DT_RANGES_CHILD_BUS_ADDRESS_BY_IDX(node_id, idx) \
 	DT_CAT4(node_id, _RANGES_IDX_, idx, _VAL_CHILD_BUS_ADDRESS)
@@ -2089,7 +2092,7 @@
  *
  * @param node_id node identifier
  * @param idx logical index into the ranges array
- * @returns range parent bus address field at idx
+ * @return range parent bus address field at idx
  */
 #define DT_RANGES_PARENT_BUS_ADDRESS_BY_IDX(node_id, idx) \
 	DT_CAT4(node_id, _RANGES_IDX_, idx, _VAL_PARENT_BUS_ADDRESS)
@@ -2138,7 +2141,7 @@
  *
  * @param node_id node identifier
  * @param idx logical index into the ranges array
- * @returns range length field at idx
+ * @return range length field at idx
  */
 #define DT_RANGES_LENGTH_BY_IDX(node_id, idx) \
 	DT_CAT4(node_id, _RANGES_IDX_, idx, _VAL_LENGTH)
@@ -2242,8 +2245,8 @@
  *
  * @param node_id node identifier
  * @param idx index of the vendor to check
- * @return 1 if @p idx is a valid vendor index,
- *         0 otherwise.
+ * @retval 1 if @p idx is a valid vendor index,
+ * @retval 0 otherwise.
  */
 #define DT_NODE_VENDOR_HAS_IDX(node_id, idx) \
 	IS_ENABLED(DT_CAT4(node_id, _COMPAT_VENDOR_IDX_, idx, _EXISTS))
@@ -2318,8 +2321,8 @@
  *
  * @param node_id node identifier
  * @param idx index of the model to check
- * @return 1 if "idx" is a valid model index,
- *         0 otherwise.
+ * @retval 1 if "idx" is a valid model index,
+ * @retval 0 otherwise.
  */
 #define DT_NODE_MODEL_HAS_IDX(node_id, idx) \
 	IS_ENABLED(DT_CAT4(node_id, _COMPAT_MODEL_IDX_, idx, _EXISTS))
@@ -2380,8 +2383,8 @@
  * If it returns 0, it is an error to use those macros with index @p idx.
  * @param node_id node identifier
  * @param idx index to check
- * @return 1 if @p idx is a valid register block index,
- *         0 otherwise.
+ * @retval 1 if @p idx is a valid register block index,
+ * @retval 0 otherwise.
  */
 #define DT_REG_HAS_IDX(node_id, idx) \
 	IS_ENABLED(DT_CAT4(node_id, _REG_IDX_, idx, _EXISTS))
@@ -2394,8 +2397,8 @@
  * If it returns 0, it is an error to use those macros with name @p name.
  * @param node_id node identifier
  * @param name name to check
- * @return 1 if @p name is a valid register block name,
- *         0 otherwise.
+ * @retval 1 if @p name is a valid register block name,
+ * @retval 0 otherwise.
  */
 #define DT_REG_HAS_NAME(node_id, name) \
 	IS_ENABLED(DT_CAT4(node_id, _REG_NAME_, name, _EXISTS))
@@ -2600,8 +2603,8 @@
  * If it returns 0, it is an error to use that macro with this index.
  * @param node_id node identifier
  * @param idx index to check
- * @return 1 if the idx is valid for the interrupt property
- *         0 otherwise.
+ * @retval 1 if the idx is valid for the interrupt property
+ * @retval 0 otherwise.
  */
 #define DT_IRQ_HAS_IDX(node_id, idx) \
 	IS_ENABLED(DT_CAT4(node_id, _IRQ_IDX_, idx, _EXISTS))
@@ -2613,8 +2616,8 @@
  * @param node_id node identifier
  * @param idx index to check
  * @param cell named cell value whose existence to check
- * @return 1 if the named cell exists in the interrupt specifier at index idx
- *         0 otherwise.
+ * @retval 1 if the named cell exists in the interrupt specifier at index idx
+ * @retval 0 otherwise.
  */
 #define DT_IRQ_HAS_CELL_AT_IDX(node_id, idx, cell) \
 	IS_ENABLED(DT_CAT6(node_id, _IRQ_IDX_, idx, _VAL_, cell, _EXISTS))
@@ -2623,8 +2626,8 @@
  * @brief Equivalent to DT_IRQ_HAS_CELL_AT_IDX(node_id, 0, cell)
  * @param node_id node identifier
  * @param cell named cell value whose existence to check
- * @return 1 if the named cell exists in the interrupt specifier at index 0
- *         0 otherwise.
+ * @retval 1 if the named cell exists in the interrupt specifier at index 0
+ * @retval 0 otherwise.
  */
 #define DT_IRQ_HAS_CELL(node_id, cell) DT_IRQ_HAS_CELL_AT_IDX(node_id, 0, cell)
 
@@ -2634,8 +2637,8 @@
  * If it returns 0, it is an error to use that macro.
  * @param node_id node identifier
  * @param name lowercase-and-underscores interrupt specifier name
- * @return 1 if "name" is a valid named specifier
- *         0 otherwise.
+ * @retval 1 if "name" is a valid named specifier
+ * @retval 0 otherwise.
  */
 #define DT_IRQ_HAS_NAME(node_id, name) \
 	IS_ENABLED(DT_CAT4(node_id, _IRQ_NAME_, name, _VAL_irq_EXISTS))
@@ -2916,8 +2919,8 @@
 /**
  * @brief Test if the devicetree has a `/chosen` node
  * @param prop lowercase-and-underscores devicetree property
- * @return 1 if the chosen property exists and refers to a node,
- *         0 otherwise
+ * @retval 1 if the chosen property exists and refers to a node,
+ * @retval 0 otherwise
  */
 #define DT_HAS_CHOSEN(prop) IS_ENABLED(DT_CAT3(DT_CHOSEN_, prop, _EXISTS))
 
@@ -3638,8 +3641,8 @@
  * whether the node exists at all.
  *
  * @param node_id a node identifier
- * @return 1 if the node identifier refers to a node,
- *         0 otherwise.
+ * @retval 1 if the node identifier refers to a node,
+ * @retval 0 otherwise.
  */
 #define DT_NODE_EXISTS(node_id) IS_ENABLED(DT_CAT(node_id, _EXISTS))
 
@@ -3662,7 +3665,8 @@
  *
  * @param node_id a node identifier
  * @param status a status as one of the tokens okay or disabled, not a string
- * @return 1 if the node has the given status, 0 otherwise.
+ * @retval 1 if the node has the given status
+ * @retval 0 otherwise.
  */
 #define DT_NODE_HAS_STATUS(node_id, status) \
 	DT_NODE_HAS_STATUS_INTERNAL(node_id, status)
@@ -3685,7 +3689,8 @@
  * `okay`.
  *
  * @param node_id a node identifier
- * @return 1 if the node has status as `okay`, 0 otherwise.
+ * @retval 1 if the node has status as `okay`
+ * @retval 0 otherwise.
  */
 #define DT_NODE_HAS_STATUS_OKAY(node_id) DT_NODE_HAS_STATUS(node_id, okay)
 
@@ -3706,7 +3711,8 @@
  * `okay`.
  *
  * @param compat lowercase-and-underscores compatible, without quotes
- * @return 1 if both of the above conditions are met, 0 otherwise
+ * @retval 1 if both of the above conditions are met
+ * @retval 0 otherwise
  */
 #define DT_HAS_COMPAT_STATUS_OKAY(compat) \
 	IS_ENABLED(DT_CAT(DT_COMPAT_HAS_OKAY_, compat))
@@ -3745,8 +3751,8 @@
  *
  * @param node_id node identifier
  * @param compat lowercase-and-underscores compatible, without quotes
- * @return 1 if the node's compatible property contains @p compat,
- *         0 otherwise.
+ * @retval 1 if the node's compatible property contains @p compat,
+ * @retval 0 otherwise.
  */
 #define DT_NODE_HAS_COMPAT(node_id, compat) \
 	IS_ENABLED(DT_CAT3(node_id, _COMPAT_MATCHES_, compat))
@@ -3779,7 +3785,8 @@
  *
  * @param node_id node identifier
  * @param prop lowercase-and-underscores property name
- * @return 1 if the node has the property, 0 otherwise.
+ * @retval 1 if the node has the property
+ * @retval 0 otherwise.
  */
 #define DT_NODE_HAS_PROP(node_id, prop) \
 	IS_ENABLED(DT_CAT4(node_id, _P_, prop, _EXISTS))
@@ -3798,8 +3805,8 @@
  * @param idx index to check within @p pha
  * @param cell lowercase-and-underscores cell name whose existence to check
  *             at index @p idx
- * @return 1 if the named cell exists in the specifier at index idx,
- *         0 otherwise.
+ * @retval 1 if the named cell exists in the specifier at index idx,
+ * @retval 0 otherwise.
  */
 #define DT_PHA_HAS_CELL_AT_IDX(node_id, pha, idx, cell)             \
 	IS_ENABLED(DT_CAT8(node_id, _P_, pha,			    \
@@ -3811,8 +3818,8 @@
  * @param pha lowercase-and-underscores property with type `phandle-array`
  * @param cell lowercase-and-underscores cell name whose existence to check
  *             at index @p idx
- * @return 1 if the named cell exists in the specifier at index 0,
- *         0 otherwise.
+ * @retval 1 if the named cell exists in the specifier at index 0,
+ * @retval 0 otherwise.
  */
 #define DT_PHA_HAS_CELL(node_id, pha, cell) \
 	DT_PHA_HAS_CELL_AT_IDX(node_id, pha, 0, cell)
@@ -4013,8 +4020,8 @@
  * @param node_id node identifier
  * @param bus lowercase-and-underscores bus type as a C token (i.e.
  *            without quotes)
- * @return 1 if the node is on a bus of the given type,
- *         0 otherwise
+ * @retval 1 if the node is on a bus of the given type,
+ * @retval 0 otherwise
  */
 #define DT_ON_BUS(node_id, bus) IS_ENABLED(DT_CAT3(node_id, _BUS_, bus))
 
@@ -4301,7 +4308,8 @@
  * @param inst instance number
  * @param prop lowercase-and-underscores property name
  * @param value lowercase-and-underscores enumeration value
- * @return 1 if the node property has the value @a value, 0 otherwise.
+ * @retval 1 if the node property has the value @a value
+ * @retval 0 otherwise.
  */
 #define DT_INST_ENUM_HAS_VALUE(inst, prop, value) \
 	DT_ENUM_HAS_VALUE(DT_DRV_INST(inst), prop, value)
@@ -4328,8 +4336,8 @@
  * @param inst instance number
  * @param prop lowercase-and-underscores property name
  * @param idx index to check
- * @return 1 if @p idx is a valid index into the given property,
- *         0 otherwise.
+ * @retval 1 if @p idx is a valid index into the given property,
+ * @retval 0 otherwise.
  */
 #define DT_INST_PROP_HAS_IDX(inst, prop, idx) \
 	DT_PROP_HAS_IDX(DT_DRV_INST(inst), prop, idx)
@@ -4568,8 +4576,8 @@
  * @brief is @p idx a valid register block index on a `DT_DRV_COMPAT` instance?
  * @param inst instance number
  * @param idx index to check
- * @return 1 if @p idx is a valid register block index,
- *         0 otherwise.
+ * @retval 1 if @p idx is a valid register block index,
+ * @retval 0 otherwise.
  */
 #define DT_INST_REG_HAS_IDX(inst, idx) DT_REG_HAS_IDX(DT_DRV_INST(inst), idx)
 
@@ -4577,8 +4585,8 @@
  * @brief is @p name a valid register block name on a `DT_DRV_COMPAT` instance?
  * @param inst instance number
  * @param name name to check
- * @return 1 if @p name is a valid register block name,
- *         0 otherwise.
+ * @retval 1 if @p name is a valid register block name,
+ * @retval 0 otherwise.
  */
 #define DT_INST_REG_HAS_NAME(inst, name) DT_REG_HAS_NAME(DT_DRV_INST(inst), name)
 
@@ -4794,8 +4802,8 @@
  * @brief Test if a `DT_DRV_COMPAT`'s bus type is a given type
  * @param inst instance number
  * @param bus a binding's bus type as a C token, lowercased and without quotes
- * @return 1 if the given instance is on a bus of the given type,
- *         0 otherwise
+ * @retval 1 if the given instance is on a bus of the given type,
+ * @retval 0 otherwise
  */
 #define DT_INST_ON_BUS(inst, bus) DT_ON_BUS(DT_DRV_INST(inst), bus)
 
@@ -4860,8 +4868,8 @@
  *
  * @param compat lowercase-and-underscores compatible, without quotes
  * @param bus a binding's bus type as a C token, lowercased and without quotes
- * @return 1 if any enabled node with that compatible is on that bus type,
- *         0 otherwise
+ * @retval 1 if any enabled node with that compatible is on that bus type,
+ * @retval 0 otherwise
  */
 #define DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(compat, bus) \
 	IS_ENABLED(DT_CAT4(DT_COMPAT_, compat, _BUS_, bus))
@@ -4895,8 +4903,8 @@
  * @endcode
  *
  * @param bus a binding's bus type as a C token, lowercased and without quotes
- * @return 1 if any enabled node with that compatible is on that bus type,
- *         0 otherwise
+ * @retval 1 if any enabled node with that compatible is on that bus type,
+ * @retval 0 otherwise
  */
 #define DT_ANY_INST_ON_BUS_STATUS_OKAY(bus) \
 	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(DT_DRV_COMPAT, bus)
@@ -5327,7 +5335,8 @@
  * @brief Does a DT_DRV_COMPAT instance have a property?
  * @param inst instance number
  * @param prop lowercase-and-underscores property name
- * @return 1 if the instance has the property, 0 otherwise.
+ * @retval 1 if the instance has the property
+ * @retval 0 otherwise.
  */
 #define DT_INST_NODE_HAS_PROP(inst, prop) \
 	DT_NODE_HAS_PROP(DT_DRV_INST(inst), prop)
@@ -5336,7 +5345,8 @@
  * @brief Does a DT_DRV_COMPAT instance have the compatible?
  * @param inst instance number
  * @param compat lowercase-and-underscores compatible, without quotes
- * @return 1 if the instance matches the compatible, 0 otherwise.
+ * @retval 1 if the instance matches the compatible
+ * @retval 0 otherwise.
  */
 #define DT_INST_NODE_HAS_COMPAT(inst, compat) \
 	DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), compat)
@@ -5348,8 +5358,8 @@
  * @param pha lowercase-and-underscores property with type `phandle-array`
  * @param idx index to check
  * @param cell named cell value whose existence to check
- * @return 1 if the named @p cell exists in the specifier at index @p idx,
- *         0 otherwise.
+ * @retval 1 if the named @p cell exists in the specifier at index @p idx,
+ * @retval 0 otherwise.
  */
 #define DT_INST_PHA_HAS_CELL_AT_IDX(inst, pha, idx, cell) \
 	DT_PHA_HAS_CELL_AT_IDX(DT_DRV_INST(inst), pha, idx, cell)
@@ -5360,8 +5370,8 @@
  * @param inst instance number
  * @param pha lowercase-and-underscores property with type `phandle-array`
  * @param cell named cell value whose existence to check
- * @return 1 if the named @p cell exists in the specifier at index 0,
- *         0 otherwise.
+ * @retval 1 if the named @p cell exists in the specifier at index 0,
+ * @retval 0 otherwise.
  */
 #define DT_INST_PHA_HAS_CELL(inst, pha, cell) \
 	DT_INST_PHA_HAS_CELL_AT_IDX(inst, pha, 0, cell)
@@ -5370,8 +5380,8 @@
  * @brief is index valid for interrupt property on a `DT_DRV_COMPAT` instance?
  * @param inst instance number
  * @param idx logical index into the interrupt specifier array
- * @return 1 if the @p idx is valid for the interrupt property
- *         0 otherwise.
+ * @retval 1 if the @p idx is valid for the interrupt property
+ * @retval 0 otherwise.
  */
 #define DT_INST_IRQ_HAS_IDX(inst, idx) DT_IRQ_HAS_IDX(DT_DRV_INST(inst), idx)
 
@@ -5380,8 +5390,8 @@
  * @param inst instance number
  * @param idx index to check
  * @param cell named cell value whose existence to check
- * @return 1 if the named @p cell exists in the interrupt specifier at index
- *         @p idx 0 otherwise.
+ * @retval 1 if the named @p cell exists in the interrupt specifier at index @p idx
+ * @retval 0 otherwise.
  */
 #define DT_INST_IRQ_HAS_CELL_AT_IDX(inst, idx, cell) \
 	DT_IRQ_HAS_CELL_AT_IDX(DT_DRV_INST(inst), idx, cell)
@@ -5390,8 +5400,8 @@
  * @brief Does a `DT_DRV_COMPAT` instance have an interrupt value?
  * @param inst instance number
  * @param cell named cell value whose existence to check
- * @return 1 if the named @p cell exists in the interrupt specifier at index 0
- *         0 otherwise.
+ * @retval 1 if the named @p cell exists in the interrupt specifier at index 0
+ * @retval 0 otherwise.
  */
 #define DT_INST_IRQ_HAS_CELL(inst, cell) \
 	DT_INST_IRQ_HAS_CELL_AT_IDX(inst, 0, cell)
@@ -5400,7 +5410,7 @@
  * @brief Does a `DT_DRV_COMPAT` instance have an interrupt value?
  * @param inst instance number
  * @param name lowercase-and-underscores interrupt specifier name
- * @return 1 if @p name is a valid named specifier
+ * @retval 1 if @p name is a valid named specifier
  */
 #define DT_INST_IRQ_HAS_NAME(inst, name) \
 	DT_IRQ_HAS_NAME(DT_DRV_INST(inst), name)

--- a/include/zephyr/devicetree/clocks.h
+++ b/include/zephyr/devicetree/clocks.h
@@ -48,7 +48,8 @@ extern "C" {
  *
  * @param node_id node identifier; may or may not have any clocks property
  * @param idx index of a clocks property phandle-array whose existence to check
- * @return 1 if the index exists, 0 otherwise
+ * @retval 1 if the index exists
+ * @retval 0 otherwise
  */
 #define DT_CLOCKS_HAS_IDX(node_id, idx) \
 	DT_PROP_HAS_IDX(node_id, clocks, idx)
@@ -79,7 +80,8 @@ extern "C" {
  *
  * @param node_id node identifier; may or may not have any clock-names property.
  * @param name lowercase-and-underscores clock-names cell value name to check
- * @return 1 if the clock name exists, 0 otherwise
+ * @retval 1 if the clock name exists
+ * @retval 0 otherwise
  */
 #define DT_CLOCKS_HAS_NAME(node_id, name) \
 	DT_PROP_HAS_NAME(node_id, clocks, name)
@@ -257,7 +259,8 @@ extern "C" {
  * @brief Equivalent to DT_CLOCKS_HAS_IDX(DT_DRV_INST(inst), idx)
  * @param inst DT_DRV_COMPAT instance number; may or may not have any clocks property
  * @param idx index of a clocks property phandle-array whose existence to check
- * @return 1 if the index exists, 0 otherwise
+ * @retval 1 if the index exists
+ * @retval 0 otherwise
  */
 #define DT_INST_CLOCKS_HAS_IDX(inst, idx) \
 	DT_CLOCKS_HAS_IDX(DT_DRV_INST(inst), idx)
@@ -266,7 +269,8 @@ extern "C" {
  * @brief Equivalent to DT_CLOCK_HAS_NAME(DT_DRV_INST(inst), name)
  * @param inst DT_DRV_COMPAT instance number; may or may not have any clock-names property.
  * @param name lowercase-and-underscores clock-names cell value name to check
- * @return 1 if the clock name exists, 0 otherwise
+ * @retval 1 if the clock name exists
+ * @retval 0 otherwise
  */
 #define DT_INST_CLOCKS_HAS_NAME(inst, name) \
 	DT_CLOCKS_HAS_NAME(DT_DRV_INST(inst), name)

--- a/include/zephyr/devicetree/display.h
+++ b/include/zephyr/devicetree/display.h
@@ -64,7 +64,9 @@ extern "C" {
  * @brief Get number of zephyr displays
  *
  * @return number of displays designated by "displays" property of "zephyr,displays" compatible
- * node, if it exists, otherwise 1 if "zephyr,display" chosen property exists, 0 otherwise
+ * node, if it exists
+ * @retval 1 if "zephyr,display" chosen property exists
+ * @retval 0 otherwise
  */
 #define DT_ZEPHYR_DISPLAYS_COUNT                                                                   \
 	COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(zephyr_displays),                                    \

--- a/include/zephyr/devicetree/dma.h
+++ b/include/zephyr/devicetree/dma.h
@@ -256,7 +256,8 @@ extern "C" {
  * @brief Is index "idx" valid for a dmas property?
  * @param node_id node identifier for a node with a dmas property
  * @param idx logical index into dmas property
- * @return 1 if the "dmas" property has index "idx", 0 otherwise
+ * @retval 1 if the "dmas" property has index "idx"
+ * @retval 0 otherwise
  */
 #define DT_DMAS_HAS_IDX(node_id, idx) \
 	IS_ENABLED(DT_CAT4(node_id, _P_dmas_IDX_, idx, _EXISTS))
@@ -265,7 +266,8 @@ extern "C" {
  * @brief Is index "idx" valid for a DT_DRV_COMPAT instance's dmas property?
  * @param inst DT_DRV_COMPAT instance number
  * @param idx logical index into dmas property
- * @return 1 if the "dmas" property has a specifier at index "idx", 0 otherwise
+ * @retval 1 if the "dmas" property has a specifier at index "idx"
+ * @retval 0 otherwise
  */
 #define DT_INST_DMAS_HAS_IDX(inst, idx) \
 	DT_DMAS_HAS_IDX(DT_DRV_INST(inst), idx)
@@ -275,7 +277,8 @@ extern "C" {
  * @param node_id node identifier for a node with a dmas property
  * @param name lowercase-and-underscores name of a dmas element
  *             as defined by the node's dma-names property
- * @return 1 if the dmas property has the named element, 0 otherwise
+ * @retval 1 if the dmas property has the named element
+ * @retval 0 otherwise
  */
 #define DT_DMAS_HAS_NAME(node_id, name) \
 	DT_PROP_HAS_NAME(node_id, dmas, name)
@@ -285,7 +288,8 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of a dmas element
  *             as defined by the node's dma-names property
- * @return 1 if the dmas property has the named element, 0 otherwise
+ * @retval 1 if the dmas property has the named element
+ * @retval 0 otherwise
  */
 #define DT_INST_DMAS_HAS_NAME(inst, name) \
 	DT_DMAS_HAS_NAME(DT_DRV_INST(inst), name)

--- a/include/zephyr/devicetree/fixed-partitions.h
+++ b/include/zephyr/devicetree/fixed-partitions.h
@@ -55,7 +55,7 @@ extern "C" {
 /**
  * @brief Test if a fixed partition with a given label property exists
  * @param label lowercase-and-underscores label property value
- * @return 1 if any "fixed-partitions" child node has the given label,
+ * @retval 1 if any "fixed-partitions" child node has the given label,
  *         0 otherwise.
  */
 #define DT_HAS_FIXED_PARTITION_LABEL(label) \
@@ -65,7 +65,8 @@ extern "C" {
  * @brief Test if fixed-partition compatible node exists
  *
  * @param node_id DTS node to test
- * @return 1 if node exists and is fixed-partition compatible, 0 otherwise.
+ * @retval 1 if node exists and is fixed-partition compatible
+ * @retval 0 otherwise.
  */
 #define DT_FIXED_PARTITION_EXISTS(node_id)		\
 	DT_NODE_HAS_COMPAT(DT_PARENT(node_id), fixed_partitions)
@@ -137,7 +138,8 @@ extern "C" {
  * @brief Test if fixed-subpartitions compatible node exists
  *
  * @param node_id DTS node to test
- * @return 1 if node exists and is fixed-subpartitions compatible, 0 otherwise.
+ * @retval 1 if node exists and is fixed-subpartitions compatible
+ * @retval 0 otherwise.
  */
 #define DT_FIXED_SUBPARTITION_EXISTS(node_id)		\
 	DT_NODE_HAS_COMPAT(DT_PARENT(node_id), fixed_subpartitions)

--- a/include/zephyr/devicetree/nvmem.h
+++ b/include/zephyr/devicetree/nvmem.h
@@ -48,7 +48,8 @@ extern "C" {
  * @param node_id node identifier; may or may not have any nvmem-cells property
  * @param idx index of a nvmem-cells property phandle-array whose existence to check
  *
- * @return 1 if the index exists, 0 otherwise
+ * @retval 1 if the index exists
+ * @retval 0 otherwise
  */
 #define DT_NVMEM_CELLS_HAS_IDX(node_id, idx) DT_PROP_HAS_IDX(node_id, nvmem_cells, idx)
 
@@ -77,7 +78,8 @@ extern "C" {
  * @param node_id node identifier; may or may not have any nvmem-cell-names property
  * @param name lowercase-and-underscores nvmem-cell-names cell value name to check
  *
- * @return 1 if the index exists, 0 otherwise
+ * @retval 1 if the index exists
+ * @retval 0 otherwise
  */
 #define DT_NVMEM_CELLS_HAS_NAME(node_id, name) DT_PROP_HAS_NAME(node_id, nvmem_cells, name)
 
@@ -200,7 +202,8 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number; may or may not have any nvmem-cells property
  * @param idx index of an nvmem-cells property phandle-array whose existence to check
  *
- * @return 1 if the index exists, 0 otherwise
+ * @retval 1 if the index exists
+ * @retval 0 otherwise
  */
 #define DT_INST_NVMEM_CELLS_HAS_IDX(inst, idx) DT_NVMEM_CELLS_HAS_IDX(DT_DRV_INST(inst), idx)
 
@@ -210,7 +213,8 @@ extern "C" {
  * @param inst DT_DRV_COMPAT instance number; may or may not have any nvmem-cell-names property.
  * @param name lowercase-and-underscores nvmem-cell-names cell value name to check
  *
- * @return 1 if the nvmem cell name exists, 0 otherwise
+ * @retval 1 if the nvmem cell name exists
+ * @retval 0 otherwise
  */
 #define DT_INST_NVMEM_CELLS_HAS_NAME(inst, name) DT_NVMEM_CELLS_HAS_NAME(DT_DRV_INST(inst), name)
 

--- a/include/zephyr/devicetree/pinctrl.h
+++ b/include/zephyr/devicetree/pinctrl.h
@@ -264,7 +264,8 @@
  *
  * @param node_id node identifier; may or may not have any pinctrl properties
  * @param pc_idx index of a pinctrl property whose existence to check
- * @return 1 if the property exists, 0 otherwise
+ * @retval 1 if the property exists
+ * @retval 0 otherwise
  */
 #define DT_PINCTRL_HAS_IDX(node_id, pc_idx) \
 	IS_ENABLED(DT_CAT4(node_id, _PINCTRL_IDX_, pc_idx, _EXISTS))
@@ -293,7 +294,8 @@
  *
  * @param node_id node identifier; may or may not have any pinctrl properties
  * @param name lowercase-and-underscores pinctrl property name to check
- * @return 1 if the property exists, 0 otherwise
+ * @retval 1 if the property exists
+ * @retval 0 otherwise
  */
 #define DT_PINCTRL_HAS_NAME(node_id, name) \
 	IS_ENABLED(DT_CAT4(node_id, _PINCTRL_NAME_, name, _EXISTS))
@@ -431,7 +433,8 @@
  *
  * @param inst instance number
  * @param pc_idx index of a pinctrl property whose existence to check
- * @return 1 if the property exists, 0 otherwise
+ * @retval 1 if the property exists
+ * @retval 0 otherwise
  */
 #define DT_INST_PINCTRL_HAS_IDX(inst, pc_idx) \
 	DT_PINCTRL_HAS_IDX(DT_DRV_INST(inst), pc_idx)
@@ -443,7 +446,8 @@
  *
  * @param inst instance number
  * @param name lowercase-and-underscores pinctrl property name to check
- * @return 1 if the property exists, 0 otherwise
+ * @retval 1 if the property exists
+ * @retval 0 otherwise
  */
 #define DT_INST_PINCTRL_HAS_NAME(inst, name) \
 	DT_PINCTRL_HAS_NAME(DT_DRV_INST(inst), name)

--- a/include/zephyr/devicetree/spi.h
+++ b/include/zephyr/devicetree/spi.h
@@ -48,7 +48,8 @@ extern "C" {
  *     DT_SPI_HAS_CS_GPIOS(DT_NODELABEL(spi2)) // 0
  *
  * @param spi a SPI bus controller node identifier
- * @return 1 if "spi" has a cs-gpios property, 0 otherwise
+ * @retval 1 if "spi" has a cs-gpios property
+ * @retval 0 otherwise
  */
 #define DT_SPI_HAS_CS_GPIOS(spi) DT_NODE_HAS_PROP(spi, cs_gpios)
 
@@ -73,8 +74,8 @@ extern "C" {
  *     DT_SPI_NUM_CS_GPIOS(DT_NODELABEL(spi2)) // 0
  *
  * @param spi a SPI bus controller node identifier
- * @return Logical length of spi's cs-gpios property, or 0 if "spi" doesn't
- *         have a cs-gpios property
+ * @return Logical length of spi's cs-gpios property
+ * @retval 0 if "spi" doesn't have a cs-gpios property
  */
 #define DT_SPI_NUM_CS_GPIOS(spi) \
 	COND_CODE_1(DT_SPI_HAS_CS_GPIOS(spi), \
@@ -112,8 +113,9 @@ extern "C" {
  *     DT_SPI_DEV_HAS_CS_GPIOS(DT_NODELABEL(c)) // 0
  *
  * @param spi_dev a SPI device node identifier
- * @return 1 if spi_dev's bus node DT_BUS(spi_dev) has a chip select
- *         pin at index DT_REG_ADDR(spi_dev), 0 otherwise
+ * @retval 1 if spi_dev's bus node DT_BUS(spi_dev) has a chip select
+ *         pin at index DT_REG_ADDR(spi_dev)
+ * @retval 0 otherwise
  */
 #define DT_SPI_DEV_HAS_CS_GPIOS(spi_dev) DT_SPI_HAS_CS_GPIOS(DT_BUS(spi_dev))
 
@@ -206,8 +208,8 @@ extern "C" {
  * cs-gpios property has no flags cell, this expands to zero.
  *
  * @param spi_dev a SPI device node identifier
- * @return flags value of spi_dev's chip select GPIO specifier, or
- *         zero if there is none
+ * @return flags value of spi_dev's chip select GPIO specifier
+ * @retval 0 if there is none
  */
 #define DT_SPI_DEV_CS_GPIOS_FLAGS(spi_dev) \
 	DT_GPIO_FLAGS_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR_RAW(spi_dev))
@@ -215,8 +217,9 @@ extern "C" {
 /**
  * @brief Equivalent to DT_SPI_DEV_HAS_CS_GPIOS(DT_DRV_INST(inst)).
  * @param inst DT_DRV_COMPAT instance number
- * @return 1 if the instance's bus has a CS pin at index
- *         DT_INST_REG_ADDR(inst), 0 otherwise
+ * @retval 1 if the instance's bus has a CS pin at index
+ *         DT_INST_REG_ADDR(inst)
+ * @retval 0 otherwise
  * @see DT_SPI_DEV_HAS_CS_GPIOS()
  */
 #define DT_INST_SPI_DEV_HAS_CS_GPIOS(inst) \
@@ -244,8 +247,8 @@ extern "C" {
 /**
  * @brief DT_SPI_DEV_CS_GPIOS_FLAGS(DT_DRV_INST(inst)).
  * @param inst DT_DRV_COMPAT instance number
- * @return flags value of the instance's chip select GPIO specifier,
- *         or zero if there is none
+ * @return flags value of the instance's chip select GPIO specifier
+ * @retval 0 if there is none
  * @see DT_SPI_DEV_CS_GPIOS_FLAGS()
  */
 #define DT_INST_SPI_DEV_CS_GPIOS_FLAGS(inst) \


### PR DESCRIPTION
Fix how Doxygen special commands \retval and \return are used in DT API doc text.

From Doxygen documentation:
"\retval: Starts a description for a function's return value with name .
\return: Starts a return value description for a function."

See https://www.doxygen.nl/manual/commands.html#cmdreturn
https://www.doxygen.nl/manual/commands.html#cmdretval

Doc build https://builds.zephyrproject.io/zephyr/pr/97878/docs/index.html