### PR TITLE
Fix size_t specifier warnings with arm64

### DIFF
--- a/drivers/eeprom/eeprom_fm25xxx.c
+++ b/drivers/eeprom/eeprom_fm25xxx.c
@@ -104,7 +104,7 @@ int eeprom_fm25xxx_read(const struct device *dev, off_t offset, void *data, size
 		sys_put_be24(offset, &read_op[1]);
 		break;
 	default:
-		LOG_ERR("Invalid number of address bytes %u", addr_bytes);
+		LOG_ERR("Invalid number of address bytes %zu", addr_bytes);
 		return -EINVAL;
 	}
 
@@ -182,7 +182,7 @@ int eeprom_fm25xxx_write(const struct device *dev, off_t offset, const void *dat
 		sys_put_be24(offset, &write_op[1]);
 		break;
 	default:
-		LOG_ERR("Invalid number of address bytes %u", addr_bytes);
+		LOG_ERR("Invalid number of address bytes %zu", addr_bytes);
 		return -EINVAL;
 	}
 

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -432,7 +432,7 @@ ZTEST_USER(uart_async_chain_read, test_chained_read)
 			      "TX_DONE timeout");
 		k_msleep(rx_timeout_ms + 10);
 		zassert_equal(rx_data_idx, sizeof(tx_buf),
-				"Unexpected amount of data received %d exp:%d",
+				"Unexpected amount of data received %d exp:%zu",
 				rx_data_idx, sizeof(tx_buf));
 		zassert_equal(memcmp(tx_buf, chained_cpy_buf, sizeof(tx_buf)), 0,
 			      "Buffers not equal exp %s, real %s", tx_buf, chained_cpy_buf);
@@ -1089,22 +1089,22 @@ static ZTEST_BMEM uint8_t tx_buffer[VAR_LENGTH_TX_BUF_SIZE];
 	ret = uart_rx_enable(uart_dev,
 			     (uint8_t *)&var_length_rx_buf_pool[var_length_buf_rx_pool_idx],
 			     buf_len, 2 * USEC_PER_MSEC);
-	zassert_true(ret == 0, "[buff=%d][tx=%d]Failed to enable RX: %d\n", buf_len, tx_len, ret);
+	zassert_true(ret == 0, "[buff=%zu][tx=%zu]Failed to enable RX: %d\n", buf_len, tx_len, ret);
 	var_length_buf_rx_pool_idx += buf_len;
 
 	ret = uart_tx(uart_dev, tx_buffer, tx_len, 100 * USEC_PER_MSEC);
-	zassert_true(ret == 0, "[buff=%d][tx=%d]Failed to TX: %d\n", buf_len, tx_len, ret);
+	zassert_true(ret == 0, "[buff=%zu][tx=%zu]Failed to TX: %d\n", buf_len, tx_len, ret);
 	k_msleep(10);
 
 	uart_rx_disable(uart_dev);
 	zassert_equal(k_sem_take(&rx_disabled, K_MSEC(500)), 0,
-		      "[buff=%d][tx=%d]RX_DISABLED timeout\n", buf_len, tx_len);
+		      "[buff=%zu][tx=%zu]RX_DISABLED timeout\n", buf_len, tx_len);
 
 	zassert_equal(var_length_buf_rx_idx, tx_len,
-		      "[buff=%d][tx=%d]Wrong number of bytes received, got: %d, expected: %d\n",
+		      "[buff=%zu][tx=%zu]Wrong number of bytes received, got: %zu, expected: %zu\n",
 		      buf_len, tx_len, var_length_buf_rx_idx, tx_len);
 	zassert_equal(memcmp((void *)var_length_rx_buf, tx_buffer, tx_len), 0,
-		      "[buff=%d][tx=%d]Buffers not equal\n", buf_len, tx_len);
+		      "[buff=%zu][tx=%zu]Buffers not equal\n", buf_len, tx_len);
 }
 
 ZTEST_USER(uart_async_var_buf_length, test_var_buf_length)


### PR DESCRIPTION
Use %zu for size_t to avoid build warnings with arm64 compiler that is causing CI failures.

CI:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/18671449016/job/53233290759
https://github.com/zephyrproject-rtos/zephyr/actions/runs/18675731301/job/53245647719

The warnings look like this
```
/__w/zephyr/zephyr/drivers/eeprom/eeprom_fm25xxx.c: In function 'eeprom_fm25xxx_read':
/__w/zephyr/zephyr/drivers/eeprom/eeprom_fm25xxx.c:107:25: error: format '%u' expects argument of type 'unsigned int', but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Werror=format=]
  107 |                 LOG_ERR("Invalid number of address bytes %u", addr_bytes);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~
      |                                                               |
      |                                                               size_t {aka long unsigned int}
/__w/zephyr/zephyr/include/zephyr/logging/log_core.h:315:50: note: in definition of macro 'Z_LOG2'
  315 |                         z_log_printf_arg_checker(__VA_ARGS__);                                     \
      |                                                  ^~~~~~~~~~~
/__w/zephyr/zephyr/include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
/__w/zephyr/zephyr/drivers/eeprom/eeprom_fm25xxx.c:107:17: note: in expansion of macro 'LOG_ERR'
  107 |                 LOG_ERR("Invalid number of address bytes %u", addr_bytes);
      |                 ^~~~~~~
/__w/zephyr/zephyr/drivers/eeprom/eeprom_fm25xxx.c:107:59: note: format string is defined here
  107 |                 LOG_ERR("Invalid number of address bytes %u", addr_bytes);
      |                                                          ~^
      |                                                           |
      |                                                           unsigned int
      |                                                          %lu
/__w/zephyr/zephyr/drivers/eeprom/eeprom_fm25xxx.c: In function 'eeprom_fm25xxx_write':
/__w/zephyr/zephyr/drivers/eeprom/eeprom_fm25xxx.c:185:25: error: format '%u' expects argument of type 'unsigned int', but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Werror=format=]
  185 |                 LOG_ERR("Invalid number of address bytes %u", addr_bytes);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~
      |                                                               |
      |                                                               size_t {aka long unsigned int}
/__w/zephyr/zephyr/include/zephyr/logging/log_core.h:315:50: note: in definition of macro 'Z_LOG2'
  315 |                         z_log_printf_arg_checker(__VA_ARGS__);                                     \
      |                                                  ^~~~~~~~~~~
/__w/zephyr/zephyr/include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
/__w/zephyr/zephyr/drivers/eeprom/eeprom_fm25xxx.c:185:17: note: in expansion of macro 'LOG_ERR'
  185 |                 LOG_ERR("Invalid number of address bytes %u", addr_bytes);
      |                 ^~~~~~~
/__w/zephyr/zephyr/drivers/eeprom/eeprom_fm25xxx.c:185:59: note: format string is defined here
  185 |                 LOG_ERR("Invalid number of address bytes %u", addr_bytes);
      |                                                          ~^
      |                                                           |
      |                                                           unsigned int
      |                                                          %lu
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
