### PR TITLE
Fix warnings caused by incorrect format specifiers when building for the 64-bit platform

### DIFF
--- a/samples/subsys/usb/legacy/audio_headphones_microphone/src/main.c
+++ b/samples/subsys/usb/legacy/audio_headphones_microphone/src/main.c
@@ -29,7 +29,7 @@ static void data_received(const struct device *dev,
 		return;
 	}
 
-	LOG_DBG("Received %d data, buffer %p", size, buffer);
+	LOG_DBG("Received %zu data, buffer %p", size, buffer);
 
 	/* Check if OUT device buffer can be used for IN device */
 	if (size == usb_audio_get_in_frame_size(mic_dev)) {

--- a/samples/subsys/usb/legacy/audio_headset/src/main.c
+++ b/samples/subsys/usb/legacy/audio_headset/src/main.c
@@ -27,7 +27,7 @@ static void data_received(const struct device *dev,
 		return;
 	}
 
-	LOG_DBG("Received %d data, buffer %p", size, buffer);
+	LOG_DBG("Received %zu data, buffer %p", size, buffer);
 
 	/* Check if the device OUT buffer can be used for input */
 	if (size == usb_audio_get_in_frame_size(dev)) {

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -174,7 +174,7 @@ static void setup_disk(void)
 			printk("End of files\n");
 			break;
 		}
-		printk("  %c %u %s\n",
+		printk("  %c %zu %s\n",
 		       (ent.type == FS_DIR_ENTRY_FILE) ? 'F' : 'D',
 		       ent.size,
 		       ent.name);

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -1010,7 +1010,7 @@ void sys_trace_socket_accept_enter(int sock)
 	ctf_top_socket_accept_enter(sock);
 }
 
-void sys_trace_socket_accept_exit(int sock, const struct sockaddr *addr, const size_t *addrlen,
+void sys_trace_socket_accept_exit(int sock, const struct sockaddr *addr, const uint32_t *addrlen,
 				  int ret)
 {
 	ctf_net_bounded_string_t addr_str = {"unknown"};

--- a/subsys/usb/device/class/audio/audio.c
+++ b/subsys/usb/device/class/audio/audio.c
@@ -902,7 +902,7 @@ int usb_audio_send(const struct device *dev, struct net_buf *buffer,
 	}
 
 	if (len > buffer->size) {
-		LOG_ERR("Cannot send %d bytes, to much data", len);
+		LOG_ERR("Cannot send %zu bytes, to much data", len);
 		return -EINVAL;
 	}
 

--- a/subsys/usb/device/class/netusb/function_rndis.c
+++ b/subsys/usb/device/class/netusb/function_rndis.c
@@ -931,7 +931,7 @@ static int rndis_send(struct net_pkt *pkt)
 	size_t len = net_pkt_get_len(pkt);
 	int ret;
 
-	LOG_DBG("send pkt %p len %u", pkt, len);
+	LOG_DBG("send pkt %p len %zu", pkt, len);
 
 	if (rndis.media_status == RNDIS_OBJECT_ID_MEDIA_DISCONNECTED) {
 		LOG_DBG("Media disconnected, drop pkt %p", pkt);

--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -174,12 +174,12 @@ static int lb_request_handler(struct usbd_class_data *const c_data,
 
 	net_buf_unref(buf);
 	if (err == -ECONNABORTED) {
-		LOG_INF("Transfer ep 0x%02x, len %u cancelled", ep, len);
+		LOG_INF("Transfer ep 0x%02x, len %zu cancelled", ep, len);
 	} else if (err != 0) {
-		LOG_ERR("Transfer ep 0x%02x, len %u failed", ep, len);
+		LOG_ERR("Transfer ep 0x%02x, len %zu failed", ep, len);
 		ret = err;
 	} else {
-		LOG_DBG("Transfer ep 0x%02x, len %u finished", ep, len);
+		LOG_DBG("Transfer ep 0x%02x, len %zu finished", ep, len);
 	}
 
 	if (!atomic_test_bit(&data->state, LB_FUNCTION_BULK_MANUAL)) {

--- a/subsys/usb/device_next/class/usbd_msc.c
+++ b/subsys/usb/device_next/class/usbd_msc.c
@@ -440,9 +440,9 @@ static void msc_process_write(struct msc_bot_ctx *ctx,
 		tmp = scsi_write_data(lun, buf, len);
 		__ASSERT(tmp <= len, "Processed more data than requested");
 		if (tmp == 0) {
-			LOG_WRN("SCSI handler didn't process %d bytes", len);
+			LOG_WRN("SCSI handler didn't process %zu bytes", len);
 		} else {
-			LOG_DBG("SCSI processed %d out of %d bytes", tmp, len);
+			LOG_DBG("SCSI processed %zu out of %zu bytes", tmp, len);
 		}
 
 		ctx->csw.dCSWDataResidue -= tmp;

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -981,7 +981,7 @@ static int uvc_get_vc_ctrl(const struct device *dev, struct net_buf *const buf,
 	}
 
 	if (size < map->size) {
-		LOG_WRN("Buffer too small (%u bytes) or unexpected size requested (%u bytes)",
+		LOG_WRN("Buffer too small (%zu bytes) or unexpected size requested (%u bytes)",
 			net_buf_tailroom(buf), setup->wLength);
 		return -ENOTSUP;
 	}
@@ -1985,7 +1985,7 @@ static int uvc_reset_transfer(const struct device *dev)
 	struct net_buf *buf;
 	int ret;
 
-	LOG_DBG("Stream restarted, terminating the transfer after %u bytes", data->vbuf_offset);
+	LOG_DBG("Stream restarted, terminating the transfer after %zu bytes", data->vbuf_offset);
 
 	buf = net_buf_alloc_len(&uvc_buf_pool, 0, K_NO_WAIT);
 	if (buf == NULL) {
@@ -2047,7 +2047,7 @@ static int uvc_flush_vbuf(const struct device *dev, struct video_buffer *const v
 	bi = (struct uvc_buf_info *)udc_get_buf_info(buf);
 	bi->udc.ep = uvc_get_bulk_in(dev);
 
-	LOG_DBG("Video buffer %p, offset %u/%u, size %u",
+	LOG_DBG("Video buffer %p, offset %zu/%u, size %d",
 		vbuf, data->vbuf_offset, vbuf->bytesused, buf->len);
 
 	/* End-of-Transfer condition */

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -590,7 +590,7 @@ static void string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
 		ascii7_str = (uint8_t *)dn->ptr;
 	}
 
-	LOG_DBG("wLength %u, bLength %u, tailroom %u",
+	LOG_DBG("wLength %u, bLength %u, tailroom %zu",
 		wLength, head.bLength, net_buf_tailroom(buf));
 
 	len = MIN(net_buf_tailroom(buf), MIN(head.bLength,  wLength));
@@ -771,8 +771,7 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 
 	desc_fill_bos_root(uds_ctx, &bos);
 	len = MIN(net_buf_tailroom(buf), MIN(setup->wLength, bos.wTotalLength));
-
-	LOG_DBG("wLength %u, bLength %u, wTotalLength %u, tailroom %u",
+	LOG_DBG("wLength %u, bLength %u, wTotalLength %u, tailroom %zu",
 		setup->wLength, bos.bLength, bos.wTotalLength, net_buf_tailroom(buf));
 
 	net_buf_add_mem(buf, &bos, MIN(len, bos.bLength));
@@ -784,7 +783,7 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 
 	SYS_DLIST_FOR_EACH_CONTAINER(&uds_ctx->descriptors, desc_nd, node) {
 		if (desc_nd->bDescriptorType == USB_DESC_BOS) {
-			LOG_DBG("bLength %u, len %u, tailroom %u",
+			LOG_DBG("bLength %u, len %zu, tailroom %zu",
 				desc_nd->bLength, len, net_buf_tailroom(buf));
 			net_buf_add_mem(buf, desc_nd->ptr, MIN(len, desc_nd->bLength));
 


### PR DESCRIPTION
Use zu% format for size_t type.
Use d% format for int type.
Use u% format for uint32_t type.
fix build error because of conflicting types