### PR TITLE
drivers: can: mcux: flexcan: move to per-instance message buffer configuration

### DIFF
--- a/boards/nxp/mr_canhubk3/doc/index.rst
+++ b/boards/nxp/mr_canhubk3/doc/index.rst
@@ -143,11 +143,8 @@ flexcan5         | PTC11  | PTC11_CAN0_RX  P22/P23
    and support maximum 32 message buffers for concurrent active instances with 8 bytes
    payload. We need to pay attention to configuration options:
 
-   1. :kconfig:option:`CONFIG_CAN_MCUX_FLEXCAN_MAX_MB` must be less or equal than the
+   1. :kconfig:option:`CONFIG_CAN_MCUX_FLEXCAN_MAX_FILTERS` must be less than the
       maximum number of message buffers that is according to the table below.
-
-   2. :kconfig:option:`CONFIG_CAN_MCUX_FLEXCAN_MAX_FILTERS` must be less or equal than
-      :kconfig:option:`CONFIG_CAN_MCUX_FLEXCAN_MAX_MB`.
 
 ===============  ==========  ================  ================
 Devicetree node  Payload     Hardware support  Software support

--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -28,29 +28,15 @@ config CAN_MCUX_FLEXCAN_WAIT_TIMEOUT
 	  Maximum number of wait loop iterations for the MCUX FlexCAN HAL when entering/leaving
 	  freeze mode.
 
-config CAN_MCUX_FLEXCAN_MAX_MB
-	int "Maximum number of message buffers for concurrent active instances"
-	default 16
-	depends on SOC_SERIES_S32K3 || SOC_SERIES_S32K1 || SOC_SERIES_S32ZE
-	range 1 96 if SOC_SERIES_S32K3
-	range 1 32 if SOC_SERIES_S32K1 && !SOC_S32K142W && !SOC_S32K144W
-	range 1 64 if SOC_S32K142W || SOC_S32K144W
-	range 1 128 if SOC_SERIES_S32ZE
-	help
-	  Defines maximum number of message buffers for concurrent active instances.
-
 config CAN_MCUX_FLEXCAN_MAX_FILTERS
 	int "Maximum number of concurrent active RX filters"
+	default 5 if CAN_MCUX_FLEXCAN_FD
 	default 13
-	range 1 15 if SOC_SERIES_KINETIS_KE1XF || SOC_SERIES_KINETIS_K6X
-	range 1 13 if (SOC_SERIES_IMXRT10XX || SOC_SERIES_IMXRT11XX) && CAN_MCUX_FLEXCAN_FD
-	range 1 63 if SOC_SERIES_IMXRT10XX || SOC_SERIES_IMXRT11XX
-	range 1 96 if SOC_SERIES_S32K3
-	range 1 32 if SOC_SERIES_S32K1 && !SOC_S32K142W && !SOC_S32K144W
-	range 1 64 if SOC_S32K142W || SOC_S32K144W
-	range 1 128 if SOC_SERIES_S32ZE
 	help
 	  Defines maximum number of concurrent active RX filters
+	  The maximum value depends on the number of available message
+	  buffers for each FlexCAN instance. CAN FD mode uses larger
+	  message buffers, resulting in fewer available filters.
 
 endif # CAN_MCUX_FLEXCAN
 

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -33,20 +33,6 @@ LOG_MODULE_REGISTER(can_mcux_flexcan, CONFIG_CAN_LOG_LEVEL);
 #define RX_START_IDX 0
 #endif
 
-/* The maximum number of message buffers for concurrent active instances */
-#ifdef CONFIG_CAN_MCUX_FLEXCAN_MAX_MB
-#define MCUX_FLEXCAN_MAX_MB CONFIG_CAN_MCUX_FLEXCAN_MAX_MB
-#else
-#define MCUX_FLEXCAN_MAX_MB FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(0)
-#endif
-
-/*
- * RX message buffers (filters) will take up the first N message
- * buffers. The rest are available for TX use.
- */
-#define MCUX_FLEXCAN_MAX_RX (CONFIG_CAN_MCUX_FLEXCAN_MAX_FILTERS + RX_START_IDX)
-#define MCUX_FLEXCAN_MAX_TX (MCUX_FLEXCAN_MAX_MB - MCUX_FLEXCAN_MAX_RX)
-
 /*
  * Convert from RX message buffer index to allocated filter ID and
  * vice versa.
@@ -58,8 +44,8 @@ LOG_MODULE_REGISTER(can_mcux_flexcan, CONFIG_CAN_LOG_LEVEL);
  * Convert from TX message buffer index to allocated TX ID and vice
  * versa.
  */
