### PR TITLE
boards: arduino: giga_r1: Fix partition size.

### DIFF
--- a/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
+++ b/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
@@ -158,7 +158,7 @@
 
 		slot0_partition: partition@40000 {
 			label = "image-0";
-			reg = <0x40000 0x000c0000>;
+			reg = <0x40000 0x000a0000>;
 		};
 	};
 };

--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -150,7 +150,7 @@ zephyr_i2c: &i2c1 {
 
 		slot0_partition: partition@40000 {
 			label = "image-0";
-			reg = <0x40000 0x000c0000>;
+			reg = <0x40000 0x000a0000>;
 		};
 	};
 };


### PR DESCRIPTION
With the current config, a debug loader overwrites the sketch.

The correct partition layout is (offset, size):
- 0x00000 - 0x40000 (256KB): Bootloader
- 0x40000 - 0xa0000 (640KB): llext loader
- 0xe0000 - 0x20000 (128KB): sketch