### PR TITLE
modules: tf-m: rework output file generation

### DIFF
--- a/doc/services/tfm/build.rst
+++ b/doc/services/tfm/build.rst
@@ -61,12 +61,6 @@ When :kconfig:option:`CONFIG_TFM_BL2` is set to ``y``, TF-M uses a secure bootlo
 is validated by the bootloader during updates using the corresponding public
 key, which is stored inside the secure bootloader firmware image.
 
-During the signing procedure, all HEX files are marked as ``confirmed``,
-whereas all BIN files remain ``unconfirmed``. This guarantees that any image
-flashed into a device possesses the required properties for compatibility
-with the `PSA Certified Firmware Update API`_. The corresponding BIN file
-can then be used as the payload in the Firmware Update procedure.
-
 By default, ``<tfm-dir>/bl2/ext/mcuboot/root-rsa-3072.pem`` is used to sign secure
 images, and ``<tfm-dir>/bl2/ext/mcuboot/root-rsa-3072_1.pem`` is used to sign
 non-secure images. These default .pem keys can (and **should**) be overridden
@@ -95,13 +89,27 @@ flags.
      and it will no longer be possible to update your devices in the field!
 
 After the built-in signing script has run, it creates a ``tfm_merged.hex``
-file that contains all three binaries: bl2, tfm_s, and the zephyr app. This
-hex file can then be flashed to your development board or run in QEMU.
+(and ``tfm_merged.bin``) file that contains all three binaries: bl2, tfm_s,
+and the zephyr app. These files can then be flashed to your development board
+or run in QEMU.
 
 .. _PSA Certified Level 1:
   https://www.psacertified.org/security-certification/psa-certified-level-1/
 .. _PSA Certified Firmware Update API:
   https://arm-software.github.io/psa-api/fwu/
+
+Output Files
+************
+
+Upon completion of the Zephyr TF-M build, the following output files exist:
+
+.. csv-table:: TF-M Output Files
+  :header: Filename, Created From, Bootloader Flags, Usage
+
+  ``tfm_s_signed.{hex/bin}``, "TF-M Secure", Signed, OTA Upgrades (:kconfig:option:`CONFIG_TFM_MCUBOOT_IMAGE_NUMBER` == 2)
+  ``zephyr_ns_signed.{hex/bin}``, "Zephyr Nonsecure", Signed, OTA Upgrades (:kconfig:option:`CONFIG_TFM_MCUBOOT_IMAGE_NUMBER` == 2)
+  ``tfm_s_zephyr_ns_signed.{hex/bin}``, "TF-M Secure, Zephyr Nonsecure", Signed, OTA Upgrades (:kconfig:option:`CONFIG_TFM_MCUBOOT_IMAGE_NUMBER` == 1)
+  ``tfm_merged.{hex/bin}``, "Bootloader, TF-M Secure, Zephyr Nonsecure", "Signed, Confirmed", "Production Programming, flashed by ``west flash``"
 
 Custom CMake arguments
 ======================

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -618,16 +618,12 @@ if(CONFIG_BUILD_WITH_TFM)
         $<$<BOOL:${CONFIG_TFM_BL1}>:$<TARGET_PROPERTY:tfm,BL2_SIGNED_HEX_FILE>>
         $<$<NOT:$<BOOL:${CONFIG_TFM_BL1}>>:$<TARGET_PROPERTY:tfm,BL2_HEX_FILE>>
         ${S_NS_SIGNED_CONFIRMED_HEX_FILE}
+
+      COMMAND ${CMAKE_OBJCOPY} --input-target=ihex --output-target=binary ${MERGED_HEX_FILE} ${MERGED_BIN_FILE}
     )
 
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
       COMMAND ${sign_cmd_s_ns_hex}
-
-      COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
-        -o ${MERGED_BIN_FILE} --output-bin
-        $<$<BOOL:${CONFIG_TFM_BL1}>:$<TARGET_PROPERTY:tfm,BL2_SIGNED_HEX_FILE>>
-        $<$<NOT:$<BOOL:${CONFIG_TFM_BL1}>>:$<TARGET_PROPERTY:tfm,BL2_HEX_FILE>>
-        ${S_NS_SIGNED_HEX_FILE}
 
       COMMAND ${CMAKE_OBJCOPY} --input-target=ihex --output-target=binary ${S_NS_SIGNED_HEX_FILE} ${S_NS_SIGNED_BIN_FILE}
     )
@@ -636,6 +632,7 @@ if(CONFIG_BUILD_WITH_TFM)
       ${S_NS_SIGNED_CONFIRMED_HEX_FILE}
       ${S_NS_HEX_FILE}
       ${S_NS_SIGNED_HEX_FILE}
+      ${S_NS_SIGNED_BIN_FILE}
       ${MERGED_HEX_FILE}
       ${MERGED_BIN_FILE}
     )

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -565,7 +565,6 @@ if(CONFIG_BUILD_WITH_TFM)
 
   set(MERGED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_merged.hex)
   set(MERGED_BIN_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_merged.bin)
-  set(S_NS_CONFIRMED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns_confirmed.hex)
   set(S_NS_SIGNED_CONFIRMED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns_confirmed_signed.hex)
   set(S_NS_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns.hex)
   set(S_NS_SIGNED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns_signed.hex)
