### PR TITLE
drivers: led: fix LED_DT_SPEC_GET to use dts index

### DIFF
--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -486,7 +486,7 @@ static inline bool led_is_ready_dt(const struct led_dt_spec *spec)
 #define LED_DT_SPEC_GET(node_id)                                               \
 	{                                                                      \
 		.dev = DEVICE_DT_GET(DT_PARENT(node_id)),                      \
-		.index = DT_NODE_CHILD_IDX(node_id),                           \
+		.index = DT_PROP_OR(node_id, index, DT_NODE_CHILD_IDX(node_id)),         \
 	}
 
 /**


### PR DESCRIPTION
Previously, LED_DT_SPEC_GET always used the node's child index. Now, if the index in the dts file is specified, it will be used as described in led-controller.yaml