### PR TITLE
boards: ESP32 related boards documentation fix

### DIFF
--- a/boards/pcbcupid/glyph_c6/doc/index.rst
+++ b/boards/pcbcupid/glyph_c6/doc/index.rst
@@ -12,78 +12,12 @@ For more information, check `Glyph-C6`_.
 Hardware
 ********
 
-ESP32-C6 is Espressif's first Wi-Fi 6 SoC integrating 2.4 GHz Wi-Fi 6, Bluetooth 5.3 (LE) and the
-802.15.4 protocol. ESP32-C6 achieves an industry-leading RF performance, with reliable security
-features and multiple memory resources for IoT products.
-It consists of a high-performance (HP) 32-bit RISC-V processor, which can be clocked up to 160 MHz,
-and a low-power (LP) 32-bit RISC-V processor, which can be clocked up to 20 MHz.
-It has a 320KB ROM, a 512KB SRAM, and works with external flash.
-
 Most of the I/O pins are broken out to the pin headers on both sides for easy interfacing.
 Developers can either connect peripherals with jumper wires or mount glyph c6 on
 a breadboard.
 
-ESP32-C6 includes the following features:
-
-- 32-bit core RISC-V microcontroller with a clock speed of up to 160 MHz
-- 400 KB of internal RAM
-- WiFi 802.11 ax 2.4GHz
-- Fully compatible with IEEE 802.11b/g/n protocol
-- Bluetooth LE: Bluetooth 5.3 certified
-- Internal co-existence mechanism between Wi-Fi and Bluetooth to share the same antenna
-- IEEE 802.15.4 (Zigbee and Thread)
-
-Digital interfaces:
-
-- 30x GPIOs (QFN40), or 22x GPIOs (QFN32)
-- 2x UART
-- 1x Low-power (LP) UART
-- 1x General purpose SPI
-- 1x I2C
-- 1x Low-power (LP) I2C
-- 1x I2S
-- 1x Pulse counter
-- 1x USB Serial/JTAG controller
-- 1x TWAI® controller, compatible with ISO 11898-1 (CAN Specification 2.0)
-- 1x SDIO 2.0 slave controller
-- LED PWM controller, up to 6 channels
-- 1x Motor control PWM (MCPWM)
-- 1x Remote control peripehral
-- 1x Parallel IO interface (PARLIO)
-- General DMA controller (GDMA), with 3 transmit channels and 3 receive channels
-- Event task matrix (ETM)
-
-Analog interfaces:
-
-- 1x 12-bit SAR ADCs, up to 7 channels
-- 1x temperature sensor
-
-Timers:
-
-- 1x 52-bit system timer
-- 1x 54-bit general-purpose timers
-- 3x Watchdog timers
-- 1x Analog watchdog timer
-
-Low Power:
-
-- Four power modes designed for typical scenarios: Active, Modem-sleep, Light-sleep, Deep-sleep
-
-Security:
-
-- Secure boot
-- Flash encryption
-- 4-Kbit OTP, up to 1792 bits for users
-- Cryptographic hardware acceleration: (AES-128/256, ECC, HMAC, RSA, SHA, Digital signature, Hash)
-- Random number generator (RNG)
-
-Memory and Storage:
-
-- While the Glyph ESP32-C6 has 512KB onboard SRAM, it also relies on an external flash chip for program storage.
-  On this board, there is 4 MB of flash memory, which is shared between the code, file storage and OTA
-
-For more information, check the datasheet at `ESP32-C6 Datasheet`_ or the technical reference
-manual at `ESP32-C6 Technical Reference Manual`_.
+.. include:: ../../../espressif/common/soc-esp32c6-features.rst
+   :start-after: espressif-soc-esp32c6-features
 
 Supported Features
 ==================
@@ -93,16 +27,8 @@ Supported Features
 System Requirements
 *******************
 
-Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
-below to retrieve those files.
-
-.. code-block:: console
-
-   west blobs fetch hal_espressif
-
-.. note::
-
-   It is recommended running the command above after :file:`west update`.
+.. include:: ../../../espressif/common/system-requirements.rst
+   :start-after: espressif-system-requirements
 
 Programming and Debugging
 *************************
