### PR TITLE
dts: arm: st: n6: fixup adc2 missing properties

### DIFF
--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -467,6 +467,9 @@
 			sampling-times = <2 3 7 12 14 47 247 1500>;
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "extended";
+			st,adc-internal-regulator = "none";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
The added stm32-adc properties in c21cdd856968 ("dts: bindings: adc: stm32: add new properties to simplify the driver") were missing from adc2 within the stm32n6.dtsi.

Since adc1 and adc2 are almost identical, just copy the missing properties from adc1 which was fixed up as part of 5f0c63ea357e ("dts: arm: st: fill out adc nodes with the new properties").

This fixes compilation when using adc2:

```
devicetree error: 'st,adc-internal-regulator' is marked as required in
'properties:' in [...]/zephyr/dts/bindings/adc/st,stm32n6-adc.yaml, but
does not appear in <Node /soc/adc@50022100 in
[...]/zephyr/dts/arm/st/n6/stm32n6.dtsi:456>
```

Fixes #99158