### PR TITLE
samples: drivers: adc: add overlay file for nucleo_f446re

### DIFF
--- a/samples/drivers/adc/adc_dt/boards/nucleo_f446re.overlay
+++ b/samples/drivers/adc/adc_dt/boards/nucleo_f446re.overlay
@@ -1,0 +1,28 @@
+/* Copyright (c) 2025 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc1 1>;
+	};
+};
+
+&adc1 {
+	status="okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/* Differential input: must specify pinctrl for both +/- inputs */
+	pinctrl-0 = <&adc1_in1_pa1 >;
+	st,adc-prescaler = <4>;
+	pinctrl-names="default";
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/adc_dt/sample.yaml
+++ b/samples/drivers/adc/adc_dt/sample.yaml
@@ -9,6 +9,7 @@ common:
 tests:
   sample.drivers.adc.adc_dt:
     platform_allow:
+      - nucleo_f446re
       - nucleo_l073rz
       - nucleo_h753zi
       - disco_l475_iot1

--- a/samples/drivers/adc/adc_sequence/boards/nucleo_f446re.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/nucleo_f446re.overlay
@@ -1,0 +1,28 @@
+/* Copyright (c) 2025 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc0 = &adc1;
+	};
+};
+
+&adc1 {
+	status="okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/* Differential input: must specify pinctrl for both +/- inputs */
+	pinctrl-0 = <&adc1_in1_pa1 >;
+	st,adc-prescaler = <4>;
+	pinctrl-names="default";
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/adc_sequence/sample.yaml
+++ b/samples/drivers/adc/adc_sequence/sample.yaml
@@ -32,6 +32,7 @@ tests:
       - xg27_rb4194a
       - xg29_rb4412a
       - raytac_an54lq_db_15/nrf54l15/cpuapp
+      - nucleo_f446re
     integration_platforms:
       - nrf52840dk/nrf52840
   sample.drivers.adc.adc_sequence.8bit:


### PR DESCRIPTION
**Overview**

This PR adds overlay files on `zephyr/samples/drivers/adc/` that supports ADC integration on `nucleo_f446re` boards

**Features Implemented**

- `nucleo_f446re.overlay` files on `boards` folder for `adc_dt` and `adc_sequence` samples
- modification on sample.yaml adding `nucleo_f446re` on list


**Files Modified/Added**

zephyr/samples/drivers/adc/adc_dt/boards/nucleo_f446re.overlay - Overlay added
zephyr/samples/drivers/adc/adc_sequence/boards/nucleo_f446re.overlay - Overlay added
zephyr/samples/drivers/adc/adc_dt/sample.yaml - adde nucleo_f446re board on platform_allow tag
zephyr/samples/drivers/adc/adc_dt/sample.yaml - adde nucleo_f446re board on platform_allow tag

Fixes #98162
