### PR TITLE
net: Last minute TCP fixes

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -5762,7 +5762,6 @@ static void notify_iface_up(struct net_if *iface)
 
 static void notify_iface_down(struct net_if *iface)
 {
-	net_tcp_close_all_for_iface(iface);
 	net_if_flag_clear(iface, NET_IF_RUNNING);
 	net_mgmt_event_notify(NET_EVENT_IF_DOWN, iface);
 	net_virtual_disable(iface);
@@ -5773,6 +5772,12 @@ static void notify_iface_down(struct net_if *iface)
 		clear_joined_ipv6_mcast_groups(iface);
 		clear_joined_ipv4_mcast_groups(iface);
 		net_ipv4_autoconf_reset(iface);
+	}
+
+	if (IS_ENABLED(CONFIG_NET_NATIVE_TCP)) {
+		net_if_unlock(iface);
+		net_tcp_close_all_for_iface(iface);
+		net_if_lock(iface);
 	}
 }
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -3705,6 +3705,17 @@ int net_tcp_put(struct net_context *context, bool force_close)
 		({ const char *state = net_context_state(context);
 					state ? state : "<unknown>"; }));
 
+	if (force_close) {
+		k_work_cancel_delayable(&conn->send_data_timer);
+		keep_alive_timer_stop(conn);
+
+		k_mutex_unlock(&conn->lock);
+
+		tcp_conn_close(conn, -ENETRESET);
+
+		return 0;
+	}
+
 	if (conn->state == TCP_ESTABLISHED ||
 	    conn->state == TCP_SYN_RECEIVED) {
 		/* Send all remaining data if possible. */
@@ -3713,43 +3724,26 @@ int net_tcp_put(struct net_context *context, bool force_close)
 				conn->send_data_total);
 			conn->in_close = true;
 
-			if (force_close) {
-				k_work_cancel_delayable(&conn->send_data_timer);
-
-				keep_alive_timer_stop(conn);
-				tcp_conn_close(conn, -ENETRESET);
-			} else {
-				/* How long to wait until all the data has been sent?
-				 */
-				k_work_reschedule_for_queue(&tcp_work_q,
-							    &conn->send_data_timer,
-							    K_MSEC(TCP_RTO_MS));
-			}
+			/* How long to wait until all the data has been sent? */
+			k_work_reschedule_for_queue(&tcp_work_q,
+						    &conn->send_data_timer,
+						    K_MSEC(TCP_RTO_MS));
 
 		} else {
-			if (force_close) {
-				NET_DBG("[%p] TCP connection in %s close, "
-					"disposing immediately",
-					conn, "forced");
+			NET_ERR("[%p] TCP connection in %s close, "
+				"not disposing yet (waiting %dms)",
+				conn, "active", tcp_max_timeout_ms);
+			k_work_reschedule_for_queue(&tcp_work_q,
+							&conn->fin_timer,
+							FIN_TIMEOUT);
 
-				keep_alive_timer_stop(conn);
-				tcp_conn_close(conn, -ENETRESET);
-			} else {
-				NET_DBG("[%p] TCP connection in %s close, "
-					"not disposing yet (waiting %dms)",
-					conn, "active", tcp_max_timeout_ms);
-				k_work_reschedule_for_queue(&tcp_work_q,
-							    &conn->fin_timer,
-							    FIN_TIMEOUT);
+			tcp_out(conn, FIN | ACK);
+			conn_seq(conn, + 1);
+			tcp_setup_retransmission(conn);
 
-				tcp_out(conn, FIN | ACK);
-				conn_seq(conn, + 1);
-				tcp_setup_retransmission(conn);
+			conn_state(conn, TCP_FIN_WAIT_1);
 
-				conn_state(conn, TCP_FIN_WAIT_1);
-
-				keep_alive_timer_stop(conn);
-			}
+			keep_alive_timer_stop(conn);
 		}
 	} else if (conn->in_connect) {
 		conn->in_connect = false;

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -217,8 +217,13 @@ static void zsock_accepted_cb(struct net_context *new_ctx,
 		net_context_ref(new_ctx);
 
 		(void)k_condvar_signal(&parent->cond.recv);
-	}
+	} else if (status < 0) {
+		parent->user_data = INT_TO_POINTER(-status);
+		sock_set_error(parent);
 
+		k_fifo_cancel_wait(&parent->recv_q);
+		(void)k_condvar_signal(&parent->cond.recv);
+	}
 }
 
 static void zsock_received_cb(struct net_context *ctx,


### PR DESCRIPTION
* Fix error reporting on listening socket on iface down 
* Close the connection unconditionally on forced close to avoid issues with incorrect TCP context dereferencing
* Fix potential iface/TCP mutexes deadlock

Fixes #99242
Fixes #99245

