### PR TITLE
input: use single evaluation clamp

### DIFF
--- a/drivers/input/input_analog_axis.c
+++ b/drivers/input/input_analog_axis.c
@@ -204,7 +204,7 @@ static void analog_axis_loop(const struct device *dev)
 			out = analog_axis_out_linear(dev, i, raw_val);
 		}
 
-		out = CLAMP(out, axis_cfg->out_min, axis_cfg->out_max);
+		out = clamp(out, axis_cfg->out_min, axis_cfg->out_max);
 
 		if (axis_cfg->invert_output) {
 			out = axis_cfg->out_max - out;

--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -309,7 +309,7 @@ static void input_kbd_matrix_poll(const struct device *dev)
 		} else {
 			poll_period_us = cfg->stable_poll_period_us;
 		}
-		wait_period_us = CLAMP(poll_period_us - k_cyc_to_us_floor32(cycles_diff),
+		wait_period_us = clamp(poll_period_us - k_cyc_to_us_floor32(cycles_diff),
 				       USEC_PER_MSEC, poll_period_us);
 
 		LOG_DBG("wait_period_us: %d", wait_period_us);

--- a/drivers/input/input_stmpe811.c
+++ b/drivers/input/input_stmpe811.c
@@ -344,8 +344,8 @@ static void stmpe811_report_touch(const struct device *dev)
 		y = (((int)data->touch_y - config->raw_y_min) * common->screen_height) /
 			(config->raw_y_max - config->raw_y_min);
 
-		x = CLAMP(x, 0, common->screen_width);
-		y = CLAMP(y, 0, common->screen_height);
+		x = clamp(x, 0, common->screen_width);
+		y = clamp(y, 0, common->screen_height);
 	}
 
 	input_touchscreen_report_pos(dev, x, y, K_FOREVER);


### PR DESCRIPTION
Use single evaluation clamp for few input drivers. No reason not to, make some sense for the input_kbd_matrix call since one of the arguments is a function.