### PR TITLE
github: Update security page for 4.3.0 release

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,11 +8,11 @@ updates:
   - The most recent release, and the release prior to that.
   - Active LTS releases.
 
-At this time, with the latest release of v4.2, the supported
+At this time, with the latest release of v4.3, the supported
 versions are:
 
-  - v4.2: Current release
-  - v4.1: Prior release
+  - v4.3: Current release
+  - v4.2: Prior release
   - v3.7: Current LTS
 
 ## Reporting process


### PR DESCRIPTION
Update the GitHub security page to include the recently released 4.3.0 version.