### PR TITLE
manifest: mbedtls: bump to 3.6.5

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -46,6 +46,10 @@ The following CVEs are addressed by this release:
 * :cve:`2025-9557`: Under embargo until 2025-11-24
 * :cve:`2025-9558`: Under embargo until 2025-11-24
 * :cve:`2025-12035`: Under embargo until 2025-12-13
+* :cve:`2025-59438` `Padding oracle through timing of cipher error reporting
+  <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-10-invalid-padding-error/>`_
+* :cve:`2025-54764` `Side channel in RSA key generation and operations (SSBleed, M-Step)
+  <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-10-ssbleed-mstep/>`_
 
 More detailed information can be found in:
 https://docs.zephyrproject.org/latest/security/vulnerabilities.html
@@ -1193,6 +1197,11 @@ Libraries / Subsystems
     case while :kconfig:option:`CONFIG_PSA_CRYPTO_PROVIDER_MBEDTLS` is set in the latter.
     :kconfig:option:`CONFIG_PSA_CRYPTO_PROVIDER_CUSTOM` is also added to allow end users to
     provide a custom solution.
+
+  * Updated from version 3.6.4 to version 3.6.5. Release notes for this release can be found at the
+    following link:
+
+    * https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.5
 
 * Secure storage
 

--- a/tests/bsim/bluetooth/mesh/overlay_gatt.conf
+++ b/tests/bsim/bluetooth/mesh/overlay_gatt.conf
@@ -8,3 +8,8 @@ CONFIG_BT_MESH_PROXY_CLIENT=y
 CONFIG_BT_MESH_PROXY_SOLICITATION=y
 
 CONFIG_BT_BUF_CMD_TX_COUNT=3
+
+# Increase number of retransmissions for PB-ADV when running tests with PB-GATT. This is to avoid
+# test failures due to pb-adv packets loss by provisionee which runs PB-GATT in parallel with
+# PB-ADV.
+CONFIG_BT_MESH_PB_ADV_TRANS_PDU_RETRANSMIT_COUNT=2

--- a/tests/bsim/bluetooth/mesh/src/test_brg.c
+++ b/tests/bsim/bluetooth/mesh/src/test_brg.c
@@ -837,6 +837,9 @@ static void check_subnet_list_get(struct bt_mesh_brg_cfg_filter_netkey filter, u
 
 	net_buf_simple_init(rsp.list, 0);
 
+	/* Sleep here to avoid packet collision. */
+	k_sleep(K_MSEC(100));
+
 	LOG_INF("Getting subnet list, filter = (filter: %d, subnet: %d), start_idx = %d",
 		filter.filter, filter.net_idx, start_idx);
 	ASSERT_OK(bt_mesh_brg_cfg_cli_subnets_get(0, BRIDGE_ADDR, filter, start_idx, &rsp));

--- a/west.yml
+++ b/west.yml
@@ -316,7 +316,7 @@ manifest:
       revision: b03edc8e6282a963cd312cd0b409eb5ce263ea75
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: f4c0283ca55fc4085815d4793a26e19f20be2f97
+      revision: c5b06d89c9c498d8fc8659ce31f7e53137b6270f
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
Update Mbed TLS revision to 3.6.5 release.

This PR depends on https://github.com/zephyrproject-rtos/mbedtls/pull/79

Fixes #98994