### PR TITLE
doc: Clarify SoB when cherry picking

### DIFF
--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -209,6 +209,9 @@ Additional requirements:
 - If you are altering an existing commit created by someone else, you must add
   your Signed-off-by: line without removing the existing one.
 
+- Even cherry picking a commit contributed by someone else, you must add a
+  Signed-off-by line, without removing existing ones.
+
 .. _source_tree_v2:
 
 Source Tree Structure


### PR DESCRIPTION
The DCO requires a signed-off-by by any one that "handles" the change. This means that cherry-picking another's change requires a signed-off-by, and the paragraph about "if you are altering a commit created by someone else" it not sufficient.

Starting with an invalid change, with a bogus author, in order to test if our compliance check is testing this.