### PR TITLE
boards: stm32: doc: cleanup trademark symbols

### DIFF
--- a/boards/st/b_g474e_dpow1/doc/index.rst
+++ b/boards/st/b_g474e_dpow1/doc/index.rst
@@ -6,7 +6,7 @@ The B-G474E-DPOW1 Discovery kit is a digital power solution and a complete
 demonstration and development platform for the STMicroelectronics STM32G474RET6
 microcontroller. Leveraging the new HRTimer-oriented features, 96 Kbytes of
 embedded RAM, math accelerator functions and USB-PD 3.0 offered by STM32G474RET6,
-the B-G474E-DPOW1 Discovery kit, based on the USB 2.0 FS Type-C™ connector
+the B-G474E-DPOW1 Discovery kit, based on the USB 2.0 FS USB Type-C |reg| connector
 interface, helps the user to prototype applications with digital power such as a
 buck-boost converter, RGB power LED lighting or a class-D audio amplifier. The
 B-G474E-DPOW1 Discovery kit does not require any separate probe, as it integrates
@@ -14,7 +14,7 @@ the STLINK-V3E debugger and programmer.
 
 - STM32G474RET6 Arm® Cortex®-M4 core-based microcontroller, featuring 512 Kbytes
   of Flash memory and 128 Kbytes of SRAM, in LQFP64 package
-- USB Type-C™ with USB 2.0 FS interface compatible with USB-PD 3.0
+- USB Type-C |reg| with USB 2.0 FS interface compatible with USB-PD 3.0
 - RGB power LED for a bright lighting
 - Digital power buck-boost converter with internal or external Input voltage and
   with onboard resistor loads
@@ -24,10 +24,10 @@ the STLINK-V3E debugger and programmer.
 - 4-direction joystick with a selection button
 - Reset push-button
 - Board connectors:
-    - USB Type-C™
+    - USB Type-C |reg|
     - USB Micro-B
     - 2 x 32-pin header, 2.54 mm pitch, daughterboard extension connector for breadboard connection
-- Flexible power-supply options: ST-LINK USB VBUS or USB Type-C™ VBUS or external source
+- Flexible power-supply options: ST-LINK USB VBUS or USB Type-C |reg| VBUS or external source
 - On-board STLINK-V3E debugger/programmer with USB re-enumeration capability: mass storage,
   Virtual COM port, and debug port
 

--- a/boards/st/b_u585i_iot02a/doc/index.rst
+++ b/boards/st/b_u585i_iot02a/doc/index.rst
@@ -38,7 +38,7 @@ Hardware
 ********
 
 The STM32U585xx devices are an ultra-low-power microcontrollers family (STM32U5
-Series) based on the high-performance Arm|reg| Cortex|reg|-M33 32-bit RISC core.
+Series) based on the high-performance Arm |reg| Cortex |reg|-M33 32-bit RISC core.
 They operate at a frequency of up to 160 MHz.
 
 - Ultra-low-power with FlexPowerControl (down to 300 nA Standby mode and 19.5 uA/MHz run mode)

--- a/boards/st/nucleo_g431rb/doc/index.rst
+++ b/boards/st/nucleo_g431rb/doc/index.rst
@@ -72,7 +72,7 @@ The STM32G431RB SoC provides the following hardware IPs:
   - 1x SAI (serial audio interface)
   - USB 2.0 full-speed interface with LPM and BCD support
   - IRTIM (Infrared interface)
-  - USB Type-C™ /USB power delivery controller (UCPD)
+  - USB Type-C |reg| /USB power delivery controller (UCPD)
 
 - 12-channel DMA controller
 - True random number generator (RNG)

--- a/boards/st/nucleo_g474re/doc/index.rst
+++ b/boards/st/nucleo_g474re/doc/index.rst
@@ -72,7 +72,7 @@ The STM32G474RE SoC provides the following hardware IPs:
   - 1x SAI (serial audio interface)
   - USB 2.0 full-speed interface with LPM and BCD support
   - IRTIM (Infrared interface)
-  - USB Type-C™ /USB power delivery controller (UCPD)
+  - USB Type-C |reg| /USB power delivery controller (UCPD)
 
 - 12-channel DMA controller
 - True random number generator (RNG)

--- a/boards/st/nucleo_h533re/doc/index.rst
+++ b/boards/st/nucleo_h533re/doc/index.rst
@@ -13,7 +13,7 @@ Here are some highlights of the Nucleo H533RE board:
 
 - Board connectors:
 
