### PR TITLE
soc: silabs: siwg917: Add configurable NWP boot features via DTS and Kconfig

### DIFF
--- a/drivers/wifi/siwx91x/Kconfig.siwx91x
+++ b/drivers/wifi/siwx91x/Kconfig.siwx91x
@@ -178,4 +178,30 @@ config WIFI_SILABS_SIWX91X_ENABLE_INSTANT_SCAN
 # This device supports filtering scan results for only one SSID.
 config WIFI_MGMT_SCAN_SSID_FILT_MAX
 	default 1
+
+config WIFI_SILABS_SIWX91X_MFP
+	bool "802.11w Management Frame Protection (MFP) support"
+	default y
+	help
+	  Enable IEEE 802.11w Management Frame Protection (MFP) for secure
+	  handling of management frames.
+
+	  Note:
+	    - Required for WPA3-Personal and WPA3-Transition modes.
+	    - Disabling this frees memory used by MFP, improving TCP throughput
+	      by about 10–12% (≈1–2 Mbps).
+
+config WIFI_SILABS_SIWX91X_FEAT_SECURITY_PSK
+	bool "WPA/WPA2 (PSK) Security Support"
+	default y
+	help
+	  Enable WPA/WPA2 (PSK-based) security in client mode.
+	  Recommended for configurations requiring WPA, WPA2, or mixed security modes.
+	  Disabling this feature can reduce data buffer usage, potentially improving throughput.
+
+config WIFI_SILABS_SIWX91X_FEAT_HIDE_PSK_CREDENTIALS
+	bool "Hide PSK and Sensitive Credentials in Logs"
+	help
+	  When enabled, prevents printing sensitive credentials such as
+	  PSK, PMK, and EAP keys in debug or log messages.
 endif

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -81,6 +81,10 @@
 		interrupt-parent = <&nvic>;
 		interrupts = <30 0>, <74 0>;
 		interrupt-names = "nwp_stack", "nwp_irq";
+		antenna-selection = "ext-gpios";
+		support-1p8v;
+		enable-xtal-correction;
+		qspi-80mhz-clk;
 		status = "okay";
 
 		bt_hci0: bt_hci {

--- a/dts/bindings/net/wireless/silabs,siwx91x-nwp.yaml
+++ b/dts/bindings/net/wireless/silabs,siwx91x-nwp.yaml
@@ -31,3 +31,49 @@ properties:
       - deep-sleep-without-ram-retention
       - deep-sleep-with-ram-retention
     required: true
+
+  support-1p8v:
+    type: boolean
+    description: |
+      Enables 1.8 V operation support.
+
+  enable-xtal-correction:
+    type: boolean
+    description: |
+      Enables automatic 40 MHz XTAL frequency correction.
+      Disable this when using a custom or uncalibrated XTAL and manual tuning is required.
+
+  qspi-80mhz-clk:
+    type: boolean
+    description: |
+      Enables 80 MHz QSPI clock mode for the NWP flash interface to improve
+      throughput. Enable this if the external flash device supports 80 MHz
+      operation; otherwise, keep it disabled.
+  # Note:
+  # Zephyr typically manages clocks via a clock-controller driver.
+  # However, the NWP is not yet fully compatible with that model.
+  # This property is kept as a temporary solution for NWP-specific configuration.
+
+  antenna-selection:
+    type: string
+    description: |
+      Selects the front-end (antenna) switch configuration for the NWP.
+
+      This property determines how the RF path is controlled:
+        - "none": Reserved or unused configuration.
+        - "ext-gpios": Use external ULP GPIOs (4, 5, and 0) as ANT_SEL control lines
+          for the external RF switch network.
+        - "internal": Use the internal on-chip RF switch logic. No external GPIO
+          control is required. Recommended for boards without an external RF
+          switch circuit.
+
+      The value maps directly to bits [30:29] of the SL_SI91X_EXT_FEAT register:
+        - 00b: Reserved
+        - 01b: External GPIOs (ULP_GPIO4/5/0)
+        - 10b: Internal front-end switch
+        - 11b: Reserved
+    enum:
+      - "none"
+      - "ext-gpios"
+      - "internal"
+    required: true


### PR DESCRIPTION
Adds support for configuring SiWx91x NWP boot features using Devicetree and Kconfig.
Introduces new DTS properties for hardware-specific options (e.g., RTC sync, 1.8 V support, XTAL correction, QSPI 80 MHz, front-end switch modes) and Kconfig entries for software-defined boot configurations.