### PR TITLE
dts: arm: nxp: add missed sub-parts dtsi files

### DIFF
--- a/dts/arm/nxp/nxp_mcxe315.dtsi
+++ b/dts/arm/nxp/nxp_mcxe315.dtsi
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+
+/ {
+	soc {
+		itcm: memory@0 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x0 DT_SIZE_K(32)>;
+			zephyr,memory-region = "ITCM";
+		};
+
+		dtcm: memory@20000000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20000000 DT_SIZE_K(64)>;
+			zephyr,memory-region = "DTCM";
+		};
+
+		/* stdby_ram memory supports content retention in Standby mode */
+		stdby_ram: memory@20400000 {
+			compatible = "mmio-sram";
+			reg = <0x20400000 DT_SIZE_K(16)>;
+		};
+
+		peripheral: peripheral@40000000 {
+			ranges = <0x0 0x40000000 0x10000000>;
+		};
+	};
+};
+
+#include <nxp/nxp_mcxe31x_common.dtsi>
+
+&program_flash {
+	reg = <0x400000 DT_SIZE_K(512)>;
+};
+
+&peripheral {
+	/delete-node/ flexcan@310000;
+	/delete-node/ flexcan@314000;
+	/delete-node/ flexcan@318000;
+	/delete-node/ emac@480000;
+	/delete-node/ sai@36c000;
+	/delete-node/ sai@4dc000;
+	/delete-node/ lpuart@338000;
+	/delete-node/ lpuart@33c000;
+	/delete-node/ lpuart@340000;
+	/delete-node/ lpuart@344000;
+	/delete-node/ lpuart@48c000;
+	/delete-node/ lpuart@490000;
+	/delete-node/ lpuart@494000;
+	/delete-node/ lpuart@498000;
+	/delete-node/ lpuart@49c000;
+	/delete-node/ lpuart@4a0000;
+	/delete-node/ lpuart@4a4000;
+	/delete-node/ lpuart@4a8000;
+	/delete-node/ lpspi@4bc000;
+	/delete-node/ lpspi@4c0000;
+	/delete-node/ qspi@4cc000;
+	/delete-node/ adc@a8000;
+	/delete-node/ lpcmp@374000;
+	/delete-node/ lpcmp@4e8000;
+	/delete-node/ pit@2fc000;
+	/delete-node/ stm@474000;
+	/delete-node/ emios@90000;
+};

--- a/dts/arm/nxp/nxp_mcxe316.dtsi
+++ b/dts/arm/nxp/nxp_mcxe316.dtsi
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+
+/ {
+	soc {
+		itcm: memory@0 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x0 DT_SIZE_K(32)>;
+			zephyr,memory-region = "ITCM";
+		};
+
+		dtcm: memory@20000000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20000000 DT_SIZE_K(64)>;
+			zephyr,memory-region = "DTCM";
+		};
+
+		/* stdby_ram memory supports content retention in Standby mode */
+		stdby_ram: memory@20400000 {
+			compatible = "mmio-sram";
+			reg = <0x20400000 DT_SIZE_K(32)>;
+		};
+
+		peripheral: peripheral@40000000 {
+			ranges = <0x0 0x40000000 0x10000000>;
+		};
+	};
+};
+
+#include <nxp/nxp_mcxe31x_common.dtsi>
+
+&program_flash {
+	reg = <0x400000 DT_SIZE_K(1024)>;
+};
+
+&peripheral {
+	/delete-node/ flexcan@310000;
+	/delete-node/ flexcan@314000;
+	/delete-node/ flexcan@318000;
+	/delete-node/ emac@480000;
+	/delete-node/ sai@36c000;
+	/delete-node/ sai@4dc000;
+	/delete-node/ lpuart@338000;
+	/delete-node/ lpuart@33c000;
+	/delete-node/ lpuart@340000;
+	/delete-node/ lpuart@344000;
+	/delete-node/ lpuart@48c000;
+	/delete-node/ lpuart@490000;
+	/delete-node/ lpuart@494000;
+	/delete-node/ lpuart@498000;
+	/delete-node/ lpuart@49c000;
+	/delete-node/ lpuart@4a0000;
+	/delete-node/ lpuart@4a4000;
+	/delete-node/ lpuart@4a8000;
+	/delete-node/ lpspi@4bc000;
+	/delete-node/ lpspi@4c0000;
+	/delete-node/ qspi@4cc000;
+	/delete-node/ adc@a8000;
+	/delete-node/ lpcmp@374000;
+	/delete-node/ lpcmp@4e8000;
+	/delete-node/ pit@2fc000;
+	/delete-node/ stm@474000;
+	/delete-node/ emios@90000;
+};

--- a/dts/arm/nxp/nxp_mcxe317.dtsi
+++ b/dts/arm/nxp/nxp_mcxe317.dtsi
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+
+/ {
+	soc {
+		itcm: memory@0 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x0 DT_SIZE_K(32)>;
+			zephyr,memory-region = "ITCM";
+		};
+
+		dtcm: memory@20000000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x20000000 DT_SIZE_K(64)>;
+			zephyr,memory-region = "DTCM";
+		};
+
+		/* stdby_ram memory supports content retention in Standby mode */
+		stdby_ram: memory@20400000 {
+			compatible = "mmio-sram";
+			reg = <0x20400000 DT_SIZE_K(32)>;
+		};
+
+		/* sram memory is available only in Run mode */
+		sram: memory@20408000 {
+			compatible = "mmio-sram";
+			reg = <0x20408000 DT_SIZE_K(64)>;
+		};
+
+		peripheral: peripheral@40000000 {
+			ranges = <0x0 0x40000000 0x10000000>;
+		};
+	};
+};
+
+#include <nxp/nxp_mcxe31x_common.dtsi>
+
+&program_flash {
+	reg = <0x400000 DT_SIZE_K(2048)>;
+};
+
+&peripheral {
+	/delete-node/ emac@480000;
+	/delete-node/ sai@36c000;
+	/delete-node/ sai@4dc000;
+	/delete-node/ lpuart@48c000;
+	/delete-node/ lpuart@490000;
+	/delete-node/ lpuart@494000;
+	/delete-node/ lpuart@498000;
+	/delete-node/ lpuart@49c000;
+	/delete-node/ lpuart@4a0000;
+	/delete-node/ lpuart@4a4000;
+	/delete-node/ lpuart@4a8000;
+	/delete-node/ lpspi@4bc000;
+	/delete-node/ lpspi@4c0000;
+	/delete-node/ qspi@4cc000;
+	/delete-node/ adc@a8000;
+	/delete-node/ lpcmp@4e8000;
+	/delete-node/ pit@2fc000;
+	/delete-node/ stm@474000;
+	/delete-node/ emios@90000;
+};


### PR DESCRIPTION
- Add back missed sub-parts dtsi files for mcxe31x platform
- This subparts files won't affect the default supported cases on frdm board