### PR TITLE
Bluetooth: host: Disconnect BR/EDR ACL link on security block

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -2746,6 +2746,9 @@ static void l2cap_br_conn_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 
 no_chan:
 	l2cap_br_send_conn_rsp(conn, scid, 0, ident, result);
+	if (result == BT_L2CAP_BR_ERR_SEC_BLOCK) {
+		bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
+	}
 }
 
 #define L2CAP_QOS_TOKEN_RATE_DEFAULT        0x00000000


### PR DESCRIPTION
When an incoming BR/EDR L2CAP channel request targets a server requiring
encryption (`sec_level > BT_SECURITY_L0`) while the current ACL link is
still unencrypted and the remote device supports SSP, the stack returns
`BT_L2CAP_BR_ERR_SEC_BLOCK`.

Previously, the ACL link remained connected after this failure case,
leaving the connection in a blocked state where the remote could not
retry pairing or request encryption.

This patch ensures the ACL is disconnected with `BT_HCI_ERR_AUTH_FAIL`
when this security block occurs, prompting the remote side to initiate
proper authentication and avoiding a stalled link state.