### PR TITLE
drivers: counter: Fix TPM_CONTROLS_COUNT undefined issue.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 24eff600bd8001fe2b4813f68aa4b0f78e55c219
+      revision: 75bb1262e5bc2a701c63602734738a9c8b096ee5
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Maximum channel number can be indicated by the number of "Channel Status and Control Register".
For sdk-ng, it's defined by macro TPM_CONTROLS_COUNT. 
For some devices using legacy sdk, use TPM_CnSC_COUNT instead.