### PR TITLE
logging: log_core: fix bug where logging messages slowly would never flush

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -943,7 +943,6 @@ static void log_process_thread_func(void *dummy1, void *dummy2, void *dummy3)
 	 * If all backends are ready periodic wake up is not needed.
 	 */
 	k_timeout_t timeout = (activate_mask != 0) ? K_MSEC(50) : K_FOREVER;
-	bool processed_any = false;
 	thread_set(k_current_get());
 
 	/* Logging thread is periodically waken up until all backends that
@@ -968,13 +967,8 @@ static void log_process_thread_func(void *dummy1, void *dummy2, void *dummy3)
 
 
 		if (log_process() == false) {
-			if (processed_any) {
-				processed_any = false;
-				log_backend_notify_all(LOG_BACKEND_EVT_PROCESS_THREAD_DONE, NULL);
-			}
+			log_backend_notify_all(LOG_BACKEND_EVT_PROCESS_THREAD_DONE, NULL);
 			(void)k_sem_take(&log_process_thread_sem, timeout);
-		} else {
-			processed_any = true;
 		}
 	}
 }


### PR DESCRIPTION


Fix a flawed check in `log_core`. The check would check the return value of `log_process`, which returns true if there are more messages to be processed. This would then be taken to mean that any messages were processed, meaning if only a single message was logged per `log_core` loop, the backends would never be notified to flush the logs.

Another way to fix this could be to change the return value of `log_process` to mean that a log entry was processed?