### PR TITLE
Bluetooth: Controller: Fix ISO Receiver Sync Lost assertion

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
@@ -84,6 +84,9 @@ struct lll_sync_iso {
 	uint8_t chm_chan_map[PDU_CHANNEL_MAP_SIZE];
 	uint8_t chm_chan_count:6;
 
+	/* Flag to stop events in LLL pipeline */
+	uint8_t is_lll_stop:1;
+
 	uint8_t term_reason;
 
 	uint16_t ctrl_instant;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -186,6 +186,15 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 
 	lll = p->param;
 
+	/* Check if stopped (on disconnection between prepare and preempt)
+	 */
+	if (unlikely(lll->is_lll_stop != 0U)) {
+		radio_isr_set(lll_isr_early_abort, lll);
+		radio_disable();
+
+		return 0;
+	}
+
 	/* Calculate the current event latency */
 	lll->lazy_prepare = p->lazy;
 	lll->latency_event = lll->latency_prepare + lll->lazy_prepare;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -185,6 +185,7 @@ uint8_t ll_big_sync_create(uint8_t big_handle, uint16_t sync_handle,
 
 	/* Initialize sync LLL context */
 	lll = &sync_iso->lll;
+	lll->is_lll_stop = 0U;
 	lll->lazy_prepare = 0U;
 	lll->latency_prepare = 0U;
 	lll->latency_event = 0U;
@@ -304,8 +305,9 @@ uint8_t ll_big_sync_terminate(uint8_t big_handle, void **rx)
 	/* Do a blocking mayfly call to LLL context for flushing any outstanding
 	 * operations.
 	 */
-	sync_iso->flush_sem = &sem;
 	k_sem_init(&sem, 0, 1);
+	sync_iso->flush_sem = &sem;
+
 	mfy.param = &sync_iso->lll;
 
 	ret = mayfly_enqueue(TICKER_USER_ID_THREAD, TICKER_USER_ID_LLL, 0, &mfy);
@@ -766,15 +768,24 @@ void ull_sync_iso_done(struct node_rx_event_done *done)
 	sync_iso = CONTAINER_OF(done->param, struct ll_sync_iso_set, ull);
 	lll = &sync_iso->lll;
 
+	/* Sync is lost, ignore all stale done for events in LLL pipeline */
+	if (lll->is_lll_stop != 0U) {
+		return;
+	}
+
 	/* Events elapsed used in timeout checks below */
 	latency_event = lll->latency_event;
 
 	/* Check for establishmet failure */
 	if (done->extra.estab_failed) {
+		/* Flag events in LLL pipeline to stop */
+		lll->is_lll_stop = 1U;
+
 		/* Stop Sync ISO Ticker directly. Establishment failure has been
 		 * notified.
 		 */
 		stop_ticker(sync_iso, NULL);
+
 		return;
 	}
 
@@ -864,11 +875,16 @@ void ull_sync_iso_done_terminate(struct node_rx_event_done *done)
 	sync_iso = CONTAINER_OF(done->param, struct ll_sync_iso_set, ull);
 	lll = &sync_iso->lll;
 
+	/* Flag events in LLL pipeline to stop */
+	LL_ASSERT_DBG(lll->is_lll_stop == 0U);
+	lll->is_lll_stop = 1U;
+
 	/* Populate the Sync Lost which will be enqueued in disabled_cb */
 	rx = (void *)&sync_iso->node_rx_lost;
 	rx->hdr.handle = sync_iso_handle_get(sync_iso);
 	rx->hdr.type = NODE_RX_TYPE_SYNC_ISO_LOST;
 	rx->rx_ftr.param = sync_iso;
+
 	*((uint8_t *)rx->pdu) = lll->term_reason;
 
 	/* Stop Sync ISO Ticker */
@@ -956,6 +972,9 @@ static uint16_t sync_iso_stream_handle_get(struct lll_sync_iso_stream *stream)
 static void timeout_cleanup(struct ll_sync_iso_set *sync_iso)
 {
 	struct node_rx_pdu *rx;
+
+	/* Flag events in LLL pipeline to stop */
+	sync_iso->lll.is_lll_stop = 1U;
 
 	/* Populate the Sync Lost which will be enqueued in disabled_cb */
 	rx = (void *)&sync_iso->node_rx_lost;


### PR DESCRIPTION
Fix ISO Receiver Sync Lost assertion due to successive calls to stop ticker instance under conditions where there are more than one ISO Sync LLL events enqueued in the LLL prepare pipeline. This is visible when supporting LLL resume for ISO Sync LLL events.