### PR TITLE
llext: option to preserve EDK folder

### DIFF
--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -281,4 +281,6 @@ file(ARCHIVE_CREATE
     ${llext_edk_format}
 )
 
-file(REMOVE_RECURSE ${llext_edk})
+if(NOT CONFIG_LLEXT_EDK_PRESERVE_INPUT_FOLDER)
+    file(REMOVE_RECURSE ${llext_edk})
+endif()

--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -147,7 +147,7 @@ endfunction()
 # read in computed build configuration
 import_kconfig(CONFIG ${PROJECT_BINARY_DIR}/.config)
 
-if (CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID)
+if(CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID)
   message(FATAL_ERROR
     "The LLEXT EDK is not compatible with CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID.")
 endif()
@@ -211,7 +211,7 @@ list(APPEND base_flags ${llext_edk_cflags} ${imacros})
 
 file(MAKE_DIRECTORY ${llext_edk_inc})
 foreach(dir ${INTERFACE_INCLUDE_DIRECTORIES})
-    if (NOT EXISTS ${dir})
+    if(NOT EXISTS ${dir})
         continue()
     endif()
 

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -182,8 +182,9 @@ config LLEXT_EDK_NAME
 	  instance, the default name, "llext-edk", becomes LLEXT_EDK_INSTALL_DIR.
 
 choice LLEXT_EDK_FORMAT
-prompt "EDK compression and output format"
-default LLEXT_EDK_FORMAT_TAR_XZ
+	prompt "EDK compression and output format"
+	default LLEXT_EDK_FORMAT_TAR_ZSTD if LLEXT_EDK_PRESERVE_INPUT_FOLDER
+	default LLEXT_EDK_FORMAT_TAR_XZ
 
 config LLEXT_EDK_FORMAT_TAR_XZ
 	bool ".tar.xz"
@@ -212,5 +213,8 @@ config LLEXT_EDK_USERSPACE_ONLY
 	  or kernel space and route the call accordingly. If the EDK is expected
 	  to be used by userspace only extensions, this option will make EDK stubs
 	  not contain the routing code, and only generate the userspace one.
+
+config LLEXT_EDK_PRESERVE_INPUT_FOLDER
+	bool "Don't delete the EDK source folder"
 
 endif


### PR DESCRIPTION
Add an option to preserve the EDK folder, instead of deleting it after creating the archive. This can simplify test scripting which can now avoid immediately uncompressing the archive when compiling an extension.

If this option is enabled, default to the much faster `.tar.Z` archive format, since the compression ratio of the archive is not important.