### PR TITLE
ipc: intel_adsp_host_ipc: clear tx_ack_pending on PM resume

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_intel_adsp_host_ipc.c
+++ b/subsys/ipc/ipc_service/backends/ipc_intel_adsp_host_ipc.c
@@ -434,6 +434,10 @@ static int ipc_pm_action(const struct device *dev, enum pm_device_action action)
 		if (devdata->resume_fn) {
 			ret = devdata->resume_fn(dev, devdata->resume_fn_args);
 		}
+		/* Clear tx_ack_pending to ensure driver is operational after resume.
+		 * Structure now contains function pointers, so memset() cannot be used.
+		 */
+		devdata->tx_ack_pending = false;
 		break;
 	default:
 		/* Return as default value when given PM action is not supported */


### PR DESCRIPTION
Fix IPC driver becoming non-operational after power management resume due to stale tx_ack_pending state from before suspend.

After the IPC service backend refactor (commit cf7e2e63c17a), the intel_adsp_ipc_data structure contains function pointers for suspend/resume handlers. This prevents using `memset` to clear the entire structure during initialization, which was previously done in intel_adsp_ipc_init.

Without clearing tx_ack_pending on resume, if the device enters D3 state while still waiting for an IPC acknowledgment (e.g., from a previous test iteration), the driver remains stuck in the waiting state after resume. This prevents sending any new IPC messages, including the FW_READY notification after D3 exit.

The fix explicitly clears tx_ack_pending during PM_DEVICE_ACTION_RESUME to ensure the driver starts in a clean operational state after resume, regardless of the state before suspend.

Fixes regression introduced in commit cf7e2e63c17a