### PR TITLE
bluetooth: mesh: Increase BT RX Stack Size for PB-GATT

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -111,6 +111,7 @@ config BT_RX_STACK_SIZE
 	int "Size of the receiving thread stack"
 	default 768 if BT_HCI_RAW
 	default 3092 if BT_MESH_GATT_CLIENT
+	default 2800 if BT_MESH_PB_GATT
 	default 2600 if BT_MESH
 	default 2048 if BT_AUDIO
 	default 1200


### PR DESCRIPTION
Increase BT RX Thread Stack Size which is needed for successfull provisioning over PB-GATT.

Output from `kernel thread stacks` shell command:
```
BT RX WQ (real size 4096): unused 1408 usage 2688 / 4096 (65 %)
```

Fixes #98521