### PR TITLE
drivers: flash: shell: Use timing functions for speed tests

### DIFF
--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -108,6 +108,7 @@ if FLASH_SHELL
 config FLASH_SHELL_TEST_COMMANDS
 	bool "Flash read/write/erase test commands"
 	select CBPRINTF_FP_SUPPORT
+	select TIMING_FUNCTIONS
 	help
 	  Enable additional flash shell commands for performing
 	  read/write/erase tests with speed output.


### PR DESCRIPTION
Use the timing functions to increase the accuracy of the flash speed measurements.