### PR TITLE
arch: indirect executable RAM symbol

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -241,6 +241,20 @@ config XIP
 	  supply a linker command file when building your image. Enabling this
 	  option increases both the code and data footprint of the image.
 
+config XIP_NOT
+	bool
+	default y
+	depends on !XIP
+	select EXECUTABLE_RAM if (MMU || MPU)
+	help
+	  Helper symbol that forces EXECUTABLE_RAM if !XIP.
+
+config EXECUTABLE_RAM
+	bool "Configure RAM to be executable"
+	depends on (MMU || MPU)
+	default y if LLEXT
+	help
+	  Configure RAM to be executable. Changes the attributes of REGION_RAM_ATTR.
 
 if ARC || ARM || ARM64 || X86 || RISCV || RX || ARCH_POSIX
 

--- a/include/zephyr/arch/arm/mpu/arm_mpu_v7m.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_v7m.h
@@ -111,13 +111,12 @@
 
 /* Some helper defines for common regions */
 
-/* On Cortex-M, we can only set the XN bit when CONFIG_XIP=y. When
- * CONFIG_XIP=n, the entire image will be linked to SRAM, so we need to keep
- * the SRAM region XN bit clear or the application code will not be executable.
- */
+/* Executable flag for RAM */
+#define RAM_EXEC COND_CODE_1(CONFIG_EXECUTABLE_RAM, (0), (NOT_EXEC))
+
 #define REGION_RAM_ATTR(size)                                                                      \
 	{(NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE |                        \
-	  IF_ENABLED(CONFIG_XIP, (MPU_RASR_XN_Msk |)) size | P_RW_U_NA_Msk)}
+	  RAM_EXEC | size | P_RW_U_NA_Msk)}
 #define REGION_RAM_NOCACHE_ATTR(size)                                                              \
 	{(NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE | MPU_RASR_XN_Msk | size | P_RW_U_NA_Msk)}
 #if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)

--- a/include/zephyr/arch/arm/mpu/arm_mpu_v8.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_v8.h
@@ -67,6 +67,9 @@
 /* Attribute flag for not-allowing execution (eXecute Never) */
 #define NOT_EXEC MPU_RBAR_XN_Msk
 
+/* Executable flag for RAM */
+#define RAM_EXEC        COND_CODE_1(CONFIG_EXECUTABLE_RAM, (0), (NOT_EXEC))
+
 /* To prevent execution of MPU region in privileged mode */
 #define PRIV_EXEC_NEVER (1)
 
@@ -236,17 +239,12 @@
 		.attr = p_attr(p_base, p_size),                                                    \
 	}
 
-/* On Cortex-M, we can only set the XN bit when CONFIG_XIP=y. When
- * CONFIG_XIP=n, the entire image will be linked to SRAM, so we need to keep
- * the SRAM region XN bit clear or the application code will not be executable.
- */
 /* clang-format off */
 #define REGION_RAM_ATTR(base, size)                                                                \
 	{                                                                                          \
-		.rbar = IF_ENABLED(CONFIG_XIP, (NOT_EXEC |)) P_RW_U_NA_Msk |                       \
-			NON_SHAREABLE_Msk,                /* AP, XN, SH */                         \
-		.mair_idx = MPU_MAIR_INDEX_SRAM,          /* Cache-ability */                      \
-		.r_limit = REGION_LIMIT_ADDR(base, size), /* Region Limit */                       \
+		.rbar = RAM_EXEC | P_RW_U_NA_Msk | NON_SHAREABLE_Msk,  /* AP, XN, SH */            \
+		.mair_idx = MPU_MAIR_INDEX_SRAM,                       /* Cache-ability */         \
+		.r_limit = REGION_LIMIT_ADDR(base, size),              /* Region Limit */          \
 		IF_ENABLED(CONFIG_ARM_MPU_PXN, (.pxn = !PRIV_EXEC_NEVER,))			   \
 	}
 


### PR DESCRIPTION
Instead of marking RAM regions as executable when `CONFIG_XIP=n`, add a dedicated symbol to control the behaviour. XIP is the most obvious case that requires this, but LLEXT for example can also load code into RAM that is then executed.

The addition of `XIP_NOT` forces `EXECUTABLE_RAM` when `XIP` is disabled in order to prevent users from accidently turning it off.

Intended to solve usage faults when using LLEXT on platforms with an MPU or MMU, since currently any attempt to execute a loaded function will fault. Whether this is the right place or not to solve the problem I don't know, but it does solve it for `mps2/an385`.