### PR TITLE
tests: bluetooth: tester: Fix VCS tests

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp/btp_vcs.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_vcs.h
@@ -8,6 +8,8 @@
 
 #include <stdint.h>
 
+#define BTP_VCS_REGISTER_FLAG_MUTED		BIT(0)
+
 #define BTP_VCS_READ_SUPPORTED_COMMANDS		0x01
 struct btp_vcs_read_supported_commands_rp {
 	uint8_t data[0];
@@ -22,3 +24,10 @@ struct btp_vcs_set_vol_cmd {
 #define BTP_VCS_VOL_DOWN			0x04
 #define BTP_VCS_MUTE				0x05
 #define BTP_VCS_UNMUTE				0x06
+
+#define BTP_VCS_REGISTER			0x07
+struct btp_vcs_register_cmd {
+	uint8_t step;
+	uint8_t flags;
+	uint8_t volume;
+} __packed;

--- a/tests/bsim/bluetooth/tester/src/audio/vcp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/vcp_peripheral.c
@@ -35,6 +35,7 @@ static void test_vcp_peripheral(void)
 	bsim_btp_core_register(BTP_SERVICE_ID_AICS);
 
 	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
+	bsim_btp_vcs_register(1U, 0U, 100U);
 	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
 	bsim_btp_wait_for_gap_device_connected(&remote_addr);
 	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.c
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.c
@@ -873,6 +873,8 @@ static bool is_valid_vcs_packet_len(const struct btp_hdr *hdr, struct net_buf_si
 		return buf_simple->len == 0U;
 	case BTP_VCS_UNMUTE:
 		return buf_simple->len == 0U;
+	case BTP_VCS_REGISTER:
+		return buf_simple->len == 0U;
 
 	/* no events */
 	default:

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.h
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.h
@@ -563,6 +563,27 @@ static inline void bsim_btp_wait_for_tmap_discovery_complete(void)
 	net_buf_unref(buf);
 }
 
+static inline void bsim_btp_vcs_register(uint8_t step, uint8_t flags, uint8_t vol)
+{
+	struct btp_vcs_register_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_VCS;
+	cmd_hdr->opcode = BTP_VCS_REGISTER;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	cmd->step = step;
+	cmd->flags = flags;
+	cmd->volume = vol;
+
+	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
 static inline void bsim_btp_vcp_discover(const bt_addr_le_t *address)
 {
 	struct btp_vcp_discover_cmd *cmd;


### PR DESCRIPTION
Zephyr automatically sets the persisted flag for VCS if the volume is changed after the service is registered. As some of these PTS tests require a set volume with the flag cleared, the initial volume needs to be set before registering VCS.

This PR is associated with https://github.com/auto-pts/auto-pts/pull/1603