### PR TITLE
drivers: sensor: fix 2 clang warnings (promoted to error in CI)

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345_stream.c
+++ b/drivers/sensor/adi/adxl345/adxl345_stream.c
@@ -309,11 +309,9 @@ static void adxl345_process_status1_cb(struct rtio *r, const struct rtio_sqe *sq
 		return;
 	}
 
-	enum sensor_stream_data_opt data_opt;
-
-	if (fifo_wmark_cfg != NULL) {
-		data_opt = fifo_wmark_cfg->opt;
-	}
+	/* fifo_wmark_cfg is guaranteed to be non-NULL here since fifo_full_irq is true */
+	__ASSERT_NO_MSG(fifo_wmark_cfg != NULL);
+	enum sensor_stream_data_opt data_opt = fifo_wmark_cfg->opt;
 
 	if (data_opt == SENSOR_STREAM_DATA_NOP || data_opt == SENSOR_STREAM_DATA_DROP) {
 		uint8_t *buf;

--- a/drivers/sensor/pni/rm3100/rm3100_stream.c
+++ b/drivers/sensor/pni/rm3100/rm3100_stream.c
@@ -183,13 +183,6 @@ static void rm3100_gpio_callback(const struct device *gpio_dev,
 	rm3100_stream_get_data(dev);
 }
 
-static inline bool settings_changed(const struct rm3100_stream *a,
-				    const struct rm3100_stream *b)
-{
-	return (a->settings.enabled.drdy != b->settings.enabled.drdy) ||
-	       (a->settings.opt.drdy != b->settings.opt.drdy);
-}
-
 void rm3100_stream_submit(const struct device *dev,
 			  struct rtio_iodev_sqe *iodev_sqe)
 {


### PR DESCRIPTION
- Fix -Wsometimes-uninitialized warning by initializing data_opt directly from fifo_wmark_cfg->opt. At this point in the code flow, fifo_wmark_cfg is guaranteed to be non-NULL because we can only reach this code after fifo_full_irq is true, which requires fifo_wmark_cfg to be non-NULL.
Added an assertion to document the invariant (but happy to drop it if people think it's overkill)
- Removed an unused static inline function in rm3100 driver

Fixes clang build failures in CI on main https://github.com/zephyrproject-rtos/zephyr/actions/runs/18695942161/job/53315458706 (the bug fixed in the second commit of this PR actually doesn't show up in build log, but pops up as soon as first fixes is applied).