### PR TITLE
devicetree: Add DT_CHILD_BY_UNIT_ADDR_INT

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -77,6 +77,8 @@ node-macro =/ %s"DT_N" path-id %s"_P_" prop-id %s"_FOREACH_PROP_ELEM_SEP_VARGS"
 ; These are used by DT_CHILD_NUM and DT_CHILD_NUM_STATUS_OKAY macros
 node-macro =/ %s"DT_N" path-id %s"_CHILD_NUM"
 node-macro =/ %s"DT_N" path-id %s"_CHILD_NUM_STATUS_OKAY"
+; This is used by DT_CHILD_BY_UNIT_ADDR_INT
+node-macro =/ %s"DT_N" path-id %s"_CHILD_UNIT_ADDR_INT_" DIGIT
 ; These are used internally by DT_FOREACH_CHILD, which iterates over
 ; each child node.
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD"

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -155,6 +155,11 @@ New Samples
   Same as above, this will also be recomputed at the time of the release.
  Just link the sample, further details go in the sample documentation itself.
 
+DeviceTree
+**********
+
+* :c:macro:`DT_CHILD_BY_UNIT_ADDR_INT`
+* :c:macro:`DT_INST_CHILD_BY_UNIT_ADDR_INT`
 
 Libraries / Subsystems
 **********************

--- a/dts/bindings/test/vnd,child-bindings.yaml
+++ b/dts/bindings/test/vnd,child-bindings.yaml
@@ -10,6 +10,9 @@ include: [base.yaml]
 child-binding:
   description: Test child binding
   properties:
+    reg:
+      type: array
+      required: true
     val:
       type: int
       required: true

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -436,6 +436,41 @@
 #define DT_CHILD(node_id, child) UTIL_CAT(node_id, DT_S_PREFIX(child))
 
 /**
+ * @brief Get a node identifier for a child node with a matching unit address
+ *
+ * @note Only works for children with unique integer unit addresses.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     / {
+ *             soc-label: soc {
+ *                     serial1: serial@40001000 {
+ *                             status = "okay";
+ *                             current-speed = <115200>;
+ *                             ...
+ *                     };
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage with DT_PROP() to get the status of the
+ * `serial@40001000` node:
+ *
+ * @code{.c}
+ *     #define SOC_NODE DT_NODELABEL(soc_label)
+ *     DT_PROP(DT_CHILD_BY_UNIT_ADDR_INT(SOC_NODE, 1073745920), status) // "okay"
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param addr Integer unit address for the child node.
+ *
+ * @return node identifier for the child node with the specified unit address
+ */
+#define DT_CHILD_BY_UNIT_ADDR_INT(node_id, addr) \
+	DT_CAT3(node_id, _CHILD_UNIT_ADDR_INT_, addr)
+
+/**
  * @brief Get a node identifier for a status `okay` node with a compatible
  *
  * Use this if you want to get an arbitrary enabled node with a given
@@ -4065,6 +4100,21 @@
  */
 #define DT_INST_CHILD(inst, child) \
 	DT_CHILD(DT_DRV_INST(inst), child)
+
+/**
+ * @brief Get a node identifier for a child node with a matching unit address of DT_DRV_INST(inst)
+ *
+ * @note Only works for children with unique integer unit addresses.
+ *
+ * @param inst instance number
+ * @param addr Integer unit address for the child node.
+ *
+ * @return node identifier for the child node with the specified unit address
+ *
+ * @see DT_CHILD_BY_UNIT_ADDR_INT
+ */
+#define DT_INST_CHILD_BY_UNIT_ADDR_INT(inst, addr) \
+	DT_CHILD_BY_UNIT_ADDR_INT(DT_DRV_INST(inst), addr)
 
 /**
  * @brief Get the number of child nodes of a given node

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -340,10 +340,7 @@ struct adc_dt_spec {
 	}
 
 #define ADC_CHANNEL_DT_NODE(ctlr, input) \
-	DT_FOREACH_CHILD_VARGS(ctlr, ADC_FOREACH_INPUT, input)
-
-#define ADC_FOREACH_INPUT(node, input) \
-	IF_ENABLED(IS_EQ(DT_REG_ADDR_RAW(node), input), (node))
+	DT_CHILD_BY_UNIT_ADDR_INT(ctlr, input)
 
 #define ADC_CHANNEL_CFG_FROM_DT_NODE(node_id) \
 	IF_ENABLED(DT_NODE_EXISTS(node_id), \

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -484,6 +484,19 @@ def write_children(node: edtlib.Node) -> None:
 
     out_dt_define(f"{node.z_path_id}_CHILD_NUM_STATUS_OKAY", ok_nodes_num)
 
+    child_unit_addrs = {}
+    for child in node.children.values():
+        # Provide a way to query child nodes
+        if (addr := child.unit_addr) is not None:
+            child_unit_addrs.setdefault(addr, []).append(child)
+
+    for addr, children in child_unit_addrs.items():
+        if len(children) != 1:
+            # Duplicate unit addresses for different children, skip
+            continue
+
+        out_dt_define(f"{node.z_path_id}_CHILD_UNIT_ADDR_INT_{addr}", f"DT_{children[0].z_path_id}")
+
     out_dt_define(f"{node.z_path_id}_FOREACH_CHILD(fn)",
             " ".join(f"fn(DT_{child.z_path_id})" for child in
                 node.children.values()))

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -658,18 +658,23 @@
 		/* there should only be one of these */
 		test_children: test-children {
 			compatible = "vnd,child-bindings";
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-			test_child_a: child-a {
+			test_child_a: child@a {
+				reg = <0xa>;
 				val = <0>;
 				status = "okay";
 			};
 
-			test_child_b: child-b {
+			test_child_b: child@b {
+				reg = <0xb>;
 				val = <1>;
 				status = "okay";
 			};
 
-			test_child_c: child-c {
+			test_child_c: child@c {
+				reg = <0xc>;
 				val = <2>;
 				status = "disabled";
 			};

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2514,6 +2514,14 @@ ZTEST(devicetree_api, test_children)
 	zassert_equal(DT_PROP(DT_INST_CHILD(0, child_a), val), 0, "");
 	zassert_equal(DT_PROP(DT_INST_CHILD(0, child_b), val), 1, "");
 	zassert_equal(DT_PROP(DT_INST_CHILD(0, child_c), val), 2, "");
+
+	zassert_equal(DT_PROP(DT_CHILD_BY_UNIT_ADDR_INT(DT_NODELABEL(test_children), 10), val), 0);
+	zassert_equal(DT_PROP(DT_CHILD_BY_UNIT_ADDR_INT(DT_NODELABEL(test_children), 11), val), 1);
+	zassert_equal(DT_PROP(DT_CHILD_BY_UNIT_ADDR_INT(DT_NODELABEL(test_children), 12), val), 2);
+
+	zassert_equal(DT_PROP(DT_INST_CHILD_BY_UNIT_ADDR_INT(0, 10), val), 0);
+	zassert_equal(DT_PROP(DT_INST_CHILD_BY_UNIT_ADDR_INT(0, 11), val), 1);
+	zassert_equal(DT_PROP(DT_INST_CHILD_BY_UNIT_ADDR_INT(0, 12), val), 2);
 }
 
 #undef DT_DRV_COMPAT


### PR DESCRIPTION
Allow fetching child node identifiers by unit address.

It also modifies the `ADC_DT_SPEC_STRUCT` macro to not use `FOREACH` macro expansion, which doesn't play nice with `COND_CODE_X` and other macro loops.