### PR TITLE
memc: stm32_xspi_psram: Fix compilation issues for STM32H5 series

### DIFF
--- a/drivers/memc/memc_stm32_xspi_psram.c
+++ b/drivers/memc/memc_stm32_xspi_psram.c
@@ -294,6 +294,7 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 		return -EIO;
 	}
 
+#if defined(HAL_XSPIM_IOPORT_1) || defined(HAL_XSPIM_IOPORT_2)
 	if (!IS_ENABLED(CONFIG_STM32_APP_IN_EXT_FLASH)) {
 		/*
 		 * Do not configure the XSPIManager if running on the ext flash
@@ -313,6 +314,7 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 			return -EIO;
 		}
 	}
+#endif /* XSPIM */
 
 	/* Configure AP memory registers */
 	ret = ap_memory_configure(hxspi);
@@ -415,9 +417,13 @@ static struct memc_stm32_xspi_psram_data memc_stm32_xspi_data = {
 			.SampleShifting = HAL_XSPI_SAMPLE_SHIFT_NONE,
 			.DelayHoldQuarterCycle = HAL_XSPI_DHQC_ENABLE,
 			.ChipSelectBoundary = DT_INST_PROP(0, st_csbound),
+#if defined(XSPI_DCR3_MAXTRAN)
 			.MaxTran = 0U,
+#endif /* XSPI_DCR3_MAXTRAN */
 			.Refresh = 0x81U,
+#if defined(HAL_XSPIM_IOPORT_1) || defined(HAL_XSPIM_IOPORT_2)
 			.MemorySelect = HAL_XSPI_CSSEL_NCS1,
+#endif /* XSPIM */
 		},
 	},
 };

--- a/drivers/memc/memc_stm32_xspi_psram.c
+++ b/drivers/memc/memc_stm32_xspi_psram.c
@@ -336,8 +336,13 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 	cmd.AddressMode = HAL_XSPI_ADDRESS_8_LINES;
 	cmd.AddressWidth = HAL_XSPI_ADDRESS_32_BITS;
 	cmd.AddressDTRMode = HAL_XSPI_ADDRESS_DTR_ENABLE;
+#if defined(HAL_XSPI_DATA_16_LINES)
 	cmd.DataMode = DT_INST_PROP(0, io_x16_mode) ? HAL_XSPI_DATA_16_LINES
 						    : HAL_XSPI_DATA_8_LINES;
+#else
+	BUILD_ASSERT(!DT_INST_PROP(0, io_x16_mode), "SoC does not support io-x16-mode");
+	cmd.DataMode = HAL_XSPI_DATA_8_LINES;
+#endif
 	cmd.DataDTRMode = HAL_XSPI_DATA_DTR_ENABLE;
 	cmd.DummyCycles = DUMMY_CLK_CYCLES_WRITE;
 	cmd.DQSMode = HAL_XSPI_DQS_ENABLE;
@@ -407,9 +412,13 @@ static struct memc_stm32_xspi_psram_data memc_stm32_xspi_data = {
 		.Init = {
 			.FifoThresholdByte = 2U,
 			.MemoryMode = HAL_XSPI_SINGLE_MEM,
+#if defined(HAL_XSPI_DATA_16_LINES)
 			.MemoryType = (DT_INST_PROP(0, io_x16_mode) ?
 					HAL_XSPI_MEMTYPE_APMEM_16BITS :
 					HAL_XSPI_MEMTYPE_APMEM),
+#else
+			.MemoryType = HAL_XSPI_MEMTYPE_APMEM,
+#endif
 			.ChipSelectHighTimeCycle = 5U,
 			.FreeRunningClock = HAL_XSPI_FREERUNCLK_DISABLE,
 			.ClockMode = HAL_XSPI_CLOCK_MODE_0,

--- a/tests/drivers/build_all/memc/CMakeLists.txt
+++ b/tests/drivers/build_all/memc/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 CodeWrights GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(build_all)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/build_all/memc/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/build_all/memc/boards/stm32h573i_dk.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 CodeWrights GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &ext_flash_ctrl;
+
+&xspi1 {
+	memc: aps256xxn_obr: memory@0 {
+		compatible = "st,stm32-xspi-psram";
+		reg = <0>;
+		size = <DT_SIZE_M(256)>; /* 256 Mbits */
+		max-frequency = <DT_FREQ_M(200)>;
+		fixed-latency;
+		read-latency = <4>;
+		write-latency = <1>;
+		burst-length = <0>;
+		st,csbound = <11>;
+		status = "okay";
+	};
+};

--- a/tests/drivers/build_all/memc/prj.conf
+++ b/tests/drivers/build_all/memc/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_MEMC=y

--- a/tests/drivers/build_all/memc/src/main.c
+++ b/tests/drivers/build_all/memc/src/main.c
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 CodeWrights GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+int main(void)
+{
+	return 0;
+}

--- a/tests/drivers/build_all/memc/testcase.yaml
+++ b/tests/drivers/build_all/memc/testcase.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 CodeWrights GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  tags:
+    - drivers
+    - memc
+  build_only: true
+tests:
+  drivers.memc.stm32_xspi_psram.build:
+    platform_allow:
+      - stm32h7s78_dk
+      - stm32h573i_dk


### PR DESCRIPTION
The STM32H5 series has only a single XSPI interface and does not support the XSPI manager, the related `MaxTran` parameter and 16-bit IO. Configure these only if they are supported by the chip.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99191