### PR TITLE
display: ensure samples check display api func return value + ltdc read/write rectangle check

### DIFF
--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -181,6 +181,12 @@ static int stm32_ltdc_write(const struct device *dev, const uint16_t x,
 	const uint8_t *src = buf;
 	uint16_t row;
 
+	/* Validate the given parameters */
+	if (x + desc->width > config->width || y + desc->height > config->height) {
+		LOG_ERR("Rectangle does not fit into the display");
+		return -EINVAL;
+	}
+
 	if ((x == 0) && (y == 0) &&
 	    (desc->width == config->width) &&
 	    (desc->height ==  config->height) &&
@@ -248,6 +254,12 @@ static int stm32_ltdc_read(const struct device *dev, const uint16_t x,
 	uint8_t *dst = buf;
 	const uint8_t *src = data->front_buf;
 	uint16_t row;
+
+	/* Validate the given parameters */
+	if (x + desc->width > config->width || y + desc->height > config->height) {
+		LOG_ERR("Rectangle does not fit into the display");
+		return -EINVAL;
+	}
 
 	/* src = pointer to upper left pixel of the rectangle to be read from frame buffer */
 	src += (x * data->current_pixel_size);

--- a/samples/drivers/video/capture_to_lvgl/src/main.c
+++ b/samples/drivers/video/capture_to_lvgl/src/main.c
@@ -160,7 +160,11 @@ int main(void)
 		return 0;
 	}
 
-	display_blanking_off(display_dev);
+	err = display_blanking_off(display_dev);
+	if (err < 0 && err != -ENOSYS) {
+		LOG_ERR("Failed to turn blanking off (error %d)", err);
+		return 0;
+	}
 
 	const lv_img_dsc_t video_img = {
 		.header.w = CONFIG_VIDEO_WIDTH,

--- a/samples/modules/lvgl/accelerometer_chart/src/main.c
+++ b/samples/modules/lvgl/accelerometer_chart/src/main.c
@@ -68,6 +68,7 @@ static void create_accelerometer_chart(lv_obj_t *parent)
 int main(void)
 {
 	const struct device *display_dev;
+	int ret;
 
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {
@@ -86,7 +87,11 @@ int main(void)
 					1000 / CONFIG_SAMPLE_ACCEL_SAMPLING_RATE,
 					NULL);
 	lv_timer_handler();
-	display_blanking_off(display_dev);
+	ret = display_blanking_off(display_dev);
+	if (ret < 0 && ret != -ENOSYS) {
+		LOG_ERR("Failed to turn blanking off (error %d)", ret);
+		return 0;
+	}
 
 	while (1) {
 		uint32_t sleep_ms = lv_timer_handler();

--- a/samples/modules/lvgl/demos/src/main.c
+++ b/samples/modules/lvgl/demos/src/main.c
@@ -23,6 +23,7 @@ int main(void)
 	k_timepoint_t next_scene_switch;
 	lv_demo_render_scene_t cur_scene = LV_DEMO_RENDER_SCENE_FILL;
 #endif /* CONFIG_LV_Z_DEMO_RENDER_SCENE_DYNAMIC */
+	int ret;
 
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {
@@ -61,7 +62,12 @@ int main(void)
 #endif
 	lvgl_unlock();
 
-	display_blanking_off(display_dev);
+	ret = display_blanking_off(display_dev);
+	if (ret < 0 && ret != -ENOSYS) {
+		LOG_ERR("Failed to turn blanking off (error %d)", ret);
+		return 0;
+	}
+
 #ifdef CONFIG_LV_Z_MEM_POOL_SYS_HEAP
 	lvgl_print_heap_info(false);
 #else

--- a/samples/modules/lvgl/multi_display/src/main.c
+++ b/samples/modules/lvgl/multi_display/src/main.c
@@ -76,7 +76,14 @@ int main(void)
 
 	lv_timer_handler();
 	for (int i = 0; i < DT_ZEPHYR_DISPLAYS_COUNT; i++) {
-		display_blanking_off(display_dev[i]);
+		int ret;
+
+		ret = display_blanking_off(display_dev[i]);
+		if (ret < 0 && ret != -ENOSYS) {
+			LOG_ERR("Failed to turn display %s blanking off (error %d)",
+				display_dev[i]->name, ret);
+			return 0;
+		}
 	}
 
 #ifdef CONFIG_LV_Z_MEM_POOL_SYS_HEAP

--- a/samples/modules/lvgl/screen_transparency/src/main.c
+++ b/samples/modules/lvgl/screen_transparency/src/main.c
@@ -46,6 +46,7 @@ static void initialize_gui(void)
 int main(void)
 {
 	const struct device *display_dev;
+	int ret;
 
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {
@@ -56,7 +57,11 @@ int main(void)
 	initialize_gui();
 
 	lv_timer_handler();
-	display_blanking_off(display_dev);
+	ret = display_blanking_off(display_dev);
+	if (ret < 0 && ret != -ENOSYS) {
+		LOG_ERR("Failed to turn blanking off (error %d)", ret);
+		return 0;
+	}
 
 	while (1) {
 		uint32_t sleep_ms = lv_timer_handler();

--- a/samples/subsys/display/lvgl/src/main.c
+++ b/samples/subsys/display/lvgl/src/main.c
@@ -60,6 +60,7 @@ int main(void)
 	const struct device *display_dev;
 	lv_obj_t *hello_world_label;
 	lv_obj_t *count_label;
+	int ret;
 
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {
@@ -142,7 +143,11 @@ int main(void)
 	lv_obj_align(count_label, LV_ALIGN_BOTTOM_MID, 0, 0);
 
 	lv_timer_handler();
-	display_blanking_off(display_dev);
+	ret = display_blanking_off(display_dev);
+	if (ret < 0 && ret != -ENOSYS) {
+		LOG_ERR("Failed to turn blanking off (error %d)", ret);
+		return 0;
+	}
 
 	while (1) {
 		if ((count % 100) == 0U) {

--- a/samples/subsys/input/draw_touch_events/src/main.c
+++ b/samples/subsys/input/draw_touch_events/src/main.c
@@ -63,10 +63,11 @@ static void touch_event_callback(struct input_event *evt, void *user_data)
 }
 INPUT_CALLBACK_DEFINE(touch_dev, touch_event_callback, NULL);
 
-static void clear_screen(void)
+static int clear_screen(void)
 {
 	int x;
 	int y;
+	int ret;
 
 	for (x = 0; x < WIDTH; x += CROSS_DIM) {
 		for (y = 0; y < HEIGHT; y += CROSS_DIM) {
@@ -78,9 +79,15 @@ static void clear_screen(void)
 			ddesc.height = MIN(buf_desc.height, rem_h);
 			ddesc.buf_size = ddesc.width * ddesc.height * BPP;
 
-			display_write(display_dev, x, y, &ddesc, buffer_cross_empty);
+			ret = display_write(display_dev, x, y, &ddesc, buffer_cross_empty);
+			if (ret < 0) {
+				LOG_ERR("Failed to write to display (error %d)", ret);
+				return ret;
+			}
 		}
 	}
+
+	return 0;
 }
 
 static void fill_cross_buffer(void)
@@ -117,6 +124,7 @@ static int get_draw_position(int value, int upper_bound)
 
 int main(void)
 {
+	int ret;
 
 	LOG_INF("Touch sample for touchscreen: %s, dc: %s", touch_dev->name, display_dev->name);
 
@@ -135,9 +143,18 @@ int main(void)
 		return 0;
 	}
 	fill_cross_buffer();
-	display_blanking_off(display_dev);
+	ret = display_blanking_off(display_dev);
+	if (ret < 0 && ret != -ENOSYS) {
+		LOG_ERR("Failed to turn blanking off (error %d)", ret);
+		return 0;
+	}
 
-	clear_screen();
+	ret = clear_screen();
+	if (ret < 0) {
+		LOG_ERR("Failed to clear the screen");
+		return 0;
+	}
+
 	touch_point_drawn.x = CROSS_DIM / 2;
 	touch_point_drawn.y = CROSS_DIM / 2;
 	touch_point.x = -1;
@@ -151,12 +168,21 @@ int main(void)
 		LOG_INF("TOUCH %s X, Y: (%d, %d)", touch_point.pressed ? "PRESS" : "RELEASE",
 			touch_point.x, touch_point.y);
 
-		display_write(display_dev, get_draw_position(touch_point_drawn.x, WIDTH),
-			      get_draw_position(touch_point_drawn.y, HEIGHT), &buf_desc,
-			      buffer_cross_empty);
+		ret = display_write(display_dev, get_draw_position(touch_point_drawn.x, WIDTH),
+				    get_draw_position(touch_point_drawn.y, HEIGHT), &buf_desc,
+				    buffer_cross_empty);
+		if (ret < 0) {
+			LOG_ERR("Failed to write to display (error %d)", ret);
+			return 0;
+		}
 
-		display_write(display_dev, get_draw_position(touch_point.x, WIDTH),
-			      get_draw_position(touch_point.y, HEIGHT), &buf_desc, buffer_cross);
+		ret = display_write(display_dev, get_draw_position(touch_point.x, WIDTH),
+				    get_draw_position(touch_point.y, HEIGHT), &buf_desc,
+				    buffer_cross);
+		if (ret < 0) {
+			LOG_ERR("Failed to write to display (error %d)", ret);
+			return 0;
+		}
 
 		touch_point_drawn.x = touch_point.x;
 		touch_point_drawn.y = touch_point.y;

--- a/samples/subsys/smf/smf_calculator/src/main.c
+++ b/samples/subsys/smf/smf_calculator/src/main.c
@@ -112,6 +112,7 @@ static void lv_btn_matrix_click_callback(lv_event_t *e)
 static int setup_display(void)
 {
 	const struct device *display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
+	int ret;
 
 	if (!device_is_ready(display_dev)) {
 		LOG_ERR("Device not ready, aborting setup");
@@ -165,7 +166,11 @@ static int setup_display(void)
 	update_display("0");
 
 	lv_task_handler();
-	display_blanking_off(display_dev);
+	ret = display_blanking_off(display_dev);
+	if (ret < 0 && ret != -ENOSYS) {
+		LOG_ERR("Failed to turn blanking off (error %d)", ret);
+		return ret;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Following PR #98719, add proper display API function return value checks in all samples in order to fail if an error happen.

Moreover, within the LTDC driver, ensure that the rectangle given (x,y / width-height) properly fit into the framebuffer in order xto avoid OOB access.

Such check is currently done within the LTDC only, however I think that some of those checks should be done within the API functions themself to ensure a first level of proper parameter validity. In order to have proper behavior of all display drivers, some level of framework level checks can be done, removing amount of duplicated code between drivers.
I will prepare a PR for that purpose and propose it.