### PR TITLE
tests: drivers: counter: maxim_ds3231: Add missing assert print param

### DIFF
--- a/tests/drivers/counter/maxim_ds3231_api/src/test_counter.c
+++ b/tests/drivers/counter/maxim_ds3231_api/src/test_counter.c
@@ -398,7 +398,7 @@ void test_multiple_alarms_instance(const struct device *dev)
 
 	err = counter_set_top_value(dev, &top_cfg);
 	zassert_equal(-ENOTSUP, err,
-		      "%s: Counter failed to set top value: %d", dev->name);
+		      "%s: Counter failed to set top value: %d", dev->name, err);
 
 	k_sleep(K_USEC(3 * (uint32_t)counter_ticks_to_us(dev, alarm_cfg.ticks)));
 


### PR DESCRIPTION
Add a missing assert print parameter.

Failing in main
https://github.com/zephyrproject-rtos/zephyr/actions/runs/18811754455/job/53673945420#step:14:406
Can be repro'ed with 
`cmake -GNinja -DBOARD=nrf52840dk/nrf52840 ../tests/drivers/counter/maxim_ds3231_api/ && ninja`

Fixes #97834