### PR TITLE
drivers: ieee802154: esp32: Fix start/stop API

### DIFF
--- a/drivers/ieee802154/ieee802154_esp32.c
+++ b/drivers/ieee802154/ieee802154_esp32.c
@@ -61,8 +61,7 @@ void esp_ieee802154_receive_done(uint8_t *frame, esp_ieee802154_frame_info_t *fr
 
 	/* The ESP-IDF HAL handles FCS already and drops frames with bad checksum. The checksum at
 	 * the end of a valid frame is replaced with RSSI and LQI values.
-	 *
-	 * ToDo: Check if L2 needs a valid checksum in the frame.
+	 * Zephyr L2 expects only valid frames, so checksum is not needed for a re-check.
 	 */
 	if (IS_ENABLED(CONFIG_IEEE802154_L2_PKT_INCL_FCS)) {
 		len = frame[0];
@@ -121,7 +120,7 @@ static enum ieee802154_hw_caps esp32_get_capabilities(const struct device *dev)
 
 	/* ToDo: Double-check and extend */
 	return IEEE802154_HW_ENERGY_SCAN | IEEE802154_HW_FILTER | IEEE802154_HW_TX_RX_ACK |
-	       IEEE802154_HW_CSMA;
+	       IEEE802154_HW_CSMA | IEEE802154_HW_PROMISC | IEEE802154_RX_ON_WHEN_IDLE;
 }
 
 /* override weak function in components/ieee802154/esp_ieee802154.c of ESP-IDF */
@@ -391,7 +390,7 @@ void IRAM_ATTR esp_ieee802154_energy_detect_done(int8_t power)
 	callback = esp32_data.energy_scan_done;
 	esp32_data.energy_scan_done = NULL;
 	dev = net_if_get_device(esp32_data.iface);
-	callback(dev, power); /* TODO: check scaling */
+	callback(dev, power);
 }
 
 static int esp32_ed_scan(const struct device *dev, uint16_t duration, energy_scan_done_cb_t done_cb)
@@ -403,7 +402,7 @@ static int esp32_ed_scan(const struct device *dev, uint16_t duration, energy_sca
 	if (esp32_data.energy_scan_done == NULL) {
 		esp32_data.energy_scan_done = done_cb;
 
-		/* The duration of energy detection, in symbol unit (16 us). TODO: check scaling */
+		/* The duration of energy detection, in symbol unit (16 us) */
 		if (esp_ieee802154_energy_detect(duration * USEC_PER_MSEC / US_PER_SYMBLE) != 0) {
 			esp32_data.energy_scan_done = NULL;
 			err = -EBUSY;

--- a/drivers/ieee802154/ieee802154_esp32.h
+++ b/drivers/ieee802154/ieee802154_esp32.h
@@ -24,8 +24,6 @@ struct ieee802154_esp32_data {
 	/* CCA result. Holds information whether channel is free or not. */
 	bool channel_free;
 
-	bool is_started;
-
 	/* TX synchronization semaphore. Unlocked when frame has been
 	 * sent or send procedure failed.
 	 */

--- a/samples/net/openthread/shell/socs/esp32c6.overlay
+++ b/samples/net/openthread/shell/socs/esp32c6.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2025 Espressif Systems (Shanghai) Co., Ltd.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&ieee802154 {
-	status = "okay";
-};


### PR DESCRIPTION
Fix start/stop driver API implementation. OT stack expects these functions to only put IEEE802.15.4 in sleep mode and back in RX mode when calling start. Fixes `ifconfig` down/up cycling as well as nodes staying in leader role and not forming a network.