### PR TITLE
subsys: random: fix CSPRNG enablement

### DIFF
--- a/modules/mbedtls/Kconfig.mbedtls
+++ b/modules/mbedtls/Kconfig.mbedtls
@@ -522,11 +522,11 @@ config MBEDTLS_SSL_EXTENDED_MASTER_SECRET
 	  which ensures that master secrets are different for every
 	  connection and every session.
 
-# CONFIG_CSPRNG_AVAILABLE must automatically enable CONFIG_ENTROPY_GENERATOR.
+# CONFIG_ENTROPY_NODE_ENABLED must automatically enable CONFIG_ENTROPY_GENERATOR.
 # But we're doing it here because this enablement should be gated by Mbed TLS
 # being also enabled in the build, otherwise this will result in entropy
 # drivers being enabled without anyone needing them.
-config CSPRNG_AVAILABLE
+config ENTROPY_NODE_ENABLED
 	select ENTROPY_GENERATOR
 
 choice MBEDTLS_PSA_CRYPTO_RNG_SOURCE

--- a/modules/mbedtls/Kconfig.mbedtls
+++ b/modules/mbedtls/Kconfig.mbedtls
@@ -522,21 +522,9 @@ config MBEDTLS_SSL_EXTENDED_MASTER_SECRET
 	  which ensures that master secrets are different for every
 	  connection and every session.
 
-# CONFIG_ENTROPY_NODE_ENABLED must automatically enable CONFIG_ENTROPY_GENERATOR.
-# But we're doing it here because this enablement should be gated by Mbed TLS
-# being also enabled in the build, otherwise this will result in entropy
-# drivers being enabled without anyone needing them.
-config ENTROPY_NODE_ENABLED
-	select ENTROPY_GENERATOR
-
 choice MBEDTLS_PSA_CRYPTO_RNG_SOURCE
 	prompt "Select random source for built-in PSA crypto"
 	depends on MBEDTLS_PSA_CRYPTO_C
-	# The only way to check if there is any entropy driver available on the
-	# platform is to check if the "zephyr,entropy" chosen property exists.
-	# CONFIG_CSPRNG_ENABLED cannot be used for this because it gets enabled by
-	# entropy drivers but these are gated by CONFIG_ENTROPY_GENERATOR which
-	# is disabled by default.
 	default MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG if CSPRNG_ENABLED
 	default MBEDTLS_PSA_CRYPTO_LEGACY_RNG
 
@@ -592,6 +580,7 @@ config MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG_ALLOW_NON_CSPRNG
 config MBEDTLS_PSA_CRYPTO_C
 	bool "Platform Security Architecture cryptography API"
 	depends on !BUILD_WITH_TFM
+	select CSPRNG_NEEDED
 
 config MBEDTLS_USE_PSA_CRYPTO
 	bool "Use PSA APIs instead of legacy MbedTLS when possible"

--- a/subsys/jwt/Kconfig
+++ b/subsys/jwt/Kconfig
@@ -18,7 +18,7 @@ choice
 
 config JWT_SIGN_RSA_LEGACY
 	bool "Use RSA signature (RS-256). Use Mbed TLS as crypto library [DEPRECATED]"
-	depends on CSPRNG_AVAILABLE
+	depends on ENTROPY_NODE_ENABLED
 	select DEPRECATED
 	select MBEDTLS
 	select MBEDTLS_MD_C

--- a/subsys/mgmt/osdp/Kconfig
+++ b/subsys/mgmt/osdp/Kconfig
@@ -74,7 +74,7 @@ config OSDP_SKIP_MARK_BYTE
 
 config OSDP_SC_ENABLED
 	bool "OSDP Secure Channel"
-	depends on CSPRNG_AVAILABLE
+	depends on ENTROPY_NODE_ENABLED
 	default y
 	select CRYPTO
 	select CRYPTO_MBEDTLS_SHIM

--- a/subsys/random/Kconfig
+++ b/subsys/random/Kconfig
@@ -77,7 +77,7 @@ endchoice # RNG_GENERATOR_CHOICE
 
 
 DT_CHOSEN_Z_ENTROPY := zephyr,entropy
-config CSPRNG_AVAILABLE
+config ENTROPY_NODE_ENABLED
 	bool
 	default y if $(dt_chosen_enabled,$(DT_CHOSEN_Z_ENTROPY))
 	help
