### PR TITLE
dfu: Kconfig: fix MCUBoot UPDATE_FOOTER_SIZE build warning

### DIFF
--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -52,14 +52,6 @@ config MCUBOOT_TRAILER_SWAP_TYPE
 	  Disable this option if need to be compatible with earlier version
 	  of MCUBoot.
 
-config MCUBOOT_UPDATE_FOOTER_SIZE
-	hex "Estimated update footer size"
-	default 0x0
-	help
-	  Estimated size of update image data, which is used to prevent loading of firmware updates
-	  that MCUboot cannot update due to being too large. This should be set from sysbuild, only
-	  used when MCUMGR_GRP_IMG_TOO_LARGE_SYSBUILD is enabled.
-
 config IMG_BLOCK_BUF_SIZE
 	int "Image writer buffer size"
 	default 512
@@ -103,3 +95,12 @@ config UPDATEABLE_IMAGE_NUMBER
 endif
 
 endif # IMG_MANAGER
+
+config MCUBOOT_UPDATE_FOOTER_SIZE
+	hex "Estimated update footer size"
+	depends on BOOTLOADER_MCUBOOT
+	default 0x0
+	help
+	  Estimated size of update image data, which is used to prevent loading of firmware updates
+	  that MCUboot cannot update due to being too large. This should be set from sysbuild, only
+	  used when MCUBOOT_IMG_MANAGER and MCUMGR_GRP_IMG_TOO_LARGE_SYSBUILD are enabled.


### PR DESCRIPTION
`CONFIG_MCUBOOT_UPDATE_FOOTER_SIZE` depends on `CONFIG_MCUBOOT_IMG_MANAGER` on Zephyr side, but Sysbuild tries to set it always on MCUboot side [1] which results in the following annoying warning when building with IMG_MANAGER=n:

"warning: MCUBOOT_UPDATE_FOOTER_SIZE (defined at subsys/dfu/Kconfig:55) was assigned the value '0x30' but got the value ''. Check these unsatisfied dependencies: MCUBOOT_IMG_MANAGER (=n), IMG_MANAGER (=n)"

Since we cannot condition `MCUBOOT_UPDATE_FOOTER_SIZE`'s use by Sysbuild on MCUboot side, because "it sets the config of the application before the application is configured...we cannot read any application configuration" at that moment (see [2] for the full quote), remove `MCUBOOT_UPDATE_FOOTER_SIZE`'s dependence on `MCUBOOT_IMG_MANAGER` and make it depend on `BOOTLOADER_MCUBOOT` only.
The symbol help text still says that it is only useful when `MCUBOOT_IMG_MANAGER` and `MCUMGR_GRP_IMG_TOO_LARGE_SYSBUILD` are set.

[1] https://github.com/mcu-tools/mcuboot/blob/e4fc5ae221cee2ce9f1120afc2092a693ac5e8a2/boot/zephyr/sysbuild/CMakeLists.txt#L39
[2] https://github.com/mcu-tools/mcuboot/pull/2504#discussion_r2447423337

This is an alternative to https://github.com/mcu-tools/mcuboot/pull/2504