### PR TITLE
drivers: flash: Fixed the typo in clear_flash_caches

### DIFF
--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -124,7 +124,7 @@ static void clear_flash_caches(void)
 {
 	FLASH_CacheClear();
 }
-#elif
+#else
 static void clear_flash_caches(void)
 {
 	volatile uint32_t *const smscm_ocmdr0 = (volatile uint32_t *)0x40015400;


### PR DESCRIPTION
Fixes the typo in clear_flash_caches().
"elif" should be "else"

 According to the comment from https://github.com/zephyrproject-rtos/zephyr/pull/98373#discussion_r2478364183, it blocks the CI on main.