### PR TITLE
drivers: spi: renesas: Fix issues with spi_bitbang sample on RZ/A3UL

### DIFF
--- a/drivers/spi/spi_renesas_rz_rspi.c
+++ b/drivers/spi/spi_renesas_rz_rspi.c
@@ -164,11 +164,6 @@ static int spi_rz_rspi_configure(const struct device *dev, const struct spi_conf
 	spi_bit_width_t spi_width;
 	fsp_err_t err;
 
-	if (spi_context_configured(&data->ctx, spi_cfg)) {
-		/* This configuration is already in use */
-		return 0;
-	}
-
 	if (data->fsp_ctrl->open != 0) {
 		config->fsp_api->close(data->fsp_ctrl);
 	}

--- a/dts/arm64/renesas/rz/rza/r9a07g063.dtsi
+++ b/dts/arm64/renesas/rz/rza/r9a07g063.dtsi
@@ -891,6 +891,7 @@
 			channel = <2>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			status = "disabled";
 		};
 
 		gtm0: gtm@12801000 {


### PR DESCRIPTION
- Add status property to spi2 node in RZ/A3UL devicetree
- When running the spi_bitbang sample on the RZ/A3UL, the config struct in the functions test_basic_write_9bit_words, test_9bit_loopback_partial and test_8bit_xfer are initialized at the same memory address. As a result, when the spi_rz_rspi_configure calling spi_context_configured is executed, the config struct of test_8bit_xfer is ignored. This causes incorrect data transmission because the word size is not configured. Therefore, the spi_context_configured variable should be removed to avoid this issue.