### PR TITLE
drivers: syscon: Preparation for NVMEM usage

### DIFF
--- a/drivers/syscon/CMakeLists.txt
+++ b/drivers/syscon/CMakeLists.txt
@@ -2,4 +2,8 @@
 
 zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_SYSCON_GENERIC          syscon.c)
+zephyr_library_sources_ifdef(CONFIG_SYSCON_SHELL            syscon_shell.c)
+
+# zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_SYSCON_BFLB_EFUSE       syscon_bflb_efuse.c)
+# zephyr-keep-sorted-stop

--- a/drivers/syscon/CMakeLists.txt
+++ b/drivers/syscon/CMakeLists.txt
@@ -6,4 +6,5 @@ zephyr_library_sources_ifdef(CONFIG_SYSCON_SHELL            syscon_shell.c)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_SYSCON_BFLB_EFUSE       syscon_bflb_efuse.c)
+zephyr_library_sources_ifdef(CONFIG_SYSCON_IMX_OCOTP        syscon_imx_ocotp.c)
 # zephyr-keep-sorted-stop

--- a/drivers/syscon/Kconfig
+++ b/drivers/syscon/Kconfig
@@ -38,6 +38,12 @@ config SYSCON_INIT_PRIORITY
 	  initialized earlier in the startup cycle. If unsure, leave at default
 	  value
 
+config SYSCON_SHELL
+	bool "SYSCON Shell"
+	depends on SHELL
+	help
+	  Enable the SYSCON shell with SYSCON related commands.
+
 source "drivers/syscon/Kconfig.bflb_efuse"
 
 endif # SYSCON

--- a/drivers/syscon/Kconfig
+++ b/drivers/syscon/Kconfig
@@ -44,6 +44,9 @@ config SYSCON_SHELL
 	help
 	  Enable the SYSCON shell with SYSCON related commands.
 
+# zephyr-keep-sorted-start
 source "drivers/syscon/Kconfig.bflb_efuse"
+source "drivers/syscon/Kconfig.nxp_imx_ocotp"
+# zephyr-keep-sorted-stop
 
 endif # SYSCON

--- a/drivers/syscon/Kconfig.nxp_imx_ocotp
+++ b/drivers/syscon/Kconfig.nxp_imx_ocotp
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Basalte bv
+# SPDX-License-Identifier: Apache-2.0
+
+config SYSCON_IMX_OCOTP
+	bool "NXP i.MX on-chip OTP (OCOTP)"
+	default y
+	depends on DT_HAS_NXP_IMX_OCOTP_ENABLED
+	help
+	  OCOTP access via SYSCON API for NXP i.MX platforms.

--- a/drivers/syscon/syscon.c
+++ b/drivers/syscon/syscon.c
@@ -103,11 +103,19 @@ static int syscon_generic_get_size(const struct device *dev, size_t *size)
 	return 0;
 }
 
+static int syscon_generic_get_reg_width(const struct device *dev)
+{
+	const struct syscon_generic_config *config = dev->config;
+
+	return config->reg_width;
+}
+
 static DEVICE_API(syscon, syscon_generic_driver_api) = {
 	.read = syscon_generic_read_reg,
 	.write = syscon_generic_write_reg,
 	.get_base = syscon_generic_get_base,
 	.get_size = syscon_generic_get_size,
+	.get_reg_width = syscon_generic_get_reg_width,
 };
 
 static int syscon_generic_init(const struct device *dev)

