### PR TITLE
boards: stm32n6570_dk: fix overlapping partitions

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -415,7 +415,7 @@ zephyr_udc0: &usbotg_hs1 {
 			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(256)>;
+				reg = <0x00000000 DT_SIZE_K(64)>;
 			};
 
 			slot0_partition: partition@10000 {


### PR DESCRIPTION
* reducing mcuboot partition size so slot_0 and slot_1 can stay where they are
* fixes #97850