### PR TITLE
Bluetooth: Classic: HFP_AG: Optimize audio connect management

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -1354,18 +1354,6 @@ static struct bt_hfp_ag_call *get_call_with_flag(struct bt_hfp_ag *ag, int bit)
 	return NULL;
 }
 
-static struct bt_hfp_ag_call *get_call_clear_flag(struct bt_hfp_ag *ag, int bit)
-{
-	struct bt_hfp_ag_call *call;
-
-	call = get_call_with_flag(ag, bit);
-	if (call != NULL) {
-		atomic_clear_bit(call->flags, bit);
-	}
-
-	return call;
-}
-
 static struct bt_hfp_ag_call *get_call_with_flag_and_state(struct bt_hfp_ag *ag, int bit,
 						    bt_hfp_call_state_t state)
 {
@@ -1416,23 +1404,6 @@ static void bt_hfp_ag_call_ringing_cb(struct bt_hfp_ag_call *call, bool in_bond)
 	}
 }
 
-static void hfp_ag_sco_valid_call_update(struct bt_hfp_ag *ag)
-{
-	struct bt_hfp_ag_call *call;
-
-	call = get_call_clear_flag(ag, BT_HFP_AG_CALL_OPEN_SCO);
-
-	if (call == NULL) {
-		return;
-	}
-
-	if ((call->call_state == BT_HFP_CALL_INCOMING) ||
-	    atomic_test_and_clear_bit(call->flags, BT_HFP_AG_CALL_ALERTING)) {
-		bt_hfp_ag_set_call_state(call, BT_HFP_CALL_ALERTING);
-		bt_hfp_ag_call_ringing_cb(call, true);
-	}
-}
-
 static void hfp_ag_sco_connected(struct bt_sco_chan *chan)
 {
 	struct bt_hfp_ag *ag = CONTAINER_OF(chan, struct bt_hfp_ag, sco_chan);
@@ -1440,8 +1411,6 @@ static void hfp_ag_sco_connected(struct bt_sco_chan *chan)
 	if (ag->sco_conn == NULL) {
 		ag->sco_conn = bt_conn_ref(chan->sco);
 	}
-
-	hfp_ag_sco_valid_call_update(ag);
 
 	if ((bt_ag) && bt_ag->sco_connected) {
 		bt_ag->sco_connected(ag, chan->sco);
@@ -1451,10 +1420,6 @@ static void hfp_ag_sco_connected(struct bt_sco_chan *chan)
 static void hfp_ag_sco_disconnected(struct bt_sco_chan *chan, uint8_t reason)
 {
 	struct bt_hfp_ag *ag = CONTAINER_OF(chan, struct bt_hfp_ag, sco_chan);
-	bt_hfp_call_state_t call_state;
-	struct bt_hfp_ag_call *call;
-
-	call = get_call_clear_flag(ag, BT_HFP_AG_CALL_OPEN_SCO);
 
 	if ((bt_ag != NULL) && bt_ag->sco_disconnected) {
 		bt_ag->sco_disconnected(chan->sco, reason);
@@ -1463,15 +1428,6 @@ static void hfp_ag_sco_disconnected(struct bt_sco_chan *chan, uint8_t reason)
 	if (ag->sco_conn != NULL) {
 		bt_conn_unref(ag->sco_conn);
 		ag->sco_conn = NULL;
-	}
-
-	if (!call) {
-		return;
-	}
-
-	call_state = call->call_state;
-	if ((call_state == BT_HFP_CALL_INCOMING) || (call_state == BT_HFP_CALL_OUTGOING)) {
-		bt_hfp_ag_call_reject(ag, call);
 	}
 }
 
@@ -1493,7 +1449,7 @@ static struct bt_conn *bt_hfp_ag_create_sco(struct bt_hfp_ag *ag)
 			LOG_DBG("Created sco %p", ag->sco_conn);
 			if (ag->sco_chan.sco == NULL) {
 				/* SCO connection exists */
-				hfp_ag_sco_valid_call_update(ag);
+				LOG_WRN("SCO conn has been created outside");
 			}
 		}
 	}
@@ -1529,19 +1485,18 @@ static int hfp_ag_open_sco(struct bt_hfp_ag *ag, struct bt_hfp_ag_call *call)
 		}
 
 		atomic_set_bit_to(ag->flags, BT_HFP_AG_AUDIO_CONN, call == NULL);
-		if (call) {
-			atomic_set_bit(call->flags, BT_HFP_AG_CALL_OPEN_SCO);
-		}
 
 		LOG_DBG("SCO connection created (%p)", sco_conn);
-	} else {
-		if (call) {
-			if ((call->call_state == BT_HFP_CALL_INCOMING) ||
-			    atomic_test_and_clear_bit(call->flags, BT_HFP_AG_CALL_ALERTING)) {
-				bt_hfp_ag_set_call_state(call, BT_HFP_CALL_ALERTING);
-				bt_hfp_ag_call_ringing_cb(call, true);
-			}
-		}
+	}
+
+	if (call == NULL) {
+		return 0;
+	}
+
+	if ((call->call_state == BT_HFP_CALL_INCOMING) ||
+	    atomic_test_and_clear_bit(call->flags, BT_HFP_AG_CALL_ALERTING)) {
+		bt_hfp_ag_set_call_state(call, BT_HFP_CALL_ALERTING);
+		bt_hfp_ag_call_ringing_cb(call, true);
 	}
 
 	return 0;
