### PR TITLE
NXP imx943 add gpt as system tick

### DIFF
--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.dts
@@ -143,3 +143,7 @@
 	zephyr,random-mac-address;
 	status = "disabled";
 };
+
+&gpt_hw_timer1 {
+	status = "okay";
+};

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_0.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_0.dts
@@ -46,3 +46,7 @@
 	pinctrl-0 = <&lpuart11_default>;
 	pinctrl-names = "default";
 };
+
+&gpt_hw_timer2 {
+	status = "okay";
+};

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_0.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_0.dts
@@ -24,12 +24,14 @@
 
 &flexio1 {
 	status = "okay";
+
 	/* Signal can be checked by the connector J44 Pin10(M1_LED_TP1) via logic analyzer */
 	flexio1_pwm: flexio1_pwm {
 		compatible = "nxp,flexio-pwm";
 		#pwm-cells = <3>;
 		pinctrl-0 = <&flexio1_io5_default>;
 		pinctrl-names = "default";
+
 		pwm_1 {
 			pin-id = <5>;
 			prescaler = <1>;

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_1.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_1.dts
@@ -24,12 +24,14 @@
 
 &flexio1 {
 	status = "okay";
+
 	/* Signal can be checked by the connector J44 Pin10(M1_LED_TP1) via logic analyzer */
 	flexio1_pwm: flexio1_pwm {
 		compatible = "nxp,flexio-pwm";
 		#pwm-cells = <3>;
 		pinctrl-0 = <&flexio1_io5_default>;
 		pinctrl-names = "default";
+
 		pwm_1 {
 			pin-id = <5>;
 			prescaler = <1>;

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_1.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_1.dts
@@ -46,3 +46,7 @@
 	pinctrl-0 = <&lpuart12_default>;
 	pinctrl-names = "default";
 };
+
+&gpt_hw_timer3 {
+	status = "okay";
+};

--- a/dts/arm/nxp/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/nxp_imx94x.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <freq.h>
 #include <dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/imx943_clock.h>
 #include <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>
@@ -498,6 +499,35 @@
 			#gpio-cells = <2>;
 			ngpios = <16>;
 			status = "disabled";
+		};
+
+		gpt_hw_timer1: gpt@446f0000 {
+			compatible = "nxp,gpt-hw-timer";
+			reg = <0x446f0000 0x4000>;
+			interrupts = <39 0>;
+			status = "disabled";
+		};
+
+		gpt_hw_timer2: gpt@428a0000 {
+			compatible = "nxp,gpt-hw-timer";
+			reg = <0x428a0000 0x4000>;
+			interrupts = <144 0>;
+			status = "disabled";
+		};
+
+		gpt_hw_timer3: gpt@428b0000 {
+			compatible = "nxp,gpt-hw-timer";
+			reg = <0x428b0000 0x4000>;
+			interrupts = <145 0>;
+			status = "disabled";
+		};
+
+		gpt4: gpt@428c0000 {
+			compatible = "nxp,imx-gpt";
+			reg = <0x428c0000 0x4000>;
+			interrupts = <146 0>;
+			gptfreq = <DT_FREQ_M(24)>;
+			clocks = <&scmi_clk IMX943_CLK_GPT4>;
 		};
 
 		netc: ethernet {

--- a/dts/arm/nxp/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/nxp_imx94x.dtsi
@@ -44,6 +44,7 @@
 				pinctrl: pinctrl {
 					compatible = "nxp,imx943-pinctrl", "nxp,imx93-pinctrl";
 				};
+
 				/*
 				 * Use the NULL pinmux for the GPIO io port
 				 * which is not available to
@@ -572,7 +573,7 @@
 			emdio: mdio@4cde0000 {
 				compatible = "nxp,imx-netc-emdio";
 				reg = <0x4cde0000 0x10000>,
-					<0x4cbc0000 0x40000>;
+				      <0x4cbc0000 0x40000>;
 				reg-names = "basic", "pfconfig";
 				clocks = <&scmi_clk IMX943_CLK_ENET>;
 				#address-cells = <1>;
@@ -676,73 +677,74 @@
 			status = "disabled";
 		};
 	};
+
 	/* Define memory regions for IPC between m33s and m71 */
 	dram_m33s_m71_ipc0: memory0@87000000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x87000000 DT_SIZE_K(16)>;
-		zephyr,memory-region="DRAM_M33S_M71_IPC0";
-		zephyr,memory-attr = <(DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE))>;
+		zephyr,memory-region = "DRAM_M33S_M71_IPC0";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 	};
 
 	dram_m33s_m71_ipc1: memory1@87004000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x87004000 DT_SIZE_K(16)>;
-		zephyr,memory-region="DRAM_M33S_M71_IPC1";
-		zephyr,memory-attr = <(DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE))>;
+		zephyr,memory-region = "DRAM_M33S_M71_IPC1";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 	};
 
 	/* Define memory regions for IPC between m70 and m71 */
 	dram_m70_m71_ipc0: memory2@87008000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x87008000 DT_SIZE_K(16)>;
-		zephyr,memory-region="DRAM_M70_M71_IPC0";
-		zephyr,memory-attr = <(DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE))>;
+		zephyr,memory-region = "DRAM_M70_M71_IPC0";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 	};
 
 	dram_m70_m71_ipc1: memory3@8700c000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x8700c000 DT_SIZE_K(16)>;
