### PR TITLE
tests: intel_adsp/smoke: cast to signed ints before abs()

### DIFF
--- a/tests/boards/intel_adsp/smoke/src/cpus.c
+++ b/tests/boards/intel_adsp/smoke/src/cpus.c
@@ -120,7 +120,7 @@ static void core_smoke(void *arg)
 	       clk_ratios[cpu] / 1000, clk_ratios[cpu] % 1000);
 
 	for (int i = 0; i < cpu; i++) {
-		int32_t diff = MAX(1, abs(clk_ratios[i] - clk_ratios[cpu]));
+		int32_t diff = MAX(1, abs((int32_t)((int64_t)clk_ratios[i] - clk_ratios[cpu])));
 
 		zassert_true((clk_ratios[cpu] / diff) > 100,
 			     "clocks off by more than 1%%");


### PR DESCRIPTION
xt-clang complains about the clock ratio difference is unsigned when being fed to abs(), though GCC does not. So type cast that to signed integer before feeding to abs(). Clock ratio could be big enough to overflow signed 32-bit integer. So we first cast it to be a signed 64-bit integer before substraction.