### PR TITLE
soc: xlnx: zynq7000: add I2C Controllers

### DIFF
--- a/dts/arm/xilinx/zynq7000.dtsi
+++ b/dts/arm/xilinx/zynq7000.dtsi
@@ -48,6 +48,28 @@
 			#interrupt-cells = <4>;
 		};
 
+		i2c0: i2c@e0004000 {
+			compatible = "cdns,i2c";
+			reg = <0xe0004000 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			fifo-depth = <16>;
+		};
+
+		i2c1: i2c@e0005000 {
+			compatible = "cdns,i2c";
+			reg = <0xe0005000 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 48 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			fifo-depth = <16>;
+		};
+
 		gem0: ethernet@e000b000 {
 			compatible = "xlnx,gem";
 			status = "disabled";

--- a/soc/xlnx/zynq7000/Kconfig.defconfig
+++ b/soc/xlnx/zynq7000/Kconfig.defconfig
@@ -23,4 +23,11 @@ config FLASH_BASE_ADDRESS
 config SOC_RESET_HOOK
 	default y
 
+if I2C_CADENCE
+
+config I2C_CADENCE_BROKEN_HOLD_BIT
+	default y if $(dt_nodelabel_enabled,i2c0) || $(dt_nodelabel_enabled,i2c1)
+
+endif # I2C_CADENCE
+
 endif # SOC_FAMILY_XILINX_ZYNQ7000


### PR DESCRIPTION
Add device tree nodes for the Cadence I2C controllers and corresponding MMU entries.