### PR TITLE
shell: modules: devmem: support 64-bit read & write

### DIFF
--- a/include/zephyr/arch/arc/sys-io-common.h
+++ b/include/zephyr/arch/arc/sys-io-common.h
@@ -74,6 +74,26 @@ static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 	compiler_barrier();
 }
 
+#ifdef CONFIG_64BIT
+static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
+{
+	uint64_t value;
+
+	compiler_barrier();
+	value = *(volatile uint64_t *)addr;
+	compiler_barrier();
+
+	return value;
+}
+
+static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
+{
+	compiler_barrier();
+	*(volatile uint64_t *)addr = data;
+	compiler_barrier();
+}
+#endif /* CONFIG_64BIT */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Combination of #98055 and #97875

Tested:
```
west build -p -b qemu_arc/qemu_arc_hs6x tests/drivers/eeprom/shell -T drivers.eeprom.shell
west build -p -b qemu_arc/qemu_arc_hs6x tests/subsys/shell/shell_custom_header -T shell.shell_custom_header
```

that failed in https://github.com/zephyrproject-rtos/zephyr/actions/runs/18708256236/job/53350518248