### PR TITLE
modules/hal_st: Align to stmemsc HAL i/f v2.11

### DIFF
--- a/drivers/sensor/st/iis2dlpc/iis2dlpc.c
+++ b/drivers/sensor/st/iis2dlpc/iis2dlpc.c
@@ -298,7 +298,7 @@ static int iis2dlpc_init(const struct device *dev)
 	}
 
 	/* reset device */
-	if (iis2dlpc_reset_set(ctx, PROPERTY_ENABLE) < 0) {
+	if (iis2dlpc_reset_set(ctx) < 0) {
 		return -EIO;
 	}
 

--- a/drivers/sensor/st/lis2dux12/lis2duxs12_api.c
+++ b/drivers/sensor/st/lis2dux12/lis2duxs12_api.c
@@ -164,14 +164,17 @@ static void st_lis2duxs12_stream_config_fifo(const struct device *dev,
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&config->ctx;
 	lis2duxs12_pin_int_route_t pin_int = { 0 };
 	lis2duxs12_fifo_mode_t fifo_mode = { 0 };
+	lis2duxs12_fifo_batch_t batch = { 0 };
+	lis2duxs12_fifo_event_t fifo_event = { 0 };
+	uint16_t watermark = 0;
 
 	/* disable FIFO as first thing */
 	fifo_mode.store = LIS2DUXS12_FIFO_1X;
 	fifo_mode.xl_only = 0;
-	fifo_mode.watermark = 0;
 	fifo_mode.operation = LIS2DUXS12_BYPASS_MODE;
-	fifo_mode.batch.dec_ts = LIS2DUXS12_DEC_TS_OFF;
-	fifo_mode.batch.bdr_xl = LIS2DUXS12_BDR_XL_ODR_OFF;
+	batch.dec_ts = LIS2DUXS12_DEC_TS_OFF;
+	batch.bdr_xl = LIS2DUXS12_BDR_XL_ODR_OFF;
+	watermark = 0;
 
 	pin_int.fifo_th = PROPERTY_DISABLE;
 	pin_int.fifo_full = PROPERTY_DISABLE;
@@ -181,9 +184,9 @@ static void st_lis2duxs12_stream_config_fifo(const struct device *dev,
 		pin_int.fifo_full = (trig_cfg.int_fifo_full) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
 
 		if (pin_int.fifo_th) {
-			fifo_mode.fifo_event = LIS2DUXS12_FIFO_EV_WTM;
+			fifo_event = LIS2DUXS12_FIFO_EV_WTM;
 		} else if (pin_int.fifo_full) {
-			fifo_mode.fifo_event = LIS2DUXS12_FIFO_EV_FULL;
+			fifo_event = LIS2DUXS12_FIFO_EV_FULL;
 		}
 
 		switch (config->fifo_mode_sel) {
@@ -202,27 +205,32 @@ static void st_lis2duxs12_stream_config_fifo(const struct device *dev,
 		}
 
 		fifo_mode.operation = LIS2DUXS12_STREAM_MODE;
-		fifo_mode.batch.dec_ts = config->ts_batch;
-		fifo_mode.batch.bdr_xl = config->accel_batch;
-		fifo_mode.watermark = config->fifo_wtm;
+		batch.dec_ts = config->ts_batch;
+		batch.bdr_xl = config->accel_batch;
+		watermark = config->fifo_wtm;
 
 		/* In case each FIFO word contains 2x accelerometer samples,
 		 * then watermark can be divided by two to match user expectation.
 		 */
 		if (config->fifo_mode_sel == 2) {
-			fifo_mode.watermark /= 2;
+			watermark /= 2;
 		}
 	}
+
+	lis2duxs12_fifo_mode_set(ctx, fifo_mode);
 
 	/*
 	 * Set FIFO watermark (number of unread sensor data TAG + 6 bytes
 	 * stored in FIFO) to FIFO_WATERMARK samples
 	 */
-	lis2duxs12_fifo_mode_set(ctx, fifo_mode);
+	lis2duxs12_fifo_watermark_set(ctx, watermark);
+
+	lis2duxs12_fifo_batch_set(ctx, batch);
+	lis2duxs12_fifo_stop_on_wtm_set(ctx, fifo_event);
 
 	/* Set FIFO batch rates */
-	lis2dux12->accel_batch_odr = fifo_mode.batch.bdr_xl;
-	lis2dux12->ts_batch_odr = fifo_mode.batch.dec_ts;
+	lis2dux12->accel_batch_odr = batch.bdr_xl;
+	lis2dux12->ts_batch_odr = batch.dec_ts;
 
 	/* Set pin interrupt (fifo_th could be on or off) */
 	if (config->drdy_pin == 1) {
@@ -356,17 +364,18 @@ int st_lis2duxs12_init(const struct device *dev)
 	}
 
 	/* reset device */
-	ret = lis2duxs12_init_set(ctx, LIS2DUXS12_RESET);
+	ret = lis2duxs12_sw_reset(ctx);
 	if (ret < 0) {
 		return ret;
 	}
 
-	k_busy_wait(100);
-
 	LOG_INF("%s: chip id 0x%x", dev->name, chip_id);
 
 	/* Set bdu and if_inc recommended for driver usage */
-	lis2duxs12_init_set(ctx, LIS2DUXS12_SENSOR_ONLY_ON);
+	ret = lis2duxs12_init_set(ctx);
+	if (ret < 0) {
+		return ret;
+	}
 
 	lis2duxs12_timestamp_set(ctx, PROPERTY_ENABLE);
 

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -1106,13 +1106,13 @@ static int lsm6dsv16x_init_chip(const struct device *dev)
 	 */
 	if (ON_I3C_BUS(cfg)) {
 		/* Restore default configuration */
-		lsm6dsv16x_reset_set(ctx, LSM6DSV16X_RESTORE_CAL_PARAM);
+		lsm6dsv16x_reboot(ctx);
 
 		/* wait 150us as reported in AN5763 */
 		k_sleep(K_USEC(150));
 	} else {
 		/* reset device (sw_por) */
-		if (lsm6dsv16x_reset_set(ctx, LSM6DSV16X_GLOBAL_RST) < 0) {
+		if (lsm6dsv16x_sw_por(ctx) < 0) {
 			return -EIO;
 		}
 

--- a/west.yml
+++ b/west.yml
@@ -245,7 +245,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: 9f81b4427e955885398805b7bca0da3a8cd9109c
+      revision: 6d03b42859c2f8cedd6872da20b1dbdbef5c2392
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
Align all sensor drivers that are using stmemsc (STdC) HAL i/f to new APIs of stmemsc v2.11.

Requires https://github.com/zephyrproject-rtos/hal_st/pull/28