### PR TITLE
boards: *: doc: cleanups around "Arm Cortex"

### DIFF
--- a/boards/ambiq/apollo2_evb/doc/index.rst
+++ b/boards/ambiq/apollo2_evb/doc/index.rst
@@ -7,7 +7,7 @@ Hardware
 
 The Ambiq Apollo2 SoC provides the following hardware features:
 
-- ARM® Cortex® M4F core with a Floating Point Unit
+- ARM® Cortex®-M4F core with a Floating Point Unit
 - Up to 48 MHz operating frequency
 - 16 kB 2-way Associative Cache
 - Up to 1 MB of flash memory for code/data

--- a/boards/ambiq/apollo3_evb/doc/index.rst
+++ b/boards/ambiq/apollo3_evb/doc/index.rst
@@ -6,7 +6,7 @@ Hardware
 ********
 
 - Apollo3 Blue SoC with up to 96 MHz operating frequency
-- ARM® Cortex® M4F core
+- ARM® Cortex®-M4F core
 - 16 kB 2-way Associative/Direct-Mapped Cache per core
 - Up to 1 MB of flash memory for code/data
 - Up to 384 KB of low leakage / low power RAM for code/data

--- a/boards/ambiq/apollo3p_evb/doc/index.rst
+++ b/boards/ambiq/apollo3p_evb/doc/index.rst
@@ -6,7 +6,7 @@ Hardware
 ********
 
 - Apollo3 Blue Plus SoC with up to 96 MHz operating frequency
-- ARM® Cortex® M4F core
+- ARM® Cortex®-M4F core
 - 16 kB 2-way Associative/Direct-Mapped Cache per core
 - Up to 2 MB of flash memory for code/data
 - Up to 768 KB of low leakage / low power RAM for code/data

--- a/boards/ambiq/apollo4p_blue_kxr_evb/doc/index.rst
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/doc/index.rst
@@ -6,7 +6,7 @@ Hardware
 ********
 
 - Apollo4 Blue Plus SoC with upto 192 MHz operating frequency
-- ARM® Cortex® M4F core
+- ARM® Cortex®-M4F core
 - 64 kB 2-way Associative/Direct-Mapped Cache per core
 - Up to 2 MB of non-volatile memory (NVM) for code/data
 - Up to 2.75 MB of low leakage / low power RAM for code/data

--- a/boards/ambiq/apollo4p_evb/doc/index.rst
+++ b/boards/ambiq/apollo4p_evb/doc/index.rst
@@ -6,7 +6,7 @@ Hardware
 ********
 
 - Apollo4 Plus SoC with upto 192 MHz operating frequency
-- ARM® Cortex® M4F core
+- ARM® Cortex®-M4F core
 - 64 kB 2-way Associative/Direct-Mapped Cache per core
 - Up to 2 MB of non-volatile memory (NVM) for code/data
 - Up to 2.75 MB of low leakage / low power RAM for code/data

--- a/boards/ambiq/apollo510_evb/doc/index.rst
+++ b/boards/ambiq/apollo510_evb/doc/index.rst
@@ -6,7 +6,7 @@ Hardware
 ********
 
 - Apollo510 SoC with up to 250 MHz operating frequency
-- ARM® Cortex® M55 core
+- ARM® Cortex®-M55 core
 - 64 kB Instruction Cache and 64 kB Data Cache
 - Up to 4 MB of non-volatile memory (NVM) for code/data
 - Up to 3 MB of low leakage / low power RAM for code/data

--- a/boards/infineon/cyw920829m2evk_02/doc/index.rst
+++ b/boards/infineon/cyw920829m2evk_02/doc/index.rst
@@ -11,7 +11,7 @@ amplifier (PA). This provides enough link budget for the entire spectrum of Blue
 including industrial IoT applications, smart home, asset tracking, beacons and sensors, and
 medical devices.
 
-The system features Dual Arm® Cortex® - M33s for powering the MCU and Bluetooth subsystem with
+The system features Dual Arm® Cortex®-M33s for powering the MCU and Bluetooth subsystem with
 programmable and reconfigurable analog and digital blocks. In addition, on the kit, there is a
 suite of on-board peripherals including six-axis inertial measurement unit (IMU), thermistor,
 analog mic, user programmable buttons (2), LEDs (2), and RGB LED. There is also extensive GPIO

--- a/boards/infineon/kit_psc3m5_evk/doc/index.rst
+++ b/boards/infineon/kit_psc3m5_evk/doc/index.rst
@@ -4,7 +4,7 @@ Overview
 ********
 
 This is the standard evaluation board for the PSOC™ Control C3 family of MCU's. PSOC™ Control C3M5