@@ -121,36 +47,9 @@ Debugging
 .. include:: ../../../espressif/common/openocd-debugging.rst
    :start-after: espressif-openocd-debugging
 
-Low-Power CPU (LP CORE)
-***********************
-
-The ESP32-C6 SoC has two RISC-V cores: the High-Performance Core (HP CORE) and the Low-Power Core (LP CORE).
-The LP Core features ultra low power consumption, an interrupt controller, a debug module and a system bus
-interface for memory and peripheral access.
-
-The LP Core is in sleep mode by default. It has two application scenarios:
-
-- Power insensitive scenario: When the High-Performance CPU (HP Core) is active, the LP Core can assist the HP CPU with some speed and efficiency-insensitive controls and computations.
-- Power sensitive scenario: When the HP CPU is in the power-down state to save power, the LP Core can be woken up to handle some external wake-up events.
-
-For more information, check the datasheet at `ESP32-C6 Datasheet`_ or the technical reference
-manual at `ESP32-C6 Technical Reference Manual`_.
-
-The LP Core support is fully integrated with :ref:`sysbuild`. The user can enable the LP Core by adding
-the following configuration to the project:
-
-.. code:: cfg
-
-   CONFIG_ULP_COPROC_ENABLED=y
-
-See :zephyr:code-sample-category:`lp-core` folder as code reference.
-
 References
 **********
 
 .. target-notes::
 
 .. _`Glyph-C6`: https://learn.pcbcupid.com/boards/glyph-c6/overview
-.. _`ESP32-C6 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf
-.. _`ESP32-C6 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf
-.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/rakwireless/rak3112/doc/index.rst
+++ b/boards/rakwireless/rak3112/doc/index.rst
@@ -39,24 +39,19 @@ For more information about the RAK3112 stamp module:
 - `WisDuo RAK3112 Website`_
 - `Espressif ESP32-S3 Website`_
 
+.. include:: ../../../espressif/common/soc-esp32s3-features.rst
+   :start-after: espressif-soc-esp32s3-features
+
 Supported Features
 ==================
 
 .. zephyr:board-supported-hw::
 
-System requirements
+System Requirements
 *******************
 
-Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
-below to retrieve those files.
-
-.. code-block:: console
-
-   west blobs fetch hal_espressif
-
-.. note::
-
-   It is recommended running the command above after :file:`west update`.
+.. include:: ../../../espressif/common/system-requirements.rst
+   :start-after: espressif-system-requirements
 
 Programming and Debugging
 *************************
@@ -69,13 +64,16 @@ Programming and Debugging
 .. include:: ../../../espressif/common/board-variants.rst
    :start-after: espressif-board-variants
 
+Debugging
+=========
+
+.. include:: ../../../espressif/common/openocd-debugging.rst
+   :start-after: espressif-openocd-debugging
+
 References
 **********
 
 .. target-notes::
 
-.. _WisDuo RAK3112 Website:
-   https://docs.rakwireless.com/Product-Categories/WisDuo/RAK3112-Module/Overview/
-
-.. _Espressif ESP32-S3 Website:
-   https://www.espressif.com/en/products/socs/esp32-s3
+.. _`WisDuo RAK3112 Website`: https://docs.rakwireless.com/Product-Categories/WisDuo/RAK3112-Module/Overview/
+.. _`Espressif ESP32-S3 Website`: https://www.espressif.com/en/products/socs/esp32-s3

--- a/boards/weact/esp32c3_mini/doc/index.rst
+++ b/boards/weact/esp32c3_mini/doc/index.rst
@@ -10,34 +10,8 @@ For more information, check `WeAct Studio ESP32-C3 Core Board`_.
 Hardware
 ********
 
