### PR TITLE
drivers: espi: rts5912: Reset HOST_RST_ACK to inactive on PLTRST asse…

### DIFF
--- a/drivers/espi/espi_realtek_rts5912.c
+++ b/drivers/espi/espi_realtek_rts5912.c
@@ -1272,7 +1272,7 @@ static void vw_pltrst_handler(const struct device *dev)
 
 		espi_rts5912_send_vwire(dev, ESPI_VWIRE_SIGNAL_SMI, 1);
 		espi_rts5912_send_vwire(dev, ESPI_VWIRE_SIGNAL_SCI, 1);
-		espi_rts5912_send_vwire(dev, ESPI_VWIRE_SIGNAL_HOST_RST_ACK, 1);
+		espi_rts5912_send_vwire(dev, ESPI_VWIRE_SIGNAL_HOST_RST_ACK, 0);
 		espi_rts5912_send_vwire(dev, ESPI_VWIRE_SIGNAL_RST_CPU_INIT, 1);
 	}
 


### PR DESCRIPTION
…rtion

When PLTRST signal is asserted (goes high), the HOST_RST_ACK virtual wire should be reset to inactive state (0) according to eSPI specification.