### PR TITLE
drivers: memc: stm32 xspi psram aps6404

### DIFF
--- a/drivers/memc/CMakeLists.txt
+++ b/drivers/memc/CMakeLists.txt
@@ -36,3 +36,4 @@ zephyr_library_sources_ifdef(CONFIG_MEMC_STM32_SDRAM             memc_stm32_sdra
 
 zephyr_library_sources_ifdef(CONFIG_MEMC_STM32_XSPI_PSRAM        memc_stm32_xspi_psram.c)
 zephyr_library_sources_ifdef(CONFIG_MEMC_STM32_OSPI_PSRAM        memc_stm32_ospi_psram.c)
+zephyr_library_sources_ifdef(CONFIG_MEMC_STM32_XSPI_PSRAM_APS6404        memc_stm32_xspi_psram_aps6404.c)

--- a/drivers/memc/Kconfig.stm32
+++ b/drivers/memc/Kconfig.stm32
@@ -42,6 +42,15 @@ config MEMC_STM32_XSPI_PSRAM
 	help
 	  Enable STM32 XSPI Memory Controller.
 
+config MEMC_STM32_XSPI_PSRAM_APS6404
+	bool "STM32 XSPI PSRAM APS6404"
+	default y
+	depends on DT_HAS_ST_STM32_XSPI_PSRAM_APS6404_ENABLED
+	select USE_STM32_HAL_XSPI
+	select PINCTRL
+	help
+	  Enable STM32 XSPI Memory Controller.
+
 config MEMC_STM32_OSPI_PSRAM
 	bool "STM32 OSPI PSRAM"
 	default y

--- a/drivers/memc/memc_stm32_xspi_psram_aps6404.c
+++ b/drivers/memc/memc_stm32_xspi_psram_aps6404.c
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2025 Mario Paja
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdint.h>
+#define DT_DRV_COMPAT st_stm32_xspi_psram_aps6404
+
+#include <errno.h>
+#include <soc.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/multi_heap/shared_multi_heap.h>
+
+LOG_MODULE_REGISTER(memc_stm32_xspi_psram_aps6404, CONFIG_MEMC_LOG_LEVEL);
+
+#define STM32_XSPI_NODE DT_INST_PARENT(0)
+
+#ifdef CONFIG_SHARED_MULTI_HEAP
+struct shared_multi_heap_region smh_psram = {
+	.addr = DT_REG_ADDR(DT_NODELABEL(psram)),
+	.size = DT_REG_SIZE(DT_NODELABEL(psram)),
+	.attr = SMH_REG_ATTR_EXTERNAL,
+};
+#endif
+
+#define STM32_XSPI_CLOCK_PRESCALER_MIN                0U
+#define STM32_XSPI_CLOCK_PRESCALER_MAX                255U
+#define STM32_XSPI_CLOCK_COMPUTE(bus_freq, prescaler) ((bus_freq) / ((prescaler) + 1U))
+
+struct memc_stm32_xspi_psram_config {
+	const struct pinctrl_dev_config *pcfg;
+	const struct stm32_pclken pclken;
+	const struct stm32_pclken pclken_ker;
+	const struct stm32_pclken pclken_mgr;
+	size_t memory_size;
+	bool qspi_enable;
+	uint32_t max_frequency;
+};
+
+struct memc_stm32_xspi_psram_data {
+	XSPI_HandleTypeDef hxspi;
+};
+
+static int ap_memory_reset(XSPI_HandleTypeDef *hxspi)
+{
+	XSPI_RegularCmdTypeDef cmd = {0};
+
+	cmd.Instruction = 0x66;
+	cmd.InstructionMode = HAL_XSPI_INSTRUCTION_1_LINE;
+	cmd.InstructionWidth = HAL_XSPI_INSTRUCTION_8_BITS;
+
+	/* Configure the command */
+	if (HAL_XSPI_Command(hxspi, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+		LOG_ERR("XSPI write command failed");
+		return -EIO;
+	}
+	k_busy_wait(100);
+
+	cmd.Instruction = 0x99;
+
+	/* Configure the command */
+	if (HAL_XSPI_Command(hxspi, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+		LOG_ERR("XSPI write command failed");
+		return -EIO;
+	}
+	k_busy_wait(100);
+
+	return 0;
+}
+
+static int ap_memory_read_id(XSPI_HandleTypeDef *hxspi, uint8_t *pID)
+{
+	XSPI_RegularCmdTypeDef cmd = {0};
+
+	cmd.Instruction = 0x9F;
+	cmd.InstructionMode = HAL_XSPI_INSTRUCTION_1_LINE;
+	cmd.AddressMode = HAL_XSPI_ADDRESS_1_LINE;
+	cmd.AddressWidth = HAL_XSPI_ADDRESS_24_BITS;
+	cmd.DataMode = HAL_XSPI_DATA_1_LINE;
+	cmd.DataLength = 2U;
+
+	/* Configure the command */
+	if (HAL_XSPI_Command(hxspi, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+		LOG_ERR("XSPI write command failed");
+		return -EIO;
+	}
+	k_busy_wait(100);
+
+	return HAL_XSPI_Receive(hxspi, pID, HAL_TIMEOUT);
+}
+
+static int memc_stm32_xspi_psram_init(const struct device *dev)
+{
+	const struct memc_stm32_xspi_psram_config *dev_cfg = dev->config;
+	struct memc_stm32_xspi_psram_data *dev_data = dev->data;
+	XSPI_HandleTypeDef hxspi = dev_data->hxspi;
+	uint32_t ahb_clock_freq;
+	XSPIM_CfgTypeDef cfg = {0};
+	XSPI_RegularCmdTypeDef cmd = {0};
+	XSPI_MemoryMappedTypeDef mem_mapped_cfg = {0};
+	uint32_t prescaler = STM32_XSPI_CLOCK_PRESCALER_MIN;
+	uint8_t id[2];
+	int ret;
+
+	/* Signals configuration */
+	ret = pinctrl_apply_state(dev_cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		LOG_ERR("XSPI pinctrl setup failed (%d)", ret);
+		return ret;
+	}
+
+	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
+	/* Clock configuration */
+	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+			     (clock_control_subsys_t)&dev_cfg->pclken) != 0) {
+		LOG_ERR("Could not enable XSPI clock");
+		return -EIO;
+	}
+	if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+				   (clock_control_subsys_t)&dev_cfg->pclken, &ahb_clock_freq) < 0) {
+		LOG_ERR("Failed call clock_control_get_rate(pclken)");
+		return -EIO;
+	}
+
+#if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_ker)
+	/* Kernel clock config for peripheral if any */
+	if (clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+				    (clock_control_subsys_t)&dev_cfg->pclken_ker, NULL) != 0) {
+		LOG_ERR("Could not select XSPI domain clock");
+		return -EIO;
+	}
+
+	if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+				   (clock_control_subsys_t)&dev_cfg->pclken_ker,
+				   &ahb_clock_freq) < 0) {
+		LOG_ERR("Failed call clock_control_get_rate(pclken_ker)");
+		return -EIO;
+	}
+#endif
+
+#if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_mgr)
+	/* Clock domain corresponding to the IO-Mgr (XSPIM) */
+	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+			     (clock_control_subsys_t)&dev_cfg->pclken_mgr) != 0) {
+		LOG_ERR("Could not enable XSPI Manager clock");
+		return -EIO;
+	}
+#endif
+
+	for (; prescaler <= STM32_XSPI_CLOCK_PRESCALER_MAX; prescaler++) {
+		uint32_t clk = STM32_XSPI_CLOCK_COMPUTE(ahb_clock_freq, prescaler);
+
+		if (clk <= dev_cfg->max_frequency) {
+			break;
+		}
+	}
+
+	if (prescaler > STM32_XSPI_CLOCK_PRESCALER_MAX) {
+		LOG_ERR("XSPI could not find valid prescaler value");
+		return -EINVAL;
+	}
+
+	hxspi.Init.ClockPrescaler = prescaler;
+	LOG_DBG("ClockPrescaler: %d", hxspi.Init.ClockPrescaler);
+	hxspi.Init.MemorySize = find_msb_set(dev_cfg->memory_size) - 2;
+
+	if (HAL_XSPI_Init(&hxspi) != HAL_OK) {
+		LOG_ERR("XSPI Init failed");
+		return -EIO;
+	}
+	k_busy_wait(100);
+
+	cfg.nCSOverride = HAL_XSPI_CSSEL_OVR_NCS1;
+	cfg.IOPort = HAL_XSPIM_IOPORT_1;
+
+	if (HAL_XSPIM_Config(&hxspi, &cfg, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+		LOG_ERR("XSPIMgr Init failed");
+		return -EIO;
+	}
+	k_busy_wait(100);
+
+	/* Memory Reset */
+	ap_memory_reset(&hxspi);
+	k_busy_wait(300);
+
+	ret = ap_memory_read_id(&hxspi, id);
+	if (ret != 0) {
+		LOG_ERR("XSPI read ID failed");
+	}
+	k_busy_wait(100);
+
+	/* Memory QSPI Enable */
+	if (dev_cfg->qspi_enable) {
+		/* Memory Mapped Write */
+		cmd.OperationType = HAL_XSPI_OPTYPE_WRITE_CFG;
+		cmd.InstructionMode = HAL_XSPI_INSTRUCTION_1_LINE;
+		cmd.InstructionWidth = HAL_XSPI_INSTRUCTION_8_BITS;
+		cmd.Instruction = 0x38;
+		cmd.AddressMode = HAL_XSPI_ADDRESS_4_LINES;
+		cmd.AddressWidth = HAL_XSPI_ADDRESS_24_BITS;
+		cmd.DataMode = HAL_XSPI_DATA_4_LINES;
+		cmd.DQSMode = HAL_XSPI_DQS_ENABLE;
+
+		if (HAL_XSPI_Command(&hxspi, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+			LOG_ERR("XSPI write command failed");
+		}
+		k_busy_wait(100);
+
+		/* Memory Mapped Read */
+		cmd.OperationType = HAL_XSPI_OPTYPE_READ_CFG;
+		cmd.Instruction = 0xEB;
+		cmd.DummyCycles = 6U;
+		cmd.DQSMode = HAL_XSPI_DQS_DISABLE;
+
+		if (HAL_XSPI_Command(&hxspi, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+			LOG_ERR("XSPI write command failed");
+		}
+		k_busy_wait(100);
+	} else {
+		/* Memory Mapped Write */
+		cmd.OperationType = HAL_XSPI_OPTYPE_WRITE_CFG;
+		cmd.InstructionMode = HAL_XSPI_INSTRUCTION_1_LINE;
+		cmd.InstructionWidth = HAL_XSPI_INSTRUCTION_8_BITS;
+		cmd.Instruction = 0x02;
+		cmd.AddressMode = HAL_XSPI_ADDRESS_1_LINE;
+		cmd.AddressWidth = HAL_XSPI_ADDRESS_24_BITS;
+		cmd.DataMode = HAL_XSPI_DATA_1_LINE;
+		cmd.DQSMode = HAL_XSPI_DQS_ENABLE;
+
+		if (HAL_XSPI_Command(&hxspi, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+			LOG_ERR("XSPI write command failed");
+		}
+		k_busy_wait(100);
+		/* Memory Mapped Read */
+		cmd.OperationType = HAL_XSPI_OPTYPE_READ_CFG;
+		cmd.Instruction = 0x0B;
+		cmd.DummyCycles = 8U;
+		cmd.DQSMode = HAL_XSPI_DQS_DISABLE;
+
+		if (HAL_XSPI_Command(&hxspi, &cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+			LOG_ERR("XSPI write command failed");
+		}
+		k_busy_wait(100);
+	}
+
+	mem_mapped_cfg.TimeOutActivation = HAL_XSPI_TIMEOUT_COUNTER_DISABLE;
+
+#if defined(XSPI_CR_NOPREF)
+	mem_mapped_cfg.NoPrefetchData = HAL_XSPI_AUTOMATIC_PREFETCH_ENABLE;
+#endif
+#if defined(XSPI_CR_NOPREF_AXI)
+	mem_mapped_cfg.NoPrefetchAXI = HAL_XSPI_AXI_PREFETCH_DISABLE;
+#endif
+
+	if (HAL_XSPI_MemoryMapped(&hxspi, &mem_mapped_cfg) != HAL_OK) {
+		LOG_ERR("XSPI memory mapped failed");
+		return -EIO;
+	}
+	k_busy_wait(100);
+#if defined(XSPI_CR_NOPREF)
+	MODIFY_REG(hxspi.Instance->CR, XSPI_CR_NOPREF, HAL_XSPI_AUTOMATIC_PREFETCH_DISABLE);
+#endif
+
+#ifdef CONFIG_SHARED_MULTI_HEAP
+	shared_multi_heap_pool_init();
+	ret = shared_multi_heap_add(&smh_psram, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+#endif
+
+	return 0;
+}
+
+PINCTRL_DT_DEFINE(STM32_XSPI_NODE);
+
+static const struct memc_stm32_xspi_psram_config memc_stm32_xspi_cfg = {
+	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(STM32_XSPI_NODE),
+	.pclken = {.bus = DT_CLOCKS_CELL_BY_NAME(STM32_XSPI_NODE, xspix, bus),
+		   .enr = DT_CLOCKS_CELL_BY_NAME(STM32_XSPI_NODE, xspix, bits)},
+#if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_ker)
+	.pclken_ker = {.bus = DT_CLOCKS_CELL_BY_NAME(STM32_XSPI_NODE, xspi_ker, bus),
+		       .enr = DT_CLOCKS_CELL_BY_NAME(STM32_XSPI_NODE, xspi_ker, bits)},
+#endif
+#if DT_CLOCKS_HAS_NAME(STM32_XSPI_NODE, xspi_mgr)
+	.pclken_mgr = {.bus = DT_CLOCKS_CELL_BY_NAME(STM32_XSPI_NODE, xspi_mgr, bus),
+		       .enr = DT_CLOCKS_CELL_BY_NAME(STM32_XSPI_NODE, xspi_mgr, bits)},
+#endif
+	.memory_size = DT_INST_PROP(0, size) / 8, /* In Bytes */
+	.max_frequency = DT_INST_PROP(0, max_frequency),
+	.qspi_enable = DT_INST_PROP(0, qspi_enable),
+};
+
+static struct memc_stm32_xspi_psram_data memc_stm32_xspi_data = {
+	.hxspi = {
+		.Instance = (XSPI_TypeDef *)DT_REG_ADDR(STM32_XSPI_NODE),
+		.Init = {
+			.FifoThresholdByte = 1U,
+			.MemoryMode = HAL_XSPI_SINGLE_MEM,
+			.MemoryType = HAL_XSPI_MEMTYPE_APMEM,
+			.ChipSelectHighTimeCycle = 1U,
+			.FreeRunningClock = HAL_XSPI_FREERUNCLK_DISABLE,
+			.ClockMode = HAL_XSPI_CLOCK_MODE_0,
+			.WrapSize = HAL_XSPI_WRAP_NOT_SUPPORTED,
+			.SampleShifting = HAL_XSPI_SAMPLE_SHIFT_NONE,
+			.DelayHoldQuarterCycle = HAL_XSPI_DHQC_ENABLE,
+			.ChipSelectBoundary = DT_INST_PROP(0, st_csbound),
+			.MaxTran = 0U,
+			.Refresh = 0U,
+			.MemorySelect = HAL_XSPI_CSSEL_NCS1,
+		},
+	},
+};
+
+DEVICE_DT_INST_DEFINE(0, &memc_stm32_xspi_psram_init, NULL, &memc_stm32_xspi_data,
+		      &memc_stm32_xspi_cfg, POST_KERNEL, CONFIG_MEMC_INIT_PRIORITY, NULL);

--- a/dts/bindings/memory-controllers/st,stm32-xspi-psram-aps6404.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-xspi-psram-aps6404.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2025 Mario Paja
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32 XSPI PSRAM.
+
+compatible: "st,stm32-xspi-psram-aps6404"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  size:
+    type: int
+    required: true
+    description: Flash Memory size in bits
+
+  max-frequency:
+    type: int
+    required: true
+    description: Maximum clock frequency of device's xSPI (SPI) interface in Hz
+
+  qspi-enable:
+    type: boolean
+    description: |
+      Enable QSPI, SPI otherwise.
+
+  st,csbound:
+    type: int
+    default: 3
+    description: |
+      Limit a transaction to a boundary of aligned addresses. The size of the
+      alignment is given by the value: 2^(csbound) bits.
+      A csbound value of 0 means the feature is disabled.
+      The default is the minimum recommended value in the Reference Manual. It
+      is recommended to set this value according to the length of the burst wrap
+      of the PSRAM device for the linear burst command.
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+           21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]

--- a/tests/drivers/memc/ram/boards/nucleo_h7s3l8.overlay
+++ b/tests/drivers/memc/ram/boards/nucleo_h7s3l8.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Mario Paja
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	psram: memory@90000000 {
+		compatible = "zephyr,memory-region";
+		reg = <0x90000000 DT_SIZE_M(8)>;
+		zephyr,memory-region = "PSRAM";
+		zephyr,memory-attr = <DT_MEM_ARM_MPU_RAM>;
+	};
+};
+
+&xspi1 {
+	pinctrl-0 = <&xspim_p1_clk_po4 &xspim_p1_ncs1_po0
+		     &xspim_p1_io0_pp0 &xspim_p1_io1_pp1
+		     &xspim_p1_io2_pp2 &xspim_p1_io3_pp3>;
+
+	pinctrl-names = "default";
+	status = "okay";
+
+	memc: aps6404l: memory@0 {
+		status = "okay";
+		compatible = "st,stm32-xspi-psram-aps6404";
+		reg = <0>;
+		size = <DT_SIZE_M(64)>;
+		max-frequency = <DT_FREQ_M(80)>;
+		qspi-enable;
+		st,csbound = <4>;
+	};
+};
+
+&sram0 {
+	status = "disabled";
+};
+
+&sram1 {
+	status = "disabled";
+};
+
+&sram2 {
+	status = "disabled";
+};


### PR DESCRIPTION
Add support APS6404 (QSPI) PSRAM on XSPI BUS.

Tested on Nucleo H7S3L8 and a custom APS6408L module

```
Memory region         Used Size  Region Size  %age Used
           FLASH:       35880 B        64 KB     54.75%
             RAM:        6272 B       128 KB      4.79%
            DTCM:          0 GB       128 KB      0.00%
            ITCM:          0 GB        64 KB      0.00%
          EXTMEM:          0 GB        64 MB      0.00%
           PSRAM:          2 MB         8 MB     25.00%
        IDT_LIST:          0 GB        32 KB      0.00%
```

```
*** Booting Zephyr OS build v4.3.0-rc2-6-gcf9a9dd4135d ***
Running TESTSUITE test_ram
===================================================================
START - test_psram
 PASS - test_psram in 0.084 seconds
===================================================================
START - test_ram0
 SKIP - test_ram0 in 0.001 seconds
===================================================================
START - test_sdram1
 SKIP - test_sdram1 in 0.001 seconds
===================================================================
START - test_sdram2
 SKIP - test_sdram2 in 0.001 seconds
===================================================================
START - test_sram1
 SKIP - test_sram1 in 0.001 seconds
===================================================================
START - test_sram2
 SKIP - test_sram2 in 0.001 seconds
===================================================================
TESTSUITE test_ram succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [test_ram]: pass = 1, fail = 0, skip = 5, total = 6 duration = 0.089 seconds
 - PASS - [test_ram.test_psram] duration = 0.084 seconds
 - SKIP - [test_ram.test_ram0] duration = 0.001 seconds
 - SKIP - [test_ram.test_sdram1] duration = 0.001 seconds
 - SKIP - [test_ram.test_sdram2] duration = 0.001 seconds
 - SKIP - [test_ram.test_sram1] duration = 0.001 seconds
 - SKIP - [test_ram.test_sram2] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

![IMG_8035](https://github.com/user-attachments/assets/db119d6d-ce24-4899-8fad-31f429d24e5f)

