### PR TITLE
dts: realtek: Add I2C SCL count offset properties

### DIFF
--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -12,7 +12,7 @@ menuconfig I2C_DW
 config I2C_DW_CLOCK_SPEED
 	int "Set the clock speed for I2C"
 	depends on I2C_DW
-	default 110 if I2C_RTS5912
+	default 100 if I2C_RTS5912
 	default 32
 
 config I2C_DW_LPSS_DMA

--- a/dts/arm/realtek/ec/rts5912.dtsi
+++ b/dts/arm/realtek/ec/rts5912.dtsi
@@ -32,7 +32,6 @@
 				power-state-name = "suspend-to-idle";
 				min-residency-us = <100000000>;
 			};
-
 		};
 	};
 
@@ -532,6 +531,8 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
+			lcnt-offset = <35>;
+			hcnt-offset = <35>;
 		};
 
 		i2c_1: i2c@4000d200 {
@@ -543,6 +544,8 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
+			lcnt-offset = <35>;
+			hcnt-offset = <35>;
 		};
 
 		i2c_2: i2c@4000d400 {
@@ -554,6 +557,8 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
+			lcnt-offset = <35>;
+			hcnt-offset = <35>;
 		};
 
 		i2c_3: i2c@4000d600 {
@@ -565,6 +570,8 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
+			lcnt-offset = <35>;
+			hcnt-offset = <35>;
 		};
 
 		i2c_4: i2c@4000d800 {
@@ -576,6 +583,8 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
+			lcnt-offset = <35>;
+			hcnt-offset = <35>;
 		};
 
 		i2c_5: i2c@4000da00 {
@@ -587,6 +596,8 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
+			lcnt-offset = <35>;
+			hcnt-offset = <35>;
 		};
 
 		i2c_6: i2c@4000dc00 {
@@ -598,6 +609,8 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
+			lcnt-offset = <35>;
+			hcnt-offset = <35>;
 		};
 
 		i2c_7: i2c@4000de00 {
@@ -609,6 +622,8 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
+			lcnt-offset = <35>;
+			hcnt-offset = <35>;
 		};
 
 		sha0: crypto@40000000 {


### PR DESCRIPTION
Add devicetree properties `lcnt-offset` and `hcnt-offset` to allow board-specific tuning of SCL high/low count timing on RTS5912.