### PR TITLE
drivers: i2c: reduce the use of i2c_burst_write

### DIFF
--- a/drivers/audio/cs43l22.c
+++ b/drivers/audio/cs43l22.c
@@ -71,24 +71,12 @@ LOG_MODULE_REGISTER(cirrus_cs43l22);
 #define SPEAKER_A_MUTE    (1 << 4)
 
 #define cs43l22_write(_i2c, _reg, _value) \
-	cs43l22_write_masked(_i2c, _reg, _value, 0xff)
+	i2c_reg_write_byte_dt(_i2c, _reg, _value)
 
 static inline int cs43l22_write_masked(const struct i2c_dt_spec *i2c, uint8_t reg,
 				       uint8_t value, uint8_t mask)
 {
-	int ret;
-	uint8_t actual_value = 0;
-
-	if (mask != 0xff) {
-		ret = i2c_burst_read_dt(i2c, reg, &actual_value, 1);
-		if (ret) {
-			LOG_ERR("Unable to get actual register value [%02X]", reg);
-			return ret;
-		}
-	}
-	actual_value = (actual_value & ~mask) | (value & mask);
-
-	return i2c_burst_write_dt(i2c, reg, &actual_value, 1);
+	return i2c_reg_update_byte_dt(i2c, reg, mask, value);
 }
 
 #define cs43l22_soft_power_down(_i2c) cs43l22_write(_i2c, REG_POWER_CTL_1, 0x01)

