### PR TITLE
tests: drivers: dma: configure alignment based on devicetree

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
@@ -8,5 +8,8 @@
 
 #include "test_buffers.h"
 
-__aligned(32) char tx_data[TEST_BUF_SIZE] = "It is harder to be kind than to be wise........";
-__aligned(32) char rx_data[TEST_BUF_SIZE] = { 0 };
+#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
+
+__aligned(DMA_DATA_ALIGNMENT) char tx_data[TEST_BUF_SIZE] =
+	"It is harder to be kind than to be wise........";
+__aligned(DMA_DATA_ALIGNMENT) char rx_data[TEST_BUF_SIZE] = {0};

--- a/tests/drivers/dma/chan_link_transfer/boards/bg29_rb4420a.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/bg29_rb4420a.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_link_transfer/boards/frdm_k64f.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/frdm_k64f.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/intel_adsp_ace15_mtpm.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/intel_adsp_ace15_mtpm.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-tst_dma0: &edma0 {};
+tst_dma0: &lpgpdma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/intel_adsp_cavs25.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/intel_adsp_cavs25.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-tst_dma0: &edma0 {};
+tst_dma0: &lpgpdma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/intel_adsp_cavs25_tgph.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/intel_adsp_cavs25_tgph.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-tst_dma0: &edma0 {};
+tst_dma0: &lpgpdma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1010_evk.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1010_evk.overlay
@@ -5,4 +5,4 @@
  *
  */
 
-dma0: &edma0 {};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
@@ -5,4 +5,4 @@
  *
  */
 
-dma0: &edma0 {};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1064_evk.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1064_evk.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Andes Technology Corporation.
+ * Copyright (c) 2025 Tenstorrent AI ULC
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/drivers/dma/chan_link_transfer/boards/mr_canhubk3.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/mr_canhubk3.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dma0: &edma0 {};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/native_sim.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/native_sim.overlay
@@ -9,4 +9,4 @@
 	status = "okay";
 };
 
-dma0: &dma {};
+tst_dma0: &dma {};

--- a/tests/drivers/dma/chan_link_transfer/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-dma0: &edma0 {};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/chan_link_transfer/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-dma0: &edma5 {};
+tst_dma0: &edma5 {};

--- a/tests/drivers/dma/chan_link_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_link_transfer/src/test_dma.c
@@ -24,19 +24,21 @@
 #define TEST_DMA_CHANNEL_0 (0)
 #define TEST_DMA_CHANNEL_1 (1)
 #define RX_BUFF_SIZE (48)
+#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
 
 #ifdef CONFIG_NOCACHE_MEMORY
-static __aligned(32) char tx_data[RX_BUFF_SIZE] __used
+static __aligned(DMA_DATA_ALIGNMENT) char tx_data[RX_BUFF_SIZE] __used
 	__attribute__((__section__(".nocache")));
 static const char TX_DATA[] = "It is harder to be kind than to be wise........";
-static __aligned(32) char rx_data[RX_BUFF_SIZE] __used
+static __aligned(DMA_DATA_ALIGNMENT) char rx_data[RX_BUFF_SIZE] __used
 	__attribute__((__section__(".nocache.dma")));
-static __aligned(32) char rx_data2[RX_BUFF_SIZE] __used
+static __aligned(DMA_DATA_ALIGNMENT) char rx_data2[RX_BUFF_SIZE] __used
 	__attribute__((__section__(".nocache.dma")));
 #else
