### PR TITLE
drivers: udc_dwc2: Fix deactivate when hibernated

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1733,7 +1733,19 @@ static int udc_dwc2_ep_deactivate(const struct device *dev,
 	mem_addr_t dxepctl_reg;
 	uint32_t dxepctl;
 
-	dxepctl_reg = dwc2_get_dxepctl_reg(dev, cfg->addr);
+	if (priv->hibernated) {
+		/* If usbd_disable() is called when core is hibernated, modify
+		 * backup registers instead of real ones.
+		 */
+		if (USB_EP_DIR_IS_OUT(cfg->addr)) {
+			dxepctl_reg = (mem_addr_t)&priv->backup.doepctl[ep_idx];
+		} else {
+			dxepctl_reg = (mem_addr_t)&priv->backup.diepctl[ep_idx];
+		}
+	} else {
+		dxepctl_reg = dwc2_get_dxepctl_reg(dev, cfg->addr);
+	}
+
 	dxepctl = sys_read32(dxepctl_reg);
 
 	if (dxepctl & USB_DWC2_DEPCTL_USBACTEP) {


### PR DESCRIPTION
It is possible for usbd_disable() to be called when the core is hibernated. When done so, the USB stack will attempt to deactivate all the endpoints. Because the core is hibernated, register reads are really undefined. This can lead to udc_dwc2_ep_deactivate() not calling udc_dwc2_ep_disable() which will leave struct udc_ep_config busy flag set.

When endpoint 0x00 busy flag is left to true, the driver won't allocate buffer to receive SETUP data which is mandatory in Buffer DMA mode. This leads to essentially dead device after reconnect, because the device will not respond to any control transfers.

Solve the issue by modifying backup register value instead of real one when endpoint is deactivated while core is hibernated.