### PR TITLE
drivers: watchdog: document and enforce semantics of `WDT_DISABLE_AT_BOOT`

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -694,6 +694,27 @@ Video
 * The :dtcompatible:`ovti,ov2640` reset pin handling has been corrected, resulting in an inverted
   active level compared to before, to match the active level expected by the sensor.
 
+Watchdog
+========
+
+  * The semantics of :kconfig:option:`CONFIG_WDT_DISABLE_AT_BOOT` have been clarified: the expected
+    behavior when ``CONFIG_WDT_DISABLE_AT_BOOT=n``, which was unclear and implemented inconsistently
+    across drivers, is now explicitly documented in :kconfig:option:`CONFIG_WDT_DISABLE_AT_BOOT`'s
+    description (refer to it for more details).
+
+    All in-tree watchdog drivers have been updated to follow the now documented semantics.
+
+    Notably, ``CONFIG_WDT_DISABLE_AT_BOOT=n`` can no longer be used to have watchdog(s) enabled at
+    boot "*automatically*". Users which relied on this behavior must update their application to
+    explicitly configure a watchdog, as done in the :zephyr:code-sample:`watchdog`. The following
+    Kconfig options related to this incorrect usage have been removed:
+
+      * ``CONFIG_IWDG_STM32_INITIAL_TIMEOUT``
+      * ``CONFIG_WDT_RPI_PICO_INITIAL_TIMEOUT``
+      * ``CONFIG_WDT_CC13XX_CC26XX_INITIAL_TIMEOUT``
+      * ``CONFIG_WDT_CC23X0_INITIAL_TIMEOUT``
+      * ``CONFIG_WDT_CC32XX_INITIAL_TIMEOUT``
+
 .. zephyr-keep-sorted-stop
 
 Bluetooth

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -13,12 +13,27 @@ if WATCHDOG
 
 config HAS_WDT_DISABLE_AT_BOOT
 	bool
+	help
+	  This hidden symbol must be selected by drivers which
+	  implement support for a watchdog timer that is enabled
+	  by default after system reset.
 
 config WDT_DISABLE_AT_BOOT
-	bool "Disable at boot"
+	bool "Disable watchdog timers at boot"
 	depends on HAS_WDT_DISABLE_AT_BOOT
 	help
-	  Disable watchdog at Zephyr system startup.
+	  Disable watchdog timers during Zephyr system startup.
+
+	  This option has no effect when disabled and only applies to drivers
+	  that select HAS_WDT_DISABLE_AT_BOOT. Drivers that do not select
+	  HAS_WDT_DISABLE_AT_BOOT must ignore this option.
+
+	  When enabled, all watchdog timer instances enabled in Devicetree must
+	  be disabled by their respective drivers during instance initialization.
+
+	  Note that enabling this option may render certain watchdog timers
+	  unusable by the application, depending on the hardware implementation
+	  (e.g., if the timer cannot be re-enabled after being disabled).
 
 config HAS_WDT_NO_CALLBACKS
 	bool

--- a/drivers/watchdog/Kconfig.andes_atcwdt200
+++ b/drivers/watchdog/Kconfig.andes_atcwdt200
@@ -9,7 +9,6 @@ config WDT_ANDES_ATCWDT200
 	bool "Andes Watchdog driver"
 	default y
 	depends on DT_HAS_ANDESTECH_ATCWDT200_ENABLED
-	select HAS_WDT_DISABLE_AT_BOOT
 	select COUNTER
 	help
 	  Enable driver for the Andes Watchdog driver.

--- a/drivers/watchdog/Kconfig.cc13xx_cc26xx
+++ b/drivers/watchdog/Kconfig.cc13xx_cc26xx
@@ -5,17 +5,5 @@ config WDT_CC13XX_CC26XX
 	bool "Watchdog Driver for CC13xx / CC26xx family of MCUs"
 	default y
 	depends on DT_HAS_TI_CC13XX_CC26XX_WATCHDOG_ENABLED
-	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable watchdog for CC13xx / CC26xx family of MCUs
-
-config WDT_CC13XX_CC26XX_INITIAL_TIMEOUT
-	int "Value for initial WDT timeout in ms"
-	depends on WDT_CC13XX_CC26XX
-	default 2000
-	range 1 2863311
-	help
-	  The CC13xx/CC26xx watchdog timer is sourced from the MCU clock
-	  using a fixed prescaler of 32.
-	  E.g., for the standard 48 MHz MCU clock, the following:
-	  0xFFFFFFFF / (48^9 / 32 / 1000) [ms]

--- a/drivers/watchdog/Kconfig.cc23x0
+++ b/drivers/watchdog/Kconfig.cc23x0
@@ -5,15 +5,5 @@ config WDT_CC23X0
 	bool "Watchdog Driver for CC23x0 family of MCUs"
 	default y
 	depends on DT_HAS_TI_CC23X0_WDT_ENABLED
