### PR TITLE
Bluetooth: Controller: Fix use-after-release in lll_scan/lll_scan_aux

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -17,6 +17,14 @@ struct lll_scan {
 	uint8_t  adv_addr[BDADDR_SIZE];
 	uint32_t conn_win_offset_us;
 	uint16_t conn_timeout;
+
+#if defined(CONFIG_BT_CTLR_SCHED_ADVANCED)
+	/* Stores prepare parameters for deferred mayfly execution.
+	 * This prevents use-after-release issues by ensuring the parameters
+	 * remain valid until execution.
+	 */
+	struct lll_prepare_param prepare_param;
+#endif /* CONFIG_BT_CTLR_SCHED_ADVANCED */
 #endif /* CONFIG_BT_CENTRAL */
 
 	uint8_t  state:1;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -509,13 +509,19 @@ static int common_prepare_cb(struct lll_prepare_param *p, bool is_resume)
 		static memq_link_t link;
 		static struct mayfly mfy_after_cen_offset_get = {
 			0U, 0U, &link, NULL, ull_sched_mfy_after_cen_offset_get};
-		uint32_t retval;
+		struct lll_prepare_param *prepare_param;
 
-		mfy_after_cen_offset_get.param = p;
+		/* Copy the required values to calculate the offsets */
+		prepare_param = &lll->prepare_param;
+		prepare_param->ticks_at_expire = p->ticks_at_expire;
+		prepare_param->remainder = p->remainder;
+		prepare_param->param = lll;
 
-		retval = mayfly_enqueue(TICKER_USER_ID_LLL, TICKER_USER_ID_ULL_LOW, 1U,
-					&mfy_after_cen_offset_get);
-		LL_ASSERT_ERR(!retval);
+		mfy_after_cen_offset_get.param = prepare_param;
+
+		ret = mayfly_enqueue(TICKER_USER_ID_LLL, TICKER_USER_ID_ULL_LOW, 1U,
+				     &mfy_after_cen_offset_get);
+		LL_ASSERT_ERR(!ret);
 	}
 #endif /* CONFIG_BT_CENTRAL && CONFIG_BT_CTLR_SCHED_ADVANCED */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -607,12 +607,19 @@ sync_aux_prepare_done:
 		static memq_link_t link;
 		static struct mayfly mfy_after_cen_offset_get = {
 			0U, 0U, &link, NULL, ull_sched_mfy_after_cen_offset_get};
+		struct lll_prepare_param *prepare_param;
 
-		/* NOTE: LLL scan instance passed, as done when
+		/* Copy the required values to calculate the offsets
+		 *
+		 * NOTE: LLL scan instance passed, as done when
 		 *       establishing legacy connections.
 		 */
-		p->param = lll;
-		mfy_after_cen_offset_get.param = p;
+		prepare_param = &lll->prepare_param;
+		prepare_param->ticks_at_expire = p->ticks_at_expire;
+		prepare_param->remainder = p->remainder;
+		prepare_param->param = lll;
+
+		mfy_after_cen_offset_get.param = prepare_param;
 
 		ret = mayfly_enqueue(TICKER_USER_ID_LLL, TICKER_USER_ID_ULL_LOW, 1U,
 				     &mfy_after_cen_offset_get);


### PR DESCRIPTION
Fix use-after-release in lll_scan/lll_scan_aux when using mayfly_enqueue to defer execution of the offset calculation using ull_sched_mfy_after_cen_offset_get().

Fixes #97967.