### PR TITLE
boards: esp32_cam: remove unused SD card detect pin and fix LED polarity

### DIFF
--- a/boards/aithinker/esp32_cam/esp32_cam-pinctrl.dtsi
+++ b/boards/aithinker/esp32_cam/esp32_cam-pinctrl.dtsi
@@ -43,12 +43,4 @@
 			output-low;
 		};
 	};
-
-	sdhc0_default: sdhc0_default {
-		group1 {
-			pinmux = <SDHC0_CD_GPIO21>;
-			bias-pull-up;
-			output-high;
-		};
-	};
 };

--- a/boards/aithinker/esp32_cam/esp32_cam_procpu.dts
+++ b/boards/aithinker/esp32_cam/esp32_cam_procpu.dts
@@ -19,14 +19,14 @@
 		led0 = &led0;
 		led1 = &led1;
 		watchdog0 = &wdt0;
-		sdhc0 = &sdhc0;
+		sdhc0 = &sdhc1;
 	};
 
 	leds {
 		compatible = "gpio-leds";
 
 		led0: led_0 {
-			gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
 			label = "Status LED";
 		};
 
@@ -43,7 +43,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &esp32_bt_hci;
-		zephyr,sdhc = &sdhc0;
+		zephyr,sdhc = &sdhc1;
 	};
 };
 
@@ -108,12 +108,9 @@
 };
 
 &sdhc {
-	sdhc0: sdhc@0 {
+	sdhc1: sdhc@1 {
 		status = "okay";
 
-		pinctrl-0 = <&sdhc0_default>;
-		pinctrl-names = "default";
-		power-delay-ms = <100>;
 		max-bus-freq = <52000000>;
 		bus-width = <4>;
 


### PR DESCRIPTION
The ESP32-CAM board does not connect the SD card detect pin, so the SDHC0_CD_GPIO21 pinmux configuration has been removed. This commit also updates the status LED to use active-low polarity for correct operation.

<img width="177" height="83" alt="Screenshot from 2025-11-04 21-56-07" src="https://github.com/user-attachments/assets/ef8117ce-d6b7-4214-a286-9721514ad30a" />

<img width="309" height="181" alt="Screenshot from 2025-11-04 21-54-56" src="https://github.com/user-attachments/assets/66bae67c-978d-40ed-9c55-b8c4059d2148" />

Reference: https://i0.wp.com/randomnerdtutorials.com/wp-content/uploads/2020/03/ESP32-CAM-AI-Thinker-schematic-diagram.png?quality=100&strip=all&ssl=1

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99140