### PR TITLE
tests: bluetooth: tester: Fix CSIS/SR/SP/BV-07-C

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp/btp_csis.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_csis.h
@@ -12,6 +12,10 @@
 #include <zephyr/bluetooth/audio/csip.h>
 
 /* CSIS commands */
+#define BTP_CSIS_SIRK_TYPE_PLAINTEXT		0x00
+#define BTP_CSIS_SIRK_TYPE_ENCRYPTED		0x01
+#define BTP_CSIS_SIRK_TYPE_OOB_ONLY		0x02
+
 #define BTP_CSIS_READ_SUPPORTED_COMMANDS	0x01
 struct btp_csis_read_supported_commands_rp {
 	uint8_t data[0];
@@ -33,7 +37,7 @@ struct btp_csis_get_member_rsi_rp {
 	uint8_t rsi[BT_CSIP_RSI_SIZE];
 } __packed;
 
-#define BTP_CSIS_ENC_SIRK_TYPE			0x04
-struct btp_csis_sirk_type_cmd {
-	uint8_t encrypted;
+#define BTP_CSIS_SET_SIRK_TYPE			0x04
+struct btp_csis_sirk_set_type_cmd {
+	uint8_t type;
 } __packed;

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.c
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.c
@@ -1236,7 +1236,7 @@ static bool is_valid_csis_packet_len(const struct btp_hdr *hdr, struct net_buf_s
 		return buf_simple->len == 0U;
 	case BTP_CSIS_GET_MEMBER_RSI:
 		return buf_simple->len == sizeof(struct btp_csis_get_member_rsi_rp);
-	case BTP_CSIS_ENC_SIRK_TYPE:
+	case BTP_CSIS_SET_SIRK_TYPE:
 		return buf_simple->len == 0U;
 
 	/* No events */


### PR DESCRIPTION
This particular test-case requires bttester to respond with an OOB procedure SIRK only error. To enable this response, the BTP command to set SIRK mode has been extended with a new selection.

Associated AutoPTS PR: https://github.com/auto-pts/auto-pts/pull/1613