### PR TITLE
drivers: timer: Improve wording for AMD Xilinx PS TTC support

### DIFF
--- a/drivers/timer/Kconfig.xlnx_psttc
+++ b/drivers/timer/Kconfig.xlnx_psttc
@@ -4,17 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config XLNX_PSTTC_TIMER
-	bool "Xilinx PS ttc timer support"
+	bool "Xilinx PS Triple-Timer Counter support"
 	default y
 	depends on DT_HAS_XLNX_TTCPS_ENABLED
 	select TICKLESS_CAPABLE
 	help
-	  This module implements a kernel device driver for the Xilinx ZynqMP
-	  platform provides the standard "system clock driver" interfaces.
-	  If unchecked, no timer will be used.
+	  Enable the AMD Xilinx PS Triple Timer Counter (TTC) timer driver for
+	  Zynq UltraScale+ MPSoC (ZynqMP) and Versal platforms. This TTC-based
+	  timer driver provides the "standard system clock driver" interface.
+	  If disabled, the TTC will not be used as the system timer.
 
 config XLNX_PSTTC_TIMER_INDEX
-	int "Xilinx PS ttc timer index"
+	int "Xilinx PS Triple-Timer Counter index"
 	range 0 3
 	default 0
 	depends on XLNX_PSTTC_TIMER

--- a/dts/bindings/timer/xlnx,ttcps.yaml
+++ b/dts/bindings/timer/xlnx,ttcps.yaml
@@ -1,4 +1,4 @@
-description: Xilinx ZynqMP PS TTC timer
+description: Xilinx PS Triple-Timer Counter
 
 compatible: "xlnx,ttcps"
 


### PR DESCRIPTION
Clarify that the AMD Xilinx PS Triple Timer Counter (TTC) is used in both Zynq UltraScale+ MPSoC (ZynqMP) and Versal platforms. Update the device tree binding description and Kconfig accordingly.

Also, rephrase the Kconfig help text to fix grammar issues and improve clarity.

For reference, here’s the page from the [Versal Adaptive SoC Technical Reference Manual (AM011 v1.8)](https://docs.amd.com/r/en-US/am011-versal-acap-trm).


<img width="888" height="1159" alt="image" src="https://github.com/user-attachments/assets/0d1cf413-1fb9-457b-8755-3dd76d4acebb" />
