### PR TITLE
devicetree: spi: fix DT_SPI_DEV_HAS_CS_GPIOS macro

### DIFF
--- a/include/zephyr/devicetree/spi.h
+++ b/include/zephyr/devicetree/spi.h
@@ -115,7 +115,8 @@ extern "C" {
  * @return 1 if spi_dev's bus node DT_BUS(spi_dev) has a chip select
  *         pin at index DT_REG_ADDR(spi_dev), 0 otherwise
  */
-#define DT_SPI_DEV_HAS_CS_GPIOS(spi_dev) DT_SPI_HAS_CS_GPIOS(DT_BUS(spi_dev))
+#define DT_SPI_DEV_HAS_CS_GPIOS(spi_dev)                                                           \
+	DT_PROP_HAS_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR_RAW(spi_dev))
 
 /**
  * @brief Get a SPI device's chip select GPIO controller's node identifier


### PR DESCRIPTION
Fixes DT_SPI_DEV_HAS_CS_GPIOS behavior. 

The presence of a cs-gpios property caused every SPI device to be configured to use GPIO CS, no matter if there was a valid entry in cs-gpios for the given child device or not. This fix ensures that the implementation matches the documented behavior, where GPIO CS is only used if the cs-gpios property has an entry matching the reg address of the child device.

This restores the behavior of the devicetree init API prior to https://github.com/zephyrproject-rtos/zephyr/commit/a60f93d742a48660882af5785fb4352f414ecd11 , which accidentally introduced this issue by relying on the `DT_SPI_DEV_HAS_CS_GPIOS` macro, which has deviated from its documented behavior ever since it was originally introduced 6 years ago.

This problem has been discovered because of a null pointer dereference in the case where the unit address of a child node exceeded the size of cs-gpios.

Fixes #98830