### PR TITLE
stm32: tests: drivers: flash: fix regressions on stm32h7x serie after cache management enable by default

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -796,6 +796,9 @@ static int flash_stm32h7_write(const struct device *dev, off_t offset, const voi
 		rc = rc2;
 	}
 
+#ifdef CONFIG_DCACHE
+	flash_stm32h7_flush_caches(dev, offset, len);
+#endif
 	flash_stm32_sem_give(dev);
 
 	return rc;

--- a/tests/drivers/flash/stm32/src/main.c
+++ b/tests/drivers/flash/stm32/src/main.c
@@ -278,6 +278,16 @@ ZTEST(flash_stm32, test_stm32_block_registers)
 	TC_PRINT("Try to unlock blocked OPT\n");
 	__set_FAULTMASK(1);
 	flash_stm32_option_bytes_lock(flash_dev, false);
+
+	/* Ensure the Imprecise Bus Fault caused by the illegal
+	 * access is seen now while BusFault is still masked by
+	 * triggering a Context synchronization event. This is
+	 * notably required on series such as STM32H7 when Icache
+	 * is enabled - the Imprecise Bus Fault is reported after
+	 * we unmask BusFault and triggers a kernel panic.
+	 */
+	barrier_isync_fence_full();
+
 	/* Clear Bus Fault pending bit */
 	SCB->SHCSR &= ~SCB_SHCSR_BUSFAULTPENDED_Msk;
 	barrier_dsync_fence_full();


### PR DESCRIPTION
This commit https://github.com/zephyrproject-rtos/zephyr/commit/d5ead50fc69daa682e18cfe89d4ea22d0fcd6445 enable cache management by default on Cortex-M7 of the STM32H7x. 

This PR addresses two issues observed on STM32H7 after this addition. 

- **Fix flash data coherency after write**
     Flash writes on STM32H7 require explicit cache flushing to ensure data coherency.

- **Prevent Bus Fault when unlocking blocked flash registers**
     Blocking access to flash option/control registers may cause imprecise Bus Faults when attempting to unlock 
     them immediately afterward. 
    No regressions encountered on other platforms with this fix. 