### PR TITLE
subsys: random: let CONFIG_CSPRNG_AVAILABLE select CONFIG_ENTROPY_GENERATOR

### DIFF
--- a/drivers/entropy/Kconfig.nrf5
+++ b/drivers/entropy/Kconfig.nrf5
@@ -16,6 +16,7 @@ menuconfig ENTROPY_NRF5_RNG
 	default y
 	depends on !ENTROPY_NRF_FORCE_ALT
 	depends on DT_HAS_NORDIC_NRF_RNG_ENABLED
+	depends on MULTITHREADING # for k_sem
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the RNG peripheral, which is a random number

--- a/modules/mbedtls/Kconfig.mbedtls
+++ b/modules/mbedtls/Kconfig.mbedtls
@@ -522,6 +522,13 @@ config MBEDTLS_SSL_EXTENDED_MASTER_SECRET
 	  which ensures that master secrets are different for every
 	  connection and every session.
 
+# CONFIG_CSPRNG_AVAILABLE must automatically enable CONFIG_ENTROPY_GENERATOR.
+# But we're doing it here because this enablement should be gated by Mbed TLS
+# being also enabled in the build, otherwise this will result in entropy
+# drivers being enabled without anyone needing them.
+config CSPRNG_AVAILABLE
+	select ENTROPY_GENERATOR
+
 choice MBEDTLS_PSA_CRYPTO_RNG_SOURCE
 	prompt "Select random source for built-in PSA crypto"
 	depends on MBEDTLS_PSA_CRYPTO_C
@@ -530,12 +537,11 @@ choice MBEDTLS_PSA_CRYPTO_RNG_SOURCE
 	# CONFIG_CSPRNG_ENABLED cannot be used for this because it gets enabled by
 	# entropy drivers but these are gated by CONFIG_ENTROPY_GENERATOR which
 	# is disabled by default.
-	default MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG if CSPRNG_AVAILABLE
+	default MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG if CSPRNG_ENABLED
 	default MBEDTLS_PSA_CRYPTO_LEGACY_RNG
 
 config MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
 	bool "Use a cryptographically secure driver as random source"
-	select ENTROPY_GENERATOR
 	help
 	  Use a cryptographically secure random generator to provide random data
 	  instead of legacy Mbed TLS modules. This has a smaller footprint


### PR DESCRIPTION
modules: mbedtls: let CSPRNG_AVAILABLE select ENTROPY_GENERATOR

It might happen that some boards have "zephyr,entropy" node set, but under the hood the driver is not available (ex: entropy_bt_hci not being available because CONFIG_BT_HOST is not enabled in the build).

This commit changes the behavior so that:
1. if "zephyr,entropy" is set in the DT then CONFIG_CSPRNG_AVAILABLE get enabled;
2. CONFIG_CSPRNG_AVAILABLE selects CONFIG_ENTROPY_GENERATOR
3. if there really is a driver available then CONFIG_ENTROPY_HAS_DRIVER will be enabled by that driver;
4. CONFIG_ENTROPY_HAS_DRIVER selects CONFIG_CSPRNG_ENABLED;
5 . Mbed TLS can consume the CONFIG_CSPRNG_ENABLED information to decide whethere to enable CONFIG_MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG or the legacy CONFIG_MBEDTLS_PSA_CRYPTO_LEGACY_RNG.