### PR TITLE
drivers: stm32: clean indentation in instance definition macros

### DIFF
--- a/drivers/clock_control/clock_stm32_mco.c
+++ b/drivers/clock_control/clock_stm32_mco.c
@@ -69,21 +69,19 @@ static int stm32_mco_init(const struct device *dev)
 	return pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 }
 
-#define STM32_MCO_INIT(inst)                                            \
-									\
-PINCTRL_DT_INST_DEFINE(inst);                                           \
-									\
-const static struct stm32_mco_config stm32_mco_config_##inst = {        \
-	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                   \
-	.pclken = STM32_DT_INST_CLOCKS(inst),                           \
-	IF_ENABLED(HAS_PRESCALER,                                       \
-		(.prescaler = DT_PROP(DT_DRV_INST(inst), prescaler),))  \
-};                                                                      \
-									\
-DEVICE_DT_INST_DEFINE(inst, stm32_mco_init, NULL,                       \
-	NULL,                                                           \
-	&stm32_mco_config_##inst,                                       \
-	PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,               \
-	NULL);
+#define STM32_MCO_INIT(inst)								\
+	PINCTRL_DT_INST_DEFINE(inst);							\
+											\
+	const static struct stm32_mco_config stm32_mco_config_##inst = {		\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),				\
+		.pclken = STM32_DT_INST_CLOCKS(inst),					\
+		IF_ENABLED(HAS_PRESCALER,						\
+			   (.prescaler = DT_PROP(DT_DRV_INST(inst), prescaler),))	\
+	};										\
+											\
+	DEVICE_DT_INST_DEFINE(inst, stm32_mco_init, NULL, NULL,				\
+			      &stm32_mco_config_##inst,					\
+			      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			      NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(STM32_MCO_INIT);

--- a/drivers/clock_control/clock_stm32_mux.c
+++ b/drivers/clock_control/clock_stm32_mux.c
@@ -34,15 +34,14 @@ static int stm32_clk_mux_init(const struct device *dev)
 	return 0;
 }
 
-#define STM32_MUX_CLK_INIT(id)						\
-									\
-static const struct stm32_clk_mux_config stm32_clk_mux_cfg_##id = {	\
-	.pclken = STM32_CLOCK_INFO(0, DT_DRV_INST(id))			\
-};									\
-									\
-DEVICE_DT_INST_DEFINE(id, stm32_clk_mux_init, NULL,			\
-		      NULL, &stm32_clk_mux_cfg_##id,			\
-		      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,\
-		      NULL);
+#define STM32_MUX_CLK_INIT(id)							\
+	static const struct stm32_clk_mux_config stm32_clk_mux_cfg_##id = {	\
+		.pclken = STM32_CLOCK_INFO(0, DT_DRV_INST(id)),			\
+	};									\
+										\
+	DEVICE_DT_INST_DEFINE(id, stm32_clk_mux_init, NULL,			\
+			      NULL, &stm32_clk_mux_cfg_##id,			\
+			      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,\
+			      NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(STM32_MUX_CLK_INIT)

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -940,19 +940,18 @@ void stm32_sdmmc_get_card_csd(const struct device *dev, uint32_t csd[4])
 				STM32_DMA_CHANNEL_CONFIG(0, dir)),	\
 		.dma_callback = stm32_sdmmc_dma_cb,			\
 		.linked_channel = STM32_DMA_HAL_OVERRIDE,		\
-	},								\
-
-
-#define SDMMC_DMA_CHANNEL(dir, DIR)					\
-.dma_##dir = {								\
-	COND_CODE_1(DT_INST_DMAS_HAS_NAME(0, dir),			\
-		 (SDMMC_DMA_CHANNEL_INIT(dir, DIR)),			\
-		 (NULL))						\
 	},
 
-#else
+#define SDMMC_DMA_CHANNEL(dir, DIR)					\
+	.dma_##dir = {							\
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(0, dir),		\
+			    (SDMMC_DMA_CHANNEL_INIT(dir, DIR)),		\
+			    (NULL))					\
+	},
+
+#else /* STM32_SDMMC_USE_DMA */
 #define SDMMC_DMA_CHANNEL(dir, DIR)
-#endif
+#endif /* STM32_SDMMC_USE_DMA */
 
 PINCTRL_DT_INST_DEFINE(0);
 

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -467,7 +467,7 @@ void i2c_stm32_smbalert_disable(const struct device *dev)
 				(DEVICE_DT_GET(STM32_DMA_CTLR(index, dir))), (NULL)),		\
 		.dma_channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),			\
 				(DT_INST_DMAS_CELL_BY_NAME(index, dir, channel)), (-1)),	\
-		},
+	},
 
 void i2c_stm32_dma_tx_cb(const struct device *dma_dev, void *user_data,
 			 uint32_t channel, int status)
@@ -498,23 +498,23 @@ void i2c_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 #define I2C_DMA_DATA_INIT(index, dir, src, dest)						\
 	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, dir),						\
 		(.dma_##dir##_cfg = {								\
-		.dma_slot = STM32_DMA_SLOT(index, dir, slot),					\
-		.channel_direction = STM32_DMA_CONFIG_DIRECTION(				\
-					STM32_DMA_CHANNEL_CONFIG(index, dir)),			\
-		.cyclic =  STM32_DMA_CONFIG_CYCLIC(						\
+			.dma_slot = STM32_DMA_SLOT(index, dir, slot),				\
+			.channel_direction = STM32_DMA_CONFIG_DIRECTION(			\
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-		.channel_priority = STM32_DMA_CONFIG_PRIORITY(					\
+			.cyclic =  STM32_DMA_CONFIG_CYCLIC(					\
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-		.source_data_size = STM32_DMA_CONFIG_##src##_DATA_SIZE(				\
-					STM32_DMA_CHANNEL_CONFIG(index, dir)),			\
-		.dest_data_size = STM32_DMA_CONFIG_##dest##_DATA_SIZE(				\
+			.channel_priority = STM32_DMA_CONFIG_PRIORITY(				\
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-		.source_burst_length = 1,							\
-		.dest_burst_length = 1,								\
-		.dma_callback = i2c_stm32_dma_##dir##_cb,					\
-	},))
+			.source_data_size = STM32_DMA_CONFIG_##src##_DATA_SIZE(			\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.dest_data_size = STM32_DMA_CONFIG_##dest##_DATA_SIZE(			\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.source_burst_length = 1,						\
+			.dest_burst_length = 1,							\
+			.dma_callback = i2c_stm32_dma_##dir##_cb,				\
+		},))
 
