### PR TITLE
drivers: i2c_stm32_v2:  fix assert in i2c event isr

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -577,6 +577,11 @@ void i2c_stm32_event(const struct device *dev)
 		__ASSERT_NO_MSG(0);
 	}
 
+	/* Make a dummy read from ISR to ensure we don't return before
+	 * i2c controller had a chance to clear its interrupt flags due
+	 * to bus delays
+	 */
+	(void)LL_I2C_ReadReg(regs, ISR);
 	return;
 
 irq_xfer_completed:


### PR DESCRIPTION
For systems where the CPU / NVIC bus are considerably faster than the peripheral bus used for I2C, there is a risk that the isr handler returns before I2C controller had time to clear its interrupt status flags

This would cause immediate re-entry to isr handler which begins read from ISR register.
During time it take to re-enter and read from ISR register, flags had time to be cleared
The isr handler expects that a flag is set, and in this case when its not, an assert is triggered

The solution here is to make a dummy read from the ISR register before returning from isr handler, this forces CPU to wait as long as needed to ensure all writes to the I2C peripheral are completed

Fixes issue #97904