### PR TITLE
host: Implement bt_gatt_cb_unregister method for sys_slist_find_and_remove.

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -56,6 +56,12 @@ Deprecated APIs and options
 New APIs and options
 ====================
 
+* Bluetooth
+
+  * Host
+
+    * :c:func:`bt_gatt_cb_unregister` Added an API to unregister GATT callback handlers.
+
 ..
   Link to new APIs here, in a group if you think it's necessary, no need to get
   fancy just list the link, that should contain the documentation. If you feel

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -622,6 +622,17 @@ static inline const char *bt_gatt_err_to_str(int gatt_err)
  */
 void bt_gatt_cb_register(struct bt_gatt_cb *cb);
 
+/** @brief Unregister GATT callbacks.
+ *
+ *  Unregister callbacks for monitoring the state of GATT. The callback
+ *  struct should be one that was previously registered.
+ *
+ *  @param cb Callback struct.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_gatt_cb_unregister(struct bt_gatt_cb *cb);
+
 /** @brief Register GATT authorization callbacks.
  *
  *  Register callbacks to perform application-specific authorization of GATT

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1628,6 +1628,19 @@ void bt_gatt_cb_register(struct bt_gatt_cb *cb)
 	sys_slist_append(&callback_list, &cb->node);
 }
 
+int bt_gatt_cb_unregister(struct bt_gatt_cb *cb)
+{
+	if (cb == NULL) {
+		return -EINVAL;
+	}
+
+	if (!sys_slist_find_and_remove(&callback_list, &cb->node)) {
+		return -ENOENT;
+	}
+
+	return 0;
+}
+
 #if defined(CONFIG_BT_GATT_DYNAMIC_DB)
 static void db_changed(void)
 {
@@ -6023,9 +6036,9 @@ void bt_gatt_connected(struct bt_conn *conn)
 
 void bt_gatt_att_max_mtu_changed(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
-	struct bt_gatt_cb *cb;
+	struct bt_gatt_cb *cb, *tmp;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, cb, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&callback_list, cb, tmp, node) {
 		if (cb->att_mtu_updated) {
 			cb->att_mtu_updated(conn, tx, rx);
 		}

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -756,6 +756,27 @@ static int common_init(void)
 	return 0;
 }
 
+static int common_deinit(void)
+{
+	int err;
+
+	bt_le_scan_cb_unregister(&common_scan_cb);
+
+	err = bt_bap_broadcast_assistant_unregister_cb(&broadcast_assistant_cbs);
+	if (err != 0) {
+		FAIL("Bluetooth enable failed (err %d)\n", err);
+		return err;
+	}
+
+	err = bt_gatt_cb_unregister(&gatt_callbacks);
+	if (err != 0) {
+		FAIL("Failed to unregister GATT callbacks (err %d)\n", err);
+		return err;
+	}
+
+	return 0;
+}
+
 static void test_main_client_sync(void)
 {
 	int err;
@@ -780,6 +801,12 @@ static void test_main_client_sync(void)
 
 	test_bass_remove_source();
 
+	err = common_deinit();
+	if (err != 0) {
+		FAIL("Failed to deinitialize resources (err %d)\n", err);
+		return;
+	}
+
 	PASS("BAP Broadcast Assistant Client Sync Passed\n");
 }
 
@@ -803,6 +830,12 @@ static void test_main_client_sync_incorrect_code(void)
 	WAIT_FOR_FLAG(flag_incorrect_broadcast_code);
 
 	test_bass_remove_source();
+
+	err = common_deinit();
+	if (err != 0) {
+		FAIL("Failed to deinitialize resources (err %d)\n", err);
+		return;
+	}
 
 	PASS("BAP Broadcast Assistant Client Sync Passed\n");
 }
@@ -832,6 +865,12 @@ static void test_main_server_sync_client_rem(void)
 
 	test_bass_remove_source();
 
+	err = common_deinit();
+	if (err != 0) {
+		FAIL("Failed to deinitialize resources (err %d)\n", err);
+		return;
+	}
+
 	PASS("BAP Broadcast Assistant Server Sync Passed\n");
 }
 
@@ -853,6 +892,12 @@ static void test_main_server_sync_server_rem(void)
 	WAIT_FOR_FLAG(flag_recv_state_updated_with_bis_sync);
 
 	WAIT_FOR_FLAG(flag_recv_state_removed);
+
+	err = common_deinit();
+	if (err != 0) {
+		FAIL("Failed to deinitialize resources (err %d)\n", err);
+		return;
+	}
 
 	PASS("BAP Broadcast Assistant Server Sync Passed\n");
 }

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -492,6 +492,25 @@ static void init(void)
 	}
 }
 
+static void deinit(void)
+{
+	int err;
+
+	err = bt_bap_unicast_client_unregister_cb(&unicast_client_cbs);
+	if (err != 0) {
+		FAIL("Failed to unregister client callbacks: %d", err);
+		return;
+	}
+
+	err = bt_gatt_cb_unregister(&gatt_callbacks);
+	if (err != 0) {
+		FAIL("Failed to unregister GATT callbacks: %d", err);
+		return;
+	}
+
+	bt_le_scan_cb_unregister(&bap_scan_cb);
+}
+
 static void scan_and_connect(void)
 {
 	int err;
@@ -1088,6 +1107,8 @@ static void test_main(void)
 
 	disconnect_acl();
 
+	deinit();
+
 	PASS("Unicast client passed\n");
 }
 
@@ -1140,6 +1161,8 @@ static void test_main_acl_disconnect(void)
 
 	disconnect_acl();
 
+	deinit();
+
 	PASS("Unicast client ACL disconnect passed\n");
 }
 
@@ -1177,6 +1200,8 @@ static void test_main_async_group(void)
 
 		return;
 	}
+
+	deinit();
 
 	PASS("Unicast client async group parameters passed\n");
 }
@@ -1224,6 +1249,8 @@ static void test_main_reconf_group(void)
 
 		return;
 	}
+
+	deinit();
 
 	PASS("Unicast client async group parameters passed\n");
 }

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -690,6 +690,36 @@ static void init(size_t acceptor_cnt)
 	UNSET_FLAG(flag_syncable);
 }
 
+static void deinit(void)
+{
+	int err;
+
+	bt_le_scan_cb_unregister(&bap_scan_cb);
+
+	err = bt_bap_broadcast_assistant_unregister_cb(&ba_cbs);
+	if (err != 0) {
+		FAIL("Failed to unregister broadcast assistant callbacks (err %d)\n", err);
+	}
+
+	err = bt_vcp_vol_ctlr_cb_unregister(&vcp_cb);
+	if (err != 0) {
+		FAIL("Failed to unregister VCP callbacks (err %d)\n", err);
+		return;
+	}
+
+	err = bt_cap_commander_unregister_cb(&cap_cb);
+	if (err != 0) {
+		FAIL("Failed to unregister CAP callbacks (err %d)\n", err);
+		return;
+	}
+
+	err = bt_gatt_cb_unregister(&gatt_callbacks);
+	if (err != 0) {
+		FAIL("Failed to unregister GATT callbacks (err %d)\n", err);
+		return;
+	}
+}
+
 static void scan_and_connect(void)
 {
 	int err;
@@ -1176,6 +1206,8 @@ static void test_main_cap_commander_capture_and_render(void)
 	/* Disconnect all CAP acceptors */
 	disconnect_acl(acceptor_cnt);
 
