### PR TITLE
west.yml: Update hal_silabs revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -240,7 +240,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 5d75cba8a1b0e9a747ae387d9ffbb1bf7cd8c529
+      revision: pull/151/head
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Last version of hal_silabs reduces the number of patches applied on upstream SDKs.