### PR TITLE
boards: sifli: add sf32lb52_devkit_lcd revisions

### DIFF
--- a/boards/sifli/sf32lb52_devkit_lcd/board.cmake
+++ b/boards/sifli/sf32lb52_devkit_lcd/board.cmake
@@ -2,7 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # keep first
-board_runner_args(sftool "--chip=SF32LB52")
+set(sf32lb52_sftool_args "--chip=SF32LB52")
+
+if(DEFINED BOARD_REVISION)
+  if(BOARD_REVISION STREQUAL "n16r8")
+    list(APPEND sf32lb52_sftool_args "--tool-opt=--memory nor")
+  elseif(BOARD_REVISION STREQUAL "a128r8")
+    list(APPEND sf32lb52_sftool_args "--tool-opt=--memory nand")
+  endif()
+endif()
+
+board_runner_args(sftool ${sf32lb52_sftool_args})
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/sftool.board.cmake)

--- a/boards/sifli/sf32lb52_devkit_lcd/board.yml
+++ b/boards/sifli/sf32lb52_devkit_lcd/board.yml
@@ -5,5 +5,11 @@ board:
   name: sf32lb52_devkit_lcd
   full_name: SF32LB52-DevKit-LCD
   vendor: sifli
+  revision:
+    format: custom
+    default: "n16r8"
+    revisions:
+      - name: "n16r8"
+      - name: "a128r8"
   socs:
     - name: sf32lb525uc6

--- a/boards/sifli/sf32lb52_devkit_lcd/revision.cmake
+++ b/boards/sifli/sf32lb52_devkit_lcd/revision.cmake
@@ -1,0 +1,9 @@
+set(BOARD_REVISIONS "n16r8" "a128r8")
+
+if(NOT DEFINED BOARD_REVISION)
+  set(BOARD_REVISION "n16r8")
+else()
+  if(NOT BOARD_REVISION IN_LIST BOARD_REVISIONS)
+    message(FATAL_ERROR "${BOARD_REVISION} is not a valid revision for sf32lb52_devkit_lcd. Accepted revisions: ${BOARD_REVISIONS}")
+  endif()
+endif()


### PR DESCRIPTION
- declare n16r8 (default) and a128r8 revisions in board.yml
- add revision.cmake to validate BOARD_REVISION and keep n16r8 as fallback