+	deinit();
+
 	PASS("CAP commander capture and rendering passed\n");
 }
 
@@ -1224,6 +1256,8 @@ static void test_main_cap_commander_broadcast_reception(void)
 
 	backchannel_sync_send_all(); /* let others know we have received what we wanted */
 
+	deinit();
+
 	PASS("Broadcast reception passed\n");
 }
 
@@ -1266,6 +1300,7 @@ static void test_main_cap_commander_cancel(void)
 	/* Disconnect all CAP acceptors */
 	disconnect_acl(acceptor_count);
 
+	deinit();
 	/* restore the default callback */
 	cap_cb.volume_changed = cap_volume_changed_cb;
 

--- a/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
@@ -473,6 +473,17 @@ static void init(void)
 	}
 }
 
+static void deinit(void)
+{
+	int err;
+
+	err = bt_gatt_cb_unregister(&gatt_callbacks);
+	if (err != 0) {
+		FAIL("Failed to unregister GATT callbacks (err %d)\n", err);
+		return;
+	}
+}
+
 static void scan_and_connect(struct bt_conn **conn)
 {
 	int err;
@@ -888,6 +899,8 @@ static void test_main_cap_handover_central(void)
 
 	unicast_audio_stop();
 
+	deinit();
+
 	PASS("CAP initiator handover unicast to broadcast passed\n");
 }
 
