### PR TITLE
native_simulator: Get latest from upstream

### DIFF
--- a/scripts/native_simulator/common/src/nct.c
+++ b/scripts/native_simulator/common/src/nct.c
@@ -61,6 +61,7 @@
 #define NCT_DEBUG_PRINTS 0
 
 /* For pthread_setname_np() */
+#undef _GNU_SOURCE
 #define _GNU_SOURCE
 #include <stdbool.h>
 #include <stdlib.h>


### PR DESCRIPTION
Align with native_simulator's upstream main
95f560a2140aacb03a74b8c933f3b27a59c56d50
    
Which includes:
95f560a: nct: fix possible redefinition of GNU_SOURCE