### PR TITLE
drivers: i2c: i2c-priv: drop logging and document

### DIFF
--- a/drivers/i2c/i2c-priv.h
+++ b/drivers/i2c/i2c-priv.h
@@ -9,7 +9,6 @@
 
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
-#include <zephyr/logging/log.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,8 +28,6 @@ static inline uint32_t i2c_map_dt_bitrate(uint32_t bitrate)
 	case I2C_BITRATE_ULTRA:
 		return I2C_SPEED_ULTRA << I2C_SPEED_SHIFT;
 	}
-
-	LOG_ERR("Invalid I2C bit rate value");
 
 	return 0;
 }

--- a/drivers/i2c/i2c-priv.h
+++ b/drivers/i2c/i2c-priv.h
@@ -14,6 +14,14 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Map I2C bitrate from DT (in bps) to I2C interface encoding.
+ *
+ * @param bitrate I2C bitrate from DT (in bps)
+ *
+ * @retval bitrate I2C interface encoded bitrate.
+ * @retval 0 If given @p bitrate is not valid.
+ */
 static inline uint32_t i2c_map_dt_bitrate(uint32_t bitrate)
 {
 	switch (bitrate) {


### PR DESCRIPTION
i2c_map_dt_bitrate uses LOG_ERR, however, one must define (or declare) a
log module where to sink the logs. Since this sits on a header file,
it creates a hidden include order dependency: you must include
i2c-priv.h after registering or declaring a log module on your driver.
Even worse, you are forced to use logging in your drivers even if you do
not want to!

Also document the helper function.