### PR TITLE
boards: beagle: play: Disable internal capacitors

### DIFF
--- a/boards/beagle/beagleplay/beagleplay_cc1352p7_defconfig
+++ b/boards/beagle/beagleplay/beagleplay_cc1352p7_defconfig
@@ -16,8 +16,9 @@ CONFIG_CC13X2_CC26X2_BOOTLOADER_BACKDOOR_PIN=15
 CONFIG_ARM_MPU=y
 CONFIG_HW_STACK_PROTECTION=y
 
-# Adjust for oscillator capacitors
-CONFIG_CC13X2_CC26X2_XOSC_CAPARRAY_DELTA=0x02
+# Disable internal capacitors. BeaglePlay has external load capacitors.
+# Source: https://www.ti.com/lit/er/swrz109a/swrz109a.pdf?ts=1761755410798 Radio_01
+CONFIG_CC13X2_CC26X2_XOSC_CAPARRAY_DELTA=0xFF
 
 # Enable default uart console
 CONFIG_SERIAL=y


### PR DESCRIPTION
- BeaglePlay has external load capacitors for the 48 MHz crystal. The reason for this is described in Radio_01 here [0]. So we should disable the internal capacitors.
- I have tested connection between play and bcf with the new play settings. For anyone wanting to replicate it, I have used greybus loopback protocol [1]. Here is my script:
```
echo 50 > /sys/class/gb_loopback/gb_loopback0/iteration_max
echo 2 > /sys/class/gb_loopback/gb_loopback0/type
sleep 10
cat /sys/class/gb_loopback/gb_loopback0/latency_avg
```
- Results:
  - Before change: 89545.880000 microsec
  - After change: 87822.620000 microsec
- Basically, no regression.

[0]: https://www.ti.com/lit/er/swrz109a/swrz109a.pdf?ts=1761755410798
[1]: https://github.com/zephyrproject-rtos/zephyr/issues/98259