### PR TITLE
dts: vendor: ti: k3-am62-main: Change license to Apache-2

### DIFF
--- a/dts/vendor/ti/k3-am62-main.dtsi
+++ b/dts/vendor/ti/k3-am62-main.dtsi
@@ -1,9 +1,9 @@
-// SPDX-License-Identifier: GPL-2.0-only OR MIT
 /*
  * Device Tree Source for AM625 SoC Family Main Domain peripherals
  *
- * Copyright (C) 2020-2024 Texas Instruments Incorporated - https://www.ti.com/
  * Copyright (c) 2025 Ayush Singh, BeagleBoard.org Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 / {


### PR DESCRIPTION
This probably should have been caught much earlier, but well, here we are. The original license came from the following linux dt that BeagleBoard.org uses [0]. However, due to differences between linux and zephyr dt and the fact that zephyr does not yet support most of the devices on this soc, the only lines same between the two files are the `status = "disabled";`, and some of the address (not all since things like GPIO are handled differently). Keeping that in mind, this file should never have used that license or have TI Copyright.

If it's too late to change the license now, we can probably add this file to exceptions, since the current license of the file, i.e. GPL-2.0 and MIT should cover all cases where Apache-2 can be used. Again, apologies since there was no reason for this file to use the dual license.

[0]:https://github.com/beagleboard/BeagleBoard-DeviceTrees/blob/v6.12.x-Beagle/src/arm64/ti/k3-am62-main.dtsi

cc @kartben 