### PR TITLE
sd: speed up mmc init

### DIFF
--- a/drivers/disk/mmc_subsys.c
+++ b/drivers/disk/mmc_subsys.c
@@ -114,6 +114,7 @@ static int disk_mmc_init(const struct device *dev)
 
 	data->status = SD_UNINIT;
 	data->card.bus_width = config->bus_width;
+	data->card.type = CARD_MMC;
 
 	return disk_access_register(data->disk_info);
 }

--- a/subsys/sd/sd.c
+++ b/subsys/sd/sd.c
@@ -202,7 +202,16 @@ static int sd_command_init(struct sd_card *card)
 	if (ret) {
 		return ret;
 	}
-
+#ifdef CONFIG_MMC_STACK
+	/*
+	 * If card type is already known, skip to relevant init.
+	 * SDMMC init takes pretty long, until it fails and we can
+	 * try MMC init.
+	 */
+	if (card->type == CARD_MMC) {
+		goto mmc_init;
+	}
+#endif /* CONFIG_MMC_STACK */
 #ifdef CONFIG_SDIO_STACK
 	/* Attempt to initialize SDIO card */
 	if (!sdio_card_init(card)) {
@@ -216,6 +225,7 @@ static int sd_command_init(struct sd_card *card)
 	}
 #endif /* CONFIG_SDMMC_STACK */
 #ifdef CONFIG_MMC_STACK
+mmc_init:
 	ret = sd_idle(card);
 	if (ret) {
 		LOG_ERR("Card error on CMD0");


### PR DESCRIPTION
speed up mmc init, when sdmmc is also
used. as sdmmc has to fail for that and
can take some long time.