### PR TITLE
tests: drivers: can: *: remove Kconfig based can_recover() skip

### DIFF
--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -1120,8 +1120,6 @@ ZTEST_USER(can_classic, test_recover)
 	can_mode_t cap;
 	int err;
 
-	Z_TEST_SKIP_IFNDEF(CONFIG_CAN_MANUAL_RECOVERY_MODE);
-
 	err = can_get_capabilities(can_dev, &cap);
 	zassert_equal(err, 0, "failed to get CAN capabilities (err %d)", err);
 
@@ -1337,8 +1335,6 @@ ZTEST_USER(can_classic, test_recover_while_stopped)
 {
 	can_mode_t cap;
 	int err;
-
-	Z_TEST_SKIP_IFNDEF(CONFIG_CAN_MANUAL_RECOVERY_MODE);
 
 	err = can_get_capabilities(can_dev, &cap);
 	zassert_equal(err, 0, "failed to get CAN capabilities (err %d)", err);

--- a/tests/drivers/can/shell/src/main.c
+++ b/tests/drivers/can/shell/src/main.c
@@ -572,8 +572,6 @@ static void can_shell_test_recover(const char *cmd, k_timeout_t expected)
 	const struct shell *sh = shell_backend_dummy_get_ptr();
 	int err;
 
-	Z_TEST_SKIP_IFNDEF(CONFIG_CAN_MANUAL_RECOVERY_MODE);
-
 	err = shell_execute_cmd(sh, cmd);
 	zassert_ok(err, "failed to execute shell command (err %d)", err);
 


### PR DESCRIPTION
Remove false `Z_TEST_SKIP_IFNDEF(CONFIG_CAN_MANUAL_RECOVERY_MODE)` from the CAN test suites.
    
The `can_recover()` API function must always be tested and `CONFIG_CAN_MANUAL_RECOVERY_MODE` is enabled in the test suites' `prj.conf`.
    
The test suites already rely on the capabilities of the CAN controller driver for determining how to validate the API contract.
