### PR TITLE
tests: pm: power_domain: add ISR safe power management test coverage

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2018 Intel Corporation.
  * Copyright (c) 2021 Nordic Semiconductor ASA.
  * Copyright (c) 2025 HubbleNetwork.
+ * Copyright (c) 2025 NXP.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -159,16 +160,20 @@ static int get_sync_locked(const struct device *dev)
 	uint32_t flags = pm->base.flags;
 
 	if (pm->base.usage == 0) {
-		if (flags & BIT(PM_DEVICE_FLAG_PD_CLAIMED)) {
+		if ((flags & BIT(PM_DEVICE_FLAG_PD_CLAIMED)) == 0) {
 			const struct device *domain = PM_DOMAIN(&pm->base);
 
-			if (domain->pm_base->flags & BIT(PM_DEVICE_FLAG_ISR_SAFE)) {
-				ret = pm_device_runtime_get(domain);
-				if (ret < 0) {
-					return ret;
+			if (domain != NULL) {
+				if ((domain->pm_base->flags & BIT(PM_DEVICE_FLAG_ISR_SAFE)) != 0) {
+					ret = pm_device_runtime_get(domain);
+					if (ret < 0) {
+						return ret;
+					}
+					/* Power domain successfully claimed */
+					pm->base.flags |= BIT(PM_DEVICE_FLAG_PD_CLAIMED);
+				} else {
+					return -EWOULDBLOCK;
 				}
-			} else {
-				return -EWOULDBLOCK;
 			}
 		}
 
@@ -331,6 +336,7 @@ static int put_sync_locked(const struct device *dev)
 
 			if (domain->pm_base->flags & BIT(PM_DEVICE_FLAG_ISR_SAFE)) {
 				ret = put_sync_locked(domain);
+				pm->base.flags &= ~BIT(PM_DEVICE_FLAG_PD_CLAIMED);
 			} else {
 				ret = -EWOULDBLOCK;
 			}

--- a/tests/subsys/pm/power_domain/Kconfig
+++ b/tests/subsys/pm/power_domain/Kconfig
@@ -1,0 +1,8 @@
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config TEST_PM_DEVICE_ISR_SAFE
+	bool "Use ISR safe PM for the test"

--- a/tests/subsys/pm/power_domain/testcase.yaml
+++ b/tests/subsys/pm/power_domain/testcase.yaml
@@ -5,3 +5,11 @@ tests:
     integration_platforms:
       - native_sim
     tags: pm
+  pm.power_doamin.isr_safe:
+    platform_allow:
+      - native_sim
+    integration_platforms:
+      - native_sim
+    extra_configs:
+      - CONFIG_TEST_PM_DEVICE_ISR_SAFE=y
+    tags: pm


### PR DESCRIPTION
Fixes: [#98501](https://github.com/zephyrproject-rtos/zephyr/issues/98501)
Add a new test configuration to verify power domain functionality with
ISR safe power management enabled. The test conditionally applies
PM_DEVICE_ISR_SAFE flags to test devices based on the new
CONFIG_TEST_PM_DEVICE_ISR_SAFE configuration option.

Enhance existing test assertions to verify the PD_CLAIMED flag is
properly set when devices claim power domains and cleared when they
release them, ensuring correct power domain reference counting in
both regular and ISR safe contexts.

Signed-off-by: Albort Xue <yao.xue@nxp.com>