### PR TITLE
riscv: pmp: Clarify IRQ stack PMP index for SMP

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -482,6 +482,9 @@ void z_riscv_pmp_init(void)
 	/* Write those entries to PMP regs. */
 	write_pmp_entries(0, index, true, pmp_addr, pmp_cfg, ARRAY_SIZE(pmp_addr));
 #endif /* CONFIG_MULTITHREADING */
+#ifdef CONFIG_SMP
+	unsigned int irq_stack_pmp_index = index;
+#endif
 #else
 	 /* Write those entries to PMP regs. */
 	write_pmp_entries(0, index, true, pmp_addr, pmp_cfg, ARRAY_SIZE(pmp_addr));
@@ -494,7 +497,7 @@ void z_riscv_pmp_init(void)
 	 * Make sure TOR entry sharing won't be attempted with it by
 	 * remembering a bogus address for those entries.
 	 */
-	pmp_addr[index - 1] = -1L;
+	pmp_addr[irq_stack_pmp_index - 1] = -1L;
 #endif
 
 	/* Make sure secondary CPUs produced the same values */


### PR DESCRIPTION
Use `irq_stack_pmp_index` for per-CPU IRQ stack PMP index in SMP. This improves clarity by explicitly naming the index in `pmp_addr` that is being marked to prevent unintended TOR entry sharing.