### PR TITLE
Bluetooth: hci_nxp: Fix Unique ID offset when setting MAC address

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -254,6 +254,7 @@ config BT_NXP
 	default y
 	depends on DT_HAS_NXP_HCI_BLE_ENABLED
 	select BT_HCI_SETUP
+	select CRC if BT_HCI_SET_PUBLIC_ADDR
 	help
 	  NXP HCI bluetooth interface
 


### PR DESCRIPTION
Fixes <https://github.com/zephyrproject-rtos/zephyr/issues/98951>

The previous method for generating the local MAC address from the MCU's Unique ID (UID) by slicing 3 bytes had two issues:
- Low Entropy: Risk of address collision due to poor randomization from the sliced bytes.
- Offset Error: The calculation for the slice starting point was incorrect.

This patch implements a CRC-32 hash over the entire 16-byte UID. The lower 3 bytes of the resulting hash are used as the MAC address's local part.

This change ensures a robust, highly unique address, resolving both the technical offset error and the underlying entropy problem