### PR TITLE
dts: vendor/arduino: fix QSPI partitioning

### DIFF
--- a/dts/vendor/arduino/partitions_qspi_h7_r1.dtsi
+++ b/dts/vendor/arduino/partitions_qspi_h7_r1.dtsi
@@ -19,19 +19,25 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Partition 1: WiFi firmware and certificates 1MB - 4kB */
+		/* Partition 1: Master Boot Record 4kB */
+		mbr_partition: partition@0 {
+			label = "mbr";
+			reg = <0x0 DT_SIZE_K(4)>;
+		};
+
+		/* Partition 2: WiFi firmware and certificates 1MB - 4kB */
 		wlan_partition: partition@1000 {
 			label = "wlan";
 			reg = <0x001000 DT_SIZE_K(1020)>;
 		};
 
-		/* Partition 2: User data 13MB */
+		/* Partition 3: User data 13MB */
 		storage_partition: partition@100000 {
 			label = "storage";
 			reg = <0x100000 DT_SIZE_M(13)>;
 		};
 
-		/* Partition 3: Binary FW image for the Airoc WLAN */
+		/* Partition 4: Binary FW image for the Airoc WLAN */
 		airoc_firmware: partition@e80000 {
 			label = "4343WA1.bin";
 			reg = <0xe80000 DT_SIZE_K(512)>;

--- a/dts/vendor/arduino/partitions_qspi_h7_r1.dtsi
+++ b/dts/vendor/arduino/partitions_qspi_h7_r1.dtsi
@@ -38,9 +38,9 @@
 		};
 
 		/* Partition 4: Binary FW image for the Airoc WLAN */
-		airoc_firmware: partition@e80000 {
+		airoc_firmware: partition@f80000 {
 			label = "4343WA1.bin";
-			reg = <0xe80000 DT_SIZE_K(512)>;
+			reg = <0xf80000 DT_SIZE_K(512)>;
 		};
 	};
 };

--- a/dts/vendor/arduino/partitions_qspi_h7_r2.dtsi
+++ b/dts/vendor/arduino/partitions_qspi_h7_r2.dtsi
@@ -44,9 +44,9 @@
 		};
 
 		/* Partition 5: Binary FW image for the Airoc WLAN */
-		airoc_firmware: partition@e80000 {
+		airoc_firmware: partition@f80000 {
 			label = "4343WA1.bin";
-			reg = <0xe80000 DT_SIZE_K(512)>;
+			reg = <0xf80000 DT_SIZE_K(512)>;
 		};
 	};
 };

--- a/dts/vendor/arduino/partitions_qspi_h7_r2.dtsi
+++ b/dts/vendor/arduino/partitions_qspi_h7_r2.dtsi
@@ -19,25 +19,31 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Partition 1: WiFi firmware and certificates 1MB - 4kB */
+		/* Partition 1: Master Boot Record 4kB */
+		mbr_partition: partition@0 {
+			label = "mbr";
+			reg = <0x0 DT_SIZE_K(4)>;
+		};
+
+		/* Partition 2: WiFi firmware and certificates 1MB - 4kB */
 		wlan_partition: partition@1000 {
 			label = "wlan";
 			reg = <0x001000 DT_SIZE_K(1020)>;
 		};
 
-		/* Partition 2: OTA 5MB */
+		/* Partition 3: OTA 5MB */
 		ota_partition: partition@100000 {
 			label = "ota";
 			reg = <0x100000 DT_SIZE_M(5)>;
 		};
 
-		/* Partition 3: User data 8MB */
+		/* Partition 4: User data 8MB */
 		storage_partition: partition@600000 {
 			label = "storage";
 			reg = <0x600000 DT_SIZE_M(8)>;
 		};
 
-		/* Partition 4: Binary FW image for the Airoc WLAN */
+		/* Partition 5: Binary FW image for the Airoc WLAN */
 		airoc_firmware: partition@e80000 {
 			label = "4343WA1.bin";
 			reg = <0xe80000 DT_SIZE_K(512)>;

--- a/dts/vendor/arduino/partitions_qspi_h7_r3.dtsi
+++ b/dts/vendor/arduino/partitions_qspi_h7_r3.dtsi
@@ -51,9 +51,9 @@
 		};
 
 		/* Partition 6: Binary FW image for the Airoc WLAN */
-		airoc_firmware: partition@e80000 {
+		airoc_firmware: partition@f80000 {
 			label = "4343WA1.bin";
-			reg = <0xe80000 DT_SIZE_K(512)>;
+			reg = <0xf80000 DT_SIZE_K(512)>;
 		};
 	};
 };

--- a/dts/vendor/arduino/partitions_qspi_h7_r3.dtsi
+++ b/dts/vendor/arduino/partitions_qspi_h7_r3.dtsi
@@ -20,31 +20,37 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Partition 1: WiFi firmware and certificates 1MB - 4kB */
+		/* Partition 1: Master Boot Record 4kB */
+		mbr_partition: partition@0 {
+			label = "mbr";
+			reg = <0x0 DT_SIZE_K(4)>;
+		};
+
+		/* Partition 2: WiFi firmware and certificates 1MB - 4kB */
 		wlan_partition: partition@1000 {
 			label = "wlan";
 			reg = <0x001000 DT_SIZE_K(1020)>;
 		};
 
-		/* Partition 2: OTA 5MB */
+		/* Partition 3: OTA 5MB */
 		ota_partition: partition@100000 {
 			label = "ota";
 			reg = <0x100000 DT_SIZE_M(5)>;
 		};
 
-		/* Partition 3: Provisioning KVStore 1MB */
+		/* Partition 4: Provisioning KVStore 1MB */
 		kvs_partition: partition@600000 {
 			label = "kvs";
 			reg = <0x600000 DT_SIZE_M(1)>;
 		};
 
-		/* Partition 4: User data 7MB */
+		/* Partition 5: User data 7MB */
 		storage_partition: partition@700000 {
 			label = "storage";
 			reg = <0x700000 DT_SIZE_M(7)>;
 		};
 
-		/* Partition 5: Binary FW image for the Airoc WLAN */
+		/* Partition 6: Binary FW image for the Airoc WLAN */
 		airoc_firmware: partition@e80000 {
 			label = "4343WA1.bin";
 			reg = <0xe80000 DT_SIZE_K(512)>;


### PR DESCRIPTION
The Wi-Fi firmware image in the QSPI flash devices has always been located at 512kB from the end of the 16MB Flash device. This offset is 0xf80000, not 0xe80000 as it was mistakenly set.

Also, add the definition for the Master Boot Record partition at the beginning of the flash. This is used by existing Arduino 'Storage' libraries to store partition table information.