### PR TITLE
libsbc: replace zephyr_compile_definitions

### DIFF
--- a/modules/libsbc/CMakeLists.txt
+++ b/modules/libsbc/CMakeLists.txt
@@ -3,8 +3,8 @@ if(CONFIG_LIBSBC_ENCODER OR CONFIG_LIBSBC_DECODER)
 zephyr_library_named(libsbc)
 zephyr_library_compile_options(-O3 -std=c11 -ffast-math -Wno-array-bounds)
 
-zephyr_compile_definitions(SBC_FOR_EMBEDDED_LINUX)
-zephyr_compile_definitions(SBC_NO_PCM_CPY_OPTION)
+zephyr_library_compile_definitions(SBC_FOR_EMBEDDED_LINUX)
+zephyr_library_compile_definitions(SBC_NO_PCM_CPY_OPTION)
 zephyr_library_sources(sbc.c)
 
 zephyr_include_directories(


### PR DESCRIPTION
Replace zephyr_compile_definitions with zephyr_library_compile_definitions to avoid setting options globally.