### PR TITLE
drivers: ethernet: stm32: factorize clock handles

### DIFF
--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -32,16 +32,9 @@ PINCTRL_DT_INST_DEFINE(0);
 static const struct pinctrl_dev_config *eth0_pcfg =
 	PINCTRL_DT_INST_DEV_CONFIG_GET(0);
 
-/* Temporary helper macro to smooth moving clocks from mac node to controller (parent) node */
-#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk_tx)
-#define MAC_CLOCKS_NODE		DT_INST_PARENT(0)
-#else
-#define MAC_CLOCKS_NODE		DT_DRV_INST(0)
-#endif
-
 static const struct stm32_pclken pclken = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), stm_eth);
-static const struct stm32_pclken pclken_tx = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, mac_clk_tx);
-static const struct stm32_pclken pclken_rx = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, mac_clk_rx);
+static const struct stm32_pclken pclken_tx = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), mac_clk_tx);
+static const struct stm32_pclken pclken_rx = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), mac_clk_rx);
 
 int dwmac_bus_init(struct dwmac_priv *p)
 {

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -32,9 +32,16 @@ PINCTRL_DT_INST_DEFINE(0);
 static const struct pinctrl_dev_config *eth0_pcfg =
 	PINCTRL_DT_INST_DEV_CONFIG_GET(0);
 
+/* Temporary helper macro to smooth moving clocks from mac node to controller (parent) node */
+#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk_tx)
+#define MAC_CLOCKS_NODE		DT_INST_PARENT(0)
+#else
+#define MAC_CLOCKS_NODE		DT_DRV_INST(0)
+#endif
+
 static const struct stm32_pclken pclken = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), stm_eth);
-static const struct stm32_pclken pclken_tx = STM32_DT_INST_CLOCK_INFO_BY_NAME(0, mac_clk_tx);
-static const struct stm32_pclken pclken_rx = STM32_DT_INST_CLOCK_INFO_BY_NAME(0, mac_clk_rx);
+static const struct stm32_pclken pclken_tx = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, mac_clk_tx);
+static const struct stm32_pclken pclken_rx = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, mac_clk_rx);
 
 int dwmac_bus_init(struct dwmac_priv *p)
 {

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -32,9 +32,7 @@ PINCTRL_DT_INST_DEFINE(0);
 static const struct pinctrl_dev_config *eth0_pcfg =
 	PINCTRL_DT_INST_DEV_CONFIG_GET(0);
 
-static const struct stm32_pclken pclken = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), stm_eth);
-static const struct stm32_pclken pclken_tx = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), mac_clk_tx);
-static const struct stm32_pclken pclken_rx = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), mac_clk_rx);
+static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(DT_INST_PARENT(0));
 
 int dwmac_bus_init(struct dwmac_priv *p)
 {
@@ -48,12 +46,12 @@ int dwmac_bus_init(struct dwmac_priv *p)
 		return -ENODEV;
 	}
 
-	ret  = clock_control_on(p->clock, (clock_control_subsys_t)&pclken);
-	ret |= clock_control_on(p->clock, (clock_control_subsys_t)&pclken_tx);
-	ret |= clock_control_on(p->clock, (clock_control_subsys_t)&pclken_rx);
-	if (ret) {
-		LOG_ERR("Failed to enable ethernet clock");
-		return -EIO;
+	for (size_t n = 0; n < ARRAY_SIZE(pclken); n++) {
+		ret  = clock_control_on(p->clock, (clock_control_subsys_t)&pclken[n]);
+		if (ret) {
+			LOG_ERR("Failed to enable ethernet clock #%zu", n);
+			return -EIO;
+		}
 	}
 
 	ret = pinctrl_apply_state(eth0_pcfg, PINCTRL_STATE_DEFAULT);

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -42,6 +42,13 @@ LOG_MODULE_REGISTER(eth_stm32_hal, CONFIG_ETHERNET_LOG_LEVEL);
 #define ETH_STM32_HAL_MTU NET_ETH_MTU
 #define ETH_STM32_HAL_FRAME_SIZE_MAX (ETH_STM32_HAL_MTU + 18)
 
+/* Temporary helper macro to smooth moving clocks from mac node to controller (parent) node */
+#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk_tx)
+#define MAC_CLOCKS_NODE		DT_INST_PARENT(0)
+#else
+#define MAC_CLOCKS_NODE		DT_DRV_INST(0)
+#endif
+
 uint8_t dma_rx_buffer[ETH_RXBUFNB][ETH_STM32_RX_BUF_SIZE] __eth_stm32_buf;
 uint8_t dma_tx_buffer[ETH_TXBUFNB][ETH_STM32_TX_BUF_SIZE] __eth_stm32_buf;
 
@@ -159,16 +166,16 @@ static int eth_initialize(const struct device *dev)
 		(clock_control_subsys_t)&cfg->pclken_tx);
 	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 		(clock_control_subsys_t)&cfg->pclken_rx);
