### PR TITLE
Bluetooth: Host: Make use of common array helper macros

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -187,11 +187,9 @@ static struct bt_le_ext_adv adv_pool[CONFIG_BT_EXT_ADV_MAX_ADV_SET];
 #if defined(CONFIG_BT_EXT_ADV)
 uint8_t bt_le_ext_adv_get_index(struct bt_le_ext_adv *adv)
 {
-	ptrdiff_t index = adv - adv_pool;
+	__ASSERT(IS_ARRAY_ELEMENT(adv_pool, adv), "Invalid bt_adv pointer");
 
-	__ASSERT(index >= 0 && index < ARRAY_SIZE(adv_pool),
-		 "Invalid bt_adv pointer");
-	return (uint8_t)index;
+	return (uint8_t)ARRAY_INDEX(adv_pool, adv);
 }
 
 static struct bt_le_ext_adv *adv_new(void)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1546,23 +1546,20 @@ uint8_t bt_conn_index(const struct bt_conn *conn)
 	switch (conn->type) {
 #if defined(CONFIG_BT_ISO)
 	case BT_CONN_TYPE_ISO:
-		index = conn - iso_conns;
-		__ASSERT(index >= 0 && index < ARRAY_SIZE(iso_conns),
-			"Invalid bt_conn pointer");
+		__ASSERT(IS_ARRAY_ELEMENT(iso_conns, conn), "Invalid bt_conn pointer");
+		index = ARRAY_INDEX(iso_conns, conn);
 		break;
 #endif
 #if defined(CONFIG_BT_CLASSIC)
 	case BT_CONN_TYPE_SCO:
-		index = conn - sco_conns;
-		__ASSERT(index >= 0 && index < ARRAY_SIZE(sco_conns),
-			"Invalid bt_conn pointer");
+		__ASSERT(IS_ARRAY_ELEMENT(sco_conns, conn), "Invalid bt_conn pointer");
+		index = ARRAY_INDEX(sco_conns, conn);
 		break;
 #endif
 	default:
 #if defined(CONFIG_BT_CONN)
-		index = conn - acl_conns;
-		__ASSERT(index >= 0 && index < ARRAY_SIZE(acl_conns),
-			 "Invalid bt_conn pointer");
+		__ASSERT(IS_ARRAY_ELEMENT(acl_conns, conn), "Invalid bt_conn pointer");
+		index = ARRAY_INDEX(acl_conns, conn);
 #else
 		__ASSERT(false, "Invalid connection type %u", conn->type);
 #endif /* CONFIG_BT_CONN */

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1841,11 +1841,10 @@ void bt_le_scan_cb_unregister(struct bt_le_scan_cb *cb)
 #if defined(CONFIG_BT_PER_ADV_SYNC)
 uint8_t bt_le_per_adv_sync_get_index(struct bt_le_per_adv_sync *per_adv_sync)
 {
-	ptrdiff_t index = per_adv_sync - per_adv_sync_pool;
-
-	__ASSERT(index >= 0 && ARRAY_SIZE(per_adv_sync_pool) > index,
+	__ASSERT(IS_ARRAY_ELEMENT(per_adv_sync_pool, per_adv_sync),
 		 "Invalid per_adv_sync pointer");
-	return (uint8_t)index;
+
+	return (uint8_t)ARRAY_INDEX(per_adv_sync_pool, per_adv_sync);
 }
 
 struct bt_le_per_adv_sync *bt_le_per_adv_sync_lookup_index(uint8_t index)


### PR DESCRIPTION
There's a bunch of convenience macros in sys/util.h that are intended to help out with translating array indices and determining if an element is part of an array or not. Use those instead of custom code.