### PR TITLE
west: bindesc: add extract subcommand

### DIFF
--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -252,6 +252,10 @@ You can dump all of the descriptors in an image using::
 
    west bindesc dump build/zephyr/zephyr.bin
 
+You can extract the descriptor data area of the image to a file using::
+
+   west bindesc extract
+
 You can list all known standard descriptor names using::
 
    west bindesc list


### PR DESCRIPTION
Add a new `west bindesc extract` subcommand that dumps all binary descriptors into a separate binary file. It will also report the range (offset and length) of the dumped data within the original image.