### PR TITLE
dts: arm: nuvoton: add spi nodes for numaker m333x

### DIFF
--- a/dts/arm/nuvoton/m333x.dtsi
+++ b/dts/arm/nuvoton/m333x.dtsi
@@ -45,7 +45,7 @@
 			lxt = "enable";
 			hirc48m = "enable";
 			clk-pclkdiv = <(NUMAKER_CLK_PCLKDIV_APB0DIV_DIV2 |
-					NUMAKER_CLK_PCLKDIV_APB1DIV_DIV2)>;
+				       NUMAKER_CLK_PCLKDIV_APB1DIV_DIV2)>;
 			core-clock = <DT_FREQ_M(180)>;
 			powerdown-mode = <NUMAKER_CLK_PMUCTL_PDMSEL_DPD>;
 
@@ -225,6 +225,39 @@
 			reg = <0x40096000 0x10>;
 			interrupts = <9 0>;
 			clocks = <&pcc NUMAKER_WWDT0_MODULE NUMAKER_CLK_CLKSEL1_WWDT0SEL_LIRC 0>;
+			status = "disabled";
+		};
+
+		spi0: spi@40061000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x40061000 0x1000>;
+			interrupts = <23 0>;
+			resets = <&rst NUMAKER_SPI0_RST>;
+			clocks = <&pcc NUMAKER_SPI0_MODULE NUMAKER_CLK_CLKSEL2_SPI0SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		spi1: spi@40062000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x40062000 0x1000>;
+			interrupts = <51 0>;
+			resets = <&rst NUMAKER_SPI1_RST>;
+			clocks = <&pcc NUMAKER_SPI1_MODULE NUMAKER_CLK_CLKSEL2_SPI1SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		spi2: spi@40063000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x40063000 0x1000>;
+			interrupts = <52 0>;
+			resets = <&rst NUMAKER_SPI2_RST>;
+			clocks = <&pcc NUMAKER_SPI2_MODULE NUMAKER_CLK_CLKSEL2_SPI2SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 	};

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m3334ki.conf
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m3334ki.conf
@@ -1,0 +1,1 @@
+CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m3334ki.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m3334ki.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	/* EVB's NU5: SS/CLK/MISO/MOSI */
+	spi2_default: spi2_default {
+		group0 {
+			pinmux = <PA11MFP_SPI2_SS>,
+				 <PA10MFP_SPI2_CLK>,
+				 <PA9MFP_SPI2_MISO>,
+				 <PA8MFP_SPI2_MOSI>;
+		};
+	};
+};
+
+&spi2 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_K(500)>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
+	};
+	status = "okay";
+	pinctrl-0 = <&spi2_default>;
+	pinctrl-names = "default";
+};

--- a/west.yml
+++ b/west.yml
@@ -205,7 +205,7 @@ manifest:
       groups:
         - hal
     - name: hal_nuvoton
-      revision: 9b455fffd6dd3936c5a4eb575e4d33edbcf1b6b0
+      revision: 602db600cae5275ab0946de696a6068d769a6b3d
       path: modules/hal/nuvoton
       groups:
         - hal


### PR DESCRIPTION
This PR is to add SPI nodes for Nuvoton NuMaker M333X series.
Also add support of Nuvoton numaker board numaker_m3334ki in spi_loopback test.

Test result of spi_loopback on numaker_m3334ki board as:
```
SUITE PASS - 100.00% [spi_loopback]: pass = 23, fail = 0, skip = 3, total = 26 duration = 0.356 seconds
 - PASS - [spi_loopback.test_nop_nil_bufs] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_large_transfers] duration = 0.296 seconds
 - PASS - [spi_loopback.test_spi_complete_loop_mode_0] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_loop_mode_1] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_loop_mode_2] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_loop_mode_3] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_multiple] duration = 0.003 seconds
 - PASS - [spi_loopback.test_spi_complete_multiple_timed] duration = 0.008 seconds
 - PASS - [spi_loopback.test_spi_concurrent_transfer_different_spec] duration = 0.004 seconds
 - PASS - [spi_loopback.test_spi_concurrent_transfer_same_spec] duration = 0.004 seconds
 - SKIP - [spi_loopback.test_spi_deinit] duration = 0.005 seconds
 - PASS - [spi_loopback.test_spi_null_rx_buf_set] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_null_tx_buf] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_null_tx_buf_set] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_null_tx_rx_buf_set] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_bigger_than_tx] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_every_4] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_half_end] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_half_start] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_same_buf_cmd] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_word_size_16] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_word_size_24] duration = 0.002 seconds
 - PASS - [spi_loopback.test_spi_word_size_32] duration = 0.002 seconds
 - SKIP - [spi_loopback.test_spi_word_size_7] duration = 0.008 seconds
 - SKIP - [spi_loopback.test_spi_word_size_9] duration = 0.008 seconds
 - PASS - [spi_loopback.test_spi_write_back] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```