### PR TITLE
docs: security: vulnerabilities: Add CVE 2025 section title

### DIFF
--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -1838,6 +1838,9 @@ This has been fixed in main for v4.0.0
 - `PR 81370 fix for 3.7
   <https://github.com/zephyrproject-rtos/zephyr/pull/81370>`_
 
+CVE-2025
+========
+
 :cve:`2025-1673`
 ----------------
 


### PR DESCRIPTION
A section title for CVE reported in 2025 was missing.