### PR TITLE
subsys: debug: xtensa: enable thread awarenes

### DIFF
--- a/subsys/debug/thread_info.c
+++ b/subsys/debug/thread_info.c
@@ -88,10 +88,14 @@ const size_t _kernel_thread_info_offsets[] = {
 #elif defined(CONFIG_XTENSA)
 	/* Xtensa does not store stack pointers inside thread objects.
 	 * The registers are saved in thread stack where there is
-	 * no fixed location for this to work. So mark this as
-	 * unimplemented to avoid the #warning below.
+	 * no fixed location for this to work. It needs arch_switch in
+	 * order to work on Xtensa.
 	 */
+#ifdef CONFIG_USE_SWITCH
+	[THREAD_INFO_OFFSET_T_STACK_PTR] = offsetof(struct k_thread, switch_handle),
+#else
 	[THREAD_INFO_OFFSET_T_STACK_PTR] = THREAD_INFO_UNIMPLEMENTED,
+#endif
 #elif defined(CONFIG_RX)
 	/* RX doesn't store *anything* inside thread objects yet */
 	[THREAD_INFO_OFFSET_T_STACK_PTR] = THREAD_INFO_UNIMPLEMENTED,


### PR DESCRIPTION
Enable stack offset switching for Xtensa targets if arch_switch is used.
This change is coupled with OpenOCD update, which could be obtained here https://github.com/erhankur/openocd-esp32/actions/runs/19377013518