### PR TITLE
boards: renesas: Correct reg for ethernet-phy node on ek_ra6m3

### DIFF
--- a/boards/renesas/ek_ra6m3/ek_ra6m3.dts
+++ b/boards/renesas/ek_ra6m3/ek_ra6m3.dts
@@ -216,7 +216,7 @@
 	pinctrl-names = "default";
 	status = "okay";
 
-	phy: ethernet-phy@5 {
+	phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0>;
 		status = "okay";


### PR DESCRIPTION
Since the `reg` value for the `ethernet-phy` node on `ek_ra6m3` is already correctly set to `0`, but the node label incorrectly uses `ethernet-phy@5`, this PR aims to correct the `reg` value in the node label to `0`.

Fixes #98909