### PR TITLE
modem: ppp: use peer control character map

### DIFF
--- a/include/zephyr/net/ppp.h
+++ b/include/zephyr/net/ppp.h
@@ -597,6 +597,15 @@ struct net_if;
 
 /** @endcond */
 
+/**
+ * @brief Retrieve the PPP peers Asynchronous Control Character Map
+ *
+ * @param iface PPP network interface.
+ *
+ * @return uint32_t Current bitmask for the Asynchronous Control Character Map
+ */
+uint32_t ppp_peer_async_control_character_map(struct net_if *iface);
+
 /** Event emitted when PPP carrier is on */
 #define NET_EVENT_PPP_CARRIER_ON					\
 	(NET_PPP_EVENT | NET_EVENT_PPP_CMD_CARRIER_ON)

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/ppp.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/iterable_sections.h>
 
 #include "net_private.h"
@@ -343,6 +344,15 @@ static int ppp_enable(struct net_if *iface, bool state)
 	}
 
 	return ret;
+}
+
+uint32_t ppp_peer_async_control_character_map(struct net_if *iface)
+{
+	struct ppp_context *ctx;
+
+	__ASSERT(net_if_l2(iface) == &NET_L2_GET_NAME(PPP), "Not PPP L2");
+	ctx = net_if_l2_data(iface);
+	return ctx->lcp.peer_options.async_map;
 }
 
 NET_L2_INIT(PPP_L2, ppp_recv, ppp_send, ppp_enable, ppp_flags);

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -350,7 +350,9 @@ uint32_t ppp_peer_async_control_character_map(struct net_if *iface)
 {
 	struct ppp_context *ctx;
 
+#ifndef CONFIG_ZTEST
 	__ASSERT(net_if_l2(iface) == &NET_L2_GET_NAME(PPP), "Not PPP L2");
+#endif /* !CONFIG_ZTEST */
 	ctx = net_if_l2_data(iface);
 	return ctx->lcp.peer_options.async_map;
 }


### PR DESCRIPTION
Use the peers asynchronous control character map to only escape characters that need to be, instead of always escaping bytes 0 to 31.

For data packets with values randomly distributed, this results in 11% fewer bytes needing to be transmitted over the link, if no bytes need to be escaped (256+2)/(256+2+32).

Validated on a Telit LE910C1, which attempts to configure the control character map as `0x00000000`.