### PR TITLE
tests: kernel/pipe_api: skip zero size test if KERNEL_COHERENCE

### DIFF
--- a/tests/kernel/pipe/pipe_api/src/concurrency.c
+++ b/tests/kernel/pipe/pipe_api/src/concurrency.c
@@ -190,6 +190,14 @@ ZTEST(k_pipe_concurrency, test_zero_size_pipe_read_write)
 	uint8_t input[DUMMY_DATA_SIZE];
 	uint8_t output[DUMMY_DATA_SIZE];
 
+#ifdef CONFIG_KERNEL_COHERENCE
+	/* Zero size pipes are not supported due to requiring cache
+	 * management on data buffers as the buffers can reside in
+	 * incoherent memory. So skip this test.
+	 */
+	ztest_test_skip();
+#endif
+
 	memset(input, 0xAA, sizeof(input));
 	memset(output, 0xCC, sizeof(output));
 	k_pipe_init(&input_pipe, NULL, 0);


### PR DESCRIPTION
Zero size buffer pipes are not currently supported if memory is not coherent between CPUs (CONFIG_KERNEL_COHERENCE=y) due to possibility of buffers being in incoherent memory. So skip the zero size test for now.
