### PR TITLE
llext-edk: capture full build properties for EDK export 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2395,18 +2395,14 @@ if(CONFIG_LLEXT_EDK)
   zephyr_get_compile_definitions_for_lang(C zephyr_defs)
   zephyr_get_compile_options_for_lang(C zephyr_flags)
 
-  # Filter out non LLEXT and LLEXT_EDK flags - and add required ones
-  llext_filter_zephyr_flags(LLEXT_REMOVE_FLAGS ${zephyr_flags} llext_filt_flags)
-  llext_filter_zephyr_flags(LLEXT_EDK_REMOVE_FLAGS ${llext_filt_flags} llext_filt_flags)
+  set(llext_edk_cflags ${zephyr_defs} ${zephyr_flags})
 
-  set(llext_edk_cflags ${zephyr_defs} -DLL_EXTENSION_BUILD)
-  list(APPEND llext_edk_cflags ${llext_filt_flags})
-  list(APPEND llext_edk_cflags ${LLEXT_APPEND_FLAGS})
-  list(APPEND llext_edk_cflags ${LLEXT_EDK_APPEND_FLAGS})
-
+  # Export current settings for use in LLEXT EDK generation
   build_info(llext-edk file PATH ${llext_edk_file})
   build_info(llext-edk cflags VALUE ${llext_edk_cflags})
   build_info(llext-edk include-dirs VALUE "$<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>")
+  build_info(llext-edk remove-cflags VALUE ${LLEXT_REMOVE_FLAGS} ${LLEXT_EDK_REMOVE_FLAGS})
+  build_info(llext-edk append-cflags VALUE ${LLEXT_APPEND_FLAGS} ${LLEXT_EDK_APPEND_FLAGS} -DLL_EXTENSION_BUILD)
 
   add_custom_command(
     OUTPUT ${llext_edk_file}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2391,18 +2391,13 @@ if(CONFIG_LLEXT_EDK)
   endif()
   set(llext_edk_file ${PROJECT_BINARY_DIR}/${CONFIG_LLEXT_EDK_NAME}.${llext_edk_extension})
 
-  # TODO maybe generate flags for C CXX ASM
-  zephyr_get_compile_definitions_for_lang(C zephyr_defs)
-  zephyr_get_compile_options_for_lang(C zephyr_flags)
-
-  set(llext_edk_cflags ${zephyr_defs} ${zephyr_flags})
-
   # Export current settings for use in LLEXT EDK generation
   build_info(llext-edk file PATH ${llext_edk_file})
-  build_info(llext-edk cflags VALUE ${llext_edk_cflags})
-  build_info(llext-edk include-dirs VALUE "$<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>")
   build_info(llext-edk remove-cflags VALUE ${LLEXT_REMOVE_FLAGS} ${LLEXT_EDK_REMOVE_FLAGS})
   build_info(llext-edk append-cflags VALUE ${LLEXT_APPEND_FLAGS} ${LLEXT_EDK_APPEND_FLAGS} -DLL_EXTENSION_BUILD)
+
+  # Generate the compiler flag files that will be used by the EDK
+  add_subdirectory(misc/llext_edk)
 
   add_custom_command(
     OUTPUT ${llext_edk_file}
@@ -2421,7 +2416,7 @@ if(CONFIG_LLEXT_EDK)
       ${SYSCALL_SPLIT_TIMEOUT_ARG}
     COMMAND ${CMAKE_COMMAND}
         -P ${ZEPHYR_BASE}/cmake/llext-edk.cmake
-    DEPENDS ${logical_target_for_zephyr_elf} ${syscalls_json} build_info_yaml_saved
+    DEPENDS ${logical_target_for_zephyr_elf} ${syscalls_json} build_info_yaml_saved llext_edk_build_props
     COMMAND_EXPAND_LISTS
   )
   add_custom_target(llext-edk DEPENDS ${llext_edk_file})

--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -156,6 +156,13 @@ set(build_info_file ${PROJECT_BINARY_DIR}/../build_info.yml)
 yaml_load(FILE ${build_info_file} NAME build_info)
 
 yaml_get(llext_edk_cflags NAME build_info KEY cmake llext-edk cflags)
+yaml_get(llext_remove_cflags NAME build_info KEY cmake llext-edk remove-cflags)
+yaml_get(llext_append_cflags NAME build_info KEY cmake llext-edk append-cflags)
+foreach(item IN_LIST ${llext_remove_cflags})
+  list(FILTER llext_edk_cflags EXCLUDE REGEX "^${item}$")
+endforeach()
+list(APPEND llext_edk_cflags ${llext_append_cflags})
+
 yaml_get(llext_edk_file NAME build_info KEY cmake llext-edk file)
 yaml_get(INTERFACE_INCLUDE_DIRECTORIES NAME build_info KEY cmake llext-edk include-dirs)
 yaml_get(APPLICATION_SOURCE_DIR NAME build_info KEY cmake application source-dir)

--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -3,7 +3,7 @@
 
 # This script generates a tarball containing all headers and flags necessary to
 # build an llext extension. It does so by copying all headers accessible from
-# INTERFACE_INCLUDE_DIRECTORIES and generating a Makefile.cflags file (and a
+# a C compiler command line and generating a Makefile.cflags file (and a
 # cmake.cflags one) with all flags necessary to build the extension.
 #
 # The tarball can be extracted and used in the extension build system to include
@@ -152,10 +152,14 @@ if(CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID)
     "The LLEXT EDK is not compatible with CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID.")
 endif()
 
