### PR TITLE
tests: fix: skip stack unwind on unsupported platforms

### DIFF
--- a/tests/arch/common/stack_unwind/testcase.yaml
+++ b/tests/arch/common/stack_unwind/testcase.yaml
@@ -3,6 +3,7 @@ common:
   ignore_faults: true
   ignore_qemu_crash: true
   tags: kernel
+  filter: CONFIG_ARCH_STACKWALK
 tests:
   arch.common.stack_unwind.riscv_fp:
     arch_allow: riscv


### PR DESCRIPTION
Add ARCH_HAS_STACKWALK as a dependency to the stack unwind test to avoid running it on 64bit Cortex-R platforms, which do not implement the arch_stack_walk() api.