### PR TITLE
boards: st: minor fixes in boards documentation

### DIFF
--- a/boards/st/nucleo_n657x0_q/doc/index.rst
+++ b/boards/st/nucleo_n657x0_q/doc/index.rst
@@ -293,6 +293,7 @@ To do so, it is advised to use Twister's hardware map feature with the following
 
 .. _NUCLEO-N657X0-Q User Manual:
    https://www.st.com/resource/en/user_manual/um3417-stm32n6-nucleo144-board-mb1940-stmicroelectronics.pdf
+
 .. _STM32N657X0 on www.st.com:
    https://www.st.com/en/microcontrollers-microprocessors/stm32n657x0.html
 

--- a/boards/st/stm32h573i_dk/doc/index.rst
+++ b/boards/st/stm32h573i_dk/doc/index.rst
@@ -385,7 +385,7 @@ launch:
    https://www.st.com/en/evaluation-tools/stm32h573i-dk.html
 
 .. _STM32H573I-DK Discovery board User Manual:
-   https://www.st.com/en/evaluation-tools/stm32h573i-dk.html
+   https://www.st.com/resource/en/user_manual/um3143-discovery-kit-with-stm32h573ii-mcu-stmicroelectronics.pdf
 
 .. _STM32H573 on www.st.com:
    https://www.st.com/en/microcontrollers/stm32h573ii.html

--- a/boards/st/stm32h745i_disco/doc/index.rst
+++ b/boards/st/stm32h745i_disco/doc/index.rst
@@ -62,7 +62,7 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
-For more details please refer to `STM32H745-Disco UM`_.
+For more details please refer to the `STM32H745-Disco User Manual`_.
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
@@ -228,7 +228,7 @@ In order to debug a Zephyr application on Cortex M4 side, you can use
 .. _STM32H745xx datasheet:
    https://www.st.com/resource/en/datasheet/stm32h745xi.pdf
 
-.. _STM32H745-Disco UM:
+.. _STM32H745-Disco User Manual:
    https://www.st.com/resource/en/user_manual/um2488-discovery-kits-with-stm32h745xi-and-stm32h750xb-mcus-stmicroelectronics.pdf
 
 .. _STM32CubeProgrammer:

--- a/boards/st/stm32h745i_disco/doc/index.rst
+++ b/boards/st/stm32h745i_disco/doc/index.rst
@@ -192,7 +192,7 @@ Here is an example for the :zephyr:code-sample:`blinky` application on M4 core.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
-   :board: stm32h745i_disco/stm32h745xx/m7
+   :board: stm32h745i_disco/stm32h745xx/m4
    :goals: build flash
 
 .. note::

--- a/boards/st/stm32h747i_disco/doc/index.rst
+++ b/boards/st/stm32h747i_disco/doc/index.rst
@@ -248,7 +248,7 @@ Here is an example for the :zephyr:code-sample:`blinky` application on M4 core.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
-   :board: stm32h747i_disco/stm32h747xx/m7
+   :board: stm32h747i_disco/stm32h747xx/m4
    :goals: build flash
 
 Debugging

--- a/boards/st/stm32h757i_eval/doc/index.rst
+++ b/boards/st/stm32h757i_eval/doc/index.rst
@@ -223,7 +223,7 @@ Here is an example for the :zephyr:code-sample:`blinky` application on M4 core.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
-   :board: stm32h757i_eval/stm32h757xx/m7
+   :board: stm32h757i_eval/stm32h757xx/m4
    :goals: build flash
 
 Debugging

--- a/boards/st/stm32h7s78_dk/doc/index.rst
+++ b/boards/st/stm32h7s78_dk/doc/index.rst
@@ -337,7 +337,7 @@ launch:
    https://www.st.com/en/evaluation-tools/stm32h7s78-dk.html
 
 .. _STM32H7S78-DK Discovery board User Manual:
-   https://www.st.com/en/evaluation-tools/stm32h7s78-dk.html
+   https://www.st.com/resource/en/user_manual/um3289-discovery-kit-with-stm32h7s7l8-mcu-stmicroelectronics.pdf
 
 .. _STM32H7Sx on www.st.com:
    https://www.st.com/en/evaluation-tools/stm32h7s78-dk.html


### PR DESCRIPTION
Fix a few user manual links.
Reword UM to plain User Manual.
Fix typos in board doc on M4 related variants.