### PR TITLE
maintainers: Add Kedareswara Rao Appana as Xilinx collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6222,6 +6222,7 @@ Xilinx Platforms:
   collaborators:
     - henrikbrixandersen
     - ibirnbaum
+    - kedareswararao
   files:
     - boards/amd/
     - drivers/*/*xilinx*


### PR DESCRIPTION
Add myself as a collaborator for Xilinx components. I have been actively contributing and will continue reviewing and testing patches for the Xilinx subsystems.