-	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable watchdog for CC23x0 family of MCUs
-
-config WDT_CC23X0_INITIAL_TIMEOUT
-	int "Value for initial WDT timeout in ms"
-	depends on WDT_CC23X0
-	default 2000
-	range 1 131072
-	help
-	  The CC23x0 watchdog timer is sourced from the LFOSC 32.768 clock
-	  Resolution is 32768 ticks per ms

--- a/drivers/watchdog/Kconfig.cc32xx
+++ b/drivers/watchdog/Kconfig.cc32xx
@@ -5,15 +5,5 @@ config WDT_CC32XX
 	bool "Watchdog Driver for cc32xx family of MCUs"
 	default y
 	depends on DT_HAS_TI_CC32XX_WATCHDOG_ENABLED
-	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Watchdog for cc32xx family of MCUs
-
-config WDT_CC32XX_INITIAL_TIMEOUT
-	int "Value for WDT timeout in ms"
-	depends on WDT_CC32XX
-	default 2000
-	range 1 53687
-	help
-	  Max value depend on system frequency.
-	  80 Mhz: 0xFFFFFFFF / (80e9 / 1000)

--- a/drivers/watchdog/Kconfig.dw
+++ b/drivers/watchdog/Kconfig.dw
@@ -7,6 +7,5 @@ config WDT_DW
 	bool "Synopsys DesignWare Watchdog driver"
 	default y
 	depends on DT_HAS_SNPS_DESIGNWARE_WATCHDOG_ENABLED
-	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Synopsys DesignWare Watchdog driver.

--- a/drivers/watchdog/Kconfig.esp32
+++ b/drivers/watchdog/Kconfig.esp32
@@ -7,7 +7,6 @@ config WDT_ESP32
 	bool "ESP32 Watchdog (WDT) Driver"
 	default y
 	depends on DT_HAS_ESPRESSIF_ESP32_WATCHDOG_ENABLED
-	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable WDT driver for ESP32.
 

--- a/drivers/watchdog/Kconfig.gd32
+++ b/drivers/watchdog/Kconfig.gd32
@@ -5,7 +5,6 @@ config FWDGT_GD32
 	bool "GD32 Free watchdog timer (FWDGT) driver"
 	default y
 	depends on DT_HAS_GD_GD32_FWDGT_ENABLED
-	select HAS_WDT_DISABLE_AT_BOOT
 	select USE_GD32_FWDGT
 	help
 	  Enable the Free watchdog timer (FWDGT) driver for GD32 SoCs.

--- a/drivers/watchdog/Kconfig.litex
+++ b/drivers/watchdog/Kconfig.litex
@@ -7,6 +7,5 @@ config WDT_LITEX
 	bool "LiteX Watchdog (WDT) Driver"
 	default y
 	depends on DT_HAS_LITEX_WATCHDOG_ENABLED
-	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable WDT driver for LiteX.

--- a/drivers/watchdog/Kconfig.rpi_pico
+++ b/drivers/watchdog/Kconfig.rpi_pico
@@ -5,16 +5,4 @@ config WDT_RPI_PICO
 	bool "Raspberry Pi Pico Watchdog driver"
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_WATCHDOG_ENABLED
-	select HAS_WDT_DISABLE_AT_BOOT
 	select HAS_WDT_NO_CALLBACKS
-
-config WDT_RPI_PICO_INITIAL_TIMEOUT
-	int "Default watchdog timeout in us"
-	depends on WDT_RPI_PICO
-	default 8388607
-	range 1 8388607
-	help
-	  Sets the default watchdog timeout at start-up, the feed function must
-	  be called every interval prior to this time elapsing to prevent a
-	  reboot of the module. The default is just over 8 seconds, which is the
-	  largest timeout possible.

--- a/drivers/watchdog/Kconfig.stm32
+++ b/drivers/watchdog/Kconfig.stm32
@@ -5,11 +5,10 @@
 # Copyright (c) 2019 Centaur Analytics, Inc
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig IWDG_STM32
+config IWDG_STM32
 	bool "Independent Watchdog (IWDG) Driver for STM32 family of MCUs"
 	default y
 	depends on DT_HAS_ST_STM32_WATCHDOG_ENABLED
-	select HAS_WDT_DISABLE_AT_BOOT
 	select HAS_WDT_NO_CALLBACKS
 	help
 	  Enable IWDG driver for STM32 line of MCUs

--- a/drivers/watchdog/wdt_andes_atcwdt200.c
+++ b/drivers/watchdog/wdt_andes_atcwdt200.c
@@ -315,13 +315,6 @@ static int wdt_atcwdt200_init(const struct device *dev)
 
 	counter_start(pit_counter_dev);
 
