### PR TITLE
drivers: flash: Fix devicetree API typo in AT25XV021A flash driver

### DIFF
--- a/drivers/flash/spi_flash_at25xv021a.c
+++ b/drivers/flash/spi_flash_at25xv021a.c
@@ -942,12 +942,12 @@ static DEVICE_API(flash, spi_flash_at25xv021a_api) = {
 #define SPI_OP (SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8))
 
 #define PAGE_SIZE_IF_WRITEABLE(inst)                                                               \
-	COND_CODE_0(DT_INST_NODE_PROP_OR(inst, read_only, false),	\
+	COND_CODE_0(DT_INST_PROP_OR(inst, read_only, false),	\
 		(.page_size = DT_INST_PROP(inst, page_size),),	\
 		(EMPTY))
 
 #define TIMEOUT_ERASE_IF_WRITEABLE(inst)                                                           \
-	COND_CODE_0(DT_INST_NODE_PROP_OR(inst, read_only, false),	\
+	COND_CODE_0(DT_INST_PROP_OR(inst, read_only, false),	\
 		(.timeout_erase = K_MSEC(DT_INST_PROP(inst, timeout_erase)),),	\
 		(EMPTY))
 


### PR DESCRIPTION
Fix typos in the driver instantiation macro, which leads to page_size and timeout_erase defaulting to 0 regardless of whether the devicetree instance has the read-only property or not.

DT_INST_NODE_PROP_OR() -> DT_INST_PROP_OR()

Fixes #98938