### PR TITLE
samples: zbus: benchmark: also filter SMP from MSG_SUBSCRIBERS test

### DIFF
--- a/samples/subsys/zbus/benchmark/sample.yaml
+++ b/samples/subsys/zbus/benchmark/sample.yaml
@@ -25,7 +25,10 @@ tests:
   sample.zbus.benchmark_async_msg_sub:
     tags: zbus
     min_ram: 16
-    filter: CONFIG_SYS_CLOCK_EXISTS and not (CONFIG_ARCH_POSIX and not CONFIG_BOARD_NATIVE_SIM)
+    filter: >-
+      CONFIG_SYS_CLOCK_EXISTS and
+      not (CONFIG_ARCH_POSIX and not CONFIG_BOARD_NATIVE_SIM) and
+      not CONFIG_SMP
     harness: console
     harness_config:
       type: multi_line


### PR DESCRIPTION
Commit d93561da682e ("samples: zbus: benchmark: Filter SMP from
benchmark_sync test") avoided the SMP race condition for the
SUBSCRIBERS variant (benchmark_sync) by filtering out SMP configurations,
but the MSG_SUBSCRIBERS variant (benchmark_async_msg_sub) has the
identical race condition and needs the same filter.

Fixes #98793
