### PR TITLE
modem: chat: merge request and delimiter send phases

### DIFF
--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -212,8 +212,6 @@ enum modem_chat_script_send_state {
 	MODEM_CHAT_SCRIPT_SEND_STATE_IDLE,
 	/* Sending request */
 	MODEM_CHAT_SCRIPT_SEND_STATE_REQUEST,
-	/* Sending delimiter */
-	MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER,
 };
 
 /**

--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -132,7 +132,9 @@ struct modem_cmux_frame {
 	bool pf;
 	uint8_t type;
 	const uint8_t *data;
+	const uint8_t *tx_extra;
 	uint16_t data_len;
+	uint16_t tx_extra_len;
 };
 
 struct modem_cmux_work {

--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -50,7 +50,8 @@ typedef void (*modem_pipe_api_callback)(struct modem_pipe *pipe, enum modem_pipe
 
 typedef int (*modem_pipe_api_open)(void *data);
 
-typedef int (*modem_pipe_api_transmit)(void *data, const uint8_t *buf, size_t size);
+typedef int (*modem_pipe_api_transmit)(void *data, const uint8_t *buf, size_t size,
+				       const uint8_t *extra_buf, size_t extra_size);
 
 typedef int (*modem_pipe_api_receive)(void *data, uint8_t *buf, size_t size);
 
@@ -131,6 +132,8 @@ void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback
  * @param pipe Pipe to transmit through
  * @param buf Data to transmit
  * @param size Number of bytes to transmit
+ * @param extra_buf Optional second buffer to transmit
+ * @param extra_size Number of bytes in @a extra_buf
  *
  * @retval Number of bytes placed in pipe
  * @retval -EPERM if pipe is closed
@@ -138,7 +141,26 @@ void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback
  *
  * @warning This call must be non-blocking
  */
-int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size);
+int modem_pipe_transmit_double(struct modem_pipe *pipe, const uint8_t *buf, size_t size,
+			       const uint8_t *extra_buf, size_t extra_size);
+
+/**
+ * @brief Transmit data through pipe
+ *
+ * @param pipe Pipe to transmit through
+ * @param buf Data to transmit
+ * @param size Number of bytes to transmit
+ *
+ * @retval Number of bytes placed in pipe
+ * @retval -EPERM if pipe is closed
+ * @retval -errno code on error
+ *
+ * @warning This call must be non-blocking
+ */
+static inline int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size)
+{
+	return modem_pipe_transmit_double(pipe, buf, size, NULL, 0);
+}
 
 /**
  * @brief Receive data through pipe

--- a/subsys/modem/backends/modem_backend_tty.c
+++ b/subsys/modem/backends/modem_backend_tty.c
@@ -70,12 +70,16 @@ static int modem_backend_tty_open(void *data)
 	return 0;
 }
 
-static int modem_backend_tty_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_backend_tty_transmit(void *data, const uint8_t *buf, size_t size,
+				      const uint8_t *extra_buf, size_t extra_size)
 {
 	struct modem_backend_tty *backend = (struct modem_backend_tty *)data;
 	int ret;
 
 	ret = write(backend->tty_fd, buf, size);
+	if ((ret == size) && (extra_size > 0)) {
+		ret += write(backend->tty_fd, extra_buf, extra_size);
+	}
 	modem_pipe_notify_transmit_idle(&backend->pipe);
 	return ret;
 }

--- a/subsys/modem/backends/modem_backend_uart_async.c
+++ b/subsys/modem/backends/modem_backend_uart_async.c
@@ -202,11 +202,15 @@ static uint32_t get_transmit_buf_size(struct modem_backend_uart *backend)
 	return backend->async.common.transmit_buf_size;
 }
 
-static int modem_backend_uart_async_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_backend_uart_async_transmit(void *data, const uint8_t *buf, size_t size,
+					     const uint8_t *extra_buf, size_t extra_size)
 {
 	struct modem_backend_uart *backend = (struct modem_backend_uart *)data;
 	bool transmitting;
+	uint32_t tx_buf_size = get_transmit_buf_size(backend);
+	uint32_t extra_bytes_to_transmit;
 	uint32_t bytes_to_transmit;
+	uint32_t total_transmit;
 	int ret;
 
 	transmitting = atomic_test_and_set_bit(&backend->async.common.state,
@@ -216,25 +220,29 @@ static int modem_backend_uart_async_transmit(void *data, const uint8_t *buf, siz
 	}
 
 	/* Determine amount of bytes to transmit */
