### PR TITLE
drivers: gnss: introduce node based callback macros

### DIFF
--- a/drivers/gnss/gnss_u_blox_f9p.c
+++ b/drivers/gnss/gnss_u_blox_f9p.c
@@ -546,7 +546,7 @@ static DEVICE_API(gnss, ublox_f9p_driver_api) = {
 	static struct ubx_f9p_data ubx_f9p_data_##inst;						   \
 												   \
 	IF_ENABLED(CONFIG_GNSS_U_BLOX_F9P_RTK,							   \
-		   (GNSS_RTK_DATA_CALLBACK_DEFINE(DEVICE_DT_INST_GET(inst), f9p_rtk_data_cb)));	   \
+		   (GNSS_DT_RTK_DATA_CALLBACK_DEFINE(DT_DRV_INST(inst), f9p_rtk_data_cb)));	   \
 												   \
 	DEVICE_DT_INST_DEFINE(inst,								   \
 			      ublox_f9p_init,							   \

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -430,8 +430,17 @@ static inline int z_impl_gnss_get_latest_timepulse(const struct device *dev,
 		.dev = _dev,                                                                    \
 		.callback = _callback,                                                          \
 	}
+
+#define GNSS_DT_DATA_CALLBACK_DEFINE(_node_id, _callback)                                          \
+	static const STRUCT_SECTION_ITERABLE(                                                      \
+		gnss_data_callback,                                                                \
+		_CONCAT_4(_gnss_data_callback_, DT_DEP_ORD(_node_id), _, _callback)) = {           \
+		.dev = DEVICE_DT_GET(_node_id),                                                    \
+		.callback = _callback,                                                             \
+	}
 #else
 #define GNSS_DATA_CALLBACK_DEFINE(_dev, _callback)
+#define GNSS_DT_DATA_CALLBACK_DEFINE(_node_id, _callback)
 #endif
 
 /**
@@ -447,8 +456,17 @@ static inline int z_impl_gnss_get_latest_timepulse(const struct device *dev,
 		.dev = _dev,                                                                    \
 		.callback = _callback,                                                          \
 	}
+
+#define GNSS_DT_SATELLITES_CALLBACK_DEFINE(_node_id, _callback)                                    \
+	static const STRUCT_SECTION_ITERABLE(                                                      \
+		gnss_satellites_callback,                                                          \
+		_CONCAT_4(_gnss_satellites_callback_, DT_DEP_ORD(_node_id), _, _callback)) = {     \
+		.dev = DEVICE_DT_GET(_node_id),                                                    \
+		.callback = _callback,                                                             \
+	}
 #else
 #define GNSS_SATELLITES_CALLBACK_DEFINE(_dev, _callback)
+#define GNSS_DT_SATELLITES_CALLBACK_DEFINE(_node_id, _callback)
 #endif
 
 /**

--- a/include/zephyr/gnss/rtk/rtk.h
+++ b/include/zephyr/gnss/rtk/rtk.h
@@ -36,8 +36,17 @@ struct gnss_rtk_data_callback {
 		.dev = _dev,									   \
 		.callback = _callback,								   \
 	}
+
+#define GNSS_DT_RTK_DATA_CALLBACK_DEFINE(_node_id, _callback)                                      \
+	static const STRUCT_SECTION_ITERABLE(                                                      \
+		gnss_rtk_data_callback,                                                            \
+		_CONCAT_4(_gnss_rtk_data_callback_, DT_DEP_ORD(_node_id), _, _callback)) = {       \
+		.dev = DEVICE_DT_GET(_node_id),                                                    \
+		.callback = _callback,                                                             \
+	}
 #else
 #define GNSS_RTK_DATA_CALLBACK_DEFINE(_dev, _callback)
+#define GNSS_DT_RTK_DATA_CALLBACK_DEFINE(_node_id, _callback)
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
[drivers: gnss: introduce node based callback macros](https://github.com/zephyrproject-rtos/zephyr/commit/11472e7918d07840f0570d314288f473a60dd85e) 

The current GNSS_DATA_CALLBACK_DEFINE, GNSS_SATELLITES_CALLBACK_DEFINE and GNSS_RTK_DATA_CALLBACK_DEFINE macros only utilize `_callback` when naming the respective callback. This means that if the same callback function is used more than once, there will be naming conflicts.

In order to allow the same callback function to be used several times for specific gnss devices, introduce GNSS_DT_DATA_CALLBACK_DEFINE, GNSS_DT_SATELLITES_CALLBACK_DEFINE and GNSS_DT_RTK_DATA_CALLBACK_DEFINE macros that take a device tree node identifier instead of a device reference. This makes it possible to name the callback using both `node_id` and `_callback`. Such will uniquely identify any combination of gnss device and callback.

[drivers: gnss: f9p: fix multiple rtk enabled instances](https://github.com/zephyrproject-rtos/zephyr/commit/5ed368722cbae283b78ed7eaf642cda4a7e1f323) 

The U-blox F9P driver uses the GNSS_RTK_DATA_CALLBACK_DEFINE macro to register a callback for when RTK data is available. This is an issue when multiple instances of the F9P are available and RTK is enabled since this macro leads to a naming collision. The following compilation error is reported:

     error: redefinition of '_gnss_rtk_data_callback__f9p_rtk_data_cb'

This is because GNSS_RTK_DATA_CALLBACK_DEFINE only uses `_callback` to identify the callback being registered. As a fix, use the recently introduced GNSS_DT_RTK_DATA_CALLBACK_DEFINE instead, which takes into account the `node_id` while naming the callback.

This PR is a continuation of #98646.

Signed-off-by: Pedro André <pedro@sentrytechnologies.ai>