### PR TITLE
Revert commits from PR 98055 and 97875

### DIFF
--- a/include/zephyr/arch/arc/sys-io-common.h
+++ b/include/zephyr/arch/arc/sys-io-common.h
@@ -74,24 +74,6 @@ static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 	compiler_barrier();
 }
 
-static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
-{
-	uint64_t value;
-
-	compiler_barrier();
-	value = *(volatile uint64_t *)addr;
-	compiler_barrier();
-
-	return value;
-}
-
-static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
-{
-	compiler_barrier();
-	*(volatile uint64_t *)addr = data;
-	compiler_barrier();
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/shell/modules/devmem_service.c
+++ b/subsys/shell/modules/devmem_service.c
@@ -253,7 +253,7 @@ static int cmd_load(const struct shell *sh, size_t argc, char **argv)
 
 static int memory_read(const struct shell *sh, mem_addr_t addr, uint8_t width)
 {
-	uint64_t value;
+	uint32_t value;
 	int err = 0;
 
 	switch (width) {
@@ -266,11 +266,6 @@ static int memory_read(const struct shell *sh, mem_addr_t addr, uint8_t width)
 	case 32:
 		value = sys_read32(addr);
 		break;
-#ifdef CONFIG_64BIT
-	case 64:
-		value = sys_read64(addr);
-		break;
-#endif /* CONFIG_64BIT */
 	default:
 		shell_fprintf(sh, SHELL_NORMAL, "Incorrect data width\n");
 		err = -EINVAL;
@@ -278,7 +273,7 @@ static int memory_read(const struct shell *sh, mem_addr_t addr, uint8_t width)
 	}
 
 	if (err == 0) {
-		shell_fprintf(sh, SHELL_NORMAL, "Read value 0x%llx\n", value);
+		shell_fprintf(sh, SHELL_NORMAL, "Read value 0x%x\n", value);
 	}
 
 	return err;
@@ -298,11 +293,6 @@ static int memory_write(const struct shell *sh, mem_addr_t addr, uint8_t width, 
 	case 32:
 		sys_write32(value, addr);
 		break;
-#ifdef CONFIG_64BIT
-	case 64:
-		sys_write64(value, addr);
-		break;
-#endif /* CONFIG_64BIT */
 	default:
 		shell_fprintf(sh, SHELL_NORMAL, "Incorrect data width\n");
 		err = -EINVAL;
@@ -316,7 +306,7 @@ static int memory_write(const struct shell *sh, mem_addr_t addr, uint8_t width, 
 static int cmd_devmem(const struct shell *sh, size_t argc, char **argv)
 {
 	mem_addr_t phys_addr, addr;
-	uint64_t value = 0;
+	uint32_t value = 0;
 	uint8_t width;
 
 	phys_addr = strtoul(argv[1], NULL, 16);
@@ -345,9 +335,9 @@ static int cmd_devmem(const struct shell *sh, size_t argc, char **argv)
 	 * this value at the address provided
 	 */
 
-	value = (uint64_t)strtoull(argv[3], NULL, 16);
+	value = strtoul(argv[3], NULL, 16);
 
-	shell_fprintf(sh, SHELL_NORMAL, "Writing value 0x%llx\n", value);
+	shell_fprintf(sh, SHELL_NORMAL, "Writing value 0x%x\n", value);
 
 	return memory_write(sh, addr, width, value);
 }


### PR DESCRIPTION
Get CI back on track and give people time to come up with proper fixes.
ARC change was incorrectly marked and merged as hotfix, while the proper hotfix would have been to revert the problematic commit to devmem shell.