### PR TITLE
bluetooth: revert `bt_ctlr_set_public_addr` deprecation

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -217,9 +217,6 @@ Bluetooth Controller
       :c:struct:`bt_hci_vs_fatal_error_cpu_data_cortex_m` and now contains the program counter
       value.
 
-   * :c:func:`bt_ctlr_set_public_addr` is deprecated. To set the public Bluetooth device address,
-     sending a vendor specific HCI command with :c:struct:`bt_hci_cp_vs_write_bd_addr` can be used.
-
 .. zephyr-keep-sorted-start re(^\w)
 
 Bluetooth Audio

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -87,9 +87,6 @@ Deprecated APIs and options
 
 * :kconfig:option:`CONFIG_POSIX_READER_WRITER_LOCKS` is deprecated. Use :kconfig:option:`CONFIG_POSIX_RW_LOCKS` instead.
 
-* :c:func:`bt_ctlr_set_public_addr` is deprecated in favor of using
-  :c:struct:`bt_hci_cp_vs_write_bd_addr` for setting the public Bluetooth device address.
-
 * :kconfig:option:`CONFIG_JWT_SIGN_RSA_LEGACY` is deprecated. Please switch to the
   PSA Crypto API based alternative (i.e. :kconfig:option:`CONFIG_JWT_SIGN_RSA_PSA`).
 

--- a/include/zephyr/bluetooth/controller.h
+++ b/include/zephyr/bluetooth/controller.h
@@ -29,7 +29,7 @@ extern "C" {
  *
  *  @param addr Public address
  */
-__deprecated void bt_ctlr_set_public_addr(const uint8_t *addr);
+void bt_ctlr_set_public_addr(const uint8_t *addr);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The deprecation of `bt_ctlr_set_public_addr` in #96596 was performed without a working alternative (see #98629).
Revert the change until it is possible to set the public address through the HCI command and have it be used.