### PR TITLE
soc: st: stm32: move POWEROFF entry sequence to common code

### DIFF
--- a/soc/st/stm32/common/CMakeLists.txt
+++ b/soc/st/stm32/common/CMakeLists.txt
@@ -3,8 +3,8 @@
 zephyr_include_directories(.)
 
 zephyr_sources(
-	stm32cube_hal.c
-	soc_config.c
+  stm32cube_hal.c
+  soc_config.c
 )
 
 if(DEFINED CONFIG_STM32_CCM)

--- a/soc/st/stm32/common/CMakeLists.txt
+++ b/soc/st/stm32/common/CMakeLists.txt
@@ -35,5 +35,6 @@ in STOP modes due to internal oscillators that remain active.")
 endif()
 
 zephyr_sources_ifdef(CONFIG_DCACHE stm32_cache.c)
+zephyr_sources_ifdef(CONFIG_POWEROFF poweroff_common.c)
 
 zephyr_sources_ifdef(CONFIG_STM32_BACKUP_PROTECTION stm32_backup_domain.c)

--- a/soc/st/stm32/common/poweroff_common.c
+++ b/soc/st/stm32/common/poweroff_common.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
+
+#include <cmsis_core.h>
+
+FUNC_NORETURN void stm32_enter_poweroff(void)
+{
+	/* Disable interrupts */
+	__disable_irq();
+
+	/* Enable SoC-specific low-power state */
+	SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+	/* Make sure IRQs don't set the Event Register */
+	SCB->SCR &= ~SCB_SCR_SEVONPEND_Msk;
+
+	/*
+	 * Trigger entry in low-power mode.
+	 *
+	 * Note that "sys_poweroff()" should only be called when
+	 * the system is in "a safe state", but we still make an
+	 * effort here to ensure entry low-power state suceeds
+	 * even if the system is still somewhat active...
+	 *
+	 * According to the ARM Architecture Reference Manual,
+	 * "[WFI is] the only architectually-defined mechanism
+	 * that completely suspends execution", but WFE is also
+	 * described as being able to suspend execution and make
+	 * the CPU enter in low-power state! In practice, both
+	 * instructions seem to trigger entry in low-power state.
+	 *
+	 * WFE can "guarantee" entry in low-power state despite
+	 * pending or incoming interrupts, but spurious Events
+	 * (as in "WFE wake-up event") turn it into a no-op; on
+	 * the other hand, WFI does ignore Events but not already
+	 * pending interrupts. Since spurious interrupts have a
+	 * higher chance of occurring, we try with WFE first then
+	 * fall back to WFI.
+	 *
+	 * The sequence is restarted forever; since this function
+	 * must never return anyways, it doesn't really matter.
+	 */
+
+	while (1) {
+		/* Clear the Event Register */
+		__SEV();
+		__WFE();
+
+		/*
+		 * Attempt entry in low-power state using WFE.
+		 *
+		 * This ought to always succeed because SEVONPEND=0,
+		 * interrupts are masked and we just cleared the Event
+		 * Register, but who knows...
+		 *
+		 * It can take up to two cycles for the processor
+		 * to actually turn off - NOPs are recommended here.
+		 */
+		__WFE();
+		__NOP();
+		__NOP();
+
+		/* WFE failed - try WFI instead */
+		__WFI();
+		__NOP();
+		__NOP();
+
+		/* Neither worked... try again */
+	}
+
+	CODE_UNREACHABLE;
+}

--- a/soc/st/stm32/common/stm32_common.h
+++ b/soc/st/stm32/common/stm32_common.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
+
+/**
+ * @brief Performs the entry-in-poweroff sequence.
+ *
+ * This function is reserved for internal usage by
+ * the SoC-specific z_sys_poweroff() implementations.
+ *
+ * It merely performs the architectural low-power entry
+ * sequence: the caller must configure the PWR registers
+ * with the proper low-power mode, clear all wake-up flags
+ * and possibly other operations (disable RAM retention,
+ * turn off DBGMCU, ...) before calling this function.
+ */
+FUNC_NORETURN void stm32_enter_poweroff(void);

--- a/soc/st/stm32/stm32c0x/poweroff.c
+++ b/soc/st/stm32/stm32c0x/poweroff.c
@@ -10,7 +10,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/drivers/misc/stm32_wkup_pins/stm32_wkup_pins.h>
 
-#include <stm32_ll_cortex.h>
+#include <stm32_common.h>
 #include <stm32_ll_pwr.h>
 #include <stm32_ll_system.h>
 
@@ -23,10 +23,7 @@ void z_sys_poweroff(void)
 	LL_PWR_ClearFlag_WU();
 
 	LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
-	LL_LPM_EnableDeepSleep();
 	LL_DBGMCU_DisableDBGStandbyMode();
 
-	k_cpu_idle();
-
-	CODE_UNREACHABLE;
+	stm32_enter_poweroff();
 }

--- a/soc/st/stm32/stm32f1x/poweroff.c
+++ b/soc/st/stm32/stm32f1x/poweroff.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stm32_ll_cortex.h>
+#include <stm32_common.h>
 #include <stm32_ll_pwr.h>
 
 #include <zephyr/kernel.h>
@@ -15,11 +15,7 @@ void z_sys_poweroff(void)
 	LL_PWR_ClearFlag_SB();
 	LL_PWR_ClearFlag_WU();
 
-	LL_LPM_DisableEventOnPend();
 	LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
-	LL_LPM_EnableDeepSleep();
 
-	k_cpu_idle();
-
-	CODE_UNREACHABLE;
+	stm32_enter_poweroff();
 }

--- a/soc/st/stm32/stm32f4x/poweroff.c
+++ b/soc/st/stm32/stm32f4x/poweroff.c
@@ -11,7 +11,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/drivers/misc/stm32_wkup_pins/stm32_wkup_pins.h>
 
