### PR TITLE
stm32g4 opamp support

### DIFF
--- a/boards/st/nucleo_g474re/nucleo_g474re.yaml
+++ b/boards/st/nucleo_g474re/nucleo_g474re.yaml
@@ -23,4 +23,5 @@ supported:
   - dma
   - can
   - rtc
+  - opamp
 vendor: st

--- a/drivers/opamp/CMakeLists.txt
+++ b/drivers/opamp/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright 2025 NXP
+# Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
@@ -6,4 +7,5 @@ zephyr_library()
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_OPAMP_MCUX_OPAMP opamp_mcux_opamp.c)
 zephyr_library_sources_ifdef(CONFIG_OPAMP_MCUX_OPAMP_FAST opamp_mcux_opamp_fast.c)
+zephyr_library_sources_ifdef(CONFIG_OPAMP_STM32 opamp_stm32_opamp.c)
 # zephyr-keep-sorted-stop

--- a/drivers/opamp/Kconfig
+++ b/drivers/opamp/Kconfig
@@ -21,6 +21,7 @@ config OPAMP_INIT_PRIORITY
 # zephyr-keep-sorted-start
 rsource "Kconfig.mcux_opamp"
 rsource "Kconfig.mcux_opamp_fast"
+rsource "Kconfig.stm32_opamp"
 # zephyr-keep-sorted-stop
 
 endif # OPAMP

--- a/drivers/opamp/Kconfig.stm32_opamp
+++ b/drivers/opamp/Kconfig.stm32_opamp
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config OPAMP_STM32
+	bool "STM32 OPAMP driver"
+	default y
+	select PINCTRL
+	depends on DT_HAS_ST_STM32_OPAMP_ENABLED

