### PR TITLE
drivers: serial: Apply TX AE interrupt workaround on MAX32655

### DIFF
--- a/drivers/serial/Kconfig.max32
+++ b/drivers/serial/Kconfig.max32
@@ -19,7 +19,7 @@ config UART_MAX32
 
 config UART_MAX32_TX_AE_WORKAROUND
 	bool
-	default y if SOC_MAX32690
+	default y if SOC_MAX32690 || SOC_MAX32655
 	depends on UART_MAX32 && UART_INTERRUPT_DRIVEN
 	help
 		This option enables a small workaround for almost-empty interrupts


### PR DESCRIPTION
The workaround for missing the almost-empty interrupt when TX of very small payloads needs to also be applied for the UART on MAX32655, so default on that workaround symbol on that target.