### PR TITLE
lorawan: Move invalid requirement of 2KiB system workqueue

### DIFF
--- a/modules/loramac-node/Kconfig
+++ b/modules/loramac-node/Kconfig
@@ -33,6 +33,7 @@ config HAS_SEMTECH_LORAMAC
 config HAS_SEMTECH_SOFT_SE
 	bool "Semtech Secure Element software implementation"
 	depends on HAS_SEMTECH_LORAMAC
+	depends on SYSTEM_WORKQUEUE_STACK_SIZE >= 2048
 	help
 	  This option enables the use of Semtech's Secure Element
 	  software implementation

--- a/subsys/lorawan/Kconfig
+++ b/subsys/lorawan/Kconfig
@@ -6,7 +6,6 @@
 menuconfig LORAWAN
 	bool "LoRaWAN support [EXPERIMENTAL]"
 	depends on LORA
-	depends on SYSTEM_WORKQUEUE_STACK_SIZE >= 2048
 	select REQUIRES_FULL_LIBC
 	select HAS_SEMTECH_LORAMAC
 	imply HAS_SEMTECH_SOFT_SE


### PR DESCRIPTION
The LoRaWAN subsystem does not require 2KiB of system workqueue, testing on nrf54l15 flpr (RISCV) CPU (with custom cryptography code) shows it uses about 700 bytes of the system workqueue, therefore it is assumed that the real requirement for 2KiB is the software cryptography features, not the LoRaWAN stack itself, and the cryptography parts of LoRaWAN can be replaced with alternatives that do not need this high of a memory requirement, so the requirement has been moved to the specific Kconfig for software cryptography instead

To clarify, the **whole** application running on this core is using at most ~700 bytes of the system workqueue, this includes LoRaWAN and other parts of the code, including a duplex cross-core communication system for running commands, so it is likely that the LoRaWAN subsystem needs less than 700 bytes but I have not made a direct measurement as to how much