### PR TITLE
samples: drivers: adc: adc_sequence: remove stm32f3_disco from allow list

### DIFF
--- a/samples/drivers/adc/adc_sequence/sample.yaml
+++ b/samples/drivers/adc/adc_sequence/sample.yaml
@@ -27,7 +27,6 @@ tests:
       - ucans32k1sic
       - s32k148_evb
       - frdm_mcxc242
-      - stm32f3_disco
       - slwrb4180a
       - xg27_rb4194a
       - xg29_rb4412a


### PR DESCRIPTION
This change removes stm32f3 from the adc_sequence sample's allow list. 
The stm32f3_disco board requires an external ADC  `AD4114`  for the test to pass, which is not available in CI environments, leading to test failures.
As an alternative, a `fixture` could be added, but it's unclear whether this approach would be suitable across other vendor platforms.