### PR TITLE
boards: nxp: mimxrt700_evk: Upgrade the onboard chip to B0 silicon

### DIFF
--- a/boards/nxp/mimxrt700_evk/flash_config/flash_config.h
+++ b/boards/nxp/mimxrt700_evk/flash_config/flash_config.h
@@ -9,10 +9,6 @@
 #include <stdint.h>
 #include "fsl_common.h"
 
-#ifndef FSL_FEATURE_SILICON_VERSION_A
-#define FSL_FEATURE_SILICON_VERSION_A (1U)
-#endif
-
 /* XSPI memory config block related definitions */
 #define FC_XSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */
 #define FC_XSPI_CFG_BLK_VERSION (0x56010400UL) /* V1.4.0 */

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/nxp_imx/rt/MIMXRT798SGFOA-pinctrl.h>
+#include <nxp/nxp_imx/rt/MIMXRT798SGFOB-pinctrl.h>
 
 &pinctrl {
 	pinmux_flexcomm0_lpuart: pinmux_flexcomm0_lpuart {

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: ee1ab8aa1909d800d83ae71a379387c54ab733b3
+      revision: d622701b7fced803edb96b979fb97c10e8518759
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
- Update used pinctrl files for mimxrt700_evk
- Update FCB settings from SDK