### PR TITLE
Bluetooth: Controller: Various fixes for CIS termination handling

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -459,6 +459,12 @@ static MFIFO_DEFINE(pdu_rx_free, sizeof(void *), PDU_RX_CNT);
 #define BT_CTLR_SCAN_SYNC_ISO_SET 0
 #endif
 
+#if defined(CONFIG_BT_CTLR_CONN_ISO_STREAMS)
+#define BT_CTLR_CONN_ISO_STREAMS CONFIG_BT_CTLR_CONN_ISO_STREAMS
+#else
+#define BT_CTLR_CONN_ISO_STREAMS 0
+#endif
+
 #define PDU_RX_POOL_SIZE (PDU_RX_NODE_POOL_ELEMENT_SIZE * \
 			  (RX_CNT + BT_CTLR_MAX_CONNECTABLE + \
 			   BT_CTLR_ADV_SET + BT_CTLR_SCAN_SYNC_SET))
@@ -508,7 +514,7 @@ static struct {
 	(sizeof(memq_link_t) *                                                 \
 	 (RX_CNT + 2 + BT_CTLR_MAX_CONN + BT_CTLR_ADV_SET +                    \
 	  (BT_CTLR_ADV_ISO_SET * 2) + (BT_CTLR_SCAN_SYNC_SET * 2) +            \
-	  (BT_CTLR_SCAN_SYNC_ISO_SET * 2) +                                    \
+	  (BT_CTLR_SCAN_SYNC_ISO_SET * 2) + BT_CTLR_CONN_ISO_STREAMS +         \
 	  (IQ_REPORT_CNT)))
 static struct {
 	uint16_t quota_pdu; /* Number of un-utilized buffers */
@@ -1726,8 +1732,8 @@ void ll_rx_mem_release(void **node_rx)
 
 				ll_conn_release(conn);
 			} else if (IS_CIS_HANDLE(rx_free->hdr.handle)) {
-				ll_rx_link_quota_inc();
-				ll_rx_release(rx_free);
+				/* Notify ull_conn_iso */
+				ull_conn_iso_cis_terminate_done(rx_free);
 			}
 		}
 		break;

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -559,7 +559,7 @@ uint8_t ll_enc_req_send(uint16_t handle, uint8_t const *const rand_num,
 #if defined(CONFIG_BT_CTLR_CENTRAL_ISO)
 	struct ll_conn_iso_stream *cis = ll_conn_iso_stream_get_by_acl(conn, NULL);
 
-	if (cis || ull_lp_cc_is_enqueued(conn)) {
+	if (cis || ull_lp_cc_is_enqueued(conn, NULL)) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 #endif /* CONFIG_BT_CTLR_CENTRAL_ISO */

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso_internal.h
@@ -19,3 +19,4 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 			      uint32_t *cis_offset_max,
 			      uint16_t *conn_event_count,
 			      uint8_t  *access_addr);
+bool ull_central_iso_all_cises_terminated(struct ll_conn_iso_group *cig);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_internal.h
@@ -40,6 +40,7 @@ void ull_conn_iso_start(struct ll_conn *acl, uint16_t cis_handle,
 			uint32_t ticks_at_expire, uint32_t remainder,
 			uint16_t instant_latency);
 void ull_conn_iso_done(struct node_rx_event_done *done);
+void ull_conn_iso_cis_terminate_done(struct node_rx_pdu *rx);
 void ull_conn_iso_cis_stop(struct ll_conn_iso_stream *cis,
 			   ll_iso_stream_released_cb_t cis_released_cb,
 			   uint8_t reason);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -51,6 +51,17 @@ struct ll_conn_iso_stream {
 #if defined(CONFIG_BT_CTLR_ISOAL_PSN_IGNORE)
 	uint64_t pkt_seq_num:39;
 #endif /* CONFIG_BT_CTLR_ISOAL_PSN_IGNORE */
+
+	/* node rx type with dummy uint8_t to ensure room for terminate
+	 * reason.
+	 * HCI will reference the value using the pdu member of
+	 * struct node_rx_pdu.
+	 */
+	struct {
+		struct node_rx_pdu rx;
+		/* Dummy declaration to ensure space allocated to hold one pdu byte */
+		uint8_t dummy_reason;
+	} node_rx_terminate;
 };
 
 struct ll_conn_iso_group {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -202,7 +202,7 @@ bool ull_cp_cc_awaiting_established(struct ll_conn *conn);
 /**
  * @brief Cancel ongoing create cis procedure
  */
-bool ull_cp_cc_cancel(struct ll_conn *conn);
+bool ull_cp_cc_cancel(struct ll_conn *conn, const struct ll_conn_iso_stream *cis);
 
 /**
  * @brief Get handle of ongoing create cis procedure.
@@ -226,14 +226,25 @@ void ull_cp_cc_reject(struct ll_conn *conn, uint8_t error_code);
 void ull_cp_cc_established(struct ll_conn *conn, uint8_t error_code);
 
 /**
+ * @brief ACL disconnect.
+ */
+void ull_cp_cc_acl_disconnect(struct ll_conn *conn);
+
+/**
  * @brief CIS creation ongoing.
+ */
+bool ull_cp_cc_is_active(struct ll_conn *conn);
+
+/**
+ * @brief Local CIS creation ongoing.
  */
 bool ull_lp_cc_is_active(struct ll_conn *conn);
 
 /**
- * @brief CIS creation ongoing or enqueued.
+ * @brief CIS creation ongoing or enqueued. If cis is NULL, it will return true if
+ *        any CIS Create is enqueued, otherwise it will look for the cis specified
  */
-bool ull_lp_cc_is_enqueued(struct ll_conn *conn);
+bool ull_lp_cc_is_enqueued(struct ll_conn *conn, const struct ll_conn_iso_stream *cis);
 
 /**
  * @brief Initiate a Channel Map Update Procedure.

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -126,6 +126,9 @@ enum {
 	/* Established */
 	RP_CC_EVT_CIS_ESTABLISHED,
 
+	/* Corresponding ACL disconnected */
+	RP_CC_EVT_ACL_DISCONNECT,
+
 	/* Unknown response received */
 	RP_CC_EVT_UNKNOWN,
 };
@@ -261,21 +264,8 @@ static void rp_cc_send_reject_ind(struct ll_conn *conn, struct proc_ctx *ctx, ui
 	if (llcp_rr_ispaused(conn) || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = RP_CC_STATE_WAIT_TX_REJECT_IND;
 	} else {
-		/* Allocate TX node to use, store in case we need to wait for NTF node */
+		/* Allocate TX node */
 		ctx->node_ref.tx = llcp_tx_alloc(conn, ctx);
-		if (ctx->data.cis_create.error == BT_HCI_ERR_CONN_ACCEPT_TIMEOUT) {
-			/* We complete with error, so we must generate NTF, thus we must make sure
-			 * we have a node to use for NTF before TX'ing
-			 */
-			if (!llcp_ntf_alloc_is_available()) {
-				ctx->state = RP_CC_STATE_WAIT_NTF_AVAIL;
-				return;
-			}
-			ctx->node_ref.rx = llcp_ntf_alloc();
-
-			/* Mark node as RETAIN to trigger put/sched */
-			ctx->node_ref.rx->hdr.type = NODE_RX_TYPE_RETAIN;
-		}
 
 		llcp_rp_cc_tx_reject(conn, ctx, PDU_DATA_LLCTRL_TYPE_CIS_REQ);
 
@@ -283,7 +273,8 @@ static void rp_cc_send_reject_ind(struct ll_conn *conn, struct proc_ctx *ctx, ui
 			/* We reject due to an accept timeout, so we should generate NTF */
 			rp_cc_complete(conn, ctx, evt, param);
 		} else {
-			/* Otherwise we quietly complete the procedure */
+			/* Otherwise we quietly complete the procedure and release the ntf node */
+			llcp_rx_node_release(ctx);
 			llcp_rr_complete(conn);
 			ctx->state = RP_CC_STATE_IDLE;
 		}
@@ -426,9 +417,20 @@ static void rp_cc_state_wait_rx_cis_req(struct ll_conn *conn, struct proc_ctx *c
 		}
 
 		if (ctx->data.cis_create.error == BT_HCI_ERR_SUCCESS) {
-			/* Now controller accepts, so go ask the host to accept or decline */
-			rp_cc_ntf_create(conn, ctx);
-			ctx->state = RP_CC_STATE_WAIT_REPLY;
+			/* Now controller accepts, so go ask the host to accept or decline
+			 * Ensure we have a notification node for CIS established event to handle
+			 * a disconnect first
+			 */
+			if (llcp_ntf_alloc_is_available()) {
+				rp_cc_ntf_create(conn, ctx);
+				ctx->node_ref.rx = llcp_ntf_alloc();
+				ctx->node_ref.rx->hdr.type = NODE_RX_TYPE_RETAIN;
+				ctx->state = RP_CC_STATE_WAIT_REPLY;
+			} else {
+				/* Retain rx node and wait until a ntf node is available */
+				llcp_rx_node_retain(ctx);
+				ctx->state = RP_CC_STATE_WAIT_NTF_AVAIL;
+			}
 		} else {
 			/* Now controller rejects, right out */
 			rp_cc_send_reject_ind(conn, ctx, evt, param);
@@ -446,6 +448,10 @@ static void rp_cc_state_wait_tx_cis_rsp(struct ll_conn *conn, struct proc_ctx *c
 	switch (evt) {
 	case RP_CC_EVT_RUN:
 		rp_cc_send_cis_rsp(conn, ctx, evt, param);
+		break;
+	case RP_CC_EVT_ACL_DISCONNECT:
+		/* Complete procedure now, generating a CIS Established event (with an error) */
+		rp_cc_complete(conn, ctx, evt, param);
 		break;
 	default:
 		/* Ignore other evts */
@@ -481,9 +487,6 @@ static void rp_cc_state_wait_rx_cis_ind(struct ll_conn *conn, struct proc_ctx *c
 			/* CIS has been setup, go wait for 'instant' before starting */
 			ctx->state = RP_CC_STATE_WAIT_INSTANT;
 
-			/* Mark node as RETAIN to keep until we need for NTF */
-			llcp_rx_node_retain(ctx);
-
 			/* Check if this connection event is where we need to start the CIS */
 			rp_cc_check_instant_rx_cis_ind(conn, ctx, evt, param);
 			break;
@@ -493,6 +496,12 @@ static void rp_cc_state_wait_rx_cis_ind(struct ll_conn *conn, struct proc_ctx *c
 		LL_ASSERT_DBG(0);
 	case RP_CC_EVT_REJECT:
 		/* Handle CIS creation rejection */
+		ctx->data.cis_create.error = BT_HCI_ERR_REMOTE_USER_TERM_CONN;
+		rp_cc_complete(conn, ctx, evt, param);
+		break;
+	case RP_CC_EVT_ACL_DISCONNECT:
+		/* Complete procedure now, generating a CIS Established event (with an error) */
+		rp_cc_complete(conn, ctx, evt, param);
 		break;
 
 	default:
@@ -507,13 +516,13 @@ static void rp_cc_state_wait_ntf_avail(struct ll_conn *conn, struct proc_ctx *ct
 	switch (evt) {
 	case RP_CC_EVT_RUN:
 		if (llcp_ntf_alloc_is_available()) {
+			/* Node available, we can now continue asking the host */
+			rp_cc_ntf_create(conn, ctx);
+
 			ctx->node_ref.rx = llcp_ntf_alloc();
 			/* Mark node as RETAIN to trigger put/sched */
 			ctx->node_ref.rx->hdr.type = NODE_RX_TYPE_RETAIN;
-
-			/* Now we're good to TX reject and complete procedure*/
-			llcp_rp_cc_tx_reject(conn, ctx, PDU_DATA_LLCTRL_TYPE_CIS_REQ);
-			rp_cc_complete(conn, ctx, evt, param);
+			ctx->state = RP_CC_STATE_WAIT_REPLY;
 		}
 		break;
 	default:
@@ -602,6 +611,10 @@ static void rp_cc_state_wait_instant(struct ll_conn *conn, struct proc_ctx *ctx,
 	case RP_CC_EVT_RUN:
 		rp_cc_check_instant(conn, ctx, evt, param);
 		break;
+	case RP_CC_EVT_ACL_DISCONNECT:
+		/* Complete procedure now, generating a CIS Established event (with an error) */
+		rp_cc_complete(conn, ctx, evt, param);
+		break;
 	default:
 		/* Ignore other evts */
 		break;
@@ -613,6 +626,7 @@ static void rp_cc_state_wait_cis_established(struct ll_conn *conn, struct proc_c
 					     uint8_t evt, void *param)
 {
 	switch (evt) {
+	case RP_CC_EVT_ACL_DISCONNECT:
 	case RP_CC_EVT_CIS_ESTABLISHED:
 		rp_cc_complete(conn, ctx, evt, param);
 		break;
@@ -710,6 +724,11 @@ void llcp_rp_cc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
 	rp_cc_execute_fsm(conn, ctx, RP_CC_EVT_RUN, param);
 }
 
+bool llcp_rp_cc_is_active(const struct proc_ctx *ctx)
+{
+	return ctx->state != RP_CC_STATE_IDLE;
+}
+
 bool llcp_rp_cc_awaiting_instant(struct proc_ctx *ctx)
 {
 	return (ctx->state == RP_CC_STATE_WAIT_INSTANT);
@@ -718,6 +737,11 @@ bool llcp_rp_cc_awaiting_instant(struct proc_ctx *ctx)
 void llcp_rp_cc_established(struct ll_conn *conn, struct proc_ctx *ctx)
 {
 	rp_cc_execute_fsm(conn, ctx, RP_CC_EVT_CIS_ESTABLISHED, NULL);
+}
+
+void llcp_rp_cc_acl_disconnect(struct ll_conn *conn, struct proc_ctx *ctx)
+{
+	rp_cc_execute_fsm(conn, ctx, RP_CC_EVT_ACL_DISCONNECT, NULL);
 }
 #endif /* CONFIG_BT_PERIPHERAL */
 
@@ -755,6 +779,9 @@ enum {
 
 	/* CIS established */
 	LP_CC_EVT_ESTABLISHED,
+
+	/* Corresponding ACL disconnected */
+	LP_CC_EVT_ACL_DISCONNECT,
 
 	/* Unknown response received */
 	LP_CC_EVT_UNKNOWN,
@@ -818,8 +845,26 @@ void llcp_lp_cc_offset_calc_reply(struct ll_conn *conn, struct proc_ctx *ctx)
 	lp_cc_execute_fsm(conn, ctx, LP_CC_EVT_OFFSET_CALC_REPLY, NULL);
 }
 
-static void lp_cc_offset_calc_req(struct ll_conn *conn, struct proc_ctx *ctx,
-				  uint8_t evt, void *param)
+void llcp_lp_cc_flush(struct ll_conn *conn, struct proc_ctx *ctx)
+{
+	/* Flushing queued procedure; CIS Create always has to result in a
+	 * corresponding HCI_LE_CIS_Established event, so generate that now
+	 */
+	if (ctx->data.cis_create.error == BT_HCI_ERR_SUCCESS) {
+		ctx->data.cis_create.error = BT_HCI_ERR_CONN_FAIL_TO_ESTAB;
+	}
+
+	/* FIXME - we currently have no way to recover if we cannot allocate a node here */
+	ctx->node_ref.rx = llcp_ntf_alloc();
+	LL_ASSERT_ERR(ctx->node_ref.rx);
+
+	/* Mark node as RETAIN to trigger put/sched */
+	ctx->node_ref.rx->hdr.type = NODE_RX_TYPE_RETAIN;
+
+	cc_ntf_established(conn, ctx);
+}
+
+static void lp_cc_offset_calc_req(struct ll_conn *conn, struct proc_ctx *ctx)
 {
 	if (llcp_lr_ispaused(conn) || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = LP_CC_STATE_WAIT_OFFSET_CALC_TX_REQ;
@@ -844,13 +889,46 @@ static void lp_cc_offset_calc_req(struct ll_conn *conn, struct proc_ctx *ctx,
 	}
 }
 
+static void lp_cc_complete(struct ll_conn *conn, struct proc_ctx *ctx)
+{
+	cc_ntf_established(conn, ctx);
+	llcp_lr_complete(conn);
+	ctx->state = LP_CC_STATE_IDLE;
+}
+
+static void lp_cc_initial_checks(struct ll_conn *conn, struct proc_ctx *ctx)
+{
+	ctx->node_ref.rx = llcp_ntf_alloc();
+	/* Mark node as RETAIN to trigger put/sched */
+	ctx->node_ref.rx->hdr.type = NODE_RX_TYPE_RETAIN;
+
+	/* In case feature exchange completed after CIS create was enqueued
+	 * peer CIS peripheral support should be confirmed
+	 */
+	if (!feature_peer_iso_peripheral(conn)) {
+		/* Peer doesn't support CIS Peripheral so report unsupported */
+		ctx->data.cis_create.error = BT_HCI_ERR_UNSUPP_REMOTE_FEATURE;
+	}
+
+	if (ctx->data.cis_create.error != BT_HCI_ERR_SUCCESS) {
+		/* Error encountered while waiting in queue or for node, complete procedure */
+		lp_cc_complete(conn, ctx);
+	} else {
+		lp_cc_offset_calc_req(conn, ctx);
+	}
+}
+
 static void lp_cc_st_wait_offset_calc_tx_req(struct ll_conn *conn,
 					     struct proc_ctx *ctx,
 					     uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LP_CC_EVT_RUN:
-		lp_cc_offset_calc_req(conn, ctx, evt, param);
+		lp_cc_offset_calc_req(conn, ctx);
+		break;
+	case LP_CC_EVT_ACL_DISCONNECT:
+		/* Complete procedure and notify with the given error */
+		lp_cc_complete(conn, ctx);
 		break;
 	default:
 		/* Ignore other evts */
@@ -870,6 +948,10 @@ static void lp_cc_st_wait_offset_calc(struct ll_conn *conn,
 		break;
 	case LP_CC_EVT_OFFSET_CALC_REPLY:
 		ctx->state = LP_CC_STATE_WAIT_TX_CIS_REQ;
+		break;
+	case LP_CC_EVT_ACL_DISCONNECT:
+		/* Complete procedure and notify with the given error */
+		lp_cc_complete(conn, ctx);
 		break;
 	default:
 		/* Ignore other evts */
@@ -897,40 +979,25 @@ static void lp_cc_st_wait_tx_cis_req(struct ll_conn *conn, struct proc_ctx *ctx,
 	case LP_CC_EVT_RUN:
 		lp_cc_send_cis_req(conn, ctx, evt, param);
 		break;
+	case LP_CC_EVT_ACL_DISCONNECT:
+		/* Complete procedure and notify with the given error */
+		lp_cc_complete(conn, ctx);
+		break;
 	default:
 		/* Ignore other evts */
 		break;
 	}
 }
 
-static void lp_cc_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
-{
-	cc_ntf_established(conn, ctx);
-	llcp_lr_complete(conn);
-	ctx->state = LP_CC_STATE_IDLE;
-}
-
 static void lp_cc_st_idle(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (evt) {
 	case LP_CC_EVT_RUN:
-		switch (ctx->proc) {
-		case PROC_CIS_CREATE:
-			/* In case feature exchange completed after CIS create was enqueued
-			 * peer CIS peripheral support should be confirmed
-			 */
-			if (feature_peer_iso_peripheral(conn)) {
-				lp_cc_offset_calc_req(conn, ctx, evt, param);
-			} else {
-				/* Peer doesn't support CIS Peripheral so report unsupported */
-				ctx->data.cis_create.error = BT_HCI_ERR_UNSUPP_REMOTE_FEATURE;
-				ctx->state = LP_CC_STATE_WAIT_NTF_AVAIL;
-			}
-			break;
-		default:
-			/* Unknown procedure */
-			LL_ASSERT_DBG(0);
-			break;
+		/* Before proceeding, ensure that we have a node for host notification */
+		if (llcp_ntf_alloc_is_available()) {
+			lp_cc_initial_checks(conn, ctx);
+		} else {
+			ctx->state = LP_CC_STATE_WAIT_NTF_AVAIL;
 		}
 		break;
 	default:
@@ -945,12 +1012,8 @@ static void lp_cc_state_wait_ntf_avail(struct ll_conn *conn, struct proc_ctx *ct
 	switch (evt) {
 	case LP_CC_EVT_RUN:
 		if (llcp_ntf_alloc_is_available()) {
-			ctx->node_ref.rx = llcp_ntf_alloc();
-			/* Mark node as RETAIN to trigger put/sched */
-			ctx->node_ref.rx->hdr.type = NODE_RX_TYPE_RETAIN;
-
-			/* Now we're good to complete procedure*/
-			lp_cc_complete(conn, ctx, evt, param);
+			/* Now we're good to proceed with procedure */
+			lp_cc_initial_checks(conn, ctx);
 		}
 		break;
 	default:
@@ -998,16 +1061,13 @@ static void lp_cc_st_wait_rx_cis_rsp(struct ll_conn *conn, struct proc_ctx *ctx,
 		/* TODO: Reject response if outside offset range? */
 		llcp_pdu_decode_cis_rsp(ctx, param);
 
-		/* Mark RX node to NOT release */
-		llcp_rx_node_retain(ctx);
-
 		lp_cc_send_cis_ind(conn, ctx, evt, param);
 		break;
 	case LP_CC_EVT_UNKNOWN:
 		/* Unsupported in peer, so disable locally for this connection */
 		feature_unmask_peer_features(conn, LL_FEAT_BIT_CIS_PERIPHERAL);
 		ctx->data.cis_create.error = BT_HCI_ERR_UNSUPP_REMOTE_FEATURE;
-		lp_cc_complete(conn, ctx, evt, param);
+		lp_cc_complete(conn, ctx);
 		break;
 	case LP_CC_EVT_REJECT:
 		if (pdu->llctrl.reject_ext_ind.error_code == BT_HCI_ERR_UNSUPP_REMOTE_FEATURE) {
@@ -1015,7 +1075,11 @@ static void lp_cc_st_wait_rx_cis_rsp(struct ll_conn *conn, struct proc_ctx *ctx,
 			feature_unmask_peer_features(conn, LL_FEAT_BIT_CIS_PERIPHERAL);
 		}
 		ctx->data.cis_create.error = pdu->llctrl.reject_ext_ind.error_code;
-		lp_cc_complete(conn, ctx, evt, param);
+		lp_cc_complete(conn, ctx);
+		break;
+	case LP_CC_EVT_ACL_DISCONNECT:
+		/* Complete procedure and notify with the given error */
+		lp_cc_complete(conn, ctx);
 		break;
 	default:
 		/* Ignore other evts */
@@ -1028,14 +1092,14 @@ static void lp_cc_st_wait_notify_cancel(struct ll_conn *conn, struct proc_ctx *c
 {
 	switch (evt) {
 	case LP_CC_EVT_RUN:
-		if (llcp_ntf_alloc_is_available()) {
+		if (ctx->node_ref.rx == NULL && llcp_ntf_alloc_is_available()) {
 			ctx->node_ref.rx = llcp_ntf_alloc();
 
 			/* Mark node as RETAIN to trigger put/sched */
 			ctx->node_ref.rx->hdr.type = NODE_RX_TYPE_RETAIN;
-			ctx->state = LP_CC_STATE_WAIT_ESTABLISHED;
-
-			llcp_lp_cc_established(conn, ctx);
+		}
+		if (ctx->node_ref.rx != NULL) {
+			lp_cc_complete(conn, ctx);
 		}
 		break;
 	default:
@@ -1064,11 +1128,12 @@ static void lp_cc_st_wait_rx_cis_rsp_cancel(struct ll_conn *conn, struct proc_ct
 
 		/* Enqueue LL Control PDU towards LLL */
 		llcp_tx_enqueue(conn, tx);
-		lp_cc_complete(conn, ctx, evt, param);
+		lp_cc_complete(conn, ctx);
 		break;
 	case LP_CC_EVT_UNKNOWN:
+	case LP_CC_EVT_ACL_DISCONNECT:
 	case LP_CC_EVT_REJECT:
-		lp_cc_complete(conn, ctx, evt, param);
+		lp_cc_complete(conn, ctx);
 		break;
 	default:
 		/* Ignore other evts */
@@ -1082,6 +1147,10 @@ static void lp_cc_st_wait_tx_cis_ind(struct ll_conn *conn, struct proc_ctx *ctx,
 	switch (evt) {
 	case LP_CC_EVT_RUN:
 		lp_cc_send_cis_ind(conn, ctx, evt, param);
+		break;
+	case LP_CC_EVT_ACL_DISCONNECT:
+		/* Complete procedure and notify with the given error */
+		lp_cc_complete(conn, ctx);
 		break;
 	default:
 		/* Ignore other evts */
@@ -1119,6 +1188,11 @@ static void lp_cc_st_wait_instant(struct ll_conn *conn, struct proc_ctx *ctx, ui
 	case LP_CC_EVT_RUN:
 		lp_cc_check_instant(conn, ctx, evt, param);
 		break;
+	case LP_CC_EVT_ACL_DISCONNECT:
+	case LP_CC_EVT_ESTABLISHED:
+		/* Handle establishment error */
+		lp_cc_complete(conn, ctx);
+		break;
 	default:
 		/* Ignore other evts */
 		break;
@@ -1129,9 +1203,10 @@ static void lp_cc_st_wait_established(struct ll_conn *conn, struct proc_ctx *ctx
 				      void *param)
 {
 	switch (evt) {
+	case LP_CC_EVT_ACL_DISCONNECT:
 	case LP_CC_EVT_ESTABLISHED:
-		/* CIS was established, so let's go ahead and complete procedure */
-		lp_cc_complete(conn, ctx, evt, param);
+		/* CIS was established or connection lost, so complete procedure */
+		lp_cc_complete(conn, ctx);
 		break;
 	default:
 		/* Ignore other evts */
@@ -1202,12 +1277,18 @@ void llcp_lp_cc_established(struct ll_conn *conn, struct proc_ctx *ctx)
 	lp_cc_execute_fsm(conn, ctx, LP_CC_EVT_ESTABLISHED, NULL);
 }
 
+void llcp_lp_cc_acl_disconnect(struct ll_conn *conn, struct proc_ctx *ctx)
+{
+	lp_cc_execute_fsm(conn, ctx, LP_CC_EVT_ACL_DISCONNECT, NULL);
+}
+
 bool llcp_lp_cc_cancel(struct ll_conn *conn, struct proc_ctx *ctx)
 {
 	ctx->data.cis_create.error = BT_HCI_ERR_OP_CANCELLED_BY_HOST;
 
 	switch (ctx->state) {
 	case LP_CC_STATE_IDLE:
+	case LP_CC_STATE_WAIT_NTF_AVAIL:
 	case LP_CC_STATE_WAIT_OFFSET_CALC:
 	case LP_CC_STATE_WAIT_OFFSET_CALC_TX_REQ:
 	case LP_CC_STATE_WAIT_TX_CIS_REQ:

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -565,6 +565,7 @@ void llcp_pdu_decode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
  */
 struct proc_ctx *llcp_lr_peek(struct ll_conn *conn);
 struct proc_ctx *llcp_lr_peek_proc(struct ll_conn *conn, uint8_t proc);
+struct proc_ctx *llcp_lr_peek_cc(struct ll_conn *conn, uint16_t cc_handle);
 bool llcp_lr_ispaused(struct ll_conn *conn);
 void llcp_lr_pause(struct ll_conn *conn);
 void llcp_lr_resume(struct ll_conn *conn);
@@ -774,17 +775,21 @@ void llcp_lp_cc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 bool llcp_lp_cc_is_active(struct proc_ctx *ctx);
 bool llcp_lp_cc_awaiting_established(struct proc_ctx *ctx);
 void llcp_lp_cc_established(struct ll_conn *conn, struct proc_ctx *ctx);
+void llcp_lp_cc_acl_disconnect(struct ll_conn *conn, struct proc_ctx *ctx);
 bool llcp_lp_cc_cancel(struct ll_conn *conn, struct proc_ctx *ctx);
+void llcp_lp_cc_flush(struct ll_conn *conn, struct proc_ctx *ctx);
 
 void llcp_rp_cc_init_proc(struct proc_ctx *ctx);
 void llcp_rp_cc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
 void llcp_rp_cc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
+bool llcp_rp_cc_is_active(const struct proc_ctx *ctx);
 bool llcp_rp_cc_awaiting_reply(struct proc_ctx *ctx);
 bool llcp_rp_cc_awaiting_established(struct proc_ctx *ctx);
 void llcp_rp_cc_accept(struct ll_conn *conn, struct proc_ctx *ctx);
 void llcp_rp_cc_reject(struct ll_conn *conn, struct proc_ctx *ctx);
 bool llcp_rp_cc_awaiting_instant(struct proc_ctx *ctx);
 void llcp_rp_cc_established(struct ll_conn *conn, struct proc_ctx *ctx);
+void llcp_rp_cc_acl_disconnect(struct ll_conn *conn, struct proc_ctx *ctx);
 
 void llcp_pdu_decode_cis_req(struct proc_ctx *ctx, struct pdu_data *pdu);
 void llcp_pdu_encode_cis_rsp(struct proc_ctx *ctx, struct pdu_data *pdu);

--- a/tests/bluetooth/controller/mock_ctrl/CMakeLists.txt
+++ b/tests/bluetooth/controller/mock_ctrl/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(mocks STATIC
   src/ull_peripheral.c
   src/ull_peripheral_iso.c
   src/ull_central.c
+  src/ull_central_iso.c
   src/ull_scan.c
   src/ull_sync.c
   src/ull_adv_sync.c

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_central_iso.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_central_iso.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Demant
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/kernel.h>
+
+#include "hal/ccm.h"
+
+#include "util/mem.h"
+#include "util/memq.h"
+
+#include "isoal.h"
+#include "ull_iso_types.h"
+#include "lll.h"
+#include "lll_conn_iso.h"
+#include "ull_conn_iso_types.h"
+
+bool ull_central_iso_all_cises_terminated(struct ll_conn_iso_group *cig)
+{
+	return true;
+}

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_conn_iso.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_conn_iso.c
@@ -90,3 +90,18 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 {
 
 }
+
+uint8_t ll_remove_iso_path(uint16_t handle, uint8_t path_dir)
+{
+	return 0;
+}
+
+void ll_conn_iso_stream_release(struct ll_conn_iso_stream *cis)
+{
+
+}
+
+void ll_conn_iso_group_release(struct ll_conn_iso_group *cig)
+{
+
+}


### PR DESCRIPTION
Handling of CIS termination had several issues, most notably:

- it depended on allocating a termination node from the general rx node pool, causing asserts if the pool was exhausted
- CIS established events was not always generated when required, potentially causing CIS Centrals to get stuck without being able to create any new CISes
- Cancelling a CIS Create procedure only worked correctly if the CIS Create was currently active and happened to belong to the same CIS
- CIG state handling often (always?) assumed a CIG with only one CIS

ll_conn_iso_stream now has a dedicated termination node, same as ll_conn and ll_sync_iso_set

LLCP statemachine for Cis Create procedure has been reworked to ensure a notification node for CIS Established is available as early as possible. In addition, it should now always be sent when needed

Introduced ull_central_iso_all_cises_terminated() to check if all CISes in a CIG has been terminated (or not created yet) - which is now used for updating the CIG state

ull_cp_cc_cancel() now takes the CIS to cancel as an argument so it doesn't end up canceling an entirely different CIS Create procedure; In addition it now works for queued procedures as well

Flushing a (central) CIS Create procedure in LLCP will now properly generate a CIS Established event (with an error)

Fixes #59173