-#else
+#else /* CONFIG_I2C_STM32_V2_DMA */
 
 #define I2C_DMA_INIT(index, dir)
 #define I2C_DMA_DATA_INIT(index, dir, src, dest)
@@ -522,49 +522,48 @@ void i2c_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 #endif /* CONFIG_I2C_STM32_V2_DMA */
 
 #define I2C_STM32_INIT(index)									\
-I2C_STM32_IRQ_HANDLER_DECL(index);								\
+	I2C_STM32_IRQ_HANDLER_DECL(index);							\
 												\
-IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),						\
-	(static const uint32_t i2c_timings_##index[] =						\
-		DT_INST_PROP_OR(index, timings, {});))						\
-												\
-PINCTRL_DT_INST_DEFINE(index);									\
-												\
-static const struct stm32_pclken pclken_##index[] =						\
-				 STM32_DT_INST_CLOCKS(index);					\
-												\
-static const struct i2c_stm32_config i2c_stm32_cfg_##index = {					\
-	.i2c = (I2C_TypeDef *)DT_INST_REG_ADDR(index),						\
-	.pclken = pclken_##index,								\
-	.pclk_len = DT_INST_NUM_CLOCKS(index),							\
-	I2C_STM32_IRQ_HANDLER_FUNCTION(index)							\
-	.bitrate = DT_INST_PROP(index, clock_frequency),					\
-	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),						\
-	IF_ENABLED(CONFIG_I2C_STM32_BUS_RECOVERY,						\
-		(.scl =	GPIO_DT_SPEC_INST_GET_OR(index, scl_gpios, {0}),			\
-		 .sda = GPIO_DT_SPEC_INST_GET_OR(index, sda_gpios, {0}),))			\
 	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),					\
-		(.timings = (const struct i2c_config_timing *) i2c_timings_##index,		\
-		 .n_timings =									\
+		(static const uint32_t i2c_timings_##index[] =					\
+			DT_INST_PROP_OR(index, timings, {});))					\
+												\
+	PINCTRL_DT_INST_DEFINE(index);								\
+												\
+	static const struct stm32_pclken pclken_##index[] = STM32_DT_INST_CLOCKS(index);	\
+												\
+	static const struct i2c_stm32_config i2c_stm32_cfg_##index = {				\
+		.i2c = (I2C_TypeDef *)DT_INST_REG_ADDR(index),					\
+		.pclken = pclken_##index,							\
+		.pclk_len = DT_INST_NUM_CLOCKS(index),						\
+		I2C_STM32_IRQ_HANDLER_FUNCTION(index)						\
+		.bitrate = DT_INST_PROP(index, clock_frequency),				\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),					\
+		IF_ENABLED(CONFIG_I2C_STM32_BUS_RECOVERY,					\
+			   (.scl = GPIO_DT_SPEC_INST_GET_OR(index, scl_gpios, {0}),		\
+			    .sda = GPIO_DT_SPEC_INST_GET_OR(index, sda_gpios, {0}),))		\
+		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),				\
+			   (.timings = (const struct i2c_config_timing *)i2c_timings_##index,	\
+			    .n_timings =							\
 			sizeof(i2c_timings_##index) / (sizeof(struct i2c_config_timing)),))	\
-	I2C_DMA_INIT(index, tx)									\
-	I2C_DMA_INIT(index, rx)									\
-};												\
+		I2C_DMA_INIT(index, tx)								\
+		I2C_DMA_INIT(index, rx)								\
+	};											\
 												\
-static struct i2c_stm32_data i2c_stm32_dev_data_##index = {					\
-	I2C_DMA_DATA_INIT(index, tx, MEMORY, PERIPHERAL)					\
-	I2C_DMA_DATA_INIT(index, rx, PERIPHERAL, MEMORY)					\
-};												\
+	static struct i2c_stm32_data i2c_stm32_dev_data_##index = {				\
+		I2C_DMA_DATA_INIT(index, tx, MEMORY, PERIPHERAL)				\
+		I2C_DMA_DATA_INIT(index, rx, PERIPHERAL, MEMORY)				\
+	};											\
 												\
-PM_DEVICE_DT_INST_DEFINE(index, i2c_stm32_pm_action);						\
+	PM_DEVICE_DT_INST_DEFINE(index, i2c_stm32_pm_action);					\
 												\
-I2C_DEVICE_DT_INST_DEFINE(index, i2c_stm32_init,						\
-			 PM_DEVICE_DT_INST_GET(index),						\
-			 &i2c_stm32_dev_data_##index,						\
-			 &i2c_stm32_cfg_##index,						\
-			 POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,					\
-			 &api_funcs);								\
+	I2C_DEVICE_DT_INST_DEFINE(index, i2c_stm32_init,					\
+				  PM_DEVICE_DT_INST_GET(index),					\
+				  &i2c_stm32_dev_data_##index,					\
+				  &i2c_stm32_cfg_##index,					\
+				  POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,			\
+				  &api_funcs);							\
 												\
-I2C_STM32_IRQ_HANDLER(index)
+	I2C_STM32_IRQ_HANDLER(index)
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_STM32_INIT)

--- a/drivers/i2c/i2c_ll_stm32_rtio.c
+++ b/drivers/i2c/i2c_ll_stm32_rtio.c
@@ -275,47 +275,46 @@ static int i2c_stm32_init(const struct device *dev)
 }
 
 #define I2C_STM32_INIT(index)									\
-I2C_STM32_IRQ_HANDLER_DECL(index);								\
+	I2C_STM32_IRQ_HANDLER_DECL(index);							\
 												\
-IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),						\
-	(static const uint32_t i2c_timings_##index[] =						\
-		DT_INST_PROP_OR(index, timings, {});))						\
-												\
-PINCTRL_DT_INST_DEFINE(index);									\
-												\
-static const struct stm32_pclken pclken_##index[] =						\
-				 STM32_DT_INST_CLOCKS(index);					\
-												\
-static const struct i2c_stm32_config i2c_stm32_cfg_##index = {					\
-	.i2c = (I2C_TypeDef *)DT_INST_REG_ADDR(index),						\
-	.pclken = pclken_##index,								\
-	.pclk_len = DT_INST_NUM_CLOCKS(index),							\
-	I2C_STM32_IRQ_HANDLER_FUNCTION(index)							\
-	.bitrate = DT_INST_PROP(index, clock_frequency),					\
-	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),						\
 	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),					\
-		(.timings = (const struct i2c_config_timing *) i2c_timings_##index,		\
-		.n_timings =									\
+		   (static const uint32_t i2c_timings_##index[] =				\
+			DT_INST_PROP_OR(index, timings, {});))					\
+												\
+	PINCTRL_DT_INST_DEFINE(index);								\
+												\
+	static const struct stm32_pclken pclken_##index[] = STM32_DT_INST_CLOCKS(index);	\
+												\
+	static const struct i2c_stm32_config i2c_stm32_cfg_##index = {				\
+		.i2c = (I2C_TypeDef *)DT_INST_REG_ADDR(index),					\
+		.pclken = pclken_##index,							\
+		.pclk_len = DT_INST_NUM_CLOCKS(index),						\
+		I2C_STM32_IRQ_HANDLER_FUNCTION(index)						\
+		.bitrate = DT_INST_PROP(index, clock_frequency),				\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),					\
+		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),				\
+			   (.timings = (const struct i2c_config_timing *)i2c_timings_##index,	\
+			    .n_timings =							\
 			sizeof(i2c_timings_##index) / (sizeof(struct i2c_config_timing)),))	\
-};												\
+	};											\
 												\
-I2C_RTIO_DEFINE(CONCAT(_i2c, index, _stm32_rtio),						\
-	DT_INST_PROP_OR(index, sq_size, CONFIG_I2C_RTIO_SQ_SIZE),				\
-	DT_INST_PROP_OR(index, cq_size, CONFIG_I2C_RTIO_CQ_SIZE));				\
+	I2C_RTIO_DEFINE(CONCAT(_i2c, index, _stm32_rtio),					\
+			DT_INST_PROP_OR(index, sq_size, CONFIG_I2C_RTIO_SQ_SIZE),		\
+			DT_INST_PROP_OR(index, cq_size, CONFIG_I2C_RTIO_CQ_SIZE));		\
 												\
-static struct i2c_stm32_data i2c_stm32_dev_data_##index = {					\
-	.ctx = &CONCAT(_i2c, index, _stm32_rtio),						\
-};												\
+	static struct i2c_stm32_data i2c_stm32_dev_data_##index = {				\
+		.ctx = &CONCAT(_i2c, index, _stm32_rtio),					\
+	};											\
 												\
-PM_DEVICE_DT_INST_DEFINE(index, i2c_stm32_pm_action);						\
+	PM_DEVICE_DT_INST_DEFINE(index, i2c_stm32_pm_action);					\
 												\
-I2C_DEVICE_DT_INST_DEFINE(index, i2c_stm32_init,						\
-			 PM_DEVICE_DT_INST_GET(index),						\
-			 &i2c_stm32_dev_data_##index,						\
-			 &i2c_stm32_cfg_##index,						\
-			 POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,					\
-			 &api_funcs);								\
+	I2C_DEVICE_DT_INST_DEFINE(index, i2c_stm32_init,					\
+				  PM_DEVICE_DT_INST_GET(index),					\
+				  &i2c_stm32_dev_data_##index,					\
+				  &i2c_stm32_cfg_##index,					\
+				  POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,			\
+				  &api_funcs);							\
 												\
-I2C_STM32_IRQ_HANDLER(index)
+	I2C_STM32_IRQ_HANDLER(index)
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_STM32_INIT)

--- a/drivers/i3c/i3c_stm32.c
+++ b/drivers/i3c/i3c_stm32.c
@@ -2140,36 +2140,35 @@ static DEVICE_API(i3c, i3c_stm32_driver_api) = {
 #define STM32_I3C_DMA_CHANNEL_INIT(index, dir, dir_cap, src_dev, dest_dev)                         \
 	.dma_dev = DEVICE_DT_GET(STM32_DMA_CTLR(index, dir)),                                      \
 	.dma_channel = DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                             \
-	.dma_cfg =                                                                                 \
-		{                                                                                  \
-			.dma_slot = STM32_DMA_SLOT(index, dir, slot),                              \
-			.channel_direction =                                                       \
+	.dma_cfg = {                                                                               \
+		.dma_slot = STM32_DMA_SLOT(index, dir, slot),                                      \
+		.channel_direction =                                                               \
 				STM32_DMA_CONFIG_DIRECTION(STM32_DMA_CHANNEL_CONFIG(index, dir)),  \
-			.channel_priority =                                                        \
+		.channel_priority =                                                                \
 				STM32_DMA_CONFIG_PRIORITY(STM32_DMA_CHANNEL_CONFIG(index, dir)),   \
-			.source_data_size = STM32_DMA_CONFIG_##src_dev##_DATA_SIZE(                \
+		.source_data_size = STM32_DMA_CONFIG_##src_dev##_DATA_SIZE(                        \
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),                             \
-			.dest_data_size = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(                 \
+		.dest_data_size = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(                         \
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),                             \
-			.source_burst_length = 1, /* SINGLE transfer */                            \
-			.dest_burst_length = 1,                                                    \
-			.block_count = 1,                                                          \
-			.dma_callback = i3c_stm32_dma_##dir##_cb,                                  \
+		.source_burst_length = 1, /* SINGLE transfer */                                    \
+		.dest_burst_length = 1,                                                            \
+		.block_count = 1,                                                                  \
+		.dma_callback = i3c_stm32_dma_##dir##_cb,                                          \
 	},                                                                                         \
 	.src_addr_increment =                                                                      \
 		STM32_DMA_CONFIG_##src_dev##_ADDR_INC(STM32_DMA_CHANNEL_CONFIG(index, dir)),       \
 	.dst_addr_increment =                                                                      \
 		STM32_DMA_CONFIG_##dest_dev##_ADDR_INC(STM32_DMA_CHANNEL_CONFIG(index, dir)),      \
 	.fifo_threshold = STM32_DMA_FEATURES_FIFO_THRESHOLD(STM32_DMA_FEATURES(index, dir)),
-
 #endif
 
 #ifdef CONFIG_I3C_STM32_DMA
 #define STM32_I3C_DMA_CHANNEL(index, dir, DIR, src, dest)                                          \
-	.dma_##dir = {COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                               \
-				  (STM32_I3C_DMA_CHANNEL_INIT(index, dir, DIR, src, dest)),        \
-				  (NULL))},
-
+	.dma_##dir = {                                                                             \
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                                     \
+			    (STM32_I3C_DMA_CHANNEL_INIT(index, dir, DIR, src, dest)),              \
+			    (NULL))                                                                \
+	},
 #else
 #define STM32_I3C_DMA_CHANNEL(index, dir, DIR, src, dest)
 #endif
