### PR TITLE
Improvements for twister pytest harness and removed unused code

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
@@ -170,6 +170,7 @@ class DeviceAdapter(abc.ABC):
 
         If timeout is not provided, then use base_timeout.
         """
+        __tracebackhide__ = True   # pylint: disable=unused-variable
         timeout = timeout or self.base_timeout
         if regex:
             regex_compiled = re.compile(regex)
@@ -187,9 +188,12 @@ class DeviceAdapter(abc.ABC):
                 if num_of_lines and len(lines) == num_of_lines:
                     break
             else:
-                msg = 'Read from device timeout occurred'
+                if regex is not None:
+                    msg = f'Did not find line "{regex}" within {timeout} seconds'
+                else:
+                    msg = f'Did not find expected number of lines within {timeout} seconds'
                 logger.error(msg)
-                raise TwisterHarnessTimeoutException(msg)
+                raise AssertionError(msg)
         else:
             lines = self.readlines(print_output)
         return lines

--- a/scripts/pylib/pytest-twister-harness/tests/device/binary_adapter_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/device/binary_adapter_test.py
@@ -17,7 +17,7 @@ from twister_harness.device.binary_adapter import (
     NativeSimulatorAdapter,
     UnitSimulatorAdapter,
 )
-from twister_harness.exceptions import TwisterHarnessException, TwisterHarnessTimeoutException
+from twister_harness.exceptions import TwisterHarnessException
 from twister_harness.twister_harness_config import DeviceConfig
 
 
@@ -71,7 +71,7 @@ def test_if_binary_adapter_finishes_after_timeout_while_there_is_no_data_from_su
     device.base_timeout = 0.3
     device.command = ['python3', script_path, '--long-sleep', '--sleep=5']
     device.launch()
-    with pytest.raises(TwisterHarnessTimeoutException, match='Read from device timeout occurred'):
+    with pytest.raises(AssertionError, match='Did not find line "Returns with code" within 0.3 seconds'):
         device.readlines_until(regex='Returns with code')
     device.close()
     assert device._process is None

--- a/scripts/tests/twister/conftest.py
+++ b/scripts/tests/twister/conftest.py
@@ -19,12 +19,6 @@ pytest_plugins = ["pytester"]
 logging.getLogger("twister").setLevel(logging.DEBUG)  # requires for testing twister
 
 
-def new_get_toolchain(*args, **kwargs):
-    return 'zephyr'
-
-TestPlan.get_toolchain = new_get_toolchain
-
-
 @pytest.fixture(name='test_data')
 def _test_data():
     """ Pytest fixture to load the test data directory"""


### PR DESCRIPTION
The `readlines_until` method is part of the testing framework (pytest harness) and should not print a full stack trace
when the expected line isn't found. It should also raise an `AssertionError` instead of a `TwisterHarnessTimeoutException`,
allowing users to know that a test failed because the expected condition did not happen.

Removed some old code which is not used/needed any more. There is no `get_toolchain` method in `TestPlan`.
