### PR TITLE
west: spdx: Fix copyright parsing

### DIFF
--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -24,7 +24,7 @@ pyserial
 requests>=2.32.4
 semver
 tqdm>=4.67.1
-reuse
+reuse>=6.0.0
 
 # for ram/rom reports
 anytree

--- a/scripts/west_commands/zspdx/scanner.py
+++ b/scripts/west_commands/zspdx/scanner.py
@@ -194,8 +194,8 @@ def getCopyrightInfo(filePath):
         copyrights = []
 
         for info in infos:
-            if info.copyright_lines:
-                copyrights.extend(info.copyright_lines)
+            for notice in info.copyright_notices:
+                copyrights.extend([notice.original])
 
         return copyrights
     except Exception as e:


### PR DESCRIPTION
Fix the copyright parsing bug resulting from the new REUSE API. See the related issue for more information on the API change from v0.5.x and v0.6.x in REUSE.

Fixes #98378 
