### PR TITLE
stm32: fix memc initialization to avoid XSPIM configuration is APP_IN_EXT_FLASH

### DIFF
--- a/drivers/memc/memc_stm32_xspi_psram.c
+++ b/drivers/memc/memc_stm32_xspi_psram.c
@@ -295,8 +295,12 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 		return -EIO;
 	}
 
-	cfg.nCSOverride = HAL_XSPI_CSSEL_OVR_NCS1;
-	cfg.IOPort = HAL_XSPIM_IOPORT_1;
+	if (hxspi->Instance == XSPI1) {
+		cfg.IOPort = HAL_XSPIM_IOPORT_1;
+	} else if (hxspi->Instance == XSPI2) {
+		cfg.IOPort = HAL_XSPIM_IOPORT_2;
+	}
+	cfg.nCSOverride = HAL_XSPI_CSSEL_OVR_DISABLED;
 
 	if (HAL_XSPIM_Config(hxspi, &cfg, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
 		LOG_ERR("XSPIMgr Init failed");


### PR DESCRIPTION
While trying to use the display sample app on the STM32H7S78_DK with app being executed from FLASH, I ran into issues in which the application wouldn't start after MCUBoot.

```
west build -p -b stm32h7s78_dk//ext_flash_app samples/drivers/display --sysbuild -DCONFIG_HEAP_MEM_POOL_SIZE=65536
```

Other app such as Hello World are running just fine from the flash.

Turns out that the issue is linked to MEMC xspi_psram driver which during its initialization is reconfiguring the XSPI Manager block and, in order to do that needs to first disable both XSPI instances (which I believe would lead to issues considering that the app is running from the XSPI2).

I fixed that by preventing the reconfiguration of the XSPIManager in case of the app is running in flash, relying on the CONFIG_STM32_APP_IN_EXT_FLASH=y config for that.

While modifying the code, I also avoid hardcodying the PSRAM on the XSPI1 as it is currently, doing similar thing as already done in the flash driver.

With those modification in place, it is now possible to have the display sample app running fine on the STM32H7S78_DK.

Fixes: #98844