### PR TITLE
drivers: sensor: ti: Add INA232 native support

### DIFF
--- a/drivers/sensor/ti/ina2xx/Kconfig
+++ b/drivers/sensor/ti/ina2xx/Kconfig
@@ -7,7 +7,7 @@
 config INA2XX
 	bool "INA2XX Current and Power Monitor"
 	default y
-	depends on DT_HAS_TI_INA226_ENABLED || DT_HAS_TI_INA228_ENABLED || DT_HAS_TI_INA230_ENABLED || DT_HAS_TI_INA236_ENABLED || DT_HAS_TI_INA237_ENABLED
+	depends on DT_HAS_TI_INA226_ENABLED || DT_HAS_TI_INA228_ENABLED || DT_HAS_TI_INA230_ENABLED || DT_HAS_TI_INA232_ENABLED || DT_HAS_TI_INA236_ENABLED || DT_HAS_TI_INA237_ENABLED
 	select I2C
 	help
 	  Enable driver for INA2XX Current and Power Monitor.
@@ -48,21 +48,29 @@ config INA226
 config INA230
 	bool "INA230"
 	default y
-	depends on DT_HAS_TI_INA230_ENABLED || DT_HAS_TI_INA236_ENABLED
+	depends on DT_HAS_TI_INA230_ENABLED || DT_HAS_TI_INA232_ENABLED || DT_HAS_TI_INA236_ENABLED
 	select INA2XX_HAS_CHANNEL_BUS_VOLTAGE
 	select INA2XX_HAS_CHANNEL_CURRENT
 	select INA2XX_HAS_CHANNEL_POWER
 	help
-	  Enable driver for INA230/INA231/INA236.
+	  Enable driver for INA230/INA231/INA232/INA236.
 
 config INA230_TRIGGER
 	bool "INA230 trigger mode"
 	depends on INA230
 	depends on GPIO
-	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_INA230),alert-gpios) || $(dt_compat_any_has_prop,$(DT_COMPAT_TI_INA236),alert-gpios)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_TI_INA230),alert-gpios) || $(dt_compat_any_has_prop,$(DT_COMPAT_TI_INA232),alert-gpios) || $(dt_compat_any_has_prop,$(DT_COMPAT_TI_INA236),alert-gpios)
 	help
 	  Set to enable trigger mode using gpio interrupt, where
 	  interrupts are configured to line ALERT PIN.
+
+config INA232
+	bool "INA232"
+	default y
+	depends on DT_HAS_TI_INA232_ENABLED
+	select INA230
+	help
+	  Enable driver for INA232.
 
 config INA236
 	bool "INA236"

--- a/drivers/sensor/ti/ina2xx/ina230.h
+++ b/drivers/sensor/ti/ina2xx/ina230.h
@@ -27,6 +27,7 @@
 #define INA230_REG_CALIB           0x05
 #define INA230_REG_MASK            0x06
 #define INA230_REG_ALERT           0x07
+#define INA232_REG_MANUFACTURER_ID 0x3E
 #define INA236_REG_MANUFACTURER_ID 0x3E
 #define INA236_REG_DEVICE_ID       0x3F
 

--- a/dts/bindings/sensor/ti,ina232.yaml
+++ b/dts/bindings/sensor/ti,ina232.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright 2025 The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+description: |
+    TI INA232 Bidirectional Current and Power Monitor.
+    The <zephyr/dt-bindings/sensor/ina230.h> file includes the
+    macro for initializing the config register so it should
+    be included.
+
+compatible: "ti,ina232"
+
+include: ti,ina230.yaml
+
+properties:
+  high-precision:
+    type: boolean
+    description: |
+      Enable high precision mode (4x the resolution).

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1445,3 +1445,13 @@ test_i2c_wsen_pdms_25131308XXX05: wsen_pdms_25131308XXX05@c0 {
 	reg = <0xc0>;
 	sensor-type = <4>;
 };
+
+test_i2c_ina232: ina232@c1 {
+	compatible = "ti,ina232";
+	reg = <0xc1>;
+	current-lsb-microamps = <1000>;
+	rshunt-micro-ohms = <1000>;
+	mask = <0>;
+	alert-limit = <0>;
+	alert-gpios = <&test_gpio 0 0>;
+};

