### PR TITLE
net: dhcpv4: fix incorrect RFC2131 section reference to 4.4.1

### DIFF
--- a/subsys/net/lib/dhcpv4/Kconfig
+++ b/subsys/net/lib/dhcpv4/Kconfig
@@ -25,7 +25,7 @@ config NET_DHCPV4_INITIAL_DELAY_MAX
 	default 10
 	range 2 10
 	help
-	  As per RFC2131 4.1.1, we wait a random period between
+	  As per RFC2131 4.4.1, we wait a random period between
 	  1 and 10 seconds before sending the initial discover.
 
 config NET_DHCPV4_OPTION_CALLBACKS

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1833,7 +1833,7 @@ static void dhcpv4_start_internal(struct net_if *iface, bool first_start)
 
 		/* Use default */
 		if (first_start) {
-			/* RFC2131 4.1.1 requires we wait a random period
+			/* RFC2131 4.4.1 requires we wait a random period
 			 * between 1 and 10 seconds before sending the initial
 			 * discover.
 			 */

--- a/subsys/net/lib/dhcpv4/dhcpv4_internal.h
+++ b/subsys/net/lib/dhcpv4/dhcpv4_internal.h
@@ -102,7 +102,7 @@ struct dhcp_msg {
  * initial DISCOVER message. MAx value is defined with
  * CONFIG_NET_DHCPV4_INITIAL_DELAY_MAX. Default max value
  * should be 10.
- * RFC2131 4.1.1
+ * RFC2131 4.4.1
  */
 #define DHCPV4_INITIAL_DELAY_MIN 1
 


### PR DESCRIPTION
Corrected the RFC2131 section reference in DHCPv4 comments and help text. The random delay before sending the initial DHCPDISCOVER message is defined in Section 4.4.1 of RFC2131, not in 4.1.1 as previously stated.