### PR TITLE
Fix lp mspm0g3519 pinctrl dtsi

### DIFF
--- a/boards/ti/lp_mspm0g3519/lp_mspm0g3519.dts
+++ b/boards/ti/lp_mspm0g3519/lp_mspm0g3519.dts
@@ -3,7 +3,7 @@
 /dts-v1/;
 
 #include <ti/mspm0/g/mspm0g3519.dtsi>
-#include <ti/mspm0/g/mspm0g1x0x_g3x0x-pinctrl.dtsi>
+#include <ti/mspm0/g/mspm0gx51x-pinctrl.dtsi>
 #include <zephyr/dt-bindings/clock/mspm0_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>

--- a/west.yml
+++ b/west.yml
@@ -265,7 +265,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: cc049020152585c4e968b83c084d230234b6d852
+      revision: pull/76/head
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
The LP MSPM0G3519 board has additional pins that cannot be configured with entries defined in `mspm0g1x0x_g3x0x-pinctrl.dtsi`. The HAL was updated to include pinctrl definitions for TI gx51x family of MCUs.