### PR TITLE
linker: llext: move #ifdef CONFIG_LLEXT guard inside common file

### DIFF
--- a/boards/qemu/x86/qemu_x86_tiny.ld
+++ b/boards/qemu/x86/qemu_x86_tiny.ld
@@ -253,10 +253,7 @@ SECTIONS
 	{
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
     /DISCARD/ :
 	{

--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -80,10 +80,7 @@ MEMORY {
 SECTIONS {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
 	GROUP_START(ROMABLE_REGION)
 

--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -97,10 +97,7 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 SECTIONS
 {
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
     /*
      * .plt and .iplt are here according to 'arm-zephyr-elf-ld --verbose',

--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -101,10 +101,7 @@ SECTIONS
     {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
     /*
      * .plt and .iplt are here according to 'arm-zephyr-elf-ld --verbose',

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -81,10 +81,7 @@ SECTIONS
 {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
     /*
      * .plt and .iplt are here according to 'arm-zephyr-elf-ld --verbose',

--- a/include/zephyr/arch/mips/linker.ld
+++ b/include/zephyr/arch/mips/linker.ld
@@ -45,10 +45,7 @@ SECTIONS
 {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
     SECTION_PROLOGUE(_VECTOR_SECTION_NAME,,)
     {

--- a/include/zephyr/arch/posix/linker.ld
+++ b/include/zephyr/arch/posix/linker.ld
@@ -20,10 +20,7 @@
 
 SECTIONS
 {
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
 SECTION_PROLOGUE(rom_start,,)
 {

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -126,10 +126,7 @@ SECTIONS
     {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
     /*
      * The .plt and .iplt are here according to

--- a/include/zephyr/arch/rx/linker.ld
+++ b/include/zephyr/arch/rx/linker.ld
@@ -66,10 +66,7 @@ SECTIONS
 {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
 	GROUP_START(ROMABLE_REGION)
 	. = ROM_START;   /* for kernel logging */

--- a/include/zephyr/arch/sparc/linker.ld
+++ b/include/zephyr/arch/sparc/linker.ld
@@ -22,10 +22,7 @@ SECTIONS
     {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
     __rom_region_start = .;
 

--- a/include/zephyr/arch/x86/ia32/linker.ld
+++ b/include/zephyr/arch/x86/ia32/linker.ld
@@ -76,10 +76,7 @@ SECTIONS
 	{
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
     /DISCARD/ :
 	{

--- a/include/zephyr/arch/x86/intel64/linker.ld
+++ b/include/zephyr/arch/x86/intel64/linker.ld
@@ -262,7 +262,5 @@ SECTION_PROLOGUE(.x86shadowstack.arr,,)
 	.shstrtab 0 : { *(.shstrtab) }
 #endif
 
-#ifdef CONFIG_LLEXT
-	#include <zephyr/linker/llext-sections.ld>
-#endif
+#include <zephyr/linker/llext-sections.ld>
 }

--- a/include/zephyr/linker/llext-sections.ld
+++ b/include/zephyr/linker/llext-sections.ld
@@ -1,5 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+/*
+ * Only define LLEXT sections if the subsystem is enabled.
+ * Check here to avoid duplication in every linker script.
+ */
+#ifdef CONFIG_LLEXT
 	/*
 	 * Save the current address to avoid changing it in this file.
 	 */
@@ -35,3 +40,4 @@
 #endif
 
 	. = __llext_current_addr;
+#endif /* CONFIG_LLEXT */

--- a/soc/cdns/dc233c/include/xtensa-dc233c.ld
+++ b/soc/cdns/dc233c/include/xtensa-dc233c.ld
@@ -112,10 +112,7 @@ SECTIONS
 {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <zephyr/linker/intlist.ld>

--- a/soc/cdns/xtensa_sample_controller/include/xtensa-sample-controller.ld
+++ b/soc/cdns/xtensa_sample_controller/include/xtensa-sample-controller.ld
@@ -176,10 +176,7 @@ SECTIONS
 {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <zephyr/linker/intlist.ld>

--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -199,10 +199,7 @@ SECTIONS
 #endif /* CONFIG_BOOTLOADER_MCUBOOT */
 
   #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
   #include <zephyr/linker/llext-sections.ld>
-#endif
 
   /* --- RTC BEGIN --- */
 

--- a/soc/espressif/esp32/default_appcpu.ld
+++ b/soc/espressif/esp32/default_appcpu.ld
@@ -115,10 +115,7 @@ SECTIONS
   } > metadata
 
   #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
   #include <zephyr/linker/llext-sections.ld>
-#endif
 
   /* --- START OF IRAM --- */
 

--- a/soc/espressif/esp32c2/default.ld
+++ b/soc/espressif/esp32c2/default.ld
@@ -173,10 +173,7 @@ SECTIONS
   dram_size_field = LOADADDR(.dram0.end) - LOADADDR(.dram0.data);
 
   #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
   #include <zephyr/linker/llext-sections.ld>
-#endif
 
   /* --- START OF IRAM --- */
 

--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -178,10 +178,7 @@ SECTIONS
 #endif /* CONFIG_BOOTLOADER_MCUBOOT */
 
   #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
   #include <zephyr/linker/llext-sections.ld>
-#endif
 
   /* --- START OF RTC --- */
 

--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -185,10 +185,7 @@ SECTIONS
 #endif /* CONFIG_BOOTLOADER_MCUBOOT */
 
   #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
   #include <zephyr/linker/llext-sections.ld>
-#endif
 
   /* --- START OF RTC --- */
   .rtc.text :

--- a/soc/espressif/esp32h2/default.ld
+++ b/soc/espressif/esp32h2/default.ld
@@ -181,10 +181,7 @@ SECTIONS
 #endif /* CONFIG_BOOTLOADER_MCUBOOT */
 
   #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
   #include <zephyr/linker/llext-sections.ld>
-#endif
 
   /* --- START OF RTC --- */
   .rtc.text :

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -196,10 +196,7 @@ SECTIONS
 
 /* Virtual non-loadable sections */
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
   /* --- START OF RTC --- */
 

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -209,10 +209,7 @@ SECTIONS
 
 /* Virtual non-loadable sections */
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
   /* --- START OF RTC --- */
 

--- a/soc/espressif/esp32s3/default_appcpu.ld
+++ b/soc/espressif/esp32s3/default_appcpu.ld
@@ -156,10 +156,7 @@ SECTIONS
   } > metadata
 
   #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
   #include <zephyr/linker/llext-sections.ld>
-#endif
 
   /* --- START OF IRAM --- */
 

--- a/soc/infineon/cat1b/cyw20829/linker.ld
+++ b/soc/infineon/cat1b/cyw20829/linker.ld
@@ -120,10 +120,7 @@ SECTIONS
 	{
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
 	/*
 	 * .plt and .iplt are here according to 'arm-zephyr-elf-ld --verbose',

--- a/soc/infineon/edge/pse84/linker_exclude_syslib.ld
+++ b/soc/infineon/edge/pse84/linker_exclude_syslib.ld
@@ -102,10 +102,7 @@ SECTIONS
     {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
     /*
      * .plt and .iplt are here according to 'arm-zephyr-elf-ld --verbose',

--- a/soc/intel/intel_adsp/ace/ace-link.ld
+++ b/soc/intel/intel_adsp/ace/ace-link.ld
@@ -610,8 +610,5 @@ SECTIONS {
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <zephyr/linker/intlist.ld>
 #endif
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 }

--- a/soc/intel/intel_adsp/cavs/include/xtensa-cavs-linker.ld
+++ b/soc/intel/intel_adsp/cavs/include/xtensa-cavs-linker.ld
@@ -507,8 +507,5 @@ SECTIONS {
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <zephyr/linker/intlist.ld>
 #endif
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 }

--- a/soc/ite/ec/it51xxx/linker.ld
+++ b/soc/ite/ec/it51xxx/linker.ld
@@ -130,10 +130,7 @@ SECTIONS
     {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
     /*
      * The .plt and .iplt are here according to

--- a/soc/ite/ec/it8xxx2/linker.ld
+++ b/soc/ite/ec/it8xxx2/linker.ld
@@ -90,10 +90,7 @@ SECTIONS
     {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
     /*
      * The .plt and .iplt are here according to

--- a/soc/mediatek/mt8xxx/linker.ld
+++ b/soc/mediatek/mt8xxx/linker.ld
@@ -155,9 +155,6 @@ SECTIONS {
  * just dump it in an unreadable area at the top of memory.
  */
 #include <zephyr/linker/intlist.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
 } /* SECTIONS */

--- a/soc/nxp/imx/imx8/adsp/linker.ld
+++ b/soc/nxp/imx/imx8/adsp/linker.ld
@@ -179,10 +179,8 @@ SECTIONS
 #endif
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
+
   .ResetVector.text : ALIGN(4)
   {
     _ResetVector_text_start = ABSOLUTE(.);

--- a/soc/nxp/imx/imx8m/adsp/linker.ld
+++ b/soc/nxp/imx/imx8m/adsp/linker.ld
@@ -179,10 +179,8 @@ SECTIONS
 #endif
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
+
   .ResetVector.text : ALIGN(4)
   {
     _ResetVector_text_start = ABSOLUTE(.);

--- a/soc/nxp/imx/imx8ulp/adsp/linker.ld
+++ b/soc/nxp/imx/imx8ulp/adsp/linker.ld
@@ -180,10 +180,8 @@ SECTIONS
 #endif
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
+
   .ResetVector.text : ALIGN(4)
   {
     _ResetVector_text_start = ABSOLUTE(.);

--- a/soc/nxp/imx/imx8x/adsp/linker.ld
+++ b/soc/nxp/imx/imx8x/adsp/linker.ld
@@ -180,10 +180,8 @@ SECTIONS
 #endif
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
+
   .ResetVector.text : ALIGN(4)
   {
     _ResetVector_text_start = ABSOLUTE(.);

--- a/soc/nxp/imxrt/imxrt5xx/f1/linker.ld
+++ b/soc/nxp/imxrt/imxrt5xx/f1/linker.ld
@@ -134,10 +134,8 @@ SECTIONS
 {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
+
   .ResetVector.text : ALIGN(4)
   {
     _ResetVector_text_start = ABSOLUTE(.);

--- a/soc/openisa/rv32m1/linker.ld
+++ b/soc/openisa/rv32m1/linker.ld
@@ -86,10 +86,7 @@ SECTIONS
     {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
     SECTION_PROLOGUE(.plt,,)
 	{

--- a/soc/sensry/ganymed/sy1xx/common/linker.ld
+++ b/soc/sensry/ganymed/sy1xx/common/linker.ld
@@ -77,10 +77,7 @@ SECTIONS
         } > L2_PRIV_CH0
 
         #include <zephyr/linker/rel-sections.ld>
-
-        #ifdef CONFIG_LLEXT
         #include <zephyr/linker/llext-sections.ld>
-        #endif
 
         SECTION_PROLOGUE(.plt,,)
         {

--- a/soc/st/stm32/stm32mp1x/linker.ld
+++ b/soc/st/stm32/stm32mp1x/linker.ld
@@ -13,10 +13,7 @@ SECTIONS
     {
 
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 
 #ifdef CONFIG_OPENAMP_RSC_TABLE
 

--- a/soc/st/stm32/stm32mp2x/m33/linker.ld
+++ b/soc/st/stm32/stm32mp2x/m33/linker.ld
@@ -14,8 +14,5 @@ SECTIONS
 {
   /* Standard Zephyr relocation section */
 #include <zephyr/linker/rel-sections.ld>
-
-#ifdef CONFIG_LLEXT
 #include <zephyr/linker/llext-sections.ld>
-#endif
 }


### PR DESCRIPTION
LLEXT-related sections should only be added to the linker script when the associated `CONFIG_LLEXT` is enabled. This has been done by checking for this Kconfig symbol in every linker file, but this creates a lot of boilerplate for no good reason.

Use the much simpler solution: move the check inside the common linker file and remove existing `#ifdef CONFIG_LLEXT` checks in all linker files.

(Bonus point: this doesn't break out-of-tree users which will just be checking twice)