### PR TITLE
lib: heap: return -ENOMEM if heap_array is full

### DIFF
--- a/lib/heap/heap_array.c
+++ b/lib/heap/heap_array.c
@@ -18,7 +18,7 @@ int sys_heap_array_save(struct sys_heap *heap)
 	if (i < CONFIG_SYS_HEAP_ARRAY_SIZE) {
 		heaps[i++] = heap;
 	} else {
-		return -EINVAL;
+		return -ENOMEM;
 	}
 
 	return 0;


### PR DESCRIPTION
Replace -EINVAL which indicates an invalid input parameter.