### PR TITLE
west: Sync picolibc with SDK 0.17.4

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -357,7 +357,7 @@ manifest:
         - debug
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 560946f26db075c296beea5b39d99e6de43c9010
+      revision: ca8b6ebba5226a75545e57a140443168a26ba664
     - name: segger
       revision: 9f08435a79d41133d7046b7c59d1b25929eda450
       path: modules/debug/segger


### PR DESCRIPTION
This updates the version of picolibc to match that used by SDK 0.17.4. In the Zephyr picolibc fork, that's marked with the zephyr-sdk-0.17.4 tag now, which is on the zephyr-sdk-0.17 branch.

Changes since the previous version which impact using the module:

 * machine/arm: Disable exception tables in ARM string asm code
 * cmake: Silence messages about core-isa.h
 * Correct return type of __non_atomic_*_ungetc functions
 * Delete obsoleted _syslist.h