### PR TITLE
dts: arm: realtek: rts5912: set rtmr interrupt to highest priority

### DIFF
--- a/dts/arm/realtek/ec/rts5912.dtsi
+++ b/dts/arm/realtek/ec/rts5912.dtsi
@@ -32,7 +32,6 @@
 				power-state-name = "suspend-to-idle";
 				min-residency-us = <100000000>;
 			};
-
 		};
 	};
 
@@ -92,7 +91,7 @@
 			compatible = "realtek,rts5912-timer";
 			reg = <0x4000c300 0x14>;
 			interrupt-parent = <&nvic>;
-			interrupts = <196 0>;
+			interrupts = <196 1>;
 			clocks = <&sccon RTS5912_SCCON_PERIPH_GRP1 PERIPH_GRP1_TMR0_CLKPWR>;
 			clock-names = "tmr32";
 			max-value = <0xFFFFFFFF>;
@@ -105,7 +104,7 @@
 			compatible = "realtek,rts5912-timer";
 			reg = <0x4000c314 0x14>;
 			interrupt-parent = <&nvic>;
-			interrupts = <197 0>;
+			interrupts = <197 1>;
 			clocks = <&sccon RTS5912_SCCON_PERIPH_GRP1 PERIPH_GRP1_TMR1_CLKPWR>;
 			clock-names = "tmr32";
 			max-value = <0xFFFFFFFF>;
@@ -118,7 +117,7 @@
 			compatible = "realtek,rts5912-timer";
 			reg = <0x4000c328 0x14>;
 			interrupt-parent = <&nvic>;
-			interrupts = <198 0>;
+			interrupts = <198 1>;
 			clocks = <&sccon RTS5912_SCCON_PERIPH_GRP1 PERIPH_GRP1_TMR2_CLKPWR>;
 			clock-names = "tmr32";
 			max-value = <0xFFFFFFFF>;
@@ -131,7 +130,7 @@
 			compatible = "realtek,rts5912-timer";
 			reg = <0x4000c33c 0x14>;
 			interrupt-parent = <&nvic>;
-			interrupts = <199 0>;
+			interrupts = <199 1>;
 			clocks = <&sccon RTS5912_SCCON_PERIPH_GRP1 PERIPH_GRP1_TMR3_CLKPWR>;
 			clock-names = "tmr32";
 			max-value = <0xFFFFFFFF>;
@@ -144,7 +143,7 @@
 			compatible = "realtek,rts5912-timer";
 			reg = <0x4000c350 0x14>;
 			interrupt-parent = <&nvic>;
-			interrupts = <200 0>;
+			interrupts = <200 1>;
 			clocks = <&sccon RTS5912_SCCON_PERIPH_GRP1 PERIPH_GRP1_TMR4_CLKPWR>;
 			clock-names = "tmr32";
 			max-value = <0xFFFFFFFF>;
@@ -157,7 +156,7 @@
 			compatible = "realtek,rts5912-timer";
 			reg = <0x4000c364 0x14>;
 			interrupt-parent = <&nvic>;
-			interrupts = <201 0>;
+			interrupts = <201 1>;
 			clocks = <&sccon RTS5912_SCCON_PERIPH_GRP1 PERIPH_GRP1_TMR5_CLKPWR>;
 			clock-names = "tmr32";
 			max-value = <0xFFFFFFFF>;
@@ -214,20 +213,20 @@
 				      "promt3", "emi0", "emi1", "emi2", "emi3", "emi4", "emi5",
 				      "emi6", "emi7", "kbc";
 
