### PR TITLE
Bluetooth: SDP: Add helper functions to parse discovered record

### DIFF
--- a/include/zephyr/bluetooth/classic/sdp.h
+++ b/include/zephyr/bluetooth/classic/sdp.h
@@ -223,6 +223,44 @@ extern "C" {
 #define BT_SDP_ATTR_PROVNAME_PRIMARY (0x0002 + BT_SDP_PRIMARY_LANG_BASE)
 
 /**
+ * @name Protocol identifier codes
+ * @brief Protocol identifiers used in Bluetooth Service Discovery Protocol (SDP)
+ * @note Based on Bluetooth Assigned Numbers specification
+ *
+ * Possible values for protocol-id are listed below.
+ * See Assigned Numbers Spec, section "Protocol Identifiers" for more details.
+ *
+ * @{
+ */
+#define BT_SDP_PROTO_SDP           0x0001 /**< Service Discovery Protocol */
+#define BT_SDP_PROTO_UDP           0x0002 /**< User Datagram Protocol */
+#define BT_SDP_PROTO_RFCOMM        0x0003 /**< Radio Frequency Communication */
+#define BT_SDP_PROTO_TCP           0x0004 /**< Transmission Control Protocol */
+#define BT_SDP_PROTO_TCS_BIN       0x0005 /**< Telephony Control Specification Binary */
+#define BT_SDP_PROTO_TCS_AT        0x0006 /**< Telephony Control Specification AT */
+#define BT_SDP_PROTO_ATT           0x0007 /**< Attribute Protocol */
+#define BT_SDP_PROTO_OBEX          0x0008 /**< Object Exchange Protocol */
+#define BT_SDP_PROTO_IP            0x0009 /**< Internet Protocol */
+#define BT_SDP_PROTO_FTP           0x000a /**< File Transfer Protocol */
+#define BT_SDP_PROTO_HTTP          0x000c /**< HyperText Transfer Protocol */
+#define BT_SDP_PROTO_WSP           0x000e /**< Wireless Session Protocol */
+#define BT_SDP_PROTO_BNEP          0x000f /**< Bluetooth Network Encapsulation Protocol */
+#define BT_SDP_PROTO_UPNP          0x0010 /**< Universal Plug and Play */
+#define BT_SDP_PROTO_HID           0x0011 /**< Human Interface Device Protocol */
+#define BT_SDP_PROTO_HARDCOPY_CTRL 0x0012 /**< Hardcopy Control Channel */
+#define BT_SDP_PROTO_HARDCOPY_DATA 0x0014 /**< Hardcopy Data Channel */
+#define BT_SDP_PROTO_HARDCOPY_NTF  0x0016 /**< Hardcopy Notification Channel */
+#define BT_SDP_PROTO_AVCTP         0x0017 /**< Audio/Video Control Transport Protocol */
+#define BT_SDP_PROTO_AVDTP         0x0019 /**< Audio/Video Distribution Transport Protocol */
+#define BT_SDP_PROTO_CMTP          0x001b /**< Common ISDN Access Protocol */
+#define BT_SDP_PROTO_MCAP_CTRL     0x001e /**< Multi-Channel Adaptation Protocol Control */
+#define BT_SDP_PROTO_MCAP_DATA     0x001f /**< Multi-Channel Adaptation Protocol Data */
+#define BT_SDP_PROTO_L2CAP         0x0100 /**< Logical Link Control and Adaptation Protocol */
+/**
+ * @}
+ */
+
+/**
  * @name The Data representation in SDP PDUs (pps 339, 340 of BT SDP Spec)
  *
  * These are the exact data type+size descriptor values
@@ -669,13 +707,6 @@ int bt_sdp_discover_cancel(struct bt_conn *conn,
 
 /* Helper types & functions for SDP client to get essential data from server */
 
-/** @brief Protocols to be asked about specific parameters */
-enum bt_sdp_proto {
-	BT_SDP_PROTO_RFCOMM = 0x0003,
-	BT_SDP_PROTO_AVDTP  = 0x0019,
-	BT_SDP_PROTO_L2CAP  = 0x0100,
-};
-
 /** @brief Give to user parameter value related to given stacked protocol UUID.
  *
  *  API extracts specific parameter associated with given protocol UUID
@@ -688,7 +719,7 @@ enum bt_sdp_proto {
  *  @return 0 on success when specific parameter associated with given protocol
  *  value is found, or negative if error occurred during processing.
  */
-int bt_sdp_get_proto_param(const struct net_buf *buf, enum bt_sdp_proto proto,
+int bt_sdp_get_proto_param(const struct net_buf *buf, uint16_t proto,
 			   uint16_t *param);
 
 /** @brief Get additional parameter value related to given stacked protocol UUID.
@@ -707,8 +738,8 @@ int bt_sdp_get_proto_param(const struct net_buf *buf, enum bt_sdp_proto proto,
  *  @return 0 on success when a specific parameter associated with a given protocol
  *  value is found, or negative if error occurred during processing.
  */
-int bt_sdp_get_addl_proto_param(const struct net_buf *buf, enum bt_sdp_proto proto,
-			uint8_t param_index, uint16_t *param);
+int bt_sdp_get_addl_proto_param(const struct net_buf *buf, uint16_t proto,
+				uint8_t param_index, uint16_t *param);
 
 /** @brief Get profile version.
  *

--- a/include/zephyr/bluetooth/classic/sdp.h
+++ b/include/zephyr/bluetooth/classic/sdp.h
@@ -731,17 +731,15 @@ int bt_sdp_get_proto_param(const struct net_buf *buf, uint16_t proto,
  *
  *  @param buf Original buffered raw record data.
  *  @param proto Known protocol to be checked like RFCOMM or L2CAP.
- *  @param param_index There may be more than one parameter related to the
- *  given protocol UUID. This function returns the result that is
- *  indexed by this parameter. It's value is from 0, 0 means the
- *  first matched result, 1 means the second matched result.
+ *  @param index Zero-based index of the protocol descriptor (alternative protocol stack).
+ *               Use 0 for the first protocol descriptor, 1 for the second, etc.
  *  @param[out] param On success populated by found parameter value.
  *
  *  @return 0 on success when a specific parameter associated with a given protocol
  *  value is found, or negative if error occurred during processing.
  */
-int bt_sdp_get_addl_proto_param(const struct net_buf *buf, uint16_t proto,
-				uint8_t param_index, uint16_t *param);
+int bt_sdp_get_addl_proto_param(const struct net_buf *buf, uint16_t proto, uint8_t index,
+				uint16_t *param);
 
 /** @brief Get profile version.
  *

--- a/include/zephyr/bluetooth/classic/sdp.h
+++ b/include/zephyr/bluetooth/classic/sdp.h
@@ -18,6 +18,8 @@
  * @{
  */
 
+#include <sys/types.h>
+
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/conn.h>
 
@@ -794,6 +796,268 @@ int bt_sdp_get_vendor_id(const struct net_buf *buf, uint16_t *vendor_id);
  *  @return 0 on success if product_id found and valid, negative in case any error
  */
 int bt_sdp_get_product_id(const struct net_buf *buf, uint16_t *product_id);
+
+/** @brief Iterate through discovered SDP record
+ *
+ *  Helper API iterating through the discovered SDP record. It parses the specified SDP RAW record
+ *  data in the provided buffer and calls the specified callback function for each attribute found.
+ *  The iteration continues until all attributes have been processed or the callback function
+ *  returns false to stop the iteration.
+ *
+ *  @param buf Buffer holding original discovered raw SDP record data from remote.
+ *  @param func Callback function to be called for each attribute.
+ *              The callback receives a pointer to the current attribute and user-provided data.
+ *              Return the `true` to continue iteration, `false` to stop.
+ *  @param user_data Optional user-provided context data passed to the callback function.
+ *
+ *  @return 0 on success, negative value on error during the parsing or iteration.
+ */
+int bt_sdp_record_parse(const struct net_buf *buf,
+			bool (*func)(const struct bt_sdp_attribute *attr, void *user_data),
+			void *user_data);
+
+/** @brief check if the specific attribute identifier is found.
+ *
+ *  API checks if the specific attribute identifier is found.
+ *
+ *  @param buf Buffer containing the discovered SDP record data to be parsed.
+ *  @param attr_id Specific attribute identifier.
+ *
+ *  @return true if attribute identifier is found, false otherwise.
+ */
+bool bt_sdp_has_attr(const struct net_buf *buf, uint16_t attr_id);
+
+/** @brief Get a specific attribute by ID from SDP record
+ *
+ *  This function retrieves a specific attribute from the SDP record data by searching for the
+ *  given attribute identifier.
+ *
+ *  @param buf Buffer containing the discovered SDP record data to be parsed.
+ *  @param attr_id The specific attribute identifier to search for.
+ *  @param[out] attr Pointer to bt_sdp_attribute structure to store the found attribute.
+ *
+ *  @return 0 on success when the attribute is found and populated,
+ *          negative value if the attribute is not found or an error occurred.
+ */
+int bt_sdp_get_attr(const struct net_buf *buf, uint16_t attr_id, struct bt_sdp_attribute *attr);
+
+/** @brief SDP attribute value for unsigned integer types
+ *
+ *  Structure to hold parsed unsigned integer values from SDP attributes.
+ *  The size field indicates the actual size of the integer value.
+ */
+struct bt_sdp_attr_value_uint {
+	/** Size of the unsigned integer value in bytes */
+	uint8_t size;
+	/** Union containing the unsigned integer value based on size */
+	union {
+		uint8_t u8;   /**< 8-bit unsigned integer value */
+		uint16_t u16; /**< 16-bit unsigned integer value */
+		uint32_t u32; /**< 32-bit unsigned integer value */
+		uint64_t u64; /**< 64-bit unsigned integer value */
+		/** 128-bit unsigned integer value as byte array */
+		uint8_t u128[BIT(BT_SDP_UINT128 & BT_SDP_SIZE_DESC_MASK)];
+	};
+};
+
+/** @brief SDP attribute value for signed integer types
+ *
+ *  Structure to hold parsed signed integer values from SDP attributes.
+ *  The size field indicates the actual size of the integer value.
+ */
+struct bt_sdp_attr_value_int {
+	/** Size of the signed integer value in bytes */
+	uint8_t size;
+	/** Union containing the signed integer value based on size */
+	union {
+		int8_t s8;   /**< 8-bit signed integer value */
+		int16_t s16; /**< 16-bit signed integer value */
+		int32_t s32; /**< 32-bit signed integer value */
+		int64_t s64; /**< 64-bit signed integer value */
+		/** 128-bit signed integer value as byte array */
+		uint8_t s128[BIT(BT_SDP_INT128 & BT_SDP_SIZE_DESC_MASK)];
+	};
+};
+
+/** @brief SDP attribute value for text string types
+ *
+ *  Structure to hold parsed text string values from SDP attributes.
+ */
+struct bt_sdp_attr_value_text {
+	/** Length of the text string in bytes */
+	uint32_t len;
+	/** Pointer to the text string data */
+	uint8_t *text;
+};
+
+/** @brief SDP attribute value for URL string types
+ *
+ *  Structure to hold parsed URL string values from SDP attributes.
+ */
+struct bt_sdp_attr_value_url {
+	/** Length of the URL string in bytes */
+	uint32_t len;
+	/** Pointer to the URL string data */
+	uint8_t *url;
+};
+
+/** @brief SDP attribute value type enumeration
+ *
+ *  Enumeration defining the different types of attribute values
+ *  that can be parsed from SDP attributes.
+ */
+enum bt_sdp_attr_value_type {
+	BT_SDP_ATTR_VALUE_TYPE_NONE = 0, /**< No value */
+	BT_SDP_ATTR_VALUE_TYPE_UINT,     /**< Unsigned integer */
+	BT_SDP_ATTR_VALUE_TYPE_SINT,     /**< Signed integer  */
+	BT_SDP_ATTR_VALUE_TYPE_BOOL,     /**< Boolean */
+	BT_SDP_ATTR_VALUE_TYPE_TEXT,     /**< Text string */
+	BT_SDP_ATTR_VALUE_TYPE_URL,      /**< URL string */
+};
+
+/** @brief SDP attribute value container structure
+ *
+ *  Structure that holds a parsed attribute value of any supported type.
+ *  The type field indicates which member of the union contains the actual value.
+ *  This structure provides a unified way to handle different types of SDP
+ *  attribute values after parsing.
+ */
+struct bt_sdp_attr_value {
+	/** Type of the attribute value */
+	enum bt_sdp_attr_value_type type;
+	/** Union containing the actual attribute value based on type */
+	union {
+		/**< Boolean value (when type is BT_SDP_ATTR_VALUE_TYPE_BOOL) */
+		bool value;
+		/**< Unsigned integer value (when type is BT_SDP_ATTR_VALUE_TYPE_UINT) */
+		struct bt_sdp_attr_value_uint uint;
+		/**< Signed integer value (when type is BT_SDP_ATTR_VALUE_TYPE_SINT) */
+		struct bt_sdp_attr_value_int sint;
+		/**< Text string value (when type is BT_SDP_ATTR_VALUE_TYPE_TEXT) */
+		struct bt_sdp_attr_value_text text;
+		/**< URL string value (when type is BT_SDP_ATTR_VALUE_TYPE_URL) */
+		struct bt_sdp_attr_value_url url;
+	};
+};
+
+/** @brief SDP attribute value pair structure
+ *
+ *  Structure containing parsed attribute value information including the UUID identifier and the
+ *  actual value with its type. This structure is used to associate a UUID with its corresponding
+ *  attribute value, providing a complete representation of a parsed SDP attribute element.
+ *
+ *  @note The UUID and value pointers will be invalid if the callback function returned.
+ *
+ *  @note The UUID or value pointer may be NULL. If the UUID is NULL, it means the value does not
+ *        belong to any UUID. If the value is NULL, it means UUID has not value.
+ */
+struct bt_sdp_attr_value_pair {
+	/** UUID identifier for the attribute */
+	struct bt_uuid *uuid;
+	/** Pointer to the parsed attribute value */
+	struct bt_sdp_attr_value *value;
+};
+
+/** @brief Parse SDP attribute values
+ *
+ *  Parses the SDP attribute and calls the provided callback function for each parsed value found
+ *  within the attribute. This function handles complex attribute structures that may contain
+ *  multiple values.
+ *
+ *  @param attr Pointer to the SDP attribute to be parsed.
+ *  @param func Callback function to be called for each parsed value.
+ *              The callback receives a bt_sdp_attr_value_pair structure
+ *              containing the parsed value and user data.
+ *              Return true to continue parsing, false to stop.
+ *  @param user_data Optional user-provided context data passed to the callback.
+ *
+ *  @return 0 on success, negative value if an error occurred during parsing.
+ */
+int bt_sdp_attr_value_parse(const struct bt_sdp_attribute *attr,
+			    bool (*func)(const struct bt_sdp_attr_value_pair *value,
+					 void *user_data),
+			    void *user_data);
+
+/** @brief Check if SDP attribute contains a specific UUID
+ *
+ *  This function checks whether the specified SDP attribute contains the given UUID. This is
+ *  useful for verifying if an attribute references a particular service or protocol UUID.
+ *
+ *  @param attr Pointer to the SDP attribute to be checked.
+ *  @param uuid Pointer to the UUID to search for within the attribute.
+ *
+ *  @return true if the attribute contains the specified UUID, false otherwise.
+ */
+bool bt_sdp_attr_has_uuid(const struct bt_sdp_attribute *attr, const struct bt_uuid *uuid);
+
+/** @brief Read SDP attribute value for a specific UUID
+ *
+ *  This function reads and extracts the attribute value associated with the specified UUID
+ *  from the given SDP attribute. The parsed value is stored in the provided bt_sdp_attr_value
+ *  structure.
+ *
+ *  @param attr Pointer to the SDP attribute to read from.
+ *  @param uuid Pointer to the UUID identifier for the value to be read.
+ *  @param[out] value Pointer to bt_sdp_attr_value structure to store the extracted attribute value.
+ *
+ *  @return 0 on success when the value is found and extracted, negative value if the UUID is not
+ *          found or an error occurred.
+ */
+int bt_sdp_attr_read(const struct bt_sdp_attribute *attr, const struct bt_uuid *uuid,
+		     struct bt_sdp_attr_value *value);
+
+/** @brief Parse Additional Protocol Descriptor List attribute
+ *
+ *  This function parses the Additional Protocol Descriptor List attribute and calls the provided
+ *  callback function for each protocol descriptor found within the attribute. The Additional
+ *  Protocol Descriptor List contains alternative protocol stacks that can be used to access
+ *  the service.
+ *
+ *  @param attr Pointer to the SDP attribute containing Additional Protocol Descriptor List.
+ *  @param func Callback function to be called for each protocol descriptor.
+ *              The callback receives a pointer to the protocol descriptor attribute
+ *              and user-provided data. Return true to continue parsing, false to stop.
+ *  @param user_data Optional user-provided context data passed to the callback function.
+ *
+ *  @return 0 on success, negative value if an error occurred during parsing.
+ */
+int bt_sdp_attr_addl_proto_parse(const struct bt_sdp_attribute *attr,
+				 bool (*func)(const struct bt_sdp_attribute *attr, void *user_data),
+				 void *user_data);
+
+/** @brief Get count of protocol descriptors in Additional Protocol Descriptor List
+ *
+ *  This function returns the number of protocol descriptors contained in the
+ *  Additional Protocol Descriptor List attribute. This is useful for determining
+ *  how many alternative protocol stacks are available for the service.
+ *
+ *  @param attr Pointer to the SDP attribute containing Additional Protocol Descriptor List.
+ *
+ *  @return Number of protocol descriptors found on success, negative value if an error
+ *          occurred during parsing.
+ */
+ssize_t bt_sdp_attr_addl_proto_count(const struct bt_sdp_attribute *attr);
+
+/** @brief Read value from Additional Protocol Descriptor List for specific index and UUID
+ *
+ *  This function searches the Additional Protocol Descriptor List attribute for a specific
+ *  protocol UUID at the given protocol descriptor index and extracts its associated parameter
+ *  value. The index parameter specifies which protocol descriptor (alternative protocol stack)
+ *  to search within, and the UUID identifies the specific protocol within that descriptor.
+ *
+ *  @param attr Pointer to the SDP attribute containing Additional Protocol Descriptor List.
+ *  @param index Zero-based index of the protocol descriptor (alternative protocol stack).
+ *               Use 0 for the first protocol descriptor, 1 for the second, etc.
+ *  @param uuid Pointer to the UUID identifier of the protocol to search for within
+ *              the specified protocol descriptor.
+ *  @param[out] value Pointer to bt_sdp_attr_value structure to store the extracted parameter value.
+ *
+ *  @return 0 on success when the protocol and its parameter are found and extracted,
+ *          negative value if the protocol descriptor index is invalid, the UUID is not
+ *          found within the specified descriptor, or an error occurred during parsing.
+ */
+int bt_sdp_attr_addl_proto_read(const struct bt_sdp_attribute *attr, uint16_t index,
+				const struct bt_uuid *uuid, struct bt_sdp_attr_value *value);
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -3445,7 +3445,7 @@ static int sdp_get_u16_data(const struct bt_sdp_attr_item *attr, uint16_t *u16)
 	return 0;
 }
 
-int bt_sdp_get_proto_param(const struct net_buf *buf, enum bt_sdp_proto proto,
+int bt_sdp_get_proto_param(const struct net_buf *buf, uint16_t proto,
 			   uint16_t *param)
 {
 	struct bt_sdp_attr_item attr;
@@ -3473,7 +3473,7 @@ int bt_sdp_get_proto_param(const struct net_buf *buf, enum bt_sdp_proto proto,
 	return sdp_get_param_item(&pd, param);
 }
 
-int bt_sdp_get_addl_proto_param(const struct net_buf *buf, enum bt_sdp_proto proto,
+int bt_sdp_get_addl_proto_param(const struct net_buf *buf, uint16_t proto,
 				uint8_t param_index, uint16_t *param)
 {
 	struct bt_sdp_attr_item attr;

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -837,6 +837,205 @@ static int cmd_oob(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+static void sdp_attr_value_print_uint(struct bt_sdp_attr_value *value)
+{
+	switch (value->uint.size) {
+	case sizeof(uint8_t):
+		bt_shell_print("\tATTR value (8-bit): %x", value->uint.u8);
+		break;
+	case sizeof(uint16_t):
+		bt_shell_print("\tATTR value (16-bit): %x", value->uint.u16);
+		break;
+	case sizeof(uint32_t):
+		bt_shell_print("\tATTR value (32-bit): %x", value->uint.u32);
+		break;
+	case sizeof(uint64_t):
+		bt_shell_print("\tATTR value (64-bit): %llx", value->uint.u64);
+		break;
+	case sizeof(value->uint.u128):
+		bt_shell_print("\tATTR value (128-bit):");
+		bt_shell_hexdump(value->uint.u128, sizeof(value->uint.u128));
+		break;
+	default:
+		bt_shell_error("\tInvalid size");
+		break;
+	}
+}
+
+static void sdp_attr_value_print_sint(struct bt_sdp_attr_value *value)
+{
+	switch (value->sint.size) {
+	case sizeof(int8_t):
+		bt_shell_print("\tATTR value (8-bit): %x", value->sint.s8);
+		break;
+	case sizeof(int16_t):
+		bt_shell_print("\tATTR value (16-bit): %x", value->sint.s16);
+		break;
+	case sizeof(int32_t):
+		bt_shell_print("\tATTR value (32-bit): %x", value->sint.s32);
+		break;
+	case sizeof(int64_t):
+		bt_shell_print("\tATTR value (64-bit): %llx", value->sint.s64);
+		break;
+	case sizeof(value->sint.s128):
+		bt_shell_print("\tATTR value (128-bit):");
+		bt_shell_hexdump(value->sint.s128, sizeof(value->sint.s128));
+		break;
+	default:
+		bt_shell_error("\tInvalid size");
+		break;
+	}
+}
+
+static void sdp_attr_value_print(struct bt_sdp_attr_value *value)
+{
+	switch (value->type) {
+	case BT_SDP_ATTR_VALUE_TYPE_NONE:
+		bt_shell_print("\tATTR has not value");
+		break;
+	case BT_SDP_ATTR_VALUE_TYPE_UINT:
+		sdp_attr_value_print_uint(value);
+		break;
+	case BT_SDP_ATTR_VALUE_TYPE_SINT:
+		sdp_attr_value_print_sint(value);
+		break;
+	case BT_SDP_ATTR_VALUE_TYPE_BOOL:
+		bt_shell_print("\tATTR value (bool): %s", value->value ? "true" : "false");
+		break;
+	case BT_SDP_ATTR_VALUE_TYPE_TEXT:
+		bt_shell_print("\tATTR value (TEXT):");
+		bt_shell_hexdump(value->text.text, value->text.len);
+		break;
+	case BT_SDP_ATTR_VALUE_TYPE_URL:
+		bt_shell_hexdump(value->url.url, value->url.len);
+		break;
+	default:
+		bt_shell_error("\tUnknown type %u", value->type);
+		break;
+	}
+}
+
+static bool sdp_attr_parse_cb(const struct bt_sdp_attr_value_pair *value, void *user_data)
+{
+	char str[BT_UUID_STR_LEN];
+
+	if (value == NULL) {
+		return true;
+	}
+
+	if (value->uuid != NULL) {
+		bt_uuid_to_str(value->uuid, str, sizeof(str));
+		bt_shell_print("\tATTR UUID %s found", str);
+	}
+
+	if (value->value != NULL) {
+		sdp_attr_value_print(value->value);
+	}
+
+	return true;
+}
+
+static bool sdp_record_parse_cb(const struct bt_sdp_attribute *attr, void *user_data)
+{
+	struct bt_sdp_attr_value value;
+	int err;
+
+	if (bt_sdp_attr_has_uuid(attr, BT_UUID_DECLARE_16(BT_SDP_PROTO_L2CAP))) {
+		err = bt_sdp_attr_read(attr, BT_UUID_DECLARE_16(BT_SDP_PROTO_L2CAP), &value);
+		if (err == 0) {
+			bt_shell_print("ATTR UUID %04x read:", BT_SDP_PROTO_L2CAP);
+			sdp_attr_value_print(&value);
+		}
+	}
+
+	bt_shell_print("ATTR ID %04x:", attr->id);
+
+	err = bt_sdp_attr_value_parse(attr, sdp_attr_parse_cb, NULL);
+	if (err != 0) {
+		bt_shell_error("Failed to parse SDP attribute: %d", err);
+	}
+
+	return true;
+}
+
+static uint8_t sdp_discover_general(struct bt_conn *conn, struct bt_sdp_client_result *result,
+				    const struct bt_sdp_discover_params *params)
+{
+	int err;
+	struct bt_sdp_attribute attr;
+	struct bt_sdp_attr_value value;
+
+	if ((result == NULL) || (result->resp_buf == NULL)) {
+		return BT_SDP_DISCOVER_UUID_CONTINUE;
+	}
+
+	if (bt_sdp_has_attr(result->resp_buf, BT_SDP_ATTR_PROTO_DESC_LIST)) {
+		bt_shell_print("ATTR ID %04x found", BT_SDP_ATTR_PROTO_DESC_LIST);
+
+		err = bt_sdp_get_attr(result->resp_buf, BT_SDP_ATTR_PROTO_DESC_LIST, &attr);
+		if (err < 0) {
+			bt_shell_error("\tFailed to get ATTR");
+			goto get_addl_proto;
+		}
+
+		bt_shell_print("ATTR UUID %04x read:", BT_SDP_PROTO_L2CAP);
+
+		err = bt_sdp_attr_read(&attr, BT_UUID_DECLARE_16(BT_SDP_PROTO_L2CAP), &value);
+		if (err < 0) {
+			bt_shell_print("\tNo ATTR Value");
+			goto get_addl_proto;
+		}
+
+		sdp_attr_value_print(&value);
+	} else {
+		bt_shell_print("ATTR ID %04x not found", BT_SDP_ATTR_PROTO_DESC_LIST);
+	}
+
+get_addl_proto:
+	if (bt_sdp_has_attr(result->resp_buf, BT_SDP_ATTR_ADD_PROTO_DESC_LIST)) {
+		ssize_t count;
+
+		bt_shell_print("ATTR ID %04x found", BT_SDP_ATTR_ADD_PROTO_DESC_LIST);
+
+		err = bt_sdp_get_attr(result->resp_buf, BT_SDP_ATTR_ADD_PROTO_DESC_LIST, &attr);
+		if (err < 0) {
+			bt_shell_error("\tFailed to get ATTR");
+			goto parse_record;
+		}
+
+		count = bt_sdp_attr_addl_proto_count(&attr);
+		if (count < 0) {
+			bt_shell_print("\tNo protocol descriptors found");
+			goto parse_record;
+		} else {
+			bt_shell_print("\tProtocol descriptors count %d", count);
+		}
+
+		for (uint16_t index = 0; index < count; index++) {
+			bt_shell_print("ATTR UUID %04x[%d] read:", BT_SDP_PROTO_L2CAP, index);
+			err = bt_sdp_attr_addl_proto_read(&attr, index,
+							  BT_UUID_DECLARE_16(BT_SDP_PROTO_L2CAP),
+							  &value);
+			if (err < 0) {
+				bt_shell_print("\tNo ATTR Value");
+				goto parse_record;
+			}
+
+			sdp_attr_value_print(&value);
+		}
+	} else {
+		bt_shell_print("ATTR ID %04x not found", BT_SDP_ATTR_ADD_PROTO_DESC_LIST);
+	}
+
+parse_record:
+	err = bt_sdp_record_parse(result->resp_buf, sdp_record_parse_cb, NULL);
+	if (err != 0) {
+		bt_shell_error("Failed to parse record %d", err);
+	}
+
+	return BT_SDP_DISCOVER_UUID_CONTINUE;
+}
+
 static uint8_t sdp_hfp_ag_user(struct bt_conn *conn, struct bt_sdp_client_result *result,
 			       const struct bt_sdp_discover_params *params)
 {
@@ -1148,6 +1347,13 @@ done:
 	return BT_SDP_DISCOVER_UUID_CONTINUE;
 }
 
+static struct bt_sdp_discover_params discov_general = {
+	.type = BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR,
+	.uuid = BT_UUID_DECLARE_16(BT_SDP_PROTO_L2CAP),
+	.func = sdp_discover_general,
+	.pool = &sdp_client_pool,
+};
+
 static struct bt_sdp_discover_params discov_hfpag = {
 	.type = BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR,
 	.uuid = BT_UUID_DECLARE_16(BT_SDP_HANDSFREE_AGW_SVCLASS),
@@ -1209,6 +1415,12 @@ static int cmd_sdp_find_record(const struct shell *sh, size_t argc, char *argv[]
 		return -ENOEXEC;
 	}
 
+	if (argc == 1) {
+		discov = discov_general;
+		action = "l2cap";
+		goto discover;
+	}
+
 	action = argv[1];
 
 	if (!strcmp(action, "HFPAG")) {
@@ -1230,6 +1442,7 @@ static int cmd_sdp_find_record(const struct shell *sh, size_t argc, char *argv[]
 		return SHELL_CMD_HELP_PRINTED;
 	}
 
+discover:
 	shell_print(sh, "SDP UUID \'%s\' gets applied", action);
 
 	err = bt_sdp_discover(default_conn, &discov);
@@ -1634,8 +1847,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(br_cmds,
 	SHELL_CMD(l2cap, &l2cap_cmds, HELP_NONE, cmd_default_handler),
 	SHELL_CMD_ARG(oob, NULL, NULL, cmd_oob, 1, 0),
 	SHELL_CMD_ARG(pscan, NULL, "<value: on, off>", cmd_connectable, 2, 0),
-	SHELL_CMD_ARG(sdp-find, NULL, "<HFPAG, HFPHF, A2SRC, A2SNK, PNP, AVRCP_CT, AVRCP_TG>",
-		      cmd_sdp_find_record, 2, 0),
+	SHELL_CMD_ARG(sdp-find, NULL, "[HFPAG, HFPHF, A2SRC, A2SNK, PNP, AVRCP_CT, AVRCP_TG]",
+		      cmd_sdp_find_record, 1, 1),
 	SHELL_CMD_ARG(switch-role, NULL, "<value: central, peripheral>", cmd_switch_role, 2, 0),
 	SHELL_CMD_ARG(set-role-switchable, NULL, "<value: enable, disable>",
 		      cmd_set_role_switchable, 2, 0),


### PR DESCRIPTION
The current implementation does not support multiple attributes with the same attribute identifier in a discovered SDP record.

Add function `bt_sdp_record_parse()` to parse the received SDP record.

Add function `bt_sdp_has_attr()` to check if the specified attribute identifier has been discovered.

Add function `bt_sdp_get_attr()` to get the attribute of specified attribute identifier.

Add function `bt_sdp_attr_value_parse()` to parse the attribute value.

Add function `bt_sdp_attr_has_uuid()` to check if the attribute contains the specified UUID.

Add function `bt_sdp_attr_read()` to read the value of the attribute.

Add function `bt_sdp_attr_addl_proto_parse()` to parse the protocol descriptor from the additional protocol descriptor list.

Add function `bt_sdp_attr_addl_proto_count()` to get the protocol descriptor count of the additional protocol descriptor list.

Add function `bt_sdp_attr_addl_proto_read()` to read the attribute value from the additional protocol descriptor list for specific index and UUID.

