### PR TITLE
MAINTAINERS file: make doc/build/dts unique to devicetree area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -762,6 +762,8 @@ Build system:
     - scripts/schemas/soc-schema.yaml
     - scripts/list_shields.py
     - scripts/snippets.py
+  files-exclude:
+    - doc/build/dts/
   labels:
     - "area: Build System"
   tests:


### PR DESCRIPTION
Exclude doc/build/dts from build system area.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
