### PR TITLE
drivers: timer: nrf_grtc: Decouple clock source from CLOCK_CONTROL

### DIFF
--- a/drivers/timer/Kconfig.nrf_grtc
+++ b/drivers/timer/Kconfig.nrf_grtc
@@ -56,4 +56,29 @@ config NRF_GRTC_TIMER_AUTO_KEEP_ALIVE
 	  This feature prevents the SYSCOUNTER from sleeping when any core is in
 	  active state.
 
+if NRF_GRTC_START_SYSCOUNTER
+
+choice NRF_GRTC_TIMER_SOURCE
+	prompt "nRF GRTC clock source"
+	# Default to LFLPRC if CLOCK_CONTROL_NRF_K32SRC_RC for backwards compatibility
+	default NRF_GRTC_TIMER_SOURCE_LFLPRC if CLOCK_CONTROL_NRF_K32SRC_RC
+	# Default to LFXO if present as this allows GRTC to run in SYSTEM OFF
+	default NRF_GRTC_TIMER_SOURCE_LFXO
+	# Default to SYSTEM_LFCLK if LFXO is not present
+	default NRF_GRTC_TIMER_SOURCE_SYSTEM_LFCLK
+
+config NRF_GRTC_TIMER_SOURCE_LFXO
+	bool "Use Low Frequency XO as clock source"
+	depends on $(dt_nodelabel_enabled,lfxo)
+
+config NRF_GRTC_TIMER_SOURCE_SYSTEM_LFCLK
+	bool "Use System Low Frequency clock as clock source"
+
+config NRF_GRTC_TIMER_SOURCE_LFLPRC
+	bool "Use Low Frequency Low Power RC as clock source"
+
+endchoice # NRF_GRTC_TIMER_SOURCE
+
+endif # NRF_GRTC_START_SYSCOUNTER
+
 endif # NRF_GRTC_TIMER

--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -477,13 +477,14 @@ static int sys_clock_driver_init(void)
 #endif
 
 #if defined(CONFIG_NRF_GRTC_TIMER_CLOCK_MANAGEMENT) && NRF_GRTC_HAS_CLKSEL
-#if defined(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC)
+#if defined(CONFIG_NRF_GRTC_TIMER_SOURCE_LFLPRC)
 	/* Switch to LFPRC as the low-frequency clock source. */
 	nrfx_grtc_clock_source_set(NRF_GRTC_CLKSEL_LFLPRC);
-#elif DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lfxo))
+#elif defined(CONFIG_NRF_GRTC_TIMER_SOURCE_LFXO)
 	/* Switch to LFXO as the low-frequency clock source. */
 	nrfx_grtc_clock_source_set(NRF_GRTC_CLKSEL_LFXO);
 #else
+	/* Use LFCLK as the low-frequency clock source. */
 	nrfx_grtc_clock_source_set(NRF_GRTC_CLKSEL_LFCLK);
 #endif
 #endif


### PR DESCRIPTION
The GRTC timer, typically used as sys clock on newer nordic chips,
is currently tightly coupled to the CLOCK_CONTROL_NRF drivers though
not being dependent on it. The GRTC and its device driver is
independent from CLOCK_CONTROL, its clock requirements are managed
by hardware, based on its clock source selection.

This commit moves the clock source selection to the GRTC driver, and
removes the hard coupling to the CLOCK_CONTROL drivers. To preserve
backwards compatibility, if CLOCK_CONTROL_NRF_K32SRC_RC is selected,
GRTC will default to LFLPRC.