### PR TITLE
Ambiq sdhc update

### DIFF
--- a/boards/ambiq/apollo510_evb/apollo510_evb.dts
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.dts
@@ -29,6 +29,7 @@
 		sw0 = &button0;
 		sw1 = &button1;
 		pwm-led0 = &pwm_led0;
+		sdhc0 = &sdio0;
 	};
 
 	sram0: memory@SSRAM_BASE_NAME {

--- a/drivers/sdhc/Kconfig.ambiq
+++ b/drivers/sdhc/Kconfig.ambiq
@@ -22,10 +22,17 @@ config AMBIQ_SDIO_ASYNC
 	help
 	  This option enables Ambiq SDIO Async Mode.
 
+config SDHC_AMBIQ_HANDLE_CACHE
+	bool "Turn on cache handling in SDHC driver"
+	default y
+	depends on CACHE_MANAGEMENT && DCACHE
+	help
+	  Disable this if cache has been handled in upper layers.
+
 config SDHC_BUFFER_ALIGNMENT
-	default 32 if DCACHE
+	default DCACHE_LINE_SIZE if DCACHE
 	default 16
 	help
-	  SDHC buffer should be 32bytes aligned when placed in cacheable region.
+	  SDHC buffer should aligned to the value of DCACHE_LINE_SIZE when placed in a cacheable region.
 
 endif

--- a/drivers/sdhc/sdhc_ambiq.c
+++ b/drivers/sdhc/sdhc_ambiq.c
@@ -166,6 +166,9 @@ static int ambiq_sdio_get_host_props(const struct device *dev, struct sdhc_host_
 	props->host_caps.adma_2_support = true;
 	props->host_caps.sdio_async_interrupt_support = true;
 	props->host_caps.vol_180_support = true;
+#if defined(CONFIG_SOC_SERIES_APOLLO5X)
+	props->host_caps.vol_330_support = true;
+#endif
 	props->host_caps.bus_4_bit_support = true;
 	props->host_caps.bus_8_bit_support = true;
 	props->host_caps.high_spd_support = true;
@@ -511,7 +514,7 @@ static int ambiq_sdio_request(const struct device *dev, struct sdhc_command *cmd
 	LOG_DBG("Send SDIO CMD%d", sdio_cmd.ui8Idx);
 	LOG_DBG("CMD->Arg = 0x%x CMD->RespType = 0x%x", sdio_cmd.ui32Arg, sdio_cmd.ui32RespType);
 
-	if (sdio_cmd.ui8Idx == 1) {
+	if (sdio_cmd.ui8Idx == 1 || sdio_cmd.ui8Idx == 41) {
 		LOG_DBG("Config CMD1 RespType");
 		sdio_cmd.ui32RespType = MMC_RSP_R3;
 	} else if (sdio_cmd.ui8Idx == 3) {
@@ -525,7 +528,7 @@ static int ambiq_sdio_request(const struct device *dev, struct sdhc_command *cmd
 		sdio_cmd.bCheckBusyCmd = true;
 		sdio_cmd.ui32RespType = MMC_RSP_R1b;
 	} else if (sdio_cmd.ui8Idx == 17 || sdio_cmd.ui8Idx == 18 || sdio_cmd.ui8Idx == 24 ||
-		   sdio_cmd.ui8Idx == 25) {
+		   sdio_cmd.ui8Idx == 25 || sdio_cmd.ui8Idx == 55) {
 		sdio_cmd.ui32RespType = MMC_RSP_R1;
 	}
 

--- a/drivers/sdhc/sdhc_ambiq.c
+++ b/drivers/sdhc/sdhc_ambiq.c
@@ -21,7 +21,6 @@
 
 LOG_MODULE_REGISTER(ambiq_sdio, CONFIG_SDHC_LOG_LEVEL);
 
-#define CACHABLE_START_ADDR SSRAM_BASEADDR
 #if defined(CONFIG_SOC_SERIES_APOLLO4X)
 #define SDIO_BASE_ADDR     SDIO_BASE
 #define SDIO_ADDR_INTERVAL 1
@@ -551,13 +550,12 @@ static int ambiq_sdio_request(const struct device *dev, struct sdhc_command *cmd
 	}
 
 	if (data) {
-#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
-		/* Clean Dcache before DMA write */
-		if (cmd_data.dir == AM_HAL_DATA_DIR_WRITE &&
-		    (uint32_t)(data->data) >= CACHABLE_START_ADDR) {
+#if CONFIG_SDHC_AMBIQ_HANDLE_CACHE
+		if (!buf_in_nocache((uintptr_t)data->data, data->blocks * data->block_size)) {
+			/* Clean Dcache before DMA write or after memset*/
 			sys_cache_data_flush_range(data->data, data->blocks * data->block_size);
 		}
-#endif
+#endif /* CONFIG_SDHC_AMBIQ_HANDLE_CACHE */
 
 #ifdef CONFIG_AMBIQ_SDIO_ASYNC
 		k_sem_reset(dev_data->async_sem);
@@ -572,17 +570,19 @@ static int ambiq_sdio_request(const struct device *dev, struct sdhc_command *cmd
 		}
 #endif /* CONFIG_AMBIQ_SDIO_ASYNC */
 
-#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
-		/* Invalidate Dcache after DMA read */
-		if (cmd_data.dir == AM_HAL_DATA_DIR_READ &&
-		    (uint32_t)(data->data) >= CACHABLE_START_ADDR) {
-			sys_cache_data_invd_range(data->data, data->blocks * data->block_size);
+#if CONFIG_SDHC_AMBIQ_HANDLE_CACHE
+		if (!buf_in_nocache((uintptr_t)data->data, data->blocks * data->block_size)) {
+			/* Invalidate Dcache after DMA read */
+			if (cmd_data.dir == AM_HAL_DATA_DIR_READ) {
+				sys_cache_data_invd_range(data->data,
+							  data->blocks * data->block_size);
+			}
 		}
-#endif
+#endif /* CONFIG_SDHC_AMBIQ_HANDLE_CACHE */
 
 	} else {
-		ui32Status =
-			dev_data->host->ops->execute_cmd(dev_data->host->pHandle, &sdio_cmd, NULL);
+		ui32Status = dev_data->host->ops->execute_cmd(dev_data->host->pHandle,
+							      &sdio_cmd, NULL);
 	}
 	if ((ui32Status & 0xFFFF) != AM_HAL_STATUS_SUCCESS) {
 		if ((ui32Status & 0xFFFF) == AM_HAL_STATUS_TIMEOUT) {


### PR DESCRIPTION
Update ambiq sdhc driver for apollo series
 1. Deleted PM device macro definition
 2. Added SD card support
 3. Added buf_in_nocache to check buffer cacheability
 4. Added sdio aliases in dts.