### PR TITLE
 dts: nxp: mcxn94x: Add SoC compatible

### DIFF
--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -10,6 +10,10 @@
 	chosen {
 		zephyr,entropy = &trng;
 	};
+
+	soc {
+		compatible = "nxp,mcxn94x", "nxp,mcx", "simple-bus";
+	};
 };
 
 &peripheral {


### PR DESCRIPTION
~~Harmonize board compats between `mcx_n9xx_evk/mcxn947/cpu0(/qspi)` and `mcx_n9xx_evk/mcxn947/cpu1` variants.~~

Add SoC-level compatible string to the nxp_mcxn94x_common DT file.