### PR TITLE
Bluetooth: Classic: HFP: Force ATD cmd to end with semicolon

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_hf.h
+++ b/include/zephyr/bluetooth/classic/hfp_hf.h
@@ -705,7 +705,7 @@ int bt_hfp_hf_query_respond_hold_status(struct bt_hfp_hf *hf);
  *
  *  Initiate outgoing voice calls by providing the destination phone
  *  number to the AG.
- *  Send the ATDdd…dd command to start phone number call.
+ *  Send the ATDdd...dd; command to start phone number call.
  *  The result of the command will be notified through the callback
  *  `dialing`.
  *
@@ -720,7 +720,7 @@ int bt_hfp_hf_number_call(struct bt_hfp_hf *hf, const char *number);
  *
  *  Initiate outgoing voice calls using the memory dialing feature
  *  of the AG.
- *  Send the ATD>Nan... command to start memory dialing.
+ *  Send the ATD>nnn...; command to start memory dialing.
  *  The result of the command will be notified through the callback
  *  `dialing`.
  *

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -2914,25 +2914,43 @@ static int bt_hfp_ag_atd_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 {
 	int err;
 	char *number = NULL;
+	uint8_t *data;
 	bool is_memory_dial = false;
-
-	if (buf->data[buf->len - 1] != '\r') {
-		return -ENOTSUP;
-	}
+	uint16_t len;
 
 	if (is_char(buf, '>')) {
 		is_memory_dial = true;
 	}
 
-	if ((buf->len - 1) > CONFIG_BT_HFP_AG_PHONE_NUMBER_MAX_LEN) {
+	len = sizeof(uint8_t) + sizeof(uint8_t);
+	if (buf->len <= len) {
+		LOG_WRN("Short packet");
+		return -EINVAL;
+	}
+
+	len = buf->len - len;
+	data = net_buf_pull_mem(buf, len);
+
+	if (!is_char(buf, ';')) {
+		LOG_WRN("Missing semicolon character");
+		return -ENOTSUP;
+	}
+
+	if (!is_char(buf, '\r')) {
+		LOG_WRN("Missing enter character");
+		return -ENOTSUP;
+	}
+
+	/* Change the `;` to `\0` */
+	data[len] = 0;
+
+	if (len > CONFIG_BT_HFP_AG_PHONE_NUMBER_MAX_LEN) {
 		return -ENAMETOOLONG;
 	}
 
-	buf->data[buf->len - 1] = '\0';
-
 	if (is_memory_dial) {
-		if (bt_ag && bt_ag->memory_dial) {
-			err = bt_ag->memory_dial(ag, &buf->data[0], &number);
+		if ((bt_ag != NULL) && (bt_ag->memory_dial != NULL)) {
+			err = bt_ag->memory_dial(ag, data, &number);
 			if ((err != 0) || (number == NULL)) {
 				return -ENOTSUP;
 			}
@@ -2940,10 +2958,10 @@ static int bt_hfp_ag_atd_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 			return -ENOTSUP;
 		}
 	} else {
-		number = &buf->data[0];
-		if (bt_ag && bt_ag->number_call) {
-			err = bt_ag->number_call(ag, &buf->data[0]);
-			if (err) {
+		number = (char *)data;
+		if ((bt_ag != NULL) && (bt_ag->number_call != NULL)) {
+			err = bt_ag->number_call(ag, number);
+			if (err != 0) {
 				return err;
 			}
 		} else {

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -3289,7 +3289,7 @@ int bt_hfp_hf_number_call(struct bt_hfp_hf *hf, const char *number)
 
 	hf_call_state_update(call, BT_HFP_HF_CALL_STATE_OUTGOING);
 
-	err = hfp_hf_send_cmd(hf, NULL, atd_finish, "ATD%s", number);
+	err = hfp_hf_send_cmd(hf, NULL, atd_finish, "ATD%s;", number);
 	if (err < 0) {
 		LOG_ERR("Fail to start phone number call on %p", hf);
 	}
@@ -3323,7 +3323,7 @@ int bt_hfp_hf_memory_dial(struct bt_hfp_hf *hf, const char *location)
 
 	hf_call_state_update(call, BT_HFP_HF_CALL_STATE_OUTGOING);
 
-	err = hfp_hf_send_cmd(hf, NULL, atd_finish, "ATD>%s", location);
+	err = hfp_hf_send_cmd(hf, NULL, atd_finish, "ATD>%s;", location);
 	if (err < 0) {
 		LOG_ERR("Fail to last number re-Dial on %p", hf);
 	}


### PR DESCRIPTION
* Bluetooth: Classic: HFP_HF: Force ATD cmd to end with semicolon

Only voice calls are supported by HFP specification. And the semicolon character shall be added when the voice call is originated.

Add the semicolon character to force the ATD command to end with semicolon character.

* Bluetooth: Classic: HFP_AG: Check semicolon character of AT CMD `ATD`

Check if the received AT command `ATD` is valid. When the semicolon is missing, return the error.

Remove the semicolon from the received valid data and notify received number or memory location value.
