### PR TITLE
Nordic: SoC: Add Kconfig options for soc init code

### DIFF
--- a/soc/nordic/common/Kconfig
+++ b/soc/nordic/common/Kconfig
@@ -76,3 +76,4 @@ endif # HAS_NORDIC_DMM
 
 rsource "vpr/Kconfig"
 rsource "uicr/Kconfig"
+rsource "Kconfig.clock_config"

--- a/soc/nordic/common/Kconfig
+++ b/soc/nordic/common/Kconfig
@@ -77,3 +77,4 @@ endif # HAS_NORDIC_DMM
 rsource "vpr/Kconfig"
 rsource "uicr/Kconfig"
 rsource "Kconfig.clock_config"
+rsource "Kconfig.regulator"

--- a/soc/nordic/common/Kconfig.clock_config
+++ b/soc/nordic/common/Kconfig.clock_config
@@ -36,3 +36,46 @@ config SOC_LFXO_INTERNAL_LOAD_CAP
 endif # SOC_LFXO_LOAD_CAPS_INTERNAL
 
 endif # SOC_HAS_LFXO
+
+SOC_DT_HFXO_PATH := $(dt_nodelabel_path,hfxo)
+SOC_DT_HFXO_ENABLED := $(dt_path_enabled,$(SOC_DT_HFXO_PATH))
+SOC_DT_HFXO_HAS_STARTUP_TIME := $(dt_node_has_prop,$(SOC_DT_HFXO_PATH),startup-time-us)
+SOC_DT_HFXO_STARTUP_TIME := $(dt_node_int_prop_int,$(SOC_DT_HFXO_PATH),startup-time-us)
+SOC_DT_HFXO_LOAD_CAPS_EXTERNAL := $(dt_node_str_prop_equals,$(SOC_DT_HFXO_PATH),load-capacitors,external)
+SOC_DT_HFXO_HAS_LOAD_CAP := $(dt_node_has_prop,$(SOC_DT_HFXO_PATH),load-capacitance-femtofarad)
+SOC_DT_HFXO_LOAD_CAP := $(dt_node_int_prop_int,$(SOC_DT_HFXO_PATH),load-capacitance-femtofarad)
+
+config SOC_HAS_HFXO
+	bool "SoC has HFXO available"
+	default $(SOC_DT_HFXO_ENABLED)
+
+if SOC_HAS_HFXO
+
+config SOC_HFXO_STARTUP_TIME
+	int "Startup time of HFXO in microseconds"
+	default $(SOC_DT_HFXO_STARTUP_TIME) if $(SOC_DT_HFXO_HAS_STARTUP_TIME)
+	default 1650
+
+choice SOC_HFXO_LOAD_CAPS
+	prompt "HFXO load capacitor selection"
+	default SOC_HFXO_LOAD_CAPS_EXTERNAL if $(SOC_DT_HFXO_LOAD_CAPS_EXTERNAL)
+	default SOC_HFXO_LOAD_CAPS_INTERNAL
+
+config SOC_HFXO_LOAD_CAPS_EXTERNAL
+	bool "Use external load capacitors for HFXO"
+
+config SOC_HFXO_LOAD_CAPS_INTERNAL
+	bool "Use internal load capacitors for HFXO"
+
+endchoice # SOC_HFXO_LOAD_CAPS
+
+if SOC_HFXO_LOAD_CAPS_INTERNAL
+
+config SOC_HFXO_INTERNAL_LOAD_CAP
+	int "Internal load capacitance for HFXO"
+	default $(SOC_DT_HFXO_LOAD_CAP) if $(SOC_DT_HFXO_HAS_LOAD_CAP)
+	default 15000
+
+endif # SOC_HFXO_LOAD_CAPS_INTERNAL
+
+endif # SOC_HAS_HFXO