-  - USB Type-C |trade| Sink device FS
+  - USB Type-C |reg| Sink device FS
   - ST Zio expansion connector including Arduino Uno V3 connectivity (CN5, CN6, CN8, CN9)
   - ST morpho extension connector (CN7, CN10)
 

--- a/boards/st/nucleo_h563zi/doc/index.rst
+++ b/boards/st/nucleo_h563zi/doc/index.rst
@@ -12,7 +12,7 @@ Here are some highlights of the Nucleo H563ZI board:
   SRAM in LQFP144 package
 - Board connectors:
 
-  - USB Type-C |trade| Sink device FS
+  - USB Type-C |reg| Sink device FS
   - Ethernet RJ45 connector compliant with IEEE-802.3-2002 (depending on STM32 support)
   - ST Zio expansion connector including Arduino Uno V3 connectivity (CN7, CN8, CN9, CN10)
   - ST morpho extension connector (CN11, CN12)

--- a/boards/st/nucleo_l552ze_q/doc/nucleol552ze_q.rst
+++ b/boards/st/nucleo_l552ze_q/doc/nucleol552ze_q.rst
@@ -33,7 +33,7 @@ Hardware
 ********
 
 The STM32L552xx devices are an ultra-low-power microcontrollers family (STM32L5
-Series) based on the high-performance Arm|reg| Cortex|reg|-M33 32-bit RISC core.
+Series) based on the high-performance Arm |reg| Cortex |reg|-M33 32-bit RISC core.
 They operate at a frequency of up to 110 MHz.
 
 - Ultra-low-power with FlexPowerControl (down to 108 nA Standby mode and 62 uA/MHz run mode)

--- a/boards/st/nucleo_u575zi_q/doc/index.rst
+++ b/boards/st/nucleo_u575zi_q/doc/index.rst
@@ -25,7 +25,7 @@ board:
 
 - Three users LEDs
 - Two push-buttons: USER and RESET
-- USB Type-C |trade| Sink device FS
+- USB Type-C |reg| Sink device FS
 
 Hardware
 ********

--- a/boards/st/nucleo_u575zi_q/doc/index.rst
+++ b/boards/st/nucleo_u575zi_q/doc/index.rst
@@ -31,7 +31,7 @@ Hardware
 ********
 
 The STM32U575xx devices are an ultra-low-power microcontrollers family (STM32U5
-Series) based on the high-performance Arm|reg| Cortex|reg|-M33 32-bit RISC core.
+Series) based on the high-performance Arm |reg| Cortex |reg|-M33 32-bit RISC core.
 They operate at a frequency of up to 160 MHz.
 
 - Ultra-low-power with FlexPowerControl (down to 300 nA Standby mode and 19.5 uA/MHz run mode)

--- a/boards/st/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/st/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -41,12 +41,12 @@ provides the following hardware capabilities:
 
   - 2.4GHz
   - RF transceiver supporting Bluetooth® 5 specification, IEEE 802.15.4-2011 PHY and MAC,
-    supporting Thread and ZigBee|reg| 3.0
-  - RX Sensitivity: -96 dBm (Bluetooth|reg| Low Energy at 1 Mbps), -100 dBm (802.15.4)
+    supporting Thread and ZigBee |reg| 3.0
+  - RX Sensitivity: -96 dBm (Bluetooth |reg| Low Energy at 1 Mbps), -100 dBm (802.15.4)
   - Programmable output power up to +6 dBm with 1 dB steps
   - Integrated balun to reduce BOM
   - Support for 2 Mbps
-  - Dedicated Arm|reg| 32-bit Cortex|reg| M0 + CPU for real-time Radio layer
+  - Dedicated Arm |reg| 32-bit Cortex |reg|-M0+ CPU for real-time Radio layer
   - Accurate RSSI to enable power control
   - Suitable for systems requiring compliance with radio frequency regulations
     ETSI EN 300 328, EN 300 440, FCC CFR47 Part 15 and ARIB STD-T66
@@ -91,7 +91,7 @@ provides the following hardware capabilities:
 - System peripherals
 
   - Inter processor communication controller (IPCC) for communication with
-    Bluetooth|reg| Low Energy and 802.15.4
+    Bluetooth |reg| Low Energy and 802.15.4
   - HW semaphores for resources sharing between CPUs
   - 2x DMA controllers (7x channels each) supporting ADC, SPI, I2C, USART,
     QSPI, SAI, AES, Timers
