### PR TITLE
boards: imx93_evk: Document imx-atf TRDC config for M33 DDR access

### DIFF
--- a/boards/nxp/imx93_evk/doc/index.rst
+++ b/boards/nxp/imx93_evk/doc/index.rst
@@ -338,6 +338,34 @@ to enable this, `imx-atf`_ can to be modified in "plat/imx/imx93/trdc_config.h".
 .. _imx-atf:
     https://github.com/nxp-imx/imx-atf
 
+imx-atf changes:
+
+.. code-block:: console
+
+    git diff plat/imx/imx93/trdc_config.h
+    diff --git a/plat/imx/imx93/trdc_config.h b/plat/imx/imx93/trdc_config.h
+    index 6c8b8f8fa..b155f9048 100644
+    --- a/plat/imx/imx93/trdc_config.h
+    +++ b/plat/imx/imx93/trdc_config.h
+    @@ -302,7 +302,7 @@ struct trdc_mbc_config trdc_n_mbc[] = {
+     };
+
+     struct trdc_glbac_config trdc_n_mrc_glbac[] = {
+    -       { 0, 0, SP(RW)  | SU(RW)  | NP(RW)  | NU(RW)  },
+    +       { 0, 0, SP(RWX)  | SU(RW)  | NP(RW)  | NU(RW)  },
+            { 0, 1, SP(RWX) | SU(RWX) | NP(RWX) | NU(RWX) },
+     };
+
+    @@ -356,7 +356,7 @@ struct trdc_mrc_config trdc_n_mrc[] = {
+     struct trdc_mrc_config trdc_n_mrc[] = {
+            { 0, 0, 0, 0x80000000, 0x80000000, 0, false }, /* MRC0 DRAM for S400 DID0 */
+            { 0, 1, 0, 0x80000000, 0x80000000, 0, false }, /* MRC0 DRAM for MTR DID1 */
+    -       { 0, 2, 0, 0x80000000, 0x80000000, 0, true }, /* MRC0 DRAM for M33 DID2 */
+    +       { 0, 2, 0, 0x80000000, 0x80000000, 1, true }, /* MRC0 DRAM for M33 DID2 */
+            { 0, 3, 0, 0x80000000, 0x80000000, 1, false }, /* MRC0 DRAM for A55 DID3 */
+            { 0, 5, 0, 0x80000000, 0x80000000, 0, false }, /* MRC0 DRAM for USDHC1 DID5 */
+            { 0, 6, 0, 0x80000000, 0x80000000, 0, false }, /* MRC0 DRAM for USDHC2 DID6 */
+
 Use this configuration to run basic Zephyr applications and kernel tests,
 for example, with the :zephyr:code-sample:`synchronization` sample:
 


### PR DESCRIPTION
Add documentation for required imx-atf TRDC configuration changes to enable M33 core DDR memory access on i.MX93 EVK board.