### PR TITLE
Bluetooth: Host: Fix handling of adv reports when scanning for connection

### DIFF
--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -632,13 +632,14 @@ static void le_adv_recv(bt_addr_le_t *addr, struct bt_le_scan_recv_info *info,
 	struct bt_le_scan_cb *listener, *next;
 	struct net_buf_simple_state state;
 	bt_addr_le_t id_addr;
+	bool explicit_scan = atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	bool conn_scan     = atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_CONN);
 
 	LOG_DBG("%s event %u, len %u, rssi %d dBm", bt_addr_le_str(addr), info->adv_type, len,
 		info->rssi);
 
 	if (!IS_ENABLED(CONFIG_BT_PRIVACY) && !IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) &&
-	    atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN) &&
-	    (info->adv_props & BT_HCI_LE_ADV_PROP_DIRECT)) {
+	    explicit_scan && (info->adv_props & BT_HCI_LE_ADV_PROP_DIRECT)) {
 		LOG_DBG("Dropped direct adv report");
 		return;
 	}
@@ -650,6 +651,13 @@ static void le_adv_recv(bt_addr_le_t *addr, struct bt_le_scan_recv_info *info,
 	} else {
 		bt_addr_le_copy(&id_addr,
 				bt_lookup_id_addr(BT_ID_DEFAULT, addr));
+	}
+
+	/* For connection-purpose scanning,
+	 * skip app callbacks but allow pending-conn check logic.
+	 */
+	if (!explicit_scan && conn_scan) {
+		goto check_pending_conn;
 	}
 
 	if (scan_dev_found_cb) {
@@ -677,6 +685,7 @@ static void le_adv_recv(bt_addr_le_t *addr, struct bt_le_scan_recv_info *info,
 	/* Clear pointer to this stack frame before returning to calling function */
 	info->addr = NULL;
 
+check_pending_conn:
 #if defined(CONFIG_BT_CENTRAL)
 	check_pending_conn(&id_addr, addr, info->adv_props);
 #endif /* CONFIG_BT_CENTRAL */
@@ -805,6 +814,8 @@ static void create_ext_adv_info(struct bt_hci_evt_le_ext_advertising_info const 
 void bt_hci_le_adv_ext_report(struct net_buf *buf)
 {
 	uint8_t num_reports = net_buf_pull_u8(buf);
+	bool explicit_scan = atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	bool conn_scan     = atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_CONN);
 
 	LOG_DBG("Adv number of reports %u", num_reports);
 
@@ -817,19 +828,23 @@ void bt_hci_le_adv_ext_report(struct net_buf *buf)
 		bool more_to_come;
 		bool is_new_advertiser;
 
-		if (!atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN)) {
+		if (!explicit_scan) {
 			/* The application has not requested explicit scan, so it is not expecting
 			 * advertising reports. Discard, and reset the reassembler if not inactive
 			 * This is done in the loop as this flag can change between each iteration,
 			 * and it is not uncommon that scanning is disabled in the callback called
-			 * from le_adv_recv
+			 * from le_adv_recv.
+			 *
+			 * However, if scanning is running for connection purposes,
+			 * the report shall still be processed to allow pending connections.
 			 */
-
 			if (reassembling_advertiser.state != FRAG_ADV_INACTIVE) {
 				reset_reassembling_advertiser();
 			}
 
-			break;
+			if (!conn_scan) {
+				break;
+			}
 		}
 
 		if (buf->len < sizeof(*evt)) {
@@ -1669,18 +1684,23 @@ void bt_hci_le_adv_report(struct net_buf *buf)
 {
 	uint8_t num_reports = net_buf_pull_u8(buf);
 	struct bt_hci_evt_le_advertising_info *evt;
+	bool explicit_scan = atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	bool conn_scan     = atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_CONN);
 
 	LOG_DBG("Adv number of reports %u",  num_reports);
 
 	while (num_reports--) {
 		struct bt_le_scan_recv_info adv_info;
 
-		if (!atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN)) {
+		if (!explicit_scan && !conn_scan) {
 			/* The application has not requested explicit scan, so it is not expecting
 			 * advertising reports. Discard.
 			 * This is done in the loop as this flag can change between each iteration,
 			 * and it is not uncommon that scanning is disabled in the callback called
-			 * from le_adv_recv
+			 * from le_adv_recv.
+			 *
+			 * However, if scanning is running for connection purposes,
+			 * the report shall still be processed to allow pending connections.
 			 */
 
 			break;


### PR DESCRIPTION
🧩 Change Background

When calling:

```
int bt_conn_le_create(const bt_addr_le_t *peer,
		      const struct bt_conn_le_create_param *create_param,
		      const struct bt_le_conn_param *conn_param,
		      struct bt_conn **ret_conn)
```


Normally, a BLE connection will go through:

```
bt_conn_set_state(conn, BT_CONN_INITIATING);

err = bt_le_create_conn(conn);
if (err) {
	conn->err = 0;
	bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
	bt_conn_unref(conn);

	/* Best-effort attempt to inform the scanner that the initiator stopped. */
	int scan_check_err = bt_le_scan_user_add(BT_LE_SCAN_USER_NONE);

	if (scan_check_err) {
		LOG_WRN("Error while updating the scanner (%d)", scan_check_err);
	}
	return err;
}
```

⚠️ Problem Case

After pairing and distributing IRK,
if the controller resolving list size = 0,
the next connection will follow the “host-based resolving” path:

```
if (bt_dev.le.rl_entries > bt_dev.le.rl_size) {
	/* Use host-based identity resolving. */
	bt_conn_set_state(conn, BT_CONN_SCAN_BEFORE_INITIATING);

	err = bt_le_scan_user_add(BT_LE_SCAN_USER_CONN);
	if (err) {
		bt_le_scan_user_remove(BT_LE_SCAN_USER_CONN);
		bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
		bt_conn_unref(conn);

		return err;
	}

	*ret_conn = conn;
	return 0;
}
```


This means the Host will start a scan automatically and mark it with flag:

`BT_LE_SCAN_USER_CONN`


However, in le_adv_recv(), if the scan is not started by user (not BT_LE_SCAN_USER_EXPLICIT_SCAN),
the advertising report is ignored:

```
if (!atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN)) {
	/* skip this adv report */
	return;
}

```

As a result, the connection logic below can never be triggered:

```
conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, id_addr,
			       BT_CONN_SCAN_BEFORE_INITIATING);
if (!conn) {
	return;
}

err = bt_le_scan_user_remove(BT_LE_SCAN_USER_CONN);
bt_addr_le_copy(&conn->le.resp_addr, addr);
bt_le_create_conn(conn);
```

I found this issue when testing with a PTS dongle.
Because the dongle controller has a resolving list size of 0,
the host entered the host-based resolving path and triggered this bug logic.

The bad effect is that the host keeps scanning forever but never establishes the LE connection.