### PR TITLE
boards: witte: linum: update clock settings plus fix CAN clock settings.

### DIFF
--- a/boards/witte/linum/linum.dts
+++ b/boards/witte/linum/linum.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <st/h7/stm32h753Xi.dtsi>
 #include <st/h7/stm32h753bitx-pinctrl.dtsi>
+#include <zephyr/dt-bindings/clock/stm32h7_clock.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -126,11 +127,21 @@
 };
 
 &pll2 {
-	div-m = <2>;
-	mul-n = <48>;
+	div-m = <5>;
+	mul-n = <96>;
 	div-p = <8>;
 	div-q = <40>;
-	div-r = <3>;
+	div-r = <10>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&pll3 {
+	div-m = <5>;
+	mul-n = <128>;
+	div-p = <4>;
+	div-q = <4>;
+	div-r = <25>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };
@@ -146,8 +157,12 @@
 	d3ppre = <2>;
 };
 
-&pwr {
-	power-supply = "ldo";
+&mco1 {
+	status = "okay";
+	clocks = <&rcc STM32_SRC_HSE MCO1_SEL(MCO1_SEL_HSE)>;
+	prescaler = <MCO1_PRE(MCO_PRE_DIV_1)>;
+	pinctrl-0 = <&rcc_mco_1_pa8>;
+	pinctrl-names = "default";
 };
 
 &usart1 {
@@ -455,4 +470,8 @@ zephyr_udc0: &usbotg_fs {
 			reg = <0x000c0000 DT_SIZE_K(128)>;
 		};
 	};
+};
+
+&pwr {
+	power-supply = "ldo";
 };

--- a/boards/witte/linum/linum.dts
+++ b/boards/witte/linum/linum.dts
@@ -249,16 +249,12 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &fdcan1 {
-	clocks = <&rcc STM32_CLOCK(APB1_2, 8)>,
-		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
 	pinctrl-0 = <&fdcan1_tx_ph13 &fdcan1_rx_ph14>;
 	pinctrl-names = "default";
 	status = "okay";
 };
 
 &fdcan2 {
-	clocks = <&rcc STM32_CLOCK(APB1_2, 8)>,
-		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
 	pinctrl-0 = <&fdcan2_rx_pb12 &fdcan2_tx_pb13>;
 	pinctrl-names = "default";
 	status = "okay";


### PR DESCRIPTION
Enables proper usage for:

Ethernet
FDCANs
USB.