### PR TITLE
tests: Bluetooth: SDP: Wait for DUT connect event before send any cmd

### DIFF
--- a/tests/bluetooth/classic/sdp_c/pytest/test_sdp.py
+++ b/tests/bluetooth/classic/sdp_c/pytest/test_sdp.py
@@ -375,6 +375,8 @@ async def sdp_ssa_discover_no_record(hci_port, shell, dut, address) -> None:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
 
+            await wait_for_shell_response(dut, "Connected:")
+
             # Discover SDP Record
             shell.exec_command(f"sdp_client ssa_discovery {BT_L2CAP_PROTOCOL_ID.to_hex_str()}")
             found, lines = await wait_for_shell_response(dut, "No SDP Record")
@@ -407,6 +409,8 @@ async def sdp_ssa_discover_one_record(hci_port, shell, dut, address) -> None:
             except Exception as e:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
+
+            await wait_for_shell_response(dut, "Connected:")
 
             # Discover SDP Record
             shell.exec_command(f"sdp_client ssa_discovery {BT_L2CAP_PROTOCOL_ID.to_hex_str()}")
@@ -464,6 +468,8 @@ async def sdp_ssa_discover_two_records(hci_port, shell, dut, address) -> None:
             except Exception as e:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
+
+            await wait_for_shell_response(dut, "Connected:")
 
             # Discover SDP Record
             shell.exec_command(f"sdp_client ssa_discovery {BT_L2CAP_PROTOCOL_ID.to_hex_str()}")
@@ -535,6 +541,8 @@ async def sdp_ssa_discover_multiple_records(hci_port, shell, dut, address) -> No
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
 
+            await wait_for_shell_response(dut, "Connected:")
+
             # Discover SDP Record
             shell.exec_command(f"sdp_client ssa_discovery {BT_L2CAP_PROTOCOL_ID.to_hex_str()}")
             found, lines = await wait_for_shell_response(dut, "SDP Discovery Done")
@@ -567,6 +575,8 @@ async def sdp_ssa_discover_multiple_records_with_range(hci_port, shell, dut, add
             except Exception as e:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
+
+            await wait_for_shell_response(dut, "Connected:")
 
             # Discover SDP Record with range SDP_SERVICE_RECORD_HANDLE_ATTRIBUTE_ID ~
             # SDP_PROTOCOL_DESCRIPTOR_LIST_ATTRIBUTE_ID
@@ -636,6 +646,8 @@ async def sdp_ss_discover_no_record(hci_port, shell, dut, address) -> None:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
 
+            await wait_for_shell_response(dut, "Connected:")
+
             # Discover SDP Record
             shell.exec_command(f"sdp_client ss_discovery {BT_L2CAP_PROTOCOL_ID.to_hex_str()}")
             found, lines = await wait_for_shell_response(dut, "No SDP Record")
@@ -668,6 +680,8 @@ async def sdp_ss_discover_one_record(hci_port, shell, dut, address) -> None:
             except Exception as e:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
+
+            await wait_for_shell_response(dut, "Connected:")
 
             # Discover SDP Record
             shell.exec_command(f"sdp_client ss_discovery {BT_L2CAP_PROTOCOL_ID.to_hex_str()}")
@@ -712,6 +726,8 @@ async def sdp_ss_discover_two_records(hci_port, shell, dut, address) -> None:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
 
+            await wait_for_shell_response(dut, "Connected:")
+
             # Discover SDP Record
             shell.exec_command(f"sdp_client ss_discovery {BT_L2CAP_PROTOCOL_ID.to_hex_str()}")
             found, lines = await wait_for_shell_response(dut, "SDP Discovery Done")
@@ -754,6 +770,8 @@ async def sdp_ss_discover_multiple_records(hci_port, shell, dut, address) -> Non
             except Exception as e:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
+
+            await wait_for_shell_response(dut, "Connected:")
 
             # Discover SDP Record
             shell.exec_command(f"sdp_client ss_discovery {BT_L2CAP_PROTOCOL_ID.to_hex_str()}")
@@ -799,6 +817,8 @@ async def sdp_sa_discover_no_record(hci_port, shell, dut, address) -> None:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
 
+            await wait_for_shell_response(dut, "Connected:")
+
             # Discover SDP Record
             shell.exec_command("sdp_client sa_discovery 00010001")
             found, lines = await wait_for_shell_response(dut, "No SDP Record")
@@ -831,6 +851,8 @@ async def sdp_sa_discover_one_record(hci_port, shell, dut, address) -> None:
             except Exception as e:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
+
+            await wait_for_shell_response(dut, "Connected:")
 
             # Discover SDP Record
             shell.exec_command("sdp_client sa_discovery 00010001")
@@ -885,6 +907,8 @@ async def sdp_sa_discover_two_records(hci_port, shell, dut, address) -> None:
             except Exception as e:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
+
+            await wait_for_shell_response(dut, "Connected:")
 
             # Discover SDP Record
             shell.exec_command("sdp_client sa_discovery 00010002")
@@ -949,6 +973,8 @@ async def sdp_sa_discover_multiple_records(hci_port, shell, dut, address) -> Non
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
 
+            await wait_for_shell_response(dut, "Connected:")
+
             # Discover SDP Record
             shell.exec_command("sdp_client sa_discovery 00010003")
             found, lines = await wait_for_shell_response(dut, "SDP Discovery Done")
@@ -981,6 +1007,8 @@ async def sdp_sa_discover_multiple_records_with_range(hci_port, shell, dut, addr
             except Exception as e:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
+
+            await wait_for_shell_response(dut, "Connected:")
 
             # Discover SDP Record with range SDP_SERVICE_RECORD_HANDLE_ATTRIBUTE_ID ~
             # SDP_PROTOCOL_DESCRIPTOR_LIST_ATTRIBUTE_ID
@@ -1061,6 +1089,8 @@ async def sdp_ssa_discover_fail(hci_port, shell, dut, address) -> None:
             except Exception as e:
                 logger.error(f'Fail to connect to {target_address}!')
                 raise e
+
+            await wait_for_shell_response(dut, "Connected:")
 
             # Discover SDP Record
             shell.exec_command("sdp_client ssa_discovery_fail")


### PR DESCRIPTION
There is a corner case found that the ACL connected event may be printed when script is sending shell command by calling function `shell.exec_command()`. The echo of shell command will mix with the ACL connected event message. The received message cannot be recognized by the function `shell.exec_command()`. It caused the timeout exception reported by the function `shell.exec_command()`.

Before sending any shell commands, check the DUT connected event after the connection is established on script side.