### PR TITLE
pinctrl: nrf: add slew rate (BIAS) setting

### DIFF
--- a/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
@@ -61,6 +61,7 @@ description: |
     - bias-pull-down: Enable pull-down resistor.
     - low-power-enable: Configure pin as an input with input buffer
       disconnected.
+    - slew-rate: Configure slew rate, higher value is faster.
 
     Note that bias options are mutually exclusive.
 
@@ -93,6 +94,7 @@ child-binding:
           - bias-pull-down
           - bias-pull-up
           - low-power-enable
+          - slew-rate
 
     properties:
       psels:

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -11,7 +11,8 @@
  * organized as follows:
  *
  * - 31..24: Pin function.
- * - 19-23:  Reserved.
+ * - 21-23:  Reserved.
+ * - 19-20:  Pin slew rate setting (BIAS)
  * - 18:     Associated peripheral belongs to GD FAST ACTIVE1 (nRF54H only)
  * - 17:     Clockpin enable.
  * - 16:     Pin inversion mode.
@@ -30,6 +31,10 @@
 #define NRF_FUN_POS 24U
 /** Mask for the function field. */
 #define NRF_FUN_MSK 0xFFU
+/** Position of the slew setting field. */
+#define NRF_BIAS_POS 19U
+/** Mask for the slew setting field. */
+#define NRF_BIAS_MSK 0x3U
 /** Position of the GPD FAST ACTIVE1 */
 #define NRF_GPD_FAST_ACTIVE1_POS 18U
 /** Mask for the GPD FAST ACTIVE1 */

--- a/soc/nordic/common/pinctrl_soc.h
+++ b/soc/nordic/common/pinctrl_soc.h
@@ -70,7 +70,8 @@ typedef uint32_t pinctrl_soc_pin_t;
 	 (DT_PROP(node_id, nordic_drive_mode) << NRF_DRIVE_POS) |	       \
 	 ((NRF_LP_ENABLE * DT_PROP(node_id, low_power_enable)) << NRF_LP_POS) |\
 	 (DT_PROP(node_id, nordic_invert) << NRF_INVERT_POS) |		       \
-	 Z_GET_CLOCKPIN_ENABLE(node_id, prop, idx, p_node_id)),
+	 Z_GET_CLOCKPIN_ENABLE(node_id, prop, idx, p_node_id) |		       \
+	 ((DT_PROP_OR(node_id, slew_rate, 0) & NRF_BIAS_MSK) << NRF_BIAS_POS)),
 
 /**
  * @brief Utility macro to initialize state pins contained in a given property.
@@ -89,6 +90,13 @@ typedef uint32_t pinctrl_soc_pin_t;
  * @param pincfg Pin configuration bit field.
  */
 #define NRF_GET_FUN(pincfg) (((pincfg) >> NRF_FUN_POS) & NRF_FUN_MSK)
+
+/**
+ * @brief Utility macro to obtain port and pin combination.
+ *
+ * @param pincfg Pin configuration bit field.
+ */
+#define NRF_GET_BIAS(pincfg) (((pincfg) >> NRF_BIAS_POS) & NRF_BIAS_MSK)
 
 /**
  * @brief Utility macro to obtain pin clockpin enable flag.


### PR DESCRIPTION
Add slew rate setting, currently specifically for the HSBIAS field of GPIOHSPADCTRL for now. NRFX changes needed to allow setting the HSBIAS field for a pin.