### PR TITLE
boards: mcxw23: Use SYSTICK as the default kernel timer

### DIFF
--- a/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
+++ b/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
@@ -20,7 +20,7 @@
 		zephyr,flash-controller = &iap;
 	};
 
-	aliases{
+	aliases {
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
@@ -82,17 +82,17 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = /* Not a GPIO*/	/* AN  */
-				/* Not a GPIO*/		/* RST */
-				<2 0 &gpio0 8 0>,	/* CS   */
-				<3 0 &gpio0 10 0>,	/* SCK  */
-				<4 0 &gpio0 7 0>,	/* MISO */
-				<5 0 &gpio0 6 0>,	/* MOSI */
-				<6 0 &gpio0 15 0>,	/* PWM  */
-				<7 0 &gpio0 16 0>,	/* INT  */
-				<8 0 &gpio0 3 0>,	/* RX   */
-				<9 0 &gpio0 2 0>,	/* TX   */
-				<10 0 &gpio0 14 0>,	/* SCL  */
-				<11 0 &gpio0 13 0>;	/* SDA  */
+			   /* Not a GPIO*/		/* RST */
+			   <2 0 &gpio0 8 0>,	/* CS   */
+			   <3 0 &gpio0 10 0>,	/* SCK  */
+			   <4 0 &gpio0 7 0>,	/* MISO */
+			   <5 0 &gpio0 6 0>,	/* MOSI */
+			   <6 0 &gpio0 15 0>,	/* PWM  */
+			   <7 0 &gpio0 16 0>,	/* INT  */
+			   <8 0 &gpio0 3 0>,	/* RX   */
+			   <9 0 &gpio0 2 0>,	/* TX   */
+			   <10 0 &gpio0 14 0>,	/* SCL  */
+			   <11 0 &gpio0 13 0>;	/* SDA  */
 	};
 
 	arduino_header: arduino-connector {
@@ -101,27 +101,27 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 16 0>,
-				<ARDUINO_HEADER_R3_A1 0 &gpio0 19 0>,
-				<ARDUINO_HEADER_R3_A2 0 &gpio0 22 0>,
-				<ARDUINO_HEADER_R3_A3 0 &gpio0 20 0>,
-				<ARDUINO_HEADER_R3_A4 0 &gpio0 13 0>,
-				<ARDUINO_HEADER_R3_A5 0 &gpio0 14 0>,
-				<ARDUINO_HEADER_R3_D0 0 &gpio0 2 0>,
-				<ARDUINO_HEADER_R3_D1 0 &gpio0 3 0>,
-				<ARDUINO_HEADER_R3_D2 0 &gpio0 21 0>,
-				<ARDUINO_HEADER_R3_D3 0 &gpio0 18 0>,
-				<ARDUINO_HEADER_R3_D4 0 &gpio0 0 0>,
-				<ARDUINO_HEADER_R3_D5 0 &gpio0 9 0>,
-				<ARDUINO_HEADER_R3_D6 0 &gpio0 4 0>,
-				<ARDUINO_HEADER_R3_D7 0 &gpio0 1 0>,
-				<ARDUINO_HEADER_R3_D8 0 &gpio0 0 0>,	/* D8 is not connected */
-				<ARDUINO_HEADER_R3_D9 0 &gpio0 15 0>,
-				<ARDUINO_HEADER_R3_D10 0 &gpio0 8 0>,
-				<ARDUINO_HEADER_R3_D11 0 &gpio0 6 0>,
-				<ARDUINO_HEADER_R3_D12 0 &gpio0 7 0>,
-				<ARDUINO_HEADER_R3_D13 0 &gpio0 10 0>,
-				<ARDUINO_HEADER_R3_D14 0 &gpio0 13 0>,
-				<ARDUINO_HEADER_R3_D15 0 &gpio0 14 0>;
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 22 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 20 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 21 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 0 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 1 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 0 0>,	/* D8 is not connected */
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 8 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 6 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 10 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 14 0>;
 	};
 };
 

--- a/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
+++ b/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
@@ -177,11 +177,11 @@
 };
 
 /*
- * MCXW23 FRDM board uses OS timer as the kernel timer
- * In case we need to switch to SYSTICK timer, then
- * replace &os_timer with &systick
+ * MCXW23 FRDM board uses SYSTICK timer as the kernel timer.
+ * In case we need to switch to OS timer, then
+ * replace &systick with &os_timer
  */
