### PR TITLE
doc/releases: add instrumentation subsystem notes for release 4.3

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -179,6 +179,45 @@ New APIs and options
 
   * :kconfig:option:`CONFIG_HAPTICS_SHELL`
 
+* Instrumentation subsystem
+
+  * Introduced instrumentation subsystem
+
+    * :kconfig:option:`CONFIG_INSTRUMENTATION`
+    * :kconfig:option:`CONFIG_INSTRUMENTATION_MODE_CALLGRAPH`
+    * :kconfig:option:`CONFIG_INSTRUMENTATION_MODE_CALLGRAPH_BUFFER_SIZE`
+    * :kconfig:option:`CONFIG_INSTRUMENTATION_MODE_CALLGRAPH_BUFFER_OVERWRITE`
+    * :kconfig:option:`CONFIG_INSTRUMENTATION_MODE_STATISTICAL`
+    * :kconfig:option:`CONFIG_INSTRUMENTATION_MODE_STATISTICAL_MAX_NUM_FUNC`
+    * :kconfig:option:`CONFIG_INSTRUMENTATION_MODE_STATISTICAL_MAX_CALL_DEPTH`
+    * :kconfig:option:`CONFIG_INSTRUMENTATION_TRIGGER_FUNCTION`
+    * :kconfig:option:`CONFIG_INSTRUMENTATION_STOPPER_FUNCTION`
+    * :kconfig:option:`CONFIG_INSTRUMENTATION_EXCLUDE_FUNCTION_LIST`
+    * :kconfig:option:`CONFIG_INSTRUMENTATION_EXCLUDE_FILE_LIST`
+    * :c:struct:`instr_header`
+    * :c:struct:`instr_event_context`
+    * :c:struct:`instr_record`
+    * :c:func:`instr_tracing_supported`
+    * :c:func:`instr_profiling_supported`
+    * :c:func:`instr_fundamentals_initialized`
+    * :c:func:`instr_init`
+    * :c:func:`instr_initialized`
+    * :c:func:`instr_enabled`
+    * :c:func:`instr_enable`
+    * :c:func:`instr_disable`
+    * :c:func:`instr_turn_on`
+    * :c:func:`instr_turn_off`
+    * :c:func:`instr_turned_on`
+    * :c:func:`instr_trace_enabled`
+    * :c:func:`instr_profile_enabled`
+    * :c:func:`instr_dump_buffer_uart`
+    * :c:func:`instr_dump_deltas_uart`
+    * :c:func:`instr_event_handler`
+    * :c:func:`instr_set_trigger_func`
+    * :c:func:`instr_set_stop_func`
+    * :c:func:`instr_get_trigger_func`
+    * :c:func:`instr_get_stop_func`
+
 * Kernel
 
   * :kconfig:option:`CONFIG_HW_SHADOW_STACK`


### PR DESCRIPTION
This PR adds release notes for the 4.3 release for the instrumentation subsystem.