### PR TITLE
arch: arm: mpu: move MPU memory configuration header

### DIFF
--- a/arch/arm/core/mpu/arm_mpu_regions.c
+++ b/arch/arm/core/mpu/arm_mpu_regions.c
@@ -7,7 +7,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/arch/arm/mpu/arm_mpu.h>
 
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 static const struct arm_mpu_region mpu_regions[] = {
 #ifdef CONFIG_XIP

--- a/boards/nxp/mimxrt1180_evk/cm7/mpu_regions.c
+++ b/boards/nxp/mimxrt1180_evk/cm7/mpu_regions.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 #define MEMORY_REGION_SIZE_KB(SIZE)    (SIZE / 1024)
 

--- a/include/zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h
@@ -4,8 +4,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef _ARM_CORTEX_M_MPU_MEM_CFG_H_
-#define _ARM_CORTEX_M_MPU_MEM_CFG_H_
+#ifndef _INCLUDE_ZEPHYR_ARCH_ARM_MPU_MEM_CFG_H_
+#define _INCLUDE_ZEPHYR_ARCH_ARM_MPU_MEM_CFG_H_
 
 #include <zephyr/arch/arm/mpu/arm_mpu.h>
 
@@ -119,4 +119,4 @@
 
 #endif /* !ARMV8_M_BASELINE && !ARMV8_M_MAINLINE */
 
-#endif /* _ARM_CORTEX_M_MPU_MEM_CFG_H_ */
+#endif /* _INCLUDE_ZEPHYR_ARCH_ARM_MPU_MEM_CFG_H_ */

--- a/soc/adi/max32/mpu_regions.c
+++ b/soc/adi/max32/mpu_regions.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/storage/flash_map.h>
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 /*
  * Define noncacheable flash region attributes using noncacheable SRAM memory

--- a/soc/infineon/cat1b/cyw20829/mpu_regions.c
+++ b/soc/infineon/cat1b/cyw20829/mpu_regions.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 #define BOOTSTRAP_SAHB_RAM_BASE_ADDRESS DT_REG_ADDR(DT_NODELABEL(sram_bootstrap_sahb))
 #define BOOTSTRAP_CBUS_RAM_BASE_ADDRESS DT_REG_ADDR(DT_NODELABEL(sram_bootstrap_cbus))

--- a/soc/infineon/edge/pse84/mpu_regions.c
+++ b/soc/infineon/edge/pse84/mpu_regions.c
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 /* We are expected to give *CONFIG_SIZE* in KB, but REGION_ATTR
  * expects bytes, so we multiply by 1024 to convert.

--- a/soc/nordic/common/nrf54hx_nrf92x_mpu_regions.c
+++ b/soc/nordic/common/nrf54hx_nrf92x_mpu_regions.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 #define USBHS_BASE	DT_REG_ADDR_BY_NAME(DT_NODELABEL(usbhs), core)
 #define USBHS_SIZE	DT_REG_SIZE_BY_NAME(DT_NODELABEL(usbhs), core)

--- a/soc/nuvoton/npcx/npcx7/mpu_regions.c
+++ b/soc/nuvoton/npcx/npcx7/mpu_regions.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 static const struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("FLASH_0_0",

--- a/soc/nuvoton/numaker/m55m1x/mpu_regions.c
+++ b/soc/nuvoton/numaker/m55m1x/mpu_regions.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 static const struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("FLASH",

--- a/soc/nxp/imx/imx8m/m7/mpu_regions.c
+++ b/soc/nxp/imx/imx8m/m7/mpu_regions.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 #define REGION_MASK_BASE_ADDRESS			0x00000000U
 #define REGION_ITCM_BASE_ADDRESS			0x00000000U

--- a/soc/nxp/imxrt/mpu_regions.c
+++ b/soc/nxp/imxrt/mpu_regions.c
@@ -7,7 +7,7 @@
 #define SDRAM_BASE_ADDR 0x80000000
 
 #include <zephyr/devicetree.h>
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 0 */

--- a/soc/nxp/s32/s32k3/mpu_regions.c
+++ b/soc/nxp/s32/s32k3/mpu_regions.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/linker/devicetree_regions.h>
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 #if !defined(CONFIG_XIP)
 extern char _rom_attr[];

--- a/soc/renode/cortex_r8_virtual/arm_mpu_regions.c
+++ b/soc/renode/cortex_r8_virtual/arm_mpu_regions.c
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 extern const uint32_t __rom_region_start;
 extern const uint32_t __rom_region_mpu_size_bits;

--- a/soc/st/stm32/stm32h7rsx/mpu_regions.c
+++ b/soc/st/stm32/stm32h7rsx/mpu_regions.c
@@ -8,7 +8,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/arch/arm/mpu/arm_mpu.h>
 
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 static const struct arm_mpu_region mpu_regions[] = {
 	/* Use first region to prevent speculative access in entire memory space */

--- a/soc/st/stm32/stm32h7x/mpu_regions.c
+++ b/soc/st/stm32/stm32h7x/mpu_regions.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 static const struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("FLASH", CONFIG_FLASH_BASE_ADDRESS,

--- a/soc/ti/k3/am6x/r5/arm_mpu_regions.c
+++ b/soc/ti/k3/am6x/r5/arm_mpu_regions.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
 #include <zephyr/arch/arm/mpu/arm_mpu.h>

--- a/soc/xlnx/zynqmp/arm_mpu_regions.c
+++ b/soc/xlnx/zynqmp/arm_mpu_regions.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
 extern const uint32_t __rom_region_start;
 extern const uint32_t __rom_region_mpu_size_bits;


### PR DESCRIPTION
Result of a discussion in #96689.

Move the helper file arm_mpu_mem_cfg.h, which translates the values of the Kconfig symbols CONFIG_FLASH_SIZE and CONFIG_SRAM_SIZE to size definitions to be used during region MPU setup, from a Cortex-M-specific include directory to the Cortex-agnostic zephyr/arch/arm/mpu directory, as:

- the contents of this header file are not dependent on the target being an ARMv7M, only ARMv8M is actively excluded, but the contents are identical for the ARMv7/8 Cortex-R MPU implementation,
- the header file zephyr/arch/arm/mpu/arm_mpu.h, included within arm_mpu_mem_cfg.h, is also compatible with both Cortex-M and Cortex-R, the distinction between the two implementations takes place at an even lower level,
- several ARMv7/8 Cortex-R targets now reference this header file in their MPU region setup (Xilinx ZynqMP, TI K3, Renode cortex_r8_virtual) while so far referencing it in an ARMv7 Cortex-M-specific include directory.

Includes updated includes for all SoCs/boards referencing this header file.