### PR TITLE
scripts: Improve handling exceptions in compliance check script

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -2264,9 +2264,11 @@ class Ruff(ComplianceTest):
     doc = "Check python files with ruff."
 
     def run(self):
+        if (ruff := shutil.which("ruff")) is None:
+            raise FileNotFoundError("ruff is not installed")
         try:
             subprocess.run(
-                "ruff check --output-format=json",
+                f"{ruff} check --output-format=json",
                 check=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
@@ -2274,8 +2276,19 @@ class Ruff(ComplianceTest):
                 cwd=GIT_TOP,
             )
         except subprocess.CalledProcessError as ex:
-            output = ex.output.decode("utf-8")
-            messages = json.loads(output)
+            try:
+                output = ex.output.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                print("Decode error:", exc)
+                raise
+            try:
+                messages = json.loads(output)
+            except json.decoder.JSONDecodeError:
+                print(
+                    "Cannot parse output from ruff check, output is not valid JSON format:\n"
+                    f"{output}"
+                )
+                raise
             for m in messages:
                 self.fmtd_failure(
                     "error",
@@ -2294,7 +2307,7 @@ class Ruff(ComplianceTest):
 
             try:
                 subprocess.run(
-                    f"ruff format --force-exclude --diff {file}",
+                    f"{ruff} format --force-exclude --diff {file}",
                     check=True,
                     shell=True,
                     cwd=GIT_TOP,


### PR DESCRIPTION
When output from ruff check subprocess is not in JSON format compliance script raises an exception without any useful information about the error. This commit improves that by printing output from subprocess in case of error.

An example of unhandled exception:
```
 An exception occurred in Ruff:
Traceback (most recent call last):
  File "/home/runner/work/../zephyr/scripts/ci/check_compliance.py", line 2529, in _main
    test.run()
  File "/home/runner/work/../zephyr/scripts/ci/check_compliance.py", line 2275, in run
    messages = json.loads(output)
               ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```