### PR TITLE
manifest: hostap: Enable server certificate verification

### DIFF
--- a/doc/connectivity/networking/api/wifi.rst
+++ b/doc/connectivity/networking/api/wifi.rst
@@ -120,6 +120,29 @@ To initiate a Wi-Fi connection using enterprise security, use one of the followi
 Server certificate is also provided in the same directory for testing purposes.
 Any AAA server can be used for testing purposes, for example, ``FreeRADIUS`` or ``hostapd``.
 
+Server certificate domain name verification
+-------------------------------------------
+
+The authentication server’s identity is verified by validating the domain name in the X.509 certificate received from the server, using the ``Common Name`` (CN) field.
+
+* Exact domain match — Verifies that the certificate’s CN exactly matches the specified domain.
+
+* Domain suffix match — Allows a certificate whose CN ends with the specified domain suffix.
+
+To initiate a Wi-Fi connection using enterprise security with server certificate validation, use one of the following commands, depending on the desired validation mode:
+
+* Exact domain match
+
+  .. code-block:: console
+
+     wifi connect -s <SSID> -c <channel> -k 12 -K <Private key Password> -e <Domain match>
+
+* Domain suffix match
+
+  .. code-block:: console
+
+     wifi connect -s <SSID> -c <channel> -k 12 -K <Private key Password> -x <Domain suffix name>
+
 Certificate requirements for EAP methods
 ----------------------------------------
 

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -723,6 +723,16 @@ struct wifi_connect_req_params {
 	uint8_t ignore_broadcast_ssid;
 	/** Parameter used for frequency band */
 	enum wifi_frequency_bandwidths bandwidth;
+
+	/** Full domain name to verify in the server certificate */
+	const uint8_t *server_cert_domain_exact;
+	/** Length of the server_cert_domain_exact string, maximum 128 bytes */
+	uint8_t server_cert_domain_exact_len;
+
+	/** Domain name suffix to verify in the server certificate */
+	const uint8_t *server_cert_domain_suffix;
+	/** Length of the server_cert_domain_suffix string, maximum 64 bytes */
+	uint8_t server_cert_domain_suffix_len;
 };
 
 /** @brief Wi-Fi disconnect reason codes. To be overlaid on top of \ref wifi_status

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -969,6 +969,22 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 				goto out;
 			}
 
+			if (params->server_cert_domain_exact_len > 0) {
+				if (!wpa_cli_cmd_v("set_network %d domain_match \"%s\"",
+						   resp.network_id,
+						   params->server_cert_domain_exact)) {
+					goto out;
+				}
+			}
+
+			if (params->server_cert_domain_suffix_len > 0) {
+				if (!wpa_cli_cmd_v("set_network %d domain_suffix_match \"%s\"",
+						   resp.network_id,
+						   params->server_cert_domain_suffix)) {
+					goto out;
+				}
+			}
+
 			if (false == ((params->security == WIFI_SECURITY_TYPE_EAP_PEAP_MSCHAPV2 ||
 			    params->security == WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2) &&
 			    (!params->verify_peer_cert))) {

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -620,6 +620,8 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 		{"ignore-broadcast-ssid", required_argument, 0, 'g'},
 		{"ieee-80211r", no_argument, 0, 'R'},
 		{"iface", required_argument, 0, 'i'},
+		{"server-cert-domain-exact", required_argument, 0, 'e'},
+		{"server-cert-domain-suffix", required_argument, 0, 'x'},
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}};
 	char *endptr;
@@ -871,6 +873,16 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			break;
 		case 'i':
 			/* Unused, but parsing to avoid unknown option error */
+			break;
+		case 'e':
+			params->server_cert_domain_exact = state->optarg;
+			params->server_cert_domain_exact_len =
+					strlen(params->server_cert_domain_exact);
+			break;
+		case 'x':
+			params->server_cert_domain_suffix = state->optarg;
+			params->server_cert_domain_suffix_len =
+					strlen(params->server_cert_domain_suffix);
 			break;
 		case 'h':
 			return -ENOEXEC;
@@ -4028,10 +4040,12 @@ SHELL_SUBCMD_ADD((wifi), connect, NULL,
 		 "[-P, --eap-pwd1]: Client Password.\n"
 		 "Default no password for eap user.\n"
 		 "[-R, --ieee-80211r]: Use IEEE80211R fast BSS transition connect."
+		 "[-e, --server-cert-domain-exact]: Full domain names for server certificate match.\n"
+		 "[-x, --server-cert-domain-suffix]: Domain name suffixes for server certificate match.\n"
 		 "[-h, --help]: Print out the help for the connect command.\n"
 		 "[-i, --iface=<interface index>] : Interface index.\n",
 		 cmd_wifi_connect,
-		 2, 42);
+		 2, 46);
 
 SHELL_SUBCMD_ADD((wifi), disconnect, NULL,
 		 "Disconnect from the Wi-Fi AP.\n"

--- a/west.yml
+++ b/west.yml
@@ -286,7 +286,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: cf05f33f594de6b62840a3b0dd435f10467a2e4c
+      revision: 6086dea5ee7406e1eede7f2ca6dff1b00b0f04e2
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
Enable hostname validation for server certificate verification.

Fixes #88697