### PR TITLE
Clean-up some bleeding Kconfig options

### DIFF
--- a/drivers/usb_c/vbus/Kconfig
+++ b/drivers/usb_c/vbus/Kconfig
@@ -10,6 +10,10 @@ menuconfig USBC_VBUS_DRIVER
 
 if USBC_VBUS_DRIVER
 
+module = USBC
+module-str = usbc
+source "subsys/logging/Kconfig.template.log_config"
+
 config USBC_VBUS_INIT_PRIORITY
 	int "USB-C VBUS driver init priority"
 	default 85
@@ -21,7 +25,3 @@ source "drivers/usb_c/vbus/Kconfig.numaker"
 source "drivers/usb_c/vbus/Kconfig.usbc_vbus_tcpci"
 
 endif # USBC_VBUS_DRIVER
-
-module = USBC
-module-str = usbc
-source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/virtio/Kconfig
+++ b/drivers/virtio/Kconfig
@@ -8,6 +8,10 @@ config VIRTIO
 
 if VIRTIO
 
+module = VIRTIO
+module-str = VIRTIO
+source "subsys/logging/Kconfig.template.log_config"
+
 config VIRTIO_PCI
 	bool "support for VIRTIO over PCI"
 	default y
@@ -23,7 +27,3 @@ config VIRTIO_MMIO
 	  Enable options for VIRTIO over MMIO
 
 endif # VIRTIO
-
-module = VIRTIO
-module-str = VIRTIO
-source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
Kconfig log modules for a couple drivers were not properly gated.