### PR TITLE
tests: kernel: sched: Fix for variable hw cycles systems

### DIFF
--- a/tests/kernel/sched/deadline/src/main.c
+++ b/tests/kernel/sched/deadline/src/main.c
@@ -14,7 +14,7 @@
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
 
 #define MSEC_TO_CYCLES(msec)  (int)(((uint64_t)(msec) * \
-				     (uint64_t)CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) / \
+				     (uint64_t)sys_clock_hw_cycles_per_sec()) / \
 				    (uint64_t)MSEC_PER_SEC)
 
 struct k_thread worker_threads[NUM_THREADS];


### PR DESCRIPTION
Code was using **CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC** value. System can have non constant value for cycle counter when this constant is not valid.

Now code calls `sys_clock_hw_cycles_per_sec()` that will expand to **CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC** (as before) when needed.
It only impacts systems that can change hw cycles per second at runtime (due to calibration or some other clock change).