### PR TITLE
soc: egis_et171: add customize config value of fw size info

### DIFF
--- a/soc/egis/et171/Kconfig
+++ b/soc/egis/et171/Kconfig
@@ -30,3 +30,10 @@ config SOC_EGIS_ET171_FIRMWARE_VERSION
 	default 0xAAAAAAAA
 	help
 	  Firmware version info of bin header
+
+config SOC_EGIS_ET171_VENDOR_FIRMWARE_SIZE
+	hex "The firmware size in the binary header"
+	default 0x0 # 0 means unused
+	help
+	  Customize the firmware size info in the binary header.
+	  Unused if zero.

--- a/soc/egis/et171/start.S
+++ b/soc/egis/et171/start.S
@@ -22,7 +22,11 @@ SECTION_FUNC(init, entry)
 	.word 0x53494745 /* "EGIS" */
 	.word CONFIG_SOC_EGIS_ET171_FIRMWARE_VERSION /* version */
 	.word CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET /* flash start address */
+#if CONFIG_SOC_EGIS_ET171_VENDOR_FIRMWARE_SIZE > 0
+	.word CONFIG_SOC_EGIS_ET171_VENDOR_FIRMWARE_SIZE
+#else
 	.word __egis_binary_size /* It's not included 64 bytes signature */
+#endif
 	.word 0 /* unused */
 	.word 0 /* unused */
 


### PR DESCRIPTION
This PR allows applications to customize the firmware size information for binary header optionally.

Although the firmware size is calculated at link time, sometimes applications need to reserve a fixed space for it.

For example:
A fixed-size firmware means that its signature will be located in a specified position.
This reduces the complexity of merging flash image files with multiple partitions.