### PR TITLE
dts: renesas: fix syntax error in multiple DTS/DTSI files

### DIFF
--- a/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57.dts
+++ b/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57.dts
@@ -65,18 +65,18 @@
 		     &sd0_data0_uhs &sd0_data1_uhs &sd0_data2_uhs &sd0_data3_uhs>;
 	pinctrl-names = "default", "uhs";
 
-	disk {
-		compatible = "zephyr,sdmmc-disk";
-		disk-name = "SD";
-		status = "okay";
-	};
-
 	vmmc-supply = <&vcc_sd0>;
 	vqmmc-supply = <&vccq_sd0>;
 
 	bus-width = <4>;
 	mmc-sdr104-support;
 	status = "okay";
+
+	disk {
+		compatible = "zephyr,sdmmc-disk";
+		disk-name = "SD";
+		status = "okay";
+	};
 };
 
 &scif2 {

--- a/boards/renesas/rcar_salvator_xs/rcar_salvator_xs.dts
+++ b/boards/renesas/rcar_salvator_xs/rcar_salvator_xs.dts
@@ -45,13 +45,14 @@
 		     &emmc2_data4 &emmc2_data5 &emmc2_data6 &emmc2_data7>;
 	pinctrl-names = "default", "uhs";
 
+	bus-width = <8>;
+	mmc-hs200-1_8v;
+	mmc-hs400-1_8v;
+	non-removable;
+
 	disk {
 		compatible = "zephyr,mmc-disk";
 		disk-name = "SD2";
 		status = "disabled";
 	};
-	bus-width = <8>;
-	mmc-hs200-1_8v;
-	mmc-hs400-1_8v;
-	non-removable;
 };

--- a/boards/renesas/rcar_spider_s4/rcar_spider_s4_r8a779f0_a55.dts
+++ b/boards/renesas/rcar_spider_s4/rcar_spider_s4_r8a779f0_a55.dts
@@ -41,14 +41,15 @@
 		     &mmc_data4 &mmc_data5 &mmc_data6 &mmc_data7>;
 	pinctrl-names = "default", "uhs";
 
-	disk {
-		compatible = "zephyr,mmc-disk";
-		disk-name = "SD2";
-		status = "okay";
-	};
 	bus-width = <8>;
 	mmc-hs200-1_8v;
 	mmc-hs400-1_8v;
 	non-removable;
 	status = "okay";
+
+	disk {
+		compatible = "zephyr,mmc-disk";
+		disk-name = "SD2";
+		status = "okay";
+	};
 };

--- a/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
@@ -177,6 +177,8 @@
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
 				div = <2>;
+				#clock-cells = <2>;
+				status = "okay";
 
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
@@ -184,8 +186,6 @@
 					sdclk = <0>;
 					#clock-cells = <0>;
 				};
-				#clock-cells = <2>;
-				status = "okay";
 			};
 
 			uclk: uclk {

--- a/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
@@ -232,6 +232,8 @@
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
 				div = <2>;
+				#clock-cells = <2>;
+				status = "okay";
 
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
@@ -239,8 +241,6 @@
 					sdclk = <1>;
 					#clock-cells = <0>;
 				};
-				#clock-cells = <2>;
-				status = "okay";
 			};
 
 			uclk: uclk {

--- a/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
@@ -288,6 +288,8 @@
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
 				div = <2>;
+				#clock-cells = <2>;
+				status = "okay";
 
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
@@ -295,8 +297,6 @@
 					sdclk = <1>;
 					#clock-cells = <0>;
 				};
-				#clock-cells = <2>;
-				status = "okay";
 			};
 
 			uclk: uclk {

--- a/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
@@ -473,6 +473,8 @@
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
 				div = <2>;
+				#clock-cells = <2>;
+				status = "okay";
 
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
@@ -480,8 +482,6 @@
 					sdclk = <0>;
 					#clock-cells = <0>;
 				};
-				#clock-cells = <2>;
-				status = "okay";
 			};
 
 			fclk: fclk {

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -526,6 +526,8 @@
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
 				div = <2>;
+				#clock-cells = <2>;
+				status = "okay";
 
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
@@ -533,8 +535,6 @@
 					sdclk = <0>;
 					#clock-cells = <0>;
 				};
-				#clock-cells = <2>;
-				status = "okay";
 			};
 
 			fclk: fclk {

--- a/dts/arm/renesas/ra/ra8/r7fa8d1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8d1xh.dtsi
@@ -199,6 +199,8 @@
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
 				div = <4>;
+				#clock-cells = <2>;
+				status = "okay";
 
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
@@ -206,8 +208,6 @@
 					sdclk = <1>;
 					#clock-cells = <0>;
 				};
-				#clock-cells = <2>;
-				status = "okay";
 			};
 
 			fclk: fclk {

--- a/dts/arm/renesas/ra/ra8/r7fa8m1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8m1xh.dtsi
@@ -177,6 +177,8 @@
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
 				div = <4>;
+				#clock-cells = <2>;
+				status = "okay";
 
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
@@ -184,8 +186,6 @@
 					sdclk = <1>;
 					#clock-cells = <0>;
 				};
-				#clock-cells = <2>;
-				status = "okay";
 			};
 
 			fclk: fclk {

--- a/dts/arm/renesas/ra/ra8/r7fa8t1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8t1xh.dtsi
@@ -178,6 +178,8 @@
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
 				div = <4>;
+				#clock-cells = <2>;
+				status = "okay";
 
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
@@ -185,8 +187,6 @@
 					sdclk = <1>;
 					#clock-cells = <0>;
 				};
-				#clock-cells = <2>;
-				status = "okay";
 			};
 
 			fclk: fclk {


### PR DESCRIPTION
Properties in `bclk` nodes were defined after the bclkout subnode, `disk` subnode was defined before properties in a few boards DTS files which violates the Devicetree Specification v0.4, section 6.3:

"Nodes may contain property definitions and/or child node definitions. If both are present, properties shall come before child nodes."

This caused the Device Tree Compiler error: "Properties must precede subnodes. Unable to parse input tree"

This commit is simmilar to https://github.com/zephyrproject-rtos/zephyr/pull/97295 and moves nested nodes after properties, fixing those syntax errors and ensuring compliance with the Devicetree Specification.
