### PR TITLE
drivers: promote APIs from unstable to stable

### DIFF
--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -18,7 +18,7 @@
  * @brief Interfaces for counters.
  * @defgroup counter_interface Counter
  * @since 1.14
- * @version 0.8.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -23,7 +23,7 @@ extern "C" {
  * @brief Interfaces for Digital-to-Analog Converters.
  * @defgroup dac_interface DAC
  * @since 2.3
- * @version 0.8.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -26,7 +26,7 @@
  * @brief Interfaces for MIPI-DBI (Display Bus Interface).
  * @defgroup mipi_dbi_interface MIPI-DBI
  * @since 3.6
- * @version 0.8.0
+ * @version 1.0.0
  * @ingroup display_interface
  * @{
  */

--- a/include/zephyr/drivers/mipi_dsi.h
+++ b/include/zephyr/drivers/mipi_dsi.h
@@ -17,7 +17,7 @@
  * @brief Interfaces for MIPI-DSI (Display Serial Interface).
  * @defgroup mipi_dsi_interface MIPI-DSI
  * @since 3.1
- * @version 0.8.0
+ * @version 1.0.0
  * @ingroup display_interface
  * @{
  */

--- a/include/zephyr/drivers/retained_mem.h
+++ b/include/zephyr/drivers/retained_mem.h
@@ -32,7 +32,7 @@ BUILD_ASSERT(!(sizeof(off_t) > sizeof(size_t)),
  * @brief Interfaces for retained memory.
  * @defgroup retained_mem_interface Retained memory
  * @since 3.4
- * @version 0.8.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -147,7 +147,7 @@ typedef void (*uart_irq_callback_user_data_t)(const struct device *dev,
  *
  * @defgroup uart_async Async UART API
  * @since 1.14
- * @version 0.8.0
+ * @version 1.0.0
  * @{
  */
 


### PR DESCRIPTION
Quite a few well established APIs are stuck in unstable status, move
them to stable.

This requires some review and agreement that listed APIs are ready to be promoted.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
