### PR TITLE
fix(can): mcp2515: Guard TX interrupt handling for multi-buffer configs

### DIFF
--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -831,13 +831,17 @@ static void mcp2515_handle_interrupts(const struct device *dev)
 			mcp2515_tx_done(dev, 0, 0);
 		}
 
+#if MCP2515_TX_CNT > 1
 		if (canintf & MCP2515_CANINTF_TX1IF) {
 			mcp2515_tx_done(dev, 1, 0);
 		}
+#endif /* MCP2515_TX_CNT > 1 */
 
+#if MCP2515_TX_CNT > 2
 		if (canintf & MCP2515_CANINTF_TX2IF) {
 			mcp2515_tx_done(dev, 2, 0);
 		}
+#endif /* MCP2515_TX_CNT > 2 */
 
 		if (canintf & MCP2515_CANINTF_ERRIF) {
 			mcp2515_handle_errors(dev);


### PR DESCRIPTION
Fixes <https://github.com/zephyrproject-rtos/zephyr/issues/98954>

The MCP2515 driver can be configured with 1, 2, or 3 transmit buffers via the `MCP2515_TX_CNT`  constant.

The interrupt handler checks for transmit complete interrupts for `TXB1` and `TXB2`. However, the code for these checks was not guarded by preprocessor conditionals. This meant the code would be compiled even if the driver was configured to use only one transmit buffer (`MCP2515_TX_CNT=1`), which is the default.

This change adds the appropriate `#if MCP2515_TX_CNT > 1` and `#if MCP2515_TX_CNT > 2` guards around the interrupt handling logic for the second and third transmit buffers, respectively. This ensures that the code is only included when the corresponding buffers are actually configured, improving code clarity and preventing compilation of unused logic.