### PR TITLE
sys: device_mmio: add devcie_map for !DEVICE_MMIO_IS_IN_RAM

### DIFF
--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -132,6 +132,15 @@ struct z_device_mmio_rom {
 		.addr = (mm_reg_t)DT_REG_ADDR_BY_NAME_U64(node_id, name) \
 	}
 
+__boot_func
+static inline void device_map(mm_reg_t *virt_addr, uintptr_t phys_addr,
+			      size_t size, uint32_t flags)
+{
+	ARG_UNUSED(size);
+	ARG_UNUSED(flags);
+	*virt_addr = phys_addr;
+}
+
 #endif /* DEVICE_MMIO_IS_IN_RAM */
 #endif /* !_ASMLANGUAGE */
 /** @} */


### PR DESCRIPTION
On !MMU && !PCIE && !EXTERNAL_ADDRESS_TRANSLATION platforms, the device_map() isn't defined, thus brings below ramconsole build error:

drivers/console/ram_console.c: In function 'ram_console_init':
drivers/console/ram_console.c:49:9: error: implicit declaration of function 'device_map'

Previously, I solved this issue in a workaround style[1] as below:

+/* workaround the fact that device_map() is not defined for SoCs with no MMU */ +#ifndef DEVICE_MMIO_IS_IN_RAM
+#define device_map(virt, phys, size, flags) *(virt) = (phys) +#endif /* DEVICE_MMIO_IS_IN_RAM */

But during the PR review progress, pathcing device_mmio.h is suggested. This patch implements that suggestion.

Link: https://github.com/zephyrproject-rtos/zephyr/pull/97894 [1]