### PR TITLE
boards: st: fix Bluetooth and BLE references

### DIFF
--- a/boards/st/b_u585i_iot02a/doc/index.rst
+++ b/boards/st/b_u585i_iot02a/doc/index.rst
@@ -12,7 +12,7 @@ some highlights of the B_U585I_IOT02A Discovery kit:
 - 512-Mbit octal-SPI Flash memory, 64-Mbit octal-SPI PSRAM, 256-Kbit I2C EEPROM
 - USB FS, Sink and Source power, 2.5 W power capability
 - 802.11 b/g/n compliant Wi-Fi® module from MXCHIP
-- Bluetooth Low Energy from STMicroelectronics
+- Bluetooth |reg| Low Energy from STMicroelectronics
 - MEMS sensors from STMicroelectronics
 
   - 2 digital microphones

--- a/boards/st/nucleo_wb05kz/doc/index.rst
+++ b/boards/st/nucleo_wb05kz/doc/index.rst
@@ -32,11 +32,11 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
-Bluetooth support
------------------
+Bluetooth |reg| support
+-----------------------
 
-BLE support is enabled; however, to build a Zephyr sample using this board,
-you first need to fetch the Bluetooth controller library into Zephyr as a binary BLOB.
+Bluetooth |reg| Low Energy support is enabled; however, to build a Zephyr sample using this board,
+you first need to fetch the Bluetooth |reg| controller library into Zephyr as a binary BLOB.
 
 To fetch binary BLOBs:
 

--- a/boards/st/nucleo_wb07cc/doc/index.rst
+++ b/boards/st/nucleo_wb07cc/doc/index.rst
@@ -32,11 +32,11 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
-Bluetooth support
------------------
+Bluetooth |reg| support
+-----------------------
 
-BLE support is enabled; however, to build a Zephyr sample using this board,
-you first need to fetch the Bluetooth controller library into Zephyr as a binary BLOB.
+Bluetooth |reg| Low Energy support is enabled; however, to build a Zephyr sample using this board,
+you first need to fetch the Bluetooth |reg| controller library into Zephyr as a binary BLOB.
 
 To fetch binary BLOBs:
 

--- a/boards/st/nucleo_wb09ke/doc/index.rst
+++ b/boards/st/nucleo_wb09ke/doc/index.rst
@@ -32,11 +32,11 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
-Bluetooth support
------------------
+Bluetooth |reg| support
+-----------------------
 
-BLE support is enabled; however, to build a Zephyr sample using this board,
-you first need to fetch the Bluetooth controller library into Zephyr as a binary BLOB.
+Bluetooth |reg| Low Energy support is enabled; however, to build a Zephyr sample using this board,
+you first need to fetch the Bluetooth |reg| controller library into Zephyr as a binary BLOB.
 
 To fetch binary BLOBs:
 

--- a/boards/st/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/st/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -32,7 +32,7 @@ Hardware
 ********
 
 STM32WB55RG is an ultra-low-power dual core Arm Cortex-M4 MCU 64 MHz,Cortex-M0 32MHz
-with 1 Mbyte of Flash memory, Bluetooth 5, 802.15.4, USB, LCD, AES-256 SoC and
+with 1 Mbyte of Flash memory, Bluetooth |reg| 5, 802.15.4, USB, LCD, AES-256 SoC and
 provides the following hardware capabilities:
 
 - Ultra-low-power with FlexPowerControl (down to 600 nA Standby mode with RTC and 32KB RAM)
@@ -140,10 +140,10 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
-Bluetooth and compatibility with STM32WB Copro Wireless Binaries
-================================================================
+Bluetooth |reg| and compatibility with STM32WB Copro Wireless Binaries
+======================================================================
 
-To operate bluetooth on Nucleo WB55RG, Cortex-M0 core should be flashed with
+To operate Bluetooth |reg| on Nucleo WB55RG, Cortex-M0 core should be flashed with
 a valid STM32WB Coprocessor binaries (either 'Full stack' or 'HCI Layer').
 These binaries are delivered in STM32WB Cube packages, under
 ``Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/``

