### PR TITLE
scripts: west_commands: Pacify linter in test

### DIFF
--- a/scripts/west_commands/tests/west_build/test_dir_fmt.py
+++ b/scripts/west_commands/tests/west_build/test_dir_fmt.py
@@ -9,6 +9,7 @@ from argparse import Namespace
 from pathlib import Path
 
 import pytest
+
 from build import Build
 
 ROOT = Path(Path.cwd().anchor)


### PR DESCRIPTION
The ruff linter complains about this imports block, let's fix it as it requests.

The error:
```
ERROR   : Test Ruff failed: 
Python lint error (I001) see https://docs.astral.sh/ruff/rules/unsorted-imports:Import block is un-sorted or un-formatted
File:zephyr/scripts/west_commands/tests/west_build/test_dir_fmt.py
Line:5
Column:1
EndLine:11
EndColumn:25
```

File introduced in 5ee522efc0fa68318d70683bf42f98044b9d2692