### PR TITLE
tests: uart: silabs: introduce board overlay for silabs eusart peripheral

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/bg27_rb4110b.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/bg27_rb4110b.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025, Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Connect EXP4 (PC3) and EXP6 (PC5) of the Expansion Pin header
+ */
+
+dut: &eusart0 {
+	compatible = "silabs,eusart-uart";
+	dmas = <&dma0 DMA_REQSEL_EUSART0TXFL>,
+	       <&dma0 DMA_REQSEL_EUSART0RXFL>;
+	dma-names = "tx", "rx";
+	pinctrl-0 = <&eusart0_default>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+	/delete-property/ cs-gpios;
+};
+
+&dma0 {
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_async_api/boards/slwrb4180b.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/slwrb4180b.overlay
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025, Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Need to connect PC0 and PC1 of the Expension Pin header
+ */
+/ {
+	chosen {
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
+		zephyr,uart-pipe = &usart1;
+	};
+};
+
+&pinctrl {
+	usart0_default: usart0_default {
+		group0 {
+			pins = <USART0_TX_PC0>;
+			drive-push-pull;
+			output-high;
+		};
+
+		group1 {
+			pins = <USART0_RX_PC1>;
+			input-enable;
+			silabs,input-filter;
+		};
+	};
+
+	usart1_default: usart1_default {
+		group0 {
+			pins = <USART1_TX_PA5>;
+			drive-push-pull;
+			output-high;
+		};
+
+		group1 {
+			pins = <USART1_RX_PA6>;
+			input-enable;
+			silabs,input-filter;
+		};
+	};
+};
+
+dut: &usart0 {
+	dmas = <&dma0 DMA_REQSEL_USART0TXBL>,
+	       <&dma0 DMA_REQSEL_USART0RXDATAV>;
+	dma-names = "tx", "rx";
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+};
+
+&usart1 {
+	current-speed = <115200>;
+	pinctrl-0 = <&usart1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&dma0 {
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_async_api/boards/xg24_rb4186c.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/xg24_rb4186c.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025, Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Need to connect PC1 and PC2 of the Expension Pin header
+ */
+
+dut: &eusart1 {
+	compatible = "silabs,eusart-uart";
+	dmas = <&dma0 DMA_REQSEL_EUSART1TXFL>,
+	       <&dma0 DMA_REQSEL_EUSART1RXFL>;
+	dma-names = "tx", "rx";
+	pinctrl-0 = <&eusart1_default>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+	/delete-property/ cs-gpios;
+};
+
+&dma0 {
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_elementary/boards/bg27_rb4110b.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/bg27_rb4110b.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025, Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Connect EXP4 (PC3) and EXP6 (PC5) of the Expansion Pin header
+ */
+
+dut: &eusart0 {
+	compatible = "silabs,eusart-uart";
+	pinctrl-0 = <&eusart0_default>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+	/delete-property/ cs-gpios;
+};

--- a/tests/drivers/uart/uart_elementary/boards/slwrb4180b.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/slwrb4180b.overlay
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Connect EXP4 (PC0) and EXP6 (PC1) of the Expansion Pin header
+ */
+/ {
+	chosen {
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
+		zephyr,uart-pipe = &usart1;
+	};
+};
+
+&pinctrl {
+	usart0_default: usart0_default {
+		group0 {
+			pins = <USART0_TX_PC0>; /* EXP4 (PC0) */
+			drive-push-pull;
+			output-high;
+		};
+
+		group1 {
+			pins = <USART0_RX_PC1>; /* EXP6 (PC1) */
+			input-enable;
+			silabs,input-filter;
+		};
+	};
+
+	usart1_default: usart1_default {
+		group0 {
+			pins = <USART1_TX_PA5>;
+			drive-push-pull;
+			output-high;
+		};
+
+		group1 {
+			pins = <USART1_RX_PA6>;
+			input-enable;
+			silabs,input-filter;
+		};
+	};
+};
+
+dut: &usart0 {
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&usart1 {
+	current-speed = <115200>;
+	pinctrl-0 = <&usart1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_elementary/boards/xg23_rb4210a.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/xg23_rb4210a.overlay
@@ -12,25 +12,10 @@
 		zephyr,console = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,uart-pipe = &usart0;
-		/delete-property/ zephyr,display;
 	};
 };
 
 &pinctrl {
-	eusart1_default: eusart1_default {
-		group0 {
-			pins = <EUSART1_TX_PC1>; /* WPK EXP4 (PC1) */
-			drive-push-pull;
-			output-high;
-		};
-
-		group1 {
-			pins = <EUSART1_RX_PC2>; /* WPK EXP6 (PC2) */
-			input-enable;
-			silabs,input-filter;
-		};
-	};
-
 	usart0_default: usart0_default {
 		group0 {
 			pins = <USART0_TX_PA8>;
@@ -48,18 +33,12 @@
 
 dut: &eusart1 {
 	compatible = "silabs,eusart-uart";
-	dmas = <&dma0 DMA_REQSEL_EUSART1TXFL>,
-	       <&dma0 DMA_REQSEL_EUSART1RXFL>;
-	dma-names = "tx", "rx";
 	current-speed = <115200>;
 	pinctrl-0 = <&eusart1_default>;
 	pinctrl-names = "default";
 	status = "okay";
 	/delete-property/ cs-gpios;
 };
-
-/delete-node/ &ls0xx_ls013b7dh03;
-/delete-node/ &mx25r80;
 
 &eusart0 {
 	status = "disabled";
@@ -70,9 +49,5 @@ dut: &eusart1 {
 	current-speed = <115200>;
 	pinctrl-0 = <&usart0_default>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&dma0 {
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_elementary/boards/xg24_rb4186c.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/xg24_rb4186c.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025, Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Need to connect PC1 and PC2 of the Expension Pin header
+ */
+
+dut: &eusart1 {
+	compatible = "silabs,eusart-uart";
+	pinctrl-0 = <&eusart1_default>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+	/delete-property/ cs-gpios;
+};

--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -27,7 +27,10 @@ tests:
       - esp32s3_devkitm/esp32s3/procpu
       - bgm220_ek4314a
       - slwrb4180b
+      - xg23_rb4210a
+      - xg24_rb4186c
       - xg24_rb4187c
+      - bg27_rb4110b
       - bg29_rb4420a
       - xg29_rb4412a
       - b_u585i_iot02a

--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -26,6 +26,7 @@ tests:
       - esp32s2_saola
       - esp32s3_devkitm/esp32s3/procpu
       - bgm220_ek4314a
+      - slwrb4180b
       - xg24_rb4187c
       - bg29_rb4420a
       - xg29_rb4412a


### PR DESCRIPTION
This PR allows testing of the Silabs EUSART peripheral. It requires three different boards in order to test minor differences between peripheral IP versions.

There is also a commit to add a missing test for UART peripheral