### PR TITLE
usb: device_next: msc: Implement double buffering

### DIFF
--- a/subsys/usb/device_next/class/Kconfig.msc
+++ b/subsys/usb/device_next/class/Kconfig.msc
@@ -30,6 +30,13 @@ config USBD_MSC_SCSI_BUFFER_SIZE
 	  Buffer size must be able to hold at least one sector. All LUNs within
 	  single instance share the SCSI buffer.
 
+config USBD_MSC_DOUBLE_BUFFERING
+	bool "SCSI double buffering"
+	default y
+	help
+	  Allocate two SCSI buffers instead of one to increase throughput by
+	  using one buffer by disk subsystem and one by USB at the same time.
+
 module = USBD_MSC
 module-str = usbd msc
 default-count = 1

--- a/subsys/usb/device_next/class/usbd_msc.c
+++ b/subsys/usb/device_next/class/usbd_msc.c
@@ -214,6 +214,31 @@ static uint8_t msc_get_bulk_out(struct usbd_class_data *const c_data)
 	return desc->if0_out_ep.bEndpointAddress;
 }
 
+static void msc_stall_bulk_out_ep(struct usbd_class_data *const c_data)
+{
+	uint8_t ep;
+
+	ep = msc_get_bulk_out(c_data);
+	usbd_ep_set_halt(usbd_class_get_ctx(c_data), ep);
+}
+
+static void msc_stall_bulk_in_ep(struct usbd_class_data *const c_data)
+{
+	uint8_t ep;
+
+	ep = msc_get_bulk_in(c_data);
+	usbd_ep_set_halt(usbd_class_get_ctx(c_data), ep);
+}
+
+static void msc_stall_and_wait_for_recovery(struct msc_bot_ctx *ctx)
+{
+	atomic_set_bit(&ctx->bits, MSC_BULK_IN_WEDGED);
+	atomic_set_bit(&ctx->bits, MSC_BULK_OUT_WEDGED);
+	msc_stall_bulk_in_ep(ctx->class_node);
+	msc_stall_bulk_out_ep(ctx->class_node);
+	ctx->state = MSC_BBB_WAIT_FOR_RESET_RECOVERY;
+}
+
 static void msc_queue_bulk_out_ep(struct usbd_class_data *const c_data, bool data)
 {
 	struct msc_bot_ctx *ctx = usbd_class_get_private(c_data);
@@ -246,23 +271,9 @@ static void msc_queue_bulk_out_ep(struct usbd_class_data *const c_data, bool dat
 		LOG_ERR("Failed to enqueue net_buf for 0x%02x", ep);
 		net_buf_unref(buf);
 		atomic_clear_bit(&ctx->bits, MSC_BULK_OUT_QUEUED);
+		/* 6.6.2 Internal Device Error */
+		msc_stall_and_wait_for_recovery(ctx);
 	}
-}
-
-static void msc_stall_bulk_out_ep(struct usbd_class_data *const c_data)
-{
-	uint8_t ep;
-
-	ep = msc_get_bulk_out(c_data);
-	usbd_ep_set_halt(usbd_class_get_ctx(c_data), ep);
-}
-
-static void msc_stall_bulk_in_ep(struct usbd_class_data *const c_data)
-{
-	uint8_t ep;
-
-	ep = msc_get_bulk_in(c_data);
-	usbd_ep_set_halt(usbd_class_get_ctx(c_data), ep);
 }
 
 static void msc_reset_handler(struct usbd_class_data *c_data)
@@ -343,6 +354,8 @@ static void msc_process_read(struct msc_bot_ctx *ctx)
 		LOG_ERR("Failed to enqueue net_buf for 0x%02x", ep);
 		net_buf_unref(buf);
 		atomic_clear_bit(&ctx->bits, MSC_BULK_IN_QUEUED);
+		/* 6.6.2 Internal Device Error */
+		msc_stall_and_wait_for_recovery(ctx);
 	}
 }
 
@@ -500,11 +513,7 @@ static void msc_handle_bulk_out(struct msc_bot_ctx *ctx,
 		} else {
 			/* 6.6.1 CBW Not Valid */
 			LOG_INF("Invalid CBW");
-			atomic_set_bit(&ctx->bits, MSC_BULK_IN_WEDGED);
-			atomic_set_bit(&ctx->bits, MSC_BULK_OUT_WEDGED);
-			msc_stall_bulk_in_ep(ctx->class_node);
-			msc_stall_bulk_out_ep(ctx->class_node);
-			ctx->state = MSC_BBB_WAIT_FOR_RESET_RECOVERY;
+			msc_stall_and_wait_for_recovery(ctx);
 		}
 	} else if (ctx->state == MSC_BBB_PROCESS_WRITE) {
 		msc_process_write(ctx, buf, len);
@@ -567,8 +576,11 @@ static void msc_send_csw(struct msc_bot_ctx *ctx)
 		LOG_ERR("Failed to enqueue net_buf for 0x%02x", ep);
 		net_buf_unref(buf);
 		atomic_clear_bit(&ctx->bits, MSC_BULK_IN_QUEUED);
+		/* 6.6.2 Internal Device Error */
+		msc_stall_and_wait_for_recovery(ctx);
+	} else {
+		ctx->state = MSC_BBB_WAIT_FOR_CSW_SENT;
 	}
-	ctx->state = MSC_BBB_WAIT_FOR_CSW_SENT;
 }
 
 static void usbd_msc_handle_request(struct usbd_class_data *c_data,


### PR DESCRIPTION
Double buffering make it possible to significantly increase the transfer rates by avoiding idle states. With two SCSI buffers, one buffer can be used by disk subsystem while the other is being used by UDC (ideally with DMA).