### PR TITLE
Fix DCMIPP video driver compilation on STM32MP13

### DIFF
--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1340,18 +1340,6 @@ static int stm32_dcmipp_dequeue(const struct device *dev, struct video_buffer **
 #define DCMIPP_CEIL_DIV(val, div)								\
 		(((val) + (div) - 1) / (div))
 
-#define DCMIPP_VIDEO_FORMAT_CAP(format, pixmul)	{						\
-	.pixelformat = VIDEO_PIX_FMT_##format,							\
-	.width_min = DCMIPP_CEIL_DIV_ROUND_UP_MUL(CONFIG_VIDEO_STM32_DCMIPP_SENSOR_WIDTH,	\
-						  STM32_DCMIPP_MAX_PIPE_SCALE_FACTOR,		\
-						  pixmul),					\
-	.width_max = CONFIG_VIDEO_STM32_DCMIPP_SENSOR_WIDTH / (pixmul) * (pixmul),		\
-	.height_min = DCMIPP_CEIL_DIV(CONFIG_VIDEO_STM32_DCMIPP_SENSOR_HEIGHT,			\
-				      STM32_DCMIPP_MAX_PIPE_SCALE_FACTOR),			\
-	.height_max = CONFIG_VIDEO_STM32_DCMIPP_SENSOR_HEIGHT,					\
-	.width_step = pixmul, .height_step = 1,							\
-}
-
 static const struct video_format_cap stm32_dcmipp_dump_fmt[] = {
 	{
 		.pixelformat = VIDEO_FOURCC_FROM_STR(CONFIG_VIDEO_STM32_DCMIPP_SENSOR_PIXEL_FORMAT),
@@ -1363,6 +1351,19 @@ static const struct video_format_cap stm32_dcmipp_dump_fmt[] = {
 	},
 	{0},
 };
+
+#if defined(STM32_DCMIPP_HAS_PIXEL_PIPES)
+#define DCMIPP_VIDEO_FORMAT_CAP(format, pixmul)	{						\
+	.pixelformat = VIDEO_PIX_FMT_##format,							\
+	.width_min = DCMIPP_CEIL_DIV_ROUND_UP_MUL(CONFIG_VIDEO_STM32_DCMIPP_SENSOR_WIDTH,	\
+						  STM32_DCMIPP_MAX_PIPE_SCALE_FACTOR,		\
+						  pixmul),					\
+	.width_max = CONFIG_VIDEO_STM32_DCMIPP_SENSOR_WIDTH / (pixmul) * (pixmul),		\
+	.height_min = DCMIPP_CEIL_DIV(CONFIG_VIDEO_STM32_DCMIPP_SENSOR_HEIGHT,			\
+				      STM32_DCMIPP_MAX_PIPE_SCALE_FACTOR),			\
+	.height_max = CONFIG_VIDEO_STM32_DCMIPP_SENSOR_HEIGHT,					\
+	.width_step = pixmul, .height_step = 1,							\
+}
 
 static const struct video_format_cap stm32_dcmipp_main_fmts[] = {
 	DCMIPP_VIDEO_FORMAT_CAP(RGB565, 8),
@@ -1397,6 +1398,7 @@ static const struct video_format_cap stm32_dcmipp_aux_fmts[] = {
 	DCMIPP_VIDEO_FORMAT_CAP(BGRA32, 4),
 	{0},
 };
+#endif
 
 static int stm32_dcmipp_get_caps(const struct device *dev, struct video_caps *caps)
 {
@@ -1406,12 +1408,14 @@ static int stm32_dcmipp_get_caps(const struct device *dev, struct video_caps *ca
 	case DCMIPP_PIPE0:
 		caps->format_caps = stm32_dcmipp_dump_fmt;
 		break;
+#if defined(STM32_DCMIPP_HAS_PIXEL_PIPES)
 	case DCMIPP_PIPE1:
 		caps->format_caps = stm32_dcmipp_main_fmts;
 		break;
 	case DCMIPP_PIPE2:
 		caps->format_caps = stm32_dcmipp_aux_fmts;
 		break;
+#endif
 	default:
 		CODE_UNREACHABLE;
 	}

--- a/tests/drivers/build_all/video/testcase.yaml
+++ b/tests/drivers/build_all/video/testcase.yaml
@@ -34,8 +34,10 @@ tests:
   drivers.video.stm32_dcmipp.build:
     platform_allow:
       - stm32n6570_dk/stm32n657xx/sb
+      - stm32mp135f_dk/stm32mp135fxx
     extra_args:
       - platform:stm32n6570_dk/stm32n657xx/sb:SHIELD=st_b_cams_imx_mb1854
+      - platform:stm32mp135f_dk/stm32mp135fxx:SHIELD=st_mb1897_cam
   drivers.video.renesas_ra_ceu.build:
     platform_allow:
       - ek_ra8d1/r7fa8d1bhecbd


### PR DESCRIPTION
PR #94562 introduced a regression in build of the DCMIPP driver for the STM32MP13 due to the fact that on STM32MP13, the DCMIPP do not have PIPE1 and PIPE2.

The PR fixes this by enclosing PIPE1 (main) / PIPE2 (aux) caps within the proper preproc if statement as done in order part of the code.
Moreover, in order to avoid such future issue, add test build of dcmipp for the MP13 platform. That done, test build is done in the 2 variants of the DCMIPP driver.