### PR TITLE
doc: services: pm: use pm_device_runtime_get in power_domain diagram

### DIFF
--- a/doc/services/pm/power_domain.rst
+++ b/doc/services/pm/power_domain.rst
@@ -39,8 +39,8 @@ work flow is illustrated in the diagram below.
        }
        domain [label="gpio_domain"]
 
-      action -> devA [label="pm_device_get()"]
-      devA:se -> domain:n [label="pm_device_get()"]
+      action -> devA [label="pm_device_runtime_get()"]
+      devA:se -> domain:n [label="pm_device_runtime_get()"]
 
       domain -> devB [label="action_cb(PM_DEVICE_ACTION_TURN_ON)"]
       domain:sw -> devA:sw [label="action_cb(PM_DEVICE_ACTION_TURN_ON)"]


### PR DESCRIPTION
Update the power domain flow diagram in doc/services/pm/power_domain.rst
to use the current runtime PM API name pm_device_runtime_get instead of
the older pm_device_get. This keeps the documentation consistent with the
renamed device runtime power management APIs.

Signed-off-by: Albort Xue <yao.xue@nxp.com>