### PR TITLE
drivers: video: stm32-dcmi: correct set_frmival handling

### DIFF
--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -375,9 +375,11 @@ static int video_stm32_dcmi_set_frmival(const struct device *dev, struct video_f
 		.format = &data->fmt,
 	};
 	struct video_frmival best_sensor_frmival;
-	uint64_t best_diff_nsec = INT32_MAX;
-	uint64_t diff_nsec = 0, a, b;
+	uint32_t best_diff_us = INT32_MAX;
+	uint32_t diff_us = 0, a, b;
 	int best_capture_rate = 1;
+
+	a = video_frmival_nsec(frmival) / USEC_PER_MSEC;
 
 	/*
 	 * Try to figure out a frameinterval setting allow to reach as close as
@@ -392,16 +394,15 @@ static int video_stm32_dcmi_set_frmival(const struct device *dev, struct video_f
 		fie.discrete.numerator = frmival->numerator;
 		fie.discrete.denominator = frmival->denominator * capture_rate;
 
-		a = video_frmival_nsec(&fie.discrete);
 		video_closest_frmival(config->sensor_dev, &fie);
-		b = video_frmival_nsec(&fie.discrete);
-		diff_nsec = a > b ? a - b : b - a;
-		if (diff_nsec < best_diff_nsec) {
-			best_diff_nsec = diff_nsec;
+		b = video_frmival_nsec(&fie.discrete) * capture_rate / USEC_PER_MSEC;
+		diff_us = a > b ? a - b : b - a;
+		if (diff_us < best_diff_us) {
+			best_diff_us = diff_us;
 			best_sensor_frmival = fie.discrete;
 			best_capture_rate = capture_rate;
 		}
-		if (diff_nsec == 0) {
+		if (diff_us == 0) {
 			break;
 		}
 	}


### PR DESCRIPTION
Correct set_frmival in order to avoid having un-optimized frmival selection due to rounded values.
Computation has been done in usec, leading to incorrect frmival selection due to value being rounded internally. As an example, code was selecting 1/60 from sensor then 4 time frame drop by DCMI instead of selecting directly 1/15 from sensor.
Use msec instead to hide those rounding issue and avoid as well 64bit variables.
This also put the first video_frmival_nsec outside of the loop to avoid having to do the processing everytime.