### PR TITLE
runners: esp32: fix esptool command syntax

### DIFF
--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -87,18 +87,22 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
             cmd_flash.extend(['--port', self.device])
 
         if self.erase is True:
-            cmd_erase = cmd_flash + ['erase-flash']
+            cmd_erase = cmd_flash + ['erase_flash']
             self.check_call(cmd_erase)
 
         if self.no_stub is True:
             cmd_flash.extend(['--no-stub'])
+        
         cmd_flash.extend(['--baud', self.baud])
-        cmd_flash.extend(['--before', 'default-reset'])
+        cmd_flash.extend(['--before', 'default_reset'])
+        
         if self.reset:
-            cmd_flash.extend(['--after', 'hard-reset', 'write-flash', '-u'])
-        cmd_flash.extend(['--flash-mode', self.flash_mode])
-        cmd_flash.extend(['--flash-freq', self.flash_freq])
-        cmd_flash.extend(['--flash-size', self.flash_size])
+            cmd_flash.extend(['--after', 'hard_reset'])
+        
+        cmd_flash.extend(['write_flash'])
+        cmd_flash.extend(['--flash_mode', self.flash_mode])
+        cmd_flash.extend(['--flash_freq', self.flash_freq])
+        cmd_flash.extend(['--flash_size', self.flash_size])
 
         if self.encrypt:
             cmd_flash.extend(['--encrypt'])

--- a/soc/espressif/common/CMakeLists.txt
+++ b/soc/espressif/common/CMakeLists.txt
@@ -39,9 +39,9 @@ if((CONFIG_ESP_SIMPLE_BOOT OR CONFIG_MCUBOOT) AND NOT CONFIG_SOC_ESP32C6_LPCORE)
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
       COMMAND esptool
       ARGS --chip ${CONFIG_SOC} elf2image ${ELF2IMAGE_ARG}
-      --flash-mode dio
-      --flash-freq ${CONFIG_ESPTOOLPY_FLASHFREQ}
-      --flash-size ${esptoolpy_flashsize}MB
+      --flash_mode dio
+      --flash_freq ${CONFIG_ESPTOOLPY_FLASHFREQ}
+      --flash_size ${esptoolpy_flashsize}MB
       -o ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
       ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME})
   endif()


### PR DESCRIPTION
## Problem
The esptool utility expects underscore in command names and arguments, but the runner was using hyphens. This caused flashing to fail on ESP32-S3 devices with error messages about unrecognized commands.

## Root Cause
The esp32.py runner script was passing commands like `erase-flash` and arguments like `--flash-mode` to esptool, but esptool's actual command-line interface uses underscores: `erase_flash` and `--flash_mode`. This inconsistency prevented the `west flash` command from working on ESP32-S3 boards.

## Testing
Verified that flashing now works correctly on ESP32-S3 DevKitC-1 with both erase and write operations completing successfully.

## Changes

**Command names:**
- `erase-flash` → `erase_flash`
- `default-reset` → `default_reset`
- `hard-reset` → `hard_reset`
- `write-flash` → `write_flash`

**Argument names:**
- `--flash-mode` → `--flash_mode`
- `--flash-freq` → `--flash_freq`
- `--flash-size` → `--flash_size`

**Files modified:**
- `scripts/west_commands/runners/esp32.py`
- `soc/espressif/common/CMakeLists.txt`

The esptool utility expects underscore in command names and arguments, but the runner was using hyphens. This caused flashing to fail on ESP32-S3 devices with error messages about unrecognized commands.

Root Cause:
The esp32.py runner script was passing commands like 'erase-flash' and arguments like '--flash-mode' to esptool, but esptool's actual command-line interface uses underscores: 'erase_flash' and '--flash_mode'. This inconsistency prevented the west flash command from working on ESP32-S3 boards.

Testing:
Verified that flashing now works correctly on ESP32-S3 DevKitC-1 with both erase and write operations completing successfully.

Changed:
Command names:
- erase-flash -> erase_flash
- default-reset -> default_reset
- hard-reset -> hard_reset
- write-flash -> write_flash

Argument names:
- --flash-mode -> --flash_mode
- --flash-freq -> --flash_freq
- --flash-size -> --flash_size

Files modified:
- scripts/west_commands/runners/esp32.py
- soc/espressif/common/CMakeLists.txt