### PR TITLE
Add microchip lan867x revd0 phy support

### DIFF
--- a/drivers/ethernet/phy/Kconfig.microchip_t1s
+++ b/drivers/ethernet/phy/Kconfig.microchip_t1s
@@ -9,4 +9,4 @@ config PHY_MICROCHIP_T1S
 	select PHY_OA_TC14_PLCA_LIB
 	help
 	  Enable Microchip's LAN8650/1 Rev.B0/B1 Internal PHYs and
-	  LAN8670/1/2 Rev.C1/C2 PHYs Driver.
+	  LAN8670/1/2 Rev.C1/C2/D0 PHYs Driver.

--- a/drivers/ethernet/phy/phy_microchip_t1s.c
+++ b/drivers/ethernet/phy/phy_microchip_t1s.c
@@ -169,7 +169,7 @@ static int mdio_setup_c45_indirect_access(const struct device *dev, uint16_t dev
 	int ret;
 
 	ret = mdio_write(cfg->mdio, cfg->phy_addr, MII_MMD_ACR, devad);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -196,7 +196,7 @@ static int phy_mc_t1s_c45_read(const struct device *dev, uint8_t devad, uint16_t
 
 	/* Read C45 registers using C22 indirect access registers */
 	ret = mdio_setup_c45_indirect_access(dev, devad, reg);
-	if (ret) {
+	if (ret < 0) {
 		mdio_bus_disable(cfg->mdio);
 		return ret;
 	}
@@ -223,7 +223,7 @@ static int phy_mc_t1s_c45_write(const struct device *dev, uint8_t devad, uint16_
 
 	/* Write C45 registers using C22 indirect access registers */
 	ret = mdio_setup_c45_indirect_access(dev, devad, reg);
-	if (ret) {
+	if (ret < 0) {
 		mdio_bus_disable(cfg->mdio);
 		return ret;
 	}
@@ -244,7 +244,7 @@ static int phy_mc_t1s_get_link(const struct device *dev, struct phy_link_state *
 	int ret;
 
 	ret = phy_mc_t1s_read(dev, MII_BMSR, &value);
-	if (ret) {
+	if (ret < 0) {
 		LOG_ERR("Failed MII_BMSR register read: %d\n", ret);
 		return ret;
 	}
@@ -307,13 +307,13 @@ static int lan865x_indirect_read(const struct device *dev, uint16_t addr, uint16
 	int ret;
 
 	ret = phy_mc_t1s_c45_write(dev, MDIO_MMD_VENDOR_SPECIFIC2, LAN865X_REG_CFGPARAM_ADDR, addr);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
 	ret = phy_mc_t1s_c45_write(dev, MDIO_MMD_VENDOR_SPECIFIC2, LAN865X_REG_CFGPARAM_CTRL,
 				   LAN865X_CFGPARAM_READ_ENABLE);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -327,7 +327,7 @@ static int lan865x_calculate_offset(const struct device *dev, uint16_t address, 
 	int ret;
 
 	ret = lan865x_indirect_read(dev, address, &value);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -360,13 +360,13 @@ static int lan865x_calculate_update_cfgparams(const struct device *dev)
 
 	/* Calculate offset1 */
 	ret = lan865x_calculate_offset(dev, 0x04, &offset1);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
 	/* Calculate offset2 */
 	ret = lan865x_calculate_offset(dev, 0x08, &offset2);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -399,7 +399,7 @@ static int phy_mc_lan865x_revb_config_init(const struct device *dev)
 	int ret;
 
 	ret = lan865x_calculate_update_cfgparams(dev);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -408,7 +408,7 @@ static int phy_mc_lan865x_revb_config_init(const struct device *dev)
 		ret = phy_mc_t1s_c45_write(dev, MDIO_MMD_VENDOR_SPECIFIC2,
 					   lan865x_revb_config[i].address,
 					   lan865x_revb_config[i].value);
-		if (ret) {
+		if (ret < 0) {
 			return ret;
 		}
 	}
@@ -430,7 +430,7 @@ static int phy_mc_lan867x_revc_config_init(const struct device *dev)
 	int ret;
 
 	ret = lan865x_calculate_update_cfgparams(dev);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -438,7 +438,7 @@ static int phy_mc_lan867x_revc_config_init(const struct device *dev)
 		ret = phy_mc_t1s_c45_write(dev, MDIO_MMD_VENDOR_SPECIFIC2,
 					   lan865x_revb_config[i].address,
 					   lan865x_revb_config[i].value);
-		if (ret) {
+		if (ret < 0) {
 			return ret;
 		}
 
@@ -503,7 +503,7 @@ static int lan86xx_config_collision_detection(const struct device *dev, bool plc
 	int ret;
 
 	ret = phy_mc_t1s_c45_read(dev, MDIO_MMD_VENDOR_SPECIFIC2, LAN86XX_REG_COL_DET_CTRL0, &val);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -526,7 +526,7 @@ static int phy_mc_t1s_id(const struct device *dev, uint32_t *phy_id)
 	int ret;
 
 	ret = phy_mc_t1s_read(dev, MII_PHYID1R, &value);
-	if (ret) {
+	if (ret < 0) {
 		LOG_ERR("Failed MII_PHYID1R register read: %d\n", ret);
 		return ret;
 	}
@@ -534,7 +534,7 @@ static int phy_mc_t1s_id(const struct device *dev, uint32_t *phy_id)
 	*phy_id = value << 16;
 
 	ret = phy_mc_t1s_read(dev, MII_PHYID2R, &value);
-	if (ret) {
+	if (ret < 0) {
 		LOG_ERR("Failed MII_PHYID2R register read: %d\n", ret);
 		return ret;
 	}
@@ -558,7 +558,7 @@ static int phy_mc_t1s_set_plca_cfg(const struct device *dev, struct phy_plca_cfg
 	}
 
 	ret = genphy_set_plca_cfg(dev, plca_cfg);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -592,7 +592,7 @@ static int phy_mc_t1s_init(const struct device *dev)
 	data->dev = dev;
 
 	ret = phy_mc_t1s_id(dev, &data->phy_id);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -618,7 +618,7 @@ static int phy_mc_t1s_init(const struct device *dev)
 	}
 
 	ret = phy_mc_t1s_set_dt_plca(dev);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 


### PR DESCRIPTION
Summary

This PR adds support for the Microchip LAN8670/1/2 Rev.D0 10BASE-T1S PHYs and implements proper link status control for the new silicon revision.

The LAN867x Rev.D0 devices introduce updated initialization requirements and behavior changes that differ from previous revisions, as outlined in Microchip Application Note AN1699 (Revision G, DS60001699G – October 2025).
🔗 [Microchip AN1699 – 10BASE-T1S PHY Initialization and Configuration](https://www.microchip.com/en-us/application-notes/an1699)

Changes Included

1. Add LAN867x Rev.D0 PHY Support

- Introduces specific initialization sequences required for optimal operation and OPEN Alliance compliance.
- Ensures compatibility with Rev.D0 silicon as described in the latest application note.
- Maintains backward compatibility with earlier silicon revisions.

2. Configure Link Status Control for Rev.D0

- Implements proper link status handling for LAN867x Rev.D0 devices:
  - PLCA Mode: Link status reflects the PLCA operational state.
  - CSMA/CD Mode: Since autonegotiation is not supported, the link status is forced active using the LINK_STATUS_SEMAPHORE bit.
- Configuration occurs:
  - During PHY initialization (default CSMA/CD mode).
  - Whenever PLCA configuration is updated.
- Ensures consistent and accurate link reporting across modes.