--- a/drivers/opamp/opamp_stm32_opamp.c
+++ b/drivers/opamp/opamp_stm32_opamp.c
@@ -1,0 +1,719 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/adc.h>
+#include <zephyr/drivers/opamp.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+
+#include <stm32_ll_opamp.h>
+#include <stm32_ll_system.h>
+
+LOG_MODULE_REGISTER(opamp_stm32, CONFIG_OPAMP_LOG_LEVEL);
+
+#define DT_DRV_COMPAT st_stm32_opamp
+
+/* There is a spell-mistake in original driver - L268, stm32g4xx_ll_opamp.h
+ * use custom definitions for the macros to avoid modifying original driver
+ */
+#define OPAMP_INTERNAL_OUTPUT_DISABLED (0x00000000UL)
+#define OPAMP_INTERNAL_OUTPUT_ENABLED OPAMP_CSR_OPAMPINTEN
+
+#define STM32_OPAMP_TRIM_VAL_MAX 0x1f /* maximum allowed trimming value */
+#define STM32_OPAMP_TRIM_VAL_UNDEFINED 0xff /* undefined trimming value */
+
+/*
+ * Definitions to map Zephyr API input selections to LL driver values
+ * This definition section is needed for simpler DTS bindings match to LL values
+ * Without macros below the macros usage for DTS bindings would be clumsy and unclear
+ */
+#define OPAMP_INM_NONE (UINT32_MAX - 1) /* used to represent states not present in ll */
+/* LL_OPAMP_INPUT_INVERT_CONNECT_NO: only for OPAMP in follower or PGA
+ * with positive gain without bias
+ */
+#define OPAMP_INM_NC LL_OPAMP_INPUT_INVERT_CONNECT_NO
+#define OPAMP_INM_VINM0 LL_OPAMP_INPUT_INVERT_IO0
+#define OPAMP_INM_VINM1 LL_OPAMP_INPUT_INVERT_IO1
+
+#define OPAMP_INM_SEC_NONE (UINT32_MAX - 2) /* used to represent states not present in ll */
+/* only applicable in standalone mode */
+#define OPAMP_INM_SEC_VINM0 LL_OPAMP_INPUT_INVERT_IO0_SEC
+/* only applicable in standalone mode */
+#define OPAMP_INM_SEC_VINM1 LL_OPAMP_INPUT_INVERT_IO1_SEC
+
+#define OPAMP_INP_VINP0 LL_OPAMP_INPUT_NONINVERT_IO0
+#define OPAMP_INP_VINP1 LL_OPAMP_INPUT_NONINVERT_IO1
+#define OPAMP_INP_VINP2 LL_OPAMP_INPUT_NONINVERT_IO2
+#define OPAMP_INP_VINP3 LL_OPAMP_INPUT_NONINVERT_IO3
+#define OPAMP_INP_DAC LL_OPAMP_INPUT_NONINVERT_DAC
+
+#define OPAMP_INP_SEC_NONE (UINT32_MAX - 2) /* used to represent states not present in ll */
+#define OPAMP_INP_SEC_VINP0 LL_OPAMP_INPUT_NONINVERT_IO0_SEC
+#define OPAMP_INP_SEC_VINP1 LL_OPAMP_INPUT_NONINVERT_IO1_SEC
+#define OPAMP_INP_SEC_VINP2 LL_OPAMP_INPUT_NONINVERT_IO2_SEC
+#define OPAMP_INP_SEC_VINP3 LL_OPAMP_INPUT_NONINVERT_IO3_SEC
+#define OPAMP_INP_SEC_DAC LL_OPAMP_INPUT_NONINVERT_DAC_SEC
+
+#define OPAMP_INM_FILTERING_NONE (0)
+#define OPAMP_INM_FILTERING_VINM0 (1)
+#define OPAMP_INM_FILTERING_VINM1 (2)
+
+struct stm32_opamp_config {
+	OPAMP_TypeDef *opamp;
+	struct stm32_pclken *pclken;
+	const struct pinctrl_dev_config *pincfg;
+	const struct adc_dt_spec *adc_ch; /* ADC channel opamp is connected to */
+	const uint32_t inm[2];        /* Primary and secondary entries */
+	const uint32_t inp[2];        /* Primary and secondary entries */
+	uint32_t power_mode;
+	uint32_t inputs_mux_mode;
+	uint32_t inm_filtering;
+	const size_t pclk_len;
+	uint8_t functional_mode;
+	uint8_t pmos_trimming_value;
+	uint8_t nmos_trimming_value;
+	bool lock_enable;
+	bool self_calibration;
+};
+
+struct stm32_opamp_data {
+	struct k_mutex dev_mtx; /* Sync between device accesses */
+};
+
+static void stm32_opamp_config_log_dbg(const struct device *dev)
+{
+	const struct stm32_opamp_config *cfg = dev->config;
+	const char *self_calib_str = cfg->self_calibration ? "true" : "false";
+	const char *lock_enable_str = cfg->lock_enable ? "true" : "false";
+	const struct adc_dt_spec *adc_ch = cfg->adc_ch;
+	const int adc_ch_id = adc_ch != NULL ? adc_ch->channel_id : -1;
+	const struct device *adc_dev = adc_ch != NULL ? adc_ch->dev : NULL;
+	const char *adc_dev_name = adc_dev != NULL ? adc_dev->name : "none";
+
+	LOG_DBG("%s config:\n"
+		"  functional_mode: 0x%x\n"
+		"  power_mode: 0x%x\n"
+		"  inm: {0x%08x,0x%08x}\n"
+		"  inp: {0x%08x,0x%08x}\n"
+		"  adc_ch: %s channel: %d\n"
+		"  lock_enable: %s\n"
+		"  self_calibration: %s\n"
+		"  inputs_mux_mode: 0x%x\n"
+		"  inm_filtering: 0x%x\n"
+		"  pmos_trimming_value: 0x%02x\n"
+		"  nmos_trimming_value: 0x%02x\n"
+		"  OPAMPx_CSR: 0x%08x\n"
+		"  OPAMPx_TCMR: 0x%08x\n",
+		dev->name, cfg->functional_mode, cfg->power_mode,
+		cfg->inm[0], cfg->inm[1], cfg->inp[0], cfg->inp[1],
+		adc_dev_name, adc_ch_id, lock_enable_str,
+		self_calib_str, cfg->inputs_mux_mode, cfg->inm_filtering,
+		(uint32_t)cfg->pmos_trimming_value, (uint32_t)cfg->nmos_trimming_value,
+		(uint32_t)cfg->opamp->CSR, (uint32_t)cfg->opamp->TCMR);
+}
+
+static bool stm32_opamp_is_locked(const struct device *dev)
+{
+	const struct stm32_opamp_config *cfg = dev->config;
+	OPAMP_TypeDef *opamp = cfg->opamp;
+
+	if (cfg->inputs_mux_mode != LL_OPAMP_INPUT_MUX_DISABLE) {
+		return LL_OPAMP_IsLocked(opamp) && LL_OPAMP_IsTimerMuxLocked(opamp);
+	}
+
+	return LL_OPAMP_IsLocked(opamp);
+}
+
+static void stm32_opamp_lock(const struct device *dev)
+{
+	const struct stm32_opamp_config *cfg = dev->config;
+	OPAMP_TypeDef *opamp = cfg->opamp;
+
+	LL_OPAMP_Lock(opamp);
+	if (cfg->inputs_mux_mode != LL_OPAMP_INPUT_MUX_DISABLE) {
+		LL_OPAMP_LockTimerMux(opamp);
+	}
+}
+
+static int stm32_opamp_pm_callback(const struct device *dev, enum pm_device_action action)
+{
+	const struct stm32_opamp_config *cfg = dev->config;
+	OPAMP_TypeDef *opamp = cfg->opamp;
+
+	if (stm32_opamp_is_locked(dev)) {
+		LOG_DBG("%s: locked opamp do not accept action: %d", dev->name, action);
+		return -EPERM;
+	}
+
+	if (action == PM_DEVICE_ACTION_RESUME) {
+		LL_OPAMP_Enable(opamp);
+		if (cfg->lock_enable) {
+			stm32_opamp_lock(dev);
+		}
+	}
+
+	if (action == PM_DEVICE_ACTION_SUSPEND) {
+		LL_OPAMP_Disable(opamp);
+	}
+
+	return 0;
+}
+
+static int stm32_opamp_set_gain(const struct device *dev, enum opamp_gain gain)
+{
+	const struct stm32_opamp_config *cfg = dev->config;
+	struct stm32_opamp_data *data = dev->data;
+	OPAMP_TypeDef *opamp = cfg->opamp;
+	uint32_t ll_gain;
+
+	k_mutex_lock(&data->dev_mtx, K_FOREVER);
+
+	if (stm32_opamp_is_locked(dev)) {
+		LOG_ERR("%s: locked", dev->name);
+		k_mutex_unlock(&data->dev_mtx);
+		return -EPERM;
+	}
+
+	if (cfg->functional_mode == OPAMP_FUNCTIONAL_MODE_FOLLOWER ||
+	    cfg->functional_mode == OPAMP_FUNCTIONAL_MODE_STANDALONE) {
+		/* Avoid writing gain value to registers in standalone or follower mode */
+		LOG_DBG("%s: not supported in %s", dev->name,
+			cfg->functional_mode == OPAMP_FUNCTIONAL_MODE_FOLLOWER ? "follower"
+									       : "standalone");
+		k_mutex_unlock(&data->dev_mtx);
+		return 0;
+	}
+
+	/* In opamp-controller.yaml there are no negative gains present, but
+	 * inverting and non-inverting modes instead. Therefore OPAMP_GAIN_1
+	 * corresponds to -1 gain in inverting mode, and +2 gain in non-inverting mode.
+	 */
+	switch (gain) {
+	case OPAMP_GAIN_1:
+	case OPAMP_GAIN_2:
+		ll_gain = LL_OPAMP_PGA_GAIN_2_OR_MINUS_1;
+		break;
+	case OPAMP_GAIN_3:
+	case OPAMP_GAIN_4:
+		ll_gain = LL_OPAMP_PGA_GAIN_4_OR_MINUS_3;
+		break;
+	case OPAMP_GAIN_7:
+	case OPAMP_GAIN_8:
+		ll_gain = LL_OPAMP_PGA_GAIN_8_OR_MINUS_7;
+		break;
+	case OPAMP_GAIN_15:
+	case OPAMP_GAIN_16:
+		ll_gain = LL_OPAMP_PGA_GAIN_16_OR_MINUS_15;
+		break;
+	case OPAMP_GAIN_31:
+	case OPAMP_GAIN_32:
+		ll_gain = LL_OPAMP_PGA_GAIN_32_OR_MINUS_31;
+		break;
+	case OPAMP_GAIN_63:
+	case OPAMP_GAIN_64:
+		ll_gain = LL_OPAMP_PGA_GAIN_64_OR_MINUS_63;
+		break;
+	default:
+		LOG_ERR("%s: invalid gain %d", dev->name, gain);
+		k_mutex_unlock(&data->dev_mtx);
+		return -EINVAL;
+	}
+
+	LL_OPAMP_SetPGAGain(opamp, ll_gain);
+
+	k_mutex_unlock(&data->dev_mtx);
+	return 0;
+}
+
+static int stm32_opamp_set_functional_mode(const struct device *dev)
+{
+	const struct stm32_opamp_config *cfg = dev->config;
+	OPAMP_TypeDef *opamp = cfg->opamp;
+	uint32_t ll_functional_mode = UINT32_MAX;
+
+	/* NOTE: The register values for each mode are defined in AN5306 document */
+	switch (cfg->functional_mode) {
+	case OPAMP_FUNCTIONAL_MODE_STANDALONE:
+		LOG_DBG("%s: functional_mode: standalone", dev->name);
+		/* Standalone mode: External feedback network defines gain
+		 *	INP user defined (OPAMPx_CSR.VP_SEL - defined by DTS)
+		 *	INM tied to VINM0 (OPAMPx_CSR.VM_SEL = b00)
+		 *	PGA_GAIN = b00000 (reset value)
+		 */
+		/* Standalone mode requires explicit input configuration */
+		LL_OPAMP_SetInputNonInverting(opamp, cfg->inp[0]);
+
+		/* INM tied to VINM0 */
+		LL_OPAMP_SetInputInverting(opamp, LL_OPAMP_INPUT_INVERT_IO0);
+
+		/* Configure secondary inputs if timer-controlled mux is enabled */
+		if (cfg->inputs_mux_mode != LL_OPAMP_INPUT_MUX_DISABLE &&
+		    cfg->inm[1] != OPAMP_INM_SEC_NONE) {
+			LL_OPAMP_SetInputInvertingSecondary(opamp, cfg->inm[1]);
+		}
+		if (cfg->inputs_mux_mode != LL_OPAMP_INPUT_MUX_DISABLE &&
+		    cfg->inp[1] != OPAMP_INP_SEC_NONE) {
+			LL_OPAMP_SetInputNonInvertingSecondary(opamp, cfg->inp[1]);
+		}
+		ll_functional_mode = LL_OPAMP_MODE_STANDALONE;
+		break;
+	case OPAMP_FUNCTIONAL_MODE_FOLLOWER:
+		LOG_DBG("%s: functional_mode: follower", dev->name);
+		/* Follower mode:
+		 *	INP connected to input signal (VP_SEL - defined by DTS)
+		 *	INM internally connected to VOUT (VM_SEL = b11)
+		 *	PGA_GAIN = b00000 (reset value)
+		 */
+
+		/* Follower mode: Only configure non-inverting input INP */
+		LL_OPAMP_SetInputNonInverting(opamp, cfg->inp[0]);
+
+		/*
+		 * INM shall be forced to be not-connected -
+		 * the mode itself will define right connection
+		 */
+		LL_OPAMP_SetInputInverting(opamp, OPAMP_INM_NC);
+
+		/* Configure secondary inputs if timer-controlled mux is enabled */
+		if (cfg->inputs_mux_mode != LL_OPAMP_INPUT_MUX_DISABLE &&
+		    cfg->inp[1] != OPAMP_INP_SEC_NONE) {
+			LL_OPAMP_SetInputNonInvertingSecondary(opamp, cfg->inp[1]);
+		}
+		ll_functional_mode = LL_OPAMP_MODE_FOLLOWER;
+		break;
+	case OPAMP_FUNCTIONAL_MODE_INVERTING:
+		/* INM shall be connected to VINM0 in inverting-mode */
+		if (cfg->inm[0] != OPAMP_INM_VINM0) {
+			LOG_ERR("%s: expected inm to be set to VINM0", dev->name);
+			LOG_DBG("%s: VINM0 (0x%lx) != 0x%x", dev->name, OPAMP_INM_VINM0,
+				cfg->inm[0]);
+			return -EINVAL;
+		}
+		__fallthrough;
+	case OPAMP_FUNCTIONAL_MODE_NON_INVERTING:
+		if (cfg->functional_mode == OPAMP_FUNCTIONAL_MODE_INVERTING) {
+			LOG_DBG("%s: functional_mode: inverting", dev->name);
+		} else {
+			LOG_DBG("%s: functional_mode: non_inverting", dev->name);
+		}
+		/* PGA mode: Gain is set by resistor array feedback
+		 * There are four following sub-modes supported:
+		 * - LL_OPAMP_MODE_PGA:
+		 *	INP is connected to VINMx thus serving as an input signal pin.
+		 *		It will be selected by inp DTS property.
+		 *	VINPx secondary may be selected too to be muxed by timer
+		 *		(see: st,inputs-mux-mode DTS property)
+		 *	INM is connected to resistor array feedback (VM_SEL = b10)
+		 *	INM is NOT connected to any VINMx (e.g. external pins)
+		 *	The OPAMP is in NON-INVERTING MODE with
+		 *	positive gains: +2, +4, +8, +16, +32, +64
+		 *
+		 * - LL_OPAMP_MODE_PGA_IO0:
+		 *	Same as LL_OPAMP_MODE_PGA
+		 *	INM is additionally connected to VINM0 for filtering
+		 *		(see: st,inm-filtering DTS property)
+		 *
+		 * - LL_OPAMP_MODE_PGA_IO0_BIAS:
+		 *	Same as LL_OPAMP_MODE_PGA
+		 *	The INM is connected to VINMx
+		 *		- Input signal on VINMx, bias on VINPx:
+		 *			- negative gains: -1, -3, -7, -15, -31, -63
+		 *		- Bias on VINMx, input signal on VINPx:
+		 *			- positive gains: +2, +4, +8, +16, +32, +64
+		 *
+		 * - LL_OPAMP_MODE_PGA_IO0_IO1_BIAS:
+		 *	Same as LL_OPAMP_MODE_PGA
+		 *	The INM is connected to VINMx
+		 *		- Input signal on VINMx, bias on VINPx:
+		 *			- negative gains: -1, -3, -7, -15, -31, -63
+		 *		- Bias on VINMx, input signal on VINPx:
+		 *			- positive gains: +2, +4, +8, +16, +32, +64
+		 *	VINM1 is connected too for filtering
+		 */
+
+		/* INP is always configured in ALL PGA modes */
+		LL_OPAMP_SetInputNonInverting(opamp, cfg->inp[0]);
+
+		/* Configure secondary inputs if timer-controlled mux is enabled */
+		if (cfg->inputs_mux_mode != LL_OPAMP_INPUT_MUX_DISABLE &&
+		    cfg->inp[1] != OPAMP_INP_SEC_NONE) {
+			LL_OPAMP_SetInputNonInvertingSecondary(opamp, cfg->inp[1]);
+		}
+
+		/* Select PGA general mode - precise later */
+		ll_functional_mode = LL_OPAMP_MODE_PGA;
+		if (cfg->inm_filtering == OPAMP_INM_FILTERING_VINM0) {
+			/* INM filtering requested on VINM0 and
+			 * INM defined by DTS is don't care
+			 */
+			ll_functional_mode = LL_OPAMP_MODE_PGA_IO0;
+		}
+
+		/* Configure INM input if needed */
+		if (cfg->functional_mode == OPAMP_FUNCTIONAL_MODE_INVERTING) {
+			/* INM shall be connected to VINM0, which will be configured
+			 * by PGA mode bits, therefore there is no need to setup INM here
+			 */
+			/* Select PGA mode */
+			ll_functional_mode = LL_OPAMP_MODE_PGA_IO0_BIAS;
+			if (cfg->inm_filtering == OPAMP_INM_FILTERING_VINM1) {
+				/* INM filtering requested on VINM1 */
+				ll_functional_mode = LL_OPAMP_MODE_PGA_IO0_IO1_BIAS;
+			}
+		}
+		break;
+	default:
+		LOG_ERR("%s: invalid functional_mode: %d", dev->name, cfg->functional_mode);
+		return -EINVAL;
+	}
+
+	/* Ensure OPAMP is in functional mode (not calibration mode) */
+	LL_OPAMP_SetMode(opamp, LL_OPAMP_MODE_FUNCTIONAL);
+	LL_OPAMP_SetPGAGain(opamp, 0); /* gain reset value */
+
+	/* Set the functional mode - this configures internal connections */
+	LL_OPAMP_SetFunctionalMode(opamp, ll_functional_mode);
+
+	return 0;
+}
+
+static int stm32_opamp_get_calout(const struct device *dev, struct adc_sequence *adc_seq,
+				  uint32_t *calout)
+{
+	const struct stm32_opamp_config *cfg = dev->config;
+	OPAMP_TypeDef *opamp = cfg->opamp;
+	const struct adc_dt_spec *adc_ch = cfg->adc_ch;
+
+	if (LL_OPAMP_GetInternalOutput(opamp) == OPAMP_INTERNAL_OUTPUT_DISABLED || adc_ch == NULL) {
+		/* Internal output to ADC is disabled - use CALOUT transition check */
+		*calout = LL_OPAMP_IsCalibrationOutputSet(opamp);
+		return 0;
+	}
+
+	if (adc_read_dt(adc_ch, adc_seq) < 0) {
+		LOG_ERR("%s: could not read adc channel #%d", adc_ch->dev->name,
+			adc_ch->channel_id);
+		return -EIO;
+	}
+
+	/*
+	 * A change of CALOUT from 1 to 0 corresponds to the change of ADC output data
+	 * from values close to the maximum ADC output to values close to the minimum
+	 * ADC output (the ADC works as a comparator connected to the OPAMP output).
+	 * source: RM0440 Rev 9 pp. 785/2140
+	 */
+	*calout = (uint32_t)sys_read16((mem_addr_t)adc_seq->buffer);
+	return 0;
+}
+
+static int stm32_opamp_adc_calib_configure(const struct device *dev, struct adc_sequence *adc_seq)
+{
+	const struct stm32_opamp_config *cfg = dev->config;
+	const struct adc_dt_spec *adc_ch = cfg->adc_ch;
+	OPAMP_TypeDef *opamp = cfg->opamp;
+	int ret = 0;
+
+	if (LL_OPAMP_GetInternalOutput(opamp) == OPAMP_INTERNAL_OUTPUT_ENABLED && adc_ch != NULL) {
+		ret = adc_channel_setup_dt(adc_ch);
+		if (ret < 0) {
+			LOG_ERR("%s: could not setup channel #%d", adc_ch->dev->name,
+				adc_ch->channel_id);
+			return ret;
+		}
+
+		ret = adc_sequence_init_dt(adc_ch, adc_seq);
+		if (ret < 0) {
+			LOG_ERR("%s: could not setup adc sequence for channel #%d",
+				adc_ch->dev->name, adc_ch->channel_id);
+			return ret;
+		}
+	}
+	return ret;
+}
+
+/**
+ * @brief Self-calibrate the OPAMP
+ *
+ * @param dev - OPAMP device
+ * @return int - 0 on success, negative error code on failure
+ */
+static int stm32_opamp_self_calibration(const struct device *dev)
+{
+	const struct stm32_opamp_config *cfg = dev->config;
+	OPAMP_TypeDef *opamp = cfg->opamp;
+	int ret = 0;
+
+	uint16_t adc_buf = 0;
+	struct adc_sequence adc_seq = {
+		.buffer = &adc_buf,
+		.buffer_size = sizeof(adc_buf),
+		.calibrate = true,
+	};
+
+	/* Configure ADC for calibration if internal output is enabled */
+	ret = stm32_opamp_adc_calib_configure(dev, &adc_seq);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* User trimming values are used for offset calibration */
+	LL_OPAMP_SetTrimmingMode(opamp, LL_OPAMP_TRIMMING_USER);
+
+	/* Enable calibration mode */
+	LL_OPAMP_SetMode(opamp, LL_OPAMP_MODE_CALIBRATION);
+
+	/* Enable opamp */
+	LL_OPAMP_Enable(opamp);
+
+	const uint32_t trimming_type[] = {
+		LL_OPAMP_TRIMMING_NMOS_VREF_90PC_VDDA, /* 1st calibration - N - 90% Vref */
+		LL_OPAMP_TRIMMING_PMOS_VREF_10PC_VDDA  /* 2nd calibration - P - 10% Vref */
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(trimming_type); i++) {
+		LOG_DBG("%s: calibrating %s", dev->name, i == 0 ? "NMOS" : "PMOS");
+		uint32_t trimming_value = 0;
+		uint32_t trimming_min = 0;
+		uint32_t calout_min = UINT32_MAX;
+		uint32_t calout = 0;
+		uint32_t calout_prev = 0;
+		bool calib_done = false;
+
+		LL_OPAMP_SetCalibrationSelection(opamp, trimming_type[i]);
+		while (trimming_value < STM32_OPAMP_TRIM_VAL_MAX && !calib_done) {
+			ret = stm32_opamp_get_calout(dev, &adc_seq, &calout);
+			if (ret < 0) {
+				break;
+			}
+			LL_OPAMP_SetTrimmingValue(opamp, trimming_type[i], trimming_value);
+			/* Wait for offset trimming max time (tOFFTRIMmax >= 2 ms)
+			 * source: RM0440 Rev 9 pp. 785/2140 for stm32g4
+			 */
+			k_msleep(2);
+			trimming_value++;
+
+			if (LL_OPAMP_GetInternalOutput(opamp) !=
+			    OPAMP_INTERNAL_OUTPUT_DISABLED) {
+				/* ADC based calibration */
+				if (calout < calout_min) {
+					calout_min = calout;
+					trimming_min = trimming_value;
+				}
+			} else {
+				/* CALOUT based calibration: transition from 1 to 0 */
+				if (calout_prev == 0x1 && calout == 0x0) {
+					trimming_min = trimming_value;
+					calib_done = true;
+				}
+			}
+
+			LOG_DBG("trimming_min: 0x%x; trimming_value: 0x%x; "
+				"calout_prev: 0x%x; calout: 0x%x; "
+				"calout_min: 0x%x; adc_buf: 0x%x",
+				trimming_min, trimming_value, calout_prev, calout, calout_min,
+				adc_buf);
+
+			calout_prev = calout;
+		}
+
+		if (ret == 0) {
+			LL_OPAMP_SetTrimmingValue(opamp, trimming_type[i], trimming_min);
+			LOG_DBG("%s: calibration succeed, trimming value: 0x%x", dev->name,
+				trimming_min);
+		} else {
+			LOG_DBG("%s: calibration failed", dev->name);
+			break;
+		}
+	}
+
+	/* Revert register values */
+	LL_OPAMP_SetCalibrationSelection(opamp, 0); /* set to register reset value */
+	LL_OPAMP_SetMode(opamp, LL_OPAMP_MODE_FUNCTIONAL);
+	LL_OPAMP_Disable(opamp);
+
+	return ret;
+}
+
+static int stm32_opamp_init(const struct device *dev)
+{
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct stm32_opamp_config *cfg = dev->config;
+	struct stm32_opamp_data *data = dev->data;
+	const struct adc_dt_spec *adc_ch = cfg->adc_ch;
+	OPAMP_TypeDef *opamp = cfg->opamp;
+	int ret = 0;
+
+	if (!device_is_ready(clk)) {
+		return -ENODEV;
+	}
+
+	if (adc_ch != NULL && adc_ch->dev != NULL && !adc_is_ready_dt(adc_ch)) {
+		LOG_ERR("%s ADC device not ready", adc_ch->dev->name);
+		return -ENODEV;
+	}
+
+	/* Enable OPAMP bus clock */
+	ret = clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]);
+	if (ret != 0) {
+		LOG_ERR("%s clock op failed (%d)", dev->name, ret);
+		return ret;
+	}
+
+	/* Configure OPAMP inputs as specified in Device Tree */
+	ret = pinctrl_apply_state(cfg->pincfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		LOG_ERR("%s pinctrl setup failed (%d)", dev->name, ret);
+		return ret;
+	}
+
+	k_mutex_lock(&data->dev_mtx, K_FOREVER);
+
+	/* Power mode shall be set before calibration - since calibration is mode dependent */
+	LL_OPAMP_SetPowerMode(opamp, cfg->power_mode);
+
+	if (adc_ch != NULL && adc_ch->dev != NULL) {
+		/* Enable internal output to ADC if ADC channel is defined */
+		LL_OPAMP_SetInternalOutput(opamp, OPAMP_INTERNAL_OUTPUT_ENABLED);
+	} else {
+		/* Disable internal output to ADC */
+		LL_OPAMP_SetInternalOutput(opamp, OPAMP_INTERNAL_OUTPUT_DISABLED);
+	}
+
+	if (cfg->self_calibration) {
+		ret = stm32_opamp_self_calibration(dev);
+		if (ret != 0) {
+			k_mutex_unlock(&data->dev_mtx);
+			return ret;
+		}
+	}
+
+	/* Apply trimming values defined explicitly in DTS. OPAMPx_CSR.USERTRIM
+	 * shall be set, before setting trimming values in OPAMPx_CSR.TRIMOFFSETN
+	 * and OPAMPx_CSR.TRIMOFFSETP (RM0440 Rev 9 pp. 788/2140).
+	 */
+	if (cfg->pmos_trimming_value != STM32_OPAMP_TRIM_VAL_UNDEFINED) {
+		LL_OPAMP_SetTrimmingMode(opamp, LL_OPAMP_TRIMMING_USER);
+		LL_OPAMP_SetTrimmingValue(opamp, LL_OPAMP_TRIMMING_PMOS,
+						cfg->pmos_trimming_value);
+	}
+
+	if (cfg->nmos_trimming_value != STM32_OPAMP_TRIM_VAL_UNDEFINED) {
+		LL_OPAMP_SetTrimmingMode(opamp, LL_OPAMP_TRIMMING_USER);
+		LL_OPAMP_SetTrimmingValue(opamp, LL_OPAMP_TRIMMING_NMOS,
+						cfg->nmos_trimming_value);
+	}
+
+	ret = stm32_opamp_set_functional_mode(dev);
+	if (ret != 0) {
+		k_mutex_unlock(&data->dev_mtx);
+		return ret;
+	}
+
+	LL_OPAMP_SetInputsMuxMode(opamp, cfg->inputs_mux_mode);
+
+	/* It is always very useful to show register configuration in debug mode */
+	stm32_opamp_config_log_dbg(dev);
+
+	k_mutex_unlock(&data->dev_mtx);
+	return pm_device_driver_init(dev, stm32_opamp_pm_callback);
+}
+
+#define STM32_OPAMP_DT_POWER_MODE(inst)                                                            \
+	CONCAT(LL_OPAMP_POWERMODE_, DT_INST_STRING_TOKEN(inst, st_power_mode))
+
+#define STM32_OPAMP_DT_INPUTS_MUX_MODE(inst)                                                       \
+	CONCAT(LL_OPAMP_INPUT_MUX_, DT_INST_STRING_TOKEN(inst, st_inputs_mux_mode))
+
+#define STM32_OPAMP_DT_INM_FILTERING(inst)                                                         \
+	CONCAT(OPAMP_INM_FILTERING_, DT_INST_STRING_TOKEN(inst, st_inm_filtering))
+
+#define STM32_OPAMP_DT_INM_PRIMARY(inst)                                                           \
+	CONCAT(OPAMP_INM_, DT_INST_STRING_TOKEN_BY_IDX_OR(inst, inm, 0, NONE))
+
+#define STM32_OPAMP_DT_INM_SECONDARY(inst)                                                         \
+	CONCAT(OPAMP_INM_SEC_, DT_INST_STRING_TOKEN_BY_IDX_OR(inst, inm, 1, NONE))
+
+#define STM32_OPAMP_DT_INP_PRIMARY(inst)                                                           \
+	CONCAT(OPAMP_INP_, DT_INST_STRING_TOKEN_BY_IDX(inst, inp, 0))
+
+#define STM32_OPAMP_DT_INP_SECONDARY(inst)                                                         \
+	CONCAT(OPAMP_INP_SEC_, DT_INST_STRING_TOKEN_BY_IDX_OR(inst, inp, 1, NONE))
+
+#define STM32_OPAMP_TRIMMING_ASSERT_IMPL(inst, value)                                              \
+	BUILD_ASSERT(DT_INST_PROP(inst, value) <= STM32_OPAMP_TRIM_VAL_MAX,                        \
+		     "The value exceeds maximum allowed trimming value STM32_OPAMP_TRIM_VAL_MAX")
+
+/* This assert guarantees a value is always in allowed range at compile time */
+#define STM32_OPAMP_TRIMMING_ASSERT(inst, value)                                                   \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, value),                                            \
+		    (STM32_OPAMP_TRIMMING_ASSERT_IMPL(inst, value)),                               \
+		    (/* empty */))
+
+#define STM32_OPAMP_DT_PMOS_TRIMMING(inst)                                                         \
+	DT_INST_PROP_OR(inst, st_pmos_trimming_value, STM32_OPAMP_TRIM_VAL_UNDEFINED)
+
+#define STM32_OPAMP_DT_NMOS_TRIMMING(inst)                                                         \
+	DT_INST_PROP_OR(inst, st_nmos_trimming_value, STM32_OPAMP_TRIM_VAL_UNDEFINED)
+
+#define _STM32_OPAMP_DT_ADC_CHANNEL_DEFINE_1(inst)                                                 \
+	static const struct adc_dt_spec adc_ch_##inst = ADC_DT_SPEC_INST_GET(inst);
+
+#define _STM32_OPAMP_DT_ADC_CHANNEL_DEFINE_0(inst) /* empty */
+
+#define STM32_OPAMP_DT_ADC_CHANNEL_DEFINE(inst)                                                    \
+	UTIL_CAT(_STM32_OPAMP_DT_ADC_CHANNEL_DEFINE_,                                              \
+		 UTIL_BOOL(DT_INST_NODE_HAS_PROP(inst, io_channels)))(inst)
+
+#define STM32_OPAMP_ADC_CHANNEL_PTR(inst)                                                          \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, io_channels), (&adc_ch_##inst), (NULL))
+
+static DEVICE_API(opamp, opamp_api) = {
+	.set_gain = stm32_opamp_set_gain,
+};
+
+#define STM32_OPAMP_DEVICE(inst)                                                                   \
+	PINCTRL_DT_INST_DEFINE(inst);                                                              \
+                                                                                                   \
+	static struct stm32_pclken stm32_pclken_##inst[] = STM32_DT_INST_CLOCKS(inst);             \
+                                                                                                   \
+	STM32_OPAMP_TRIMMING_ASSERT(inst, st_pmos_trimming_value);                                 \
+	STM32_OPAMP_TRIMMING_ASSERT(inst, st_nmos_trimming_value);                                 \
+                                                                                                   \
+	STM32_OPAMP_DT_ADC_CHANNEL_DEFINE(inst)                                                    \
+                                                                                                   \
+	static const struct stm32_opamp_config stm32_opamp_config_##inst = {                       \
+		.opamp = (OPAMP_TypeDef *)DT_INST_REG_ADDR(inst),                                  \
+		.functional_mode = DT_INST_ENUM_IDX(inst, functional_mode),                        \
+		.power_mode = STM32_OPAMP_DT_POWER_MODE(inst),                                     \
+		.inp = {STM32_OPAMP_DT_INP_PRIMARY(inst), STM32_OPAMP_DT_INP_SECONDARY(inst)},     \
+		.inm = {STM32_OPAMP_DT_INM_PRIMARY(inst), STM32_OPAMP_DT_INM_SECONDARY(inst)},     \
+		.adc_ch = STM32_OPAMP_ADC_CHANNEL_PTR(inst),                                       \
+		.lock_enable = DT_INST_PROP(inst, st_lock_enable),                                 \
+		.self_calibration = DT_INST_PROP(inst, st_enable_self_calibration),                \
+		.inputs_mux_mode = STM32_OPAMP_DT_INPUTS_MUX_MODE(inst),                           \
+		.inm_filtering = STM32_OPAMP_DT_INM_FILTERING(inst),                               \
+		.pmos_trimming_value = STM32_OPAMP_DT_PMOS_TRIMMING(inst),                         \
+		.nmos_trimming_value = STM32_OPAMP_DT_NMOS_TRIMMING(inst),                         \
+		.pclken = stm32_pclken_##inst,                                                     \
+		.pclk_len = DT_INST_NUM_CLOCKS(inst),                                              \
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                    \
+	};                                                                                         \
+                                                                                                   \
+	static struct stm32_opamp_data stm32_opamp_data_##inst = {                                 \
+		.dev_mtx = Z_MUTEX_INITIALIZER(stm32_opamp_data_##inst.dev_mtx),                   \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, stm32_opamp_pm_callback);                                   \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, stm32_opamp_init, PM_DEVICE_DT_INST_GET(inst),                 \
+			      &stm32_opamp_data_##inst, &stm32_opamp_config_##inst, POST_KERNEL,   \
+			      CONFIG_OPAMP_INIT_PRIORITY, &opamp_api);
+
+DT_INST_FOREACH_STATUS_OKAY(STM32_OPAMP_DEVICE)

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -757,6 +757,48 @@
 			status = "disabled";
 		};
 
