### PR TITLE
cmake: reports: Fix puncover compatibility with v0.6.0

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -128,7 +128,7 @@ if(NOT ${PUNCOVER} STREQUAL PUNCOVER-NOTFOUND)
     puncover
     ${PUNCOVER}
     --elf_file       ${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
-    --gcc_tools_base ${CROSS_COMPILE}
+    --gcc-tools-base ${CROSS_COMPILE}
     --src_root       ${ZEPHYR_BASE}
     --build_dir      ${CMAKE_BINARY_DIR}
     ${PUNCOVER_ARGS}


### PR DESCRIPTION
Puncover v0.6.0 renamed the command-line argument
`--gcc_tools_base` to `--gcc-tools-base`.

Fixes compatibility error when running `west build -t puncover` with puncover v0.6.0 or newer.

Signed-off-by: Roy Jamil <roy.jamil@ac6.fr>