### PR TITLE
samples: led: fix the CH32V003 overlay

### DIFF
--- a/samples/drivers/led/pwm/boards/ch32v003evt.overlay
+++ b/samples/drivers/led/pwm/boards/ch32v003evt.overlay
@@ -21,6 +21,10 @@
 	 * is 1465, and the prescaler property is one less than that.
 	 */
 	prescaler = <1464>;
+};
+
+&pwm2 {
+	status = "okay";
 	pinctrl-0 = <&red_pwm_pinctrl>;
 	pinctrl-names = "default";
 };


### PR DESCRIPTION
The overlay was done before the PWM node was moved under the timer
node, breaking the build. Fix.