### PR TITLE
EDK sample fixes

### DIFF
--- a/samples/subsys/llext/edk/app/src/main.c
+++ b/samples/subsys/llext/edk/app/src/main.c
@@ -8,6 +8,7 @@
 #include <zephyr/app_memory/mem_domain.h>
 #include <zephyr/llext/llext.h>
 #include <zephyr/llext/buf_loader.h>
+#include <zephyr/sys/libc-hooks.h>
 
 #include <app_api.h>
 
@@ -160,6 +161,12 @@ int main(void)
 	k_mem_domain_init(&domain2, 0, NULL);
 	k_mem_domain_init(&domain3, 0, NULL);
 	k_mem_domain_init(&kdomain1, 0, NULL);
+
+#if Z_LIBC_PARTITION_EXISTS
+	k_mem_domain_add_partition(&domain1, &z_libc_partition);
+	k_mem_domain_add_partition(&domain2, &z_libc_partition);
+	k_mem_domain_add_partition(&domain3, &z_libc_partition);
+#endif
 
 #ifndef EDK_BUILD
 #ifndef CONFIG_LLEXT_EDK_USERSPACE_ONLY

--- a/samples/subsys/llext/edk/ext3/src/main.c
+++ b/samples/subsys/llext/edk/ext3/src/main.c
@@ -45,7 +45,6 @@ int start(void)
 
 	sub_stack = k_thread_stack_alloc(STACKSIZE, K_USER);
 	sub_thread = k_object_alloc(K_OBJ_THREAD);
-	printk("[ext3]%p - %p\n", sub_stack, sub_thread);
 	k_thread_create(sub_thread, sub_stack, STACKSIZE, tick_sub, NULL, NULL,
 			NULL, PRIORITY, K_INHERIT_PERMS | K_USER, K_NO_WAIT);
 


### PR DESCRIPTION
Add libc partition to extension memory domain - this way it should work on Cortex-M devices - tested on `frdm_mcxn947`. While at it, remove astray printk.

Note that to actually test this on `frdm_mcxn947` (or similar), one needs https://github.com/zephyrproject-rtos/zephyr/pull/98882.