### PR TITLE
boards: other: Default to RC source for ProMicro nRF52840

### DIFF
--- a/boards/others/promicro_nrf52840/promicro_nrf52840_nrf52840_defconfig
+++ b/boards/others/promicro_nrf52840/promicro_nrf52840_nrf52840_defconfig
@@ -9,6 +9,10 @@ CONFIG_HW_STACK_PROTECTION=y
 # Enable GPIO
 CONFIG_GPIO=y
 
+# Even though these boards have an external crystal, they are notoriously
+# faulty/poorly tuned, so use the internal RC by default
+CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
+
 # Board Kconfig.defconfig enables USB CDC ACM and should disable USB remote
 # wakeup by default. It needs to be disabled here, because the USB nrfx
 # driver always overwrites option from Kconfig mentioned above with the

--- a/boards/others/promicro_nrf52840/promicro_nrf52840_nrf52840_uf2_defconfig
+++ b/boards/others/promicro_nrf52840/promicro_nrf52840_nrf52840_uf2_defconfig
@@ -9,6 +9,10 @@ CONFIG_HW_STACK_PROTECTION=y
 # Enable GPIO
 CONFIG_GPIO=y
 
+# Even though these boards have an external crystal, they are notoriously
+# faulty/poorly tuned, so use the internal RC by default
+CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
+
 # Board Kconfig.defconfig enables USB CDC ACM and should disable USB remote
 # wakeup by default. It needs to be disabled here, because the USB nrfx
 # driver always overwrites option from Kconfig mentioned above with the


### PR DESCRIPTION
The various ProMicro nRF52840 boards are frequently found to have BLE issues due to their external crystals not functioning well, so default to the internal RC source.

These boards end up getting used extensively with ZMK, and we *regularly* encounter support issues due to the crystals on them being broken/poorly tuned. So much so have a troubleshooting section specifically about this: https://zmk.dev/docs/troubleshooting/connection-issues#mitigating-a-faulty-oscillator

Recommend this is a saner default for these cheaper boards.