### PR TITLE
drivers/counter/counter_native_sim: Remove deprecated

### DIFF
--- a/drivers/counter/Kconfig.native_sim
+++ b/drivers/counter/Kconfig.native_sim
@@ -4,26 +4,14 @@
 config COUNTER_NATIVE_SIM
 	bool "Counter on COUNTER_0"
 	default y
-	depends on (DT_HAS_ZEPHYR_NATIVE_SIM_COUNTER_ENABLED || DT_HAS_ZEPHYR_NATIVE_POSIX_COUNTER_ENABLED)
+	depends on DT_HAS_ZEPHYR_NATIVE_SIM_COUNTER_ENABLED
 
 config COUNTER_NATIVE_SIM_FREQUENCY
 	int "native_sim counter frequency in Hz"
-	default COUNTER_NATIVE_POSIX_FREQUENCY
+	default 1000
 	depends on COUNTER_NATIVE_SIM
 
 config COUNTER_NATIVE_SIM_NBR_CHANNELS
 	int "native_sim counter: number of channels"
-	default COUNTER_NATIVE_POSIX_NBR_CHANNELS
-	depends on COUNTER_NATIVE_SIM
-
-config COUNTER_NATIVE_POSIX
-	bool "Counter on COUNTER_0 (deprecated)"
-	select DEPRECATED
-
-config COUNTER_NATIVE_POSIX_FREQUENCY
-	int "native_posix counter frequency in Hz (deprecated)"
-	default 1000
-
-config COUNTER_NATIVE_POSIX_NBR_CHANNELS
-	int "native counter, number of channels (deprecated)"
 	default 4
+	depends on COUNTER_NATIVE_SIM

--- a/drivers/counter/counter_native_sim.c
+++ b/drivers/counter/counter_native_sim.c
@@ -4,13 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/devicetree.h>
-#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_native_posix_counter)
-#define DT_DRV_COMPAT zephyr_native_posix_counter
-#warning "zephyr,native-posix-counter is deprecated in favor of zephyr,native-sim-counter"
-#else
 #define DT_DRV_COMPAT zephyr_native_sim_counter
-#endif
 
 #include <string.h>
 #include <zephyr/device.h>

--- a/dts/bindings/counter/zephyr,native-posix-counter.yaml
+++ b/dts/bindings/counter/zephyr,native-posix-counter.yaml
@@ -1,8 +1,0 @@
-# Copyright (c) 2022, Kumar Gala <galak@kernel.org>
-# SPDX-License-Identifier: Apache-2.0
-
-description: Native POSIX Counter
-
-compatible: "zephyr,native-posix-counter"
-
-include: base.yaml


### PR DESCRIPTION
This driver was renamed in
ab7a6de5bbb2a63e30390594363c4c3ec301b042
while the old kconfig options and dts binding were deprecated for 4.2
Let's remove them now.

Note in this commit we move the defaults into their right place.
Defaults were set in the deprecated options so we could both
have the defaults and allow users to keep using the old options.

Deprecation PR:
* https://github.com/zephyrproject-rtos/zephyr/pull/86616