### PR TITLE
mgmt: mcumgr: grp: settings_mgmt: Part revert settings save change

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt_callbacks.h
@@ -59,13 +59,12 @@ struct settings_mgmt_access {
 #endif
 
 	/**
-	 * Data provided by the user (only set for SETTINGS_ACCESS_WRITE and SETTINGS_ACCESS_SAVE)
+	 * Data provided by the user (only set for SETTINGS_ACCESS_WRITE)
 	 */
 	const uint8_t *val;
 
 	/**
-	 * Length of data provided by the user (only set for SETTINGS_ACCESS_WRITE and
-	 * SETTINGS_ACCESS_SAVE)
+	 * Length of data provided by the user (only set for SETTINGS_ACCESS_WRITE)
 	 */
 	const size_t *val_length;
 };


### PR DESCRIPTION
Partially reverts commit 7d2fb6c013f94a2c1742b9b84a9dddecd6a0580e, it was originally thought that this commit added a method of saving one specific key using the value that the device already has set, but has been found to actually save the value that the user has provided, bypassing the current value that the device has, which is not compliant with the settings mgmt protocol, therefore remove this change and it will need to be reworked in future to function properly by saving one specific value from the device's current configuration, not a user-specified value