### PR TITLE
tests: net: mqtt_sn: fix build error

### DIFF
--- a/tests/net/lib/mqtt_sn_packet/src/mqtt_sn_packet.c
+++ b/tests/net/lib/mqtt_sn_packet/src/mqtt_sn_packet.c
@@ -536,7 +536,7 @@ static ZTEST(mqtt_sn_packet, test_mqtt_packet_encode)
 				"Expected data");
 		LOG_HEXDUMP_DBG(msg.data, msg.len, "Encoded data");
 		zassert_equal(msg.len, encode_tests[i].expectedsz,
-			      "Unexpected data size %zu (%zu)", msg.len,
+			      "Unexpected data size %zu (%zu)", (size_t)msg.len,
 			      encode_tests[i].expectedsz);
 		zassert_mem_equal(encode_tests[i].expected, msg.data, msg.len,
 				  "Bad encoded message");


### PR DESCRIPTION
Fix build error as follow,
- error: format %zu expects argument of type size_t, but argument 7 has type int

- build command: west build -p -b imx943_evk/mimx94398/a55 tests/net/lib/mqtt_sn_packet