### PR TITLE
boards: st: correct or add RAM/Flash sizes in some ST boards YAML files

### DIFF
--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a.yaml
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 786
+ram: 768
 flash: 2048
 supported:
   - arduino_i2c

--- a/boards/st/nucleo_f303re/nucleo_f303re.yaml
+++ b/boards/st/nucleo_f303re/nucleo_f303re.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 80
+ram: 64
 flash: 512
 supported:
   - arduino_gpio

--- a/boards/st/nucleo_f446re/nucleo_f446re.yaml
+++ b/boards/st/nucleo_f446re/nucleo_f446re.yaml
@@ -15,6 +15,6 @@ supported:
   - i2c
   - can
   - backup_sram
-ram: 96
+ram: 128
 flash: 512
 vendor: st

--- a/boards/st/nucleo_f722ze/nucleo_f722ze.yaml
+++ b/boards/st/nucleo_f722ze/nucleo_f722ze.yaml
@@ -20,6 +20,6 @@ supported:
   - spi
   - usb_device
   - rtc
-ram: 256
+ram: 192
 flash: 512
 vendor: st

--- a/boards/st/nucleo_f767zi/nucleo_f767zi.yaml
+++ b/boards/st/nucleo_f767zi/nucleo_f767zi.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 512
+ram: 384
 flash: 2048
 supported:
   - adc

--- a/boards/st/nucleo_h533re/nucleo_h533re.yaml
+++ b/boards/st/nucleo_h533re/nucleo_h533re.yaml
@@ -7,7 +7,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-ram: 272
+ram: 128
 flash: 512
 supported:
   - arduino_gpio

--- a/boards/st/nucleo_h563zi/nucleo_h563zi.yaml
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-ram: 640
+ram: 256
 flash: 2048
 supported:
   - arduino_gpio

--- a/boards/st/nucleo_h723zg/nucleo_h723zg.yaml
+++ b/boards/st/nucleo_h723zg/nucleo_h723zg.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 372
+ram: 320
 flash: 1024
 supported:
   - arduino_gpio

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.yaml
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 288
+ram: 128
 flash: 1024
 supported:
   - arduino_gpio

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m4.yaml
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m4.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 288
+ram: 128
 flash: 1024
 supported:
   - arduino_gpio

--- a/boards/st/nucleo_h7a3zi_q/nucleo_h7a3zi_q.yaml
+++ b/boards/st/nucleo_h7a3zi_q/nucleo_h7a3zi_q.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 1280
+ram: 256
 flash: 2048
 supported:
   - arduino_gpio

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.yaml
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-ram: 640
+ram: 128
 flash: 64
 supported:
   - gpio

--- a/boards/st/nucleo_l412rb_p/nucleo_l412rb_p.yaml
+++ b/boards/st/nucleo_l412rb_p/nucleo_l412rb_p.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 40
-flash: 64
+flash: 128
 supported:
   - nvs
   - pwm

--- a/boards/st/nucleo_u031r8/nucleo_u031r8.yaml
+++ b/boards/st/nucleo_u031r8/nucleo_u031r8.yaml
@@ -12,5 +12,5 @@ supported:
   - i2c
   - pwm
   - usart
-ram: 12
+ram: 8
 flash: 64

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.yaml
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.yaml
@@ -19,5 +19,5 @@ supported:
   - rtc
   - spi
   - usart
-ram: 40
+ram: 32
 flash: 256

--- a/boards/st/nucleo_u575zi_q/nucleo_u575zi_q.yaml
+++ b/boards/st/nucleo_u575zi_q/nucleo_u575zi_q.yaml
@@ -21,6 +21,6 @@ supported:
   - backup_sram
   - dma
   - rtc
-ram: 786
+ram: 768
 flash: 2048
 vendor: st

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.yaml
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.yaml
@@ -22,5 +22,5 @@ supported:
   - dma
   - rtc
   - usb_device
-ram: 2450
+ram: 2496
 flash: 4096

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.yaml
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.yaml
@@ -15,6 +15,6 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_spi
-ram: 512
+ram: 448
 flash: 2048
 vendor: st

--- a/boards/st/sensortile_box/sensortile_box.yaml
+++ b/boards/st/sensortile_box/sensortile_box.yaml
@@ -14,6 +14,6 @@ supported:
   - usb device
   - nvs
   - counter
-ram: 640
+ram: 192
 flash: 2048
 vendor: st

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.yaml
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.yaml
@@ -14,6 +14,6 @@ supported:
   - usb device
   - nvs
   - counter
-ram: 640
+ram: 768
 flash: 2048
 vendor: st

--- a/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.yaml
+++ b/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 192
+ram: 128
 flash: 1024
 supported:
   - gpio

--- a/boards/st/steval_stwinbx1/steval_stwinbx1.yaml
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 786
+ram: 768
 flash: 2048
 supported:
   - counter

--- a/boards/st/stm32373c_eval/stm32373c_eval.yaml
+++ b/boards/st/stm32373c_eval/stm32373c_eval.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 32
+flash: 256
 supported:
   - watchdog
   - counter

--- a/boards/st/stm32f0_disco/stm32f0_disco.yaml
+++ b/boards/st/stm32f0_disco/stm32f0_disco.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 8
+flash: 64
 supported:
   - watchdog
   - adc

--- a/boards/st/stm32f3_disco/stm32f3_disco_B.yaml
+++ b/boards/st/stm32f3_disco/stm32f3_disco_B.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 40
+flash: 256
 supported:
   - gpio
   - i2c

