### PR TITLE
openthread: platform: udp: init udp fds before external net connection

### DIFF
--- a/modules/openthread/platform/platform-zephyr.h
+++ b/modules/openthread/platform/platform-zephyr.h
@@ -122,6 +122,7 @@ int notify_new_tx_frame(struct net_pkt *pkt);
 otError infra_if_init(otInstance *instance, struct net_if *ail_iface);
 otError infra_if_start_icmp6_listener(void);
 void infra_if_stop_icmp6_listener(void);
+void udp_plat_init_sockfd(void);
 otError udp_plat_init(otInstance *ot_instance, struct net_if *ail_iface, struct net_if *ot_iface);
 void udp_plat_deinit(void);
 otError mdns_plat_socket_init(otInstance *ot_instance, uint32_t ail_iface_idx);

--- a/modules/openthread/platform/udp.c
+++ b/modules/openthread/platform/udp.c
@@ -36,6 +36,13 @@ static void udp_receive_handler(struct net_socket_service_event *evt);
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(handle_udp_receive, udp_receive_handler,
 				      CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_MAX_UDP_SERVICES);
 
+void udp_plat_init_sockfd(void)
+{
+	for (uint8_t i = 0; i < CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_MAX_UDP_SERVICES; i++) {
+		sockfd_udp[i].fd = -1;
+	}
+}
+
 otError udp_plat_init(otInstance *ot_instance, struct net_if *ail_iface, struct net_if *ot_iface)
 {
 	ot_instance_ptr = ot_instance;

--- a/subsys/net/l2/openthread/openthread_border_router.c
+++ b/subsys/net/l2/openthread/openthread_border_router.c
@@ -325,6 +325,7 @@ void openthread_border_router_init(struct openthread_context *ot_ctx)
 				     NET_EVENT_IPV4_ADDR_ADD);
 	net_mgmt_add_event_callback(&ail_net_event_ipv4_addr_cb);
 #endif /* CONFIG_NET_IPV4 */
+	udp_plat_init_sockfd();
 	openthread_set_bbr_multicast_listener_cb(ot_bbr_multicast_listener_handler, (void *)ot_ctx);
 	(void)infra_if_start_icmp6_listener();
 }


### PR DESCRIPTION
When OpenThread iface is brought up, `ot ifconfig up`, there are several modules that will attempt to open a platform socket and perform bind and bind to netif operation.
Since now, `sockfd_upd` structure was initialized after the backbone interface announced connectivity, but this implies that OpenThread interface will always be brought up only after this event, which is not true, or imposed.