+		opamp1: opamp1@40010300 {
+			compatible = "st,stm32g4-opamp", "st,stm32-opamp";
+			reg = <0x40010300 0x18>;
+			clocks = <&rcc STM32_CLOCK(APB2, 0)>;
+			clock-names = "opampx";
+			programmable-gain = "OPAMP_GAIN_1", "OPAMP_GAIN_2",
+					    "OPAMP_GAIN_3", "OPAMP_GAIN_4",
+					    "OPAMP_GAIN_7", "OPAMP_GAIN_8",
+					    "OPAMP_GAIN_15", "OPAMP_GAIN_16",
+					    "OPAMP_GAIN_31", "OPAMP_GAIN_32",
+					    "OPAMP_GAIN_63", "OPAMP_GAIN_64";
+			status = "disabled";
+		};
+
+		opamp2: opamp2@40010304 {
+			compatible = "st,stm32g4-opamp", "st,stm32-opamp";
+			reg = <0x40010304 0x18>;
+			clocks = <&rcc STM32_CLOCK(APB2, 0)>;
+			clock-names = "opampx";
+			programmable-gain = "OPAMP_GAIN_1", "OPAMP_GAIN_2",
+					    "OPAMP_GAIN_3", "OPAMP_GAIN_4",
+					    "OPAMP_GAIN_7", "OPAMP_GAIN_8",
+					    "OPAMP_GAIN_15", "OPAMP_GAIN_16",
+					    "OPAMP_GAIN_31", "OPAMP_GAIN_32",
+					    "OPAMP_GAIN_63", "OPAMP_GAIN_64";
+			status = "disabled";
+		};
+
+		opamp3: opamp3@40010308 {
+			compatible = "st,stm32g4-opamp", "st,stm32-opamp";
+			reg = <0x40010308 0x18>;
+			clocks = <&rcc STM32_CLOCK(APB2, 0)>;
+			clock-names = "opampx";
+			programmable-gain = "OPAMP_GAIN_1", "OPAMP_GAIN_2",
+					    "OPAMP_GAIN_3", "OPAMP_GAIN_4",
+					    "OPAMP_GAIN_7", "OPAMP_GAIN_8",
+					    "OPAMP_GAIN_15", "OPAMP_GAIN_16",
+					    "OPAMP_GAIN_31", "OPAMP_GAIN_32",
+					    "OPAMP_GAIN_63", "OPAMP_GAIN_64";
+			status = "disabled";
+		};
+
 		comp1: comparator@40010200 {
 			compatible = "st,stm32g4-comp", "st,stm32-comp";
 			reg = <0x40010200 0x4>;

--- a/dts/bindings/opamp/st,stm32-opamp.yaml
+++ b/dts/bindings/opamp/st,stm32-opamp.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32 OPAMP (Operational Amplifier)
+
+include:
+  - opamp-controller.yaml
+
+compatible: st,stm32-opamp
+
+properties:
+  reg:
+    required: true
+  clocks:
+    required: true
+  clock-names:
+    required: true
+  pinctrl-0:
+    required: true
+  pinctrl-names:
+    required: true

--- a/dts/bindings/opamp/st,stm32g4-opamp.yaml
+++ b/dts/bindings/opamp/st,stm32g4-opamp.yaml
@@ -1,0 +1,258 @@
+# Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+title: STM32G4 OPAMP (Operational Amplifier)
+
+description: |
+  One OPAMP has two inputs and one output. The three I/Os can be connected
+  to the external pins, enabling any type of external interconnection.
+  An OPAMP can be configured internally:
+    - standalone amplifier (external gain setting mode)
+    - follower
+    - non-inverting amplifier with gains ranging from 2 to 64
+    - inverting amplifier with gains ranging from -1 to -63
+
+  The positive input (INP) can be connected to the internal DAC.
+  The output (VOUT) can be connected to the internal ADC.
+
+  Main features:
+    - Rail-to-rail input voltage range
+    - Low input bias current
+    - Low input offset voltage
+    - High frequency gain bandwidth
+    - High-speed mode to achieve a better slew rate
+    - Self calibration support for better offset voltage adjustment
+      of the input NMOS and PMOS transistors
+
+  Minimal DTS examples for OPAMP2:
+
+    - Standalone amplifier (external gain):
+      ```
+      &opamp2 {
+        pinctrl-0 = <&opamp2_vinm_pa5 &opamp2_vinp_pa7 &opamp2_vout_pa6>;
+        pinctrl-names = "default";
+        functional-mode = "standalone";
+        inp = "VINP0";
+        status = "okay";
+      };
+      ```
+      NOTES: Following points regarding standalone mode are to be considered:
+        - inm is tied to VINM0 independently of the value provided in DTS
+
+    - Follower (voltage buffer):
+      ```
+      &opamp2 {
+        pinctrl-0 = <&opamp2_vout_pa6>;
+        pinctrl-names = "default";
+        functional-mode = "follower";
+        inp = "DAC";
+        status = "okay";
+      };
+      ```
+
+    - Non-inverting PGA (gain 2..64):
+      ```
+      &opamp2 {
+        pinctrl-0 = <&opamp2_vinp_pb14 &opamp2_vout_pa6>;
+        pinctrl-names = "default";
+        functional-mode = "non_inverting";
+        inp = "VINP1";
+        status = "okay";
+      };
+      ```
+
+    - Inverting PGA (gain -1..-63):
+      ```
+      &opamp2 {
+        pinctrl-0 = <&opamp2_vinm_pc5 &opamp2_vinp_pb0
+                     &opamp2_vout_pa6>;
+        pinctrl-names = "default";
+        functional-mode = "inverting";
+        inp = "VINP2"; /* shall be routed to external bias voltage */
+        inm = "VINM0"; /* VINM0 is only allowed choice */
+        status = "okay";
+      };
+      ```
+
+  Timer-controlled input MUX (non-inverting PGA):
+    - Switch between VINP0 and VINP3 on TIM1_CH6 trigger.
+    ```
+    &opamp2 {
+      pinctrl-0 = <&opamp2_vinm_pa5 &opamp2_vinm_pc5
+                   &opamp2_vinp_pa7 &opamp2_vout_pa6>;
+      pinctrl-names = "default";
+      functional-mode = "standalone";
+      st,inputs-mux-mode = "TIM1_CH6";
+      inp = "VINP0", "VINP3";
+      status = "okay";
+    };
+    ```
+
+  Usage with an ADC:
+    ```
+    / {
+        zephyr,user {
+          opamp = <&opamp2>;
+        };
+      };
+
+      &adc2 {
+        st,adc-clock-source = "SYNC";
+        st,adc-prescaler = <4>;
+        status = "okay";
+
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        channel@3 {
+          reg = <3>;
+          zephyr,gain = "ADC_GAIN_1";
+          zephyr,reference = "ADC_REF_INTERNAL";
+          zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+          zephyr,resolution = <12>;
+          zephyr,vref-mv = <3300>;
+        };
+      };
+
+      &opamp2 {
+        pinctrl-0 = <&opamp2_vinm_pa5 &opamp2_vinp_pa7>;
+        pinctrl-names = "default";
+        functional-mode = "non_inverting";
+        inm = "VINM0";
+        inp = "VINP0";
+        io-channels = <&adc2 3>;
+        status = "okay";
+      };
+      ```
+    NOTE: ADC can be read from the code with usual ADC API.
+
+  NOTE: It is highly recommended to take a look at RM0440 Rev 9 and AN5306
+        for more details about STM32G4 OPAMP features and usage.
+
+  References:
+    - AN5306:
+      https://www.st.com/resource/en/application_note/an5306-operational-amplifier-opamp-usage-in-stm32g4-series-stmicroelectronics.pdf
+    - RM0440 Rev 9:
+      https://www.st.com/content/ccc/resource/technical/document/reference_manual/group0/7c/b0/25/29/1b/a2/42/b2/DM00355726/files/DM00355726.pdf/jcr:content/translations/en.DM00355726.pdf
+
+include:
+  - st,stm32-opamp.yaml
+
+compatible: st,stm32g4-opamp
+
+properties:
+  st,power-mode:
+    type: string
+    description: |
+      OPAMP power mode has impact on slew-rate:
+        - NORMAL - slew-rate 6.5 V/µs with low power consumption.
+        - HIGHSPEED - slew-rate 45 V/µs with higher power consumption.
+      source: https://www.st.com/resource/en/product_training/STM32G4-Analog-OPAMP_OPAMP.pdf
+    enum:
+      - NORMAL
+      - HIGHSPEED
+    default: NORMAL
+
+  st,lock-enable:
+    type: boolean
+    description: |
+      Lock the OPAMP configuration after it has been configured by the driver.
+      Resetting the lock mode can only be done by a system reset.
+      If not set, the OPAMP configuration will be unlocked by default.
+      The lock property is used to prevent accidental changes to the OPAMP
+      configuration after it has been set.
+      NOTES:
+        - In st,inputs-mux-mode the timer mux register will be locked too
+
+  st,enable-self-calibration:
+    type: boolean
+    description: |
+      Enable self-calibration mode.
+      If not set, the self-calibration mode will be disabled by default.
+      The self-calibration mode is used to calibrate the OPAMP for optimal
+      performance.
+      NOTES:
+        - This step will be executed at OPAMP initialization
+
+  inp:
+    required: true
+    type: string-array
+    description: |
+      Non-Inverting input selection.
+      Please refer to RM0440 Rev 9, Table 204. pp. 777/2140 for more details.
+      NOTES:
+        - Selecting st,inputs-mux-mode expects secondary input entry too
+    enum:
+      - VINP0
+      - VINP1
+      - VINP2
+      - VINP3
+      - DAC
+
+  inm:
+    type: string-array
+    description: |
+      Inverting input selection.
+      Please refer to RM0440 Rev 9, Table 204. pp. 777/2140 for more details.
+      NOTES:
+        - In case st,inputs-mux-mode is selected:
+          * In standalone mode muxed between VINM0 and VINM1 (VM_SEL = '00' or '01')
+          * In inverting/non_inverting (VM_SEL = '10') or follower (VM_SEL = '11') mode
+            muxed between resistor feedback and VOUT.
+            Basically, multiplexing happens between PGA and follower modes.
+            ATTENTION: No VINM0/VINM1 multiplexing happens here!
+        - The values in the array shall be ordered (e.g. VINM0, VINM1)
+    enum:
+      - VINM0
+      - VINM1
+
+  st,inm-filtering:
+    type: string
+    description: |
+      Inverting input filtering selection.
+      Please refer to RM0440 Rev 9 pp. 783-784/2140 for more details.
+      NOTES:
+        - Only applicable in inverting/non_inverting PGA modes
+    enum:
+      - NONE
+      - VINM0
+      - VINM1
+    default: NONE
+
+  st,inputs-mux-mode:
+    type: string
+    description: |
+      Timer controlled multiplexer mode.
+      The selection of the OPAMP inverting and non inverting inputs can be done automatically. In
+      this case, the switch from one input to another is done automatically. This automatic switch
+      is triggered by the TIM1 CC6 or TIM8 CC6 or TIM20 CC6 output arriving on the OPAMP
+      input multiplexers.
+      This is useful for dual motor control with a need to measure the currents on the 3 phases
+      simultaneously on a first motor and then on the second motor.
+      Please refer to RM0440 Rev 9, 25.3.8 Timer controlled Multiplexer mode, pp. 786/2140
+    enum:
+      - DISABLE
+      - TIM1_CH6
+      - TIM8_CH6
+      - TIM20_CH6
+    default: DISABLE
+
+  st,pmos-trimming-value:
+    type: int
+    description: |
+      OPAMP PMOS transistor offset trimming value.
+      The value will be applied directly to TRIMOFFSETP[4:0] (Bits 23:19 in OPAMPx_CST register).
+      If value is present and self-calibration is enabled, this value will overwrite values
+      calculated during self-calibration.
+      Please refer to RM0440 Rev 9, pp. 789/2140 for more details.
+      NOTE: Acceptable range is 0x00 to 0x1f.
+
+  st,nmos-trimming-value:
+    type: int
+    description: |
+      OPAMP NMOS transistor offset trimming value.
+      The value will be applied directly to TRIMOFFSETN[4:0] (Bits 28:24 in OPAMPx_CST register).
+      If value is present and self-calibration is enabled, this value will overwrite values
+      calculated during self-calibration.
+      Please refer to RM0440 Rev 9, pp. 789/2140 for more details.
+      NOTE: Acceptable range is 0x00 to 0x1f.

--- a/samples/drivers/opamp/output_measure/boards/nucleo_g474re_stm32g474xx.overlay
+++ b/samples/drivers/opamp/output_measure/boards/nucleo_g474re_stm32g474xx.overlay
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		opamp = <&opamp2>;
+		adc-read-delay-ms = <100>;
+		io-channels = <&adc2 16>;
+	};
+};
+
+&spi2 {
+	/* Disabled to avoid conflicts with opamp gpio allocation */
+	status = "disabled";
+};
+
+&adc2 {
+	st,adc-clock-source = "SYNC";
+	st,adc-prescaler = <4>;
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@10 {
+		reg = <16>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};
+
+&opamp2 {
+	pinctrl-0 = <&opamp2_vinp_pb14>;
+	pinctrl-names = "default";
+	functional-mode = "follower";
+	inp = "VINP1"; /* PB14 */
+	/* To enable VINM0: add opamp2_vinm_pa5 to pinctrl-0 and disable spi1 */
+	/* st,inm-filtering = "VINM0"; */ /* PA5 */
+	io-channels = <&adc2 16>;
+	st,enable-self-calibration;
+	status = "okay";
+};

--- a/samples/drivers/opamp/output_measure/sample.yaml
+++ b/samples/drivers/opamp/output_measure/sample.yaml
@@ -20,3 +20,4 @@ tests:
       - frdm_mcxa366
       - frdm_mcxn947/mcxn947/cpu0
       - lpcxpresso55s36
+      - nucleo_g474re/stm32g474xx

--- a/tests/drivers/build_all/opamp/boards/nucleo_g474re_stm32g474xx.overlay
+++ b/tests/drivers/build_all/opamp/boards/nucleo_g474re_stm32g474xx.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	pinctrl-0 = <&opamp2_vinp_pa7>;
+	pinctrl-names = "default";
+	functional-mode = "follower";
+	inp = "VINP0";
+	status = "okay";
+};

