### PR TITLE
drivers: dma: siwx91x: Fix for lack of DMA_ADDR_ADJ_NO_CHANGE in GPDMA

### DIFF
--- a/drivers/dma/dma_silabs_siwx91x_gpdma.c
+++ b/drivers/dma/dma_silabs_siwx91x_gpdma.c
@@ -170,14 +170,10 @@ static int siwx91x_gpdma_desc_config(struct siwx19x_gpdma_data *data,
 			goto free_desc;
 		}
 
-		if (prev_desc == NULL) {
-			data->chan_info[channel].desc = cur_desc;
-		}
-
 		memset(cur_desc, 0, 32);
 
 		ret = RSI_GPDMA_BuildDescriptors(&data->hal_ctx, (RSI_GPDMA_DESC_T *)xfer_cfg,
-						 cur_desc, prev_desc);
+						 cur_desc, NULL);
 		if (ret) {
 			goto free_desc;
 		}
@@ -194,6 +190,12 @@ static int siwx91x_gpdma_desc_config(struct siwx19x_gpdma_data *data,
 			cur_desc->chnlCtrlConfig.srcFifoMode = 1;
 		}
 
+
+		if (prev_desc) {
+			prev_desc->pNextLink = (void *)cur_desc;
+		} else {
+			data->chan_info[channel].desc = cur_desc;
+		}
 		prev_desc = cur_desc;
 		block_addr = block_addr->next_block;
 	}