--- a/tests/drivers/sensor/ina230/boards/native_sim.overlay
+++ b/tests/drivers/sensor/ina230/boards/native_sim.overlay
@@ -23,4 +23,12 @@
 		current-lsb-microamps = <1000>;
 		status = "okay";
 	};
+
+	ina232_default_test: ina232@42 {
+		compatible = "ti,ina232";
+		reg = <0x42>;
+		rshunt-micro-ohms = <2000>;
+		current-lsb-microamps = <1000>;
+		status = "okay";
+	};
 };

--- a/tests/drivers/sensor/ina230/src/ina230_emul.c
+++ b/tests/drivers/sensor/ina230/src/ina230_emul.c
@@ -168,6 +168,10 @@ static const struct i2c_emul_api ina230_emul_api_i2c = {
 	{INA230_REG_MASK, 2, 0},                                                                   \
 	{INA230_REG_ALERT, 2, 0}
 
+#define CREATE_INA232_REGS                                                                         \
+	CREATE_INA230_REGS,                                                                        \
+	{INA232_REG_MANUFACTURER_ID, 2, 0x5449}
+
 #define CREATE_INA236_REGS                                                                         \
 	CREATE_INA230_REGS,                                                                        \
 	{INA236_REG_MANUFACTURER_ID, 2, 0x449},                                                    \
@@ -189,6 +193,10 @@ static const struct i2c_emul_api ina230_emul_api_i2c = {
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT ti_ina230
 DT_INST_FOREACH_STATUS_OKAY_VARGS(INA230_EMUL, 0)
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT ti_ina232
+DT_INST_FOREACH_STATUS_OKAY_VARGS(INA230_EMUL, 2)
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT ti_ina236

--- a/tests/drivers/sensor/ina230/src/ina230_emul.h
+++ b/tests/drivers/sensor/ina230/src/ina230_emul.h
@@ -9,6 +9,7 @@
 #define INA230_EMUL_H_
 
 #define INA230_REGISTER_COUNT 8
+#define INA232_REGISTER_COUNT 1
 #define INA236_REGISTER_COUNT 2
 
 int ina230_mock_set_register(void *data_ptr, int reg, uint32_t value);

--- a/tests/drivers/sensor/ina230/src/ina230_test.c
+++ b/tests/drivers/sensor/ina230/src/ina230_test.c
@@ -16,6 +16,7 @@
 
 enum ina23x_ids {
 	INA230,
+	INA232,
 	INA236
 };
 
@@ -153,7 +154,8 @@ static void test_bus_voltage(struct ina230_fixture *fixture)
 		0,
 	};
 
-	double bitres = fixture->dev_type == INA236 ? 1.6e-3 : 1.25e-3;
+	double bitres =
+		(fixture->dev_type == INA232 || fixture->dev_type == INA236) ? 1.6e-3 : 1.25e-3;
 
 	for (int idx = 0; idx < ARRAY_SIZE(voltage_reg_vectors); idx++) {
 		struct sensor_value sensor_val;
@@ -186,7 +188,7 @@ static void test_power(struct ina230_fixture *fixture)
 		0,
 	};
 
-	int scale = fixture->dev_type == INA236 ? 32 : 25;
+	int scale = (fixture->dev_type == INA232 || fixture->dev_type == INA236) ? 32 : 25;
 
 	for (int idx = 0; idx < ARRAY_SIZE(power_reg_vectors); idx++) {
 		struct sensor_value sensor_val;
@@ -247,6 +249,10 @@ static void test_power(struct ina230_fixture *fixture)
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT ti_ina230
 DT_INST_FOREACH_STATUS_OKAY_VARGS(INA230_TESTS, 0)
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT ti_ina232
+DT_INST_FOREACH_STATUS_OKAY_VARGS(INA230_TESTS, 2)
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT ti_ina236


### PR DESCRIPTION
The INA232 is another device in the INA2XX family and is very similar to the already implemented INA230 and INA236. The main difference between the INA232 and the INA236 is that the INA232 does not have a Device ID register. Because of these similarities, it is implemented in the ina230.x files in the same way as the INA236. Modifications to the corresponding tests are included as well.