### PR TITLE
net: tcp: Wake pending threads if non-blocking connect fails 

### DIFF
--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -358,6 +358,10 @@ static void zsock_connected_cb(struct net_context *ctx, int status, void *user_d
 	if (status < 0) {
 		ctx->user_data = INT_TO_POINTER(-status);
 		sock_set_error(ctx);
+
+		/* Wake pending threads, if any. */
+		k_fifo_cancel_wait(&ctx->recv_q);
+		(void)k_condvar_signal(&ctx->cond.recv);
 	}
 }
 


### PR DESCRIPTION
If a thread was sleeping in poll(), monitoring POLLIN only, it should
still be notified if an asynchronous connection, triggered by
non-blocking connect(), failed. Currently that's not the case.
In result the application would never know whether the connection
was successful or not and would be stuck with a disconnected socket
that would not report anything with poll().

This was not an issue if POLLOUT was monitored as well, because POLLOUT
sets up a connect semaphore that was reset in case of errors. POLLIN
however only monitors the recv fifo, which was not waken up in such
case.

Fix this by canceling any pending waits on recv fifo and recv
condition variable.