### PR TITLE
boards: mpfs_icicle: add renode simulation support

### DIFF
--- a/boards/microchip/mpfs_icicle/board.cmake
+++ b/boards/microchip/mpfs_icicle/board.cmake
@@ -1,0 +1,16 @@
+# Copyright (c) 2025 Antmicro
+# SPDX-License-Identifier: Apache-2.0
+
+set(SUPPORTED_EMU_PLATFORMS renode)
+if(CONFIG_BOARD_MPFS_ICICLE_POLARFIRE_U54)
+  set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/mpfs_icicle_polarfire_u54.resc)
+  set(RENODE_UART sysbus.mmuart1)
+elseif(CONFIG_BOARD_MPFS_ICICLE_POLARFIRE_U54_SMP)
+  set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/mpfs_icicle_polarfire_u54_smp.resc)
+  set(RENODE_UART sysbus.mmuart1)
+elseif(CONFIG_BOARD_MPFS_ICICLE_POLARFIRE_E51)
+  set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/mpfs_icicle_polarfire_e51.resc)
+  set(RENODE_UART sysbus.mmuart0)
+endif()
+
+set(OPENOCD_USE_LOAD_IMAGE NO)

--- a/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_e51.yaml
+++ b/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_e51.yaml
@@ -6,7 +6,14 @@ toolchain:
   - zephyr
 ram: 3840
 testing:
+  timeout_multiplier: 8
   ignore_tags:
     - net
     - bluetooth
+  renode:
+    uart: sysbus.mmuart0
+    resc: boards/microchip/mpfs_icicle/support/mpfs_icicle_polarfire_e51.resc
 vendor: microchip
+simulation:
+  - name: renode
+    exec: renode

--- a/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54.yaml
+++ b/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54.yaml
@@ -6,7 +6,14 @@ toolchain:
   - zephyr
 ram: 3840
 testing:
+  timeout_multiplier: 8
   ignore_tags:
     - net
     - bluetooth
+  renode:
+    uart: sysbus.mmuart1
+    resc: boards/microchip/mpfs_icicle/support/mpfs_icicle_polarfire_u54.resc
 vendor: microchip
+simulation:
+  - name: renode
+    exec: renode

--- a/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54_smp.yaml
+++ b/boards/microchip/mpfs_icicle/mpfs_icicle_polarfire_u54_smp.yaml
@@ -6,7 +6,14 @@ toolchain:
   - zephyr
 ram: 3840
 testing:
+  timeout_multiplier: 8
   ignore_tags:
     - net
     - bluetooth
+  renode:
+    uart: sysbus.mmuart1
+    resc: boards/microchip/mpfs_icicle/support/mpfs_icicle_polarfire_u54_smp.resc
 vendor: microchip
+simulation:
+  - name: renode
+    exec: renode

--- a/boards/microchip/mpfs_icicle/support/mpfs_icicle_polarfire_e51.resc
+++ b/boards/microchip/mpfs_icicle/support/mpfs_icicle_polarfire_e51.resc
@@ -1,0 +1,26 @@
+# Copyright (c) 2025 Antmicro
+# SPDX-License-Identifier: Apache-2.0
+
+:name: MPFS-ICICLE-KIT
+:description: This script is prepared to run Zephyr on E51 core of PolarFire SoC Icicle Kit RISC-V board.
+
+$name?="MPFS-ICICLE-KIT"
+
+using sysbus
+mach create $name
+machine LoadPlatformDescription @platforms/boards/mpfs-icicle-kit.repl
+
+showAnalyzer mmuart0
+e51 PerformanceInMips 80
+
+# Disable U54 cores
+u54_1 IsHalted true
+u54_2 IsHalted true
+u54_3 IsHalted true
+u54_4 IsHalted true
+
+macro reset
+"""
+    sysbus LoadELF $elf
+"""
+runMacro $reset

--- a/boards/microchip/mpfs_icicle/support/mpfs_icicle_polarfire_u54.resc
+++ b/boards/microchip/mpfs_icicle/support/mpfs_icicle_polarfire_u54.resc
@@ -1,0 +1,26 @@
+# Copyright (c) 2025 Antmicro
+# SPDX-License-Identifier: Apache-2.0
+
+:name: MPFS-ICICLE-KIT
+:description: This script is prepared to run Zephyr on a single U54 core of PolarFire SoC Icicle Kit RISC-V board.
+
+$name?="MPFS-ICICLE-KIT"
+
+using sysbus
+mach create $name
+machine LoadPlatformDescription @platforms/boards/mpfs-icicle-kit.repl
+
+showAnalyzer mmuart1
+
+# Disable E51 core
+e51 IsHalted true
+# Disable U54 harts other than u54_1 (specified with RV_BOOT_HART=1)
+u54_2 IsHalted true
+u54_3 IsHalted true
+u54_4 IsHalted true
+
+macro reset
+"""
+    sysbus LoadELF $elf
+"""
+runMacro $reset

--- a/boards/microchip/mpfs_icicle/support/mpfs_icicle_polarfire_u54_smp.resc
+++ b/boards/microchip/mpfs_icicle/support/mpfs_icicle_polarfire_u54_smp.resc
@@ -1,0 +1,25 @@
+# Copyright (c) 2025 Antmicro
+# SPDX-License-Identifier: Apache-2.0
+
+:name: MPFS-ICICLE-KIT
+:description: This script is prepared to run Zephyr on U54 cores of PolarFire SoC Icicle Kit RISC-V board.
+
+$name?="MPFS-ICICLE-KIT"
+
+using sysbus
+mach create $name
+machine LoadPlatformDescription @platforms/boards/mpfs-icicle-kit.repl
+
+# Ensure determinism for multi-core tests.
+machine SetSerialExecution True
+
+showAnalyzer mmuart1
+
+# Disable E51 core
+e51 IsHalted true
+
+macro reset
+"""
+    sysbus LoadELF $elf
+"""
+runMacro $reset

--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/boards/mpfs_icicle.resc
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/boards/mpfs_icicle.resc
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Antmicro
+# SPDX-License-Identifier: Apache-2.0
+
+emulation SetGlobalQuantum "0.00001"


### PR DESCRIPTION
Add Renode simulation support for `mpfs_icicle`.

Renode 1.16.0 required for the support was activated on Zephyr CI in https://github.com/zephyrproject-rtos/zephyr/commit/8e687fc0dd6e20dd75f9e6e8c29287cc81cfefe9.