### PR TITLE
scripts: support extra-modules specified in `module.yml`

### DIFF
--- a/scripts/west_commands/tests/test_zephyr_module.py
+++ b/scripts/west_commands/tests/test_zephyr_module.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2025 Thorsten Klein <thorsten.klein@bshg.com>
+# Copyright (c) 2025 Bosch Hausgeräte GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import os
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+import zephyr_module
+from utils import chdir, update_env
+
+
+def save_module_yml(
+    path: str | Path, extra_modules: list[(str, Any)] | None = None, recursive=None
+):
+    data = {}
+    if extra_modules:
+        data['extra-modules'] = []
+        for extra_module_path, recursive in extra_modules:
+            m_path = os.path.relpath(extra_module_path, path)
+            module = {'path': m_path}
+            if recursive is not None:
+                module['recursive'] = recursive
+            data['extra-modules'].append(module)
+
+    module_yml_path = Path(path) / 'zephyr' / 'module.yml'
+    module_yml_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(module_yml_path, 'w') as file:
+        yaml.dump(data, file, default_flow_style=False)
+    return path, data
+
+
+def create_west_workspace(topdir: str | Path, manifest: str | Path):
+    manifest = Path(manifest)
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        textwrap.dedent('''
+    manifest:
+    ''')
+    )
+
+    west_config_path = Path(topdir) / '.west' / 'config'
+    west_config_path.parent.mkdir(parents=True)
+    west_config = textwrap.dedent(f'''
+    [manifest]
+    path = {os.path.relpath(manifest.parent, topdir)}
+    file = {manifest.name}
+    ''')
+    west_config_path.write_text(west_config)
+    return manifest
+
+
+@pytest.fixture
+def run_tests_in_tempdir(tmpdir_factory):
+    # Fixture to ensure that the tests run in a tempdir
+    tmpdir = Path(tmpdir_factory.mktemp("test-configs"))
+    os.chdir(tmpdir)
+    yield
+
+
+@pytest.fixture
+def setup_workspace_v1(run_tests_in_tempdir):
+    '''
+    setup a west workspace for a manifest project (west.yml) which contains
+    some additional zephyr extra-modules. Those extra-modules are stacked,
+    so each module specifies its child module in zephyr/module.yml
+    ├── .west
+    │   └── config
+    ├── base
+    │   ├── libA
+    │   │   ├── module-1
+    │   │   │   └── zephyr
+    │   │   │       └── module.yml
+    │   │   ├── module-2
+    │   │   │   └── zephyr
+    │   │   │       └── module.yml
+    │   │   └── zephyr
+    │   │       └── module.yml
+    │   ├── libB
+    │   │   └── zephyr
+    │   │       └── module.yml
+    │   └── zephyr
+    │       └── module.yml
+    ├── west.yml
+    └── zephyr
+        └── module.yml
+    '''
+    base_a_1, _ = save_module_yml(Path('base') / 'libA' / 'module-1', [])
+    base_a_2, _ = save_module_yml(Path('base') / 'libA' / 'module-2', [])
+    base_a, _ = save_module_yml(Path('base') / 'libA', [(base_a_1, None), (base_a_2, None)])
+    base_b, _ = save_module_yml(Path('base') / 'libB', [])
+    save_module_yml(Path('base'), [(base_a, None), (base_b, None)])
+
+    # basic west.yml
+    create_west_workspace('.', 'west.yml')
+    save_module_yml(Path('.'), [])
+
+
+def test_parse_modules(setup_workspace_v1):
+    '''by default no extra-modules are considered if none are specified
+    in the module.yml of the manifest project'''
+    modules = zephyr_module.parse_modules('zephyr')
+    assert len(modules) == 1
+    assert modules[0].project == str(Path('.').resolve())
+
+
+def test_parse_modules_extra_modules(setup_workspace_v1):
+    '''consider extra-modules specified in manifest project (zephyr/module.yml)
+    but not their child extra-modules by default'''
+    save_module_yml(Path('.'), [('base', None)])
+    modules = zephyr_module.parse_modules('zephyr')
+    assert len(modules) == 2
+    assert modules[1].project == Path('base').resolve()
+
+
+def test_parse_modules_extra_modules_recursive_false(setup_workspace_v1):
+    '''consider extra-modules from manifest project (zephyr/module.yml)
+    but not their child extra-modules if 'recursive=False' '''
+    save_module_yml(Path('.'), [('base', False)])
+    modules = zephyr_module.parse_modules('zephyr')
+    assert len(modules) == 2
+    assert modules[1].project == Path('base').resolve()
+
+
+def test_parse_modules_extra_modules_recursive_true(setup_workspace_v1):
+    '''consider extra-modules from manifest project (zephyr/module.yml)
+    and also their child extra-modules if 'recursive=True' '''
+    save_module_yml(Path('.'), [('base', True)])
+    modules = zephyr_module.parse_modules('zephyr')
+    assert len(modules) == 6
+    assert modules[1].project == Path('base').resolve()
+    assert modules[2].project == (Path('base') / 'libA').resolve()
+    assert modules[3].project == (Path('base') / 'libA' / 'module-1').resolve()
+    assert modules[4].project == (Path('base') / 'libA' / 'module-2').resolve()
+    assert modules[5].project == (Path('base') / 'libB').resolve()
+
+
+def test_parse_modules_chdir(setup_workspace_v1):
+    '''consider extra-modules from manifest project (zephyr/module.yml)
+    and also their child extra-modules if 'recursive=True' '''
+    save_module_yml(Path('.'), [('base', True)])
+    with chdir('base'):
+        modules = zephyr_module.parse_modules('zephyr')
+    assert len(modules) == 6
+
+
+def test_parse_modules_env(setup_workspace_v1):
+    '''consider extra-modules from manifest project (zephyr/module.yml)
+    and also their child extra-modules if 'recursive=True' '''
+    save_module_yml(Path('.'), [])
+    for env in ['EXTRA_ZEPHYR_MODULES', 'ZEPHYR_EXTRA_MODULES']:
+        with update_env({env: 'base'}):
+            modules = zephyr_module.parse_modules('zephyr')
+        assert len(modules) == 2
+
+
+def test_parse_modules_extra_modules_recursive_invalid(setup_workspace_v1):
+    '''invalid value for 'recursive' should fail'''
+    save_module_yml(Path('.'), [('base', 'invalid')])
+    with pytest.raises(SystemExit) as e:
+        zephyr_module.parse_modules('zephyr')
+    assert "Value 'invalid' is not of type 'bool'" in str(e.value)
+
+
+def test_parse_modules_extra_modules_recursive_recursion(setup_workspace_v1):
+    '''recursion should be handled'''
+    for path in [".", Path('base') / '..', Path('non-existent') / '..']:
+        save_module_yml(Path('.'), [(path, True)])
+        modules = zephyr_module.parse_modules('zephyr')
+        assert len(modules) == 1
+
+
+def test_parse_modules_extra_modules_child_recursive_false(setup_workspace_v1):
+    '''a child module sets recursive=False'''
+    save_module_yml(
+        Path('base'), extra_modules=[(Path('base') / 'libA', False), (Path('base') / 'libB', False)]
+    )
+
+    # manifest project can override to resolve recursively
+    save_module_yml(Path('.'), [('base', True)])
+    modules = zephyr_module.parse_modules('zephyr')
+    assert len(modules) == 6

