### PR TITLE
drivers: spi: stm32: allow for using soft NSS in peripheral mode

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -710,6 +710,11 @@ STM32
   .. note:: This change aligns STM32 platforms' behavior with the generic Zephyr one. Previous
             implementation wasn't product-ready so this shouldn't cause much trouble.
 
+* The Kconfig option ``CONFIG_SPI_STM32_USE_HW_SS`` has been removed. SPI operation mode
+  is now selected automatically based on devicetree configuration: instances with either of
+  the ``cs-gpios`` or new ``st,soft-nss`` property operate in "Soft NSS" mode, while all other
+  instances operate in "Hard NSS" mode.
+
 USB
 ===
 

--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -27,12 +27,6 @@ config SPI_STM32_DMA
 	  Enable the SPI DMA mode for SPI instances
 	  that enable dma channels in their device tree node.
 
-config SPI_STM32_USE_HW_SS
-	bool "STM32 Hardware Slave Select support"
-	default y
-	help
-	  Use Slave Select pin instead of software Slave Select.
-
 config SPI_STM32_ERRATA_BUSY
 	bool
 	default y

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1013,7 +1013,7 @@ static int spi_stm32_configure(const struct device *dev,
 
 	LL_SPI_DisableCRC(spi);
 
-	if (spi_cs_is_gpio(config) || !IS_ENABLED(CONFIG_SPI_STM32_USE_HW_SS)) {
+	if (spi_cs_is_gpio(config) || cfg->soft_nss) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 		if ((SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) &&
 		    (LL_SPI_GetNSSPolarity(spi) == LL_SPI_NSS_POLARITY_LOW)) {
@@ -1028,7 +1028,6 @@ static int spi_stm32_configure(const struct device *dev,
 			LL_SPI_SetNSSMode(spi, LL_SPI_NSS_HARD_OUTPUT);
 		}
 	}
-
 	if ((config->operation & SPI_OP_MODE_SLAVE) != 0U) {
 		LL_SPI_SetMode(spi, LL_SPI_MODE_SLAVE);
 	} else {
@@ -1846,6 +1845,7 @@ static int spi_stm32_init(const struct device *dev)
 			   (.midi_clocks = DT_INST_PROP(id, midi_clock),))	\
 		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi),		\
 			   (.mssi_clocks = DT_INST_PROP(id, mssi_clock),))	\
+		.soft_nss = DT_INST_PROP(id, st_soft_nss),			\
 	};									\
 										\
 	IF_ENABLED(CONFIG_SPI_RTIO,						\

--- a/drivers/spi/spi_stm32.h
+++ b/drivers/spi/spi_stm32.h
@@ -40,6 +40,7 @@ struct spi_stm32_config {
 	int datawidth;
 	bool fifo_enabled: 1;
 	bool ioswp: 1;
+	bool soft_nss: 1;
 };
 
 #ifdef CONFIG_SPI_STM32_DMA

--- a/dts/bindings/spi/st,stm32-spi-common.yaml
+++ b/dts/bindings/spi/st,stm32-spi-common.yaml
@@ -34,3 +34,19 @@ properties:
       - full-4-to-32-bit: supports data width from 4 to 32 bits
       - full-4-to-16-bit: supports data width from 4 to 16 bits
       - limited-8-16-bit: supports only 8 and 16-bit data widths
+
+  st,soft-nss:
+    type: boolean
+    description: |
+      Force operation in "Soft NSS" mode without CS/NSS pin.
+
+      This is useful in situations where the SPI interface
+      is connected to a single controller or peripheral and
+      does not require CS/NSS for proper operation.
+
+      This property is overridden by the `cs-gpios` property:
+      if provided, SPI instance also operates in "Soft NSS"
+      mode, but GPIO CS pins are used during transactions.
+
+      If neither this property nor `cs-gpios` are provided,
+      the SPI instance operates in "Hard NSS" mode.


### PR DESCRIPTION
The current stm32 drivers will only enable soft NSS support if the device is using a Zephyr managed GPIO for CS, or if the CONFIG_SPI_STM32_USE_HW_SS flag is set.  Neither of these are actually appropriate for a peripheral, which doesn't control CS.

With this change, it is possible for the SPI interface to be configured as a peripheral but still use soft NSS -- otherwise, short of creating a "fake" GPIO configuration, the peripheral will always use hard NSS, and for some boards/configurations, that is unworkable.  In the case of a board where the CS is not hooked up, we can use soft NSS to allow the peripheral to assume CS and be driven by the SPI clock signal alone.

Our board has only three signals (clock, COPI, POCI) enabled on one of the SPI interfaces (it is communicating with another MCU on the same board), and works with this change.  Without the change, we must enable a "fake" GPIO driver configuration (which is never used for anything, and really makes little sense for a peripheral, but it just happens to force the driver to go down that code path).  We cannot disable the CONFIG_SPI_STM32_USE_HW_SS mechanism, as that impacts ALL interfaces, and we have a second interface in controller mode that speaks to flash and requires the NSS_HARD codepath.