### PR TITLE
drivers: promote APIs to unstable status

### DIFF
--- a/include/zephyr/drivers/auxdisplay.h
+++ b/include/zephyr/drivers/auxdisplay.h
@@ -17,7 +17,7 @@
  * @brief Interfaces for auxiliary (textual/non-graphical) displays.
  * @defgroup auxdisplay_interface Auxiliary (Text) Display
  * @since 3.4
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/comparator.h
+++ b/include/zephyr/drivers/comparator.h
@@ -17,7 +17,7 @@
  * @brief Interfaces for comparators.
  * @defgroup comparator_interface Comparator
  * @since 4.0
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -16,7 +16,7 @@
 /**
  * @defgroup dai_interface DAI
  * @since 3.1
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @brief Interfaces for Digital Audio Interfaces.
  *

--- a/include/zephyr/drivers/fpga.h
+++ b/include/zephyr/drivers/fpga.h
@@ -27,7 +27,7 @@ extern "C" {
  * @brief Interfaces for Field-Programmable Gate Arrays (FPGA).
  * @defgroup fpga_interface FPGA
  * @since 2.7
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -19,7 +19,7 @@
  * @brief Interfaces for fuel gauges.
  * @defgroup fuel_gauge_interface Fuel Gauge
  * @since 3.3
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -17,7 +17,7 @@
  * @brief Interfaces for Global Navigation Satellite System (GNSS) receivers.
  * @defgroup gnss_interface GNSS
  * @since 3.6
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -18,7 +18,7 @@
  * @brief Interfaces for Improved Inter-Integrated Circuit (I3C) controllers.
  * @defgroup i3c_interface I3C
  * @since 3.2
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -16,7 +16,7 @@
  * @brief Interfaces for LoRa transceivers.
  * @defgroup lora_interface LoRa
  * @since 2.2
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -27,7 +27,7 @@ extern "C" {
  * @brief Interfaces for mailbox (MBOX) devices.
  * @defgroup mbox_interface MBOX
  * @since 1.0
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  *

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -30,7 +30,7 @@ extern "C" {
  *        controllers.
  * @defgroup mspi_interface MSPI
  * @since 3.7
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -16,7 +16,7 @@
  * @brief Interfaces for pin controllers.
  * @defgroup pinctrl_interface Pin Control
  * @since 3.0
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -21,7 +21,7 @@
  * @brief Interfaces for Secure Digital Host Controllers (SDHC).
  * @defgroup sdhc_interface SDHC
  * @since 3.1
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -17,7 +17,7 @@
  * @brief Interfaces for System Management Bus (SMBus).
  * @defgroup smbus_interface SMBus
  * @since 3.4
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/stepper.h
+++ b/include/zephyr/drivers/stepper.h
@@ -17,7 +17,7 @@
  * @brief Interfaces for stepper motor controllers.
  * @defgroup stepper_interface Stepper
  * @since 4.0
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/w1.h
+++ b/include/zephyr/drivers/w1.h
@@ -28,7 +28,7 @@ extern "C" {
  * @brief Interfaces for 1-Wire devices.
  * @defgroup w1_interface 1-Wire
  * @since 3.2
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
Many APIs are stuck at experimental status although they already fullfil
the requirements to be considered unstable, i.e. they have multiple
implementations and have been in the tree for more than 2 releases.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
