### PR TITLE
soc: silabs: siwx91x: increase main stack size when nwp is active

### DIFF
--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -20,6 +20,11 @@ if SILABS_SIWX91X_NWP
 config SYS_CLOCK_TICKS_PER_SEC
 	default 1024
 
+# Wiseconnect needs more than 1024 bytes of main stack size to initialize
+# (especially with PM)
+configdefault MAIN_STACK_SIZE
+	default 2048
+
 config NUM_PREEMPT_PRIORITIES
 	default 56
 


### PR DESCRIPTION
Update the default MAIN_STACK_SIZE to 2048 bytes to accommodate the initialization requirements of the network coprocessor (nwp), particularly when power management is enabled. It resolves a bug where we can't boot when PM is enabled with multiple active peripherals. (hardfault)