### PR TITLE
boards: stm32n6570_dk: Remove invert-y property from LVGL pointer input

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -36,7 +36,6 @@
 		compatible = "zephyr,lvgl-pointer-input";
 		input = <&gt911>;
 		display = <&ltdc>;
-		invert-y;
 	};
 
 	psram: memory@90000000 {


### PR DESCRIPTION
Removed the invert-y property from the LVGL pointer input configuration as it's causing the touch events to be "flipped" vertically.

Confirmed that this gets `samples/subsys/display/lvgl` back to correctly detecting touch events, and for good measure tested `samples/subsys/input/draw_touch_events` which keeps working as expected (like it should since it's not using the LVGL pointer input ;-))

Fixes zephyrproject-rtos/zephyr#98933