### PR TITLE
dts: arm: renesas: ra: Correct address and move sdram-controller to ra8x1.dtsi

### DIFF
--- a/dts/arm/renesas/ra/ra8/r7fa8d1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8d1xh.dtsi
@@ -10,14 +10,6 @@
 
 / {
 	soc {
-		sdram: sdram-controller@40002000 {
-			compatible = "renesas,ra-sdram";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40002000 0xFFF>;
-			status = "disabled";
-		};
-
 		lcdif: display-controller@40342000 {
 			compatible = "renesas,ra-glcdc";
 			reg = <0x40342000 0x1454>;

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -738,6 +738,14 @@
 			status = "disabled";
 		};
 
+		sdram: sdram-controller@40003c00 {
+			compatible = "renesas,ra-sdram";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x54>;
+			status = "disabled";
+		};
+
 		port_irq0: external-interrupt@40006000 {
 			compatible = "renesas,ra-external-interrupt";
 			reg = <0x40006000 0x1>;


### PR DESCRIPTION
- Correct address and size for `sdram-controller` node
- Move `sdram-controller` node from `r7fa8d1xh.dtsi` to `ra8x1.dtsi`, since all RA8x1 devices have this hardware IP