### PR TITLE
samples: Bluetooth: observer: Fix Extended Scanning on BBC Micro:bit

### DIFF
--- a/samples/bluetooth/observer/overlay_bbc_microbit-bt_ll_sw_split.conf
+++ b/samples/bluetooth/observer/overlay_bbc_microbit-bt_ll_sw_split.conf
@@ -26,28 +26,6 @@ CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX=192
 # at least a primary PDU, an auxiliary PDU and a chain PDU.
 CONFIG_BT_CTLR_RX_BUFFERS=3
 
-# Enable advanced features
-CONFIG_BT_CTLR_ADVANCED_FEATURES=y
-
-# Adjust execution context priorities to achieve lower Radio ISR latencies
-CONFIG_BT_CTLR_LLL_PRIO=0
-CONFIG_BT_CTLR_ULL_HIGH_PRIO=1
-CONFIG_BT_CTLR_ULL_LOW_PRIO=1
-
-# Use just-in-time collision resolution in ticker and LLL pipeline
-CONFIG_BT_CTLR_LOW_LAT=n
-CONFIG_BT_CTLR_LOW_LAT_ULL_DONE=n
-CONFIG_BT_TICKER_LOW_LAT=n
-
-# Increase the below to receive interleaved advertising chains
-CONFIG_BT_CTLR_SCAN_AUX_SET=3
-CONFIG_BT_CTLR_LOW_LAT_ULL=y
-# CONFIG_BT_CTLR_SCAN_AUX_USE_CHAINS=y
-# CONFIG_BT_CTLR_SCAN_AUX_CHAIN_COUNT=3
-
-# Use unreserved timespace scanning
-CONFIG_BT_CTLR_SCAN_UNRESERVED=y
-
 # Use link time optimization for code size reduction
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
 CONFIG_LTO=y

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1928,11 +1928,21 @@ void ull_ticker_status_give(uint32_t status, void *param)
 uint32_t ull_ticker_status_take(uint32_t ret, uint32_t volatile *ret_cb)
 {
 	if ((ret == TICKER_STATUS_BUSY) || (*ret_cb != TICKER_STATUS_BUSY)) {
+		/* lll_prepare_done() will disable ULL_LOW execution context when inside a Radio
+		 * event. Hence, force enable ULL_LOW execution context here so that ticker
+		 * operation be processed.
+		 */
+		if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) &&
+		    (CONFIG_BT_CTLR_LLL_PRIO == CONFIG_BT_CTLR_ULL_LOW_PRIO)) {
+			mayfly_enable(TICKER_USER_ID_THREAD, TICKER_USER_ID_ULL_LOW, 1U);
+		}
+
 		/* Operation is either pending of completed via callback
 		 * prior to this function call. Take the semaphore and wait,
 		 * or take it to balance take/give counting.
 		 */
 		k_sem_take(&sem_ticker_api_cb, K_FOREVER);
+
 		return *ret_cb;
 	}
 


### PR DESCRIPTION
Fix configuration overlay file to support observer sample
with Extended Scanning on BBC Micro:bit board.

Due to slow CPU, there were assertions and, this commit
addresses them by defaulting to use of BT_CTLR_LOW_LAT.

Asserts mitigated:

- ASSERTION FAIL [start_us == (aux_start_us + 1U)]
  @ WEST_TOPDIR/zephyr/subsys/bluetooth/controller/ll_sw/
  nordic/lll/lll_scan_aux.c:359
  This will happen for small aux offset value, definitely
  for the 300 us because CPU usage latency to setup such
  auxiliary PDU reception on nRF51 is high due to slow CPU.

- ASSERTION FAIL [0]
  @ WEST_TOPDIR/zephyr/subsys/bluetooth/controller/ll_sw/
  nordic/lll/lll_scan_aux.c:592
    prepare_cb: Actual EVENT_OVERHEAD_START_US = 579
  This will happen due to CPU usage latencies scheduling
  the radio events, due to slow CPU.

Relates to commit https://github.com/zephyrproject-rtos/zephyr/commit/eba31282e8d171b2e7af58abce43b1313ba6df94 ("samples: Bluetooth:
observer: Extended Scanning on BBC Micro Bit board").