### PR TITLE
tests: flash_interface_test: Only test if flash has driver

### DIFF
--- a/tests/drivers/flash/interface_test/testcase.yaml
+++ b/tests/drivers/flash/interface_test/testcase.yaml
@@ -13,6 +13,7 @@ tests:
   flash.interface_test.build_only:
     harness: ztest
     build_only: true
-    filter: dt_label_with_parent_compat_enabled("slot1_partition", "fixed-partitions")
+    filter: CONFIG_FLASH_HAS_DRIVER_ENABLED and
+      dt_label_with_parent_compat_enabled("slot1_partition", "fixed-partitions")
     integration_platforms:
       - imx95_evk/mimx9596/m7


### PR DESCRIPTION
Add filter to check if there is actually a flash driver enabled. If not, we can't run this test.

Fixes CI blockages