### PR TITLE
samples: subsys: usb: uvc: fix undefined node label 'csi_interface' build error

### DIFF
--- a/samples/subsys/usb/uvc/sample.yaml
+++ b/samples/subsys/usb/uvc/sample.yaml
@@ -37,6 +37,8 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE="app_h264enc.overlay"
       - SHIELD=st_b_cams_imx_mb1854
     filter: dt_chosen_enabled("zephyr,camera")
+    platform_allow:
+      - stm32n6570_dk/stm32n657xx/sb
     integration_platforms:
       - stm32n6570_dk/stm32n657xx/sb
   sample.subsys.usb.uvc.encoder.jpeg:
@@ -49,5 +51,7 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE="app_jpegenc.overlay"
       - SHIELD=st_b_cams_imx_mb1854
     filter: dt_chosen_enabled("zephyr,camera")
+    platform_allow:
+      - stm32n6570_dk/stm32n657xx/sb
     integration_platforms:
       - stm32n6570_dk/stm32n657xx/sb


### PR DESCRIPTION
After the addition of https://github.com/zephyrproject-rtos/zephyr/pull/97425  

The following build error occurs:
```
devicetree error: zephyrproject/zephyr/boards/shields/st_b_cams_imx_mb1854/st_b_cams_imx_mb1854.overlay:23 (column 1): parse error: undefined node label 'csi_interface' 

CMake Error at cmake/modules/dts.cmake:306 (execute_process): 

execute_process failed command indexes: 
```
All boards that have usbd support present in <board_name>.yaml will attempt to run sample scenarios  `sample.subsys.usb.uvc.encoder.h26`4 and  `sample.subsys.usb.uvc.encoder.jpeg` with SHIELD st_b_cams_imx_mb1854 added/combined to it even if there is a no dcmipp node  in dts which I believe causes this error.  


**Non-exhaustive list of affected boards:**  
b_u585i_iot02a, disco_l475_iot1, nucleo_c071rb, nucleo_f207zg, nucleo_f429zi , nucleo_u385rg_q, nucleo_wb55rg, stm32h573i_dk , stm32h7s78_dk
                                                                                                                          
                                                                                                                         
                                                                                                                          
                                                                                                                          
                                                                                                                         