### PR TITLE
drivers: flash: Read/write arbitary commands via ex_op API

### DIFF
--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -697,6 +697,54 @@ enum flash_ex_op_types {
 	 * Reset flash device.
 	 */
 	FLASH_EX_OP_RESET = 0,
+	/*
+	 * Issue a command to read from flash device.
+	 */
+	FLASH_EX_OP_CMD_READ = 1,
+	/*
+	 * Issue a command to write to flash device.
+	 */
+	FLASH_EX_OP_CMD_WRITE = 2,
+};
+
+/**
+ *  @brief Input for FLASH_EX_OP_CMD_READ extra flash operations
+ */
+struct flash_ex_op_cmd_read_in {
+	/* register or command to read */
+	uint8_t cmd;
+	/* buffer to write the read data to */
+	uint8_t *read_buffer;
+	/* length of above buffer */
+	size_t buffer_len;
+};
+
+/**
+ *  @brief Output from FLASH_EX_OP_CMD_READ extra flash operations
+ */
+struct flash_ex_op_cmd_read_out {
+	/* bytes actually read and stored in the input buffer */
+	size_t read_len;
+};
+
+/**
+ *  @brief Input for FLASH_EX_OP_CMD_WRITE extra flash operations
+ */
+struct flash_ex_op_cmd_write_in {
+	/* register or command to write */
+	uint8_t cmd;
+	/* buffer with the data to write */
+	uint8_t *write_buffer;
+	/* length of above buffer */
+	size_t buffer_len;
+};
+
+/**
+ *  @brief Output from FLASH_EX_OP_CMD_WRITE extra flash operations
+ */
+struct flash_ex_op_cmd_write_out {
+	/* bytes actually written from input buffer */
+	size_t write_len;
 };
 
 static inline int z_impl_flash_ex_op(const struct device *dev, uint16_t code,


### PR DESCRIPTION
Some of the drivers in Zephyr are bus-HAL-specific drivers. Example: [Zephyr SPI](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/flash/spi_nor.c), [Zephyr MSPI](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/flash/flash_mspi_nor.c), [NRFX QSPI](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/flash/nrf_qspi_nor.c), [STM QSPI](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/flash/flash_stm32_qspi.c). When users want to write flash-part specific driver with the command set of their particular flash part, they should not need to reimplment or copy everything the bus-specific driver is doing. It would be easier for users to compose their flash-vendor specific driver using the bus-specific driver already in tree.

This PR introduces the `flash_ex_op` API for the above goal. [npcx_flash](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/drivers/flash/npcx_flash_api_ex.h) already implements similar function in their vendor extended operations:
https://github.com/zephyrproject-rtos/zephyr/blob/0f5e03f1fcba4326baf4507c343f3609bf32c524/include/zephyr/drivers/flash/npcx_flash_api_ex.h#L57
https://github.com/zephyrproject-rtos/zephyr/blob/0f5e03f1fcba4326baf4507c343f3609bf32c524/include/zephyr/drivers/flash/npcx_flash_api_ex.h#L66

I want this for [Flash MSPI](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/flash/flash_mspi_nor.c) driver at least because setting up the MSPI transaction is not trivial, but I believe this extended operation will be relevant for more drivers too. Implementation for Flash MSPI driver to follow after a RFC on this: https://github.com/zephyrproject-rtos/zephyr/pull/98621