### PR TITLE
Menuconfig & GUIconfig aborts on range values

### DIFF
--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -1313,7 +1313,7 @@ def _check_valid(dialog, entry, sym, s):
         entry.focus_set()
         return False
 
-    for low_sym, high_sym, cond in sym.ranges:
+    for low_sym, high_sym, cond, _ in sym.ranges:
         if expr_value(cond):
             low_s = low_sym.str_value
             high_s = high_sym.str_value
@@ -1336,7 +1336,7 @@ def _range_info(sym):
     # 'sym', or None if 'sym' doesn't have a range
 
     if sym.type in (INT, HEX):
-        for low, high, cond in sym.ranges:
+        for low, high, cond, _ in sym.ranges:
             if expr_value(cond):
                 return "Range: {}-{}".format(low.str_value, high.str_value)
 

--- a/scripts/kconfig/menuconfig.py
+++ b/scripts/kconfig/menuconfig.py
@@ -3096,7 +3096,7 @@ def _check_valid(sym, s):
                .format(s, TYPE_TO_STR[sym.orig_type]))
         return False
 
-    for low_sym, high_sym, cond in sym.ranges:
+    for low_sym, high_sym, cond, _ in sym.ranges:
         if expr_value(cond):
             low_s = low_sym.str_value
             high_s = high_sym.str_value
@@ -3116,7 +3116,7 @@ def _range_info(sym):
     # 'sym', or None if 'sym' doesn't have a range
 
     if sym.orig_type in (INT, HEX):
-        for low, high, cond in sym.ranges:
+        for low, high, cond, _ in sym.ranges:
             if expr_value(cond):
                 return "Range: {}-{}".format(low.str_value, high.str_value)
 


### PR DESCRIPTION
`menuconfig` and `guiconfig` failed on range value.

How to reproduce:

**menuconfig**
```
west update
rm -rf build
west build -t menuconfig -p -b qemu_cortex_m3 zephyr/samples/hello_world
````

**guiconfig**
```
west update
rm -rf build
west build -t guiconfig -p -b qemu_cortex_m3 zephyr/samples/hello_world
```

Once the UI is up, go to any node with int value like `CONFIG_SRAM_SIZE` or `CONFIG_LOG_CORE_INIT_PRIORITY`.

This was unnotices after 125d0daaa17aad6a6221fe33dd1f1484c33e8c1d.

See the commit message for more details.