### PR TITLE
drivers: spi_mcux_flexcomm: Fix multiple regressions

### DIFF
--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -648,8 +648,7 @@ static int spi_mcux_transfer_one_word(const struct device *dev, const struct spi
 	tmp32 = base->FIFORD;
 
 	/* copy to user buffer if given one */
-	if (ctx->rx_len) {
-		assert(ctx->rx_buf);
+	if (ctx->rx_len > 0 && ctx->rx_buf != NULL) {
 		ctx->rx_buf[0] = (uint8_t)tmp32;
 		if (data->word_size_bits > 8) {
 			ctx->rx_buf[1] = (uint8_t)(tmp32 >> 8);

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -673,6 +673,12 @@ static int transceive_dma(const struct device *dev,
 
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
 
+	if (spi_context_total_tx_len(&data->ctx) == 0 &&
+	    spi_context_total_rx_len(&data->ctx) == 0) {
+		/* nothing to do */
+		goto out;
+	}
+
 	if ((data->ctx.tx_count + data->ctx.rx_count) == 0) {
 		/* no data to transfer */
 		ret = 0;


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/98292 and multiple other regressions which were covered up by that failure. Including fixing buffer overread where data not owned by spi buffers or related to SPI was being clocked out to SPI bus due to faulty logic mixing up units of length between bytes and words.