### PR TITLE
shell: avoid immediate logging to a shell that might not be setup

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -277,7 +277,7 @@ config SHELL_CMD_ROOT
 
 config SHELL_LOG_BACKEND
 	bool "Shell log backend"
-	depends on LOG && !LOG_MODE_MINIMAL
+	depends on LOG && !LOG_MODE_MINIMAL && !LOG_MODE_IMMEDIATE
 	select MPSC_PBUF
 	select LOG_OUTPUT
 	default y if LOG


### PR DESCRIPTION
During a boot process bringup an MPU error was triggered because the log process was being called before the shell was initialized which should be avoided by a configuration guard. It seems that using log immediate intends to bypass the shell to just use a backend that is raw - ie. console, serial, etc.

So, just add the configuration guard in addition to the minimal mode