### PR TITLE
drivers: usb: udc: mcux: force ehci speep as FS

### DIFF
--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -708,6 +708,12 @@ static int udc_mcux_init(const struct device *dev)
 		return -ENOMEM;
 	}
 
+	if (!IS_ENABLED(CONFIG_UDC_DRIVER_HIGH_SPEED_SUPPORT_ENABLED)) {
+		USBHS_Type *usbBase = (USBHS_Type *)config->base;
+
+		usbBase->PORTSC1 |= USBHS_PORTSC1_PFSC_MASK;
+	}
+
 	/* enable USB interrupt */
 	config->irq_enable_func(dev);
 


### PR DESCRIPTION
When CONFIG_UDC_DRIVER_HIGH_SPEED_SUPPORT_ENABLED is disabled, force configure ehci controller to work as FS.