### PR TITLE
Add fallback for on demand policy

### DIFF
--- a/doc/services/cpu_freq/policies/on_demand.rst
+++ b/doc/services/cpu_freq/policies/on_demand.rst
@@ -7,8 +7,13 @@ The On-Demand policy evaluates the current CPU load using the
 :ref:`CPU Load metric <cpu_load_metric>`, and compares it to the trigger threshold defined by the
 SoC P-state definition.
 
-The On-Demand policy will iterate through the defined P-states and select the first P-state of which
-the CPU load exceeds the defined threshold.
+The On-Demand policy will iterate through the defined P-states and select the first P-state for which
+the CPU load is greater than or equal to the defined threshold.
+
+If no P-state matches (i.e., the CPU load is below all thresholds), the policy will select the
+last P-state in the soc_pstates array (the lowest performance state). This is intrinsic to the
+policy:  P-states must be defined in decreasing threshold order in devicetree, and the last
+P-state will be used for loads below all thresholds.
 
 For an example of the on-demand policy refer to the :zephyr:code-sample:`cpu_freq_on_demand` sample.
 

--- a/subsys/cpu_freq/cpu_freq.c
+++ b/subsys/cpu_freq/cpu_freq.c
@@ -12,6 +12,17 @@
 
 LOG_MODULE_REGISTER(cpu_freq, CONFIG_CPU_FREQ_LOG_LEVEL);
 
+/* Build-time validation: require performance_states node with at least one child */
+#define PSTATE_ROOT DT_PATH(performance_states)
+#define CPU_FREQ_COUNT_OKAY_CHILD(_node_id) + 1
+enum { CPU_FREQ_PSTATE_COUNT = 0 DT_FOREACH_CHILD_STATUS_OKAY(PSTATE_ROOT,
+		CPU_FREQ_COUNT_OKAY_CHILD) };
+
+BUILD_ASSERT(DT_NODE_EXISTS(PSTATE_ROOT),
+	"cpu_freq: performance_states node missing in devicetree");
+BUILD_ASSERT(CPU_FREQ_PSTATE_COUNT > 0,
+	"cpu_freq: No P-states defined in devicetree");
+
 #if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
 
 static struct k_ipi_work cpu_freq_work;

--- a/tests/subsys/cpu_freq/policies/on_demand/src/main.c
+++ b/tests/subsys/cpu_freq/policies/on_demand/src/main.c
@@ -15,6 +15,21 @@ LOG_MODULE_REGISTER(cpu_freq_on_demand_test, LOG_LEVEL_INF);
 
 #define WAIT_US 1000
 
+extern const struct pstate *soc_pstates[];
+extern const size_t soc_pstates_count;
+
+/*
+ * Test that P-states are defined in decreasing load_threshold order in devicetree.
+ */
+ZTEST(cpu_freq_on_demand, test_pstates_order)
+{
+	for (int i = 1; i < soc_pstates_count; ++i) {
+		zassert_true(soc_pstates[i]->load_threshold <
+			soc_pstates[i-1]->load_threshold,
+			"P-states must be in decreasing threshold order");
+	}
+}
+
 /*
  * Test APIs of on_demand CPU frequency policy.
  */


### PR DESCRIPTION
In current on_demand policy, if it doesn't find a P-state with a threshold lower than the current load, it will fail to switch state. For example, if load went from 100% -> 0% suddenly as the chip would get stuck in a "turbo mode" meanwhile its load is low.

This commit add fallback mechanism for on-demand policy, that is if no P-state matches (i.e., the load is below all thresholds), the policy will fall back to the P-state with the lowest load_threshold (typically the lowest performance state).

See https://github.com/zephyrproject-rtos/zephyr/pull/98427  for some related discussions.