### PR TITLE
Bluetooth: Host: Fix crash on bt_disable() with limited advertising

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -34,6 +34,7 @@
 #include "hci_core.h"
 #include "id.h"
 #include "scan.h"
+#include "adv.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
 LOG_MODULE_REGISTER(bt_adv);
@@ -247,12 +248,15 @@ void bt_le_ext_adv_foreach(void (*func)(struct bt_le_ext_adv *adv, void *data),
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 }
 
+static void clear_ext_adv_instance(struct bt_le_ext_adv *adv, void *data)
+{
+	bt_le_lim_adv_cancel_timeout(adv);
+	memset(adv, 0, sizeof(*adv));
+}
+
 void bt_adv_reset_adv_pool(void)
 {
-#if defined(CONFIG_BT_EXT_ADV)
-	(void)memset(&adv_pool, 0, sizeof(adv_pool));
-#endif /* defined(CONFIG_BT_EXT_ADV) */
-
+	bt_le_ext_adv_foreach(clear_ext_adv_instance, NULL);
 	(void)memset(&bt_dev.adv, 0, sizeof(bt_dev.adv));
 }
 


### PR DESCRIPTION
When limited advertising is enabled there is pending deleyable work for timing it out. If in such case struct bt_le_ext_adv is cleared by memset system will crash on next tick.

Fix this by ensuring work is cancelled before clearing struct bt_le_ext_adv. Using bt_le_ext_adv_foreach() ensures that this will be correctly handled with and without extended advertising enabled.