### PR TITLE
silabs: siwg917: cleanup and add configurable 802.11w MFP support

### DIFF
--- a/drivers/wifi/siwx91x/Kconfig.siwx91x
+++ b/drivers/wifi/siwx91x/Kconfig.siwx91x
@@ -14,6 +14,18 @@ config WIFI_SILABS_SIWX91X
 
 if WIFI_SILABS_SIWX91X
 
+config WIFI_SILABS_SIWX91X_MFP
+	bool "802.11w Management Frame Protection (MFP) support"
+	default y
+	help
+	  Enable IEEE 802.11w Management Frame Protection (MFP) for secure
+	  handling of management frames.
+
+	  Note:
+	    - Required for WPA3-Personal and WPA3-Transition modes.
+	    - Disabling this frees memory used by MFP, improving TCP throughput
+	      by about 10–12% (≈1–2 Mbps).
+
 config WIFI_SILABS_SIWX91X_ENHANCED_MAX_PSP
 	bool "Enhanced Max PSP Support"
 	default y

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
@@ -172,7 +172,9 @@ static void siwx91x_configure_sta_mode(sl_si91x_boot_configuration_t *boot_confi
 
 #ifdef CONFIG_WIFI_SILABS_SIWX91X
 	boot_config->ext_tcp_ip_feature_bit_map = SL_SI91X_CONFIG_FEAT_EXTENSION_VALID;
-	boot_config->ext_custom_feature_bit_map |= SL_SI91X_EXT_FEAT_IEEE_80211W;
+	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_MFP)) {
+		boot_config->ext_custom_feature_bit_map |= SL_SI91X_EXT_FEAT_IEEE_80211W;
+	}
 	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_ENHANCED_MAX_PSP)) {
 		boot_config->config_feature_bit_map = SL_SI91X_ENABLE_ENHANCED_MAX_PSP;
 	}

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
@@ -172,9 +172,7 @@ static void siwx91x_configure_sta_mode(sl_si91x_boot_configuration_t *boot_confi
 
 #ifdef CONFIG_WIFI_SILABS_SIWX91X
 	boot_config->ext_tcp_ip_feature_bit_map = SL_SI91X_CONFIG_FEAT_EXTENSION_VALID;
-	boot_config->ext_custom_feature_bit_map |=
-		SL_SI91X_EXT_FEAT_IEEE_80211W |
-		SL_SI91X_EXT_FEAT_FRONT_END_SWITCH_PINS_ULP_GPIO_4_5_0;
+	boot_config->ext_custom_feature_bit_map |= SL_SI91X_EXT_FEAT_IEEE_80211W;
 	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_ENHANCED_MAX_PSP)) {
 		boot_config->config_feature_bit_map = SL_SI91X_ENABLE_ENHANCED_MAX_PSP;
 	}
@@ -322,12 +320,10 @@ static int siwx91x_get_nwp_config(const struct device *dev,
 						  SL_SI91X_CUSTOM_FEAT_ASYNC_CONNECTION_STATUS |
 						  SL_SI91X_CUSTOM_FEAT_RTC_FROM_HOST,
 			.ext_custom_feature_bit_map =
-				SL_SI91X_EXT_FEAT_XTAL_CLK | SL_SI91X_EXT_FEAT_1P8V_SUPPORT |
-				SL_SI91X_EXT_FEAT_DISABLE_XTAL_CORRECTION |
+				SL_SI91X_EXT_FEAT_XTAL_CLK |
 				SL_SI91X_EXT_FEAT_NWP_QSPI_80MHZ_CLK_ENABLE |
 				SL_SI91X_EXT_FEAT_FRONT_END_SWITCH_PINS_ULP_GPIO_4_5_0 |
-				SL_SI91X_EXT_FEAT_FRONT_END_INTERNAL_SWITCH |
-				SL_SI91X_EXT_FEAT_XTAL_CLK,
+				SL_SI91X_EXT_FEAT_FRONT_END_INTERNAL_SWITCH,
 		}
 	};
 


### PR DESCRIPTION
- Remove duplicate feature configuration in boot setup.
-  Add Kconfig option CONFIG_WIFI_SILABS_SIWX91X_MFP for optional 802.11w MFP (disabling improves TCP throughput by ~10–12%).