### PR TITLE
driver: uart: stm32: Disable UART DMA before shutdown

### DIFF
--- a/drivers/serial/Kconfig.stm32
+++ b/drivers/serial/Kconfig.stm32
@@ -39,8 +39,8 @@ if UART_STM32U5_ERRATA_DMAT_AFFECTED
 
 choice UART_STM32U5_ERRATA_DMAT
 	prompt "Workaround for DMAT errata on selected devices"
-	default UART_STM32U5_ERRATA_DMAT_LOWPOWER if PM
 	default UART_STM32U5_ERRATA_DMAT_NOCLEAR if !PM
+	default UART_STM32U5_ERRATA_DMAT_LOWPOWER
 	help
 	  Handles erratum "USART does not generate DMA requests after
 	  setting/clearing DMAT bit" as described in the errata sheets:
@@ -59,6 +59,7 @@ config UART_STM32U5_ERRATA_DMAT_LOWPOWER
 
 config UART_STM32U5_ERRATA_DMAT_NOCLEAR
 	bool "Do not clear DMAT"
+	depends on !POWEROFF # DMAT must be clear to enter LL_PWR_SHUTDOWN_MODE
 	help
 	  This option keeps DMAT bit set. This may cause additional power
 	  consumption in STOP low-power modes.

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1510,7 +1510,10 @@ static inline void uart_stm32_dma_rx_enable(const struct device *dev)
 
 static inline void uart_stm32_dma_rx_disable(const struct device *dev)
 {
+	const struct uart_stm32_config *config = dev->config;
 	struct uart_stm32_data *data = dev->data;
+
+	LL_USART_DisableDMAReq_RX(config->usart);
 
 	data->dma_rx.enabled = false;
 }


### PR DESCRIPTION
Taking over [#96505](https://github.com/zephyrproject-rtos/zephyr/pull/96505) as mentioned [here.](https://github.com/zephyrproject-rtos/zephyr/pull/96505#issuecomment-3405285635)

Main difference with the first PR is:

Modified the fix so it is made in the driver directly as suggested [here.](https://github.com/zephyrproject-rtos/zephyr/pull/96505#issuecomment-3346524191)

**Note:**
`sys_poweroff` should be called when the system is in a safe state
<img width="1383" height="407" alt="image" src="https://github.com/user-attachments/assets/454c3560-c973-4cbd-9548-edbb231540aa" />

Therefore when using UART with DMA, `uart_rx_disable` should be called before `sys_poweroff` in order to disable RX DMA requests.

Fixes #63236 