### PR TITLE
samples: video: capture: Use UART2 as UART0 pins are taken by MICFIL

### DIFF
--- a/samples/drivers/video/capture/boards/frdm_mcxn236.overlay
+++ b/samples/drivers/video/capture/boards/frdm_mcxn236.overlay
@@ -6,18 +6,10 @@
 
 / {
 	chosen {
-		/* Switch to flexcomm0_lpuart0(P0_16,P0_17), since default console
+		/* Switch to flexcomm2_lpuart2(P4_2,P4_3), since default console
 		 * pins are duplicated with camera header pins
 		 */
-		zephyr,console = &flexcomm0_lpuart0;
-		zephyr,shell-uart = &flexcomm0_lpuart0;
+		zephyr,console = &flexcomm2_lpuart2;
+		zephyr,shell-uart = &flexcomm2_lpuart2;
 	};
-};
-
-&flexcomm0 {
-	status = "okay";
-};
-
-&flexcomm0_lpuart0 {
-	status = "okay";
 };


### PR DESCRIPTION
## FRDM_MCXN236 
The Video capture sample previously used the uart0 peripheral for  Console and Logging however  `6de5831a926 ` now uses these pins for MICFIL  change the uart to uart2 so the logs can still be delivered. 

Didn't keep uart0 as I cant see where P0_6 is exposed on the devkit

Fixes #98736 98736