### PR TITLE
modules: hal_nordic: nrfx: allow SWD pins as GPIOs

### DIFF
--- a/dts/bindings/arm/nordic,nrf-tampc.yaml
+++ b/dts/bindings/arm/nordic,nrf-tampc.yaml
@@ -1,0 +1,19 @@
+description: Nordic TAMPC (Tamper Controller)
+
+compatible: "nordic,nrf-tampc"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  swd-pins-as-gpios:
+    type: boolean
+    description: |
+      When enabled this property will configure pins dedicated to SWD
+      peripheral as regular GPIOs.
+
+      SWD pins in nRF54LS05B: P1.29 and P1.30
+
+      This setting, once applied, can only be unset by device reset.

--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -200,7 +200,9 @@ if(DEFINED uicr_path)
 
   dt_prop(gpio_as_nreset PATH ${uicr_path} PROPERTY "gpio-as-nreset")
   if(${gpio_as_nreset})
-    zephyr_library_compile_definitions(CONFIG_GPIO_AS_PINRESET)
+    zephyr_library_compile_definitions(
+      NRF_CONFIG_GPIO_AS_PINRESET
+    )
   endif()
 endif()
 

--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -204,6 +204,16 @@ if(DEFINED uicr_path)
   endif()
 endif()
 
+dt_nodelabel(tampc_path NODELABEL "tampc")
+if(DEFINED tampc_path)
+  dt_prop(swd_pins_as_gpios PATH ${tampc_path} PROPERTY "swd-pins-as-gpios")
+  if(${swd_pins_as_gpios})
+    zephyr_library_compile_definitions(
+      NRF_CONFIG_SWD_PINS_AS_GPIOS
+    )
+  endif()
+endif()
+
 if(CONFIG_SOC_NRF54L_CPUAPP_COMMON)
   # Ideally, hfpll should taken as a phandle from clocks property from cpu but it
   # seems that there is no such option in DT cmake functions. Assuming that nrf54l


### PR DESCRIPTION
Added binding and CMake script that enables MDK located in nrfx to configure SWD pins as GPIOs.

Also introduced a minor fix for symbol naming after alignment in MDK.