### PR TITLE
tests: i2c_ram: Fix assert message

### DIFF
--- a/tests/drivers/i2c/i2c_ram/src/test_i2c_ram.c
+++ b/tests/drivers/i2c/i2c_ram/src/test_i2c_ram.c
@@ -202,7 +202,7 @@ static void check_completion(struct rtio_cqe *cqe, const char *msg)
 	result = cqe->result;
 	rtio_cqe_release(&i2c_rtio, cqe);
 	if (result) {
-		zassert_ok(result, msg);
+		zassert_ok(result, "%s", msg);
 	}
 }
 


### PR DESCRIPTION
Being pedantic, the second parameter to zassert_ok() is supposed to be a literal format specifier string. (Just as for printf()). Not directly a variable string to be printed. Let's fix it.

Fixes this build warning:
`warning: format not a string literal and no format arguments`

Fails in main:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/18811754455/job/53673945512#step:14:1860

Can be repro'd with 
`build$ cmake -GNinja -DBOARD=nrf52840dk/nrf52840 ../tests/drivers/i2c/i2c_ram -DCONFIG_I2C_RTIO=y && ninja`
