### PR TITLE
drivers/ethernet/eth_native_tap: Fix use of deprecated kconfig

### DIFF
--- a/drivers/ethernet/eth_native_tap.c
+++ b/drivers/ethernet/eth_native_tap.c
@@ -400,7 +400,7 @@ static void eth_iface_init(struct net_if *iface)
 	}
 #endif
 
-	ctx->dev_fd = eth_iface_create(CONFIG_ETH_NATIVE_POSIX_DEV_NAME, ctx->if_name, false);
+	ctx->dev_fd = eth_iface_create(CONFIG_ETH_NATIVE_TAP_DEV_NAME, ctx->if_name, false);
 	if (ctx->dev_fd < 0) {
 		LOG_ERR("Cannot create %s (%d/%s)", ctx->if_name, ctx->dev_fd,
 			strerror(-ctx->dev_fd));


### PR DESCRIPTION
In 200b886d3c579ecbac1083c3ed35bd53f5412444 a deprecated kconfig option was brought back into the driver.
Let's fix it.