### PR TITLE
tests: Filter out various c_lib/thrd test cases

### DIFF
--- a/tests/lib/c_lib/thrd/testcase.yaml
+++ b/tests/lib/c_lib/thrd/testcase.yaml
@@ -10,13 +10,6 @@ common:
     - arch
     - simulation
 tests:
-  libraries.libc.c11_threads.minimal:
-    tags: minimal_libc
-    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
-    extra_configs:
-      - CONFIG_MINIMAL_LIBC=y
-      - CONFIG_MINIMAL_LIBC_NON_REENTRANT_FUNCTIONS=y
-      - CONFIG_MINIMAL_LIBC_RAND=y
   libraries.libc.c11_threads.picolibc:
     filter: CONFIG_PICOLIBC_SUPPORTED
     tags: picolibc

--- a/tests/lib/c_lib/thrd/testcase.yaml
+++ b/tests/lib/c_lib/thrd/testcase.yaml
@@ -23,14 +23,14 @@ tests:
     extra_configs:
       - CONFIG_PICOLIBC=y
   libraries.libc.c11_threads.picolibc.module:
-    filter: CONFIG_ZEPHYR_PICOLIBC_MODULE
+    filter: CONFIG_ZEPHYR_PICOLIBC_MODULE and CONFIG_PICOLIBC_SUPPORTED
     tags: picolibc
     extra_configs:
       - CONFIG_PICOLIBC=y
       - CONFIG_PICOLIBC_USE_MODULE=y
       - CONFIG_THREAD_LOCAL_STORAGE=y
   libraries.libc.c11_threads.picolibc.notls:
-    filter: CONFIG_ZEPHYR_PICOLIBC_MODULE
+    filter: CONFIG_ZEPHYR_PICOLIBC_MODULE and CONFIG_PICOLIBC_SUPPORTED
     tags: picolibc
     extra_configs:
       - CONFIG_PICOLIBC=y


### PR DESCRIPTION
Inspection of the build log shows that the arcmwdt toolchain overrides the enablement of MINIMAL_LIBC and PICOLIBC to use its own libc. When this happens, it can lead to build errors that stem from redefinition of various types. To account for this, the filters have been extended to catch this.