### PR TITLE
drivers: can: mcux: flexcan: add dynamic memory allocation for MB

### DIFF
--- a/boards/nxp/mr_canhubk3/doc/index.rst
+++ b/boards/nxp/mr_canhubk3/doc/index.rst
@@ -143,11 +143,8 @@ flexcan5         | PTC11  | PTC11_CAN0_RX  P22/P23
    and support maximum 32 message buffers for concurrent active instances with 8 bytes
    payload. We need to pay attention to configuration options:
 
-   1. :kconfig:option:`CONFIG_CAN_MAX_MB` must be less or equal than the
+   1. :kconfig:option:`CONFIG_CAN_MAX_FILTER` must be less or equal than the
       maximum number of message buffers that is according to the table below.
-
-   2. :kconfig:option:`CONFIG_CAN_MAX_FILTER` must be less or equal than
-      :kconfig:option:`CONFIG_CAN_MAX_MB`.
 
 ===============  ==========  ================  ================
 Devicetree node  Payload     Hardware support  Software support

--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -28,29 +28,18 @@ config CAN_MCUX_FLEXCAN_WAIT_TIMEOUT
 	  Maximum number of wait loop iterations for the MCUX FlexCAN HAL when entering/leaving
 	  freeze mode.
 
-config CAN_MAX_MB
-	int "Maximum number of message buffers for concurrent active instances"
-	default 16
-	depends on SOC_SERIES_S32K3 || SOC_SERIES_S32K1 || SOC_SERIES_S32ZE
-	range 1 96 if SOC_SERIES_S32K3
-	range 1 32 if SOC_SERIES_S32K1 && !SOC_S32K142W && !SOC_S32K144W
-	range 1 64 if SOC_S32K142W || SOC_S32K144W
-	range 1 128 if SOC_SERIES_S32ZE
-	help
-	  Defines maximum number of message buffers for concurrent active instances.
-
 config CAN_MAX_FILTER
 	int "Maximum number of concurrent active RX filters"
 	default 5
-	range 1 15 if SOC_SERIES_KINETIS_KE1XF || SOC_SERIES_KINETIS_K6X
-	range 1 13 if (SOC_SERIES_IMXRT10XX || SOC_SERIES_IMXRT11XX) && CAN_MCUX_FLEXCAN_FD
-	range 1 63 if SOC_SERIES_IMXRT10XX || SOC_SERIES_IMXRT11XX
-	range 1 96 if SOC_SERIES_S32K3
-	range 1 32 if SOC_SERIES_S32K1 && !SOC_S32K142W && !SOC_S32K144W
-	range 1 64 if SOC_S32K142W || SOC_S32K144W
-	range 1 128 if SOC_SERIES_S32ZE
 	help
 	  Defines maximum number of concurrent active RX filters
+
+config CAN_MCUX_FLEXCAN_HEAP_SIZE
+	int "The heap memory pool that FlexCAN message buffer needed"
+	default 2048
+	help
+	  Defines the heap memory pool size for FlexCAN message buffer allocation
+	  This can be adjusted based on specific platform
 
 endif # CAN_MCUX_FLEXCAN
 

--- a/dts/arm/nxp/nxp_k66.dtsi
+++ b/dts/arm/nxp/nxp_k66.dtsi
@@ -32,6 +32,7 @@
 					  "rx-warning", "wake-up";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1030 4>;
 			clk-source = <1>;
+			nxp,max-mb = <16>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -518,6 +518,7 @@
 			interrupt-names = "mb-0-15", "bus-off", "error", "tx-warning", "rx-warning", "wake-up";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 4>;
 			clk-source = <1>;
+			nxp,max-mb = <16>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -411,6 +411,7 @@
 					  "mb-0-15";
 			clocks = <&scg KINETIS_SCG_BUS_CLK>;
 			clk-source = <1>;
+			nxp,max-mb = <16>;
 			status = "disabled";
 		};
 
@@ -422,6 +423,7 @@
 					  "mb-0-15";
 			clocks = <&scg KINETIS_SCG_BUS_CLK>;
 			clk-source = <1>;