-static const char tx_data[] = "It is harder to be kind than to be wise........";
-static char rx_data[RX_BUFF_SIZE] = { 0 };
-static char rx_data2[RX_BUFF_SIZE] = { 0 };
+static __aligned(DMA_DATA_ALIGNMENT) const char tx_data[] =
+	"It is harder to be kind than to be wise........";
+static __aligned(DMA_DATA_ALIGNMENT) char rx_data[RX_BUFF_SIZE] = { 0 };
+static __aligned(DMA_DATA_ALIGNMENT) char rx_data2[RX_BUFF_SIZE] = { 0 };
 #endif
 
 static void test_done(const struct device *dma_dev, void *arg, uint32_t id,

--- a/tests/drivers/dma/chan_link_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_link_transfer/src/test_dma.c
@@ -53,7 +53,7 @@ static int test_task(int minor, int major)
 {
 	struct dma_config dma_cfg = { 0 };
 	struct dma_block_config dma_block_cfg = { 0 };
-	const struct device *const dma = DEVICE_DT_GET(DT_NODELABEL(dma0));
+	const struct device *const dma = DEVICE_DT_GET(DT_NODELABEL(tst_dma0));
 
 	if (!device_is_ready(dma)) {
 		TC_PRINT("dma controller device is not ready\n");

--- a/tests/drivers/dma/cyclic/boards/xmc45_relax_kit.overlay
+++ b/tests/drivers/dma/cyclic/boards/xmc45_relax_kit.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/cyclic/boards/xmc47_relax_kit.overlay
+++ b/tests/drivers/dma/cyclic/boards/xmc47_relax_kit.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/cyclic/src/test_dma_cyclic.c
+++ b/tests/drivers/dma/cyclic/src/test_dma_cyclic.c
@@ -48,7 +48,7 @@ static int test_cyclic(void)
 		tx_data[i] = i;
 	}
 
-	dma = DEVICE_DT_GET(DT_ALIAS(dma0));
+	dma = DEVICE_DT_GET(DT_NODELABEL(tst_dma0));
 	if (!device_is_ready(dma)) {
 		TC_PRINT("dma controller device is not ready\n");
 		return TC_FAIL;

--- a/tests/drivers/dma/cyclic/src/test_dma_cyclic.c
+++ b/tests/drivers/dma/cyclic/src/test_dma_cyclic.c
@@ -22,8 +22,10 @@
 #include <zephyr/drivers/dma.h>
 #include <zephyr/ztest.h>
 
-static __aligned(32) uint8_t tx_data[CONFIG_DMA_CYCLIC_XFER_SIZE];
-static __aligned(32) uint8_t rx_data[CONFIG_DMA_CYCLIC_XFER_SIZE];
+#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
+
+static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_CYCLIC_XFER_SIZE];
+static __aligned(DMA_DATA_ALIGNMENT) uint8_t rx_data[CONFIG_DMA_CYCLIC_XFER_SIZE];
 
 K_SEM_DEFINE(xfer_sem, 0, 1);
 

--- a/tests/drivers/dma/cyclic/testcase.yaml
+++ b/tests/drivers/dma/cyclic/testcase.yaml
@@ -7,4 +7,4 @@ tests:
     platform_allow:
       - xmc47_relax_kit
       - xmc45_relax_kit
-    filter: dt_alias_exists("dma0")
+    filter: dt_nodelabel_enabled("tst_dma0")

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -32,9 +32,11 @@
 #define SLEEPTIME 250
 
 #define TRANSFER_LOOPS (4)
+#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
 
-static __aligned(32) uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE];
-static __aligned(32) uint8_t rx_data[TRANSFER_LOOPS][CONFIG_DMA_LOOP_TRANSFER_SIZE] = { { 0 } };
+static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE];
+static __aligned(DMA_DATA_ALIGNMENT) uint8_t
+	rx_data[TRANSFER_LOOPS][CONFIG_DMA_LOOP_TRANSFER_SIZE] = { { 0 } };
 
 volatile uint32_t transfer_count;
 volatile uint32_t done;