-&os_timer {
+&systick {
 	status = "okay";
 };
 

--- a/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
+++ b/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
@@ -20,7 +20,7 @@
 		zephyr,flash-controller = &iap;
 	};
 
-	aliases{
+	aliases {
 		led0 = &red_led;
 		sw0 = &btn_wk;
 		sw1 = &btn_usr;
@@ -70,15 +70,15 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = /* Not a GPIO*/	/* AN  */
-				/* Not a GPIO*/		/* RST */
-				<2 0 &gpio0 0 0>,	/* CS   */
-				<3 0 &gpio0 4 0>,	/* SCK  */
-				<4 0 &gpio0 3 0>,	/* MISO */
-				<5 0 &gpio0 2 0>,	/* MOSI */
-				<8 0 &gpio0 2 0>,	/* RX   */
-				<9 0 &gpio0 3 0>,	/* TX   */
-				<10 0 &gpio0 3 0>,	/* SCL  */
-				<11 0 &gpio0 2 0>;	/* SDA  */
+			   /* Not a GPIO*/		/* RST */
+			   <2 0 &gpio0 0 0>,	/* CS   */
+			   <3 0 &gpio0 4 0>,	/* SCK  */
+			   <4 0 &gpio0 3 0>,	/* MISO */
+			   <5 0 &gpio0 2 0>,	/* MOSI */
+			   <8 0 &gpio0 2 0>,	/* RX   */
+			   <9 0 &gpio0 3 0>,	/* TX   */
+			   <10 0 &gpio0 3 0>,	/* SCL  */
+			   <11 0 &gpio0 2 0>;	/* SDA  */
 	};
 
 	arduino_header: arduino-connector {
@@ -87,21 +87,21 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = <ARDUINO_HEADER_R3_D0 0 &gpio0 2 0>,
-				<ARDUINO_HEADER_R3_D1  0 &gpio0 3 0>,
-				<ARDUINO_HEADER_R3_D2  0 &gpio0 0 0>,	/* D2 is not connected */
-				<ARDUINO_HEADER_R3_D3  0 &gpio0 0 0>,	/* D3 is not connected */
-				<ARDUINO_HEADER_R3_D4  0 &gpio0 0 0>,	/* D4 is not connected */
-				<ARDUINO_HEADER_R3_D5  0 &gpio0 0 0>,	/* D5 is not connected */
-				<ARDUINO_HEADER_R3_D6  0 &gpio0 0 0>,	/* D6 is not connected */
-				<ARDUINO_HEADER_R3_D7  0 &gpio0 0 0>,	/* D7 is not connected */
-				<ARDUINO_HEADER_R3_D8  0 &gpio0 0 0>,	/* D8 is not connected */
-				<ARDUINO_HEADER_R3_D9  0 &gpio0 0 0>,	/* D9 is not connected */
-				<ARDUINO_HEADER_R3_D10 0 &gpio0 0 0>,
-				<ARDUINO_HEADER_R3_D11 0 &gpio0 2 0>,
-				<ARDUINO_HEADER_R3_D12 0 &gpio0 3 0>,
-				<ARDUINO_HEADER_R3_D13 0 &gpio0 4 0>,
-				<ARDUINO_HEADER_R3_D14 0 &gpio0 2 0>,
-				<ARDUINO_HEADER_R3_D15 0 &gpio0 3 0>;
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 0 0>,	/* D2 is not connected */
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 0 0>,	/* D3 is not connected */
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 0 0>,	/* D4 is not connected */
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 0 0>,	/* D5 is not connected */
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 0 0>,	/* D6 is not connected */
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 0 0>,	/* D7 is not connected */
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 0 0>,	/* D8 is not connected */
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 0 0>,	/* D9 is not connected */
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 0 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 3 0>;
 	};
 };
 

--- a/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
+++ b/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
@@ -157,11 +157,11 @@
 };
 
 /*
- * MCXW23 EVK board uses OS timer as the kernel timer
- * In case we need to switch to SYSTICK timer, then
- * replace &os_timer with &systick
+ * MCXW23 EVK board uses SYSTICK timer as the kernel timer.
+ * In case we need to switch to OS timer, then
+ * replace &systick with &os_timer
  */
-&os_timer {
+&systick {
 	status = "okay";
 };
 


### PR DESCRIPTION
According to the RM, the FRO 1M clock source for OSTIMER is trimmed to ± 15% accuracy over the entire voltage and temperature.
The FRO 1M is not accurate enough on the silicon.
So, use SYSTICK as the default kernel timer.

Fixes #98280