### PR TITLE
boards: weact: blackpill_f401cc: change model name from V3.0 to V1.2

### DIFF
--- a/boards/weact/blackpill_f401cc/Kconfig.defconfig
+++ b/boards/weact/blackpill_f401cc/Kconfig.defconfig
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-# F401CE based Black Pill V3.0+ board board configuration
+# F401CC based Black Pill V1.2 board board configuration
 
 if BOARD_BLACKPILL_F401CC
 

--- a/boards/weact/blackpill_f401cc/blackpill_f401cc.dts
+++ b/boards/weact/blackpill_f401cc/blackpill_f401cc.dts
@@ -10,7 +10,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
-	model = "WeAct Studio Black Pill V3.0 Board";
+	model = "WeAct Studio Black Pill V1.2 Board";
 	compatible = "weact,blackpill-f401ce";
 
 	chosen {


### PR DESCRIPTION
Renames blackpill_f401cc to WeAct Studio Black Pill V1.2 Board from WeAct Studio Black Pill V3.0