### PR TITLE
Fix clock frequencies for infineon kit_pse84_eval and kit_psc3m5_evk

### DIFF
--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.dts
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.dts
@@ -52,6 +52,50 @@ uart3: &scb3 {
 	status = "okay";
 };
 
+&fll0 {
+	clock-frequency = <96000000>;
+	status = "okay";
+};
+
+/* For the dpll clocks declared below
+ * The clock-frequency value is here for dts reference, but
+ * it does not affect the frequency set by the clock_control
+ * driver. That is decided by the rest of the variables in
+ * this block. They result in the set clock-frequency. For other
+ * frequencies, they need to be calculated separately and
+ * entered into the devicetree dpll_* block.
+ */
+
+/* This dpll_lp0 is on "clock path" 1. So HF clocks sourced
+ * from *_CLKPATH1 will receive this frequency, when the
+ * dpll_lp0 is set to "okay".
+ */
+&dpll_lp0 {
+	status = "okay";
+	clock-frequency = <180000000>;
+
+	feedback-div = <45>;
+	reference-div = <6>;
+	output-div = <2>;
+	fraction-div = <0>;
+	dco-mode-enable;
+};
+
+/* This dpll_lp1 is on "clock path" 2. So HF clocks sourced
+ * from *_CLKPATH2 will receive this frequency instead, when the
+ * dpll_lp1 is set to "okay".
+ */
+&dpll_lp1 {
+	status = "okay";
+	clock-frequency = <240000000>;
+
+	feedback-div = <60>;
+	reference-div = <6>;
+	output-div = <2>;
+	fraction-div = <0>;
+	dco-mode-enable;
+};
+
 &path_mux0 {
 	status = "okay";
 };

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
@@ -103,7 +103,3 @@ uart2: &scb2 {
 &gpio_prt20 {
 	status = "okay";
 };
-
-&dpll_hp {
-	status = "okay";
-};

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.dts
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.dts
@@ -31,6 +31,61 @@
 	};
 };
 
+/* For the dpll clocks declared below
+ * The clock-frequency value is here for dts reference, but
+ * it does not affect the frequency set by the clock_control
+ * driver. That is decided by the rest of the variables in
+ * this block. They result in the set clock-frequency. For other
+ * frequencies, they need to be calculated separately and
+ * entered into the devicetree dpll_* block.
+ */
+
+/* This dpll_lp0 is on "clock path" 0. So HF clocks sourced
+ * from *_CLKPATH0 will receive this frequency, when the
+ * dpll_lp0 is set to "okay".
+ */
+&dpll_lp0 {
+	status = "okay";
+	clock-frequency = <400000000>;
+
+	feedback-div = <56>;
+	reference-div = <7>;
+	output-div = <1>;
+	fraction-div = <0>;
+	dco-mode-enable;
+};
+
+/* This dpll_lp1 is on "clock path" 1. So HF clocks sourced
+ * from *_CLKPATH1 will receive this frequency instead, when the
+ * dpll_lp1 is set to "okay".
+ */
+&dpll_lp1 {
+	status = "okay";
+	clock-frequency = <49152000>;
+
+	feedback-div = <27>;
+	reference-div = <7>;
+	output-div = <4>;
+	fraction-div = <8810051>;
+};
+
+/* This dpll_hp is on "clock path" 2. So HF clocks sourced
+ * from *_CLKPATH2 will receive this frequency, when the
+ * dpll_hp is set to "okay".
+ */
+&dpll_hp {
+	status = "okay";
+	clock-frequency = <300000000>;
+
+	div-p = <0>;
+	div-n = <11>;
+	div-k = <1>;
+	fraction-div = <0>;
+	freq-mode-sel = <7>;
+	flock-enable-threshold = <3>;
+	lf-beta-value = <20>;
+};
+
 &path_mux0 {
 	status = "okay";
 };

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
@@ -89,7 +89,3 @@ uart2: &scb2 {
 &gpio_prt16 {
 	status = "okay";
 };
-
-&dpll_hp {
-	status = "okay";
-};

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.dts
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.dts
@@ -31,6 +31,61 @@
 	};
 };
 
