### PR TITLE
modules: hal_nordic:: Add sources for nrfx HFCLK192M clk separation.

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -119,6 +119,7 @@ zephyr_library_sources_ifdef(CONFIG_NRFX_PRS     ${SRC_DIR}/prs/nrfx_prs.c)
 
 zephyr_library_sources_ifdef(CONFIG_NRFX_ADC     ${SRC_DIR}/nrfx_adc.c)
 zephyr_library_sources_ifdef(CONFIG_NRFX_CLOCK   ${SRC_DIR}/nrfx_clock.c)
+zephyr_library_sources_ifdef(CONFIG_NRFX_CLOCK   ${SRC_DIR}/nrfx_clock_hfclk192m.c)
 zephyr_library_sources_ifdef(CONFIG_NRFX_COMP    ${SRC_DIR}/nrfx_comp.c)
 zephyr_library_sources_ifdef(CONFIG_NRFX_CRACEN  ${SRC_DIR}/nrfx_cracen.c)
 zephyr_library_sources_ifdef(CONFIG_NRFX_DPPI    ${SRC_DIR}/nrfx_dppi.c)


### PR DESCRIPTION
Added sourced for nrfx HFCLK192M separation.