### PR TITLE
modules: nrf_wifi: add missing Kconfig dependency

### DIFF
--- a/modules/nrf_wifi/Kconfig
+++ b/modules/nrf_wifi/Kconfig
@@ -6,6 +6,7 @@ config ZEPHYR_NRF_WIFI_MODULE
 
 config ZVFS_OPEN_ADD_SIZE_NRF70_ENABLE_DUAL_VIF
 	int "Number of socket descriptors needed by nrf wifi driver"
+	depends on NRF70_ENABLE_DUAL_VIF
 	default 8
 
 source "modules/nrf_wifi/bus/Kconfig"

--- a/tests/lib/fdtable/Kconfig
+++ b/tests/lib/fdtable/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Embeint Pty Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+config ZVFS_OPEN_ADD_SIZE_TEST
+	int
+	default 1
+
+source "Kconfig.zephyr"


### PR DESCRIPTION
`ZVFS_OPEN_ADD_SIZE_NRF70_ENABLE_DUAL_VIF` should only exist in the build if `NRF70_ENABLE_DUAL_VIF`, not for every application in tree.