### PR TITLE
smartbond_timer: Fix tick-base behavior

### DIFF
--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -81,11 +81,34 @@ static uint32_t timer_val_32_noupdate(void)
 	return val;
 }
 
+static void schedule_next_interrupt(uint32_t ticks)
+{
+	uint32_t timer_val;
+	uint32_t target_val;
+
+	timer_val = timer_val_32_noupdate();
+
+	/* Calculate target timer value and align to full tick */
+	target_val = timer_val + TICK_TO_CYC(ticks);
+	target_val = ((target_val + CYC_PER_TICK - 1) / CYC_PER_TICK) * CYC_PER_TICK;
+
+	set_reload(target_val);
+
+	/*
+	 * If time was so small that it already fired or should fire
+	 * just now, mark interrupt as pending to avoid losing timer event.
+	 * Condition is true when target_val (point in time that should be
+	 * used for wakeup) is behind timer value or is equal to it.
+	 * In that case we don't know if reload value was set in time or
+	 * not but time expired anyway so make sure that interrupt is pending.
+	 */
+	if ((int32_t)(target_val - timer_val_32_noupdate() - 1) < 0) {
+		NVIC_SetPendingIRQ(TIMER2_IRQn);
+	}
+}
+
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
-	uint32_t target_val;
-	uint32_t timer_val;
-
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
@@ -130,25 +153,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
 
-	timer_val = timer_val_32_noupdate();
-
-	/* Calculate target timer value and align to full tick */
-	target_val = timer_val + TICK_TO_CYC(ticks);
-	target_val = ((target_val + CYC_PER_TICK - 1) / CYC_PER_TICK) * CYC_PER_TICK;
-
-	set_reload(target_val);
-
-	/*
-	 * If time was so small that it already fired or should fire
-	 * just now, mark interrupt as pending to avoid losing timer event.
-	 * Condition is true when target_val (point in time that should be
-	 * used for wakeup) is behind timer value or is equal to it.
-	 * In that case we don't know if reload value was set in time or
-	 * not but time expired anyway so make sure that interrupt is pending.
-	 */
-	if ((int32_t)(target_val - timer_val_32_noupdate() - 1) < 0) {
-		NVIC_SetPendingIRQ(TIMER2_IRQn);
-	}
+	schedule_next_interrupt(ticks);
 }
 
 uint32_t sys_clock_elapsed(void)
@@ -192,6 +197,11 @@ static void timer2_isr(const void *arg)
 	last_isr_val_rounded += TICK_TO_CYC(dticks);
 	announced_ticks += dticks;
 	sys_clock_announce(dticks);
+
+	/* For tick-based kernel, schedule interrupt after 1 tick */
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		schedule_next_interrupt(1);
+	}
 }
 
 static int sys_clock_driver_init(void)


### PR DESCRIPTION
When system was configured to use smartbond_timer with tick-based kernel, timer interrupt could fire only once and then time would not advance.

Now when tick-based kernel is chosen timer2_isr() schedules that it should be fired at next tick.
Timer comparator calculation code was extracted from existing sys_clock_set_timeout() function
without change so it can be used for tick-less and tick-based kernel.

Fixes: #99262