+/* For the dpll clocks declared below
+ * The clock-frequency value is here for dts reference, but
+ * it does not affect the frequency set by the clock_control
+ * driver. That is decided by the rest of the variables in
+ * this block. They result in the set clock-frequency. For other
+ * frequencies, they need to be calculated separately and
+ * entered into the devicetree dpll_* block.
+ */
+
+/* This dpll_lp0 is on "clock path" 0. So HF clocks sourced
+ * from *_CLKPATH0 will receive this frequency, when the
+ * dpll_lp0 is set to "okay".
+ */
+&dpll_lp0 {
+	status = "okay";
+	clock-frequency = <400000000>;
+
+	feedback-div = <56>;
+	reference-div = <7>;
+	output-div = <1>;
+	fraction-div = <0>;
+	dco-mode-enable;
+};
+
+/* This dpll_lp1 is on "clock path" 1. So HF clocks sourced
+ * from *_CLKPATH1 will receive this frequency instead, when the
+ * dpll_lp1 is set to "okay".
+ */
+&dpll_lp1 {
+	status = "okay";
+	clock-frequency = <49152000>;
+
+	feedback-div = <27>;
+	reference-div = <7>;
+	output-div = <4>;
+	fraction-div = <8810051>;
+};
+
+/* This dpll_hp is on "clock path" 2. So HF clocks sourced
+ * from *_CLKPATH2 will receive this frequency, when the
+ * dpll_hp is set to "okay".
+ */
+&dpll_hp {
+	status = "okay";
+	clock-frequency = <300000000>;
+
+	div-p = <0>;
+	div-n = <11>;
+	div-k = <1>;
+	fraction-div = <0>;
+	freq-mode-sel = <7>;
+	flock-enable-threshold = <3>;
+	lf-beta-value = <20>;
+};
+
 &path_mux0 {
 	status = "okay";
 };

--- a/drivers/clock_control/Kconfig.ifx_cat1
+++ b/drivers/clock_control/Kconfig.ifx_cat1
@@ -13,22 +13,35 @@ config CLOCK_CONTROL_INFINEON_CAT1
 	  This option enables the clock control driver for Infineon CAT1 family.
 
 config CLOCK_CONTROL_IFX_FIXED_CLOCK
-	bool "Infineon CAT1 Fixed clock driver"
+	bool "Infineon fixed clock driver"
 	default y
 	depends on DT_HAS_INFINEON_FIXED_CLOCK_ENABLED
 	help
 	  This option enables the Fixed clock driver for Infineon CAT1 family.
 
 config CLOCK_CONTROL_IFX_FIXED_FACTOR_CLOCK
-	bool "Infineon CAT1 Fixed factor clock driver"
+	bool "Infineon fixed factor clock driver"
 	default y
 	depends on DT_HAS_INFINEON_FIXED_FACTOR_CLOCK_ENABLED
 	help
 	  This option enables the Fixed clock driver for Infineon CAT1 family.
 
 config CLOCK_CONTROL_IFX_PERI_CLOCK
-	bool "Infineon CAT1 Fixed clock driver"
+	bool "Infineon peri div clock driver"
 	default y
 	depends on DT_HAS_INFINEON_PERI_DIV_ENABLED
 	help
 	  This option enables the Peripheral clock driver for Infineon CAT1 family.
+
+
+if CLOCK_CONTROL_IFX_FIXED_FACTOR_CLOCK
+
+config CLOCK_CONTROL_IFX_FIXED_FACTOR_CLOCK_INIT_PRIORITY
+	int "Infineon fixed factor clock driver init priority"
+	default 29
+	help
+	  Infineon fixed factor clock control driver initialization priority.
+	  This should be lower than the priority of fixed factor clock driver
+	  to ensure the clock paths are initialized before.
+
+endif # CLOCK_CONTROL_IFX_FIXED_FACTOR_CLOCK

