### PR TITLE
samples: drivers: led: pwm: Add fallback blink delay calculation

### DIFF
--- a/samples/drivers/led/pwm/Kconfig
+++ b/samples/drivers/led/pwm/Kconfig
@@ -26,4 +26,40 @@ config FADE_DELAY
 	  The brightness gradually increases by one level each time this
 	  delay elapses.
 
+config BLINK_DELAY_AUTO_FALLBACK
+	bool "Enable automatic fallback to calculated delays"
+	default y
+	help
+	  When enabled, if the configured blink delays fail (e.g., exceed
+	  PWM period), the sample will automatically calculate appropriate
+	  delays from the LED's PWM period.
+
+config BLINK_DELAY_SHORT_LED_PERIOD_DIV
+	int "Divisor for auto-calculating short blink delay from PWM period"
+	default 10
+	depends on BLINK_DELAY_AUTO_FALLBACK
+	help
+	  When CONFIG_BLINK_DELAY_SHORT exceeds the timer's range, this divisor
+	  is used to automatically calculate the short blink delay from the
+	  LED's PWM period defined in the devicetree.
+
+	  Formula: delay_ms = (pwm_period_ms / DIVISOR / 2)
+
+	  The division by 2 is because the delay applies to each phase
+	  (on OR off) separately, not the total period.
+
+config BLINK_DELAY_LONG_LED_PERIOD_DIV
+	int "Divisor for auto-calculating long blink delay from PWM period"
+	default 1
+	depends on BLINK_DELAY_AUTO_FALLBACK
+	help
+	  When CONFIG_BLINK_DELAY_LONG exceeds the timer's range, this divisor
+	  is used to automatically calculate the long blink delay from the
+	  LED's PWM period defined in the devicetree.
+
+	  Formula: delay_ms = (pwm_period_ms / DIVISOR / 2)
+
+	  The division by 2 is because the delay applies to each phase
+	  (on OR off) separately, not the total period.
+
 source "Kconfig.zephyr"

--- a/samples/drivers/led/pwm/README.rst
+++ b/samples/drivers/led/pwm/README.rst
@@ -25,6 +25,20 @@ For each PWM LEDs (one after the other):
 - Blinking on: 1 sec, off: 1 sec
 - Turning off
 
+Fallback Blink Delay Calculation
+=================================
+
+When the configured blink delays exceed the platform's timer range limitations,
+the sample automatically calculates fallback delays based on each LED's PWM
+period defined in the devicetree. The calculation uses configurable divisors:
+
+- Short delay = LED PWM period / :kconfig:option:`CONFIG_BLINK_DELAY_SHORT_LED_PERIOD_DIV` / 2
+- Long delay = LED PWM period / :kconfig:option:`CONFIG_BLINK_DELAY_LONG_LED_PERIOD_DIV` / 2
+
+This ensures the sample works correctly on platforms with timer limitations by
+providing hardware-appropriate delays that are compatible with each LED's PWM
+configuration.
+
 Building and Running
 ********************
 

--- a/samples/drivers/led/pwm/src/main.c
+++ b/samples/drivers/led/pwm/src/main.c
@@ -20,6 +20,43 @@ const char *led_label[] = {
 	DT_FOREACH_CHILD_SEP_VARGS(LED_PWM_NODE_ID, DT_PROP_OR, (,), label, NULL)
 };
 
+#if CONFIG_BLINK_DELAY_AUTO_FALLBACK
+/* Generic macro to get PWM period for each child */
+#define GET_LED_PERIOD(node_id) DT_PWMS_PERIOD(node_id),
+
+/* Create array of PWM periods */
+static const uint32_t led_periods_ns[] = {
+	DT_FOREACH_CHILD(LED_PWM_NODE_ID, GET_LED_PERIOD)
+};
+
+/**
+ * @brief Automatically calculate and apply a fallback blink delay for an LED
+ *
+ * This function calculates an appropriate blink delay based on the LED's PWM period
+ * when the requested delay exceeds the PWM hardware capabilities. The delay is
+ * calculated by dividing the PWM period by a divisor and ensuring a minimum
+ * visibility threshold.
+ *
+ * @param led_pwm LED PWM device
+ * @param led LED index to configure
+ * @param led_delay Pointer to store the calculated delay (in milliseconds)
+ * @param div Divisor to scale down the PWM period for delay calculation
+ *
+ * @return 0 on success, negative error code on failure from led_blink()
+ */
+static int blink_delay_auto_fallback(const struct device *led_pwm, uint8_t led,
+					uint32_t *led_delay, uint32_t div)
+{
+	*led_delay = led_periods_ns[led] / 1000000 / div / 2;
+	/* Ensure minimum 1ms for visibility */
+	*led_delay = MAX(1, *led_delay);
+
+	LOG_INF("Auto-calculated delay: %u ms.", *led_delay);
+
+	return led_blink(led_pwm, led, *led_delay, *led_delay);
+}
+#endif
+
 const int num_leds = ARRAY_SIZE(led_label);
 
 #define MAX_BRIGHTNESS	100
