### PR TITLE
drivers: disk: sdmmc_stm32: Add API to retrieve SD card CSD register

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -876,6 +876,13 @@ void stm32_sdmmc_get_card_cid(const struct device *dev, uint32_t cid[4])
 	memcpy(cid, &priv->hsd.CID, sizeof(priv->hsd.CID));
 }
 
+void stm32_sdmmc_get_card_csd(const struct device *dev, uint32_t csd[4])
+{
+	const struct stm32_sdmmc_priv *priv = dev->data;
+
+	memcpy(csd, &priv->hsd.CSD, sizeof(priv->hsd.CSD));
+}
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_DRV_INST(0))
 
 #if STM32_SDMMC_USE_DMA

--- a/include/zephyr/drivers/disk/sdmmc_stm32.h
+++ b/include/zephyr/drivers/disk/sdmmc_stm32.h
@@ -28,4 +28,22 @@
  */
 void stm32_sdmmc_get_card_cid(const struct device *dev, uint32_t cid[4]);
 
+/**
+ * @brief Get the CSD (Card Specific Data) information from the SD/MMC card.
+ *
+ * This function copies the Card Specific Data (CSD) from the internal
+ * HAL SD/MMC struct populated during device initialization. It does not check
+ * the current presence or status of the card. If the card was removed after
+ * initialization (or initialization failed), the returned CSD may be stale or
+ * all zeroes.
+ *
+ * It is the caller's responsibility to verify that the card is present and
+ * initialized (e.g., by calling @ref disk_access_status) before invoking this
+ * function.
+ *
+ * @param dev Pointer to the device structure representing the SD/MMC card.
+ * @param csd Pointer to an array where the CSD data will be stored.
+ */
+void stm32_sdmmc_get_card_csd(const struct device *dev, uint32_t csd[4]);
+
 #endif /* ZEPHYR_INCLUDE_DRIVERS_DISK_SDMMC_STM32_H_ */


### PR DESCRIPTION
Introduce a new API function in the sdmmc_stm32 driver that allows applications to access the Card Specific Data (CSD) register of the SD/MMC card. This functionality, already available in the SPI-based SD and MMC subsystems, was previously missing from the STM32 SDMMC driver.

This enhancement enables use cases such as verifying the correct SD card during manufacturing, ensuring that OEMs use the specified SD card, and preventing mismatches.

This PR is a follow-up on PR #94651.  