### PR TITLE
tests: drivers: can: host: apply ruff format and fixups

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -1088,17 +1088,6 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
-"./tests/drivers/can/host/pytest/can_shell.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "SIM401",   # https://docs.astral.sh/ruff/rules/if-else-block-instead-of-dict-get
-    "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
-    "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
-    "UP045",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation-optional
-]
-"./tests/drivers/can/host/pytest/test_can.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "UP039",    # https://docs.astral.sh/ruff/rules/unnecessary-class-parentheses
-]
 "./tests/kernel/timer/timer_behavior/pytest/saleae_logic2.py" = [
     "B905",     # https://docs.astral.sh/ruff/rules/zip-without-explicit-strict
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -1481,9 +1470,6 @@ exclude = [
     "./tests/boot/with_mcumgr/pytest/test_downgrade_prevention.py",
     "./tests/boot/with_mcumgr/pytest/test_upgrade.py",
     "./tests/boot/with_mcumgr/pytest/west_sign_wrapper.py",
-    "./tests/drivers/can/host/pytest/can_shell.py",
-    "./tests/drivers/can/host/pytest/conftest.py",
-    "./tests/drivers/can/host/pytest/test_can.py",
     "./tests/kernel/timer/timer_behavior/pytest/saleae_logic2.py",
     "./tests/kernel/timer/timer_behavior/pytest/test_timer.py",
     "./tests/lib/devicetree/memory_region_flags/pytest/test_memory_region_flags.py",

--- a/tests/drivers/can/host/pytest/conftest.py
+++ b/tests/drivers/can/host/pytest/conftest.py
@@ -16,10 +16,15 @@ from twister_harness import DeviceAdapter, Shell
 
 logger = logging.getLogger(__name__)
 
+
 def pytest_addoption(parser) -> None:
     """Add local parser options to pytest."""
-    parser.addoption('--can-context', default=None,
-                     help='Configuration context to use for python-can (default: None)')
+    parser.addoption(
+        '--can-context',
+        default=None,
+        help='Configuration context to use for python-can (default: None)',
+    )
+
 
 @pytest.fixture(name='context', scope='session')
 def fixture_context(request, dut: DeviceAdapter) -> str:
@@ -34,6 +39,7 @@ def fixture_context(request, dut: DeviceAdapter) -> str:
 
     logger.info('using python-can configuration context "%s"', ctx)
     return ctx
+
 
 @pytest.fixture(name='chosen', scope='module')
 def fixture_chosen(shell: Shell) -> str:
@@ -51,6 +57,7 @@ def fixture_chosen(shell: Shell) -> str:
     pytest.fail('zephyr,canbus chosen device not found or not ready')
     return None
 
+
 @pytest.fixture
 def can_dut(dut: DeviceAdapter, shell: Shell, chosen: str) -> BusABC:
     """Return DUT CAN bus."""
@@ -59,9 +66,10 @@ def can_dut(dut: DeviceAdapter, shell: Shell, chosen: str) -> BusABC:
     bus.shutdown()
     dut.clear_buffer()
 
+
 @pytest.fixture
 def can_host(context: str) -> BusABC:
     """Return host CAN bus."""
-    bus = Bus(config_context = context)
+    bus = Bus(config_context=context)
     yield bus
     bus.shutdown()

--- a/tests/drivers/can/host/pytest/test_can.py
+++ b/tests/drivers/can/host/pytest/test_can.py
@@ -7,9 +7,9 @@ Test suites for testing Zephyr CAN <=> host CAN.
 """
 
 import logging
-import pytest
 
 import can
+import pytest
 from can import BusABC, CanProtocol
 
 # RX/TX timeout in seconds
@@ -17,40 +17,45 @@ TIMEOUT = 1.0
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.parametrize('msg', [
-    pytest.param(
-        can.Message(arbitration_id=0x10,
-                    is_extended_id=False),
-        id='std_id_dlc_0'
-    ),
-    pytest.param(
-        can.Message(arbitration_id=0x20,
-                    data=[0xaa, 0xbb, 0xcc, 0xdd],
-                    is_extended_id=False),
-        id='std_id_dlc_4'
-    ),
-    pytest.param(
-        can.Message(arbitration_id=0x30,
-                    data=[0xee, 0xff, 0xee, 0xff, 0xee, 0xff, 0xee, 0xff],
-                    is_extended_id=True),
-        id='ext_id_dlc_8'
-    ),
-    pytest.param(
-        can.Message(arbitration_id=0x40,
-                    data=[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
-                          0x10, 0x11],
-                    is_fd=True, is_extended_id=False),
-        id='std_id_fdf_dlc_9'
-    ),
-    pytest.param(
-        can.Message(arbitration_id=0x50,
-                    data=[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
-                          0x10, 0x11],
-                    is_fd=True, bitrate_switch=True, is_extended_id=False),
-        id='std_id_fdf_brs_dlc_9'
-    ),
-])
-class TestCanRxTx():
+
+@pytest.mark.parametrize(
+    'msg',
+    [
+        pytest.param(can.Message(arbitration_id=0x10, is_extended_id=False), id='std_id_dlc_0'),
+        pytest.param(
+            can.Message(arbitration_id=0x20, data=[0xAA, 0xBB, 0xCC, 0xDD], is_extended_id=False),
+            id='std_id_dlc_4',
+        ),
+        pytest.param(
+            can.Message(
+                arbitration_id=0x30,
+                data=[0xEE, 0xFF, 0xEE, 0xFF, 0xEE, 0xFF, 0xEE, 0xFF],
+                is_extended_id=True,
+            ),
+            id='ext_id_dlc_8',
+        ),
+        pytest.param(
+            can.Message(
+                arbitration_id=0x40,
+                data=[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11],
+                is_fd=True,
+                is_extended_id=False,
+            ),
+            id='std_id_fdf_dlc_9',
+        ),
+        pytest.param(
+            can.Message(
+                arbitration_id=0x50,
+                data=[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11],
+                is_fd=True,
+                bitrate_switch=True,
+                is_extended_id=False,
+            ),
+            id='std_id_fdf_brs_dlc_9',
+        ),
+    ],
+)
+class TestCanRxTx:
     """
     Class for testing CAN RX/TX between Zephyr DUT and host.
     """
@@ -64,8 +69,7 @@ class TestCanRxTx():
         if rx is None:
             pytest.fail('no message received')
 
-        if not tx.equals(rx, timestamp_delta=None, check_channel=False,
-                         check_direction=False):
+        if not tx.equals(rx, timestamp_delta=None, check_channel=False, check_direction=False):
             pytest.fail(f'rx message "{rx}" not equal to tx message "{tx}"')
 
     @staticmethod


### PR DESCRIPTION
Apply ruff format and fixups to the CAN host test suite pytest files.