### PR TITLE
tests: drivers: eeprom: add EEPROM support for Microchip sama7d65_curiosity board

### DIFF
--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.dts
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.dts
@@ -49,7 +49,36 @@
 	};
 };
 
+&flx10 {
+	mchp,flexcom-mode = <SAM_FLEXCOM_MODE_TWI>;
+	status = "okay";
+
+	i2c10: i2c10@600 {
+		pinctrl-0 = <&pinctrl_i2c10_default>;
+		pinctrl-names = "default";
+		status = "okay";
+
+		eeprom0: eeprom0@51 {
+			compatible = "atmel,24mac02e4", "atmel,at24";
+			reg = <0x51>;
+			address-width = <8>;
+			pagesize = <16>;
+			size = <256>;
+			timeout = <5>;
+			status = "okay";
+		};
+	};
+};
+
 &pinctrl {
+	pinctrl_i2c10_default: i2c10-default {
+		group1 {
+			pinmux = <PIN_PB19__FLEXCOM10_IO1>,
+				 <PIN_PB20__FLEXCOM10_IO0>;
+			bias-disable;
+		};
+	};
+
 	pinctrl_uart6_default: uart6-default {
 		group1 {
 			pinmux = <PIN_PD18__FLEXCOM6_IO0>,

--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
@@ -9,6 +9,7 @@ toolchain:
   - zephyr
 ram: 128
 supported:
+  - eeprom
   - i2c
   - pinctrl
   - shell

--- a/tests/drivers/eeprom/api/boards/sama7d65_curiosity.overlay
+++ b/tests/drivers/eeprom/api/boards/sama7d65_curiosity.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2025 Microchip Technology Inc. and its subsidiaries
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		eeprom-0 = &eeprom0;
+	};
+};

--- a/tests/drivers/eeprom/api/testcase.yaml
+++ b/tests/drivers/eeprom/api/testcase.yaml
@@ -13,6 +13,7 @@ tests:
       - nucleo_l152re
       - nucleo_l073rz
       - sama7g54_ek
+      - sama7d65_curiosity
     integration_platforms:
       - qemu_x86
   drivers.eeprom.api.w_at2x_emul:


### PR DESCRIPTION
Changes in this PR includes:
 - add the node to dts file for sama7d65_curiosity on-board EEPROM
 - add EEPROM to the board support list
 - enable `tests/drivers/eeprom/api` for sam7d65_curiosity board

Test OK with `tests/drivers/eeprom/api` and `tests/drivers/eeprom/shell`.