### PR TITLE
drivers: i2s: mcux sai update TX state after queue is empty

### DIFF
--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -322,6 +322,7 @@ static void i2s_dma_tx_callback(const struct device *dma_dev, void *arg, uint32_
 		I2S_Type *base = (I2S_Type *)dev_cfg->base;
 
 		SAI_TxEnable(base, false);
+		strm->state = I2S_STATE_READY;
 		LOG_WRN("TX is paused.");
 	}
 	goto enabled_exit;


### PR DESCRIPTION
This change sets the TX state to ready after the TX queue has been emptied.
This allows refilling the buffer instread of starting the stream directly after the first received buffer.

Before:

```
[00:00:44.999,000] <dbg> app_audio: app_audio_entry: payload_size: 524, audio_size: 512 
[00:00:45.122,000] <wrn> dev_i2s_mcux: TX input queue empty!
[00:00:45.130,000] <wrn> dev_i2s_mcux: TX is paused.
[00:00:50.417,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:50.428,000] <wrn> dev_i2s_mcux: TX is resumed
[00:00:50.436,000] [00:00:50.440,000] <wrn> dev_i2s_mcux: TX input queue empty!
[00:00:50.448,000] <wrn> dev_i2s_mcux: TX is paused.
uart:~$ p_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:50.464,000] <wrn> dev_i2s_mcux: TX is resumed
[00:00:50.472,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:50.484,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:50.495,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:50.506,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:50.518,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:50.529,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:50.540,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:50.552,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:50.563,000] <wrn> dev_i2s_mcux: I2S_TRIGGER_START
[00:00:50.571,000] <err> dev_i2s_mcux: START trigger: invalid state 2
[00:00:50.580,000] <err> app_audio: Could not trigger I2S tx

[00:00:50.589,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:50.601,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
```

After:

```
[00:00:51.976,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:51.987,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:51.999,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:52.011,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:52.022,000] <dbg> app_audio: app_audio_entry: payload_size: 524, audio_size: 512 
[00:00:52.146,000] <wrn> dev_i2s_mcux: TX input queue empty!
[00:00:52.154,000] <wrn> dev_i2s_mcux: TX is paused.
[00:00:56.856,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:56.868,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:56.879,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:56.891,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:56.903,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:56.914,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:56.926,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:56.937,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:56.949,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:56.961,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:56.972,000] <wrn> dev_i2s_mcux: I2S_TRIGGER_START
[00:00:56.980,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:56.992,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:57.003,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:57.015,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
[00:00:57.026,000] <dbg> app_audio: app_audio_entry: payload_size: 1036, audio_size: 1024 
```