--- a/drivers/syscon/syscon_common.h
+++ b/drivers/syscon/syscon_common.h
@@ -18,8 +18,9 @@ extern "C" {
  * @param reg Pointer to the register address in question.
  * @param reg_size The size of the syscon register region.
  * @param reg_width The width of a single register (in bytes).
- * @return 0 if the register read is valid.
- * @return -EINVAL is the read is invalid.
+ *
+ * @retval 0 if the register read is valid.
+ * @retval -EINVAL if the read is invalid.
  */
 static inline int syscon_sanitize_reg(uint16_t *reg, size_t reg_size, uint8_t reg_width)
 {

--- a/drivers/syscon/syscon_imx_ocotp.c
+++ b/drivers/syscon/syscon_imx_ocotp.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025 Basalte bv
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_imx_ocotp
+
+#include <zephyr/drivers/syscon.h>
+#include <zephyr/kernel.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(imx_ocotp, CONFIG_SYSCON_LOG_LEVEL);
+
+#include <fsl_ocotp.h>
+
+struct imx_ocotp_config {
+	OCOTP_Type *base;
+	size_t size;
+};
+
+static int imx_ocotp_read_reg(const struct device *dev, uint16_t reg, uint32_t *val)
+{
+	const struct imx_ocotp_config *cfg = dev->config;
+	status_t status;
+
+	status = OCOTP_ReadFuseShadowRegisterExt(cfg->base, reg, val, 1);
+
+	return status == kStatus_Success ? 0 : -EIO;
+}
+
+static int imx_ocotp_write_reg(const struct device *dev, uint16_t reg, uint32_t val)
+{
+	const struct imx_ocotp_config *cfg = dev->config;
+	status_t status;
+
+	status = OCOTP_WriteFuseShadowRegister(cfg->base, reg, val);
+
+	return status == kStatus_Success ? 0 : -EIO;
+}
+
+static int imx_ocotp_get_base(const struct device *dev, uintptr_t *addr)
+{
+	const struct imx_ocotp_config *cfg = dev->config;
+
+	*addr = (uintptr_t)cfg->base;
+
+	return 0;
+}
+
+static int imx_ocotp_get_size(const struct device *dev, size_t *size)
+{
+	const struct imx_ocotp_config *cfg = dev->config;
+
+	*size = cfg->size;
+
+	return 0;
+}
+
+static int imx_ocotp_get_reg_width(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return sizeof(uint32_t);
+}
+
+static DEVICE_API(syscon, imx_ocotp_driver_api) = {
+	.read = imx_ocotp_read_reg,
+	.write = imx_ocotp_write_reg,
+	.get_base = imx_ocotp_get_base,
+	.get_size = imx_ocotp_get_size,
+	.get_reg_width = imx_ocotp_get_reg_width,
+};
+
+static int imx_ocotp_init(const struct device *dev)
+{
+	const struct imx_ocotp_config *cfg = dev->config;
+
+	/* FIXME: Better clock control support possible? */
+#if defined(CONFIG_SOC_SERIES_IMXRT10XX)
+	OCOTP_Init(cfg->base, CLOCK_GetIpgFreq());
+#elif defined(CONFIG_SOC_SERIES_IMXRT11XX)
+	OCOTP_Init(cfg->base, 0);
+#else
+#error "Unsupported SoC"
+#endif
+
+	return 0;
+}
+
+#define SYSCON_INIT(inst)                                                                          \
+	static const struct imx_ocotp_config imx_ocotp_config_##inst = {                           \
+		.base = (OCOTP_Type *)DT_INST_REG_ADDR(inst),                                      \
+		.size = DT_INST_PROP(inst, size),                                                  \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, imx_ocotp_init, NULL, NULL, &imx_ocotp_config_##inst,          \
+			      PRE_KERNEL_1, CONFIG_SYSCON_INIT_PRIORITY, &imx_ocotp_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(SYSCON_INIT);

--- a/drivers/syscon/syscon_shell.c
+++ b/drivers/syscon/syscon_shell.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2025 Basalte bv
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief SYSCON shell commands.
+ */
+
+#include <zephyr/shell/shell.h>
+#include <zephyr/drivers/syscon.h>
+
+static int cmd_base(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	uintptr_t base;
+	int ret;
+
+	dev = shell_device_get_binding(argv[1]);
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "SYSCON device not ready");
+		return -ENODEV;
+	}
+
+	ret = syscon_get_base(dev, &base);
+	if (ret < 0) {
+		shell_error(sh, "Failed to get SYSCON base (%d)", ret);
+		return ret;
+	}
+
+	shell_print(sh, "0x%lx", base);
+	return 0;
+}
+
+static int cmd_read(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	unsigned long addr;
+	uint32_t val;
+	int ret;
+
+	dev = shell_device_get_binding(argv[1]);
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "SYSCON device not ready");
+		return -ENODEV;
+	}
+
+	addr = shell_strtoul(argv[2], 0, &ret);
+	if (ret < 0 || addr > UINT16_MAX) {
+		shell_error(sh, "Invalid address %s (%d)", argv[2], ret);
+		return -EINVAL;
+	}
+
+	ret = syscon_read_reg(dev, addr, &val);
+	if (ret < 0) {
+		shell_error(sh, "Failed to read (%d)", ret);
+		return ret;
+	}
+
+	shell_print(sh, "0x%x", val);
+	return 0;
+}
+
+static int cmd_write(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	unsigned long addr, val;
+	int ret;
+
+	dev = shell_device_get_binding(argv[1]);
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "SYSCON device not ready");
+		return -ENODEV;
+	}
+
+	addr = shell_strtoul(argv[2], 0, &ret);
+	if (ret < 0 || addr > UINT16_MAX) {
+		shell_error(sh, "Invalid address %s (%d)", argv[2], ret);
+		return -EINVAL;
+	}
+
+	val = shell_strtoul(argv[3], 0, &ret);
+	if (ret < 0 || val > UINT32_MAX) {
+		shell_error(sh, "Invalid value %s (%d)", argv[3], ret);
+		return -EINVAL;
+	}
+
+	ret = syscon_write_reg(dev, addr, val);
+	if (ret < 0) {
+		shell_error(sh, "Failed to write (%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int cmd_size(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	size_t size;
+	int ret;
+
+	dev = shell_device_get_binding(argv[1]);
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "SYSCON device not ready");
+		return -ENODEV;
+	}
+
+	ret = syscon_get_size(dev, &size);
+	if (ret < 0) {
+		shell_error(sh, "Failed to get SYSCON size (%d)", ret);
+		return ret;
+	}
+
+	shell_print(sh, "%zu bytes", size);
+	return 0;
+}
+
+static int cmd_width(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	int ret;
+
+	dev = shell_device_get_binding(argv[1]);
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "SYSCON device not ready");
+		return -ENODEV;
+	}
+
+	ret = syscon_get_reg_width(dev);
+	if (ret < 0) {
+		shell_error(sh, "Failed to get SYSCON register width (%d)", ret);
+		return ret;
+	}
+
+	shell_print(sh, "%d bytes", ret);
+	return 0;
+}
+
+static bool device_is_syscon(const struct device *dev)
+{
+	return DEVICE_API_IS(syscon, dev);
+}
+
+/* Device name autocompletion support */
+static void device_name_get(size_t idx, struct shell_static_entry *entry)
+{
+	const struct device *dev = shell_device_filter(idx, device_is_syscon);
+
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+}
+
+SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(syscon_cmds,
+	SHELL_CMD_ARG(base, &dsub_device_name,
+		      SHELL_HELP("Get the SYSCON device base address", "<device>"),
+		      cmd_base, 2, 0),
+	SHELL_CMD_ARG(read, &dsub_device_name,
+		      SHELL_HELP("Read from a SYSCON device register", "<device> <address>"),
+		      cmd_read, 3, 0),
+	SHELL_CMD_ARG(write, &dsub_device_name,
+		      SHELL_HELP("Write to a SYSCON device register", "<device> <address> <value>"),
+		      cmd_write, 4, 0),
+	SHELL_CMD_ARG(size, &dsub_device_name,
+		      SHELL_HELP("Print the SYSCON device size in bytes", "<device>"),
+		      cmd_size, 2, 0),
+	SHELL_CMD_ARG(width, &dsub_device_name,
+		      SHELL_HELP("Print the SYSCON register width in bytes", "<device>"),
+		      cmd_width, 2, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(syscon, &syscon_cmds, "SYSCON shell commands", NULL);

--- a/dts/arm/nxp/nxp_rt1060.dtsi
+++ b/dts/arm/nxp/nxp_rt1060.dtsi
@@ -29,6 +29,11 @@
 	};
 };
 
