### PR TITLE
boards: vmu-rt1170 & mr-canhubk3: Set enet PHY role to auto

### DIFF
--- a/boards/nxp/mr_canhubk3/mr_canhubk3_common.dtsi
+++ b/boards/nxp/mr_canhubk3/mr_canhubk3_common.dtsi
@@ -475,7 +475,7 @@
 		status = "okay";
 		reg = <0x12>;
 		int-gpios = <&gpiod_l 5 GPIO_ACTIVE_LOW>;
-		master-slave = "slave";
+		master-slave = "auto";
 	};
 };
 

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -525,6 +525,7 @@
 &enet1g_phy {
 	status = "okay";
 	int-gpios = <&gpio5 10 GPIO_ACTIVE_HIGH>;
+	master-slave = "auto";
 };
 
 zephyr_udc0: &usb1 {


### PR DESCRIPTION
To allow flexibility of ethernet "just working" with various peers, including Linux peers that may be configured by default as master.