### PR TITLE
boards: st: stm32h7s78_dk: add Ethernet support

### DIFF
--- a/boards/st/stm32h7s78_dk/doc/index.rst
+++ b/boards/st/stm32h7s78_dk/doc/index.rst
@@ -181,6 +181,7 @@ Default Zephyr Peripheral Mapping:
 - XSPI1 NCS/DQS0/DQS1/CLK/IO: PO0/PO2/PO3/PO4/PP0..15
 - I2C1 SCL/SDA: PB6/PB9
 - FDCAN1 RX/TX : PB8/PB9
+- ETH: PA2/PA7/PB0/PB1/PC1/PC4/PC5/PD7/PG11
 
 System Clock
 ------------
@@ -207,6 +208,12 @@ FDCAN
 STM32H7S78-DK Discovery board has 2 FDCAN bus interfaces.
 FDCAN1 is configured but not enabled by default. To enable it, make sure
 that ``i2c1`` is disabled, since they share the PB9 pin.
+
+Ethernet
+--------
+
+In order to use Ethernet on STM32H7S78-DK, you need to set the ``JP6`` jumper
+to PC1 position on the back side of the board.
 
 Programming and Debugging
 *************************

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -11,6 +11,11 @@
 #include "zephyr/dt-bindings/display/panel.h"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
+/*
+ * WARNING:
+ * JP6 must be in PC1 position when using Ethernet.
+ */
+
 / {
 	chosen {
 		zephyr,console = &uart4;
@@ -226,6 +231,31 @@
 	 * reference: DS14359 Rev 4 page 134
 	 */
 	status = "disabled";
+};
+
+&mac {
+	pinctrl-0 = <&eth_rmii_ref_clk_pd7
+		     &eth_rmii_crs_dv_pa7
+		     &eth_rmii_rxd0_pc4
+		     &eth_rmii_rxd1_pc5
+		     &eth_rmii_tx_en_pg11
+		     &eth_rmii_txd0_pb0
+		     &eth_rmii_txd1_pb1>;
+	pinctrl-names = "default";
+	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
+	status = "okay";
+};
+
+&mdio {
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
 };
 
 &xspi1 {

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.yaml
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.yaml
@@ -17,4 +17,5 @@ supported:
   - octospi
   - usbd
   - memc
+  - netif:eth
 vendor: st

--- a/tests/drivers/memc/ram/boards/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.overlay
+++ b/tests/drivers/memc/ram/boards/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2025 Benjamin Klaric <benjamin.klaric01@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
## Changes

- Added `mac` and `mdio` configuration to `stm32h7s78_dk-common.dtsi` and enabled them. The RMII Ethernet pin configuration follows this schematic from ST: [MB1736](https://www.st.com/resource/en/schematic_pack/mb1736-h7s7l8-d01-schematic.pdf).
- ~Added fallback option for definition of `sram_eth_node` in `mpu_regions.c` and `sections.ld`. This definition earlier defaulted to `sram2`, but now has `sram1` as fallback option.~ ~Defined the SRAM region for Ethernet descriptor and buffer
using `memory-regions = <...>` in the `mac` node (as discussed) and added the updated definition of `sram_eth_node` to `mpu_regions.c` and `sections.ld`. Also added the needed property in `dts/bindings/ethernet/st,stm32h7-ethernet.yaml`.~
  - ~Added `memory-regions = <...>` to `boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts`, since they use the same `mpu_regions.c` and `sections.ld`.~
- Updated `stm32h7s78_dk.yaml` ~and `stm32h7s78_dk_stm32h7s7xx_ext_flash_app.yaml`~ to include the Ethernet tag.
- Updated `index.rst` to include the Ethernet feature and documented the steps needed in order to use Ethernet for this board.
- Added `tests/drivers/memc/ram/boards/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.overlay` and updated `tests/drivers/memc/ram/boards/stm32h7s78_dk.overlay` since Ethernet drivers fully consume `sram1` node and thus fail the test without the additions.
- ~Added `#memory-region-cells = <0>;` to all possible memory regions (`sram1` and `sram2` nodes) in `dts/arm/st/h7rs/stm32h7rs.dtsi`~

## Tests

I tested these changes with the following examples:

- [dumb_http_server](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/net/sockets/dumb_http_server)
- [http_server](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/net/sockets/http_server)

I could ping the board after flashing both samples and also open the website in the browser. Everything worked as expected.

## Notes

I opened #99164 in order to discuss how to implement the fallback for `sram2` and whether this approach is correct. Taking a look at the discussion should answer some questions about the implementation.

Closes #99164