### PR TITLE
DTS: Align *-map-mask, *-map-pass-thru types

### DIFF
--- a/dts/bindings/adc/arduino,uno-adc.yaml
+++ b/dts/bindings/adc/arduino,uno-adc.yaml
@@ -21,10 +21,10 @@ properties:
     required: true
 
   io-channel-map-mask:
-    type: compound
+    type: array
 
   io-channel-map-pass-thru:
-    type: compound
+    type: array
 
   "#io-channel-cells":
     type: int

--- a/dts/bindings/gpio/gpio-nexus.yaml
+++ b/dts/bindings/gpio/gpio-nexus.yaml
@@ -9,10 +9,10 @@ properties:
     required: true
 
   gpio-map-mask:
-    type: compound
+    type: array
 
   gpio-map-pass-thru:
-    type: compound
+    type: array
 
   "#gpio-cells":
     type: int


### PR DESCRIPTION
This PR aligns all the bindings types for Nexus nodes.

Now all are the same as ./zephyr/dts/bindings/pwm/pwm-nexus.yaml