### PR TITLE
cmake: refactor `zephyr_get_*_for_lang` functions

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -164,13 +164,84 @@ function(zephyr_ld_options)
     target_ld_options(zephyr_interface INTERFACE ${ARGV})
 endfunction()
 
-# Getter functions for extracting build information from
-# zephyr_interface. Returning lists, and strings is supported, as is
-# requesting specific categories of build information (defines,
-# includes, options).
+# Getter function for extracting information from zephyr_interface. The
+# function supports filtering for specific compile languages, prefixes, and
+# different output formats.
 #
+# The result is always returned as a generator expression, so its actual
+# value is not computed until build time.
+#
+# Usage:
+#   zephyr_get_build_property(output PROPERTY prop [options])
+#
+# where:
+#   - 'output' is the variable to write the result to
+#   - 'prop' is the CMake property to read from the target
+#
+# Options:
+#   - AS_STRING:
+#       Return the result as a string rather than a list. Equivalent to
+#       specifying DELIMITER " ".
+#  - DELIMITER <delimiter>:
+#       Specify the output delimiter to use for the list entries. Defaults to
+#       "$<SEMICOLON>". Cannot be used with AS_STRING.
+#  - LANG <C|CXX|ASM>:
+#       When set, the property value is filtered for $<COMPILE_LANGUAGE:lang>
+#       entries, and only those matching the given language are kept.
+#  - PREFIX <prefix>:
+#       Specify a prefix to use for each entry in the output list. Defaults
+#       for INCLUDE_DIRECTORIES (-I), SYSTEM_INCLUDE_DIRECTORIES (-isystem),
+#       COMPILE_DEFINITIONS (-D) and their INTERFACE_ variants are implicit.
+#  - STRIP_PREFIX:
+#       Omit the prefix string, even if implicit or given by PREFIX.
+
+function(zephyr_get_build_property output)
+  set(options AS_STRING STRIP_PREFIX)
+  set(single_args DELIMITER LANG PREFIX PROPERTY)
+  cmake_parse_arguments(args "${options}" "${single_args}" "" ${ARGN})
+  zephyr_check_arguments_required_all(zephyr_get_build_property args PROPERTY)
+  zephyr_check_flags_exclusive(zephyr_get_build_property args AS_STRING DELIMITER)
+  if(args_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "zephyr_get_build_property() given unknown arguments: ${args_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(args_AS_STRING)
+    set(args_DELIMITER " ")
+  else()
+    set_ifndef(args_DELIMITER "$<SEMICOLON>")
+  endif()
+
+  if(args_STRIP_PREFIX)
+    set(maybe_prefix "")
+  elseif(args_PREFIX)
+    set(maybe_prefix "${args_PREFIX}")
+  else()
+    set(prefix_COMPILE_DEFINITIONS "-D")
+    set(prefix_SYSTEM_INCLUDE_DIRECTORIES "-isystem")
+    set(prefix_INCLUDE_DIRECTORIES "-I")
+    set(prefix_INTERFACE_COMPILE_DEFINITIONS "-D")
+    set(prefix_INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "-isystem")
+    set(prefix_INTERFACE_INCLUDE_DIRECTORIES "-I")
+    set(maybe_prefix "${prefix_${args_PROPERTY}}")
+  endif()
+
+  get_property(flags TARGET zephyr_interface PROPERTY ${args_PROPERTY})
+  if(args_LANG)
+    process_flags(${args_LANG} flags output_list)
+  else()
+    set(output_list "${flags}")
+  endif()
+  string(REPLACE ";" "$<SEMICOLON>" genexp_output_list "${output_list}")
+
+  set(result_output_list "${maybe_prefix}$<JOIN:${genexp_output_list},${args_DELIMITER}${maybe_prefix}>")
+  set(maybe_result_output_list "$<$<BOOL:${genexp_output_list}>:${result_output_list}>")
+
+  set(${output} ${maybe_result_output_list} PARENT_SCOPE)
+endfunction()
+
+# Direct wrappers of the above function for specific build information.
 # The naming convention follows:
-# zephyr_get_${build_information}_for_lang${format}(lang x [STRIP_PREFIX])
+# zephyr_get_${build_information}_for_lang${format}(lang x [options])
 # Where
 #  the argument 'x' is written with the result
 # and
@@ -183,97 +254,60 @@ endfunction()
 #  ${format} can be
 #   - the empty string '', signifying that it should be returned as a list
 #   - _as_string signifying that it should be returned as a string
-# and
-#  ${lang} can be one of
-#   - C
-#   - CXX
-#   - ASM
-#
-# STRIP_PREFIX
-#
-# By default the result will be returned ready to be passed directly
-# to a compiler, e.g. prefixed with -D, or -I, but it is possible to
-# omit this prefix by specifying 'STRIP_PREFIX' . This option has no
-# effect for 'compile_options'.
-#
-# e.g.
-# zephyr_get_include_directories_for_lang(ASM x)
-# writes "-Isome_dir;-Isome/other/dir" to x
-
-function(zephyr_get_include_directories_for_lang_as_string lang i)
-  zephyr_get_include_directories_for_lang(${lang} list_of_flags DELIMITER " " ${ARGN})
-  set(${i} ${str_of_flags} PARENT_SCOPE)
-endfunction()
-
-function(zephyr_get_system_include_directories_for_lang_as_string lang i)
-  zephyr_get_system_include_directories_for_lang(${lang} list_of_flags DELIMITER " " ${ARGN})
-  set(${i} ${str_of_flags} PARENT_SCOPE)
-endfunction()
-
-function(zephyr_get_compile_definitions_for_lang_as_string lang i)
-  zephyr_get_compile_definitions_for_lang(${lang} list_of_flags DELIMITER " " ${ARGN})
-  set(${i} ${str_of_flags} PARENT_SCOPE)
-endfunction()
-
-function(zephyr_get_compile_options_for_lang_as_string lang i)
-  zephyr_get_compile_options_for_lang(${lang} list_of_flags DELIMITER " ")
-  set(${i} ${str_of_flags} PARENT_SCOPE)
-endfunction()
 
 function(zephyr_get_include_directories_for_lang lang i)
-  zephyr_get_parse_args(args ${ARGN})
-  get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+  zephyr_get_build_property(result_output_list
+                            PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                            LANG ${lang} ${ARGN})
+  set(${i} ${result_output_list} PARENT_SCOPE)
+endfunction()
 
-  process_flags(${lang} flags output_list)
-  string(REPLACE ";" "$<SEMICOLON>" genexp_output_list "${output_list}")
-
-  if(NOT ARGN)
-    set(result_output_list "-I$<JOIN:${genexp_output_list},$<SEMICOLON>-I>")
-  elseif(args_STRIP_PREFIX)
-    # The list has no prefix, so don't add it.
-    set(result_output_list ${output_list})
-  elseif(args_DELIMITER)
-    set(result_output_list "-I$<JOIN:${genexp_output_list},${args_DELIMITER}-I>")
-  endif()
+function(zephyr_get_include_directories_for_lang_as_string lang i)
+  zephyr_get_build_property(result_output_list AS_STRING
+                            PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                            LANG ${lang} ${ARGN})
   set(${i} ${result_output_list} PARENT_SCOPE)
 endfunction()
 
 function(zephyr_get_system_include_directories_for_lang lang i)
-  zephyr_get_parse_args(args ${ARGN})
-  get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
+  zephyr_get_build_property(result_output_list
+                            PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                            LANG ${lang} ${ARGN})
+  set(${i} ${result_output_list} PARENT_SCOPE)
+endfunction()
 
-  process_flags(${lang} flags output_list)
-  string(REPLACE ";" "$<SEMICOLON>" genexp_output_list "${output_list}")
-
-  set_ifndef(args_DELIMITER "$<SEMICOLON>")
-  set(result_output_list "$<$<BOOL:${genexp_output_list}>:-isystem$<JOIN:${genexp_output_list},${args_DELIMITER}-isystem>>")
-
+function(zephyr_get_system_include_directories_for_lang_as_string lang i)
+  zephyr_get_build_property(result_output_list AS_STRING
+                            PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                            LANG ${lang} ${ARGN})
   set(${i} ${result_output_list} PARENT_SCOPE)
 endfunction()
 
 function(zephyr_get_compile_definitions_for_lang lang i)
-  zephyr_get_parse_args(args ${ARGN})
-  get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_COMPILE_DEFINITIONS)
+  zephyr_get_build_property(result_output_list
+                            PROPERTY INTERFACE_COMPILE_DEFINITIONS
+                            LANG ${lang} ${ARGN})
+  set(${i} ${result_output_list} PARENT_SCOPE)
+endfunction()
 
