### PR TITLE
tests: arch: arm_irq_vector_table: Update to run on smartbond

### DIFF
--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -175,7 +175,7 @@ void sys_clock_disable(void)
 	TIMER2->TIMER2_CTRL_REG &= ~TIMER2_TIMER2_CTRL_REG_TIM_EN_Msk;
 }
 
-static void timer2_isr(const void *arg)
+void timer2_isr(const void *arg)
 {
 	uint32_t val;
 	int32_t delta;

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -267,6 +267,17 @@ const vth __irq_vector_table _irq_vector_table[IRQ_VECTOR_TABLE_SIZE] = {
 #endif
 };
 
+#elif defined(CONFIG_SOC_FAMILY_RENESAS_SMARTBOND)
+
+extern void timer2_isr(void);
+
+const vth __irq_vector_table _irq_vector_table[] = {
+	[_ISR_OFFSET] = isr0,
+	[_ISR_OFFSET + 1] = isr1,
+	[_ISR_OFFSET + 2] = isr2,
+	[TIMER2_IRQn] = timer2_isr,
+};
+
 #else
 
 #if defined(CONFIG_MCUX_OS_TIMER)


### PR DESCRIPTION
Update the custom vector table to have timer2_isr that is used for kernel system timer.

While test passes test immediate crashes afterwards due to missing handler for non-SysTick interrupt.

Now custom interrupt table has additional interrupt handler to prevent crash.
timer2_isr is no longer static that should not result in any conflict.

Fixes: #99288 
Similar to fix for other platform: #36526