--- a/tests/drivers/dma/scatter_gather/boards/adp_xc7k_ae350_clic.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/adp_xc7k_ae350_clic.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/bg29_rb4420a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/bg29_rb4420a.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/cy8cproto_062_4343w.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/cy8cproto_062_4343w.overlay
@@ -1,13 +1,8 @@
 /*
+ * Copyright (c) 2025 Tenstorrent AI ULC
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/cyw920829m2evk_02_common.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/cyw920829m2evk_02_common.overlay
@@ -5,12 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/frdm_k64f.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/frdm_k64f.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &edma0;
-	};
-};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/intel_adsp_ace15_mtpm.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/intel_adsp_ace15_mtpm.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &lpgpdma0;
-	};
-};
+tst_dma0: &lpgpdma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/intel_adsp_cavs25.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/intel_adsp_cavs25.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-tst_dma0: &edma0 {};
+tst_dma0: &lpgpdma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/intel_adsp_cavs25_tgph.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/intel_adsp_cavs25_tgph.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-tst_dma0: &edma0 {};
+tst_dma0: &lpgpdma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/intel_socfpga_agilex5_socdk.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/intel_socfpga_agilex5_socdk.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/lpcxpresso55s36.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/lpcxpresso55s36.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/mimxrt1010_evk.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/mimxrt1010_evk.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &edma0;
-	};
-};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &edma0;
-	};
-};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &edma0;
-	};
-};
+tst_dma0: &edma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
@@ -4,8 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/scatter_gather/boards/native_sim.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/native_sim.overlay
@@ -10,4 +10,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma {};
+tst_dma0: &dma {};

--- a/tests/drivers/dma/scatter_gather/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &edma0;
-	};
-};
-
-&edma0 {
+tst_dma0: &edma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &edma5;
-	};
-};
-
-&edma5 {
+tst_dma0: &edma5 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/siwx917_dk2605a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/siwx917_dk2605a.overlay
@@ -3,12 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
 
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/siwx917_rb4338a.overlay
@@ -3,12 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
 
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/siwx917_rb4342a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/siwx917_rb4342a.overlay
@@ -3,12 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
 
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/sltb010a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/sltb010a.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/slwrb4180a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/slwrb4180a.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/xg23_rb4210a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xg23_rb4210a.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/xg24_dk2601b.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xg24_dk2601b.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/xg27_dk2602a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xg27_dk2602a.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/xg29_rb4412a.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xg29_rb4412a.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/xmc45_relax_kit.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xmc45_relax_kit.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/boards/xmc47_relax_kit.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/xmc47_relax_kit.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	aliases {
-		dma0 = &dma0;
-	};
-};
-
-&dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
+++ b/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
@@ -22,16 +22,17 @@
 #include <zephyr/ztest.h>
 
 #define XFERS 4
+#define DMA_DATA_ALIGNMENT DT_INST_PROP_OR(tst_dma0, dma_buf_addr_alignment, 32)
 
 #if CONFIG_NOCACHE_MEMORY
-static __aligned(32) uint8_t tx_data[CONFIG_DMA_SG_XFER_SIZE] __used
+static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_SG_XFER_SIZE] __used
 	__attribute__((__section__(".nocache")));
-static __aligned(32) uint8_t rx_data[XFERS][CONFIG_DMA_SG_XFER_SIZE] __used
+static __aligned(DMA_DATA_ALIGNMENT) uint8_t rx_data[XFERS][CONFIG_DMA_SG_XFER_SIZE] __used
 	__attribute__((__section__(".nocache.dma")));
 #else
 /* this src memory shall be in RAM to support using as a DMA source pointer.*/
-static __aligned(32) uint8_t tx_data[CONFIG_DMA_SG_XFER_SIZE];
-static __aligned(32) uint8_t rx_data[XFERS][CONFIG_DMA_SG_XFER_SIZE] = { { 0 } };
+static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_SG_XFER_SIZE];
+static __aligned(DMA_DATA_ALIGNMENT) uint8_t rx_data[XFERS][CONFIG_DMA_SG_XFER_SIZE] = { { 0 } };
 #endif
 
 K_SEM_DEFINE(xfer_sem, 0, 1);

--- a/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
+++ b/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
@@ -66,7 +66,7 @@ static int test_sg(void)
 
 	memset(rx_data, 0, sizeof(rx_data));
 
-	dma = DEVICE_DT_GET(DT_ALIAS(dma0));
+	dma = DEVICE_DT_GET(DT_NODELABEL(tst_dma0));
 	if (!device_is_ready(dma)) {
 		TC_PRINT("dma controller device is not ready\n");
 		return TC_FAIL;

--- a/tests/drivers/dma/scatter_gather/testcase.yaml
+++ b/tests/drivers/dma/scatter_gather/testcase.yaml
@@ -21,7 +21,7 @@ tests:
       - adp_xc7k/ae350
       - adp_xc7k/ae350/clic
       - bg29_rb4420a
-    filter: dt_alias_exists("dma0")
+    filter: dt_nodelabel_enabled("tst_dma0")
     integration_platforms:
       - intel_adsp/cavs25
       - native_sim


### PR DESCRIPTION
Configure data buffer alignment based on devicetree `dma_buf_addr_alignment` property.

Fixes #98949 