### PR TITLE
drivers: flash: andes_xip: update include

### DIFF
--- a/drivers/flash/flash_andes_qspi_xip.c
+++ b/drivers/flash/flash_andes_qspi_xip.c
@@ -9,8 +9,7 @@
 
 #define DT_DRV_COMPAT andestech_qspi_nor_xip
 
-#include "soc_v5.h"
-
+#include <andes_csr.h>
 #include <errno.h>
 #include <string.h>
 #include <zephyr/kernel.h>


### PR DESCRIPTION
Include a new andes_csr.h file instead of soc_v5.h.

Adjust the flash driver to #93697 