### PR TITLE
manifest: tf-m: include fix for Mbed TLS cipher interface

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -369,7 +369,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: d3341a660f2f33156e1a8bb8ea47ad83066defea
+      revision: 04aa7243e04946b5422b124bea9c0675ab6b120f
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Update manifest to include a fix in Mbed TLS interface header files for cipher module.

Resolves #99153