### PR TITLE
doc: release-notes-4.2: fix up TF-M version update entry

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -1395,8 +1395,8 @@ Other notable changes
   * 3.6.3: https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.3
   * 3.6.4: https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.4
 
-* Updated TF-M to version 2.1.2 (from 2.1.1). The release notes can be found at:
-  https://trustedfirmware-m.readthedocs.io/en/tf-mv2.1.2/releases/2.1.2.html
+* Updated TF-M to version 2.2.0 (from 2.1.1). The release notes can be found at:
+  https://trustedfirmware-m.readthedocs.io/en/latest/releases/2.2.0.html
 
 * Updated all boards with an external I2C connectors (Qwiic, Stemma, Grove...)
   to use the ``zephyr_i2c`` devicetree label. This allows using the existing


### PR DESCRIPTION
TF-M had already been updated to 2.2.0 by the time 4.2 was released. (https://github.com/zephyrproject-rtos/zephyr/pull/91169)