-			interrupts = <133 0>, <134 0>, <146 0>,
-				     <145 0>, <144 0>, <143 0>,
-				     <142 0>, <141 0>, <140 0>,
-				     <139 0>, <138 0>, <137 0>,
-				     <136 0>, <135 0>, <154 0>,
-				     <155 0>, <156 0>, <157 0>,
-				     <158 0>, <159 0>, <160 0>,
-				     <161 0>, <162 0>, <163 0>,
-				     <164 0>, <165 0>, <212 0>,
-				     <213 0>, <214 0>, <215 0>,
-				     <216 0>, <217 0>, <218 0>,
-				     <219 0>, <147 0>, <148 0>,
-				     <149 0>, <152 0>, <153 0>,
-				     <166 0>, <220 0>;
+			interrupts = <133 1>, <134 1>, <146 1>,
+				     <145 1>, <144 1>, <143 1>,
+				     <142 1>, <141 1>, <140 1>,
+				     <139 1>, <138 1>, <137 1>,
+				     <136 1>, <135 1>, <154 1>,
+				     <155 1>, <156 1>, <157 1>,
+				     <158 1>, <159 1>, <160 1>,
+				     <161 1>, <162 1>, <163 1>,
+				     <164 1>, <165 1>, <212 1>,
+				     <213 1>, <214 1>, <215 1>,
+				     <216 1>, <217 1>, <218 1>,
+				     <219 1>, <147 1>, <148 1>,
+				     <149 1>, <152 1>, <153 1>,
+				     <166 1>, <220 1>;
 
 			interrupt-names = "bus-rst", "periph-ch", "vw-ch",
 					  "vw-idx2", "vw-idx3", "vw-idx7",
@@ -248,7 +247,7 @@
 		slwtmr0: slwtmr0@4000c200 {
 			compatible = "realtek,rts5912-slwtimer";
 			reg = <0x4000c200 0x10>;
-			interrupts = <202 0>;
+			interrupts = <202 1>;
 			clocks = <&sccon RTS5912_SCCON_PERIPH_GRP1 PERIPH_GRP1_SLWTMR0_CLKPWR>;
 			clock-names = "slwtmr";
 			max-value = <0xFFFFFFFF>;
@@ -268,7 +267,7 @@
 			compatible = "realtek,rts5912-adc";
 			reg = <0x4000fe00 0x38>;
 			clocks = <&sccon RTS5912_SCCON_ADC ADC0_CLKPWR>;
-			interrupts = <221 0>;
+			interrupts = <221 1>;
 			#io-channel-cells = <1>;
 			status = "disabled";
 		};
@@ -278,7 +277,7 @@
 			reg = <0x40010100 0x100>;
 			reg-shift = <2>;
 			clock-frequency = <DT_FREQ_M(100)>;
-			interrupts = <191 0>;
+			interrupts = <191 1>;
 			status = "disabled";
 		};
 
@@ -305,10 +304,10 @@
 				#gpio-cells = <2>;
 				reg = <0x40090000 0x40>;
 				ngpios = <16>;
-				interrupts = <0 0 1 0 2 0 3 0
-					      4 0 5 0 6 0 7 0
-					      8 0 9 0 10 0 11 0
-					      12 0 13 0 14 0 15 0>;
+				interrupts = <0 1 1 1 2 1 3 1
+					      4 1 5 1 6 1 7 1
+					      8 1 9 1 10 1 11 1
+					      12 1 13 1 14 1 15 1>;
 			};
 
 			/* GPIO16-GPIO31 */
@@ -318,10 +317,10 @@
 				#gpio-cells = <2>;
 				reg = <0x40090040 0x40>;
 				ngpios = <16>;
-				interrupts = <16 0 17 0 18 0 19 0
-					      20 0 21 0 22 0 23 0
-					      24 0 25 0 26 0 27 0
-					      28 0 29 0 30 0 31 0>;
+				interrupts = <16 1 17 1 18 1 19 1
+					      20 1 21 1 22 1 23 1
+					      24 1 25 1 26 1 27 1
+					      28 1 29 1 30 1 31 1>;
 			};
 
 			/* GPIO32-GPIO47 */
@@ -331,10 +330,10 @@
 				#gpio-cells = <2>;
 				reg = <0x40090080 0x40>;
 				ngpios = <16>;