-#if DT_INST_CLOCKS_HAS_NAME(0, mac_clk_ptp)
+#if DT_CLOCKS_HAS_NAME(MAC_CLOCKS_NODE, mac_clk_ptp)
 	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 		(clock_control_subsys_t)&cfg->pclken_ptp);
 #endif
-#if DT_INST_CLOCKS_HAS_NAME(0, eth_ker)
+#if DT_CLOCKS_HAS_NAME(MAC_CLOCKS_NODE, eth_ker)
 	ret |= clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 				       (clock_control_subsys_t)&cfg->pclken_ker,
 				       NULL);
 #endif
-#if DT_INST_CLOCKS_HAS_NAME(0, mac_clk)
+#if DT_CLOCKS_HAS_NAME(MAC_CLOCKS_NODE, mac_clk)
 	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 				(clock_control_subsys_t)&cfg->pclken_mac);
 #endif
@@ -401,16 +408,16 @@ PINCTRL_DT_INST_DEFINE(0);
 static const struct eth_stm32_hal_dev_cfg eth0_config = {
 	.config_func = eth0_irq_config,
 	.pclken = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), stm_eth),
-	.pclken_tx = STM32_DT_INST_CLOCK_INFO_BY_NAME(0, mac_clk_tx),
-	.pclken_rx = STM32_DT_INST_CLOCK_INFO_BY_NAME(0, mac_clk_rx),
-#if DT_INST_CLOCKS_HAS_NAME(0, mac_clk_ptp)
-	.pclken_ptp = STM32_DT_INST_CLOCK_INFO_BY_NAME(0, mac_clk_ptp),
+	.pclken_tx = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, mac_clk_tx),
+	.pclken_rx = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, mac_clk_rx),
+#if DT_CLOCKS_HAS_NAME(MAC_CLOCKS_NODE, mac_clk_ptp)
+	.pclken_ptp = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, mac_clk_ptp),
 #endif
-#if DT_INST_CLOCKS_HAS_NAME(0, mac_clk)
-	.pclken_mac = STM32_DT_INST_CLOCK_INFO_BY_NAME(0, mac_clk),
+#if DT_CLOCKS_HAS_NAME(MAC_CLOCKS_NODE, mac_clk)
+	.pclken_mac = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, mac_clk),
 #endif
-#if DT_INST_CLOCKS_HAS_NAME(0, eth_ker)
-	.pclken_ker = STM32_DT_INST_CLOCK_INFO_BY_NAME(0, eth_ker),
+#if DT_CLOCKS_HAS_NAME(MAC_CLOCKS_NODE, eth_ker)
+	.pclken_ker = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, eth_ker),
 #endif
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -407,12 +407,10 @@ static const struct eth_stm32_hal_dev_cfg eth0_config = {
 	.pclken_ptp = STM32_DT_INST_CLOCK_INFO_BY_NAME(0, mac_clk_ptp),
 #endif
 #if DT_INST_CLOCKS_HAS_NAME(0, mac_clk)
-	.pclken_mac = {.bus = DT_INST_CLOCKS_CELL_BY_NAME(0, mac_clk, bus),
-		       .enr = DT_INST_CLOCKS_CELL_BY_NAME(0, mac_clk, bits)},
+	.pclken_mac = STM32_DT_INST_CLOCK_INFO_BY_NAME(0, mac_clk),
 #endif
 #if DT_INST_CLOCKS_HAS_NAME(0, eth_ker)
-	.pclken_ker = {.bus = DT_INST_CLOCKS_CELL_BY_NAME(0, eth_ker, bus),
-		       .enr = DT_INST_CLOCKS_CELL_BY_NAME(0, eth_ker, bits)},
+	.pclken_ker = STM32_DT_INST_CLOCK_INFO_BY_NAME(0, eth_ker),
 #endif
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -42,13 +42,6 @@ LOG_MODULE_REGISTER(eth_stm32_hal, CONFIG_ETHERNET_LOG_LEVEL);
 #define ETH_STM32_HAL_MTU NET_ETH_MTU
 #define ETH_STM32_HAL_FRAME_SIZE_MAX (ETH_STM32_HAL_MTU + 18)
 
-/* Temporary helper macro to smooth moving clocks from mac node to controller (parent) node */
-#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk_tx)
-#define MAC_CLOCKS_NODE		DT_INST_PARENT(0)
-#else
-#define MAC_CLOCKS_NODE		DT_DRV_INST(0)
-#endif
-
 uint8_t dma_rx_buffer[ETH_RXBUFNB][ETH_STM32_RX_BUF_SIZE] __eth_stm32_buf;
 uint8_t dma_tx_buffer[ETH_TXBUFNB][ETH_STM32_TX_BUF_SIZE] __eth_stm32_buf;
 
@@ -166,16 +159,16 @@ static int eth_initialize(const struct device *dev)
 		(clock_control_subsys_t)&cfg->pclken_tx);
 	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 		(clock_control_subsys_t)&cfg->pclken_rx);
