### PR TITLE
tests: drivers: counter: fix -Wformat error

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -458,7 +458,7 @@ static void test_single_shot_alarm_instance(const struct device *dev, bool set_t
 		err = counter_set_top_value(dev, &top_cfg);
 
 		zassert_equal(0, err,
-			     "%s: Counter failed to set top value", dev->name);
+			     "%s: Counter failed to set top value (err: %d)", dev->name, err);
 
 		cntr_alarm_cfg.ticks = ticks + 1;
 		err = counter_set_channel_alarm(dev, 0, &cntr_alarm_cfg);
@@ -601,7 +601,8 @@ static void test_multiple_alarms_instance(const struct device *dev)
 
 	if (set_top_value_capable(dev)) {
 		err = counter_set_top_value(dev, &top_cfg);
-		zassert_equal(0, err, "%s: Counter failed to set top value", dev->name);
+		zassert_equal(0, err, "%s: Counter failed to set top value (err: %d)", dev->name,
+			      err);
 	} else {
 		/* Counter does not support top value, do not run this test
 		 * as it might take a long time to wrap and trigger the alarm

--- a/tests/drivers/counter/maxim_ds3231_api/src/test_counter.c
+++ b/tests/drivers/counter/maxim_ds3231_api/src/test_counter.c
@@ -264,7 +264,7 @@ void test_single_shot_alarm_instance(const struct device *dev, bool set_top)
 		err = counter_set_top_value(dev, &top_cfg);
 
 		zassert_equal(0, err,
-			      "%s: Counter failed to set top value", dev->name);
+			      "%s: Counter failed to set top value (err: %d)", dev->name, err);
 
 		alarm_cfg.ticks = ticks + 1;
 		err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
@@ -398,7 +398,7 @@ void test_multiple_alarms_instance(const struct device *dev)
 
 	err = counter_set_top_value(dev, &top_cfg);
 	zassert_equal(-ENOTSUP, err,
-		      "%s: Counter failed to set top value: %d", dev->name);
+		      "%s: Counter failed to set top value (err: %d)", dev->name, err);
 
 	k_sleep(K_USEC(3 * (uint32_t)counter_ticks_to_us(dev, alarm_cfg.ticks)));
 


### PR DESCRIPTION
Correct the error message in case counter failed to set top value. A format specifier for the error code was present in the zassert string but the error code was not passed to the zassert function causing a -Wformat error.

Fixes #97834