### PR TITLE
include: zephyr: nvmem: Fix _OR macros

### DIFF
--- a/include/zephyr/nvmem.h
+++ b/include/zephyr/nvmem.h
@@ -182,7 +182,7 @@ struct nvmem_cell {
  * @see NVMEM_CELL_INST_GET_BY_NAME_OR
  */
 #define NVMEM_CELL_GET_BY_NAME_OR(node_id, name, default_value)                                    \
-	COND_CODE_1(DT_NODE_HAS_PROP(node_id, nvmem_cells),                                        \
+	COND_CODE_1(DT_PROP_HAS_NAME(node_id, nvmem_cells, name),                                  \
 		    (NVMEM_CELL_GET_BY_NAME(node_id, name)),                                       \
 		    (default_value))
 
@@ -286,7 +286,7 @@ struct nvmem_cell {
  * @see NVMEM_CELL_INST_GET_BY_IDX_OR
  */
 #define NVMEM_CELL_GET_BY_IDX_OR(node_id, idx, default_value)                                      \
-	COND_CODE_1(DT_NODE_HAS_PROP(node_id, nvmem_cells),                                        \
+	COND_CODE_1(DT_PROP_HAS_IDX(node_id, nvmem_cells, idx),                                    \
 		    (NVMEM_CELL_GET_BY_IDX(node_id, idx)),                                         \
 		    (default_value))
 

--- a/tests/subsys/nvmem/api/src/main.c
+++ b/tests/subsys/nvmem/api/src/main.c
@@ -47,4 +47,13 @@ ZTEST(nvmem_api, test_nvmem_api)
 	zassert_equal(ret, -EROFS, "Expected read-only NVMEM");
 }
 
+ZTEST(nvmem_api, test_nvmem_missing)
+{
+	const struct nvmem_cell missing_idx = NVMEM_CELL_GET_BY_IDX_OR(consumer0, 10, {});
+	const struct nvmem_cell missing_name = NVMEM_CELL_GET_BY_NAME_OR(consumer0, missing, {});
+
+	zassert_is_null(missing_idx.dev);
+	zassert_is_null(missing_name.dev);
+}
+
 ZTEST_SUITE(nvmem_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Checking if a node has `nvmem-cells` is not sufficient, we need to check if the `idx` or `name` exists.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99062