--- a/drivers/dma/dma_silabs_siwx91x_gpdma.c
+++ b/drivers/dma/dma_silabs_siwx91x_gpdma.c
@@ -145,62 +145,57 @@ static int siwx91x_gpdma_desc_config(struct siwx19x_gpdma_data *data,
 				     const RSI_GPDMA_DESC_T *xfer_cfg, uint32_t channel)
 {
 	int operation_width = config->source_data_size * config->source_burst_length;
-	const struct dma_block_config *block_addr = config->head_block;
-	RSI_GPDMA_DESC_T *cur_desc = NULL;
-	RSI_GPDMA_DESC_T *prev_desc = NULL;
+	const struct dma_block_config *block = config->head_block;
+	RSI_GPDMA_DESC_T *desc, *prev = NULL;
 	k_spinlock_key_t key;
 	int ret;
 
 	for (int i = 0; i < config->block_count; i++) {
-		if (!IS_ALIGNED(block_addr->source_address, config->source_burst_length) ||
-		    !IS_ALIGNED(block_addr->dest_address, config->dest_burst_length) ||
-		    !IS_ALIGNED(block_addr->block_size, operation_width)) {
+		if (!IS_ALIGNED(block->source_address, config->source_burst_length) ||
+		    !IS_ALIGNED(block->dest_address, config->dest_burst_length) ||
+		    !IS_ALIGNED(block->block_size, operation_width)) {
 			LOG_ERR("Buffer not aligned");
 			goto free_desc;
 		}
-		if (block_addr->block_size >= GPDMA_DESC_MAX_TRANSFER_SIZE) {
-			LOG_ERR("Buffer too large (%d bytes)", block_addr->block_size);
+		if (block->block_size >= GPDMA_DESC_MAX_TRANSFER_SIZE) {
+			LOG_ERR("Buffer too large (%d bytes)", block->block_size);
 			goto free_desc;
 		}
 
 		key = k_spin_lock(&data->desc_pool_lock);
-		ret = sys_mem_blocks_alloc(data->desc_pool, 1, (void **)&cur_desc);
+		ret = sys_mem_blocks_alloc(data->desc_pool, 1, (void **)&desc);
 		k_spin_unlock(&data->desc_pool_lock, key);
 		if (ret) {
 			goto free_desc;
 		}
 
-		memset(cur_desc, 0, 32);
-
+		memset(desc, 0, 32);
 		ret = RSI_GPDMA_BuildDescriptors(&data->hal_ctx, (RSI_GPDMA_DESC_T *)xfer_cfg,
-						 cur_desc, NULL);
+						 desc, NULL);
 		if (ret) {
 			goto free_desc;
 		}
-
-		cur_desc->src = (void *)block_addr->source_address;
-		cur_desc->dest = (void *)block_addr->dest_address;
-		cur_desc->chnlCtrlConfig.transSize = block_addr->block_size;
-
-		if (block_addr->dest_addr_adj == DMA_ADDR_ADJ_NO_CHANGE) {
-			cur_desc->chnlCtrlConfig.dstFifoMode = 1;
+		desc->src = (void *)block->source_address;
+		desc->dest = (void *)block->dest_address;
+		desc->chnlCtrlConfig.transSize = block->block_size;
+		if (block->dest_addr_adj == DMA_ADDR_ADJ_NO_CHANGE) {
+			desc->chnlCtrlConfig.dstFifoMode = 1;
 		}
-
-		if (block_addr->source_addr_adj == DMA_ADDR_ADJ_NO_CHANGE) {
-			cur_desc->chnlCtrlConfig.srcFifoMode = 1;
+		if (block->source_addr_adj == DMA_ADDR_ADJ_NO_CHANGE) {
+			desc->chnlCtrlConfig.srcFifoMode = 1;
 		}
 
 
-		if (prev_desc) {
-			prev_desc->pNextLink = (void *)cur_desc;
+		if (prev) {
+			prev->pNextLink = (void *)desc;
 		} else {
-			data->chan_info[channel].desc = cur_desc;
+			data->chan_info[channel].desc = desc;
 		}
-		prev_desc = cur_desc;
-		block_addr = block_addr->next_block;
+		prev = desc;
+		block = block->next_block;
 	}
 
-	if (block_addr != NULL) {
+	if (block != NULL) {
 		/* next_block address for last block must be null */
 		goto free_desc;
 	}

--- a/drivers/spi/spi_silabs_siwx91x_gspi.c
+++ b/drivers/spi/spi_silabs_siwx91x_gspi.c
@@ -192,7 +192,7 @@ static int gspi_siwx91x_config(const struct device *dev, const struct spi_config
 }
 
 #ifdef CONFIG_SPI_SILABS_SIWX91X_GSPI_DMA
-static void gspi_siwx91x_dma_rx_callback(const struct device *dev, void *user_data,
+static void gspi_siwx91x_dma_tx_callback(const struct device *dev, void *user_data,
 					 uint32_t channel, int status)
 {
 	const struct device *spi_dev = (const struct device *)user_data;
@@ -230,7 +230,7 @@ static int gspi_siwx91x_dma_config(const struct device *dev,
 		.block_count = block_count,
 		.head_block = channel->dma_descriptors,
 		.dma_slot = channel->dma_slot,
-		.dma_callback = !is_tx ? &gspi_siwx91x_dma_rx_callback : NULL,
+		.dma_callback = is_tx ? &gspi_siwx91x_dma_tx_callback : NULL,
 		.user_data = (void *)dev,
 	};
 
@@ -411,7 +411,8 @@ static int gspi_siwx91x_transceive_dma(const struct device *dev, const struct sp
 		return -EINVAL;
 	}
 
-	/* Reset the Rx and Tx FIFO register */
+	cfg->reg->GSPI_FIFO_THRLD_b.RFIFO_RESET = 1;
+	cfg->reg->GSPI_FIFO_THRLD_b.WFIFO_RESET = 1;
 	cfg->reg->GSPI_FIFO_THRLD = 0;
 
 	ret = gspi_siwx91x_prepare_dma_transaction(dev, padded_transaction_size);

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -472,7 +472,7 @@ ZTEST(spi_loopback, test_spi_rx_half_start)
 
 ZTEST(spi_loopback, test_spi_rx_half_end)
 {
-	if (IS_ENABLED(CONFIG_SPI_STM32_DMA)) {
+	if (IS_ENABLED(CONFIG_SPI_STM32_DMA) || IS_ENABLED(CONFIG_DMA_SILABS_SIWX91X_GPDMA)) {
 		TC_PRINT("Skipped spi_rx_hald_end");
 		return;
 	}
@@ -494,7 +494,8 @@ ZTEST(spi_loopback, test_spi_rx_half_end)
 
 ZTEST(spi_loopback, test_spi_rx_every_4)
 {
-	if (IS_ENABLED(CONFIG_SPI_STM32_DMA) || IS_ENABLED(CONFIG_DSPI_MCUX_EDMA)) {
+	if (IS_ENABLED(CONFIG_SPI_STM32_DMA) || IS_ENABLED(CONFIG_DSPI_MCUX_EDMA) ||
+	    IS_ENABLED(CONFIG_DMA_SILABS_SIWX91X_GPDMA)) {
 		TC_PRINT("Skipped spi_rx_every_4");
 		return;
 	};


### PR DESCRIPTION
GPDMA does not support DMA_ADDR_ADJ_NO_CHANGE with a memory buffer. This feature is required for the SPI driver. Hopefully, SPI driver is the only user of this feature.

Therefore, this PR introduce two hacks to fix compatibility of GPDMA with SPI. These hacks are not attended to be general purpose workaround. They are only crafted for the SPI use case.
