### PR TITLE
Enable lpit on mcxe247

### DIFF
--- a/boards/nxp/frdm_mcxe247/board.c
+++ b/boards/nxp/frdm_mcxe247/board.c
@@ -211,6 +211,10 @@ __weak void clock_init(void)
 	CLOCK_SetIpSrc(kCLOCK_Adc1,
 		       DT_CLOCKS_CELL(DT_NODELABEL(adc1), ip_source));
 #endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpit0))
+	CLOCK_SetIpSrc(kCLOCK_Lpit0,
+		       DT_CLOCKS_CELL(DT_NODELABEL(lpit0), ip_source));
+#endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ftm0))
 	CLOCK_SetIpSrc(kCLOCK_Ftm0,
 		       DT_CLOCKS_CELL(DT_NODELABEL(ftm0), ip_source));

--- a/boards/nxp/frdm_mcxe247/frdm_mcxe247.dts
+++ b/boards/nxp/frdm_mcxe247/frdm_mcxe247.dts
@@ -131,6 +131,10 @@
 	clock-div = <1>;
 };
 
+&sircdiv2_clk {
+	clock-div = <1>;
+};
+
 &gpioa {
 	status = "okay";
 };
@@ -163,6 +167,26 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&pinmux_lpuart2>;
 	pinctrl-names = "default";
+};
+
+&lpit0 {
+	status = "okay";
+};
+
+&lpit0_channel0 {
+	status = "okay";
+};
+
+&lpit0_channel1 {
+	status = "okay";
+};
+
+&lpit0_channel2 {
+	status = "okay";
+};
+
+&lpit0_channel3 {
+	status = "okay";
 };
 
 &edma {

--- a/dts/arm/nxp/nxp_mcxe24x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxe24x_common.dtsi
@@ -296,6 +296,43 @@
 			status = "disabled";
 		};
 
+		lpit0: lpit@40037000 {
+			compatible = "nxp,lpit";
+			reg = <0x40037000 0x1000>;
+			interrupts = <48 0>, <49 0>, <50 0>, <51 0>;
+			interrupt-names = "chn0", "chn1", "chn2", "chn3";
+			clocks = <&pcc 0xdc KINETIS_PCC_SRC_SIRC_ASYNC>;
+			status = "disabled";
+			enable-run-in-doze;
+			max-load-value = <0xffffffff>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			lpit0_channel0: lpit_channel@0 {
+				compatible = "nxp,lpit-channel";
+				reg = <0>;
+				status = "disabled";
+			};
+
+			lpit0_channel1: lpit_channel@1 {
+				compatible = "nxp,lpit-channel";
+				reg = <1>;
+				status = "disabled";
+			};
+
+			lpit0_channel2: lpit_channel@2 {
+				compatible = "nxp,lpit-channel";
+				reg = <2>;
+				status = "disabled";
+			};
+
+			lpit0_channel3: lpit_channel@3 {
+				compatible = "nxp,lpit-channel";
+				reg = <3>;
+				status = "disabled";
+			};
+		};
+
 		ftm0: ftm@40038000 {
 			compatible = "nxp,ftm";
 			reg = <0x40038000 0x1000>;


### PR DESCRIPTION
1. Update LPIT driver to support multiple interrupts
2. Add LPIT device tree configuration
3. Enable lpit0 and its channels in frdm_mcxe247 dts