### PR TITLE
bluetooth: mesh: extend oob authentication size till 32 bytes

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/provisioning.rst
+++ b/doc/connectivity/bluetooth/api/mesh/provisioning.rst
@@ -144,7 +144,7 @@ sequence should be repeated after a delay of three seconds or more.
 When an Input OOB action is selected, the user should be prompted when the
 application receives the :c:member:`bt_mesh_prov.input` callback. The user
 response should be fed back to the Provisioning API through
-:c:func:`bt_mesh_input_string` or :c:func:`bt_mesh_input_number`. If
+:c:func:`bt_mesh_input_string` or :c:func:`bt_mesh_input_numeric`. If
 no user response is recorded within 60 seconds, the Provisioning process is
 aborted.
 

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -53,6 +53,15 @@ Removed APIs and options
 Deprecated APIs and options
 ===========================
 
+* Bluetooth
+
+  * Mesh
+
+    * The function :c:func:`bt_mesh_input_number` was deprecated. Applications should use
+      :c:func:`bt_mesh_input_numeric` instead.
+    * The callback :c:member:`output_number` in :c:struct:`bt_mesh_prov` structure was deprecated.
+      Applications should use :c:member:`output_numeric` callback instead.
+
 New APIs and options
 ====================
 
@@ -71,6 +80,12 @@ New APIs and options
 .. zephyr-keep-sorted-start re(^\* \w)
 
 * Bluetooth
+
+  * Mesh
+
+    * :c:func:`bt_mesh_input_numeric` to provide provisioning numeric input OOB value.
+    * :c:member:`output_numeric` callback in :c:struct:`bt_mesh_prov` structure to
+      output numeric values during provisioning.
 
   * Services
 

