### PR TITLE
drivers: flash: flash_mspi_nor: indicate support for flash page layout

### DIFF
--- a/drivers/flash/Kconfig.mspi
+++ b/drivers/flash/Kconfig.mspi
@@ -45,6 +45,7 @@ menuconfig FLASH_MSPI_NOR
 	select FLASH_MSPI
 	select FLASH_HAS_EXPLICIT_ERASE
 	select FLASH_JESD216
+	select FLASH_HAS_PAGE_LAYOUT
 	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_MSPI_NOR),reset-gpios) \
 		    || $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_MSPI_NOR),supply-gpios)
 


### PR DESCRIPTION
Flash MSPI NOR driver already has support for flash page layout, but did not select the Kconfig symbol indicating so. Add the selection so drivers can use the page layout api.

Fixes #99027