### PR TITLE
samples + tests: add fdtable tag for ZVFS or FILE_SYSTEM dependency

### DIFF
--- a/samples/net/cloud/tagoio_http_post/sample.yaml
+++ b/samples/net/cloud/tagoio_http_post/sample.yaml
@@ -3,6 +3,7 @@ common:
     - net
     - cloud
     - dns
+    - fdtable
     - http
     - wifi
   min_ram: 64

--- a/samples/net/dns_resolve/sample.yaml
+++ b/samples/net/dns_resolve/sample.yaml
@@ -4,6 +4,7 @@ common:
   tags:
     - net
     - dns
+    - fdtable
 sample:
   description: DNS resolver, mDNS and LLMNR responder
   name: DNS resolver and responder sample application

--- a/samples/net/dsa/sample.yaml
+++ b/samples/net/dsa/sample.yaml
@@ -6,6 +6,7 @@ common:
   tags:
     - net
     - dsa
+    - fdtable
 tests:
   sample.net.dsa:
     build_only: true

--- a/samples/net/lwm2m_client/sample.yaml
+++ b/samples/net/lwm2m_client/sample.yaml
@@ -1,6 +1,9 @@
 sample:
   description: TBD
   name: TBD
+common:
+  tags:
+    - fdtable
 tests:
   sample.net.lwm2m_client:
     harness: net

--- a/samples/net/mdns_responder/sample.yaml
+++ b/samples/net/mdns_responder/sample.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - net
     - mdns
+    - fdtable
 sample:
   name: mDNS responder
 tests:

--- a/samples/net/midi2/sample.yaml
+++ b/samples/net/midi2/sample.yaml
@@ -4,6 +4,7 @@ common:
   tags:
     - net
     - midi2
+    - fdtable
 sample:
   name: Network MIDI2.0 sample application
   description: Demonstrates usage of the Network MIDI2.0 (udp) host endpoint

--- a/samples/net/openthread/border_router/sample.yaml
+++ b/samples/net/openthread/border_router/sample.yaml
@@ -1,6 +1,7 @@
 common:
   harness: net
   tags:
+    - fdtable
     - net
     - openthread
   depends_on: openthread

--- a/samples/net/sockets/coap_client/sample.yaml
+++ b/samples/net/sockets/coap_client/sample.yaml
@@ -7,6 +7,7 @@ tests:
   sample.net.sockets.coap_client:
     harness: net
     tags:
+      - fdtable
       - net
       - socket
     platform_allow: qemu_x86

--- a/samples/net/sockets/coap_server/sample.yaml
+++ b/samples/net/sockets/coap_server/sample.yaml
@@ -1,6 +1,7 @@
 common:
   harness: net
   tags:
+    - fdtable
     - net
     - socket
   filter: CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC

--- a/samples/net/sockets/echo_async/sample.yaml
+++ b/samples/net/sockets/echo_async/sample.yaml
@@ -6,6 +6,7 @@ common:
   harness: net
   platform_allow: qemu_x86
   tags:
+    - fdtable
     - net
     - socket
 tests:

--- a/samples/net/sockets/echo_async_select/sample.yaml
+++ b/samples/net/sockets/echo_async_select/sample.yaml
@@ -5,6 +5,7 @@ common:
   harness: net
   platform_allow: qemu_x86
   tags:
+    - fdtable
     - net
     - socket
   filter: CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC

--- a/samples/net/sockets/echo_client/sample.yaml
+++ b/samples/net/sockets/echo_client/sample.yaml
@@ -1,6 +1,7 @@
 common:
   harness: net
   tags:
+    - fdtable
     - net
     - socket
   depends_on: netif

--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -1,6 +1,7 @@
 common:
   harness: net
   tags:
+    - fdtable
     - net
     - socket
   depends_on: netif

--- a/samples/net/sockets/echo_service/sample.yaml
+++ b/samples/net/sockets/echo_service/sample.yaml
@@ -8,5 +8,6 @@ common:
 tests:
   sample.net.sockets.service.echo:
     tags:
+      - fdtable
       - net
       - socket

--- a/samples/net/sockets/http_client/sample.yaml
+++ b/samples/net/sockets/http_client/sample.yaml
@@ -3,6 +3,7 @@ common:
     - net
     - http
     - http_client
+    - fdtable
   min_ram: 32
   depends_on: netif
 sample:

--- a/samples/net/sockets/http_server/sample.yaml
+++ b/samples/net/sockets/http_server/sample.yaml
@@ -6,6 +6,7 @@ common:
   depends_on: netif
   min_ram: 192
   tags:
+    - fdtable
     - http
     - net
     - server

