### PR TITLE
drivers: mm: Fix vm region range check

### DIFF
--- a/drivers/mm/mm_drv_common.c
+++ b/drivers/mm/mm_drv_common.c
@@ -38,7 +38,7 @@ int sys_mm_drv_map_region_safe(const struct sys_mm_drv_region *virtual_region,
 
 	/* check if memory to be mapped is within given virtual region */
 	if ((POINTER_TO_UINT(virt) >= virtual_region_start) &&
-	    (POINTER_TO_UINT(virt) + size < virtual_region_end)) {
+	    (POINTER_TO_UINT(virt) + size <= virtual_region_end)) {
 		return sys_mm_drv_map_region(virt, phys, size, flags);
 	}
 


### PR DESCRIPTION
Checking virtual range is incorrect because size + 1 addresses are considered: size + starting address (that is also part of an allocation). Hence the last address of the range is impossible to map

Note that this commit fixes one occurrence found during SOF memory stress tests. If you agree that this indeed is a bug, I recommend reviewing similar checks in other places.