### PR TITLE
tests: subsys: pm: Enable testing on MAX78002EVKIT

### DIFF
--- a/tests/subsys/pm/power_mgmt_soc/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt_soc/testcase.yaml
@@ -20,6 +20,7 @@ tests:
       - max32655fthr/max32655/m4
       - max32657evkit/max32657
       - max32657evkit/max32657/ns
+      - max78002evkit/max78002/m4
       - imx95_evk/mimx9596/m7
       - ek_ra8m1
       - ek_ra8d1


### PR DESCRIPTION
Adds MAX78002EVKIT board to the list of allowed platforms for SoC power management test.