### PR TITLE
boards: st: Clean up nodes with status = "disabled"

### DIFF
--- a/boards/st/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.dts
@@ -51,6 +51,7 @@
 
 	pwmleds: pwmleds {
 		compatible = "pwm-leds";
+		/* NOTE: disabled by default; PWM conflicts with SPI1 pins */
 		status = "disabled";
 
 		/*

--- a/boards/st/nucleo_f030r8/nucleo_f030r8_stm32f030x8_1.overlay
+++ b/boards/st/nucleo_f030r8/nucleo_f030r8_stm32f030x8_1.overlay
@@ -5,6 +5,7 @@
  */
 
 &clk_hse {
+	/* NOTE: Variant switches to internal HSI, so leave HSE off */
 	status = "disabled";
 };
 

--- a/boards/st/nucleo_f722ze/nucleo_f722ze.dts
+++ b/boards/st/nucleo_f722ze/nucleo_f722ze.dts
@@ -70,10 +70,6 @@
 	status = "okay";
 };
 
-&clk_hsi {
-	status = "disabled";
-};
-
 &clk_lsi {
 	status = "okay";
 };

--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -43,6 +43,7 @@
 
 	pwmleds: pwmleds {
 		compatible = "pwm-leds";
+		/* NOTE: disabled by default, TIM3_CH3 reuses PB0 (green LED) */
 		status = "disabled";
 
 		pwm_led_1: green_led_1 {

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -70,14 +70,6 @@
 	};
 };
 
-&clk_lsi {
-	status = "disabled";
-};
-
-&clk_hsi48 {
-	status = "disabled";
-};
-
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(24)>;
 	status = "okay";

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -70,6 +70,7 @@
 	csi_gpio0_hog: csi-gpio0-hog {
 		gpio-hog;
 		gpios = <5 GPIO_ACTIVE_HIGH>;
+		/* NOTE: disabled by default so PO5 stays free unless CSI is used */
 		status = "disabled";
 	};
 };
@@ -78,6 +79,7 @@
 	csi_gpio1_hog: csi-gpio1-hog {
 		gpio-hog;
 		gpios = <0 GPIO_ACTIVE_HIGH>;
+		/* NOTE: disabled by default so PA0 stays free unless CSI is used */
 		status = "disabled";
 	};
 };

