### PR TITLE
EEPROM :  Fix read/write length and buffer pointer arithmetic

### DIFF
--- a/drivers/eeprom/eeprom_mb85rcxx.c
+++ b/drivers/eeprom/eeprom_mb85rcxx.c
@@ -126,7 +126,7 @@ static int mb85rcxx_read(const struct device *dev, off_t offset, void *buf, size
 		}
 
 		len -= len_in_page;
-		*(char *)&buf += len_in_page;
+		buf = (char *)buf + len_in_page;
 		offset += len_in_page;
 	}
 
@@ -182,7 +182,7 @@ static int mb85rcxx_write(const struct device *dev, off_t offset, const void *bu
 		i2c_addr = mb85rcxx_translate_address(dev, offset, addr);
 		len_in_page = mb85rcxx_remaining_len_in_page(dev, offset, len);
 
-		ret = mb85rcxx_i2c_write(dev, i2c_addr, addr, buf, len);
+		ret = mb85rcxx_i2c_write(dev, i2c_addr, addr, buf, len_in_page);
 		if (ret < 0) {
 			LOG_ERR("failed to write to FRAM (err %d)", ret);
 			k_mutex_unlock(&data->lock);
@@ -190,7 +190,7 @@ static int mb85rcxx_write(const struct device *dev, off_t offset, const void *bu
 		}
 
 		len -= len_in_page;
-		*(char *)&buf += len_in_page;
+		buf = (const char *)buf + len_in_page;
 		offset += len_in_page;
 	}
 


### PR DESCRIPTION
Fixes <https://github.com/zephyrproject-rtos/zephyr/issues/98950>

eeprom: fram: Fix read/write length and buffer pointer arithmetic

Fixes two critical bugs in the Fujitsu MB85RCxx I2C FRAM driver when handling transfers that cross page boundaries:

Fixes incorrect write length: The mb85rcxx_write function was incorrectly passing the total remaining length (len) to the underlying I2C transfer instead of the page-limited length (len_in_page). This resulted in I2C errors or data corruption when writing past a page boundary.

Fixes buffer pointer update: Corrects the loop's buffer pointer arithmetic in both mb85rcxx_read and mb85rcxx_write. The original code used incorrect casting (*(char *)&buf += len_in_page;), leading to a strict aliasing violation and potentially undefined behavior. The pointer is now correctly advanced using explicit casting:

- mb85rcxx_read: buf = (char *)buf + len_in_page;
- mb85rcxx_write: buf = (const char *)buf + len_in_page;