### PR TITLE
drivers: sdhc: sdhc_spi: Adding support for cd_gpio

### DIFF
--- a/dts/bindings/sdhc/zephyr,sdhc-spi-slot.yaml
+++ b/dts/bindings/sdhc/zephyr,sdhc-spi-slot.yaml
@@ -34,4 +34,10 @@ properties:
       This pin defaults to active high when consumed by the SPI SDHC driver.
       It can be used to toggle card power via an external control circuit
 
+  cd-gpios:
+    type: phandle-array
+    description: |
+      Card detect pin
+      This pin can be used to detect if a card is present in the slot.
+
 bus: sd


### PR DESCRIPTION
Fixes #98242

1. This commit adds support for the `cd-gpios` property to the dts binding for the `sdhc_spi` driver.
2. The `_init` function is updated to initialize the GPIO pin if it is found.
3. The `_get_card_present` function is updated to check the GPIO pin state if the pin has been initialized.

Signed-off-by: Siddhant Modi [siddhant.modi@gmail.com](mailto:siddhant.modi@gmail.com)
