### PR TITLE
ci: doc-build: fix the "on:" clause

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -5,9 +5,10 @@ name: Documentation Build
 
 on:
   push:
+    branches:
+    - main
     tags:
     - v*
-    - main
   pull_request:
 
 permissions:


### PR DESCRIPTION
In commit f3edf5226461464ec4b00f6af089addbfa30c840, I erroneously put "main" under the existing "tags" entry which is obvisouly wrong, it should be under "branches". Sorry :|

Marking as trivial, even if it's borderline hotfix, so that we get a doc build again in the next merge or so.