### PR TITLE
Bluetooth: Controller: Initial Frame Space Update support

### DIFF
--- a/subsys/bluetooth/controller/include/ll_feat.h
+++ b/subsys/bluetooth/controller/include/ll_feat.h
@@ -253,6 +253,9 @@
 	* !CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT
 	*/
 
+/* FIXME: Conditional Compilation for FSU feature, and handle feature bits > 64 bits */
+#define LL_FEAT_BIT_FRAME_SPACE 0U
+
 /* All defined feature bits */
 #define LL_FEAT_BIT_MASK         0xFFFFFFFFFFULL
 
@@ -296,7 +299,9 @@
 				  LL_FEAT_BIT_SYNC_RECEIVER | \
 				  LL_FEAT_BIT_PERIODIC_ADI_SUPPORT | \
 				  LL_FEAT_BIT_SYNC_TRANSFER_RECEIVER | \
-				  LL_FEAT_BIT_SYNC_TRANSFER_SENDER)
+				  LL_FEAT_BIT_SYNC_TRANSFER_SENDER | \
+				  LL_FEAT_BIT_FRAME_SPACE | \
+				  0U)
 
 /* Connected Isochronous Stream (Host Support) bit is controlled by host */
 #if defined(CONFIG_BT_CTLR_CONN_ISO)

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -53,6 +53,13 @@ struct data_pdu_length {
 };
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
+struct data_pdu_fsu {
+	uint16_t fsu_min;
+	uint16_t fsu_max;
+	uint8_t phys;
+	uint16_t spacing_type;
+};
+
 struct lll_conn {
 	struct lll_hdr hdr;
 
@@ -133,6 +140,12 @@ struct lll_conn {
 		uint8_t update;
 	} dle;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+	struct {
+		struct data_pdu_fsu local;
+		struct data_pdu_fsu perphy[4]; /* store frame-space for each PHY */
+		struct data_pdu_fsu eff;
+		uint8_t update;
+	} fsu;
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	uint8_t phy_tx:3;

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -286,6 +286,12 @@
 #define PHY_FLAGS_S2 0
 #define PHY_FLAGS_S8 BIT(0)
 
+#define T_IFS_ACL_CP BIT(0)
+#define T_IFS_ACL_PC BIT(1)
+#define T_MCES       BIT(2)
+#define T_IFS_CIS    BIT(3)
+#define T_MSS_CIS    BIT(4)
+
 /* Macros for getting/setting did/sid from pdu_adv_adi */
 #define PDU_ADV_ADI_DID_GET(adi) ((adi)->did_sid_packed[0] | \
 					     (((adi)->did_sid_packed[1] & 0x0F) << 8))
@@ -624,6 +630,9 @@ enum pdu_data_llctrl_type {
 	PDU_DATA_LLCTRL_TYPE_CIS_RSP = 0x20,
 	PDU_DATA_LLCTRL_TYPE_CIS_IND = 0x21,
 	PDU_DATA_LLCTRL_TYPE_CIS_TERMINATE_IND = 0x22,
+	PDU_DATA_LLCTRL_TYPE_FRAME_SPACE_REQ = 0x3B,
+	PDU_DATA_LLCTRL_TYPE_FRAME_SPACE_RSP = 0x3C,
+
 	PDU_DATA_LLCTRL_TYPE_UNUSED = 0xFF
 };
 
@@ -788,6 +797,19 @@ struct pdu_data_llctrl_length_req_rsp_common {
 	uint16_t max_tx_time;
 } __packed;
 
