### PR TITLE
drivers: flash_mspi_nor: Implement flash_ex_op for cmd read/write 

### DIFF
--- a/drivers/flash/Kconfig.mspi
+++ b/drivers/flash/Kconfig.mspi
@@ -44,6 +44,7 @@ menuconfig FLASH_MSPI_NOR
 	depends on DT_HAS_JEDEC_MSPI_NOR_ENABLED
 	select FLASH_MSPI
 	select FLASH_HAS_EXPLICIT_ERASE
+	select FLASH_HAS_EX_OP
 	select FLASH_JESD216
 	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_MSPI_NOR),reset-gpios) \
 		    || $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_MSPI_NOR),supply-gpios)

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -697,6 +697,54 @@ enum flash_ex_op_types {
 	 * Reset flash device.
 	 */
 	FLASH_EX_OP_RESET = 0,
+	/*
+	 * Issue a command to read from flash device.
+	 */
+	FLASH_EX_OP_CMD_READ = 1,
+	/*
+	 * Issue a command to write to flash device.
+	 */
+	FLASH_EX_OP_CMD_WRITE = 2,
+};
+
+/**
+ *  @brief Input for FLASH_EX_OP_CMD_READ extra flash operations
+ */
+struct flash_ex_op_cmd_read_in {
+	/* register or command to read */
+	uint8_t cmd;
+	/* buffer to write the read data to */
+	uint8_t *read_buffer;
+	/* length of above buffer */
+	size_t buffer_len;
+};
+
+/**
+ *  @brief Output from FLASH_EX_OP_CMD_READ extra flash operations
+ */
+struct flash_ex_op_cmd_read_out {
+	/* bytes actually read and stored in the input buffer */
+	size_t read_len;
+};
+
+/**
+ *  @brief Input for FLASH_EX_OP_CMD_WRITE extra flash operations
+ */
+struct flash_ex_op_cmd_write_in {
+	/* register or command to write */
+	uint8_t cmd;
+	/* buffer with the data to write */
+	uint8_t *write_buffer;
+	/* length of above buffer */
+	size_t buffer_len;
+};
+
+/**
+ *  @brief Output from FLASH_EX_OP_CMD_WRITE extra flash operations
+ */
+struct flash_ex_op_cmd_write_out {
+	/* bytes actually written from input buffer */
+	size_t write_len;
 };
 
 static inline int z_impl_flash_ex_op(const struct device *dev, uint16_t code,


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/98619 introduced the flash extended operation API to allow other drivers to read/write arbitrary commands to the flash part. This PR implements that API for this driver.

## Testing
Tested using nRF54H with [Gigadevice GD25LE64E](https://www.mouser.com/datasheet/2/870/gd25le64e_rev1_3_20220426-2581248.pdf?srsltid=AfmBOorNVcnYnluZdrfwc0T8omPY6eENgh54MhcyPPMGnzULMow4bohG) flash part connected to the MSPI bus. Was able to send arbitary commands to the flash part to implement more vendor-specific functionalty like write-protect using this driver as the base.

Waiting for an RFC on this first: https://github.com/zephyrproject-rtos/zephyr/pull/98619