### PR TITLE
Fix compliance check: output > 64KB + annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ BoardYml.txt
 Checkpatch.txt
 ClangFormat.txt
 DevicetreeBindings.txt
+DevicetreeLinting.txt
 GitDiffCheck.txt
 Gitlint.txt
 Identity.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "dts-linter": "^0.3.0"
+        "dts-linter": "^0.3.2"
       }
     },
     "node_modules/devicetree-language-server": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/devicetree-language-server/-/devicetree-language-server-0.6.2.tgz",
-      "integrity": "sha512-zdSQXVXXheowYuX3FapLo8Mi7U3sLLzBLCZ6fLjM2p6afqD7E9Pwd9eLndhUNW2rkJGsJzu9gvVmvYa/PBdxkg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/devicetree-language-server/-/devicetree-language-server-0.6.3.tgz",
+      "integrity": "sha512-mvZC217Cq+WmqB51dk5+4slI3obcUgzaHBxroCkAR4clmiC0+PYi8hnY1PWB+HekOT2pWIDHT3/tCAfq31aK7Q==",
       "license": "Apache-2.0",
       "bin": {
         "devicetree-language-server": "dist/server.js"
@@ -21,12 +21,12 @@
       }
     },
     "node_modules/dts-linter": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dts-linter/-/dts-linter-0.3.0.tgz",
-      "integrity": "sha512-vDoUWNecAyMcyMYSNagf5UHYeiWY2cF2IYKgY7WC97lXu9la1pLf95r9jKJEmCQSSTwjS4t1nCkd7ZllWgJBlQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/dts-linter/-/dts-linter-0.3.2.tgz",
+      "integrity": "sha512-IXvPQhRuAGZ78mKn13fRfUoVhjbPiBqmy3NoVqPsFuW/0ZTbiPInBbiMxNB8dN5PImDja3Q8I2V3GG/RJNPdOg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "devicetree-language-server": "^0.6.2"
+        "devicetree-language-server": "^0.6.3"
       },
       "bin": {
         "dts-linter": "dist/dts-linter.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "dts-linter": "^0.3.0"
+    "dts-linter": "^0.3.2"
   }
 }


### PR DESCRIPTION
Bump up dts-linter to 0.3.1 to fix issue when json output is not flushed to stdout before dts-linter exits.

Bump up dts-linter to 0.3.2 to address undefined in annotation messages