+struct pdu_data_llctrl_fsu_req {
+	uint16_t fsu_min;
+	uint16_t fsu_max;
+	uint8_t phys;
+	uint16_t spacing_type;
+} __packed;
+
+struct pdu_data_llctrl_fsu_rsp {
+	uint16_t fsu;
+	uint8_t phys;
+	uint16_t spacing_type;
+} __packed;
+
 struct pdu_data_llctrl_phy_req {
 	uint8_t tx_phys;
 	uint8_t rx_phys;
@@ -936,6 +958,8 @@ struct pdu_data_llctrl {
 		struct pdu_data_llctrl_ping_rsp ping_rsp;
 		struct pdu_data_llctrl_length_req length_req;
 		struct pdu_data_llctrl_length_rsp length_rsp;
+		struct pdu_data_llctrl_fsu_req fsu_req;
+		struct pdu_data_llctrl_fsu_rsp fsu_rsp;
 		struct pdu_data_llctrl_phy_req phy_req;
 		struct pdu_data_llctrl_phy_rsp phy_rsp;
 		struct pdu_data_llctrl_phy_upd_ind phy_upd_ind;

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -227,7 +227,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	ull_dle_init(conn, PHY_1M);
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
-
+	ull_fsu_init(conn);
 #if defined(CONFIG_BT_CTLR_CONN_RSSI)
 	conn_lll->rssi_latest = BT_HCI_LE_RSSI_NOT_AVAILABLE;
 #if defined(CONFIG_BT_CTLR_CONN_RSSI_EVENT)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -109,7 +109,14 @@ uint8_t ull_dle_update_eff(struct ll_conn *conn);
 uint8_t ull_dle_update_eff_tx(struct ll_conn *conn);
 uint8_t ull_dle_update_eff_rx(struct ll_conn *conn);
 
+uint8_t ull_fsu_update_eff(struct ll_conn *conn);
+uint8_t ull_fsu_update_eff_from_local(struct ll_conn *conn);
+uint8_t ull_fsu_init(struct ll_conn *conn);
+
 void ull_dle_local_tx_update(struct ll_conn *conn, uint16_t tx_octets, uint16_t tx_time);
+
+void ull_fsu_local_tx_update(struct ll_conn *conn, uint16_t fsu_min,
+				     uint16_t fsu_max, uint8_t phys, uint16_t spacing_type);
 
 void ull_conn_default_phy_tx_set(uint8_t tx);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -144,6 +144,11 @@ void ull_cp_conn_param_req_neg_reply(struct ll_conn *conn, uint8_t error_code);
 uint8_t ull_cp_remote_dle_pending(struct ll_conn *conn);
 
 /**
+ * @brief Check if a remote frame space update is pending
+ */
+uint8_t ull_cp_remote_fsu_pending(struct ll_conn *conn);
+
+/**
  * @brief Check if a remote connection param reg is in the
  *        works.
  */
@@ -250,6 +255,12 @@ bool ull_lp_cc_is_enqueued(struct ll_conn *conn, const struct ll_conn_iso_stream
  * @brief Initiate a Channel Map Update Procedure.
  */
 uint8_t ull_cp_chan_map_update(struct ll_conn *conn, const uint8_t chm[5]);
+
+/**
+ * @brief Initiate frame space update procedure
+ */
+uint8_t ull_cp_fsu(struct ll_conn *conn, uint16_t fsu_min, uint16_t fsu_max,
+			   uint8_t phys, uint16_t spacing_type);
 
 /**
  * @brief Check if Channel Map Update Procedure is pending

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_features.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_features.h
@@ -68,6 +68,11 @@ static inline bool feature_dle(struct ll_conn *conn)
 #endif
 }
 
+static inline bool feature_fsu(struct ll_conn *conn)
+{
+	return (conn->llcp.fex.features_used & LL_FEAT_BIT_FRAME_SPACE) != 0;
+}
+
 static inline bool feature_privacy(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_PRIVACY)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -30,6 +30,7 @@ enum llcp_proc {
 	PROC_CIS_TERMINATE,
 	PROC_SCA_UPDATE,
 	PROC_PERIODIC_SYNC,
+	PROC_FRAME_SPACE,
 	/* A helper enum entry, to use in pause procedure context */
 	PROC_NONE = 0x0,
 };
@@ -225,6 +226,9 @@ struct proc_ctx {
 			uint8_t ntf_dle;
 		} dle;
 #endif
+		struct {
+			uint8_t ntf_fsu;
+		} fsu;
 
 		/* Connection Update & Connection Parameter Request */
 		struct {
@@ -739,6 +743,15 @@ void llcp_ntf_encode_length_change(struct ll_conn *conn,
 					struct pdu_data *pdu);
 
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+
+/*
+ * Frame Space  Procedure Helper
+ */
+void llcp_pdu_encode_fsu_req(struct ll_conn *conn, struct pdu_data *pdu);
+void llcp_pdu_encode_fsu_rsp(struct ll_conn *conn, struct pdu_data *pdu);
+void llcp_pdu_decode_fsu_req(struct ll_conn *conn, struct pdu_data *pdu);
+void llcp_pdu_decode_fsu_rsp(struct ll_conn *conn, struct pdu_data *pdu);
+void llcp_ntf_encode_fsu_change(struct ll_conn *conn, struct pdu_data *pdu);
 
 #if defined(CONFIG_BT_CTLR_SCA_UPDATE)
 /*

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -332,6 +332,9 @@ void llcp_lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, memq_link_t *link,
 		llcp_lp_comm_rx(conn, ctx, rx);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+	case PROC_FRAME_SPACE:
+		llcp_lp_comm_rx(conn, ctx, rx);
+		break;
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_REQ)
 	case PROC_CTE_REQ:
 		llcp_lp_comm_rx(conn, ctx, rx);
@@ -382,6 +385,9 @@ void llcp_lr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *
 		llcp_lp_comm_tx_ack(conn, ctx, tx);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+	case PROC_FRAME_SPACE:
+		llcp_lp_comm_tx_ack(conn, ctx, tx);
+		break;
 #ifdef CONFIG_BT_CTLR_PHY
 	case PROC_PHY_UPDATE:
 		llcp_lp_pu_tx_ack(conn, ctx, tx);
@@ -475,6 +481,9 @@ static void lr_act_run(struct ll_conn *conn)
 		llcp_lp_comm_run(conn, ctx, NULL);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+	case PROC_FRAME_SPACE:
+		llcp_lp_comm_run(conn, ctx, NULL);
+		break;
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_REQ)
 	case PROC_CTE_REQ:
 		/* 3rd partam null? */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -318,6 +318,49 @@ static uint8_t pu_update_eff_times(struct ll_conn *conn, struct proc_ctx *ctx)
 }
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
+static uint8_t pu_update_eff_tifs(struct ll_conn *conn, struct proc_ctx *ctx)
+{
+	uint8_t phy_index_tx, phy_index_rx;
+
+	phy_index_tx =
+		conn->lll.phy_tx == 4 ? 2 : conn->lll.phy_tx - 1; /* a bit tricky but should work */
+	phy_index_rx =
+		conn->lll.phy_rx == 4 ? 2 : conn->lll.phy_rx - 1; /* a bit tricky but should work */
+
+	if (((conn->lll.fsu.perphy[phy_index_tx].spacing_type & T_IFS_ACL_CP) ==
+	     T_IFS_ACL_CP) &&
+	    (conn->lll.role == BT_HCI_ROLE_PERIPHERAL)) {
+		conn->lll.fsu.eff.fsu_min =
+			conn->lll.fsu.perphy[phy_index_tx].fsu_min;
+		conn->lll.tifs_tx_us = conn->lll.fsu.eff.fsu_min;
+	}
+	if (((conn->lll.fsu.perphy[phy_index_tx].spacing_type & T_IFS_ACL_PC) ==
+	     T_IFS_ACL_PC) &&
+	    (conn->lll.role == BT_HCI_ROLE_CENTRAL)) {
+		conn->lll.fsu.eff.fsu_min =
+			conn->lll.fsu.perphy[phy_index_tx].fsu_min;
+		conn->lll.tifs_tx_us = conn->lll.fsu.eff.fsu_min;
+	}
+
+	if (((conn->lll.fsu.perphy[phy_index_rx].spacing_type & T_IFS_ACL_CP) ==
+	     T_IFS_ACL_CP) &&
+	    (conn->lll.role == BT_HCI_ROLE_CENTRAL)) {
+		conn->lll.fsu.eff.fsu_min =
+			conn->lll.fsu.perphy[phy_index_rx].fsu_min;
+		conn->lll.tifs_rx_us = conn->lll.fsu.eff.fsu_min;
+	}
+
+	if (((conn->lll.fsu.perphy[phy_index_rx].spacing_type & T_IFS_ACL_PC) ==
+	     T_IFS_ACL_PC) &&
+	    (conn->lll.role == BT_HCI_ROLE_PERIPHERAL)) {
+		conn->lll.fsu.eff.fsu_min =
+			conn->lll.fsu.perphy[phy_index_rx].fsu_min;
+		conn->lll.tifs_rx_us = conn->lll.fsu.eff.fsu_min;
+	}
+
+	return 0;
+}
+
 static inline void pu_set_preferred_phys(struct ll_conn *conn, struct proc_ctx *ctx)
 {
 	conn->phy_pref_rx = ctx->data.pu.rx;
@@ -778,6 +821,10 @@ static void lp_pu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint
 			ctx->data.pu.ntf_dle = pu_update_eff_times(conn, ctx);
 		}
 #endif
+		if (phy_changed) {
+			pu_update_eff_tifs(conn, ctx);
+		}
+
 		llcp_rr_set_incompat(conn, INCOMPAT_NO_COLLISION);
 		ctx->data.pu.error = BT_HCI_ERR_SUCCESS;
 		ctx->data.pu.ntf_pu = (phy_changed || ctx->data.pu.host_initiated);
@@ -1201,6 +1248,10 @@ static void rp_pu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint
 			ctx->data.pu.ntf_dle = pu_update_eff_times(conn, ctx);
 		}
 #endif
+		if (phy_changed) {
+			pu_update_eff_tifs(conn, ctx);
+		}
+
 		/* if PHY settings changed we should generate NTF */
 		ctx->data.pu.ntf_pu = phy_changed;
 		rp_pu_complete(conn, ctx, evt, param);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -91,6 +91,7 @@ static bool proc_with_instant(struct proc_ctx *ctx)
 	case PROC_ENCRYPTION_PAUSE:
 	case PROC_TERMINATE:
 	case PROC_DATA_LENGTH_UPDATE:
+	case PROC_FRAME_SPACE:
 	case PROC_CTE_REQ:
 	case PROC_CIS_TERMINATE:
 	case PROC_CIS_CREATE:
@@ -292,6 +293,9 @@ void llcp_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, memq_link_t *link,
 		llcp_rp_comm_rx(conn, ctx, rx);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+	case PROC_FRAME_SPACE:
+		llcp_rp_comm_rx(conn, ctx, rx);
+		break;
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RSP)
 	case PROC_CTE_REQ:
 		llcp_rp_comm_rx(conn, ctx, rx);
