### PR TITLE
dts: nordic: nrf91xx: fix NS partition references

### DIFF
--- a/dts/vendor/nordic/nrf91xx_partition.dtsi
+++ b/dts/vendor/nordic/nrf91xx_partition.dtsi
@@ -116,12 +116,12 @@
 		#size-cells = <1>;
 		ranges = <0x0 0x16000 DT_SIZE_K(168)>;
 
-		sram0_ns_modem: sram@0 {
+		sram0_ns_modem: sram0_ns@0 {
 			/* Modem (shared) memory */
 			reg = <0x0 DT_SIZE_K(40)>;
 		};
 
-		sram0_ns_app: sram@a000 {
+		sram0_ns_app: sram0_ns@a000 {
 			/* Non-Secure application memory */
 			reg = <0xa000 DT_SIZE_K(128)>;
 		};


### PR DESCRIPTION
`sram0_ns_modem` and `sram0_ns_app` are child nodes of `sram0_ns`, not `sram`. Addresses should be relative to the former, not the later.

Fixes #98727