### PR TITLE
Configure QSPI bus for jedec,qspi-nor and sf32lb MPI QSPI NOR

### DIFF
--- a/dts/bindings/mtd/jedec,qspi-nor.yaml
+++ b/dts/bindings/mtd/jedec,qspi-nor.yaml
@@ -5,4 +5,6 @@ description: Generic NOR flash on QSPI bus
 
 compatible: "jedec,qspi-nor"
 
+on-bus: qspi
+
 include: [base.yaml, "jedec,spi-nor-common.yaml"]

--- a/dts/bindings/mtd/sifli,sf32lb-mpi-qspi-nor.yaml
+++ b/dts/bindings/mtd/sifli,sf32lb-mpi-qspi-nor.yaml
@@ -7,6 +7,8 @@ compatible: "sifli,sf32lb-mpi-qspi-nor"
 
 include: base.yaml
 
+bus: qspi
+
 properties:
   reg:
     required: true


### PR DESCRIPTION
This makes sure bindings are used in the correct bus