### PR TITLE
shell: backends: uart: implement pm_device_runtime

### DIFF
--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/pm/device_runtime.h>
 
 #define LOG_MODULE_NAME shell_uart
 LOG_MODULE_REGISTER(shell_uart);
@@ -290,6 +291,7 @@ static int init(const struct shell_transport *transport,
 		void *context)
 {
 	struct shell_uart_common *common = (struct shell_uart_common *)transport->ctx;
+	int ret;
 
 	common->dev = (const struct device *)config;
 	common->handler = evt_handler;
@@ -299,6 +301,11 @@ static int init(const struct shell_transport *transport,
 	common->smp.buf_pool = &smp_shell_rx_pool;
 	k_fifo_init(&common->smp.buf_ready);
 #endif
+
+	ret = pm_device_runtime_get(common->dev);
+	if (ret < 0) {
+		return ret;
+	}
 
 	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_API_ASYNC)) {
 		async_init((struct shell_uart_async *)transport->ctx);
@@ -331,6 +338,8 @@ static void polling_uninit(struct shell_uart_polling *sh_uart)
 
 static int uninit(const struct shell_transport *transport)
 {
+	struct shell_uart_common *common = (struct shell_uart_common *)transport->ctx;
+
 	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_API_ASYNC)) {
 		async_uninit((struct shell_uart_async *)transport->ctx);
 	} else if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_API_INTERRUPT_DRIVEN)) {
@@ -339,7 +348,7 @@ static int uninit(const struct shell_transport *transport)
 		polling_uninit((struct shell_uart_polling *)transport->ctx);
 	}
 
-	return 0;
+	return pm_device_runtime_put(common->dev);
 }
 
 static int enable(const struct shell_transport *transport, bool blocking_tx)


### PR DESCRIPTION
The UART device used by the backend needs to be gotten before use, and put after. In limited cases, device drivers call pm_device_runtime_get() as part of the call to uart_rx_enable(), this is not the case for polling, nor interrupt driven API calls for most if not all drivers, nor is that expected.

Implement pm_device_runtime calls in shell uart backend similar to the logging uart backend to support all uart drivers in all configurations.

fixes: #98680