### PR TITLE
usb: usbd: Partially unconstify .ptr in struct usbd_desc_node

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -162,7 +162,7 @@ struct usbd_desc_node {
 		struct usbd_bos_desc_data bos;
 	};
 	/** Opaque pointer to a descriptor payload */
-	const void *const ptr;
+	const void *ptr;
 	/** Descriptor size in bytes */
 	uint8_t bLength;
 	/** Descriptor type */


### PR DESCRIPTION
It is useful to be able to set .ptr to point to a string obtained at runtime, so let's remove the second const qualifier so that the pointer itself can be adjusted.