### PR TITLE
drivers: ethernet: stm32: add PTP HAL flag for N6

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -101,7 +101,8 @@ menuconfig PTP_CLOCK_STM32_HAL
 	depends on SOC_SERIES_STM32F7X \
 		   || SOC_SERIES_STM32H5X \
 		   || SOC_SERIES_STM32H7X \
-		   || SOC_SERIES_STM32H7RSX
+		   || SOC_SERIES_STM32H7RSX \
+		   || SOC_SERIES_STM32N6X
 	help
 	  Enable STM32 PTP clock support.
 


### PR DESCRIPTION
Add depends on SOC_SERIES_STM32N6X to PTP_CLOCK_STM32_HAL in order to use PTP on the STM32N6 series.

Fixes #98132 