### PR TITLE
net_buf: change return type of net_buf_max_len as size_t

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -1375,6 +1375,14 @@ Settings
 
 * ``CONFIG_SETTINGS_TFM_ITS`` has been renamed to :kconfig:option:`CONFIG_SETTINGS_TFM_PSA`.
 
+Net buf
+========
+
+* The return type of :c:type:`net_buf_simple_max_len` has changed from ``uint16_t`` to
+  ``size_t``. (:github:`98144`)
+* The return type of :c:type:`net_buf_max_len` has changed from ``uint16_t`` to
+  ``size_t``. (:github:`98144`)
+
 Modules
 *******
 

--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -938,7 +938,7 @@ size_t net_buf_simple_tailroom(const struct net_buf_simple *buf);
  *
  * @return Number of bytes usable behind the net_buf_simple::data pointer.
  */
-uint16_t net_buf_simple_max_len(const struct net_buf_simple *buf);
+size_t net_buf_simple_max_len(const struct net_buf_simple *buf);
 
 /**
  * @brief Parsing state of a buffer.
@@ -2557,7 +2557,7 @@ static inline size_t net_buf_headroom(const struct net_buf *buf)
  *
  * @return Number of bytes usable behind the net_buf::data pointer.
  */
-static inline uint16_t net_buf_max_len(const struct net_buf *buf)
+static inline size_t net_buf_max_len(const struct net_buf *buf)
 {
 	return net_buf_simple_max_len(&buf->b);
 }

--- a/lib/net_buf/buf_simple.c
+++ b/lib/net_buf/buf_simple.c
@@ -620,7 +620,7 @@ size_t net_buf_simple_tailroom(const struct net_buf_simple *buf)
 	return buf->size - net_buf_simple_headroom(buf) - buf->len;
 }
 
-uint16_t net_buf_simple_max_len(const struct net_buf_simple *buf)
+size_t net_buf_simple_max_len(const struct net_buf_simple *buf)
 {
 	return buf->size - net_buf_simple_headroom(buf);
 }

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -426,7 +426,7 @@ static inline void net_pkt_print_buffer_info(struct net_pkt *pkt, const char *st
 	}
 
 	while (buf) {
-		printk("%p[%ld/%u (%u/%u)]", buf, atomic_get(&pkt->atomic_ref),
+		printk("%p[%ld/%u (%zu/%u)]", buf, atomic_get(&pkt->atomic_ref),
 		       buf->len, net_buf_max_len(buf), buf->size);
 
 		buf = buf->frags;

--- a/subsys/net/lib/shell/pkt.c
+++ b/subsys/net/lib/shell/pkt.c
@@ -113,7 +113,7 @@ static void net_pkt_buffer_info(const struct shell *sh, struct net_pkt *pkt)
 	}
 
 	while (buf) {
-		PR("%p[%ld/%u (%u/%u)]", buf, atomic_get(&pkt->atomic_ref),
+		PR("%p[%ld/%u (%zu/%u)]", buf, atomic_get(&pkt->atomic_ref),
 		   buf->len, net_buf_max_len(buf), buf->size);
 
 		buf = buf->frags;


### PR DESCRIPTION
Change net_buf_max_len to use size_t as return value type to align with the rest of the net_buf APIs.