### PR TITLE
nRF: remove cross domain handling from drivers

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -127,27 +127,6 @@ LOG_MODULE_REGISTER(uart_nrfx_uarte, CONFIG_UART_LOG_LEVEL);
  */
 #define UARTE_ANY_HIGH_SPEED (UARTE_FOR_EACH_INSTANCE(INSTANCE_IS_HIGH_SPEED, (||), (0)))
 
-#define UARTE_PINS_CROSS_DOMAIN(unused, prefix, idx, _)			\
-	COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(UARTE(prefix##idx)),	\
-		   (UARTE_PROP(idx, cross_domain_pins_supported)),	\
-		   (0))
-
-#if UARTE_FOR_EACH_INSTANCE(UARTE_PINS_CROSS_DOMAIN, (||), (0))
-#include <hal/nrf_gpio.h>
-/* Certain UARTE instances support usage of cross domain pins in form of dedicated pins on
- * a port different from the default one.
- */
-#define UARTE_CROSS_DOMAIN_PINS_SUPPORTED 1
-#endif
-
-#if UARTE_CROSS_DOMAIN_PINS_SUPPORTED && defined(CONFIG_NRF_SYS_EVENT)
-#include <nrf_sys_event.h>
-/* To use cross domain pins, constant latency mode needs to be applied, which is
- * handled via nrf_sys_event requests.
- */
-#define UARTE_CROSS_DOMAIN_PINS_HANDLE 1
-#endif
-
 #ifdef UARTE_ANY_CACHE
 /* uart120 instance does not retain BAUDRATE register when ENABLE=0. When this instance
  * is used then baudrate must be set after enabling the peripheral and not before.
@@ -353,10 +332,6 @@ struct uarte_nrfx_config {
 #endif
 	uint8_t *poll_out_byte;
 	uint8_t *poll_in_byte;
-#if UARTE_CROSS_DOMAIN_PINS_SUPPORTED
-	bool cross_domain;
-	int8_t default_port;
-#endif
 };
 
 /* Using Macro instead of static inline function to handle NO_OPTIMIZATIONS case
@@ -424,32 +399,6 @@ static void uarte_disable_locked(const struct device *dev, uint32_t dis_mask)
 	nrf_uarte_disable(get_uarte_instance(dev));
 	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
 }
-
-#if UARTE_CROSS_DOMAIN_PINS_SUPPORTED
-static bool uarte_has_cross_domain_connection(const struct uarte_nrfx_config *config)
-{
-	const struct pinctrl_dev_config *pcfg = config->pcfg;
-	const struct pinctrl_state *state;
-	int ret;
-
-	ret = pinctrl_lookup_state(pcfg, PINCTRL_STATE_DEFAULT, &state);
-	if (ret < 0) {
-		LOG_ERR("Unable to read pin state");
-		return false;
-	}
-
-	for (uint8_t i = 0U; i < state->pin_cnt; i++) {
-		uint32_t pin = NRF_GET_PIN(state->pins[i]);
-
-		if ((pin != NRF_PIN_DISCONNECTED) &&
-		    (nrf_gpio_pin_port_number_extract(&pin) != config->default_port)) {
-			return true;
-		}
-	}
-
-	return false;
-}
-#endif
 
 #if defined(UARTE_ANY_NONE_ASYNC) && !defined(CONFIG_UART_NRFX_UARTE_NO_IRQ)
 /**
@@ -723,20 +672,6 @@ static void uarte_periph_enable(const struct device *dev)
 
 	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	nrf_uarte_enable(uarte);
-
-#if UARTE_CROSS_DOMAIN_PINS_SUPPORTED
-	if (config->cross_domain && uarte_has_cross_domain_connection(config)) {
-#if UARTE_CROSS_DOMAIN_PINS_HANDLE
-		int err;
-
-		err = nrf_sys_event_request_global_constlat();
-		(void)err;
-		__ASSERT_NO_MSG(err >= 0);
-#else
-		__ASSERT(false, "NRF_SYS_EVENT needs to be enabled to use cross domain pins.\n");
-#endif
-	}
-#endif
 
 #if UARTE_BAUDRATE_RETENTION_WORKAROUND
 	nrf_uarte_baudrate_set(uarte,
@@ -2364,20 +2299,6 @@ static void uarte_pm_suspend(const struct device *dev)
 		wait_for_tx_stopped(dev);
 	}
 
-#if UARTE_CROSS_DOMAIN_PINS_SUPPORTED
-	if (cfg->cross_domain && uarte_has_cross_domain_connection(cfg)) {
-#if UARTE_CROSS_DOMAIN_PINS_HANDLE
-		int err;
-
-		err = nrf_sys_event_release_global_constlat();
-		(void)err;
-		__ASSERT_NO_MSG(err >= 0);
-#else
-		__ASSERT(false, "NRF_SYS_EVENT needs to be enabled to use cross domain pins.\n");
-#endif
-	}
-#endif
-
 	(void)pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
 	nrf_uarte_disable(uarte);
 }
@@ -2655,11 +2576,6 @@ static int uarte_instance_deinit(const struct device *dev)
 		IF_ENABLED(CONFIG_UART_##idx##_NRF_HW_ASYNC,		       \
 			(.timer = NRFX_TIMER_INSTANCE(			       \
 				CONFIG_UART_##idx##_NRF_HW_ASYNC_TIMER),))     \
-		IF_ENABLED(UARTE_PINS_CROSS_DOMAIN(_, /*empty*/, idx, _),      \
-			(.cross_domain = true,				       \
-			 .default_port =				       \
-				DT_PROP_OR(DT_PHANDLE(UARTE(idx),	       \
-					default_gpio_port), port, -1),))       \
 	};								       \
 	UARTE_DIRECT_ISR_DECLARE(idx)					       \
 	static int uarte_##idx##_init(const struct device *dev)		       \

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -32,27 +32,6 @@ LOG_MODULE_REGISTER(spi_nrfx_spis, CONFIG_SPI_LOG_LEVEL);
 #define SPIS_PROP(idx, prop) DT_PROP(SPIS(idx), prop)
 #define SPIS_HAS_PROP(idx, prop) DT_NODE_HAS_PROP(SPIS(idx), prop)
 
