### PR TITLE
Redefine UART alternate funcsel constant to match pinmux declarations.

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/rpi-pico-rp2350-pinctrl-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/rpi-pico-rp2350-pinctrl-common.h
@@ -12,7 +12,7 @@
 #define RP2_PINCTRL_GPIO_FUNC_PIO2     8
 #define RP2_PINCTRL_GPIO_FUNC_GPCK     9
 #define RP2_PINCTRL_GPIO_FUNC_USB      10
-#define RP2_PINCTRL_GPIO_FUNC_UART_AUX 11
+#define RP2_PINCTRL_GPIO_FUNC_UART_ALT 11
 #define RP2_PINCTRL_GPIO_FUNC_NULL     0x1f
 
 #include "rpi-pico-pinctrl-common.h"


### PR DESCRIPTION
UART pinmux definitions all use RP2_PINCTRL_GPIO_FUNC_UART_ALT while the constant definition is RP2_PINCTRL_GPIO_FUNC_UART_AUX.  This minor change redefines the constant to match the usage.