### PR TITLE
dts: arm: st: u0: deprecate sram0 node label

### DIFF
--- a/boards/st/nucleo_u031r8/nucleo_u031r8.dts
+++ b/boards/st/nucleo_u031r8/nucleo_u031r8.dts
@@ -20,7 +20,7 @@
 	chosen {
 		zephyr,console = &usart2;
 		zephyr,shell-uart = &usart2;
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram1;
 		zephyr,flash = &flash0;
 	};
 

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.dts
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.dts
@@ -20,7 +20,7 @@
 	chosen {
 		zephyr,console = &usart2;
 		zephyr,shell-uart = &usart2;
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram1;
 		zephyr,flash = &flash0;
 	};
 

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -21,7 +21,7 @@
 	chosen {
 		zephyr,console = &usart2;
 		zephyr,shell-uart = &usart2;
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram1;
 		zephyr,flash = &flash0;
 	};
 

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -34,6 +34,10 @@ Kernel
 Boards
 ******
 
+* Node label ``sram0`` is deprecated in STM32U0xx SoCs in favor to label ``sram1`` that better
+  match the wording used to refer to this internal memory in the SoCs reference manuals and
+  litterature. The label is still defined but will be removed in the future.
+
 Device Drivers and Devicetree
 *****************************
 

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -59,9 +59,14 @@
 		};
 	};
 
-	sram0: memory@20000000 {
+	sram1: memory@20000000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		zephyr,memory-region = "SRAM0";
+		zephyr,memory-region = "SRAM1";
+	};
+
+	sram2: memory@20080000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		zephyr,memory-region = "SRAM2";
 	};
 
 	clocks {
@@ -602,3 +607,6 @@
 &nvic {
 	arm,num-irq-priority-bits = <2>;
 };
+
+/* Define deprecated sram0 node label for compatibility until it is removed */
+sram0: &sram1 {};

--- a/dts/arm/st/u0/stm32u031X4.dtsi
+++ b/dts/arm/st/u0/stm32u031X4.dtsi
@@ -6,14 +6,8 @@
 
 #include <st/u0/stm32u031.dtsi>
 
-/ {
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(16)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(16)>;
 };
 
 &sram1 {

--- a/dts/arm/st/u0/stm32u031X4.dtsi
+++ b/dts/arm/st/u0/stm32u031X4.dtsi
@@ -7,18 +7,6 @@
 #include <st/u0/stm32u031.dtsi>
 
 / {
-	sram1: memory@20000000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20000000 DT_SIZE_K(8)>;
-		zephyr,memory-region = "SRAM1";
-	};
-
-	sram2: memory@20080000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20080000 DT_SIZE_K(4)>;
-		zephyr,memory-region = "SRAM2";
-	};
-
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
@@ -26,4 +14,12 @@
 			};
 		};
 	};
+};
+
+&sram1 {
+	reg = <0x20000000 DT_SIZE_K(8)>;
+};
+
+&sram2 {
+	reg = <0x20080000 DT_SIZE_K(4)>;
 };

--- a/dts/arm/st/u0/stm32u031X6.dtsi
+++ b/dts/arm/st/u0/stm32u031X6.dtsi
@@ -6,14 +6,8 @@
 
 #include <st/u0/stm32u031.dtsi>
 
-/ {
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(32)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(32)>;
 };
 
 &sram1 {

--- a/dts/arm/st/u0/stm32u031X6.dtsi
+++ b/dts/arm/st/u0/stm32u031X6.dtsi
@@ -7,18 +7,6 @@
 #include <st/u0/stm32u031.dtsi>
 
 / {
-	sram1: memory@20000000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20000000 DT_SIZE_K(8)>;
-		zephyr,memory-region = "SRAM1";
-	};
-
-	sram2: memory@20080000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20080000 DT_SIZE_K(4)>;
-		zephyr,memory-region = "SRAM2";
-	};
-
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
@@ -26,4 +14,12 @@
 			};
 		};
 	};
+};
+
+&sram1 {
+	reg = <0x20000000 DT_SIZE_K(8)>;
+};
+
+&sram2 {
+	reg = <0x20080000 DT_SIZE_K(4)>;
 };

--- a/dts/arm/st/u0/stm32u031X8.dtsi
+++ b/dts/arm/st/u0/stm32u031X8.dtsi
@@ -6,14 +6,8 @@
 
 #include <st/u0/stm32u031.dtsi>
 
-/ {
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(64)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(64)>;
 };
 
 &sram1 {

--- a/dts/arm/st/u0/stm32u031X8.dtsi
+++ b/dts/arm/st/u0/stm32u031X8.dtsi
@@ -7,18 +7,6 @@
 #include <st/u0/stm32u031.dtsi>
 
 / {
-	sram1: memory@20000000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20000000 DT_SIZE_K(8)>;
-		zephyr,memory-region = "SRAM1";
-	};
-
-	sram2: memory@20080000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20080000 DT_SIZE_K(4)>;
-		zephyr,memory-region = "SRAM2";
-	};
-
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
@@ -26,4 +14,12 @@
 			};
 		};
 	};