-#define SPIS_PINS_CROSS_DOMAIN(unused, prefix, idx, _)			\
-	COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(SPIS(prefix##idx)),		\
-		   (SPIS_PROP(idx, cross_domain_pins_supported)),	\
-		   (0))
-
-#if NRFX_FOREACH_PRESENT(SPIS, SPIS_PINS_CROSS_DOMAIN, (||), (0))
-#include <hal/nrf_gpio.h>
-/* Certain SPIM instances support usage of cross domain pins in form of dedicated pins on
- * a port different from the default one.
- */
-#define SPIS_CROSS_DOMAIN_SUPPORTED 1
-#endif
-
-#if SPIS_CROSS_DOMAIN_SUPPORTED && defined(CONFIG_NRF_SYS_EVENT)
-#include <nrf_sys_event.h>
-/* To use cross domain pins, constant latency mode needs to be applied, which is
- * handled via nrf_sys_event requests.
- */
-#define SPIS_CROSS_DOMAIN_PINS_HANDLE 1
-#endif
-
 struct spi_nrfx_data {
 	struct spi_context ctx;
 	const struct device *dev;
@@ -72,37 +51,7 @@ struct spi_nrfx_config {
 	const struct pinctrl_dev_config *pcfg;
 	struct gpio_dt_spec wake_gpio;
 	void *mem_reg;
-#if SPIS_CROSS_DOMAIN_SUPPORTED
-	bool cross_domain;
-	int8_t default_port;
-#endif
 };
-
-#if SPIS_CROSS_DOMAIN_SUPPORTED
-static bool spis_has_cross_domain_connection(const struct spi_nrfx_config *config)
-{
-	const struct pinctrl_dev_config *pcfg = config->pcfg;
-	const struct pinctrl_state *state;
-	int ret;
-
-	ret = pinctrl_lookup_state(pcfg, PINCTRL_STATE_DEFAULT, &state);
-	if (ret < 0) {
-		LOG_ERR("Unable to read pin state");
-		return false;
-	}
-
-	for (uint8_t i = 0U; i < state->pin_cnt; i++) {
-		uint32_t pin = NRF_GET_PIN(state->pins[i]);
-
-		if ((pin != NRF_PIN_DISCONNECTED) &&
-		    (nrf_gpio_pin_port_number_extract(&pin) != config->default_port)) {
-			return true;
-		}
-	}
-
-	return false;
-}
-#endif
 
 static inline nrf_spis_mode_t get_nrf_spis_mode(uint16_t operation)
 {
@@ -423,20 +372,6 @@ static void spi_nrfx_suspend(const struct device *dev)
 		nrf_spis_disable(dev_config->spis.p_reg);
 	}
 
-#if SPIS_CROSS_DOMAIN_SUPPORTED
-	if (dev_config->cross_domain && spis_has_cross_domain_connection(dev_config)) {
-#if SPIS_CROSS_DOMAIN_PINS_HANDLE
-		int err;
-
-		err = nrf_sys_event_release_global_constlat();
-		(void)err;
-		__ASSERT_NO_MSG(err >= 0);
-#else
-		__ASSERT(false, "NRF_SYS_EVENT needs to be enabled to use cross domain pins.\n");
-#endif
-	}
-#endif
-
 	(void)pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_SLEEP);
 }
 
