### PR TITLE
arch: arm64: mmu: Call k_panic() when translation tables exhausted

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -54,7 +54,15 @@ static uint64_t *new_table(void)
 		}
 	}
 
-	LOG_ERR("CONFIG_MAX_XLAT_TABLES, too small");
+#if defined(CONFIG_LOG)
+	LOG_ERR("CONFIG_MAX_XLAT_TABLES is too small");
+#else
+	printk("ERROR: CONFIG_MAX_XLAT_TABLES is too small\n");
+#endif
+
+	/* Unfortunately many code paths are not ready for failure */
+	k_panic();
+
 	return NULL;
 }
 


### PR DESCRIPTION

When CONFIG_MAX_XLAT_TABLES is too small and new_table() cannot allocate
a translation table, the system must halt rather than continue with
undefined behavior.

This change ensures k_panic() is called after reporting the error,
preventing the system from proceeding when it runs out of translation
tables. Additionally, adds printk() fallback for configurations where
CONFIG_LOG is disabled to ensure the error is always visible.
