### PR TITLE
ipc: icmsg: Increase default stack size

### DIFF
--- a/subsys/ipc/ipc_service/lib/Kconfig.icmsg
+++ b/subsys/ipc/ipc_service/lib/Kconfig.icmsg
@@ -43,6 +43,7 @@ if IPC_SERVICE_BACKEND_ICMSG_WQ_ENABLE
 
 config IPC_SERVICE_BACKEND_ICMSG_WQ_STACK_SIZE
 	int "Size of RX work queue stack"
+	default 5400 if NRF71_ON_IPC
 	default 1280
 	help
 	  Size of stack used by work queue RX thread. This work queue is


### PR DESCRIPTION
For nRF71 Wi-Fi a higher stack size is needed.