### PR TITLE
tests: driver: flash: Increase the single I/O test transfer timeout

### DIFF
--- a/tests/drivers/flash/common/boards/mx25uw63_single_io.overlay
+++ b/tests/drivers/flash/common/boards/mx25uw63_single_io.overlay
@@ -58,5 +58,5 @@
 	status = "okay";
 	mspi-max-frequency = <DT_FREQ_M(50)>;
 	mspi-io-mode = "MSPI_IO_MODE_SINGLE";
-	transfer-timeout = <500>;
+	transfer-timeout = <1000>;
 };

--- a/tests/drivers/flash/common/boards/mx25uw63_single_io_4B_addr_sreset.overlay
+++ b/tests/drivers/flash/common/boards/mx25uw63_single_io_4B_addr_sreset.overlay
@@ -60,5 +60,5 @@
 	mspi-io-mode = "MSPI_IO_MODE_SINGLE";
 	use-4byte-addressing;
 	initial-soft-reset;
-	transfer-timeout = <500>;
+	transfer-timeout = <1000>;
 };


### PR DESCRIPTION
Increase the allowed transfer timeout for the signel I/O test.