@@ -2222,9 +2221,9 @@ static DEVICE_API(i3c, i3c_stm32_driver_api) = {
 		.drv_data.ctrl_config.scl.i2c = DT_INST_PROP_OR(index, i2c_scl_hz, 0),             \
 		.drv_data.ctrl_config.scl.i3c = DT_INST_PROP_OR(index, i3c_scl_hz, 0),             \
 		STM32_I3C_DMA_CHANNEL(index, rx, RX, PERIPHERAL, MEMORY)                           \
-		STM32_I3C_DMA_CHANNEL(index, tx, TX, MEMORY, PERIPHERAL)                   \
-		STM32_I3C_DMA_CHANNEL(index, tc, TC, MEMORY, PERIPHERAL)           \
-		STM32_I3C_DMA_CHANNEL(index, rs, RS, PERIPHERAL, MEMORY)}; \
+		STM32_I3C_DMA_CHANNEL(index, tx, TX, MEMORY, PERIPHERAL)                           \
+		STM32_I3C_DMA_CHANNEL(index, tc, TC, MEMORY, PERIPHERAL)                           \
+		STM32_I3C_DMA_CHANNEL(index, rs, RS, PERIPHERAL, MEMORY)};                         \
                                                                                                    \
 	PM_DEVICE_DT_INST_DEFINE(index, i3c_stm32_pm_action);                                      \
                                                                                                    \

