### PR TITLE
boards: arduino: add ADC support for the Nano Matter

### DIFF
--- a/boards/arduino/nano_matter/arduino_nano_matter-pinctrl.dtsi
+++ b/boards/arduino/nano_matter/arduino_nano_matter-pinctrl.dtsi
@@ -36,6 +36,28 @@
 		};
 	};
 
+	iadc0_default: iadc0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_AEVEN0_IADC0>;
+		};
+
+		group1 {
+			silabs,analog-bus = <ABUS_AODD0_IADC0>;
+		};
+
+		group2 {
+			silabs,analog-bus = <ABUS_BEVEN0_IADC0>;
+		};
+
+		group3 {
+			silabs,analog-bus = <ABUS_BODD0_IADC0>;
+		};
+
+		group4 {
+			silabs,analog-bus = <ABUS_CDEVEN0_IADC0>;
+		};
+	};
+
 	i2c0_default: i2c0_default {
 		group0 {
 			pins = <I2C0_SCL_PA7>, <I2C0_SDA_PA6>;

--- a/boards/arduino/nano_matter/arduino_nano_matter.dts
+++ b/boards/arduino/nano_matter/arduino_nano_matter.dts
@@ -8,6 +8,7 @@
 /dts-v1/;
 #include <silabs/xg24/mgm240sd22vna.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include "arduino_nano_matter-pinctrl.dtsi"
 #include "arduino_nano_matter_connector.dtsi"
@@ -36,6 +37,7 @@
 		pwm-led2 = &blue_pwm_led;
 		sw0 = &button0;
 		watchdog0 = &wdog0;
+		adc0 = &adc0;
 	};
 
 	leds {
@@ -83,6 +85,17 @@
 			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+	};
+
+	zephyr,user {
+		io-channels = <&adc0 0>,
+			      <&adc0 1>,
+			      <&adc0 2>,
+			      <&adc0 3>,
+			      <&adc0 4>,
+			      <&adc0 5>,
+			      <&adc0 6>,
+			      <&adc0 7>;
 	};
 };
 
@@ -201,6 +214,102 @@
 
 &se {
 	status = "okay";
+};
+
+&adc0 {
+	pinctrl-0 = <&iadc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	// A0 - PB0
+	channel@0 {
+		reg = <0>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,input-positive = <IADC_INPUT_PB0>;
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	// A1 - PB2
+	channel@1 {
+		reg = <1>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,input-positive = <IADC_INPUT_PB2>;
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	// A2 - PB5
+	channel@2 {
+		reg = <2>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,input-positive = <IADC_INPUT_PB5>;
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	// A3 - PC0
+	channel@3 {
+		reg = <3>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,input-positive = <IADC_INPUT_PC0>;
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	// A4 - PA6
+	channel@4 {
+		reg = <4>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,input-positive = <IADC_INPUT_PA6>;
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	// A5 - PA7
+	channel@5 {
+		reg = <5>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,input-positive = <IADC_INPUT_PA7>;
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	// A6 - PB1
+	channel@6 {
+		reg = <6>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,input-positive = <IADC_INPUT_PB1>;
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	// A7 - PB3
+	channel@7 {
+		reg = <7>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,input-positive = <IADC_INPUT_PB3>;
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
 };
 
 &flash0 {


### PR DESCRIPTION
This PR adds ADC support for the Arduino Nano Matter on its analog pins A0-A7.