### PR TITLE
stm32/ltdc/dsi: correct properly use the pixel-format properties from ltdc node and mipi-dsi panel

### DIFF
--- a/boards/ruiside/art_pi/art_pi.dts
+++ b/boards/ruiside/art_pi/art_pi.dts
@@ -195,7 +195,7 @@
 	clocks = <&rcc STM32_CLOCK(APB3, 3)>, <&rcc STM32_SRC_PLL3_R NO_SEL>;
 	width = <800>;
 	height = <480>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 	def-back-color-red = <0X00>;
 	def-back-color-green = <0X00>;
 	def-back-color-blue = <0X00>;

--- a/boards/shields/arduino_giga_display_shield/boards/arduino_giga_r1_m7.overlay
+++ b/boards/shields/arduino_giga_display_shield/boards/arduino_giga_r1_m7.overlay
@@ -30,7 +30,7 @@
 	def-back-color-red = <0>;
 	def-back-color-green = <0>;
 	def-back-color-blue = <0>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 
 	disp-on-gpios = <&gpioc 6 GPIO_ACTIVE_HIGH>;
 	bl-ctrl-gpios = <&gpiob 12 GPIO_ACTIVE_HIGH>;

--- a/boards/shields/st_lcd_dsi_mb1835/st_lcd_dsi_mb1835.overlay
+++ b/boards/shields/st_lcd_dsi_mb1835/st_lcd_dsi_mb1835.overlay
@@ -89,7 +89,7 @@
 	status = "okay";
 	width = <480>;
 	height = <480>;
-	pixel-format = <PANEL_PIXEL_FORMAT_ARGB_8888>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 
 	bl-ctrl-gpios = <&dsi_lcd_qsh_030 53 GPIO_ACTIVE_HIGH>;
 

