### PR TITLE
net: lwm2m: get cache free slots

### DIFF
--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -516,6 +516,10 @@ must be enabled separately and each resource needs their own storage.
   lwm2m_enable_cache(LWM2M_OBJ(IPSO_OBJECT_TEMP_SENSOR_ID, 0, SENSOR_VALUE_RID),
           temperature_cache, ARRAY_SIZE(temperature_cache));
 
+Applications can inspect the available space in a cached resource with
+:c:func:`lwm2m_cache_free_slots_get`, which returns the number of samples that
+can still be stored or a negative errno value if the query fails.
+
 LwM2M engine have room for four resources that have cache enabled. Limit can be increased by
 changing :kconfig:option:`CONFIG_LWM2M_MAX_CACHED_RESOURCES`. This affects a static memory usage of
 engine.

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -29,6 +29,7 @@
 
 #include <time.h>
 #include <zephyr/kernel.h>
+#include <zephyr/types.h>
 #include <zephyr/sys/mutex.h>
 #include <zephyr/net/coap.h>
 #include <zephyr/net/lwm2m_path.h>
@@ -1618,6 +1619,15 @@ int lwm2m_enable_cache(const struct lwm2m_obj_path *path, struct lwm2m_time_seri
  */
 int lwm2m_set_cache_filter(const struct lwm2m_obj_path *path,
 			   lwm2m_cache_filter_cb_t filter_cb);
+
+/**
+ * @brief Return number of free slots in a cached resource.
+ *
+ * @param path LwM2M path to the cached resource.
+ *
+ * @return Number of free slots, or negative errno code in case of error.
+ */
+int lwm2m_cache_free_slots_get(const struct lwm2m_obj_path *path);
 
 /**
  * @brief Security modes as defined in LwM2M Security object.

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -1660,6 +1660,30 @@ int lwm2m_set_cache_filter(const struct lwm2m_obj_path *path,
 #endif /* CONFIG_LWM2M_RESOURCE_DATA_CACHE_SUPPORT */
 }
 
+int lwm2m_cache_free_slots_get(const struct lwm2m_obj_path *path)
+{
+#if defined(CONFIG_LWM2M_RESOURCE_DATA_CACHE_SUPPORT)
+	struct lwm2m_time_series_resource *cache_entry;
+	uint32_t free_bytes;
+
+	if (path == NULL) {
+		return -EINVAL;
+	}
+
+	cache_entry = lwm2m_cache_entry_get_by_object(path);
+	if (cache_entry == NULL) {
+		return -ENOENT;
+	}
+
+	free_bytes = ring_buf_space_get(&cache_entry->rb);
+
+	return (int)(free_bytes / sizeof(struct lwm2m_time_series_elem));
+#else
+	ARG_UNUSED(path);
+	return -ENOTSUP;
+#endif /* CONFIG_LWM2M_RESOURCE_DATA_CACHE_SUPPORT */
+}
+
 #if defined(CONFIG_LWM2M_RESOURCE_DATA_CACHE_SUPPORT)
 static int lwm2m_engine_data_cache_init(void)
 {

--- a/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
+++ b/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
@@ -629,6 +629,7 @@ ZTEST(lwm2m_registry, test_resource_cache)
 	zassert_is_null(lwm2m_cache_entry_get_by_object(&path));
 	zassert_equal(lwm2m_enable_cache(&path, &e, 1), -ENOTSUP);
 	zassert_equal(lwm2m_set_cache_filter(&path, NULL), -ENOTSUP);
+	zassert_equal(lwm2m_cache_free_slots_get(&path), -ENOTSUP);
 	zassert_false(lwm2m_cache_write(NULL, NULL));
 	zassert_false(lwm2m_cache_read(NULL, NULL));
 	zassert_equal(lwm2m_cache_size(NULL), 0);


### PR DESCRIPTION
Add function to query LwM2M cache free slots on a given path.

This is usefull to detect if the buffer start to be full and flush the content using lwm2m_send