### PR TITLE
checkpatch: ignore COMPARISON_TO_NULL

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -29,3 +29,4 @@
 --ignore ENOSYS
 --ignore IS_ENABLED_CONFIG
 --ignore EXPORT_SYMBOL
+--ignore COMPARISON_TO_NULL


### PR DESCRIPTION
Ignore COMPARISON_TO_NULL since it conflicts with Zephyr coding guidelines main rule 85:
  The controlling expression of an if statement and the
  controlling expression of an iteration-statement shall have
  essentially Boolean type

Link: https://docs.zephyrproject.org/latest/contribute/coding_guidelines