### PR TITLE
include: zephyr: arch: add missing stddef.h/stdbool.h in cache.h

### DIFF
--- a/include/zephyr/arch/cache.h
+++ b/include/zephyr/arch/cache.h
@@ -24,6 +24,9 @@
 #include <zephyr/arch/xtensa/cache.h>
 #endif
 
+#include <stddef.h>
+#include <stdbool.h>
+
 #if defined(CONFIG_DCACHE) || defined(__DOXYGEN__)
 
 /**


### PR DESCRIPTION
Add missing inclusion of stddef.h and stdbool.h to respectively define size_t and bool types used in some cache.h function declarations.

This change prevents build errors like:
```
.../zephyr/include/zephyr/arch/cache.h:105:41: error: unknown type name 'size_t'
  105 | int arch_dcache_flush_range(void *addr, size_t size);
      |                                         ^~~~~~