### PR TITLE
Bluetooth: Classic: HFP: Compatible old version

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_hf.h
+++ b/include/zephyr/bluetooth/classic/hfp_hf.h
@@ -747,9 +747,8 @@ int bt_hfp_hf_redial(struct bt_hfp_hf *hf);
 
 /** @brief Handsfree HF setup audio connection
  *
- *  Setup audio conenction by sending AT+BCC.
- *  If @kconfig{CONFIG_BT_HFP_HF_CODEC_NEG} is not enabled, the error
- *  `-ENOTSUP` will be returned if the function called.
+ *  Setup audio conenction by sending AT+BCC if the Codec Negotiation is supported by both side.
+ *  Or, initialize the SCO audio connection directly.
  *
  *  @param hf HFP HF object.
  *

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -83,6 +83,8 @@ static struct bt_ag_tx ag_tx[CONFIG_BT_HFP_AG_TX_BUF_COUNT * 2];
 static K_FIFO_DEFINE(ag_tx_free);
 static K_FIFO_DEFINE(ag_tx_notify);
 
+#define BT_HFP_AG_VERSION BT_HFP_VERSION_1_9
+
 /* HFP Gateway SDP record */
 static struct bt_sdp_attribute hfp_ag_attrs[] = {
 	BT_SDP_NEW_SERVICE,
@@ -141,7 +143,7 @@ static struct bt_sdp_attribute hfp_ag_attrs[] = {
 			},
 			{
 				BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
-				BT_SDP_ARRAY_16(0x0109)
+				BT_SDP_ARRAY_16(BT_HFP_AG_VERSION)
 			},
 			)
 		},
@@ -3687,12 +3689,30 @@ static void hfp_ag_postprocess_at_cmd(struct bt_hfp_ag *ag)
 	k_work_reschedule(&ag->tx_work, K_NO_WAIT);
 }
 
+static int hfp_ag_at_cmd_ack(struct bt_hfp_ag *ag, int err)
+{
+	enum at_cme cme_err;
+
+	if ((err != 0) && atomic_test_bit(ag->flags, BT_HFP_AG_CMEE_ENABLE)) {
+		cme_err = bt_hfp_ag_get_cme_err(err);
+		err = hfp_ag_send_data(ag, NULL, NULL, "\r\n+CME ERROR:%d\r\n", (uint32_t)cme_err);
+	} else {
+		bt_hfp_ag_tx_cb_t cb;
+
+		cb = atomic_test_and_clear_bit(ag->flags, BT_HFP_AG_SLC_CONNECTED)
+			     ? bt_hfp_ag_slc_connected
+			     : NULL;
+		err = hfp_ag_send_data(ag, cb, NULL, "\r\n%s\r\n", (err == 0) ? "OK" : "ERROR");
+	}
+
+	return err;
+}
+
 static void hfp_ag_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 {
 	struct bt_hfp_ag *ag = CONTAINER_OF(dlc, struct bt_hfp_ag, rfcomm_dlc);
 	uint8_t *data = buf->data;
 	uint16_t len = buf->len;
-	enum at_cme cme_err;
 	int err = -ENOEXEC;
 
 	LOG_HEXDUMP_DBG(data, len, "Received:");
@@ -3720,17 +3740,14 @@ static void hfp_ag_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 		return;
 	}
 
-	if ((err != 0) && atomic_test_bit(ag->flags, BT_HFP_AG_CMEE_ENABLE)) {
-		cme_err = bt_hfp_ag_get_cme_err(err);
-		err = hfp_ag_send_data(ag, NULL, NULL, "\r\n+CME ERROR:%d\r\n", (uint32_t)cme_err);
-	} else {
-		bt_hfp_ag_tx_cb_t cb;
-
-		cb = atomic_test_and_clear_bit(ag->flags, BT_HFP_AG_SLC_CONNECTED)
-			     ? bt_hfp_ag_slc_connected
-			     : NULL;
-		err = hfp_ag_send_data(ag, cb, NULL, "\r\n%s\r\n", (err == 0) ? "OK" : "ERROR");
+	if (!atomic_test_and_set_bit(ag->flags, BT_HFP_AG_1ST_AT_RECV)) {
+		LOG_DBG("First AT command ack will be replied later");
+		ag->ack_err = err;
+		k_work_submit(&ag->slc_work);
+		return;
 	}
+
+	err = hfp_ag_at_cmd_ack(ag, err);
 
 	hfp_ag_postprocess_at_cmd(ag);
 
@@ -3964,16 +3981,123 @@ static void bt_ag_ongoing_call_work(struct k_work *work)
 	bt_ag_send_ok_code(ag);
 }
 