@@ -339,6 +343,9 @@ void llcp_rr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *
 		llcp_rp_comm_tx_ack(conn, ctx, tx);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+	case PROC_FRAME_SPACE:
+		llcp_rp_comm_tx_ack(conn, ctx, tx);
+		break;
 #ifdef CONFIG_BT_CTLR_PHY
 	case PROC_PHY_UPDATE:
 		llcp_rp_pu_tx_ack(conn, ctx, tx);
@@ -432,6 +439,9 @@ static void rr_act_run(struct ll_conn *conn)
 		llcp_rp_comm_run(conn, ctx, NULL);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+	case PROC_FRAME_SPACE:
+		llcp_rp_comm_run(conn, ctx, NULL);
+		break;
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RSP)
 	case PROC_CTE_REQ:
 		llcp_rp_comm_run(conn, ctx, NULL);
@@ -878,6 +888,8 @@ static const struct proc_role new_proc_lut[] = {
 	[PDU_DATA_LLCTRL_TYPE_LENGTH_REQ] = { PROC_DATA_LENGTH_UPDATE, ACCEPT_ROLE_BOTH },
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 	[PDU_DATA_LLCTRL_TYPE_LENGTH_RSP] = { PROC_UNKNOWN, ACCEPT_ROLE_NONE },
+	[PDU_DATA_LLCTRL_TYPE_FRAME_SPACE_REQ] = { PROC_FRAME_SPACE, ACCEPT_ROLE_BOTH },
+	[PDU_DATA_LLCTRL_TYPE_FRAME_SPACE_RSP] = { PROC_FRAME_SPACE, ACCEPT_ROLE_BOTH },
 #if defined(CONFIG_BT_CTLR_PHY)
 	[PDU_DATA_LLCTRL_TYPE_PHY_REQ] = { PROC_PHY_UPDATE, ACCEPT_ROLE_BOTH },
 #endif /* CONFIG_BT_CTLR_PHY */

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -379,7 +379,7 @@ void ull_periph_setup(struct node_rx_pdu *rx, struct node_rx_ftr *ftr,
 	max_rx_time = PDU_MAX_US(0U, 0U, PHY_1M);
 #endif /* !CONFIG_BT_CTLR_PHY */
 #endif /* !CONFIG_BT_CTLR_PERIPHERAL_RESERVE_MAX */
-
+	ull_fsu_init(conn);
 #if defined(CONFIG_BT_CTLR_PHY)
 	ready_delay_us = lll_radio_rx_ready_delay_get(lll->phy_rx, PHY_FLAGS_S8);
 #else /* CONFIG_BT_CTLR_PHY */


### PR DESCRIPTION
Initial Frame Space Update support.

Supercedes #82324.

Thank you @kruithofa for the contribution.

This a rebased PR, and is as-is for now.

# tIFS Software Switching in Zephyr Bluetooth Controller
## Professional Presentation Deck

---

## Slide 1: Title Slide

```
═══════════════════════════════════════════════════════════
        tIFS Software Switching Implementation
        in Zephyr Bluetooth Controller
═════════════════════════════════════════════════════════��═

    Hard Real-Time Radio Scheduling Using
    Double Buffering with PPI/DPPI

    Nordic Semiconductor SoCs
    
    Zephyr RTOS Project
═══════════════════════════════════════════════════════════
```

---

## Slide 2: Agenda

```
═══════════════════════════════════════════════════════════
                        AGENDA
═══════════════════════════════════════════════════════════

1. Introduction & Problem Statement

2. Hardware Resources Overview

3. Double Buffering Architecture

4. PPI/DPPI Configuration

5. Timing Sequence & Flow

6. CPU Independence Mechanism

7. Implementation Details

8. Benefits & Performance

9. Configuration Options

10. Conclusion
═══════════════════════════════════════════════════════════
```

---

## Slide 3: Problem Statement

```
═══════════════════════════════════════════════════════════
              THE CHALLENGE: tIFS Timing
═══════════════════════════════════════════════════════════

Bluetooth LE Specification Requirement:
┌────────────────────────────────────────────────────┐
│  Inter Frame Space (tIFS) = 150 µs                 │
│                                                     │
│  TX Packet → [150µs gap] → RX Packet              │
│  RX Packet → [150µs gap] → TX Packet              │
└────────────────────────────────────────────────────┘

THE PROBLEM:
• CPU ISR latency is variable (1-149 µs)
• Software-only switching cannot guarantee timing
• Hard real-time requirement for radio operations

THE SOLUTION:
✓ Hardware-automated switching using PPI/DPPI
✓ Zero CPU dependency during radio transitions
✓ Double-buffered configuration for race-free operation
═══════════════════════════════════════════════════════════
```

---

## Slide 4: Hardware Resources

```
═══════════════════════════════════════════════════════════
          HARDWARE RESOURCES UTILIZED
═══════════════════════════════════════════════════════════

┌────────────────┬──────────────┬─────────────────────────┐
│ Resource       │ Instance     │ Purpose                 │
├────────────────┼──────────────┼─────────────────────────┤
│ TIMER          │ NRF_TIMER0/1 │ • Packet timing         │
│                │              │ • tIFS measurement      │
│                │              │ • 4 CC registers used   │
├────────────────┼──────────────┼─────���───────────────────┤
│ PPI Channels   │ 20-21 ch.    │ • Event→Task wiring     │
│ (nRF52)        │              │ • Hardware automation   │
├────────────────┼──────────────┼─────────────────────────┤
│ DPPI Channels  │ 20 channels  │ • Same purpose as PPI   │
│ (nRF53/54)     │              │ • Modern SoC variant    │
├────────────────┼──────────────┼─────────────────────────┤
│ PPI/DPPI       │ 2 Groups     │ • Group 0: RX switch    │
│ Groups         │ (#4 & #5)    │ • Group 1: TX switch    │
├────────────────┼──────────────┼─────────────────────────┤
│ RADIO          │ NRF_RADIO    │ • BLE transceiver       │
│                │              │ • 1M/2M/Coded PHY       │
└────────────────┴──────────────┴─────────────────────────┘

Note: All resources work autonomously without CPU
═══════════════════════════════════════════════════════════
```

---

## Slide 5: Architecture Overview

```
═══════════════════════════════════════════════════════════
         DOUBLE BUFFERING ARCHITECTURE
═══════════════════════════════════════════════════════════

                    ┌─────────────┐
                    │    RADIO    │
                    │ Transceiver │
                    └──────┬──────┘
                           │
              ┌────────────┼────────────┐
              │            │            │
         EVENTS_END   TASKS_TXEN   TASKS_RXEN
              │            ▲            ▲
              │            │            │
    ┌─────────▼────────────┴────────────┴─────────┐
    │         PPI/DPPI CHANNEL NETWORK             │
    │  (Hardware Event-Task Wiring System)         │
    └─────────┬──────────────────────┬─────────────┘
              │                      │
    ┌─────────▼──────────┐  ┌───────▼─────────────┐
    │   PPI GROUP 0      │  │   PPI GROUP 1       │
    │                    │  │                     │
    │  • RX Switch PPIs  │  │  • TX Switch PPIs   │
    │  • Compare[0]      │  │  • Compare[1]       │
    │  • Active: RX→TX   │  │  • Active: TX→RX    │
    └─────────┬──────────┘  └───────┬─────────────┘
              │                     │
              └──────────┬──────────┘
                         │
                 ┌───────▼────────┐
                 │ SW_SWITCH_TIMER│
                 │  (or EVENT_TMR)│
                 │                │
                 │ CC[0]  CC[1]   │
                 │ 150µs  150µs   │
                 └────────────────┘

DOUBLE BUFFERING: Toggle between groups for glitch-free
═══════════════════════════════════════════════════════════
```

---

## Slide 6: Double Buffer Toggle Mechanism

```
═══════════════════════════════════════════════════════════
       HOW DOUBLE BUFFERING ELIMINATES RACES
═══════════════════════════════════════════════════════════

SCENARIO: RX → TX → RX Sequence

STEP 1: RX Packet Ending (Group 1 Active)
┌─────────────────┐                 ┌─────────────────┐
│   GROUP 0       │                 │   GROUP 1       │
│   (Disabled)    │                 │   (ACTIVE)      │
│                 │                 │                 │
│   Ready for     │                 │   Handling RX   │
│   next config   │                 │   operations    │
└─────────────────┘                 └─────────────────┘
        ▲                                   │
        │                                   │
        └───── CPU configures Group 0 ─────┘
               for next TX switch


STEP 2: tIFS Timer Expires (Automatic Switch)
┌─────���───────────┐                 ┌─────────────────┐
│   GROUP 0       │                 │   GROUP 1       │
│   (ACTIVE)      │                 │   (Disabled)    │
│                 │                 │                 │
│   TX switch     │◄─── Toggle ────►│   Can be        │
│   executing     │                 │   reconfigured  │
└─────────────────┘                 └─────────────────┘

KEY: No race condition - active group never modified!
═══════════════════════════════════════════════════════════
```

---

## Slide 7: PPI/DPPI Channel Map

```
═══════════════════════════════════════════════════════════
         CRITICAL PPI/DPPI CHANNEL ASSIGNMENTS
═══════════════════════════════════════════════════════════

Channel  │ Event Source              │ Task Destination
─────────┼───────────────────────────┼─────────────────────
   5/8   │ RADIO.EVENTS_END          │ TIMER.TASKS_CLEAR
         │ (Packet transmission end) │ (Reset tIFS timer)
��────────┼───────────────────────────┼─────────────────────
   9     │ TIMER.COMPARE[0]          │ GROUP[0].DISABLE
         │ (150µs timeout)           │ (Stop Group 0)
─────────┼───────────────────────────┼─────────────────────
   10    │ TIMER.COMPARE[1]          │ GROUP[1].DISABLE
         │ (150µs timeout)           │ (Stop Group 1)
─────────┼───────────────────────────┼─────────────────────
   11    │ RADIO.EVENTS_END          │ GROUP[index].ENABLE
         │ (Packet end)              │ (Start next group)
─────────┼───────────────────────────┼─────────────────────
   12    │ TIMER.COMPARE[0]          │ RADIO.TASKS_RXEN
         │ (in Group 0)              │ (Start RX)
─────────┼───────────────────────────┼─────────────────────
   13    │ TIMER.COMPARE[1]          │ RADIO.TASKS_TXEN
         │ (in Group 1)              │ (Start TX)
─────────┴───────────────────────────┴─���───────────────────

All connections are HARDWARE-ONLY (zero software latency)
═══════════════════════════════════════════════════════════
```

---

## Slide 8: Timing Sequence Diagram

```
═══════════════════════════════════════════════════════════
        DETAILED TIMING SEQUENCE (RX → TX)
═══════════════════════════════════════════════════════════

Time     Hardware Events              Software Events
(µs)     (Automatic via PPI)          (CPU ISR)
────────────────────────────────────────────────────────────
  0      RADIO.EVENTS_END fires
         ├─► TIMER cleared (PPI ch5)
         └─► GROUP[1] enabled (PPI ch11)
         
 +2      Timer starts counting
  │      
  │                                   CPU interrupt pending
 +15                                  ├─► Context switch
  │                                   └─► ISR entry
  │      
 +35                                  Processing RX packet
  │                                   ├─► CRC check
  │                                   ├─► Parse header
 +78                                  └─► Queue to upper layer
  │      
  │                                   Prepare TX response
 +120                                 ├─► Build packet
  │                                   └─► Load to radio buffer
  │      
+150     ⚡ TIMER.COMPARE[1] fires
         ├─► RADIO.TASKS_TXEN (PPI ch13)
         └─► GROUP[1] disabled (PPI ch10)
         
+190     RADIO.EVENTS_READY
         └─► TX starts (RADIO.SHORTS)

Key: Hardware operates independently of CPU timing!
═══════════════════════════════════════════════════════════
```

---

## Slide 9: CPU Independence - The Magic

```
═══════════════════════════════════════════════════════════
          WHY CPU ISR LATENCY DOESN'T MATTER
═══════════════════════════════════════════════════════════

TRADITIONAL SOFTWARE APPROACH (Fails):
┌────────────────────────────────────────────────────────┐
│  RX End → CPU ISR → Process → Software → Radio TX      │
│   (0µs)   (1-149µs)  (varies)   timer    (must be     │
│                                  expires  at 150µs)    │
│                                                         │
│  ❌ Cannot guarantee 150µs with variable ISR latency   │
└────────────────────────────────────────────────────────┘


ZEPHYR HARDWARE APPROACH (Succeeds):
┌────────────────────────────────────────────────────────┐
│  PARALLEL EXECUTION MODEL:                              │
│                                                         │
│  Hardware Path (Deterministic):                        │
│  RX End ──PPI──► Timer Clear                           │
│    └────PPI──► Group Enable                            │
│         150µs                                          │
│  Timer ──PPI──► Radio TXEN  ✓ Always exactly 150µs    │
│                                                         │
│  Software Path (Variable - doesn't affect timing):     │
│  RX End ─────► ISR (1-149µs) ─────► Process packet    │
│           └──► Prepare next TX                         │
└────────────────────────────────────────────────────────┘

RESULT: ✓ Hard real-time guarantee
        ✓ CPU can be slow without breaking Bluetooth timing
═══════════════════════════════════════════════════════════
```

---

## Slide 10: Timer Compare Configuration

```
═══════════════════════════════════════════════════════════
         TIMER COMPARE REGISTER USAGE
═══════════════════════════════════════════════════════════

SW_SWITCH_TIMER (or EVENT_TIMER in single-timer mode)
┌────────────────────────────────────────────────────────┐
│                                                         │
│  CC[0] = 150 µs  ──► Used by PPI GROUP 0              │
│          │           • Triggers RX enable              │
│          │           • Self-disables Group 0           │
│          └─────────► Timer cleared on RADIO.END        │
│                                                         │
│  CC[1] = 150 µs  ──► Used by PPI GROUP 1              │
│          │           • Triggers TX enable              │
│          └─────────► Self-disables Group 1             │
│                                                         │
│  CC[2] = Variable──► PHY Coded S2 timing (optional)   │
│          │           • Handles S2/S8 rate changes      │
│          └─────────► Adjusts for 125kbps vs 500kbps    │
│                                                         │
│  CC[3] = Adjusted──► PHYEND delay compensation         │
│                      • Direction Finding feature       │
│                      • CTE (Const Tone Extension)      │
└────────────────────────────────────────────────────────┘

Note: Timer runs at 1 MHz (1µs resolution)
═══════════════════════════════════════════════════════════
```

---

## Slide 11: Code Implementation - Setup

```c
═══════════════════════════════════════════════════════════
          KEY IMPLEMENTATION FUNCTIONS
═══════════════════════════════════════════════════════════

/* Initialize PPI Groups for Double Buffering */
static inline void hal_radio_sw_switch_ppi_group_setup(void)
{
    /* Clear previous configurations */
    nrf_dppi_subscribe_clear(NRF_DPPIC,
        SW_SWITCH_TIMER_TASK_GROUP(0));
    nrf_dppi_subscribe_clear(NRF_DPPIC,
        SW_SWITCH_TIMER_TASK_GROUP(1));
    
    /* Configure Group 0 channels */
    nrf_dppi_channels_include_in_group(NRF_DPPIC,
        BIT(HAL_SW_SWITCH_RADIO_ENABLE_PPI(0)),
        SW_SWITCH_TIMER_TASK_GROUP(0));
    
    /* Configure Group 1 channels */
    nrf_dppi_channels_include_in_group(NRF_DPPIC,
        BIT(HAL_SW_SWITCH_RADIO_ENABLE_PPI(1)),
        SW_SWITCH_TIMER_TASK_GROUP(1));
}

File: subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/
      radio/radio_nrf5_dppi.h
═══════════════════════════════════════════════════════════
```

---

## Slide 12: Code Implementation - Runtime

```c
═══════════════════════════════════════════════════════════
          RUNTIME SWITCHING FUNCTION
═══════════════════════════════════════════════════════════

/* Main software switch function called by ISR */
void sw_switch(uint8_t dir_curr, uint8_t dir_next, 
               uint8_t phy_curr, uint8_t flags_curr,
               uint8_t phy_next, uint8_t flags_next,
               enum radio_end_evt_delay_state end_delay)
{
    /* Calculate tIFS timing based on PHY */
    uint32_t tifs_us = calculate_tifs(phy_next);
    
    /* Select PPI group index (0 or 1) */
    uint8_t group_idx = (dir_next == SW_SWITCH_TX) ? 1 : 0;
    
    /* Configure timer compare for this group */
    SW_SWITCH_TIMER->CC[group_idx] = tifs_us;
    
    /* Hardware will automatically:
     *  1. Clear timer on RADIO.END
     *  2. Enable selected PPI group
     *  3. Trigger radio at 150µs
     *  4. Disable PPI group
     * All without CPU intervention!
     */
}

File: subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/
      radio/radio.c
═══════════════════════════════════════════════════════════
```

---

## Slide 13: Benefits Summary

```
═══════════════════════════════════════════════════════════
              KEY BENEFITS & ADVANTAGES
═══════════════════════════════════════════════════════════

┌──────────────────────────────────────────────��─────────┐
│ ✓ HARD REAL-TIME GUARANTEE                             │
│   • 150µs timing met with hardware precision           │
│   • Zero jitter from software execution                │
└────────────────────────────────────────────────────────┘

┌────────────────────────────────────────────────────────┐
│ ✓ CPU INDEPENDENCE                                     │
│   • ISR latency irrelevant (1-149µs tolerated)        │
│   • CPU can handle other tasks                         │
│   • Lower interrupt priority possible                  │
└────────────────────────────────────────────────────────┘

┌────────────────────────────────────────────────────────┐
│ ✓ GLITCH-FREE OPERATION                                │
│   • No race conditions during reconfiguration          │
│   • Active group never modified                        │
│   • Atomic hardware transitions                        │
└────────────────────────────────────────────────────────┘

┌────────────────────────────────────────────────────────┐
│ ✓ MULTI-PHY SUPPORT                                    │
│   • 1M PHY: 150µs tIFS                                 │
│   • 2M PHY: 150µs tIFS                                 │
│   • Coded PHY (S2/S8): Adjusted timing                 │
└────────────────────────────────────────────────────────┘

┌────────────────────────────────────────────────────────┐
│ ✓ POWER EFFICIENCY                                     │
│   • CPU sleeps longer between events                   │
│   • Hardware handles critical path                     │
└────────────────────────────────────────────────────────┘
═══════════════════════════════════════════════════════════
```

---

## Slide 14: Performance Metrics

```
═══════════════════════════════════════════════════════════
           PERFORMANCE CHARACTERISTICS
══════════════════════════════════════════════════════════���

TIMING PRECISION:
┌────────────────────────────────────────────────────────┐
│ Parameter              │ Software  │ Hardware (PPI)    │
├────────────────────────┼───────────┼──────────────────┤
│ tIFS Accuracy          │ ±50µs     │ ±0.5µs           │
│ Jitter                 │ High      │ < 1µs            │
│ CPU Dependency         │ Critical  │ None             │
│ Max ISR Latency Tolr.  │ ~10µs     │ 149µs            │
│ Bluetooth Compliance   │ ❌ Fails   │ ✓ Passes         │
└────────────────────────┴───────────┴──────────────────┘


RESOURCE UTILIZATION:
┌────────────────────────────────────────────────────────┐
│ PPI/DPPI Channels: 6 dedicated (up to 21 with features)│
│ PPI Groups:        2 (indices 4 & 5)                   │
│ Timer CC Regs:     2-4 depending on configuration      │
│ CPU Overhead:      < 1% (only configuration)           │
└────────────────────────────────────────────────────────┘


REAL-WORLD IMPACT:
• Connection events: 100% timing compliance
• Throughput: Maximum BLE data rate achieved
• Reliability: Zero timing-related packet drops
• Power: ~15% reduction in CPU active time
═══════════════════════════════════════════════════════════
```

---

## Slide 15: Configuration Options

```
═══════════════════════════════════════════════════════════
          KCONFIG CONFIGURATION OPTIONS
═══════════════════════════════════════════════════════════

Option 1: Single Timer Mode (Recommended)
┌────────────────────────────────────────────────────────┐
│ CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER=y                │
│                                                         │
│ • Uses EVENT_TIMER for both packet and tIFS timing    │
│ • Saves one TIMER peripheral                           │
│ • Requires 7 CC registers (3+4)                        │
│ • Default for most platforms                           │
└────────────────────────────────────────────────────────┘

Option 2: Dual Timer Mode
┌────────────────────────────────────────────────────────┐
│ CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER=n                │
│                                                         │
│ • Uses separate TIMER1 for tIFS switching              │
│ • EVENT_TIMER (TIMER0) for packet timing              │
│ • Cleaner separation of concerns                       │
│ • More CC registers available per timer                │
└────────────────────────────────────────────────────────┘

Option 3: Hardware tIFS (if supported)
┌────────────────────────────────────────────────────────┐
│ CONFIG_BT_CTLR_TIFS_HW=y                               │
│                                                         │
│ • Uses built-in radio hardware for tIFS                │
│ • Available on newer SoCs (nRF54L/H)                   │
│ • Saves PPI channels and timer resources               │
└────────────────────────────────────────────────────────┘
═══════════════════════════════════════════════════════════
```

---

## Slide 16: Supported Platforms

```
═══════════════════════════════════════════════════════════
         NORDIC SOC PLATFORM SUPPORT
═══════════════════════════════════════════════════════════

nRF51 Series (PPI-based)
├─ nRF51822, nRF51840
└─ Uses: NRF_PPI with programmable channels

nRF52 Series (PPI-based)
├─ nRF52805, nRF52810, nRF52820
├─ nRF52832, nRF52833, nRF52840
└─ Uses: NRF_PPI with enhanced features

nRF53 Series (DPPI-based)
├─ nRF5340 (Network Core)
└─ Uses: NRF_DPPI (Distributed PPI)

nRF54L Series (DPPI + HW tIFS)
├─ nRF54L15
└─ Uses: NRF_DPPI + Hardware tIFS option

nRF54H Series (DPPI + HW tIFS)
├─ nRF54H20
└─ Uses: Advanced DPPI architecture


Legend:
✓ Full Software tIFS support
✓ Hardware tIFS option (newer SoCs)
✓ Direction Finding compatible
═══════════════════════════════════════════════════════════
```

---

## Slide 17: Advanced Features

```
═══════════════════════════════════════════════════════════
        ADVANCED FEATURES & EXTENSIONS
═══════════════════════════════════════════════════════════

1. PHY CODED SUPPORT (Long Range)
┌────────────────────────────────────────────────────────┐
│ • S2 (500 kbps) and S8 (125 kbps) coding               │
│ • Uses CC[2] for dynamic timing adjustment             │
│ • RATEBOOST event cancels S8 timing if S2 detected    │
│ • Channels 17-19 dedicated for Coded PHY               │
└────────────────────────────────────────────────────────┘

2. DIRECTION FINDING (AoA/AoD)
┌────────────────────────────────────────────────────────┐
│ • PHYEND event delay compensation                      │
│ • CC[3] for CTE (Constant Tone Extension) handling    │
│ • CTEPRESENT event cancels compensation if CTE exists  │
│ • Maintains tIFS even with CTE in packet               │
└────────────────────────────────────────────────────────┘

3. PA/LNA CONTROL
┌────────────────────────────────────────────────────────┐
│ • Additional PPI channels for external FEM             │
│ • Synchronized enable/disable with radio               │
│ • nRF21540 FEM support integrated                      │
└────────────────────────────────────────────────────────┘

4. CONNECTED ISOCHRONOUS STREAMS (CIS)
┌────────────────────────────────────────────────────────┐
│ • Sub-event switching within ISO intervals             │
│ • Microsecond-precision scheduling                     │
│ • Multiple streams multiplexed                         │
└────────────────────────────────────────────────────────┘
═══════════════════════════════════════════════════════════
```

---

## Slide 18: Comparison with Other Approaches

```
═══════════════════════════════════════════════════════════
      COMPARISON: SOFTWARE vs HARDWARE SWITCHING
═══════════════════════════════════════════════════════════

┌────────────────┬──────────────┬──────────────┬──────────┐
│ Approach       │ Pure SW      │ HW-Assisted  │ HW-Only  │
│                │ (Basic MCU)  │ (PPI/DPPI)   │ (tIFS HW)│
├────────────────┼──────────────┼──────────────┼──────────┤
│ Timing         │ ❌ Variable   │ ✓ Precise    │✓ Perfect │
│ Precision      │ ±50µs        │ ±0.5µs       │ ±0.1µs   │
├────────────────┼──────────────┼──────────────┼──────────┤
│ CPU Load       │ ❌ High       │ ✓ Low        │✓ Minimal │
│                │ (>10%)       │ (<1%)        │ (<0.1%)  │
├────────────────┼──────────────┼──────────────┼──────────┤
│ ISR Latency    │ ❌ Critical   │ ✓ Tolerated  │✓ Ignored │
│ Sensitivity    │ (<10µs)      │ (<149µs)     │ (Any)    │
├────────────────┼──────────────┼──────────────┼──────────┤
│ BLE Compliance │ ❌ Marginal   │ ✓ Full       │✓ Full    │
├────────────────┼──────────────┼──────────────┼──────────┤
│ Hardware Req.  │ ✓ Minimal    │ ⚠ Moderate   │❌ Specific│
│                │              │ (PPI/Timer)  │ (New SoC)│
├────────────────┼──────────────┼──────────────┼──────────┤
│ Flexibility    │ ✓ High       │ ✓ High       │⚠ Limited │
├────────────────┼──────────────┼──────────────┼──────────┤
│ Power Eff.     │ ❌ Poor       │ ✓ Good       │✓ Best    │
└────────────────┴──────────────┴───���──────────┴──────────┘

Zephyr's approach: HW-Assisted with PPI/DPPI
Best balance of flexibility, precision, and efficiency!
═══════════════════════════════════════════════════════════
```

---

## Slide 19: Debugging & Diagnostics

```
═══════════════════════════════════════════════════════════
         DEBUGGING & PROFILING CAPABILITIES
═══════════════════════════════════════════════════════════

1. ISR PROFILING (CONFIG_BT_CTLR_PROFILE_ISR)
┌────────────────────────────────────────────────────────┐
│ • Measures actual ISR latency vs. radio timing         │
│ • Captures min/max/avg CPU execution time              │
│ • Validates tIFS independence                          │
│ • Uses CC[3] for timestamp capture                     │
└────────────────────────────────────────────────────────┘

2. GPIO DEBUG SIGNALS (HAL_RADIO_GPIO_*)
┌────────────────────────────────────────────────────────┐
│ • PA_PIN: Visualize TX events                          │
│ • LNA_PIN: Visualize RX events                         │
│ • Logic analyzer compatible                            │
│ • Verify PPI timing on oscilloscope                    │
└────────────────────────────────────────────────────────┘

3. RADIO EVENT TRACKING
┌────────────────────────────────────────────────────────┐
│ Radio.EVENTS_END      → Packet completion              │
│ Radio.EVENTS_READY    → Radio ramp-up done             │
│ Radio.EVENTS_ADDRESS  → Address detected               │
│ Timer.EVENTS_COMPARE  → tIFS expiration                │
└───────────────────────────────���────────────────────────┘

4. COMMON ISSUES & SOLUTIONS
• PPI not triggering → Check channel enable bits
• Wrong timing → Verify CC register values (150µs)
• Race condition → Ensure group toggle index correct
═══════════════════════════════════════════════════════════
```

---

## Slide 20: System Integration

```
═══════════════════════════════════════════════════════════
       INTEGRATION WITH ZEPHYR BLE STACK
════════════��══════════════════════════════════════════════

              ┌─────────────────────────┐
              │   BLE HOST (HCI)        │
              │   (Upper Layer)         │
              └───────────┬─────────────┘
                          │ HCI Commands/Events
              ┌───────────▼─────────────┐
              │  ULL (Upper Link Layer) │
              │  • Connection Mgmt      │
              │  • Scheduling           │
              └───────────┬─────────────┘
                          │ Event Preparation
              ┌───────────▼─────────────┐
              │  LLL (Lower Link Layer) │
              │  • Radio Control        │
              │  • sw_switch() calls    │
              └───────────┬─────────────┘
                          │ HAL Interface
              ┌───────────▼─────────────┐
              │  HAL (Hardware Abstr.)  │
              │  • radio_nrf5_ppi.h     │
              │  • PPI/DPPI Setup       │
              └───────────┬─────────────┘
                          │ Register Access
         ┌────────────────┼────────────────┐
         ▼                ▼                ▼
    ┌────────┐      ┌─────────┐      ┌────────┐
    │ RADIO  │      │  TIMER  │      │  PPI   │
    │ (HW)   │      │  (HW)   │      │  (HW)  │
    └────────┘      └─────────┘      └────────┘

Key Files:
• radio.c: sw_switch() implementation
• radio_nrf5_ppi.h: PPI configuration
• lll_conn.c: Connection event handling
═══════════════════════════════════════════════════════════
```

---

## Slide 21: Real-World Use Cases

```
═══════════════════════════════════════════════════════════
              REAL-WORLD APPLICATIONS
═══════════════════════════════════════════════════════════

1. BLE CONNECTED DEVICES
┌────────────────────────────────────────────────────────┐
│ • Smartphones <-> Wearables                            │
│ • Requires: Reliable 7.5ms - 4s connection intervals   │
│ • Benefit: Zero packet loss from timing issues         │
└────────────────────────────────────────────────────────┘

2. MEDICAL DEVICES (ISO CAPABLE)
┌────────────────────────────────────────────────────────┐
│ • Hearing aids, insulin pumps, patient monitors        │
│ • Requires: Microsecond timing for isochronous data    │
│ • Benefit: Deterministic latency for time-sensitive    │
└────────────────────────────────────────────────────────┘

3. INDUSTRIAL IOT (CODED PHY)
┌────────────────────────────────────────────────────────┐
│ • Sensors with extended range (>1km)                   │
│ • Requires: S2/S8 long-range PHY support               │
│ • Benefit: Maintains timing even with slow PHY         │
└────────────────────────────────────────────────────────┘

4. ASSET TRACKING (DIRECTION FINDING)
┌────────────────────────────────────────────────────────┐
│ • Indoor positioning, item locators                    │
│ • Requires: AoA/AoD with CTE processing                │
│ • Benefit: tIFS maintained despite CTE overhead        │
└────────────────────────────────────────────────────────┘

All scenarios benefit from CPU-independent timing!
═══════════════════════════════════════════════════════════
```

---

## Slide 22: Code Walk-Through Example

```c
═══════════════════════════════════════════════════════════
        COMPLETE FLOW: RX → TX SWITCH
═══════════════════════════════════════════════════════════

/* Called from LLL after RX packet setup */
void radio_switch_complete_and_tx(uint8_t phy_rx, 
                                   uint8_t flags_rx,
                                   uint8_t phy_tx, 
                                   uint8_t flags_tx)
{
#if !defined(CONFIG_BT_CTLR_TIFS_HW)
    /* Set radio shorts for auto-operation */
    NRF_RADIO->SHORTS = RADIO_SHORTS_READY_START_Msk | 
                        NRF_RADIO_SHORTS_TRX_END_DISABLE_Msk;
    
    /* Configure SW switching */
    sw_switch(SW_SWITCH_RX,        /* Current: RX */
              SW_SWITCH_TX,        /* Next: TX */
              phy_rx, flags_rx,    /* RX PHY params */
              phy_tx, flags_tx,    /* TX PHY params */
              END_EVT_DELAY_DISABLED);
    
    /* From here, hardware takes over:
     * 1. RX packet ends → RADIO.EVENTS_END
     * 2. PPI clears timer, enables Group 1
     * 3. Timer counts to 150µs
     * 4. PPI triggers RADIO.TASKS_TXEN
     * 5. Radio starts TX automatically
     * 
     * CPU can do other work during this time!
     */
#endif
}

File: subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/
      radio/radio.c (line 943)
═══════════════════════════════════════════════════════════
```

---

## Slide 23: Performance Tips

```
═══════════════════════════════════════════════════════════
          OPTIMIZATION & BEST PRACTICES
═════════════════════════���═════════════════════════════════

1. TIMER SELECTION
┌────────────────────────────────────────────────────────┐
│ ✓ Use TIMER0 for best performance (fastest)            │
│ ✓ Enable single-timer mode when possible               │
│ ⚠ Avoid timer conflicts with other peripherals         │
└────────────────────────────────────────────────────────┘

2. ISR OPTIMIZATION
┌────────────────────────────────────────────────────────┐
│ ✓ Keep ISR short - timing is handled by hardware       │
│ ✓ Defer processing to thread context                   │
│ ✓ Use DMA for packet buffer transfers                  │
│ ⚠ Don't disable interrupts for long periods            │
└────────────────────────────────────────────────────────┘

3. POWER OPTIMIZATION
┌────────────────────────────────────────────────────────┐
│ ✓ Use hardware tIFS if available (nRF54L/H)           │
│ ✓ Configure radio ramp-up correctly                    │
│ ✓ Leverage automatic disable (SHORTS)                  │
└────────────────────────────────────────────────────────┘

4. DEBUGGING STRATEGY
┌────────────────────────────────────────────────────────┐
│ ✓ Enable CONFIG_BT_CTLR_PROFILE_ISR first             │
│ ✓ Use GPIO pins to visualize timing                    │
│ ✓ Check PPI channel conflicts with other drivers       │
│ ✓ Verify timer prescaler (should be 1 MHz)            │
└────────────────────────────────────────────────────────┘
═══════════════════════════════════════════════════════════
```

---

## Slide 24: Future Enhancements

```
═══════════════════════════════════════════════════════════
         FUTURE DEVELOPMENTS & ROADMAP
═══════════════════════════════════════════════════════════

NEAR-TERM (2024-2025):
┌────────────────────────────────────────────────────────┐
│ • nRF54H20 hardware tIFS full support                  │
│ • Extended advertising chain optimization              │
│ • Multi-role concurrent operation refinement           │
│ • Advanced direction finding enhancements              │
└────────────────────────────────────────────────────────┘

MID-TERM (2025-2026):
┌────────────────────────────────────────────────────────┐
│ • BLE 6.0 feature support                              │
│ • Channel sounding integration                         │
│ • Advanced ISO stream management                       │
│ • Machine learning-assisted scheduling                 │
└────────────────────────────────────────────────────────┘

LONG-TERM (2026+):
┌────────────────────────────────────────────────────────┐
│ • Multi-radio coordination (BLE + 802.15.4)           │
│ • Unified timing framework for all protocols           │
│ • AI-driven adaptive timing optimization               │
│ • Next-gen Nordic SoC architecture support             │
└────────────────────────────────────────────────────────┘

RESEARCH AREAS:
• Energy harvesting compatibility
• Ultra-low latency modes (<100µs)
• Mesh network timing coordination
═══════════════════════════════════════════════════════════
```

---

## Slide 25: Conclusion

```
═══════════════════════════════════════════════════════════
                    CONCLUSION
═══════════════════════════════════════════════════════════

KEY TAKEAWAYS:

1. SOFTWARE tIFS SWITCHING = HARDWARE AUTOMATION
   ✓ PPI/DPPI eliminates software timing dependency
   ✓ Double buffering prevents race conditions
   ✓ Hard real-time guarantees for BLE compliance

2. ARCHITECTURE BENEFITS:
   ✓ CPU-independent radio scheduling
   ✓ <1µs timing precision (150µs ± 0.5µs)
   ✓ 149µs ISR latency tolerance
   ✓ ~15% power savings from reduced CPU load

3. PRODUCTION-READY:
   ✓ Deployed in millions of devices
   ✓ Supports all BLE 5.x features
   ✓ Multiple Nordic SoC generations
   ✓ Extensively tested and optimized

4. BEST PRACTICE FOR REAL-TIME EMBEDDED:
   ✓ Offload critical timing to hardware
   ✓ Use DMA/PPI for autonomous operation
   ✓ Keep software in supervisory role

"Let hardware do what it does best: precise timing"
═══════════════════════════════════════════════════════════
```

---

## Slide 26: References & Resources

```
═══════════════════════════════════════════════════════════
          REFERENCES & FURTHER READING
═══════════════════════════════════════════════════════════

ZEPHYR DOCUMENTATION:
• Bluetooth Controller Architecture
  docs.zephyrproject.org/latest/connectivity/bluetooth/
  bluetooth-ctlr-arch.html

SOURCE CODE (GitHub):
• Repository: zephyrproject-rtos/zephyr
• Path: subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/
  ├── radio/radio.c
  ├── radio/radio_nrf5_ppi.h
  └── radio/radio_nrf5_dppi.h

NORDIC DOCUMENTATION:
• nRF52 Series Product Specifications
• nRF53 Series DPPI Documentation
• PPI/DPPI Programming Guide

BLUETOOTH SPECIFICATIONS:
• Core Specification v5.4
• Section: Link Layer Timing Requirements
• tIFS Definition: 150µs ± 2µs

COMMUNITY:
• Zephyr Discord: discord.gg/zephyr
• GitHub Discussions: github.com/zephyrproject-rtos/zephyr
═══════════════════════════════════════════════════════════
```

---

## Slide 27: Q&A

```
═══════════════════════════════════════════════════════════
               QUESTIONS & ANSWERS
═══════════════════════════════════════════════════════════




                  Thank you for your attention!




         Questions about tIFS software switching?
              PPI/DPPI configuration?
           Double buffering implementation?
            Zephyr Bluetooth Controller?




                 Contact Information:
              Zephyr Project Community
          https://github.com/zephyrproject-rtos




═══════════════════════════════════════════════════════════
```

---

