### PR TITLE
dts: ra6: fix typo in pinctrl node name

### DIFF
--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -118,7 +118,7 @@
 			status = "disabled";
 		};
 
-		pinctrl: pin-contrller@40080800 {
+		pinctrl: pin-controller@40080800 {
 			compatible = "renesas,ra-pinctrl-pfs";
 			reg = <0x40080800 0x3c0>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
@@ -136,7 +136,7 @@
 			status = "disabled";
 		};
 
-		pinctrl: pin-contrller@40040800 {
+		pinctrl: pin-controller@40040800 {
 			compatible = "renesas,ra-pinctrl-pfs";
 			reg = <0x40040800 0x3c0>;
 			status = "okay";


### PR DESCRIPTION
Correct a typo in the pinctrl node name to maintain consistent naming across the RA family.