### PR TITLE
Bluetooth: Mesh: Fix invalid write in private beacon server

### DIFF
--- a/subsys/bluetooth/mesh/priv_beacon_srv.c
+++ b/subsys/bluetooth/mesh/priv_beacon_srv.c
@@ -151,13 +151,14 @@ static int handle_node_id_get(const struct bt_mesh_model *mod,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
-	uint8_t node_id, status;
+	enum bt_mesh_feat_state node_id;
 	uint16_t net_idx;
+	uint8_t status;
 
 	net_idx = net_buf_simple_pull_le16(buf) & 0xfff;
 
-	status = bt_mesh_subnet_priv_node_id_get(net_idx, (enum bt_mesh_feat_state *)&node_id);
-	node_id_status_rsp(mod, ctx, status, net_idx, node_id);
+	status = bt_mesh_subnet_priv_node_id_get(net_idx, &node_id);
+	node_id_status_rsp(mod, ctx, status, net_idx, (uint8_t)node_id);
 
 	return 0;
 }


### PR DESCRIPTION
There is no guarantess enum will be packed so passing uint8_t as node_id to bt_mesh_subnet_priv_node_id_get() could (and likely will) result in writing past stack variable.

This is affecting following bluetooth qualification test cases:
MESH/SR/PRB/PNID/BI-01-C 
MESH/SR/PRB/PNID/BI-02-C 
MESH/SR/PRB/PNID/BV-01-C 
MESH/SR/PRB/PNID/BV-02-C 
MESH/SR/PRB/PNID/BV-03-C 