--- a/tests/drivers/build_all/opamp/testcase.yaml
+++ b/tests/drivers/build_all/opamp/testcase.yaml
@@ -1,4 +1,5 @@
 # Copyright 2025 NXP
+# Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 common:
@@ -16,3 +17,6 @@ tests:
     platform_allow:
       - frdm_mcxa366
       - frdm_mcxa346
+  drivers.build_all.opamp.stm32_opamp:
+    platform_allow:
+      - nucleo_g474re

--- a/tests/drivers/opamp/opamp_api/boards/nucleo_g474re_stm32g474xx.overlay
+++ b/tests/drivers/opamp/opamp_api/boards/nucleo_g474re_stm32g474xx.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		opamp = <&opamp2>;
+	};
+};
+
+/* Disable spi1 to prevent conflict with opmap2 on PA5 pinctrl state */
+&spi1 {
+	status = "disabled";
+};
+
+&opamp2 {
+	pinctrl-0 = <&opamp2_vinm_pa5 &opamp2_vinp_pb0>;
+	pinctrl-names = "default";
+	functional-mode = "follower";
+	inm = "VINM0";
+	inp = "VINP2";
+	st,enable-self-calibration;
+	status = "okay";
+};

--- a/tests/drivers/opamp/opamp_api/testcase.yaml
+++ b/tests/drivers/opamp/opamp_api/testcase.yaml
@@ -9,3 +9,7 @@ tests:
   drivers.opamp.api.nxp:
     depends_on: opamp
     filter: dt_compat_enabled("nxp,opamp") or dt_compat_enabled("nxp,opamp-fast")
