### PR TITLE
shields: nxp: lcd_par_s035: fix gt911 touch initialization

### DIFF
--- a/boards/shields/lcd_par_s035/CMakeLists.txt
+++ b/boards/shields/lcd_par_s035/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_library()
+zephyr_library_sources(shield.c)

--- a/boards/shields/lcd_par_s035/Kconfig.defconfig
+++ b/boards/shields/lcd_par_s035/Kconfig.defconfig
@@ -28,13 +28,4 @@ config INPUT_GT911_INTERRUPT
 
 endif # LVGL
 
-if INPUT
-
-# GT911 driver drives reset pin low, so it needs to initialize before
-# the display driver but after the MIPI DBI driver
-config INPUT_INIT_PRIORITY
-	default 82
-
-endif # INPUT
-
 endif # SHIELD_LCD_PAR_S035

--- a/boards/shields/lcd_par_s035/Kconfig.shield
+++ b/boards/shields/lcd_par_s035/Kconfig.shield
@@ -4,3 +4,10 @@
 config SHIELD_LCD_PAR_S035
 	def_bool $(shields_list_contains,lcd_par_s035_spi) ||\
 		$(shields_list_contains,lcd_par_s035_8080)
+
+config SHIELD_LCD_PAR_S035_INIT_PRIORITY
+	int "LCD_PAR_S035 shield init priority"
+	default 85
+	depends on SHIELD_LCD_PAR_S035
+	help
+	  SYSINIT() priority to initialize the shield

--- a/boards/shields/lcd_par_s035/lcd_par_s035_8080.overlay
+++ b/boards/shields/lcd_par_s035/lcd_par_s035_8080.overlay
@@ -12,6 +12,10 @@
 		zephyr,touch = &gt911_lcd_par_s035;
 	};
 
+	aliases {
+		mipi-dbi = &zephyr_mipi_dbi_parallel;
+	};
+
 	lvgl_pointer {
 		compatible = "zephyr,lvgl-pointer-input";
 		input = <&gt911_lcd_par_s035>;
@@ -20,6 +24,9 @@
 	};
 };
 
+/* Initialization of touch, MIPI DBI and display devices is deferred to
+ * lcd_par_s035_init() in shield.c
+ */
 &nxp_8080_touch_panel_i2c {
 	status = "okay";
 
@@ -27,7 +34,7 @@
 		compatible = "goodix,gt911";
 		reg = <0x5d>;
 		irq-gpios = <&nxp_lcd_8080_connector 9 GPIO_ACTIVE_HIGH>;
-		reset-gpios = <&nxp_lcd_8080_connector 11 GPIO_ACTIVE_LOW>;
+		zephyr,deferred-init;
 	};
 };
 
@@ -35,6 +42,7 @@
 	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
+	zephyr,deferred-init;
 
 	st7796s: st7796s@0 {
 		compatible = "sitronix,st7796s";
@@ -57,5 +65,6 @@
 		ngc = [F0 09 0D 09 08 23 2E 33 46 38 13 13 2C 32];
 		madctl = <0x28>;
 		color-invert;
+		zephyr,deferred-init;
 	};
 };

--- a/boards/shields/lcd_par_s035/lcd_par_s035_spi.overlay
+++ b/boards/shields/lcd_par_s035/lcd_par_s035_spi.overlay
@@ -13,6 +13,10 @@
 		zephyr,touch = &gt911_lcd_par_s035;
 	};
 
+	aliases {
+		mipi-dbi = &zephyr_mipi_dbi_spi;
+	};
+
 	lvgl_pointer {
 		compatible = "zephyr,lvgl-pointer-input";
 		input = <&gt911_lcd_par_s035>;
@@ -21,6 +25,9 @@
 	};
 };
 
+/* Initialization of touch, MIPI DBI and display devices is deferred to
+ * lcd_par_s035_init() in shield.c
+ */
 &nxp_pmod_touch_panel_i2c {
 	status = "okay";
 
@@ -28,6 +35,7 @@
 		compatible = "goodix,gt911";
 		reg = <0x5d>;
 		irq-gpios = <&nxp_lcd_pmod_connector 12 GPIO_ACTIVE_HIGH>;
+		zephyr,deferred-init;
 	};
 };
 
