### PR TITLE
modbus: client: change 'EXNO' to '-EIO'

### DIFF
--- a/subsys/modbus/modbus_client.c
+++ b/subsys/modbus/modbus_client.c
@@ -227,7 +227,7 @@ static int mbc_validate_wr_response(struct modbus_context *ctx,
 	case MODBUS_FC15_COILS_WR:
 	case MODBUS_FC16_HOLDING_REGS_WR:
 		if (req_addr != resp_addr || req_value != resp_value) {
-			err = ENXIO;
+			err = -EIO;
 		} else {
 			err = 0;
 		}


### PR DESCRIPTION
Fix error in Modbus client write response validation.

See discussion [here](https://github.com/zephyrproject-rtos/zephyr/discussions/78061)