### PR TITLE
drivers: i2s: stm32: replace UTIL_AND() with IF_ENABLED + clean macros indentation

### DIFF
--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -936,73 +936,74 @@ static const struct device *get_dev_from_tx_dma_channel(uint32_t dma_channel)
 }
 
 /* src_dev and dest_dev should be 'MEMORY' or 'PERIPHERAL'. */
-#define I2S_DMA_CHANNEL_INIT(index, dir, dir_cap, src_dev, dest_dev)	\
-.dir = {								\
-	.dev_dma = DEVICE_DT_GET(STM32_DMA_CTLR(index, dir)),		\
-	.dma_channel = DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),	\
-	.dma_cfg = {							\
-		.block_count = 2,					\
-		.dma_slot = STM32_DMA_SLOT(index, dir, slot),\
-		.channel_direction = src_dev##_TO_##dest_dev,		\
-		.source_data_size = 2,  /* 16bit default */		\
-		.dest_data_size = 2,    /* 16bit default */		\
-		.source_burst_length = 1, /* SINGLE transfer */		\
-		.dest_burst_length = 1,					\
-		.channel_priority = STM32_DMA_CONFIG_PRIORITY(		\
-					STM32_DMA_CHANNEL_CONFIG(index, dir)),\
-		.dma_callback = dma_##dir##_callback,			\
-	},								\
-	.src_addr_increment = STM32_DMA_CONFIG_##src_dev##_ADDR_INC(	\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
-	.dst_addr_increment = STM32_DMA_CONFIG_##dest_dev##_ADDR_INC(	\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
-	.fifo_threshold = STM32_DMA_FEATURES_FIFO_THRESHOLD(		\
-				STM32_DMA_FEATURES(index, dir)),	\
-	.stream_start = dir##_stream_start,				\
-	.stream_disable = dir##_stream_disable,				\
-	.msgq = &dir##_##index##_queue,		\
-}
+#define I2S_DMA_CHANNEL_INIT(index, dir, dir_cap, src_dev, dest_dev)		\
+	.dir = {								\
+		.dev_dma = DEVICE_DT_GET(STM32_DMA_CTLR(index, dir)),		\
+		.dma_channel = DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),	\
+		.dma_cfg = {							\
+			.block_count = 2,					\
+			.dma_slot = STM32_DMA_SLOT(index, dir, slot),		\
+			.channel_direction = src_dev##_TO_##dest_dev,		\
+			.source_data_size = 2,  /* 16bit default */		\
+			.dest_data_size = 2,    /* 16bit default */		\
+			.source_burst_length = 1, /* SINGLE transfer */		\
+			.dest_burst_length = 1,					\
+			.channel_priority = STM32_DMA_CONFIG_PRIORITY(		\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),		\
+			.dma_callback = dma_##dir##_callback,			\
+		},								\
+		.src_addr_increment = STM32_DMA_CONFIG_##src_dev##_ADDR_INC(	\
+					STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
+		.dst_addr_increment = STM32_DMA_CONFIG_##dest_dev##_ADDR_INC(	\
+					STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
+		.fifo_threshold = STM32_DMA_FEATURES_FIFO_THRESHOLD(		\
+					STM32_DMA_FEATURES(index, dir)),	\
+		.stream_start = dir##_stream_start,				\
+		.stream_disable = dir##_stream_disable,				\
+		.msgq = &dir##_##index##_queue,					\
+	}
 
 #define I2S_STM32_INIT(index)							\
