### PR TITLE
Bluetooth: Controller: Replace Kconfig select with depends

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -63,11 +63,20 @@ config BT_LLL_VENDOR_NORDIC
 	select BT_TICKER_REMAINDER_SUPPORT if !SOC_COMPATIBLE_NRF54LX
 	select BT_TICKER_UPDATE if BT_BROADCASTER || BT_CONN || \
 				   (BT_OBSERVER && BT_CTLR_ADV_EXT)
-	select BT_TICKER_START_REMAINDER if BT_TICKER_REMAINDER_SUPPORT && BT_CTLR_CENTRAL_ISO
+	select BT_TICKER_START_REMAINDER if BT_TICKER_REMAINDER_SUPPORT && \
+					    BT_CTLR_CENTRAL_ISO
 	select BT_TICKER_REMAINDER_GET if BT_TICKER_REMAINDER_SUPPORT && \
 					  (BT_BROADCASTER && BT_CTLR_ADV_EXT)
-	select BT_TICKER_LAZY_GET if BT_CTLR_ADV_PERIODIC || BT_CTLR_CONN_ISO || BT_CTLR_SYNC_TRANSFER_SENDER
-
+	select BT_TICKER_LAZY_GET if BT_CTLR_ADV_PERIODIC || \
+				     BT_CTLR_CONN_ISO || \
+				     BT_CTLR_SYNC_TRANSFER_SENDER
+	select BT_TICKER_NEXT_SLOT_GET if (BT_BROADCASTER && \
+					   BT_CTLR_ADV_EXT) || \
+					  BT_CENTRAL || BT_CTLR_CONN_ISO
+	select BT_TICKER_NEXT_SLOT_GET_MATCH if (BT_BROADCASTER && \
+						 BT_CTLR_ADV_EXT) || \
+						BT_CENTRAL || BT_CTLR_CONN_ISO
+	select BT_TICKER_CNTR_FREE_RUNNING if SOC_COMPATIBLE_NRF54LX
 	select BT_TICKER_PREFER_START_BEFORE_STOP if BT_TICKER_SLOT_AGNOSTIC
 
 	select BT_CTLR_ASSERT_OPTIMIZE_FOR_SIZE_SUPPORT if CPU_CORTEX_M
@@ -286,7 +295,7 @@ config BT_CTLR_CONN_ISO_AVOID_SEGMENTATION
 	  interface, the config provides a way to force the Max_PDU to Max_SDU +
 	  5 (header + offset).
 
-choice
+choice BT_CTLR_CONN_ISO_POLICY_CHOICE
 	prompt "CIS Creation Policy Selection"
 	default BT_CTLR_CONN_ISO_RELIABILITY_POLICY
 
@@ -357,7 +366,6 @@ config BT_CTLR_DATA_LENGTH_CLEAR
 config BT_CTLR_PHY_2M_NRF
 	bool "2Mbps Nordic Semiconductor PHY Support (Cleartext only)"
 	depends on SOC_SERIES_NRF51X
-	select BT_CTLR_PHY_2M
 	help
 	  Enable support for Nordic Semiconductor proprietary 2Mbps PHY in the
 	  Controller. Encrypted connections are not supported.
@@ -398,6 +406,7 @@ config BT_CTLR_ADV_PDU_LINK
 	# Enables extra space in each advertising PDU to allow linking PDUs.
 	# This is required to enable advertising data trains (i.e. transmission
 	# of AUX_CHAIN_IND).
+	depends on BT_CTLR_ADV_EXT && BT_BROADCASTER
 	bool
 
 config BT_CTLR_ADV_AUX_PDU_LINK
@@ -407,9 +416,8 @@ config BT_CTLR_ADV_AUX_PDU_LINK
 
 config BT_CTLR_ADV_AUX_PDU_BACK2BACK
 	bool "Back-to-back transmission of extended advertising trains"
-	depends on BT_BROADCASTER && BT_CTLR_ADV_EXT
 	select BT_CTLR_ADV_AUX_PDU_LINK
-	default y if BT_CTLR_ADV_DATA_LEN_MAX > 191
+	default y if BT_CTLR_ADV_DATA_CHAIN
 	help
 	  Enables transmission of AUX_CHAIN_IND in extended advertising train by
 	  sending each AUX_CHAIN_IND one after another back-to-back.
@@ -430,8 +438,8 @@ config BT_CTLR_ADV_SYNC_PDU_LINK
 
 config BT_CTLR_ADV_SYNC_PDU_BACK2BACK
 	bool "Back-to-back transmission of periodic advertising trains"
-	depends on BT_CTLR_ADV_PERIODIC
 	select BT_CTLR_ADV_SYNC_PDU_LINK
+	default y if BT_CTLR_ADV_PERIODIC && BT_CTLR_ADV_DATA_CHAIN
 	help
 	  Enables transmission of AUX_CHAIN_IND in periodic advertising train by
 	  sending each AUX_CHAIN_IND one after another back-to-back.
