### PR TITLE
maintainers: Add Holt-Sun to NXP Platform Drivers collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3448,6 +3448,7 @@ NXP Platform Drivers:
     - manuargue
     - dbaluta
     - Raymond0225
+    - Holt-Sun
   files-regex:
     - ^drivers/.*nxp.*
     - ^drivers/.*mcux.*


### PR DESCRIPTION
Add Holt-Sun to the NXP drivers area.

- [x] #99459