--- a/scripts/west_commands/utils.py
+++ b/scripts/west_commands/utils.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2025 Thorsten Klein <thorsten.klein@bshg.com>
+# Copyright (c) 2025 Bosch Hausgeräte GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Common code used by commands or tests"""
+
+import contextlib
+import os
+
+
+@contextlib.contextmanager
+def chdir(path):
+    """
+    Temporarily change the current working directory.
+    This context manager changes the current working directory to `path`
+    for the duration of the `with` block. After the block exits, the
+    working directory is restored to its original value.
+    """
+    oldpwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(oldpwd)
+
+
+@contextlib.contextmanager
+def update_env(env: dict[str, str | None]):
+    """
+    Temporarily update the process environment variables.
+    This context manager updates `os.environ` with the key-value pairs
+    provided in the `env` dictionary for the duration of the `with` block.
+    The existing environment is preserved and fully restored when the block
+    exits. If the value is set to None, the environment variable is unset.
+    """
+    env_bak = dict(os.environ)
+    env_vars = {}
+    for k, v in env.items():
+        # unset if value is None
+        if v is None and k in os.environ:
+            del os.environ[k]
+        # set env variable to new value only if v is not None
+        elif v is not None:
+            env_vars[k] = v
+    # apply the new environment
+    os.environ.update(env_vars)
+    try:
+        yield
+    finally:
+        # reset to previous environment
+        os.environ.clear()
+        os.environ.update(env_bak)


### PR DESCRIPTION
## Motivation

Currently, extra modules can only be specified via the environment variable `EXTRA_ZEPHYR_MODULES`.
This approach makes it difficult to version-control or share configurations across team members.

Allowing these extra modules to be defined in a file would make configurations:
- Easier to reproduce
- Trackable in git
- More maintainable for collaborative projects

## Proposal

Introduce support for defining extra-modules in configuration file **`zephyr/module.yml`**:

```yaml
extra-modules:
- path: module-1
  recursive: true
- path: module-2
```

### Behavior

- Each entry under `extra-modules` specifies the relative path to an additional module.
- The `zephyr/module.yml` from each west project is automatically considered.
- A boolean option `recursive` (default: `false`) controls whether the extra module’s own `extra-modules` should be included as well.
- When `recursive: true` is set, zephyr resolves extra modules recursively by reading each referenced module’s `zephyr/module.yml`.
- West projects can decide per extra-module entry in the `zephyr/module.yml` whether recursion should happen or not.


## Benefits
- Simplifies sharing and versioning of extra module configurations
- Reduces reliance on environment variables
- Supports more flexible, hierarchical module setups

---

> The zephyr/module.yml from each west project is automatically considered.

I am not sure if this behavior makes sense. I have started this way, but now I want to align with you about the rough feature, before I continue with details.
