### PR TITLE
tests: kernel/common: skip test_nested_irq_offload if (arch_num_cpus(…

### DIFF
--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -111,7 +111,7 @@ static void offload_thread_fn(void *p0, void *p1, void *p2)
  */
 ZTEST(common_1cpu, test_nested_irq_offload)
 {
-	if (!IS_ENABLED(CONFIG_IRQ_OFFLOAD_NESTED)) {
+	if (arch_num_cpus() > 1 || !IS_ENABLED(CONFIG_IRQ_OFFLOAD_NESTED)) {
 		ztest_test_skip();
 	}
 


### PR DESCRIPTION
test_nested_irq_offload is meant for single CPU.
Skip it if there is more than 1 CPU.
