### PR TITLE
twister: Add support for passing extra serial port to pytest

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -1259,6 +1259,10 @@ the following new options:
 The ``--device-serial`` option denotes the serial device the board is connected to.
 This needs to be accessible by the user running twister. You can run this on
 only one board at a time, specified using the ``--platform`` option.
+If the platform supports multiple serial ports, you can provide ``--device-serial``
+multiple times, and it will be passed to the pytest harness.
+However, currently the pytest-twister-harness plugin handles only the first serial port,
+other ports must be opened manually in the test code.
 
 The ``--device-serial-baud`` option is only needed if your device does not run at
 115200 baud.

--- a/samples/sysbuild/hello_world/pytest/test_both_uart.py
+++ b/samples/sysbuild/hello_world/pytest/test_both_uart.py
@@ -7,6 +7,7 @@
 import logging
 import re
 import time
+from collections.abc import Generator
 
 import pytest
 import serial
@@ -18,57 +19,48 @@ logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture(scope=determine_scope)
-def dut(request: pytest.FixtureRequest, device_object: DeviceAdapter):
-    device_object.initialize_log_files(request.node.name)
+def second_serial(
+    request: pytest.FixtureRequest, device_object: DeviceAdapter
+) -> Generator[serial.Serial | None, None, None]:
+    """Return second serial port if provided."""
+    device_serials = request.config.getoption('--device-serial')
 
-    device_object.second_serial = None
-    second_serial_port_name = device_object.device_config.serial
-    if "if00" in device_object.device_config.serial:
-        second_serial_port_name = device_object.device_config.serial.replace("if00", "if02")
-    elif "if02" in device_object.device_config.serial:
-        second_serial_port_name = device_object.device_config.serial.replace("if02", "if00")
+    if not device_serials or len(device_serials) <= 1:
+        pytest.skip("Second serial not available")
 
-    if second_serial_port_name != device_object.device_config.serial:
-        device_object.second_serial = serial.Serial(
-            port=second_serial_port_name,
-            baudrate=device_object.device_config.baud,
-            timeout=1,
-            rtscts=True,
-        )
-    device_object.launch()
-    try:
-        yield device_object
-    finally:
-        device_object.close()
-        if device_object.second_serial is not None:
-            device_object.second_serial.close()
+    logger.debug(f"Opening serial connection for {device_serials[1]}")
+    second_serial = serial.Serial(
+        port=device_serials[1],
+        baudrate=device_object.device_config.baud,
+        timeout=1,
+        rtscts=True,
+    )
+    yield second_serial
+    second_serial.close()
 
 
-def test_both_uart(dut: DeviceAdapter):
-    """
-    Verify logs from both uarts
-    """
+def test_uart_in_app(dut: DeviceAdapter):
+    """Verify logs from uart in application"""
+    timeout = 5
+    regex = "Hello world from .*"
+    dut.readlines_until(regex=regex, print_output=True, timeout=timeout)
+
+
+def test_uart_in_second_core(second_serial: serial.Serial | None, dut: DeviceAdapter):
+    """Verify logs from uart in second core"""
     timeout = 5
     regex = "Hello world from .*"
 
-    # verify first port
-    dut.readlines_until(regex=regex, print_output=True, timeout=timeout)
-
-    # verify second port
-    # skip if there is no second port
-    if dut.second_serial is not None:
-        regex_compiled = re.compile(regex)
-        timeout_time: float = time.time() + timeout
-        while time.time() < timeout_time:
-            try:
-                line = dut.second_serial.readline().decode("utf-8")
-                logger.debug(f"Second serial: -{line}-")
-            except serial.SerialException:
-                logger.exception("Second serial")
-            if regex_compiled.search(line):
-                logger.debug("Second serial - found")
-                break
-        else:
-            raise AssertionError(f"Second serial - regex not found: {regex}")
+    regex_compiled = re.compile(regex)
+    timeout_time: float = time.time() + timeout
+    while time.time() < timeout_time:
+        try:
+            line = second_serial.readline().decode("utf-8")
+            logger.debug(f"Second serial: -{line}-")
+        except serial.SerialException:
+            logger.exception("Second serial")
+        if regex_compiled.search(line):
+            logger.debug("Second serial - found")
+            break
     else:
-        logger.error("Second serial - skipped")
+        raise AssertionError(f"Second serial - regex not found: {regex}")

--- a/samples/sysbuild/hello_world/sample.yaml
+++ b/samples/sysbuild/hello_world/sample.yaml
@@ -7,9 +7,6 @@ sample:
 common:
   sysbuild: true
   harness: pytest
-  harness_config:
-    pytest_dut_scope: session
-  timeout: 20
 
 tests:
   sample.sysbuild.hello_world.nrf5340dk_cpuapp_cpunet:
