### PR TITLE
drivers: ksz8081: Start monitoring phy after init

### DIFF
--- a/drivers/ethernet/phy/phy_microchip_ksz8081.c
+++ b/drivers/ethernet/phy/phy_microchip_ksz8081.c
@@ -707,6 +707,8 @@ static int phy_mc_ksz8081_init(const struct device *dev)
 
 	data->flags |= KSZ8081_INITIALIZED;
 
+	k_work_reschedule(&data->phy_monitor_work, K_MSEC(CONFIG_PHY_MONITOR_PERIOD));
+
 	return 0;
 }
 

--- a/drivers/mdio/mdio_nxp_enet.c
+++ b/drivers/mdio/mdio_nxp_enet.c
@@ -216,7 +216,6 @@ static int nxp_enet_mdio_init(const struct device *dev)
 
 	data->base = (ENET_Type *)DEVICE_MMIO_GET(config->module_dev);
 
-	k_busy_wait(100000);
 	ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (ret) {
 		return ret;


### PR DESCRIPTION
For some reason, a regression happened where the phy monitor was never happening. Fix by starting the monitor at the end of init function. The monitor will then reschedule itself from then on.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/97368

Also includes another fix for nxp mdio that was missed in 3d4a2beb9a2ea0c00fb805460b6415d6d514f931