-				interrupts = <32 0 33 0 34 0 35 0
-					      36 0 37 0 38 0 39 0
-					      40 0 41 0 42 0 43 0
-					      44 0 45 0 46 0 47 0>;
+				interrupts = <32 1 33 1 34 1 35 1
+					      36 1 37 1 38 1 39 1
+					      40 1 41 1 42 1 43 1
+					      44 1 45 1 46 1 47 1>;
 			};
 
 			/* GPIO48-GPIO63 */
@@ -344,10 +343,10 @@
 				#gpio-cells = <2>;
 				reg = <0x400900c0 0x40>;
 				ngpios = <16>;
-				interrupts = <48 0 49 0 50 0 51 0
-					      52 0 53 0 54 0 55 0
-					      56 0 57 0 58 0 59 0
-					      60 0 61 0 62 0 63 0>;
+				interrupts = <48 1 49 1 50 1 51 1
+					      52 1 53 1 54 1 55 1
+					      56 1 57 1 58 1 59 1
+					      60 1 61 1 62 1 63 1>;
 			};
 
 			/* GPIO64-GPIO79 */
@@ -357,10 +356,10 @@
 				#gpio-cells = <2>;
 				reg = <0x40090100 0x40>;
 				ngpios = <16>;
-				interrupts = <64 0 65 0 66 0 67 0
-					      68 0 69 0 70 0 71 0
-					      72 0 73 0 74 0 75 0
-					      76 0 77 0 78 0 79 0>;
+				interrupts = <64 1 65 1 66 1 67 1
+					      68 1 69 1 70 1 71 1
+					      72 1 73 1 74 1 75 1
+					      76 1 77 1 78 1 79 1>;
 			};
 
 			/* GPIO80-GPIO95 */
@@ -370,10 +369,10 @@
 				#gpio-cells = <2>;
 				reg = <0x40090140 0x40>;
 				ngpios = <16>;
-				interrupts = <80 0 81 0 82 0 83 0
-					      84 0 85 0 86 0 87 0
-					      88 0 89 0 90 0 91 0
-					      92 0 93 0 94 0 95 0>;
+				interrupts = <80 1 81 1 82 1 83 1
+					      84 1 85 1 86 1 87 1
+					      88 1 89 1 90 1 91 1
+					      92 1 93 1 94 1 95 1>;
 			};
 
 			/* GPIO96-GPIO111 */
@@ -383,10 +382,10 @@
 				#gpio-cells = <2>;
 				reg = <0x40090180 0x40>;
 				ngpios = <16>;
-				interrupts = <96 0 97 0 98 0 99 0
-					      100 0 101 0 102 0 103 0
-					      104 0 105 0 106 0 107 0
-					      108 0 109 0 110 0 111 0>;
+				interrupts = <96 1 97 1 98 1 99 1
+					      100 1 101 1 102 1 103 1
+					      104 1 105 1 106 1 107 1
+					      108 1 109 1 110 1 111 1>;
 			};
 
 			/* GPIO112-GPIO127 */
@@ -396,10 +395,10 @@
 				#gpio-cells = <2>;
 				reg = <0x400901c0 0x40>;
 				ngpios = <16>;
-				interrupts = <112 0 113 0 114 0 115 0
-					      116 0 117 0 118 0 119 0
-					      120 0 121 0 122 0 123 0
-					      124 0 125 0 126 0 127 0>;
+				interrupts = <112 1 113 1 114 1 115 1
+					      116 1 117 1 118 1 119 1
+					      120 1 121 1 122 1 123 1
+					      124 1 125 1 126 1 127 1>;
 			};
 
 			/* GPIO128-GPIO131 */
@@ -409,10 +408,10 @@
 				#gpio-cells = <2>;
 				reg = <0x40090200 0x10>;
 				ngpios = <4>;
