### PR TITLE
conf: fix typo in (samples, tests)

### DIFF
--- a/samples/bluetooth/bap_unicast_client/overlay-bt_ll_sw_split.conf
+++ b/samples/bluetooth/bap_unicast_client/overlay-bt_ll_sw_split.conf
@@ -13,7 +13,7 @@ CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX=191
 CONFIG_BT_CTLR_ISOAL_SOURCES=2
 CONFIG_BT_CTLR_ISOAL_SINKS=1
 
-# Numbe of ISO Tx Buffers
+# Number of ISO Tx Buffers
 CONFIG_BT_CTLR_ISO_TX_BUFFERS=6
 
 # Support the highest SDU size required by any BAP LC3 presets (155) + 8 bytes of HCI ISO Data

--- a/samples/bluetooth/bap_unicast_server/overlay-bt_ll_sw_split.conf
+++ b/samples/bluetooth/bap_unicast_server/overlay-bt_ll_sw_split.conf
@@ -12,7 +12,7 @@ CONFIG_BT_CTLR_ADV_DATA_LEN_MAX=191
 CONFIG_BT_CTLR_ISOAL_SOURCES=1
 CONFIG_BT_CTLR_ISOAL_SINKS=2
 
-# Numbe of ISO Tx Buffers
+# Number of ISO Tx Buffers
 CONFIG_BT_CTLR_ISO_TX_BUFFERS=3
 
 # Support the highest SDU size required by any BAP LC3 presets (155) + 8 bytes of HCI ISO Data

--- a/samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf
+++ b/samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf
@@ -158,7 +158,7 @@ CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y
 # The hci_ipc image has a quite high RAM usage so we need to carefully
 # tweak Mbed TLS parameters in order to build successfully:
 # - use CSPRNG source as random source for PSA. This removes
-#   requiement for legacy Mbed TLS entropy+ctr-drbg modules, which
+#   requirement for legacy Mbed TLS entropy+ctr-drbg modules, which
 #   saves RAM and ROM;
 # - use ROM pre-computed tables for AES;
 # - reduce the number of key slots to 3 in the PSA core. This is not a

--- a/samples/drivers/ethernet/eth_ivshmem/prj.conf
+++ b/samples/drivers/ethernet/eth_ivshmem/prj.conf
@@ -32,7 +32,7 @@ CONFIG_NET_TCP_WORKQ_STACK_SIZE=4096
 CONFIG_NET_RX_STACK_SIZE=4096
 CONFIG_SHELL_STACK_SIZE=4096
 
-# Increase net buffer size/count for increased performace
+# Increase net buffer size/count for increased performance
 CONFIG_NET_TCP_MAX_RECV_WINDOW_SIZE=5120
 CONFIG_NET_PKT_TX_COUNT=6
 CONFIG_NET_BUF_RX_COUNT=64

--- a/samples/net/mqtt_sn_publisher/compose/mosquitto.conf
+++ b/samples/net/mqtt_sn_publisher/compose/mosquitto.conf
@@ -321,7 +321,7 @@ listener 1883
 #keyfile
 
 # If you wish to control which encryption ciphers are used, use the ciphers
-# option. The list of available ciphers can be optained using the "openssl
+# option. The list of available ciphers can be obtained using the "openssl
 # ciphers" command and should be provided in the same format as the output of
 # that command. This applies to TLS 1.2 and earlier versions only. Use
 # ciphers_tls1.3 for TLS v1.3.
@@ -389,7 +389,7 @@ listener 1883
 
 # When using PSK, the encryption ciphers used will be chosen from the list of
 # available PSK ciphers. If you want to control which ciphers are available,
-# use the "ciphers" option.  The list of available ciphers can be optained
+# use the "ciphers" option.  The list of available ciphers can be obtained
 # using the "openssl ciphers" command and should be provided in the same format
 # as the output of that command.
 #ciphers
@@ -455,7 +455,7 @@ listener 1883
 # where severity is one of D, E, W, N, I, M which are debug, error,
 # warning, notice, information and message. Message type severity is used by
 # the subscribe/unsubscribe log_types and publishes log messages to
-# $SYS/broker/log/M/susbcribe or $SYS/broker/log/M/unsubscribe.
+# $SYS/broker/log/M/subscribe or $SYS/broker/log/M/unsubscribe.
 #
 # The file destination requires an additional parameter which is the file to be
 # logged to, e.g. "log_dest file /var/log/mosquitto.log". The file will be
