### PR TITLE
bluetooth: Classic: HFP: Set eSCO S4 bit if controller supports SC

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -140,7 +140,7 @@ struct bt_hci_cmd_hdr {
 #define BT_CMD_TEST(cmd, octet, bit)            (cmd[octet] & BIT(bit))
 #define BT_CMD_LE_STATES(cmd)                   BT_CMD_TEST(cmd, 28, 3)
 
-#define BT_FEAT_TEST(feat, page, octet, bit)    (feat[page][octet] & BIT(bit))
+#define BT_FEAT_TEST(feat, page, octet, bit)    ((feat[page][octet] & BIT(bit)) != 0)
 
 #define BT_FEAT_BREDR(feat)                     !BT_FEAT_TEST(feat, 0, 4, 5)
 #define BT_FEAT_LE(feat)                        BT_FEAT_TEST(feat, 0, 4, 6)

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -3865,6 +3865,7 @@ static struct bt_hfp_ag *hfp_ag_create(struct bt_conn *conn)
 
 	/* Set the supported features*/
 	ag->ag_features = BT_HFP_AG_SUPPORTED_FEATURES;
+	ag->ag_features |= BT_FEAT_SC(bt_dev.features) ? BT_HFP_AG_FEATURE_ESCO_S4 : 0;
 
 	/* Support HF indicators */
 	if (IS_ENABLED(CONFIG_BT_HFP_AG_HF_INDICATOR_ENH_SAFETY)) {

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -4149,6 +4149,7 @@ static struct bt_hfp_hf *hfp_hf_create(struct bt_conn *conn)
 
 	/* Set the supported features*/
 	hf->hf_features = BT_HFP_HF_SUPPORTED_FEATURES;
+	hf->hf_features |= BT_FEAT_SC(bt_dev.features) ? BT_HFP_HF_FEATURE_ESCO_S4 : 0;
 
 	/* Set supported codec ids */
 	hf->hf_codec_ids = BT_HFP_HF_SUPPORTED_CODEC_IDS;


### PR DESCRIPTION
The eSCO S4 settings feature should be enabled for CVSD Coding. It is suggested by the HFP specification.

Set the eSCO S4 Settings Supported bit if the Secure connection is supported by controller.