### PR TITLE
boards: sifli: sf32lb52_devkit_lcd: enable ft6146 touch controller

### DIFF
--- a/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.dts
+++ b/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.dts
@@ -148,4 +148,11 @@
 	pinctrl-0 = <&i2c1_default>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_FAST>;
+
+	ft6146: ft6146@38 {
+		compatible = "focaltech,ft6146";
+		reg = <0x38>;
+		int-gpios = <&gpioa_00_31 31 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&gpioa_00_31 9 GPIO_ACTIVE_LOW>;
+	};
 };


### PR DESCRIPTION
Enable ft6146 touch controller on sf32lb52_devkit_lcd board