### PR TITLE
xtensa: suppress warning on variable used uninitialized

### DIFF
--- a/arch/xtensa/core/irq_manage.c
+++ b/arch/xtensa/core/irq_manage.c
@@ -122,6 +122,7 @@ int xtensa_irq_is_enabled(unsigned int irq)
 		break;
 #endif
 	default:
+		ie = 0;
 		break;
 	}
 #else


### PR DESCRIPTION
This change suppress the warning:
variable 'ie' is used uninitialized whenever switch default is taken [-Wsometimes-uninitialized]