@@ -59,6 +56,9 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
+    harness_config: &pytest_only_first_uart
+      pytest_root:
+        - "pytest/test_both_uart.py::test_uart_in_app"
     extra_args:
       - SB_CONFIG_REMOTE_NRF54H20_CPUFLPR_CORE=y
       - hello_world_SNIPPET=nordic-flpr
@@ -67,6 +67,7 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
+    harness_config: *pytest_only_first_uart
     extra_args:
       - SB_CONFIG_REMOTE_NRF54H20_CPUFLPR_XIP_CORE=y
       - hello_world_SNIPPET=nordic-flpr-xip

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -59,7 +59,7 @@ def pytest_addoption(parser: pytest.Parser):
         help='Name of used platform (qemu_x86, nrf52840dk/nrf52840, etc.).'
     )
     twister_harness_group.addoption(
-        '--device-serial',
+        '--device-serial', action='append', default=[],
         help='Serial device for accessing the board (e.g., /dev/ttyACM0).'
     )
     twister_harness_group.addoption(

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -74,7 +74,7 @@ class TwisterHarnessConfig:
             base_timeout=config.option.base_timeout,
             flash_timeout=config.option.flash_timeout,
             platform=config.option.platform,
-            serial=config.option.device_serial,
+            serial=config.option.device_serial[0] if config.option.device_serial else '',
             baud=config.option.device_serial_baud,
             runner=config.option.runner,
             runner_params=runner_params,

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -189,7 +189,7 @@ Artificially long but functional example:
              "argument is not passed, then the first simulator is selected.")
 
 
