### PR TITLE
modules: nordic: select correct timer for NFCT on nRF54L

### DIFF
--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -281,6 +281,7 @@ config NRFX_NFCT
 	depends on $(dt_nodelabel_exists,nfct)
 	select NRFX_TIMER4 if SOC_SERIES_NRF52X
 	select NRFX_TIMER2 if SOC_SERIES_NRF53X
+	select NRFX_TIMER24 if SOC_SERIES_NRF54LX
 
 config NRFX_NVMC
 	bool "NVMC driver"


### PR DESCRIPTION
Set the appropriate default NFC timer for the nRF54L series SoCs.
The timer is used for workarounds in the driver.