### PR TITLE
drivers: counter: npcx: add support for the LCT driver

### DIFF
--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -68,3 +68,4 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_WUT_MAX32           counter_max32_wu
 zephyr_library_sources_ifdef(CONFIG_COUNTER_CC23X0_RTC          counter_cc23x0_rtc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_CC23X0_LGPT         counter_cc23x0_lgpt.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MSPM0_TIMER         counter_mspm0_timer.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_NPCX_LCT            counter_npcx_lct.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -132,4 +132,6 @@ source "drivers/counter/Kconfig.cc23x0_lgpt"
 
 source "drivers/counter/Kconfig.mspm0"
 
+source "drivers/counter/Kconfig.npcx"
+
 endif # COUNTER

--- a/drivers/counter/Kconfig.npcx
+++ b/drivers/counter/Kconfig.npcx
@@ -1,0 +1,31 @@
+# NPCX LCT driver configuration options
+
+# Copyright (c) 2025 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+config COUNTER_NPCX_NPCXN_V1
+	bool
+	help
+	  This option enables LCT version 1 support for npcxn variant.
+
+config COUNTER_NPCX_NPCXN_V2
+	bool
+	help
+	  This option enables LCT version 2 support for npcxn variant.
+
+config COUNTER_NPCX_NPCKN
+	bool
+	help
+	  This option enables LCT version 1 support for npckn variant.
+
+config COUNTER_NPCX_LCT
+	bool "NPCX Long Countdown Timer Module driver"
+	default y
+	depends on DT_HAS_NUVOTON_NPCX_LCT_V1_ENABLED ||\
+		   DT_HAS_NUVOTON_NPCX_LCT_V2_ENABLED ||\
+		   DT_HAS_NUVOTON_NPCK_LCT_ENABLED
+	select COUNTER_NPCX_NPCXN_V1 if DT_HAS_NUVOTON_NPCX_LCT_V1_ENABLED
+	select COUNTER_NPCX_NPCXN_V2 if DT_HAS_NUVOTON_NPCX_LCT_V2_ENABLED
+	select COUNTER_NPCX_NPCKN if DT_HAS_NUVOTON_NPCK_LCT_ENABLED
+	help
+	  Enable support for NPCX Long Countdown Timer Module (LCT) driver.

--- a/drivers/counter/counter_npcx_lct.c
+++ b/drivers/counter/counter_npcx_lct.c
@@ -1,0 +1,393 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/counter.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys_clock.h>
+
+#include "soc_miwu.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(counter_npcx_lct, CONFIG_COUNTER_LOG_LEVEL);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npcx_lct_v1)
+#define DT_DRV_COMPAT    nuvoton_npcx_lct_v1
+#elif DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npcx_lct_v2)
+#define DT_DRV_COMPAT    nuvoton_npcx_lct_v2
+#elif DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npck_lct)
+#define DT_DRV_COMPAT    nuvoton_npck_lct
+#endif
+BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1, "Invalid number of NPCX LCT peripherals");
+
+BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(nuvoton_npcx_lct_v1) +
+	     DT_NUM_INST_STATUS_OKAY(nuvoton_npcx_lct_v2) +
+	     DT_NUM_INST_STATUS_OKAY(nuvoton_npck_lct) <= 1,
+	     "Multiple npcx LCT instances in DT");
+
+#define COUNTER_NPCX_LCT_MAX_SECOND        DT_INST_PROP(0, maximum_cnt_in_sec)
+#define COUNTER_NPCX_LCT_CHECK_TIMEOUT_US  200
+
+#define DAY_PER_WEEK 7U
+#define SEC_PER_WEEK ((DAY_PER_WEEK) * (SEC_PER_DAY))
+
+#define NPCX_LCT_PWR_VCC1 0
+#define NPCX_LCT_PWR_VSBY 1
+
+#define NPCX_LCT_STAT_EV_MASK 0x01
+
+struct counter_npcx_lct_config {
+	struct counter_config_info info;
+	struct lct_reg *reg_base;
+	bool pwr_by_vsby;
+#if defined(CONFIG_COUNTER_NPCX_NPCXN_V1) || defined(CONFIG_COUNTER_NPCX_NPCXN_V2)
+	const struct npcx_wui lct_wui;
+#endif
+#if defined(CONFIG_COUNTER_NPCX_NPCKN)
+	int irq;
+#endif
+};
+
+struct counter_npcx_lct_data {
+	struct k_sem lock;
+#if defined(CONFIG_COUNTER_NPCX_NPCXN_V1) || defined(CONFIG_COUNTER_NPCX_NPCXN_V2)
+	struct miwu_callback lct_wui_cb;
+#endif
+	counter_alarm_callback_t alarm_cb;
+	void *user_data;
+};
+
+static void npcx_lct_handle_isr(const struct device *dev)
+{
+	const struct counter_npcx_lct_config *const config = dev->config;
+	struct counter_npcx_lct_data *data = dev->data;
+	struct lct_reg *const reg_base = config->reg_base;
+	counter_alarm_callback_t alarm_cb = data->alarm_cb;
+
+	/* The counter needs some time to stop. Wait for the LCT enable bit to clear, or the event
+	 * status won’t clear properly.
+	 */
+	if (WAIT_FOR(!IS_BIT_SET(reg_base->LCTCONT, NPCX_LCTCONT_LCTEN),
+		     COUNTER_NPCX_LCT_CHECK_TIMEOUT_US, NULL) == false) {
+		LOG_ERR("The LCT function is still working");
+	}
+
+	reg_base->LCTCONT &= ~BIT(NPCX_LCTCONT_LCTEVEN);
+	reg_base->LCTSTAT |= BIT(NPCX_LCTSTAT_LCTEVST);
+
+	if (data->alarm_cb) {
+		data->alarm_cb = NULL;
+		alarm_cb(dev, 0, 0, data->user_data);
+	}
+}
+
+#if defined(CONFIG_COUNTER_NPCX_NPCKN)
+static void counter_npcx_lct_isr(const struct device *dev)
+{
+	npcx_lct_handle_isr(dev);
+}
+#endif
+#if defined(CONFIG_COUNTER_NPCX_NPCXN_V1) || defined(CONFIG_COUNTER_NPCX_NPCXN_V2)
+static void counter_npcx_lct_isr(const struct device *dev, struct npcx_wui *wui)
+{
+	npcx_lct_handle_isr(dev);
+}
+#endif
+
+#if defined(CONFIG_COUNTER_NPCX_NPCXN_V2)
+#define LCT_REG_WEEKM(base) (base->LCTWEEKM)
+#else
+#define LCT_REG_WEEKM(base) 0U
+#endif
+
+static int npcx_lct_enable(struct lct_reg *const reg_base, bool enable)
+{
+	if (enable) {
+		reg_base->LCTCONT |= BIT(NPCX_LCTCONT_LCTEN);
+	} else {
+		reg_base->LCTCONT &= ~BIT(NPCX_LCTCONT_LCTEN);
+	}
+
+	/* The counter takes time to start and stop. Wait until the LCT enable bit is in the correct
+	 * state, otherwise the hardware behavior may be incorrect.
+	 */
+	if (WAIT_FOR(IS_BIT_SET(reg_base->LCTCONT, NPCX_LCTCONT_LCTEN) == enable,
+		     COUNTER_NPCX_LCT_CHECK_TIMEOUT_US, NULL) == false) {
+		LOG_ERR("LCT enable/disable timeout");
+		return -ETIMEDOUT;
+	}
+
+	return 0;
+}
+
+static void npcx_lct_set_alarm_time(struct lct_reg *const reg_base, int32_t seconds)
+{
+	uint32_t weeks;
+
+	weeks = seconds / SEC_PER_WEEK;
+#if defined(CONFIG_COUNTER_NPCX_NPCXN_V2)
+	reg_base->LCTWEEKM = (weeks >> 8) & 0xf;
+#endif
+	reg_base->LCTWEEK = weeks & 0xff;
+	seconds %= SEC_PER_WEEK;
+	reg_base->LCTDAY = seconds / SEC_PER_DAY;
+	seconds %= SEC_PER_DAY;
+	reg_base->LCTHOUR = seconds / SEC_PER_HOUR;
+	seconds %= SEC_PER_HOUR;
+	reg_base->LCTMINUTE = seconds / SEC_PER_MIN;
+	reg_base->LCTSECOND = seconds % SEC_PER_MIN;
+}
+
+static int counter_npcx_lct_cancel_alarm(const struct device *dev, uint8_t chan_id)
+{
+	const struct counter_npcx_lct_config *const config = dev->config;
+	struct counter_npcx_lct_data *data = dev->data;
+	struct lct_reg *const reg_base = config->reg_base;
+	int ret = 0;
+
+	if (chan_id != 0) {
+		LOG_ERR("Invalid channel id %u", chan_id);
+		return -ENOTSUP;
+	}
+
+	k_sem_take(&data->lock, K_FOREVER);
+
+	ret = npcx_lct_enable(reg_base, false);
+	if (ret != 0) {
+		LOG_ERR("disable LCT failed");
+		ret = -EBUSY;
+		goto return_exit;
+	}
+	reg_base->LCTCONT &= ~BIT(NPCX_LCTCONT_LCTEVEN);
+
+#if defined(CONFIG_COUNTER_NPCX_NPCXN_V2)
+	reg_base->LCTWEEKM = 0;
+#endif
+	reg_base->LCTWEEK = 0;
+	reg_base->LCTDAY = 0;
+	reg_base->LCTHOUR = 0;
+	reg_base->LCTMINUTE = 0;
+	reg_base->LCTSECOND = 0;
+
+	data->alarm_cb = NULL;
+	data->user_data = NULL;
+
+return_exit:
+	k_sem_give(&data->lock);
+
+	return ret;
+}
+
+static int counter_npcx_lct_start(const struct device *dev)
+{
+
+	const struct counter_npcx_lct_config *const config = dev->config;
+	struct counter_npcx_lct_data *data = dev->data;
+	struct lct_reg *const reg_base = config->reg_base;
+	int ret = 0;
+
+	k_sem_take(&data->lock, K_FOREVER);
+
+	if (IS_BIT_SET(reg_base->LCTCONT, NPCX_LCTCONT_LCTEN)) {
+		ret = -EALREADY;
+		goto return_exit;
+	}
+
+	ret = npcx_lct_enable(reg_base, true);
+	if (ret != 0) {
+		LOG_ERR("enable LCT failed");
+		ret = -EBUSY;
+		goto return_exit;
+	}
+
+return_exit:
+	k_sem_give(&data->lock);
+
+	return ret;
+}
+static int counter_npcx_lct_stop(const struct device *dev)
+{
+	const struct counter_npcx_lct_config *const config = dev->config;
+	struct counter_npcx_lct_data *data = dev->data;
+	struct lct_reg *const reg_base = config->reg_base;
+	int ret = 0;
+
+	k_sem_take(&data->lock, K_FOREVER);
+
+	if (!IS_BIT_SET(reg_base->LCTCONT, NPCX_LCTCONT_LCTEN)) {
+		/* Already stop, nothing to do. */
+		goto return_exit;
+	}
+
+	ret = npcx_lct_enable(reg_base, false);
+	if (ret != 0) {
+		LOG_ERR("disable LCT failed");
+		ret = -EBUSY;
+		goto return_exit;
+	}
+
+return_exit:
+	k_sem_give(&data->lock);
+
+	return ret;
+}
+static int counter_npcx_lct_get_value(const struct device *dev, uint32_t *ticks)
+{
+	const struct counter_npcx_lct_config *const config = dev->config;
+	struct lct_reg *const reg_base = config->reg_base;
+	struct counter_npcx_lct_data *data = dev->data;
+	uint32_t second;
+	uint8_t week, day, hour, minute;
+	uint16_t weekm;
+
+	k_sem_take(&data->lock, K_FOREVER);
+
+	do {
+		weekm = LCT_REG_WEEKM(reg_base);
+		week = reg_base->LCTWEEK;
+		day = reg_base->LCTDAY;
+		hour = reg_base->LCTHOUR;
+		minute = reg_base->LCTMINUTE;
+		second = reg_base->LCTSECOND;
+	} while (weekm != LCT_REG_WEEKM(reg_base) || week != reg_base->LCTWEEK ||
+		 day != reg_base->LCTDAY || hour != reg_base->LCTHOUR ||
+		 minute != reg_base->LCTMINUTE || second != reg_base->LCTSECOND);
+
+	weekm = (weekm << 8) + week;
+
+	*ticks = weekm * SEC_PER_WEEK + day * SEC_PER_DAY + hour * SEC_PER_HOUR +
+		 minute * SEC_PER_MIN + second;
+
+	k_sem_give(&data->lock);
+
+	return 0;
+}
+
+static int counter_npcx_lct_set_alarm(const struct device *dev, uint8_t chan_id,
+				      const struct counter_alarm_cfg *alarm_cfg)
+{
+	const struct counter_npcx_lct_config *const config = dev->config;
+	struct counter_npcx_lct_data *data = dev->data;
+	struct lct_reg *const reg_base = config->reg_base;
+	int ret;
+
+	if (chan_id != 0) {
+		LOG_ERR("Invalid channel id %u", chan_id);
+		ret = -ENOTSUP;
+		goto return_exit;
+	}
+
+	/*
+	 * Interrupts are only triggered when the counter reaches 0.
+	 * So only relative alarms are supported.
+	 */
+	if (alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) {
+		LOG_ERR("Invalid flags %x", alarm_cfg->flags);
+		ret = -ENOTSUP;
+		goto return_exit;
+	}
+
+	if (data->alarm_cb != NULL) {
+		ret = -EBUSY;
+		goto return_exit;
+	}
+
+	if (alarm_cfg->ticks > COUNTER_NPCX_LCT_MAX_SECOND) {
+		ret = -EINVAL;
+		goto return_exit;
+	}
+
+	k_sem_take(&data->lock, K_FOREVER);
+
+	data->alarm_cb = alarm_cfg->callback;
+	data->user_data = alarm_cfg->user_data;
+
+	npcx_lct_set_alarm_time(reg_base, alarm_cfg->ticks);
+	/* Clear pending LCT event */
+	reg_base->LCTSTAT |= BIT(NPCX_LCTSTAT_LCTEVST);
+
+	reg_base->LCTCONT |= BIT(NPCX_LCTCONT_LCTEVEN);
+
+	if (config->pwr_by_vsby == true) {
+		reg_base->LCTCONT |= BIT(NPCX_LCTCONT_LCTPSLEN);
+	}
+
+	ret = npcx_lct_enable(reg_base, true);
+
+return_exit:
+	k_sem_give(&data->lock);
+
+	return ret;
+}
+
+static uint32_t counter_npcx_get_pending_int(const struct device *dev)
+{
+	const struct counter_npcx_lct_config *const config = dev->config;
+	struct lct_reg *const reg_base = config->reg_base;
+
+	return reg_base->LCTSTAT & NPCX_LCT_STAT_EV_MASK;
+}
+
+static const struct counter_driver_api counter_npcx_lct_api = {
+	.start = counter_npcx_lct_start,
+	.stop = counter_npcx_lct_stop,
+	.get_value = counter_npcx_lct_get_value,
+	.set_alarm = counter_npcx_lct_set_alarm,
+	.cancel_alarm = counter_npcx_lct_cancel_alarm,
+	.get_pending_int = counter_npcx_get_pending_int,
+};
+
+static int counter_npcx_lct_init(const struct device *dev)
+{
+	const struct counter_npcx_lct_config *const config = dev->config;
+	struct counter_npcx_lct_data *const data = dev->data;
+	struct lct_reg *const reg_base = config->reg_base;
+
+#if defined(CONFIG_COUNTER_NPCX_NPCXN_V1) || defined(CONFIG_COUNTER_NPCX_NPCXN_V2)
+	npcx_miwu_init_dev_callback(&data->lct_wui_cb, &config->lct_wui, counter_npcx_lct_isr, dev);
+	npcx_miwu_manage_callback(&data->lct_wui_cb, true);
+	npcx_miwu_interrupt_configure(&config->lct_wui, NPCX_MIWU_MODE_EDGE, NPCX_MIWU_TRIG_HIGH);
+	/* Enable irq of t0-out expired event */
+	npcx_miwu_irq_enable(&config->lct_wui);
+
+	reg_base->LCTCONT |= BIT(NPCX_LCTCONT_LCT_CLK_EN);
+
+#endif
+#if defined(CONFIG_COUNTER_NPCX_NPCKN)
+	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), counter_npcx_lct_isr,
+		    DEVICE_DT_INST_GET(0), 0);
+	irq_enable(DT_INST_IRQN(0));
+#endif
+
+	k_sem_init(&data->lock, 1, 1);
+
+	if (config->pwr_by_vsby == true) {
+		reg_base->LCTCONT |= BIT(NPCX_LCTCONT_LCT_VSBY_PWR);
+
+	} else {
+		reg_base->LCTCONT &= ~BIT(NPCX_LCTCONT_LCT_VSBY_PWR);
+	}
+
+	return 0;
+}
+
+static const struct counter_npcx_lct_config npcx_lct_cfg = {
+	.info = {
+			.channels = 1,
+		},
+	.reg_base = (struct lct_reg *)DT_INST_REG_ADDR(0),
+	.pwr_by_vsby = DT_INST_PROP(0, pwr_by_vsby),
+#if defined(CONFIG_COUNTER_NPCX_NPCKN)
+	.irq = DT_INST_IRQN(0),
+#endif
+#if defined(CONFIG_COUNTER_NPCX_NPCXN_V1) || defined(CONFIG_COUNTER_NPCX_NPCXN_V2)
+	.lct_wui = NPCX_DT_WUI_ITEM_BY_NAME(0, lct_wui),
+#endif
+};
+
+static struct counter_npcx_lct_data npcx_lct_data;
+
+DEVICE_DT_INST_DEFINE(0, counter_npcx_lct_init, NULL, &npcx_lct_data, &npcx_lct_cfg, POST_KERNEL,
+		      CONFIG_COUNTER_INIT_PRIORITY, &counter_npcx_lct_api);