-    device.add_argument("--device-serial",
+    device.add_argument("--device-serial", action="append", default=[],
                         help="""Serial device for accessing the board
                         (e.g., /dev/ttyACM0)
                         """)

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -29,6 +29,7 @@ from queue import Empty, Queue
 import psutil
 from twisterlib.environment import ZEPHYR_BASE, strip_ansi_sequences
 from twisterlib.error import TwisterException
+from twisterlib.hardwaremap import DUT
 from twisterlib.platform import Platform
 from twisterlib.statuses import TwisterStatus
 
@@ -105,6 +106,7 @@ class Handler:
 
         self.args = []
         self.terminated = False
+        self.duts: list[DUT] = []
 
     def get_test_timeout(self):
         return math.ceil(self.instance.testsuite.timeout *
@@ -507,10 +509,10 @@ class DeviceHandler(Handler):
             for d in duts:
                 d.lock.release()
 
-    def device_is_available(self, instance):
+    def device_is_available(self, instance) -> DUT | None:
         device = instance.platform.name
         fixture = instance.testsuite.harness_config.get("fixture")
-        duts_found = []
+        duts_found: list[DUT] = []
 
         for d in self.duts:
             if fixture and fixture not in map(lambda f: f.split(sep=':')[0], d.fixtures):
@@ -540,7 +542,7 @@ class DeviceHandler(Handler):
 
         return None
 
-    def make_dut_available(self, dut):
+    def make_dut_available(self, dut: DUT) -> None:
         if self.instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
             dut.failures_increment()
         logger.debug(f"Release DUT:{dut.platform}, Id:{dut.id}, "
@@ -688,8 +690,15 @@ class DeviceHandler(Handler):
 
         self.make_dut_available(dut)
 
+    def get_more_serials_from_device(self, hardware: DUT) -> list[str]:
+        serials = set()
+        dut_shared_hw = [_d for _d in self.duts if _d.id == hardware.id]
+        for d in dut_shared_hw:
+            if d.serial and d.serial != hardware.serial:
+                serials.add(d.serial)
+        return list(serials)
 
-    def get_hardware(self):
+    def get_hardware(self) -> DUT | None:
         hardware = None
         try:
             hardware = self.device_is_available(self.instance)
@@ -697,7 +706,7 @@ class DeviceHandler(Handler):
             while not hardware:
                 time.sleep(1)
                 in_waiting += 1
-                if in_waiting%60 == 0:
+                if in_waiting % 60 == 0:
                     logger.debug(f"Waiting for a DUT to run {self.instance.name}")
                 hardware = self.device_is_available(self.instance)
         except TwisterException as error:

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -169,7 +169,7 @@ class HardwareMap:
 
     def __init__(self, env=None):
         self.detected = []
-        self.duts = []
+        self.duts: list[DUT] = []
         self.options = env.options
 
     def discover(self):
@@ -195,7 +195,7 @@ class HardwareMap:
                             self.options.platform.append(d.platform)
 
             elif self.options.device_serial:
-                self.add_device(self.options.device_serial,
+                self.add_device(self.options.device_serial[0],
                                 self.options.platform[0],
                                 self.options.pre_script,
                                 False,
@@ -204,6 +204,12 @@ class HardwareMap:
                                 flash_with_test=self.options.device_flash_with_test,
                                 flash_before=self.options.flash_before,
                                 )
+                if len(self.options.device_serial) > 1:
+                    for serial in self.options.device_serial[1:]:
+                        self.add_device(serial,
+                                        platform=None,
+                                        pre_script=None,
+                                        is_pty=False)
 
             elif self.options.device_serial_pty:
                 self.add_device(self.options.device_serial_pty,

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
@@ -469,6 +470,8 @@ class Pytest(Harness):
                 f'--device-serial={hardware.serial}',
                 f'--device-serial-baud={hardware.baud}'
             ])
+            for extra_serial in handler.get_more_serials_from_device(hardware):
+                command.append(f'--device-serial={extra_serial}')
 
         if hardware.flash_timeout:
             command.append(f'--flash-timeout={hardware.flash_timeout}')

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -29,6 +29,7 @@ from packaging import version
 from twisterlib.cmakecache import CMakeCache
 from twisterlib.environment import canonical_zephyr_base
 from twisterlib.error import BuildError, ConfigurationError, StatusAttributeError
+from twisterlib.hardwaremap import DUT
 from twisterlib.log_helper import setup_logging
 from twisterlib.statuses import TwisterStatus
 
@@ -878,7 +879,7 @@ class ProjectBuilder(FilterBuilder):
         self.filtered_tests = 0
         self.options = env.options
         self.env = env
-        self.duts = None
+        self.duts: list[DUT] = []
 
     @property
     def trace(self) -> bool:
@@ -1813,7 +1814,7 @@ class TwisterRunner:
         self.env = env
         self.instances: dict[str, TestInstance] = instances
         self.suites: dict[str, TestSuite] = suites
-        self.duts = None
+        self.duts: list[DUT] = []
         self.jobs = 1
         self.results = None
         self.jobserver = None

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -573,6 +573,7 @@ def test_pytest__generate_parameters_for_hardware(tmp_path, pty_value, hardware_
     # Act
     if hardware_value == 0:
         handler.get_hardware.return_value = hardware
+        handler.get_more_serials_from_device = mock.Mock(return_value=[])
         command = pytest_test._generate_parameters_for_hardware(handler)
     else:
         handler.get_hardware.return_value = None


### PR DESCRIPTION
Extend twister's device serial handling to support multiple serial ports
for pytest-based tests. This enables testing scenarios that require
communication with multiple UART interfaces on the same device.
This enhancement enables comprehensive testing of multi-UART devices
while maintaining backward compatibility with single serial setups.

Updated from samples/sysbuild/hello_world (fixes problem from https://github.com/zephyrproject-rtos/zephyr/pull/95848, where interface identifiers are required and changed between if00 and if01 in test).

Tested with commands:
```
# using hardware map:
./scripts/twister -vv -ll debug --no-clean --west-flash=--erase -T samples/sysbuild/hello_world --device-testing --hardware-map ~/tmp/hardware_map.yml

# or passing second serial with command line:
./scripts/twister -vv -ll debug --no-clean --west-flash=--erase -T samples/sysbuild/hello_world --device-testing --device-serial /dev/ttyACM1 --device-serial /dev/ttyACM0 -p nrf54l15dk/nrf54l15/cpuapp

INFO    - 1/1 nrf54l15dk/nrf54l15/cpuapp sample.sysbuild.hello_world.nrf54l15dk_nrf54l15_cpuflpr PASSED (device 7.911s <zephyr>)
INFO    -                                    sample.sysbuild.hello_world.nrf54l15dk_nrf54l15_cpuflpr.test_uart_in_app    PASSED      
INFO    -                                    sample.sysbuild.hello_world.nrf54l15dk_nrf54l15_cpuflpr.test_uart_in_second_core PASSED 

# when only one serial is given then second test is skipped:
./scripts/twister -vv -ll debug --no-clean --west-flash=--erase -T samples/sysbuild/hello_world --device-testing --device-serial /dev/ttyACM1 -p nrf54l15dk/nrf54l15/cpuapp

INFO    - 1/1 nrf54l15dk/nrf54l15/cpuapp sample.sysbuild.hello_world.nrf54l15dk_nrf54l15_cpuflpr PASSED (device 3.777s <zephyr>)
INFO    -                                    sample.sysbuild.hello_world.nrf54l15dk_nrf54l15_cpuflpr.test_uart_in_app    PASSED      
INFO    -                                    sample.sysbuild.hello_world.nrf54l15dk_nrf54l15_cpuflpr.test_uart_in_second_core SKIPPED      Second serial not available
```
