### PR TITLE
scripts: ci: check_compliance: Fix not checking CMakeLists.txt files

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1859,7 +1859,7 @@ class CMakeStyle(ComplianceTest):
     def run(self):
         # Loop through added/modified files
         for fname in get_files(filter="d"):
-            if fname.endswith(".cmake") or fname == "CMakeLists.txt":
+            if fname.endswith(".cmake") or fname.endswith("CMakeLists.txt"):
                 self.check_style(fname)
 
     def check_style(self, fname):


### PR DESCRIPTION
Fixes an oversight of only checking files that are exactly named CMakeLists.txt - this includes the directory name, so that it actually checks any file in the tree with this name