@@ -698,7 +706,7 @@ config BT_CTLR_DYNAMIC_INTERRUPTS
 	  permit use of SoC's peripheral for custom use when Bluetooth is not
 	  enabled.
 
-choice BT_CTLR_OPTIMIZE
+choice BT_CTLR_OPTIMIZE_CHOICE
 	prompt "Optimization options"
 	depends on !LTO
 	default BT_CTLR_OPTIMIZE_FOR_SPEED
@@ -763,8 +771,8 @@ config BT_CTLR_SCHED_ADVANCED
 	depends on BT_CTLR_SCHED_ADVANCED_SUPPORT && \
 		   (BT_CONN || \
 		    (BT_CTLR_ADV_EXT && (BT_CTLR_ADV_AUX_SET > 0)) || \
-		    BT_CTLR_ADV_ISO)
-	select BT_TICKER_NEXT_SLOT_GET
+		    BT_CTLR_ADV_ISO) && \
+		   BT_TICKER_NEXT_SLOT_GET
 	default y if BT_CENTRAL || (BT_BROADCASTER && BT_CTLR_ADV_EXT) || BT_CTLR_ADV_ISO
 	help
 	  Enable non-overlapping placement of observer, initiator and central
@@ -908,7 +916,7 @@ config BT_CTLR_ULL_LOW_PRIO
 
 config BT_CTLR_LOW_LAT
 	bool "Low latency non-negotiating event preemption"
-	select BT_CTLR_LOW_LAT_ULL_DONE
+	depends on BT_CTLR_LOW_LAT_ULL && BT_CTLR_LOW_LAT_ULL_DONE
 	default y if SOC_SERIES_NRF51X
 	help
 	  Use low latency non-negotiating event preemption. This reduces
@@ -917,33 +925,32 @@ config BT_CTLR_LOW_LAT
 	  radio state switches.
 
 config BT_CTLR_LOW_LAT_ULL
-	prompt "Low latency ULL"
-	bool
+	bool "Low latency ULL"
+	default y if SOC_SERIES_NRF51X
 	help
 	  Low latency ULL implementation that uses tailchaining instead of while
 	  loop to demux rx messages from LLL.
 
 config BT_CTLR_LOW_LAT_ULL_DONE
-	prompt "Low latency ULL prepare dequeue"
-	bool
+	bool "Low latency ULL prepare dequeue"
+	default y if SOC_SERIES_NRF51X
 	help
 	  Done events be processed and dequeued in ULL context.
 
 config BT_CTLR_CONN_META
-	prompt "Connection meta data extension"
-	bool
+	bool "Connection meta data extension"
 	help
 	  Enables vendor specific per-connection meta data as part of the
 	  LLL connection object.
 
 config BT_CTLR_RX_PDU_META
-	prompt "RX pdu meta data"
-	bool
+	bool "RX pdu meta data"
+	help
+	  Enables vendor specific Rx PDU meta data as part of the Rx object.
 
 config BT_CTLR_NRF_GRTC
 	bool "Use nRF GRTC peripheral"
-	depends on SOC_COMPATIBLE_NRF54LX
-	select BT_TICKER_CNTR_FREE_RUNNING
+	depends on BT_TICKER_CNTR_FREE_RUNNING && SOC_COMPATIBLE_NRF54LX
 	default y
 	help
 	  Enable use of nRF54Lx NRF_GRTC peripheral.
@@ -974,8 +981,9 @@ config BT_CTLR_NRF_GRTC_AUTOEN_DEFAULT
 
 config BT_CTLR_RADIO_ENABLE_FAST
 	bool "Use tTXEN/RXEN,FAST ramp-up"
-	depends on SOC_COMPATIBLE_NRF52X || SOC_COMPATIBLE_NRF53X || SOC_COMPATIBLE_NRF54LX
-	select BT_CTLR_SW_SWITCH_SINGLE_TIMER if SOC_COMPATIBLE_NRF54LX
+	depends on SOC_COMPATIBLE_NRF52X || \
+		   SOC_COMPATIBLE_NRF53X || \
+		   SOC_COMPATIBLE_NRF54LX
 	default y
 	help
 	  Enable use of fast radio ramp-up mode.
@@ -989,15 +997,18 @@ config BT_CTLR_RADIO_TIMER_ISR
 
 config BT_CTLR_TIFS_HW
 	bool "H/w Accelerated tIFS Trx switching"
-	depends on !BT_CTLR_RADIO_ENABLE_FAST && BT_CTLR_TIFS_HW_SUPPORT
+	depends on BT_CTLR_TIFS_HW_SUPPORT && !BT_CTLR_RADIO_ENABLE_FAST
 	default y
 	help
 	  Enable use of hardware accelerated tIFS Trx switching.
 
 config BT_CTLR_SW_SWITCH_SINGLE_TIMER
 	bool "Single TIMER tIFS Trx SW switching"
