### PR TITLE
arch: arm: dwt: use DCB instead of CoreDebug

### DIFF
--- a/arch/arm/include/cortex_m/dwt.h
+++ b/arch/arm/include/cortex_m/dwt.h
@@ -82,7 +82,7 @@ static inline void dwt_access(bool ena)
 static inline int z_arm_dwt_init(void)
 {
 	/* Enable tracing */
-	CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+	DCB->DEMCR |= DCB_DEMCR_TRCENA_Msk;
 
 	/* Unlock DWT access if any */
 	dwt_access(true);
@@ -149,7 +149,7 @@ static inline void z_arm_dwt_enable_debug_monitor(void)
 	 * unpredictable if the DebugMonitor exception is triggered. We
 	 * assert that the CPU is in normal mode.
 	 */
-	__ASSERT((CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) == 0,
+	__ASSERT((DCB->DHCSR & DCB_DHCSR_C_DEBUGEN_Msk) == 0,
 		 "Cannot enable DBM when CPU is in Debug mode\n");
 
 #if defined(CONFIG_ARMV8_M_SE) && !defined(CONFIG_ARM_NONSECURE_FIRMWARE)
@@ -160,7 +160,7 @@ static inline void z_arm_dwt_enable_debug_monitor(void)
 	 * when enabling the DebugMonitor exception, assert that
 	 * it is not targeting the Non Secure domain.
 	 */
-	__ASSERT((CoreDebug->DEMCR & DCB_DEMCR_SDME_Msk) != 0, "DebugMonitor targets Non-Secure\n");
+	__ASSERT((DCB->DEMCR & DCB_DEMCR_SDME_Msk) != 0, "DebugMonitor targets Non-Secure\n");
 #endif
 
 	/* The DebugMonitor handler priority is set already
@@ -169,7 +169,7 @@ static inline void z_arm_dwt_enable_debug_monitor(void)
 	 */
 
 	/* Enable debug monitor exception triggered on debug events */
-	CoreDebug->DEMCR |= CoreDebug_DEMCR_MON_EN_Msk;
+	DCB->DEMCR |= DCB_DEMCR_MON_EN_Msk;
 }
 
 #endif /* CONFIG_CORTEX_M_DWT */

--- a/samples/subsys/debug/debugmon/src/main.c
+++ b/samples/subsys/debug/debugmon/src/main.c
@@ -25,14 +25,14 @@ int debug_mon_enable(void)
 	 * Cannot enable monitor mode if C_DEBUGEN bit is set. This bit can only be
 	 * altered from debug access port. It is cleared on power-on-reset.
 	 */
-	bool is_in_halting_mode = (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) == 1;
+	bool is_in_halting_mode = (DCB->DHCSR & DCB_DHCSR_C_DEBUGEN_Msk) == 1;
 
 	if (is_in_halting_mode) {
 		return -1;
 	}
 
 	/* Enable monitor mode debugging by setting MON_EN bit of DEMCR */
-	CoreDebug->DEMCR |= CoreDebug_DEMCR_MON_EN_Msk;
+	DCB->DEMCR |= DCB_DEMCR_MON_EN_Msk;
 	return 0;
 }
 

--- a/subsys/logging/backends/log_backend_swo.c
+++ b/subsys/logging/backends/log_backend_swo.c
@@ -93,7 +93,7 @@ static int format_set(const struct log_backend *const backend, uint32_t log_type
 static void log_backend_swo_init(struct log_backend const *const backend)
 {
 	/* Enable DWT and ITM units */
-	CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+	DCB->DEMCR |= DCB_DEMCR_TRCENA_Msk;
 #if (__CORTEX_M <= 7U)
 	/* Enable access to ITM registers */
 	ITM->LAR  = 0xC5ACCE55;

--- a/tests/lib/mpsc_pbuf/src/main.c
+++ b/tests/lib/mpsc_pbuf/src/main.c
@@ -96,7 +96,7 @@ static void init(struct mpsc_pbuf_buffer *buffer, uint32_t wlen, bool overwrite)
 	mpsc_pbuf_init(buffer, &mpsc_buf_cfg);
 
 #if CONFIG_SOC_SERIES_NRF52X
-	CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+	DCB->DEMCR |= DCB_DEMCR_TRCENA_Msk;
 	DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
 	DWT->CYCCNT = 0;
 #endif


### PR DESCRIPTION
commit a76320796276 ("arch: arm: dwt: use the cmsis_6 macro unconditionally") use cmsis_6 macro unconditionally, we can use DCB instead of CoreDebug macro unconditionally.