### PR TITLE
tests: bluetooth: Recycle ext_adv_sets when stopping adv

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_gap.h
+++ b/tests/bluetooth/tester/src/btp/btp_gap.h
@@ -585,6 +585,7 @@ struct bt_le_adv_param;
 struct bt_data;
 struct bt_le_ext_adv *tester_gap_ext_adv_get(uint8_t ext_adv_idx);
 struct bt_le_per_adv_sync *tester_gap_padv_get(void);
+int tester_gap_clear_adv_instance(struct bt_le_ext_adv *ext_adv);
 int tester_gap_create_adv_instance(struct bt_le_adv_param *param, uint8_t own_addr_type,
 				   const struct bt_data *ad, size_t ad_len,
 				   const struct bt_data *sd, size_t sd_len,

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -600,6 +600,21 @@ static int tester_gap_ext_adv_idx_free_get(void)
 	return -ENOMEM;
 }
 
+static int tester_gap_ext_adv_idx_get(struct bt_le_ext_adv *ext_adv)
+{
+	if (!IS_ENABLED(CONFIG_BT_EXT_ADV)) {
+		return -ENOTSUP;
+	}
+
+	for (int i = 0; i < ARRAY_SIZE(ext_adv_sets); i++) {
+		if (ext_adv_sets[i] == ext_adv) {
+			return i;
+		}
+	}
+
+	return -EINVAL;
+}
+
 int tester_gap_start_ext_adv(struct bt_le_ext_adv *ext_adv)
 {
 	if (!IS_ENABLED(CONFIG_BT_EXT_ADV)) {
@@ -643,6 +658,8 @@ int tester_gap_stop_ext_adv(struct bt_le_ext_adv *ext_adv)
 
 		return -EINVAL;
 	}
+
+	tester_gap_clear_adv_instance(ext_adv);
 
 	atomic_clear_bit(&current_settings, BTP_GAP_SETTINGS_ADVERTISING);
 
@@ -748,6 +765,29 @@ static uint8_t set_bondable(const void *cmd, uint16_t cmd_len,
 	rp->current_settings = sys_cpu_to_le32(current_settings);
 	*rsp_len = sizeof(*rp);
 	return BTP_STATUS_SUCCESS;
+}
+
+int tester_gap_clear_adv_instance(struct bt_le_ext_adv *ext_adv)
+{
+	if (!IS_ENABLED(CONFIG_BT_EXT_ADV)) {
+		return -ENOTSUP;
+	}
+
+	if (ext_adv == NULL) {
+		LOG_ERR("Invalid ext_adv");
+		return -EINVAL;
+	}
+
+	int index = tester_gap_ext_adv_idx_get(ext_adv);
+
+	if (index < 0) {
+		LOG_ERR("Failed to get ext_adv index");
+		return -EINVAL;
+	}
+
+	ext_adv_sets[index] = NULL;
+
+	return 0;
 }
 
 int tester_gap_create_adv_instance(struct bt_le_adv_param *param,
@@ -973,7 +1013,7 @@ static uint8_t stop_advertising(const void *cmd, uint16_t cmd_len,
 
 	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
 	    atomic_test_bit(&current_settings, BTP_GAP_SETTINGS_EXTENDED_ADVERTISING)) {
-		err = bt_le_ext_adv_stop(gap_ext_adv);
+		err = tester_gap_stop_ext_adv(gap_ext_adv);
 	} else {
 		err = bt_le_adv_stop();
 	}


### PR DESCRIPTION
- We want to reuse ext_advs when first stopped and restarted
- This ensures SID is the same
- Fixes CAP/CL/ADV/BV-03-C