### PR TITLE
cmake: mcuboot: Flash encrypted image when loading to RAM

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -283,6 +283,9 @@ function(zephyr_mcuboot_tasks)
       set_property(GLOBAL APPEND PROPERTY extra_post_build_commands COMMAND
                    ${imgtool_sign} ${imgtool_args} --encrypt "${keyfile_enc}" ${output}.hex
                    ${output}.signed.encrypted.hex)
+      if(CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD)
+        zephyr_runner_file(hex ${output}.signed.encrypted.hex)
+      endif()
     endif()
 
     if(CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD OR CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD_WITH_REVERT)


### PR DESCRIPTION
When image encryption is enabled with sysbuild configuration variable `SB_CONFIG_BOOT_ENCRYPTION`, we get 4 files in the build directory: 
 - `build/project/zephyr/zephyr.signed.encrypted.hex`
 - `build/project/zephyr/zephyr.signed.hex`
 - `build/project/zephyr/zephyr.slot1.signed.encrypted.hex`
 - `build/project/zephyr/zephyr.slot1.signed.hex`

When running `west flash`, the runner flashes file `zephyr.signed.hex`.

When using `SB_CONFIG_MCUBOOT_MODE_RAM_LOAD` to load the image from external flash to ram and execute from ram, the image is encrypted in the external flash, and MCUBoot decrypts it when loading to ram. `west flash` writes the un-encrypted image in external flash so it fails when mcuboot tries to decrypt it.

This PR set file `zephyr.signed.encrypted.hex` to be flashed instead in this situation.

cc @nordicjm as discussed on discord : https://discord.com/channels/720317445772017664/906521547672522752/1431263691055042591

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99235