### PR TITLE
drivers: audio: Add get_caps API to DMIC, I2S, and Codec subsystems

### DIFF
--- a/drivers/audio/da7212.c
+++ b/drivers/audio/da7212.c
@@ -642,6 +642,25 @@ static int da7212_apply_properties(const struct device *dev)
 	return 0;
 }
 
+static int da7212_get_caps(const struct device *dev, struct audio_caps *caps)
+{
+	memset(caps, 0, sizeof(struct audio_caps));
+
+	caps->min_total_channels = 1;
+	caps->max_total_channels = 2;
+	caps->supported_sample_rates =
+		AUDIO_SAMPLE_RATE_8000 | AUDIO_SAMPLE_RATE_11025 | AUDIO_SAMPLE_RATE_12000 |
+		AUDIO_SAMPLE_RATE_16000 | AUDIO_SAMPLE_RATE_22050 | AUDIO_SAMPLE_RATE_24000 |
+		AUDIO_SAMPLE_RATE_32000 | AUDIO_SAMPLE_RATE_44100 | AUDIO_SAMPLE_RATE_48000;
+	caps->supported_bit_widths = AUDIO_BIT_WIDTH_16 | AUDIO_BIT_WIDTH_32;
+	caps->min_num_buffers = 1;
+	caps->min_frame_interval = 1000;   /* 1ms minimum */
+	caps->max_frame_interval = 100000; /* 100ms maximum */
+	caps->interleaved = true;
+
+	return 0;
+}
+
 static DEVICE_API(audio_codec, da7212_driver_api) = {
 	.configure = da7212_configure,
 	.start_output = da7212_start_output,
@@ -650,6 +669,7 @@ static DEVICE_API(audio_codec, da7212_driver_api) = {
 	.apply_properties = da7212_apply_properties,
 	.route_input = da7212_route_input,
 	.route_output = da7212_route_output,
+	.get_caps = da7212_get_caps,
 };
 
 #define DA7212_INIT(n)									\

--- a/drivers/audio/dmic_mcux.c
+++ b/drivers/audio/dmic_mcux.c
@@ -658,10 +658,33 @@ static int dmic_mcux_read(const struct device *dev,
 	return 0;
 }
 
+static int dmic_mcux_get_caps(const struct device *dev, struct audio_caps *caps)
+{
+	memset(caps, 0, sizeof(struct audio_caps));
+
+	caps->min_total_channels = 1;
+	caps->max_total_channels = FSL_FEATURE_DMIC_CHANNEL_NUM;
+	/*
+	 * These sample rates are static approximations. The actual achievable
+	 * rates depend on the PDM bit clock configured at runtime in
+	 * dmic_mcux_configure().
+	 */
+	caps->supported_sample_rates = AUDIO_SAMPLE_RATE_16000 | AUDIO_SAMPLE_RATE_48000;
+	/* Currently, driver supports only 16-bit samples */
+	caps->supported_bit_widths = AUDIO_BIT_WIDTH_16;
+	caps->min_num_buffers = CONFIG_DMIC_MCUX_DMA_BUFFERS;
+	caps->min_frame_interval = 1000;   /* 1ms minimum */
+	caps->max_frame_interval = 100000; /* 100ms maximum */
+	caps->interleaved = true;
+
+	return 0;
+}
+
 static DEVICE_API(dmic, dmic_ops) = {
 	.configure = dmic_mcux_configure,
 	.trigger = dmic_mcux_trigger,
 	.read = dmic_mcux_read,
+	.get_caps = dmic_mcux_get_caps,
 };
 
 /* Converts integer gainshift into 5 bit 2's complement value for GAINSHIFT reg */

--- a/drivers/audio/dmic_mcux.c
+++ b/drivers/audio/dmic_mcux.c
@@ -61,8 +61,7 @@ static int dmic_mcux_get_osr(uint32_t pcm_rate, uint32_t bit_clk, bool use_2fs)
 }
 
 /* Gets hardware channel index from logical channel */
