### PR TITLE
MAINTAINERS: Clarify status fields

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -10,11 +10,12 @@
 #         One of the following:
 #
 #         * maintained:
-#             The area has a Maintainer (approved by the TSC) who
-#             looks after the area.
+#             The area maintainers and collaborators keep the area actively maintained.
 #
 #         * odd fixes:
-#            The area gets odd fixes and may have collaborators.
+#             The current area maintainers and collaborators do not have sufficient time to take
+#             care of it. You should expect longer time for reviews and bug handling.
+#             Consider volunteering to help in the area.
 #
 #         * obsolete:
 #             Old code. Something being marked obsolete generally means it has


### PR DESCRIPTION
Following the discussions in the process working group on 2025/10/08 & 2025/10/22.
Clarify the "status" key/field definition:
With the current definitions of maintained and odd-fixes we ended up equating these with having or not somebody listed in the "maintainers" key.
Let's instead change the definition to indicate how actively the area is maintained, and to encourage people to step up in areas where we lack bandwidth.