### PR TITLE
bindings: pwm-leds: Include base.yaml

### DIFF
--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -1,5 +1,6 @@
 # Copyright (c) 2018, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
+include: base.yaml
 
 description: |
   Group of PWM-controlled LEDs.


### PR DESCRIPTION
Include base.yaml in order to support zephyr,deferred-init property.