### PR TITLE
usb: host: update udev->addr after setting the address

### DIFF
--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -447,6 +447,27 @@ error:
 	return err;
 }
 
+int usbh_device_set_address(struct usb_device *const udev, const uint8_t new_addr)
+{
+	int err;
+
+	err = usbh_req_set_address(udev, new_addr);
+	if (err) {
+		LOG_ERR("Failed to set device address to 0x%02x", new_addr);
+		return err;
+	}
+
+	udev->addr = new_addr;
+
+	if (new_addr == 0) {
+		udev->state = USB_STATE_DEFAULT;
+	} else {
+		udev->state = USB_STATE_ADDRESSED;
+	}
+
+	return 0;
+}
+
 int usbh_device_init(struct usb_device *const udev)
 {
 	struct usbh_context *const uhs_ctx = udev->ctx;
@@ -505,16 +526,10 @@ int usbh_device_init(struct usb_device *const udev)
 		goto error;
 	}
 
-	err = usbh_req_set_address(udev, new_addr);
+	err = usbh_device_set_address(udev, new_addr);
 	if (err) {
-		LOG_ERR("Failed to set device address");
-		udev->addr = 0;
-
 		goto error;
 	}
-
-	udev->addr = new_addr;
-	udev->state = USB_STATE_ADDRESSED;
 
 	LOG_INF("New device with address %u state %u", udev->addr, udev->state);
 

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -36,6 +36,9 @@ int usbh_device_interface_set(struct usb_device *const udev,
 			      const uint8_t iface, const uint8_t alt,
 			      const bool dry);
 
+/* Set USB device address */
+int usbh_device_set_address(struct usb_device *const udev, const uint8_t num);
+
 /* Wrappers around to avoid glue UHC calls. */
 static inline struct uhc_transfer *usbh_xfer_alloc(struct usb_device *udev,
 						   const uint8_t ep,

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -561,7 +561,7 @@ static int cmd_device_address(const struct shell *sh,
 
 	new_addr = strtol(argv[2], NULL, 10);
 
-	err = usbh_req_set_address(udev, new_addr);
+	err = usbh_device_set_address(udev, new_addr);
 	if (err) {
 		shell_error(sh, "host: Failed to set address");
 	} else {


### PR DESCRIPTION
Build:
```
git remote add josuah https://github.com/josuah/zephyr/
git fetch josuah
git checkout da1f3ee6f95fbecb502ed823c202d8aca9426d7e

west build -d build_nrf54lm20 -b nrf54lm20dk/nrf54lm20a/cpuapp samples/subsys/usb/shell/ \
-DEXTRA_CONF_FILE=host_prj.conf -DCONFIG_USB_DEVICE_STACK_NEXT=n
```
Before:
```
uart:~$ usbh init
uart:~$ usbh enable
uart:~$ usbh device address 1 2
host: New device address is 2
uart:~$ usbh device list 
1
uart:~$ usbh device descriptor device 1
host: Failed to request device descriptor
uart:~$ usbh device descriptor device 2
host: No USB device with address 2
```
After:
```
uart:~$ usbh init
uart:~$ usbh enable
uart:~$ usbh device address 1 2
host: New device address is 2
uart:~$ usbh device list 
2
uart:~$ usbh device descriptor device 2
bLength			18
bDescriptorType		1
bcdUSB			200
bDeviceClass		0
bDeviceSubClass		0
bDeviceProtocol		0
bMaxPacketSize0		64
idVendor		bda
idProduct		8176
bcdDevice		200
iManufacturer		1
iProduct		2
iSerial			3
bNumConfigurations	1
```