--- a/drivers/clock_control/clock_control_ifx_fixed_clock.c
+++ b/drivers/clock_control/clock_control_ifx_fixed_clock.c
@@ -25,6 +25,9 @@
 struct fixed_rate_clock_config {
 	uint32_t rate;
 	uint32_t system_clock; /* ifx_cat1_clock_block */
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_hp))
+	cy_stc_dpll_hp_config_t dpll_hp_config;
+#endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp0)) ||                                             \
 	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp1))
 	cy_stc_dpll_lp_config_t dpll_lp_config;
@@ -46,8 +49,13 @@ static void clock_startup_error(uint32_t error)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp0)) ||                                             \
 	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp1))
+#if defined(CONFIG_SOC_SERIES_PSC3)
 #define DPLL_LP0 SRSS_PLL_250M_0_PATH_NUM
 #define DPLL_LP1 SRSS_PLL_250M_1_PATH_NUM
+#elif defined(CONFIG_SOC_SERIES_PSE84)
+#define DPLL_LP0 SRSS_DPLL_LP_0_PATH_NUM
+#define DPLL_LP1 SRSS_DPLL_LP_1_PATH_NUM
+#endif
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp0)) ||                                             \
@@ -93,31 +101,9 @@ static void clk_dpll_lp_init(uint32_t dpll_lp, cy_stc_dpll_lp_config_t dpll_lp_c
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_hp))
-static void ifx_clk_dpll_hp0_init(void)
+static void clk_dpll_hp_init(cy_stc_dpll_hp_config_t dpll_hp_config)
 {
-#define CY_CFG_SYSCLK_PLL_ERROR 3
-
-	static cy_stc_dpll_hp_config_t dpll_hp_config = {
-		.pDiv = 0,
-		.nDiv = 15,
-		.kDiv = 1,
-		.nDivFract = 0,
-		.freqModeSel = CY_SYSCLK_DPLL_HP_CLK50MHZ_1US_CNT_VAL,
-		.ivrTrim = 0x8U,
-		.clkrSel = 0x1U,
-		.alphaCoarse = 0xCU,
-		.betaCoarse = 0x5U,
-		.flockThresh = 0x3U,
-		.flockWait = 0x6U,
-		.flockLkThres = 0x7U,
-		.flockLkWait = 0x4U,
-		.alphaExt = 0x14U,
-		.betaExt = 0x14U,
-		.lfEn = 0x1U,
-		.dcEn = 0x1U,
-		.outputMode = CY_SYSCLK_FLLPLL_OUTPUT_AUTO,
-	};
-	static cy_stc_pll_manual_config_t dpll_config = {
+	cy_stc_pll_manual_config_t dpll_config = {
 		.hpPllCfg = &dpll_hp_config,
 	};
 
@@ -183,7 +169,7 @@ static int fixed_rate_clk_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_hp))
 	case IFX_DPLL500:
-		ifx_clk_dpll_hp0_init();
+		clk_dpll_hp_init(config->dpll_hp_config);
 		SystemCoreClockUpdate();
 		break;
 #endif
@@ -194,8 +180,35 @@ static int fixed_rate_clk_init(const struct device *dev)
 	return 0;
 }
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_hp))
+#define DPLL_HP_INIT(n)                                                                            \
+	.dpll_hp_config = {                                                                        \
+		.pDiv = DT_INST_PROP_OR(n, div_p, 0),                                              \
+		.nDiv = DT_INST_PROP_OR(n, div_n, 0),                                              \
+		.kDiv = DT_INST_PROP_OR(n, div_k, 0),                                              \
+		.nDivFract = DT_INST_PROP_OR(n, fraction_div, 0),                                  \
+		.freqModeSel = ((cy_en_wait_mode_select_t)DT_INST_PROP_OR(n, freq_mode_sel, 0)),   \
+		.ivrTrim = 0x8U,                                                                   \
+		.clkrSel = 0x1U,                                                                   \
+		.alphaCoarse = 0xCU,                                                               \
+		.betaCoarse = 0x5U,                                                                \
+		.flockThresh = DT_INST_PROP_OR(n, flock_enable_threshold, 0),                      \
+		.flockWait = 0x6U,                                                                 \
+		.flockLkThres = 0x7U,                                                              \
+		.flockLkWait = 0x4U,                                                               \
+		.alphaExt = 0x14U,                                                                 \
+		.betaExt = DT_INST_PROP_OR(n, lf_beta_value, 0),                                   \
+		.lfEn = 0x1U,                                                                      \
+		.dcEn = 0x1U,                                                                      \
+		.outputMode = CY_SYSCLK_FLLPLL_OUTPUT_AUTO,                                        \
+	},
+#else
+#define DPLL_HP_INIT(n)
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp0)) ||                                             \
 	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp1))
