### PR TITLE
nxp: mcxw7x: integrate MCUXSDK 25.09 blobs

### DIFF
--- a/drivers/ieee802154/ieee802154_mcxw.c
+++ b/drivers/ieee802154/ieee802154_mcxw.c
@@ -1253,6 +1253,12 @@ static int mcxw_init(const struct device *dev)
 	msg.msgType = gPlmeEnableEncryption_c;
 	(void)MAC_PLME_SapHandler(&msg, ot_phy_ctx);
 
+	/* Disable poll optimization */
+	msg.msgType = gPlmeSetReq_c;
+	msg.msgData.setReq.PibAttribute = gPhyPibRxTimePoll_c;
+	msg.msgData.setReq.PibAttributeValue = 0;
+	(void)MAC_PLME_SapHandler(&msg, ot_phy_ctx);
+
 	mcxw_radio->state = RADIO_STATE_DISABLED;
 	mcxw_radio->energy_scan_done = NULL;
 

--- a/dts/arm/nxp/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/nxp_mcxw71.dtsi
@@ -6,6 +6,20 @@
 
 #include "nxp_mcxw7x_common.dtsi"
 
+&fast_peripheral1 {
+	smu2: smu2@1c0000 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		rpmsgmem: memory@8800 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x8800 DT_SIZE_K(6)>;
+			zephyr,memory-region = "rpmsg_sh_mem";
+			zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
+		};
+	};
+};
+
 &fmu {
 	ranges = <0x0 0x10000000 DT_SIZE_M(1)>;
 };

--- a/dts/arm/nxp/nxp_mcxw72.dtsi
+++ b/dts/arm/nxp/nxp_mcxw72.dtsi
@@ -6,6 +6,20 @@
 
 #include "nxp_mcxw7x_common.dtsi"
 
+&fast_peripheral1 {
+	smu2: smu2@1c0000 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		rpmsgmem: memory@220 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x220 0x1100>;
+			zephyr,memory-region = "rpmsg_sh_mem";
+			zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
+		};
+	};
+};
+
 &fmu {
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 };

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -461,17 +461,3 @@
 		interrupts = <63 0>, <64 0>;
 	};
 };
-
-&fast_peripheral1 {
-	smu2: smu2@1c0000 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		rpmsgmem: memory@8800 {
-			compatible = "zephyr,memory-region", "mmio-sram";
-			reg = <0x8800 DT_SIZE_K(6)>;
-			zephyr,memory-region = "rpmsg_sh_mem";
-			zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
-		};
-	};
-};

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 6adb4c509dc86d5702f48b952f209b7c91270250
+      revision: 7bf6f09cc6e544d75bdc29ddde054d83208262d7
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
1. Update MCUX 25.09 blobs for mcxw71/mcxw72
2. Update shared memory placement for mcxw72

Created this PR as previous github PR https://github.com/zephyrproject-rtos/zephyr/pull/97814 got stuck after updating the HAL SHA
Associated HAL PR https://github.com/zephyrproject-rtos/hal_nxp/pull/625

3. Update ieee802154_mcxw driver