### PR TITLE
eventfd POSIX API deadlock fixes

### DIFF
--- a/lib/os/zvfs/zvfs_eventfd.c
+++ b/lib/os/zvfs/zvfs_eventfd.c
@@ -189,9 +189,6 @@ static int zvfs_eventfd_close_op(void *obj)
 	__ASSERT_NO_MSG(lock != NULL);
 	__ASSERT_NO_MSG(cond != NULL);
 
-	err = k_mutex_lock(lock, K_FOREVER);
-	__ASSERT(err == 0, "k_mutex_lock() failed: %d", err);
-
 	key = k_spin_lock(&efd->lock);
 
 	if (!zvfs_eventfd_is_in_use(efd)) {
@@ -213,8 +210,6 @@ unlock:
 	/* when closing an zvfs_eventfd, broadcast to all waiters */
 	err = k_condvar_broadcast(cond);
 	__ASSERT(err == 0, "k_condvar_broadcast() failed: %d", err);
-	err = k_mutex_unlock(lock);
-	__ASSERT(err == 0, "k_mutex_unlock() failed: %d", err);
 
 	return ret;
 }
@@ -351,10 +346,7 @@ static ssize_t zvfs_eventfd_rw_op(void *obj, void *buf, size_t sz,
 	__ASSERT_NO_MSG(lock != NULL);
 	__ASSERT_NO_MSG(cond != NULL);
 
-	/* do not hold a spinlock when taking a mutex */
 	k_spin_unlock(&efd->lock, key);
-	err = k_mutex_lock(lock, K_FOREVER);
-	__ASSERT(err == 0, "k_mutex_lock() failed: %d", err);
 
 	while (true) {
 		/* retake the spinlock */
@@ -368,13 +360,13 @@ static ssize_t zvfs_eventfd_rw_op(void *obj, void *buf, size_t sz,
 		case 0:
 			/* success! */
 			ret = sizeof(zvfs_eventfd_t);
-			goto unlock_mutex;
+			goto unlock;
 		default:
 			/* some other error */
 			__ASSERT_NO_MSG(ret < 0);
 			errno = -ret;
 			ret = -1;
-			goto unlock_mutex;
+			goto unlock;
 		}
 
 		/* do not hold a spinlock when taking a mutex */
@@ -385,13 +377,11 @@ static ssize_t zvfs_eventfd_rw_op(void *obj, void *buf, size_t sz,
 		__ASSERT(err == 0, "k_condvar_wait() failed: %d", err);
 	}
 
-unlock_mutex:
+unlock:
 	k_spin_unlock(&efd->lock, key);
 	/* only wake a single waiter */
 	err = k_condvar_signal(cond);
 	__ASSERT(err == 0, "k_condvar_signal() failed: %d", err);
-	err = k_mutex_unlock(lock);
-	__ASSERT(err == 0, "k_mutex_unlock() failed: %d", err);
 	goto out;
 
 unlock_spin:
@@ -450,14 +440,29 @@ int zvfs_eventfd_read(int fd, zvfs_eventfd_t *value)
 {
 	int ret;
 	void *obj;
+	int err;
+	struct k_mutex *lock = NULL;
+	struct k_condvar *cond = NULL;
 
 	obj = zvfs_get_fd_obj(fd, &zvfs_eventfd_fd_vtable, EBADF);
 	if (obj == NULL) {
 		return -1;
 	}
 
+	err = (int)zvfs_get_obj_lock_and_cond(obj, &zvfs_eventfd_fd_vtable, &lock, &cond);
+	__ASSERT((bool)err, "zvfs_get_obj_lock_and_cond() failed");
+	__ASSERT_NO_MSG(lock != NULL);
+	__ASSERT_NO_MSG(cond != NULL);
+
+	err = k_mutex_lock(lock, K_FOREVER);
+	__ASSERT(err == 0, "k_mutex_lock() failed: %d", err);
+
 	ret = zvfs_eventfd_rw_op(obj, value, sizeof(zvfs_eventfd_t), zvfs_eventfd_read_locked);
 	__ASSERT_NO_MSG(ret == -1 || ret == sizeof(zvfs_eventfd_t));
+
+	err = k_mutex_unlock(lock);
+	__ASSERT(err == 0, "k_mutex_unlock() failed: %d", err);
+
 	if (ret < 0) {
 		return -1;
 	}
@@ -469,14 +474,29 @@ int zvfs_eventfd_write(int fd, zvfs_eventfd_t value)
 {
 	int ret;
 	void *obj;
+	int err;
+	struct k_mutex *lock = NULL;
+	struct k_condvar *cond = NULL;
 
 	obj = zvfs_get_fd_obj(fd, &zvfs_eventfd_fd_vtable, EBADF);
 	if (obj == NULL) {
 		return -1;
 	}
 
+	err = (int)zvfs_get_obj_lock_and_cond(obj, &zvfs_eventfd_fd_vtable, &lock, &cond);
+	__ASSERT((bool)err, "zvfs_get_obj_lock_and_cond() failed");
+	__ASSERT_NO_MSG(lock != NULL);
+	__ASSERT_NO_MSG(cond != NULL);
+
+	err = k_mutex_lock(lock, K_FOREVER);
+	__ASSERT(err == 0, "k_mutex_lock() failed: %d", err);
+
 	ret = zvfs_eventfd_rw_op(obj, &value, sizeof(zvfs_eventfd_t), zvfs_eventfd_write_locked);
 	__ASSERT_NO_MSG(ret == -1 || ret == sizeof(zvfs_eventfd_t));
+
+	err = k_mutex_unlock(lock);
+	__ASSERT(err == 0, "k_mutex_unlock() failed: %d", err);
+
 	if (ret < 0) {
 		return -1;
 	}

--- a/lib/os/zvfs/zvfs_eventfd.c
+++ b/lib/os/zvfs/zvfs_eventfd.c
@@ -208,8 +208,7 @@ static int zvfs_eventfd_close_op(void *obj)
 unlock:
 	k_spin_unlock(&efd->lock, key);
 	/* when closing an zvfs_eventfd, broadcast to all waiters */
-	err = k_condvar_broadcast(cond);
-	__ASSERT(err == 0, "k_condvar_broadcast() failed: %d", err);
+	k_condvar_broadcast(cond);
 
 	return ret;
 }

--- a/tests/posix/eventfd/src/blocking.c
+++ b/tests/posix/eventfd/src/blocking.c
@@ -97,6 +97,29 @@ ZTEST_F(eventfd, test_read_then_write_block)
 	k_thread_join(&thread, K_FOREVER);
 }
 
+static void thread_eventfd_posix_read_42(void *arg1, void *arg2, void *arg3)
+{
+	uint64_t value;
+	struct eventfd_fixture *fixture = arg1;
+	int ret;
+
+	ret = read(fixture->fd, &value, sizeof(value));
+	zassert(ret == sizeof(value), "read(2) failed");
+	zassert_equal(value, 42);
+}
+
+ZTEST_F(eventfd, test_posix_read_then_write_block)
+{
+	k_thread_create(&thread, thread_stack, K_THREAD_STACK_SIZEOF(thread_stack),
+			thread_eventfd_posix_read_42, fixture, NULL, NULL, 0, 0, K_NO_WAIT);
+
+	k_msleep(100);
+
+	zassert_ok(eventfd_write(fixture->fd, 42));
+
+	k_thread_join(&thread, K_FOREVER);
+}
+
 static void thread_eventfd_write(void *arg1, void *arg2, void *arg3)
 {
 	struct eventfd_fixture *fixture = arg1;

--- a/tests/posix/eventfd/src/blocking.c
+++ b/tests/posix/eventfd/src/blocking.c
@@ -185,3 +185,23 @@ ZTEST_F(eventfd, test_read_while_pollout)
 
 	zassert_ok(k_thread_join(&thread, K_FOREVER));
 }
+
+static void thread_eventfd_close(void *arg1, void *arg2, void *arg3)
+{
+	struct eventfd_fixture *fixture = arg1;
+
+	zassert_ok(close(fixture->fd));
+}
+
+ZTEST_F(eventfd, test_read_then_close_block)
+{
+	eventfd_t value;
+
+	k_thread_create(&thread, thread_stack, K_THREAD_STACK_SIZEOF(thread_stack),
+			thread_eventfd_close, fixture, NULL, NULL, 0, 0, K_MSEC(100));
+
+	zassert_equal(read(fixture->fd, &value, sizeof(value)), -1);
+	printf("ERRNO: %d\n", errno);
+
+	k_thread_join(&thread, K_FOREVER);
+}


### PR DESCRIPTION
When eventfd is used through read(2) and write(2), the mutex is
already locked from the fdtable implementation. So we remove the
usage of the mutex from the zvfs_eventfd_*_op functions, as it is
already managed by fdtable.

However, when zvfs_eventfd_{read,write} are used, no fdtable layer
is used and we shuld call the _op function with the mutex locked
(the same behavior as with fdtable), so these functions should
manage the mutex. We add it there.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99234

**If this fix is correct, I can proceed to add the other missing tests before we merge.**