### PR TITLE
Bluetooth: Decode Bluetooth 6.2 version number

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -928,6 +928,7 @@ struct bt_hci_rp_configure_data_path {
 #define BT_HCI_VERSION_5_4                      13
 #define BT_HCI_VERSION_6_0                      14
 #define BT_HCI_VERSION_6_1                      15
+#define BT_HCI_VERSION_6_2                      16
 
 #define BT_HCI_OP_READ_LOCAL_VERSION_INFO       BT_OP(BT_OGF_INFO, 0x0001) /* 0x1001 */
 struct bt_hci_rp_read_local_version_info {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3974,7 +3974,7 @@ const char *bt_hci_get_ver_str(uint8_t core_version)
 {
 	const char * const str[] = {
 		"1.0b", "1.1", "1.2", "2.0", "2.1", "3.0", "4.0", "4.1", "4.2",
-		"5.0", "5.1", "5.2", "5.3", "5.4", "6.0", "6.1"
+		"5.0", "5.1", "5.2", "5.3", "5.4", "6.0", "6.1", "6.2"
 	};
 
 	if (core_version < ARRAY_SIZE(str)) {


### PR DESCRIPTION
Bluetooth 6.2 has version number 0x10 and was released in November 2025.
This commit ensures this version number is properly decoded.