### PR TITLE
STM32 RNG: NIST SP800-90B support

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -218,8 +218,10 @@ static void configure_rng(void)
 #ifdef STM32_CONDRST_SUPPORT
 	uint32_t desired_nist_cfg = DT_INST_PROP_OR(0, nist_config, 0U);
 	uint32_t desired_htcr = DT_INST_PROP_OR(0, health_test_config, 0U);
+	uint32_t desired_nscr = DT_INST_PROP_OR(0, noise_source_control, 0U);
 	uint32_t cur_nist_cfg = 0U;
 	uint32_t cur_htcr = 0U;
+	uint32_t cur_nscr = 0U;
 
 #if DT_INST_NODE_HAS_PROP(0, nist_config)
 	/*
@@ -242,7 +244,12 @@ static void configure_rng(void)
 	cur_htcr = LL_RNG_GetHealthConfig(rng);
 #endif /* health_test_config */
 
-	if (cur_nist_cfg != desired_nist_cfg || cur_htcr != desired_htcr) {
+#if DT_INST_NODE_HAS_PROP(0, noise_source_control)
+	cur_nscr = LL_RNG_GetNoiseConfig(rng);
+#endif /* noise_source_control */
+
+	if (cur_nist_cfg != desired_nist_cfg || cur_htcr != desired_htcr ||
+	    cur_nscr != desired_nscr) {
 		stm32_reg_modify_bits(&rng->CR, cur_nist_cfg, desired_nist_cfg | RNG_CR_CONDRST);
 
 #if DT_INST_NODE_HAS_PROP(0, health_test_config)
@@ -254,6 +261,10 @@ static void configure_rng(void)
 #endif /* health_test_magic */
 		LL_RNG_SetHealthConfig(rng, desired_htcr);
 #endif /* health_test_config */
+
+#if DT_INST_NODE_HAS_PROP(0, noise_source_control)
+		LL_RNG_SetNoiseConfig(rng, DT_INST_PROP(0, noise_source_control));
+#endif /* noise_source_control */
 
 		LL_RNG_DisableCondReset(rng);
 		/* Wait for conditioning reset process to be completed */

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -525,6 +525,12 @@
 			status = "disabled";
 		};
 
+		rng: rng@420c0800 {
+			nist-config = <0xf00e00>;
+			health-test-config = <0x6a91>;
+			noise-source-control = <0x3af66>;
+		};
+
 		sdmmc1: sdmmc@46008000 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x46008000 0x400>;

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -62,6 +62,7 @@
 		};
 
 		rng: rng@48021800 {
+			nist-config = <0xf00d00>;
 			health-test-magic = <0x17590abc>;
 			health-test-config = <0xaa74>;
 		};

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -917,6 +917,8 @@
 			reg = <0x48020000 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB3, 0)>;
 			interrupts = <37 0>;
+			nist-config = <0xf00d00>;
+			health-test-config = <0xaac7>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -454,6 +454,12 @@
 			#size-cells = <0>;
 			status = "disabled";
 		};
+
+		rng: rng@50060800 {
+			nist-config = <0xf00d00>;
+			health-test-magic = <0x17590abc>;
+			health-test-config = <0xaa74>;
+		};
 	};
 
 	otgfs_phy: otgfs_phy {

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -41,5 +41,12 @@
 				STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
 				STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
 		};
+
+		rng: rng@50060800 {
+			/* L4R/S RNG differs from L4P/Q; these properties are not available */
+			/delete-property/ nist-config;
+			/delete-property/ health-test-magic;
+			/delete-property/ health-test-config;
+		};
 	};
 };

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1288,6 +1288,8 @@
 			reg = <0x54020000 0x400>;
 			interrupts = <40 0>;
 			clocks = <&rcc STM32_CLOCK(AHB3, 0)>;
+			nist-config = <0xf00d00>;
+			health-test-config = <0xaac7>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -402,6 +402,8 @@
 			clocks = <&rcc STM32_CLOCK(AHB1, 18)>,
 				 <&rcc STM32_SRC_CK48 NO_SEL>;
 			interrupts = <31 0>;
