### PR TITLE
manifest: Update nrf_wifi for wps pbc

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -342,7 +342,7 @@ manifest:
       revision: 26ed181181eed53e400db8f63fa83c566a05d971
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: e269670cd17fb8ccc4b7004544276bc7d9578496
+      revision: pull/82/head
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: c30a6d8b92fcebdb797fc1a7698e8729e250f637


### PR DESCRIPTION
Update nrf_wifi for wps pbc and regulatory domain update in softap mode.