### PR TITLE
usb: host: usbip: check pool's buffer size USBIP_CMD_SUBMIT and fix actual_length in USBIP_RET_SUBMIT handling

### DIFF
--- a/subsys/usb/host/usbip.c
+++ b/subsys/usb/host/usbip.c
@@ -151,7 +151,11 @@ static int usbip_req_cb(struct usb_device *const udev, struct uhc_transfer *cons
 	}
 
 	if (xfer->err == 0 && cmd->submit.length != 0) {
-		ret.submit.actual_length = htonl(buf->len);
+		if (USB_EP_DIR_IS_IN(xfer->ep)) {
+			ret.submit.actual_length = htonl(buf->len);
+		} else {
+			ret.submit.actual_length = htonl(cmd->submit.length);
+		}
 	}
 
 
@@ -166,7 +170,7 @@ static int usbip_req_cb(struct usb_device *const udev, struct uhc_transfer *cons
 		goto usbip_req_cb_error;
 	}
 
-	if (ret.submit.actual_length != 0) {
+	if (USB_EP_DIR_IS_IN(xfer->ep) && ret.submit.actual_length != 0) {
 		LOG_INF("Send RET_SUBMIT transfer_buffer len %u", buf->len);
 		err = zsock_send(dev_ctx->connfd, buf->data, buf->len, 0);
 		if (err != buf->len) {

--- a/subsys/usb/host/usbip.c
+++ b/subsys/usb/host/usbip.c
@@ -253,6 +253,12 @@ static int usbip_handle_submit(struct usbip_dev_ctx *const dev_ctx,
 
 	ep = cmd->hdr.ep;
 	if (cmd->submit.length != 0) {
+		if (cmd->submit.length > USBIP_MAX_PKT_SIZE) {
+			LOG_ERR("Buffer size %u too small, requested length %zu",
+				USBIP_MAX_PKT_SIZE, cmd->submit.length);
+			return -ENOMEM;
+		}
+
 		buf = net_buf_alloc(&usbip_pool, K_NO_WAIT);
 		if (buf == NULL) {
 			LOG_ERR("Failed to allocate net_buf");


### PR DESCRIPTION
Check pool's buffer size USBIP_CMD_SUBMIT and fix actual_length in USBIP_RET_SUBMIT handling.