### PR TITLE
soc: nxp: rt118x: Move container header in tree

### DIFF
--- a/soc/nxp/imxrt/imxrt118x/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt118x/CMakeLists.txt
@@ -19,7 +19,6 @@ if((CONFIG_NXP_IMXRT_BOOT_HEADER) AND (CONFIG_BOOT_FLEXSPI_NOR))
   set(RT118x_DEVICE_BOOT_HEADER_DIR
     "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk-ng/devices/RT/RT1180/MIMXRT1189")
 
-  zephyr_library_sources(${RT118x_DEVICE_BOOT_HEADER_DIR}/xip/fsl_flexspi_nor_boot.c)
   zephyr_library_include_directories(${RT118x_DEVICE_BOOT_HEADER_DIR}/xip)
   zephyr_library_include_directories(${RT118x_DEVICE_BOOT_HEADER_DIR})
 endif()

--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -26,6 +26,50 @@
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_CPU_CORTEX_M33)
+#include <fsl_flexspi_nor_boot.h>
+
+extern char __start[];
+extern char _flash_used[];
+extern char __rom_start_address[];
+const __imx_boot_container_section container boot_header = {
+	.hdr = {
+		CNT_VERSION,
+		CNT_SIZE,
+		CNT_TAG_HEADER,
+		CNT_FLAGS,
+		CNT_SW_VER,
+		CNT_FUSE_VER,
+		CNT_NUM_IMG,
+		sizeof(cnt_hdr) + CNT_NUM_IMG * sizeof(image_entry),
+		0
+	},
+	.array = {
+		{
+			(uint32_t)(-1 * CONFIG_IMAGE_CONTAINER_OFFSET),
+			(uint32_t)_flash_used,
+			(uint32_t)__rom_start_address,
+			0x00000000,
+			(uint32_t)__start,
+			0x00000000,
+			IMG_FLAGS,
+			0x0,
+			{0},
+			{0}
+		},
+	},
+	.sign_block = {
+		SGNBK_VERSION,
+		SGNBK_SIZE,
+		SGNBK_TAG,
+		0x0,
+		0x0,
+		0x0,
+		0x0
+	},
+};
+#endif
+
 #if defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M33)
 #if !defined(CONFIG_CM7_BOOT_FROM_FLASH)
 #include <zephyr_image_info.h>


### PR DESCRIPTION
Instead of gluing to the one in the HAL which is not very flexible to configure, define the container header in the zephyr SOC code. This fixes the bug of CONFIG_NXP_FLEXSPI_ROM_RAMLOADER not working.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/97676