### PR TITLE
github: workflows: Disable getting all toolchains

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -68,7 +68,6 @@ jobs:
         uses: zephyrproject-rtos/action-zephyr-setup@c125c5ebeeadbd727fa740b407f862734af1e52a # v1.0.9
         with:
           app-path: zephyr
-          toolchains: all
           enable-ccache: false
 
       - name: Environment Setup


### PR DESCRIPTION
This fixes an issue of CI failing due to the github runner being out of memory when cleaning up, and speed up the build prep stage