+			nist-config = <0xf00d00>;
+			health-test-config = <0xaac7>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -335,6 +335,8 @@
 			reg = <0x420c0800 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 18)>;
 			interrupts = <94 0>;
+			nist-config = <0xf00d00>;
+			health-test-config = <0xaac7>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -816,8 +816,6 @@
 			reg = <0x420c0800 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 18)>;
 			interrupts = <94 0>;
-			nist-config = <0xf60d00>;
-			health-test-config = <0x9aae>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u535.dtsi
+++ b/dts/arm/st/u5/stm32u535.dtsi
@@ -19,5 +19,11 @@
 
 	soc {
 		compatible = "st,stm32u535", "st,stm32u5", "simple-bus";
+
+		rng: rng@420c0800 {
+			nist-config = <0xf10f00>;
+			health-test-config = <0x76b3>;
+			noise-source-control = <0x24c2>;
+		};
 	};
 };

--- a/dts/arm/st/u5/stm32u575.dtsi
+++ b/dts/arm/st/u5/stm32u575.dtsi
@@ -21,5 +21,11 @@
 
 	soc {
 		compatible = "st,stm32u575", "st,stm32u5", "simple-bus";
+
+		rng: rng@420c0800 {
+			nist-config = <0xf00d00>;
+			health-test-config = <0xa2b0>;
+			noise-source-control = <0x17cbb>;
+		};
 	};
 };

--- a/dts/arm/st/u5/stm32u595.dtsi
+++ b/dts/arm/st/u5/stm32u595.dtsi
@@ -114,6 +114,12 @@
 			st,adc-has-differential-support;
 			status = "disabled";
 		};
+
+		rng: rng@420c0800 {
+			nist-config = <0xf10f00>;
+			health-test-config = <0x92f3>;
+			noise-source-control = <0x1609>;
+		};
 	};
 
 	smbus5: smbus5 {

--- a/dts/arm/st/u5/stm32u5f9.dtsi
+++ b/dts/arm/st/u5/stm32u5f9.dtsi
@@ -9,6 +9,12 @@
 / {
 	soc {
 		compatible = "st,stm32u5f9", "st,stm32u5", "simple-bus";
+
+		rng: rng@420c0800 {
+			nist-config = <0xf10f00>;
+			health-test-config = <0xa715>;
+			noise-source-control = <0x9049>;
+		};
 	};
 };
 

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -540,7 +540,7 @@
 			interrupts = <59 0>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
 				 <&rcc STM32_SRC_HSI16 RNG_SEL(2)>;
-			nist-config = <0xf00d>;
+			nist-config = <0xf00d00>;
 			health-test-config = <0xaac7>;
 			status = "disabled";
 		};

--- a/dts/arm/st/wba/stm32wba65.dtsi
+++ b/dts/arm/st/wba/stm32wba65.dtsi
@@ -69,6 +69,10 @@
 			status = "disabled";
 		};
 
+		rng: rng@420c0800 {
+			nist-config = <0x8200f00>;
+		};
+
 		spi2: spi@40003800 {
 			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -486,6 +486,7 @@
 			reg = <0x58001000 0x400>;
 			interrupts = <52 0>;
 			clocks = <&rcc STM32_CLOCK(AHB3, 18)>;
+			nist-config = <0xf00d00>;
 			health-test-magic = <0x17590abc>;
 			health-test-config = <0xaa74>;
 			status = "disabled";

--- a/dts/bindings/rng/st,stm32-rng.yaml
+++ b/dts/bindings/rng/st,stm32-rng.yaml
@@ -45,3 +45,9 @@ properties:
     description: |
          Heath Test Configuration, necessary to have proper RNG behavior,
          when available.
+
+  noise-source-control:
+    type: int
+    description: |
+      This property is used to configure the RNG_NSCR register for the NIST
+      certification.


### PR DESCRIPTION
In order to comply to NIST SP800-90B, the STM32 RNG should set its registers as documented in Application Note AN4230 (Table 3). To that effect, some values have been modified to match the table, and some have been added.