### PR TITLE
script: west: completion: add missing west completion

### DIFF
--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -1208,12 +1208,14 @@ __comp_west()
 		update
 		list
 		manifest
+		compare
 		diff
 		status
 		forall
+		grep
+		help
 		config
 		topdir
-		help
 	)
 
 	local zephyr_ext_cmds=(
@@ -1221,16 +1223,23 @@ __comp_west()
 		boards
 		shields
 		build
+		twister
 		sign
 		flash
 		debug
 		debugserver
 		attach
+		rtt
 		zephyr-export
 		spdx
 		blobs
-		twister
+		bindesc
+		robot
+		simulate
 		sdk
+		packages
+		patch
+		gtags
 	)
 
 	local cmds=(${builtin_cmds[*]} ${zephyr_ext_cmds[*]})

--- a/scripts/west_commands/completion/west-completion.fish
+++ b/scripts/west_commands/completion/west-completion.fish
@@ -161,26 +161,37 @@ function __zephyr_west_complete_help
                         "update" "update projects described in west manifest" \
                         "list" "print information about projects" \
                         "manifest" "manage the west manifest" \
+                        "compare" "compare project status against the manifest" \
                         "diff" '"git diff" for one or more projects' \
                         "status" '"git status" for one or more projects' \
                         "forall" "run a command in one or more local projects" \
+                        "grep" "run grep or a grep-like tool in one or more local projects" \
+                        "help" "get help for west or a command" \
                         "config" "get or set config file values" \
-                        "topdir" "print the top level directory of the workspace" \
-                        "help" "get help for west or a command"
+                        "topdir" "print the top level directory of the workspace"
     set -l nb_builtin_cmds (count $builtin_cmds)
 
     set -l ext_cmds "completion" "display shell completion scripts" \
                     "boards" "display information about supported boards" \
+                    "shields" "display list of supported shields" \
                     "build" "compile a Zephyr application" \
+                    "twister" "west twister wrapper" \
                     "sign" "sign a Zephyr binary for bootloader chain-loading" \
                     "flash" "flash and run a binary on a board" \
                     "debug" "flash and interactively debug a Zephyr application" \
                     "debugserver" "connect to board and launch a debug server" \
                     "attach" "interactively debug a board" \
+                    "rtt" "open an rtt shell" \
                     "zephyr-export" "export Zephyr installation as a CMake config package" \
                     "spdx" "create SPDX bill of materials" \
                     "blobs" "work with binary blobs" \
-                    "sdk" "manage SDKs"
+                    "bindesc" "work with Binary Descriptors" \
+                    "robot" "run RobotFramework test suites" \
+                    "simulate" "simulate board" \
+                    "sdk" "manage SDKs" \
+                    "packages" "manage packages for Zephyr" \
+                    "patch" "manage patches for Zephyr modules" \
+                    "gtags" "create a GNU global tags file for the current workspace"
     set -l nb_ext_cmds (count $ext_cmds)
 
     if __zephyr_west_check_if_in_workspace

--- a/scripts/west_commands/completion/west-completion.zsh
+++ b/scripts/west_commands/completion/west-completion.zsh
@@ -16,10 +16,11 @@ _west_cmds() {
   'manifest[manage the west manifest]'
   'diff["git diff" for one or more projects]'
   'status["git status" for one or more projects]'
+  'grep["run grep or a grep-like tool in one or more local projects]'
   'forall[run a command in one or more local projects]'
+  'help[get help for west or a command]'
   'config[get or set config file values]'
   'topdir[print the top level directory of the workspace]'
-  'help[get help for west or a command]'
   )
 
   local -a zephyr_ext_cmds=(
@@ -32,10 +33,16 @@ _west_cmds() {
   'debug[flash and interactively debug a Zephyr application]'
   'debugserver[connect to board and launch a debug server]'
   'attach[interactively debug a board]'
+  'rtt[open an rtt shell]'
   'zephyr-export[export Zephyr installation as a CMake config package]'
   'spdx[create SPDX bill of materials]'
   'blobs[work with binary blobs]'
+  'bindesc[work with Binary Descriptors]'
+  'robot[run RobotFramework test suites]'
   'sdk[manage SDKs]'
+  'packages[manage packages for Zephyr]'
+  'patch[manage patches for Zephyr modules]'
+  'gtags[create a GNU global tags file for the current workspace]'
   )
 
   local -a all_cmds=(${builtin_cmds} ${zephyr_ext_cmds})


### PR DESCRIPTION
this path only provides autocompletion for the `west` command
itself, not for its subcommands. (i.e. `west [tab]` rather than
`west packages [tab]`). However, it remains highly userful,
significantly reducing typing time and errors when using longer
commands like `west packages`.