@@ -2526,8 +2481,8 @@ static void bt_hfp_ag_audio_connection(struct bt_hfp_ag *ag, void *user_data)
 	struct bt_hfp_ag_call *call = (struct bt_hfp_ag_call *)user_data;
 
 	err = bt_hfp_ag_create_audio_connection(ag, call);
-	if (err) {
-		bt_hfp_ag_unit_call_terminate(ag, user_data);
+	if (err != 0) {
+		LOG_ERR("Failed to create audio conn: %d", err);
 	}
 }
 
@@ -2688,8 +2643,8 @@ static void bt_hfp_ag_unit_codec_conn_setup(struct bt_hfp_ag *ag, void *user_dat
 {
 	int err = hfp_ag_open_sco(ag, user_data);
 
-	if (err) {
-		bt_hfp_ag_call_reject(ag, user_data);
+	if (err != 0) {
+		LOG_ERR("Failed to open sco: %d", err);
 	}
 }
 
@@ -2757,6 +2712,7 @@ static int bt_hfp_ag_bcs_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 static void bt_hfp_ag_outgoing_cb(struct bt_hfp_ag *ag, void *user_data)
 {
 	struct bt_hfp_ag_call *call = (struct bt_hfp_ag_call *)user_data;
+	bool in_bond = false;
 
 	bt_hfp_ag_set_call_state(call, BT_HFP_CALL_OUTGOING);
 
@@ -2769,12 +2725,16 @@ static void bt_hfp_ag_outgoing_cb(struct bt_hfp_ag *ag, void *user_data)
 		int err;
 
 		err = bt_hfp_ag_create_audio_connection(ag, call);
-		if (err) {
-			bt_hfp_ag_call_reject(ag, user_data);
+		if (err != 0) {
+			LOG_ERR("Failed to create audio conn: %d", err);
+		} else {
+			in_bond = true;
 		}
-	} else if (atomic_test_and_clear_bit(call->flags, BT_HFP_AG_CALL_ALERTING)) {
+	}
+
+	if (atomic_test_and_clear_bit(call->flags, BT_HFP_AG_CALL_ALERTING)) {
 		bt_hfp_ag_set_call_state(call, BT_HFP_CALL_ALERTING);
-		bt_hfp_ag_call_ringing_cb(call, false);
+		bt_hfp_ag_call_ringing_cb(call, in_bond);
 	}
 }
 
@@ -3129,8 +3089,8 @@ static void btrh_accept_cb(struct bt_hfp_ag *ag, void *user_data)
 	}
 
 	err = bt_hfp_ag_create_audio_connection(ag, call);
-	if (err) {
-		bt_hfp_ag_unit_call_terminate(ag, user_data);
+	if (err != 0) {
+		LOG_ERR("Failed to create audio connection: %d", err);
 	}
 }
 
@@ -4146,6 +4106,7 @@ int bt_hfp_ag_register(struct bt_hfp_ag_cb *cb)
 static void bt_hfp_ag_incoming_cb(struct bt_hfp_ag *ag, void *user_data)
 {
 	struct bt_hfp_ag_call *call = (struct bt_hfp_ag_call *)user_data;
+	bool in_bond = false;
 
 	__ASSERT(call, "Invalid call object");
 
@@ -4159,13 +4120,15 @@ static void bt_hfp_ag_incoming_cb(struct bt_hfp_ag *ag, void *user_data)
 		int err;
 
 		err = bt_hfp_ag_create_audio_connection(ag, call);
-		if (err) {
-			bt_hfp_ag_call_reject(ag, user_data);
+		if (err != 0) {
+			LOG_ERR("Failed to create audio conn: %d", err);
+		} else {
+			in_bond = true;
 		}
-	} else {
-		bt_hfp_ag_set_call_state(call, BT_HFP_CALL_ALERTING);
-		bt_hfp_ag_call_ringing_cb(call, false);
 	}
+
+	bt_hfp_ag_set_call_state(call, BT_HFP_CALL_ALERTING);
+	bt_hfp_ag_call_ringing_cb(call, in_bond);
 }
 
 #if defined(CONFIG_BT_HFP_AG_3WAY_CALL)
@@ -4661,11 +4624,6 @@ int bt_hfp_ag_remote_ringing(struct bt_hfp_ag_call *call)
 	if (call->call_state != BT_HFP_CALL_OUTGOING) {
 		hfp_ag_unlock(ag);
 		return -EBUSY;
-	}
-
-	if (atomic_test_bit(ag->flags, BT_HFP_AG_INBAND_RING) && (ag->sco_conn == NULL)) {
-		hfp_ag_unlock(ag);
-		return -ENOTCONN;
 	}
 	hfp_ag_unlock(ag);
 


### PR DESCRIPTION
In current implementation, the call will be terminated, or rejected if the audio connect cannot be established. But from the application view, if the sco connect cannot be established, the audio paths can be routed towards the AG. So force routeing the audio towards the HF is not reasonable and it is not the mandatory.

The changes aim to keep the sequence that creating SCO connect in the right time. And ignore the result whether the SCO connect has been created or can be established.

If the audio connect cannot be established, the application can try to change the audio route paths according to the audio connection procedure.