### PR TITLE
boards: st: stm32h7s78_dk: remove unnecessary CONFIG_SYS_HEAP_AUTO in both defconfigs

### DIFF
--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk_defconfig
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk_defconfig
@@ -18,10 +18,3 @@ CONFIG_UART_CONSOLE=y
 
 # enable GPIO
 CONFIG_GPIO=y
-
-# SRAM0 being small (128KB), SYS_HEAP_SMALL_ONLY
-# is automatically selected, leading to not being
-# able to tackle HEAP on the large PSRAM. Force it
-# to AUTO in order to be able to handle HEAP on
-# both SRAM and PSRAM
-CONFIG_SYS_HEAP_AUTO=y

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk_stm32h7s7xx_ext_flash_app_defconfig
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk_stm32h7s7xx_ext_flash_app_defconfig
@@ -18,10 +18,3 @@ CONFIG_UART_CONSOLE=y
 
 # Enable GPIO
 CONFIG_GPIO=y
-
-# SRAM0 being small (128KB), SYS_HEAP_SMALL_ONLY
-# is automatically selected, leading to not being
-# able to tackle HEAP on the large PSRAM. Force it
-# to AUTO in order to be able to handle HEAP on
-# both SRAM and PSRAM
-CONFIG_SYS_HEAP_AUTO=y


### PR DESCRIPTION
# Changes
Remove the CONFIG_SYS_HEAP_AUTO=y config from both defconfig files, since it is no longer needed.

It was necessary when sram0 was smaller than 262136 bytes, as stated [here](https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_STM32_APP_IN_EXT_FLASH).  
But since #97448 increased the sram0 size to 456kB, this option is selected by default.

# Tests
Tested as following:
1. Commented out `CONFIG_SYS_HEAP_AUTO=y` in `stm32h7s78_dk_stm32h7s7xx_ext_flash_app_defconfig`
2. Built and flashed a sample (dumb_http_server, since I was already testing something else with it)
3. Checked `\build\zephyr\.config` and confirmed that CONFIG_SYS_HEAP_AUTO=y is enabled by default