### PR TITLE
Mark custom headers as experimental

### DIFF
--- a/subsys/logging/Kconfig.mode
+++ b/subsys/logging/Kconfig.mode
@@ -61,7 +61,8 @@ config LOG_FRONTEND_OPT_API
 	  used for the most common log messages.
 
 config LOG_CUSTOM_HEADER
-	bool "Include Custom Log Header"
+	bool "Include Custom Log Header [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  When enabled, a custom application provided header, named
 	  "zephyr_custom_log.h", is included at the end of log.h. This enables

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -318,7 +318,8 @@ config SHELL_CMDS_RETURN_VALUE
 	  the return value from the most recently executed command.
 
 config SHELL_CUSTOM_HEADER
-	bool "Include Custom Shell Header"
+	bool "Include Custom Shell Header [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  When enabled, a custom application provided header, named
 	  "zephyr_custom_shell.h", is included at the end of shell.h. This enables


### PR DESCRIPTION
Mark custom header inclusion as experimental as discussed in the Arch WG 2025-11-11.
Please see https://github.com/zephyrproject-rtos/zephyr/pull/96514#issuecomment-3517709720