### PR TITLE
libc: minimal: add missing ctype.h functions

### DIFF
--- a/lib/libc/minimal/include/ctype.h
+++ b/lib/libc/minimal/include/ctype.h
@@ -15,42 +15,47 @@ extern "C" {
 
 static inline int isupper(int a)
 {
-	return (int)(((unsigned int)(a)-(unsigned int)'A') < 26U);
+	return (int)(((int)'A' <= a) && (a <= (int)'Z'));
 }
 
 static inline int isalpha(int c)
 {
-	return (int)((((unsigned int)c|32u)-(unsigned int)'a') < 26U);
+	/* force to lowercase */
+	c += 32U;
+
+	return (int)(((int)'a' <= c) && (c <= (int)'z'));
 }
 
 static inline int isspace(int c)
 {
-	return (int)(c == (int)' ' || ((unsigned int)c-(unsigned int)'\t') < 5U);
+	return (int)((c == (int)' ') || (((int)'\t' <= c) && (c <= (int)'\r')));
 }
 
 static inline int isgraph(int c)
 {
-	return (int)((((unsigned int)c) > ' ') &&
-			(((unsigned int)c) <= (unsigned int)'~'));
+	return (int)(((int)' ' < c) && (c <= (int)'~'));
 }
 
 static inline int isprint(int c)
 {
-	return (int)((((unsigned int)c) >= ' ') &&
-			(((unsigned int)c) <= (unsigned int)'~'));
+	return (int)(((int)' ' <= c) && (c <= (int)'~'));
 }
 
 static inline int isdigit(int a)
 {
-	return (int)(((unsigned int)(a)-(unsigned int)'0') < 10U);
+	return (int)(((int)'0' <= a) && (a <= (int)'9'));
 }
 
 static inline int isxdigit(int a)
 {
-	unsigned int ua = (unsigned int)a;
+	if (isdigit(a) != 0) {
+		return 1;
+	}
 
-	return (int)(((ua - (unsigned int)'0') < 10U) ||
-			((ua | 32U) - (unsigned int)'a' < 6U));
+	/* force to lowercase */
+	a += 32U;
+
+	return (int)(((int)'a' <= a) && (a <= (int)'f'));
 }
 
 static inline int tolower(int chr)

--- a/lib/libc/minimal/include/ctype.h
+++ b/lib/libc/minimal/include/ctype.h
@@ -15,35 +15,35 @@ extern "C" {
 
 static inline int isupper(int a)
 {
-	return (int)(((int)'A' <= a) && (a <= (int)'Z'));
+	return (('A' <= a) && (a <= 'Z'));
 }
 
 static inline int isalpha(int c)
 {
 	/* force to lowercase */
-	c += 32U;
+	c |= 32;
 
-	return (int)(((int)'a' <= c) && (c <= (int)'z'));
+	return (('a' <= c) && (c <= 'z'));
 }
 
 static inline int isspace(int c)
 {
-	return (int)((c == (int)' ') || (((int)'\t' <= c) && (c <= (int)'\r')));
+	return ((c == ' ') || (('\t' <= c) && (c <= '\r')));
 }
 
 static inline int isgraph(int c)
 {
-	return (int)(((int)' ' < c) && (c <= (int)'~'));
+	return ((' ' < c) && (c <= '~'));
 }
 
 static inline int isprint(int c)
 {
-	return (int)(((int)' ' <= c) && (c <= (int)'~'));
+	return ((' ' <= c) && (c <= '~'));
 }
 
 static inline int isdigit(int a)
 {
-	return (int)(((int)'0' <= a) && (a <= (int)'9'));
+	return (('0' <= a) && (a <= '9'));
 }
 
 static inline int isxdigit(int a)
@@ -53,30 +53,29 @@ static inline int isxdigit(int a)
 	}
 
 	/* force to lowercase */
-	a += 32U;
+	a |= 32;
 
-	return (int)(((int)'a' <= a) && (a <= (int)'f'));
+	return (('a' <= a) && (a <= 'f'));
 }
 
 static inline int tolower(int chr)
 {
-	return (chr >= (int)'A' && chr <= (int)'Z') ? (chr + 32) : (chr);
+	return (chr >= 'A' && chr <= 'Z') ? (chr + 32) : (chr);
 }
 
 static inline int toupper(int chr)
 {
-	return (int)((chr >= (int)'a' && chr <=
-				(int)'z') ? (chr - 32) : (chr));
+	return ((chr >= 'a' && chr <= 'z') ? (chr - 32) : (chr));
 }
 
 static inline int isalnum(int chr)
 {
-	return (int)(isalpha(chr) || isdigit(chr));
+	return (isalpha(chr) || isdigit(chr));
 }
 
 static inline int iscntrl(int c)
 {
-	return (int)((((unsigned int)c) <= 31U) || (((unsigned int)c) == 127U));
+	return ((((unsigned int)c) <= 31U) || (((unsigned int)c) == 127U));
 }
 
 #ifdef __cplusplus

