### PR TITLE
dts: mcxw23x: Correct the flash0 in common dtsi

### DIFF
--- a/dts/arm/nxp/nxp_mcxw23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw23x_common.dtsi
@@ -89,8 +89,8 @@
 		flash0: flash@0 {
 			compatible = "soc-nv-flash";
 			reg = <0x0 DT_SIZE_K(1016)>;
-			erase-block-size = <512>;
-			write-block-size = <512>;
+			erase-block-size = <DT_SIZE_K(8)>;
+			write-block-size = <16>;
 		};
 
 		flash_reserved: flash@fe000 {


### PR DESCRIPTION
According to the RM, erasing must be done per sector. So, the start address and the size of an erase operation must be a multiple of 8192 bytes. So, the erase-block-size should be 8192 bytes. Programming can be done per phrase (start address and size a multiple of 16 bytes). So, write-block-size should be 16 bytes.