### PR TITLE
nvmem: Add flash support

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -102,6 +102,13 @@ New APIs and options
   * :dtcompatible:`jedec,mspi-nor` now allows MSPI configuration of read, write and
     control commands separately via devicetree.
 
+* NVMEM
+
+  * Flash device support
+
+    * :kconfig:option:`CONFIG_NVMEM_FLASH`
+    * :kconfig:option:`CONFIG_NVMEM_FLASH_WRITE`
+
 * Settings
 
    * :kconfig:option:`CONFIG_SETTINGS_SAVE_SINGLE_SUBTREE_WITHOUT_MODIFICATION`

--- a/subsys/nvmem/Kconfig
+++ b/subsys/nvmem/Kconfig
@@ -11,6 +11,21 @@ config NVMEM_EEPROM
 	default y
 	depends on EEPROM
 
+config NVMEM_FLASH
+	bool "NVMEM (read) support for flash devices"
+	default y
+	depends on FLASH
+
+config NVMEM_FLASH_WRITE
+	bool "NVMEM write support for flash devices"
+	depends on NVMEM_FLASH
+	help
+	  Allow writing to NVMEM cells in flash devices.
+
+	  An explicit option is added for this as it's non-trivial
+	  to write to flash devices requiring out-of-bands erase or
+	  taking write-block sizes into account.
+
 module = NVMEM
 module-str = nvmem
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/nvmem/nvmem.c
+++ b/subsys/nvmem/nvmem.c
@@ -6,6 +6,7 @@
 
 #include <errno.h>
 #include <zephyr/drivers/eeprom.h>
+#include <zephyr/drivers/flash.h>
 #include <zephyr/nvmem.h>
 #include <zephyr/sys/__assert.h>
 
@@ -19,6 +20,10 @@ int nvmem_cell_read(const struct nvmem_cell *cell, void *buf, off_t off, size_t 
 
 	if (IS_ENABLED(CONFIG_NVMEM_EEPROM) && DEVICE_API_IS(eeprom, cell->dev)) {
 		return eeprom_read(cell->dev, cell->offset + off, buf, len);
+	}
+
+	if (IS_ENABLED(CONFIG_NVMEM_FLASH) && DEVICE_API_IS(flash, cell->dev)) {
+		return flash_read(cell->dev, cell->offset + off, buf, len);
 	}
 
 	return -ENXIO;
@@ -38,6 +43,10 @@ int nvmem_cell_write(const struct nvmem_cell *cell, const void *buf, off_t off, 
 
 	if (IS_ENABLED(CONFIG_NVMEM_EEPROM) && DEVICE_API_IS(eeprom, cell->dev)) {
 		return eeprom_write(cell->dev, cell->offset + off, buf, len);
+	}
+
+	if (IS_ENABLED(CONFIG_NVMEM_FLASH_WRITE) && DEVICE_API_IS(flash, cell->dev)) {
+		return flash_write(cell->dev, cell->offset + off, buf, len);
 	}
 
 	return -ENXIO;

--- a/tests/subsys/nvmem/api/CMakeLists.txt
+++ b/tests/subsys/nvmem/api/CMakeLists.txt
@@ -3,6 +3,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(nvmem_eeprom)
+project(nvmem_api)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/nvmem/api/flash.overlay
+++ b/tests/subsys/nvmem/api/flash.overlay
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2025, Basalte bv
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		nvmem0 = &flashcontroller0;
+	};
+
+	test_consumer0: test-consumer0 {
+		compatible = "vnd,nvmem-consumer";
+		nvmem-cells = <&cell0>, <&cell10>;
+		nvmem-cell-names = "cell0", "cell10";
+	};
+};
+
+&flashcontroller0 {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cell0: cell@0 {
+			reg = <0x0 0x10>;
+			#nvmem-cell-cells = <0>;
+		};
+
+		cell10: cell@10 {
+			reg = <0x10 0x10>;
+			read-only;
+			#nvmem-cell-cells = <0>;
+		};
+	};
+};

--- a/tests/subsys/nvmem/api/testcase.yaml
+++ b/tests/subsys/nvmem/api/testcase.yaml
@@ -11,3 +11,9 @@ tests:
       - CONFIG_EEPROM=y
     extra_dtc_overlay_files:
       - eeprom.overlay
+  nvmem.api.flash:
+    extra_configs:
+      - CONFIG_FLASH=y
+      - CONFIG_NVMEM_FLASH_WRITE=y
+    extra_dtc_overlay_files:
+      - flash.overlay


### PR DESCRIPTION
Allow flash devices to be accessed using the NVMEM API. Note that it simply uses the read/write API functions. Erasing should be handled by the application.