### PR TITLE
Update NXP HAL to get fix for uart_async_api

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 6d6ab91d5cc71c872353af1957d19f3d930df0fd
+      revision: 80e2a56683ba0affaca504c9ef72b1023616a86d
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
The UART async API was failing due to incorrect ITCM address conversion
    between M7 and DMA
    - ITCM: 0x00000000-0x0003FFFF (offset: 0x203C0000)
    
Fixes #98295
