### PR TITLE
drivers: bluetooth: silabs_siwx91x: Add RF power config

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -186,6 +186,7 @@ config BT_SILABS_SIWX91X
 	depends on DT_HAS_SILABS_SIWX91X_BT_HCI_ENABLED
 	select WISECONNECT_NETWORK_STACK
 	select ENTROPY_GENERATOR
+	select BT_HCI_SETUP
 	help
 	  Use Silicon Labs Wiseconnect 3.x Bluetooth library to connect to the controller.
 

--- a/drivers/bluetooth/hci/hci_silabs_siwx91x.c
+++ b/drivers/bluetooth/hci/hci_silabs_siwx91x.c
@@ -12,13 +12,51 @@
 LOG_MODULE_REGISTER(bt_hci_driver_siwg917);
 
 #include "rsi_ble.h"
+#include "rsi_ble_common_config.h"
+#define BLE_RF_POWER_INDEX     0x0006
+#define BT_OP_VS_RF_POWER_MODE BT_OP(BT_OGF_VS, BLE_RF_POWER_INDEX)
+#define BT_LE_MODE             2
 
+static int rsi_bt_driver_send_tx_pwr_vs_cmd(const struct device *dev, uint8_t protocol_mode,
+					    uint8_t le_tx_power_index);
 static void siwx91x_bt_resp_rcvd(uint16_t status, rsi_ble_event_rcp_rcvd_info_t *resp_buf);
 
 struct hci_data {
 	bt_hci_recv_t recv;
 	rsi_data_packet_t rsi_data_packet;
 };
+
+/**
+ * @brief Send RF power mode configuration command to controller
+ * @param dev Pointer to the device structure
+ * @return 0 on success, negative errno on failure
+ */
+static int rsi_bt_driver_send_tx_pwr_vs_cmd(const struct device *dev, uint8_t protocol_mode,
+					    uint8_t le_tx_power_index)
+{
+	struct net_buf *buf;
+	int err;
+
+	/* Allocate HCI command buffer with timeout */
+	buf = bt_hci_cmd_alloc(K_FOREVER);
+	if (!buf) {
+		LOG_ERR("Failed to allocate HCI command buffer");
+		return -ENOMEM;
+	}
+	net_buf_add_u8(buf, protocol_mode);
+	net_buf_add_u8(buf, le_tx_power_index);
+	LOG_DBG("Sending RF Power Mode command (OCF 0x%04X) with power index %d",
+		BLE_RF_POWER_INDEX, le_tx_power_index);
+
+	err = bt_hci_cmd_send_sync(BT_OP_VS_RF_POWER_MODE, buf, NULL);
+	if (err) {
+		LOG_ERR("RF Power Mode command failed: %d", err);
+		return err;
+	}
+
+	LOG_DBG("RF Power Mode configured successfully");
+	return 0;
+}
 
 static int siwx91x_bt_open(const struct device *dev, bt_hci_recv_t recv)
 {
@@ -30,6 +68,17 @@ static int siwx91x_bt_open(const struct device *dev, bt_hci_recv_t recv)
 		hci->recv = recv;
 	}
 	return status ? -EIO : 0;
+}
+
+static int siwx91x_bt_setup(const struct device *dev, const struct bt_hci_setup_params *params)
+{
+	int err = rsi_bt_driver_send_tx_pwr_vs_cmd(dev, BT_LE_MODE, RSI_BLE_PWR_INX);
+
+	if (err < 0) {
+		LOG_ERR("Failed to send RF power config command: %d", err);
+		return err;
+	}
+	return 0;
 }
 
 static int siwx91x_bt_send(const struct device *dev, struct net_buf *buf)
@@ -98,6 +147,7 @@ static void siwx91x_bt_resp_rcvd(uint16_t status, rsi_ble_event_rcp_rcvd_info_t 
 static DEVICE_API(bt_hci, siwx91x_api) = {
 	.open = siwx91x_bt_open,
 	.send = siwx91x_bt_send,
+	.setup = siwx91x_bt_setup,
 };
 
 #define HCI_DEVICE_INIT(inst)                                                                      \


### PR DESCRIPTION
Add vendor-specific RF power mode configuration during HCI setup
for SiLabs SiWx91x devices. This configures the BLE TX power
index in the controller's RF subsystem.

The implementation sends a vendor command (OCF 0x0006) with
protocol mode (2) and power index (RSI_BLE_PWR_INX) during the
setup phase. This ensures proper RF power configuration before
normal Bluetooth operations begin.

Technical details:
- Uses bt_hci_cmd_alloc() with manual HCI header construction
- Command opcode: 0xFC06 (OGF=0x3F, OCF=0x0006)
- Parameters: protocol_mode=2, power_index from RSI_BLE_PWR_INX
- Executed during bt_hci_setup callback