### PR TITLE
boards: shields: st: enable the touch input on st_lcd_dsi_mb1835

### DIFF
--- a/boards/shields/st_lcd_dsi_mb1835/Kconfig.defconfig
+++ b/boards/shields/st_lcd_dsi_mb1835/Kconfig.defconfig
@@ -7,6 +7,9 @@ orsource "boards/*.defconfig"
 
 if LVGL
 
+config INPUT
+	default y
+
 config LV_Z_BITS_PER_PIXEL
 	default 32
 

--- a/boards/shields/st_lcd_dsi_mb1835/doc/index.rst
+++ b/boards/shields/st_lcd_dsi_mb1835/doc/index.rst
@@ -116,6 +116,19 @@ Set ``--shield "st_lcd_dsi_mb1835"`` when you invoke ``west build``. For example
    :shield: st_lcd_dsi_mb1835
    :goals: build
 
+You can test both the display and the capacitive touch using the
+:zephyr:code-sample:`draw_touch_events` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/input/draw_touch_events
+   :board: stm32u5g9j_dk1
+   :shield: st_lcd_dsi_mb1835
+   :goals: build
+
+This sample renders a cross that follows your finger and is a quick way to
+verify that the panel, LTDC, and touch controller are wired and configured
+correctly on STM32U5G9J-DK1 with this shield.
+
 References
 **********
 

--- a/boards/shields/st_lcd_dsi_mb1835/st_lcd_dsi_mb1835.overlay
+++ b/boards/shields/st_lcd_dsi_mb1835/st_lcd_dsi_mb1835.overlay
@@ -9,6 +9,12 @@
 / {
 	chosen {
 		zephyr,display = &zephyr_lcd_controller;
+		zephyr,touch = &st1633i;
+	};
+
+	lvgl_pointer {
+		compatible = "zephyr,lvgl-pointer-input";
+		input = <&st1633i>;
 	};
 };
 
@@ -109,5 +115,14 @@
 		vsync-len = <1>;
 		vback-porch = <13>;
 		vfront-porch = <50>;
+	};
+};
+
+&qsh_030_i2c {
+	st1633i: st1633i@70 {
+		compatible = "sitronix,cf1133";
+		reg = <0x70>;
+		int-gpios = <&dsi_lcd_qsh_030 4 GPIO_ACTIVE_LOW>;
+		status = "okay";
 	};
 };

--- a/boards/st/stm32u5g9j_dk1/doc/index.rst
+++ b/boards/st/stm32u5g9j_dk1/doc/index.rst
@@ -140,6 +140,22 @@ Here is an example for the :zephyr:code-sample:`blinky` application.
    :goals: debug
 
 
+Using the ST LCD DSI MB1835 shield
+**********************************
+
+The :ref:`st_lcd_dsi_mb1835` shield provides a 480x480 round LCD panel with
+capacitive touch for this board via MIPI DSI and I2C. You can exercise both
+display and touch using the :zephyr:code-sample:`draw_touch_events` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/input/draw_touch_events
+   :board: stm32u5g9j_dk1
+   :shield: st_lcd_dsi_mb1835
+   :goals: build flash
+
+See the shield documentation for details: :ref:`st_lcd_dsi_mb1835`.
+
+
 .. _STM32U5G9J-DK1 website:
    https://www.st.com/en/evaluation-tools/stm32u5g9j-dk1.html
 

--- a/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
+++ b/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
@@ -311,6 +311,13 @@ zephyr_udc0: &usbotg_hs {
 	status = "okay";
 };
 
+qsh_030_i2c: &i2c5 {
+	pinctrl-0 = <&i2c5_scl_ph5 &i2c5_sda_ph4>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
+};
+
 /* alias used by display shields */
 zephyr_mipi_dsi: &mipi_dsi {};
 


### PR DESCRIPTION
Add devicetree and configuration for the touch controller on STM32U5G9J-DK1 and st_lcd_dsi_mb1835 shield.

Testing with:
`west build -p -b stm32u5g9j_dk1 --shield st_lcd_dsi_mb1835 samples/subsys/input/draw_touch_events`

Related to:
- https://github.com/zephyrproject-rtos/zephyr/pull/98719

https://github.com/user-attachments/assets/7b683d06-aa66-40fa-94b1-8c70fc4cd384

