### PR TITLE
tests: drivers: mspi: flash: disallow a53/smp in no-multi-threading case

### DIFF
--- a/tests/drivers/mspi/flash/testcase.yaml
+++ b/tests/drivers/mspi/flash/testcase.yaml
@@ -37,7 +37,8 @@ tests:
     extra_configs:
       - CONFIG_MSPI_DW_HANDLE_FIFOS_IN_SYSTEM_WORKQUEUE=y
   drivers.mspi.flash.mspi_nor_no_multithreading:
-    filter: dt_alias_exists("mspi0") and CONFIG_FLASH_MSPI_NOR
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_configs:


### PR DESCRIPTION
Exclude `qemu_cortex_a53/qemu_cortex_a53/smp` for the `drivers.mspi.flash.mspi_nor_no_multithreading` test configuration, since it caused a build failure that has been difficult to diagnose and fix.

https://github.com/zephyrproject-rtos/zephyr/actions/runs/18951062399/job/54115550437