### PR TITLE
drivers: pwm: stm32: add device tree configuration for deadtime

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -90,6 +90,7 @@ struct pwm_stm32_config {
 	TIM_TypeDef *timer;
 	uint32_t prescaler;
 	uint32_t countermode;
+	uint32_t deadtime;
 	const struct stm32_pclken *pclken;
 	size_t pclk_len;
 	const struct pinctrl_dev_config *pcfg;
@@ -699,12 +700,29 @@ static int pwm_stm32_init(const struct device *dev)
 	}
 #endif
 
-#if !defined(CONFIG_SOC_SERIES_STM32L0X) && !defined(CONFIG_SOC_SERIES_STM32L1X)
-	/* enable outputs and counter */
+#ifdef IS_TIM_BREAK_INSTANCE
+	/* Use the macro IS_TIM_BREAK_INSTANCE to check for supporting the
+	 * break instance timers since some socs like L0/L1 will not
+	 * compile and this checks explicitly for the api instead of the soc
+	 */
 	if (IS_TIM_BREAK_INSTANCE(timer)) {
+		/* enable outputs and counter */
 		LL_TIM_EnableAllOutputs(timer);
+
+		/* set the deadtime from the configuration */
+		LL_TIM_OC_SetDeadTime(timer, cfg->deadtime);
+	} else if (cfg->deadtime != 0) {
+		LOG_ERR("Setting deadtime %d on a non-break timer %s",
+			cfg->deadtime, dev->name);
+		return -ENOTSUP;
 	}
-#endif
+#else
+	if (cfg->deadtime != 0) {
+		LOG_ERR("Setting deadtime %d on a non-break timer %s",
+			cfg->deadtime, dev->name);
+		return -ENOTSUP;
+	}
+#endif /* IS_TIM_BREAK_INSTANCE */
 
 	LL_TIM_EnableCounter(timer);
 
@@ -766,6 +784,7 @@ static void pwm_stm32_irq_config_func_##index(const struct device *dev)		\
 		.timer = (TIM_TypeDef *)DT_REG_ADDR(PWM(index)),	       \
 		.prescaler = DT_PROP(PWM(index), st_prescaler),		       \
 		.countermode = DT_PROP(PWM(index), st_countermode),	       \
+		.deadtime = DT_PROP(PWM(index), st_deadtime),		       \
 		.pclken = pclken_##index,				       \
 		.pclk_len = DT_NUM_CLOCKS(PWM(index)),			       \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),		       \

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -46,3 +46,19 @@ properties:
                                                down.
 
       If absent, then STM32_TIM_COUNTERMODE_UP is used (reset state).
+
+  st,deadtime:
+    type: int
+    default: 0
+    description: |
+      Sets the dead-time configuration on the associated timer which will add
+      a delay between the rising edge of the reference signal and the rising
+      edge of both the OCx and OCxN signals. This is commonly used and required
+      with bridge circuits to prevent shoot-through currents.
+
+      This feature is supported only by certain timer instances. Refer
+      to your product's Reference Manual for more information about this
+      feature's availability. (In particular, certain series such as
+      STM32L0/STM32L1 have no instance supporting this feature).
+
+      Valid range [0 ... 255].


### PR DESCRIPTION
When using an stm32 in a bridge circuit with complementary outputs, the deadtime needs to be configurable to avoid shoot-thru current on the circuit. So, the HAL has the configuration in the BDTR init and use that api access to set the configuration.