### PR TITLE
testsuite: Do not specify dump method if hardware coverage is not set

### DIFF
--- a/subsys/testsuite/Kconfig.coverage
+++ b/subsys/testsuite/Kconfig.coverage
@@ -61,6 +61,8 @@ config COVERAGE_GCOV_HEAP_SIZE
 	  data to be dumped over serial. If the value is 0, no buffer will be used,
 	  data will be dumped directly over serial.
 
+if COVERAGE_GCOV
+
 choice COVERAGE_DUMP_METHOD
 	prompt "Method to dump coverage data"
 	default COVERAGE_DUMP
@@ -77,6 +79,8 @@ config COVERAGE_SEMIHOST
 	  Use semihosting to write coverage data to a file on the host.
 
 endchoice
+
+endif # COVERAGE_GCOV
 
 config FORCE_COVERAGE
 	bool "Force coverage"


### PR DESCRIPTION
After #94079, CONFIG_COVERAGE_DUMP is enabled even if CONFIG_COVERAGE is not set. As a result CONFIG_ZTEST_NO_YIELD is disabled which has some implications on other tests.

Coverage dump method is necessary only if coverage is collected on hardware, which is enabled by CONFIG_COVERAGE_GCOV. Let's specify default dump method, only if CONFIG_COVERAGE_GCOV is set.

Fixes: #94079