-is a high-performance and low-power 32-bit single-core Arm® Cortex® M33-based MCU.
+is a high-performance and low-power 32-bit single-core Arm® Cortex®-M33-based MCU.
 In addition to the CPU subsystem, the devices contain advanced real-time control peripherals,
 such as a high-performance programmable analog subsystem, comparators, advanced timers with
 high-resolution capability, up to six SCBs, and two CAN FDs for communication.

--- a/boards/infineon/kit_xmc72_evk/doc/index.rst
+++ b/boards/infineon/kit_xmc72_evk/doc/index.rst
@@ -34,7 +34,7 @@ For more information about XMC7200D and KIT_XMC72_EVK:
 Kit Features
 =============
 
-- Evaluation board for XMC7200D-E272K8384 in BGA package with 272 pins, dual-core Arm®Cortex® M7 CPUs running at 350-MHz and an Arm® Cortex® M0+ CPU running at 100-MHz
+- Evaluation board for XMC7200D-E272K8384 in BGA package with 272 pins, dual-core Arm®Cortex®-M7 CPUs running at 350-MHz and an Arm® Cortex®-M0+ CPU running at 100-MHz
 - Full-system approach on the board, featuring Gigabit Ethernet PHY and connector, CAN FD transceiver, user LEDs, buttons, and potentiometer
 - M.2 interface connector for interfacing radio modules based on AIROC™ Wi-Fi & Bluetooth®combos (currently not - supported)
 - Headers compatible with Arduino for interfacing Arduino shields

--- a/boards/mikroe/mini_m4_for_stm32/doc/mikroe_mini_m4_for_stm32.rst
+++ b/boards/mikroe/mini_m4_for_stm32/doc/mikroe_mini_m4_for_stm32.rst
@@ -3,7 +3,7 @@
 Overview
 ********
 
-MINI-M4 for STM32 is a small ARM® Cortex™-M4 development board containing
+MINI-M4 for STM32 is a small ARM® Cortex |reg|-M4 development board containing
 an `STM32F415RG`_ microcontroller. It is pin compatible with PIC16F887 and
 PIC18(L)F45K20 microcontrollers and it perfectly fits into a standard DIP40
 socket. The board is equipped with a 16MHz SMD crystal oscillator, and

--- a/boards/rakwireless/rak11720/doc/index.rst
+++ b/boards/rakwireless/rak11720/doc/index.rst
@@ -19,7 +19,7 @@ supply and programming/debug interface is the base to plug a
 RAK11722 (WisBlock Core module with the RAK11720) in.
 
 - Apollo3 Blue SoC with up to 96 MHz operating frequency
-- ARM® Cortex® M4F core
+- ARM® Cortex®-M4F core
 - 16 kB 2-way Associative/Direct-Mapped Cache per core
 - Up to 1 MB of flash memory for code/data
 - Up to 384 KB of low leakage / low power RAM for code/data

--- a/boards/raytac/an54lq_db_15/doc/index.rst
+++ b/boards/raytac/an54lq_db_15/doc/index.rst
@@ -29,7 +29,7 @@ internal or external capacitors.
 - A recommended 3rd-party module by Nordic Semiconductor.
 - Intended for Bluetooth specification BT6
 - Intended for FCC, IC, CE, Telec (MIC), KC, SRRC, NCC, RCM, WPC
-- 128 MHz ARM® Cortex™-M33 processor with TrustZone® technology
+- 128 MHz ARM® Cortex |reg|-M33 processor with TrustZone® technology
 - 128 MHz RISC-V coprocessor with TrustZone® technology
 - 1.5MB Flash Memory / 256KB RAM
 - RoHS & Reach Compliant.

--- a/boards/raytac/mdbt50q_cx_40_dongle/doc/index.rst
+++ b/boards/raytac/mdbt50q_cx_40_dongle/doc/index.rst
@@ -14,7 +14,7 @@ Semiconductor nRF52840 ARM Cortex-M4F CPU and the following devices:
 - Supports BT5 Long Range Feature
 - Deployed Raytac MDBT50Q-P1M Module
 - Certifications: FCC, IC, CE, UKCA, Telec (MIC), KC, SRRC, NCC, RCM, WPC
-- 32-bit ARM® Cortex™ M4F CPU
+- 32-bit ARM® Cortex |reg| M4F CPU
 - 1MB Flash Memory / 256kB RAM
 - RoHS & Reach Compliant.
 - Dimension：26.2 x 15.1 x 6.8 mm (excluding Type C USB Connector)

--- a/boards/raytac/mdbt50q_db_33/doc/index.rst
+++ b/boards/raytac/mdbt50q_db_33/doc/index.rst
@@ -34,7 +34,7 @@ Hardware
 - BT5.2&BT5.1&BT5 Bluetooth Specification Certified
 - Supports BT5 Long Range Features
 - Certifications: FCC, IC, CE, Telec(MIC), KC, SRRC, NCC, RCM, WPC
