### PR TITLE
Drivers: MCUX ADC16: Correct buffer size calculation for multi-channel read sequences

### DIFF
--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -191,6 +191,9 @@ static int start_read(const struct device *dev,
 	int error;
 	uint32_t tmp32;
 	ADC_Type *base = config->base;
+	size_t min_buffer_size = 0;
+
+	uint32_t channels_count = POPCOUNT(sequence->channels);
 
 	switch (sequence->resolution) {
 	case 8:
@@ -247,10 +250,25 @@ static int start_read(const struct device *dev,
 		return -EINVAL;
 	}
 
+	min_buffer_size = channels_count * sizeof(uint16_t);
+
+	if (channels_count == 0) {
+		LOG_ERR("No channels selected");
+		return -EINVAL;
+	}
+
+	if (sequence->buffer_size < min_buffer_size) {
+		LOG_ERR("sequence buffer size too small %d < %d",
+			sequence->buffer_size, min_buffer_size);
+		return -EINVAL;
+	}
+
 	if (sequence->options) {
-		if (sequence->buffer_size <
-			2 * (sequence->options->extra_samplings + 1)) {
-			LOG_ERR("sequence buffer size too small < 2 * extra + 2");
+		min_buffer_size = channels_count * sizeof(uint16_t) *
+				  (sequence->options->extra_samplings + 1);
+		if (sequence->buffer_size < min_buffer_size) {
+			LOG_ERR("sequence buffer size too small for samplings: %d < %d",
+				sequence->buffer_size, min_buffer_size);
 			return -EINVAL;
 		}
 	}


### PR DESCRIPTION
Fixes <https://github.com/zephyrproject-rtos/zephyr/issues/98953>

drivers: adc: mcux_adc16: Fix buffer size validation for multi-channel sequences

The mcux_adc16 driver's read function fails to correctly validate the user-provided buffer size when `adc_sequence.options` are used (i.e., for extra samplings or continuous conversions).

The validation calculation erroneously considered only the size required for a single channel multiplied by the total number of samplings: `sizeof(uint16_t) * (extra_samplings + 1)`.

This neglects the total number of channels enabled in `adc_sequence.channels`, leading to a **buffer overflow** if the sequence includes multiple channels.

Fix this by using `POPCOUNT(sequence->channels)` to determine the correct number of channels and ensuring the buffer size is sufficient for all requested samples.