### PR TITLE
boards: mps3/mps4: improve board searchability and naming

### DIFF
--- a/boards/arm/mps3/board.yml
+++ b/boards/arm/mps3/board.yml
@@ -1,6 +1,6 @@
 board:
   name: mps3
-  full_name: MPS3 AN547
+  full_name: MPS3 FPGA/Corstone FVP
   vendor: arm
   socs:
   - name: 'corstone300'

--- a/boards/arm/mps3/doc/index.rst
+++ b/boards/arm/mps3/doc/index.rst
@@ -1,7 +1,4 @@
-.. _mps3_board:
-
-ARM MPS3
-###############
+.. zephyr:board:: mps3
 
 Overview
 ********

--- a/boards/arm/mps4/board.yml
+++ b/boards/arm/mps4/board.yml
@@ -1,6 +1,6 @@
 board:
   name: mps4
-  full_name: MPS4
+  full_name: MPS4 Corstone FVP
   vendor: arm
   socs:
   - name: 'corstone315'

--- a/doc/services/tfm/requirements.rst
+++ b/doc/services/tfm/requirements.rst
@@ -10,7 +10,7 @@ The following are some of the boards that can be used with TF-M:
      - NSPE board name
    * - :ref:`mps2_an521_board`
      - ``mps2/an521/cpu0/ns`` (qemu supported)
-   * - :ref:`mps3_board`
+   * - :zephyr:board:`mps3`
      -
        - ``mps3/corstone300/fvp/ns`` (armfvp supported)
        - ``mps3/corstone310/fvp/ns`` (armfvp supported)


### PR DESCRIPTION
Update board YAML full_name to improve searchability and make it easier to find Corstone FVP platforms in the supported boards list.

Update the mps3 .rst file to align the title and zephyr:board directive with the YAML full_name, consistent with the mps4 board documentation.

- mps3_an547 -> "MPS3 FPGA/Corstone FVP"
- mps4 -> "MPS4 Corstone FVP"
