### PR TITLE
arch: arm: core: mpu: configure ITCM region if zephyr,itcm is set

### DIFF
--- a/arch/arm/core/mpu/arm_mpu_regions.c
+++ b/arch/arm/core/mpu/arm_mpu_regions.c
@@ -22,7 +22,19 @@ static const struct arm_mpu_region mpu_regions[] = {
 #endif
 #endif
 
+#if DT_REG_SIZE(DT_CHOSEN(zephyr_itcm)) > 0 &&                                                     \
+	!DT_SAME_NODE(DT_CHOSEN(zephyr_itcm), DT_CHOSEN(zephyr_flash))
 	/* Region 1 */
+	MPU_REGION_ENTRY("ITCM", DT_REG_ADDR(DT_CHOSEN(zephyr_itcm)),
+#if defined(CONFIG_ARMV8_M_BASELINE) || defined(CONFIG_ARMV8_M_MAINLINE)
+			 REGION_FLASH_ATTR(DT_REG_ADDR(DT_CHOSEN(zephyr_itcm)),
+					   DT_REG_SIZE(DT_CHOSEN(zephyr_itcm)))),
+#else
+			 REGION_FLASH_ATTR(REGION_ITCM_SIZE)),
+#endif
+#endif
+
+	/* Region 2 */
 	MPU_REGION_ENTRY("SRAM_0",
 			 CONFIG_SRAM_BASE_ADDRESS,
 #if defined(CONFIG_ARMV8_M_BASELINE) || defined(CONFIG_ARMV8_M_MAINLINE)

--- a/include/zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h
@@ -48,6 +48,32 @@
 #error "Unsupported flash size configuration"
 #endif
 
+#if DT_REG_SIZE(DT_CHOSEN(zephyr_itcm)) > 0 &&                                                     \
+	!DT_SAME_NODE(DT_CHOSEN(zephyr_itcm), DT_CHOSEN(zephyr_flash))
+/* ITCM Region Definitions */
+#if DT_REG_SIZE(DT_CHOSEN(zephyr_itcm)) <= (64 * 1024)
+#define REGION_ITCM_SIZE REGION_64K
+#elif DT_REG_SIZE(DT_CHOSEN(zephyr_itcm)) <= (128 * 1024)
+#define REGION_ITCM_SIZE REGION_128K
+#elif DT_REG_SIZE(DT_CHOSEN(zephyr_itcm)) <= (256 * 1024)
+#define REGION_ITCM_SIZE REGION_256K
+#elif DT_REG_SIZE(DT_CHOSEN(zephyr_itcm)) <= (512 * 1024)
+#define REGION_ITCM_SIZE REGION_512K
+#elif DT_REG_SIZE(DT_CHOSEN(zephyr_itcm)) <= (1024 * 1024)
+#define REGION_ITCM_SIZE REGION_1M
+#elif DT_REG_SIZE(DT_CHOSEN(zephyr_itcm)) <= (2048 * 1024)
+#define REGION_ITCM_SIZE REGION_2M
+#elif DT_REG_SIZE(DT_CHOSEN(zephyr_itcm)) <= (4096 * 1024)
+#define REGION_ITCM_SIZE REGION_4M
+#elif DT_REG_SIZE(DT_CHOSEN(zephyr_itcm)) <= (8192 * 1024)
+#define REGION_ITCM_SIZE REGION_8M
+#elif DT_REG_SIZE(DT_CHOSEN(zephyr_itcm)) <= (16384 * 1024)
+#define REGION_ITCM_SIZE REGION_16M
+#else
+#error "Unsupported ITCM size configuration"
+#endif
+#endif
+
 /* SRAM Region Definitions */
 #if CONFIG_SRAM_SIZE <= 16
 #define REGION_SRAM_SIZE REGION_16K


### PR DESCRIPTION
Right now arm_mpu_regions only sets the flash and ram region in the mpu. However when using zephyr,itcm you also want to specify the the ITCM region.

This PR specifies the ITCM region if the zephyr,itcm is selected.