### PR TITLE
dts: nrf54lm20a: align GPIOTE IRQn to non-secure build

### DIFF
--- a/dts/arm/nordic/nrf54lm20a_enga_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54lm20a_enga_cpuapp.dtsi
@@ -75,11 +75,19 @@ nvic: &cpuapp_nvic {};
 };
 
 &gpiote20 {
+#ifdef USE_NON_SECURE_ADDRESS_MAP
+	interrupts = <218 NRF_DEFAULT_IRQ_PRIORITY>;
+#else
 	interrupts = <219 NRF_DEFAULT_IRQ_PRIORITY>;
+#endif
 };
 
 &gpiote30 {
+#ifdef USE_NON_SECURE_ADDRESS_MAP
+	interrupts = <268 NRF_DEFAULT_IRQ_PRIORITY>;
+#else
 	interrupts = <269 NRF_DEFAULT_IRQ_PRIORITY>;
+#endif
 };
 
 &dppic00 {


### PR DESCRIPTION
Use different GPIOTE interrupt number when building for cpuapp/ns.