### PR TITLE
Renesas: crc : Fix state management and locking

### DIFF
--- a/drivers/crc/crc_renesas_ra.c
+++ b/drivers/crc/crc_renesas_ra.c
@@ -103,8 +103,8 @@ static int crc_set_config(const struct device *dev, struct crc_ctx *ctx)
 	err = RP_CRC_Reconfigure(&data->ctrl, crc_cfg);
 
 	if (err != FSP_SUCCESS) {
+		data->flag_crc_updated = false;
 		ctx->state = CRC_STATE_IDLE;
-		crc_unlock(dev);
 		return -EINVAL;
 	}
 
@@ -158,6 +158,7 @@ static int crc_renesas_ra_update(const struct device *dev, struct crc_ctx *ctx, 
 
 		err = R_CRC_Calculate(&data->ctrl, &data->input_data, &ctx->result);
 		if (err != FSP_SUCCESS) {
+			data->flag_crc_updated = false;
 			ctx->state = CRC_STATE_IDLE;
 			crc_unlock(dev);
 			return -EINVAL;
@@ -179,6 +180,7 @@ static int crc_renesas_ra_update(const struct device *dev, struct crc_ctx *ctx, 
 
 		err = R_CRC_Calculate(&data->ctrl, &data->input_data, &ctx->result);
 		if (err != FSP_SUCCESS) {
+			data->flag_crc_updated = false;
 			ctx->state = CRC_STATE_IDLE;
 			crc_unlock(dev);
 			return -EINVAL;


### PR DESCRIPTION
Fixes #98834

This PR resolves several critical issues concerning state management, thread safety, and data correctness when using the Renesas RA CRC driver for incremental calculations (i.e., using the `begin`/`update`/`finish` API sequence).

### 🐞 Issues Fixed:

#### 1. Semaphore Double-Release

The `crc_set_config` function prematurely called `crc_unlock(dev)` upon failure of `RP_CRC_Reconfigure`. Since `crc_renesas_ra_begin` also calls `crc_unlock(dev)` when `crc_set_config` returns an error, this resulted in calling `k_sem_give()` twice for a single `k_sem_take()`. This violated semaphore usage rules and corrupted the driver's thread safety.

* **Fix:** Removed the `crc_unlock()` call from `crc_set_config`. The locking/unlocking is now strictly managed by `crc_renesas_ra_begin` and `crc_renesas_ra_finish`.

#### 2. Inconsistent State Management

Upon errors during `crc_set_config` or `crc_renesas_ra_update`, the driver cleared `ctx->state` but failed to reset the internal `data->flag_crc_updated` flag. This could cause a subsequent attempt to incorrectly use the corrupted previous result as a seed.

* **Fix:** Added `data->flag_crc_updated = false;` to all error paths to ensure the driver state is fully reset and a new sequence correctly starts from the user-provided seed.