-#ifdef CONFIG_WDT_DISABLE_AT_BOOT
-	wdt_atcwdt200_disable(dev);
-#else
-	data->timeout_valid = true;
-	wdt_atcwdt200_set_max_timeout(dev);
-	wdt_atcwdt200_setup(dev, 0x0);
-#endif
 	return 0;
 }
 

--- a/drivers/watchdog/wdt_cc13xx_cc26xx.c
+++ b/drivers/watchdog/wdt_cc13xx_cc26xx.c
@@ -201,16 +201,7 @@ static int wdt_cc13xx_cc26xx_init(const struct device *dev)
 	LOG_DBG("init");
 	config->irq_cfg_func();
 
-	if (IS_ENABLED(CONFIG_WDT_DISABLE_AT_BOOT)) {
-		return 0;
-	}
-
-#ifdef CONFIG_DEBUG
-	/* when CONFIG_DEBUG is enabled, pause the WDT during debugging */
-	options = WDT_OPT_PAUSE_HALTED_BY_DBG;
-#endif /* CONFIG_DEBUG */
-
-	return wdt_cc13xx_cc26xx_setup(dev, options);
+	return 0;
 }
 
 static DEVICE_API(wdt, wdt_cc13xx_cc26xx_api) = {
@@ -232,8 +223,7 @@ static DEVICE_API(wdt, wdt_cc13xx_cc26xx_api) = {
 		irq_enable(DT_INST_IRQN(index));				 \
 	}									 \
 	static struct wdt_cc13xx_cc26xx_data wdt_cc13xx_cc26xx_data_##index = {	 \
-		.reload = WATCHDOG_MS_TO_TICKS(					 \
-			CONFIG_WDT_CC13XX_CC26XX_INITIAL_TIMEOUT),		 \
+		.reload = 0,							 \
 		.cb = NULL,							 \
 		.flags = 0,							 \
 	};									 \

--- a/drivers/watchdog/wdt_cc23x0.c
+++ b/drivers/watchdog/wdt_cc23x0.c
@@ -95,13 +95,6 @@ static int wdt_cc23x0_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static int wdt_cc23x0_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static DEVICE_API(wdt, wdt_cc23x0_api) = {
 	.setup = wdt_cc23x0_setup,
 	.disable = wdt_cc23x0_disable,
@@ -111,12 +104,11 @@ static DEVICE_API(wdt, wdt_cc23x0_api) = {
 
 #define CC23X0_WDT_INIT(index)                                                                     \
 	static struct wdt_cc23x0_data wdt_cc23x0_data_##index = {                                  \
-		.reload = WDT_MS_TO_TICKS(CONFIG_WDT_CC23X0_INITIAL_TIMEOUT),                      \
 	};                                                                                         \
 	static struct wdt_cc23x0_config wdt_cc23x0_config_##index = {                              \
 		.base = DT_INST_REG_ADDR(index),                                                   \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(index, wdt_cc23x0_init, NULL, &wdt_cc23x0_data_##index,              \
+	DEVICE_DT_INST_DEFINE(index, NULL, NULL, &wdt_cc23x0_data_##index,              \
 			      &wdt_cc23x0_config_##index, POST_KERNEL,                             \
 			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &wdt_cc23x0_api);
 

--- a/drivers/watchdog/wdt_cc32xx.c
+++ b/drivers/watchdog/wdt_cc32xx.c
@@ -151,14 +151,7 @@ static int wdt_cc32xx_init(const struct device *dev)
 	while (!MAP_PRCMPeripheralStatusGet(PRCM_WDT)) {
 	}
 
-	if (IS_ENABLED(CONFIG_WDT_DISABLE_AT_BOOT)) {
-		return 0;
-	}
-
-	MAP_WatchdogUnlock(config->reg);
-	rv = wdt_cc32xx_enable(dev);
-	MAP_WatchdogLock(config->reg);
-	return rv;
+	return 0;
 }
 
 static DEVICE_API(wdt, wdt_cc32xx_api) = {
@@ -179,7 +172,7 @@ static DEVICE_API(wdt, wdt_cc32xx_api) = {
 	}									 \
 										 \
 	static struct wdt_cc32xx_data wdt_cc32xx_data_##index = {		 \
-		.reload = CONFIG_WDT_CC32XX_INITIAL_TIMEOUT,			 \
+		.reload = 0,							 \
 		.cb = NULL,							 \
 		.flags = 0,							 \
 	};									 \

--- a/drivers/watchdog/wdt_dw.c
+++ b/drivers/watchdog/wdt_dw.c
@@ -197,15 +197,6 @@ static int dw_wdt_init(const struct device *dev)
 	}
 #endif
 
