### PR TITLE
drivers: bluetooth: h4: Fix check for sufficient buffer size

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -338,7 +338,7 @@ static inline void read_payload(const struct device *dev)
 		LOG_DBG("Allocated rx.buf %p", h4->rx.buf);
 
 		buf_tailroom = net_buf_tailroom(h4->rx.buf);
-		if (buf_tailroom < h4->rx.remaining) {
+		if (buf_tailroom < (h4->rx.remaining + h4->rx.hdr_len)) {
 			LOG_ERR("Not enough space in buffer %u/%zu", h4->rx.remaining,
 				buf_tailroom);
 			h4->rx.discard = h4->rx.remaining;


### PR DESCRIPTION
When alloc the evt buffer,such as the adv report, only compare the remaining data len, should aslo consider the hdr_len, because the hdr also copy to alloced buffer.if not consider the hdr, then hdr + remaining data may larger than alloced buffer, because the alloced buffer is not enough,then will assert when receive the remaining data.

Fixes #98469