### PR TITLE
boards native_sim: Remove NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME

### DIFF
--- a/boards/native/native_sim/Kconfig
+++ b/boards/native/native_sim/Kconfig
@@ -28,14 +28,6 @@ config NATIVE_SIM_SLOWDOWN_TO_REAL_TIME
 	  case the zephyr kernel and application cannot tell the difference unless they
 	  interact with some other driver/device which runs at real time.
 
-config NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
-	bool "Slow down execution to real time (native_posix compat)"
-	select NATIVE_SIM_SLOWDOWN_TO_REAL_TIME
-	select DEPRECATED
-	help
-	  Transitional option which allows applications which targeted native_posix
-	  to set the correct native_sim option (CONFIG_NATIVE_SIM_SLOWDOWN_TO_REAL_TIME)
-
 config NATIVE_SIM_REBOOT
 	bool "Reboot support"
 	depends on REBOOT


### PR DESCRIPTION
The kconfig option NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME was deprecated in bd42df26626a82fa14cafc86d9dfec728aa366da for the 4.2 release. Let's remove it now.

Users should be using NATIVE_SIM_SLOWDOWN_TO_REAL_TIME instead.

Deprecation PR:
* https://github.com/zephyrproject-rtos/zephyr/pull/86343