### PR TITLE
drivers: i2s: stm32 i2s bit clock continuous mode

### DIFF
--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -687,7 +687,9 @@ static void dma_tx_callback(const struct device *dma_dev, void *arg,
 	return;
 
 tx_disable:
-	tx_stream_disable(stream, dev);
+	if ((stream->cfg.options & I2S_OPT_BIT_CLK_GATED) != 0) {
+		tx_stream_disable(stream, dev);
+	}
 }
 
 static uint32_t i2s_stm32_irq_count;


### PR DESCRIPTION
Added check for continuous or gated bit clock. 
Clock does not stop if I2S_OPT_BIT_CLK_CONT is selected.

Currently, there is no check and clock always acts as if it's in gated mode. This is supposed to fix that.

Fixes #98170