-static uint8_t dmic_mcux_hw_chan(struct mcux_dmic_drv_data *drv_data,
-				 uint8_t log_chan)
+static uint8_t dmic_mcux_hw_chan(struct mcux_dmic_drv_data *drv_data, uint8_t log_chan)
 {
 	enum pdm_lr lr;
 	uint8_t hw_chan;
@@ -71,9 +70,8 @@ static uint8_t dmic_mcux_hw_chan(struct mcux_dmic_drv_data *drv_data,
 	 * and hardware channel "n+1" to the right channel. This choice is
 	 * arbitrary, but must be followed throughout the driver.
 	 */
-	dmic_parse_channel_map(drv_data->chan_map_lo,
-			       drv_data->chan_map_hi,
-			       log_chan, &hw_chan, &lr);
+	dmic_parse_channel_map(drv_data->chan_map_lo, drv_data->chan_map_hi, log_chan, &hw_chan,
+			       &lr);
 	if (lr == PDM_CHAN_LEFT) {
 		return hw_chan * 2;
 	} else {
@@ -81,8 +79,7 @@ static uint8_t dmic_mcux_hw_chan(struct mcux_dmic_drv_data *drv_data,
 	}
 }
 
-static void dmic_mcux_activate_channels(struct mcux_dmic_drv_data *drv_data,
-					bool enable)
+static void dmic_mcux_activate_channels(struct mcux_dmic_drv_data *drv_data, bool enable)
 {
 
 	/* PDM channel 0 must always be enabled, as the RM states:
@@ -119,27 +116,23 @@ static int dmic_mcux_enable_dma(struct mcux_dmic_drv_data *drv_data, bool enable
 		if (enable) {
 			ret = dma_start(pdm_channel->dma, pdm_channel->dma_chan);
 			if (ret < 0) {
-				LOG_ERR("Could not start DMA for HW channel %d",
-					hw_chan);
+				LOG_ERR("Could not start DMA for HW channel %d", hw_chan);
 				return ret;
 			}
 		} else {
 			if (dma_stop(pdm_channel->dma, pdm_channel->dma_chan)) {
-				LOG_ERR("Error stopping DMA for HW channel %d",
-					hw_chan);
+				LOG_ERR("Error stopping DMA for HW channel %d", hw_chan);
 				ret = -EIO;
 			}
 		}
-		DMIC_EnableChannelDma(drv_data->base_address,
-				      (dmic_channel_t)hw_chan, enable);
+		DMIC_EnableChannelDma(drv_data->base_address, (dmic_channel_t)hw_chan, enable);
 	}
 
 	return ret;
 }
 
 /* Helper to reload DMA engine for all active channels with new buffer */
-static void dmic_mcux_reload_dma(struct mcux_dmic_drv_data *drv_data,
-				 void *buffer)
+static void dmic_mcux_reload_dma(struct mcux_dmic_drv_data *drv_data, void *buffer)
 {
 	int ret;
 	uint8_t hw_chan;
@@ -158,8 +151,7 @@ static void dmic_mcux_reload_dma(struct mcux_dmic_drv_data *drv_data,
 		pdm_channel = drv_data->pdm_channels[hw_chan];
 		src = DMIC_FifoGetAddress(drv_data->base_address, hw_chan);
 		dst = (uint32_t)(((uint16_t *)buffer) + chan);
-		ret = dma_reload(pdm_channel->dma, pdm_channel->dma_chan,
-				 src, dst, dma_buf_size);
+		ret = dma_reload(pdm_channel->dma, pdm_channel->dma_chan, src, dst, dma_buf_size);
 		if (ret < 0) {
 			LOG_ERR("Could not reload DMIC HW channel %d", hw_chan);
 			return;
@@ -199,8 +191,8 @@ static int dmic_mcux_stop(struct mcux_dmic_drv_data *drv_data)
 	return 0;
 }
 
-static void dmic_mcux_dma_cb(const struct device *dev, void *user_data,
-			     uint32_t channel, int status)
+static void dmic_mcux_dma_cb(const struct device *dev, void *user_data, uint32_t channel,
+			     int status)
 {
 
 	struct mcux_dmic_drv_data *drv_data = (struct mcux_dmic_drv_data *)user_data;
@@ -237,8 +229,7 @@ static void dmic_mcux_dma_cb(const struct device *dev, void *user_data,
 		/* Reload DMA */
 		dmic_mcux_reload_dma(drv_data, done_buffer);
 		/* Advance active buffer index */
-		drv_data->active_buf_idx =
-			dmic_mcux_next_buf_idx(drv_data->active_buf_idx);
+		drv_data->active_buf_idx = dmic_mcux_next_buf_idx(drv_data->active_buf_idx);
 		return;
 	}
 
@@ -260,8 +251,7 @@ static void dmic_mcux_dma_cb(const struct device *dev, void *user_data,
 		/* Reload DMA */
 		dmic_mcux_reload_dma(drv_data, done_buffer);
 		/* Advance active buffer index */
-		drv_data->active_buf_idx =
-			dmic_mcux_next_buf_idx(drv_data->active_buf_idx);
+		drv_data->active_buf_idx = dmic_mcux_next_buf_idx(drv_data->active_buf_idx);
 		return;
 	}
 
@@ -321,10 +311,8 @@ static int dmic_mcux_setup_dma(const struct device *dev)
 			 *  pdm0_l_s1, pdm0_r_s1, pdm1_r_s1, pdm1_l_s1, ...]
 			 * Each sample is 16 bits wide.
 			 */
-			blk_cfg[blk].dest_address =
-				(uint32_t)(((uint16_t *)dma_buf) + chan);
-			blk_cfg[blk].dest_scatter_interval =
-				num_chan * sizeof(uint16_t);
+			blk_cfg[blk].dest_address = (uint32_t)(((uint16_t *)dma_buf) + chan);
+			blk_cfg[blk].dest_scatter_interval = num_chan * sizeof(uint16_t);
 			blk_cfg[blk].dest_scatter_en = 1;
 			blk_cfg[blk].source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 			blk_cfg[blk].dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
@@ -362,8 +350,8 @@ static int dmic_mcux_setup_dma(const struct device *dev)
 }
 
 /* Initializes a DMIC hardware channel */
-static int dmic_mcux_init_channel(const struct device *dev, uint32_t osr,
-				  uint8_t chan, enum pdm_lr lr)
+static int dmic_mcux_init_channel(const struct device *dev, uint32_t osr, uint8_t chan,
+				  enum pdm_lr lr)
 {
 	struct mcux_dmic_drv_data *drv_data = dev->data;
 
@@ -406,8 +394,7 @@ static int mcux_dmic_init(const struct device *dev)
 	return 0;
 }
 
-static int dmic_mcux_configure(const struct device *dev,
-			       struct dmic_cfg *config)
+static int dmic_mcux_configure(const struct device *dev, struct dmic_cfg *config)
 {
 
 	const struct mcux_dmic_cfg *drv_config = dev->config;
@@ -467,8 +454,7 @@ static int dmic_mcux_configure(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	ret = clock_control_get_rate(drv_config->clock_dev,
-				     drv_config->clock_name, &bit_clk_rate);
+	ret = clock_control_get_rate(drv_config->clock_dev, drv_config->clock_name, &bit_clk_rate);
 	if (ret < 0) {
 		return ret;
 	}
@@ -493,24 +479,19 @@ static int dmic_mcux_configure(const struct device *dev,
 	drv_data->chan_map_hi = channel->req_chan_map_hi;
 	for (uint8_t chan = 0; chan < channel->req_num_chan; chan += 2) {
 		/* Get the channel map data for channel pair */
-		dmic_parse_channel_map(channel->req_chan_map_lo,
-				       channel->req_chan_map_hi,
-				       chan, &hw_chan_0, &lr_0);
+		dmic_parse_channel_map(channel->req_chan_map_lo, channel->req_chan_map_hi, chan,
+				       &hw_chan_0, &lr_0);
 		if ((chan + 1) < channel->req_num_chan) {
 			/* Paired channel is enabled */
-			dmic_parse_channel_map(channel->req_chan_map_lo,
-					       channel->req_chan_map_hi,
+			dmic_parse_channel_map(channel->req_chan_map_lo, channel->req_chan_map_hi,
 					       chan + 1, &hw_chan_1, &lr_1);
 			/* Verify that paired channels use same hardware index */
-			if ((lr_0 == lr_1) ||
-			    (hw_chan_0 != hw_chan_1)) {
+			if ((lr_0 == lr_1) || (hw_chan_0 != hw_chan_1)) {
 				return -EINVAL;
 			}
 		}
 		/* Configure selected channels in DMIC */
-		ret = dmic_mcux_init_channel(dev, osr,
-					     dmic_mcux_hw_chan(drv_data, chan),
-					     lr_0);
+		ret = dmic_mcux_init_channel(dev, osr, dmic_mcux_hw_chan(drv_data, chan), lr_0);
 		if (ret < 0) {
 			return ret;
 		}
@@ -518,9 +499,7 @@ static int dmic_mcux_configure(const struct device *dev,
 		if ((chan + 1) < channel->req_num_chan) {
 			/* Paired channel is enabled */
 			ret = dmic_mcux_init_channel(dev, osr,
-						     dmic_mcux_hw_chan(drv_data,
-								       chan + 1),
-						     lr_1);
+						     dmic_mcux_hw_chan(drv_data, chan + 1), lr_1);
 			if (ret < 0) {
 				return ret;
 			}
@@ -531,8 +510,8 @@ static int dmic_mcux_configure(const struct device *dev,
 	channel->act_chan_map_lo = channel->req_chan_map_lo;
 	channel->act_chan_map_hi = channel->req_chan_map_hi;
 
-	drv_data->mem_slab   = stream->mem_slab;
-	drv_data->block_size   = stream->block_size;
+	drv_data->mem_slab = stream->mem_slab;
+	drv_data->block_size = stream->block_size;
 	drv_data->act_num_chan = channel->act_num_chan;
 	drv_data->dmic_state = DMIC_STATE_CONFIGURED;
 
@@ -554,8 +533,7 @@ static int dmic_mcux_start(const struct device *dev)
 
 	for (uint32_t i = 0; i < CONFIG_DMIC_MCUX_DMA_BUFFERS; i++) {
 		/* Allocate buffers for DMA */
-		ret = k_mem_slab_alloc(drv_data->mem_slab,
-				       &drv_data->dma_bufs[i], K_NO_WAIT);
+		ret = k_mem_slab_alloc(drv_data->mem_slab, &drv_data->dma_bufs[i], K_NO_WAIT);
 		if (ret < 0) {
 			LOG_ERR("failed to allocate buffer");
 			return -ENOBUFS;
@@ -576,8 +554,7 @@ static int dmic_mcux_start(const struct device *dev)
 	return 0;
 }
 
-static int dmic_mcux_trigger(const struct device *dev,
-				 enum dmic_trigger cmd)
+static int dmic_mcux_trigger(const struct device *dev, enum dmic_trigger cmd)
 {
 	struct mcux_dmic_drv_data *drv_data = dev->data;
 
@@ -627,9 +604,8 @@ static int dmic_mcux_trigger(const struct device *dev,
 	return 0;
 }
 
-static int dmic_mcux_read(const struct device *dev,
-			      uint8_t stream,
-			      void **buffer, size_t *size, int32_t timeout)
+static int dmic_mcux_read(const struct device *dev, uint8_t stream, void **buffer, size_t *size,
+			  int32_t timeout)
 {
 	struct mcux_dmic_drv_data *drv_data = dev->data;
 	int ret;
@@ -688,69 +664,60 @@ static DEVICE_API(dmic, dmic_ops) = {
 };
 
 /* Converts integer gainshift into 5 bit 2's complement value for GAINSHIFT reg */
-#define PDM_DMIC_GAINSHIFT(val)							\
-	(val >= 0) ? (val & 0xF) : (BIT(4) | (0x10 - (val & 0xF)))
+#define PDM_DMIC_GAINSHIFT(val) (val >= 0) ? (val & 0xF) : (BIT(4) | (0x10 - (val & 0xF)))
 
 /* Defines structure for a given PDM channel node */
-#define PDM_DMIC_CHAN_DEFINE(pdm_node)						\
-	static struct mcux_dmic_pdm_chan					\
-		pdm_channel_##pdm_node = {					\
-		.dma = DEVICE_DT_GET(DT_DMAS_CTLR(pdm_node)),			\
-		.dma_chan = DT_DMAS_CELL_BY_IDX(pdm_node, 0, channel),		\
-		.dmic_channel_cfg = {						\
-			.gainshft = PDM_DMIC_GAINSHIFT(DT_PROP(pdm_node,	\
-							       gainshift)),	\
-			.preac2coef = DT_ENUM_IDX(pdm_node, compensation_2fs),	\
-			.preac4coef = DT_ENUM_IDX(pdm_node, compensation_4fs),	\
-			.dc_cut_level = DT_ENUM_IDX(pdm_node, dc_cutoff),	\
-			.post_dc_gain_reduce = DT_PROP(pdm_node, dc_gain),	\
-			.sample_rate = kDMIC_PhyFullSpeed,			\
-			.saturate16bit = 1U,					\
-		},								\
+#define PDM_DMIC_CHAN_DEFINE(pdm_node)                                                             \
+	static struct mcux_dmic_pdm_chan pdm_channel_##pdm_node = {                                \
+		.dma = DEVICE_DT_GET(DT_DMAS_CTLR(pdm_node)),                                      \
+		.dma_chan = DT_DMAS_CELL_BY_IDX(pdm_node, 0, channel),                             \
+		.dmic_channel_cfg =                                                                \
+			{                                                                          \
+				.gainshft = PDM_DMIC_GAINSHIFT(DT_PROP(pdm_node, gainshift)),      \
+				.preac2coef = DT_ENUM_IDX(pdm_node, compensation_2fs),             \
+				.preac4coef = DT_ENUM_IDX(pdm_node, compensation_4fs),             \
+				.dc_cut_level = DT_ENUM_IDX(pdm_node, dc_cutoff),                  \
+				.post_dc_gain_reduce = DT_PROP(pdm_node, dc_gain),                 \
+				.sample_rate = kDMIC_PhyFullSpeed,                                 \
+				.saturate16bit = 1U,                                               \
+			},                                                                         \
 	};
 
 /* Defines structures for all enabled PDM channels */
-#define PDM_DMIC_CHANNELS_DEFINE(idx)						\
-	DT_INST_FOREACH_CHILD_STATUS_OKAY(idx, PDM_DMIC_CHAN_DEFINE)
+#define PDM_DMIC_CHANNELS_DEFINE(idx) DT_INST_FOREACH_CHILD_STATUS_OKAY(idx, PDM_DMIC_CHAN_DEFINE)
 
 /* Gets pointer for a given PDM channel node */
-#define PDM_DMIC_CHAN_GET(pdm_node)						\
+#define PDM_DMIC_CHAN_GET(pdm_node)                                                                \
 	COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(pdm_node),				\
 		    (&pdm_channel_##pdm_node), (NULL)),
 
 /* Gets array of pointers to PDM channels */
-#define PDM_DMIC_CHANNELS_GET(idx)						\
-	DT_INST_FOREACH_CHILD(idx, PDM_DMIC_CHAN_GET)
+#define PDM_DMIC_CHANNELS_GET(idx) DT_INST_FOREACH_CHILD(idx, PDM_DMIC_CHAN_GET)
 
-#define MCUX_DMIC_DEVICE(idx)							\
-	PDM_DMIC_CHANNELS_DEFINE(idx);						\
-	static struct mcux_dmic_pdm_chan					\
-		*pdm_channels##idx[FSL_FEATURE_DMIC_CHANNEL_NUM] = {		\
-			PDM_DMIC_CHANNELS_GET(idx)				\
-	};									\
-	K_MSGQ_DEFINE(dmic_msgq##idx, sizeof(void *),				\
-		      CONFIG_DMIC_MCUX_QUEUE_SIZE, 1);				\
-	static struct mcux_dmic_drv_data mcux_dmic_data##idx = {		\
-		.pdm_channels = pdm_channels##idx,				\
-		.base_address = (DMIC_Type *) DT_INST_REG_ADDR(idx),		\
-		.dmic_state = DMIC_STATE_UNINIT,				\
-		.rx_queue = &dmic_msgq##idx,					\
-		.active_buf_idx = 0U,						\
-	};									\
-										\
-	PINCTRL_DT_INST_DEFINE(idx);						\
-	static struct mcux_dmic_cfg mcux_dmic_cfg##idx = {			\
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),			\
-		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),		\
-		.clock_name = (clock_control_subsys_t)				\
-				DT_INST_CLOCKS_CELL(idx, name),			\
-		.use2fs = DT_INST_PROP(idx, use2fs),				\
-	};									\
-										\
-	DEVICE_DT_INST_DEFINE(idx, mcux_dmic_init, NULL,			\
-			&mcux_dmic_data##idx, &mcux_dmic_cfg##idx,		\
-			POST_KERNEL, CONFIG_AUDIO_DMIC_INIT_PRIORITY,		\
-			&dmic_ops);
+#define MCUX_DMIC_DEVICE(idx)                                                                      \
+	PDM_DMIC_CHANNELS_DEFINE(idx);                                                             \
+	static struct mcux_dmic_pdm_chan *pdm_channels##idx[FSL_FEATURE_DMIC_CHANNEL_NUM] = {      \
+		PDM_DMIC_CHANNELS_GET(idx)};                                                       \
+	K_MSGQ_DEFINE(dmic_msgq##idx, sizeof(void *), CONFIG_DMIC_MCUX_QUEUE_SIZE, 1);             \
+	static struct mcux_dmic_drv_data mcux_dmic_data##idx = {                                   \
+		.pdm_channels = pdm_channels##idx,                                                 \
+		.base_address = (DMIC_Type *)DT_INST_REG_ADDR(idx),                                \
+		.dmic_state = DMIC_STATE_UNINIT,                                                   \
+		.rx_queue = &dmic_msgq##idx,                                                       \
+		.active_buf_idx = 0U,                                                              \
+	};                                                                                         \
+                                                                                                   \
+	PINCTRL_DT_INST_DEFINE(idx);                                                               \
+	static struct mcux_dmic_cfg mcux_dmic_cfg##idx = {                                         \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),                                       \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),                              \
+		.clock_name = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, name),              \
+		.use2fs = DT_INST_PROP(idx, use2fs),                                               \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(idx, mcux_dmic_init, NULL, &mcux_dmic_data##idx,                     \
+			      &mcux_dmic_cfg##idx, POST_KERNEL, CONFIG_AUDIO_DMIC_INIT_PRIORITY,   \
+			      &dmic_ops);
 
 /* Existing SoCs only have one PDM instance. */
 DT_INST_FOREACH_STATUS_OKAY(MCUX_DMIC_DEVICE)

--- a/drivers/audio/dmic_nxp_micfil.c
+++ b/drivers/audio/dmic_nxp_micfil.c
@@ -614,10 +614,28 @@ static int nxp_micfil_init(const struct device *dev)
 	return 0;
 }
 
+static int nxp_micfil_get_caps(const struct device *dev, struct audio_caps *caps)
+{
+	memset(caps, 0, sizeof(struct audio_caps));
+
+	caps->min_total_channels = 1;
+	caps->max_total_channels = 8;
+	caps->supported_sample_rates = AUDIO_SAMPLE_RATE_16000;
+	/* Currently, driver supports only 32-bit samples */
+	caps->supported_bit_widths = AUDIO_BIT_WIDTH_32;
+	caps->min_num_buffers = 4;
+	caps->min_frame_interval = 1000;   /* 1ms minimum */
+	caps->max_frame_interval = 100000; /* 100ms maximum */
+	caps->interleaved = true;
+
+	return 0;
+}
+
 static DEVICE_API(dmic, dmic_ops) = {
 	.configure = nxp_micfil_configure,
 	.trigger = nxp_micfil_trigger,
 	.read = nxp_micfil_read,
+	.get_caps = nxp_micfil_get_caps,
 };
 
 #define NXP_MICFIL_IRQ_CONFIG(inst)							\

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -672,13 +672,34 @@ static void wm8904_configure_input(const struct device *dev)
 	wm8904_in_mute_config(dev, AUDIO_CHANNEL_ALL, false);
 }
 
+static int wm8904_get_caps(const struct device *dev, struct audio_caps *caps)
+{
+	memset(caps, 0, sizeof(struct audio_caps));
+
+	caps->min_total_channels = 1;
+	caps->max_total_channels = 2;
+	caps->supported_sample_rates =
+		AUDIO_SAMPLE_RATE_8000 | AUDIO_SAMPLE_RATE_11025 | AUDIO_SAMPLE_RATE_12000 |
+		AUDIO_SAMPLE_RATE_16000 | AUDIO_SAMPLE_RATE_22050 | AUDIO_SAMPLE_RATE_24000 |
+		AUDIO_SAMPLE_RATE_32000 | AUDIO_SAMPLE_RATE_44100 | AUDIO_SAMPLE_RATE_48000;
+	caps->supported_bit_widths =
+		AUDIO_BIT_WIDTH_16 | AUDIO_BIT_WIDTH_20 | AUDIO_BIT_WIDTH_24 | AUDIO_BIT_WIDTH_32;
+	caps->min_num_buffers = 1;
+	caps->min_frame_interval = 1000;   /* 1ms minimum */
+	caps->max_frame_interval = 100000; /* 100ms maximum */
+	caps->interleaved = true;
+
+	return 0;
+}
+
 static DEVICE_API(audio_codec, wm8904_driver_api) = {
 	.configure = wm8904_configure,
 	.start_output = wm8904_start_output,
 	.stop_output = wm8904_stop_output,
 	.set_property = wm8904_set_property,
 	.apply_properties = wm8904_apply_properties,
-	.route_input = wm8904_route_input
+	.route_input = wm8904_route_input,
+	.get_caps = wm8904_get_caps,
 };
 
 #define WM8904_INIT(n)                                                                             \

--- a/drivers/audio/wm8962.c
+++ b/drivers/audio/wm8962.c
@@ -706,14 +706,36 @@ static void WM8962_read_all_reg(const struct device *dev, uint16_t endAddress)
 }
 #endif
 
-static DEVICE_API(audio_codec, wm8962_driver_api) = {.configure = wm8962_configure,
-							 .start_output = wm8962_start_output,
-							 .stop_output = wm8962_stop_output,
-							 .set_property = wm8962_set_property,
-							 .apply_properties =
-								 wm8962_apply_properties,
-							 .route_input = wm8962_route_input,
-							 .route_output = wm8962_route_output};
+static int wm8962_get_caps(const struct device *dev, struct audio_caps *caps)
+{
+	memset(caps, 0, sizeof(struct audio_caps));
+
+	caps->min_total_channels = 1;
+	caps->max_total_channels = 2;
+	caps->supported_sample_rates =
+		AUDIO_SAMPLE_RATE_8000 | AUDIO_SAMPLE_RATE_11025 | AUDIO_SAMPLE_RATE_12000 |
+		AUDIO_SAMPLE_RATE_16000 | AUDIO_SAMPLE_RATE_22050 | AUDIO_SAMPLE_RATE_24000 |
+		AUDIO_SAMPLE_RATE_32000 | AUDIO_SAMPLE_RATE_44100 | AUDIO_SAMPLE_RATE_48000;
+	caps->supported_bit_widths =
+		AUDIO_BIT_WIDTH_16 | AUDIO_BIT_WIDTH_20 | AUDIO_BIT_WIDTH_24 | AUDIO_BIT_WIDTH_32;
+	caps->min_num_buffers = 1;
+	caps->min_frame_interval = 1000;   /* 1ms minimum */
+	caps->max_frame_interval = 100000; /* 100ms maximum */
+	caps->interleaved = true;
+
+	return 0;
+}
+
+static DEVICE_API(audio_codec, wm8962_driver_api) = {
+	.configure = wm8962_configure,
+	.start_output = wm8962_start_output,
+	.stop_output = wm8962_stop_output,
+	.set_property = wm8962_set_property,
+	.apply_properties = wm8962_apply_properties,
+	.route_input = wm8962_route_input,
+	.route_output = wm8962_route_output,
+	.get_caps = wm8962_get_caps,
+};
 
 #define wm8962_INIT(n)                                                                             \
 	static const struct wm8962_driver_config wm8962_device_config_##n = {                      \

--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -866,12 +866,39 @@ static int i2s_mcux_write(const struct device *dev, void *mem_block, size_t size
 	return ret;
 }
 
+static int i2s_mcux_get_caps(const struct device *dev, struct audio_caps *caps, enum i2s_dir dir)
+{
+	ARG_UNUSED(dev);
+
+	memset(caps, 0, sizeof(struct audio_caps));
+
+	caps->min_total_channels = 2; /* Stereo minimum */
+	caps->max_total_channels = 8; /* Up to 4 stereo pairs in TDM mode */
+	caps->supported_sample_rates =
+		AUDIO_SAMPLE_RATE_8000 | AUDIO_SAMPLE_RATE_11025 | AUDIO_SAMPLE_RATE_16000 |
+		AUDIO_SAMPLE_RATE_22050 | AUDIO_SAMPLE_RATE_32000 | AUDIO_SAMPLE_RATE_44100 |
+		AUDIO_SAMPLE_RATE_48000 | AUDIO_SAMPLE_RATE_88200 | AUDIO_SAMPLE_RATE_96000;
+	caps->supported_bit_widths =
+		AUDIO_BIT_WIDTH_8 | AUDIO_BIT_WIDTH_16 | AUDIO_BIT_WIDTH_24 | AUDIO_BIT_WIDTH_32;
+	if (dir == I2S_DIR_TX) {
+		caps->min_num_buffers = CONFIG_I2S_MCUX_FLEXCOMM_DMA_TX_BLOCKS;
+	} else {
+		caps->min_num_buffers = CONFIG_I2S_MCUX_FLEXCOMM_DMA_RX_BLOCKS;
+	}
+	caps->min_frame_interval = 1000;   /* 1ms minimum */
+	caps->max_frame_interval = 100000; /* 100ms maximum */
+	caps->interleaved = true;
+
+	return 0;
+}
+
 static DEVICE_API(i2s, i2s_mcux_driver_api) = {
 	.configure = i2s_mcux_configure,
 	.config_get = i2s_mcux_config_get,
 	.read = i2s_mcux_read,
 	.write = i2s_mcux_write,
 	.trigger = i2s_mcux_trigger,
+	.get_caps = i2s_mcux_get_caps,
 };
 
 static void i2s_mcux_isr(const struct device *dev)

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -1066,6 +1066,32 @@ static int i2s_mcux_write(const struct device *dev, void *mem_block, size_t size
 	return ret;
 }
 
+static int i2s_mcux_get_caps(const struct device *dev, struct audio_caps *caps, enum i2s_dir dir)
+{
+	ARG_UNUSED(dev);
+	/*
+	 * TX and RX share the same SAI capabilities on this controller, so the
+	 * reported caps are identical regardless of direction.
+	 */
+	ARG_UNUSED(dir);
+
+	memset(caps, 0, sizeof(struct audio_caps));
+
+	caps->min_total_channels = 1; /* Mono minimum */
+	caps->max_total_channels = 8; /* Up to 4 stereo pairs in TDM mode */
+	caps->supported_sample_rates =
+		AUDIO_SAMPLE_RATE_8000 | AUDIO_SAMPLE_RATE_11025 | AUDIO_SAMPLE_RATE_12000 |
+		AUDIO_SAMPLE_RATE_16000 | AUDIO_SAMPLE_RATE_22050 | AUDIO_SAMPLE_RATE_24000 |
+		AUDIO_SAMPLE_RATE_32000 | AUDIO_SAMPLE_RATE_44100 | AUDIO_SAMPLE_RATE_48000;
+	caps->supported_bit_widths = AUDIO_BIT_WIDTH_16 | AUDIO_BIT_WIDTH_24 | AUDIO_BIT_WIDTH_32;
+	caps->min_num_buffers = 1;
+	caps->min_frame_interval = 1000;   /* 1ms minimum */
+	caps->max_frame_interval = 100000; /* 100ms maximum */
+	caps->interleaved = true;
+
+	return 0;
+}
+
 static void sai_driver_irq(const struct device *dev)
 {
 	I2S_Type *base = get_base(dev);
@@ -1243,6 +1269,7 @@ static DEVICE_API(i2s, i2s_mcux_driver_api) = {
 	.write = i2s_mcux_write,
 	.config_get = i2s_mcux_config_get,
 	.trigger = i2s_mcux_trigger,
+	.get_caps = i2s_mcux_get_caps,
 };
 
 #define I2S_MCUX_PINMUX_INIT(i2s_id)                                                               \

--- a/include/zephyr/audio/audio_caps.h
+++ b/include/zephyr/audio/audio_caps.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Common Audio Capabilities Definitions
+ *
+ * This file contains common audio format and sample rate definitions used across
+ * all audio subsystems (DMIC, I2S, Audio Codec, etc.)
+ */
+
+#ifndef ZEPHYR_INCLUDE_AUDIO_CAPS_H_
+#define ZEPHYR_INCLUDE_AUDIO_CAPS_H_
+
+#include <zephyr/sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup audio_bit_width Audio Bit Width Definitions
+ * @brief Common audio bit width definitions - can be used across DMIC, I2S, Audio Codec APIs
+ * @{
+ */
+/** @brief 8 bit width */
+#define AUDIO_BIT_WIDTH_8  BIT(0)
+/** @brief 16 bit width */
+#define AUDIO_BIT_WIDTH_16 BIT(1)
+/** @brief 18 bit width */
+#define AUDIO_BIT_WIDTH_18 BIT(2)
+/** @brief 20 bit width */
+#define AUDIO_BIT_WIDTH_20 BIT(3)
+/** @brief 24 bit width */
+#define AUDIO_BIT_WIDTH_24 BIT(4)
+/** @brief 32 bit width */
+#define AUDIO_BIT_WIDTH_32 BIT(5)
+/** @brief 64 bit width */
+#define AUDIO_BIT_WIDTH_64 BIT(6)
+/** @} */
+
+/**
+ * @defgroup audio_sample_rate Audio Sample Rate Definitions
+ * @brief Common audio sample rate definitions - can be used across DMIC, I2S, Audio Codec APIs
+ * @{
+ */
+/** @brief 7.35 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_7350   BIT(0)
+/** @brief 8 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_8000   BIT(1)
+/** @brief 11.025 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_11025  BIT(2)
+/** @brief 12 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_12000  BIT(3)
+/** @brief 14.7 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_14700  BIT(4)
+/** @brief 16 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_16000  BIT(5)
+/** @brief 20 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_20000  BIT(6)
+/** @brief 22.05 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_22050  BIT(7)
+/** @brief 24 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_24000  BIT(8)
+/** @brief 29.4 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_29400  BIT(9)
+/** @brief 32 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_32000  BIT(10)
+/** @brief 44.1 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_44100  BIT(11)
+/** @brief 48 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_48000  BIT(12)
+/** @brief 50 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_50000  BIT(13)
+/** @brief 50.4 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_50400  BIT(14)
+/** @brief 64 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_64000  BIT(15)
+/** @brief 88.2 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_88200  BIT(16)
+/** @brief 96 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_96000  BIT(17)
+/** @brief 100.8 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_100800 BIT(18)
+/** @brief 128 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_128000 BIT(19)
+/** @brief 176.4 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_176400 BIT(20)
+/** @brief 192 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_192000 BIT(21)
+/** @brief 352.8 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_352800 BIT(22)
+/** @brief 384 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_384000 BIT(23)
+/** @brief 705.6 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_705600 BIT(24)
+/** @brief 768 kHz sample rate */
+#define AUDIO_SAMPLE_RATE_768000 BIT(25)
+/** @} */
+
+/**
+ * @struct audio_caps
+ * @brief Audio capabilities structure
+ *
+ * Structure that describes the audio capabilities of a device, including
+ * supported channels, sample rates, bit widths, buffering requirements,
+ * and data layout format.
+ */
+struct audio_caps {
+	/** Minimum supported number of channels */
+	uint8_t min_total_channels;
+	/** Maximum supported number of channels */
+	uint8_t max_total_channels;
+	/** Bitwise OR of supported PCM sample rates */
+	uint32_t supported_sample_rates;
+	/** Bitwise OR of supported PCM bit width */
+	uint32_t supported_bit_widths;
+	/** Minimum number of data buffers required */
+	uint8_t min_num_buffers;
+	/** Minimum supported frame interval in microseconds */
+	uint32_t min_frame_interval;
+	/** Maximum supported frame interval in microseconds */
+	uint32_t max_frame_interval;
+	/** Channel layout: interleaved (LRLRLRLR) or non-interleaved (LLLLRRRR) */
+	bool interleaved;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_AUDIO_CAPS_H_ */

--- a/include/zephyr/audio/codec.h
+++ b/include/zephyr/audio/codec.h
@@ -27,6 +27,8 @@
 #include <errno.h>
 #include <zephyr/drivers/i2s.h>
 
+#include <zephyr/audio/audio_caps.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -322,6 +324,12 @@ typedef int (*audio_codec_register_done_callback_t)(
 	audio_codec_rx_done_callback_t rx_cb, void *rx_cb_user_data);
 
 /**
+ * @brief Callback API to get audio codec capabilities.
+ * See audio_codec_get_caps() for argument descriptions.
+ */
+typedef int (*audio_codec_get_caps_t)(const struct device *dev, struct audio_caps *caps);
+
+/**
  * Legacy struct tag alias for @ref audio_codec_driver_api for audio codec drivers that have not
  * been updated to use audio_codec_driver_api for their backend struct.
  *
@@ -385,6 +393,10 @@ __subsystem struct audio_codec_driver_api {
 	 * @driver_ops_optional @copybrief audio_codec_register_done_callback
 	 */
 	audio_codec_register_done_callback_t register_done_callback;
+	/**
+	 * @driver_ops_optional @copybrief audio_codec_get_caps
+	 */
+	audio_codec_get_caps_t get_caps;
 };
 
 /**
@@ -672,6 +684,31 @@ static inline int audio_codec_register_done_callback(const struct device *dev,
 	}
 
 	return api->register_done_callback(dev, tx_cb, tx_cb_user_data, rx_cb, rx_cb_user_data);
+}
+
+/**
+ * @brief Get audio codec capabilities
+ *
+ * @param dev Pointer to device structure
+ * @param caps Pointer to capabilities structure to populate
+ *
+ * @retval 0 on success
+ * @retval -ENOSYS if the get_caps is not implemented by the driver
+ * @retval -EINVAL if invalid parameters are provided (e.g., caps is NULL)
+ */
+static inline int audio_codec_get_caps(const struct device *dev, struct audio_caps *caps)
+{
+	const struct audio_codec_driver_api *api = DEVICE_API_GET(audio_codec, dev);
+
+	if (api->get_caps == NULL) {
+		return -ENOSYS;
+	}
+
+	if (caps == NULL) {
+		return -EINVAL;
+	}
+
+	return api->get_caps(dev, caps);
 }
 
 #ifdef __cplusplus

--- a/include/zephyr/audio/dmic.h
+++ b/include/zephyr/audio/dmic.h
@@ -38,6 +38,8 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 
+#include <zephyr/audio/audio_caps.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -240,6 +242,12 @@ typedef int (*dmic_read_t)(const struct device *dev, uint8_t stream, void **buff
 			   size_t *size, int32_t timeout);
 
 /**
+ * @brief Callback API to get DMIC capabilities.
+ * See dmic_get_caps() for argument descriptions.
+ */
+typedef int (*dmic_get_caps_t)(const struct device *dev, struct audio_caps *caps);
+
+/**
  * Legacy struct tag alias for @ref dmic_driver_api for DMIC drivers that have not been updated to
  * to use dmic_driver_api for their backend struct.
  *
@@ -263,6 +271,10 @@ __subsystem struct dmic_driver_api {
 	 * @driver_ops_mandatory @copybrief dmic_read
 	 */
 	dmic_read_t read;
+	/**
+	 * @driver_ops_optional @copybrief dmic_get_caps
+	 */
+	dmic_get_caps_t get_caps;
 };
 
 /**
@@ -381,6 +393,31 @@ static inline int dmic_read(const struct device *dev, uint8_t stream,
 			    size_t *size, int32_t timeout)
 {
 	return DEVICE_API_GET(dmic, dev)->read(dev, stream, buffer, size, timeout);
+}
+
+/**
+ * @brief Get dmic capabilities
+ *
+ * @param dev Pointer to device structure
+ * @param caps Pointer to capabilities structure to populate
+ *
+ * @retval 0 on success
+ * @retval -ENOSYS if the get_caps is not implemented by the driver
+ * @retval -EINVAL if invalid parameters are provided (e.g., caps is NULL)
+ */
+static inline int dmic_get_caps(const struct device *dev, struct audio_caps *caps)
+{
+	const struct dmic_driver_api *api = DEVICE_API_GET(dmic, dev);
+
+	if (api->get_caps == NULL) {
+		return -ENOSYS;
+	}
+
+	if (caps == NULL) {
+		return -EINVAL;
+	}
+
+	return api->get_caps(dev, caps);
 }
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -29,6 +29,8 @@
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 
+#include <zephyr/audio/audio_caps.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -361,6 +363,11 @@ __subsystem struct i2s_driver_api {
 	 */
 	int (*trigger)(const struct device *dev, enum i2s_dir dir,
 		       enum i2s_trigger_cmd cmd);
+	/**
+	 * @driver_ops_optional @copybrief i2s_get_caps
+	 * See i2s_get_caps() for arguments description.
+	 */
+	int (*get_caps)(const struct device *dev, struct audio_caps *caps, enum i2s_dir dir);
 };
 
 /** @} */
@@ -553,6 +560,35 @@ static inline int z_impl_i2s_trigger(const struct device *dev,
 				     enum i2s_trigger_cmd cmd)
 {
 	return DEVICE_API_GET(i2s, dev)->trigger(dev, dir, cmd);
+}
+
+/**
+ * @brief Get i2s capabilities
+ *
+ * @param dev Pointer to device structure
+ * @param caps Pointer to capabilities structure to populate
+ * @param dir Stream direction: RX, TX, or both, as defined by I2S_DIR_*.
+ *            The I2S_DIR_BOTH value may not be supported by some drivers.
+ *            For those, triggering need to be done separately for the RX
+ *            and TX streams.
+ *
+ * @retval 0 on success
+ * @retval -ENOSYS if the get_caps is not implemented by the driver
+ * @retval -EINVAL if invalid parameters are provided (e.g., caps is NULL)
+ */
+static inline int i2s_get_caps(const struct device *dev, struct audio_caps *caps, enum i2s_dir dir)
+{
+	const struct i2s_driver_api *api = DEVICE_API_GET(i2s, dev);
+
+	if (api->get_caps == NULL) {
+		return -ENOSYS;
+	}
+
+	if (caps == NULL) {
+		return -EINVAL;
+	}
+
+	return api->get_caps(dev, caps, dir);
 }
 
 /**

--- a/tests/drivers/audio/dmic_api/src/main.c
+++ b/tests/drivers/audio/dmic_api/src/main.c
@@ -10,6 +10,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/audio/audio_caps.h>
 #include <zephyr/audio/dmic.h>
 #include <zephyr/ztest.h>
 
@@ -291,6 +292,66 @@ ZTEST(dmic, test_bad_pair)
 	ret = dmic_configure(dmic_dev, &dmic_cfg);
 	zassert_not_equal(ret, 0, "DMIC configure should fail with "
 			  "non adjacent channels in map");
+}
+
+/**
+ * @brief Test the dmic_get_caps API function
+ *
+ * This test validates the DMIC get_caps API functionality by testing both
+ * successful operation and error handling scenarios.
+ */
+ZTEST(dmic, test_get_caps)
+{
+	int ret;
+	struct audio_caps caps;
+
+	zassert_true(device_is_ready(dmic_dev), "DMIC device is not ready");
+
+	/**
+	 * Test Case 1: Normal operation - Valid parameters
+	 * Expected: Function should return 0 (success) or -ENOSYS (not implemented)
+	 */
+	ret = dmic_get_caps(dmic_dev, &caps);
+
+	/* Handle case where driver doesn't implement get_caps */
+	if (ret == -ENOSYS) {
+		TC_PRINT("DMIC get_caps not implemented by driver\n");
+		ztest_test_skip();
+		return;
+	}
+
+	/* Verify successful execution */
+	zassert_equal(ret, 0, "dmic_get_caps should return 0, got %d", ret);
+
+	/**
+	 * Test Case 2: Capability value validation
+	 * Verify that returned capability values are within reasonable ranges
+	 */
+	zassert_true(caps.min_total_channels >= 1, "min_total_channels should be >= 1, got %d",
+		     caps.min_total_channels);
+
+	zassert_true(caps.max_total_channels >= caps.min_total_channels,
+		     "max_total_channels (%u) should be >= min_total_channels (%u)",
+		     caps.max_total_channels, caps.min_total_channels);
+
+	zassert_not_equal(caps.supported_sample_rates, 0, "supported_sample_rates should not be 0");
+
+	zassert_not_equal(caps.supported_bit_widths, 0, "supported_bit_widths should not be 0");
+
+	zassert_true(caps.min_num_buffers >= 1, "min_num_buffers should be >= 1, got %u",
+		     caps.min_num_buffers);
+
+	zassert_true(caps.max_frame_interval >= caps.min_frame_interval,
+		     "max_frame_interval (%u) should be >= min_frame_interval (%u)",
+		     caps.max_frame_interval, caps.min_frame_interval);
+
+	/**
+	 * Test Case 3: Error handling - NULL caps pointer
+	 * Expected: Function should return -EINVAL for invalid parameter
+	 */
+	ret = dmic_get_caps(dmic_dev, NULL);
+	zassert_equal(ret, -EINVAL,
+		      "dmic_get_caps should return -EINVAL for NULL caps pointer, got %d", ret);
 }
 
 ZTEST_SUITE(dmic, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/i2s/i2s_api/src/test_i2s_errors.c
+++ b/tests/drivers/i2s/i2s_api/src/test_i2s_errors.c
@@ -6,7 +6,10 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
+
+#include <zephyr/audio/audio_caps.h>
 #include <zephyr/drivers/i2s.h>
+
 #include "i2s_api_test.h"
 
 #define INVALID_TRIGGER_SETTING 7
@@ -153,4 +156,62 @@ ZTEST_USER(i2s_errors, test_i2s_improper_block_size_write)
 	zassert_not_equal(
 		err, 0,
 		"I2S attempting write with incorrect block size did not raise error, err=%d", err);
+}
+
+/**
+ * @brief Test the i2s_get_caps API function
+ *
+ * This test validates the I2S get_caps API functionality by testing both
+ * successful operation and error handling scenarios.
+ */
+ZTEST_USER(i2s_errors, test_i2s_get_caps)
+{
+	int ret;
+	struct audio_caps caps;
+
+	/**
+	 * Test Case 1: Normal operation - Valid parameters
+	 * Expected: Function should return 0 (success) or -ENOSYS (not implemented)
+	 */
+	ret = i2s_get_caps(dev_i2s, &caps, I2S_DIR_RX);
+
+	/* Handle case where driver doesn't implement get_caps */
+	if (ret == -ENOSYS) {
+		TC_PRINT("I2S get_caps not implemented by driver\n");
+		ztest_test_skip();
+		return;
+	}
+
+	/* Verify successful execution */
+	zassert_equal(ret, 0, "i2s_get_caps should return 0, got %d", ret);
+
+	/**
+	 * Test Case 2: Capability value validation
+	 * Verify that returned capability values are within reasonable ranges
+	 */
+	zassert_true(caps.min_total_channels >= 1, "min_total_channels should be >= 1, got %u",
+		     caps.min_total_channels);
+
+	zassert_true(caps.max_total_channels >= caps.min_total_channels,
+		     "max_total_channels (%u) should be >= min_total_channels (%u)",
+		     caps.max_total_channels, caps.min_total_channels);
+
+	zassert_not_equal(caps.supported_sample_rates, 0, "supported_sample_rates should not be 0");
+
+	zassert_not_equal(caps.supported_bit_widths, 0, "supported_bit_widths should not be 0");
+
+	zassert_true(caps.min_num_buffers >= 1, "min_num_buffers should be >= 1, got %u",
+		     caps.min_num_buffers);
+
+	zassert_true(caps.max_frame_interval >= caps.min_frame_interval,
+		     "max_frame_interval (%u) should be >= min_frame_interval (%u)",
+		     caps.max_frame_interval, caps.min_frame_interval);
+
+	/**
+	 * Test Case 3: Error handling - NULL caps pointer
+	 * Expected: Function should return -EINVAL for invalid parameter
+	 */
+	ret = i2s_get_caps(dev_i2s, NULL, I2S_DIR_RX);
+	zassert_equal(ret, -EINVAL,
+		      "i2s_get_caps should return -EINVAL for NULL caps pointer, got %d", ret);
 }


### PR DESCRIPTION
This PR introduces `get_caps()` API to DMIC, I2S, and Codec subsystems, enabling
drivers to report their audio capabilities such as supported sample rates, bit widths,
channel counts, buffer requirements, and frame timing.

It implements the API for MCUX I2S Flexcomm, DMIC, and WM8904 audio drivers.

It also introduces common audio definitions in audio_caps.h to unify capability
flags across subsystems.

Changes are related to new MediaPipe library.

This PR depends on: [I2s mcux flexcomm tx rx num buff to kconfig #108239](https://github.com/zephyrproject-rtos/zephyr/pull/108239)