--- a/boards/st/nucleo_wba55cg/doc/nucleo_wba55cg.rst
+++ b/boards/st/nucleo_wba55cg/doc/nucleo_wba55cg.rst
@@ -146,11 +146,11 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
-Bluetooth support
------------------
+Bluetooth |reg| support
+-----------------------
 
-BLE support is enabled on nucleo_wba55cg. To build a zephyr sample using this board
-you first need to install Bluetooth Controller libraries available in Zephyr as binary
+Bluetooth |reg| Low Energy support is enabled on nucleo_wba55cg. To build a zephyr sample using this board
+you first need to install Bluetooth |reg| Controller libraries available in Zephyr as binary
 blobs.
 
 To fetch Binary Blobs:

--- a/boards/st/nucleo_wba65ri/doc/index.rst
+++ b/boards/st/nucleo_wba65ri/doc/index.rst
@@ -150,11 +150,11 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
-Bluetooth and IEEE 802.15.4 support
------------------------------------
+Bluetooth |reg| and IEEE 802.15.4 support
+-----------------------------------------
 
-BLE and IEEE 802.15.4 support are enabled on nucleo_wba65ri. To build a zephyr sample using this board
-you first need to install Bluetooth and/or IEEE 802.15.4 Controller libraries available in Zephyr as
+Bluetooth |reg| Low Energy and IEEE 802.15.4 support are enabled on nucleo_wba65ri. To build a zephyr sample using this board
+you first need to install Bluetooth |reg| and/or IEEE 802.15.4 Controller libraries available in Zephyr as
 binary blobs.
 
 To fetch Binary Blobs:

--- a/boards/st/sensortile_box/doc/index.rst
+++ b/boards/st/sensortile_box/doc/index.rst
@@ -7,7 +7,7 @@ The STEVAL-MKSBOX1V1 (SensorTile.box) is a ready-to-use box kit for wireless
 IoT and wearable sensor platforms to help you use and develop apps based on
 remote motion and environmental sensor data.
 The SensorTile.box board fits into a small plastic box with a long-life rechargeable
-battery, and communicates with a standard smartphone through its Bluetooth interface,
+battery, and communicates with a standard smartphone through its Bluetooth |reg| interface,
 providing data coming from the sensors.
 
 More information about the board can be found at the `SensorTile.box website`_.
@@ -31,7 +31,7 @@ SensorTile.box provides the following hardware components:
 
 - Communication
 
-  - Bluetooth Smart connectivity v4.2 (SPBTLE-1S)
+  - Bluetooth |reg| Smart connectivity v4.2 (SPBTLE-1S)
   - 1 x USB OTG FS (SoC) with micro-B connector
     (USB device role only)
 

--- a/boards/st/sensortile_box_pro/doc/index.rst
+++ b/boards/st/sensortile_box_pro/doc/index.rst
@@ -8,7 +8,7 @@ and is a ready-to-use box kit for wireless IoT and wearable sensor platforms to 
 and developing apps based on remote motion and environmental sensor data.
 
 The SensorTile.box PRO board fits into a small plastic box with a long-life rechargeable
-battery, and communicates with a standard smartphone through its Bluetooth interface,
+battery, and communicates with a standard smartphone through its Bluetooth |reg| interface,
 providing data coming from the sensors.
 
 More information about the board can be found at the `SensorTile.box PRO website`_.
@@ -213,7 +213,7 @@ functions.
 BlueNRG-LP chip
 ===============
 
-The board is equipped with an STMicroelectronics `BlueNRG-LP`_ chip. Before running Zephyr Bluetooth samples
+The board is equipped with an STMicroelectronics `BlueNRG-LP`_ chip. Before running Zephyr Bluetooth |reg| samples
 on SensorTile.box PRO, it is required to upgrade the BlueNRG chip with a Zephyr BLE stack compatible firmware.
 The upgrade may be easily performed using the application provided in `SensorTile.box PRO BLE firmware upgrade package`_.
 For more information about BLE binaries for SensorTile.box family, see `stsw-mkbox-bleco`_.