@@ -586,7 +586,7 @@ allow_anonymous true
 #
 #
 # If is also possible to define ACLs based on pattern substitution within the
-# topic. The patterns available for substition are:
+# topic. The patterns available for substitution are:
 #
 # %c to match the client id of the client
 # %u to match the username of the client

--- a/samples/net/zperf/boards/mimxrt1050_evk_mimxrt1052_hyperflash.conf
+++ b/samples/net/zperf/boards/mimxrt1050_evk_mimxrt1052_hyperflash.conf
@@ -1,4 +1,4 @@
-# Note: HW accleration does not support IPV6
+# Note: HW acceleration does not support IPV6
 CONFIG_ETH_NXP_ENET_HW_ACCELERATION=y
 CONFIG_NET_SAMPLE_CODE_RELOCATE=y
 CONFIG_NET_SAMPLE_CODE_RAM_NAME="ITCM"

--- a/samples/net/zperf/boards/mimxrt1060_evk_mimxrt1062_qspi.conf
+++ b/samples/net/zperf/boards/mimxrt1060_evk_mimxrt1062_qspi.conf
@@ -1,4 +1,4 @@
-# Note: HW accleration does not support IPV6
+# Note: HW acceleration does not support IPV6
 CONFIG_ETH_NXP_ENET_HW_ACCELERATION=y
 CONFIG_NET_SAMPLE_CODE_RELOCATE=y
 CONFIG_NET_SAMPLE_CODE_RAM_NAME="ITCM"

--- a/samples/net/zperf/boards/mimxrt1064_evk.conf
+++ b/samples/net/zperf/boards/mimxrt1064_evk.conf
@@ -1,4 +1,4 @@
-# Note: HW accleration does not support IPV6
+# Note: HW acceleration does not support IPV6
 CONFIG_ETH_NXP_ENET_HW_ACCELERATION=y
 CONFIG_NET_SAMPLE_CODE_RELOCATE=y
 CONFIG_NET_SAMPLE_CODE_RAM_NAME="ITCM"

--- a/samples/net/zperf/boards/mimxrt1170_evk_mimxrt1176_cm7_A.conf
+++ b/samples/net/zperf/boards/mimxrt1170_evk_mimxrt1176_cm7_A.conf
@@ -1,4 +1,4 @@
-# Note: HW accleration does not support IPV6
+# Note: HW acceleration does not support IPV6
 CONFIG_ETH_NXP_ENET_HW_ACCELERATION=y
 CONFIG_NET_SAMPLE_CODE_RELOCATE=y
 CONFIG_NET_SAMPLE_CODE_RAM_NAME="ITCM"

--- a/tests/drivers/dma/loop_transfer/boards/stm32h750b_dk.conf
+++ b/tests/drivers/dma/loop_transfer/boards/stm32h750b_dk.conf
@@ -2,7 +2,7 @@ CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=3
 CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS=2
 
 # Required by BDMA which only has access to
-# SRAM4 & the driver excpects it to be uncached as well.
+# SRAM4 & the driver expects it to be uncached as well.
 # Other DMAs have access to SRAM4 as well.
 CONFIG_CODE_DATA_RELOCATION=y
 CONFIG_DMA_LOOP_TRANSFER_RELOCATE_SECTION="SRAM4"

--- a/tests/modules/thrift/ThriftTest/overlay-tls.conf
+++ b/tests/modules/thrift/ThriftTest/overlay-tls.conf
@@ -1,6 +1,6 @@
 CONFIG_THRIFT_SSL_SOCKET=y
 
-# Currenty, in Zephyr's MBedTLS IPPROTO_TLS_1_0 implementation, 2 sockets are
+# Currently, in Zephyr's MBedTLS IPPROTO_TLS_1_0 implementation, 2 sockets are
 # needed for every connection.
 #
 # Additionally, upstream Apache Thrift uses socketpair for cancellation rather

--- a/tests/net/ipv6_fragment/prj.conf
+++ b/tests/net/ipv6_fragment/prj.conf
@@ -31,6 +31,6 @@ CONFIG_INIT_STACKS=y
 CONFIG_PRINTK=y
 CONFIG_NET_STATISTICS=n
 
-# Ensure that all TX/RX is exectued directly from the test thread
+# Ensure that all TX/RX is executed directly from the test thread
 CONFIG_NET_TC_TX_COUNT=0
 CONFIG_NET_TC_RX_COUNT=0


### PR DESCRIPTION
Utilize a code spell-checking tool to scan for and correct spelling errors in `.conf` files within the `samples` and `tests` directories.