### PR TITLE
Openthread border router fix socket close

### DIFF
--- a/modules/openthread/platform/dhcp6_pd.c
+++ b/modules/openthread/platform/dhcp6_pd.c
@@ -63,9 +63,9 @@ void otPlatInfraIfDhcp6PdClientSend(otInstance *aInstance,
 	VerifyOrExit(dhcpv6_pd_client_sock != -1 && aInfraIfIndex == ail_iface_idx);
 	uint16_t length = otMessageGetLength(aMessage);
 	struct net_sockaddr_in6 dest_sock_addr = {.sin6_family = NET_AF_INET6,
-					      .sin6_port = net_htons(DHCPV6_SERVER_PORT),
-					      .sin6_addr = NET_IN6ADDR_ANY_INIT,
-					      .sin6_scope_id = 0};
+						  .sin6_port = net_htons(DHCPV6_SERVER_PORT),
+						  .sin6_addr = NET_IN6ADDR_ANY_INIT,
+						  .sin6_scope_id = 0};
 
 	memcpy(&dest_sock_addr.sin6_addr, aDestAddress, sizeof(otIp6Address));
 
@@ -116,9 +116,9 @@ static void dhcpv6_pd_client_socket_init(uint32_t infra_if_index)
 	int hop_limit = 255;
 	int on = 1;
 	struct net_sockaddr_in6 addr = {.sin6_family = NET_AF_INET6,
-				    .sin6_port = net_htons(DHCPV6_CLIENT_PORT),
-				    .sin6_addr = NET_IN6ADDR_ANY_INIT,
-				    .sin6_scope_id = 0};
+					.sin6_port = net_htons(DHCPV6_CLIENT_PORT),
+					.sin6_addr = NET_IN6ADDR_ANY_INIT,
+					.sin6_scope_id = 0};
 
 	dhcpv6_pd_client_sock = zsock_socket(NET_AF_INET6, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
 	VerifyOrExit(dhcpv6_pd_client_sock >= 0);
@@ -163,6 +163,9 @@ static void dhcpv6_pd_client_socket_deinit(uint32_t infra_if_index)
 
 	sockfd_udp[0].fd = -1;
 	dhcpv6_pd_client_sock = -1;
+
+	net_socket_service_register(&dhcpv6_pd_client_udp_receive, sockfd_udp,
+				    ARRAY_SIZE(sockfd_udp), NULL);
 exit:
 	return;
 }

--- a/modules/openthread/platform/mdns_socket.c
+++ b/modules/openthread/platform/mdns_socket.c
@@ -20,6 +20,7 @@
 #include <zephyr/net/socket_service.h>
 #include <openthread/nat64.h>
 #include "sockets_internal.h"
+#include <errno.h>
 
 #define MULTICAST_PORT 5353
 #define MAX_SERVICES CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_MAX_MDNS_SERVICES
@@ -104,13 +105,14 @@ static otError mdns_socket_init_v6(uint32_t ail_iface_idx)
 	struct net_ipv6_mreq mreq_v6 = {0};
 	int mcast_hops = 255;
 	int on = 1;
+	int mcast_join_ret = 0;
 
 	struct net_sockaddr_in6 addr = {.sin6_family = NET_AF_INET6,
-				    .sin6_port = net_htons(MULTICAST_PORT),
-				    .sin6_addr = {{{0}}},
-				    .sin6_scope_id = 0};
+					.sin6_port = net_htons(MULTICAST_PORT),
+					.sin6_addr = {{{0}}},
+					.sin6_scope_id = 0};
 