--- a/soc/nordic/common/Kconfig.clock_config
+++ b/soc/nordic/common/Kconfig.clock_config
@@ -1,0 +1,38 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+SOC_DT_LFXO_PATH := $(dt_nodelabel_path,lfxo)
+SOC_DT_LFXO_ENABLED := $(dt_path_enabled,$(SOC_DT_LFXO_PATH))
+SOC_DT_LFXO_LOAD_CAPS_EXTERNAL := $(dt_node_str_prop_equals,$(SOC_DT_LFXO_PATH),load-capacitors,external)
+SOC_DT_LFXO_HAS_LOAD_CAP := $(dt_node_has_prop,$(SOC_DT_LFXO_PATH),load-capacitance-femtofarad)
+SOC_DT_LFXO_LOAD_CAP := $(dt_node_int_prop_int,$(SOC_DT_LFXO_PATH),load-capacitance-femtofarad)
+
+config SOC_HAS_LFXO
+	bool "SoC has LFXO available"
+	default $(SOC_DT_LFXO_ENABLED)
+
+if SOC_HAS_LFXO
+
+choice SOC_LFXO_LOAD_CAPS
+	prompt "LFXO load capacitor selection"
+	default SOC_LFXO_LOAD_CAPS_EXTERNAL if $(SOC_DT_LFXO_LOAD_CAPS_EXTERNAL)
+	default SOC_LFXO_LOAD_CAPS_INTERNAL
+
+config SOC_LFXO_LOAD_CAPS_EXTERNAL
+	bool "Use external load capacitors for LFXO"
+
+config SOC_LFXO_LOAD_CAPS_INTERNAL
+	bool "Use internal load capacitors for LFXO"
+
+endchoice # SOC_LFXO_LOAD_CAPS
+
+if SOC_LFXO_LOAD_CAPS_INTERNAL
+
+config SOC_LFXO_INTERNAL_LOAD_CAP
+	int "Internal load capacitance for LFXO"
+	default $(SOC_DT_LFXO_LOAD_CAP) if $(SOC_DT_LFXO_HAS_LOAD_CAP)
+	default 17000
+
+endif # SOC_LFXO_LOAD_CAPS_INTERNAL
+
+endif # SOC_HAS_LFXO

--- a/soc/nordic/common/Kconfig.regulator
+++ b/soc/nordic/common/Kconfig.regulator
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+SOC_DT_VREGMAIN_PATH := $(dt_nodelabel_path,vregmain)
+SOC_DT_VREGMAIN_HAS_INITIAL_MODE := $(dt_node_has_prop,$(SOC_DT_VREGMAIN_PATH),regulator-initial-mode)
+SOC_DT_VREGMAIN_INITIAL_MODE := $(dt_node_int_prop_int,$(SOC_DT_VREGMAIN_PATH),regulator-initial-mode)
+
+config SOC_VREGMAIN_INITIAL_MODE
+	int "Initial mode of VREGMAIN volage regulator"
+	default $(SOC_DT_VREGMAIN_INITIAL_MODE) if $(SOC_DT_VREGMAIN_HAS_INITIAL_MODE)
+	default 1

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -89,7 +89,7 @@ static inline void power_and_clock_configuration(void)
 	nrf_oscillators_lfxo_cap_set(NRF_OSCILLATORS, (nrf_oscillators_lfxo_cap_t)0);
 #endif
 
-#if DT_ENUM_HAS_VALUE(HFXO_NODE, load_capacitors, internal)
+#if CONFIG_SOC_HFXO_LOAD_CAPS_INTERNAL
 	uint32_t xosc32mtrim = NRF_FICR->XOSC32MTRIM;
 	/* The SLOPE field is in the two's complement form, hence this special
 	 * handling. Ideally, it would result in just one SBFX instruction for
@@ -112,7 +112,7 @@ static inline void power_and_clock_configuration(void)
 	 * holding any value between 4.0 pF and 17.0 pF in 0.25 pF steps.
 	 */
 