+};
+
+&sram1 {
+	reg = <0x20000000 DT_SIZE_K(8)>;
+};
+
+&sram2 {
+	reg = <0x20080000 DT_SIZE_K(4)>;
 };

--- a/dts/arm/st/u0/stm32u073.dtsi
+++ b/dts/arm/st/u0/stm32u073.dtsi
@@ -72,16 +72,6 @@
 		};
 	};
 
-	sram1: memory@20000000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		zephyr,memory-region = "SRAM1";
-	};
-
-	sram2: memory@20008000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		zephyr,memory-region = "SRAM2";
-	};
-
 	usb_fs_phy: usbphy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;

--- a/dts/arm/st/u0/stm32u073X8.dtsi
+++ b/dts/arm/st/u0/stm32u073X8.dtsi
@@ -5,14 +5,8 @@
  */
 #include <st/u0/stm32u073.dtsi>
 
-/ {
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(64)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(64)>;
 };
 
 &sram1 {

--- a/dts/arm/st/u0/stm32u073X8.dtsi
+++ b/dts/arm/st/u0/stm32u073X8.dtsi
@@ -6,14 +6,6 @@
 #include <st/u0/stm32u073.dtsi>
 
 / {
-	sram1: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(32)>;
-	};
-
-	sram2: memory@20008000 {
-		reg = <0x20008000 DT_SIZE_K(8)>;
-	};
-
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
@@ -21,4 +13,12 @@
 			};
 		};
 	};
+};
+
+&sram1 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
+};
+
+&sram2 {
+	reg = <0x20080000 DT_SIZE_K(8)>;
 };

--- a/dts/arm/st/u0/stm32u073Xb.dtsi
+++ b/dts/arm/st/u0/stm32u073Xb.dtsi
@@ -5,14 +5,8 @@
  */
 #include <st/u0/stm32u073.dtsi>
 
-/ {
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(128)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(128)>;
 };
 
 &sram1 {

--- a/dts/arm/st/u0/stm32u073Xb.dtsi
+++ b/dts/arm/st/u0/stm32u073Xb.dtsi
@@ -6,14 +6,6 @@
 #include <st/u0/stm32u073.dtsi>
 
 / {
-	sram1: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(32)>;
-	};
-
-	sram2: memory@20008000 {
-		reg = <0x20008000 DT_SIZE_K(8)>;
-	};
-
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
@@ -21,4 +13,12 @@
 			};
 		};
 	};
+};
+
+&sram1 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
+};
+
+&sram2 {
+	reg = <0x20080000 DT_SIZE_K(8)>;
 };

--- a/dts/arm/st/u0/stm32u073Xc.dtsi
+++ b/dts/arm/st/u0/stm32u073Xc.dtsi
@@ -6,14 +6,6 @@
 #include <st/u0/stm32u073.dtsi>
 
 / {
-	sram1: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(32)>;
-	};
-
-	sram2: memory@20008000 {
-		reg = <0x20008000 DT_SIZE_K(8)>;
-	};
-
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
@@ -21,4 +13,12 @@
 			};
 		};
 	};
+};
+
+&sram1 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
+};
+
+&sram2 {
+	reg = <0x20080000 DT_SIZE_K(8)>;
 };

--- a/dts/arm/st/u0/stm32u073Xc.dtsi
+++ b/dts/arm/st/u0/stm32u073Xc.dtsi
@@ -5,14 +5,8 @@
  */
 #include <st/u0/stm32u073.dtsi>
 
-/ {
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(256)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(256)>;
 };
 
 &sram1 {

--- a/dts/arm/st/u0/stm32u083Xc.dtsi
+++ b/dts/arm/st/u0/stm32u083Xc.dtsi
@@ -5,14 +5,8 @@
  */
 #include <st/u0/stm32u083.dtsi>
 
-/ {
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(256)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(256)>;
 };
 
 &sram1 {

--- a/dts/arm/st/u0/stm32u083Xc.dtsi
+++ b/dts/arm/st/u0/stm32u083Xc.dtsi
@@ -6,18 +6,6 @@
 #include <st/u0/stm32u083.dtsi>
 
 / {
-	sram1: memory@20000000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20000000 DT_SIZE_K(32)>;
-		zephyr,memory-region = "SRAM1";
-	};
-
-	sram2: memory@20008000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20008000 DT_SIZE_K(8)>;
-		zephyr,memory-region = "SRAM2";
-	};
-
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
@@ -25,4 +13,12 @@
 			};
 		};
 	};
+};
+
+&sram1 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
+};
+
+&sram2 {
+	reg = <0x20080000 DT_SIZE_K(8)>;
 };


### PR DESCRIPTION
Deprecate sram0 node label from STM32U0xx SoC series DTSI files since it duplicates existing sram1 label that better matches SoCs reference manual wording. Update board DTSI files accordingly.

This prevents confusion for 2 nodes labels defining the same RAM but defined at different places.

Factorize definitions of `sram0` node (embedded SRAM1) and `sram2` node (embedded SRAM2) in STM32U0xx SoCs series. U031xx all have 8kB of SRAM1 and 4kB of SRAM2. U073xx and U083xx all have 32kB of SRAM1 and 8kB of SRAM2.

