### PR TITLE
doc: releases: introduce release notes and migration guide docs for 4.4

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -1,0 +1,48 @@
+:orphan:
+
+..
+  See
+  https://docs.zephyrproject.org/latest/releases/index.html#migration-guides
+  for details of what is supposed to go into this document.
+
+.. _migration_4.4:
+
+Migration guide to Zephyr v4.4.0 (Working Draft)
+################################################
+
+This document describes the changes required when migrating your application from Zephyr v4.3.0 to
+Zephyr v4.4.0.
+
+Any other changes (not directly related to migrating applications) can be found in
+the :ref:`release notes<zephyr_4.4>`.
+
+.. contents::
+    :local:
+    :depth: 2
+
+Build System
+************
+
+Kernel
+******
+
+Boards
+******
+
+Device Drivers and Devicetree
+*****************************
+
+Bluetooth
+*********
+
+Networking
+**********
+
+Other subsystems
+****************
+
+Modules
+*******
+
+Architectures
+*************

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -1,0 +1,108 @@
+:orphan:
+
+..
+  What goes here: removed/deprecated apis, new boards, new drivers, notable
+  features. If you feel like something new can be useful to a user, put it
+  under "Other Enhancements" in the first paragraph, if you feel like something
+  is worth mentioning in the project media (release blog post, release
+  livestream) put it under "Major enhancement".
+..
+  If you are describing a feature or functionality, consider adding it to the
+  actual project documentation rather than the release notes, so that the
+  information does not get lost in time.
+..
+  No list of bugfixes, minor changes, those are already in the git log, this is
+  not a changelog.
+..
+  Does the entry have a link that contains the details? Just add the link, if
+  you think it needs more details, put them in the content that shows up on the
+  link.
+..
+  Are you thinking about generating this? Don't put anything at all.
+..
+  Does the thing require the user to change their application? Put it on the
+  migration guide instead. (TODO: move the removed APIs section in the
+  migration guide)
+
+.. _zephyr_4.4:
+
+Zephyr 4.4.0 (Working Draft)
+############################
+
+We are pleased to announce the release of Zephyr version 4.4.0.
+
+Major enhancements with this release include:
+
+An overview of the changes required or recommended when migrating your application from Zephyr
+v4.3.0 to Zephyr v4.4.0 can be found in the separate :ref:`migration guide<migration_4.4>`.
+
+The following sections provide detailed lists of changes by component.
+
+Security Vulnerability Related
+******************************
+
+API Changes
+***********
+
+..
+  Only removed, deprecated and new APIs. Changes go in migration guide.
+
+Removed APIs and options
+========================
+
+Deprecated APIs and options
+===========================
+
+New APIs and options
+====================
+
+..
+  Link to new APIs here, in a group if you think it's necessary, no need to get
+  fancy just list the link, that should contain the documentation. If you feel
+  like you need to add more details, add them in the API documentation code
+  instead.
+
+.. zephyr-keep-sorted-start re(^\* \w)
+
+
+.. zephyr-keep-sorted-stop
+
+New Boards
+**********
+
+..
+  You may update this list as you contribute a new board during the release cycle, in order to make
+  it visible to people who might be looking at the working draft of the release notes. However, note
+  that this list will be recomputed at the time of the release, so you don't *have* to update it.
+  In any case, just link the board, further details go in the board description.
+
+New Shields
+***********
+
+..
+  Same as above, this will also be recomputed at the time of the release.
+
+New Drivers
+***********
+
+..
+  Same as above, this will also be recomputed at the time of the release.
+  Just link the driver, further details go in the binding description
+
+New Samples
+***********
+
+..
+  Same as above, this will also be recomputed at the time of the release.
+ Just link the sample, further details go in the sample documentation itself.
+
+
+Libraries / Subsystems
+**********************
+
+Other notable changes
+*********************
+
+..
+  Any more descriptive subsystem or driver changes. Do you really want to write
+  a paragraph or is it enough to link to the api/driver/Kconfig/board page above?


### PR DESCRIPTION
This introduces the release notes and migration guide for Zephyr 4.4.0 earlier so that people have a placeholder to start adding content as they line up pull requests for the 4.4 release.