### PR TITLE
dts: arm: silabs: Fix HFRCO configuration in open-loop mode

### DIFF
--- a/dts/arm/silabs/xg22/xg22.dtsi
+++ b/dts/arm/silabs/xg22/xg22.dtsi
@@ -214,7 +214,6 @@
 			reg = <0x50010000 0x4000>;
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(19)>;
-			clocks = <&cmu CLOCK_HFRCO0 CLOCK_BRANCH_INVALID>;
 			interrupt-names = "hfrco0";
 			interrupts = <45 2>;
 		};

--- a/dts/arm/silabs/xg23/xg23.dtsi
+++ b/dts/arm/silabs/xg23/xg23.dtsi
@@ -225,7 +225,6 @@
 			reg = <0x50010000 0x4000>;
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(19)>;
-			clocks = <&cmu CLOCK_HFRCO0 CLOCK_BRANCH_INVALID>;
 			interrupt-names = "hfrco0";
 			interrupts = <46 2>;
 		};

--- a/dts/arm/silabs/xg24/xg24.dtsi
+++ b/dts/arm/silabs/xg24/xg24.dtsi
@@ -219,7 +219,6 @@
 			reg = <0x50010000 0x4000>;
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(19)>;
-			clocks = <&cmu CLOCK_HFRCO0 CLOCK_BRANCH_INVALID>;
 			interrupt-names = "hfrco0";
 			interrupts = <45 2>;
 		};

--- a/dts/arm/silabs/xg26/xg26.dtsi
+++ b/dts/arm/silabs/xg26/xg26.dtsi
@@ -233,7 +233,6 @@
 			reg = <0x50010000 0x4000>;
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(19)>;
-			clocks = <&cmu CLOCK_HFRCO0 CLOCK_BRANCH_INVALID>;
 			interrupt-names = "hfrco0";
 			interrupts = <61 2>;
 		};

--- a/dts/arm/silabs/xg27/xg27.dtsi
+++ b/dts/arm/silabs/xg27/xg27.dtsi
@@ -214,7 +214,6 @@
 			reg = <0x50010000 0x4000>;
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(19)>;
-			clocks = <&cmu CLOCK_HFRCO0 CLOCK_BRANCH_INVALID>;
 			interrupt-names = "hfrco0";
 			interrupts = <51 2>;
 		};

--- a/dts/arm/silabs/xg28/xg28.dtsi
+++ b/dts/arm/silabs/xg28/xg28.dtsi
@@ -225,7 +225,6 @@
 			reg = <0x50010000 0x4000>;
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(19)>;
-			clocks = <&cmu CLOCK_HFRCO0 CLOCK_BRANCH_INVALID>;
 			interrupt-names = "hfrco0";
 			interrupts = <46 2>;
 		};

--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -219,7 +219,6 @@
 			reg = <0x50010000 0x4000>;
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(19)>;
-			clocks = <&cmu CLOCK_HFRCO0 CLOCK_BRANCH_INVALID>;
 			interrupt-names = "hfrco0";
 			interrupts = <51 2>;
 		};

--- a/modules/hal_silabs/simplicity_sdk/config/sl_clock_manager_oscillator_config.h
+++ b/modules/hal_silabs/simplicity_sdk/config/sl_clock_manager_oscillator_config.h
@@ -29,22 +29,7 @@
 	(DT_ENUM_IDX(DT_NODELABEL(lfxo), timeout) << _LFXO_CFG_TIMEOUT_SHIFT)
 
 /* HFRCODPLL */
-#define SL_CLOCK_MANAGER_HFRCO_BAND                                                                \
-	(DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 1500000    ? 1000000U                 \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 3000000  ? 2000000U                 \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 5500000  ? 4000000U                 \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 10000000 ? 7000000U                 \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 14500000 ? 13000000U                \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 17500000 ? 16000000U                \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 23000000 ? 19000000U                \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 29000000 ? 26000000U                \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 35000000 ? 32000000U                \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 44000000 ? 38000000U                \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 52000000 ? 48000000U                \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 60000000 ? 56000000U                \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 72000000 ? 64000000U                \
-	 : DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency) < 90000000 ? 80000000U                \
-									: 100000000U)
+#define SL_CLOCK_MANAGER_HFRCO_BAND    DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency)
 #define SL_CLOCK_MANAGER_HFRCO_DPLL_EN DT_NUM_CLOCKS(DT_NODELABEL(hfrcodpll))
 #define SL_CLOCK_MANAGER_DPLL_FREQ     DT_PROP(DT_NODELABEL(hfrcodpll), clock_frequency)
 #define SL_CLOCK_MANAGER_DPLL_N        DT_PROP(DT_NODELABEL(hfrcodpll), dpll_n)


### PR DESCRIPTION
This PR fixes two issues when using HFRCO in open-loop mode.

The CMU clock controller node for HFRCO was wrongly interpreted as a PLL reference clock. This prevented configuring the HFRCO in open-loop mode. Since the node isn't used for anything, remove it as a minimal stopgap solution.

Recent versions of the HAL rely on interpreting the HFRCO frequency selection as a plain integer in preprocessor comparisons. The adaptation layer in Zephyr created a C expression that was not possible to evaluate by the preprocessor. Simplify the logic to directly passing the devicetree value to the driver.

This slightly changes the behavior of the code by no longer accepting arbitrary frequencies and mapping them to the closest HFRCO band. However, the binding documentation already states that the frequency should match the band.

Fixes #98860 