### PR TITLE
scripts: ... :edtlib.py: update edtlib.py to generate some warning messages

### DIFF
--- a/scripts/dts/gen_edt.py
+++ b/scripts/dts/gen_edt.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2019 - 2020 Nordic Semiconductor ASA
 # Copyright (c) 2019 Linaro Limited
 # Copyright (c) 2024 SILA Embedded Solutions GmbH
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 # This script uses edtlib to generate a pickled edt from a devicetree
@@ -50,7 +51,8 @@ def main():
                          default_prop_types=True,
                          infer_binding_for_paths=["/zephyr,user", "/cpus"],
                          werror=args.edtlib_Werror,
-                         vendor_prefixes=vendor_prefixes)
+                         vendor_prefixes=vendor_prefixes,
+                         warn_bus_mismatch=args.warn_bus_mismatch)
     except edtlib.EDTError as e:
         sys.exit(f"devicetree error: {e}")
 
@@ -87,6 +89,9 @@ def parse_args() -> argparse.Namespace:
                         help="if set, edtlib-specific warnings become errors. "
                              "(this does not apply to warnings shared "
                              "with dtc.)")
+    parser.add_argument("--warn-bus-mismatch", action="store_true",
+                        help="warn when devicetree nodes are on buses that "
+                             "don't match available binding expectations")
 
     return parser.parse_args()
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # Copyright (c) 2019 Linaro Limited
+# Copyright 2025 NXP
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Tip: You can view just the documentation with 'pydoc3 devicetree.edtlib'
@@ -1361,6 +1362,14 @@ class Node:
                 # works the same way in Zephyr as it does elsewhere.
                 binding = None
 
+                # Collect all available bindings for this compatible for warning purposes
+                available_bindings = [
+                    (binding_bus, candidate_binding.path)
+                    for (binding_compat, binding_bus), candidate_binding
+                    in self.edt._compat2binding.items()
+                    if binding_compat == compat
+                ]
+
                 for bus in on_buses:
                     if (compat, bus) in self.edt._compat2binding:
                         binding = self.edt._compat2binding[compat, bus]
@@ -1370,6 +1379,27 @@ class Node:
                     if (compat, None) in self.edt._compat2binding:
                         binding = self.edt._compat2binding[compat, None]
                     else:
+                        # No matching binding found - warn if bindings exist for other buses
+                        if (available_bindings and
+                            self.edt._warn_bus_mismatch):
+                            current_bus = on_buses[0] if on_buses else "none"
+
+                            # Format available bus information for the warning
+                            available_bus_info = []
+                            for bus, binding_path in available_bindings:  # type: ignore
+                                bus_name = bus if bus is not None else "any"
+                                # Get relative path for cleaner output
+                                rel_path = (os.path.relpath(binding_path)
+                                            if binding_path is not None else "unknown")
+                                bus_info = f"'{bus_name}' (from {rel_path})"
+                                available_bus_info.append(bus_info)
+
+                            _LOG.warning(
+                                f"Node '{self.path}' with compatible '{compat}' "
+                                f"is on bus '{current_bus}', but available bindings "
+                                f"expect: {', '.join(available_bus_info)}. "
+                                f"No binding will be applied to this node."
+                            )
                         continue
 
                 self._binding = binding
@@ -1995,7 +2025,8 @@ class EDT:
                  support_fixed_partitions_on_any_bus: bool = True,
                  infer_binding_for_paths: Optional[Iterable[str]] = None,
                  vendor_prefixes: Optional[dict[str, str]] = None,
-                 werror: bool = False):
+                 werror: bool = False,
+                 warn_bus_mismatch: bool = False):
         """EDT constructor.
 
         dts:
@@ -2039,6 +2070,10 @@ class EDT:
           If True, some edtlib specific warnings become errors. This currently
           errors out if 'dts' has any deprecated properties set, or an unknown
           vendor prefix is used.
+
+        warn_bus_mismatch (default: False):
+          If True, a warning is logged if a node's actual bus does not match
+            the bus specified in its binding.
         """
         # All instance attributes should be initialized here.
         # This makes it easy to keep track of them, which makes
@@ -2065,6 +2100,7 @@ class EDT:
         self._infer_binding_for_paths: set[str] = set(infer_binding_for_paths or [])
         self._vendor_prefixes: dict[str, str] = vendor_prefixes or {}
         self._werror: bool = bool(werror)
+        self._warn_bus_mismatch: bool = warn_bus_mismatch
 
         # Other internal state
         self._compat2binding: dict[tuple[str, Optional[str]], Binding] = {}


### PR DESCRIPTION
During the actual development process, it was discovered that the controller/device' would describe the bus type in the binding. However, when the two sides did not match, the generated process would not be affected and there were no any prompts. This made it very difficult for developers to identify the problem.

I've updated the implementation to:
1. Add a `warn_bus_mismatch` kwarg to `edtlib.EDT()` constructor (default: False)
2. Add a `--warn-bus-mismatch` flag to gen_edt.py
3. Only show the warning when explicitly opted in
4. Add some checks in the edtlib. When the bus type of the node does not match the binding requirements, provide some auxiliary judgment information:
                  -  bus position of the node
                  -  available binding types
                  -  expected binding type.