### PR TITLE
west.yml: update hal_stm32 revision for 802.15.4 data transmission fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -250,7 +250,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 93e7944879c99bc5e0bb6371f9d2cb5d9a9f3482
+      revision: 286dd285b5bb4fddafdfff27b5405264e5a61bfe
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update hal_stm32 revision to update the stm32wba link layer 802.15.4 libraries including 802.15.4 data transmission fix.
Fixes #98425 