### PR TITLE
modules: openthread: Remove SOCK_NONBLOCK as it is not supported

### DIFF
--- a/modules/openthread/platform/dhcp6_pd.c
+++ b/modules/openthread/platform/dhcp6_pd.c
@@ -120,7 +120,7 @@ static void dhcpv6_pd_client_socket_init(uint32_t infra_if_index)
 				    .sin6_addr = IN6ADDR_ANY_INIT,
 				    .sin6_scope_id = 0};
 
-	dhcpv6_pd_client_sock = zsock_socket(AF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, IPPROTO_UDP);
+	dhcpv6_pd_client_sock = zsock_socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
 	VerifyOrExit(dhcpv6_pd_client_sock >= 0);
 
 	VerifyOrExit(zsock_bind(dhcpv6_pd_client_sock, (struct sockaddr *)&addr,

--- a/modules/openthread/platform/mdns_socket.c
+++ b/modules/openthread/platform/mdns_socket.c
@@ -114,7 +114,7 @@ static otError mdns_socket_init_v6(uint32_t ail_iface_idx)
 				    .sin6_addr = {{{0}}},
 				    .sin6_scope_id = 0};
 
-	mdns_sock_v6 = zsock_socket(AF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, IPPROTO_UDP);
+	mdns_sock_v6 = zsock_socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
 	VerifyOrExit(mdns_sock_v6 >= 0, error = OT_ERROR_FAILED);
 	VerifyOrExit(net_if_get_name(net_if_get_by_index(ail_iface_idx), name,
 				     CONFIG_NET_INTERFACE_NAME_LEN) > 0,
@@ -175,7 +175,7 @@ static otError mdns_socket_init_v4(uint32_t ail_iface_idx)
 				   .sin_port = htons(MULTICAST_PORT),
 				   .sin_addr = {{{0}}}};
 
-	mdns_sock_v4 = zsock_socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, IPPROTO_UDP);
+	mdns_sock_v4 = zsock_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	VerifyOrExit(mdns_sock_v4 >= 0, error = OT_ERROR_FAILED);
 	VerifyOrExit(net_if_get_name(net_if_get_by_index(ail_iface_idx), name,
 				     CONFIG_NET_INTERFACE_NAME_LEN) > 0,

--- a/modules/openthread/platform/trel.c
+++ b/modules/openthread/platform/trel.c
@@ -35,7 +35,7 @@ void otPlatTrelEnable(otInstance *aInstance, uint16_t *aUdpPort)
 				    .sin6_scope_id = 0};
 	socklen_t len = sizeof(addr);
 
-	trel_sock = zsock_socket(AF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, IPPROTO_UDP);
+	trel_sock = zsock_socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
 	VerifyOrExit(trel_sock >= 0);
 	VerifyOrExit(zsock_bind(trel_sock, (struct sockaddr *)&addr, sizeof(addr)) == 0);
 

--- a/modules/openthread/platform/udp.c
+++ b/modules/openthread/platform/udp.c
@@ -78,7 +78,7 @@ otError otPlatUdpSocket(otUdpSocket *aUdpSocket)
 	VerifyOrExit(sock_cnt < CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_MAX_UDP_SERVICES,
 		     error = OT_ERROR_INVALID_STATE);
 
-	sock = zsock_socket(AF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, IPPROTO_UDP);
+	sock = zsock_socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
 	VerifyOrExit(sock >= 0, error = OT_ERROR_FAILED);
 
 #if defined(CONFIG_NET_IPV4) && defined(CONFIG_NET_IPV4_MAPPING_TO_IPV6)


### PR DESCRIPTION
There is no SOCK_NONBLOCK support in zephyr so remove the option.