### PR TITLE
Bluetooth: CSIP: Only allow rank changes with set size changes

### DIFF
--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -236,6 +236,8 @@ int bt_csip_set_member_sirk(struct bt_csip_set_member_svc_inst *svc_inst,
  * It is important to note that a set cannot have multiple devices with the same rank in a set,
  * and it is up to the caller of this function to ensure that.
  * Similarly, it is important that the size is updated on all devices in the set at the same time.
+ * The rank of a device cannot be modified on its own, and a new rank can only be set if the @p size
+ * is different from the current set size.
  *
  * If @kconfig{CONFIG_BT_CSIP_SET_MEMBER_SIZE_NOTIFIABLE} is enabled, this will also send a
  * notification to all connected or bonded clients.
@@ -246,7 +248,7 @@ int bt_csip_set_member_sirk(struct bt_csip_set_member_svc_inst *svc_inst,
  *
  * @retval -EINVAL @p svc_inst is NULL, @p size is less than 1, @p rank is less than 1 or higher
  *                 than @p size for a lockable @p svc_inst.
- * @retval -EALREADY @p size and @p rank are already the provided values.
+ * @retval -EALREADY @p size is already set.
  * @retval 0 Success.
  */
 int bt_csip_set_member_set_size_and_rank(struct bt_csip_set_member_svc_inst *svc_inst, uint8_t size,

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -1095,8 +1095,8 @@ int bt_csip_set_member_set_size_and_rank(struct bt_csip_set_member_svc_inst *svc
 		return -EINVAL;
 	}
 
-	if (svc_inst->set_size == size && svc_inst->rank == rank) {
-		LOG_DBG("Set size %u and rank %u is already set", size, rank);
+	if (svc_inst->set_size == size) {
+		LOG_DBG("Set size %u is already set", size);
 		return -EALREADY;
 	}
 


### PR DESCRIPTION
The rank cannot be notified and the function allowed for just updated to the rank. The CSIS spec does not mention the usecase, nor support, for changing the rank of a device. The spec only seems to allow for dynamic changes to the set size (and only during that can the rank be set).