### PR TITLE
Mspi dw ddr and pm init fix

### DIFF
--- a/drivers/mspi/Kconfig.dw
+++ b/drivers/mspi/Kconfig.dw
@@ -11,6 +11,13 @@ config MSPI_DW
 
 if MSPI_DW
 
+config MSPI_DW_DDR
+	bool "Dual Data-Rate (DDR) capabilities"
+	default y
+	help
+	  Dual data rate is supported by some devices and requires specific
+	  registers to be enabled in the IP.
+
 config MSPI_DW_HANDLE_FIFOS_IN_SYSTEM_WORKQUEUE
 	bool "Handle FIFO in system workqueue"
 	depends on MULTITHREADING
@@ -23,6 +30,7 @@ config MSPI_DW_HANDLE_FIFOS_IN_SYSTEM_WORKQUEUE
 
 config MSPI_DW_TXD_DIV
 	int "Designware SSI TX Drive edge divisor"
+	depends on MSPI_DW_DDR
 	default 4
 	help
 	  Division factor to apply to calculated BAUDR value when writing it
@@ -31,6 +39,7 @@ config MSPI_DW_TXD_DIV
 
 config MSPI_DW_TXD_MUL
 	int "Designware SSI TX Drive edge multiplier"
+	depends on MSPI_DW_DDR
 	default 1
 	help
 	  Multiplication factor to apply to calculated BAUDR value when writing

--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -1864,9 +1864,6 @@ static int dev_init(const struct device *dev)
 		}
 	}
 
-	/* Make sure controller is disabled. */
-	write_ssienr(dev, 0);
-
 #if defined(CONFIG_PINCTRL)
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
 		rc = pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_SLEEP);
@@ -1877,7 +1874,15 @@ static int dev_init(const struct device *dev)
 	}
 #endif
 
-	return pm_device_driver_init(dev, dev_pm_action_cb);
+	rc = pm_device_driver_init(dev, dev_pm_action_cb);
+	if (rc < 0) {
+		return rc;
+	}
+
+	/* Make sure controller is disabled. */
+	write_ssienr(dev, 0);
+
+	return 0;
 }
 
 static DEVICE_API(mspi, drv_api) = {

--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -937,6 +937,7 @@ static int _api_dev_config(const struct device *dev,
 		switch (cfg->data_rate) {
 		case MSPI_DATA_RATE_SINGLE:
 			break;
+#if defined(CONFIG_MSPI_DW_DDR)
 		case MSPI_DATA_RATE_DUAL:
 			dev_data->spi_ctrlr0 |= SPI_CTRLR0_INST_DDR_EN_BIT;
 			/* Also need to set DDR_EN bit */
@@ -944,6 +945,7 @@ static int _api_dev_config(const struct device *dev,
 		case MSPI_DATA_RATE_S_D_D:
 			dev_data->spi_ctrlr0 |= SPI_CTRLR0_SPI_DDR_EN_BIT;
 			break;
+#endif
 		default:
 			LOG_ERR("Data rate %d not supported",
 				cfg->data_rate);
@@ -1238,6 +1240,7 @@ static int start_next_packet(const struct device *dev)
 	write_spi_ctrlr0(dev, dev_data->spi_ctrlr0);
 	write_baudr(dev, dev_data->baudr);
 	write_rx_sample_dly(dev, dev_data->rx_sample_dly);
+#if defined(CONFIG_MSPI_DW_DDR)
 	if (dev_data->spi_ctrlr0 & (SPI_CTRLR0_SPI_DDR_EN_BIT |
 				    SPI_CTRLR0_INST_DDR_EN_BIT)) {
 		int txd = (CONFIG_MSPI_DW_TXD_MUL * dev_data->baudr) /
@@ -1247,6 +1250,7 @@ static int start_next_packet(const struct device *dev)
 	} else {
 		write_txd_drive_edge(dev, 0);
 	}
+#endif
 
 	if (xip_enabled) {
 		write_ssienr(dev, SSIENR_SSIC_EN_BIT);


### PR DESCRIPTION
Adding of config to enable/disable DDR for MSPI_DW driver and fix for initialisation of peripheral.