### PR TITLE
west.yml: Update libmetal and open-amp for v2025.10.0 release

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -299,7 +299,7 @@ manifest:
       revision: b97860e78998551af99931ece149eeffc538bdb1
       path: modules/lib/libmctp
     - name: libmetal
-      revision: 91d38634d1882f0a2151966f8c5c230ce1c0de7b
+      revision: 66e084293b2a7ced5a73fbd247deddba8915883a
       path: modules/hal/libmetal
       groups:
         - hal
@@ -350,7 +350,7 @@ manifest:
       revision: 9f09f0785f9fc716514d8956a2a446021697400c
       path: modules/lib/nrf_wifi
     - name: open-amp
-      revision: c30a6d8b92fcebdb797fc1a7698e8729e250f637
+      revision: 5efe7974f9546582e99f5a842a816ea4b65f5227
       path: modules/lib/open-amp
     - name: openthread
       revision: 2bc7712f57af22058770d1ef131ad3da79a0c764


### PR DESCRIPTION
Update to the last release of open-amp and libmetal libraries