-				interrupts = <128 0 129 0 130 0 131 0
-					      132 0 133 0 134 0 135 0
-					      136 0 137 0 138 0 139 0
-					      140 0 141 0 142 0 143 0>;
+				interrupts = <128 1 129 1 130 1 131 1
+					      132 1 133 1 134 1 135 1
+					      136 1 137 1 138 1 139 1
+					      140 1 141 1 142 1 143 1>;
 			};
 		};
 
@@ -420,7 +419,7 @@
 			compatible = "realtek,rts5912-watchdog";
 			reg = <0x4000c000 0x14>;
 			interrupt-parent = <&nvic>;
-			interrupts = <209 0>;
+			interrupts = <209 1>;
 			clocks = <&sccon RTS5912_SCCON_PERIPH_GRP2 PERIPH_GRP2_WDT_CLKPWR>;
 			clock-names = "watchdog";
 			clk-divider = <33>;
@@ -431,7 +430,7 @@
 			compatible = "realtek,rts5912-kbd";
 			reg = <0x40010000 0x10>;
 			clocks = <&sccon RTS5912_SCCON_PERIPH_GRP0 PERIPH_GRP0_KBM_CLKPWR>;
-			interrupts = <210 0>;
+			interrupts = <210 1>;
 			interrupt-parent = <&nvic>;
 			status = "disabled";
 		};
@@ -441,7 +440,16 @@
 			reg = <0x4000fd00 0x40>;
 			clocks = <&sccon RTS5912_SCCON_PERIPH_GRP0 PERIPH_GRP0_TACH0_CLKPWR>;
 			clock-names = "tacho";
-			interrupts = <192 0>;
+			interrupts = <192 1>;
+			status = "disabled";
+		};
+
+		tach1: tach@4000fd40 {
+			compatible = "realtek,rts5912-tach";
+			reg = <0x4000fd40 0x40>;
+			clocks = <&sccon RTS5912_SCCON_PERIPH_GRP0 PERIPH_GRP0_TACH1_CLKPWR>;
+			clock-names = "tacho";
+			interrupts = <193 1>;
 			status = "disabled";
 		};
 
@@ -528,7 +536,7 @@
 			reg = <0x4000d000 0x154>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupt-parent = <&nvic>;
-			interrupts = <182 1>;
+			interrupts = <182 2>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -539,7 +547,7 @@
 			reg = <0x4000d200 0x154>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupt-parent = <&nvic>;
-			interrupts = <183 1>;
+			interrupts = <183 2>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -550,7 +558,7 @@
 			reg = <0x4000d400 0x154>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupt-parent = <&nvic>;
-			interrupts = <184 1>;
+			interrupts = <184 2>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -561,7 +569,7 @@
 			reg = <0x4000d600 0x154>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupt-parent = <&nvic>;
-			interrupts = <185 1>;
+			interrupts = <185 2>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -572,7 +580,7 @@
 			reg = <0x4000d800 0x154>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupt-parent = <&nvic>;
-			interrupts = <186 1>;
+			interrupts = <186 2>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -583,7 +591,7 @@
 			reg = <0x4000da00 0x154>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupt-parent = <&nvic>;
-			interrupts = <187 1>;
+			interrupts = <187 2>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -594,7 +602,7 @@
 			reg = <0x4000dc00 0x154>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupt-parent = <&nvic>;
-			interrupts = <188 1>;
+			interrupts = <188 2>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -605,7 +613,7 @@
 			reg = <0x4000de00 0x154>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupt-parent = <&nvic>;
-			interrupts = <189 1>;
+			interrupts = <189 2>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
When another ISR is executing and the RTMR times out, the RTMR stops operating until its ISR clears the interrupt status and restarts the timer. If the executing ISR calls functions like k_cycle_get_32() or WAIT_FOR() that rely on the RTMR counter to determine timeout conditions, these functions will never timeout because the RTMR counter stops updating.

This PR assigns the highest interrupt priority to the RTMR to ensure that even when a timeout occurs during ISR execution, the interrupt status can be cleared and the timer restarted immediately.