### PR TITLE
kernel: events: Depend on multithreading

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -734,6 +734,7 @@ config NUM_MBOX_ASYNC_MSGS
 
 config EVENTS
 	bool "Event objects"
+	depends on MULTITHREADING
 	help
 	  This option enables event objects. Threads may wait on event
 	  objects for specific events, but both threads and ISRs may deliver


### PR DESCRIPTION
Kernel events depend on multithreading being enabled, and mixing them with a non-multithreaded build gives linker failures internal to events.c. To avoid this, make events depend on multithreading.

```
/Users/carles/bin/zephyr-sdk-0.17.4/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/kernel/libkernel.a(events.c.obj): in function `k_event_post_internal':
/Users/carles/src/ncs/zephyr/kernel/events.c:175: undefined reference to `z_sched_waitq_walk'
/Users/carles/bin/zephyr-sdk-0.17.4/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: /Users/carles/src/ncs/zephyr/kernel/events.c:183: undefined reference to `z_sched_wake_thread'
/Users/carles/bin/zephyr-sdk-0.17.4/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: /Users/carles/src/ncs/zephyr/kernel/events.c:191: undefined reference to `z_reschedule'
/Users/carles/bin/zephyr-sdk-0.17.4/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/kernel/libkernel.a(events.c.obj): in function `k_sched_current_thread_query':
/Users/carles/src/ncs/nrf/build/flash/zephyr/include/generated/zephyr/syscalls/kernel.h:216: undefined reference to `z_impl_k_sched_current_thread_query'
/Users/carles/bin/zephyr-sdk-0.17.4/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/kernel/libkernel.a(events.c.obj): in function `k_event_wait_internal':
/Users/carles/src/ncs/zephyr/kernel/events.c:312: undefined reference to `z_pend_curr'
```