+			nxp,max-mb = <16>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -266,6 +266,7 @@
 			interrupt-names = "common";
 			clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 			clk-source = <0>;
+			nxp,max-mb = <32>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/nxp_mcxa344.dtsi
@@ -256,6 +256,7 @@
 			interrupt-names = "common";
 			clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 			clk-source = <0>;
+			nxp,max-mb = <32>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxe245.dtsi
+++ b/dts/arm/nxp/nxp_mcxe245.dtsi
@@ -39,12 +39,14 @@
 	compatible = "nxp,flexcan";
 	interrupts = <85 0>, <86 0>, <88 0>;
 	interrupt-names = "ored-warning-bus-off", "error", "mb-0-15";
+	nxp,max-mb = <16>;
 };
 
 &flexcan2 {
 	compatible = "nxp,flexcan";
 	interrupts = <92 0>, <93 0>, <95 0>;
 	interrupt-names = "ored-warning-bus-off", "error", "mb-0-15";
+	nxp,max-mb = <16>;
 };
 
 /delete-node/ &ftm4;

--- a/dts/arm/nxp/nxp_mcxe246.dtsi
+++ b/dts/arm/nxp/nxp_mcxe246.dtsi
@@ -39,6 +39,7 @@
 	compatible = "nxp,flexcan";
 	interrupts = <92 0>, <93 0>, <95 0>;
 	interrupt-names = "ored-warning-bus-off", "error", "mb-0-15";
+	nxp,max-mb = <16>;
 };
 
 /delete-node/ &ftm4;

--- a/dts/arm/nxp/nxp_mcxe24x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxe24x_common.dtsi
@@ -263,6 +263,7 @@
 				"wake-up", "mb-0-15", "mb-16-31";
 			clocks = <&scg KINETIS_SCG_CORESYS_CLK>;
 			clk-source = <0>;
+			nxp,max-mb = <32>;
 			status = "disabled";
 		};
 
@@ -273,6 +274,7 @@
 			interrupt-names = "ored-warning-bus-off", "error", "mb-0-15", "mb-16-31";
 			clocks = <&scg KINETIS_SCG_CORESYS_CLK>;
 			clk-source = <0>;
+			nxp,max-mb = <32>;
 			status = "disabled";
 		};
 
@@ -283,6 +285,7 @@
 			interrupt-names = "ored-warning-bus-off", "error", "mb-0-15", "mb-16-31";
 			clocks = <&scg KINETIS_SCG_CORESYS_CLK>;
 			clk-source = <0>;
+			nxp,max-mb = <32>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxe31b.dtsi
+++ b/dts/arm/nxp/nxp_mcxe31b.dtsi
@@ -52,3 +52,27 @@
 };
 
 #include <nxp/nxp_mcxe31x_common.dtsi>
+
+&flexcan_0 {
+	nxp,max-mb = <96>;
+};
+
+&flexcan_1 {
+	nxp,max-mb = <64>;
+};
+
+&flexcan_2 {
+	nxp,max-mb = <64>;
+};
+
+&flexcan_3 {
+	nxp,max-mb = <32>;
+};
+
+&flexcan_4 {
+	nxp,max-mb = <32>;
+};
+
+&flexcan_5 {
+	nxp,max-mb = <32>;
+};

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -814,6 +814,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 		clk-source = <0>;
+		nxp,max-mb = <32>;
 		status = "disabled";
 	};
 
@@ -824,6 +825,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		clk-source = <0>;
+		nxp,max-mb = <32>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -112,6 +112,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		clk-source = <0>;
+		nxp,max-mb = <32>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -1001,6 +1001,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 		clk-source = <0>;
+		nxp,max-mb = <32>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -376,6 +376,7 @@
 		interrupt-names = "common";
 		clocks = <&scg SCG_K4_FIRC_CLK 0xec>;
 		clk-source = <2>;
+		nxp,max-mb = <32>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -970,6 +970,7 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 14>;
 			clk-source = <2>;
+			nxp,max-mb = <64>;
 			status = "disabled";
 		};
 
