### PR TITLE
Bluetooth: Classic: HFP: Terminate outgoing call without alerting

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -2358,6 +2358,8 @@ static int bt_hfp_ag_chup_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 			}
 		} else if (call_state == BT_HFP_CALL_ACTIVE) {
 			next_step = bt_hfp_ag_unit_call_terminate;
+		} else if (call_state == BT_HFP_CALL_OUTGOING) {
+			next_step = bt_hfp_ag_call_terminate;
 		}
 
 		if (next_step) {


### PR DESCRIPTION
If the outgoing call is not alerted, support the case to terminate the call when receiving the AT command `AT+CHUP`.