### PR TITLE
modules: lvgl: CMakeLists: Replace zephyr_compile_definitions

### DIFF
--- a/modules/lvgl/CMakeLists.txt
+++ b/modules/lvgl/CMakeLists.txt
@@ -15,9 +15,9 @@ zephyr_library()
 zephyr_include_directories(${LVGL_DIR}/src/)
 zephyr_include_directories(include)
 
-zephyr_compile_definitions(LV_CONF_INCLUDE_SIMPLE=1)
+zephyr_library_compile_definitions(LV_CONF_INCLUDE_SIMPLE=1)
 zephyr_library_compile_definitions(_POSIX_C_SOURCE=200809L)
-zephyr_compile_definitions(LV_CONF_PATH="${CMAKE_CURRENT_SOURCE_DIR}/include/lv_conf.h")
+zephyr_library_compile_definitions(LV_CONF_PATH="${CMAKE_CURRENT_SOURCE_DIR}/include/lv_conf.h")
 
 zephyr_library_sources(
 


### PR DESCRIPTION
Replace zephyr_compile_definitions with zephyr_library_compile_definitions to avoid setting options globally.

cc @nordicjm 

