### PR TITLE
arch: riscv: core: vector_table alignement fix

### DIFF
--- a/arch/riscv/core/vector_table.ld
+++ b/arch/riscv/core/vector_table.ld
@@ -6,6 +6,7 @@
 
 #if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
 KEEP(*(.vectors.__start))
+. = ALIGN(CONFIG_ARCH_IRQ_VECTOR_TABLE_ALIGN);
 INCLUDE isr_tables_vt.ld
 #else
 KEEP(*(.vectors.*))


### PR DESCRIPTION
For RISCV vector table needs to be aligned depending on CONFIG_ARCH_IRQ_VECTOR_TABLE_ALIGN. This was missing when using LTO making issues when direct ISR were in use.

This fixes for example failing arch.interrupt.gen_isr_table_local.riscv twister test on Nordic VPRs.