@@ -114,7 +114,7 @@ provides the following hardware capabilities:
 - Security and ID
 
  - 3x hardware encryption AES maximum 256-bit for the application,
-   the Bluetooth|reg| Low Energy and IEEE802.15.4
+   the Bluetooth |reg| Low Energy and IEEE802.15.4
  - Customer key storage / key manager services
  - HW public key authority (PKA)
  - Cryptographic algorithms: RSA, Diffie-Helman, ECC over GF(p)
@@ -123,7 +123,7 @@ provides the following hardware capabilities:
  - CRC calculation unit
  - 96-bit unique ID
  - 64-bit unique ID. Possibility to derive 802.15.5 64-bit and
-   Bluetooth|reg| Low Energy 48-bit EUI
+   Bluetooth |reg| Low Energy 48-bit EUI
 
 - Up to 72 fast I/Os, 70 of them 5 V-tolerant
 - Development support: serial wire debug (SWD), JTAG, Embedded Trace Macrocell |trade|

--- a/boards/st/sensortile_box_pro/doc/index.rst
+++ b/boards/st/sensortile_box_pro/doc/index.rst
@@ -40,7 +40,7 @@ The following is a summary of the main board features. More info can be find on 
 and the `schematic`_.
 
 The STM32U585xx devices are an ultra-low-power microcontrollers family (STM32U5
-Series) based on the high-performance Arm|reg| Cortex|reg|-M33 32-bit RISC core.
+Series) based on the high-performance Arm |reg| Cortex |reg|-M33 32-bit RISC core.
 They operate at a frequency of up to 160 MHz.
 
 - Ultra-low-power with FlexPowerControl (down to 300 nA Standby mode and 19.5 uA/MHz run mode)

--- a/boards/st/steval_stwinbx1/doc/index.rst
+++ b/boards/st/steval_stwinbx1/doc/index.rst
@@ -3,7 +3,7 @@
 Overview
 ********
 
-The STWIN.box (STEVAL-STWINBX1) is a development kit that features an Arm|reg| Cortex|reg|-M33 based STM32U585AI MCU
+The STWIN.box (STEVAL-STWINBX1) is a development kit that features an Arm |reg| Cortex |reg|-M33 based STM32U585AI MCU
 and is a reference design that simplifies prototyping and testing of advanced industrial sensing applications in
 IoT contexts such as condition monitoring and predictive maintenance.
 
@@ -37,7 +37,7 @@ Hardware
 ********
 
 The STM32U585xx devices are an ultra-low-power microcontrollers family (STM32U5
-Series) based on the high-performance Arm|reg| Cortex|reg|-M33 32-bit RISC core.
+Series) based on the high-performance Arm |reg| Cortex |reg|-M33 32-bit RISC core.
 They operate at a frequency of up to 160 MHz.
 
 - Ultra-low-power with FlexPowerControl (down to 300 nA Standby mode and 19.5 uA/MHz run mode)
@@ -150,7 +150,7 @@ More information about STM32U585AI can be found here:
 Connectivity
 ************
 
-   - **BlueNRG-M2SA** Bluetooth|reg| low energy v5.2 wireless technology module
+   - **BlueNRG-M2SA** Bluetooth |reg| low energy v5.2 wireless technology module
      (`BlueNRG-M2 datasheet`_)
    - **MXCHIP EMW3080** (802.11 b/g/n compliant Wi-Fi module)
    - **ST25DV64K** dynamic NFC/RFID tag IC with 64-Kbit EEPROM

--- a/boards/st/steval_stwinbx1/doc/index.rst
+++ b/boards/st/steval_stwinbx1/doc/index.rst
@@ -155,7 +155,7 @@ Connectivity
    - **MXCHIP EMW3080** (802.11 b/g/n compliant Wi-Fi module)
    - **ST25DV64K** dynamic NFC/RFID tag IC with 64-Kbit EEPROM
      (`st25dv64k datasheet`_)
-   - USB Type-C|trade| connector (power supply and data)
+   - USB Type-C |reg| connector (power supply and data)
    - STDC14 programming connector for **STLINK-V3MINI**
      (`stlink-v3mini`_)
    - microSD card socket

--- a/boards/st/stm32g071b_disco/doc/index.rst
+++ b/boards/st/stm32g071b_disco/doc/index.rst
@@ -3,40 +3,40 @@
 Overview
 ********
 The STM32G071B-DISCO Discovery board is a demonstration and development platform
