### PR TITLE
cve: Disclose CVE-2025-9408

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -83,7 +83,8 @@ Security Vulnerability Related
 ******************************
 The following CVEs are addressed by this release:
 
-* :cve:`2025-9408`: Under embargo until 2025-11-10
+* :cve:`2025-9408` `Zephyr project bug tracker GHSA-3r6j-5mp3-75wr
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3r6j-5mp3-75wr>`_
 * :cve:`2025-9557`: Under embargo until 2025-11-24
 * :cve:`2025-9558`: Under embargo until 2025-11-24
 * :cve:`2025-12035`: Under embargo until 2025-12-13

--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -2006,7 +2006,36 @@ This has been fixed in main for v4.2.0
 :cve:`2025-9408`
 ----------------
 
-Under embargo until 2025-11-10
+Userspace privilege escalation vulnerability on Cortex M
+
+System call entry on Cortex M (and possibly R and A, but I think not) has a race which allows very
+practical privilege escalation for malicious userspace processes.
+
+
+- `Zephyr project bug tracker GHSA-3r6j-5mp3-75wr
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3r6j-5mp3-75wr>`_
+
+This has been fixed in main for v4.3.0
+
+- `PR 95101 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/95101>`_
+- `PR 96850 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/96850>`_
+
+- `PR 96014 fix for 4.2
+  <https://github.com/zephyrproject-rtos/zephyr/pull/96014>`_
+- `PR 97306 fix for 4.2
+  <https://github.com/zephyrproject-rtos/zephyr/pull/97306>`_
+
+- `PR 96015 fix for 4.1
+  <https://github.com/zephyrproject-rtos/zephyr/pull/96015>`_
+- `PR 97305 fix for 4.1
+  <https://github.com/zephyrproject-rtos/zephyr/pull/97305>`_
+
+- `PR 96030 fix for 3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/96030>`_
+- `PR 97313 fix for 3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/97313>`_
 
 :cve:`2025-9557`
 ----------------


### PR DESCRIPTION
 CVE-2025-9408 has left embargo. Publish info about it.