### PR TITLE
Drivers: SPI: Add new  SPI  module to PG23, PG28

### DIFF
--- a/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a-pinctrl.dtsi
@@ -21,6 +21,20 @@
 		};
 	};
 
+	usart0_default: usart0_default {
+		group0 {
+			pins = <USART0_TX_PD11>, <EUSART1_SCLK_PD13>;
+			drive-push-pull;
+			output-high;
+		};
+
+		group1 {
+			pins = <USART0_RX_PD12>;
+			input-enable;
+			silabs,input-filter;
+		};
+	};
+
 	i2c0_default: i2c0_default {
 		group0 {
 			pins = <I2C0_SCL_PD10>, <I2C0_SDA_PD9>;

--- a/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a-pinctrl.dtsi
@@ -23,7 +23,7 @@
 
 	usart0_default: usart0_default {
 		group0 {
-			pins = <USART0_TX_PD11>, <EUSART1_SCLK_PD13>;
+			pins = <USART0_TX_PD11>;
 			drive-push-pull;
 			output-high;
 		};

--- a/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a.dts
+++ b/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a.dts
@@ -168,6 +168,18 @@
 	status = "okay";
 };
 
+&usart0 {
+	compatible = "silabs,usart-spi";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <4000000>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	cs-gpios = <&gpiod 14 GPIO_ACTIVE_LOW>;
+};
+
 &i2c0 {
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";


### PR DESCRIPTION
Our goal is to extend usart capabilities to help users to use additional SPI device aout of the box.

signed-off by: silabs-vifisch <viktor.fisch@silabs.com>