### PR TITLE
smf: improve sibling transitions speed 

### DIFF
--- a/lib/smf/smf.c
+++ b/lib/smf/smf.c
@@ -300,7 +300,10 @@ void smf_set_state(struct smf_ctx *const ctx, const struct smf_state *new_state)
 #ifdef CONFIG_SMF_ANCESTOR_SUPPORT
 	const struct smf_state *topmost;
 
-	if (is_descendant_of(ctx->executing, new_state)) {
+	if (ctx->executing != new_state && ctx->executing->parent == new_state->parent) {
+		/* Optimize sibling transitions (different states under same parent) */
+		topmost = ctx->executing->parent;
+	} else if (is_descendant_of(ctx->executing, new_state)) {
 		/* new state is a parent of where we are now*/
 		topmost = new_state;
 	} else if (is_descendant_of(new_state, ctx->executing)) {


### PR DESCRIPTION
This PR introduces `CONFIG_SMF_FAR_TRANSITION` to optimize transitions
between distant hierarchical states (classified as "far" when the depth
difference between source and destination is >= 3). When enabled, SMF
can use a hybrid strategy: near transitions use the classic LCA, and far
transitions use a dedicated far-LCA routine tuned for deep hierarchies.
Public APIs are unchanged.

* New variable ,`int32_t transition`, is added to `struct smf_ctx` (built only when 
`CONFIG_SMF_FAR_TRANSITION` is enabled).
A state can request the far-LCA algorithm for the next transition by setting
`ctx->transition = SMF_TRANSITION_FAR`.
During `smf_set_state()`, the transition type is read. If it is FAR, `get_lca_far()`
is used. The transition type is then reset to NEAR so subsequent transitions
use the classic LCA unless explicitly requested again.
 
* New `get_depth()` helper was added to calculate the depth of a state from root
(built only when `CONFIG_SMF_FAR_TRANSITION` is enabled):
`static inline uint8_t get_depth(const struct smf_state *state)`
 
* New enumeration is introduced in order to describe the type of transition:
```
  /**
 * @brief enum for choosing which transition function suits best with smf_set_state
 */
enum smf_transition_distance {
	SMF_TRANSITION_NEAR,
	SMF_TRANSITION_FAR
};
```
 
* Added a new ztest for testing benchmark on different boards. 
 
Micro-benchmark setup
- Board: NUCLEO-F746ZG (STM32F746, ~192 MHz)
- 200000 iterations per pair
- HSM topology (R is root):
      R
    /   \
   A     B
  / \   / \
 C  D  E  F
/ \        \
G  H        J
- Entry/exit are NULL to measure raw transition overhead.
- Results are cycles/transition; % is relative to baseline.

Baseline (CONFIG_SMF_FAR_TRANSITION=n)
  G<->G: 229 cycles
  C->G : 308 cycles
  A->H : 423 cycles
  G->H : 458 cycles
  G->D : 606 cycles
  D->E : 700 cycles
  J->D : 856 cycles
  J->G : 1025 cycles

Enabled but not used (CONFIG_SMF_FAR_TRANSITION=y; far-LCA never taken)
  G<->G: 262 vs 229 cycles  = +33 (+14.40%)
  C->G : 347 vs 308 cycles = +39 (+12.66%)
  A->H : 455 vs 423 cycles = +32 (+7.57%)
  G->H : 494 vs 458 cycles = +36 (+7.86%)
  G->D : 614 vs 606 cycles =  +8 (+1.32%)
  D->E : 703 vs 700 cycles =  +3 (+0.43%)
  J->D : 819 vs 856 cycles =  -37 (-4.32%)  improvement
  J->G : 957 vs 1025 cycles =  -68 (-6.63%)  improvement

Hybrid (only far pairs use far-LCA)
  G<->G: 233 vs 229 cycles =  +4 (+1.75%)
  C->G : 352 vs 308 cycles = +44 (+14.29%)
  A->H : 489 vs 423 cycles = +66 (+15.60%)
  G->H : 552 vs 458 cycles = +94 (+20.52%)
  G->D : 646 vs 606 cycles = +40 (+6.60%)
  D->E : 739 vs 700 cycles = +39 (+5.57%)
  J->D : 743 vs 856 cycles = -113 (-13.20%) improvement
  J->G : 817 vs 1025 cycles = -208 (-20.29%) improvement

All-far (force far-LCA for all transitions) -- not proposed
  G<->G: 378 vs 229 cycles = +149 (+65.07%)
  C->G : 430 vs 308 cycles = +122 (+39.61%)
  A->H : 612 vs 423 cycles = +189 (+44.68%)
  G->H : 483 vs 458 cycles =  +25 (+5.46%)
  G->D : 594 vs 606 cycles =  -12 (-1.98%)  improvement
  D->E : 624 vs 700 cycles =  -76 (-10.86%) improvement
  J->D : 729 vs 856 cycles = -127 (-14.84%) improvement
  J->G : 802 vs 1025 cycles = -223 (-21.76%) improvement

Summary
- Hybrid mode improves far transitions by ~13–20% on this setup while
  keeping default behavior unchanged when the option is off.
- Enabling the option introduces small overheads on near/mid paths if
  far-LCA is not taken; therefore default remains 'n'.
- Greater depth differences generally yield larger speedups because
   the far-LCA routine runs in O(h) time, while the classic ancestor-scan
   approach is O(h^2), in worst case. Here h is the number of steps from
   the deeper nodes to the LCA. As h grows, the far-LCA avoids repeated
   re-traversals and wins proportionally more.
 - Calculated use of far-LCA routine, can improve the speed of transitions
    in the HSM drastically. 