### PR TITLE
cmake: Fix extensions module's implicit dependency on yaml module

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3,6 +3,7 @@
 include_guard(GLOBAL)
 
 include(user_cache)
+include(yaml)
 
 # Dependencies on CMake modules from the CMake distribution.
 include(CheckCCompilerFlag)


### PR DESCRIPTION
The CMake `extensions` module depends on the `yaml` module, but `extensions` did not explicitly include `yaml`.

When using `find_package(Zephyr ...)` with no components specified this issue is not seen as `zephyr_default` is included which includes many other modules, including `yaml` and `extensions`.
However, when `find_package(Zephyr ... COMPONENTS ...)` is used only the components specified are included, which can result in a build error.

For example, using `find_package(Zephyr ... COMPONENTS FindHostTools ...)` includes `FindHostTools`, which includes `extensions`, which depends on `yaml` but doesn't include it.
<img width="935" height="50" alt="image" src="https://github.com/user-attachments/assets/da813bb1-4c9f-4dd4-a5f9-0d65968fc676" />

This issue is fixed by including `yaml` in `extensions`.