--- a/boards/st/st25dv_mb1283_disco/doc/index.rst
+++ b/boards/st/st25dv_mb1283_disco/doc/index.rst
@@ -34,7 +34,7 @@ The ST25DV Discovery kit provides the following hardware components:
   - ST link mini USB
   - User micro USB
   - USB micro or mini connector for board powering
-  - Demonstration edition (optional add-on module) with Bluetooth Low Energy module,
+  - Demonstration edition (optional add-on module) with Bluetooth |reg| Low Energy module,
     Wi-Fi ® module and JTAG 20 pin connector
 
 It exists in two variants, MB1283 and MB1285.

--- a/boards/st/steval_fcu001v1/doc/index.rst
+++ b/boards/st/steval_fcu001v1/doc/index.rst
@@ -27,7 +27,7 @@ STM32 Flight Controller Unit provides the following hardware components:
 - 2 User LEDS
 - USART/UART (1)
 - I2C (1)
-- Bluetooth LE over SPI
+- Bluetooth |reg| Low Energy over SPI
 
 More information about the STM32 Flight Controller Unit
 can be found in these documents:

--- a/boards/st/stm32wb5mm_dk/doc/stm32wb5mm_dk.rst
+++ b/boards/st/stm32wb5mm_dk/doc/stm32wb5mm_dk.rst
@@ -108,10 +108,10 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
-Bluetooth and compatibility with STM32WB Copro Wireless Binaries
-================================================================
+Bluetooth |reg| and compatibility with STM32WB Copro Wireless Binaries
+======================================================================
 
-To operate bluetooth on STM32WB5MMG, Cortex-M0 core should be flashed with
+To operate Bluetooth |reg| on STM32WB5MMG, Cortex-M0 core should be flashed with
 a valid STM32WB Coprocessor binaries (either 'Full stack' or 'HCI Layer').
 These binaries are delivered in STM32WB Cube packages, under
 ``Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/``.

--- a/boards/st/stm32wb5mmg/doc/stm32wb5mmg.rst
+++ b/boards/st/stm32wb5mmg/doc/stm32wb5mmg.rst
@@ -11,7 +11,7 @@ module on other boards as HCI layer (Specifically B-U585I-IOT02A Development boa
 
 STM32WB5MMG supports the following features:
 
-- Bluetooth module in SiP-LGA86 package
+- Bluetooth |reg| module in SiP-LGA86 package
 - Integrated chip antenna
 - Bluetooth|reg| Low Energy 5.4, Zigbee|reg| 3.0, OpenThread certified
   Dynamic and static concurrent modes
@@ -159,10 +159,10 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
-Bluetooth and compatibility with STM32WB Copro Wireless Binaries
-================================================================
+Bluetooth |reg| and compatibility with STM32WB Copro Wireless Binaries
+======================================================================
 
-To operate bluetooth on STM32WB5MMG, Cortex-M0 core should be flashed with
+To operate Bluetooth |reg| on STM32WB5MMG, Cortex-M0 core should be flashed with
 a valid STM32WB Coprocessor binaries (either 'Full stack' or 'HCI Layer').
 These binaries are delivered in STM32WB Cube packages, under
 ``Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/``
@@ -251,8 +251,8 @@ Then build and flash the application for the STM32WB5MMG module.
    :goals: build flash
 
 Next, reverse back the buttons to default mode (SW4 on ON and SW5
-on OFF) mode. In this case we will upload the Bluetooth sample on the
-main microcontroller.Then, build the bluetooth
+on OFF) mode. In this case we will upload the Bluetooth |reg| sample on the
+main microcontroller. Then, build the Bluetooth |reg|
 :zephyr_file:`samples/bluetooth/observer` demo application for
 B-U585I-IOT02A board:
 


### PR DESCRIPTION
Add registered trademark symbol to Bluetooth where missing and replace BLE with explicit Bluetooth Low Energy where applicable in ST boards documentation.