--- a/boards/st/stm32f3_disco/stm32f3_disco_stm32f303xc_E.yaml
+++ b/boards/st/stm32f3_disco/stm32f3_disco_stm32f303xc_E.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 40
+flash: 256
 supported:
   - gpio
   - i2c

--- a/boards/st/stm32f411e_disco/stm32f411e_disco_stm32f411xe_B.yaml
+++ b/boards/st/stm32f411e_disco/stm32f411e_disco_stm32f411xe_B.yaml
@@ -5,6 +5,8 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+ram: 128
+flash: 512
 supported:
   - counter
 vendor: st

--- a/boards/st/stm32f411e_disco/stm32f411e_disco_stm32f411xe_D.yaml
+++ b/boards/st/stm32f411e_disco/stm32f411e_disco_stm32f411xe_D.yaml
@@ -5,6 +5,8 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+ram: 128
+flash: 512
 supported:
   - counter
 vendor: st

--- a/boards/st/stm32f412g_disco/stm32f412g_disco.yaml
+++ b/boards/st/stm32f412g_disco/stm32f412g_disco.yaml
@@ -5,6 +5,8 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+ram: 256
+flash: 1024
 supported:
   - arduino_gpio
   - arduino_serial

--- a/boards/st/stm32f413h_disco/stm32f413h_disco.yaml
+++ b/boards/st/stm32f413h_disco/stm32f413h_disco.yaml
@@ -5,6 +5,8 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+ram: 320
+flash: 1536
 supported:
   - arduino_gpio
   - arduino_serial

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.yaml
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.yaml
@@ -8,7 +8,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 320
+ram: 256
 flash: 64
 supported:
   - arduino_i2c

--- a/boards/st/stm32g081b_eval/stm32g081b_eval.yaml
+++ b/boards/st/stm32g081b_eval/stm32g081b_eval.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 32
+ram: 36
 flash: 128
 supported:
   - adc

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-ram: 640
+ram: 256
 flash: 2048
 supported:
   - arduino_gpio

--- a/boards/st/stm32h573i_dk/stm32h573i_dk_stm32h573xx_ext_flash_app.yaml
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk_stm32h573xx_ext_flash_app.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
 sysbuild: true
-ram: 640
+ram: 256
 flash: 32767 # size in kB of 1 app slot minus MCUboot header size (1KB)
 supported:
   - arduino_gpio

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.yaml
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 368
+ram: 320
 flash: 1024
 supported:
   - gpio

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m4.yaml
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m4.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 288
+ram: 128
 flash: 1024
 supported:
   - arduino_gpio

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m4.yaml
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m4.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 288
+ram: 128
 flash: 1024
 supported:
   - arduino_gpio

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.yaml
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 1024
+ram: 512
 flash: 128
 supported:
   - arduino_gpio

--- a/boards/st/stm32h750b_dk/stm32h750b_dk_stm32h750xx_ext_flash_app.yaml
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk_stm32h750xx_ext_flash_app.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
 sysbuild: true
-ram: 1024
+ram: 512
 flash: 61439  # size in kB of 1 app slot minus MCUboot header size (1KB)
 supported:
   - arduino_gpio

--- a/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m4.yaml
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m4.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 288
+ram: 128
 flash: 1024
 supported:
   - gpio

--- a/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.yaml
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 2048
+ram: 512
 flash: 1024
 supported:
   - gpio

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.yaml
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 1376
+ram: 256
 flash: 2048
 supported:
   - arduino_gpio

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.yaml
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.yaml
@@ -4,7 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - zephyr
-ram: 640
+ram: 128
 flash: 64
 supported:
   - arduino_gpio

--- a/boards/st/stm32mp135f_dk/twister.yaml
+++ b/boards/st/stm32mp135f_dk/twister.yaml
@@ -9,6 +9,6 @@ supported:
   - gpio
   - uart
   - shell
-ram: 256
-flash: 256
+ram: 262144
+flash: 262144
 vendor: st

--- a/boards/st/stm32mp157c_dk2/stm32mp157c_dk2.yaml
+++ b/boards/st/stm32mp157c_dk2/stm32mp157c_dk2.yaml
@@ -22,6 +22,6 @@ testing:
     - cmm
     - LED
     - nfc
-ram: 256
+ram: 320
 flash: 64
 vendor: st

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.yaml
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.yaml
@@ -16,5 +16,5 @@ supported:
   - pwm
   - usart
   - tsc
-ram: 40
+ram: 32
 flash: 256

--- a/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.yaml
+++ b/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.yaml
@@ -21,6 +21,6 @@ supported:
   - timer
   - rng
   - rtc
-ram: 3072
+ram: 3008
 flash: 4096
 vendor: st

--- a/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.yaml
+++ b/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.yaml
@@ -5,8 +5,8 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 256
-flash: 876
+ram: 192
+flash: 808
 supported:
   - gpio
   - uart

--- a/boards/st/stm32wb5mmg/stm32wb5mmg.yaml
+++ b/boards/st/stm32wb5mmg/stm32wb5mmg.yaml
@@ -5,8 +5,8 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 256
-flash: 1024
+ram: 192
+flash: 808
 supported:
   - gpio
   - dma

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.yaml
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.yaml
@@ -5,6 +5,6 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 512
+ram: 448
 flash: 2048
 vendor: st


### PR DESCRIPTION
Correct the Zephyr RAM and flash sizes defined in ST boards YAML files to help twister with these boards constraints.