@@ -919,6 +932,8 @@ static void test_main_cap_handover_central_reception_stop(void)
 	backchannel_sync_wait_all();
 
 	unicast_audio_stop();
+
+	deinit();
 
 	PASS("CAP initiator handover unicast to broadcast passed\n");
 }

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -531,6 +531,29 @@ static void init(void)
 	}
 }
 
+static void deinit(void)
+{
+	int err;
+
+	err = bt_cap_initiator_unregister_cb(&cap_cb);
+	if (err != 0) {
+		FAIL("Failed to unregister CAP callbacks (err %d)\n", err);
+		return;
+	}
+
+	err = bt_bap_unicast_client_unregister_cb(&unicast_client_cbs);
+	if (err != 0) {
+		FAIL("Failed to unregister BAP callbacks (err %d)\n", err);
+		return;
+	}
+
+	err = bt_gatt_cb_unregister(&gatt_callbacks);
+	if (err != 0) {
+		FAIL("Failed to unregister GATT callbacks (err %d)\n", err);
+		return;
+	}
+}
+
 static void scan_and_connect(void)
 {
 	int err;
@@ -1015,6 +1038,8 @@ static void test_gmap_ugg_unicast_ac(const struct gmap_unicast_ac_param *param)
 		connected_conns[i] = NULL;
 	}
 
+	deinit();
+
 	PASS("GMAP UGG passed for %s with Sink Preset %s and Source Preset %s\n", param->name,
 	     param->snk_named_preset != NULL ? param->snk_named_preset->name : "None",
 	     param->src_named_preset != NULL ? param->src_named_preset->name : "None");
@@ -1221,6 +1246,8 @@ static int test_gmap_ugg_broadcast_ac(const struct gmap_broadcast_ac_param *para
 
 	stop_and_delete_extended_adv(adv);
 	adv = NULL;
+
+	deinit();
 
 	PASS("CAP initiator broadcast passed\n");
 

--- a/tests/bsim/bluetooth/host/att/eatt/src/main_reconfigure.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/main_reconfigure.c
@@ -32,6 +32,8 @@ static struct bt_gatt_cb cb = {
 
 static void test_peripheral_main(void)
 {
+	int err;
+
 	TEST_ASSERT(bk_sync_init() == 0, "Failed to open backchannel");
 
 	peripheral_setup_and_connect();
@@ -52,6 +54,12 @@ static void test_peripheral_main(void)
 	bk_sync_wait();
 
 	disconnect();
+
+	err = bt_gatt_cb_unregister(&cb);
+	if (err != 0) {
+		TEST_FAIL("Unregister GATT callbacks failed (%d)", err);
+		return;
+	}
 
 	TEST_PASS("EATT Peripheral tests Passed");
 }
@@ -84,6 +92,12 @@ static void test_central_main(void)
 	bk_sync_wait();
 
 	wait_for_disconnect();
+
+	err = bt_gatt_cb_unregister(&cb);
+	if (err != 0) {
+		TEST_FAIL("Unregister GATT callbacks failed (%d)", err);
+		return;
+	}
 
 	TEST_PASS("EATT Central tests Passed");
 }

--- a/tests/bsim/bluetooth/host/misc/conn_stress/central/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/central/src/main.c
@@ -741,6 +741,12 @@ void test_central_main(void)
 		k_msleep(10);
 	}
 
+	err = bt_gatt_cb_unregister(&gatt_callbacks);
+	if (err != 0) {
+		TEST_FAIL("Unregister GATT callbacks failed (%d)", err);
+		return;
+	}
+
 	TEST_PASS("Central tests passed");
 }
 

--- a/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
@@ -474,6 +474,12 @@ void test_peripheral_main(void)
 		}
 	}
 
+	err = bt_gatt_cb_unregister(&gatt_callbacks);
+	if (err != 0) {
+		TEST_FAIL("Unregister GATT callbacks failed (%d)", err);
+		return;
+	}
+
 	TEST_PASS("Peripheral tests passed");
 }
 


### PR DESCRIPTION
Introduce bt_gatt_cb_unregister() to unregister  callbacks.

Replace callback_list traversal with SYS_SLIST_FOR_EACH_CONTAINER_SAFE()