### PR TITLE
it8xxx2: add support for putting switch.S in ram code section

### DIFF
--- a/soc/ite/ec/it8xxx2/Kconfig
+++ b/soc/ite/ec/it8xxx2/Kconfig
@@ -216,6 +216,13 @@ config SOC_IT8XXX2_LIBRARY_TO_RAM
 	  If this is selected it means that there is a library that needs to be excluded
 	  from the text section.
 
+config SOC_IT8XXX2_SWITCH_IN_RAM
+	bool "Place switch handling code in RAM"
+	select SOC_IT8XXX2_USE_ILM
+	select SOC_IT8XXX2_LIBRARY_TO_RAM
+	help
+	  Place content switching code in ILM for better performance.
+
 config SOC_IT8XXX2_SERIAL_IN_RAM
 	bool "Place serial handling code in RAM"
 	select SOC_IT8XXX2_USE_ILM

--- a/soc/ite/ec/it8xxx2/linker.ld
+++ b/soc/ite/ec/it8xxx2/linker.ld
@@ -173,6 +173,9 @@ SECTIONS
 #ifdef CONFIG_SOC_IT8XXX2_LIBRARY_TO_RAM
 		*(EXCLUDE_FILE (
 #endif
+#ifdef CONFIG_SOC_IT8XXX2_SWITCH_IN_RAM
+			*libarch__riscv__core.a:*
+#endif
 #ifdef CONFIG_SOC_IT8XXX2_SERIAL_IN_RAM
 			*libdrivers__serial.a:*
 #endif
@@ -190,6 +193,9 @@ SECTIONS
 
 #ifdef CONFIG_SOC_IT8XXX2_LIBRARY_TO_RAM
 		*(EXCLUDE_FILE (
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_SWITCH_IN_RAM
+			*libarch__riscv__core.a:*
 #endif
 #ifdef CONFIG_SOC_IT8XXX2_SERIAL_IN_RAM
 			*libdrivers__serial.a:*
@@ -226,6 +232,9 @@ SECTIONS
 #ifdef CONFIG_SOC_IT8XXX2_EXCEPTIONS_IN_RAM
 		KEEP(*(".exception.entry.*"))
 		*(".exception.other.*")
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_SWITCH_IN_RAM
+		*libarch__riscv__core.a:*(.text .text.*)
 #endif
 #ifdef CONFIG_SOC_IT8XXX2_SERIAL_IN_RAM
 		*libdrivers__serial.a:*(.text .text.*)


### PR DESCRIPTION
Get better performance from executing z_riscv_switch() function.