### PR TITLE
intel_adsp: select log_backend_xtensa_sim for simulator

### DIFF
--- a/soc/intel/intel_adsp/ace/Kconfig.defconfig.series
+++ b/soc/intel/intel_adsp/ace/Kconfig.defconfig.series
@@ -52,8 +52,11 @@ config DYNAMIC_INTERRUPTS
 
 if LOG
 
+config LOG_BACKEND_XTENSA_SIM
+	default y if SIMULATOR_XTENSA
+
 config LOG_BACKEND_ADSP
-	default y
+	default y if !SIMULATOR_XTENSA
 
 endif # LOG
 


### PR DESCRIPTION
Workaround for logging test failures on intel_adsp_ace*/sim first observed in [weekly build](https://github.com/zephyrproject-rtos/zephyr/actions/runs/18811754455).

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/98451