--- a/drivers/ipm/ipm_stm32_hsem.c
+++ b/drivers/ipm/ipm_stm32_hsem.c
@@ -203,15 +203,16 @@ static const struct stm32_hsem_mailbox_config stm32_hsem_mailbox_0_config = {
  * a virtual mailbox device. So there will have only one instance.
  */
 #define IPM_STM32_HSEM_INIT(inst)						\
-	BUILD_ASSERT((inst) == 0,							\
-		     "multiple instances not supported");		\
-	DEVICE_DT_INST_DEFINE(0,							\
-				&stm32_hsem_mailbox_init,				\
-				NULL,			\
-				&stm32_hsem_mailbox_0_data,				\
-				&stm32_hsem_mailbox_0_config,			\
-				POST_KERNEL,							\
-				CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
-				&stm32_hsem_mailbox_ipm_dirver_api);	\
+	BUILD_ASSERT((inst) == 0,						\
+		     "multiple instances not supported");			\
+										\
+	DEVICE_DT_INST_DEFINE(0,						\
+			      &stm32_hsem_mailbox_init,				\
+			      NULL,						\
+			      &stm32_hsem_mailbox_0_data,			\
+			      &stm32_hsem_mailbox_0_config,			\
+			      POST_KERNEL,					\
+			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\
+			      &stm32_hsem_mailbox_ipm_dirver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(IPM_STM32_HSEM_INIT)

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -737,64 +737,64 @@ static int pwm_stm32_init(const struct device *dev)
 
 #ifdef CONFIG_PWM_CAPTURE
 #define IRQ_CONNECT_AND_ENABLE_BY_NAME(index, name)				\
-{										\
-	IRQ_CONNECT(DT_IRQ_BY_NAME(PWM(index), name, irq),			\
-			DT_IRQ_BY_NAME(PWM(index), name, priority),		\
-			pwm_stm32_isr, DEVICE_DT_INST_GET(index), 0);		\
-	irq_enable(DT_IRQ_BY_NAME(PWM(index), name, irq));			\
-}
+	{									\
+		IRQ_CONNECT(DT_IRQ_BY_NAME(PWM(index), name, irq),		\
+			    DT_IRQ_BY_NAME(PWM(index), name, priority),		\
+			    pwm_stm32_isr, DEVICE_DT_INST_GET(index), 0);	\
+		irq_enable(DT_IRQ_BY_NAME(PWM(index), name, irq));		\
+	}
 
 #define IRQ_CONNECT_AND_ENABLE_DEFAULT(index)					\
-{										\
-	IRQ_CONNECT(DT_IRQN(PWM(index)),					\
-			DT_IRQ(PWM(index), priority),				\
-			pwm_stm32_isr, DEVICE_DT_INST_GET(index), 0);		\
-	irq_enable(DT_IRQN(PWM(index)));					\
-}
+	{									\
+		IRQ_CONNECT(DT_IRQN(PWM(index)),				\
+			    DT_IRQ(PWM(index), priority),			\
+			    pwm_stm32_isr, DEVICE_DT_INST_GET(index), 0);	\
+		irq_enable(DT_IRQN(PWM(index)));				\
+	}
 
 #define IRQ_CONFIG_FUNC(index)                                                  \
-static void pwm_stm32_irq_config_func_##index(const struct device *dev)		\
-{										\
-	COND_CODE_1(DT_IRQ_HAS_NAME(PWM(index), cc),				\
-		(IRQ_CONNECT_AND_ENABLE_BY_NAME(index, cc)),			\
-		(IRQ_CONNECT_AND_ENABLE_DEFAULT(index))				\
-	);									\
-}
-#define CAPTURE_INIT(index)                                                                        \
-	.irq_config_func = pwm_stm32_irq_config_func_##index,                                      \
+	static void pwm_stm32_irq_config_func_##index(const struct device *dev)	\
+	{									\
+		COND_CODE_1(DT_IRQ_HAS_NAME(PWM(index), cc),			\
+			    (IRQ_CONNECT_AND_ENABLE_BY_NAME(index, cc)),	\
+			    (IRQ_CONNECT_AND_ENABLE_DEFAULT(index)))		\
+	}
+
+#define CAPTURE_INIT(index)							\
+	.irq_config_func = pwm_stm32_irq_config_func_##index,			\
 	.four_channel_capture_support = DT_INST_PROP(index, four_channel_capture_support)
-#else
+#else /* CONFIG_PWM_CAPTURE */
 #define IRQ_CONFIG_FUNC(index)
 #define CAPTURE_INIT(index)
 #endif /* CONFIG_PWM_CAPTURE */
 
-#define PWM_DEVICE_INIT(index)                                                 \
-	static struct pwm_stm32_data pwm_stm32_data_##index = {		       \
-		.reset = RESET_DT_SPEC_GET(PWM(index)),			       \
-	};								       \
-									       \
-	IRQ_CONFIG_FUNC(index)						       \
-									       \
-	PINCTRL_DT_INST_DEFINE(index);					       \
-									       \
-	static const struct stm32_pclken pclken_##index[] =		       \
-					STM32_DT_CLOCKS(PWM(index));	      \
-									       \
-	static const struct pwm_stm32_config pwm_stm32_config_##index = {      \
-		.timer = (TIM_TypeDef *)DT_REG_ADDR(PWM(index)),	       \
-		.prescaler = DT_PROP(PWM(index), st_prescaler),		       \
-		.countermode = DT_PROP(PWM(index), st_countermode),	       \
-		.deadtime = DT_PROP(PWM(index), st_deadtime),		       \
-		.pclken = pclken_##index,				       \
-		.pclk_len = DT_NUM_CLOCKS(PWM(index)),			       \
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),		       \
-		CAPTURE_INIT(index)					       \
-	};                                                                     \
-									       \
-	DEVICE_DT_INST_DEFINE(index, &pwm_stm32_init, NULL,                    \
-			    &pwm_stm32_data_##index,                           \
-			    &pwm_stm32_config_##index, POST_KERNEL,            \
-			    CONFIG_PWM_INIT_PRIORITY,                          \
+#define PWM_DEVICE_INIT(index)							\
+	static struct pwm_stm32_data pwm_stm32_data_##index = {			\
+		.reset = RESET_DT_SPEC_GET(PWM(index)),				\
+	};									\
+										\
+	IRQ_CONFIG_FUNC(index)							\
+										\
+	PINCTRL_DT_INST_DEFINE(index);						\
+										\
+	static const struct stm32_pclken pclken_##index[] =			\
+					STM32_DT_CLOCKS(PWM(index));		\
+										\
+	static const struct pwm_stm32_config pwm_stm32_config_##index = {	\
+		.timer = (TIM_TypeDef *)DT_REG_ADDR(PWM(index)),		\
+		.prescaler = DT_PROP(PWM(index), st_prescaler),			\
+		.countermode = DT_PROP(PWM(index), st_countermode),		\
+		.deadtime = DT_PROP(PWM(index), st_deadtime),			\
+		.pclken = pclken_##index,					\
+		.pclk_len = DT_NUM_CLOCKS(PWM(index)),				\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
+		CAPTURE_INIT(index)						\
+	};									\
+										\
+	DEVICE_DT_INST_DEFINE(index, &pwm_stm32_init, NULL,			\
+			    &pwm_stm32_data_##index,				\
+			    &pwm_stm32_config_##index, POST_KERNEL,		\
+			    CONFIG_PWM_INIT_PRIORITY,				\
 			    &pwm_stm32_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_DEVICE_INIT)

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -2488,13 +2488,12 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 #endif /* CONFIG_PM_DEVICE */
 
 #ifdef CONFIG_UART_ASYNC_API
-
 /* src_dev and dest_dev should be 'MEMORY' or 'PERIPHERAL'. */
 #define UART_DMA_CHANNEL_INIT(index, dir, dir_cap, src_dev, dest_dev)	\
-	.dma_dev = DEVICE_DT_GET(STM32_DMA_CTLR(index, dir)),			\
+	.dma_dev = DEVICE_DT_GET(STM32_DMA_CTLR(index, dir)),		\
 	.dma_channel = DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),	\
 	.dma_cfg = {							\
-		.dma_slot = STM32_DMA_SLOT(index, dir, slot),\
+		.dma_slot = STM32_DMA_SLOT(index, dir, slot),		\
 		.channel_direction = STM32_DMA_CONFIG_DIRECTION(	\
 					STM32_DMA_CHANNEL_CONFIG(index, dir)),\
 		.cyclic =  STM32_DMA_CONFIG_CYCLIC(			\
@@ -2504,7 +2503,7 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 		.source_data_size = STM32_DMA_CONFIG_##src_dev##_DATA_SIZE(\
 					STM32_DMA_CHANNEL_CONFIG(index, dir)),\
 		.dest_data_size = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
 		.source_burst_length = 1, /* SINGLE transfer */		\
 		.dest_burst_length = 1,					\
 		.block_count = 1,					\
@@ -2515,23 +2514,20 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 	.dst_addr_increment = STM32_DMA_CONFIG_##dest_dev##_ADDR_INC(	\
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
 	.fifo_threshold = STM32_DMA_FEATURES_FIFO_THRESHOLD(		\
-				STM32_DMA_FEATURES(index, dir)),		\
-
-#endif
+				STM32_DMA_FEATURES(index, dir)),
+#endif /* CONFIG_UART_ASYNC_API */
 
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) || \
 	defined(CONFIG_PM)
 #define STM32_UART_IRQ_HANDLER_DECL(index)				\
 	static void uart_stm32_irq_config_func_##index(const struct device *dev);
 #define STM32_UART_IRQ_HANDLER(index)					\
