### PR TITLE
samples: instrumentation: remove unnecessary include of instrumentation.h

### DIFF
--- a/samples/subsys/instrumentation/src/main.c
+++ b/samples/subsys/instrumentation/src/main.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/instrumentation/instrumentation.h>
 
 #define SLEEPTIME 10
 #define STACKSIZE 1024


### PR DESCRIPTION
The instrumentation.h header is not needed to compile the instrumentation sample and it can be misleading for folks to think they have to include it in their code to use the subsystem, so remove it.