+#if defined(CONFIG_SOC_SERIES_PSC3)
 #define DPLL_LP_INIT(n)                                                                            \
 	.dpll_lp_config = {                                                                        \
 		.feedbackDiv = DT_INST_PROP_OR(n, feedback_div, 0),                                \
@@ -229,6 +242,26 @@ static int fixed_rate_clk_init(const struct device *dev)
 		.kiAccSscg = 0x16U,                                                                \
 		.kpAccSscg = 0x14U,                                                                \
 	},
+#elif defined(CONFIG_SOC_SERIES_PSE84)
+#define DPLL_LP_INIT(n)                                                                            \
+	.dpll_lp_config = {                                                                        \
+		.feedbackDiv = DT_INST_PROP_OR(n, feedback_div, 0),                                \
+		.referenceDiv = DT_INST_PROP_OR(n, reference_div, 0),                              \
+		.outputDiv = DT_INST_PROP_OR(n, output_div, 0),                                    \
+		.pllDcoMode = DT_INST_PROP_OR(n, dco_mode_enable, false),                          \
+		.outputMode = CY_SYSCLK_FLLPLL_OUTPUT_AUTO,                                        \
+		.fracDiv = DT_INST_PROP_OR(n, fraction_div, 0),                                    \
+		.fracDitherEn = false,                                                             \
+		.fracEn = true,                                                                    \
+		.dcoCode = 0xFU,                                                                   \
+		.kiInt = 0xAU,                                                                     \
+		.kiFrac = 0xBU,                                                                    \
+		.kiSscg = 0x7U,                                                                    \
+		.kpInt = 0x8U,                                                                     \
+		.kpFrac = 0x9U,                                                                    \
+		.kpSscg = 0x7U,                                                                    \
+	},
+#endif
 #else
 #define DPLL_LP_INIT(n)
 #endif
@@ -237,6 +270,7 @@ static int fixed_rate_clk_init(const struct device *dev)
 	static const struct fixed_rate_clock_config fixed_rate_clock_config_##n = {                \
 		.rate = DT_INST_PROP(n, clock_frequency),                                          \
 		.system_clock = DT_INST_PROP(n, system_clock),                                     \
+		DPLL_HP_INIT(n)                                                                    \
 		DPLL_LP_INIT(n)                                                                    \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(n, fixed_rate_clk_init, NULL, NULL, &fixed_rate_clock_config_##n,    \

--- a/drivers/clock_control/clock_control_ifx_fixed_clock.c
+++ b/drivers/clock_control/clock_control_ifx_fixed_clock.c
@@ -9,11 +9,11 @@
  * @brief Clock control driver for Infineon CAT1 MCU family.
  */
 
+#include <infineon_kconfig.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/kernel.h>
 #include <stdlib.h>
 
-#include <infineon_kconfig.h>
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_boards.h>
@@ -25,17 +25,75 @@
 struct fixed_rate_clock_config {
 	uint32_t rate;
 	uint32_t system_clock; /* ifx_cat1_clock_block */
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp0)) ||                                             \
+	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp1))
+	cy_stc_dpll_lp_config_t dpll_lp_config;
+#endif
 };
 
-__WEAK void ifx_clock_startup_error(uint32_t error)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_hp)) ||                                              \
+	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp0)) ||                                         \
+	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp1))
+static void clock_startup_error(uint32_t error)
 {
 	(void)error; /* Suppress the compiler warning */
 	while (1) {
 	}
 }
