### PR TITLE
arch: arm: Add missing MPU header include

### DIFF
--- a/arch/arm/include/kernel_arch_data.h
+++ b/arch/arm/include/kernel_arch_data.h
@@ -38,6 +38,10 @@
 #include <zephyr/sys/dlist.h>
 #include <zephyr/sys/atomic.h>
 
+#ifdef CONFIG_ARM_MPU
+#include <zephyr/arch/arm/mpu/arm_mpu.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Add missing ARM MPU header include when CONFIG_ARM_MPU is enabled. This fixes compilation errors when using MPU on ARM platforms.