### PR TITLE
tests: arm: exclude mps2/an385 on user stack test

### DIFF
--- a/tests/arch/arm/arm_user_stack_test/testcase.yaml
+++ b/tests/arch/arm/arm_user_stack_test/testcase.yaml
@@ -2,6 +2,9 @@ common:
   tags:
     - arm
   timeout: 120
+  # TODO: remove the platform_exclude once the issue with MPS2/AN385 is fixed.
+  platform_exclude:
+    - mps2/an385
 tests:
   arch.arm.user.stack:
     filter: CONFIG_CPU_CORTEX_M


### PR DESCRIPTION
Temporarily disable running the user stack tests on mps2/an385 to unblock ci issues reported in #98494.

Fixes #98494