-	bytes_to_transmit = MIN(size, get_transmit_buf_size(backend));
+	bytes_to_transmit = MIN(size, tx_buf_size);
+	extra_bytes_to_transmit = MIN(extra_size, tx_buf_size - bytes_to_transmit);
+	total_transmit = bytes_to_transmit + extra_bytes_to_transmit;
 
 	/* Copy buf to transmit buffer which is passed to UART */
 	memcpy(backend->async.common.transmit_buf, buf, bytes_to_transmit);
+	memcpy(backend->async.common.transmit_buf + bytes_to_transmit, extra_buf,
+	       extra_bytes_to_transmit);
 
-	ret = uart_tx(backend->uart, backend->async.common.transmit_buf, bytes_to_transmit,
+	ret = uart_tx(backend->uart, backend->async.common.transmit_buf, total_transmit,
 		      CONFIG_MODEM_BACKEND_UART_ASYNC_TRANSMIT_TIMEOUT_MS * 1000L);
 
 #if CONFIG_MODEM_STATS
-	advertise_transmit_buf_stats(backend, bytes_to_transmit);
+	advertise_transmit_buf_stats(backend, total_transmit);
 #endif
 
 	if (ret != 0) {
 		LOG_ERR("Failed to %s %u bytes. (%d)",
-			"start async transmit for", bytes_to_transmit, ret);
+			"start async transmit for", total_transmit, ret);
 		return ret;
 	}
 
-	return (int)bytes_to_transmit;
+	return (int)total_transmit;
 }
 
 static int modem_backend_uart_async_receive(void *data, uint8_t *buf, size_t size)

--- a/subsys/modem/backends/modem_backend_uart_isr.c
+++ b/subsys/modem/backends/modem_backend_uart_isr.c
@@ -166,7 +166,8 @@ static bool modem_backend_uart_isr_transmit_buf_above_limit(struct modem_backend
 	return backend->isr.transmit_buf_put_limit < get_transmit_buf_length(backend);
 }
 
