### PR TITLE
doc: kconfig: document "named choices" as a language extension

### DIFF
--- a/doc/build/kconfig/extensions.rst
+++ b/doc/build/kconfig/extensions.rst
@@ -126,3 +126,35 @@ which includes some Kconfig extensions:
 - ``def_int``, ``def_hex``, and ``def_string`` keywords are available,
   analogous to ``def_bool``. These set the type and add a ``default`` at the
   same time.
+
+- A symbol name can be associated to ``choice`` groups using the ``choice <symbol>`` syntax.
+  Such choices, called *named choices*, can be modified from places other than their initial
+  definition. For example, the following statements define the named choice ``FOOBAR``:
+
+  .. code-block:: kconfig
+
+    choice FOOBAR
+	    prompt "Example choice"
+	    default BAR
+
+    config FOO
+	    bool "Foo"
+
+    config BAR
+	    bool "Bar"
+
+    endchoice
+
+  The following statements could then be used, in a ``Kconfig.defconfig`` file for example,
+  to override the default option of choice ``FOOBAR``:
+
+  .. code-block:: kconfig
+
+    # Note how "prompt" is not present here
+    choice FOOBAR
+        default FOO
+    endchoice
+
+  .. note::
+    The *named choices* feature originates from Linux, but it is no longer supported in Linux
+    since kernel release 6.9, and has thus become a Kconfiglib language extension.


### PR DESCRIPTION
When creating a `choice` block, it is possible to associate a name to the choice, resulting in a so-called *named choice* being created. This allows modification of the choice after its initial declaration - for example, its default value can be overridden from another Kconfig file.

This feature originates from Linux and is supported by Kconfiglib; however, since commit [c83f020973bc72d9eec65474d8c47495191aef20](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/Documentation/kbuild/kconfig-language.rst?h=v6.18-rc5&id=c83f020973bc72d9eec65474d8c47495191aef20) (first found in release v6.9), Linux no longer supports this feature. Critically, this means that the feature is no longer covered by the [Linux Kconfig Language documentation](https://www.kernel.org/doc/html/latest/kbuild/kconfig-language.html), even though it is supported and used in Zephyr.

Add "named choices" to the Kconfig language extensions documentation page since it has de facto become an extension after its support was dropped from Linux.