### PR TITLE
soc: silabs: siwx91x_nwp: fix coex_mode in nwp initialization

### DIFF
--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
@@ -163,11 +163,13 @@ static void siwx91x_configure_sta_mode(sl_si91x_boot_configuration_t *boot_confi
 		boot_config->coex_mode = SL_SI91X_WLAN_BLE_MODE;
 	} else if (wifi_enabled) {
 		boot_config->coex_mode = SL_SI91X_WLAN_ONLY_MODE;
+	} else if (bt_enabled) {
+		boot_config->coex_mode = SL_SI91X_BLE_MODE;
 	} else {
 		/*
 		 * Even if neither WiFi or BLE is used we have to specify a Coex mode
 		 */
-		boot_config->coex_mode = SL_SI91X_BLE_MODE;
+		boot_config->coex_mode = SL_SI91X_WLAN_ONLY_MODE;
 	}
 
 #ifdef CONFIG_WIFI_SILABS_SIWX91X


### PR DESCRIPTION
Change the default coex mode when there is neither WiFi or BT activated. Switch from BLE_ONLY to WLAN_ONLY. It fix a bug where we can't go in deepsleep if we didn't select CONFIG_WIFI.