### PR TITLE
riscv: gcc: optimize riscv_march string

### DIFF
--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -64,6 +64,10 @@ if(CONFIG_RISCV_ISA_EXT_ZIFENCEI)
   string(CONCAT riscv_march ${riscv_march} "_zifencei")
 endif()
 
+# If it matches the g extension, replace it. We don't do it based on CONFIG_RISCV_ISA_EXT_G
+# as f and d are only used when CONFIG_FPU is enabled
+string(REGEX REPLACE "(imafd)(.*)(_zicsr_zifencei)" "g\\2" riscv_march ${riscv_march})
+
 # Check whether we already imply Zaamo/Zalrsc by selecting the A extension; if not - check them
 # individually and enable them as needed
 if(NOT CONFIG_RISCV_ISA_EXT_A)


### PR DESCRIPTION
shorten riscv_march string, when
extensions match the g extention.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>