@@ -445,20 +380,6 @@ static void spi_nrfx_resume(const struct device *dev)
 	const struct spi_nrfx_config *dev_config = dev->config;
 
 	(void)pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_DEFAULT);
-
-#if SPIS_CROSS_DOMAIN_SUPPORTED
-	if (dev_config->cross_domain && spis_has_cross_domain_connection(dev_config)) {
-#if SPIS_CROSS_DOMAIN_PINS_HANDLE
-		int err;
-
-		err = nrf_sys_event_request_global_constlat();
-		(void)err;
-		__ASSERT_NO_MSG(err >= 0);
-#else
-		__ASSERT(false, "NRF_SYS_EVENT needs to be enabled to use cross domain pins.\n");
-#endif
-	}
-#endif
 
 	if (dev_config->wake_gpio.port == NULL) {
 		nrf_spis_enable(dev_config->spis.p_reg);
@@ -578,11 +499,6 @@ static int spi_nrfx_init(const struct device *dev)
 		.max_buf_len = BIT_MASK(SPIS_PROP(idx, easydma_maxcnt_bits)),  \
 		.wake_gpio = GPIO_DT_SPEC_GET_OR(SPIS(idx), wake_gpios, {0}),  \
 		.mem_reg = DMM_DEV_TO_REG(SPIS(idx)),			       \
-		IF_ENABLED(SPIS_PINS_CROSS_DOMAIN(_, /*empty*/, idx, _),       \
-			(.cross_domain = true,				       \
-			 .default_port =				       \
-				DT_PROP_OR(DT_PHANDLE(SPIS(idx),	       \
-					default_gpio_port), port, -1),))       \
 	};								       \
 	BUILD_ASSERT(!DT_NODE_HAS_PROP(SPIS(idx), wake_gpios) ||	       \
 		     !(DT_GPIO_FLAGS(SPIS(idx), wake_gpios) & GPIO_ACTIVE_LOW),\

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -61,13 +61,3 @@ properties:
         and SPI master again keeps the line in the low state
       Please note that the line must be configured and properly handled on
       both sides for the mechanism to work correctly.
-
-  default-gpio-port:
-    type: phandle
-    description: |
-      SPI default GPIO port.
-
-  cross-domain-pins-supported:
-    type: boolean
-    description: |
-      SPI allows usage of cross domain pins with constant latency mode required.

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -315,8 +315,6 @@
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";
-				default-gpio-port = <&gpio1>;
-				cross-domain-pins-supported;
 			};
 
 			uart20: uart@c6000 {
@@ -326,8 +324,6 @@
 				status = "disabled";
 				endtx-stoptx-supported;
 				frame-timeout-supported;
-				default-gpio-port = <&gpio1>;
-				cross-domain-pins-supported;
 			};
 
 			i2c21: i2c@c7000 {
@@ -358,8 +354,6 @@
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";
-				default-gpio-port = <&gpio1>;
-				cross-domain-pins-supported;
 			};
 
 			uart21: uart@c7000 {
@@ -369,8 +363,6 @@
 				status = "disabled";
 				endtx-stoptx-supported;
 				frame-timeout-supported;
-				default-gpio-port = <&gpio1>;
-				cross-domain-pins-supported;
 			};
 
 			i2c22: i2c@c8000 {

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -109,6 +109,8 @@ tests:
     extra_configs:
       - CONFIG_TESTED_SPI_MODE=0
       - CONFIG_NRF_SYS_EVENT=y
+      - CONFIG_SOC_NRF_FORCE_CONSTLAT=y
+      - CONFIG_POWER_DOMAIN=n
     extra_args: DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_cross_domain.overlay"
     platform_exclude:
       - nrf52840dk/nrf52840

--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -107,3 +107,4 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_cross_domain.overlay"
     extra_configs:
       - CONFIG_NRF_SYS_EVENT=y
+      - CONFIG_SOC_NRF_FORCE_CONSTLAT=y


### PR DESCRIPTION
Remove the handling of cross domain pins from nrf drivers. To use cross domain in tests, force on constlat and disable power domains for the test.