### PR TITLE
soc: silabs: siwx91x: Improve performance

### DIFF
--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -64,7 +64,7 @@
 		 * Less memory is allocated to Zephyr, more memory is allocated
 		 * to NWP, better are the WiFi and BLE performances.
 		 */
-		reg = <0x00000400 DT_SIZE_K(255)>;
+		reg = <0x00000400 DT_SIZE_K(319)>;
 	};
 
 	sram_dma1: memory-dma@24061c00 {
@@ -85,6 +85,7 @@
 		support-1p8v;
 		enable-xtal-correction;
 		qspi-80mhz-clk;
+		clock-frequency = <120000000>;
 		status = "okay";
 
 		bt_hci0: bt_hci {

--- a/dts/bindings/net/wireless/silabs,siwx91x-nwp.yaml
+++ b/dts/bindings/net/wireless/silabs,siwx91x-nwp.yaml
@@ -77,3 +77,15 @@ properties:
       - "ext-gpios"
       - "internal"
     required: true
+  clock-frequency:
+    type: int
+    enum:
+      - 80000000
+      - 120000000
+      - 160000000
+    required: true
+    description: |
+      SoC clock frequency configuration for the NWP in Hz. 80 MHz (80000000)
+      is the default and offers lower power consumption; 120 MHz (120000000)
+      can be used for higher throughput. 160 MHz (160000000) is not
+      recommended due to potential instabilities


### PR DESCRIPTION
To enhance throughput performance on the SiWx91x series, certain configurations need to be enabled in the SiWx91x.