+#endif
+
+#define CY_CFG_SYSCLK_PLL_ERROR 3
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp0)) ||                                             \
+	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp1))
+#define DPLL_LP0 SRSS_PLL_250M_0_PATH_NUM
+#define DPLL_LP1 SRSS_PLL_250M_1_PATH_NUM
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp0)) ||                                             \
+	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp1))
+static void clk_dpll_lp_init(uint32_t dpll_lp, cy_stc_dpll_lp_config_t dpll_lp_config)
+{
+	cy_stc_pll_manual_config_t dpll_config = {
+		.lpPllCfg = &dpll_lp_config,
+	};
+
+#if !defined(CY_PDL_TZ_ENABLED)
+	if (Cy_SysClk_PllIsEnabled(dpll_lp)) {
+		return;
+	}
+#endif
+
+	Cy_SysClk_PllDisable(dpll_lp);
+	if (CY_SYSCLK_SUCCESS != Cy_SysClk_PllManualConfigure(dpll_lp, &dpll_config)) {
+		clock_startup_error(CY_CFG_SYSCLK_PLL_ERROR);
+	}
+
+#if (defined(CY_IP_MXS22SRSS_VERSION) && defined(CY_IP_MXS22SRSS_VERSION)) &&                      \
+	((CY_IP_MXS22SRSS_VERSION == 1) && (CY_IP_MXS22SRSS_VERSION_MINOR == 0))
+	/* The workaround for devices with MXS22SRSS block 1.0 */
+	uint32_t clk_hf_mask = Cy_SysClk_ClkHfGetMaskOnPath((cy_en_clkhf_in_sources_t)dpll_lp);
+
+	if (clk_hf_mask) {
+		Cy_SysClk_ClkHfEnableDirectMuxWithMask(clk_hf_mask, true);
+	}
+#endif /* ((CY_IP_MXS22SRSS_VERSION == 1) && (CY_IP_MXS22SRSS_VERSION_MINOR == 0)) */
+
+	if (CY_SYSCLK_SUCCESS != Cy_SysClk_PllEnable(dpll_lp, 10000u)) {
+		clock_startup_error(CY_CFG_SYSCLK_PLL_ERROR);
+	} else {
+		/* The workaround for devices with MXS22SRSS block 1.0 */
+#if (defined(CY_IP_MXS22SRSS_VERSION) && defined(CY_IP_MXS22SRSS_VERSION)) &&                      \
+	((CY_IP_MXS22SRSS_VERSION == 1) && (CY_IP_MXS22SRSS_VERSION_MINOR == 0))
+		Cy_SysLib_DelayUs(SRSS_DPLL_LP_INIT_DELAY_USEC);
+		Cy_SysClk_ClkHfEnableDirectMuxWithMask(clk_hf_mask, false);
+#endif /* ((CY_IP_MXS22SRSS_VERSION == 1) && (CY_IP_MXS22SRSS_VERSION_MINOR == 0)) */
+	}
+}
+#endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_hp))
-void ifx_clk_dpll_hp0_init(void)
+static void ifx_clk_dpll_hp0_init(void)
 {
 #define CY_CFG_SYSCLK_PLL_ERROR 3
 
@@ -71,10 +129,10 @@ void ifx_clk_dpll_hp0_init(void)
 	Cy_SysClk_PllDisable(SRSS_DPLL_HP_0_PATH_NUM);
 	if (CY_SYSCLK_SUCCESS !=
 	    Cy_SysClk_PllManualConfigure(SRSS_DPLL_HP_0_PATH_NUM, &dpll_config)) {
-		ifx_clock_startup_error(CY_CFG_SYSCLK_PLL_ERROR);
+		clock_startup_error(CY_CFG_SYSCLK_PLL_ERROR);
 	}
 	if (CY_SYSCLK_SUCCESS != Cy_SysClk_PllEnable(SRSS_DPLL_HP_0_PATH_NUM, 10000u)) {
-		ifx_clock_startup_error(CY_CFG_SYSCLK_PLL_ERROR);
+		clock_startup_error(CY_CFG_SYSCLK_PLL_ERROR);
 	}
 }
 #endif
