### PR TITLE
[Backport v4.1-branch] drivers: entropy: Fix non-stop RNG ISR firing for STM32WB09

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -301,9 +301,14 @@ static int recover_seed_error(RNG_TypeDef *rng)
 {
 	ll_rng_clear_seis(rng);
 
+#if !defined(CONFIG_SOC_SERIES_STM32WB0X)
+	/* After a noise source error is detected, 12 words must be read from the RNG_DR register
+	 * and discarded to restart the entropy generation.
+	 */
 	for (int i = 0; i < 12; ++i) {
 		(void)ll_rng_read_rand_data(rng);
 	}
+#endif /* !CONFIG_SOC_SERIES_STM32WB0X */
 
 	if (ll_rng_is_active_seis(rng) != 0) {
 		return -EIO;
@@ -419,7 +424,7 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 		byte = random_byte_get();
 #if !IRQLESS_TRNG
 		NVIC_ClearPendingIRQ(IRQN);
-#endif /* IRQLESS_TRNG */
+#endif /* !IRQLESS_TRNG */
 
 		if (byte < 0) {
 			continue;

--- a/drivers/entropy/entropy_stm32.h
+++ b/drivers/entropy/entropy_stm32.h
@@ -56,6 +56,7 @@ static inline void ll_rng_clear_seis(RNG_TypeDef *RNGx)
 #if defined(CONFIG_SOC_SERIES_STM32WB0X)
 #	if defined(CONFIG_SOC_STM32WB09XX)
 		LL_RNG_SetResetHealthErrorFlags(RNGx, 1);
+		WRITE_REG(RNGx->IRQ_SR, RNG_IRQ_SR_ERROR_IRQ);
 #	else
 		LL_RNG_ClearFlag_FAULT(RNGx);
 #	endif


### PR DESCRIPTION
Backport from https://github.com/zephyrproject-rtos/zephyr/pull/98151 with excluding the third commit as it does not compatible with v4.1.

Modification w.r.t the original PR:
- Replace stm32_reg_write with WRITE_REG.

Fixes #98617 and  https://github.com/zephyrproject-rtos/zephyr/issues/98668 for the backport v4.1