### PR TITLE
samples: video: capture: fix index increment in caps display

### DIFF
--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -170,7 +170,6 @@ static int app_query_video_info(const struct device *const video_dev,
 			VIDEO_FOURCC_TO_STR(fcap->pixelformat),
 			fcap->width_min, fcap->width_max, fcap->width_step,
 			fcap->height_min, fcap->height_max, fcap->height_step);
-		i++;
 	}
 
 	/* Get default/native format */


### PR DESCRIPTION
Since the i index is already being incremented as part of the for loop statement, the i++ done as part of the loop body should not be done since this lead to skip of entries of the table and moreover might lead to invalid access outside of the table.