### PR TITLE
soc: silabs: siwg917: add needed dependency when PM device is enabled

### DIFF
--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -13,6 +13,16 @@ configdefault SYS_CLOCK_TICKS_PER_SEC
 configdefault UART_NS16550_DW8250_DW_APB
 	default y
 
+if PM_DEVICE
+
+configdefault PM_DEVICE_RUNTIME
+	default y
+
+configdefault POWER_DOMAIN
+	default y
+
+endif # PM_DEVICE
+
 if SILABS_SIWX91X_NWP
 
 # WiseConnect create threads with realtime priority. Default (10kHz) clock tick


### PR DESCRIPTION
This PR fixes a compilation error when CONFIG_PM_DEVICE is enabled without CONFIG_PM_DEVICE_RUNTIME and CONFIG_POWER_DOMAIN.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/99644

Fix CI error :https://github.com/zephyrproject-rtos/zephyr/actions/runs/19399100918/job/55503531414 