-#define TX_MBIDX_TO_ALLOC_IDX(x) (x - MCUX_FLEXCAN_MAX_RX)
-#define ALLOC_IDX_TO_TXMB_IDX(x) (x + MCUX_FLEXCAN_MAX_RX)
+#define TX_MBIDX_TO_ALLOC_IDX(x) (x - ((const struct mcux_flexcan_config *)dev->config)->rx_mb)
+#define ALLOC_IDX_TO_TXMB_IDX(x) (x + ((const struct mcux_flexcan_config *)dev->config)->rx_mb)
 
 /* Convert from back from FLEXCAN IDs to Zephyr CAN IDs. */
 #define FLEXCAN_ID_TO_CAN_ID_STD(id) \
@@ -79,6 +65,9 @@ struct mcux_flexcan_config {
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	int clk_source;
+	uint32_t number_of_mb;
+	uint32_t rx_mb;
+	uint32_t tx_mb;
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 	bool flexcan_fd;
 #endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
@@ -113,16 +102,18 @@ struct mcux_flexcan_data {
 	const struct device *dev;
 	flexcan_handle_t handle;
 
-	ATOMIC_DEFINE(rx_allocs, MCUX_FLEXCAN_MAX_RX);
-	struct k_mutex rx_mutex;
-	struct mcux_flexcan_rx_callback rx_cbs[MCUX_FLEXCAN_MAX_RX];
-
-	ATOMIC_DEFINE(tx_allocs, MCUX_FLEXCAN_MAX_TX);
-	struct k_sem tx_allocs_sem;
-	struct k_mutex tx_mutex;
-	struct mcux_flexcan_tx_callback tx_cbs[MCUX_FLEXCAN_MAX_TX];
 	enum can_state state;
 	struct can_timing timing;
+
+	atomic_t *rx_allocs;
+	atomic_t *tx_allocs;
+	struct mcux_flexcan_rx_callback *rx_cbs;
+	struct mcux_flexcan_tx_callback *tx_cbs;
+
+	struct k_mutex rx_mutex;
+	struct k_mutex tx_mutex;
+	struct k_sem tx_allocs_sem;
+
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 	struct can_timing timing_data;
 #endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
@@ -204,12 +195,13 @@ static int mcux_flexcan_get_capabilities(const struct device *dev, can_mode_t *c
 
 static status_t mcux_flexcan_mb_start(const struct device *dev, int alloc)
 {
+	__maybe_unused const struct mcux_flexcan_config *config = dev->config;
 	struct mcux_flexcan_data *data = dev->data;
 	CAN_Type *base = get_base(dev);
 	flexcan_mb_transfer_t xfer;
 	status_t status;
 
-	__ASSERT_NO_MSG(alloc >= 0 && alloc < ARRAY_SIZE(data->rx_cbs));
+	__ASSERT_NO_MSG(alloc >= 0 && alloc < config->rx_mb);
 
 	xfer.mbIdx = ALLOC_IDX_TO_RXMB_IDX(alloc);
 
@@ -234,10 +226,11 @@ static status_t mcux_flexcan_mb_start(const struct device *dev, int alloc)
 
 static void mcux_flexcan_mb_stop(const struct device *dev, int alloc)
 {
+	__maybe_unused const struct mcux_flexcan_config *config = dev->config;
 	struct mcux_flexcan_data *data = dev->data;
 	CAN_Type *base = get_base(dev);
 
-	__ASSERT_NO_MSG(alloc >= 0 && alloc < ARRAY_SIZE(data->rx_cbs));
+	__ASSERT_NO_MSG(alloc >= 0 && alloc < config->rx_mb);
 
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 	if ((data->common.mode & CAN_MODE_FD) != 0U) {
@@ -288,7 +281,7 @@ static int mcux_flexcan_start(const struct device *dev)
 		/* Re-add all RX filters using current mode */
 		k_mutex_lock(&data->rx_mutex, K_FOREVER);
 
-		for (alloc = RX_START_IDX; alloc < MCUX_FLEXCAN_MAX_RX; alloc++) {
+		for (alloc = RX_START_IDX; alloc < config->rx_mb; alloc++) {
 			if (atomic_test_bit(data->rx_allocs, alloc)) {
 				status = mcux_flexcan_mb_start(dev, alloc);
 				if (status != kStatus_Success) {
@@ -362,7 +355,7 @@ static int mcux_flexcan_stop(const struct device *dev)
 	data->common.started = false;
 
 	/* Abort any pending TX frames before entering freeze mode */
-	for (alloc = 0; alloc < MCUX_FLEXCAN_MAX_TX; alloc++) {
+	for (alloc = 0; alloc < config->tx_mb; alloc++) {
 		function = data->tx_cbs[alloc].function;
 		arg = data->tx_cbs[alloc].arg;
 
@@ -393,7 +386,7 @@ static int mcux_flexcan_stop(const struct device *dev)
 		 */
 		k_mutex_lock(&data->rx_mutex, K_FOREVER);
 
-		for (alloc = RX_START_IDX; alloc < MCUX_FLEXCAN_MAX_RX; alloc++) {
+		for (alloc = RX_START_IDX; alloc < config->rx_mb; alloc++) {
 			if (atomic_test_bit(data->rx_allocs, alloc)) {
 				mcux_flexcan_mb_stop(dev, alloc);
 			}
@@ -755,7 +748,7 @@ static int mcux_flexcan_send(const struct device *dev,
 		return -EAGAIN;
 	}
 
-	for (alloc = 0; alloc < MCUX_FLEXCAN_MAX_TX; alloc++) {
+	for (alloc = 0; alloc < config->tx_mb; alloc++) {
 		if (!atomic_test_and_set_bit(data->tx_allocs, alloc)) {
 			break;
 		}
@@ -810,9 +803,7 @@ static int mcux_flexcan_add_rx_filter(const struct device *dev,
 				      void *user_data,
 				      const struct can_filter *filter)
 {
-#ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 	const struct mcux_flexcan_config *config = dev->config;
-#endif
 	struct mcux_flexcan_data *data = dev->data;
 	CAN_Type *base = get_base(dev);
 	status_t status;
@@ -828,7 +819,7 @@ static int mcux_flexcan_add_rx_filter(const struct device *dev,
 	k_mutex_lock(&data->rx_mutex, K_FOREVER);
 
 	/* Find and allocate RX message buffer */
-	for (i = RX_START_IDX; i < MCUX_FLEXCAN_MAX_RX; i++) {
+	for (i = RX_START_IDX; i < config->rx_mb; i++) {
 		if (!atomic_test_and_set_bit(data->rx_allocs, i)) {
 			alloc = i;
 			break;
@@ -929,9 +920,10 @@ static int mcux_flexcan_recover(const struct device *dev, k_timeout_t timeout)
 
 static void mcux_flexcan_remove_rx_filter(const struct device *dev, int filter_id)
 {
+	const struct mcux_flexcan_config *config = dev->config;
 	struct mcux_flexcan_data *data = dev->data;
 
-	if (filter_id < 0 || filter_id >= MCUX_FLEXCAN_MAX_RX) {
+	if (filter_id < 0 || filter_id >= config->rx_mb) {
 		LOG_ERR("filter ID %d out of bounds", filter_id);
 		return;
 	}
@@ -940,8 +932,6 @@ static void mcux_flexcan_remove_rx_filter(const struct device *dev, int filter_i
 
 	if (atomic_test_and_clear_bit(data->rx_allocs, filter_id)) {
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
-		const struct mcux_flexcan_config *config = dev->config;
-
 		/* Stop FlexCAN FD MBs unless already in stopped mode */
 		if (!config->flexcan_fd || data->common.started) {
 #endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
@@ -962,6 +952,7 @@ static void mcux_flexcan_remove_rx_filter(const struct device *dev, int filter_i
 static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 						      uint64_t error)
 {
+	const struct mcux_flexcan_config *config = dev->config;
 	struct mcux_flexcan_data *data = dev->data;
 	CAN_Type *base = get_base(dev);
 	const can_state_change_callback_t cb = data->common.state_change_cb;
@@ -1007,7 +998,7 @@ static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 
 	if (state == CAN_STATE_BUS_OFF) {
 		/* Abort any pending TX frames in case of bus-off */
-		for (alloc = 0; alloc < MCUX_FLEXCAN_MAX_TX; alloc++) {
+		for (alloc = 0; alloc < config->tx_mb; alloc++) {
 			/* Copy callback function and argument before clearing bit */
 			function = data->tx_cbs[alloc].function;
 			arg = data->tx_cbs[alloc].arg;
@@ -1187,10 +1178,12 @@ static int mcux_flexcan_init(const struct device *dev)
 
 	DEVICE_MMIO_NAMED_MAP(dev, flexcan_mmio, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
 
+	LOG_DBG("Message Buffers: %d, RX MB: %d, TX MB: %d",
+		 config->number_of_mb, config->rx_mb, config->tx_mb);
+
 	k_mutex_init(&data->rx_mutex);
 	k_mutex_init(&data->tx_mutex);
-	k_sem_init(&data->tx_allocs_sem, MCUX_FLEXCAN_MAX_TX,
-		   MCUX_FLEXCAN_MAX_TX);
+	k_sem_init(&data->tx_allocs_sem, config->tx_mb, config->tx_mb);
 
 	err = can_calc_timing(dev, &data->timing, config->common.bitrate,
 			      config->common.sample_point);
@@ -1246,7 +1239,7 @@ static int mcux_flexcan_init(const struct device *dev)
 	data->dev = dev;
 
 	FLEXCAN_GetDefaultConfig(&flexcan_config);
-	flexcan_config.maxMbNum = MCUX_FLEXCAN_MAX_MB;
+	flexcan_config.maxMbNum = config->number_of_mb;
 	flexcan_config.clkSrc = config->clk_source;
 	flexcan_config.baudRate = clock_freq /
 	      (1U + data->timing.prop_seg + data->timing.phase_seg1 +
@@ -1482,12 +1475,45 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 #define FLEXCAN_DRIVER_API(id) mcux_flexcan_driver_api
 #endif /* !CONFIG_CAN_MCUX_FLEXCAN_FD */
 
+#define FLEXCAN_INST_NUMBER_OF_MB(id)						\
+	COND_CODE_1(UTIL_AND(IS_ENABLED(CONFIG_CAN_MCUX_FLEXCAN_FD),		\
+			DT_INST_NODE_HAS_COMPAT(id, FLEXCAN_FD_DRV_COMPAT)),	\
+		(DT_INST_PROP(id, number_of_mb_fd)),				\
+		(DT_INST_PROP(id, number_of_mb)))
+
+/*
+ * RX message buffers (filters) will take up the first N message
+ * buffers. The rest are available for TX use.
+ */
+#define FLEXCAN_INST_RX_MB(id) (CONFIG_CAN_MCUX_FLEXCAN_MAX_FILTERS + RX_START_IDX)
+#define FLEXCAN_INST_TX_MB(id) (FLEXCAN_INST_NUMBER_OF_MB(id) - FLEXCAN_INST_RX_MB(id))
+
+#define FLEXCAN_CHECK_MAX_FILTER(id)						\
+	BUILD_ASSERT(CONFIG_CAN_MCUX_FLEXCAN_MAX_FILTERS > 0,			\
+		"Maximum number of RX filters should greater than 0");		\
+	BUILD_ASSERT(FLEXCAN_INST_NUMBER_OF_MB(id) > FLEXCAN_INST_RX_MB(id),	\
+		     "FlexCAN instance " STRINGIFY(id) " number-of-mb ("	\
+		     STRINGIFY(FLEXCAN_INST_NUMBER_OF_MB(id))			\
+		     ") is too small for required RX filters ("			\
+		     STRINGIFY(FLEXCAN_INST_RX_MB(id)) ")")
+
 #define FLEXCAN_DEVICE_INIT_MCUX(id)					\
 	PINCTRL_DT_INST_DEFINE(id);					\
+	FLEXCAN_CHECK_MAX_FILTER(id);					\
 									\
 	static void mcux_flexcan_irq_config_##id(const struct device *dev); \
 	static void mcux_flexcan_irq_enable_##id(void); \
 	static void mcux_flexcan_irq_disable_##id(void); \
+									\
+	static struct mcux_flexcan_rx_callback flexcan_rx_cbs_##id	\
+			[FLEXCAN_INST_RX_MB(id)] = {0};			\
+									\
+	static struct mcux_flexcan_tx_callback flexcan_tx_cbs_##id	\
+			[FLEXCAN_INST_TX_MB(id)] = {0};			\
+									\
+	static ATOMIC_DEFINE(flexcan_rx_allocs_##id, FLEXCAN_INST_RX_MB(id));	\
+									\
+	static ATOMIC_DEFINE(flexcan_tx_allocs_##id, FLEXCAN_INST_TX_MB(id));	\
 									\
 	static const struct mcux_flexcan_config mcux_flexcan_config_##id = { \
 		DEVICE_MMIO_NAMED_ROM_INIT(flexcan_mmio, DT_DRV_INST(id)),	\
@@ -1496,6 +1522,9 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 		.clock_subsys = (clock_control_subsys_t)		\
 			DT_INST_CLOCKS_CELL(id, name),			\
 		.clk_source = DT_INST_PROP(id, clk_source),		\
+		.number_of_mb = FLEXCAN_INST_NUMBER_OF_MB(id),		\
+		.rx_mb = FLEXCAN_INST_RX_MB(id),			\
+		.tx_mb = FLEXCAN_INST_TX_MB(id),			\
 		IF_ENABLED(CONFIG_CAN_MCUX_FLEXCAN_FD, (		\
 			.flexcan_fd = DT_INST_NODE_HAS_COMPAT(id, FLEXCAN_FD_DRV_COMPAT), \
 		))							\
@@ -1505,7 +1534,12 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),		\
 	};								\
 									\
-	static struct mcux_flexcan_data mcux_flexcan_data_##id;		\
+	static struct mcux_flexcan_data mcux_flexcan_data_##id = {	\
+		.rx_cbs = flexcan_rx_cbs_##id,				\
+		.tx_cbs = flexcan_tx_cbs_##id,				\
+		.rx_allocs = flexcan_rx_allocs_##id,			\
+		.tx_allocs = flexcan_tx_allocs_##id,			\
+	};								\
 									\
 	CAN_DEVICE_DT_INST_DEFINE(id, mcux_flexcan_init,		\
 				  NULL, &mcux_flexcan_data_##id,	\

--- a/dts/arm/nxp/nxp_k66.dtsi
+++ b/dts/arm/nxp/nxp_k66.dtsi
@@ -32,6 +32,7 @@
 					  "rx-warning", "wake-up";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1030 4>;
 			clk-source = <1>;
+			number-of-mb = <16>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -523,6 +523,7 @@
 					  "wake-up";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 4>;
 			clk-source = <1>;
+			number-of-mb = <16>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -1,4 +1,8 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <freq.h>

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -411,6 +411,7 @@
 					  "mb-0-15";
 			clocks = <&scg KINETIS_SCG_BUS_CLK>;
 			clk-source = <1>;
+			number-of-mb = <16>;
 			status = "disabled";
 		};
 
@@ -422,6 +423,7 @@
 					  "mb-0-15";
 			clocks = <&scg KINETIS_SCG_BUS_CLK>;
 			clk-source = <1>;
+			number-of-mb = <16>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -267,6 +267,7 @@
 			interrupt-names = "common";
 			clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 			clk-source = <0>;
+			number-of-mb = <32>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/nxp_mcxa344.dtsi
@@ -258,6 +258,7 @@
 			interrupt-names = "common";
 			clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 			clk-source = <0>;
+			number-of-mb = <32>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxa5x_common.dtsi
@@ -488,6 +488,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 		clk-source = <0>;
+		number-of-mb = <32>;
 		status = "disabled";
 	};
 
@@ -498,6 +499,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		clk-source = <0>;
+		number-of-mb = <32>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxe245.dtsi
+++ b/dts/arm/nxp/nxp_mcxe245.dtsi
@@ -45,16 +45,23 @@
 	};
 };
 
+&flexcan0 {
+	number-of-mb = <32>;
+	number-of-mb-fd = <7>;
+};
+
 &flexcan1 {
 	compatible = "nxp,flexcan";
 	interrupts = <85 0>, <86 0>, <88 0>;
 	interrupt-names = "ored-warning-bus-off", "error", "mb-0-15";
+	number-of-mb = <16>;
 };
 
 &flexcan2 {
 	compatible = "nxp,flexcan";
 	interrupts = <92 0>, <93 0>, <95 0>;
 	interrupt-names = "ored-warning-bus-off", "error", "mb-0-15";
+	number-of-mb = <16>;
 };
 
 /delete-node/ &ftm4;

--- a/dts/arm/nxp/nxp_mcxe246.dtsi
+++ b/dts/arm/nxp/nxp_mcxe246.dtsi
@@ -45,10 +45,21 @@
 	};
 };
 
+&flexcan0 {
+	number-of-mb = <32>;
+	number-of-mb-fd = <7>;
+};
+
+&flexcan1 {
+	number-of-mb = <32>;
+	number-of-mb-fd = <7>;
+};
+
 &flexcan2 {
 	compatible = "nxp,flexcan";
 	interrupts = <92 0>, <93 0>, <95 0>;
 	interrupt-names = "ored-warning-bus-off", "error", "mb-0-15";
+	number-of-mb = <16>;
 };
 
 /delete-node/ &ftm4;

--- a/dts/arm/nxp/nxp_mcxe247.dtsi
+++ b/dts/arm/nxp/nxp_mcxe247.dtsi
@@ -44,3 +44,18 @@
 		write-block-size = <8>;
 	};
 };
+
+&flexcan0 {
+	number-of-mb = <32>;
+	number-of-mb-fd = <7>;
+};
+
+&flexcan1 {
+	number-of-mb = <32>;
+	number-of-mb-fd = <7>;
+};
+
+&flexcan2 {
+	number-of-mb = <32>;
+	number-of-mb-fd = <7>;
+};

--- a/dts/arm/nxp/nxp_mcxe315.dtsi
+++ b/dts/arm/nxp/nxp_mcxe315.dtsi
@@ -39,6 +39,18 @@
 	reg = <0x400000 DT_SIZE_K(512)>;
 };
 
+&flexcan_0 {
+	number-of-mb = <64>;
+};
+
+&flexcan_1 {
+	number-of-mb = <64>;
+};
+
+&flexcan_2 {
+	number-of-mb = <64>;
+};
+
 &peripheral {
 	/delete-node/ flexcan@310000;
 	/delete-node/ flexcan@314000;

--- a/dts/arm/nxp/nxp_mcxe316.dtsi
+++ b/dts/arm/nxp/nxp_mcxe316.dtsi
@@ -39,6 +39,18 @@
 	reg = <0x400000 DT_SIZE_K(1024)>;
 };
 
+&flexcan_0 {
+	number-of-mb = <64>;
+};
+
+&flexcan_1 {
+	number-of-mb = <64>;
+};
+
+&flexcan_2 {
+	number-of-mb = <64>;
+};
+
 &peripheral {
 	/delete-node/ flexcan@310000;
 	/delete-node/ flexcan@314000;

--- a/dts/arm/nxp/nxp_mcxe317.dtsi
+++ b/dts/arm/nxp/nxp_mcxe317.dtsi
@@ -45,6 +45,30 @@
 	reg = <0x400000 DT_SIZE_K(2048)>;
 };
 
+&flexcan_0 {
+	number-of-mb = <64>;
+};
+
+&flexcan_1 {
+	number-of-mb = <64>;
+};
+
+&flexcan_2 {
+	number-of-mb = <64>;
+};
+
+&flexcan_3 {
+	number-of-mb = <32>;
+};
+
+&flexcan_4 {
+	number-of-mb = <32>;
+};
+
+&flexcan_5 {
+	number-of-mb = <32>;
+};
+
 &peripheral {
 	/delete-node/ emac@480000;
 	/delete-node/ sai@36c000;

--- a/dts/arm/nxp/nxp_mcxe31b.dtsi
+++ b/dts/arm/nxp/nxp_mcxe31b.dtsi
@@ -67,3 +67,27 @@
 	start-address = <0x20010000>;
 	size = <DT_SIZE_K(32)>;
 };
+
+&flexcan_0 {
+	number-of-mb = <96>;
+};
+
+&flexcan_1 {
+	number-of-mb = <64>;
+};
+
+&flexcan_2 {
+	number-of-mb = <64>;
+};
+
+&flexcan_3 {
+	number-of-mb = <32>;
+};
+
+&flexcan_4 {
+	number-of-mb = <32>;
+};
+
+&flexcan_5 {
+	number-of-mb = <32>;
+};

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -926,6 +926,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 		clk-source = <0>;
+		number-of-mb = <32>;
 		status = "disabled";
 	};
 
@@ -936,6 +937,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		clk-source = <0>;
+		number-of-mb = <32>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -119,6 +119,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		clk-source = <0>;
+		number-of-mb = <32>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -1080,6 +1080,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 		clk-source = <0>;
+		number-of-mb = <32>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -377,6 +377,7 @@
 		interrupt-names = "common";
 		clocks = <&scg SCG_K4_FIRC_CLK 0xec>;
 		clk-source = <2>;
+		number-of-mb = <32>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -970,6 +970,7 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 14>;
 			clk-source = <2>;
+			number-of-mb = <64>;
 			status = "disabled";
 		};
 
@@ -980,6 +981,7 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 18>;
 			clk-source = <2>;
+			number-of-mb = <64>;
 			status = "disabled";
 		};
 
@@ -990,6 +992,8 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
 			clk-source = <2>;
+			number-of-mb = <64>;
+			number-of-mb-fd = <14>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -786,6 +786,8 @@
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
 		clk-source = <0>;
+		number-of-mb = <96>;
+		number-of-mb-fd = <21>;
 		status = "disabled";
 	};
 
@@ -796,6 +798,8 @@
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 18>;
 		clk-source = <0>;
+		number-of-mb = <96>;
+		number-of-mb-fd = <21>;
 		status = "disabled";
 	};
 
@@ -806,6 +810,8 @@
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN3_CLK 0x84 6>;
 		clk-source = <0>;
+		number-of-mb = <96>;
+		number-of-mb-fd = <21>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -917,6 +917,8 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
 			clk-source = <0>;
+			number-of-mb = <64>;
+			number-of-mb-fd = <14>;
 			status = "disabled";
 		};
 
@@ -927,6 +929,8 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 18>;
 			clk-source = <0>;
+			number-of-mb = <64>;
+			number-of-mb-fd = <14>;
 			status = "disabled";
 		};
 
@@ -937,6 +941,8 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN3_CLK 0x84 6>;
 			clk-source = <0>;
+			number-of-mb = <64>;
+			number-of-mb-fd = <14>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_s32k146.dtsi
+++ b/dts/arm/nxp/nxp_s32k146.dtsi
@@ -65,12 +65,16 @@
 &flexcan0 {
 	interrupts = <78 0>, <79 0>, <80 0>, <81 0>, <82 0>;
 	interrupt-names = "warning", "error", "wake-up", "mb-0-15", "mb-16-31";
+	number-of-mb = <32>;
+	number-of-mb-fd = <7>;
 };
 
 &flexcan1 {
 	interrupts = <85 0>, <86 0>, <88 0>, <89 0>;
 	interrupt-names = "warning", "error", "mb-0-15", "mb-16-31";
 	clocks = <&clock NXP_S32_FLEXCAN1_CLK>;
+	number-of-mb = <32>;
+	number-of-mb-fd = <7>;
 };
 
 &flexcan2 {
@@ -78,4 +82,5 @@
 	interrupts = <92 0>, <93 0>, <95 0>;
 	interrupt-names = "warning", "error", "mb-0-15";
 	clocks = <&clock NXP_S32_FLEXCAN2_CLK>;
+	number-of-mb = <16>;
 };

--- a/dts/arm/nxp/nxp_s32k148.dtsi
+++ b/dts/arm/nxp/nxp_s32k148.dtsi
@@ -88,16 +88,22 @@
 &flexcan0 {
 	interrupts = <78 0>, <79 0>, <80 0>, <81 0>, <82 0>;
 	interrupt-names = "warning", "error", "wake-up", "mb-0-15", "mb-16-31";
+	number-of-mb = <32>;
+	number-of-mb-fd = <7>;
 };
 
 &flexcan1 {
 	interrupts = <85 0>, <86 0>, <88 0>, <89 0>;
 	interrupt-names = "warning", "error", "mb-0-15", "mb-16-31";
 	clocks = <&clock NXP_S32_FLEXCAN1_CLK>;
+	number-of-mb = <32>;
+	number-of-mb-fd = <7>;
 };
 
 &flexcan2 {
 	interrupts = <92 0>, <93 0>, <95 0>, <96 0>;
 	interrupt-names = "warning", "error", "mb-0-15", "mb-16-31";
 	clocks = <&clock NXP_S32_FLEXCAN2_CLK>;
+	number-of-mb = <32>;
+	number-of-mb-fd = <7>;
 };

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -479,6 +479,8 @@
 			interrupts = <109 0>, <110 0>, <111 0>, <112 0>;
 			interrupt-names = "ored", "ored_0_31_mb",
 					  "ored_32_63_mb", "ored_64_95_mb";
+			number-of-mb = <96>;
+			number-of-mb-fd = <21>;
 			status = "disabled";
 		};
 
@@ -489,6 +491,8 @@
 			clk-source = <0>;
 			interrupts = <113 0>, <114 0>, <115 0>;
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb";
+			number-of-mb = <64>;
+			number-of-mb-fd = <14>;
 			status = "disabled";
 		};
 
@@ -499,6 +503,8 @@
 			clk-source = <0>;
 			interrupts = <116 0>, <117 0>, <118 0>;
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb";
+			number-of-mb = <64>;
+			number-of-mb-fd = <14>;
 			status = "disabled";
 		};
 
@@ -509,6 +515,8 @@
 			clk-source = <0>;
 			interrupts = <119 0>, <120 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
+			number-of-mb = <32>;
+			number-of-mb-fd = <7>;
 			status = "disabled";
 		};
 
@@ -519,6 +527,8 @@
 			clk-source = <0>;
 			interrupts = <121 0>, <122 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
+			number-of-mb = <32>;
+			number-of-mb-fd = <7>;
 			status = "disabled";
 		};
 
@@ -529,6 +539,8 @@
 			clk-source = <0>;
 			interrupts = <123 0>, <124 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
+			number-of-mb = <32>;
+			number-of-mb-fd = <7>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -756,6 +756,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -771,6 +773,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -786,6 +790,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -801,6 +807,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -816,6 +824,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -831,6 +841,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -846,6 +858,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -861,6 +875,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -876,6 +892,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -891,6 +909,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -906,6 +926,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -921,6 +943,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -936,6 +960,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -951,6 +977,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -966,6 +994,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -981,6 +1011,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -996,6 +1028,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1011,6 +1045,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1026,6 +1062,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1041,6 +1079,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1056,6 +1096,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1071,6 +1113,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1086,6 +1130,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 
@@ -1101,6 +1147,8 @@
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			number-of-mb = <128>;
+			number-of-mb-fd = <28>;
 			status = "disabled";
 		};
 

--- a/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
@@ -198,6 +198,8 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
 			clk-source = <0>;
+			number-of-mb = <64>;
+			number-of-mb-fd = <14>;
 			rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
 			       RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
 			status = "disabled";
@@ -212,6 +214,8 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 14>;
 			clk-source = <0>;
+			number-of-mb = <64>;
+			number-of-mb-fd = <14>;
 			rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
 			       RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
 			status = "disabled";

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -420,6 +420,8 @@
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
 		clk-source = <0>;
+		number-of-mb = <96>;
+		number-of-mb-fd = <21>;
 		status = "disabled";
 	};
 
@@ -432,6 +434,8 @@
 		interrupt-names = "common", "error";
 		clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 14>;
 		clk-source = <0>;
+		number-of-mb = <96>;
+		number-of-mb-fd = <21>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/can/nxp,flexcan-fd.yaml
+++ b/dts/bindings/can/nxp,flexcan-fd.yaml
@@ -15,6 +15,8 @@ description: |
       interrupt-names = "common";
       clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
       clk-source = <2>;
+      number-of-mb = <64>;
+      number-of-mb-fd = <14>;
       pinctrl-0 = <&pinmux_flexcan3>;
       pinctrl-names = "default";
 
@@ -27,3 +29,9 @@ compatible: "nxp,flexcan-fd"
 
 include: ["nxp,flexcan.yaml", "can-fd-controller.yaml", "pinctrl-device.yaml",
           "nxp,rdc-policy.yaml"]
+
+properties:
+  number-of-mb-fd:
+    type: int
+    required: true
+    description: Number of 64-byte payload message buffers FlexCAN FD instance supported

--- a/dts/bindings/can/nxp,flexcan.yaml
+++ b/dts/bindings/can/nxp,flexcan.yaml
@@ -13,6 +13,7 @@ description: |
       interrupt-names = "warning", "error", "wake-up", "mb-0-15";
       clocks = <&scg KINETIS_SCG_BUS_CLK>;
       clk-source = <1>;
+      number-of-mb = <16>;
       pinctrl-0 = <&pinmux_flexcan0>;
       pinctrl-names = "default";
 
@@ -39,3 +40,8 @@ properties:
     type: int
     required: true
     description: CAN engine clock source
+
+  number-of-mb:
+    type: int
+    required: true
+    description: Number of 8-byte payload message buffers FlexCAN instance supported


### PR DESCRIPTION
This change refactors the FlexCAN driver to use per-instance message buffer configuration instead of global Kconfig options. The driver now calculates message buffer allocation at compile time based on device tree properties for each FlexCAN instance.
    
Key changes:
- Remove global CAN_MAX_MB Kconfig option and associated range constraint
- Add max_mb, rx_mb, and tx_mb fields to mcux_flexcan_config structure
- Move callback arrays and atomic allocation bitmaps from static global arrays to per-instance static arrays generated by macros
- Update data structure to use pointers to per-instance arrays instead of fixed-size embedded arrays
- Add compile-time validation to ensure sufficient message buffers are available for required RX filters
    
This approach allows different FlexCAN instances to have different message buffer configurations based on their hardware capabilities and device tree settings, improving memory efficiency and flexibility. The change maintains backward compatibility while enabling better resource utilization across different SoC variants.
    
Fixes #92798