### PR TITLE
Update zc143ac72mipi co5300 driver and display driver example

### DIFF
--- a/boards/shields/zc143ac72mipi/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
+++ b/boards/shields/zc143ac72mipi/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
@@ -25,3 +25,9 @@
 &gpio3 {
 	status = "okay";
 };
+
+&co5300_zc143ac72mipi {
+	ext-ram = <&sram1>;
+	addr-align = <64>;
+	pitch-align = <64>;
+};

--- a/boards/shields/zc143ac72mipi/zc143ac72mipi.overlay
+++ b/boards/shields/zc143ac72mipi/zc143ac72mipi.overlay
@@ -8,6 +8,13 @@
 	chosen {
 		zephyr,display = &co5300_zc143ac72mipi;
 	};
+
+	en_mipi_display_zc143ac72mipi: enable-mipi-display {
+		compatible = "regulator-fixed";
+		regulator-name = "en_mipi_display";
+		enable-gpios = <&nxp_mipi_connector 32 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
+	};
 };
 
 &zephyr_mipi_dsi {
@@ -20,9 +27,8 @@
 		compatible = "chipone,co5300";
 		reg = <0x0>;
 		reset-gpios = <&nxp_mipi_connector 21 GPIO_ACTIVE_HIGH>;
-		backlight-gpios = <&nxp_mipi_connector 34 GPIO_ACTIVE_HIGH>;
+		backlight-gpios = <&nxp_mipi_connector 0 GPIO_ACTIVE_HIGH>;
 		tear-effect-gpios = <&nxp_mipi_connector 22 GPIO_ACTIVE_HIGH>;
-		power-gpios = <&nxp_mipi_connector 32 GPIO_ACTIVE_HIGH>;
 		data-lanes = <1>;
 		width = <466>;
 		height = <466>;

--- a/dts/bindings/display/chipone,co5300.yaml
+++ b/dts/bindings/display/chipone,co5300.yaml
@@ -29,8 +29,24 @@ properties:
       VSYNC interval. This permits the controller to send new display
       data during a VSYNC interval, removing tearing.
 
-  power-gpios:
-    type: phandle-array
+  pitch-align:
+    type: int
+    default: 1
     description: |
-      The RESETn pin is asserted to disable the controller causing a hard
-      reset. The controller receives this as an active-low signal.
+      The CO5300 driver maintains an internal frame buffer. This property
+      serves for defining a pitch for it that's compliant with the SoC's
+      display controller's requirements.
+
+  addr-align:
+    type: int
+    default: 1
+    description: |
+      The CO5300 driver maintains an internal frame buffer. This property
+      serves for defining an alignment for its address that's compliant
+      with the SoC's display controller's requirements.
+
+  ext-ram:
+    type: phandle
+    description: |
+      Secondary RAM in which the panel controller's frame buffer will
+      be stored. If not defined, the 'zephyr,ram' chosen memory will be used.

--- a/samples/drivers/display/Kconfig
+++ b/samples/drivers/display/Kconfig
@@ -1,0 +1,16 @@
+# Private config options for display sample
+
+# Copyright (c) 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Display sample application"
+
+source "Kconfig.zephyr"
+
+config SAMPLE_BUFFER_ADDR_ALIGN
+	int "The display buffer address alignment"
+	default 1
+
+config SAMPLE_PITCH_ALIGN
+	int "The update area pitch alignment"
+	default 1

--- a/samples/drivers/display/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.conf
+++ b/samples/drivers/display/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.conf
@@ -1,0 +1,8 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SAMPLE_BUFFER_ADDR_ALIGN=64
+CONFIG_SAMPLE_PITCH_ALIGN=64

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -271,6 +271,8 @@ int main(void)
 		rect_w = capabilities.x_resolution;
 	}
 
+	rect_w = ROUND_UP(rect_w, CONFIG_SAMPLE_PITCH_ALIGN);
+
 	buf_size = rect_w * rect_h;
 
 	if (buf_size < (capabilities.x_resolution * h_step)) {
@@ -328,7 +330,7 @@ int main(void)
 #endif
 	}
 
-	buf = k_malloc(buf_size);
+	buf = k_aligned_alloc(CONFIG_SAMPLE_BUFFER_ADDR_ALIGN, buf_size);
 
 	if (buf == NULL) {
 		LOG_ERR("Could not allocate memory. Aborting sample.");
@@ -342,7 +344,7 @@ int main(void)
 	(void)memset(buf, bg_color, buf_size);
 
 	buf_desc.buf_size = buf_size;
-	buf_desc.pitch = capabilities.x_resolution;
+	buf_desc.pitch = ROUND_UP(capabilities.x_resolution, CONFIG_SAMPLE_PITCH_ALIGN);
 	buf_desc.width = capabilities.x_resolution;
 	buf_desc.height = h_step;
 
@@ -374,7 +376,7 @@ int main(void)
 		}
 	}
 
-	buf_desc.pitch = rect_w;
+	buf_desc.pitch = ROUND_UP(rect_w, CONFIG_SAMPLE_PITCH_ALIGN);
 	buf_desc.width = rect_w;
 	buf_desc.height = rect_h;
 

--- a/samples/modules/lvgl/demos/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.conf
+++ b/samples/modules/lvgl/demos/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.conf
@@ -1,0 +1,10 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_LV_Z_MEM_POOL_SIZE=81920
+# RT700 uses DC8000 to drive all panels which requires a 64 byte align of buffer address and stride.
+CONFIG_LV_DRAW_BUF_STRIDE_ALIGN=64
+CONFIG_LV_DRAW_BUF_ALIGN=64


### PR DESCRIPTION
1. Add user configuration of buffer address alignment and update area pitch's alignment for display driver sample.
2. Add board specific configuration for mimxrt700_evk lvgl examples. The mimxrt700_evk uses DC8000 to drive all panels which requires a 64-byte align of buffer address and stride.
3. Update CO5300 panel driver
3.1 Fix wrong backlight pin in driver overlay
3.2 Remove the power-on pin configuration in code and binding, and add mipi display panel regulator in panel overlay instead. Set 'regulator-boot-on' to true means the power-on pin will be enabled during system boot.
3.3 Remove 'last_known_framebuffer' from panel data structure. It is not used anywhere
3.4 Fix bug in 'co5300_set_pixel_format' function.
3.5 Fix the issue that the panel does not support start coordinates and the width/height of the updated area being odd value.
       Solution: In panel driver, maintain a full screen-sized buffer, its address and pitch alignment is configurable in device tree and shall be compliant with the display controller's requirements. It can be placed in RAM or if the RAM space is not enough it can also be placed in other memory resion. When there is a frame update request, the updated area will be first filled to the buffer, if the area's size or coordinate is odd, adjust the value so the real updated area covers the requested updated area, then use this buffer to send pixel to panel, this can ensure the updated area's size and coordinate are always even.
