### PR TITLE
drivers: nrf_wifi: buffers from Kconfig

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -448,6 +448,7 @@ config NRF70_BAND_UNII_4_UPPER_EDGE_BACKOFF_HE
 
 config NRF70_RX_NUM_BUFS
 	int "Number of RX buffers"
+	default 6 if !NRF70_DATA_TX
 	default 48
 
 config NRF70_MAX_TX_AGGREGATION
@@ -465,6 +466,7 @@ config NRF70_TX_MAX_DATA_SIZE
 
 config NRF70_RX_MAX_DATA_SIZE
 	int "Maximum size of RX data"
+	default 1000 if !NRF70_DATA_TX
 	default 1600
 
 config NRF70_TX_DONE_WQ_ENABLED

--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -448,6 +448,7 @@ config NRF70_BAND_UNII_4_UPPER_EDGE_BACKOFF_HE
 
 config NRF70_RX_NUM_BUFS
 	int "Number of RX buffers"
+	range 3 256
 	default 6 if !NRF70_DATA_TX
 	default 48
 
@@ -466,6 +467,7 @@ config NRF70_TX_MAX_DATA_SIZE
 
 config NRF70_RX_MAX_DATA_SIZE
 	int "Maximum size of RX data"
+	range 400 65536
 	default 1000 if !NRF70_DATA_TX
 	default 1600
 

--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -54,8 +54,6 @@ extern const struct nrf_wifi_osal_ops nrf_wifi_os_zep_ops;
 #ifndef CONFIG_NRF70_RADIO_TEST
 #ifdef CONFIG_NRF70_DATA_TX
 
-#define MAX_RX_QUEUES 3
-
 #define MAX_TX_FRAME_SIZE \
 	(CONFIG_NRF_WIFI_IFACE_MTU + NRF_WIFI_FMAC_ETH_HDR_LEN + TX_BUF_HEADROOM)
 #define TOTAL_TX_SIZE \
@@ -67,8 +65,6 @@ BUILD_ASSERT(CONFIG_NRF70_MAX_TX_TOKENS >= 1,
 	"At least one TX token is required");
 BUILD_ASSERT(CONFIG_NRF70_MAX_TX_AGGREGATION <= 15,
 	"Max TX aggregation is 15");
-BUILD_ASSERT(CONFIG_NRF70_RX_NUM_BUFS >= 1,
-	"At least one RX buffer is required");
 #ifndef CONFIG_NRF71_ON_IPC
 BUILD_ASSERT(RPU_PKTRAM_SIZE - TOTAL_RX_SIZE >= TOTAL_TX_SIZE,
 	"Packet RAM overflow: not enough memory for TX");
@@ -78,10 +74,6 @@ BUILD_ASSERT(CONFIG_NRF70_TX_MAX_DATA_SIZE >= MAX_TX_FRAME_SIZE,
 
 BUILD_ASSERT(CONFIG_NRF70_TX_MAX_DATA_SIZE % 4 == 0,
 	"TX buffer size must be a multiple of 4");
-BUILD_ASSERT(CONFIG_NRF70_RX_MAX_DATA_SIZE % 4 == 0,
-	"RX buffer size must be a multiple of 4");
-BUILD_ASSERT(CONFIG_NRF70_RX_MAX_DATA_SIZE >= 400,
-	"RX buffer size must be at least 400 bytes");
 
 static const unsigned char aggregation = 1;
 static const unsigned char max_num_tx_agg_sessions = 4;
@@ -91,6 +83,18 @@ static const unsigned char max_rxampdu_size = MAX_RX_AMPDU_SIZE_64KB;
 
 static const unsigned char max_tx_aggregation = CONFIG_NRF70_MAX_TX_AGGREGATION;
 
+static const unsigned char rate_protection_type;
+#endif
+
+BUILD_ASSERT(CONFIG_NRF70_RX_NUM_BUFS >= 1,
+	"At least one RX buffer is required");
+BUILD_ASSERT(CONFIG_NRF70_RX_MAX_DATA_SIZE % 4 == 0,
+	"RX buffer size must be a multiple of 4");
+BUILD_ASSERT(CONFIG_NRF70_RX_MAX_DATA_SIZE >= 400,
+	"RX buffer size must be at least 400 bytes");
+
+#define MAX_RX_QUEUES 3
+
 static const unsigned int rx1_num_bufs = CONFIG_NRF70_RX_NUM_BUFS / MAX_RX_QUEUES;
 static const unsigned int rx2_num_bufs = CONFIG_NRF70_RX_NUM_BUFS / MAX_RX_QUEUES;
 static const unsigned int rx3_num_bufs = CONFIG_NRF70_RX_NUM_BUFS / MAX_RX_QUEUES;
@@ -98,18 +102,6 @@ static const unsigned int rx3_num_bufs = CONFIG_NRF70_RX_NUM_BUFS / MAX_RX_QUEUE
 static const unsigned int rx1_buf_sz = CONFIG_NRF70_RX_MAX_DATA_SIZE;
 static const unsigned int rx2_buf_sz = CONFIG_NRF70_RX_MAX_DATA_SIZE;
 static const unsigned int rx3_buf_sz = CONFIG_NRF70_RX_MAX_DATA_SIZE;
-
-static const unsigned char rate_protection_type;
-#else
-/* Reduce buffers to Scan only operation */
-static const unsigned int rx1_num_bufs = 2;
-static const unsigned int rx2_num_bufs = 2;
-static const unsigned int rx3_num_bufs = 2;
-
-static const unsigned int rx1_buf_sz = 1000;
-static const unsigned int rx2_buf_sz = 1000;
-static const unsigned int rx3_buf_sz = 1000;
-#endif
 
 struct nrf_wifi_drv_priv_zep rpu_drv_priv_zep;
 static K_MUTEX_DEFINE(reg_lock);

--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -86,12 +86,8 @@ static const unsigned char max_tx_aggregation = CONFIG_NRF70_MAX_TX_AGGREGATION;
 static const unsigned char rate_protection_type;
 #endif
 
-BUILD_ASSERT(CONFIG_NRF70_RX_NUM_BUFS >= 1,
-	"At least one RX buffer is required");
 BUILD_ASSERT(CONFIG_NRF70_RX_MAX_DATA_SIZE % 4 == 0,
 	"RX buffer size must be a multiple of 4");
-BUILD_ASSERT(CONFIG_NRF70_RX_MAX_DATA_SIZE >= 400,
-	"RX buffer size must be at least 400 bytes");
 
 #define MAX_RX_QUEUES 3
 


### PR DESCRIPTION
Remove C code overrides of RX buffer counts and sizes when the TX path is disabled. Move the reduced resource requirements into the Kconfig default values. Default RX buffer sizes are not changed by the commit.

Move compile time validation of Kconfig symbols into the symbols themselves.

Fixes #92356