-- 32-bit ARM® Cortex™ M4F CPU
+- 32-bit ARM® Cortex |reg| M4F CPU
 - 512kB Flash Memory/128kB RAM
 - RoHs & Reach Compliant.
 - 42 GPIO

--- a/boards/raytac/mdbt50q_db_40/doc/index.rst
+++ b/boards/raytac/mdbt50q_db_40/doc/index.rst
@@ -34,7 +34,7 @@ Hardware
 - BT5.2&BT5.1&BT5 Bluetooth Specification Certified
 - Supports BT5 Long Range Features
 - Certifications: FCC, IC, CE, Telec(MIC), KC, SRRC, NCC, RCM, WPC
-- 32-bit ARM® Cortex™ M4F CPU
+- 32-bit ARM® Cortex |reg| M4F CPU
 - 1MB Flash Memory/256kB RAM
 - RoHs & Reach Compliant.
 - 48 GPIO

--- a/boards/raytac/mdbt53_db_40/doc/index.rst
+++ b/boards/raytac/mdbt53_db_40/doc/index.rst
@@ -49,7 +49,7 @@ Hardware
 - Module Demo Board build by MDBT53-1M
 - Nordic nRF5340 SoC Solution
 - A recommended 3rd-party module by Nordic Semiconductor.
-- Dual-core Arm® Cortex® M33
+- Dual-core Arm® Cortex®-M33
 - 1MB/256KB Flash Memory; 512kB/ 64kB RAM
 - Supports BT5 Long Range Features
 - Bluetooth specification v5.2

--- a/boards/raytac/mdbt53v_db_40/doc/index.rst
+++ b/boards/raytac/mdbt53v_db_40/doc/index.rst
@@ -48,7 +48,7 @@ Hardware
 - Module Demo Board build by MDBT53V-1M
 - Nordic nRF5340 SoC Solution
 - A recommended 3rd-party module by Nordic Semiconductor.
-- Dual-core Arm® Cortex® M33
+- Dual-core Arm® Cortex®-M33
 - 1MB/256KB Flash Memory; 512kB/ 64kB RAM
 - Supports BT5 Long Range Features
 - Bluetooth specification v5.2

--- a/boards/silabs/dev_kits/sltb004a/doc/index.rst
+++ b/boards/silabs/dev_kits/sltb004a/doc/index.rst
@@ -11,7 +11,7 @@ Hardware
 ********
 
 - EFR32MG12 Mighty Gecko Wireless SoC with 38.4 MHz operating frequency
-- ARM® Cortex® M4 core with 256 kB RAM and 1024 kB Flash
+- ARM® Cortex®-M4 core with 256 kB RAM and 1024 kB Flash
 - Macronix ultra low power 8-Mbit SPI flash (MX25R8035F)
 - 2.4 GHz ceramic antenna for wireless transmission
 - Silicon Labs Si7021 relative humidity and temperature sensor

--- a/boards/silabs/dev_kits/sltb010a/doc/index.rst
+++ b/boards/silabs/dev_kits/sltb010a/doc/index.rst
@@ -8,7 +8,7 @@ Hardware
 ********
 
 - EFR32BG22 Blue Gecko Wireless SoC with upto 76.8 MHz operating frequency
-- ARM® Cortex® M33 core with 32 kB RAM and 512 kB Flash
+- ARM® Cortex®-M33 core with 32 kB RAM and 512 kB Flash
 - Macronix ultra low power 8-Mbit SPI flash (MX25R8035F)
 - 2.4 GHz ceramic antenna for wireless transmission
 - Silicon Labs Si7021 relative humidity and temperature sensor

--- a/boards/silabs/dev_kits/xg27_dk2602a/doc/index.rst
+++ b/boards/silabs/dev_kits/xg27_dk2602a/doc/index.rst
@@ -7,7 +7,7 @@ Hardware
 ********
 
 - EFR32BG27 Blue Gecko Wireless SoC with up to 76.8 MHz operating frequency
-- ARM® Cortex® M33 core with 64 kB RAM and 768 kB Flash
+- ARM® Cortex®-M33 core with 64 kB RAM and 768 kB Flash
 - Macronix ultra low power 8-Mbit SPI flash (MX25R8035F)
 - 2.4 GHz ceramic antenna for wireless transmission
 - Silicon Labs Si7021 relative humidity and temperature sensor

