### PR TITLE
Adding snippet to activate s2ram config for stm32wbax when rf enabled 

### DIFF
--- a/snippets/st/index.rst
+++ b/snippets/st/index.rst
@@ -1,0 +1,10 @@
+.. _st-snippets:
+
+STMicroelectronics snippets
+###########################
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*

--- a/snippets/st/stm32wbax-rf-s2ram/README.rst
+++ b/snippets/st/stm32wbax-rf-s2ram/README.rst
@@ -1,0 +1,22 @@
+.. _snippet-st-stm32wbax-rf-s2ram:
+
+STM32WBAX RF-compatible PM-with-S2RAM configuration (stm32wbax-rf-s2ram)
+########################################################################
+
+Overview
+********
+
+This snippet enables Power Management with ``suspend-to-ram`` support (mapped to
+STM32 ``Standby`` hardware low-power mode) on boards equipped with an STMicroelectronics
+STM32WBA series SoC. The configuration applied is suitable for RF applications.
+
+Tested successfully on :zephyr:board:`nucleo_wba55cg` and :zephyr:board:`nucleo_wba65ri`.
+
+.. code-block:: console
+
+   west build -S stm32wbax-rf-s2ram [...]
+
+Requirements
+************
+
+This snippet is only valid for boards with an STM32WBA series SoC.

--- a/snippets/st/stm32wbax-rf-s2ram/snippet.yml
+++ b/snippets/st/stm32wbax-rf-s2ram/snippet.yml
@@ -1,0 +1,11 @@
+# Copyright 2025 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: stm32wbax-rf-s2ram
+
+boards:
+  /.*wba(65|55).*/:
+    append:
+      EXTRA_CONF_FILE: stm32wbax-rf-s2ram.conf
+      EXTRA_DTC_OVERLAY_FILE: stm32wbax-rf-s2ram.overlay

--- a/snippets/st/stm32wbax-rf-s2ram/stm32wbax-rf-s2ram.conf
+++ b/snippets/st/stm32wbax-rf-s2ram/stm32wbax-rf-s2ram.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_PM=y

--- a/snippets/st/stm32wbax-rf-s2ram/stm32wbax-rf-s2ram.overlay
+++ b/snippets/st/stm32wbax-rf-s2ram/stm32wbax-rf-s2ram.overlay
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 STMicroelectronics
+ */
+/ {
+	/* Change min residency time to ease power consumption measurement */
+	cpus {
+		cpu0: cpu@0 {
+			cpu-power-states = <&stop0 &stop1 &standby>;
+		};
+
+		power-states {
+			standby: state2 {
+				exit-latency-us = <500>;
+			};
+		};
+	};
+};
+
+&lptim1 {
+	status = "okay";
+};


### PR DESCRIPTION
Adding snippet to activate stm32wbax s2ram configuration when rf enabled.
For the moment tested only nucleo_wba55cg and nucleo_wba65ri.

By adding "-S stm32wbax-rf-s2ram" at the end of any build command, we can enable standby in any application.

Have a look at zephyr snippet documentation for extra details:
https://docs.zephyrproject.org/latest/build/snippets/index.html

FYI: @Chastillon, @vtardy-st, @corentin-sename, @ericmechin, @msmttchr, @FrancescoCiminoST 
 