### PR TITLE
scripts: west_commands: Extend ruff config in pyproject.toml

### DIFF
--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from west.commands import WestCommand
+
 from zephyr_ext_common import ZEPHYR_BASE
 
 sys.path.append(os.fspath(Path(__file__).parent.parent))

--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -10,6 +10,7 @@ import textwrap
 from pathlib import Path
 
 from west.commands import WestCommand
+
 from zephyr_ext_common import ZEPHYR_BASE
 
 sys.path.append(os.fspath(Path(__file__).parent.parent))

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -10,11 +10,12 @@ import shlex
 import sys
 
 import yaml
-from build_helpers import FIND_BUILD_DIR_DESCRIPTION, find_build_dir, is_zephyr_build, load_domains
 from west.commands import Verbosity
 from west.configuration import config
 from west.util import WestNotFound, west_topdir
 from west.version import __version__
+
+from build_helpers import FIND_BUILD_DIR_DESCRIPTION, find_build_dir, is_zephyr_build, load_domains
 from zcmake import DEFAULT_CMAKE_GENERATOR, CMakeCache, run_build, run_cmake
 from zephyr_ext_common import Forceable
 

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -14,10 +14,11 @@ import os
 import sys
 from pathlib import Path
 
-import zcmake
 from west import log
 from west.configuration import config
 from west.util import escapes_directory
+
+import zcmake
 
 # Domains.py must be imported from the pylib directory, since
 # twister also uses the implementation

--- a/scripts/west_commands/debug.py
+++ b/scripts/west_commands/debug.py
@@ -8,8 +8,9 @@
 
 from textwrap import dedent
 
-from run_common import add_parser_common, do_run_common
 from west.commands import WestCommand
+
+from run_common import add_parser_common, do_run_common
 
 
 class Debug(WestCommand):

--- a/scripts/west_commands/export.py
+++ b/scripts/west_commands/export.py
@@ -6,6 +6,7 @@ import argparse
 from pathlib import Path
 
 from west.commands import WestCommand
+
 from zcmake import run_cmake
 
 EXPORT_DESCRIPTION = '''\

--- a/scripts/west_commands/flash.py
+++ b/scripts/west_commands/flash.py
@@ -8,8 +8,9 @@
 
 from pathlib import Path
 
-from run_common import add_parser_common, do_run_common, get_build_dir
 from west.commands import WestCommand
+
+from run_common import add_parser_common, do_run_common, get_build_dir
 
 
 class Flash(WestCommand):

--- a/scripts/west_commands/packages.py
+++ b/scripts/west_commands/packages.py
@@ -13,6 +13,7 @@ from pathlib import Path, PureWindowsPath
 
 from west.commands import WestCommand
 from west.util import quote_sh_list
+
 from zephyr_ext_common import ZEPHYR_BASE
 
 sys.path.append(os.fspath(Path(__file__).parent.parent))

--- a/scripts/west_commands/patch.py
+++ b/scripts/west_commands/patch.py
@@ -19,6 +19,7 @@ from west.commands import WestCommand
 
 sys.path.append(os.fspath(Path(__file__).parent.parent))
 import zephyr_module
+
 from zephyr_ext_common import ZEPHYR_BASE
 
 try:

--- a/scripts/west_commands/pyproject.toml
+++ b/scripts/west_commands/pyproject.toml
@@ -4,3 +4,6 @@ mypy_path = "."
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+
+[tool.ruff]
+extend = "../../.ruff.toml"

--- a/scripts/west_commands/robot.py
+++ b/scripts/west_commands/robot.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from run_common import add_parser_common, do_run_common
 from west.commands import WestCommand
+
+from run_common import add_parser_common, do_run_common
 
 EXPORT_DESCRIPTION = '''\
 Run RobotFramework test suites with a runner of choice.

--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -12,9 +12,8 @@ import re
 import shutil
 import sys
 
-from zephyr_ext_common import ZEPHYR_BASE
-
 from runners.core import RunnerCaps, ZephyrBinaryRunner
+from zephyr_ext_common import ZEPHYR_BASE
 
 DEFAULT_CAVSTOOL='soc/intel/intel_adsp/tools/cavstool_client.py'
 

--- a/scripts/west_commands/shields.py
+++ b/scripts/west_commands/shields.py
@@ -11,6 +11,7 @@ import textwrap
 from pathlib import Path
 
 from west.commands import WestCommand
+
 from zephyr_ext_common import ZEPHYR_BASE
 
 sys.path.append(os.fspath(Path(__file__).parent.parent))

--- a/scripts/west_commands/simulate.py
+++ b/scripts/west_commands/simulate.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from run_common import add_parser_common, do_run_common
 from west.commands import WestCommand
+
+from run_common import add_parser_common, do_run_common
 
 EXPORT_DESCRIPTION = '''\
 Simulate the board on a runner of choice using generated artifacts.

--- a/scripts/west_commands/spdx.py
+++ b/scripts/west_commands/spdx.py
@@ -6,6 +6,7 @@ import os
 import uuid
 
 from west.commands import WestCommand
+
 from zspdx.sbom import SBOMConfig, makeSPDX, setupCmakeQuery
 from zspdx.version import SPDX_VERSION_2_3, SUPPORTED_SPDX_VERSIONS, parse
 

--- a/scripts/west_commands/tests/test_nxp_s32dbg.py
+++ b/scripts/west_commands/tests/test_nxp_s32dbg.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 from conftest import RC_KERNEL_ELF
+
 from runners.nxp_s32dbg import NXPS32DebugProbeConfig, NXPS32DebugProbeRunner
 
 TEST_DEVICE = 's32dbg'

--- a/scripts/west_commands/tests/test_rfp.py
+++ b/scripts/west_commands/tests/test_rfp.py
@@ -7,6 +7,7 @@ import os
 from unittest.mock import call, patch
 
 from conftest import RC_KERNEL_HEX
+
 from runners.rfp import RfpBinaryRunner
 
 TEST_RFP_PORT = 'test-rfp-serial'

--- a/scripts/west_commands/tests/test_twister.py
+++ b/scripts/west_commands/tests/test_twister.py
@@ -6,6 +6,7 @@ import argparse
 from argparse import Namespace
 
 import pytest
+
 from twister_cmd import Twister
 
 TEST_CASES = [

--- a/scripts/west_commands/tests/west_build/test_dir_fmt.py
+++ b/scripts/west_commands/tests/west_build/test_dir_fmt.py
@@ -9,6 +9,7 @@ from argparse import Namespace
 from pathlib import Path
 
 import pytest
+
 from build import Build
 
 ROOT = Path(Path.cwd().anchor)

--- a/scripts/west_commands/tests/west_build/test_resolve_build_dir.py
+++ b/scripts/west_commands/tests/west_build/test_resolve_build_dir.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 
 import pytest
+
 from build_helpers import _resolve_build_dir
 
 cwd = Path.cwd()


### PR DESCRIPTION
Now that the west_commands directory has a pyproject.toml configuration file, it should consider local packages for first party imports.

Make sure the top-level ruff config is extended, and fix some import sorting.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/98204