--- a/dts/arm/nuvoton/npck/npck3.dtsi
+++ b/dts/arm/nuvoton/npck/npck3.dtsi
@@ -265,6 +265,16 @@
 				status = "disabled";
 			};
 		};
+
+		lct0: lct@400dd000 {
+			compatible = "nuvoton,npck-lct";
+			reg = <0x400dd000 0x10>;
+			interrupts = <17 4>;
+			/* The maximum counter value is (16 weeks - 1 second) */
+			maximum-cnt-in-sec = <9676799>;
+			pwr-by-vsby;
+			status = "disabled";
+		};
 	};
 
 	soc-id {

--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -543,6 +543,16 @@
 			#size-cells = <0>;
 			status = "disabled";
 		};
+
+		lct0: lct@400d7000 {
+			compatible = "nuvoton,npcx-lct-v2";
+			reg = <0x400d7000 0x10>;
+			lct-wui = <&wui_lct>;
+			/* The maximum counter value is (1025 weeks - 1 second) */
+			maximum-cnt-in-sec = <619919999>;
+			pwr-by-vsby;
+			status = "disabled";
+		};
 	};
 
 	soc-if {

--- a/dts/arm/nuvoton/npcx/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9.dtsi
@@ -420,6 +420,16 @@
 			reg-io-width = <1>;
 			status = "disabled";
 		};
