### PR TITLE
drivers: serial: ns16550: support loopback mode and interrupt API

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -245,6 +245,11 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "NS16550(s) in DT need CONFIG_PCIE");
 #define MSR_RI 0x40   /* complement of ring signal */
 #define MSR_DCD 0x80  /* complement of dcd */
 
+/* constants for uart status register */
+#define USR_TFNF 0x02 /* Transmit FIFO Not Full */
+#define USR_TFE 0x04 /* Transmit FIFO Empty */
+#define USR_RFNE 0x08 /* Receive FIFO Not Empty */
+
 #define THR(dev) (get_port(dev) + (REG_THR * reg_interval(dev)))
 #define RDR(dev) (get_port(dev) + (REG_RDR * reg_interval(dev)))
 #define BRDL(dev) (get_port(dev) + (REG_BRDL * reg_interval(dev)))
@@ -1132,7 +1137,15 @@ static int uart_ns16550_irq_tx_ready(const struct device *dev)
 	struct uart_ns16550_dev_data *data = dev->data;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
+#ifdef CONFIG_UART_NS16550_DW8250_DW_APB
+	/* Use USR register to check if TX FIFO has space */
+	const struct uart_ns16550_dev_config * const dev_cfg = dev->config;
+
+	int ret = ((ns16550_inbyte(dev_cfg, USR(dev)) & (USR_TFNF | USR_TFE)) &&
+		(ns16550_inbyte(dev_cfg, IER(dev)) & IER_TBE)) ? 1 : 0;
+#else
 	int ret = ((IIRC(dev) & IIR_ID) == IIR_THRE) ? 1 : 0;
+#endif
 
 	k_spin_unlock(&data->lock, key);
 
@@ -1205,7 +1218,15 @@ static int uart_ns16550_irq_rx_ready(const struct device *dev)
 	struct uart_ns16550_dev_data *data = dev->data;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
+#ifdef CONFIG_UART_NS16550_DW8250_DW_APB
+	/* Use USR register to check if RX FIFO has data */
+	const struct uart_ns16550_dev_config * const dev_cfg = dev->config;
+
+	int ret = ((ns16550_inbyte(dev_cfg, USR(dev)) & USR_RFNE) &&
+		(ns16550_inbyte(dev_cfg, IER(dev)) & IER_RXRDY)) ? 1 : 0;
+#else
 	int ret = ((IIRC(dev) & IIR_ID) == IIR_RBRF) ? 1 : 0;
+#endif
 
 	k_spin_unlock(&data->lock, key);
 
@@ -1260,7 +1281,18 @@ static int uart_ns16550_irq_is_pending(const struct device *dev)
 	struct uart_ns16550_dev_data *data = dev->data;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
+#ifdef CONFIG_UART_NS16550_DW8250_DW_APB
+	/* Use USR register to check if any IRQ is pending */
+	const struct uart_ns16550_dev_config * const dev_cfg = dev->config;
+
+	bool tx_pending = ((ns16550_inbyte(dev_cfg, USR(dev)) & (USR_TFNF | USR_TFE)) &&
+		(ns16550_inbyte(dev_cfg, IER(dev)) & IER_TBE));
+	bool rx_pending = ((ns16550_inbyte(dev_cfg, USR(dev)) & USR_RFNE) &&
+		(ns16550_inbyte(dev_cfg, IER(dev)) & IER_RXRDY));
+	int ret = (tx_pending || rx_pending) ? 1 : 0;
+#else
 	int ret = (!(IIRC(dev) & IIR_NIP)) ? 1 : 0;
+#endif
 
 	k_spin_unlock(&data->lock, key);
 

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -355,6 +355,7 @@ struct uart_ns16550_dev_config {
 #if UART_NS16550_RESET_ENABLED
 	struct reset_dt_spec reset_spec;
 #endif
+	bool loopback;
 };
 
 /** Device data structure */
@@ -701,6 +702,10 @@ static int uart_ns16550_configure(const struct device *dev,
 		mdc |= MCR_AFCE;
 	}
 #endif
+
+	if (dev_cfg->loopback) {
+		mdc |= MCR_LOOP;
+	}
 
 	ns16550_outbyte(dev_cfg, MDC(dev), mdc);
 
@@ -1982,7 +1987,8 @@ static DEVICE_API(uart, uart_ns16550_driver_api) = {
 		IF_ENABLED(CONFIG_PINCTRL,                                           \
 			(.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),))              \
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(n, resets),                         \
-			(.reset_spec = RESET_DT_SPEC_INST_GET(n),))
+			(.reset_spec = RESET_DT_SPEC_INST_GET(n),))                  \
+		.loopback = DT_INST_PROP(n, loopback),
 
 #define UART_NS16550_COMMON_DEV_DATA_INITIALIZER(n)                                  \
 		.uart_config.baudrate = DT_INST_PROP_OR(n, current_speed, 0),        \

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -687,7 +687,10 @@ static int uart_ns16550_configure(const struct device *dev,
 		uart_cfg.parity = LCR_PDIS;
 		break;
 	case UART_CFG_PARITY_EVEN:
-		uart_cfg.parity = LCR_EPS;
+		uart_cfg.parity = LCR_EPS | LCR_PEN;
+		break;
+	case UART_CFG_PARITY_ODD:
+		uart_cfg.parity = LCR_PEN;
 		break;
 	default:
 		ret = -ENOTSUP;

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -21,3 +21,9 @@ properties:
   io-mapped:
     type: boolean
     description: specify registers are IO mapped or memory mapped
+
+  loopback:
+    type: boolean
+    description: |
+      Connects TX to RX internally creating a loop back connection. Useful
+      for testing.


### PR DESCRIPTION
This PR includes several fixes for the ns16550 uart driver:

- Add support for loopback mode in ns16550 uart driver, by setting LOOP
bit in MDC register.
- correctly support the uart interrupt API for IP variants that feature the USR register. The base ns16550 IP spec does not seem to be able to support the interrupt API correctly, since it should be possible to call `uart_irq_pending` multiple times after calling `uart_irq_update` (as far as I can tell from reading the UART API)
- support odd parity in the driver

Signed-off-by: Daniel DeGrasse <ddegrasse@tenstorrent.com>