### PR TITLE
doc: remove "zephyr,usb-device" from chosen properties documentation

### DIFF
--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -458,9 +458,6 @@ device.
      - UART used for :ref:`device_mgmt`
    * - zephyr,uart-pipe
      - Sets UART device used by serial pipe driver
-   * - zephyr,usb-device
-     - USB device node. If defined and has a ``vbus-gpios`` property, these
-       will be used by the USB subsystem to enable/disable VBUS
    * - zephyr,led-strip
      - A LED-strip node which is used to determine the timings of the
        WS2812 GPIO driver


### PR DESCRIPTION
Chosen property "zephyr,usb-device" can be used with the deprecated legacy USB device stack, but actually was never used in the tree. There are no plans to use it in the future. Remove it from the documentation, as there seems to be some misunderstanding and the property appears in the board's DTS without any use or benefit.