### PR TITLE
drivers: spi: shell: fix deprecation warning

### DIFF
--- a/drivers/spi/spi_shell.c
+++ b/drivers/spi/spi_shell.c
@@ -57,7 +57,7 @@ struct map {
 #define INST_SPI_SHELL_DEVICE_AS_SPI_DEV(node_id)                                                  \
 	{                                                                                          \
 		.name = DEVICE_DT_NAME(node_id),                                                   \
-		.spec = SPI_DT_SPEC_GET(node_id, 0, 0),                                            \
+		.spec = SPI_DT_SPEC_GET(node_id, 0),                                               \
 	},
 
 #define INST_SPI_SHELL_DEVICE_AS_SPI_DEV_AS_SPI_BUS(dev)                                           \


### PR DESCRIPTION
Remove the deprecated delay parameter from the SPI DT macro in the SPI shell code.

Fixes the following warning:
```
zephyr/drivers/spi/spi_shell.c:92:20: warning: Delay parameter in SPI DT macros is deprecated, use DT prop instead
   92 |         DT_FOREACH_STATUS_OKAY_NODE(INST_ALL_SPI_DEVICES_AS_SPI_SHELL_DEVICES)
```