### PR TITLE
revert: modules: nrf_wifi: add missing Kconfig dependency

### DIFF
--- a/modules/nrf_wifi/Kconfig
+++ b/modules/nrf_wifi/Kconfig
@@ -6,7 +6,6 @@ config ZEPHYR_NRF_WIFI_MODULE
 
 config ZVFS_OPEN_ADD_SIZE_NRF70_ENABLE_DUAL_VIF
 	int "Number of socket descriptors needed by nrf wifi driver"
-	depends on NRF70_ENABLE_DUAL_VIF
 	default 8
 
 source "modules/nrf_wifi/bus/Kconfig"

--- a/tests/lib/fdtable/Kconfig
+++ b/tests/lib/fdtable/Kconfig
@@ -1,8 +1,0 @@
-# Copyright (c) 2025 Embeint Pty Ltd
-# SPDX-License-Identifier: Apache-2.0
-
-config ZVFS_OPEN_ADD_SIZE_TEST
-	int
-	default 1
-
-source "Kconfig.zephyr"


### PR DESCRIPTION
Revert commits from PR #98550

They somehow seemed to have caused a cascade of failures in CI, although it's not immediately clear why or how that happened, given that it was passing CI when it was merged.

https://github.com/zephyrproject-rtos/zephyr/actions/runs/18941909020/job/54083027931

The test I used for bisecting is
```shell
twister -c -p mps2/an385 -s net.mdns.resolve
```

```shell
(20250910) cfriedt@ubuntu:~/zephyrproject/zephyr$ git bisect start
(20250910) cfriedt@ubuntu:~/zephyrproject/zephyr$ git bisect good fb01c781b6c
status: waiting for bad commit, 1 good commit known
(20250910) cfriedt@ubuntu:~/zephyrproject/zephyr$ git bisect bad HEAD
Bisecting: 9 revisions left to test after this (roughly 3 steps)
[3dc72db57e2b92105b44004b3cdffb03a898126e] wifi: nrf_wifi: named MAC address choice
(20250910) cfriedt@ubuntu:~/zephyrproject/zephyr$ git bisect run ~/bisect.sh
running '/home/cfriedt/bisect.sh'
Updating west projects..
Bisecting: 4 revisions left to test after this (roughly 2 steps)
[093bb9972c487f85fbf709f4fced6ab62b3f9943] scripts: compliance: Harden the execution of npx
running '/home/cfriedt/bisect.sh'
Updating west projects..
Bisecting: 2 revisions left to test after this (roughly 1 step)
[bfd033df81a82960cc5a99f731acc931c504339a] modules: nrf_wifi: add missing Kconfig dependency
running '/home/cfriedt/bisect.sh'
Updating west projects..
Bisecting: 0 revisions left to test after this (roughly 0 steps)
[1d357e042c6a131439c00de59cc752a693c6ca11] tests: lib: fdtable: declare the fd used by test
running '/home/cfriedt/bisect.sh'
Updating west projects..
1d357e042c6a131439c00de59cc752a693c6ca11 is the first bad commit
commit 1d357e042c6a131439c00de59cc752a693c6ca11
Author: Jordan Yates <jordan@embeint.com>
Date:   Thu Oct 30 18:13:36 2025 +1000

    tests: lib: fdtable: declare the fd used by test
    
    Ensure that the test has a free file descriptor to use.
    
    Signed-off-by: Jordan Yates <jordan@embeint.com>

 tests/lib/fdtable/Kconfig | 8 ++++++++
 1 file changed, 8 insertions(+)
 create mode 100644 tests/lib/fdtable/Kconfig
bisect found first bad commit
```