-  process_flags(${lang} flags output_list)
-  string(REPLACE ";" "$<SEMICOLON>" genexp_output_list "${output_list}")
-
-  set_ifndef(args_DELIMITER "$<SEMICOLON>")
-  set(result_output_list "-D$<JOIN:${genexp_output_list},${args_DELIMITER}-D>")
-
+function(zephyr_get_compile_definitions_for_lang_as_string lang i)
+  zephyr_get_build_property(result_output_list AS_STRING
+                            PROPERTY INTERFACE_COMPILE_DEFINITIONS
+                            LANG ${lang} ${ARGN})
   set(${i} ${result_output_list} PARENT_SCOPE)
 endfunction()
 
 function(zephyr_get_compile_options_for_lang lang i)
-  zephyr_get_parse_args(args ${ARGN})
-  get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_COMPILE_OPTIONS)
+  zephyr_get_build_property(result_output_list
+                            PROPERTY INTERFACE_COMPILE_OPTIONS
+                            LANG ${lang} ${ARGN})
+  set(${i} ${result_output_list} PARENT_SCOPE)
+endfunction()
 
-  process_flags(${lang} flags output_list)
-  string(REPLACE ";" "$<SEMICOLON>" genexp_output_list "${output_list}")
-
-  set_ifndef(args_DELIMITER "$<SEMICOLON>")
-  set(result_output_list "$<JOIN:${genexp_output_list},${args_DELIMITER}>")
-
+function(zephyr_get_compile_options_for_lang_as_string lang i)
+  zephyr_get_build_property(result_output_list AS_STRING
+                            PROPERTY INTERFACE_COMPILE_OPTIONS
+                            LANG ${lang} ${ARGN})
   set(${i} ${result_output_list} PARENT_SCOPE)
 endfunction()
 

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -202,33 +202,21 @@ endfunction()
 
 function(zephyr_get_include_directories_for_lang_as_string lang i)
   zephyr_get_include_directories_for_lang(${lang} list_of_flags DELIMITER " " ${ARGN})
