### PR TITLE
drivers: watchdog: siwx91x: Fix pause in sleep

### DIFF
--- a/drivers/watchdog/wdt_silabs_siwx91x.c
+++ b/drivers/watchdog/wdt_silabs_siwx91x.c
@@ -149,10 +149,6 @@ static int siwx91x_wdt_setup(const struct device *dev, uint8_t options)
 		return -ENOTSUP;
 	}
 
-	if (options & (WDT_OPT_PAUSE_IN_SLEEP)) {
-		return -ENOTSUP;
-	}
-
 	RSI_WWDT_ConfigSysRstTimer(config->reg, data->delay_reset);
 	RSI_WWDT_ConfigIntrTimer(config->reg, data->delay_irq);
 

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -162,3 +162,9 @@ tests:
     platform_allow:
       - frdm_mcxw23
       - mcxw23_evk
+  drivers.watchdog.pm_enabled:
+    platform_allow:
+      - siwx917_rb4338a
+    extra_configs:
+      - CONFIG_PM=y
+      - CONFIG_PM_DEVICE=y


### PR DESCRIPTION
- The watchdog timer on Siwx91x devices is designed to pause during deep-sleep and resume after wakeup.
However, an incorrect check in`wdt_setup` was preventing this intended behavior. Remove the check, restoring the correct pause-in-sleep functionality.

- Add a configuration file for the siwx917_rb4338a and siwx917_rb4342a boards to run the test_wdt_enable_wait_mode
test with power management enabled.