### PR TITLE
net: sockets: tls: Remove leftover todo comment

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1552,7 +1552,6 @@ static int tls_check_psk(struct tls_credential *psk)
 #endif
 }
 
-/* TODO add decent logs */
 static int tls_check_credentials(const sec_tag_t *sec_tags, int sec_tag_count)
 {
 	int err = 0;


### PR DESCRIPTION
Follow-up to https://github.com/zephyrproject-rtos/zephyr/pull/97630. Logs were added, but the todo comment about this was overlooked, remove it.