### PR TITLE
arch: riscv: stacktrace: support stacktrace in early system init

### DIFF
--- a/arch/riscv/core/stacktrace.c
+++ b/arch/riscv/core/stacktrace.c
@@ -41,8 +41,17 @@ static inline bool in_kernel_thread_stack_bound(uintptr_t addr, const struct k_t
 #ifdef CONFIG_THREAD_STACK_INFO
 	uintptr_t start, end;
 
-	start = thread->stack_info.start;
-	end = Z_STACK_PTR_ALIGN(thread->stack_info.start + thread->stack_info.size);
+	/*
+	 * Special handling to support stacktrace in dummy thread during system initialization,
+	 * as its stack info isn't initialized.
+	 */
+	if (is_thread_dummy(thread)) {
+		start = (uintptr_t)z_interrupt_stacks;
+		end = Z_STACK_PTR_ALIGN(start + __z_interrupt_stack_SIZEOF);
+	} else {
+		start = thread->stack_info.start;
+		end = Z_STACK_PTR_ALIGN(thread->stack_info.start + thread->stack_info.size);
+	}
 
 	return (addr >= start) && (addr < end);
 #else

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -62,14 +62,14 @@ static inline void thread_schedule_new(struct k_thread *thread, k_timeout_t dela
 #endif /* CONFIG_SYS_CLOCK_EXISTS */
 }
 
-static inline int thread_is_preemptible(struct k_thread *thread)
+static inline int thread_is_preemptible(const struct k_thread *thread)
 {
 	/* explanation in kernel_struct.h */
 	return thread->base.preempt <= _PREEMPT_THRESHOLD;
 }
 
 
-static inline int thread_is_metairq(struct k_thread *thread)
+static inline int thread_is_metairq(const struct k_thread *thread)
 {
 #if CONFIG_NUM_METAIRQ_PRIORITIES > 0
 	return (thread->base.prio - K_HIGHEST_THREAD_PRIO)
@@ -81,43 +81,43 @@ static inline int thread_is_metairq(struct k_thread *thread)
 }
 
 #ifdef CONFIG_ASSERT
-static inline bool is_thread_dummy(struct k_thread *thread)
+static inline bool is_thread_dummy(const struct k_thread *thread)
 {
 	return (thread->base.thread_state & _THREAD_DUMMY) != 0U;
 }
 #endif /* CONFIG_ASSERT */
 
 
-static inline bool z_is_thread_suspended(struct k_thread *thread)
+static inline bool z_is_thread_suspended(const struct k_thread *thread)
 {
 	return (thread->base.thread_state & _THREAD_SUSPENDED) != 0U;
 }
 
-static inline bool z_is_thread_pending(struct k_thread *thread)
+static inline bool z_is_thread_pending(const struct k_thread *thread)
 {
 	return (thread->base.thread_state & _THREAD_PENDING) != 0U;
 }
 
-static inline bool z_is_thread_dead(struct k_thread *thread)
+static inline bool z_is_thread_dead(const struct k_thread *thread)
 {
 	return (thread->base.thread_state & _THREAD_DEAD) != 0U;
 }
 
 /* Return true if the thread is aborting, else false */
-static inline bool z_is_thread_aborting(struct k_thread *thread)
+static inline bool z_is_thread_aborting(const struct k_thread *thread)
 {
 	return (thread->base.thread_state & _THREAD_ABORTING) != 0U;
 }
 
 /* Return true if the thread is aborting or suspending, else false */
-static inline bool z_is_thread_halting(struct k_thread *thread)
+static inline bool z_is_thread_halting(const struct k_thread *thread)
 {
 	return (thread->base.thread_state &
 		(_THREAD_ABORTING | _THREAD_SUSPENDING)) != 0U;
 }
 
 
-static inline bool z_is_thread_prevented_from_running(struct k_thread *thread)
+static inline bool z_is_thread_prevented_from_running(const struct k_thread *thread)
 {
 	uint8_t state = thread->base.thread_state;
 
@@ -125,22 +125,22 @@ static inline bool z_is_thread_prevented_from_running(struct k_thread *thread)
 			 _THREAD_DUMMY | _THREAD_SUSPENDED)) != 0U;
 }
 
