### PR TITLE
net: http_server: No Error ENETDOWN

### DIFF
--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -612,9 +612,14 @@ static int http_server_run(struct http_server_ctx *ctx)
 					continue;
 				}
 
-				/* Listening socket error, abort. */
-				LOG_ERR("Listening socket error, aborting.");
 				ret = -sock_error;
+
+				if (ret == -ENETDOWN) {
+					LOG_INF("Network is down");
+				} else {
+					LOG_ERR("Listening socket error, aborting. (%d)", ret);
+				}
+
 				goto closing;
 
 			}


### PR DESCRIPTION
Set Log Level to Info when the HTTP socket reports ENETDOWN, instead of logging an error each time the network is down.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99792