### PR TITLE
LLEXT: add discarded symbol groups inspector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2144,17 +2144,29 @@ if(CONFIG_BUILD_OUTPUT_INFO_HEADER)
     )
 endif()
 
-if(CONFIG_LLEXT AND CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID)
-  #slidgen must be the first post-build command to be executed
-  #on the Zephyr ELF to ensure that all other commands, such as
-  #binary file generation, are operating on a preparated ELF.
-  list(PREPEND
+if(CONFIG_LLEXT)
+  # Add discarded groups inspector to post-build commands
+  list(APPEND
     post_build_commands
     COMMAND ${PYTHON_EXECUTABLE}
-    ${ZEPHYR_BASE}/scripts/build/llext_prepare_exptab.py
+    ${ZEPHYR_BASE}/scripts/build/llext_inspect_discarded_groups.py
     --elf-file ${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}
-    --slid-listing ${PROJECT_BINARY_DIR}/slid_listing.txt
+    --dotconfig-file ${DOTCONFIG}
+    --output-report ${PROJECT_BINARY_DIR}/llext_discarded_groups.txt
   )
+
+  if(CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID)
+    #slidgen must be the first post-build command to be executed
+    #on the Zephyr ELF to ensure that all other commands, such as
+    #binary file generation, are operating on a preparated ELF.
+    list(PREPEND
+      post_build_commands
+      COMMAND ${PYTHON_EXECUTABLE}
+      ${ZEPHYR_BASE}/scripts/build/llext_prepare_exptab.py
+      --elf-file ${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}
+      --slid-listing ${PROJECT_BINARY_DIR}/slid_listing.txt
+    )
+  endif()
 endif()
 
 if(NOT CMAKE_C_COMPILER_ID STREQUAL "ARMClang")

--- a/include/zephyr/linker/llext-sections.ld
+++ b/include/zephyr/linker/llext-sections.ld
@@ -39,5 +39,23 @@
 	}
 #endif
 
+	/*
+	 * Special sections for symbols marked for export but ultimately rejected
+	 * from the Zephyr export table. This corresponds to symbols which have
+	 * been placed in an export group whose corresponding Kconfig symbol has
+	 * value "n" or is missing (the latter is an error from application author).
+	 * The first section contains (modified) export table entries whereas the
+	 * second holds strings such that they don't go in the final binary.
+	 */
+	SECTION_PROLOGUE(llext_discarded_exports_table, 0 (INFO), )
+	{
+		KEEP(*(llext_discarded_exports_table))
+	}
+
+	SECTION_PROLOGUE(llext_discarded_exports_strtab, 0 (INFO), )
+	{
+		KEEP(*(llext_discarded_exports_strtab))
+	}
+
 	. = __llext_current_addr;
 #endif /* CONFIG_LLEXT */

--- a/scripts/build/llext_elf_toolkit.py
+++ b/scripts/build/llext_elf_toolkit.py
@@ -7,10 +7,10 @@
 ELF utilities shared by LLEXT scripts
 """
 
+import struct
+
 import elftools.elf.elffile
 import elftools.elf.sections
-
-import struct
 
 
 def get_target_specific_structure(struct_desc: str, ptr_size: int, endianness: str):
@@ -27,7 +27,7 @@ def get_target_specific_structure(struct_desc: str, ptr_size: int, endianness: s
         ptr_size: Pointer size of target, in bytes (4/8)
         endianness: Endianness of target ('little'/'big')
     """
-    assert ptr_size == 4 or ptr_size == 8
+    assert ptr_size in (4, 8)
     assert endianness in ['little', 'big']
 
     endspec = "<" if endianness == 'little' else ">"

