### PR TITLE
net: support for easier out of tree net stack implementations

### DIFF
--- a/include/zephyr/net/net_linkaddr.h
+++ b/include/zephyr/net/net_linkaddr.h
@@ -30,7 +30,9 @@ extern "C" {
  */
 
 /** Maximum length of the link address */
-#if defined(CONFIG_NET_L2_PHY_IEEE802154) || defined(CONFIG_NET_L2_PPP)
+#if CONFIG_NET_LINK_ADDR_CUSTOM_LENGTH > 0
+#define NET_LINK_ADDR_MAX_LENGTH CONFIG_NET_LINK_ADDR_CUSTOM_LENGTH
+#elif defined(CONFIG_NET_L2_PHY_IEEE802154) || defined(CONFIG_NET_L2_PPP)
 #define NET_LINK_ADDR_MAX_LENGTH 8
 #else
 #define NET_LINK_ADDR_MAX_LENGTH 6

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -804,6 +804,14 @@ config NET_HEADERS_ALWAYS_CONTIGUOUS
 	  NET_BUF_FIXED_DATA_SIZE enabled and NET_BUF_DATA_SIZE of 128 for
 	  instance.
 
+config NET_LINK_ADDR_CUSTOM_LENGTH
+	int "Size of custom link layer address length"
+	default 0
+	help
+	  This option allows to define custom link layer address length
+	  if your link layer technology is not supported directly.
+	  As a default, custom link layer address length is not used.
+
 # If we are running network tests found in tests/net, then the NET_TEST is
 # set and in that case we default to Dummy L2 layer as typically the tests
 # use that by default.

--- a/subsys/net/ip/Kconfig.mgmt
+++ b/subsys/net/ip/Kconfig.mgmt
@@ -95,15 +95,23 @@ config NET_MGMT_EVENT_INFO
 	  and listeners will then be able to get it. Such information depends
 	  on the type of event.
 
+if NET_MGMT_EVENT_INFO
+config NET_MGMT_EVENT_INFO_DEFAULT_DATA_SIZE
+	int "Default size of event information data"
+	default 32
+	help
+	  The default size of the data which can be passed along with an event.
+
 config NET_MGMT_EVENT_MONITOR
 	bool "Monitor network events from net shell"
-	depends on NET_SHELL && NET_MGMT_EVENT_INFO
+	depends on NET_SHELL
 	help
 	  Allow user to monitor network events from net shell using
 	  "net events [on|off]" command. The monitoring is disabled by
 	  default. Note that you should probably increase the value of
 	  NET_MGMT_EVENT_QUEUE_SIZE from the default in order not to miss
 	  any events.
+endif # NET_MGMT_EVENT_INFO
 
 config NET_MGMT_EVENT_MONITOR_STACK_SIZE
 	int "Size of the stack allocated for the event_mon_stack thread"

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -26,7 +26,7 @@
 #include <zephyr/net/wifi_mgmt.h>
 #endif /* CONFIG_NET_L2_WIFI_MGMT */
 
-#define DEFAULT_NET_EVENT_INFO_SIZE 32
+#define DEFAULT_NET_EVENT_INFO_SIZE CONFIG_NET_MGMT_EVENT_INFO_DEFAULT_DATA_SIZE
 /* NOTE: Update this union with all *big* event info structs */
 union net_mgmt_events {
 #if defined(CONFIG_NET_DHCPV4)


### PR DESCRIPTION
Current default functionality is not changed, but this PR adds customization points by introducing 2 new Kconfig items:
- NET_LINK_ADDR_CUSTOM_LENGTH that allows to set custom link layer address length if your link layer technology is not supported directly
- NET_MGMT_EVENT_INFO_DEFAULT_DATA_SIZE is used to set the default size of the data field in the net_mgmt_event_info structure. This change allows the user to configure the size of the data field according to their needs.