### PR TITLE
Bluetooth: Classic: L2CAP: Reset rx.cid when channel is deleted

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -2614,6 +2614,9 @@ destroy:
 	/* Reset internal members of common channel */
 	bt_l2cap_br_chan_set_state(chan, BT_L2CAP_DISCONNECTED);
 	BR_CHAN(chan)->psm = 0U;
+	if (L2CAP_BR_CID_IS_DYN(BR_CHAN(chan)->rx.cid)) {
+		BR_CHAN(chan)->rx.cid = 0U;
+	}
 #endif
 	if (chan->destroy) {
 		chan->destroy(chan);


### PR DESCRIPTION
rootcause: The dynamic L2CAP channel rx.cid is not reset, it will be intercepted by the judgment condition of the fixed channel, directly using the last alloced cid may cause cid conflict.