### PR TITLE
drivers: dmic_mcux: Revert identity mapping

### DIFF
--- a/drivers/audio/dmic_mcux.c
+++ b/drivers/audio/dmic_mcux.c
@@ -67,11 +67,18 @@ static uint8_t dmic_mcux_hw_chan(struct mcux_dmic_drv_data *drv_data,
 	enum pdm_lr lr;
 	uint8_t hw_chan;
 
+	/* This function assigns hardware channel "n" to the left channel,
+	 * and hardware channel "n+1" to the right channel. This choice is
+	 * arbitrary, but must be followed throughout the driver.
+	 */
 	dmic_parse_channel_map(drv_data->chan_map_lo,
 			       drv_data->chan_map_hi,
 			       log_chan, &hw_chan, &lr);
-
-	return hw_chan;
+	if (lr == PDM_CHAN_LEFT) {
+		return hw_chan * 2;
+	} else {
+		return (hw_chan * 2) + 1;
+	}
 }
 
 static void dmic_mcux_activate_channels(struct mcux_dmic_drv_data *drv_data,
@@ -494,9 +501,9 @@ static int dmic_mcux_configure(const struct device *dev,
 			dmic_parse_channel_map(channel->req_chan_map_lo,
 					       channel->req_chan_map_hi,
 					       chan + 1, &hw_chan_1, &lr_1);
-			/* Verify that paired channels use consecutive hardware index */
+			/* Verify that paired channels use same hardware index */
 			if ((lr_0 == lr_1) ||
-			    (hw_chan_1 != (hw_chan_0 + 1))) {
+			    (hw_chan_0 != hw_chan_1)) {
 				return -EINVAL;
 			}
 		}

--- a/samples/drivers/i2s/i2s_codec/src/main.c
+++ b/samples/drivers/i2s/i2s_codec/src/main.c
@@ -132,7 +132,7 @@ int main(void)
 #if CONFIG_USE_DMIC
 	cfg.channel.req_num_chan = 2;
 	cfg.channel.req_chan_map_lo = dmic_build_channel_map(0, 0, PDM_CHAN_LEFT) |
-				      dmic_build_channel_map(1, 1, PDM_CHAN_RIGHT);
+				      dmic_build_channel_map(1, 0, PDM_CHAN_RIGHT);
 	cfg.streams[0].pcm_rate = SAMPLE_FREQUENCY;
 	cfg.streams[0].block_size = BLOCK_SIZE;
 


### PR DESCRIPTION
Revert commits 1f69b91e909cc37301ac15d7e7f30e87c413ab21 and d11474ce6463c89a8e43565142fae5914850c845.

The identity mapping introduced in 1f69b91e909cc37301ac15d7e7f30e87c413ab21 by @mjchen0 constitutes a deviation from the dmic API, against which tests and samples are written.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/93494.