### PR TITLE
doc: samples: drivers: clock_control: fix dts include

### DIFF
--- a/samples/drivers/clock_control_litex/README.rst
+++ b/samples/drivers/clock_control_litex/README.rst
@@ -20,19 +20,19 @@ Configuration
 *************
 Basic configuration of the driver, including default settings for clock outputs, is held in Device Tree clock control nodes.
 
-.. literalinclude:: ../../../dts/riscv/riscv32-litex-vexriscv.dtsi
+.. literalinclude:: ../../../boards/enjoydigital/litex_vexriscv/litex_vexriscv.dts
    :language: dts
    :start-at: clk0: clock-controller@0 {
    :end-at: };
    :dedent:
 
-.. literalinclude:: ../../../dts/riscv/riscv32-litex-vexriscv.dtsi
+.. literalinclude:: ../../../boards/enjoydigital/litex_vexriscv/litex_vexriscv.dts
    :language: dts
    :start-at: clk1: clock-controller@1 {
    :end-at: };
    :dedent:
 
-.. literalinclude:: ../../../dts/riscv/riscv32-litex-vexriscv.dtsi
+.. literalinclude:: ../../../boards/enjoydigital/litex_vexriscv/litex_vexriscv.dts
    :language: dts
    :start-at: clock0: clock@e0004800 {
    :end-at: };


### PR DESCRIPTION
fix dts include for doc
Forgotten in https://github.com/zephyrproject-rtos/zephyr/pull/97444

broke it here: https://github.com/zephyrproject-rtos/zephyr/actions/runs/18687482762/job/53284072939