+
+		lct0: lct@400d7000 {
+			compatible = "nuvoton,npcx-lct-v1";
+			reg = <0x400d7000 0x10>;
+			lct-wui = <&wui_lct>;
+			/* The maximum counter value is (16 weeks - 1 second) */
+			maximum-cnt-in-sec = <9676799>;
+			pwr-by-vsby;
+			status = "disabled";
+		};
 	};
 
 	soc-id {

--- a/dts/bindings/counter/nuvoton,npck-lct.yaml
+++ b/dts/bindings/counter/nuvoton,npck-lct.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton, NPCK-LCT node for npck variant
+
+compatible: "nuvoton,npck-lct"
+
+include: ["nuvoton,npcx-lct-base.yaml"]
+
+properties:
+  maximum-cnt-in-sec:
+    type: int
+    required: true
+    const: 9676799
+    description: |
+      The maximum count that the LCT module can support.
+      One count means 1 second.
+      Npck can support (16 weeks - 1 second).

--- a/dts/bindings/counter/nuvoton,npcx-lct-base.yaml
+++ b/dts/bindings/counter/nuvoton,npcx-lct-base.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton, NPCX-LCT node
+
+compatible: "nuvoton,npcx-lct-base"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  pwr-by-vsby:
+    type: boolean
+    description: |
+      Select the LCT power supply source to VSBY.

--- a/dts/bindings/counter/nuvoton,npcx-lct-v1.yaml
+++ b/dts/bindings/counter/nuvoton,npcx-lct-v1.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2025 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton, NPCX-LCT Version 1 node for npcx variant
+
+compatible: "nuvoton,npcx-lct-v1"
+
+include: ["nuvoton,npcx-lct-base.yaml"]
+
+properties:
+  lct-wui:
+    type: phandle
+    required: true
+    description: |
+        Mapping table between Wake-Up Input (WUI) and LCT count down reaches zero.
+        For example,
+           lct-wui = <&wui_lct>;
+
+  maximum-cnt-in-sec:
+    type: int
+    required: true
+    const: 9676799
+    description: |
+      The maximum count that the LCT module can support.
+      One count means 1 second.
+      This version can support (16 weeks - 1 second).

--- a/dts/bindings/counter/nuvoton,npcx-lct-v2.yaml
+++ b/dts/bindings/counter/nuvoton,npcx-lct-v2.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton, NPCX-LCT Version 2 node for npcx variant
+
+compatible: "nuvoton,npcx-lct-v2"
+
+include: ["nuvoton,npcx-lct-base.yaml"]
+
+properties:
+  lct-wui:
+    type: phandle
+    required: true
+    description: |
+        Mapping table between Wake-Up Input (WUI) and LCT count down reaches zero.
+        For example,
+           lct-wui = <&wui_lct>;
+
+  maximum-cnt-in-sec:
+    type: int
+    required: true
+    const: 619919999
+    description: |
+      The maximum count that the LCT module can support.
+      One count means 1 second.
+      This version can support (1025 weeks - 1 second).

--- a/soc/nuvoton/npcx/common/npckn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npckn/include/reg_def.h
@@ -1853,10 +1853,6 @@ struct lct_reg {
 	volatile uint8_t reserved5;
 	/* 0x00C: LCT Weeks */
 	volatile uint8_t LCTWEEK;
-#if DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npcx_lct_v2)
-	/* 0x00D: LCT Weeks MSB */
-	volatile uint8_t LCTWEEKM;
-#endif
 };
 
 #define NPCX_LCTCONT_LCTEN        0

--- a/soc/nuvoton/npcx/common/npckn/registers.c
+++ b/soc/nuvoton/npcx/common/npckn/registers.c
@@ -207,12 +207,7 @@ NPCX_REG_OFFSET_CHECK(mbi_reg, MBICCON, 0x070);
 NPCX_REG_OFFSET_CHECK(lct_reg, LCTCONT, 0x002);
 NPCX_REG_OFFSET_CHECK(lct_reg, LCTHOUR, 0x008);
 NPCX_REG_OFFSET_CHECK(lct_reg, LCTWEEK, 0x00c);
-#if DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npcx_lct_v2)
-NPCX_REG_OFFSET_CHECK(lct_reg, LCTWEEKM, 0x00d);
-NPCX_REG_SIZE_CHECK(lct_reg, 0x00e);
-#else
 NPCX_REG_SIZE_CHECK(lct_reg, 0x00d);
-#endif
 
 /* GDMA register structure check */
 NPCX_REG_SIZE_CHECK(gdma_reg, 0x01C);

--- a/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
@@ -2236,4 +2236,43 @@ struct gdma_reg {
 #define NPCX_DMACTL_BMSAFIX              30
 #define NPCX_DMACTL_BMDAFIX              31
 
+/* LCT (Long Countdown Timer) registers */
+struct lct_reg {
+	/* 0x000-0x001 */
+	volatile uint8_t reserved1[2];
+	/* 0x002: LCT Control */
+	volatile uint8_t LCTCONT;
+	/* 0x003 */
+	volatile uint8_t reserved2;
+	/* 0x004: LCT Status */
+	volatile uint8_t LCTSTAT;
+	/* 0x005: LCT Seconds */
+	volatile uint8_t LCTSECOND;
+	/* 0x006: LCT Minutes */
+	volatile uint8_t LCTMINUTE;
+	/* 0x007 */
+	volatile uint8_t reserved3;
+	/* 0x008: LCT Hours */
+	volatile uint8_t LCTHOUR;
+	/* 0x009 */
+	volatile uint8_t reserved4;
+	/* 0x00A: LCT Days */
+	volatile uint8_t LCTDAY;
+	/* 0x00B */
+	volatile uint8_t reserved5;
+	/* 0x00C: LCT Weeks */
+	volatile uint8_t LCTWEEK;
+#if DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npcx_lct_v2)
+	/* 0x00D: LCT Weeks MSB */
+	volatile uint8_t LCTWEEKM;
+#endif
+};
+
+#define NPCX_LCTCONT_LCTEN        0
+#define NPCX_LCTCONT_LCTEVEN      1
+#define NPCX_LCTCONT_LCTPSLEN     2
+#define NPCX_LCTCONT_LCT_CLK_EN   6
+#define NPCX_LCTCONT_LCT_VSBY_PWR 7
+#define NPCX_LCTSTAT_LCTEVST      0
+
 #endif /* _NUVOTON_NPCX_REG_DEF_H */

--- a/soc/nuvoton/npcx/common/npcxn/registers.c
+++ b/soc/nuvoton/npcx/common/npcxn/registers.c
@@ -242,3 +242,14 @@ NPCX_REG_OFFSET_CHECK(gdma_reg, CONTROL, 0x000);
 NPCX_REG_OFFSET_CHECK(gdma_reg, SRCB, 0x004);
 NPCX_REG_OFFSET_CHECK(gdma_reg, DSTB, 0x008);
 NPCX_REG_OFFSET_CHECK(gdma_reg, TCNT, 0x00C);
+
+/* LCT register structure check */
+NPCX_REG_OFFSET_CHECK(lct_reg, LCTCONT, 0x002);
+NPCX_REG_OFFSET_CHECK(lct_reg, LCTHOUR, 0x008);
+NPCX_REG_OFFSET_CHECK(lct_reg, LCTWEEK, 0x00c);
+#if DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npcx_lct_v2)
+NPCX_REG_OFFSET_CHECK(lct_reg, LCTWEEKM, 0x00d);
+NPCX_REG_SIZE_CHECK(lct_reg, 0x00e);
+#else
+NPCX_REG_SIZE_CHECK(lct_reg, 0x00d);
+#endif


### PR DESCRIPTION
This PR introduces LCT driver support for NPCXn and NPCKn variants.