### PR TITLE
test: ram_context_for_isr: exclude imx95 m7

### DIFF
--- a/tests/application_development/ram_context_for_isr/testcase.yaml
+++ b/tests/application_development/ram_context_for_isr/testcase.yaml
@@ -11,6 +11,8 @@ tests:
       - mps3/corstone310/fvp
       - mps4/corstone315/fvp
       - mps4/corstone320/fvp
+      - imx95_evk/mimx9596/m7
+      - imx95_evk/mimx9596/m7/ddr
       - imx943_evk/mimx94398/m33
       - imx943_evk/mimx94398/m33/ddr
       - frdm_mcxc444/mcxc444


### PR DESCRIPTION
i.MX95 M7 supports multi-level interrupt.
Current ram_context_for_isr test does not cover multi-level interrupt. So exclude i.MX95 M7.