-static inline bool z_is_thread_timeout_active(struct k_thread *thread)
+static inline bool z_is_thread_timeout_active(const struct k_thread *thread)
 {
 	return !z_is_inactive_timeout(&thread->base.timeout);
 }
 
-static inline bool z_is_thread_ready(struct k_thread *thread)
+static inline bool z_is_thread_ready(const struct k_thread *thread)
 {
 	return !z_is_thread_prevented_from_running(thread);
 }
 
-static inline bool z_is_thread_state_set(struct k_thread *thread, uint32_t state)
+static inline bool z_is_thread_state_set(const struct k_thread *thread, uint32_t state)
 {
 	return (thread->base.thread_state & state) != 0U;
 }
 
-static inline bool z_is_thread_queued(struct k_thread *thread)
+static inline bool z_is_thread_queued(const struct k_thread *thread)
 {
 	return z_is_thread_state_set(thread, _THREAD_QUEUED);
 }
@@ -218,13 +218,13 @@ static inline void z_thread_essential_clear(struct k_thread *thread)
  *
  * Returns true if current thread is essential, false if it is not.
  */
-static inline bool z_is_thread_essential(struct k_thread *thread)
+static inline bool z_is_thread_essential(const struct k_thread *thread)
 {
 	return (thread->base.user_options & K_ESSENTIAL) == K_ESSENTIAL;
 }
 
 
