### PR TITLE
Settings documentation fixes

### DIFF
--- a/include/zephyr/settings/settings.h
+++ b/include/zephyr/settings/settings.h
@@ -204,7 +204,7 @@ struct settings_handler_static {
 };
 
 /**
- * Define a static handler for settings items
+ * Define a static handler for settings items with priority
  *
  * @param _hname handler name
  * @param _tree subtree name
@@ -230,7 +230,21 @@ struct settings_handler_static {
 		.h_export = _export,					     \
 	}
 
-/* Handlers without commit priority are set to priority O */
+/**
+ * Define a static handler for settings items
+ *
+ * @param _hname handler name
+ * @param _tree subtree name
+ * @param _get get routine (can be NULL)
+ * @param _set set routine (can be NULL)
+ * @param _commit commit routine (can be NULL)
+ * @param _export export routine (can be NULL)
+ *
+ * Sets the commit priority of the defined handler to O.
+ *
+ * This creates a variable _hname prepended by settings_handler_.
+ *
+ */
 #define SETTINGS_STATIC_HANDLER_DEFINE(_hname, _tree, _get, _set, _commit,   \
 				       _export)				     \
 	SETTINGS_STATIC_HANDLER_DEFINE_WITH_CPRIO(_hname, _tree, _get, _set, \

--- a/include/zephyr/settings/settings.h
+++ b/include/zephyr/settings/settings.h
@@ -70,53 +70,54 @@ typedef ssize_t (*settings_read_cb)(void *cb_arg, void *data, size_t len);
  */
 struct settings_handler {
 
+	/** Name of subtree. */
 	const char *name;
-	/**< Name of subtree. */
 
+	/** Priority of commit, lower value is higher priority */
 	int cprio;
-	/**< Priority of commit, lower value is higher priority */
 
-	int (*h_get)(const char *key, char *val, int val_len_max);
-	/**< Get values handler of settings items identified by keyword names.
+	/**
+	 * @brief Get values handler of settings items identified by keyword names.
 	 *
-	 * Parameters:
-	 *  - key[in] the name with skipped part that was used as name in
-	 *    handler registration
-	 *  - val[out] buffer to receive value.
-	 *  - val_len_max[in] size of that buffer.
+	 * @param[in] key The name with skipped part that was used as name in
+	 *   handler registration
+	 * @param[out] val Buffer to receive value.
+	 * @param[in] val_len_max Size of that buffer.
 	 *
-	 * Return: length of data read on success, negative on failure.
+	 * @return Length of data read on success, negative on failure.
 	 */
+	int (*h_get)(const char *key, char *val, int val_len_max);
 
+	/**
+	 * @brief Set value handler of settings items identified by keyword names.
+	 *
+	 * @param[in] key The name with skipped part that was used as name in
+	 *   handler registration
+	 * @param[in] len the Size of the data found in the backend.
+	 * @param[in] read_cb Function provided to read the data from the backend.
+	 * @param[in] cb_arg Arguments for the read function provided by the
+	 *   backend.
+	 *
+	 * @return 0 on success, non-zero on failure.
+	 */
 	int (*h_set)(const char *key, size_t len, settings_read_cb read_cb,
 		     void *cb_arg);
-	/**< Set value handler of settings items identified by keyword names.
-	 *
-	 * Parameters:
-	 *  - key[in] the name with skipped part that was used as name in
-	 *    handler registration
-	 *  - len[in] the size of the data found in the backend.
-	 *  - read_cb[in] function provided to read the data from the backend.
-	 *  - cb_arg[in] arguments for the read function provided by the
-	 *    backend.
-	 *
-	 *  Return: 0 on success, non-zero on failure.
-	 */
 
-	int (*h_commit)(void);
-	/**< This handler gets called after settings has been loaded in full.
+	/**
+	 * @brief This handler gets called after settings has been loaded in full.
+	 *
 	 * User might use it to apply setting to the application.
 	 *
-	 * Return: 0 on success, non-zero on failure.
+	 * @return 0 on success, non-zero on failure.
 	 */
+	int (*h_commit)(void);
 
-	int (*h_export)(int (*export_func)(const char *name, const void *val,
-					   size_t val_len));
-	/**< This gets called to dump all current settings items.
+	/**
+	 * @brief This gets called to dump all current settings items.
 	 *
 	 * This happens when @ref settings_save tries to save the settings.
-	 * Parameters:
-	 *  - export_func: the pointer to the internal function which appends
+	 *
+	 * @param[in] export_func The pointer to the internal function which appends
 	 *   a single key-value pair to persisted settings. Don't store
 	 *   duplicated value. The name is subtree/key string, val is the string
 	 *   with value.
@@ -125,11 +126,13 @@ struct settings_handler {
 	 * only one keyword at one call - what will impose limit to get/set
 	 * values using full subtree/key name.
 	 *
-	 * Return: 0 on success, non-zero on failure.
+	 * @return 0 on success, non-zero on failure.
 	 */
+	int (*h_export)(int (*export_func)(const char *name, const void *val,
+					   size_t val_len));
 
+	/** Linked list node info for module internal usage. */
 	sys_snode_t node;
-	/**< Linked list node info for module internal usage. */
 };
 
 /**
@@ -138,62 +141,66 @@ struct settings_handler {
  * These are registered using a call to SETTINGS_STATIC_HANDLER_DEFINE().
  */
 struct settings_handler_static {
-
+	/** Name of subtree. */
 	const char *name;
-	/**< Name of subtree. */
 
+	/** Priority of commit, lower value is higher priority */
 	int cprio;
-	/**< Priority of commit, lower value is higher priority */
 
-	int (*h_get)(const char *key, char *val, int val_len_max);
-	/**< Get values handler of settings items identified by keyword names.
+	/**
+	 * @brief Get values handler of settings items identified by keyword names.
 	 *
-	 * Parameters:
-	 *  - key[in] the name with skipped part that was used as name in
-	 *    handler registration
-	 *  - val[out] buffer to receive value.
-	 *  - val_len_max[in] size of that buffer.
+	 * @param[in] key The name with skipped part that was used as name in
+	 *   handler registration
+	 * @param[out] val Buffer to receive value.
+	 * @param[in] val_len_max Size of that buffer.
 	 *
-	 * Return: length of data read on success, negative on failure.
+	 * @return Length of data read on success, negative on failure.
 	 */
+	int (*h_get)(const char *key, char *val, int val_len_max);
 
+	/**
+	 * @brief Set value handler of settings items identified by keyword names.
+	 *
+	 * @param[in] key The name with skipped part that was used as name in
+	 *  handler registration
+	 * @param[in] len The size of the data found in the backend.
+	 * @param[in] read_cb Function provided to read the data from the backend.
+	 * @param[in] cb_arg Arguments for the read function provided by the
+	 *   backend.
+	 *
+	 * @return 0 on success, non-zero on failure.
+	 */
 	int (*h_set)(const char *key, size_t len, settings_read_cb read_cb,
 		     void *cb_arg);
-	/**< Set value handler of settings items identified by keyword names.
-	 *
-	 * Parameters:
-	 *  - key[in] the name with skipped part that was used as name in
-	 *    handler registration
-	 *  - len[in] the size of the data found in the backend.
-	 *  - read_cb[in] function provided to read the data from the backend.
-	 *  - cb_arg[in] arguments for the read function provided by the
-	 *    backend.
-	 *
-	 * Return: 0 on success, non-zero on failure.
-	 */
 
-	int (*h_commit)(void);
-	/**< This handler gets called after settings has been loaded in full.
+	/**
+	 * @brief This handler gets called after settings has been loaded in full.
+	 *
 	 * User might use it to apply setting to the application.
+	 *
+	 * @return 0 on success, non-zero on failure.
 	 */
+	int (*h_commit)(void);
 
-	int (*h_export)(int (*export_func)(const char *name, const void *val,
-					   size_t val_len));
-	/**< This gets called to dump all current settings items.
+	/**
+	 * @brief This gets called to dump all current settings items.
 	 *
 	 * This happens when @ref settings_save tries to save the settings.
-	 * Parameters:
-	 *  - export_func: the pointer to the internal function which appends
-	 *   a single key-value pair to persisted settings. Don't store
-	 *   duplicated value. The name is subtree/key string, val is the string
-	 *   with value.
+	 *
+	 * @param[in] export_func The pointer to the internal function which appends
+	 * a single key-value pair to persisted settings. Don't store
+	 * duplicated value. The name is subtree/key string, val is the string
+	 * with value.
 	 *
 	 * @remarks The User might limit a implementations of handler to serving
 	 * only one keyword at one call - what will impose limit to get/set
 	 * values using full subtree/key name.
 	 *
-	 * Return: 0 on success, non-zero on failure.
+	 * @return 0 on success, non-zero on failure.
 	 */
+	int (*h_export)(int (*export_func)(const char *name, const void *val,
+					   size_t val_len));
 };
 
 /**
@@ -426,11 +433,11 @@ struct settings_store_itf;
  * Backend handler node for storage handling.
  */
 struct settings_store {
+	/** Linked list node info for internal usage. */
 	sys_snode_t cs_next;
-	/**< Linked list node info for internal usage. */
 
+	/** Backend handler structure. */
 	const struct settings_store_itf *cs_itf;
-	/**< Backend handler structure. */
 };
 
 /**
@@ -464,13 +471,11 @@ struct settings_load_arg {
  * Destinations are registered using a call to @ref settings_dst_register.
  */
 struct settings_store_itf {
-	int (*csi_load)(struct settings_store *cs,
-			const struct settings_load_arg *arg);
-	/**< Loads values from storage limited to subtree defined by subtree.
+	/**
+	 * @brief Loads values from storage limited to subtree defined by subtree.
 	 *
-	 * Parameters:
-	 *  - cs[in] - Corresponding backend handler node,
-	 *  - arg[in] - Structure that holds additional data for data loading.
+	 * @param[in] cs Corresponding backend handler node,
+	 * @param[in] arg Structure that holds additional data for data loading.
 	 *
 	 * @note
 	 * Backend is expected not to provide duplicates of the entities.
@@ -478,56 +483,61 @@ struct settings_store_itf {
 	 * really delete old keys, it has to filter out old entities and call
 	 * load callback only on the final entity.
 	 */
+	int (*csi_load)(struct settings_store *cs,
+			const struct settings_load_arg *arg);
 
+	/**
+	 * @brief Loads one value from storage that corresponds to the key defined by name.
+	 *
+	 * @param[in] cs Corresponding backend handler node.
+	 * @param[in] name Key in string format.
+	 * @param[in] buf Buffer where data should be copied.
+	 * @param[in] buf_len Length of buf.
+	 */
 	ssize_t (*csi_load_one)(struct settings_store *cs, const char *name,
 				char *buf, size_t buf_len);
-	/**< Loads one value from storage that corresponds to the key defined by name.
-	 *
-	 * Parameters:
-	 *  - cs[in] - Corresponding backend handler node.
-	 *  - name[in] - Key in string format.
-	 *  - buf[in] - Buffer where data should be copied.
-	 *  - buf_len[in] - Length of buf.
-	 */
 
-	ssize_t (*csi_get_val_len)(struct settings_store *cs, const char *name);
-	/**< Gets the value's length associated to the Key defined by name.
+	/**
+	 * @brief Gets the value's length associated to the Key defined by name.
+	 *
 	 * It returns 0 if the Key/Value doesn't exist.
 	 *
-	 * Parameters:
-	 *  - cs[in] - Corresponding backend handler node.
-	 *  - name[in] - Key in string format.
-	 */
-
-	int (*csi_save_start)(struct settings_store *cs);
-	/**< Handler called before an export operation.
+	 * @param[in] cs Corresponding backend handler node.
+	 * @param[in] name Key in string format.
 	 *
-	 * Parameters:
-	 *  - cs[in] - Corresponding backend handler node
+	 * @return 0 if the Key/Value doesn't exist
 	 */
+	ssize_t (*csi_get_val_len)(struct settings_store *cs, const char *name);
 
+	/**
+	 * @brief Handler called before an export operation.
+	 *
+	 * @param[in] cs Corresponding backend handler node
+	 */
+	int (*csi_save_start)(struct settings_store *cs);
+
+	/**
+	 * @brief Save a single key-value pair to storage.
+	 *
+	 * @param[in] cs Corresponding backend handler node
+	 * @param[in] name Key in string format
+	 * @param[in] value Binary value
+	 * @param[in] val_len Length of value in bytes.
+	 */
 	int (*csi_save)(struct settings_store *cs, const char *name,
 			const char *value, size_t val_len);
-	/**< Save a single key-value pair to storage.
-	 *
-	 * Parameters:
-	 *  - cs[in] - Corresponding backend handler node
-	 *  - name[in] - Key in string format
-	 *  - value[in] - Binary value
-	 *  - val_len[in] - Length of value in bytes.
-	 */
 
+	/**
+	 * @brief Handler called after an export operation.
+	 *
+	 * @param[in] cs Corresponding backend handler node
+	 */
 	int (*csi_save_end)(struct settings_store *cs);
-	/**< Handler called after an export operation.
-	 *
-	 * Parameters:
-	 *  - cs[in] - Corresponding backend handler node
-	 */
 
-	/**< Get pointer to the storage instance used by the backend.
+	/**
+	 * @brief Get pointer to the storage instance used by the backend.
 	 *
-	 * Parameters:
-	 *  - cs[in] - Corresponding backend handler node
+	 * @param[in] cs Corresponding backend handler node
 	 */
 	void *(*csi_storage_get)(struct settings_store *cs);
 };
@@ -607,11 +617,11 @@ int settings_call_set_handler(const char *name,
  * settings_name_steq("bt/btmesh/iv", "bt/", &next) returns 0, next=NULL
  * settings_name_steq("bt/btmesh/iv", "bta", &next) returns 0, next=NULL
  *
- * REMARK: This routine could be simplified if the settings_handler names
+ * @remark This routine could be simplified if the settings_handler names
  * would include a separator at the end.
  *
- * @return 0: no match
- *         1: match, next can be used to check if match is full
+ * @retval 0 no match
+ * @retval 1 match, next can be used to check if match is full
  */
 int settings_name_steq(const char *name, const char *key, const char **next);
 

--- a/include/zephyr/settings/settings.h
+++ b/include/zephyr/settings/settings.h
@@ -18,7 +18,6 @@
 extern "C" {
 #endif
 
-
 /**
  * @defgroup file_system_storage File System Storage
  * @ingroup os_services
@@ -34,11 +33,11 @@ extern "C" {
  * @{
  */
 
-#define SETTINGS_MAX_DIR_DEPTH	8	/* max depth of settings tree */
-#define SETTINGS_MAX_NAME_LEN	(8 * SETTINGS_MAX_DIR_DEPTH)
-#define SETTINGS_MAX_VAL_LEN	256
-#define SETTINGS_NAME_SEPARATOR	'/'
-#define SETTINGS_NAME_END '='
+#define SETTINGS_MAX_DIR_DEPTH  8 /* max depth of settings tree */
+#define SETTINGS_MAX_NAME_LEN   (8 * SETTINGS_MAX_DIR_DEPTH)
+#define SETTINGS_MAX_VAL_LEN    256
+#define SETTINGS_NAME_SEPARATOR '/'
+#define SETTINGS_NAME_END       '='
 
 /* place for settings additions:
  * up to 7 separators, '=', '\0'
@@ -100,8 +99,7 @@ struct settings_handler {
 	 *
 	 * @return 0 on success, non-zero on failure.
 	 */
-	int (*h_set)(const char *key, size_t len, settings_read_cb read_cb,
-		     void *cb_arg);
+	int (*h_set)(const char *key, size_t len, settings_read_cb read_cb, void *cb_arg);
 
 	/**
 	 * @brief This handler gets called after settings has been loaded in full.
@@ -128,8 +126,7 @@ struct settings_handler {
 	 *
 	 * @return 0 on success, non-zero on failure.
 	 */
-	int (*h_export)(int (*export_func)(const char *name, const void *val,
-					   size_t val_len));
+	int (*h_export)(int (*export_func)(const char *name, const void *val, size_t val_len));
 
 	/** Linked list node info for module internal usage. */
 	sys_snode_t node;
@@ -171,8 +168,7 @@ struct settings_handler_static {
 	 *
 	 * @return 0 on success, non-zero on failure.
 	 */
-	int (*h_set)(const char *key, size_t len, settings_read_cb read_cb,
-		     void *cb_arg);
+	int (*h_set)(const char *key, size_t len, settings_read_cb read_cb, void *cb_arg);
 
 	/**
 	 * @brief This handler gets called after settings has been loaded in full.
@@ -199,8 +195,7 @@ struct settings_handler_static {
 	 *
 	 * @return 0 on success, non-zero on failure.
 	 */
-	int (*h_export)(int (*export_func)(const char *name, const void *val,
-					   size_t val_len));
+	int (*h_export)(int (*export_func)(const char *name, const void *val, size_t val_len));
 };
 
 /**
@@ -218,16 +213,15 @@ struct settings_handler_static {
  *
  */
 
-#define SETTINGS_STATIC_HANDLER_DEFINE_WITH_CPRIO(_hname, _tree, _get, _set, \
-						  _commit, _export, _cprio)  \
-	const STRUCT_SECTION_ITERABLE(settings_handler_static,		     \
-				      settings_handler_ ## _hname) = {       \
-		.name = _tree,						     \
-		.cprio = _cprio,					     \
-		.h_get = _get,						     \
-		.h_set = _set,						     \
-		.h_commit = _commit,					     \
-		.h_export = _export,					     \
+#define SETTINGS_STATIC_HANDLER_DEFINE_WITH_CPRIO(_hname, _tree, _get, _set, _commit, _export,     \
+						  _cprio)                                          \
+	const STRUCT_SECTION_ITERABLE(settings_handler_static, settings_handler_##_hname) = {      \
+		.name = _tree,                                                                     \
+		.cprio = _cprio,                                                                   \
+		.h_get = _get,                                                                     \
+		.h_set = _set,                                                                     \
+		.h_commit = _commit,                                                               \
+		.h_export = _export,                                                               \
 	}
 
 /**
@@ -245,10 +239,8 @@ struct settings_handler_static {
  * This creates a variable _hname prepended by settings_handler_.
  *
  */
-#define SETTINGS_STATIC_HANDLER_DEFINE(_hname, _tree, _get, _set, _commit,   \
-				       _export)				     \
-	SETTINGS_STATIC_HANDLER_DEFINE_WITH_CPRIO(_hname, _tree, _get, _set, \
-		_commit, _export, 0)
+#define SETTINGS_STATIC_HANDLER_DEFINE(_hname, _tree, _get, _set, _commit, _export)                \
+	SETTINGS_STATIC_HANDLER_DEFINE_WITH_CPRIO(_hname, _tree, _get, _set, _commit, _export, 0)
 
 /**
  * Initialization of settings and backend
@@ -270,8 +262,7 @@ int settings_subsys_init(void);
  *
  * @return 0 on success, non-zero on failure.
  */
-int settings_register_with_cprio(struct settings_handler *cf,
-				 int cprio);
+int settings_register_with_cprio(struct settings_handler *cf, int cprio);
 
 /**
  * Register a handler for settings items stored in RAM with
@@ -336,12 +327,8 @@ ssize_t settings_get_val_len(const char *key);
  *
  * @return When nonzero value is returned, further subtree searching is stopped.
  */
-typedef int (*settings_load_direct_cb)(
-	const char      *key,
-	size_t           len,
-	settings_read_cb read_cb,
-	void            *cb_arg,
-	void            *param);
+typedef int (*settings_load_direct_cb)(const char *key, size_t len, settings_read_cb read_cb,
+				       void *cb_arg, void *param);
 
 /**
  * Load limited set of serialized items using given callback.
@@ -360,10 +347,7 @@ typedef int (*settings_load_direct_cb)(
  *                        function is called.
  * @return 0 on success, non-zero on failure.
  */
-int settings_load_subtree_direct(
-	const char             *subtree,
-	settings_load_direct_cb cb,
-	void                   *param);
+int settings_load_subtree_direct(const char *subtree, settings_load_direct_cb cb, void *param);
 
 /**
  * Save currently running serialized items. All serialized items which are
@@ -429,7 +413,6 @@ int settings_commit_subtree(const char *subtree);
 /**
  * @} settings
  */
-
 
 /**
  * @defgroup settings_backend Settings backend interface
@@ -497,8 +480,7 @@ struct settings_store_itf {
 	 * really delete old keys, it has to filter out old entities and call
 	 * load callback only on the final entity.
 	 */
-	int (*csi_load)(struct settings_store *cs,
-			const struct settings_load_arg *arg);
+	int (*csi_load)(struct settings_store *cs, const struct settings_load_arg *arg);
 
 	/**
 	 * @brief Loads one value from storage that corresponds to the key defined by name.
@@ -508,8 +490,8 @@ struct settings_store_itf {
 	 * @param[in] buf Buffer where data should be copied.
 	 * @param[in] buf_len Length of buf.
 	 */
-	ssize_t (*csi_load_one)(struct settings_store *cs, const char *name,
-				char *buf, size_t buf_len);
+	ssize_t (*csi_load_one)(struct settings_store *cs, const char *name, char *buf,
+				size_t buf_len);
 
 	/**
 	 * @brief Gets the value's length associated to the Key defined by name.
@@ -538,8 +520,8 @@ struct settings_store_itf {
 	 * @param[in] value Binary value
 	 * @param[in] val_len Length of value in bytes.
 	 */
-	int (*csi_save)(struct settings_store *cs, const char *name,
-			const char *value, size_t val_len);
+	int (*csi_save)(struct settings_store *cs, const char *name, const char *value,
+			size_t val_len);
 
 	/**
 	 * @brief Handler called after an export operation.
@@ -572,7 +554,6 @@ void settings_src_register(struct settings_store *cs);
  */
 void settings_dst_register(struct settings_store *cs);
 
-
 /*
  * API for handler lookup
  */
@@ -585,8 +566,7 @@ void settings_dst_register(struct settings_store *cs);
  *
  * @return settings_handler_static on success, NULL on failure.
  */
-struct settings_handler_static *settings_parse_and_lookup(const char *name,
-							  const char **next);
+struct settings_handler_static *settings_parse_and_lookup(const char *name, const char **next);
 
 /**
  * Calls settings handler.
@@ -601,11 +581,8 @@ struct settings_handler_static *settings_parse_and_lookup(const char *name,
  *
  * @return 0 or negative error code
  */
-int settings_call_set_handler(const char *name,
-			      size_t len,
-			      settings_read_cb read_cb,
-			      void *read_cb_arg,
-			      const struct settings_load_arg *load_arg);
+int settings_call_set_handler(const char *name, size_t len, settings_read_cb read_cb,
+			      void *read_cb_arg, const struct settings_load_arg *load_arg);
 /**
  * @}
  */


### PR DESCRIPTION
Harmonize the settings docstring style within the public header. Try to bring the style closer to what is used elsewhere in-tree.