### PR TITLE
Smf/add vlad kulikov maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4775,10 +4775,10 @@ State machine framework:
   status: maintained
   maintainers:
     - sambhurst
+    - vlad-kulikov
   collaborators:
     - keith-zephyr
     - glenn-andrews
-    - vlad-kulikov
   files:
     - doc/services/smf/
     - include/zephyr/smf.h


### PR DESCRIPTION
This is a follow-up to @keith-zephyr’s note that SMF is looking for a new
maintainer:
https://github.com/zephyrproject-rtos/zephyr/pull/97943#issuecomment-3439589314

I realize this is coming shortly after I was added as a collaborator, but
the request is only because there is an active need right now and I’m
already spending most of my time in SMF: submitting source-level 
changes, sending SMF-related RFCs and making performance-oriented
tweaks. If there wasn’t an open search, I would have waited longer 
before proposing this.

I would be happy to take on the SMF maintainer duties so the 
subsystem has someone who is active in it.