### PR TITLE
NXP add arch reboot interface by scmi for iMX95/943 Mcore

### DIFF
--- a/dts/arm/nxp/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/nxp_imx94x.dtsi
@@ -32,6 +32,11 @@
 				#power-domain-cells = <1>;
 			};
 
+			scmi_system: protocol@12 {
+				compatible = "arm,scmi-system";
+				reg = <0x12>;
+			};
+
 			scmi_clk: protocol@14 {
 				compatible = "arm,scmi-clock";
 				reg = <0x14>;

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -81,6 +81,11 @@
 				#power-domain-cells = <1>;
 			};
 
+			scmi_system: protocol@12 {
+				compatible = "arm,scmi-system";
+				reg = <0x12>;
+			};
+
 			scmi_clk: protocol@14 {
 				compatible = "arm,scmi-clock";
 				reg = <0x14>;


### PR DESCRIPTION
Added reboot interface for iMX95/IMX943 Mcore, warm/cold reboot is supported now, but it only work in force reboot, grace reboot not work, tested imx943 mcore reboot with rpmsg sm config, once reboot can only reboot its currently core, if used alt config, it will reboot all boot cpu which defined in system config
this PR relied on another scmi system PR: https://github.com/zephyrproject-rtos/zephyr/pull/99037
verified by another pm cpu shell PR: https://github.com/zephyrproject-rtos/zephyr/pull/99038

thanks