### PR TITLE
sensor: bq274xx: fix design energy calculation

### DIFF
--- a/drivers/sensor/ti/bq274xx/bq274xx.c
+++ b/drivers/sensor/ti/bq274xx/bq274xx.c
@@ -418,7 +418,8 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	}
 	regs = data->regs;
 
-	designenergy_mwh = (uint32_t)config->design_capacity * 37 / 10; /* x3.7 */
+	designenergy_mwh = (uint32_t)config->design_capacity *
+					((uint32_t)config->design_voltage) / 1000;
 	taperrate = config->design_capacity * 10 / config->taper_current;
 
 	ret = bq274xx_ctrl_reg_write(dev, BQ274XX_UNSEAL_KEY_A);


### PR DESCRIPTION
In the function bq274xx_gauge_configure it was being used an hardcoded value of 3.7V instead of using the design voltage parameter defined in the device tree.