### PR TITLE
tests: arm_irq_advanced_features: Use first-level IRQ for direct inte…

### DIFF
--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
@@ -10,7 +10,11 @@
 #include <zephyr/sys/barrier.h>
 
 /* Offset for the Direct interrupt used in this test. */
+#ifdef CONFIG_2ND_LVL_ISR_TBL_OFFSET
+#define DIRECT_ISR_OFFSET (CONFIG_2ND_LVL_ISR_TBL_OFFSET - 1)
+#else
 #define DIRECT_ISR_OFFSET (CONFIG_NUM_IRQS - 1)
+#endif
 
 static volatile int test_flag;
 


### PR DESCRIPTION
…rrupt test

CONFIG_NUM_IRQS - 1 may be a second-level interrupt number on platforms with multi-level interrupt support. Second-level interrupts cannot be used for direct ISR testing.

Use CONFIG_2ND_LVL_ISR_TBL_OFFSET - 1 when available to ensure we test with a first-level interrupt that supports direct ISR functionality.