-		zephyr,memory-region="DRAM_M70_M71_IPC1";
-		zephyr,memory-attr = <(DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE))>;
+		zephyr,memory-region = "DRAM_M70_M71_IPC1";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 	};
 
 	/* Define memory regions for IPC between m33s and m70 */
 	dram_m33s_m70_ipc0: memory4@87010000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x87010000 DT_SIZE_K(16)>;
-		zephyr,memory-region="DRAM_M33S_M70_IPC0";
-		zephyr,memory-attr = <(DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE))>;
+		zephyr,memory-region = "DRAM_M33S_M70_IPC0";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 	};
 
 	dram_m33s_m70_ipc1: memory5@87014000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x87014000 DT_SIZE_K(16)>;
-		zephyr,memory-region="DRAM_M33S_M70_IPC1";
-		zephyr,memory-attr = <(DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE))>;
+		zephyr,memory-region = "DRAM_M33S_M70_IPC1";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 	};
 
 	/* Define memory regions for IPC between m33s and m71 */
 	dram_m33s_m71_sh_mem: memory@87000000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x87000000 DT_SIZE_K(32)>;
-		zephyr,memory-region="DRAM_M33S_M71_SH_MEM";
-		zephyr,memory-attr = <(DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE))>;
+		zephyr,memory-region = "DRAM_M33S_M71_SH_MEM";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 	};
 
 	/* Define memory regions for IPC between m70 and m71 */
 	dram_m70_m71_sh_mem: memory@87008000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x87008000 DT_SIZE_K(32)>;
-		zephyr,memory-region="DRAM_M70_M71_SH_MEM";
-		zephyr,memory-attr = <(DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE))>;
+		zephyr,memory-region = "DRAM_M70_M71_SH_MEM";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 	};
 
 	/* Define memory regions for IPC between m33s and m70 */
 	dram_m33s_m70_sh_mem: memory@87010000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x87010000 DT_SIZE_K(32)>;
-		zephyr,memory-region="DRAM_M33S_M70_SH_MEM";
-		zephyr,memory-attr = <(DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE))>;
+		zephyr,memory-region = "DRAM_M33S_M70_SH_MEM";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 	};
 };
 
@@ -752,221 +754,221 @@
  * select GPIO mux options during GPIO configuration.
  */
 
