### PR TITLE
drivers: timer: nrf_grtc: Add app-defined post-init function

### DIFF
--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -589,6 +589,11 @@ int nrf_grtc_timer_clock_driver_init(void)
 {
 	return sys_clock_driver_init();
 }
+
+int nrf_grtc_timer_post_init(void)
+{
+	return grtc_post_init();
+}
 #else
 SYS_INIT(sys_clock_driver_init, EARLY, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);
 SYS_INIT(grtc_post_init, PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/include/zephyr/drivers/timer/nrf_grtc_timer.h
+++ b/include/zephyr/drivers/timer/nrf_grtc_timer.h
@@ -209,6 +209,15 @@ uint64_t z_nrf_grtc_timer_startup_value_get(void);
  */
 int nrf_grtc_timer_clock_driver_init(void);
 
+/**
+ * @brief Perform second-stage initialization of the GRTC from an application-
+ *        defined function.
+ *
+ * @retval 0 on success.
+ * @retval -errno Negative error code on failure.
+ */
+int nrf_grtc_timer_post_init(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
When CONFIG_NRF_GRTC_TIMER_APP_DEFINED_INIT=y, the compiler would warn that `grtc_post_init()` was unused, because this feature was not updated to account for the fact that clock init has been split into two stages.