### PR TITLE
tests: drivers: memc: ram: Fix build error on hifive_unmatched

### DIFF
--- a/tests/drivers/memc/ram/src/main.c
+++ b/tests/drivers/memc/ram/src/main.c
@@ -71,7 +71,7 @@ ZTEST(test_ram, test_sdram1)
 ZTEST(test_ram, test_ram0)
 {
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ram0))
-	test_ram_rw(buf_ram0, RAM_SIZE_SRAM);
+	test_ram_rw(buf_ram0, RAM_SIZE);
 #else
 	ztest_test_skip();
 #endif


### PR DESCRIPTION
Fix 'RAM_SIZE_SRAM' undeclared error in function 'test_ram_test_ram0'.

To reproduce:

```sh
west build -p -b hifive_unmatched/fu740/s7 tests/drivers/memc/ram -T drivers.memc
```

It results in an error:

```txt
/zephyrproject/zephyr/tests/drivers/memc/ram/src/main.c: In function 'test_ram_test_ram0':
/zephyrproject/zephyr/tests/drivers/memc/ram/src/main.c:74:31: error: 'RAM_SIZE_SRAM' undeclared (first use in this function); did you mean 'BUF_SIZE_SRAM'?
   74 |         test_ram_rw(buf_ram0, RAM_SIZE_SRAM);
      |                               ^~~~~~~~~~~~~
      |                               BUF_SIZE_SRAM
/zephyrproject/zephyr/tests/drivers/memc/ram/src/main.c:74:31: note: each undeclared identifier is reported only once for each function it appears in
```

It was probably overlooked in https://github.com/zephyrproject-rtos/zephyr/commit/569a4ab8a7f9bb5d3230925b5af8c625c03804f0. `RAM_SIZE` constant for this case is declared in https://github.com/zephyrproject-rtos/zephyr/blob/8b2c75a2fbe4eef38a99f0a050d9d1d268d1bb69/tests/drivers/memc/ram/src/main.c#L55-L58.

Fixes #99002