### PR TITLE
llext: export symbols by groups

### DIFF
--- a/doc/services/llext/config.rst
+++ b/doc/services/llext/config.rst
@@ -126,6 +126,44 @@ LLEXT subsystem to optimize memory footprint in this case.
            information on this topic is available on GitHub issue `#75341
            <https://github.com/zephyrproject-rtos/zephyr/issues/75341>`_.
 
+.. _llext_symbol_groups:
+
+Symbol Groups
+-------------
+
+All LLEXT symbols belong to a group, with the inclusion of each group in the
+exported symbol table controlled by a corresponding Kconfig symbol. Exporting
+a symbol as part of a group is done with the :c:macro:`EXPORT_GROUP_SYMBOL`
+and :c:macro:`EXPORT_GROUP_SYMBOL_NAMED` macros. For example the following
+exports the symbol ``memcpy`` as part of the ``LIBC`` group:
+
+.. code:: c
+
+   EXPORT_GROUP_SYMBOL(LIBC, memcpy);
+
+Group names are arbitrary, but they must be all uppercase. For each group
+used in C code, there **MUST** be a corresponding Kconfig symbol of the form:
+
+.. code::
+
+   config LLEXT_EXPORT_SYMBOL_GROUP_{GROUP_NAME}
+      bool "Export all symbols from the {GROUP_NAME} group"
+
+The default group for symbols (those declared with :c:macro:`EXPORT_SYMBOL`
+or :c:macro:`EXPORT_SYMBOL_NAMED`) is the ``UNASSIGNED`` group. As per the
+above rules, the inclusion of this group is controlled by
+:kconfig:option:`CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_UNASSIGNED`.
+
+The groups currently defined by Zephyr are:
+
+.. csv-table:: Zephyr LLEXT symbol groups
+  :header: Group Name, Kconfig Symbol, Description
+
+  ``UNASSIGNED``, :kconfig:option:`CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_UNASSIGNED`, Symbols without an explicit group
+  ``SYSCALL``, :kconfig:option:`CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_SYSCALL`, Zephyr kernel system calls
+  ``LIBC``, :kconfig:option:`CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_LIBC`, C standard library functions (:c:func:`memcpy` etc)
+  ``DEVICE``, :kconfig:option:`CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_DEVICE`, Devicetree devices
+
 .. _llext_kconfig_slid:
 
 Using SLID for symbol lookups

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -112,8 +112,9 @@ typedef int16_t device_handle_t;
 
 /* By default, device identifiers are obtained using the dependency ordinal.
  * When LLEXT_EXPORT_DEV_IDS_BY_HASH is defined, the main Zephyr binary exports
- * DT identifiers via EXPORT_SYMBOL_NAMED as hashed versions of their paths.
- * When matching extensions are built, that is what they need to look for.
+ * DT identifiers via EXPORT_GROUP_SYMBOL_NAMED as hashed versions of their
+ * paths. When matching extensions are built, that is what they need to look
+ * for.
  *
  * The ordinal or hash used in this name can be mapped to the path by
  * examining zephyr/include/generated/zephyr/devicetree_generated.h.
@@ -127,11 +128,13 @@ typedef int16_t device_handle_t;
 #if defined(CONFIG_LLEXT_EXPORT_DEV_IDS_BY_HASH)
 /* Export device identifiers by hash */
 #define Z_DEVICE_EXPORT(node_id)					       \
-	EXPORT_SYMBOL_NAMED(DEVICE_DT_NAME_GET(node_id),		       \
-			    DEVICE_NAME_GET(Z_DEVICE_DT_HASH(node_id)))
-#elif defined(CONFIG_LLEXT_EXPORT_DEVICES)
+	EXPORT_GROUP_SYMBOL_NAMED(DEVICE,				       \
+				  DEVICE_DT_NAME_GET(node_id),		       \
+				  DEVICE_NAME_GET(Z_DEVICE_DT_HASH(node_id)))
+#else
 /* Export device identifiers using the builtin name */