-static int modem_backend_uart_isr_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_backend_uart_isr_transmit(void *data, const uint8_t *buf, size_t size,
+					   const uint8_t *extra_buf, size_t extra_size)
 {
 	struct modem_backend_uart *backend = (struct modem_backend_uart *)data;
 	int written;
@@ -177,6 +178,9 @@ static int modem_backend_uart_isr_transmit(void *data, const uint8_t *buf, size_
 
 	uart_irq_tx_disable(backend->uart);
 	written = ring_buf_put(&backend->isr.transmit_rb, buf, size);
+	if (extra_size > 0) {
+		written += ring_buf_put(&backend->isr.transmit_rb, extra_buf, extra_size);
+	}
 	uart_irq_tx_enable(backend->uart);
 
 	/* Update transmit buf capacity tracker */

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -274,32 +274,30 @@ static bool modem_chat_send_script_request_part(struct modem_chat *chat)
 {
 	const struct modem_chat_script_chat *script_chat =
 		&chat->script->script_chats[chat->script_chat_it];
-
-	uint8_t *request_part;
-	uint16_t request_size;
-	uint16_t request_part_size;
+	uint32_t total_size = script_chat->request_size + chat->delimiter_size;
+	const uint8_t *buf;
+	size_t buf_len;
+	const uint8_t *extra_buf = NULL;
+	size_t extra_len = 0;
 	int ret;
 
-	switch (chat->script_send_state) {
-	case MODEM_CHAT_SCRIPT_SEND_STATE_REQUEST:
-		request_part = (uint8_t *)(&script_chat->request[chat->script_send_pos]);
-		request_size = script_chat->request_size;
-		break;
-
-	case MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER:
-		request_part = (uint8_t *)(&chat->delimiter[chat->script_send_pos]);
-		request_size = chat->delimiter_size;
-		break;
-
-	default:
-		return false;
+	if (chat->script_send_pos < script_chat->request_size) {
+		/* Still sending the request */
+		buf = &script_chat->request[chat->script_send_pos];
+		buf_len = script_chat->request_size - chat->script_send_pos;
+		extra_buf = (uint8_t *)chat->delimiter;
+		extra_len = chat->delimiter_size;
+	} else {
+		/* Purely into the delimiter */
+		buf = &chat->delimiter[chat->script_send_pos - script_chat->request_size];
+		buf_len = total_size - chat->script_send_pos;
 	}
 
-	request_part_size = request_size - chat->script_send_pos;
-	ret = modem_pipe_transmit(chat->pipe, request_part, request_part_size);
+	ret = modem_pipe_transmit_double(chat->pipe, buf, buf_len, extra_buf, extra_len);
 	if (ret < 1) {
 		if (ret < 0) {
-			LOG_ERR("Failed to %s %u bytes. (%d)", "transmit", request_part_size, ret);
+			LOG_ERR("Failed to %s %u bytes. (%d)", "transmit",
+				buf_len + extra_len, ret);
 		}
 		return false;
 	}
@@ -307,7 +305,7 @@ static bool modem_chat_send_script_request_part(struct modem_chat *chat)
 	chat->script_send_pos += (uint16_t)ret;
 
 	/* Return true if all data was sent */
-	return request_size <= chat->script_send_pos;
+	return total_size <= chat->script_send_pos;
 }
 
 static void modem_chat_script_send_handler(struct k_work *item)
@@ -318,26 +316,17 @@ static void modem_chat_script_send_handler(struct k_work *item)
 		return;
 	}
 
-	switch (chat->script_send_state) {
-	case MODEM_CHAT_SCRIPT_SEND_STATE_IDLE:
+	if (chat->script_send_state == MODEM_CHAT_SCRIPT_SEND_STATE_IDLE) {
 		return;
-
-	case MODEM_CHAT_SCRIPT_SEND_STATE_REQUEST:
-		if (!modem_chat_send_script_request_part(chat)) {
-			return;
-		}
-
-		modem_chat_set_script_send_state(chat, MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER);
-		__fallthrough;
-
-	case MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER:
-		if (!modem_chat_send_script_request_part(chat)) {
-			return;
-		}
-
-		modem_chat_set_script_send_state(chat, MODEM_CHAT_SCRIPT_SEND_STATE_IDLE);
-		break;
 	}
+
+	if (!modem_chat_send_script_request_part(chat)) {
+		/* Request still in progress */
+		return;
+	}
+
+	/* Request transmission complete */
+	modem_chat_set_script_send_state(chat, MODEM_CHAT_SCRIPT_SEND_STATE_IDLE);
 
 	if (modem_chat_script_chat_has_matches(chat)) {
 		modem_chat_script_set_response_matches(chat);

--- a/subsys/modem/modem_pipe.c
+++ b/subsys/modem/modem_pipe.c
@@ -62,9 +62,10 @@ static int pipe_call_open(struct modem_pipe *pipe)
 	return pipe->api->open(pipe->data);
 }
 
-static int pipe_call_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size)
+static int pipe_call_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size,
+			      const uint8_t *extra_buf, size_t extra_size)
 {
-	return pipe->api->transmit(pipe->data, buf, size);
+	return pipe->api->transmit(pipe->data, buf, size, extra_buf, extra_size);
 }
 
 static int pipe_call_receive(struct modem_pipe *pipe, uint8_t *buf, size_t size)
@@ -133,14 +134,15 @@ void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback
 	}
 }
 
-int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size)
+int modem_pipe_transmit_double(struct modem_pipe *pipe, const uint8_t *buf, size_t size,
+			const uint8_t *extra_buf, size_t extra_size)
 {
 	if (!pipe_test_events(pipe, PIPE_EVENT_OPENED_BIT)) {
 		return -EPERM;
 	}
 
 	pipe_clear_events(pipe, PIPE_EVENT_TRANSMIT_IDLE_BIT);
-	return pipe_call_transmit(pipe, buf, size);
+	return pipe_call_transmit(pipe, buf, size, extra_buf, extra_size);
 }
 
 int modem_pipe_receive(struct modem_pipe *pipe, uint8_t *buf, size_t size)

--- a/tests/subsys/modem/modem_chat/Kconfig
+++ b/tests/subsys/modem/modem_chat/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Embeint Pty Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+config MODEM_MOCK_BACKEND_LIMIT
+	int "Mock backend TX limit for test"
+	default 8
+
+source "Kconfig.zephyr"

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -276,7 +276,7 @@ static void *test_modem_chat_setup(void)
 		.rx_buf_size = ARRAY_SIZE(mock_rx_buf),
 		.tx_buf = mock_tx_buf,
 		.tx_buf_size = ARRAY_SIZE(mock_tx_buf),
