### PR TITLE
lsm6dsv16x: Switch the driver to use level triggered IRQ

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_trigger.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_trigger.c
@@ -273,7 +273,7 @@ static void lsm6dsv16x_handle_interrupt(const struct device *dev)
 
 	if (!ON_I3C_BUS(cfg) || (I3C_INT_PIN(cfg))) {
 		ret = gpio_pin_interrupt_configure_dt(lsm6dsv16x->drdy_gpio,
-						GPIO_INT_EDGE_TO_ACTIVE);
+						GPIO_INT_LEVEL_ACTIVE);
 		if (ret < 0) {
 			LOG_ERR("%s: Not able to configure pin_int", dev->name);
 		}
@@ -488,5 +488,5 @@ int lsm6dsv16x_init_interrupt(const struct device *dev)
 #endif
 
 	return gpio_pin_interrupt_configure_dt(lsm6dsv16x->drdy_gpio,
-					       GPIO_INT_EDGE_TO_ACTIVE);
+					       GPIO_INT_LEVEL_ACTIVE);
 }


### PR DESCRIPTION
The benefit of using edge triggered interrupt is that they allow one to write handlers that don't require disabling/enabling of the interrupts. This driver donesn't leverage that and, in fact, by using edge trigger it opens up a race condition window between the read of the status register and re-enablement of the IRQ. During that window and IRQ can arrive and be lost stalling the data fetching completely.