### PR TITLE
drivers: timer: Remove unused CONFIG_XLNX_PSTTC_TIMER_INDEX

### DIFF
--- a/drivers/timer/Kconfig.xlnx_psttc
+++ b/drivers/timer/Kconfig.xlnx_psttc
@@ -13,11 +13,3 @@ config XLNX_PSTTC_TIMER
 	  Zynq UltraScale+ MPSoC (ZynqMP) and Versal platforms. This TTC-based
 	  timer driver provides the "standard system clock driver" interface.
 	  If disabled, the TTC will not be used as the system timer.
-
-config XLNX_PSTTC_TIMER_INDEX
-	int "Xilinx PS Triple-Timer Counter index"
-	range 0 3
-	default 0
-	depends on XLNX_PSTTC_TIMER
-	help
-	  This is the index of TTC timer picked to provide system clock.

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -15,8 +15,6 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include "xlnx_psttc_timer_priv.h"
 
-#define TIMER_INDEX		CONFIG_XLNX_PSTTC_TIMER_INDEX
-
 #define TIMER_IRQ		DT_INST_IRQN(0)
 #define TIMER_BASE_ADDR		DT_INST_REG_ADDR(0)
 #define TIMER_CLOCK_FREQUECY	DT_INST_PROP(0, clock_frequency)


### PR DESCRIPTION
`CONFIG_XLNX_PSTTC_TIMER_INDEX` has been unused since commit 57784fb9d52 (v2.3 era), which switched to using the `DT_INST_` macro and defaulted to the first instance via `DT_INST_REG_ADDR(0)`.

Remove the obsolete and broken `CONFIG_XLNX_PSTTC_TIMER_INDEX`.