### PR TITLE
cmake: modules: boards: Fix board moved check

### DIFF
--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -141,7 +141,7 @@ Hints:
   endif()
 endforeach()
 
-if(NOT EXISTS ${BOARD_DIR}/board.yml)
+if(DEFINED BOARD_DIR AND NOT EXISTS ${BOARD_DIR}/board.yml)
   message(WARNING "BOARD_DIR: ${BOARD_DIR} has been moved or deleted. "
                   "Trying to find new location."
   )


### PR DESCRIPTION
Fixes checking for board folders that have moved by checking if the BOARD_DIR variable is already set (i.e. loaded from cache)