### PR TITLE
samples: posix: env: Add delay before printing environment variables

### DIFF
--- a/samples/posix/env/src/main.c
+++ b/samples/posix/env/src/main.c
@@ -41,6 +41,9 @@ static void *entry(void *arg)
 {
 	static char alert_msg_buf[42];
 
+	/* Give the shell time to initialize and print its prompt before we print */
+	sleep(1);
+
 	setenv("BOARD", CONFIG_BOARD, 1);
 	setenv("BUILD_VERSION", VERSION_BUILD, 1);
 	setenv("ALERT", "", 1);


### PR DESCRIPTION
Add a 1 second delay before printing environment variables to give the
shell time to initialize and print its prompt. This prevents a race
condition where the shell prompt could interleave with the environment
variable output on SMP systems, causing test failures.

Without this delay, the output could appear as:

```
BUILD_VERSIuart:~$ ON=v4.2.0...
```

With the delay, the shell completes initialization first:

```
uart:~$
BOARD=...
BUILD_VERSION=...
ALERT=
```

This fixes the sample.posix.env test timeout on FVP v9a/smp where the
test harness regex failed to match the corrupted output.
