### PR TITLE
usb: device_next: cdc_acm: Use a separate buffer pool for OUT

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -709,6 +709,7 @@ static void cdc_acm_rx_fifo_handler(struct k_work *work)
 
 	buf = cdc_acm_buf_alloc(c_data, cdc_acm_get_bulk_out(c_data));
 	if (buf == NULL) {
+	        atomic_clear_bit(&data->state, CDC_ACM_RX_FIFO_BUSY);
 		return;
 	}
 
@@ -720,6 +721,7 @@ static void cdc_acm_rx_fifo_handler(struct k_work *work)
 		LOG_ERR("Failed to enqueue net_buf for 0x%02x",
 			cdc_acm_get_bulk_out(c_data));
 		net_buf_unref(buf);
+	        atomic_clear_bit(&data->state, CDC_ACM_RX_FIFO_BUSY);
 	}
 }
 


### PR DESCRIPTION
CDC ACM code will try to eagerly consume buffers from the buffer pool as long as there some data in it's TX FIFO. Since both IN and OUT transfers share the same buffer pool this make the code vulnerable to the "noisy neighbor" problem, where a influx of TX/IN traffic can completely deplete the buffer pool and cause a buffer allocation failure in cdc_acm_rx_fifo_handler(). Since there is no retry mechanism on buffer allocation failure there we end up stuck with USB controller NAK-ing every OUT transfer.

To avoid this problem, let's just split the buffer pools into IN/OUT. This way we know that an allocation failure in cdc_acm_rx_fifo_handler() implies that there are queued IN transfers which will re-arm the DMA in USB peripheral once they complete.

cc: @jfischer-no 