### PR TITLE
dts: arm: silabs: fix siwg917 default nwp power state

### DIFF
--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -76,7 +76,7 @@
 
 	nwp: nwp {
 		compatible = "silabs,siwx91x-nwp";
-		power-profile = "high-performance";
+		power-profile = "deep-sleep-with-ram-retention";
 		stack-size = <10240>;
 		interrupt-parent = <&nvic>;
 		interrupts = <30 0>, <74 0>;


### PR DESCRIPTION
This patch fixes a bug where the siwg917 SoC didn't enter deep sleep even when the CONFIG_PM Kconfig option was selected, due to the default power state of the network coprocessor.

Users should only need to activate the CONFIG_PM Kconfig option when they want to enable power management and be able to deep sleep by default.