### PR TITLE
drivers: sensor: adi: fix build warnings in ADXL decoder drivers

### DIFF
--- a/drivers/sensor/adi/adxl362/adxl362_decoder.c
+++ b/drivers/sensor/adi/adxl362/adxl362_decoder.c
@@ -89,8 +89,8 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
 
 	/* Calculate which sample is decoded. */
-	if ((uint8_t *)*fit >= buffer) {
-		sample_num = ((uint8_t *)*fit - buffer) / sample_set_size;
+	if (*fit >= (uintptr_t)buffer) {
+		sample_num = (*fit - (uintptr_t)buffer) / sample_set_size;
 	}
 
 	while (count < max_count && buffer < buffer_end) {

--- a/drivers/sensor/adi/adxl367/adxl367_decoder.c
+++ b/drivers/sensor/adi/adxl367/adxl367_decoder.c
@@ -530,8 +530,8 @@ static int adxl367_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 			data_out, enc_data);
 	} else {
 		/* Calculate which sample is decoded. */
-		if ((uint8_t *)*fit >= buffer) {
-			sample_num = ((uint8_t *)*fit - buffer) / packet_size;
+		if (*fit >= (uintptr_t)buffer) {
+			sample_num = (*fit - (uintptr_t)buffer) / packet_size;
 		}
 
 		while (count < max_count && buffer < buffer_end) {

--- a/drivers/sensor/adi/adxl372/adxl372_decoder.c
+++ b/drivers/sensor/adi/adxl372/adxl372_decoder.c
@@ -58,8 +58,8 @@ static int adxl372_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
 
 	/* Calculate which sample is decoded. */
-	if ((uint8_t *)*fit >= buffer) {
-		sample_num = ((uint8_t *)*fit - buffer) / sample_set_size;
+	if (*fit >= (uintptr_t)buffer) {
+		sample_num = (*fit - (uintptr_t)buffer) / sample_set_size;
 	}
 
 	while (count < max_count && buffer < buffer_end) {


### PR DESCRIPTION
Fix invalid pointer-to-integer cast and comparison warnings in ADXL362, ADXL367, and ADXL372 decoder drivers. The previous code used `(uint8_t *)*fit` for offset comparison, which triggered `-Wint-to-pointer-cast` warnings on recent compilers and could lead to undefined behavior.

This patch replaces unsafe casts with `uintptr_t` arithmetic and ensures type-safe offset calculations, preserving existing logic while eliminating all build warnings.