-	/*
-	 * Enable watchdog if it needs to be enabled at boot.
-	 * watchdog timer will be started with maximum timeout
-	 * that is the default value.
-	 */
-	if (!IS_ENABLED(CONFIG_WDT_DISABLE_AT_BOOT)) {
-		dw_wdt_enable((uint32_t)reg_base);
-	}
-
 	return 0;
 }
 

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -169,10 +169,6 @@ static int wdt_esp32_init(const struct device *dev)
 		return ret;
 	}
 
-#ifndef CONFIG_WDT_DISABLE_AT_BOOT
-	wdt_esp32_enable(dev);
-#endif
-
 	return 0;
 }
 

--- a/drivers/watchdog/wdt_fwdgt_gd32.c
+++ b/drivers/watchdog/wdt_fwdgt_gd32.c
@@ -162,14 +162,6 @@ static int gd32_fwdgt_init(const struct device *dev)
 	while (!rcu_osci_stab_wait(RCU_IRC_LOW_SPEED)) {
 	}
 
-#if !defined(CONFIG_WDT_DISABLE_AT_BOOT)
-	const struct wdt_timeout_cfg config = {
-		.window.max = FWDGT_INITIAL_TIMEOUT
-	};
-
-	ret = gd32_fwdgt_install_timeout(dev, &config);
-#endif
-
 	return ret;
 }
 

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -293,15 +293,6 @@ static int iwdg_stm32_init(const struct device *dev)
 #endif /* defined(CONFIG_SOC_SERIES_STM32WB0X) */
 #endif /* DT_INST_NODE_HAS_PROP(0, clocks) */
 
-#ifndef CONFIG_WDT_DISABLE_AT_BOOT
-	struct wdt_timeout_cfg config = {
-		.window.max = CONFIG_IWDG_STM32_INITIAL_TIMEOUT
-	};
-	/* Watchdog should be configured and started by `wdt_setup`*/
-	iwdg_stm32_install_timeout(dev, &config);
-	iwdg_stm32_setup(dev, 0); /* no option specified */
-#endif
-
 	/*
 	 * The ST production value for the option bytes where WDG_SW bit is
 	 * present is 0x00FF55AA, namely the Software watchdog mode is

--- a/drivers/watchdog/wdt_litex.c
+++ b/drivers/watchdog/wdt_litex.c
@@ -196,10 +196,6 @@ static int wdt_litex_init(const struct device *dev)
 
 	config->irq_cfg_func();
 
-#ifndef CONFIG_WDT_DISABLE_AT_BOOT
-	wdt_litex_enable(dev);
-#endif
-
 	return 0;
 }
 

--- a/drivers/watchdog/wdt_rpi_pico.c
+++ b/drivers/watchdog/wdt_rpi_pico.c
@@ -163,15 +163,6 @@ static int wdt_rpi_pico_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static int wdt_rpi_pico_init(const struct device *dev)
-{
-#ifndef CONFIG_WDT_DISABLE_AT_BOOT
-	return wdt_rpi_pico_setup(dev, WDT_OPT_PAUSE_HALTED_BY_DBG);
-#endif
-
-	return 0;
-}
-
 static DEVICE_API(wdt, wdt_rpi_pico_driver_api) = {
 	.setup = wdt_rpi_pico_setup,
 	.disable = wdt_rpi_pico_disable,
@@ -186,11 +177,10 @@ static DEVICE_API(wdt, wdt_rpi_pico_driver_api) = {
 	};                                                                                         \
 	static struct wdt_rpi_pico_data wdt_##idx##_data = {                                       \
 		.reset_type = WDT_FLAG_RESET_SOC,                                                  \
-		.load = (CONFIG_WDT_RPI_PICO_INITIAL_TIMEOUT *                                     \
-			 RPI_PICO_WDT_TIME_MULTIPLICATION_FACTOR),                                 \
+		.load = 0,                                                                         \
 		.enabled = false                                                                   \
 	};                                                                                         \
-	DEVICE_DT_DEFINE(DT_NODELABEL(wdt##idx), wdt_rpi_pico_init, NULL, &wdt_##idx##_data,       \
+	DEVICE_DT_DEFINE(DT_NODELABEL(wdt##idx), NULL, NULL, &wdt_##idx##_data,       \
 			 &wdt_##idx##_config, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,    \
 			 &wdt_rpi_pico_driver_api)
 


### PR DESCRIPTION
Fixes #86223 (hopefully).

The `WDT_DISABLE_AT_BOOT` Kconfig option has been interpreted as "enable the WDT if disabled" by *some* driver implementers, even though this is at best a hack. Document its true purpose explicitly and update all drivers to follow the now-documented semantics.

I took a conservative approach and only updated drivers which were explicitly playing the `if (!IS_ENABLED(WDT_DISABLE_AT_BOOT)) { enable_myself(); }` game, but maybe other drivers need to be updated too.
