### PR TITLE
hostap: fix cmd error for wifi reg_domain

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1740,7 +1740,9 @@ int supplicant_reg_domain(const struct device *dev,
 		}
 
 		if (IS_ENABLED(CONFIG_WIFI_NM_HOSTAPD_AP)) {
-			if (!hostapd_ap_reg_domain(dev, reg_domain)) {
+			const struct device *dev2 = net_if_get_device(net_if_get_wifi_sap());
+
+			if (!hostapd_ap_reg_domain(dev2, reg_domain)) {
 				goto out;
 			}
 		}


### PR DESCRIPTION
When CONFIG_WIFI_NM_HOSTAPD_AP is enabled, input 'wifi reg_domain', there is error log shows 'zephyr_get_hapd_handle_by_ifname: Unable to get hapd hanl, Interface ml not found'. The reason is the parameter dev of hostapd_ap_reg_domain is from STA not SAP interface. Getting the correct SAP dev can fix this issue.