--- a/boards/st/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/st/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -11,7 +11,7 @@ Low Energy (BLE) SIG specification v5.0 and with IEEE 802.15.4-2011.
 - STM32 microcontroller in VFQFPN68 package
 - 2.4 GHz RF transceiver supporting Bluetooth® specification v5.0 and
   IEEE 802.15.4-2011 PHY and MAC
-- Dedicated Arm® 32-bit Cortex® M0+ CPU for real-time Radio layer
+- Dedicated Arm® 32-bit Cortex®-M0+ CPU for real-time Radio layer
 - Three user LEDs
 - Board connector: USB user with Micro-B
 - Two types of extension resources:

--- a/boards/st/nucleo_wba55cg/doc/nucleo_wba55cg.rst
+++ b/boards/st/nucleo_wba55cg/doc/nucleo_wba55cg.rst
@@ -12,13 +12,13 @@ easy expansion of the functionality of the STM32 Nucleo open development
 platform with a wide choice of specialized shields.
 
 - Ultra-low-power wireless STM32WBA55CG microcontroller based on the Arm®
-  Cortex®‑M33 core, featuring 1 Mbyte of flash memory and 128 Kbytes of SRAM in
+  Cortex®-M33 core, featuring 1 Mbyte of flash memory and 128 Kbytes of SRAM in
   a UFQFPN48 package
 
 - MCU RF board (MB1863):
 
   - 2.4 GHz RF transceiver supporting Bluetooth® specification v5.3
-  - Arm® Cortex® M33 CPU with TrustZone®, MPU, DSP, and FPU
+  - Arm® Cortex®-M33 CPU with TrustZone®, MPU, DSP, and FPU
   - Integrated PCB antenna
 
 - Three user LEDs

--- a/boards/st/stm32g071b_disco/doc/index.rst
+++ b/boards/st/stm32g071b_disco/doc/index.rst
@@ -3,7 +3,7 @@
 Overview
 ********
 The STM32G071B-DISCO Discovery board is a demonstration and development platform
-for the STMicroelectronics Arm® Cortex® -M0+ core-based STM32G071RB USB Type-C |reg|
+for the STMicroelectronics Arm® Cortex®-M0+ core-based STM32G071RB USB Type-C |reg|
 and Power Delivery microcontroller. The STM32G071B-DISCO Discovery board is
 presented with all necessary interfaces for easy connection and
 interoperability with other USB Type-C |reg| devices. The STM32G071B-DISCO Discovery

--- a/boards/toradex/verdin_imx8mp/doc/index.rst
+++ b/boards/toradex/verdin_imx8mp/doc/index.rst
@@ -28,8 +28,8 @@ Quoting NXP:
    industrial automation with high reliability. It is built to meet the needs of Smart Home,
    Building, City and Industry 4.0 applications.
 
-The Verdin iMX8M Plus integrates a total of 4 Arm Cortex™-A53 CPUs, operating at 1.6 GHz, alongside
-a single Arm Cortex™-M7F microcontroller operating at 800 MHz.
+The Verdin iMX8M Plus integrates a total of 4 Arm Cortex |reg|-A53 CPUs, operating at 1.6 GHz, alongside
+a single Arm Cortex |reg|-M7F microcontroller operating at 800 MHz.
 
 Regarding the Cortex-A53 cluster, it employs the ARMv8-A architecture as a mid-range and
 energy-efficient processor. With four cores in this cluster, each core is equipped with its own L1
@@ -53,8 +53,8 @@ Hardware
 ********
 
 - SoC name: NXP® i.MX 8M Plus
-- CPU Type:	4x Arm Cortex™-A53 (1.6 GHz)
-- Microcontroller:	1x Arm Cortex™-M7F (800 MHz)
+- CPU Type:	4x Arm Cortex |reg|-A53 (1.6 GHz)
+- Microcontroller:	1x Arm Cortex |reg|-M7F (800 MHz)
 
 - Memory:
 

--- a/boards/waveshare/nrf51_ble400/doc/index.rst
+++ b/boards/waveshare/nrf51_ble400/doc/index.rst
@@ -32,7 +32,7 @@ Features
 ========
 
 - 2.4 GHz multiprotocol RF transceiver
-- ARM® Cortex™-M0 32 bit processor
+- ARM® Cortex |reg|-M0 32 bit processor
 - 128 bit AES HW encryption
 - 256kB flash & 32kB RAM
 - Programmable Peripheral Interconnect (PPI)


### PR DESCRIPTION
* use the proper trademark symbol for Arm® Cortex®
  * [Cortex® is a registered trademark of Arm Limited](https://www.arm.com/company/policies/trademarks/arm-trademark-list/cortex-trademark) so the ® symbol should be used, not ™
* add missing hyphen between `Cortex®` and core name
  * e.g., `Cortex® M0+` --> `Cortex-M0+`