### PR TITLE
Support watchdog for frdm_mcxe31b

### DIFF
--- a/boards/nxp/frdm_mcxe31b/CMakeLists.txt
+++ b/boards/nxp/frdm_mcxe31b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_library_sources(board.c)
 if(CONFIG_BOARD_NXP_MCXE31X_BOOT_HEADER)
   zephyr_library_sources(boot_header/boot_header.c)
   zephyr_library_include_directories(boot_header)

--- a/boards/nxp/frdm_mcxe31b/Kconfig
+++ b/boards/nxp/frdm_mcxe31b/Kconfig
@@ -1,6 +1,9 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
+config BOARD_FRDM_MCXE31B
+	select BOARD_EARLY_INIT_HOOK
+
 config BOARD_NXP_MCXE31X_BOOT_HEADER
 	bool "MCXE31x boot header support"
 	select SOC_NXP_MCXE31X_BOOT_HEADER
@@ -10,3 +13,15 @@ config BOARD_NXP_MCXE31X_BOOT_HEADER
 	  image. The boot header is required for proper operation of the
 	  on-chip bootloader.
 	  See the MCXE31x reference manual for more details.
+
+config CLEAR_DESTRUCTIVE_RESET_FLAG
+	hex "Clear destructive reset flag"
+	default 0x0
+	help
+	  Clear the destructive reset flag to ensure proper system initialization
+
+config CLEAR_FUNCTIONAL_RESET_FLAG
+	hex "Clear functional reset flag"
+	default 0x0
+	help
+	  Clear the functional reset flag to ensure proper system initialization

--- a/boards/nxp/frdm_mcxe31b/board.c
+++ b/boards/nxp/frdm_mcxe31b/board.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/devicetree.h>
+#include <zephyr/platform/hooks.h>
+#include <soc.h>
+
+#if CONFIG_BOARD_EARLY_INIT_HOOK
+void board_early_init_hook(void)
+{
+#if defined(CONFIG_CLEAR_DESTRUCTIVE_RESET_FLAG) && (CONFIG_CLEAR_DESTRUCTIVE_RESET_FLAG)
+	MC_RGM->DES = CONFIG_CLEAR_DESTRUCTIVE_RESET_FLAG;
+#endif /* CONFIG_CLEAR_DESTRUCTIVE_RESET_FLAG */
+
+#if defined(CONFIG_CLEAR_FUNCTIONAL_RESET_FLAG) && (CONFIG_CLEAR_FUNCTIONAL_RESET_FLAG)
+	MC_RGM->FES = CONFIG_CLEAR_FUNCTIONAL_RESET_FLAG;
+#endif
+}
+
+#endif /* CONFIG_BOARD_EARLY_INIT_HOOK */

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
@@ -22,6 +22,7 @@
 		led2 = &blue_led;
 		sw0 = &user_button;
 		rtc = &counter_rtc;
+		watchdog0 = &swt_0;
 	};
 
 	chosen {
@@ -180,5 +181,9 @@
 };
 
 &counter_rtc {
+	status = "okay";
+};
+
+&swt_0 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
@@ -14,4 +14,5 @@ supported:
   - arduino_gpio
   - gpio
   - rtc
+  - watchdog
 vendor: nxp

--- a/drivers/clock_control/clock_control_nxp_mc_cgm.c
+++ b/drivers/clock_control/clock_control_nxp_mc_cgm.c
@@ -187,6 +187,9 @@ static int mc_cgm_get_subsys_rate(const struct device *dev, clock_control_subsys
 	uint32_t clock_name = (uint32_t)sub_system;
 
 	switch (clock_name) {
+	case MCUX_SIRC_CLK:
+		*rate = CLOCK_SIRC_CLK_FREQ;
+		break;
 #if defined(CONFIG_UART_MCUX_LPUART)
 	case MCUX_LPUART0_CLK:
 	case MCUX_LPUART8_CLK:

--- a/drivers/watchdog/wdt_nxp_s32.c
+++ b/drivers/watchdog/wdt_nxp_s32.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 NXP
+ * Copyright 2022-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +16,18 @@
 LOG_MODULE_REGISTER(swt_nxp_s32);
 
 /* Software Watchdog Timer (SWT) register definitions */
+#ifdef PERI_SWT_H_
+#define SWT_CR          0x0
+#define SWT_CR_MAP_MASK GENMASK(31, 24)
+#define SWT_CR_MAP(v)   FIELD_PREP(SWT_CR_MAP_MASK, (v))
+#define SWT_IR          0x4
+#define SWT_TO          0x8
+#define SWT_WN          0xc
+#define SWT_SR          0x10
+#define SWT_CO          0x14
+#define SWT_SK          0x18
+#define SWT_RRR         0x1c
+#else
 /* Control */
 #define SWT_CR           0x0
 #define SWT_CR_WEN_MASK  BIT(0)
@@ -66,6 +78,7 @@ LOG_MODULE_REGISTER(swt_nxp_s32);
 #define SWT_RRR          0x1c
 #define SWT_RRR_RRF_MASK BIT(0)
 #define SWT_RRR_RRF(v)   FIELD_PREP(SWT_RRR_RRF_MASK, (v))
+#endif
 
 #define SWT_TO_WTO_MIN 0x100
 
@@ -208,8 +221,8 @@ static int swt_nxp_s32_disable(const struct device *dev)
 	int err;
 
 	if (!FIELD_GET(SWT_CR_WEN_MASK, REG_READ(SWT_CR))) {
-		LOG_ERR("Watchdog is not enabled");
-		return -EFAULT;
+		LOG_DBG("watchdog already disabled");
+		return 0;
 	}
 
 	err = swt_unlock(config);

--- a/dts/arm/nxp/nxp_mcxe31x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxe31x_common.dtsi
@@ -994,9 +994,11 @@
 	};
 
 	swt_0: swt@270000 {
-		compatible = "nxp,swt";
+		compatible = "nxp,s32-swt";
 		reg = <0x270000 0x3c>;
 		interrupts = <42 0>;
+		clocks = <&mc_cgm MCUX_SIRC_CLK>;
+		service-mode = "fixed";
 		status = "disabled";
 	};
 

--- a/tests/drivers/watchdog/wdt_basic_api/boards/frdm_mcxe31b.conf
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/frdm_mcxe31b.conf
@@ -1,0 +1,4 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CLEAR_DESTRUCTIVE_RESET_FLAG=0x1


### PR DESCRIPTION
Use the existing `nxp_s32_swt` driver.