@@ -85,7 +85,7 @@ config CSPRNG_AVAILABLE
 	  CS random values. For this to be enabled, there must be the "zephyr,entropy"
 	  chosen property defined in the devicetree. This means that there is an
 	  HW entropy generator that can be used for this purpose.
-	  Once CONFIG_CSPRNG_AVAILABLE is set, then CONFIG_ENTROPY_GENERATOR can
+	  Once CONFIG_ENTROPY_NODE_ENABLED is set, then CONFIG_ENTROPY_GENERATOR can
 	  be enabled to enable the platform specific entropy driver.
 
 #

--- a/subsys/random/Kconfig
+++ b/subsys/random/Kconfig
@@ -81,12 +81,16 @@ config ENTROPY_NODE_ENABLED
 	bool
 	default y if $(dt_chosen_enabled,$(DT_CHOSEN_Z_ENTROPY))
 	help
-	  Helper that can be used to check if the platform is capable of generating
-	  CS random values. For this to be enabled, there must be the "zephyr,entropy"
-	  chosen property defined in the devicetree. This means that there is an
-	  HW entropy generator that can be used for this purpose.
-	  Once CONFIG_ENTROPY_NODE_ENABLED is set, then CONFIG_ENTROPY_GENERATOR can
-	  be enabled to enable the platform specific entropy driver.
+	  Helper to state that in the DT the "zephyr,entropy" property points to
+	  the node of an entropy generator unit.
+	  Warning #1: unfortunately having this property set does not guarantee in
+	  all cases that enabling CONFIG_ENTROPY_GENERATOR will make the corresponding
+	  driver available. This because that driver might be gated by other
+	  Kconfig that are not enabled in the build.
+	  Warning #2: even in case blindly enabling CONFIG_ENTROPY_GENERATOR whenever
+	  CONFIG_ENTROPY_NODE_ENABLED is set works fine, it might not be the desired
+	  effect for all the scenarios because then the driver will effectively be
+	  enabled even if there is no usage of it.
 
 #
 # Implied dependency on a cryptographically secure entropy source when
@@ -97,6 +101,8 @@ config CSPRNG_ENABLED
 	bool
 	default y
 	depends on ENTROPY_HAS_DRIVER
+	help
+
 
 choice CSPRNG_GENERATOR_CHOICE
 	prompt "Cryptographically secure random generator"

--- a/subsys/random/Kconfig
+++ b/subsys/random/Kconfig
@@ -91,6 +91,18 @@ config ENTROPY_NODE_ENABLED
 	  CONFIG_ENTROPY_NODE_ENABLED is set works fine, it might not be the desired
 	  effect for all the scenarios because then the driver will effectively be
 	  enabled even if there is no usage of it.
+	  The only workaround for these problems to tentatively enable
+	  CONFIG_CSPRNG_NEEDED and check the "return value" on CONFIG_CSPRNG_ENABLED.
+
+config CSPRNG_NEEDED
+	bool "Use CSPRNG if possible on the current platform"
+	select ENTROPY_GENERATOR if ENTROPY_NODE_ENABLED
+	help
+	  If a DT node exists for an entropy generator (i.e. CONFIG_ENTROPY_NODE_ENABLED
+	  is set) then enable this symbol and check the "result" in CONFIG_CSPRNG_ENABLED
+	  to see if the corresponding driver was really enabled in the build.
+	  This will ensure that (a) there really is a entropy driver for this platform and
+	  (b) it will only get enabled when there is someone needing it.
 
 #
 # Implied dependency on a cryptographically secure entropy source when

--- a/subsys/random/Kconfig
+++ b/subsys/random/Kconfig
@@ -114,6 +114,8 @@ config CSPRNG_ENABLED
 	default y
 	depends on ENTROPY_HAS_DRIVER
 	help
+	  Helper to confirm that there is an hardware entropy unit enabled in the build
+	  that can be used to provide CS random values.
 
 
 choice CSPRNG_GENERATOR_CHOICE


### PR DESCRIPTION
Propose an organized and reliable way to enable CSPRNG on the platform depending on:
- device-tree node declaration;
- real entropy driver availability;
- any interested user for the resulting driver support.

Commits and comments on the code should clarify better each step.