### PR TITLE
samples: adc_stream: fix sample filter

### DIFF
--- a/samples/drivers/adc/adc_stream/sample.yaml
+++ b/samples/drivers/adc/adc_stream/sample.yaml
@@ -2,14 +2,15 @@ sample:
   name: ADC stream sample
 common:
   tags: adc
+  depends_on: adc
+  filter: dt_alias_exists("adc0") and dt_node_has_prop("/zephyr,user","io-channels")
   harness: console
   harness_config:
     type: one_line
     regex:
       - "^ADC data for [^@]+@\\d+ \\([0-9.]+\\) \\d+n$"
 tests:
-  sample.driver.adc_stream:
-    filter: dt_alias_exists("adc0")
+  sample.driver.adc_stream: {}
   sample.driver.adc_stream.ad4052-stream:
     extra_args:
       - SHIELD=eval_ad4052_ardz

--- a/samples/drivers/adc/adc_stream/src/main.c
+++ b/samples/drivers/adc/adc_stream/src/main.c
@@ -19,13 +19,11 @@
 
 #define SAMPLE_DT_SPEC_AND_COMMA(node_id, prop, idx) ADC_DT_SPEC_GET_BY_IDX(node_id, idx),
 
-#if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), io_channels)
 /* Data of ADC io-channels specified in devicetree. */
 static const struct adc_dt_spec adc_channels[] = {
 	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels, SAMPLE_DT_SPEC_AND_COMMA)
 };
 static const int adc_channels_count = ARRAY_SIZE(adc_channels);
-#endif
 
 static void init_adc(void)
 {


### PR DESCRIPTION
io-channels in zephyr,user is required for this sample to compile, so add that to the filter and remove the redundant ifdef in the source code.