### PR TITLE
scripts: coccinelle: add fork as a reserved name

### DIFF
--- a/samples/philosophers/src/main.c
+++ b/samples/philosophers/src/main.c
@@ -87,7 +87,7 @@
 
 #include "phil_obj_abstract.h"
 
-#define fork(x) (forks[x])
+#define philosopher_fork(x) (forks[x])
 
 static void set_phil_state_pos(int id)
 {
@@ -149,11 +149,11 @@ void philosopher(void *id, void *unused1, void *unused2)
 
 	/* Dijkstra's solution: always pick up the lowest numbered fork first */
 	if (is_last_philosopher(my_id)) {
-		my_fork1 = fork(0);
-		my_fork2 = fork(my_id);
+		my_fork1 = philosopher_fork(0);
+		my_fork2 = philosopher_fork(my_id);
 	} else {
-		my_fork1 = fork(my_id);
-		my_fork2 = fork(my_id + 1);
+		my_fork1 = philosopher_fork(my_id);
+		my_fork2 = philosopher_fork(my_id + 1);
 	}
 
 	while (1) {
@@ -202,7 +202,7 @@ static void init_objects(void)
 {
 #if !STATIC_OBJS
 	for (int i = 0; i < NUM_PHIL; i++) {
-		fork_init(fork(i));
+		fork_init(philosopher_fork(i));
 	}
 #endif
 }
@@ -225,8 +225,8 @@ static void start_threads(void)
 		snprintk(tname, CONFIG_THREAD_MAX_NAME_LEN, "Philosopher %d", i);
 		k_thread_name_set(&threads[i], tname);
 #endif /* CONFIG_THREAD_NAME */
-		k_object_access_grant(fork(i), &threads[i]);
-		k_object_access_grant(fork((i + 1) % NUM_PHIL), &threads[i]);
+		k_object_access_grant(philosopher_fork(i), &threads[i]);
+		k_object_access_grant(philosopher_fork((i + 1) % NUM_PHIL), &threads[i]);
 
 		k_thread_start(&threads[i]);
 	}

--- a/samples/posix/philosophers/src/main.c
+++ b/samples/posix/philosophers/src/main.c
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <zephyr/sys/util.h>
 #include <zephyr/logging/log.h>
@@ -47,7 +48,7 @@ static inline void fork_init(fork_t frk)
 	}
 }
 
-static inline fork_t fork(size_t idx)
+static inline fork_t philosopher_fork(size_t idx)
 {
 	return &forks[idx];
 }
@@ -148,11 +149,11 @@ static void *philosopher(void *arg)
 
 	/* Djkstra's solution: always pick up the lowest numbered fork first */
 	if (is_last_philosopher(my_id)) {
-		my_fork1 = fork(0);
-		my_fork2 = fork(my_id);
+		my_fork1 = philosopher_fork(0);
+		my_fork2 = philosopher_fork(my_id);
 	} else {
-		my_fork1 = fork(my_id);
-		my_fork2 = fork(my_id + 1);
+		my_fork1 = philosopher_fork(my_id);
+		my_fork2 = philosopher_fork(my_id + 1);
 	}
 
 	while (1) {
@@ -204,7 +205,7 @@ static void init_objects(void)
 {
 	ARRAY_FOR_EACH(forks, i) {
 		LOG_DBG("Initializing fork %zu", i);
-		fork_init(fork(i));
+		fork_init(philosopher_fork(i));
 	}
 }
 

--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/src/main.c
@@ -69,7 +69,7 @@
 /***************************************/
 osSemaphoreId forks[NUM_PHIL];
 
-#define fork(x) (forks[x])
+#define philosopher_fork(x) (forks[x])
 
 /*
  * CMSIS limits the stack size, but qemu_x86_64, qemu_xtensa (all),
@@ -149,11 +149,11 @@ void philosopher(void const *id)
 
 	/* Djkstra's solution: always pick up the lowest numbered fork first */
 	if (is_last_philosopher(my_id)) {
-		fork1 = fork(0);
-		fork2 = fork(my_id);
+		fork1 = philosopher_fork(0);
+		fork2 = philosopher_fork(my_id);
 	} else {
-		fork1 = fork(my_id);
-		fork2 = fork(my_id + 1);
+		fork1 = philosopher_fork(my_id);
+		fork2 = philosopher_fork(my_id + 1);
 	}
 
 	while (1) {

--- a/samples/subsys/portability/cmsis_rtos_v2/philosophers/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v2/philosophers/src/main.c
@@ -65,7 +65,7 @@
 /***************************************/
 osSemaphoreId_t forks[NUM_PHIL];
 
-#define fork(x) (forks[x])
+#define philosopher_fork(x) (forks[x])
 
 #define STACK_SIZE CONFIG_CMSIS_V2_THREAD_MAX_STACK_SIZE
 static K_THREAD_STACK_ARRAY_DEFINE(stacks, NUM_PHIL, STACK_SIZE);
@@ -174,11 +174,11 @@ void philosopher(void *id)
 
 	/* Djkstra's solution: always pick up the lowest numbered fork first */
 	if (is_last_philosopher(my_id)) {
-		fork1 = fork(0);
-		fork2 = fork(my_id);
+		fork1 = philosopher_fork(0);
+		fork2 = philosopher_fork(my_id);
 	} else {
-		fork1 = fork(my_id);
-		fork2 = fork(my_id + 1);
+		fork1 = philosopher_fork(my_id);
+		fork2 = philosopher_fork(my_id + 1);
 	}
 
 	while (1) {

--- a/scripts/coccinelle/symbols.txt
+++ b/scripts/coccinelle/symbols.txt
@@ -49,6 +49,7 @@ fileno5
 floor
 fmod
 fopen
+fork
 fprintf
 fputc1
 fputs1


### PR DESCRIPTION
Fix internal code to use a different identifier than `fork` and avoid reserved names.

* samples: philosophers: rename 'fork' to avoid POSIX conflict
* samples: cmsis: philosophers: rename 'fork' to avoid POSIX conflict
* samples: posix: philosophers: rename 'fork' to avoid POSIX conflict
* scripts: coccinelle: add fork as a reserved name

`fork()` is defined by POSIX for creating a new child process.

It is the preferred method of doing so on systems with virtual memory and the symbol should not be used outside of the context defined by the POSIX standard.

https://pubs.opengroup.org/onlinepubs/9699919799/functions/fork.html

Required by #97855