### PR TITLE
modules: openthread: platform: udp: Fix otPlatUdpClose bug

### DIFF
--- a/modules/openthread/platform/udp.c
+++ b/modules/openthread/platform/udp.c
@@ -120,6 +120,10 @@ otError otPlatUdpClose(otUdpSocket *aUdpSocket)
 		}
 	}
 
+	VerifyOrExit(net_socket_service_register(&handle_udp_receive, sockfd_udp,
+						 ARRAY_SIZE(sockfd_udp), NULL) == 0,
+						 error = OT_ERROR_FAILED);
+
 exit:
 	return error;
 }


### PR DESCRIPTION
This commit fixes a bug which occurred when a socket was closed.

It was observed when multiple attempts to obtain dataset using ephemeral key were performed. Failure was seen starting with attempt number 2, incoming packets were not processed.

In a open-close-open scenario, incoming traffic was dropped, most likely because there was stale data in the corresponding socket service structure.

By calling, `net_socket_service_register` after a socket in closed, the problem was resolved, and data shown in `net sockets` cli command is now updated and correct.