### PR TITLE
boards: stm32: stm32n6570_dk:  Reduce the Tx clock signal skew

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -445,7 +445,7 @@ zephyr_udc0: &usbotg_hs1 {
  */
 &eth1_rgmii_gtx_clk_pf0 {
 	st,io-delay-path = "output";
-	st,io-delay-ps = <2000>;
+	st,io-delay-ps = <1000>;
 };
 
 &mac {


### PR DESCRIPTION
Reduce the Tx clock signal skew to 1ns as the previous value (2ns) caused ping packet loss on some board of the series.

Fixes: #98977 