### PR TITLE
drivers: fuel_gauge: ltc2959: Fix build warnings from declarations

### DIFF
--- a/drivers/fuel_gauge/ltc2959/ltc2959.c
+++ b/drivers/fuel_gauge/ltc2959/ltc2959.c
@@ -461,7 +461,7 @@ static int ltc2959_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	int ret;
 
 	switch (prop) {
-	case FUEL_GAUGE_STATUS:
+	case FUEL_GAUGE_STATUS: {
 		uint8_t raw_st;
 
 		ret = i2c_reg_read_byte_dt(&cfg->i2c, LTC2959_REG_STATUS, &raw_st);
@@ -473,8 +473,8 @@ static int ltc2959_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		val->fg_status = raw_st;
 
 		break;
-
-	case FUEL_GAUGE_VOLTAGE:
+	}
+	case FUEL_GAUGE_VOLTAGE: {
 		uint16_t raw_voltage;
 
 		ret = ltc2959_read16(dev, LTC2959_REG_VOLTAGE_MSB, &raw_voltage);
@@ -490,8 +490,8 @@ static int ltc2959_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		val->voltage = raw_voltage * LTC2959_VOLT_UV_SF;
 
 		return 0;
-
-	case FUEL_GAUGE_CURRENT:
+	}
+	case FUEL_GAUGE_CURRENT: {
 		uint16_t raw_current;
 
 		ret = ltc2959_read16(dev, LTC2959_REG_CURRENT_MSB, &raw_current);
@@ -506,8 +506,8 @@ static int ltc2959_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		val->current = current_raw * cfg->current_lsb_ua;
 
 		break;
-
-	case FUEL_GAUGE_TEMPERATURE:
+	}
+	case FUEL_GAUGE_TEMPERATURE: {
 		uint16_t raw_temp;
 
 		ret = ltc2959_read16(dev, LTC2959_REG_TEMP_MSB, &raw_temp);
@@ -525,8 +525,8 @@ static int ltc2959_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		 */
 		val->temperature = ((uint32_t)raw_temp * LTC2959_TEMP_K_SF) >> 16;
 		break;
-
-	case FUEL_GAUGE_REMAINING_CAPACITY:
+	}
+	case FUEL_GAUGE_REMAINING_CAPACITY: {
 		uint32_t acr;
 
 		ret = ltc2959_read_acr(dev, &acr);
@@ -537,7 +537,7 @@ static int ltc2959_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 
 		val->remaining_capacity = ltc2959_counts_to_uah(acr, cfg);
 		break;
-
+	}
 	case FUEL_GAUGE_ADC_MODE:
 		ret = ltc2959_get_adc_mode(dev, &val->adc_mode);
 		break;
@@ -636,7 +636,7 @@ static int ltc2959_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		ret = ltc2959_set_cc_config(dev, val.cc_config);
 		break;
 
-	case FUEL_GAUGE_REMAINING_CAPACITY:
+	case FUEL_GAUGE_REMAINING_CAPACITY: {
 		uint32_t counts = ltc2959_uah_to_counts(val.remaining_capacity, cfg);
 
 		if (counts == LTC2959_ACR_CLR) {
@@ -644,7 +644,7 @@ static int ltc2959_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		}
 		ret = ltc2959_write_acr(dev, counts);
 		break;
-
+	}
 	default:
 		ret = -ENOTSUP;
 		break;


### PR DESCRIPTION
C standards prior to C23 do not allow variable declarations immediately after labels. Wrap such declarations in blocks to eliminate build warnings. Should hopefully fix the CI failure occurring in main https://github.com/zephyrproject-rtos/zephyr/actions/runs/18721827138/job/53395989790

Tested locally on `native_sim`:
```bash
$ west build -p -b native_sim/native tests/drivers/fuel_gauge/ltc2959 -T drivers.fuel_gauge.ltc2959 --
-DZEPHYR_TOOLCHAIN_VARIANT=llvm
```

```
/home/tahsin/zephyr/zephyr/drivers/fuel_gauge/ltc2959/ltc2959.c:465:3: warning: label followed by a declaration is a C23 extension [-Wc23-extensions]
  465 |                 uint8_t raw_st;
      |                 ^
/home/tahsin/zephyr/zephyr/drivers/fuel_gauge/ltc2959/ltc2959.c:478:3: warning: label followed by a declaration is a C23 extension [-Wc23-extensions]
  478 |                 uint16_t raw_voltage;
      |                 ^
/home/tahsin/zephyr/zephyr/drivers/fuel_gauge/ltc2959/ltc2959.c:495:3: warning: label followed by a declaration is a C23 extension [-Wc23-extensions]
  495 |                 uint16_t raw_current;
      |                 ^
/home/tahsin/zephyr/zephyr/drivers/fuel_gauge/ltc2959/ltc2959.c:511:3: warning: label followed by a declaration is a C23 extension [-Wc23-extensions]
  511 |                 uint16_t raw_temp;
      |                 ^
/home/tahsin/zephyr/zephyr/drivers/fuel_gauge/ltc2959/ltc2959.c:530:3: warning: label followed by a declaration is a C23 extension [-Wc23-extensions]
  530 |                 uint32_t acr;
      |                 ^
/home/tahsin/zephyr/zephyr/drivers/fuel_gauge/ltc2959/ltc2959.c:640:3: warning: label followed by a declaration is a C23 extension [-Wc23-extensions]
  640 |                 uint32_t counts = ltc2959_uah_to_counts(val.remaining_capacity, cfg);
      |                 ^
6 warnings generated.
[110/112] Linking C executable zephyr/zephyr.elf
Generating files from /home/tahsin/zephyr/zephyr/build/zephyr/zephyr.elf for board: native_sim
[112/112] Running utility command for native_runner_executable
```

Warnings go away after applying the patch:
```
-- west build: building application
[1/112] Preparing syscall dependency handling

[3/112] Generating include/generated/zephyr/version.h
-- Zephyr version: 4.2.99 (/home/tahsin/zephyr/zephyr), build: v4.2.0-6706-g4842828358b5
[110/112] Linking C executable zephyr/zephyr.elf
Generating files from /home/tahsin/zephyr/zephyr/build/zephyr/zephyr.elf for board: native_sim
[112/112] Running utility command for native_runner_executable
```