### PR TITLE
Fix gpio iopctl instance map

### DIFF
--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -54,7 +54,7 @@ static int gpio_mcux_iopctl_configure(const struct device *dev, gpio_pin_t pin, 
 	const struct gpio_mcux_config *config = dev->config;
 	GPIO_Type *gpio_base = config->gpio_base;
 	uint32_t port_no = config->port_no;
-	volatile uint32_t pinconfig = 0;
+	uint32_t pinconfig = 0;
 
 	if (((flags & GPIO_INPUT) != 0) && ((flags & GPIO_OUTPUT) != 0)) {
 		return -ENOTSUP;
@@ -100,7 +100,6 @@ static int gpio_mcux_iopctl_configure(const struct device *dev, gpio_pin_t pin, 
 		pinconfig |= (IOPCTL_PUPD_EN | IOPCTL_PULLDOWN_EN);
 	}
 
-#if defined(FSL_FEATURE_PORT_HAS_DRIVE_STRENGTH) && FSL_FEATURE_PORT_HAS_DRIVE_STRENGTH
 	/* Determine the drive strength */
 	switch (flags & KINETIS_GPIO_DS_MASK) {
 	case KINETIS_GPIO_DS_DFLT:
@@ -114,7 +113,6 @@ static int gpio_mcux_iopctl_configure(const struct device *dev, gpio_pin_t pin, 
 	default:
 		return -ENOTSUP;
 	}
-#endif /* defined(FSL_FEATURE_PORT_HAS_DRIVE_STRENGTH) && FSL_FEATURE_PORT_HAS_DRIVE_STRENGTH */
 
 	IOPCTL_PinMuxSet(port_no, pin, pinconfig);
 

--- a/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
@@ -210,7 +210,8 @@
 	gpio0: gpio@100000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
-		reg = <0x100000 0x1000>;
+		reg = <0x100000 0x1000>, <0x4000 0x80>;
+		reg-names = "gpio", "iopctl_pio";
 		interrupts = <91 0>, <92 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -220,7 +221,8 @@
 	gpio1: gpio@102000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
-		reg = <0x102000 0x1000>;
+		reg = <0x102000 0x1000>, <0x4080 0x80>;
+		reg-names = "gpio", "iopctl_pio";
 		interrupts = <93 0>, <94 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -230,7 +232,8 @@
 	gpio2: gpio@104000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
-		reg = <0x104000 0x1000>;
+		reg = <0x104000 0x1000>, <0x4100 0x80>;
+		reg-names = "gpio", "iopctl_pio";
 		interrupts = <95 0>, <96 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -240,7 +243,8 @@
 	gpio3: gpio@106000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
-		reg = <0x106000 0x1000>;
+		reg = <0x106000 0x1000>, <0x4180 0x80>;
+		reg-names = "gpio", "iopctl_pio";
 		interrupts = <97 0>, <98 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -250,7 +254,8 @@
 	gpio4: gpio@108000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
-		reg = <0x108000 0x1000>;
+		reg = <0x108000 0x1000>, <0xa5000 0x80>;
+		reg-names = "gpio", "iopctl_pio";
 		interrupts = <99 0>, <100 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -260,7 +265,8 @@
 	gpio5: gpio@10a000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
-		reg = <0x10a000 0x1000>;
+		reg = <0x10a000 0x1000>, <0xa5080 0x80>;
+		reg-names = "gpio", "iopctl_pio";
 		interrupts = <101 0>, <102 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -270,7 +276,8 @@
 	gpio6: gpio@10c000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
-		reg = <0x10c000 0x1000>;
+		reg = <0x10c000 0x1000>, <0xa5100 0x80>;
+		reg-names = "gpio", "iopctl_pio";
 		interrupts = <103 0>, <104 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -280,7 +287,8 @@
 	gpio7: gpio@10e000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
-		reg = <0x10e000 0x1000>;
+		reg = <0x10e000 0x1000>, <0xa5180 0x80>;
+		reg-names = "gpio", "iopctl_pio";
 		interrupts = <105 0>, <106 0>;
 		gpio-controller;
 		#gpio-cells = <2>;

--- a/dts/arm/nxp/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_cm33_cpu1.dtsi
@@ -129,34 +129,34 @@
 	gpio8: gpio@320000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
-		reg = <0x320000 0x1000>;
+		reg = <0x320000 0x1000>, <0x64000 0x80>;
+		reg-names = "gpio", "iopctl_pio";
 		interrupts = <61 0>, <62 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		nxp,kinetis-port = <&gpio8>;
-		gpio-port-offest = <8>;
 	};
 
 	gpio9: gpio@322000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
-		reg = <0x322000 0x1000>;
+		reg = <0x322000 0x1000>, <0x64080 0x80>;
+		reg-names = "gpio", "iopctl_pio";
 		interrupts = <63 0>, <64 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		nxp,kinetis-port = <&gpio9>;
-		gpio-port-offest = <8>;
 	};
 
 	gpio10: gpio@324000 {
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
-		reg = <0x324000 0x1000>;
+		reg = <0x324000 0x1000>, <0x64100 0x80>;
+		reg-names = "gpio", "iopctl_pio";
 		interrupts = <65 0>, <66 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		nxp,kinetis-port = <&gpio10>;
-		gpio-port-offest = <8>;
 	};
 
 	flexcomm17: flexcomm@326000 {

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -18,12 +18,6 @@ properties:
       A phandle reference to the device tree node that contains the pinmux
       port associated with this GPIO controller.
 
-  gpio-port-offest:
-    type: int
-    default: 0
-    description: |
-      Describes an offset between inst index and actual GPIO port number.
-
 gpio-cells:
   - pin
   - flags


### PR DESCRIPTION
 When GPIO works with IOPCTL, the PIO instance offset in IOPCTL can't be calculated easily. It should be recorded in DTS based on    SOC integration.

When IOPCTL is used, add PIO register address in DTS, gpio_mcux driver will configure the PIO register based on this address.