### PR TITLE
drivers: spi: dw: Skip version detection on aux-reg platforms

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -566,11 +566,13 @@ int spi_dw_init(const struct device *dev)
 	write_imr(dev, DW_SPI_IMR_MASK);
 	clear_bit_ssienr(dev);
 
+#if !DT_ANY_INST_PROP_STATUS_OKAY(aux_reg)
 	/* SSI component version */
 	spi->version = read_ssi_comp_version(dev);
 	LOG_DBG("Version: %c.%c%c%c", (spi->version >> 24) & 0xff,
 		(spi->version >> 16) & 0xff, (spi->version >> 8) & 0xff,
 		spi->version & 0xff);
+#endif
 
 	LOG_DBG("Designware SPI driver initialized on device: %p", dev);
 

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -20,6 +20,15 @@
 extern "C" {
 #endif
 
+/* Helper macros for checking property status across instances */
+#define DT_INST_NODE_PROP_NOT_OR(inst, prop) !DT_INST_PROP(inst, prop) ||
+#define DT_ANY_INST_NOT_PROP_STATUS_OKAY(prop)                                                     \
+	(DT_INST_FOREACH_STATUS_OKAY_VARGS(DT_INST_NODE_PROP_NOT_OR, prop) 0)
+
+#define DT_INST_NODE_PROP_AND_OR(inst, prop) DT_INST_PROP(inst, prop) ||
+#define DT_ANY_INST_PROP_STATUS_OKAY(prop)                                                         \
+	(DT_INST_FOREACH_STATUS_OKAY_VARGS(DT_INST_NODE_PROP_AND_OR, prop) 0)
+
 typedef void (*spi_dw_config_t)(void);
 typedef uint32_t (*spi_dw_read_t)(uint8_t size, mm_reg_t addr, uint32_t off);
 typedef void (*spi_dw_write_t)(uint8_t size, uint32_t data, mm_reg_t addr, uint32_t off);
@@ -48,22 +57,14 @@ struct spi_dw_config {
 struct spi_dw_data {
 	DEVICE_MMIO_RAM;
 	struct spi_context ctx;
+#if !DT_ANY_INST_PROP_STATUS_OKAY(aux_reg)
 	uint32_t version;	/* ssi comp version */
+#endif
 	uint8_t dfs;	/* dfs in bytes: 1,2 or 4 */
 	uint8_t fifo_diff;	/* cannot be bigger than FIFO depth */
 };
 
 /* Register operation functions */
-#define DT_INST_NODE_PROP_NOT_OR(inst, prop) \
-	!DT_INST_PROP(inst, prop) ||
-#define DT_ANY_INST_NOT_PROP_STATUS_OKAY(prop) \
-	(DT_INST_FOREACH_STATUS_OKAY_VARGS(DT_INST_NODE_PROP_NOT_OR, prop) 0)
-
-#define DT_INST_NODE_PROP_AND_OR(inst, prop) \
-	DT_INST_PROP(inst, prop) ||
-#define DT_ANY_INST_PROP_STATUS_OKAY(prop) \
-	(DT_INST_FOREACH_STATUS_OKAY_VARGS(DT_INST_NODE_PROP_AND_OR, prop) 0)
-
 #if DT_ANY_INST_PROP_STATUS_OKAY(aux_reg)
 static uint32_t aux_reg_read(uint8_t size, mm_reg_t addr, uint32_t off)
 {


### PR DESCRIPTION
The version register is not accessible through aux-reg interface, So skip it entirely on platforms with aux-reg device tree property.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/93620