--- a/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -248,7 +248,7 @@
 
 	width = <240>;
 	height = <320>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 
 	display-timings {
 		compatible = "zephyr,panel-timing";

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -298,7 +298,7 @@ zephyr_udc0: &usbotg_fs {
 
 	width = <480>;
 	height = <272>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 
 	display-timings {
 		compatible = "zephyr,panel-timing";

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -285,7 +285,7 @@ zephyr_udc0: &usbotg_fs {
 
 	width = <480>;
 	height = <272>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 
 	display-timings {
 		compatible = "zephyr,panel-timing";

--- a/boards/st/stm32h750b_dk/stm32h750b_dk-common.dtsi
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk-common.dtsi
@@ -99,7 +99,7 @@
 
 	width = <480>;
 	height = <272>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 
 	display-timings {
 		compatible = "zephyr,panel-timing";

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -254,7 +254,7 @@ st_cam_i2c: &i2c4 {
 
 	width = <480>;
 	height = <272>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 
 	display-timings {
 		compatible = "zephyr,panel-timing";

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -332,7 +332,7 @@ zephyr_udc0: &usb2 {};
 
 	width = <800>;
 	height = <480>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 
 	display-timings {
 		compatible = "zephyr,panel-timing";

--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -247,7 +247,7 @@ csi_interface: &dcmipp {
 
 	width = <480>;
 	height = <272>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 
 	display-timings {
 		compatible = "zephyr,panel-timing";

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -503,7 +503,7 @@ zephyr_udc0: &usbotg_hs1 {
 
 	width = <800>;
 	height = <480>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 
 	display-timings {
 		compatible = "zephyr,panel-timing";

--- a/boards/witte/linum/linum.dts
+++ b/boards/witte/linum/linum.dts
@@ -389,7 +389,7 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 	width = <1024>;
 	height = <600>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 
 	display-timings {
 		compatible = "zephyr,panel-timing";

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -573,6 +573,11 @@ static DEVICE_API(display, stm32_ltdc_display_api) = {
 		frame_buffer_##inst[CONFIG_STM32_LTDC_FB_NUM * STM32_LTDC_FRAME_BUFFER_LEN(inst)];
 #endif
 
+/* LTDC supports RGB888 and RGB666 for output however only RGB_888 is supported for now */
+#if DT_INST_PROP(0, pixel_format) != PANEL_PIXEL_FORMAT_RGB_888
+#error "Only RGB_888 is supported as a LTDC output (aka panel or mipi-dsi input format)"
+#endif
+
 #define STM32_LTDC_DEVICE(inst)									\
 	STM32_LTDC_FRAME_BUFFER_DEFINE(inst);                       \
 	STM32_LTDC_DEVICE_PINCTRL_INIT(inst);							\

--- a/drivers/mipi_dsi/dsi_stm32.c
+++ b/drivers/mipi_dsi/dsi_stm32.c
@@ -21,16 +21,6 @@
 
 LOG_MODULE_REGISTER(dsi_stm32, CONFIG_MIPI_DSI_LOG_LEVEL);
 
-#if defined(CONFIG_STM32_LTDC_ARGB8888)
-#define STM32_DSI_INIT_PIXEL_FORMAT	DSI_RGB888
-#elif defined(CONFIG_STM32_LTDC_RGB888)
-#define STM32_DSI_INIT_PIXEL_FORMAT	DSI_RGB888
-#elif defined(CONFIG_STM32_LTDC_RGB565)
-#define STM32_DSI_INIT_PIXEL_FORMAT	DSI_RGB565
-#else
-#error "Invalid LTDC pixel format chosen"
-#endif /* CONFIG_STM32_LTDC_ARGB8888 */
-
 #define MAX_TX_ESC_CLK_KHZ 20000
 #define MAX_TX_ESC_CLK_DIV 8
 
@@ -272,6 +262,21 @@ static int mipi_dsi_stm32_host_init(const struct device *dev)
 	return 0;
 }
 
+static int mipi_dsi_stm32_set_colorcoding(uint32_t pixfmt, uint32_t *colorcoding)
+{
+	switch (pixfmt) {
+	case MIPI_DSI_PIXFMT_RGB888:
+		*colorcoding = DSI_RGB888;
+		break;
+	case MIPI_DSI_PIXFMT_RGB565:
+		*colorcoding = DSI_RGB565;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
 
 static int mipi_dsi_stm32_attach(const struct device *dev, uint8_t channel,
 				 const struct mipi_dsi_device *mdev)
@@ -287,7 +292,10 @@ static int mipi_dsi_stm32_attach(const struct device *dev, uint8_t channel,
 	}
 
 	vcfg->VirtualChannelID = channel;
-	vcfg->ColorCoding = STM32_DSI_INIT_PIXEL_FORMAT;
+	if (mipi_dsi_stm32_set_colorcoding(mdev->pixfmt, &vcfg->ColorCoding) < 0) {
+		LOG_ERR("MIPI PIXFMT not supported by the DSI host");
+		return -ENOTSUP;
+	}
 
 	if (mdev->mode_flags & MIPI_DSI_MODE_VIDEO_BURST) {
 		vcfg->Mode = DSI_VID_MODE_BURST;

--- a/dts/bindings/display/lcd-controller.yaml
+++ b/dts/bindings/display/lcd-controller.yaml
@@ -10,5 +10,6 @@ properties:
     type: int
     required: true
     description: |
-      Initial Pixel format for panel attached to this controller.
-      See dt-bindings/display/panel.h for a list
+      Initial Pixel format of this controller's output data, which is sent
+      to a panel directly or to an adapter.
+      See dt-bindings/display/panel.h for a list of pixel format.


### PR DESCRIPTION
So far the pixel-format properties from within the ltdc node is being set (mandatory in the yaml) but never used within the driver.
This is described in the yaml as the format used by the panel of the display-controller.
As a matter of fact, currently the LTDC controller only support RGB888 as output format of the controller (not to be confused with the format of data within the framebuffers, aka formats of the input layers of the LTDC).

The two first commits of this PR correct this, by checking that the pixel-format is well RGB888 and correct all formats written in dts.

Last commit correct the way MIPI-DSI is configured. Currently, the DSI format was set by looking at the LTDC format (which is in fact LTDC layer format) in order to set the ColorCoding of the MIPI-DSI. This is not correct since the ColorCoding has to be based on the format supported (and set) to the DSI panel.