### PR TITLE
Corrected arduino_portenta_c33.dts file.

### DIFF
--- a/boards/arduino/portenta_c33/arduino_portenta_c33.dts
+++ b/boards/arduino/portenta_c33/arduino_portenta_c33.dts
@@ -37,12 +37,12 @@
 		};
 
 		led2: led2 {
-			gpios = <&ioport4 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&ioport4 0 GPIO_ACTIVE_LOW>;
 			label = "LEDG";
 		};
 
 		led3: led3 {
-			gpios = <&ioport8 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&ioport8 0 GPIO_ACTIVE_LOW>;
 			label = "LEDB";
 		};
 	};


### PR DESCRIPTION
The logic levels of the green and blue LED pins for the Portenta C33 board were set as 'GPIO_ACTIVE_HIGH', thus rendering them not functional in the sketches. Both were changed to the correct value of 'GPIO_ACTIVE_LOW'. The correct value was already configured for the pin used to drive the RED LED.