### PR TITLE
drivers: gpio: litex: rework litex,gpio driver

### DIFF
--- a/boards/enjoydigital/litex_vexriscv/litex_vexriscv.dts
+++ b/boards/enjoydigital/litex_vexriscv/litex_vexriscv.dts
@@ -297,9 +297,8 @@
 		gpio_out: gpio@e0005800 {
 			compatible = "litex,gpio";
 			reg = <0xe0005800 0x4>;
-			reg-names = "control";
+			reg-names = "out";
 			ngpios = <4>;
-			port-is-output;
 			status = "okay";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -314,11 +313,11 @@
 			      <0xe0006014 0x4>;
 			interrupt-parent = <&intc0>;
 			interrupts = <4 2>;
-			reg-names = "base",
-				    "irq_mode",
-				    "irq_edge",
-				    "irq_pend",
-				    "irq_en";
+			reg-names = "in",
+				    "mode",
+				    "edge",
+				    "ev_pending",
+				    "ev_enable";
 			ngpios = <4>;
 			status = "okay";
 			gpio-controller;

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -100,6 +100,14 @@ Ethernet
   reworked to be used as active low, you may have to set the pin as
   ``GPIO_ACTIVE_LOW`` in devicetree (:github:`100751`).
 
+GPIO
+====
+
+* The LiteX GPIO driver :dtcompatible:`litex,gpio` has been reworked to support changing direction.
+  The driver now uses the reg-names property to detect supported modes of the GPIO controller.
+  The Devicetree property ``port-is-output`` has been removed.
+  The reg-names are now taken directly from LiteX. (:github:`99329`)
+
 Infineon
 ========
 

--- a/dts/bindings/gpio/litex,gpio.yaml
+++ b/dts/bindings/gpio/litex,gpio.yaml
@@ -11,10 +11,6 @@ compatible: "litex,gpio"
 include: [gpio-controller.yaml, base.yaml]
 
 properties:
-  port-is-output:
-    type: boolean
-    description: Indicates if the port is an output port
-
   reg:
     required: true
 

--- a/dts/bindings/test/vnd,reg-holder-2.yaml
+++ b/dts/bindings/test/vnd,reg-holder-2.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 Linaro Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test register property container
+
+compatible: "vnd,reg-holder-2"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  reg-names:
+    required: true

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -5217,6 +5217,25 @@
 	IS_EMPTY(DT_INST_FOREACH_STATUS_OKAY_VARGS(DT_ALL_INST_HAS_BOOL_STATUS_OKAY_, prop))
 
 /**
+ * @brief Check if any `DT_DRV_COMPAT` node with status `okay` has a given
+ *        register name.
+ *
+ * @param name lowercase-and-underscores register name
+ */
+#define DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(name)						\
+	UTIL_NOT(IS_EMPTY(									\
+		DT_INST_FOREACH_STATUS_OKAY_VARGS(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY_, name)))
+
+/**
+ * @brief Check if all `DT_DRV_COMPAT` node with status `okay` has a given
+ *        register name. If all nodes are disabled, this will return 1.
+ *
+ * @param name lowercase-and-underscores register name
+ */
+#define DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(name) \
+	IS_EMPTY(DT_INST_FOREACH_STATUS_OKAY_VARGS(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY_, name))
+
+/**
  * @brief Call @p fn on all nodes with compatible `DT_DRV_COMPAT`
  *        and status `okay`
  *
@@ -5514,6 +5533,21 @@
 #define DT_ANY_INST_HAS_BOOL_STATUS_OKAY_(idx, prop)	\
 	IF_ENABLED(DT_INST_PROP(idx, prop), (1,))
 
+/** @brief Helper for DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY
+ *
+ * This macro generates token "1," for instance of a device,
+ * identified by index @p inst, if instance has named register
+ * @p name.
+ *
+ * @param inst instance number
+ * @param name register name to check for
+ *
+ * @return Macro evaluates to `1,` if instance register name exists,
+ * otherwise it evaluates to literal nothing.
+ */
+#define DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY_(inst, name)	\
+	IF_ENABLED(DT_INST_REG_HAS_NAME(inst, name), (1,))
+
 /** @brief Helper for DT_ALL_INST_HAS_PROP_STATUS_OKAY
  *
  * This macro generates token "1," for instance of a device,
@@ -5542,6 +5576,21 @@
  */
 #define DT_ALL_INST_HAS_BOOL_STATUS_OKAY_(idx, prop)	\
 	IF_DISABLED(DT_INST_PROP(idx, prop), (1,))
+
+/** @brief Helper for DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY
+ *
+ * This macro generates token "1," for instance of a device,
+ * identified by index @p inst, if instance has no named register
+ * @p name.
+ *
+ * @param inst instance number
+ * @param name register name to check for
+ *
+ * @return Macro evaluates to `1,` if instance register name exists,
+ * otherwise it evaluates to literal nothing.
+ */
+#define DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY_(inst, name)	\
+	IF_DISABLED(DT_INST_REG_HAS_NAME(inst, name), (1,))
 
 #define DT_PATH_INTERNAL(...) \
 	UTIL_CAT(DT_ROOT, MACRO_MAP_CAT(DT_S_PREFIX, __VA_ARGS__))

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -435,6 +435,27 @@
 			misc-prop = <1234>;
 		};
 
