### PR TITLE
drivers: firmware: scmi: Introduce basic system power protocol

### DIFF
--- a/drivers/clock_control/clock_control_arm_scmi.c
+++ b/drivers/clock_control/clock_control_arm_scmi.c
@@ -121,4 +121,4 @@ static struct scmi_clock_data data;
 
 DT_INST_SCMI_PROTOCOL_DEFINE(0, &scmi_clock_init, NULL, &data, NULL,
 			     PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
-			     &scmi_clock_api);
+			     &scmi_clock_api, SCMI_CLK_PROTOCOL_SUPPORTED_VERSION);

--- a/drivers/firmware/scmi/CMakeLists.txt
+++ b/drivers/firmware/scmi/CMakeLists.txt
@@ -11,6 +11,7 @@ zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_SHMEM shmem.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_CLK_HELPERS clk.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_PINCTRL_HELPERS pinctrl.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_POWER_DOMAIN_HELPERS power.c)
+zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_REBOOT reboot.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_SYSTEM system.c)
 
 add_subdirectory_ifdef(CONFIG_ARM_SCMI nxp)

--- a/drivers/firmware/scmi/CMakeLists.txt
+++ b/drivers/firmware/scmi/CMakeLists.txt
@@ -3,7 +3,7 @@
 zephyr_library()
 
 # SCMI core files
-zephyr_library_sources_ifdef(CONFIG_ARM_SCMI core.c)
+zephyr_library_sources_ifdef(CONFIG_ARM_SCMI core.c common.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_MAILBOX_TRANSPORT mailbox.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_SHMEM shmem.c)
 

--- a/drivers/firmware/scmi/CMakeLists.txt
+++ b/drivers/firmware/scmi/CMakeLists.txt
@@ -11,5 +11,6 @@ zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_SHMEM shmem.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_CLK_HELPERS clk.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_PINCTRL_HELPERS pinctrl.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_POWER_DOMAIN_HELPERS power.c)
+zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_SYSTEM system.c)
 
 add_subdirectory_ifdef(CONFIG_ARM_SCMI nxp)

--- a/drivers/firmware/scmi/Kconfig
+++ b/drivers/firmware/scmi/Kconfig
@@ -48,6 +48,13 @@ config ARM_SCMI_SHMEM_INIT_PRIORITY
 	help
 	  SCMI SHMEM driver device initialization priority.
 
+config ARM_SCMI_SYSTEM
+	bool "SCMI system power protocol"
+	default y
+	depends on DT_HAS_ARM_SCMI_SYSTEM_ENABLED
+	help
+	  Enable support for SCMI system protocol functions.
+
 config ARM_SCMI_TRANSPORT_HAS_STATIC_CHANNELS
 	bool "Transport layer has static channels"
 	help

--- a/drivers/firmware/scmi/Kconfig
+++ b/drivers/firmware/scmi/Kconfig
@@ -35,6 +35,14 @@ config ARM_SCMI_POWER_DOMAIN_HELPERS
 	help
 	  Enable support for SCMI power domain protocol helper functions.
 
+config ARM_SCMI_REBOOT
+	bool "SCMI system reboot support"
+	depends on ARM_SCMI_SYSTEM && REBOOT
+	default y
+	help
+	  Enable system reboot functionality using SCMI system power protocol.
+	  This provides sys_arch_reboot() implementation for platforms with SCMI.
+
 config ARM_SCMI_SHMEM
 	bool "SCMI shared memory (SHMEM) driver"
 	default y

--- a/drivers/firmware/scmi/common.c
+++ b/drivers/firmware/scmi/common.c
@@ -124,7 +124,7 @@ int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
 	reply.len = sizeof(reply_buffer);
 	reply.content = &reply_buffer;
 