+&ocotp {
+	/* i.MX RT106X has 16 additional 32-bit registers */
+	size = <256>;
+};
+
 / {
 	soc {
 		/* i.MX rt1060 has a second Ethernet controller. */

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -161,6 +161,13 @@
 			#size-cells = <1>;
 		};
 
+		ocotp: ocotp@401f4000 {
+			compatible = "nxp,imx-ocotp";
+			reg = <0x401f4000 0x4000>;
+			size = <192>;
+			status = "okay";
+		};
+
 		/* GPT1 is used for the hardware timer, not as a standard counter */
 		gpt_hw_timer: gpt@401ec000 {
 			compatible = "nxp,gpt-hw-timer";

--- a/dts/bindings/syscon/nxp,imx-ocotp.yaml
+++ b/dts/bindings/syscon/nxp,imx-ocotp.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 Basalte bv
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP i.MX On-Chip OTP
+
+compatible: "nxp,imx-ocotp"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  size:
+    required: true
+    type: int
+    description: Size of OTP storage (bytes)

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -72,8 +72,9 @@ __subsystem struct syscon_driver_api {
  *
  * @param dev The device to get the register size for.
  * @param addr Where to write the base address.
- * @return 0 When @a addr was written to.
- * @return -ENOSYS If the API or function isn't implemented.
+ *
+ * @retval 0 When @a addr was written to.
+ * @retval -ENOSYS If the API or function isn't implemented.
  */
 __syscall int syscon_get_base(const struct device *dev, uintptr_t *addr);
 
@@ -98,8 +99,8 @@ static inline int z_impl_syscon_get_base(const struct device *dev, uintptr_t *ad
  * @param reg The register offset
  * @param val The returned value read from the syscon register
  *
- * @return 0 on success.
- * @return -ENOSYS If the API or function isn't implemented.
+ * @retval 0 on success.
+ * @retval -ENOSYS If the API or function isn't implemented.
  */
 __syscall int syscon_read_reg(const struct device *dev, uint16_t reg, uint32_t *val);
 
@@ -124,8 +125,8 @@ static inline int z_impl_syscon_read_reg(const struct device *dev, uint16_t reg,
  * @param reg The register offset
  * @param val The value to be written in the register
  *
- * @return 0 on success.
- * @return -ENOSYS If the API or function isn't implemented.
+ * @retval 0 on success.
+ * @retval -ENOSYS If the API or function isn't implemented.
  */
 __syscall int syscon_write_reg(const struct device *dev, uint16_t reg, uint32_t val);
 
@@ -145,8 +146,9 @@ static inline int z_impl_syscon_write_reg(const struct device *dev, uint16_t reg
  *
  * @param dev The device to get the register size for.
  * @param size Pointer to write the size to.
- * @return 0 for success.
- * @return -ENOSYS If the API or function isn't implemented.
+ *
+ * @retval 0 on success.
+ * @retval -ENOSYS If the API or function isn't implemented.
  */
 __syscall int syscon_get_size(const struct device *dev, size_t *size);
 

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -58,6 +58,13 @@ typedef int (*syscon_api_write_reg)(const struct device *dev, uint16_t reg, uint
 typedef int (*syscon_api_get_size)(const struct device *dev, size_t *size);
 
 /**
+ * API template to get the width of the syscon register.
+ *
+ * @see syscon_get_reg_width
+ */
+typedef int (*syscon_api_get_reg_width)(const struct device *dev);
+
+/**
  * @brief System Control (syscon) register driver API
  */
 __subsystem struct syscon_driver_api {
@@ -65,6 +72,7 @@ __subsystem struct syscon_driver_api {
 	syscon_api_write_reg write;
 	syscon_api_get_base get_base;
 	syscon_api_get_size get_size;
+	syscon_api_get_reg_width get_reg_width;
 };
 
 /**
@@ -161,6 +169,27 @@ static inline int z_impl_syscon_get_size(const struct device *dev, size_t *size)
 	}
 
 	return api->get_size(dev, size);
+}
+
+/**
+ * Get the width of the syscon registers in bytes.
+ *
+ * @param dev The device to get the register size for.
+ *
+ * @retval -ENOSYS If the API or function isn't implemented.
+ * @return The width of the syscon registers in bytes.
+ */
+__syscall int syscon_get_reg_width(const struct device *dev);
+
+static inline int z_impl_syscon_get_reg_width(const struct device *dev)
+{
+	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
+
+	if ((api == NULL) || (api->get_reg_width == NULL)) {
+		return -ENOSYS;
+	}
+
+	return api->get_reg_width(dev);
 }
 
 /**


### PR DESCRIPTION
This PR has the necessary bits to make the SYSCON API usable in NVMEM. Some of the parts

- Add a `syscon_get_reg_width` API function to determine how many bytes are read
- Add shell commands for easy testing
- Implement i.MX OCOTP SYSCON driver

This work relates to https://github.com/zephyrproject-rtos/zephyr/pull/96598 as the OCOTP SYSCON driver will be used as an NVMEM backend. This allows to rework the following with NVMEM:

https://github.com/zephyrproject-rtos/zephyr/blob/8aba2e3f3aa87deb9c8606ef54fddca1d936d031/drivers/ethernet/eth_nxp_enet.c#L646-L673