### PR TITLE
boards: arduino: fix long startup time with WIFI enabled

### DIFF
--- a/boards/arduino/giga_r1/arduino_giga_r1.dtsi
+++ b/boards/arduino/giga_r1/arduino_giga_r1.dtsi
@@ -60,6 +60,7 @@ sdhc: &sdmmc1 {
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	sdhi-on-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+	power-delay-ms = <50>;
 	min-bus-freq = <DT_FREQ_K(400)>;
 	max-bus-freq = <DT_FREQ_M(208)>;
 	hw-flow-control;

--- a/boards/arduino/nicla_vision/arduino_nicla_vision.dtsi
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision.dtsi
@@ -48,6 +48,7 @@ sdhc: &sdmmc2 {
 		     &sdmmc2_ck_pd6 &sdmmc2_cmd_pd7>;
 	pinctrl-names = "default";
 	sdhi-on-gpios = <&gpiog 4 GPIO_ACTIVE_HIGH>;
+	power-delay-ms = <50>;
 	min-bus-freq = <DT_FREQ_K(400)>;
 	max-bus-freq = <DT_FREQ_M(208)>;
 	hw-flow-control;

--- a/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
@@ -237,6 +237,7 @@ sdhc: &sdmmc1 {
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	sdhi-on-gpios = <&gpioj 1 GPIO_ACTIVE_HIGH>;
+	power-delay-ms = <50>;
 	interrupts = <49 0>;
 	interrupt-names = "event";
 	min-bus-freq = <DT_FREQ_K(400)>;


### PR DESCRIPTION
Wi-Fi support for these boards is being introduced in this release; however, boot time with `CONFIG_WIFI` is currently increased by over 5 seconds waiting for the card to initialize.
Turns out this is mostly due to the default SDHC `power-delay-ms`, which is an unnecessarily long 500 ms. Shortening this to 50 ms greatly improves boot time while keeping compatibility with the controller spec.

Tested on Arduino Giga R1.