-	ret = scmi_send_message(proto, &msg, &reply, k_is_pre_kernel());
+	ret = scmi_send_message(proto, &msg, &reply, true);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/common.c
+++ b/drivers/firmware/scmi/common.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief SCMI Common Protocol Commands Implementation
+ *
+ * This file contains the implementation of the SCMI commands that are
+ * common to all protocols (generic or vendor-specific) as listed in
+ * ARM SCMI Specification such as v4.0 (DEN0056F), Section 3.2.2 "Base protocol Commands".
+ *
+ * The following common commands are implemented:
+ * - PROTOCOL_VERSION (0x0): Query protocol version
+ * - PROTOCOL_ATTRIBUTES (0x1): Get protocol-specific attributes
+ * - MESSAGE_ATTRIBUTES (0x2): Query message capabilities
+ * - NEGOTIATE_PROTOCOL_VERSION (0x10): Negotiate protocol version support
+ *
+ * These commands provide standardized interfaces that can be reused across
+ * different SCMI protocol implementations, ensuring consistency and reducing
+ * code duplication.
+ *
+ * Reference: ARM System Control and Management Interface Platform Design Document
+ * Version 4.0, Document number: DEN0056F
+ * Available at: https://developer.arm.com/documentation/den0056/latest
+ */
+
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/firmware/scmi/protocol.h>
+
+struct scmi_protocol_version_reply {
+	int32_t status;
+	uint32_t version;
+};
+
+struct scmi_protocol_attributes_reply {
+	int32_t status;
+	uint32_t attributes;
+};
+
+struct scmi_protocol_message_attributes_reply {
+	int32_t status;
+	uint32_t attributes;
+};
+
+int scmi_protocol_get_version(struct scmi_protocol *proto, uint32_t *version)
+{
+	struct scmi_protocol_version_reply reply_buffer;
+	struct scmi_message msg, reply;
+	int ret;
+
+	if (!proto || !version) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_MSG_PROTOCOL_VERSION, SCMI_COMMAND,
+			proto->id, 0x0);
+	msg.len = 0;
+	msg.content = NULL;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(reply_buffer);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply, k_is_pre_kernel());
+	if (ret < 0) {
+		return ret;
+	}
+
+	*version = reply_buffer.version;
+
+	return scmi_status_to_errno(reply_buffer.status);
+}
+
+int scmi_protocol_attributes_get(struct scmi_protocol *proto, uint32_t *attributes)
+{
+	struct scmi_protocol_attributes_reply reply_buffer;
+	struct scmi_message msg, reply;
+	int ret;
+
+	if (!proto || !attributes) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_MSG_PROTOCOL_ATTRIBUTES, SCMI_COMMAND,
+			proto->id, 0x0);
+	msg.len = 0;
+	msg.content = NULL;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(reply_buffer);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply, k_is_pre_kernel());
+	if (ret < 0) {
+		return ret;
+	}
+
+	*attributes = reply_buffer.attributes;
+
+	return scmi_status_to_errno(reply_buffer.status);
+}
+
+int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
+					uint32_t message_id, uint32_t *attributes)
+{
+	struct scmi_protocol_message_attributes_reply reply_buffer;
+	struct scmi_message msg, reply;
+	int ret;
+
+	if (!proto || !attributes) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_MSG_MESSAGE_ATTRIBUTES, SCMI_COMMAND,
+			proto->id, 0x0);
+	msg.len = sizeof(message_id);
+	msg.content = &message_id;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(reply_buffer);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply, k_is_pre_kernel());
+	if (ret < 0) {
+		return ret;
+	}
+
+	*attributes = reply_buffer.attributes;
+
+	return scmi_status_to_errno(reply_buffer.status);
+}
+
+int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t version)
+{
+	struct scmi_message msg, reply;
+	int32_t status;
+	int ret;
+
+	if (!proto) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_MSG_NEGOTIATE_PROTOCOL_VERSION, SCMI_COMMAND,
+			proto->id, 0x0);
+	msg.len = sizeof(version);
+	msg.content = &version;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(status);
+	reply.content = &status;
+
+	ret = scmi_send_message(proto, &msg, &reply, k_is_pre_kernel());
+	if (ret < 0) {
+		return ret;
+	}
+
+	return scmi_status_to_errno(status);
+}

--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -8,7 +8,8 @@
 #include <zephyr/drivers/firmware/scmi/nxp/cpu.h>
 #include <zephyr/kernel.h>
 
-DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, nxp_scmi_cpu), NULL);
+DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, nxp_scmi_cpu), NULL,
+		SCMI_NXP_CPU_PROTOCOL_SUPPORTED_VERSION);
 
 struct scmi_cpu_info_get_reply {
 	int32_t status;

--- a/drivers/firmware/scmi/pinctrl.c
+++ b/drivers/firmware/scmi/pinctrl.c
@@ -7,7 +7,8 @@
 #include <zephyr/drivers/firmware/scmi/pinctrl.h>
 #include <zephyr/kernel.h>
 
-DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_pinctrl), NULL);
+DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_pinctrl), NULL,
+		SCMI_PIN_CONTROL_PROTOCOL_SUPPORTED_VERSION);
 
 int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 {

--- a/drivers/firmware/scmi/power.c
+++ b/drivers/firmware/scmi/power.c
@@ -8,7 +8,8 @@
 #include <string.h>
 #include <zephyr/kernel.h>
 
-DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_power), NULL);
+DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_power), NULL,
+		SCMI_POWER_DOMAIN_PROTOCOL_SUPPORTED_VERSION);
 
 struct scmi_power_state_get_reply {
 	int32_t status;

--- a/drivers/firmware/scmi/reboot.c
+++ b/drivers/firmware/scmi/reboot.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/firmware/scmi/system.h>
+#include <string.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(scmi_reboot, CONFIG_PM_LOG_LEVEL);
+
+static int scmi_reboot_handler(int type)
+{
+	struct scmi_system_power_state_config cfg;
+	int ret;
+	uint32_t mesg_attr;
+
+	cfg.flags = SCMI_SYSTEM_POWER_FLAG_FORCEFUL;
+
+	switch (type) {
+	case SYS_REBOOT_WARM:
+		ret = scmi_system_protocol_message_attributes(SCMI_SYSTEM_MSG_POWER_STATE_SET,
+							      &mesg_attr);
+		if (ret < 0) {
+			LOG_ERR("Failed to query SCMI system capabilities: %d", ret);
+			return ret;
+		}
+
+		if (!(mesg_attr & SCMI_SYSTEM_MSG_ATTR_WARM_RESET)) {
+			LOG_WRN("Warm reset not supported by platform");
+			return -ENOTSUP;
+		}
+
+		cfg.system_state = SCMI_SYSTEM_POWER_STATE_WARM_RESET;
+		break;
+
+	case SYS_REBOOT_COLD:
+		cfg.system_state = SCMI_SYSTEM_POWER_STATE_COLD_RESET;
+		break;
+
+	default:
+		LOG_ERR("Unsupported reboot type: %d", type);
+		return -EINVAL;
+	}
+
+	ret = scmi_system_power_state_set(&cfg);
+	if (ret < 0) {
+		LOG_ERR("System reboot failed with error: %d", ret);
+	}
+
+	return ret;
+}
+
+void sys_arch_reboot(int type)
+{
+	scmi_reboot_handler(type);
+}

--- a/drivers/firmware/scmi/system.c
+++ b/drivers/firmware/scmi/system.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/firmware/scmi/system.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+
+DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_system), NULL,
+		SCMI_SYSTEM_POWER_PROTOCOL_SUPPORTED_VERSION);
+
+int scmi_system_protocol_version(uint32_t *version)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_SYSTEM);
+
+	return scmi_protocol_get_version(proto, version);
+}
+
+int scmi_system_protocol_attributes(uint32_t *attributes)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_SYSTEM);
+
+	return scmi_protocol_attributes_get(proto, attributes);
+}
+
+int scmi_system_protocol_message_attributes(uint32_t message_id, uint32_t *attributes)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_SYSTEM);
+
+	return scmi_protocol_message_attributes_get(proto, message_id, attributes);
+}
+
+int scmi_system_protocol_version_negotiate(uint32_t version)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_SYSTEM);
+
+	return scmi_protocol_version_negotiate(proto, version);
+}
+
+int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_SYSTEM);
+	struct scmi_message msg, reply;
+	int32_t status;
+	int ret;
+	bool use_polling;
+
+	/* sanity checks */
+	if (!proto || !cfg) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_SYSTEM) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_SYSTEM_MSG_POWER_STATE_SET, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(*cfg);
+	msg.content = cfg;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(status);
+	reply.content = &status;
+
+	use_polling = k_is_pre_kernel();
+
+	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return scmi_status_to_errno(status);
+}

