### PR TITLE
scripts: list_boards: Add support for using parent files

### DIFF
--- a/boards/nordic/nrf5340dk/board.yml
+++ b/boards/nordic/nrf5340dk/board.yml
@@ -7,3 +7,8 @@ board:
     variants:
     - name: 'ns'
       cpucluster: 'cpuapp'
+      include-parent-kconfig: True
+      include-parent-dts: True
+      variants:
+      - name: 'shop'
+        include-parent-dts: True

--- a/scripts/schemas/board-schema.yaml
+++ b/scripts/schemas/board-schema.yaml
@@ -32,6 +32,10 @@ $defs:
           type: string
         variants:
           $ref: "#/$defs/variantSchema" # Recursive definition
+        include-parent-kconfig:
+          type: boolean
+        include-parent-dts:
+          type: boolean
       required:
         - name
       additionalProperties: false


### PR DESCRIPTION
Adds 2 new fields which can be used in board.yml files for board variants which allow them to include the configuration files of the parent board/board target. This is just the script changes needed for this functionality and does not alter CMake to allow usage of this