### PR TITLE
Enable set_alarm and cancel_alarm feature for lptmr

### DIFF
--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -27,6 +27,11 @@ struct mcux_lptmr_config {
 struct mcux_lptmr_data {
 	counter_top_callback_t top_callback;
 	void *top_user_data;
+	counter_alarm_callback_t alarm_callback;
+	void *alarm_user_data;
+	uint32_t alarm_target_ticks;
+	bool alarm_active;
+	uint32_t current_top;
 };
 
 static int mcux_lptmr_start(const struct device *dev)
@@ -65,22 +70,54 @@ static int mcux_lptmr_set_top_value(const struct device *dev,
 {
 	const struct mcux_lptmr_config *config = dev->config;
 	struct mcux_lptmr_data *data = dev->data;
+	uint32_t now;
 
 	if (cfg->ticks == 0) {
 		return -EINVAL;
 	}
 
+	/* Top value can only be changed when there is no active alarm */
+	if (data->alarm_active) {
+		return -EBUSY;
+	}
+
 	data->top_callback = cfg->callback;
 	data->top_user_data = cfg->user_data;
+	data->current_top = cfg->ticks;
 
 	if (config->base->CSR & LPTMR_CSR_TEN_MASK) {
-		/* Timer already enabled, check flags before resetting */
+		/* If the COUNTER_TOP_CFG_DONT_RESET flag is true, then we further examine
+		 * the current counter value and the COUNTER_TOP_CFG_RESET_WHEN_LATE flag.
+		 */
 		if (cfg->flags & COUNTER_TOP_CFG_DONT_RESET) {
-			return -ENOTSUP;
+			now = LPTMR_GetCurrentTimerCount(config->base);
+			if (now >= cfg->ticks) {
+				/* Current counter value is greater than or equal to the new
+				 * top value.
+				 * - If the COUNTER_TOP_CFG_RESET_WHEN_LATE flag is set,
+				 *   go through stop-configure-start LPTMR flow.
+				 *
+				 * - Else, return -ETIME.
+				 */
+				if (cfg->flags & COUNTER_TOP_CFG_RESET_WHEN_LATE) {
+					LPTMR_StopTimer(config->base);
+					LPTMR_SetTimerPeriod(config->base, cfg->ticks);
+					LPTMR_StartTimer(config->base);
+				} else {
+					return -ETIME;
+				}
+			} else {
+				/* Current counter value is samller than the new top value.
+				 * Update compare register without stopping (free-running mode).
+				 */
+				LPTMR_SetTimerPeriod(config->base, cfg->ticks);
+			}
+		} else {
+			/* Go through stop-configure-start LPTMR flow. */
+			LPTMR_StopTimer(config->base);
+			LPTMR_SetTimerPeriod(config->base, cfg->ticks);
+			LPTMR_StartTimer(config->base);
 		}
-		LPTMR_StopTimer(config->base);
-		LPTMR_SetTimerPeriod(config->base, cfg->ticks);
-		LPTMR_StartTimer(config->base);
 	} else {
 		LPTMR_SetTimerPeriod(config->base, cfg->ticks);
 	}
@@ -122,9 +159,118 @@ static void mcux_lptmr_isr(const struct device *dev)
 	flags = LPTMR_GetStatusFlags(config->base);
 	LPTMR_ClearStatusFlags(config->base, flags);
 
-	if (data->top_callback) {
+	if (data->alarm_active && data->alarm_callback) {
+		/* One-shot: call alarm callback then disarm */
+		counter_alarm_callback_t cb = data->alarm_callback;
+		void *ud = data->alarm_user_data;
+		uint32_t ticks = data->alarm_target_ticks;
+
+		/* Disarm to avoid repeated interrupts */
+		data->alarm_active = false;
+		data->alarm_callback = NULL;
+		data->alarm_user_data = NULL;
+
+		/* Restore compare to current top period and keep timer running */
+		LPTMR_SetTimerPeriod(config->base, data->current_top);
+
+		/* If no periodic top callback, mask further interrupts */
+		if (!data->top_callback) {
+			LPTMR_DisableInterrupts(config->base, kLPTMR_TimerInterruptEnable);
+		}
+
+		cb(dev, 0, ticks, ud);
+	} else {
 		data->top_callback(dev, data->top_user_data);
 	}
+}
+
+static int mcux_lptmr_set_alarm(const struct device *dev, uint8_t chan_id,
+				const struct counter_alarm_cfg *alarm_cfg)
+{
+	ARG_UNUSED(chan_id);
+
+	const struct mcux_lptmr_config *config = dev->config;
+	struct mcux_lptmr_data *data = dev->data;
+	uint32_t top;
+	uint32_t now;
+	uint32_t target;
+	uint32_t delta;
+
+	if (alarm_cfg == NULL || alarm_cfg->callback == NULL) {
+		return -EINVAL;
+	}
+	if (data->alarm_active) {
+		return -EBUSY;
+	}
+
+	top = data->current_top;
+	if (alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) {
+		if (alarm_cfg->ticks > top) {
+			return -EINVAL;
+		}
+		now = LPTMR_GetCurrentTimerCount(config->base);
+		/* Determine if already late (now >= target) */
+		if ((alarm_cfg->ticks == now) || (now > alarm_cfg->ticks)) {
+			if (alarm_cfg->flags & COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE) {
+				/* Immediate expiration in caller context */
+				alarm_cfg->callback(dev, 0, alarm_cfg->ticks, alarm_cfg->user_data);
+				return 0;
+			}
+			return -ETIME;
+		}
+		/* Program delta to the absolute target from now */
+		target = alarm_cfg->ticks;
+		delta = target - now;
+	} else {
+		/* Relative */
+		delta = alarm_cfg->ticks;
+		if (delta > top) {
+			return -EINVAL;
+		}
+		if (delta == 0U) {
+			/* Treat 0 as the smallest possible delay */
+			delta = 1U;
+		}
+		now = LPTMR_GetCurrentTimerCount(config->base);
+		/* Absolute target relative to now, modulo top */
+		target = (now + delta) % top;
+	}
+
+	LPTMR_SetTimerPeriod(config->base, delta);
+	LPTMR_EnableInterrupts(config->base, kLPTMR_TimerInterruptEnable);
+
+	if ((config->base->CSR & LPTMR_CSR_TEN_MASK) != 0U) {
+		LPTMR_StartTimer(config->base);
+	}
+
+	data->alarm_callback = alarm_cfg->callback;
+	data->alarm_user_data = alarm_cfg->user_data;
+	data->alarm_target_ticks = target;
+	data->alarm_active = true;
+
+	return 0;
+}
+
+static int mcux_lptmr_cancel_alarm(const struct device *dev, uint8_t chan_id)
+{
+	ARG_UNUSED(chan_id);
+
+	const struct mcux_lptmr_config *config = dev->config;
+	struct mcux_lptmr_data *data = dev->data;
+
+	LPTMR_DisableInterrupts(config->base, kLPTMR_TimerInterruptEnable);
+	LPTMR_SetTimerPeriod(config->base, data->current_top);
+
+	if (data->top_callback) {
+		LPTMR_EnableInterrupts(config->base, kLPTMR_TimerInterruptEnable);
+	}
+
+	data->alarm_active = false;
+	data->alarm_callback = NULL;
+	data->alarm_user_data = NULL;
+	data->alarm_target_ticks = 0U;
+
+	return 0;
 }
 
 static int mcux_lptmr_init(const struct device *dev)
@@ -148,6 +294,9 @@ static int mcux_lptmr_init(const struct device *dev)
 
 	LPTMR_SetTimerPeriod(config->base, config->info.max_top_value);
 
+	/* Initialize runtime top tracker */
+	((struct mcux_lptmr_data *)dev->data)->current_top = config->info.max_top_value;
+
 	config->irq_config_func(dev);
 
 	return 0;
@@ -161,6 +310,8 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 	.get_pending_int = mcux_lptmr_get_pending_int,
 	.get_top_value = mcux_lptmr_get_top_value,
 	.get_freq = mcux_lptmr_get_freq,
+	.set_alarm = mcux_lptmr_set_alarm,
+	.cancel_alarm = mcux_lptmr_cancel_alarm,
 };
 
 #define COUNTER_MCUX_LPTMR_DEVICE_INIT(n)					\

--- a/tests/drivers/counter/counter_basic_api/boards/frdm_mcxn236.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/frdm_mcxn236.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lptmr0 {
+	status = "okay";
+};
+
+&lptmr1 {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -4,6 +4,8 @@ tests:
       - drivers
       - counter
     depends_on: counter
+    platform_allow:
+      - frdm_mcxn236
     min_ram: 16
     platform_exclude: nucleo_f302r8
     timeout: 600


### PR DESCRIPTION
For many NXP MCUs, LPTMR is a very commonly used wakeup source. LPTMR can serve as a SysTick companion low-power
mode timer when PM is enabled, which requires LPTMR to implement set_alarm and cancel_alarm functionality. This PR enabled set_alarm and cancel_alarm feature for lptmr.

tested with counter_basic_api, log see details.

<details>

```
*** Booting Zephyr OS build v4.3.0-rc2-129-gca29cd45ef52 ***
Running TESTSUITE counter_basic
===================================================================
START - test_all_channels
Testing ctimer@c000
Skipped for mrt0_channel@0
W: MRT channel resets upon stopping
Skipped for lptmr@4a000
Skipped for lptmr@4b000
 PASS - test_all_channels in 0.442 seconds
===================================================================
START - test_cancelled_alarm_does_not_expire
Skipped for ctimer@c000
Skipped for mrt0_channel@0
W: MRT channel resets upon stopping
Skipped for lptmr@4a000
Skipped for lptmr@4b000
 SKIP - test_cancelled_alarm_does_not_expire in 0.412 seconds
===================================================================
START - test_late_alarm
Skipped for ctimer@c000
Skipped for mrt0_channel@0
W: MRT channel resets upon stopping
Skipped for lptmr@4a000
Skipped for lptmr@4b000
 SKIP - test_late_alarm in 0.412 seconds
===================================================================
START - test_late_alarm_error
Skipped for ctimer@c000
Skipped for mrt0_channel@0
W: MRT channel resets upon stopping
Skipped for lptmr@4a000
Skipped for lptmr@4b000
 SKIP - test_late_alarm_error in 0.412 seconds
===================================================================
START - test_multiple_alarms
Testing ctimer@c000
Skipped for mrt0_channel@0
W: MRT channel resets upon stopping
Skipped for lptmr@4a000
Skipped for lptmr@4b000
 PASS - test_multiple_alarms in 0.466 seconds
===================================================================
START - test_set_top_value_with_alarm
Testing ctimer@c000
Testing mrt0_channel@0
I: "Started" MRT@0x50013000 channel 0 with default value 16777215
W: MRT@0x50013000 channel 0 received requested top value 3000000 which is smaller than current count 16026475
W: MRT channel resets upon stopping
Testing lptmr@4a000
Testing lptmr@4b000
 PASS - test_set_top_value_with_alarm in 0.862 seconds
===================================================================
START - test_short_relative_alarm
Skipped for ctimer@c000
Skipped for mrt0_channel@0
W: MRT channel resets upon stopping
Skipped for lptmr@4a000
Skipped for lptmr@4b000
 SKIP - test_short_relative_alarm in 0.413 seconds
===================================================================
START - test_single_shot_alarm_notop
Testing ctimer@c000
Skipped for mrt0_channel@0
W: MRT channel resets upon stopping
Skipped for lptmr@4a000
Skipped for lptmr@4b000
 PASS - test_single_shot_alarm_notop in 0.482 seconds
===================================================================
START - test_single_shot_alarm_top
Testing ctimer@c000
Skipped for mrt0_channel@0
W: MRT channel resets upon stopping
Skipped for lptmr@4a000
Skipped for lptmr@4b000
 PASS - test_single_shot_alarm_top in 0.482 seconds
===================================================================
START - test_valid_function_without_alarm
Testing ctimer@c000
Skipped for mrt0_channel@0
W: MRT channel resets upon stopping
Testing lptmr@4a000
Testing lptmr@4b000
 PASS - test_valid_function_without_alarm in 0.537 seconds
===================================================================
TESTSUITE counter_basic succeeded
Running TESTSUITE counter_no_callback
===================================================================
START - test_set_top_value_without_alarm
Testing ctimer@c000
Testing mrt0_channel@0
I: "Started" MRT@0x50013000 channel 0 with default value 16777215
W: MRT@0x50013000 channel 0 received requested top value 3000000 which is smaller than current count 16023654
W: MRT channel resets upon stopping
Testing lptmr@4a000
Testing lptmr@4b000
 PASS - test_set_top_value_without_alarm in 0.447 seconds
===================================================================
TESTSUITE counter_no_callback succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [counter_basic]: pass = 6, fail = 0, skip = 4, total = 10 duration = 4.920 seconds
 - PASS - [counter_basic.test_all_channels] duration = 0.442 seconds
 - SKIP - [counter_basic.test_cancelled_alarm_does_not_expire] duration = 0.412 seconds
 - SKIP - [counter_basic.test_late_alarm] duration = 0.412 seconds
 - SKIP - [counter_basic.test_late_alarm_error] duration = 0.412 seconds
 - PASS - [counter_basic.test_multiple_alarms] duration = 0.466 seconds
 - PASS - [counter_basic.test_set_top_value_with_alarm] duration = 0.862 seconds
 - SKIP - [counter_basic.test_short_relative_alarm] duration = 0.413 seconds
 - PASS - [counter_basic.test_single_shot_alarm_notop] duration = 0.482 seconds
 - PASS - [counter_basic.test_single_shot_alarm_top] duration = 0.482 seconds
 - PASS - [counter_basic.test_valid_function_without_alarm] duration = 0.537 seconds

SUITE PASS - 100.00% [counter_no_callback]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.447 seconds
 - PASS - [counter_no_callback.test_set_top_value_without_alarm] duration = 0.447 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```
</details>