### PR TITLE
drivers: mfd: npm13xx: add delay between timer strobing and hibernate

### DIFF
--- a/drivers/mfd/mfd_npm13xx.c
+++ b/drivers/mfd/mfd_npm13xx.c
@@ -273,6 +273,9 @@ int mfd_npm13xx_hibernate(const struct device *dev, uint32_t time_ms)
 		return ret;
 	}
 
+	/* give nPM13xx time to load the timer value */
+	k_msleep(1);
+
 	return mfd_npm13xx_reg_write(dev, NPM13XX_SHIP_BASE, SHIP_OFFSET_HIBERNATE, 1U);
 }
 


### PR DESCRIPTION
When using I2C clock frequency >= 250 kHz, it's been observed that the nPM1300 would unexpectedly wake up before requested time has expired. Add a delay between applying a new timer value and triggering hibernate to mitigate this.