### PR TITLE
llext: linker: use INFO type instead of COPY

### DIFF
--- a/include/zephyr/linker/llext-sections.ld
+++ b/include/zephyr/linker/llext-sections.ld
@@ -16,7 +16,7 @@
 	 * This section is used for mapping that symbol only and is not
 	 * to be included in the final binary.
 	 */
-	SECTION_PROLOGUE(llext_no_syscall_impl, 0 (COPY), )
+	SECTION_PROLOGUE(llext_no_syscall_impl, 0 (INFO), )
 	{
 	  *(llext_no_syscall_impl)
 	}
@@ -33,7 +33,7 @@
 	 * strictly equivalent to the offset inside the section.
 	 */
 #ifdef CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID
-	SECTION_PROLOGUE(llext_exports_strtab, 0 (COPY), )
+	SECTION_PROLOGUE(llext_exports_strtab, 0 (INFO), )
 	{
 	  KEEP(*(llext_exports_strtab))
 	}


### PR DESCRIPTION
`COPY` and `INFO` are different names for the same Output Section Type (see [documentation page](https://sourceware.org/binutils/docs/ld/Output-Section-Type.html)), but the latter is easier to understand in the context we are using it.

Replace `COPY` with `INFO` in the LLEXT linker script snippet.

Note that both names are supported by `ld` [since basically forever](https://github.com/bminor/binutils-gdb/blame/1f841a9348f189a8ee4423eb416d6e5495b5b49d/ld/ld.texi#L5485) so there's no compatibility risk for GNU toolchain users; adding non-GNU toolchain folks as reviewers to confirm that their linker also supports `INFO` instead of `COPY` (which I ***assume*** was supported by all toolchains)