### PR TITLE
drivers: spi: renesas_ra8: fix for issue with gpio based chip select

### DIFF
--- a/drivers/spi/spi_b_renesas_ra8.c
+++ b/drivers/spi/spi_b_renesas_ra8.c
@@ -373,6 +373,8 @@ static int transceive(const struct device *dev, const struct spi_config *config,
 
 	/* Disable the SPI Transfer. */
 	p_spi_reg->SPCR_b.SPE = 0;
+
+	spi_context_cs_control(&data->ctx, false);
 #endif
 #ifdef CONFIG_SPI_SLAVE
 	if (spi_context_is_slave(&data->ctx) && !ret) {


### PR DESCRIPTION
This patch fixes an issue in the SPI driver that caused the chip select line to remain low after a transaction completed (when using a GPIO and operating in non-interrupt mode).