### PR TITLE
boards: nxp: frdm_mcxe31b: add zephyr,shell-uart node

### DIFF
--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
@@ -30,6 +30,7 @@
 		zephyr,flash = &program_flash;
 		zephyr,flash-controller = &flash;
 		zephyr,console = &lpuart_5;
+		zephyr,shell-uart = &lpuart_5;
 	};
 
 	leds {


### PR DESCRIPTION
Add missing zephyr,shell-uart device tree node to enable shell functionality.

Fixes #98307