-#if DT_CLOCKS_HAS_NAME(MAC_CLOCKS_NODE, mac_clk_ptp)
+#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk_ptp)
 	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 		(clock_control_subsys_t)&cfg->pclken_ptp);
 #endif
-#if DT_CLOCKS_HAS_NAME(MAC_CLOCKS_NODE, eth_ker)
+#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), eth_ker)
 	ret |= clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 				       (clock_control_subsys_t)&cfg->pclken_ker,
 				       NULL);
 #endif
-#if DT_CLOCKS_HAS_NAME(MAC_CLOCKS_NODE, mac_clk)
+#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk)
 	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 				(clock_control_subsys_t)&cfg->pclken_mac);
 #endif
@@ -408,16 +401,16 @@ PINCTRL_DT_INST_DEFINE(0);
 static const struct eth_stm32_hal_dev_cfg eth0_config = {
 	.config_func = eth0_irq_config,
 	.pclken = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), stm_eth),
-	.pclken_tx = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, mac_clk_tx),
-	.pclken_rx = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, mac_clk_rx),
-#if DT_CLOCKS_HAS_NAME(MAC_CLOCKS_NODE, mac_clk_ptp)
-	.pclken_ptp = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, mac_clk_ptp),
+	.pclken_tx = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), mac_clk_tx),
+	.pclken_rx = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), mac_clk_rx),
+#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk_ptp)
+	.pclken_ptp = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), mac_clk_ptp),
 #endif
-#if DT_CLOCKS_HAS_NAME(MAC_CLOCKS_NODE, mac_clk)
-	.pclken_mac = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, mac_clk),
+#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk)
+	.pclken_mac = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), mac_clk),
 #endif
-#if DT_CLOCKS_HAS_NAME(MAC_CLOCKS_NODE, eth_ker)
-	.pclken_ker = STM32_CLOCK_INFO_BY_NAME(MAC_CLOCKS_NODE, eth_ker),
+#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), eth_ker)
+	.pclken_ker = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), eth_ker),
 #endif
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -20,6 +20,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>
 #include <ethernet/eth_stats.h>
+#include <stdint.h>
 
 #include "eth.h"
 #include "eth_stm32_hal_priv.h"
@@ -152,30 +153,21 @@ static int eth_initialize(const struct device *dev)
 		return -ENODEV;
 	}
 
-	/* enable clock */
-	ret = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-		(clock_control_subsys_t)&cfg->pclken);
-	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-		(clock_control_subsys_t)&cfg->pclken_tx);
-	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-		(clock_control_subsys_t)&cfg->pclken_rx);
-#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk_ptp)
-	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-		(clock_control_subsys_t)&cfg->pclken_ptp);
-#endif
-#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), eth_ker)
-	ret |= clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				       (clock_control_subsys_t)&cfg->pclken_ker,
-				       NULL);
-#endif
-#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk)
-	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t)&cfg->pclken_mac);
-#endif
+	/* Enable clocks */
+	for (size_t n = 0; n < cfg->pclken_cnt; n++) {
+		if (n == cfg->kclk_sel_idx) {
+			ret = clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+						      (clock_control_subsys_t)&cfg->pclken[n],
+						      NULL);
+		} else {
+			ret = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+					       (clock_control_subsys_t)&cfg->pclken[n]);
+		}
 
