### PR TITLE
tests: gpio: siwx91x: Add gpio_basic_api overlay files

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/siwx917_rb4342a-uulp.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/siwx917_rb4342a-uulp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&uulpgpio 0 0>; /* WPK P14 */
+		in-gpios = <&uulpgpio 3 0>; /* WPK P18 */
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/siwx917_rb4342a.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/siwx917_rb4342a.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpiod 0 0>; /* WPK P28 */
+		in-gpios = <&gpiod 2 0>; /* WPK P32 */
+	};
+};


### PR DESCRIPTION
This commit adds the GPIO overlay files for the brd4342a board, enabling gpio_basic_api support in Zephyr.