### PR TITLE
hostap: avoid configuring region domain when SAP is enabled

### DIFF
--- a/modules/hostap/src/hapd_api.c
+++ b/modules/hostap/src/hapd_api.c
@@ -365,18 +365,28 @@ out:
 }
 #endif
 
-bool hostapd_ap_reg_domain(const struct device *dev,
+int hostapd_ap_reg_domain(const struct device *dev,
 	struct wifi_reg_domain *reg_domain)
 {
 	struct hostapd_iface *iface;
+	int ret = 0;
 
 	iface = get_hostapd_handle(dev);
 	if (iface == NULL) {
 		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
-		return false;
+		ret = -ENODEV;
 	}
 
-	return hostapd_cli_cmd_v("set country_code %s", reg_domain->country_code);
+	if (iface->state == HAPD_IFACE_ENABLED) {
+		wpa_printf(MSG_ERROR, "Interface %s is operational and in SAP mode", dev->name);
+		ret = -EACCES;
+	}
+
+	if (!hostapd_cli_cmd_v("set country_code %s", reg_domain->country_code)) {
+		ret = -ENOTSUP;
+	}
+
+	return ret;
 }
 
 static int hapd_config_chan_center_seg0(struct hostapd_iface *iface,

--- a/modules/hostap/src/hapd_api.h
+++ b/modules/hostap/src/hapd_api.h
@@ -26,9 +26,9 @@ int hostapd_ap_config_params(const struct device *dev, struct wifi_ap_config_par
  *
  * @param reg_domain region domain parameters
  * @param dev Wi-Fi device
- * @return true for OK; false for ERROR
+ * @return 0 if OK; < 0 if error
  */
-bool hostapd_ap_reg_domain(const struct device *dev,
+int hostapd_ap_reg_domain(const struct device *dev,
 	struct wifi_reg_domain *reg_domain);
 
 #ifdef CONFIG_WIFI_NM_HOSTAPD_WPS

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1729,6 +1729,15 @@ int supplicant_reg_domain(const struct device *dev,
 	if (reg_domain->oper == WIFI_MGMT_SET) {
 		k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
+		if (IS_ENABLED(CONFIG_WIFI_NM_HOSTAPD_AP)) {
+			const struct device *dev2 = net_if_get_device(net_if_get_wifi_sap());
+
+			ret = hostapd_ap_reg_domain(dev2, reg_domain);
+			if (ret) {
+				goto out;
+			}
+		}
+
 		wpa_s = get_wpa_s_handle(dev);
 		if (!wpa_s) {
 			wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
@@ -1737,14 +1746,6 @@ int supplicant_reg_domain(const struct device *dev,
 
 		if (!wpa_cli_cmd_v("set country %s", reg_domain->country_code)) {
 			goto out;
-		}
-
-		if (IS_ENABLED(CONFIG_WIFI_NM_HOSTAPD_AP)) {
-			const struct device *dev2 = net_if_get_device(net_if_get_wifi_sap());
-
-			if (!hostapd_ap_reg_domain(dev2, reg_domain)) {
-				goto out;
-			}
 		}
 
 		ret = 0;


### PR DESCRIPTION
Configuring the region domain while SAP is enabled may lead to instability in SAP's state and functionality. This change ensures the region domain is not set when SAP is active.

Fixes #98967