### PR TITLE
dts: arm: nxp: fix formatting and update copyright headers

### DIFF
--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ */
 
 #include <mem.h>
 #include <freq.h>

--- a/dts/arm/nxp/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/nxp_mcxa344.dtsi
@@ -38,6 +38,7 @@
 			compatible = "nxp,lpc-syscon";
 			reg = <0x40091000 0x4000>;
 			#clock-cells = <1>;
+
 			reset: reset {
 				compatible = "nxp,lpc-syscon-reset";
 				#reset-cells = <1>;
@@ -239,12 +240,11 @@
 			#dma-cells = <2>;
 			compatible = "nxp,mcux-edma";
 			nxp,version = <4>;
+			reg = <0x40080000 0x1000>;
 			dma-channels = <8>;
 			dma-requests = <86>;
-
-			reg = <0x40080000 0x1000>;
 			interrupts = <2 0>, <3 0>, <4 0>, <5 0>,
-				<6 0>, <7 0>, <8 0>, <9 0>;
+				     <6 0>, <7 0>, <8 0>, <9 0>;
 			no-error-irq;
 			status = "disabled";
 		};
@@ -264,6 +264,7 @@
 			reg = <0x400a9000 0x1000>;
 			interrupt-names = "RELOAD-ERROR", "FAULT";
 			interrupts = <44 0>, <45 0>;
+
 			flexpwm0_pwm0: pwm0 {
 				compatible = "nxp,imx-pwm";
 				index = <0>;
@@ -303,6 +304,7 @@
 			reg = <0x400aa000 0x1000>;
 			interrupt-names = "RELOAD-ERROR", "FAULT";
 			interrupts = <79 0>, <80 0>;
+
 			flexpwm1_pwm0: pwm0 {
 				compatible = "nxp,imx-pwm";
 				index = <0>;
@@ -344,7 +346,7 @@
 			status = "disabled";
 			clk-divider = <1>;
 			clk-source = <0>;
-			voltage-ref= <2>;
+			voltage-ref = <2>;
 			calibration-average = <128>;
 			power-level = <0>;
 			offset-value-a = <0>;
@@ -360,7 +362,7 @@
 			status = "disabled";
 			clk-divider = <1>;
 			clk-source = <0>;
-			voltage-ref= <2>;
+			voltage-ref = <2>;
 			calibration-average = <128>;
 			power-level = <1>;
 			offset-value-a = <0>;

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -48,6 +48,7 @@
 				power-state-name = "suspend-to-idle";
 				exit-latency-us = <10>;
 			};
+
 			deep_sleep: deep-sleep {
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
@@ -434,9 +435,9 @@
 		reg = <0x2000 0x140>;
 		clocks = <&scg SCG_K4_EDMA_CLK 0x410>;
 		interrupts = <2 0>, <3 0>, <4 0>, <5 0>,
-			<6 0>, <7 0>, <8 0>, <9 0>,
-			<10 0>, <11 0>, <12 0>, <13 0>,
-			<14 0>, <15 0>, <16 0>, <17 0>;
+			     <6 0>, <7 0>, <8 0>, <9 0>,
+			     <10 0>, <11 0>, <12 0>, <13 0>,
+			     <14 0>, <15 0>, <16 0>, <17 0>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -1488,10 +1488,10 @@
 		pre-div = <0>;
 		podf = <12>;
 		pll-clocks = <&anatop 0 0 0>,
-				<&anatop 0 0 32>,
-				<&anatop 0 0 1>,
-				<&anatop 0 0 768>,
-				<&anatop 0 0 1000>;
+			     <&anatop 0 0 32>,
+			     <&anatop 0 0 1>,
+			     <&anatop 0 0 768>,
+			     <&anatop 0 0 1000>;
 		pll-clock-names = "src", "lp", "pd", "num", "den";
 		pinmuxes = <&blkctrl_ns_aon 0x20 0x100>;
 		interrupts = <45 0>;
@@ -1515,10 +1515,10 @@
 		pre-div = <0>;
 		podf = <12>;
 		pll-clocks = <&anatop 0 0 0>,
-				<&anatop 0 0 32>,
-				<&anatop 0 0 1>,
-				<&anatop 0 0 768>,
-				<&anatop 0 0 1000>;
+			     <&anatop 0 0 32>,
+			     <&anatop 0 0 1>,
+			     <&anatop 0 0 768>,
+			     <&anatop 0 0 1000>;
 		pll-clock-names = "src", "lp", "pd", "num", "den";
 		pinmuxes = <&blkctrl_wakeup 0x38 0x100>;
 		interrupts = <198 0>;
@@ -1542,10 +1542,10 @@
 		pre-div = <0>;
 		podf = <12>;
 		pll-clocks = <&anatop 0 0 0>,
-				<&anatop 0 0 32>,
-				<&anatop 0 0 1>,
-				<&anatop 0 0 768>,
-				<&anatop 0 0 1000>;
+			     <&anatop 0 0 32>,
+			     <&anatop 0 0 1>,
+			     <&anatop 0 0 768>,
+			     <&anatop 0 0 1000>;
 		pll-clock-names = "src", "lp", "pd", "num", "den";
 		pinmuxes = <&blkctrl_wakeup 0x3c 0x100>;
 		interrupts = <199 0>;
@@ -1569,10 +1569,10 @@
 		pre-div = <0>;
 		podf = <12>;
 		pll-clocks = <&anatop 0 0 0>,
-				<&anatop 0 0 32>,
-				<&anatop 0 0 1>,
-				<&anatop 0 0 768>,
-				<&anatop 0 0 1000>;
+			     <&anatop 0 0 32>,
+			     <&anatop 0 0 1>,
+			     <&anatop 0 0 768>,
+			     <&anatop 0 0 1000>;
 		pll-clock-names = "src", "lp", "pd", "num", "den";
 		pinmuxes = <&blkctrl_wakeup 0x40 0x100>;
 		interrupts = <154 0>;
@@ -1613,6 +1613,7 @@
 		reg = <0x0 DT_SIZE_K(512)>;
 		#address-cells = <1>;
 		#size-cells = <1>;
+
 		ocram1_available: memory@4000 {
 			/* OCRAM1 first 16K access is blocked by TRDC */
 			reg = <0x0 DT_SIZE_K(496)>;


### PR DESCRIPTION
Fix various formatting issues in NXP device tree files including:
- Inconsistent indentation in multi-line interrupt and pll-clocks arrays
- Missing spaces around assignment operators
- Inconsistent blank line spacing between device tree nodes

Also update copyright header in nxp_k6x.dtsi.