### PR TITLE
drivers: dma: stm32: enable isr only if needed

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -500,10 +500,13 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 #endif
 	LL_DMA_Init(dma, dma_stm32_id_to_stream(id), &DMA_InitStruct);
 
-	LL_DMA_EnableIT_TC(dma, dma_stm32_id_to_stream(id));
+	/* Enable transfer complete ISR if in non-cyclic mode or a callback is requested */
+	if (!stream->cyclic || stream->dma_callback != NULL) {
+		LL_DMA_EnableIT_TC(dma, dma_stm32_id_to_stream(id));
+	}
 
-	/* Enable Half-Transfer irq if circular mode is enabled */
-	if (stream->cyclic) {
+	/* Enable Half-Transfer irq if circular mode is enabled and a callback is requested */
+	if (stream->cyclic && stream->dma_callback != NULL) {
 		LL_DMA_EnableIT_HT(dma, dma_stm32_id_to_stream(id));
 	}
 


### PR DESCRIPTION
Improve the STM32 DMA driver to only enable transfer and half-transfer interrupts if the interrupt handler has effects beside clearing the isr flag. 
This improves system performance as unnecessary interrupts are no longer raised by the hardware.