### PR TITLE
soc: nordic: common: uicr: Get watchdog enable at boot config

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -334,6 +334,16 @@ zephyr_udc0: &usbhs {
 	status = "okay";
 };
 
+&wdt010 {
+	/*
+	 * Sets the UICR up to have this watchdog running by default without needing the
+	 * application to set it up and start it.
+	 * Note: This is for demo purposes only and should be set by applications (i.e. in the
+	 * watchdog sample as a board overlay).
+	 */
+	enable-at-boot;
+};
+
 /* Trim this RAM block for power management related features. */
 &cpuapp_ram0 {
 	reg = <0x22000000 (DT_SIZE_K(32) - 256)>;

--- a/dts/arm/nordic/nrf54h20_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpuapp.dtsi
@@ -18,7 +18,9 @@ cpuflpr_vevif: &cpuflpr_vevif_tx {};
 
 cpusys_vevif: &cpusys_vevif_tx {};
 
-wdt010: &cpuapp_wdt010 {};
+wdt010: &cpuapp_wdt010 {
+	compatible = "nordic,nrf-wdt-v2";
+};
 
 wdt011: &cpuapp_wdt011 {};
 

--- a/dts/bindings/watchdog/nordic,nrf-wdt-v2.yaml
+++ b/dts/bindings/watchdog/nordic,nrf-wdt-v2.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2018-2025, Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nordic nRF family WDT (Watchdog Timer version 2)
+
+compatible: "nordic,nrf-wdt-v2"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  enable-at-boot:
+    type: boolean
+    description: |
+      When enabled this property will configure the UICR to start the watchdog at device boot,
+      before the application has been booted.

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -19,6 +19,24 @@ find_package(Zephyr
 
 project(uicr)
 
+# Import the main application's DTS output for processing
+zephyr_get(default_image_dir SYSBUILD LOCAL)
+add_custom_target(default_image_devicetree_target)
+zephyr_dt_import(EDT_PICKLE_FILE ${default_image_dir}/zephyr/edt.pickle TARGET default_image_devicetree_target)
+
+# Method 1: Get alias first then property
+#dt_alias(watchdog_node PROPERTY watchdog0 TARGET default_image_devicetree_target)
+#dt_prop(watchdog_enable_at_boot PATH "${watchdog_node}" PROPERTY "enable-at-boot" TARGET default_image_devicetree_target)
+
+# Method 2: Get property directly from the alias
+dt_prop(watchdog_enable_at_boot PATH watchdog0 PROPERTY "enable-at-boot" TARGET default_image_devicetree_target)
+
+if(watchdog_enable_at_boot)
+  message(WARNING "UICR: Enable watchdog at boot")
+else()
+  message(WARNING "UICR: Do not enable watchdog at boot")
+endif()
+
 # Function to parse a Kconfig value from a .config file
 function(parse_kconfig_value config_file config_name output_var)
   file(STRINGS ${config_file} config_lines ENCODING "UTF-8")

--- a/soc/nordic/common/uicr/sysbuild.cmake
+++ b/soc/nordic/common/uicr/sysbuild.cmake
@@ -8,6 +8,7 @@ ExternalZephyrProject_Add(
 
 # Ensure UICR is configured and built after the default image so EDT/ELFs exist.
 sysbuild_add_dependencies(CONFIGURE uicr ${DEFAULT_IMAGE})
+sysbuild_cache_set(VAR uicr_default_image_dir ${APPLICATION_BINARY_DIR}/${DEFAULT_IMAGE})
 
 # Add build dependencies for all images whose ELF files may be used by gen_uicr.
 # The gen_uicr/CMakeLists.txt scans all sibling build directories and adds their


### PR DESCRIPTION
Demonstrates how the uicr CMake project can read this configuration in from the main application's devicetree file