### PR TITLE
drivers: adc: siwx91x: Fix clock name

### DIFF
--- a/drivers/clock_control/clock_control_silabs_siwx91x.c
+++ b/drivers/clock_control/clock_control_silabs_siwx91x.c
@@ -104,7 +104,7 @@ static int siwx91x_clock_on(const struct device *dev, clock_control_subsys_t sys
 		ULPCLK->ULP_I2S_CLK_GEN_REG_b.ULP_I2S_MASTER_SLAVE_MODE_b = 1;
 		RSI_ULPSS_PeripheralEnable(ULPCLK, ULP_I2S_CLK, ENABLE_STATIC_CLK);
 		break;
-	case SIWX91X_ADC_CLK:
+	case SIWX91X_CLK_ADC:
 		RSI_ADC_PowerControl(ADC_POWER_ON);
 		break;
 	case SIWX91X_CLK_GPDMA0:
@@ -145,7 +145,7 @@ static int siwx91x_clock_off(const struct device *dev, clock_control_subsys_t sy
 	case SIWX91X_CLK_STATIC_ULP_I2S:
 		RSI_ULPSS_PeripheralDisable(ULPCLK, ULP_I2S_CLK);
 		break;
-	case SIWX91X_ADC_CLK:
+	case SIWX91X_CLK_ADC:
 		RSI_ADC_PowerControl(ADC_POWER_OFF);
 		break;
 	case SIWX91X_CLK_ULP_UART:
@@ -216,7 +216,7 @@ static int siwx91x_clock_set_rate(const struct device *dev, clock_control_subsys
 			return -EIO;
 		}
 		return 0;
-	case SIWX91X_ADC_CLK:
+	case SIWX91X_CLK_ADC:
 		RSI_ADC_ClkDivfactor(AUX_ADC_DAC_COMP, div_numerator, div_denominator);
 		return 0;
 	default:

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -438,7 +438,7 @@
 			interrupts = <11 0>;
 			interrupt-names = "adc0";
 			silabs,adc-sampling-rate = <100000>;
-			clocks = <&clock0 SIWX91X_ADC_CLK>;
+			clocks = <&clock0 SIWX91X_CLK_ADC>;
 			#io-channel-cells = <1>;
 			status = "disabled";
 		};

--- a/include/zephyr/dt-bindings/clock/silabs/siwx91x-clock.h
+++ b/include/zephyr/dt-bindings/clock/silabs/siwx91x-clock.h
@@ -21,7 +21,7 @@
 #define SIWX91X_CLK_STATIC_I2S0    14
 #define SIWX91X_CLK_ULP_I2S        15
 #define SIWX91X_CLK_STATIC_ULP_I2S 16
-#define SIWX91X_ADC_CLK            17
+#define SIWX91X_CLK_ADC            17
 #define SIWX91X_CLK_GPDMA0         18
 
 #endif


### PR DESCRIPTION
All the clocks names on SiWx91x follow the pattern "SIWX91X_CLK_xxx". SIWX91X_ADC_CLK was an exception.