### PR TITLE
doc: contribute: guidelines: Don't encourage to "re-request review"

### DIFF
--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -881,8 +881,7 @@ attention needed and it will be ready for merge sooner than later:
    is green
 
 #. If you get request for changes and submit a change to address them, make
-   sure you click the "Re-request review" button on the GitHub UI to notify
-   those who asked for the changes
+   sure to notify those who asked for the changes
 
 Identifying Contribution Origin
 ===============================


### PR DESCRIPTION
Pressing the "re-request review" tends to not be a good way of requesting a re-review as it hides in the reviewer list the fact that the PR had been rejected.
If the reviewer does not dismiss their review, the "requested changes"/rejection remains in fact still applicable. This has created confusion in between some people who then are not aware a PR is still blocked.

On the other hand, reviewers will normally get notified by all changes in the PR. So an extra notification tends to be unnecessary, but, if needed it would be better for the author to just write a comment pinging the reviewers.