### PR TITLE
drivers: tmag5273: Add mag gain correction property

### DIFF
--- a/drivers/sensor/ti/tmag5273/tmag5273.c
+++ b/drivers/sensor/ti/tmag5273/tmag5273.c
@@ -58,6 +58,7 @@ struct tmag5273_config {
 	uint8_t temperature_coefficient;
 	uint8_t angle_magnitude_axis;
 	uint8_t ch_mag_gain_correction;
+	uint8_t mag_gain_correction;
 
 	uint8_t operation_mode;
 	uint8_t averaging;
@@ -1075,6 +1076,13 @@ static inline int tmag5273_init_sensor_settings(const struct tmag5273_config *dr
 		return -EIO;
 	}
 
+	retval = i2c_reg_write_byte_dt(&drv_cfg->i2c, TMAG5273_REG_MAG_GAIN_CONFIG,
+				       drv_cfg->mag_gain_correction);
+	if (retval < 0) {
+		LOG_ERR("error setting MAG_GAIN_CONFIG %d", retval);
+		return -EIO;
+	}
+
 	return 0;
 }
 
@@ -1258,6 +1266,7 @@ static DEVICE_API(sensor, tmag5273_driver_api) = {
 			DT_PROP(DT_INST(inst, compat), temperature_coefficient),                   \
 		.angle_magnitude_axis = DT_PROP(DT_INST(inst, compat), angle_magnitude_axis),      \
 		.ch_mag_gain_correction = DT_PROP(DT_INST(inst, compat), ch_mag_gain_correction),  \
+		.mag_gain_correction = DT_PROP(DT_INST(inst, compat), mag_gain_correction),        \
 		.operation_mode = DT_PROP(DT_INST(inst, compat), operation_mode),                  \
 		.averaging = DT_PROP(DT_INST(inst, compat), average_mode),                         \
 		.trigger_conv_via_int =                                                            \

--- a/dts/bindings/sensor/ti,tmag5273.yaml
+++ b/dts/bindings/sensor/ti,tmag5273.yaml
@@ -134,6 +134,18 @@ properties:
 
       Only active if angle-magnitude-calculation is active.
 
+  mag-gain-correction:
+    type: int
+    default: 0
+    description: |
+      Gain value for axis determined by ch-mag-gain-correction.
+
+      The value is between 0 and 255, interpreted as a fractional
+      value between 0 and 1 (mag-gain-correction/256). Gain value of 0
+      is interpreted as 1.
+
+      The default corresponds to the reset value of the register field.
+
   average-mode:
     type: int
     default: 1


### PR DESCRIPTION
Adds `mag-gain-correction` DT property, which sets the mag gain correction value.

It was already possible to select the channel for the gain correction `ch-mag-gain-correction`, but there is no property to choose the correction value itself.