### PR TITLE
Drivers: Uart: Fix missing extern "C" in uart_bridge.h

### DIFF
--- a/include/zephyr/drivers/uart/uart_bridge.h
+++ b/include/zephyr/drivers/uart/uart_bridge.h
@@ -6,6 +6,10 @@
 
 #include <zephyr/device.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Update the hardware port settings on a uart bridge
  *
@@ -17,3 +21,7 @@
  */
 void uart_bridge_settings_update(const struct device *dev,
 				 const struct device *bridge_dev);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
uart_bridge.h is missing extern "C", causing link errors for C++ files