-&gpio1{
+&gpio1 {
 	pinmux = <&iomuxc_i2c1_scl_gpio_io_gpio1_io0>,
-		<&iomuxc_i2c1_sda_gpio_io_gpio1_io1>,
-		<&iomuxc_i2c2_scl_gpio_io_gpio1_io2>,
-		<&iomuxc_i2c2_sda_gpio_io_gpio1_io3>,
-		<&iomuxc_uart1_rxd_gpio_io_gpio1_io4>,
-		<&iomuxc_uart1_txd_gpio_io_gpio1_io5>,
-		<&iomuxc_uart2_rxd_gpio_io_gpio1_io6>,
-		<&iomuxc_uart2_txd_gpio_io_gpio1_io7>,
-		<&iomuxc_pdm_clk_gpio_io_gpio1_io8>,
-		<&iomuxc_pdm_bit_stream0_gpio_io_gpio1_io9>,
-		<&iomuxc_pdm_bit_stream1_gpio_io_gpio1_io10>,
-		<&iomuxc_sai1_txfs_gpio_io_gpio1_io11>,
-		<&iomuxc_sai1_txc_gpio_io_gpio1_io12>,
-		<&iomuxc_sai1_txd0_gpio_io_gpio1_io13>,
-		<&iomuxc_sai1_rxd0_gpio_io_gpio1_io14>,
-		<&iomuxc_wdog_any_gpio_io_gpio1_io15>;
+		 <&iomuxc_i2c1_sda_gpio_io_gpio1_io1>,
+		 <&iomuxc_i2c2_scl_gpio_io_gpio1_io2>,
+		 <&iomuxc_i2c2_sda_gpio_io_gpio1_io3>,
+		 <&iomuxc_uart1_rxd_gpio_io_gpio1_io4>,
+		 <&iomuxc_uart1_txd_gpio_io_gpio1_io5>,
+		 <&iomuxc_uart2_rxd_gpio_io_gpio1_io6>,
+		 <&iomuxc_uart2_txd_gpio_io_gpio1_io7>,
+		 <&iomuxc_pdm_clk_gpio_io_gpio1_io8>,
+		 <&iomuxc_pdm_bit_stream0_gpio_io_gpio1_io9>,
+		 <&iomuxc_pdm_bit_stream1_gpio_io_gpio1_io10>,
+		 <&iomuxc_sai1_txfs_gpio_io_gpio1_io11>,
+		 <&iomuxc_sai1_txc_gpio_io_gpio1_io12>,
+		 <&iomuxc_sai1_txd0_gpio_io_gpio1_io13>,
+		 <&iomuxc_sai1_rxd0_gpio_io_gpio1_io14>,
+		 <&iomuxc_wdog_any_gpio_io_gpio1_io15>;
 };
 
-&gpio2{
+&gpio2 {
 	pinmux = <&iomuxc_gpio_io00_gpio_io_gpio2_io0>,
-		<&iomuxc_gpio_io01_gpio_io_gpio2_io1>,
-		<&iomuxc_gpio_io02_gpio_io_gpio2_io2>,
-		<&iomuxc_gpio_io03_gpio_io_gpio2_io3>,
-		<&iomuxc_gpio_io04_gpio_io_gpio2_io4>,
-		<&iomuxc_gpio_io05_gpio_io_gpio2_io5>,
-		<&iomuxc_gpio_io06_gpio_io_gpio2_io6>,
-		<&iomuxc_gpio_io07_gpio_io_gpio2_io7>,
-		<&iomuxc_gpio_io08_gpio_io_gpio2_io8>,
-		<&iomuxc_gpio_io09_gpio_io_gpio2_io9>,
-		<&iomuxc_gpio_io10_gpio_io_gpio2_io10>,
-		<&iomuxc_gpio_io11_gpio_io_gpio2_io11>,
-		<&iomuxc_gpio_io12_gpio_io_gpio2_io12>,
-		<&iomuxc_gpio_io13_gpio_io_gpio2_io13>,
-		<&iomuxc_gpio_io14_gpio_io_gpio2_io14>,
-		<&iomuxc_gpio_io15_gpio_io_gpio2_io15>,
-		<&iomuxc_gpio_io16_gpio_io_gpio2_io16>,
-		<&iomuxc_gpio_io17_gpio_io_gpio2_io17>,
-		<&iomuxc_gpio_io18_gpio_io_gpio2_io18>,
-		<&iomuxc_gpio_io19_gpio_io_gpio2_io19>,
-		<&iomuxc_gpio_io20_gpio_io_gpio2_io20>,
-		<&iomuxc_gpio_io21_gpio_io_gpio2_io21>,
-		<&iomuxc_gpio_io22_gpio_io_gpio2_io22>,
-		<&iomuxc_gpio_io23_gpio_io_gpio2_io23>,
-		<&iomuxc_gpio_io24_gpio_io_gpio2_io24>,
-		<&iomuxc_gpio_io25_gpio_io_gpio2_io25>,
-		<&iomuxc_gpio_io26_gpio_io_gpio2_io26>,
-		<&iomuxc_gpio_io27_gpio_io_gpio2_io27>,
-		<&iomuxc_gpio_io28_gpio_io_gpio2_io28>,
-		<&iomuxc_gpio_io29_gpio_io_gpio2_io29>,
-		<&iomuxc_gpio_io30_gpio_io_gpio2_io30>,
-		<&iomuxc_gpio_io31_gpio_io_gpio2_io31>;
+		 <&iomuxc_gpio_io01_gpio_io_gpio2_io1>,
+		 <&iomuxc_gpio_io02_gpio_io_gpio2_io2>,
+		 <&iomuxc_gpio_io03_gpio_io_gpio2_io3>,
+		 <&iomuxc_gpio_io04_gpio_io_gpio2_io4>,
+		 <&iomuxc_gpio_io05_gpio_io_gpio2_io5>,
+		 <&iomuxc_gpio_io06_gpio_io_gpio2_io6>,
+		 <&iomuxc_gpio_io07_gpio_io_gpio2_io7>,
+		 <&iomuxc_gpio_io08_gpio_io_gpio2_io8>,
+		 <&iomuxc_gpio_io09_gpio_io_gpio2_io9>,
+		 <&iomuxc_gpio_io10_gpio_io_gpio2_io10>,
+		 <&iomuxc_gpio_io11_gpio_io_gpio2_io11>,
+		 <&iomuxc_gpio_io12_gpio_io_gpio2_io12>,
+		 <&iomuxc_gpio_io13_gpio_io_gpio2_io13>,
+		 <&iomuxc_gpio_io14_gpio_io_gpio2_io14>,
+		 <&iomuxc_gpio_io15_gpio_io_gpio2_io15>,
+		 <&iomuxc_gpio_io16_gpio_io_gpio2_io16>,
+		 <&iomuxc_gpio_io17_gpio_io_gpio2_io17>,
+		 <&iomuxc_gpio_io18_gpio_io_gpio2_io18>,
+		 <&iomuxc_gpio_io19_gpio_io_gpio2_io19>,
+		 <&iomuxc_gpio_io20_gpio_io_gpio2_io20>,
+		 <&iomuxc_gpio_io21_gpio_io_gpio2_io21>,
+		 <&iomuxc_gpio_io22_gpio_io_gpio2_io22>,
+		 <&iomuxc_gpio_io23_gpio_io_gpio2_io23>,
+		 <&iomuxc_gpio_io24_gpio_io_gpio2_io24>,
+		 <&iomuxc_gpio_io25_gpio_io_gpio2_io25>,
+		 <&iomuxc_gpio_io26_gpio_io_gpio2_io26>,
+		 <&iomuxc_gpio_io27_gpio_io_gpio2_io27>,
+		 <&iomuxc_gpio_io28_gpio_io_gpio2_io28>,
+		 <&iomuxc_gpio_io29_gpio_io_gpio2_io29>,
+		 <&iomuxc_gpio_io30_gpio_io_gpio2_io30>,
+		 <&iomuxc_gpio_io31_gpio_io_gpio2_io31>;
 };
 
-&gpio3{
+&gpio3 {
 	pinmux = <&iomuxc_gpio_io32_gpio_io_gpio3_io0>,
-		<&iomuxc_gpio_io33_gpio_io_gpio3_io1>,
-		<&iomuxc_gpio_io34_gpio_io_gpio3_io2>,
-		<&iomuxc_gpio_io35_gpio_io_gpio3_io3>,
-		<&iomuxc_gpio_io36_gpio_io_gpio3_io4>,
-		<&iomuxc_gpio_io37_gpio_io_gpio3_io5>,
-		<&iomuxc_gpio_io38_gpio_io_gpio3_io6>,
-		<&iomuxc_gpio_io39_gpio_io_gpio3_io7>,
-		<&iomuxc_gpio_io40_gpio_io_gpio3_io8>,
-		<&iomuxc_gpio_io41_gpio_io_gpio3_io9>,
-		<&iomuxc_gpio_io42_gpio_io_gpio3_io10>,
-		<&iomuxc_gpio_io43_gpio_io_gpio3_io11>,
-		<&iomuxc_gpio_io44_gpio_io_gpio3_io12>,
-		<&iomuxc_gpio_io45_gpio_io_gpio3_io13>,
-		<&iomuxc_gpio_io46_gpio_io_gpio3_io14>,
-		<&iomuxc_gpio_io47_gpio_io_gpio3_io15>,
-		<&iomuxc_gpio_io48_gpio_io_gpio3_io16>,
-		<&iomuxc_gpio_io49_gpio_io_gpio3_io17>,
-		<&iomuxc_gpio_io50_gpio_io_gpio3_io18>,
-		<&iomuxc_gpio_io51_gpio_io_gpio3_io19>,
-		<&iomuxc_gpio_io52_gpio_io_gpio3_io20>,
-		<&iomuxc_gpio_io53_gpio_io_gpio3_io21>,
-		<&iomuxc_gpio_io54_gpio_io_gpio3_io22>,
-		<&iomuxc_gpio_io55_gpio_io_gpio3_io23>,
-		<&iomuxc_gpio_io56_gpio_io_gpio3_io24>,
-		<&iomuxc_gpio_io57_gpio_io_gpio3_io25>;
+		 <&iomuxc_gpio_io33_gpio_io_gpio3_io1>,
+		 <&iomuxc_gpio_io34_gpio_io_gpio3_io2>,
+		 <&iomuxc_gpio_io35_gpio_io_gpio3_io3>,
+		 <&iomuxc_gpio_io36_gpio_io_gpio3_io4>,
+		 <&iomuxc_gpio_io37_gpio_io_gpio3_io5>,
+		 <&iomuxc_gpio_io38_gpio_io_gpio3_io6>,
+		 <&iomuxc_gpio_io39_gpio_io_gpio3_io7>,
+		 <&iomuxc_gpio_io40_gpio_io_gpio3_io8>,
+		 <&iomuxc_gpio_io41_gpio_io_gpio3_io9>,
+		 <&iomuxc_gpio_io42_gpio_io_gpio3_io10>,
+		 <&iomuxc_gpio_io43_gpio_io_gpio3_io11>,
+		 <&iomuxc_gpio_io44_gpio_io_gpio3_io12>,
+		 <&iomuxc_gpio_io45_gpio_io_gpio3_io13>,
+		 <&iomuxc_gpio_io46_gpio_io_gpio3_io14>,
+		 <&iomuxc_gpio_io47_gpio_io_gpio3_io15>,
+		 <&iomuxc_gpio_io48_gpio_io_gpio3_io16>,
+		 <&iomuxc_gpio_io49_gpio_io_gpio3_io17>,
+		 <&iomuxc_gpio_io50_gpio_io_gpio3_io18>,
+		 <&iomuxc_gpio_io51_gpio_io_gpio3_io19>,
+		 <&iomuxc_gpio_io52_gpio_io_gpio3_io20>,
+		 <&iomuxc_gpio_io53_gpio_io_gpio3_io21>,
+		 <&iomuxc_gpio_io54_gpio_io_gpio3_io22>,
+		 <&iomuxc_gpio_io55_gpio_io_gpio3_io23>,
+		 <&iomuxc_gpio_io56_gpio_io_gpio3_io24>,
+		 <&iomuxc_gpio_io57_gpio_io_gpio3_io25>;
 };
 
-&gpio4{
+&gpio4 {
 	pinmux = <&iomuxc_ccm_clko1_gpio_io_gpio4_io0>,
-		<&iomuxc_ccm_clko2_gpio_io_gpio4_io1>,
-		<&iomuxc_ccm_clko3_gpio_io_gpio4_io2>,
-		<&iomuxc_ccm_clko4_gpio_io_gpio4_io3>,
-		<&iomuxc_dap_tdi_gpio_io_gpio4_io4>,
-		<&iomuxc_dap_tms_swdio_gpio_io_gpio4_io5>,
-		<&iomuxc_dap_tclk_swclk_gpio_io_gpio4_io6>,
-		<&iomuxc_dap_tdo_traceswo_gpio_io_gpio4_io7>,
-		<&iomuxc_sd1_clk_gpio_io_gpio4_io8>,
-		<&iomuxc_sd1_cmd_gpio_io_gpio4_io9>,
-		<&iomuxc_sd1_data0_gpio_io_gpio4_io10>,
-		<&iomuxc_sd1_data1_gpio_io_gpio4_io11>,
-		<&iomuxc_sd1_data2_gpio_io_gpio4_io12>,
-		<&iomuxc_sd1_data3_gpio_io_gpio4_io13>,
-		<&iomuxc_sd1_data4_gpio_io_gpio4_io14>,
-		<&iomuxc_sd1_data5_gpio_io_gpio4_io15>,
-		<&iomuxc_sd1_data6_gpio_io_gpio4_io16>,
-		<&iomuxc_sd1_data7_gpio_io_gpio4_io17>,
-		<&iomuxc_sd1_strobe_gpio_io_gpio4_io18>,
-		<&iomuxc_sd2_vselect_gpio_io_gpio4_io19>,
-		<&iomuxc_sd2_cd_b_gpio_io_gpio4_io20>,
-		<&iomuxc_sd2_clk_gpio_io_gpio4_io21>,
-		<&iomuxc_sd2_cmd_gpio_io_gpio4_io22>,
-		<&iomuxc_sd2_data0_gpio_io_gpio4_io23>,
-		<&iomuxc_sd2_data1_gpio_io_gpio4_io24>,
-		<&iomuxc_sd2_data2_gpio_io_gpio4_io25>,
-		<&iomuxc_sd2_data3_gpio_io_gpio4_io26>,
-		<&iomuxc_sd2_reset_b_gpio_io_gpio4_io27>,
-		<&iomuxc_sd2_gpio0_gpio_io_gpio4_io28>,
-		<&iomuxc_sd2_gpio1_gpio_io_gpio4_io29>,
-		<&iomuxc_sd2_gpio2_gpio_io_gpio4_io30>,
-		<&iomuxc_sd2_gpio3_gpio_io_gpio4_io31>;
+		 <&iomuxc_ccm_clko2_gpio_io_gpio4_io1>,
+		 <&iomuxc_ccm_clko3_gpio_io_gpio4_io2>,
+		 <&iomuxc_ccm_clko4_gpio_io_gpio4_io3>,
+		 <&iomuxc_dap_tdi_gpio_io_gpio4_io4>,
+		 <&iomuxc_dap_tms_swdio_gpio_io_gpio4_io5>,
+		 <&iomuxc_dap_tclk_swclk_gpio_io_gpio4_io6>,
+		 <&iomuxc_dap_tdo_traceswo_gpio_io_gpio4_io7>,
+		 <&iomuxc_sd1_clk_gpio_io_gpio4_io8>,
+		 <&iomuxc_sd1_cmd_gpio_io_gpio4_io9>,
+		 <&iomuxc_sd1_data0_gpio_io_gpio4_io10>,
+		 <&iomuxc_sd1_data1_gpio_io_gpio4_io11>,
+		 <&iomuxc_sd1_data2_gpio_io_gpio4_io12>,
+		 <&iomuxc_sd1_data3_gpio_io_gpio4_io13>,
+		 <&iomuxc_sd1_data4_gpio_io_gpio4_io14>,
+		 <&iomuxc_sd1_data5_gpio_io_gpio4_io15>,
+		 <&iomuxc_sd1_data6_gpio_io_gpio4_io16>,
+		 <&iomuxc_sd1_data7_gpio_io_gpio4_io17>,
+		 <&iomuxc_sd1_strobe_gpio_io_gpio4_io18>,
+		 <&iomuxc_sd2_vselect_gpio_io_gpio4_io19>,
+		 <&iomuxc_sd2_cd_b_gpio_io_gpio4_io20>,
+		 <&iomuxc_sd2_clk_gpio_io_gpio4_io21>,
+		 <&iomuxc_sd2_cmd_gpio_io_gpio4_io22>,
+		 <&iomuxc_sd2_data0_gpio_io_gpio4_io23>,
+		 <&iomuxc_sd2_data1_gpio_io_gpio4_io24>,
+		 <&iomuxc_sd2_data2_gpio_io_gpio4_io25>,
+		 <&iomuxc_sd2_data3_gpio_io_gpio4_io26>,
+		 <&iomuxc_sd2_reset_b_gpio_io_gpio4_io27>,
+		 <&iomuxc_sd2_gpio0_gpio_io_gpio4_io28>,
+		 <&iomuxc_sd2_gpio1_gpio_io_gpio4_io29>,
+		 <&iomuxc_sd2_gpio2_gpio_io_gpio4_io30>,
+		 <&iomuxc_sd2_gpio3_gpio_io_gpio4_io31>;
 };
 
-&gpio5{
+&gpio5 {
 	pinmux = <&iomuxc_eth0_txd0_gpio_io_gpio5_io0>,
-		<&iomuxc_eth0_txd1_gpio_io_gpio5_io1>,
-		<&iomuxc_eth0_tx_en_gpio_io_gpio5_io2>,
-		<&iomuxc_eth0_tx_clk_gpio_io_gpio5_io3>,
-		<&iomuxc_eth0_rxd0_gpio_io_gpio5_io4>,
-		<&iomuxc_eth0_rxd1_gpio_io_gpio5_io5>,
-		<&iomuxc_eth0_rx_dv_gpio_io_gpio5_io6>,
-		<&iomuxc_eth0_txd2_gpio_io_gpio5_io7>,
-		<&iomuxc_eth0_txd3_gpio_io_gpio5_io8>,
-		<&iomuxc_eth0_rxd2_gpio_io_gpio5_io9>,
-		<&iomuxc_eth0_rxd3_gpio_io_gpio5_io10>,
-		<&iomuxc_eth0_rx_clk_gpio_io_gpio5_io11>,
-		<&iomuxc_eth0_rx_er_gpio_io_gpio5_io12>,
-		<&iomuxc_eth0_tx_er_gpio_io_gpio5_io13>,
-		<&iomuxc_eth0_crs_gpio_io_gpio5_io14>,
-		<&iomuxc_eth0_col_gpio_io_gpio5_io15>,
-		<&iomuxc_eth1_txd0_gpio_io_gpio5_io16>,
-		<&iomuxc_eth1_txd1_gpio_io_gpio5_io17>,
-		<&iomuxc_eth1_tx_en_gpio_io_gpio5_io18>,
-		<&iomuxc_eth1_tx_clk_gpio_io_gpio5_io19>,
-		<&iomuxc_eth1_rxd0_gpio_io_gpio5_io20>,
-		<&iomuxc_eth1_rxd1_gpio_io_gpio5_io21>,
-		<&iomuxc_eth1_rx_dv_gpio_io_gpio5_io22>,
-		<&iomuxc_eth1_txd2_gpio_io_gpio5_io23>,
-		<&iomuxc_eth1_txd3_gpio_io_gpio5_io24>,
-		<&iomuxc_eth1_rxd2_gpio_io_gpio5_io25>,
-		<&iomuxc_eth1_rxd3_gpio_io_gpio5_io26>,
-		<&iomuxc_eth1_rx_clk_gpio_io_gpio5_io27>,
-		<&iomuxc_eth1_rx_er_gpio_io_gpio5_io28>,
-		<&iomuxc_eth1_tx_er_gpio_io_gpio5_io29>,
-		<&iomuxc_eth1_crs_gpio_io_gpio5_io30>,
-		<&iomuxc_eth1_col_gpio_io_gpio5_io31>;
+		 <&iomuxc_eth0_txd1_gpio_io_gpio5_io1>,
+		 <&iomuxc_eth0_tx_en_gpio_io_gpio5_io2>,
+		 <&iomuxc_eth0_tx_clk_gpio_io_gpio5_io3>,
+		 <&iomuxc_eth0_rxd0_gpio_io_gpio5_io4>,
+		 <&iomuxc_eth0_rxd1_gpio_io_gpio5_io5>,
+		 <&iomuxc_eth0_rx_dv_gpio_io_gpio5_io6>,
+		 <&iomuxc_eth0_txd2_gpio_io_gpio5_io7>,
+		 <&iomuxc_eth0_txd3_gpio_io_gpio5_io8>,
+		 <&iomuxc_eth0_rxd2_gpio_io_gpio5_io9>,
+		 <&iomuxc_eth0_rxd3_gpio_io_gpio5_io10>,
+		 <&iomuxc_eth0_rx_clk_gpio_io_gpio5_io11>,
+		 <&iomuxc_eth0_rx_er_gpio_io_gpio5_io12>,
+		 <&iomuxc_eth0_tx_er_gpio_io_gpio5_io13>,
+		 <&iomuxc_eth0_crs_gpio_io_gpio5_io14>,
+		 <&iomuxc_eth0_col_gpio_io_gpio5_io15>,
+		 <&iomuxc_eth1_txd0_gpio_io_gpio5_io16>,
+		 <&iomuxc_eth1_txd1_gpio_io_gpio5_io17>,
+		 <&iomuxc_eth1_tx_en_gpio_io_gpio5_io18>,
+		 <&iomuxc_eth1_tx_clk_gpio_io_gpio5_io19>,
+		 <&iomuxc_eth1_rxd0_gpio_io_gpio5_io20>,
+		 <&iomuxc_eth1_rxd1_gpio_io_gpio5_io21>,
+		 <&iomuxc_eth1_rx_dv_gpio_io_gpio5_io22>,
+		 <&iomuxc_eth1_txd2_gpio_io_gpio5_io23>,
+		 <&iomuxc_eth1_txd3_gpio_io_gpio5_io24>,
+		 <&iomuxc_eth1_rxd2_gpio_io_gpio5_io25>,
+		 <&iomuxc_eth1_rxd3_gpio_io_gpio5_io26>,
+		 <&iomuxc_eth1_rx_clk_gpio_io_gpio5_io27>,
+		 <&iomuxc_eth1_rx_er_gpio_io_gpio5_io28>,
+		 <&iomuxc_eth1_tx_er_gpio_io_gpio5_io29>,
+		 <&iomuxc_eth1_crs_gpio_io_gpio5_io30>,
+		 <&iomuxc_eth1_col_gpio_io_gpio5_io31>;
 };
 
-&gpio6{
+&gpio6 {
 	pinmux = <&iomuxc_eth2_mdc_gpio1_gpio_io_gpio6_io0>,
-		<&iomuxc_eth2_mdio_gpio2_gpio_io_gpio6_io1>,
-		<&iomuxc_eth2_txd3_gpio_io_gpio6_io2>,
-		<&iomuxc_eth2_txd2_gpio_io_gpio6_io3>,
-		<&iomuxc_eth2_txd1_gpio_io_gpio6_io4>,
-		<&iomuxc_eth2_txd0_gpio_io_gpio6_io5>,
-		<&iomuxc_eth2_tx_ctl_gpio_io_gpio6_io6>,
-		<&iomuxc_eth2_tx_clk_gpio_io_gpio6_io7>,
-		<&iomuxc_eth2_rx_ctl_gpio_io_gpio6_io8>,
-		<&iomuxc_eth2_rx_clk_gpio_io_gpio6_io9>,
-		<&iomuxc_eth2_rxd0_gpio_io_gpio6_io10>,
-		<&iomuxc_eth2_rxd1_gpio_io_gpio6_io11>,
-		<&iomuxc_eth2_rxd2_gpio_io_gpio6_io12>,
-		<&iomuxc_eth2_rxd3_gpio_io_gpio6_io13>,
-		<&iomuxc_eth3_mdc_gpio1_gpio_io_gpio6_io14>,
-		<&iomuxc_eth3_mdio_gpio2_gpio_io_gpio6_io15>,
-		<&iomuxc_eth3_txd3_gpio_io_gpio6_io16>,
-		<&iomuxc_eth3_txd2_gpio_io_gpio6_io17>,
-		<&iomuxc_eth3_txd1_gpio_io_gpio6_io18>,
-		<&iomuxc_eth3_txd0_gpio_io_gpio6_io19>,
-		<&iomuxc_eth3_tx_ctl_gpio_io_gpio6_io20>,
-		<&iomuxc_eth3_tx_clk_gpio_io_gpio6_io21>,
-		<&iomuxc_eth3_rx_ctl_gpio_io_gpio6_io22>,
-		<&iomuxc_eth3_rx_clk_gpio_io_gpio6_io23>,
-		<&iomuxc_eth3_rxd0_gpio_io_gpio6_io24>,
-		<&iomuxc_eth3_rxd1_gpio_io_gpio6_io25>,
-		<&iomuxc_eth3_rxd2_gpio_io_gpio6_io26>,
-		<&iomuxc_eth3_rxd3_gpio_io_gpio6_io27>,
-		<&iomuxc_eth4_mdc_gpio1_gpio_io_gpio6_io28>,
-		<&iomuxc_eth4_mdio_gpio2_gpio_io_gpio6_io29>,
-		<&iomuxc_eth4_tx_clk_gpio_io_gpio6_io30>,
-		<&iomuxc_eth4_tx_ctl_gpio_io_gpio6_io31>;
+		 <&iomuxc_eth2_mdio_gpio2_gpio_io_gpio6_io1>,
+		 <&iomuxc_eth2_txd3_gpio_io_gpio6_io2>,
+		 <&iomuxc_eth2_txd2_gpio_io_gpio6_io3>,
+		 <&iomuxc_eth2_txd1_gpio_io_gpio6_io4>,
+		 <&iomuxc_eth2_txd0_gpio_io_gpio6_io5>,
+		 <&iomuxc_eth2_tx_ctl_gpio_io_gpio6_io6>,
+		 <&iomuxc_eth2_tx_clk_gpio_io_gpio6_io7>,
+		 <&iomuxc_eth2_rx_ctl_gpio_io_gpio6_io8>,
+		 <&iomuxc_eth2_rx_clk_gpio_io_gpio6_io9>,
+		 <&iomuxc_eth2_rxd0_gpio_io_gpio6_io10>,
+		 <&iomuxc_eth2_rxd1_gpio_io_gpio6_io11>,
+		 <&iomuxc_eth2_rxd2_gpio_io_gpio6_io12>,
+		 <&iomuxc_eth2_rxd3_gpio_io_gpio6_io13>,
+		 <&iomuxc_eth3_mdc_gpio1_gpio_io_gpio6_io14>,
+		 <&iomuxc_eth3_mdio_gpio2_gpio_io_gpio6_io15>,
+		 <&iomuxc_eth3_txd3_gpio_io_gpio6_io16>,
+		 <&iomuxc_eth3_txd2_gpio_io_gpio6_io17>,
+		 <&iomuxc_eth3_txd1_gpio_io_gpio6_io18>,
+		 <&iomuxc_eth3_txd0_gpio_io_gpio6_io19>,
+		 <&iomuxc_eth3_tx_ctl_gpio_io_gpio6_io20>,
+		 <&iomuxc_eth3_tx_clk_gpio_io_gpio6_io21>,
+		 <&iomuxc_eth3_rx_ctl_gpio_io_gpio6_io22>,
+		 <&iomuxc_eth3_rx_clk_gpio_io_gpio6_io23>,
+		 <&iomuxc_eth3_rxd0_gpio_io_gpio6_io24>,
+		 <&iomuxc_eth3_rxd1_gpio_io_gpio6_io25>,
+		 <&iomuxc_eth3_rxd2_gpio_io_gpio6_io26>,
+		 <&iomuxc_eth3_rxd3_gpio_io_gpio6_io27>,
+		 <&iomuxc_eth4_mdc_gpio1_gpio_io_gpio6_io28>,
+		 <&iomuxc_eth4_mdio_gpio2_gpio_io_gpio6_io29>,
+		 <&iomuxc_eth4_tx_clk_gpio_io_gpio6_io30>,
+		 <&iomuxc_eth4_tx_ctl_gpio_io_gpio6_io31>;
 };
 
-&gpio7{
+&gpio7 {
 	pinmux = <&iomuxc_eth4_txd0_gpio_io_gpio7_io0>,
-		<&iomuxc_eth4_txd1_gpio_io_gpio7_io1>,
-		<&iomuxc_eth4_txd2_gpio_io_gpio7_io2>,
-		<&iomuxc_eth4_txd3_gpio_io_gpio7_io3>,
-		<&iomuxc_eth4_rxd0_gpio_io_gpio7_io4>,
-		<&iomuxc_eth4_rxd1_gpio_io_gpio7_io5>,
-		<&iomuxc_eth4_rxd2_gpio_io_gpio7_io6>,
-		<&iomuxc_eth4_rxd3_gpio_io_gpio7_io7>,
-		<&iomuxc_eth4_rx_ctl_gpio_io_gpio7_io8>,
-		<&iomuxc_eth4_rx_clk_gpio_io_gpio7_io9>,
-		<&null_pinmux>,
-		<&null_pinmux>,
-		<&null_pinmux>,
-		<&null_pinmux>,
-		<&null_pinmux>,
-		<&null_pinmux>,
-		<&iomuxc_xspi1_data0_gpio_io_gpio7_io16>,
-		<&iomuxc_xspi1_data1_gpio_io_gpio7_io17>,
-		<&iomuxc_xspi1_data2_gpio_io_gpio7_io18>,
-		<&iomuxc_xspi1_data3_gpio_io_gpio7_io19>,
-		<&iomuxc_xspi1_data4_gpio_io_gpio7_io20>,
-		<&iomuxc_xspi1_data5_gpio_io_gpio7_io21>,
-		<&iomuxc_xspi1_data6_gpio_io_gpio7_io22>,
-		<&iomuxc_xspi1_data7_gpio_io_gpio7_io23>,
-		<&iomuxc_xspi1_dqs_gpio_io_gpio7_io24>,
-		<&iomuxc_xspi1_sclk_gpio_io_gpio7_io25>,
-		<&iomuxc_xspi1_ss0_b_gpio_io_gpio7_io26>,
-		<&iomuxc_xspi1_ss1_b_gpio_io_gpio7_io27>;
+		 <&iomuxc_eth4_txd1_gpio_io_gpio7_io1>,
+		 <&iomuxc_eth4_txd2_gpio_io_gpio7_io2>,
+		 <&iomuxc_eth4_txd3_gpio_io_gpio7_io3>,
+		 <&iomuxc_eth4_rxd0_gpio_io_gpio7_io4>,
+		 <&iomuxc_eth4_rxd1_gpio_io_gpio7_io5>,
+		 <&iomuxc_eth4_rxd2_gpio_io_gpio7_io6>,
+		 <&iomuxc_eth4_rxd3_gpio_io_gpio7_io7>,
+		 <&iomuxc_eth4_rx_ctl_gpio_io_gpio7_io8>,
+		 <&iomuxc_eth4_rx_clk_gpio_io_gpio7_io9>,
+		 <&null_pinmux>,
+		 <&null_pinmux>,
+		 <&null_pinmux>,
+		 <&null_pinmux>,
+		 <&null_pinmux>,
+		 <&null_pinmux>,
+		 <&iomuxc_xspi1_data0_gpio_io_gpio7_io16>,
+		 <&iomuxc_xspi1_data1_gpio_io_gpio7_io17>,
+		 <&iomuxc_xspi1_data2_gpio_io_gpio7_io18>,
+		 <&iomuxc_xspi1_data3_gpio_io_gpio7_io19>,
+		 <&iomuxc_xspi1_data4_gpio_io_gpio7_io20>,
+		 <&iomuxc_xspi1_data5_gpio_io_gpio7_io21>,
+		 <&iomuxc_xspi1_data6_gpio_io_gpio7_io22>,
+		 <&iomuxc_xspi1_data7_gpio_io_gpio7_io23>,
+		 <&iomuxc_xspi1_dqs_gpio_io_gpio7_io24>,
+		 <&iomuxc_xspi1_sclk_gpio_io_gpio7_io25>,
+		 <&iomuxc_xspi1_ss0_b_gpio_io_gpio7_io26>,
+		 <&iomuxc_xspi1_ss1_b_gpio_io_gpio7_io27>;
 };

--- a/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m33
+++ b/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m33
@@ -17,8 +17,12 @@ config MCUX_CORE_SUFFIX
 config NUM_IRQS
 	default 405
 
+config CORTEX_M_SYSTICK
+	default n if MCUX_GPT_TIMER
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
+	default 32768 if MCUX_GPT_TIMER
 
 choice CACHE_TYPE
 	default EXTERNAL_CACHE
@@ -34,6 +38,12 @@ if PM
 
 config IDLE_STACK_SIZE
 	default 640
+
+config MCUX_GPT_TIMER
+	default y
+
+config SYS_CLOCK_TICKS_PER_SEC
+	default 1024
 
 endif
 

--- a/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m7_0
+++ b/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m7_0
@@ -17,8 +17,12 @@ config MCUX_CORE_SUFFIX
 config NUM_IRQS
 	default 238
 
+config CORTEX_M_SYSTICK
+	default n if MCUX_GPT_TIMER
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
+	default 32768 if MCUX_GPT_TIMER
 
 config ETH_NXP_IMX_MSGINTR
 	default 2
@@ -36,6 +40,12 @@ config PM_S2RAM
 
 config HAS_PM_S2RAM_CUSTOM_MARKING
 	default y
+
+config MCUX_GPT_TIMER
+	default y
+
+config SYS_CLOCK_TICKS_PER_SEC
+	default 1024
 
 endif
 

--- a/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m7_1
+++ b/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m7_1
@@ -17,8 +17,12 @@ config MCUX_CORE_SUFFIX
 config NUM_IRQS
 	default 238
 
+config CORTEX_M_SYSTICK
+	default n if MCUX_GPT_TIMER
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
+	default 32768 if MCUX_GPT_TIMER
 
 config ETH_NXP_IMX_MSGINTR
 	default 2
@@ -36,6 +40,12 @@ config PM_S2RAM
 
 config HAS_PM_S2RAM_CUSTOM_MARKING
 	default y
+
+config MCUX_GPT_TIMER
+	default y
+
+config SYS_CLOCK_TICKS_PER_SEC
+	default 1024
 
 endif
 


### PR DESCRIPTION
Added gpt node for imx943 Mcore, use GPT1 for M33, GPT2 for M70, GPT3 for M71, aimed to support system suspend by it