-static ALWAYS_INLINE bool should_preempt(struct k_thread *thread,
+static ALWAYS_INLINE bool should_preempt(const struct k_thread *thread,
 					 int preempt_ok)
 {
 	/* Preemption is OK if it's being explicitly allowed by
@@ -267,7 +267,7 @@ static inline bool z_is_idle_thread_entry(k_thread_entry_t entry_point)
 	return entry_point == idle;
 }
 
-static inline bool z_is_idle_thread_object(struct k_thread *thread)
+static inline bool z_is_idle_thread_object(const struct k_thread *thread)
 {
 #ifdef CONFIG_MULTITHREADING
 #ifdef CONFIG_SMP

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -80,13 +80,10 @@ static inline int thread_is_metairq(const struct k_thread *thread)
 #endif /* CONFIG_NUM_METAIRQ_PRIORITIES */
 }
 
-#ifdef CONFIG_ASSERT
 static inline bool is_thread_dummy(const struct k_thread *thread)
 {
 	return (thread->base.thread_state & _THREAD_DUMMY) != 0U;
 }
-#endif /* CONFIG_ASSERT */
-
 
 static inline bool z_is_thread_suspended(const struct k_thread *thread)
 {


### PR DESCRIPTION
Add support for stacktrace in dummy thread which is used to run
the early system initialization code before the kernel switches
to the main thread.

On RISC-V, the dummy thread will be running temporarily on the
interrupt stack, but currently we do not initialize the stack
info for the dummy thread, hence check the address against the
interrupt stack.

___

before:
```
ASSERTION FAIL [!k_is_pre_kernel()] @ ZEPHYR_BASE/include/zephyr/kernel.h:736
       k_current_get called pre-kernel
[0101_000000.000] <err> os: 
[0101_000000.000] <err> os:  mcause: 11, Environment call from M-mode
[0101_000000.000] <err> os:   mtval: 0
[0101_000000.000] <err> os:      a0: 0000000000000000    t0: 0000000000000000
[0101_000000.000] <err> os:      a1: 0000000000000000    t1: 0000000000000000
[0101_000000.000] <err> os:      a2: 0000000000000000    t2: 0000000000000000
[0101_000000.000] <err> os:      a3: 0000000000000000    t3: 0000000000000000
[0101_000000.000] <err> os:      a4: 0000000000000000    t4: 0000000000000000
[0101_000000.000] <err> os:      a5: 0000000000000000    t5: 0000000000000000
[0101_000000.000] <err> os:      a6: 0000000000000000    t6: 0000000000000000
[0101_000000.000] <err> os:      a7: 0000000000000000
[0101_000000.000] <err> os:      sp: 0000000000000000
[0101_000000.000] <err> os:      ra: 0000000000000000
[0101_000000.000] <err> os:    mepc: 0000000000000000
[0101_000000.000] <err> os: mstatus: 0000000000000000
[0101_000000.000] <err> os: 
[0101_000000.000] <err> os:      s0: 0000000000000000    s6: 0000000000000000
[0101_000000.000] <err> os:      s1: 0000000000000000    s7: 0000000000000000
[0101_000000.000] <err> os:      s2: 0000000000000000    s8: 0000000000000000
[0101_000000.000] <err> os:      s3: 0000000000000000    s9: 0000000000000000
[0101_000000.000] <err> os:      s4: 0000000000000000   s10: 0000000000000000
[0101_000000.000] <err> os:      s5: 0000000000000000   s11: 0000000000000000
[0101_000000.000] <err> os: 
[0101_000000.000] <err> os: call trace:
[0101_000000.000] <err> os: 
[0101_000000.000] <err> os: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
[0101_000000.000] <err> os: Current thread: 0x00000000 (unknown)
[0101_000000.000] <err> os:  mcause: 11, Environment call from M-mode
[0101_000000.000] <err> os: mdcause: 0, unknown
[0101_000000.000] <err> os:   mtval: 0
[0101_000000.000] <err> os: 
[0101_000000.000] <err> os: Halting system
```

after:
```
ASSERTION FAIL [!k_is_pre_kernel()] @ ZEPHYR_BASE/include/zephyr/kernel.h:736
       k_current_get called pre-kernel
[0101_000000.000] <err> os: 
[0101_000000.000] <err> os:  mcause: 11, Environment call from M-mode
[0101_000000.000] <err> os:   mtval: 0
[0101_000000.000] <err> os:      a0: 0000000000000000    t0: 0000000000000000
[0101_000000.000] <err> os:      a1: 0000000000000000    t1: 0000000000000000
[0101_000000.000] <err> os:      a2: 0000000000000000    t2: 0000000000000000
[0101_000000.000] <err> os:      a3: 0000000000000000    t3: 0000000000000000
[0101_000000.000] <err> os:      a4: 0000000000000000    t4: 0000000000000000
[0101_000000.000] <err> os:      a5: 0000000000000000    t5: 0000000000000000
[0101_000000.000] <err> os:      a6: 0000000000000000    t6: 0000000000000000
[0101_000000.000] <err> os:      a7: 0000000000000000
[0101_000000.000] <err> os:      sp: 0000000000000000
[0101_000000.000] <err> os:      ra: 0000000000000000
[0101_000000.000] <err> os:    mepc: 0000000000000000
[0101_000000.000] <err> os: mstatus: 0000000000000000
[0101_000000.000] <err> os: 
[0101_000000.000] <err> os:      s0: 0000000000000000    s6: 0000000000000000
[0101_000000.000] <err> os:      s1: 0000000000000000    s7: 0000000000000000
[0101_000000.000] <err> os:      s2: 0000000000000000    s8: 0000000000000000
[0101_000000.000] <err> os:      s3: 0000000000000000    s9: 0000000000000000
[0101_000000.000] <err> os:      s4: 0000000000000000   s10: 0000000000000000
[0101_000000.000] <err> os:      s5: 0000000000000000   s11: 0000000000000000
[0101_000000.000] <err> os: 
[0101_000000.000] <err> os: call trace:
[0101_000000.000] <err> os:       0: fp: 0000000000000000 ra: 0000000000000000 [assert_post_action+0x10]
[0101_000000.000] <err> os:       1: fp: 0000000000000000 ra: 0000000000000000 [k_current_get+0x4e]
[0101_000000.000] <err> os:       2: fp: 0000000000000000 ra: 0000000000000000 [k_current_get+0x4e]
[0101_000000.000] <err> os:       3: fp: 0000000000000000 ra: 0000000000000000 [sys_trace_thread_switched_out_user+0xc]
[0101_000000.000] <err> os:       4: fp: 0000000000000000 ra: 0000000000000000 [z_cstart+0x1e0]
[0101_000000.000] <err> os: 
[0101_000000.000] <err> os: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
[0101_000000.000] <err> os: Current thread: 0x00000000 (unknown)
[0101_000000.000] <err> os:  mcause: 11, Environment call from M-mode
[0101_000000.000] <err> os: mdcause: 0, unknown
[0101_000000.000] <err> os:   mtval: 0
[0101_000000.000] <err> os: 
[0101_000000.000] <err> os: Halting system
```