### PR TITLE
drivers: can: numaker: support m333x series

### DIFF
--- a/drivers/can/Kconfig.numaker
+++ b/drivers/can/Kconfig.numaker
@@ -9,6 +9,7 @@ config CAN_NUMAKER
 	select CAN_MCAN
 	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_CANFD_ENABLED
-	depends on SOC_SERIES_M46X || SOC_SERIES_M2L31X || SOC_SERIES_M55M1X
+	depends on SOC_SERIES_M46X || SOC_SERIES_M2L31X || SOC_SERIES_M55M1X || \
+		   SOC_SERIES_M333X
 	help
 	  Enables Nuvoton NuMaker CAN FD driver, using Bosch M_CAN

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -49,7 +49,7 @@ static int can_numaker_get_core_clock(const struct device *dev, uint32_t *rate)
 	clkdiv_divider = CLK_GetModuleClockDivider(config->clk_modidx) + 1;
 
 	switch (clksrc_rate_idx) {
-#if defined(CONFIG_SOC_SERIES_M46X)
+#if defined(CONFIG_SOC_SERIES_M46X) || defined(CONFIG_SOC_SERIES_M333X)
 	case (CLK_CLKSEL0_CANFD0SEL_HXT >> CLK_CLKSEL0_CANFD0SEL_Pos):
 		*rate = __HXT / clkdiv_divider;
 		break;

--- a/dts/arm/nuvoton/m333x.dtsi
+++ b/dts/arm/nuvoton/m333x.dtsi
@@ -211,6 +211,34 @@
 			interrupts = <88 2>;
 		};
 
+		canfd0: canfd@40020000 {
+			compatible = "nuvoton,numaker-canfd";
+			reg = <0x40020000 0x200>, <0x40020200 0x400>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <112 0>, <113 0>;
+			interrupt-names = "int0", "int1";
+			resets = <&rst NUMAKER_CANFD0_RST>;
+			clocks = <&pcc NUMAKER_CANFD0_MODULE
+				  NUMAKER_CLK_CLKSEL0_CANFD0SEL_HCLK
+				  NUMAKER_CLK_CLKDIV1_CANFD0(1)>;
+			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			status = "disabled";
+		};
+
+		canfd1: canfd@40024000 {
+			compatible = "nuvoton,numaker-canfd";
+			reg = <0x40024000 0x200>, <0x40024200 0x400>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <114 0>, <115 0>;
+			interrupt-names = "int0", "int1";
+			resets = <&rst NUMAKER_CANFD1_RST>;
+			clocks = <&pcc NUMAKER_CANFD1_MODULE
+				  NUMAKER_CLK_CLKSEL0_CANFD1SEL_HCLK
+				  NUMAKER_CLK_CLKDIV1_CANFD1(1)>;
+			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			status = "disabled";
+		};
+
 		rtc: rtc@40041000 {
 			compatible = "nuvoton,numaker-rtc";
 			reg = <0x40041000 0x138>;


### PR DESCRIPTION
This adds support for Nuvoton NuMaker M3331 series SoC CAN-FD driver.