### PR TITLE
cbprintf: fix Z_CONSTIFY()

### DIFF
--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -562,7 +562,7 @@ extern "C" {
 #else
 #define Z_CONSTIFY(v) ({ \
 	__auto_type _uv = (v); \
-	__typeof__(_uv) const _cv = _uv; \
+	const __typeof__(_uv) _cv = _uv; \
 	_cv; \
 })
 #define Z_CBPRINTF_ARG_SIZE(v) ({\


### PR DESCRIPTION
An earlier commit changed the definition of Z_CONSTIFY() and broke sparse analyzer support. Before commit 8b11221746e0 ("sys: cbprintf: Fix performance-no-int-to-ptr warning") Z_CONSTIFY() used to type-cast char * to const char *, while after it the typecast becomes from char * to char * const. Fix it back to the correct meaning and fix sparse errors.

Fixes: #93444