-									\
-static void i2s_stm32_irq_config_func_##index(const struct device *dev);\
-									\
-PINCTRL_DT_INST_DEFINE(index);						\
-									\
-static const struct stm32_pclken clk_##index[] =			\
-				 STM32_DT_INST_CLOCKS(index);		\
-									\
-static const struct i2s_stm32_cfg i2s_stm32_config_##index = {		\
-	.i2s = (SPI_TypeDef *)DT_INST_REG_ADDR(index),			\
-	.pclken = clk_##index,						\
-	.pclk_len = DT_INST_NUM_CLOCKS(index),				\
-	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
-	.irq_config = i2s_stm32_irq_config_func_##index,		\
-	.master_clk_sel = DT_INST_PROP(index, mck_enabled),		\
-	.ioswp = DT_INST_PROP(index, ioswp),				\
-};									\
-									\
-K_MSGQ_DEFINE(rx_##index##_queue, sizeof(struct queue_item), CONFIG_I2S_STM32_RX_BLOCK_COUNT, 4);\
-K_MSGQ_DEFINE(tx_##index##_queue, sizeof(struct queue_item), CONFIG_I2S_STM32_TX_BLOCK_COUNT, 4);\
-									\
-static struct i2s_stm32_data i2s_stm32_data_##index = {			\
-	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),			\
-		   (I2S_DMA_CHANNEL_INIT(index, rx, RX, PERIPHERAL, MEMORY))),\
-	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),			\
-		   (I2S_DMA_CHANNEL_INIT(index, tx, TX, MEMORY, PERIPHERAL))),\
-};									\
-DEVICE_DT_INST_DEFINE(index,						\
-		      &i2s_stm32_initialize, NULL,			\
-		      &i2s_stm32_data_##index,				\
-		      &i2s_stm32_config_##index, POST_KERNEL,		\
-		      CONFIG_I2S_INIT_PRIORITY, &i2s_stm32_driver_api);	\
-									\
-static void i2s_stm32_irq_config_func_##index(const struct device *dev)	\
-{									\
-	IRQ_CONNECT(DT_INST_IRQN(index),				\
-		    DT_INST_IRQ(index, priority),			\
-		    i2s_stm32_isr, DEVICE_DT_INST_GET(index), 0);	\
-	irq_enable(DT_INST_IRQN(index));				\
-}
+										\
+	static void i2s_stm32_irq_config_func_##index(const struct device *dev);\
+										\
+	PINCTRL_DT_INST_DEFINE(index);						\
+										\
+	static const struct stm32_pclken clk_##index[] = STM32_DT_INST_CLOCKS(index); \
+										\
+	static const struct i2s_stm32_cfg i2s_stm32_config_##index = {		\
+		.i2s = (SPI_TypeDef *)DT_INST_REG_ADDR(index),			\
+		.pclken = clk_##index,						\
+		.pclk_len = DT_INST_NUM_CLOCKS(index),				\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
+		.irq_config = i2s_stm32_irq_config_func_##index,		\
+		.master_clk_sel = DT_INST_PROP(index, mck_enabled),		\
+		.ioswp = DT_INST_PROP(index, ioswp),				\
+	};									\
+										\
+	K_MSGQ_DEFINE(rx_##index##_queue, sizeof(struct queue_item),		\
+		      CONFIG_I2S_STM32_RX_BLOCK_COUNT, 4);			\
+	K_MSGQ_DEFINE(tx_##index##_queue, sizeof(struct queue_item),		\
+		      CONFIG_I2S_STM32_TX_BLOCK_COUNT, 4);			\
+										\
+	static struct i2s_stm32_data i2s_stm32_data_##index = {			\
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),			\
+			   (I2S_DMA_CHANNEL_INIT(index, rx, RX, PERIPHERAL, MEMORY))),\
+		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),			\
+			   (I2S_DMA_CHANNEL_INIT(index, tx, TX, MEMORY, PERIPHERAL))),\
+	};									\
+	DEVICE_DT_INST_DEFINE(index,						\
+			      &i2s_stm32_initialize, NULL,			\
+			      &i2s_stm32_data_##index,				\
+			      &i2s_stm32_config_##index, POST_KERNEL,		\
+			      CONFIG_I2S_INIT_PRIORITY, &i2s_stm32_driver_api);	\
+										\
+	static void i2s_stm32_irq_config_func_##index(const struct device *dev)	\
+	{									\
+		IRQ_CONNECT(DT_INST_IRQN(index),				\
+			    DT_INST_IRQ(index, priority),			\
+			    i2s_stm32_isr, DEVICE_DT_INST_GET(index), 0);	\
+		irq_enable(DT_INST_IRQN(index));				\
+	}
 
 DT_INST_FOREACH_STATUS_OKAY(I2S_STM32_INIT)

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -986,10 +986,10 @@ K_MSGQ_DEFINE(rx_##index##_queue, sizeof(struct queue_item), CONFIG_I2S_STM32_RX
 K_MSGQ_DEFINE(tx_##index##_queue, sizeof(struct queue_item), CONFIG_I2S_STM32_TX_BLOCK_COUNT, 4);\
 									\
 static struct i2s_stm32_data i2s_stm32_data_##index = {			\
-	UTIL_AND(DT_INST_DMAS_HAS_NAME(index, rx),			\
-		I2S_DMA_CHANNEL_INIT(index, rx, RX, PERIPHERAL, MEMORY)),\
-	UTIL_AND(DT_INST_DMAS_HAS_NAME(index, tx),			\
-		I2S_DMA_CHANNEL_INIT(index, tx, TX, MEMORY, PERIPHERAL)),\
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),			\
+		   (I2S_DMA_CHANNEL_INIT(index, rx, RX, PERIPHERAL, MEMORY))),\
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, tx),			\
+		   (I2S_DMA_CHANNEL_INIT(index, tx, TX, MEMORY, PERIPHERAL))),\
 };									\
 DEVICE_DT_INST_DEFINE(index,						\
 		      &i2s_stm32_initialize, NULL,			\

--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -815,12 +815,11 @@ static DEVICE_API(i2s, i2s_stm32_driver_api) = {
 		.dma_channel = DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                     \
 		.reg = (DMA_TypeDef *)DT_REG_ADDR(                                                 \
 			DT_PHANDLE_BY_NAME(DT_DRV_INST(index), dmas, dir)),                        \
-		.dma_cfg =                                                                         \
-			{                                                                          \
-				.dma_slot = STM32_DMA_SLOT(index, dir, slot),                      \
-				.channel_direction = src_dev##_TO_##dest_dev,                      \
-				.dma_callback = dma_callback,                                      \
-			},                                                                         \
+		.dma_cfg = {                                                                       \
+			.dma_slot = STM32_DMA_SLOT(index, dir, slot),                              \
+			.channel_direction = src_dev##_TO_##dest_dev,                              \
+			.dma_callback = dma_callback,                                              \
+		},                                                                                 \
 		.stream_start = stream_start,                                                      \
 		.queue_drop = queue_drop,                                                          \
 	}
@@ -832,18 +831,18 @@ static DEVICE_API(i2s, i2s_stm32_driver_api) = {
 	static const struct stm32_pclken clk_##index[] = STM32_DT_INST_CLOCKS(index);              \
                                                                                                    \
 	struct i2s_stm32_sai_data sai_data_##index = {                                             \
-		.hsai =                                                                            \
-			{                                                                          \
-				.Instance = (SAI_Block_TypeDef *)DT_INST_REG_ADDR(index),          \
-				.Init.OutputDrive = SAI_OUTPUTDRIVE_DISABLE,                       \
-				.Init.FIFOThreshold = SAI_FIFOTHRESHOLD_FULL,                      \
-				.Init.SynchroExt = SAI_SYNCEXT_DISABLE,                            \
-				.Init.CompandingMode = SAI_NOCOMPANDING,                           \
-				.Init.TriState = SAI_OUTPUT_NOTRELEASED,                           \
-			},                                                                         \
-		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                                     \
-			(SAI_DMA_CHANNEL_INIT(index, tx, MEMORY, PERIPHERAL)),                  \
-		(SAI_DMA_CHANNEL_INIT(index, rx, PERIPHERAL, MEMORY)))};                     \
+		.hsai = {                                                                          \
+			.Instance = (SAI_Block_TypeDef *)DT_INST_REG_ADDR(index),                  \
+			.Init.OutputDrive = SAI_OUTPUTDRIVE_DISABLE,                               \
+			.Init.FIFOThreshold = SAI_FIFOTHRESHOLD_FULL,                              \
+			.Init.SynchroExt = SAI_SYNCEXT_DISABLE,                                    \
+			.Init.CompandingMode = SAI_NOCOMPANDING,                                   \
+			.Init.TriState = SAI_OUTPUT_NOTRELEASED,                                   \
+		},                                                                                 \
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, tx),                                      \
+			    (SAI_DMA_CHANNEL_INIT(index, tx, MEMORY, PERIPHERAL)),                 \
+			    (SAI_DMA_CHANNEL_INIT(index, rx, PERIPHERAL, MEMORY))),                \
+	};                                                                                         \
                                                                                                    \
 	struct i2s_stm32_sai_cfg sai_config_##index = {                                            \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                   \


### PR DESCRIPTION
Replace uses of `UTIL_AND()` with `IF_ENABLED()` that is far more readable when initializing or not a structure instance.

By the way, clean indentation in macros used to define I2S instances resources.