### PR TITLE
Support DMIC sample and test on mcxn9xx boards

### DIFF
--- a/samples/drivers/audio/dmic/Kconfig
+++ b/samples/drivers/audio/dmic/Kconfig
@@ -1,0 +1,11 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config SAMPLE_BIT_WIDTH
+	int "Sample bit width"
+	default 32 if DT_HAS_NXP_MICFIL_ENABLED
+	default 16
+	help
+	  PCM sample bit width.

--- a/samples/drivers/audio/dmic/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/samples/drivers/audio/dmic/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 NXP
+ */
+
+dmic_dev: &micfil {
+
+	status = "okay";
+	channel0: micfil-channel@0 {
+		status = "okay";
+	};
+	channel1: micfil-channel@1 {
+		status = "okay";
+	};
+};

--- a/samples/drivers/audio/dmic/boards/frdm_mcxn947_mcxn947_cpu1.overlay
+++ b/samples/drivers/audio/dmic/boards/frdm_mcxn947_mcxn947_cpu1.overlay
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 NXP
+ */
+
+dmic_dev: &micfil {
+
+	status = "okay";
+	channel0: micfil-channel@0 {
+		status = "okay";
+	};
+	channel1: micfil-channel@1 {
+		status = "okay";
+	};
+};

--- a/samples/drivers/audio/dmic/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
+++ b/samples/drivers/audio/dmic/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 NXP
+ */
+
+dmic_dev: &micfil {
+
+	status = "okay";
+	channel0: micfil-channel@0 {
+		status = "okay";
+	};
+	channel1: micfil-channel@1 {
+		status = "okay";
+	};
+};

--- a/samples/drivers/audio/dmic/boards/mcx_n9xx_evk_mcxn947_cpu1.overlay
+++ b/samples/drivers/audio/dmic/boards/mcx_n9xx_evk_mcxn947_cpu1.overlay
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 NXP
+ */
+
+dmic_dev: &micfil {
+
+	status = "okay";
+	channel0: micfil-channel@0 {
+		status = "okay";
+	};
+	channel1: micfil-channel@1 {
+		status = "okay";
+	};
+};

--- a/samples/drivers/audio/dmic/src/main.c
+++ b/samples/drivers/audio/dmic/src/main.c
@@ -11,8 +11,8 @@
 LOG_MODULE_REGISTER(dmic_sample);
 
 #define MAX_SAMPLE_RATE  16000
-#define SAMPLE_BIT_WIDTH 16
-#define BYTES_PER_SAMPLE sizeof(int16_t)
+#define SAMPLE_BIT_WIDTH CONFIG_SAMPLE_BIT_WIDTH
+#define BYTES_PER_SAMPLE SAMPLE_BIT_WIDTH / 8
 /* Milliseconds to wait for a block to be read. */
 #define READ_TIMEOUT     1000
 

--- a/tests/drivers/audio/dmic_api/Kconfig
+++ b/tests/drivers/audio/dmic_api/Kconfig
@@ -1,0 +1,18 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config SAMPLE_BIT_WIDTH
+	int "Sample bit width"
+	default 32 if DT_HAS_NXP_MICFIL_ENABLED
+	default 16
+	help
+	  PCM sample bit width.
+
+config SAMPLE_PDM_CHANNELS
+	int "Number of DMIC channels"
+	default 4 if DT_HAS_NXP_MICFIL_ENABLED || DT_HAS_NXP_DMIC_ENABLED
+	default 2
+	help
+	  Count of DMIC channels to capture and process.

--- a/tests/drivers/audio/dmic_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/drivers/audio/dmic_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 NXP
+ */
+
+/ {
+	aliases {
+		dmic-dev = &micfil;
+	};
+};
+
+dmic_dev: &micfil {
+
+	status = "okay";
+	channel0: micfil-channel@0 {
+		status = "okay";
+	};
+	channel1: micfil-channel@1 {
+		status = "okay";
+	};
+};

--- a/tests/drivers/audio/dmic_api/boards/frdm_mcxn947_mcxn947_cpu1.overlay
+++ b/tests/drivers/audio/dmic_api/boards/frdm_mcxn947_mcxn947_cpu1.overlay
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 NXP
+ */
+
+/ {
+	aliases {
+		dmic-dev = &micfil;
+	};
+};
+
+dmic_dev: &micfil {
+
+	status = "okay";
+	channel0: micfil-channel@0 {
+		status = "okay";
+	};
+	channel1: micfil-channel@1 {
+		status = "okay";
+	};
+};

--- a/tests/drivers/audio/dmic_api/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
+++ b/tests/drivers/audio/dmic_api/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 NXP
+ */
+
+/ {
+	aliases {
+		dmic-dev = &micfil;
+	};
+};
+
+dmic_dev: &micfil {
+
+	status = "okay";
+	channel0: micfil-channel@0 {
+		status = "okay";
+	};
+	channel1: micfil-channel@1 {
+		status = "okay";
+	};
+};

--- a/tests/drivers/audio/dmic_api/boards/mcx_n9xx_evk_mcxn947_cpu1.overlay
+++ b/tests/drivers/audio/dmic_api/boards/mcx_n9xx_evk_mcxn947_cpu1.overlay
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 NXP
+ */
+
+/ {
+	aliases {
+		dmic-dev = &micfil;
+	};
+};
+
+dmic_dev: &micfil {
+
+	status = "okay";
+	channel0: micfil-channel@0 {
+		status = "okay";
+	};
+	channel1: micfil-channel@1 {
+		status = "okay";
+	};
+};

--- a/tests/drivers/audio/dmic_api/src/main.c
+++ b/tests/drivers/audio/dmic_api/src/main.c
@@ -15,21 +15,11 @@
 
 static const struct device *dmic_dev = DEVICE_DT_GET(DT_ALIAS(dmic_dev));
 
-#if DT_HAS_COMPAT_STATUS_OKAY(nxp_dmic)
-#define PDM_CHANNELS 4 /* Two L/R pairs of channels */
-#define SAMPLE_BIT_WIDTH 16
-#define BYTES_PER_SAMPLE sizeof(int16_t)
-#define SLAB_ALIGN 4
+#define SAMPLE_BIT_WIDTH CONFIG_SAMPLE_BIT_WIDTH
+#define PDM_CHANNELS     CONFIG_SAMPLE_PDM_CHANNELS
+#define BYTES_PER_SAMPLE SAMPLE_BIT_WIDTH / 8
+#define SLAB_ALIGN       4
 #define MAX_SAMPLE_RATE  48000
-#elif DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_pdm)
-#define PDM_CHANNELS 2
-#define SAMPLE_BIT_WIDTH 16
-#define BYTES_PER_SAMPLE sizeof(int16_t)
-#define SLAB_ALIGN 4
-#define MAX_SAMPLE_RATE  48000
-#else
-#error "Unsupported DMIC device"
-#endif
 
 /* Milliseconds to wait for a block to be read. */
 #define READ_TIMEOUT 1000


### PR DESCRIPTION
Add dmic_api test support for mcx_n9xx_evk and frdm_mcxn947 boards.
Add Kconfig configuration of pcm width to dmic sample.
Add dmic sample support for mcx_n9xx_evk and frdm_mcxn947 boards.
Depends on #96980