### PR TITLE
runners: stlink_gdbserver: various fixes

### DIFF
--- a/scripts/west_commands/runners/stlink_gdbserver.py
+++ b/scripts/west_commands/runners/stlink_gdbserver.py
@@ -100,7 +100,10 @@ class STLinkGDBServerRunner(ZephyrBinaryRunner):
     def do_add_parser(cls, parser: argparse.ArgumentParser):
         # Expose a subset of the ST-LINK GDB server arguments
         parser.add_argument(
-            "--swd", action='store_true', default=True, help="Enable SWD debug mode"
+            "--swd",
+            default=True,
+            action=argparse.BooleanOptionalAction,
+            help="Enable SWD debug mode (default: %(default)s)\nUse --no-swd to disable.",
         )
         parser.add_argument("--apid", type=int, default=0, help="Target DAP ID")
         parser.add_argument(

--- a/scripts/west_commands/runners/stlink_gdbserver.py
+++ b/scripts/west_commands/runners/stlink_gdbserver.py
@@ -112,11 +112,22 @@ class STLinkGDBServerRunner(ZephyrBinaryRunner):
             default=STLINK_GDB_SERVER_DEFAULT_PORT,
             help="Port number for GDB client",
         )
+        parser.add_argument(
+            "--external-init",
+            action='store_true',
+            help="Run Init() from external loader after reset",
+        )
 
     @classmethod
     def do_create(cls, cfg: RunnerConfig, args: argparse.Namespace) -> "STLinkGDBServerRunner":
         return STLinkGDBServerRunner(
-            cfg, args.swd, args.apid, args.dev_id, args.port_number, args.extload
+            cfg,
+            args.swd,
+            args.apid,
+            args.dev_id,
+            args.port_number,
+            args.extload,
+            args.external_init,
         )
 
     def __init__(
@@ -127,6 +138,7 @@ class STLinkGDBServerRunner(ZephyrBinaryRunner):
         stlink_serial: str | None,
         gdb_port: int,
         external_loader: str | None,
+        external_init: bool,
     ):
         super().__init__(cfg)
         self.ensure_output('elf')
@@ -136,6 +148,7 @@ class STLinkGDBServerRunner(ZephyrBinaryRunner):
         self._stlink_serial = stlink_serial
         self._ap_id = ap_id
         self._external_loader = external_loader
+        self._do_external_init = external_init
 
     def do_run(self, command: str, **kwargs):
         if command in ["attach", "debug", "debugserver"]:
@@ -177,7 +190,9 @@ class STLinkGDBServerRunner(ZephyrBinaryRunner):
             extldr_path = cubeprg_path / "ExternalLoader" / self._external_loader
             if not extldr_path.exists():
                 raise RuntimeError(f"External loader {self._external_loader} does not exist")
-            gdbserver_cmd += ["--external-init"]
+
+            if self._do_external_init:
+                gdbserver_cmd += ["--external-init"]
             gdbserver_cmd += ["--extload", str(extldr_path)]
 
         self.require(gdbserver_cmd[0])


### PR DESCRIPTION
* make it possible to disable SWD mode
  * Arguments with `action='store_true', default=True` can't be "unset": not providing the argument uses the default value of True, and providing it sets the value to True!
  * Use `argparse.BooleanOptionalAction` type instead which creates a `--swd`/`--no-swd` argument pair
* make `--external-init` a runner argument instead of always providing it to the ST-LINK GDB Server default
   * https://github.com/zephyrproject-rtos/zephyr/commit/3cc9a843e8154612f71d249f79458d69b3a1edd9 made it always provided, but this breaks debugging on STM32N6 series

The only thing that really matters in patchset is basically reverting https://github.com/zephyrproject-rtos/zephyr/commit/3cc9a843e8154612f71d249f79458d69b3a1edd9 because it breaks debugging on STM32N6 series; if changes seem too big for current RC state, I'm fine with keeping this PR for later and sticking to a mere revert.