### PR TITLE
twister: fix environment:os tag

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -12,6 +12,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from platform import system as platform_system
 
 from colorama import Fore
 from twisterlib.statuses import TwisterStatus
@@ -302,7 +303,7 @@ class Reporting:
             report_options = self.env.non_default_options()
 
         report = {}
-        report["environment"] = {"os": os.name,
+        report["environment"] = {"os": platform_system(),
                                  "zephyr_version": version,
                                  "toolchain": self.env.toolchain,
                                  "commit_date": self.env.commit_date,


### PR DESCRIPTION
Set the environment:os tag to the return value of platform.system(), which is more useful than os.name() which always returns "posix".