### PR TITLE
SCMI expand nxp cpu api

### DIFF
--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -114,3 +114,35 @@ int scmi_cpu_set_irq_mask(struct scmi_cpu_irq_mask_config *cfg)
 
 	return scmi_status_to_errno(status);
 }
+
+int scmi_cpu_reset_vector(struct scmi_cpu_vector_config *cfg)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_CPU_DOMAIN);
+	struct scmi_message msg, reply;
+	int status, ret;
+
+	/* sanity checks */
+	if (!proto || !cfg) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_CPU_DOMAIN) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_CPU_DOMAIN_MSG_CPU_RESET_VECTOR_SET, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(*cfg);
+	msg.content = cfg;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(status);
+	reply.content = &status;
+
+	ret = scmi_send_message(proto, &msg, &reply, true);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return scmi_status_to_errno(status);
+}

--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -10,6 +10,11 @@
 
 DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, nxp_scmi_cpu), NULL);
 
+struct scmi_cpu_info_get_reply {
+	int32_t status;
+	struct scmi_cpu_info data;
+};
+
 int scmi_cpu_sleep_mode_set(struct scmi_cpu_sleep_mode_config *cfg)
 {
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_CPU_DOMAIN);
@@ -145,4 +150,39 @@ int scmi_cpu_reset_vector(struct scmi_cpu_vector_config *cfg)
 	}
 
 	return scmi_status_to_errno(status);
+}
+
+int scmi_cpu_info_get(uint32_t cpu_id, struct scmi_cpu_info *cfg)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_CPU_DOMAIN);
+	struct scmi_message msg, reply;
+	struct scmi_cpu_info_get_reply reply_buffer;
+	int ret;
+
+	/* sanity checks */
+	if (!proto || !cfg) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_CPU_DOMAIN) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_CPU_DOMAIN_MSG_CPU_INFO_GET, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(uint32_t);
+	msg.content = &cpu_id;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(reply_buffer);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply, true);
+	if (ret < 0) {
+		return ret;
+	}
+
+	*cfg = reply_buffer.data;
+
+	return scmi_status_to_errno(reply_buffer.status);
 }

--- a/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
+++ b/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
@@ -25,6 +25,15 @@
 
 #define SCMI_CPU_IRQ_WAKE_NUM	22U
 
+/** CPU vector flag: Boot address (cold boot/reset) */
+#define SCMI_CPU_VEC_FLAGS_BOOT    BIT(29)
+
+/** CPU vector flag: Start address (warm start) */
+#define SCMI_CPU_VEC_FLAGS_START   BIT(30)
+
+/** CPU vector flag: Resume address (exit from suspend) */
+#define SCMI_CPU_VEC_FLAGS_RESUME  BIT(31)
+
 /**
  * @struct scmi_cpu_sleep_mode_config
  *
@@ -64,6 +73,18 @@ struct scmi_cpu_irq_mask_config {
 	uint32_t mask_idx;
 	uint32_t num_mask;
 	uint32_t mask[SCMI_CPU_IRQ_WAKE_NUM];
+};
+
+/**
+ * @struct scmi_cpu_vector_config
+ *
+ * @brief Describes the parameters for the CPU_RESET_VECTOR_SET command
+ */
+struct scmi_cpu_vector_config {
+	uint32_t cpu_id;
+	uint32_t flags;
+	uint32_t vector_low;
+	uint32_t vector_high;
 };
 
 /**
@@ -117,4 +138,14 @@ int scmi_cpu_pd_lpm_set(struct scmi_cpu_pd_lpm_config *cfg);
  * @retval negative errno if failure
  */
 int scmi_cpu_set_irq_mask(struct scmi_cpu_irq_mask_config *cfg);
+
+/**
+ * @brief Send the CPU_RESET_VECTOR_SET command and get its reply
+ *
+ * @param cfg pointer to structure containing configuration to be set
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_cpu_reset_vector(struct scmi_cpu_vector_config *cfg);
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CPU_H_ */

--- a/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
+++ b/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
@@ -88,6 +88,18 @@ struct scmi_cpu_vector_config {
 };
 
 /**
+ * @struct scmi_cpu_info
+ *
+ * @brief Describes the parameters for the CPU_INFO_GET command
+ */
+struct scmi_cpu_info {
+	uint32_t run_mode;
+	uint32_t sleep_mode;
+	uint32_t vector_low;
+	uint32_t vector_high;
+};
+
+/**
  * @brief CPU domain protocol command message IDs
  */
 enum scmi_cpu_domain_message {
@@ -148,4 +160,15 @@ int scmi_cpu_set_irq_mask(struct scmi_cpu_irq_mask_config *cfg);
  * @retval negative errno if failure
  */
 int scmi_cpu_reset_vector(struct scmi_cpu_vector_config *cfg);
+
+/**
+ * @brief Send the CPU_INFO_GET command and get its reply
+ *
+ * @param cpu_id CPU ID to query (input)
+ * @param cfg pointer to structure to receive CPU information (output)
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_cpu_info_get(uint32_t cpu_id, struct scmi_cpu_info *cfg);
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CPU_H_ */


### PR DESCRIPTION
Added two nxp cpu driver api:
scmi_cpu_reset_vector to reset cpu vector table address
scmi_cpu_info_get to get cpu running mode, sleep mode and vector table address