### PR TITLE
tests: drivers: spi: fix silabs overlays for loopback tests

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/bg29_rb4420a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/bg29_rb4420a.overlay
@@ -20,14 +20,16 @@
 	pinctrl-names = "default";
 	status = "okay";
 	cs-gpios = <&gpioc 6 GPIO_ACTIVE_LOW>;
+
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;
 		spi-max-frequency = <500000>;
 	};
-	fast@1 {
+
+	fast@0 {
 		compatible = "test-spi-loopback-fast";
-		reg = <1>;
+		reg = <0>;
 		spi-max-frequency = <10000000>;
 	};
 };

--- a/tests/drivers/spi/spi_loopback/boards/siwx917_dk2605a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/siwx917_dk2605a.overlay
@@ -9,6 +9,7 @@
 		out { /* Breakout PAD 3 - 5 */
 			pinmux = <GSPI_CLK_HP25>, <GSPI_MOSI_HP27>;
 		};
+
 		in {  /* Breakout PAD 7 */
 			pinmux = <GSPI_MISO_HP26>;
 		};
@@ -29,9 +30,10 @@
 		reg = <0>;
 		spi-max-frequency = <500000>;
 	};
-	fast@1 {
+
+	fast@0 {
 		compatible = "test-spi-loopback-fast";
-		reg = <1>;
+		reg = <0>;
 		spi-max-frequency = <10000000>;
 	};
 };

--- a/tests/drivers/spi/spi_loopback/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/siwx917_rb4338a.overlay
@@ -9,6 +9,7 @@
 		out {
 			pinmux = <GSPI_CLK_HP25>, <GSPI_MOSI_HP27>;
 		};
+
 		in {
 			pinmux = <GSPI_MISO_HP26>;
 		};
@@ -29,7 +30,8 @@
 		reg = <0>;
 		spi-max-frequency = <500000>;
 	};
-	fast@1 {
+
+	fast@0 {
 		compatible = "test-spi-loopback-fast";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/tests/drivers/spi/spi_loopback/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/xg24_rb4187c.overlay
@@ -13,6 +13,7 @@
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <EUSART1_RX_PC2>;
 			input-enable;
@@ -30,14 +31,16 @@
 	pinctrl-names = "default";
 	status = "okay";
 	cs-gpios = <&gpioc 0 GPIO_ACTIVE_LOW>;
+
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;
 		spi-max-frequency = <500000>;
 	};
-	fast@1 {
+
+	fast@0 {
 		compatible = "test-spi-loopback-fast";
-		reg = <1>;
+		reg = <0>;
 		spi-max-frequency = <10000000>;
 	};
 };

--- a/tests/drivers/spi/spi_loopback/boards/xg29_rb4412a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/xg29_rb4412a.overlay
@@ -20,14 +20,16 @@
 	pinctrl-names = "default";
 	status = "okay";
 	cs-gpios = <&gpioc 0 GPIO_ACTIVE_LOW>;
+
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;
 		spi-max-frequency = <500000>;
 	};
-	fast@1 {
+
+	fast@0 {
 		compatible = "test-spi-loopback-fast";
-		reg = <1>;
+		reg = <0>;
 		spi-max-frequency = <10000000>;
 	};
 };


### PR DESCRIPTION
Changed the 'reg' property from <1> to <0> for 'fast' nodes in multiple board overlays (bg29_rb4420a, siwx917_dk2605a, xg24_rb4187c, xg29_rb4412a) to ensure correct SPI device addressing.

This used to work before but now broken since https://github.com/zephyrproject-rtos/zephyr/commit/a60f93d742a48660882af5785fb4352f414ecd11

Another way to fix the test is also to declare two same cs-gpio property.

Finally decided to use fast@0 with reg=<0> to have consistency with other overlays.