### PR TITLE
LICENSES: Add note to README file

### DIFF
--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,0 +1,10 @@
+> [!IMPORTANT]
+> The license files in this directory are maintained as per the recommendation
+> of the REUSE specification (https://reuse.software/spec-3.3).
+> These are licenses that may apply to some components hosted in the source tree
+> but that do not end up in built binaries
+> (see https://docs.zephyrproject.org/latest/LICENSING.html#zephyr-licensing).
+>
+> These files do _not_ define the license of the Zephyr project itself.
+> Zephyr is licensed under the Apache 2.0 license, as specified in
+> the [LICENSE](/LICENSE) file at the root of the repository.


### PR DESCRIPTION
The files in the LICENSES directory are for the reuse tool, and not the licenses of the Zephyr repository itself.

As was suggested here https://github.com/zephyrproject-rtos/zephyr/pull/91476#pullrequestreview-3223093926[
Example here: https://github.com/pdgendt/zephyr/tree/reuse-readme-licenses/LICENSES