### PR TITLE
drivers: watchdog: Fix Numaker driver bug in test suite

### DIFF
--- a/drivers/watchdog/wdt_wwdt_numaker.c
+++ b/drivers/watchdog/wdt_wwdt_numaker.c
@@ -21,6 +21,10 @@ LOG_MODULE_REGISTER(wwdt_numaker, CONFIG_WDT_LOG_LEVEL);
 #define NUMAKER_COUNTER_MAX   0x3eU
 #define NUMAKER_COUNTER_MIN   0x01U
 
+#if defined(CLK_CLKSEL1_WWDT0SEL_LIRC)
+#define CLK_CLKSEL1_WWDTSEL_LIRC CLK_CLKSEL1_WWDT0SEL_LIRC
+#endif
+
 /* Device config */
 struct wwdt_numaker_config {
 	/* wdt base address */
@@ -151,15 +155,9 @@ static int wwdt_numaker_install_timeout(const struct device *dev,
 static int wwdt_numaker_disable(const struct device *dev)
 {
 	struct wwdt_numaker_data *data = dev->data;
-	const struct wwdt_numaker_config *cfg = dev->config;
-	WWDT_T *wwdt_base = cfg->wwdt_base;
 
+	/* watchdog counting cannot be stopped once started */
 	LOG_DBG("");
-	/* stop counting */
-	wwdt_base->CTL &= ~WWDT_CTL_WWDTEN_Msk;
-
-	/* disable interrupt enable bit */
-	wwdt_base->CTL &= ~WWDT_CTL_INTEN_Msk;
 
 	/* disable interrupt */
 	irq_disable(DT_INST_IRQN(0));

--- a/tests/drivers/watchdog/wdt_basic_api/boards/numaker_m3334ki.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/numaker_m3334ki.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wwdt {
+	status = "okay";
+};


### PR DESCRIPTION
This PR is to fix Numaker driver bug in test suite.

Pass wdt_basic_api as:
```
Running TESTSUITE wdt_basic_test_suite
===================================================================
START - test_wdt
Testcase: test_wdt_no_callback
Waiting to restart MCU
Running TESTSUITE wdt_basic_test_suite
===================================================================
START - test_wdt
Testcase: test_wdt_no_callback
Testcase passed
Testcase: test_wdt_callback_1
Waiting to restart MCU
Running TESTSUITE wdt_basic_test_suite
===================================================================
START - test_wdt
Testcase: test_wdt_callback_1
Testcase passed
Testcase: test_wdt_enable_wait_mode
 SKIP - test_wdt in 0.008 seconds
===================================================================
TESTSUITE wdt_basic_test_suite succeeded

------ TESTSUITE SUMMARY START ------

SUITE SKIP -   0.00% [wdt_basic_test_suite]: pass = 0, fail = 0, skip = 1, total = 1 duration = 0.008 seconds
 - SKIP - [wdt_basic_test_suite.test_wdt] duration = 0.008 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

