### PR TITLE
tests: drivers: Add overlays and update yaml tags for RTC, Counter, and PWM support

### DIFF
--- a/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a.yaml
+++ b/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a.yaml
@@ -22,4 +22,5 @@ supported:
   - wifi
   - rtc
   - counter
+  - pwm
 vendor: silabs

--- a/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.yaml
+++ b/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.yaml
@@ -20,6 +20,7 @@ supported:
   - pwm
   - uart
   - watchdog
+  - rtc
   - counter
   - wifi
 vendor: silabs

--- a/tests/drivers/counter/counter_basic_api/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/siwx917_rb4338a.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+&sysrtc0 {
+	status = "okay";
+};

--- a/tests/drivers/pwm/pwm_api/boards/siwx917_rb4342a.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/siwx917_rb4342a.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-test = &pwm;
+	};
+};
+
+&pinctrl0 {
+	pwm_ch: pwm_ch {
+		group1 {
+			pinmux = <PWM_0H_HP7>; /* GPIO_7 P20 */
+		};
+	};
+};
+
+&pwm {
+	pinctrl-0 = <&pwm_ch>;
+	pinctrl-names = "default";
+
+	pwm_channel1: pwm_channel1 {
+		pwms = <&pwm 0 1000000>;
+	};
+	silabs,pwm-polarity = <PWM_POLARITY_NORMAL>;
+	status = "okay";
+};

--- a/tests/drivers/rtc/rtc_api/boards/siwx917_rb4342a.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/siwx917_rb4342a.overlay
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ */
+
+/ {
+	aliases {
+		rtc = &rtc0;
+	};
+};
+
+&rtc0 {
+	status = "okay";
+};


### PR DESCRIPTION
This PR adds and updates board overlays and test configuration YAMLs for RTC, Counter, and PWM driver tests:

- **RTC**: Adds an `rtc_api` test app overlay for the `brd4342a` board, enabling RTC support, and updates the `rtc` tag in `siwx917_rb4342a.yaml`.
- **Counter**: Adds a `counter_basic_api` test app overlay file for the `brd4338a` board to enable counter support.
- **PWM**: Adds a `pwm_api` test app overlay for the `brd4342a` board and updates the `pwm` tag in `siwx917_dk2605a.yaml`.