### PR TITLE
shell: allow empty prompt

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1688,7 +1688,7 @@ int shell_prompt_change(const struct shell *sh, const char *prompt)
 		return -EBUSY;
 	}
 
-	if ((prompt_length + 1 > CONFIG_SHELL_PROMPT_BUFF_SIZE) || (prompt_length == 0)) {
+	if (prompt_length + 1 > CONFIG_SHELL_PROMPT_BUFF_SIZE) {
 		z_shell_unlock(sh);
 		return -EINVAL;
 	}


### PR DESCRIPTION
Setting the prompt to the empty string allows it to be hidden. This is the intent of the shell command 'shell prompt off'. However, in the most recent change to the prompt handling, this functionality was lost. Presumably, the check for 'prompt_length == 0' was to avoid a NULL prompt. However, NULL is already checked for. Remove the zero-length check and restore the ability to set the prompt to the empty string.