### PR TITLE
drivers: gnss: allow same callback

### DIFF
--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -424,11 +424,11 @@ static inline int z_impl_gnss_get_latest_timepulse(const struct device *dev,
  * @param _callback The callback function
  */
 #if CONFIG_GNSS
-#define GNSS_DATA_CALLBACK_DEFINE(_dev, _callback)                                              \
-	static const STRUCT_SECTION_ITERABLE(gnss_data_callback,                                \
-					     _gnss_data_callback__##_callback) = {              \
-		.dev = _dev,                                                                    \
-		.callback = _callback,                                                          \
+#define GNSS_DATA_CALLBACK_DEFINE(_dev, _callback)                                                 \
+	static const STRUCT_SECTION_ITERABLE(gnss_data_callback,                                   \
+					     _CONCAT(_gnss_data_callback_, __COUNTER__)) = {       \
+		.dev = _dev,                                                                       \
+		.callback = _callback,                                                             \
 	}
 #else
 #define GNSS_DATA_CALLBACK_DEFINE(_dev, _callback)
@@ -441,11 +441,11 @@ static inline int z_impl_gnss_get_latest_timepulse(const struct device *dev,
  * @param _callback The callback function
  */
 #if CONFIG_GNSS_SATELLITES
-#define GNSS_SATELLITES_CALLBACK_DEFINE(_dev, _callback)                                        \
-	static const STRUCT_SECTION_ITERABLE(gnss_satellites_callback,                          \
-					     _gnss_satellites_callback__##_callback) = {        \
-		.dev = _dev,                                                                    \
-		.callback = _callback,                                                          \
+#define GNSS_SATELLITES_CALLBACK_DEFINE(_dev, _callback)                                           \
+	static const STRUCT_SECTION_ITERABLE(gnss_satellites_callback,                             \
+					     _CONCAT(_gnss_satellites_callback_, __COUNTER__)) = { \
+		.dev = _dev,                                                                       \
+		.callback = _callback,                                                             \
 	}
 #else
 #define GNSS_SATELLITES_CALLBACK_DEFINE(_dev, _callback)

--- a/include/zephyr/gnss/rtk/rtk.h
+++ b/include/zephyr/gnss/rtk/rtk.h
@@ -30,11 +30,11 @@ struct gnss_rtk_data_callback {
 };
 
 #if CONFIG_GNSS_RTK
-#define GNSS_RTK_DATA_CALLBACK_DEFINE(_dev, _callback)						   \
-	static const STRUCT_SECTION_ITERABLE(gnss_rtk_data_callback,				   \
-					     _gnss_rtk_data_callback__##_callback) = {		   \
-		.dev = _dev,									   \
-		.callback = _callback,								   \
+#define GNSS_RTK_DATA_CALLBACK_DEFINE(_dev, _callback)                                             \
+	static const STRUCT_SECTION_ITERABLE(gnss_rtk_data_callback,                               \
+					     _CONCAT(_gnss_rtk_data_callback_, __COUNTER__)) = {   \
+		.dev = _dev,                                                                       \
+		.callback = _callback,                                                             \
 	}
 #else
 #define GNSS_RTK_DATA_CALLBACK_DEFINE(_dev, _callback)


### PR DESCRIPTION
[drivers: gnss: allow same callback](https://github.com/zephyrproject-rtos/zephyr/commit/4a285165d58c192017499836befb211182d32282) 

The current implementation of GNSS_DATA_CALLBACK_DEFINE and
GNSS_SATELLITES_CALLBACK_DEFINE only use the provided `_callback` to
uniquely identify the entry that will be created. This implies that the
same callback cannot be registered twice, even if the device it is being
attached to is different.

In order to allow the same callback to be registered several times, the
ideal would be to also use `_dev` in combination with `_callback` to
uniquely identify the generated entry. But this would require getting the
node_id of the device, hence breaking the current API. In order to avoid
that, use __COUNTER__ to avoid collisions.

[gnss: rtk: fix multiple instances of same device](https://github.com/zephyrproject-rtos/zephyr/commit/7eea2f77b618f455cdffeaf64157ed4f46926ecb) 

When multiple instances of the same type of RTK enabled GNSS device are
instantiated on the same board, there will be a collision with their RTK
data callbacks. The u-blox F9P module is a clear example of that, where the
following compilation error is reported:

     error: redefinition of '_gnss_rtk_data_callback__f9p_rtk_data_cb'

Similar to the solution used at https://github.com/zephyrproject-rtos/zephyr/commit/d36a0fcb9503f6e79a8844cfd12daeb225d24a5a (drivers: gnss: allow same
callback), use `__COUNTER__` instead of `_callback` in the generated entry
to avoid collisions.
