### PR TITLE
Enable I2C nodes and nPM1300 PMIC on PT2

### DIFF
--- a/boards/coredevices/pt2/pt2-pinctrl.dtsi
+++ b/boards/coredevices/pt2/pt2-pinctrl.dtsi
@@ -6,6 +6,34 @@
 #include <zephyr/dt-bindings/pinctrl/sf32lb52x-pinctrl.h>
 
 &pinctrl {
+	i2c1_default: i2c1_default {
+		group1 {
+			pinmux = <PA31_I2C1_SCL>, <PA30_I2C1_SDA>;
+			input-enable;
+		};
+	};
+
+	i2c2_default: i2c2_default {
+		group1 {
+			pinmux = <PA32_I2C2_SCL>, <PA33_I2C2_SDA>;
+			input-enable;
+		};
+	};
+
+	i2c3_default: i2c3_default {
+		group1 {
+			pinmux = <PA11_I2C3_SCL>, <PA10_I2C3_SDA>;
+			input-enable;
+		};
+	};
+
+	i2c4_default: i2c4_default {
+		group1 {
+			pinmux = <PA09_I2C4_SCL>, <PA20_I2C4_SDA>;
+			input-enable;
+		};
+	};
+
 	usart1_default: usart1_default {
 		group1 {
 			pinmux = <PA19_USART1_TXD>;

--- a/boards/coredevices/pt2/pt2.dts
+++ b/boards/coredevices/pt2/pt2.dts
@@ -9,6 +9,7 @@
 #include <sifli/sf32lb52x-ram012.dtsi>
 #include <zephyr/dt-bindings/dma/sf32lb52x-dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 #include "pt2-pinctrl.dtsi"
@@ -77,6 +78,34 @@
 
 &hxt48 {
 	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&i2c2 {
+	status = "okay";
+	pinctrl-0 = <&i2c2_default>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&i2c3 {
+	status = "okay";
+	pinctrl-0 = <&i2c3_default>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&i2c4 {
+	status = "okay";
+	pinctrl-0 = <&i2c4_default>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &mpi2 {

--- a/boards/coredevices/pt2/pt2.dts
+++ b/boards/coredevices/pt2/pt2.dts
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/regulator/npm13xx.h>
 
 #include "pt2-pinctrl.dtsi"
 
@@ -72,6 +73,10 @@
 	status = "okay";
 };
 
+&gpioa_00_31 {
+	status = "okay";
+};
+
 &gpioa_32_44 {
 	status = "okay";
 };
@@ -85,6 +90,51 @@
 	pinctrl-0 = <&i2c1_default>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_FAST>;
+
+	npm1300: pmic@6b {
+		compatible = "nordic,npm1300";
+		reg = <0x6b>;
+		pmic-int-pin = <1>;
+		host-int-gpios = <&gpioa_00_31 26 GPIO_ACTIVE_HIGH>;
+
+		npm1300_charger: charger {
+			compatible = "nordic,npm1300-charger";
+			term-microvolt = <4350000>;
+			term-warm-microvolt = <4000000>;
+			current-microamp = <185000>;
+			dischg-limit-microamp = <200000>;
+			vbus-limit-microamp = <500000>;
+			thermistor-ohms = <10000>;
+			thermistor-beta = <3380>;
+			charging-enable;
+			vbatlow-charge-enable;
+		};
+
+		npm1300_gpio: gpio-controller {
+			compatible = "nordic,npm1300-gpio";
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <4>;
+		};
+
+		regulators {
+			compatible = "nordic,npm1300-regulator";
+
+			npm1300_ldo1: LDO1 {
+				regulator-allowed-modes = <NPM13XX_LDSW_MODE_LDO>;
+				regulator-initial-mode = <NPM13XX_LDSW_MODE_LDO>;
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+			};
+
+			npm1300_ldo2: LDO2 {
+				regulator-allowed-modes = <NPM13XX_LDSW_MODE_LDO>;
+				regulator-initial-mode = <NPM13XX_LDSW_MODE_LDO>;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+			};
+		};
+	};
 };
 
 &i2c2 {


### PR DESCRIPTION
Enables all used I2C peripherals and PMIC on PT2 board.