+		test_reg_0: reg-holder-0@9999baaa {
+			compatible = "vnd,reg-holder-2";
+			reg = <0x9999baaa 0x1000 0xbbbbcccc 0x3f>;
+			status = "okay";
+			reg-names = "foo", "bar";
+		};
+
+		test_reg_1: reg-holder-1@9999caaa {
+			compatible = "vnd,reg-holder-2";
+			reg = <0x9999caaa 0x1000>;
+			status = "okay";
+			reg-names = "foo";
+		};
+
+		test_reg_2: reg-holder-2@9999daaa {
+			compatible = "vnd,reg-holder-2";
+			reg = <0x9999daaa 0x1000>;
+			status = "disabled";
+			reg-names = "baz";
+		};
+
 		test_vendor: vendor {
 			compatible = "vnd,model1", "gpio", "zephyr,model2";
 			status = "okay";

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -206,6 +206,50 @@ ZTEST(devicetree_api, test_inst_props)
 }
 
 #undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_reg_holder_2
+ZTEST(devicetree_api, test_any_inst_reg_names)
+{
+	zassert_equal(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(foo), 1, "");
+	zassert_equal(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(bar), 1, "");
+	zassert_equal(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(baz), 0, "");
+	zassert_equal(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(does_not_exist), 0, "");
+
+	zassert_equal(COND_CODE_1(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(foo),
+				  (5), (6)), 5, "");
+	zassert_equal(COND_CODE_0(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(foo),
+				  (5), (6)), 6, "");
+	zassert_equal(COND_CODE_1(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(baz),
+				  (5), (6)), 6, "");
+	zassert_equal(COND_CODE_0(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(baz),
+				  (5), (6)), 5, "");
+	zassert_true(IS_ENABLED(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(foo)), "");
+	zassert_true(!IS_ENABLED(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(baz)), "");
+	zassert_equal(IF_ENABLED(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(foo), (1)) + 1, 2, "");
+	zassert_equal(IF_ENABLED(DT_ANY_INST_REG_HAS_NAME_STATUS_OKAY(baz), (1)) + 1, 1, "");
+}
+
+ZTEST(devicetree_api, test_all_inst_reg_names)
+{
+	zassert_equal(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(foo), 1, "");
+	zassert_equal(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(bar), 0, "");
+	zassert_equal(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(baz), 0, "");
+	zassert_equal(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(does_not_exist), 0, "");
+
+	zassert_equal(COND_CODE_1(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(foo),
+				  (5), (6)), 5, "");
+	zassert_equal(COND_CODE_0(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(foo),
+				  (5), (6)), 6, "");
+	zassert_equal(COND_CODE_1(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(baz),
+				  (5), (6)), 6, "");
+	zassert_equal(COND_CODE_0(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(baz),
+				  (5), (6)), 5, "");
+	zassert_true(IS_ENABLED(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(foo)), "");
+	zassert_true(!IS_ENABLED(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(baz)), "");
+	zassert_equal(IF_ENABLED(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(foo), (1)) + 1, 2, "");
+	zassert_equal(IF_ENABLED(DT_ALL_INST_REG_HAS_NAME_STATUS_OKAY(baz), (1)) + 1, 1, "");
+}
+
+#undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_device_with_props
 ZTEST(devicetree_api, test_any_inst_prop)
 {


### PR DESCRIPTION
rework litex gpio driver.
It is now also supported to change direction.
now uses the reg names to detect if what modes the gpio
controller supports.
use the reg names directly from litex.