-for the STMicroelectronics Arm® Cortex® -M0+ core-based STM32G071RB USB Type-C™
+for the STMicroelectronics Arm® Cortex® -M0+ core-based STM32G071RB USB Type-C |reg|
 and Power Delivery microcontroller. The STM32G071B-DISCO Discovery board is
 presented with all necessary interfaces for easy connection and
-interoperability with other USB Type-C™ devices. The STM32G071B-DISCO Discovery
-board is intended for discovery and display of USB Type-C™ port characteristics
+interoperability with other USB Type-C |reg| devices. The STM32G071B-DISCO Discovery
+board is intended for discovery and display of USB Type-C |reg| port characteristics
 such as data role, power role, VBUS and IBUS monitoring. It offers an advanced
 user mode when associated with the STM32CubeMonUCPD software GUI and can be used
-as a USB Type-C™ and Power Delivery analyzer.
+as a USB Type-C |reg| and Power Delivery analyzer.
 
 - STM32G071RBT6 microcontroller featuring 128 Kbytes of Flash memory and
   32 Kbytes of RAM in LQFP64 package
 - Plastic case
 - 1” 128 x 64 pixels OLED LCD module with SPI interface
-- USB Type-C™ interface plug cable and receptacle connector accessible by door
+- USB Type-C |reg| interface plug cable and receptacle connector accessible by door
   with reed sensor detection
 - 3 bidirectional current and power monitors with I2C interface to measure VBUS,
   CC1 and CC2 protected and isolated lines
 - On-board DC/DC converter to sustain power supply with VBUS varying from 3 V to
   20 V (+/- 5 %)
-- 4 user status LEDs about USB Type-C™ configuration
+- 4 user status LEDs about USB Type-C |reg| configuration
 - 3 LEDs for power and ST-LINK communication
 - 4-way joystick with selection button
 - 1 reset push-button
 - Board external connectors:
-    - USB Type-C™ plug cable
-    - USB Type-C™ receptacle connector
+    - USB Type-C |reg| plug cable
+    - USB Type-C |reg| receptacle connector
     - 8-pin user extension connector including ADC, SPI, USART and
       I2C communication signals
     - USB with Micro-AB (ST-LINK)
 - Board internal connectors:
     - 2 x 8-pin GPIOs free pins from microcontroller
 	  (accessible internally when case is removed)
-    - USB Type-C™ test points for main signals
-- Flexible power-supply options: ST-LINK USB VBUS or USB Type-C™ VBUS
+    - USB Type-C |reg| test points for main signals
+- Flexible power-supply options: ST-LINK USB VBUS or USB Type-C |reg| VBUS
 - On-board ST-LINK/V2-1 debugger/programmer with USB enumeration capability:
   mass storage, Virtual COM port and debug port
 

--- a/boards/st/stm32h573i_dk/doc/index.rst
+++ b/boards/st/stm32h573i_dk/doc/index.rst
@@ -11,7 +11,7 @@ the STM32H573I-DK Discovery board:
 
 - STM32H573IIK3Q microcontroller featuring 2 Mbytes of Flash memory and 640 Kbytes of SRAM in 176-pin BGA package
 - 1.54-inch 240x240 pixels TFT-LCD with LED  backlight and touch panel
-- USB Type-C |trade| Host and device with USB power-delivery controller
+- USB Type-C |reg| Host and device with USB power-delivery controller
 - SAI Audio DAC stereo with one audio jacks for input/output,
 - ST MEMS digital microphone with PDM interface
 - Octo-SPI interface connected to 512Mbit Octo-SPI NORFlash memory device (MX25LM51245GXDI00 from MACRONIX)

--- a/boards/st/stm32h7s78_dk/doc/index.rst
+++ b/boards/st/stm32h7s78_dk/doc/index.rst
@@ -9,7 +9,7 @@ STM32H7S7L8H6H microcontroller. Here are some highlights of the STM32H7S78-DK Di
 
 
 - STM32H7S7L8H6H microcontroller featuring 64Kbytes of Flash memory and 620 Kbytes of SRAM in 225-pin TFBGA package
-- USB Type-C |trade| Host and device with USB power-delivery controller
+- USB Type-C |reg| Host and device with USB power-delivery controller
 - SAI Audio DAC stereo with one audio jacks for input/output,
 - ST MEMS digital microphone with PDM interface
 - Octo-SPI interface connected to 512Mbit Octo-SPI NORFlash memory device (MX66UW1G45GXD100 from MACRONIX)

