### PR TITLE
drivers: hwspinlock: Fix context initializer build warning

### DIFF
--- a/include/zephyr/drivers/hwspinlock.h
+++ b/include/zephyr/drivers/hwspinlock.h
@@ -73,7 +73,7 @@ struct hwspinlock_dt_spec {
  */
 #define HWSPINLOCK_CTX_INITIALIZER                                                                 \
 	{                                                                                          \
-		.lock = {0},                                                                       \
+		.lock = {},                                                                        \
 	}
 
 /**


### PR DESCRIPTION
Fixes a build warning in the hwspinlock context initializer macro that occurs when struct k_spinlock has no members ("warning: excess elements in struct initializer"). This change is consistent with other struct k_spinlock initializers in kernel.h.

Fixes #98961