### PR TITLE
drivers: i3c: cdns: make idle timeout a kconfig

### DIFF
--- a/drivers/i3c/Kconfig.cdns
+++ b/drivers/i3c/Kconfig.cdns
@@ -13,3 +13,18 @@ config I3C_CADENCE
 	default y
 	help
 	  Enable Cadence I3C driver.
+
+if I3C_CADENCE
+
+config I3C_CADENCE_IDLE_TIMEOUT_US
+	int "I3C Idle Timeout (us)"
+	default 250
+	help
+	  The timeout value waiting for to entry I3C idle state.
+	  This is due to the odd state machine of the I3C peripheral,
+	  where it can be not in an idle state for a while after a transfer
+	  is complete, and it does another transfer before it goes to idle.
+	  It needs to wait for it to be back in the idle state before it can
+	  start another transfer.
+
+endif # I3C_CADENCE

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -466,7 +466,7 @@
 #define I3C_MAX_IDLE_CANCEL_WAIT_RETRIES 50
 #define I3C_PRESCL_REG_SCALE             (4)
 #define I2C_PRESCL_REG_SCALE             (5)
-#define I3C_WAIT_FOR_IDLE_STATE_US       100
+#define I3C_WAIT_FOR_IDLE_STATE_US       CONFIG_I3C_CADENCE_IDLE_TIMEOUT_US
 #define I3C_IDLE_TIMEOUT_CYC                                                                       \
 	(I3C_WAIT_FOR_IDLE_STATE_US * (sys_clock_hw_cycles_per_sec() / USEC_PER_SEC))
 
@@ -935,6 +935,7 @@ static inline int cdns_i3c_wait_for_idle(const struct device *dev)
 	 */
 	while (!(sys_read32(config->base + MST_STATUS0) & MST_STATUS0_IDLE)) {
 		if (k_cycle_get_32() - start_time > I3C_IDLE_TIMEOUT_CYC) {
+			LOG_ERR("%s: Timeout waiting for idle", dev->name);
 			return -EAGAIN;
 		}
 	}


### PR DESCRIPTION
Rather than having a hardcoded timeout for entering idle, make it a KConfig.