### PR TITLE
scripts: Allow using test config and level with test_plan.py script

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -118,6 +118,8 @@ class Filters:
         detailed_test_id=False,
         quarantine_list=None,
         tc_roots_th=20,
+        test_config=None,
+        level=None,
     ):
         self.modified_files = modified_files
         self.testsuite_root = testsuite_root
@@ -133,6 +135,8 @@ class Filters:
         self.tag_cfg_file = alt_tags
         self.quarantine_list = quarantine_list
         self.tc_roots_th = tc_roots_th
+        self.test_config = test_config
+        self.level = level
 
     def process(self):
         self.find_modules()
@@ -163,6 +167,10 @@ class Filters:
         if self.quarantine_list:
             for q in self.quarantine_list:
                 cmd += ["--quarantine-list", q]
+        if self.test_config:
+            cmd += ["--test-config", self.test_config]
+        if self.level:
+            cmd += ["--level", self.level]
 
         logging.info(" ".join(cmd))
         _ = subprocess.call(cmd)
@@ -509,6 +517,16 @@ def parse_args():
         "corresponding tests .yaml files. These scenarios "
         "will be skipped with quarantine as the reason.",
     )
+    parser.add_argument(
+        '--test-config',
+        default=None,
+        help="Path to file with plans and test configurations.",
+    )
+    parser.add_argument(
+        '--level',
+        default=None,
+        help="Test level to be used.",
+    )
 
     # Do not include paths in names by default.
     parser.set_defaults(detailed_test_id=False)
@@ -545,6 +563,8 @@ if __name__ == "__main__":
         args.detailed_test_id,
         args.quarantine_list,
         args.testcase_roots_threshold,
+        args.test_config,
+        args.level,
     )
     f.process()
 


### PR DESCRIPTION
In Twister, test config and level options are ignored when --load-test is used. To combine these with dynamic scope from test_plan.py, pass them through the script instead.