-#define Z_DEVICE_EXPORT(node_id) EXPORT_SYMBOL(DEVICE_DT_NAME_GET(node_id))
+#define Z_DEVICE_EXPORT(node_id)					       \
+	EXPORT_GROUP_SYMBOL(DEVICE, DEVICE_DT_NAME_GET(node_id))
 #endif
 
 /**
@@ -213,8 +216,8 @@ typedef int16_t device_handle_t;
  * The device is declared with extern visibility, so a pointer to a global
  * device object can be obtained with `DEVICE_DT_GET(node_id)` from any source
  * file that includes `<zephyr/device.h>` (even from extensions, when
- * @kconfig{CONFIG_LLEXT_EXPORT_DEVICES} is enabled). Before using the
- * pointer, the referenced object should be checked using device_is_ready().
+ * @kconfig{CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_DEVICE} is enabled). Before using
+ * the pointer, the referenced object should be checked using device_is_ready().
  *
  * Note: deinit_fn will only be used if CONFIG_DEVICE_DEINIT_SUPPORT is enabled.
  *
@@ -1306,8 +1309,8 @@ device_get_dt_nodelabels(const struct device *dev)
                                                                                 \
 	Z_DEVICE_INIT_ENTRY_DEFINE(node_id, dev_id, level, prio);               \
                                                                                 \
-	IF_ENABLED(CONFIG_LLEXT_EXPORT_DEVICES,                                 \
-		(IF_ENABLED(DT_NODE_EXISTS(node_id),                            \
+	IF_ENABLED(CONFIG_LLEXT,                                                \
+		   (IF_ENABLED(DT_NODE_EXISTS(node_id),                         \
 				(Z_DEVICE_EXPORT(node_id);))))
 
 /**

--- a/include/zephyr/llext/symbol.h
+++ b/include/zephyr/llext/symbol.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_LLEXT_SYMBOL_H
 
 #include <zephyr/sys/iterable_sections.h>
+#include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -155,19 +156,33 @@ struct llext_symtable {
 #endif
 /** @endcond */
 
+#if defined(LL_EXTENSION_BUILD)
+/* Extension build: No Kconfig conditionals */
+#define Z_EXPORT_SYMBOL_NAMED_IN_GROUP(group, sym_ident, sym_name)		\
+	Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)
+#else
+/* LLEXT application: Export if relevant group is enabled */
+#define Z_EXPORT_SYMBOL_NAMED_IN_GROUP(group, sym_ident, sym_name)		\
+	IF_ENABLED(CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_ ## group,			\
+		(Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)))
+#endif /* defined(LL_EXTENSION_BUILD) */
+
 /**
  * @brief Export a constant symbol from the current build with a custom name
  *
  * Version of @ref EXPORT_SYMBOL that allows the user to specify a custom name
- * for the exported symbol.
+ * for the exported symbol. The symbol is part of the UNASSIGNED group.
  *
  * When @c CONFIG_LLEXT is not enabled, this macro is a no-op.
+ *
+ * When @c CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_UNASSIGNED  is not enabled, this
+ * macro is a no-op.
  *
  * @param sym_ident Symbol to export
  * @param sym_name Name associated with the symbol
  */
 #define EXPORT_SYMBOL_NAMED(sym_ident, sym_name)				\
-	Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)
+	Z_EXPORT_SYMBOL_NAMED_IN_GROUP(UNASSIGNED, sym_ident, sym_name)
 
 /**
  * @brief Export a constant symbol from the current build
@@ -175,8 +190,12 @@ struct llext_symtable {
  * Takes a symbol (function or object) by symbolic name and adds the name
  * and address of the symbol to a table of symbols that may be referenced
  * by extensions or by the base image, depending on the current build type.
+ * The symbol is part of the UNASSIGNED group.
  *
  * When @c CONFIG_LLEXT is not enabled, this macro is a no-op.
+ *
+ * When @c CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_UNASSIGNED  is not enabled, this
+ * macro is a no-op.
  *
  * @param x Symbol to export
  */

