### PR TITLE
Bluetooth: Controller: Fix radio_tmr_start_us added +1 us

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -607,6 +607,9 @@ static void isr_tx(void *param)
 		subevent_us += cis_lll->offset - cis_offset_first +
 			       (cis_lll->sub_interval * se_curr);
 
+		/* +1 us radio_tmr_start_us compensation */
+		subevent_us -= 1U;
+
 		start_us = radio_tmr_start_us(1U, subevent_us);
 		LL_ASSERT_ERR(start_us == (subevent_us + 1U));
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
@@ -650,6 +653,9 @@ static void isr_tx(void *param)
 
 		subevent_us = radio_tmr_ready_restore();
 		subevent_us += next_cis_lll->offset - cis_offset_first;
+
+		/* +1 us radio_tmr_start_us compensation */
+		subevent_us -= 1U;
 
 		start_us = radio_tmr_start_us(1U, subevent_us);
 		LL_ASSERT_ERR(start_us == (subevent_us + 1U));
@@ -911,6 +917,9 @@ isr_rx_next_subevent:
 			subevent_us = radio_tmr_ready_restore();
 			subevent_us += next_cis_lll->offset - cis_offset_first;
 
+			/* +1 us radio_tmr_start_us compensation */
+			subevent_us -= 1U;
+
 			start_us = radio_tmr_start_us(1U, subevent_us);
 			LL_ASSERT_ERR(start_us == (subevent_us + 1U));
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
@@ -1133,12 +1142,14 @@ static void isr_prepare_subevent(void *param)
 		       (cis_lll->sub_interval * se_curr);
 
 #if defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+	/* +1 us radio_tmr_start_us compensation */
+	subevent_us -= 1U;
+
 	start_us = radio_tmr_start_us(1U, subevent_us);
 	LL_ASSERT_ERR(start_us == (subevent_us + 1U));
 
 #else /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
-	/* Compensate for the 1 us added by radio_tmr_start_us() */
-	start_us = subevent_us + 1U;
+	start_us = subevent_us;
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 
 #endif /* HAL_RADIO_GPIO_HAVE_PA_PIN ||

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -883,6 +883,9 @@ static void isr_rx(void *param)
 	subevent_us -= radio_rx_chain_delay_get(0U, 0U);
 #endif /* !CONFIG_BT_CTLR_PHY */
 
+	/* +1 us radio_tmr_start_us compensation */
+	subevent_us -= 1U;
+
 	start_us = radio_tmr_start_us(0U, subevent_us);
 	LL_ASSERT_ERR(start_us == (subevent_us + 1U));
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
@@ -998,12 +1001,14 @@ static void isr_tx(void *param)
 #endif /* !CONFIG_BT_CTLR_PHY */
 
 #if defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+	/* +1 us radio_tmr_start_us compensation */
+	subevent_us -= 1U;
+
 	start_us = radio_tmr_start_us(0U, subevent_us);
 	LL_ASSERT_ERR(start_us == (subevent_us + 1U));
 
 #else /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
-	/* Compensate for the 1 us added by radio_tmr_start_us() */
-	start_us = subevent_us + 1U;
+	start_us = subevent_us;
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 
 	hcto = start_us +
@@ -1234,6 +1239,9 @@ static void isr_prepare_subevent_common(void *param)
 		subevent_us += cis_lll->offset - cis_offset_first +
 			       (cis_lll->sub_interval * se_curr);
 	}
+
+	/* +1 us radio_tmr_start_us compensation */
+	subevent_us -= 1U;
 
 	start_us = radio_tmr_start_us(0U, subevent_us);
 	LL_ASSERT_ERR(!trx_performed_bitmask || (start_us == (subevent_us + 1U)));

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -355,6 +355,9 @@ void lll_scan_aux_isr_aux_setup(void *param)
 	aux_start_us -= window_widening_us;
 	aux_start_us -= EVENT_JITTER_US;
 
+	/* +1 us radio_tmr_start_us compensation */
+	aux_start_us -= 1U;
+
 	start_us = radio_tmr_start_us(0, aux_start_us);
 	LL_ASSERT_MSG(start_us == (aux_start_us + 1U), "aux_offset %u us, start_us %u != %u",
 		      aux_offset_us, start_us, (aux_start_us + 1U));

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -744,6 +744,9 @@ static void isr_aux_setup(void *param)
 	aux_start_us -= window_widening_us;
 	aux_start_us -= EVENT_JITTER_US;
 
+	/* +1 us radio_tmr_start_us compensation */
+	aux_start_us -= 1U;
+
 	start_us = radio_tmr_start_us(0, aux_start_us);
 	LL_ASSERT_ERR(start_us == (aux_start_us + 1U));
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -1380,7 +1380,9 @@ isr_rx_next_subevent:
 
 		hcto -= jitter_us;
 
-		start_us = hcto;
+		/* +1 us radio_tmr_start_us compensation */
+		start_us = hcto - 1U;
+
 		hcto = radio_tmr_start_us(0U, start_us);
 		LL_ASSERT_ERR(hcto == (start_us + 1U));
 
@@ -1397,7 +1399,9 @@ isr_rx_next_subevent:
 		 */
 		hcto += radio_tmr_ready_restore();
 
-		start_us = hcto;
+		/* +1 us radio_tmr_start_us compensation */
+		start_us = hcto - 1U;
+
 		hcto = radio_tmr_start_us(0U, start_us);
 		LL_ASSERT_ERR(hcto == (start_us + 1U));
 


### PR DESCRIPTION
Fix radio_tmr_start_us() calls for the added +1 us used when starting radio using the packet timer.