### PR TITLE
soc: egis_et171: update config and resolve issue of ram func

### DIFF
--- a/boards/egis/egis_et171/Kconfig.defconfig
+++ b/boards/egis/egis_et171/Kconfig.defconfig
@@ -1,7 +1,2 @@
 # Copyright (c) 2025 Egis Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
-
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_FLASH))

--- a/boards/egis/egis_et171/doc/index.rst
+++ b/boards/egis/egis_et171/doc/index.rst
@@ -22,10 +22,6 @@ The platform provides following hardware components:
 - DMA
 - USB
 
-.. figure:: img/et171_snapshot.webp
-     :align: center
-     :alt: EGIS_ET171_SOC
-
 Supported Features
 ==================
 
@@ -34,7 +30,7 @@ Supported Features
 Connections and IOs
 ===================
 
-The et171 platform has 1 GPIO controller. It providing 17 bits of IO.
+The et171 platform has 1 GPIO controller. It is providing 17 bits of IO.
 It is responsible for pin input/output, pull-up, etc.
 
 The et171 platform has 3 SPI controllers, 2 of which can

--- a/soc/egis/et171/soc.c
+++ b/soc/egis/et171/soc.c
@@ -9,6 +9,14 @@
 
 void soc_early_init_hook(void)
 {
+#if CONFIG_XIP && CONFIG_ICACHE
+	/* Since caching is enabled before z_data_copy(), RAM functions may still be cached
+	 * in the d-cache instead of being written to SRAM. In this case, the i-cache will
+	 * fetch the wrong content from SRAM. Thus, using "fence.i" to fix it.
+	 */
+	__asm__ volatile("fence.i" ::: "memory");
+#endif
+
 	/* AHB ~200Mhz / 3 = 66MHz AHB , ~66Mhz / 2 / 2 = 18Mhz APB */
 	sys_write32(0x01 | 0x20 | 0x02, 0xF0100004U);
 


### PR DESCRIPTION
There are four modificaions of following commits.
1. Remove the default configuration "[FLASH_LOAD_SIZE](https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/egis/egis_et171/Kconfig.defconfig#L6)" from "[Kconfig.defconfig](https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/egis/egis_et171/Kconfig.defconfig)".
Because of it is only used by "linker.ld" and it will automatically assign the [same default value](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/arch/riscv/common/linker.ld#L46-L53) as "Kconfig.defconfig".

2. Add a "__weak" declaration to "[soc_early_init_hook](https://github.com/zephyrproject-rtos/zephyr/blob/main/soc/egis/et171/soc.c#L10)" function.
This is because "soc_early_init_hook" is already implemented in the et171 SOC.
By overriding the weak function, applications or external modules can implement their own "soc_early_init_hook".

3. To fixed the i-cache activation order issue 
Because ANDES's family of SOCs enables cache in [reset.S](https://github.com/zephyrproject-rtos/zephyr/blob/main/arch/riscv/custom/andes/reset.S#L24-L39), this execution precedes z_data_copy() (which copies the flash code to RAM).
That might cause the i-cache to fetch instructions from SRAM before the d-cache writes them back to SRAM.
To prevent this, executing "fence.i" instruction to force cache synchronization.

4. Updated boards/index.rst
Modify index.rst according to the suggestions in [#91940](https://github.com/zephyrproject-rtos/zephyr/pull/91940#discussion_r2409553150)

