### PR TITLE
 drivers: spi: sam0: Add DMA support for synchronous transfers

### DIFF
--- a/drivers/spi/Kconfig.sam0
+++ b/drivers/spi/Kconfig.sam0
@@ -8,6 +8,14 @@ config SPI_SAM0
 	default y
 	depends on DT_HAS_ATMEL_SAM0_SPI_ENABLED
 	select PINCTRL
-	select DMA if SPI_ASYNC
 	help
 	  Enable support for the SAM0 SERCOM SPI driver.
+
+config SPI_SAM0_DMA
+	bool "Atmel SAM0 dma support"
+	default y
+	depends on SPI_SAM0
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ATMEL_SAM0_SPI),dmas)
+	depends on DMA
+	help
+	  Enable DMA-based data transfers for the Atmel SAM0 SPI driver.

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -36,7 +36,7 @@ struct spi_sam0_config {
 	uint32_t gclk_gen;
 	uint16_t gclk_id;
 
-#ifdef CONFIG_SPI_ASYNC
+#ifdef CONFIG_SPI_SAM0_DMA
 	const struct device *dma_dev;
 	uint8_t tx_dma_request;
 	uint8_t tx_dma_channel;
@@ -48,7 +48,7 @@ struct spi_sam0_config {
 /* Device run time data */
 struct spi_sam0_data {
 	struct spi_context ctx;
-#ifdef CONFIG_SPI_ASYNC
+#ifdef CONFIG_SPI_SAM0_DMA
 	const struct device *dev;
 	uint32_t dma_segment_len;
 #endif
@@ -372,57 +372,7 @@ static bool spi_sam0_is_regular(const struct spi_buf_set *tx_bufs,
 	return true;
 }
 
-static int spi_sam0_transceive(const struct device *dev,
-			       const struct spi_config *config,
-			       const struct spi_buf_set *tx_bufs,
-			       const struct spi_buf_set *rx_bufs)
-{
-	const struct spi_sam0_config *cfg = dev->config;
-	struct spi_sam0_data *data = dev->data;
-	SercomSpi *regs = cfg->regs;
-	int err;
-
-	spi_context_lock(&data->ctx, false, NULL, NULL, config);
-
-	err = spi_sam0_configure(dev, config);
-	if (err != 0) {
-		goto done;
-	}
-
-	spi_context_cs_control(&data->ctx, true);
-
-	/* This driver special cases the common send only, receive
-	 * only, and transmit then receive operations.	This special
-	 * casing is 4x faster than the spi_context() routines
-	 * and allows the transmit and receive to be interleaved.
-	 */
-	if (spi_sam0_is_regular(tx_bufs, rx_bufs)) {
-		spi_sam0_fast_transceive(dev, config, tx_bufs, rx_bufs);
-	} else {
-		spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
-
-		do {
-			spi_sam0_shift_master(regs, data);
-		} while (spi_sam0_transfer_ongoing(data));
-	}
-
-	spi_context_cs_control(&data->ctx, false);
-
-done:
-	spi_context_release(&data->ctx, err);
-	return err;
-}
-
-static int spi_sam0_transceive_sync(const struct device *dev,
-				    const struct spi_config *config,
-				    const struct spi_buf_set *tx_bufs,
-				    const struct spi_buf_set *rx_bufs)
-{
-	return spi_sam0_transceive(dev, config, tx_bufs, rx_bufs);
-}
-
-#ifdef CONFIG_SPI_ASYNC
-
+#ifdef CONFIG_SPI_SAM0_DMA
 static void spi_sam0_dma_rx_done(const struct device *dma_dev, void *arg,
 				 uint32_t id, int error_code);
 
@@ -599,28 +549,22 @@ static void spi_sam0_dma_rx_done(const struct device *dma_dev, void *arg,
 		return;
 	}
 }
+#endif /* CONFIG_SPI_SAM0_DMA */
 
-
-static int spi_sam0_transceive_async(const struct device *dev,
-				     const struct spi_config *config,
-				     const struct spi_buf_set *tx_bufs,
-				     const struct spi_buf_set *rx_bufs,
-				     spi_callback_t cb,
-				     void *userdata)
+static int spi_sam0_transceive(const struct device *dev,
+			       const struct spi_config *config,
+			       const struct spi_buf_set *tx_bufs,
+			       const struct spi_buf_set *rx_bufs,
+			       bool asynchronous,
+			       spi_callback_t cb,
+			       void *userdata)
 {
 	const struct spi_sam0_config *cfg = dev->config;
 	struct spi_sam0_data *data = dev->data;
+	SercomSpi *regs = cfg->regs;
 	int retval;
 
-	/*
-	 * Transmit clocks the output and we use receive to determine when
-	 * the transmit is done, so we always need both
-	 */
-	if (cfg->tx_dma_channel == 0xFF || cfg->rx_dma_channel == 0xFF) {
-		return -ENOTSUP;
-	}
-
-	spi_context_lock(&data->ctx, true, cb, userdata, config);
+	spi_context_lock(&data->ctx, asynchronous, cb, userdata, config);
 
 	retval = spi_sam0_configure(dev, config);
 	if (retval != 0) {
@@ -629,19 +573,51 @@ static int spi_sam0_transceive_async(const struct device *dev,
 
 	spi_context_cs_control(&data->ctx, true);
 
-	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
+#ifdef CONFIG_SPI_SAM0_DMA
+	/*
+	 * Transmit clocks the output and we use receive to determine when
+	 * the transmit is done, so we always need both
+	 */
+	if (cfg->dma_dev != NULL && cfg->tx_dma_channel != 0xFF && cfg->rx_dma_channel != 0xFF) {
+		spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
 
-	spi_sam0_dma_advance_segment(dev);
-	retval = spi_sam0_dma_advance_buffers(dev);
-	if (retval != 0) {
-		goto err_cs;
+		spi_sam0_dma_advance_segment(dev);
+		retval = spi_sam0_dma_advance_buffers(dev);
+		if (retval != 0) {
+			dma_stop(cfg->dma_dev, cfg->tx_dma_channel);
+			dma_stop(cfg->dma_dev, cfg->rx_dma_channel);
+
+			spi_context_cs_control(&data->ctx, false);
+		} else {
+			/* Wait for DMA completion signaled by spi_sam0_dma_rx_done() */
+			retval = spi_context_wait_for_completion(&data->ctx);
+		}
+		spi_context_release(&data->ctx, retval);
+
+		return retval;
 	}
 
-	return 0;
+	if (asynchronous) {
+		retval = -ENOTSUP;
+		spi_context_cs_control(&data->ctx, false);
+		goto err_unlock;
+	}
+#endif /* CONFIG_SPI_SAM0_DMA */
 
-err_cs:
-	dma_stop(cfg->dma_dev, cfg->tx_dma_channel);
-	dma_stop(cfg->dma_dev, cfg->rx_dma_channel);
+	/* This driver special cases the common send only, receive
+	 * only, and transmit then receive operations.	This special
+	 * casing is 4x faster than the spi_context() routines
+	 * and allows the transmit and receive to be interleaved.
+	 */
+	if (spi_sam0_is_regular(tx_bufs, rx_bufs)) {
+		spi_sam0_fast_transceive(dev, config, tx_bufs, rx_bufs);
+	} else {
+		spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
+
+		do {
+			spi_sam0_shift_master(regs, data);
+		} while (spi_sam0_transfer_ongoing(data));
+	}
 
 	spi_context_cs_control(&data->ctx, false);
 
@@ -649,7 +625,26 @@ err_unlock:
 	spi_context_release(&data->ctx, retval);
 	return retval;
 }
+
+#ifdef CONFIG_SPI_ASYNC
+static int spi_sam0_transceive_async(const struct device *dev,
+				     const struct spi_config *config,
+				     const struct spi_buf_set *tx_bufs,
+				     const struct spi_buf_set *rx_bufs,
+				     spi_callback_t cb,
+				     void *userdata)
+{
+	return spi_sam0_transceive(dev, config, tx_bufs, rx_bufs, true, cb, userdata);
+}
 #endif /* CONFIG_SPI_ASYNC */
+
+static int spi_sam0_transceive_sync(const struct device *dev,
+				    const struct spi_config *config,
+				    const struct spi_buf_set *tx_bufs,
+				    const struct spi_buf_set *rx_bufs)
+{
+	return spi_sam0_transceive(dev, config, tx_bufs, rx_bufs, false, NULL, NULL);
+}
 
 static int spi_sam0_release(const struct device *dev,
 			    const struct spi_config *config)
@@ -692,8 +687,8 @@ static int spi_sam0_init(const struct device *dev)
 		return err;
 	}
 
-#ifdef CONFIG_SPI_ASYNC
-	if (!device_is_ready(cfg->dma_dev)) {
+#ifdef CONFIG_SPI_SAM0_DMA
+	if ((cfg->dma_dev != NULL) && !device_is_ready(cfg->dma_dev)) {
 		return -ENODEV;
 	}
 	data->dev = dev;
@@ -724,13 +719,15 @@ static DEVICE_API(spi, spi_sam0_driver_api) = {
 	.release = spi_sam0_release,
 };
 
-#if CONFIG_SPI_ASYNC
+#if CONFIG_SPI_SAM0_DMA
 #define SPI_SAM0_DMA_CHANNELS(n)					\
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(n, dmas), (                    \
 	.dma_dev = DEVICE_DT_GET(ATMEL_SAM0_DT_INST_DMA_CTLR(n, tx)),	\
 	.tx_dma_request = ATMEL_SAM0_DT_INST_DMA_TRIGSRC(n, tx),	\
 	.tx_dma_channel = ATMEL_SAM0_DT_INST_DMA_CHANNEL(n, tx),	\
 	.rx_dma_request = ATMEL_SAM0_DT_INST_DMA_TRIGSRC(n, rx),	\
-	.rx_dma_channel = ATMEL_SAM0_DT_INST_DMA_CHANNEL(n, rx),
+	.rx_dma_channel = ATMEL_SAM0_DT_INST_DMA_CHANNEL(n, rx),        \
+	))
 #else
 #define SPI_SAM0_DMA_CHANNELS(n)
 #endif

--- a/dts/bindings/spi/atmel,sam0-spi.yaml
+++ b/dts/bindings/spi/atmel,sam0-spi.yaml
@@ -53,3 +53,79 @@ properties:
 
       For example
          dma-names = "tx", "rx";
+
+examples:
+  - |
+    #Example devicetree configuration with DMA (recommended for best performance):
+
+    &sercom4 {
+            compatible = "atmel,sam0-spi";
+            status = "okay";
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            dipo = <0>;
+            dopo = <2>;
+
+            pinctrl-0 = <&sercom4_spi_default>;
+            pinctrl-names = "default";
+
+            /* DMA channels: TX on channel 0, RX on channel 1 */
+            dmas = <&dmac 0 TRIGSRC_SERCOM4_TX>,
+                   <&dmac 1 TRIGSRC_SERCOM4_RX>;
+            dma-names = "tx", "rx";
+    };
+
+  - |
+    #Example devicetree configuration without DMA (polling mode):
+
+    &sercom6 {
+            compatible = "atmel,sam0-spi";
+            status = "okay";
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            dipo = <0>;
+            dopo = <2>;
+
+            pinctrl-0 = <&sercom6_spi_default>;
+            pinctrl-names = "default";
+
+            /* No 'dmas' property -> driver uses polling transfer path */
+    };
+
+  - |
+    #Mixed configuration: one SPI instance uses DMA, another uses polling.
+    #Both instances coexist on the same SoC without conflict.
+
+    &sercom4 {
+            compatible = "atmel,sam0-spi";
+            status = "okay";
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            dipo = <0>;
+            dopo = <2>;
+
+            pinctrl-0 = <&sercom4_spi_default>;
+            pinctrl-names = "default";
+
+            dmas = <&dmac 0 TRIGSRC_SERCOM4_TX>,
+                   <&dmac 1 TRIGSRC_SERCOM4_RX>;
+            dma-names = "tx", "rx";
+    };
+
+    &sercom6 {
+            compatible = "atmel,sam0-spi";
+            status = "okay";
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            dipo = <0>;
+            dopo = <2>;
+
+            pinctrl-0 = <&sercom6_spi_default>;
+            pinctrl-names = "default";
+
+            /* Polling mode — no dmas property */
+    };


### PR DESCRIPTION
The SAM0 SPI driver previously supported DMA only for asynchronous operations, which required higher-level drivers needing blocking DMA transfers to implement workarounds. This patch extends DMA support to the synchronous transfer path, enabling efficient blocking SPI transactions without driver-specific hacks.

With this change, both synchronous and asynchronous SPI operations can leverage DMA for improved performance and reduced CPU overhead.