### PR TITLE
Bugfix/98281 drivers flash common failed test

### DIFF
--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -119,6 +119,12 @@ static status_t is_area_readable(uint32_t addr, size_t len)
 
 #define SOC_FLASH_NEED_CLEAR_CACHES 1
 #ifdef CONFIG_SOC_FAMILY_MCXW
+#ifdef CONFIG_SOC_SERIES_MCXW2XX
+static void clear_flash_caches(void)
+{
+	FLASH_CacheClear();
+}
+#elif
 static void clear_flash_caches(void)
 {
 	volatile uint32_t *const smscm_ocmdr0 = (volatile uint32_t *)0x40015400;
@@ -128,6 +134,7 @@ static void clear_flash_caches(void)
 	/* this bit clears the code cache */
 	*mcm_cpcr2 |= BIT(0);
 }
+#endif
 #elif CONFIG_SOC_FAMILY_MCXN
 static void clear_flash_caches(void)
 {

--- a/soc/nxp/mcx/mcxw/mcxw2xx/soc.c
+++ b/soc/nxp/mcx/mcxw/mcxw2xx/soc.c
@@ -102,6 +102,13 @@ __weak void clock_init(void)
 	PMC->OSTIMERr &= ~PMC_OSTIMER_OSTIMERCLKSEL_MASK;
 	PMC->OSTIMERr |= OSTIMERCLKSEL_FRO_1MHz << PMC_OSTIMER_OSTIMERCLKSEL_SHIFT;
 #endif
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(iap), nxp_iap_fmc55, okay)
+	/* kCLOCK_Sysctl must be enabled for FLASH_CacheClear,
+	 * FLASH_CacheSpeculationControl and FLASH_CheckECC to have an effect.
+	 */
+	CLOCK_EnableClock(kCLOCK_Sysctl);
+#endif
 }
 
 #ifdef CONFIG_SOC_RESET_HOOK


### PR DESCRIPTION
1. Added clear_flash_caches function for MCXW2XX in drivers/flash/soc_flash_mcux.c.
MCXW2XX ROMAPI provide the function FLASH_CacheClear to clear the cache.
The SMSCM is not supported on MCXW2XX platform.

2. Add clock enablement for flash controller.
kCLOCK_Sysctl must be enabled for FLASH_CacheClear,
FLASH_CacheSpeculationControl and FLASH_CheckECC to have an effect.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/98281