### PR TITLE
west: boards: remove `arch` format option

### DIFF
--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -52,8 +52,6 @@ class Boards(WestCommand):
             - revision_default: board default revision
             - revisions: list of board revisions
             - qualifiers: board qualifiers (will be empty for legacy boards)
-            - arch: board architecture (deprecated)
-                    (arch is ambiguous for boards described in new hw model)
             - dir: directory that contains the board definition
             - vendor: board vendor
             '''))


### PR DESCRIPTION
HWMv2 boards do not support this field. As a result of this, running `west boards -f '{arch}'` results in:


```text
Traceback (most recent call last):
  File "/usr/bin/west", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/lib/python3.13/site-packages/west/app/main.py", line 1199, in main
    app.run(argv or sys.argv[1:])
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/west/app/main.py", line 278, in run
    self.run_command(argv, early_args)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/west/app/main.py", line 584, in run_command
    self.run_extension(args.command, argv)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/west/app/main.py", line 739, in run_extension
    self.cmd.run(args, unknown, self.topdir, manifest=self.manifest,
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 config=self.config)
                 ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/west/commands.py", line 200, in run
    self.do_run(args, unknown)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/home/pkoscik/zephyrproject/zephyr/scripts/west_commands/boards.py", line 105, in do_run
    args.format.format(
    ~~~~~~~~~~~~~~~~~~^
        name=board.name,
        ^^^^^^^^^^^^^^^^
    ...<6 lines>...
        qualifiers=list_boards.board_v2_qualifiers_csv(board),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
KeyError: 'arch'
```

Even after patching this `KeyError`, there are no boards where `arch` is set, since this enumerates `board.yml` files - where schema does not support `arch` https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/schemas/board-schema.yaml

This patch removes this format option from the `--help` page.