### PR TITLE
include: zephyr: drivers: Add BUS_DT_INST_IODEV_DEFINE variants

### DIFF
--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -1133,6 +1133,18 @@ extern const struct rtio_iodev_api i2c_iodev_api;
 	RTIO_IODEV_DEFINE(name, &i2c_iodev_api, (void *)&_i2c_dt_spec_##name)
 
 /**
+ * @brief Define an iodev for a devicetree instance on the bus
+ *
+ * This is equivalent to
+ * <tt>I2C_DT_IODEV_DEFINE(name, DT_DRV_INST(inst))</tt>.
+ *
+ * @param name Symbolic name of the iodev to define
+ * @param inst Devicetree instance number
+ */
+#define I2C_DT_INST_IODEV_DEFINE(name, inst)					\
+	I2C_DT_IODEV_DEFINE(name, DT_DRV_INST(inst))
+
+/**
  * @brief Define an iodev for a given i2c device on a bus
  *
  * These do not need to be shared globally but doing so

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -2751,6 +2751,18 @@ extern const struct rtio_iodev_api i3c_iodev_api;
 	RTIO_IODEV_DEFINE(name, &i3c_iodev_api, (void *)&_i3c_iodev_data_##name)
 
 /**
+ * @brief Define an iodev for a devicetree instance on the bus
+ *
+ * This is equivalent to
+ * <tt>I3C_DT_IODEV_DEFINE(name, DT_DRV_INST(inst))</tt>.
+ *
+ * @param name Symbolic name of the iodev to define
+ * @param inst Devicetree instance number
+ */
+#define I3C_DT_INST_IODEV_DEFINE(name, inst)					\
+	I3C_DT_IODEV_DEFINE(name, DT_DRV_INST(inst))
+
+/**
  * @brief Copy the i3c_msgs into a set of RTIO requests
  *
  * @param r RTIO context

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -1367,6 +1367,19 @@ extern const struct rtio_iodev_api spi_iodev_api;
 	RTIO_IODEV_DEFINE(name, &spi_iodev_api, (void *)&_spi_dt_spec_##name)
 
 /**
+ * @brief Define an iodev for a devicetree instance on the bus
+ *
+ * This is equivalent to
+ * <tt>SPI_DT_IODEV_DEFINE(name, DT_DRV_INST(inst), operation)</tt>.
+ *
+ * @param name Symbolic name to use for defining the iodev
+ * @param inst Devicetree instance number
+ * @param operation_ SPI operational mode
+ */
+#define SPI_DT_INST_IODEV_DEFINE(name, inst, operation_, ...)			\
+	SPI_DT_IODEV_DEFINE(name, DT_DRV_INST(inst), operation_, __VA_ARGS__)
+
+/**
  * @brief Validate that SPI bus (and CS gpio if defined) is ready.
  *
  * @param spi_iodev SPI iodev defined with SPI_DT_IODEV_DEFINE


### PR DESCRIPTION
Add helper macros for `I2C_DT_IODEV_DEFINE`/`I3C_DT_IODEV_DEFINE`/`SPI_DT_IODEV_DEFINE` with an instance variant.

I can update the PR with updating in-tree usages too, if desired.