### PR TITLE
posix: c_lib_ext: fnmatch: fix escape-oriented regression

### DIFF
--- a/lib/posix/c_lib_ext/fnmatch.c
+++ b/lib/posix/c_lib_ext/fnmatch.c
@@ -90,9 +90,7 @@ static const char *rangematch(const char *pattern, int test, int flags)
 		}
 
 		if (c == '\\' && !(flags & FNM_NOESCAPE)) {
-			if (*pattern != ']' && *pattern != EOS) {
-				c = FOLDCASE(*pattern++, flags);
-			}
+			c = FOLDCASE(*pattern++, flags);
 		}
 
 		if (c == EOS) {

--- a/lib/posix/c_lib_ext/fnmatch.c
+++ b/lib/posix/c_lib_ext/fnmatch.c
@@ -9,6 +9,11 @@
  * This code is derived from software contributed to Berkeley by
  * Guido van Rossum.
  *
+ * Copyright (c) 2011 The FreeBSD Foundation
+ * All rights reserved.
+ * Portions of this software were developed by David Chisnall
+ * under sponsorship from the FreeBSD Foundation.
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -48,26 +53,121 @@
 
 #define EOS '\0'
 
+#ifndef FNM_NORES
+#define FNM_NORES 3
+#endif
+
+#ifndef FNM_LEADING_DIR
+#define FNM_LEADING_DIR 0x08
+#endif
+
+#ifndef FNM_CASEFOLD
+#define FNM_CASEFOLD 0x10
+#endif
+
+#define FOLDCASE(ch, flags) foldcase((unsigned char)(ch), (flags))
+
+#define RANGE_ERROR   (-1)
+#define RANGE_NOMATCH 1
+#define RANGE_MATCH   0
+
+/* POSIX character class matching was missing from the BSD version. This was added in 2025 */
+static int rangematch_cc(const char **pattern, int ch)
+{
+	typedef unsigned long long ull;
+
+	/*
+	 * [:alnum:] et al are 9 characters. [:xdigits:] is 10.
+	 * If we first check for the leading "[:", then we have at most 8 remaining characters to
+	 * compare. Rather than using string comparison, encode the 8 characters into an integer and
+	 * compare to a precomputed constants. This likely only works for the "C" locale.
+	 */
+#define FNM_CC5(a, b, c, d, e)                                                                     \
+	(((ull)(a) << 48) | ((ull)(b) << 40) | ((ull)(c) << 32) | ((ull)(d) << 24) |               \
+	 ((ull)(e) << 16) | ((ull)':' << 8) | ((ull)']' << 0))
+#define FNM_CC6(a, b, c, d, e, f)                                                                  \
+	(((ull)(a) << 56) | ((ull)(b) << 48) | ((ull)(c) << 40) | ((ull)(d) << 32) |               \
+	 ((ull)(e) << 24) | ((ull)(f) << 16) | ((ull)':' << 8) | ((ull)']' << 0))
+
+	ull key;
+	int ret;
+	const char *p = *pattern;
+
+	/* check the leading "[:" */
+	if ((p[0] != '[') || (p[1] != ':')) {
+		return RANGE_ERROR;
+	}
+
+	/* encode the remaining characters into a 64-bit integer */
+	for (p += 2, key = 0; *p != EOS; ++p) {
+		if (*(p - 1) == ']') {
+			break;
+		}
+
+		key <<= 8;
+		key |= (unsigned char)(*p);
+	}
+
+	switch (key) {
+	case FNM_CC5('a', 'l', 'n', 'u', 'm'):
+		ret = !isalnum(ch);
+		break;
+	case FNM_CC5('a', 'l', 'p', 'h', 'a'):
+		ret = !isalpha(ch);
+		break;
+	case FNM_CC5('b', 'l', 'a', 'n', 'k'):
+		ret = !isblank(ch);
+		break;
+	case FNM_CC5('c', 'n', 't', 'r', 'l'):
+		ret = !iscntrl(ch);
+		break;
+	case FNM_CC5('d', 'i', 'g', 'i', 't'):
+		ret = !isdigit(ch);
+		break;
+	case FNM_CC5('g', 'r', 'a', 'p', 'h'):
+		ret = !isgraph(ch);
+		break;
+	case FNM_CC5('l', 'o', 'w', 'e', 'r'):
+		ret = !islower(ch);
+		break;
+	case FNM_CC5('p', 'r', 'i', 'n', 't'):
+		ret = !isprint(ch);
+		break;
+	case FNM_CC5('p', 'u', 'n', 'c', 't'):
+		ret = !ispunct(ch);
+		break;
+	case FNM_CC5('s', 'p', 'a', 'c', 'e'):
+		ret = !isspace(ch);
+		break;
+	case FNM_CC5('u', 'p', 'p', 'e', 'r'):
+		ret = !isupper(ch);
+		break;
+	case FNM_CC6('x', 'd', 'i', 'g', 'i', 't'):
+		ret = !isxdigit(ch);
+		break;
+	default:
+		return RANGE_ERROR;
+	}
+
+	*pattern = p;
+	return ret;
+}
+
 static inline int foldcase(int ch, int flags)
 {
-
-	if ((flags & FNM_CASEFOLD) != 0 && isupper(ch)) {
+	if (((flags & FNM_CASEFOLD) != 0) && isupper(ch)) {
 		return tolower(ch);
 	}
 
 	return ch;
 }
 
-#define FOLDCASE(ch, flags) foldcase((unsigned char)(ch), (flags))
-
-static const char *rangematch(const char *pattern, int test, int flags)
+static int rangematch(const char **pattern, char test, int flags)
 {
-	bool negate, ok, need;
 	char c, c2;
-
-	if (pattern == NULL) {
-		return NULL;
-	}
+	int negate, ok;
+	const char *origpat;
+	const char *pat = *pattern;
 
 	/*
 	 * A bracket expression starting with an unquoted circumflex
@@ -76,88 +176,113 @@ static const char *rangematch(const char *pattern, int test, int flags)
 	 * consistency with the regular expression syntax.
 	 * J.T. Conklin (conklin@ngai.kaleida.com)
 	 */
-	negate = *pattern == '!' || *pattern == '^';
+	negate = (*pat == '!' || *pat == '^');
 	if (negate) {
-		++pattern;
+		++pat;
 	}
 
-	for (need = true, ok = false, c = FOLDCASE(*pattern++, flags); c != ']' || need;
-	     c = FOLDCASE(*pattern++, flags)) {
-		need = false;
+	test = FOLDCASE(test, flags);
 
-		if (c == '/' && (flags & FNM_PATHNAME)) {
-			return (void *)-1;
+	/*
+	 * A right bracket shall lose its special meaning and represent
+	 * itself in a bracket expression if it occurs first in the list.
+	 * -- POSIX.2 2.8.3.2
+	 */
+	ok = 0;
+	origpat = pat;
+	for (;;) {
+		if (*pat == ']' && pat > origpat) {
+			pat++;
+			break;
+		} else if (*pat == '\0') {
+			return RANGE_ERROR;
+		} else if (*pat == '/' && (flags & FNM_PATHNAME)) {
+			return RANGE_NOMATCH;
+		} else if (*pat == '\\' && !(flags & FNM_NOESCAPE)) {
+			pat++;
+		} else {
+			switch (rangematch_cc(&pat, test)) {
+			case RANGE_ERROR:
+				/* not a character class, proceed below */
+				break;
+			case RANGE_MATCH:
+				/* a valid character class that was matched */
+				ok = 1;
+				continue;
+			case RANGE_NOMATCH:
+				/* a valid character class that was not matched */
+				continue;
+			}
 		}
 
-		if (c == '\\' && !(flags & FNM_NOESCAPE)) {
-			c = FOLDCASE(*pattern++, flags);
-		}
+		c = FOLDCASE(*pat++, flags);
 
-		if (c == EOS) {
-			return NULL;
-		}
-
-		if (*pattern == '-') {
-			c2 = FOLDCASE(*(pattern + 1), flags);
-			if (c2 != EOS && c2 != ']') {
-				pattern += 2;
-				if (c2 == '\\' && !(flags & FNM_NOESCAPE)) {
-					c2 = FOLDCASE(*pattern++, flags);
-				}
-
-				if (c2 == EOS) {
-					return NULL;
-				}
-
-				if (c <= test && test <= c2) {
-					ok = true;
+		if (*pat == '-' && *(pat + 1) != EOS && *(pat + 1) != ']') {
+			if (*++pat == '\\' && !(flags & FNM_NOESCAPE)) {
+				if (*pat != EOS) {
+					pat++;
 				}
 			}
+			c2 = FOLDCASE(*pat, flags);
+			pat++;
+			if (c2 == EOS) {
+				return RANGE_ERROR;
+			}
+
+			if (flags & FNM_CASEFOLD) {
+				c2 = tolower(c2);
+			}
+
+			if (c <= test && test <= c2) {
+				ok = 1;
+			}
 		} else if (c == test) {
-			ok = true;
+			ok = 1;
 		}
 	}
 
-	return ok == negate ? NULL : pattern;
+	if (ok != negate) {
+		*pattern = pat;
+		return RANGE_MATCH;
+	}
+
+	return RANGE_NOMATCH;
 }
 
-static int fnmatchx(const char *pattern, const char *string, int flags, size_t recursion)
+static int fnmatchx(const char *pattern, const char *string, const char *stringstart, int flags,
+		    size_t recursion)
 {
-	const char *stringstart, *r;
-	char c, test;
-
-	if (pattern == NULL || string == NULL) {
-		return FNM_NOMATCH;
-	}
+	char c;
+	char pc, sc;
 
 	if (recursion-- == 0) {
 		return FNM_NORES;
 	}
 
-	for (stringstart = string;;) {
-		c = FOLDCASE(*pattern++, flags);
-		switch (c) {
+	while (true) {
+		pc = FOLDCASE(*pattern++, flags);
+		sc = FOLDCASE(*string, flags);
+		switch (pc) {
 		case EOS:
-			if ((flags & FNM_LEADING_DIR) && *string == '/') {
+			if (((flags & FNM_LEADING_DIR) != 0) && (sc == '/')) {
 				return 0;
 			}
-
-			return *string == EOS ? 0 : FNM_NOMATCH;
+			if (sc == EOS) {
+				return 0;
+			}
+			return FNM_NOMATCH;
 		case '?':
-			if (*string == EOS) {
+			if (sc == EOS) {
 				return FNM_NOMATCH;
 			}
-
-			if (*string == '/' && (flags & FNM_PATHNAME)) {
+			if ((sc == '/') && ((flags & FNM_PATHNAME) != 0)) {
 				return FNM_NOMATCH;
 			}
-
-			if (*string == '.' && (flags & FNM_PERIOD) &&
-			    (string == stringstart ||
-			     ((flags & FNM_PATHNAME) && *(string - 1) == '/'))) {
+			if ((sc == '.') && ((flags & FNM_PERIOD) != 0) &&
+			    ((string == stringstart) ||
+			     (((flags & FNM_PATHNAME) != 0) && (*(string - 1) == '/')))) {
 				return FNM_NOMATCH;
 			}
-
 			++string;
 			break;
 		case '*':
@@ -167,107 +292,85 @@ static int fnmatchx(const char *pattern, const char *string, int flags, size_t r
 				c = FOLDCASE(*++pattern, flags);
 			}
 
-			if (*string == '.' && (flags & FNM_PERIOD) &&
-			    (string == stringstart ||
-			     ((flags & FNM_PATHNAME) && *(string - 1) == '/'))) {
+			if ((sc == '.') && ((flags & FNM_PERIOD) != 0) &&
+			    ((string == stringstart) ||
+			     (((flags & FNM_PATHNAME) != 0) && (*(string - 1) == '/')))) {
 				return FNM_NOMATCH;
 			}
 
 			/* Optimize for pattern with * at end or before /. */
 			if (c == EOS) {
-				if (flags & FNM_PATHNAME) {
-					return (flags & FNM_LEADING_DIR) ||
-							       strchr(string, '/') == NULL
-						       ? 0
-						       : FNM_NOMATCH;
-				} else {
+				if ((flags & FNM_PATHNAME) == 0) {
 					return 0;
 				}
-			} else if (c == '/' && flags & FNM_PATHNAME) {
+
+				if (((flags & FNM_LEADING_DIR) != 0) ||
+				    (strchr(string, '/') == NULL)) {
+					return 0;
+				}
+
+				return FNM_NOMATCH;
+			} else if ((c == '/') && ((flags & FNM_PATHNAME) != 0)) {
 				string = strchr(string, '/');
 				if (string == NULL) {
 					return FNM_NOMATCH;
 				}
-
 				break;
 			}
 
 			/* General case, use recursion. */
-			do {
-				test = FOLDCASE(*string, flags);
-				if (test == EOS) {
+			while (sc != EOS) {
+				if (fnmatchx(pattern, string, stringstart, flags, recursion) == 0) {
+					return 0;
+				}
+				sc = FOLDCASE(*string, flags);
+				if ((sc == '/') && ((flags & FNM_PATHNAME) != 0)) {
 					break;
 				}
-
-				int e = fnmatchx(pattern, string, flags & ~FNM_PERIOD, recursion);
-
-				if (e != FNM_NOMATCH) {
-					return e;
-				}
-
-				if (test == '/' && flags & FNM_PATHNAME) {
-					break;
-				}
-
 				++string;
-			} while (true);
-
+			}
 			return FNM_NOMATCH;
 		case '[':
-			if (*string == EOS) {
+			if (sc == EOS) {
+				return FNM_NOMATCH;
+			}
+			if ((sc == '/') && ((flags & FNM_PATHNAME) != 0)) {
+				return FNM_NOMATCH;
+			}
+			if ((sc == '.') && ((flags & FNM_PERIOD) != 0) &&
+			    ((string == stringstart) ||
+			     (((flags & FNM_PATHNAME) != 0) && (*(string - 1) == '/')))) {
 				return FNM_NOMATCH;
 			}
 
-			if (*string == '/' && flags & FNM_PATHNAME) {
-				return FNM_NOMATCH;
-			}
-
-			if (*string == '.' && (flags & FNM_PERIOD) &&
-			    (string == stringstart ||
-			     ((flags & FNM_PATHNAME) && *(string - 1) == '/'))) {
-				return FNM_NOMATCH;
-			}
-
-			r = rangematch(pattern, FOLDCASE(*string, flags), flags);
-
-			if (r == NULL) {
-				if (FOLDCASE('[', flags) != FOLDCASE(*string, flags)) {
-					return FNM_NOMATCH;
-				}
-				++string;
+			switch (rangematch(&pattern, sc, flags)) {
+			case RANGE_ERROR:
+				goto norm;
+			case RANGE_MATCH:
 				break;
+			case RANGE_NOMATCH:
+				return FNM_NOMATCH;
 			}
-
-			if (r == (void *)-1) {
-				if (*string != '[') {
-					return FNM_NOMATCH;
-				}
-			} else {
-				pattern = r;
-			}
-
 			++string;
 			break;
 		case '\\':
-			if (!(flags & FNM_NOESCAPE)) {
-				c = FOLDCASE(*pattern++, flags);
-				if (c == EOS) {
-					c = '\0';
-					--pattern;
-				}
+			if ((flags & FNM_NOESCAPE) == 0) {
+				pc = FOLDCASE(*pattern++, flags);
 			}
 			__fallthrough;
 		default:
-			if (c != FOLDCASE(*string++, flags)) {
+norm:
+			if (pc != sc) {
 				return FNM_NOMATCH;
 			}
-
+			++string;
 			break;
 		}
 	}
+	CODE_UNREACHABLE;
 }
 
 int fnmatch(const char *pattern, const char *string, int flags)
 {
-	return fnmatchx(pattern, string, flags, 64);
+	return fnmatchx(pattern, string, string, flags, 64);
 }

--- a/tests/posix/c_lib_ext/src/fnmatch.c
+++ b/tests/posix/c_lib_ext/src/fnmatch.c
@@ -1,11 +1,28 @@
 /*
- * Copyright (c) 2023 Meta
+ * Copyright (c) The Zephyr Project Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <ctype.h>
 #include <zephyr/posix/fnmatch.h>
+
 #include <zephyr/ztest.h>
+
+/*
+ * Note: the \x00 control character is specifically excluded below, since testing for it is
+ * equivalent to reading past the end of a '\0'-terminated string (i.e. can fault).
+ */
+#define TEST_BLANK_CHARS " \t"
+#define TEST_CNTRL_CHARS                                                                           \
+	"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16" \
+	"\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f"
+#define TEST_DIGIT_CHARS  "0123456789"
+#define TEST_LOWER_CHARS  "abcdefghijklmnopqrstuvwxyz"
+#define TEST_PUNCT_CHARS  "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+#define TEST_SPACE_CHARS  " \f\n\r\t\v"
+#define TEST_UPPER_CHARS  "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+#define TEST_XDIGIT_CHARS "0123456789ABCDEFabcdef"
 
 /*
  * Adapted from
@@ -13,8 +30,6 @@
  */
 ZTEST(posix_c_lib_ext, test_fnmatch)
 {
-	/* Note: commented out lines indicate known problems to be addressed in #55186 */
-
 	zassert_ok(fnmatch("*.c", "foo.c", 0));
 	zassert_ok(fnmatch("*.c", ".c", 0));
 	zassert_equal(fnmatch("*.a", "foo.c", 0), FNM_NOMATCH);
@@ -96,11 +111,58 @@ ZTEST(posix_c_lib_ext, test_fnmatch)
 	zassert_equal(fnmatch("*/*", "a/.b", FNM_PATHNAME | FNM_PERIOD), FNM_NOMATCH);
 	zassert_ok(fnmatch("*?*/*", "a/.b", FNM_PERIOD));
 	zassert_ok(fnmatch("*[.]/b", "a./b", FNM_PATHNAME | FNM_PERIOD));
-	/* zassert_ok(fnmatch("*[[:alpha:]]/""*[[:alnum:]]", "a/b", FNM_PATHNAME)); */
-	zassert_not_equal(fnmatch("*[![:digit:]]*/[![:d-d]", "a/b", FNM_PATHNAME), 0);
-	zassert_not_equal(fnmatch("*[![:digit:]]*/[[:d-d]", "a/[", FNM_PATHNAME), 0);
-	zassert_not_equal(fnmatch("*[![:digit:]]*/[![:d-d]", "a/[", FNM_PATHNAME), 0);
+	zassert_ok(fnmatch("*[[:alpha:]]/*[[:alnum:]]", "a/b", FNM_PATHNAME));
+	zassert_ok(fnmatch("*[![:digit:]]*/[![:d-d]", "a/b", FNM_PATHNAME), 0);
+	zassert_ok(fnmatch("*[![:digit:]]*/[[:d-d]", "a/[", FNM_PATHNAME), 0);
+	zassert_equal(fnmatch("*[![:digit:]]*/[![:d-d]", "a/[", FNM_PATHNAME), FNM_NOMATCH);
 	zassert_ok(fnmatch("a?b", "a.b", FNM_PATHNAME | FNM_PERIOD));
 	zassert_ok(fnmatch("a*b", "a.b", FNM_PATHNAME | FNM_PERIOD));
 	zassert_ok(fnmatch("a[.]b", "a.b", FNM_PATHNAME | FNM_PERIOD));
+
+	/* Additional test cases for POSIX character classes (C-locale only) */
+	static const struct test_data_s {
+		const char *pattern;
+		const char *match;
+		const char *nomatch;
+	} test_data[] = {
+		{"[[:alnum:]]", TEST_DIGIT_CHARS TEST_UPPER_CHARS TEST_LOWER_CHARS, " "},
+		{"[[:alpha:]]", TEST_UPPER_CHARS TEST_LOWER_CHARS, "0"},
+		{"[[:blank:]]", TEST_BLANK_CHARS, "x"},
+		{"[[:cntrl:]]", TEST_CNTRL_CHARS, "x"},
+		{"[[:digit:]]", TEST_DIGIT_CHARS, "a"},
+		{"[[:graph:]]", TEST_DIGIT_CHARS TEST_UPPER_CHARS TEST_LOWER_CHARS TEST_PUNCT_CHARS,
+		 " "},
+		{"[[:lower:]]", TEST_LOWER_CHARS, "X"},
+		{"[[:print:]]",
+		 TEST_DIGIT_CHARS TEST_UPPER_CHARS TEST_LOWER_CHARS TEST_PUNCT_CHARS " ", "\t"},
+		{"[[:punct:]]", TEST_PUNCT_CHARS, "x"},
+		{"[[:space:]]", TEST_SPACE_CHARS, "x"},
+		{"[[:upper:]]", TEST_UPPER_CHARS, "x"},
+		{"[[:xdigit:]]", TEST_XDIGIT_CHARS, "h"},
+	};
+
+	ARRAY_FOR_EACH_PTR(test_data, data) {
+		/* ensure that characters in "nomatch" do not match "pattern" */
+		for (size_t j = 0; j < strlen(data->nomatch); j++) {
+			char c = data->nomatch[j];
+			char input[] = {c, '\0'};
+
+			zexpect_equal(fnmatch(data->pattern, input, 0), FNM_NOMATCH,
+				      "pattern \"%s\" unexpectedly matched char 0x%02x (%c)",
+				      data->pattern, c, isprint(c) ? c : '.');
+		}
+
+		/* ensure that characters in "match" do match "pattern" */
+		for (size_t j = 0; j < strlen(data->match); j++) {
+			char c = data->match[j];
+			char input[] = {c, '\0'};
+
+			zexpect_ok(fnmatch(data->pattern, input, 0),
+				   "pattern \"%s\" did not match char 0x%02x (%c)", data->pattern,
+				   c, isprint(c) ? c : '.');
+		}
+	}
+
+	/* ensure that an invalid character class generates an error */
+	zassert_equal(fnmatch("[[:foobarbaz:]]", "Z", 0), FNM_NOMATCH);
 }


### PR DESCRIPTION
A regression in 936d0278bdfa773390469aa102a3de004f355514 introduced a subtle bug in the way that escaped expressions were handled.

The regression originated with the assumption that test data (originally adapted from a 3rd-party testsuite) was correct when it was in fact flawed.

Specifically, `fnmatch("[[?*\\]", "\\", 0)` should fail (`FNM_NOMATCH`), since the "\\" sequence (a single backslash after compilation) escapes the following ']' character, thus leaving the bracket expression incomplete.

As @keith-packard  has pointed out, [pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_13_01](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_13_01), a bracket expression is only interpreted as a bracket expression, when a proper bracket expression is formed.

Therefore, the pattern is interpreted as the sequence `'['`, `'['`, `'?'`, `'*'`, `']'` and the call should return `FNM_NOMATCH` to indicate failure rather than 0 to indicate success.

Additionally, add support for POSIX character classes, as that was a blocking change request. Partial implementation and tests pulled in from #97400.

Fixes #55186

Verified that tests are compatible with glibc.

Rebased after #99451 was merged