### PR TITLE
net: l2: openthread: border_router: Delete multicast route by iface

### DIFF
--- a/subsys/net/l2/openthread/openthread_border_router.c
+++ b/subsys/net/l2/openthread/openthread_border_router.c
@@ -297,7 +297,8 @@ static void ot_bbr_multicast_listener_handler(void *context,
 			}
 		}
 	} else {
-		struct net_route_entry_mcast *route_to_del = net_route_mcast_lookup(&recv_addr);
+		struct net_route_entry_mcast *route_to_del =
+			net_route_mcast_lookup_by_iface(&recv_addr, ot_context->iface);
 		struct net_if_mcast_addr *addr_to_del;
 
 		addr_to_del = net_if_ipv6_maddr_lookup(&recv_addr, &(ot_context->iface));
@@ -307,6 +308,8 @@ static void ot_bbr_multicast_listener_handler(void *context,
 
 		if (addr_to_del != NULL && net_if_ipv6_maddr_is_joined(addr_to_del)) {
 			net_if_ipv6_maddr_leave(ot_context->iface, addr_to_del);
+			net_if_ipv6_maddr_rm(ot_context->iface,
+					     (const struct in6_addr *)&recv_addr);
 		}
 	}
 }


### PR DESCRIPTION
This commit makes use of #98464 and deletes a multicast route by specified interface.