### PR TITLE
drivers: led_strip: ws2812_spi: Ensure MOSI is low during reset

### DIFF
--- a/drivers/led_strip/Kconfig.ws2812
+++ b/drivers/led_strip/Kconfig.ws2812
@@ -26,6 +26,13 @@ config WS2812_STRIP_SPI_FORCE_NOCACHE
 	  For SPI communication using DMA, place the WS2812 SPI buffer in the __nocache section to
 	  ensure it is stored in uncached memory, as DMA usually requires access to uncached regions.
 
+config WS2812_STRIP_SPI_RESET_DELAY_SEND_NOP
+	bool "Send reset delay using NOP frames"
+	help
+	  Use SPI NOP frames to generate the reset delay before and after sending pixel data. This
+	  ensures the MOSI line is held low during the reset period, which may not be guaranteed on
+	  some platforms such as STM32.
+
 endif
 
 config WS2812_STRIP_UART


### PR DESCRIPTION
Some platforms, such as STM32, do not guarantee that the MOSI line is held low when the SPI peripheral is disabled. This can prevent WS2812-based LEDs from resetting correctly, as they require a low signal for a specific duration to trigger a reset.

This commit introduces a Kconfig option to actively drive the MOSI line low during the reset period by sending zero-byte frames via SPI. This ensures the reset condition is reliably met across all hardware platforms.

