### PR TITLE
tests: sensor: Fix fdc2x1x in build_all test suite

### DIFF
--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -593,6 +593,7 @@ test_i2c_fdc2x1x: fdc2x1x@54 {
 	sd-gpios = <&test_gpio 0 0>;
 	deglitch = <5>;
 	fref = <43360>;
+
 	channel_0 {
 		rcount = <7499>;
 		settlecount = <48>;


### PR DESCRIPTION
Add missing new line before channel entry which was causing CI fail
```

RUN #230575
Run if [[ ! -s "compliance.xml" ]]; then
Error: See https://docs.zephyrproject.org/latest/contribute/style/devicetree.html for more details.

 Not correctly formatted.:Index: a/tests/drivers/build_all/sensor/i2c.dtsi
===================================================================
--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ a/tests/drivers/build_all/sensor/i2c.dtsi
@@ -592,8 +592,9 @@
        intb-gpios = <&test_gpio 0 0>;
        sd-gpios = <&test_gpio 0 0>;
        deglitch = <5>;
        fref = <43360>;
+
        channel_0 {
                rcount = <7499>;
                settlecount = <48>;
                fref-divider = <1>;
File:tests/drivers/build_all/sensor/i2c.dtsi
 :Insert new lines. Expecting 2.
File:tests/drivers/build_all/sensor/i2c.dtsi
Line:595
Column:16
EndLine:595
EndColumn:16
Compliance error, check for error messages in the "Run Compliance Tests" step
You can run this step locally with the ./scripts/ci/check_compliance.py script.
Error: Process completed with exit code 1.

```