+static void bt_ag_slc_work(struct k_work *work)
+{
+	struct bt_hfp_ag *ag = CONTAINER_OF(work, struct bt_hfp_ag, slc_work);
+	int err;
+
+	if (!atomic_test_bit(ag->flags, BT_HFP_AG_DISCOVER_DONE)) {
+		return;
+	}
+
+	if (!atomic_test_bit(ag->flags, BT_HFP_AG_1ST_AT_RECV)) {
+		return;
+	}
+
+	if (atomic_test_and_set_bit(ag->flags, BT_HFP_AG_FEAT_UPDATED)) {
+		return;
+	}
+
+	if (atomic_test_bit(ag->flags, BT_HFP_AG_RECORD_FOUND)) {
+		err = hfp_ag_at_cmd_ack(ag, ag->ack_err);
+		hfp_ag_postprocess_at_cmd(ag);
+		if (err != 0) {
+			LOG_ERR("Failed to send AT command ACK: %d", err);
+		}
+		return;
+	}
+
+	err = bt_hfp_ag_disconnect(ag);
+	if (err != 0) {
+		LOG_ERR("Failed to disconnect HF: %d", err);
+	}
+}
+
+#define HFP_SDP_FEAT_MASK GENMASK(4, 0)
+
+static uint8_t bt_hfp_ag_discover_cb(struct bt_conn *conn, struct bt_sdp_client_result *result,
+				     const struct bt_sdp_discover_params *params)
+{
+	size_t index;
+	struct bt_hfp_ag *ag;
+	int err;
+
+	index = (size_t)bt_conn_index(conn);
+	__ASSERT(index < ARRAY_SIZE(bt_hfp_ag_pool), "Index is out of bounds");
+
+	ag = &bt_hfp_ag_pool[index];
+
+	if ((result == NULL) || (result->resp_buf == NULL)) {
+		LOG_ERR("SDP discovery failed");
+		goto failed;
+	}
+
+	err = bt_sdp_get_profile_version(result->resp_buf, BT_SDP_HANDSFREE_SVCLASS,
+					 &ag->hf_sdp_version);
+	if (err != 0) {
+		LOG_ERR("Failed to get HF profile version");
+		goto failed;
+	}
+	err = bt_sdp_get_features(result->resp_buf, &ag->hf_sdp_features);
+	if (err != 0) {
+		LOG_ERR("Failed to get HF feature");
+		goto failed;
+	}
+
+	if ((ag->hf_sdp_version <= BT_HFP_VERSION_1_5) ||
+	    (BT_HFP_AG_VERSION <= BT_HFP_VERSION_1_5)) {
+		if (ag->hf_sdp_features & BT_HFP_HF_SDP_FEATURE_WBS) {
+			LOG_WRN("Unsupported SDP feature (WBS) is enabled.");
+			ag->hf_sdp_features &= ~BT_HFP_HF_SDP_FEATURE_WBS;
+		}
+
+		if (ag->hf_sdp_features & BT_HFP_HF_SDP_FEATURE_SUPER_WBS) {
+			LOG_WRN("Unsupported SDP feature (Super WBS) is enabled.");
+			ag->hf_sdp_features &= ~BT_HFP_HF_SDP_FEATURE_SUPER_WBS;
+		}
+	}
+
+	if ((ag->hf_sdp_version <= BT_HFP_VERSION_0_96) ||
+	    (BT_HFP_AG_VERSION <= BT_HFP_VERSION_0_96)) {
+		/* Update the AG features according to the SDP features for HFP version 0.96.
+		 *
+		 * Hands-Free Profile Specification V1.9, 6.3 SDP Interoperability Requirements
+		 * The values of the “SupportedFeatures” bitmap given in Table 6.6 shall be the
+		 * same as the values of the Bits 0 to 4 of the unsolicited result code +BRSF.
+		 */
+		ag->hf_features = ag->hf_sdp_features & HFP_SDP_FEAT_MASK;
+	}
+
+	atomic_set_bit(ag->flags, BT_HFP_AG_RECORD_FOUND);
+failed:
+	atomic_set_bit(ag->flags, BT_HFP_AG_DISCOVER_DONE);
+	k_work_submit(&ag->slc_work);
+
+	return BT_SDP_DISCOVER_UUID_STOP;
+}
+
 static struct bt_hfp_ag *hfp_ag_create(struct bt_conn *conn)
 {
+	size_t index;
+	struct bt_hfp_ag *ag;
+	int err;
+
 	static struct bt_rfcomm_dlc_ops ops = {
 		.connected = hfp_ag_connected,
 		.disconnected = hfp_ag_disconnected,
 		.recv = hfp_ag_recv,
 		.sent = hfp_ag_sent,
 	};
-	size_t index;
-	struct bt_hfp_ag *ag;
+	static struct bt_sdp_attribute_id_range id_range[] = {
+		{ BT_SDP_ATTR_PROTO_DESC_LIST, BT_SDP_ATTR_PROTO_DESC_LIST },
+		{ BT_SDP_ATTR_PROFILE_DESC_LIST, BT_SDP_ATTR_PROFILE_DESC_LIST },
+		{ BT_SDP_ATTR_SUPPORTED_FEATURES, BT_SDP_ATTR_SUPPORTED_FEATURES },
+	};
+	static struct bt_sdp_attribute_id_list id_list = {
+		.count = ARRAY_SIZE(id_range),
+		.ranges = id_range,
+	};
+	static struct bt_uuid_16 uuid;
 
 	LOG_DBG("conn %p", conn);
 
@@ -3988,6 +4112,20 @@ static struct bt_hfp_ag *hfp_ag_create(struct bt_conn *conn)
 
 	(void)memset(ag, 0, sizeof(struct bt_hfp_ag));
 
+	uuid.uuid.type = BT_UUID_TYPE_16;
+	uuid.val = BT_SDP_HANDSFREE_SVCLASS;
+
+	ag->sdp_param.func = bt_hfp_ag_discover_cb;
+	ag->sdp_param.type = BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR;
+	ag->sdp_param.uuid = &uuid.uuid;
+	ag->sdp_param.pool = &ag_pool;
+	ag->sdp_param.ids  = &id_list;
+
+	err = bt_sdp_discover(conn, &ag->sdp_param);
+	if (err != 0) {
+		return NULL;
+	}
+
 	sys_slist_init(&ag->tx_pending);
 	sys_slist_init(&ag->tx_submit_pending);
 
@@ -3999,6 +4137,10 @@ static struct bt_hfp_ag *hfp_ag_create(struct bt_conn *conn)
 	/* Set the supported features*/
 	ag->ag_features = BT_HFP_AG_SUPPORTED_FEATURES;
 	ag->ag_features |= BT_FEAT_SC(bt_dev.features) ? BT_HFP_AG_FEATURE_ESCO_S4 : 0;
+
+	/* Set the default HF infrmation */
+	ag->hf_sdp_features = 0;
+	ag->hf_sdp_version = BT_HFP_VERSION_0_96;
 
 	/* Support HF indicators */
 	if (IS_ENABLED(CONFIG_BT_HFP_AG_HF_INDICATOR_ENH_SAFETY)) {
@@ -4041,6 +4183,8 @@ static struct bt_hfp_ag *hfp_ag_create(struct bt_conn *conn)
 
 	/* Set Codec ID*/
 	ag->selected_codec_id = BT_HFP_AG_CODEC_CVSD;
+
+	k_work_init(&ag->slc_work, bt_ag_slc_work);
 
 	/* Init delay work */
 	k_work_init_delayable(&ag->tx_work, bt_ag_tx_work);

--- a/subsys/bluetooth/host/classic/hfp_ag_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_ag_internal.h
@@ -173,6 +173,10 @@ enum {
 	BT_HGP_AG_ONGOING_CALLS, /* Waiting ongoing calls */
 	BT_HFP_AG_SLC_CONNECTED, /* SLC connected event needs to be notified */
 	BT_HFP_AG_AT_PROCESS,    /* AT command is in processing */
+	BT_HFP_AG_DISCOVER_DONE, /* SDP Record discovered done */
+	BT_HFP_AG_RECORD_FOUND,  /* SDP HF Record found */
+	BT_HFP_AG_1ST_AT_RECV,   /* 1st AT is received */
+	BT_HFP_AG_FEAT_UPDATED,  /* Remote feature has been updated */
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_HFP_AG_NUM_FLAGS,
@@ -266,6 +270,10 @@ struct bt_hfp_ag {
 	uint32_t hf_indicators_of_hf;
 	uint32_t hf_indicators;
 
+	/* AG profile information */
+	uint16_t hf_sdp_version;
+	uint16_t hf_sdp_features;
+
 	/* operator */
 	uint8_t mode;
 	char operator[AT_COPS_OPERATOR_MAX_LEN + 1];
@@ -284,6 +292,13 @@ struct bt_hfp_ag {
 
 	/* SCO connect */
 	struct bt_conn *sco_conn;
+
+	/* SDP discover params */
+	struct bt_sdp_discover_params sdp_param;
+
+	/* SCL work */
+	struct k_work slc_work;
+	int ack_err;
 
 	/* HFP TX pending */
 	sys_slist_t tx_pending;

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -80,6 +80,10 @@ static const struct {
 	{"battchg", 0, 5} /* HF_BATTERY_IND */
 };
 
+#define BT_HFP_HF_FEAT_TEST(feat, mask) (((feat) & (mask)) != 0)
+
+#define BT_HFP_HF_VERSION BT_HFP_VERSION_1_9
+
 /* HFP Hands-Free SDP record */
 static struct bt_sdp_attribute hfp_attrs[] = {
 	BT_SDP_NEW_SERVICE,
@@ -138,7 +142,7 @@ static struct bt_sdp_attribute hfp_attrs[] = {
 			},
 			{
 				BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
-				BT_SDP_ARRAY_16(0x0109)
+				BT_SDP_ARRAY_16(BT_HFP_HF_VERSION)
 			},
 			)
 		},
@@ -294,6 +298,13 @@ int brsf_handle(struct at_client *hf_at)
 	}
 
 	hf->ag_features = val;
+	if ((hf->ag_sdp_version <= BT_HFP_VERSION_1_5) ||
+	    (BT_HFP_HF_VERSION <= BT_HFP_VERSION_1_5)) {
+		if (hf->ag_features & BT_HFP_AG_FEATURE_CODEC_NEG) {
+			LOG_WRN("Unsupported feature (Codec Negotiation) is enabled.");
+			hf->ag_features &= ~BT_HFP_AG_FEATURE_CODEC_NEG;
+		}
+	}
 
 	return 0;
 }
@@ -2236,8 +2247,30 @@ static int send_at_bac(struct bt_hfp_hf *hf, at_finish_cb_t cb)
 }
 #endif /* CONFIG_BT_HFP_HF_CODEC_NEG */
 
+#define HFP_SDP_FEAT_MASK GENMASK(4, 0)
+
 static int send_at_brsf(struct bt_hfp_hf *hf, at_finish_cb_t cb)
 {
+	if ((hf->ag_sdp_version <= BT_HFP_VERSION_0_96) ||
+	    (BT_HFP_HF_VERSION <= BT_HFP_VERSION_0_96)) {
+		/* Update the AG features according to the SDP features for HFP version 0.96.
+		 *
+		 * Hands-Free Profile Specification V1.9, 6.3 SDP Interoperability Requirements
+		 * The values of the “SupportedFeatures” bitmap given in Table 6.6 shall be the
+		 * same as the values of the Bits 0 to 4 of the unsolicited result code +BRSF.
+		 */
+		hf->ag_features = hf->ag_sdp_features & HFP_SDP_FEAT_MASK;
+
+		/* Due to the AT command `AT+BRSF` cannot be sent if the peer version is v.96,
+		 * notify the upper layer directly.
+		 */
+		if (cb != NULL) {
+			cb(&hf->at, AT_RESULT_OK, CME_ERROR_AG_FAILURE);
+		}
+		LOG_WRN("CMD AT+BRSF not sent, AG features %04x", hf->ag_features);
+		return 0;
+	}
+
 	return hfp_hf_send_cmd(hf, brsf_resp, cb, "AT+BRSF=%u", hf->hf_features);
 }
 
@@ -3409,23 +3442,120 @@ static int bcc_finish(struct at_client *hf_at, enum at_result result,
 }
 #endif /* CONFIG_BT_HFP_HF_CODEC_NEG */
 
+static void hfp_hf_sco_connected(struct bt_sco_chan *chan)
+{
+	struct bt_hfp_hf *hf = CONTAINER_OF(chan, struct bt_hfp_hf, chan);
+
+	if (hf->sco_conn == NULL) {
+		hf->sco_conn = bt_conn_ref(chan->sco);
+	}
+
+	if ((bt_hf != NULL) && (bt_hf->sco_connected != NULL)) {
+		bt_hf->sco_connected(hf, chan->sco);
+	}
+}
+
+static void hfp_hf_sco_disconnected(struct bt_sco_chan *chan, uint8_t reason)
+{
+	struct bt_hfp_hf *hf = CONTAINER_OF(chan, struct bt_hfp_hf, chan);
+
+	if ((bt_hf != NULL) && (bt_hf->sco_disconnected != NULL)) {
+		bt_hf->sco_disconnected(chan->sco, reason);
+	}
+
+	if (hf->sco_conn != NULL) {
+		bt_conn_unref(hf->sco_conn);
+		hf->sco_conn = NULL;
+	}
+}
+
+static int hfp_hf_set_voice_setting(struct bt_hfp_hf *hf)
+{
+	uint16_t air_coding_fmt;
+
+	switch (hf->active_codec_id) {
+	case BT_HFP_HF_CODEC_CVSD:
+		air_coding_fmt = BT_HCI_VOICE_SETTING_AIR_CODING_FMT_CVSD;
+		break;
+#if defined(CONFIG_BT_HFP_HF_CODEC_NEG)
+	case BT_HFP_HF_CODEC_MSBC:
+		if (!IS_ENABLED(CONFIG_BT_HFP_HF_CODEC_MSBC)) {
+			LOG_ERR("mSBC is not enabled");
+			return -EINVAL;
+		}
+		air_coding_fmt = BT_HCI_VOICE_SETTING_AIR_CODING_FMT_TRANSPARENT;
+		break;
+	case BT_HFP_HF_CODEC_LC3_SWB:
+		if (!IS_ENABLED(CONFIG_BT_HFP_HF_CODEC_LC3_SWB)) {
+			LOG_ERR("LC3 SWB is not enabled");
+			return -EINVAL;
+		}
+		air_coding_fmt = BT_HCI_VOICE_SETTING_AIR_CODING_FMT_TRANSPARENT;
+		break;
+#endif /* CONFIG_BT_HFP_HF_CODEC_NEG */
+	default:
+		LOG_ERR("Unsupported codec ID %u", hf->active_codec_id);
+		return -EINVAL;
+	}
+
+	hf->chan.voice_setting = BT_HCI_VOICE_SETTINGS(
+		air_coding_fmt, BT_HCI_VOICE_SETTING_PCM_BIT_POS_DEFAULT,
+		BT_HCI_VOICE_SETTING_SAMPLE_SIZE_16_BITS,
+		BT_HCI_VOICE_SETTING_DATA_FMT_2_COMPLEMENT, BT_HCI_VOICE_SETTING_CODING_FMT_LINEAR);
+
+	return 0;
+}
+
+static int hfp_hf_create_sco(struct bt_hfp_hf *hf)
+{
+	static const struct bt_sco_chan_ops ops = {
+		.connected = hfp_hf_sco_connected,
+		.disconnected = hfp_hf_sco_disconnected,
+	};
+	int err;
+
+	LOG_DBG("Creating SCO connection");
+
+	hf->chan.ops = &ops;
+
+	err = hfp_hf_set_voice_setting(hf);
+	if (err < 0) {
+		LOG_ERR("Failed to set voice setting");
+		return err;
+	}
+
+	hf->sco_conn = bt_conn_create_sco(&hf->acl->br.dst, &hf->chan);
+	if (hf->sco_conn == NULL) {
+		LOG_ERR("Failed to create SCO");
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
 int bt_hfp_hf_audio_connect(struct bt_hfp_hf *hf)
 {
-#if defined(CONFIG_BT_HFP_HF_CODEC_NEG)
 	int err;
 
 	LOG_DBG("");
 
-	if (!hf) {
+	if (hf == NULL) {
 		LOG_ERR("No HF connection found");
 		return -ENOTCONN;
 	}
 
-	if (hf->chan.sco) {
+	if (hf->sco_conn != NULL) {
 		LOG_ERR("Audio conenction has been connected");
 		return -ECONNREFUSED;
 	}
 
+	if (!(BT_HFP_HF_FEAT_TEST(hf->ag_features, BT_HFP_AG_FEATURE_CODEC_NEG) &&
+	      BT_HFP_HF_FEAT_TEST(hf->hf_features, BT_HFP_HF_FEATURE_CODEC_NEG))) {
+		err = hfp_hf_create_sco(hf);
+		return err;
+	}
+
+#if defined(CONFIG_BT_HFP_HF_CODEC_NEG)
 	err = hfp_hf_send_cmd(hf, NULL, bcc_finish, "AT+BCC");
 	if (err < 0) {
 		LOG_ERR("Fail to setup audio connection on %p", hf);
@@ -4087,8 +4217,8 @@ static void hfp_hf_connected(struct bt_rfcomm_dlc *dlc)
 
 	LOG_DBG("hf connected");
 
-	BT_ASSERT(hf);
-	hf_slc_establish(hf);
+	atomic_set_bit(hf->flags, BT_HFP_HF_FLAG_DLC_CONNECTED);
+	k_work_submit(&hf->slc_work);
 }
 
 static void hfp_hf_disconnected(struct bt_rfcomm_dlc *dlc)
@@ -4129,16 +4259,107 @@ static void bt_hf_work(struct k_work *work)
 	hfp_hf_send_data(hf);
 }
 
+static void bt_hf_slc_work(struct k_work *work)
+{
+	struct bt_hfp_hf *hf = CONTAINER_OF(work, struct bt_hfp_hf, slc_work);
+	int err;
+
+	if (!atomic_test_bit(hf->flags, BT_HFP_HF_FLAG_DISCOVER_DONE)) {
+		return;
+	}
+
+	if (!atomic_test_bit(hf->flags, BT_HFP_HF_FLAG_DLC_CONNECTED)) {
+		return;
+	}
+
+	if (atomic_test_and_set_bit(hf->flags, BT_HFP_HF_FLAG_FEAT_UPDATED)) {
+		return;
+	}
+
+	if (atomic_test_bit(hf->flags, BT_HFP_HF_FLAG_RECORD_FOUND)) {
+		hf_slc_establish(hf);
+		return;
+	}
+
+	err = bt_hfp_hf_disconnect(hf);
+	if (err != 0) {
+		LOG_ERR("Failed to disconnect AG: %d", err);
+	}
+}
+
+static uint8_t bt_hfp_hf_discover_cb(struct bt_conn *conn, struct bt_sdp_client_result *result,
+				     const struct bt_sdp_discover_params *params)
+{
+	size_t index;
+	struct bt_hfp_hf *hf;
+	int err;
+
+	index = (size_t)bt_conn_index(conn);
+	__ASSERT(index < ARRAY_SIZE(bt_hfp_hf_pool), "Index is out of bounds");
+
+	hf = &bt_hfp_hf_pool[index];
+
+	if ((result == NULL) || (result->resp_buf == NULL)) {
+		LOG_ERR("SDP discovery failed");
+		goto failed;
+	}
+
+	err = bt_sdp_get_profile_version(result->resp_buf, BT_SDP_HANDSFREE_SVCLASS,
+					 &hf->ag_sdp_version);
+	if (err != 0) {
+		LOG_ERR("Failed to get AG profile version");
+		goto failed;
+	}
+
+	err = bt_sdp_get_features(result->resp_buf, &hf->ag_sdp_features);
+	if (err != 0) {
+		LOG_ERR("Failed to get AG feature");
+		goto failed;
+	}
+
+	if ((hf->ag_sdp_version <= BT_HFP_VERSION_1_5) ||
+	    (BT_HFP_HF_VERSION <= BT_HFP_VERSION_1_5)) {
+		if (hf->ag_sdp_features & BT_HFP_AG_SDP_FEATURE_WBS) {
+			LOG_WRN("Unsupported SDP feature (WBS) is enabled.");
+			hf->ag_sdp_features &= ~BT_HFP_AG_SDP_FEATURE_WBS;
+		}
+
+		if (hf->ag_sdp_features & BT_HFP_AG_SDP_FEATURE_SUPER_WBS) {
+			LOG_WRN("Unsupported SDP feature (Super WBS) is enabled.");
+			hf->ag_sdp_features &= ~BT_HFP_AG_SDP_FEATURE_SUPER_WBS;
+		}
+	}
+
+	atomic_set_bit(hf->flags, BT_HFP_HF_FLAG_RECORD_FOUND);
+failed:
+	atomic_set_bit(hf->flags, BT_HFP_HF_FLAG_DISCOVER_DONE);
+	k_work_submit(&hf->slc_work);
+
+	return BT_SDP_DISCOVER_UUID_STOP;
+}
+
 static struct bt_hfp_hf *hfp_hf_create(struct bt_conn *conn)
 {
 	size_t index;
+	struct bt_hfp_hf *hf;
+	int err;
+
 	static struct bt_rfcomm_dlc_ops ops = {
 		.connected = hfp_hf_connected,
 		.disconnected = hfp_hf_disconnected,
 		.recv = hfp_hf_recv,
 		.sent = hfp_hf_sent,
 	};
-	struct bt_hfp_hf *hf;
+	static struct bt_sdp_attribute_id_range id_range[] = {
+		{ BT_SDP_ATTR_PROTO_DESC_LIST, BT_SDP_ATTR_PROTO_DESC_LIST },
+		{ BT_SDP_ATTR_PROFILE_DESC_LIST, BT_SDP_ATTR_PROFILE_DESC_LIST },
+		{ BT_SDP_ATTR_SUPPORTED_FEATURES, BT_SDP_ATTR_SUPPORTED_FEATURES },
+	};
+	static struct bt_sdp_attribute_id_list id_list = {
+		.count = ARRAY_SIZE(id_range),
+		.ranges = id_range,
+	};
+	static struct bt_uuid_16 uuid;
 
 	LOG_DBG("conn %p", conn);
 
@@ -4152,6 +4373,20 @@ static struct bt_hfp_hf *hfp_hf_create(struct bt_conn *conn)
 	}
 
 	memset(hf, 0, sizeof(*hf));
+
+	uuid.uuid.type = BT_UUID_TYPE_16;
+	uuid.val = BT_SDP_HANDSFREE_AGW_SVCLASS;
+
+	hf->sdp_param.func = bt_hfp_hf_discover_cb;
+	hf->sdp_param.type = BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR;
+	hf->sdp_param.uuid = &uuid.uuid;
+	hf->sdp_param.pool = &hf_pool;
+	hf->sdp_param.ids  = &id_list;
+
+	err = bt_sdp_discover(conn, &hf->sdp_param);
+	if (err != 0) {
+		return NULL;
+	}
 
 	hf->acl = conn;
 	hf->at.buf = hf->hf_buffer;
@@ -4168,7 +4403,14 @@ static struct bt_hfp_hf *hfp_hf_create(struct bt_conn *conn)
 	hf->hf_codec_ids = BT_HFP_HF_SUPPORTED_CODEC_IDS;
 	hf->active_codec_id = BT_HFP_HF_CODEC_CVSD;
 
+	/* Set the default AG infrmation */
+	hf->ag_sdp_features = BT_HFP_AG_SDP_FEATURE_3WAY_CALL |
+			      BT_HFP_AG_SDP_FEATURE_INBAND_RINGTONE;
+	hf->ag_sdp_version = BT_HFP_VERSION_0_96;
+
 	k_fifo_init(&hf->tx_pending);
+
+	k_work_init(&hf->slc_work, bt_hf_slc_work);
 
 	k_work_init(&hf->work, bt_hf_work);
 
@@ -4193,59 +4435,6 @@ static int hfp_hf_accept(struct bt_conn *conn, struct bt_rfcomm_server *server,
 	}
 
 	*dlc = &hf->rfcomm_dlc;
-
-	return 0;
-}
-
-static void hfp_hf_sco_connected(struct bt_sco_chan *chan)
-{
-	struct bt_hfp_hf *hf = CONTAINER_OF(chan, struct bt_hfp_hf, chan);
-
-	if ((bt_hf != NULL) && (bt_hf->sco_connected)) {
-		bt_hf->sco_connected(hf, chan->sco);
-	}
-}
-
-static void hfp_hf_sco_disconnected(struct bt_sco_chan *chan, uint8_t reason)
-{
-	if ((bt_hf != NULL) && (bt_hf->sco_disconnected)) {
-		bt_hf->sco_disconnected(chan->sco, reason);
-	}
-}
-
-static int hfp_hf_set_voice_setting(struct bt_hfp_hf *hf)
-{
-	uint16_t air_coding_fmt;
-
-	switch (hf->active_codec_id) {
-	case BT_HFP_HF_CODEC_CVSD:
-		air_coding_fmt = BT_HCI_VOICE_SETTING_AIR_CODING_FMT_CVSD;
-		break;
-#if defined(CONFIG_BT_HFP_HF_CODEC_NEG)
-	case BT_HFP_HF_CODEC_MSBC:
-		if (!IS_ENABLED(CONFIG_BT_HFP_HF_CODEC_MSBC)) {
-			LOG_ERR("mSBC is not enabled");
-			return -EINVAL;
-		}
-		air_coding_fmt = BT_HCI_VOICE_SETTING_AIR_CODING_FMT_TRANSPARENT;
-		break;
-	case BT_HFP_HF_CODEC_LC3_SWB:
-		if (!IS_ENABLED(CONFIG_BT_HFP_HF_CODEC_LC3_SWB)) {
-			LOG_ERR("LC3 SWB is not enabled");
-			return -EINVAL;
-		}
-		air_coding_fmt = BT_HCI_VOICE_SETTING_AIR_CODING_FMT_TRANSPARENT;
-		break;
-#endif /* CONFIG_BT_HFP_HF_CODEC_NEG */
-	default:
-		LOG_ERR("Unsupported codec ID %u", hf->active_codec_id);
-		return -EINVAL;
-	}
-
-	hf->chan.voice_setting = BT_HCI_VOICE_SETTINGS(
-		air_coding_fmt, BT_HCI_VOICE_SETTING_PCM_BIT_POS_DEFAULT,
-		BT_HCI_VOICE_SETTING_SAMPLE_SIZE_16_BITS,
-		BT_HCI_VOICE_SETTING_DATA_FMT_2_COMPLEMENT, BT_HCI_VOICE_SETTING_CODING_FMT_LINEAR);
 
 	return 0;
 }

--- a/subsys/bluetooth/host/classic/hfp_hf_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_hf_internal.h
@@ -161,6 +161,10 @@ enum {
 	BT_HFP_HF_FLAG_QUERY_CALLS,   /* Require to query list of current calls */
 	BT_HFP_HF_FLAG_USR_CLCC_CMD,  /* User-initiated AT+CLCC command */
 	BT_HFP_HF_FLAG_USR_CLCC_PND,  /* User-initiated AT+CLCC command is pending */
+	BT_HFP_HF_FLAG_DISCOVER_DONE, /* SDP discovered done */
+	BT_HFP_HF_FLAG_RECORD_FOUND,  /* SDP AG Record found */
+	BT_HFP_HF_FLAG_DLC_CONNECTED, /* HFP HF DLC is connected */
+	BT_HFP_HF_FLAG_FEAT_UPDATED,  /* Remote feature has been updated */
 	/* Total number of flags - must be at the end of the enum */
 	BT_HFP_HF_NUM_FLAGS,
 };
@@ -210,6 +214,15 @@ struct bt_hfp_hf {
 	struct k_fifo tx_pending;
 	/* SCO Channel */
 	struct bt_sco_chan chan;
+	/* SCO connect */
+	struct bt_conn *sco_conn;
+
+	/* SDP discover params */
+	struct bt_sdp_discover_params sdp_param;
+
+	/* SCL work */
+	struct k_work slc_work;
+
 	char hf_buffer[HF_MAX_BUF_LEN];
 	struct at_client at;
 	uint32_t hf_features;
@@ -224,6 +237,10 @@ struct bt_hfp_hf {
 	uint32_t hf_ind;
 	uint32_t ag_ind;
 	uint32_t ind_enable;
+
+	/* AG profile information */
+	uint16_t ag_sdp_version;
+	uint16_t ag_sdp_features;
 
 	/* AT command initialization indicator */
 	uint8_t cmd_init_seq;

--- a/subsys/bluetooth/host/classic/hfp_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_internal.h
@@ -8,6 +8,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* HFP Profile Version */
+#define BT_HFP_VERSION_0_96 0x0096 /* HFP Rev. 0.96 */
+#define BT_HFP_VERSION_1_0  0x0100 /* HFP Rev. 1.0 */
+#define BT_HFP_VERSION_1_5  0x0105 /* HFP Rev. 1.5 */
+#define BT_HFP_VERSION_1_6  0x0106 /* HFP Rev. 1.6 */
+#define BT_HFP_VERSION_1_7  0x0107 /* HFP Rev. 1.7 */
+#define BT_HFP_VERSION_1_8  0x0108 /* HFP Rev. 1.8 */
+#define BT_HFP_VERSION_1_9  0x0109 /* HFP Rev. 1.9 */
+
 #define BT_HFP_MAX_MTU       (BT_L2CAP_RX_MTU - BT_RFCOMM_HDR_MAX_SIZE - BT_RFCOMM_FCS_SIZE)
 #define BT_HF_CLIENT_MAX_PDU BT_HFP_MAX_MTU
 


### PR DESCRIPTION
* Bluetooth: Classic: HFP_HF: Compatible old version AG

In current implementation, the AG with old version cannot be supported properly. Such as, if the AG is version 0.96, the AT command `AT+BRSF` should not be sent. And if the AG is no newer than version 1.5, the `Codec Negotiation` should be unsupported.

Compatible old version with the following changes,

Discover the AG SDP record to get the profile version and AG features. If the SDP discovery is failed, break the RFCOMM DLC
connection.

If the AG version is v0.96, do not send AT command `AT+BRSF`.

Create SCO connection directly if the AG is not newer than version 1.5 in the function `bt_hfp_hf_audio_connect()`.

* Bluetooth: Classic: HFP_AG: Compatible old version HF

In current implementation, the HF with old version cannot be supported properly. Such as, if the AG is version 0.96, the AT command `AT+BRSF` will not be sent. It causes the AG cannot know the features of HF.

Compatible old version with the following changes, 

Discover the HF SDP record to get the profile version and HF features.
If the SDP discovery is failed, break the RFCOMM DLC connection.

If the AG version is v0.96, update the HF features according to the discovered HF features.

* Bluetooth: Classic: HFP_HF: Register SCO connect callback

There is an issue that the SCO connect cannot be un-referenced by HFP HF when the SCO connection is broken if the SCO connect is not created by HFP HF.

Register SCO connect change callback. And un-reference the SCO connect in SCO disconnected callback.
