### PR TITLE
dts: fix typo in (boards, dts)

### DIFF
--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -42,7 +42,7 @@
 		compatible = "gpio-keys";
 
 		/* The switch is labeled SW300 in the schematic, and labeled
-		 * SW0 on the board, and labeld SW1 User Button on docs
+		 * SW0 on the board, and labeled SW1 User Button on docs
 		 */
 		sw0_user_button: button_1 {
 			label = "User Button";

--- a/boards/fanke/fk743m5_xih6/fk743m5_xih6.dts
+++ b/boards/fanke/fk743m5_xih6/fk743m5_xih6.dts
@@ -36,7 +36,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x90000000 DT_SIZE_M(256)>;
 		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
 	};
 

--- a/boards/native/nrf_bsim/nrf52_bsim.dts
+++ b/boards/native/nrf_bsim/nrf52_bsim.dts
@@ -9,7 +9,7 @@
 
 #include <mem.h>
 #include <arm/nordic/nrf52833.dtsi>
-/* We resuse the pinctrl definitions directly from the real board : */
+/* We reuse the pinctrl definitions directly from the real board : */
 #include <../boards/nordic/nrf52833dk/nrf52833dk_nrf52833-pinctrl.dtsi>
 
 / {

--- a/boards/phytec/phyboard_polis/phyboard_polis_mimx8mm6_m4.dts
+++ b/boards/phytec/phyboard_polis/phyboard_polis_mimx8mm6_m4.dts
@@ -113,7 +113,7 @@
 
 /*
  * needs to be configured, so the leds don't generate an error,
- * but does not interfer with the A53-Core
+ * but does not interfere with the A53-Core
  */
 &gpio1 {
 	status = "okay";

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a.dts
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a.dts
@@ -33,7 +33,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x70000000 DT_SIZE_M(64)>;
 		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
 	};
 };

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -65,7 +65,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x70000000 DT_SIZE_M(64)>;
 		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
 	};
 };

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -46,7 +46,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
 	};
 

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -35,7 +35,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
 	};
 

--- a/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
@@ -37,7 +37,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
 	};
 

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -67,7 +67,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x90000000 DT_SIZE_M(64)>;
 		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
 	};
 

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -75,7 +75,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x70000000 DT_SIZE_M(128)>;
 		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
 	};
 };

--- a/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
+++ b/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
@@ -63,7 +63,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0xa0000000 DT_SIZE_M(128)>;
 		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
 	};
 };

--- a/dts/arm/atmel/samx7x.dtsi
+++ b/dts/arm/atmel/samx7x.dtsi
@@ -441,7 +441,7 @@
 			status = "okay";
 		};
 
