### PR TITLE
tracing: Change tracing state dynamically at runtime

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -70,6 +70,8 @@ New APIs and options
 
 * :c:func:`lora_recv_duty_cycle_async`
 
+* :c:macro:`sys_trace_set_state` to set tracing state (i.e. enable/disable) from application dynamically at runtime.
+
 .. zephyr-keep-sorted-stop
 
 New Boards

--- a/doc/services/tracing/index.rst
+++ b/doc/services/tracing/index.rst
@@ -45,6 +45,43 @@ Users can generate a custom trace event by calling
 arbitrary 4 byte arguments. Tracing backends may truncate the provided event
 name if it is too long for the serialization format they support.
 
+Dynamic Tracing State
+*********************
+
+The tracing state can be changed at runtime by calling :c:macro:`sys_trace_set_state`.
+This is useful when tracing backends use a fixed-size or circular buffer, where
+continuously tracing all events may cause important data to be overwritten before it
+can be retrieved.
+
+For example, an application can disable tracing during uninteresting activity and
+re-enable it just before the section of interest:
+
+.. code-block:: c
+
+   #include <zephyr/tracing/tracing.h>
+
+   /* Disable tracing to avoid filling the buffer with uninteresting events */
+   sys_trace_set_state(false);
+
+   /* ... uninteresting work ... */
+
+   /* Re-enable tracing before the critical section to be diagnosed */
+   sys_trace_set_state(true);
+
+   /* ... critical section being diagnosed ... */
+
+This is particularly useful with:
+
+* The CTF format, where the ring buffer may overflow and overwrite earlier events
+* The User-Defined format, which receives state changes via
+  :c:func:`sys_trace_set_state_user`
+
+.. note::
+
+   :kconfig:option:`CONFIG_TRACING_HANDLE_HOST_CMD` allows a host to control tracing
+   state over UART. :c:macro:`sys_trace_set_state` provides an in-application
+   alternative that works with all backends and without a host connection.
+
 Serialization Formats
 **********************
 

--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -2842,6 +2842,12 @@ void sys_trace_idle_exit(void);
  */
 #define sys_trace_sys_init_exit(entry, level, result)
 
+/**
+ * @brief Enable/Disable Tracing
+ * @param state A boolean value either true or false
+ */
+#define sys_trace_set_state(state)
+
 /** @} */ /* end of subsys_tracing_apis */
 
 /** @} */ /* end of subsys_tracing */

--- a/samples/subsys/tracing/README.rst
+++ b/samples/subsys/tracing/README.rst
@@ -91,6 +91,26 @@ or:
 
 After the application has run for a while, check the trace output file.
 
+Dynamic Tracing State
+*********************
+
+The sample demonstrates :c:macro:`sys_trace_set_state`, which allows an application
+to enable or disable tracing at runtime. In ``main.c``, tracing is disabled after the
+counter reaches 5 and re-enabled at 10. This is useful when a fixed-size or circular
+trace buffer is used and you only want to capture events around a specific point of
+interest.
+
+The expected console output includes::
+
+   Disabling tracing
+   Re-enabling tracing
+
+When using the User-defined tracing backend, the state change is also visible via the
+``sys_trace_set_state_user`` callback::
+
+   set current tracing state to 0
+   set current tracing state to 1
+
 Usage for USER Tracing Backend
 *******************************
 