-
-  convert_list_of_flags_to_string_of_flags(list_of_flags str_of_flags)
-
   set(${i} ${str_of_flags} PARENT_SCOPE)
 endfunction()
 
 function(zephyr_get_system_include_directories_for_lang_as_string lang i)
   zephyr_get_system_include_directories_for_lang(${lang} list_of_flags DELIMITER " " ${ARGN})
-
-  convert_list_of_flags_to_string_of_flags(list_of_flags str_of_flags)
-
   set(${i} ${str_of_flags} PARENT_SCOPE)
 endfunction()
 
 function(zephyr_get_compile_definitions_for_lang_as_string lang i)
   zephyr_get_compile_definitions_for_lang(${lang} list_of_flags DELIMITER " " ${ARGN})
-
-  convert_list_of_flags_to_string_of_flags(list_of_flags str_of_flags)
-
   set(${i} ${str_of_flags} PARENT_SCOPE)
 endfunction()
 
 function(zephyr_get_compile_options_for_lang_as_string lang i)
   zephyr_get_compile_options_for_lang(${lang} list_of_flags DELIMITER " ")
-
-  convert_list_of_flags_to_string_of_flags(list_of_flags str_of_flags)
-
   set(${i} ${str_of_flags} PARENT_SCOPE)
 endfunction()
 
@@ -373,31 +361,6 @@ function(process_flags lang input output)
 
   set(${output} ${tmp_list} PARENT_SCOPE)
 endfunction()
-
-function(convert_list_of_flags_to_string_of_flags ptr_list_of_flags string_of_flags)
-  # Convert the list to a string so we can do string replace
-  # operations on it and replace the ";" list separators with a
-  # whitespace so the flags are spaced out
-  string(REPLACE ";"  " "  locally_scoped_string_of_flags "${${ptr_list_of_flags}}")
-
-  # Set the output variable in the parent scope
-  set(${string_of_flags} ${locally_scoped_string_of_flags} PARENT_SCOPE)
-endfunction()
-
-macro(get_property_and_add_prefix result target property prefix)
-  zephyr_get_parse_args(args ${ARGN})
-
-  if(args_STRIP_PREFIX)
-    set(maybe_prefix "")
-  else()
-    set(maybe_prefix ${prefix})
-  endif()
-
-  get_property(target_property TARGET ${target} PROPERTY ${property})
-  foreach(x ${target_property})
-    list(APPEND ${result} ${maybe_prefix}${x})
-  endforeach()
-endmacro()
 
 # 1.2 zephyr_library_*
 #


### PR DESCRIPTION
**Not for 4.3.**

This PR unifies the implementation of the various `zephyr_get_*_for_lang` functions and their string variants with a generic `zephyr_get_property`, so that the same feature set is available to all wrappers. It also adds several new options that expand the possible use cases:

  - `AS_STRING`: Return the result as a string rather than a list. Equivalent to specifying `DELIMITER " "`.
  - `DELIMITER <delim>`: Specify the output delimiter to use for the list entries. Defaults to `$<SEMICOLON>`.
  - `GENEX`: Use generator expressions to get the property entries at build time, for targets that are not yet fully configured. Cannot be used with `LANG`. Also, CMake will complain if the requested property includes `$<COMPILE_OPTIONS:...>` expressions.
  - `LANG <C|CXX|ASM>`: When set, the property value is filtered for `$<COMPILE_LANGUAGE:lang>` entries, and only those matching the given language are kept. Cannot be used with `GENEX`.
  - `PREFIX <prefix>`: Specify a prefix to use for each entry in the output list.
  - `STRIP_PREFIX`: Omit the prefix string, even if given by `PREFIX`.
  - `TARGET <target>`: Specify the target to get the property from. Defaults to `zephyr_interface`.

This work was done while experimenting with alternatives to #98348. It is no longer useful for the EDK, but I think it is still worth considering for merge.