--- a/boards/st/stm32l562e_dk/doc/index.rst
+++ b/boards/st/stm32l562e_dk/doc/index.rst
@@ -11,7 +11,7 @@ the STM32L562E-DK Discovery board:
 
 - STM32L562QEI6QU microcontroller featuring 512 Kbytes of Flash memory and 256 Kbytes of SRAM in BGA132 package
 - 1.54" 240 x 240 pixel-262K color TFT LCD module with parallel interface and touch-control panel
-- USB Type-C |trade| Sink device FS
+- USB Type-C |reg| Sink device FS
 - On-board energy meter: 300 nA to 150 mA measurement range with a dedicated USB interface
 - SAI Audio CODEC
 - MEMS digital microphones

--- a/boards/st/stm32wb5mmg/doc/stm32wb5mmg.rst
+++ b/boards/st/stm32wb5mmg/doc/stm32wb5mmg.rst
@@ -4,7 +4,7 @@ Overview
 ********
 
 STM32WB5MMG is an ultra-low-power and small form factor certified 2.4 GHz
-wireless module. It supports Bluetooth|reg| Low Energy 5.4, Zigbee|reg| 3.0,
+wireless module. It supports Bluetooth |reg| Low Energy 5.4, Zigbee |reg| 3.0,
 OpenThread, dynamic, and static concurrent modes, and 802.15.4 proprietary
 protocols. This board support is added in order to make it possible use this
 module on other boards as HCI layer (Specifically B-U585I-IOT02A Development board).
@@ -13,16 +13,16 @@ STM32WB5MMG supports the following features:
 
 - Bluetooth module in SiP-LGA86 package
 - Integrated chip antenna
-- Bluetooth|reg| Low Energy 5.4, Zigbee|reg| 3.0, OpenThread certified
+- Bluetooth |reg| Low Energy 5.4, Zigbee |reg| 3.0, OpenThread certified
   Dynamic and static concurrent modes
 - IEEE 802.15.4-2011 MAC PHY Supports 2 Mbits/s
 - Frequency band 2402-2480 MHz
 - Advertising extension
 - Tx output power up to +6 dBm
-- Rx sensitivity: -96 dBm (Bluetooth|reg| Low Energy at 1 Mbps), -100 dBm (802.15.4)
+- Rx sensitivity: -96 dBm (Bluetooth |reg| Low Energy at 1 Mbps), -100 dBm (802.15.4)
 - Range: up to 75 meters
-- Dedicated Arm|reg| Cortex|reg|-M0+ CPU for radio and security tasks
-- Dedicated Arm|reg| Cortex|reg|-M4 CPU with FPU and ART (adaptive real-time accelerator) up to 64 MHz speed
+- Dedicated Arm |reg| Cortex |reg|-M0+ CPU for radio and security tasks
+- Dedicated Arm |reg| Cortex |reg|-M4 CPU with FPU and ART (adaptive real-time accelerator) up to 64 MHz speed
 - 1-Mbyte flash memory, 256-Kbyte SRAM
 - Fully integrated BOM, including 32 MHz radio and 32 kHz RTC crystals
 - Integrated SMPS
@@ -36,9 +36,9 @@ Hardware
 ********
 
 STM32WB5MMG is an ultra-low-power and small form factor certified 2.4 GHz
-wireless module. It supportsBluetooth|reg| Low Energy 5.4, Zigbee|reg| 3.0, OpenThread,
-dynamic, and static concurrent modes, and 802.15.4proprietary protocols. Based
-on the STMicroelectronics STM32WB55VGY wireless microcontroller,STM32WB5MMG
+wireless module. It supports Bluetooth |reg| Low Energy 5.4, Zigbee |reg| 3.0, OpenThread,
+dynamic, and static concurrent modes, and 802.15.4 proprietary protocols. Based
+on the STMicroelectronics STM32WB55VGY wireless microcontroller, STM32WB5MMG
 provides best-in-class RF performance thanks to its high receiver sensitivity
 and output power signal. Its low-power features enable extended battery life,
 small coin-cell batteries, and energy harvesting. STM32WB5MMG revision Y is
@@ -50,10 +50,10 @@ cut 2.2.
 - Radio:
 
   - 2.4GHz
-  - RF transceiver supporting Bluetooth|reg| 5.4
+  - RF transceiver supporting Bluetooth |reg| 5.4
     specification, IEEE 802.15.4-2011 PHY
     and MAC, supporting Thread 1.3 and
