### PR TITLE
drivers: serial: ns16550: Fix TX IRQ not triggered when FIFO is empty

### DIFF
--- a/drivers/serial/Kconfig.ns16550
+++ b/drivers/serial/Kconfig.ns16550
@@ -103,6 +103,17 @@ config UART_NS16550_WA_ISR_REENABLE_INTERRUPT
 	  the IER is being toggled to re-assert interrupts at the end of ISR
 	  to nudge the host interrupt controller to fire the ISR again.
 
+config UART_NS16550_WA_TX_FIFO_EMPTY_INTERRUPT
+	bool "Callback directly when the TX FIFO is already empty"
+	depends on UART_INTERRUPT_DRIVEN
+	default y if (SHELL_BACKEND_SERIAL && SOC_EGIS_ET171)
+	help
+	  When calling uart_ns16550_irq_tx_enable() to wait for the TX FIFO
+	  ready interrupt, but this interrupt will only be triggered if the
+	  current state is not empty. Therefore, if the current state is
+	  empty, you need to solve this problem by calling the callback
+	  function directly.
+
 endmenu
 
 endif # UART_NS16550


### PR DESCRIPTION
This is a reissued PR.

The original [PR#90135](https://github.com/zephyrproject-rtos/zephyr/pull/90135) has been merged,
but it was reverted at [PR#92195](https://github.com/zephyrproject-rtos/zephyr/pull/92195) due to [issue #92187](https://github.com/zephyrproject-rtos/zephyr/issues/92187) that reported by @nashif.

After in-depth investigation,
we found that due to slight differences in the UART hardware of SOC et171 and NS16550,
Therefore, this WA is only applicable to SOC et171.

This PR is based on [PR#90135](https://github.com/zephyrproject-rtos/zephyr/pull/90135) and has the following limitations added only.


// Comparison with  [Kconfig.ns16550@PR#90135](https://github.com/zephyrproject-rtos/zephyr/blob/47e43d552e813c1f9acc4e999c5dd59008d72905/drivers/serial/Kconfig.ns16550)
```
config UART_NS16550_WA_TX_FIFO_EMPTY_INTERRUPT
	bool "Callback directly when the TX FIFO is already empty"
-	default y if SHELL_BACKEND_SERIAL
	depends on UART_INTERRUPT_DRIVEN
+	default y if (UART_INTERRUPT_DRIVEN && SOC_EGIS_ET171)
	help
	  When calling uart_ns16550_irq_tx_enable() to wait for the TX FIFO
	  ready interrupt, but this interrupt will only be triggered if the
	  current state is not empty. Therefore, if the current state is
	  empty, you need to solve this problem by calling the callback
	  function directly.
```

The following test results verify that non-ET171 SoCs are not affected.
```
$ west twister -p qemu_x86_64/atom -s sample.sensor.shell.pytest --no-detailed-test-id

INFO    - Using Ninja..
INFO    - Zephyr version: v4.3.0-rc2-3-g078d9bb229ad
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/jacky/zephyrproject_upstream/zephyr/twister-out/testplan.json
INFO    - JOBS: 12
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    1/   1  100%  built (not run):    0, filtered:    0, failed:    0, error:    0
INFO    - 1 test scenarios (1 configurations) selected, 0 configurations filtered (0 by static filter, 0 at runtime).
INFO    - 1 of 1 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 27.85 seconds.
INFO    - 5 of 5 executed test cases passed (100.00%) on 1 out of total 1259 platforms (0.08%).
INFO    - 1 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/jacky/zephyrproject_upstream/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/jacky/zephyrproject_upstream/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/jacky/zephyrproject_upstream/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```