### PR TITLE
west: blobs: fix UnicodeDecodeError on Windows

### DIFF
--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -186,7 +186,7 @@ class Blobs(WestCommand):
                     self.wrn('Skip fetching this blob.')
                     continue
 
-                with open(blob['license-abspath']) as license_file:
+                with open(blob['license-abspath'], encoding="utf-8") as license_file:
                     license_content = license_file.read()
                     print(license_content)
 


### PR DESCRIPTION
Ensure the blobs command is trying to display the license file for click-through approval. Ensure that special characters doesn't cause a problem in Windows by opening the file with utf-8 encoding.

Fixes #98520