### PR TITLE
tests: drivers: uart: exclude Infineon cy8ckit boards

### DIFF
--- a/samples/drivers/uart/async_api/sample.yaml
+++ b/samples/drivers/uart/async_api/sample.yaml
@@ -4,6 +4,9 @@ tests:
   sample.drivers.uart.async_api:
     integration_platforms:
       - nrf52840dk/nrf52840
+    platform_exclude:
+      - cy8ckit_062s4
+      - cy8ckit_062s2_ai
     tags:
       - serial
       - uart

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -3,6 +3,8 @@ common:
     - stamp_c3
     - wio_terminal
     - xiao_esp32c3
+    - cy8ckit_062s4
+    - cy8ckit_062s2_ai
   tags:
     - drivers
     - uart


### PR DESCRIPTION
Add cy8ckit_062s4 and cy8ckit_062s2_ai to platform_exclude list for UART async API tests. These boards lack proper async UART support implementation.