### PR TITLE
tests: drivers: flash: Fix for MAX32 flash1 testing

### DIFF
--- a/tests/drivers/flash/common/boards/max32690_flash1_storage_partition.overlay
+++ b/tests/drivers/flash/common/boards/max32690_flash1_storage_partition.overlay
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	chosen {
-		zephyr,flash-controller = &flc1;
-		zephyr,flash = &flash1;
-	};
-};
-
 &flash1 {
 	status = "okay";
 


### PR DESCRIPTION
Remove the erronously added chosen node for the MAX32690EVKit, to ensure the flash base address is correct for the build.

This is causing test failures (in error) in `main` and the 4.3 RC, so hoping we can get this in as part of my efforts to have tests green on MAX32 for the release. Thanks!

Fixes #98809