### PR TITLE
include: drivers: edac: add doxygen documentation to edac_synopsys.h

### DIFF
--- a/include/zephyr/drivers/edac.h
+++ b/include/zephyr/drivers/edac.h
@@ -24,6 +24,10 @@
  * @version 0.8.0
  * @ingroup io_interfaces
  * @{
+ *
+ * @defgroup edac_interface_ext Device-specific EDAC API extensions
+ * @{
+ * @}
  */
 
 /**

--- a/include/zephyr/drivers/edac/edac_synopsys.h
+++ b/include/zephyr/drivers/edac/edac_synopsys.h
@@ -4,50 +4,65 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended EDAC API of Synopsys DDR controller
+ * @ingroup edac_interface_ext
+ */
+
 #ifndef ZEPHYR_DRIVERS_EDAC_EDAC_SYNOPSYS_H_
 #define ZEPHYR_DRIVERS_EDAC_EDAC_SYNOPSYS_H_
 
+/**
+ * @brief Synopsys DDR controller EDAC driver
+ * @defgroup edac_synopsys_interface Synopsys DDR controller EDAC
+ * @ingroup edac_interface_ext
+ * @{
+ */
+
 #include <stdint.h>
 
-/* Callback data provided to function passed to notify_cb_set */
+/** Callback data provided to function passed to @ref edac_notify_callback_set */
 struct edac_synopsys_callback_data {
-	/* Number of corrected errors since last callback */
+	/** Number of corrected errors since last callback */
 	uint16_t corr_err_count;
-	/* Rank number of last corrected ECC error */
+	/** Rank number of last corrected ECC error */
 	uint8_t corr_err_rank;
-	/* Bank group number of last corrected ECC error */
+	/** Bank group number of last corrected ECC error */
 	uint8_t corr_err_bg;
-	/* Bank number of last corrected ECC error */
+	/** Bank number of last corrected ECC error */
 	uint8_t corr_err_bank;
-	/* Row number of last corrected ECC error */
+	/** Row number of last corrected ECC error */
 	uint32_t corr_err_row;
-	/* Column number of last corrected ECC error */
+	/** Column number of last corrected ECC error */
 	uint8_t corr_err_col;
-	/* Syndrome (data pattern) of last corrected ECC error */
+	/** Syndrome (data pattern) of last corrected ECC error */
 	uint64_t corr_err_syndrome;
-	/* Syndrome ECC bits for last corrected ECC error */
+	/** Syndrome ECC bits for last corrected ECC error */
 	uint8_t corr_err_syndrome_ecc;
-	/* Bitmask of corrected error bits in data word */
+	/** Bitmask of corrected error bits in data word */
 	uint64_t corr_err_bitmask;
-	/* Bitmask of corrected error bits in ECC word */
+	/** Bitmask of corrected error bits in ECC word */
 	uint8_t corr_err_bitmask_ecc;
 
-	/* Number of uncorrected errors since last callback */
+	/** Number of uncorrected errors since last callback */
 	uint16_t uncorr_err_count;
-	/* Rank number of last uncorrected ECC error */
+	/** Rank number of last uncorrected ECC error */
 	uint8_t uncorr_err_rank;
-	/* Bank group number of last uncorrected ECC error */
+	/** Bank group number of last uncorrected ECC error */
 	uint8_t uncorr_err_bg;
-	/* Bank number of last uncorrected ECC error */
+	/** Bank number of last uncorrected ECC error */
 	uint8_t uncorr_err_bank;
-	/* Row number of last uncorrected ECC error */
+	/** Row number of last uncorrected ECC error */
 	uint32_t uncorr_err_row;
-	/* Column number of last uncorrected ECC error */
+	/** Column number of last uncorrected ECC error */
 	uint8_t uncorr_err_col;
-	/* Syndrome (data pattern) of last uncorrected ECC error */
+	/** Syndrome (data pattern) of last uncorrected ECC error */
 	uint64_t uncorr_err_syndrome;
-	/* Syndrome ECC bits of last uncorrected ECC error */
+	/** Syndrome ECC bits of last uncorrected ECC error */
 	uint8_t uncorr_err_syndrome_ecc;
 };
+
+/** @} */
 
 #endif /* ZEPHYR_DRIVERS_EDAC_EDAC_SYNOPSYS_H_ */

--- a/include/zephyr/drivers/edac/edac_synopsys.h
+++ b/include/zephyr/drivers/edac/edac_synopsys.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_DRIVERS_EDAC_SYNOPSYS_H_
-#define ZEPHYR_DRIVERS_EDAC_SYNOPSYS_H_
+#ifndef ZEPHYR_DRIVERS_EDAC_EDAC_SYNOPSYS_H_
+#define ZEPHYR_DRIVERS_EDAC_EDAC_SYNOPSYS_H_
 
 #include <stdint.h>
 
@@ -50,4 +50,4 @@ struct edac_synopsys_callback_data {
 	uint8_t uncorr_err_syndrome_ecc;
 };
 
-#endif /* ZEPHYR_DRIVERS_EDAC_SYNOPSYS_H_ */
+#endif /* ZEPHYR_DRIVERS_EDAC_EDAC_SYNOPSYS_H_ */


### PR DESCRIPTION
This ensures the vendor-specific API provided in this header file is fully documented and exposed in our API documentation.

https://builds.zephyrproject.io/zephyr/pr/98553/docs/doxygen/html/group__edac__interface__ext.html

cc @robhancocksed 