-  - Zigbee|reg| 3.0
+  - Zigbee |reg| 3.0
   - RX sensitivity: -96 dBm (Bluetooth |reg| Low
     Energy at 1 Mbps), -100 dBm (802.15.4)
   - Programmable output power up to +6 dBm
@@ -63,7 +63,7 @@ cut 2.2.
   - Support GATT caching
   - Support EATT (enhanced ATT)
   - Support advertising extension
-  - Dedicated Arm|reg| 32-bit Cortex|reg| M0+ CPU
+  - Dedicated Arm |reg| 32-bit Cortex |reg| M0+ CPU
     for real-time Radio layer
   - Accurate RSSI to enable power control
   - Suitable for systems requiring compliance
@@ -134,9 +134,9 @@ cut 2.2.
 - Security and ID
 
  - Secure firmware installation (SFI) for
-   Bluetooth|reg| Low Energy and 802.15.4 SW stack
+   Bluetooth |reg| Low Energy and 802.15.4 SW stack
  - 3x hardware encryption AES maximum 256-bit for
-   the application, the Bluetooth|reg|
+   the application, the Bluetooth |reg|
  - Low Energy and IEEE802.15.4
  - Customer key storage/manager services
  - HW public key authority (PKA)
@@ -146,7 +146,7 @@ cut 2.2.
  - CRC calculation unit
  - Die information: 96-bit unique ID
  - IEEE 64-bit unique ID, possibility to derive 802.15.4 64-bit
-   and Bluetooth|reg| Low Energy
+   and Bluetooth |reg| Low Energy
  - 48-bit EUI
 
 More information about STM32WB5MMG can be found here:

--- a/boards/weact/stm32wb55_core/doc/index.rst
+++ b/boards/weact/stm32wb55_core/doc/index.rst
@@ -5,12 +5,12 @@ Overview
 
 The WeAct Studio STM32WB55 Core Board is a compact multi-protocol wireless and
 ultra-low-power development board embedding a powerful radio compliant with the
-Bluetooth|reg| Low Energy (BLE) SIG specification v5.0 and with IEEE 802.15.4-2011.
+Bluetooth |reg| Low Energy (BLE) SIG specification v5.0 and with IEEE 802.15.4-2011.
 
 - STM32WB55CGU6 microcontroller in UFQFPN48 package
-- 2.4 GHz RF transceiver supporting Bluetooth|reg| specification v5.0 and
+- 2.4 GHz RF transceiver supporting Bluetooth |reg| specification v5.0 and
   IEEE 802.15.4-2011 PHY and MAC
-- Dedicated Arm|reg| 32-bit Cortex|reg| M0+ CPU for real-time Radio layer
+- Dedicated Arm |reg| 32-bit Cortex |reg| M0+ CPU for real-time Radio layer
 - One user LED (Blue)
 - One BOOT button
 - One RESET button
@@ -34,13 +34,13 @@ provides the following hardware capabilities:
 - Radio:
 
   - 2.4GHz
-  - RF transceiver supporting Bluetooth|reg| 5 specification, IEEE 802.15.4-2011 PHY and MAC,
-    supporting Thread and ZigBee|reg| 3.0
-  - RX Sensitivity: -96 dBm (Bluetooth|reg| Low Energy at 1 Mbps), -100 dBm (802.15.4)
+  - RF transceiver supporting Bluetooth |reg| 5 specification, IEEE 802.15.4-2011 PHY and MAC,
+    supporting Thread and ZigBee |reg| 3.0
+  - RX Sensitivity: -96 dBm (Bluetooth |reg| Low Energy at 1 Mbps), -100 dBm (802.15.4)
   - Programmable output power up to +6 dBm with 1 dB steps
   - Integrated balun to reduce BOM
   - Support for 2 Mbps
-  - Dedicated Arm|reg| 32-bit Cortex|reg| M0+ CPU for real-time Radio layer
+  - Dedicated Arm |reg| 32-bit Cortex |reg| M0+ CPU for real-time Radio layer
   - Accurate RSSI to enable power control
 
 - Clock Sources:


### PR DESCRIPTION
* change instances of ™ to ® for the "USB Type-C" trademark
  * [USB Type-C® is a registered trademark of USB Implementers Forum](https://www.usb.org/sites/default/files/usb_type-c_cable_logo_usage_guidelines_20240903.pdf)
* Add missing space before inline markup `|reg|`/`|trade|` preventing proper rendering
  * See for example: https://docs.zephyrproject.org/latest/boards/st/stm32wb5mmg/doc/stm32wb5mmg.html