### PR TITLE
Bluetooth: MPL: Fix NULL pointer dereference in on_obj_selected

### DIFF
--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -722,7 +722,8 @@ static void on_obj_selected(struct bt_ots *ots, struct bt_conn *conn,
 		/* Next track, if the next track has been explicitly set */
 		LOG_DBG("Next Track Object ID");
 		(void)setup_track_object(media_player.next.track);
-	} else if (id == media_player.group->track->next->id) {
+	} else if (media_player.group->track->next != NULL &&
+		   id == media_player.group->track->next->id) {
 		/* Next track, if next track has not been explicitly set */
 		LOG_DBG("Next Track Object ID");
 		(void)setup_track_object(media_player.group->track->next);


### PR DESCRIPTION
Track may not have next track and thus this must be checked before trying to match ID.

This was affecting following qualification test cases: GMCS/SR/MCP/BV-38-C
GMCS/SR/MCP/BV-39-C
GMCS/SR/MCP/BV-40-C

fixes https://github.com/zephyrproject-rtos/zephyr/issues/99066