### PR TITLE
doc: doxygen: add doxygen sitemap

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -271,6 +271,7 @@ doxyrunner_projects = {
         "outdir_var": "DOXY_OUT",
     },
 }
+os.environ["DOXYGEN_SITEMAP_URL"] = f"{html_baseurl}doxygen/html"
 
 # -- Options for zephyr.doxybridge plugin ---------------------------------
 

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1683,7 +1683,7 @@ TOC_EXPAND             = NO
 # protocol see https://www.sitemaps.org
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-SITEMAP_URL            =
+SITEMAP_URL            = $(DOXYGEN_SITEMAP_URL)
 
 # If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and
 # QHP_VIRTUAL_FOLDER are set, an additional index file will be generated that


### PR DESCRIPTION
In order to help search engines pick up _all_ our Doxygen documentation, ensure that a sitemap.xml file is generated for it.

http://builds.zephyrproject.io/zephyr/pr/98592/docs/doxygen/html/sitemap.xml