### PR TITLE
MAINTAINERS: add the newly added CANPico shield to the CAN area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1274,6 +1274,7 @@ Documentation Infrastructure:
     - martinjaeger
     - str4t0m
   files:
+    - boards/shields/canis_canpico/
     - boards/shields/mcp2515/
     - boards/shields/tcan4550evm/
     - doc/connectivity/canbus/


### PR DESCRIPTION
Add the newly added Canis Labs CANPico shield to the CAN area, similar to other CAN shields.