### PR TITLE
include: net: fix Doxygen \retval & \return commands usage

### DIFF
--- a/include/zephyr/net/capture.h
+++ b/include/zephyr/net/capture.h
@@ -70,7 +70,8 @@ struct net_capture_interface_api {
  *        also port number which is used as UDP destination port.
  * @param dev Network capture device. This is returned to the caller.
  *
- * @return 0 if ok, <0 if network packet capture setup failed
+ * @retval 0 if ok
+ * @retval <0 if network packet capture setup failed
  */
 int net_capture_setup(const char *remote_addr, const char *my_local_addr, const char *peer_addr,
 		      const struct device **dev);
@@ -84,7 +85,8 @@ int net_capture_setup(const char *remote_addr, const char *my_local_addr, const 
  * @param dev Network capture device. User must allocate using the
  *            net_capture_setup() function.
  *
- * @return 0 if ok, <0 if network packet capture cleanup failed
+ * @retval 0 if ok
+ * @retval <0 if network packet capture cleanup failed
  */
 static inline int net_capture_cleanup(const struct device *dev)
 {
@@ -110,7 +112,8 @@ static inline int net_capture_cleanup(const struct device *dev)
  * @param dev Network capture device
  * @param iface Network interface we are starting to capture packets.
  *
- * @return 0 if ok, <0 if network packet capture enable failed
+ * @retval 0 if ok
+ * @retval <0 if network packet capture enable failed
  */
 static inline int net_capture_enable(const struct device *dev, struct net_if *iface)
 {
@@ -133,7 +136,8 @@ static inline int net_capture_enable(const struct device *dev, struct net_if *if
  * @param dev Network capture device. If set to NULL, then the
  *            default capture device is used.
  *
- * @return True if enabled, False if network capture is disabled.
+ * @retval true if enabled
+ * @retval false if network capture is disabled.
  */
 static inline bool net_capture_is_enabled(const struct device *dev)
 {
@@ -163,7 +167,8 @@ static inline bool net_capture_is_enabled(const struct device *dev)
  *
  * @param dev Network capture device
  *
- * @return 0 if ok, <0 if network packet capture disable failed
+ * @retval 0 if ok
+ * @retval <0 if network packet capture disable failed
  */
 static inline int net_capture_disable(const struct device *dev)
 {
@@ -188,7 +193,8 @@ static inline int net_capture_disable(const struct device *dev)
  * @param iface Network interface the packet is being sent
  * @param pkt The network packet that is sent
  *
- * @return 0 if ok, <0 if network packet capture send failed
+ * @retval 0 if ok
+ * @retval <0 if network packet capture send failed
  */
 static inline int net_capture_send(const struct device *dev, struct net_if *iface,
 				   struct net_pkt *pkt)
@@ -233,7 +239,8 @@ static inline void net_capture_pkt(struct net_if *iface, struct net_pkt *pkt)
  * @param iface Network interface the packet is being sent
  * @param pkt The network packet that is sent
  *
- * @return 0 if captured packet was handled ok, <0 if the capture failed
+ * @retval 0 if captured packet was handled ok
+ * @retval <0 if the capture failed
  */
 #if defined(CONFIG_NET_CAPTURE)
 int net_capture_pkt_with_status(struct net_if *iface, struct net_pkt *pkt);
@@ -278,7 +285,8 @@ struct net_capture_cooked {
  * @param halen Link-layer address length (maximum is 8 bytes)
  * @param addr Link-layer address
  *
- * @return 0 if ok, <0 if context initialization failed
+ * @retval 0 if ok
+ * @retval <0 if context initialization failed
  */
 #if defined(CONFIG_NET_CAPTURE_COOKED_MODE)
 int net_capture_cooked_setup(struct net_capture_cooked *ctx,

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -447,7 +447,8 @@ uint8_t coap_header_get_code(const struct coap_packet *cpkt);
  *
  * @param cpkt CoAP packet representation
  * @param code CoAP code
- * @return 0 on success, -EINVAL on failure
+ * @retval 0 on success
+ * @retval -EINVAL on failure
  */
 int coap_header_set_code(const struct coap_packet *cpkt, uint8_t code);
 
@@ -479,8 +480,8 @@ const uint8_t *coap_packet_get_payload(const struct coap_packet *cpkt,
  * @param options Parsed options from coap_packet_parse()
  * @param opt_num Number of options
  *
- * @return true if the CoAP URI path matches,
- *        false otherwise.
+ * @retval true if the CoAP URI path matches,
+ * @retval false otherwise.
  */
 bool coap_uri_path_match(const char * const *path,
 			 struct coap_option *options,
@@ -512,7 +513,8 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
  * @param cpkt Packet to append path and query options for.
  * @param path Null-terminated string of coap path, query or both.
  *
- * @retval 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_packet_set_path(struct coap_packet *cpkt, const char *path);
 
@@ -529,7 +531,8 @@ int coap_packet_set_path(struct coap_packet *cpkt, const char *path);
  * @param code CoAP header code
  * @param id CoAP header message id
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_packet_init(struct coap_packet *cpkt, uint8_t *data, uint16_t max_len,
 		     uint8_t ver, uint8_t type, uint8_t token_len,
@@ -548,7 +551,8 @@ int coap_packet_init(struct coap_packet *cpkt, uint8_t *data, uint16_t max_len,
  * @param max_len Maximum allowable length of data
  * @param code CoAP header code
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_ack_init(struct coap_packet *cpkt, const struct coap_packet *req,
 		  uint8_t *data, uint16_t max_len, uint8_t code);
@@ -564,7 +568,8 @@ int coap_ack_init(struct coap_packet *cpkt, const struct coap_packet *req,
  * @param data Data that will contain a CoAP packet information
  * @param max_len Maximum allowable length of data
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_rst_init(struct coap_packet *cpkt, const struct coap_packet *req,
 		  uint8_t *data, uint16_t max_len);
@@ -594,7 +599,7 @@ uint16_t coap_next_id(void);
  * @param veclen Number of elements in the options array
  *
  * @return The number of options found in packet matching code,
- * negative on error.
+ * @retval <0 negative on error.
  */
 int coap_find_options(const struct coap_packet *cpkt, uint16_t code,
 		      struct coap_option *options, uint16_t veclen);
@@ -611,7 +616,8 @@ int coap_find_options(const struct coap_packet *cpkt, uint16_t code,
  * packet
  * @param len Size of the data to be added
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_packet_append_option(struct coap_packet *cpkt, uint16_t code,
 			      const uint8_t *value, uint16_t len);
@@ -622,7 +628,8 @@ int coap_packet_append_option(struct coap_packet *cpkt, uint16_t code,
  * @param cpkt Packet to be updated
  * @param code Option code to remove from the packet, see #coap_option_num
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_packet_remove_option(struct coap_packet *cpkt, uint16_t code);
 
@@ -649,7 +656,8 @@ unsigned int coap_option_value_to_int(const struct coap_option *option);
  * @param code Option code to add to the packet, see #coap_option_num
  * @param val Integer value to be added
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_append_option_int(struct coap_packet *cpkt, uint16_t code,
 			   unsigned int val);
@@ -659,7 +667,8 @@ int coap_append_option_int(struct coap_packet *cpkt, uint16_t code,
  *
  * @param cpkt Packet to append the payload marker (0xFF)
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_packet_append_payload_marker(struct coap_packet *cpkt);
 
@@ -670,7 +679,8 @@ int coap_packet_append_payload_marker(struct coap_packet *cpkt);
  * @param payload CoAP packet payload
  * @param payload_len CoAP packet payload len
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_packet_append_payload(struct coap_packet *cpkt, const uint8_t *payload,
 			       uint16_t payload_len);
@@ -680,8 +690,8 @@ int coap_packet_append_payload(struct coap_packet *cpkt, const uint8_t *payload,
  *
  * @param cpkt Packet to be checked.
  *
- * @return true if the packet is a request,
- *        false otherwise.
+ * @retval true if the packet is a request,
+ * @retval false otherwise.
  */
 bool coap_packet_is_request(const struct coap_packet *cpkt);
 
@@ -697,7 +707,7 @@ bool coap_packet_is_request(const struct coap_packet *cpkt);
  * @param addr Peer address
  * @param addr_len Peer address length
  *
- * @retval >= 0 in case of success.
+ * @retval >=0 in case of success.
  * @retval -ENOTSUP in case of invalid request code.
  * @retval -EPERM in case resource handler is not implemented.
  * @retval -ENOENT in case the resource is not found.
@@ -720,7 +730,7 @@ int coap_handle_request_len(struct coap_packet *cpkt,
  * @param addr Peer address
  * @param addr_len Peer address length
  *
- * @retval >= 0 in case of success.
+ * @retval >=0 in case of success.
  * @retval -ENOTSUP in case of invalid request code.
  * @retval -EPERM in case resource handler is not implemented.
  * @retval -ENOENT in case the resource is not found.
@@ -803,7 +813,8 @@ struct coap_block_context {
  * @param block_size The size of the block
  * @param total_size The total size of the transfer, if known
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_block_transfer_init(struct coap_block_context *ctx,
 			     enum coap_block_size block_size,
@@ -819,7 +830,8 @@ int coap_block_transfer_init(struct coap_block_context *ctx,
  * @param ctx Block context from which to retrieve the
  * information for the block option
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_append_descriptive_block_option(struct coap_packet *cpkt, struct coap_block_context *ctx);
 
@@ -831,7 +843,7 @@ int coap_append_descriptive_block_option(struct coap_packet *cpkt, struct coap_b
  *
  * @param cpkt Packet to be checked.
  *
- * @return true if the corresponding block option is set,
+ * @retval true if the corresponding block option is set,
  *        false otherwise.
  */
 bool coap_has_descriptive_block_option(struct coap_packet *cpkt);
@@ -844,7 +856,8 @@ bool coap_has_descriptive_block_option(struct coap_packet *cpkt);
  *
  * @param cpkt Packet to be updated.
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_remove_descriptive_block_option(struct coap_packet *cpkt);
 
@@ -852,8 +865,8 @@ int coap_remove_descriptive_block_option(struct coap_packet *cpkt);
  * @brief Check if BLOCK1 or BLOCK2 option has more flag set
  *
  * @param cpkt Packet to be checked.
- * @return true If more flag is set in BLOCK1 or BLOCK2
- * @return false If MORE flag is not set or BLOCK header not found.
+ * @retval true If more flag is set in BLOCK1 or BLOCK2
+ * @retval false If MORE flag is not set or BLOCK header not found.
  */
 bool coap_block_has_more(struct coap_packet *cpkt);
 
@@ -864,7 +877,8 @@ bool coap_block_has_more(struct coap_packet *cpkt);
  * @param ctx Block context from which to retrieve the
  * information for the Block1 option
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_append_block1_option(struct coap_packet *cpkt,
 			      struct coap_block_context *ctx);
@@ -876,7 +890,8 @@ int coap_append_block1_option(struct coap_packet *cpkt,
  * @param ctx Block context from which to retrieve the
  * information for the Block2 option
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_append_block2_option(struct coap_packet *cpkt,
 			      struct coap_block_context *ctx);
@@ -888,7 +903,8 @@ int coap_append_block2_option(struct coap_packet *cpkt,
  * @param ctx Block context from which to retrieve the
  * information for the Size1 option
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_append_size1_option(struct coap_packet *cpkt,
 			     struct coap_block_context *ctx);
@@ -900,7 +916,8 @@ int coap_append_size1_option(struct coap_packet *cpkt,
  * @param ctx Block context from which to retrieve the
  * information for the Size2 option
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_append_size2_option(struct coap_packet *cpkt,
 			     struct coap_block_context *ctx);
@@ -911,8 +928,8 @@ int coap_append_size2_option(struct coap_packet *cpkt,
  * @param cpkt Packet to be inspected
  * @param code CoAP option code
  *
- * @return Integer value >= 0 in case of success or negative in case
- * of error.
+ * @retval >=0 Integer value in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_get_option_int(const struct coap_packet *cpkt, uint16_t code);
 
@@ -925,7 +942,7 @@ int coap_get_option_int(const struct coap_packet *cpkt, uint16_t code);
  * @param block_number Is set to the number of the block
  *
  * @return Integer value of the block size in case of success
- * or negative in case of error.
+ * @retval <0 negative in case of error.
  */
 int coap_get_block1_option(const struct coap_packet *cpkt, bool *has_more, uint32_t *block_number);
 
@@ -939,7 +956,7 @@ int coap_get_block1_option(const struct coap_packet *cpkt, bool *has_more, uint3
  * @param block_number Is set to the number of the block
  *
  * @return Integer value of the block size in case of success
- * or negative in case of error.
+ * @retval <0 negative in case of error.
  */
 int coap_get_block2_option(const struct coap_packet *cpkt, bool *has_more,
 			   uint32_t *block_number);
@@ -951,7 +968,8 @@ int coap_get_block2_option(const struct coap_packet *cpkt, bool *has_more,
  * @param cpkt Packet in which to look for block-wise transfers options
  * @param ctx Block context to be updated
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_update_from_block(const struct coap_packet *cpkt,
 			   struct coap_block_context *ctx);
@@ -965,8 +983,9 @@ int coap_update_from_block(const struct coap_packet *cpkt,
  * @param ctx Block context to be updated
  * @param option Either COAP_OPTION_BLOCK1 or COAP_OPTION_BLOCK2
  *
- * @return The offset in the block-wise transfer, 0 if the transfer
- * has finished or a negative value in case of an error.
+ * @return The offset in the block-wise transfer
+ * @retval 0 if the transfer has finished
+ * @retval <0 a negative value in case of an error.
  */
 int coap_next_block_for_option(const struct coap_packet *cpkt,
 			       struct coap_block_context *ctx,
@@ -980,8 +999,8 @@ int coap_next_block_for_option(const struct coap_packet *cpkt,
  * @param cpkt Packet in which to look for block-wise transfers options
  * @param ctx Block context to be updated
  *
- * @return The offset in the block-wise transfer, 0 if the transfer
- * has finished.
+ * @return The offset in the block-wise transfer
+ * @retval 0 if the transfer has finished
  */
 size_t coap_next_block(const struct coap_packet *cpkt,
 		       struct coap_block_context *ctx);
@@ -1005,7 +1024,7 @@ void coap_observer_init(struct coap_observer *observer,
  * @param resource Resource to add an observer
  * @param observer Observer to be added
  *
- * @return true if this is the first observer added to this resource.
+ * @retval true if this is the first observer added to this resource.
  */
 bool coap_register_observer(struct coap_resource *resource,
 			    struct coap_observer *observer);
@@ -1017,7 +1036,7 @@ bool coap_register_observer(struct coap_resource *resource,
  * @param resource Resource in which to remove the observer
  * @param observer Observer to be removed
  *
- * @return true if the observer was found and removed.
+ * @retval true if the observer was found and removed.
  */
 bool coap_remove_observer(struct coap_resource *resource,
 			  struct coap_observer *observer);
@@ -1032,8 +1051,8 @@ bool coap_remove_observer(struct coap_resource *resource,
  * @param token Pointer to the token
  * @param token_len Length of valid bytes in the token
  *
- * @return A pointer to a observer if a match is found, NULL
- * otherwise.
+ * @return A pointer to a observer if a match is found
+ * @retval NULL otherwise.
  */
 struct coap_observer *coap_find_observer(
 	struct coap_observer *observers, size_t len,
@@ -1050,8 +1069,8 @@ struct coap_observer *coap_find_observer(
  * @note The function coap_find_observer() should be preferred
  * if both the observer's address and token are known.
  *
- * @return A pointer to a observer if a match is found, NULL
- * otherwise.
+ * @return A pointer to a observer if a match is found
+ * @retval NULL otherwise.
  */
 struct coap_observer *coap_find_observer_by_addr(
 	struct coap_observer *observers, size_t len,
@@ -1068,8 +1087,8 @@ struct coap_observer *coap_find_observer_by_addr(
  * @note The function coap_find_observer() should be preferred
  * if both the observer's address and token are known.
  *
- * @return A pointer to a observer if a match is found, NULL
- * otherwise.
+ * @return A pointer to a observer if a match is found
+ * @retval NULL otherwise.
  */
 struct coap_observer *coap_find_observer_by_token(
 	struct coap_observer *observers, size_t len,
@@ -1082,7 +1101,7 @@ struct coap_observer *coap_find_observer_by_token(
  * @param len Size of the array of observers
  *
  * @return A pointer to a observer if there's an available observer,
- * NULL otherwise.
+ * @retval NULL otherwise.
  */
 struct coap_observer *coap_observer_next_unused(
 	struct coap_observer *observers, size_t len);
@@ -1110,7 +1129,8 @@ void coap_reply_init(struct coap_reply *reply,
  * @param params Pointer to the CoAP transmission parameters struct,
  * or NULL to use default values
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_pending_init(struct coap_pending *pending,
 		      const struct coap_packet *request,
@@ -1124,8 +1144,8 @@ int coap_pending_init(struct coap_pending *pending,
  * @param pendings Pointer to the array of #coap_pending structures
  * @param len Size of the array of #coap_pending structures
  *
- * @return pointer to a free #coap_pending structure, NULL in case
- * none could be found.
+ * @return pointer to a free #coap_pending structure
+ * @retval NULL in case none could be found.
  */
 struct coap_pending *coap_pending_next_unused(
 	struct coap_pending *pendings, size_t len);
@@ -1137,8 +1157,8 @@ struct coap_pending *coap_pending_next_unused(
  * @param replies Pointer to the array of #coap_reply structures
  * @param len Size of the array of #coap_reply structures
  *
- * @return pointer to a free #coap_reply structure, NULL in case
- * none could be found.
+ * @return pointer to a free #coap_reply structure
+ * @retval NULL in case none could be found.
  */
 struct coap_reply *coap_reply_next_unused(
 	struct coap_reply *replies, size_t len);
@@ -1153,8 +1173,8 @@ struct coap_reply *coap_reply_next_unused(
  * @param pendings Pointer to the array of #coap_reply structures
  * @param len Size of the array of #coap_reply structures
  *
- * @return pointer to the associated #coap_pending structure, NULL in
- * case none could be found.
+ * @return pointer to the associated #coap_pending structure
+ * @retval NULL in case none could be found.
  */
 struct coap_pending *coap_pending_received(
 	const struct coap_packet *response,
@@ -1169,8 +1189,8 @@ struct coap_pending *coap_pending_received(
  * @param replies Pointer to the array of #coap_reply structures
  * @param len Size of the array of #coap_reply structures
  *
- * @return Pointer to the reply matching the packet received, NULL if
- * none could be found.
+ * @return Pointer to the reply matching the packet received
+ * @retval NULL if none could be found.
  */
 struct coap_reply *coap_response_received(
 	const struct coap_packet *response,
@@ -1184,8 +1204,8 @@ struct coap_reply *coap_response_received(
  * @param pendings Pointer to the array of #coap_pending structures
  * @param len Size of the array of #coap_pending structures
  *
- * @return The next #coap_pending to expire, NULL if none is about to
- * expire.
+ * @return The next #coap_pending to expire
+ * @retval NULL if none is about to expire.
  */
 struct coap_pending *coap_pending_next_to_expire(
 	struct coap_pending *pendings, size_t len);
@@ -1196,7 +1216,7 @@ struct coap_pending *coap_pending_next_to_expire(
  *
  * @param pending Pending representation to have its timeout updated
  *
- * @return false if this is the last retransmission.
+ * @retval false if this is the last retransmission.
  */
 bool coap_pending_cycle(struct coap_pending *pending);
 
@@ -1248,7 +1268,8 @@ void coap_replies_clear(struct coap_reply *replies, size_t len);
  *
  * @param resource Resource that was updated
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_resource_notify(struct coap_resource *resource);
 
@@ -1257,8 +1278,8 @@ int coap_resource_notify(struct coap_resource *resource);
  *
  * @param request Request to be checked
  *
- * @return True if the request is enabling observing a resource, False
- * otherwise
+ * @retval true if the request is enabling observing a resource
+ * @retval false otherwise
  */
 bool coap_request_is_observe(const struct coap_packet *request);
 

--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -181,7 +181,8 @@ struct coap_client {
  * @param[in] info Name for the receiving thread of the client. Setting this NULL will result as
  *                 default name of "coap_client".
  *
- * @return int Zero on success, otherwise a negative error code.
+ * @retval 0 on success
+ * @retval <0 a negative error code otherwise.
  */
 int coap_client_init(struct coap_client *client, const char *info);
 
@@ -203,7 +204,8 @@ int coap_client_init(struct coap_client *client, const char *info);
  * @param addr the destination address of the request, NULL if socket is already connected.
  * @param req CoAP request structure
  * @param params Pointer to transmission parameters structure or NULL to use default values.
- * @return zero when operation started successfully or negative error code otherwise.
+ * @retval 0 when operation started successfully
+ * @retval <0 negative error code otherwise.
  */
 
 int coap_client_req(struct coap_client *client, int sock, const struct sockaddr *addr,
@@ -262,7 +264,8 @@ struct coap_client_option coap_client_option_initial_block2(void);
  *
  * @param client Pointer to the CoAP client instance.
  *
- * @return true if there is an ongoing exchange, false otherwise.
+ * @retval true if there is an ongoing exchange
+ * @retval false otherwise.
  */
 bool coap_client_has_ongoing_exchange(struct coap_client *client);
 

--- a/include/zephyr/net/coap_link_format.h
+++ b/include/zephyr/net/coap_link_format.h
@@ -39,7 +39,8 @@ extern "C" {
  * @param data A data pointer to be used to build the CoAP response
  * @param data_len The maximum length of the data buffer
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_well_known_core_get(struct coap_resource *resource,
 			     const struct coap_packet *request,
@@ -56,7 +57,8 @@ int coap_well_known_core_get(struct coap_resource *resource,
  * @param data A data pointer to be used to build the CoAP response
  * @param data_len The maximum length of the data buffer
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_well_known_core_get_len(struct coap_resource *resources,
 				 size_t resources_len,

--- a/include/zephyr/net/coap_service.h
+++ b/include/zephyr/net/coap_service.h
@@ -271,7 +271,7 @@ int coap_service_stop(const struct coap_service *service);
  * @param service Pointer to CoAP service
  * @retval 1 if the service is running
  * @retval 0 if the service is stopped
- * @retval negative in case of an error.
+ * @retval <0 negative in case of an error.
  */
 int coap_service_is_running(const struct coap_service *service);
 
@@ -285,7 +285,8 @@ int coap_service_is_running(const struct coap_service *service);
  * @param addr Peer address
  * @param addr_len Peer address length
  * @param params Pointer to transmission parameters structure or NULL to use default values.
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_service_send(const struct coap_service *service, const struct coap_packet *cpkt,
 		      const struct sockaddr *addr, socklen_t addr_len,
@@ -301,7 +302,8 @@ int coap_service_send(const struct coap_service *service, const struct coap_pack
  * @param addr Peer address
  * @param addr_len Peer address length
  * @param params Pointer to transmission parameters structure or NULL to use default values.
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_resource_send(const struct coap_resource *resource, const struct coap_packet *cpkt,
 		       const struct sockaddr *addr, socklen_t addr_len,
@@ -318,7 +320,8 @@ int coap_resource_send(const struct coap_resource *resource, const struct coap_p
  * @param resource Pointer to CoAP resource
  * @param request CoAP request to parse
  * @param addr Peer address
- * @return the observe option value in case of success or negative in case of error.
+ * @return the observe option value in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_resource_parse_observe(struct coap_resource *resource, const struct coap_packet *request,
 				const struct sockaddr *addr);
@@ -330,7 +333,8 @@ int coap_resource_parse_observe(struct coap_resource *resource, const struct coa
  *
  * @param resource Pointer to CoAP resource
  * @param addr Peer address
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_resource_remove_observer_by_addr(struct coap_resource *resource,
 					  const struct sockaddr *addr);
@@ -343,7 +347,8 @@ int coap_resource_remove_observer_by_addr(struct coap_resource *resource,
  * @param resource Pointer to CoAP resource
  * @param token Pointer to the token
  * @param token_len Length of valid bytes in the token
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success
+ * @retval <0 negative in case of error.
  */
 int coap_resource_remove_observer_by_token(struct coap_resource *resource,
 					   const uint8_t *token, uint8_t token_len);

--- a/include/zephyr/net/conn_mgr_connectivity.h
+++ b/include/zephyr/net/conn_mgr_connectivity.h
@@ -138,7 +138,7 @@ enum conn_mgr_if_flag {
  * @retval 0 on success.
  * @retval -ESHUTDOWN if the iface is not admin-up.
  * @retval -ENOTSUP if the iface does not have a connectivity implementation.
- * @retval implementation-specific status code otherwise.
+ * @return implementation-specific status code otherwise.
  */
 int conn_mgr_if_connect(struct net_if *iface);
 
@@ -154,7 +154,7 @@ int conn_mgr_if_connect(struct net_if *iface);
  *
  * @retval 0 on success.
  * @retval -ENOTSUP if the iface does not have a connectivity implementation.
- * @retval implementation-specific status code otherwise.
+ * @return implementation-specific status code otherwise.
  */
 int conn_mgr_if_disconnect(struct net_if *iface);
 
@@ -185,7 +185,7 @@ bool conn_mgr_if_is_bound(struct net_if *iface);
  * @retval -ENOBUFS if optlen is too long.
  * @retval -EINVAL if NULL optval pointer provided.
  * @retval -ENOPROTOOPT if the optname is not recognized.
- * @retval implementation-specific error code otherwise.
+ * @return implementation-specific error code otherwise.
  */
 int conn_mgr_if_set_opt(struct net_if *iface, int optname, const void *optval, size_t optlen);
 
@@ -213,7 +213,7 @@ int conn_mgr_if_set_opt(struct net_if *iface, int optname, const void *optval, s
  * @retval -EINVAL if invalid retrieval buffer length is provided, or if NULL optval or
  *		   optlen pointer provided.
  * @retval -ENOPROTOOPT if the optname is not recognized.
- * @retval implementation-specific error code otherwise.
+ * @return implementation-specific error code otherwise.
  */
 int conn_mgr_if_get_opt(struct net_if *iface, int optname, void *optval, size_t *optlen);
 
@@ -225,7 +225,8 @@ int conn_mgr_if_get_opt(struct net_if *iface, int optname, void *optval, size_t 
  *
  * @param iface - Pointer to the network interface to check.
  * @param flag - The flag to check.
- * @return True if the flag is set, otherwise False.
+ * @retval true if the flag is set
+ * @retval false otherwise.
  *	   Also returns False if the provided iface is not bound to a connectivity implementation,
  *	   or the requested flag doesn't exist.
  */
@@ -253,8 +254,8 @@ int conn_mgr_if_set_flag(struct net_if *iface, enum conn_mgr_if_flag flag, bool 
  * in seconds for it.
  *
  * @param iface - Pointer to the iface to check.
- * @return int - The connectivity timeout value (in seconds) if it could be retrieved, otherwise
- *		 CONN_MGR_IF_NO_TIMEOUT.
+ * @retval timeout The connectivity timeout value (in seconds) if it could be retrieved
+ * @retval CONN_MGR_IF_NO_TIMEOUT otherwise.
  */
 int conn_mgr_if_get_timeout(struct net_if *iface);
 
@@ -279,8 +280,8 @@ int conn_mgr_if_set_timeout(struct net_if *iface, int timeout);
  * setting in seconds for it.
  *
  * @param iface - Pointer to the iface to check.
- * @return int - The connectivity timeout value (in seconds) if it could be retrieved, otherwise
- *		 CONN_MGR_IF_NO_TIMEOUT.
+ * @retval timeout The connectivity timeout value (in seconds) if it could be retrieved
+ * @retval CONN_MGR_IF_NO_TIMEOUT otherwise.
  */
 int conn_mgr_if_get_idle_timeout(struct net_if *iface);
 
@@ -331,8 +332,8 @@ void conn_mgr_if_used(struct net_if *iface);
  *
  * @param skip_ignored - If true, only affect ifaces that aren't ignored by conn_mgr.
  *			 Otherwise, affect all ifaces.
- * @return 0 if all net_if_up calls returned 0, otherwise the first nonzero value
- *         returned by a net_if_up call.
+ * @retval 0 if all net_if_up calls returned 0
+ * @retval val otherwise the first nonzero value returned by a net_if_up call.
  */
 int conn_mgr_all_if_up(bool skip_ignored);
 
@@ -344,8 +345,8 @@ int conn_mgr_all_if_up(bool skip_ignored);
  *
  * @param skip_ignored - If true, only affect ifaces that aren't ignored by conn_mgr.
  *			 Otherwise, affect all ifaces.
- * @return 0 if all net_if_down calls returned 0, otherwise the first nonzero value
- *         returned by a net_if_down call.
+ * @retval 0 if all net_if_down calls returned 0
+ * @retval val otherwise the first nonzero value returned by a net_if_down call.
  */
 int conn_mgr_all_if_down(bool skip_ignored);
 
@@ -357,8 +358,9 @@ int conn_mgr_all_if_down(bool skip_ignored);
  *
  * @param skip_ignored - If true, only affect ifaces that aren't ignored by conn_mgr.
  *			 Otherwise, affect all ifaces.
- * @return 0 if all net_if_up and conn_mgr_if_connect calls returned 0, otherwise the first nonzero
- *	   value returned by either net_if_up or conn_mgr_if_connect.
+ * @retval 0 if all net_if_up and conn_mgr_if_connect calls returned 0
+ * @retval val otherwise the first nonzero value returned by either net_if_up
+ *             or conn_mgr_if_connect.
  */
 int conn_mgr_all_if_connect(bool skip_ignored);
 
@@ -370,8 +372,9 @@ int conn_mgr_all_if_connect(bool skip_ignored);
  *
  * @param skip_ignored - If true, only affect ifaces that aren't ignored by conn_mgr.
  *			 Otherwise, affect all ifaces.
- * @return 0 if all net_if_up and conn_mgr_if_connect calls returned 0, otherwise the first nonzero
- *	   value returned by either net_if_up or conn_mgr_if_connect.
+ * @retval 0 if all net_if_up and conn_mgr_if_connect calls returned 0
+ * @retval val otherwise the first nonzero value returned by either net_if_up
+ *             or conn_mgr_if_connect.
  */
 int conn_mgr_all_if_disconnect(bool skip_ignored);
 

--- a/include/zephyr/net/dhcpv4.h
+++ b/include/zephyr/net/dhcpv4.h
@@ -152,14 +152,16 @@ static inline void net_dhcpv4_init_option_callback(struct net_dhcpv4_option_call
 /**
  * @brief Add an application callback.
  * @param cb A valid application's callback structure pointer.
- * @return 0 if successful, negative errno code on failure.
+ * @retval 0 if successful
+ * @retval <0 negative errno code on failure.
  */
 int net_dhcpv4_add_option_callback(struct net_dhcpv4_option_callback *cb);
 
 /**
  * @brief Remove an application callback.
  * @param cb A valid application's callback structure pointer.
- * @return 0 if successful, negative errno code on failure.
+ * @retval 0 if successful
+ * @retval <0 negative errno code on failure.
  */
 int net_dhcpv4_remove_option_callback(struct net_dhcpv4_option_callback *cb);
 
@@ -190,14 +192,16 @@ net_dhcpv4_init_option_vendor_callback(struct net_dhcpv4_option_callback *callba
 /**
  * @brief Add an application callback for encapsulated vendor-specific options.
  * @param cb A valid application's callback structure pointer.
- * @return 0 if successful, negative errno code on failure.
+ * @retval 0 if successful
+ * @retval <0 negative errno code on failure.
  */
 int net_dhcpv4_add_option_vendor_callback(struct net_dhcpv4_option_callback *cb);
 
 /**
  * @brief Remove an application callback for encapsulated vendor-specific options.
  * @param cb A valid application's callback structure pointer.
- * @return 0 if successful, negative errno code on failure.
+ * @retval 0 if successful
+ * @retval <0 negative errno code on failure.
  */
 int net_dhcpv4_remove_option_vendor_callback(struct net_dhcpv4_option_callback *cb);
 

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -211,7 +211,8 @@ struct dns_socket_dispatcher;
  * @param buf Pointer to data buffer containing the DNS message.
  * @param data_len Length of the data in buffer chain.
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 typedef int (*dns_socket_dispatcher_cb)(struct dns_socket_dispatcher *ctx, int sock,
 					struct sockaddr *addr, size_t addrlen,
@@ -263,7 +264,8 @@ struct dns_socket_dispatcher {
  *
  * @param ctx DNS socket dispatcher context.
  *
- * @return 0 if ok, <1 if error
+ * @retval 0 if ok
+ * @retval <1 if error
  */
 int dns_dispatcher_register(struct dns_socket_dispatcher *ctx);
 
@@ -274,7 +276,8 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx);
  *
  * @param ctx DNS socket dispatcher context.
  *
- * @return 0 if ok, <1 if error
+ * @retval 0 if ok
+ * @retval <1 if error
  */
 int dns_dispatcher_unregister(struct dns_socket_dispatcher *ctx);
 
@@ -575,7 +578,8 @@ struct mdns_responder_context {
  * is NULL terminated. Port numbers are optional in struct sockaddr, the
  * default will be used if set to 0.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int dns_resolve_init(struct dns_resolve_context *ctx,
 		     const char *dns_servers_str[],
@@ -586,7 +590,8 @@ int dns_resolve_init(struct dns_resolve_context *ctx,
  *
  * @param ctx DNS context.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int dns_resolve_init_default(struct dns_resolve_context *ctx);
 
@@ -598,7 +603,8 @@ int dns_resolve_init_default(struct dns_resolve_context *ctx);
  *
  * @param ctx DNS context
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int dns_resolve_close(struct dns_resolve_context *ctx);
 
@@ -620,7 +626,8 @@ int dns_resolve_close(struct dns_resolve_context *ctx);
  * default will be used if set to 0.
  * @param source Source of the DNS servers, e.g., manual, DHCPv4/6, etc.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int dns_resolve_reconfigure(struct dns_resolve_context *ctx,
 			    const char *servers_str[],
@@ -647,7 +654,8 @@ int dns_resolve_reconfigure(struct dns_resolve_context *ctx,
  *        the same length as the servers_str and servers_sa arrays.
  * @param source Source of the DNS servers, e.g., manual, DHCPv4/6, etc.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int dns_resolve_reconfigure_with_interfaces(struct dns_resolve_context *ctx,
 					    const char *servers_str[],
@@ -661,7 +669,8 @@ int dns_resolve_reconfigure_with_interfaces(struct dns_resolve_context *ctx,
  * @param ctx DNS context
  * @param if_index Network interface from which the DNS servers are removed.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int dns_resolve_remove(struct dns_resolve_context *ctx, int if_index);
 
@@ -673,7 +682,8 @@ int dns_resolve_remove(struct dns_resolve_context *ctx, int if_index);
  * @param if_index Network interface from which the DNS servers are removed.
  * @param source Source of the DNS servers, e.g., manual, DHCPv4/6, etc.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int dns_resolve_remove_source(struct dns_resolve_context *ctx, int if_index,
 			      enum dns_server_source source);
@@ -689,7 +699,8 @@ int dns_resolve_remove_source(struct dns_resolve_context *ctx, int if_index,
  *        This is an array of network interface indices. The array must be
  *        the same length as the servers_sa array.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int dns_resolve_remove_server_addresses(struct dns_resolve_context *ctx,
 					const struct sockaddr *servers_sa[],
@@ -703,7 +714,8 @@ int dns_resolve_remove_server_addresses(struct dns_resolve_context *ctx,
  * @param ctx DNS context
  * @param dns_id DNS id of the pending query
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int dns_resolve_cancel(struct dns_resolve_context *ctx,
 		       uint16_t dns_id);
@@ -718,7 +730,8 @@ int dns_resolve_cancel(struct dns_resolve_context *ctx,
  * @param query_name Name of the resource we are trying to query (hostname)
  * @param query_type Type of the query (A or AAAA)
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int dns_resolve_cancel_with_name(struct dns_resolve_context *ctx,
 				 uint16_t dns_id,
@@ -750,7 +763,8 @@ int dns_resolve_cancel_with_name(struct dns_resolve_context *ctx,
  *            manually if it takes too long time to finish
  * >0: start the query and let the system timeout it after specified ms
  *
- * @return 0 if resolving was started ok, < 0 otherwise
+ * @retval 0 if resolving was started ok
+ * @retval <0 otherwise
  */
 int dns_resolve_name(struct dns_resolve_context *ctx,
 		     const char *query,
@@ -785,7 +799,8 @@ int dns_resolve_name(struct dns_resolve_context *ctx,
  *            manually if it takes too long time to finish
  * >0: start the query and let the system timeout it after specified ms
  *
- * @return 0 if resolving was started ok, < 0 otherwise
+ * @retval 0 if resolving was started ok
+ * @retval <0 otherwise
  */
 static inline int dns_resolve_service(struct dns_resolve_context *ctx,
 				      const char *query,
@@ -854,7 +869,8 @@ static inline void dns_resolve_enable_packet_forwarding(struct dns_resolve_conte
  *            manually if it takes too long time to finish
  * >0: start the query and let the system timeout it after specified ms
  *
- * @return 0 if resolving was started ok, < 0 otherwise
+ * @retval 0 if resolving was started ok
+ * @retval <0 otherwise
  */
 static inline int dns_get_addr_info(const char *query,
 				    enum dns_query_type type,
@@ -879,7 +895,8 @@ static inline int dns_get_addr_info(const char *query,
  *
  * @param dns_id DNS id of the pending query
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 static inline int dns_cancel_addr_info(uint16_t dns_id)
 {

--- a/include/zephyr/net/dns_sd.h
+++ b/include/zephyr/net/dns_sd.h
@@ -272,7 +272,7 @@ static inline size_t dns_sd_txt_size(const struct dns_sd_rec *rec)
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc6763#section-9">Service Type Enumeration, RFC 6763</a>.
  *
  * @param rec the record to in question
- * @return true if @a rec is a DNS-SD Service Type Enumeration
+ * @retval true if @a rec is a DNS-SD Service Type Enumeration
  */
 bool dns_sd_is_service_type_enumeration(const struct dns_sd_rec *rec);
 

--- a/include/zephyr/net/dsa.h
+++ b/include/zephyr/net/dsa.h
@@ -76,7 +76,8 @@ typedef enum net_verdict (*dsa_net_recv_cb_t)(struct net_if *iface,
  * @param iface Network interface
  * @param cb Receive callback function
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int dsa_register_recv_callback(struct net_if *iface, dsa_net_recv_cb_t cb);
 
@@ -101,8 +102,8 @@ typedef int (*dsa_send_t)(const struct device *dev, struct net_pkt *pkt);
  * @param iface Network interface (master)
  * @param fn Pointer to master interface send method
  *
- * Returns:
- *  - 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int dsa_register_master_tx(struct net_if *iface, dsa_send_t fn);
 
@@ -111,8 +112,8 @@ int dsa_register_master_tx(struct net_if *iface, dsa_send_t fn);
  *
  * @param iface Network interface (master)
  *
- * Returns:
- *  - true if ok, false otherwise
+ * @retval true if ok
+ * @retval false otherwise
  */
 bool dsa_is_port_master(struct net_if *iface);
 
@@ -198,7 +199,7 @@ struct dsa_api {
  * @param[in]  slave_num  Slave port number
  *
  * @return     network interface of the slave if successful
- * @return     NULL if slave port does not exist
+ * @retval NULL if slave port does not exist
  */
 struct net_if *dsa_get_slave_port(struct net_if *iface, int slave_num);
 
@@ -209,7 +210,8 @@ struct net_if *dsa_get_slave_port(struct net_if *iface, int slave_num);
  * @param[in]  reg_addr  The register address
  * @param      value     The value
  *
- * @return     0 if successful, negative if error
+ * @retval     0  if successful
+ * @retval     <0 negative if error
  */
 int dsa_switch_read(struct net_if *iface, uint16_t reg_addr, uint8_t *value);
 
@@ -233,7 +235,8 @@ int dsa_switch_write(struct net_if *iface, uint16_t reg_addr, uint8_t value);
  * @param[in]  tbl_entry_idx  Table entry index
  * @param[in]  flags          Flags
  *
- * @return     0 if successful, negative if error
+ * @retval     0  if successful
+ * @retval     <0 negative if error
  */
 int dsa_switch_set_mac_table_entry(struct net_if *iface,
 					const uint8_t *mac,
@@ -248,7 +251,8 @@ int dsa_switch_set_mac_table_entry(struct net_if *iface,
  * @param      buf            Buffer to receive MAC address
  * @param[in]  tbl_entry_idx  Table entry index
  *
- * @return     0 if successful, negative if error
+ * @retval     0  if successful
+ * @retval     <0 negative if error
  */
 int dsa_switch_get_mac_table_entry(struct net_if *iface,
 					uint8_t *buf,

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -755,7 +755,8 @@ struct net_eth_vlan_hdr {
  *
  * @param addr A valid pointer to a Ethernet MAC address.
  *
- * @return true if address is a broadcast address, false if not
+ * @retval true if address is a broadcast address
+ * @retval false if not
  */
 static inline bool net_eth_is_addr_broadcast(struct net_eth_addr *addr)
 {
@@ -776,7 +777,8 @@ static inline bool net_eth_is_addr_broadcast(struct net_eth_addr *addr)
  *
  * @param addr A valid pointer to an Ethernet MAC address.
  *
- * @return true if address is an all zeroes address, false if not
+ * @retval true if address is an all zeroes address
+ * @retval false if not
  */
 static inline bool net_eth_is_addr_all_zeroes(struct net_eth_addr *addr)
 {
@@ -797,7 +799,8 @@ static inline bool net_eth_is_addr_all_zeroes(struct net_eth_addr *addr)
  *
  * @param addr A valid pointer to a Ethernet MAC address.
  *
- * @return true if address is unspecified, false if not
+ * @retval true if address is unspecified
+ * @retval false if not
  */
 static inline bool net_eth_is_addr_unspecified(struct net_eth_addr *addr)
 {
@@ -818,7 +821,8 @@ static inline bool net_eth_is_addr_unspecified(struct net_eth_addr *addr)
  *
  * @param addr A valid pointer to a Ethernet MAC address.
  *
- * @return true if address is a multicast address, false if not
+ * @retval true if address is a multicast address
+ * @retval false if not
  */
 static inline bool net_eth_is_addr_multicast(struct net_eth_addr *addr)
 {
@@ -845,7 +849,8 @@ static inline bool net_eth_is_addr_multicast(struct net_eth_addr *addr)
  *
  * @param addr A valid pointer to a Ethernet MAC address.
  *
- * @return true if address is a group address, false if not
+ * @retval true if address is a group address
+ * @retval false if not
  */
 static inline bool net_eth_is_addr_group(struct net_eth_addr *addr)
 {
@@ -857,7 +862,8 @@ static inline bool net_eth_is_addr_group(struct net_eth_addr *addr)
  *
  * @param addr A valid pointer to a Ethernet MAC address.
  *
- * @return true if address is valid, false if not
+ * @retval true if address is valid
+ * @retval false if not
  */
 static inline bool net_eth_is_addr_valid(struct net_eth_addr *addr)
 {
@@ -869,7 +875,8 @@ static inline bool net_eth_is_addr_valid(struct net_eth_addr *addr)
  *
  * @param addr A valid pointer to a Ethernet MAC address.
  *
- * @return true if address is a LLDP multicast address, false if not
+ * @retval true if address is a LLDP multicast address
+ * @retval false if not
  */
 static inline bool net_eth_is_addr_lldp_multicast(struct net_eth_addr *addr)
 {
@@ -894,7 +901,8 @@ static inline bool net_eth_is_addr_lldp_multicast(struct net_eth_addr *addr)
  *
  * @param addr A valid pointer to a Ethernet MAC address.
  *
- * @return true if address is a PTP multicast address, false if not
+ * @retval true if address is a PTP multicast address
+ * @retval false if not
  */
 static inline bool net_eth_is_addr_ptp_multicast(struct net_eth_addr *addr)
 {
@@ -975,7 +983,8 @@ enum ethernet_hw_caps net_eth_get_hw_capabilities(struct net_if *iface)
  * @param type configuration type
  * @param config Ethernet configuration
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline
 int net_eth_get_hw_config(struct net_if *iface, enum ethernet_config_type type,
@@ -998,7 +1007,8 @@ int net_eth_get_hw_config(struct net_if *iface, enum ethernet_config_type type,
  * @param iface Interface to use.
  * @param tag VLAN tag to add
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 #if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 int net_eth_vlan_enable(struct net_if *iface, uint16_t tag);
@@ -1018,7 +1028,8 @@ static inline int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
  * @param iface Interface to use.
  * @param tag VLAN tag to remove
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 #if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 int net_eth_vlan_disable(struct net_if *iface, uint16_t tag);
@@ -1040,8 +1051,8 @@ static inline int net_eth_vlan_disable(struct net_if *iface, uint16_t tag)
  *
  * @param iface VLAN network interface.
  *
- * @return VLAN tag for this interface or NET_VLAN_TAG_UNSPEC if VLAN
- * is not configured for that interface.
+ * @return VLAN tag for this interface
+ * @retval NET_VLAN_TAG_UNSPEC if VLAN is not configured for that interface.
  */
 #if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 uint16_t net_eth_get_vlan_tag(struct net_if *iface);
@@ -1060,8 +1071,8 @@ static inline uint16_t net_eth_get_vlan_tag(struct net_if *iface)
  * @param iface Main network interface (not the VLAN one).
  * @param tag VLAN tag
  *
- * @return Network interface related to this tag or NULL if no such interface
- * exists.
+ * @return Network interface related to this tag
+ * @retval NULL if no such interface exists.
  */
 #if defined(CONFIG_NET_VLAN)
 struct net_if *net_eth_get_vlan_iface(struct net_if *iface, uint16_t tag);
@@ -1082,8 +1093,8 @@ struct net_if *net_eth_get_vlan_iface(struct net_if *iface, uint16_t tag)
  * @param iface VLAN network interface. This is used to get the
  *        pointer to ethernet L2 context
  *
- * @return Network interface related to this tag or NULL if no such interface
- * exists.
+ * @return Network interface related to this tag
+ * @retval NULL if no such interface exists.
  */
 #if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 struct net_if *net_eth_get_vlan_main(struct net_if *iface);
@@ -1107,8 +1118,8 @@ struct net_if *net_eth_get_vlan_main(struct net_if *iface)
  * @param ctx Ethernet context
  * @param iface Ethernet network interface
  *
- * @return True if there are enabled VLANs for this network interface,
- *         false if not.
+ * @retval true if there are enabled VLANs for this network interface,
+ * @retval false if not.
  */
 #if defined(CONFIG_NET_VLAN)
 bool net_eth_is_vlan_enabled(struct ethernet_context *ctx,
@@ -1129,7 +1140,8 @@ static inline bool net_eth_is_vlan_enabled(struct ethernet_context *ctx,
  *
  * @param iface Network interface
  *
- * @return True if VLAN is enabled for this network interface, false if not.
+ * @retval true if VLAN is enabled for this network interface
+ * @retval false if not.
  */
 #if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 bool net_eth_get_vlan_status(struct net_if *iface);
@@ -1147,7 +1159,8 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  *
  * @param iface Network interface
  *
- * @return True if this network interface is VLAN one, false if not.
+ * @retval true if this network interface is VLAN one
+ * @retval false if not.
  */
 #if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 bool net_eth_is_vlan_interface(struct net_if *iface);
@@ -1310,7 +1323,8 @@ void net_eth_carrier_off(struct net_if *iface);
  *
  * @param enable on (true) or off (false)
  *
- * @return 0 if mode set or unset was successful, <0 otherwise.
+ * @retval 0 if mode set or unset was successful
+ * @retval <0 otherwise.
  */
 int net_eth_promisc_mode(struct net_if *iface, bool enable);
 
@@ -1321,7 +1335,8 @@ int net_eth_promisc_mode(struct net_if *iface, bool enable);
  *
  * @param enable on (true) or off (false)
  *
- * @return 0 if mode set or unset was successful, <0 otherwise.
+ * @retval 0 if mode set or unset was successful
+ * @retval <0 otherwise.
  */
 int net_eth_txinjection_mode(struct net_if *iface, bool enable);
 
@@ -1333,7 +1348,8 @@ int net_eth_txinjection_mode(struct net_if *iface, bool enable);
  * @param type Filter type, either source or destination
  * @param enable Set (true) or unset (false)
  *
- * @return 0 if filter set or unset was successful, <0 otherwise.
+ * @retval 0 if filter set or unset was successful
+ * @retval <0 otherwise.
  */
 int net_eth_mac_filter(struct net_if *iface, struct net_eth_addr *mac,
 		       enum ethernet_filter_type type, bool enable);
@@ -1343,7 +1359,8 @@ int net_eth_mac_filter(struct net_if *iface, struct net_eth_addr *mac,
  *
  * @param iface Network interface
  *
- * @return Pointer to PHY device if found, NULL if not found.
+ * @return Pointer to PHY device if found
+ * @retval NULL if not found.
  */
 const struct device *net_eth_get_phy(struct net_if *iface);
 
@@ -1352,8 +1369,8 @@ const struct device *net_eth_get_phy(struct net_if *iface);
  *
  * @param iface Network interface
  *
- * @return Pointer to PTP clock if found, NULL if not found or if this
- * ethernet interface does not support PTP.
+ * @return Pointer to PTP clock if found
+ * @retval NULL if not found or if this ethernet interface does not support PTP.
  */
 #if defined(CONFIG_PTP_CLOCK)
 const struct device *net_eth_get_ptp_clock(struct net_if *iface);
@@ -1372,8 +1389,8 @@ static inline const struct device *net_eth_get_ptp_clock(struct net_if *iface)
  *
  * @param index Network interface index
  *
- * @return Pointer to PTP clock if found, NULL if not found or if this
- * ethernet interface index does not support PTP.
+ * @return Pointer to PTP clock if found
+ * @retval NULL if not found or if this ethernet interface index does not support PTP.
  */
 __syscall const struct device *net_eth_get_ptp_clock_by_index(int index);
 
@@ -1382,7 +1399,8 @@ __syscall const struct device *net_eth_get_ptp_clock_by_index(int index);
  *
  * @param iface Network interface
  *
- * @return Port number, no such port if < 0
+ * @return Port number
+ * @retval <0 no such port
  */
 #if defined(CONFIG_NET_L2_PTP)
 int net_eth_get_ptp_port(struct net_if *iface);
@@ -1416,7 +1434,8 @@ static inline void net_eth_set_ptp_port(struct net_if *iface, int port)
  *
  * @param iface Pointer to network interface
  *
- * @return True if interface supports Wi-Fi, False otherwise.
+ * @retval true if interface supports Wi-Fi
+ * @retval false otherwise.
  */
 static inline bool net_eth_type_is_wifi(struct net_if *iface)
 {

--- a/include/zephyr/net/ethernet_bridge.h
+++ b/include/zephyr/net/ethernet_bridge.h
@@ -80,7 +80,8 @@ struct eth_bridge_iface_context {
  * @param br A pointer to a bridge interface
  * @param iface Interface to add
  *
- * @return 0 if OK, negative error code otherwise.
+ * @retval 0 if OK
+ * @retval <0 negative error code otherwise.
  */
 int eth_bridge_iface_add(struct net_if *br, struct net_if *iface);
 
@@ -95,7 +96,8 @@ int eth_bridge_iface_add(struct net_if *br, struct net_if *iface);
  * @param br A pointer to a bridge interface
  * @param iface Interface to remove
  *
- * @return 0 if OK, negative error code otherwise.
+ * @retval 0 if OK
+ * @retval <0 negative error code otherwise.
  */
 int eth_bridge_iface_remove(struct net_if *br, struct net_if *iface);
 
@@ -113,7 +115,8 @@ int eth_bridge_get_index(struct net_if *br);
  *
  * @param index Bridge instance index
  *
- * @return Pointer to bridge interface or NULL if not found.
+ * @return Pointer to bridge interface
+ * @retval NULL if not found.
  */
 struct net_if *eth_bridge_get_by_index(int index);
 

--- a/include/zephyr/net/gptp.h
+++ b/include/zephyr/net/gptp.h
@@ -281,7 +281,8 @@ void gptp_call_phase_dis_cb(void);
  * @param gm_present A pointer to a boolean where status of the
  *        presence of a grand master will be saved.
  *
- * @return Error code. 0 if no error.
+ * @retval 0 if no error.
+ * @retval err error code otherwise
  */
 int gptp_event_capture(struct net_ptp_time *slave_time, bool *gm_present);
 
@@ -320,7 +321,8 @@ void gptp_foreach_port(gptp_port_cb_t cb, void *user_data);
  * @brief Get gPTP domain.
  * @details This contains all the configuration / status of the gPTP domain.
  *
- * @return Pointer to domain or NULL if not found.
+ * @return Pointer to domain
+ * @retval NULL if not found.
  */
 struct gptp_domain *gptp_get_domain(void);
 

--- a/include/zephyr/net/hostname.h
+++ b/include/zephyr/net/hostname.h
@@ -73,7 +73,8 @@ static inline const char *net_hostname_get(void)
  * @param host new hostname as char array.
  * @param len Length of the hostname array.
  *
- * @return 0 if ok, <0 on error
+ * @retval 0 if ok
+ * @retval <0 on error
  */
 #if defined(CONFIG_NET_HOSTNAME_DYNAMIC)
 int net_hostname_set(char *host, size_t len);
@@ -109,7 +110,8 @@ static inline void net_hostname_init(void)
  * to a hexadecimal string.
  * @param postfix_len Length of the hostname_postfix array.
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 #if defined(CONFIG_NET_HOSTNAME_UNIQUE)
 int net_hostname_set_postfix(const uint8_t *hostname_postfix,
@@ -136,7 +138,8 @@ static inline int net_hostname_set_postfix(const uint8_t *hostname_postfix,
  * @param hostname_postfix Pointer to the postfix string to be appended to the network hostname.
  * @param postfix_len Length of the hostname_postfix array.
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 #if defined(CONFIG_NET_HOSTNAME_UNIQUE)
 int net_hostname_set_postfix_str(const uint8_t *hostname_postfix,

--- a/include/zephyr/net/icmp.h
+++ b/include/zephyr/net/icmp.h
@@ -186,7 +186,8 @@ int net_icmp_cleanup_ctx(struct net_icmp_ctx *ctx);
  *        suitable default parameters are used.
  * @param user_data User supplied opaque data passed to the handler. May be NULL.
  *
- * @return Return 0 if the sending succeed, <0 otherwise.
+ * @retval 0 if the sending succeed
+ * @retval <0 otherwise.
  */
 int net_icmp_send_echo_request(struct net_icmp_ctx *ctx,
 			       struct net_if *iface,
@@ -210,7 +211,8 @@ int net_icmp_send_echo_request(struct net_icmp_ctx *ctx,
  *        suitable default parameters are used.
  * @param user_data User supplied opaque data passed to the handler. May be NULL.
  *
- * @return Return 0 if the sending succeed, <0 otherwise.
+ * @retval 0 if the sending succeed
+ * @retval <0 otherwise.
  */
 int net_icmp_send_echo_request_no_wait(struct net_icmp_ctx *ctx,
 				       struct net_if *iface,
@@ -249,7 +251,8 @@ struct net_icmp_offload {
  * @param iface Network interface of the offloaded device.
  * @param ping_handler Function to be called when offloaded ping request is done.
  *
- * @return Return 0 if the register succeed, <0 otherwise.
+ * @retval 0 if the register succeed
+ * @retval <0 otherwise.
  */
 int net_icmp_register_offload_ping(struct net_icmp_offload *ctx,
 				   struct net_if *iface,
@@ -260,7 +263,8 @@ int net_icmp_register_offload_ping(struct net_icmp_offload *ctx,
  *
  * @param ctx ICMP offload context used for this interface.
  *
- * @return Return 0 if the call succeed, <0 otherwise.
+ * @retval 0 if the call succeed
+ * @retval <0 otherwise.
  */
 int net_icmp_unregister_offload_ping(struct net_icmp_offload *ctx);
 
@@ -275,7 +279,8 @@ int net_icmp_unregister_offload_ping(struct net_icmp_offload *ctx);
  *        is received by the offloaded driver. The ICMP response handler
  *        function is returned and the caller should call it when appropriate.
  *
- * @return Return 0 if the call succeed, <0 otherwise.
+ * @retval 0 if the call succeed
+ * @retval <0 otherwise.
  */
 int net_icmp_get_offload_rsp_handler(struct net_icmp_offload *ctx,
 				     net_icmp_handler_t *resp_handler);

--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -1969,7 +1969,8 @@ BUILD_ASSERT(offsetof(struct ieee802154_radio_api, iface_api) == 0);
  *        and its length should be at least 1 byte (ImmAck frames are the
  *        shortest supported frames with 3 bytes excluding FCS).
  *
- * @return true if AR flag is set, false otherwise
+ * @retval true if AR flag is set
+ * @retval false otherwise
  */
 static inline bool ieee802154_is_ar_flag_set(struct net_buf *frag)
 {

--- a/include/zephyr/net/igmp.h
+++ b/include/zephyr/net/igmp.h
@@ -43,7 +43,8 @@ struct igmp_param {
  * @param addr Multicast group to join
  * @param param Optional parameters
  *
- * @return Return 0 if joining was done, <0 otherwise.
+ * @retval 0 if joining was done
+ * @retval <0 otherwise.
  */
 #if defined(CONFIG_NET_IPV4_IGMP)
 int net_ipv4_igmp_join(struct net_if *iface, const struct in_addr *addr,
@@ -66,7 +67,8 @@ static inline int net_ipv4_igmp_join(struct net_if *iface, const struct in_addr 
  * @param iface Network interface where leave message is sent
  * @param addr Multicast group to leave
  *
- * @return Return 0 if leaving is done, <0 otherwise.
+ * @retval 0 if leaving is done
+ * @retval <0 otherwise.
  */
 #if defined(CONFIG_NET_IPV4_IGMP)
 int net_ipv4_igmp_leave(struct net_if *iface, const struct in_addr *addr);

--- a/include/zephyr/net/latmon.h
+++ b/include/zephyr/net/latmon.h
@@ -30,7 +30,8 @@ extern "C" {
  * @brief Callback function type for retrieving latency deltas.
  *
  * @param delta Pointer to store the calculated latency delta in cycles.
- * @return 0 on success, negative errno code on failure.
+ * @retval 0 on success
+ * @retval <0 negative errno code on failure.
  */
 typedef int (*net_latmon_measure_t)(uint32_t *delta);
 
@@ -56,7 +57,7 @@ void net_latmon_start(int latmus, net_latmon_measure_t measure_func);
  * @param socket A valid socket descriptor for listening.
  * @param ip The client's IP address.
  * @return A valid client socket descriptor connected to latmus on success,
- * negative errno code on failure.
+ * @retval <0 negative errno code on failure.
  *
  */
 int net_latmon_connect(int socket, struct in_addr *ip);
@@ -71,7 +72,8 @@ int net_latmon_connect(int socket, struct in_addr *ip);
  * will be bound to the first available address using the build time configured
  * latmus port.
  *
- * @return A valid socket descriptor on success, negative errno code on failure.
+ * @return A valid socket descriptor on success
+ * @retval <0 negative errno code on failure.
  */
 int net_latmon_get_socket(struct sockaddr *bind_addr);
 
@@ -81,8 +83,8 @@ int net_latmon_get_socket(struct sockaddr *bind_addr);
  * @details This function checks whether the latency monitor is currently
  * active and running.
  *
- * @return True if the latency monitor is running, false if it is waiting for a
- * Latmus connection
+ * @retval true if the latency monitor is running
+ * @retval false if it is waiting for a Latmus connection
  */
 bool net_latmon_running(void);
 

--- a/include/zephyr/net/lldp.h
+++ b/include/zephyr/net/lldp.h
@@ -181,7 +181,8 @@ struct net_lldpdu {
  * @param iface Network interface
  * @param lldpdu LLDP data unit struct
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_lldp_config(struct net_if *iface, const struct net_lldpdu *lldpdu);
 
@@ -192,7 +193,8 @@ int net_lldp_config(struct net_if *iface, const struct net_lldpdu *lldpdu);
  * @param tlv LLDP optional TLVs following mandatory part
  * @param len Length of the optional TLVs
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_lldp_config_optional(struct net_if *iface, const uint8_t *tlv,
 			     size_t len);
@@ -224,7 +226,8 @@ typedef enum net_verdict (*net_lldp_recv_cb_t)(struct net_if *iface,
  * @param iface Network interface
  * @param cb Callback function
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_lldp_register_callback(struct net_if *iface, net_lldp_recv_cb_t cb);
 
@@ -233,7 +236,8 @@ int net_lldp_register_callback(struct net_if *iface, net_lldp_recv_cb_t cb);
  *
  * @param iface Network interface
  *
- * @return <0 if error, index in lldp array if iface is found there
+ * @return index in lldp array if iface is found there
+ * @retval <0 if error
  */
 #if defined(CONFIG_NET_LLDP)
 int net_lldp_set_lldpdu(struct net_if *iface);

--- a/include/zephyr/net/loopback.h
+++ b/include/zephyr/net/loopback.h
@@ -21,7 +21,8 @@ extern "C" {
  *
  * @param[in] ratio Value between 0 = no packet loss and 1 = all packets dropped
  *
- * @return 0 on success, otherwise a negative integer.
+ * @retval 0 on success
+ * @retval <0 otherwise a negative integer.
  */
 int loopback_set_packet_drop_ratio(float ratio);
 

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -357,7 +357,8 @@ struct lwm2m_time_series_elem {
  * @param path    Object path of the cached resource.
  * @param element Sample produced by the engine for the cache.
  *
- * @return true to keep the sample, false to discard it.
+ * @retval true to keep the sample
+ * @retval false to discard it.
  */
 typedef bool (*lwm2m_cache_filter_cb_t)(const struct lwm2m_obj_path *path,
 					const struct lwm2m_time_series_elem *element);
@@ -379,7 +380,8 @@ typedef bool (*lwm2m_cache_filter_cb_t)(const struct lwm2m_obj_path *path,
  *                        (typically 0 for non-multi instance resources).
  * @param[out] data_len Length of the data buffer.
  *
- * @return Callback returns a pointer to the data buffer or NULL for failure.
+ * @return Callback returns a pointer to the data buffer
+ * @retval NULL for failure.
  */
 typedef void *(*lwm2m_engine_get_data_cb_t)(uint16_t obj_inst_id,
 					    uint16_t res_id,
@@ -415,7 +417,8 @@ typedef void *(*lwm2m_engine_get_data_cb_t)(uint16_t obj_inst_id,
  * @param[in] offset Offset of the data block. For non-block transfers this is always 0.
  *
  * @return Callback returns a negative error code (errno.h) indicating
- *         reason of failure or 0 for success.
+ *         reason of failure
+ * @retval 0 for success.
  */
 typedef int (*lwm2m_engine_set_data_cb_t)(uint16_t obj_inst_id,
 					  uint16_t res_id, uint16_t res_inst_id,
@@ -436,7 +439,8 @@ typedef int (*lwm2m_engine_set_data_cb_t)(uint16_t obj_inst_id,
  * @param[in] obj_inst_id Object instance ID generating the callback.
  *
  * @return Callback returns a negative error code (errno.h) indicating
- *         reason of failure or 0 for success.
+ *         reason of failure
+ * @retval 0 for success.
  */
 typedef int (*lwm2m_engine_user_cb_t)(uint16_t obj_inst_id);
 
@@ -454,7 +458,8 @@ typedef int (*lwm2m_engine_user_cb_t)(uint16_t obj_inst_id);
  * @param[in] args_len Length of argument payload in bytes.
  *
  * @return Callback returns a negative error code (errno.h) indicating
- *         reason of failure or 0 for success.
+ *         reason of failure
+ * @retval 0 for success.
  */
 typedef int (*lwm2m_engine_execute_cb_t)(uint16_t obj_inst_id,
 					 uint8_t *args, uint16_t args_len);
@@ -520,7 +525,8 @@ typedef int (*lwm2m_engine_execute_cb_t)(uint16_t obj_inst_id,
  *
  * @param[in] error_code New error code.
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_device_add_err(uint8_t error_code);
 
@@ -694,7 +700,8 @@ lwm2m_engine_execute_cb_t lwm2m_firmware_get_update_cb_inst(uint16_t obj_inst_id
  * @param[in] obj_inst_id The instance number to set the callback for.
  * @param[in] cb A callback function to receive the execute event.
  *
- * @return 0 on success, otherwise a negative integer.
+ * @retval 0 on success
+ * @retval <0 otherwise a negative integer.
  */
 int lwm2m_swmgmt_set_activate_cb(uint16_t obj_inst_id, lwm2m_engine_execute_cb_t cb);
 
@@ -707,7 +714,8 @@ int lwm2m_swmgmt_set_activate_cb(uint16_t obj_inst_id, lwm2m_engine_execute_cb_t
  * @param[in] obj_inst_id The instance number to set the callback for.
  * @param[in] cb A callback function to receive the execute event.
  *
- * @return 0 on success, otherwise a negative integer.
+ * @retval 0 on success
+ * @retval <0 otherwise a negative integer.
  */
 int lwm2m_swmgmt_set_deactivate_cb(uint16_t obj_inst_id, lwm2m_engine_execute_cb_t cb);
 
@@ -720,7 +728,8 @@ int lwm2m_swmgmt_set_deactivate_cb(uint16_t obj_inst_id, lwm2m_engine_execute_cb
  * @param[in] obj_inst_id The instance number to set the callback for.
  * @param[in] cb A callback function to receive the execute event.
  *
- * @return 0 on success, otherwise a negative integer.
+ * @retval 0 on success
+ * @retval <0 otherwise a negative integer.
  */
 int lwm2m_swmgmt_set_install_package_cb(uint16_t obj_inst_id, lwm2m_engine_execute_cb_t cb);
 
@@ -733,7 +742,8 @@ int lwm2m_swmgmt_set_install_package_cb(uint16_t obj_inst_id, lwm2m_engine_execu
  * @param[in] obj_inst_id The instance number to set the callback for.
  * @param[in] cb A callback function for handling the execute event.
  *
- * @return 0 on success, otherwise a negative integer.
+ * @retval 0 on success
+ * @retval <0 otherwise a negative integer.
  */
 int lwm2m_swmgmt_set_delete_package_cb(uint16_t obj_inst_id, lwm2m_engine_execute_cb_t cb);
 
@@ -746,7 +756,8 @@ int lwm2m_swmgmt_set_delete_package_cb(uint16_t obj_inst_id, lwm2m_engine_execut
  * @param[in] obj_inst_id The instance number to set the callback for.
  * @param[in] cb A callback function for handling the read event.
  *
- * @return 0 on success, otherwise a negative integer.
+ * @retval 0 on success
+ * @retval <0 otherwise a negative integer.
  */
 int lwm2m_swmgmt_set_read_package_version_cb(uint16_t obj_inst_id, lwm2m_engine_get_data_cb_t cb);
 
@@ -759,7 +770,8 @@ int lwm2m_swmgmt_set_read_package_version_cb(uint16_t obj_inst_id, lwm2m_engine_
  * @param[in] obj_inst_id The instance number to set the callback for.
  * @param[in] cb A callback function for handling the block write event.
  *
- * @return 0 on success, otherwise a negative integer.
+ * @retval 0 on success
+ * @retval <0 otherwise a negative integer.
  */
 int lwm2m_swmgmt_set_write_package_cb(uint16_t obj_inst_id, lwm2m_engine_set_data_cb_t cb);
 
@@ -816,7 +828,8 @@ struct lwm2m_objlnk {
  * @param[in] path LwM2M path as a struct
  * @param[in] period_s Value of pmin to be given (in seconds).
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_update_observer_min_period(struct lwm2m_ctx *client_ctx,
 				     const struct lwm2m_obj_path *path, uint32_t period_s);
@@ -833,7 +846,8 @@ int lwm2m_update_observer_min_period(struct lwm2m_ctx *client_ctx,
  * @param[in] path LwM2M path as a struct
  * @param[in] period_s Value of pmax to be given (in seconds).
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_update_observer_max_period(struct lwm2m_ctx *client_ctx,
 				     const struct lwm2m_obj_path *path, uint32_t period_s);
@@ -847,7 +861,8 @@ int lwm2m_update_observer_max_period(struct lwm2m_ctx *client_ctx,
  *
  * @param[in] path LwM2M path as a struct
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_create_object_inst(const struct lwm2m_obj_path *path);
 
@@ -858,7 +873,8 @@ int lwm2m_create_object_inst(const struct lwm2m_obj_path *path);
  *
  * @param[in] path LwM2M path as a struct
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_delete_object_inst(const struct lwm2m_obj_path *path);
 
@@ -884,7 +900,8 @@ void lwm2m_registry_unlock(void);
  * @param[in] data_ptr Data buffer
  * @param[in] data_len Length of buffer
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_opaque(const struct lwm2m_obj_path *path, const char *data_ptr, uint16_t data_len);
 
@@ -894,7 +911,8 @@ int lwm2m_set_opaque(const struct lwm2m_obj_path *path, const char *data_ptr, ui
  * @param[in] path LwM2M path as a struct
  * @param[in] data_ptr NULL terminated char buffer
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_string(const struct lwm2m_obj_path *path, const char *data_ptr);
 
@@ -904,7 +922,8 @@ int lwm2m_set_string(const struct lwm2m_obj_path *path, const char *data_ptr);
  * @param[in] path LwM2M path as a struct
  * @param[in] value u8 value
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_u8(const struct lwm2m_obj_path *path, uint8_t value);
 
@@ -914,7 +933,8 @@ int lwm2m_set_u8(const struct lwm2m_obj_path *path, uint8_t value);
  * @param[in] path LwM2M path as a struct
  * @param[in] value u16 value
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_u16(const struct lwm2m_obj_path *path, uint16_t value);
 
@@ -924,7 +944,8 @@ int lwm2m_set_u16(const struct lwm2m_obj_path *path, uint16_t value);
  * @param[in] path LwM2M path as a struct
  * @param[in] value u32 value
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_u32(const struct lwm2m_obj_path *path, uint32_t value);
 
@@ -934,7 +955,8 @@ int lwm2m_set_u32(const struct lwm2m_obj_path *path, uint32_t value);
  * @param[in] path LwM2M path as a struct
  * @param[in] value s8 value
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_s8(const struct lwm2m_obj_path *path, int8_t value);
 
@@ -944,7 +966,8 @@ int lwm2m_set_s8(const struct lwm2m_obj_path *path, int8_t value);
  * @param[in] path LwM2M path as a struct
  * @param[in] value s16 value
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_s16(const struct lwm2m_obj_path *path, int16_t value);
 
@@ -954,7 +977,8 @@ int lwm2m_set_s16(const struct lwm2m_obj_path *path, int16_t value);
  * @param[in] path LwM2M path as a struct
  * @param[in] value s32 value
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_s32(const struct lwm2m_obj_path *path, int32_t value);
 
@@ -964,7 +988,8 @@ int lwm2m_set_s32(const struct lwm2m_obj_path *path, int32_t value);
  * @param[in] path LwM2M path as a struct
  * @param[in] value s64 value
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_s64(const struct lwm2m_obj_path *path, int64_t value);
 
@@ -974,7 +999,8 @@ int lwm2m_set_s64(const struct lwm2m_obj_path *path, int64_t value);
  * @param[in] path LwM2M path as a struct
  * @param[in] value bool value
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_bool(const struct lwm2m_obj_path *path, bool value);
 
@@ -984,7 +1010,8 @@ int lwm2m_set_bool(const struct lwm2m_obj_path *path, bool value);
  * @param[in] path LwM2M path as a struct
  * @param[in] value double value
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_f64(const struct lwm2m_obj_path *path, const double value);
 
@@ -994,7 +1021,8 @@ int lwm2m_set_f64(const struct lwm2m_obj_path *path, const double value);
  * @param[in] path LwM2M path as a struct
  * @param[in] value pointer to the lwm2m_objlnk structure
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_objlnk(const struct lwm2m_obj_path *path, const struct lwm2m_objlnk *value);
 
@@ -1004,7 +1032,8 @@ int lwm2m_set_objlnk(const struct lwm2m_obj_path *path, const struct lwm2m_objln
  * @param[in] path LwM2M path as a struct
  * @param[in] value Epoch timestamp
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_time(const struct lwm2m_obj_path *path, time_t value);
 
@@ -1050,7 +1079,8 @@ struct lwm2m_res_item {
  * @param[in] res_list LwM2M resource item list
  * @param[in] res_list_size Length of resource list
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_bulk(const struct lwm2m_res_item res_list[], size_t res_list_size);
 
@@ -1061,7 +1091,8 @@ int lwm2m_set_bulk(const struct lwm2m_res_item res_list[], size_t res_list_size)
  * @param[out] buf Data buffer to copy data into
  * @param[in] buflen Length of buffer
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_opaque(const struct lwm2m_obj_path *path, void *buf, uint16_t buflen);
 
@@ -1072,7 +1103,8 @@ int lwm2m_get_opaque(const struct lwm2m_obj_path *path, void *buf, uint16_t bufl
  * @param[out] str String buffer to copy data into
  * @param[in] buflen Length of buffer
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_string(const struct lwm2m_obj_path *path, void *str, uint16_t buflen);
 
@@ -1082,7 +1114,8 @@ int lwm2m_get_string(const struct lwm2m_obj_path *path, void *str, uint16_t bufl
  * @param[in] path LwM2M path as a struct
  * @param[out] value u8 buffer to copy data into
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_u8(const struct lwm2m_obj_path *path, uint8_t *value);
 
@@ -1092,7 +1125,8 @@ int lwm2m_get_u8(const struct lwm2m_obj_path *path, uint8_t *value);
  * @param[in] path LwM2M path as a struct
  * @param[out] value u16 buffer to copy data into
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_u16(const struct lwm2m_obj_path *path, uint16_t *value);
 
@@ -1102,7 +1136,8 @@ int lwm2m_get_u16(const struct lwm2m_obj_path *path, uint16_t *value);
  * @param[in] path LwM2M path as a struct
  * @param[out] value u32 buffer to copy data into
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_u32(const struct lwm2m_obj_path *path, uint32_t *value);
 
@@ -1112,7 +1147,8 @@ int lwm2m_get_u32(const struct lwm2m_obj_path *path, uint32_t *value);
  * @param[in] path LwM2M path as a struct
  * @param[out] value s8 buffer to copy data into
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_s8(const struct lwm2m_obj_path *path, int8_t *value);
 
@@ -1122,7 +1158,8 @@ int lwm2m_get_s8(const struct lwm2m_obj_path *path, int8_t *value);
  * @param[in] path LwM2M path as a struct
  * @param[out] value s16 buffer to copy data into
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_s16(const struct lwm2m_obj_path *path, int16_t *value);
 
@@ -1132,7 +1169,8 @@ int lwm2m_get_s16(const struct lwm2m_obj_path *path, int16_t *value);
  * @param[in] path LwM2M path as a struct
  * @param[out] value s32 buffer to copy data into
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_s32(const struct lwm2m_obj_path *path, int32_t *value);
 
@@ -1142,7 +1180,8 @@ int lwm2m_get_s32(const struct lwm2m_obj_path *path, int32_t *value);
  * @param[in] path LwM2M path as a struct
  * @param[out] value s64 buffer to copy data into
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_s64(const struct lwm2m_obj_path *path, int64_t *value);
 
@@ -1152,7 +1191,8 @@ int lwm2m_get_s64(const struct lwm2m_obj_path *path, int64_t *value);
  * @param[in] path LwM2M path as a struct
  * @param[out] value bool buffer to copy data into
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_bool(const struct lwm2m_obj_path *path, bool *value);
 
@@ -1162,7 +1202,8 @@ int lwm2m_get_bool(const struct lwm2m_obj_path *path, bool *value);
  * @param[in] path LwM2M path as a struct
  * @param[out] value double buffer to copy data into
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_f64(const struct lwm2m_obj_path *path, double *value);
 
@@ -1172,7 +1213,8 @@ int lwm2m_get_f64(const struct lwm2m_obj_path *path, double *value);
  * @param[in] path LwM2M path as a struct
  * @param[out] buf lwm2m_objlnk buffer to copy data into
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_objlnk(const struct lwm2m_obj_path *path, struct lwm2m_objlnk *buf);
 
@@ -1182,7 +1224,8 @@ int lwm2m_get_objlnk(const struct lwm2m_obj_path *path, struct lwm2m_objlnk *buf
  * @param[in] path LwM2M path as a struct
  * @param[out] buf time_t pointer to copy data
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_time(const struct lwm2m_obj_path *path, time_t *buf);
 
@@ -1202,7 +1245,8 @@ int lwm2m_get_time(const struct lwm2m_obj_path *path, time_t *buf);
  * @param[in] path LwM2M path as a struct
  * @param[in] cb Read resource callback
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_register_read_callback(const struct lwm2m_obj_path *path, lwm2m_engine_get_data_cb_t cb);
 
@@ -1216,7 +1260,8 @@ int lwm2m_register_read_callback(const struct lwm2m_obj_path *path, lwm2m_engine
  * @param[in] path LwM2M path as a struct
  * @param[in] cb Pre-write resource callback
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_register_pre_write_callback(const struct lwm2m_obj_path *path,
 				      lwm2m_engine_get_data_cb_t cb);
@@ -1239,7 +1284,8 @@ int lwm2m_register_pre_write_callback(const struct lwm2m_obj_path *path,
  * @param[in] path LwM2M path as a struct
  * @param[in] cb Validate resource data callback
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_register_validate_callback(const struct lwm2m_obj_path *path,
 				     lwm2m_engine_set_data_cb_t cb);
@@ -1256,7 +1302,8 @@ int lwm2m_register_validate_callback(const struct lwm2m_obj_path *path,
  * @param[in] path LwM2M path as a struct
  * @param[in] cb Post-write resource callback
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_register_post_write_callback(const struct lwm2m_obj_path *path,
 				       lwm2m_engine_set_data_cb_t cb);
@@ -1269,7 +1316,8 @@ int lwm2m_register_post_write_callback(const struct lwm2m_obj_path *path,
  * @param[in] path LwM2M path as a struct
  * @param[in] cb Execute resource callback
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_register_exec_callback(const struct lwm2m_obj_path *path, lwm2m_engine_execute_cb_t cb);
 
@@ -1281,7 +1329,8 @@ int lwm2m_register_exec_callback(const struct lwm2m_obj_path *path, lwm2m_engine
  * @param[in] obj_id LwM2M object id
  * @param[in] cb Create object instance callback
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_register_create_callback(uint16_t obj_id,
 				   lwm2m_engine_user_cb_t cb);
@@ -1294,7 +1343,8 @@ int lwm2m_register_create_callback(uint16_t obj_id,
  * @param[in] obj_id LwM2M object id
  * @param[in] cb Delete object instance callback
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_register_delete_callback(uint16_t obj_id,
 					  lwm2m_engine_user_cb_t cb);
@@ -1326,7 +1376,8 @@ int lwm2m_register_delete_callback(uint16_t obj_id,
  * @param[in] data_len Length of existing data in the buffer
  * @param[in] data_flags Data buffer flags (such as read-only, etc)
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_res_buf(const struct lwm2m_obj_path *path, void *buffer_ptr, uint16_t buffer_len,
 		      uint16_t data_len, uint8_t data_flags);
@@ -1339,7 +1390,8 @@ int lwm2m_set_res_buf(const struct lwm2m_obj_path *path, void *buffer_ptr, uint1
  *
  * @param[in] path LwM2M path as a struct
  * @param[in] data_len Length of data
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_res_data_len(const struct lwm2m_obj_path *path, uint16_t data_len);
 
@@ -1360,7 +1412,8 @@ int lwm2m_set_res_data_len(const struct lwm2m_obj_path *path, uint16_t data_len)
  * @param[out] data_len Length of existing data in the buffer
  * @param[out] data_flags Data buffer flags (such as read-only, etc)
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_get_res_buf(const struct lwm2m_obj_path *path, void **buffer_ptr, uint16_t *buffer_len,
 		      uint16_t *data_len, uint8_t *data_flags);
@@ -1374,7 +1427,8 @@ int lwm2m_get_res_buf(const struct lwm2m_obj_path *path, void **buffer_ptr, uint
  *
  * @param[in] path LwM2M path as a struct
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_create_res_inst(const struct lwm2m_obj_path *path);
 
@@ -1385,7 +1439,8 @@ int lwm2m_create_res_inst(const struct lwm2m_obj_path *path);
  *
  * @param[in] path LwM2M path as a struct
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_delete_res_inst(const struct lwm2m_obj_path *path);
 
@@ -1397,7 +1452,8 @@ int lwm2m_delete_res_inst(const struct lwm2m_obj_path *path);
  *
  * @param[in] period_ms New period for the device service (in milliseconds)
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_update_device_service_period(uint32_t period_ms);
 
@@ -1406,7 +1462,7 @@ int lwm2m_update_device_service_period(uint32_t period_ms);
  *
  * @param[in] path LwM2M path as a struct to check
  *
- * @return true when there exists an observation of the same level
+ * @retval true when there exists an observation of the same level
  *         or lower as the given path, false if it doesn't or path is not a
  *         valid LwM2M-path.
  *         E.g. true if path refers to a resource and the parent object has an
@@ -1423,7 +1479,8 @@ bool lwm2m_path_is_observed(const struct lwm2m_obj_path *path);
  *
  * @param[in] client_ctx LwM2M context
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_engine_stop(struct lwm2m_ctx *client_ctx);
 
@@ -1436,7 +1493,8 @@ int lwm2m_engine_stop(struct lwm2m_ctx *client_ctx);
  *
  * @param[in] client_ctx LwM2M context
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_engine_start(struct lwm2m_ctx *client_ctx);
 
@@ -1480,8 +1538,9 @@ void lwm2m_acknowledge(struct lwm2m_ctx *client_ctx);
  *			 added or deleted, and when a notification was acked or
  *			 has timed out
  *
- * @return 0 for success, -EINPROGRESS when client is already running
- *         or negative error codes in case of failure.
+ * @retval 0 for success
+ * @retval -EINPROGRESS when client is already running
+ * @retval <0 negative error codes in case of failure.
  */
 int lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 			   uint32_t flags, lwm2m_ctx_event_cb_t event_cb,
@@ -1500,7 +1559,8 @@ int lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
  * @param[in] deregister True to deregister the client if registered.
  *                       False to force close the connection.
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
 			  lwm2m_ctx_event_cb_t event_cb, bool deregister);
@@ -1512,7 +1572,8 @@ int lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
  * LwM2M Engine indicate before it suspend by
  * LWM2M_RD_CLIENT_EVENT_ENGINE_SUSPENDED event.
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_engine_pause(void);
 
@@ -1524,7 +1585,8 @@ int lwm2m_engine_pause(void);
  * Event's LWM2M_RD_CLIENT_EVENT_REGISTRATION_COMPLETE or LWM2M_RD_CLIENT_EVENT_REG_UPDATE_COMPLETE
  * indicate that client is connected to server.
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_engine_resume(void);
 
@@ -1574,13 +1636,14 @@ typedef void (*lwm2m_send_cb_t)(enum lwm2m_send_status status);
  * @param path_list_size Length of path list. Max size is CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE
  * @param reply_cb Callback triggered with confirmation state or NULL if not used
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  *
  */
 int lwm2m_send_cb(struct lwm2m_ctx *ctx, const struct lwm2m_obj_path path_list[],
 			  uint8_t path_list_size, lwm2m_send_cb_t reply_cb);
 
-/** 
+/**
  * @brief Returns LwM2M client context
  *
  * @return ctx LwM2M context
@@ -1588,7 +1651,7 @@ int lwm2m_send_cb(struct lwm2m_ctx *ctx, const struct lwm2m_obj_path path_list[]
  */
 struct lwm2m_ctx *lwm2m_rd_client_ctx(void);
 
-/** 
+/**
  * @brief Enable data cache for a resource.
  *
  * Application may enable caching of resource data by allocating buffer for LwM2M engine to use.
@@ -1598,7 +1661,8 @@ struct lwm2m_ctx *lwm2m_rd_client_ctx(void);
  * @param data_cache Pointer to Data cache array
  * @param cache_len number of cached entries
  *
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  *
  */
 int lwm2m_enable_cache(const struct lwm2m_obj_path *path, struct lwm2m_time_series_elem *data_cache,
@@ -1614,7 +1678,8 @@ int lwm2m_enable_cache(const struct lwm2m_obj_path *path, struct lwm2m_time_seri
  * @param path      LwM2M path to the cached resource.
  * @param filter_cb Callback used to decide whether samples should be cached.
  *
- * @return 0 for success or a negative errno code in case of error.
+ * @retval 0 for success
+ * @retval <0 a negative errno code in case of error.
  */
 int lwm2m_set_cache_filter(const struct lwm2m_obj_path *path,
 			   lwm2m_cache_filter_cb_t filter_cb);
@@ -1636,7 +1701,8 @@ enum lwm2m_security_mode_e {
  * This data is valid only if RD client is running.
  *
  * @param ctx Pointer to client context.
- * @return int Positive values are @ref lwm2m_security_mode_e, negative error codes otherwise.
+ * @return Positive values are @ref lwm2m_security_mode_e
+ * @retval <0 negative error codes otherwise.
  */
 int lwm2m_security_mode(struct lwm2m_ctx *ctx);
 
@@ -1648,7 +1714,8 @@ int lwm2m_security_mode(struct lwm2m_ctx *ctx);
  * before defaults.
  *
  * @param ctx Client context
- * @return 0 for success or negative in case of error.
+ * @retval 0 for success
+ * @retval <0 negative in case of error.
  */
 int lwm2m_set_default_sockopt(struct lwm2m_ctx *ctx);
 

--- a/include/zephyr/net/mdns_responder.h
+++ b/include/zephyr/net/mdns_responder.h
@@ -27,7 +27,8 @@
  *                without copying the content so it must be kept valid. It can
  *                be set to NULL, e.g. before freeing the memory block.
  * @param count The number of elements
- * @return 0 for OK; -EINVAL for invalid parameters.
+ * @retval 0 for OK
+ * @retval -EINVAL for invalid parameters.
  */
 int mdns_responder_set_ext_records(const struct dns_sd_rec *records, size_t count);
 

--- a/include/zephyr/net/mld.h
+++ b/include/zephyr/net/mld.h
@@ -37,7 +37,8 @@ extern "C" {
  * @param iface Network interface where join message is sent
  * @param addr Multicast group to join
  *
- * @return 0 if joining was done, <0 otherwise.
+ * @retval 0 if joining was done
+ * @retval <0 otherwise.
  */
 #if defined(CONFIG_NET_IPV6_MLD)
 int net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr);
@@ -58,7 +59,8 @@ net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr)
  * @param iface Network interface where leave message is sent
  * @param addr Multicast group to leave
  *
- * @return 0 if leaving is done, <0 otherwise.
+ * @retval 0 if leaving is done
+ * @retval <0 otherwise.
  */
 #if defined(CONFIG_NET_IPV6_MLD)
 int net_ipv6_mld_leave(struct net_if *iface, const struct in6_addr *addr);

--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -1042,7 +1042,8 @@ void mqtt_client_init(struct mqtt_client *client);
  * @param[in] proxy_addr Proxy server address.
  * @param[in] addrlen Proxy server address length.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  *
  * @note Must be called before calling mqtt_connect().
  */
@@ -1061,7 +1062,8 @@ int mqtt_client_set_proxy(struct mqtt_client *client,
  * @note Any subsequent changes to parameters like broker address, user name,
  *       device id, etc. have no effect once MQTT connection is established.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  *
  * @note Default protocol revision used for connection request is 3.1.1. Please
  *       set client.protocol_version = MQTT_VERSION_3_1_0 to use protocol 3.1.0.
@@ -1079,7 +1081,8 @@ int mqtt_connect(struct mqtt_client *client);
  * @param[in] param Parameters to be used for the publish message.
  *                  Shall not be NULL.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_publish(struct mqtt_client *client,
 		 const struct mqtt_publish_param *param);
@@ -1093,7 +1096,8 @@ int mqtt_publish(struct mqtt_client *client,
  *                   Shall not be NULL.
  * @param[in] param Identifies message being acknowledged.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_publish_qos1_ack(struct mqtt_client *client,
 			  const struct mqtt_puback_param *param);
@@ -1107,7 +1111,8 @@ int mqtt_publish_qos1_ack(struct mqtt_client *client,
  *                   requested. Shall not be NULL.
  * @param[in] param Identifies message being acknowledged.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_publish_qos2_receive(struct mqtt_client *client,
 			      const struct mqtt_pubrec_param *param);
@@ -1120,7 +1125,8 @@ int mqtt_publish_qos2_receive(struct mqtt_client *client,
  *                   Shall not be NULL.
  * @param[in] param Identifies message being released.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_publish_qos2_release(struct mqtt_client *client,
 			      const struct mqtt_pubrel_param *param);
@@ -1134,7 +1140,8 @@ int mqtt_publish_qos2_release(struct mqtt_client *client,
  *                   requested. Shall not be NULL.
  * @param[in] param Identifies message being completed.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_publish_qos2_complete(struct mqtt_client *client,
 			       const struct mqtt_pubcomp_param *param);
@@ -1146,7 +1153,8 @@ int mqtt_publish_qos2_complete(struct mqtt_client *client,
  *                   is requested. Shall not be NULL.
  * @param[in] param Subscription parameters. Shall not be NULL.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_subscribe(struct mqtt_client *client,
 		   const struct mqtt_subscription_list *param);
@@ -1161,7 +1169,8 @@ int mqtt_subscribe(struct mqtt_client *client,
  *
  * @note QoS included in topic description is unused in this API.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_unsubscribe(struct mqtt_client *client,
 		     const struct mqtt_subscription_list *param);
@@ -1173,7 +1182,8 @@ int mqtt_unsubscribe(struct mqtt_client *client,
  * @param[in] client Identifies client instance for which procedure is
  *                   requested.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_ping(struct mqtt_client *client);
 
@@ -1185,7 +1195,8 @@ int mqtt_ping(struct mqtt_client *client);
  * @param[in] param Optional Disconnect parameters. May be NULL.
  *                  Ignored if MQTT 3.1.1 is used.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_disconnect(struct mqtt_client *client,
 		    const struct mqtt_disconnect_param *param);
@@ -1199,7 +1210,8 @@ int mqtt_disconnect(struct mqtt_client *client,
  * @param[in] param Parameters to be used for the auth message.
  *                  Shall not be NULL.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_auth(struct mqtt_client *client, const struct mqtt_auth_param *param);
 #endif /* CONFIG_MQTT_VERSION_5_0 */
@@ -1212,7 +1224,8 @@ int mqtt_auth(struct mqtt_client *client, const struct mqtt_auth_param *param);
  * @param[in] client Identifies client instance for which procedure is
  *                   requested.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_abort(struct mqtt_client *client);
 
@@ -1228,7 +1241,8 @@ int mqtt_abort(struct mqtt_client *client);
  *        broker on connection. @ref mqtt_connect for details on Keep Alive
  *        time.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_live(struct mqtt_client *client);
 
@@ -1257,7 +1271,8 @@ int mqtt_keepalive_time_left(const struct mqtt_client *client);
  * @param[in] client Client instance for which the procedure is requested.
  *                   Shall not be NULL.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_input(struct mqtt_client *client);
 
@@ -1273,8 +1288,8 @@ int mqtt_input(struct mqtt_client *client);
  * @param[out] buffer Buffer where payload should be stored.
  * @param[in] length Length of the buffer, in bytes.
  *
- * @return Number of bytes read or a negative error code (errno.h) indicating
- *         reason of failure.
+ * @return Number of bytes read
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_read_publish_payload(struct mqtt_client *client, void *buffer,
 			      size_t length);
@@ -1287,8 +1302,8 @@ int mqtt_read_publish_payload(struct mqtt_client *client, void *buffer,
  * @param[out] buffer Buffer where payload should be stored.
  * @param[in] length Length of the buffer, in bytes.
  *
- * @return Number of bytes read or a negative error code (errno.h) indicating
- *         reason of failure.
+ * @return Number of bytes read
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_read_publish_payload_blocking(struct mqtt_client *client, void *buffer,
 				       size_t length);
@@ -1302,7 +1317,8 @@ int mqtt_read_publish_payload_blocking(struct mqtt_client *client, void *buffer,
  * @param[out] buffer Buffer where payload should be stored.
  * @param[in] length Number of bytes to read.
  *
- * @return 0 if success, otherwise a negative error code (errno.h) indicating
+ * @retval 0 on success if success
+ * @retval <0 otherwise a negative error code (errno.h) indicating
  *         reason of failure.
  */
 int mqtt_readall_publish_payload(struct mqtt_client *client, uint8_t *buffer,

--- a/include/zephyr/net/mqtt_sn.h
+++ b/include/zephyr/net/mqtt_sn.h
@@ -351,7 +351,8 @@ struct mqtt_sn_client {
  * @param rx            Pointer to the receive buffer.
  * @param rxsz          Size of the receive buffer.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_client_init(struct mqtt_sn_client *client, const struct mqtt_sn_data *client_id,
 			struct mqtt_sn_transport *transport, mqtt_sn_evt_cb_t evt_cb, void *tx,
@@ -375,7 +376,8 @@ void mqtt_sn_client_deinit(struct mqtt_sn_client *client);
  * @param gw_id       Single byte Gateway Identifier
  * @param gw_addr     Address data structure to be used by the transport layer.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_add_gw(struct mqtt_sn_client *client, uint8_t gw_id, struct mqtt_sn_data gw_addr);
 
@@ -385,7 +387,8 @@ int mqtt_sn_add_gw(struct mqtt_sn_client *client, uint8_t gw_id, struct mqtt_sn_
  * @param client     The MQTT-SN client to connect.
  * @param radius     Broadcast radius for the search message.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_search(struct mqtt_sn_client *client, uint8_t radius);
 
@@ -396,7 +399,8 @@ int mqtt_sn_search(struct mqtt_sn_client *client, uint8_t radius);
  * @param will              Flag indicating if a Will message should be sent.
  * @param clean_session     Flag indicating if a clean session should be started.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_connect(struct mqtt_sn_client *client, bool will, bool clean_session);
 
@@ -405,7 +409,8 @@ int mqtt_sn_connect(struct mqtt_sn_client *client, bool will, bool clean_session
  *
  * @param client            The MQTT-SN client to disconnect.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_disconnect(struct mqtt_sn_client *client);
 
@@ -415,7 +420,8 @@ int mqtt_sn_disconnect(struct mqtt_sn_client *client);
  * @param client            The MQTT-SN client to be put to sleep.
  * @param duration          Sleep duration (in seconds).
  *
- * @return 0 on success, negative errno code on failure.
+ * @retval 0 on success
+ * @retval <0 negative errno code on failure.
  */
 int mqtt_sn_sleep(struct mqtt_sn_client *client, uint16_t duration);
 
@@ -426,7 +432,8 @@ int mqtt_sn_sleep(struct mqtt_sn_client *client, uint16_t duration);
  * @param qos               The desired quality of service for the subscription.
  * @param topic_name        The name of the topic to subscribe to.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_subscribe(struct mqtt_sn_client *client, enum mqtt_sn_qos qos,
 		      struct mqtt_sn_data *topic_name);
@@ -438,7 +445,8 @@ int mqtt_sn_subscribe(struct mqtt_sn_client *client, enum mqtt_sn_qos qos,
  * @param qos               The quality of service used when subscribing.
  * @param topic_name        The name of the topic to unsubscribe from.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_unsubscribe(struct mqtt_sn_client *client, enum mqtt_sn_qos qos,
 			struct mqtt_sn_data *topic_name);
@@ -454,7 +462,8 @@ int mqtt_sn_unsubscribe(struct mqtt_sn_client *client, enum mqtt_sn_qos qos,
  * @param retain            Flag indicating if the message should be retained by the broker.
  * @param data              The data to be published.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_publish(struct mqtt_sn_client *client, enum mqtt_sn_qos qos,
 		    struct mqtt_sn_data *topic_name, bool retain, struct mqtt_sn_data *data);
@@ -467,7 +476,8 @@ int mqtt_sn_publish(struct mqtt_sn_client *client, enum mqtt_sn_qos qos,
  *
  * @param client            The MQTT-SN client to check for incoming data.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_input(struct mqtt_sn_client *client);
 
@@ -478,8 +488,9 @@ int mqtt_sn_input(struct mqtt_sn_client *client);
  * @param[in] id Topic identifier.
  * @param[out] topic_name Will be assigned to topic name.
  *
- * @return 0 on success, -ENOENT if topic ID doesn't exist,
- * or -EINVAL on invalid arguments.
+ * @retval 0 on success
+ * @retval -ENOENT if topic ID doesn't exist,
+ * @retval -EINVAL on invalid arguments.
  */
 int mqtt_sn_get_topic_name(struct mqtt_sn_client *client, uint16_t id,
 			   struct mqtt_sn_data *topic_name);
@@ -496,7 +507,8 @@ int mqtt_sn_get_topic_name(struct mqtt_sn_client *client, uint16_t id,
  * @param[in] topic_id Topic identifier.
  * @param[in] topic_name The name of the topic.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_predefine_topic(struct mqtt_sn_client *client, uint16_t topic_id,
 			    struct mqtt_sn_data *topic_name);
@@ -509,7 +521,8 @@ int mqtt_sn_predefine_topic(struct mqtt_sn_client *client, uint16_t topic_id,
  * @param[in] client The MQTT-SN client to define the topic on.
  * @param[in] topic_name The name of the topic. Must be exactly 2 bytes long.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_define_short_topic(struct mqtt_sn_client *client, struct mqtt_sn_data *topic_name);
 
@@ -527,7 +540,8 @@ int mqtt_sn_define_short_topic(struct mqtt_sn_client *client, struct mqtt_sn_dat
  *
  * @param[in] client The MQTT-SN client to use for sending the update.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_update_will_topic(struct mqtt_sn_client *client);
 
@@ -543,7 +557,8 @@ int mqtt_sn_update_will_topic(struct mqtt_sn_client *client);
  *
  * @param[in] client The MQTT-SN client to use for sending the update.
  *
- * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure.
  */
 int mqtt_sn_update_will_message(struct mqtt_sn_client *client);
 

--- a/include/zephyr/net/net_config.h
+++ b/include/zephyr/net/net_config.h
@@ -59,7 +59,8 @@ extern "C" {
  * @param timeout How long to wait the network setup before continuing
  * the startup.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int net_config_init(const char *app_info, uint32_t flags, int32_t timeout);
 
@@ -76,7 +77,8 @@ int net_config_init(const char *app_info, uint32_t flags, int32_t timeout);
  * @param timeout How long to wait the network setup before continuing
  * the startup.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int net_config_init_by_iface(struct net_if *iface, const char *app_info,
 			     uint32_t flags, int32_t timeout);
@@ -94,7 +96,8 @@ int net_config_init_by_iface(struct net_if *iface, const char *app_info,
  *        then default network interface is used by the function.
  * @param app_info String describing this application.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int net_config_init_app(const struct device *dev, const char *app_info);
 

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -442,7 +442,8 @@ __net_socket struct net_context {
  *
  * @param context Network context.
  *
- * @return True if the context is currently in use, False otherwise.
+ * @retval true if the context is currently in use
+ * @retval alse otherwise.
  */
 static inline bool net_context_is_used(struct net_context *context)
 {
@@ -456,7 +457,8 @@ static inline bool net_context_is_used(struct net_context *context)
  *
  * @param context Network context.
  *
- * @return True if the context is bound to network interface, False otherwise.
+ * @retval true if the context is bound to network interface
+ * @retval false otherwise.
  */
 static inline bool net_context_is_bound_to_iface(struct net_context *context)
 {
@@ -470,7 +472,8 @@ static inline bool net_context_is_bound_to_iface(struct net_context *context)
  *
  * @param context Network context.
  *
- * @return True if the context is accepting connections, False otherwise.
+ * @retval true if the context is accepting connections
+ * @retval false otherwise.
  */
 static inline bool net_context_is_accepting(struct net_context *context)
 {
@@ -502,7 +505,8 @@ static inline void net_context_set_accepting(struct net_context *context,
  *
  * @param context Network context.
  *
- * @return True if the context is closing, False otherwise.
+ * @retval true if the context is closing
+ * @retval false otherwise.
  */
 static inline bool net_context_is_closing(struct net_context *context)
 {
@@ -746,7 +750,7 @@ static inline void net_context_set_proto(struct net_context *context,
  * @param context Network context.
  *
  * @return Context network interface if context is bind to interface,
- * NULL otherwise.
+ * @retval NULL otherwise.
  */
 static inline
 struct net_if *net_context_get_iface(struct net_context *context)
@@ -1006,7 +1010,8 @@ static inline void net_context_set_proxy_enabled(struct net_context *context,
  *
  * @param context Network context.
  *
- * @return True if socks proxy is enabled for this context, False otherwise
+ * @retval true if socks proxy is enabled for this context
+ * @retval false otherwise
  */
 #if defined(CONFIG_SOCKS)
 static inline bool net_context_is_proxy_enabled(struct net_context *context)
@@ -1036,7 +1041,8 @@ static inline bool net_context_is_proxy_enabled(struct net_context *context)
  * access, the value is the L2 protocol value from IEEE 802.3 (see ethernet.h)
  * @param context The allocated context is returned to the caller.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_context_get(sa_family_t family,
 		    enum net_sock_type type,
@@ -1054,7 +1060,8 @@ int net_context_get(sa_family_t family,
  *
  * @param context The context to be closed.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_context_put(struct net_context *context);
 
@@ -1083,7 +1090,8 @@ int net_context_ref(struct net_context *context);
  *
  * @param context The context on which to decrement the reference count
  *
- * @return The new reference count, zero if the context was destroyed
+ * @return The new reference count
+ * @retval 0 if the context was destroyed
  */
 int net_context_unref(struct net_context *context);
 
@@ -1095,7 +1103,8 @@ int net_context_unref(struct net_context *context);
  * @param src Source address, or NULL to choose a default
  * @param dst Destination IPv4 address
  *
- * @return Return 0 on success, negative errno otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno otherwise.
  */
 #if defined(CONFIG_NET_IPV4)
 int net_context_create_ipv4_new(struct net_context *context,
@@ -1120,7 +1129,8 @@ static inline int net_context_create_ipv4_new(struct net_context *context,
  * @param src Source address, or NULL to choose a default from context
  * @param dst Destination IPv6 address
  *
- * @return Return 0 on success, negative errno otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno otherwise.
  */
 #if defined(CONFIG_NET_IPV6)
 int net_context_create_ipv6_new(struct net_context *context,
@@ -1150,7 +1160,8 @@ static inline int net_context_create_ipv6_new(struct net_context *context,
  * @param addr Address to assigned.
  * @param addrlen Length of the address.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_context_bind(struct net_context *context,
 		     const struct sockaddr *addr,
@@ -1164,7 +1175,8 @@ int net_context_bind(struct net_context *context,
  * @param context The context to use.
  * @param backlog The size of the pending connections backlog.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_context_listen(struct net_context *context,
 		       int backlog);
@@ -1227,7 +1239,8 @@ int net_context_connect(struct net_context *context,
  * are K_FOREVER, K_NO_WAIT, >0.
  * @param user_data Caller-supplied user data.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_context_accept(struct net_context *context,
 		       net_tcp_accept_cb_t cb,
@@ -1251,7 +1264,8 @@ int net_context_accept(struct net_context *context,
  * @param timeout Currently this value is not used.
  * @param user_data Caller-supplied user data.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_context_send(struct net_context *context,
 		     const void *buf,
@@ -1306,7 +1320,8 @@ int net_context_sendto(struct net_context *context,
  * @param timeout Currently this value is not used.
  * @param user_data Caller-supplied user data.
  *
- * @return numbers of bytes sent on success, a negative errno otherwise
+ * @return numbers of bytes sent on success
+ * @retval <0 a negative errno otherwise
  */
 int net_context_sendmsg(struct net_context *context,
 			const struct msghdr *msghdr,
@@ -1349,7 +1364,8 @@ int net_context_sendmsg(struct net_context *context,
  * are K_FOREVER, K_NO_WAIT, >0.
  * @param user_data Caller-supplied user data.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_context_recv(struct net_context *context,
 		     net_context_recv_cb_t cb,
@@ -1374,7 +1390,8 @@ int net_context_recv(struct net_context *context,
  * @param delta Size, in bytes, by which to increase TCP receive
  * window (negative value to decrease).
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_context_update_recv_wnd(struct net_context *context,
 				int32_t delta);
@@ -1415,7 +1432,8 @@ enum net_context_option {
  * @param value Option value
  * @param len Option length
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_context_set_option(struct net_context *context,
 			   enum net_context_option option,
@@ -1429,7 +1447,8 @@ int net_context_set_option(struct net_context *context,
  * @param value Option value
  * @param len Option length (returned to caller)
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_context_get_option(struct net_context *context,
 			   enum net_context_option option,
@@ -1497,8 +1516,8 @@ static inline void net_context_setup_pools(struct net_context *context,
  * @param local_port the port to check
  * @param local_addr the network address
  *
- * @return true if the port is bound
- * @return false if the port is not bound
+ * @retval true if the port is bound
+ * @retval false if the port is not bound
  */
 bool net_context_port_in_use(enum net_ip_protocol ip_proto,
 	uint16_t local_port, const struct sockaddr *local_addr);

--- a/include/zephyr/net/net_core.h
+++ b/include/zephyr/net/net_core.h
@@ -125,7 +125,8 @@ enum net_verdict {
  * @param iface Network interface where the packet was received.
  * @param pkt Network packet data.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int net_recv_data(struct net_if *iface, struct net_pkt *pkt);
 
@@ -139,7 +140,8 @@ int net_recv_data(struct net_if *iface, struct net_pkt *pkt);
  * @param pkt Network packet.
  * @param timeout Timeout for send.
  *
- * @return 0 if ok, <0 if error. If <0 is returned, then the caller needs
+ * @retval 0 if ok
+ * @retval <0 if error. If <0 is returned, then the caller needs
  * to unref the pkt in order to avoid memory leak.
  */
 int net_try_send_data(struct net_pkt *pkt, k_timeout_t timeout);
@@ -153,7 +155,8 @@ int net_try_send_data(struct net_pkt *pkt, k_timeout_t timeout);
  *
  * @param pkt Network packet.
  *
- * @return 0 if ok, <0 if error. If <0 is returned, then the caller needs
+ * @retval 0 if ok
+ * @retval <0 if error. If <0 is returned, then the caller needs
  * to unref the pkt in order to avoid memory leak.
  */
 static inline int net_send_data(struct net_pkt *pkt)

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -833,7 +833,8 @@ static inline void net_if_flag_set(struct net_if *iface,
  * @param iface Pointer to network interface
  * @param value Flag value
  *
- * @return true if the bit was set, false if it wasn't.
+ * @retval true if the bit was set
+ * @retval false if it wasn't.
  */
 static inline bool net_if_flag_test_and_set(struct net_if *iface,
 					    enum net_if_flag value)
@@ -867,7 +868,8 @@ static inline void net_if_flag_clear(struct net_if *iface,
  * @param iface Pointer to network interface
  * @param value Flag value
  *
- * @return true if the bit was set, false if it wasn't.
+ * @retval true if the bit was set
+ * @retval false if it wasn't.
  */
 static inline bool net_if_flag_test_and_clear(struct net_if *iface,
 					      enum net_if_flag value)
@@ -885,7 +887,8 @@ static inline bool net_if_flag_test_and_clear(struct net_if *iface,
  * @param iface Pointer to network interface
  * @param value Flag value
  *
- * @return True if the value is set, false otherwise
+ * @retval true if the value is set
+ * @retval false otherwise
  */
 static inline bool net_if_flag_is_set(struct net_if *iface,
 				      enum net_if_flag value)
@@ -950,7 +953,8 @@ static inline enum net_if_oper_state net_if_oper_state(struct net_if *iface)
  *        If the interface operational state has not been changed yet,
  *        then the value is 0.
  *
- * @return 0 if ok, -EINVAL if operational state change time could not be
+ * @retval 0 if ok
+ * @retval -EINVAL if operational state change time could not be
  *         retrieved (for example if iface or change_time is NULL).
  */
 static inline int net_if_oper_state_change_time(struct net_if *iface,
@@ -1084,7 +1088,8 @@ static inline void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt)
  *
  * @param iface Network interface
  *
- * @return True if IP offloading is active, false otherwise.
+ * @retval true if IP offloading is active
+ * @retval false otherwise.
  */
 static inline bool net_if_is_ip_offloaded(struct net_if *iface)
 {
@@ -1103,7 +1108,8 @@ static inline bool net_if_is_ip_offloaded(struct net_if *iface)
  *
  * @param iface Network interface
  *
- * @return True if IP or socket offloading is active, false otherwise.
+ * @retval true if IP or socket offloading is active
+ * @retval false otherwise.
  */
 bool net_if_is_offloaded(struct net_if *iface);
 
@@ -1112,7 +1118,8 @@ bool net_if_is_offloaded(struct net_if *iface);
  *
  * @param iface Network interface
  *
- * @return NULL if there is no offload plugin defined, valid pointer otherwise
+ * @retval NULL if there is no offload plugin defined
+ * @return valid pointer otherwise
  */
 static inline struct net_offload *net_if_offload(struct net_if *iface)
 {
@@ -1134,7 +1141,8 @@ static inline struct net_offload *net_if_offload(struct net_if *iface)
  *
  * @param iface Network interface
  *
- * @return True if socket offloading is active, false otherwise.
+ * @retval true if socket offloading is active
+ * @retval false otherwise.
  */
 static inline bool net_if_is_socket_offloaded(struct net_if *iface)
 {
@@ -1177,7 +1185,8 @@ static inline void net_if_socket_offload_set(
  *
  * @param iface Network interface
  *
- * @return NULL if the interface is not socket offloaded, valid pointer otherwise
+ * @retval NULL if the interface is not socket offloaded
+ * @return valid pointer otherwise
  */
 static inline net_socket_create_t net_if_socket_offload(struct net_if *iface)
 {
@@ -1352,7 +1361,7 @@ extern struct net_if_addr *net_if_addr_ref(struct net_if *iface,
  * @param len length of the address buffer
  * @param type network bearer type of this link address
  *
- * @return 0 on success
+ * @retval 0 on success
  */
 static inline int net_if_set_link_addr(struct net_if *iface,
 				       uint8_t *addr, uint8_t len,
@@ -1418,7 +1427,8 @@ static inline void net_if_addr_set_lf(struct net_if_addr *ifaddr,
  *
  * @param ll_addr Link layer address.
  *
- * @return Network interface or NULL if not found.
+ * @return Network interface
+ * @retval NULL if not found.
  */
 struct net_if *net_if_get_by_link_addr(struct net_linkaddr *ll_addr);
 
@@ -1436,7 +1446,8 @@ struct net_if *net_if_lookup_by_dev(const struct device *dev);
  *
  * @param iface Interface to use.
  *
- * @return NULL if not found or pointer to correct config settings.
+ * @retval NULL if not found
+ * @return pointer to correct config settings.
  */
 static inline struct net_if_config *net_if_config_get(struct net_if *iface)
 {
@@ -1464,7 +1475,8 @@ void net_if_set_default(struct net_if *iface);
 /**
  * @brief Get the default network interface.
  *
- * @return Default interface or NULL if no interfaces are configured.
+ * @return Default interface
+ * @retval NULL if no interfaces are configured.
  */
 struct net_if *net_if_get_default(void);
 
@@ -1473,16 +1485,16 @@ struct net_if *net_if_get_default(void);
  *
  * @param l2 Layer 2 type of the network interface.
  *
- * @return First network interface of a given type or NULL if no such
- * interfaces was found.
+ * @return First network interface of a given type
+ * @retval NULL if no such interfaces was found.
  */
 struct net_if *net_if_get_first_by_type(const struct net_l2 *l2);
 
 /**
  * @brief Get the first network interface which is up.
  *
- * @return First network interface which is up or NULL if all
- * interfaces are down.
+ * @return First network interface which is up
+ * @retval NULL if all interfaces are down.
  */
 struct net_if *net_if_get_first_up(void);
 
@@ -1507,7 +1519,8 @@ static inline struct net_if *net_if_get_ieee802154(void)
  * @param iface Interface to use.
  * @param ipv6 Pointer to allocated IPv6 struct is returned to caller.
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_if_config_ipv6_get(struct net_if *iface,
 			   struct net_if_ipv6 **ipv6);
@@ -1517,7 +1530,8 @@ int net_if_config_ipv6_get(struct net_if *iface,
  *
  * @param iface Interface to use.
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_if_config_ipv6_put(struct net_if *iface);
 
@@ -1533,7 +1547,8 @@ struct net_if_addr *net_if_ipv6_addr_lookup_raw(const uint8_t *addr,
  * @param addr IPv6 address
  * @param iface Pointer to interface is returned
  *
- * @return Pointer to interface address, NULL if not found.
+ * @return Pointer to interface address
+ * @retval NULL if not found.
  */
 struct net_if_addr *net_if_ipv6_addr_lookup(const struct in6_addr *addr,
 					    struct net_if **iface);
@@ -1549,7 +1564,8 @@ struct net_if_addr *net_if_ipv6_addr_lookup_by_iface_raw(struct net_if *iface,
  * @param iface Network interface
  * @param addr IPv6 address
  *
- * @return Pointer to interface address, NULL if not found.
+ * @return Pointer to interface address
+ * @retval NULL if not found.
  */
 struct net_if_addr *net_if_ipv6_addr_lookup_by_iface(struct net_if *iface,
 						     const struct in6_addr *addr);
@@ -1559,8 +1575,8 @@ struct net_if_addr *net_if_ipv6_addr_lookup_by_iface(struct net_if *iface,
  *
  * @param addr IPv6 address
  *
- * @return >0 if address was found in given network interface index,
- * all other values mean address was not found
+ * @retval >0 if address was found in given network interface index
+ * @return all other values mean address was not found
  */
 __syscall int net_if_ipv6_addr_lookup_by_index(const struct in6_addr *addr);
 
@@ -1587,7 +1603,8 @@ struct net_if_addr *net_if_ipv6_addr_add(struct net_if *iface,
  * @param addr_type IPv6 address type
  * @param vlifetime Validity time for this address
  *
- * @return True if ok, false if address could not be added
+ * @retval true if ok
+ * @retval false if address could not be added
  */
 __syscall bool net_if_ipv6_addr_add_by_index(int index,
 					     const struct in6_addr *addr,
@@ -1609,7 +1626,8 @@ void net_if_ipv6_addr_update_lifetime(struct net_if_addr *ifaddr,
  * @param iface Network interface
  * @param addr IPv6 address
  *
- * @return True if successfully removed, false otherwise
+ * @retval true if successfully removed
+ * @retval false otherwise
  */
 bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr);
 
@@ -1619,7 +1637,8 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr);
  * @param index Network interface index
  * @param addr IPv6 address
  *
- * @return True if successfully removed, false otherwise
+ * @retval true if successfully removed
+ * @retval false otherwise
  */
 __syscall bool net_if_ipv6_addr_rm_by_index(int index,
 					    const struct in6_addr *addr);
@@ -1653,7 +1672,8 @@ void net_if_ipv6_addr_foreach(struct net_if *iface, net_if_ip_addr_cb_t cb,
  * @param iface Network interface
  * @param addr IPv6 multicast address
  *
- * @return Pointer to interface multicast address, NULL if cannot be added
+ * @return Pointer to interface multicast address
+ * @retval NULL if cannot be added
  */
 struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 						const struct in6_addr *addr);
@@ -1664,7 +1684,8 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
  * @param iface Network interface
  * @param addr IPv6 multicast address
  *
- * @return True if successfully removed, false otherwise
+ * @retval true if successfully removed
+ * @retval false otherwise
  */
 bool net_if_ipv6_maddr_rm(struct net_if *iface, const struct in6_addr *addr);
 
@@ -1705,7 +1726,8 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_lookup_raw(const uint8_t *maddr,
  * @param iface If *iface is null, then pointer to interface is returned,
  * otherwise the *iface value needs to be matched.
  *
- * @return Pointer to interface multicast address, NULL if not found.
+ * @return Pointer to interface multicast address
+ * @retval NULL if not found.
  */
 struct net_if_mcast_addr *net_if_ipv6_maddr_lookup(const struct in6_addr *addr,
 						   struct net_if **iface);
@@ -1786,7 +1808,8 @@ void net_if_ipv6_maddr_join(struct net_if *iface,
  *
  * @param addr IPv6 multicast address
  *
- * @return True if address is joined, False otherwise.
+ * @retval true if address is joined
+ * @retval false otherwise.
  */
 static inline bool net_if_ipv6_maddr_is_joined(struct net_if_mcast_addr *addr)
 {
@@ -1812,7 +1835,8 @@ void net_if_ipv6_maddr_leave(struct net_if *iface,
  * @param iface Network interface
  * @param addr IPv6 address
  *
- * @return Pointer to prefix, NULL if not found.
+ * @return Pointer to prefix
+ * @retval NULL if not found.
  */
 struct net_if_ipv6_prefix *net_if_ipv6_prefix_get(struct net_if *iface,
 						  const struct in6_addr *addr);
@@ -1824,7 +1848,8 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_get(struct net_if *iface,
  * @param addr IPv6 address
  * @param len Prefix length
  *
- * @return Pointer to prefix, NULL if not found.
+ * @return Pointer to prefix
+ * @retval NULL if not found.
  */
 struct net_if_ipv6_prefix *net_if_ipv6_prefix_lookup(struct net_if *iface,
 						     const struct in6_addr *addr,
@@ -1838,7 +1863,8 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_lookup(struct net_if *iface,
  * @param len Prefix length
  * @param lifetime Prefix lifetime in seconds
  *
- * @return Pointer to prefix, NULL if the prefix was not added.
+ * @return Pointer to prefix
+ * @retval NULL if the prefix was not added.
  */
 struct net_if_ipv6_prefix *net_if_ipv6_prefix_add(struct net_if *iface,
 						  const struct in6_addr *prefix,
@@ -1852,7 +1878,8 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_add(struct net_if *iface,
  * @param addr IPv6 prefix address
  * @param len Prefix length
  *
- * @return True if successfully removed, false otherwise
+ * @retval true if successfully removed
+ * @retval false otherwise
  */
 bool net_if_ipv6_prefix_rm(struct net_if *iface, const struct in6_addr *addr,
 			   uint8_t len);
@@ -1893,7 +1920,8 @@ void net_if_ipv6_prefix_unset_timer(struct net_if_ipv6_prefix *prefix);
  * The iface can be NULL in which case we check all the interfaces.
  * @param addr IPv6 address
  *
- * @return True if address is part of our subnet, false otherwise
+ * @retval true if address is part of our subnet
+ * @retval false otherwise
  */
 bool net_if_ipv6_addr_onlink(struct net_if **iface, const struct in6_addr *addr);
 
@@ -1930,7 +1958,8 @@ static inline struct in6_addr *net_if_router_ipv6(struct net_if_router *router)
  * @param iface Network interface
  * @param addr IPv6 address
  *
- * @return Pointer to router information, NULL if cannot be found
+ * @return Pointer to router information
+ * @retval NULL if cannot be found
  */
 struct net_if_router *net_if_ipv6_router_lookup(struct net_if *iface,
 						const struct in6_addr *addr);
@@ -1942,7 +1971,8 @@ struct net_if_router *net_if_ipv6_router_lookup(struct net_if *iface,
  * go through all the network interfaces to find a suitable router.
  * @param addr IPv6 address
  *
- * @return Pointer to router information, NULL if cannot be found
+ * @return Pointer to router information
+ * @retval NULL if cannot be found
  */
 struct net_if_router *net_if_ipv6_router_find_default(struct net_if *iface,
 						      const struct in6_addr *addr);
@@ -1963,7 +1993,8 @@ void net_if_ipv6_router_update_lifetime(struct net_if_router *router,
  * @param addr IPv6 address
  * @param router_lifetime Lifetime of the router
  *
- * @return Pointer to router information, NULL if could not be added
+ * @return Pointer to router information
+ * @retval NULL if could not be added
  */
 struct net_if_router *net_if_ipv6_router_add(struct net_if *iface,
 					     const struct in6_addr *addr,
@@ -1974,7 +2005,8 @@ struct net_if_router *net_if_ipv6_router_add(struct net_if *iface,
  *
  * @param router Router information.
  *
- * @return True if successfully removed, false otherwise
+ * @retval true if successfully removed
+ * @retval false otherwise
  */
 bool net_if_ipv6_router_rm(struct net_if_router *router);
 
@@ -2202,8 +2234,8 @@ static inline uint32_t net_if_ipv6_get_retrans_timer(struct net_if *iface)
  * If the interface is not known, then NULL can be given.
  * @param dst IPv6 destination address
  *
- * @return Pointer to IPv6 address to use, NULL if no IPv6 address
- * could be found.
+ * @return Pointer to IPv6 address to use
+ * @retval NULL if no IPv6 address could be found.
  */
 #if defined(CONFIG_NET_IPV6)
 const struct in6_addr *net_if_ipv6_select_src_addr(struct net_if *iface,
@@ -2229,8 +2261,8 @@ static inline const struct in6_addr *net_if_ipv6_select_src_addr(
  * @param dst IPv6 destination address
  * @param flags Hint from the related socket. See RFC 5014 for value details.
  *
- * @return Pointer to IPv6 address to use, NULL if no IPv6 address
- * could be found.
+ * @return Pointer to IPv6 address to use
+ * @retval NULL if no IPv6 address could be found.
  */
 #if defined(CONFIG_NET_IPV6)
 const struct in6_addr *net_if_ipv6_select_src_addr_hint(struct net_if *iface,
@@ -2254,8 +2286,8 @@ static inline const struct in6_addr *net_if_ipv6_select_src_addr_hint(
  *
  * @param dst IPv6 destination address
  *
- * @return Pointer to network interface to use, NULL if no suitable interface
- * could be found.
+ * @return Pointer to network interface to use
+ * @retval NULL if no suitable interface could be found.
  */
 #if defined(CONFIG_NET_IPV6)
 struct net_if *net_if_ipv6_select_src_iface(const struct in6_addr *dst);
@@ -2278,8 +2310,8 @@ static inline struct net_if *net_if_ipv6_select_src_iface(
  * @param src_addr IPv6 source address. This can be set to NULL if the source
  *                 address is not needed.
  *
- * @return Pointer to network interface to use, NULL if no suitable interface
- * could be found.
+ * @return Pointer to network interface to use
+ * @retval NULL if no suitable interface could be found.
  */
 #if defined(CONFIG_NET_IPV6)
 struct net_if *net_if_ipv6_select_src_iface_addr(const struct in6_addr *dst,
@@ -2301,8 +2333,8 @@ static inline struct net_if *net_if_ipv6_select_src_iface_addr(
  * @param iface Interface to use. Must be a valid pointer to an interface.
  * @param addr_state IPv6 address state (preferred, tentative, deprecated)
  *
- * @return Pointer to link local IPv6 address, NULL if no proper IPv6 address
- * could be found.
+ * @return Pointer to link local IPv6 address
+ * @retval NULL if no proper IPv6 address could be found.
  */
 struct in6_addr *net_if_ipv6_get_ll(struct net_if *iface,
 				    enum net_addr_state addr_state);
@@ -2314,7 +2346,8 @@ struct in6_addr *net_if_ipv6_get_ll(struct net_if *iface,
  * @param state IPv6 address state (ANY, TENTATIVE, PREFERRED, DEPRECATED)
  * @param iface Pointer to interface is returned
  *
- * @return Pointer to IPv6 address, NULL if not found.
+ * @return Pointer to IPv6 address
+ * @retval NULL if not found.
  */
 struct in6_addr *net_if_ipv6_get_ll_addr(enum net_addr_state state,
 					 struct net_if **iface);
@@ -2337,7 +2370,8 @@ void net_if_ipv6_dad_failed(struct net_if *iface, const struct in6_addr *addr);
  * then all the interfaces are checked. Pointer to interface where the IPv6
  * address is defined is returned to the caller.
  *
- * @return Pointer to IPv6 address, NULL if not found.
+ * @return Pointer to IPv6 address
+ * @retval NULL if not found.
  */
 struct in6_addr *net_if_ipv6_get_global_addr(enum net_addr_state state,
 					     struct net_if **iface);
@@ -2350,7 +2384,8 @@ struct in6_addr *net_if_ipv6_get_global_addr(enum net_addr_state state,
  * @param iface Interface to use.
  * @param ipv4 Pointer to allocated IPv4 struct is returned to caller.
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_if_config_ipv4_get(struct net_if *iface,
 			   struct net_if_ipv4 **ipv4);
@@ -2360,7 +2395,8 @@ int net_if_config_ipv4_get(struct net_if *iface,
  *
  * @param iface Interface to use.
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_if_config_ipv4_put(struct net_if *iface);
 
@@ -2404,7 +2440,8 @@ void net_if_ipv4_set_mcast_ttl(struct net_if *iface, uint8_t ttl);
  * @param addr IPv4 address
  * @param iface Interface is returned
  *
- * @return Pointer to interface address, NULL if not found.
+ * @return Pointer to interface address
+ * @retval NULL if not found.
  */
 struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
 					    struct net_if **iface);
@@ -2417,7 +2454,8 @@ struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
  * @param addr_type IPv4 address type
  * @param vlifetime Validity time for this address
  *
- * @return Pointer to interface address, NULL if cannot be added
+ * @return Pointer to interface address
+ * @retval NULL if cannot be added
  */
 struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 					 const struct in_addr *addr,
@@ -2430,7 +2468,8 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
  * @param iface Network interface
  * @param addr IPv4 address
  *
- * @return True if successfully removed, false otherwise
+ * @retval true if successfully removed
+ * @retval false otherwise
  */
 bool net_if_ipv4_addr_rm(struct net_if *iface, const struct in_addr *addr);
 
@@ -2439,8 +2478,8 @@ bool net_if_ipv4_addr_rm(struct net_if *iface, const struct in_addr *addr);
  *
  * @param addr IPv4 address
  *
- * @return >0 if address was found in given network interface index,
- * all other values mean address was not found
+ * @retval >0 if address was found in given network interface index
+ * @return all other values mean address was not found
  */
 __syscall int net_if_ipv4_addr_lookup_by_index(const struct in_addr *addr);
 
@@ -2452,7 +2491,7 @@ __syscall int net_if_ipv4_addr_lookup_by_index(const struct in_addr *addr);
  * @param addr_type IPv4 address type
  * @param vlifetime Validity time for this address
  *
- * @return True if ok, false if the address could not be added
+ * @retval true if ok, false if the address could not be added
  */
 __syscall bool net_if_ipv4_addr_add_by_index(int index,
 					     const struct in_addr *addr,
@@ -2465,7 +2504,8 @@ __syscall bool net_if_ipv4_addr_add_by_index(int index,
  * @param index Network interface index
  * @param addr IPv4 address
  *
- * @return True if successfully removed, false otherwise
+ * @retval true if successfully removed
+ * @retval false otherwise
  */
 __syscall bool net_if_ipv4_addr_rm_by_index(int index,
 					    const struct in_addr *addr);
@@ -2487,7 +2527,8 @@ void net_if_ipv4_addr_foreach(struct net_if *iface, net_if_ip_addr_cb_t cb,
  * @param iface Network interface
  * @param addr IPv4 multicast address
  *
- * @return Pointer to interface multicast address, NULL if cannot be added
+ * @return Pointer to interface multicast address
+ * @retval NULL if cannot be added
  */
 struct net_if_mcast_addr *net_if_ipv4_maddr_add(struct net_if *iface,
 						const struct in_addr *addr);
@@ -2498,7 +2539,8 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_add(struct net_if *iface,
  * @param iface Network interface
  * @param addr IPv4 multicast address
  *
- * @return True if successfully removed, false otherwise
+ * @retval true if successfully removed
+ * @retval false otherwise
  */
 bool net_if_ipv4_maddr_rm(struct net_if *iface, const struct in_addr *addr);
 
@@ -2521,7 +2563,8 @@ void net_if_ipv4_maddr_foreach(struct net_if *iface, net_if_ip_maddr_cb_t cb,
  * @param iface If *iface is null, then pointer to interface is returned,
  * otherwise the *iface value needs to be matched.
  *
- * @return Pointer to interface multicast address, NULL if not found.
+ * @return Pointer to interface multicast address
+ * @retval NULL if not found.
  */
 struct net_if_mcast_addr *net_if_ipv4_maddr_lookup(const struct in_addr *addr,
 						   struct net_if **iface);
@@ -2540,7 +2583,7 @@ void net_if_ipv4_maddr_join(struct net_if *iface,
  *
  * @param addr IPv4 multicast address
  *
- * @return True if address is joined, False otherwise.
+ * @retval true if address is joined, False otherwise.
  */
 static inline bool net_if_ipv4_maddr_is_joined(struct net_if_mcast_addr *addr)
 {
@@ -2617,7 +2660,8 @@ struct net_if_router *net_if_ipv4_router_find_default(struct net_if *iface,
  * @param is_default Is this router the default one
  * @param router_lifetime Lifetime of the router
  *
- * @return Pointer to router information, NULL if could not be added
+ * @return Pointer to router information
+ * @retval NULL if could not be added
  */
 struct net_if_router *net_if_ipv4_router_add(struct net_if *iface,
 					     const struct in_addr *addr,
@@ -2629,7 +2673,8 @@ struct net_if_router *net_if_ipv4_router_add(struct net_if *iface,
  *
  * @param router Router information.
  *
- * @return True if successfully removed, false otherwise
+ * @retval true if successfully removed
+ * @retval false otherwise
  */
 bool net_if_ipv4_router_rm(struct net_if_router *router);
 
@@ -2639,7 +2684,8 @@ bool net_if_ipv4_router_rm(struct net_if_router *router);
  * @param iface Interface to use. Must be a valid pointer to an interface.
  * @param addr IPv4 address
  *
- * @return True if address is part of local subnet, false otherwise.
+ * @retval true if address is part of local subnet
+ * @retval false otherwise.
  */
 bool net_if_ipv4_addr_mask_cmp(struct net_if *iface,
 			       const struct in_addr *addr);
@@ -2650,7 +2696,8 @@ bool net_if_ipv4_addr_mask_cmp(struct net_if *iface,
  * @param iface Interface to use. Must be a valid pointer to an interface.
  * @param addr IPv4 address, this should be in network byte order
  *
- * @return True if address is a broadcast address, false otherwise.
+ * @retval true if address is a broadcast address
+ * @retval false otherwise.
  */
 bool net_if_ipv4_is_addr_bcast(struct net_if *iface,
 			       const struct in_addr *addr);
@@ -2661,7 +2708,8 @@ bool net_if_ipv4_is_addr_bcast(struct net_if *iface,
  *
  * @param dst IPv4 destination address
  *
- * @return Pointer to network interface to use, NULL if no suitable interface
+ * @return Pointer to network interface to use
+ * @retval NULL if no suitable interface
  * could be found.
  */
 #if defined(CONFIG_NET_IPV4)
@@ -2685,8 +2733,8 @@ static inline struct net_if *net_if_ipv4_select_src_iface(
  * @param src_addr IPv4 source address. This can be set to NULL if the source
  *                 address is not needed.
  *
- * @return Pointer to network interface to use, NULL if no suitable interface
- * could be found.
+ * @return Pointer to network interface to use
+ * @retval NULL if no suitable interface could be found.
  */
 #if defined(CONFIG_NET_IPV4)
 struct net_if *net_if_ipv4_select_src_iface_addr(const struct in_addr *dst,
@@ -2710,8 +2758,8 @@ static inline struct net_if *net_if_ipv4_select_src_iface_addr(
  * If the interface is not known, then NULL can be given.
  * @param dst IPv4 destination address
  *
- * @return Pointer to IPv4 address to use, NULL if no IPv4 address
- * could be found.
+ * @return Pointer to IPv4 address to use
+ * @retval NULL if no IPv4 address could be found.
  */
 #if defined(CONFIG_NET_IPV4)
 const struct in_addr *net_if_ipv4_select_src_addr(struct net_if *iface,
@@ -2733,8 +2781,8 @@ static inline const struct in_addr *net_if_ipv4_select_src_addr(
  * @param iface Interface to use. Must be a valid pointer to an interface.
  * @param addr_state IPv4 address state (preferred, tentative, deprecated)
  *
- * @return Pointer to link local IPv4 address, NULL if no proper IPv4 address
- * could be found.
+ * @return Pointer to link local IPv4 address
+ * @retval NULL if no proper IPv4 address could be found.
  */
 struct in_addr *net_if_ipv4_get_ll(struct net_if *iface,
 				   enum net_addr_state addr_state);
@@ -2745,8 +2793,8 @@ struct in_addr *net_if_ipv4_get_ll(struct net_if *iface,
  * @param iface Interface to use. Must be a valid pointer to an interface.
  * @param addr_state IPv4 address state (preferred, tentative, deprecated)
  *
- * @return Pointer to link local IPv4 address, NULL if no proper IPv4 address
- * could be found.
+ * @return Pointer to link local IPv4 address
+ * @retval NULL if no proper IPv4 address could be found.
  */
 struct in_addr *net_if_ipv4_get_global_addr(struct net_if *iface,
 					    enum net_addr_state addr_state);
@@ -2793,7 +2841,8 @@ __deprecated void net_if_ipv4_set_netmask(struct net_if *iface,
  * @param index Network interface index
  * @param netmask IPv4 netmask
  *
- * @return True if netmask was added, false otherwise.
+ * @retval true if netmask was added
+ * @retval false otherwise.
  */
 __deprecated __syscall bool net_if_ipv4_set_netmask_by_index(int index,
 							     const struct in_addr *netmask);
@@ -2805,7 +2854,8 @@ __deprecated __syscall bool net_if_ipv4_set_netmask_by_index(int index,
  * @param addr IPv4 address related to this netmask
  * @param netmask IPv4 netmask
  *
- * @return True if netmask was added, false otherwise.
+ * @retval true if netmask was added
+ * @retval false otherwise.
  */
 __syscall bool net_if_ipv4_set_netmask_by_addr_by_index(int index,
 							const struct in_addr *addr,
@@ -2818,7 +2868,8 @@ __syscall bool net_if_ipv4_set_netmask_by_addr_by_index(int index,
  * @param addr IPv4 address related to this netmask
  * @param netmask IPv4 netmask
  *
- * @return True if netmask was added, false otherwise.
+ * @retval true if netmask was added
+ * @retval false otherwise.
  */
 bool net_if_ipv4_set_netmask_by_addr(struct net_if *iface,
 				     const struct in_addr *addr,
@@ -2847,7 +2898,8 @@ void net_if_ipv4_set_gw(struct net_if *iface, const struct in_addr *gw);
  * @param index Network interface index
  * @param gw IPv4 address of an gateway
  *
- * @return True if gateway was added, false otherwise.
+ * @retval true if gateway was added
+ * @retval false otherwise.
  */
 __syscall bool net_if_ipv4_set_gw_by_index(int index, const struct in_addr *gw);
 
@@ -2968,7 +3020,8 @@ enum net_if_checksum_type {
  * @param iface Network interface
  * @param chksum_type L3 and/or L4 protocol for which to compute checksum
  *
- * @return True if checksum needs to be calculated, false otherwise.
+ * @retval true if checksum needs to be calculated
+ * @retval false otherwise.
  */
 bool net_if_need_calc_rx_checksum(struct net_if *iface,
 				  enum net_if_checksum_type chksum_type);
@@ -2982,7 +3035,8 @@ bool net_if_need_calc_rx_checksum(struct net_if *iface,
  * @param iface Network interface
  * @param chksum_type L3 and/or L4 protocol for which to compute checksum
  *
- * @return True if checksum needs to be calculated, false otherwise.
+ * @retval true if checksum needs to be calculated
+ * @retval false otherwise.
  */
 bool net_if_need_calc_tx_checksum(struct net_if *iface,
 				  enum net_if_checksum_type chksum_type);
@@ -3031,7 +3085,7 @@ void net_if_foreach(net_if_cb_t cb, void *user_data);
  *
  * @param iface Pointer to network interface
  *
- * @return 0 on success
+ * @retval 0 on success
  */
 int net_if_up(struct net_if *iface);
 
@@ -3040,7 +3094,7 @@ int net_if_up(struct net_if *iface);
  *
  * @param iface Pointer to network interface
  *
- * @return True if interface is up, False if it is down.
+ * @retval true if interface is up, False if it is down.
  */
 static inline bool net_if_is_up(struct net_if *iface)
 {
@@ -3057,7 +3111,7 @@ static inline bool net_if_is_up(struct net_if *iface)
  *
  * @param iface Pointer to network interface
  *
- * @return 0 on success
+ * @retval 0 on success
  */
 int net_if_down(struct net_if *iface);
 
@@ -3066,7 +3120,8 @@ int net_if_down(struct net_if *iface);
  *
  * @param iface Pointer to network interface
  *
- * @return True if interface is admin up, false otherwise.
+ * @retval true if interface is admin up
+ * @retval false otherwise.
  */
 static inline bool net_if_is_admin_up(struct net_if *iface)
 {
@@ -3102,7 +3157,8 @@ void net_if_carrier_off(struct net_if *iface);
  *
  * @param iface Pointer to network interface
  *
- * @return True if carrier is present, false otherwise.
+ * @retval true if carrier is present
+ * @retval false otherwise.
  */
 static inline bool net_if_is_carrier_ok(struct net_if *iface)
 {
@@ -3140,7 +3196,8 @@ void net_if_dormant_off(struct net_if *iface);
  *
  * @param iface Pointer to network interface
  *
- * @return True if interface is dormant, false otherwise.
+ * @retval true if interface is dormant
+ * @retval false otherwise.
  */
 static inline bool net_if_is_dormant(struct net_if *iface)
 {
@@ -3231,7 +3288,8 @@ void net_if_add_tx_timestamp(struct net_pkt *pkt);
  *
  * @param iface Pointer to network interface
  *
- * @return 0 on success, <0 if error
+ * @retval 0 on success
+ * @retval <0 if error
  */
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 int net_if_set_promisc(struct net_if *iface);
@@ -3263,8 +3321,8 @@ static inline void net_if_unset_promisc(struct net_if *iface)
  *
  * @param iface Pointer to network interface
  *
- * @return True if interface is in promisc mode,
- *         False if interface is not in promiscuous mode.
+ * @retval true if interface is in promisc mode,
+ * @retval false if interface is not in promiscuous mode.
  */
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 bool net_if_is_promisc(struct net_if *iface);
@@ -3283,8 +3341,9 @@ static inline bool net_if_is_promisc(struct net_if *iface)
  *
  * @param iface Pointer to network interface
  *
- * @return True if there are pending TX network packets for this network
- *         interface, False otherwise.
+ * @retval true if there are pending TX network packets for this network
+ *         interface
+ * @retval false otherwise.
  */
 static inline bool net_if_are_pending_tx_packets(struct net_if *iface)
 {
@@ -3303,7 +3362,8 @@ static inline bool net_if_are_pending_tx_packets(struct net_if *iface)
  *
  * @param iface Pointer to network interface
  *
- * @return 0 on success, or -EALREADY/-EBUSY as possible errors.
+ * @retval 0 on success
+ * @retval -EALREADY/-EBUSY as possible errors.
  */
 int net_if_suspend(struct net_if *iface);
 
@@ -3312,7 +3372,8 @@ int net_if_suspend(struct net_if *iface);
  *
  * @param iface Pointer to network interface
  *
- * @return 0 on success, or -EALREADY as a possible error.
+ * @retval 0 on success
+ * @retval -EALREADY as a possible error.
  */
 int net_if_resume(struct net_if *iface);
 
@@ -3321,7 +3382,8 @@ int net_if_resume(struct net_if *iface);
  *
  * @param iface Pointer to network interface
  *
- * @return True if interface is suspended, False otherwise.
+ * @retval true if interface is suspended
+ * @retval false otherwise.
  */
 bool net_if_is_suspended(struct net_if *iface);
 #endif /* CONFIG_NET_POWER_MANAGEMENT */
@@ -3331,28 +3393,32 @@ bool net_if_is_suspended(struct net_if *iface);
  *
  * @param iface Pointer to network interface
  *
- * @return True if interface supports Wi-Fi, False otherwise.
+ * @retval true if interface supports Wi-Fi
+ * @retval false otherwise.
  */
 bool net_if_is_wifi(struct net_if *iface);
 
 /**
  * @brief Get first Wi-Fi network interface.
  *
- * @return Pointer to network interface, NULL if not found.
+ * @return Pointer to network interface
+ * @retval NULL if not found.
  */
 struct net_if *net_if_get_first_wifi(void);
 
 /**
  * @brief Get Wi-Fi network station interface.
  *
- * @return Pointer to network interface, NULL if not found.
+ * @return Pointer to network interface
+ * @retval NULL if not found.
  */
 struct net_if *net_if_get_wifi_sta(void);
 
 /**
  * @brief Get first Wi-Fi network Soft-AP interface.
  *
- * @return Pointer to network interface, NULL if not found.
+ * @return Pointer to network interface
+ * @retval NULL if not found.
  */
 struct net_if *net_if_get_wifi_sap(void);
 
@@ -3366,9 +3432,9 @@ struct net_if *net_if_get_wifi_sap(void);
  * @param len Length of the user supplied buffer
  *
  * @return Length of the interface name copied to buf,
- *         -EINVAL if invalid parameters,
- *         -ERANGE if name cannot be copied to the user supplied buffer,
- *         -ENOTSUP if interface name support is disabled,
+ * @retval -EINVAL if invalid parameters,
+ * @retval -ERANGE if name cannot be copied to the user supplied buffer,
+ * @retval -ENOTSUP if interface name support is disabled,
  */
 int net_if_get_name(struct net_if *iface, char *buf, int len);
 
@@ -3381,10 +3447,10 @@ int net_if_get_name(struct net_if *iface, char *buf, int len);
  * @param iface Pointer to network interface
  * @param buf User supplied name
  *
- * @return 0 name is set correctly
- *         -ENOTSUP interface name support is disabled
- *         -EINVAL if invalid parameters are given,
- *         -ENAMETOOLONG if name is too long
+ * @retval 0 name is set correctly
+ * @retval -ENOTSUP interface name support is disabled
+ * @retval -EINVAL if invalid parameters are given,
+ * @retval -ENAMETOOLONG if name is too long
  */
 int net_if_set_name(struct net_if *iface, const char *buf);
 

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -690,7 +690,8 @@ static inline bool net_ipv6_is_addr_loopback_raw(const uint8_t *addr)
  *
  * @param addr IPv6 address
  *
- * @return True if address is a loopback address, False otherwise.
+ * @retval true if address is a loopback address
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_addr_loopback(const struct in6_addr *addr)
 {
@@ -709,7 +710,8 @@ static inline bool net_ipv6_is_addr_mcast_raw(const uint8_t *addr)
  *
  * @param addr IPv6 address
  *
- * @return True if address is multicast address, False otherwise.
+ * @retval true if address is multicast address
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_addr_mcast(const struct in6_addr *addr)
 {
@@ -737,7 +739,8 @@ extern struct net_if_addr *net_if_ipv6_addr_lookup(const struct in6_addr *addr,
  *
  * @param addr IPv6 address
  *
- * @return True if address was found, False otherwise.
+ * @retval true if address was found
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_my_addr(struct in6_addr *addr)
 {
@@ -753,7 +756,8 @@ extern struct net_if_mcast_addr *net_if_ipv6_maddr_lookup(
  *
  * @param maddr Multicast IPv6 address
  *
- * @return True if address was found, False otherwise.
+ * @retval true if address was found
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_my_maddr(struct in6_addr *maddr)
 {
@@ -767,7 +771,8 @@ static inline bool net_ipv6_is_my_maddr(struct in6_addr *maddr)
  * @param addr2 Second IPv6 address.
  * @param length Prefix length (max length is 128).
  *
- * @return True if IPv6 prefixes are the same, False otherwise.
+ * @retval true if IPv6 prefixes are the same
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_prefix(const uint8_t *addr1,
 				      const uint8_t *addr2,
@@ -843,7 +848,8 @@ static inline bool net_ipv4_is_addr_loopback_raw(const uint8_t *addr)
  *
  * @param addr IPv4 address
  *
- * @return True if address is a loopback address, False otherwise.
+ * @retval true if address is a loopback address
+ * @retval false otherwise.
  */
 static inline bool net_ipv4_is_addr_loopback(const struct in_addr *addr)
 {
@@ -862,7 +868,8 @@ static inline bool net_ipv4_is_addr_unspecified_raw(const uint8_t *addr)
  *
  *  @param addr IPv4 address.
  *
- *  @return True if the address is unspecified, false otherwise.
+ *  @retval true if the address is unspecified
+ *  @retval false otherwise.
  */
 static inline bool net_ipv4_is_addr_unspecified(const struct in_addr *addr)
 {
@@ -881,7 +888,8 @@ static inline bool net_ipv4_is_addr_mcast_raw(const uint8_t *addr)
  *
  * @param addr IPv4 address
  *
- * @return True if address is multicast address, False otherwise.
+ * @retval true if address is multicast address
+ * @retval false otherwise.
  */
 static inline bool net_ipv4_is_addr_mcast(const struct in_addr *addr)
 {
@@ -900,7 +908,8 @@ static inline bool net_ipv4_is_ll_addr_raw(const uint8_t *addr)
  *
  * @param addr A valid pointer on an IPv4 address
  *
- * @return True if it is, false otherwise.
+ * @retval true if it is
+ *  @retval false otherwise.
  */
 static inline bool net_ipv4_is_ll_addr(const struct in_addr *addr)
 {
@@ -914,7 +923,8 @@ static inline bool net_ipv4_is_ll_addr(const struct in_addr *addr)
  *
  * @param addr A valid pointer on an IPv4 address
  *
- * @return True if it is, false otherwise.
+ * @retval true if it is
+ * @retval false otherwise.
  */
 static inline bool net_ipv4_is_private_addr(const struct in_addr *addr)
 {
@@ -976,7 +986,8 @@ static inline void net_ipv6_addr_copy_raw(uint8_t *dest,
  *  @param addr1 Pointer to IPv4 address buffer.
  *  @param addr2 Pointer to IPv4 address buffer.
  *
- *  @return True if the addresses are the same, false otherwise.
+ *  @retval true if the addresses are the same
+ *  @retval false otherwise.
  */
 static inline bool net_ipv4_addr_cmp_raw(const uint8_t *addr1,
 					 const uint8_t *addr2)
@@ -990,7 +1001,8 @@ static inline bool net_ipv4_addr_cmp_raw(const uint8_t *addr1,
  *  @param addr1 Pointer to IPv4 address.
  *  @param addr2 Pointer to IPv4 address.
  *
- *  @return True if the addresses are the same, false otherwise.
+ *  @retval true if the addresses are the same
+ *  @retval false otherwise.
  */
 static inline bool net_ipv4_addr_cmp(const struct in_addr *addr1,
 				     const struct in_addr *addr2)
@@ -1004,7 +1016,8 @@ static inline bool net_ipv4_addr_cmp(const struct in_addr *addr1,
  *  @param addr1 Pointer to IPv6 address.
  *  @param addr2 Pointer to IPv6 address.
  *
- *  @return True if the addresses are the same, false otherwise.
+ *  @retval true if the addresses are the same
+ *  @retval false otherwise.
  */
 static inline bool net_ipv6_addr_cmp(const struct in6_addr *addr1,
 				     const struct in6_addr *addr2)
@@ -1018,7 +1031,8 @@ static inline bool net_ipv6_addr_cmp(const struct in6_addr *addr1,
  *  @param addr1 Pointer to IPv6 address buffer.
  *  @param addr2 Pointer to IPv6 address buffer.
  *
- *  @return True if the addresses are the same, false otherwise.
+ *  @retval true if the addresses are the same
+ *  @retval false otherwise.
  */
 static inline bool net_ipv6_addr_cmp_raw(const uint8_t *addr1,
 					 const uint8_t *addr2)
@@ -1039,7 +1053,8 @@ static inline bool net_ipv6_is_ll_addr_raw(const uint8_t *addr)
  *
  * @param addr A valid pointer on an IPv6 address
  *
- * @return True if it is, false otherwise.
+ * @retval true if it is
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_ll_addr(const struct in6_addr *addr)
 {
@@ -1051,7 +1066,8 @@ static inline bool net_ipv6_is_ll_addr(const struct in6_addr *addr)
  *
  * @param addr A valid pointer on an IPv6 address
  *
- * @return True if it is, false otherwise.
+ * @retval true if it is
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_sl_addr(const struct in6_addr *addr)
 {
@@ -1064,7 +1080,8 @@ static inline bool net_ipv6_is_sl_addr(const struct in6_addr *addr)
  *
  * @param addr A valid pointer on an IPv6 address
  *
- * @return True if it is, false otherwise.
+ * @retval true if it is
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_ula_addr(const struct in6_addr *addr)
 {
@@ -1076,7 +1093,8 @@ static inline bool net_ipv6_is_ula_addr(const struct in6_addr *addr)
  *
  * @param addr A valid pointer on an IPv6 address
  *
- * @return True if it is, false otherwise.
+ * @retval true if it is
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_global_addr(const struct in6_addr *addr)
 {
@@ -1090,7 +1108,8 @@ static inline bool net_ipv6_is_global_addr(const struct in6_addr *addr)
  *
  * @param addr A valid pointer on an IPv6 address
  *
- * @return True if it is, false otherwise.
+ * @retval true if it is
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_private_addr(const struct in6_addr *addr)
 {
@@ -1135,7 +1154,8 @@ extern bool net_if_ipv4_addr_mask_cmp(struct net_if *iface,
  * @param iface A valid pointer on an interface
  * @param addr IPv4 address
  *
- * @return True if address is in same subnet, false otherwise.
+ * @retval true if address is in same subnet
+ * @retval false otherwise.
  */
 static inline bool net_ipv4_addr_mask_cmp(struct net_if *iface,
 					  const struct in_addr *addr)
@@ -1178,7 +1198,8 @@ extern bool net_if_ipv4_is_addr_bcast(struct net_if *iface,
  * @param iface Interface to use. Must be a valid pointer to an interface.
  * @param addr IPv4 address
  *
- * @return True if address is a broadcast address, false otherwise.
+ * @retval true if address is a broadcast address
+ * @retval false otherwise.
  */
 #if defined(CONFIG_NET_NATIVE_IPV4)
 static inline bool net_ipv4_is_addr_bcast(struct net_if *iface,
@@ -1227,8 +1248,8 @@ extern struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
  *
  * @param addr A valid pointer on an IPv4 address
  *
- * @return True if IPv4 address is found in one of the network interfaces,
- * False otherwise.
+ * @retval true if IPv4 address is found in one of the network interfaces,
+ * @retval false otherwise.
  */
 static inline bool net_ipv4_is_my_addr(const struct in_addr *addr)
 {
@@ -1257,7 +1278,8 @@ static inline bool net_ipv6_is_addr_unspecified_raw(const uint8_t *addr)
  *
  *  @param addr IPv6 address.
  *
- *  @return True if the address is unspecified, false otherwise.
+ *  @retval true if the address is unspecified
+ *  @retval false otherwise.
  */
 static inline bool net_ipv6_is_addr_unspecified(const struct in6_addr *addr)
 {
@@ -1281,7 +1303,8 @@ static inline bool net_ipv6_is_addr_solicited_node_raw(const uint8_t *addr)
  *
  *  @param addr IPv6 address.
  *
- *  @return True if the address is solicited node address, false otherwise.
+ *  @retval true if the address is solicited node address
+ *  @retval false otherwise.
  */
 static inline bool net_ipv6_is_addr_solicited_node(const struct in6_addr *addr)
 {
@@ -1314,8 +1337,8 @@ static inline int net_ipv6_get_addr_mcast_scope_raw(const uint8_t *addr)
  * @param addr IPv6 address
  * @param scope Scope to check
  *
- * @return True if the address is in given scope multicast address,
- * false otherwise.
+ * @retval true if the address is in given scope multicast address,
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_addr_mcast_scope(const struct in6_addr *addr,
 						int scope)
@@ -1329,8 +1352,8 @@ static inline bool net_ipv6_is_addr_mcast_scope(const struct in6_addr *addr,
  * @param addr_1 IPv6 address 1
  * @param addr_2 IPv6 address 2
  *
- * @return True if both addresses have same multicast scope,
- * false otherwise.
+ * @retval true if both addresses have same multicast scope,
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_same_mcast_scope(const struct in6_addr *addr_1,
 						const struct in6_addr *addr_2)
@@ -1383,7 +1406,8 @@ static inline bool net_ipv6_is_addr_mcast_org_raw(const uint8_t *addr)
  *
  * @param addr IPv6 address.
  *
- * @return True if the address is global multicast address, false otherwise.
+ * @retval true if the address is global multicast address
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_addr_mcast_global(const struct in6_addr *addr)
 {
@@ -1396,8 +1420,8 @@ static inline bool net_ipv6_is_addr_mcast_global(const struct in6_addr *addr)
  *
  * @param addr IPv6 address.
  *
- * @return True if the address is a interface scope multicast address,
- * false otherwise.
+ * @retval true if the address is a interface scope multicast address,
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_addr_mcast_iface(const struct in6_addr *addr)
 {
@@ -1410,8 +1434,8 @@ static inline bool net_ipv6_is_addr_mcast_iface(const struct in6_addr *addr)
  *
  * @param addr IPv6 address.
  *
- * @return True if the address is a link local scope multicast address,
- * false otherwise.
+ * @retval true if the address is a link local scope multicast address,
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_addr_mcast_link(const struct in6_addr *addr)
 {
@@ -1424,8 +1448,8 @@ static inline bool net_ipv6_is_addr_mcast_link(const struct in6_addr *addr)
  *
  * @param addr IPv6 address.
  *
- * @return True if the address is a mesh-local scope multicast address,
- * false otherwise.
+ * @retval true if the address is a mesh-local scope multicast address,
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_addr_mcast_mesh(const struct in6_addr *addr)
 {
@@ -1438,8 +1462,8 @@ static inline bool net_ipv6_is_addr_mcast_mesh(const struct in6_addr *addr)
  *
  * @param addr IPv6 address.
  *
- * @return True if the address is a site scope multicast address,
- * false otherwise.
+ * @retval true if the address is a site scope multicast address,
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_addr_mcast_site(const struct in6_addr *addr)
 {
@@ -1452,8 +1476,8 @@ static inline bool net_ipv6_is_addr_mcast_site(const struct in6_addr *addr)
  *
  * @param addr IPv6 address.
  *
- * @return True if the address is an organization scope multicast address,
- * false otherwise.
+ * @retval true if the address is an organization scope multicast address,
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_addr_mcast_org(const struct in6_addr *addr)
 {
@@ -1478,8 +1502,9 @@ static inline bool net_ipv6_is_addr_mcast_group_raw(const uint8_t *addr,
  * @param group Group id IPv6 address, the values must be in network
  * byte order
  *
- * @return True if the IPv6 multicast address belongs to given multicast
- * group, false otherwise.
+ * @retval true if the IPv6 multicast address belongs to given multicast
+ * group
+ * @retval false otherwise.
  */
 static inline bool net_ipv6_is_addr_mcast_group(const struct in6_addr *addr,
 						const struct in6_addr *group)
@@ -1504,8 +1529,9 @@ static inline bool net_ipv6_is_addr_mcast_all_nodes_group_raw(const uint8_t *add
  *
  * @param addr IPv6 address
  *
- * @return True if the IPv6 multicast address belongs to the all nodes multicast
- * group, false otherwise
+ * @retval true if the IPv6 multicast address belongs to the all nodes multicast
+ * group
+ * @retval false otherwise
  */
 static inline bool
 net_ipv6_is_addr_mcast_all_nodes_group(const struct in6_addr *addr)
@@ -1519,8 +1545,8 @@ net_ipv6_is_addr_mcast_all_nodes_group(const struct in6_addr *addr)
  *
  * @param addr IPv6 address.
  *
- * @return True if the address is a interface scope all nodes multicast address,
- * false otherwise.
+ * @retval true if the address is a interface scope all nodes multicast address,
+ * @retval false otherwise.
  */
 static inline bool
 net_ipv6_is_addr_mcast_iface_all_nodes(const struct in6_addr *addr)
@@ -1543,8 +1569,9 @@ static inline bool net_ipv6_is_addr_mcast_link_all_nodes_raw(const uint8_t *addr
  *
  * @param addr IPv6 address.
  *
- * @return True if the address is a link local scope all nodes multicast
- * address, false otherwise.
+ * @retval true if the address is a link local scope all nodes multicast
+ * address
+ * @retval false otherwise.
  */
 static inline bool
 net_ipv6_is_addr_mcast_link_all_nodes(const struct in6_addr *addr)
@@ -1645,7 +1672,7 @@ static inline void net_ipv6_addr_create_v4_mapped(const struct in_addr *addr4,
  *
  *  @param addr IPv6 address
  *
- *  @return True if IPv6 address is a IPv4 mapped address, False otherwise.
+ *  @retval true if IPv6 address is a IPv4 mapped address, False otherwise.
  */
 static inline bool net_ipv6_addr_is_v4_mapped(const struct in6_addr *addr)
 {
@@ -1674,7 +1701,8 @@ static inline bool net_ipv6_addr_is_v4_mapped(const struct in6_addr *addr)
  *  @param addr IPv6 address
  *  @param lladdr Link local address
  *
- *  @return 0 if ok, < 0 if error
+ *  @retval 0 if ok
+ *  @retval <0 if error
  */
 int net_ipv6_addr_generate_iid(struct net_if *iface,
 			       const struct in6_addr *prefix,
@@ -1750,7 +1778,8 @@ static inline bool net_ipv6_addr_based_on_ll_raw(const uint8_t *addr,
 /**
  *  @brief Check if given address is based on link layer address
  *
- *  @return True if it is, False otherwise
+ *  @retval true if it is
+ *  @retval false otherwise
  */
 static inline bool net_ipv6_addr_based_on_ll(const struct in6_addr *addr,
 					     const struct net_linkaddr *lladdr)
@@ -1868,7 +1897,8 @@ struct sockaddr_can_ptr *net_can_ptr(const struct sockaddr_ptr *addr)
  * @note This function doesn't do precise error checking,
  * do not use for untrusted strings.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 __syscall int net_addr_pton(sa_family_t family, const char *src, void *dst);
 
@@ -1881,7 +1911,8 @@ __syscall int net_addr_pton(sa_family_t family, const char *src, void *dst);
  * @param dst Buffer for IP address as a null terminated string
  * @param size Number of bytes available in the buffer
  *
- * @return dst pointer if ok, NULL if error
+ * @return dst pointer if ok
+ * @retval NULL if error
  */
 __syscall char *net_addr_ntop(sa_family_t family, const void *src,
 			      char *dst, size_t size);
@@ -1894,7 +1925,8 @@ __syscall char *net_addr_ntop(sa_family_t family, const void *src,
  * @param mask Pointer to struct sockaddr_in if family is AF_INET or
  * pointer to struct sockaddr_in6 if family is AF_INET6
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_mask_len_to_netmask(sa_family_t family, uint8_t mask_len,
 			    struct sockaddr *mask);
@@ -1907,7 +1939,8 @@ int net_mask_len_to_netmask(sa_family_t family, uint8_t mask_len,
  * pointer to struct sockaddr_in6 if family is AF_INET6
  * @param mask_len Netmask length (in IPv4) or prefix length (in IPv6)
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_netmask_to_mask_len(sa_family_t family, struct sockaddr *mask,
 			    uint8_t *mask_len);
@@ -1931,7 +1964,8 @@ int net_netmask_to_mask_len(sa_family_t family, struct sockaddr *mask,
  * @param str_len Length of the string to be parsed.
  * @param addr Pointer to user supplied struct sockaddr.
  *
- * @return True if parsing could be done, false otherwise.
+ * @retval true if parsing could be done
+ * @retval false otherwise.
  */
 bool net_ipaddr_parse(const char *str, size_t str_len,
 		      struct sockaddr *addr);
@@ -1959,9 +1993,9 @@ bool net_ipaddr_parse(const char *str, size_t str_len,
  * @param addr Pointer to user supplied struct sockaddr.
  * @param mask_len Pointer to mask_len which is returned to the caller.
  *
- * @return NULL if there was an error while parsing.
- *         "" if we could parse the IP address and there is nothing more to parse.
- *         All other values point to next character after the "," or " " in the string.
+ * @retval NULL if there was an error while parsing.
+ * @retval "" if we could parse the IP address and there is nothing more to parse.
+ * @return All other values point to next character after the "," or " " in the string.
  */
 const char *net_ipaddr_parse_mask(const char *str, size_t str_len,
 				  struct sockaddr *addr, uint8_t *mask_len);
@@ -1973,7 +2007,8 @@ const char *net_ipaddr_parse_mask(const char *str, size_t str_len,
  * @param addr Pointer to user supplied struct sockaddr.
  * @param default_port Default port number to set.
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_port_set_default(struct sockaddr *addr, uint16_t default_port);
 
@@ -1986,7 +2021,9 @@ int net_port_set_default(struct sockaddr *addr, uint16_t default_port);
  * @param seq1 First sequence number
  * @param seq2 Seconds sequence number
  *
- * @return < 0 if seq1 < seq2, 0 if seq1 == seq2, > 0 if seq > seq2
+ * @retval <0 if seq1 < seq2
+ * @retval 0 if seq1 == seq2
+ * @retval >0 if seq > seq2
  */
 static inline int32_t net_tcp_seq_cmp(uint32_t seq1, uint32_t seq2)
 {
@@ -2001,7 +2038,7 @@ static inline int32_t net_tcp_seq_cmp(uint32_t seq1, uint32_t seq2)
  * @param seq1 First sequence number
  * @param seq2 Seconds sequence number
  *
- * @return True if seq > seq2
+ * @retval true if seq > seq2
  */
 static inline bool net_tcp_seq_greater(uint32_t seq1, uint32_t seq2)
 {
@@ -2017,7 +2054,8 @@ static inline bool net_tcp_seq_greater(uint32_t seq1, uint32_t seq2)
  * @param buf_len Length of the memory area.
  * @param src String of bytes.
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int net_bytes_from_str(uint8_t *buf, int buf_len, const char *src);
 
@@ -2090,7 +2128,8 @@ static inline uint8_t net_priority2vlan(enum net_priority priority)
  *
  * @param family Network address family code
  *
- * @return Network address family as a string, or NULL if family is unknown.
+ * @return Network address family as a string,
+ * @retval NULL if family is unknown.
  */
 const char *net_family2str(sa_family_t family);
 
@@ -2102,7 +2141,8 @@ const char *net_family2str(sa_family_t family);
  * @param addr IPv6 prefix
  * @param is_denylist Tells if this filter is for allowing or denying listing.
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 #if defined(CONFIG_NET_IPV6_PE)
 int net_ipv6_pe_add_filter(struct in6_addr *addr, bool is_denylist);
@@ -2122,7 +2162,8 @@ static inline int net_ipv6_pe_add_filter(struct in6_addr *addr,
  *
  * @param addr IPv6 prefix
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 #if defined(CONFIG_NET_IPV6_PE)
 int net_ipv6_pe_del_filter(struct in6_addr *addr);

--- a/include/zephyr/net/net_linkaddr.h
+++ b/include/zephyr/net/net_linkaddr.h
@@ -84,7 +84,8 @@ struct net_linkaddr {
  * @param lladdr1 Pointer to a link layer address
  * @param lladdr2 Pointer to a link layer address
  *
- * @return True if the addresses are the same, false otherwise.
+ * @retval true if the addresses are the same
+ * @retval false otherwise.
  */
 static inline bool net_linkaddr_cmp(struct net_linkaddr *lladdr1,
 				    struct net_linkaddr *lladdr2)
@@ -108,7 +109,8 @@ static inline bool net_linkaddr_cmp(struct net_linkaddr *lladdr1,
  * @param new_addr Array of bytes containing the link address.
  * @param new_len Length of the link address array.
  * This value should always be <= NET_LINK_ADDR_MAX_LENGTH.
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline int net_linkaddr_set(struct net_linkaddr *lladdr,
 				   const uint8_t *new_addr,
@@ -133,7 +135,8 @@ static inline int net_linkaddr_set(struct net_linkaddr *lladdr,
  *
  * @param dst The link address structure destination.
  * @param src The link address structure to source.
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline int net_linkaddr_copy(struct net_linkaddr *dst,
 				    const struct net_linkaddr *src)
@@ -161,7 +164,8 @@ static inline int net_linkaddr_copy(struct net_linkaddr *dst,
  * the address will be cleared.
  * @param len Length of the link address array.
  * @param type Type of the link address.
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline int net_linkaddr_create(struct net_linkaddr *lladdr,
 				      const uint8_t *addr, uint8_t len,
@@ -191,7 +195,8 @@ static inline int net_linkaddr_create(struct net_linkaddr *lladdr,
  * @brief Clear link address.
  *
  * @param lladdr The link address structure.
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline int net_linkaddr_clear(struct net_linkaddr *lladdr)
 {

--- a/include/zephyr/net/net_mgmt.h
+++ b/include/zephyr/net/net_mgmt.h
@@ -344,9 +344,10 @@ static inline void net_mgmt_event_notify(uint64_t mgmt_event,
  *        the info is not NULL.
  * @param timeout A timeout delay. K_FOREVER can be used to wait indefinitely.
  *
- * @return 0 on success, a negative error code otherwise. -ETIMEDOUT will
- *         be specifically returned if the timeout kick-in instead of an
- *         actual event.
+ * @retval 0 on success
+ * @retval -ETIMEDOUT will be specifically returned if the timeout kick-in
+ *         instead of an actual event.
+ * @retval <0 a negative error code otherwise
  */
 #ifdef CONFIG_NET_MGMT_EVENT
 int net_mgmt_event_wait(uint64_t mgmt_event_mask,
@@ -388,9 +389,10 @@ static inline int net_mgmt_event_wait(uint64_t mgmt_event_mask,
  *        the info is not NULL.
  * @param timeout A timeout delay. K_FOREVER can be used to wait indefinitely.
  *
- * @return 0 on success, a negative error code otherwise. -ETIMEDOUT will
- *         be specifically returned if the timeout kick-in instead of an
- *         actual event.
+ * @retval 0 on success
+ * @retval -ETIMEDOUT will be specifically returned if the timeout kick-in
+ *         instead of an actual event.
+ * @retval <0 a negative error code otherwise
  */
 #ifdef CONFIG_NET_MGMT_EVENT
 int net_mgmt_event_wait_on_iface(struct net_if *iface,

--- a/include/zephyr/net/net_offload.h
+++ b/include/zephyr/net/net_offload.h
@@ -139,7 +139,8 @@ struct net_offload {
  * @param ip_proto IP protocol, IPPROTO_UDP or IPPROTO_TCP
  * @param context The allocated context is returned to the caller.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline int net_offload_get(struct net_if *iface,
 				  sa_family_t family,
@@ -165,7 +166,8 @@ static inline int net_offload_get(struct net_if *iface,
  * @param addr Address to assigned.
  * @param addrlen Length of the address.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline int net_offload_bind(struct net_if *iface,
 				   struct net_context *context,
@@ -189,7 +191,8 @@ static inline int net_offload_bind(struct net_if *iface,
  * @param context The context to use.
  * @param backlog The size of the pending connections backlog.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline int net_offload_listen(struct net_if *iface,
 				     struct net_context *context,
@@ -274,7 +277,8 @@ static inline int net_offload_connect(struct net_if *iface,
  * are K_FOREVER, K_NO_WAIT, >0.
  * @param user_data Caller-supplied user data.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline int net_offload_accept(struct net_if *iface,
 				     struct net_context *context,
@@ -316,7 +320,8 @@ static inline int net_offload_accept(struct net_if *iface,
  * are K_FOREVER, K_NO_WAIT, >0.
  * @param user_data Caller-supplied user data.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline int net_offload_send(struct net_if *iface,
 				   struct net_pkt *pkt,
@@ -360,7 +365,8 @@ static inline int net_offload_send(struct net_if *iface,
  * are K_FOREVER, K_NO_WAIT, >0.
  * @param user_data Caller-supplied user data.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline int net_offload_sendto(struct net_if *iface,
 				     struct net_pkt *pkt,
@@ -411,7 +417,8 @@ static inline int net_offload_sendto(struct net_if *iface,
  * are K_FOREVER, K_NO_WAIT, >0.
  * @param user_data Caller-supplied user data.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline int net_offload_recv(struct net_if *iface,
 				   struct net_context *context,
@@ -440,7 +447,8 @@ static inline int net_offload_recv(struct net_if *iface,
  * reached.
  * @param context The context to be closed.
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 static inline int net_offload_put(struct net_if *iface,
 				  struct net_context *context)

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -2077,7 +2077,8 @@ struct net_pkt *net_pkt_rx_alloc_on_iface(struct net_if *iface,
  * @param proto   The IP protocol type (can be 0 for none).
  * @param timeout Maximum time to wait for an allocation.
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 int net_pkt_alloc_buffer(struct net_pkt *pkt,
 			 size_t size,
@@ -2101,7 +2102,8 @@ int net_pkt_alloc_buffer(struct net_pkt *pkt,
  * @param proto   The IP protocol type (can be 0 for none).
  * @param timeout Maximum time to wait for an allocation.
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 #if !defined(NET_PKT_DEBUG_ENABLED)
 int net_pkt_alloc_buffer_with_reserve(struct net_pkt *pkt,
@@ -2122,7 +2124,8 @@ int net_pkt_alloc_buffer_with_reserve(struct net_pkt *pkt,
  * @param size    The size of buffer being requested.
  * @param timeout Maximum time to wait for an allocation.
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 int net_pkt_alloc_buffer_raw(struct net_pkt *pkt, size_t size,
 			     k_timeout_t timeout);
@@ -2138,7 +2141,8 @@ int net_pkt_alloc_buffer_raw(struct net_pkt *pkt, size_t size,
  * @param proto   The IP protocol type (can be 0 for none).
  * @param timeout Maximum time to wait for an allocation.
  *
- * @return a pointer to a newly allocated net_pkt on success, NULL otherwise.
+ * @return a pointer to a newly allocated net_pkt on success
+ * @retval NULL otherwise.
  */
 struct net_pkt *net_pkt_alloc_with_buffer(struct net_if *iface,
 					  size_t size,
@@ -2288,7 +2292,8 @@ static inline void *net_pkt_cursor_get_pos(struct net_pkt *pkt)
  *               amount of data from the buffer.
  * @param length Amount of data to skip in the buffer
  *
- * @return 0 in success, negative errno code otherwise.
+ * @retval 0 in success
+ * @retval <0 negative errno code otherwise.
  */
 int net_pkt_skip(struct net_pkt *pkt, size_t length);
 
@@ -2304,7 +2309,8 @@ int net_pkt_skip(struct net_pkt *pkt, size_t length);
  * @param byte   The byte to write in memory
  * @param length Amount of data to memset with given byte
  *
- * @return 0 in success, negative errno code otherwise.
+ * @retval 0 in success
+ * @retval <0 negative errno code otherwise.
  */
 int net_pkt_memset(struct net_pkt *pkt, int byte, size_t length);
 
@@ -2319,7 +2325,8 @@ int net_pkt_memset(struct net_pkt *pkt, int byte, size_t length);
  * @param pkt_src Source network packet.
  * @param length  Length of data to be copied.
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 int net_pkt_copy(struct net_pkt *pkt_dst,
 		 struct net_pkt *pkt_src,
@@ -2343,7 +2350,8 @@ struct net_pkt *net_pkt_clone(struct net_pkt *pkt, k_timeout_t timeout);
  * @param pkt Original pkt to be cloned
  * @param timeout Timeout to wait for free buffer
  *
- * @return NULL if error, cloned packet otherwise.
+ * @return cloned packet
+ * @retval NULL if error.
  */
 struct net_pkt *net_pkt_rx_clone(struct net_pkt *pkt, k_timeout_t timeout);
 
@@ -2353,7 +2361,8 @@ struct net_pkt *net_pkt_rx_clone(struct net_pkt *pkt, k_timeout_t timeout);
  * @param pkt Original pkt to be shallow cloned
  * @param timeout Timeout to wait for free packet
  *
- * @return NULL if error, cloned packet otherwise.
+ * @return cloned packet
+ * @retval NULL if error.
  */
 struct net_pkt *net_pkt_shallow_clone(struct net_pkt *pkt,
 				      k_timeout_t timeout);
@@ -2369,7 +2378,8 @@ struct net_pkt *net_pkt_shallow_clone(struct net_pkt *pkt,
  * @param data   The destination buffer where to copy the data
  * @param length The amount of data to copy
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 int net_pkt_read(struct net_pkt *pkt, void *data, size_t length);
 
@@ -2383,7 +2393,8 @@ int net_pkt_read(struct net_pkt *pkt, void *data, size_t length);
  * @param pkt  The network packet from where to read
  * @param data The destination uint8_t where to copy the data
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 static inline int net_pkt_read_u8(struct net_pkt *pkt, uint8_t *data)
 {
@@ -2400,7 +2411,8 @@ static inline int net_pkt_read_u8(struct net_pkt *pkt, uint8_t *data)
  * @param pkt  The network packet from where to read
  * @param data The destination uint16_t where to copy the data
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 int net_pkt_read_be16(struct net_pkt *pkt, uint16_t *data);
 
@@ -2414,7 +2426,8 @@ int net_pkt_read_be16(struct net_pkt *pkt, uint16_t *data);
  * @param pkt  The network packet from where to read
  * @param data The destination uint16_t where to copy the data
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 int net_pkt_read_le16(struct net_pkt *pkt, uint16_t *data);
 
@@ -2428,7 +2441,8 @@ int net_pkt_read_le16(struct net_pkt *pkt, uint16_t *data);
  * @param pkt  The network packet from where to read
  * @param data The destination uint32_t where to copy the data
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 int net_pkt_read_be32(struct net_pkt *pkt, uint32_t *data);
 
@@ -2443,7 +2457,8 @@ int net_pkt_read_be32(struct net_pkt *pkt, uint32_t *data);
  * @param data   Data to be written
  * @param length Length of the data to be written
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 int net_pkt_write(struct net_pkt *pkt, const void *data, size_t length);
 
@@ -2457,7 +2472,8 @@ int net_pkt_write(struct net_pkt *pkt, const void *data, size_t length);
  * @param pkt  The network packet from where to read
  * @param data The uint8_t value to write
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 static inline int net_pkt_write_u8(struct net_pkt *pkt, uint8_t data)
 {
@@ -2474,7 +2490,8 @@ static inline int net_pkt_write_u8(struct net_pkt *pkt, uint8_t data)
  * @param pkt  The network packet from where to read
  * @param data The uint16_t value in host byte order to write
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 static inline int net_pkt_write_be16(struct net_pkt *pkt, uint16_t data)
 {
@@ -2493,7 +2510,8 @@ static inline int net_pkt_write_be16(struct net_pkt *pkt, uint16_t data)
  * @param pkt  The network packet from where to read
  * @param data The uint32_t value in host byte order to write
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 static inline int net_pkt_write_be32(struct net_pkt *pkt, uint32_t data)
 {
@@ -2512,7 +2530,8 @@ static inline int net_pkt_write_be32(struct net_pkt *pkt, uint32_t data)
  * @param pkt  The network packet from where to read
  * @param data The uint32_t value in host byte order to write
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 static inline int net_pkt_write_le32(struct net_pkt *pkt, uint32_t data)
 {
@@ -2531,7 +2550,8 @@ static inline int net_pkt_write_le32(struct net_pkt *pkt, uint32_t data)
  * @param pkt  The network packet from where to read
  * @param data The uint16_t value in host byte order to write
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 static inline int net_pkt_write_le16(struct net_pkt *pkt, uint16_t data)
 {
@@ -2571,7 +2591,8 @@ static inline size_t net_pkt_get_len(struct net_pkt *pkt)
  * @param pkt    Network packet
  * @param length The new length of the packet
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 int net_pkt_update_length(struct net_pkt *pkt, size_t length);
 
@@ -2586,7 +2607,8 @@ int net_pkt_update_length(struct net_pkt *pkt, size_t length);
  * @param pkt    Network packet
  * @param length Number of bytes to be removed
  *
- * @return 0 on success, negative errno code otherwise.
+ * @retval 0 on success
+ * @retval <0 negative errno code otherwise.
  */
 int net_pkt_pull(struct net_pkt *pkt, size_t length);
 
@@ -2595,8 +2617,8 @@ int net_pkt_pull(struct net_pkt *pkt, size_t length);
  *
  * @param pkt Network packet.
  *
- * @return a valid offset on success, 0 otherwise as there is nothing that
- *         can be done to evaluate the offset.
+ * @return a valid offset on success
+ * @retval 0 otherwise as there is nothing that can be done to evaluate the offset.
  */
 uint16_t net_pkt_get_current_offset(struct net_pkt *pkt);
 
@@ -2609,7 +2631,8 @@ uint16_t net_pkt_get_current_offset(struct net_pkt *pkt);
  * @param pkt  Network packet.
  * @param size The size to check for contiguity
  *
- * @return true if that is the case, false otherwise.
+ * @retval true if that is the case
+ * @retval false otherwise.
  */
 bool net_pkt_is_contiguous(struct net_pkt *pkt, size_t size);
 
@@ -2619,7 +2642,8 @@ bool net_pkt_is_contiguous(struct net_pkt *pkt, size_t size);
  * @param pkt Network packet
  *
  * @return The available contiguous buffer space in bytes starting from the
- *         current cursor position. 0 in case of an error.
+ *         current cursor position.
+ * @retval 0 in case of an error.
  */
 size_t net_pkt_get_contiguous_len(struct net_pkt *pkt);
 
@@ -2670,7 +2694,8 @@ struct net_pkt_data_access {
  * @param access A pointer to a valid net_pkt_data_access describing the
  *        data to get in a contiguous way.
  *
- * @return a pointer to the requested contiguous data, NULL otherwise.
+ * @return a pointer to the requested contiguous data
+ * @retval NULL otherwise.
  */
 void *net_pkt_get_data(struct net_pkt *pkt,
 		       struct net_pkt_data_access *access);
@@ -2686,7 +2711,8 @@ void *net_pkt_get_data(struct net_pkt *pkt,
  * @param access A pointer to a valid net_pkt_data_access describing the
  *        data to set.
  *
- * @return 0 on success, a negative errno otherwise.
+ * @retval 0 on success
+ * @retval <0 a negative errno otherwise.
  */
 int net_pkt_set_data(struct net_pkt *pkt,
 		     struct net_pkt_data_access *access);

--- a/include/zephyr/net/ocpp.h
+++ b/include/zephyr/net/ocpp.h
@@ -161,7 +161,8 @@ typedef void *ocpp_session_handle_t;
  * @param[in] io reffered corresponding to reason.
  * @param[in] user_data passed on ocpp_init.
  *
- * @return 0 or a negative error code (errno.h)
+ * @retval 0
+ * @retval <0 a negative error code (errno.h)
  */
 typedef int (*ocpp_user_notify_callback_t)(enum ocpp_notify_reason reason,
 					   union ocpp_io_value *io,
@@ -175,7 +176,8 @@ typedef int (*ocpp_user_notify_callback_t)(enum ocpp_notify_reason reason,
  * @param[in] cb user register callback
  * @param[in] user_data same reference will be passed on callback
  *
- * @return 0 on success or a negative error code (errno.h) indicating reason of failure
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure
  *
  * @note Must be called before any other ocpp API
  */
@@ -189,7 +191,8 @@ int ocpp_init(struct ocpp_cp_info *cpi,
  *
  * @param[out] hndl a valid opaque handle
  *
- * @return 0 on success or a negative error code (errno.h) indicating reason of failure
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure
  *
  * @note Each connector should open unique session after ocpp_init and
  * prior to anyother ocpp_* request message api
@@ -211,7 +214,8 @@ void ocpp_session_close(ocpp_session_handle_t hndl);
  * @param[out] status authorization status
  * @param[in] timeout_ms timeout in msec
  *
- * @return 0 on success or a negative error code (errno.h) indicating reason of failure
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure
  */
 int ocpp_authorize(ocpp_session_handle_t hndl,
 		   char *idtag,
@@ -226,9 +230,9 @@ int ocpp_authorize(ocpp_session_handle_t hndl,
  * @param[in] conn_id connector id should be > 0 and sequential number
  * @param[in] timeout_ms timeout in msec
  *
- * @return: 0 on success
- *	    EACCES - not authorized, should follow the stop charging process
- *	    a negative error code (errno.h) indicating reason of failure
+ * @retval 0 on success
+ * @retval -EACCES not authorized, should follow the stop charging process
+ * @retval <0 a negative error code (errno.h) indicating reason of failure
  */
 int ocpp_start_transaction(ocpp_session_handle_t hndl,
 			   int meter_val,
@@ -242,7 +246,8 @@ int ocpp_start_transaction(ocpp_session_handle_t hndl,
  * @param[in] meter_val energy meter reading of this connector in Wh
  * @param[in] timeout_ms timeout in msec
  *
- * @return 0 on success or a negative error code (errno.h) indicating reason of failure
+ * @retval 0 on success
+ * @retval <0 a negative error code (errno.h) indicating reason of failure
  */
 int ocpp_stop_transaction(ocpp_session_handle_t hndl,
 			  int meter_val,

--- a/include/zephyr/net/offloaded_netdev.h
+++ b/include/zephyr/net/offloaded_netdev.h
@@ -72,7 +72,8 @@ BUILD_ASSERT(offsetof(struct offloaded_if_api, iface_api) == 0);
  *
  * @param iface Pointer to network interface
  *
- * @return True if interface supports Wi-Fi, False otherwise.
+ * @retval true if interface supports Wi-Fi
+ * @retval false otherwise.
  */
 static inline bool net_off_is_wifi_offloaded(struct net_if *iface)
 {

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -56,7 +56,8 @@ enum phy_link_speed {
  *
  * @param x Link capabilities
  *
- * @return True if link is full duplex, false if not.
+ * @retval true if link is full duplex
+ * @retval false if not.
  */
 #define PHY_LINK_IS_FULL_DUPLEX(x)                                                                 \
 	(x & (LINK_FULL_10BASE | LINK_FULL_100BASE | LINK_FULL_1000BASE | LINK_FULL_2500BASE |     \
@@ -67,7 +68,8 @@ enum phy_link_speed {
  *
  * @param x Link capabilities
  *
- * @return True if link is 1 Gbit/sec, false if not.
+ * @retval true if link is 1 Gbit/sec
+ * @retval false if not.
  */
 #define PHY_LINK_IS_SPEED_1000M(x) (x & (LINK_HALF_1000BASE | LINK_FULL_1000BASE))
 
@@ -76,7 +78,8 @@ enum phy_link_speed {
  *
  * @param x Link capabilities
  *
- * @return True if link is 100 Mbit/sec, false if not.
+ * @retval true if link is 100 Mbit/sec
+ * @retval false if not.
  */
 #define PHY_LINK_IS_SPEED_100M(x) (x & (LINK_HALF_100BASE | LINK_FULL_100BASE))
 
@@ -85,7 +88,8 @@ enum phy_link_speed {
  *
  * @param x Link capabilities
  *
- * @return True if link is 10 Mbit/sec, false if not.
+ * @retval true if link is 10 Mbit/sec
+ * @retval false if not.
  */
 #define PHY_LINK_IS_SPEED_10M(x) (x & (LINK_HALF_10BASE | LINK_FULL_10BASE))
 

--- a/include/zephyr/net/ppp.h
+++ b/include/zephyr/net/ppp.h
@@ -676,8 +676,8 @@ static inline void ppp_mgmt_raise_phase_dead_event(struct net_if *iface)
  * @param timeout Amount of time to wait Echo-Reply. The value is in
  * milliseconds.
  *
- * @return 0 if Echo-Reply was received, < 0 if there is a timeout or network
- * index is not a valid PPP network index.
+ * @retval 0 if Echo-Reply was received
+ * @retval <0 if there is a timeout or network index is not a valid PPP network index.
  */
 #if defined(CONFIG_NET_L2_PPP)
 int net_ppp_ping(int idx, int32_t timeout);
@@ -697,7 +697,8 @@ static inline int net_ppp_ping(int idx, int32_t timeout)
  *
  * @param idx PPP network interface index
  *
- * @return PPP context or NULL if idx is invalid.
+ * @return PPP context
+ * @retval NULL if idx is invalid.
  */
 #if defined(CONFIG_NET_L2_PPP) && defined(CONFIG_NET_SHELL)
 struct ppp_context *net_ppp_context_get(int idx);

--- a/include/zephyr/net/promiscuous.h
+++ b/include/zephyr/net/promiscuous.h
@@ -53,7 +53,8 @@ static inline struct net_pkt *net_promisc_mode_wait_data(k_timeout_t timeout)
  *
  * @param iface Network interface
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 int net_promisc_mode_on(struct net_if *iface);
@@ -71,7 +72,8 @@ static inline int net_promisc_mode_on(struct net_if *iface)
  *
  * @param iface Network interface
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 int net_promisc_mode_off(struct net_if *iface);

--- a/include/zephyr/net/sntp.h
+++ b/include/zephyr/net/sntp.h
@@ -64,7 +64,8 @@ struct sntp_ctx {
  * @param addr IP address of NTP/SNTP server.
  * @param addr_len IP address length of NTP/SNTP server.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int sntp_init(struct sntp_ctx *ctx, struct sockaddr *addr,
 	      socklen_t addr_len);
@@ -77,7 +78,8 @@ int sntp_init(struct sntp_ctx *ctx, struct sockaddr *addr,
  * @param ts Timestamp including integer and fractional seconds since
  * 1 Jan 1970 (output).
  *
- * @return 0 if ok, <0 if error (-ETIMEDOUT if timeout).
+ * @retval 0 if ok
+ * @retval <0 if error (-ETIMEDOUT if timeout).
  */
 int sntp_query(struct sntp_ctx *ctx, uint32_t timeout, struct sntp_time *ts);
 
@@ -89,7 +91,8 @@ int sntp_query(struct sntp_ctx *ctx, uint32_t timeout, struct sntp_time *ts);
  * @param ts Timestamp including integer and fractional seconds since
  * 1 Jan 1970 (output).
  *
- * @return 0 if ok, <0 if error (-ETIMEDOUT if timeout).
+ * @retval 0 if ok
+ * @retval <0 if error (-ETIMEDOUT if timeout).
  */
 int sntp_recv_response(struct sntp_ctx *ctx, uint32_t timeout, struct sntp_time *ts);
 
@@ -110,7 +113,8 @@ void sntp_close(struct sntp_ctx *ctx);
  * @param addr_len IP address length of NTP/SNTP server.
  * @param service Socket service defined by @ref NET_SOCKET_SERVICE_SYNC_DEFINE
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int sntp_init_async(struct sntp_ctx *ctx, struct sockaddr *addr, socklen_t addr_len,
 		    const struct net_socket_service_desc *service);
@@ -120,7 +124,8 @@ int sntp_init_async(struct sntp_ctx *ctx, struct sockaddr *addr, socklen_t addr_
  *
  * @param ctx Address of sntp context.
  *
- * @return 0 if ok, <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int sntp_send_async(struct sntp_ctx *ctx);
 
@@ -134,7 +139,8 @@ int sntp_send_async(struct sntp_ctx *ctx);
  * @param ts Timestamp including integer and fractional seconds since
  * 1 Jan 1970 (output).
  *
- * @return 0 if ok, <0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int sntp_read_async(struct net_socket_service_event *event, struct sntp_time *ts);
 
@@ -156,7 +162,8 @@ void sntp_close_async(const struct net_socket_service_desc *service);
  * @param ts Timestamp including integer and fractional seconds since
  * 1 Jan 1970 (output).
  *
- * @return 0 if ok, <0 if error (-ETIMEDOUT if timeout).
+ * @retval 0 if ok
+ * @retval <0 if error (-ETIMEDOUT if timeout).
  */
 int sntp_simple(const char *server, uint32_t timeout,
 		struct sntp_time *ts);
@@ -174,7 +181,8 @@ int sntp_simple(const char *server, uint32_t timeout,
  * @param ts Timestamp including integer and fractional seconds since
  * 1 Jan 1970 (output).
  *
- * @return 0 if ok, <0 if error (-ETIMEDOUT if timeout).
+ * @retval 0 if ok
+ * @retval <0 if error (-ETIMEDOUT if timeout).
  */
 int sntp_simple_addr(struct sockaddr *addr, socklen_t addr_len, uint32_t timeout,
 		     struct sntp_time *ts);

--- a/include/zephyr/net/tftp.h
+++ b/include/zephyr/net/tftp.h
@@ -144,7 +144,7 @@ struct tftpc {
  * @param remote_file Name of the remote file to get.
  * @param mode        TFTP Client "mode" setting.
  *
- * @retval The size of data being received if the operation completed successfully.
+ * @return The size of data being received if the operation completed successfully.
  * @retval TFTPC_BUFFER_OVERFLOW if the file is larger than the user buffer.
  * @retval TFTPC_REMOTE_ERROR if the server failed to process our request.
  * @retval TFTPC_RETRIES_EXHAUSTED if the client timed out waiting for server.
@@ -165,7 +165,7 @@ int tftp_get(struct tftpc *client,
  * @param user_buf    Data buffer containing the data to put.
  * @param user_buf_size Length of the data to put.
  *
- * @retval The size of data being sent if the operation completed successfully.
+ * @return The size of data being sent if the operation completed successfully.
  * @retval TFTPC_REMOTE_ERROR if the server failed to process our request.
  * @retval TFTPC_RETRIES_EXHAUSTED if the client timed out waiting for server.
  * @retval -EINVAL if `client` or `user_buf` is NULL or if `user_buf_size` is zero.

--- a/include/zephyr/net/trickle.h
+++ b/include/zephyr/net/trickle.h
@@ -81,7 +81,8 @@ struct net_trickle {
  * @param Imax Max number of doublings.
  * @param k Redundancy constant parameter. See RFC 6206 for details.
  *
- * @return Return 0 if ok and <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int net_trickle_create(struct net_trickle *trickle,
 		       uint32_t Imin,
@@ -96,7 +97,8 @@ int net_trickle_create(struct net_trickle *trickle,
  * interval
  * @param user_data User pointer that is passed to callback.
  *
- * @return Return 0 if ok and <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int net_trickle_start(struct net_trickle *trickle,
 		      net_trickle_cb_t cb,
@@ -107,7 +109,8 @@ int net_trickle_start(struct net_trickle *trickle,
  *
  * @param trickle Pointer to Trickle struct.
  *
- * @return Return 0 if ok and <0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int net_trickle_stop(struct net_trickle *trickle);
 
@@ -132,7 +135,8 @@ void net_trickle_inconsistency(struct net_trickle *trickle);
  *
  * @param trickle Pointer to Trickle struct.
  *
- * @return Return True if timer is running and False if not.
+ * @retval true if timer is running
+ * @retval false if not.
  */
 static inline bool net_trickle_is_running(struct net_trickle *trickle)
 {

--- a/include/zephyr/net/virtual.h
+++ b/include/zephyr/net/virtual.h
@@ -190,7 +190,8 @@ struct virtual_interface_context {
  * @param iface Network interface we are attached to. This can be NULL,
  * if we want to detach.
  *
- * @return 0 if ok, <0 if attaching failed
+ * @retval 0 if ok
+ * @retval <0 if attaching failed
  */
 int net_virtual_interface_attach(struct net_if *virtual_iface,
 				  struct net_if *iface);

--- a/include/zephyr/net/websocket.h
+++ b/include/zephyr/net/websocket.h
@@ -58,7 +58,8 @@ enum websocket_opcode  {
  * @param req HTTP handshake request
  * @param user_data A valid pointer on some user data or NULL
  *
- * @return 0 if ok, <0 if there is an error and connection should be aborted
+ * @retval 0 if ok
+ * @retval <0 if there is an error and connection should be aborted
  */
 typedef int (*websocket_connect_cb_t)(int ws_sock, struct http_request *req,
 				      void *user_data);
@@ -148,7 +149,8 @@ int websocket_connect(int http_sock, struct websocket_request *req,
  * @param timeout How long to try to send the message. The value is in
  *        milliseconds. Value SYS_FOREVER_MS means to wait forever.
  *
- * @return <0 if error, >=0 amount of bytes sent
+ * @retval >=0 amount of bytes sent
+ * @retval <0 if error
  */
 int websocket_send_msg(int ws_sock, const uint8_t *payload, size_t payload_len,
 		       enum websocket_opcode opcode, bool mask, bool final,
@@ -186,7 +188,8 @@ int websocket_recv_msg(int ws_sock, uint8_t *buf, size_t buf_len,
  *
  * @param ws_sock Websocket id returned by websocket_connect().
  *
- * @return <0 if error, 0 the connection was closed successfully
+ * @retval 0 the connection was closed successfully
+ * @retval <0 if error
  */
 int websocket_disconnect(int ws_sock);
 
@@ -200,7 +203,8 @@ int websocket_disconnect(int ws_sock);
  *        websocket session.
  * @param recv_buf_len Length of the temporary receive buffer.
  *
- * @return <0 if error, >=0 the actual websocket to be used by application
+ * @retval >=0 the actual websocket to be used by application
+ * @retval <0 if error
  */
 int websocket_register(int http_sock, uint8_t *recv_buf, size_t recv_buf_len);
 
@@ -211,7 +215,8 @@ int websocket_register(int http_sock, uint8_t *recv_buf, size_t recv_buf_len);
  *
  * @param ws_sock Websocket connection socket.
  *
- * @return <0 if error, 0 the websocket connection is now fully closed
+ * @retval 0 the websocket connection is now fully closed
+ * @retval <0 if error
  */
 int websocket_unregister(int ws_sock);
 

--- a/include/zephyr/net/wifi_certs.h
+++ b/include/zephyr/net/wifi_certs.h
@@ -26,7 +26,8 @@
  * @param iface Network interface
  * @param is_ap AP or Station mode
  *
- * @return 0 if ok, < 0 if error
+ * @retval 0 if ok
+ * @retval <0 if error
  */
 int wifi_set_enterprise_credentials(struct net_if *iface, bool is_ap);
 

--- a/include/zephyr/net/wifi_credentials.h
+++ b/include/zephyr/net/wifi_credentials.h
@@ -155,10 +155,10 @@ struct wifi_credentials_enterprise {
  * @param[out] channel			channel
  * @param[out] timeout			timeout
  *
- * @return 0		Success.
- * @return -ENOENT	No network with this SSID was found.
- * @return -EINVAL	A required buffer was NULL or invalid SSID length.
- * @return -EPROTO	The network with this SSID is not a personal network.
+ * @retval 0		Success.
+ * @retval -ENOENT	No network with this SSID was found.
+ * @retval -EINVAL	A required buffer was NULL or invalid SSID length.
+ * @retval -EPROTO	The network with this SSID is not a personal network.
  */
 int wifi_credentials_get_by_ssid_personal(const char *ssid, size_t ssid_len,
 					  enum wifi_security_type *type, uint8_t *bssid_buf,
@@ -180,10 +180,10 @@ int wifi_credentials_get_by_ssid_personal(const char *ssid, size_t ssid_len,
  * @param[in] channel			Channel
  * @param[in] timeout			Timeout
  *
- * @return 0			Success. Credentials are stored in persistent storage.
- * @return -EINVAL		A required buffer was NULL or security type is not supported.
- * @return -ENOTSUP		Security type is not supported.
- * @return -ENOBUFS		All slots are already taken.
+ * @retval 0			Success. Credentials are stored in persistent storage.
+ * @retval -EINVAL		A required buffer was NULL or security type is not supported.
+ * @retval -ENOTSUP		Security type is not supported.
+ * @retval -ENOBUFS		All slots are already taken.
  */
 int wifi_credentials_set_personal(const char *ssid, size_t ssid_len, enum wifi_security_type type,
 				  const uint8_t *bssid, size_t bssid_len, const char *password,
@@ -197,10 +197,10 @@ int wifi_credentials_set_personal(const char *ssid, size_t ssid_len, enum wifi_s
  * @param[in] ssid_len		length of SSID
  * @param[out] buf		credentials Pointer to struct where credentials are stored
  *
- * @return 0			Success.
- * @return -ENOENT		No network with this SSID was found.
- * @return -EINVAL		A required buffer was NULL or too small.
- * @return -EPROTO		The network with this SSID is not a personal network.
+ * @retval 0			Success.
+ * @retval -ENOENT		No network with this SSID was found.
+ * @retval -EINVAL		A required buffer was NULL or too small.
+ * @retval -EPROTO		The network with this SSID is not a personal network.
  */
 int wifi_credentials_get_by_ssid_personal_struct(const char *ssid, size_t ssid_len,
 						 struct wifi_credentials_personal *buf);
@@ -210,10 +210,10 @@ int wifi_credentials_get_by_ssid_personal_struct(const char *ssid, size_t ssid_l
  *
  * @param[in] creds		credentials Pointer to struct from which credentials are loaded
  *
- * @return 0			Success.
- * @return -ENOENT		No network with this SSID was found.
- * @return -EINVAL		A required buffer was NULL or incorrect size.
- * @return -ENOBUFS		All slots are already taken.
+ * @retval 0			Success.
+ * @retval -ENOENT		No network with this SSID was found.
+ * @retval -EINVAL		A required buffer was NULL or incorrect size.
+ * @retval -ENOBUFS		All slots are already taken.
  */
 int wifi_credentials_set_personal_struct(const struct wifi_credentials_personal *creds);
 

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -1468,7 +1468,8 @@ struct wifi_mgmt_ops {
 	 *           result by the driver. The wifi mgmt part will take care of
 	 *           raising the necessary event etc.
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*scan)(const struct device *dev,
 		    struct wifi_scan_params *params,
@@ -1478,7 +1479,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param params Connect parameters
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*connect)(const struct device *dev,
 		       struct wifi_connect_req_params *params);
@@ -1486,7 +1488,8 @@ struct wifi_mgmt_ops {
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*disconnect)(const struct device *dev);
 	/** Enable AP mode
@@ -1494,7 +1497,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param params AP mode parameters
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*ap_enable)(const struct device *dev,
 			 struct wifi_connect_req_params *params);
@@ -1502,7 +1506,8 @@ struct wifi_mgmt_ops {
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*ap_disable)(const struct device *dev);
 	/** Disconnect a STA from AP
@@ -1510,7 +1515,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param mac MAC address of the STA to disconnect
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*ap_sta_disconnect)(const struct device *dev, const uint8_t *mac);
 	/** Get interface status
@@ -1518,7 +1524,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param status Interface status
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*iface_status)(const struct device *dev, struct wifi_iface_status *status);
 #if defined(CONFIG_NET_STATISTICS_WIFI) || defined(__DOXYGEN__)
@@ -1527,14 +1534,16 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param stats Wi-Fi statistics
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*get_stats)(const struct device *dev, struct net_stats_wifi *stats);
 	/** Reset  Wi-Fi statistics
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*reset_stats)(const struct device *dev);
 #endif /* CONFIG_NET_STATISTICS_WIFI */
@@ -1543,7 +1552,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param params 11k parameters
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*cfg_11k)(const struct device *dev, struct wifi_11k_params *params);
 	/** Send 11k neighbor request
@@ -1551,7 +1561,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param params 11k parameters
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*send_11k_neighbor_request)(const struct device *dev, struct wifi_11k_params *params);
 	/** Set power save status
@@ -1559,7 +1570,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param params Power save parameters
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*set_power_save)(const struct device *dev, struct wifi_ps_params *params);
 	/** Setup or teardown TWT flow
@@ -1567,7 +1579,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param params TWT parameters
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*set_twt)(const struct device *dev, struct wifi_twt_params *params);
 	/** Setup BTWT flow
@@ -1575,7 +1588,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param params BTWT parameters
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*set_btwt)(const struct device *dev, struct wifi_twt_params *params);
 	/** Get power save config
@@ -1583,7 +1597,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param config Power save config
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*get_power_save_config)(const struct device *dev, struct wifi_ps_config *config);
 	/** Set or get regulatory domain
@@ -1591,7 +1606,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param reg_domain Regulatory domain
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*reg_domain)(const struct device *dev, struct wifi_reg_domain *reg_domain);
 	/** Set or get packet filter settings for monitor and promiscuous modes
@@ -1599,7 +1615,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param packet filter settings
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*filter)(const struct device *dev, struct wifi_filter_info *filter);
 	/** Set or get mode of operation
@@ -1607,7 +1624,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param mode settings
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*mode)(const struct device *dev, struct wifi_mode_info *mode);
 	/** Set or get current channel of operation
@@ -1615,7 +1633,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param channel settings
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*channel)(const struct device *dev, struct wifi_channel_info *channel);
 
@@ -1624,14 +1643,16 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param reason query reason
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*btm_query)(const struct device *dev, uint8_t reason);
 
 	/** Check if ap support Neighbor Report or not.
 	 * @param dev Pointer to the device structure for the driver instance.
 	 *
-	 * @return true if support, false if not support
+	 * @retval true if support
+	 * @retval false if not support
 	 */
 	bool (*bss_support_neighbor_rep)(const struct device *dev);
 
@@ -1640,7 +1661,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param capab is the capability to judge
 	 *
-	 * @return 1 if support, 0 if not support
+	 * @retval 1 if support
+	 * @retval 0 if not support
 	 */
 	int (*bss_ext_capab)(const struct device *dev, int capab);
 
@@ -1648,7 +1670,8 @@ struct wifi_mgmt_ops {
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*legacy_roam)(const struct device *dev);
 
@@ -1662,7 +1685,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance
 	 * @param params Version parameters
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*get_version)(const struct device *dev, struct wifi_version *params);
 	/** Get Wi-Fi connection parameters recently used
@@ -1670,7 +1694,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance
 	 * @param params the Wi-Fi connection parameters recently used
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*get_conn_params)(const struct device *dev, struct wifi_connect_req_params *params);
 	/** Set RTS threshold value
@@ -1678,7 +1703,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param RTS threshold value
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*set_rts_threshold)(const struct device *dev, unsigned int rts_threshold);
 	/** Configure AP parameter
@@ -1686,7 +1712,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param params AP mode parameter configuration parameter info
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*ap_config_params)(const struct device *dev, struct wifi_ap_config_params *params);
 	/** Configure STA parameter
@@ -1694,7 +1721,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param params STA mode parameter configuration parameter info
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*config_params)(const struct device *dev, struct wifi_config_params *params);
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP
@@ -1703,7 +1731,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance
 	 * @param params DPP action enum and parameters in string
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*dpp_dispatch)(const struct device *dev, struct wifi_dpp_params *params);
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */
@@ -1711,7 +1740,8 @@ struct wifi_mgmt_ops {
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*pmksa_flush)(const struct device *dev);
 	/** Set Wi-Fi enterprise mode CA/client Cert and key
@@ -1719,7 +1749,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param creds Pointer to the CA/client Cert and key.
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 	int (*enterprise_creds)(const struct device *dev,
@@ -1730,7 +1761,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param rts_threshold Pointer to the RTS threshold value.
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*get_rts_threshold)(const struct device *dev, unsigned int *rts_threshold);
 	/** Start a WPS PBC/PIN connection
@@ -1738,7 +1770,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance
 	 * @param params wps operarion parameters
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*wps_config)(const struct device *dev, struct wifi_wps_config_params *params);
 	/** Trigger candidate scan
@@ -1746,14 +1779,16 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance
 	 * @param params Scan parameters
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*candidate_scan)(const struct device *dev, struct wifi_scan_params *params);
 	/** Start 11r roaming
 	 *
 	 * @param dev Pointer to the device structure for the driver instance
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*start_11r_roaming)(const struct device *dev);
 	/** Set BSS max idle period
@@ -1761,7 +1796,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param BSS max idle period value
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*set_bss_max_idle_period)(const struct device *dev,
 			unsigned short bss_max_idle_period);
@@ -1771,7 +1807,8 @@ struct wifi_mgmt_ops {
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param params Background scanning configuration parameters
 	 *
-	 * @return 0 if ok, < 0 if error
+	 * @retval 0 if ok
+	 * @retval <0 if error
 	 */
 	int (*set_bgscan)(const struct device *dev, struct wifi_bgscan_params *params);
 #endif

--- a/include/zephyr/net/zperf.h
+++ b/include/zephyr/net/zperf.h
@@ -111,7 +111,8 @@ typedef void (*zperf_callback)(enum zperf_status status,
  * @param param Upload parameters.
  * @param result Session results.
  *
- * @return 0 if session completed successfully, a negative error code otherwise.
+ * @retval 0 if session completed successfully
+ * @retval <0 a negative error code otherwise.
  */
 int zperf_udp_upload(const struct zperf_upload_params *param,
 		     struct zperf_results *result);
@@ -123,7 +124,8 @@ int zperf_udp_upload(const struct zperf_upload_params *param,
  * @param param Upload parameters.
  * @param result Session results.
  *
- * @return 0 if session completed successfully, a negative error code otherwise.
+ * @retval 0 if session completed successfully
+ * @retval <0 a negative error code otherwise.
  */
 int zperf_tcp_upload(const struct zperf_upload_params *param,
 		     struct zperf_results *result);
@@ -137,8 +139,8 @@ int zperf_tcp_upload(const struct zperf_upload_params *param,
  * @param callback Session results callback.
  * @param user_data A pointer to the user data to be provided with the callback.
  *
- * @return 0 if session was scheduled successfully, a negative error code
- *         otherwise.
+ * @retval 0 if session was scheduled successfully
+ * @retval <0 a negative error code otherwise.
  */
 int zperf_udp_upload_async(const struct zperf_upload_params *param,
 			   zperf_callback callback, void *user_data);
@@ -152,8 +154,8 @@ int zperf_udp_upload_async(const struct zperf_upload_params *param,
  * @param callback Session results callback.
  * @param user_data A pointer to the user data to be provided with the callback.
  *
- * @return 0 if session was scheduled successfully, a negative error code
- *         otherwise.
+ * @retval 0 if session was scheduled successfully
+ * @retval <0 a negative error code otherwise.
  */
 int zperf_tcp_upload_async(const struct zperf_upload_params *param,
 			   zperf_callback callback, void *user_data);
@@ -167,7 +169,8 @@ int zperf_tcp_upload_async(const struct zperf_upload_params *param,
  * @param callback Session results callback.
  * @param user_data A pointer to the user data to be provided with the callback.
  *
- * @return 0 if server was started, a negative error code otherwise.
+ * @retval 0 if server was started
+ * @retval <0 a negative error code otherwise.
  */
 int zperf_udp_download(const struct zperf_download_params *param,
 		       zperf_callback callback, void *user_data);
@@ -181,7 +184,8 @@ int zperf_udp_download(const struct zperf_download_params *param,
  * @param callback Session results callback.
  * @param user_data A pointer to the user data to be provided with the callback.
  *
- * @return 0 if server was started, a negative error code otherwise.
+ * @retval 0 if server was started
+ * @retval <0 a negative error code otherwise.
  */
 int zperf_tcp_download(const struct zperf_download_params *param,
 		       zperf_callback callback, void *user_data);
@@ -189,14 +193,16 @@ int zperf_tcp_download(const struct zperf_download_params *param,
 /**
  * @brief Stop UDP server.
  *
- * @return 0 if server was stopped successfully, a negative error code otherwise.
+ * @retval 0 if server was stopped successfully
+ * @retval <0 a negative error code otherwise.
  */
 int zperf_udp_download_stop(void);
 
 /**
  * @brief Stop TCP server.
  *
- * @return 0 if server was stopped successfully, a negative error code otherwise.
+ * @retval 0 if server was stopped successfully
+ * @retval <0 a negative error code otherwise.
  */
 int zperf_tcp_download_stop(void);
 


### PR DESCRIPTION
Fix how Doxygen special commands \retval and \return are used in Networking API doc text.

From Doxygen documentation:
"\retval: Starts a description for a function's return value with name .
\return: Starts a return value description for a function."

See https://www.doxygen.nl/manual/commands.html#cmdreturn
https://www.doxygen.nl/manual/commands.html#cmdretval