### PR TITLE
drivers: timer: mcux_lptmr: Fix prescaler bypass issue from devicetree

### DIFF
--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -24,7 +24,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 /* Devicetree properties */
 #define LPTMR_BASE ((LPTMR_Type *)(DT_INST_REG_ADDR(0)))
 #define LPTMR_CLK_SOURCE TO_LPTMR_CLK_SEL(DT_INST_PROP_OR(0, clk_source, 0))
-#define LPTMR_PRESCALER BIT(DT_INST_PROP_OR(0, prescale_glitch_filter, 0))
+#define LPTMR_PRESCALER DT_INST_PROP_OR(0, prescale_glitch_filter, 0)
 #define LPTMR_IRQN DT_INST_IRQN(0)
 #define LPTMR_IRQ_PRIORITY DT_INST_IRQ(0, priority)
 
@@ -85,8 +85,8 @@ static int sys_clock_driver_init(void)
 	config.timerMode = kLPTMR_TimerModeTimeCounter;
 	config.enableFreeRunning = false;
 	config.prescalerClockSource = LPTMR_CLK_SOURCE;
-	config.bypassPrescaler = !LPTMR_PRESCALER;
-	config.value = LPTMR_PRESCALER;
+	config.bypassPrescaler = (LPTMR_PRESCALER == 0);
+	config.value = (LPTMR_PRESCALER == 0) ? 0 : (LPTMR_PRESCALER - 1);
 
 	LPTMR_Init(LPTMR_BASE, &config);
 


### PR DESCRIPTION
The previous implementation had a logical error where the prescaler could never be bypassed due to incorrect use of BIT() macro:

This patch fixes the issue by:

1. Remove BIT() wrapper from LPTMR_PRESCALER macro to use raw devicetree property value
2. Update bypass logic to check for zero value explicitly
3. Map DTS values to hardware register values correctly:
   - prescale_glitch_filter = 0 -> bypass prescaler
   - prescale_glitch_filter = n -> divide by 2^n, using register value (n-1)

The devicetree semantic is now:
- prescale_glitch_filter = <0>: No prescaling (bypass)
- prescale_glitch_filter = <1>: Divide by 2
- prescale_glitch_filter = <2>: Divide by 4
- prescale_glitch_filter = <3>: Divide by 8
- And so on...