-ESP32-C3 is a single-core Wi-Fi and Bluetooth 5 (LE) microcontroller SoC,
-based on the open-source RISC-V architecture.
-
-The features include the following:
-
-- 32-bit core RISC-V microcontroller with a maximum clock speed of 160 MHz
-- 400 KB of internal RAM
-- 4 MB of internal flash (FH4 variant)
-- 802.11b/g/n/e/i
-- A Bluetooth LE subsystem that supports features of Bluetooth 5 and Bluetooth Mesh
-- Various peripherals:
-
-  - 12-bit ADC with up to 6 channels
-  - TWAI compatible with CAN bus 2.0
-  - Temperature sensor
-  - 3x SPI
-  - 1x I2S
-  - 1x I2C
-  - 2x UART
-  - LED PWM with up to 6 channels
-
-- Cryptographic hardware acceleration (RNG, ECC, RSA, SHA-2, AES)
-- USB Serial/JTAG for flashing and debugging
-- On-board blue LED (GPIO8)
-- Boot button (GPIO9)
-
-For more information, check the datasheet at `ESP32-C3 Datasheet`_ or the technical reference
-manual at `ESP32-C3 Technical Reference Manual`_.
+.. include:: ../../../espressif/common/soc-esp32c3-features.rst
+   :start-after: espressif-soc-esp32c3-features
 
 Supported Features
 ==================
@@ -47,16 +21,8 @@ Supported Features
 System Requirements
 *******************
 
-Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
-below to retrieve those files.
-
-.. code-block:: console
-
-   west blobs fetch hal_espressif
-
-.. note::
-
-   It is recommended running the command above after :file:`west update`.
+.. include:: ../../../espressif/common/system-requirements.rst
+   :start-after: espressif-system-requirements
 
 Programming and Debugging
 *************************
@@ -65,6 +31,9 @@ Programming and Debugging
 
 .. include:: ../../../espressif/common/building-flashing.rst
    :start-after: espressif-building-flashing
+
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
 
 Debugging
 =========
@@ -78,6 +47,3 @@ References
 .. target-notes::
 
 .. _`WeAct Studio ESP32-C3 Core Board`: https://github.com/WeActStudio/WeActStudio.ESP32C3CoreBoard
-.. _`ESP32-C3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
-.. _`ESP32-C3 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf
-.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/weact/esp32c6_mini/doc/index.rst
+++ b/boards/weact/esp32c6_mini/doc/index.rst
@@ -11,74 +11,11 @@ For more information, check `WeAct ESP32-C6 Mini`_.
 Hardware
 ********
 
-ESP32-C6 is Espressif's first Wi-Fi 6 SoC integrating 2.4 GHz Wi-Fi 6, Bluetooth 5.3 (LE) and the
-802.15.4 protocol. It consists of a high-performance (HP) 32-bit RISC-V processor, which can be
-clocked up to 160 MHz, and a low-power (LP) 32-bit RISC-V processor, which can be clocked up to 20 MHz.
-It has a 320KB ROM, a 512KB SRAM, and works with external flash.
-
 The WeAct ESP32-C6 Mini is a compact board with the ESP32-C6FH4 chip directly mounted, featuring
 a 4 MB SPI flash. The board includes a USB Type-C connector, boot and reset buttons, and an RGB LED.
 
