### PR TITLE
docs: bindings-syntax: re-add note about `title` being optional

### DIFF
--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -73,9 +73,9 @@ These keys are explained in the following sections.
 Title
 *****
 
-Short description of the bound device, typically the hardware model. It should
-typically be on the format "Vendor Family Model". If acronyms are used, they
-should be spelled out in parentheses. The naming should stay as close to the
+An *optional*, short description of the bound device, typically the hardware model.
+It should typically be of the format "Vendor Family Model". If acronyms are used,
+they should be spelled out in parentheses. The naming should stay as close to the
 vendor datasheet as possible.
 
 Titles should not exceed 100 characters. The description field should be used


### PR DESCRIPTION
When originally introduced in ee17657ad3290465e8255c8c9da7efbd5343f789, `title` was described as optional, but this information was lost when the documentation was reworked in 3a2f839d459ae20597f1bc4af0e78d35a68b5dd4, even though the underlying behavior in `edtlib` is unchanged:
https://github.com/zephyrproject-rtos/zephyr/blob/9ef73c88f6bc4721277933f57f893f81989beb68/scripts/dts/python-devicetree/src/devicetree/edtlib.py#L187-L189

Add a note to specify that `title` is still optional (but recommended) and indicate that `description` should be short when `title` is not used.