-static void uart_stm32_irq_config_func_##index(const struct device *dev)	\
-{									\
-	IRQ_CONNECT(DT_INST_IRQN(index),				\
-		DT_INST_IRQ(index, priority),				\
-		uart_stm32_isr, DEVICE_DT_INST_GET(index),		\
-		0);							\
-	irq_enable(DT_INST_IRQN(index));				\
-}
+	static void uart_stm32_irq_config_func_##index(const struct device *dev)\
+	{									\
+		IRQ_CONNECT(DT_INST_IRQN(index), DT_INST_IRQ(index, priority),	\
+			    uart_stm32_isr, DEVICE_DT_INST_GET(index), 0);	\
+		irq_enable(DT_INST_IRQN(index));				\
+	}
 #else
 #define STM32_UART_IRQ_HANDLER_DECL(index) /* Not used */
 #define STM32_UART_IRQ_HANDLER(index) /* Not used */
@@ -2546,13 +2542,12 @@ static void uart_stm32_irq_config_func_##index(const struct device *dev)	\
 #endif
 
 #ifdef CONFIG_UART_ASYNC_API
-#define UART_DMA_CHANNEL(index, dir, DIR, src, dest)			\
-.dma_##dir = {								\
-	COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),			\
-		 (UART_DMA_CHANNEL_INIT(index, dir, DIR, src, dest)),	\
-		 (NULL))						\
+#define UART_DMA_CHANNEL(index, dir, DIR, src, dest)				\
+	.dma_##dir = {								\
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),			\
+			 (UART_DMA_CHANNEL_INIT(index, dir, DIR, src, dest)),	\
+			 (NULL))						\
 	},
-
 #else
 #define UART_DMA_CHANNEL(index, dir, DIR, src, dest)
 #endif
@@ -2571,16 +2566,16 @@ static void uart_stm32_irq_config_func_##index(const struct device *dev)	\
  * Mark/space parity isn't supported on the STM32 family.
  * If 9 data bits are configured, ensure that a parity bit isn't set.
  */