-#include <stm32_ll_cortex.h>
+#include <stm32_common.h>
 #include <stm32_ll_pwr.h>
 
 void z_sys_poweroff(void)
@@ -19,9 +19,6 @@ void z_sys_poweroff(void)
 	LL_PWR_ClearFlag_WU();
 
 	LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
-	LL_LPM_EnableDeepSleep();
 
-	k_cpu_idle();
-
-	CODE_UNREACHABLE;
+	stm32_enter_poweroff();
 }

--- a/soc/st/stm32/stm32g0x/poweroff.c
+++ b/soc/st/stm32/stm32g0x/poweroff.c
@@ -11,7 +11,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/drivers/misc/stm32_wkup_pins/stm32_wkup_pins.h>
 
-#include <stm32_ll_cortex.h>
+#include <stm32_common.h>
 #include <stm32_ll_pwr.h>
 #include <stm32_ll_system.h>
 
@@ -28,10 +28,7 @@ void z_sys_poweroff(void)
 #else
 	LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
 #endif
-	LL_LPM_EnableDeepSleep();
 	LL_DBGMCU_DisableDBGStandbyMode();
 
-	k_cpu_idle();
-
-	CODE_UNREACHABLE;
+	stm32_enter_poweroff();
 }

--- a/soc/st/stm32/stm32l4x/poweroff.c
+++ b/soc/st/stm32/stm32l4x/poweroff.c
@@ -10,7 +10,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/drivers/misc/stm32_wkup_pins/stm32_wkup_pins.h>
 
-#include <stm32_ll_cortex.h>
+#include <stm32_common.h>
 #include <stm32_ll_pwr.h>
 #include <stm32_ll_system.h>
 
@@ -23,10 +23,7 @@ void z_sys_poweroff(void)
 	LL_PWR_ClearFlag_WU();
 
 	LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
-	LL_LPM_EnableDeepSleep();
 	LL_DBGMCU_DisableDBGStandbyMode();
 
-	k_cpu_idle();
-
-	CODE_UNREACHABLE;
+	stm32_enter_poweroff();
 }

--- a/soc/st/stm32/stm32u5x/poweroff.c
+++ b/soc/st/stm32/stm32u5x/poweroff.c
@@ -10,7 +10,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/drivers/misc/stm32_wkup_pins/stm32_wkup_pins.h>
 
-#include <stm32_ll_cortex.h>
+#include <stm32_common.h>
 #include <stm32_ll_pwr.h>
 
 void z_sys_poweroff(void)
@@ -20,11 +20,7 @@ void z_sys_poweroff(void)
 #endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_ClearFlag_WU();
-
 	LL_PWR_SetPowerMode(LL_PWR_SHUTDOWN_MODE);
-	LL_LPM_EnableDeepSleep();
 
-	k_cpu_idle();
-
-	CODE_UNREACHABLE;
+	stm32_enter_poweroff();
 }

--- a/soc/st/stm32/stm32wbax/poweroff.c
+++ b/soc/st/stm32/stm32wbax/poweroff.c
@@ -9,7 +9,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/drivers/misc/stm32_wkup_pins/stm32_wkup_pins.h>
 
-#include <stm32_ll_cortex.h>
+#include <stm32_common.h>
 #include <stm32_ll_pwr.h>
 
 void z_sys_poweroff(void)
@@ -24,9 +24,6 @@ void z_sys_poweroff(void)
 	LL_PWR_SetRadioSBRetention(LL_PWR_RADIO_SB_NO_RETENTION);
 	LL_PWR_SetSRAM1SBRetention(LL_PWR_SRAM1_SB_NO_RETENTION);
 	LL_PWR_SetSRAM2SBRetention(LL_PWR_SRAM2_SB_NO_RETENTION);
-	LL_LPM_EnableDeepSleep();
 
-	__WFI();
-
-	CODE_UNREACHABLE;
+	stm32_enter_poweroff();
 }

--- a/soc/st/stm32/stm32wbx/poweroff.c
+++ b/soc/st/stm32/stm32wbx/poweroff.c
@@ -10,7 +10,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/drivers/misc/stm32_wkup_pins/stm32_wkup_pins.h>
 
-#include <stm32_ll_cortex.h>
+#include <stm32_common.h>
 #include <stm32_ll_pwr.h>
 
 void z_sys_poweroff(void)
@@ -22,9 +22,6 @@ void z_sys_poweroff(void)
 	LL_PWR_ClearFlag_WU();
 
 	LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
-	LL_LPM_EnableDeepSleep();
 
-	k_cpu_idle();
-
-	CODE_UNREACHABLE;
+	stm32_enter_poweroff();
 }

--- a/soc/st/stm32/stm32wlx/poweroff.c
+++ b/soc/st/stm32/stm32wlx/poweroff.c
@@ -10,7 +10,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/drivers/misc/stm32_wkup_pins/stm32_wkup_pins.h>
 
-#include <stm32_ll_cortex.h>
+#include <stm32_common.h>
 #include <stm32_ll_pwr.h>
 
 void z_sys_poweroff(void)
@@ -22,9 +22,6 @@ void z_sys_poweroff(void)
 	LL_PWR_ClearFlag_WU();
 
 	LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
-	LL_LPM_EnableDeepSleep();
 
-	k_cpu_idle();
-
-	CODE_UNREACHABLE;
+	stm32_enter_poweroff();
 }


### PR DESCRIPTION
Move the architecture-specific (but implementation dependent!) code which performs entry in poweroff state (`Shutdown`/`Standby without retention`) to a common implementation shared by all STM32 SoC series. This is a first step and could be further refined at a later time; eventually, a unified `z_sys_poweroff()` implementation may even be possible.