-	mdns_sock_v6 = zsock_socket(NET_AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+	mdns_sock_v6 = zsock_socket(NET_AF_INET6, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
 	VerifyOrExit(mdns_sock_v6 >= 0, error = OT_ERROR_FAILED);
 	VerifyOrExit(net_if_get_name(net_if_get_by_index(ail_iface_idx), name,
 				     CONFIG_NET_INTERFACE_NAME_LEN) > 0,
@@ -130,8 +132,9 @@ static otError mdns_socket_init_v6(uint32_t ail_iface_idx)
 		     error = OT_ERROR_FAILED);
 	mreq_v6.ipv6mr_ifindex = ail_iface_idx;
 	net_ipv6_addr_create(&mreq_v6.ipv6mr_multiaddr, 0xff02, 0, 0, 0, 0, 0, 0, 0x00fb);
-	VerifyOrExit(zsock_setsockopt(mdns_sock_v6, NET_IPPROTO_IPV6, ZSOCK_IPV6_ADD_MEMBERSHIP,
-				      &mreq_v6, sizeof(mreq_v6)) == 0,
+	mcast_join_ret = zsock_setsockopt(mdns_sock_v6, NET_IPPROTO_IPV6, ZSOCK_IPV6_ADD_MEMBERSHIP,
+					  &mreq_v6, sizeof(mreq_v6));
+	VerifyOrExit(mcast_join_ret == 0 || (mcast_join_ret == -1 && errno == EALREADY),
 		     error = OT_ERROR_FAILED);
 	VerifyOrExit(zsock_setsockopt(mdns_sock_v6, NET_IPPROTO_IPV6, ZSOCK_IPV6_MULTICAST_LOOP,
 				      &on, sizeof(on)) == 0,
@@ -168,10 +171,11 @@ static otError mdns_socket_init_v4(uint32_t ail_iface_idx)
 	struct net_ip_mreqn mreq_v4 = {0};
 	int mcast_hops = 255;
 	int on = 1;
+	int mcast_join_ret = 0;
 
 	struct net_sockaddr_in addr = {.sin_family = NET_AF_INET,
-				   .sin_port = net_htons(MULTICAST_PORT),
-				   .sin_addr = {{{0}}}};
+				       .sin_port = net_htons(MULTICAST_PORT),
+				       .sin_addr = {{{0}}}};
 
 	mdns_sock_v4 = zsock_socket(NET_AF_INET, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
 	VerifyOrExit(mdns_sock_v4 >= 0, error = OT_ERROR_FAILED);
@@ -190,8 +194,9 @@ static otError mdns_socket_init_v4(uint32_t ail_iface_idx)
 		     error = OT_ERROR_FAILED);
 	mreq_v4.imr_ifindex = ail_iface_idx;
 	mreq_v4.imr_multiaddr.s_addr = net_htonl(0xE00000FB);
-	VerifyOrExit(zsock_setsockopt(mdns_sock_v4, NET_IPPROTO_IP, ZSOCK_IP_ADD_MEMBERSHIP,
-				      &mreq_v4, sizeof(mreq_v4)) == 0,
+	mcast_join_ret = zsock_setsockopt(mdns_sock_v4, NET_IPPROTO_IP, ZSOCK_IP_ADD_MEMBERSHIP,
+					  &mreq_v4, sizeof(mreq_v4));
+	VerifyOrExit(mcast_join_ret == 0 || (mcast_join_ret == -1 && errno == EALREADY),
 		     error = OT_ERROR_FAILED);
 	VerifyOrExit(zsock_setsockopt(mdns_sock_v4, NET_IPPROTO_IP, ZSOCK_IP_MULTICAST_LOOP,
 				      &on, sizeof(on)) == 0,
@@ -237,6 +242,10 @@ static otError mdns_socket_deinit(void)
 	sockfd_udp[1].fd = -1;
 	mdns_sock_v4 = -1;
 #endif /* CONFIG_NET_IPV4 */
+
+	VerifyOrExit(net_socket_service_register(&mdns_udp_service, sockfd_udp,
+						 ARRAY_SIZE(sockfd_udp), NULL) == 0,
+						 error = OT_ERROR_FAILED);
 exit:
 	return error;
 }
@@ -246,13 +255,13 @@ static void mdns_send_multicast(otMessage *message, uint32_t ail_iface_idx)
 	uint16_t length = otMessageGetLength(message);
 	struct otbr_msg_ctx *req = NULL;
 	struct net_sockaddr_in6 addr_v6 = {.sin6_family = NET_AF_INET6,
-				       .sin6_port = net_htons(MULTICAST_PORT),
-				       .sin6_addr = NET_IN6ADDR_ANY_INIT,
-				       .sin6_scope_id = 0};
+					   .sin6_port = net_htons(MULTICAST_PORT),
+					   .sin6_addr = NET_IN6ADDR_ANY_INIT,
+					   .sin6_scope_id = 0};
 #if defined(CONFIG_NET_IPV4)
 	struct net_sockaddr_in addr_v4 = {.sin_family = NET_AF_INET,
-				      .sin_port = net_htons(MULTICAST_PORT),
-				      .sin_addr = NET_INADDR_ANY_INIT};
+					  .sin_port = net_htons(MULTICAST_PORT),
+					  .sin_addr = NET_INADDR_ANY_INIT};
 #endif /* CONFIG_NET_IPV4*/
 
 	VerifyOrExit(length <= OTBR_MESSAGE_SIZE);
@@ -267,11 +276,11 @@ static void mdns_send_multicast(otMessage *message, uint32_t ail_iface_idx)
 
 	VerifyOrExit(zsock_sendto(mdns_sock_v6, req->buffer, length, 0,
 				  (struct net_sockaddr *)&addr_v6,
-		     sizeof(addr_v6)) > 0);
+				  sizeof(addr_v6)) > 0);
 #if defined(CONFIG_NET_IPV4)
 	VerifyOrExit(zsock_sendto(mdns_sock_v4, req->buffer, length, 0,
 				  (struct net_sockaddr *)&addr_v4,
-		     sizeof(addr_v4)) > 0);
+				  sizeof(addr_v4)) > 0);
 #endif /* CONFIG_NET_IPV4 */
 exit:
 	otMessageFree(message);
