### PR TITLE
arch: arc: add sys_write64/sys_read64 functions

### DIFF
--- a/include/zephyr/arch/arc/sys-io-common.h
+++ b/include/zephyr/arch/arc/sys-io-common.h
@@ -74,6 +74,24 @@ static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 	compiler_barrier();
 }
 
+static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
+{
+	uint64_t value;
+
+	compiler_barrier();
+	value = *(volatile uint64_t *)addr;
+	compiler_barrier();
+
+	return value;
+}
+
+static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
+{
+	compiler_barrier();
+	*(volatile uint64_t *)addr = data;
+	compiler_barrier();
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Added sys_read64 and sys_write64 functions for 64-bit memory operations, similar to sys_read32 and sys_write32.