### PR TITLE
logging: add all format options to Kconfig and std_get_flags()

### DIFF
--- a/include/zephyr/logging/log_backend_std.h
+++ b/include/zephyr/logging/log_backend_std.h
@@ -46,8 +46,20 @@ static inline uint32_t log_backend_std_get_flags(void)
 		flags |= LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 	}
 
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_CRLF_NONE)) {
+		flags |= LOG_OUTPUT_FLAG_CRLF_NONE;
+	}
+
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_CRLF_LFONLY)) {
+		flags |= LOG_OUTPUT_FLAG_CRLF_LFONLY;
+	}
+
 	if (IS_ENABLED(CONFIG_LOG_THREAD_ID_PREFIX)) {
 		flags |= LOG_OUTPUT_FLAG_THREAD;
+	}
+
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_SKIP_SOURCE)) {
+		flags |= LOG_OUTPUT_FLAG_SKIP_SOURCE;
 	}
 
 	return flags;

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -226,4 +226,19 @@ config LOG_OUTPUT_FORMAT_CUSTOM_TIMESTAMP
 
 endchoice
 
+config LOG_BACKEND_CRLF_NONE
+	bool "Prevent adding CR and LF in logger"
+	help
+	  When enabled, selected backend prints do not add CR and LF to log
+
+config LOG_BACKEND_CRLF_LFONLY
+	bool "Force a single LF for line breaks in logger"
+	help
+	  When enabled, selected backend prints use single LF for line breaks in log
+
+config LOG_BACKEND_SKIP_SOURCE
+	bool "Skip logging the source"
+	help
+	  When enabled, selected backend prints do not add the source to log
+
 endmenu


### PR DESCRIPTION
Some but not all LOG_OUTPUT_ format flags were Kconfigurable for log backends using log_backend_std_get_flags()

Adding the missing configurable flags to Kconfig and referencing them in log_backend_std_get_flags() for full control of output:
- CRLF_NONE
- CRLF_LFONLY
- SKIP_SOURCE

FORMAT_SYSLOG was omitted b/c it is specific to NET log backend.