### PR TITLE
api: codec: Add support for custom channel identifiers

### DIFF
--- a/include/zephyr/audio/codec.h
+++ b/include/zephyr/audio/codec.h
@@ -95,6 +95,22 @@ typedef enum {
 	AUDIO_CHANNEL_HEADPHONE_LEFT,   /**< Headphone left */
 	AUDIO_CHANNEL_HEADPHONE_RIGHT,  /**< Headphone right */
 	AUDIO_CHANNEL_ALL,		/**< All channels */
+
+	/**
+	 * Number of all common channel identifiers.
+	 */
+	AUDIO_CHANNEL_COMMON_COUNT,
+
+	/**
+	 * This and higher values are codec specific.
+	 * Refer to the codec's header file.
+	 */
+	AUDIO_CHANNEL_PRIV_START = AUDIO_CHANNEL_COMMON_COUNT,
+
+	/**
+	 * Maximum value describing an audio codec channel identifier.
+	 */
+	AUDIO_CHANNEL_MAX = INT16_MAX
 } audio_channel_t;
 
 /**


### PR DESCRIPTION
Currently the codec API has a limited set of predefined "channel identifiers" which doesn't map to all codecs (e.g. where they are a numeric set that don't correspond to a position like "front left").

Follow the convention used elsewhere, e.g. in the ADC API, DMA API, and sensor API to allow users to define their own channel identifiers.

Edit: typos corrected.