### PR TITLE
soc: nxp: mcux: Enable DMAMUX driver for S32Z270

### DIFF
--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -304,7 +304,7 @@ if(CONFIG_SOC_SERIES_IMXRT118X)
   set_variable_ifdef(CONFIG_WDT_MCUX_RTWDOG	CONFIG_MCUX_COMPONENT_driver.src_3)
 endif()
 
-if(${MCUX_DEVICE} MATCHES "S32K3")
+if(CONFIG_SOC_SERIES_S32K3 OR CONFIG_SOC_SERIES_S32ZE)
   if(CONFIG_DMA)
     zephyr_include_directories(${MCUX_SDK_NG_DIR}/drivers/dmamux)
     set(CONFIG_MCUX_COMPONENT_driver.dmamux ON)


### PR DESCRIPTION
The S32Z270 uses DMAMUX instead of TRIGMUX.
Update the configuration to enable the DMAMUX driver

This fix #98168

test drivers.dma.chan_blen_transfer log:
```
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [dma_m2m]: pass = 4, fail = 0, skip = 0, total = 4 duration = 8.061 seconds
 - PASS - [dma_m2m.test_tst_dma0_m2m_chan0_burst16] duration = 2.016 seconds
 - PASS - [dma_m2m.test_tst_dma0_m2m_chan0_burst8] duration = 2.015 seconds
 - PASS - [dma_m2m.test_tst_dma0_m2m_chan1_burst16] duration = 2.015 seconds
 - PASS - [dma_m2m.test_tst_dma0_m2m_chan1_burst8] duration = 2.015 seconds
```

test drivers.dma.loop_transfer log:
```
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [dma_m2m_loop]: pass = 3, fail = 0, skip = 0, total = 3 duration = 1.103 seconds
 - PASS - [dma_m2m_loop.test_tst_dma0_m2m_loop] duration = 0.282 seconds
 - PASS - [dma_m2m_loop.test_tst_dma0_m2m_loop_repeated_start_stop] duration = 0.277 seconds
 - PASS - [dma_m2m_loop.test_tst_dma0_m2m_loop_suspend_resume] duration = 0.544 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```