### PR TITLE
boards: st: OpenOCD Fix for WB55 Based Boards

### DIFF
--- a/boards/st/nucleo_wb55rg/support/openocd.cfg
+++ b/boards/st/nucleo_wb55rg/support/openocd.cfg
@@ -1,1 +1,1 @@
-source [find board/st_nucleo_wb55rg]
+source [find board/st_nucleo_wb55.cfg]

--- a/boards/st/stm32wb5mm_dk/support/openocd.cfg
+++ b/boards/st/stm32wb5mm_dk/support/openocd.cfg
@@ -1,2 +1,2 @@
-# OpenOCD st_nucleo_wb55rg.cfg matches stm32wb55mm_dk support
-source [find board/st_nucleo_wb55rg.cfg]
+# OpenOCD st_nucleo_wb55.cfg matches stm32wb55mm_dk support
+source [find board/st_nucleo_wb55.cfg]

--- a/boards/st/stm32wb5mmg/support/openocd.cfg
+++ b/boards/st/stm32wb5mmg/support/openocd.cfg
@@ -1,2 +1,2 @@
-# OpenOCD st_nucleo_wb55rg.cfg matches stm32wb55mmg support
-source [find board/st_nucleo_wb55k.cfg]
+# OpenOCD st_nucleo_wb55.cfg matches stm32wb55mmg support
+source [find board/st_nucleo_wb55.cfg]


### PR DESCRIPTION
Fixes the OpenOCD configuration for nucleo_wb55rg, stm32wb55mm_dk and stm32wb55mmg.

PR #97638 changed the OpenOCD configurations to address deprecation. There were however some issues in the configuration files for the named boards. They reference non-existing OpenOCD configuration files, causing flashing to fail when using the `openocd` runner. This PR fixes this.

Note that because of hardwareavailability reasons I could only test this fix on the Nucleo WB55RG board, but as mentioned in their configuration files, the other boards use the same configuration.

Resolves #99011 