### PR TITLE
Bluetooth: Fix double set random address for every advertising enable

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1509,12 +1509,14 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 	if (atomic_test_bit(adv->flags, BT_ADV_CONNECTABLE)) {
 		if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
 		    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY) &&
-		    !atomic_test_and_clear_bit(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED)) {
+		    (atomic_test_bit(adv->flags, BT_PER_ADV_ENABLED) ||
+		     !atomic_test_and_clear_bit(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED))) {
 			bt_id_set_adv_private_addr(adv);
 		}
 	} else {
 		if (!atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY) &&
-		    !atomic_test_and_clear_bit(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED)) {
+		    (atomic_test_bit(adv->flags, BT_PER_ADV_ENABLED) ||
+		     !atomic_test_and_clear_bit(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED))) {
 			bt_id_set_adv_private_addr(adv);
 		}
 	}

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1509,14 +1509,14 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 	if (atomic_test_bit(adv->flags, BT_ADV_CONNECTABLE)) {
 		if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
 		    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY) &&
-		    (atomic_test_bit(adv->flags, BT_PER_ADV_ENABLED) ||
-		     !atomic_test_and_clear_bit(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED))) {
+		    (!atomic_test_and_clear_bit(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED) ||
+		     atomic_test_bit(adv->flags, BT_PER_ADV_ENABLED))) {
 			bt_id_set_adv_private_addr(adv);
 		}
 	} else {
 		if (!atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY) &&
-		    (atomic_test_bit(adv->flags, BT_PER_ADV_ENABLED) ||
-		     !atomic_test_and_clear_bit(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED))) {
+		    (!atomic_test_and_clear_bit(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED) ||
+		     atomic_test_bit(adv->flags, BT_PER_ADV_ENABLED))) {
 			bt_id_set_adv_private_addr(adv);
 		}
 	}

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1176,6 +1176,9 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 	atomic_set_bit_to(adv->flags, BT_ADV_EXT_ADV,
 			  param->options & BT_LE_ADV_OPT_EXT_ADV);
 
+	atomic_set_bit_to(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED,
+			  own_addr_type == BT_HCI_OWN_ADDR_RANDOM);
+
 	return 0;
 }
 
@@ -1505,11 +1508,13 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 
 	if (atomic_test_bit(adv->flags, BT_ADV_CONNECTABLE)) {
 		if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
-		    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
+		    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY) &&
+		    !atomic_test_and_clear_bit(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED)) {
 			bt_id_set_adv_private_addr(adv);
 		}
 	} else {
-		if (!atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
+		if (!atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY) &&
+		    !atomic_test_and_clear_bit(adv->flags, BT_ADV_RANDOM_ADDR_UPDATED)) {
 			bt_id_set_adv_private_addr(adv);
 		}
 	}

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -116,6 +116,10 @@ enum {
 	BT_ADV_PARAMS_SET,
 	/* Advertising data has been set in the controller. */
 	BT_ADV_DATA_SET,
+	/* Advertising random address has been updated in the controller before
+	 * enabling advertising.
+	 */
+	BT_ADV_RANDOM_ADDR_UPDATED,
 	/* Advertising random address pending to be set in the controller. */
 	BT_ADV_RANDOM_ADDR_PENDING,
 	/* The private random address of the advertiser is valid for this cycle

--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -264,20 +264,20 @@ void start_broadcast_adv(struct bt_le_ext_adv *adv)
 		return;
 	}
 
-	if (info.ext_adv_state == BT_LE_EXT_ADV_STATE_DISABLED) {
-		/* Start extended advertising */
-		err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
-		if (err != 0) {
-			FAIL("Failed to start extended advertising: %d\n", err);
-			return;
-		}
-	}
-
 	if (info.per_adv_state == BT_LE_PER_ADV_STATE_DISABLED) {
 		/* Enable Periodic Advertising */
 		err = bt_le_per_adv_start(adv);
 		if (err != 0) {
 			FAIL("Failed to enable periodic advertising: %d\n", err);
+			return;
+		}
+	}
+
+	if (info.ext_adv_state == BT_LE_EXT_ADV_STATE_DISABLED) {
+		/* Start extended advertising */
+		err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
+		if (err != 0) {
+			FAIL("Failed to start extended advertising: %d\n", err);
 			return;
 		}
 	}


### PR DESCRIPTION
For Bluetooth Mesh, all Mesh messages will use private address by default, and then will call `bt_le_ext_adv_update_param`
for Mesh message, this function will call `bt_id_set_adv_own_addr` to set controller random address

But when call `bt_le_ext_adv_start` to start advertising, will also call `bt_id_set_adv_private_addr` to set new random address, that is duplicated, BTW, also increase latency to send mesh message, because every hci command/event complete/status need time.

This PR also fix two bbsim test problem:
1. Mesh relay, look like timing changed after this PR, not real problem.
2. PAST, look like address in `ADV_EXT_IND`, `AUX_ADV_IND` shall not same with `ADV_SYNC_IND`;