--- a/samples/net/sockets/sntp_client/sample.yaml
+++ b/samples/net/sockets/sntp_client/sample.yaml
@@ -3,7 +3,9 @@ sample:
   name: sntp_client
 common:
   harness: net
-  tags: net
+  tags:
+    - fdtable
+    - net
 tests:
   sample.net.sockets.sntp_client:
     platform_allow:

--- a/samples/net/sockets/websocket_client/sample.yaml
+++ b/samples/net/sockets/websocket_client/sample.yaml
@@ -1,5 +1,6 @@
 common:
   tags:
+    - fdtable
     - net
     - http
     - http_client

--- a/samples/net/zperf/sample.yaml
+++ b/samples/net/zperf/sample.yaml
@@ -1,5 +1,6 @@
 common:
   tags:
+    - fdtable
     - net
     - zperf
   platform_exclude:

--- a/samples/subsys/fs/ext2_fstab/sample.yaml
+++ b/samples/subsys/fs/ext2_fstab/sample.yaml
@@ -6,7 +6,9 @@ tests:
       - native_sim
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE="ext2_fstab.overlay"
-    tags: filesystem
+    tags:
+      - filesystem
+      - fdtable
     harness: console
     harness_config:
       type: one_line

--- a/samples/subsys/fs/fatfs_fstab/sample.yaml
+++ b/samples/subsys/fs/fatfs_fstab/sample.yaml
@@ -6,7 +6,9 @@ tests:
       - native_sim
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE="fatfs_fstab.overlay"
-    tags: filesystem
+    tags:
+      - filesystem
+      - fdtable
     harness: console
     harness_config:
       type: one_line

--- a/samples/subsys/fs/format/sample.yaml
+++ b/samples/subsys/fs/format/sample.yaml
@@ -1,5 +1,8 @@
 sample:
   name: format filesystem sample
+common:
+  tags:
+    - fdtable
 tests:
   sample.filesystem.format.littlefs:
     platform_allow:

--- a/samples/subsys/fs/fs_sample/sample.yaml
+++ b/samples/subsys/fs/fs_sample/sample.yaml
@@ -1,7 +1,9 @@
 sample:
   name: Filesystems sample
 common:
-  tags: filesystem
+  tags:
+    - filesystem
+    - fdtable
   modules:
     - fatfs
 tests:

--- a/samples/subsys/fs/littlefs/sample.yaml
+++ b/samples/subsys/fs/littlefs/sample.yaml
@@ -2,6 +2,7 @@ sample:
   name: littlefs filesystem sample
 common:
   tags:
+    - fdtable
     - filesystem
     - littefs
 tests:

--- a/samples/subsys/fs/virtiofs/sample.yaml
+++ b/samples/subsys/fs/virtiofs/sample.yaml
@@ -2,6 +2,7 @@ sample:
   name: virtio filesystem sample
 common:
   tags:
+    - fdtable
     - filesystem
     - virtio
 tests:

--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -30,6 +30,8 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
   sample.mcumgr.smp_svr.udp:
+    tags:
+      - fdtable
     extra_args: EXTRA_CONF_FILE="udp.conf"
     platform_allow:
       - frdm_mcxn947/mcxn947/cpu0
@@ -38,6 +40,8 @@ tests:
     integration_platforms:
       - frdm_k64f
   sample.mcumgr.smp_svr.udp_dtls:
+    tags:
+      - fdtable
     extra_args:
       - EXTRA_CONF_FILE="udp_dtls.conf"
       - CONFIG_IMG_MANAGER=n

--- a/samples/subsys/shell/fs/sample.yaml
+++ b/samples/subsys/shell/fs/sample.yaml
@@ -5,6 +5,7 @@ common:
   tags:
     - shell
     - filesystem
+    - fdtable
   harness: keyboard
 tests:
   sample.filesystem.shell:

--- a/tests/boot/with_mcumgr/testcase.yaml
+++ b/tests/boot/with_mcumgr/testcase.yaml
@@ -8,6 +8,7 @@ common:
   timeout: 600
   slow: true
   tags:
+    - fdtable
     - pytest
     - mcuboot
     - mcumgr

--- a/tests/lib/c_lib/stdio/testcase.yaml
+++ b/tests/lib/c_lib/stdio/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   tags:
     - clib
+    - fdtable
   min_ram: 128
   filter: not CONFIG_NATIVE_LIBC
 tests:

--- a/tests/lib/gui/lvgl/testcase.yaml
+++ b/tests/lib/gui/lvgl/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   tags:
     - display
+    - fdtable
     - gui
 tests:
   libraries.gui.lvgl:

--- a/tests/modules/thrift/ThriftTest/testcase.yaml
+++ b/tests/modules/thrift/ThriftTest/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - thrift
     - cpp
