### PR TITLE
tests: smf: use BIT() for flat state flags

### DIFF
--- a/tests/lib/smf/src/test_lib_flat_smf.c
+++ b/tests/lib/smf/src/test_lib_flat_smf.c
@@ -22,17 +22,17 @@
 
 #define SMF_RUN 3
 
-#define STATE_A_ENTRY_BIT (1 << 0)
-#define STATE_A_RUN_BIT   (1 << 1)
-#define STATE_A_EXIT_BIT  (1 << 2)
+#define STATE_A_ENTRY_BIT BIT(0)
+#define STATE_A_RUN_BIT   BIT(1)
+#define STATE_A_EXIT_BIT  BIT(2)
 
-#define STATE_B_ENTRY_BIT (1 << 3)
-#define STATE_B_RUN_BIT   (1 << 4)
-#define STATE_B_EXIT_BIT  (1 << 5)
+#define STATE_B_ENTRY_BIT BIT(3)
+#define STATE_B_RUN_BIT   BIT(4)
+#define STATE_B_EXIT_BIT  BIT(5)
 
-#define STATE_C_ENTRY_BIT (1 << 6)
-#define STATE_C_RUN_BIT   (1 << 7)
-#define STATE_C_EXIT_BIT  (1 << 8)
+#define STATE_C_ENTRY_BIT BIT(6)
+#define STATE_C_RUN_BIT   BIT(7)
+#define STATE_C_EXIT_BIT  BIT(8)
 
 #define TEST_ENTRY_VALUE_NUM 0
 #define TEST_RUN_VALUE_NUM   4


### PR DESCRIPTION
Replace manual `1 << n` flag definitions in the flat SMF test with the common `BIT(n)` macro. This aligns the test with other SMF test.