### PR TITLE
boards: imx93_evk_mimx9352_m33_ddr.yaml: remove 'flash: 0'

### DIFF
--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_m33_ddr.yaml
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_m33_ddr.yaml
@@ -9,7 +9,6 @@ toolchain:
   - zephyr
   - cross-compile
 ram: 4096
-flash: 0
 supported:
   - gpio
   - uart


### PR DESCRIPTION
It was preventing this variant (imx93_evk/mimx9352/m33/ddr) to show up in the boards documentation. Other similar boards with similar DDR variants (e.g. imx95_evk/mimx9596/m7/ddr) don't include this 'flash: 0' line.

As per the Discord discussion with @kartben and @JarmouniA.

Thanks!