### PR TITLE
Thread runtime stack safety

### DIFF
--- a/include/zephyr/debug/thread_analyzer.h
+++ b/include/zephyr/debug/thread_analyzer.h
@@ -40,6 +40,10 @@ struct thread_analyzer_info {
 #endif
 #endif
 
+#ifdef CONFIG_THREAD_ANALYZER_STACK_SAFETY
+	uint32_t stack_safety;
+#endif
+
 #ifdef CONFIG_THREAD_ANALYZER_PRIV_STACK_USAGE
 	/** Total size of privileged stack */
 	size_t priv_stack_size;
@@ -48,6 +52,44 @@ struct thread_analyzer_info {
 	size_t priv_stack_used;
 #endif
 };
+
+/** Stack safety issue codes */
+
+/* No stack safety issues detected */
+#define THREAD_ANALYZE_STACK_SAFETY_NO_ISSUES 0
+
+/* Unused stack space is below the defined threshold */
+#define THREAD_ANALYZE_STACK_SAFETY_THRESHOLD_EXCEEDED 1
+
+/* No unused stack space is left */
+#define THREAD_ANALYZE_STACK_SAFETY_AT_LIMIT 2
+
+/* Stack overflow detected */
+#define THREAD_ANALYZE_STACK_SAFETY_OVERFLOW 3
+
+/** @brief Thread analyzer stack safety callback function
+ *
+ *  Stack safety callback function.
+ *
+ *  @param thread Pointer to the thread being analyzed.
+ *  @param unused_space Amount of unused stack space.
+ *  @param stack_issue Pointer to variable to store stack safety issue code
+ */
+typedef void (*thread_analyzer_stack_safety_handler)(struct k_thread *thread,
+						     size_t unused_space,
+						     uint32_t *stack_issue);
+
+/** @brief Change the thread analyzer stack safety callback function
+ *
+ *  This function changes the thread analyzer's stack safety handler. This
+ *  allows an application to customize behavior when a thread's unused stack
+ *  drops below its configured threshold.
+ *
+ *  @param handler Function pointer to the new handler (NULL for default)
+ */
+void thread_analyzer_stack_safety_handler_set(thread_analyzer_stack_safety_handler handler);
+
+
 
 /** @brief Thread analyzer stack size callback function
  *

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -140,6 +140,13 @@ struct _thread_base {
 typedef struct _thread_base _thread_base_t;
 
 #if defined(CONFIG_THREAD_STACK_INFO)
+
+#if defined(CONFIG_THREAD_RUNTIME_STACK_SAFETY)
+struct _thread_stack_usage {
+	size_t unused_threshold; /* Threshold below which to trigger hook */
+};
+#endif
+
 /* Contains the stack information of a thread */
 struct _thread_stack_info {
 	/* Stack start - Represents the start address of the thread-writable
@@ -171,6 +178,10 @@ struct _thread_stack_info {
 		size_t sz;
 	} mapped;
 #endif /* CONFIG_THREAD_STACK_MEM_MAPPED */
+
+#if defined(CONFIG_THREAD_RUNTIME_STACK_SAFETY)
+	struct _thread_stack_usage usage;
+#endif
 };
 
 typedef struct _thread_stack_info _thread_stack_info_t;

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -570,6 +570,27 @@ config SCHED_THREAD_USAGE_AUTO_ENABLE
 
 endif # THREAD_RUNTIME_STATS
 
+menuconfig THREAD_RUNTIME_STACK_SAFETY
+	bool "Thread runtime stack safety support"
+	default n
+	help
+	  This option enables support for the thread runtime stack safety check routines.
+	  These routines are used to  detect a thread's unused stack space and invoke a
+	  user-defined handler if it was found to have dropped below a configured threshold.
+
+if THREAD_RUNTIME_STACK_SAFETY
+config THREAD_RUNTIME_STACK_SAFETY_DEFAULT_UNUSED_THRESHOLD_PCT
+	int "Runtime Stack Safety unused stack usage percentage threshold"
+	default 0
+	range 0 99
+	help
+	  This option specifies a thread's default runtime stack safety
+	  threshold as a percentage of the stack size. When the runtime stack
+	  safety routines detect that a thread's unused stack percentage has fallen
+	  _below_ this threshold, a user-defined handler is invoked.
+	  Setting this to 0 disables the check by default for all threads.
+endif
+
 endmenu
 
 rsource "Kconfig.obj_core"

--- a/subsys/debug/thread_analyzer/Kconfig
+++ b/subsys/debug/thread_analyzer/Kconfig
@@ -68,6 +68,16 @@ config THREAD_ANALYZER_RUN_UNLOCKED
 	  For the limitation of such configuration see the k_thread_foreach
 	  documentation.
 
+config THREAD_ANALYZER_STACK_SAFETY
+	bool "Thread analysis includes thread runtime stack safety check"
+	default n
+	select THREAD_RUNTIME_STACK_SAFETY
+	help
+	  If enabled, the stack usage analysis is enhanced by calling a customizable handler
+	  when the unused stack space of a thread falls below its configured threshold. This
+	  customized handler may take actions such as logging warnings, suspending or even
+	  aborting threads.
+
 config THREAD_ANALYZER_AUTO
 	bool "Run periodic thread analysis in a thread"
 	help

--- a/tests/subsys/debug/thread_analyzer/testcase.yaml
+++ b/tests/subsys/debug/thread_analyzer/testcase.yaml
@@ -27,6 +27,18 @@ tests:
       regex:
         - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
         - "(.*)ISR0([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+  debug.thread_analyzer.printk.stack_safety:
+    extra_configs:
+      - CONFIG_THREAD_ANALYZER_USE_PRINTK=y
+      - CONFIG_THREAD_ANALYZER_STACK_SAFETY=y
+      - CONFIG_THREAD_RUNTIME_STACK_SAFETY_DEFAULT_UNUSED_THRESHOLD_PCT=90
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+        - " : Stack Safety Warning: Threshold crossed"
+        - "(.*)ISR0([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
   debug.thread_analyzer.printk.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:


### PR DESCRIPTION
This set of commits adds support for thread runtime stack safety. It has been divided into two parts--kernel support and thread analyzer integration.

On the kernel side, this extends the idea of the existing k_thread_stack_space_get() to invoke a caller defined handler/callback if the amount of unused stack space is less than a configured threshold. Two new stack checking routines have been added: k_thread_runtime_stack_safety_full_check() and k_thread_runtime_stack_safety_threshold_check(). The latter performs an abbreviated check on the stack that is limited to the configured threshold.

On the thread analyzer integration side, when enabled it replaces the stack check with the full stack safety check. The default handler can be replaced at runtime by calling thread_analyzer_stack_safety_handler_set(). This allows a developer to leverage the existing analyzer to periodically scan stack usages and act upon them accordingly if their configured thresholds have been crossed (log the incident, suspend a thread, abort a thread, reboot the system, ...).