### PR TITLE
Fix SPI loopback CS testing race condition in GPIO callback

### DIFF
--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -643,8 +643,8 @@ static int transceive_dma(const struct device *dev,
 	const struct spi_mcux_config *config = dev->config;
 	struct spi_mcux_data *data = dev->data;
 	SPI_Type *base = config->base;
-	int ret;
 	uint8_t word_size = (uint8_t)SPI_WORD_SIZE_GET(spi_cfg->operation);
+	int ret = 0;
 
 	if (word_size > SPI_MAX_DATA_WIDTH) {
 		LOG_ERR("Word size %d is greater than %d", word_size, SPI_MAX_DATA_WIDTH);
@@ -655,14 +655,20 @@ static int transceive_dma(const struct device *dev,
 
 	spi_context_lock(&data->ctx, asynchronous, cb, userdata, spi_cfg);
 
+	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
+
+	if ((data->ctx.tx_count + data->ctx.rx_count) == 0) {
+		/* no data to transfer */
+		ret = 0;
+		goto out;
+	}
+
 	data->word_size_bits = word_size;
 	data->word_size_bytes = (word_size > 8) ? (sizeof(uint16_t)) : (sizeof(uint8_t));
 	ret = spi_mcux_configure(dev, spi_cfg);
 	if (ret) {
 		goto out;
 	}
-
-	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
 
 	spi_context_cs_control(&data->ctx, true);
 

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -142,21 +142,66 @@ static const struct gpio_dt_spec cs_loopback_gpio =
 			GPIO_DT_SPEC_GET_OR(DT_PATH(zephyr_user), cs_loopback_gpios, {0});
 static struct gpio_callback cs_cb_data;
 atomic_t cs_count;
+int cs_start;
 
 static void spi_loopback_gpio_cs_loopback_prepare(void)
 {
+	/* record start state of CS pin and reset edge counter */
+	cs_start = gpio_pin_get_dt(&cs_loopback_gpio);
 	atomic_set(&cs_count, 0);
 }
 
+/* valid expected triggers are 0, 1, or 2, and this function input is not validated */
 static int spi_loopback_gpio_cs_loopback_check(int expected_triggers)
 {
 	int actual_triggers = atomic_get(&cs_count);
+	/* 1 should mean CS is asserted, 0 not */
+	int cs_level = gpio_pin_get_dt(&cs_loopback_gpio);
 
-	if (actual_triggers != expected_triggers) {
-		TC_PRINT("Expected %d CS triggers, got %d", expected_triggers, actual_triggers);
+	/* putting this first simplifies a lot of the checks needed below */
+	if (actual_triggers > expected_triggers) {
+		goto error;
+	}
+
+	/* Case should not happen unless test is set up wrong */
+	if (actual_triggers == 0 && cs_level != cs_start) {
+		TC_PRINT("Got 0 triggers but CS changed, GPIO interrupt not working?");
 		return -1;
 	}
+
+	/* already handled error case for this */
+	if (expected_triggers == 0) {
+		return 0;
+	}
+
+	/* all the other cases should get at least one gpio callback */
+	if (actual_triggers == 0) {
+		goto error;
+	}
+
+	/* a lot of the following code for cases of expecting 1 and 2 is for
+	 * handling race conditions due to gpio interrupt latency, where two edges can happen
+	 * before the first one's interrupt is processed
+	 */
+
+	/* expected case is that cs level is opposite of start */
+	if ((expected_triggers == 1) && (cs_level == cs_start)) {
+		/* only possibly case at this point is that the CS triggered twice */
+		actual_triggers = 2;
+		goto error;
+	}
+
+	/* expected case is that cs level is same as start */
+	if ((expected_triggers == 2) && (cs_level != cs_start)) {
+		/* only possibly case at this point is that the CS triggered once */
+		actual_triggers = 1;
+		goto error;
+	}
+
 	return 0;
+error:
+	TC_PRINT("Expected %d CS triggers, got %d", expected_triggers, actual_triggers);
+	return -1;
 }
 
 static void cs_callback(const struct device *port,
@@ -167,7 +212,6 @@ static void cs_callback(const struct device *port,
 	ARG_UNUSED(cb);
 	ARG_UNUSED(pins);
 
-	/* Give semaphore to indicate CS triggered */
 	atomic_inc(&cs_count);
 }
 


### PR DESCRIPTION
  There is a race condition in this method of CS behavior verification,
    where multiple CS signal transitions can happen during one interrupt
    processing, thereby only getting one callback and marking the trigger
    count as being less than what is accurate. At least we can account for
    most real situations where this happens by also looking at the CS pin
    logic level and comparing to how it started, to potentially realize that
    there was another edge that happened when it either should or shouldn't
    have happened.

Also contains another fix to just report that the HOLD_ON_CS flag is not supported by the flexcomm SPI driver, because this PR is originally for fixing #95359 and both commits are related to that.

Fixes #95359 (I think)