### PR TITLE
drivers: gpio: cc13xx_cc26xx: Remove multi functions

### DIFF
--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -32,6 +32,9 @@
 /* the rest are for general (non-interrupt) config */
 #define IOCFG_GEN_MASK    (~IOCFG_INT_MASK)
 
+/* GPIO all DIOs mask */
+#define GPIO_DIO_ALL_MASK 0xFFFFFFFF
+
 struct gpio_cc13xx_cc26xx_data {
 	/* gpio_driver_data needs to be first */
 	struct gpio_driver_data common;
@@ -128,7 +131,7 @@ static int gpio_cc13xx_cc26xx_port_get_raw(const struct device *port,
 {
 	__ASSERT_NO_MSG(value != NULL);
 
-	*value = GPIO_readMultiDio(GPIO_DIO_ALL_MASK);
+	*value = HWREG(GPIO_BASE + GPIO_O_DIN31_0) & GPIO_DIO_ALL_MASK;
 
 	return 0;
 }
@@ -137,8 +140,8 @@ static int gpio_cc13xx_cc26xx_port_set_masked_raw(const struct device *port,
 						  uint32_t mask,
 						  uint32_t value)
 {
-	GPIO_setMultiDio(mask & value);
-	GPIO_clearMultiDio(mask & ~value);
+	gpio_cc13xx_cc26xx_port_set_bits_raw(port, mask & value);
+	gpio_cc13xx_cc26xx_port_clear_bits_raw(port, mask & ~value);
 
 	return 0;
 }
@@ -146,7 +149,7 @@ static int gpio_cc13xx_cc26xx_port_set_masked_raw(const struct device *port,
 static int gpio_cc13xx_cc26xx_port_set_bits_raw(const struct device *port,
 						uint32_t mask)
 {
-	GPIO_setMultiDio(mask);
+	HWREG(GPIO_BASE + GPIO_O_DOUTSET31_0) = mask;
 
 	return 0;
 }
@@ -154,7 +157,7 @@ static int gpio_cc13xx_cc26xx_port_set_bits_raw(const struct device *port,
 static int gpio_cc13xx_cc26xx_port_clear_bits_raw(const struct device *port,
 						  uint32_t mask)
 {
-	GPIO_clearMultiDio(mask);
+	HWREG(GPIO_BASE + GPIO_O_DOUTCLR31_0) = mask;
 
 	return 0;
 }
@@ -162,7 +165,7 @@ static int gpio_cc13xx_cc26xx_port_clear_bits_raw(const struct device *port,
 static int gpio_cc13xx_cc26xx_port_toggle_bits(const struct device *port,
 					       uint32_t mask)
 {
-	GPIO_toggleMultiDio(mask);
+	HWREG(GPIO_BASE + GPIO_O_DOUTTGL31_0) = mask;
 
 	return 0;
 }
@@ -209,16 +212,16 @@ static int gpio_cc13xx_cc26xx_manage_callback(const struct device *port,
 
 static uint32_t gpio_cc13xx_cc26xx_get_pending_int(const struct device *dev)
 {
-	return GPIO_getEventMultiDio(GPIO_DIO_ALL_MASK);
+	return HWREG(GPIO_BASE + GPIO_O_EVFLAGS31_0) & GPIO_DIO_ALL_MASK;
 }
 
 static void gpio_cc13xx_cc26xx_isr(const struct device *dev)
 {
 	struct gpio_cc13xx_cc26xx_data *data = dev->data;
 
-	uint32_t status = GPIO_getEventMultiDio(GPIO_DIO_ALL_MASK);
+	uint32_t status = HWREG(GPIO_BASE + GPIO_O_EVFLAGS31_0) & GPIO_DIO_ALL_MASK;
 
-	GPIO_clearEventMultiDio(status);
+	HWREG(GPIO_BASE + GPIO_O_EVFLAGS31_0) = status;
 
 	gpio_fire_callbacks(&data->callbacks, dev, status);
 }


### PR DESCRIPTION
- It seems that the mask variants of GPIO functions are not present in the latest sdk, so replace those with direct register access.
- This was already done in [0], but was reverted due to some hal problems.
- I am working on a hal update, but since this change does not require a hal update to work, it would be best to merge this first.

[0]: https://github.com/zephyrproject-rtos/zephyr/pull/83402