### PR TITLE
tests: drivers: i2c: Fix incorrect file paths in SCI I2C test support

### DIFF
--- a/tests/drivers/i2c/i2c_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_api/testcase.yaml
@@ -43,8 +43,8 @@ tests:
       - ek_ra6m5
       - ek_ra6m4
     extra_args:
-      - DTC_OVERLAY_FILE="./boards/${BOARD}${NORMALIZED_BOARD_QUALIFIERS}_sci_i2c.overlay"
-      - CONF_FILE="./prj.conf ./boards/${BOARD}${NORMALIZED_BOARD_QUALIFIERS}_sci_i2c.conf"
+      - DTC_OVERLAY_FILE="./boards/${BOARD}_sci_i2c.overlay"
+      - CONF_FILE="./prj.conf ./boards/${BOARD}_sci_i2c.conf"
   drivers.i2c.stm32.interrupt_disabled:
     depends_on:
       - i2c


### PR DESCRIPTION
The current paths to the `.overlay` and `.conf` files used for SCI I2C tests are incorrect, as they include `{NORMALIZED_BOARD_QUALIFIERS}`, which does not exist in the actual file names.

This commit corrects the file paths in the test support configuration.