### PR TITLE
net: lib: ocpp: fix misnamed State of Charge (SoC) measurand

### DIFF
--- a/subsys/net/lib/ocpp/core.c
+++ b/subsys/net/lib/ocpp/core.c
@@ -47,7 +47,7 @@ static struct {
 	FILL_METER_TABLE(OCPP_OMM_FAN_SPEED,
 			 "RPM", "rpm"),
 	FILL_METER_TABLE(OCPP_OMM_CHARGING_PERCENT,
-			 "SoCState", "Percent"),
+			 "SoC", "Percent"),
 	FILL_METER_TABLE(OCPP_OMM_TEMPERATURE,
 			 "Temperature", "Celsius"),
 	FILL_METER_TABLE(OCPP_OMM_VOLTAGE_AC_RMS,


### PR DESCRIPTION
As per OCPP 1.6, "State of charge of charging vehicle in percentage" is "Soc", not "SoCState".

Fixes: zephyrproject-rtos/zephyr#98870