### PR TITLE
scripts: ci: check_compliance: Handle missing npx

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -510,7 +510,7 @@ class DevicetreeLintingCheck(ComplianceTest):
             return True
         except subprocess.CalledProcessError:
             return False
-        except FileNotFoundError:
+        except (FileNotFoundError, PermissionError):
             # npx itself not installed
             return False
 


### PR DESCRIPTION
If npm/npx is not installed, (at least in my system) the raised exception is PermissionError when trying to execute it.

Let's handle this exception instead of crashing.

This fix stops check_compliance.py from crashing when npx/npm is not installed

Issue introduced in c581297f2c38855d2c1c70ef5a2a7862afce9da2