### PR TITLE
scripts: runners: generalize dry run

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -318,6 +318,7 @@ class RunnerCaps:
     hide_load_files: bool = False
     rtt: bool = False  # This capability exists separately from the rtt command
                        # to allow other commands to use the rtt address
+    dry_run: bool = False
 
     def __post_init__(self):
         if self.mult_dev_ids and not self.dev_id:
@@ -632,6 +633,10 @@ class ZephyrBinaryRunner(abc.ABC):
         else:
             parser.add_argument('--rtt-address', help=argparse.SUPPRESS)
 
+        parser.add_argument('--dry-run', action='store_true',
+                            help=('''Print all the commands without actually
+                            executing them''' if caps.dry_run else argparse.SUPPRESS))
+
         # Runner-specific options.
         cls.do_add_parser(parser)
 
@@ -678,6 +683,8 @@ class ZephyrBinaryRunner(abc.ABC):
             _missing_cap(cls, '--file-type')
         if args.rtt_address and not caps.rtt:
             _missing_cap(cls, '--rtt-address')
+        if args.dry_run and not caps.dry_run:
+            _missing_cap(cls, '--dry-run')
 
         ret = cls.do_create(cfg, args)
         if args.erase:

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -488,6 +488,9 @@ class ZephyrBinaryRunner(abc.ABC):
         self.logger = logging.getLogger(f'runners.{self.name()}')
         '''logging.Logger for this instance.'''
 
+        self.dry_run = _DRY_RUN
+        '''log commands instead of executing them. Can be set by subclasses'''
+
     @staticmethod
     def get_runners() -> list[type['ZephyrBinaryRunner']]:
         '''Get a list of all currently defined runner classes.'''
@@ -860,7 +863,7 @@ class ZephyrBinaryRunner(abc.ABC):
 
     def _log_cmd(self, cmd: list[str]):
         escaped = ' '.join(shlex.quote(s) for s in cmd)
-        if not _DRY_RUN:
+        if not self.dry_run:
             self.logger.debug(escaped)
         else:
             self.logger.info(escaped)
@@ -873,7 +876,7 @@ class ZephyrBinaryRunner(abc.ABC):
         using subprocess directly, to keep accurate debug logs.
         '''
         self._log_cmd(cmd)
-        if _DRY_RUN:
+        if self.dry_run:
             return 0
         return subprocess.call(cmd, **kwargs)
 
@@ -885,7 +888,7 @@ class ZephyrBinaryRunner(abc.ABC):
         using subprocess directly, to keep accurate debug logs.
         '''
         self._log_cmd(cmd)
-        if _DRY_RUN:
+        if self.dry_run:
             return
         subprocess.check_call(cmd, **kwargs)
 
@@ -897,7 +900,7 @@ class ZephyrBinaryRunner(abc.ABC):
         using subprocess directly, to keep accurate debug logs.
         '''
         self._log_cmd(cmd)
-        if _DRY_RUN:
+        if self.dry_run:
             return b''
         return subprocess.check_output(cmd, **kwargs)
 
@@ -918,7 +921,7 @@ class ZephyrBinaryRunner(abc.ABC):
             preexec = os.setsid # type: ignore
 
         self._log_cmd(cmd)
-        if _DRY_RUN:
+        if self.dry_run:
             return _DebugDummyPopen()  # type: ignore
 
         return subprocess.Popen(cmd, creationflags=cflags, preexec_fn=preexec, **kwargs)

--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -75,10 +75,10 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
                 self.tool_opt += opts
 
     @classmethod
-    def _capabilities(cls, mult_dev_ids=False):
+    def _capabilities(cls, mult_dev_ids=False, dry_run=False):
         return RunnerCaps(commands={'flash'}, dev_id=True,
                           mult_dev_ids=mult_dev_ids, erase=True, reset=True,
-                          tool_opt=True)
+                          tool_opt=True, dry_run=dry_run)
 
     @classmethod
     def _dev_id_help(cls) -> str:

--- a/scripts/west_commands/runners/nrfutil.py
+++ b/scripts/west_commands/runners/nrfutil.py
@@ -37,7 +37,7 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return NrfBinaryRunner._capabilities(mult_dev_ids=True)
+        return NrfBinaryRunner._capabilities(mult_dev_ids=True, dry_run=True)
 
     @classmethod
     def dev_id_help(cls) -> str:
@@ -65,10 +65,6 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
         parser.add_argument('--ext-mem-config-file', required=False,
                             dest='ext_mem_config_file',
                             help='path to an JSON file with external memory configuration')
-        parser.add_argument('--dry-run', required=False,
-                            action='store_true',
-                            help='''Generate all the commands without actually
-                            executing them''')
 
     def _exec(self, args, force=False):
         jout_all = []

--- a/scripts/west_commands/runners/nrfutil.py
+++ b/scripts/west_commands/runners/nrfutil.py
@@ -5,12 +5,10 @@
 '''Runner for flashing with nrfutil.'''
 
 import json
-import shlex
 import subprocess
 import sys
 from pathlib import Path
 
-from runners.core import _DRY_RUN
 from runners.nrf_common import NrfBinaryRunner
 
 
@@ -70,14 +68,10 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
         jout_all = []
 
         cmd = ['nrfutil', '--json', 'device'] + args
+        self._log_cmd(cmd)
 
-        escaped = ' '.join(shlex.quote(s) for s in cmd)
-        if _DRY_RUN or (self.dry_run):
-            self.logger.info(escaped)
-            if not force:
-                return {}
-        else:
-            self.logger.debug(escaped)
+        if self.dry_run and not force:
+            return {}
 
         with subprocess.Popen(cmd, stdout=subprocess.PIPE) as p:
             for line in iter(p.stdout.readline, b''):


### PR DESCRIPTION
- The first commit should be non-controversial, it just moves the argparse call to the abstract ZephyrBinaryRunner class
- The second commit is there to avoid duplicating logic in individual runners, reusing the infrastructure in core.py. The usage of the global `_DRY_RUN` should remain unaffected, but subclasses can now set `self.dry_run` and then use the base classe methods (`_log_cmd()`, `call()`, `check_call()` and `check_output()`) directly without having to implement the logic themselves