### PR TITLE
scripts: kconfig: improve search results ordering using scoring

### DIFF
--- a/scripts/kconfig/config_utils.py
+++ b/scripts/kconfig/config_utils.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Common utilities for Kconfig configuration interfaces.
+
+This module provides shared functionality for menuconfig.py and guiconfig.py.
+"""
+
+import re
+
+from kconfiglib import Choice, Symbol
+
+
+def score_search_matches(search_str, nodes):
+    """
+    Scores and sorts search results for Kconfig nodes based on relevance.
+
+    This implements a basic scoring system where:
+    - A match in a symbol's name is given more weight than a match in its prompt
+    - Field-length normalization is applied so that the shorter the field, the higher its relevance
+
+    Args:
+        search_str: The search string (space-separated regexes)
+        nodes: List of MenuNode objects to search through
+
+    Returns:
+        List of tuples (node, score) sorted by score (highest first)
+    """
+    # Parse the search string into regexes
+    try:
+        regexes = [re.compile(regex.lower()) for regex in search_str.split()]
+        # If no regexes, all nodes match, order is unchanged
+        if len(regexes) == 0:
+            return [(node, 1) for node in nodes]
+    except re.error:
+        # Invalid regex - return empty results
+        return []
+
+    NAME_WEIGHT = 2.0
+    PROMPT_WEIGHT = 1.0
+
+    scored_results = []
+
+    for node in nodes:
+        # Get lowercase versions for matching
+        name = ""
+        if isinstance(node.item, Symbol | Choice):
+            name = node.item.name.lower() if node.item.name else ""
+
+        prompt = node.prompt[0].lower() if node.prompt else ""
+
+        # Check if all regexes match in either name or prompt
+        name_matches = name and all(regex.search(name) for regex in regexes)
+        prompt_matches = prompt and all(regex.search(prompt) for regex in regexes)
+
+        if not (name_matches or prompt_matches):
+            continue
+
+        # Apply field-length normalization (shorter fields = higher relevance)
+        score = 0
+        if name_matches:
+            score += NAME_WEIGHT / (len(name) ** 0.5)
+        if prompt_matches:
+            score += PROMPT_WEIGHT / (len(prompt) ** 0.5)
+
+        scored_results.append((node, score))
+
+    # Sort by score (highest first)
+    scored_results.sort(key=lambda x: x[1], reverse=True)
+
+    return scored_results

--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -61,23 +61,11 @@ $srctree is supported through Kconfiglib.
 import errno
 import os
 import re
-import sys
 
-_PY2 = sys.version_info[0] < 3
-
-if _PY2:
-    # Python 2
-    from Tkinter import *
-    import ttk
-    import tkFont as font
-    import tkFileDialog as filedialog
-    import tkMessageBox as messagebox
-else:
-    # Python 3
-    from tkinter import *
-    import tkinter.ttk as ttk
-    import tkinter.font as font
-    from tkinter import filedialog, messagebox
+from tkinter import *
+import tkinter.ttk as ttk
+import tkinter.font as font
+from tkinter import filedialog, messagebox
 
 from kconfiglib import Symbol, Choice, MENU, COMMENT, MenuNode, \
                        BOOL, TRISTATE, STRING, INT, HEX, \
@@ -1123,11 +1111,6 @@ def _change_node(node, parent):
 
     if sc.type in (INT, HEX, STRING):
         s = _set_val_dialog(node, parent)
-
-        # Tkinter can return 'unicode' strings on Python 2, which Kconfiglib
-        # can't deal with. UTF-8-encode the string to work around it.
-        if _PY2 and isinstance(s, unicode):
-            s = s.encode("utf-8", "ignore")
 
         if s is not None:
             _set_val(sc, s)

--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -489,7 +489,7 @@ def _create_kconfig_tree_and_desc(parent):
     # Panedwindow and the Treeview. This code is shared between the main window
     # and the jump-to dialog.
 
-    panedwindow = ttk.Panedwindow(parent, orient=VERTICAL)
+    panedwindow = ttk.Panedwindow(parent, orient="vertical")
 
     tree_frame, tree = _create_kconfig_tree(panedwindow)
     desc_frame, desc = _create_kconfig_desc(panedwindow)

--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -1144,7 +1144,6 @@ def _jump_to(node):
     global _cur_menu
     global _shown
     global _sel_node_i
-    global _menu_scroll
     global _show_all
     global _parent_screen_rows
 


### PR DESCRIPTION
This implements the same improved sorting algorithm as was recently added to the documentation (see zephyrproject-rtos/zephyr#98016), namely:

- A match in a Kconfig symbol's name is given more weight than a match in its prompt.
- Field-length normalization is applied so that the shorter the field, the higher its relevance (e.g. searching for "sensor" will now basically yield CONFIG_SENSOR as the top result as the query basically matches 100% of the symbol's name.

Also clean up guiconfig script to get rid of legacy Python 2 support that's actually getting in the way by making CI compliance checks (PyLint and PyCompat) unhappy