### PR TITLE
doc: smf: Fix return type in event sample

### DIFF
--- a/doc/services/smf/index.rst
+++ b/doc/services/smf/index.rst
@@ -471,7 +471,7 @@ Code::
 		printk("STATE0\n");
 	}
 
-	static void s0_run(void *o)
+	static enum smf_state_result s0_run(void *o)
 	{
 		struct s_object *s = (struct s_object *)o;
 
@@ -488,7 +488,7 @@ Code::
 		printk("STATE1\n");
 	}
 
-	static void s1_run(void *o)
+	static enum smf_state_result s1_run(void *o)
 	{
 		struct s_object *s = (struct s_object *)o;
 


### PR DESCRIPTION
Fix the mismatch between the `*_run` function return type and implementation. The run functions return `enum smf_state_result`, but the event-driven sample defined them as void while still returning a value.