### PR TITLE
lib/posix: Adopt newlib-style re-entrant API for getopt family

### DIFF
--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -690,9 +690,11 @@ in the FreeBSD project. This feature is activated by:
 :kconfig:option:`CONFIG_POSIX_C_LIB_EXT` set to ``y`` and :kconfig:option:`CONFIG_GETOPT_LONG`
 set to ``y``.
 
-This feature can be used in thread safe as well as non thread safe manner.
-The former is full compatible with regular getopt usage while the latter
-a bit differs.
+This feature can be used in thread safe as well as non thread safe
+manner.  The former is full compatible with regular getopt usage while
+the latter differs a bit. To gain access to the thread-safe APIs, add
+`#define __need_getopt_newlib` before `#include <getopt.h>` in your
+source code.
 
 An example non-thread safe usage:
 
@@ -714,20 +716,20 @@ An example thread safe usage:
 .. code-block:: c
 
   char *cvalue = NULL;
-  struct getopt_state *state;
-  while ((char c = getopt(argc, argv, "abhc:")) != -1) {
-        state = getopt_state_get();
+  struct getopt_data state = GETOPT_DATA_INITIALIZER;
+  while ((char c = getopt_r(argc, argv, "abhc:", &state)) != -1) {
         switch (c) {
         case 'c':
-                cvalue = state->optarg;
+                cvalue = state.optarg;
                 break;
         default:
                 break;
         }
   }
 
-Thread safe getopt functionality is activated by
-:kconfig:option:`CONFIG_SHELL_GETOPT` set to ``y``.
+Thread safe getopt functionality is enabled by defining `__need_getopt_newlib`
+before including getopt.h
+
 
 Obscured Input Feature
 **********************

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -20,6 +20,12 @@
 #include <zephyr/toolchain.h>
 
 #if defined CONFIG_SHELL_GETOPT
+/*
+ * All shell commands should use the re-entrant APIs provided by the
+ * newlib-compatible getopt APIs. This exposes those and hides the
+ * globals used by the non-reentrant APIs.
+ */
+#define __need_getopt_newlib
 #include <getopt.h>
 #endif
 
@@ -992,11 +998,6 @@ struct shell_ctx {
 
 	/*!< Logging level for a backend. */
 	uint32_t log_level;
-
-#if defined CONFIG_SHELL_GETOPT
-	/*!< getopt context for a shell backend. */
-	struct getopt_state getopt;
-#endif
 
 	uint16_t cmd_buff_len; /*!< Command length.*/
 	uint16_t cmd_buff_pos; /*!< Command buffer cursor position.*/

--- a/lib/posix/c_lib_ext/Kconfig
+++ b/lib/posix/c_lib_ext/Kconfig
@@ -23,7 +23,7 @@ config GETOPT_LONG
 	  not interfere with each other.
 	  All not shell threads share one global instance of getopt state, hence
 	  apart from shell this library is not thread safe. User can add support
-	  for other threads by extending function getopt_state_get in
+	  for other threads by extending function getopt_data_get in
 	  getopt_common.c file.
 
 endif # POSIX_C_LIB_EXT

--- a/lib/posix/c_lib_ext/getopt/getopt.h
+++ b/lib/posix/c_lib_ext/getopt/getopt.h
@@ -13,7 +13,8 @@ extern "C" {
 
 #include <zephyr/kernel.h>
 
-struct getopt_state {
+#ifdef __need_getopt_newlib
+struct getopt_data {
 	int opterr;   /* if error message should be printed */
 	int optind;   /* index into parent argv vector */
 	int optopt;   /* character checked for validity */
@@ -28,11 +29,23 @@ struct getopt_state {
 #endif
 };
 
+/*
+ * The GETOPT_DATA_INITIALIZER macro is used to initialize a statically-
+ * allocated variable of type struct getopt_data.
+ */
+
+#define GETOPT_DATA_INITIALIZER	{ 0 }
+
+#endif
+
+#if defined(__need_getopt_legacy) || !defined(__need_getopt_newlib)
+/* Applications using the newlib-style APIs "shouldn't" be using these variables */
 extern int optreset; /* reset getopt */
 extern char *optarg;
 extern int opterr;
 extern int optind;
 extern int optopt;
+#endif
 
 #define no_argument       0
 #define required_argument 1
@@ -51,12 +64,6 @@ struct option {
 	/* if flag not NULL, value to set *flag to; else return value */
 	int val;
 };
-
-/* Function initializes getopt_state structure for current thread */
-void getopt_init(void);
-
-/* Function returns getopt_state structure for the current thread. */
-struct getopt_state *getopt_state_get(void);
 
 /**
  * @brief Parses the command-line arguments.
@@ -107,6 +114,28 @@ int getopt_long(int nargc, char *const *nargv, const char *options,
  */
 int getopt_long_only(int nargc, char *const *nargv, const char *options,
 		     const struct option *long_options, int *idx);
+
+/* Re-entrant forms of the above functions. These follow the newlib/picolibc API */
+
+#ifdef __need_getopt_newlib
+
+/* These #defines are to make accessing the reentrant functions easier.  */
+#define getopt_r		__getopt_r
+#define getopt_long_r		__getopt_long_r
+#define getopt_long_only_r	__getopt_long_only_r
+
+int __getopt_r(int __argc, char *const __argv[], const char *__optstring,
+	       struct getopt_data *__data);
+
+int __getopt_long_r(int __argc, char *const __argv[], const char *__shortopts,
+		    const struct option *__longopts, int *__longind,
+		    struct getopt_data *__data);
+
+int __getopt_long_only_r(int __argc, char *const __argv[], const char *__shortopts,
+			 const struct option *__longopts, int *__longind,
+			 struct getopt_data *__data);
+
+#endif /* __need_getopt_newlib */
 
 #ifdef __cplusplus
 }

--- a/lib/posix/c_lib_ext/getopt/getopt_common.h
+++ b/lib/posix/c_lib_ext/getopt/getopt_common.h
@@ -7,14 +7,21 @@
 #ifndef _GETOPT_COMMON_H__
 #define _GETOPT_COMMON_H__
 
+#define __need_getopt_newlib
+#include "getopt.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* This function is not thread safe. All threads using getopt are calling
- * this function.
+/* These functions are not thread safe. All threads using getopt are calling
+ * them.
  */
-void z_getopt_global_state_update(struct getopt_state *state);
+/* Put state into POSIX global variables */
+void z_getopt_global_state_put(struct getopt_data *state);
+
+/* Get state from POSIX global variables */
+void z_getopt_global_state_get(struct getopt_data *state);
 
 #ifdef __cplusplus
 }

--- a/lib/posix/c_lib_ext/getopt/getopt_long.c
+++ b/lib/posix/c_lib_ext/getopt/getopt_long.c
@@ -1,5 +1,6 @@
 /*	$OpenBSD: getopt_long.c,v 1.22 2006/10/04 21:29:04 jmc Exp $	*/
 /*	$NetBSD: getopt_long.c,v 1.15 2002/01/31 22:43:40 tv Exp $	*/
+/* SPDX-License-Identifier: BSD-2-Clause */
 
 /*
  * Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>

--- a/lib/posix/shell/uname.c
+++ b/lib/posix/shell/uname.c
@@ -42,7 +42,7 @@ static void uname_print_usage(const struct shell *sh)
 
 static int uname_cmd_handler(const struct shell *sh, size_t argc, char **argv)
 {
-	struct getopt_state *state = getopt_state_get();
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	struct utsname info;
 	unsigned int set;
 	int option;
@@ -53,8 +53,8 @@ static int uname_cmd_handler(const struct shell *sh, size_t argc, char **argv)
 
 	/* Get the uname options */
 
-	optind = 1;
-	while ((option = getopt(argc, argv, "asonrvmpi")) != -1) {
+	state.optind = 1;
+	while ((option = getopt_r(argc, argv, "asonrvmpi", &state)) != -1) {
 		switch (option) {
 		case 'a':
 			set = UNAME_ALL;
@@ -93,13 +93,13 @@ static int uname_cmd_handler(const struct shell *sh, size_t argc, char **argv)
 
 		case '?':
 		default:
-			badarg = (char)state->optopt;
+			badarg = (char)state.optopt;
 			break;
 		}
 	}
 
-	if (argc != optind) {
-		shell_error(sh, "uname: extra operand %s", argv[optind]);
+	if (argc != state.optind) {
+		shell_error(sh, "uname: extra operand %s", argv[state.optind]);
 		uname_print_usage(sh);
 		return -1;
 	}

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -109,14 +109,13 @@ static int cmd_demo_board(const struct shell *sh, size_t argc, char **argv)
 static int cmd_demo_getopt_ts(const struct shell *sh, size_t argc,
 			      char **argv)
 {
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	char *cvalue = NULL;
 	int aflag = 0;
 	int bflag = 0;
 	int c;
 
-	while ((c = getopt(argc, argv, "abhc:")) != -1) {
-		state = getopt_state_get();
+	while ((c = getopt_r(argc, argv, "abhc:", &state)) != -1) {
 		switch (c) {
 		case 'a':
 			aflag = 1;
@@ -125,7 +124,7 @@ static int cmd_demo_getopt_ts(const struct shell *sh, size_t argc,
 			bflag = 1;
 			break;
 		case 'c':
-			cvalue = state->optarg;
+			cvalue = state.optarg;
 			break;
 		case 'h':
 			/* When getopt is active shell is not parsing
@@ -135,18 +134,18 @@ static int cmd_demo_getopt_ts(const struct shell *sh, size_t argc,
 			shell_help(sh);
 			return SHELL_CMD_HELP_PRINTED;
 		case '?':
-			if (state->optopt == 'c') {
+			if (state.optopt == 'c') {
 				shell_print(sh,
 					"Option -%c requires an argument.",
-					state->optopt);
-			} else if (isprint(state->optopt) != 0) {
+					state.optopt);
+			} else if (isprint(state.optopt) != 0) {
 				shell_print(sh,
 					"Unknown option `-%c'.",
-					state->optopt);
+					state.optopt);
 			} else {
 				shell_print(sh,
 					"Unknown option character `\\x%x'.",
-					state->optopt);
+					state.optopt);
 			}
 			return 1;
 		default:
@@ -161,12 +160,13 @@ static int cmd_demo_getopt_ts(const struct shell *sh, size_t argc,
 static int cmd_demo_getopt(const struct shell *sh, size_t argc,
 			      char **argv)
 {
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	char *cvalue = NULL;
 	int aflag = 0;
 	int bflag = 0;
 	int c;
 
-	while ((c = getopt(argc, argv, "abhc:")) != -1) {
+	while ((c = getopt_r(argc, argv, "abhc:", &state)) != -1) {
 		switch (c) {
 		case 'a':
 			aflag = 1;
@@ -175,7 +175,7 @@ static int cmd_demo_getopt(const struct shell *sh, size_t argc,
 			bflag = 1;
 			break;
 		case 'c':
-			cvalue = optarg;
+			cvalue = state.optarg;
 			break;
 		case 'h':
 			/* When getopt is active shell is not parsing
@@ -188,14 +188,14 @@ static int cmd_demo_getopt(const struct shell *sh, size_t argc,
 			if (optopt == 'c') {
 				shell_print(sh,
 					"Option -%c requires an argument.",
-					optopt);
-			} else if (isprint(optopt) != 0) {
+					state.optopt);
+			} else if (isprint(state.optopt) != 0) {
 				shell_print(sh, "Unknown option `-%c'.",
-					optopt);
+					state.optopt);
 			} else {
 				shell_print(sh,
 					"Unknown option character `\\x%x'.",
-					optopt);
+					state.optopt);
 			}
 			return 1;
 		default:

--- a/subsys/crc/crc_shell.c
+++ b/subsys/crc/crc_shell.c
@@ -78,10 +78,9 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 	bool reflect = false;
 	void *addr = (void *)-1;
 	enum crc_type type = CRC32_IEEE;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 
-	optind = 1;
-
-	while ((rv = getopt(argc, argv, "fhlp:rs:t:")) != -1) {
+	while ((rv = getopt_r(argc, argv, "fhlp:rs:t:", &state)) != -1) {
 		switch (rv) {
 		case 'f':
 			first = true;
@@ -93,9 +92,9 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 			last = true;
 			break;
 		case 'p':
-			poly = (size_t)strtoul(optarg, NULL, 16);
+			poly = (size_t)strtoul(state.optarg, NULL, 16);
 			if (poly == 0 && errno == EINVAL) {
-				shell_error(sh, "invalid seed '%s'", optarg);
+				shell_error(sh, "invalid seed '%s'", state.optarg);
 				return -EINVAL;
 			}
 			break;
@@ -103,16 +102,16 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 			reflect = true;
 			break;
 		case 's':
-			seed = (size_t)strtoul(optarg, NULL, 16);
+			seed = (size_t)strtoul(state.optarg, NULL, 16);
 			if (seed == 0 && errno == EINVAL) {
 				shell_error(sh, "invalid seed '%s'", optarg);
 				return -EINVAL;
 			}
 			break;
 		case 't':
-			type = string_to_crc_type(optarg);
+			type = string_to_crc_type(state.optarg);
 			if (type == -1) {
-				shell_error(sh, "invalid type '%s'", optarg);
+				shell_error(sh, "invalid type '%s'", state.optarg);
 				return -EINVAL;
 			}
 			break;
@@ -123,21 +122,21 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 		}
 	}
 
-	if (optind + 2 > argc) {
+	if (state.optind + 2 > argc) {
 		shell_error(sh, "'address' and 'size' arguments are mandatory");
 		usage(sh);
 		return -EINVAL;
 	}
 
-	addr = (void *)strtoul(argv[optind], NULL, 16);
+	addr = (void *)strtoul(argv[state.optind], NULL, 16);
 	if (addr == 0 && errno == EINVAL) {
 		shell_error(sh, "invalid address '%s'", argv[optind]);
 		return -EINVAL;
 	}
 
-	size = (size_t)strtoul(argv[optind + 1], NULL, 0);
+	size = (size_t)strtoul(argv[state.optind + 1], NULL, 0);
 	if (size == 0 && errno == EINVAL) {
-		shell_error(sh, "invalid size '%s'", argv[optind + 1]);
+		shell_error(sh, "invalid size '%s'", argv[state.optind + 1]);
 		return -EINVAL;
 	}
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -583,7 +583,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"ssid", required_argument, 0, 's'},
 		{"passphrase", required_argument, 0, 'p'},
@@ -650,12 +650,11 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 	params->bandwidth = WIFI_FREQ_BANDWIDTH_20MHZ;
 	params->verify_peer_cert = false;
 
-	while ((opt = getopt_long(argc, argv, "s:p:k:e:w:b:c:m:t:a:B:K:S:T:A:V:I:P:g:Rh:i:",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "s:p:k:e:w:b:c:m:t:a:B:K:S:T:A:V:I:P:g:Rh:i:",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 's':
-			params->ssid = state->optarg;
+			params->ssid = state.optarg;
 			params->ssid_length = strlen(params->ssid);
 			if (params->ssid_length > WIFI_SSID_MAX_LEN) {
 				PR_WARNING("SSID too long (max %d characters)\n",
@@ -664,17 +663,17 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			}
 			break;
 		case 'k':
-			params->security = atoi(state->optarg);
+			params->security = atoi(state.optarg);
 			if (params->security) {
 				secure_connection = true;
 			}
 			break;
 		case 'p':
-			params->psk = state->optarg;
+			params->psk = state.optarg;
 			params->psk_length = strlen(params->psk);
 			break;
 		case 'c':
-			channel = strtol(state->optarg, &endptr, 10);
+			channel = strtol(state.optarg, &endptr, 10);
 			if (iface_mode == WIFI_MODE_AP && channel == 0) {
 				params->channel = channel;
 				break;
@@ -711,7 +710,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 		case 'b':
 			if (iface_mode == WIFI_MODE_INFRA ||
 			    iface_mode == WIFI_MODE_AP) {
-				switch (atoi(state->optarg)) {
+				switch (atoi(state.optarg)) {
 				case 2:
 					params->band = WIFI_FREQ_BAND_2_4_GHZ;
 					break;
@@ -729,7 +728,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 					}
 					__fallthrough;
 				default:
-					PR_ERROR("Invalid band: %d\n", atoi(state->optarg));
+					PR_ERROR("Invalid band: %d\n", atoi(state.optarg));
 					return -EINVAL;
 				}
 			}
@@ -741,26 +740,26 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 					 wifi_security_txt(params->security));
 				return -EINVAL;
 			}
-			params->mfp = atoi(state->optarg);
+			params->mfp = atoi(state.optarg);
 			break;
 		case 'm':
 			if (net_bytes_from_str(params->bssid, sizeof(params->bssid),
-					       state->optarg) < 0) {
+					       state.optarg) < 0) {
 				PR_WARNING("Invalid MAC address\n");
 				return -EINVAL;
 			}
 			break;
 		case 't':
 			if (iface_mode == WIFI_MODE_INFRA) {
-				params->timeout = strtol(state->optarg, &endptr, 10);
+				params->timeout = strtol(state.optarg, &endptr, 10);
 				if (*endptr != '\0') {
-					PR_ERROR("Invalid timeout: %s\n", state->optarg);
+					PR_ERROR("Invalid timeout: %s\n", state.optarg);
 					return -EINVAL;
 				}
 			}
 			break;
 		case 'a':
-			params->anon_id = state->optarg;
+			params->anon_id = state.optarg;
 			params->aid_length = strlen(params->anon_id);
 			if (params->aid_length > WIFI_ENT_IDENTITY_MAX_LEN) {
 				PR_WARNING("anon_id too long (max %d characters)\n",
@@ -770,7 +769,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			break;
 		case 'B':
 			if (iface_mode == WIFI_MODE_AP) {
-				switch (atoi(state->optarg)) {
+				switch (atoi(state.optarg)) {
 				case 1:
 					params->bandwidth = WIFI_FREQ_BANDWIDTH_20MHZ;
 					break;
@@ -781,7 +780,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 					params->bandwidth = WIFI_FREQ_BANDWIDTH_80MHZ;
 					break;
 				default:
-					PR_ERROR("Invalid bandwidth: %d\n", atoi(state->optarg));
+					PR_ERROR("Invalid bandwidth: %d\n", atoi(state.optarg));
 					return -EINVAL;
 				}
 			}
@@ -793,7 +792,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			}
 
 			if (key_passwd_cnt == 0) {
-				params->key_passwd = state->optarg;
+				params->key_passwd = state.optarg;
 				params->key_passwd_length = strlen(params->key_passwd);
 				if (params->key_passwd_length > WIFI_ENT_PSWD_MAX_LEN) {
 					PR_WARNING("key_passwd too long (max %d characters)\n",
@@ -801,7 +800,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 					return -EINVAL;
 				}
 			} else if (key_passwd_cnt == 1) {
-				params->key2_passwd = state->optarg;
+				params->key2_passwd = state.optarg;
 				params->key2_passwd_length = strlen(params->key2_passwd);
 				if (params->key2_passwd_length > WIFI_ENT_PSWD_MAX_LEN) {
 					PR_WARNING("key2_passwd too long (max %d characters)\n",
@@ -812,18 +811,18 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			key_passwd_cnt++;
 			break;
 		case 'S':
-			params->wpa3_ent_mode = atoi(state->optarg);
+			params->wpa3_ent_mode = atoi(state.optarg);
 			break;
 		case 'T':
-			params->TLS_cipher = atoi(state->optarg);
+			params->TLS_cipher = atoi(state.optarg);
 			break;
 		case 'A':
 			if (iface_mode == WIFI_MODE_INFRA) {
-				params->verify_peer_cert = !!atoi(state->optarg);
+				params->verify_peer_cert = !!atoi(state.optarg);
 			}
 			break;
 		case 'V':
-			params->eap_ver = atoi(state->optarg);
+			params->eap_ver = atoi(state.optarg);
 			if (params->eap_ver != 0U && params->eap_ver != 1U) {
 				PR_WARNING("eap_ver error %d\n", params->eap_ver);
 				return -EINVAL;
@@ -836,10 +835,10 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 				return -EINVAL;
 			}
 
-			params->eap_identity = state->optarg;
+			params->eap_identity = state.optarg;
 			params->eap_id_length = strlen(params->eap_identity);
 
-			params->identities[params->nusers] = state->optarg;
+			params->identities[params->nusers] = state.optarg;
 			params->nusers++;
 			if (params->eap_id_length > WIFI_ENT_IDENTITY_MAX_LEN) {
 				PR_WARNING("eap identity too long (max %d characters)\n",
@@ -854,10 +853,10 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 				return -EINVAL;
 			}
 
-			params->eap_password = state->optarg;
+			params->eap_password = state.optarg;
 			params->eap_passwd_length = strlen(params->eap_password);
 
-			params->passwords[params->passwds] = state->optarg;
+			params->passwords[params->passwds] = state.optarg;
 			params->passwds++;
 			if (params->eap_passwd_length > WIFI_ENT_PSWD_MAX_LEN) {
 				PR_WARNING("eap password length too long (max %d characters)\n",
@@ -869,25 +868,25 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			params->ft_used = true;
 			break;
 		case 'g':
-			params->ignore_broadcast_ssid = shell_strtol(state->optarg, 10, &ret);
+			params->ignore_broadcast_ssid = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'i':
 			/* Unused, but parsing to avoid unknown option error */
 			break;
 		case 'e':
-			params->server_cert_domain_exact = state->optarg;
+			params->server_cert_domain_exact = state.optarg;
 			params->server_cert_domain_exact_len =
 					strlen(params->server_cert_domain_exact);
 			break;
 		case 'x':
-			params->server_cert_domain_suffix = state->optarg;
+			params->server_cert_domain_suffix = state.optarg;
 			params->server_cert_domain_suffix_len =
 					strlen(params->server_cert_domain_suffix);
 			break;
 		case 'h':
 			return -ENOEXEC;
 		default:
-			PR_ERROR("Invalid option %c\n", state->optopt);
+			PR_ERROR("Invalid option %c\n", state.optopt);
 			return -EINVAL;
 		}
 
@@ -1029,7 +1028,7 @@ static int wifi_scan_args_to_params(const struct shell *sh,
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"type", required_argument, 0, 't'},
 		{"bands", required_argument, 0, 'b'},
@@ -1046,24 +1045,23 @@ static int wifi_scan_args_to_params(const struct shell *sh,
 
 	*do_scan = true;
 
-	while ((opt = getopt_long(argc, argv, "t:b:a:p:s:m:c:i:h",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "t:b:a:p:s:m:c:i:h",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 't':
-			if (!strncasecmp(state->optarg, "passive", 7)) {
+			if (!strncasecmp(state.optarg, "passive", 7)) {
 				params->scan_type = WIFI_SCAN_TYPE_PASSIVE;
-			} else if (!strncasecmp(state->optarg, "active", 6)) {
+			} else if (!strncasecmp(state.optarg, "active", 6)) {
 				params->scan_type = WIFI_SCAN_TYPE_ACTIVE;
 			} else {
-				PR_ERROR("Invalid scan type %s\n", state->optarg);
+				PR_ERROR("Invalid scan type %s\n", state.optarg);
 				return -ENOEXEC;
 			}
 
 			opt_num++;
 			break;
 		case 'b':
-			if (wifi_utils_parse_scan_bands(state->optarg, &params->bands)) {
+			if (wifi_utils_parse_scan_bands(state.optarg, &params->bands)) {
 				PR_ERROR("Invalid band value(s)\n");
 				return -ENOEXEC;
 			}
@@ -1071,7 +1069,7 @@ static int wifi_scan_args_to_params(const struct shell *sh,
 			opt_num++;
 			break;
 		case 'a':
-			val = atoi(state->optarg);
+			val = atoi(state.optarg);
 
 			if (val < 0) {
 				PR_ERROR("Invalid dwell_time_active val\n");
@@ -1082,7 +1080,7 @@ static int wifi_scan_args_to_params(const struct shell *sh,
 			opt_num++;
 			break;
 		case 'p':
-			val = atoi(state->optarg);
+			val = atoi(state.optarg);
 
 			if (val < 0) {
 				PR_ERROR("Invalid dwell_time_passive val\n");
@@ -1093,7 +1091,7 @@ static int wifi_scan_args_to_params(const struct shell *sh,
 			opt_num++;
 			break;
 		case 's':
-			if (wifi_utils_parse_scan_ssids(state->optarg,
+			if (wifi_utils_parse_scan_ssids(state.optarg,
 							params->ssids,
 							ARRAY_SIZE(params->ssids))) {
 				PR_ERROR("Invalid SSID(s)\n");
@@ -1103,7 +1101,7 @@ static int wifi_scan_args_to_params(const struct shell *sh,
 			opt_num++;
 			break;
 		case 'm':
-			val = atoi(state->optarg);
+			val = atoi(state.optarg);
 
 			if ((val < 0) || (val > WIFI_MGMT_SCAN_MAX_BSS_CNT)) {
 				PR_ERROR("Invalid max_bss val\n");
@@ -1114,7 +1112,7 @@ static int wifi_scan_args_to_params(const struct shell *sh,
 			opt_num++;
 			break;
 		case 'c':
-			if (wifi_utils_parse_scan_chan(state->optarg,
+			if (wifi_utils_parse_scan_chan(state.optarg,
 						       params->band_chan,
 						       ARRAY_SIZE(params->band_chan))) {
 				PR_ERROR("Invalid band or channel value(s)\n");
@@ -1741,7 +1739,7 @@ static int twt_args_to_params(const struct shell *sh, size_t argc, char *argv[],
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	long value;
 	double twt_mantissa_scale = 0.0;
 	double twt_interval_scale = 0.0;
@@ -1768,12 +1766,11 @@ static int twt_args_to_params(const struct shell *sh, size_t argc, char *argv[],
 
 	params->operation = WIFI_TWT_SETUP;
 
-	while ((opt = getopt_long(argc, argv, "n:c:t:f:r:T:I:a:t:w:p:D:d:e:m:i:h",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "n:c:t:f:r:T:I:a:t:w:p:D:d:e:m:i:h",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 'n':
-			if (!parse_number(sh, &value, state->optarg, NULL,
+			if (!parse_number(sh, &value, state.optarg, NULL,
 					  WIFI_TWT_INDIVIDUAL,
 					  WIFI_TWT_WAKE_TBTT)) {
 				return -EINVAL;
@@ -1782,7 +1779,7 @@ static int twt_args_to_params(const struct shell *sh, size_t argc, char *argv[],
 			break;
 
 		case 'c':
-			if (!parse_number(sh, &value, state->optarg, NULL,
+			if (!parse_number(sh, &value, state.optarg, NULL,
 					  WIFI_TWT_SETUP_CMD_REQUEST,
 					  WIFI_TWT_SETUP_CMD_DEMAND)) {
 				return -EINVAL;
@@ -1791,14 +1788,14 @@ static int twt_args_to_params(const struct shell *sh, size_t argc, char *argv[],
 			break;
 
 		case 't':
-			if (!parse_number(sh, &value, state->optarg, NULL, 1, 255)) {
+			if (!parse_number(sh, &value, state.optarg, NULL, 1, 255)) {
 				return -EINVAL;
 			}
 			params->dialog_token = (uint8_t)value;
 			break;
 
 		case 'f':
-			if (!parse_number(sh, &value, state->optarg, NULL, 0,
+			if (!parse_number(sh, &value, state.optarg, NULL, 0,
 					  (WIFI_MAX_TWT_FLOWS - 1))) {
 				return -EINVAL;
 			}
@@ -1806,35 +1803,35 @@ static int twt_args_to_params(const struct shell *sh, size_t argc, char *argv[],
 			break;
 
 		case 'r':
-			if (!parse_number(sh, &value, state->optarg, NULL, 0, 1)) {
+			if (!parse_number(sh, &value, state.optarg, NULL, 0, 1)) {
 				return -EINVAL;
 			}
 			params->setup.responder = (bool)value;
 			break;
 
 		case 'T':
-			if (!parse_number(sh, &value, state->optarg, NULL, 0, 1)) {
+			if (!parse_number(sh, &value, state.optarg, NULL, 0, 1)) {
 				return -EINVAL;
 			}
 			params->setup.trigger = (bool)value;
 			break;
 
 		case 'I':
-			if (!parse_number(sh, &value, state->optarg, NULL, 0, 1)) {
+			if (!parse_number(sh, &value, state.optarg, NULL, 0, 1)) {
 				return -EINVAL;
 			}
 			params->setup.implicit = (bool)value;
 			break;
 
 		case 'a':
-			if (!parse_number(sh, &value, state->optarg, NULL, 0, 1)) {
+			if (!parse_number(sh, &value, state.optarg, NULL, 0, 1)) {
 				return -EINVAL;
 			}
 			params->setup.announce = (bool)value;
 			break;
 
 		case 'w':
-			if (!parse_number(sh, &value, state->optarg, NULL, 1,
+			if (!parse_number(sh, &value, state.optarg, NULL, 1,
 					  WIFI_MAX_TWT_WAKE_INTERVAL_US)) {
 				return -EINVAL;
 			}
@@ -1842,7 +1839,7 @@ static int twt_args_to_params(const struct shell *sh, size_t argc, char *argv[],
 			break;
 
 		case 'p':
-			if (!parse_number(sh, &value, state->optarg, NULL, 1,
+			if (!parse_number(sh, &value, state.optarg, NULL, 1,
 					  WIFI_MAX_TWT_INTERVAL_US)) {
 				return -EINVAL;
 			}
@@ -1850,7 +1847,7 @@ static int twt_args_to_params(const struct shell *sh, size_t argc, char *argv[],
 			break;
 
 		case 'D':
-			if (!parse_number(sh, &value, state->optarg, NULL, 0,
+			if (!parse_number(sh, &value, state.optarg, NULL, 0,
 					  WIFI_MAX_TWT_WAKE_AHEAD_DURATION_US)) {
 				return -EINVAL;
 			}
@@ -1858,14 +1855,14 @@ static int twt_args_to_params(const struct shell *sh, size_t argc, char *argv[],
 			break;
 
 		case 'd':
-			if (!parse_number(sh, &value, state->optarg, NULL, 0, 1)) {
+			if (!parse_number(sh, &value, state.optarg, NULL, 0, 1)) {
 				return -EINVAL;
 			}
 			params->setup.twt_info_disable = (bool)value;
 			break;
 
 		case 'e':
-			if (!parse_number(sh, &value, state->optarg, NULL, 0,
+			if (!parse_number(sh, &value, state.optarg, NULL, 0,
 					  WIFI_MAX_TWT_EXPONENT)) {
 				return -EINVAL;
 			}
@@ -1873,7 +1870,7 @@ static int twt_args_to_params(const struct shell *sh, size_t argc, char *argv[],
 			break;
 
 		case 'm':
-			if (!parse_number(sh, &value, state->optarg, NULL, 0, 0xFFFF)) {
+			if (!parse_number(sh, &value, state.optarg, NULL, 0, 0xFFFF)) {
 				return -EINVAL;
 			}
 			params->setup.twt_mantissa = (uint16_t)value;
@@ -2150,7 +2147,7 @@ static int wifi_ap_config_args_to_params(const struct shell *sh, size_t argc, ch
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"max_inactivity", required_argument, 0, 't'},
 		{"max_num_sta", required_argument, 0, 's'},
@@ -2163,12 +2160,11 @@ static int wifi_ap_config_args_to_params(const struct shell *sh, size_t argc, ch
 		{0, 0, 0, 0}};
 	long val;
 
-	while ((opt = getopt_long(argc, argv, "t:s:n:c:i:h",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "t:s:n:c:i:h",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 't':
-			if (!parse_number(sh, &val, state->optarg, "max_inactivity",
+			if (!parse_number(sh, &val, state.optarg, "max_inactivity",
 					  0, WIFI_AP_STA_MAX_INACTIVITY)) {
 				return -EINVAL;
 			}
@@ -2176,7 +2172,7 @@ static int wifi_ap_config_args_to_params(const struct shell *sh, size_t argc, ch
 			params->type |= WIFI_AP_CONFIG_PARAM_MAX_INACTIVITY;
 			break;
 		case 's':
-			if (!parse_number(sh, &val, state->optarg, "max_num_sta",
+			if (!parse_number(sh, &val, state.optarg, "max_num_sta",
 					  0, CONFIG_WIFI_MGMT_AP_MAX_NUM_STA)) {
 				return -EINVAL;
 			}
@@ -2185,11 +2181,11 @@ static int wifi_ap_config_args_to_params(const struct shell *sh, size_t argc, ch
 			break;
 #if defined(CONFIG_WIFI_NM_HOSTAPD_AP)
 		case 'n':
-			strncpy(params->ht_capab, state->optarg, WIFI_AP_IEEE_80211_CAPAB_MAX_LEN);
+			strncpy(params->ht_capab, state.optarg, WIFI_AP_IEEE_80211_CAPAB_MAX_LEN);
 			params->type |= WIFI_AP_CONFIG_PARAM_HT_CAPAB;
 			break;
 		case 'c':
-			strncpy(params->vht_capab, state->optarg, WIFI_AP_IEEE_80211_CAPAB_MAX_LEN);
+			strncpy(params->vht_capab, state.optarg, WIFI_AP_IEEE_80211_CAPAB_MAX_LEN);
 			params->type |= WIFI_AP_CONFIG_PARAM_VHT_CAPAB;
 			break;
 #endif
@@ -2200,7 +2196,7 @@ static int wifi_ap_config_args_to_params(const struct shell *sh, size_t argc, ch
 			shell_help(sh);
 			return SHELL_CMD_HELP_PRINTED;
 		default:
-			PR_ERROR("Invalid option %c\n", state->optopt);
+			PR_ERROR("Invalid option %c\n", state.optopt);
 			shell_help(sh);
 			return SHELL_CMD_HELP_PRINTED;
 		}
@@ -2277,6 +2273,7 @@ static int cmd_wifi_reg_domain(const struct shell *sh, size_t argc,
 	bool force = false;
 	bool verbose = false;
 	int opt_index = 0;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"force", no_argument, 0, 'f'},
 		{"verbose", no_argument, 0, 'v'},
@@ -2284,7 +2281,7 @@ static int cmd_wifi_reg_domain(const struct shell *sh, size_t argc,
 		{NULL, 0, NULL, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "fvi:", long_options, &opt_index)) != -1) {
+	while ((opt = getopt_long_r(argc, argv, "fvi:", long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 'f':
 			force = true;
@@ -2300,24 +2297,25 @@ static int cmd_wifi_reg_domain(const struct shell *sh, size_t argc,
 		}
 	}
 
-	if (optind == argc) {
+	if (state.optind == argc) {
 		regd.chan_info = &chan_info[0];
 		regd.oper = WIFI_MGMT_GET;
-	} else if (optind == argc - 1) {
-		if (strlen(argv[optind]) != 2) {
+	} else if (state.optind == argc - 1) {
+		if (strlen(argv[state.optind]) != 2) {
 			PR_WARNING("Invalid reg domain: Length should be two letters/digits\n");
 			return -ENOEXEC;
 		}
 
 		/* Two letter country code with special case of 00 for WORLD */
-		if (((argv[optind][0] < 'A' || argv[optind][0] > 'Z') ||
-			(argv[optind][1] < 'A' || argv[optind][1] > 'Z')) &&
-			(argv[optind][0] != '0' || argv[optind][1] != '0')) {
-			PR_WARNING("Invalid reg domain %c%c\n", argv[optind][0], argv[optind][1]);
+		if (((argv[state.optind][0] < 'A' || argv[state.optind][0] > 'Z') ||
+			(argv[state.optind][1] < 'A' || argv[state.optind][1] > 'Z')) &&
+			(argv[state.optind][0] != '0' || argv[state.optind][1] != '0')) {
+			PR_WARNING("Invalid reg domain %c%c\n",
+				   argv[state.optind][0], argv[state.optind][1]);
 			return -ENOEXEC;
 		}
-		regd.country_code[0] = argv[optind][0];
-		regd.country_code[1] = argv[optind][1];
+		regd.country_code[0] = argv[state.optind][0];
+		regd.country_code[1] = argv[state.optind][1];
 		regd.force = force;
 		regd.oper = WIFI_MGMT_SET;
 	} else {
@@ -2646,7 +2644,7 @@ void parse_mode_args_to_params(const struct shell *sh, int argc,
 	int opt;
 	int opt_index = 0;
 	int opt_num = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"iface", required_argument, 0, 'i'},
 		{"sta", no_argument, 0, 's'},
@@ -2657,9 +2655,8 @@ void parse_mode_args_to_params(const struct shell *sh, int argc,
 		{0, 0, 0, 0}};
 
 	mode->oper = WIFI_MGMT_GET;
-	while ((opt = getopt_long(argc, argv, "i:smtpakh",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "i:smtpakh",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 's':
 			mode->mode |= WIFI_STA_MODE;
@@ -2678,7 +2675,7 @@ void parse_mode_args_to_params(const struct shell *sh, int argc,
 			opt_num++;
 			break;
 		case 'i':
-			mode->if_index = (uint8_t)atoi(state->optarg);
+			mode->if_index = (uint8_t)atoi(state.optarg);
 			/* Don't count iface as it's common for both get and set */
 			break;
 		case 'h':
@@ -2749,7 +2746,7 @@ void parse_channel_args_to_params(const struct shell *sh, int argc,
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"iface", optional_argument, 0, 'i'},
 		{"channel", required_argument, 0, 'c'},
@@ -2757,15 +2754,14 @@ void parse_channel_args_to_params(const struct shell *sh, int argc,
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}};
 
-	while ((opt = getopt_long(argc, argv, "i:c:gh",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "i:c:gh",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 'c':
-			channel->channel = (uint16_t)atoi(state->optarg);
+			channel->channel = (uint16_t)atoi(state.optarg);
 			break;
 		case 'i':
-			channel->if_index = (uint8_t)atoi(state->optarg);
+			channel->if_index = (uint8_t)atoi(state.optarg);
 			break;
 		case 'g':
 			channel->oper = WIFI_MGMT_GET;
@@ -2847,7 +2843,7 @@ void parse_filter_args_to_params(const struct shell *sh, int argc,
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"iface", required_argument, 0, 'i'},
 		{"capture-len", optional_argument, 0, 'b'},
@@ -2859,9 +2855,8 @@ void parse_filter_args_to_params(const struct shell *sh, int argc,
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}};
 
-	while ((opt = getopt_long(argc, argv, "i:b:amcdgh",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "i:b:amcdgh",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 'a':
 			filter->filter |= WIFI_PACKET_FILTER_ALL;
@@ -2876,10 +2871,10 @@ void parse_filter_args_to_params(const struct shell *sh, int argc,
 			filter->filter |= WIFI_PACKET_FILTER_DATA;
 			break;
 		case 'i':
-			filter->if_index = (uint8_t)atoi(state->optarg);
+			filter->if_index = (uint8_t)atoi(state.optarg);
 			break;
 		case 'b':
-			filter->buffer_size = (uint16_t)atoi(state->optarg);
+			filter->buffer_size = (uint16_t)atoi(state.optarg);
 			break;
 		case 'h':
 			shell_help(sh);
@@ -2971,7 +2966,7 @@ static int parse_dpp_args_auth_init(const struct shell *sh, size_t argc, char *a
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"peer", required_argument, 0, 'p'},
 		{"role", required_argument, 0, 'r'},
@@ -2982,30 +2977,29 @@ static int parse_dpp_args_auth_init(const struct shell *sh, size_t argc, char *a
 		{0, 0, 0, 0}};
 	int ret = 0;
 
-	while ((opt = getopt_long(argc, argv, "p:r:c:m:s:i:",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "p:r:c:m:s:i:",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 'p':
-			params->auth_init.peer = shell_strtol(state->optarg, 10, &ret);
+			params->auth_init.peer = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'r':
-			params->auth_init.role = shell_strtol(state->optarg, 10, &ret);
+			params->auth_init.role = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'c':
-			params->auth_init.configurator = shell_strtol(state->optarg, 10, &ret);
+			params->auth_init.configurator = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'm':
-			params->auth_init.conf = shell_strtol(state->optarg, 10, &ret);
+			params->auth_init.conf = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 's':
-			strncpy(params->auth_init.ssid, state->optarg, WIFI_SSID_MAX_LEN);
+			strncpy(params->auth_init.ssid, state.optarg, WIFI_SSID_MAX_LEN);
 			break;
 		case 'i':
 			/* Unused, but parsing to avoid unknown option error */
 			break;
 		default:
-			PR_ERROR("Invalid option %c\n", state->optopt);
+			PR_ERROR("Invalid option %c\n", state.optopt);
 			return -EINVAL;
 		}
 
@@ -3023,7 +3017,7 @@ static int parse_dpp_args_chirp(const struct shell *sh, size_t argc, char *argv[
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"own", required_argument, 0, 'o'},
 		{"freq", required_argument, 0, 'f'},
@@ -3031,21 +3025,20 @@ static int parse_dpp_args_chirp(const struct shell *sh, size_t argc, char *argv[
 		{0, 0, 0, 0}};
 	int ret = 0;
 
-	while ((opt = getopt_long(argc, argv, "o:f:i:",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "o:f:i:",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 'o':
-			params->chirp.id = shell_strtol(state->optarg, 10, &ret);
+			params->chirp.id = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'f':
-			params->chirp.freq = shell_strtol(state->optarg, 10, &ret);
+			params->chirp.freq = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'i':
 			/* Unused, but parsing to avoid unknown option error */
 			break;
 		default:
-			PR_ERROR("Invalid option %c\n", state->optopt);
+			PR_ERROR("Invalid option %c\n", state.optopt);
 			return -EINVAL;
 		}
 
@@ -3063,7 +3056,7 @@ static int parse_dpp_args_listen(const struct shell *sh, size_t argc, char *argv
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"role", required_argument, 0, 'r'},
 		{"freq", required_argument, 0, 'f'},
@@ -3071,21 +3064,20 @@ static int parse_dpp_args_listen(const struct shell *sh, size_t argc, char *argv
 		{0, 0, 0, 0}};
 	int ret = 0;
 
-	while ((opt = getopt_long(argc, argv, "r:f:i:",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "r:f:i:",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 'r':
-			params->listen.role = shell_strtol(state->optarg, 10, &ret);
+			params->listen.role = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'f':
-			params->listen.freq = shell_strtol(state->optarg, 10, &ret);
+			params->listen.freq = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'i':
 			/* Unused, but parsing to avoid unknown option error */
 			break;
 		default:
-			PR_ERROR("Invalid option %c\n", state->optopt);
+			PR_ERROR("Invalid option %c\n", state.optopt);
 			return -EINVAL;
 		}
 
@@ -3103,7 +3095,7 @@ static int parse_dpp_args_btstrap_gen(const struct shell *sh, size_t argc, char 
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"type", required_argument, 0, 't'},
 		{"opclass", required_argument, 0, 'o'},
@@ -3113,28 +3105,27 @@ static int parse_dpp_args_btstrap_gen(const struct shell *sh, size_t argc, char 
 		{0, 0, 0, 0}};
 	int ret = 0;
 
-	while ((opt = getopt_long(argc, argv, "t:o:h:a:i:",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "t:o:h:a:i:",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 't':
-			params->bootstrap_gen.type = shell_strtol(state->optarg, 10, &ret);
+			params->bootstrap_gen.type = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'o':
-			params->bootstrap_gen.op_class = shell_strtol(state->optarg, 10, &ret);
+			params->bootstrap_gen.op_class = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'h':
-			params->bootstrap_gen.chan = shell_strtol(state->optarg, 10, &ret);
+			params->bootstrap_gen.chan = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'a':
 			ret = net_bytes_from_str(params->bootstrap_gen.mac,
-						 WIFI_MAC_ADDR_LEN, state->optarg);
+						 WIFI_MAC_ADDR_LEN, state.optarg);
 			break;
 		case 'i':
 			/* Unused, but parsing to avoid unknown option error */
 			break;
 		default:
-			PR_ERROR("Invalid option %c\n", state->optopt);
+			PR_ERROR("Invalid option %c\n", state.optopt);
 			return -EINVAL;
 		}
 
@@ -3169,7 +3160,7 @@ static int parse_dpp_args_set_config_param(const struct shell *sh, size_t argc, 
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"configurator", required_argument, 0, 'c'},
 		{"mode", required_argument, 0, 'm'},
@@ -3178,25 +3169,24 @@ static int parse_dpp_args_set_config_param(const struct shell *sh, size_t argc, 
 		{0, 0, 0, 0}};
 	int ret = 0;
 
-	while ((opt = getopt_long(argc, argv, "p:r:c:m:s:i:",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "p:r:c:m:s:i:",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 'c':
 			params->configurator_set.configurator =
-				shell_strtol(state->optarg, 10, &ret);
+				shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'm':
-			params->configurator_set.conf = shell_strtol(state->optarg, 10, &ret);
+			params->configurator_set.conf = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 's':
-			strncpy(params->configurator_set.ssid, state->optarg, WIFI_SSID_MAX_LEN);
+			strncpy(params->configurator_set.ssid, state.optarg, WIFI_SSID_MAX_LEN);
 			break;
 		case 'i':
 			/* Unused, but parsing to avoid unknown option error */
 			break;
 		default:
-			PR_ERROR("Invalid option %c\n", state->optopt);
+			PR_ERROR("Invalid option %c\n", state.optopt);
 			return -EINVAL;
 		}
 
@@ -3461,7 +3451,7 @@ static int cmd_wifi_dpp_ap_auth_init(const struct shell *sh, size_t argc, char *
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"peer", required_argument, 0, 'p'},
 		{"iface", required_argument, 0, 'i'},
@@ -3472,18 +3462,17 @@ static int cmd_wifi_dpp_ap_auth_init(const struct shell *sh, size_t argc, char *
 
 	params.action = WIFI_DPP_AUTH_INIT;
 
-	while ((opt = getopt_long(argc, argv, "p:i:",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "p:i:",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 'p':
-			params.auth_init.peer = shell_strtol(state->optarg, 10, &ret);
+			params.auth_init.peer = shell_strtol(state.optarg, 10, &ret);
 			break;
 		case 'i':
 			/* Unused, but parsing to avoid unknown option error */
 			break;
 		default:
-			PR_ERROR("Invalid option %c\n", state->optopt);
+			PR_ERROR("Invalid option %c\n", state.optopt);
 			return -EINVAL;
 		}
 
@@ -3574,7 +3563,7 @@ static int wifi_bgscan_args_to_params(const struct shell *sh, size_t argc, char 
 	int err;
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"type", required_argument, 0, 't'},
 		{"short-interval", required_argument, 0, 's'},
@@ -3586,50 +3575,50 @@ static int wifi_bgscan_args_to_params(const struct shell *sh, size_t argc, char 
 	unsigned long uval;
 	long val;
 
-	while ((opt = getopt_long(argc, argv, "t:s:r:l:b:i:", long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "t:s:r:l:b:i:",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 't':
-			if (strcmp("simple", state->optarg) == 0) {
+			if (strcmp("simple", state.optarg) == 0) {
 				params->type = WIFI_BGSCAN_SIMPLE;
-			} else if (strcmp("learn", state->optarg) == 0) {
+			} else if (strcmp("learn", state.optarg) == 0) {
 				params->type = WIFI_BGSCAN_LEARN;
-			} else if (strcmp("none", state->optarg) == 0) {
+			} else if (strcmp("none", state.optarg) == 0) {
 				params->type = WIFI_BGSCAN_NONE;
 			} else {
-				PR_ERROR("Invalid type %s\n", state->optarg);
+				PR_ERROR("Invalid type %s\n", state.optarg);
 				shell_help(sh);
 				return SHELL_CMD_HELP_PRINTED;
 			}
 			break;
 		case 's':
-			uval = shell_strtoul(state->optarg, 10, &err);
+			uval = shell_strtoul(state.optarg, 10, &err);
 			if (err < 0) {
-				PR_ERROR("Invalid short interval %s\n", state->optarg);
+				PR_ERROR("Invalid short interval %s\n", state.optarg);
 				return err;
 			}
 			params->short_interval = uval;
 			break;
 		case 'l':
-			uval = shell_strtoul(state->optarg, 10, &err);
+			uval = shell_strtoul(state.optarg, 10, &err);
 			if (err < 0) {
-				PR_ERROR("Invalid long interval %s\n", state->optarg);
+				PR_ERROR("Invalid long interval %s\n", state.optarg);
 				return err;
 			}
 			params->long_interval = uval;
 			break;
 		case 'b':
-			uval = shell_strtoul(state->optarg, 10, &err);
+			uval = shell_strtoul(state.optarg, 10, &err);
 			if (err < 0) {
-				PR_ERROR("Invalid BTM queries %s\n", state->optarg);
+				PR_ERROR("Invalid BTM queries %s\n", state.optarg);
 				return err;
 			}
 			params->btm_queries = uval;
 			break;
 		case 'r':
-			val = shell_strtol(state->optarg, 10, &err);
+			val = shell_strtol(state.optarg, 10, &err);
 			if (err < 0) {
-				PR_ERROR("Invalid RSSI threshold %s\n", state->optarg);
+				PR_ERROR("Invalid RSSI threshold %s\n", state.optarg);
 				return err;
 			}
 			params->rssi_threshold = val;
@@ -3638,7 +3627,7 @@ static int wifi_bgscan_args_to_params(const struct shell *sh, size_t argc, char 
 			/* Unused, but parsing to avoid unknown option error */
 			break;
 		default:
-			PR_ERROR("Invalid option %c\n", state->optopt);
+			PR_ERROR("Invalid option %c\n", state.optopt);
 			shell_help(sh);
 			return SHELL_CMD_HELP_PRINTED;
 		}
@@ -3679,19 +3668,18 @@ static int wifi_config_args_to_params(const struct shell *sh, size_t argc, char 
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"okc", required_argument, 0, 'o'},
 		{"iface", required_argument, 0, 'i'},
 		{0, 0, 0, 0}};
 	long val;
 
-	while ((opt = getopt_long(argc, argv, "o:i:",
-				  long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "o:i:",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 'o':
-			if (!parse_number(sh, &val, state->optarg, "okc", 0, 1)) {
+			if (!parse_number(sh, &val, state.optarg, "okc", 0, 1)) {
 				return -EINVAL;
 			}
 			params->okc = val;
@@ -3701,7 +3689,7 @@ static int wifi_config_args_to_params(const struct shell *sh, size_t argc, char 
 			/* Unused, but parsing to avoid unknown option error */
 			break;
 		default:
-			PR_ERROR("Invalid option %c\n", state->optopt);
+			PR_ERROR("Invalid option %c\n", state.optopt);
 			shell_help(sh);
 			return SHELL_CMD_HELP_PRINTED;
 		}

--- a/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
@@ -117,7 +117,7 @@ static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
 {
 	int opt;
 	int opt_index = 0;
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	static const struct option long_options[] = {
 		{"ssid", required_argument, 0, 's'},	 {"passphrase", required_argument, 0, 'p'},
 		{"key-mgmt", required_argument, 0, 'k'}, {"ieee-80211w", required_argument, 0, 'w'},
@@ -138,27 +138,26 @@ static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
 	long channel;
 	long mfp = WIFI_MFP_OPTIONAL;
 
-	while ((opt = getopt_long(argc, argv, "s:p:k:w:b:c:m:t:a:K:h", long_options, &opt_index)) !=
-	       -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "s:p:k:w:b:c:m:t:a:K:h",
+				    long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 's':
-			creds.header.ssid_len = strlen(state->optarg);
+			creds.header.ssid_len = strlen(state.optarg);
 			if (creds.header.ssid_len > WIFI_SSID_MAX_LEN) {
 				shell_warn(sh, "SSID too long (max %d characters)\n",
 					   WIFI_SSID_MAX_LEN);
 				return -EINVAL;
 			}
-			memcpy(creds.header.ssid, state->optarg, creds.header.ssid_len);
+			memcpy(creds.header.ssid, state.optarg, creds.header.ssid_len);
 			break;
 		case 'k':
-			creds.header.type = atoi(state->optarg);
+			creds.header.type = atoi(state.optarg);
 			if (creds.header.type) {
 				secure_connection = true;
 			}
 			break;
 		case 'p':
-			creds.password_len = strlen(state->optarg);
+			creds.password_len = strlen(state.optarg);
 			if (creds.password_len < WIFI_PSK_MIN_LEN) {
 				shell_warn(sh, "Passphrase should be minimum %d characters\n",
 					   WIFI_PSK_MIN_LEN);
@@ -169,12 +168,12 @@ static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
 					   WIFI_PSK_MAX_LEN);
 				return -EINVAL;
 			}
-			memcpy(creds.password, state->optarg, creds.password_len);
+			memcpy(creds.password, state.optarg, creds.password_len);
 			break;
 		case 'c':
-			channel = strtol(state->optarg, &endptr, 10);
+			channel = strtol(state.optarg, &endptr, 10);
 			if (*endptr != '\0') {
-				shell_error(sh, "Invalid channel: %s\n", state->optarg);
+				shell_error(sh, "Invalid channel: %s\n", state.optarg);
 				return -EINVAL;
 			}
 
@@ -205,7 +204,7 @@ static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
 			creds.header.channel = channel;
 			break;
 		case 'b':
-			switch (atoi(state->optarg)) {
+			switch (atoi(state.optarg)) {
 			case 2:
 				creds.header.flags |= WIFI_CREDENTIALS_FLAG_2_4GHz;
 				break;
@@ -216,7 +215,7 @@ static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
 				creds.header.flags |= WIFI_CREDENTIALS_FLAG_6GHz;
 				break;
 			default:
-				shell_error(sh, "Invalid band: %d\n", atoi(state->optarg));
+				shell_error(sh, "Invalid band: %d\n", atoi(state.optarg));
 				return -EINVAL;
 			}
 			break;
@@ -227,9 +226,9 @@ static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
 					    wifi_security_txt(creds.header.type));
 				return -ENOTSUP;
 			}
-			mfp = strtol(state->optarg, &endptr, 10);
+			mfp = strtol(state.optarg, &endptr, 10);
 			if (*endptr != '\0') {
-				shell_error(sh, "Invalid IEEE 802.11w value: %s", state->optarg);
+				shell_error(sh, "Invalid IEEE 802.11w value: %s", state.optarg);
 				return -EINVAL;
 			}
 			if (mfp == WIFI_MFP_DISABLE) {
@@ -238,36 +237,36 @@ static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
 				creds.header.flags |= WIFI_CREDENTIALS_FLAG_MFP_REQUIRED;
 			} else if (mfp > 2) {
 				shell_error(sh, "Invalid IEEE 802.11w value: %s",
-					    state->optarg);
+					    state.optarg);
 				return -EINVAL;
 			}
 			break;
 		case 'm':
 			if (net_bytes_from_str(creds.header.bssid, sizeof(creds.header.bssid),
-					       state->optarg) < 0) {
+					       state.optarg) < 0) {
 				shell_warn(sh, "Invalid MAC address\n");
 				return -EINVAL;
 			}
 			creds.header.flags |= WIFI_CREDENTIALS_FLAG_BSSID;
 			break;
 		case 'a':
-			creds.header.aid_length = strlen(state->optarg);
+			creds.header.aid_length = strlen(state.optarg);
 			if (creds.header.aid_length > WIFI_ENT_IDENTITY_MAX_LEN) {
 				shell_warn(sh, "anon_id too long (max %d characters)\n",
 					   WIFI_ENT_IDENTITY_MAX_LEN);
 				return -EINVAL;
 			}
-			memcpy(creds.header.anon_id, state->optarg, creds.header.aid_length);
+			memcpy(creds.header.anon_id, state.optarg, creds.header.aid_length);
 			creds.header.flags |= WIFI_CREDENTIALS_FLAG_ANONYMOUS_IDENTITY;
 			break;
 		case 'K':
-			creds.header.key_passwd_length = strlen(state->optarg);
+			creds.header.key_passwd_length = strlen(state.optarg);
 			if (creds.header.key_passwd_length > WIFI_ENT_PSWD_MAX_LEN) {
 				shell_warn(sh, "key_passwd too long (max %d characters)\n",
 					   WIFI_ENT_PSWD_MAX_LEN);
 				return -EINVAL;
 			}
-			memcpy(creds.header.key_passwd, state->optarg,
+			memcpy(creds.header.key_passwd, state.optarg,
 			       creds.header.key_passwd_length);
 			creds.header.flags |= WIFI_CREDENTIALS_FLAG_KEY_PASSWORD;
 			break;
@@ -275,7 +274,7 @@ static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
 			shell_help(sh);
 			return -ENOEXEC;
 		default:
-			shell_error(sh, "Invalid option %c\n", state->optopt);
+			shell_error(sh, "Invalid option %c\n", state.optopt);
 			return -EINVAL;
 		}
 	}

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -192,9 +192,9 @@ config SHELL_GETOPT
 	bool "Threadsafe getopt support in shell"
 	select POSIX_C_LIB_EXT
 	help
-	  This config creates a separate getopt_state for the shell instance.
+	  This config creates a separate getopt_data for the shell instance.
 	  It ensures that using getopt with shell is thread safe.
-	  When more threads are using getopt please call getopt_state_get to
+	  When more threads are using getopt please call getopt_data_get to
 	  get getopt state of the shell thread.
 
 config SHELL_METAKEYS

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -54,7 +54,9 @@ static inline void receive_state_change(const struct shell *sh,
 
 static void cmd_buffer_clear(const struct shell *sh)
 {
+#if CONFIG_SHELL_CMD_BUFF_SIZE > 0
 	sh->ctx->cmd_buff[0] = '\0'; /* clear command buffer */
+#endif
 	sh->ctx->cmd_buff_pos = 0;
 	sh->ctx->cmd_buff_len = 0;
 }

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -545,10 +545,6 @@ static int exec_cmd(const struct shell *sh, size_t argc, const char **argv,
 	}
 
 	if (!ret_val) {
-#if CONFIG_SHELL_GETOPT
-		getopt_init();
-#endif
-
 		z_flag_cmd_ctx_set(sh, true);
 		/* Unlock thread mutex in case command would like to borrow
 		 * shell context to other thread to avoid mutex deadlock.

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -1253,7 +1253,7 @@ static int cmd_runall(const struct shell *sh, size_t argc, char **argv)
 static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 {
 
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	int opt;
 	static struct option long_options[] = {{"suite_iter", required_argument, 0, 's'},
 					       {"case_iter", required_argument, 0, 'c'},
@@ -1265,11 +1265,10 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 	int suite_iter = 1;
 	int case_iter = 1;
 
-	while ((opt = getopt_long(argc, argv, "s:c:", long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "s:c:", long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 's':
-			val = atoi(state->optarg);
+			val = atoi(state.optarg);
 			if (val < 1) {
 				shell_error(sh, "Invalid number of suite iterations");
 				return -ENOEXEC;
@@ -1278,7 +1277,7 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 			opt_num++;
 			break;
 		case 'c':
-			val = atoi(state->optarg);
+			val = atoi(state.optarg);
 			if (val < 1) {
 				shell_error(sh, "Invalid number of case iterations");
 				return -ENOEXEC;
@@ -1301,7 +1300,7 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_run_suite(const struct shell *sh, size_t argc, char **argv)
 {
-	struct getopt_state *state;
+	struct getopt_data state = GETOPT_DATA_INITIALIZER;
 	int opt;
 	static struct option long_options[] = {{"repeat_iter", required_argument, NULL, 'r'},
 		{NULL, 0, NULL, 0}};
@@ -1311,11 +1310,10 @@ static int cmd_run_suite(const struct shell *sh, size_t argc, char **argv)
 	void *param = NULL;
 	int repeat_iter = 1;
 
-	while ((opt = getopt_long(argc, argv, "r:p:", long_options, &opt_index)) != -1) {
-		state = getopt_state_get();
+	while ((opt = getopt_long_r(argc, argv, "r:p:", long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 'r':
-			val = atoi(state->optarg);
+			val = atoi(state.optarg);
 			if (val < 1) {
 				shell_fprintf(sh, SHELL_ERROR,
 					"Invalid number of suite interations\n");
@@ -1325,7 +1323,7 @@ static int cmd_run_suite(const struct shell *sh, size_t argc, char **argv)
 			opt_num++;
 			break;
 		case 'p':
-			param = state->optarg;
+			param = state.optarg;
 			opt_num++;
 			break;
 		default:

--- a/tests/posix/c_lib_ext/src/getopt.c
+++ b/tests/posix/c_lib_ext/src/getopt.c
@@ -9,6 +9,9 @@
  *
  */
 
+/* We need both APIs for testing */
+#define __need_getopt_legacy
+#define __need_getopt_newlib
 #include <getopt.h>
 #include <string.h>
 
@@ -16,22 +19,22 @@
 #include <zephyr/posix/unistd.h>
 #include <zephyr/ztest.h>
 
+static const struct getopt_data state_init = GETOPT_DATA_INITIALIZER;
+
 ZTEST(posix_c_lib_ext, test_getopt_basic)
 {
 	static const char *const nargv[] = {
-		"cmd_name", "-b", "-a", "-h", "-c", "-l", "-h", "-a", "-i", "-w",
+		"cmd_name", "-b", "-a", "-h", "-c", "-l", "-h", "-a", "-i", "-w", NULL,
 	};
 	static const char *accepted_opt = "abchw";
 	static const char *expected = "bahc?ha?w";
-	size_t argc = ARRAY_SIZE(nargv);
+	size_t argc = ARRAY_SIZE(nargv) - 1;
 	int cnt = 0;
 	int c;
 	char **argv;
 
 	argv = (char **)nargv;
-
-	/* Get state of the current thread */
-	getopt_init();
+	optind = 0;
 
 	do {
 		c = getopt(argc, argv, accepted_opt);
@@ -46,6 +49,35 @@ ZTEST(posix_c_lib_ext, test_getopt_basic)
 	zassert_equal(c, -1, "unexpected opt character");
 }
 
+ZTEST(posix_c_lib_ext, test_getopt_r_basic)
+{
+	static const char *const nargv[] = {
+		"cmd_name", "-b", "-a", "-h", "-c", "-l", "-h", "-a", "-i", "-w", NULL,
+	};
+	static const char *accepted_opt = "abchw";
+	static const char *expected = "bahc?ha?w";
+	struct getopt_data state;
+	size_t argc = ARRAY_SIZE(nargv) - 1;
+	int cnt = 0;
+	int c;
+	char **argv;
+
+	argv = (char **)nargv;
+	state = state_init;
+
+	do {
+		c = getopt_r(argc, argv, accepted_opt, &state);
+		if (cnt >= strlen(expected)) {
+			break;
+		}
+
+		zassert_equal(c, expected[cnt++], "unexpected opt character");
+	} while (c != -1);
+
+	c = getopt_r(argc, argv, accepted_opt, &state);
+	zassert_equal(c, -1, "unexpected opt character");
+}
+
 enum getopt_idx {
 	GETOPT_IDX_CMD_NAME,
 	GETOPT_IDX_OPTION1,
@@ -55,38 +87,57 @@ enum getopt_idx {
 
 ZTEST(posix_c_lib_ext, test_getopt)
 {
-	struct getopt_state *state;
 	static const char *test_opts = "ac:";
 	static const char *const nargv[] = {
 		[GETOPT_IDX_CMD_NAME] = "cmd_name",
 		[GETOPT_IDX_OPTION1] = "-a",
 		[GETOPT_IDX_OPTION2] = "-c",
 		[GETOPT_IDX_OPTARG] = "foo",
+		NULL,
 	};
-	int argc = ARRAY_SIZE(nargv);
+	int argc = ARRAY_SIZE(nargv) - 1;
 	char **argv;
 	int c;
 
-	/* Get state of the current thread */
-	getopt_init();
-
 	argv = (char **)nargv;
+	optind = 0;
 
-	/* Test uknown option */
+	/* Test unknown option */
 
 	c = getopt(argc, argv, test_opts);
 	zassert_equal(c, 'a', "unexpected opt character");
 	c = getopt(argc, argv, test_opts);
 	zassert_equal(c, 'c', "unexpected opt character");
-
-	c = getopt(argc, argv, test_opts);
-	state = getopt_state_get();
-
-	/* Thread safe usge: */
-	zassert_equal(0, strcmp(argv[GETOPT_IDX_OPTARG], state->optarg),
+	zassert_equal(0, strcmp(argv[GETOPT_IDX_OPTARG], optarg),
 		      "unexpected optarg result");
-	/* Non thread safe usage: */
-	zassert_equal(0, strcmp(argv[GETOPT_IDX_OPTARG], optarg), "unexpected optarg result");
+}
+
+ZTEST(posix_c_lib_ext, test_getopt_r)
+{
+	static const char *test_opts = "ac:";
+	static const char *const nargv[] = {
+		[GETOPT_IDX_CMD_NAME] = "cmd_name",
+		[GETOPT_IDX_OPTION1] = "-a",
+		[GETOPT_IDX_OPTION2] = "-c",
+		[GETOPT_IDX_OPTARG] = "foo",
+		NULL,
+	};
+	int argc = ARRAY_SIZE(nargv) - 1;
+	char **argv;
+	int c;
+	struct getopt_data state;
+
+	argv = (char **)nargv;
+	state = state_init;
+
+	/* Test unknown option */
+
+	c = getopt_r(argc, argv, test_opts, &state);
+	zassert_equal(c, 'a', "unexpected opt character");
+	c = getopt_r(argc, argv, test_opts, &state);
+	zassert_equal(c, 'c', "unexpected opt character");
+	zassert_equal(0, strcmp(argv[GETOPT_IDX_OPTARG], state.optarg),
+		      "unexpected optarg result");
 }
 
 enum getopt_long_idx {
@@ -101,7 +152,6 @@ ZTEST(posix_c_lib_ext, test_getopt_long)
 	/* Below test is based on example
 	 * https://www.gnu.org/software/libc/manual/html_node/Getopt-Long-Option-Example.html
 	 */
-	struct getopt_state *state;
 	int verbose_flag = 0;
 	/* getopt_long stores the option index here. */
 	int option_index = 0;
@@ -127,23 +177,26 @@ ZTEST(posix_c_lib_ext, test_getopt_long)
 		[GETOPT_LONG_IDX_VERBOSE] = "--verbose",
 		[GETOPT_LONG_IDX_OPT] = "--create",
 		[GETOPT_LONG_IDX_OPTARG] = "some_file",
+		NULL,
 	};
-	int argc1 = ARRAY_SIZE(argv1);
+	int argc1 = ARRAY_SIZE(argv1) - 1;
 
 	static const char *const argv2[] = {
 		[GETOPT_LONG_IDX_CMD_NAME] = "cmd_name",
 		[GETOPT_LONG_IDX_VERBOSE] = "--brief",
 		[GETOPT_LONG_IDX_OPT] = "-d",
 		[GETOPT_LONG_IDX_OPTARG] = "other_file",
+		NULL,
 	};
-	int argc2 = ARRAY_SIZE(argv2);
+	int argc2 = ARRAY_SIZE(argv2) - 1;
 
 	static const char *const argv3[] = {
 		[GETOPT_LONG_IDX_CMD_NAME] = "cmd_name",
 		[GETOPT_LONG_IDX_VERBOSE] = "--brief",
 		[GETOPT_LONG_IDX_OPT] = "-a",
+		NULL,
 	};
-	int argc3 = ARRAY_SIZE(argv3);
+	int argc3 = ARRAY_SIZE(argv3) - 1;
 
 	/* this test distinguish getopt_long and getopt_long_only functions */
 	static const char *const argv4[] = {
@@ -152,37 +205,36 @@ ZTEST(posix_c_lib_ext, test_getopt_long)
 		/* below should not be interpreted as "--long/-e" option */
 		[GETOPT_LONG_IDX_OPT] = "-l",
 		[GETOPT_LONG_IDX_OPTARG] = "long_argument",
+		NULL,
 	};
-	int argc4 = ARRAY_SIZE(argv4);
+	int argc4 = ARRAY_SIZE(argv4) - 1;
 
 	/* Test scenario 1 */
 	/* Get state of the current thread */
-	getopt_init();
+	optind = 0;
 	argv = (char **)argv1;
 	c = getopt_long(argc1, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 1, "verbose flag expected");
 	c = getopt_long(argc1, argv, accepted_opt, long_options, &option_index);
-	state = getopt_state_get();
 	zassert_equal('c', c, "unexpected option");
-	zassert_equal(0, strcmp(state->optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
+	zassert_equal(0, strcmp(optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
 	c = getopt_long(argc1, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(-1, c, "getopt_long shall return -1");
 
 	/* Test scenario 2 */
 	argv = (char **)argv2;
-	getopt_init();
+	optind = 0;
 	c = getopt_long(argc2, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 0, "verbose flag expected");
 	c = getopt_long(argc2, argv, accepted_opt, long_options, &option_index);
 	zassert_equal('d', c, "unexpected option");
-	state = getopt_state_get();
-	zassert_equal(0, strcmp(state->optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
+	zassert_equal(0, strcmp(optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
 	c = getopt_long(argc2, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(-1, c, "getopt_long shall return -1");
 
 	/* Test scenario 3 */
 	argv = (char **)argv3;
-	getopt_init();
+	optind = 0;
 	c = getopt_long(argc3, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 0, "verbose flag expected");
 	c = getopt_long(argc3, argv, accepted_opt, long_options, &option_index);
@@ -192,7 +244,7 @@ ZTEST(posix_c_lib_ext, test_getopt_long)
 
 	/* Test scenario 4 */
 	argv = (char **)argv4;
-	getopt_init();
+	optind = 0;
 	c = getopt_long(argc4, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 0, "verbose flag expected");
 	c = getopt_long(argc4, argv, accepted_opt, long_options, &option_index);
@@ -203,12 +255,120 @@ ZTEST(posix_c_lib_ext, test_getopt_long)
 	c = getopt_long(argc4, argv, accepted_opt, long_options, &option_index);
 }
 
+ZTEST(posix_c_lib_ext, test_getopt_long_r)
+{
+	/* Below test is based on example
+	 * https://www.gnu.org/software/libc/manual/html_node/Getopt-Long-Option-Example.html
+	 */
+	int verbose_flag = 0;
+	/* getopt_long stores the option index here. */
+	int option_index = 0;
+	char **argv;
+	int c;
+	struct getopt_data state;
+	struct option long_options[] = {
+		/* These options set a flag. */
+		{"verbose", no_argument, &verbose_flag, 1},
+		{"brief", no_argument, &verbose_flag, 0},
+		/* These options don’t set a flag.
+		 * We distinguish them by their indices.
+		 */
+		{"add", no_argument, 0, 'a'},
+		{"create", required_argument, 0, 'c'},
+		{"delete", required_argument, 0, 'd'},
+		{"long", required_argument, 0, 'e'},
+		{0, 0, 0, 0},
+	};
+	static const char *accepted_opt = "ac:d:e:";
+
+	static const char *const argv1[] = {
+		[GETOPT_LONG_IDX_CMD_NAME] = "cmd_name",
+		[GETOPT_LONG_IDX_VERBOSE] = "--verbose",
+		[GETOPT_LONG_IDX_OPT] = "--create",
+		[GETOPT_LONG_IDX_OPTARG] = "some_file",
+		NULL,
+	};
+	int argc1 = ARRAY_SIZE(argv1) - 1;
+
+	static const char *const argv2[] = {
+		[GETOPT_LONG_IDX_CMD_NAME] = "cmd_name",
+		[GETOPT_LONG_IDX_VERBOSE] = "--brief",
+		[GETOPT_LONG_IDX_OPT] = "-d",
+		[GETOPT_LONG_IDX_OPTARG] = "other_file",
+		NULL,
+	};
+	int argc2 = ARRAY_SIZE(argv2) - 1;
+
+	static const char *const argv3[] = {
+		[GETOPT_LONG_IDX_CMD_NAME] = "cmd_name",
+		[GETOPT_LONG_IDX_VERBOSE] = "--brief",
+		[GETOPT_LONG_IDX_OPT] = "-a",
+		NULL,
+	};
+	int argc3 = ARRAY_SIZE(argv3) - 1;
+
+	/* this test distinguish getopt_long_r and getopt_long_only_r functions */
+	static const char *const argv4[] = {
+		[GETOPT_LONG_IDX_CMD_NAME] = "cmd_name",
+		[GETOPT_LONG_IDX_VERBOSE] = "--brief",
+		/* below should not be interpreted as "--long/-e" option */
+		[GETOPT_LONG_IDX_OPT] = "-l",
+		[GETOPT_LONG_IDX_OPTARG] = "long_argument",
+		NULL,
+	};
+	int argc4 = ARRAY_SIZE(argv4) - 1;
+
+	/* Test scenario 1 */
+	/* Get state of the current thread */
+	state = state_init;
+	argv = (char **)argv1;
+	c = getopt_long_r(argc1, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(verbose_flag, 1, "verbose flag expected");
+	c = getopt_long_r(argc1, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal('c', c, "unexpected option");
+	zassert_equal(0, strcmp(state.optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
+	c = getopt_long_r(argc1, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(-1, c, "getopt_long_r shall return -1");
+
+	/* Test scenario 2 */
+	argv = (char **)argv2;
+	state = state_init;
+	c = getopt_long_r(argc2, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(verbose_flag, 0, "verbose flag expected");
+	c = getopt_long_r(argc2, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal('d', c, "unexpected option");
+	zassert_equal(0, strcmp(state.optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
+	c = getopt_long_r(argc2, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(-1, c, "getopt_long_r shall return -1");
+
+	/* Test scenario 3 */
+	argv = (char **)argv3;
+	state = state_init;
+	c = getopt_long_r(argc3, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(verbose_flag, 0, "verbose flag expected");
+	c = getopt_long_r(argc3, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal('a', c, "unexpected option");
+	c = getopt_long_r(argc3, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(-1, c, "getopt_long_r shall return -1");
+
+	/* Test scenario 4 */
+	argv = (char **)argv4;
+	state = state_init;
+	c = getopt_long_r(argc4, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(verbose_flag, 0, "verbose flag expected");
+	c = getopt_long_r(argc4, argv, accepted_opt, long_options, &option_index, &state);
+	/* Function was called with option '-l'. It is expected it will be
+	 * NOT evaluated to '--long' which has flag 'e'.
+	 */
+	zassert_not_equal('e', c, "unexpected option match");
+	c = getopt_long_r(argc4, argv, accepted_opt, long_options, &option_index, &state);
+}
+
 ZTEST(posix_c_lib_ext, test_getopt_long_only)
 {
 	/* Below test is based on example
 	 * https://www.gnu.org/software/libc/manual/html_node/Getopt-Long-Option-Example.html
 	 */
-	struct getopt_state *state;
 	int verbose_flag = 0;
 	/* getopt_long stores the option index here. */
 	int option_index = 0;
@@ -234,23 +394,26 @@ ZTEST(posix_c_lib_ext, test_getopt_long_only)
 		[GETOPT_LONG_IDX_VERBOSE] = "--verbose",
 		[GETOPT_LONG_IDX_OPT] = "--create",
 		[GETOPT_LONG_IDX_OPTARG] = "some_file",
+		NULL,
 	};
-	int argc1 = ARRAY_SIZE(argv1);
+	int argc1 = ARRAY_SIZE(argv1) - 1;
 
 	static const char *const argv2[] = {
 		[GETOPT_LONG_IDX_CMD_NAME] = "cmd_name",
 		[GETOPT_LONG_IDX_VERBOSE] = "--brief",
 		[GETOPT_LONG_IDX_OPT] = "-d",
 		[GETOPT_LONG_IDX_OPTARG] = "other_file",
+		NULL,
 	};
-	int argc2 = ARRAY_SIZE(argv2);
+	int argc2 = ARRAY_SIZE(argv2) - 1;
 
 	static const char *const argv3[] = {
 		[GETOPT_LONG_IDX_CMD_NAME] = "cmd_name",
 		[GETOPT_LONG_IDX_VERBOSE] = "--brief",
 		[GETOPT_LONG_IDX_OPT] = "-a",
+		NULL,
 	};
-	int argc3 = ARRAY_SIZE(argv3);
+	int argc3 = ARRAY_SIZE(argv3) - 1;
 
 	/* this test distinguish getopt_long and getopt_long_only functions */
 	static const char *const argv4[] = {
@@ -259,37 +422,35 @@ ZTEST(posix_c_lib_ext, test_getopt_long_only)
 		/* below should be interpreted as "--long/-e" option */
 		[GETOPT_LONG_IDX_OPT] = "-l",
 		[GETOPT_LONG_IDX_OPTARG] = "long_argument",
+		NULL,
 	};
-	int argc4 = ARRAY_SIZE(argv4);
+	int argc4 = ARRAY_SIZE(argv4) - 1;
 
 	/* Test scenario 1 */
 	argv = (char **)argv1;
-	getopt_init();
+	optind = 0;
 	c = getopt_long_only(argc1, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 1, "verbose flag expected");
 	c = getopt_long_only(argc1, argv, accepted_opt, long_options, &option_index);
-	state = getopt_state_get();
 	zassert_equal('c', c, "unexpected option");
-	zassert_equal(0, strcmp(state->optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
+	zassert_equal(0, strcmp(optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
 	c = getopt_long_only(argc1, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(-1, c, "getopt_long_only shall return -1");
 
 	/* Test scenario 2 */
 	argv = (char **)argv2;
-	getopt_init();
-	state = getopt_state_get();
+	optind = 0;
 	c = getopt_long_only(argc2, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 0, "verbose flag expected");
 	c = getopt_long_only(argc2, argv, accepted_opt, long_options, &option_index);
-	state = getopt_state_get();
 	zassert_equal('d', c, "unexpected option");
-	zassert_equal(0, strcmp(state->optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
+	zassert_equal(0, strcmp(optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
 	c = getopt_long_only(argc2, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(-1, c, "getopt_long_only shall return -1");
 
 	/* Test scenario 3 */
 	argv = (char **)argv3;
-	getopt_init();
+	optind = 0;
 	c = getopt_long_only(argc3, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 0, "verbose flag expected");
 	c = getopt_long_only(argc3, argv, accepted_opt, long_options, &option_index);
@@ -299,7 +460,7 @@ ZTEST(posix_c_lib_ext, test_getopt_long_only)
 
 	/* Test scenario 4 */
 	argv = (char **)argv4;
-	getopt_init();
+	optind = 0;
 	c = getopt_long_only(argc4, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 0, "verbose flag expected");
 	c = getopt_long_only(argc4, argv, accepted_opt, long_options, &option_index);
@@ -309,4 +470,113 @@ ZTEST(posix_c_lib_ext, test_getopt_long_only)
 	 */
 	zassert_equal('e', c, "unexpected option");
 	c = getopt_long_only(argc4, argv, accepted_opt, long_options, &option_index);
+}
+
+ZTEST(posix_c_lib_ext, test_getopt_long_only_r)
+{
+	/* Below test is based on example
+	 * https://www.gnu.org/software/libc/manual/html_node/Getopt-Long-Option-Example.html
+	 */
+	int verbose_flag = 0;
+	/* getopt_long stores the option index here. */
+	int option_index = 0;
+	char **argv;
+	int c;
+	struct getopt_data state;
+	struct option long_options[] = {
+		/* These options set a flag. */
+		{"verbose", no_argument, &verbose_flag, 1},
+		{"brief", no_argument, &verbose_flag, 0},
+		/* These options don’t set a flag.
+		 * We distinguish them by their indices.
+		 */
+		{"add", no_argument, 0, 'a'},
+		{"create", required_argument, 0, 'c'},
+		{"delete", required_argument, 0, 'd'},
+		{"long", required_argument, 0, 'e'},
+		{0, 0, 0, 0},
+	};
+	static const char *accepted_opt = "ac:d:e:";
+
+	static const char *const argv1[] = {
+		[GETOPT_LONG_IDX_CMD_NAME] = "cmd_name",
+		[GETOPT_LONG_IDX_VERBOSE] = "--verbose",
+		[GETOPT_LONG_IDX_OPT] = "--create",
+		[GETOPT_LONG_IDX_OPTARG] = "some_file",
+		NULL,
+	};
+	int argc1 = ARRAY_SIZE(argv1) - 1;
+
+	static const char *const argv2[] = {
+		[GETOPT_LONG_IDX_CMD_NAME] = "cmd_name",
+		[GETOPT_LONG_IDX_VERBOSE] = "--brief",
+		[GETOPT_LONG_IDX_OPT] = "-d",
+		[GETOPT_LONG_IDX_OPTARG] = "other_file",
+		NULL,
+	};
+	int argc2 = ARRAY_SIZE(argv2) - 1;
+
+	static const char *const argv3[] = {
+		[GETOPT_LONG_IDX_CMD_NAME] = "cmd_name",
+		[GETOPT_LONG_IDX_VERBOSE] = "--brief",
+		[GETOPT_LONG_IDX_OPT] = "-a",
+		NULL,
+	};
+	int argc3 = ARRAY_SIZE(argv3) - 1;
+
+	/* this test distinguish getopt_long and getopt_long_only functions */
+	static const char *const argv4[] = {
+		[GETOPT_LONG_IDX_CMD_NAME] = "cmd_name",
+		[GETOPT_LONG_IDX_VERBOSE] = "--brief",
+		/* below should be interpreted as "--long/-e" option */
+		[GETOPT_LONG_IDX_OPT] = "-l",
+		[GETOPT_LONG_IDX_OPTARG] = "long_argument",
+		NULL,
+	};
+	int argc4 = ARRAY_SIZE(argv4) - 1;
+
+	/* Test scenario 1 */
+	argv = (char **)argv1;
+	state = state_init;
+	c = getopt_long_only_r(argc1, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(verbose_flag, 1, "verbose flag expected");
+	c = getopt_long_only_r(argc1, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal('c', c, "unexpected option");
+	zassert_equal(0, strcmp(state.optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
+	c = getopt_long_only_r(argc1, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(-1, c, "getopt_long_only shall return -1");
+
+	/* Test scenario 2 */
+	argv = (char **)argv2;
+	state = state_init;
+	c = getopt_long_only_r(argc2, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(verbose_flag, 0, "verbose flag expected");
+	c = getopt_long_only_r(argc2, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal('d', c, "unexpected option");
+	zassert_equal(0, strcmp(state.optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
+	c = getopt_long_only_r(argc2, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(-1, c, "getopt_long_only shall return -1");
+
+	/* Test scenario 3 */
+	argv = (char **)argv3;
+	state = state_init;
+	c = getopt_long_only_r(argc3, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(verbose_flag, 0, "verbose flag expected");
+	c = getopt_long_only_r(argc3, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal('a', c, "unexpected option");
+	c = getopt_long_only_r(argc3, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(-1, c, "getopt_long_only shall return -1");
+
+	/* Test scenario 4 */
+	argv = (char **)argv4;
+	state = state_init;
+	c = getopt_long_only_r(argc4, argv, accepted_opt, long_options, &option_index, &state);
+	zassert_equal(verbose_flag, 0, "verbose flag expected");
+	c = getopt_long_only_r(argc4, argv, accepted_opt, long_options, &option_index, &state);
+
+	/* Function was called with option '-l'. It is expected it will be
+	 * evaluated to '--long' which has flag 'e'.
+	 */
+	zassert_equal('e', c, "unexpected option");
+	c = getopt_long_only_r(argc4, argv, accepted_opt, long_options, &option_index, &state);
 }


### PR DESCRIPTION
Replace the Zephyr-specific re-entrant getopt family APIs with those from newlib. This allows use of the newlib and picolibc native implementations and provides a cleaner re-entrant mechanism, using a local variable to hold the getopt state instead of having a thread-local variabled tucked away in the shell context.

This will require changing all re-entrant users of getopt, switching from the Zephyr-style interfaces to the newlib-style.