### PR TITLE
kernel: macro to approximate heap overhead

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5949,6 +5949,42 @@ void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
 #define Z_HEAP_MIN_SIZE ((sizeof(void *) > 4) ? 56 : 44)
 #endif /* CONFIG_SYS_HEAP_RUNTIME_STATS */
 
+/* Size of `struct z_heap` */
+#define _Z_HEAP_SIZE                                                                               \
+	((4 * sizeof(uint32_t)) +                                                                  \
+	 (3 * (IS_ENABLED(CONFIG_SYS_HEAP_RUNTIME_STATS) ? sizeof(size_t) : 0)))
+
+/* Number of buckets required to store @a bytes */
+#define _Z_HEAP_NUM_BUCKETS(bytes) ((31 - __builtin_clz((bytes / 8) - 1)) + 1)
+
+/* Number of bytes consumed by buckets */
+#define _Z_HEAP_BUCKETS_SIZE(bytes) (_Z_HEAP_NUM_BUCKETS(bytes) * sizeof(uint32_t))
+
+/**
+ * @brief Minimum heap size required for allocating a given size
+ *
+ * Heaps store metadata at the start of the provided array, resulting in a
+ * heap declaration of N bytes having an actual allocation capacity of less
+ * than N bytes. This macro approximates how much overhead in bytes the metadata
+ * consumes, allowing for real allocations closer to the requested size.
+ *
+ * Assumes small heaps, since for large heaps the importance of tuning single bytes
+ * is small.
+ *
+ * The parameters considered:
+ *   Size of the header "struct z_heap"
+ *   Buckets holding chunk metadata
+ *   Free heap chunk
+ *   End chunk
+ *   Chunk metadata for single allocation
+ *
+ * @param alloc_bytes Size of a desired allocation
+ *
+ * @retval Approximate size of the heap required to allocate @a alloc_bytes
+ */
+#define Z_HEAP_MIN_SIZE_FOR(alloc_bytes) \
+	((alloc_bytes) + _Z_HEAP_SIZE + _Z_HEAP_BUCKETS_SIZE(alloc_bytes) + (3 * 8))
+
 /**
  * @brief Define a static k_heap in the specified linker section
  *

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -74,7 +74,7 @@ void k_free(void *ptr)
 
 #if (K_HEAP_MEM_POOL_SIZE > 0)
 
-K_HEAP_DEFINE(_system_heap, K_HEAP_MEM_POOL_SIZE);
+K_HEAP_DEFINE(_system_heap, Z_HEAP_MIN_SIZE_FOR(K_HEAP_MEM_POOL_SIZE));
 #define _SYSTEM_HEAP (&_system_heap)
 
 void *k_aligned_alloc(size_t align, size_t size)

--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -13,6 +13,9 @@
 #include <sanitizer/msan_interface.h>
 #endif
 
+/* Validate the `kernel.h` macro */
+BUILD_ASSERT(_Z_HEAP_SIZE == sizeof(struct z_heap), "Incorrect _Z_HEAP_SIZE value");
+
 #ifdef CONFIG_SYS_HEAP_RUNTIME_STATS
 static inline void increase_allocated_bytes(struct z_heap *h, size_t num_bytes)
 {


### PR DESCRIPTION
Add a macro to approximate the heap size required by a heap in order for an allocation of N bytes to succeed. The intent is to provide a way for small heaps to more accurately specify their sizes.
Add a testcase that outputs the overhead of heaps declared multiple different ways, by printing the largest single allocation that can be made from the heap.
```
START - test_heap_overhead
    Base |  Raw | Z_HEAP_MIN_SIZE | Z_HEAP_MIN_SIZE_FOR
      64 |   12 |              60 |                  68
     128 |   68 |             124 |                 132
     256 |  196 |             244 |                 260
     512 |  444 |             500 |                 516
    1024 |  956 |            1004 |                1028
    2048 | 1972 |            2028 |                2052
```

Use `Z_HEAP_MIN_SIZE_FOR` on the system heap. This fixes allocations failing when there is only a single small user of the heap defining a symbol like the following, even when only allocating 16 bytes.
```
config HEAP_MEM_POOL_ADD_SIZE_{X}
        int
        default 64
```

The motivation for this PR is https://github.com/nrfconnect/sdk-nrf/pull/25117. When that symbol is the only heap user in the build, allocating a single default context fails, even though the declared size is 4x the size of the requested memory. Rather than increasing that Kconfig, which only solves the problem once, this should solve the problem everywhere.