### PR TITLE
Bluetooth: Classic: HFP_AG: Add callback `redial` to get number

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_ag.h
+++ b/include/zephyr/bluetooth/classic/hfp_ag.h
@@ -197,6 +197,30 @@ struct bt_hfp_ag_cb {
 	 */
 	int (*number_call)(struct bt_hfp_ag *ag, const char *number);
 
+	/** HF last number redial request Callback
+	 *
+	 *  If this callback is provided it will be called whenever a
+	 *  last number redial request is received from HF via `AT+BLDN` command.
+	 *  When the callback is triggered, the application needs to provide
+	 *  the last dialed phone number.
+	 *  If the callback is invalid, the last number redial from HF
+	 *  cannot be supported.
+	 *
+	 *  The application should:
+	 *  1. Retrieve the last dialed phone number from its call history
+	 *  2. Copy the phone number to the provided buffer
+	 *
+	 *  @param ag HFP AG object.
+	 *  @param number Buffer to store the last dialed phone number.
+	 *                The buffer size is @kconfig{BT_HFP_AG_PHONE_NUMBER_MAX_LEN} + 1,
+	 *                and should be null-terminated.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 *          If successful, the AG will proceed with the call setup procedure.
+	 *          If error, an ERROR response will be sent to HF.
+	 */
+	int (*redial)(struct bt_hfp_ag *ag, char number[CONFIG_BT_HFP_AG_PHONE_NUMBER_MAX_LEN + 1]);
+
 	/** HF outgoing Callback
 	 *
 	 *  If this callback is provided it will be called whenever a

--- a/subsys/bluetooth/host/classic/hfp_ag_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_ag_internal.h
@@ -245,10 +245,6 @@ struct bt_hfp_ag {
 	/* ongoing calls work */
 	struct k_work_delayable ongoing_call_work;
 
-	/* last dialing number and type */
-	char last_number[CONFIG_BT_HFP_AG_PHONE_NUMBER_MAX_LEN + 1];
-	uint8_t type;
-
 	/* SCO Connection Object */
 	struct bt_sco_chan sco_chan;
 


### PR DESCRIPTION
If a phone was made during the previous SLC, AG cannot properly process the redial request sent by HF after reconnecting.

Add a callback `redial` to get the last dial number from the upper layer when `AT+BLDN` command is received.

If the callback is not provided or the error is returned after the callback returned, send error response to the HF.