--- a/dts/bindings/firmware/arm,scmi-system.yaml
+++ b/dts/bindings/firmware/arm,scmi-system.yaml
@@ -1,0 +1,13 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: System Control and Management Interface (SCMI) system power protocol
+
+compatible: "arm,scmi-system"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+    const: [0x12]

--- a/include/zephyr/drivers/firmware/scmi/clk.h
+++ b/include/zephyr/drivers/firmware/scmi/clk.h
@@ -25,6 +25,8 @@
 #define SCMI_CLK_RATE_SET_FLAGS_ROUNDS_UP_DOWN       BIT(2)
 #define SCMI_CLK_RATE_SET_FLAGS_ROUNDS_AUTO          BIT(3)
 
+#define SCMI_CLK_PROTOCOL_SUPPORTED_VERSION	0x30000
+
 /**
  * @struct scmi_clock_config
  *

--- a/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
+++ b/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
@@ -34,6 +34,8 @@
 /** CPU vector flag: Resume address (exit from suspend) */
 #define SCMI_CPU_VEC_FLAGS_RESUME  BIT(31)
 
+#define SCMI_NXP_CPU_PROTOCOL_SUPPORTED_VERSION	0x10000
+
 /**
  * @struct scmi_cpu_sleep_mode_config
  *

--- a/include/zephyr/drivers/firmware/scmi/nxp/system.h
+++ b/include/zephyr/drivers/firmware/scmi/nxp/system.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_NXP_SYSTEM_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_NXP_SYSTEM_H_
+
+/**
+ * @file
+ * @brief NXP SCMI System Protocol Extensions
+ */
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name NXP Vendor System Power States
+ * @{
+ */
+#define SCMI_NXP_SYSTEM_POWER_STATE_WAKE           0x80000000U
+#define SCMI_NXP_SYSTEM_POWER_STATE_FULL_SHUTDOWN  0x80000001U
+#define SCMI_NXP_SYSTEM_POWER_STATE_FULL_RESET     0x80000002U
+#define SCMI_NXP_SYSTEM_POWER_STATE_FULL_SUSPEND   0x80000003U
+#define SCMI_NXP_SYSTEM_POWER_STATE_FULL_WAKE      0x80000004U
+#define SCMI_NXP_SYSTEM_POWER_STATE_GRP_SHUTDOWN   0x80000005U
+#define SCMI_NXP_SYSTEM_POWER_STATE_GRP_RESET      0x80000006U
+#define SCMI_NXP_SYSTEM_POWER_STATE_SUBSYS_RESET   0x80000007U
+#define SCMI_NXP_SYSTEM_POWER_STATE_MODE           0xC0000000U
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_NXP_SYSTEM_H_ */

--- a/include/zephyr/drivers/firmware/scmi/pinctrl.h
+++ b/include/zephyr/drivers/firmware/scmi/pinctrl.h
@@ -29,6 +29,8 @@
 #define SCMI_PINCTRL_ATTRIBUTES_CONFIG_NUM(attributes)\
 	(((attributes) & GENMASK(9, 2)) >> 2)
 
+#define SCMI_PIN_CONTROL_PROTOCOL_SUPPORTED_VERSION	0x10000
+
 /**
  * @brief Pinctrl protocol command message IDs
  */

--- a/include/zephyr/drivers/firmware/scmi/power.h
+++ b/include/zephyr/drivers/firmware/scmi/power.h
@@ -16,6 +16,8 @@
 
 #define SCMI_POWER_STATE_SET_FLAGS_ASYNC BIT(0)
 
+#define SCMI_POWER_DOMAIN_PROTOCOL_SUPPORTED_VERSION	0x30001
+
 /**
  * @struct scmi_power_state_config
  *

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -90,6 +90,8 @@ struct scmi_protocol {
 	const struct device *transport;
 	/** protocol private data */
 	void *data;
+	/** protocol supported version */
+	uint32_t version;
 };
 
 /**

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -67,6 +67,16 @@ enum scmi_status_code {
 };
 
 /**
+ * @brief SCMI common command
+ */
+enum scmi_common_cmd {
+	SCMI_MSG_PROTOCOL_VERSION = 0x0,
+	SCMI_MSG_PROTOCOL_ATTRIBUTES = 0x1,
+	SCMI_MSG_MESSAGE_ATTRIBUTES = 0x2,
+	SCMI_MSG_NEGOTIATE_PROTOCOL_VERSION = 0x10,
+};
+
+/**
  * @struct scmi_protocol
  *
  * @brief SCMI protocol structure
@@ -125,5 +135,51 @@ int scmi_status_to_errno(int scmi_status);
 int scmi_send_message(struct scmi_protocol *proto,
 		      struct scmi_message *msg, struct scmi_message *reply,
 		      bool use_polling);
+
+/**
+ * @brief Get protocol version
+ *
+ * @param proto Protocol instance
+ * @param version Pointer to store protocol version
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_protocol_get_version(struct scmi_protocol *proto, uint32_t *version);
+
+/**
+ * @brief Get protocol attributes
+ *
+ * @param proto Protocol instance
+ * @param attributes Pointer to store protocol attributes
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_protocol_attributes_get(struct scmi_protocol *proto, uint32_t *attributes);
+
+/**
+ * @brief Get protocol message attributes
+ *
+ * @param proto Protocol instance
+ * @param message_id Message ID to query
+ * @param attributes Pointer to store message attributes
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
+					uint32_t message_id, uint32_t *attributes);
+
+/**
+ * @brief Negotiate protocol version
+ *
+ * @param proto Protocol instance
+ * @param version Desired protocol version
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t version);
 
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PROTOCOL_H_ */

