### PR TITLE
drivers: gnss: Fix snprintk return value check in gnss_dump

### DIFF
--- a/drivers/gnss/gnss_dump.c
+++ b/drivers/gnss/gnss_dump.c
@@ -112,7 +112,7 @@ int gnss_dump_nav_data(char *str, uint16_t strsize, const struct navigation_data
 		       nav_data->speed / 1000, nav_data->speed % 1000,
 		       alt_sign, abs(nav_data->altitude) / 1000, abs(nav_data->altitude) % 1000);
 
-	return (strsize < ret) ? -ENOMEM : 0;
+	return (ret < 0 || ret >= strsize) ? -ENOMEM : 0;
 }
 
 int gnss_dump_time(char *str, uint16_t strsize, const struct gnss_time *utc)
@@ -124,7 +124,7 @@ int gnss_dump_time(char *str, uint16_t strsize, const struct gnss_time *utc)
 	ret = snprintk(str, strsize, fmt, utc->hour, utc->minute, utc->millisecond,
 		       utc->month_day, utc->month, utc->century_year);
 
-	return (strsize < ret) ? -ENOMEM : 0;
+	return (ret < 0 || ret >= strsize) ? -ENOMEM : 0;
 }
 
 #if CONFIG_GNSS_SATELLITES
@@ -138,7 +138,7 @@ int gnss_dump_satellite(char *str, uint16_t strsize, const struct gnss_satellite
 		       satellite->azimuth, gnss_system_to_str(satellite->system),
 		       satellite->is_tracked);
 
-	return (strsize < ret) ? -ENOMEM : 0;
+	return (ret < 0 || ret >= strsize) ? -ENOMEM : 0;
 }
 #endif
 


### PR DESCRIPTION
Fixes <https://github.com/zephyrproject-rtos/zephyr/issues/98948>

The snprintk function returns the number of characters that *would have been* written if the buffer was large enough. This means if the return value `ret` is greater than or equal to the buffer size `strsize`, the output was truncated.

The existing check `(strsize < ret)` was incorrect as it did not handle the case where `ret == strsize` (output fits exactly, but no room for null terminator) and did not check for negative return values which indicate an encoding error.

This commit corrects the check to `(ret < 0 || ret >= strsize)` to properly detect truncation and errors, returning -ENOMEM in these cases. This fix is applied to `gnss_dump_nav_data`, `gnss_dump_time`, and `gnss_dump_satellite` functions.