### PR TITLE
sys: util: remove extra call in WAIT_FOR

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -1092,11 +1092,13 @@ static inline size_t sys_count_bits(const void *value, size_t len)
 	({                                                                                         \
 		uint32_t _wf_cycle_count = k_us_to_cyc_ceil32(timeout);                            \
 		uint32_t _wf_start = k_cycle_get_32();                                             \
-		while (!(expr) && (_wf_cycle_count > (k_cycle_get_32() - _wf_start))) {            \
+		bool _wf_ret;                                                                      \
+		while (!(_wf_ret = (expr)) &&                                                      \
+		       (_wf_cycle_count > (k_cycle_get_32() - _wf_start))) {                       \
 			delay_stmt;                                                                \
 			Z_SPIN_DELAY(10);                                                          \
 		}                                                                                  \
-		(expr);                                                                            \
+		(_wf_ret);                                                                         \
 	})
 
 /**

--- a/tests/lib/sys_util/src/main.c
+++ b/tests/lib/sys_util/src/main.c
@@ -22,6 +22,7 @@
 ZTEST(sys_util, test_wait_for)
 {
 	uint32_t start, end, expected;
+	int i = 0;
 
 	zassert_true(WAIT_FOR(true, 0, NULL), "true, no wait, NULL");
 	zassert_true(WAIT_FOR(true, 0, k_yield()), "true, no wait, yield");
@@ -30,6 +31,8 @@ ZTEST(sys_util, test_wait_for)
 	zassert_false(WAIT_FOR(false, 1, k_yield()), "false, 1usec, yield");
 	zassert_true(WAIT_FOR(true, 1000, k_yield()), "true, 1msec, yield");
 
+	WAIT_FOR(++i == 2, 1000, NULL);
+	zassert_equal(i, 2);
 
 	expected = 1000*(sys_clock_hw_cycles_per_sec()/USEC_PER_SEC);
 	start = k_cycle_get_32();


### PR DESCRIPTION
WAIT_FOR calls `expr` after it has evaluated to true.

Store `expr` in a variable and return it instead to prevent the additional `expr` call.