### PR TITLE
boards: adi: Correct flash node assignment for MAX32655 boards

### DIFF
--- a/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
+++ b/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
@@ -19,7 +19,8 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram2;
-		zephyr,flash = &code_partition;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	leds {

--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
@@ -19,7 +19,8 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram2;
-		zephyr,flash = &code_partition;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	leds {


### PR DESCRIPTION
Fixes a regression introduced in commit ef6aad9ca6a where the flash node was incorrectly set to `code_partition`, causing `FLASH_BASE_ADDRESS` to default to `0x0` and making the device unprogrammable.