### PR TITLE
driver: spi: egis_et171_spi supports clock driver

### DIFF
--- a/drivers/spi/spi_egis_et171.h
+++ b/drivers/spi/spi_egis_et171.h
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(spi_egis_et171);
 
 #include "spi_context.h"
 #include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/spi.h>
 
 #ifdef CONFIG_EGIS_SPI_DMA_MODE


### PR DESCRIPTION
The original design used a fixed SPI base frequency to calculate the transfer frequency,
that base frequency is declared with "clock-frequency" perporty in DTS.
```
		spi0: spi@f0b00000 {
...
			clock-frequency = <66000000>; /* base frequency */
...
		};
```

In this PR:
If the SPI's DTS has configured with the "clocks" property,
the driver will obtain the SPI base frequency through the clock driver.

```
		spi0: spi@f0b00000 {
...
			clocks = <&clock CLOCK_SPI0>; /* clock driver */
...
		};
```

Therefore, when there is using different the SPI base frequency,
it's no need to update the "clock-frequency" property manually anymore.