+set(build_flags_dir ${PROJECT_BINARY_DIR}/misc/llext_edk)
 set(build_info_file ${PROJECT_BINARY_DIR}/../build_info.yml)
 yaml_load(FILE ${build_info_file} NAME build_info)
 
-yaml_get(llext_edk_cflags NAME build_info KEY cmake llext-edk cflags)
+# process C flags
+file(READ ${build_flags_dir}/c_flags.txt llext_edk_c_flags_raw)
+string(STRIP ${llext_edk_c_flags_raw} llext_edk_c_flags)
+string(REPLACE " " ";" llext_edk_cflags "${llext_edk_c_flags}")
 yaml_get(llext_remove_cflags NAME build_info KEY cmake llext-edk remove-cflags)
 yaml_get(llext_append_cflags NAME build_info KEY cmake llext-edk append-cflags)
 foreach(item IN_LIST ${llext_remove_cflags})
@@ -163,8 +167,19 @@ foreach(item IN_LIST ${llext_remove_cflags})
 endforeach()
 list(APPEND llext_edk_cflags ${llext_append_cflags})
 
+# process C definitions
+file(READ ${build_flags_dir}/c_defs.txt llext_edk_c_defs_raw)
+string(STRIP ${llext_edk_c_defs_raw} llext_edk_c_defs)
+string(REPLACE " " ";" llext_edk_c_defs "${llext_edk_c_defs}")
+list(PREPEND llext_edk_cflags ${llext_edk_c_defs})
+
+# process C include directories
+file(READ ${build_flags_dir}/c_incs.txt llext_edk_c_incs_raw)
+string(STRIP ${llext_edk_c_incs_raw} llext_edk_c_incs)
+string(REPLACE " " ";" llext_edk_c_incs "${llext_edk_c_incs}")
+list(TRANSFORM llext_edk_c_incs REPLACE "^-I" "")
+
 yaml_get(llext_edk_file NAME build_info KEY cmake llext-edk file)
-yaml_get(INTERFACE_INCLUDE_DIRECTORIES NAME build_info KEY cmake llext-edk include-dirs)
 yaml_get(APPLICATION_SOURCE_DIR NAME build_info KEY cmake application source-dir)
 yaml_get(WEST_TOPDIR NAME build_info KEY west topdir)
 
@@ -217,7 +232,7 @@ set(llext_edk_cflags ${new_cflags})
 list(APPEND base_flags ${llext_edk_cflags} ${imacros})
 
 file(MAKE_DIRECTORY ${llext_edk_inc})
-foreach(dir ${INTERFACE_INCLUDE_DIRECTORIES})
+foreach(dir ${llext_edk_c_incs})
     if(NOT EXISTS ${dir})
         continue()
     endif()

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -38,7 +38,6 @@ include(CheckCXXCompilerFlag)
 # 7 Linkable loadable extensions (llext)
 # 7.1 llext_* configuration functions
 # 7.2 add_llext_* build control functions
-# 7.3 llext helper functions
 # 8. Script mode handling
 
 ########################################################
@@ -5962,11 +5961,24 @@ function(add_llext_target target_name)
   set(llext_pkg_output ${LLEXT_OUTPUT})
   set(source_files ${LLEXT_SOURCES})
 