--- a/scripts/build/llext_elf_toolkit.py
+++ b/scripts/build/llext_elf_toolkit.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+ELF utilities shared by LLEXT scripts
+"""
+
+import elftools.elf.elffile
+import elftools.elf.sections
+
+import struct
+
+
+def get_target_specific_structure(struct_desc: str, ptr_size: int, endianness: str):
+    """
+    Obtain target-specific 'struct.Struct' from structure description string.
+    Internally, pointer-sized elements ('P') is replaced with an integer field
+    of the proper size, and the endianness indicator is prepended automatically.
+
+    Parameters:
+        struct_template:
+            Python 'struct' descriptor, with 'P' for pointer-sized fields
+            and without an endianness indicator
+
+        ptr_size: Pointer size of target, in bytes (4/8)
+        endianness: Endianness of target ('little'/'big')
+    """
+    assert ptr_size == 4 or ptr_size == 8
+    assert endianness in ['little', 'big']
+
+    endspec = "<" if endianness == 'little' else ">"
+    if ptr_size == 4:
+        ptrspec = "I"
+    elif ptr_size == 8:
+        ptrspec = "Q"
+
+    return struct.Struct(endspec + struct_desc.replace("P", ptrspec))
+
+
+# ELF Shdr flag applied to the export table section, to indicate
+# the section has already been prepared by this script. This is
+# mostly a security measure to prevent the script from running
+# twice on the same ELF file, which can result in catastrophic
+# failures if SLID-based linking is enabled (in this case, the
+# preparation process is destructive).
+#
+# This flag is part of the SHF_MASKOS mask, of which all bits
+# are "reserved for operating system-specific semantics".
+# See: https://refspecs.linuxbase.org/elf/gabi4+/ch4.sheader.html
+SHF_LLEXT_PREPARATION_DONE = 0x08000000
+
+
+class SectionDescriptor:
+    """ELF Section descriptor
+
+    This is a wrapper class around pyelftools' "Section" object.
+
+    Attributes:
+        name: Section name
+        size: Section size
+        flags: Section flags
+        offset: File offset to section
+        shdr_index: Section header index
+        shdr_offset: File offset to section header
+        section: pyelftools Section object
+    """
+
+    def __init__(self, elffile: elftools.elf.elffile.ELFFile, section_name: str):
+        self.name = section_name
+        self.section = elffile.get_section_by_name(section_name)
+        if not isinstance(self.section, elftools.elf.sections.Section):
+            raise KeyError(f"section {section_name} not found")
+
+        self.shdr_index = elffile.get_section_index(section_name)
+        self.shdr_offset = elffile['e_shoff'] + self.shdr_index * elffile['e_shentsize']
+        self.size = self.section['sh_size']
+        self.flags = self.section['sh_flags']
+        self.offset = self.section['sh_offset']

--- a/scripts/build/llext_inspect_discarded_groups.py
+++ b/scripts/build/llext_inspect_discarded_groups.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Inspects Zephyr build artifacts (ELF, plus Kconfig if available)
+to display information about symbols placed in the discard exports
+table due to their symbol group not being enabled.
+"""
+
+import argparse
+import logging
+import re
+import sys
+from pathlib import Path
+
+import llext_elf_toolkit
+from elftools.elf.elffile import ELFFile
+
+#!!!!! WARNING !!!!!
+#
+# These constants MUST be kept in sync with linker script
+# 'include/zephyr/linker/llext-sections.ld' and various
+# definitions in 'include/subsys/llext/llext.h'.
+#
+#!!!!! WARNING !!!!!
+
+LLEXT_DISCARDED_EXPORTS_TABLE_SECTION_NAME = "llext_discarded_exports_table"
+LLEXT_DISCARDED_EXPORTS_STRTAB_SECTION_NAME = "llext_discarded_exports_strtab"
+STRUCT_Z_LLEXT_DISCARDED_CONST_SYMBOL_DESC = "PP"  # two pointers
+GROUP_EXPORT_KCONFIG_PREFIX = "CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_"
+
+
+REPORT_TOP_LEVEL_NOTICE = """\
+This file lists all symbols that have been marked as LLEXT exports
+but will not be added to the export table because their symbol group
+has not been enabled. Refer to LLEXT Documentation for more details.
+"""
+
+
+class Export:
+    def __init__(self, tpl, read_str):
+        # [0] = name (pseudo pointer)
+        # [1] = group name (pseudo pointer)
+        self.name = read_str(tpl[0])
+        self.group = read_str(tpl[1])
+
+    def __lt__(self, other):  # Sort by symbol name
+        return self.name < other.name
+
+
+def parse_dotconfig(dotconfig_path: Path):
+    """
+    Parses options from `.config` file at location 'dotconfig_path'.
+
+    Note: tri-state `"m"` is transformed into integer `2`.
+    """
+    # Options should receive value 'n' if a line
+    # containing 'CONFIG_xxx is not set' is present
+    UNSET_OPTION_REGEXP = re.compile(r"# (CONFIG_.+) is not set")
+
+    options: dict[str, str | int | bool] = {}
+
+    with dotconfig_path.open("r") as fd:
+        for line in fd:
+            line = line.strip()
+            if len(line) <= 1:
+                continue
+
+            # Handle comment lines
+            if line[0] == '#':
+                if match := UNSET_OPTION_REGEXP.match(line):
+                    options[match.group(1)] = False
+                continue
+
+            key, value = line.split("=")
+
+            if value == "y":
+                value = True
+            elif value == "n":
+                value = False
+            elif value == "m":
+                value = 2
+            elif value[0] == value[-1] == '"':
+                value = value.strip('"')
+            else:
+                value = int(value, base=0)
+
+            options[key] = value
+
+    return options
+
+
+def _init_log(verbose: int):
+    """Initialize a logger object."""
+    log = logging.getLogger(__file__)
+
+    console = logging.StreamHandler()
+    console.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    log.addHandler(console)
+
+    if verbose > 1:
+        log.setLevel(logging.DEBUG)
+    elif verbose > 0:
+        log.setLevel(logging.INFO)
+    else:
+        log.setLevel(logging.WARNING)
+
+    return log
+
+
+def _parse_args(argv):
+    """Parse the command line arguments."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+
+    parser.add_argument("-f", "--elf-file", type=Path, help="ELF file to process")
+    parser.add_argument("--output-report", type=Path, help="Output report file (plaintext)")
+    parser.add_argument(
+        "--dotconfig-file",
+        type=Path,
+        required=False,
+        help=".config file of build - used to check for missing Kconfig options",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        help=("enable verbose output, can be used multiple times to increase verbosity level"),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+
+    log = _init_log(args.verbose or 0)
+
+    log.info(f"{__file__}: {args.elf_file}")
+
+    if args.dotconfig_file:
+        kconfig_options = parse_dotconfig(args.dotconfig_file)
+    else:
+        kconfig_options = None
+
+    with open(args.elf_file, 'rb') as elf_fd:
+        elf = ELFFile(elf_fd)
+        ptr_size = elf.elfclass // 8
+
+        sym_desc = llext_elf_toolkit.get_target_specific_structure(
+            STRUCT_Z_LLEXT_DISCARDED_CONST_SYMBOL_DESC,
+            ptr_size,
+            endianness='little' if elf.little_endian else 'big',
+        )
+
+        # Find discarded exports table and strtab
+        try:
+            exptab_section = llext_elf_toolkit.SectionDescriptor(
+                elf, LLEXT_DISCARDED_EXPORTS_TABLE_SECTION_NAME
+            )
+            strtab_section = llext_elf_toolkit.SectionDescriptor(
+                elf, LLEXT_DISCARDED_EXPORTS_STRTAB_SECTION_NAME
+            )
+
+            # Create helper to read strings from strtab
+            def read_str(ptr):
+                # Implementation detail: in linker script, we force
+                # section base to 0x0; no need to subtract it here.
+                raw_str = b''
+
+                elf_fd.seek(strtab_section.offset + ptr)
+
+                c = elf_fd.read(1)
+                while c != b'\0':
+                    raw_str += c
+                    c = elf_fd.read(1)
+
+                return raw_str.decode("utf-8")
+
+            # Parse discarded exports table
+            if (exptab_section.size % sym_desc.size) != 0:
+                log.error(
+                    "Unexpected discarded exptab section size %u (not multiple of entry size=%u)",
+                    exptab_section.size,
+                    sym_desc.size,
+                )
+                return 1
+
+            # Separate based on group
+            discarded_exports: dict[str, list[Export]] = {}
+
+            num_discarded_exports = exptab_section.size // sym_desc.size
+            for i in range(num_discarded_exports):
+                elf_fd.seek(exptab_section.offset + i * sym_desc.size)
+                raw_entry = elf_fd.read(sym_desc.size)
+
+                export = Export(sym_desc.unpack(raw_entry), read_str)
+
+                group_exports = discarded_exports.get(export.group, [])
+                group_exports.append(export)
+                discarded_exports[export.group] = group_exports
+        except KeyError:
+            log.info("Discarded exports table or strtab section not found")
+            discarded_exports = {}
+
+    # Sort symbol groups by name
+    discarded_exports = dict(sorted(discarded_exports.items()))
+
+    # Inspect all groups and print information to output
+    with open(args.output_report, 'w') as out_fd:
+        out_fd.write(REPORT_TOP_LEVEL_NOTICE + "\n")
+
+        exps = discarded_exports.items()
+        if len(exps) == 0:
+            out_fd.write("<No discarded symbols found in image>")
+
+        for group_name, exports in exps:
+            exports = sorted(exports)
+
+            # Write group header
+            out_fd.write("=" * 100 + "\n" + f"{'Group ' + group_name:^100}\n")
+
+            if group_name.upper() != group_name:
+                log.warning("Name of LLEXT symbol group '%s' is not uppercase", group_name)
+                out_fd.write("Group name should be uppercase!\n")
+            elif kconfig_options:
+                # Verify that Kconfig option for group exists if we have
+                # .config, but only if the group's name is in uppercase
+                kcfg_sym = GROUP_EXPORT_KCONFIG_PREFIX + group_name
+                if kconfig_options.get(kcfg_sym) is None:
+                    log.warning("Could not find Kconfig option %s", kcfg_sym)
+                    out_fd.write(
+                        f'{"Could not find Kconfig option " + kcfg_sym + ":":^100}\n'
+                        f'{"symbol group will never be included in the LLEXT export table!":^100}\n'
+                    )
+
+            out_fd.write("=" * 100 + "\n")
+
+            # Write symbols listing
+            out_fd.write("Symbol Name\n")
+            out_fd.write("-" * 80 + "\n")
+            for e in exports:
+                out_fd.write(e.name + "\n")
+
+            out_fd.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1554,6 +1554,8 @@ flagged.
         # with older versions of the ICMsg.
         "IPC_SERVICE_ICMSG_BOND_NOTIFY_REPEAT_TO_MS",
         "LIBGCC_RTLIB",
+        "LLEXT_EXPORT_SYMBOL_GROUP_",  # Used in regexp by
+        # scripts/build/llext_inspect_discarded_groups.py
         "LLVM_USE_LD",  # Both LLVM_USE_* are in cmake/toolchain/llvm/Kconfig
         # which are only included if LLVM is selected but
         # not other toolchains. Compliance check would complain,


### PR DESCRIPTION
Follow-up to #98990 (c.f. https://github.com/zephyrproject-rtos/zephyr/pull/98990#discussion_r2499663423)


When the LLEXT subsystem detects that a symbol is marked for export from the main image, but the symbol group in which the export belongs is not enabled, add a marker in a special section in addition to not placing the symbol in the final export table.

Add a post-build script which consumes the special section as post-build to dump information about all discarded symbols in a build artifact, and also check for common errors (missing Kconfig symbol / improperly named groups).

While at it, rework LLEXT scripts organization a little bit - maybe a dedicated `scripts/llext` directory is starting to make sense though... I also wanted to create a `${PROJECT_BINARY_DIR}/llext` directory for all artifacts, but I'm not super confident about how to ensure CMake will create said directory, so the report is in artifacts root for now (like SLID listings).

There's also a bit more clean-up I found along the way (namely: a single `llext_discarded_strtab` could replace the two sections `llext_discarded_exports_strtab`+`llext_exports_strtab`, and `read_str` could possibly be shared between scripts), but that can always come later.


Example output on `west build samples/subsys/llext/modules`:
<details>

```
This file lists all symbols that have been marked as LLEXT exports
but will not be added to the export table because their symbol group
has not been enabled. Refer to LLEXT Documentation for more details.

====================================================================================================
                                            Group DEVICE                                            
====================================================================================================
Symbol Name                                                  | Address
--------------------------------------------------------------------------------
__device_dts_ord_36                                          | 0800744c
__device_dts_ord_39                                          | 0800748c
__device_dts_ord_47                                          | 0800736c
__device_dts_ord_57                                          | 0800738c
__device_dts_ord_61                                          | 080074ac
__device_dts_ord_64                                          | 080074cc
__device_dts_ord_72                                          | 0800746c
__device_dts_ord_9                                           | 0800734c
__device_dts_ord_90                                          | 0800742c
__device_dts_ord_91                                          | 0800740c
__device_dts_ord_92                                          | 080073ec
__device_dts_ord_93                                          | 080073cc
__device_dts_ord_94                                          | 080073ac
```

</details>

Example build log + output when a group Kconfig is missing:
<details>

```
...
Memory region         Used Size  Region Size  %age Used
           FLASH:       39728 B       512 KB      7.58%
             RAM:        7752 B        96 KB      7.89%
           SRAM0:          0 GB        96 KB      0.00%
        IDT_LIST:          0 GB        32 KB      0.00%
Generating files from /local/zprj/builds/default/zephyr/zephyr.elf for board: nucleo_f401re
WARNING: Could not find Kconfig symbol CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_NONEXISTENT
```
```
====================================================================================================
                                         Group NONEXISTENT                                          
Could not find Kconfig symbol CONFIG_LLEXT_EXPORT_SYMBOL_GROUP_NONEXISTENT:
symbol group will never be included in the LLEXT export table!
====================================================================================================
Symbol Name                                                  | Address
--------------------------------------------------------------------------------
example_fn                                                   | 080054e3
```

</details>

