### PR TITLE
usb: device_next: hid: add a suspend callback

### DIFF
--- a/include/zephyr/usb/class/usbd_hid.h
+++ b/include/zephyr/usb/class/usbd_hid.h
@@ -104,6 +104,12 @@ struct hid_device_ops {
 	void (*iface_ready)(const struct device *dev, const bool ready);
 
 	/**
+	 * This callback is called when the HID interface is suspended by the
+	 * host. This callback is optional.
+	 */
+	void (*iface_suspended)(const struct device *dev, const bool suspended);
+
+	/**
 	 * This callback is called for the HID Get Report request to get a
 	 * feature, input, or output report, which is specified by the argument
 	 * type. If there is no report ID in the report descriptor, the id

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -474,6 +474,12 @@ static void usbd_hid_disable(struct usbd_class_data *const c_data)
 static void usbd_hid_suspended(struct usbd_class_data *const c_data)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
+	struct hid_device_data *ddata = dev->data;
+	const struct hid_device_ops *const ops = ddata->ops;
+
+	if (ops->iface_suspended) {
+		ops->iface_suspended(dev, true);
+	}
 
 	LOG_DBG("Configuration suspended, device %s", dev->name);
 }
@@ -481,6 +487,12 @@ static void usbd_hid_suspended(struct usbd_class_data *const c_data)
 static void usbd_hid_resumed(struct usbd_class_data *const c_data)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
+	struct hid_device_data *ddata = dev->data;
+	const struct hid_device_ops *const ops = ddata->ops;
+
+	if (ops->iface_suspended) {
+		ops->iface_suspended(dev, false);
+	}
 
 	LOG_DBG("Configuration resumed, device %s", dev->name);
 }


### PR DESCRIPTION
Add an optional suspend callback to let a downstream hid driver be notified of HID suspend and resume events.