### PR TITLE
cpu_load: rename conflicting API

### DIFF
--- a/include/zephyr/sys/cpu_load.h
+++ b/include/zephyr/sys/cpu_load.h
@@ -34,7 +34,7 @@ extern "C" {
  * @retval -errno code in case of failure.
  *
  */
-int cpu_load_get(int cpu_id);
+int cpu_load_metric_get(int cpu_id);
 
 /**
  * @}

--- a/lib/os/cpu_load/cpu_load.c
+++ b/lib/os/cpu_load/cpu_load.c
@@ -14,7 +14,7 @@ static uint64_t total_cycles_prev[CONFIG_MP_MAX_NUM_CPUS];
 
 static struct k_spinlock lock[CONFIG_MP_MAX_NUM_CPUS];
 
-int cpu_load_get(int cpu_id)
+int cpu_load_metric_get(int cpu_id)
 {
 	int ret;
 	int load;

--- a/samples/subsys/cpu_freq/on_demand/sample.yaml
+++ b/samples/subsys/cpu_freq/on_demand/sample.yaml
@@ -8,7 +8,7 @@ common:
     type: multi_line
     regex:
       - "^.*<inf> cpu_freq_sample: Starting CPU Freq Subsystem Sample!"
-      - "^.*<dbg> cpu_load_metric: cpu_load_get: CPU[0-9]+ Execution cycles: \
+      - "^.*<dbg> cpu_load_metric: cpu_load_metric_get: CPU[0-9]+ Execution cycles: \
          [0-9]+, Total cycles: [0-9]+"
       - "^.*<dbg> cpu_freq_policy_on_demand: cpu_freq_policy_select_pstate: \
          CPU[0-9]+ Load: [0-9]+%"

--- a/subsys/cpu_freq/policies/on_demand/on_demand.c
+++ b/subsys/cpu_freq/policies/on_demand/on_demand.c
@@ -53,7 +53,7 @@ int cpu_freq_policy_select_pstate(const struct pstate **pstate_out)
 	cpu_id = arch_curr_cpu()->id;
 #endif
 
-	cpu_load = cpu_load_get(cpu_id);
+	cpu_load = cpu_load_metric_get(cpu_id);
 	if (cpu_load < 0) {
 		LOG_ERR("Unable to retrieve CPU load");
 		return cpu_load;


### PR DESCRIPTION
We have two places defining cpu_load_get() and trying to the same thing,
one is a core kernel feature supported on all architecture, the other is
part of debug, requires tracing and supported only on a subset of
architectures. Both deliver different results and accuracy.

While we figure our how to merge those into one API and with the
advanatges of both, rename the API so there is no confusion about what
is being used.

Fixes #97845

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
