### PR TITLE
STM32: H7RSx skip clock and xspi config when using XiP

### DIFF
--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -217,7 +217,7 @@
 
 	status = "okay";
 
-	mx25uw25645: xspi-nor-flash@0 {
+	ext_flash_ctrl: xspi-nor-flash@0 {
 		compatible = "st,stm32-xspi-nor";
 		reg = <0>;
 		size = <DT_SIZE_M(256)>; /* 256Mbits */
@@ -227,29 +227,40 @@
 		four-byte-opcodes;
 		status = "okay";
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x70000000 DT_SIZE_M(32)>;
 
-			slot0_partition: partition@0 {
-				label = "image-0";
-				reg = <0x00000000 DT_SIZE_K(512)>;
-			};
+		ext_flash: mx25uw25645: xspi-nor-flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(32)>;
+			write-block-size = <1>;
+			erase-block-size = <DT_SIZE_K(4)>;
 
-			slot1_partition: partition@80000 {
-				label = "image-1";
-				reg = <0x0080000 DT_SIZE_K(512)>;
-			};
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
 
-			scratch_partition: partition@100000 {
-				label = "image-scratch";
-				reg = <0x00100000 DT_SIZE_K(64)>;
-			};
+				slot0_partition: partition@0 {
+					label = "image-0";
+					reg = <0x00000000 DT_SIZE_K(512)>;
+				};
 
-			storage_partition: partition@110000 {
-				label = "storage";
-				reg = <0x00110000 DT_SIZE_K(64)>;
+				slot1_partition: partition@80000 {
+					label = "image-1";
+					reg = <0x0080000 DT_SIZE_K(512)>;
+				};
+
+				scratch_partition: partition@100000 {
+					label = "image-scratch";
+					reg = <0x00100000 DT_SIZE_K(64)>;
+				};
+
+				storage_partition: partition@110000 {
+					label = "storage";
+					reg = <0x00110000 DT_SIZE_K(64)>;
+				};
 			};
 		};
 	};

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -680,10 +680,36 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 	return 0;
 }
 
+static enum clock_control_status stm32_clock_control_get_status(const struct device *dev,
+								clock_control_subsys_t sub_system)
+{
+	struct stm32_pclken *pclken = (struct stm32_pclken *)sub_system;
+
+	ARG_UNUSED(dev);
+
+	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == true) {
+		/* Gated clocks */
+		if ((sys_read32(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus) & pclken->enr)
+			== pclken->enr) {
+			return CLOCK_CONTROL_STATUS_ON;
+		} else {
+			return CLOCK_CONTROL_STATUS_OFF;
+		}
+	} else {
+		/* Domain clock sources */
+		if (enabled_clock(pclken->bus) == 0) {
+			return CLOCK_CONTROL_STATUS_ON;
+		} else {
+			return CLOCK_CONTROL_STATUS_OFF;
+		}
+	}
+}
+
 static DEVICE_API(clock_control, stm32_clock_control_api) = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,
+	.get_status = stm32_clock_control_get_status,
 	.configure = stm32_clock_control_configure,
 };
 

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2118,9 +2118,14 @@ static int flash_stm32_xspi_init(const struct device *dev)
 		return -ENOTSUP;
 	}
 #if defined(CONFIG_SOC_SERIES_STM32H7RSX)
-	LL_PWR_EnableXSPIM2();
 	__HAL_RCC_SBS_CLK_ENABLE();
-	LL_SBS_EnableXSPI2SpeedOptim();
+	if (dev_data->hxspi.Instance == XSPI1) {
+		LL_PWR_EnableXSPIM1();
+		LL_SBS_EnableXSPI1SpeedOptim();
+	} else if (dev_data->hxspi.Instance == XSPI2) {
+		LL_PWR_EnableXSPIM2();
+		LL_SBS_EnableXSPI2SpeedOptim();
+	}
 #endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 
 	/* Signals configuration */

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -111,7 +111,7 @@
 			compatible = "st,stm32h7-hsi-clock";
 			hsi-div = <1>;	/* HSI RC: 64MHz, hsi_clk = 64MHz */
 			clock-frequency = <DT_FREQ_M(64)>;
-			status = "disabled";
+			status = "okay"; /* controller reset default is on */
 		};
 
 		clk_hsi48: clk-hsi48 {

--- a/samples/sysbuild/with_mcuboot/boards/nucleo_h7s3l8.overlay
+++ b/samples/sysbuild/with_mcuboot/boards/nucleo_h7s3l8.overlay
@@ -11,7 +11,7 @@
 / {
 	chosen {
 		zephyr,flash = &mx25uw25645;
-		zephyr,flash-controller = &mx25uw25645;
+		zephyr,flash-controller = &ext_flash_ctrl;
 		zephyr,code-partition = &slot0_partition;
 	};
 };

--- a/soc/st/stm32/stm32h7rsx/soc.c
+++ b/soc/st/stm32/stm32h7rsx/soc.c
@@ -55,9 +55,14 @@ void soc_early_init_hook(void)
 #else
 	LL_PWR_ConfigSupply(LL_PWR_LDO_SUPPLY);
 #endif
+
+/* The chain-loaded application must not switch to LL_PWR_REGU_VOLTAGE_SCALE1, because the
+ * bootloader most likely setup a fast core clock. */
+#if !defined(CONFIG_STM32_APP_IN_EXT_FLASH)
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
 	while (LL_PWR_IsActiveFlag_VOSRDY() == 0) {
 	}
+#endif /* defined(CONFIG_STM32_APP_IN_EXT_FLASH) */
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpioo), okay) || DT_NODE_HAS_STATUS(DT_NODELABEL(gpiop), okay)
 	LL_PWR_EnableXSPIM1(); /* Required for powering GPIO O and P */


### PR DESCRIPTION
I am using a customized OpenBLT bootloader which configures the clock system and the XSPI peripheral, then a Zephyr app is executed from external flash. I have not used MCUboot yet, but the problematic should be the same: 
Zephyr must not change the clock path used for clocking the XSPI peripheral and must not change XSPI configuration nor set a VOLTAGE_SCALE not allowed for the already high cpu clock.

I have `CONFIG_XIP=y` set in my prj.conf, `CONFIG_STM32_APP_IN_EXT_FLASH` is automatically set because of  its `default $(DT_FLASH_PARENT_IS_XSPI)` value.

With the changes in this PR, the combination of bootloader and zephyr runs fine on the nucleo_h7s3l8. But I'm not sure if this is the best way to handle things, so I open this up for discussion...