### PR TITLE
twister: pytest: Bluetooth: multi harness boards test against DuT

### DIFF
--- a/scripts/pylib/poc_plugins/README.rst
+++ b/scripts/pylib/poc_plugins/README.rst
@@ -1,0 +1,115 @@
+.. _integration_with_pytest:
+
+Integration with pytest test framework
+######################################
+
+Getting Started
+***************
+
+This plugin enables easy multi-device testing with pytest through three fixtures:
+
+1. ``harness_build_dirs`` — Specify and select build directories for each harness device.
+2. ``harness_devices`` — Access the initialized test devices.
+3. ``harness_shells`` — Access the command shells for each harness device.
+
+**Step 1: Configure Your Hardware Map**
+
+Add a Twister fixture to your standard ``map.yaml``:
+
+.. code-block:: yaml
+
+   map.yml:
+     - connected: true
+       fixtures:
+         - multi_instance_harness: C:/Users/97014/zephyrproject/harness_boards_for_one_dut.yml
+       id: 001061256778
+       platform: frdm_mcxw72/mcxw27c/cpu0
+       product: J-Link
+       runner: jlink
+       serial: COM4
+
+   multi_harness_devices_for_one_dut:
+      - connected: true
+        id: 001063989196
+        platform: frdm_mcxw72/mcxw27c/cpu0
+        product: J-Link
+        runner: jlink
+        serial: COM4
+      - connected: true
+        id: 001063989178
+        platform: frdm_mcxw72/mcxw27c/cpu0
+        product: J-Link
+        runner: jlink
+        serial: COM5
+
+**Step 2: Write Pytest Test Cases**
+
+- *Override ``harness_build_dirs``*: In your test suite, override this fixture to return one build directory per device.
+- *Use ``harness_devices`` or ``harness_shells``*: it will handle flashing and initialization for each harness device.
+
+
+Fixtures
+********
+
+harness_build_dirs
+==================
+    return [build_dir] for one harness devices as default.
+    if there are multiple harness devices, need to be overridden in test suite.
+
+    such as, flash differernt build dirs for harness devices,
+    the harness_build_dirs should be set as: [build_dir_1, build_dir_2, ...],
+    build_dir_1 could be build_dir, or from required_build_dirs fixture.
+    """
+
+.. code-block:: python
+
+   import pytest
+   from typing import List
+   from twister_harness import DeviceAdapter, harness_devices
+
+   def harness_build_dirs(request: pytest.FixtureRequest) -> List[str]:
+    build_dir = request.config.getoption('--build-dir')
+    return [build_dir, build_dir]
+
+harness_devices
+===============
+This pytest fixture is designed for multi-device testing in connectivity test, such as BLE, etc.
+This pytest fixture will load harness devices info from
+multi_instance_harness Twister fixture (defined in test yaml and hardware map),
+then flash and initialize the devices as dut fixture,
+Give access to a list of `DeviceAdapter`_ type objects (has to be same platform).
+To use this pytest fixture, ``harness_build_dirs`` fixture must to be defined in test suite.
+which should return the buid_dirs for each harness devices.
+
+.. code-block:: python
+
+   import pytest
+   from typing import List
+   from twister_harness import DeviceAdapter, harness_devices
+
+   def harness_build_dirs(request: pytest.FixtureRequest) -> List[str]:
+    build_dir = request.config.getoption('--build-dir')
+    return [build_dir, build_dir]
+
+   def test_sample(harness_devices: list[DeviceAdapter]):
+      for harness_device in harness_devices:
+         harness_device.readlines_until(regex=r'Bluetooth initialized', timeout=3)
+
+harness_shells
+==============
+This fixture is designed with harness_devices, just like shell fixture with dut.
+give access to a list of `Shell`_ type objects for each harness device.
+
+.. code-block:: python
+
+   from twister_harness import Shell
+
+   def test_sample(harness_shells: list[Shell]):
+      for shell in harness_shells:
+        shell.exec_command('help')
+
+
+Limitations
+***********
+
+* Not every platform type is supported in the plugin (yet).

--- a/scripts/pylib/poc_plugins/__init__.py
+++ b/scripts/pylib/poc_plugins/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025 NXP
+# SPDX-License-Identifier: Apache-2.0

--- a/scripts/pylib/poc_plugins/multi_device_fixtures.py
+++ b/scripts/pylib/poc_plugins/multi_device_fixtures.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# Copyright (c) 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import logging
+import time
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from twister_harness.device.device_adapter import DeviceAdapter
+from twister_harness.device.hardware_adapter import HardwareAdapter
+from twister_harness.fixtures import determine_scope
+from twister_harness.helpers.shell import Shell
+from twister_harness.helpers.utils import find_in_config
+from twister_harness.twister_harness_config import DeviceConfig, TwisterHarnessConfig
+from twisterlib.hardwaremap import HardwareMap
+
+logger = logging.getLogger(__name__)
+
+
+class DefaultTwisterOptionsWrapper:
+    """
+    Default wrapper class for Twister options.
+
+    These default parameters will be overwritten by the attributes of the hardware object,
+    which is loaded with the HardwareMap class from the multi_instance_harness Twister fixture,
+    as defined in the hardware map YAML file.
+    """
+
+    device_flash_timeout: float = 60.0  # [s]
+    device_flash_with_test: bool = True
+    flash_before: bool = False
+
+
+class TwisterEnvWrapper:
+    """Wrapper class for twister environment options"""
+
+    def __init__(self, options: DefaultTwisterOptionsWrapper):
+        self.options = options
+
+
+class HarnessHardwareAdapter(HardwareAdapter):
+    """Adapter class for real device."""
+
+    def __init__(self, device_config: DeviceConfig) -> None:
+        super().__init__(device_config)
+
+        self.device_log_path: Path = device_config.build_dir / f"device_{device_config.id}.log"
+        self.handler_log_path: Path = device_config.build_dir / f"handler_{device_config.id}.log"
+
+        self._log_files: list[Path] = [self.handler_log_path, self.device_log_path]
+
+
+@pytest.fixture(scope=determine_scope)
+def harness_build_dirs(request: pytest.FixtureRequest) -> list[str]:
+    """
+    return [build_dir] for one harness devices as default.
+    if there are multiple harness devices, need to be overridden in test suite.
+
+    such as, flash differernt build dirs for harness devices,
+    the harness_build_dirs should be set as: [build_dir_1, build_dir_2, ...],
+    build_dir_1 could be build_dir, or from required_build_dirs fixture.
+    """
+    build_dir = request.config.getoption('--build-dir')
+    return [build_dir]
+
+
+@pytest.fixture(scope=determine_scope)
+def harness_devices(
+    request: pytest.FixtureRequest,
+    dut: DeviceAdapter,
+    twister_harness_config: TwisterHarnessConfig,
+    harness_build_dirs: list[str],
+) -> Generator[DeviceAdapter, None, None]:
+    """
+    Create a list of harness device objects.
+
+    Args:
+        request (pytest.FixtureRequest): The pytest fixture request.
+        dut (DeviceAdapter): The main device under test.
+        twister_harness_config (TwisterHarnessConfig): The Twister Harness configuration.
+        harness_build_dirs (list[str]): list of build directories for harness devices.
+
+    Yields:
+        list[DeviceAdapter]: list of harness device adapter instances.
+    """
+    multi_instance_harness: str | None = None
+    for fixture in dut.device_config.fixtures:
+        if fixture.startswith("multi_instance_harness"):
+            multi_instance_harness = fixture.split(sep=":", maxsplit=1)[1]
+            break
+    if not multi_instance_harness:
+        pytest.fail("No multi_instance_harness fixture, do not need to call this pytest fixture")
+    if not Path(multi_instance_harness).exists():
+        pytest.fail(f"multi_instance_harness: {multi_instance_harness} not found")
+
+    # reuse twister HardwareMap class to load harness device config yaml
+    env = TwisterEnvWrapper(DefaultTwisterOptionsWrapper())
+    harness_device_hwm = HardwareMap(env)
+    harness_device_hwm.load(multi_instance_harness)
+    logger.info(f"harness_device_hwm[0]: {harness_device_hwm.duts[0]}")
+
+    if not harness_device_hwm.duts or (len(harness_build_dirs) > len(harness_device_hwm.duts)):
+        pytest.fail(
+            "Please check the harness_devices yaml, the number of devices and images do not match"
+        )
+        return
+
+    # Reuse most dut config for harness_device, only build and flash different app into them
+    dut_device_config: DeviceConfig = twister_harness_config.devices[0]
+    logger.info(f"dut_device_config: {dut_device_config}")
+
+    harness_devices_list: list[DeviceAdapter] = []
+    for index, harness_build_dir in enumerate(harness_build_dirs):
+        harness_hw = harness_device_hwm.duts[index]
+        harness_device_config = copy.deepcopy(dut_device_config)
+        # Assign all attributes of harness_hw to harness_device_config
+        for attr in vars(harness_hw):
+            setattr(harness_device_config, attr, getattr(harness_hw, attr))
+        harness_device_config.build_dir = Path(harness_build_dir)
+
+        # Init harness device as DuT
+        device_obj = HarnessHardwareAdapter(harness_device_config)
+        device_obj.initialize_log_files(request.node.name)
+        harness_devices_list.append(device_obj)
+
+    try:
+        for device_obj in harness_devices_list:
+            device_obj.launch()
+        yield harness_devices_list
+    finally:
+        for device_obj in harness_devices_list:
+            device_obj.close()
+
+
+@pytest.fixture(scope=determine_scope)
+def harness_shells(harness_devices: list[DeviceAdapter]) -> list[Shell]:
+    """
+    Create a list of ready-to-use shell interfaces for harness devices.
+
+    Args:
+        harness_devices (list[DeviceAdapter]): list of harness device adapter instances.
+
+    Returns:
+        list[Shell]: list of shell interfaces for harness devices.
+    """
+    shells: list[Shell] = []
+    for device_obj in harness_devices:
+        shell_interface = Shell(device_obj, timeout=20.0)
+        prompt = find_in_config(
+            Path(device_obj.device_config.app_build_dir) / "zephyr" / ".config",
+            "CONFIG_SHELL_PROMPT_UART",
+        )
+        if prompt:
+            shell_interface.prompt = prompt
+        logger.info("Wait for prompt")
+        if not shell_interface.wait_for_prompt():
+            pytest.fail("Prompt not found")
+        if device_obj.device_config.type == "hardware":
+            # After booting up the device, there might appear additional logs
+            # after first prompt, so we need to wait and clear the buffer
+            time.sleep(0.5)
+            device_obj.clear_buffer()
+        shells.append(shell_interface)
+    return shells

--- a/tests/bluetooth/shell/pytest/conftest.py
+++ b/tests/bluetooth/shell/pytest/conftest.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# Copyright (c) 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+# Add the directory to PYTHONPATH
+zephyr_base = os.path.abspath(os.getenv("ZEPHYR_BASE"))
+if zephyr_base:
+    sys.path.insert(
+        0, os.path.join(zephyr_base, "scripts")
+    )  # import zephyr_module in environment.py
+    sys.path.insert(0, os.path.join(zephyr_base, "scripts/pylib"))
+    sys.path.insert(0, os.path.join(zephyr_base, "scripts", "pylib", "twister"))
+else:
+    raise OSError("ZEPHYR_BASE environment variable is not set")
+
+pytest_plugins = [
+    "poc_plugins.multi_device_fixtures",
+]

--- a/tests/bluetooth/shell/pytest/test_shell.py
+++ b/tests/bluetooth/shell/pytest/test_shell.py
@@ -1,0 +1,78 @@
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import random
+import re
+import time
+
+import pytest
+from twister_harness import Shell
+from twister_harness.fixtures import determine_scope
+
+logger = logging.getLogger(__name__)
+
+
+def get_addr_with_name_from_lines(lines: list[str], name: str):
+    dut_adv_line = ''
+    pattern = r"([0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5}) \((.*?)\)"
+    for line in lines:
+        if name in line:
+            dut_adv_line = line.strip()
+            break
+    if dut_adv_line:
+        match = re.search(pattern, dut_adv_line)
+        if match:
+            address = match.group(1)  # get address
+            address_type = match.group(2)  # get address type
+            return address, address_type
+    return None, None
+
+
+@pytest.fixture(scope=determine_scope)
+def harness_build_dirs(request: pytest.FixtureRequest) -> list[str]:
+    """
+    Return a list of build directories for each harness device.
+    """
+    build_dir = request.config.getoption('--build-dir')
+    return [build_dir]
+
+
+def test_ble_connection(shell: Shell, harness_shells: list[Shell]) -> None:
+    """Test BLE connection between central and peripheral devices.
+
+    Args:
+        shell (Shell): The central device shell interface.
+        harness_shells (list[Shell]): List of harness device shell interfaces.
+    """
+    adv_device_name = f"ztest_{random.randint(0, 999999):06}"
+    central_device = shell
+    peripheral_device = harness_shells[0]
+
+    # Initialize both devices
+    peripheral_device.exec_command('bt init')
+    central_device.exec_command('bt init')
+    central_device._device.readlines_until(regex=r'Bluetooth initialized', timeout=3)
+
+    # Set advertising name and start advertising
+    peripheral_device.exec_command(f'bt name {adv_device_name}')
+    peripheral_device.exec_command('bt advertise on')
+
+    # Central device scans for the peripheral
+    central_device.exec_command('bt scan on')
+    lines = central_device._device.readlines_until(regex=rf'{adv_device_name}.*\r?\n?$', timeout=5)
+    address, address_type = get_addr_with_name_from_lines(lines, adv_device_name)
+    logger.info(f'ADV device address: {address}, address_type: {address_type}')
+    central_device.exec_command('bt scan off')
+
+    # Central connects to peripheral
+    central_device.exec_command(f'bt connect {address} {address_type}')
+    central_device._device.readlines_until(
+        regex=rf'Connected: {address} \({address_type}\)', timeout=5
+    )
+    time.sleep(3)
+
+    # Disconnect and stop advertising
+    central_device.exec_command('bt disconnect')
+    peripheral_device.exec_command('bt advertise off')

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -17,8 +17,11 @@ tests:
       - qemu_x86
     platform_exclude: nrf52dk/nrf52810
     tags: bluetooth
-    harness: keyboard
+    harness: pytest
     min_flash: 145
+    harness_config:
+      pytest_dut_scope: session
+      fixture: multi_instance_harness
   bluetooth.shell.power_control_request:
     extra_configs:
       - CONFIG_BT_TRANSMIT_POWER_CONTROL=y


### PR DESCRIPTION
Add one harness_devices pytest fixture,
Which will load harness board info from harness_devices_yaml fixture, and flash same/different build dirs apps into multi harness boards, then init all harness devices as dut for tests.
Add tests for bt shell app with this feature.

`west twister -T tests/bluetooth/shell -p frdm_mcxw72/mcxw727c/cpu0 -s bluetooth.shell.main --device-testing --hardware-map ../map.yml --west-flash --force-platform
`

tests/bluetooth/shell app is flashed into 2 frdm_mcxw72 boards, 
one to adv, and one to scan and connect.

<img width="1047" height="1302" alt="image" src="https://github.com/user-attachments/assets/6528fedf-db7e-48ac-bc60-dfd53e54594d" />

this feature is for https://github.com/zephyrproject-rtos/zephyr/issues/83643, 
and will be very easy to be used with https://github.com/zephyrproject-rtos/zephyr/pull/94167 for ble central and peripheral testing, and other multi-devices tests.
