### PR TITLE
drivers: i2c: gpio_i2c_switch: pm nop deprecated

### DIFF
--- a/drivers/i2c/gpio_i2c_switch.c
+++ b/drivers/i2c/gpio_i2c_switch.c
@@ -11,7 +11,7 @@
 #define DT_DRV_COMPAT gpio_i2c_switch
 
 #define GPIO_I2C_TOGGLE_DELAY_US 1
-#define GPIO_I2C_LOCK_TIMEOUT_US   (GPIO_I2C_TOGGLE_DELAY_US * 2 + 100)
+#define GPIO_I2C_LOCK_TIMEOUT_US (GPIO_I2C_TOGGLE_DELAY_US * 2 + 100)
 
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
@@ -91,8 +91,9 @@ static int gpio_i2c_switch_init(const struct device *dev)
 		.gpio = GPIO_DT_SPEC_GET(DT_DRV_INST(inst), gpios),                                \
 	};                                                                                         \
                                                                                                    \
-	I2C_DEVICE_DT_INST_DEFINE(inst, gpio_i2c_switch_init, device_pm_control_nop,               \
-			      &gpio_i2c_switch_dev_data_##inst, &gpio_i2c_switch_dev_cfg_##inst,   \
-			      POST_KERNEL, CONFIG_I2C_INIT_PRIORITY, &gpio_i2c_switch_api_funcs);
+	I2C_DEVICE_DT_INST_DEFINE(inst, gpio_i2c_switch_init, NULL,                                \
+				  &gpio_i2c_switch_dev_data_##inst,                                \
+				  &gpio_i2c_switch_dev_cfg_##inst, POST_KERNEL,                    \
+				  CONFIG_I2C_INIT_PRIORITY, &gpio_i2c_switch_api_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_GPIO_I2C_SWITCH)


### PR DESCRIPTION
The function `device_pm_control_nop` has been deprecated and replacing it with `NULL` is required for compilation.