### PR TITLE
soc: nxp: mcx: mcxw7xx: Update power management in case of NBU is used.

### DIFF
--- a/soc/nxp/mcx/mcxw/mcxw7xx/power.c
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/power.c
@@ -69,11 +69,13 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 	case PM_STATE_SUSPEND_TO_IDLE:
 		cmc_power_domain_config_t config;
 
+#if CONFIG_NXP_NBU == 0
 		/* Set NBU into Sleep Mode */
 		RFMC->RF2P4GHZ_CTRL = (RFMC->RF2P4GHZ_CTRL &
 				       (~RFMC_RF2P4GHZ_CTRL_LP_MODE_MASK)) |
 				       RFMC_RF2P4GHZ_CTRL_LP_MODE(0x1);
 		RFMC->RF2P4GHZ_CTRL |= RFMC_RF2P4GHZ_CTRL_LP_ENTER_MASK;
+#endif /* CONFIG_NXP_NBU == 0 */
 
 		/* Set MAIN_CORE and MAIN_WAKE power domain into sleep mode. */
 		config.clock_mode  = kCMC_GateAllSystemClocksEnterLowPowerMode;
@@ -86,10 +88,12 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		/* Enable CORE VDD Voltage scaling. */
 		SPC_EnableLowPowerModeCoreVDDInternalVoltageScaling(MCXW7_SPC_ADDR, true);
 
+#if CONFIG_NXP_NBU == 0
 		/* Set NBU into Deep Sleep Mode */
 		RFMC->RF2P4GHZ_CTRL = (RFMC->RF2P4GHZ_CTRL & (~RFMC_RF2P4GHZ_CTRL_LP_MODE_MASK)) |
 				       RFMC_RF2P4GHZ_CTRL_LP_MODE(0x3);
 		RFMC->RF2P4GHZ_CTRL |= RFMC_RF2P4GHZ_CTRL_LP_ENTER_MASK;
+#endif /* CONFIG_NXP_NBU == 0 */
 
 		/* Set MAIN_CORE and MAIN_WAKE power domain into Deep Sleep Mode. */
 		config.clock_mode  = kCMC_GateAllSystemClocksEnterLowPowerMode;


### PR DESCRIPTION
Added conditional compilication for 'power_state_set' function. The changes ensure that mode of NBU domain is manually set only when the NBU is not used. If NBU is enabled, the mode of NBU domain is auto updated by software run on NBU.

Change include:
- Conditional checks around the NBU mode in sleep and deep sleep mode.