### PR TITLE
runners: promote --no-load argument into common code and add support in stlink_gdbrunner

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -304,6 +304,10 @@ class RunnerCaps:
 
     - rtt: whether the runner supports SEGGER RTT. This adds a --rtt-address
       option.
+
+    - skip_load: whether the runner supports the --load/--no-load option, which
+      allows skipping the load of image on target before starting a debug session
+      (this option only affects the 'debug' command)
     '''
 
     commands: set[str] = field(default_factory=lambda: set(_RUNNERCAPS_COMMANDS))
@@ -319,6 +323,7 @@ class RunnerCaps:
     rtt: bool = False  # This capability exists separately from the rtt command
                        # to allow other commands to use the rtt address
     dry_run: bool = False
+    skip_load: bool = False
 
     def __post_init__(self):
         if self.mult_dev_ids and not self.dev_id:
@@ -639,6 +644,12 @@ class ZephyrBinaryRunner(abc.ABC):
         parser.add_argument('--dry-run', action='store_true',
                             help=('''Print all the commands without actually
                             executing them''' if caps.dry_run else argparse.SUPPRESS))
+
+        # by default, 'west debug' is expected to flash before starting the session
+        parser.add_argument('--load', action=argparse.BooleanOptionalAction,
+                            help=("load image on target before 'west debug' session"
+                                  if caps.skip_load else argparse.SUPPRESS),
+                            default=True)
 
         # Runner-specific options.
         cls.do_add_parser(parser)

--- a/scripts/west_commands/runners/intel_cyclonev.py
+++ b/scripts/west_commands/runners/intel_cyclonev.py
@@ -28,7 +28,7 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
                  tcl_port=DEFAULT_OPENOCD_TCL_PORT,
                  telnet_port=DEFAULT_OPENOCD_TELNET_PORT,
                  gdb_port=DEFAULT_OPENOCD_GDB_PORT,
-                 gdb_init=None, no_load=False):
+                 gdb_init=None, load=True):
         super().__init__(cfg)
 
         support = path.join(cfg.board_dir, 'support')
@@ -89,7 +89,7 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
         self.serial = ['-c set _ZEPHYR_BOARD_SERIAL ' + serial] if serial else []
         self.use_elf = use_elf
         self.gdb_init = gdb_init
-        self.load_arg = [] if no_load else ['-ex', 'load']
+        self.load_arg = ['-ex', 'load'] if load else []
 
     @classmethod
     def name(cls):
@@ -98,7 +98,7 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'attach'},
-                          dev_id=False, flash_addr=False, erase=False)
+                          dev_id=False, flash_addr=False, erase=False, skip_load=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -151,8 +151,6 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
                             help='if given, no init issued in gdb server cmd')
         parser.add_argument('--no-targets', action='store_true',
                             help='if given, no target issued in gdb server cmd')
-        parser.add_argument('--no-load', action='store_true',
-                            help='if given, no load issued in gdb server cmd')
 
     @classmethod
     def do_create(cls, cfg, args):
@@ -166,7 +164,7 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
             use_elf=args.use_elf, no_halt=args.no_halt, no_init=args.no_init,
             no_targets=args.no_targets, tcl_port=args.tcl_port,
             telnet_port=args.telnet_port, gdb_port=args.gdb_port,
-            gdb_init=args.gdb_init, no_load=args.no_load)
+            gdb_init=args.gdb_init, load=args.load)
 
     def print_gdbserver_message(self):
         if not self.thread_info_enabled:

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -57,7 +57,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                  telnet_port=DEFAULT_OPENOCD_TELNET_PORT,
                  gdb_port=DEFAULT_OPENOCD_GDB_PORT,
                  gdb_client_port=DEFAULT_OPENOCD_GDB_PORT,
-                 gdb_init=None, no_load=False,
+                 gdb_init=None, load=True,
                  target_handle=DEFAULT_OPENOCD_TARGET_HANDLE,
                  rtt_port=DEFAULT_OPENOCD_RTT_PORT, rtt_server=False):
         super().__init__(cfg)
@@ -118,7 +118,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         self.serial = ['-c set _ZEPHYR_BOARD_SERIAL ' + serial] if serial else []
         self.use_elf = use_elf
         self.gdb_init = gdb_init
-        self.load_arg = [] if no_load else ['-ex', 'load']
+        self.load_arg = ['-ex', 'load'] if load else []
         self.target_handle = target_handle
         self.rtt_port = rtt_port
         self.rtt_server = rtt_server
@@ -130,7 +130,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach', 'rtt'},
-                          rtt=True, erase=True)
+                          rtt=True, erase=True, skip_load=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -188,8 +188,6 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                             help='if given, no init issued in gdb server cmd')
         parser.add_argument('--no-targets', action='store_true',
                             help='if given, no target issued in gdb server cmd')
-        parser.add_argument('--no-load', action='store_true',
-                            help='if given, no load issued in gdb server cmd')
         parser.add_argument('--target-handle', default=DEFAULT_OPENOCD_TARGET_HANDLE,
                             help=f'''Internal handle used in openocd targets cfg
                             files, defaults to "{DEFAULT_OPENOCD_TARGET_HANDLE}".
@@ -215,7 +213,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             no_targets=args.no_targets, tcl_port=args.tcl_port,
             telnet_port=args.telnet_port, gdb_port=args.gdb_port,
             gdb_client_port=args.gdb_client_port, gdb_init=args.gdb_init,
-            no_load=args.no_load, target_handle=args.target_handle,
+            load=args.load, target_handle=args.target_handle,
             rtt_port=args.rtt_port, rtt_server=args.rtt_server)
 
     def print_gdbserver_message(self):


### PR DESCRIPTION
Promote the existing `--no-load` argument from OpenOCD/Intel Cyclone V runners into common runner code. This argument inhibits loading of image on target before a debug session, allowing `west debug` to effectively be used as a `west attach`-after-reset.

Also add support of this argument to the `stlink_gdbserver` runner.