+    - fdtable
   modules:
     - thrift
   filter: CONFIG_FULL_LIBC_SUPPORTED

--- a/tests/net/all/testcase.yaml
+++ b/tests/net/all/testcase.yaml
@@ -4,6 +4,7 @@ common:
   build_only: true
   min_ram: 32
   tags:
+    - fdtable
     - net
     - net-all
 tests:

--- a/tests/net/dhcpv4/client/testcase.yaml
+++ b/tests/net/dhcpv4/client/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - net
     - dhcpv4
+    - fdtable
 tests:
   net.dhcpv4_client:
     extra_configs:

--- a/tests/net/lib/dns_addremove/testcase.yaml
+++ b/tests/net/lib/dns_addremove/testcase.yaml
@@ -2,6 +2,7 @@ common:
   tags:
     - dns
     - net
+    - fdtable
   depends_on: netif
   min_ram: 16
   timeout: 600

--- a/tests/net/lib/dns_dispatcher/testcase.yaml
+++ b/tests/net/lib/dns_dispatcher/testcase.yaml
@@ -2,6 +2,7 @@ common:
   tags:
     - dns
     - net
+    - fdtable
   depends_on: netif
   min_ram: 21
   timeout: 600

--- a/tests/net/lib/dns_resolve/testcase.yaml
+++ b/tests/net/lib/dns_resolve/testcase.yaml
@@ -2,6 +2,7 @@ common:
   tags:
     - dns
     - net
+    - fdtable
   depends_on: netif
   timeout: 600
   min_ram: 21

--- a/tests/net/lib/dns_sd/testcase.yaml
+++ b/tests/net/lib/dns_sd/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   tags:
     - dns
+    - fdtable
     - net
   depends_on: netif
 tests:

--- a/tests/net/lib/http_server/core/testcase.yaml
+++ b/tests/net/lib/http_server/core/testcase.yaml
@@ -3,6 +3,7 @@ common:
   min_ram: 80
   min_flash: 200
   tags:
+    - fdtable
     - http
     - net
     - server

--- a/tests/net/lib/http_server/crime/testcase.yaml
+++ b/tests/net/lib/http_server/crime/testcase.yaml
@@ -2,6 +2,7 @@ common:
   depends_on: netif
   min_ram: 60
   tags:
+    - fdtable
     - http
     - net
     - server

--- a/tests/net/lib/http_server/tls/testcase.yaml
+++ b/tests/net/lib/http_server/tls/testcase.yaml
@@ -2,6 +2,7 @@ common:
   depends_on: netif
   min_ram: 192
   tags:
+    - fdtable
     - http
     - net
     - server

--- a/tests/net/lib/lwm2m/interop/testcase.yaml
+++ b/tests/net/lib/lwm2m/interop/testcase.yaml
@@ -14,3 +14,4 @@ tests:
       - testing
       - pytest
       - shell
+      - fdtable

--- a/tests/net/lib/lwm2m/lwm2m_engine/testcase.yaml
+++ b/tests/net/lib/lwm2m/lwm2m_engine/testcase.yaml
@@ -3,6 +3,7 @@ tests:
     platform_key:
       - simulation
     tags:
+      - fdtable
       - lwm2m
       - net
     integration_platforms:

--- a/tests/net/lib/mdns_responder/testcase.yaml
+++ b/tests/net/lib/mdns_responder/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   tags:
     - dns
+    - fdtable
     - net
   depends_on: netif
 tests:

--- a/tests/net/socket/poll/testcase.yaml
+++ b/tests/net/socket/poll/testcase.yaml
@@ -7,3 +7,4 @@ tests:
       - net
       - socket
       - poll
+      - fdtable

--- a/tests/net/socket/select/testcase.yaml
+++ b/tests/net/socket/select/testcase.yaml
@@ -2,6 +2,7 @@ common:
   depends_on: netif
   min_ram: 21
   tags:
+    - fdtable
     - net
     - socket
     - userspace

--- a/tests/net/socket/service/testcase.yaml
+++ b/tests/net/socket/service/testcase.yaml
@@ -7,3 +7,4 @@ tests:
       - net
       - socket
       - poll
+      - fdtable

--- a/tests/net/socket/socketpair/testcase.yaml
+++ b/tests/net/socket/socketpair/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   tags:
+    - fdtable
     - net
     - socket
     - userspace

--- a/tests/net/socket/tls/testcase.yaml
+++ b/tests/net/socket/tls/testcase.yaml
@@ -3,6 +3,7 @@ common:
   min_ram: 32
   min_flash: 260
   tags:
+    - fdtable
     - net
     - socket
     - tls

--- a/tests/net/socket/tls_ext/testcase.yaml
+++ b/tests/net/socket/tls_ext/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   tags:
+    - fdtable
     - net
     - socket
     - tls