-	if (ret) {
-		LOG_ERR("Failed to enable ethernet clock");
-		return -EIO;
+		if (ret != 0) {
+			LOG_ERR("Failed to setup ethernet clock #%zu", n);
+			return -EIO;
+		}
 	}
 
 	/* configure pinmux */
@@ -398,19 +390,22 @@ static void eth0_irq_config(void)
 
 PINCTRL_DT_INST_DEFINE(0);
 
+static const struct stm32_pclken eth0_pclken[] = STM32_DT_CLOCKS(DT_INST_PARENT(0));
+
+#define ETH_STM32_HAS_PTP_CLOCK	DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk_ptp)
+
 static const struct eth_stm32_hal_dev_cfg eth0_config = {
 	.config_func = eth0_irq_config,
-	.pclken = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), stm_eth),
-	.pclken_tx = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), mac_clk_tx),
-	.pclken_rx = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), mac_clk_rx),
-#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk_ptp)
-	.pclken_ptp = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), mac_clk_ptp),
-#endif
-#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), mac_clk)
-	.pclken_mac = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), mac_clk),
-#endif
-#if DT_CLOCKS_HAS_NAME(DT_INST_PARENT(0), eth_ker)
-	.pclken_ker = STM32_CLOCK_INFO_BY_NAME(DT_INST_PARENT(0), eth_ker),
+	.pclken = eth0_pclken,
+	.pclken_cnt = DT_NUM_CLOCKS(DT_INST_PARENT(0)),
+	.kclk_sel_idx = COND_CODE_1(DT_PROP_HAS_NAME(DT_INST_PARENT(0), clocks, eth_ker),
+				    (DT_PHA_ELEM_IDX_BY_NAME(DT_INST_PARENT(0), clocks, eth_ker)),
+				    (UINT8_MAX)),
+#ifdef CONFIG_PTP_CLOCK_STM32_HAL
+	/* If no PTP clock is defined, bus clock ("stm-eth") gives the ethernet clock rate */
+	.rate_pclken_idx = DT_PHA_ELEM_IDX_BY_NAME(DT_INST_PARENT(0), clocks,
+						   COND_CODE_1(ETH_STM32_HAS_PTP_CLOCK,
+							       (mac_clk_ptp), (stm_eth))),
 #endif
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -105,17 +105,11 @@ extern ETH_DMADescTypeDef dma_tx_desc_tab[ETH_TXBUFNB];
 struct eth_stm32_hal_dev_cfg {
 	void (*config_func)(void);
 	struct stm32_pclken pclken;
-#if DT_INST_CLOCKS_HAS_NAME(0, mac_clk)
 	struct stm32_pclken pclken_mac;
-#endif
-#if DT_INST_CLOCKS_HAS_NAME(0, eth_ker)
 	struct stm32_pclken pclken_ker;
-#endif
 	struct stm32_pclken pclken_rx;
 	struct stm32_pclken pclken_tx;
-#if DT_INST_CLOCKS_HAS_NAME(0, mac_clk_ptp)
 	struct stm32_pclken pclken_ptp;
-#endif
 	const struct pinctrl_dev_config *pcfg;
 };
 

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -104,12 +104,14 @@ extern ETH_DMADescTypeDef dma_tx_desc_tab[ETH_TXBUFNB];
 /* Device constant configuration parameters */
 struct eth_stm32_hal_dev_cfg {
 	void (*config_func)(void);
-	struct stm32_pclken pclken;
-	struct stm32_pclken pclken_mac;
-	struct stm32_pclken pclken_ker;
-	struct stm32_pclken pclken_rx;
-	struct stm32_pclken pclken_tx;
-	struct stm32_pclken pclken_ptp;
+	const struct stm32_pclken *pclken;
+	uint8_t pclken_cnt;
+	/* Index of the clock used for kernel clock selection ("eth-ker"), or UINT8_MAX if none */
+	uint8_t kclk_sel_idx;
+#ifdef CONFIG_PTP_CLOCK_STM32_HAL
+	/* Index of the clock that gives the ethernet clock rate */
+	uint8_t rate_pclken_idx;
+#endif
 	const struct pinctrl_dev_config *pcfg;
 };
 