-ESP32-C6FH4 is part of the ESP32-C6 series in a QFN32 (5x5 mm) package with in-package flash.
-
-Most of the I/O pins are broken out to the pin headers on both sides for easy interfacing.
-
-ESP32-C6 includes the following features:
-
-- 32-bit core RISC-V microcontroller with a clock speed of up to 160 MHz
-- 400 KB of internal RAM
-- WiFi 802.11 ax 2.4GHz
-- Fully compatible with IEEE 802.11b/g/n protocol
-- Bluetooth LE: Bluetooth 5.3 certified
-- Internal co-existence mechanism between Wi-Fi and Bluetooth to share the same antenna
-- IEEE 802.15.4 (Zigbee and Thread)
-
-Digital interfaces:
-
-- 22x GPIOs
-- 2x UART
-- 1x Low-power (LP) UART
-- 1x SPI (SPI2)
-- 1x I2C
-- 1x Low-power (LP) I2C
-- 1x I2S
-- 1x Pulse counter
-- 1x USB Serial/JTAG controller
-- 1x TWAI® controllers, compatible with ISO 11898-1 (CAN Specification 2.0)
-- 1x SDIO 2.0 slave controller
-- LED PWM controller, up to 6 channels
-- 1x Motor control PWM (MCPWM)
-- 1x Remote control peripheral
-- 1x Parallel IO interface (PARLIO)
-- General DMA controller (GDMA), with 3 transmit channels and 3 receive channels
-- Event task matrix (ETM)
-
-Analog interfaces:
-
-- 1x 12-bit SAR ADCs, up to 7 channels
-- 1x temperature sensor
-
-Timers:
-
-- 1x 52-bit system timer
-- 1x 54-bit general-purpose timers
-- 3x Watchdog timers
-- 1x Analog watchdog timer
-
-Low Power:
-
-- Four power modes: Active, Modem-sleep, Light-sleep, Deep-sleep
-
-Security:
-
-- Secure boot
-- Flash encryption
-- 4-Kbit OTP, up to 1792 bits for users
-- Cryptographic hardware acceleration: (AES-128/256, ECC, HMAC, RSA, SHA, Digital signature, Hash)
-- Random number generator (RNG)
-
-For more information, check the datasheet at `ESP32-C6 Datasheet`_ or the technical reference
-manual at `ESP32-C6 Technical Reference Manual`_.
+.. include:: ../../../espressif/common/soc-esp32c6-features.rst
+   :start-after: espressif-soc-esp32c6-features
 
 Supported Features
 ==================
@@ -88,16 +25,8 @@ Supported Features
 System Requirements
 *******************
 
-Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
-below to retrieve those files.
-
-.. code-block:: console
-
-   west blobs fetch hal_espressif
-
-.. note::
-
-   It is recommended running the command above after :file:`west update`.
+.. include:: ../../../espressif/common/system-requirements.rst
+   :start-after: espressif-system-requirements
 
 Programming and Debugging
 *************************
@@ -107,32 +36,14 @@ Programming and Debugging
 .. include:: ../../../espressif/common/building-flashing.rst
    :start-after: espressif-building-flashing
 
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
+
 Debugging
 =========
 
 .. include:: ../../../espressif/common/openocd-debugging.rst
    :start-after: espressif-openocd-debugging
-
-Low-Power CPU (LP CORE)
-***********************
-
-The ESP32-C6 SoC has two RISC-V cores: the High-Performance Core (HP CORE) and the Low-Power Core (LP CORE).
-The LP Core features ultra low power consumption, an interrupt controller, a debug module and a system bus
-interface for memory and peripheral access.
-
-The LP Core is in sleep mode by default. It has two application scenarios:
-
-- Power insensitive scenario: When the High-Performance CPU (HP Core) is active, the LP Core can assist the HP CPU with some speed and efficiency-insensitive controls and computations.
-- Power sensitive scenario: When the HP CPU is in the power-down state to save power, the LP Core can be woken up to handle some external wake-up events.
-
-The LP Core support is fully integrated with :ref:`sysbuild`. The user can enable the LP Core by adding
-the following configuration to the project:
-
-.. code:: cfg
-
-   CONFIG_ULP_COPROC_ENABLED=y
-
-See :zephyr:code-sample-category:`lp-core` folder as code reference.
 
 References
 **********
@@ -140,6 +51,3 @@ References
 .. target-notes::
 
 .. _`WeAct ESP32-C6 Mini`: https://github.com/WeActStudio/WeActStudio.ESP32C6-MINI
-.. _`ESP32-C6 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf
-.. _`ESP32-C6 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf
-.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/weact/esp32s3_mini/doc/index.rst
+++ b/boards/weact/esp32s3_mini/doc/index.rst
@@ -11,72 +11,17 @@ check `WeAct Studio ESP32-S3-MINI`_.
 Hardware
 ********
 
