### PR TITLE
doc: rst: fix typo in (boards, doc, samples)

### DIFF
--- a/boards/adi/max32657evkit/doc/index.rst
+++ b/boards/adi/max32657evkit/doc/index.rst
@@ -414,7 +414,7 @@ in the Secure world, and ideally has robust software running that can protect as
 a wide range of possible software attacks (`1`_).
 
 MPC (Memory Protection Controller) and PPC (Peripheral Protection Controller) are allow to
-protect memory and peripheral. Incase of need peripheral and flash ownership can be updated in
+protect memory and peripheral. In case of need peripheral and flash ownership can be updated in
 <zephyr_path>../modules/tee/tf-m/trusted-firmware-m/platform/ext/target/adi/max32657/s_ns_access.cmake`
 file by updating cmake flags to ON/OFF.
 

--- a/boards/adi/max32658evkit/doc/index.rst
+++ b/boards/adi/max32658evkit/doc/index.rst
@@ -410,7 +410,7 @@ in the Secure world, and ideally has robust software running that can protect as
 a wide range of possible software attacks (`1`_).
 
 MPC (Memory Protection Controller) and PPC (Peripheral Protection Controller) are allow to
-protect memory and peripheral. Incase of need peripheral and flash ownership can be updated in
+protect memory and peripheral. In case of need peripheral and flash ownership can be updated in
 <zephyr_path>../modules/tee/tf-m/trusted-firmware-m/platform/ext/target/adi/max32657/s_ns_access.cmake`
 file by updating cmake flags to ON/OFF.
 

--- a/boards/arduino/uno_q/doc/index.rst
+++ b/boards/arduino/uno_q/doc/index.rst
@@ -17,7 +17,7 @@ Hardware
 - 2 Mbyte of Flash memory and 786 Kbytes of RAM
 - 2 RGB user LEDs
 - One 13x8 LED Matrix
-- Internal UART and SPI busses connected to the QRB2210
+- Internal UART and SPI buses connected to the QRB2210
 - Built-in CMSIS-DAP debug adapter (through QRB2210)
 
 Supported Features

--- a/boards/intel/socfpga_std/cyclonev_socdk/doc/index.rst
+++ b/boards/intel/socfpga_std/cyclonev_socdk/doc/index.rst
@@ -183,7 +183,7 @@ This provisions the Zephyr kernel and the CPU configuration onto the board,
 using the customized OpenOCD runner script :zephyr_file:`scripts/west_commands/runners/intel_cyclonev.py`
 After it completes the kernel will immediately boot using the GSRD preloader.
 Notice that there a lot of helper files to ``flash`` the application with
-OpenOCD and GDB Debbuger (Zephyr SDK must be installed in your machine).
+OpenOCD and GDB Debugger (Zephyr SDK must be installed in your machine).
 This files should be located in :zephyr_file:`boards/intel/socfpga_std/cyclonev_socdk/support/` including:
 
 * blaster_6810.hex : USB-BlasterII firmware
@@ -326,7 +326,7 @@ You will see output similar to the following:
 
 Try other examples
 ==================
-There are varios examples that can be downloaded to the Cyclone® V SoC FPGA
+There are various examples that can be downloaded to the Cyclone® V SoC FPGA
 Development Kit Board. Try to ``blink`` an LED from the HPS side of the chip:
 
 .. zephyr-app-commands::

--- a/boards/ite/it8xxx2_evb/doc/index.rst
+++ b/boards/ite/it8xxx2_evb/doc/index.rst
@@ -116,7 +116,7 @@ Use the winflash tool to program a zephyr application
 to the it8xxx2 board flash.
 
 #. Open winflash tool and make sure the order you open the switch is right.
-   Fisrt, turn on the Download board switch.
+   First, turn on the Download board switch.
    Second, turn on the it8xxx2_evb board switch.
    Then, configure your winflash tool like below.
 

