### PR TITLE
ring_buffer: update assert message and enable `RING_BUFFER_LARGE` by default depending on Kconfig

### DIFF
--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -32,12 +32,13 @@ extern "C" {
 #ifdef CONFIG_RING_BUFFER_LARGE
 typedef uint32_t ring_buf_idx_t;
 #define RING_BUFFER_MAX_SIZE (UINT32_MAX / 2)
+#define RING_BUFFER_SIZE_ASSERT_MSG "Size too big"
 #else
 typedef uint16_t ring_buf_idx_t;
 #define RING_BUFFER_MAX_SIZE (UINT16_MAX / 2)
+#define RING_BUFFER_SIZE_ASSERT_MSG "Size too big, please enable CONFIG_RING_BUFFER_LARGE"
 #endif
 
-#define RING_BUFFER_SIZE_ASSERT_MSG "Size too big"
 
 struct ring_buf_index { ring_buf_idx_t head, tail, base; };
 

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -98,6 +98,15 @@ config SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE
 	  escape sequences). However, if bulk data is transferred it may be
 	  required to increase it.
 
+config SHELL_BACKEND_SERIAL_NEEDS_LARGE_RING_BUFFER
+	bool
+	default y if SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE > $(INT16_MAX)
+	default y if SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE > $(INT16_MAX)
+	select RING_BUFFER_LARGE
+	help
+	  This is a helper Kconfig to select RING_BUFFER_LARGE when the implementation
+	  requires a ring buffer of > 32kB.
+
 if SHELL_BACKEND_SERIAL_API_ASYNC
 
 config SHELL_BACKEND_SERIAL_ASYNC_RX_TIMEOUT
@@ -321,6 +330,14 @@ config SHELL_MQTT_RX_BUF_SIZE
 	default 256
 	help
 	  Buffer size for the MQTT data reception.
+
+config SHELL_MQTT_NEEDS_LARGE_RING_BUFFER
+	bool
+	default y if SHELL_MQTT_RX_BUF_SIZE > $(INT16_MAX)
+	select RING_BUFFER_LARGE
+	help
+	  This is a helper Kconfig to select RING_BUFFER_LARGE when the implementation
+	  requires a ring buffer of > 32kB.
 
 config SHELL_MQTT_TX_BUF_SIZE
 	int "TX buffer size"


### PR DESCRIPTION
It's possible for user to trigger the ringbuffer size assert in runtime when they are upgrading from an older version of Zephyr with > 32767 bytes of ringbuf for components such as the shell UART backend.

i.e.: `CONFIG_SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE=65536`

```
ASSERTION FAIL [size <= (0xffff / 2)] @ ZEPHYR_BASE/include/zephyr/sys/ring_buffer.h:169
Size too big
[0101_000000.048] <err> os: 
[0101_000000.048] <err> os:  mcause: 11, Environment call from M-mode
```

https://github.com/zephyrproject-rtos/zephyr/blob/05899583fdcd1d2a10e0ef3ca619fe5c57367041/subsys/shell/backends/shell_uart.c#L211-L227

The first commit updates the assert message to not only points out what's wrong, but also the way to fix it:

```
ASSERTION FAIL [size <= (0xffff / 2)] @ ZEPHYR_BASE/include/zephyr/sys/ring_buffer.h:169
Size too big, please enable CONFIG_RING_BUFFER_LARGE
[0101_000000.048] <err> os: 
[0101_000000.048] <err> os:  mcause: 11, Environment call from M-mode
```

The second commit takes care of getting the `CONFIG_RING_BUFFER_LARGE` enabled when the user configures in-tree kernel components like the shell UART backend.

Fixes #98523