### PR TITLE
stm32: use generic LL headers everywhere

### DIFF
--- a/boards/arduino/nicla_vision/board_gpio_hse.c
+++ b/boards/arduino/nicla_vision/board_gpio_hse.c
@@ -5,8 +5,8 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
-#include <stm32h7xx_ll_bus.h>
-#include <stm32h7xx_ll_gpio.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_gpio.h>
 
 static int board_gpio_hse(void)
 {

--- a/boards/arduino/opta/board_gpio_init.c
+++ b/boards/arduino/opta/board_gpio_init.c
@@ -5,8 +5,8 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
-#include <stm32h7xx_ll_bus.h>
-#include <stm32h7xx_ll_gpio.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_gpio.h>
 
 static int board_gpio_init(void)
 {

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -15,13 +15,8 @@
 #include <zephyr/sys/barrier.h>
 #include <soc.h>
 #include <stm32_bitops.h>
-#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
-#include <stm32h7rsxx_ll_bus.h>
-#include <stm32h7rsxx_ll_utils.h>
-#else
-#include <stm32h7xx_ll_bus.h>
-#include <stm32h7xx_ll_utils.h>
-#endif /* CONFIG_SOC_SERIES_STM32H7RSX */
+#include <stm32_ll_bus.h>
+#include <stm32_ll_utils.h>
 
 #include "flash_stm32.h"
 #include "stm32_hsem.h"

--- a/drivers/ieee802154/ieee802154_stm32wba.c
+++ b/drivers/ieee802154/ieee802154_stm32wba.c
@@ -30,8 +30,8 @@
 #include <zephyr/pm/pm.h>
 #include "app_conf.h"
 #include "linklayer_plat.h"
-#include <stm32wbaxx_ll_bus.h>
-#include <stm32wbaxx_ll_pwr.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
 #endif
 
 #include <linklayer_plat_local.h>

--- a/drivers/lora/loramac_node/sx126x_stm32wl.c
+++ b/drivers/lora/loramac_node/sx126x_stm32wl.c
@@ -8,9 +8,9 @@
 
 #include "sx126x_common.h"
 
-#include <stm32wlxx_ll_exti.h>
-#include <stm32wlxx_ll_pwr.h>
-#include <stm32wlxx_ll_rcc.h>
+#include <stm32_ll_exti.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>

--- a/samples/boards/st/power_mgmt/stop3/src/main.c
+++ b/samples/boards/st/power_mgmt/stop3/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/printk.h>
-#include <stm32u5xx_ll_pwr.h>
+#include <stm32_ll_pwr.h>
 #include <gpio/gpio_stm32.h>
 
 #define SLEEP_TIME_MS   2000

--- a/soc/st/stm32/stm32c0x/power.c
+++ b/soc/st/stm32/stm32c0x/power.c
@@ -8,9 +8,8 @@
 #include <clock_control/clock_stm32_ll_common.h>
 #include <soc.h>
 
-#include <stm32c0xx_ll_cortex.h>
-#include <stm32c0xx_ll_pwr.h>
-#include <stm32c0xx.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>

--- a/soc/st/stm32/stm32f1x/power.c
+++ b/soc/st/stm32/stm32f1x/power.c
@@ -5,8 +5,8 @@
  */
 
 #include <clock_control/clock_stm32_ll_common.h>
-#include <stm32f1xx_ll_cortex.h>
-#include <stm32f1xx_ll_pwr.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>

--- a/soc/st/stm32/stm32f1x/poweroff.c
+++ b/soc/st/stm32/stm32f1x/poweroff.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stm32f1xx_ll_cortex.h>
-#include <stm32f1xx_ll_pwr.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/poweroff.h>

--- a/soc/st/stm32/stm32f1x/soc.c
+++ b/soc/st/stm32/stm32f1x/soc.c
@@ -13,7 +13,7 @@
 #include <zephyr/init.h>
 
 #include <stm32_ll_system.h>
-#include <stm32f1xx_ll_bus.h>
+#include <stm32_ll_bus.h>
 
 #include <cmsis_core.h>
 

--- a/soc/st/stm32/stm32f4x/power.c
+++ b/soc/st/stm32/stm32f4x/power.c
@@ -7,10 +7,9 @@
 #include <clock_control/clock_stm32_ll_common.h>
 #include <soc.h>
 
-#include <stm32f4xx_ll_bus.h>
-#include <stm32f4xx_ll_cortex.h>
-#include <stm32f4xx_ll_pwr.h>
-#include <stm32f4xx.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
 
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/counter.h>

--- a/soc/st/stm32/stm32g0x/power.c
+++ b/soc/st/stm32/stm32g0x/power.c
@@ -9,11 +9,11 @@
 #include <soc.h>
 #include <zephyr/init.h>
 
-#include <stm32g0xx_ll_utils.h>
-#include <stm32g0xx_ll_bus.h>
-#include <stm32g0xx_ll_cortex.h>
-#include <stm32g0xx_ll_pwr.h>
-#include <stm32g0xx_ll_system.h>
+#include <stm32_ll_utils.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
 
 #include <zephyr/logging/log.h>

--- a/soc/st/stm32/stm32g4x/power.c
+++ b/soc/st/stm32/stm32g4x/power.c
@@ -12,11 +12,11 @@
 #include <soc.h>
 
 #include <clock_control/clock_stm32_ll_common.h>
-#include <stm32g4xx_ll_bus.h>
-#include <stm32g4xx_ll_cortex.h>
-#include <stm32g4xx_ll_pwr.h>
-#include <stm32g4xx_ll_system.h>
-#include <stm32g4xx_ll_utils.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_system.h>
+#include <stm32_ll_utils.h>
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */

--- a/soc/st/stm32/stm32h5x/power.c
+++ b/soc/st/stm32/stm32h5x/power.c
@@ -8,8 +8,8 @@
 #include <soc.h>
 #include <zephyr/init.h>
 
-#include <stm32h5xx_ll_cortex.h>
-#include <stm32h5xx_ll_pwr.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
 #include <clock_control/clock_stm32_ll_common.h>
 
 #include <zephyr/logging/log.h>

--- a/soc/st/stm32/stm32l0x/power.c
+++ b/soc/st/stm32/stm32l0x/power.c
@@ -8,12 +8,12 @@
 #include <soc.h>
 #include <zephyr/init.h>
 
-#include <stm32l0xx_ll_utils.h>
-#include <stm32l0xx_ll_bus.h>
-#include <stm32l0xx_ll_cortex.h>
-#include <stm32l0xx_ll_pwr.h>
-#include <stm32l0xx_ll_rcc.h>
-#include <stm32l0xx_ll_system.h>
+#include <stm32_ll_utils.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 

--- a/soc/st/stm32/stm32l1x/power.c
+++ b/soc/st/stm32/stm32l1x/power.c
@@ -5,8 +5,8 @@
  */
 
 #include <clock_control/clock_stm32_ll_common.h>
-#include <stm32l1xx_ll_cortex.h>
-#include <stm32l1xx_ll_pwr.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>

--- a/soc/st/stm32/stm32l1x/poweroff.c
+++ b/soc/st/stm32/stm32l1x/poweroff.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stm32l1xx_ll_cortex.h>
-#include <stm32l1xx_ll_pwr.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/poweroff.h>

--- a/soc/st/stm32/stm32l4x/power.c
+++ b/soc/st/stm32/stm32l4x/power.c
@@ -8,12 +8,12 @@
 #include <soc.h>
 #include <zephyr/init.h>
 
-#include <stm32l4xx_ll_utils.h>
-#include <stm32l4xx_ll_bus.h>
-#include <stm32l4xx_ll_cortex.h>
-#include <stm32l4xx_ll_pwr.h>
-#include <stm32l4xx_ll_rcc.h>
-#include <stm32l4xx_ll_system.h>
+#include <stm32_ll_utils.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 

--- a/soc/st/stm32/stm32l5x/power.c
+++ b/soc/st/stm32/stm32l5x/power.c
@@ -8,12 +8,12 @@
 #include <soc.h>
 #include <zephyr/init.h>
 
-#include <stm32l5xx_ll_utils.h>
-#include <stm32l5xx_ll_bus.h>
-#include <stm32l5xx_ll_cortex.h>
-#include <stm32l5xx_ll_pwr.h>
-#include <stm32l5xx_ll_rcc.h>
-#include <stm32l5xx_ll_system.h>
+#include <stm32_ll_utils.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 

--- a/soc/st/stm32/stm32u0x/power.c
+++ b/soc/st/stm32/stm32u0x/power.c
@@ -10,9 +10,9 @@
 #include <zephyr/pm/pm.h>
 
 #include <clock_control/clock_stm32_ll_common.h>
-#include <stm32u0xx_ll_cortex.h>
-#include <stm32u0xx_ll_pwr.h>
-#include <stm32u0xx_ll_rcc.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
 
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 

--- a/soc/st/stm32/stm32u5x/power.c
+++ b/soc/st/stm32/stm32u5x/power.c
@@ -9,12 +9,12 @@
 #include <soc.h>
 #include <zephyr/init.h>
 
-#include <stm32u5xx_ll_utils.h>
-#include <stm32u5xx_ll_bus.h>
-#include <stm32u5xx_ll_cortex.h>
-#include <stm32u5xx_ll_pwr.h>
-#include <stm32u5xx_ll_rcc.h>
-#include <stm32u5xx_ll_system.h>
+#include <stm32_ll_utils.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
 
 #include <zephyr/logging/log.h>

--- a/soc/st/stm32/stm32wbax/power.c
+++ b/soc/st/stm32/stm32wbax/power.c
@@ -18,11 +18,11 @@
 
 #include <cmsis_core.h>
 
-#include <stm32wbaxx_ll_bus.h>
-#include <stm32wbaxx_ll_cortex.h>
-#include <stm32wbaxx_ll_pwr.h>
-#include <stm32wbaxx_ll_rcc.h>
-#include <stm32wbaxx_ll_system.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
 
 #include <zephyr/logging/log.h>

--- a/soc/st/stm32/stm32wbx/power.c
+++ b/soc/st/stm32/stm32wbx/power.c
@@ -9,11 +9,11 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
-#include <stm32wbxx_ll_utils.h>
-#include <stm32wbxx_ll_bus.h>
-#include <stm32wbxx_ll_cortex.h>
-#include <stm32wbxx_ll_pwr.h>
-#include <stm32wbxx_ll_rcc.h>
+#include <stm32_ll_utils.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
 #include <clock_control/clock_stm32_ll_common.h>
 #include "stm32_hsem.h"
 

--- a/soc/st/stm32/stm32wlx/power.c
+++ b/soc/st/stm32/stm32wlx/power.c
@@ -8,12 +8,12 @@
 #include <soc.h>
 #include <zephyr/init.h>
 
-#include <stm32wlxx_ll_utils.h>
-#include <stm32wlxx_ll_bus.h>
-#include <stm32wlxx_ll_cortex.h>
-#include <stm32wlxx_ll_pwr.h>
-#include <stm32wlxx_ll_rcc.h>
-#include <stm32wlxx_ll_system.h>
+#include <stm32_ll_utils.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 

--- a/soc/st/stm32/stm32wlx/soc.c
+++ b/soc/st/stm32/stm32wlx/soc.c
@@ -12,7 +12,7 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 
-#include <stm32wlxx_ll_system.h>
+#include <stm32_ll_system.h>
 
 #include <zephyr/logging/log.h>
 


### PR DESCRIPTION
A few places are still including series-specific LL headers despite the existence of generic (series-agnostic) `stm32_ll_PPP` variants.

Replace all such includes with the generic header: `s/#include <stm32[^_]_ll_(.+)\.h>/#include <stm32_ll_$1.h>`. This also allows removal of include guards in a few places.

While at it, also remove CMSIS include which is already covered by `<soc.h>` in a few places too. (A second pass could be required; this is not the main objective of this PR) 