+  # Convert the LLEXT_REMOVE_FLAGS list to a regular expression, and use it to
+  # filter out these flags from the Zephyr target settings
+  list(TRANSFORM LLEXT_REMOVE_FLAGS
+       REPLACE "(.+)" "^\\1$"
+       OUTPUT_VARIABLE llext_remove_flags_regexp
+  )
+  list(JOIN llext_remove_flags_regexp "|" llext_remove_flags_regexp)
+  if("${llext_remove_flags_regexp}" STREQUAL "")
+    # an empty regexp would match anything, we actually need the opposite
+    # so set it to match empty strings
+    set(llext_remove_flags_regexp "^$")
+  endif()
   set(zephyr_flags
       "$<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>"
   )
-  llext_filter_zephyr_flags(LLEXT_REMOVE_FLAGS ${zephyr_flags}
-      zephyr_filtered_flags)
+  set(zephyr_filtered_flags
+      "$<FILTER:${zephyr_flags},EXCLUDE,${llext_remove_flags_regexp}>"
+  )
 
   # Compile the source file using current Zephyr settings but a different
   # set of flags to obtain the desired llext object type.
@@ -6199,38 +6211,6 @@ function(add_llext_command)
     ${LLEXT_UNPARSED_ARGUMENTS}
     COMMAND_EXPAND_LISTS
   )
-endfunction()
-
-# 7.3 llext helper functions
-
-# Usage:
-#   llext_filter_zephyr_flags(<filter> <flags> <outvar>)
-#
-# Filter out flags from a list of flags. The filter is a list of regular
-# expressions that will be used to exclude flags from the input list.
-#
-# The resulting generator expression will be stored in the variable <outvar>.
-#
-# Example:
-#   llext_filter_zephyr_flags(LLEXT_REMOVE_FLAGS zephyr_flags zephyr_filtered_flags)
-#
-function(llext_filter_zephyr_flags filter flags outvar)
-  list(TRANSFORM ${filter}
-       REPLACE "(.+)" "^\\1$"
-       OUTPUT_VARIABLE llext_remove_flags_regexp
-  )
-  list(JOIN llext_remove_flags_regexp "|" llext_remove_flags_regexp)
-  if("${llext_remove_flags_regexp}" STREQUAL "")
-    # an empty regexp would match anything, we actually need the opposite
-    # so set it to match empty strings
-    set(llext_remove_flags_regexp "^$")
-  endif()
-
-  set(zephyr_filtered_flags
-      "$<FILTER:${flags},EXCLUDE,${llext_remove_flags_regexp}>"
-  )
-
-  set(${outvar} ${zephyr_filtered_flags} PARENT_SCOPE)
 endfunction()
 
 ########################################################

--- a/misc/llext_edk/CMakeLists.txt
+++ b/misc/llext_edk/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright 2025 Arduino SA
+# SPDX-License-Identifier: Apache-2.0
+
+# This CMake script is used to capture the full set of build properties for the
+# Zephyr 'app' target so that it can be properly exported by the EDK build
+# system.
+
+# Getting the whole list of build properties via CMake functions is tricky.
+# The 'app' target is not fully configured at the time Zephyr scripts are
+# included, so querying its properties directly would yield incomplete results.
+# CMake generator expressions would in normal circumstances be useful, but
+# there are limitations in cases where the properties on the app library
+# contain language-specific '$<COMPILE_LANGUAGE:...>' generator expressions,
+# because those are only resolved in a compile context.
+#
+# To work around this, the following code creates a dummy target that imports
+# build configuration from 'app', but overrides the C compile rules to simply
+# output the resulting properties to text files. The EDK will then read those
+# text files to get the full set of build properties.
+
+unset(CMAKE_C_COMPILER_LAUNCHER)
+unset(CMAKE_DEPFILE_FLAGS_C)
+set(CMAKE_C_COMPILE_OBJECT
+    "${CMAKE_COMMAND} -E echo '<DEFINES>' > ${CMAKE_CURRENT_BINARY_DIR}/c_defs.txt"
+    "${CMAKE_COMMAND} -E echo '<INCLUDES>' > ${CMAKE_CURRENT_BINARY_DIR}/c_incs.txt"
+    "${CMAKE_COMMAND} -E echo '<FLAGS>' > ${CMAKE_CURRENT_BINARY_DIR}/c_flags.txt"
+    "${CMAKE_C_COMPILE_OBJECT}")
+
+add_library(llext_edk_build_props ${ZEPHYR_BASE}/misc/empty_file.c)
+target_link_libraries(llext_edk_build_props PUBLIC app)

--- a/scripts/schemas/build-schema.yml
+++ b/scripts/schemas/build-schema.yml
@@ -85,16 +85,8 @@ mapping:
       llext-edk:
         type: map
         mapping:
