### PR TITLE
drivers: stepper: adi_tmc: refactor common headers

### DIFF
--- a/drivers/stepper/adi_tmc/CMakeLists.txt
+++ b/drivers/stepper/adi_tmc/CMakeLists.txt
@@ -9,3 +9,4 @@ zephyr_library_sources_ifdef(CONFIG_STEPPER_ADI_TMC50XX tmc50xx.c)
 add_subdirectory_ifdef(CONFIG_STEPPER_ADI_TMC51XX tmc51xx)
 
 add_subdirectory(bus)
+add_subdirectory(common)

--- a/drivers/stepper/adi_tmc/common/CMakeLists.txt
+++ b/drivers/stepper/adi_tmc/common/CMakeLists.txt
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Jilay Sandeep Pandya
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_include_directories(include)

--- a/drivers/stepper/adi_tmc/common/include/adi_tmc5xxx_common.h
+++ b/drivers/stepper/adi_tmc/common/include/adi_tmc5xxx_common.h
@@ -9,10 +9,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_DRIVERS_STEPPER_ADI_TMC_ADI_TMC5XXX_COMMON_H_
-#define ZEPHYR_DRIVERS_STEPPER_ADI_TMC_ADI_TMC5XXX_COMMON_H_
+#ifndef ZEPHYR_DRIVERS_STEPPER_ADI_TMC_COMMON_ADI_TMC5XXX_COMMON_H_
+#define ZEPHYR_DRIVERS_STEPPER_ADI_TMC_COMMON_ADI_TMC5XXX_COMMON_H_
 
-#include "adi_tmc_reg.h"
+#include <adi_tmc_reg.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,4 +48,4 @@ static inline uint32_t tmc5xxx_calculate_velocity_from_hz_to_fclk(uint64_t veloc
 }
 #endif
 
-#endif /* ZEPHYR_DRIVERS_STEPPER_ADI_TMC_ADI_TMC5XXX_COMMON_H_ */
+#endif /* ZEPHYR_DRIVERS_STEPPER_ADI_TMC_COMMON_ADI_TMC5XXX_COMMON_H_ */

--- a/drivers/stepper/adi_tmc/common/include/adi_tmc_reg.h
+++ b/drivers/stepper/adi_tmc/common/include/adi_tmc_reg.h
@@ -11,8 +11,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_DRIVERS_STEPPER_ADI_TMC_REG_H_
-#define ZEPHYR_DRIVERS_STEPPER_ADI_TMC_REG_H_
+#ifndef ZEPHYR_DRIVERS_STEPPER_ADI_TMC_COMMON_ADI_TMC_REG_H_
+#define ZEPHYR_DRIVERS_STEPPER_ADI_TMC_COMMON_ADI_TMC_REG_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -192,4 +192,4 @@ extern "C" {
 }
 #endif
 
-#endif /* ZEPHYR_DRIVERS_STEPPER_ADI_TMC_REG_H_ */
+#endif /* ZEPHYR_DRIVERS_STEPPER_ADI_TMC_COMMON_ADI_TMC_REG_H_ */

--- a/drivers/stepper/adi_tmc/tmc50xx.c
+++ b/drivers/stepper/adi_tmc/tmc50xx.c
@@ -12,7 +12,7 @@
 #include <zephyr/drivers/stepper/stepper_trinamic.h>
 
 #include <adi_tmc_spi.h>
-#include "adi_tmc5xxx_common.h"
+#include <adi_tmc5xxx_common.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(tmc50xx, CONFIG_STEPPER_LOG_LEVEL);

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
@@ -9,8 +9,8 @@
 #include <zephyr/drivers/stepper.h>
 
 #include <adi_tmc_bus.h>
+#include <adi_tmc5xxx_common.h>
 #include "tmc51xx.h"
-#include "../adi_tmc5xxx_common.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(tmc51xx, CONFIG_STEPPER_LOG_LEVEL);

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx_spi.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx_spi.c
@@ -8,9 +8,9 @@
 
 #include <adi_tmc_bus.h>
 #include <adi_tmc_spi.h>
+#include <adi_tmc_reg.h>
 
 #include "tmc51xx.h"
-#include "../adi_tmc_reg.h"
 
 #if TMC51XX_BUS_SPI
 LOG_MODULE_DECLARE(tmc51xx, CONFIG_STEPPER_LOG_LEVEL);


### PR DESCRIPTION
currently adi_tmc5xxx_common.h and adi_tmc_reg.h are placed directly in the adi_tmc folder, hence the drivers have to include these headers using relative paths.
 
However placing them in a common include folder and adding it to the include directories results in the drivers not having to include these headers using relative paths.