### PR TITLE
net: lib: sockets: add socket service fd requirement

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -95,6 +95,13 @@ config NET_SOCKETS_SERVICE
 	  system needs as multiple services can be activated at the same time
 	  depending on network configuration.
 
+config ZVFS_OPEN_ADD_SIZE_SOCKETS_SERVICE
+	int "Socket service file descriptor requirements"
+	default 1
+	help
+	  The socket service opens a permanent eventfd, which consumes a file
+	  descriptor.
+
 config NET_SOCKETS_SERVICE_THREAD_PRIO
 	int "Priority of the socket service dispatcher thread"
 	default NUM_PREEMPT_PRIORITIES


### PR DESCRIPTION
The net socket service implementation permanently opens a file descriptor, which should be taken into account by the build system.