-          cflags:
-            type: seq
-            sequence:
-              - type: str
           file:
             type: str
-          include-dirs:
-            type: seq
-            sequence:
-              - type: str
           remove-cflags:
             type: seq
             sequence:

--- a/scripts/schemas/build-schema.yml
+++ b/scripts/schemas/build-schema.yml
@@ -95,6 +95,14 @@ mapping:
             type: seq
             sequence:
               - type: str
+          remove-cflags:
+            type: seq
+            sequence:
+              - type: str
+          append-cflags:
+            type: seq
+            sequence:
+              - type: str
       sysbuild:
         type: bool
       toolchain:

--- a/tests/misc/llext-edk/CMakeLists.txt
+++ b/tests/misc/llext-edk/CMakeLists.txt
@@ -2,11 +2,17 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+# verify information from dependencies is available to extensions
+add_library(dependency INTERFACE)
+target_compile_definitions(dependency INTERFACE GLOBAL_OPT="set")
+
 project(llext_edk_test LANGUAGES C)
 
 target_sources(app PRIVATE src/main.c src/foo.c)
 zephyr_include_directories(include)
 zephyr_include_directories(${ZEPHYR_BASE}/boards/native/common)
+target_link_libraries(app PUBLIC dependency)
 
 if(EXTENSION_DIR)
     target_include_directories(app PRIVATE ${EXTENSION_DIR})

--- a/tests/misc/llext-edk/extension/src/main.c
+++ b/tests/misc/llext-edk/extension/src/main.c
@@ -9,9 +9,14 @@
 
 #include <app_api.h>
 
+#ifndef GLOBAL_OPT
+#define GLOBAL_OPT "MISSING"
+#endif
+
 int start(int bar)
 {
 	printk("foo(%d) is %d\n", bar, foo(bar));
+	printk("GLOBAL_OPT is %s\n", GLOBAL_OPT);
 	return 0;
 }
 EXPORT_SYMBOL(start);

--- a/tests/misc/llext-edk/pytest/test_edk.py
+++ b/tests/misc/llext-edk/pytest/test_edk.py
@@ -115,6 +115,7 @@ def test_edk(unlaunched_dut: DeviceAdapter):
                 assert "Calling extension from user" in lines
                 assert "foo(42) is 1764" in lines
                 assert "foo(43) is 1849" in lines
+                assert "GLOBAL_OPT is set" in lines
 
             finally:
                 unlaunched_dut.close()


### PR DESCRIPTION
### The symptom

While developing the Arduino core, we encountered an issue compiling code that used the `fatfs` module via the EDK; it looked like some defaults were being used in the extension, even though specific compile options were applied during the main Zephyr build.

### The actual problem

Tracking down the source revealed that the EDK is not exporting all build information, but only those defined by the Zephyr core (the `zephyr_interface` target). Modules do not interfere with the Zephyr core but insert themselves as dependencies of the `app` target, so transitive evaluation applies there only. 

### Ruled-out solutions

* The current way of reading properties (e.g. `zephyr_get_compile_options_for_lang`) cannot be used for the `app` target, because at the time the main Zephyr `CMakeLists.txt` is evaluated, that target is not yet available (and definitely not fully configured).

* Trying to use generator expressions is also not possible, due to CMake not allowing expansion of `$<COMPILE_LANGUAGE:...>` outside of a proper compile context. These expressions were stripped by complex code in `get_*_for_lang` functions, but that's no longer possible if the actual flags are hidden in a genex. The process errors out at configuration time.

### The proposed solution

To work around this, this change introduces a new CMake subdirectory (`misc/llext_edk`) that creates a dummy target which imports the build configuration from `app`, but overrides the C compile rules to simply output the resulting properties (defines, include directories, flags) to text files. The EDK generation script then reads those text files to get the full set of build properties, and includes them in the EDK tarball.

> [!IMPORTANT]
>  This (ab-)uses the CMake build process in a way that is often cited as an error - setting toolchain variables from a `CMakeLists.txt` selectively overrides an existing configuration, and is typically discouraged. However, that's 1) documented, stable behavior and 2) exactly what we are after in this case: use every option from the existing toolchain, but "discard" the compiler executable.

A test has been added to verify the functionality by checking if a symbol defined in an interface library that is a dependency of `app` is properly exported to the extension.

This has been in use for the past 4 months in the Arduino core for Zephyr workflows and it has fixed numerous issues related to missing compile options.  