### PR TITLE
native_sim: enable cross compilation of native simulator

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -39,9 +39,18 @@ set_property(TARGET native_simulator PROPERTY LOCALIZE_EXTRA_OPTIONS "")
 
 set(NSI_DIR ${ZEPHYR_BASE}/scripts/native_simulator CACHE PATH "Path to the native simulator")
 
-if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/${CMAKE_HOST_SYSTEM_NAME}.${CMAKE_HOST_SYSTEM_PROCESSOR}.cmake)
+# Use ZEPHYR_POSIX_ARCH if specified (for cross-compilation), otherwise use detected host arch
+if(ZEPHYR_POSIX_ARCH)
+  set(POSIX_ARCH ${ZEPHYR_POSIX_ARCH})
+  message(STATUS "POSIX architecture overridden: ${POSIX_ARCH}")
+else()
+  set(POSIX_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
+  message(STATUS "POSIX architecture detected: ${POSIX_ARCH}")
+endif()
+
+if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/${CMAKE_HOST_SYSTEM_NAME}.${POSIX_ARCH}.cmake)
   # @Intent: Set necessary compiler & linker options for this specific host architecture & OS
-  include(${CMAKE_HOST_SYSTEM_NAME}.${CMAKE_HOST_SYSTEM_PROCESSOR}.cmake)
+  include(${CMAKE_HOST_SYSTEM_NAME}.${POSIX_ARCH}.cmake)
 else() # Linux.x86_64
   if(CONFIG_64BIT)
     # some gcc versions fail to build without -fPIC

--- a/boards/native/native_sim/doc/index.rst
+++ b/boards/native/native_sim/doc/index.rst
@@ -59,6 +59,32 @@ To build, simply specify the ``native_sim`` board as target:
    :goals: build
    :compact:
 
+Cross Compiling
+===============
+
+To cross-compile for the ``native_sim`` board (for example, targeting aarch64), use the following command:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: native_sim/native/64
+   :goals: build
+   :cmake-args: -DZEPHYR_TOOLCHAIN_VARIANT=cross-compile -DZEPHYR_POSIX_ARCH=aarch64 -DCROSS_COMPILE=<path-to-cross-compiler>/aarch64-none-linux-gnu- -DSYSROOT_DIR=<path-to-sysroot>
+   :compact:
+
+**Notes:**
+- Replace ``<path-to-cross-compiler>`` and ``<path-to-sysroot>`` with the actual locations on your system.
+- Ensure your cross-compiler toolchain is installed and accessible.
+
+Example:
+.. code-block:: console
+
+   west build -b native_sim/native/64 samples/hello_world -- \
+     -DZEPHYR_TOOLCHAIN_VARIANT=cross-compile \
+     -DZEPHYR_POSIX_ARCH=aarch64 \
+     -DCROSS_COMPILE=<path-to-cross-compiler>/aarch64-none-linux-gnu- \
+     -DSYSROOT_DIR=<path-to-sysroot>
+
 Running
 =======
 

--- a/cmake/modules/FindHostTools.cmake
+++ b/cmake/modules/FindHostTools.cmake
@@ -70,11 +70,13 @@ if("${PTY_INTERFACE}" STREQUAL "PTY_INTERFACE-NOTFOUND")
   set(PTY_INTERFACE "")
 endif()
 
-# Default to the host system's toolchain if we are targeting a host based target
-if((${BOARD_DIR} MATCHES "boards\/native") OR ("${ARCH}" STREQUAL "posix")
-   OR ("${BOARD}" STREQUAL "unit_testing"))
-  if(NOT "${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "llvm")
-    set(ZEPHYR_TOOLCHAIN_VARIANT "host")
+# Default to the host system's toolchain if we are targeting a host based targets and is not defined
+if(NOT ZEPHYR_PROJECT_TOOLCHAIN)
+  if((${BOARD_DIR} MATCHES "boards\/native") OR ("${ARCH}" STREQUAL "posix")
+    OR ("${BOARD}" STREQUAL "unit_testing"))
+    if(NOT "${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "llvm")
+      set(ZEPHYR_TOOLCHAIN_VARIANT "host")
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
need to set following flags for cross compilation:
* DZEPHYR_TOOLCHAIN_VARIANT
* DZEPHYR_POSIX_ARCH
* DCROSS_COMPILE
* DSYSROOT_DIR

Example (with x86 platform as host):

Compiling using cross compiler:
```
west build -b native_sim/native/64 samples/hello_world -- \
    -DZEPHYR_TOOLCHAIN_VARIANT=cross-compile \
    -DZEPHYR_POSIX_ARCH=aarch64 \
    -DCROSS_COMPILE=~/aarch64-buildroot-linux-gnu_sdk-buildroot/bin/aarch64-none-linux-gnu- \
    -DSYSROOT_DIR=~/aarch64-buildroot-linux-gnu_sdk-buildroot/aarch64-buildroot-linux-gnu/sysroot 
```

Output:
```
(venv-zephyr) zephyr$ file build/zephyr/zephyr.exe 
build/zephyr/zephyr.exe: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, with debug_info, not stripped
```


Compiling using host compiler:
`west build -b native_sim/native/64 samples/hello_world`

```
(venv-zephyr) zephyr$ file build/zephyr/zephyr.exe 
build/zephyr/zephyr.exe: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=2cf336e1f239f90be1de8f298c2fabc095660b22, for GNU/Linux 3.2.0, with debug_info, not stripped
```




fixes: https://github.com/zephyrproject-rtos/zephyr/issues/99434

Signed-off-by: nakulchauhan111@gmail.com