### PR TITLE
tests: fix test failure for smp targets

### DIFF
--- a/tests/subsys/ipc/pbuf/prj.conf
+++ b/tests/subsys/ipc/pbuf/prj.conf
@@ -12,3 +12,5 @@ CONFIG_PBUF=y
 # In the tests, the reader and the writer are executed on a single CPU.
 # Disable data cache management to prevent potential data corruption.
 CONFIG_CACHE_MANAGEMENT=n
+# make sure the test runs on single cpu
+CONFIG_MP_MAX_NUM_CPUS=1


### PR DESCRIPTION
The test is expected to run on single cpu so set max number of cpus to 1
so that it doesn't fail smp targets like fvp_baser_aemv8r in ci.