### PR TITLE
boards: seeed: xiao_nrf54l15: update Kconfig and DTS for ROM start of…

### DIFF
--- a/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuapp.dts
+++ b/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuapp.dts
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Seeed Technology Co., Ltd.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -44,9 +45,11 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &cpuapp_sram;
 		zephyr,flash = &cpuapp_rram;
+		zephyr,flash-controller = &rram_controller;
 		zephyr,console = &uart20;
 		zephyr,shell-uart = &uart20;
 		nordic,rpc-uart = &uart20;
+		zephyr,ieee802154 = &ieee802154;
 	};
 
 	aliases {


### PR DESCRIPTION
Set the starting address to 0 if the partition manager is enabled.
Designate the flash controller as rram_controller. 
Enable IEEE 802.15.4 wireless communication support.