### PR TITLE
arch: arm64: mmu: revert useless cache handling

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -855,21 +855,6 @@ static inline void add_arm_mmu_region(struct arm_mmu_ptables *ptables,
 	}
 }
 
-static inline void inv_dcache_after_map_helper(void *virt, size_t size, uint32_t attrs)
-{
-	/*
-	 * DC IVAC instruction requires write access permission to the VA,
-	 * otherwise it can generate a permission fault
-	 */
-	if ((attrs & MT_RW) != MT_RW) {
-		return;
-	}
-
-	if (MT_TYPE(attrs) == MT_NORMAL || MT_TYPE(attrs) == MT_NORMAL_WT) {
-		sys_cache_data_invd_range(virt, size);
-	}
-}
-
 static void setup_page_tables(struct arm_mmu_ptables *ptables)
 {
 	unsigned int index;
@@ -909,20 +894,6 @@ static void setup_page_tables(struct arm_mmu_ptables *ptables)
 	}
 
 	invalidate_tlb_all();
-
-	for (index = 0U; index < ARRAY_SIZE(mmu_zephyr_ranges); index++) {
-		size_t size;
-
-		range = &mmu_zephyr_ranges[index];
-		size = POINTER_TO_UINT(range->end) - POINTER_TO_UINT(range->start);
-		inv_dcache_after_map_helper(range->start, size, range->attrs);
-	}
-
-	for (index = 0U; index < mmu_config.num_regions; index++) {
-		region = &mmu_config.mmu_regions[index];
-		inv_dcache_after_map_helper(UINT_TO_POINTER(region->base_va), region->size,
-					    region->attrs);
-	}
 }
 
 /* Translation table control register settings */
@@ -1117,20 +1088,8 @@ void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 		LOG_ERR("__arch_mem_map() returned %d", ret);
 		k_panic();
 	} else {
-		uint32_t mem_flags = flags & K_MEM_CACHE_MASK;
-
 		sync_domains((uintptr_t)virt, size, "mem_map");
 		invalidate_tlb_all();
-
-		switch (mem_flags) {
-		case K_MEM_CACHE_WB:
-		case K_MEM_CACHE_WT:
-			mem_flags = (mem_flags == K_MEM_CACHE_WB) ? MT_NORMAL : MT_NORMAL_WT;
-			mem_flags |= (flags & K_MEM_PERM_RW) ? MT_RW : 0;
-			inv_dcache_after_map_helper(virt, size, mem_flags);
-		default:
-			break;
-		}
 	}
 }
 
@@ -1246,7 +1205,6 @@ static int private_map(struct arm_mmu_ptables *ptables, const char *name,
 	__ASSERT(ret == 0, "add_map() returned %d", ret);
 	invalidate_tlb_all();
 
-	inv_dcache_after_map_helper(UINT_TO_POINTER(virt), size, attrs);
 	return ret;
 }
 


### PR DESCRIPTION
This reverts the following commits:

commit c9b534c4ebca
("arch: arm64: mmu: avoid using of set/way cache instructions")

commit c4ffadb0b61f
("arch: arm64: avoid invalidating of RO mem after mem map")

The reason for the former is about Xen not virtualizing set/way cache
operations used by sys_cache_data_invd_all() originally used prior to
enabling the MMU and data cache. But the cure is worse than the Xen
issue as:

- Cache invalidation is performed on _every_ mapping change.

- Those invalidations are completely unnecessary with a PIPT data cache.
  ARM64 implementations use Physically Indexed, Physically Tagged (PIPT)
  data caches where cache maintenance is not needed during MMU operations.

- `arch_mem_map()` invoked with `K_MEM_MAP_UNPAGED` triggers page faults
  when accessing the unmapped region for cache operations. The page
  fault handler in `do_page_fault()` tries to reacquire `z_mm_lock` which
  is already held by the caller of `arch_mem_map()`. This results in a
  deadlock.

And the latter commit disables cache operations for read-only mappings,
effectively rendering the workaround described in the first commit
inoperative on half the mappings, making the performance cost of the
first commit's approach unjustifiable since it doesn't actually solve
the problem it set out to fix.

Given the above, the actual "fix" should simply have been the removal of
the `sys_cache_data_invd_all()` as, in theory, it isn't strictly needed
and its replacement is already ineffective on read-only areas as mentioned.

So let's revert them, which fixes the deadlock-induced CI test failures
on Arm FVP SMP configurations that were triggered when demand paging or
memory mapping operations were involved.

Fixes #98351