--- a/drivers/ethernet/eth_stm32_hal_ptp.c
+++ b/drivers/ethernet/eth_stm32_hal_ptp.c
@@ -303,12 +303,9 @@ static int ptp_stm32_init(const struct device *port)
 	eth_stm32_ptp_enable_timestamping(heth);
 
 	/* Query ethernet clock rate */
-	ret = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet)
-				     (clock_control_subsys_t)&eth_cfg->pclken,
-#else
-				     (clock_control_subsys_t)&eth_cfg->pclken_ptp,
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet) */
+	clock_control_subsys_t rate_clk = (void *)&eth_cfg->pclken[eth_cfg->rate_pclken_idx];
+
+	ret = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE), rate_clk,
 				     &ptp_hclk_rate);
 	if (ret) {
 		LOG_ERR("Failed to query ethernet clock");

--- a/dts/arm/st/f1/stm32f107.dtsi
+++ b/dts/arm/st/f1/stm32f107.dtsi
@@ -21,15 +21,14 @@
 
 		ethernet@40028000 {
 			reg = <0x40028000 0x2000>;
-			clock-names = "stm-eth";
-			clocks = <&rcc STM32_CLOCK(AHB1, 14)>;
+			clock-names = "stm-eth", "mac-clk-tx", "mac-clk-rx";
+			clocks = <&rcc STM32_CLOCK(AHB1, 14)>,
+				 <&rcc STM32_CLOCK(AHB1, 15)>,
+				 <&rcc STM32_CLOCK(AHB1, 16)>;
 
 			mac: ethernet {
 				compatible = "st,stm32-ethernet";
 				interrupts = <61 0>;
-				clock-names = "mac-clk-tx", "mac-clk-rx";
-				clocks = <&rcc STM32_CLOCK(AHB1, 15)>,
-					 <&rcc STM32_CLOCK(AHB1, 16)>;
 				status = "disabled";
 			};
 

--- a/dts/arm/st/f2/stm32f207.dtsi
+++ b/dts/arm/st/f2/stm32f207.dtsi
@@ -13,17 +13,15 @@
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
 			compatible = "st,stm32-ethernet-controller";
-			clock-names = "stm-eth";
-			clocks = <&rcc STM32_CLOCK(AHB1, 25)>;
+			clock-names = "stm-eth", "mac-clk-tx", "mac-clk-rx", "mac-clk-ptp";
+			clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
+				 <&rcc STM32_CLOCK(AHB1, 26)>,
+				 <&rcc STM32_CLOCK(AHB1, 27)>,
+				 <&rcc STM32_CLOCK(AHB1, 28)>;
 
 			mac: ethernet {
 				compatible = "st,stm32-ethernet";
 				interrupts = <61 0>;
-				clock-names = "mac-clk-tx", "mac-clk-rx",
-					      "mac-clk-ptp";
-				clocks = <&rcc STM32_CLOCK(AHB1, 26)>,
-					 <&rcc STM32_CLOCK(AHB1, 27)>,
-					 <&rcc STM32_CLOCK(AHB1, 28)>;
 				status = "disabled";
 			};
 

--- a/dts/arm/st/f4/stm32f407.dtsi
+++ b/dts/arm/st/f4/stm32f407.dtsi
@@ -13,17 +13,15 @@
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
 			compatible = "st,stm32-ethernet-controller";
-			clock-names = "stm-eth";
-			clocks = <&rcc STM32_CLOCK(AHB1, 25)>;
+			clock-names = "stm-eth", "mac-clk-tx", "mac-clk-rx", "mac-clk-ptp";
+			clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
+				 <&rcc STM32_CLOCK(AHB1, 26)>,
+				 <&rcc STM32_CLOCK(AHB1, 27)>,
+				 <&rcc STM32_CLOCK(AHB1, 28)>;
 
 			mac: ethernet {
 				compatible = "st,stm32-ethernet";
 				interrupts = <61 0>;
-				clock-names = "mac-clk-tx", "mac-clk-rx",
-					      "mac-clk-ptp";
-				clocks = <&rcc STM32_CLOCK(AHB1, 26)>,
-					 <&rcc STM32_CLOCK(AHB1, 27)>,
-					 <&rcc STM32_CLOCK(AHB1, 28)>;
 				status = "disabled";
 			};
 

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -79,17 +79,15 @@
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
 			compatible = "st,stm32-ethernet-controller";
-			clock-names = "stm-eth";
-			clocks = <&rcc STM32_CLOCK(AHB1, 25)>;
+			clock-names = "stm-eth", "mac-clk-tx", "mac-clk-rx", "mac-clk-ptp";
+			clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
+				 <&rcc STM32_CLOCK(AHB1, 26)>,
+				 <&rcc STM32_CLOCK(AHB1, 27)>,
+				 <&rcc STM32_CLOCK(AHB1, 28)>;
 
 			mac: ethernet {
 				compatible = "st,stm32-ethernet";
 				interrupts = <61 0>;
-				clock-names = "mac-clk-tx", "mac-clk-rx",
-					      "mac-clk-ptp";
-				clocks = <&rcc STM32_CLOCK(AHB1, 26)>,
-					 <&rcc STM32_CLOCK(AHB1, 27)>,
-					 <&rcc STM32_CLOCK(AHB1, 28)>;
 				status = "disabled";
 			};
 

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -72,17 +72,15 @@
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
 			compatible = "st,stm32-ethernet-controller";
-			clock-names = "stm-eth";
-			clocks = <&rcc STM32_CLOCK(AHB1, 25)>;
+			clock-names = "stm-eth", "mac-clk-tx", "mac-clk-rx", "mac-clk-ptp";
+			clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
+				 <&rcc STM32_CLOCK(AHB1, 26)>,
+				 <&rcc STM32_CLOCK(AHB1, 27)>,
+				 <&rcc STM32_CLOCK(AHB1, 28)>;
 
 			mac: ethernet {
 				compatible = "st,stm32-ethernet";
 				interrupts = <61 0>;
-				clock-names = "mac-clk-tx", "mac-clk-rx",
-					      "mac-clk-ptp";
-				clocks = <&rcc STM32_CLOCK(AHB1, 26)>,
-					 <&rcc STM32_CLOCK(AHB1, 27)>,
-					 <&rcc STM32_CLOCK(AHB1, 28)>;
 				status = "disabled";
 			};
 

--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -23,16 +23,15 @@
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
 			compatible = "st,stm32-ethernet-controller";
-			clock-names = "stm-eth";
-			clocks = <&rcc STM32_CLOCK(AHB1, 19)>;
+			clock-names = "stm-eth", "mac-clk-tx", "mac-clk-rx";
+			clocks = <&rcc STM32_CLOCK(AHB1, 19)>,
+				 <&rcc STM32_CLOCK(AHB1, 20)>,
+				 <&rcc STM32_CLOCK(AHB1, 21)>;
 
 			mac: ethernet {
 				compatible = "st,stm32h5-ethernet", "st,stm32h7-ethernet",
 					     "st,stm32-ethernet";
 				interrupts = <106 0>;
-				clock-names = "mac-clk-tx", "mac-clk-rx";
-				clocks = <&rcc STM32_CLOCK(AHB1, 20)>,
-					 <&rcc STM32_CLOCK(AHB1, 21)>;
 				status = "disabled";
 			};
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1147,15 +1147,14 @@
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
 			compatible = "st,stm32-ethernet-controller";
-			clock-names = "stm-eth";
-			clocks = <&rcc STM32_CLOCK(AHB1, 15)>;
+			clock-names = "stm-eth", "mac-clk-tx", "mac-clk-rx";
+			clocks = <&rcc STM32_CLOCK(AHB1, 15)>,
+				 <&rcc STM32_CLOCK(AHB1, 16)>,
+				 <&rcc STM32_CLOCK(AHB1, 17)>;
 
 			mac: ethernet {
 				compatible = "st,stm32h7-ethernet", "st,stm32-ethernet";
 				interrupts = <61 0>;
-				clock-names = "mac-clk-tx", "mac-clk-rx";
-				clocks = <&rcc STM32_CLOCK(AHB1, 16)>,
-					 <&rcc STM32_CLOCK(AHB1, 17)>;
 				memory-regions = <&sram2>;
 				status = "disabled";
 			};

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -930,15 +930,14 @@
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
 			compatible = "st,stm32-ethernet-controller";
-			clock-names = "stm-eth";
-			clocks = <&rcc STM32_CLOCK(AHB1, 15)>;
+			clock-names = "stm-eth", "mac-clk-tx", "mac-clk-rx";
+			clocks = <&rcc STM32_CLOCK(AHB1, 15)>,
+				 <&rcc STM32_CLOCK(AHB1, 16)>,
+				 <&rcc STM32_CLOCK(AHB1, 17)>;
 
 			mac: ethernet {
 				compatible = "st,stm32h7-ethernet", "st,stm32-ethernet";
 				interrupts = <92 0>;
-				clock-names = "mac-clk-tx", "mac-clk-rx";
-				clocks = <&rcc STM32_CLOCK(AHB1, 16)>,
-					 <&rcc STM32_CLOCK(AHB1, 17)>;
 				memory-regions = <&sram2>;
 				status = "disabled";
 			};

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -250,19 +250,18 @@
 		eth0: ethernet@5800a000 {
 			reg = <0x5800a000 0x2000>;
 			compatible = "st,stm32-ethernet-controller";
-			clock-names = "stm-eth";
-			clocks = <&rcc STM32_CLOCK(AHB6, 7)>;
+			clock-names = "stm-eth", "mac-clk", "mac-clk-tx", "mac-clk-rx", "eth-ker";
+			clocks = <&rcc STM32_CLOCK(AHB6, 7)>,
+				 <&rcc STM32_CLOCK(AHB6, 8)>,
+				 <&rcc STM32_CLOCK(AHB6, 9)>,
+				 <&rcc STM32_CLOCK(AHB6, 10)>,
+				 <&rcc STM32_SRC_PLL4_Q ETH1_SEL(0)>;
 
 			mac: ethernet {
 				compatible = "st,stm32mp13-ethernet", "st,stm32h7-ethernet",
 					     "st,stm32-ethernet";
 				interrupts = <GIC_SPI 62 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 					     <GIC_SPI 63 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-				clock-names = "mac-clk", "mac-clk-tx", "mac-clk-rx", "eth-ker";
-				clocks = <&rcc STM32_CLOCK(AHB6, 8)>,
-					 <&rcc STM32_CLOCK(AHB6, 9)>,
-					 <&rcc STM32_CLOCK(AHB6, 10)>,
-					 <&rcc STM32_SRC_PLL4_Q ETH1_SEL(0)>;
 				status = "disabled";
 			};
 

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -790,16 +790,15 @@
 		ethernet@58036000 {
 			reg = <0x58036000 0x8000>;
 			compatible = "st,stm32-ethernet-controller";
-			clock-names = "stm-eth";
-			clocks = <&rcc STM32_CLOCK(AHB5, 22)>;
+			clock-names = "stm-eth", "mac-clk-tx", "mac-clk-rx";
+			clocks = <&rcc STM32_CLOCK(AHB5, 22)>,
+				 <&rcc STM32_CLOCK(AHB5, 23)>,
+				 <&rcc STM32_CLOCK(AHB5, 24)>;
 
 			mac: ethernet {
 				compatible = "st,stm32n6-ethernet", "st,stm32h7-ethernet",
 					     "st,stm32-ethernet";
 				interrupts = <179 0>;
-				clock-names = "mac-clk-tx", "mac-clk-rx";
-				clocks = <&rcc STM32_CLOCK(AHB5, 23)>,
-					 <&rcc STM32_CLOCK(AHB5, 24)>;
 				status = "disabled";
 			};
 

--- a/dts/bindings/ethernet/st,stm32-ethernet-common.yaml
+++ b/dts/bindings/ethernet/st,stm32-ethernet-common.yaml
@@ -8,10 +8,6 @@ include: [ethernet-controller.yaml, pinctrl-device.yaml]
 properties:
   interrupts:
     required: true
-  clocks:
-    required: true
-  clock-names:
-    required: true
   pinctrl-0:
     required: true
   pinctrl-names:


### PR DESCRIPTION
Factorize STM32 interface clocks configuration in a single array. This change eases later integration of other SoCs with different clocks names while the driver only has to enable (possibly disable) the clocks on a single sequence.

Ethernet MAC clocks are moved from MAC node to ethernet controller (parent) node for sake of simplicity.