### PR TITLE
llext: (trivial) fix bad file reference in comment

### DIFF
--- a/include/zephyr/llext/loader.h
+++ b/include/zephyr/llext/loader.h
@@ -29,7 +29,7 @@ extern "C" {
 #include <zephyr/llext/llext.h>
 
 /** @cond ignore */
-struct llext_elf_sect_map; /* defined in llext_priv.h */
+struct llext_elf_sect_map; /* defined in llext_internal.h */
 /** @endcond */
 
 /**


### PR DESCRIPTION
The structure was moved in 44c7a14 ("llext: add ELF inspection APIs"), but the comment was not updated.