### PR TITLE
llext: load: memcpy section header

### DIFF
--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -177,24 +177,24 @@ static int llext_find_tables(struct llext_loader *ldr, struct llext *ext)
 
 		if (shdr->sh_type == SHT_SYMTAB && ldr->hdr.e_type == ET_REL) {
 			LOG_DBG("symtab at %d", i);
-			ldr->sects[LLEXT_MEM_SYMTAB] = *shdr;
+			memcpy(&ldr->sects[LLEXT_MEM_SYMTAB], shdr, sizeof(*shdr));
 			ldr->sect_map[i].mem_idx = LLEXT_MEM_SYMTAB;
 			strtab_ndx = shdr->sh_link;
 			table_cnt++;
 		} else if (shdr->sh_type == SHT_DYNSYM && ldr->hdr.e_type == ET_DYN) {
 			LOG_DBG("dynsym at %d", i);
-			ldr->sects[LLEXT_MEM_SYMTAB] = *shdr;
+			memcpy(&ldr->sects[LLEXT_MEM_SYMTAB], shdr, sizeof(*shdr));
 			ldr->sect_map[i].mem_idx = LLEXT_MEM_SYMTAB;
 			strtab_ndx = shdr->sh_link;
 			table_cnt++;
 		} else if (shdr->sh_type == SHT_STRTAB && i == shstrtab_ndx) {
 			LOG_DBG("shstrtab at %d", i);
-			ldr->sects[LLEXT_MEM_SHSTRTAB] = *shdr;
+			memcpy(&ldr->sects[LLEXT_MEM_SHSTRTAB], shdr, sizeof(*shdr));
 			ldr->sect_map[i].mem_idx = LLEXT_MEM_SHSTRTAB;
 			table_cnt++;
 		} else if (shdr->sh_type == SHT_STRTAB && i == strtab_ndx) {
 			LOG_DBG("strtab at %d", i);
-			ldr->sects[LLEXT_MEM_STRTAB] = *shdr;
+			memcpy(&ldr->sects[LLEXT_MEM_STRTAB], shdr, sizeof(*shdr));
 			ldr->sect_map[i].mem_idx = LLEXT_MEM_STRTAB;
 			table_cnt++;
 		}


### PR DESCRIPTION
When loading from `.elf` files, it is not guaranteed that section headers are word aligned within the `.elf` file. Attempting to perform a direct assignment results in the compiler assuming the input pointer is aligned, resulting in usage faults if the assumption is broken.

Example logs from my first attempt loading an `.elf`
```
START - test_loading
qemu-system-arm: warning: icount sleep disabled and no active timers
D: Loading ELF data...
D: Loading relocatable ELF
D: Finding ELF tables...
D: section 0 at 0: name 0, type 0, flags 0, addr 0, align 0, size 0, link 0, info 0
D: section 1 at 0x34: name 31, type 1, flags 0x6, addr 0, align 0x4, size 56, link 0, info 0
D: section 2 at 0x274: name 27, type 9, flags 0x40, addr 0, align 0x4, size 16, link 10, info 1
D: section 3 at 0x6c: name 37, type 1, flags 0x3, addr 0, align 0x1, size 0, link 0, info 0
D: section 4 at 0x6c: name 43, type 8, flags 0x3, addr 0, align 0x1, size 0, link 0, info 0
D: section 5 at 0x6c: name 48, type 1, flags 0x2, addr 0, align 0x4, size 57, link 0, info 0
D: section 6 at 0xa8: name 60, type 1, flags 0x2, addr 0, align 0x4, size 16, link 0, info 0
D: section 7 at 0x284: name 56, type 9, flags 0x40, addr 0, align 0x4, size 32, link 10, info 6
D: section 8 at 0xb8: name 74, type 1, flags 0x30, addr 0, align 0x1, size 33, link 0, info 0
D: section 9 at 0xd9: name 83, type 1879048195, flags 0, addr 0, align 0x1, size 47, link 0, info 0
D: section 10 at 0x108: name 1, type 2, flags 0, addr 0, align 0x4, size 288, link 11, info 15
D: symtab at 10
E: ***** USAGE FAULT *****
E:   Unaligned memory access
E: r0/a1:  0x00000010  r1/a2:  0x0000f174  r2/a3:  0x00000000
E: r3/a4:  0x00005179 r12/ip:  0x200025c0 r14/lr:  0x200005ee
E:  xpsr:  0x61000000
E: Faulting instruction address (r15/pc): 0x00004352
E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
E: Current thread: 0x200008c0 (test_loading)
E: Halting system
```