### PR TITLE
boards: st: nucleo_h7s3l8 & stm32h7s78_dk: Add runner jlink

### DIFF
--- a/boards/st/nucleo_h7s3l8/board.cmake
+++ b/boards/st/nucleo_h7s3l8/board.cmake
@@ -11,7 +11,10 @@ board_runner_args(pyocd "--target=stm32h7s3l8hx")
 board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
 board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 
+board_runner_args(jlink "--device=STM32H7S3L8" "--speed=4000")
+
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32h7s78_dk/board.cmake
+++ b/boards/st/stm32h7s78_dk/board.cmake
@@ -15,8 +15,11 @@ board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 board_runner_args(stlink_gdbserver "--apid=1")
 board_runner_args(stlink_gdbserver "--extload=MX66UW1G45G_STM32H7S78-DK.stldr")
 
+board_runner_args(jlink "--device=STM32H7S7L8" "--speed=4000")
+
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Adds support for Segger J-Link debug probes connected to MIPI20 connector on the boards nucleo_h7s3l8 and stm32h7s78_dk.

### Testing
Using it every day on nucleo_h7s3l8, but the connector on the stm32h7s78_dk is similar, only different h7rs controller type.
