### PR TITLE
MAINTAINERS: (trivial) add dts/vendor/arduino/ to Arduino Platforms section

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -337,6 +337,7 @@ Arduino Platforms:
     - boards/arduino/
     - boards/shields/arduino_*/
     - drivers/*/*modulino*
+    - dts/vendor/arduino/
 
 Base OS:
   status: maintained


### PR DESCRIPTION
Files in that directory relate to Arduino hardware products, so it makes sense to include them in the Arduino Platforms section.