### PR TITLE
drivers: serial/i2c/spi: nrfx: Fix not guarding deinit functions

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -224,10 +224,12 @@ static int i2c_nrfx_twim_init(const struct device *dev)
 	return i2c_nrfx_twim_common_init(dev);
 }
 
+#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
 static int i2c_nrfx_twim_deinit(const struct device *dev)
 {
 	return i2c_nrfx_twim_common_deinit(dev);
 }
+#endif
 
 static DEVICE_API(i2c, i2c_nrfx_twim_driver_api) = {
 	.configure = i2c_nrfx_twim_configure,

--- a/drivers/i2c/i2c_nrfx_twim_common.c
+++ b/drivers/i2c/i2c_nrfx_twim_common.c
@@ -151,6 +151,7 @@ int i2c_nrfx_twim_common_init(const struct device *dev)
 	return pm_device_driver_init(dev, twim_nrfx_pm_action);
 }
 
+#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
 int i2c_nrfx_twim_common_deinit(const struct device *dev)
 {
 	const struct i2c_nrfx_twim_common_config *config = dev->config;
@@ -178,3 +179,4 @@ int i2c_nrfx_twim_common_deinit(const struct device *dev)
 	nrfx_twim_uninit(&config->twim);
 	return 0;
 }
+#endif

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -211,10 +211,12 @@ static int i2c_nrfx_twim_rtio_init(const struct device *dev)
 	return i2c_nrfx_twim_common_init(dev);
 }
 
+#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
 static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
 {
 	return i2c_nrfx_twim_common_deinit(dev);
 }
+#endif
 
 #define CONCAT_BUF_SIZE(idx)                                                                       \
 	COND_CODE_1(DT_NODE_HAS_PROP(I2C(idx), zephyr_concat_buf_size),                            \

--- a/drivers/i2c/i2c_nrfx_twis.c
+++ b/drivers/i2c/i2c_nrfx_twis.c
@@ -292,6 +292,7 @@ static int shim_nrf_twis_init(const struct device *dev)
 	return pm_device_driver_init(dev, shim_nrf_twis_pm_action_cb);
 }
 
+#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
 static int shim_nrf_twis_deinit(const struct device *dev)
 {
 	const struct shim_nrf_twis_config *dev_config = dev->config;
@@ -320,6 +321,7 @@ static int shim_nrf_twis_deinit(const struct device *dev)
 	nrfx_twis_uninit(&dev_config->twis);
 	return 0;
 }
+#endif
 
 #define SHIM_NRF_TWIS_NAME(id, name) \
 	_CONCAT_4(shim_nrf_twis_, name, _, id)

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -2412,10 +2412,12 @@ static int uarte_instance_init(const struct device *dev,
 	return pm_device_driver_init(dev, uarte_nrfx_pm_action);
 }
 
+#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
 static int uarte_instance_deinit(const struct device *dev)
 {
 	return pm_device_driver_deinit(dev, uarte_nrfx_pm_action);
 }
+#endif
 
 #define UARTE_GET_ISR(idx) \
 	COND_CODE_1(CONFIG_UART_##idx##_ASYNC, (uarte_nrfx_isr_async), (uarte_nrfx_isr_int))

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -711,6 +711,7 @@ static int spi_nrfx_init(const struct device *dev)
 	return pm_device_driver_init(dev, spim_nrfx_pm_action);
 }
 
+#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
 static int spi_nrfx_deinit(const struct device *dev)
 {
 #if defined(CONFIG_PM_DEVICE)
@@ -731,6 +732,7 @@ static int spi_nrfx_deinit(const struct device *dev)
 
 	return 0;
 }
+#endif
 
 #define SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)				\
 	IF_ENABLED(NRFX_SPIM_EXTENDED_ENABLED,				\


### PR DESCRIPTION
Properly guards the deinit function with the corresponding Kconfig

Fixes #96762
Fixes #96699