### PR TITLE
drivers: ethernet: lan9250: add support for a random mac address

### DIFF
--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -697,6 +697,8 @@ static int lan9250_init(const struct device *dev)
 		return ret;
 	}
 	lan9250_configure(dev);
+
+	(void)net_eth_mac_load(&config->mac_cfg, context->mac_address);
 	lan9250_set_macaddr(dev);
 
 	k_thread_create(&context->thread, context->thread_stack,
@@ -719,6 +721,7 @@ static int lan9250_init(const struct device *dev)
 		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8)),                                \
 		.interrupt = GPIO_DT_SPEC_INST_GET(inst, int_gpios),                               \
 		.timeout = CONFIG_ETH_LAN9250_BUF_ALLOC_TIMEOUT,                                   \
+		.mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(inst),                                  \
 	};                                                                                         \
                                                                                                    \
 	ETH_NET_DEVICE_DT_INST_DEFINE(inst, lan9250_init, NULL, &lan9250_##inst##_runtime,         \

--- a/drivers/ethernet/eth_lan9250_priv.h
+++ b/drivers/ethernet/eth_lan9250_priv.h
@@ -312,6 +312,7 @@ struct lan9250_config {
 	struct gpio_dt_spec reset;
 	uint8_t full_duplex;
 	int32_t timeout;
+	struct net_eth_mac_config mac_cfg;
 };
 
 struct lan9250_runtime {


### PR DESCRIPTION
Extend the lan9250 driver to support using a local administered unicast random mac address during init. This follows the device tree settings for zephyr_random_mac_address from other ethernet drivers for the added support.