### PR TITLE
dts: arm: silabs: Use separate rtcc and sysrtc bindings

### DIFF
--- a/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
@@ -183,7 +183,7 @@ zephyr_i2c: &i2c0 {
 	status = "okay";
 };
 
-&stimer0 {
+&sysrtc0 {
 	status = "okay";
 };
 

--- a/drivers/counter/Kconfig.gecko
+++ b/drivers/counter/Kconfig.gecko
@@ -3,6 +3,8 @@
 # Copyright (c) 2019, Piotr Mienkowski
 # SPDX-License-Identifier: Apache-2.0
 
+DT_CHOSEN_SILABS_SLEEPTIMER := silabs,sleeptimer
+
 config COUNTER_GECKO_RTCC
 	bool "Silicon Labs Gecko Counter (RTCC) driver"
 	default y
@@ -16,7 +18,7 @@ config COUNTER_GECKO_RTCC
 config COUNTER_GECKO_STIMER
 	bool "Silicon Labs Gecko Counter Sleep Timer driver"
 	default y
-	depends on DT_HAS_SILABS_GECKO_STIMER_ENABLED
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_SILABS_SLEEPTIMER))
 	select SILABS_SISDK_SLEEPTIMER
 	help
 	  Enable the counter driver for Sleep Timer module for Silicon Labs

--- a/drivers/counter/counter_gecko_stimer.c
+++ b/drivers/counter/counter_gecko_stimer.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT silabs_gecko_stimer
-
 #include <errno.h>
 #include <stddef.h>
 #include <string.h>
@@ -21,7 +19,7 @@
 
 LOG_MODULE_REGISTER(counter_gecko, CONFIG_COUNTER_LOG_LEVEL);
 
-#define DT_RTC DT_COMPAT_GET_ANY_STATUS_OKAY(silabs_gecko_stimer)
+#define DT_RTC DT_CHOSEN(silabs_sleeptimer)
 
 #define STIMER_ALARM_NUM 2
 #define STIMER_MAX_VALUE 0xFFFFFFFFUL
@@ -273,7 +271,7 @@ static DEVICE_API(counter, counter_gecko_driver_api) = {
 	.get_top_value = counter_gecko_get_top_value,
 };
 
-BUILD_ASSERT((DT_INST_PROP(0, prescaler) > 0U) && (DT_INST_PROP(0, prescaler) <= 32768U));
+BUILD_ASSERT((DT_PROP(DT_RTC, prescaler) > 0U) && (DT_PROP(DT_RTC, prescaler) <= 32768U));
 
 static void counter_gecko_0_irq_config(void)
 {
@@ -281,22 +279,22 @@ static void counter_gecko_0_irq_config(void)
 	IRQ_DIRECT_CONNECT(DT_IRQ(DT_RTC, irq), DT_IRQ(DT_RTC, priority),
 			   CONCAT(DT_STRING_UPPER_TOKEN_BY_IDX(DT_RTC, interrupt_names, 0),
 			   _IRQHandler), 0);
-	irq_enable(DT_INST_IRQN(0));
+	irq_enable(DT_IRQN(DT_RTC));
 #endif
 }
 
 static const struct counter_gecko_config counter_gecko_0_config = {
 	.info = {
 			.max_top_value = STIMER_MAX_VALUE,
-			.freq = DT_INST_PROP(0, clock_frequency) / DT_INST_PROP(0, prescaler),
+			.freq = DT_PROP(DT_RTC, clock_frequency) / DT_PROP(DT_RTC, prescaler),
 			.flags = COUNTER_CONFIG_INFO_COUNT_UP,
 			.channels = STIMER_ALARM_NUM,
 		},
 	.irq_config = counter_gecko_0_irq_config,
-	.prescaler = DT_INST_PROP(0, prescaler),
+	.prescaler = DT_PROP(DT_RTC, prescaler),
 };
 
 static struct counter_gecko_data counter_gecko_0_data;
 
-DEVICE_DT_INST_DEFINE(0, counter_gecko_init, NULL, &counter_gecko_0_data, &counter_gecko_0_config,
-		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &counter_gecko_driver_api);
+DEVICE_DT_DEFINE(DT_RTC, counter_gecko_init, NULL, &counter_gecko_0_data, &counter_gecko_0_config,
+		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &counter_gecko_driver_api);

--- a/drivers/timer/Kconfig.silabs
+++ b/drivers/timer/Kconfig.silabs
@@ -1,10 +1,12 @@
 # Copyright (c) 2024 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+DT_CHOSEN_SILABS_SLEEPTIMER := silabs,sleeptimer
+
 config SILABS_SLEEPTIMER_TIMER
 	bool "Silabs Sleeptimer system clock driver"
 	depends on SOC_FAMILY_SILABS_S2 || SOC_FAMILY_SILABS_SIWX91X
