### PR TITLE
west: blobs: list/clean `--allow-regex` filter

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1816,10 +1816,11 @@ endfunction()
 # fatal error message is printed (depends on REQUIRED flag).
 #
 # Usage:
-#   zephyr_blobs_verify(<MODULE module|FILES file [files...]> [REQUIRED] [REGEX])
+#   zephyr_blobs_verify(<MODULE module|FILES file [files...]> [REQUIRED] [REGEX regex_pattern])
 #
 # Example:
 # zephyr_blobs_verify(MODULE my_module REQUIRED) # verify all blobs in my_module and fail on error
+# zephyr_blobs_verify(MODULE my_module REGEX ".*esp32c6.*" REQUIRED) # verify only esp32c6 blobs
 # zephyr_blobs_verify(FILES img/file.bin)        # verify a single file and print on error
 function(zephyr_blobs_verify)
   cmake_parse_arguments(BLOBS_VERIFY "REQUIRED" "MODULE;REGEX" "FILES" ${ARGN})

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1816,13 +1816,13 @@ endfunction()
 # fatal error message is printed (depends on REQUIRED flag).
 #
 # Usage:
-#   zephyr_blobs_verify(<MODULE module|FILES file [files...]> [REQUIRED])
+#   zephyr_blobs_verify(<MODULE module|FILES file [files...]> [REQUIRED] [REGEX])
 #
 # Example:
 # zephyr_blobs_verify(MODULE my_module REQUIRED) # verify all blobs in my_module and fail on error
 # zephyr_blobs_verify(FILES img/file.bin)        # verify a single file and print on error
 function(zephyr_blobs_verify)
-  cmake_parse_arguments(BLOBS_VERIFY "REQUIRED" "MODULE" "FILES" ${ARGN})
+  cmake_parse_arguments(BLOBS_VERIFY "REQUIRED" "MODULE;REGEX" "FILES" ${ARGN})
 
   if((DEFINED BLOBS_VERIFY_MODULE) EQUAL (DEFINED BLOBS_VERIFY_FILES))
     message(FATAL_ERROR "Either MODULE or FILES required when calling ${CMAKE_CURRENT_FUNCTION}")
@@ -1832,8 +1832,21 @@ function(zephyr_blobs_verify)
     return()
   endif()
 
+  # Build the west command arguments
+  set(west_args blobs list)
+  if(DEFINED BLOBS_VERIFY_MODULE)
+    list(APPEND west_args ${BLOBS_VERIFY_MODULE})
+  endif()
+
+  # if REGEX is specified, add --allow-regex to the west command
+  if(BLOBS_VERIFY_REGEX)
+    list(APPEND west_args --allow-regex ${BLOBS_VERIFY_REGEX})
+  endif()
+
+  list(APPEND west_args --format "{status} {abspath}")
+
   execute_process(
-    COMMAND ${WEST} blobs list ${BLOBS_VERIFY_MODULE} --format "{status} {abspath}"
+    COMMAND ${WEST} ${west_args}
     OUTPUT_VARIABLE BLOBS_LIST_OUTPUT
     OUTPUT_STRIP_TRAILING_WHITESPACE
     COMMAND_ERROR_IS_FATAL ANY

--- a/drivers/wifi/CMakeLists.txt
+++ b/drivers/wifi/CMakeLists.txt
@@ -13,7 +13,8 @@ if(CONFIG_BUILD_ONLY_NO_BLOBS)
 else()
 
 if(CONFIG_DT_HAS_ESPRESSIF_ESP32_WIFI_ENABLED)
-  zephyr_blobs_verify(MODULE hal_espressif REQUIRED)
+message(WARNING "Verifying presence of Espressif ESP32 Wi-Fi binary blobs.")
+  zephyr_blobs_verify(MODULE hal_espressif REGEX ".*${CONFIG_SOC}.*" REQUIRED)
 endif()
 
 endif() # CONFIG_BUILD_ONLY_NO_BLOBS


### PR DESCRIPTION
Enable filtering the blobs selected by `west blobs list` and `west blobs clean` with a regex pattern, just like `west blobs fetch`.

Support this when checking for blob existence in `drivers/wifi` for esp32, so now it's possible to build for a selected esp32 family SOC (for example `esp32c6`) with only the blobs for that chip downloaded:

```bash
west blobs clean hal_espressif  # delete all hal_espressif blobs
west blobs fetch hal_espressif --allow-regex '.*esp32c6.*'
west build -b esp32c6_devkitc/esp32c6/hpcore zephyr/samples/net/wifi/shell
```