### PR TITLE
drivers: i2s: stm32 sai code cleanup

### DIFF
--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -255,14 +255,12 @@ static int stm32_sai_enable_clock(const struct device *dev)
 static int i2s_stm32_sai_dma_init(const struct device *dev)
 {
 	struct i2s_stm32_sai_data *dev_data = dev->data;
+	struct stream *stream = &dev_data->stream;
+	struct dma_config dma_cfg = dev_data->stream.dma_cfg;
+	int ret;
+
 	SAI_HandleTypeDef *hsai = &dev_data->hsai;
 	DMA_HandleTypeDef *hdma = &dev_data->hdma;
-
-	struct stream *stream = &dev_data->stream;
-
-	struct dma_config dma_cfg = dev_data->stream.dma_cfg;
-
-	int ret;
 
 	if (!device_is_ready(stream->dma_dev)) {
 		LOG_ERR("%s DMA device not ready", stream->dma_dev->name);
@@ -276,30 +274,21 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 	dma_cfg.linked_channel = STM32_DMA_HAL_OVERRIDE;
 
 	ret = dma_config(stream->dma_dev, stream->dma_channel, &dma_cfg);
-
 	if (ret != 0) {
 		LOG_ERR("Failed to configure DMA channel %d", stream->dma_channel);
 		return ret;
 	}
 
 	hdma->Instance = STM32_DMA_GET_INSTANCE(stream->reg, stream->dma_channel);
-#if defined(CONFIG_SOC_SERIES_STM32F4X) || defined(CONFIG_SOC_SERIES_STM32F7X)
+	hdma->Init.Mode = DMA_NORMAL;
+
+#if defined(DMA_CHANNEL_1)
 	hdma->Init.Channel = dma_cfg.dma_slot * DMA_CHANNEL_1;
 #else
 	hdma->Init.Request = dma_cfg.dma_slot;
 #endif
-	hdma->Init.Mode = DMA_NORMAL;
 
-#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32L4X) ||                  \
-	defined(CONFIG_SOC_SERIES_STM32G4X) || defined(CONFIG_SOC_SERIES_STM32L5X) ||              \
-	defined(CONFIG_SOC_SERIES_STM32F4X) || defined(CONFIG_SOC_SERIES_STM32F7X)
-
-	hdma->Init.PeriphDataAlignment = DMA_PDATAALIGN_HALFWORD;
-	hdma->Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;
-	hdma->Init.Priority = DMA_PRIORITY_HIGH;
-	hdma->Init.PeriphInc = DMA_PINC_DISABLE;
-	hdma->Init.MemInc = DMA_MINC_ENABLE;
-#else
+#if defined(CONFIG_DMA_STM32U5)
 	hdma->Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
 	hdma->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
 	hdma->Init.DestDataWidth = DMA_DEST_DATAWIDTH_HALFWORD;
@@ -308,19 +297,22 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 	hdma->Init.DestBurstLength = 1;
 	hdma->Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0;
 	hdma->Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+#else
+	hdma->Init.PeriphDataAlignment = DMA_PDATAALIGN_HALFWORD;
+	hdma->Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;
+	hdma->Init.Priority = DMA_PRIORITY_HIGH;
+	hdma->Init.PeriphInc = DMA_PINC_DISABLE;
+	hdma->Init.MemInc = DMA_MINC_ENABLE;
 #endif
 
-#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32F4X) ||                  \
-	defined(CONFIG_SOC_SERIES_STM32F7X)
+#if defined(DMA_FIFOMODE_DISABLE)
 	hdma->Init.FIFOMode = DMA_FIFOMODE_DISABLE;
 #endif
 
 	if (stream->dma_cfg.channel_direction == (enum dma_channel_direction)MEMORY_TO_PERIPHERAL) {
 		hdma->Init.Direction = DMA_MEMORY_TO_PERIPH;
 
-#if !defined(CONFIG_SOC_SERIES_STM32H7X) && !defined(CONFIG_SOC_SERIES_STM32L4X) &&                \
-	!defined(CONFIG_SOC_SERIES_STM32G4X) && !defined(CONFIG_SOC_SERIES_STM32L5X) &&            \
-	!defined(CONFIG_SOC_SERIES_STM32F4X) && !defined(CONFIG_SOC_SERIES_STM32F7X)
+#if defined(CONFIG_DMA_STM32U5)
 		hdma->Init.SrcInc = DMA_SINC_INCREMENTED;
 		hdma->Init.DestInc = DMA_DINC_FIXED;
 #endif
@@ -329,9 +321,7 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 	} else {
 		hdma->Init.Direction = DMA_PERIPH_TO_MEMORY;
 
-#if !defined(CONFIG_SOC_SERIES_STM32H7X) && !defined(CONFIG_SOC_SERIES_STM32L4X) &&                \
-	!defined(CONFIG_SOC_SERIES_STM32G4X) && !defined(CONFIG_SOC_SERIES_STM32L5X) &&            \
-	!defined(CONFIG_SOC_SERIES_STM32F4X) && !defined(CONFIG_SOC_SERIES_STM32F7X)
+#if defined(CONFIG_DMA_STM32U5)
 		hdma->Init.SrcInc = DMA_SINC_FIXED;
 		hdma->Init.DestInc = DMA_DINC_INCREMENTED;
 #endif
@@ -350,9 +340,7 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 		LOG_ERR("HAL_DMA_ConfigChannelAttributes: <Failed>");
 		return -EIO;
 	}
-#elif !defined(CONFIG_SOC_SERIES_STM32H7X) && !defined(CONFIG_SOC_SERIES_STM32L4X) &&              \
-	!defined(CONFIG_SOC_SERIES_STM32G4X) && !defined(CONFIG_SOC_SERIES_STM32L5X) &&            \
-	!defined(CONFIG_SOC_SERIES_STM32F4X) && !defined(CONFIG_SOC_SERIES_STM32F7X)
+#elif defined(CONFIG_DMA_STM32U5)
 	if (HAL_DMA_ConfigChannelAttributes(&dev_data->hdma, DMA_CHANNEL_NPRIV) != HAL_OK) {
 		LOG_ERR("HAL_DMA_ConfigChannelAttributes: <Failed>");
 		return -EIO;
@@ -467,9 +455,8 @@ static int i2s_stm32_sai_configure(const struct device *dev, enum i2s_dir dir,
 		return -EINVAL;
 	}
 
-	/* Control of MCLK output from SAI configuration is not possible on STM32L4/F4/F7xx MCUs */
-#if !defined(CONFIG_SOC_SERIES_STM32L4X) && !defined(CONFIG_SOC_SERIES_STM32F4X) &&                \
-	!defined(CONFIG_SOC_SERIES_STM32F7X)
+	/* MckOutput is not supported by all MCU series */
+#if defined(SAI_MCK_OUTPUT_ENABLE)
 	if (cfg->mclk_enable && stream->master) {
 		hsai->Init.MckOutput = SAI_MCK_OUTPUT_ENABLE;
 	} else {
@@ -482,10 +469,8 @@ static int i2s_stm32_sai_configure(const struct device *dev, enum i2s_dir dir,
 	} else {
 		hsai->Init.NoDivider = SAI_MASTERDIVIDER_ENABLE;
 
-		/* MckOverSampling is not supported by all STM32L4xx MCUs */
-		/* MckOverSampling is not supported by STM32F4/F7xx MCUs */
-#if !defined(CONFIG_SOC_SERIES_STM32L4X) && !defined(CONFIG_SOC_SERIES_STM32F4X) &&                \
-	!defined(CONFIG_SOC_SERIES_STM32F7X)
+		/* MckOverSampling is not supported by all MCU series */
+#if defined(SAI_MCK_OVERSAMPLING_DISABLE)
 		if (cfg->mclk_div == (enum mclk_divider)MCLK_DIV_256) {
 			hsai->Init.MckOverSampling = SAI_MCK_OVERSAMPLING_DISABLE;
 		} else {


### PR DESCRIPTION
Replace series-specific macros with generic macros shared across multiple STM32 series to improve readability and maintainability.

Tested on the following to verify that everything works as intended:

1.  nucleo_h745zi_q (CONFIG_DMAMUX_STM32)
2. nucleo_f767zi (CONFIG_DMA_STM32_V1)
3. nucleo_l432kc (CONFIG_DMA_STM32_V2)
4. nucleo_h563zi (CONFIG_DMA_STM32U5)