### PR TITLE
doc: zbus: fix benchmark sample execution command error

### DIFF
--- a/samples/subsys/zbus/benchmark/README.rst
+++ b/samples/subsys/zbus/benchmark/README.rst
@@ -11,7 +11,7 @@ Building and Running
 ********************
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/subsys/zbus/dyn_channel
+   :zephyr-app: samples/subsys/zbus/benchmark
    :host-os: unix
    :board: qemu_cortex_m3
    :gen-args: -DCONFIG_BM_MESSAGE_SIZE=512 -DCONFIG_BM_ONE_TO=1 -DCONFIG_BM_LISTENERS=y


### PR DESCRIPTION
Correct the benchmark sample execution command in the sample's README. 

Fixes #98070