### PR TITLE
Bluetooth: classic: obex: Fix active client validation logic

### DIFF
--- a/subsys/bluetooth/host/classic/obex.c
+++ b/subsys/bluetooth/host/classic/obex.c
@@ -2077,7 +2077,7 @@ int bt_obex_abort(struct bt_obex_client *client, struct net_buf *buf)
 	}
 
 	active_client = atomic_ptr_get(&client->obex->_active_client);
-	if (active_client != client) {
+	if ((active_client != NULL) && (active_client != client)) {
 		LOG_WRN("One OBEX request is executing");
 		return -EBUSY;
 	}


### PR DESCRIPTION
Fix the active client validation in OBEX abort operations to handle concurrent request scenarios. The check now ensures that if there is an active client and it's different from the current client, the operation is rejected with -EBUSY.