-#define STM32_UART_CHECK_DT_PARITY(index)				\
-BUILD_ASSERT(								\
-	!(DT_INST_ENUM_IDX(index, parity) == UART_CFG_PARITY_MARK ||	\
-	DT_INST_ENUM_IDX(index, parity) == UART_CFG_PARITY_SPACE),	\
-	"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
-	" has unsupported parity configuration");			\
-BUILD_ASSERT(								\
-	!(DT_INST_ENUM_IDX(index, parity) != UART_CFG_PARITY_NONE &&	\
-	DT_INST_ENUM_IDX(index, data_bits) == UART_CFG_DATA_BITS_9),	\
-	"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
+#define STM32_UART_CHECK_DT_PARITY(index)					\
+	BUILD_ASSERT(								\
+		!(DT_INST_ENUM_IDX(index, parity) == UART_CFG_PARITY_MARK ||	\
+		DT_INST_ENUM_IDX(index, parity) == UART_CFG_PARITY_SPACE),	\
+		"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
+		" has unsupported parity configuration");			\
+	BUILD_ASSERT(								\
+		!(DT_INST_ENUM_IDX(index, parity) != UART_CFG_PARITY_NONE &&	\
+		DT_INST_ENUM_IDX(index, data_bits) == UART_CFG_DATA_BITS_9),	\
+		"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
 		" has unsupported parity + data bits combination");
 
 /* Ensure DTS doesn't present an incompatible data bits configuration
@@ -2588,21 +2583,21 @@ BUILD_ASSERT(								\
  * Only some series support 7 data bits.
  */
 #ifdef LL_USART_DATAWIDTH_7B
-#define STM32_UART_CHECK_DT_DATA_BITS(index)				\
-BUILD_ASSERT(								\
-	!(DT_INST_ENUM_IDX(index, data_bits) == UART_CFG_DATA_BITS_5 ||	\
-	(DT_INST_ENUM_IDX(index, data_bits) == UART_CFG_DATA_BITS_6 &&	\
-	DT_INST_ENUM_IDX(index, parity) == UART_CFG_PARITY_NONE)),	\
-	"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
-		" has unsupported data bits configuration");
+#define STM32_UART_CHECK_DT_DATA_BITS(index)					\
+	BUILD_ASSERT(								\
+		!(DT_INST_ENUM_IDX(index, data_bits) == UART_CFG_DATA_BITS_5 ||	\
+		(DT_INST_ENUM_IDX(index, data_bits) == UART_CFG_DATA_BITS_6 &&	\
+		DT_INST_ENUM_IDX(index, parity) == UART_CFG_PARITY_NONE)),	\
+		"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
+			" has unsupported data bits configuration");
 #else
-#define STM32_UART_CHECK_DT_DATA_BITS(index)				\
-BUILD_ASSERT(								\
-	!(DT_INST_ENUM_IDX(index, data_bits) == UART_CFG_DATA_BITS_5 ||	\
-	DT_INST_ENUM_IDX(index, data_bits) == UART_CFG_DATA_BITS_6 ||	\
-	(DT_INST_ENUM_IDX(index, data_bits) == UART_CFG_DATA_BITS_7 &&	\
-	DT_INST_ENUM_IDX(index, parity) == UART_CFG_PARITY_NONE)),	\
-	"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
+#define STM32_UART_CHECK_DT_DATA_BITS(index)					\
+	BUILD_ASSERT(								\
+		!(DT_INST_ENUM_IDX(index, data_bits) == UART_CFG_DATA_BITS_5 ||	\
+		DT_INST_ENUM_IDX(index, data_bits) == UART_CFG_DATA_BITS_6 ||	\
+		(DT_INST_ENUM_IDX(index, data_bits) == UART_CFG_DATA_BITS_7 &&	\
+		DT_INST_ENUM_IDX(index, parity) == UART_CFG_PARITY_NONE)),	\
+		"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
 		" has unsupported data bits configuration");
 #endif
 
@@ -2611,18 +2606,18 @@ BUILD_ASSERT(								\
  * supported for LPUART.
  */
 #ifndef LL_USART_STOPBITS_0_5
-#define STM32_UART_CHECK_DT_STOP_BITS_0_5(index)			\
-BUILD_ASSERT(								\
-	DT_INST_ENUM_IDX(index, stop_bits) != UART_CFG_STOP_BITS_0_5,	\
-	"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
+#define STM32_UART_CHECK_DT_STOP_BITS_0_5(index)				\
+	BUILD_ASSERT(								\
+		DT_INST_ENUM_IDX(index, stop_bits) != UART_CFG_STOP_BITS_0_5,	\
+		"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
 		" has unsupported stop bits configuration");
 /* LPUARTs don't support 0.5 stop bits configurations */
 #else
-#define STM32_UART_CHECK_DT_STOP_BITS_0_5(index)			\
-BUILD_ASSERT(								\
-	!(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_lpuart) &&			\
-	DT_INST_ENUM_IDX(index, stop_bits) == UART_CFG_STOP_BITS_0_5),	\
-	"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
+#define STM32_UART_CHECK_DT_STOP_BITS_0_5(index)				\
+	BUILD_ASSERT(								\
+		!(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_lpuart) &&			\
+		DT_INST_ENUM_IDX(index, stop_bits) == UART_CFG_STOP_BITS_0_5),	\
+		"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
 		" has unsupported stop bits configuration");
 #endif
 
@@ -2631,78 +2626,78 @@ BUILD_ASSERT(								\
  * supported for LPUART.
  */
 #ifndef LL_USART_STOPBITS_1_5
-#define STM32_UART_CHECK_DT_STOP_BITS_1_5(index)			\
-BUILD_ASSERT(								\
-	DT_INST_ENUM_IDX(index, stop_bits) != UART_CFG_STOP_BITS_1_5,	\
-	"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
+#define STM32_UART_CHECK_DT_STOP_BITS_1_5(index)				\
+	BUILD_ASSERT(								\
+		DT_INST_ENUM_IDX(index, stop_bits) != UART_CFG_STOP_BITS_1_5,	\
+		"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
 		" has unsupported stop bits configuration");
 /* LPUARTs don't support 1.5 stop bits configurations */
 #else
-#define STM32_UART_CHECK_DT_STOP_BITS_1_5(index)			\
-BUILD_ASSERT(								\
-	!(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_lpuart) &&			\
-	DT_INST_ENUM_IDX(index, stop_bits) == UART_CFG_STOP_BITS_1_5),	\
-	"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
+#define STM32_UART_CHECK_DT_STOP_BITS_1_5(index)				\
+	BUILD_ASSERT(								\
+		!(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_lpuart) &&			\
+		DT_INST_ENUM_IDX(index, stop_bits) == UART_CFG_STOP_BITS_1_5),	\
+		"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
 		" has unsupported stop bits configuration");
 #endif
 
-#define STM32_UART_INIT(index)						\
-STM32_UART_IRQ_HANDLER_DECL(index)					\
-									\
-PINCTRL_DT_INST_DEFINE(index);						\
-									\
-static const struct stm32_pclken pclken_##index[] =			\
-					    STM32_DT_INST_CLOCKS(index);\
-									\
-static struct uart_config uart_cfg_##index = {				\
-	.baudrate = DT_INST_PROP(index, current_speed),			\
-	.parity = DT_INST_ENUM_IDX(index, parity),			\
-	.stop_bits = DT_INST_ENUM_IDX(index, stop_bits),		\
-	.data_bits = DT_INST_ENUM_IDX(index, data_bits),		\
-	.flow_ctrl = DT_INST_PROP(index, hw_flow_control)		\
-					? UART_CFG_FLOW_CTRL_RTS_CTS	\
-					: UART_CFG_FLOW_CTRL_NONE,	\
-};									\
-									\
-static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
-	.usart = (USART_TypeDef *)DT_INST_REG_ADDR(index),		\
-	.reset = RESET_DT_SPEC_GET(DT_DRV_INST(index)),			\
-	.pclken = pclken_##index,					\
-	.pclk_len = DT_INST_NUM_CLOCKS(index),				\
-	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
-	.single_wire = DT_INST_PROP(index, single_wire),		\
-	.tx_rx_swap = DT_INST_PROP(index, tx_rx_swap),			\
-	.rx_invert = DT_INST_PROP(index, rx_invert),			\
-	.tx_invert = DT_INST_PROP(index, tx_invert),			\
-	.de_enable = DT_INST_PROP(index, de_enable),			\
-	.de_assert_time = DT_INST_PROP(index, de_assert_time),		\
-	.de_deassert_time = DT_INST_PROP(index, de_deassert_time),	\
-	.de_invert = DT_INST_PROP(index, de_invert),			\
-	.fifo_enable = DT_INST_PROP(index, fifo_enable),		\
-	STM32_UART_IRQ_HANDLER_FUNC(index)				\
-	STM32_UART_PM_WAKEUP(index)					\
-};									\
-									\
-static struct uart_stm32_data uart_stm32_data_##index = {		\
-	.uart_cfg = &uart_cfg_##index,					\
-	UART_DMA_CHANNEL(index, rx, RX, PERIPHERAL, MEMORY)		\
-	UART_DMA_CHANNEL(index, tx, TX, MEMORY, PERIPHERAL)		\
-};									\
-									\
-PM_DEVICE_DT_INST_DEFINE(index, uart_stm32_pm_action);			\
-									\
-DEVICE_DT_INST_DEFINE(index,						\
-		    uart_stm32_init,					\
-		    PM_DEVICE_DT_INST_GET(index),			\
-		    &uart_stm32_data_##index, &uart_stm32_cfg_##index,	\
-		    PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,		\
-		    &uart_stm32_driver_api);				\
-									\
-STM32_UART_IRQ_HANDLER(index)						\
-									\
-STM32_UART_CHECK_DT_PARITY(index)					\
-STM32_UART_CHECK_DT_DATA_BITS(index)					\
-STM32_UART_CHECK_DT_STOP_BITS_0_5(index)				\
-STM32_UART_CHECK_DT_STOP_BITS_1_5(index)
+#define STM32_UART_INIT(index)							\
+	STM32_UART_IRQ_HANDLER_DECL(index)					\
+										\
+	PINCTRL_DT_INST_DEFINE(index);						\
+										\
+	static const struct stm32_pclken pclken_##index[] =			\
+		STM32_DT_INST_CLOCKS(index);					\
+										\
+	static struct uart_config uart_cfg_##index = {				\
+		.baudrate = DT_INST_PROP(index, current_speed),			\
+		.parity = DT_INST_ENUM_IDX(index, parity),			\
+		.stop_bits = DT_INST_ENUM_IDX(index, stop_bits),		\
+		.data_bits = DT_INST_ENUM_IDX(index, data_bits),		\
+		.flow_ctrl = DT_INST_PROP(index, hw_flow_control)		\
+					? UART_CFG_FLOW_CTRL_RTS_CTS		\
+					: UART_CFG_FLOW_CTRL_NONE,		\
+	};									\
+										\
+	static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
+		.usart = (USART_TypeDef *)DT_INST_REG_ADDR(index),		\
+		.reset = RESET_DT_SPEC_GET(DT_DRV_INST(index)),			\
+		.pclken = pclken_##index,					\
+		.pclk_len = DT_INST_NUM_CLOCKS(index),				\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
+		.single_wire = DT_INST_PROP(index, single_wire),		\
+		.tx_rx_swap = DT_INST_PROP(index, tx_rx_swap),			\
+		.rx_invert = DT_INST_PROP(index, rx_invert),			\
+		.tx_invert = DT_INST_PROP(index, tx_invert),			\
+		.de_enable = DT_INST_PROP(index, de_enable),			\
+		.de_assert_time = DT_INST_PROP(index, de_assert_time),		\
+		.de_deassert_time = DT_INST_PROP(index, de_deassert_time),	\
+		.de_invert = DT_INST_PROP(index, de_invert),			\
+		.fifo_enable = DT_INST_PROP(index, fifo_enable),		\
+		STM32_UART_IRQ_HANDLER_FUNC(index)				\
+		STM32_UART_PM_WAKEUP(index)					\
+	};									\
+										\
+	static struct uart_stm32_data uart_stm32_data_##index = {		\
+		.uart_cfg = &uart_cfg_##index,					\
+		UART_DMA_CHANNEL(index, rx, RX, PERIPHERAL, MEMORY)		\
+		UART_DMA_CHANNEL(index, tx, TX, MEMORY, PERIPHERAL)		\
+	};									\
+										\
+	PM_DEVICE_DT_INST_DEFINE(index, uart_stm32_pm_action);			\
+										\
+	DEVICE_DT_INST_DEFINE(index,						\
+			      uart_stm32_init,					\
+			      PM_DEVICE_DT_INST_GET(index),			\
+			      &uart_stm32_data_##index, &uart_stm32_cfg_##index,\
+			      PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,	\
+			      &uart_stm32_driver_api);				\
+										\
+	STM32_UART_IRQ_HANDLER(index)						\
+										\
+	STM32_UART_CHECK_DT_PARITY(index)					\
+	STM32_UART_CHECK_DT_DATA_BITS(index)					\
+	STM32_UART_CHECK_DT_STOP_BITS_0_5(index)				\
+	STM32_UART_CHECK_DT_STOP_BITS_1_5(index)
 
 DT_INST_FOREACH_STATUS_OKAY(STM32_UART_INIT)

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -2517,29 +2517,21 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 				STM32_DMA_FEATURES(index, dir)),
 #endif /* CONFIG_UART_ASYNC_API */
 