--- a/include/zephyr/drivers/firmware/scmi/system.h
+++ b/include/zephyr/drivers/firmware/scmi/system.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_SYSTEM_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_SYSTEM_H_
+
+/**
+ * @file
+ * @brief SCMI System Power Management Protocol
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/firmware/scmi/protocol.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief System protocol command message IDs
+ */
+enum scmi_system_message {
+	SCMI_SYSTEM_MSG_PROTOCOL_VERSION = 0x0,
+	SCMI_SYSTEM_MSG_PROTOCOL_ATTRIBUTES = 0x1,
+	SCMI_SYSTEM_MSG_MESSAGE_ATTRIBUTES = 0x2,
+	SCMI_SYSTEM_MSG_POWER_STATE_SET = 0x3,
+	SCMI_SYSTEM_MSG_POWER_STATE_NOTIFY = 0x5,
+	SCMI_SYSTEM_MSG_NEGOTIATE_PROTOCOL_VERSION = 0x10,
+};
+
+#define SCMI_SYSTEM_POWER_PROTOCOL_SUPPORTED_VERSION 0x20001
+
+/**
+ * @name Standard SCMI System Power States
+ * @{
+ */
+
+/**< Shutdown off */
+#define SCMI_SYSTEM_POWER_STATE_SHUTDOWN      0x00000000U
+/**< Cold reset */
+#define SCMI_SYSTEM_POWER_STATE_COLD_RESET    0x00000001U
+/**< Warm reset */
+#define SCMI_SYSTEM_POWER_STATE_WARM_RESET    0x00000002U
+/**< Power up */
+#define SCMI_SYSTEM_POWER_STATE_POWER_UP      0x00000003U
+/**< Suspend */
+#define SCMI_SYSTEM_POWER_STATE_SUSPEND       0x00000004U
+
+/** @} */
+
+/**
+ * @name System Power State flags
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+#define SCMI_SYSTEM_POWER_FLAG_SHIFT	(0)
+/** @endcond */
+
+/**< Forceful request */
+#define SCMI_SYSTEM_POWER_FLAG_FORCEFUL	(0 << SCMI_SYSTEM_POWER_FLAG_SHIFT)
+/**< Graceful request */
+#define SCMI_SYSTEM_POWER_FLAG_GRACEFUL	(1 << SCMI_SYSTEM_POWER_FLAG_SHIFT)
+
+/** @} */
+
+
+/*!
+ * @name SCMI system message attributes
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+#define SCMI_SYSTEM_MSG_ATTR_SUSPEND_SHIFT	(30U)
+#define SCMI_SYSTEM_MSG_ATTR_WARM_RESET_SHIFT	(31U)
+/** @endcond */
+
+/*! System suspend support */
+#define SCMI_SYSTEM_MSG_ATTR_SUSPEND	(1 << SCMI_SYSTEM_MSG_ATTR_SUSPEND_SHIFT)
+/*! System warm reset support */
+#define SCMI_SYSTEM_MSG_ATTR_WARM_RESET	(1 << SCMI_SYSTEM_MSG_ATTR_WARM_RESET_SHIFT)
+
+/** @} */
+
+/**
+ * @struct scmi_system_power_state_config
+ * @brief System power state configuration
+ */
+struct scmi_system_power_state_config {
+	uint32_t flags;
+	uint32_t system_state;
+};
+
+/**
+ * @brief Get protocol version
+ *
+ * @param version Protocol version
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_system_protocol_version(uint32_t *version);
+
+/**
+ * @brief Get protocol attributes
+ *
+ * @param attributes Protocol attributes
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_system_protocol_attributes(uint32_t *attributes);
+
+/**
+ * @brief Get protocol message attributes
+ *
+ * @param message_id Message ID of the message
+ * @param attributes Message attributes
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_system_protocol_message_attributes(uint32_t message_id, uint32_t *attributes);
+
+/**
+ * @brief Negotiate protocol version
+ *
+ * @param version desired protocol version
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_system_protocol_version_negotiate(uint32_t version);
+
+/**
+ * @brief Set system power state
+ *
+ * @param cfg pointer to power state configuration
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_SYSTEM_H_ */

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -146,12 +146,13 @@
  * @param proto protocol ID in decimal format
  * @param pdata protocol private data
  */