@@ -35,6 +43,7 @@
 	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
+	zephyr,deferred-init;
 
 	st7796s: st7796s@0 {
 		compatible = "sitronix,st7796s";
@@ -64,5 +73,6 @@
 		ngc = [F0 09 0D 09 08 23 2E 33 46 38 13 13 2C 32];
 		madctl = <0x28>;
 		color-invert;
+		zephyr,deferred-init;
 	};
 };

--- a/boards/shields/lcd_par_s035/shield.c
+++ b/boards/shields/lcd_par_s035/shield.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(lcd_par_s035);
+
+#define INT_GPIO_DT_SPEC GPIO_DT_SPEC_GET(DT_NODELABEL(gt911_lcd_par_s035), irq_gpios)
+
+static int lcd_par_s035_init(void)
+{
+	int ret;
+
+#ifdef CONFIG_INPUT_GT911
+	static const struct gpio_dt_spec int_gpio = INT_GPIO_DT_SPEC;
+
+	if (!gpio_is_ready_dt(&int_gpio)) {
+		LOG_ERR("GT911 INT_GPIO controller device not ready");
+		return -ENODEV;
+	}
+
+	/*
+	 * We need to configure the int-pin to 0, in order to enter the
+	 * AddressMode0. Keeping the INT pin low during the reset sequence
+	 * should result in the device selecting an I2C address of 0x5D.
+	 */
+	ret = gpio_pin_configure_dt(&int_gpio, GPIO_OUTPUT_INACTIVE);
+	if (ret != 0) {
+		LOG_ERR("Failed to configure GT911 INT_GPIO: %d", ret);
+		return ret;
+	}
+#endif /* CONFIG_INPUT_GT911 */
+
+#ifdef CONFIG_MIPI_DBI
+	ret = device_init(DEVICE_DT_GET(DT_ALIAS(mipi_dbi)));
+	if (ret != 0) {
+		LOG_ERR("Failed to init mipi_dbi: %d", ret);
+		return ret;
+	}
+#endif /* CONFIG_MIPI_DBI */
+
+#ifdef CONFIG_DISPLAY
+	ret = device_init(DEVICE_DT_GET(DT_NODELABEL(st7796s)));
+	if (ret != 0) {
+		LOG_ERR("Failed to init st7796s display driver: %d", ret);
+		return ret;
+	}
+#endif /* CONFIG_DISPLAY */
+
+#ifdef CONFIG_INPUT_GT911
+	ret = device_init(DEVICE_DT_GET(DT_NODELABEL(gt911_lcd_par_s035)));
+	if (ret != 0) {
+		LOG_ERR("Failed to init gt911_lcd_par_s035 input driver: %d", ret);
+		return ret;
+	}
+#endif /* CONFIG_DISPLAY */
+
+	return 0;
+}
+
+SYS_INIT(lcd_par_s035_init, POST_KERNEL, CONFIG_SHIELD_LCD_PAR_S035_INIT_PRIORITY);


### PR DESCRIPTION
Fixes #98876 

Defers init of GT911 touch, MIPI DBI, and display device drivers.  `lcd_par_s035_init()` in shield.c now initializes these to control the GT911 INT_GPIO state during the Reset sequence.

- Fixes issue with this shield caused by shared Reset signal between the GT911 and display driver.
- Removes `reset-gpios` property from `gt911` node.  The GT911 driver does not need to assert the Reset signal because the display driver asserts Reset before the GT911 driver initializes.

Tested this fix on the following:
- LCD_PAR_S035 shield with FRDM_MCXN947
- LCD_PAR_S035 shield with FRDM_RW612

This capture is from the LCD_PAR_S035 with the FRDM_RW612 and this change applied.  The GT911 INT_GPIO is driven low first, then the LCDIC display driver asserts Reset and INT_GPIO remains low through the init process.
<img width="1717" height="355" alt="image" src="https://github.com/user-attachments/assets/31de8746-3f05-4235-b596-923dfc7940cd" />
