### PR TITLE
manifest: Update hal_renesas revision to get the correct ofs1 label

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -226,7 +226,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: fbe4b815ab838a13d24f1d3fc963846ff18c6b0e
+      revision: 62136a8ff8a2e644b72f0dc902d33b397991cace
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Since we defined and used the wrong label for the `option_setting_ofs1_sec` node in a file for `RA4E2` within `hal_renesas`, we have corrected it. This PR updates the revision to include that fix commit.