### PR TITLE
doc: security: Disclose CVE-2025-12890

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -71,6 +71,8 @@ Security Vulnerability Related
 
 The following CVEs are addressed by this release:
 
+* :cve:`2025-12890` `Bluetooth: peripheral: Invalid handling of malformed connection request
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-8hrf-pfww-83v9>`_
 * :cve:`2025-27809` `TLS clients may unwittingly skip server authentication
   <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-1/>`_
 * :cve:`2025-27810` `Potential authentication bypass in TLS handshake

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -87,6 +87,7 @@ The following CVEs are addressed by this release:
 * :cve:`2025-9557`: Under embargo until 2025-11-24
 * :cve:`2025-9558`: Under embargo until 2025-11-24
 * :cve:`2025-12035`: Under embargo until 2025-12-13
+* :cve:`2025-12899`: Under embargo until 2026-01-28
 * :cve:`2025-59438` `Padding oracle through timing of cipher error reporting
   <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-10-invalid-padding-error/>`_
 * :cve:`2025-54764` `Side channel in RSA key generation and operations (SSBleed, M-Step)

--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -2039,3 +2039,8 @@ This has been fixed in main for v4.2.0
 
 - `PR 89955 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/89955>`_
+
+:cve:`2025-12899`
+-----------------
+
+Under embargo until 2026-01-28

--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -2022,3 +2022,20 @@ Under embargo until 2025-11-24
 -----------------
 
 Under embargo until 2025-12-13
+
+:cve:`2025-12890`
+-----------------
+
+Bluetooth: peripheral: Invalid handling of malformed connection request
+
+Improper handling of malformed Connection Request with the interval
+set to be 1 (which supposed to be illegal) and the chM 0x7CFFFFFFFF
+triggers a crash. The peripheral will not be connectable after it.
+
+- `Zephyr project bug tracker GHSA-8hrf-pfww-83v9
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-8hrf-pfww-83v9>`_
+
+This has been fixed in main for v4.2.0
+
+- `PR 89955 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/89955>`_


### PR DESCRIPTION
Disclose information about published CVE.

*update

Add an entry for the CVE-2025-12899 fixed during 4.3 development but still under embargo.