### PR TITLE
arch: riscv + xtensa + x86: workaround needed for LLVM linker

### DIFF
--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -207,6 +207,15 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 int arch_thread_priv_stack_space_get(const struct k_thread *thread, size_t *stack_size,
 				     size_t *unused_ptr)
 {
+	if (!IS_ENABLED(CONFIG_INIT_STACKS) || !IS_ENABLED(CONFIG_THREAD_STACK_INFO)) {
+		/*
+		 * This is needed to ensure that the call to z_stack_space_get() below is properly
+		 * dead-stripped when linking using LLVM / lld. For more info, please see issue
+		 * #98491.
+		 */
+		return -EINVAL;
+	}
+
 	if ((thread->base.user_options & K_USER) != K_USER) {
 		return -EINVAL;
 	}

--- a/arch/x86/core/userspace.c
+++ b/arch/x86/core/userspace.c
@@ -189,6 +189,15 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 int arch_thread_priv_stack_space_get(const struct k_thread *thread, size_t *stack_size,
 				     size_t *unused_ptr)
 {
+	if (!IS_ENABLED(CONFIG_INIT_STACKS) || !IS_ENABLED(CONFIG_THREAD_STACK_INFO)) {
+		/*
+		 * This is needed to ensure that the call to z_stack_space_get() below is properly
+		 * dead-stripped when linking using LLVM / lld. For more info, please see issue
+		 * #98491.
+		 */
+		return -EINVAL;
+	}
+
 	struct z_x86_thread_stack_header *hdr_stack_obj;
 
 	if ((thread->base.user_options & K_USER) != K_USER) {

--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -240,6 +240,15 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 int arch_thread_priv_stack_space_get(const struct k_thread *thread, size_t *stack_size,
 				     size_t *unused_ptr)
 {
+	if (!IS_ENABLED(CONFIG_INIT_STACKS) || !IS_ENABLED(CONFIG_THREAD_STACK_INFO)) {
+		/*
+		 * This is needed to ensure that the call to z_stack_space_get() below is properly
+		 * dead-stripped when linking using LLVM / lld. For more info, please see issue
+		 * #98491.
+		 */
+		return -EINVAL;
+	}
+
 	struct xtensa_thread_stack_header *hdr_stack_obj;
 
 	if ((thread->base.user_options & K_USER) != K_USER) {


### PR DESCRIPTION
Due to slight differences in the way that LLVM and GNU linkers work, the call to `z_stack_space_get()` is not dead-stripped when linking with LLVM `lld` but it is dead-stripped when linking with GNU `ld`.

The `z_stack_space_get()` function is only available when `CONFIG_INIT_STACKS` and `CONFIG_THREAD_STACK_INFO` are defined. So add a workaround to `arch_thread_priv_stack_space_get()` for riscv, x86, and xtensa, to return an error earlier if those Kconfig options are not enabled. This triggers LLVM to strip the call to `z_stack_space_get()` as dead code.

The issue is reproducible (although requires building LLVM and setting up some environment variables) and goes away with the proposed workaround.

Fixes #98491