### PR TITLE
tests/kernel/context: Properly idle on MAX32 family

### DIFF
--- a/tests/kernel/context/prj.conf
+++ b/tests/kernel/context/prj.conf
@@ -1,3 +1,6 @@
 CONFIG_IRQ_OFFLOAD=y
 CONFIG_ZTEST=y
 CONFIG_MP_MAX_NUM_CPUS=1
+
+# On MAX32, this will prevent WFI by default, so disable this config
+CONFIG_MAX32_ON_ENTER_CPU_IDLE_HOOK=n


### PR DESCRIPTION
Make sure MAX32_ON_ENTER_CPU_IDLE_HOOK is disabled for the context test, so the CPU will actually idle with WFI and not return before the timer expires for test_cpu_idle test.

This fixes #98957

The fix here adds the Kconfig flag to the test's `prj.conf`. I considered other options, like adding dedicated entries in the testcase.yml to override this config, but that seemed to overcomplicate things without much upside. I'm open to other ideas if the fix here isn't acceptable.