### PR TITLE
drivers: flash: flash_mspi_nor: support custom read frequency

### DIFF
--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -88,6 +88,7 @@ struct flash_mspi_nor_config {
 #endif
 	uint32_t reset_recovery_us;
 	uint32_t transfer_timeout;
+	uint32_t read_freq;
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 	struct flash_pages_layout layout;
 #endif

--- a/dts/bindings/mtd/jedec,mspi-nor.yaml
+++ b/dts/bindings/mtd/jedec,mspi-nor.yaml
@@ -60,3 +60,9 @@ properties:
     description: |
       When set, the flash driver performs software reset of the flash chip
       at initialization.
+
+  read-frequency:
+    type: int
+    description: |
+      Frequency, in Hz, to be used for read operations. If not specified,
+      the driver uses the same frequency as for other operations.


### PR DESCRIPTION
Many flash chips support a higher read frequency than other operations. Support specifying a custom read frequency to take advantage of the performance improvements available with this approach.