### PR TITLE
drivers: serial: stm32: don't disable DMA in circular mode

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1962,7 +1962,9 @@ static void uart_stm32_async_rx_timeout(struct k_work *work)
 	 */
 	unsigned int key = irq_lock();
 
-	if (data->dma_rx.counter == data->dma_rx.buffer_length) {
+	/* When cyclic DMA is used, do not disable the RX on timeout */
+	if (data->dma_rx.dma_cfg.cyclic == 0 &&
+	    data->dma_rx.counter == data->dma_rx.buffer_length) {
 		uart_stm32_async_rx_disable(dev);
 	} else {
 		uart_stm32_dma_rx_flush(dev, STM32_ASYNC_STATUS_TIMEOUT);


### PR DESCRIPTION
When cyclic mode is enabled, do not disable RX.
This mode ensures continuous availability of RX buffers.

Fortunately, this problem exists only when `HAS_RTO` is disabled.
Handling for  `HAS_RTO`  is following
```
#if HAS_RTO
	} else if (LL_USART_IsEnabledIT_RTO(usart) && LL_USART_IsActiveFlag_RTO(usart)) {

		LOG_DBG("rx timeout interrupt occurred");

		LL_USART_ClearFlag_RTO(usart);
		uart_stm32_dma_rx_flush(dev, STM32_ASYNC_STATUS_TIMEOUT);
#endif /* HAS_RTO */
```