@@ -980,6 +981,7 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 18>;
 			clk-source = <2>;
+			nxp,max-mb = <64>;
 			status = "disabled";
 		};
 
@@ -990,6 +992,7 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
 			clk-source = <2>;
+			nxp,max-mb = <64>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -774,6 +774,7 @@
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
 		clk-source = <0>;
+		nxp,max-mb = <96>;
 		status = "disabled";
 	};
 
@@ -784,6 +785,7 @@
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 18>;
 		clk-source = <0>;
+		nxp,max-mb = <96>;
 		status = "disabled";
 	};
 
@@ -794,6 +796,7 @@
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN3_CLK 0x84 6>;
 		clk-source = <0>;
+		nxp,max-mb = <96>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -917,6 +917,7 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
 			clk-source = <0>;
+			nxp,max-mb = <64>;
 			status = "disabled";
 		};
 
@@ -927,6 +928,7 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 18>;
 			clk-source = <0>;
+			nxp,max-mb = <64>;
 			status = "disabled";
 		};
 
@@ -937,6 +939,7 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN3_CLK 0x84 6>;
 			clk-source = <0>;
+			nxp,max-mb = <64>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_s32k146.dtsi
+++ b/dts/arm/nxp/nxp_s32k146.dtsi
@@ -65,16 +65,19 @@
 &flexcan0 {
 	interrupts = <78 0>, <79 0>, <80 0>, <81 0>, <82 0>;
 	interrupt-names = "warning", "error", "wake-up", "mb-0-15", "mb-16-31";
+	nxp,max-mb = <32>;
 };
 
 &flexcan1 {
 	interrupts = <85 0>, <86 0>, <88 0>, <89 0>;
 	interrupt-names = "warning", "error", "mb-0-15", "mb-16-31";
 	clocks = <&clock NXP_S32_FLEXCAN1_CLK>;
+	nxp,max-mb = <32>;
 };
 
 &flexcan2 {
 	interrupts = <92 0>, <93 0>, <95 0>;
 	interrupt-names = "warning", "error", "mb-0-15";
 	clocks = <&clock NXP_S32_FLEXCAN2_CLK>;
+	nxp,max-mb = <16>;
 };

--- a/dts/arm/nxp/nxp_s32k148.dtsi
+++ b/dts/arm/nxp/nxp_s32k148.dtsi
@@ -88,16 +88,19 @@
 &flexcan0 {
 	interrupts = <78 0>, <79 0>, <80 0>, <81 0>, <82 0>;
 	interrupt-names = "warning", "error", "wake-up", "mb-0-15", "mb-16-31";
+	nxp,max-mb = <32>;
 };
 
 &flexcan1 {
 	interrupts = <85 0>, <86 0>, <88 0>, <89 0>;
 	interrupt-names = "warning", "error", "mb-0-15", "mb-16-31";
 	clocks = <&clock NXP_S32_FLEXCAN1_CLK>;
+	nxp,max-mb = <32>;
 };
 
 &flexcan2 {
 	interrupts = <92 0>, <93 0>, <95 0>, <96 0>;
 	interrupt-names = "warning", "error", "mb-0-15", "mb-16-31";
 	clocks = <&clock NXP_S32_FLEXCAN2_CLK>;
+	nxp,max-mb = <32>;
 };

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -471,6 +471,7 @@
 			interrupts = <109 0>, <110 0>, <111 0>, <112 0>;
 			interrupt-names = "ored", "ored_0_31_mb",
 					  "ored_32_63_mb", "ored_64_95_mb";
+			nxp,max-mb = <96>;
 			status = "disabled";
 		};
 
@@ -481,6 +482,7 @@
 			clk-source = <0>;
 			interrupts = <113 0>, <114 0>, <115 0>;
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb";
+			nxp,max-mb = <64>;
 			status = "disabled";
 		};
 
@@ -491,6 +493,7 @@
 			clk-source = <0>;
 			interrupts = <116 0>, <117 0>, <118 0>;
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb";
+			nxp,max-mb = <64>;
 			status = "disabled";
 		};
 
