### PR TITLE
drivers: can: nrf: use CAN_DEVICE_DT_INST_DEFINE

### DIFF
--- a/drivers/can/can_nrf.c
+++ b/drivers/can/can_nrf.c
@@ -201,8 +201,8 @@ static int can_nrf_init(const struct device *dev)
                                                                                                    \
 	static struct can_mcan_data can_mcan_nrf_data##n = CAN_MCAN_DATA_INITIALIZER(NULL);        \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, can_nrf_init, NULL, &can_mcan_nrf_data##n,                        \
-			      &can_mcan_nrf_config##n, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,      \
-			      &can_nrf_api);
+	CAN_DEVICE_DT_INST_DEFINE(n, can_nrf_init, NULL, &can_mcan_nrf_data##n,                    \
+				  &can_mcan_nrf_config##n, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,  \
+				  &can_nrf_api);
 
 DT_INST_FOREACH_STATUS_OKAY(CAN_NRF_DEFINE)


### PR DESCRIPTION
The can_nrf.c device driver used DEVICE_DT_INST_DEFINE instead of CAN_DEVICE_DT_INST_DEFINE, which means we are missing initialization of some CAN structures, namely STATS.

Update driver to use CAN_DEVICE_DT_INST_DEFINE()

Before update:
```
uart:~$ can show can@8d8000
core clock:      80000000 Hz
max bitrate:     8000000 bps
max std filters: 28
max ext filters: 8
capabilities:    normal loopback listen-only fd 
mode:            normal 
state:           stopped
rx errors:       0
tx errors:       0
timing:          sjw 1..128, prop_seg 0..0, phase_seg1 2..256, phase_seg2 2..128, prescaler 1..512
timing data:     sjw 1..16, prop_seg 0..0, phase_seg1 1..32, phase_seg2 1..16, prescaler 1..32
transceiver:     passive/none
statistics:
  bit errors:    16777472
    bit0 errors: 16777472
    bit1 errors: 16777472
  stuff errors:  54788352
  crc errors:    54800128
  form errors:   4992768
  ack errors:    327680
  rx overruns:   1095237632
```
after update:
```
uart:~$ can show can@8d8000
core clock:      80000000 Hz
max bitrate:     8000000 bps
max std filters: 28
max ext filters: 8
capabilities:    normal loopback listen-only fd 
mode:            normal 
state:           error-active
rx errors:       0
tx errors:       0
timing:          sjw 1..128, prop_seg 0..0, phase_seg1 2..256, phase_seg2 2..128, prescaler 1..512
timing data:     sjw 1..16, prop_seg 0..0, phase_seg1 1..32, phase_seg2 1..16, prescaler 1..32
transceiver:     passive/none
statistics:
  bit errors:    0
    bit0 errors: 0
    bit1 errors: 0
  stuff errors:  0
  crc errors:    0
  form errors:   0
  ack errors:    0
  rx overruns:   0
```