--- a/boards/native/native_sim/doc/index.rst
+++ b/boards/native/native_sim/doc/index.rst
@@ -518,7 +518,7 @@ By default one ready UART of this type is setup in DTS, but any number can be en
 Normally these UARTs are connected to new pseudoterminals PTYs, i.e. :file:`/dev/pts{<nbr>}`,
 but it is also possible to map one of them to the executable's ``stdin`` and ``stdout``.
 This can be done in two ways, either with the command line option ``--<uart_name>_stdinout``
-(where ``<uart_name>`` is the UART DTS node name), or, for the first PTY UART instance by chosing
+(where ``<uart_name>`` is the UART DTS node name), or, for the first PTY UART instance by choosing
 :kconfig:option:`CONFIG_UART_NATIVE_PTY_0_ON_STDINOUT` instead of the default
 :kconfig:option:`CONFIG_UART_NATIVE_PTY_0_ON_OWN_PTY`.
 For interactive use with the :ref:`shell_api`, it is recommended to choose the PTY option.

--- a/boards/nxp/frdm_mcxe31b/doc/index.rst
+++ b/boards/nxp/frdm_mcxe31b/doc/index.rst
@@ -39,7 +39,7 @@ bank), and ``PTA20`` is the pin 4 of ``gpioa_h`` (high bank).
 The GPIO controller provides the option to route external input pad interrupts
 to either the SIUL2 EIRQ or WKPU interrupt controllers, as supported by the SoC.
 By default, GPIO interrupts are routed to SIUL2 EIRQ interrupt controller,
-unless they are explicity configured to be directed to the WKPU interrupt
+unless they are explicitly configured to be directed to the WKPU interrupt
 controller, as outlined in :zephyr_file:`dts/bindings/gpio/nxp,siul2-gpio.yaml`.
 
 To find information about which GPIOs are compatible with each interrupt

--- a/boards/nxp/imx8mp_evk/doc/index.rst
+++ b/boards/nxp/imx8mp_evk/doc/index.rst
@@ -266,7 +266,7 @@ Load and Run M7 Zephyr Image by using Linux remoteproc
 
 Prepare device tree:
 
-The device tree must inlcude CM7 dts node with compatible string "fsl,imx8mn-cm7",
+The device tree must include CM7 dts node with compatible string "fsl,imx8mn-cm7",
 and also need to reserve M4 DDR memory if using DDR code and sys address, and also
 need to put "m4_reserved" in the list of memory-region property of the cm7 node.
 

--- a/boards/olimex/olimex_esp32_evb/doc/index.rst
+++ b/boards/olimex/olimex_esp32_evb/doc/index.rst
@@ -26,7 +26,7 @@ Hardware
 - BL4054B LiPo battery charger with status LEDs for stand-alone operation during
   power outages.
 - Power jack for external 5VDC power supply.
-- Univeral EXTension (UEXT) connector for connecting UEXT modules.
+- Universal EXTension (UEXT) connector for connecting UEXT modules.
 - User push button.
 - 40 pin GPIO connector with all ESP32 pins.
 

--- a/boards/others/icev_wireless/doc/index.rst
+++ b/boards/others/icev_wireless/doc/index.rst
@@ -13,7 +13,7 @@ Hardware
 This board combines an Espressif ESP32-C3-MINI-1 (which includes 4MB of flash in the module) with a
 Lattice iCE40UP5k-SG48 FPGA to allow WiFi and Bluetooth control of the FPGA. ESP32 and FPGA I/O is
 mostly uncommitted except for the pins used for SPI communication between ESP32 and FPGA. Several
-of the ESP32C3 GPIO pins are available for additonal interfaces such as serial, ADC, I2C, etc.
+of the ESP32C3 GPIO pins are available for additional interfaces such as serial, ADC, I2C, etc.
 
 For details on ESP32-C3 hardware please refer to the following resources:
 

--- a/boards/renesas/mck_ra8t2/doc/index.rst
+++ b/boards/renesas/mck_ra8t2/doc/index.rst
@@ -57,7 +57,7 @@ The specifications of the CPU board are shown below:
 
 This product has the onboard debugger circuit, J-Link On-Board (hereinafter called “J-Link-OB”). When you write a
 program, open the JP3 and connect the USB connector(CN13) on CPU board to PC with USB cable. J-Link-OB operates as debugger equivalent to J-Link.
