### PR TITLE
edtlib: Fix unformatted error message

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -438,7 +438,7 @@ class Binding:
 
             if key not in ok_top and not key.endswith("-cells"):
                 _err(f"unknown key '{key}' in {self.path}, "
-                     "expected one of {', '.join(ok_top)}, or *-cells")
+                     f"expected one of {', '.join(ok_top)}, or *-cells")
 
         if "bus" in raw:
             bus = raw["bus"]


### PR DESCRIPTION
The current error handling for unexpected top-level keys in a DTS binding YAML file prints out a partially unformatted error message, omitting the list of allowed keys:
```
$ west build -p always -b nrf5340dk/nrf5340/cpuapp samples/basic/blinky
...
devicetree error: unknown key 'dummy' in ~/zephyrproject/zephyr/dts/bindings/cpu/arm,cortex-m33f.yaml, expected one of {', '.join(ok_top)}, or *-cells
...
```

This is due to a missing `f` prefix on the second line of a multiline f-string. Simply adding the missing f fixes the error message:
```
$ west build -p always -b nrf5340dk/nrf5340/cpuapp samples/basic/blinky
...
devicetree error: unknown key 'dummy' in ~/zephyrproject/zephyr/dts/bindings/cpu/arm,cortex-m33f.yaml, expected one of child-binding, description, title, compatible, bus, properties, on-bus, or *-cells
...
```

To reproduce the outputs above, add `dummy: abc` (or some other syntactically valid but disallowed key) at the end of any used binding file, in this case `dts/bindings/cpu/arm,cortex-m33f.yaml`.

In practice, the error seems to usually be triggered by wrong indentation after copy-pasting from an example or tutorial.

Due to the trivial nature of this fix, I did not add a test case. Please let me know if a test case is needed in this case.