### PR TITLE
STM32 video devices fixes (yaml title / VENC - JPEG build_all)

### DIFF
--- a/dts/bindings/video/st,mipid02.yaml
+++ b/dts/bindings/video/st,mipid02.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2025 STMicroelectronics.
 # SPDX-License-Identifier: Apache-2.0
 
-description: MIPID02 CSI to DVP interface bridge
+title: MIPID02 CSI to DVP interface bridge
+
+description: |
+    The MIPID02 allows connecting a DVP sensor to a CSI-2–enabled
+    camera receiver.
 
 compatible: "st,mipid02"
 

--- a/dts/bindings/video/st,stm32-dcmi.yaml
+++ b/dts/bindings/video/st,stm32-dcmi.yaml
@@ -4,8 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+title: STM32 DCMI (Digital Camera Memory Interface)
+
 description: |
-    STM32 Digital Camera Memory Interface (DCMI).
+    The STM32 DCMI (Digital Camera Memory Interface) allows
+    capturing data via a parallel interface (DVP).
 
     Example of node configuration at board level:
 

--- a/dts/bindings/video/st,stm32-dcmipp.yaml
+++ b/dts/bindings/video/st,stm32-dcmipp.yaml
@@ -4,8 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+title: STM32 DCMIPP (Digital Camera Memory Interface Pixel Processor)
+
 description: |
-    STM32 Digital Camera Memory Interface Pixel Processor (DCMIPP).
+    The STM32 DCMIPP (Digital Camera Memory Interface Pixel Processor) supports,
+    depending on the platform, data capture from either parallel (DVP) or
+    CSI-2 interfaces. It integrates up to three processing pipelines capable of
+    performing frame operations, including one pipeline with ISP functionality
+    enabled.
 
     Example of node configuration at board level:
 

--- a/dts/bindings/video/st,stm32-jpeg.yaml
+++ b/dts/bindings/video/st,stm32-jpeg.yaml
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: |
-    STM32 JPEG HW Codec.
+title: STM32 JPEG HW Codec
 
+description: |
     The STM32 JPEG HW codec can decode JPEG compressed frames
     and encode uncompressed frames to the JPEG format.
 

--- a/tests/drivers/build_all/video/testcase.yaml
+++ b/tests/drivers/build_all/video/testcase.yaml
@@ -44,3 +44,10 @@ tests:
   drivers.video.stm32_venc.build:
     platform_allow:
       - stm32n6570_dk/stm32n657xx/sb
+    extra_configs:
+      - CONFIG_VIDEO_ENCODER_H264=y
+  drivers.video.stm32_jpeg.build:
+    platform_allow:
+      - stm32n6570_dk/stm32n657xx/sb
+    extra_configs:
+      - CONFIG_VIDEO_ENCODER_JPEG=y


### PR DESCRIPTION
Correct stm32 video bindings files by adding the title entry in them. This correct a comment made by @josuah (https://github.com/zephyrproject-rtos/zephyr/pull/96678#discussion_r2440173788) on a previous PR and which had not been fixed in that PR.

Correct the STM32 VENC build_all test entry and add the STM32 JPEG entry into testcase in order to be able to test build those two drivers.