--- a/drivers/charger/sbs_charger.c
+++ b/drivers/charger/sbs_charger.c
@@ -40,11 +40,12 @@ static int sbs_cmd_reg_read(const struct device *dev, uint8_t reg_addr, uint16_t
 static int sbs_cmd_reg_write(const struct device *dev, uint8_t reg_addr, uint16_t val)
 {
 	const struct sbs_charger_config *config = dev->config;
-	uint8_t buf[2];
+	uint8_t buf[3];
 
-	sys_put_le16(val, buf);
+	buf[0] = reg_addr;
+	sys_put_le16(val, &buf[1]);
 
-	return i2c_burst_write_dt(&config->i2c, reg_addr, buf, sizeof(buf));
+	return i2c_write_dt(&config->i2c, buf, sizeof(buf));
 }
 
 static int sbs_cmd_reg_update(const struct device *dev, uint8_t reg_addr, uint16_t mask,

--- a/drivers/display/display_sh1122.c
+++ b/drivers/display/display_sh1122.c
@@ -113,16 +113,17 @@ static inline int sh1122_write_bus_cmd_i2c(const struct device *dev, const uint8
 					   const uint8_t *data, size_t len)
 {
 	const struct sh1122_config *config = dev->config;
-	static uint8_t buf[SH1122_MAXIMUM_CMD_LENGTH];
+	static uint8_t buf[SH1122_MAXIMUM_CMD_LENGTH + 1];
 
 	if (len > SH1122_MAXIMUM_CMD_LENGTH - 1) {
 		return -EINVAL;
 	}
 
-	buf[0] = cmd;
-	memcpy(&(buf[1]), data, len);
+	buf[0] = SH1122_CONTROL_ALL_BYTES_CMD;
+	buf[1] = cmd;
+	memcpy(&(buf[2]), data, len);
 
-	return i2c_burst_write_dt(&config->i2c, SH1122_CONTROL_ALL_BYTES_CMD, buf, len + 1);
+	return i2c_write_dt(&config->i2c, buf, len + 2);
 }
 
 static inline int sh1122_set_hardware_config(const struct device *dev)

--- a/drivers/display/display_ssd1320.c
+++ b/drivers/display/display_ssd1320.c
@@ -115,16 +115,17 @@ static inline int ssd1320_write_bus_cmd_i2c(const struct device *dev, const uint
 					    const uint8_t *data, size_t len)
 {
 	const struct ssd1320_config *config = dev->config;
-	static uint8_t buf[SSD1320_MAXIMUM_CMD_LENGTH];
+	static uint8_t buf[SSD1320_MAXIMUM_CMD_LENGTH + 1];
 
 	if (len > SSD1320_MAXIMUM_CMD_LENGTH - 1) {
 		return -EINVAL;
 	}
 
-	buf[0] = cmd;
-	memcpy(&(buf[1]), data, len);
+	buf[0] = SSD1320_CONTROL_ALL_BYTES_CMD;
+	buf[1] = cmd;
+	memcpy(&(buf[2]), data, len);
 
-	return i2c_burst_write_dt(&config->i2c, SSD1320_CONTROL_ALL_BYTES_CMD, buf, len + 1);
+	return i2c_write_dt(&config->i2c, buf, len + 2);
 }
 
 static inline int ssd1320_set_hardware_config(const struct device *dev)

--- a/drivers/display/ssd1327.c
+++ b/drivers/display/ssd1327.c
@@ -86,16 +86,17 @@ static inline int ssd1327_write_bus_cmd_i2c(const struct device *dev, const uint
 					    const uint8_t *data, size_t len)
 {
 	const struct ssd1327_config *config = dev->config;
-	uint8_t buf[SSD1327_MAXIMUM_CMD_LENGTH];
+	uint8_t buf[SSD1327_MAXIMUM_CMD_LENGTH + 1];
 
 	if (len > SSD1327_MAXIMUM_CMD_LENGTH - 1) {
 		return -EINVAL;
 	}
 
-	buf[0] = cmd;
-	memcpy(&(buf[1]), data, len);
+	buf[0] = SSD1327_CONTROL_ALL_BYTES_CMD;
+	buf[1] = cmd;
+	memcpy(&(buf[2]), data, len);
 
-	return i2c_burst_write_dt(&config->i2c, SSD1327_CONTROL_ALL_BYTES_CMD, buf, len + 1);
+	return i2c_write_dt(&config->i2c, buf, len + 2);
 }
 
 static inline int ssd1327_set_timing_setting(const struct device *dev)

--- a/drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c
@@ -226,6 +226,7 @@ static int sbs_gauge_emul_transfer_i2c(const struct emul *target, struct i2c_msg
 	/* Largely copied from emul_bmi160.c */
 	struct sbs_gauge_emul_data *data;
 	unsigned int val;
+	uint16_t value;
 	int reg;
 	int rc;
 
@@ -235,6 +236,21 @@ static int sbs_gauge_emul_transfer_i2c(const struct emul *target, struct i2c_msg
 
 	i2c_dump_msgs_rw(target->dev, msgs, num_msgs, addr, false);
 	switch (num_msgs) {
+	case 1:
+		if (msgs->flags & I2C_MSG_READ) {
+			LOG_ERR("Unexpected single-message read");
+			return -EIO;
+		}
+		if (msgs->len != 3) {
+			LOG_ERR("Unexpected msg0 length %d", msgs->len);
+			return -EIO;
+		}
+		reg = msgs->buf[0];
+
+		value = sys_get_le16(&(msgs->buf[1]));
+
+		rc = emul_sbs_gauge_reg_write(target, reg, value);
+		break;
 	case 2:
 		if (msgs->flags & I2C_MSG_READ) {
 			LOG_ERR("Unexpected read");
@@ -274,7 +290,7 @@ static int sbs_gauge_emul_transfer_i2c(const struct emul *target, struct i2c_msg
 			if (msgs->len != 2) {
 				LOG_ERR("Unexpected msg1 length %d", msgs->len);
 			}
-			uint16_t value = sys_get_le16(msgs->buf);
+			value = sys_get_le16(msgs->buf);
 
 			rc = emul_sbs_gauge_reg_write(target, reg, value);
 		}

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -59,11 +59,12 @@ static int sbs_cmd_reg_read(const struct device *dev, uint8_t reg_addr, uint16_t
 static int sbs_cmd_reg_write(const struct device *dev, uint8_t reg_addr, uint16_t val)
 {
 	const struct sbs_gauge_config *config = dev->config;
-	uint8_t buf[2];
+	uint8_t buf[3];
 
-	sys_put_le16(val, buf);
+	buf[0] = reg_addr;
+	sys_put_le16(val, &buf[1]);
 
-	return i2c_burst_write_dt(&config->i2c, reg_addr, buf, sizeof(buf));
+	return i2c_write_dt(&config->i2c, buf, sizeof(buf));
 }
 
 static int sbs_cmd_buffer_read(const struct device *dev, uint8_t reg_addr, char *buffer,

--- a/drivers/led/ncp5623.c
+++ b/drivers/led/ncp5623.c
@@ -121,7 +121,13 @@ static int ncp5623_led_init(const struct device *dev)
 	const struct ncp5623_config *config = dev->config;
 	const struct led_info *led_info = NULL;
 	int i;
-	uint8_t buf[6] = {0x70, NCP5623_LED_PWM0, 0x70, NCP5623_LED_PWM1, 0x70, NCP5623_LED_PWM2};
+	uint8_t buf[7] = {NCP5623_LED_CURRENT | NCP5623_MAX_BRIGHTNESS,
+			  0x70,
+			  NCP5623_LED_PWM0,
+			  0x70,
+			  NCP5623_LED_PWM1,
+			  0x70,
+			  NCP5623_LED_PWM2};
 
 	if (!i2c_is_ready_dt(&config->bus)) {
 		LOG_ERR("%s: I2C device not ready", dev->name);
@@ -161,8 +167,7 @@ static int ncp5623_led_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	if (i2c_burst_write_dt(&config->bus, NCP5623_LED_CURRENT | NCP5623_MAX_BRIGHTNESS, buf,
-			       6)) {
+	if (i2c_write_dt(&config->bus, buf, sizeof(buf))) {
 		LOG_ERR("%s: LED write failed", dev->name);
 		return -EIO;
 	}

--- a/drivers/rtc/rtc_am1805.c
+++ b/drivers/rtc/rtc_am1805.c
@@ -116,7 +116,7 @@ struct am1805_data {
 static int am1805_set_time(const struct device *dev, const struct rtc_time *tm)
 {
 	int err;
-	uint8_t regs[7];
+	uint8_t regs[8];
 
 	struct am1805_data *data = dev->data;
 	const struct am1805_config *config = dev->config;
@@ -135,15 +135,16 @@ static int am1805_set_time(const struct device *dev, const struct rtc_time *tm)
 			tm->tm_year, tm->tm_mon, tm->tm_mday, tm->tm_wday, tm->tm_hour, tm->tm_min,
 			tm->tm_sec);
 
-	regs[0] = bin2bcd(tm->tm_sec) & SECONDS_BITS;
-	regs[1] = bin2bcd(tm->tm_min) & MINUTES_BITS;
-	regs[2] = bin2bcd(tm->tm_hour) & HOURS_BITS;
-	regs[3] = bin2bcd(tm->tm_mday) & DATE_BITS;
-	regs[4] = bin2bcd(tm->tm_mon) & MONTHS_BITS;
-	regs[5] = bin2bcd(tm->tm_year) & YEAR_BITS;
-	regs[6] = bin2bcd(tm->tm_wday) & WEEKDAY_BITS;
+	regs[0] = REG_SECONDS_ADDR;
+	regs[1] = bin2bcd(tm->tm_sec) & SECONDS_BITS;
+	regs[2] = bin2bcd(tm->tm_min) & MINUTES_BITS;
+	regs[3] = bin2bcd(tm->tm_hour) & HOURS_BITS;
+	regs[4] = bin2bcd(tm->tm_mday) & DATE_BITS;
+	regs[5] = bin2bcd(tm->tm_mon) & MONTHS_BITS;
+	regs[6] = bin2bcd(tm->tm_year) & YEAR_BITS;
+	regs[7] = bin2bcd(tm->tm_wday) & WEEKDAY_BITS;
 
-	err = i2c_burst_write_dt(&config->int_i2c, REG_SECONDS_ADDR, regs, sizeof(regs));
+	err = i2c_write_dt(&config->int_i2c, regs, sizeof(regs));
 	if (err != 0) {
 		goto unlock;
 	}
@@ -361,7 +362,7 @@ static int am1805_alarm_set_time(const struct device *dev, uint16_t id, uint16_t
 		const struct rtc_time *timeptr)
 {
 	int err;
-	uint8_t regs[6];
+	uint8_t regs[7];
 
 	struct am1805_data *data = dev->data;
 	const struct am1805_config *config = dev->config;
@@ -405,19 +406,20 @@ static int am1805_alarm_set_time(const struct device *dev, uint16_t id, uint16_t
 		goto unlock;
 	}
 
-	regs[0] = bin2bcd(timeptr->tm_sec) & SECONDS_BITS;
-	regs[1] = bin2bcd(timeptr->tm_min) & MINUTES_BITS;
-	regs[2] = bin2bcd(timeptr->tm_hour) & HOURS_BITS;
-	regs[3] = bin2bcd(timeptr->tm_mday) & DATE_BITS;
-	regs[4] = bin2bcd(timeptr->tm_mon) & MONTHS_BITS;
-	regs[5] = bin2bcd(timeptr->tm_wday) & WEEKDAY_BITS;
+	regs[0] = REG_ALM_SECONDS_ADDR;
+	regs[1] = bin2bcd(timeptr->tm_sec) & SECONDS_BITS;
+	regs[2] = bin2bcd(timeptr->tm_min) & MINUTES_BITS;
+	regs[3] = bin2bcd(timeptr->tm_hour) & HOURS_BITS;
+	regs[4] = bin2bcd(timeptr->tm_mday) & DATE_BITS;
+	regs[5] = bin2bcd(timeptr->tm_mon) & MONTHS_BITS;
+	regs[6] = bin2bcd(timeptr->tm_wday) & WEEKDAY_BITS;
 
 	LOG_DBG("set alarm: second = %d, min = %d, hour = %d, mday = %d, month = %d,"
 			"wday = %d,  mask = 0x%04x",
 			timeptr->tm_sec, timeptr->tm_min, timeptr->tm_hour, timeptr->tm_mday,
 			timeptr->tm_mon, timeptr->tm_wday, mask);
 
-	err = i2c_burst_write_dt(&config->int_i2c, REG_ALM_SECONDS_ADDR, regs, sizeof(regs));
+	err = i2c_write_dt(&config->int_i2c, regs, sizeof(regs));
 	if (err != 0) {
 		goto unlock;
 	}

--- a/drivers/rtc/rtc_ds1307.c
+++ b/drivers/rtc/rtc_ds1307.c
@@ -64,7 +64,7 @@ struct ds1307_data {
 static int ds1307_set_time(const struct device *dev, const struct rtc_time *tm)
 {
 	int err;
-	uint8_t regs[7];
+	uint8_t regs[8];
 
 	struct ds1307_data *data = dev->data;
 	const struct ds1307_config *config = dev->config;
@@ -76,15 +76,16 @@ static int ds1307_set_time(const struct device *dev, const struct rtc_time *tm)
 		tm->tm_year, tm->tm_mon, tm->tm_mday, tm->tm_wday, tm->tm_hour, tm->tm_min,
 		tm->tm_sec);
 
-	regs[0] = bin2bcd(tm->tm_sec) & SECONDS_BITS;
-	regs[1] = bin2bcd(tm->tm_min);
-	regs[2] = bin2bcd(tm->tm_hour);
-	regs[3] = bin2bcd(tm->tm_wday);
-	regs[4] = bin2bcd(tm->tm_mday);
-	regs[5] = bin2bcd(tm->tm_mon);
-	regs[6] = bin2bcd((tm->tm_year % 100));
+	regs[0] = DS1307_REG_SECONDS;
+	regs[1] = bin2bcd(tm->tm_sec) & SECONDS_BITS;
+	regs[2] = bin2bcd(tm->tm_min);
+	regs[3] = bin2bcd(tm->tm_hour);
+	regs[4] = bin2bcd(tm->tm_wday);
+	regs[5] = bin2bcd(tm->tm_mday);
+	regs[6] = bin2bcd(tm->tm_mon);
+	regs[7] = bin2bcd((tm->tm_year % 100));
 
-	err = i2c_burst_write_dt(&config->i2c_bus, DS1307_REG_SECONDS, regs, sizeof(regs));
+	err = i2c_write_dt(&config->i2c_bus, regs, sizeof(regs));
 
 	k_spin_unlock(&data->lock, key);
 

--- a/drivers/sensor/als31300/als31300.c
+++ b/drivers/sensor/als31300/als31300.c
@@ -198,7 +198,8 @@ static DEVICE_API(sensor, als31300_api) = {
 static int als31300_configure_device(const struct device *dev)
 {
 	const struct als31300_config *cfg = dev->config;
-	uint32_t reg27_value = 0x00000000; /* All bits to 0 = Active Mode */
+	/* All bits to 0 = Active Mode */
+	uint8_t reg27_value[5] = {ALS31300_REG_VOLATILE_27, 0x00, 0x00, 0x00, 0x00};
 	int ret;
 
 	LOG_INF("Configuring ALS31300 to Active Mode...");
@@ -209,8 +210,7 @@ static int als31300_configure_device(const struct device *dev)
 	 * Bits [6:4] = 0 → Low-power count = 0.5ms (doesn't matter in Active Mode)
 	 * Bits [31:7] = 0 → Reserved (should be 0)
 	 */
-	ret = i2c_burst_write_dt(&cfg->i2c, ALS31300_REG_VOLATILE_27, (uint8_t *)&reg27_value,
-				 sizeof(reg27_value));
+	ret = i2c_write_dt(&cfg->i2c, reg27_value, sizeof(reg27_value));
 	if (ret < 0) {
 		LOG_ERR("Failed to write to register 0x27: %d", ret);
 		return ret;

--- a/drivers/sensor/bosch/bmg160/bmg160.c
+++ b/drivers/sensor/bosch/bmg160/bmg160.c
@@ -57,9 +57,8 @@ int bmg160_read_byte(const struct device *dev, uint8_t reg_addr,
 	return bmg160_read(dev, reg_addr, byte, 1);
 }
 
-static int bmg160_write(const struct device *dev, uint8_t reg_addr,
-			uint8_t *data,
-			uint8_t len)
+int bmg160_write_byte(const struct device *dev, uint8_t reg_addr,
+		      uint8_t byte)
 {
 	const struct bmg160_device_config *dev_cfg = dev->config;
 	struct bmg160_device_data *bmg160 = dev->data;
@@ -69,20 +68,13 @@ static int bmg160_write(const struct device *dev, uint8_t reg_addr,
 
 	k_sem_take(&bmg160->sem, K_FOREVER);
 
-	if (i2c_burst_write_dt(&dev_cfg->i2c,
-			       reg_addr, data, len) < 0) {
+	if (i2c_reg_write_byte_dt(&dev_cfg->i2c, reg_addr, byte) < 0) {
 		ret = -EIO;
 	}
 
 	k_sem_give(&bmg160->sem);
 
 	return ret;
-}
-
-int bmg160_write_byte(const struct device *dev, uint8_t reg_addr,
-		      uint8_t byte)
-{
-	return bmg160_write(dev, reg_addr, &byte, 1);
 }
 
 int bmg160_update_byte(const struct device *dev, uint8_t reg_addr,

--- a/drivers/sensor/honeywell/hmc5883l/hmc5883l.c
+++ b/drivers/sensor/honeywell/hmc5883l/hmc5883l.c
@@ -90,7 +90,7 @@ int hmc5883l_init(const struct device *dev)
 {
 	struct hmc5883l_data *drv_data = dev->data;
 	const struct hmc5883l_config *config = dev->config;
-	uint8_t chip_cfg[3], id[3], idx;
+	uint8_t chip_cfg[4], id[3], idx;
 
 	if (!device_is_ready(config->i2c.bus)) {
 		LOG_ERR("I2C bus device not ready");
@@ -136,12 +136,12 @@ int hmc5883l_init(const struct device *dev)
 	}
 
 	/* configure device */
-	chip_cfg[0] = idx << HMC5883L_ODR_SHIFT;
-	chip_cfg[1] = drv_data->gain_idx << HMC5883L_GAIN_SHIFT;
-	chip_cfg[2] = HMC5883L_MODE_CONTINUOUS;
+	chip_cfg[0] = HMC5883L_REG_CONFIG_A;
+	chip_cfg[1] = idx << HMC5883L_ODR_SHIFT;
+	chip_cfg[2] = drv_data->gain_idx << HMC5883L_GAIN_SHIFT;
+	chip_cfg[3] = HMC5883L_MODE_CONTINUOUS;
 
-	if (i2c_burst_write_dt(&config->i2c, HMC5883L_REG_CONFIG_A,
-			       chip_cfg, 3) < 0) {
+	if (i2c_write_dt(&config->i2c, chip_cfg, sizeof(chip_cfg)) < 0) {
 		LOG_ERR("Failed to configure chip.");
 		return -EIO;
 	}

--- a/drivers/sensor/hp206c/hp206c.c
+++ b/drivers/sensor/hp206c/hp206c.c
@@ -48,31 +48,23 @@ static int hp206c_read(const struct device *dev, uint8_t cmd, uint8_t *data,
 static int hp206c_read_reg(const struct device *dev, uint8_t reg_addr,
 			   uint8_t *reg_val)
 {
-	uint8_t cmd = HP206C_CMD_READ_REG | (reg_addr & HP206C_REG_ADDR_MASK);
-
-	return hp206c_read(dev, cmd, reg_val, 1);
-}
-
-static int hp206c_write(const struct device *dev, uint8_t cmd, uint8_t *data,
-			uint8_t len)
-{
 	const struct hp206c_device_config *cfg = dev->config;
+	uint8_t cmd = HP206C_CMD_READ_REG | (reg_addr & HP206C_REG_ADDR_MASK);
 
 	hp206c_bus_config(dev);
 
-	if (i2c_burst_write_dt(&cfg->i2c, cmd, data, len) < 0) {
-		return -EIO;
-	}
-
-	return 0;
+	return i2c_reg_read_byte_dt(&cfg->i2c, cmd, reg_val);
 }
 
 static int hp206c_write_reg(const struct device *dev, uint8_t reg_addr,
 			    uint8_t reg_val)
 {
+	const struct hp206c_device_config *cfg = dev->config;
 	uint8_t cmd = HP206C_CMD_WRITE_REG | (reg_addr & HP206C_REG_ADDR_MASK);
 
-	return hp206c_write(dev, cmd, &reg_val, 1);
+	hp206c_bus_config(dev);
+
+	return i2c_reg_write_byte_dt(&cfg->i2c, cmd, reg_val);
 }
 
 static int hp206c_cmd_send(const struct device *dev, uint8_t cmd)

--- a/drivers/sensor/ti/tmp435/tmp435.c
+++ b/drivers/sensor/ti/tmp435/tmp435.c
@@ -24,12 +24,6 @@ static inline int tmp435_reg_read(const struct tmp435_config *cfg, uint8_t reg, 
 	return i2c_burst_read_dt(&cfg->i2c, reg, buf, size);
 }
 
-static inline int tmp435_reg_write(const struct tmp435_config *cfg, uint8_t reg, uint8_t *buf,
-				   uint32_t size)
-{
-	return i2c_burst_write_dt(&cfg->i2c, reg, buf, size);
-}
-
 static inline int tmp435_get_status(const struct tmp435_config *cfg, uint8_t *status)
 {
 	return tmp435_reg_read(cfg, TMP435_STATUS_REG, status, 1);
@@ -43,7 +37,7 @@ static int tmp435_one_shot(const struct device *dev)
 	const struct tmp435_config *cfg = dev->config;
 
 	data = 1; /* write anything to start */
-	ret = tmp435_reg_write(cfg, TMP435_ONE_SHOT_START_REG, &data, 1);
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, TMP435_ONE_SHOT_START_REG, data);
 	for (uint16_t i = 0; i < TMP435_CONV_LOOP_LIMIT; i++) {
 		ret = tmp435_get_status(cfg, &status);
 		if (ret < 0) {
@@ -160,14 +154,14 @@ static int tmp435_init(const struct device *dev)
 	}
 
 	data = 1; /* write anything to reset */
-	ret = tmp435_reg_write(cfg, TMP435_SOFTWARE_RESET_REG, &data, 1);
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, TMP435_SOFTWARE_RESET_REG, data);
 	if (ret < 0) {
 		LOG_ERR("Failed to write TMP435_SOFTWARE_RESET_REG ret:%d", ret);
 		return ret;
 	}
 
 	data = TMP435_CONF_REG_1_DATA;
-	ret = tmp435_reg_write(cfg, TMP435_CONF_REG_1, &data, 1);
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, TMP435_CONF_REG_1, data);
 	if (ret < 0) {
 		LOG_ERR("Failed to write TMP435_CONF_REG_1 ret:%d", ret);
 		return ret;
@@ -180,14 +174,14 @@ static int tmp435_init(const struct device *dev)
 	if (cfg->resistance_correction) {
 		data = data + TMP435_CONF_REG_2_RC;
 	}
-	ret = tmp435_reg_write(cfg, TMP435_CONF_REG_2, &data, 1);
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, TMP435_CONF_REG_2, data);
 	if (ret < 0) {
 		LOG_ERR("Failed to write TMP435_CONF_REG_2 ret:%d", ret);
 		return ret;
 	}
 
 	data = cfg->beta_compensation;
-	ret = tmp435_reg_write(cfg, TMP435_BETA_RANGE_REG, &data, 1);
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, TMP435_BETA_RANGE_REG, data);
 	if (ret < 0) {
 		LOG_ERR("Failed to write TMP435_BETA_RANGE_REG ret:%d", ret);
 		return ret;

--- a/drivers/sensor/vishay/veml6031/veml6031.c
+++ b/drivers/sensor/vishay/veml6031/veml6031.c
@@ -169,8 +169,9 @@ static int veml6031_read16(const struct device *dev, uint8_t cmd, uint8_t *data)
 static int veml6031_write16(const struct device *dev, uint8_t cmd, uint8_t *data)
 {
 	const struct veml6031_config *conf = dev->config;
+	uint8_t buf[3] = {cmd, data[0], data[1]};
 
-	return i2c_burst_write_dt(&conf->bus, cmd, data, 2);
+	return i2c_write_dt(&conf->bus, buf, sizeof(buf));
 }
 
 static int veml6031_write_conf(const struct device *dev)

--- a/drivers/sensor/vishay/veml6046/veml6046.c
+++ b/drivers/sensor/vishay/veml6046/veml6046.c
@@ -147,8 +147,9 @@ static int veml6046_read16(const struct device *dev, uint8_t cmd, uint16_t *data
 static int veml6046_write16(const struct device *dev, uint8_t cmd, uint8_t *data)
 {
 	const struct veml6046_config *conf = dev->config;
+	uint8_t buf[3] = {cmd, data[0], data[1]};
 
-	return i2c_burst_write_dt(&conf->bus, cmd, data, 2);
+	return i2c_write_dt(&conf->bus, buf, sizeof(buf));
 }
 
 static int veml6046_write_conf(const struct device *dev)


### PR DESCRIPTION
i2c_burst_write is not portable,
as it is not supported by some drivers,
replace its use with i2c_write.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>