### PR TITLE
adc: esp32 add missing header

### DIFF
--- a/drivers/adc/adc_esp32.h
+++ b/drivers/adc/adc_esp32.h
@@ -8,6 +8,7 @@
 #include <hal/adc_oneshot_hal.h>
 #include <hal/adc_types.h>
 #include <esp_adc/adc_cali.h>
+#include <esp_adc/adc_cali_scheme.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/adc.h>


### PR DESCRIPTION
Without this header the logic in adc_esp32.c will never have either ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED or
ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED defined. This means that we always see the warnings aout uncalibrated samples.

Fixes #98692