### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 96576b341ee19f1c3af6622256b0d4f3d408e1e3
+      revision: f3cc9476e233364031e9ab842290392f260fba82
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  f3cc9476e233364031e9ab842290392f260fba82

Brings following Zephyr relevant fixes:

  - f3cc9476 updates for 2.3.0-rc1 release
  - 496f74f3 zephyr: Fix BOOT_DOWNGRADE_PREVENTION_CHOICE symbol
  - 6ab9afc6 boot_serial: Use boot_state_init where intent to initialize
  - e6fefac2 bootutil: Temporarly drop mem cleanup from boot_state_clear
  - 457be0cf bootutil: Fix some debug log format specifiers
  - f9ad3ee2 bootutil: Add API to lock HW counter
  - 6e602004 boot: bootutil: bootutil_area: Add debug for adjusted offset
  - 9d334f9b boot: bootutil: bootutil_area: Fix swap using offset min scramble
  - 76036133 boot: zephyr: Remove enable from beginning of prompts
  - d14ba22d bootutil: Fix encryption context de initialization in boot_state_clear
  - d8c4cc69 bootutil: Remove NULL state logic from boot_state_clear
  - 8ff6b678 bootutil: Use boot_state_init instead of boot_state_clear
  - dd4b01f4 boot_serial: Initialize state with boot_state_init
  - a312656b bootutil: Add boot_loader_state_init
  - e9255183 bootutil: Allow using psa_key_id_t in AES crypto context
  - 3af40a31 boot: zephyr: sysflash: Increase number of supported images
  - c27bb0f4 boot_serial: Use struct enc_data in decrypt_region_inplace
  - 0287fd4d boot_serial: Fix double boot_loader_state init
  - f846e9e9 boot: zephyr: Allow disabling default multiple RAM region file
  - 0ccce2f7 bootutil: In boot_swap_image add return check from boot_read_enc_key
  - 32b3c18b bootutil: Refactor boot_read_enc_key

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.