### PR TITLE
drivers: flash: Shell commands to automatically infer addr/size base

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -50,7 +50,7 @@ static int parse_helper(const struct shell *sh, size_t *argc,
 {
 	char *endptr;
 
-	*addr = strtoul((*argv)[1], &endptr, 16);
+	*addr = strtoul((*argv)[1], &endptr, 0);
 
 	if (*endptr != '\0') {
 		/* flash controller from user input */
@@ -79,7 +79,7 @@ static int parse_helper(const struct shell *sh, size_t *argc,
 		shell_error(sh, "Missing address.");
 		return -EINVAL;
 	}
-	*addr = strtoul((*argv)[2], &endptr, 16);
+	*addr = strtoul((*argv)[2], &endptr, 0);
 	(*argc)--;
 	(*argv)++;
 	return 0;
@@ -99,7 +99,7 @@ static int cmd_erase(const struct shell *sh, size_t argc, char *argv[])
 		return result;
 	}
 	if (argc > 2) {
-		size = strtoul(argv[2], NULL, 16);
+		size = strtoul(argv[2], NULL, 0);
 	} else {
 		struct flash_pages_info info;
 
@@ -266,8 +266,8 @@ static int cmd_test(const struct shell *sh, size_t argc, char *argv[])
 		return result;
 	}
 
-	size = strtoul(argv[2], NULL, 16);
-	repeat = strtoul(argv[3], NULL, 16);
+	size = strtoul(argv[2], NULL, 0);
+	repeat = strtoul(argv[3], NULL, 0);
 	if (size > CONFIG_FLASH_SHELL_BUFFER_SIZE) {
 		shell_error(sh, "<size> must be at most 0x%x.",
 			    CONFIG_FLASH_SHELL_BUFFER_SIZE);
@@ -772,7 +772,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(flash_cmds,
 		"[<device>] <page address> [<size>]",
 		cmd_erase, 2, 2),
 	SHELL_CMD_ARG(read, &dsub_device_name,
-		"[<device>] <address> [<Dword count>]",
+		"[<device>] <address> [<dword count>]",
 		cmd_read, 2, 2),
 	SHELL_CMD_ARG(test, &dsub_device_name,
 		"[<device>] <address> <size> <repeat count>",


### PR DESCRIPTION
Note that in the flash commands, you cannot tell some of these need to be in hex base. After this PR, only those commands which need Dwords are expected to be in hex, all of the rest of the addresses and sizes are inferred from the prefix.
```
syncboss:~$ flash
flash: wrong parameter count
flash - Flash shell commands
Subcommands:
  copy              : <src_device> <dst_device> <src_offset> <dst_offset> <size>
  erase             : [<device>] <page address> [<size>]
  erase_test        : [<device>] <address> <size> <repeat count>
  erase_write_test  : [<device>] <address> <size> <repeat count>
  load              : [<device>] <address> <size>
  page_info         : [<device>] <address>
  read              : [<device>] <address> [<Dword count>]
  read_test         : [<device>] <address> <size> <repeat count>
  sfdp_read         : [<device>] <address> <size>
  test              : [<device>] <address> <size> <repeat count>
  write             : [<device>] <address> <dword> [<dword>...]
  write_test        : [<device>] <address> <size> <repeat count>
```

This might break some existing test workflows for users, but I believe making this consistent is worth it:
https://github.com/zephyrproject-rtos/zephyr/blob/bf0e0b3cad2b317a055712fdb304443857108216/drivers/flash/flash_shell.c#L53
https://github.com/zephyrproject-rtos/zephyr/blob/bf0e0b3cad2b317a055712fdb304443857108216/drivers/flash/flash_shell.c#L198-L199
https://github.com/zephyrproject-rtos/zephyr/blob/bf0e0b3cad2b317a055712fdb304443857108216/drivers/flash/flash_shell.c#L269-L270
https://github.com/zephyrproject-rtos/zephyr/blob/bf0e0b3cad2b317a055712fdb304443857108216/drivers/flash/flash_shell.c#L340-L341


## Local Testing
Earlier:
```
uart:~$ flash erase ext_flash 0 1000
Erase success.

uart:~$ flash erase_test ext_flash 0 1000 1
Erase failed: -22

uart:~$ flash erase_write_test ext_flash 0 1000 1
Erase failed: -22
```

Now:
```
uart:~$ flash erase ext_flash 0 0x1000
Erase success.

uart:~$ flash erase_test ext_flash 0 0x1000 1
Loop #1 done in 39ms.
Total: 39ms, Per loop: ~39ms, Speed: ~102.6KiBps

uart:~$ flash erase_write_test ext_flash 0 0x1000 1
Loop #1 done in 55ms.
Total: 55ms, Per loop: ~55ms, Speed: ~72.7KiBps
```