-If connecting from flash programing tool (e.g. J-Flash Lite by SEGGER), set the type of debugger (tool) to “J-Link”
+If connecting from flash programming tool (e.g. J-Flash Lite by SEGGER), set the type of debugger (tool) to “J-Link”
 
 Hardware
 ********

--- a/boards/shields/mikroe_ambient_2_click/doc/index.rst
+++ b/boards/shields/mikroe_ambient_2_click/doc/index.rst
@@ -29,7 +29,7 @@ Requirements
 
 
 This shield can only be used with a board that provides a mikroBUS |trade| socket and defines a
-``mikrobus_i2c`` node label for the mikroBUS |trade| I2C interfac e. See :ref:`shields` for more
+``mikrobus_i2c`` node label for the mikroBUS |trade| I2C interface. See :ref:`shields` for more
 details.
 
 Programming

--- a/boards/ti/cc1352p7_launchpad/doc/index.rst
+++ b/boards/ti/cc1352p7_launchpad/doc/index.rst
@@ -120,7 +120,7 @@ Prerequisites:
 #. Install OpenOCD
 
    Currently, OpenOCD doesn't support the CC1352P7.
-   Until its support get merged, we have to builld a downstream version that could found `here <https://github.com/anobli/openocd>`_.
+   Until its support get merged, we have to build a downstream version that could found `here <https://github.com/anobli/openocd>`_.
    Please refer to OpenOCD documentation to build and install OpenOCD.
 
    For your convenience, we provide a `prebuilt binary <https://github.com/anobli/openocd/actions/runs/10566225265>`_.

--- a/boards/ti/lp_em_cc2340r5/doc/index.rst
+++ b/boards/ti/lp_em_cc2340r5/doc/index.rst
@@ -86,7 +86,7 @@ Programming and Debugging
 The LP_EM_CC2340R5 requires an external debug probe such as the LP-XDS110 or
 LP-XDS110ET.
 
-Alternativly a J-Link could be used on the J4 header, in combination with a 3.3V
+Alternatively a J-Link could be used on the J4 header, in combination with a 3.3V
 power supply over the pinheader.
 Debugging and flashing is currently only tested using a J-Link on the J4 header.
 

--- a/boards/waveshare/rp2040_keyboard_3/doc/index.rst
+++ b/boards/waveshare/rp2040_keyboard_3/doc/index.rst
@@ -6,7 +6,7 @@ Overview
 The `Waveshare 3-Key Shortcut Keyboard Development Board`_ is based on the RP2040 microcontroller
 from Raspberry Pi Ltd. It has three keys with the default values "CTRL", "C" and "V". The board
 is equipped with two USB type C connectors. There are two versions of the keyboard, where the
-diffence is in the housing (plastic or metal). This board definition can be used with both versions.
+difference is in the housing (plastic or metal). This board definition can be used with both versions.
 
 
 Hardware

