### PR TITLE
crypto: Fix SHA-256 padding length field to 64-bit

### DIFF
--- a/drivers/crypto/crypto_it8xxx2_sha_v2.c
+++ b/drivers/crypto/crypto_it8xxx2_sha_v2.c
@@ -227,11 +227,17 @@ static int it8xxx2_hash_handler(struct hash_ctx *ctx, struct hash_pkt *pkt,
 		}
 
 		/*
-		 * Since input data (big-endian) are copied 1byte by 1byte to
-		 * it8xxx2 memory (little-endian), so the bit length needs to
-		 * be transformed into big-endian format and then write to memory.
+		 * SHA-256 requires the message length (in bits) as a 64-bit big-endian
+		 * integer in the final 8 bytes (words 14 and 15). The message is stored
+		 * in little-endian memory, so conversion is necessary.
 		 */
-		chip_ctx.w_sha[15] = sys_cpu_to_be32(chip_ctx.total_len * 8);
+		uint64_t bit_len = (uint64_t)chip_ctx.total_len * 8;
+
+		/* Word 14: Most Significant 32 bits */
+		chip_ctx.w_sha[14] = sys_cpu_to_be32((uint32_t)(bit_len >> 32));
+
+		/* Word 15: Least Significant 32 bits */
+		chip_ctx.w_sha[15] = sys_cpu_to_be32((uint32_t)(bit_len & 0xFFFFFFFFUL));
 
 		/* HW automatically load 64Bytes data from DLM */
 		sys_write8(IT8XXX2_SHAEXEC_64Byte, IT8XXX2_SHA_REGS_BASE + IT8XXX2_REG_SHAECR);


### PR DESCRIPTION
Fixes <https://github.com/zephyrproject-rtos/zephyr/issues/98952>

The SHA-256 standard (FIPS 180-4) requires the total message length (L) in bits to be appended as a **64-bit big-endian integer**.

The previous implementation incorrectly calculated and wrote only the lower **32 bits** of the length field (to W[15]), implicitly assuming the upper 32 bits (W[14]) were correctly zeroed.

This commit updates `it51xxx_hash_handler()` to explicitly calculate the length using `uint64_t` and writes both the MSB (W[14]) and LSB (W[15]) words in big-endian format. This ensures standard compliance and correct hashing for all message lengths.

Reference: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf

<img width="500" height="577" alt="image" src="https://github.com/user-attachments/assets/93a16b9b-4560-47f5-9e0b-d3211b5e85d1" />
