### PR TITLE
soc: intel_adsp: add IPC message payload handling

### DIFF
--- a/include/zephyr/ipc/backends/intel_adsp_host_ipc.h
+++ b/include/zephyr/ipc/backends/intel_adsp_host_ipc.h
@@ -58,6 +58,12 @@ struct intel_adsp_ipc_msg {
 	/** Extension specific to platform. */
 	uint32_t ext_data;
 
+	/** Pointer to message payload. */
+	uintptr_t payload;
+
+	/** Size of payload buffer in bytes. */
+	size_t payload_length;
+
 	/** Timeout for sending synchronuous message. */
 	k_timeout_t timeout;
 };


### PR DESCRIPTION
The current IPC backend for Intel DSPs only handles the "doorbell" part of the IPC mechanism. This isn't very useful as any user of the IPC mechanism has to handle the IPC payload transport as well.

This commit adds functinality to handle message payload handling to the IPC service. This change makes the IPC a more complete abstraction and paves the way to use this interface with larger set of hardware than just Intel DSPs. The IPC backend is free to use other transports than the the shared memory mailbox used in the Intel DSP backend.