### PR TITLE
tests: drivers: flash: Add test with buffer size over the bus packet limit

### DIFF
--- a/tests/drivers/flash/common/boards/mx25uw63_freq_256k.overlay
+++ b/tests/drivers/flash/common/boards/mx25uw63_freq_256k.overlay
@@ -7,4 +7,5 @@
 &mx25uw63 {
 	status = "okay";
 	mspi-max-frequency = <DT_FREQ_K(256)>;
+	transfer-timeout = <500>;
 };

--- a/tests/drivers/flash/common/boards/mx25uw63_single_io.overlay
+++ b/tests/drivers/flash/common/boards/mx25uw63_single_io.overlay
@@ -58,4 +58,5 @@
 	status = "okay";
 	mspi-max-frequency = <DT_FREQ_M(50)>;
 	mspi-io-mode = "MSPI_IO_MODE_SINGLE";
+	transfer-timeout = <500>;
 };

--- a/tests/drivers/flash/common/boards/mx25uw63_single_io_4B_addr_sreset.overlay
+++ b/tests/drivers/flash/common/boards/mx25uw63_single_io_4B_addr_sreset.overlay
@@ -40,7 +40,6 @@
 				<NRF_PSEL(EXMIF_DQ7, 6, 4)>;
 		};
 	};
-
 };
 
 &gpio6 {
@@ -61,4 +60,5 @@
 	mspi-io-mode = "MSPI_IO_MODE_SINGLE";
 	use-4byte-addressing;
 	initial-soft-reset;
+	transfer-timeout = <500>;
 };


### PR DESCRIPTION
Applicable to flash devices with MSPI controller