-#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) || \
-	defined(CONFIG_PM)
-#define STM32_UART_IRQ_HANDLER_DECL(index)				\
-	static void uart_stm32_irq_config_func_##index(const struct device *dev);
-#define STM32_UART_IRQ_HANDLER(index)					\
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) || defined(CONFIG_PM)
+#define STM32_UART_IRQ_HANDLER_DEFINE(index)					\
 	static void uart_stm32_irq_config_func_##index(const struct device *dev)\
 	{									\
 		IRQ_CONNECT(DT_INST_IRQN(index), DT_INST_IRQ(index, priority),	\
 			    uart_stm32_isr, DEVICE_DT_INST_GET(index), 0);	\
 		irq_enable(DT_INST_IRQN(index));				\
 	}
-#else
-#define STM32_UART_IRQ_HANDLER_DECL(index) /* Not used */
-#define STM32_UART_IRQ_HANDLER(index) /* Not used */
-#endif
 
-#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) || \
-	defined(CONFIG_PM)
-#define STM32_UART_IRQ_HANDLER_FUNC(index)				\
+#define STM32_UART_IRQ_HANDLER_FUNC(index)					\
 	.irq_config_func = uart_stm32_irq_config_func_##index,
 #else
+#define STM32_UART_IRQ_HANDLER_DEFINE(index) /* Not used */
 #define STM32_UART_IRQ_HANDLER_FUNC(index) /* Not used */
-#endif
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API || CONFIG_PM */
 
 #ifdef CONFIG_UART_ASYNC_API
 #define UART_DMA_CHANNEL(index, dir, DIR, src, dest)				\
@@ -2642,7 +2634,7 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 #endif
 
 #define STM32_UART_INIT(index)							\
-	STM32_UART_IRQ_HANDLER_DECL(index)					\
+	STM32_UART_IRQ_HANDLER_DEFINE(index)					\
 										\
 	PINCTRL_DT_INST_DEFINE(index);						\
 										\
@@ -2692,8 +2684,6 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 			      &uart_stm32_data_##index, &uart_stm32_cfg_##index,\
 			      PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,	\
 			      &uart_stm32_driver_api);				\
-										\
-	STM32_UART_IRQ_HANDLER(index)						\
 										\
 	STM32_UART_CHECK_DT_PARITY(index)					\
 	STM32_UART_CHECK_DT_DATA_BITS(index)					\


### PR DESCRIPTION
Clean indentation in macros used to define STM32 driver instances resources. The main issue is a missing tabulation at the beginning of the each line participating to the macro value.

No functional changes.

A few other driver would deserve equivalent changes. I've proposed them in other P-Rs that already modify the related macros content for other purposes: stm32-clk-info P-R https://github.com/zephyrproject-rtos/zephyr/pull/98995, i2s P-R https://github.com/zephyrproject-rtos/zephyr/pull/98925.