--- a/lib/libc/minimal/include/ctype.h
+++ b/lib/libc/minimal/include/ctype.h
@@ -15,42 +15,42 @@ extern "C" {
 
 static inline int isupper(int a)
 {
-	return (int)(((unsigned)(a)-(unsigned)'A') < 26U);
+	return (int)(((unsigned int)(a)-(unsigned int)'A') < 26U);
 }
 
 static inline int isalpha(int c)
 {
-	return (int)((((unsigned)c|32u)-(unsigned)'a') < 26U);
+	return (int)((((unsigned int)c|32u)-(unsigned int)'a') < 26U);
 }
 
 static inline int isspace(int c)
 {
-	return (int)(c == (int)' ' || ((unsigned)c-(unsigned)'\t') < 5U);
+	return (int)(c == (int)' ' || ((unsigned int)c-(unsigned int)'\t') < 5U);
 }
 
 static inline int isgraph(int c)
 {
-	return (int)((((unsigned)c) > ' ') &&
-			(((unsigned)c) <= (unsigned)'~'));
+	return (int)((((unsigned int)c) > ' ') &&
+			(((unsigned int)c) <= (unsigned int)'~'));
 }
 
 static inline int isprint(int c)
 {
-	return (int)((((unsigned)c) >= ' ') &&
-			(((unsigned)c) <= (unsigned)'~'));
+	return (int)((((unsigned int)c) >= ' ') &&
+			(((unsigned int)c) <= (unsigned int)'~'));
 }
 
 static inline int isdigit(int a)
 {
-	return (int)(((unsigned)(a)-(unsigned)'0') < 10U);
+	return (int)(((unsigned int)(a)-(unsigned int)'0') < 10U);
 }
 
 static inline int isxdigit(int a)
 {
 	unsigned int ua = (unsigned int)a;
 
-	return (int)(((ua - (unsigned)'0') < 10U) ||
-			((ua | 32U) - (unsigned)'a' < 6U));
+	return (int)(((ua - (unsigned int)'0') < 10U) ||
+			((ua | 32U) - (unsigned int)'a' < 6U));
 }
 
 static inline int tolower(int chr)

--- a/lib/libc/minimal/include/ctype.h
+++ b/lib/libc/minimal/include/ctype.h
@@ -26,6 +26,11 @@ static inline int isalpha(int c)
 	return (('a' <= c) && (c <= 'z'));
 }
 
+static inline int isblank(int c)
+{
+	return ((c == ' ') || (c == '\t'));
+}
+
 static inline int isspace(int c)
 {
 	return ((c == ' ') || (('\t' <= c) && (c <= '\r')));
@@ -44,6 +49,11 @@ static inline int isprint(int c)
 static inline int isdigit(int a)
 {
 	return (('0' <= a) && (a <= '9'));
+}
+
+static inline int islower(int c)
+{
+	return (('a' <= c) && (c <= 'z'));
 }
 
 static inline int isxdigit(int a)
@@ -71,6 +81,11 @@ static inline int toupper(int chr)
 static inline int isalnum(int chr)
 {
 	return (isalpha(chr) || isdigit(chr));
+}
+
+static inline int ispunct(int c)
+{
+	return (isgraph(c) && !isalnum(c));
 }
 
 static inline int iscntrl(int c)


### PR DESCRIPTION
Add the functions below to the minimal libc `ctype.h` since they are missing, and are required as of C89 (C99 for `isblank()`)

* `isblank()`
* `islower()`
* `ispunct()`

Fixes #99452