### PR TITLE
include: can: Always provide z_impl_can_recover()

### DIFF
--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1455,9 +1455,9 @@ static inline int z_impl_can_get_state(const struct device *dev, enum can_state 
  */
 __syscall int can_recover(const struct device *dev, k_timeout_t timeout);
 
-#ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
 static inline int z_impl_can_recover(const struct device *dev, k_timeout_t timeout)
 {
+#ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
 	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
 
 	if (api->recover == NULL) {
@@ -1465,8 +1465,10 @@ static inline int z_impl_can_recover(const struct device *dev, k_timeout_t timeo
 	}
 
 	return api->recover(dev, timeout);
-}
+#else /* !CONFIG_CAN_MANUAL_RECOVERY_MODE */
+	return -ENOSYS;
 #endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
+}
 
 /**
  * @brief Set a callback for CAN controller state change events


### PR DESCRIPTION
Where the CAN API tests were configured with

```
CONFIG_CAN_MANUAL_RECOVERY_MODE = n
```

the tests did not link due to:

```
classic.c:1351: undefined reference to `z_impl_can_recover'
classic.c:1128: undefined reference to `z_impl_can_recover'
classic.c:1142: undefined reference to `z_impl_can_recover'
```

Fix this by always providing a z_impl_can_recover() implementation.