### PR TITLE
driver: i2c: npcx: workaround invalid stop condition

### DIFF
--- a/drivers/i2c/Kconfig.npcx
+++ b/drivers/i2c/Kconfig.npcx
@@ -38,3 +38,10 @@ config I2C_NPCX_DMA_DRIVEN
 	help
 	  For I2C peripherals that support DMA mode, data transfers shall be performed
 	  using DMA‑driven transactions.
+
+config I2C_NPCX_INVALID_STOP_WORKAROUND
+	bool
+	default y
+	depends on NPCX_SOC_VARIANT_NPCXN
+	help
+	  Workaround for invalid STOP condition issue in NPCXn variant I2C controllers.

--- a/drivers/i2c/i2c_npcx_controller.h
+++ b/drivers/i2c/i2c_npcx_controller.h
@@ -78,6 +78,9 @@ struct i2c_ctrl_data {
 	struct k_sem lock_sem;               /* mutex of i2c controller */
 	struct k_sem sync_sem;               /* semaphore used for synchronization */
 	uint32_t bus_freq;                   /* operation freq of i2c */
+#if defined(CONFIG_I2C_NPCX_INVALID_STOP_WORKAROUND)
+	uint32_t stop_dealy_cycle_time;      /* delay time in cycles before sending STOP */
+#endif
 	enum npcx_i2c_oper_state oper_state; /* controller operation state */
 	int trans_err;                       /* error code during transaction */
 	struct i2c_msg *msg;                 /* cache msg for transaction state machine */
@@ -112,13 +115,6 @@ static inline void i2c_ctrl_start(const struct device *dev)
 	struct smb_reg *const inst = HAL_I2C_INSTANCE(dev);
 
 	inst->SMBCTL1 |= BIT(NPCX_SMBCTL1_START);
-}
-
-static inline void i2c_ctrl_stop(const struct device *dev)
-{
-	struct smb_reg *const inst = HAL_I2C_INSTANCE(dev);
-
-	inst->SMBCTL1 |= BIT(NPCX_SMBCTL1_STOP);
 }
 
 static inline void i2c_ctrl_data_write(const struct device *dev, uint8_t data)
@@ -317,6 +313,7 @@ bool i2c_ctrl_toggle_scls(const struct device *dev);
 size_t i2c_ctrl_calculate_msg_remains(const struct device *dev);
 void i2c_ctrl_handle_write_int_event(const struct device *dev);
 void i2c_ctrl_handle_read_int_event(const struct device *dev);
+void i2c_ctrl_stop(const struct device *dev);
 
 /* FIFO-Driven public fucntions */
 #if defined(CONFIG_I2C_NPCX_FIFO_DRIVEN)

--- a/drivers/i2c/i2c_npcx_controller_dma.c
+++ b/drivers/i2c/i2c_npcx_controller_dma.c
@@ -117,6 +117,13 @@ size_t i2c_ctrl_dma_proceed_read(const struct device *dev)
 	return dma_lens;
 }
 
+void i2c_ctrl_stop(const struct device *dev)
+{
+	struct smb_reg *const inst = HAL_I2C_INSTANCE(dev);
+
+	inst->SMBCTL1 |= BIT(NPCX_SMBCTL1_STOP);
+}
+
 /* I2C controller recover function in `DMA` mode */
 bool i2c_ctrl_toggle_scls(const struct device *dev)
 {

--- a/drivers/i2c/i2c_npcx_controller_fifo.c
+++ b/drivers/i2c/i2c_npcx_controller_fifo.c
@@ -134,6 +134,20 @@ static inline int i2c_ctrl_fifo_rx_occupied(const struct device *dev)
 	return inst->SMBRXF_STS & 0x3f;
 }
 
+void i2c_ctrl_stop(const struct device *dev)
+{
+	struct smb_reg *const inst = HAL_I2C_INSTANCE(dev);
+	struct i2c_ctrl_data *const data = dev->data;
+	uint32_t delay_cycle = data->stop_dealy_cycle_time;
+	uint32_t delay_start = k_cycle_get_32();
+
+	while (k_cycle_get_32() - delay_start < delay_cycle) {
+		arch_nop();
+	}
+
+	inst->SMBCTL1 |= BIT(NPCX_SMBCTL1_STOP);
+}
+
 /* I2C controller `FIFO` interrupt functions */
 void i2c_ctrl_handle_write_int_event(const struct device *dev)
 {


### PR DESCRIPTION
The I2C state machine may fail to generate a valid STOP condition. This may happen when the firmware sets the STOP bit in SMBCTL1 register approximately half an SMB clock cycle following the last ACK bit in the transaction.
Note:
  1. This issue is not expected to occur when the core clock runs at the default frequency (15 MHz). However, since more applications reuquires higher core clock frequency, this commit introduce the bypass to prevent the potential risk.
  2. Only NPCXn variant chips require this workaround.