### PR TITLE
boards: stm32mp135f_dk: add touchscreen and lvgl pointer

### DIFF
--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -23,6 +23,7 @@
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
 		zephyr,display = &ltdc;
+		zephyr,touch = &gt911;
 	};
 
 	gpio_keys {
@@ -57,6 +58,11 @@
 			gpios = <&mcp23017 15 GPIO_ACTIVE_HIGH>;
 			label = "LD6";
 		};
+	};
+
+	lvgl_pointer {
+		compatible = "zephyr,lvgl-pointer-input";
+		input = <&gt911>;
 	};
 
 	aliases {
@@ -180,6 +186,13 @@ csi_i2c: &i2c5 {
 				};
 			};
 		};
+	};
+
+	gt911: gt911@5d {
+		compatible = "goodix,gt911";
+		reg = <0x5d>;
+		reset-gpios = <&gpioh 2 GPIO_ACTIVE_LOW>;
+		irq-gpios = <&gpiof 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 	};
 };
 


### PR DESCRIPTION
STM32MP135F_DK board embeds a LCD screen with touchscreen driven by I2C5. GT911 touchscreen already have driver support in Zephyr so just add necessary nodes here.