### PR TITLE
Fix two deficiencies in the CPU frequency scaling subsystem

### DIFF
--- a/doc/services/cpu_freq/index.rst
+++ b/doc/services/cpu_freq/index.rst
@@ -43,7 +43,7 @@ For an example of a metric in use, see the :ref:`on_demand <on_demand_policy>` p
 P-state Drivers
 ***************
 
-A SoC supporting the CPU Freq subsystem must implement a P-state driver that implements
+A SoC supporting the CPU Frequency Scaling subsystem must implement a P-state driver that implements
 :c:func:`cpu_freq_pstate_set` which applies the passed in ``p_state`` to
 the CPU when called.
 
@@ -61,8 +61,9 @@ undergo a P-state transition, then all other CPUs will also undergo the same P-s
 This can be overridden by the SoC by enabling the :kconfig:option:`CONFIG_CPU_FREQ_PER_CPU_SCALING`
 configuration option to allow each CPU to be clocked independently.
 
-The SoC supporting CPU Freq must uphold Zephyr's requirement that the system timer remains constant
-over the lifetime of the program. See :ref:`Kernel Timing <kernel_timing>` for more information.
+The SoC supporting CPU Frequency Scaling must uphold Zephyr's requirement that the system timer
+frequency remains steady over the lifetime of the program. See :ref:`Kernel Timing <kernel_timing>`
+for more information.
 
 The CPU Frequency Scaling subsystem runs as a handler function to a ``k_timer``, which means it runs
 in interrupt context (IRQ). The SoC P-state driver must ensure that its implementation of

--- a/subsys/cpu_freq/cpu_freq.c
+++ b/subsys/cpu_freq/cpu_freq.c
@@ -28,8 +28,6 @@ static void cpu_freq_next_pstate(void)
 	/* Get next performance state */
 	const struct pstate *pstate_next;
 
-	cpu_freq_policy_reset();
-
 	ret = cpu_freq_policy_select_pstate(&pstate_next);
 	if (ret) {
 		LOG_ERR("Failed to get pstate: %d", ret);

--- a/subsys/cpu_freq/cpu_freq.c
+++ b/subsys/cpu_freq/cpu_freq.c
@@ -70,11 +70,9 @@ static void cpu_freq_timer_handler(struct k_timer *timer)
 	 */
 
 	target_cpus = (num_cpus == 32U) ? 0xFFFFFFFF : (1U << num_cpus) - 1U;
-	target_cpus ^= (1U << _current_cpu->id),
+	target_cpus ^= (1U << _current_cpu->id);
 
-	ret = k_ipi_work_add(&cpu_freq_work,
-			     target_cpus ^ (1U << _current_cpu->id),
-			     cpu_freq_ipi_handler);
+	ret = k_ipi_work_add(&cpu_freq_work, target_cpus, cpu_freq_ipi_handler);
 
 	if (ret != 0) {
 		/*


### PR DESCRIPTION
Three changes in this PR:
1. Remove redundant XOR calculation in `k_ipi_work_add`
In the current code, `target_cpus ^= (1U << _current_cpu->id)` is first used to remove the current core. Then, `k_ipi_work_add` performs `target_cpus ^ (1U << _current_cpu->id)` again when passing parameters. This will add the current core to the mask again, causing the current core to receive IPI and directly call `cpu_freq_next_pstate()` at the end, which may lead to duplicate execution. This first change is to change `target_cpus ^ (1U << _current_cpu->id)` to `target_cpus` in `k_ipi_work_add` to avoid the second XOR.
2. Avoid redundant `cpu_freq_policy_reset()`
The current code calls `cpu_freq_policy_reset()` once within the SMP branch of the `cpu_freq_timer_handler` function, and then calls it again at the beginning of `cpu_freq_next_pstate()`. This causes repeated resets of `pstate_best `and `num_unprocessed_cpus`, which prevents the 'last core' from being reached. The initiating core should perform a reset before broadcasting, and other cores should not reset again.
3. Improve `cpu_freq` documentation.