### PR TITLE
doc: migration-buide-4.3: Remove empty Architectures section

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -553,6 +553,3 @@ Trusted Firmware-M
   the in-tree versions of these modules will be used instead. To use custom versions, create a
   :ref:`west manifest <west-manifest-files>` which pulls in the desired versions of these
   repositories instead.
-
-Architectures
-*************


### PR DESCRIPTION
There's no content in this section, so just remove it.