@@ -290,9 +299,9 @@ static void mdns_send_unicast(otMessage *message, const otPlatMdnsAddressInfo *a
 	struct net_sockaddr_in addr_v4 = {0};
 #endif /* CONFIG_NET_IPV4*/
 	struct net_sockaddr_in6 addr_v6 = {.sin6_family = NET_AF_INET6,
-				       .sin6_port = net_htons(aAddress->mPort),
-				       .sin6_addr = NET_IN6ADDR_ANY_INIT,
-				       .sin6_scope_id = 0};
+					   .sin6_port = net_htons(aAddress->mPort),
+					   .sin6_addr = NET_IN6ADDR_ANY_INIT,
+					   .sin6_scope_id = 0};
 
 	VerifyOrExit(length <= OTBR_MESSAGE_SIZE);
 	VerifyOrExit(openthread_border_router_allocate_message((void **)&req) == OT_ERROR_NONE);
@@ -310,7 +319,7 @@ static void mdns_send_unicast(otMessage *message, const otPlatMdnsAddressInfo *a
 
 	VerifyOrExit(zsock_sendto(mdns_sock_v6, req->buffer, length, 0,
 				  (struct net_sockaddr *)&addr_v6,
-		     sizeof(addr_v6)) > 0);
+				  sizeof(addr_v6)) > 0);
 #if defined(CONFIG_NET_IPV4)
 	if (send_ipv4) {
 		VerifyOrExit(zsock_sendto(mdns_sock_v4, req->buffer, length, 0,
@@ -345,7 +354,7 @@ static void mdns_receive_handler(struct net_socket_service_event *evt)
 	if (family == NET_AF_INET) {
 		addrlen = sizeof(addr_v4);
 		len = zsock_recvfrom(mdns_sock_v4, req->buffer, sizeof(req->buffer), 0,
-			       (struct net_sockaddr *)&addr_v4, &addrlen);
+				     (struct net_sockaddr *)&addr_v4, &addrlen);
 		VerifyOrExit(len > 0);
 		otIp4ToIp4MappedIp6Address((otIp4Address *)&addr_v4.sin_addr.s_addr,
 					   &req->addr_info.mAddress);
@@ -354,7 +363,7 @@ static void mdns_receive_handler(struct net_socket_service_event *evt)
 #endif /* CONFIG_NET_IPV4 */
 		addrlen = sizeof(addr_v6);
 		len = zsock_recvfrom(mdns_sock_v6, req->buffer, sizeof(req->buffer), 0,
-			       (struct net_sockaddr *)&addr_v6, &addrlen);
+				     (struct net_sockaddr *)&addr_v6, &addrlen);
 		VerifyOrExit(len > 0);
 		memcpy(&req->addr_info.mAddress, &addr_v6.sin6_addr,
 		       sizeof(req->addr_info.mAddress));

--- a/modules/openthread/platform/platform-zephyr.h
+++ b/modules/openthread/platform/platform-zephyr.h
@@ -129,7 +129,7 @@ otError mdns_plat_socket_init(otInstance *ot_instance, uint32_t ail_iface_idx);
 void mdns_plat_monitor_interface(struct net_if *ail_iface);
 otError border_agent_init(otInstance *instance);
 void border_agent_deinit(void);
-otError trel_plat_init(otInstance *instance, struct net_if *ail_iface_ptr);
+otError trel_plat_init(otInstance *instance, struct net_if *ail_iface);
 otError dhcpv6_pd_client_init(otInstance *ot_instance, uint32_t ail_iface_index);
 otError dns_upstream_resolver_init(otInstance *ot_instance);
 void openthread_border_router_set_nat64_translator_enabled(bool enable);

--- a/modules/openthread/platform/platform-zephyr.h
+++ b/modules/openthread/platform/platform-zephyr.h
@@ -120,6 +120,7 @@ int notify_new_tx_frame(struct net_pkt *pkt);
 
 #if defined(CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER)
 otError infra_if_init(otInstance *instance, struct net_if *ail_iface);
+otError infra_if_deinit(void);
 otError infra_if_start_icmp6_listener(void);
 void infra_if_stop_icmp6_listener(void);
 void udp_plat_init_sockfd(void);

--- a/modules/openthread/platform/trel.c
+++ b/modules/openthread/platform/trel.c
@@ -32,9 +32,9 @@ NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(trel_udp_service, trel_receive_handler, MA
 void otPlatTrelEnable(otInstance *aInstance, uint16_t *aUdpPort)
 {
 	struct net_sockaddr_in6 addr = {.sin6_family = NET_AF_INET6,
-				    .sin6_port = 0,
-				    .sin6_addr = NET_IN6ADDR_ANY_INIT,
-				    .sin6_scope_id = 0};
+					.sin6_port = 0,
+					.sin6_addr = NET_IN6ADDR_ANY_INIT,
+					.sin6_scope_id = 0};
 	net_socklen_t len = sizeof(addr);
 
 	trel_sock = zsock_socket(NET_AF_INET6, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
@@ -70,6 +70,9 @@ void otPlatTrelDisable(otInstance *aInstance)
 	sockfd_udp[0].fd = -1;
 	trel_sock = -1;
 
+	net_socket_service_register(&trel_udp_service, sockfd_udp,
+				    ARRAY_SIZE(sockfd_udp), NULL);
+
 	trel_is_enabled = false;
 
 exit:
@@ -82,15 +85,15 @@ void otPlatTrelSend(otInstance *aInstance, const uint8_t *aUdpPayload, uint16_t 
 	VerifyOrExit(trel_is_enabled);
 
 	struct net_sockaddr_in6 dest_sock_addr = {.sin6_family = NET_AF_INET6,
-				.sin6_port = net_htons(aDestSockAddr->mPort),
-				.sin6_addr = {{{0}}},
-				.sin6_scope_id = 0};
+						  .sin6_port = net_htons(aDestSockAddr->mPort),
+						  .sin6_addr = {{{0}}},
+						  .sin6_scope_id = 0};
 
 	memcpy(&dest_sock_addr.sin6_addr, &aDestSockAddr->mAddress, sizeof(otIp6Address));
 
 	if (zsock_sendto(trel_sock, aUdpPayload, aUdpPayloadLen, 0,
-				(struct net_sockaddr *)&dest_sock_addr,
-				sizeof(dest_sock_addr)) == aUdpPayloadLen) {
+			 (struct net_sockaddr *)&dest_sock_addr,
+			 sizeof(dest_sock_addr)) == aUdpPayloadLen) {
 		trel_counters.mTxBytes += aUdpPayloadLen;
 		trel_counters.mTxPackets++;
 	} else {
@@ -126,7 +129,7 @@ static void trel_receive_handler(struct net_socket_service_event *evt)
 	VerifyOrExit(openthread_border_router_allocate_message((void **)&req) == OT_ERROR_NONE);
 
 	len = zsock_recvfrom(trel_sock, req->buffer, sizeof(req->buffer), 0,
-		       (struct net_sockaddr *)&addr, &addrlen);
+			     (struct net_sockaddr *)&addr, &addrlen);
 	VerifyOrExit(len > 0);
 
 	trel_counters.mRxBytes += len;

--- a/modules/openthread/platform/udp.c
+++ b/modules/openthread/platform/udp.c
@@ -66,6 +66,9 @@ void udp_plat_deinit(void)
 			sockfd_udp[idx].fd = -1;
 		}
 	}
+
+	net_socket_service_register(&handle_udp_receive, sockfd_udp,
+				    ARRAY_SIZE(sockfd_udp), NULL);
 }
 
 otError otPlatUdpSocket(otUdpSocket *aUdpSocket)

