### PR TITLE
doc: migration-guide: release-notes: 4.3: move and extend ethernet

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -159,6 +159,12 @@ Ethernet
   register at run-time, making the devicetree property ``amba-ahb-dbus-width`` obsolete, which
   has therefore been removed.
 
+* The :dtcompatible:`nxp,enet-mac` and :dtcompatible:`xlnx,gem` drivers are no longer configuring
+  the link speed and duplex mode of the phy via  :c:func:`phy_configure_link` during initialization.
+  Instead, the user has to use the ``default-speeds`` devicetree property of the phy, if they want
+  to restrict the advertised speeds for auto-negotiation, when the mac only supports a subset of the
+  phy supported speeds. (:github:`91572`)
+
 MFD
 ===
 

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -136,6 +136,29 @@ DMA
   too broadly defined in access and impossible to implement the syscall parameter verification step
   in another.
 
+Ethernet
+========
+
+* The :dtcompatible:`microchip,vsc8541` PHY driver now expects the reset-gpios entry to specify
+  the GPIO_ACTIVE_LOW flag when the reset is being used as active low. Previously the active-low
+  nature was hard-coded into the driver. (:github:`91726`).
+
+* CRC checksum generation offloading to hardware is now explicitly disabled rather then explicitly
+  enabled in the Xilinx GEM Ethernet driver (:dtcompatible:`xlnx,gem`). By default, offloading is
+  now enabled by default to improve performance, however, offloading is always disabled for QEMU
+  targets due to the checksum generation in hardware not being emulated regardless of whether it
+  is explicitly disabled via the devicetree or not. (:github:`95435`)
+
+    * Replaced devicetree property ``rx-checksum-offload`` which enabled RX checksum offloading
+      ``disable-rx-checksum-offload`` which now actively disables it.
+    * Replaced devicetree property ``tx-checksum-offload`` which enabled TX checksum offloading
+      ``disable-tx-checksum-offload`` which now actively disables it.
+
+* The Xilinx GEM Ethernet driver (:dtcompatible:`xlnx,gem`) now obtains the AMBA AHB data bus
+  width matching the current target SoC (either Zynq-7000 or ZynqMP) from a design configuration
+  register at run-time, making the devicetree property ``amba-ahb-dbus-width`` obsolete, which
+  has therefore been removed.
+
 MFD
 ===
 
@@ -262,29 +285,6 @@ Bluetooth Host
   available when :kconfig:option:`CONFIG_BT_APP_PASSKEY` is enabled. The application can return the
   passkey for pairing, or :c:macro:`BT_PASSKEY_RAND` for the Host to generate a random passkey
   instead.
-
-Ethernet
-========
-
-* The :dtcompatible:`microchip,vsc8541` PHY driver now expects the reset-gpios entry to specify
-  the GPIO_ACTIVE_LOW flag when the reset is being used as active low. Previously the active-low
-  nature was hard-coded into the driver. (:github:`91726`).
-
-* CRC checksum generation offloading to hardware is now explicitly disabled rather then explicitly
-  enabled in the Xilinx GEM Ethernet driver (:dtcompatible:`xlnx,gem`). By default, offloading is
-  now enabled by default to improve performance, however, offloading is always disabled for QEMU
-  targets due to the checksum generation in hardware not being emulated regardless of whether it
-  is explicitly disabled via the devicetree or not. (:github:`95435`)
-
-    * Replaced devicetree property ``rx-checksum-offload`` which enabled RX checksum offloading
-      ``disable-rx-checksum-offload`` which now actively disables it.
-    * Replaced devicetree property ``tx-checksum-offload`` which enabled TX checksum offloading
-      ``disable-tx-checksum-offload`` which now actively disables it.
-
-* The Xilinx GEM Ethernet driver (:dtcompatible:`xlnx,gem`) now obtains the AMBA AHB data bus
-  width matching the current target SoC (either Zynq-7000 or ZynqMP) from a design configuration
-  register at run-time, making the devicetree property ``amba-ahb-dbus-width`` obsolete, which
-  has therefore been removed.
 
 Power management
 ****************

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -227,6 +227,11 @@ New APIs and options
     * :kconfig:option:`CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88`
     * :kconfig:option:`CONFIG_SDL_DISPLAY_COLOR_TINT`
 
+* Ethernet
+
+   * The devicetree property ``default-speeds`` was added to most of the ethernet phys to configure
+     the advertised speeds for auto-negotiation during initialization of the driver.
+
 * Haptics
 
   * :kconfig:option:`CONFIG_HAPTICS_SHELL`


### PR DESCRIPTION
move ethernet to the right place. It was wrongly part of bluetooth

mention changes from #91572

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>