### PR TITLE
soc: infineon: PSOC Edge: Remove board references from soc cmake

### DIFF
--- a/modules/hal_infineon/mtb-template-cat1/CMakeLists.txt
+++ b/modules/hal_infineon/mtb-template-cat1/CMakeLists.txt
@@ -47,14 +47,10 @@ if(CONFIG_SOC_FAMILY_INFINEON_EDGE)
   zephyr_include_directories(${edge_dir}/devices/include)
 
   zephyr_library_sources(${edge_dir}/system_edge.c)
-  if(CONFIG_BOARD_KIT_PSE84_EVAL_PSE846GPS2DBZC4A_M33)
-    zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M33
-      ${edge_dir}/COMPONENT_CM33/COMPONENT_SECURE_DEVICE/s_system_pse84.c)
-    zephyr_include_directories(${edge_dir}/COMPONENT_CM33/COMPONENT_SECURE_DEVICE)
-  else()
-    zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M33
-      ${edge_dir}/COMPONENT_CM33/COMPONENT_NON_SECURE_DEVICE/ns_system_pse84.c)
-  endif()
-    zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M55
-      ${edge_dir}/COMPONENT_CM55/COMPONENT_NON_SECURE_DEVICE/ns_system_pse84.c)
+  zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M33
+    ${edge_dir}/COMPONENT_CM33/COMPONENT_SECURE_DEVICE/s_system_pse84.c)
+  zephyr_include_directories_ifdef(CONFIG_CPU_CORTEX_M33
+    ${edge_dir}/COMPONENT_CM33/COMPONENT_SECURE_DEVICE)
+  zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M55
+    ${edge_dir}/COMPONENT_CM55/COMPONENT_NON_SECURE_DEVICE/ns_system_pse84.c)
 endif()

--- a/soc/infineon/edge/pse84/CMakeLists.txt
+++ b/soc/infineon/edge/pse84/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 zephyr_include_directories(security_config)
 zephyr_sources(security_config/pse84_boot.c)
 
-if(CONFIG_BOARD_KIT_PSE84_EVAL_PSE846GPS2DBZC4A_M55 AND CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS)
+if(CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS)
   zephyr_sources_ifdef(CONFIG_CPU_CORTEX_M55 mpu_regions.c)
 endif()
 
@@ -51,7 +51,7 @@ if(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "armclang")
 endif()
 
 # Add sections
-if(CONFIG_BOARD_KIT_PSE84_EVAL_PSE846GPS2DBZC4A_M33)
+if(CONFIG_CPU_CORTEX_M33)
   zephyr_linker_sources(SECTIONS shared_mem_sec.ld)
   set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
 else()


### PR DESCRIPTION
Removes references to the kit_pse84_eval board from the soc cmake file.