-	depends on (!BT_CTLR_TIFS_HW) && (SOC_COMPATIBLE_NRF52X || SOC_COMPATIBLE_NRF53X || \
-					  SOC_COMPATIBLE_NRF54LX)
+	depends on BT_CTLR_RADIO_ENABLE_FAST && \
+		   (SOC_COMPATIBLE_NRF52X || \
+		    SOC_COMPATIBLE_NRF53X || \
+		    SOC_COMPATIBLE_NRF54LX)
+	default y if SOC_COMPATIBLE_NRF54LX
 	help
 	  Implement the tIFS Trx SW switch with the same TIMER
 	  instance, as the one used for Bluetooth event timing. Requires
@@ -1102,7 +1113,7 @@ config BT_CTLR_TX_RETRY_DISABLE
 
 config BT_CTLR_TX_DEFER
 	bool "Deferred ACL Tx packet transmission setup"
-	select BT_CTLR_RADIO_TIMER_ISR
+	depends on BT_CTLR_RADIO_TIMER_ISR
 	help
 	  Enable deferred ACL Tx packet transmission setup by radio, so that an
 	  enqueued ACL Data packet by the upper layer can be transmitted with
@@ -1110,6 +1121,7 @@ config BT_CTLR_TX_DEFER
 
 config BT_CTLR_THROUGHPUT
 	bool "Measure incoming Tx throughput"
+	default y if BT_HCI_RAW
 	help
 	  Measure incoming Tx throughput and log the results.
 
@@ -1129,9 +1141,8 @@ config BT_CTLR_FORCE_MD_COUNT
 
 config BT_CTLR_FORCE_MD_AUTO
 	bool "Forced MD bit automatic calculation"
-	depends on !BT_CTLR_LOW_LAT
-	select BT_CTLR_THROUGHPUT
-	default y if BT_HCI_RAW
+	depends on BT_CTLR_THROUGHPUT && !BT_CTLR_LOW_LAT
+	default y
 	help
 	  Force MD bit in transmitted PDU based on runtime incoming transmit
 	  data throughput.
@@ -1268,9 +1279,8 @@ config BT_TICKER_NEXT_SLOT_GET
 
 config BT_TICKER_REMAINDER_GET
 	bool "Ticker Next Slot Get with Remainder"
-	depends on BT_TICKER_REMAINDER_SUPPORT
-	select BT_TICKER_NEXT_SLOT_GET
-	select BT_TICKER_NEXT_SLOT_GET_MATCH
+	depends on BT_TICKER_REMAINDER_SUPPORT && BT_TICKER_NEXT_SLOT_GET && \
+		   BT_TICKER_NEXT_SLOT_GET_MATCH
 	help
 	  This option enables ticker interface to iterate through active
 	  ticker nodes, returning tick to expire and remainder from a reference
@@ -1278,8 +1288,7 @@ config BT_TICKER_REMAINDER_GET
 
 config BT_TICKER_LAZY_GET
 	bool "Ticker Next Slot Get with Lazy"
-	select BT_TICKER_NEXT_SLOT_GET
-	select BT_TICKER_NEXT_SLOT_GET_MATCH
+	depends on BT_TICKER_NEXT_SLOT_GET && BT_TICKER_NEXT_SLOT_GET_MATCH
 	help
 	  This option enables ticker interface to iterate through active
 	  ticker nodes, returning tick to expire and lazy count from a reference
@@ -1315,7 +1324,7 @@ config BT_TICKER_EXT_SLOT_WINDOW_YIELD
 
 config BT_TICKER_EXT_EXPIRE_INFO
 	bool "Ticker timeout with other ticker's expire information"
-	select BT_TICKER_EXT
+	depends on BT_TICKER_EXT
 	help
 	  This option enables ticker to return expiration info. The extended
 	  ticker interface) is used to ask for expiration information for
@@ -1362,7 +1371,7 @@ config BT_TICKER_PREFER_START_BEFORE_STOP
 
 config BT_CTLR_JIT_SCHEDULING
 	bool "Just-in-Time Scheduling"
-	select BT_TICKER_SLOT_AGNOSTIC
+	depends on BT_TICKER_SLOT_AGNOSTIC
 	help
 	  This option enables the experimental 'Next Generation' scheduling
 	  feature, which eliminates priorities and collision resolving in the
@@ -1377,8 +1386,7 @@ config BT_CTLR_PERIPHERAL_ISO_EARLY_CIG_START
 	  and hence adjust CIG offset and reference point ahead one interval.
 
 config BT_CTLR_USER_EXT
-	prompt "Proprietary extensions in Controller"
-	bool
+	bool "Proprietary extensions in Controller"
 	help
 	  Catch-all for enabling proprietary event types in Controller behavior.
 
@@ -1428,7 +1436,7 @@ config BT_CTLR_USER_CPR_ANCHOR_POINT_MOVE
 endmenu
 
 # Workaround to be able to have default for "choice" in hidden "menu" above
-choice BT_CTLR_OPTIMIZE
+choice BT_CTLR_OPTIMIZE_CHOICE
 	prompt "Optimization options"
 	depends on !LTO
 


### PR DESCRIPTION
Replace use of `select` with `depends on` in the LL_SW_SPLIT Kconfig options.