### PR TITLE
Enable SPI0 and SPI2 in PocketBeagle

### DIFF
--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am62_a53-common.dtsi
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am62_a53-common.dtsi
@@ -102,3 +102,15 @@
 &main_rti0 {
 	status = "okay";
 };
+
+&main_spi0 {
+	pinctrl-0 = <&main_spi0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&main_spi2 {
+	pinctrl-0 = <&main_spi2_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am62_a53-pinctrl.dtsi
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am62_a53-pinctrl.dtsi
@@ -376,4 +376,26 @@
 		/* (C13) SPI0_CS1.GPIO1_16 */
 		pinmux = <K3_PINMUX(0x01B8, PIN_INPUT, MUX_MODE_7)>;
 	};
+
+	main_spi0_default: main-spi0-default-pins {
+		pinmux = </* (A14) SPI0_CLK */
+			  K3_PINMUX(0x01bc, PIN_OUTPUT, MUX_MODE_0)
+			  /* (A13) SPI0_CS0 */
+			  K3_PINMUX(0x01b4, PIN_OUTPUT, MUX_MODE_0)
+			  /* (B13) SPI0_D0 */
+			  K3_PINMUX(0x01c0, PIN_INPUT, MUX_MODE_0)
+			  /* (B14) SPI0_D1 */
+			  K3_PINMUX(0x01c4, PIN_OUTPUT, MUX_MODE_0)>;
+	};
+
+	main_spi2_default: main-spi2-default-pins {
+		pinmux = </* (A20) MCASP0_ACLKR.SPI2_CLK */
+			  K3_PINMUX(0x01b0, PIN_OUTPUT, MUX_MODE_1)
+			  /* (E19) MCASP0_AFSR.SPI2_CS0 */
+			  K3_PINMUX(0x01ac, PIN_OUTPUT, MUX_MODE_1)
+			  /* (B19) MCASP0_AXR3.SPI2_D0 */
+			  K3_PINMUX(0x0194, PIN_INPUT, MUX_MODE_1)
+			  /* (A19) MCASP0_AXR2.SPI2_D1 */
+			  K3_PINMUX(0x0198, PIN_OUTPUT, MUX_MODE_1)>;
+	};
 };

--- a/dts/vendor/ti/k3-am62-main.dtsi
+++ b/dts/vendor/ti/k3-am62-main.dtsi
@@ -160,4 +160,32 @@
 		clock-frequency = <DT_FREQ_M(25)>;
 		status = "disabled";
 	};
+
+	main_spi0: spi@20100000 {
+		compatible = "ti,omap-mcspi";
+		reg = <0x20100000 0x400>;
+		clock-frequency = <DT_FREQ_M(50)>;
+		ti,spi-num-cs = <4>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	main_spi1: spi@20110000 {
+		compatible = "ti,omap-mcspi";
+		reg = <0x20110000 0x400>;
+		clock-frequency = <DT_FREQ_M(50)>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	main_spi2: spi@20120000 {
+		compatible = "ti,omap-mcspi";
+		reg = <0x20120000 0x400>;
+		clock-frequency = <DT_FREQ_M(50)>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
- SPI0 and SPI1 are the default states of these header pins, so enable
  them.