### PR TITLE
Enable ftm on mcxe247

### DIFF
--- a/boards/nxp/frdm_mcxe247/board.c
+++ b/boards/nxp/frdm_mcxe247/board.c
@@ -16,7 +16,7 @@
 
 #define ASSERT_ASYNC_CLK_DIV_VALID(val, str) \
 	BUILD_ASSERT(val == 0 || val == 1 || val == 2 || val == 4 ||	\
-		     val == 8 || val == 16 || val == 2 || val == 64, str)
+		     val == 8 || val == 16 || val == 32 || val == 64, str)
 
 #define kSCG_AsyncClkDivBy0 kSCG_AsyncClkDisable
 

--- a/boards/nxp/frdm_mcxe247/frdm_mcxe247.dts
+++ b/boards/nxp/frdm_mcxe247/frdm_mcxe247.dts
@@ -153,7 +153,7 @@
 };
 
 &fircdiv1_clk {
-	clock-div = <1>;
+	clock-div = <8>;
 };
 
 &fircdiv2_clk {
@@ -265,6 +265,10 @@
 };
 
 &crc {
+	status = "okay";
+};
+
+&ftm0 {
 	status = "okay";
 };
 

--- a/boards/nxp/frdm_mcxe247/frdm_mcxe247.yaml
+++ b/boards/nxp/frdm_mcxe247/frdm_mcxe247.yaml
@@ -24,5 +24,7 @@ supported:
   - arduino_gpio
   - comparator
   - dma
+  - counter
+  - pwm
   - watchdog
 vendor: nxp

--- a/dts/arm/nxp/nxp_mcxe24x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxe24x_common.dtsi
@@ -371,7 +371,8 @@
 			interrupts = <99 0>, <100 0>, <101 0>, <102 0>, <104 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
 			clocks = <&pcc 0xe0 KINETIS_PCC_SRC_FIRC_ASYNC>;
-			prescaler = <1>;
+			clock-source = "external";
+			prescaler = <32>;
 			status = "disabled";
 		};
 

--- a/tests/drivers/pwm/pwm_api/boards/frdm_mcxe247.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/frdm_mcxe247.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &ftm3;
+	};
+};
+
+&pinctrl {
+	ftm3_default: ftm3_default {
+		group0 {
+			pinmux = <FTM3_CH7_PTC13>,
+				 <FTM3_CH3_PTB11>,
+				 <FTM3_CH6_PTC12>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+};
+
+&ftm3 {
+	status = "okay";
+	compatible = "nxp,ftm-pwm";
+	clock-source = "external";
+	prescaler = <128>;
+	#pwm-cells = <3>;
+	pinctrl-0 = <&ftm3_default>;
+	pinctrl-names = "default";
+};

--- a/tests/drivers/pwm/pwm_loopback/boards/frdm_mcxe247.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/frdm_mcxe247.overlay
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+&pinctrl {
+	ftm0_default: ftm0_default {
+		group0 {
+			pinmux = <FTM0_CH0_PTD15>,
+				 <FTM0_CH1_PTD16>,
+				 <FTM0_CH4_PTB16>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+
+	ftm3_default: ftm3_default {
+		group0 {
+			pinmux = <FTM3_CH5_PTC11>,
+				 <FTM3_CH0_PTB8>,
+				 <FTM3_CH1_PTB9>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+};
+
+/* To test this sample, connect
+ * PTC11(J1-12) ---> PTD15(J1-14)
+ */
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&ftm3 5 0 PWM_POLARITY_NORMAL>, /* PTC11 J1 pin 12 out*/
+		       <&ftm0 0 0 PWM_POLARITY_NORMAL>; /* PTD15 J1 pin 14 in */
+	};
+};
+
+&ftm0 {
+	status = "okay";
+	compatible = "nxp,ftm-pwm";
+	clock-source = "external";
+	prescaler = <32>;
+	#pwm-cells = <3>;
+	pinctrl-0 = <&ftm0_default>;
+	pinctrl-names = "default";
+};
+
+&ftm3 {
+	status = "okay";
+	compatible = "nxp,ftm-pwm";
+	clock-source = "external";
+	prescaler = <128>;
+	#pwm-cells = <3>;
+	pinctrl-0 = <&ftm3_default>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
1. Improve FTM counter driver to support single or multiple interrupts based on irq number.
2. Fix typo in ASSERT_ASYNC_CLK_DIV_VALID macro
3. Enable FTM0 in frdm_mcxe31b device tree
4. Enable test for FTM on frdm_mcxe247. passed tests:
    a. counter_basic_api
    b. pwm_api
    c. pwm_loopback