### PR TITLE
drivers: entropy: Fix non-stop RNG ISR firing for STM32WB09

### DIFF
--- a/drivers/bluetooth/hci/hci_stm32wb0.c
+++ b/drivers/bluetooth/hci/hci_stm32wb0.c
@@ -343,7 +343,7 @@ static int ble_pm_action(const struct device *dev,
 
 static void rng_get_random(void *num, size_t size)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
+	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 	int res;
 
 	/* try to allocate from pool */

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -328,9 +328,14 @@ static int recover_seed_error(RNG_TypeDef *rng)
 {
 	ll_rng_clear_seis(rng);
 
+#if !defined(CONFIG_SOC_SERIES_STM32WB0X)
+	/* After a noise source error is detected, 12 words must be read from the RNG_DR register
+	 * and discarded to restart the entropy generation.
+	 */
 	for (int i = 0; i < 12; ++i) {
 		(void)ll_rng_read_rand_data(rng);
 	}
+#endif /* !CONFIG_SOC_SERIES_STM32WB0X */
 
 	if (ll_rng_is_active_seis(rng) != 0) {
 		return -EIO;
@@ -446,7 +451,7 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 		ret = random_sample_get(&rnd_sample);
 #if !IRQLESS_TRNG
 		NVIC_ClearPendingIRQ(IRQN);
-#endif /* IRQLESS_TRNG */
+#endif /* !IRQLESS_TRNG */
 
 		if (ret < 0) {
 			continue;

--- a/drivers/entropy/entropy_stm32.h
+++ b/drivers/entropy/entropy_stm32.h
@@ -55,6 +55,7 @@ static inline void ll_rng_clear_seis(RNG_TypeDef *RNGx)
 {
 #if defined(CONFIG_SOC_STM32WB09XX)
 	LL_RNG_SetResetHealthErrorFlags(RNGx, 1);
+	stm32_reg_write(&RNGx->IRQ_SR, RNG_IRQ_SR_ERROR_IRQ);
 #elif defined(CONFIG_SOC_SERIES_STM32WB0X)
 	/* STM32WB05 / STM32WB06 / STM32WB07 */
 	LL_RNG_ClearFlag_FAULT(RNGx);

--- a/soc/st/stm32/stm32wb0x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32wb0x/Kconfig.defconfig
@@ -20,6 +20,9 @@ endif # STM32WB0_RADIO_TIMER
 
 if BT
 
+configdefault SYSTEM_WORKQUEUE_STACK_SIZE
+	default 1152
+
 config BT_AUTO_PHY_UPDATE
 	default n
 


### PR DESCRIPTION
- Fix the TRNG driver issue regarding non-stop ISR firing by clearing RNG_IRQ_SR_ERROR_IRQ flag.

- Exclude the WB0x series from discarding data 12 times from the RNG data register.

- Add a comment to the recover_seed_error function explaining the reason for reading and discarding data from the RNG data register 12 times.

- Fix the issue regarding passing the TRNG peripheral instance to the BLE driver.

- Increase the SYSTEM_WORKQUEUE_STACK_SIZE when CONFIG_BT is set.

Here is the screenshot of `beacon` sample to show the reason for increasing `SYSTEM_WORKQUEUE_STACK_SIZE`. Previously, the default was 1024 bytes.

<img width="971" height="434" alt="image" src="https://github.com/user-attachments/assets/d206c3ba-904e-4270-977b-8490795de995" />
