### PR TITLE
kernel: `Z_HEAP_MIN_SIZE` for runtime stats

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5930,10 +5930,14 @@ void *k_heap_realloc(struct k_heap *h, void *ptr, size_t bytes, k_timeout_t time
  */
 void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
 
-/* Hand-calculated minimum heap sizes needed to return a successful
- * 1-byte allocation.  See details in lib/os/heap.[ch]
+/* Minimum heap sizes needed to return a successful 1-byte allocation.
+ * Assumes a chunk aligned (8 byte) memory buffer.
  */
+#ifdef CONFIG_SYS_HEAP_RUNTIME_STATS
+#define Z_HEAP_MIN_SIZE ((sizeof(void *) > 4) ? 80 : 52)
+#else
 #define Z_HEAP_MIN_SIZE ((sizeof(void *) > 4) ? 56 : 44)
+#endif /* CONFIG_SYS_HEAP_RUNTIME_STATS */
 
 /**
  * @brief Define a static k_heap in the specified linker section

--- a/tests/lib/heap_min/CMakeLists.txt
+++ b/tests/lib/heap_min/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(heap_min)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/heap_min/prj.conf
+++ b/tests/lib/heap_min/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/lib/heap_min/src/assert.c
+++ b/tests/lib/heap_min/src/assert.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include "assert.h"
+
+DEFINE_FAKE_VALUE_FUNC(bool, mock_check_if_assert_expected);
+
+void assert_print(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	vprintk(fmt, ap);
+	va_end(ap);
+}
+
+void assert_post_action(const char *file, unsigned int line)
+{
+	/* ztest_test_pass()/ztest_test_fail() are used to stop the execution
+	 * If this is an unexpected assert (i.e. not following expect_assert())
+	 * calling mock_check_if_assert_expected() will return 'false' as
+	 * a default return value
+	 */
+	if (mock_check_if_assert_expected() == true) {
+		printk("Assertion expected as part of a test case.\n");
+		/* Mark the test as passed and stop execution:
+		 * Needed in the passing scenario to prevent undefined behavior after hitting the
+		 * assert. In real builds (non-UT), the system will be halted by the assert.
+		 */
+		ztest_test_pass();
+	} else {
+		/* Mark the test as failed and stop execution */
+		ztest_test_fail();
+	}
+}

--- a/tests/lib/heap_min/src/assert.h
+++ b/tests/lib/heap_min/src/assert.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/fff.h>
+#include <zephyr/kernel.h>
+
+/* List of fakes used by this unit tester */
+#define ASSERT_FFF_FAKES_LIST(FAKE)           \
+		FAKE(mock_check_if_assert_expected)   \
+
+DECLARE_FAKE_VALUE_FUNC(bool, mock_check_if_assert_expected);
+
+#define expect_assert()     (mock_check_if_assert_expected_fake.return_val = 1)

--- a/tests/lib/heap_min/src/main.c
+++ b/tests/lib/heap_min/src/main.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Embeint Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/sys/sys_heap.h>
+#include <inttypes.h>
+
+#include "assert.h"
+
+DEFINE_FFF_GLOBALS;
+
+/* Align the test memory to the heap chunk size */
+uint8_t heapmem[8192] __aligned(8);
+
+ZTEST(lib_heap_min, test_heap_min_size_assert)
+{
+	struct sys_heap heap;
+
+	expect_assert();
+	sys_heap_init(&heap, (void *)heapmem, Z_HEAP_MIN_SIZE - 1);
+	zassert_unreachable();
+}
+
+ZTEST(lib_heap_min, test_heap_min_size)
+{
+	struct sys_heap heap;
+	void *mem;
+
+	sys_heap_init(&heap, (void *)heapmem, Z_HEAP_MIN_SIZE);
+	mem = sys_heap_alloc(&heap, 1);
+	zassert_not_null(mem, "Could not allocate 1 byte from a Z_HEAP_MIN_SIZE heap");
+	sys_heap_free(&heap, mem);
+}
+
+ZTEST_SUITE(lib_heap_min, NULL, NULL, NULL, NULL, NULL);

--- a/tests/lib/heap_min/testcase.yaml
+++ b/tests/lib/heap_min/testcase.yaml
@@ -1,0 +1,10 @@
+common:
+  tags: heap
+  integration_platforms:
+    - native_sim
+    - qemu_x86
+tests:
+  libraries.heap_min: {}
+  libraries.heap_min.runtime_stats:
+    extra_configs:
+      - CONFIG_SYS_HEAP_RUNTIME_STATS=y


### PR DESCRIPTION
Increase `Z_HEAP_MIN_SIZE` values to successfully allocate a 1 byte chunk when `CONFIG_SYS_HEAP_RUNTIME_STATS=y`.

Validate that `Z_HEAP_MIN_SIZE` is the minimum required size.

Fixes #98754