### PR TITLE
Fix DCMIPP parallel interface based RGB565 & GC2145 CSI RGB565 formats

### DIFF
--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -328,7 +328,26 @@ static int stm32_dcmipp_conf_parallel(const struct device *dev,
 	HAL_StatusTypeDef hal_ret;
 
 	parallel_cfg.Format           = input_fmt->dcmipp_format;
-	parallel_cfg.SwapCycles       = DCMIPP_SWAPCYCLES_DISABLE;
+	/*
+	 * On parallel interface, the DCMIPP expects data in RGB565_BE, aka
+	 *		D7 D6 D5 D4 D3 D2 D1 D0
+	 *
+	 * cycle 1:	R4 R3 R2 R1 R0 G5 G4 G3
+	 * cycle 2:	G2 G1 G0 B4 B3 B2 B1 B0
+	 *
+	 * Use swapped cycle mode for RGB565 which correspond to the commonly
+	 * used RGB565 LE, aka
+	 *
+	 *		D7 D6 D5 D4 D3 D2 D1 D0
+	 *
+	 * cycle 1:	G2 G1 G0 B4 B3 B2 B1 B0
+	 * cycle 2:	R4 R3 R2 R1 R0 G5 G4 G3
+	 */
+	if (input_fmt->pixelformat == VIDEO_PIX_FMT_RGB565) {
+		parallel_cfg.SwapCycles = DCMIPP_SWAPCYCLES_ENABLE;
+	} else {
+		parallel_cfg.SwapCycles = DCMIPP_SWAPCYCLES_DISABLE;
+	}
 	parallel_cfg.VSPolarity       = config->parallel.vs_polarity;
 	parallel_cfg.HSPolarity       = config->parallel.hs_polarity;
 	parallel_cfg.PCKPolarity      = config->parallel.pck_polarity;


### PR DESCRIPTION
While preparing addition of the camera pipeline into the STM32H7RS, I ran the OV5640 sensor (st_b_cams_omv shield) on it and noticed that the colors were not correct.

It turns out that both DCMIPP parallel interface configuration is not correct in case of RGB565 format. As indicated in the 1st commit of this PR, the expected RGB565 format by the DCMIPP in parallel is cycled swapped compared to the RGB565 defined by Zephyr for RGB565 (and from sensors). For this reason it is necessary to apply a cycle swap on the input of the DCMIPP in case of parallel interface based in RGB565.

The MP135F-DK board is also using this format in parallel but issue was not seen so far due to a 2nd bug this time within the GC2145 driver when used in RGB565 / CSI mode (The MP135F-DK embeds a CSI to parallel bridge). The GC2145 (in CSI mode) was outputting RGB565 but in Big Endian formatting instead of the common Little Endian formatting defined by MIPI. This was leading swapped cycles at the input of the DCMIPP, hence "hiding" the DCMIPP issue.

This PR corrects both GC2145 and DCMIPP side and I can confirm now that DCMIPP can properly work with the default OV5640 sensor / drive on the STM32H7RS soc. (this support will be pushed in a separate PR since this STM32H7RS / Camera is not to be considered as a fix).

Fixes: #98839