### PR TITLE
tests: net: mqtt_sn: Fix format specifier for uint16_t

### DIFF
--- a/tests/net/lib/mqtt_sn_packet/src/mqtt_sn_packet.c
+++ b/tests/net/lib/mqtt_sn_packet/src/mqtt_sn_packet.c
@@ -536,7 +536,7 @@ static ZTEST(mqtt_sn_packet, test_mqtt_packet_encode)
 				"Expected data");
 		LOG_HEXDUMP_DBG(msg.data, msg.len, "Encoded data");
 		zassert_equal(msg.len, encode_tests[i].expectedsz,
-			      "Unexpected data size %zu (%zu)", msg.len,
+			      "Unexpected data size %u (%zu)", msg.len,
 			      encode_tests[i].expectedsz);
 		zassert_mem_equal(encode_tests[i].expected, msg.data, msg.len,
 				  "Bad encoded message");


### PR DESCRIPTION
The `msg.len` field is of type `uint16_t`, so the correct format
specifier is `%u`, not `%zu`.
