### PR TITLE
include: doc: fix trivial doxygen warnings

### DIFF
--- a/include/zephyr/linker/linker-tool-gcc.h
+++ b/include/zephyr/linker/linker-tool-gcc.h
@@ -100,11 +100,11 @@
  *
  * The GROUP_ROM_LINK_IN() macro is located at the end of the section
  * description and tells the linker that this a read-only section
- * that is physically placed at the 'lregion` argument.
+ * that is physically placed at the `lregion` argument.
  *
- * If CONFIG_XIP is active, the 'lregion' area is flash memory.
+ * If CONFIG_XIP is active, the `lregion` area is flash memory.
  *
- * If CONFIG_MMU is active, the vregion argument will be used to
+ * If CONFIG_MMU is active, the `vregion` argument will be used to
  * determine where this is located in the virtual memory map, otherwise
  * it is ignored.
  *

--- a/include/zephyr/linker/linker-tool-mwdt.h
+++ b/include/zephyr/linker/linker-tool-mwdt.h
@@ -39,7 +39,7 @@
 /**
  * The GROUP_ROM_LINK_IN() macro is located at the end of the section
  * description and tells the linker that this a read-only section
- * that is physically placed at the 'lregion` argument.
+ * that is physically placed at the `region` argument.
  *
  */
 #define GROUP_ROM_LINK_IN(vregion, lregion) > lregion

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -337,7 +337,7 @@ struct dns_addrinfo {
  * Status values for the callback.
  */
 enum dns_resolve_status {
-	/** Invalid value for `ai_flags' field */
+	/** Invalid value for `ai_flags` field */
 	DNS_EAI_BADFLAGS    = -1,
 	/** NAME or SERVICE is unknown */
 	DNS_EAI_NONAME      = -2,
@@ -347,17 +347,17 @@ enum dns_resolve_status {
 	DNS_EAI_FAIL        = -4,
 	/** No address associated with NAME */
 	DNS_EAI_NODATA      = -5,
-	/** `ai_family' not supported */
+	/** `ai_family` not supported */
 	DNS_EAI_FAMILY      = -6,
-	/** `ai_socktype' not supported */
+	/** `ai_socktype` not supported */
 	DNS_EAI_SOCKTYPE    = -7,
-	/** SRV not supported for `ai_socktype' */
+	/** SRV not supported for `ai_socktype` */
 	DNS_EAI_SERVICE     = -8,
 	/** Address family for NAME not supported */
 	DNS_EAI_ADDRFAMILY  = -9,
 	/** Memory allocation failure */
 	DNS_EAI_MEMORY      = -10,
-	/** System error returned in `errno' */
+	/** System error returned in `errno` */
 	DNS_EAI_SYSTEM      = -11,
 	/** Argument buffer overflow */
 	DNS_EAI_OVERFLOW    = -12,

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -338,7 +338,7 @@ struct zsock_addrinfo {
  *
  * This is achieved by tagging data structure definitions that implement the
  * underlying object associated with a network socket file descriptor with
- * '__net_socket`. All pointers to instances of these will be known to the
+ * `__net_socket`. All pointers to instances of these will be known to the
  * kernel as kernel objects with type K_OBJ_NET_SOCKET.
  *
  * This API is intended for threads that need to grant access to the object

--- a/include/zephyr/sys/timeutil.h
+++ b/include/zephyr/sys/timeutil.h
@@ -107,7 +107,7 @@ int64_t timeutil_timegm64(const struct tm *tm);
  *
  * @return the corresponding time in the POSIX epoch time scale.  If
  * the time cannot be represented then @c (time_t)-1 is returned and
- * @c errno is set to @c ERANGE`.
+ * @c errno is set to @c ERANGE.
  *
  * @see http://man7.org/linux/man-pages/man3/timegm.3.html
  */


### PR DESCRIPTION
Fix incorrect/unbalanced usage of backticks in a bunch of headers causing doxygen warnings.