### PR TITLE
modules: wiseconnect: kernel sleeptimer bug fix siwx91x

### DIFF
--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -216,6 +216,13 @@ if(CONFIG_SILABS_SISDK_SLEEPTIMER)
     SL_CODE_COMPONENT_SLEEPTIMER=sleeptimer
     SL_CODE_COMPONENT_HAL_SYSRTC=hal_sysrtc
   )
+  zephyr_code_relocate(FILES
+    ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/service/sleeptimer/src/sl_sleeptimer_hal_si91x_sysrtc.c
+    ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_sysrtc.c
+    ${SISDK_DIR}/platform/service/sleeptimer/src/sl_sleeptimer.c
+    ${ZEPHYR_BASE}/arch/arm/core/cortex_m/isr_wrapper.c
+    LOCATION RAM
+  )
 endif() # CONFIG_SILABS_SISDK_SLEEPTIMER
 
 if(CONFIG_SOC_SIWX91X_PM_BACKEND_PMGR)
@@ -246,9 +253,6 @@ if(CONFIG_SOC_SIWX91X_PM_BACKEND_PMGR)
   ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/core/chip/src/rsi_deepsleep_soc.c
   ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/service/power_manager/src/sl_si91x_power_manager.c
   ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/service/power_manager/src/sli_si91x_power_manager.c
-  ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/service/sleeptimer/src/sl_sleeptimer_hal_si91x_sysrtc.c
-  ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_sysrtc.c
-  ${SISDK_DIR}/platform/service/sleeptimer/src/sl_sleeptimer.c
   ${WISECONNECT_DIR}/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_ram.c
   ${WISECONNECT_DIR}/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_rom.c
   ${ZEPHYR_BASE}/drivers/gpio/*.c

--- a/modules/hal_silabs/wiseconnect/Kconfig
+++ b/modules/hal_silabs/wiseconnect/Kconfig
@@ -6,6 +6,8 @@ menu "WiSeConnect configuration"
 
 config SILABS_SISDK_SLEEPTIMER
 	bool "Sleeptimer service"
+	select SRAM_VECTOR_TABLE
+	select CODE_DATA_RELOCATION_SRAM
 	help
 	  Set if the Sleeptimer HAL module is used.
 

--- a/soc/silabs/silabs_siwx91x/Kconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig
@@ -32,8 +32,6 @@ config SOC_SIWX91X_PM_BACKEND_PMGR
 	bool
 	select SILABS_SIWX91X_NWP
 	select SILABS_SLEEPTIMER_TIMER
-	select SRAM_VECTOR_TABLE
-	select CODE_DATA_RELOCATION_SRAM
 	default y if PM
 	help
 	  Implement PM using sl_power_manager service from Gecko SDK


### PR DESCRIPTION
The fix resolves the drift test failure as part of kernel timer behaviour and timer api test suite.
Have moved the sleeptimer-related source files to RAM using zephyr_code_relocate when CONFIG_SILABS_SISDK_SLEEPTIMER is enabled, and removed duplicate listing from PMGR backend. Updated Kconfig to select SRAM_VECTOR_TABLE and CODE_DATA_RELOCATION_SRAM for the sleeptimer service.