### PR TITLE
net: l2: ppp: Allow PPP to transtition ESTABLISH->DEAD

### DIFF
--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -53,6 +53,13 @@ struct net_if *ppp_fsm_iface(struct ppp_fsm *fsm)
 	return ctx->iface;
 }
 
+static bool ppp_fsm_is_dead(struct ppp_fsm *fsm)
+{
+	struct ppp_context *ctx = ppp_fsm_ctx(fsm);
+
+	return ctx->phase == PPP_DEAD;
+}
+
 static void fsm_send_configure_req(struct ppp_fsm *fsm, bool retransmit)
 {
 	struct net_pkt *pkt = NULL;
@@ -246,6 +253,10 @@ void ppp_fsm_close(struct ppp_fsm *fsm, const uint8_t *reason)
 
 	case PPP_STOPPING:
 		ppp_change_state(fsm, PPP_CLOSING);
+		if (ppp_fsm_is_dead(fsm)) {
+			fsm->retransmits = 0;
+			k_work_reschedule(&fsm->timer, K_NO_WAIT);
+		}
 		break;
 
 	default:

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -189,7 +189,12 @@ static void lcp_open(struct ppp_context *ctx)
 static void lcp_close(struct ppp_context *ctx, const uint8_t *reason)
 {
 	if (ctx->phase != PPP_DEAD) {
-		ppp_change_phase(ctx, PPP_TERMINATE);
+		if (ctx->phase == PPP_ESTABLISH) {
+			/* Link is not established yet, so we can go directly to DEAD */
+			ppp_change_phase(ctx, PPP_DEAD);
+		} else {
+			ppp_change_phase(ctx, PPP_TERMINATE);
+		}
 	}
 
 	ppp_fsm_close(&ctx->lcp.fsm, reason);


### PR DESCRIPTION
When remote peer have closed the PPP link normally (LCP Terminate-Request), the PPP stack on Zephyr side switches back to ESTABLISH phase to be ready for next handshake.

When calling net_if_down() on the interface, it should not try to initiate LCP link termination, but instead go directly to DEAD phase.

See https://datatracker.ietf.org/doc/html/rfc1661#section-3.2
```
   +------+        +-----------+           +--------------+
   |      | UP     |           | OPENED    |              | SUCCESS/NONE
   | Dead |------->| Establish |---------->| Authenticate |--+
   |      |        |           |           |              |  |
   +------+        +-----------+           +--------------+  |
      ^               |                        |             |
      |          FAIL |                   FAIL |             |
      +<--------------+             +----------+             |
      |                             |                        |
      |            +-----------+    |           +---------+  |
      |       DOWN |           |    |   CLOSING |         |  |
      +------------| Terminate |<---+<----------| Network |<-+
                   |           |                |         |
                   +-----------+                +---------+
```

ESTABLISH->DEAD is a valid transition.
It does not have to go to ESTABLISH->TERMINATE->DEAD.

Without this change, the `net_if_down()` waits for `CONFIG_NET_L2_PPP_TIMEOUT` until returning if the link was already closed by the remote peer. If the link was up, the termination is faster as peer is responding.

This is because when reaching the `DEAD` phase, the `lcp_down()` returns to `ESTABLISH` if we still indicate carrier is OK.
https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/net/l2/ppp/lcp.c#L208-L210

This delay basically only affects the peer which is serving the connection (PPP server/modem).