@@ -600,14 +599,14 @@ if(CONFIG_BUILD_WITH_TFM)
   elseif(CONFIG_TFM_MCUBOOT_IMAGE_NUMBER STREQUAL "1")
     tfm_sign(sign_cmd_s_ns_confirm_hex SUFFIX "S_NS"
       HEADER TRAILER CONFIRM MAX_SECTORS ${S_NS_MAX_SECTORS}
-      INPUT_FILE ${S_NS_CONFIRMED_HEX_FILE} OUTPUT_FILE ${S_NS_SIGNED_CONFIRMED_HEX_FILE})
+      INPUT_FILE ${S_NS_HEX_FILE} OUTPUT_FILE ${S_NS_SIGNED_CONFIRMED_HEX_FILE})
     tfm_sign(sign_cmd_s_ns_hex SUFFIX "S_NS"
       HEADER TRAILER MAX_SECTORS ${S_NS_MAX_SECTORS}
       INPUT_FILE ${S_NS_HEX_FILE} OUTPUT_FILE ${S_NS_SIGNED_HEX_FILE})
 
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
       COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
-        -o ${S_NS_CONFIRMED_HEX_FILE}
+        -o ${S_NS_HEX_FILE}
         $<TARGET_PROPERTY:tfm,TFM_S_HEX_FILE>
         ${NS_HEX_APP_FILE}
 
@@ -621,11 +620,6 @@ if(CONFIG_BUILD_WITH_TFM)
     )
 
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
-        -o ${S_NS_HEX_FILE}
-        $<TARGET_PROPERTY:tfm,TFM_S_HEX_FILE>
-        ${NS_HEX_APP_FILE}
-
       COMMAND ${sign_cmd_s_ns_hex}
 
       COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
@@ -636,7 +630,6 @@ if(CONFIG_BUILD_WITH_TFM)
     )
 
     set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
-      ${S_NS_CONFIRMED_HEX_FILE}
       ${S_NS_SIGNED_CONFIRMED_HEX_FILE}
       ${S_NS_HEX_FILE}
       ${S_NS_SIGNED_HEX_FILE}

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -568,6 +568,7 @@ if(CONFIG_BUILD_WITH_TFM)
   set(S_NS_SIGNED_CONFIRMED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns_confirmed_signed.hex)
   set(S_NS_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns.hex)
   set(S_NS_SIGNED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns_signed.hex)
+  set(S_NS_SIGNED_BIN_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns_signed.bin)
   set(NS_SIGNED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/zephyr_ns_signed.hex)
   set(S_SIGNED_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_signed.hex)
   set(NS_SIGNED_BIN_FILE ${CMAKE_BINARY_DIR}/zephyr/zephyr_ns_signed.bin)
@@ -627,6 +628,8 @@ if(CONFIG_BUILD_WITH_TFM)
         $<$<BOOL:${CONFIG_TFM_BL1}>:$<TARGET_PROPERTY:tfm,BL2_SIGNED_HEX_FILE>>
         $<$<NOT:$<BOOL:${CONFIG_TFM_BL1}>>:$<TARGET_PROPERTY:tfm,BL2_HEX_FILE>>
         ${S_NS_SIGNED_HEX_FILE}
+
+      COMMAND ${CMAKE_OBJCOPY} --input-target=ihex --output-target=binary ${S_NS_SIGNED_HEX_FILE} ${S_NS_SIGNED_BIN_FILE}
     )
 
     set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -319,8 +319,8 @@ if(CONFIG_BUILD_WITH_TFM)
     # number of parallel jobs to 1.
     set(PARALLEL_JOBS -j 1)
   else()
-	# Leave PARALLEL_JOBS unset and use the default number of
-	# threads. Which is num_cores+2 on Ninja and MAKEFLAGS with Make.
+    # Leave PARALLEL_JOBS unset and use the default number of
+    # threads. Which is num_cores+2 on Ninja and MAKEFLAGS with Make.
   endif()
 
   set(tfm_image_info MAP "name: tfm, source-dir: ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}")

--- a/scripts/build/mergehex.py
+++ b/scripts/build/mergehex.py
@@ -42,7 +42,7 @@ def parse_args():
     parser.add_argument("--overlap", default="error",
                         help="What to do when files overlap (error, ignore, replace). "
                              "See IntelHex.merge() for more info.")
-    parser.add_argument("--output-bin", default=False,
+    parser.add_argument("--output-bin", action='store_true',
                         help="Save the merged content as binary file.")
     parser.add_argument("input_files", nargs='*')
     return parser.parse_args()


### PR DESCRIPTION
Stop `mergehex.py` argument `--output-bin` from consuming the first trailing argument that should have been in `input_files`.

`S_NS_CONFIRMED_HEX_FILE` was never generating a confirmed file, just the same file contents as `S_NS_HEX_FILE`. Since no logic needs a confirmed merge of `tfm_s.hex` and `zephyr.hex`, just remove the logic instead of fixing it.

Generate a binary version of `tfm_s_zephyr_ns_signed.hex` with objcopy. This file is valid for performing OTA upgrades, unlike `tfm_merged.bin`, which now contains BL2.

Generate `tfm_merged.bin` from `tfm_merged.hex` with objcopy.

Fixes #98728

After this PR, the correct file to use for OTA upgrades with `CONFIG_TFM_MCUBOOT_IMAGE_NUMBER=1` is `tfm_s_zephyr_ns_signed.bin`, not `tfm_merged.bin`.