### PR TITLE
tests: Fix warning found with arcmwdt toolchain

### DIFF
--- a/tests/lib/notify/src/main.c
+++ b/tests/lib/notify/src/main.c
@@ -223,7 +223,7 @@ ZTEST(sys_notify_api, test_callback)
 		      "flags not cleared");
 
 	res = ~set_res;
-	((sys_notify_generic_callback)cb)(&notify, &res);
+	((void (*)(struct sys_notify *, int *))cb)(&notify, &res);
 	zassert_equal(res, set_res,
 		      "result not set");
 }


### PR DESCRIPTION
In the lib/notify test, the callback function pointer should be cast to the proper type when calling it. This fixes a warning found when using the arcmwdt toolchain.