### PR TITLE
tracing: ctf: Fix arguments for socket tracing functions (again)

### DIFF
--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -1010,7 +1010,7 @@ void sys_trace_socket_accept_enter(int sock)
 	ctf_top_socket_accept_enter(sock);
 }
 
-void sys_trace_socket_accept_exit(int sock, const struct sockaddr *addr, const size_t *addrlen,
+void sys_trace_socket_accept_exit(int sock, const struct sockaddr *addr, const uint32_t *addrlen,
 				  int ret)
 {
 	ctf_net_bounded_string_t addr_str = {"unknown"};


### PR DESCRIPTION
Zephyr's socklen_t was changed in
c546c1cad1f86977dbf3fb3354469db9cda926aa
to be uint32_t instea of size_t.
Let's fix accordingly the prototypes which expect it.

Note this was already fixed in
37ff1b254fdf84c5fd9787cd2223342d7bfb1931
But it was reverted in
d849ab12639e9faf754f38fc2bd7315c31fd2fad

Fails in main:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/18811754455/job/53673945528#step:14:3521