### PR TITLE
drivers: usb: dc: stm32: fix usb_disable() deadlock on certain series

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -201,6 +201,16 @@ static struct usb_dc_stm32_state usb_dc_stm32_state;
 
 /* Internal functions */
 
+static bool usb_dc_stm32_clock_enabled(void)
+{
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+
+	enum clock_control_status status = clock_control_get_status(
+						clk, (clock_control_subsys_t)&pclken[0]);
+
+	return status == CLOCK_CONTROL_STATUS_ON;
+}
+
 static struct usb_dc_stm32_ep_state *usb_dc_stm32_get_ep_state(uint8_t ep)
 {
 	struct usb_dc_stm32_ep_state *ep_state_base;
@@ -938,6 +948,17 @@ int usb_dc_ep_disable(const uint8_t ep)
 
 	if (!ep_state) {
 		return -EINVAL;
+	}
+
+	if (!usb_dc_stm32_clock_enabled()) {
+		/*
+		 * During device teardown, EP disable is attempted after
+		 * the USB controller clock has been turned off. Accessing
+		 * it would do nothing and even deadlocks the SoC on certain
+		 * series: don't even bother trying. Return success as all
+		 * endpoints are disabled anyways when USB controller is off.
+		 */
+		return 0;
 	}
 
 	status = HAL_PCD_EP_Close(&usb_dc_stm32_state.pcd, ep);


### PR DESCRIPTION
During a teardown sequence performed by the USB DC stack's `usb_disable()`, the controller is first disabled by calling `usb_dc_detach()`, which turns off the USB controller clock in the STM32 implementation. `usb_disable()` then disables endpoints by calling `usb_dc_ep_disable()` on each of them, which is merely forwarded to `HAL_PCD_EP_Close()` by the STM32 driver. This order of operations means that the latter operation is actually operating on the no-longer-clocks USB controller!

Up until recently, memory accesses to MMIO of unclocked peripherals in STM32 SoCs would not cause issues, even if the resulting access was a no-op (read returns zero, write is ignored), so everything worked fine even if the access was *technically* illegal... However, on newer series with a different bus fabric, accesses to unclocked peripherals will instead deadlock the SoC!

Prevent illegal accesses inside `usb_dc_stm32_ep_disable()` by checking if the USB controller clock is enabled before calling `HAL_PCD_EP_Close()`, and skipping the call if it isn't. This allows `usb_disable()` to complete on series such as STM32N6.

Fixes #98857