### PR TITLE
samples: subsys: input: draw_touch_events: fix overflow in clear_screen loop

### DIFF
--- a/boards/shields/st_lcd_dsi_mb1835/st_lcd_dsi_mb1835.overlay
+++ b/boards/shields/st_lcd_dsi_mb1835/st_lcd_dsi_mb1835.overlay
@@ -88,7 +88,7 @@
 	status = "okay";
 	width = <480>;
 	height = <480>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
+	pixel-format = <PANEL_PIXEL_FORMAT_ARGB_8888>;
 
 	bl-ctrl-gpios = <&dsi_lcd_qsh_030 53 GPIO_ACTIVE_HIGH>;
 

--- a/samples/subsys/input/draw_touch_events/src/main.c
+++ b/samples/subsys/input/draw_touch_events/src/main.c
@@ -70,7 +70,15 @@ static void clear_screen(void)
 
 	for (x = 0; x < WIDTH; x += CROSS_DIM) {
 		for (y = 0; y < HEIGHT; y += CROSS_DIM) {
-			display_write(display_dev, x, y, &buf_desc, buffer_cross_empty);
+			struct display_buffer_descriptor ddesc = buf_desc;
+			uint16_t rem_w = WIDTH - x;
+			uint16_t rem_h = HEIGHT - y;
+
+			ddesc.width = MIN(buf_desc.width, rem_w);
+			ddesc.height = MIN(buf_desc.height, rem_h);
+			ddesc.buf_size = ddesc.width * ddesc.height * BPP;
+
+			display_write(display_dev, x, y, &ddesc, buffer_cross_empty);
 		}
 	}
 }


### PR DESCRIPTION
Problem: On STM32U5G9J-DK1 + st_lcd_dsi_mb1835, the sample could BUS FAULT with SCREEN_WIDTH_TO_CROSS_DIM=25 and show only a horizontal line with 20.

~~Root cause: The tile buffer BPP is derived from the devicetree pixel format (e.g., RGB888 = 3 BPP), but the driver may be using a different current pixel format.~~

~~Fix: Explicitly set the driver pixel format to the DT-selected format at init.~~

**EDIT:**
The `clear_screen` loop used fixed-size tiles (CROSS_DIM). When WIDTH/HEIGHT aren’t multiples of CROSS_DIM, the right/bottom tiles exceeded the panel bounds, causing the driver’s row copy (memcpy) to write past the framebuffer and fault.

Fix: clip only the edge tiles

- width = min(CROSS_DIM, WIDTH - x)
- height = min(CROSS_DIM, HEIGHT - y)
- pitch remains CROSS_DIM (source stride)
- buf_size = width * height * BPP

Prevents out-of-bounds writes on edge tiles.

Related with:
- https://github.com/zephyrproject-rtos/zephyr/pull/98717

https://github.com/user-attachments/assets/993ed0d1-ee71-4d50-bfe4-0e9eb88f03c9

Fixes #98922