### PR TITLE
drivers: flash: stm32 qspi: Make delayed data sampling configurable

### DIFF
--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -176,6 +176,7 @@
 		     &quadspi_bk2_io0_ph2
 		     &quadspi_bk2_io1_ph3>;
 	dual-flash;
+	ssht-enable;
 	status = "okay";
 
 	mt25ql512ab1: qspi-nor-flash-1@0 {

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -251,6 +251,7 @@ zephyr_udc0: &usbotg_hs {
 		     &quadspi_bk2_io2_pg9 &quadspi_bk2_io3_pg14>;
 	pinctrl-names = "default";
 	dual-flash;
+	ssht-enable;
 	status = "okay";
 
 	mt25ql512ab1: qspi-nor-flash-1@0 {

--- a/boards/st/stm32h750b_dk/stm32h750b_dk-common.dtsi
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk-common.dtsi
@@ -169,6 +169,7 @@
 	 * and accessed simultaneously, 4bits sent to/received from each.
 	 */
 	dual-flash;
+	ssht-enable;
 	status = "okay";
 
 	ext_flash_ctrl: qspi-flash-controller@0 {

--- a/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
@@ -265,6 +265,7 @@ zephyr_udc0: &usbotg_hs {
 		     &quadspi_bk2_io2_pg9 &quadspi_bk2_io3_pg14>;
 	pinctrl-names = "default";
 	dual-flash;
+	ssht-enable;
 	status = "okay";
 
 	mt25ql512ab1: qspi-nor-flash-1@0 {

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -32,6 +32,14 @@ Boards
 Device Drivers and Devicetree
 *****************************
 
+QSPI
+===
+
+* :dtcompatible:`st,stm32-qspi` compatible nodes configured with ``dual-flash`` property
+  now need to also include the ``ssht-enable`` property to reenable sample shifting.
+  Sample shifting is configurable now and disabled by default.
+  (:github:`98999`).
+
 Bluetooth
 *********
 

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1631,7 +1631,6 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	dev_data->hqspi.Init.ClockPrescaler = prescaler;
 	/* Give a bit position from 0 to 31 to the HAL init minus 1 for the DCR1 reg */
 	dev_data->hqspi.Init.FlashSize = find_lsb_set(dev_cfg->flash_size) - 2;
-	dev_data->hqspi.Init.SampleShifting = QSPI_SAMPLE_SHIFTING_HALFCYCLE;
 	dev_data->hqspi.Init.ChipSelectHighTime = dev_cfg->cs_high_time - 1;
 #if STM32_QSPI_DOUBLE_FLASH
 	dev_data->hqspi.Init.DualFlash = QSPI_DUALFLASH_ENABLE;
@@ -1840,7 +1839,9 @@ static struct flash_stm32_qspi_data flash_stm32_qspi_dev_data = {
 		.Instance = (QUADSPI_TypeDef *)DT_REG_ADDR(STM32_QSPI_NODE),
 		.Init = {
 			.FifoThreshold = STM32_QSPI_FIFO_THRESHOLD,
-			.SampleShifting = QSPI_SAMPLE_SHIFTING_NONE,
+			.SampleShifting = DT_PROP(STM32_QSPI_NODE, ssht_enable)
+					? QSPI_SAMPLE_SHIFTING_HALFCYCLE
+					: QSPI_SAMPLE_SHIFTING_NONE,
 			.ChipSelectHighTime = QSPI_CS_HIGH_TIME_1_CYCLE,
 			.ClockMode = QSPI_CLOCK_MODE_0,
 			},

--- a/dts/bindings/qspi/st,stm32-qspi.yaml
+++ b/dts/bindings/qspi/st,stm32-qspi.yaml
@@ -60,6 +60,13 @@ properties:
       For example
          dma-names = "tx_rx";
 
+  ssht-enable:
+    type: boolean
+    description: |
+      Enables Sample Shifting half-cycle.
+
+      It is recommended to be enabled in STR mode and disabled in DTR mode.
+
   dual-flash:
     type: boolean
     description: |


### PR DESCRIPTION
PR #92742 enabled STM32 QSPI delayed data sampling (SSHIFT) for single flash mode. This caused communication issues with our flash chip starting with SFDP reading. From my point of view this is regression introduced in v4.3.

The only reliable solution found was to disable SSHIFT. SSHIFT is not configurable in the current codebase.

This PR implements configurable SSHIFT (ssht-enable), similarly to what XSPI and OSPI drivers implement.

Fixes #99099 