### PR TITLE
twister: Fix serial open for software devices that do not immediately appear

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from queue import Empty, Queue
 
 import psutil
+from serial.tools import list_ports
 from twisterlib.environment import ZEPHYR_BASE, strip_ansi_sequences
 from twisterlib.error import TwisterException
 from twisterlib.platform import Platform
@@ -851,6 +852,10 @@ class DeviceHandler(Handler):
                     # Return to normal boot
                     ser.rts = False
                 else:
+                    while ser.port not in (p.name for p in list_ports.comports()):
+                        time.sleep(0.1)
+                        if time.time() - start_time > flash_timeout:
+                            break
                     ser.open()
 
             except serial.SerialException as e:


### PR DESCRIPTION

* Testing on linux, --flash-before argument did not work to wait for jlink upload to complete. Instead Serial port opening throws file not found.
* The fix ensures that the code waits for the serial port to appear before attempting to connect.