### PR TITLE
scripts: zephyr_module: ignore empty paths in extra modules env variables

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -772,7 +772,7 @@ def parse_modules(zephyr_base, manifest=None, west_projs=None, modules=None,
             extra_module = os.environ.get(var, None)
             if not extra_module:
                 continue
-            extra_modules.extend(PurePosixPath(p) for p in extra_module.split(';'))
+            extra_modules.extend(PurePosixPath(p) for p in extra_module.split(';') if p)
 
     Module = namedtuple('Module', ['project', 'meta', 'depends'])
 


### PR DESCRIPTION
Successor of #94603.

Ignore empty paths in environment variable `ZEPHYR_EXTRA_MODULES` or `EXTRA_ZEPHYR_MODULES`.
This can happen easily when you append paths to env variables, e.g. in bash
```
ZEPHYR_EXTRA_MODULES+=";/my/module"
```
#### Actual:
If the variable was empty, it results in `;/my/module`.
Currently, this string resolves to `[Path(), Path('/my/module')]`, which is same as `[Path('.'), Path('/my/module')]`.
As you can see, `Path('.')` is wrong.

#### Expected:
`zephyr_module.py` should ignore empty paths.

