### PR TITLE
debug: coredump: stack top limit for current thread

### DIFF
--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -151,20 +151,33 @@ config DEBUG_COREDUMP_THREAD_STACK_TOP
 		   DEBUG_COREDUMP_MEMORY_DUMP_THREADS
 	depends on ARCH_SUPPORTS_COREDUMP_STACK_PTR
 	help
-	  This option enables dumping only the top portion of each thread's
-	  stack, rather than the entire stack region. The top of the stack is
-	  defined as the area from the stack pointer to the stack end, but the
-	  size of this region can additionally be constrained using the
-	  DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT option.
+	  Dump only the top part of each thread's stack instead of the entire
+	  stack region. The top of the stack is defined as the area starting
+	  from the stack pointer and extending up to the smaller of the stack
+	  end or the limit configured by either
+	  DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT_FOR_CURRENT (for the current
+	  thread) or DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT (for remaining ones).
+
+if DEBUG_COREDUMP_THREAD_STACK_TOP
+
+config DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT_FOR_CURRENT
+	int "Stack top size limit for current thread"
+	default DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT
+	help
+	  The maximum number of stack bytes to be dumped for the thread running
+	  when the exception occurred.
+	  A negative value indicates that there is no limit, meaning that the
+	  stack is dumped till the end of its region.
 
 config DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT
-	int "Stack top size limit"
+	int "Stack top size limit for non-current threads"
 	default -1
-	depends on DEBUG_COREDUMP_THREAD_STACK_TOP
 	help
-	  See the description of the DEBUG_COREDUMP_THREAD_STACK_TOP option.
-	  The value -1 indicates that there is no limit, meaning that the stack
-	  is dumped till the end of its region.
+	  The maximum number of stack bytes to be dumped for threads that were
+	  not running when the exception occurred.
+	  A negative value indicates that there is no limit, meaning that the
+	  stack is dumped till the end of its region.
 
+endif # DEBUG_COREDUMP_THREAD_STACK_TOP
 
 endif # DEBUG_COREDUMP

--- a/subsys/debug/coredump/coredump_core.c
+++ b/subsys/debug/coredump/coredump_core.c
@@ -41,8 +41,16 @@ static struct coredump_backend_api
 #define DT_DRV_COMPAT zephyr_coredump
 #endif
 
+#if defined(CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT_FOR_CURRENT) &&                           \
+	CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT_FOR_CURRENT >= 0
+#define STACK_TOP_LIMIT_FOR_CURRENT                                                                \
+	((size_t)CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT_FOR_CURRENT)
+#else
+#define STACK_TOP_LIMIT_FOR_CURRENT SIZE_MAX
+#endif
+
 #if defined(CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT) &&                                       \
-	CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT > 0
+	CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT >= 0
 #define STACK_TOP_LIMIT ((size_t)CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP_LIMIT)
 #else
 #define STACK_TOP_LIMIT SIZE_MAX
@@ -80,10 +88,11 @@ static void dump_header(unsigned int reason)
 #if defined(CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN) ||                                              \
 	defined(CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS)
 
-static inline void select_stack_region(const struct k_thread *thread, uintptr_t *start,
-				       uintptr_t *end)
+static inline void select_stack_region(const struct k_thread *thread, bool is_current,
+				       uintptr_t *start, uintptr_t *end)
 {
 	uintptr_t sp;
+	size_t limit;
 
 	*start = thread->stack_info.start;
 	*end = thread->stack_info.start + thread->stack_info.size;
@@ -99,11 +108,12 @@ static inline void select_stack_region(const struct k_thread *thread, uintptr_t 
 		*start = sp;
 	}
 
-	/* Make sure no more than STACK_TOP_LIMIT bytes of the stack are dumped. */
-	*end = *start + MIN((size_t)(*end - *start), STACK_TOP_LIMIT);
+	/* Make sure no more than STACK_TOP_LIMIT[_FOR_CURRENT] bytes of the stack are dumped. */
+	limit = (is_current ? STACK_TOP_LIMIT_FOR_CURRENT : STACK_TOP_LIMIT);
+	*end = *start + MIN((size_t)(*end - *start), limit);
 }
 
-static void dump_thread(struct k_thread *thread)
+static void dump_thread(struct k_thread *thread, bool is_current)
 {
 	uintptr_t start_addr;
 	uintptr_t end_addr;
@@ -122,7 +132,7 @@ static void dump_thread(struct k_thread *thread)
 	end_addr = start_addr + sizeof(*thread);
 	coredump_memory_dump(start_addr, end_addr);
 
-	select_stack_region(thread, &start_addr, &end_addr);
+	select_stack_region(thread, is_current, &start_addr, &end_addr);
 	coredump_memory_dump(start_addr, end_addr);
 
 #if defined(CONFIG_DEBUG_COREDUMP_DUMP_THREAD_PRIV_STACK)
@@ -140,7 +150,7 @@ static void process_coredump_dev_memory(const struct device *dev)
 }
 #endif
 
-void process_memory_region_list(void)
+void process_memory_region_list(struct k_thread *current)
 {
 #ifdef CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_LINKER_RAM
 	unsigned int idx = 0;
@@ -164,10 +174,10 @@ void process_memory_region_list(void)
 	 * Content of _kernel.threads not being modified during dump
 	 * capture so no need to lock z_thread_monitor_lock.
 	 */
-	struct k_thread *current;
+	struct k_thread *thread;
 
-	for (current = _kernel.threads; current; current = current->next_thread) {
-		dump_thread(current);
+	for (thread = _kernel.threads; thread; thread = thread->next_thread) {
+		dump_thread(thread, thread == current);
 	}
 
 	/* Also add interrupt stack, in case error occurred in an interrupt */
@@ -216,11 +226,11 @@ void coredump(unsigned int reason, const struct arch_esf *esf,
 
 	if (thread != NULL) {
 #ifdef CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN
-		dump_thread(thread);
+		dump_thread(thread, /* is_current */ true);
 #endif
 	}
 
-	process_memory_region_list();
+	process_memory_region_list(thread);
 
 	z_coredump_end();
 }


### PR DESCRIPTION
Extend the functionality to limit the number of stack bytes included in the core dump by allowing the limit to be different for the current thread and remaining threads.

This is useful because it is more likely that we need more call frames of the thread that was running when the exception occurred than of the other threads in order to analyze the exception.