### PR TITLE
tests: Bluetooth: Tester: Fix accessing out of scope variables in  VCP

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_vcp.c
+++ b/tests/bluetooth/tester/src/audio/btp_vcp.c
@@ -465,10 +465,10 @@ struct bt_aics_cb aics_server_cb = {
 /* General profile handling */
 static void set_register_params(uint8_t gain_mode)
 {
-	char input_desc[CONFIG_BT_VCP_VOL_REND_AICS_INSTANCE_COUNT]
-		       [BT_AICS_MAX_INPUT_DESCRIPTION_SIZE];
-	char output_desc[CONFIG_BT_VCP_VOL_REND_VOCS_INSTANCE_COUNT]
-			[BT_AICS_MAX_OUTPUT_DESCRIPTION_SIZE];
+	static char input_desc[CONFIG_BT_VCP_VOL_REND_AICS_INSTANCE_COUNT]
+			      [BT_AICS_MAX_INPUT_DESCRIPTION_SIZE];
+	static char output_desc[CONFIG_BT_VCP_VOL_REND_VOCS_INSTANCE_COUNT]
+			      [BT_AICS_MAX_OUTPUT_DESCRIPTION_SIZE];
 
 	memset(&vcp_register_param, 0, sizeof(vcp_register_param));
 


### PR DESCRIPTION
Input and output descriptors are writable storage for VCP parameters and shall be valid for use duration. This fix usage of variables being used outside of their declaration scope.