### PR TITLE
bluetooth: host: Make le conn update as async

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -4019,7 +4019,7 @@ int bt_conn_le_conn_update(struct bt_conn *conn,
 	conn_update->conn_latency = sys_cpu_to_le16(param->latency);
 	conn_update->supervision_timeout = sys_cpu_to_le16(param->timeout);
 
-	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CONN_UPDATE, buf, NULL);
+	return bt_hci_cmd_send(BT_HCI_OP_LE_CONN_UPDATE, buf);
 }
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_CLASSIC)


### PR DESCRIPTION
**Problem Statement**:

As per current implementation, bt_conn_le_conn_update API uses async transport [API](https://github.com/zephyrproject-rtos/zephyr/blob/d054025fa39547198c73cce0a4fdacf3f2a72afa/subsys/bluetooth/host/conn.c#L4022).   

The implementation of sync API uses system work queue context and doesn't actually respect the HCI_CMD_TIMEOUT wait time at this [condition](https://github.com/zephyrproject-rtos/zephyr/blob/d054025fa39547198c73cce0a4fdacf3f2a72afa/subsys/bluetooth/host/hci_core.c#L503) and returns immediately from semaphore causing false assert even though controller responds correctly to the HCI message with success status and before the semaphore is given.

Due to above behavior, application such as peripheral_gatt_write and cetral_gatt_write when tested against each other causes incorrect behavior when changing conn update parameter resulting in assert.

In order to overcome such scenarios particularly in LE conn update params which would require the controller or the LL to complete the conn update procedures before sending event made changes to use async API rather than sync.