+
+  drivers.opamp.api.stm32:
+    depends_on: opamp
+    filter: dt_compat_enabled("st,stm32-opamp")

--- a/tests/drivers/opamp/opamp_stm32/CMakeLists.txt
+++ b/tests/drivers/opamp/opamp_stm32/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(opamp_stm32)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/opamp/opamp_stm32/boards/nucleo_g474re_stm32g474xx.overlay
+++ b/tests/drivers/opamp/opamp_stm32/boards/nucleo_g474re_stm32g474xx.overlay
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		opamp = <&opamp2>;
+	};
+};
+
+&spi1 {
+	/* Disabled to avoid conflicts with opamp gpio allocation */
+	status = "disabled";
+};
+
+&spi2 {
+	/* Disabled to avoid conflicts with opamp gpio allocation */
+	status = "disabled";
+};
+
+&usart1 {
+	/* Disabled to avoid conflicts with opamp gpio allocation */
+	status = "disabled";
+};
+
+&adc2 {
+	st,adc-clock-source = "SYNC";
+	st,adc-prescaler = <4>;
+	status = "disabled";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@10 { /* channel number in hex */
+		reg = <16>; /* channel number in decimal */
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};
+
+&opamp2 {
+	/* For sake of simplicity all the pins of OPAMP2 will be configured in analog
+	 * mode, which allows free choice of pins across the tests
+	 */
+	pinctrl-0 = <&opamp2_vinm_pa5 &opamp2_vinm_pc5
+		     &opamp2_vinp_pa7 &opamp2_vinp_pb14 &opamp2_vinp_pb0
+		     &opamp2_vout_pa6>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/tests/drivers/opamp/opamp_stm32/config/adc.conf
+++ b/tests/drivers/opamp/opamp_stm32/config/adc.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ADC=y

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_adc_output.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_adc_output.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&adc2 {
+	status = "okay";
+};
+
+&opamp2 {
+	io-channels = <&adc2 16>;
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_filtering_vinm0.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_filtering_vinm0.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	st,inm-filtering = "VINM0";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_filtering_vinm1.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_filtering_vinm1.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	st,inm-filtering = "VINM1";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_functional_mode_differential.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_functional_mode_differential.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	functional-mode = "differential";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_functional_mode_follower.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_functional_mode_follower.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	functional-mode = "follower";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_functional_mode_inverting.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_functional_mode_inverting.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	functional-mode = "inverting";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_functional_mode_non_inverting.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_functional_mode_non_inverting.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	functional-mode = "non_inverting";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_functional_mode_standalone.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_functional_mode_standalone.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	functional-mode = "standalone";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_inm_double.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_inm_double.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	inm = "VINM0", "VINM1";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_inm_single.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_inm_single.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	inm = "VINM1";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_inm_single_vinm0.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_inm_single_vinm0.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	inm = "VINM0";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_inm_single_vinm1.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_inm_single_vinm1.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	inm = "VINM1";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_inp_double.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_inp_double.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	inp = "VINP0", "VINP1";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_inp_single.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_inp_single.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	inp = "VINP2";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_inp_single_vinp0.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_inp_single_vinp0.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	inp = "VINP0";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_inp_single_vinp1.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_inp_single_vinp1.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	inp = "VINP1";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_lock_enable.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_lock_enable.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	st,lock-enable;
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_power_mode_highspeed.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_power_mode_highspeed.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	st,power-mode = "HIGHSPEED";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_self_calibration.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_self_calibration.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	st,enable-self-calibration;
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_timer_mux.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_timer_mux.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	st,inputs-mux-mode = "TIM1_CH6";
+};

--- a/tests/drivers/opamp/opamp_stm32/dts/opamp2_user_trimming.overlay
+++ b/tests/drivers/opamp/opamp_stm32/dts/opamp2_user_trimming.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp2 {
+	st,pmos-trimming-value = <0x11>;
+	st,nmos-trimming-value = <0x07>;
+};

--- a/tests/drivers/opamp/opamp_stm32/prj.conf
+++ b/tests/drivers/opamp/opamp_stm32/prj.conf
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_OPAMP=y
+CONFIG_ZTEST=y
+
+CONFIG_LOG=y
+CONFIG_LOG_MODE_DEFERRED=y
+CONFIG_LOG_BUFFER_SIZE=4096

--- a/tests/drivers/opamp/opamp_stm32/src/main.c
+++ b/tests/drivers/opamp/opamp_stm32/src/main.c
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/opamp.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#include <stm32_ll_opamp.h>
+
+/* There is a spell-mistake in original driver - L268, stm32g4xx_ll_opamp.h
+ * use custom definitions for the macros to avoid modifying original driver
+ */
+#define OPAMP_INTERNAL_OUTPUT_DISABLED (0x00000000UL)
+#define OPAMP_INTERNAL_OUTPUT_ENABLED  OPAMP_CSR_OPAMPINTEN
+
+#define OPAMP_NODE   DT_PHANDLE(DT_PATH(zephyr_user), opamp)
+#define OPAMP_LL_DEV ((OPAMP_TypeDef *)DT_REG_ADDR(OPAMP_NODE))
+
+#define OPAMP_SUPPORT_PROGRAMMABLE_GAIN DT_NODE_HAS_PROP(OPAMP_NODE, programmable_gain)
+
+#define OPAMP_INM_FILTERING_NONE  (0)
+#define OPAMP_INM_FILTERING_VINM0 (1)
+#define OPAMP_INM_FILTERING_VINM1 (2)
+
+#define OPAMP_FILTERING_INPUT                                                                      \
+	CONCAT(OPAMP_INM_FILTERING_, DT_STRING_TOKEN(OPAMP_NODE, st_inm_filtering))
+#if OPAMP_FILTERING_INPUT
+#define OPAMP_FILTERING_INPUT_PRESENT 1
+#else
+#define OPAMP_FILTERING_INPUT_PRESENT 0
+#endif
+
+#if OPAMP_SUPPORT_PROGRAMMABLE_GAIN
+static const enum opamp_gain programmable_gain[] = {
+	DT_FOREACH_PROP_ELEM_SEP(OPAMP_NODE, programmable_gain,
+				 DT_ENUM_IDX_BY_IDX, (,)) };
+#endif
+
+#define STM32_OPAMP_TRIM_VAL_MAX       0x1f /* maximum allowed trimming value */
+#define STM32_OPAMP_TRIM_VAL_UNDEFINED 0xff /* undefined trimming value */
+
+#define IS_OPAMP_TRIM_IN_RANGE(trim_val) ((trim_val) <= STM32_OPAMP_TRIM_VAL_MAX)
+
+const struct device *get_opamp_device(void)
+{
+	return DEVICE_DT_GET(OPAMP_NODE);
+}
+
+static const struct device *init_opamp(void)
+{
+	const struct device *const opamp_dev = DEVICE_DT_GET(OPAMP_NODE);
+	const uint32_t dts_functional_mode = DT_ENUM_IDX(OPAMP_NODE, functional_mode);
+
+	bool ret = device_is_ready(opamp_dev);
+
+	if (dts_functional_mode != OPAMP_FUNCTIONAL_MODE_DIFFERENTIAL) {
+		/* The device shall be ready for all modes except differential,
+		 * which will be handled below during mode testing.
+		 */
+		zassert_true(ret, "OPAMP device %s shall be ready", opamp_dev->name);
+
+		/* Verify OPAMP is enabled */
+		zassert_true(LL_OPAMP_IsEnabled(OPAMP_LL_DEV) == 1,
+			     "OPAMP device %s shall be enabled (e.g. OPAEN bit is set)",
+			     opamp_dev->name);
+	}
+
+	/* Verify clock is enabled: RCC_APB2ENR SYSCFGEN bit 0 shall be set */
+	zassert_equal(IS_BIT_SET(RCC->APB2ENR, 0), 1,
+		      "RCC_APB2ENR SYSCFGEN bit 0 shall be set (RCC->APB2ENR = 0x%x)",
+		      RCC->APB2ENR);
+
+	return opamp_dev;
+}
+
+ZTEST(opamp_stm32, test_init_opamp)
+{
+	const struct device *opamp_dev = init_opamp();
+	const uint32_t dts_functional_mode = DT_ENUM_IDX(OPAMP_NODE, functional_mode);
+
+	/* inp shall be ALWAYS defined in DTS */
+	const uint32_t inp = LL_OPAMP_GetInputNonInverting(OPAMP_LL_DEV);
+
+	zassert_true(inp == LL_OPAMP_INPUT_NONINVERT_IO0 || inp == LL_OPAMP_INPUT_NONINVERT_IO1 ||
+			     inp == LL_OPAMP_INPUT_NONINVERT_IO2 ||
+			     inp == LL_OPAMP_INPUT_NONINVERT_IO3 ||
+			     inp == LL_OPAMP_INPUT_NONINVERT_DAC,
+		     "%s: OPAMP shall have at least one inp defined", opamp_dev->name);
+
+	/* Secondary inp may be defined in DTS */
+#if DT_NODE_HAS_PROP(OPAMP_NODE, st_inputs_mux_mode)
+	/* INP secondary could be any value defined in DTS */
+	const uint32_t inp_sec = LL_OPAMP_GetInputNonInvertingSecondary(OPAMP_LL_DEV);
+
+	zassert_true(inp_sec == LL_OPAMP_INPUT_NONINVERT_IO0_SEC ||
+			     inp_sec == LL_OPAMP_INPUT_NONINVERT_IO1_SEC ||
+			     inp_sec == LL_OPAMP_INPUT_NONINVERT_IO2_SEC ||
+			     inp_sec == LL_OPAMP_INPUT_NONINVERT_IO3_SEC ||
+			     inp_sec == LL_OPAMP_INPUT_NONINVERT_DAC_SEC,
+		     "%s: OPAMP shall have at least one inp secondary defined", opamp_dev->name);
+#endif /* st_inputs_mux_mode */
+
+	/* Verify registers have expected values for functional mode set.
+	 * Functional_mode is a required property, therefore no need to check
+	 * it is present on preprocessor level.
+	 */
+	const uint32_t functional_mode = LL_OPAMP_GetFunctionalMode(OPAMP_LL_DEV);
+	const uint32_t inm = LL_OPAMP_GetInputInverting(OPAMP_LL_DEV);
+	const uint32_t inm_sec = LL_OPAMP_GetInputInvertingSecondary(OPAMP_LL_DEV);
+
+	switch (dts_functional_mode) {
+	case OPAMP_FUNCTIONAL_MODE_FOLLOWER:
+		zassert_equal(functional_mode, LL_OPAMP_MODE_FOLLOWER,
+			      "%s: OPAMP shall be in follower mode", opamp_dev->name);
+
+		/* INM shall stay not-connected in follower mode */
+		zassert_equal(inm, LL_OPAMP_INPUT_INVERT_CONNECT_NO,
+			      "%s: OPAMP shall have INM disconnected "
+			      "(LL_OPAMP_INPUT_INVERT_CONNECT_NO = 0x%x), but it is 0x%x",
+			      opamp_dev->name, (uint32_t)LL_OPAMP_INPUT_INVERT_CONNECT_NO, inm);
+		break;
+	case OPAMP_FUNCTIONAL_MODE_STANDALONE:
+		zassert_equal(functional_mode, LL_OPAMP_MODE_STANDALONE,
+			      "%s: OPAMP shall be in standalone mode", opamp_dev->name);
+
+		/* INM shall be tied to VINM0 in standalone mode */
+		zassert_equal(inm, LL_OPAMP_INPUT_INVERT_IO0,
+			      "%s: inm shall be VINM0 (0x%x), but it is 0x%x", opamp_dev->name,
+			      (uint32_t)LL_OPAMP_INPUT_INVERT_IO0, inm);
+
+#if DT_NODE_HAS_PROP(OPAMP_NODE, st_inputs_mux_mode)
+		/* INM secondary shall be either VINM0 or VINM1 */
+		zassert_true(inm_sec == LL_OPAMP_INPUT_INVERT_IO0_SEC ||
+				     inm_sec == LL_OPAMP_INPUT_INVERT_IO1_SEC,
+			     "%s: inm secondary shall be VINM0 (0x%x) or VINM1 (0x%x), "
+			     "but it is 0x%x",
+			     opamp_dev->name, (uint32_t)LL_OPAMP_INPUT_INVERT_IO0_SEC,
+			     (uint32_t)LL_OPAMP_INPUT_INVERT_IO1_SEC, inm_sec);
+#endif /* st_inputs_mux_mode */
+
+		break;
+	case OPAMP_FUNCTIONAL_MODE_INVERTING:
+#if OPAMP_FILTERING_INPUT_PRESENT
+		zassert_equal(functional_mode, LL_OPAMP_MODE_PGA_IO0_IO1_BIAS,
+			      "%s: OPAMP shall be in LL_OPAMP_MODE_PGA_IO0_IO1_BIAS",
+			      opamp_dev->name);
+#else  /* OPAMP_FILTERING_INPUT_PRESENT */
+		zassert_equal(functional_mode, LL_OPAMP_MODE_PGA_IO0_BIAS,
+			      "%s: OPAMP shall be in LL_OPAMP_MODE_PGA_IO0_BIAS", opamp_dev->name);
+#endif /* OPAMP_FILTERING_INPUT_PRESENT */
+
+		/* VM_SEL = b10 in all PGA modes (OPAMPx_CSR register bits 6 to 5) */
+		zassert_true(IS_BIT_SET(OPAMP_LL_DEV->CSR, 6),
+			     "%s: OPAMP CSR VM_SEL (bit 6) shall be SET in "
+			     "inverting mode",
+			     opamp_dev->name);
+		zassert_false(IS_BIT_SET(OPAMP_LL_DEV->CSR, 5),
+			      "%s: OPAMP CSR VM_SEL (bit 5) shall be RESET in "
+			      "inverting mode",
+			      opamp_dev->name);
+
+#if DT_NODE_HAS_PROP(OPAMP_NODE, st_inputs_mux_mode)
+		/* The inverting mode is a sub-mode of PGA mode.
+		 * In this case VMS_SEL is defined by OPAMPx_TCMR register bit 0.
+		 * The value of VMS_SEL in OPAMPx_TCMR is therefore don't care here.
+		 *
+		 * From RM0440 Rev 9 pp. 809/2140:
+		 * When PGA (VM_SEL = “10”) or Follower mode (VM_SEL = “11”) is used:
+		 *	0: Resistor feedback output selected (PGA mode)
+		 *	1: VOUT selected as input minus (follower mode)
+		 */
+#endif /* st_inputs_mux_mode */
+		break;
+	case OPAMP_FUNCTIONAL_MODE_NON_INVERTING:
+#if OPAMP_FILTERING_INPUT_PRESENT
+		zassert_equal(functional_mode, LL_OPAMP_MODE_PGA_IO0,
+			      "%s: OPAMP shall be in LL_OPAMP_MODE_PGA_IO0", opamp_dev->name);
+#else /* OPAMP_FILTERING_INPUT_PRESENT */
+		zassert_equal(functional_mode, LL_OPAMP_MODE_PGA,
+			      "%s: OPAMP shall be in LL_OPAMP_MODE_PGA", opamp_dev->name);
+
+#endif /* OPAMP_FILTERING_INPUT_PRESENT */
+
+		/* VM_SEL = b10 in all PGA modes (OPAMPx_CSR register bits 6 to 5) */
+		zassert_true(IS_BIT_SET(OPAMP_LL_DEV->CSR, 6),
+			     "%s: OPAMP CSR VM_SEL (bit 6) shall be SET in "
+			     "inverting mode",
+			     opamp_dev->name);
+		zassert_false(IS_BIT_SET(OPAMP_LL_DEV->CSR, 5),
+			      "%s: OPAMP CSR VM_SEL (bit 5) shall be RESET in "
+			      "inverting mode",
+			      opamp_dev->name);
+		break;
+	case OPAMP_FUNCTIONAL_MODE_DIFFERENTIAL:
+		/* differential mode is not supported directly - device shall not be ready */
+		/* The device shall not be ready in differential mode */
+		zassert_false(device_is_ready(opamp_dev),
+			      "OPAMP device %s shall be NOT ready in differential mode",
+			      opamp_dev->name);
+		break;
+	default:
+		zassert_unreachable("Unsupported functional mode %d", dts_functional_mode);
+		break;
+	};
+
+	/* Gain shall have register reset value (0x0) after init */
+	const uint32_t gain = LL_OPAMP_GetPGAGain(OPAMP_LL_DEV);
+
+	zassert_equal(gain, 0x0,
+		      "%s: OPAMP gain shall be reset to 0x0 after init, "
+		      "but it is 0x%x",
+		      opamp_dev->name, gain);
+
+	/* Power mode: Allowed to be NORMAL or HIGHSPEED */
+	const uint32_t dts_power_mode = DT_ENUM_IDX(OPAMP_NODE, st_power_mode);
+	const uint32_t power_mode = LL_OPAMP_GetPowerMode(OPAMP_LL_DEV);
+
+	if (dts_power_mode == 0) {
+		/* Power mode: NORMAL (enum value 0) */
+		zassert_true(power_mode == LL_OPAMP_POWERMODE_NORMALSPEED,
+			     "%s: OPAMP power mode shall match DTS setting 0x%x != 0x%x",
+			     opamp_dev->name, (uint32_t)power_mode,
+			     (uint32_t)LL_OPAMP_POWERMODE_NORMALSPEED);
+	} else {
+		/* Power mode: HIGHSPEED (enum value 1) */
+		zassert_true(power_mode == LL_OPAMP_POWERMODE_HIGHSPEED,
+			     "%s: OPAMP power mode shall match DTS setting 0x%x != 0x%x",
+			     opamp_dev->name, (uint32_t)power_mode,
+			     (uint32_t)LL_OPAMP_POWERMODE_HIGHSPEED);
+	}
+
+#if DT_PROP(OPAMP_NODE, st_lock_enable)
+	/* Verify that OPAMP is locked when lock-enable is set in DTS */
+	zassert_true(LL_OPAMP_IsLocked(OPAMP_LL_DEV) == 1,
+		     "%s: OPAMP shall be locked when lock-enable is set in DTS", opamp_dev->name);
+	if (LL_OPAMP_GetInputsMuxMode(OPAMP_LL_DEV) != LL_OPAMP_INPUT_MUX_DISABLE) {
+		/* Same DTS lock property locks timer mux if enabled */
+		zassert_true(LL_OPAMP_IsTimerMuxLocked(OPAMP_LL_DEV) == 1,
+			     "%s: OPAMP timer MUX shall be locked when lock-enable is set in DTS",
+			     opamp_dev->name);
+	}
+#endif /* lock-enable */
+
+	zassert_equal(LL_OPAMP_GetMode(OPAMP_LL_DEV), LL_OPAMP_MODE_FUNCTIONAL,
+		      "%s: OPAMP shall be in functional mode after init", opamp_dev->name);
+
+	/* The function LL_OPAMP_GetCalibrationSelection() is buggy
+	 * at least for stm32g4 and returns the wrong value after initialization,
+	 * therefore read it manually. CALSEL bits are 13:12
+	 */
+	const uint32_t calsel_val = OPAMP_LL_DEV->CSR & (BIT(13) | BIT(12));
+
+	zassert_equal(calsel_val, 0,
+		      "%s: OPAMP's CALSEL (calibration selection) shall be in "
+		      "reset state (0) after init, but it is 0x%x",
+		      opamp_dev->name, calsel_val);
+
+#if DT_NODE_HAS_PROP(OPAMP_NODE, io_channels)
+	/* io-channels is present - the OPAMP shall be connected to ADC */
+	zassert_equal(LL_OPAMP_GetInternalOutput(OPAMP_LL_DEV), OPAMP_INTERNAL_OUTPUT_ENABLED,
+		      "%s: OPAMP expected to be connected to ADC", opamp_dev->name);
+#endif /* io_channels */
+
+	const uint32_t trim_mode = LL_OPAMP_GetTrimmingMode(OPAMP_LL_DEV);
+#if DT_PROP(OPAMP_NODE, st_enable_self_calibration)
+	/* Calibration is running at driver initalization step (POST_KERNEL).
+	 * Verify that OPAMP is configured to be user calibrated
+	 */
+	zassert_equal(trim_mode, LL_OPAMP_TRIMMING_USER,
+		      "%s: OPAMP shall have user trimming mode after self-calibration",
+		      opamp_dev->name);
+
+#else /* st_enable_self_calibration */
+	/* Calibration is not used */
+#if DT_NODE_HAS_PROP(OPAMP_NODE, st_pmos_trimming_value) ||                                        \
+	DT_NODE_HAS_PROP(OPAMP_NODE, st_nmos_trimming_value)
+#if DT_NODE_HAS_PROP(OPAMP_NODE, st_pmos_trimming_value)
+	/* PMOS trim value is provided - verify user trimming mode is enabled */
+	const uint8_t dts_pmos_trimming = DT_PROP(OPAMP_NODE, st_pmos_trimming_value);
+	const uint8_t pmos_trimming =
+		LL_OPAMP_GetTrimmingValue(OPAMP_LL_DEV, LL_OPAMP_TRIMMING_PMOS);
+
+	if (IS_OPAMP_TRIM_IN_RANGE(dts_pmos_trimming)) {
+		/* Verify if user-trimming is enabled */
+		zassert_equal(trim_mode, LL_OPAMP_TRIMMING_USER,
+			      "%s: OPAMP shall have user trimming mode when trimming "
+			      "values are set in DTS",
+			      opamp_dev->name);
+		/* Verify PMOS trimming value match DTS defined one */
+		zassert_equal(pmos_trimming, dts_pmos_trimming,
+			      "%s: OPAMP PMOS trimming value shall match "
+			      "DTS setting: 0x%x != 0x%x",
+			      opamp_dev->name, pmos_trimming, dts_pmos_trimming);
+	}
+#endif /* st_pmos_trimming_value */
+#if DT_NODE_HAS_PROP(OPAMP_NODE, st_nmos_trimming_value)
+	/* NMOS trim value is provided - verify user trimming mode is enabled */
+	const uint8_t dts_nmos_trimming = DT_PROP(OPAMP_NODE, st_nmos_trimming_value);
+	const uint8_t nmos_trimming =
+		LL_OPAMP_GetTrimmingValue(OPAMP_LL_DEV, LL_OPAMP_TRIMMING_NMOS);
+
+	if (IS_OPAMP_TRIM_IN_RANGE(dts_nmos_trimming)) {
+		/* Verify if user-trimming is enabled */
+		zassert_equal(trim_mode, LL_OPAMP_TRIMMING_USER,
+			      "%s: OPAMP shall have user trimming mode when trimming "
+			      "values are set in DTS",
+			      opamp_dev->name);
+		/* Verify NMOS trimming value match DTS defined one */
+		zassert_equal(nmos_trimming, dts_nmos_trimming,
+			      "%s: OPAMP NMOS trimming value shall match "
+			      "DTS setting: 0x%x != 0x%x",
+			      opamp_dev->name, nmos_trimming, dts_nmos_trimming);
+	}
+#endif /* st_nmos_trimming_value */
+#else  /* st_pmos_trimming_value || st_nmos_trimming_value */
+	/* No trimming values provided and calibration is disabled.
+	 * Factory trimming mode shall be used
+	 */
+	zassert_equal(trim_mode, LL_OPAMP_TRIMMING_FACTORY,
+		      "%s: OPAMP shall have factory trimming mode", opamp_dev->name);
+#endif /* st_pmos_trimming_value || st_nmos_trimming_value */
+#endif /* st_enable_self_calibration */
+}
+
+#if OPAMP_SUPPORT_PROGRAMMABLE_GAIN
+/* Test OPAMP opamp_set_gain API, Only OPAMPs
+ * that support PGA need to test this API.
+ */
+ZTEST(opamp_stm32, test_gain_set)
+{
+	int ret;
+
+	const uint32_t dts_functional_mode = DT_ENUM_IDX(OPAMP_NODE, functional_mode);
+	const struct device *opamp_dev = init_opamp();
+
+	if (dts_functional_mode == OPAMP_FUNCTIONAL_MODE_DIFFERENTIAL) {
+		/* differential mode is not supported directly - the test is done in
+		 * init_opamp() function
+		 */
+		return;
+	}
+	zassert_not_equal(opamp_dev, NULL, "Failed to get OPAMP device");
+
+	for (uint8_t index = 0; index < ARRAY_SIZE(programmable_gain); ++index) {
+		ret = opamp_set_gain(opamp_dev, programmable_gain[index]);
+#if DT_PROP(OPAMP_NODE, st_lock_enable)
+		/* Lock enabled: Gain can NOT be set */
+		zassert_not_ok(ret, "lock enabled: opamp_set_gain() failed with code %d", ret);
+#else  /* lock-enable */
+		/* Lock disabled: Gain can be set */
+		zassert_ok(ret, "opamp_set_gain() failed with code %d", ret);
+		printk("%s: gain set to %d, 0x%x\n", opamp_dev->name, programmable_gain[index],
+		       LL_OPAMP_GetPGAGain(OPAMP_LL_DEV));
+#endif /* lock-enable */
+	}
+
+	/* Twister could execute gain setting test (this test) before init test without
+	 * power-cycling the device. To have reproducible tests, the gain shall be reverted
+	 * to OPAMPx_CSR registers default value (e.g. resetting bits 14 to 16 to zero).
+	 * Bits 17 to 18 shall be untouched since they may contain information about
+	 * PGA sub-mode (e.g. inverting/non-inverting, filtering and bias connections).
+	 * Refer to RM0440 Rev 9 pp. 791/2140 for more details on OPAMPx_CSR register reset value.
+	 */
+	OPAMP_LL_DEV->CSR &= ~(BIT(14) | BIT(15) | BIT(16));
+}
+#endif
+
+static void *opamp_setup(void)
+{
+	k_object_access_grant(get_opamp_device(), k_current_get());
+
+	return NULL;
+}
+
+ZTEST_SUITE(opamp_stm32, NULL, opamp_setup, NULL, NULL, NULL);

--- a/tests/drivers/opamp/opamp_stm32/testcase.yaml
+++ b/tests/drivers/opamp/opamp_stm32/testcase.yaml
@@ -1,0 +1,147 @@
+# Copyright (c) 2025 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  tags:
+    - drivers
+    - opamp
+  platform_allow:
+    - nucleo_g474re
+  vendor_allow:
+    - st
+
+tests:
+  drivers.opamp.api.stm32.opamp_stm32.opamp_functional_mode_standalone:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_standalone.overlay;
+                                dts/opamp2_inp_single.overlay;
+                                dts/opamp2_inm_single.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp2_functional_mode_standalone_single_inm_single_inp:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_standalone.overlay;
+                                dts/opamp2_inp_single.overlay;
+                                dts/opamp2_inm_single.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp2_functional_mode_standalone_double_inm_double_inp:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_standalone.overlay;
+                                dts/opamp2_inm_double.overlay;
+                                dts/opamp2_inp_double.overlay;
+                                dts/opamp2_lock_enable.overlay;
+                                dts/opamp2_timer_mux.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp2_user_trimming:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_standalone.overlay;
+                                dts/opamp2_inp_single.overlay;
+                                dts/opamp2_user_trimming.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp_functional_mode_differential:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_differential.overlay;
+                                dts/opamp2_inp_single.overlay;
+                                dts/opamp2_inm_single.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.power_mode_highspeed:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_standalone.overlay;
+                                dts/opamp2_inp_single.overlay;
+                                dts/opamp2_power_mode_highspeed.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.lock_enable:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_standalone.overlay;
+                                dts/opamp2_inp_single.overlay;
+                                dts/opamp2_lock_enable.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.lock_enable_with_timer_mux:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_standalone.overlay;
+                                dts/opamp2_inp_single.overlay;
+                                dts/opamp2_lock_enable.overlay;
+                                dts/opamp2_timer_mux.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp_self_calibration_without_adc:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_standalone.overlay;
+                                dts/opamp2_inp_single.overlay;
+                                dts/opamp2_self_calibration.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp_self_calibration_with_adc:
+    extra_args:
+      - EXTRA_CONF_FILE="config/adc.conf"
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_standalone.overlay;
+                                dts/opamp2_inp_single.overlay;
+                                dts/opamp2_self_calibration.overlay;
+                                dts/opamp2_adc_output.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp_functional_mode_follower:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_follower.overlay;
+                                dts/opamp2_inp_single.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp2_functional_mode_follower_double_inp_double_inm:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_follower.overlay;
+                                dts/opamp2_inm_double.overlay;
+                                dts/opamp2_inp_double.overlay;
+                                dts/opamp2_timer_mux.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp_functional_mode_inverting:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_inverting.overlay;
+                                dts/opamp2_inp_single_vinp0.overlay;
+                                dts/opamp2_inm_single_vinm0.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp2_functional_mode_inverting_double_inm:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_inverting.overlay;
+                                dts/opamp2_inp_single.overlay;
+                                dts/opamp2_inm_double.overlay;
+                                dts/opamp2_timer_mux.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp_functional_mode_non_inverting:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_non_inverting.overlay;
+                                dts/opamp2_inp_single_vinp0.overlay;
+                                dts/opamp2_inm_single_vinm0.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp_functional_mode_non_inverting_double_inm_double_inp:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_non_inverting.overlay;
+                                dts/opamp2_inp_double.overlay;
+                                dts/opamp2_inm_double.overlay;
+                                dts/opamp2_timer_mux.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp_functional_mode_non_inverting_filtering_vinm0:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_non_inverting.overlay;
+                                dts/opamp2_inp_single_vinp0.overlay;
+                                dts/opamp2_inm_single_vinm0.overlay;
+                                dts/opamp2_filtering_vinm0.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")
+
+  drivers.opamp.api.stm32.opamp_stm32.opamp_functional_mode_inverting_filtering_vinm1:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dts/opamp2_functional_mode_inverting.overlay;
+                                dts/opamp2_inp_single_vinp0.overlay;
+                                dts/opamp2_inm_single_vinm0.overlay;
+                                dts/opamp2_filtering_vinm1.overlay"
+    filter: dt_compat_enabled("st,stm32-opamp")


### PR DESCRIPTION
This PR adds stm32g4 opamp including following features implemented:
- functional mode selection according to existing opamp_api
- self-calibration routine at initialization stage with and without adc connected
- adc connection of opamp instance
- power-mode selection for slew-rate definition
- different pinouts configurations for IN+/IN-/ VOUT and filtering pins routing

I am highly appreciating any well structured review especially due to the fact, that the documented behavior of opamp in RM0440 Rev. 9 was a kind of tricky to implement within existing opamp_api definition. But it looks good now. 

Thank you for your reviews.

It is currently NO MORE blocked by following PRs:
1. https://github.com/zephyrproject-rtos/zephyr/pull/97404
2. https://github.com/zephyrproject-rtos/zephyr/pull/98877

The changes from 1 & 2 PRs are included here too to allow CI to run successfully, but I will drop them after 1 & 2 were merged. Also 1 & 2 PRs shall be merged definitely before this PR.
Please do not review changes of PRs 1 & 2 here, instead follow the link to provide your review.