### PR TITLE
MAINTAINERS: Add open-amp and libmetal maintainers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5836,9 +5836,10 @@ West:
     - "area: MCTP"
 
 "West project: libmetal":
-  status: odd fixes
-  collaborators:
+  status: maintained
+  maintainers:
     - arnopo
+    - iuliana-prodan
   files:
     - modules/Kconfig.libmetal
   labels:
@@ -5991,10 +5992,12 @@ West:
     - "area: Wi-Fi"
 
 "West project: open-amp":
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - arnopo
+    - iuliana-prodan
   collaborators:
     - uLipe
-    - iuliana-prodan
   files:
     - modules/Kconfig.open-amp
   labels:


### PR DESCRIPTION
- Add Iulia Prodan as she is already a maintainer of the OpenAMP module.
- Add myself as I am maintainer of the openAMP project.

