### PR TITLE
xtensa: fix error: use of undeclared identifier 'intenable2'

### DIFF
--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -468,7 +468,7 @@ __unused static void xtensa_handle_irq_lvl(int irq_lvl)
 
 #if XCHAL_NUM_INTERRUPTS > 64
 	__asm__ volatile("rsr.interrupt2 %0" : "=r"(irq_mask));
-	__asm__ volatile("rsr.intenable2 %0" : "=r"(intenable2));
+	__asm__ volatile("rsr.intenable2 %0" : "=r"(intenable));
 	irq_mask &= intenable;
 	irq_mask &= xtensa_lvl_mask[irq_lvl - 1][2];
 	while (irq_mask) {


### PR DESCRIPTION
This is likely a miss from:
df40dff6fb1 arch: xtensa: clean up interrupt handling