### PR TITLE
Add 5V power regulators for external outputs on CoreS3/S3-SE

### DIFF
--- a/boards/m5stack/m5stack_cores3/Kconfig.defconfig
+++ b/boards/m5stack/m5stack_cores3/Kconfig.defconfig
@@ -24,19 +24,36 @@ endif # LVGL
 
 # Takes good care of initialization priorities
 
+if REGULATOR_FIXED
+
+# Needs to init after MFD_AW9523B (80), since bus_5v uses aw9523b_gpio.
+config REGULATOR_FIXED_INIT_PRIORITY
+	default 81
+
+endif # REGULATOR_FIXED
+
 if REGULATOR_AXP192_AXP2101
+
+# Needs to init before the display (83), since AXP2101 powers it.
 config REGULATOR_AXP192_AXP2101_INIT_PRIORITY
 	default 81
+
 endif # REGULATOR_AXP192_AXP2101
 
 if MIPI_DBI
+
+# Needs to init after MFD_AW9523B (80), since reset-gpios uses aw9523b_gpio on this board.
 config MIPI_DBI_INIT_PRIORITY
 	default 82
+
 endif # MIPI_DBI
 
 if DISPLAY
+
+# Needs to init after REGULATOR_AXP192_AXP2101 (81) and MIPI_DBI (82).
 config DISPLAY_INIT_PRIORITY
 	default 83
+
 endif # DISPLAY
 
 endif # BOARD_M5STACK_CORES3_ESP32S3_PROCPU || BOARD_M5STACK_CORES3_ESP32S3_PROCPU_SE

--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
@@ -69,6 +69,19 @@
 		regulator-name = "bus_5v";
 		enable-gpios = <&aw9523b_gpio 15 GPIO_ACTIVE_HIGH>;
 	};
+
+	bus_out_reg: bus_out {
+		compatible = "regulator-fixed";
+		regulator-name = "bus_out";
+		regulator-boot-on;
+		enable-gpios = <&aw9523b_gpio 1 GPIO_ACTIVE_HIGH>;
+	};
+
+	usb_otg_reg: usb_otg {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_otg";
+		enable-gpios = <&aw9523b_gpio 5 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &usb_serial {

--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
@@ -63,6 +63,12 @@
 			rotation = <0>;
 		};
 	};
+
+	bus_5v: bus_5v {
+		compatible = "regulator-fixed";
+		regulator-name = "bus_5v";
+		enable-gpios = <&aw9523b_gpio 15 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &usb_serial {


### PR DESCRIPTION
This PR models all GPIO-controlled 5V rails on the M5Stack CoreS3/CoreS3-SE as fixed regulators: `bus_5v`, `bus_out_reg`, and `usb_otg_reg`.

The `bus_5v` regulator matches the equivalent node present on the M5Stack Core2 (#67280).

The `bus_out_reg` and `usb_otg_reg` regulators expose the two load switches that control the direction of 5V power between the USB-C port, the battery, and the M-Bus/Grove connectors, as summarized below:

| `BUS_OUT_EN` | `USB_OTG_EN` | Battery   | USB-OTG | M-Bus/Grove |
|--------------|--------------|-----------|---------|-------------|
| 0            | 0            | Charging  | Input   | Input       |
| 1            | 0            | Charging  | Input   | Output      |
| 0            | 1            | Charging  | Output  | Input       |
| 1            | 1            | Discharge | Output  | Output      |

The `bus_out_reg` regulator is enabled by default to match the behavior of existing M5Stack boards. `usb_otg_reg` remains disabled by default, as the ESP32-S3 does not currently support USB host mode.