### PR TITLE
Bluetooth: Classic: RFCOMM: Fix NULL pointer access issue

### DIFF
--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -1375,8 +1375,7 @@ static void rfcomm_handle_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 
 		if (!session->dlcs) {
 			/* Start a session idle timer */
-			k_work_reschedule(&dlc->session->rtx_work,
-					  RFCOMM_IDLE_TIMEOUT);
+			k_work_reschedule(&session->rtx_work, RFCOMM_IDLE_TIMEOUT);
 		}
 	} else {
 		/* Cancel idle timer */


### PR DESCRIPTION
When received the DLC disconnect request, after prime the DLC disconnect response, the DLC will be cleared and the `dlc->session` is cleared. If the no DLC is linked in current session, the idle timer of the session will be scheduled.

In current implementation, the `dlc->session` is used to get the session pointer, but it is invalid in this time. And the unexpected fault occurs.

Fix the issue by getting the session pointer from parameter of the function `rfcomm_handle_disc()` instead of `dlc->session`.

Fixes #99035