### PR TITLE
scripts: west_commands: add `pyproject.toml` file

### DIFF
--- a/scripts/west_commands/mypy.ini
+++ b/scripts/west_commands/mypy.ini
@@ -1,2 +1,0 @@
-[mypy]
-ignore_missing_imports=True

--- a/scripts/west_commands/pyproject.toml
+++ b/scripts/west_commands/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.mypy]
+ignore_missing_imports = true
+mypy_path = "."
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/scripts/west_commands/run_tests.py
+++ b/scripts/west_commands/run_tests.py
@@ -26,15 +26,12 @@ import sys
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-mypy = [sys.executable, '-m', 'mypy', f'--config-file={here}/mypy.ini',
-        '--package', 'runners']
-pytest = [sys.executable, '-m', 'pytest'] + sys.argv[1:]
+mypy = ['mypy', '--package=runners']
+pytest = ['pytest'] + sys.argv[1:]
 
-print(f'Running mypy from {here}:\n\t' +
-      ' '.join(shlex.quote(s) for s in mypy),
-      flush=True)
-subprocess.run(mypy, check=True, cwd=here)
-print(f'Running pytest from {here}:\n\t' +
-      ' '.join(shlex.quote(s) for s in pytest),
-      flush=True)
-subprocess.run(pytest, check=True, cwd=here)
+for cmd in [mypy, pytest]:
+    command = [sys.executable, '-m'] + cmd
+    print(f"Running {cmd[0]} in cwd '{here}':\n\t" +
+          ' '.join(shlex.quote(s) for s in command),
+          flush=True)
+    subprocess.run(command, check=True, cwd=here)


### PR DESCRIPTION
### Why?
It is common that tools like `pytest` or `mypy` can be invoked directly.
Especially `pytest` is helpful for being able to debug tests in some IDE.
This should work without any additional effort.

### Actual
Running pytest python module works:
```
/usr/bin/python3 -m pytest
```
Whereby invokation of pytest executable fails:
```
$ pytest
ImportError while loading conftest '/home/user/GIT/zephyr/scripts/west_commands/tests/conftest.py'.
tests/conftest.py:9: in <module>
    from runners.core import RunnerConfig, FileType
E   ModuleNotFoundError: No module named 'runners
```

To fix this, `PYTHONPATH` must be manually set to contain correct path so that `import runner` works:
```
cd scripts/west_commands
PYTHONPATH=. pytest
pytest -o pythonpath=.
```
or from git root folder:
```
pytest scripts/west_commands/ -o pythonpath=scripts/west_commands
```

### Expected
`pytest` can be invoked directly, e.g.:
```
cd scripts/west_commands
pytest
```

Therefore a config file is necessary for pytest.
In order to avoid too many config files for different tools, a `pyproject.toml` config file can be introduced, which allows configuration of both tools `pytest` and `mypy`.