### PR TITLE
can: mcux: flexcan: Add CAN FD support for MCXN SOC family

### DIFF
--- a/boards/nxp/frdm_mcxn236/board.c
+++ b/boards/nxp/frdm_mcxn236/board.c
@@ -211,8 +211,8 @@ void board_early_init_hook(void)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexcan1))
-	CLOCK_SetClkDiv(kCLOCK_DivFlexcan1Clk, 1U);
-	CLOCK_AttachClk(kFRO_HF_to_FLEXCAN1);
+	CLOCK_SetClkDiv(kCLOCK_DivFlexcan1Clk, 3U);
+	CLOCK_AttachClk(kPLL0_to_FLEXCAN1);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(vref))

--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -291,8 +291,8 @@ void board_early_init_hook(void)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexcan0))
-	CLOCK_SetClkDiv(kCLOCK_DivFlexcan0Clk, 1U);
-	CLOCK_AttachClk(kFRO_HF_to_FLEXCAN0);
+	CLOCK_SetClkDiv(kCLOCK_DivFlexcan0Clk, 3U);
+	CLOCK_AttachClk(kPLL0_to_FLEXCAN0);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usdhc0))

--- a/boards/nxp/mcx_nx4x_evk/board.c
+++ b/boards/nxp/mcx_nx4x_evk/board.c
@@ -286,8 +286,8 @@ void board_early_init_hook(void)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexcan0))
-	CLOCK_SetClkDiv(kCLOCK_DivFlexcan0Clk, 1U);
-	CLOCK_AttachClk(kFRO_HF_to_FLEXCAN0);
+	CLOCK_SetClkDiv(kCLOCK_DivFlexcan0Clk, 3U);
+	CLOCK_AttachClk(kPLL0_to_FLEXCAN0);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usdhc0))

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -918,24 +918,26 @@
 	};
 
 	flexcan0: can@d4000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0xd4000 0x4000>;
 		interrupts = <62 0>;
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 		clk-source = <0>;
 		number-of-mb = <32>;
+		number-of-mb-fd = <7>;
 		status = "disabled";
 	};
 
 	flexcan1: can@d8000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0xd8000 0x4000>;
 		interrupts = <63 0>;
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		clk-source = <0>;
 		number-of-mb = <32>;
+		number-of-mb-fd = <7>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -112,13 +112,14 @@
 	};
 
 	flexcan1: can@d8000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0xd8000 0x4000>;
 		interrupts = <63 0>;
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		clk-source = <0>;
 		number-of-mb = <32>;
+		number-of-mb-fd = <7>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -1072,13 +1072,14 @@
 	};
 
 	flexcan0: can@d4000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0xd4000 0x4000>;
 		interrupts = <62 0>;
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 		clk-source = <0>;
 		number-of-mb = <32>;
+		number-of-mb-fd = <7>;
 		status = "disabled";
 	};
 


### PR DESCRIPTION
Add CAN FD support for MCXN SOC family, including mcxn23x, mcxn94x and mcxn54x.
 
Update FlexCAN clock configuration across NXP MCXN family boards to use PLL0 as clock source with a divider of 3 instead of FRO_HF with divider of 1.

The new configuration provides FlexCAN peripherals by using the PLL0 output (150MHz) divided by 3 to achieve 50MHz, replace previous 48MHz FRO_HF.
 
Tested with tests/drivers/can.
 
Fixes #91138