### PR TITLE
tests: drivers: dma: iterate over all testing dma nodes

### DIFF
--- a/tests/drivers/dma/chan_link_transfer/Kconfig
+++ b/tests/drivers/dma/chan_link_transfer/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Alex Apostolu
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config DMA_LOOP_TRANSFER_NUMBER_OF_DMAS
+	int "Number of DMAs to test"
+	default 1

--- a/tests/drivers/dma/chan_link_transfer/boards/bg29_rb4420a.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/bg29_rb4420a.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_link_transfer/boards/frdm_k64f.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/frdm_k64f.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+test_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1010_evk.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1010_evk.overlay
@@ -5,4 +5,4 @@
  *
  */
 
-dma0: &edma0 {};
+test_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1024_evk.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1024_evk.overlay
@@ -1,1 +1,7 @@
-dma0: &edma0 {};
+/*
+ * Copyright (c) 2025 Alex Apostolu
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+test_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
@@ -5,4 +5,4 @@
  *
  */
 
-dma0: &edma0 {};
+test_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+test_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+test_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1064_evk.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1064_evk.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+test_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+test_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+test_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mr_canhubk3.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mr_canhubk3.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+test_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/native_sim.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/native_sim.overlay
@@ -9,4 +9,4 @@
 	status = "okay";
 };
 
-dma0: &dma {};
+test_dma0: &dma {};

--- a/tests/drivers/dma/chan_link_transfer/boards/rpi_pico2_rp2350a_hazard3.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/rpi_pico2_rp2350a_hazard3.overlay
@@ -6,3 +6,5 @@
 
 /* Pico 2 is compatible with the Pico 1, so reuse. */
 #include "rpi_pico.overlay"
+
+test_dma0: &dma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-dma0: &edma0 {};
+test_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-dma0: &edma5 {};
+test_dma0: &edma5 {};

--- a/tests/drivers/dma/chan_link_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_link_transfer/src/test_dma.c
@@ -49,11 +49,10 @@ static void test_done(const struct device *dma_dev, void *arg, uint32_t id,
 	}
 }
 
