### PR TITLE
dts: arm: microchip: same5xd5x: update port nodes for GPIO driver support

### DIFF
--- a/boards/microchip/sam/sam_e54_xpro/sam_e54_xpro.dts
+++ b/boards/microchip/sam/sam_e54_xpro/sam_e54_xpro.dts
@@ -23,7 +23,18 @@
 	};
 
 	aliases {
+		led0 = &led0;
 		pwm-led0 = &pwm_led0;
+		sw0 = &button0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&portc 18 GPIO_ACTIVE_LOW>;
+			label = "Yellow LED";
+		};
 	};
 
 	pwmleds {
@@ -32,6 +43,16 @@
 		pwm_led0: pwm_led_0 {
 			status = "okay";
 			pwms = <&tcc0 2 PWM_MSEC(20) 0>;
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		button0: button_0 {
+			gpios = <&portb 31 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "SW0";
+			zephyr,code = <INPUT_KEY_0>;
 		};
 	};
 };
@@ -169,4 +190,12 @@
 	max-bit-width = <24>;
 	prescaler = <8>;
 	channels = <6>;
+};
+
+&portb {
+	status = "okay";
+};
+
+&portc {
+	status = "okay";
 };

--- a/boards/microchip/sam/sam_e54_xpro/sam_e54_xpro.yaml
+++ b/boards/microchip/sam/sam_e54_xpro/sam_e54_xpro.yaml
@@ -12,6 +12,7 @@ ram: 256
 supported:
   - clock_control
   - flash
+  - gpio
   - mcuboot
   - pinctrl
   - pwm

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51g18a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51g18a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_g.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_18.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51g19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51g19a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_g.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51j18a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51j18a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_18.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51j19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51j19a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51j20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51j20a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51n19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51n19a.dtsi
@@ -5,6 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51n20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51n20a.dtsi
@@ -5,6 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51p19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51p19a.dtsi
@@ -5,6 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_p.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51p20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsamd51/atsamd51p20a.dtsi
@@ -5,6 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_p.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51g18a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51g18a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_g.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_18.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51g19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51g19a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_g.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51j18a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51j18a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_18.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51j19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51j19a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51j20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51j20a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51n19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51n19a.dtsi
@@ -5,6 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51n20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame51/atsame51n20a.dtsi
@@ -5,6 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53j18a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53j18a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_18.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53j19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53j19a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53j20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53j20a.dtsi
@@ -5,5 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53n19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53n19a.dtsi
@@ -5,6 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53n20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame53/atsame53n20a.dtsi
@@ -5,6 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54n19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54n19a.dtsi
@@ -5,6 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54n20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54n20a.dtsi
@@ -5,6 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54p19a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54p19a.dtsi
@@ -5,6 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_19.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_p.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54p20a.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/atsame54/atsame54p20a.dtsi
@@ -5,6 +5,5 @@
  */
 
 #include <mem.h>
-#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_20.dtsi>
 #include <microchip/sam/sam_d5x_e5x/common/samd5xe5x_p.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/clock/mchp_sam_d5x_e5x_clock.h>
 
@@ -142,19 +143,21 @@
 			ranges = <0x41008000 0x41008000 0x200>;
 
 			porta: gpio@41008000 {
+				compatible = "microchip,port-g1-gpio";
 				reg = <0x41008000 0x80>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#microchip,pin-cells = <2>;
+				status = "disabled";
 			};
 
 			portb: gpio@41008080 {
+				compatible = "microchip,port-g1-gpio";
 				reg = <0x41008080 0x80>;
-			};
-
-			portc: gpio@41008100 {
-				reg = <0x41008100 0x80>;
-			};
-
-			portd: gpio@41008180 {
-				reg = <0x41008180 0x80>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#microchip,pin-cells = <2>;
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_g.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_g.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>

--- a/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_j.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+
 / {
 	soc {
 		tcc3: tcc@42001000 {

--- a/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_n.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+
 / {
 	soc {
 		tcc3: tcc@42001000 {
@@ -47,5 +49,16 @@
 			max-bit-width = <16>;
 			channels = <2>;
 		};
+	};
+};
+
+&pinctrl {
+	portc: gpio@41008100 {
+		compatible = "microchip,port-g1-gpio";
+		reg = <0x41008100 0x80>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#microchip,pin-cells = <2>;
+		status = "disabled";
 	};
 };

--- a/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_p.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x_p.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi>
+
 / {
 	soc {
 		tcc3: tcc@42001000 {
@@ -47,5 +49,25 @@
 			max-bit-width = <16>;
 			channels = <2>;
 		};
+	};
+};
+
+&pinctrl {
+	portc: gpio@41008100 {
+		compatible = "microchip,port-g1-gpio";
+		reg = <0x41008100 0x80>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#microchip,pin-cells = <2>;
+		status = "disabled";
+	};
+
+	portd: gpio@41008180 {
+		compatible = "microchip,port-g1-gpio";
+		reg = <0x41008180 0x80>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#microchip,pin-cells = <2>;
+		status = "disabled";
 	};
 };


### PR DESCRIPTION
This pull request enhances the device tree support for the Microchip SAM D5x/E5x SoC series and the sam_e54_xpro board by:

- Adding the GPIO DTS node for Microchip port g1, enabling proper GPIO configuration and usage in the SAM D5x/E5x SoC series.
- Adding the respective LED and button DTS nodes for the sam_e54_xpro board, allowing board-level applications and drivers to utilize these peripherals.