### PR TITLE
llext: option to exclude all default exported symbols

### DIFF
--- a/doc/services/llext/config.rst
+++ b/doc/services/llext/config.rst
@@ -166,6 +166,18 @@ significant as the number of exported symbols increases.
            forbidden to load an extension that was compiled with
            ``CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=n``.
 
+Minimizing exporting symbols
+----------------------------
+
+To minimize the size of the exported symbol table, the main application can
+disable :kconfig:option:`CONFIG_LLEXT_EXPORT_DEFAULT_SYMBOLS`. This option
+causes :c:macro:`EXPORT_SYMBOL` and :c:macro:`EXPORT_SYMBOL_NAMED` to not
+export a symbol, which forces the symbol table to be empty by default.
+
+The main application is then responsible for explicitly exporting the symbols
+that are required by the extension with :c:macro:`EXPORT_APP_SYMBOL` and
+:c:macro:`EXPORT_APP_SYMBOL_NAMED`.
+
 EDK configuration
 -----------------
 

--- a/include/zephyr/llext/symbol.h
+++ b/include/zephyr/llext/symbol.h
@@ -161,13 +161,18 @@ struct llext_symtable {
  * Version of @ref EXPORT_SYMBOL that allows the user to specify a custom name
  * for the exported symbol.
  *
- * When @c CONFIG_LLEXT is not enabled, this macro is a no-op.
+ * When @c CONFIG_LLEXT or @c CONFIG_LLEXT_EXPORT_DEFAULT_SYMBOLS are not
+ * enabled, this macro is a no-op.
  *
  * @param sym_ident Symbol to export
  * @param sym_name Name associated with the symbol
  */
+#if defined(CONFIG_LLEXT_EXPORT_DEFAULT_SYMBOLS) || defined(LL_EXTENSION_BUILD)
 #define EXPORT_SYMBOL_NAMED(sym_ident, sym_name)				\
 	Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)
+#else
+#define EXPORT_SYMBOL_NAMED(sym_ident, sym_name)
+#endif
 
 /**
  * @brief Export a constant symbol from the current build
@@ -176,11 +181,38 @@ struct llext_symtable {
  * and address of the symbol to a table of symbols that may be referenced
  * by extensions or by the base image, depending on the current build type.
  *
- * When @c CONFIG_LLEXT is not enabled, this macro is a no-op.
+ * When @c CONFIG_LLEXT or @c CONFIG_LLEXT_EXPORT_DEFAULT_SYMBOLS are not
+ * enabled, this macro is a no-op.
  *
  * @param x Symbol to export
  */
 #define EXPORT_SYMBOL(x) EXPORT_SYMBOL_NAMED(x, x)
+
+/**
+ * @brief Export a constant symbol from the current build with a custom name
+ *
+ * Same behaviour as @ref  EXPORT_SYMBOL_NAMED, except the symbol is still
+ * included when @c CONFIG_LLEXT_EXPORT_DEFAULT_SYMBOLS is not enabled.
+ *
+ * @note This macro MUST NOT be used from common Zephyr code.
+ *
+ * @param sym_ident Symbol to export
+ * @param sym_name Name associated with the symbol
+ */
+#define EXPORT_APP_SYMBOL_NAMED(sym_ident, sym_name)				\
+	Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)
+
+/**
+ * @brief Export a constant symbol from the current build
+ *
+ * Same behaviour as @ref EXPORT_SYMBOL, except the symbol is still included
+ * when @c CONFIG_LLEXT_EXPORT_DEFAULT_SYMBOLS is not enabled.
+ *
+ * @note This macro MUST NOT be used from common Zephyr code.
+ *
+ * @param x Symbol to export
+ */
+#define EXPORT_APP_SYMBOL(x) EXPORT_APP_SYMBOL_NAMED(x, x)
 
 /**
  * @}

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -108,6 +108,14 @@ config LLEXT_STORAGE_WRITABLE
 	  Select if LLEXT storage is writable, i.e. if extensions are stored in
 	  RAM and can be modified in place
 
+config LLEXT_EXPORT_DEFAULT_SYMBOLS
+	bool "Export all symbols to llexts"
+	default y
+	help
+	  Export all symbols declared with EXPORT_SYMBOL and EXPORT_SYMBOL_NAMED to
+	  llexts. Disabling this option results in only symbols declared by the application
+	  with EXPORT_APP_SYMBOL and EXPORT_APP_SYMBOL_NAMED being available for linking.
+
 config LLEXT_EXPORT_DEVICES
 	bool "Export all DT devices to llexts"
 	help


### PR DESCRIPTION
Introduce a Kconfig option to exclude all symbols declared with `EXPORT_SYMBOL` or `EXPORT_SYMBOL_NAMED` from the application build. It is instead the applications responsibility to export exactly the symbols that it wants available for linking, done through two new macros, `EXPORT_APP_SYMBOL` and `EXPORT_APP_SYMBOL_NAMED`.

The reasoning behind this option is to reduce the size of the exported symbol array and speed up link times.
For one of my standard applications, a nRF54L15 connected to a LTE modem and running Bluetooth, enabling LLEXT increases the text size of the application from `548124` to `561828` bytes, over 13kB, from ~260 exported symbols (without `CONFIG_LLEXT_EXPORT_DEVICES`). This is obviously undesirable when it is known at development time that the extensions are going to be restricted to linking against a handful of symbols.

The names I've chosen (`LLEXT_EXPORT_DEFAULT_SYMBOLS`, `EXPORT_APP_SYMBOL`) probably aren't ideal, but the best I could come up with.