### PR TITLE
manifest: update hal_nuvoton for M55M1 HyperRAM

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -205,7 +205,7 @@ manifest:
       groups:
         - hal
     - name: hal_nuvoton
-      revision: 9b455fffd6dd3936c5a4eb575e4d33edbcf1b6b0
+      revision: 9d1b8dafcef58a50c0edef2efb876807a959a332
       path: modules/hal/nuvoton
       groups:
         - hal


### PR DESCRIPTION
The updates M55M1 HyperRAM driver to BSP V3.01.003.

Depend on:
https://github.com/zephyrproject-rtos/hal_nuvoton/pull/22