-		.limit = 8,
+		.limit = CONFIG_MODEM_MOCK_BACKEND_LIMIT,
 	};
 
 	mock_pipe = modem_backend_mock_init(&mock, &mock_config);

--- a/tests/subsys/modem/modem_chat/testcase.yaml
+++ b/tests/subsys/modem/modem_chat/testcase.yaml
@@ -10,6 +10,9 @@ common:
     - native_sim
 tests:
   modem.modem_chat: {}
+  modem.modem_chat.single_byte:
+    extra_configs:
+      - CONFIG_MODEM_MOCK_BACKEND_LIMIT=1
   modem.modem_chat.workq:
     extra_configs:
       - CONFIG_MODEM_DEDICATED_WORKQUEUE=y

--- a/tests/subsys/modem/modem_cmux/src/main.c
+++ b/tests/subsys/modem/modem_cmux/src/main.c
@@ -919,6 +919,25 @@ ZTEST(modem_cmux, test_modem_cmux_split_large_data)
 		     "Incorrect number of bytes transmitted %d", ret);
 }
 
+ZTEST(modem_cmux, test_modem_cmux_dual_send)
+{
+	int ret;
+	uint32_t events;
+	const char *request = "ATE0";
+	const char *delim = "\r";
+
+	ret = modem_pipe_transmit_double(dlci2_pipe, request, 4, delim, 1);
+	zassert_true(ret == 5, "Failed to transmit both buffers %d", ret);
+
+	events = k_event_wait(&cmux_event, EVENT_CMUX_DLCI2_TRANSMIT_IDLE, false, K_MSEC(200));
+	zassert_equal(events, EVENT_CMUX_DLCI2_TRANSMIT_IDLE,
+		      "Transmit idle event not received for DLCI2 pipe");
+
+	ret = modem_backend_mock_get(&bus_mock, buffer2, sizeof(buffer2));
+	zassert_true(ret == CMUX_BASIC_HRD_SMALL_SIZE + 5,
+		     "Incorrect number of bytes transmitted %d", ret);
+}
+
 ZTEST(modem_cmux, test_modem_cmux_invalid_cr)
 {
 	uint32_t events;

--- a/tests/subsys/modem/modem_pipe/src/main.c
+++ b/tests/subsys/modem/modem_pipe/src/main.c
@@ -32,6 +32,8 @@ struct modem_backend_fake {
 
 	const uint8_t *transmit_buffer;
 	size_t transmit_buffer_size;
+	const uint8_t *extra_transmit_buffer;
+	size_t extra_transmit_buffer_size;
 
 	uint8_t *receive_buffer;
 	size_t receive_buffer_size;
@@ -76,13 +78,16 @@ static void modem_backend_fake_transmit_idle_handler(struct k_work *item)
 	modem_pipe_notify_transmit_idle(&backend->pipe);
 }
 
-static int modem_backend_fake_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_backend_fake_transmit(void *data, const uint8_t *buf, size_t size,
+				       const uint8_t *extra_buf, size_t extra_size)
 {
 	struct modem_backend_fake *backend = data;
 
 	backend->transmit_called = true;
 	backend->transmit_buffer = buf;
 	backend->transmit_buffer_size = size;
+	backend->extra_transmit_buffer = extra_buf;
+	backend->extra_transmit_buffer_size = extra_size;
 
 	if (backend->synchronous) {
 		modem_pipe_notify_transmit_idle(&backend->pipe);


### PR DESCRIPTION
Handle sending the request and delimiter strings in a single call to the pipe backend. This has two advantages:
     1. No time gap between request and delimiter on the interface (more efficient line utilization)
     2. Fewer bytes transmitted on the line for pipes that perform wrapping (CMUX).

For example, sending "ATE0" + "\n" through CMUX now takes 11 bytes, instead of the previous 17 bytes (10 + 7):
```
[00:00:38.268,064] <wrn> modem_cmux: TX
                                     f9 0b ef 0b 41 54 45 30  0d 5d f9                |....ATE0 .].
```

The double buffer send functionality is exposed through a new function in the modem pipe API, meaning all existing code does not require any changes.

Tested on real hardware with the UART ASYNC HWFC backend.