### PR TITLE
drivers: mipi-dbi-spi: Fix initialization of GPIO CS

### DIFF
--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -41,6 +41,19 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
+#define MIPI_DBI_DT_SPI_DEV(node_id)					\
+	DT_PHANDLE(DT_PARENT(node_id), spi_dev)
+
+#define MIPI_DBI_SPI_CS_GPIOS_DT_SPEC_GET(node_id)			\
+	GPIO_DT_SPEC_GET_BY_IDX_OR(MIPI_DBI_DT_SPI_DEV(node_id),	\
+		cs_gpios, DT_REG_ADDR_RAW(node_id), {})
+
+#define MIPI_DBI_SPI_CS_CONTROL_INIT_GPIO(node_id, delay_)		\
+	.gpio = MIPI_DBI_SPI_CS_GPIOS_DT_SPEC_GET(node_id),		\
+	.delay = delay_,
+/** @endcond */
+
 /**
  * @brief initialize a MIPI DBI SPI configuration struct from devicetree
  *
@@ -61,12 +74,12 @@ extern "C" {
 			COND_CODE_1(DT_PROP(node_id, mipi_cpha), SPI_MODE_CPHA, (0)) |	\
 			COND_CODE_1(DT_PROP(node_id, mipi_hold_cs), SPI_HOLD_ON_CS, (0)),	\
 		.slave = DT_REG_ADDR(node_id),				\
-		.cs = {							\
-			COND_CODE_1(DT_SPI_DEV_HAS_CS_GPIOS(node_id),	\
-			(SPI_CS_CONTROL_INIT_GPIO(node_id, delay_)),	\
-			(SPI_CS_CONTROL_INIT_NATIVE(node_id)))		\
-			.cs_is_gpio = DT_SPI_DEV_HAS_CS_GPIOS(node_id),	\
-		},							\
+		.cs = {									\
+			COND_CODE_1(DT_SPI_HAS_CS_GPIOS(MIPI_DBI_DT_SPI_DEV(node_id)),	\
+			(MIPI_DBI_SPI_CS_CONTROL_INIT_GPIO(node_id, delay_)),		\
+			(SPI_CS_CONTROL_INIT_NATIVE(node_id)))				\
+			.cs_is_gpio = DT_SPI_HAS_CS_GPIOS(MIPI_DBI_DT_SPI_DEV(node_id)),\
+		},									\
 	}
 
 /**


### PR DESCRIPTION
Access the correct node to get the SPI device GPIO CS. It comes from the parent spi-dev node, not the bus

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/97746
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/98029