### PR TITLE
MAINTAINERS: Adds Liam-Ogletree as a Haptics collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1758,6 +1758,8 @@ Documentation Infrastructure:
   status: maintained
   maintainers:
     - rriveramcrus
+  collaborators:
+    - Liam-Ogletree
   files:
     - drivers/haptics/
     - dts/bindings/haptics/


### PR DESCRIPTION
Adds Liam-Ogletree as a collaborator for the haptic driver API.

Liam is a colleague of mine here at Cirrus Logic and has already been contributing to the Zephyr project:
- #97744
- #92980