### PR TITLE
boards: nordic: nrf54h20dk: Add reserved partition for IronSide SE

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -131,6 +131,10 @@
 		#size-cells = <1>;
 		ranges;
 
+		ironside_se_reserved: partition@0 {
+			reg = <0x0 DT_SIZE_K(192)>;
+		};
+
 		cpuapp_boot_partition: partition@30000 {
 			compatible = "zephyr,mapped-partition";
 			reg = <0x30000 DT_SIZE_K(64)>;


### PR DESCRIPTION
Add a self-documenting devicetree node in the default memory map file, to communicate how much memory is reserved for this firmware.