-	depends on DT_HAS_SILABS_GECKO_STIMER_ENABLED
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_SILABS_SLEEPTIMER))
 	select SILABS_SISDK_SLEEPTIMER
 	select TICKLESS_CAPABLE
 	select TIMER_READS_ITS_FREQUENCY_AT_RUNTIME

--- a/drivers/timer/silabs_sleeptimer_timer.c
+++ b/drivers/timer/silabs_sleeptimer_timer.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(silabs_sleeptimer_timer);
 /* Maximum time interval between timer interrupts (in hw_cycles) */
 #define MAX_TIMEOUT_CYC (UINT32_MAX >> 1)
 
-#define DT_RTC DT_COMPAT_GET_ANY_STATUS_OKAY(silabs_gecko_stimer)
+#define DT_RTC DT_CHOSEN(silabs_sleeptimer)
 
 /* Ensure interrupt names don't expand to register interface struct pointers */
 #undef RTCC

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -11,6 +11,7 @@
 
 / {
 	chosen {
+		silabs,sleeptimer = &sysrtc0;
 		zephyr,sram = &sram0;
 		zephyr,entropy = &rng0;
 		zephyr,flash = &flash0;
@@ -359,8 +360,8 @@
 			status = "disabled";
 		};
 
-		sysrtc0: stimer0: sysrtc@24048c00 {
-			compatible = "silabs,gecko-stimer";
+		sysrtc0: sysrtc@24048c00 {
+			compatible = "silabs,sysrtc";
 			reg = <0x24048c00 0x78>;
 			interrupts = <22 0>;
 			interrupt-names = "sysrtc";

--- a/dts/arm/silabs/xg21/xg21.dtsi
+++ b/dts/arm/silabs/xg21/xg21.dtsi
@@ -16,6 +16,7 @@
 
 / {
 	chosen {
+		silabs,sleeptimer = &rtcc0;
 		zephyr,entropy = &se;
 		zephyr,flash-controller = &msc;
 	};
@@ -448,8 +449,8 @@
 			status = "disabled";
 		};
 
-		rtcc0: stimer0: rtcc@58000000 {
-			compatible = "silabs,gecko-stimer";
+		rtcc0: rtcc@58000000 {
+			compatible = "silabs,rtcc";
 			reg = <0x58000000 0x4000>;
 			clock-frequency = <32768>;
 			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_RTCCCLK>;

--- a/dts/arm/silabs/xg22/xg22.dtsi
+++ b/dts/arm/silabs/xg22/xg22.dtsi
@@ -15,6 +15,7 @@
 
 / {
 	chosen {
+		silabs,sleeptimer = &rtcc0;
 		zephyr,entropy = &trng;
 		zephyr,flash-controller = &msc;
 	};
@@ -491,8 +492,8 @@
 			status = "disabled";
 		};
 
-		rtcc0: stimer0: rtcc@58000000 {
-			compatible = "silabs,gecko-stimer";
+		rtcc0: rtcc@58000000 {
+			compatible = "silabs,rtcc";
 			reg = <0x58000000 0x4000>;
 			clock-frequency = <32768>;
 			clocks = <&cmu CLOCK_RTCC CLOCK_BRANCH_RTCCCLK>;

--- a/dts/arm/silabs/xg23/xg23.dtsi
+++ b/dts/arm/silabs/xg23/xg23.dtsi
@@ -15,6 +15,7 @@
 
 / {
 	chosen {
+		silabs,sleeptimer = &sysrtc0;
 		zephyr,entropy = &se;
 		zephyr,flash-controller = &msc;
 	};
@@ -511,8 +512,8 @@
 			status = "disabled";
 		};
 
-		sysrtc0: stimer0: sysrtc@500a8000 {
-			compatible = "silabs,gecko-stimer";
+		sysrtc0: sysrtc@500a8000 {
+			compatible = "silabs,sysrtc";
 			reg = <0x500a8000 0x4000>;
 			clock-frequency = <32768>;
 			clocks = <&cmu CLOCK_SYSRTC0 CLOCK_BRANCH_SYSRTCCLK>;

--- a/dts/arm/silabs/xg24/xg24.dtsi
+++ b/dts/arm/silabs/xg24/xg24.dtsi
@@ -15,6 +15,7 @@
 
 / {
 	chosen {
+		silabs,sleeptimer = &sysrtc0;
 		zephyr,entropy = &se;
 		zephyr,flash-controller = &msc;
 	};
@@ -494,8 +495,8 @@
 			status = "disabled";
 		};
 
-		sysrtc0: stimer0: sysrtc@500a8000 {
-			compatible = "silabs,gecko-stimer";
+		sysrtc0: sysrtc@500a8000 {
+			compatible = "silabs,sysrtc";
 			reg = <0x500a8000 0x4000>;
 			clock-frequency = <32768>;
 			clocks = <&cmu CLOCK_SYSRTC0 CLOCK_BRANCH_SYSRTCCLK>;

--- a/dts/arm/silabs/xg27/xg27.dtsi
+++ b/dts/arm/silabs/xg27/xg27.dtsi
@@ -15,6 +15,7 @@
 
 / {
 	chosen {
+		silabs,sleeptimer = &rtcc0;
 		zephyr,entropy = &trng;
 		zephyr,flash-controller = &msc;
 	};
@@ -491,8 +492,8 @@
 			status = "disabled";
 		};
 
-		rtcc0: stimer0: rtcc@58000000 {
-			compatible = "silabs,gecko-stimer";
+		rtcc0: rtcc@58000000 {
+			compatible = "silabs,rtcc";
 			reg = <0x58000000 0x4000>;
 			clock-frequency = <32768>;
 			clocks = <&cmu CLOCK_RTCC CLOCK_BRANCH_RTCCCLK>;

--- a/dts/arm/silabs/xg28/xg28.dtsi
+++ b/dts/arm/silabs/xg28/xg28.dtsi
@@ -15,6 +15,7 @@
 
 / {
 	chosen {
+		silabs,sleeptimer = &sysrtc0;
 		zephyr,entropy = &se;
 		zephyr,flash-controller = &msc;
 	};
@@ -511,8 +512,8 @@
 			status = "disabled";
 		};
 
-		sysrtc0: stimer0: sysrtc@500a8000 {
-			compatible = "silabs,gecko-stimer";
+		sysrtc0: sysrtc@500a8000 {
+			compatible = "silabs,sysrtc";
 			reg = <0x500a8000 0x4000>;
 			clock-frequency = <32768>;
 			clocks = <&cmu CLOCK_SYSRTC0 CLOCK_BRANCH_SYSRTCCLK>;

--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -14,6 +14,7 @@
 
 / {
 	chosen {
+		silabs,sleeptimer = &rtcc0;
 		zephyr,entropy = &se;
 		zephyr,flash-controller = &msc;
 	};
@@ -505,8 +506,8 @@
 			status = "disabled";
 		};
 
-		rtcc0: stimer0: rtcc@58000000 {
-			compatible = "silabs,gecko-stimer";
+		rtcc0: rtcc@58000000 {
+			compatible = "silabs,rtcc";
 			reg = <0x58000000 0x4000>;
 			clock-frequency = <32768>;
 			clocks = <&cmu CLOCK_RTCC CLOCK_BRANCH_RTCCCLK>;

--- a/dts/bindings/rtc/silabs,rtcc.yaml
+++ b/dts/bindings/rtc/silabs,rtcc.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2025 Silicon Laboratories Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+title: Silicon Labs Series 2 RTCC (Real Time Clock with Capture)
+
+description: |
+  The Real Time Clock with Capture (RTCC) is a 32-bit counter kept running down to energy mode EM3.
+  It can be used as an EM2/3 wakeup source as well as a timekeeping counter during low energy mode.
+
+compatible: "silabs,rtcc"
+
+include: rtc.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/bindings/rtc/silabs,sysrtc.yaml
+++ b/dts/bindings/rtc/silabs,sysrtc.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Silicon Laboratories Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+title: Silicon Labs Series 2 SYSRTC (System Real Time Clock)
+
+description: |
+  The SYSRTC (System Real Time Counter) is a 32-bit counter kept running down to energy mode EM3.
+  It can be used as a sleep timer / wakeup source as well as a timekeeping counter during low energy
+  modes. Multiple groups of capture / compare registers are available to different cores in the
+  system, allowing the peripheral and time base to be shared across cores and save energy.
+
+compatible: "silabs,sysrtc"
+
+include: rtc.yaml
+
+properties:
+  reg:
+    required: true

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -94,7 +94,7 @@ static const struct device *const devices[] = {
 	DEVS_FOR_DT_COMPAT(st_stm32_rtc)
 #endif
 #ifdef CONFIG_COUNTER_GECKO_STIMER
-	DEVS_FOR_DT_COMPAT(silabs_gecko_stimer)
+	DEVICE_DT_GET(DT_CHOSEN(silabs_sleeptimer)),
 #endif
 #ifdef CONFIG_COUNTER_NXP_PIT
 	DEVS_FOR_DT_COMPAT(nxp_pit_channel)


### PR DESCRIPTION
Series 2 devices have multiple different RTC IPs that all share a HAL driver. Introduce separate bindings for the different IPs, and use a chosen node to select the node to use for timekeeping.