### PR TITLE
x86: fix issues found by ruff and formatting `gen_*.py` scripts

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -5,10 +5,6 @@
 # remove entries for files that pass CI compliance testing.
 
 [lint.per-file-ignores]
-"./arch/x86/gen_gdt.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-]
 "./arch/x86/gen_idt.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP030",    # https://docs.astral.sh/ruff/rules/format-literals

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -1138,7 +1138,6 @@
 
 [format]
 exclude = [
-    "./arch/x86/gen_gdt.py",
     "./arch/x86/gen_idt.py",
     "./arch/x86/gen_mmu.py",
     "./arch/x86/zefi/zefi.py",

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -5,11 +5,6 @@
 # remove entries for files that pass CI compliance testing.
 
 [lint.per-file-ignores]
-"./arch/x86/gen_idt.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "UP030",    # https://docs.astral.sh/ruff/rules/format-literals
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-]
 "./arch/x86/gen_mmu.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -1133,7 +1133,6 @@
 
 [format]
 exclude = [
-    "./arch/x86/gen_idt.py",
     "./arch/x86/gen_mmu.py",
     "./arch/x86/zefi/zefi.py",
     "./boards/microchip/mec172xevb_assy6906/support/mec172x_remote_flasher.py",

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -5,12 +5,6 @@
 # remove entries for files that pass CI compliance testing.
 
 [lint.per-file-ignores]
-"./arch/x86/gen_mmu.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
-    "UP034",    # https://docs.astral.sh/ruff/rules/extraneous-parentheses
-    "UP039",    # https://docs.astral.sh/ruff/rules/unnecessary-class-parentheses
-]
 "./arch/x86/zefi/zefi.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -1127,7 +1127,6 @@
 
 [format]
 exclude = [
-    "./arch/x86/gen_mmu.py",
     "./arch/x86/zefi/zefi.py",
     "./boards/microchip/mec172xevb_assy6906/support/mec172x_remote_flasher.py",
     "./doc/_scripts/gen_devicetree_rest.py",

--- a/arch/x86/gen_gdt.py
+++ b/arch/x86/gen_gdt.py
@@ -36,16 +36,14 @@ flat code/data segments for ring 3 execution.
 """
 
 import argparse
-import sys
-import struct
 import os
-
-from packaging import version
+import struct
+import sys
 
 import elftools
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
-
+from packaging import version
 
 if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
@@ -75,7 +73,7 @@ ACCESS_RW = 1 << 1  # read or write permission
 
 def create_gdt_pseudo_desc(addr, size):
     """Create pseudo GDT descriptor"""
-    debug("create pseudo descriptor: %x %x" % (addr, size))
+    debug(f"create pseudo descriptor: {addr:x} {size:x}")
     # ...and take back one byte for the Intel god whose Ark this is...
     size = size - 1
     return struct.pack(GDT_PD_FMT, size, addr, 0)
@@ -98,8 +96,7 @@ GDT_ENT_FMT = "<HHBBBB"
 
 def create_code_data_entry(base, limit, dpl, flags, access):
     """Create GDT entry for code or data"""
-    debug("create code or data entry: %x %x %x %x %x" %
-          (base, limit, dpl, flags, access))
+    debug(f"create code or data entry: {base:x} {limit:x} {dpl:x} {flags:x} {access:x}")
 
     base_lo, base_mid, base_hi, limit_lo, limit_hi = chop_base_limit(base,
                                                                      limit)
@@ -127,7 +124,7 @@ def create_code_data_entry(base, limit, dpl, flags, access):
 
 def create_tss_entry(base, limit, dpl):
     """Create GDT TSS entry"""
-    debug("create TSS entry: %x %x %x" % (base, limit, dpl))
+    debug(f"create TSS entry: {base:x} {limit:x} {dpl:x}")
     present = 1
 
     base_lo, base_mid, base_hi, limit_lo, limit_hi, = chop_base_limit(base,

--- a/arch/x86/gen_gdt.py
+++ b/arch/x86/gen_gdt.py
@@ -98,8 +98,7 @@ def create_code_data_entry(base, limit, dpl, flags, access):
     """Create GDT entry for code or data"""
     debug(f"create code or data entry: {base:x} {limit:x} {dpl:x} {flags:x} {access:x}")
 
-    base_lo, base_mid, base_hi, limit_lo, limit_hi = chop_base_limit(base,
-                                                                     limit)
+    base_lo, base_mid, base_hi, limit_lo, limit_hi = chop_base_limit(base, limit)
 
     # This is a valid descriptor
     present = 1
@@ -118,8 +117,7 @@ def create_code_data_entry(base, limit, dpl, flags, access):
     access = access | (present << 7) | (dpl << 5) | (desc_type << 4) | accessed
     flags = flags | (size << 6) | limit_hi
 
-    return struct.pack(GDT_ENT_FMT, limit_lo, base_lo, base_mid,
-                       access, flags, base_hi)
+    return struct.pack(GDT_ENT_FMT, limit_lo, base_lo, base_mid, access, flags, base_hi)
 
 
 def create_tss_entry(base, limit, dpl):
@@ -127,8 +125,13 @@ def create_tss_entry(base, limit, dpl):
     debug(f"create TSS entry: {base:x} {limit:x} {dpl:x}")
     present = 1
 
-    base_lo, base_mid, base_hi, limit_lo, limit_hi, = chop_base_limit(base,
-                                                                      limit)
+    (
+        base_lo,
+        base_mid,
+        base_hi,
+        limit_lo,
+        limit_hi,
+    ) = chop_base_limit(base, limit)
 
     type_code = 0x9  # non-busy 32-bit TSS descriptor
     gran = 0
@@ -136,16 +139,14 @@ def create_tss_entry(base, limit, dpl):
     flags = (gran << 7) | limit_hi
     type_byte = (present << 7) | (dpl << 5) | type_code
 
-    return struct.pack(GDT_ENT_FMT, limit_lo, base_lo, base_mid,
-                       type_byte, flags, base_hi)
+    return struct.pack(GDT_ENT_FMT, limit_lo, base_lo, base_mid, type_byte, flags, base_hi)
 
 
 def get_symbols(obj):
     """Extract all symbols from ELF file object"""
     for section in obj.iter_sections():
         if isinstance(section, SymbolTableSection):
-            return {sym.name: sym.entry.st_value
-                    for sym in section.iter_symbols()}
+            return {sym.name: sym.entry.st_value for sym in section.iter_symbols()}
 
     raise LookupError("Could not find symbol table")
 
@@ -155,14 +156,15 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
 
-    parser.add_argument("-k", "--kernel", required=True,
-                        help="Zephyr kernel image")
-    parser.add_argument("-v", "--verbose", action="store_true",
-                        help="Print extra debugging information")
-    parser.add_argument("-o", "--output-gdt", required=True,
-                        help="output GDT binary")
+    parser.add_argument("-k", "--kernel", required=True, help="Zephyr kernel image")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Print extra debugging information"
+    )
+    parser.add_argument("-o", "--output-gdt", required=True, help="output GDT binary")
     args = parser.parse_args()
     if "VERBOSE" in os.environ:
         args.verbose = 1
@@ -202,12 +204,10 @@ def main():
         output_fp.write(create_gdt_pseudo_desc(gdt_base, num_entries * 8))
 
         # Selector 0x08: code descriptor
-        output_fp.write(create_code_data_entry(0, 0xFFFFF, 0,
-                                        FLAGS_GRAN, ACCESS_EX | ACCESS_RW))
+        output_fp.write(create_code_data_entry(0, 0xFFFFF, 0, FLAGS_GRAN, ACCESS_EX | ACCESS_RW))
 
         # Selector 0x10: data descriptor
-        output_fp.write(create_code_data_entry(0, 0xFFFFF, 0,
-                                        FLAGS_GRAN, ACCESS_RW))
+        output_fp.write(create_code_data_entry(0, 0xFFFFF, 0, FLAGS_GRAN, ACCESS_RW))
 
         if num_entries >= 5:
             main_tss = syms["_main_tss"]
@@ -221,12 +221,12 @@ def main():
 
         if num_entries >= 7:
             # Selector 0x28: code descriptor, dpl = 3
-            output_fp.write(create_code_data_entry(0, 0xFFFFF, 3,
-                                            FLAGS_GRAN, ACCESS_EX | ACCESS_RW))
+            output_fp.write(
+                create_code_data_entry(0, 0xFFFFF, 3, FLAGS_GRAN, ACCESS_EX | ACCESS_RW)
+            )
 
             # Selector 0x30: data descriptor, dpl = 3
-            output_fp.write(create_code_data_entry(0, 0xFFFFF, 3,
-                                            FLAGS_GRAN, ACCESS_RW))
+            output_fp.write(create_code_data_entry(0, 0xFFFFF, 3, FLAGS_GRAN, ACCESS_RW))
 
         if use_tls:
             # Selector 0x18, 0x28 or 0x38 (depending on entries above):
@@ -234,8 +234,7 @@ def main():
             #
             # for use with thread local storage while this will be
             # modified at runtime.
-            output_fp.write(create_code_data_entry(0, 0xFFFFF, 3,
-                                            FLAGS_GRAN, ACCESS_RW))
+            output_fp.write(create_code_data_entry(0, 0xFFFFF, 3, FLAGS_GRAN, ACCESS_RW))
 
 
 if __name__ == "__main__":

--- a/arch/x86/gen_idt.py
+++ b/arch/x86/gen_idt.py
@@ -70,8 +70,7 @@ def create_irq_gate(handler, dpl):
     offset_hi = handler >> 16
     offset_lo = handler & 0xFFFF
 
-    data = struct.pack(gate_desc_format, offset_lo, KERNEL_CODE_SEG, 0,
-                       type_attr, offset_hi)
+    data = struct.pack(gate_desc_format, offset_lo, KERNEL_CODE_SEG, 0, type_attr, offset_hi)
     return data
 
 
@@ -189,27 +188,27 @@ def setup_idt(spur_code, spur_nocode, intlist, max_vec, max_irq):
 def get_symbols(obj):
     for section in obj.iter_sections():
         if isinstance(section, SymbolTableSection):
-            return {sym.name: sym.entry.st_value
-                    for sym in section.iter_symbols()}
+            return {sym.name: sym.entry.st_value for sym in section.iter_symbols()}
 
     raise LookupError("Could not find symbol table")
 
+
 # struct genidt_header_s {
-#	uint32_t spurious_addr;
-#	uint32_t spurious_no_error_addr;
-#	int32_t num_entries;
+# uint32_t spurious_addr;
+# uint32_t spurious_no_error_addr;
+# int32_t num_entries;
 # };
 
 
 intlist_header_fmt = "<II"
 
 # struct genidt_entry_s {
-#	uint32_t isr;
-#	int32_t irq;
-#	int32_t priority;
-#	int32_t vector_id;
-#	int32_t dpl;
-#	int32_t tss;
+# uint32_t isr;
+# int32_t irq;
+# int32_t priority;
+# int32_t vector_id;
+# int32_t dpl;
+# int32_t tss;
 # };
 
 intlist_entry_fmt = "<Iiiiii"
@@ -228,8 +227,7 @@ def get_intlist(elf):
     debug(f"spurious handler (code)    : {hex(header[0]):s}")
     debug(f"spurious handler (no code) : {hex(header[1]):s}")
 
-    intlist = [i for i in
-               struct.iter_unpack(intlist_entry_fmt, intdata)]
+    intlist = [i for i in struct.iter_unpack(intlist_entry_fmt, intdata)]
 
     debug("Configured interrupt routing")
     debug("handler    irq pri vec dpl")
@@ -251,18 +249,26 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
 
-    parser.add_argument("-m", "--vector-map", required=True,
-                        help="Output file mapping IRQ lines to IDT vectors")
-    parser.add_argument("-o", "--output-idt", required=True,
-                        help="Output file containing IDT binary")
-    parser.add_argument("-a", "--output-vectors-alloc", required=False,
-                        help="Output file indicating allocated vectors")
-    parser.add_argument("-k", "--kernel", required=True,
-                        help="Zephyr kernel image")
-    parser.add_argument("-v", "--verbose", action="store_true",
-                        help="Print extra debugging information")
+    parser.add_argument(
+        "-m", "--vector-map", required=True, help="Output file mapping IRQ lines to IDT vectors"
+    )
+    parser.add_argument(
+        "-o", "--output-idt", required=True, help="Output file containing IDT binary"
+    )
+    parser.add_argument(
+        "-a",
+        "--output-vectors-alloc",
+        required=False,
+        help="Output file indicating allocated vectors",
+    )
+    parser.add_argument("-k", "--kernel", required=True, help="Zephyr kernel image")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Print extra debugging information"
+    )
     args = parser.parse_args()
     if "VERBOSE" in os.environ:
         args.verbose = 1
@@ -274,7 +280,7 @@ def create_irq_vectors_allocated(vectors, spur_code, spur_nocode, filename):
     # interrupt handlers installed, they are free for runtime installation
     # of interrupts
     num_chars = (len(vectors) + 7) // 8
-    vbits = num_chars*[0]
+    vbits = num_chars * [0]
     for i, (handler, _, _) in enumerate(vectors):
         if handler not in (spur_code, spur_nocode):
             continue
@@ -300,14 +306,12 @@ def main():
     max_irq = syms["CONFIG_MAX_IRQ_LINES"]
     max_vec = syms["CONFIG_IDT_NUM_VECTORS"]
 
-    vectors, irq_vec_map = setup_idt(spur_code, spur_nocode, intlist, max_vec,
-                                     max_irq)
+    vectors, irq_vec_map = setup_idt(spur_code, spur_nocode, intlist, max_vec, max_irq)
 
     create_idt_binary(vectors, args.output_idt)
     create_irq_vec_map_binary(irq_vec_map, args.vector_map)
     if args.output_vectors_alloc:
-        create_irq_vectors_allocated(vectors, spur_code, spur_nocode,
-                                     args.output_vectors_alloc)
+        create_irq_vectors_allocated(vectors, spur_code, spur_nocode, args.output_vectors_alloc)
 
 
 if __name__ == "__main__":

--- a/arch/x86/gen_idt.py
+++ b/arch/x86/gen_idt.py
@@ -29,13 +29,14 @@ This script outputs three binary tables:
 """
 
 import argparse
-import sys
-import struct
 import os
+import struct
+import sys
+
 import elftools
-from packaging import version
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
+from packaging import version
 
 if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
@@ -121,15 +122,14 @@ def update_irq_vec_map(irq_vec_map, irq, vector, max_irq):
         return
 
     if irq >= max_irq:
-        error("irq %d specified, but CONFIG_MAX_IRQ_LINES is %d" %
-              (irq, max_irq))
+        error(f"irq {irq:d} specified, but CONFIG_MAX_IRQ_LINES is {max_irq:d}")
 
     # This table will never have values less than 32 since those are for
     # exceptions; 0 means unconfigured
     if irq_vec_map[irq] != 0:
-        error("multiple vector assignments for interrupt line %d" % irq)
+        error(f"multiple vector assignments for interrupt line {irq:d}")
 
-    debug("assign IRQ %d to vector %d" % (irq, vector))
+    debug(f"assign IRQ {irq:d} to vector {vector:d}")
     irq_vec_map[irq] = vector
 
 
@@ -145,11 +145,10 @@ def setup_idt(spur_code, spur_nocode, intlist, max_vec, max_irq):
             continue
 
         if vec >= max_vec:
-            error("Vector %d specified, but size of IDT is only %d vectors" %
-                  (vec, max_vec))
+            error(f"Vector {vec:d} specified, but size of IDT is only {max_vec:d} vectors")
 
         if vectors[vec] is not None:
-            error("Multiple assignments for vector %d" % vec)
+            error(f"Multiple assignments for vector {vec:d}")
 
         vectors[vec] = (handler, tss, dpl)
         update_irq_vec_map(irq_vec_map, irq, vec, max_irq)
@@ -167,7 +166,7 @@ def setup_idt(spur_code, spur_nocode, intlist, max_vec, max_irq):
                 break
 
         if vec == -1:
-            error("can't find a free vector in priority level %d" % prio)
+            error(f"can't find a free vector in priority level {prio:d}")
 
         vectors[vec] = (handler, tss, dpl)
         update_irq_vec_map(irq_vec_map, irq, vec, max_irq)
@@ -226,8 +225,8 @@ def get_intlist(elf):
     spurious_code = header[0]
     spurious_nocode = header[1]
 
-    debug("spurious handler (code)    : %s" % hex(header[0]))
-    debug("spurious handler (no code) : %s" % hex(header[1]))
+    debug(f"spurious handler (code)    : {hex(header[0]):s}")
+    debug(f"spurious handler (no code) : {hex(header[1]):s}")
 
     intlist = [i for i in
                struct.iter_unpack(intlist_entry_fmt, intdata)]
@@ -237,12 +236,13 @@ def get_intlist(elf):
     debug("--------------------------")
 
     for irq in intlist:
-        debug("{0:<10} {1:<3} {2:<3} {3:<3} {4:<2}".format(
-            hex(irq[0]),
-            "-" if irq[1] == -1 else irq[1],
-            "-" if irq[2] == -1 else irq[2],
-            "-" if irq[3] == -1 else irq[3],
-            irq[4]))
+        debug(
+            f"{hex(irq[0]):<10} "
+            f"{'-' if irq[1] == -1 else irq[1]:<3} "
+            f"{'-' if irq[2] == -1 else irq[2]:<3} "
+            f"{'-' if irq[3] == -1 else irq[3]:<3} "
+            f"{irq[4]:<2}"
+        )
 
     return (spurious_code, spurious_nocode, intlist)
 

--- a/arch/x86/gen_mmu.py
+++ b/arch/x86/gen_mmu.py
@@ -65,20 +65,19 @@ to the end of the binary produced by this script, minus the size of the
 top-level paging structure as it is written out last.
 """
 
-import sys
-import array
 import argparse
+import array
 import ctypes
 import os
-import struct
 import re
+import struct
+import sys
 import textwrap
-
-from packaging import version
 
 import elftools
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
+from packaging import version
 
 if version.parse(elftools.__version__) < version.parse('0.24'):
     sys.exit("pyelftools is out of date, need version 0.24 or later")
@@ -134,9 +133,9 @@ def error(text):
 def align_check(base, size, scope=4096):
     """Make sure base and size are page-aligned"""
     if (base % scope) != 0:
-        error("unaligned base address %x" % base)
+        error(f"unaligned base address {base:x}")
     if (size % scope) != 0:
-        error("Unaligned region size 0x%x for base %x" % (size, base))
+        error(f"Unaligned region size 0x{size:x} for base {base:x}")
 
 
 def dump_flags(flags):
@@ -184,7 +183,7 @@ def round_down(val, align):
 # access or set caching properties at leaf levels.
 INT_FLAGS = FLAG_P | FLAG_RW | FLAG_US
 
-class MMUTable():
+class MMUTable:
     """Represents a particular table in a set of page tables, at any level"""
 
     def __init__(self):
@@ -261,9 +260,9 @@ class MMUTable():
         this is the physical address of the next level table"""
         index = self.entry_index(virt_addr)
 
-        verbose("%s: mapping 0x%x to 0x%x : %s" %
-                (self.__class__.__name__,
-                 phys_addr, virt_addr, dump_flags(entry_flags)))
+        verbose(f"{self.__class__.__name__:s}: "
+                f"mapping 0x{phys_addr:x} to 0x{virt_addr:x} : "
+                f"{dump_flags(entry_flags):s}")
 
         self.entries[index] = ((phys_addr & self.addr_mask) |
                                (entry_flags & self.supported_flags))
@@ -274,9 +273,9 @@ class MMUTable():
         Unsupported flags will be filtered out."""
         index = self.entry_index(virt_addr)
 
-        verbose("%s: changing perm at 0x%x : %s" %
-                (self.__class__.__name__,
-                 virt_addr, dump_flags(entry_flags)))
+        verbose(f"{self.__class__.__name__:s}: "
+                f"changing perm at 0x{virt_addr:x} : "
+                f"{dump_flags(entry_flags):s}")
 
         self.entries[index] = ((self.entries[index] & self.addr_mask) |
                                (entry_flags & self.supported_flags))
@@ -336,7 +335,7 @@ class PtXd(Pt):
                        FLAG_D | FLAG_IGNORED0 | FLAG_IGNORED1 | FLAG_IGNORED2)
 
 
-class PtableSet():
+class PtableSet:
     """Represents a complete set of page tables for any paging mode"""
 
     def __init__(self, pages_start):
@@ -345,8 +344,8 @@ class PtableSet():
         self.toplevel = self.levels[0]()
         self.page_pos = pages_start
 
-        debug("%s starting at physical address 0x%x" %
-              (self.__class__.__name__, self.page_pos))
+        debug(f"{self.__class__.__name__:s} "
+              f"starting at physical address 0x{self.page_pos:x}")
 
         # Database of page table pages. Maps physical memory address to
         # MMUTable objects, excluding the top-level table which is tracked
@@ -408,8 +407,7 @@ class PtableSet():
         """Create a new child table"""
         new_table_addr = self.get_new_mmutable_addr()
         new_table = self.levels[depth]()
-        debug("new %s at physical addr 0x%x"
-                      % (self.levels[depth].__name__, new_table_addr))
+        debug(f"new {self.levels[depth].__name__:s} at physical addr 0x{new_table_addr:x}")
         self.tables[new_table_addr] = new_table
         table.map(virt_addr, new_table_addr, INT_FLAGS)
 
@@ -436,8 +434,7 @@ class PtableSet():
 
     def reserve(self, virt_base, size, to_level=PT_LEVEL):
         """Reserve page table space with already aligned virt_base and size"""
-        debug("Reserving paging structures for 0x%x (0x%x)" %
-              (virt_base, size))
+        debug(f"Reserving paging structures for 0x{virt_base:x} (0x{size:x})")
 
         align_check(virt_base, size)
 
@@ -445,8 +442,8 @@ class PtableSet():
         scope = 1 << self.levels[PD_LEVEL].addr_shift
 
         if virt_base % scope != 0:
-            error("misaligned virtual address space, 0x%x not a multiple of 0x%x" %
-                  (virt_base, scope))
+            error(f"misaligned virtual address space, 0x{virt_base:x} "
+                  f"not a multiple of 0x{scope:x}")
 
         for addr in range(virt_base, virt_base + size, scope):
             self.map_page(addr, 0, 0, True, to_level)
@@ -473,8 +470,7 @@ class PtableSet():
 
         scope = 1 << self.levels[level].addr_shift
 
-        debug("Mapping 0x%x (0x%x) to 0x%x: %s" %
-                (phys_base, size, virt_base, dump_flags(flags)))
+        debug(f"Mapping 0x{phys_base:x} (0x{size:x}) to 0x{virt_base:x}: {dump_flags(flags):s}")
 
         align_check(phys_base, size, scope)
         align_check(virt_base, size, scope)
@@ -537,8 +533,7 @@ class PtableSet():
         if size == 0:
             return
 
-        debug("change flags for %s at 0x%x (0x%x): %s" %
-              (name, base, size, dump_flags(flags)))
+        debug(f"change flags for {name:s} at 0x{base:x} (0x{size:x}): {dump_flags(flags):s}")
 
         num_levels = len(self.levels) + level + 1
         scope = 1 << self.levels[level].addr_shift
@@ -556,8 +551,7 @@ class PtableSet():
                     table = self.tables[table.lookup(addr)]
                 table.set_perms(addr, flags)
         except KeyError:
-            error("no mapping for %s region 0x%x (size 0x%x)" %
-                  (name, base, size))
+            error(f"no mapping for {name:s} region 0x{base:x} (size 0x{size:x})")
 
     def write_output(self, filename):
         """Write the page tables to the output file in binary format"""
@@ -574,9 +568,8 @@ class PtableSet():
             # in PAE, the top-level PDPT has only 4 entries and is not a
             # full page in size. We do not put it in the tables dictionary
             # and treat it as a special case.
-            debug("top-level %s at physical addr 0x%x" %
-                  (self.toplevel.__class__.__name__,
-                   self.get_new_mmutable_addr()))
+            debug(f"top-level {self.toplevel.__class__.__name__:s} at "
+                  f"physical addr 0x{self.get_new_mmutable_addr():x}")
             top_level_bin = self.toplevel.get_binary()
             output_fp.write(top_level_bin)
             written_size += len(top_level_bin)
@@ -666,7 +659,7 @@ def map_extra_regions(pt):
         elements = entry.split(',')
 
         if len(elements) < 2:
-            error("Not enough arguments for --map %s" % entry)
+            error(f"Not enough arguments for --map {entry:s}")
 
         one_map = {}
 
@@ -681,7 +674,7 @@ def map_extra_regions(pt):
 
             # Check for allowed flags
             if not bool(re.match('^[LUWXD]*$', map_flags)):
-                error("Unrecognized flags: %s" % map_flags)
+                error(f"Unrecognized flags: {map_flags:s}")
 
             flags = FLAG_P | ENTRY_XD
             if 'W' in map_flags:
@@ -716,8 +709,8 @@ def map_extra_regions(pt):
         # Check if addresses have already been mapped.
         # Error out if so as they could override kernel mappings.
         if pt.is_region_mapped(virt, size, level):
-            error(("Region 0x%x (%d) already been mapped "
-                   "for --map %s" % (virt, size, one_map['cmdline'])))
+            error(f"Region 0x{virt:x} ({size:d}) already been mapped "
+                  f"for --map {one_map['cmdline']:x}")
 
         # Reserve space in page table, and map the region
         pt.reserve_unaligned(virt, size, level)
@@ -746,7 +739,7 @@ def main():
     else:
         pclass = Ptables32bit
 
-    debug("building %s" % pclass.__name__)
+    debug(f"building {pclass.__name__:s}")
 
     vm_base = syms["CONFIG_KERNEL_VM_BASE"]
     vm_size = syms["CONFIG_KERNEL_VM_SIZE"]
@@ -778,15 +771,14 @@ def main():
 
     ptables_phys = syms["z_x86_pagetables_start"] + virt_to_phys_offset
 
-    debug("Address space: 0x%x - 0x%x size 0x%x" %
-          (vm_base, vm_base + vm_size - 1, vm_size))
+    debug(f"Address space: 0x{vm_base:x} - 0x{vm_base + vm_size - 1:x} size 0x{vm_size:x}")
 
-    debug("Zephyr image: 0x%x - 0x%x size 0x%x" %
-          (image_base, image_base + image_size - 1, image_size))
+    debug(f"Zephyr image: 0x{image_base:x} - 0x{image_base + image_size - 1:x} "
+          f"size 0x{image_size:x}")
 
     if virt_to_phys_offset != 0:
-        debug("Physical address space: 0x%x - 0x%x size 0x%x" %
-              (sram_base, sram_base + sram_size - 1, sram_size))
+        debug(f"Physical address space: 0x{sram_base:x} - 0x{sram_base + sram_size - 1:x} "
+              f"size 0x{sram_size:x}")
 
     is_perm_regions = isdef("CONFIG_SRAM_REGION_PERMISSIONS")
 
@@ -794,7 +786,7 @@ def main():
     is_generic_section_present = isdef("CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT")
 
     if image_size >= vm_size:
-        error("VM size is too small (have 0x%x need more than 0x%x)" % (vm_size, image_size))
+        error(f"VM size is too small (have 0x{vm_size:x} need more than 0x{image_size:x})")
 
     map_flags = 0
 
@@ -835,8 +827,7 @@ def main():
         # from real mode
         locore_base = syms["_locore_start"]
         locore_size = syms["_lodata_end"] - locore_base
-        debug("Base addresses: physical 0x%x size 0x%x" % (locore_base,
-                                                         locore_size))
+        debug(f"Base addresses: physical 0x{locore_base:x} size 0x{locore_size:x}")
         pt.map(locore_base, None, locore_size, map_flags | FLAG_P | ENTRY_RW)
 
     if isdef("CONFIG_XIP"):
@@ -917,7 +908,7 @@ def main():
             pt.set_region_perms("__x86shadowstack", FLAG_P | FLAG_D | ENTRY_XD)
 
     written_size = pt.write_output(args.output)
-    debug("Written %d bytes to %s" % (written_size, args.output))
+    debug(f"Written {written_size:d} bytes to {args.output:s}")
 
     # Warn if reserved page table is not of correct size
     if reserved_pt_size and written_size != reserved_pt_size:
@@ -935,9 +926,8 @@ def main():
 
         reason = "big" if reserved_pt_size > written_size else "small"
 
-        error(("Reserved space for page table is too %s."
-               " Set CONFIG_X86_EXTRA_PAGE_TABLE_PAGES=%d") %
-               (reason, extra_pages_needed))
+        error(f"Reserved space for page table is too {reason:s}."
+              f" Set CONFIG_X86_EXTRA_PAGE_TABLE_PAGES={extra_pages_needed:d}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes issues found by ruff on `gen_gdt.py`, `gen_idt.py` and `gen_mmu.py` scripts. Also format those scripts via ruff.