### PR TITLE
soc/ite/it8xxx2: make ARCH_IRQ_VECTOR_TABLE_ALIGN constant

### DIFF
--- a/soc/ite/ec/it8xxx2/Kconfig
+++ b/soc/ite/ec/it8xxx2/Kconfig
@@ -187,6 +187,9 @@ config SOC_IT8XXX2_EXT_32K
 
 endchoice
 
+config ARCH_IRQ_VECTOR_TABLE_ALIGN
+	default 4
+
 config SOC_IT8XXX2_USE_ILM
 	bool
 	default y


### PR DESCRIPTION
The IQR vector table changed size since https://github.com/zephyrproject-rtos/zephyr/commit/a825e014d858eb2badd600da6f3163e413b6bf3f and it is
causing issues with downstream applications, for example,
data stored in bin specific field is shifted by
the ARCH_IRQ_VECTOR_TABLE_ALIGN, so I make
ARCH_IRQ_VECTOR_TABLE_ALIGN constant.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99000