### PR TITLE
drivers/espi: it8xxx2: Add a config to share h2ram pool space

### DIFF
--- a/drivers/espi/Kconfig.it8xxx2
+++ b/drivers/espi/Kconfig.it8xxx2
@@ -145,4 +145,20 @@ config ESPI_IT8XXX2_PORT_81_CYCLE
 	  This allows EC to accept 2 bytes of port 80 data written from the Host.
 	  (e.g. using iotools: iotools io_write16 0x80 0x1234)
 
+config ESPI_IT8XXX2_H2RAM_SHARED
+	bool "Shared access to h2ram_pool"
+	help
+	  Enabling this option exposes the eSPI driver h2ram_pool as a
+	  global symbol (non-static), allowing other modules to reuse
+	  this memory space.
+	  The configurations CONFIG_ESPI_PERIPHERAL_HOST_CMD_PARAM_PORT_NUM and
+	  CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION_PORT_NUM have a gap in RAM space.
+	  By enabling CONFIG_ESPI_IT8XXX2_H2RAM_SHARED, this unused gap can be
+	  reused by other modules to reduce overall RAM usage.
+
+	  NOTE: A build-time assertion must ensure that the shared region size
+	  does not exceed the available space defined by
+	  CONFIG_ESPI_PERIPHERAL_HOST_CMD_PARAM_PORT_NUM and
+	  CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION_PORT_NUM.
+
 endif #ESPI_IT8XXX2

--- a/drivers/espi/espi_it8xxx2.c
+++ b/drivers/espi/espi_it8xxx2.c
@@ -948,8 +948,14 @@ static const struct ec2i_t pmc2_settings[] = {
 #endif
 #endif
 
-static uint8_t h2ram_pool[MAX(H2RAM_ACPI_SHM_MAX, H2RAM_EC_HOST_CMD_MAX)]
-					__attribute__((section(".h2ram_pool")));
+#ifdef CONFIG_ESPI_IT8XXX2_H2RAM_SHARED
+#define H2RAM_STORAGE
+#else
+#define H2RAM_STORAGE static
+#endif
+
+H2RAM_STORAGE uint8_t h2ram_pool[MAX(H2RAM_ACPI_SHM_MAX, H2RAM_EC_HOST_CMD_MAX)]
+	__attribute__((section(".h2ram_pool")));
 
 #define H2RAM_WINDOW_SIZE(ram_size) ((find_msb_set((ram_size) / 16) - 1) & 0x7)
 


### PR DESCRIPTION
The h2ram is an independent 4KB section. With default settings of CONFIG_ESPI_PERIPHERAL_HOST_CMD_PARAM_PORT_NUM and CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION_PORT_NUM,
There is a 2KB gap that is unused. This change was made to make unused gap can be reused by other modules to reduce overall RAM usage.