--- a/boards/witte/linum/doc/index.rst
+++ b/boards/witte/linum/doc/index.rst
@@ -314,7 +314,7 @@ flashed in the usual way (see :ref:`build_an_application` and
 .. note::
 
   For debugging or programming Linum you will need to use an external debug
-  debug or flash tool and connect it to the SWD Connnector. JLink or ST-Link
+  debug or flash tool and connect it to the SWD Connector. JLink or ST-Link
   probes are examples of out of the box compatible tools.
 
 Flashing

--- a/doc/build/sysbuild/images.rst
+++ b/doc/build/sysbuild/images.rst
@@ -279,7 +279,7 @@ Image configuration script
 ==========================
 
 An image configuration script is a CMake file that can be used to configure an image with common
-configuration values, multiple can be used per image, the configuration should be transferrable to
+configuration values, multiple can be used per image, the configuration should be transferable to
 different images to correctly configure them based upon options set in sysbuild. MCUboot
 configuration options are configured in both the application the MCUboot image using this method
 which allows sysbuild to be the central location for things like the signing key which are then

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -73,7 +73,7 @@ Deprecated APIs and options
 ===========================
 
 * :dtcompatible:`maxim,ds3231` is deprecated in favor of :dtcompatible:`maxim,ds3231-rtc`.
-* Providing a third agument to :c:macro:`SPI_CONFIG_DT`, :c:macro:`SPI_CONFIG_DT_INST`,
+* Providing a third argument to :c:macro:`SPI_CONFIG_DT`, :c:macro:`SPI_CONFIG_DT_INST`,
   :c:macro:`SPI_DT_SPEC_GET`, :c:macro:`SPI_DT_SPEC_INST_GET` is deprecated. Providing a
   second argument to :c:macro:`SPI_CS_CONTROL_INIT` is deprecated. Use new DT properties
   ``spi-cs-setup-delay-ns`` and ``spi-cs-hold-delay-ns`` to specify delay instead.

--- a/doc/services/pm/device.rst
+++ b/doc/services/pm/device.rst
@@ -265,7 +265,7 @@ for brevity, in real drivers they must be handled.
            /* Disable the device. In this case, we use the enable pin */
            (void)gpio_pin_set_dt(&config->enable_pin, 0);
 
-           /* Release devices currenty not needed by device */
+           /* Release devices currently not needed by device */
            (void)pm_device_runtime_put(config->enable_pin.port);
            (void)pm_device_runtime_put(config->int_pin.port);
 
@@ -304,7 +304,7 @@ for brevity, in real drivers they must be handled.
            (void)gpio_pin_interrupt_configure_dt(&config->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 
            /*
-            * Release devices currenty not needed by device. In this case, we
+            * Release devices currently not needed by device. In this case, we
             * are releasing the bus and the enable pin.
             *
             * The device driver would keep the bus ACTIVE while the device is

--- a/samples/drivers/adc/adc_stream/README.rst
+++ b/samples/drivers/adc/adc_stream/README.rst
@@ -23,7 +23,7 @@ For example:
 		};
 	};
 
-Make sure the aliase are in devicetree, then build and run with:
+Make sure the aliases are in devicetree, then build and run with:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/adc/adc_stream

--- a/samples/modules/chre/README.rst
+++ b/samples/modules/chre/README.rst
@@ -10,7 +10,7 @@ Android's context hub enables the use of nanoapps. A single nanoapp has 3 entry 
 `chre_api/chre/nanoapp.h`_:
 
 * A ``nanoappStart`` function used to notify the nanoapp that it is now active.
-* A ``nanoappHandleEvent`` function used to notify the nanoapp tha an event of interest took place.
+* A ``nanoappHandleEvent`` function used to notify the nanoapp that an event of interest took place.
 * A ``nanoappEnd`` function used to notify the nanoapp that it is now deactivated.
 
 The CHRE connects to several frameworks called Platform Abstraction Layers (PAL)s. Note that

--- a/samples/net/openthread/coap/README.rst
+++ b/samples/net/openthread/coap/README.rst
@@ -76,7 +76,7 @@ Example building CoAP client for the cc1352p7 launchpad:
 Checking Thread network state
 *****************************
 
-Open a console on both server and client boards then check the sate:
+Open a console on both server and client boards then check the state:
 
 .. code-block:: console
 

--- a/samples/sensor/sgp40_sht4x/README.rst
+++ b/samples/sensor/sgp40_sht4x/README.rst
@@ -62,6 +62,6 @@ Sample Output
         SHT4X: 23.66 Temp. [C] ; 32.16 RH [%] -- SGP40: 30541 Gas [a.u.]
         SHT4X: 23.63 Temp. [C] ; 30.83 RH [%] -- SGP40: 30522 Gas [a.u.]
 
-The datasheet states that the raw sensor signal for the SGP40 ist proportional
+The datasheet states that the raw sensor signal for the SGP40 is proportional
 to the logarithm of the sensors resistance, hence it is labeled as [a.u.]
 (arbitrary units) in the example.


### PR DESCRIPTION
Utilize a code spell-checking tool to scan for and correct spelling errors in `.rst` files within the `boards`, `doc`, and `tests` directories.