### PR TITLE
tests: kernel: smp_abort: add delay to ensure circular dependency

### DIFF
--- a/tests/kernel/smp_abort/src/main.c
+++ b/tests/kernel/smp_abort/src/main.c
@@ -39,6 +39,15 @@ static void isr(const void *args)
 	}
 
 	k_thread_abort(var->target);    /* Abort thread on another CPU */
+
+	/*
+	 * Give other CPUs time to also call k_thread_abort() to establish
+	 * the circular dependency that this test is designed to exercise.
+	 * On platforms with large emulator/simulator quantum sizes, without
+	 * this delay one thread may complete its ISR and return before
+	 * another thread even calls k_thread_abort() on it.
+	 */
+	k_busy_wait(100);
 }
 
 static void thread_entry(void *p1, void *p2, void *p3)


### PR DESCRIPTION
The test_smp_thread_abort_deadlock test assumes all CPUs will
simultaneously establish a circular abort dependency (each thread
aborts the next in a ring). However, on platforms with large
emulator/simulator quantum sizes, one thread's ISR may complete
and return before another thread even calls `k_thread_abort()` on it,
preventing the circular dependency from forming.

This manifested on ARMv8-R FVP but not on QEMU or ARMv8-A/ARMv9-A FVP
due to different timing characteristics and quantum sizes.

Add a `k_busy_wait(100)` after `k_thread_abort()` to give all CPUs time
to call abort before any ISR completes.

Fixes #98819