--- a/include/zephyr/llext/symbol.h
+++ b/include/zephyr/llext/symbol.h
@@ -175,7 +175,7 @@ struct llext_symtable {
  *
  * When @c CONFIG_LLEXT is not enabled, this macro is a no-op.
  *
- * When @c CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_UNASSIGNED  is not enabled, this
+ * When @c CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_UNASSIGNED is not enabled, this
  * macro is a no-op.
  *
  * @param sym_ident Symbol to export
@@ -194,12 +194,47 @@ struct llext_symtable {
  *
  * When @c CONFIG_LLEXT is not enabled, this macro is a no-op.
  *
- * When @c CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_UNASSIGNED  is not enabled, this
+ * When @c CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_UNASSIGNED is not enabled, this
  * macro is a no-op.
  *
  * @param x Symbol to export
  */
 #define EXPORT_SYMBOL(x) EXPORT_SYMBOL_NAMED(x, x)
+
+/**
+ * @brief Export a constant symbol with a custom name and group
+ *
+ * Version of @ref EXPORT_SYMBOL_NAMED that allows placing the symbol in a
+ * custom group.
+ *
+ * When @c CONFIG_LLEXT is not enabled, this macro is a no-op.
+ *
+ * When @c CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_{group} is not enabled, this macro
+ * is a no-op.
+ *
+ * @param group Group in which symbol is exported (must be uppercase)
+ * @param sym_ident Symbol to export
+ * @param sym_name Name associated with the symbol
+ */
+#define EXPORT_GROUP_SYMBOL_NAMED(group, sym_ident, sym_name)			\
+	Z_EXPORT_SYMBOL_NAMED_IN_GROUP(group, sym_ident, sym_name)
+
+/**
+ * @brief Export a constant symbol in a custom group
+ *
+ * Version of @ref EXPORT_SYMBOL that allows placing the symbol in a
+ * custom group.
+ *
+ * When @c CONFIG_LLEXT is not enabled, this macro is a no-op.
+ *
+ * When @c CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_{group} is not enabled, this macro
+ * is a no-op.
+ *
+ * @param group Group in which symbol is exported (must be uppercase)
+ * @param sym_ident Symbol to export
+ */
+#define EXPORT_GROUP_SYMBOL(group, sym_ident) \
+	EXPORT_GROUP_SYMBOL_NAMED(group, sym_ident, sym_ident)
 
 /**
  * @}

--- a/scripts/build/gen_syscalls.py
+++ b/scripts/build/gen_syscalls.py
@@ -531,7 +531,7 @@ def main():
             # Export symbols for emitted syscalls
             extern_refs = "\n".join("extern void * const %s;"
                                   % e for e in exported)
-            exported_symbols = "\n".join("EXPORT_SYMBOL(%s);"
+            exported_symbols = "\n".join("EXPORT_GROUP_SYMBOL(SYSCALL, %s);"
                                          % e for e in exported)
             fp.write(llext_exports_template % (extern_refs, exported_symbols))
 

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -110,13 +110,14 @@ config LLEXT_STORAGE_WRITABLE
 
 config LLEXT_EXPORT_DEVICES
 	bool "Export all DT devices to llexts"
+	select LLEXT_EXPORT_SYMBOL_GROUP_DEVICE
 	help
 	  When enabled, all Zephyr devices defined in the device tree are
 	  made available to llexts via the standard DT_ / DEVICE_* macros.
 
 config LLEXT_EXPORT_DEV_IDS_BY_HASH
 	bool "Use hash of device path in device name"
-	depends on LLEXT_EXPORT_DEVICES
+	depends on LLEXT_EXPORT_SYMBOL_GROUP_DEVICE
 	help
 	  When enabled, exported device names are generated from a hash of the
 	  node path instead of an ordinal number. Identifiers generated this
@@ -173,6 +174,12 @@ config LLEXT_EXPORT_SYMBOL_GROUP_LIBC
 	default y
 	help
 	  Export symbols such as memcpy, memset, strlen.
+
+config LLEXT_EXPORT_SYMBOL_GROUP_DEVICE
+	bool "Export Zephyr devices"
+	help
+	  When enabled, all Zephyr devices defined in the device tree are
+	  made available to llexts via the standard DT_ / DEVICE_* macros.
 
 endmenu
 

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -162,6 +162,12 @@ config LLEXT_EXPORT_SYMBOL_GROUP_UNASSIGNED
 	help
 	  Exports all symbols declared without an explicit group.
 
+config LLEXT_EXPORT_SYMBOL_GROUP_SYSCALL
+	bool "Export all syscalls"
+	default y
+	help
+	  Exports all syscall symbols.
+
 endmenu
 
 module = LLEXT

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -154,6 +154,16 @@ config LLEXT_EXPERIMENTAL
 	  Include support for LLEXT experimental and unstable functionality that
 	  has a very high likelihood to change in the future.
 
+menu "Exported symbol groups"
+
+config LLEXT_EXPORT_SYMBOL_GROUP_UNASSIGNED
+	bool "Export all symbols from the UNASSIGNED group"
+	default y
+	help
+	  Exports all symbols declared without an explicit group.
+
+endmenu
+
 module = LLEXT
 module-str = llext
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -168,6 +168,12 @@ config LLEXT_EXPORT_SYMBOL_GROUP_SYSCALL
 	help
 	  Exports all syscall symbols.
 
+config LLEXT_EXPORT_SYMBOL_GROUP_LIBC
+	bool "Export standard library symbols"
+	default y
+	help
+	  Export symbols such as memcpy, memset, strlen.
+
 endmenu
 
 module = LLEXT

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -157,21 +157,27 @@ config LLEXT_EXPERIMENTAL
 
 menu "Exported symbol groups"
 
+config LLEXT_EXPORT_DEFAULT_GROUPS
+	bool "Export the default set of Zephyr application symbols"
+	default y
+	help
+	  Exports default, syscall and libc symbols
+
 config LLEXT_EXPORT_SYMBOL_GROUP_UNASSIGNED
 	bool "Export all symbols from the UNASSIGNED group"
-	default y
+	default y if LLEXT_EXPORT_DEFAULT_GROUPS
 	help
 	  Exports all symbols declared without an explicit group.
 
 config LLEXT_EXPORT_SYMBOL_GROUP_SYSCALL
 	bool "Export all syscalls"
-	default y
+	default y if LLEXT_EXPORT_DEFAULT_GROUPS
 	help
 	  Exports all syscall symbols.
 
 config LLEXT_EXPORT_SYMBOL_GROUP_LIBC
 	bool "Export standard library symbols"
-	default y
+	default y if LLEXT_EXPORT_DEFAULT_GROUPS
 	help
 	  Export symbols such as memcpy, memset, strlen.
 

--- a/subsys/llext/llext_export.c
+++ b/subsys/llext/llext_export.c
@@ -7,14 +7,14 @@
 #include <string.h>
 #include <zephyr/llext/symbol.h>
 
-EXPORT_SYMBOL(strcpy);
-EXPORT_SYMBOL(strncpy);
-EXPORT_SYMBOL(strlen);
-EXPORT_SYMBOL(strcmp);
-EXPORT_SYMBOL(strncmp);
-EXPORT_SYMBOL(memcmp);
-EXPORT_SYMBOL(memcpy);
-EXPORT_SYMBOL(memset);
+EXPORT_GROUP_SYMBOL(LIBC, strcpy);
+EXPORT_GROUP_SYMBOL(LIBC, strncpy);
+EXPORT_GROUP_SYMBOL(LIBC, strlen);
+EXPORT_GROUP_SYMBOL(LIBC, strcmp);
+EXPORT_GROUP_SYMBOL(LIBC, strncmp);
+EXPORT_GROUP_SYMBOL(LIBC, memcmp);
+EXPORT_GROUP_SYMBOL(LIBC, memcpy);
+EXPORT_GROUP_SYMBOL(LIBC, memset);
 
 /* These symbols are used if CCAC is given the flag -Os */
 #ifdef __CCAC__


### PR DESCRIPTION
Add the concept of "groups" to exported symbols, that allows including or excluding those groups from the exported symbol list through Kconfig.

Alternative to #98890