### PR TITLE
doc: releases: cosmetic/typo fixes to 4.3 release notes & migration guide

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -58,7 +58,7 @@ Base Libraries
   The old Kconfig option still exists, but will be overridden if the custom requirements
   are larger. To force the old Kconfig option to be used, even when its value is less
   than the indicated custom requirements, a new :kconfig:option:`CONFIG_ZVFS_OPEN_IGNORE_MIN`
-  option has been introduced (which defaults being disabled).
+  option has been introduced (which defaults to being disabled).
 
 Boards
 ******
@@ -83,7 +83,7 @@ Boards
   (> v0.12.0) in which the HLA/SWD transport has been deprecated (see
   https://review.openocd.org/c/openocd/+/8523 and commit
   https://sourceforge.net/p/openocd/code/ci/34ec5536c0ba3315bc5a841244bbf70141ccfbb4/).
-  Issues may be encountered when connecting to an ST-Link adapter running firmware prior
+  Issues may be encountered when connecting to an ST-Link adapter running firmware prior to
   v2j24 which do not support the new transport. In this case, the ST-Link firmware should
   be upgraded or, if not possible, the OpenOCD configuration script should be changed to
   source "interface/stlink-hla.cfg" and select the "hla_swd" interface explicitly.
@@ -134,7 +134,7 @@ DMA
 
 * DMA no longer implements user mode syscalls as part of its API. The syscalls were determined to be
   too broadly defined in access and impossible to implement the syscall parameter verification step
-  in another.
+  in a safe manner.
 
 Ethernet
 ========
@@ -147,21 +147,21 @@ Ethernet
   enabled in the Xilinx GEM Ethernet driver (:dtcompatible:`xlnx,gem`). By default, offloading is
   now enabled by default to improve performance, however, offloading is always disabled for QEMU
   targets due to the checksum generation in hardware not being emulated regardless of whether it
-  is explicitly disabled via the devicetree or not. (:github:`95435`)
+  is explicitly disabled via the Devicetree or not. (:github:`95435`)
 
-    * Replaced devicetree property ``rx-checksum-offload`` which enabled RX checksum offloading
-      ``disable-rx-checksum-offload`` which now actively disables it.
-    * Replaced devicetree property ``tx-checksum-offload`` which enabled TX checksum offloading
-      ``disable-tx-checksum-offload`` which now actively disables it.
+  * Replaced Devicetree property ``rx-checksum-offload`` which enabled RX checksum offloading
+    ``disable-rx-checksum-offload`` which now actively disables it.
+  * Replaced Devicetree property ``tx-checksum-offload`` which enabled TX checksum offloading
+    ``disable-tx-checksum-offload`` which now actively disables it.
 
 * The Xilinx GEM Ethernet driver (:dtcompatible:`xlnx,gem`) now obtains the AMBA AHB data bus
   width matching the current target SoC (either Zynq-7000 or ZynqMP) from a design configuration
-  register at run-time, making the devicetree property ``amba-ahb-dbus-width`` obsolete, which
+  register at run-time, making the Devicetree property ``amba-ahb-dbus-width`` obsolete, which
   has therefore been removed.
 
 * The :dtcompatible:`nxp,enet-mac` and :dtcompatible:`xlnx,gem` drivers are no longer configuring
   the link speed and duplex mode of the phy via  :c:func:`phy_configure_link` during initialization.
-  Instead, the user has to use the ``default-speeds`` devicetree property of the phy, if they want
+  Instead, the user has to use the ``default-speeds`` Devicetree property of the phy, if they want
   to restrict the advertised speeds for auto-negotiation, when the mac only supports a subset of the
   phy supported speeds. (:github:`91572`)
 
@@ -240,11 +240,11 @@ Bluetooth Controller
 
 * The following have been renamed:
 
-    * :kconfig:option:`CONFIG_BT_CTRL_ADV_ADI_IN_SCAN_RSP` to
-      :kconfig:option:`CONFIG_BT_CTLR_ADV_ADI_IN_SCAN_RSP`
-    * :c:struct:`bt_hci_vs_fata_error_cpu_data_cortex_m` to
-      :c:struct:`bt_hci_vs_fatal_error_cpu_data_cortex_m` and now contains the program counter
-      value.
+  * :kconfig:option:`CONFIG_BT_CTRL_ADV_ADI_IN_SCAN_RSP` to
+    :kconfig:option:`CONFIG_BT_CTLR_ADV_ADI_IN_SCAN_RSP`
+  * :c:struct:`bt_hci_vs_fata_error_cpu_data_cortex_m` to
+    :c:struct:`bt_hci_vs_fatal_error_cpu_data_cortex_m` and now contains the program counter
+    value.
 
 .. zephyr-keep-sorted-start re(^\w)
 
@@ -264,7 +264,7 @@ Bluetooth Audio
 * The BAP Scan Delegator will no longer automatically update the PA sync state, and
   :c:func:`bt_bap_scan_delegator_set_pa_state` must be used to update the state. If the
   BAP Scan Delegator is used together with the BAP Broadcast Sink, then the PA state of the
-  receive state of a  :c:struct:`bt_bap_broadcast_sink` will still be automatically updated when the
+  receive state of a :c:struct:`bt_bap_broadcast_sink` will still be automatically updated when the
   PA state changes. (:github:`95453`)
 
 
@@ -273,7 +273,7 @@ Bluetooth Audio
 Bluetooth HCI
 =============
 
-* The deprecated ``ipm`` value was removed from ``bt-hci-bus`` devicetree property.
+* The deprecated ``ipm`` value was removed from ``bt-hci-bus`` Devicetree property.
   ``ipc`` should be used instead.
 
 Bluetooth Mesh
@@ -296,13 +296,13 @@ Power management
 ****************
 
 * :kconfig:option:`CONFIG_PM_S2RAM` and :kconfig:option:`PM_S2RAM_CUSTOM_MARKING` have been
-  refactored to be automatically managed by SoCs and the devicetree. Applications shall no
+  refactored to be automatically managed by SoCs and the Devicetree. Applications shall no
   longer enable them directly, instead, enable or disable the "suspend-to-ram" power states
-  in the devicetree.
+  in the Devicetree.
 
-* For the NXP RW61x, the devicetree property ``exit-latency-us`` has been updated to reflect more
+* For the NXP RW61x, the Devicetree property ``exit-latency-us`` has been updated to reflect more
   accurate, measured wake-up times. For applications utilizing Standby mode (PM3), this update and
-  an increase to the ``min-residency-us`` devicetree property may influence how the system
+  an increase to the ``min-residency-us`` Devicetree property may influence how the system
   transitions between power modes. In some cases, this could lead to changes in power consumption.
 
 Networking
@@ -361,7 +361,7 @@ PTP Clock
 *********
 
 * The doc of :c:func:`ptp_clock_rate_adjust` API didn't provide proper and clear function description.
-  Drivers implemented it to adjust rate ratio relatively based on current frequency.
+  Drivers implemented it to adjust rate ratio relative to the current frequency.
   Now PI servo is introduced in both PTP and gPTP, and this API function is changed to use for rate
   ratio adjusting based on nominal frequency. Drivers implementing :c:func:`ptp_clock_rate_adjust`
   should be adjusted to account for the new behavior.
@@ -458,7 +458,7 @@ Shell
 =====
 
 * The MQTT topics related to :kconfig:option:`SHELL_BACKEND_MQTT` have been renamed. Renamed
-  ``<device_id>_rx`` to ``<device_id>/sh/rx`` and ``<device_id>_tx`` to ``<device_id>/sh/rx``. The
+  ``<device_id>_rx`` to ``<device_id>/sh/rx`` and ``<device_id>_tx`` to ``<device_id>/sh/tx``. The
   part after the ``<device_id>`` is now configurable via :kconfig:option:`SHELL_MQTT_TOPIC_RX_ID`
   and :kconfig:option:`SHELL_MQTT_TOPIC_TX_ID`. This allows keeping the previous topics for backward
   compatibility.
@@ -483,7 +483,7 @@ MCUboot
 =======
 
 * The default operating mode for MCUboot has been changed to swap using offset, this provides
-  faster swap updates needed less overhead and reduces the flash endurance cycles required to
+  faster swap updates, needs less overhead, and reduces the flash endurance cycles required to
   perform an update, the previous default was swap using move. If a board was optimised for swap
   using move by having a primary slot that was one sector larger than the secondary then this
   needs to change to have the secondary slot one sector larger than the primary (for optimised
@@ -496,14 +496,14 @@ Silabs
 
 * Aligned the name of the Rail options with the other SiSDK related options:
 
-   * :kconfig:option:`CONFIG_RAIL_PA_CURVE_HEADER` to
-     :kconfig:option:`CONFIG_SILABS_SISDK_RAIL_PA_CURVE_HEADER`
-   * :kconfig:option:`CONFIG_RAIL_PA_CURVE_TYPES_HEADER` to
-     :kconfig:option:`CONFIG_SILABS_SISDK_RAIL_PA_CURVE_TYPES_HEADER`
-   * :kconfig:option:`CONFIG_RAIL_PA_ENABLE_CALIBRATION` to
-     :kconfig:option:`CONFIG_SILABS_SISDK_RAIL_PA_ENABLE_CALIBRATION`
+  * :kconfig:option:`CONFIG_RAIL_PA_CURVE_HEADER` to
+    :kconfig:option:`CONFIG_SILABS_SISDK_RAIL_PA_CURVE_HEADER`
+  * :kconfig:option:`CONFIG_RAIL_PA_CURVE_TYPES_HEADER` to
+    :kconfig:option:`CONFIG_SILABS_SISDK_RAIL_PA_CURVE_TYPES_HEADER`
+  * :kconfig:option:`CONFIG_RAIL_PA_ENABLE_CALIBRATION` to
+    :kconfig:option:`CONFIG_SILABS_SISDK_RAIL_PA_ENABLE_CALIBRATION`
 
-* Fixed name of the :kconfig:option:`CONFIG_SOC_*`. These option contained PART_NUMBER in their
+* Fixed name of the :kconfig:option:`CONFIG_SOC_*`. These options contained PART_NUMBER in their
   while they shouldn't.
 
 * The separate ``em3`` power state was removed from Series 2 SoCs. The system automatically
@@ -530,19 +530,19 @@ Trusted Firmware-M
   TF-M NS and require BL2 must have their flash layout with the flash controller
   information. This will ensure that when signing the hex/bin files all the
   details will be present in the S and NS images. The image now has the details
-  to allow the FWU state machine be correct and allow FOTA.
+  to allow the FWU state machine to be correct and allow FOTA.
   (:github:`94470`)
 
-    * The ``--align`` parameter was fixed to 1. Now, it's set to the flash DT ``write_block_size``
-      property, but still provides 1 as a fallback for specific vendors.
-    * The ``--max-sectors`` value is now calculated based on the number of images, taking into
-      consideration the largest image size.
-    * The ``--confirm`` option now confirms both S and NS HEX images, ensuring that any image
-      that runs is valid for production and development.
-    * S and NS BIN images are now available. These are the correct images to be used in FOTA. Note
-      that S and NS images are unconfirmed by default, and the application is responsible for
-      confirming them with ``psa_fwu_accept()``. Otherwise, the images will roll back on the next
-      reboot.
+  * The ``--align`` parameter was fixed to 1. Now, it's set to the flash DT ``write_block_size``
+    property, but still provides 1 as a fallback for specific vendors.
+  * The ``--max-sectors`` value is now calculated based on the number of images, taking into
+    consideration the largest image size.
+  * The ``--confirm`` option now confirms both S and NS HEX images, ensuring that any image
+    that runs is valid for production and development.
+  * S and NS BIN images are now available. These are the correct images to be used in FOTA. Note
+    that S and NS images are unconfirmed by default, and the application is responsible for
+    confirming them with ``psa_fwu_accept()``. Otherwise, the images will roll back on the next
+    reboot.
 
 * A compatibility issue was identified in the TF-M attestation procedure introduced
   after the TF-M v2.1.0 release. As a result, systems using TF-M v2.1 cannot be

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -159,6 +159,12 @@ Ethernet
   register at run-time, making the devicetree property ``amba-ahb-dbus-width`` obsolete, which
   has therefore been removed.
 
+* The :dtcompatible:`nxp,enet-mac` and :dtcompatible:`xlnx,gem` drivers are no longer configuring
+  the link speed and duplex mode of the phy via  :c:func:`phy_configure_link` during initialization.
+  Instead, the user has to use the ``default-speeds`` devicetree property of the phy, if they want
+  to restrict the advertised speeds for auto-negotiation, when the mac only supports a subset of the
+  phy supported speeds. (:github:`91572`)
+
 MFD
 ===
 

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -559,6 +559,3 @@ Trusted Firmware-M
   the in-tree versions of these modules will be used instead. To use custom versions, create a
   :ref:`west manifest <west-manifest-files>` which pulls in the desired versions of these
   repositories instead.
-
-Architectures
-*************

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -136,6 +136,29 @@ DMA
   too broadly defined in access and impossible to implement the syscall parameter verification step
   in another.
 
+Ethernet
+========
+
+* The :dtcompatible:`microchip,vsc8541` PHY driver now expects the reset-gpios entry to specify
+  the GPIO_ACTIVE_LOW flag when the reset is being used as active low. Previously the active-low
+  nature was hard-coded into the driver. (:github:`91726`).
+
+* CRC checksum generation offloading to hardware is now explicitly disabled rather then explicitly
+  enabled in the Xilinx GEM Ethernet driver (:dtcompatible:`xlnx,gem`). By default, offloading is
+  now enabled by default to improve performance, however, offloading is always disabled for QEMU
+  targets due to the checksum generation in hardware not being emulated regardless of whether it
+  is explicitly disabled via the devicetree or not. (:github:`95435`)
+
+    * Replaced devicetree property ``rx-checksum-offload`` which enabled RX checksum offloading
+      ``disable-rx-checksum-offload`` which now actively disables it.
+    * Replaced devicetree property ``tx-checksum-offload`` which enabled TX checksum offloading
+      ``disable-tx-checksum-offload`` which now actively disables it.
+
+* The Xilinx GEM Ethernet driver (:dtcompatible:`xlnx,gem`) now obtains the AMBA AHB data bus
+  width matching the current target SoC (either Zynq-7000 or ZynqMP) from a design configuration
+  register at run-time, making the devicetree property ``amba-ahb-dbus-width`` obsolete, which
+  has therefore been removed.
+
 MFD
 ===
 
@@ -262,29 +285,6 @@ Bluetooth Host
   available when :kconfig:option:`CONFIG_BT_APP_PASSKEY` is enabled. The application can return the
   passkey for pairing, or :c:macro:`BT_PASSKEY_RAND` for the Host to generate a random passkey
   instead.
-
-Ethernet
-========
-
-* The :dtcompatible:`microchip,vsc8541` PHY driver now expects the reset-gpios entry to specify
-  the GPIO_ACTIVE_LOW flag when the reset is being used as active low. Previously the active-low
-  nature was hard-coded into the driver. (:github:`91726`).
-
-* CRC checksum generation offloading to hardware is now explicitly disabled rather then explicitly
-  enabled in the Xilinx GEM Ethernet driver (:dtcompatible:`xlnx,gem`). By default, offloading is
-  now enabled by default to improve performance, however, offloading is always disabled for QEMU
-  targets due to the checksum generation in hardware not being emulated regardless of whether it
-  is explicitly disabled via the devicetree or not. (:github:`95435`)
-
-    * Replaced devicetree property ``rx-checksum-offload`` which enabled RX checksum offloading
-      ``disable-rx-checksum-offload`` which now actively disables it.
-    * Replaced devicetree property ``tx-checksum-offload`` which enabled TX checksum offloading
-      ``disable-tx-checksum-offload`` which now actively disables it.
-
-* The Xilinx GEM Ethernet driver (:dtcompatible:`xlnx,gem`) now obtains the AMBA AHB data bus
-  width matching the current target SoC (either Zynq-7000 or ZynqMP) from a design configuration
-  register at run-time, making the devicetree property ``amba-ahb-dbus-width`` obsolete, which
-  has therefore been removed.
 
 Power management
 ****************

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -42,13 +42,13 @@ Major enhancements with this release include:
 **CPU load and dynamic frequency scaling subsystems**
   A new experimental :ref:`CPU frequency <cpu_freq>` scaling subsystem enables dynamic,
   policy-driven, clock adjustments to balance power consumption and performance.
-  Alongside it, a new :ref:`cpu_load` subsystem allows to obtain CPU usage metrics based on
+  Alongside it, a new :ref:`cpu_load` subsystem allows users to obtain CPU usage metrics based on
   scheduler statistics, which can be used to drive the frequency scaling policy.
 
 **Instrumentation Subsystem**
   A new :ref:`instrumentation subsystem <instrumentation>` simplifies tracing and profiling of
-  Zephyr applications by leveraging compiler-managed function instrumentation, allowing to record
-  call-graph traces and statistical profiles at runtime.
+  Zephyr applications by leveraging compiler-managed function instrumentation, allowing the
+  recording of call-graph traces and statistical profiles at runtime.
 
 **OCPP 1.6 library**
   A new :ref:`OCPP (Open Charge Point Protocol) <ocpp_interface>` library enables EV charging
@@ -115,9 +115,9 @@ Removed APIs and options
 * The legacy pipe object API was removed. Use the new pipe API instead.
 * ``bt_le_set_auto_conn``
 * ``CONFIG_BT_BUF_ACL_RX_COUNT``
-* ``ok`` enum value has now been removed completely from ``base.yaml`` binding ``status`` property in devicetree.
-* STM32 LPTIM clock source selection through Kconfig was removed. Device Tree must now be used instead.
-  Affected Kconfig symbols: ``CONFIG_STM32_LPTIM_CLOCK_LSI`` / ``CONFIG_STM32_LPTIM_CLOCK_LSI``
+* ``ok`` enum value has now been removed completely from ``base.yaml`` binding ``status`` property in Devicetree.
+* STM32 LPTIM clock source selection through Kconfig was removed. Devicetree must now be used instead.
+  Affected Kconfig symbols: :kconfig:option:`CONFIG_STM32_LPTIM_CLOCK_LSI` / :kconfig:option:`CONFIG_STM32_LPTIM_CLOCK_LSE`
 
 Deprecated APIs and options
 ===========================
@@ -437,7 +437,7 @@ New APIs and options
   * Wi-Fi
 
     * :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_DEBUG_SHOW_KEYS`
-    * Set enterprise crypto insecure because certifcate validation is disabled.
+    * Set enterprise crypto insecure because certificate validation is disabled.
     * If the usage mode option has AP enabled, then automatically enable AP mode.
     * Add configuration options for background scanning (bgscan) in wpa_supplicant.
     * Add support for multiple virtual interfaces (VIF).
@@ -458,7 +458,7 @@ New APIs and options
    * :c:func:`pm_device_driver_deinit`
    * :kconfig:option:`CONFIG_PM_DEVICE_RUNTIME_DEFAULT_ENABLE`
    * :kconfig:option:`CONFIG_PM_S2RAM` has been refactored to be promptless. The application now
-     only needs to enable any "suspend-to-ram" power state in the devicetree.
+     only needs to enable any "suspend-to-ram" power state in the Devicetree.
    * The :kconfig:option:`PM_S2RAM_CUSTOM_MARKING` has been renamed to
      :kconfig:option:`HAS_PM_S2RAM_CUSTOM_MARKING` and refactored to be promptless. This option
      is now selected by SoCs if they need it for their "suspend-to-ram" implementations.

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -229,6 +229,11 @@ New APIs and options
     * :kconfig:option:`CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88`
     * :kconfig:option:`CONFIG_SDL_DISPLAY_COLOR_TINT`
 
+* Ethernet
+
+   * The devicetree property ``default-speeds`` was added to most of the ethernet phys to configure
+     the advertised speeds for auto-negotiation during initialization of the driver.
+
 * Haptics
 
   * :kconfig:option:`CONFIG_HAPTICS_SHELL`


### PR DESCRIPTION
Fixes a few minor typos / copy-paste errors, etc.