### PR TITLE
MAINTAINERS: Cleanup inactive collaborators in OpenThread area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3925,10 +3925,8 @@ Networking:
     - rlubos
   collaborators:
     - pdgendt
-    - canisLupus1313
     - kkasperczyk-no
     - edmont
-    - maciejbaczmanski
   files:
     - subsys/net/l2/openthread/
     - samples/net/openthread/
@@ -6011,10 +6009,8 @@ West:
     - rlubos
   collaborators:
     - pdgendt
-    - canisLupus1313
-    - mariuszpos
+    - kkasperczyk-no
     - edmont
-    - maciejbaczmanski
   files:
     - modules/openthread/
   labels:


### PR DESCRIPTION
Remove collaborators in OpenThread area that haven't been active for months. Also unify the collaborator list in "Networking: OpenThread" and "West project: openthread" areas.