### PR TITLE
input: keymap: add a MATRIX_CODE macro

### DIFF
--- a/include/zephyr/input/input_keymap.h
+++ b/include/zephyr/input/input_keymap.h
@@ -41,6 +41,17 @@
  */
 #define MATRIX_COL(keymap_entry) (((keymap_entry) >> 16) & 0xff)
 
+/**
+ * @brief Extract the key code from a keymap entry.
+ *
+ * This macro extracts the key code from a 32-bit keymap entry. The key code
+ * s stored in bits 0-15 of the keymap entry.
+ *
+ * @param keymap_entry The 32-bit keymap entry value.
+ * @return The key code (0-0xffff) extracted from the keymap entry.
+ */
+#define MATRIX_CODE(keymap_entry) (keymap_entry & 0xffff)
+
 /** @} */
 
 #endif /* ZEPHYR_INCLUDE_INPUT_INPUT_KEYMAP_H_ */

--- a/subsys/input/input_keymap.c
+++ b/subsys/input/input_keymap.c
@@ -86,8 +86,6 @@ static int keymap_init(const struct device *dev)
 #define KEYMAP_ENTRY_OFFSET(keymap_entry, col_size) \
 	(MATRIX_ROW(keymap_entry) * col_size + MATRIX_COL(keymap_entry))
 
-#define KEYMAP_ENTRY_CODE(keymap_entry) (keymap_entry & 0xffff)
-
 #define KEYMAP_ENTRY_VALIDATE(node_id, prop, idx)			\
 	BUILD_ASSERT(MATRIX_ROW(DT_PROP_BY_IDX(node_id, prop, idx)) <	\
 		     DT_PROP(node_id, row_size), "invalid row");	\
@@ -96,7 +94,7 @@ static int keymap_init(const struct device *dev)
 
 #define CODES_INIT(node_id, prop, idx) \
 	[KEYMAP_ENTRY_OFFSET(DT_PROP_BY_IDX(node_id, prop, idx), DT_PROP(node_id, col_size))] = \
-		KEYMAP_ENTRY_CODE(DT_PROP_BY_IDX(node_id, prop, idx)),
+		MATRIX_CODE(DT_PROP_BY_IDX(node_id, prop, idx)),
 
 #define INPUT_KEYMAP_DEFINE(inst)								\
 	INPUT_CALLBACK_DEFINE_NAMED(DEVICE_DT_GET(DT_INST_PARENT(inst)), keymap_cb,		\


### PR DESCRIPTION
Add a MATRIX_CODE macro to extract the key code from a key value created in DT with MATRIX_KEY. This can be handy for code other than input_keymap.c