-#define DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, proto, pdata)			\
+#define DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, proto, pdata, version_val)	\
 	STRUCT_SECTION_ITERABLE(scmi_protocol, SCMI_PROTOCOL_NAME(proto)) =	\
 	{									\
 		.id = proto,							\
 		.tx = DT_SCMI_TRANSPORT_TX_CHAN(node_id),			\
 		.data = pdata,							\
+		.version = version_val						\
 	}
 
 #else /* CONFIG_ARM_SCMI_TRANSPORT_HAS_STATIC_CHANNELS */
@@ -209,9 +210,10 @@
  * @param prio protocol's priority within its initialization level
  */
 #define DT_SCMI_PROTOCOL_DEFINE(node_id, init_fn, pm, data, config,		\
-				level, prio, api)				\
+				level, prio, api, version_val)			\
 	DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)				\
-	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR_RAW(node_id), data);	\
+	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR_RAW(node_id), data,	\
+			version_val);						\
 	DEVICE_DT_DEFINE(node_id, init_fn, pm,					\
 			 &SCMI_PROTOCOL_NAME(DT_REG_ADDR_RAW(node_id)),		\
 					     config, level, prio, api)
@@ -230,9 +232,9 @@
  * @param prio protocol's priority within its initialization level
  */
 #define DT_INST_SCMI_PROTOCOL_DEFINE(inst, init_fn, pm, data, config,		\
-				     level, prio, api)				\
+				     level, prio, api, version)			\
 	DT_SCMI_PROTOCOL_DEFINE(DT_INST(inst, DT_DRV_COMPAT), init_fn, pm,	\
-				data, config, level, prio, api)
+				data, config, level, prio, api, version)
 
 /**
  * @brief Define an SCMI protocol with no device
@@ -245,9 +247,10 @@
  * @param node_id protocol node identifier
  * @param data protocol private data
  */
-#define DT_SCMI_PROTOCOL_DEFINE_NODEV(node_id, data)				\
+#define DT_SCMI_PROTOCOL_DEFINE_NODEV(node_id, data, version)			\
 	DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)				\
-	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR_RAW(node_id), data)
+	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR_RAW(node_id), data,	\
+			version)						\
 
 /**
  * @brief Create an SCMI message field


### PR DESCRIPTION
Add SCMI System Power Domain Protocol support with:

- System power state set operations
- Protocol version/attributes query operations
- Standard SCMI power states (shutdown, cold/warm reset, suspend)
- Graceful and forceful power transitions
- Optional NXP vendor-specific power states
- Device tree binding for "arm,scmi-system"

This enables system-wide power management through standardized SCMI interfaces for reboot and power control operations.