### PR TITLE
manifest: Update hal_renesas revision for smartbond

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -226,7 +226,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: 62136a8ff8a2e644b72f0dc902d33b397991cace
+      revision: a279c14e196cb0904593035888a334dcd2c720bd
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
hal/renesas was updated with fix for the case when watchdog was unnecessary disabled after deep sleep.

Related PR: https://github.com/zephyrproject-rtos/hal_renesas/pull/166

This should be testable by **samples/drivers/watchdog**
Before fix test printed
```
*** Booting Zephyr OS build v4.3.0-rc2-78-g80be486c8779 ***
Watchdog sample application
Attempting to test pre-reset callback
Callback support rejected, continuing anyway
Feeding watchdog 5 times
Feeding watchdog...
Feeding watchdog...
Feeding watchdog...
Feeding watchdog...
Feeding watchdog...
Waiting for reset...
```
but it never did reset

