### PR TITLE
tests: spi_loopback: Skip tests properly

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -473,7 +473,7 @@ ZTEST(spi_loopback, test_spi_rx_half_start)
 ZTEST(spi_loopback, test_spi_rx_half_end)
 {
 	if (IS_ENABLED(CONFIG_SPI_STM32_DMA) || IS_ENABLED(CONFIG_DMA_SILABS_SIWX91X_GPDMA)) {
-		TC_PRINT("Skipped spi_rx_hald_end");
+		ztest_test_skip();
 		return;
 	}
 
@@ -496,7 +496,7 @@ ZTEST(spi_loopback, test_spi_rx_every_4)
 {
 	if (IS_ENABLED(CONFIG_SPI_STM32_DMA) || IS_ENABLED(CONFIG_DSPI_MCUX_EDMA) ||
 	    IS_ENABLED(CONFIG_DMA_SILABS_SIWX91X_GPDMA)) {
-		TC_PRINT("Skipped spi_rx_every_4");
+		ztest_test_skip();
 		return;
 	};
 
@@ -523,7 +523,7 @@ ZTEST(spi_loopback, test_spi_rx_bigger_than_tx)
 {
 	if (IS_ENABLED(CONFIG_SPI_STM32_DMA) || IS_ENABLED(CONFIG_DSPI_MCUX_EDMA)) {
 		TC_PRINT("Skipped spi_rx_bigger_than_tx");
-		return;
+		ztest_test_skip();
 	}
 
 	struct spi_dt_spec *spec = loopback_specs[spec_idx];
@@ -626,6 +626,10 @@ ZTEST(spi_loopback, test_spi_write_back)
 /* similar to test_spi_write_back, simulates the real common case of 1 word command */
 ZTEST(spi_loopback, test_spi_same_buf_cmd)
 {
+	if (IS_ENABLED(CONFIG_SPI_STM32_DMA) || IS_ENABLED(CONFIG_DSPI_MCUX_EDMA)) {
+		ztest_test_skip();
+	}
+
 	struct spi_dt_spec *spec = loopback_specs[spec_idx];
 
 	struct spi_buf buf[2] = {


### PR DESCRIPTION
There is a couple test cases which for whatever reason does not work on certain platform drivers, and they are being hardcoded to be skipped in the test if using those drivers. This decision was made a long time ago, and I do not have great insight into why, but regardless, the proper way to skip a ztest case is to call the proper ztest skip API instead of just returning, because it should be marked as skipped, not passed. Also, the problem for these couple drivers is clearly the cases where rx is bigger than tx, so add the same skip for the other new case where rx is bigger than tx, the same_buf_cmd case.

After analyzing the DSPI driver a bit, I have a suspicion that this is just a software driver limitation, that could be overcome to function properly, and not a hardware limitation. But this commit is just to skip the test properly that is already being skipped, not fix the underlying issues with these drivers.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/97987