### PR TITLE
boards: stm32h750b-dk: add ST-Link GDB Server support

### DIFF
--- a/boards/st/stm32h750b_dk/board.cmake
+++ b/boards/st/stm32h750b_dk/board.cmake
@@ -7,10 +7,13 @@ if(CONFIG_STM32_MEMMAP OR CONFIG_BOOTLOADER_MCUBOOT)
   board_runner_args(stm32cubeprogrammer "--extload=MT25TL01G_STM32H750B-DISCO.stldr")
 endif()
 
+board_runner_args(stlink_gdbserver "--extload=MT25TL01G_STM32H750B-DISCO.stldr")
+
 board_runner_args(jlink "--device=STM32H735IG" "--speed=4000")
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32h750b_dk/doc/index.rst
+++ b/boards/st/stm32h750b_dk/doc/index.rst
@@ -210,6 +210,22 @@ perform application upgrade, refer to `MCUboot design`_.
 To learn more about how to secure the application images stored in external Flash,
 refer to `MCUboot Encryption`_.
 
+Debugging
+---------
+
+You can debug the application in external flash using ``west`` and ``GDB``.
+
+After flashing MCUboot and the app, execute the following command:
+
+.. code-block:: console
+
+   $ west debugserver
+
+Then, open another terminal (don't forget to activate Zephyr's environment) and execute:
+
+.. code-block:: console
+
+   $ west attach
 
 .. _STM32H750B-DK website:
    https://www.st.com/en/evaluation-tools/stm32h750b-dk.html

--- a/scripts/west_commands/runners/stlink_gdbserver.py
+++ b/scripts/west_commands/runners/stlink_gdbserver.py
@@ -174,6 +174,7 @@ class STLinkGDBServerRunner(ZephyrBinaryRunner):
             extldr_path = cubeprg_path / "ExternalLoader" / self._external_loader
             if not extldr_path.exists():
                 raise RuntimeError(f"External loader {self._external_loader} does not exist")
+            gdbserver_cmd += ["--external-init"]
             gdbserver_cmd += ["--extload", str(extldr_path)]
 
         self.require(gdbserver_cmd[0])


### PR DESCRIPTION
Add support for the ST-Link GDB Server runner for debugging STM32H750B-DK apps, including those running from external flash.
Update the board's documentation accordingly.
Also, add `--external-init` command to the West runner script of ST-LINK GDB Server. This command makes external Flash accessible for read and write by the debugger when debugging boards with app in external Flash.