### PR TITLE
wifi: nrf_wifi: named MAC address choice

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -538,7 +538,7 @@ config WIFI_FIXED_MAC_ADDRESS
 	help
 	  This option overrides the MAC address read from OTP. It is strictly for testing purposes only.
 
-choice
+choice WIFI_MAC_ADDRESS
 	prompt "Wi-Fi MAC address type"
 	default WIFI_FIXED_MAC_ADDRESS_ENABLED if WIFI_FIXED_MAC_ADDRESS != ""
 	default WIFI_OTP_MAC_ADDRESS


### PR DESCRIPTION
Add a name to the "Wi-Fi MAC address type" choice symbol so that the default can be updated on a per-board basis.