### PR TITLE
drivers: udc_dwc2: avoid register read on disabled controller

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -2338,6 +2338,7 @@ static int udc_dwc2_disable(const struct device *dev)
 	}
 
 	config->irq_disable_func(dev);
+	cancel_hibernation_request(priv);
 
 	if (priv->hibernated) {
 		dwc2_exit_hibernation(dev, false, true);


### PR DESCRIPTION
The VBUS bounces when the USB connector is plugged in. This can lead to events VBUS removed and Suspended occurring in that order. With hibernation support enabled, hibernation request, as result of the suspend interrupt, will be delegated to the driver thread. Once the driver thread is scheduled to process hibernation request, the controller may be already disabled and controller/phy clocks be off. On nRF54LM20 this leads to CPU crash and a hang. To avoid this happening, the call to disable interrupts should be a first act in udc_disable(). Also, check if the UDC is still enabled before hibernation.