### PR TITLE
include: zephyr: APIs doc: fix Doxygen \retval command usage

### DIFF
--- a/include/zephyr/bluetooth/addr.h
+++ b/include/zephyr/bluetooth/addr.h
@@ -84,8 +84,8 @@ static inline int bt_addr_cmp(const bt_addr_t *a, const bt_addr_t *b)
 
 /** @brief Determine equality of two Bluetooth device addresses.
  *
- *  @retval #true if the two addresses are equal
- *  @retval #false otherwise
+ *  @retval true if the two addresses are equal
+ *  @retval false otherwise
  */
 static inline bool bt_addr_eq(const bt_addr_t *a, const bt_addr_t *b)
 {
@@ -111,8 +111,8 @@ static inline int bt_addr_le_cmp(const bt_addr_le_t *a, const bt_addr_le_t *b)
  *  The Bluetooth LE addresses are equal if and only if both the types and
  *  the 48-bit addresses are numerically equal.
  *
- *  @retval #true if the two addresses are equal
- *  @retval #false otherwise
+ *  @retval true if the two addresses are equal
+ *  @retval false otherwise
  */
 static inline bool bt_addr_le_eq(const bt_addr_le_t *a, const bt_addr_le_t *b)
 {

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -176,7 +176,7 @@ int bt_hci_get_adv_sync_handle(const struct bt_le_per_adv_sync *sync, uint16_t *
  *
  * @param handle The periodic sync set handle
  *
- * @retval The corresponding periodic advertising sync set object on success,
+ * @return The corresponding periodic advertising sync set object on success,
  *         NULL if it does not exist.
  */
 struct bt_le_per_adv_sync *bt_hci_per_adv_sync_lookup_handle(uint16_t handle);

--- a/include/zephyr/canbus/isotp.h
+++ b/include/zephyr/canbus/isotp.h
@@ -275,7 +275,7 @@ void isotp_unbind(struct isotp_recv_ctx *rctx);
  * @param len     Size of the buffer.
  * @param timeout Timeout for incoming data.
  *
- * @retval Number of bytes copied on success
+ * @return Number of bytes copied on success
  * @retval ISOTP_RECV_TIMEOUT when "timeout" timed out
  * @retval ISOTP_N_* on error
  */
@@ -295,7 +295,7 @@ int isotp_recv(struct isotp_recv_ctx *rctx, uint8_t *data, size_t len, k_timeout
  * @param buffer  Pointer where the net_buf pointer is written to.
  * @param timeout Timeout for incoming data.
  *
- * @retval Remaining data length for this transfer if BS > 0, 0 for BS = 0
+ * @return Remaining data length for this transfer if BS > 0, 0 for BS = 0
  * @retval ISOTP_RECV_TIMEOUT when "timeout" timed out
  * @retval ISOTP_N_* on error
  */

--- a/include/zephyr/cpu_freq/cpu_freq.h
+++ b/include/zephyr/cpu_freq/cpu_freq.h
@@ -38,7 +38,7 @@ extern "C" {
  * @param state Pointer to performance state.
  *
  *
- * @retval 0 if request received successfully, -errno in case of failure.
+ * @return 0 if request received successfully, -errno in case of failure.
  */
 int cpu_freq_pstate_set(const struct pstate *state);
 

--- a/include/zephyr/cpu_freq/policy.h
+++ b/include/zephyr/cpu_freq/policy.h
@@ -39,7 +39,7 @@ extern "C" {
  *
  * @param pstate_out Pointer to the P-state struct where the next P-state is returned.
  *
- * @retval 0 in case of success, nonzero in case of failure.
+ * @return 0 in case of success, nonzero in case of failure.
  */
 int cpu_freq_policy_select_pstate(const struct pstate **pstate_out);
 

--- a/include/zephyr/debug/cpu_load.h
+++ b/include/zephyr/debug/cpu_load.h
@@ -36,8 +36,8 @@ void cpu_load_on_exit_idle(void);
  *
  * @param reset Reset the measurement after reading.
  *
- * @retval Positive number - CPU load in per mille.
- * @retval Negative number - error code.
+ * @retval >=0 Positive number - CPU load in per mille.
+ * @retval <0 Negative number - error code.
  */
 int cpu_load_get(bool reset);
 

--- a/include/zephyr/debug/mipi_stp_decoder.h
+++ b/include/zephyr/debug/mipi_stp_decoder.h
@@ -110,7 +110,7 @@ struct mipi_stp_decoder_config {
  * @param config	Configuration.
  *
  * @retval 0		On successful initialization.
- * @retval negative	On failure.
+ * @retval <0	On failure.
  */
 int mipi_stp_decoder_init(const struct mipi_stp_decoder_config *config);
 
@@ -122,7 +122,7 @@ int mipi_stp_decoder_init(const struct mipi_stp_decoder_config *config);
  * @param len		Data length.
  *
  * @retval 0		On successful decoding.
- * @retval negative	On failure.
+ * @retval <0	On failure.
  */
 int mipi_stp_decoder_decode(const uint8_t *data, size_t len);
 

--- a/include/zephyr/display/ssd16xx.h
+++ b/include/zephyr/display/ssd16xx.h
@@ -36,7 +36,7 @@ enum ssd16xx_ram {
  * @param desc Structure describing the buffer layout
  * @param buf Output buffer
  *
- * @retval 0 on success, negative errno on failure.
+ * @return 0 on success, negative errno on failure.
  */
 int ssd16xx_read_ram(const struct device *dev, enum ssd16xx_ram ram_type,
 		     const uint16_t x, const uint16_t y,

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -1309,7 +1309,7 @@ static inline int adc_sequence_init_dt(const struct adc_dt_spec *spec,
  *
  * @param spec ADC specification from devicetree
  *
- * @retval true if the ADC device is ready for use and false otherwise.
+ * @return true if the ADC device is ready for use and false otherwise.
  */
 static inline bool adc_is_ready_dt(const struct adc_dt_spec *spec)
 {

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1002,7 +1002,7 @@ static inline const struct can_timing *z_impl_can_get_timing_data_max(const stru
  * @param sample_pnt Sample point for the data phase in permille of the entire bit
  *                   time or 0 for automatic sample point location.
  *
- * @retval 0 or positive sample point error on success.
+ * @return 0 or positive sample point error on success.
  * @retval -EINVAL if the requested bitrate or sample point is out of range.
  * @retval -ENOTSUP if the requested bitrate is not supported.
  * @retval -EIO if @a can_get_core_clock() is not available.
@@ -1387,7 +1387,7 @@ static inline void z_impl_can_remove_rx_filter(const struct device *dev, int fil
  * @param ide Get the maximum standard (11-bit) CAN ID filters if false, or extended (29-bit) CAN ID
  *            filters if true.
  *
- * @retval Positive number of maximum concurrent filters.
+ * @retval >=0 number of maximum concurrent filters.
  * @retval -EIO General input/output error.
  * @retval -ENOSYS If this function is not implemented by the driver.
  */
@@ -1684,7 +1684,7 @@ static inline uint32_t z_impl_can_stats_get_rx_overruns(const struct device *dev
  *
  * @param dlc Data Length Code (DLC).
  *
- * @retval Number of bytes.
+ * @return Number of bytes.
  */
 static inline uint8_t can_dlc_to_bytes(uint8_t dlc)
 {
@@ -1699,7 +1699,7 @@ static inline uint8_t can_dlc_to_bytes(uint8_t dlc)
  *
  * @param num_bytes Number of bytes.
  *
- * @retval Data Length Code (DLC).
+ * @return Data Length Code (DLC).
  */
 static inline uint8_t can_bytes_to_dlc(uint8_t num_bytes)
 {

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -237,7 +237,7 @@ __subsystem struct cellular_driver_api {
  * @retval 0 if successful.
  * @retval -EINVAL if any provided cellular network configuration is invalid or unsupported.
  * @retval -ENOTSUP if API is not supported by cellular network device.
- * @retval Negative errno-code otherwise.
+ * @retval <0 Negative errno-code otherwise.
  */
 static inline int cellular_configure_networks(const struct device *dev,
 					      const struct cellular_network *networks, uint8_t size)
@@ -260,7 +260,7 @@ static inline int cellular_configure_networks(const struct device *dev,
  *
  * @retval 0 if successful.
  * @retval -ENOTSUP if API is not supported by cellular network device.
- * @retval Negative errno-code otherwise.
+ * @retval <0 Negative errno-code otherwise.
  */
 static inline int cellular_get_supported_networks(const struct device *dev,
 						  const struct cellular_network **networks,
@@ -285,7 +285,7 @@ static inline int cellular_get_supported_networks(const struct device *dev,
  * @retval 0 if successful.
  * @retval -ENOTSUP if API is not supported by cellular network device.
  * @retval -ENODATA if device is not in a state where signal can be polled
- * @retval Negative errno-code otherwise.
+ * @retval <0 Negative errno-code otherwise.
  */
 static inline int cellular_get_signal(const struct device *dev,
 				      const enum cellular_signal_type type, int16_t *value)
@@ -310,7 +310,7 @@ static inline int cellular_get_signal(const struct device *dev,
  * @retval 0 if successful.
  * @retval -ENOTSUP if API is not supported by cellular network device.
  * @retval -ENODATA if modem does not provide info requested
- * @retval Negative errno-code from chat module otherwise.
+ * @retval <0 Negative errno-code from chat module otherwise.
  */
 static inline int cellular_get_modem_info(const struct device *dev,
 					  const enum cellular_modem_info_type type, char *info,
@@ -335,7 +335,7 @@ static inline int cellular_get_modem_info(const struct device *dev,
  * @retval 0 if successful.
  * @retval -ENOSYS if API is not supported by cellular network device.
  * @retval -ENODATA if modem does not provide info requested
- * @retval Negative errno-code from chat module otherwise.
+ * @retval <0 Negative errno-code from chat module otherwise.
  */
 static inline int cellular_get_registration_status(const struct device *dev,
 						   enum cellular_access_technology tech,
@@ -364,7 +364,7 @@ static inline int cellular_get_registration_status(const struct device *dev,
  * @retval -EINVAL if APN string invalid or too long.
  * @retval -EALREADY if APN identical to current one, nothing to do
  * @retval -EBUSY if modem is already dialled, APN cannot be changed
- * @retval Negative errno-code otherwise.
+ * @retval <0 Negative errno-code otherwise.
  */
 static inline int cellular_set_apn(const struct device *dev, const char *apn)
 {

--- a/include/zephyr/drivers/charger.h
+++ b/include/zephyr/drivers/charger.h
@@ -376,7 +376,7 @@ __subsystem struct charger_driver_api {
  * @param val Pointer to charger_propval union
  *
  * @retval 0 if successful
- * @retval < 0 if getting property failed
+ * @retval <0 if getting property failed
  */
 __syscall int charger_get_prop(const struct device *dev, const charger_prop_t prop,
 			       union charger_propval *val);
@@ -397,7 +397,7 @@ static inline int z_impl_charger_get_prop(const struct device *dev, const charge
  * @param val Pointer to charger_propval union
  *
  * @retval 0 if successful
- * @retval < 0 if setting property failed
+ * @retval <0 if setting property failed
  */
 __syscall int charger_set_prop(const struct device *dev, const charger_prop_t prop,
 			       const union charger_propval *val);

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -174,7 +174,7 @@ static inline int clock_control_off(const struct device *dev,
  * @retval -EALREADY if clock was already started and is starting or running.
  * @retval -ENOTSUP If the requested mode of operation is not supported.
  * @retval -ENOSYS if the interface is not implemented.
- * @retval other negative errno on vendor specific error.
+ * @retval <0 other negative errno on vendor specific error.
  */
 static inline int clock_control_async_on(const struct device *dev,
 					 clock_control_subsys_t sys,
@@ -252,7 +252,7 @@ static inline int clock_control_get_rate(const struct device *dev,
  * @retval -EALREADY if clock was already in the given rate.
  * @retval -ENOTSUP If the requested mode of operation is not supported.
  * @retval -ENOSYS if the interface is not implemented.
- * @retval other negative errno on vendor specific error.
+ * @retval <0 other negative errno on vendor specific error.
  */
 static inline int clock_control_set_rate(const struct device *dev,
 		clock_control_subsys_t sys,

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -377,7 +377,7 @@ static inline uint32_t z_impl_counter_get_max_top_value(const struct device *dev
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 __syscall int counter_start(const struct device *dev);
 
@@ -414,7 +414,7 @@ static inline int z_impl_counter_stop(const struct device *dev)
  * @param ticks Pointer to where to store the current counter value
  *
  * @retval 0 If successful.
- * @retval Negative error code on failure getting the counter value
+ * @retval <0 Negative error code on failure getting the counter value
  */
 __syscall int counter_get_value(const struct device *dev, uint32_t *ticks);
 
@@ -433,7 +433,7 @@ static inline int z_impl_counter_get_value(const struct device *dev,
  * @param ticks Pointer to where to store the current counter value
  *
  * @retval 0 If successful.
- * @retval Negative error code on failure getting the counter value
+ * @retval <0 Negative error code on failure getting the counter value
  */
 __syscall int counter_get_value_64(const struct device *dev, uint64_t *ticks);
 

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -410,7 +410,7 @@ static inline int dai_config_set(const struct device *dev,
  * @param dev Pointer to the device structure for the driver instance
  * @param cfg Pointer to the config structure to be filled by the instance
  * @param dir Stream direction: RX or TX as defined by DAI_DIR_*
- * @retval 0 if success, negative if invalid parameters or DAI un-configured
+ * @return 0 if success, negative if invalid parameters or DAI un-configured
  */
 static inline int dai_config_get(const struct device *dev,
 				 struct dai_config *cfg,
@@ -428,7 +428,7 @@ static inline int dai_config_get(const struct device *dev,
  * @param dir Stream direction: RX or TX as defined by DAI_DIR_*
  * @param stream_id Stream id: some drivers may have stream specific
  *        properties, this id specifies the stream.
- * @retval Pointer to the structure containing properties,
+ * @return Pointer to the structure containing properties,
  *         or NULL if error or no properties
  */
 static inline const struct dai_properties *dai_get_properties(const struct device *dev,
@@ -565,7 +565,7 @@ static inline int dai_ts_get(const struct device *dev, struct dai_ts_cfg *cfg,
  *
  * @retval 0 If successful.
  * @retval -ENOSYS If the configuration update operation is not implemented.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 static inline int dai_config_update(const struct device *dev,
 									const void *bespoke_cfg,

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -275,7 +275,7 @@ __subsystem struct display_driver_api {
  * @param desc Pointer to a structure describing the buffer layout
  * @param buf Pointer to buffer array
  *
- * @retval 0 on success else negative errno code.
+ * @return 0 on success else negative errno code.
  */
 static inline int display_write(const struct device *dev, const uint16_t x,
 				const uint16_t y,
@@ -297,7 +297,7 @@ static inline int display_write(const struct device *dev, const uint16_t x,
  * @param desc Pointer to a structure describing the buffer layout
  * @param buf Pointer to buffer array
  *
- * @retval 0 on success else negative errno code.
+ * @return 0 on success else negative errno code.
  * @retval -ENOSYS if not implemented.
  */
 static inline int display_read(const struct device *dev, const uint16_t x,
@@ -320,7 +320,7 @@ static inline int display_read(const struct device *dev, const uint16_t x,
  *
  * @param dev Pointer to device structure
  *
- * @retval 0 on success else negative errno code.
+ * @return 0 on success else negative errno code.
  * @retval -ENOSYS if not implemented.
  */
 static inline int display_clear(const struct device *dev)
@@ -340,7 +340,7 @@ static inline int display_clear(const struct device *dev)
  *
  * @param dev Pointer to device structure
  *
- * @retval Pointer to frame buffer or NULL if direct framebuffer access
+ * @return Pointer to frame buffer or NULL if direct framebuffer access
  * is not supported
  *
  */
@@ -372,7 +372,7 @@ static inline void *display_get_framebuffer(const struct device *dev)
  *
  * @param dev Pointer to device structure
  *
- * @retval 0 on success else negative errno code.
+ * @return 0 on success else negative errno code.
  * @retval -ENOSYS if not implemented.
  */
 static inline int display_blanking_on(const struct device *dev)
@@ -396,7 +396,7 @@ static inline int display_blanking_on(const struct device *dev)
  *
  * @param dev Pointer to device structure
  *
- * @retval 0 on success else negative errno code.
+ * @return 0 on success else negative errno code.
  * @retval -ENOSYS if not implemented.
  */
 static inline int display_blanking_off(const struct device *dev)
@@ -420,7 +420,7 @@ static inline int display_blanking_off(const struct device *dev)
  * @param dev Pointer to device structure
  * @param brightness Brightness in steps of 1/256
  *
- * @retval 0 on success else negative errno code.
+ * @return 0 on success else negative errno code.
  * @retval -ENOSYS if not implemented.
  */
 static inline int display_set_brightness(const struct device *dev,
@@ -445,7 +445,7 @@ static inline int display_set_brightness(const struct device *dev,
  * @param dev Pointer to device structure
  * @param contrast Contrast in steps of 1/256
  *
- * @retval 0 on success else negative errno code.
+ * @return 0 on success else negative errno code.
  * @retval -ENOSYS if not implemented.
  */
 static inline int display_set_contrast(const struct device *dev, uint8_t contrast)
@@ -482,7 +482,7 @@ static inline void display_get_capabilities(const struct device *dev,
  * @param dev Pointer to device structure
  * @param pixel_format Pixel format to be used by display
  *
- * @retval 0 on success else negative errno code.
+ * @return 0 on success else negative errno code.
  * @retval -ENOSYS if not implemented.
  */
 static inline int
@@ -505,7 +505,7 @@ display_set_pixel_format(const struct device *dev,
  * @param dev Pointer to device structure
  * @param orientation Orientation to be used by display
  *
- * @retval 0 on success else negative errno code.
+ * @return 0 on success else negative errno code.
  * @retval -ENOSYS if not implemented.
  */
 static inline int display_set_orientation(const struct device *dev,

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -346,7 +346,7 @@ typedef int (*dma_api_get_attribute)(const struct device *dev, uint32_t type, ui
  * @param channel the channel id to use
  * @param filter_param filter function parameter, can be NULL
  *
- * @retval True on filter matched otherwise return False.
+ * @return True on filter matched otherwise return False.
  */
 typedef bool (*dma_api_chan_filter)(const struct device *dev,
 				int channel, void *filter_param);
@@ -390,7 +390,7 @@ __subsystem struct dma_driver_api {
  *                selected channel
  *
  * @retval 0 if successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 static inline int dma_config(const struct device *dev, uint32_t channel,
 			     struct dma_config *config)
@@ -412,7 +412,7 @@ static inline int dma_config(const struct device *dev, uint32_t channel,
  * @param size    size of DMA transfer
  *
  * @retval 0 if successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 #ifdef CONFIG_DMA_64BIT
 static inline int dma_reload(const struct device *dev, uint32_t channel,
@@ -449,7 +449,7 @@ static inline int dma_reload(const struct device *dev, uint32_t channel,
  *                be processed
  *
  * @retval 0 if successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 static inline int dma_start(const struct device *dev, uint32_t channel)
 {
@@ -475,7 +475,7 @@ static inline int dma_start(const struct device *dev, uint32_t channel)
  *                being processed
  *
  * @retval 0 if successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 static inline int dma_stop(const struct device *dev, uint32_t channel)
 {
@@ -551,8 +551,8 @@ static inline int dma_resume(const struct device *dev, uint32_t channel)
  * @param dev Pointer to the device structure for the driver instance.
  * @param filter_param filter function parameter
  *
- * @retval dma channel if successful.
- * @retval Negative errno code if failure.
+ * @return dma channel if successful.
+ * @retval <0 Negative errno code if failure.
  */
 static inline int dma_request_channel(const struct device *dev, void *filter_param)
 {
@@ -624,7 +624,7 @@ static inline void dma_release_channel(const struct device *dev, uint32_t channe
  * @param channel  channel number
  * @param filter_param filter attribute
  *
- * @retval Negative errno code if not support
+ * @retval <0 Negative errno code if not support
  *
  */
 static inline int dma_chan_filter(const struct device *dev, int channel, void *filter_param)
@@ -652,8 +652,8 @@ static inline int dma_chan_filter(const struct device *dev, int channel, void *f
  *                being processed
  * @param stat   a non-NULL dma_status object for storing DMA status
  *
- * @retval non-negative if successful.
- * @retval Negative errno code if failure.
+ * @retval >=0 non-negative if successful.
+ * @retval <0 Negative errno code if failure.
  */
 static inline int dma_get_status(const struct device *dev, uint32_t channel,
 				 struct dma_status *stat)
@@ -682,8 +682,8 @@ static inline int dma_get_status(const struct device *dev, uint32_t channel,
  * @param type    Numeric identification of the attribute
  * @param value   A non-NULL pointer to the variable where the read value is to be placed
  *
- * @retval non-negative if successful.
- * @retval Negative errno code if failure.
+ * @retval >=0 non-negative if successful.
+ * @retval <0 Negative errno code if failure.
  */
 static inline int dma_get_attribute(const struct device *dev, uint32_t type, uint32_t *value)
 {
@@ -707,7 +707,7 @@ static inline int dma_get_attribute(const struct device *dev, uint32_t type, uin
  *
  * @param size: width of bus (in bytes)
  *
- * @retval common DMA index to be placed into registers.
+ * @return common DMA index to be placed into registers.
  */
 static inline uint32_t dma_width_index(uint32_t size)
 {
@@ -736,7 +736,7 @@ static inline uint32_t dma_width_index(uint32_t size)
  *
  * @param burst: number of bytes to be sent in a single burst
  *
- * @retval common DMA index to be placed into registers.
+ * @return common DMA index to be placed into registers.
  */
 static inline uint32_t dma_burst_index(uint32_t burst)
 {

--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -103,7 +103,7 @@ static inline int z_impl_entropy_get_entropy(const struct device *dev,
  * @param buffer Buffer to fill with entropy.
  * @param length Buffer length.
  * @param flags Flags to modify the behavior of the call.
- * @retval number of bytes filled with entropy or -error.
+ * @return number of bytes filled with entropy or -error.
  */
 static inline int entropy_get_entropy_isr(const struct device *dev,
 					  uint8_t *buffer,

--- a/include/zephyr/drivers/espi_emul.h
+++ b/include/zephyr/drivers/espi_emul.h
@@ -69,7 +69,7 @@ typedef int (*emul_espi_api_get_vw)(const struct emul *target, enum espi_vwire_s
  *
  * @param target The device Emulator instance
  *
- * @retval The address of the memory.
+ * @return The address of the memory.
  */
 typedef uintptr_t (*emul_espi_api_get_acpi_shm)(const struct emul *target);
 #endif

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -525,7 +525,7 @@ void flash_page_foreach(const struct device *dev, flash_page_cb cb,
  *
  * @retval 0 on success
  * @retval -ENOTSUP if the flash driver does not support SFDP access
- * @retval negative values for other errors.
+ * @retval <0 negative values for other errors.
  */
 __syscall int flash_sfdp_read(const struct device *dev, off_t offset,
 			      void *data, size_t len);
@@ -553,7 +553,7 @@ static inline int z_impl_flash_sfdp_read(const struct device *dev,
  *
  * @retval 0 on successful store of 3-byte JEDEC id
  * @retval -ENOTSUP if flash driver doesn't support this function
- * @retval negative values for other errors
+ * @retval <0 negative values for other errors
  */
 __syscall int flash_read_jedec_id(const struct device *dev, uint8_t *id);
 
@@ -637,7 +637,7 @@ static inline const struct flash_parameters *z_impl_flash_get_parameters(const s
  *  @retval 0 on success.
  *  @retval -ENOTSUP if given device doesn't support extended operation.
  *  @retval -ENOSYS if support for extended operations is not enabled in Kconfig
- *  @retval negative value on extended operation errors.
+ *  @retval <0 negative value on extended operation errors.
  */
 __syscall int flash_ex_op(const struct device *dev, uint16_t code,
 			  const uintptr_t in, void *out);

--- a/include/zephyr/drivers/fpga.h
+++ b/include/zephyr/drivers/fpga.h
@@ -89,7 +89,7 @@ static inline enum FPGA_status fpga_get_status(const struct device *dev)
  * @param dev FPGA device structure.
  *
  * @retval 0 if successful.
- * @retval Failed Otherwise.
+ * @return Failed Otherwise.
  */
 static inline int fpga_reset(const struct device *dev)
 {
@@ -111,7 +111,7 @@ static inline int fpga_reset(const struct device *dev)
  * @param img_size Bitstream size in bytes.
  *
  * @retval 0 if successful.
- * @retval Failed Otherwise.
+ * @return Failed Otherwise.
  */
 static inline int fpga_load(const struct device *dev, uint32_t *image_ptr,
 			    uint32_t img_size)
@@ -132,7 +132,7 @@ static inline int fpga_load(const struct device *dev, uint32_t *image_ptr,
  * @param dev FPGA device structure.
  *
  * @retval 0 if successful.
- * @retval negative errno code on failure.
+ * @retval <0 negative errno code on failure.
  */
 static inline int fpga_on(const struct device *dev)
 {
@@ -173,7 +173,7 @@ static inline const char *fpga_get_info(const struct device *dev)
  * @param dev FPGA device structure.
  *
  * @retval 0 if successful.
- * @retval negative errno code on failure.
+ * @retval <0 negative errno code on failure.
  */
 static inline int fpga_off(const struct device *dev)
 {

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -1892,7 +1892,7 @@ static inline int gpio_remove_callback_dt(const struct gpio_dt_spec *spec,
  *
  * @param dev Pointer to the device structure for the driver instance.
  *
- * @retval status != 0 if at least one gpio interrupt is pending.
+ * @return status != 0 if at least one gpio interrupt is pending.
  * @retval 0 if no gpio interrupt is pending.
  * @retval -ENOSYS If driver does not implement the operation
  */

--- a/include/zephyr/drivers/hwinfo.h
+++ b/include/zephyr/drivers/hwinfo.h
@@ -91,9 +91,9 @@ extern "C" {
  * @param buffer  Buffer to write the ID to.
  * @param length  Max length of the buffer.
  *
- * @retval size of the device ID copied.
+ * @return size of the device ID copied.
  * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval any negative value on driver specific errors.
+ * @retval <0 any negative value on driver specific errors.
  */
 __syscall ssize_t hwinfo_get_device_id(uint8_t *buffer, size_t length);
 
@@ -107,9 +107,9 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length);
  *
  * @param buffer  Buffer of 8 bytes to write the ID to.
  *
- * @retval zero if successful.
+ * @retval 0 if successful.
  * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval any negative value on driver specific errors.
+ * @retval <0 any negative value on driver specific errors.
  */
 __syscall int hwinfo_get_device_eui64(uint8_t *buffer);
 
@@ -131,9 +131,9 @@ int z_impl_hwinfo_get_device_eui64(uint8_t *buffer);
  * Successive calls to this routine will return the same value, unless
  * `hwinfo_clear_reset_cause` has been called.
  *
- * @retval zero if successful.
+ * @retval 0 if successful.
  * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval any negative value on driver specific errors.
+ * @retval <0 any negative value on driver specific errors.
  */
 __syscall int hwinfo_get_reset_cause(uint32_t *cause);
 
@@ -144,9 +144,9 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause);
  *
  * Clears reset cause flags.
  *
- * @retval zero if successful.
+ * @retval 0 if successful.
  * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval any negative value on driver specific errors.
+ * @retval <0 any negative value on driver specific errors.
  */
 __syscall int hwinfo_clear_reset_cause(void);
 
@@ -159,9 +159,9 @@ int z_impl_hwinfo_clear_reset_cause(void);
  *
  * Retrieves all `reset_cause` flags that are supported by this device.
  *
- * @retval zero if successful.
+ * @retval 0 if successful.
  * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval any negative value on driver specific errors.
+ * @retval <0 any negative value on driver specific errors.
  */
 __syscall int hwinfo_get_supported_reset_cause(uint32_t *supported);
 

--- a/include/zephyr/drivers/hwspinlock.h
+++ b/include/zephyr/drivers/hwspinlock.h
@@ -337,7 +337,7 @@ static inline void hw_spin_unlock(const struct device *dev, hwspinlock_ctx_t *ct
  *
  * @param dev HW spinlock device instance.
  *
- * @retval HW spinlock max ID.
+ * @return HW spinlock max ID.
  */
 static inline uint32_t hw_spinlock_get_max_id(const struct device *dev)
 {

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -982,7 +982,7 @@ static inline int i2c_transfer_cb_dt(const struct i2c_dt_spec *spec,
  * @param userdata Userdata passed to callback.
  *
  * @retval 0 if successful
- * @retval negative on error.
+ * @retval <0 negative on error.
  */
 static inline int i2c_write_read_cb(const struct device *dev, struct i2c_msg *msgs,
 				 uint8_t num_msgs, uint16_t addr, const void *write_buf,

--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -373,7 +373,7 @@ static inline int z_impl_i2s_configure(const struct device *dev,
  *
  * @param dev Pointer to the device structure for the driver instance
  * @param dir Stream direction: RX or TX as defined by I2S_DIR_*
- * @retval Pointer to the structure containing configuration parameters,
+ * @return Pointer to the structure containing configuration parameters,
  *         or NULL if un-configured
  */
 static inline const struct i2s_config *i2s_config_get(const struct device *dev,

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -2596,7 +2596,7 @@ void i3c_sec_handoffed(struct k_work *work);
  *
  * This allocates memory from a mem slab for a i3c_device_desc
  *
- * @retval Pointer to allocated i3c_device_desc
+ * @return Pointer to allocated i3c_device_desc
  * @retval NULL if no mem slabs available
  */
 struct i3c_device_desc *i3c_device_desc_alloc(void);

--- a/include/zephyr/drivers/led_strip.h
+++ b/include/zephyr/drivers/led_strip.h
@@ -159,7 +159,7 @@ static inline int led_strip_update_channels(const struct device *dev,
  *
  * @param dev	LED strip device.
  *
- * @retval	Length of LED strip device.
+ * @return	Length of LED strip device.
  */
 static inline size_t led_strip_length(const struct device *dev)
 {

--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -271,7 +271,7 @@ __subsystem struct peci_driver_api {
  * @param bitrate the selected bitrate expressed in Kbps.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 __syscall int peci_config(const struct device *dev, uint32_t bitrate);
 
@@ -290,7 +290,7 @@ static inline int z_impl_peci_config(const struct device *dev,
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 __syscall int peci_enable(const struct device *dev);
 
@@ -308,7 +308,7 @@ static inline int z_impl_peci_enable(const struct device *dev)
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 __syscall int peci_disable(const struct device *dev);
 
@@ -327,7 +327,7 @@ static inline int z_impl_peci_disable(const struct device *dev)
  * @param msg Structure representing a PECI transaction.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 
 __syscall int peci_transfer(const struct device *dev, struct peci_msg *msg);

--- a/include/zephyr/drivers/pm_cpu_ops.h
+++ b/include/zephyr/drivers/pm_cpu_ops.h
@@ -35,7 +35,7 @@ extern "C" {
  * This call is intended for use in hotplug. A core that is powered down by
  * cpu_off can only be powered up again in response to a cpu_on
  *
- * @retval The call does not return when successful
+ * @return The call does not return when successful
  * @retval -ENOTSUP If the operation is not supported
  */
 int pm_cpu_off(void);
@@ -50,7 +50,7 @@ int pm_cpu_off(void);
  * @param cpuid CPU id to power on
  * @param entry_point Address at which the core must commence execution
  *
- * @retval 0 on success, a negative errno otherwise
+ * @return 0 on success, a negative errno otherwise
  * @retval -ENOTSUP If the operation is not supported
  */
 int pm_cpu_on(unsigned long cpuid, uintptr_t entry_point);
@@ -62,7 +62,7 @@ int pm_cpu_on(unsigned long cpuid, uintptr_t entry_point);
  *
  * @param reset system reset type, cold or warm.
  *
- * @retval 0 on success, a negative errno otherwise
+ * @return 0 on success, a negative errno otherwise
  */
 int pm_system_reset(unsigned char reset);
 

--- a/include/zephyr/drivers/ps2.h
+++ b/include/zephyr/drivers/ps2.h
@@ -74,7 +74,7 @@ __subsystem struct ps2_driver_api {
  * command or when a mouse/keyboard send data to the client application.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 __syscall int ps2_config(const struct device *dev,
 			 ps2_callback_t callback_isr);
@@ -95,7 +95,7 @@ static inline int z_impl_ps2_config(const struct device *dev,
  * @param value Data for the PS2 device.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 __syscall int ps2_write(const struct device *dev, uint8_t value);
 
@@ -113,7 +113,7 @@ static inline int z_impl_ps2_write(const struct device *dev, uint8_t value)
  * @param value Pointer used for reading the PS/2 device.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 __syscall int ps2_read(const struct device *dev,  uint8_t *value);
 
@@ -130,7 +130,7 @@ static inline int z_impl_ps2_read(const struct device *dev, uint8_t *value)
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 __syscall int ps2_enable_callback(const struct device *dev);
 
@@ -151,7 +151,7 @@ static inline int z_impl_ps2_enable_callback(const struct device *dev)
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval <0 Negative errno code if failure.
  */
 __syscall int ps2_disable_callback(const struct device *dev);
 

--- a/include/zephyr/drivers/retained_mem.h
+++ b/include/zephyr/drivers/retained_mem.h
@@ -90,7 +90,7 @@ __subsystem struct retained_mem_driver_api {
  *
  * @param dev		Retained memory device to use.
  *
- * @retval		Positive value indicating size in bytes on success, else negative errno
+ * @return		Positive value indicating size in bytes on success, else negative errno
  *			code.
  */
 __syscall ssize_t retained_mem_size(const struct device *dev);
@@ -110,7 +110,7 @@ static inline ssize_t z_impl_retained_mem_size(const struct device *dev)
  * @param buffer	Buffer to store read data in.
  * @param size		Size of data to read.
  *
- * @retval		0 on success else negative errno code.
+ * @return		0 on success else negative errno code.
  */
 __syscall int retained_mem_read(const struct device *dev, off_t offset, uint8_t *buffer,
 				size_t size);
@@ -144,7 +144,7 @@ static inline int z_impl_retained_mem_read(const struct device *dev, off_t offse
  * @param buffer	Data to write.
  * @param size		Size of data to be written.
  *
- * @retval		0 on success else negative errno code.
+ * @return		0 on success else negative errno code.
  */
 __syscall int retained_mem_write(const struct device *dev, off_t offset, const uint8_t *buffer,
 				 size_t size);
@@ -174,7 +174,7 @@ static inline int z_impl_retained_mem_write(const struct device *dev, off_t offs
  *
  * @param dev		Retained memory device to use.
  *
- * @retval		0 on success else negative errno code.
+ * @return		0 on success else negative errno code.
  */
 __syscall int retained_mem_clear(const struct device *dev);
 

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -283,8 +283,8 @@ __subsystem struct sdhc_driver_api {
  *
  * @param dev: SD host controller device
  * @retval 0 reset succeeded
- * @retval -ETIMEDOUT: controller reset timed out
- * @retval -EIO: reset failed
+ * @retval -ETIMEDOUT controller reset timed out
+ * @retval -EIO reset failed
  */
 __syscall int sdhc_hw_reset(const struct device *dev);
 
@@ -311,7 +311,7 @@ static inline int z_impl_sdhc_hw_reset(const struct device *dev)
  * @retval 0 command was sent successfully
  * @retval -ETIMEDOUT command timed out while sending
  * @retval -ENOTSUP host controller does not support command
- * @retval -EIO: I/O error
+ * @retval -EIO I/O error
  */
 __syscall int sdhc_request(const struct device *dev, struct sdhc_command *cmd,
 			   struct sdhc_data *data);
@@ -387,9 +387,9 @@ static inline int z_impl_sdhc_card_present(const struct device *dev)
  * allows an application to request the SD host controller to tune the card.
  * @param dev: SDHC device
  * @retval 0 tuning succeeded, card is ready for commands
- * @retval -ETIMEDOUT: tuning failed after timeout
- * @retval -ENOTSUP: controller does not support tuning
- * @retval -EIO: I/O error while tuning
+ * @retval -ETIMEDOUT tuning failed after timeout
+ * @retval -ENOTSUP controller does not support tuning
+ * @retval -EIO I/O error while tuning
  */
 __syscall int sdhc_execute_tuning(const struct device *dev);
 
@@ -466,8 +466,8 @@ static inline int z_impl_sdhc_get_host_props(const struct device *dev,
  *        indicating which interrupts should produce a callback
  * @param user_data: parameter that will be passed to callback function
  * @retval 0 interrupts were enabled, and callback was installed
- * @retval -ENOTSUP: controller does not support this function
- * @retval -EIO: I/O error
+ * @retval -ENOTSUP controller does not support this function
+ * @retval -EIO I/O error
  */
 __syscall int sdhc_enable_interrupt(const struct device *dev,
 				    sdhc_interrupt_cb_t callback,
@@ -495,8 +495,8 @@ static inline int z_impl_sdhc_enable_interrupt(const struct device *dev,
  * @param sources: bitmask of @ref sdhc_interrupt_source values
  *        indicating which interrupts should be disabled.
  * @retval 0 interrupts were disabled
- * @retval -ENOTSUP: controller does not support this function
- * @retval -EIO: I/O error
+ * @retval -ENOTSUP controller does not support this function
+ * @retval -EIO I/O error
  */
 __syscall int sdhc_disable_interrupt(const struct device *dev, int sources);
 

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -149,7 +149,7 @@ extern "C" {
  * @brief Get SPI word size in bits from a @ref spi_operation_t
  *
  * @param operation A @ref spi_operation_t from which to get the configured word size.
- * @retval The size (in bits) of a spi word for the operation.
+ * @return The size (in bits) of a spi word for the operation.
  */
 #define SPI_WORD_SIZE_GET(operation)					\
 	(((operation) & SPI_WORD_SIZE_MASK) >> SPI_WORD_SIZE_SHIFT)
@@ -158,7 +158,7 @@ extern "C" {
  * @brief Get a bitmask to set the word size in a @ref spi_operation_t
  *
  * @param word_size The size of a SPI data frame in bits.
- * @retval A bitmask to apply to a @ref spi_operation_t
+ * @return A bitmask to apply to a @ref spi_operation_t
  */
 #define SPI_WORD_SET(word_size)			\
 	((word_size) << SPI_WORD_SIZE_SHIFT)

--- a/include/zephyr/drivers/tee.h
+++ b/include/zephyr/drivers/tee.h
@@ -640,7 +640,7 @@ static inline int z_impl_tee_suppl_recv(const struct device *dev, uint32_t *func
  * @param param List of the params for send/receive
  *
  * @retval -ENOSYS If callback was not implemented
- * @retval         Return value for sent request
+ * @return         Return value for sent request
  *
  * @retval 0       On success, negative on error
  */

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -870,7 +870,7 @@ static inline int video_get_selection(const struct device *dev, struct video_sel
  * @param align Alignment of the requested memory, must be a power of two.
  * @param timeout Timeout duration or K_NO_WAIT
  *
- * @retval pointer to allocated video buffer
+ * @return pointer to allocated video buffer
  */
 struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align, k_timeout_t timeout);
 
@@ -880,7 +880,7 @@ struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align, k_tim
  * @param size Size of the video buffer (in bytes).
  * @param timeout Timeout duration or K_NO_WAIT
  *
- * @retval pointer to allocated video buffer
+ * @return pointer to allocated video buffer
  */
 struct video_buffer *video_buffer_alloc(size_t size, k_timeout_t timeout);
 

--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -436,7 +436,7 @@ int fs_seek(struct fs_file_t *zfp, off_t offset, int whence);
  *
  * @param zfp Pointer to the file object
  *
- * @retval >= 0 a current position in file;
+ * @retval >=0 a current position in file;
  * @retval -EBADF when invoked on zfp that represents unopened/closed file;
  * @retval -ENOTSUP if not supported by underlying file system driver;
  * @retval <0 an other negative errno code on error.
@@ -497,7 +497,7 @@ int fs_sync(struct fs_file_t *zfp);
  * @retval -EROFS if @p path is within read-only directory, or when
  *         file system has been mounted with the FS_MOUNT_FLAG_READ_ONLY flag;
  * @retval -ENOTSUP when not implemented by underlying file system driver;
- * @retval <0 an other negative errno code on error
+ * @retval <0 another negative errno code on error
  */
 int fs_mkdir(const char *path);
 
@@ -576,7 +576,7 @@ int fs_closedir(struct fs_dir_t *zdp);
  *         support it.
  * @retval -EROFS if system requires formatting but @c FS_MOUNT_FLAG_READ_ONLY
  *	   has been set;
- * @retval <0 an other negative errno code on error.
+ * @retval <0 another negative errno code on error.
  */
 int fs_mount(struct fs_mount_t *mp);
 
@@ -643,7 +643,7 @@ int fs_stat(const char *path, struct fs_dirent *entry);
  * @retval 0 on success;
  * @retval -EINVAL when a bad path to a directory, or a file, is given;
  * @retval -ENOTSUP when not implemented by underlying file system driver;
- * @retval <0 an other negative errno code on error.
+ * @retval <0 another negative errno code on error.
  */
 int fs_statvfs(const char *path, struct fs_statvfs *stat);
 
@@ -701,7 +701,7 @@ int fs_unregister(int type, const struct fs_file_system_t *fs);
  * @retval 0 on success;
  * @retval -EINVAL when a bad path to a directory, or a file, is given;
  * @retval -ENOTSUP when not implemented by underlying file system driver;
- * @retval <0 an other negative errno code on error.
+ * @retval <0 another negative errno code on error.
  */
 int fs_gc(struct fs_mount_t *mp);
 

--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -132,7 +132,7 @@ int zms_clear(struct zms_fs *fs);
  * to be written or 0.
  * When a rewrite of the same data already stored is attempted, nothing is written to flash,
  * thus 0 is returned. On error, returns negative value of error codes defined in `errno.h`.
- * @retval Number of bytes written (`len` or 0) on success.
+ * @return Number of bytes written (`len` or 0) on success.
  * @retval -EACCES if ZMS is still not initialized.
  * @retval -ENXIO if there is a device error.
  * @retval -EIO if there is a memory read/write error.
@@ -166,7 +166,7 @@ int zms_delete(struct zms_fs *fs, zms_id_t id);
  * @return Number of bytes read. On success, it will be equal to the number of bytes requested
  * to be read or less than that if the stored data has a smaller size than the requested one.
  * On error, returns negative value of error codes defined in `errno.h`.
- * @retval Number of bytes read (> 0) on success.
+ * @return Number of bytes read (> 0) on success.
  * @retval -EACCES if ZMS is still not initialized.
  * @retval -EIO if there is a memory read/write error.
  * @retval -ENOENT if there is no entry with the given `id`.
@@ -187,7 +187,7 @@ ssize_t zms_read(struct zms_fs *fs, zms_id_t id, void *data, size_t len);
  * to be read. When the return value is larger than the number of bytes requested to read this
  * indicates not all bytes were read, and more data is available. On error, returns negative
  * value of error codes defined in `errno.h`.
- * @retval Number of bytes read (> 0) on success.
+ * @return Number of bytes read (> 0) on success.
  * @retval -EACCES if ZMS is still not initialized.
  * @retval -EIO if there is a memory read/write error.
  * @retval -ENOENT if there is no entry with the given `id` and history counter.
@@ -203,7 +203,7 @@ ssize_t zms_read_hist(struct zms_fs *fs, zms_id_t id, void *data, size_t len, ui
  *
  * @return Data length contained in the ATE. On success, it will be equal to the number of bytes
  * in the ATE. On error, returns negative value of error codes defined in `errno.h`.
- * @retval Length of the entry with the given `id` (> 0) on success.
+ * @return Length of the entry with the given `id` (> 0) on success.
  * @retval -EACCES if ZMS is still not initialized.
  * @retval -EIO if there is a memory read/write error.
  * @retval -ENOENT if there is no entry with the given id.
@@ -220,7 +220,7 @@ ssize_t zms_get_data_length(struct zms_fs *fs, zms_id_t id);
  * still be written to the file system.
  * Calculating the free space is a time-consuming operation, especially on SPI flash.
  * On error, returns negative value of error codes defined in `errno.h`.
- * @retval Number of free bytes (>= 0) on success.
+ * @return Number of free bytes (>= 0) on success.
  * @retval -EACCES if ZMS is still not initialized.
  * @retval -EIO if there is a memory read/write error.
  * @retval -EINVAL if `fs` is NULL.

--- a/include/zephyr/input/input.h
+++ b/include/zephyr/input/input.h
@@ -75,7 +75,7 @@ struct input_event {
  * @param timeout Timeout for reporting the event, ignored if
  *                @kconfig{CONFIG_INPUT_MODE_SYNCHRONOUS} is used.
  * @retval 0 if the message has been processed.
- * @retval negative if @kconfig{CONFIG_INPUT_MODE_THREAD} is enabled and the
+ * @retval <0 negative if @kconfig{CONFIG_INPUT_MODE_THREAD} is enabled and the
  *         message failed to be enqueued.
  */
 int input_report(const struct device *dev,

--- a/include/zephyr/input/input_hid.h
+++ b/include/zephyr/input/input_hid.h
@@ -26,7 +26,7 @@
  * safely be casted to a uint8_t type.
  *
  * @param input_code Event code (see @ref INPUT_KEY_CODES).
- * @retval the HID code corresponding to the input code.
+ * @return the HID code corresponding to the input code.
  * @retval -1 if there's no HID code for the specified input code.
  */
 int16_t input_to_hid_code(uint16_t input_code);
@@ -38,7 +38,7 @@ int16_t input_to_hid_code(uint16_t input_code);
  * output or 0.
  *
  * @param input_code Event code (see @ref INPUT_KEY_CODES).
- * @retval the HID modifier corresponding to the input code.
+ * @return the HID modifier corresponding to the input code.
  * @retval 0 if there's no HID modifier for the specified input code.
  */
 uint8_t input_to_hid_modifier(uint16_t input_code);

--- a/include/zephyr/kernel/mm.h
+++ b/include/zephyr/kernel/mm.h
@@ -288,7 +288,7 @@ int k_mem_update_flags(void *addr, size_t size, uint32_t flags);
  * @param[in]  addr Region base address
  * @param[in]  size Region size
  * @param[in]  align What to align the address and size to
- * @retval offset between aligned_addr and addr
+ * @return offset between aligned_addr and addr
  */
 size_t k_mem_region_align(uintptr_t *aligned_addr, size_t *aligned_size,
 			  uintptr_t addr, size_t size, size_t align);

--- a/include/zephyr/kernel/obj_core.h
+++ b/include/zephyr/kernel/obj_core.h
@@ -136,7 +136,7 @@ struct k_obj_core {
  * @param id A means to identify the object type
  * @param off Offset of object core within the structure
  *
- * @retval Pointer to initialized object type
+ * @return Pointer to initialized object type
  */
 struct k_obj_type *z_obj_type_init(struct k_obj_type *type,
 				   uint32_t id, size_t off);
@@ -150,7 +150,7 @@ struct k_obj_type *z_obj_type_init(struct k_obj_type *type,
  * @param type_id  Type ID associated with object type
  *
  * @retval NULL if object type not found
- * @retval Pointer to object type if found
+ * @return Pointer to object type if found
  */
 struct k_obj_type *k_obj_type_find(uint32_t type_id);
 

--- a/include/zephyr/logging/log_ctrl.h
+++ b/include/zephyr/logging/log_ctrl.h
@@ -232,7 +232,7 @@ void log_backend_disable(struct log_backend const *const backend);
  *
  * @param[in] backend_name Name of the backend as defined by the LOG_BACKEND_DEFINE.
  *
- * @retval Pointer to the backend instance if found, NULL if backend is not found.
+ * @return Pointer to the backend instance if found, NULL if backend is not found.
  */
 const struct log_backend *log_backend_get_by_name(const char *backend_name);
 
@@ -240,7 +240,7 @@ const struct log_backend *log_backend_get_by_name(const char *backend_name);
  *
  * @param log_type Log format.
  *
- * @retval Pointer to the last backend that failed, NULL for success.
+ * @return Pointer to the last backend that failed, NULL for success.
  */
 const struct log_backend *log_format_set_all_active_backends(size_t log_type);
 

--- a/include/zephyr/logging/log_frontend_stmesp_demux.h
+++ b/include/zephyr/logging/log_frontend_stmesp_demux.h
@@ -305,7 +305,7 @@ void log_frontend_stmesp_demux_reset(void);
 
 /** @brief Get maximum buffer utilization.
  *
- * @retval Non-negative Maximum buffer utilization.
+ * @retval >=0 Maximum buffer utilization.
  * @retval -ENOTSUP Feature not enabled.
  */
 int log_frontend_stmesp_demux_max_utilization(void);

--- a/include/zephyr/mem_mgmt/mem_attr.h
+++ b/include/zephyr/mem_mgmt/mem_attr.h
@@ -72,7 +72,7 @@ struct mem_attr_region_t {
  *
  * @param region Pointer to pointer to the list of memory regions.
  *
- * @retval Number of memory regions returned in the parameter.
+ * @return Number of memory regions returned in the parameter.
  */
 size_t mem_attr_get_regions(const struct mem_attr_region_t **region);
 

--- a/include/zephyr/modbus/modbus.h
+++ b/include/zephyr/modbus/modbus.h
@@ -393,7 +393,7 @@ struct modbus_user_callbacks {
  *
  * @param iface_name Modbus interface name
  *
- * @retval           Modbus interface index or negative error value.
+ * @return           Modbus interface index or negative error value.
  */
 int modbus_iface_get_by_name(const char *iface_name);
 
@@ -428,7 +428,7 @@ typedef int (*modbus_raw_cb_t)(const int iface, const struct modbus_adu *adu,
  * @param excep_code Pointer to possible exception code
  * @param user_data  Pointer to user data
  *
- * @retval           true If response should be sent, false otherwise
+ * @return           true If response should be sent, false otherwise
  */
 typedef bool (*modbus_custom_cb_t)(const int iface,
 				const struct modbus_adu *const rx_adu,

--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -132,7 +132,7 @@ void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback
  * @param buf Data to transmit
  * @param size Number of bytes to transmit
  *
- * @retval Number of bytes placed in pipe
+ * @return Number of bytes placed in pipe
  * @retval -EPERM if pipe is closed
  * @retval -errno code on error
  *
@@ -147,7 +147,7 @@ int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size
  * @param buf Destination for received data; must not be already in use in a modem module.
  * @param size Capacity of destination for received data
  *
- * @retval Number of bytes received from pipe
+ * @return Number of bytes received from pipe
  * @retval -EPERM if pipe is closed
  * @retval -errno code on error
  *

--- a/include/zephyr/modem/pipelink.h
+++ b/include/zephyr/modem/pipelink.h
@@ -83,7 +83,7 @@ bool modem_pipelink_is_connected(struct modem_pipelink *link);
 /**
  * @brief Get pipe from pipelink
  * @param link Pipelink instance
- * @retval Pointer to pipe if pipelink has been initialized
+ * @return Pointer to pipe if pipelink has been initialized
  * @retval NULL if pipelink has not been initialized
  */
 struct modem_pipe *modem_pipelink_get_pipe(struct modem_pipelink *link);

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -697,7 +697,7 @@ bool coap_packet_is_request(const struct coap_packet *cpkt);
  * @param addr Peer address
  * @param addr_len Peer address length
  *
- * @retval >= 0 in case of success.
+ * @retval >=0 in case of success.
  * @retval -ENOTSUP in case of invalid request code.
  * @retval -EPERM in case resource handler is not implemented.
  * @retval -ENOENT in case the resource is not found.
@@ -720,7 +720,7 @@ int coap_handle_request_len(struct coap_packet *cpkt,
  * @param addr Peer address
  * @param addr_len Peer address length
  *
- * @retval >= 0 in case of success.
+ * @retval >=0 in case of success.
  * @retval -ENOTSUP in case of invalid request code.
  * @retval -EPERM in case resource handler is not implemented.
  * @retval -ENOENT in case the resource is not found.

--- a/include/zephyr/net/coap_service.h
+++ b/include/zephyr/net/coap_service.h
@@ -271,7 +271,7 @@ int coap_service_stop(const struct coap_service *service);
  * @param service Pointer to CoAP service
  * @retval 1 if the service is running
  * @retval 0 if the service is stopped
- * @retval negative in case of an error.
+ * @retval <0 negative in case of an error.
  */
 int coap_service_is_running(const struct coap_service *service);
 

--- a/include/zephyr/net/conn_mgr_connectivity.h
+++ b/include/zephyr/net/conn_mgr_connectivity.h
@@ -138,7 +138,7 @@ enum conn_mgr_if_flag {
  * @retval 0 on success.
  * @retval -ESHUTDOWN if the iface is not admin-up.
  * @retval -ENOTSUP if the iface does not have a connectivity implementation.
- * @retval implementation-specific status code otherwise.
+ * @return implementation-specific status code otherwise.
  */
 int conn_mgr_if_connect(struct net_if *iface);
 
@@ -154,7 +154,7 @@ int conn_mgr_if_connect(struct net_if *iface);
  *
  * @retval 0 on success.
  * @retval -ENOTSUP if the iface does not have a connectivity implementation.
- * @retval implementation-specific status code otherwise.
+ * @return implementation-specific status code otherwise.
  */
 int conn_mgr_if_disconnect(struct net_if *iface);
 
@@ -185,7 +185,7 @@ bool conn_mgr_if_is_bound(struct net_if *iface);
  * @retval -ENOBUFS if optlen is too long.
  * @retval -EINVAL if NULL optval pointer provided.
  * @retval -ENOPROTOOPT if the optname is not recognized.
- * @retval implementation-specific error code otherwise.
+ * @return implementation-specific error code otherwise.
  */
 int conn_mgr_if_set_opt(struct net_if *iface, int optname, const void *optval, size_t optlen);
 
@@ -213,7 +213,7 @@ int conn_mgr_if_set_opt(struct net_if *iface, int optname, const void *optval, s
  * @retval -EINVAL if invalid retrieval buffer length is provided, or if NULL optval or
  *		   optlen pointer provided.
  * @retval -ENOPROTOOPT if the optname is not recognized.
- * @retval implementation-specific error code otherwise.
+ * @return implementation-specific error code otherwise.
  */
 int conn_mgr_if_get_opt(struct net_if *iface, int optname, void *optval, size_t *optlen);
 

--- a/include/zephyr/net/net_timeout.h
+++ b/include/zephyr/net/net_timeout.h
@@ -130,7 +130,7 @@ int64_t net_timeout_deadline(const struct net_timeout *timeout,
  * k_uptime_get_32().
  *
  * @retval 0 if the timeout has completed.
- * @retval positive the remaining duration of the timeout, in seconds.
+ * @retval >0 the remaining duration of the timeout, in seconds.
  */
 uint32_t net_timeout_remaining(const struct net_timeout *timeout,
 			       uint32_t now);
@@ -150,7 +150,7 @@ uint32_t net_timeout_remaining(const struct net_timeout *timeout,
  * k_uptime_get_32().
  *
  * @retval 0 if the timeout has completed
- * @retval positive the maximum delay until the state of this timeout should
+ * @retval >0 the maximum delay until the state of this timeout should
  * be re-evaluated, in milliseconds.
  */
 uint32_t net_timeout_evaluate(struct net_timeout *timeout,

--- a/include/zephyr/net/tftp.h
+++ b/include/zephyr/net/tftp.h
@@ -144,7 +144,7 @@ struct tftpc {
  * @param remote_file Name of the remote file to get.
  * @param mode        TFTP Client "mode" setting.
  *
- * @retval The size of data being received if the operation completed successfully.
+ * @return The size of data being received if the operation completed successfully.
  * @retval TFTPC_BUFFER_OVERFLOW if the file is larger than the user buffer.
  * @retval TFTPC_REMOTE_ERROR if the server failed to process our request.
  * @retval TFTPC_RETRIES_EXHAUSTED if the client timed out waiting for server.
@@ -165,7 +165,7 @@ int tftp_get(struct tftpc *client,
  * @param user_buf    Data buffer containing the data to put.
  * @param user_buf_size Length of the data to put.
  *
- * @retval The size of data being sent if the operation completed successfully.
+ * @return The size of data being sent if the operation completed successfully.
  * @retval TFTPC_REMOTE_ERROR if the server failed to process our request.
  * @retval TFTPC_RETRIES_EXHAUSTED if the client timed out waiting for server.
  * @retval -EINVAL if `client` or `user_buf` is NULL or if `user_buf_size` is zero.

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -490,7 +490,7 @@ void __z_pthread_cleanup_pop(int execute);
  * @retval 0 Success
  * @retval ESRCH Thread does not exist
  * @retval EINVAL Name buffer is NULL
- * @retval Negative value if kernel function error
+ * @retval <0 Negative value if kernel function error
  *
  */
 int pthread_setname_np(pthread_t thread, const char *name);
@@ -508,7 +508,7 @@ int pthread_setname_np(pthread_t thread, const char *name);
  * @retval 0 Success
  * @retval ESRCH Thread does not exist
  * @retval EINVAL Name buffer is NULL
- * @retval Negative value if kernel function error
+ * @retval <0 negative value if kernel function error
  */
 int pthread_getname_np(pthread_t thread, char *name, size_t len);
 

--- a/include/zephyr/retention/blinfo.h
+++ b/include/zephyr/retention/blinfo.h
@@ -41,7 +41,7 @@ extern "C" {
  * @param val		Where the return information will be placed.
  * @param val_len_max	The maximum size of the provided buffer.
  *
- * @retval >= 0		If successful (contains length of read value)
+ * @retval >=0		If successful (contains length of read value)
  * @retval -EOVERFLOW	If the data is too large to fit the supplied buffer.
  * @retval -EIO		If the requested key was not found.
  * @retval -errno	Error code.

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -1049,7 +1049,7 @@ static inline uint32_t rtio_sqe_acquirable(struct rtio *r)
  * @param iodev_sqe Submission queue entry
  *
  * @retval NULL if current sqe is last in transaction
- * @retval struct rtio_sqe * if available
+ * @return struct rtio_sqe * if available
  */
 static inline struct rtio_iodev_sqe *rtio_txn_next(const struct rtio_iodev_sqe *iodev_sqe)
 {
@@ -1067,7 +1067,7 @@ static inline struct rtio_iodev_sqe *rtio_txn_next(const struct rtio_iodev_sqe *
  * @param iodev_sqe Submission queue entry
  *
  * @retval NULL if current sqe is last in chain
- * @retval struct rtio_sqe * if available
+ * @return struct rtio_sqe * if available
  */
 static inline struct rtio_iodev_sqe *rtio_chain_next(const struct rtio_iodev_sqe *iodev_sqe)
 {
@@ -1084,7 +1084,7 @@ static inline struct rtio_iodev_sqe *rtio_chain_next(const struct rtio_iodev_sqe
  * @param iodev_sqe Submission queue entry
  *
  * @retval NULL if current sqe is last in chain
- * @retval struct rtio_iodev_sqe * if available
+ * @return struct rtio_iodev_sqe * if available
  */
 static inline struct rtio_iodev_sqe *rtio_iodev_sqe_next(const struct rtio_iodev_sqe *iodev_sqe)
 {

--- a/include/zephyr/settings/settings.h
+++ b/include/zephyr/settings/settings.h
@@ -682,9 +682,9 @@ int settings_runtime_commit(const char *name);
  * It might pointer to: `struct nvs_fs`, `struct fcb` or string witch file name
  * depends on settings backend type used.
  *
- * @retval Pointer to which reference to the storage object can be stored.
+ * @return Pointer to which reference to the storage object can be stored.
  *
- * @retval 0 on success, negative error code on failure.
+ * @return 0 on success, negative error code on failure.
  */
 int settings_storage_get(void **storage);
 

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -1383,7 +1383,7 @@ bool shell_ready(const struct shell *sh);
  * @param[in] sh	Pointer to the shell instance.
  * @param[in] val	Insert mode.
  *
- * @retval 0 or 1: previous value
+ * @return 0 or 1: previous value
  * @retval -EINVAL if shell is NULL.
  */
 int shell_insert_mode_set(const struct shell *sh, bool val);
@@ -1396,7 +1396,7 @@ int shell_insert_mode_set(const struct shell *sh, bool val);
  * @param[in] sh	Pointer to the shell instance.
  * @param[in] val	Color mode.
  *
- * @retval 0 or 1: previous value
+ * @return 0 or 1: previous value
  * @retval -EINVAL if shell is NULL.
  */
 int shell_use_colors_set(const struct shell *sh, bool val);
@@ -1408,7 +1408,7 @@ int shell_use_colors_set(const struct shell *sh, bool val);
  * @param[in] sh	Pointer to the shell instance.
  * @param[in] val	vt100 mode.
  *
- * @retval 0 or 1: previous value
+ * @return 0 or 1: previous value
  * @retval -EINVAL if shell is NULL.
  */
 int shell_use_vt100_set(const struct shell *sh, bool val);
@@ -1420,7 +1420,7 @@ int shell_use_vt100_set(const struct shell *sh, bool val);
  * @param[in] sh	Pointer to the shell instance.
  * @param[in] val	Echo mode.
  *
- * @retval 0 or 1: previous value
+ * @return 0 or 1: previous value
  * @retval -EINVAL if shell is NULL.
  */
 int shell_echo_set(const struct shell *sh, bool val);
@@ -1433,7 +1433,7 @@ int shell_echo_set(const struct shell *sh, bool val);
  * @param[in] sh	Pointer to the shell instance.
  * @param[in] obscure	Obscure mode.
  *
- * @retval 0 or 1: previous value.
+ * @return 0 or 1: previous value.
  * @retval -EINVAL if shell is NULL.
  */
 int shell_obscure_set(const struct shell *sh, bool obscure);
@@ -1446,7 +1446,7 @@ int shell_obscure_set(const struct shell *sh, bool obscure);
  * @param[in] sh	Pointer to the shell instance.
  * @param[in] val	Delete mode.
  *
- * @retval 0 or 1: previous value
+ * @return 0 or 1: previous value
  * @retval -EINVAL if shell is NULL.
  */
 int shell_mode_delete_set(const struct shell *sh, bool val);
@@ -1456,7 +1456,7 @@ int shell_mode_delete_set(const struct shell *sh, bool val);
  *
  * @param[in] sh Pointer to the shell instance
  *
- * @retval return value of previous command
+ * @return return value of previous command
  */
 int shell_get_return_value(const struct shell *sh);
 

--- a/include/zephyr/shell/shell_backend.h
+++ b/include/zephyr/shell/shell_backend.h
@@ -50,7 +50,7 @@ static inline int shell_backend_count_get(void)
  *
  * @param[in] backend_name Name of the backend as defined by the SHELL_DEFINE.
  *
- * @retval Pointer to the backend instance if found, NULL if backend is not found.
+ * @return Pointer to the backend instance if found, NULL if backend is not found.
  */
 const struct shell *shell_backend_get_by_name(const char *backend_name);
 

--- a/include/zephyr/sip_svc/sip_svc.h
+++ b/include/zephyr/sip_svc/sip_svc.h
@@ -127,7 +127,7 @@ int sip_svc_open(void *ctrl, uint32_t c_token, k_timeout_t k_timeout);
  * @param c_token Client's token
  * @param pre_close_req pre close request sent to lower layer on channel close.
  *
- * @retval 0 on success, negative errno on failure.
+ * @return 0 on success, negative errno on failure.
  * @retval -EINVAL invalid arguments.
  * @retval -ENOTSUP error on sending pre_close_request.
  * @retval -EPROTO client is not in OPEN state.
@@ -149,7 +149,7 @@ int sip_svc_close(void *ctrl, uint32_t c_token, struct sip_svc_request *pre_clos
  * @param cb Callback. SMC/SVC return value will be passed to client via
  *           context in struct sip_svc_response format in callback.
  *
- * @retval transaction id on success.
+ * @return transaction id on success.
  * @retval -EINVAL invalid arguments.
  * @retval -EOPNOTSUPP invalid command id or function id.
  * @retval -ESRCH invalid client state.
@@ -170,7 +170,7 @@ int sip_svc_send(void *ctrl, uint32_t c_token, struct sip_svc_request *req, sip_
  * @param ctrl Pointer to controller instance which provides ARM SiP service.
  * @param c_token Client's token
  *
- * @retval Address pointer to the client private data.
+ * @return Address pointer to the client private data.
  * @retval NULL invalid arguments and failure to get lock.
  */
 void *sip_svc_get_priv_data(void *ctrl, uint32_t c_token);
@@ -180,7 +180,7 @@ void *sip_svc_get_priv_data(void *ctrl, uint32_t c_token);
  *
  * @param method Pointer to controller instance which provides ARM SiP service.
  *
- * @retval Valid pointer.
+ * @return Valid pointer.
  * @retval NULL invalid arguments and on providing unsupported method name.
  */
 void *sip_svc_get_controller(char *method);

--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -420,7 +420,7 @@ typedef int (*cbvprintf_external_formatter_func)(cbprintf_cb out, void *ctx,
  * @param ... arguments corresponding to the conversion specifications found
  * within @p format.
  *
- * @retval nonegative the number of bytes successfully stored at @p packaged.
+ * @retval >=0 the number of bytes successfully stored at @p packaged.
  * This will not exceed @p len.
  * @retval -EINVAL if @p format is not acceptable
  * @retval -EFAULT if @p packaged alignment is not acceptable
@@ -462,7 +462,7 @@ int cbprintf_package(void *packaged,
  * @param ap captured stack arguments corresponding to the conversion
  * specifications found within @p format.
  *
- * @retval nonegative the number of bytes successfully stored at @p packaged.
+ * @retval >=0 the number of bytes successfully stored at @p packaged.
  * This will not exceed @p len.
  * @retval -EINVAL if @p format is not acceptable
  * @retval -ENOSPC if @p packaged was not null and the space required to store
@@ -505,7 +505,7 @@ int cbvprintf_package(void *packaged,
  *
  * @param strl_len Number of elements in @p strl array.
  *
- * @retval Positive output package size.
+ * @retval >=0 output package size.
  * @retval -ENOSPC if @p packaged was not null and the space required to store
  * exceed @p len.
  */
@@ -569,7 +569,7 @@ static inline int z_cbprintf_cpy(const void *buf, size_t len, void *ctx)
  *
  * @param strl_len Number of elements in @p strl array.
  *
- * @retval Positive Output package size.
+ * @retval >=0 Output package size.
  * @retval -ENOSPC if @p packaged was not null and the space required to store
  * exceed @p len.
  */
@@ -615,7 +615,7 @@ static inline int cbprintf_package_copy(void *in_packaged,
  * @param len must be set to the number of bytes available at @p packaged. Not
  * used if @p packaged is null.
  *
- * @retval nonegative the number of bytes successfully stored at @p packaged.
+ * @retval >=0 the number of bytes successfully stored at @p packaged.
  * This will not exceed @p len. If @p packaged is null, calculated length.
  * @retval -ENOSPC if @p packaged was not null and the space required to store
  * exceed @p len.

--- a/include/zephyr/sys/clock.h
+++ b/include/zephyr/sys/clock.h
@@ -260,7 +260,7 @@ typedef struct {
  *
  * @param timeout Timeout value relative to current time (may also be
  *                `K_FOREVER` or `K_NO_WAIT`).
- * @retval Timepoint value corresponding to given timeout
+ * @return Timepoint value corresponding to given timeout
  *
  * @see sys_timepoint_timeout()
  * @see sys_timepoint_expired()
@@ -276,7 +276,7 @@ k_timepoint_t sys_timepoint_calc(k_timeout_t timeout);
  * `K_FOREVER` is returned.
  *
  * @param timepoint Timepoint for which a timeout value is wanted.
- * @retval Corresponding timeout value.
+ * @return Corresponding timeout value.
  *
  * @see sys_timepoint_calc()
  */

--- a/include/zephyr/sys/cpu_load.h
+++ b/include/zephyr/sys/cpu_load.h
@@ -30,7 +30,7 @@ extern "C" {
  *
  * @param cpu_id The ID of the CPU for which to get the load.
  *
- * @retval CPU load in percent (0-100) in case of success
+ * @return CPU load in percent (0-100) in case of success
  * @retval -errno code in case of failure.
  *
  */

--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -236,7 +236,7 @@ struct z_device_mmio_rom {
  * be used in this case.
  *
  * @param dev device instance object
- * @retval struct device_mmio_rom * pointer to storage location
+ * @return struct device_mmio_rom * pointer to storage location
  */
 #define DEVICE_MMIO_ROM_PTR(dev) \
 	((struct z_device_mmio_rom *)((dev)->config))
@@ -430,7 +430,7 @@ struct z_device_mmio_rom {
  *
  * @param dev device instance object
  * @param name Member name within config
- * @retval struct device_mmio_rom * pointer to storage location
+ * @return struct device_mmio_rom * pointer to storage location
  */
 #define DEVICE_MMIO_NAMED_ROM_PTR(dev, name) (&(DEV_CFG(dev)->name))
 
@@ -686,7 +686,7 @@ struct z_device_mmio_rom {
  * Return a pointer to the ROM-based storage area for a toplevel MMIO region.
  *
  * @param name MMIO region name
- * @retval struct device_mmio_rom * pointer to storage location
+ * @return struct device_mmio_rom * pointer to storage location
  */
 #define DEVICE_MMIO_TOPLEVEL_ROM_PTR(name) &Z_TOPLEVEL_ROM_NAME(name)
 

--- a/include/zephyr/sys/onoff.h
+++ b/include/zephyr/sys/onoff.h
@@ -338,7 +338,7 @@ static inline bool onoff_has_error(const struct onoff_manager *mgr)
  * passes a pointer object associated with an incomplete service
  * operation.
  *
- * @retval non-negative the observed state of the machine at the time
+ * @retval >=0 the observed state of the machine at the time
  * the request was processed, if successful.
  * @retval -EIO if service has recorded an error.
  * @retval -EINVAL if the parameters are invalid.
@@ -359,7 +359,7 @@ int onoff_request(struct onoff_manager *mgr,
  *
  * @param mgr the manager for which a request was successful.
  *
- * @retval non-negative the observed state (ONOFF_STATE_ON) of the
+ * @retval >=0 the observed state (ONOFF_STATE_ON) of the
  * machine at the time of the release, if the release succeeds.
  * @retval -EIO if service has recorded an error.
  * @retval -ENOTSUP if the machine is not in a state that permits
@@ -389,7 +389,7 @@ int onoff_release(struct onoff_manager *mgr);
  * @param cli a pointer to the same client state that was provided
  * when the operation to be cancelled was issued.
  *
- * @retval non-negative the observed state of the machine at the time
+ * @retval >=0 the observed state of the machine at the time
  * of the cancellation, if the cancellation succeeds.  On successful
  * cancellation ownership of @c *cli reverts to the client.
  * @retval -EINVAL if the parameters are invalid.
@@ -430,7 +430,7 @@ int onoff_cancel(struct onoff_manager *mgr,
  *
  * @retval -EINVAL if the parameters are invalid.
  *
- * @retval negative other errors produced by onoff_release().
+ * @retval <0 other errors produced by onoff_release().
  */
 static inline int onoff_cancel_or_release(struct onoff_manager *mgr,
 					  struct onoff_client *cli)
@@ -472,7 +472,7 @@ static inline int onoff_cancel_or_release(struct onoff_manager *mgr,
  * if cli references an object associated with an incomplete service
  * operation.
  *
- * @retval non-negative the observed state of the machine at the time
+ * @retval >=0 the observed state of the machine at the time
  * of the reset, if the reset succeeds.
  * @retval -ENOTSUP if reset is not supported by the service.
  * @retval -EINVAL if the parameters are invalid.

--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -354,7 +354,7 @@ static inline int ring_buf_put_finish(struct ring_buf *buf, uint32_t size)
  * @param data Address of data.
  * @param size Data size (in bytes).
  *
- * @retval Number of bytes written.
+ * @return Number of bytes written.
  */
 uint32_t ring_buf_put(struct ring_buf *buf, const uint8_t *data, uint32_t size);
 
@@ -436,7 +436,7 @@ static inline int ring_buf_get_finish(struct ring_buf *buf, uint32_t size)
  * @param data Address of the output buffer. Can be NULL to discard data.
  * @param size Data size (in bytes).
  *
- * @retval Number of bytes written to the output buffer.
+ * @return Number of bytes written to the output buffer.
  */
 uint32_t ring_buf_get(struct ring_buf *buf, uint8_t *data, uint32_t size);
 
@@ -464,7 +464,7 @@ uint32_t ring_buf_get(struct ring_buf *buf, uint8_t *data, uint32_t size);
  * @param data Address of the output buffer. Cannot be NULL.
  * @param size Data size (in bytes).
  *
- * @retval Number of bytes written to the output buffer.
+ * @return Number of bytes written to the output buffer.
  */
 uint32_t ring_buf_peek(struct ring_buf *buf, uint8_t *data, uint32_t size);
 

--- a/include/zephyr/sys/spsc_pbuf.h
+++ b/include/zephyr/sys/spsc_pbuf.h
@@ -140,7 +140,7 @@ static inline uint32_t spsc_pbuf_capacity(struct spsc_pbuf *pb)
  *				bytes of data (one is reserved for written
  *				messages length).
  * @param flags			Option flags. See @ref SPSC_PBUF_FLAGS.
- * @retval struct spsc_pbuf*	Pointer to the created buffer. The pointer
+ * @return struct spsc_pbuf*	Pointer to the created buffer. The pointer
  *				points to the same address as buf.
  * @retval NULL			Invalid buffer alignment.
  */
@@ -186,7 +186,7 @@ int spsc_pbuf_write(struct spsc_pbuf *pb, const char *buf, uint16_t len);
  *			buffer without applying wrap padding is performed.
  * @param[out] buf	Location where buffer address is written on successful allocation.
  *
- * @retval non-negative Amount of space that got allocated. Can be equal or smaller than %p len.
+ * @return non-negative amount of space that got allocated. Can be equal or smaller than %p len.
  * @retval -EINVAL if @p len is forbidden.
  */
 int spsc_pbuf_alloc(struct spsc_pbuf *pb, uint16_t len, char **buf);
@@ -236,7 +236,7 @@ int spsc_pbuf_read(struct spsc_pbuf *pb, char *buf, uint16_t len);
  *                      It is 32 bit word aligned and points to the continuous memory.
  *
  * @retval 0 No packets in the buffer.
- * @retval positive packet length.
+ * @return positive packet length.
  */
 uint16_t spsc_pbuf_claim(struct spsc_pbuf *pb, char **buf);
 
@@ -259,7 +259,7 @@ void spsc_pbuf_free(struct spsc_pbuf *pb, uint16_t len);
  * @param pb	A packet buffer.
  *
  * @retval -ENOTSUP	Feature not enabled.
- * @retval non-negative	Maximum utilization.
+ * @return non-negative	Maximum utilization.
  */
 int spsc_pbuf_get_utilization(struct spsc_pbuf *pb);
 /**

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -645,7 +645,7 @@ extern "C" {
  * @param[in] first_match If true returns when first match is found, else returns the best fit.
  *
  * @retval -1 Contiguous bits not found.
- * @retval non-negative Starting index of the bits group.
+ * @retval >=0 Starting index of the bits group.
  */
 int bitmask_find_gap(uint32_t mask, size_t num_bits, size_t total_bits, bool first_match);
 
@@ -1086,7 +1086,7 @@ static inline size_t sys_count_bits(const void *value, size_t len)
  * @param delay_stmt Delay statement to perform each poll iteration
  *                   e.g.: NULL, k_yield(), k_msleep(1) or k_busy_wait(1)
  *
- * @retval expr As a boolean return, if false then it has timed out.
+ * @return expr As a boolean return, if false then it has timed out.
  */
 #define WAIT_FOR(expr, timeout, delay_stmt)                                                        \
 	({                                                                                         \

--- a/include/zephyr/usb_c/usbc.h
+++ b/include/zephyr/usb_c/usbc.h
@@ -374,7 +374,7 @@ void usbc_set_dpm_data(const struct device *dev, void *dpm_data);
  *
  * @param dev Runtime device structure
  *
- * @retval pointer to dpm data that was set with usbc_set_dpm_data
+ * @return pointer to dpm data that was set with usbc_set_dpm_data
  * @retval NULL if dpm data was not set
  */
 void *usbc_get_dpm_data(const struct device *dev);


### PR DESCRIPTION
Fix how Doxygen special command \retval is used in APIs doc text.

\retval: Starts a description for a function's return value with name `<return value>`, which needs to be attached and to not be a word that is part of the sentence, and each return value should have its own \retval.
Otherwise \retval is replaced with \return.

See https://www.doxygen.nl/manual/commands.html#cmdreturn
https://www.doxygen.nl/manual/commands.html#cmdretval
https://docs.rtems.org/docs/main/eng/coding-doxygen.html 

Doc preview https://builds.zephyrproject.io/zephyr/pr/98324/docs/doxygen/html/topics.html 