### PR TITLE
[mcumgr] Increment `data_off` after reading the SHA

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -345,6 +345,7 @@ int img_mgmt_read_info(int image_slot, struct image_version *ver, uint8_t *hash,
 				return rc;
 			}
 		}
+		data_off += IMAGE_SHA_LEN;
 	}
 
 	if (!hash_found) {


### PR DESCRIPTION
This PR fixes a bug in `img_mgmt_read_info()` which causes it to read invalid TLV keys after it locates the TLV containing the image's SHA.

The bug occurs because, after reading the SHA with `img_mgmt_read(image_slot, data_off, hash, IMAGE_SHA_LEN);`, `data_off` is not incremented to account for the `IMAGE_SHA_LEN`.

Instead, it loops back around and begins interpreting the SHA data as additional TLVs.

The SHA is normally 32 bytes long, and a `struct image_tlv` is 4 bytes, so it normally reads an additional 8 garbage TLVs.

If the SHA contains the bytes `0xff` or `IMAGE_TLV_SHA` in a position that aligns with a `tlv.it_type`, then the entire `img_mgmt_read_info()` function will fail due to checks in the loop.

The fix for this issue is to increment the `data_off` appropriately after reading the SHA data. 

Fixes #98747