### PR TITLE
Renesas: Add DTC support for SPI and I2C drivers

### DIFF
--- a/boards/renesas/rsk_rx130/rsk_rx130.dts
+++ b/boards/renesas/rsk_rx130/rsk_rx130.dts
@@ -120,6 +120,7 @@
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 	clock-frequency = <DT_FREQ_K(400)>;
+	status = "okay";
 };
 
 &ctsu {

--- a/drivers/i2c/Kconfig.renesas_rx
+++ b/drivers/i2c/Kconfig.renesas_rx
@@ -21,4 +21,12 @@ config I2C_RENESAS_RX_CALLBACK
 	help
 	  Enable Callback support for the I2C Driver
 
+config RENESAS_RX_I2C_DTC
+	bool "Renesas RX I2C transfer through DTC"
+	default y
+	depends on DT_HAS_RENESAS_RX_DTC_ENABLED
+	select RENESAS_RX_DTC
+	help
+	  Enable Using DTC module to transfer data
+
 endif # I2C_RENESAS_RX_RIIC

--- a/drivers/spi/Kconfig.renesas_rx
+++ b/drivers/spi/Kconfig.renesas_rx
@@ -29,4 +29,15 @@ config SPI_RENESAS_RX_HIGH_SPEED_READ
 	help
 	  Enable high speed read mode of RX RSPI Driver
 
+config SPI_RENESAS_RX_DTC
+	bool "RSPI DTC activate"
+	default y
+	depends on DT_HAS_RENESAS_RX_DTC_ENABLED
+	select RENESAS_RX_DTC
+	help
+	  Use DTC in RX RSPI transfer
+
+config SPI_RENESAS_RX_16BITS_FRAME
+	bool "Test loopback: 16 bits"
+
 endif # SPI_RENESAS_RX

--- a/drivers/spi/spi_renesas_rx.c
+++ b/drivers/spi/spi_renesas_rx.c
@@ -10,13 +10,16 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 #include <soc.h>
+#include <zephyr/logging/log.h>
 #include "r_rspi_rx_if.h"
 #include "iodefine.h"
 
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(rx_rspi);
-
 #include "spi_context.h"
+
+#ifdef CONFIG_SPI_RENESAS_RX_DTC
+#include <zephyr/drivers/misc/renesas_rx_dtc/renesas_rx_dtc.h>
+#endif
 
 #if defined(CONFIG_SPI_RENESAS_RX_INTERRUPT)
 typedef enum {
@@ -28,7 +31,8 @@ typedef enum {
 
 typedef struct rx_rspi_tcb_s {
 	rspi_operation_t transfer_mode;
-	rspi_str_tranmode_t data_tran_mode;
+	rspi_str_tranmode_t rx_data_tran_mode;
+	rspi_str_tranmode_t tx_data_tran_mode;
 	uint16_t tx_count;
 	uint16_t rx_count;
 	uint16_t xfr_length;
@@ -79,7 +83,15 @@ struct rx_rspi_data {
 	rx_rspi_tcb_t tcb;
 	uint32_t rxdata;
 	uint32_t data_len;
-#endif
+#if defined(CONFIG_SPI_RENESAS_RX_DTC)
+	/* dtc device handle */
+	const struct device *dtc;
+	transfer_info_t tx_dtc_info;
+	transfer_info_t rx_dtc_info;
+	uint8_t rx_dtc_activation_irq;
+	uint8_t tx_dtc_activation_irq;
+#endif /* CONFIG_SPI_RENESAS_RX_DTC */
+#endif /* CONFIG_SPI_RENESAS_RX_INTERRUPT */
 };
 
 struct rx_rspi_config {
@@ -240,7 +252,6 @@ static int rx_rspi_configure(const struct device *dev, const struct spi_config *
 	}
 
 	data->channel_setting.bps_target = config->frequency;
-	data->channel_setting.tran_mode = RSPI_TRANS_MODE_SW;
 
 	uint8_t array_rspi_bit_length[] = {
 		RSPI_SPCMD_BIT_LENGTH_8,  RSPI_SPCMD_BIT_LENGTH_9,  RSPI_SPCMD_BIT_LENGTH_10,
@@ -266,16 +277,41 @@ static int rx_rspi_configure(const struct device *dev, const struct spi_config *
 			return -ENOTSUP;
 		}
 	}
+	data->tcb.rx_data_tran_mode = RSPI_TRANS_MODE_SW;
+	data->tcb.tx_data_tran_mode = RSPI_TRANS_MODE_SW;
+	data->channel_setting.tran_mode = RSPI_TRANS_MODE_SW;
 
+#ifdef CONFIG_SPI_RENESAS_RX_DTC
+	int ret = 0;
+
+	/* Configure RX DTC */
+	data->rx_dtc_info.p_src = (void *)(&data->preg->SPDR);
+	ret = dtc_renesas_rx_configuration(data->dtc, data->rx_dtc_activation_irq,
+					   &data->rx_dtc_info);
+	if (ret != 0) {
+		LOG_ERR("DTC SPI rx config error");
+		dtc_renesas_rx_stop_transfer(data->dtc, data->rx_dtc_activation_irq);
+		return ret;
+	}
+	data->tcb.rx_data_tran_mode = RSPI_TRANS_MODE_DTC;
+
+	/* Configure TX DTC */
+	data->tx_dtc_info.p_dest = (void *)(&data->preg->SPDR);
+	ret = dtc_renesas_rx_configuration(data->dtc, data->tx_dtc_activation_irq,
+					   &data->tx_dtc_info);
+	if (ret != 0) {
+		LOG_ERR("DTC SPI tx config error");
+		dtc_renesas_rx_stop_transfer(data->dtc, data->tx_dtc_activation_irq);
+		return ret;
+	}
+	data->tcb.tx_data_tran_mode = RSPI_TRANS_MODE_DTC;
+	data->channel_setting.tran_mode = RSPI_TRANS_MODE_DTC;
+#endif /* CONFIG_SPI_RENESAS_RX_DTC */
 	err = R_RSPI_Open(data->channel_id, &data->channel_setting, data->command_word, spi_cb,
 			  &data->rspi);
 	if (err != RSPI_SUCCESS) {
 		LOG_ERR("R_RSPI_Open error: %d", err);
 		return -EINVAL;
-#if defined(CONFIG_SPI_RENESAS_RX_INTERRUPT)
-	} else {
-		data->tcb.data_tran_mode = data->channel_setting.tran_mode;
-#endif
 	}
 	/* Manually set these bits, because the Open function not */
 	data->preg->SPCMD0.BIT.CPHA = data->command_word.cpha;
@@ -470,6 +506,73 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 		goto end;
 	}
 
+#ifdef CONFIG_SPI_RENESAS_RX_DTC
+	/* Determine DTC transfer size */
+	transfer_size_t size;
+
+	if (data->tcb.bytes_per_transfer == RSPI_LONG_DATA) {
+		size = TRANSFER_SIZE_4_BYTE;
+	} else if (data->tcb.bytes_per_transfer == RSPI_WORD_DATA) {
+		size = TRANSFER_SIZE_2_BYTE;
+	} else {
+		size = TRANSFER_SIZE_1_BYTE;
+	}
+
+	/* Set up RX DTC */
+	transfer_info_t *p_info = &data->rx_dtc_info;
+
+	p_info->transfer_settings_word_b.size = size;
+	p_info->length = (uint16_t)data->data_len;
+	p_info->transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED;
+	p_info->p_dest = data->ctx.rx_buf;
+
+	if (data->ctx.rx_buf == NULL) {
+		static uint32_t dummy_rx;
+
+		p_info->transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_FIXED;
+		p_info->p_dest = &dummy_rx;
+	}
+
+	ret = dtc_renesas_rx_configuration(data->dtc, data->rx_dtc_activation_irq, p_info);
+	if (ret != 0) {
+		LOG_ERR("DTC SPI rx re-config error");
+		dtc_renesas_rx_stop_transfer(data->dtc, data->rx_dtc_activation_irq);
+		goto end;
+	}
+	ret = dtc_renesas_rx_start_transfer(data->dtc, data->rx_dtc_activation_irq);
+	if (ret != 0) {
+		LOG_ERR("DTC SPI rx start failed");
+		dtc_renesas_rx_stop_transfer(data->dtc, data->rx_dtc_activation_irq);
+		goto end;
+	}
+
+	/* Set up TX DTC */
+	p_info = &data->tx_dtc_info;
+	p_info->transfer_settings_word_b.size = size;
+	p_info->length = (uint16_t)data->data_len;
+	p_info->transfer_settings_word_b.src_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED;
+	p_info->p_src = data->ctx.tx_buf;
+	if (data->ctx.tx_buf == NULL) {
+		static uint32_t dummy_tx;
+
+		p_info->transfer_settings_word_b.src_addr_mode = TRANSFER_ADDR_MODE_FIXED;
+		p_info->p_src = &dummy_tx;
+	}
+
+	ret = dtc_renesas_rx_configuration(data->dtc, data->tx_dtc_activation_irq, p_info);
+	if (ret != 0) {
+		LOG_ERR("DTC SPI tx re-config error");
+		dtc_renesas_rx_stop_transfer(data->dtc, data->tx_dtc_activation_irq);
+		goto end;
+	}
+	ret = dtc_renesas_rx_start_transfer(data->dtc, data->tx_dtc_activation_irq);
+	if (ret != 0) {
+		LOG_ERR("DTC SPI tx start failed");
+		dtc_renesas_rx_stop_transfer(data->dtc, data->tx_dtc_activation_irq);
+		goto end;
+	}
+#endif /* CONFIG_SPI_RENESAS_RX_DTC */
+
 	if (data->ctx.rx_buf == NULL) {
 		data->tcb.transfer_mode = RSPI_DO_TX;
 		rspi_err_t err = R_RSPI_Write(data->rspi, data->command_word,
@@ -498,7 +601,6 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 		}
 	}
 	ret = spi_context_wait_for_completion(&data->ctx);
-
 #else
 	data->preg->SPCR.BIT.TXMD = 0x0; /* tx - rx */
 	if (!spi_context_rx_on(&data->ctx)) {
@@ -617,15 +719,58 @@ static void rx_rspi_retransmit(struct rx_rspi_data *data)
 	data->tcb.tx_count = 0;
 	data->tcb.rx_count = 0;
 	data->tcb.xfr_length = data->data_len;
+#ifdef CONFIG_SPI_RENESAS_RX_DTC
+	/* Determine DTC transfer size */
+	transfer_size_t size;
 
-	/* Execute the transmit of first byte here to start transmit on the new buffer */
-	rx_rspi_tcb_t *rspi_tcb = &(data->tcb);
-	uint16_t tx_count = rspi_tcb->tx_count;
-
-	if (tx_count < rspi_tcb->xfr_length) {
-		transmit_data(data, tx_count);
-		rspi_tcb->tx_count++;
+	if (data->tcb.bytes_per_transfer == RSPI_LONG_DATA) {
+		size = TRANSFER_SIZE_4_BYTE;
+	} else if (data->tcb.bytes_per_transfer == RSPI_WORD_DATA) {
+		size = TRANSFER_SIZE_2_BYTE;
+	} else {
+		size = TRANSFER_SIZE_1_BYTE;
 	}
+	/* Re-configure RX DTC */
+	transfer_info_t *p_info = &data->rx_dtc_info;
+
+	p_info->transfer_settings_word_b.size = size;
+	p_info->length = (uint16_t)data->data_len;
+	p_info->transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED;
+	p_info->p_dest = data->ctx.rx_buf;
+
+	if (data->ctx.rx_buf == NULL) {
+		static uint32_t dummy_rx;
+
+		p_info->transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_FIXED;
+		p_info->p_dest = &dummy_rx;
+	}
+
+	dtc_renesas_rx_configuration(data->dtc, data->rx_dtc_activation_irq, p_info);
+	dtc_renesas_rx_start_transfer(data->dtc, data->rx_dtc_activation_irq);
+
+	/* Re-configure TX DTC */
+	p_info = &data->tx_dtc_info;
+
+	p_info->transfer_settings_word_b.size = size;
+	p_info->length = (uint16_t)data->data_len;
+	p_info->transfer_settings_word_b.src_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED;
+	p_info->p_src = data->ctx.tx_buf;
+
+	if (data->ctx.tx_buf == NULL) {
+		static uint32_t dummy_tx;
+
+		p_info->transfer_settings_word_b.src_addr_mode = TRANSFER_ADDR_MODE_FIXED;
+		p_info->p_src = &dummy_tx;
+	}
+
+	dtc_renesas_rx_configuration(data->dtc, data->tx_dtc_activation_irq, p_info);
+	dtc_renesas_rx_start_transfer(data->dtc, data->tx_dtc_activation_irq);
+#endif /* CONFIG_SPI_RENESAS_RX_DTC */
+	/** These code lines are to trigger the next transmit interrupt */
+	data->preg->SPCR.BIT.SPTIE = 0;
+	data->preg->SPCR.BIT.SPE = 0;
+	data->preg->SPCR.BIT.SPTIE = 1;
+	data->preg->SPCR.BIT.SPE = 1;
 }
 
 static void rx_rspi_spri_isr(const struct device *dev)
@@ -634,7 +779,7 @@ static void rx_rspi_spri_isr(const struct device *dev)
 	rx_rspi_tcb_t *rspi_tcb = &(data->tcb);
 	uint32_t *rxdata = &(data->rxdata);
 
-	if (RSPI_TRANS_MODE_SW == rspi_tcb->data_tran_mode) {
+	if (RSPI_TRANS_MODE_SW == rspi_tcb->rx_data_tran_mode) {
 		*rxdata = data->preg->SPDR.LONG;
 		rspi_tcb->rx_count++;
 #if RSPI_CFG_HIGH_SPEED_READ == 0
@@ -674,18 +819,24 @@ static void rx_rspi_spri_isr(const struct device *dev)
 			}
 		}
 	} else {
-		R_RSPI_IntSpriIerClear(data->rspi);
-		R_RSPI_DisableRSPI(data->rspi);
+		data->tcb.rx_count = data->data_len;
+		data->preg->SPCR2.BIT.SPIIE = 1;
 
-		/**
-		 * Transfer complete. Call the user callback function passing pointer to the result
-		 * structure.
-		 */
-		if (data->rspi->pcallback != NULL) {
-			data->callback_data.handle = data->rspi;
-			data->callback_data.event_code = RSPI_EVT_TRANSFER_COMPLETE;
+		/* If the SPI is in slave mode */
+		if (spi_context_is_slave(&data->ctx)) {
+			spi_context_update_rx(&data->ctx, data->dfs, data->data_len);
+			/* Disable RSPI */
+			data->preg->SPCR.BIT.SPE = 0;
 
-			data->rspi->pcallback((void *)dev);
+			/**
+			 * Transfer complete. Call the user callback function passing
+			 * pointer to the result structure.
+			 */
+			if (data->rspi->pcallback != NULL) {
+				data->callback_data.handle = data->rspi;
+				data->callback_data.event_code = RSPI_EVT_TRANSFER_COMPLETE;
+				data->rspi->pcallback((void *)dev);
+			}
 		}
 	}
 }
@@ -696,7 +847,7 @@ static void rx_rspi_spti_isr(const struct device *dev)
 	uint32_t *rxdata = &(data->rxdata);
 	rx_rspi_tcb_t *rspi_tcb = &(data->tcb);
 
-	if (RSPI_TRANS_MODE_SW == rspi_tcb->data_tran_mode) {
+	if (RSPI_TRANS_MODE_SW == rspi_tcb->tx_data_tran_mode) {
 		if (0 == rspi_tcb->tx_count) {
 			*rxdata = data->preg->SPDR.LONG;
 		}
@@ -722,15 +873,37 @@ static void rx_rspi_spti_isr(const struct device *dev)
 			}
 		}
 	} else {
-		R_RSPI_DisableSpti(data->rspi);
-		R_RSPI_IntSptiIerClear(data->rspi);
+		/** Update count by data_len when using DTC */
+		data->tcb.tx_count = data->data_len;
+		/** Disable SPTI to avoid redundant interrupt after SPDR is fully written by DTC */
+		data->preg->SPCR.BIT.SPTIE = 0;
+
+		/* If transmit only, enable SPII interrupt in transmit */
+		if (!spi_context_rx_on(&data->ctx)) {
+			data->preg->SPCR2.BIT.SPIIE = 1;
+
+			/* If the SPI is in slave mode */
+			if (spi_context_is_slave(&data->ctx)) {
+				/* Disable RSPI */
+				data->preg->SPCR.BIT.SPE = 0;
+
+				/**
+				 * Transfer complete. Call the user callback function passing
+				 * pointer to the result structure.
+				 */
+				if (data->rspi->pcallback != NULL) {
+					data->callback_data.handle = data->rspi;
+					data->callback_data.event_code = RSPI_EVT_TRANSFER_COMPLETE;
+					data->rspi->pcallback((void *)dev);
+				}
+			}
+		}
 	}
 }
 
 static void rx_rspi_spii_isr(const struct device *dev)
 {
 	struct rx_rspi_data *data = dev->data;
-
 	if (data->tcb.rx_count >= data->tcb.xfr_length) {
 		spi_context_update_rx(&data->ctx, data->dfs, data->data_len);
 	}
@@ -840,6 +1013,44 @@ error_callback:
 
 #endif
 
+/* clang-format off */
+#ifndef CONFIG_SPI_RENESAS_RX_DTC
+#define RX_RSPI_DTC_STRUCT_INIT(n)
+#else
+#define RX_RSPI_DTC_STRUCT_INIT(n)                                                                 \
+	.dtc = DEVICE_DT_GET(DT_PHANDLE(DT_DRV_INST(n), dtc)),                                     \
+	.rx_dtc_activation_irq = DT_INST_IRQ_BY_NAME(n, spri, irq),                                \
+	.rx_dtc_info =                                                                             \
+		{                                                                                  \
+			.transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED, \
+			.transfer_settings_word_b.repeat_area = TRANSFER_REPEAT_AREA_DESTINATION,  \
+			.transfer_settings_word_b.irq = TRANSFER_IRQ_END,                          \
+			.transfer_settings_word_b.chain_mode = TRANSFER_CHAIN_MODE_DISABLED,       \
+			.transfer_settings_word_b.src_addr_mode = TRANSFER_ADDR_MODE_FIXED,        \
+			.transfer_settings_word_b.size = TRANSFER_SIZE_1_BYTE,                     \
+			.transfer_settings_word_b.mode = TRANSFER_MODE_NORMAL,                     \
+			.p_dest = (void *)NULL,                                                    \
+			.p_src = (void const *)NULL,                                               \
+			.num_blocks = 0,                                                           \
+			.length = 0,                                                               \
+	},                                                                                         \
+	.tx_dtc_activation_irq = DT_INST_IRQ_BY_NAME(n, spti, irq),                                \
+	.tx_dtc_info = {                                                                           \
+		.transfer_settings_word_b.dest_addr_mode = TRANSFER_ADDR_MODE_FIXED,               \
+		.transfer_settings_word_b.repeat_area = TRANSFER_REPEAT_AREA_SOURCE,               \
+		.transfer_settings_word_b.irq = TRANSFER_IRQ_END,                                  \
+		.transfer_settings_word_b.chain_mode = TRANSFER_CHAIN_MODE_DISABLED,               \
+		.transfer_settings_word_b.src_addr_mode = TRANSFER_ADDR_MODE_INCREMENTED,          \
+		.transfer_settings_word_b.size = TRANSFER_SIZE_1_BYTE,                             \
+		.transfer_settings_word_b.mode = TRANSFER_MODE_NORMAL,                             \
+		.p_dest = (void *)NULL,                                                            \
+		.p_src = (void const *)NULL,                                                       \
+		.num_blocks = 0,                                                                   \
+		.length = 0,                                                                       \
+	},
+#endif
+/* clang-format on */
+
 #define RX_RSPI_INIT(n)                                                                            \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
 	static const struct rx_rspi_config rx_rspi_config_##n = {                                  \
@@ -852,7 +1063,7 @@ error_callback:
 		.preg = (struct st_rspi *)DT_INST_REG_ADDR(n),                                     \
 		.channel_id = DT_INST_PROP(n, channel),                                            \
 		.ssl_assert = DT_INST_PROP(n, ssl_assert),                                         \
-	};                                                                                         \
+		RX_RSPI_DTC_STRUCT_INIT(n)};                                                       \
 	static int rspi_rx_init##n(const struct device *dev)                                       \
 	{                                                                                          \
 		int err = rspi_rx_init(dev);                                                       \

--- a/dts/bindings/i2c/renesas,rx-i2c.yaml
+++ b/dts/bindings/i2c/renesas,rx-i2c.yaml
@@ -17,3 +17,7 @@ properties:
 
   interrupt-names:
     required: true
+
+  dtc:
+    type: phandle
+    description: DTC controller

--- a/dts/bindings/spi/renesas,rx-rspi.yaml
+++ b/dts/bindings/spi/renesas,rx-rspi.yaml
@@ -17,6 +17,9 @@ properties:
     description: |
       The index of SPI channel
 
+  clocks:
+    required: true
+
   dtc:
     type: phandle
     description: DTC controller

--- a/dts/bindings/spi/renesas,rx-rspi.yaml
+++ b/dts/bindings/spi/renesas,rx-rspi.yaml
@@ -17,6 +17,10 @@ properties:
     description: |
       The index of SPI channel
 
+  dtc:
+    type: phandle
+    description: DTC controller
+
   ssl-assert:
     type: int
     default: 0

--- a/dts/rx/renesas/rx130-common.dtsi
+++ b/dts/rx/renesas/rx130-common.dtsi
@@ -804,6 +804,8 @@
 			channel = <0>;
 			interrupts = <246 1>, <247 1>, <248 1>, <249 1>;
 			interrupt-names = "eei", "rxi", "txi", "tei";
+			clocks = <&pclkb MSTPB 21>;
+			dtc = <&dtc>;
 			status = "disabled";
 		};
 
@@ -850,6 +852,7 @@
 			clocks = <&pclkb MSTPB 17>;
 			interrupts = <44 1>, <45 1>, <46 1>, <47 1>;
 			interrupt-names = "spei", "spri", "spti", "spii";
+			dtc = <&dtc>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Based on #93498  merged, add Data Transfer Controller (DTC) support for SPI and I2C driver of Renesas RX