--- a/samples/subsys/tracing/src/main.c
+++ b/samples/subsys/tracing/src/main.c
@@ -44,6 +44,19 @@ void helloLoop(const char *my_name,
 		/* take my semaphore */
 		k_sem_take(my_sem, K_FOREVER);
 
+		/*
+		 * Demonstrate dynamic tracing state: disable tracing after 5 iterations so
+		 * uninteresting events do not fill the buffer, then re-enable it at 10 to
+		 * capture the next critical section.
+		 */
+		if (counter == 5U) {
+			printk("Disabling tracing\n");
+			sys_trace_set_state(false);
+		} else if (counter == 10U) {
+			sys_trace_set_state(true);
+			printk("Re-enabling tracing\n");
+		}
+
 		/* Provide a named trace, with the counter value */
 		sys_trace_named_event("counter_value", counter, 0);
 		counter++;

--- a/samples/subsys/tracing/src/tracing_user.c
+++ b/samples/subsys/tracing/src/tracing_user.c
@@ -101,3 +101,8 @@ void sys_trace_gpio_pin_interrupt_configure_exit_user(const struct device *port,
 {
 	printk("port: %s, pin: %d ret: %d\n", port->name, pin, ret);
 }
+
+void sys_trace_set_state_user(bool state)
+{
+	printk("set current tracing state to %d\n", state);
+}

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -14,6 +14,9 @@
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/debug/cpu_load.h>
+#include <zephyr/sys/atomic.h>
+
+static atomic_t tracing_state = ATOMIC_INIT(true);
 
 static void _get_thread_name(struct k_thread *thread, ctf_bounded_string_t *name)
 {
@@ -1616,4 +1619,14 @@ void sys_trace_k_event_wait_blocking(struct k_event *event, uint32_t events, uin
 void sys_trace_k_event_wait_exit(struct k_event *event, uint32_t events, int ret)
 {
 	ctf_top_event_wait_exit((uint32_t)(uintptr_t)event, events, (int32_t)ret);
+}
+
+void sys_trace_set_state_ctf(bool state)
+{
+	(void)atomic_set(&tracing_state, state);
+}
+
+bool ctf_trace_is_enabled(void)
+{
+	return atomic_get(&tracing_state);
 }

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -28,6 +28,8 @@
  */
 #define CTF_INTERNAL_FIELD_SIZE(x) + sizeof(x)
 
+bool ctf_trace_is_enabled(void);
+
 /*
  * Append a field to current event-packet.
  */
@@ -42,11 +44,13 @@
  */
 #define CTF_GATHER_FIELDS(...)                                                                     \
 	{                                                                                          \
-		uint8_t epacket[0 MAP(CTF_INTERNAL_FIELD_SIZE, ##__VA_ARGS__)];                    \
-		uint8_t *epacket_cursor = &epacket[0];                                             \
+		if (ctf_trace_is_enabled()) {                                                      \
+			uint8_t epacket[0 MAP(CTF_INTERNAL_FIELD_SIZE, ##__VA_ARGS__)];            \
+			uint8_t *epacket_cursor = &epacket[0];                                     \
                                                                                                    \
-		MAP(CTF_INTERNAL_FIELD_APPEND, ##__VA_ARGS__)                                      \
-		tracing_format_raw_data(epacket, sizeof(epacket));                                 \
+			MAP(CTF_INTERNAL_FIELD_APPEND, ##__VA_ARGS__)                              \
+			tracing_format_raw_data(epacket, sizeof(epacket));                         \
+		}                                                                                  \
 	}
 
 #ifdef CONFIG_TRACING_CTF_TIMESTAMP

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -636,6 +636,7 @@ void sys_trace_k_event_wait_enter(struct k_event *event, uint32_t events, uint32
 void sys_trace_k_event_wait_blocking(struct k_event *event, uint32_t events, uint32_t options,
 				     k_timeout_t timeout);
 void sys_trace_k_event_wait_exit(struct k_event *event, uint32_t events, int ret);
+void sys_trace_set_state_ctf(bool state);
 
 #define sys_port_trace_socket_init(sock, family, type, proto)                                      \
 	sys_trace_socket_init(sock, family, type, proto)
@@ -879,6 +880,8 @@ void sys_trace_gpio_fire_callback(const struct device *port, struct gpio_callbac
 #define sys_port_trace_rtio_txn_next_exit(rtio, iodev_sqe)
 #define sys_port_trace_rtio_chain_next_enter(rtio, iodev_sqe)
 #define sys_port_trace_rtio_chain_next_exit(rtio, iodev_sqe)
+
+#define sys_trace_set_state(state) sys_trace_set_state_ctf(state)
 
 #ifdef __cplusplus
 }

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -870,6 +870,7 @@ void sys_trace_named_event(const char *name, uint32_t arg0, uint32_t arg1);
 #define sys_port_trace_gpio_get_pending_int_exit(dev, ret)
 #define sys_port_trace_gpio_fire_callbacks_enter(list, port, pins)
 #define sys_port_trace_gpio_fire_callback(port, cb)
+#define sys_trace_set_state(state)
 
 #define sys_port_trace_rtio_submit_enter(rtio, wait_count)
 #define sys_port_trace_rtio_submit_exit(rtio)

--- a/subsys/tracing/test/tracing_string_format_test.c
+++ b/subsys/tracing/test/tracing_string_format_test.c
@@ -603,3 +603,8 @@ void sys_trace_k_event_wait_exit(struct k_event *event, uint32_t events, uint32_
 {
 	TRACING_STRING("%s: %p wait exit\n", __func__, event);
 }
+
+void _sys_trace_set_state(bool state)
+{
+	TRACING_STRING("%s: %d state\n", __func__, state);
+}

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -715,6 +715,7 @@ void sys_trace_k_event_wait_enter(struct k_event *event, uint32_t events, unsign
 void sys_trace_k_event_wait_blocking(struct k_event *event, uint32_t events, unsigned int options,
 				     k_timeout_t timeout);
 void sys_trace_k_event_wait_exit(struct k_event *event, uint32_t events, uint32_t ret);
+void _sys_trace_set_state(bool state);
 
 #define sys_port_trace_socket_init(sock, family, type, proto)
 #define sys_port_trace_socket_close_enter(sock)
@@ -811,4 +812,5 @@ void sys_trace_k_event_wait_exit(struct k_event *event, uint32_t events, uint32_
 #define sys_port_trace_rtio_chain_next_enter(rtio, iodev_sqe)
 #define sys_port_trace_rtio_chain_next_exit(rtio, iodev_sqe)
 
+#define sys_trace_set_state(state) _sys_trace_set_state(state)
 #endif /* ZEPHYR_TRACE_TEST_H */

--- a/subsys/tracing/user/tracing_user.c
+++ b/subsys/tracing/user/tracing_user.c
@@ -88,6 +88,7 @@ void __weak sys_trace_timer_expiry_enter_user(struct k_timer *timer) {}
 void __weak sys_trace_timer_expiry_exit_user(struct k_timer *timer) {}
 void __weak sys_trace_timer_stop_fn_expiry_enter_user(struct k_timer *timer) {}
 void __weak sys_trace_timer_stop_fn_expiry_exit_user(struct k_timer *timer) {}
+void __weak sys_trace_set_state_user(bool state) {}
 
 void __weak sys_trace_rtio_submit_enter_user(const struct rtio *r, uint32_t wait_count)
 {
@@ -525,4 +526,9 @@ void sys_trace_timer_stop_fn_expiry_enter(struct k_timer *timer)
 void sys_trace_timer_stop_fn_expiry_exit(struct k_timer *timer)
 {
 	sys_trace_timer_stop_fn_expiry_exit_user(timer);
+}
+
+void _sys_trace_set_state(bool state)
+{
+	sys_trace_set_state_user(state);
 }

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -31,6 +31,7 @@ void sys_trace_isr_exit_user(void);
 void sys_trace_idle_user(void);
 void sys_trace_sys_init_enter_user(const struct init_entry *entry, int level);
 void sys_trace_sys_init_exit_user(const struct init_entry *entry, int level, int result);
+void sys_trace_set_state_user(bool state);
 
 void sys_trace_thread_create(struct k_thread *thread);
 void sys_trace_thread_abort(struct k_thread *thread);
@@ -59,6 +60,7 @@ void sys_trace_timer_expiry_enter(struct k_timer *timer);
 void sys_trace_timer_expiry_exit(struct k_timer *timer);
 void sys_trace_timer_stop_fn_expiry_enter(struct k_timer *timer);
 void sys_trace_timer_stop_fn_expiry_exit(struct k_timer *timer);
+void _sys_trace_set_state(bool state);
 
 struct rtio;
 struct rtio_sqe;
@@ -585,6 +587,8 @@ void sys_trace_rtio_chain_next_exit(const struct rtio *r, const struct rtio_iode
 
 #define sys_port_trace_rtio_chain_next_exit(rtio, iodev_sqe)                                       \
 	sys_trace_rtio_chain_next_exit(rtio, iodev_sqe)
+
+#define sys_trace_set_state(state) _sys_trace_set_state(state)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This commit adds support for applications to enable/disable tracing dynamically at runtime. Current implementation only allow changing tracing state when `CONFIG_TRACING_HANDLE_HOST_CMD` is enabled. Thus application cannot enable/disable tracing to save tracing buffer after some unexpected event.