### PR TITLE
MAINTAINERS: SMF: add @vlad-kulikov as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4747,6 +4747,7 @@ State machine framework:
   collaborators:
     - keith-zephyr
     - glenn-andrews
+    - vlad-kulikov
   files:
     - doc/services/smf/
     - include/zephyr/smf.h


### PR DESCRIPTION
I nominate my self as s collaborator for the State machine framework (SMF). Rationale: sustained contributions to SMF (performance work, tests, reviews).
Representative PRs:
#98386
#97943
#97369
#97216
#97030
#96964
#96660

RFCs: 
#95847
#95952

@keith-zephyr @glenn-andrews - PTAL.