### PR TITLE
drivers: usb: udc: stm32: use instance MPS for IN endpoints capabilities

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1531,7 +1531,7 @@ static int udc_stm32_driver_init0(const struct device *dev)
 			ep_cfg_in[i].caps.bulk = 1;
 			ep_cfg_in[i].caps.interrupt = 1;
 			ep_cfg_in[i].caps.iso = 1;
-			ep_cfg_in[i].caps.mps = 1023;
+			ep_cfg_in[i].caps.mps = cfg->ep_mps;
 		}
 
 		ep_cfg_in[i].addr = USB_EP_DIR_IN | i;


### PR DESCRIPTION
When setting endpoint capabilities, the driver uses the MPS stored in each instance's configuration for OUT endpoints, but used a hardcoded 1023 for IN endpoints.

Use the instance MPS when preparing IN endpoints' capabilities too.