### PR TITLE
stm32: nucleo u385rg_q: fix wrong spi node assigned to arduino_spi 

### DIFF
--- a/boards/st/nucleo_u385rg_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u385rg_q/arduino_r3_connector.dtsi
@@ -39,6 +39,6 @@
 
 arduino_i2c: &i2c1 {};
 
-arduino_spi: &spi3 {};
+arduino_spi: &spi1 {};
 
 arduino_serial: &lpuart1 {};

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -145,9 +145,9 @@
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &fdcan1 {
@@ -168,15 +168,22 @@
 	status = "okay";
 };
 
-&i2c3 {
-	pinctrl-0 = <&i2c3_scl_pa7 &i2c3_sda_pc1>;
-	pinctrl-names = "default";
-	status = "okay";
-};
-
 &rng {
 	clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
 		 <&rcc STM32_SRC_MSIK RNG_SEL(1)>;
+	status = "okay";
+};
+
+&spi1 {
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6
+		     &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+
+	/* Arduino D10 (SPI_NSS) is wired to PC9 which
+	 * doesn't support hardware NSS; the software
+	 * cs-gpios must be used instead.
+	 */
+	cs-gpios = <&gpioc 9 GPIO_ACTIVE_LOW>;
 	status = "okay";
 };
 

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_u385rg_q.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_u385rg_q.overlay
@@ -14,6 +14,10 @@
  */
 
 &i2c3 {
+	pinctrl-0 = <&i2c3_scl_pa7 &i2c3_sda_pc1>;
+	pinctrl-names = "default";
+	status = "okay";
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -27,4 +31,8 @@
 		reg = <0x56>;
 		size = <256>;
 	};
+};
+
+&spi1 {
+	status = "disabled";
 };


### PR DESCRIPTION
This PR fixes an incorrect peripheral node assignment to arduino_spi and updates the board's device tree to avoid conflicts with other enabled peripheral nodes (i2c3) on PA7 pin.

Fixes: #97543