### PR TITLE
tests: Bluetooth: Tester: Fix GATT Notify Multiple BTP command

### DIFF
--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -2111,7 +2111,7 @@ static uint8_t notify_mult(const void *cmd, uint16_t cmd_len,
 	struct bt_conn *conn;
 	const size_t min_cnt = 1U;
 	int err = 0;
-	uint16_t attr_data_len = 0;
+	uint16_t server_db_start_handle = server_db[0].handle;
 
 	if ((cmd_len < sizeof(*cp)) ||
 	    (cmd_len != sizeof(*cp) + (cp->cnt * sizeof(cp->attr_id[0])))) {
@@ -2133,14 +2133,23 @@ static uint8_t notify_mult(const void *cmd, uint16_t cmd_len,
 	(void)memset(params, 0, sizeof(params));
 
 	for (uint16_t i = 0U; i < cp->cnt; i++) {
-		struct bt_gatt_attr attr = server_db[cp->attr_id[i] -
-			server_db[0].handle];
+		const struct bt_gatt_attr *attr;
+		const struct gatt_value *value;
+		uint16_t handle = sys_le16_to_cpu(cp->attr_id[i]);
 
-		attr_data_len = strtoul(attr.user_data, NULL, 16);
+		if (!IN_RANGE(handle, server_db_start_handle,
+			      server_db_start_handle + attr_count)) {
+			LOG_ERR("ATT handle %u not in server DB range", handle);
+			return BTP_STATUS_FAILED;
+		}
+
+		attr = &server_db[handle - server_db_start_handle];
+		value = attr->user_data;
+
 		params[i].uuid = 0;
-		params[i].attr = &attr;
-		params[i].data = &attr.user_data;
-		params[i].len = attr_data_len;
+		params[i].attr = attr;
+		params[i].data = value->data;
+		params[i].len = value->len;
 		params[i].func = notify_cb;
 		params[i].user_data = NULL;
 	}


### PR DESCRIPTION
This fix multiple issues with command implementation:
 - lack of LE to host convertion
 - using strtoul() on non-string data
 - passing stack variable as attr data (which must be present until notification is sent)

This was affecting GATT/SR/GAN/BV-02-C qualification test case.

Fixes #98971