### PR TITLE
drivers: flash: nrf_qspi_nor: Fix compilation with QER set to NONE

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -481,7 +481,6 @@ static int qspi_send_cmd(const struct device *dev, const struct qspi_cmd *cmd,
 	return qspi_get_zephyr_ret_code(res);
 }
 
-#if !IS_EQUAL(INST_0_QER, JESD216_DW15_QER_VAL_NONE)
 /* RDSR.  Negative value is error. */
 static int qspi_rdsr(const struct device *dev, uint8_t sr_num)
 {
@@ -525,6 +524,7 @@ static int qspi_wait_while_writing(const struct device *dev, k_timeout_t poll_pe
 	return (rc < 0) ? rc : 0;
 }
 
+#if !IS_EQUAL(INST_0_QER, JESD216_DW15_QER_VAL_NONE)
 static int qspi_wrsr(const struct device *dev, uint8_t sr_val, uint8_t sr_num)
 {
 	int rc = 0;
@@ -657,7 +657,6 @@ static int qspi_erase(const struct device *dev, uint32_t addr, uint32_t size)
 
 static int configure_chip(const struct device *dev)
 {
-	const struct qspi_nor_config *dev_config = dev->config;
 	int rc = 0;
 
 	/* Set QE to match transfer mode.  If not using quad
@@ -668,6 +667,7 @@ static int configure_chip(const struct device *dev)
 	 * S2B1v1/4/5/6. Other options require more logic.
 	 */
 #if !IS_EQUAL(INST_0_QER, JESD216_DW15_QER_VAL_NONE)
+		const struct qspi_nor_config *dev_config = dev->config;
 		nrf_qspi_prot_conf_t const *prot_if =
 			&dev_config->nrfx_cfg.prot_if;
 		bool qe_value = (prot_if->writeoc == NRF_QSPI_WRITEOC_PP4IO) ||

--- a/tests/drivers/flash/common/boards/nrf52840dk_qer_none.overlay
+++ b/tests/drivers/flash/common/boards/nrf52840dk_qer_none.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025, Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mx25r64 {
+	quad-enable-requirements = "NONE";
+};

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -38,6 +38,13 @@ tests:
       - CONFIG_TEST_DRIVER_FLASH_SIZE=8388608
     integration_platforms:
       - nrf52840dk/nrf52840
+  drivers.flash.common.nrf_qspi_nor.qer_none:
+    build_only: true
+    platform_allow: nrf52840dk/nrf52840
+    extra_args:
+      - DTC_OVERLAY_FILE=boards/nrf52840dk_qer_none.overlay
+    integration_platforms:
+      - nrf52840dk/nrf52840
   drivers.flash.common.nrf_qspi_nor_4B_addr:
     platform_allow: nrf52840dk/nrf52840
     extra_configs:


### PR DESCRIPTION
This is a follow-up to commit d1abe40fb0af5d6219a0bcd824c4ea93ab90877a.

Function `qspi_wait_while_writing()` (and also `qspi_rdsr()` that is called by it) is now always required for `qspi_erase()`, so it can no longer be under `#if !IS_EQUAL(INST_0_QER, JESD216_DW15_QER_VAL_NONE)`.

Also definition of `dev_config` in `configure_chip()` needs to be moved, as for QER set to NONE, it is not used and causes a compilation warning.

Add a test case that will ensure the driver can be built successfully with `quad-enable-requirements = "NONE"`.

Fixes #91269.