-static int test_task(int minor, int major)
+static int test_task(const struct device *dma, int minor, int major)
 {
 	struct dma_config dma_cfg = { 0 };
 	struct dma_block_config dma_block_cfg = { 0 };
-	const struct device *const dma = DEVICE_DT_GET(DT_NODELABEL(dma0));
 
 	if (!device_is_ready(dma)) {
 		TC_PRINT("dma controller device is not ready\n");
@@ -148,18 +147,26 @@ static int test_task(int minor, int major)
 	return TC_PASS;
 }
 
-/* export test cases */
-ZTEST(dma_m2m_link, test_dma_m2m_chan0_1_major_link)
-{
-	zassert_true((test_task(0, 1) == TC_PASS));
-}
+#define DMA_NAME(i, _) test_dma##i
+#define DMA_LIST       LISTIFY(CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS, DMA_NAME, (,))
 
-ZTEST(dma_m2m_link, test_dma_m2m_chan0_1_minor_link)
-{
-	zassert_true((test_task(1, 0) == TC_PASS));
-}
+#define TEST_LINKS(dma_name)                                                                       \
+	ZTEST(dma_m2m_link, test_##dma_name##_m2m_chan0_1_major_link)                              \
+	{                                                                                          \
+		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
+		zassert_true((test_task(dma, 0, 1) == TC_PASS));                                   \
+	}                                                                                          \
+                                                                                                   \
+	ZTEST(dma_m2m_link, test_##dma_name##_m2m_chan0_1_minor_link)                              \
+	{                                                                                          \
+		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
+		zassert_true((test_task(dma, 1, 0) == TC_PASS));                                   \
+	}                                                                                          \
+                                                                                                   \
+	ZTEST(dma_m2m_link, test_##dma_name##_m2m_chan0_1_minor_major_link)                        \
+	{                                                                                          \
+		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
+		zassert_true((test_task(dma, 1, 1) == TC_PASS));                                   \
+	}
 
-ZTEST(dma_m2m_link, test_dma_m2m_chan0_1_minor_major_link)
-{
-	zassert_true((test_task(1, 1) == TC_PASS));
-}
+FOR_EACH(TEST_LINKS, (), DMA_LIST)

--- a/tests/drivers/dma/cyclic/Kconfig
+++ b/tests/drivers/dma/cyclic/Kconfig
@@ -5,6 +5,10 @@ mainmenu "DMA Cyclic Test"
 
 source "Kconfig.zephyr"
 
+config DMA_LOOP_TRANSFER_NUMBER_OF_DMAS
+	int "Number of DMAs to test"
+	default 1
+
 config DMA_CYCLIC_CHANNEL_NR
 	int "DMA channel to use"
 	default 0

--- a/tests/drivers/dma/cyclic/boards/xmc45_relax_kit.overlay
+++ b/tests/drivers/dma/cyclic/boards/xmc45_relax_kit.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/cyclic/boards/xmc47_relax_kit.overlay
+++ b/tests/drivers/dma/cyclic/boards/xmc47_relax_kit.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/Kconfig
+++ b/tests/drivers/dma/scatter_gather/Kconfig
@@ -5,6 +5,10 @@ mainmenu "DMA Scatter Gather Test"
 
 source "Kconfig.zephyr"
 
+config DMA_LOOP_TRANSFER_NUMBER_OF_DMAS
+	int "Number of DMAs to test"
+	default 1
+
 config DMA_SG_CHANNEL_NR
 	int "DMA channel to use"
 	default 0

--- a/tests/drivers/dma/scatter_gather/boards/adp_xc7k_ae350.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/adp_xc7k_ae350.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
+test_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/adp_xc7k_ae350_clic.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/adp_xc7k_ae350_clic.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
+test_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/bg29_rb4420a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/bg29_rb4420a.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/cy8cproto_062_4343w.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/cy8cproto_062_4343w.overlay
@@ -1,13 +1,9 @@
 /*
+ * Copyright (c) 2025 Alex Apostolu
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/cyw920829m2evk_02.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/cyw920829m2evk_02.overlay
@@ -1,13 +1,9 @@
 /*
+ * Copyright (c) 2025 Alex Apostolu
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/frdm_k64f.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/frdm_k64f.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &edma0;
-	};
-};
+test_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/intel_adsp_ace15_mtpm.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/intel_adsp_ace15_mtpm.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &lpgpdma0;
-	};
-};
+test_dma0: &lpgpdma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/intel_socfpga_agilex5_socdk.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/intel_socfpga_agilex5_socdk.overlay
@@ -4,12 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
-	status = "okay";
-};
+test_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/lpcxpresso55s36.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/lpcxpresso55s36.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
+test_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/mimxrt1010_evk.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/mimxrt1010_evk.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &edma0;
-	};
-};
+test_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &edma0;
-	};
-};
+test_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &edma0;
-	};
-};
+test_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
+test_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
+test_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &edma0;
-	};
-};
-
-&edma0 {
+test_dma0: &edma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &edma5;
-	};
-};
-
-&edma5 {
+test_dma0: &edma5 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/siwx917_dk2605a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/siwx917_dk2605a.overlay
@@ -3,11 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-&dma0 {
+
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/siwx917_rb4338a.overlay
@@ -3,11 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-&dma0 {
+
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/siwx917_rb4342a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/siwx917_rb4342a.overlay
@@ -3,11 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-&dma0 {
+
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/sltb010a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/sltb010a.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/slwrb4180a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/slwrb4180a.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/xg23_rb4210a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xg23_rb4210a.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/xg24_dk2601b.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xg24_dk2601b.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/xg27_dk2602a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xg27_dk2602a.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/xg29_rb4412a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xg29_rb4412a.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/xmc45_relax_kit.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xmc45_relax_kit.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/xmc47_relax_kit.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xmc47_relax_kit.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+test_dma0: &dma0 {
 	status = "okay";
 };


### PR DESCRIPTION
Iterate over all testing dma nodes `test_dma_n` instead of using the hardcoded `dma0` node. This allows more flexibility in choosing what nodes to test, and is consistent with other DMA tests like `loop_transfer`.