### PR TITLE
driver: sensor: st: implemented fifo watermark triggers for ism330dhcx

### DIFF
--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.c
@@ -266,22 +266,20 @@ static int ism330dhcx_fifo_wtm_set(const struct device *dev, uint16_t val)
     struct ism330dhcx_data *data = dev->data;
 	stmdev_ctx_t *ctx = data->ctx;
 
-    // 1) Set the FIFO watermark level (writes to FIFO_CTRL1 and FIFO_CTRL2)
+    /* 1) Set the FIFO watermark level (writes to FIFO_CTRL1 and FIFO_CTRL2) */
     if (ism330dhcx_fifo_watermark_set(ctx, val) < 0) {
         LOG_ERR("Failed to set FIFO watermark to %u", val);
         return -EIO;
     }
 
-	// 2. Set the FIFO operating mode (writes to FIFO_CTRL4)
+	/* 2. Set the FIFO operating mode (writes to FIFO_CTRL4) */
     if (val > 0) {
-        // "Continuous mode" (6).
         if (ism330dhcx_fifo_mode_set(ctx, ISM330DHCX_STREAM_MODE) < 0) {
             LOG_ERR("Failed to set FIFO STREAM mode");
             return -EIO;
         }
         LOG_DBG("FIFO enabled in Continuous mode, WTM at %u", val);
     } else {
-        // "Bypass mode" (0).
         if (ism330dhcx_fifo_mode_set(ctx, ISM330DHCX_BYPASS_MODE) < 0) {
             LOG_ERR("Failed to set FIFO BYPASS mode");
             return -EIO;
@@ -298,13 +296,11 @@ static int ism330dhcx_attr_set(const struct device *dev,
 			       const struct sensor_value *val)
 {
 
-	// switch attr: check fifo attribute, then check channel
+	/* switch attr: check fifo attribute, then check channel specific attributes */
 	switch(attr) {
 		case SENSOR_ATTR_FIFO_WATERMARK:
-			// Set FIFO watermark level to val->val1 samples
 			return ism330dhcx_fifo_wtm_set(dev, (uint16_t)val->val1);
 		case SENSOR_ATTR_FIFO_XL_BATCH:
-			// Enable accelerometer batching at val->val1 Hz
 			struct ism330dhcx_data *data = dev->data;
 			stmdev_ctx_t *ctx = data->ctx;
 			return ism330dhcx_fifo_xl_batch_set(ctx, val->val1);

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.c
@@ -260,19 +260,16 @@ static int ism330dhcx_gyro_config(const struct device *dev,
 	return 0;
 }
 
-/* Set FIFO watermark and operating mode */
 static int ism330dhcx_fifo_wtm_set(const struct device *dev, uint16_t val)
 {
     struct ism330dhcx_data *data = dev->data;
 	stmdev_ctx_t *ctx = data->ctx;
 
-    /* 1) Set the FIFO watermark level (writes to FIFO_CTRL1 and FIFO_CTRL2) */
     if (ism330dhcx_fifo_watermark_set(ctx, val) < 0) {
-        LOG_ERR("Failed to set FIFO watermark to %u", val);
+    	LOG_ERR("Failed to set FIFO watermark to %u", val);
         return -EIO;
     }
 
-	/* 2. Set the FIFO operating mode (writes to FIFO_CTRL4) */
     if (val > 0) {
         if (ism330dhcx_fifo_mode_set(ctx, ISM330DHCX_STREAM_MODE) < 0) {
             LOG_ERR("Failed to set FIFO STREAM mode");
@@ -282,7 +279,7 @@ static int ism330dhcx_fifo_wtm_set(const struct device *dev, uint16_t val)
     } else {
         if (ism330dhcx_fifo_mode_set(ctx, ISM330DHCX_BYPASS_MODE) < 0) {
             LOG_ERR("Failed to set FIFO BYPASS mode");
-            return -EIO;
+        	return -EIO;
         }
         LOG_DBG("FIFO disabled (Bypass mode)");
     }

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.h
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.h
@@ -98,6 +98,8 @@ struct ism330dhcx_data {
 	const struct sensor_trigger *trig_drdy_gyr;
 	sensor_trigger_handler_t handler_drdy_temp;
 	const struct sensor_trigger *trig_drdy_temp;
+	sensor_trigger_handler_with_data_t handler_fifo_wtm;
+	const struct sensor_trigger *trig_fifo_wtm;
 
 #if defined(CONFIG_ISM330DHCX_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_ISM330DHCX_THREAD_STACK_SIZE);
@@ -124,6 +126,9 @@ int ism330dhcx_shub_config(const struct device *dev, enum sensor_channel chan,
 int ism330dhcx_trigger_set(const struct device *dev,
 			   const struct sensor_trigger *trig,
 			   sensor_trigger_handler_t handler);
+int ism330dhcx_trigger_set_with_data(const struct device *dev,
+			   const struct sensor_trigger *trig,
+			   sensor_trigger_handler_with_data_t handler);
 
 int ism330dhcx_init_interrupt(const struct device *dev);
 #endif

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx_trigger.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx_trigger.c
@@ -121,6 +121,58 @@ static int ism330dhcx_enable_g_int(const struct device *dev, int enable)
 }
 
 /**
+ * ism330dhcx_enable_fifo_wtm_int - FIFO WTM enable selected int pin to generate interrupt
+ */
+static int ism330dhcx_enable_fifo_wtm_int(const struct device *dev, int enable)
+{
+    const struct ism330dhcx_config *cfg = dev->config;
+    struct ism330dhcx_data *data = dev->data;
+    stmdev_ctx_t *ctx = data->ctx;
+    int ret;
+
+    if (cfg->int_pin == 1) {
+        ism330dhcx_pin_int1_route_t int1_route;
+
+        ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT1_CTRL,
+                                  (uint8_t *)&int1_route.int1_ctrl, 1);
+        if (ret < 0) {
+            LOG_ERR("Failed to read INT1_CTRL");
+            return -EIO;
+        }
+
+        int1_route.int1_ctrl.int1_fifo_th = enable ? 1 : 0;
+
+        ret = ism330dhcx_write_reg(ctx, ISM330DHCX_INT1_CTRL,
+                                   (uint8_t *)&int1_route.int1_ctrl, 1);
+        if (ret < 0) {
+            LOG_ERR("Failed to write INT1_CTRL");
+            return -EIO;
+        }
+    } else {
+        ism330dhcx_pin_int2_route_t int2_route;
+
+        ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT2_CTRL,
+                                  (uint8_t *)&int2_route.int2_ctrl, 1);
+        if (ret < 0) {
+            LOG_ERR("Failed to read INT2_CTRL");
+            return -EIO;
+        }
+
+        int2_route.int2_ctrl.int2_fifo_th = enable ? 1 : 0;
+
+        ret = ism330dhcx_write_reg(ctx, ISM330DHCX_INT2_CTRL,
+                                   (uint8_t *)&int2_route.int2_ctrl, 1);
+        if (ret < 0) {
+            LOG_ERR("Failed to write INT2_CTRL");
+            return -EIO;
+        }
+    }
+
+    LOG_DBG("FIFO WTM interrupt %s", enable ? "enabled" : "disabled");
+    return 0;
+}
+
+/**
  * ism330dhcx_trigger_set - link external trigger to event data ready
  */
 int ism330dhcx_trigger_set(const struct device *dev,
@@ -166,8 +218,29 @@ int ism330dhcx_trigger_set(const struct device *dev,
 	return -ENOTSUP;
 }
 
+int ism330dhcx_trigger_set_with_data(const struct device *dev,
+			   const struct sensor_trigger *trig,
+			   sensor_trigger_handler_with_data_t handler) 
+{
+	struct ism330dhcx_data *ism330dhcx = dev->data;
+	const struct ism330dhcx_config *cfg = dev->config;
+
+	if (!cfg->drdy_gpio.port) {
+		return -ENOTSUP;
+	}
+
+	// Handle the FIFO Watermark trigger type
+	if (trig->type == SENSOR_TRIG_FIFO_WATERMARK) {
+		ism330dhcx->handler_fifo_wtm = handler;
+		ism330dhcx->trig_fifo_wtm = trig;
+		return ism330dhcx_enable_fifo_wtm_int(dev, handler != NULL);
+	}
+
+	return -ENOTSUP;
+}
+
 /**
- * ism330dhcx_handle_interrupt - handle the drdy event
+ * ism330dhcx_handle_interrupt - handle the fifo/drdy event
  * read data and call handler if registered any
  */
 static void ism330dhcx_handle_interrupt(const struct device *dev)
@@ -175,35 +248,81 @@ static void ism330dhcx_handle_interrupt(const struct device *dev)
 	struct ism330dhcx_data *ism330dhcx = dev->data;
 	const struct ism330dhcx_config *cfg = dev->config;
 	ism330dhcx_status_reg_t status;
+	ism330dhcx_fifo_status2_t fifo_status;
 
-	while (1) {
-		if (ism330dhcx_status_reg_get(ism330dhcx->ctx, &status) < 0) {
-			LOG_DBG("failed reading status reg");
-			return;
-		}
+	if (ism330dhcx_fifo_status_get(ism330dhcx->ctx, &fifo_status) < 0) {
+        LOG_DBG("failed reading fifo status reg");
+    }
 
-		if ((status.xlda == 0) && (status.gda == 0)
-#if defined(CONFIG_ISM330DHCX_ENABLE_TEMP)
-					&& (status.tda == 0)
-#endif
-					) {
-			break;
-		}
+	/* Check if the FIFO Watermark Interrupt Active bit is set */
+	if ((fifo_status.fifo_wtm_ia) && (ism330dhcx->handler_fifo_wtm != NULL)) {
 
-		if ((status.xlda) && (ism330dhcx->handler_drdy_acc != NULL)) {
-			ism330dhcx->handler_drdy_acc(dev, ism330dhcx->trig_drdy_acc);
-		}
+		ism330dhcx_fifo_tag_t tag;
+    	uint8_t raw_data[6];
+		int16_t buffer[1024];
+		uint16_t num_samples_in_fifo = 0;
+		
+		if (ism330dhcx_fifo_data_level_get(ism330dhcx->ctx, &num_samples_in_fifo) < 0) {
+            LOG_WRN("Failed to get FIFO data level");
+            num_samples_in_fifo = 0;
+        }
+		
+        for (int i = 0; i < num_samples_in_fifo; i++) {
+            // Read the 1-byte TAG
+            if (ism330dhcx_fifo_sensor_tag_get(ism330dhcx->ctx, &tag) < 0) {
+                LOG_WRN("Failed to get FIFO tag on sample %d", i);
+                break;
+            }
+            // Read the 6-byte DATA
+            if (ism330dhcx_fifo_out_raw_get(ism330dhcx->ctx, raw_data) < 0) {
+                LOG_WRN("Failed to get FIFO data on sample %d", i);
+                break; 
+            }
+			int16_t x_raw, y_raw, z_raw;
 
-		if ((status.gda) && (ism330dhcx->handler_drdy_gyr != NULL)) {
-			ism330dhcx->handler_drdy_gyr(dev, ism330dhcx->trig_drdy_gyr);
-		}
+			// Convert raw_data to x, y, z int16_t values
+			x_raw = (int16_t)(raw_data[1] << 8 | raw_data[0]);
+			y_raw = (int16_t)(raw_data[3] << 8 | raw_data[2]);
+			z_raw = (int16_t)(raw_data[5] << 8 | raw_data[4]);
 
-#if defined(CONFIG_ISM330DHCX_ENABLE_TEMP)
-		if ((status.tda) && (ism330dhcx->handler_drdy_temp != NULL)) {
-			ism330dhcx->handler_drdy_temp(dev, ism330dhcx->trig_drdy_temp);
+			// Store the raw values into buffer
+			buffer[i*3 + 0] = x_raw;
+			buffer[i*3 + 1] = y_raw;
+			buffer[i*3 + 2] = z_raw;
+        }
+        
+		ism330dhcx->handler_fifo_wtm(dev, ism330dhcx->trig_fifo_wtm, buffer, num_samples_in_fifo * 3);
+
+    } else {
+		while (1) {
+			if (ism330dhcx_status_reg_get(ism330dhcx->ctx, &status) < 0) {
+				LOG_DBG("failed reading status reg");
+				return;
+			}
+
+			if ((status.xlda == 0) && (status.gda == 0)
+	#if defined(CONFIG_ISM330DHCX_ENABLE_TEMP)
+						&& (status.tda == 0)
+	#endif
+						) {
+				break;
+			}
+
+			if ((status.xlda) && (ism330dhcx->handler_drdy_acc != NULL)) {
+				ism330dhcx->handler_drdy_acc(dev, ism330dhcx->trig_drdy_acc);
+			}
+
+			if ((status.gda) && (ism330dhcx->handler_drdy_gyr != NULL)) {
+				ism330dhcx->handler_drdy_gyr(dev, ism330dhcx->trig_drdy_gyr);
+			}
+
+	#if defined(CONFIG_ISM330DHCX_ENABLE_TEMP)
+			if ((status.tda) && (ism330dhcx->handler_drdy_temp != NULL)) {
+				ism330dhcx->handler_drdy_temp(dev, ism330dhcx->trig_drdy_temp);
+			}
+	#endif
 		}
-#endif
-	}
+}
 
 	gpio_pin_interrupt_configure_dt(&cfg->drdy_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 }

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx_trigger.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx_trigger.c
@@ -286,7 +286,6 @@ static void ism330dhcx_handle_fifo_interrupt(struct ism330dhcx_data *ism330dhcx,
 			buffer[i*3 + 1] = y_raw;
 			buffer[i*3 + 2] = z_raw;
 		}
-		
 		ism330dhcx->handler_fifo_wtm(dev, ism330dhcx->trig_fifo_wtm, buffer, num_samples_in_fifo*3);
 	}
 }

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -890,7 +890,7 @@ static inline int sensor_trigger_set(const struct device *dev,
  */
 static inline int sensor_trigger_set_with_data(const struct device *dev,
 				     const struct sensor_trigger *trig,
-				     sensor_trigger_handler_with_data_t handler) // DEN
+				     sensor_trigger_handler_with_data_t handler)
 {
 	const struct sensor_driver_api *api =
 		(const struct sensor_driver_api *)dev->api;

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -386,6 +386,12 @@ enum sensor_attribute {
 	 * Maximum value describing a sensor attribute type.
 	 */
 	SENSOR_ATTR_MAX = INT16_MAX,
+
+	/** FIFO watermark level */
+	SENSOR_ATTR_FIFO_WATERMARK,
+
+	/** FIFO operating mode*/
+	SENSOR_ATTR_FIFO_XL_BATCH,
 };
 
 /**
@@ -397,6 +403,21 @@ enum sensor_attribute {
  */
 typedef void (*sensor_trigger_handler_t)(const struct device *dev,
 					 const struct sensor_trigger *trigger);
+
+/**
+ * @typedef sensor_trigger_handler_with_data_t
+ * @brief Callback API upon firing of a trigger with raw data
+ *
+ * @param dev Pointer to the sensor device
+ * @param trigger The trigger
+ * @param raw_data Pointer to raw data associated with the trigger
+ * @param len Length of the raw data buffer
+ */
+typedef void (*sensor_trigger_handler_with_data_t)(const struct device *dev,
+					 const struct sensor_trigger *trigger,
+					 int16_t *raw_data, uint32_t len);
+
+
 
 /**
  * @typedef sensor_attr_set_t
@@ -429,6 +450,18 @@ typedef int (*sensor_attr_get_t)(const struct device *dev,
 typedef int (*sensor_trigger_set_t)(const struct device *dev,
 				    const struct sensor_trigger *trig,
 				    sensor_trigger_handler_t handler);
+
+/**
+ * @typedef sensor_trigger_set_with_data_t
+ * @brief Callback API for setting a sensor's trigger and handler with data
+ *
+ * See sensor_trigger_set_with_data() for argument description
+ */
+typedef int (*sensor_trigger_set_with_data_t)(const struct device *dev,
+				    const struct sensor_trigger *trig,
+				    sensor_trigger_handler_with_data_t handler); 
+
+
 /**
  * @typedef sensor_sample_fetch_t
  * @brief Callback API for fetching data from a sensor
@@ -730,6 +763,7 @@ __subsystem struct sensor_driver_api {
 	sensor_channel_get_t channel_get;
 	sensor_get_decoder_t get_decoder;
 	sensor_submit_t submit;
+	sensor_trigger_set_with_data_t trigger_set_with_data;
 };
 
 /**
@@ -830,6 +864,42 @@ static inline int sensor_trigger_set(const struct device *dev,
 	}
 
 	return api->trigger_set(dev, trig, handler);
+}
+
+/**
+ * @brief Activate a sensor's trigger and set the trigger handler with data
+ *
+ * The handler will be called from a thread, so I2C or SPI operations are
+ * safe.  However, the thread's stack is limited and defined by the
+ * driver.  It is currently up to the caller to ensure that the handler
+ * does not overflow the stack.
+ *
+ * The user-allocated trigger will be stored by the driver as a pointer, rather
+ * than a copy, and passed back to the handler. This enables the handler to use
+ * CONTAINER_OF to retrieve a context pointer when the trigger is embedded in a
+ * larger struct and requires that the trigger is not allocated on the stack.
+ *
+ * @funcprops \supervisor
+ *
+ * @param dev Pointer to the sensor device
+ * @param trig The trigger to activate
+ * @param handler The function that should be called when the trigger
+ * fires, with associated raw data
+ *
+ * @return 0 if successful, negative errno code if failure.
+ */
+static inline int sensor_trigger_set_with_data(const struct device *dev,
+				     const struct sensor_trigger *trig,
+				     sensor_trigger_handler_with_data_t handler) // DEN
+{
+	const struct sensor_driver_api *api =
+		(const struct sensor_driver_api *)dev->api;
+
+	if (api->trigger_set_with_data == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->trigger_set_with_data(dev, trig, handler);
 }
 
 /**


### PR DESCRIPTION
implemented a new handler ```sensor_trigger_handler_with_data_t``` in order to have as ```@param``` a buffer of data that can be used by the [ocre-runtime](https://github.com/project-ocre/ocre-runtime) handler. The idea is that the runtime can then push the buffer to a queue of events that will be read by the container: in this way the runtime doesn't have to call the low-level driver functions (such as  ```ism330dhcx_fifo_sensor_tag_get```, ```ism330dhcx_fifo_out_raw_get```) to empty the fifo
<img width="1193" height="405" alt="Screenshot 2025-11-03 at 11 25 58" src="https://github.com/user-attachments/assets/a76d1f63-3c9b-458c-9a3c-89eb5eeb0ce9" />