### PR TITLE
subsys: usb: host: Add USB Host Class Support

### DIFF
--- a/include/zephyr/usb/usbh.h
+++ b/include/zephyr/usb/usbh.h
@@ -34,6 +34,16 @@ extern "C" {
  */
 
 /**
+ * USB host support status
+ */
+struct usbh_status {
+	/** USB host support is initialized */
+	unsigned int initialized : 1;
+	/** USB host support is enabled */
+	unsigned int enabled : 1;
+};
+
+/**
  * USB host support runtime context
  */
 struct usbh_context {
@@ -43,6 +53,8 @@ struct usbh_context {
 	struct k_mutex mutex;
 	/** Pointer to UHC device struct */
 	const struct device *dev;
+	/** Status of the USB host support */
+	struct usbh_status status;
 	/** USB device list */
 	sys_dlist_t udevs;
 	/** USB root device */

--- a/include/zephyr/usb/usbh.h
+++ b/include/zephyr/usb/usbh.h
@@ -84,28 +84,45 @@ struct usbh_code_triple {
 	uint8_t proto;
 };
 
+struct usbh_class_data;
+
 /**
- * @brief USB host class data and class instance API
+ * @brief USB host class instance API
+ */
+struct usbh_class_api {
+	/** Initialization of the class implementation */
+	int (*init)(struct usbh_class_data *const c_data);
+	/** Request completion event handler */
+	int (*request)(struct usbh_class_data *const c_data,
+		       struct uhc_transfer *const xfer, int err);
+	/** Device connected handler */
+	int (*connected)(struct usbh_class_data *const c_data,
+			 void *const desc_start_addr,
+			 void *const desc_end_addr);
+	/** Device removed handler */
+	int (*removed)(struct usbh_class_data *const c_data);
+	/** Bus remote wakeup handler */
+	int (*rwup)(struct usbh_class_data *const c_data);
+	/** Bus suspended handler */
+	int (*suspended)(struct usbh_class_data *const c_data);
+	/** Bus resumed handler */
+	int (*resumed)(struct usbh_class_data *const c_data);
+};
+
+/**
+ * @brief USB host class instance data
  */
 struct usbh_class_data {
+	/** Name of the USB host class instance */
+	const char *name;
+	/** Pointer to USB host stack context structure */
+	struct usbh_context *uhs_ctx;
 	/** Class code supported by this instance */
 	struct usbh_code_triple code;
-
-	/** Initialization of the class implementation */
-	/* int (*init)(struct usbh_context *const uhs_ctx); */
-	/** Request completion event handler */
-	int (*request)(struct usbh_context *const uhs_ctx,
-			struct uhc_transfer *const xfer, int err);
-	/** Device connected handler  */
-	int (*connected)(struct usbh_context *const uhs_ctx);
-	/** Device removed handler  */
-	int (*removed)(struct usbh_context *const uhs_ctx);
-	/** Bus remote wakeup handler  */
-	int (*rwup)(struct usbh_context *const uhs_ctx);
-	/** Bus suspended handler  */
-	int (*suspended)(struct usbh_context *const uhs_ctx);
-	/** Bus resumed handler  */
-	int (*resumed)(struct usbh_context *const uhs_ctx);
+	/** Pointer to host support class API */
+	struct usbh_class_api *api;
+	/** Pointer to private data */
+	void *priv;
 };
 
 /**

--- a/include/zephyr/usb/usbh.h
+++ b/include/zephyr/usb/usbh.h
@@ -90,19 +90,18 @@ struct usbh_class_data;
  * @brief USB host class instance API
  */
 struct usbh_class_api {
-	/** Initialization of the class implementation */
-	int (*init)(struct usbh_class_data *const c_data);
+	/** Host init handler, before any device is connected */
+	int (*init)(struct usbh_class_data *const c_data,
+		    struct usbh_context *const uhs_ctx);
 	/** Request completion event handler */
-	int (*request)(struct usbh_class_data *const c_data,
-		       struct uhc_transfer *const xfer, int err);
-	/** Device connected handler */
-	int (*connected)(struct usbh_class_data *const c_data,
-			 void *const desc_start_addr,
-			 void *const desc_end_addr);
-	/** Device removed handler */
+	int (*completion_cb)(struct usbh_class_data *const c_data,
+			     struct uhc_transfer *const xfer);
+	/** Device connection handler */
+	int (*probe)(struct usbh_class_data *const c_data,
+		     struct usb_device *const udev,
+		     const uint8_t iface);
+	/** Device removal handler */
 	int (*removed)(struct usbh_class_data *const c_data);
-	/** Bus remote wakeup handler */
-	int (*rwup)(struct usbh_class_data *const c_data);
 	/** Bus suspended handler */
 	int (*suspended)(struct usbh_class_data *const c_data);
 	/** Bus resumed handler */
@@ -117,8 +116,10 @@ struct usbh_class_data {
 	const char *name;
 	/** Pointer to USB host stack context structure */
 	struct usbh_context *uhs_ctx;
-	/** Class code supported by this instance */
-	struct usbh_code_triple code;
+	/** Pointer to USB device this class is used for */
+	struct usb_device *udev;
+	/** Interface number for which this class matched */
+	uint8_t iface;
 	/** Pointer to host support class API */
 	struct usbh_class_api *api;
 	/** Pointer to private data */

--- a/subsys/usb/host/CMakeLists.txt
+++ b/subsys/usb/host/CMakeLists.txt
@@ -5,9 +5,11 @@ zephyr_library()
 zephyr_library_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 zephyr_library_sources(
-	usbh_ch9.c
-	usbh_core.c
 	usbh_api.c
+	usbh_ch9.c
+	usbh_class.c
+	usbh_core.c
+	usbh_desc.c
 	usbh_device.c
 )
 

--- a/subsys/usb/host/usbh_class.c
+++ b/subsys/usb/host/usbh_class.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/usb/usbh.h>
+#include <zephyr/logging/log.h>
+
+#include "usbh_class.h"
+#include "usbh_class_api.h"
+#include "usbh_desc.h"
+
+LOG_MODULE_REGISTER(usbh_class, CONFIG_USBH_LOG_LEVEL);
+
+int usbh_class_init_all(struct usbh_context *const uhs_ctx)
+{
+	int ret;
+
+	STRUCT_SECTION_FOREACH(usbh_class_node, c_node) {
+		ret = usbh_class_init(c_node->c_data, uhs_ctx);
+		if (ret != 0) {
+			LOG_ERR("Failed to initialize all registered class instances");
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+int usbh_class_remove_all(const struct usb_device *const udev)
+{
+	int ret;
+
+	STRUCT_SECTION_FOREACH(usbh_class_node, c_node) {
+		if (c_node->c_data->udev == udev) {
+			ret = usbh_class_removed(c_node->c_data);
+			if (ret != 0) {
+				LOG_ERR("Failed to handle device removal for each classes");
+				return ret;
+			}
+
+			/* The class instance is now free to bind to a new device */
+			c_node->c_data->udev = NULL;
+		}
+	}
+
+	return 0;
+}
+
+static int usbh_class_probe_each_iface(struct usbh_class_node *const c_node,
+				       struct usb_device *const udev)
+{
+	const void *const desc_beg = usbh_desc_get_cfg_beg(udev);
+	const void *const desc_end = usbh_desc_get_cfg_end(udev);
+	const struct usb_desc_header *desc = desc_beg;
+	struct usbh_class_data *const c_data = c_node->c_data;
+	struct usbh_class_filter info = {
+		.vid = udev->dev_desc.idVendor,
+		.pid = udev->dev_desc.idProduct,
+	};
+	uint8_t iface;
+	int ret;
+
+	while (true) {
+		desc = usbh_desc_get_next_function(desc, desc_end);
+		if (desc == NULL) {
+			break;
+		}
+
+		if (desc->bDescriptorType == USB_DESC_INTERFACE_ASSOC) {
+			iface = ((struct usb_association_descriptor *)desc)->bFirstInterface;
+		} else if (desc->bDescriptorType == USB_DESC_INTERFACE) {
+			iface = ((struct usb_if_descriptor *)desc)->bInterfaceNumber;
+		} else {
+			__ASSERT(false, "bad implementation of usbh_desc_get_next_function()");
+			return -EINVAL;
+		}
+
+		ret = usbh_desc_get_iface_info(desc, &info, &iface);
+		if (ret < 0) {
+			LOG_ERR("Failed to collect class codes for matching interface %u", iface);
+			return ret;
+		}
+
+		if (!usbh_class_is_matching(c_node->filters, c_node->num_filters, &info)) {
+			LOG_DBG("Class %s not matching interface %u", c_data->name, iface);
+			continue;
+		}
+
+		ret = usbh_class_probe(c_data, udev, iface);
+		if (ret == -ENOTSUP) {
+			LOG_DBG("Class %s not supporting this device, skipping", c_data->name);
+			continue;
+		}
+		if (ret != 0) {
+			LOG_ERR("Error while probing the class %s for interface %u",
+				c_data->name, iface);
+			return ret;
+		}
+
+		LOG_INF("Class %s matches this device's interface %u", c_data->name, iface);
+		c_data->udev = udev;
+		c_data->iface = iface;
+
+		return 0;
+	}
+
+	return -ENOTSUP;
+}
+
+int usbh_class_probe_all(struct usb_device *const udev)
+{
+	bool matching = false;
+	int ret;
+
+	STRUCT_SECTION_FOREACH(usbh_class_node, c_node) {
+		struct usbh_class_data *const c_data = c_node->c_data;
+
+		/* If the class is not already having a device */
+		if (c_data->udev == NULL) {
+			ret = usbh_class_probe_each_iface(c_node, udev);
+			if (ret == -ENOTSUP) {
+				LOG_DBG("USB device not matching %s", c_node->c_data->name);
+				continue;
+			}
+			if (ret != 0) {
+				return ret;
+			}
+			matching = true;
+		}
+	}
+
+	if (!matching) {
+		LOG_WRN("Could not find any class for this device");
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+bool usbh_class_is_matching(struct usbh_class_filter *const filters, size_t num_filters,
+			    struct usbh_class_filter *const info)
+{
+	/* Make empty filter set match everything (use class_api->probe() only) */
+	if (num_filters == 0) {
+		return true;
+	}
+
+	/* Try to find a rule that matches completely */
+	for (int i = 0; i < num_filters; i++) {
+		const struct usbh_class_filter *filt = &filters[i];
+
+		if ((filt->flags & USBH_CLASS_MATCH_VID) &&
+		    info->vid != filt->vid) {
+			continue;
+		}
+
+		if ((filt->flags & USBH_CLASS_MATCH_PID) &&
+		    info->pid != filt->pid) {
+			continue;
+		}
+
+		if (filt->flags & USBH_CLASS_MATCH_CLASS &&
+		    info->class != filt->class) {
+			continue;
+		}
+
+		if ((filt->flags & USBH_CLASS_MATCH_SUB) &&
+		    info->sub != filt->sub) {
+			continue;
+		}
+
+		if ((filt->flags & USBH_CLASS_MATCH_PROTO) &&
+		    info->proto != filt->proto) {
+			continue;
+		}
+
+		/* All the selected filters did match */
+		return true;
+	}
+
+	/* At the end of the filter table and still no match */
+	return false;
+}

--- a/subsys/usb/host/usbh_class.h
+++ b/subsys/usb/host/usbh_class.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_USBD_CLASS_H
+#define ZEPHYR_INCLUDE_USBD_CLASS_H
+
+#include <zephyr/usb/usbh.h>
+
+/** Match a device's vendor ID */
+#define USBH_CLASS_MATCH_VID BIT(1)
+
+/** Match a device's product ID */
+#define USBH_CLASS_MATCH_PID BIT(2)
+
+/** Match a class code */
+#define USBH_CLASS_MATCH_CLASS BIT(3)
+
+/** Match a subclass code */
+#define USBH_CLASS_MATCH_SUB BIT(4)
+
+/** Match a protocol code */
+#define USBH_CLASS_MATCH_PROTO BIT(5)
+
+/** Match a code triple */
+#define USBH_CLASS_MATCH_CODE_TRIPLE \
+	(USBH_CLASS_MATCH_CLASS | USBH_CLASS_MATCH_SUB | USBH_CLASS_MATCH_PROTO)
+
+/**
+ * @brief Match an USB host class (a driver) against a device descriptor.
+ *
+ * @param[in] filters Array of filter rules to match
+ * @param[in] num_filters Number of rules in the array.
+ * @param[in] device_info Device information filled by this function
+ * @retval true if the USB Device descriptor matches at least one rule.
+ */
+bool usbh_class_is_matching(struct usbh_class_filter *const filters, size_t num_filters,
+			    struct usbh_class_filter *const device_info);
+
+/**
+ * @brief Initialize every class instantiated on the system
+ *
+ * @param[in] uhs_ctx USB Host context to pass to the class.
+ * @retval 0 on success or negative error code on failure
+ */
+int usbh_class_init_all(struct usbh_context *const uhs_ctx);
+
+/**
+ * @brief Probe all classes to against a newly connected USB device.
+ *
+ * @param[in] udev USB device to probe.
+ * @retval 0 on success or negative error code on failure
+ */
+int usbh_class_probe_all(struct usb_device *const udev);
+
+/**
+ * @brief Call the device removal handler for every class configured with it
+ *
+ * @param[in] udev USB device that got removed.
+ * @retval 0 on success or negative error code on failure
+ */
+int usbh_class_remove_all(const struct usb_device *const udev);
+
+#endif /* ZEPHYR_INCLUDE_USBD_CLASS_H */

--- a/subsys/usb/host/usbh_class_api.h
+++ b/subsys/usb/host/usbh_class_api.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief USB host stack class instances API
+ *
+ * This file contains the USB host stack class instances API.
+ */
+
+#ifndef ZEPHYR_INCLUDE_USBH_CLASS_API_H
+#define ZEPHYR_INCLUDE_USBH_CLASS_API_H
+
+#include <zephyr/usb/usbh.h>
+
+/**
+ * @brief Initialization of the class implementation
+ *
+ * This is called for each instance during the initialization phase,
+ * for every registered class.
+ * It can be used to initialize underlying systems.
+ *
+ * @param[in] c_data Pointer to USB host class data
+ * @param[in] uhs_ctx USB host context to assign to this class
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+
+static inline int usbh_class_init(struct usbh_class_data *const c_data,
+				  struct usbh_context *const uhs_ctx)
+{
+	const struct usbh_class_api *api = c_data->api;
+
+	if (api->init != NULL) {
+		return api->init(c_data, uhs_ctx);
+	}
+
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Request completion event handler
+ *
+ * Called upon completion of a request made by the host to this class.
+ *
+ * @param[in] c_data Pointer to USB host class data
+ * @param[in] udev USB device connected
+ * @param[in] xfer Completed transfer
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+static inline int usbh_class_completion_cb(struct usbh_class_data *const c_data,
+					   struct uhc_transfer *const xfer)
+{
+	const struct usbh_class_api *api = c_data->api;
+
+	if (api->completion_cb != NULL) {
+		return api->completion_cb(c_data, xfer);
+	}
+
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Device initialization handler
+ *
+ * Called when a device is connected to the bus for every device.
+ *
+ * @param[in] c_data Pointer to USB host class data
+ * @param[in] udev USB device connected
+ * @param[in] iface The @c bInterfaceNumber or @c bFirstInterface of this class
+ *
+ * @return 0 on success, negative error code on failure.
+ * @return -ENOTSUP if the class is not matching
+ */
+static inline int usbh_class_probe(struct usbh_class_data *const c_data,
+				   struct usb_device *const udev,
+				   const uint8_t iface)
+{
+	const struct usbh_class_api *api = c_data->api;
+
+	if (api->probe != NULL) {
+		return api->probe(c_data, udev, iface);
+	}
+
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Device removed handler
+ *
+ * Called when the device is removed from the bus
+ * and it matches the class filters of this instance.
+ *
+ * @param[in] c_data Pointer to USB host class data
+ * @param[in] udev USB device connected
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+static inline int usbh_class_removed(struct usbh_class_data *const c_data)
+{
+	const struct usbh_class_api *api = c_data->api;
+
+	if (api->removed != NULL) {
+		return api->removed(c_data);
+	}
+
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Bus suspended handler
+ *
+ * Called when the host has suspending the bus.
+ * It can be used to suspend underlying systems.
+ *
+ * @param[in] c_data Pointer to USB host class data
+ * @param[in] udev USB device connected
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+static inline int usbh_class_suspended(struct usbh_class_data *const c_data)
+{
+	const struct usbh_class_api *api = c_data->api;
+
+	if (api->suspended != NULL) {
+		return api->suspended(c_data);
+	}
+
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Bus resumed handler
+ *
+ * Called when the host resumes the activity on a bus.
+ * It can be used to wake-up underlying systems.
+ *
+ * @param[in] c_data Pointer to USB host class data
+ * @param[in] udev USB device connected
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+static inline int usbh_class_resumed(struct usbh_class_data *const c_data)
+{
+	const struct usbh_class_api *api = c_data->api;
+
+	if (api->resumed != NULL) {
+		return api->resumed(c_data);
+	}
+
+	return -ENOTSUP;
+}
+
+#endif /* ZEPHYR_INCLUDE_USBD_CLASS_API_H */

--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -85,6 +85,7 @@ static void dev_connected_handler(struct usbh_context *const ctx,
 static void dev_removed_handler(struct usbh_context *const ctx)
 {
 	if (ctx->root != NULL) {
+		usbh_class_remove_all(ctx->root);
 		usbh_device_free(ctx->root);
 		ctx->root = NULL;
 		LOG_DBG("Device removed");

--- a/subsys/usb/host/usbh_data.ld
+++ b/subsys/usb/host/usbh_data.ld
@@ -1,4 +1,4 @@
 #include <zephyr/linker/iterable_sections.h>
 
 ITERABLE_SECTION_RAM(usbh_context, Z_LINK_ITERABLE_SUBALIGN)
-ITERABLE_SECTION_RAM(usbh_class_data, Z_LINK_ITERABLE_SUBALIGN)
+ITERABLE_SECTION_RAM(usbh_class_node, Z_LINK_ITERABLE_SUBALIGN)

--- a/subsys/usb/host/usbh_desc.c
+++ b/subsys/usb/host/usbh_desc.c
@@ -152,6 +152,11 @@ const void *usbh_desc_get_next_function(const void *const desc_beg, const void *
 		return usbh_desc_get_by_type(desc_beg, desc_end, type_mask);
 	}
 
+	desc = usbh_desc_get_next(desc_beg, desc_end);
+	if (desc == NULL) {
+		return NULL;
+	}
+
 	while (skip_num > 0) {
 		desc = usbh_desc_get_by_type(desc, desc_end, type_mask);
 		if (desc == NULL) {
@@ -168,6 +173,14 @@ const void *usbh_desc_get_next_function(const void *const desc_beg, const void *
 			if (if_desc->bInterfaceNumber != iface) {
 				iface = if_desc->bInterfaceNumber;
 				skip_num--;
+				if(skip_num == 0) {
+					return desc;
+				}
+			}
+
+			desc = usbh_desc_get_next(desc, desc_end);
+			if (desc == NULL) {
+				return NULL;
 			}
 		} else {
 			__ASSERT(false, "invalid implementation of usbh_desc_get_by_iface()");

--- a/subsys/usb/host/usbh_desc.c
+++ b/subsys/usb/host/usbh_desc.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ * Copyright NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/usb/usb_ch9.h>
+
+#include "usbh_class.h"
+#include "usbh_desc.h"
+
+const void *usbh_desc_get_next(const void *const desc_beg, const void *const desc_end)
+{
+	const struct usb_desc_header *const desc = desc_beg;
+	const struct usb_desc_header *next;
+
+	if (desc_beg == NULL || desc_end == NULL) {
+		return NULL;
+	}
+
+	next = (const struct usb_desc_header *)((uint8_t *)desc + desc->bLength);
+
+	/* Validate the bLength field to make sure it does not point past the end */
+	if ((uint8_t *)next >= (uint8_t *)desc_end ||
+	    (uint8_t *)next + next->bLength > (uint8_t *)desc_end ||
+	    desc->bLength == 0) {
+		return NULL;
+	}
+
+	return next;
+}
+
+const bool usbh_desc_size_is_valid(const void *const desc, size_t expected_size,
+				   const void *const desc_end)
+{
+	return desc != NULL && desc_end != NULL &&
+	       (uint8_t *)desc + expected_size <= (uint8_t *)desc_end;
+}
+
+const struct usb_desc_header *usbh_desc_get_by_type(const void *const desc_beg,
+						    const void *const desc_end,
+						    uint32_t type_mask)
+{
+	const struct usb_desc_header *desc;
+
+	if (desc_beg == NULL || desc_end == NULL) {
+		return NULL;
+	}
+
+	for (desc = desc_beg; desc != NULL; desc = usbh_desc_get_next(desc, desc_end)) {
+		if ((BIT(desc->bDescriptorType) & type_mask) != 0) {
+			return desc;
+		}
+	}
+
+	return NULL;
+}
+
+const void *usbh_desc_get_by_iface(const void *const desc_beg, const void *const desc_end,
+				   const uint8_t iface)
+{
+	const struct usb_desc_header *desc;
+
+	if (desc_beg == NULL || desc_end == NULL) {
+		return NULL;
+	}
+
+	for (desc = desc_beg; desc != NULL; desc = usbh_desc_get_next(desc, desc_end)) {
+		if (desc->bDescriptorType == USB_DESC_INTERFACE &&
+		    ((struct usb_if_descriptor *)desc)->bInterfaceNumber == iface) {
+			return desc;
+		}
+		if (desc->bDescriptorType == USB_DESC_INTERFACE_ASSOC &&
+		    ((struct usb_association_descriptor *)desc)->bFirstInterface == iface) {
+			return desc;
+		}
+	}
+
+	return NULL;
+}
+
+const void *usbh_desc_get_cfg_beg(const struct usb_device *udev)
+{
+	return udev->cfg_desc;
+}
+
+const void *usbh_desc_get_cfg_end(const struct usb_device *udev)
+{
+	const struct usb_cfg_descriptor *cfg_desc;
+
+	if (udev->cfg_desc == NULL) {
+		return NULL;
+	}
+
+	cfg_desc = (struct usb_cfg_descriptor *)udev->cfg_desc;
+
+	return (uint8_t *)cfg_desc + cfg_desc->wTotalLength;
+}
+
+const int usbh_desc_get_iface_info(const struct usb_desc_header *desc,
+				   struct usbh_class_filter *const iface_code,
+				   uint8_t *const iface_num)
+{
+	if (desc->bDescriptorType == USB_DESC_INTERFACE_ASSOC) {
+		struct usb_association_descriptor *iad_desc = (void *)desc;
+
+		iface_code->class = iad_desc->bFunctionClass;
+		iface_code->sub = iad_desc->bFunctionSubClass;
+		iface_code->proto = iad_desc->bFunctionProtocol;
+		if (iface_num != NULL) {
+			*iface_num = iad_desc->bFirstInterface;
+		}
+		return 0;
+	}
+
+	if (desc->bDescriptorType == USB_DESC_INTERFACE) {
+		struct usb_if_descriptor *if_desc = (void *)desc;
+
+		iface_code->class = if_desc->bInterfaceClass;
+		iface_code->sub = if_desc->bInterfaceSubClass;
+		iface_code->proto = if_desc->bInterfaceProtocol;
+		if (iface_num != NULL) {
+			*iface_num = if_desc->bInterfaceNumber;
+		}
+		return 0;
+	}
+
+	return -EINVAL;
+}
+
+const void *usbh_desc_get_next_function(const void *const desc_beg, const void *const desc_end)
+{
+	const struct usb_desc_header *desc = desc_beg;
+	const struct usb_association_descriptor *iad_desc = desc_beg;
+	const struct usb_if_descriptor *if_desc = desc_beg;
+	uint32_t type_mask = BIT(USB_DESC_INTERFACE_ASSOC) | BIT(USB_DESC_INTERFACE);
+	size_t skip_num;
+	int8_t iface;
+
+	if (desc_beg == NULL || desc_end == NULL) {
+		return NULL;
+	}
+
+	if (desc->bDescriptorType == USB_DESC_INTERFACE_ASSOC) {
+		iface = iad_desc->bFirstInterface;
+		skip_num = iad_desc->bInterfaceCount;
+	} else if (desc->bDescriptorType == USB_DESC_INTERFACE) {
+		iface = if_desc->bInterfaceNumber;
+		skip_num = 1;
+	} else {
+		return usbh_desc_get_by_type(desc_beg, desc_end, type_mask);
+	}
+
+	while (skip_num > 0) {
+		desc = usbh_desc_get_by_type(desc, desc_end, type_mask);
+		if (desc == NULL) {
+			return NULL;
+		}
+
+		if (desc->bDescriptorType == USB_DESC_INTERFACE_ASSOC) {
+			/* No alternate setting */
+			return desc;
+		} else if (desc->bDescriptorType == USB_DESC_INTERFACE) {
+			if_desc = (struct usb_if_descriptor  *)desc;
+
+			/* Skip all the alternate settings for the same interface number */
+			if (if_desc->bInterfaceNumber != iface) {
+				iface = if_desc->bInterfaceNumber;
+				skip_num--;
+			}
+		} else {
+			__ASSERT(false, "invalid implementation of usbh_desc_get_by_iface()");
+			return NULL;
+		}
+	}
+
+	return desc;
+}

--- a/subsys/usb/host/usbh_desc.h
+++ b/subsys/usb/host/usbh_desc.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Descriptor matching and searching utilities
+ *
+ * This file contains utilities to browse USB descriptors returned by a device
+ * according to the USB Specification 2.0 Chapter 9.
+ */
+
+#ifndef ZEPHYR_INCLUDE_USBH_DESC_H
+#define ZEPHYR_INCLUDE_USBH_DESC_H
+
+#include <stdint.h>
+
+#include <zephyr/usb/usbh.h>
+
+/**
+ * @brief Get the next descriptor in an array of descriptors.
+ *
+ * This
+ * to search either an interface or  interface association descriptor:
+ *
+ * @code{.c}
+ * BIT(USB_DESC_INTERFACE) | BIT(USB_DESC_INTERFACE_ASSOC)
+ * @endcode
+ *
+ * @param[in] desc_beg Pointer to the beginning of the descriptor array; to search. May be NULL.
+ * @param[in] desc_end Pointer after the end of the descriptor array to search
+ * @param[in] type_mask Bitmask of bDescriptorType values to match
+ * @return A pointer to the first descriptor matching
+ */
+const void *usbh_desc_get_next(const void *const desc_beg, const void *const desc_end);
+
+/**
+ * @brief Search the first descriptor matching the selected type(s).
+ *
+ * As an example, the @p type_mask argument can be constructed this way
+ * to search either an interface or  interface association descriptor:
+ *
+ * @code{.c}
+ * BIT(USB_DESC_INTERFACE) | BIT(USB_DESC_INTERFACE_ASSOC)
+ * @endcode
+ *
+ * @param[in] desc_beg Pointer to the beginning of the descriptor array; to search. May be NULL.
+ * @param[in] desc_end Pointer after the end of the descriptor array to search
+ * @param[in] type_mask Bitmask of bDescriptorType values to match
+ * @return A pointer to the first descriptor matching
+ */
+const struct usb_desc_header *usbh_desc_get_by_type(const void *const desc_beg,
+						    const void *const desc_end,
+						    uint32_t type_mask);
+
+/**
+ * @brief Search a descriptor matching the interace number wanted.
+ *
+ * The descriptors are going to be scanned until either an interface association
+ * @c bFirstInterface field or an interface @c bInterfaceNumber field match.
+ *
+ * The descriptors following it can be browsed using @ref usbh_desc_get_next
+ *
+ * @param[in] desc_beg Pointer to the beginning of the descriptor array; to search. May be NULL.
+ * @param[in] desc_end Pointer after the end of the descriptor array to search
+ * @param[in] iface The interface number to search
+ * @return A pointer to the first descriptor matching
+ */
+const void *usbh_desc_get_by_iface(const void *const desc_beg, const void *const desc_end,
+				   const uint8_t iface);
+
+/**
+ * @brief Get the start of a device's configuration descriptor.
+ *
+ * @param[in] udev The device holding the confiugration descriptor
+ * @return A pointer to the beginning of the descriptor
+ */
+const void *usbh_desc_get_cfg_beg(const struct usb_device *udev);
+
+/**
+ * @brief Get the end of a device's configuration descriptor.
+ *
+ * @param[in] udev The device holding the confiugration descriptor
+ * @return A pointer to the beginning of the descriptor
+ */
+const void *usbh_desc_get_cfg_end(const struct usb_device *udev);
+
+/**
+ * @brief Extract information from an interface or interface association descriptors
+ *
+ * @param[in] desc The descriptor to use
+ * @param[out] device_info Device information filled by this function
+ * @param[out] iface_num Pointer filled with the interface number, or NULL
+ * @return 0 on success or negative error code on failure.
+ */
+const int usbh_desc_get_iface_info(const struct usb_desc_header *desc,
+				   struct usbh_class_filter *const iface_code,
+				   uint8_t *const iface_num);
+
+/**
+ * Checks that the pointed descriptor is not truncated.
+ *
+ * @param[in] desc The descriptor to use
+ * @return true if the descriptor size is valid
+ */
+const bool usbh_desc_size_is_valid(const void *const desc, size_t expected_size,
+				   const void *const desc_end);
+
+/**
+ * @brief Get the next function in the descriptor list.
+ *
+ * This returns the interface or interface association of the next USB function, if found.
+ * This can be used to walk through the list of USB functions to associate a class to each.
+ *
+ * If @p desc_beg is an interface association descriptor, it will return a pointer to the interface
+ * after all those related to the association descriptor.
+ *
+ * If @p desc_beg is an interface descriptor, it will skip all the interface alternate settings
+ * and return a pointer to the next interface with a different number.
+ *
+ * If @p desc_beg is not one of these types of descriptors, it will return a pointer to the first
+ * interface or interface association descriptor following @p desc_beg.
+ *
+ * @param[in] desc_beg Pointer to the beginning of the descriptor array; to search. May be NULL.
+ * @param[in] desc_end Pointer after the end of the descriptor array to search.
+ * @return A pointer to the next interface after following @p desc_beg or NULL if none.
+ */
+const void *usbh_desc_get_next_function(const void *const desc_beg, const void *const desc_end);
+
+#endif /* ZEPHYR_INCLUDE_USBH_DESC_H */

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -397,7 +397,7 @@ int usbh_device_set_configuration(struct usb_device *const udev, const uint8_t n
 	}
 
 	udev->cfg_desc = k_heap_alloc(&usb_device_heap,
-				      cfg_desc.wTotalLength,
+				      cfg_desc.wTotalLength + sizeof(struct usb_desc_header),
 				      K_NO_WAIT);
 	if (udev->cfg_desc == NULL) {
 		LOG_ERR("Failed to allocate memory for configuration descriptor");

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -487,18 +487,6 @@ int usbh_device_init(struct usb_device *const udev)
 		goto error;
 	}
 
-	err = usbh_req_desc_dev(udev, sizeof(udev->dev_desc), &udev->dev_desc);
-	if (err) {
-		LOG_ERR("Failed to read device descriptor");
-		goto error;
-	}
-
-	if (!udev->dev_desc.bNumConfigurations) {
-		LOG_ERR("Device has no configurations, bNumConfigurations %d",
-			udev->dev_desc.bNumConfigurations);
-		goto error;
-	}
-
 	err = alloc_device_address(udev, &new_addr);
 	if (err) {
 		LOG_ERR("Failed to allocate device address");
@@ -517,6 +505,18 @@ int usbh_device_init(struct usb_device *const udev)
 	udev->state = USB_STATE_ADDRESSED;
 
 	LOG_INF("New device with address %u state %u", udev->addr, udev->state);
+
+	err = usbh_req_desc_dev(udev, sizeof(udev->dev_desc), &udev->dev_desc);
+	if (err) {
+		LOG_ERR("Failed to read device descriptor");
+		goto error;
+	}
+
+	if (!udev->dev_desc.bNumConfigurations) {
+		LOG_ERR("Device has no configurations, bNumConfigurations %d",
+			udev->dev_desc.bNumConfigurations);
+		goto error;
+	}
 
 	err = usbh_device_set_configuration(udev, 1);
 	if (err) {


### PR DESCRIPTION
Dependency:

* https://github.com/zephyrproject-rtos/zephyr/pull/94590

Downstream:

* https://github.com/zephyrproject-rtos/zephyr/pull/99097
* https://github.com/zephyrproject-rtos/zephyr/pull/99173

Upstream Reference:

* https://github.com/zephyrproject-rtos/zephyr/pull/94504

This implementation contains all commits from #94590 plus the following enhancements:

* Invoke usbh_class_remove_all() from dev_remove_handler() to cleanup classes on device removal.

* Improve descriptor traversal to prevent infinite loop.

* Read device descriptor only after setting a valid device address.

WIP: Currently, this is a draft PR and further changes are planned.
    
Signed-off-by: Santhosh Charles <santhosh@linumiz.com>