### PR TITLE
fs: ext2: (trivial) only enable logging config when ext2 is enabled

### DIFF
--- a/subsys/fs/ext2/Kconfig
+++ b/subsys/fs/ext2/Kconfig
@@ -9,11 +9,11 @@ config FILE_SYSTEM_EXT2
 	help
 	  Enable Ext2 file system support.
 
+if FILE_SYSTEM_EXT2
+
 module = EXT2
 module-str = Ext2
 source "subsys/logging/Kconfig.template.log_config"
-
-if FILE_SYSTEM_EXT2
 
 menu "Ext2 file system Settings"
 	visible if FILE_SYSTEM_EXT2


### PR DESCRIPTION
Avoid polluting every build that includes this Kconfig with useless EXT2 log configuration if the ext2 filesystem is not actually enabled.