### PR TITLE
net: lib: shell: dns: Fix field precission specifier type

### DIFF
--- a/subsys/net/lib/shell/dns.c
+++ b/subsys/net/lib/shell/dns.c
@@ -494,7 +494,7 @@ static int cmd_net_dns_service(const struct shell *sh, size_t argc, char *argv[]
 				port = info.ai_srv.port;
 
 				snprintf(query, sizeof(query), "%.*s",
-					info.ai_srv.targetlen,
+					(int)info.ai_srv.targetlen,
 					info.ai_srv.target);
 
 				/*


### PR DESCRIPTION
Explicitly cast down the string width to int, as otherwise it is size_t which may have a bigger size.

Avoids the following build error when building with native_sim//64 (longs are 64, ints 32):

subsys/net/lib/shell/dns.c:496:67: error: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 4 has type ‘size_t’ {aka ‘long unsigned int’}

Code introduced in 7158f33c2b00