### PR TITLE
scripts: west_commands: patch: fix handling of stdout and stderr from subprocess.run()

### DIFF
--- a/scripts/west_commands/patch.py
+++ b/scripts/west_commands/patch.py
@@ -391,7 +391,7 @@ class Patch(WestCommand):
             self.dbg(f"patching {mod}... ", end="")
             apply_cmd += patch_path
             apply_cmd_list.extend([patch_path])
-            proc = subprocess.run(apply_cmd_list, cwd=mod_path)
+            proc = subprocess.run(apply_cmd_list, capture_output=True, cwd=mod_path)
             if proc.returncode:
                 self.dbg("FAIL")
                 self.err(proc.stderr)

--- a/scripts/west_commands/patch.py
+++ b/scripts/west_commands/patch.py
@@ -391,7 +391,9 @@ class Patch(WestCommand):
             self.dbg(f"patching {mod}... ", end="")
             apply_cmd += patch_path
             apply_cmd_list.extend([patch_path])
-            proc = subprocess.run(apply_cmd_list, capture_output=True, cwd=mod_path)
+            proc = subprocess.run(
+                apply_cmd_list, capture_output=True, cwd=mod_path, encoding="utf-8"
+            )
             if proc.returncode:
                 self.dbg("FAIL")
                 self.err(proc.stderr)
@@ -430,7 +432,9 @@ class Patch(WestCommand):
             try:
                 if checkout_cmd:
                     self.dbg(f"Running '{checkout_cmd}' in {mod}.. ", end="")
-                    proc = subprocess.run(checkout_cmd_list, capture_output=True, cwd=mod_path)
+                    proc = subprocess.run(
+                        checkout_cmd_list, capture_output=True, cwd=mod_path, encoding="utf-8"
+                    )
                     if proc.returncode:
                         self.dbg("FAIL")
                         self.err(f"{checkout_cmd} failed for {mod}\n{proc.stderr}")
@@ -439,7 +443,9 @@ class Patch(WestCommand):
 
                 if clean_cmd:
                     self.dbg(f"Running '{clean_cmd}' in {mod}.. ", end="")
-                    proc = subprocess.run(clean_cmd_list, capture_output=True, cwd=mod_path)
+                    proc = subprocess.run(
+                        clean_cmd_list, capture_output=True, cwd=mod_path, encoding="utf-8"
+                    )
                     if proc.returncode:
                         self.dbg("FAIL")
                         self.err(f"{clean_cmd} failed for {mod}\n{proc.stderr}")


### PR DESCRIPTION
Pass `capture_output=True` and `encoding="utf-8"` to `subprocess.run()` where appropriate, to correctly handle stdout and stderr from the process created by `subprocess.run()`.