### PR TITLE
samples: usb: uvc: fix target sample filters for board specific overlays

### DIFF
--- a/samples/subsys/usb/uvc/sample.yaml
+++ b/samples/subsys/usb/uvc/sample.yaml
@@ -34,8 +34,8 @@ tests:
     extra_configs:
       - CONFIG_VIDEO_ENCODER_H264=y
     extra_args:
-      - EXTRA_DTC_OVERLAY_FILE="app_h264enc.overlay"
-      - SHIELD=st_b_cams_imx_mb1854
+      - platform:stm32n6570_dk/stm32n657xx/sb:EXTRA_DTC_OVERLAY_FILE="app_h264enc.overlay"
+      - platform:stm32n6570_dk/stm32n657xx/sb:SHIELD=st_b_cams_imx_mb1854
     filter: dt_chosen_enabled("zephyr,camera")
     integration_platforms:
       - stm32n6570_dk/stm32n657xx/sb
@@ -46,8 +46,8 @@ tests:
     extra_configs:
       - CONFIG_VIDEO_ENCODER_JPEG=y
     extra_args:
-      - EXTRA_DTC_OVERLAY_FILE="app_jpegenc.overlay"
-      - SHIELD=st_b_cams_imx_mb1854
+      - platform:stm32n6570_dk/stm32n657xx/sb:EXTRA_DTC_OVERLAY_FILE="app_jpegenc.overlay"
+      - platform:stm32n6570_dk/stm32n657xx/sb:SHIELD=st_b_cams_imx_mb1854
     filter: dt_chosen_enabled("zephyr,camera")
     integration_platforms:
       - stm32n6570_dk/stm32n657xx/sb


### PR DESCRIPTION
Recent addition of UVC Video encoder added sample targets to the sample without the proper filter to ensure twister didn't try to automatically build the sample target on unsupported boards.

Not all boards have the zephyr_h264enc and zephyr_h264enc in their device tree.

Fixes #98275