### PR TITLE
net: Replace Posix eventfd by zvfs_eventfd API

### DIFF
--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -20,7 +20,7 @@
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/tls_credentials.h>
-#include <zephyr/posix/sys/eventfd.h>
+#include <zephyr/zvfs/eventfd.h>
 #include <zephyr/posix/fnmatch.h>
 #include <zephyr/sys/util_macro.h>
 
@@ -98,7 +98,7 @@ int http_server_init(struct http_server_ctx *ctx)
 	}
 
 	/* Create an eventfd that can be used to trigger events during polling */
-	fd = eventfd(0, 0);
+	fd = zvfs_eventfd(0, 0);
 	if (fd < 0) {
 		fd = -errno;
 		LOG_ERR("eventfd failed (%d)", fd);
@@ -555,7 +555,7 @@ static int http_server_run(struct http_server_ctx *ctx)
 {
 	struct http_client_ctx *client;
 	const struct http_service_desc *service;
-	eventfd_t value;
+	zvfs_eventfd_t value;
 	bool found_slot;
 	int new_socket;
 	int ret, i, j;
@@ -578,7 +578,7 @@ static int http_server_run(struct http_server_ctx *ctx)
 		}
 
 		if (ret == 1 && ctx->fds[0].revents) {
-			eventfd_read(ctx->fds[0].fd, &value);
+			zvfs_eventfd_read(ctx->fds[0].fd, &value);
 			LOG_DBG("Received stop event. exiting ..");
 			ret = 0;
 			goto closing;
@@ -968,7 +968,7 @@ int http_server_stop(void)
 
 	server_running = false;
 	k_sem_reset(&server_start);
-	eventfd_write(server_ctx.fds[0].fd, 1);
+	zvfs_eventfd_write(server_ctx.fds[0].fd, 1);
 
 	LOG_DBG("Stopping HTTP server");
 

--- a/subsys/net/lib/ptp/clock.c
+++ b/subsys/net/lib/ptp/clock.c
@@ -11,7 +11,7 @@ LOG_MODULE_REGISTER(ptp_clock, CONFIG_PTP_LOG_LEVEL);
 #include <stdlib.h>
 #include <string.h>
 
-#include <zephyr/posix/sys/eventfd.h>
+#include <zephyr/zvfs/eventfd.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/ptp_clock.h>
@@ -286,7 +286,7 @@ const struct ptp_clock *ptp_clock_init(void)
 		return NULL;
 	}
 
-	ptp_clk.pollfd[0].fd = eventfd(0, EFD_NONBLOCK);
+	ptp_clk.pollfd[0].fd = zvfs_eventfd(0, ZVFS_EFD_NONBLOCK);
 	ptp_clk.pollfd[0].events = ZSOCK_POLLIN;
 
 	sys_slist_init(&ptp_clk.ports_list);
@@ -301,9 +301,9 @@ struct zsock_pollfd *ptp_clock_poll_sockets(void)
 	clock_check_pollfd();
 	ret = zsock_poll(ptp_clk.pollfd, PTP_SOCKET_CNT * ptp_clk.default_ds.n_ports + 1, -1);
 	if (ret > 0 && ptp_clk.pollfd[0].revents) {
-		eventfd_t value;
+		zvfs_eventfd_t value;
 
-		eventfd_read(ptp_clk.pollfd[0].fd, &value);
+		zvfs_eventfd_read(ptp_clk.pollfd[0].fd, &value);
 	}
 
 	return &ptp_clk.pollfd[1];
@@ -658,7 +658,7 @@ void ptp_clock_pollfd_invalidate(void)
 
 void ptp_clock_signal_timeout(void)
 {
-	eventfd_write(ptp_clk.pollfd[0].fd, 1);
+	zvfs_eventfd_write(ptp_clk.pollfd[0].fd, 1);
 }
 
 void ptp_clock_state_decision_req(void)

--- a/tests/net/dhcpv4/server/prj.conf
+++ b/tests/net/dhcpv4/server/prj.conf
@@ -14,7 +14,3 @@ CONFIG_NET_DHCPV4_SERVER=y
 # Reduce probe/decline timeout to speed up tests
 CONFIG_NET_DHCPV4_SERVER_ICMP_PROBE_TIMEOUT=10
 CONFIG_NET_DHCPV4_SERVER_ADDR_DECLINE_TIME=1
-
-# We need to set POSIX_API and use picolibc for eventfd to work
-CONFIG_POSIX_API=y
-CONFIG_PICOLIBC=y

--- a/tests/net/lib/http_server/core/src/main.c
+++ b/tests/net/lib/http_server/core/src/main.c
@@ -12,7 +12,6 @@
 
 #include <zephyr/net/http/service.h>
 #include <zephyr/net/socket.h>
-#include <zephyr/posix/sys/eventfd.h>
 #include <zephyr/ztest.h>
 
 #define BUFFER_SIZE                    1024

--- a/tests/net/socket/tls_configurations/src/main.c
+++ b/tests/net/socket/tls_configurations/src/main.c
@@ -10,8 +10,6 @@ LOG_MODULE_REGISTER(tls_configuration_sample, LOG_LEVEL_INF);
 #include <errno.h>
 #include <stdio.h>
 
-#include <zephyr/posix/sys/eventfd.h>
-
 #include <zephyr/net/socket.h>
 #include <zephyr/net/tls_credentials.h>
 #include <zephyr/net/net_if.h>


### PR DESCRIPTION
No need to use Posix eventfd API in core network code as zvfs_eventfd is compatible with it and we can now avoid using Posix headers unnecessarily.