### PR TITLE
boards: espressif: esp32_devkitc: Duplicit record

### DIFF
--- a/boards/espressif/esp32_devkitc/esp32_devkitc_procpu.yaml
+++ b/boards/espressif/esp32_devkitc/esp32_devkitc_procpu.yaml
@@ -14,7 +14,6 @@ supported:
   - uart
   - nvs
   - pwm
-  - dac
   - spi
   - counter
   - entropy


### PR DESCRIPTION
Remove duplicit string from list of supported peripherals.