### PR TITLE
dts: microchip: pinctrl: pic32cx_sg: Add support for pincontrol

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -11,4 +11,5 @@ flash: 1024
 ram: 256
 supported:
   - gpio
+  - pinctrl
 vendor: microchip

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -38,22 +38,29 @@
 			reg = <0x20000000 DT_SIZE_K(256)>;
 		};
 
-		porta: gpio@41008000 {
-			status = "disabled";
-			compatible = "microchip,port-g1-gpio";
-			reg = <0x41008000 0x80>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			#microchip,pin-cells = <2>;
-		};
+		pinctrl: pinctrl@41008000 {
+			compatible = "microchip,port-g1-pinctrl";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x41008000 0x41008000 0x200>;
 
-		portb: gpio@41008080 {
-			status = "disabled";
-			compatible = "microchip,port-g1-gpio";
-			reg = <0x41008080 0x80>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			#microchip,pin-cells = <2>;
+			porta: gpio@41008000 {
+				compatible = "microchip,port-g1-gpio";
+				reg = <0x41008000 0x80>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#microchip,pin-cells = <2>;
+				status = "disabled";
+			};
+
+			portb: gpio@41008080 {
+				compatible = "microchip,port-g1-gpio";
+				reg = <0x41008080 0x80>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				#microchip,pin-cells = <2>;
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg_100.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg_100.dtsi
@@ -8,15 +8,13 @@
 
 #include <microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi>
 
-/ {
-	soc {
-		portc: gpio@41008100 {
-			status = "disabled";
-			compatible = "microchip,port-g1-gpio";
-			reg = <0x41008100 0x80>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			#microchip,pin-cells = <2>;
-		};
+&pinctrl {
+	portc: gpio@41008100 {
+		compatible = "microchip,port-g1-gpio";
+		reg = <0x41008100 0x80>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#microchip,pin-cells = <2>;
+		status = "disabled";
 	};
 };

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg_128.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg_128.dtsi
@@ -8,24 +8,22 @@
 
 #include <microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi>
 
-/ {
-	soc {
-		portc: gpio@41008100 {
-			status = "disabled";
-			compatible = "microchip,port-g1-gpio";
-			reg = <0x41008100 0x80>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			#microchip,pin-cells = <2>;
-		};
+&pinctrl {
+	portc: gpio@41008100 {
+		compatible = "microchip,port-g1-gpio";
+		reg = <0x41008100 0x80>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#microchip,pin-cells = <2>;
+		status = "disabled";
+	};
 
-		portd: gpio@41008180 {
-			status = "disabled";
-			compatible = "microchip,port-g1-gpio";
-			reg = <0x41008180 0x80>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			#microchip,pin-cells = <2>;
-		};
+	portd: gpio@41008180 {
+		compatible = "microchip,port-g1-gpio";
+		reg = <0x41008180 0x80>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#microchip,pin-cells = <2>;
+		status = "disabled";
 	};
 };

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg_80.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg_80.dtsi
@@ -8,15 +8,13 @@
 
 #include <microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi>
 
-/ {
-	soc {
-		portc: gpio@41008100 {
-			status = "disabled";
-			compatible = "microchip,port-g1-gpio";
-			reg = <0x41008100 0x80>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			#microchip,pin-cells = <2>;
-		};
+&pinctrl {
+	portc: gpio@41008100 {
+		compatible = "microchip,port-g1-gpio";
+		reg = <0x41008100 0x80>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#microchip,pin-cells = <2>;
+		status = "disabled";
 	};
 };

--- a/soc/microchip/pic32c/pic32cx_sg/common/CMakeLists.txt
+++ b/soc/microchip/pic32c/pic32cx_sg/common/CMakeLists.txt
@@ -1,4 +1,6 @@
 # Copyright (c) 2025 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_include_directories(.)
+
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/microchip/pic32c/pic32cx_sg/common/pinctrl_soc.h
+++ b/soc/microchip/pic32c/pic32cx_sg/common/pinctrl_soc.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SOC_MICROCHIP_PIC32C_PIC32CX_SG_COMMON_PINCTRL_SOC_H
+#define ZEPHYR_SOC_MICROCHIP_PIC32C_PIC32CX_SG_COMMON_PINCTRL_SOC_H
+
+#include <zephyr/devicetree.h>
+#include <zephyr/types.h>
+#include <dt-bindings/pic32c/pic32cx_sg/common/mchp_pinctrl_pinmux_pic32c.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @brief Structure representing the pin control settings for a SOC pin.
+ *
+ * This structure is used to define the pinmux and pin configuration settings
+ * for a specific pin on the SOC. It includes information about the port, pin,
+ * function, bias, drive, and other configuration options.
+ */
+typedef struct pinctrl_soc_pin {
+	/** Pinmux settings (port, pin and function). */
+	uint16_t pinmux;
+	/** Pin configuration (bias, drive etc). */
+	uint16_t pinflag;
+} pinctrl_soc_pin_t;
+
+/**
+ * @brief Utility macro to initialize pinmux field.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name.
+ * @param idx Property entry index.
+ */
+#define Z_PINCTRL_MCHP_PINMUX_INIT(node_id, prop, idx) DT_PROP_BY_IDX(node_id, prop, idx)
+
+/**
+ * @brief Utility macro to initialize each pin flag.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name.
+ * @param idx Property entry index.
+ */
+#define Z_PINCTRL_MCHP_PINFLAG_INIT(node_id, prop, idx)                                            \
+	((DT_PROP(node_id, bias_pull_up) << MCHP_PINCTRL_PULLUP_POS) |                             \
+	 (DT_PROP(node_id, bias_pull_down) << MCHP_PINCTRL_PULLDOWN_POS) |                         \
+	 (DT_PROP(node_id, input_enable) << MCHP_PINCTRL_INPUTENABLE_POS) |                        \
+	 (DT_PROP(node_id, output_enable) << MCHP_PINCTRL_OUTPUTENABLE_POS) |                      \
+	 (DT_ENUM_IDX(node_id, drive_strength) << MCHP_PINCTRL_DRIVESTRENGTH_POS)),
+
+/**
+ * @brief Utility macro to initialize each pin.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name.
+ * @param idx Property entry index.
+ */
+#define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)                                               \
+	{.pinmux = Z_PINCTRL_MCHP_PINMUX_INIT(node_id, prop, idx),                                 \
+	 .pinflag = Z_PINCTRL_MCHP_PINFLAG_INIT(node_id, prop, idx)},
+
+/**
+ * @brief Utility macro to initialize state pins contained in a given property.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name describing state pins.
+ */
+#define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)                                                   \
+	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop), DT_FOREACH_PROP_ELEM, pinmux,           \
+				Z_PINCTRL_STATE_PIN_INIT)}
+
+/** @endcond */
+
+/**
+ * @brief Pin flags/attributes
+ * @anchor MCHP_PINFLAGS
+ *
+ * @{
+ */
+
+#define MCHP_PINCTRL_FLAGS_DEFAULT     (0U)
+#define MCHP_PINCTRL_FLAGS_POS         (0U)
+#define MCHP_PINCTRL_FLAGS_MASK        (0x3F << MCHP_PINCTRL_FLAGS_POS)
+#define MCHP_PINCTRL_FLAG_MASK         (1U)
+#define MCHP_PINCTRL_PULLUP_POS        (MCHP_PINCTRL_FLAGS_POS)
+#define MCHP_PINCTRL_PULLUP            (1U << MCHP_PINCTRL_PULLUP_POS)
+#define MCHP_PINCTRL_PULLDOWN_POS      (MCHP_PINCTRL_PULLUP_POS + 1U)
+#define MCHP_PINCTRL_PULLDOWN          (1U << MCHP_PINCTRL_PULLDOWN_POS)
+#define MCHP_PINCTRL_OPENDRAIN_POS     (MCHP_PINCTRL_PULLDOWN_POS + 1U)
+#define MCHP_PINCTRL_OPENDRAIN         (1U << MCHP_PINCTRL_OPENDRAIN_POS)
+#define MCHP_PINCTRL_INPUTENABLE_POS   (MCHP_PINCTRL_OPENDRAIN_POS + 1U)
+#define MCHP_PINCTRL_INPUTENABLE       (1U << MCHP_PINCTRL_INPUTENABLE_POS)
+#define MCHP_PINCTRL_OUTPUTENABLE_POS  (MCHP_PINCTRL_INPUTENABLE_POS + 1U)
+#define MCHP_PINCTRL_OUTPUTENABLE      (1U << MCHP_PINCTRL_OUTPUTENABLE_POS)
+#define MCHP_PINCTRL_DRIVESTRENGTH_POS (MCHP_PINCTRL_OUTPUTENABLE_POS + 1U)
+#define MCHP_PINCTRL_DRIVESTRENGTH     (1U << MCHP_PINCTRL_DRIVESTRENGTH_POS)
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*ZEPHYR_SOC_MICROCHIP_PIC32C_PIC32CX_SG_COMMON_PINCTRL_SOC_H*/

--- a/west.yml
+++ b/west.yml
@@ -195,7 +195,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: ac9c1231020d29aa0285a4e63b66f465b3942eed
+      revision: 89754d87258945ceb1cff8ecee0ddd8852396ae8
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
- Adds support for pincontrol for pic32cx_sg family
- Added device tree nodes for pincontrol
- Uses pincontrol g1 driver

Associated pull request for the addition of the pincontrol definitions to hal_microchip:
https://github.com/zephyrproject-rtos/hal_microchip/pull/44