### PR TITLE
doc: contribute: Fixed missing code block new line

### DIFF
--- a/doc/contribute/style/index.rst
+++ b/doc/contribute/style/index.rst
@@ -96,6 +96,7 @@ to quickly reformat large amounts of devicetree files to our `Coding Style Guide
 standards. You can also run it manually like this:
 
 For individual files
+
 .. code-block:: bash
 
    npx dts-linter --format --file board.dts --file board_pinctrl.dtsi --patchFile diff.patch
@@ -106,6 +107,7 @@ has been called. Alternatively ``--cwd`` can also be passed set the base dir whe
 should look for files. This option is also used to make the paths relative in the patch file.
 
 You can also fix in place with
+
 .. code-block:: bash
 
    npx dts-linter --formatFixAll


### PR DESCRIPTION
dts-linter command was not correctly rendered in doc site.