### PR TITLE
cmake: build: Introduce early extra conf environment variable

### DIFF
--- a/cmake/modules/configuration_files.cmake
+++ b/cmake/modules/configuration_files.cmake
@@ -12,6 +12,7 @@
 #
 # - CONF_FILE:              List of Kconfig fragments
 # - EXTRA_CONF_FILE:        List of additional Kconfig fragments
+# - PRE_CONF_FILE:          List of additional Kconfig fragments to merge before CONF_FILE
 # - DTC_OVERLAY_FILE:       List of devicetree overlay files
 # - EXTRA_DTC_OVERLAY_FILE  List of additional devicetree overlay files
 # - DTS_EXTRA_CPPFLAGS      List of additional devicetree preprocessor defines
@@ -93,6 +94,7 @@ DTC_OVERLAY_FILE=\"dts1.overlay dts2.overlay\"")
 zephyr_boilerplate_watch(DTC_OVERLAY_FILE)
 
 zephyr_get(EXTRA_CONF_FILE SYSBUILD LOCAL VAR EXTRA_CONF_FILE OVERLAY_CONFIG MERGE REVERSE)
+zephyr_get(PRE_CONF_FILE SYSBUILD LOCAL VAR PRE_CONF_FILE MERGE REVERSE)
 zephyr_get(EXTRA_DTC_OVERLAY_FILE SYSBUILD LOCAL MERGE REVERSE)
 zephyr_get(DTS_EXTRA_CPPFLAGS SYSBUILD LOCAL MERGE REVERSE)
 build_info(application source-dir VALUE ${APPLICATION_SOURCE_DIR})

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -91,6 +91,12 @@ if(EXTRA_CONF_FILE)
   build_info(kconfig extra-user-files PATH ${EXTRA_CONF_FILE_AS_LIST})
 endif()
 
+if(PRE_CONF_FILE)
+  string(CONFIGURE "${PRE_CONF_FILE}" PRE_CONF_FILE_EXPANDED)
+  string(REPLACE " " ";" PRE_CONF_FILE_AS_LIST "${PRE_CONF_FILE_EXPANDED}")
+  build_info(kconfig pre-user-files PATH ${PRE_CONF_FILE_AS_LIST})
+endif()
+
 zephyr_file(CONF_FILES ${BOARD_EXTENSION_DIRS} KCONF board_extension_conf_files SUFFIX ${FILE_SUFFIX})
 
 # DTS_ROOT_BINDINGS is a semicolon separated list, this causes
@@ -286,6 +292,7 @@ set(
   ${BOARD_DEFCONFIG}
   ${BOARD_REVISION_CONFIG}
   ${board_extension_conf_files}
+  ${PRE_CONF_FILE_AS_LIST}
   ${CONF_FILE_AS_LIST}
   ${shield_conf_files}
   ${EXTRA_CONF_FILE_AS_LIST}

--- a/scripts/schemas/build-schema.yml
+++ b/scripts/schemas/build-schema.yml
@@ -82,6 +82,10 @@ mapping:
             type: seq
             sequence:
               - type: str
+          pre-user-files:
+            type: seq
+            sequence:
+              - type: str
       llext-edk:
         type: map
         mapping:

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -169,6 +169,13 @@ class Build(Forceable):
                            Do not use this option with manually specified
                            -DEXTRA_DTC_OVERLAY_FILE... cmake arguments: the results are
                            undefined''')
+        group.add_argument('--pre-conf', dest='pre_conf_files', metavar='PRE_CONF_FILE',
+                           action='append', default=[],
+                           help='''add the argument to PRE_CONF_FILE; may be given
+                           multiple times. Forces CMake to run again if given.
+                           Do not use this option with manually specified
+                           -DPRE_CONF_FILE... cmake arguments: the results are
+                           undefined''')
 
         group.add_argument('--sysbuild', action=argparse.BooleanOptionalAction,
                            help='''create multi domain build system or disable it (default)''')
@@ -222,7 +229,7 @@ class Build(Forceable):
                 if (self.args.cmake or self.args.cmake_opts or
                         self.args.cmake_only or self.args.snippets or
                         self.args.shields or self.args.extra_conf_files or
-                        self.args.extra_dtc_overlay_files):
+                        self.args.extra_dtc_overlay_files or self.args.pre_conf_files):
                     self.run_cmake = True
         else:
             self.run_cmake = True
@@ -350,6 +357,7 @@ class Build(Forceable):
             extra_dtc_overlay_files = []
             extra_overlay_confs = []
             extra_conf_files = []
+            pre_conf_files = []
             required_snippets = []
             for section in [common, item]:
                 if not section:
@@ -359,6 +367,7 @@ class Build(Forceable):
                         'extra_args',
                         'extra_configs',
                         'extra_conf_files',
+                        'pre_conf_files',
                         'extra_overlay_confs',
                         'extra_dtc_overlay_files',
                         'required_snippets'
@@ -397,6 +406,9 @@ class Build(Forceable):
                     elif data == 'extra_conf_files':
                         extra_conf_files.extend(arg_list)
                         continue
+                    elif data == 'pre_conf_files':
+                        pre_conf_files.extend(arg_list)
+                        continue
                     elif data == 'extra_overlay_confs':
                         extra_overlay_confs.extend(arg_list)
                         continue
@@ -418,6 +430,9 @@ class Build(Forceable):
             args = []
             if extra_conf_files:
                 args.append(f"CONF_FILE=\"{';'.join(extra_conf_files)}\"")
+
+            if pre_conf_files:
+                args.append(f"PRE_CONF_FILE=\"{';'.join(extra_conf_files)}\"")
 
             if extra_dtc_overlay_files:
                 args.append(f"DTC_OVERLAY_FILE=\"{';'.join(extra_dtc_overlay_files)}\"")
@@ -651,6 +666,8 @@ class Build(Forceable):
             cmake_opts.append(f'-DSHIELD={";".join(self.args.shields)}')
         if self.args.extra_conf_files:
             cmake_opts.append(f'-DEXTRA_CONF_FILE={";".join(self.args.extra_conf_files)}')
+        if self.args.pre_conf_files:
+            cmake_opts.append(f'-DPRE_CONF_FILE={";".join(self.args.pre_conf_files)}')
         if self.args.extra_dtc_overlay_files:
             cmake_opts.append(
                 f'-DEXTRA_DTC_OVERLAY_FILE='


### PR DESCRIPTION
### Summary
This change introduces a new CMake variable, PRE_CONF_FILE, that can be set by the end user to provide configuration files which have a higher precedence than board configurations, but a lower precedence than all others. This change allows projects which have a common configuration and multiple applications to specify the platform configurations via this variable, but still use the default Zephyr mechanics for app-board-variant configuration file discovery, which would then supercede any platform-level configs.

See the issue for more details and a contrived example.

### Change Description
- Introduce a new `PRE_CONF_FILE` variable, and parse the paths into `PRE_CONF_FILE_AS_LIST`
- Include `PRE_CONF_FILE_AS_LIST` in `merge_config_files` before the `CONF_FILE_AS_LIST` variable
- Add parsing for `PRE_CONF_FILE` in the west build command implementation

Fixes zephyrproject-rtos/zephyr#98679