-ESP32-S3 is a low-power MCU-based system on a chip (SoC) with integrated 2.4 GHz Wi-Fi
-and Bluetooth® Low Energy (Bluetooth LE). It consists of high-performance dual-core microprocessor
-(Xtensa® 32-bit LX7), a low power coprocessor, a Wi-Fi baseband, a Bluetooth LE baseband,
-RF module, and numerous peripherals.
 
 WeAct Studio ESP32-S3-MINI includes the following features:
 
-- Dual core 32-bit Xtensa Microprocessor (Tensilica LX7), running up to 240MHz
 - 4MB integrated Flash memory
 - 2MB integrated PSRAM
-- 512KB of SRAM
-- Wi-Fi 802.11b/g/n
-- Bluetooth LE 5.0 with long-range support and up to 2Mbps data rate
 - Onboard RGB WS2812 LED (GPIO48)
 - BOOT button (GPIO0)
 - USB Type-C connector
 
-Digital interfaces:
-
-- 36 programmable GPIOs
-- 4x SPI
-- 3x UART
-- 2x I2C
-- 2x I2S
-- 1x RMT (TX/RX)
-- LED PWM controller, up to 8 channels
-- 1x full-speed USB OTG
-- 1x USB Serial/JTAG controller
-- 2x MCPWM
-- General DMA controller (GDMA), with 5 transmit channels and 5 receive channels
-- 1x TWAI® controller, compatible with ISO 11898-1 (CAN Specification 2.0)
-- Addressable RGB LED, driven by GPIO48.
-
-Analog interfaces:
-
-- 2x 12-bit SAR ADCs, up to 20 channels
-- 1x temperature sensor
-- 14x touch sensing IOs
-
-Timers:
-
-- 4x 54-bit general-purpose timers
-- 1x 52-bit system timer
-- 3x watchdog timers
-
-Low Power:
-
-- Power Management Unit with five power modes
-- Ultra-Low-Power (ULP) coprocessors: ULP-RISC-V and ULP-FSM
-
-Security:
-
-- Secure boot
-- Flash encryption
-- 4-Kbit OTP, up to 1792 bits for users
-- Cryptographic hardware acceleration: (AES-128/256, Hash, RSA, RNG, HMAC, Digital signature)
-
-Asymmetric Multiprocessing (AMP)
-********************************
-
-WeAct Studio ESP32-S3-MINI supports dual-core execution allowing two different applications
-to run on ESP32-S3 SoC. Each core can execute customized tasks in stand-alone mode
-and/or exchange data over OpenAMP framework. See :zephyr:code-sample-category:`ipc` folder as reference.
-
-For more information, check the datasheet at `ESP32-S3 Datasheet`_ or the technical reference
-manual at `ESP32-S3 Technical Reference Manual`_.
+.. include:: ../../../espressif/common/soc-esp32s3-features.rst
+   :start-after: espressif-soc-esp32s3-features
 
 Supported Features
 ==================
@@ -86,16 +31,8 @@ Supported Features
 System Requirements
 *******************
 
-Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
-below to retrieve those files.
-
-.. code-block:: console
-
-   west blobs fetch hal_espressif
-
-.. note::
-
-   It is recommended running the command above after :file:`west update`.
+.. include:: ../../../espressif/common/system-requirements.rst
+   :start-after: espressif-system-requirements
 
 Programming and Debugging
 *************************
@@ -104,6 +41,9 @@ Programming and Debugging
 
 .. include:: ../../../espressif/common/building-flashing.rst
    :start-after: espressif-building-flashing
+
+.. include:: ../../../espressif/common/board-variants.rst
+   :start-after: espressif-board-variants
 
 Debugging
 =========
@@ -117,5 +57,3 @@ References
 .. target-notes::
 
 .. _`WeAct Studio ESP32-S3-MINI`: https://github.com/WeActStudio/WeActStudio.ESP32S3-MINI/
-.. _`ESP32-S3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s3-mini-1_mini-1u_datasheet_en.pdf
-.. _`ESP32-S3 Technical Reference Manual`: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf


### PR DESCRIPTION
Providing documentation update for ESP32 related boards that was missed during the first round.