### PR TITLE
driver: pwm: pwm_silabs_siwx91x: fix pm actions when pm is enabled

### DIFF
--- a/drivers/pwm/pwm_silabs_siwx91x.c
+++ b/drivers/pwm/pwm_silabs_siwx91x.c
@@ -188,7 +188,12 @@ static int pwm_siwx91x_pm_action(const struct device *dev, enum pm_device_action
 	uint32_t pwm_frequency;
 	int ret;
 
-	if (action == PM_DEVICE_ACTION_RESUME) {
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		break;
+	case PM_DEVICE_ACTION_TURN_ON:
 		ret = clock_control_on(config->clock_dev, config->clock_subsys);
 		if (ret) {
 			return ret;
@@ -214,9 +219,10 @@ static int pwm_siwx91x_pm_action(const struct device *dev, enum pm_device_action
 		if (ret) {
 			return -EINVAL;
 		}
-	} else if (IS_ENABLED(CONFIG_PM_DEVICE) && (action == PM_DEVICE_ACTION_SUSPEND)) {
-		return 0;
-	} else {
+		break;
+	case PM_DEVICE_ACTION_TURN_OFF:
+		break;
+	default:
 		return -ENOTSUP;
 	}
 

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -361,6 +361,8 @@
 			clocks = <&clock0 SIWX91X_CLK_PWM>;
 			#pwm-cells = <2>;
 			silabs,ch-prescaler = <64 64 64 64>;
+			power-domains = <&siwx91x_soc_pd>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
This fix addresses the issue encountered when power management (pm) is enabled, as the PWM test suites utilize the GPIO driver, which now incorporates the latest power domain enhancements and requires CONFIG_POWER_DOMAIN to be enabled. Power domain functionality manages device power actions such as turning on and off.

Accordingly, the pm device support for the pwm_silabs_siwx91x driver has been updated to align with the recent power domain improvements