@@ -99,6 +157,30 @@ static int fixed_rate_clk_init(const struct device *dev)
 		Cy_SysClk_PiloEnable();
 		break;
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp0))
+	case IFX_DPLL250_0:
+#ifdef WA__DRIVERS_21925
+		/* Workaround: update DPLL_LP trim values */
+		CY_SET_REG32(0x52403218, 0x921F190A); /* DPLL_LP0_TEST3 */
+		CY_SET_REG32(0x5240321C, 0x08100000); /* DPLL_LP0_TEST4 */
+#endif
+		clk_dpll_lp_init(DPLL_LP0, config->dpll_lp_config);
+		SystemCoreClockUpdate();
+		break;
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp1))
+	case IFX_DPLL250_1:
+#ifdef WA__DRIVERS_21925
+		/* Workaround: update DPLL_LP trim values */
+		CY_SET_REG32(0x52403238, 0x921F190A); /* DPLL_LP1_TEST3 */
+		CY_SET_REG32(0x5240323C, 0x08100000); /* DPLL_LP1_TEST4 */
+#endif
+		clk_dpll_lp_init(DPLL_LP1, config->dpll_lp_config);
+		SystemCoreClockUpdate();
+		break;
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_hp))
 	case IFX_DPLL500:
 		ifx_clk_dpll_hp0_init();
@@ -112,10 +194,50 @@ static int fixed_rate_clk_init(const struct device *dev)
 	return 0;
 }
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp0)) ||                                             \
+	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp1))
+#define DPLL_LP_INIT(n)                                                                            \
+	.dpll_lp_config = {                                                                        \
+		.feedbackDiv = DT_INST_PROP_OR(n, feedback_div, 0),                                \
+		.referenceDiv = DT_INST_PROP_OR(n, reference_div, 0),                              \
+		.outputDiv = DT_INST_PROP_OR(n, output_div, 0),                                    \
+		.pllDcoMode = DT_INST_PROP_OR(n, dco_mode_enable, false),                          \
+		.outputMode = CY_SYSCLK_FLLPLL_OUTPUT_AUTO,                                        \
+		.fracDiv = DT_INST_PROP_OR(n, fraction_div, 0),                                    \
+		.fracDitherEn = false,                                                             \
+		.fracEn = true,                                                                    \
+		.sscgDepth = 0x0U,                                                                 \
+		.sscgRate = 0x0U,                                                                  \
+		.sscgDitherEn = 0x0U,                                                              \
+		.sscgMode = 0x0U,                                                                  \
+		.sscgEn = 0x0U,                                                                    \
+		.dcoCode = 0x0U,                                                                   \
+		.accMode = 0x1U,                                                                   \
+		.tdcMode = 0x1U,                                                                   \
+		.pllTg = 0x0U,                                                                     \
+		.accCntLock = 0x0U,                                                                \
+		.kiInt = 0x24U,                                                                    \
+		.kpInt = 0x1CU,                                                                    \
+		.kiAccInt = 0x23U,                                                                 \
+		.kpAccInt = 0x1AU,                                                                 \
+		.kiFrac = 0x24U,                                                                   \
+		.kpFrac = 0x20U,                                                                   \
+		.kiAccFrac = 0x23U,                                                                \
+		.kpAccFrac = 0x1AU,                                                                \
+		.kiSscg = 0x18U,                                                                   \
+		.kpSscg = 0x18U,                                                                   \
+		.kiAccSscg = 0x16U,                                                                \
+		.kpAccSscg = 0x14U,                                                                \
+	},
+#else
+#define DPLL_LP_INIT(n)
+#endif
+
 #define FIXED_CLK_INIT(n)                                                                          \
 	static const struct fixed_rate_clock_config fixed_rate_clock_config_##n = {                \
 		.rate = DT_INST_PROP(n, clock_frequency),                                          \
 		.system_clock = DT_INST_PROP(n, system_clock),                                     \
