### PR TITLE
ci: compliance: call dts linter safely under windows

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -499,12 +499,13 @@ class DevicetreeLintingCheck(ComplianceTest):
     NPX_EXECUTABLE = "npx"
 
     def ensure_npx(self) -> bool:
-        if not shutil.which(self.NPX_EXECUTABLE):
+        if not (npx_executable := shutil.which(self.NPX_EXECUTABLE)):
             return False
         try:
+            self.npx_exe = npx_executable
             # --no prevents npx from fetching from registry
             subprocess.run(
-                [self.NPX_EXECUTABLE, "--prefix", "./scripts/ci", "--no", 'dts-linter', "--", "--version"],
+                [self.npx_exe, "--prefix", "./scripts/ci", "--no", 'dts-linter', "--", "--version"],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 check=True,
@@ -535,6 +536,7 @@ class DevicetreeLintingCheck(ComplianceTest):
             raise RuntimeError(f"Failed to parse dts-linter JSON output: {e}")
 
     def run(self):
+        self.npx_exe = self.NPX_EXECUTABLE
         # Get changed DTS files
         dts_files = [
             file for file in get_files(filter="d")
@@ -560,7 +562,7 @@ class DevicetreeLintingCheck(ComplianceTest):
             temp_patch_files.append(temp_patch)
 
             cmd = [
-                "npx", "--prefix", "./scripts/ci", "--no",
+                self.npx_exe, "--prefix", "./scripts/ci", "--no",
                 "dts-linter", "--", "--outputFormat",
                 "json", "--format",
                 "--patchFile", temp_patch,

--- a/scripts/ci/package-lock.json
+++ b/scripts/ci/package-lock.json
@@ -1,17 +1,17 @@
 {
-  "name": "zephyr",
+  "name": "ci",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
-        "dts-linter": "^0.3.2"
+        "dts-linter": "^0.3.6"
       }
     },
     "node_modules/devicetree-language-server": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/devicetree-language-server/-/devicetree-language-server-0.6.3.tgz",
-      "integrity": "sha512-mvZC217Cq+WmqB51dk5+4slI3obcUgzaHBxroCkAR4clmiC0+PYi8hnY1PWB+HekOT2pWIDHT3/tCAfq31aK7Q==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/devicetree-language-server/-/devicetree-language-server-0.6.7.tgz",
+      "integrity": "sha512-ov/f8B8WcKAgOR4TVmr3cgH5KWsrmFnHZJL4Zha6x7b7gpux9eXWWAg/XsgE0Aifexu8ht0txy1us7/IiUs/dg==",
       "license": "Apache-2.0",
       "bin": {
         "devicetree-language-server": "dist/server.js"
@@ -21,12 +21,12 @@
       }
     },
     "node_modules/dts-linter": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/dts-linter/-/dts-linter-0.3.2.tgz",
-      "integrity": "sha512-IXvPQhRuAGZ78mKn13fRfUoVhjbPiBqmy3NoVqPsFuW/0ZTbiPInBbiMxNB8dN5PImDja3Q8I2V3GG/RJNPdOg==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/dts-linter/-/dts-linter-0.3.6.tgz",
+      "integrity": "sha512-MG7r0hWOcmhue4k0oSd0+/mNC9nNnpdRKfW4EhQevOd1apHUhmTW4SsI6Um5zfVP1fNpy95IpBS0/dja9UYCXw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "devicetree-language-server": "^0.6.3"
+        "devicetree-language-server": "^0.6.7"
       },
       "bin": {
         "dts-linter": "dist/dts-linter.js"

--- a/scripts/ci/package.json
+++ b/scripts/ci/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "dts-linter": "^0.3.2"
+    "dts-linter": "^0.3.6"
   }
 }


### PR DESCRIPTION
subprocess run without shell requires npx shim under windows. FIx #98824