@@ -34,6 +71,7 @@ static void run_led_test(const struct device *led_pwm, uint8_t led)
 {
 	int err;
 	int16_t level;
+	uint32_t led_delay;
 
 	LOG_INF("Testing LED %d - %s", led, led_label[led] ? : "no label");
 
@@ -80,31 +118,43 @@ static void run_led_test(const struct device *led_pwm, uint8_t led)
 	k_sleep(K_MSEC(1000));
 
 #if CONFIG_BLINK_DELAY_SHORT > 0
+	led_delay = (uint32_t)CONFIG_BLINK_DELAY_SHORT;
 	/* Start LED blinking (short cycle) */
-	err = led_blink(led_pwm, led, CONFIG_BLINK_DELAY_SHORT, CONFIG_BLINK_DELAY_SHORT);
+	err = led_blink(led_pwm, led, led_delay, led_delay);
 	if (err < 0) {
-		LOG_ERR("err=%d", err);
-		return;
+#if CONFIG_BLINK_DELAY_AUTO_FALLBACK && CONFIG_BLINK_DELAY_SHORT_LED_PERIOD_DIV > 0
+		LOG_INF("CONFIG_BLINK_DELAY_SHORT (%u ms) exceeds PWM capabilities for LED %u.",
+			led_delay, led);
+		err = blink_delay_auto_fallback(led_pwm, led, &led_delay,
+			(uint32_t)CONFIG_BLINK_DELAY_SHORT_LED_PERIOD_DIV);
+#endif
+		if (err < 0) {
+			LOG_ERR("err=%d", err);
+			return;
+		}
 	}
-	LOG_INF("  Blinking "
-		"on: " STRINGIFY(CONFIG_BLINK_DELAY_SHORT) " msec, "
-		"off: " STRINGIFY(CONFIG_BLINK_DELAY_SHORT) " msec");
+	LOG_INF("  Blinking on: %u msec, off: %u msec", led_delay, led_delay);
 	k_sleep(K_MSEC(5000));
 #endif
 
 #if CONFIG_BLINK_DELAY_LONG > 0
+	led_delay = (uint32_t)CONFIG_BLINK_DELAY_LONG;
 	/* Start LED blinking (long cycle) */
-	err = led_blink(led_pwm, led, CONFIG_BLINK_DELAY_LONG, CONFIG_BLINK_DELAY_LONG);
+	err = led_blink(led_pwm, led, led_delay, led_delay);
 	if (err < 0) {
-		LOG_ERR("err=%d", err);
-		LOG_INF("  Cycle period not supported - "
-			"on: " STRINGIFY(CONFIG_BLINK_DELAY_LONG) "  msec, "
-			"off: " STRINGIFY(CONFIG_BLINK_DELAY_LONG) " msec");
-	} else {
-		LOG_INF("  Blinking "
-			"on: " STRINGIFY(CONFIG_BLINK_DELAY_LONG) " msec, "
-			"off: " STRINGIFY(CONFIG_BLINK_DELAY_LONG) " msec");
+#if CONFIG_BLINK_DELAY_AUTO_FALLBACK && CONFIG_BLINK_DELAY_LONG_LED_PERIOD_DIV > 0
+		LOG_INF("CONFIG_BLINK_DELAY_LONG (%u ms) exceeds PWM capabilities for LED %u.",
+			led_delay, led);
+		err = blink_delay_auto_fallback(led_pwm, led, &led_delay,
+			(uint32_t)CONFIG_BLINK_DELAY_LONG_LED_PERIOD_DIV);
+#endif
+		if (err < 0) {
+			LOG_ERR("err=%d", err);
+			LOG_INF("  Cycle period not supported - on: %u msec, "
+				"off: %u msec", led_delay, led_delay);
+		}
 	}
+	LOG_INF("  Blinking on: %u msec, off: %u msec", led_delay, led_delay);
 	k_sleep(K_MSEC(5000));
 #endif
 


### PR DESCRIPTION
When CONFIG_BLINK_DELAY_SHORT or CONFIG_BLINK_DELAY_LONG exceed the timer's range, automatically calculate blink delays from the LED's PWM period defined in devicetree using configurable divisors.

Add led_periods_ns array to store PWM periods for each LED and new Kconfig options BLINK_DELAY_SHORT_LED_PERIOD_DIV and BLINK_DELAY_LONG_LED_PERIOD_DIV to control the calculation.

This ensures the LED PWM sample works on platforms with timer limitations by providing hardware-appropriate fallback delays.