### PR TITLE
nxp: drop SOF dependencies

### DIFF
--- a/boards/nxp/imx95_evk/CMakeLists.txt
+++ b/boards/nxp/imx95_evk/CMakeLists.txt
@@ -1,17 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if (CONFIG_SOF AND CONFIG_BOARD_IMX95_EVK_MIMX9596_M7_DDR)
-  add_custom_target(zephyr.ri ALL
-    DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
-  )
-
-  add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
-    COMMAND west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR} ${WEST_SIGN_OPTS}
-    DEPENDS ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
-  )
-endif()
-
 if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
   AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
   find_program(7Z_EXECUTABLE 7z REQUIRED)

--- a/boards/nxp/imx95_evk/board.cmake
+++ b/boards/nxp/imx95_evk/board.cmake
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if (CONFIG_SOF AND CONFIG_BOARD_IMX95_EVK_MIMX9596_M7_DDR)
-  board_set_rimage_target(imx95)
-endif()
-
 if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
   AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
   board_set_flasher_ifnset(spsdk)

--- a/soc/nxp/imx/imx9/imx93/a55/mmu_regions.c
+++ b/soc/nxp/imx/imx9/imx93/a55/mmu_regions.c
@@ -31,25 +31,6 @@ static const struct arm_mmu_region mmu_regions[] = {
 
 	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_lpuart,
 						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
-
-#if CONFIG_SOF
-		MMU_REGION_FLAT_ENTRY("MU2_A", DT_REG_ADDR(DT_NODELABEL(mu2_a)),
-				      DT_REG_SIZE(DT_NODELABEL(mu2_a)),
-				      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
-
-	MMU_REGION_FLAT_ENTRY("OUTBOX", DT_REG_ADDR(DT_NODELABEL(outbox)),
-			      DT_REG_SIZE(DT_NODELABEL(outbox)), MT_NORMAL | MT_P_RW_U_NA | MT_NS),
-
-	MMU_REGION_FLAT_ENTRY("INBOX", DT_REG_ADDR(DT_NODELABEL(inbox)),
-			      DT_REG_SIZE(DT_NODELABEL(inbox)), MT_NORMAL | MT_P_RW_U_NA | MT_NS),
-
-	MMU_REGION_FLAT_ENTRY("STREAM", DT_REG_ADDR(DT_NODELABEL(stream)),
-			      DT_REG_SIZE(DT_NODELABEL(stream)), MT_NORMAL | MT_P_RW_U_NA | MT_NS),
-
-	MMU_REGION_FLAT_ENTRY("HOST_RAM", DT_REG_ADDR(DT_NODELABEL(host_ram)),
-			      DT_REG_SIZE(DT_NODELABEL(host_ram)),
-			      MT_NORMAL | MT_P_RW_U_NA | MT_NS),
-#endif /* CONFIG_SOF */
 };
 
 const struct arm_mmu_config mmu_config = {


### PR DESCRIPTION
Drop SOF dependencies from MX93 and MX95.
See https://github.com/zephyrproject-rtos/zephyr/pull/97946 and https://github.com/zephyrproject-rtos/zephyr/issues/91061.