+		DPLL_LP_INIT(n)                                                                    \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(n, fixed_rate_clk_init, NULL, NULL, &fixed_rate_clock_config_##n,    \
 			      PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY, NULL);

--- a/drivers/clock_control/clock_control_ifx_fixed_factor_clock.c
+++ b/drivers/clock_control/clock_control_ifx_fixed_factor_clock.c
@@ -90,6 +90,6 @@ static int fixed_factor_clk_init(const struct device *dev)
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(n, fixed_factor_clk_init, NULL, NULL,                                \
 			      &fixed_factor_clock_config_##n, PRE_KERNEL_1,                        \
-			      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, NULL);
+			      CONFIG_CLOCK_CONTROL_IFX_FIXED_FACTOR_CLOCK_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(FIXED_CLK_INIT)

--- a/dts/arm/infineon/cat1b/psc3/system_clocks.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/system_clocks.dtsi
@@ -46,7 +46,23 @@
 			compatible = "infineon,fixed-clock";
 			clock-frequency = <96000000>;
 			system-clock = <IFX_FLL>;
-			status = "okay";
+			status = "disabled";
+		};
+
+		dpll_lp0: dpll_lp0 {
+			#clock-cells = <0>;
+			compatible = "infineon,fixed-clock";
+			clock-frequency = <0>;
+			system-clock = <IFX_DPLL250_0>;
+			status = "disabled";
+		};
+
+		dpll_lp1: dpll_lp1 {
+			#clock-cells = <0>;
+			compatible = "infineon,fixed-clock";
+			clock-frequency = <0>;
+			system-clock = <IFX_DPLL250_1>;
+			status = "disabled";
 		};
 
 		/* path mux0 */

--- a/dts/arm/infineon/edge/pse84/system_clocks.dtsi
+++ b/dts/arm/infineon/edge/pse84/system_clocks.dtsi
@@ -35,8 +35,24 @@
 	dpll_hp: dpll_hp {
 		#clock-cells = <0>;
 		compatible = "infineon,fixed-clock";
-		clock-frequency = <100000000>;
+		clock-frequency = <0>;
 		system-clock = <IFX_DPLL500>;
+		status = "disabled";
+	};
+
+	dpll_lp0: dpll_lp0 {
+		#clock-cells = <0>;
+		compatible = "infineon,fixed-clock";
+		clock-frequency = <0>;
+		system-clock = <IFX_DPLL250_0>;
+		status = "disabled";
+	};
+
+	dpll_lp1: dpll_lp1 {
+		#clock-cells = <0>;
+		compatible = "infineon,fixed-clock";
+		clock-frequency = <0>;
+		system-clock = <IFX_DPLL250_1>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/clock/infineon,fixed-clock.yaml
+++ b/dts/bindings/clock/infineon,fixed-clock.yaml
@@ -17,3 +17,18 @@ properties:
       The type of clock (refer to include/.../dt-bindings/clock/ifx_clock_source_common.h):
       clk_iho  : system-clock = <IFX_IHO>
       clk_pilo : system-clock = <IFX_PILO>
+
+  feedback-div:
+    type: int
+
+  reference-div:
+    type: int
+
+  output-div:
+    type: int
+
+  fraction-div:
+    type: int
+
+  dco-mode-enable:
+    type: boolean

--- a/dts/bindings/clock/infineon,fixed-clock.yaml
+++ b/dts/bindings/clock/infineon,fixed-clock.yaml
@@ -32,3 +32,21 @@ properties:
 
   dco-mode-enable:
     type: boolean
+
+  div-p:
+    type: int
+
+  div-n:
+    type: int
+
+  div-k:
+    type: int
+
+  freq-mode-sel:
+    type: int
+
+  flock-enable-threshold:
+    type: int
+
+  lf-beta-value:
+    type: int


### PR DESCRIPTION
- add dpll_lp support to infineon clock_control drivers
- fix dpll_hp support
- update kit_pse84_eval dts for dpll fixes
- update kit_psc3m5_evk dts for dpll fixes