### PR TITLE
doc: develop: twister: fix level-4 titles underline inconsistency

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -1202,7 +1202,7 @@ testing using video fingerprints.
    Window being displayed for a "compare" run where fingerprint is a 90% match with the reference.
 
 Hardware setup
-++++++++++++++
+--------------
 
 The display capture harness requires:
 
@@ -1212,7 +1212,7 @@ The display capture harness requires:
 - DUT connected to the same PC for flashing and serial console access
 
 Configuration
-+++++++++++++
+-------------
 
 The harness uses a YAML configuration file that defines camera settings, test parameters, and video
 signature analysis options. A typical configuration is shown below:
@@ -1327,7 +1327,7 @@ environment variable:
       display_capture_config: "${DISPLAY_TEST_DIR}/display_config.yaml"
 
 Workflow
-++++++++
+--------
 
 First, generate **reference fingerprints** for a known-good display output:
 


### PR DESCRIPTION
Fix underline inconsistency of titles of level 4 by replacing `+` with `-`.

Fixes CI doc build failure in https://github.com/zephyrproject-rtos/zephyr/actions/runs/19142720251/job/54712057829?pr=99023
and https://github.com/zephyrproject-rtos/zephyr/actions/runs/19140701875/job/54704752910?pr=99016