### PR TITLE
kernel:  add compiler barrier in k_is_pre_kernel between checking whether we are in user context and accessing a kernel mode only variable.

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -711,6 +711,16 @@ static inline bool k_is_pre_kernel(void)
 		return false;
 	}
 
+	/*
+	 * Some compilers might optimize by pre-reading
+	 * z_sys_post_kernel. This is absolutely not desirable.
+	 * We are trying to avoid reading it if we are in user
+	 * context as reading z_sys_post_kernel in user context
+	 * will result in access fault. So add a compiler barrier
+	 * here to stop that kind of optimizations.
+	 */
+	compiler_barrier();
+
 	return !z_sys_post_kernel;
 }
 


### PR DESCRIPTION
For some unknown reasons only knew to Cadence engineers, the Cadence toolchain will always read z_sys_boot_kernel at the beginning of k_is_pre_kernel() instead of after k_is_user_context() is called. So it would always result in access violation if this is called in user mode. Forcing a compiler barrier seems to fix that. So force it here.
