### PR TITLE
soc: nxp: imx9: add HAS_DWT to i.MX95 M7

### DIFF
--- a/soc/nxp/imx/imx9/imx95/Kconfig
+++ b/soc/nxp/imx/imx9/imx95/Kconfig
@@ -4,6 +4,7 @@
 config SOC_MIMX9596_M7
 	select ARM
 	select CPU_CORTEX_M7
+	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 	select CPU_HAS_ICACHE


### PR DESCRIPTION
The Cortex-M7 in IMX95 has the DWT feature but wasn't specified in Kconfig