### PR TITLE
riscv: linker: work around for sizes not being addresses

### DIFF
--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -294,16 +294,24 @@ extern char z_kobject_data_begin[];
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 extern char __tdata_start[];
 extern char __tdata_end[];
-extern char __tdata_size[];
 extern char __tdata_align[];
 extern char __tbss_start[];
 extern char __tbss_end[];
-extern char __tbss_size[];
 extern char __tbss_align[];
 extern char __tls_start[];
 extern char __tls_end[];
 extern char __tls_size[];
+
+#ifdef CONFIG_RISCV_CMODEL_MEDANY
+#define  __tbss_size (size_t)((uintptr_t)__tbss_end  - (uintptr_t)__tbss_start)
+#define  __tdata_size (size_t)((uintptr_t)__tdata_end - (uintptr_t)__tdata_start)
+#else
+extern char __tbss_size[];
+extern char __tdata_size[];
+#endif
+
 #endif /* CONFIG_THREAD_LOCAL_STORAGE */
+
 
 #ifdef CONFIG_LINKER_USE_BOOT_SECTION
 /* lnkr_boot_start[] and lnkr_boot_end[]


### PR DESCRIPTION
In the RISC-V code model medany, only accesses around PC +/- 2GB are allowed. This means that our abuse of symbols as sizes, cause problems with linker relocations.

GCC does a trick where it relaxes these accesses to absolute accesses, but this is dubious from a standards standpoint and should not be relied upon. However I don't think the GOT solutions proposed from the psABI is preferable from an embedded standpoint.

This only works around the most pressing issue, we will want a more general solution in the future.

Should this be done to ALL size variables?
Can we add qemu_riscv64 to lld tests perhaps?

Fixes #89505
Here is some more context:

### Linux kernel discussion:

https://github.com/ClangBuiltLinux/linux/issues/1409

### lld discussions:

https://reviews.llvm.org/D149751
https://github.com/llvm/llvm-project/issues/78346

### PSABI discussions:
https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/197
https://github.com/riscv-non-isa/riscv-elf-psabi-doc/pull/201