@@ -501,6 +504,7 @@
 			clk-source = <0>;
 			interrupts = <119 0>, <120 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
+			nxp,max-mb = <32>;
 			status = "disabled";
 		};
 
@@ -511,6 +515,7 @@
 			clk-source = <0>;
 			interrupts = <121 0>, <122 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
+			nxp,max-mb = <32>;
 			status = "disabled";
 		};
 
@@ -521,6 +526,7 @@
 			clk-source = <0>;
 			interrupts = <123 0>, <124 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
+			nxp,max-mb = <32>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -756,6 +756,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -771,6 +772,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -786,6 +788,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -801,6 +804,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -816,6 +820,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -831,6 +836,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -846,6 +852,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -861,6 +868,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -876,6 +884,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -891,6 +900,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -906,6 +916,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -921,6 +932,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -936,6 +948,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -951,6 +964,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -966,6 +980,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -981,6 +996,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -996,6 +1012,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -1011,6 +1028,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -1026,6 +1044,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -1041,6 +1060,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -1056,6 +1076,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -1071,6 +1092,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -1086,6 +1108,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 
@@ -1101,6 +1124,7 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			nxp,max-mb = <128>;
 			status = "disabled";
 		};
 

--- a/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
@@ -198,6 +198,7 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
 			clk-source = <0>;
+			nxp,max-mb = <64>;
 			rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
 			       RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
 			status = "disabled";
@@ -212,6 +213,7 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 14>;
 			clk-source = <0>;
+			nxp,max-mb = <64>;
 			rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
 			       RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
 			status = "disabled";

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -420,6 +420,7 @@
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
 		clk-source = <0>;
+		nxp,max-mb = <96>;
 		status = "disabled";
 	};
 
@@ -432,6 +433,7 @@
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 14>;
 		clk-source = <0>;
+		nxp,max-mb = <96>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/can/nxp,flexcan-fd.yaml
+++ b/dts/bindings/can/nxp,flexcan-fd.yaml
@@ -15,6 +15,7 @@ description: |
       interrupt-names = "common";
       clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
       clk-source = <2>;
+      nxp,max-mb = <64>;
       pinctrl-0 = <&pinmux_flexcan3>;
       pinctrl-names = "default";
 

--- a/dts/bindings/can/nxp,flexcan.yaml
+++ b/dts/bindings/can/nxp,flexcan.yaml
@@ -13,6 +13,7 @@ description: |
       interrupt-names = "warning", "error", "wake-up", "mb-0-15";
       clocks = <&scg KINETIS_SCG_BUS_CLK>;
       clk-source = <1>;
+      nxp,max-mb = <16>;
       pinctrl-0 = <&pinmux_flexcan0>;
       pinctrl-names = "default";
 
@@ -39,3 +40,8 @@ properties:
     type: int
     required: true
     description: CAN engine clock source
+
+  nxp,max-mb:
+    type: int
+    required: true
+    description: Maximum number of 8-byte payload message buffers FlexCAN instance supported


### PR DESCRIPTION
This change replaces static memory allocation for FlexCAN message buffers with dynamic allocation using a per-instance heap. The motivation is to support FlexCAN instances with varying message buffer counts and CAN FD configurations.
For CAN FD instances, message buffer count is adjusted based on 64-byte payload size (7 buffers per RAM block vs 32 for 8-byte payload).

Key changes:
  - Add CAN_MCUX_FLEXCAN_HEAP_SIZE Kconfig option (default 2048 bytes) to configure heap size for message buffer allocation
  - Replace compile-time MCUX_FLEXCAN_MAX_MB/RX/TX macros with runtime calculation in mcux_flexcan_get_mb_config()
  - Add dynamic allocation of rx_allocs, tx_allocs, rx_cbs, and tx_cbs arrays using k_heap during driver initialization
  - Update all array bounds checks and loop limits to use runtime values stored in driver data structure
  - Remove Kconfig symbol `CAN_MAX_MB` beacuse such information is added to device tree.
  - Remove range limitation in Kconfig symbol `CAN_MAX_FILTER` because such validation is added in mcux_flexcan_get_mb_config()

 Fixes #92798