### PR TITLE
drivers: coredump: Use correct output function for callbacks

### DIFF
--- a/drivers/coredump/coredump_impl.c
+++ b/drivers/coredump/coredump_impl.c
@@ -45,7 +45,7 @@ static void coredump_impl_dump(const struct device *dev)
 
 			/* Invoke callback to allow consumer to fill array with desired data */
 			data->dump_callback(start_address, size);
-			coredump_memory_dump(start_address, start_address + size);
+			coredump_buffer_output((uint8_t *)start_address, size);
 		}
 	} else { /* COREDUMP_TYPE_MEMCPY */
 		/*


### PR DESCRIPTION
**Description:**

This PR fixes a bug in the `coredump_impl` driver where data from a `COREDUMP_TYPE_CALLBACK` device was not being correctly written to the coredump.

**Problem:** The driver was using `coredump_memory_dump()`, which expects a physical memory address. It was being passed the virtual address of a static buffer, causing the backend to fail to find the memory region and skip dumping the data.

**Solution:** The fix is to use `coredump_buffer_output()` instead. This function is designed to handle arbitrary memory buffers, ensuring the data from the user callback is correctly written to the coredump log.