--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   depends_on: netif
   tags:
+    - fdtable
     - net
     - socket
     - udp

--- a/tests/posix/fs/testcase.yaml
+++ b/tests/posix/fs/testcase.yaml
@@ -4,6 +4,7 @@ common:
     - posix
     - filesystem
     - fatfs
+    - fdtable
   min_ram: 128
   modules:
     - fatfs

--- a/tests/posix/headers/testcase.yaml
+++ b/tests/posix/headers/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   filter: not CONFIG_NATIVE_LIBC
   tags:
+    - fdtable
     - posix
   min_ram: 32
   # 1 tier0 platform per supported architecture

--- a/tests/posix/xsi_realtime/testcase.yaml
+++ b/tests/posix/xsi_realtime/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   filter: not CONFIG_NATIVE_LIBC
   tags:
+    - fdtable
     - posix
     - xsi_realtime
   # 1 tier0 platform per supported architecture

--- a/tests/subsys/fs/ext2/testcase.yaml
+++ b/tests/subsys/fs/ext2/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: filesystem
+  tags:
+    - fdtable
+    - filesystem
 tests:
   filesystem.ext2.default:
     platform_allow:

--- a/tests/subsys/fs/fat_fs_api/testcase.yaml
+++ b/tests/subsys/fs/fat_fs_api/testcase.yaml
@@ -2,6 +2,7 @@ common:
   tags:
     - filesystem
     - fatfs
+    - fdtable
   modules:
     - fatfs
 tests:

--- a/tests/subsys/fs/fat_fs_dual_drive/testcase.yaml
+++ b/tests/subsys/fs/fat_fs_dual_drive/testcase.yaml
@@ -6,6 +6,8 @@ tests:
       - qemu_leon3
       - qemu_riscv32
       - qemu_riscv64
-    tags: filesystem
+    tags:
+      - fdtable
+      - filesystem
     integration_platforms:
       - native_sim

--- a/tests/subsys/fs/fs_api/testcase.yaml
+++ b/tests/subsys/fs/fs_api/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   filesystem.api:
-    tags: filesystem
+    tags:
+      - fdtable
+      - filesystem
     integration_platforms:
       - native_sim

--- a/tests/subsys/fs/lib_link/testcase.yaml
+++ b/tests/subsys/fs/lib_link/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   filesystem.lib_link:
-    tags: filesystem
+    tags:
+      - fdtable
+      - filesystem
     integration_platforms:
       - native_sim

--- a/tests/subsys/fs/littlefs/testcase.yaml
+++ b/tests/subsys/fs/littlefs/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   tags:
+    - fdtable
     - filesystem
     - littlefs
   platform_allow:

--- a/tests/subsys/fs/multi-fs/testcase.yaml
+++ b/tests/subsys/fs/multi-fs/testcase.yaml
@@ -3,6 +3,7 @@ common:
     - littlefs
     - fatfs
     - filesystem
+    - fdtable
   modules:
     - fatfs
     - littlefs

--- a/tests/subsys/logging/log_backend_fs/testcase.yaml
+++ b/tests/subsys/logging/log_backend_fs/testcase.yaml
@@ -7,6 +7,7 @@ common:
     - filesystem
     - fs
     - littlefs
+    - fdtable
   platform_allow:
     - native_sim
     - native_sim/native/64

--- a/tests/subsys/mgmt/mcumgr/all_options/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/all_options/testcase.yaml
@@ -6,6 +6,7 @@
 common:
   platform_allow: nrf52840dk/nrf52840
   tags:
+    - fdtable
     - mgmt
     - mcumgr
     - all_options

--- a/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported/testcase.yaml
@@ -8,6 +8,7 @@ common:
     - mgmt
     - mcumgr
     - fs_mgmt_hash_supported
+    - fdtable
   integration_platforms:
     - native_sim
   platform_exclude:

--- a/tests/subsys/settings/file/testcase.yaml
+++ b/tests/subsys/settings/file/testcase.yaml
@@ -18,3 +18,4 @@ tests:
       - settings
       - file
       - littlefs
+      - fdtable

--- a/tests/subsys/settings/functional/file/testcase.yaml
+++ b/tests/subsys/settings/functional/file/testcase.yaml
@@ -15,3 +15,4 @@ tests:
     tags:
       - settings
       - file
+      - fdtable


### PR DESCRIPTION
Previously, making changes to the Zephyr fdtable would not necessarily trigger all of the testsuites that depend on fdtable.

These are mostly limited to networking and filesystem consumers.

tested using

```
twister -c -p mps2/an385 -y --tag fdtable -T .
jq -r '.testsuites[].path' twister-out/testplan.json | sort -u
```