--- a/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -42,6 +42,7 @@
 
 	pwmleds: pwmleds {
 		compatible = "pwm-leds";
+		/* NOTE: disabled by default, PWM reuses LED pins */
 		status = "disabled";
 
 		pwm_led_1: green_led_1 {

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
@@ -41,6 +41,7 @@
 
 	pwmleds: pwmleds {
 		compatible = "pwm-leds";
+		/* NOTE: disabled by default, PWM reuses LED pins */
 		status = "disabled";
 
 		pwm_led_1: green_led_1 {

--- a/boards/st/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/st/stm32f072b_disco/stm32f072b_disco.dts
@@ -57,6 +57,7 @@
 
 	pwmleds: pwmleds {
 		compatible = "pwm-leds";
+		/* NOTE: disabled by default; TIM3_CH1 shares LD3 pin PC6 */
 		status = "disabled";
 
 		red_pwm_led: red_pwm_led {

--- a/boards/st/stm32h747i_disco/stm32h747i_disco.dtsi
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
+	/* NOTE: shared resources enabled by the CM7/CM4 specific DTS files */
 	leds {
 		compatible = "gpio-leds";
 
@@ -39,6 +40,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+		/* NOTE: joystick buttons assigned per core in top-level DTS */
 
 		wake_up: button {
 			label = "Wakeup";
@@ -106,21 +108,21 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <3  0 &gpiod 12  0>,  /* I2C4_SCL */
-			   <4  0 &gpiod 13  0>,  /* I2C4_SDA */
+		gpio-map = <3 0 &gpiod 12 0>,  /* I2C4_SCL */
+			   <4 0 &gpiod 13 0>,  /* I2C4_SDA */
 			   /* RESET is directly connected to MCU reset */
-			   <6  0 &gpioj 14  0>,  /* PWDN_EN */
-			   <12 0 &gpiob  7  0>,  /* DCMI_VSYNC */
-			   <14 0 &gpioa  4  0>,  /* DCMI_HSYNC */
-			   <16 0 &gpioa  6  0>,  /* DCMI_PIXCK */
-			   <20 0 &gpiob  9  0>,  /* DCMI_D7 */
-			   <21 0 &gpiob  8  0>,  /* DCMI_D6 */
-			   <22 0 &gpiod  3  0>,  /* DCMI_D5 */
-			   <23 0 &gpioc 11  0>,  /* DCMI_D4 */
-			   <24 0 &gpioc  9  0>,  /* DCMI_D3 */
-			   <25 0 &gpiog 10  0>,  /* DCMI_D2 */
-			   <26 0 &gpioc  7  0>,  /* DCMI_D1 */
-			   <27 0 &gpioc  6  0>;  /* DCMI_D0 */
+			   <6 0 &gpioj 14 0>,  /* PWDN_EN */
+			   <12 0 &gpiob 7 0>,  /* DCMI_VSYNC */
+			   <14 0 &gpioa 4 0>,  /* DCMI_HSYNC */
+			   <16 0 &gpioa 6 0>,  /* DCMI_PIXCK */
+			   <20 0 &gpiob 9 0>,  /* DCMI_D7 */
+			   <21 0 &gpiob 8 0>,  /* DCMI_D6 */
+			   <22 0 &gpiod 3 0>,  /* DCMI_D5 */
+			   <23 0 &gpioc 11 0>,  /* DCMI_D4 */
+			   <24 0 &gpioc 9 0>,  /* DCMI_D3 */
+			   <25 0 &gpiog 10 0>,  /* DCMI_D2 */
+			   <26 0 &gpioc 7 0>,  /* DCMI_D1 */
+			   <27 0 &gpioc 6 0>;  /* DCMI_D0 */
 	};
 };
 

--- a/boards/st/stm32h757i_eval/stm32h757i_eval.dtsi
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval.dtsi
@@ -8,6 +8,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
+	/* NOTE: shared peripherals, enabled selectively by each core's DTS */
 	leds {
 		compatible = "gpio-leds";
 
@@ -38,6 +39,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+		/* NOTE: buttons are assigned per core in the CM7/CM4 DTS files */
 
 		wake_up: button_1 {
 			label = "Wakeup";

--- a/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.dts
+++ b/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.dts
@@ -85,6 +85,7 @@
 };
 
 &usart6 {
+	/* NOTE: optional console UART, remains disabled by default */
 	pinctrl-0 = <&usart6_tx_pf13 &usart6_rx_pf14>;
 	pinctrl-names = "default";
 	current-speed = <115200>;

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -90,6 +90,7 @@
 	csi_gpio0_hog: csi-gpio0-hog {
 		gpio-hog;
 		gpios = <8 GPIO_ACTIVE_HIGH>;
+		/* NOTE: keep CSI pins free unless the camera connector is used */
 		status = "disabled";
 	};
 };
@@ -98,6 +99,7 @@
 	csi_gpio1_hog: csi-gpio1-hog {
 		gpio-hog;
 		gpios = <2 GPIO_ACTIVE_HIGH>;
+		/* NOTE: keep CSI pins free unless the camera connector is used */
 		status = "disabled";
 	};
 };

--- a/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
+++ b/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
@@ -32,6 +32,7 @@
 		color-mapping = <LED_COLOR_ID_BLUE
 				 LED_COLOR_ID_GREEN
 				 LED_COLOR_ID_RED>;
+		/* NOTE: optional LED strip on PA7, keep disabled by default */
 		status = "disabled";
 	};
 
@@ -176,6 +177,7 @@ zephyr_udc0: &usb {
 		gpios = <1 GPIO_ACTIVE_HIGH>;
 		gpio-hog;
 		output-high;
+		/* NOTE: only assert when the external LED strip is used */
 		status = "disabled";
 	};
 };


### PR DESCRIPTION
## Summary
- remove redundant `status = "disabled"` overrides already defined in SoC `.dtsi` files
- add NOTE comments where board-side disables remain intentional (pin conflicts, shared resources, optional peripherals)
- keep USART6 on stm32mp257f EV1 configured but disabled by default so overlays can enable it when needed

## Testing
- none (Devicetree-only changes)

Fixes #97995

If I missed any remaining board-side disables or if you prefer a different treatment for USART6, please let me know and I’ll adjust.
