### PR TITLE
net: mqtt_sn: fix returning address from zsock_recvfrom

### DIFF
--- a/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
@@ -213,7 +213,7 @@ static ssize_t tp_udp_recvfrom(struct mqtt_sn_client *client, void *buffer, size
 	struct mqtt_sn_transport_udp *udp = UDP_TRANSPORT(client->transport);
 	int rc;
 	struct sockaddr *srcaddr = src_addr;
-	socklen_t addrlen_local;
+	socklen_t addrlen_local = *addrlen;
 
 	rc = zsock_recvfrom(udp->sock, buffer, length, 0, src_addr, &addrlen_local);
 	LOG_DBG("recv %d", rc);


### PR DESCRIPTION
The fix in 1264a923f37bce88146674a3c7f93d3886a50669 was incomplete, because it doesn't initialize the variable. To quote from opengroup [1]: address_len
    Either a null pointer, if address is a null pointer, or a pointer to a
    socklen_t object which on input specifies the length of the supplied
    sockaddr structure, and on output specifies the length of the stored
    address.

This caused the returned address to be incomplete, because it got truncated depending on what addrlen_local got initialized with implicitly. This broke talking to discovered MQTT-SN gateways.

I intend to implement integration tests for the MQTT-SN UDP transport to prevent such issues in future, but that will be done in a separate PR.

[1] https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html