### PR TITLE
tests: watchdog: retain memory for frdm_mcxw23 and mcxw23_evk

### DIFF
--- a/boards/nxp/frdm_mcxw23/dts/bypass_first_32k.overlay
+++ b/boards/nxp/frdm_mcxw23/dts/bypass_first_32k.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sram0 {
+	reg = <0x2000C000 DT_SIZE_K(80)>;
+};

--- a/boards/nxp/mcxw23_evk/dts/bypass_first_32k.overlay
+++ b/boards/nxp/mcxw23_evk/dts/bypass_first_32k.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sram0 {
+	reg = <0x2000C000 DT_SIZE_K(80)>;
+};

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -35,6 +35,8 @@ tests:
       - frdm_mcxw71
       - frdm_mcxw72/mcxw727c/cpu0
       - raytac_an54lq_db_15/nrf54l15/cpuapp/ns
+      - frdm_mcxw23
+      - mcxw23_evk
   drivers.watchdog.stm32wwdg:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg.overlay"
@@ -156,3 +158,8 @@ tests:
     platform_allow:
       - frdm_mcxw71
       - frdm_mcxw72/mcxw727c/cpu0
+  drivers.watchdog.nxp_mcxw2xx_bypass_first_32k:
+    extra_args: EXTRA_DTC_OVERLAY_FILE="bypass_first_32k.overlay"
+    platform_allow:
+      - frdm_mcxw23
+      - mcxw23_evk


### PR DESCRIPTION
Added board shared sram bypass first 8KB overlay.
The overlay configure shall bypass first 8KB memory to avoid being clear during system startup.
In test_wdt.c, there're three variables m_state, m_testcase_index and m_testvalue which are linked in the NOINIT_SECTION section.
And these three variables are used to store the test state and the test case index, after the watchdog reset, this case will check the value of the m_state and m_testcase_index, then add 1 to m_testcase_index and run the next test case.
I checked the memory map and found these three variables are linked to:
0x200055e8 m_testvalue
0x200055ec m_testcase_index
0x200055f0 m_state
After the watchdog trigger a reset, the memory starts from 0x20005000 ~ 0x20005BC0 will be set to 0 automatically (Confirmed it is a silicon behaviour, maybe ROM code do this).
As a result, the value of the variables will be cleared to 0. This is why this case is always reset.

Validated the commands below, hi @hakehuang, please help to double check, thank you!
_west build -p=auto tests/drivers/watchdog/wdt_basic_api -b frdm_mcxw23 -T drivers.watchdog.nxp_mcxw2xx_bypass_first_8k
west build -p=auto tests/drivers/watchdog/wdt_basic_api -b mcxw23_evk -T drivers.watchdog.nxp_mcxw2xx_bypass_first_8k_

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/98282