### PR TITLE
drivers: comparator: Silence GCC 14 uninitialized variable warning.

### DIFF
--- a/drivers/comparator/comparator_renesas_ra_lvd.c
+++ b/drivers/comparator/comparator_renesas_ra_lvd.c
@@ -70,7 +70,7 @@ static int lvd_renesas_ra_set_trigger(const struct device *dev, enum comparator_
 	struct lvd_renesas_ra_data *data = dev->data;
 	bool trigger_set = trigger != COMPARATOR_TRIGGER_NONE;
 	bool reset = config->action == LVD_ACTION_RESET;
-	lvd_voltage_slope_t voltage_slope;
+	lvd_voltage_slope_t voltage_slope = LVD_VOLTAGE_SLOPE_BOTH;
 	fsp_err_t fsp_err;
 
 	if (config->action == LVD_ACTION_NONE) {


### PR DESCRIPTION
When the renesas-rv-lvd driver is built with SDK 1.0 using GCC 14, the compiler emits a spurious uninitialized variable warning because it can't follow the control flow to figure out that the variable wasn't ever used without being initialized. Work around this by simply initializing it to one of the valid values.