--- a/subsys/net/l2/openthread/openthread_border_router.c
+++ b/subsys/net/l2/openthread/openthread_border_router.c
@@ -6,6 +6,7 @@
 
 #include "openthread_border_router.h"
 #include <openthread.h>
+#include <openthread/border_agent.h>
 #include <openthread/backbone_router_ftd.h>
 #include <openthread/border_router.h>
 #include <openthread/border_routing.h>
@@ -60,7 +61,7 @@ K_MEM_SLAB_DEFINE_STATIC(border_router_messages_slab, sizeof(struct otbr_msg_ctx
 		  CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_MSG_POOL_NUM, sizeof(void *));
 
 static const char *create_base_name(otInstance *ot_instance, char *base_name);
-static void openthread_border_router_add_route_to_multicast_groups(void);
+static void openthread_border_router_add_or_rm_route_to_multicast_groups(bool add);
 #if defined(CONFIG_OPENTHREAD_NAT64_TRANSLATOR)
 static void openthread_border_router_start_nat64_service(void);
 static void openthread_border_router_stop_nat64_service(void);
@@ -83,7 +84,7 @@ int openthread_start_border_router_services(struct net_if *ot_iface, struct net_
 	net_if_flag_set(ot_iface, NET_IF_FORWARD_MULTICASTS);
 	net_if_flag_set(ail_iface, NET_IF_FORWARD_MULTICASTS);
 
-	openthread_border_router_add_route_to_multicast_groups();
+	openthread_border_router_add_or_rm_route_to_multicast_groups(true);
 
 	openthread_mutex_lock();
 
@@ -136,6 +137,9 @@ int openthread_start_border_router_services(struct net_if *ot_iface, struct net_
 		error = -EIO;
 		goto exit;
 	}
+	if (!otBorderAgentIsEnabled(instance)) {
+		otBorderAgentSetEnabled(instance, true);
+	}
 	if (otPlatInfraIfStateChanged(instance, ail_iface_index, true) != OT_ERROR_NONE) {
 		error = -EIO;
 		goto exit;
@@ -187,11 +191,14 @@ static int openthread_stop_border_router_services(struct net_if *ot_iface,
 		}
 		otBackboneRouterSetEnabled(instance, false);
 		border_agent_deinit();
+		(void)infra_if_deinit();
 		infra_if_stop_icmp6_listener();
+		otBorderAgentSetEnabled(instance, false);
 		udp_plat_deinit();
 #if defined(CONFIG_OPENTHREAD_NAT64_TRANSLATOR)
 		openthread_border_router_stop_nat64_service();
 #endif /* CONFIG_OPENTHREAD_NAT64_TRANSLATOR */
+		openthread_border_router_add_or_rm_route_to_multicast_groups(false);
 
 	}
 exit:
@@ -604,7 +611,7 @@ bool openthread_border_router_check_packet_forwarding_rules(struct net_pkt *pkt)
 	return true;
 }
 
-static void openthread_border_router_add_route_to_multicast_groups(void)
+static void openthread_border_router_add_or_rm_route_to_multicast_groups(bool add)
 {
 	static uint8_t mcast_group_idx[] = {
 		0x04, /** Admin-Local scope multicast address */
@@ -619,12 +626,29 @@ static void openthread_border_router_add_route_to_multicast_groups(void)
 	ARRAY_FOR_EACH(mcast_group_idx, i) {
 
 		net_ipv6_addr_create(&addr, (0xff << 8) | mcast_group_idx[i], 0, 0, 0, 0, 0, 0, 0);
-		entry = net_route_mcast_add(ail_iface_ptr, &addr, 16);
-		if (entry != NULL) {
-			mcast_addr = net_if_ipv6_maddr_add(ail_iface_ptr,
-							   (const struct net_in6_addr *)&addr);
+		if (add) {
+			entry = net_route_mcast_add(ail_iface_ptr, &addr, 16);
+			if (entry != NULL) {
+				mcast_addr = net_if_ipv6_maddr_add(ail_iface_ptr,
+								(const struct net_in6_addr *)&addr);
+				if (mcast_addr != NULL) {
+					net_if_ipv6_maddr_join(ail_iface_ptr, mcast_addr);
+				}
+			}
+		} else {
+			entry = net_route_mcast_lookup(&addr);
+			mcast_addr = net_if_ipv6_maddr_lookup(&addr, &(ail_iface_ptr));
+			if (entry != NULL) {
+				net_route_mcast_del(entry);
+			}
+			/* There is no need to check if address is joined,
+			 * as `clear_joined_ipv6_mcast_groups` was previously
+			 * called
+			 */
 			if (mcast_addr != NULL) {
-				net_if_ipv6_maddr_join(ail_iface_ptr, mcast_addr);
+				net_if_ipv6_maddr_leave(ail_iface_ptr, mcast_addr);
+				net_if_ipv6_maddr_rm(ail_iface_ptr,
+						(const struct net_in6_addr *)&addr);
 			}
 		}
 	}
@@ -647,8 +671,8 @@ void openthread_border_router_set_nat64_translator_enabled(bool enable)
 static void openthread_border_router_start_nat64_service(void)
 {
 	otInstance *instance = openthread_get_default_instance();
-	struct in_addr *ipv4_addr = NULL;
-	struct in_addr ipv4_def_route = {0};
+	struct net_in_addr *ipv4_addr = NULL;
+	struct net_in_addr ipv4_def_route = {0};
 	bool translator_state = false;
 	otIp4Cidr cidr;
 


### PR DESCRIPTION
Main goal of this PR is to handle a WI-Fi connect/disconnect or link lost and link re-established scenario.
OpenThread's platform code has been enhanced to handle those events.
Border Router application code has been updated to de-initialize platform modules and remove its multicast routes.
TREL code has been updated to accommodate user enable/disable interaction from CLI.