### PR TITLE
lib: smf: rename share_parent() to is_descendant_of()

### DIFF
--- a/lib/smf/smf.c
+++ b/lib/smf/smf.c
@@ -22,7 +22,8 @@ struct internal_ctx {
 };
 
 #ifdef CONFIG_SMF_ANCESTOR_SUPPORT
-static bool share_parent(const struct smf_state *test_state, const struct smf_state *target_state)
+static bool is_descendant_of(const struct smf_state *test_state,
+			     const struct smf_state *target_state)
 {
 	for (const struct smf_state *state = test_state; state != NULL; state = state->parent) {
 		if (target_state == state) {
@@ -65,7 +66,7 @@ static const struct smf_state *get_lca_of(const struct smf_state *source,
 	for (const struct smf_state *ancestor = source->parent; ancestor != NULL;
 	     ancestor = ancestor->parent) {
 		/* First common ancestor */
-		if (share_parent(dest, ancestor)) {
+		if (is_descendant_of(dest, ancestor)) {
 			return ancestor;
 		}
 	}
@@ -301,10 +302,10 @@ void smf_set_state(struct smf_ctx *const ctx, const struct smf_state *new_state)
 #ifdef CONFIG_SMF_ANCESTOR_SUPPORT
 	const struct smf_state *topmost;
 
-	if (share_parent(ctx->executing, new_state)) {
+	if (is_descendant_of(ctx->executing, new_state)) {
 		/* new state is a parent of where we are now*/
 		topmost = new_state;
-	} else if (share_parent(new_state, ctx->executing)) {
+	} else if (is_descendant_of(new_state, ctx->executing)) {
 		/* we are a parent of the new state */
 		topmost = ctx->executing;
 	} else {


### PR DESCRIPTION
Match behavior: returns true when target_state equals or
is an ancestor of test_state.