### PR TITLE
logging: log_output: Extend API with optional get_available function

### DIFF
--- a/subsys/logging/backends/log_backend_rtt.c
+++ b/subsys/logging/backends/log_backend_rtt.c
@@ -282,7 +282,16 @@ static int data_out(uint8_t *data, size_t length, void *ctx)
 	return logging_func(data, length, ctx);
 }
 
-LOG_OUTPUT_DEFINE(log_output_rtt, data_out, char_buf, sizeof(char_buf));
+static int get_available(void *ctx)
+{
+	ARG_UNUSED(ctx);
+
+	return SEGGER_RTT_GetAvailWriteSpace(CONFIG_LOG_BACKEND_RTT_BUFFER);
+}
+
+LOG_OUTPUT_EXT_DEFINE(log_output_rtt, data_out,
+		IS_ENABLED(CONFIG_LOG_BACKEND_RTT_OUTPUT_DICTIONARY_HEX) ? get_available : NULL,
+		char_buf, sizeof(char_buf));
 
 static void log_backend_rtt_cfg(void)
 {

--- a/subsys/logging/log_output_dict.c
+++ b/subsys/logging/log_output_dict.c
@@ -28,22 +28,40 @@ void log_dict_output_msg_process(const struct log_output *output,
 
 	output_hdr.source = (source != NULL) ? log_source_id(source) : 0U;
 
+	int available = log_output_get_available(output);
+	size_t pkg_len, hex_len;
+	uint8_t *pkg_data = log_msg_get_package(pkg_msg, &pkg_len);
+	uint8_t *hex_data = log_msg_get_data(msg, &hex_len);
+	k_spinlock_key_t key;
+
+	if (available >= 0) {
+		int total_msg_len = sizeof(output_hdr) + pkg_len + hex_len;
+
+		key = k_spin_lock(&output->control_block->lock);
+		available = log_output_get_available(output);
+		if (available < total_msg_len);
+			k_spin_unlock(&output->control_block->lock, key);
+			return;
+		}
+	}
+
 	log_output_write(output->func, (uint8_t *)&output_hdr, sizeof(output_hdr),
 			 (void *)output->control_block->ctx);
 
-	size_t len;
-	uint8_t *data = log_msg_get_package(msg, &len);
-
-	if (len > 0U) {
-		log_output_write(output->func, data, len, (void *)output->control_block->ctx);
+	if (pkg_len > 0U) {
+		log_output_write(output->func, pkg_data, pkg_len, output->control_block->ctx);
 	}
 
-	data = log_msg_get_data(msg, &len);
-	if (len > 0U) {
-		log_output_write(output->func, data, len, (void *)output->control_block->ctx);
+	if (hex_len > 0U) {
+		log_output_write(output->func, hex_data, hex_len, output->control_block->ctx);
 	}
 
 	log_output_flush(output);
+
+	if (available >= 0) {
+		k_spin_unlock(&output->control_block->lock, key);
+		return;
+	}
 }
 
 void log_dict_output_dropped_process(const struct log_output *output, uint32_t cnt)


### PR DESCRIPTION
Add optional `log_output_get_available` function which returns amount of data that can be currently accepted by the backend. Extend RTT backend to implement that functionality and allow getting amount of space in the write buffer.

Use that functionality in dictionary mode to ensure that only whole messages are written to the log output.