### PR TITLE
soc: smartbond: Change SYS_CLOCK_TICKS_PER_SEC

### DIFF
--- a/soc/renesas/smartbond/da1469x/Kconfig.defconfig
+++ b/soc/renesas/smartbond/da1469x/Kconfig.defconfig
@@ -20,7 +20,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,$(DT_CLOCK_SRC_PATH),clock-frequency) if SMARTBOND_TIMER
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default $(dt_node_int_prop_int,$(DT_CLOCK_SRC_PATH),clock-frequency) if SMARTBOND_TIMER
+	default 5000 if SMARTBOND_TIMER && SYS_CLOCK_HW_CYCLES_PER_SEC <= 20000
 
 config USE_DT_CODE_PARTITION
 	default y if MCUBOOT


### PR DESCRIPTION
Zephyr default configuration for **SYS_CLOCK_TICKS_PER_SEC** is 10000.
For Smartbond this value was changed to frequency of **lp_clk**. For **XTAL32K** **SYS_CLOCK_TICKS_PER_SEC** would increase to 32768 that would equal **SYS_CLOCK_HW_CYCLES_PER_SEC**.

One would expect **SYS_CLOCK_TICKS_PER_SEC** to be less then HW clock cycles.

This restores default value for **SYS_CLOCK_TICKS_PER_SEC** and changes it to 5000 only when **RCX** is used (that runs at around 15kHz) and keeping it at 10000 would result in big rounding errors.

Fixes: #99315