-		wdt: watchog@400e1850 {
+		wdt: watchdog@400e1850 {
 			compatible = "atmel,sam-watchdog";
 			reg = <0x400e1850 0xc>;
 			interrupts = <4 0>;

--- a/dts/arm/infineon/edge/pse84/system_clocks.dtsi
+++ b/dts/arm/infineon/edge/pse84/system_clocks.dtsi
@@ -12,6 +12,7 @@
 
 #include <dt-bindings/clock/ifx_clock_source_common.h>
 #include <dt-bindings/clock/ifx_clock_source_pse8xx.h>
+
 / {
 	/* iho */
 	clk_iho: clk_iho {
@@ -244,9 +245,9 @@
 		peri0_group1_8bit_0: peri0_group1_8bit_0 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_8_BIT>;
-			channel  = <0>;
+			channel = <0>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -254,9 +255,9 @@
 		peri0_group1_8bit_1: peri0_group1_8bit_1 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_8_BIT>;
-			channel  = <1>;
+			channel = <1>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -264,9 +265,9 @@
 		peri0_group1_8bit_2: peri0_group1_8bit_2 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_8_BIT>;
-			channel  = <2>;
+			channel = <2>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -274,9 +275,9 @@
 		peri0_group1_8bit_3: peri0_group1_8bit_3 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_8_BIT>;
-			channel  = <3>;
+			channel = <3>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -284,9 +285,9 @@
 		peri0_group1_8bit_4: peri0_group1_8bit_4 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_8_BIT>;
-			channel  = <4>;
+			channel = <4>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -294,9 +295,9 @@
 		peri0_group1_16bit_0: peri0_group1_16bit_0 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_16_BIT>;
-			channel  = <0>;
+			channel = <0>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -304,9 +305,9 @@
 		peri0_group1_16bit_1: peri0_group1_16bit_1 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_16_BIT>;
-			channel  = <1>;
+			channel = <1>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -314,9 +315,9 @@
 		peri0_group1_16bit_2: peri0_group1_16bit_2 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_16_BIT>;
-			channel  = <2>;
+			channel = <2>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -324,9 +325,9 @@
 		peri0_group1_16bit_3: peri0_group1_16bit_3 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_16_BIT>;
-			channel  = <3>;
+			channel = <3>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -334,9 +335,9 @@
 		peri0_group1_16_5bit_0: peri0_group1_16_5bit_0 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_16_5_BIT>;
-			channel  = <0>;
+			channel = <0>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -344,9 +345,9 @@
 		peri0_group1_16_5bit_1: peri0_group1_16_5bit_1 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_16_5_BIT>;
-			channel  = <1>;
+			channel = <1>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -354,9 +355,9 @@
 		peri0_group1_24_5bit_0: peri0_group1_24_5bit_0 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_24_5_BIT>;
-			channel  = <0>;
+			channel = <0>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -364,20 +365,20 @@
 		peri0_group1_24_5bit_1: peri0_group1_24_5bit_1 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 01]; /* inst#, group# */
+			peri-group = [00 01]; /* inst#, group# */
 			div-type = <DIV_24_5_BIT>;
-			channel  = <1>;
+			channel = <1>;
 			clock-div = <1>;
 			status = "disabled";
 		};
 
-		/* Peripheral clock deviders Group 8 (Use for SCB1) */
+		/* Peripheral clock dividers Group 8 (Use for SCB1) */
 		peri0_group8_16bit_0: peri0_group8_16bit_0 {
 			#clock-cells = <0>;
 			compatible = "infineon,peri-div";
-			peri-group  = [00 08]; /* inst#, group# */
+			peri-group = [00 08]; /* inst#, group# */
 			div-type = <DIV_16_BIT>;
-			channel  = <0>;
+			channel = <0>;
 			clock-div = <1>;
 			status = "disabled";
 		};

--- a/dts/arm/microchip/mec/mec152x/mec152xhsz-pinctrl.dtsi
+++ b/dts/arm/microchip/mec/mec152x/mec152xhsz-pinctrl.dtsi
@@ -532,7 +532,7 @@
 	/* MEC152x QMSPI Port 2 can be external pins named gpspi_xxx or
 	 * for the MEC1727 variant internal pins named int_spi_xxx.
 	 * The MEC1527 variant includes a SST25PF040 512 KB SPI flash
-	 * in the package conntected to the int_spi_xxx pins.
+	 * in the package connected to the int_spi_xxx pins.
 	 */
 	/omit-if-no-ref/ gpspi_cs_n_gpio024: gpspi_cs_n_gpio024 {
 		pinmux = <MCHP_XEC_PINMUX(024, MCHP_AF1)>;

--- a/dts/arm/nxp/nxp_rt1040.dtsi
+++ b/dts/arm/nxp/nxp_rt1040.dtsi
@@ -56,7 +56,7 @@
 };
 
 /*
- * RT1040 RM descibes the SPI peripheral at 0x403a0000 as LPSPI3.
+ * RT1040 RM describes the SPI peripheral at 0x403a0000 as LPSPI3.
  * other RT10xx SOCs describe this as LPSPI4, so just add an alias.
  */
 lpspi3: &lpspi4 {};

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -92,7 +92,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x70000000 DT_SIZE_M(256)>;
 		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
 	};
 

--- a/dts/arm/st/wb0/stm32wb0.dtsi
+++ b/dts/arm/st/wb0/stm32wb0.dtsi
@@ -43,7 +43,7 @@
 				power-state-name = "suspend-to-ram";
 				substate-id = <0>;
 
-				/* One milisecond seems reasonable for now. */
+				/* One millisecond seems reasonable for now. */
 				min-residency-us = <1000>;
 
 				/* exit-latency-us property is not needed


### PR DESCRIPTION
Utilize a code spell-checking tool to scan for and correct spelling errors in `.dts` and `.dtsi` files within the `boards` and `dts` directories.