### PR TITLE
manifest: Update hal_adi revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -144,7 +144,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: eeb155f7382343438114605963ae64436cc53434
+      revision: 4a189d5d2d20267084d9066cd0c4548dd730f809
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Update hal_adi revision to get HAL fix commits. One of the fix commits addresses an issue where the MAX32650 system clock frequency value was not set correctly, which could lead to improper operation of time-dependent functions.