### PR TITLE
drivers: modem: use pm_device_driver_init() in modem_cellular.c

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -2133,7 +2133,6 @@ static DEVICE_API(cellular, modem_cellular_api) = {
 	.set_callback = modem_cellular_set_callback,
 };
 
-#ifdef CONFIG_PM_DEVICE
 static int modem_cellular_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	struct modem_cellular_data *data = (struct modem_cellular_data *)dev->data;
@@ -2157,7 +2156,6 @@ static int modem_cellular_pm_action(const struct device *dev, enum pm_device_act
 
 	return ret;
 }
-#endif /* CONFIG_PM_DEVICE */
 
 static void net_mgmt_event_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt_event,
 				   struct net_if *iface)
@@ -2311,13 +2309,7 @@ static int modem_cellular_init(const struct device *dev)
 
 	modem_cellular_init_apn(data);
 
-#ifndef CONFIG_PM_DEVICE
-	modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_RESUME);
-#else
-	pm_device_init_suspended(dev);
-#endif /* CONFIG_PM_DEVICE */
-
-	return 0;
+	return pm_device_driver_init(dev, modem_cellular_pm_action);
 }
 
 /*


### PR DESCRIPTION
Remove Device Runtime PM "hack" used for modem cellular driver initialization and use `pm_device_driver_init()` instead.

This is done based on the @bjarki-andreasen comment: https://github.com/zephyrproject-rtos/zephyr/pull/92096#discussion_r2163913663