### PR TITLE
MAINTAINERS: update TI MSPM0 maintainers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4872,6 +4872,7 @@ TI MSPM0 Platforms:
   status: maintained
   maintainers:
     - ssekar15
+    - d-philpot
   files:
     - soc/ti/mspm0/
     - boards/ti/lp_mspm0g3507/
@@ -5764,6 +5765,7 @@ West:
   maintainers:
     - vaishnavachath
     - ssekar15
+    - d-philpot
   files: []
   labels:
     - "platform: TI"


### PR DESCRIPTION
Adds d-philpot as maintainer for TI MSPM0 platform and hal-ti west project.