### PR TITLE
treewide: align drivers to nrfx drivers returning errno

### DIFF
--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -265,12 +265,12 @@ static int init_adc(const struct device *dev)
 {
 	const nrfx_adc_config_t config = NRFX_ADC_DEFAULT_CONFIG;
 
-	nrfx_err_t result = nrfx_adc_init(&config, event_handler);
+	int result = nrfx_adc_init(&config, event_handler);
 
-	if (result != NRFX_SUCCESS) {
+	if (result != 0) {
 		LOG_ERR("Failed to initialize device: %s",
 			    dev->name);
-		return -EBUSY;
+		return result;
 	}
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -383,11 +383,11 @@ static int adc_nrfx_channel_setup(const struct device *dev,
 		m_data.divide_single_ended_value &= ~BIT(channel_cfg->channel_id);
 	}
 
-	nrfx_err_t ret = nrfx_saadc_channel_config(&cfg);
+	err = nrfx_saadc_channel_config(&cfg);
 
-	if (ret != NRFX_SUCCESS) {
-		LOG_ERR("Cannot configure channel %d: 0x%08x", channel_cfg->channel_id, ret);
-		return -EINVAL;
+	if (err != 0) {
+		LOG_ERR("Cannot configure channel %d: %d", channel_cfg->channel_id, err);
+		return err;
 	}
 
 	return 0;
@@ -398,10 +398,10 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 	if (ctx->sequence.calibrate) {
 		nrfx_saadc_offset_calibrate(event_handler);
 	} else {
-		nrfx_err_t ret = nrfx_saadc_mode_trigger();
+		int ret = nrfx_saadc_mode_trigger();
 
-		if (ret != NRFX_SUCCESS) {
-			LOG_ERR("Cannot start sampling: 0x%08x", ret);
+		if (ret != 0) {
+			LOG_ERR("Cannot start sampling: %d", ret);
 			adc_context_complete(ctx, -EIO);
 		}
 	}
@@ -426,10 +426,9 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx, bool repe
 			return;
 		}
 
-		nrfx_err_t nrfx_err =
-			nrfx_saadc_buffer_set(samples_buffer, m_data.active_channel_cnt);
-		if (nrfx_err != NRFX_SUCCESS) {
-			LOG_ERR("Failed to set buffer: 0x%08x", nrfx_err);
+		error = nrfx_saadc_buffer_set(samples_buffer, m_data.active_channel_cnt);
+		if (error != 0) {
+			LOG_ERR("Failed to set buffer: %d", error);
 			adc_context_complete(ctx, -EIO);
 		}
 	}
@@ -440,10 +439,10 @@ static inline void adc_context_enable_timer(struct adc_context *ctx)
 	if (!m_data.internal_timer_enabled) {
 		k_timer_start(&m_data.timer, K_NO_WAIT, K_USEC(ctx->options.interval_us));
 	} else {
-		nrfx_err_t ret = nrfx_saadc_mode_trigger();
+		int ret = nrfx_saadc_mode_trigger();
 
-		if (ret != NRFX_SUCCESS) {
-			LOG_ERR("Cannot start sampling: 0x%08x", ret);
+		if (ret != 0) {
+			LOG_ERR("Cannot start sampling: %d", ret);
 			adc_context_complete(&m_data.ctx, -EIO);
 		}
 	}
@@ -613,7 +612,6 @@ static inline uint16_t interval_to_cc(uint16_t interval_us)
 static int start_read(const struct device *dev,
 		      const struct adc_sequence *sequence)
 {
-	nrfx_err_t nrfx_err;
 	int error;
 	uint32_t selected_channels = sequence->channels;
 	nrf_saadc_resolution_t resolution;
@@ -671,21 +669,21 @@ static int start_read(const struct device *dev,
 
 		m_data.internal_timer_enabled = true;
 
-		nrfx_err = nrfx_saadc_advanced_mode_set(selected_channels, resolution, &adv_config,
-							event_handler);
+		error = nrfx_saadc_advanced_mode_set(selected_channels, resolution, &adv_config,
+						     event_handler);
 	} else {
 		m_data.internal_timer_enabled = false;
 
-		nrfx_err = nrfx_saadc_simple_mode_set(selected_channels, resolution, oversampling,
-						      event_handler);
+		error = nrfx_saadc_simple_mode_set(selected_channels, resolution, oversampling,
+						   event_handler);
 	}
 
-	if (nrfx_err != NRFX_SUCCESS) {
-		return -EINVAL;
+	if (error != 0) {
+		return error;
 	}
 
 	error = check_buffer_size(sequence, active_channel_cnt);
-	if (error) {
+	if (error != 0) {
 		return error;
 	}
 
@@ -706,14 +704,13 @@ static int start_read(const struct device *dev,
 	/* Buffer is filled in chunks, each chunk composed of number of samples equal to number
 	 * of active channels. Buffer pointer is advanced and reloaded after each chunk.
 	 */
-	nrfx_err = nrfx_saadc_buffer_set(
-		samples_buffer,
-		(m_data.internal_timer_enabled
-			 ? (1 + sequence->options->extra_samplings)
-			 : active_channel_cnt));
-	if (nrfx_err != NRFX_SUCCESS) {
-		LOG_ERR("Failed to set buffer: 0x%08x", nrfx_err);
-		return -EINVAL;
+	error = nrfx_saadc_buffer_set(samples_buffer,
+				      (m_data.internal_timer_enabled
+				      ? (1 + sequence->options->extra_samplings)
+				      : active_channel_cnt));
+	if (error != 0) {
+		LOG_ERR("Failed to set buffer: %d", error);
+		return error;
 	}
 
 	adc_context_start_read(&m_data.ctx, sequence);
@@ -761,7 +758,7 @@ static int adc_nrfx_read_async(const struct device *dev,
 
 static void event_handler(const nrfx_saadc_evt_t *event)
 {
-	nrfx_err_t err;
+	int err;
 
 	if (event->type == NRFX_SAADC_EVT_DONE) {
 		dmm_buffer_in_release(
@@ -780,8 +777,8 @@ static void event_handler(const nrfx_saadc_evt_t *event)
 		adc_context_on_sampling_done(&m_data.ctx, DEVICE_DT_INST_GET(0));
 	} else if (event->type == NRFX_SAADC_EVT_CALIBRATEDONE) {
 		err = nrfx_saadc_mode_trigger();
-		if (err != NRFX_SUCCESS) {
-			LOG_ERR("Cannot start sampling: 0x%08x", err);
+		if (err != 0) {
+			LOG_ERR("Cannot start sampling: %d", err);
 			adc_context_complete(&m_data.ctx, -EIO);
 		}
 	} else if (event->type == NRFX_SAADC_EVT_FINISHED) {
@@ -798,13 +795,13 @@ static int saadc_pm_handler(const struct device *dev, enum pm_device_action acti
 
 static int init_saadc(const struct device *dev)
 {
-	nrfx_err_t err;
+	int err;
 
 	k_timer_init(&m_data.timer, external_timer_expired_handler, NULL);
 
 	/* The priority value passed here is ignored (see nrfx_glue.h). */
 	err = nrfx_saadc_init(0);
-	if (err != NRFX_SUCCESS) {
+	if (err != 0) {
 		LOG_ERR("Failed to initialize device: %s", dev->name);
 		return -EIO;
 	}

--- a/drivers/comparator/comparator_nrf_comp.c
+++ b/drivers/comparator/comparator_nrf_comp.c
@@ -717,7 +717,7 @@ static int shim_nrf_comp_init(const struct device *dev)
 	(void)shim_nrf_comp_diff_config_to_nrf(&shim_nrf_comp_config0, &nrf);
 #endif
 
-	if (nrfx_comp_init(&nrf, shim_nrf_comp_event_handler) != NRFX_SUCCESS) {
+	if (nrfx_comp_init(&nrf, shim_nrf_comp_event_handler) != 0) {
 		return -ENODEV;
 	}
 

--- a/drivers/comparator/comparator_nrf_lpcomp.c
+++ b/drivers/comparator/comparator_nrf_lpcomp.c
@@ -457,7 +457,7 @@ static int shim_nrf_lpcomp_init(const struct device *dev)
 					    &shim_nrf_lpcomp_data0.config);
 
 	if (nrfx_lpcomp_init(&shim_nrf_lpcomp_data0.config,
-			     shim_nrf_lpcomp_event_handler) != NRFX_SUCCESS) {
+			     shim_nrf_lpcomp_event_handler) != 0) {
 		return -ENODEV;
 	}
 

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -380,6 +380,7 @@ static int ppi_setup(const struct device *dev, uint8_t chan)
 	NRF_RTC_Type *rtc = nrfx_config->rtc;
 	nrf_rtc_event_t evt = NRF_RTC_CHANNEL_EVENT_ADDR(chan);
 	nrfx_err_t result;
+	int ret;
 
 	if (!nrfx_config->use_ppi) {
 		return 0;
@@ -405,10 +406,10 @@ static int ppi_setup(const struct device *dev, uint8_t chan)
 	evt_addr = nrfy_rtc_event_address_get(rtc, evt);
 	task_addr = nrfy_rtc_task_address_get(rtc, NRF_RTC_TASK_CLEAR);
 
-	result = nrfx_ppi_channel_alloc(&data->ppi_ch);
-	if (result != NRFX_SUCCESS) {
+	ret = nrfx_ppi_channel_alloc(&data->ppi_ch);
+	if (ret != 0) {
 		ERR("Failed to allocate PPI channel.");
-		return -ENODEV;
+		return ret;
 	}
 	(void)nrfx_ppi_channel_assign(data->ppi_ch, evt_addr, task_addr);
 	(void)nrfx_ppi_channel_enable(data->ppi_ch);

--- a/drivers/display/display_nrf_led_matrix.c
+++ b/drivers/display/display_nrf_led_matrix.c
@@ -438,19 +438,20 @@ static int instance_init(const struct device *dev)
 	nrf_pwm_shorts_set(dev_config->pwm, NRF_PWM_SHORT_SEQEND0_STOP_MASK);
 #else
 	nrfx_err_t err;
+	int ret;
 	nrf_ppi_channel_t ppi_ch;
 
 	for (int i = 0; i < GROUP_SIZE; ++i) {
 		uint8_t *gpiote_ch = &dev_data->gpiote_ch[i];
 
-		err = nrfx_ppi_channel_alloc(&ppi_ch);
-		if (err != NRFX_SUCCESS) {
+		ret = nrfx_ppi_channel_alloc(&ppi_ch);
+		if (ret != 0) {
 			LOG_ERR("Failed to allocate PPI channel.");
 			/* Do not bother with freeing resources allocated
 			 * so far. The application needs to be reconfigured
 			 * anyway.
 			 */
-			return -ENOMEM;
+			return ret;
 		}
 
 		err = nrfx_gpiote_channel_alloc(&dev_config->gpiote, gpiote_ch);

--- a/drivers/entropy/entropy_nrf_cracen.c
+++ b/drivers/entropy/entropy_nrf_cracen.c
@@ -23,12 +23,10 @@ static int nrf_cracen_get_entropy_isr(const struct device *dev, uint8_t *buf, ui
 
 	irq_unlock(key);
 
-	if (likely(ret == NRFX_SUCCESS)) {
+	if (likely(ret == 0)) {
 		return len;
-	} else if (ret == NRFX_ERROR_INVALID_PARAM) {
-		return -EINVAL;
 	} else {
-		return -EAGAIN;
+		return ret;
 	}
 }
 
@@ -47,13 +45,7 @@ static int nrf_cracen_cracen_init(const struct device *dev)
 {
 	(void)dev;
 
-	int ret = nrfx_cracen_ctr_drbg_init();
-
-	if (ret == NRFX_SUCCESS) {
-		return 0;
-	} else {
-		return -EIO;
-	}
+	return nrfx_cracen_ctr_drbg_init();
 }
 
 static DEVICE_API(entropy, nrf_cracen_api_funcs) = {

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -238,32 +238,6 @@ static int exit_dpd(const struct device *const dev);
 #define QSPI_IS_SECTOR_ALIGNED(_ofs) (((_ofs) & (QSPI_SECTOR_SIZE - 1U)) == 0)
 #define QSPI_IS_BLOCK_ALIGNED(_ofs) (((_ofs) & (QSPI_BLOCK_SIZE - 1U)) == 0)
 
-/**
- * @brief Converts NRFX return codes to the zephyr ones
- */
-static inline int qspi_get_zephyr_ret_code(nrfx_err_t res)
-{
-	switch (res) {
-	case NRFX_SUCCESS:
-		return 0;
-	case NRFX_ERROR_INVALID_PARAM:
-	case NRFX_ERROR_INVALID_ADDR:
-		return -EINVAL;
-	case NRFX_ERROR_INVALID_STATE:
-		return -ECANCELED;
-#if NRF53_ERRATA_159_ENABLE_WORKAROUND
-	case NRFX_ERROR_FORBIDDEN:
-		LOG_ERR("nRF5340 anomaly 159 conditions detected");
-		LOG_ERR("Set the CPU clock to 64 MHz before starting QSPI operation");
-		return -ECANCELED;
-#endif
-	case NRFX_ERROR_BUSY:
-	case NRFX_ERROR_TIMEOUT:
-	default:
-		return -EBUSY;
-	}
-}
-
 static inline void qspi_lock(const struct device *dev)
 {
 #ifdef CONFIG_MULTITHREADING
@@ -375,12 +349,11 @@ static void qspi_release(const struct device *dev)
 	}
 }
 
-static inline void qspi_wait_for_completion(const struct device *dev,
-					    nrfx_err_t res)
+static inline void qspi_wait_for_completion(const struct device *dev, int res)
 {
 	struct qspi_nor_data *dev_data = dev->data;
 
-	if (res == NRFX_SUCCESS) {
+	if (res == 0) {
 #ifdef CONFIG_MULTITHREADING
 		k_sem_take(&dev_data->sync, K_FOREVER);
 #else /* CONFIG_MULTITHREADING */
@@ -476,9 +449,7 @@ static int qspi_send_cmd(const struct device *dev, const struct qspi_cmd *cmd,
 		.wren = wren,
 	};
 
-	int res = nrfx_qspi_cinstr_xfer(&cinstr_cfg, tx_buf, rx_buf);
-
-	return qspi_get_zephyr_ret_code(res);
+	return nrfx_qspi_cinstr_xfer(&cinstr_cfg, tx_buf, rx_buf);
 }
 
 #if !IS_EQUAL(INST_0_QER, JESD216_DW15_QER_VAL_NONE)
@@ -606,7 +577,7 @@ static int qspi_erase(const struct device *dev, uint32_t addr, uint32_t size)
 		return rc;
 	}
 	while (size > 0) {
-		nrfx_err_t res = !NRFX_SUCCESS;
+		int res = -1;
 		uint32_t adj = 0;
 
 		if (size == params->size) {
@@ -626,11 +597,11 @@ static int qspi_erase(const struct device *dev, uint32_t addr, uint32_t size)
 		} else {
 			/* minimal erase size is at least a sector size */
 			LOG_ERR("unsupported at 0x%lx size %zu", (long)addr, size);
-			res = NRFX_ERROR_INVALID_PARAM;
+			res = -EINVAL;
 		}
 
 		qspi_wait_for_completion(dev, res);
-		if (res == NRFX_SUCCESS) {
+		if (res == 0) {
 			addr += adj;
 			size -= adj;
 
@@ -645,7 +616,7 @@ static int qspi_erase(const struct device *dev, uint32_t addr, uint32_t size)
 			}
 		} else {
 			LOG_ERR("erase error at 0x%lx size %zu", (long)addr, size);
-			rc = qspi_get_zephyr_ret_code(res);
+			rc = res;
 			break;
 		}
 	}
@@ -780,24 +751,24 @@ static int qspi_sfdp_read(const struct device *dev, off_t offset,
 		.io2_level = true,
 		.io3_level = true,
 	};
-	nrfx_err_t res;
+	int res;
 
 	qspi_acquire(dev);
 
 	res = nrfx_qspi_lfm_start(&cinstr_cfg);
-	if (res != NRFX_SUCCESS) {
+	if (res != 0) {
 		LOG_DBG("lfm_start: %x", res);
 		goto out;
 	}
 
 	res = nrfx_qspi_lfm_xfer(addr_buf, NULL, sizeof(addr_buf), false);
-	if (res != NRFX_SUCCESS) {
+	if (res != 0) {
 		LOG_DBG("lfm_xfer addr: %x", res);
 		goto out;
 	}
 
 	res = nrfx_qspi_lfm_xfer(NULL, data, len, true);
-	if (res != NRFX_SUCCESS) {
+	if (res != 0) {
 		LOG_DBG("lfm_xfer read: %x", res);
 		goto out;
 	}
@@ -805,14 +776,14 @@ static int qspi_sfdp_read(const struct device *dev, off_t offset,
 out:
 	qspi_release(dev);
 
-	return qspi_get_zephyr_ret_code(res);
+	return res;
 }
 
 #endif /* CONFIG_FLASH_JESD216_API */
 
-static inline nrfx_err_t read_non_aligned(const struct device *dev,
-					  off_t addr,
-					  void *dest, size_t size)
+static inline int read_non_aligned(const struct device *dev,
+				   off_t addr,
+				   void *dest, size_t size)
 {
 	uint8_t __aligned(WORD_SIZE) buf[WORD_SIZE * 2];
 	uint8_t *dptr = dest;
@@ -839,14 +810,14 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev,
 		flash_suffix = size - flash_prefix - flash_middle;
 	}
 
-	nrfx_err_t res = NRFX_SUCCESS;
+	int res = 0;
 
 	/* read from aligned flash to aligned memory */
 	if (flash_middle != 0) {
 		res = nrfx_qspi_read(dptr + dest_prefix, flash_middle,
 				     addr + flash_prefix);
 		qspi_wait_for_completion(dev, res);
-		if (res != NRFX_SUCCESS) {
+		if (res != 0) {
 			return res;
 		}
 
@@ -861,7 +832,7 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev,
 		res = nrfx_qspi_read(buf, WORD_SIZE, addr -
 				     (WORD_SIZE - flash_prefix));
 		qspi_wait_for_completion(dev, res);
-		if (res != NRFX_SUCCESS) {
+		if (res != 0) {
 			return res;
 		}
 		memcpy(dptr, buf + WORD_SIZE - flash_prefix, flash_prefix);
@@ -872,7 +843,7 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev,
 		res = nrfx_qspi_read(buf, WORD_SIZE * 2,
 				     addr + flash_prefix + flash_middle);
 		qspi_wait_for_completion(dev, res);
-		if (res != NRFX_SUCCESS) {
+		if (res != 0) {
 			return res;
 		}
 		memcpy(dptr + flash_prefix + flash_middle, buf, flash_suffix);
@@ -885,7 +856,7 @@ static int qspi_nor_read(const struct device *dev, off_t addr, void *dest,
 			 size_t size)
 {
 	const struct qspi_nor_config *params = dev->config;
-	nrfx_err_t res;
+	int res;
 
 	if (!dest) {
 		return -EINVAL;
@@ -911,15 +882,15 @@ static int qspi_nor_read(const struct device *dev, off_t addr, void *dest,
 
 	qspi_release(dev);
 
-	return qspi_get_zephyr_ret_code(res);
+	return res;
 }
 
 /* addr aligned, sptr not null, slen less than 4 */
-static inline nrfx_err_t write_sub_word(const struct device *dev, off_t addr,
-					const void *sptr, size_t slen)
+static inline int write_sub_word(const struct device *dev, off_t addr,
+				 const void *sptr, size_t slen)
 {
 	uint8_t __aligned(4) buf[4];
-	nrfx_err_t res;
+	int res;
 
 	/* read out the whole word so that unchanged data can be
 	 * written back
@@ -927,7 +898,7 @@ static inline nrfx_err_t write_sub_word(const struct device *dev, off_t addr,
 	res = nrfx_qspi_read(buf, sizeof(buf), addr);
 	qspi_wait_for_completion(dev, res);
 
-	if (res == NRFX_SUCCESS) {
+	if (res == 0) {
 		memcpy(buf, sptr, slen);
 		res = nrfx_qspi_write(buf, sizeof(buf), addr);
 		qspi_wait_for_completion(dev, res);
@@ -944,30 +915,30 @@ BUILD_ASSERT((CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE % 4) == 0,
  *
  * If not enabled return the error the peripheral would have produced.
  */
-static nrfx_err_t write_through_buffer(const struct device *dev, off_t addr,
+static int write_through_buffer(const struct device *dev, off_t addr,
 				       const void *sptr, size_t slen)
 {
-	nrfx_err_t res = NRFX_SUCCESS;
+	int res = 0;
 
 	if (CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE > 0) {
 		uint8_t __aligned(4) buf[CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE];
 		const uint8_t *sp = sptr;
 
-		while ((slen > 0) && (res == NRFX_SUCCESS)) {
+		while ((slen > 0) && (res == 0)) {
 			size_t len = MIN(slen, sizeof(buf));
 
 			memcpy(buf, sp, len);
 			res = nrfx_qspi_write(buf, len, addr);
 			qspi_wait_for_completion(dev, res);
 
-			if (res == NRFX_SUCCESS) {
+			if (res == 0) {
 				slen -= len;
 				sp += len;
 				addr += len;
 			}
 		}
 	} else {
-		res = NRFX_ERROR_INVALID_ADDR;
+		res = -EACCES;
 	}
 	return res;
 }
@@ -1006,19 +977,15 @@ static int qspi_nor_write(const struct device *dev, off_t addr,
 
 	rc = qspi_nor_write_protection_set(dev, false);
 	if (rc == 0) {
-		nrfx_err_t res;
-
 		if (size < 4U) {
-			res = write_sub_word(dev, addr, src, size);
+			rc = write_sub_word(dev, addr, src, size);
 		} else if (!nrfx_is_in_ram(src) ||
 			   !nrfx_is_word_aligned(src)) {
-			res = write_through_buffer(dev, addr, src, size);
+			rc = write_through_buffer(dev, addr, src, size);
 		} else {
-			res = nrfx_qspi_write(src, size, addr);
-			qspi_wait_for_completion(dev, res);
+			rc = nrfx_qspi_write(src, size, addr);
+			qspi_wait_for_completion(dev, rc);
 		}
-
-		rc = qspi_get_zephyr_ret_code(res);
 	}
 
 	rc2 = qspi_nor_write_protection_set(dev, true);
@@ -1080,11 +1047,9 @@ static int qspi_init(const struct device *dev)
 {
 	const struct qspi_nor_config *dev_config = dev->config;
 	uint8_t id[SPI_NOR_MAX_ID_LEN];
-	nrfx_err_t res;
 	int rc;
 
-	res = nrfx_qspi_init(&dev_config->nrfx_cfg, qspi_handler, dev->data);
-	rc = qspi_get_zephyr_ret_code(res);
+	rc = nrfx_qspi_init(&dev_config->nrfx_cfg, qspi_handler, dev->data);
 	if (rc < 0) {
 		return rc;
 	}
@@ -1269,15 +1234,14 @@ static int exit_dpd(const struct device *const dev)
 			.op_code = SPI_NOR_CMD_RDPD,
 		};
 		uint32_t t_exit_dpd = DT_INST_PROP_OR(0, t_exit_dpd, 0);
-		nrfx_err_t res;
 		int rc;
 
 		nrf_qspi_pins_get(NRF_QSPI, &pins);
 		nrf_qspi_pins_set(NRF_QSPI, &disconnected_pins);
-		res = nrfx_qspi_activate(true);
+		rc = nrfx_qspi_activate(true);
 		nrf_qspi_pins_set(NRF_QSPI, &pins);
 
-		if (res != NRFX_SUCCESS) {
+		if (rc != 0) {
 			return -EIO;
 		}
 
@@ -1301,11 +1265,10 @@ static int exit_dpd(const struct device *const dev)
 static int qspi_suspend(const struct device *dev)
 {
 	const struct qspi_nor_config *dev_config = dev->config;
-	nrfx_err_t res;
 	int rc;
 
-	res = nrfx_qspi_mem_busy_check();
-	if (res != NRFX_SUCCESS) {
+	rc = nrfx_qspi_mem_busy_check();
+	if (rc != -) {
 		return -EBUSY;
 	}
 
@@ -1322,7 +1285,6 @@ static int qspi_suspend(const struct device *dev)
 static int qspi_resume(const struct device *dev)
 {
 	const struct qspi_nor_config *dev_config = dev->config;
-	nrfx_err_t res;
 	int rc;
 
 	rc = pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_DEFAULT);
@@ -1330,9 +1292,9 @@ static int qspi_resume(const struct device *dev)
 		return rc;
 	}
 
-	res = nrfx_qspi_init(&dev_config->nrfx_cfg, qspi_handler, dev->data);
-	if (res != NRFX_SUCCESS) {
-		return -EIO;
+	rc = nrfx_qspi_init(&dev_config->nrfx_cfg, qspi_handler, dev->data);
+	if (rc < 0) {
+		return rc;
 	}
 
 	return exit_dpd(dev);

--- a/drivers/flash/soc_flash_nrf_mramc.c
+++ b/drivers/flash/soc_flash_nrf_mramc.c
@@ -186,11 +186,11 @@ static int mramc_sys_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	nrfx_mramc_config_t config = NRFX_MRAMC_DEFAULT_CONFIG();
-	nrfx_err_t err = nrfx_mramc_init(&config, NULL);
+	int ret = nrfx_mramc_init(&config, NULL);
 
-	if (err != NRFX_SUCCESS) {
+	if (ret != 0) {
 		LOG_ERR("Failed to initialize MRAMC: %d", err);
-		return -EIO;
+		return ret;
 	}
 	LOG_DBG("MRAMC initialized successfully");
 	return 0;

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -27,7 +27,7 @@ struct i2c_nrfx_twi_data {
 	uint32_t dev_config;
 	struct k_sem transfer_sync;
 	struct k_sem completion_sync;
-	volatile nrfx_err_t res;
+	volatile int res;
 };
 
 /* Enforce dev_config matches the same offset as the common structure,
@@ -109,16 +109,16 @@ static void event_handler(nrfx_twi_evt_t const *p_event, void *p_context)
 
 	switch (p_event->type) {
 	case NRFX_TWI_EVT_DONE:
-		dev_data->res = NRFX_SUCCESS;
+		dev_data->res = 0;
 		break;
 	case NRFX_TWI_EVT_ADDRESS_NACK:
-		dev_data->res = NRFX_ERROR_DRV_TWI_ERR_ANACK;
+		dev_data->res = -EIO;
 		break;
 	case NRFX_TWI_EVT_DATA_NACK:
-		dev_data->res = NRFX_ERROR_DRV_TWI_ERR_DNACK;
+		dev_data->res = -EAGAIN;
 		break;
 	default:
-		dev_data->res = NRFX_ERROR_INTERNAL;
+		dev_data->res = -ECANCELED;
 		break;
 	}
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -91,7 +91,7 @@ static int configure(const struct device *dev,
 	const struct spi_nrfx_config *dev_config = dev->config;
 	struct spi_context *ctx = &dev_data->ctx;
 	nrfx_spi_config_t config;
-	nrfx_err_t result;
+	int result;
 	uint32_t sck_pin;
 
 	if (dev_data->initialized && spi_context_configured(ctx, spi_cfg)) {
@@ -149,8 +149,8 @@ static int configure(const struct device *dev,
 
 	result = nrfx_spi_init(&dev_config->spi, &config,
 			       event_handler, dev_data);
-	if (result != NRFX_SUCCESS) {
-		LOG_ERR("Failed to initialize nrfx driver: %08x", result);
+	if (result != 0) {
+		LOG_ERR("Failed to initialize nrfx driver: %d", result);
 		return -EIO;
 	}
 
@@ -183,7 +183,6 @@ static void transfer_next_chunk(const struct device *dev)
 
 	if (chunk_len > 0) {
 		nrfx_spi_xfer_desc_t xfer;
-		nrfx_err_t result;
 
 		dev_data->chunk_len = chunk_len;
 
@@ -191,8 +190,8 @@ static void transfer_next_chunk(const struct device *dev)
 		xfer.tx_length   = spi_context_tx_buf_on(ctx) ? chunk_len : 0;
 		xfer.p_rx_buffer = ctx->rx_buf;
 		xfer.rx_length   = spi_context_rx_buf_on(ctx) ? chunk_len : 0;
-		result = nrfx_spi_xfer(&dev_config->spi, &xfer, 0);
-		if (result == NRFX_SUCCESS) {
+		error = nrfx_spi_xfer(&dev_config->spi, &xfer, 0);
+		if (error == 0) {
 			return;
 		}
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -444,14 +444,15 @@ static int anomaly_58_workaround_init(const struct device *dev)
 	struct spi_nrfx_data *dev_data = dev->data;
 	const struct spi_nrfx_config *dev_config = dev->config;
 	nrfx_err_t err_code;
+	int ret;
 
 	dev_data->anomaly_58_workaround_active = false;
 
 	if (dev_config->anomaly_58_workaround) {
-		err_code = nrfx_ppi_channel_alloc(&dev_data->ppi_ch);
-		if (err_code != NRFX_SUCCESS) {
+		ret = nrfx_ppi_channel_alloc(&dev_data->ppi_ch);
+		if (ret != 0) {
 			LOG_ERR("Failed to allocate PPI channel");
-			return -ENODEV;
+			return ret;
 		}
 
 		err_code = nrfx_gpiote_channel_alloc(&gpiote, &dev_data->gpiote_ch);

--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -93,20 +93,6 @@ static inline uint64_t counter(void)
 	return now;
 }
 
-static inline int get_comparator(uint32_t chan, uint64_t *cc)
-{
-	nrfx_err_t result;
-
-	result = nrfx_grtc_syscounter_cc_value_read(chan, cc);
-	if (result != NRFX_SUCCESS) {
-		if (result != NRFX_ERROR_INVALID_PARAM) {
-			return -EAGAIN;
-		}
-		return -EPERM;
-	}
-	return 0;
-}
-
 /*
  * Program a new callback <value> microseconds in the future
  */
@@ -175,15 +161,15 @@ static void sys_clock_timeout_handler(int32_t id, uint64_t cc_val, void *p_conte
 int32_t z_nrf_grtc_timer_chan_alloc(void)
 {
 	uint8_t chan;
-	nrfx_err_t err_code;
+	int ret;
 
 	/* Prevent allocating all available channels - one must be left for system purposes. */
 	if (ext_channels_allocated >= EXT_CHAN_COUNT) {
 		return -ENOMEM;
 	}
-	err_code = nrfx_grtc_channel_alloc(&chan);
-	if (err_code != NRFX_SUCCESS) {
-		return -ENOMEM;
+	ret = nrfx_grtc_channel_alloc(&chan);
+	if (ret != 0) {
+		return ret;
 	}
 	ext_channels_allocated++;
 	return (int32_t)chan;
@@ -192,9 +178,9 @@ int32_t z_nrf_grtc_timer_chan_alloc(void)
 void z_nrf_grtc_timer_chan_free(int32_t chan)
 {
 	IS_CHANNEL_ALLOWED_ASSERT(chan);
-	nrfx_err_t err_code = nrfx_grtc_channel_free(chan);
+	int ret = nrfx_grtc_channel_free(chan);
 
-	if (err_code == NRFX_SUCCESS) {
+	if (ret == 0) {
 		ext_channels_allocated--;
 	}
 }
@@ -245,25 +231,20 @@ int z_nrf_grtc_timer_compare_read(int32_t chan, uint64_t *val)
 {
 	IS_CHANNEL_ALLOWED_ASSERT(chan);
 
-	return get_comparator(chan, val);
+	return nrfx_grtc_syscounter_cc_value_read(chan, val);
 }
 
 static int compare_set_nolocks(int32_t chan, uint64_t target_time,
 			       z_nrf_grtc_timer_compare_handler_t handler, void *user_data)
 {
-	nrfx_err_t result;
-
 	__ASSERT_NO_MSG(target_time < COUNTER_SPAN);
 	nrfx_grtc_channel_t user_channel_data = {
 		.handler = handler,
 		.p_context = user_data,
 		.channel = chan,
 	};
-	result = nrfx_grtc_syscounter_cc_absolute_set(&user_channel_data, target_time, true);
-	if (result != NRFX_SUCCESS) {
-		return -EPERM;
-	}
-	return 0;
+
+	return nrfx_grtc_syscounter_cc_absolute_set(&user_channel_data, target_time, true);
 }
 
 static int compare_set(int32_t chan, uint64_t target_time,
@@ -316,7 +297,6 @@ int z_nrf_grtc_timer_capture_prepare(int32_t chan)
 		.p_context = NULL,
 		.channel = chan,
 	};
-	nrfx_err_t result;
 
 	IS_CHANNEL_ALLOWED_ASSERT(chan);
 
@@ -324,19 +304,13 @@ int z_nrf_grtc_timer_capture_prepare(int32_t chan)
 	 * (makes CCEN=1). COUNTER_SPAN is used so as not to fire an event unnecessarily
 	 * - it can be assumed that such a large value will never be reached.
 	 */
-	result = nrfx_grtc_syscounter_cc_absolute_set(&user_channel_data, COUNTER_SPAN, false);
-
-	if (result != NRFX_SUCCESS) {
-		return -EPERM;
-	}
-
-	return 0;
+	return nrfx_grtc_syscounter_cc_absolute_set(&user_channel_data, COUNTER_SPAN, false);
 }
 
 int z_nrf_grtc_timer_capture_read(int32_t chan, uint64_t *captured_time)
 {
 	uint64_t capt_time;
-	nrfx_err_t result;
+	int result;
 
 	IS_CHANNEL_ALLOWED_ASSERT(chan);
 
@@ -347,8 +321,8 @@ int z_nrf_grtc_timer_capture_read(int32_t chan, uint64_t *captured_time)
 		return -EBUSY;
 	}
 	result = nrfx_grtc_syscounter_cc_value_read(chan, &capt_time);
-	if (result != NRFX_SUCCESS) {
-		return -EPERM;
+	if (result != 0) {
+		return result;
 	}
 
 	__ASSERT_NO_MSG(capt_time < COUNTER_SPAN);
@@ -366,7 +340,6 @@ uint64_t z_nrf_grtc_timer_startup_value_get(void)
 #if defined(CONFIG_POWEROFF) && defined(CONFIG_NRF_GRTC_START_SYSCOUNTER)
 int z_nrf_grtc_wakeup_prepare(uint64_t wake_time_us)
 {
-	nrfx_err_t err_code;
 	static uint8_t systemoff_channel;
 	uint64_t now = counter();
 	nrfx_grtc_sleep_config_t sleep_cfg;
@@ -388,10 +361,10 @@ int z_nrf_grtc_wakeup_prepare(uint64_t wake_time_us)
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	err_code = nrfx_grtc_channel_alloc(&systemoff_channel);
-	if (err_code != NRFX_SUCCESS) {
+	ret = nrfx_grtc_channel_alloc(&systemoff_channel);
+	if (ret != 0) {
 		k_spin_unlock(&lock, key);
-		return -ENOMEM;
+		return ret;
 	}
 	(void)nrfx_grtc_syscounter_cc_int_disable(systemoff_channel);
 	ret = compare_set(systemoff_channel,
@@ -465,7 +438,7 @@ ISR_DIRECT_DECLARE(nrfx_grtc_direct_irq_handler)
 
 static int sys_clock_driver_init(void)
 {
-	nrfx_err_t err_code;
+	int ret;
 
 #if defined(CONFIG_GEN_SW_ISR_TABLE)
 	IRQ_CONNECT(DT_IRQN(GRTC_NODE), DT_IRQ(GRTC_NODE, priority), nrfx_isr,
@@ -488,20 +461,20 @@ static int sys_clock_driver_init(void)
 #endif
 #endif
 
-	err_code = nrfx_grtc_init(0);
-	if (err_code != NRFX_SUCCESS) {
-		return -EPERM;
+	ret = nrfx_grtc_init(0);
+	if (ret != 0) {
+		return ret;
 	}
 
 #if defined(CONFIG_NRF_GRTC_START_SYSCOUNTER)
-	err_code = nrfx_grtc_syscounter_start(true, &system_clock_channel_data.channel);
-	if (err_code != NRFX_SUCCESS) {
-		return err_code == NRFX_ERROR_NO_MEM ? -ENOMEM : -EPERM;
+	ret = nrfx_grtc_syscounter_start(true, &system_clock_channel_data.channel);
+	if (ret != 0) {
+		return ret;
 	}
 #else
-	err_code = nrfx_grtc_channel_alloc(&system_clock_channel_data.channel);
-	if (err_code != NRFX_SUCCESS) {
-		return -ENOMEM;
+	ret = nrfx_grtc_channel_alloc(&system_clock_channel_data.channel);
+	if (ret != 0) {
+		return ret;
 	}
 #endif /* CONFIG_NRF_GRTC_START_SYSCOUNTER */
 

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -806,7 +806,7 @@ static int sys_clock_driver_init(void)
 	alloc_mask &= ~BIT(WRAP_CH);
 
 	nrf_rtc_event_t evt = NRF_RTC_CHANNEL_EVENT_ADDR(WRAP_CH);
-	nrfx_err_t result;
+	int result;
 	nrf_ppi_channel_t ch;
 
 	nrfy_rtc_event_enable(RTC, NRF_RTC_CHANNEL_INT_MASK(WRAP_CH));
@@ -818,8 +818,8 @@ static int sys_clock_driver_init(void)
 	task_addr = nrfy_rtc_task_address_get(RTC, NRF_RTC_TASK_CLEAR);
 
 	result = nrfx_ppi_channel_alloc(&ch);
-	if (result != NRFX_SUCCESS) {
-		return -ENODEV;
+	if (result != 0) {
+		return result;
 	}
 	(void)nrfx_ppi_channel_assign(ch, evt_addr, task_addr);
 	(void)nrfx_ppi_channel_enable(ch);

--- a/modules/hal_nordic/nrfx/nrfx_glue.c
+++ b/modules/hal_nordic/nrfx/nrfx_glue.c
@@ -45,3 +45,25 @@ char const *nrfx_error_string_get(nrfx_err_t code)
 		default: return "unknown";
 	}
 }
+
+char const *nrfx_new_error_string_get(int code)
+{
+	#define NRFX_NEW_ERROR_STRING_CASE(code)  case code: return #code
+	switch (-code)
+	{
+		NRFX_NEW_ERROR_STRING_CASE(0);
+		NRFX_NEW_ERROR_STRING_CASE(ECANCELED);
+		NRFX_NEW_ERROR_STRING_CASE(ENOMEM);
+		NRFX_NEW_ERROR_STRING_CASE(ENOTSUP);
+		NRFX_NEW_ERROR_STRING_CASE(EINVAL);
+		NRFX_NEW_ERROR_STRING_CASE(EINPROGRESS);
+		NRFX_NEW_ERROR_STRING_CASE(E2BIG);
+		NRFX_NEW_ERROR_STRING_CASE(ETIMEDOUT);
+		NRFX_NEW_ERROR_STRING_CASE(EPERM);
+		NRFX_NEW_ERROR_STRING_CASE(EFAULT);
+		NRFX_NEW_ERROR_STRING_CASE(EACCES);
+		NRFX_NEW_ERROR_STRING_CASE(EBUSY);
+		NRFX_NEW_ERROR_STRING_CASE(EALREADY);
+		default: return "unknown";
+	}
+}

--- a/modules/hal_nordic/nrfx/nrfx_log.h
+++ b/modules/hal_nordic/nrfx/nrfx_log.h
@@ -128,6 +128,16 @@ LOG_MODULE_REGISTER(NRFX_MODULE_PREFIX, NRFX_MODULE_LOG_LEVEL);
 #define NRFX_LOG_ERROR_STRING_GET(error_code)  nrfx_error_string_get(error_code)
 extern char const *nrfx_error_string_get(nrfx_err_t code);
 
+/**
+ * @brief Macro for getting the textual representation of a given errno error code.
+ *
+ * @param[in] error_code Errno error code.
+ *
+ * @return String containing the textual representation of the errno error code.
+ */
+#define NRFX_NEW_LOG_ERROR_STRING_GET(error_code)  nrfx_new_error_string_get(error_code)
+extern char const *nrfx_new_error_string_get(int code);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/modules/nrf_wifi/bus/qspi_if.c
+++ b/modules/nrf_wifi/bus/qspi_if.c
@@ -296,17 +296,17 @@ static inline int qspi_get_lines_read(uint8_t lines)
 	return ret;
 }
 
-nrfx_err_t _nrfx_qspi_read(void *p_rx_buffer, size_t rx_buffer_length, uint32_t src_address)
+int _nrfx_qspi_read(void *p_rx_buffer, size_t rx_buffer_length, uint32_t src_address)
 {
 	return nrfx_qspi_read(p_rx_buffer, rx_buffer_length, src_address);
 }
 
-nrfx_err_t _nrfx_qspi_write(void const *p_tx_buffer, size_t tx_buffer_length, uint32_t dst_address)
+int _nrfx_qspi_write(void const *p_tx_buffer, size_t tx_buffer_length, uint32_t dst_address)
 {
 	return nrfx_qspi_write(p_tx_buffer, tx_buffer_length, dst_address);
 }
 
-nrfx_err_t _nrfx_qspi_init(nrfx_qspi_config_t const *p_config, nrfx_qspi_handler_t handler,
+int _nrfx_qspi_init(nrfx_qspi_config_t const *p_config, nrfx_qspi_handler_t handler,
 			   void *p_context)
 {
 	NRF_QSPI_Type *p_reg = NRF_QSPI;
@@ -319,7 +319,7 @@ nrfx_err_t _nrfx_qspi_init(nrfx_qspi_config_t const *p_config, nrfx_qspi_handler
 	/* LOG_DBG("%04x : IFTIMING", p_reg->IFTIMING & qspi_cfg->RDC4IO); */
 
 	/* ACTIVATE task fails for slave bitfile so ignore it */
-	return NRFX_SUCCESS;
+	return 0;
 }
 
 
@@ -338,32 +338,6 @@ static struct qspi_nor_data qspi_nor_memory_data = {
 NRF_DT_CHECK_NODE_HAS_PINCTRL_SLEEP(QSPI_IF_BUS_NODE);
 
 IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(QSPI_IF_BUS_NODE)));
-
-/**
- * @brief Converts NRFX return codes to the zephyr ones
- */
-static inline int qspi_get_zephyr_ret_code(nrfx_err_t res)
-{
-	switch (res) {
-	case NRFX_SUCCESS:
-		return 0;
-	case NRFX_ERROR_INVALID_PARAM:
-	case NRFX_ERROR_INVALID_ADDR:
-		return -EINVAL;
-	case NRFX_ERROR_INVALID_STATE:
-		return -ECANCELED;
-#if NRF53_ERRATA_159_ENABLE_WORKAROUND
-	case NRFX_ERROR_FORBIDDEN:
-		LOG_ERR("nRF5340 anomaly 159 conditions detected");
-		LOG_ERR("Set the CPU clock to 64 MHz before starting QSPI operation");
-		return -ECANCELED;
-#endif
-	case NRFX_ERROR_BUSY:
-	case NRFX_ERROR_TIMEOUT:
-	default:
-		return -EBUSY;
-	}
-}
 
 static inline struct qspi_nor_data *get_dev_data(const struct device *dev)
 {
@@ -431,11 +405,11 @@ static inline void qspi_trans_unlock(const struct device *dev)
 #endif /* CONFIG_MULTITHREADING */
 }
 
-static inline void qspi_wait_for_completion(const struct device *dev, nrfx_err_t res)
+static inline void qspi_wait_for_completion(const struct device *dev, int res)
 {
 	struct qspi_nor_data *dev_data = get_dev_data(dev);
 
-	if (res == NRFX_SUCCESS) {
+	if (res == 0) {
 #ifdef CONFIG_MULTITHREADING
 		k_sem_take(&dev_data->sync, K_FOREVER);
 #else /* CONFIG_MULTITHREADING */
@@ -469,7 +443,7 @@ static inline void _qspi_complete(struct qspi_nor_data *dev_data)
 
 	qspi_complete(dev_data);
 }
-static inline void _qspi_wait_for_completion(const struct device *dev, nrfx_err_t res)
+static inline void _qspi_wait_for_completion(const struct device *dev, int res)
 {
 	if (!qspi_cfg->easydma) {
 		return;
@@ -499,7 +473,6 @@ static bool qspi_initialized;
 static int qspi_device_init(const struct device *dev)
 {
 	struct qspi_nor_data *dev_data = get_dev_data(dev);
-	nrfx_err_t res;
 	int ret = 0;
 
 	if (!IS_ENABLED(CONFIG_NRF70_QSPI_LOW_POWER)) {
@@ -517,8 +490,7 @@ static int qspi_device_init(const struct device *dev)
 #endif
 
 	if (!qspi_initialized) {
-		res = nrfx_qspi_init(&QSPIconfig, qspi_handler, dev_data);
-		ret = qspi_get_zephyr_ret_code(res);
+		ret = nrfx_qspi_init(&QSPIconfig, qspi_handler, dev_data);
 		NRF_QSPI->IFTIMING |= qspi_cfg->RDC4IO;
 		qspi_initialized = (ret == 0);
 	}
@@ -543,7 +515,7 @@ static void _qspi_device_uninit(const struct device *dev)
 #endif
 
 	if (last) {
-		while (nrfx_qspi_mem_busy_check() != NRFX_SUCCESS) {
+		while (nrfx_qspi_mem_busy_check() != 0) {
 			if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 				k_msleep(50);
 			} else {
@@ -632,7 +604,7 @@ static int qspi_send_cmd(const struct device *dev, const struct qspi_cmd *cmd, b
 	int res = nrfx_qspi_cinstr_xfer(&cinstr_cfg, tx_buf, rx_buf);
 
 	qspi_unlock(dev);
-	return qspi_get_zephyr_ret_code(res);
+	return res
 }
 
 /* RDSR wrapper.  Negative value is error. */
@@ -740,16 +712,13 @@ static int qspi_nrfx_configure(const struct device *dev)
 	k_busy_wait(BASE_CLOCK_SWITCH_DELAY_US);
 #endif
 
-	nrfx_err_t res = _nrfx_qspi_init(&QSPIconfig, qspi_handler, dev_data);
+	int ret = _nrfx_qspi_init(&QSPIconfig, qspi_handler, dev_data);
 
 #if defined(CONFIG_SOC_SERIES_NRF53X)
 	/* Restore the default /4 divider after the QSPI initialization. */
 	nrf_clock_hfclk192m_div_set(NRF_CLOCK, NRF_CLOCK_HFCLK_DIV_4);
 	k_busy_wait(BASE_CLOCK_SWITCH_DELAY_US);
 #endif
-
-	int ret = qspi_get_zephyr_ret_code(res);
-
 	if (ret == 0) {
 		/* Set QE to match transfer mode. If not using quad
 		 * it's OK to leave QE set, but doing so prevents use
@@ -806,7 +775,7 @@ static int qspi_nrfx_configure(const struct device *dev)
 	return ret;
 }
 
-static inline nrfx_err_t read_non_aligned(const struct device *dev, int addr, void *dest,
+static inline int read_non_aligned(const struct device *dev, int addr, void *dest,
 					  size_t size)
 {
 	uint8_t __aligned(WORD_SIZE) buf[WORD_SIZE * 2];
@@ -833,7 +802,7 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev, int addr, vo
 		flash_suffix = size - flash_prefix - flash_middle;
 	}
 
-	nrfx_err_t res = NRFX_SUCCESS;
+	int res = 0;
 
 	/* read from aligned flash to aligned memory */
 	if (flash_middle != 0) {
@@ -841,7 +810,7 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev, int addr, vo
 
 		_qspi_wait_for_completion(dev, res);
 
-		if (res != NRFX_SUCCESS) {
+		if (res != 0) {
 			return res;
 		}
 
@@ -857,7 +826,7 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev, int addr, vo
 
 		_qspi_wait_for_completion(dev, res);
 
-		if (res != NRFX_SUCCESS) {
+		if (res != 0) {
 			return res;
 		}
 
@@ -870,7 +839,7 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev, int addr, vo
 
 		_qspi_wait_for_completion(dev, res);
 
-		if (res != NRFX_SUCCESS) {
+		if (res != 0) {
 			return res;
 		}
 
@@ -891,31 +860,28 @@ static int qspi_nor_read(const struct device *dev, int addr, void *dest, size_t 
 		return 0;
 	}
 
-	int rc = qspi_device_init(dev);
+	int ret = qspi_device_init(dev);
 
-	if (rc != 0) {
+	if (ret != 0) {
 		goto out;
 	}
 
 	qspi_lock(dev);
 
-	nrfx_err_t res = read_non_aligned(dev, addr, dest, size);
+	int ret = read_non_aligned(dev, addr, dest, size);
 
 	qspi_unlock(dev);
-
-	rc = qspi_get_zephyr_ret_code(res);
-
 out:
 	qspi_device_uninit(dev);
-	return rc;
+	return ret;
 }
 
 /* addr aligned, sptr not null, slen less than 4 */
-static inline nrfx_err_t write_sub_word(const struct device *dev, int addr, const void *sptr,
+static inline int write_sub_word(const struct device *dev, int addr, const void *sptr,
 					size_t slen)
 {
 	uint8_t __aligned(4) buf[4];
-	nrfx_err_t res;
+	int res;
 
 	/* read out the whole word so that unchanged data can be
 	 * written back
@@ -923,7 +889,7 @@ static inline nrfx_err_t write_sub_word(const struct device *dev, int addr, cons
 	res = _nrfx_qspi_read(buf, sizeof(buf), addr);
 	_qspi_wait_for_completion(dev, res);
 
-	if (res == NRFX_SUCCESS) {
+	if (res == 0) {
 		memcpy(buf, sptr, slen);
 		res = _nrfx_qspi_write(buf, sizeof(buf), addr);
 		_qspi_wait_for_completion(dev, res);
@@ -948,11 +914,9 @@ static int qspi_nor_write(const struct device *dev, int addr, const void *src, s
 		return -EINVAL;
 	}
 
-	nrfx_err_t res = NRFX_SUCCESS;
+	int res = qspi_device_init(dev);
 
-	int rc = qspi_device_init(dev);
-
-	if (rc != 0) {
+	if (res != 0) {
 		goto out;
 	}
 
@@ -970,11 +934,9 @@ static int qspi_nor_write(const struct device *dev, int addr, const void *src, s
 	qspi_unlock(dev);
 
 	qspi_trans_unlock(dev);
-
-	rc = qspi_get_zephyr_ret_code(res);
 out:
 	qspi_device_uninit(dev);
-	return rc;
+	return res;
 }
 
 /**
@@ -1460,7 +1422,7 @@ int qspi_enable_encryption(uint8_t *key)
 	memcpy(qspi_cfg->p_cfg.key, key, 16);
 
 	err = nrfx_qspi_dma_encrypt(&qspi_cfg->p_cfg);
-	if (err != NRFX_SUCCESS) {
+	if (err != 0) {
 		LOG_ERR("nrfx_qspi_dma_encrypt failed: %d", err);
 		return -EIO;
 	}

--- a/soc/nordic/common/nrf_sys_event.c
+++ b/soc/nordic/common/nrf_sys_event.c
@@ -76,20 +76,12 @@ int nrf_sys_event_release_global_constlat(void)
 
 int nrf_sys_event_request_global_constlat(void)
 {
-	nrfx_err_t err;
-
-	err = nrfx_power_constlat_mode_request();
-
-	return (err == NRFX_SUCCESS || err == NRFX_ERROR_ALREADY) ? 0 : -EAGAIN;
+	return nrfx_power_constlat_mode_request();
 }
 
 int nrf_sys_event_release_global_constlat(void)
 {
-	nrfx_err_t err;
-
-	err = nrfx_power_constlat_mode_free();
-
-	return (err == NRFX_SUCCESS || err == NRFX_ERROR_BUSY) ? 0 : -EAGAIN;
+	return nrfx_power_constlat_mode_free();
 }
 
 #endif


### PR DESCRIPTION
NRFX drivers now return errno codes instead of nrfx-specific error codes. Aligned drivers not covered by other PRs.