### PR TITLE
soc: stm32f7: add power management support

### DIFF
--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -27,6 +27,7 @@
 	chosen {
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash;
+		zephyr,cortex-m-idle-timer = &rtc;
 	};
 
 	cpus {
@@ -37,12 +38,22 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m7";
 			reg = <0>;
+			cpu-power-states = <&stop>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
+			};
+		};
+
+		power-states {
+			stop: stop {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				min-residency-us = <400>;
+				exit-latency-us = <300>;
 			};
 		};
 	};

--- a/soc/st/stm32/stm32f7x/CMakeLists.txt
+++ b/soc/st/stm32/stm32f7x/CMakeLists.txt
@@ -8,3 +8,7 @@ zephyr_sources(
 zephyr_include_directories(.)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
+
+zephyr_sources_ifdef(CONFIG_PM
+  power.c
+  )

--- a/soc/st/stm32/stm32f7x/Kconfig
+++ b/soc/st/stm32/stm32f7x/Kconfig
@@ -14,4 +14,5 @@ config SOC_SERIES_STM32F7X
 	select HAS_STM32_FLASH_PREFETCH
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
+	select HAS_PM
 	select SOC_EARLY_INIT_HOOK

--- a/soc/st/stm32/stm32f7x/power.c
+++ b/soc/st/stm32/stm32f7x/power.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 Ac6
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/pm.h>
+#include <clock_control/clock_stm32_ll_common.h>
+#include <soc.h>
+
+#include <stm32_ll_bus.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+
+LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+void pm_state_set(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+		/* Prepare STOP mode with low-power regulator */
+		LL_LPM_DisableEventOnPend();
+		LL_PWR_ClearFlag_WU1();
+		LL_PWR_ClearFlag_WU2();
+		LL_PWR_ClearFlag_WU3();
+		LL_PWR_ClearFlag_WU4();
+		LL_PWR_ClearFlag_WU5();
+		LL_PWR_ClearFlag_WU6();
+
+		/* Use low-power regulator in STOP to reduce consumption */
+		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP_LPREGU);
+		LL_LPM_EnableDeepSleep();
+
+		__WFI();
+
+		break;
+	default:
+		LOG_DBG("Unsupported power state %u", state);
+		break;
+	}
+}
+
+void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+		/* Back to normal sleep and restore clocks after STOP */
+		LL_LPM_DisableSleepOnExit();
+		LL_LPM_EnableSleep();
+
+		/* Restore the clock setup after STOP mode */
+		stm32_clock_control_init(NULL);
+		break;
+
+	default:
+		LOG_DBG("Unsupported power substate-id %u", state);
+		break;
+	}
+
+	/* System is now active, re-enable interrupts disabled on entry */
+	irq_unlock(0);
+}

--- a/soc/st/stm32/stm32f7x/soc.c
+++ b/soc/st/stm32/stm32f7x/soc.c
@@ -16,6 +16,7 @@
 #include <soc.h>
 
 #include <cmsis_core.h>
+#include <stm32_ll_bus.h>
 #include <stm32_ll_system.h>
 
 /**
@@ -37,4 +38,7 @@ void soc_early_init_hook(void)
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 16 MHz from HSI */
 	SystemCoreClock = 16000000;
+
+	/* Ensure PWR peripheral clock is enabled on APB1 */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 }


### PR DESCRIPTION
Adds low-power mode support for STM32F7 series
Implements basic sleep and stop modes integrated
with the power management subsystem, similar to
the STM32F4 implementation.

Added Mode:
STOP low-power mode, exposed as Zephyr PM state
"suspend-to-idle".

Tested on: NUCLEO-F722ZE board.
Signed-off-by: Roy Jamil <roy.jamil@ac6.fr>