--- a/include/zephyr/bluetooth/mesh/main.h
+++ b/include/zephyr/bluetooth/mesh/main.h
@@ -173,6 +173,7 @@ struct bt_mesh_prov {
 	 */
 	void         (*capabilities)(const struct bt_mesh_dev_capabilities *cap);
 
+#if defined CONFIG_BT_MESH_PROV_OOB_API_LEGACY
 	/** @brief Output of a number is requested.
 	 *
 	 *  This callback notifies the application that it should
@@ -183,7 +184,21 @@ struct bt_mesh_prov {
 	 *
 	 *  @return Zero on success or negative error code otherwise
 	 */
-	int         (*output_number)(bt_mesh_output_action_t act, uint32_t num);
+	int         (*output_number)(bt_mesh_output_action_t act, uint32_t num) __deprecated;
+#else
+	/** @brief Output of a numeric value is requested.
+	 *
+	 *  This callback notifies the application that it should
+	 *  output the given numeric value using the given action.
+	 *
+	 *  @param act Action for outputting the numeric value.
+	 *  @param numeric memory with numeric value in the little endian format to be outputted.
+	 *  @param size size of the numeric value in bytes.
+	 *
+	 *  @return Zero on success or negative error code otherwise
+	 */
+	int         (*output_numeric)(bt_mesh_output_action_t act, uint8_t *numeric, size_t size);
+#endif
 
 	/** @brief Output of a string is requested.
 	 *
@@ -202,7 +217,7 @@ struct bt_mesh_prov {
 	 *  request input from the user using the given action. The
 	 *  requested input will either be a string or a number, and
 	 *  the application needs to consequently call the
-	 *  bt_mesh_input_string() or bt_mesh_input_number() functions
+	 *  bt_mesh_input_string() or bt_mesh_input_numeric() functions
 	 *  once the data has been acquired from the user.
 	 *
 	 *  @param act Action for inputting data.
@@ -313,7 +328,7 @@ struct bt_mesh_rpr_node;
 
 /** @brief Provide provisioning input OOB string.
  *
- *  This is intended to be called after the bt_mesh_prov input callback
+ *  This is intended to be called after the @ref bt_mesh_prov::input callback
  *  has been called with BT_MESH_ENTER_STRING as the action.
  *
  *  @param str String.
@@ -322,16 +337,30 @@ struct bt_mesh_rpr_node;
  */
 int bt_mesh_input_string(const char *str);
 
+#if defined CONFIG_BT_MESH_PROV_OOB_API_LEGACY
 /** @brief Provide provisioning input OOB number.
  *
- *  This is intended to be called after the bt_mesh_prov input callback
- *  has been called with BT_MESH_ENTER_NUMBER as the action.
+ *  This is intended to be called after the @ref bt_mesh_prov::input callback
+ *  has been called with @ref BT_MESH_ENTER_NUMBER as the action.
  *
  *  @param num Number.
  *
  *  @return Zero on success or (negative) error code otherwise.
  */
-int bt_mesh_input_number(uint32_t num);
+__deprecated int bt_mesh_input_number(uint32_t num);
+#endif
+
+/** @brief Provide provisioning input OOB numeric value.
+ *
+ *  This is intended to be called after the @ref bt_mesh_prov::input callback
+ *  has been called with @ref BT_MESH_ENTER_NUMBER as the action.
+ *
+ *  @param numeric Pointer to the numeric value in little endian.
+ *  @param size Size of the numeric value in bytes (this is not OOB size).
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int bt_mesh_input_numeric(uint8_t *numeric, size_t size);
 
 /** @brief Provide Device public key.
  *
@@ -347,7 +376,7 @@ int bt_mesh_prov_remote_pub_key_set(const uint8_t public_key[64]);
  *
  *  Instruct the unprovisioned device to use the specified Input OOB
  *  authentication action. When using @ref BT_MESH_PUSH, @ref BT_MESH_TWIST or
- *  @ref BT_MESH_ENTER_NUMBER, the @ref bt_mesh_prov::output_number callback is
+ *  @ref BT_MESH_ENTER_NUMBER, the @ref bt_mesh_prov::output_numeric callback is
  *  called with a random number that has to be entered on the unprovisioned
  *  device.
  *
@@ -372,7 +401,7 @@ int bt_mesh_auth_method_set_input(bt_mesh_input_action_t action, uint8_t size);
  *
  *  When using @ref BT_MESH_BLINK, @ref BT_MESH_BEEP, @ref BT_MESH_VIBRATE
  *  or @ref BT_MESH_DISPLAY_NUMBER, and the application has to call
- *  @ref bt_mesh_input_number with the random number indicated by
+ *  @ref bt_mesh_input_numeric with the random number indicated by
  *  the unprovisioned device.
  *
  *  When using @ref BT_MESH_DISPLAY_STRING, the application has to call

--- a/samples/bluetooth/mesh/src/main.c
+++ b/samples/bluetooth/mesh/src/main.c
@@ -267,9 +267,16 @@ static const struct bt_mesh_comp comp = {
 };
 
 /* Provisioning */
-
-static int output_number(bt_mesh_output_action_t action, uint32_t number)
+static int output_numeric(bt_mesh_output_action_t action, uint8_t *numeric, size_t size)
 {
+	uint32_t number;
+
+	if (size != sizeof(number)) {
+		printk("Wrong OOB size: %u\n", size);
+		return -EINVAL;
+	}
+
+	number = sys_get_le32(numeric);
 	printk("OOB Number: %u\n", number);
 
 	board_output_number(action, number);
@@ -293,7 +300,7 @@ static const struct bt_mesh_prov prov = {
 	.uuid = dev_uuid,
 	.output_size = 4,
 	.output_actions = BT_MESH_DISPLAY_NUMBER,
-	.output_number = output_number,
+	.output_numeric = output_numeric,
 	.complete = prov_complete,
 	.reset = prov_reset,
 };

--- a/samples/boards/nordic/mesh/onoff-app/src/main.c
+++ b/samples/boards/nordic/mesh/onoff-app/src/main.c
@@ -47,6 +47,7 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/mesh.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 /* Model Operation Codes */
 #define BT_MESH_MODEL_OP_GEN_ONOFF_GET		BT_MESH_MODEL_OP_2(0x82, 0x01)
@@ -366,9 +367,13 @@ static int gen_onoff_status(const struct bt_mesh_model *model,
 	return 0;
 }
 
-static int output_number(bt_mesh_output_action_t action, uint32_t number)
+static int output_numeric(bt_mesh_output_action_t action, uint8_t *numeric, size_t size)
 {
-	printk("OOB Number %06u\n", number);
+	uint64_t number = 0ull;
+
+	sys_get_le(&number, numeric, size);
+
+	printk("OOB Number %06" PRIu64 "\n", number);
 	return 0;
 }
 
@@ -525,7 +530,7 @@ static const struct bt_mesh_prov prov = {
 #if 1
 	.output_size = 6,
 	.output_actions = (BT_MESH_DISPLAY_NUMBER | BT_MESH_DISPLAY_STRING),
-	.output_number = output_number,
+	.output_numeric = output_numeric,
 	.output_string = output_string,
 #else
 	.output_size = 0,

--- a/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/mesh/ble_mesh.c
+++ b/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/mesh/ble_mesh.c
@@ -10,9 +10,13 @@
 
 #ifdef OOB_AUTH_ENABLE
 
-static int output_number(bt_mesh_output_action_t action, uint32_t number)
+static int output_numeric(bt_mesh_output_action_t action, uint8_t *numeric, size_t size)
 {
-	printk("OOB Number: %u\n", number);
+	uint64_t number = 0ull;
+
+	sys_get_le(&number, numeric, size);
+
+	printk("OOB Number %06" PRIu64 "\n", number);
 	return 0;
 }
 
@@ -42,7 +46,7 @@ static const struct bt_mesh_prov prov = {
 
 	.output_size = 6,
 	.output_actions = BT_MESH_DISPLAY_NUMBER | BT_MESH_DISPLAY_STRING,
-	.output_number = output_number,
+	.output_numeric = output_numeric,
 	.output_string = output_string,
 
 #endif

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -361,6 +361,18 @@ config BT_MESH_OOB_AUTH_REQUIRED
 	bool "OOB authentication mandates to use HMAC SHA256"
 	depends on BT_MESH_ECDH_P256_HMAC_SHA256_AES_CCM
 
+config BT_MESH_PROV_OOB_API_LEGACY
+	bool "Reduced maximum OOB authentication size support [DEPRECATED]"
+	select DEPRECATED
+	depends on BT_MESH_PROV
+	help
+	  By default, the maximum OOB authentication size is 32 bytes.
+	  Enable this option to use the legacy API which is only compatible with
+	  specification v1.1 and earlier. This limits OOB authentication to 8
+	  bytes maximum.
+	  This option is intended for backward compatibility.
+	  Not recommended for new designs due to reduced security.
+
 config BT_MESH_PROVISIONER
 	bool "Provisioner support"
 	depends on BT_MESH_CDB

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -72,7 +72,8 @@ if BT_MESH_ADV_LEGACY
 
 config BT_MESH_ADV_STACK_SIZE
 	int "Mesh advertiser thread stack size"
-	default 1024 if BT_HOST_CRYPTO
+	default 1800 if BT_MESH_PROVISIONER
+	default 1536 if BT_MESH_PROXY
 	default 776 if BT_MESH_PRIV_BEACONS
 	default 768
 	help
@@ -142,8 +143,8 @@ if BT_MESH_WORKQ_MESH
 
 config BT_MESH_ADV_STACK_SIZE
 	int "Mesh extended advertiser thread stack size"
+	default 2048 if BT_MESH_PROVISIONER
 	default 1536 if BT_MESH_PROXY
-	default 1024 if BT_HOST_CRYPTO
 	default 776 if BT_MESH_PRIV_BEACONS
 	default 768
 	help

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -28,6 +28,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_prov);
 
+/* 10 power 32 represents 14 bytes maximum in little-endian format */
+#define MAX_NUMERIC_OOB_BYTES 14
+
 struct bt_mesh_prov_link bt_mesh_prov_link;
 const struct bt_mesh_prov *bt_mesh_prov;
 
@@ -122,57 +125,121 @@ static int check_input_auth(bt_mesh_input_action_t input, uint8_t size)
 
 static void get_auth_string(char *str, uint8_t size)
 {
-	uint64_t value;
-
-	bt_rand(&value, sizeof(value));
-
 	static const char characters[36] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
+	bt_rand(str, size);
+
 	for (int i = 0; i < size; i++) {
-		/* pull base-36 digits: */
-		int idx = value % 36;
-
-		value = value / 36;
-		str[i] = characters[idx];
+		str[i] = characters[(uint8_t)str[i] % (uint8_t)36];
 	}
-
-	str[size] = '\0';
 
 	memcpy(bt_mesh_prov_link.auth, str, size);
 	memset(bt_mesh_prov_link.auth + size, 0,
 			sizeof(bt_mesh_prov_link.auth) - size);
 }
 
-static uint32_t get_auth_number(bt_mesh_output_action_t output,
-		bt_mesh_input_action_t input, uint8_t size)
+/* Computes 10^n - 1 in little endian array */
+static void compute_pow10_minus1(uint8_t n, uint8_t *out, size_t *out_len)
 {
-	const uint32_t divider[PROV_IO_OOB_SIZE_MAX] = { 10, 100, 1000, 10000,
-			100000, 1000000, 10000000, 100000000 };
-	uint8_t auth_size = bt_mesh_prov_auth_size_get();
-	uint32_t num = 0;
+	out[0] = 1; /* Start with value 1 at LSB */
+	size_t len = 1;
 
-	bt_rand(&num, sizeof(num));
+	/* Compute 10^n */
+	for (uint8_t i = 0; i < n; ++i) {
+		uint16_t carry = 0;
 
-	if (output == BT_MESH_BLINK || output == BT_MESH_BEEP || output == BT_MESH_VIBRATE ||
-	    input == BT_MESH_PUSH || input == BT_MESH_TWIST) {
-		/* According to MshPRTv1.1: 5.4.2.4, blink, beep vibrate, push and twist should be
-		 * a random integer between 0 and 10^size, *exclusive*:
-		 */
-		num = (num % (divider[size - 1] - 1)) + 1;
-	} else {
-		num %= divider[size - 1];
+		for (size_t j = 0; j < len; ++j) {
+			uint16_t prod = out[j] * 10 + carry;
+
+			out[j] = prod & 0xFF;
+			carry = prod >> 8;
+		}
+
+		if (carry > 0 && len < MAX_NUMERIC_OOB_BYTES) {
+			out[len] = carry;
+			len++;
+		}
 	}
 
-	sys_put_be32(num, &bt_mesh_prov_link.auth[auth_size - sizeof(num)]);
-	memset(bt_mesh_prov_link.auth, 0, auth_size - sizeof(num));
+	/* Subtract 1 from the result (10^n - 1) */
+	size_t j = 0;
 
-	return num;
+	while (j < len) {
+		if (out[j] > 0) {
+			out[j] -= 1;
+			break;
+		}
+		out[j] = 0xFF;
+		j++;
+	}
+
+	/* Adjust length if highest byte becomes 0 */
+	while (len > 1 && out[len - 1] == 0) {
+		len--;
+	}
+
+	*out_len = len;
 }
 
-int bt_mesh_prov_auth(bool is_provisioner, uint8_t method, uint8_t action, uint8_t size)
+static void random_byte_shift(uint8_t max_inclusive, uint8_t *out)
+{
+	if (max_inclusive == 0) {
+		*out = 0;
+		return;
+	}
+
+	while (*out > max_inclusive) {
+		*out >>= 1;
+	}
+}
+
+static void generate_random_below_pow10(uint8_t n, uint8_t *output, size_t *out_len)
+{
+	uint8_t max_val[MAX_NUMERIC_OOB_BYTES] = {0};
+	size_t max_len = 0;
+
+	compute_pow10_minus1(n, max_val, &max_len);
+	bt_rand(output, max_len);
+
+	/* Generate random number less than max_val, starting from MSB in little-endian */
+	for (int i = max_len - 1; i >= 0; --i) {
+		random_byte_shift(max_val[i], &output[i]);
+		if (output[i] < max_val[i]) {
+			break;
+		}
+	}
+
+	/* Ensure the result is not all zero */
+	int all_zero = 1;
+
+	for (size_t i = 0; i < max_len; ++i) {
+		if (output[i] != 0) {
+			all_zero = 0;
+			break;
+		}
+	}
+
+	if (all_zero) {
+		output[0] = 1;
+	}
+
+	*out_len = max_len;
+}
+
+static void get_auth_number(uint8_t *rand_bytes, size_t *size)
+{
+	uint8_t auth_size = bt_mesh_prov_auth_size_get();
+
+	generate_random_below_pow10(*size, rand_bytes, size);
+	sys_memcpy_swap(bt_mesh_prov_link.auth + (auth_size - *size), rand_bytes, *size);
+	memset(bt_mesh_prov_link.auth, 0, auth_size - *size);
+}
+
+int bt_mesh_prov_auth(bool is_provisioner, uint8_t method, uint8_t action, size_t size)
 {
 	bt_mesh_output_action_t output;
 	bt_mesh_input_action_t input;
+	uint8_t rand_bytes[PROV_IO_OOB_SIZE_MAX + 1] = {0};
 	uint8_t auth_size = bt_mesh_prov_auth_size_get();
 	int err;
 
@@ -214,18 +281,22 @@ int bt_mesh_prov_auth(bool is_provisioner, uint8_t method, uint8_t action, uint8
 			return bt_mesh_prov->input(input, size);
 		}
 
+		atomic_set_bit(bt_mesh_prov_link.flags, NOTIFY_INPUT_COMPLETE);
 
 		if (output == BT_MESH_DISPLAY_STRING) {
-			char str[9];
-
-			atomic_set_bit(bt_mesh_prov_link.flags, NOTIFY_INPUT_COMPLETE);
-			get_auth_string(str, size);
-			return bt_mesh_prov->output_string(str);
+			get_auth_string(rand_bytes, MIN(size, auth_size));
+			return bt_mesh_prov->output_string(rand_bytes);
 		}
 
-		atomic_set_bit(bt_mesh_prov_link.flags, NOTIFY_INPUT_COMPLETE);
-		return bt_mesh_prov->output_number(output,
-				get_auth_number(output, BT_MESH_NO_INPUT, size));
+		get_auth_number(rand_bytes, &size);
+#if defined CONFIG_BT_MESH_PROV_OOB_API_LEGACY
+		uint32_t output_num;
+
+		memcpy(&output_num, rand_bytes, sizeof(output_num));
+		return bt_mesh_prov->output_number(output, output_num);
+#else
+		return bt_mesh_prov->output_numeric(output, rand_bytes, size);
+#endif
 
 	case AUTH_METHOD_INPUT:
 		input = input_action(action);
@@ -244,24 +315,30 @@ int bt_mesh_prov_auth(bool is_provisioner, uint8_t method, uint8_t action, uint8
 			return bt_mesh_prov->input(input, size);
 		}
 
-		if (input == BT_MESH_ENTER_STRING) {
-			char str[9];
+		atomic_set_bit(bt_mesh_prov_link.flags, NOTIFY_INPUT_COMPLETE);
 
-			atomic_set_bit(bt_mesh_prov_link.flags, NOTIFY_INPUT_COMPLETE);
-			get_auth_string(str, size);
-			return bt_mesh_prov->output_string(str);
+		if (input == BT_MESH_ENTER_STRING) {
+			get_auth_string(rand_bytes, MIN(size, auth_size));
+			return bt_mesh_prov->output_string(rand_bytes);
 		}
 
-		atomic_set_bit(bt_mesh_prov_link.flags, NOTIFY_INPUT_COMPLETE);
+		get_auth_number(rand_bytes, &size);
 		output = BT_MESH_DISPLAY_NUMBER;
-		return bt_mesh_prov->output_number(output,
-				get_auth_number(BT_MESH_NO_OUTPUT, input, size));
+#if defined CONFIG_BT_MESH_PROV_OOB_API_LEGACY
+		uint32_t input_num;
+
+		memcpy(&input_num, rand_bytes, sizeof(input_num));
+		return bt_mesh_prov->output_number(output, input_num);
+#else
+		return bt_mesh_prov->output_numeric(output, rand_bytes, size);
+#endif
 
 	default:
 		return -EINVAL;
 	}
 }
 
+#if defined CONFIG_BT_MESH_PROV_OOB_API_LEGACY
 int bt_mesh_input_number(uint32_t num)
 {
 	uint8_t auth_size = bt_mesh_prov_auth_size_get();
@@ -278,13 +355,37 @@ int bt_mesh_input_number(uint32_t num)
 
 	return 0;
 }
+#endif
+
+int bt_mesh_input_numeric(uint8_t *numeric, size_t size)
+{
+	uint8_t auth_size = bt_mesh_prov_auth_size_get();
+
+	LOG_HEXDUMP_DBG(numeric, size, "");
+
+	if (size > MAX_NUMERIC_OOB_BYTES) {
+		return -ENOTSUP;
+	}
+
+	if (!atomic_test_and_clear_bit(bt_mesh_prov_link.flags, WAIT_NUMBER)) {
+		return -EINVAL;
+	}
+
+	sys_memcpy_swap(bt_mesh_prov_link.auth + (auth_size - size), numeric, size);
+	memset(bt_mesh_prov_link.auth, 0, auth_size - size);
+
+	bt_mesh_prov_link.role->input_complete();
+
+	return 0;
+}
 
 int bt_mesh_input_string(const char *str)
 {
+	size_t size = strlen(str);
+
 	LOG_DBG("%s", str);
 
-	if (strlen(str) > PROV_IO_OOB_SIZE_MAX ||
-			strlen(str) > bt_mesh_prov_link.oob_size) {
+	if (size > PROV_IO_OOB_SIZE_MAX || size > bt_mesh_prov_link.oob_size) {
 		return -ENOTSUP;
 	}
 
@@ -292,7 +393,7 @@ int bt_mesh_input_string(const char *str)
 		return -EINVAL;
 	}
 
-	memcpy(bt_mesh_prov_link.auth, str, strlen(str));
+	memcpy(bt_mesh_prov_link.auth, str, size);
 	memset(bt_mesh_prov_link.auth + size, 0, sizeof(bt_mesh_prov_link.auth) - size);
 
 	bt_mesh_prov_link.role->input_complete();

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -293,6 +293,7 @@ int bt_mesh_input_string(const char *str)
 	}
 
 	memcpy(bt_mesh_prov_link.auth, str, strlen(str));
+	memset(bt_mesh_prov_link.auth + size, 0, sizeof(bt_mesh_prov_link.auth) - size);
 
 	bt_mesh_prov_link.role->input_complete();
 

--- a/subsys/bluetooth/mesh/prov.h
+++ b/subsys/bluetooth/mesh/prov.h
@@ -164,10 +164,14 @@ static inline void bt_mesh_prov_buf_init(struct net_buf_simple *buf, uint8_t typ
 	net_buf_simple_add_u8(buf, type);
 }
 
-
 static inline uint8_t bt_mesh_prov_auth_size_get(void)
 {
-	return bt_mesh_prov_link.algorithm == BT_MESH_PROV_AUTH_CMAC_AES128_AES_CCM ? 16 : 32;
+	if (IS_ENABLED(CONFIG_BT_MESH_ECDH_P256_HMAC_SHA256_AES_CCM)) {
+		return bt_mesh_prov_link.algorithm == BT_MESH_PROV_AUTH_CMAC_AES128_AES_CCM ? 16
+											    : 32;
+	} else {
+		return 16;
+	}
 }
 
 static inline k_timeout_t bt_mesh_prov_protocol_timeout_get(void)

--- a/subsys/bluetooth/mesh/prov.h
+++ b/subsys/bluetooth/mesh/prov.h
@@ -68,7 +68,11 @@
 
 #define PROV_ALG_P256          0x00
 
+#if defined CONFIG_BT_MESH_PROV_OOB_API_LEGACY
 #define PROV_IO_OOB_SIZE_MAX   8  /* in bytes */
+#else
+#define PROV_IO_OOB_SIZE_MAX   32  /* in bytes */
+#endif
 
 #define PRIV_KEY_SIZE 32
 #define PUB_KEY_SIZE  PDU_LEN_PUB_KEY
@@ -186,7 +190,7 @@ int bt_mesh_prov_reset_state(void);
 
 bool bt_mesh_prov_active(void);
 
-int bt_mesh_prov_auth(bool is_provisioner, uint8_t method, uint8_t action, uint8_t size);
+int bt_mesh_prov_auth(bool is_provisioner, uint8_t method, uint8_t action, size_t size);
 
 int bt_mesh_pb_remote_open(struct bt_mesh_rpr_cli *cli,
 			   const struct bt_mesh_rpr_node *srv, const uint8_t uuid[16],

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -172,8 +172,12 @@ static bool prov_check_method(struct bt_mesh_dev_capabilities *caps)
 				return false;
 			}
 		} else {
+#if defined CONFIG_BT_MESH_PROV_OOB_API_LEGACY
 			if (!bt_mesh_prov->output_number) {
-				LOG_WRN("Not support output number");
+#else
+			if (!bt_mesh_prov->output_numeric) {
+#endif
+				LOG_WRN("Not support output numeric");
 				return false;
 			}
 		}

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -1175,9 +1175,17 @@ static void link_close(bt_mesh_prov_bearer_t bearer)
 	tester_event(BTP_SERVICE_ID_MESH, BTP_MESH_EV_PROV_LINK_CLOSED, &ev, sizeof(ev));
 }
 
-static int output_number(bt_mesh_output_action_t action, uint32_t number)
+static int output_numeric(bt_mesh_output_action_t action, uint8_t *numeric, size_t size)
 {
 	struct btp_mesh_out_number_action_ev ev;
+	uint32_t number;
+
+	if (size > sizeof(number)) {
+		LOG_ERR("Unsupported size %zu", size);
+		return -EINVAL;
+	}
+
+	number = sys_get_le32(numeric);
 
 	LOG_DBG("action 0x%04x number 0x%08x", action, number);
 
@@ -1297,7 +1305,7 @@ static struct bt_mesh_prov prov = {
 	.uuid = dev_uuid,
 	.static_val = static_auth,
 	.static_val_len = sizeof(static_auth),
-	.output_number = output_number,
+	.output_numeric = output_numeric,
 	.output_string = output_string,
 	.input = input,
 	.link_open = link_open,
@@ -1505,7 +1513,7 @@ static uint8_t input_number(const void *cmd, uint16_t cmd_len,
 
 	LOG_DBG("number 0x%04x", number);
 
-	err = bt_mesh_input_number(number);
+	err = bt_mesh_input_numeric((uint8_t *)&cp->number, sizeof(cp->number));
 	if (err) {
 		return BTP_STATUS_FAILED;
 	}


### PR DESCRIPTION
PR includes:
Updates maximum OOB authentication size from 8 bytes till 32 bytes according to specification errata ES-27446 (mandatory changes). Since previous OOB API does not allow exposing OOB values with such width, the new API has been introduced: 
`int (*output_numeric)(bt_mesh_output_action_t act, uint8_t *numeric, size_t size);`
`int bt_mesh_input_numeric(uint8_t *numeric, size_t size);`
The previous API has been hidden under BT_MESH_REDUCED_MAX_OOB_SIZE option and left for backward compatibility with existing code base.
Additionally, PR includes updates of the relevant bsim tests, adaptation of the qualification test environment and adaptation of some samples, adaptation advertisement stack size dependency as well as size. The issues with size have been figured out during mesh_shell usage on `nrf52840dk/nrf52840` platform for manual testing oob related changes.
