### PR TITLE
 dts: arm: imx95: specify ITCM zephyr,memory-region

### DIFF
--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -105,8 +105,9 @@
 
 	soc {
 		itcm: itcm@0 {
-			compatible = "nxp,imx-itcm";
-			reg = <0x0 DT_SIZE_K(256)>;
+			compatible = "zephyr,memory-region", "nxp,imx-itcm";
+			reg = <0x00000000 DT_SIZE_K(256)>;
+			zephyr,memory-region = "ITCM";
 		};
 
 		dtcm: dtcm@20000000 {


### PR DESCRIPTION
When using `zephyr,itcm` on a imx95 based board the linkage may fail due to the absence of a defined ITCM region. This issue can be resolved by specifying the ITCM region using `zephyr,memory-region`.