-	uint32_t hfxo_intcap_femto_f = DT_PROP(HFXO_NODE, load_capacitance_femtofarad);
+	uint32_t hfxo_intcap_femto_f = CONFIG_SOC_HFXO_INTERNAL_LOAD_CAP;
 
 	/* Capacitance value passed to the formula is in femto Farads to
 	 * avoid floating point data type. Hence, offset_m needs to be multiplied by 1000.
@@ -129,8 +129,7 @@ static inline void power_and_clock_configuration(void)
 	}
 
 	nrf_oscillators_hfxo_cap_set(NRF_OSCILLATORS, true, hfxo_intcap);
-
-#elif DT_ENUM_HAS_VALUE(HFXO_NODE, load_capacitors, external)
+#else
 	nrf_oscillators_hfxo_cap_set(NRF_OSCILLATORS, false, 0);
 #endif
 

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -15,7 +15,6 @@
 /* Include autoconf for cases when this file is used in special build (e.g. TFM) */
 #include <zephyr/autoconf.h>
 
-#include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
@@ -34,9 +33,6 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 #include <hal/nrf_regulators.h>
 #include <zephyr/dt-bindings/regulator/nrf5x.h>
 
-#define LFXO_NODE DT_NODELABEL(lfxo)
-#define HFXO_NODE DT_NODELABEL(hfxo)
-
 static inline void power_and_clock_configuration(void)
 {
 /* NRF_REGULATORS and NRF_OSCILLATORS are configured to be secure
@@ -46,7 +42,7 @@ static inline void power_and_clock_configuration(void)
  * NRF_OSCILLATORS is also configured as secure because of a HW limitation
  * that requires them to be configured with the same security property.
  */
-#if DT_ENUM_HAS_VALUE(LFXO_NODE, load_capacitors, internal)
+#if CONFIG_SOC_LFXO_LOAD_CAPS_INTERNAL
 	uint32_t xosc32ktrim = NRF_FICR->XOSC32KTRIM;
 	/* The SLOPE field is in the two's complement form, hence this special
 	 * handling. Ideally, it would result in just one SBFX instruction for
@@ -69,7 +65,7 @@ static inline void power_and_clock_configuration(void)
 	 * value between 4 pF and 18 pF in 0.5 pF steps.
 	 */
 
-	uint32_t lfxo_intcap_femto_f = DT_PROP(LFXO_NODE, load_capacitance_femtofarad);
+	uint32_t lfxo_intcap_femto_f = CONFIG_SOC_LFXO_INTERNAL_LOAD_CAP;
 
 	/* Calculation of INTCAP code before rounding. Min that calculations here are done on
 	 * values multiplied by 2^9, e.g. 0.765625 * 2^9 = 392.
@@ -89,7 +85,7 @@ static inline void power_and_clock_configuration(void)
 	}
 
 	nrf_oscillators_lfxo_cap_set(NRF_OSCILLATORS, lfxo_intcap);
-#elif DT_ENUM_HAS_VALUE(LFXO_NODE, load_capacitors, external)
+#else
 	nrf_oscillators_lfxo_cap_set(NRF_OSCILLATORS, (nrf_oscillators_lfxo_cap_t)0);
 #endif
 

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -133,10 +133,9 @@ static inline void power_and_clock_configuration(void)
 	nrf_oscillators_hfxo_cap_set(NRF_OSCILLATORS, false, 0);
 #endif
 
-#if (DT_PROP(DT_NODELABEL(vregmain), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
+#if CONFIG_SOC_VREGMAIN_INITIAL_MODE == NRF5X_REG_MODE_DCDC
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
 #endif
-
 }
 #endif /* NRF_APPLICATION && !CONFIG_TRUSTED_EXECUTION_NONSECURE */
 


### PR DESCRIPTION
Add Kconfig options which configure soc init code. These Kconfig options default to values found in the devicetree, while allowing users to overwrite them using Kconfig in cases where users prefer that over devicetree.