### PR TITLE
drivers: clock_control: smartbond: Move calibration to DT

### DIFF
--- a/drivers/clock_control/Kconfig.smartbond
+++ b/drivers/clock_control/Kconfig.smartbond
@@ -8,14 +8,3 @@ config CLOCK_CONTROL_SMARTBOND
 	depends on SOC_FAMILY_RENESAS_SMARTBOND
 	help
 	  Enable driver for Clock Control subsystem found in SmartBond
-
-if CLOCK_CONTROL_SMARTBOND
-
-config SMARTBOND_LP_OSC_CALIBRATION_INTERVAL
-	int "Low-power oscillators calibration interval"
-	default 1
-	range 1 10
-	help
-	  Time in seconds between calibration of low power clock RC32K and RCX.
-
-endif # CLOCK_CONTROL_SMARTBOND

--- a/dts/arm/renesas/smartbond/da1469x.dtsi
+++ b/dts/arm/renesas/smartbond/da1469x.dtsi
@@ -56,6 +56,7 @@
 				compatible = "renesas,smartbond-lp-osc";
 				clock-frequency = <DT_FREQ_K(32)>;
 				#clock-cells = <0>;
+				calibration-interval = <1000>;
 				status = "okay";
 			};
 
@@ -71,6 +72,7 @@
 				compatible = "renesas,smartbond-lp-osc";
 				clock-frequency = <DT_FREQ_K(15)>;
 				#clock-cells = <0>;
+				calibration-interval = <1000>;
 				status = "okay";
 			};
 

--- a/dts/bindings/clock/renesas,smartbond-lp-osc.yaml
+++ b/dts/bindings/clock/renesas,smartbond-lp-osc.yaml
@@ -18,3 +18,12 @@ properties:
     default: 8000
     description: |
       This is only valid for XTAL32K. Time in ms needed to XTAL32K to settle.
+  calibration-interval:
+    type: int
+    default: 1000
+    description: |
+      Time interval (ms) between oscillator calibrations.
+      Setting this value to 0 disables calibration entirely.
+      Calibration should only be disabled in tests that require strict thread
+      scheduling, where even minimal unexpected CPU usage from calibration
+      could cause failures.

--- a/tests/kernel/sched/schedule_api/boards/da14695_dk_usb.overlay
+++ b/tests/kernel/sched/schedule_api/boards/da14695_dk_usb.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Clock control for Smartbond schedules delayed work
+ * that interferes with slice scheduling test.
+ * Slice scheduling test does not expect any additional
+ * thread to be scheduled during test.
+ * This simply sets xtal32k settle time to fire way
+ * before slice test is started.
+ * RCX and RC32K calibration intervals are set to 0
+ * to disable calibration for tests.
+ */
+
+&xtal32k {
+	settle-time = <500>;
+};
+
+&rcx {
+	calibration-interval = <0>;
+};
+
+&rc32k {
+	calibration-interval = <0>;
+};

--- a/tests/kernel/sched/schedule_api/boards/da1469x_dk_pro.overlay
+++ b/tests/kernel/sched/schedule_api/boards/da1469x_dk_pro.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Clock control for Smartbond schedules delayed work
+ * that interferes with slice scheduling test.
+ * Slice scheduling test does not expect any additional
+ * thread to be scheduled during test.
+ * This simply sets xtal32k settle time to fire way
+ * before slice test is started.
+ * RCX and RC32K calibration intervals are set to 0
+ * to disable calibration for tests.
+ */
+
+&xtal32k {
+	settle-time = <500>;
+};
+
+&rcx {
+	calibration-interval = <0>;
+};
+
+&rc32k {
+	calibration-interval = <0>;
+};


### PR DESCRIPTION
With this change calibration interval for oscillator is configurable in DT instead of Kconfig.
This allows to have different calibration intervals for RCX and RC32K.

This change also allows to have calibration interval set to 0 to disable calibration.

Second commit adds overlays for Smartbond boards to **shedul_api** tests to disable calibration works during tests that require very strict timing.

This fixes: #99501

Test output with this change and another required fix: #99316
```sh
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [threads_scheduling]: pass = 28, fail = 0, skip = 0, total = 28 duration = 17.059 seconds
 - PASS - [threads_scheduling.test_bad_priorities] duration = 0.002 seconds
 - PASS - [threads_scheduling.test_busy_wait_cooperative] duration = 0.103 seconds
 - PASS - [threads_scheduling.test_k_thread_priority_get_init_null] duration = 0.047 seconds
 - PASS - [threads_scheduling.test_k_thread_priority_set_init_null] duration = 0.047 seconds
 - PASS - [threads_scheduling.test_k_thread_priority_set_overmax] duration = 0.042 seconds
 - PASS - [threads_scheduling.test_k_thread_priority_set_upgrade] duration = 0.044 seconds
 - PASS - [threads_scheduling.test_k_thread_resume_init_null] duration = 0.046 seconds
 - PASS - [threads_scheduling.test_k_thread_suspend_init_null] duration = 0.046 seconds
 - PASS - [threads_scheduling.test_k_wakeup_init_null] duration = 0.045 seconds
 - PASS - [threads_scheduling.test_lock_preemptible] duration = 0.204 seconds
 - PASS - [threads_scheduling.test_pending_thread_wakeup] duration = 0.003 seconds
 - PASS - [threads_scheduling.test_priority_cooperative] duration = 0.103 seconds
 - PASS - [threads_scheduling.test_priority_preemptible] duration = 0.105 seconds
 - PASS - [threads_scheduling.test_priority_scheduling] duration = 0.041 seconds
 - PASS - [threads_scheduling.test_sched_is_preempt_thread] duration = 0.004 seconds
 - PASS - [threads_scheduling.test_sleep_cooperative] duration = 0.103 seconds
 - PASS - [threads_scheduling.test_sleep_wakeup_preemptible] duration = 0.004 seconds
 - PASS - [threads_scheduling.test_slice_perthread] duration = 0.016 seconds
 - PASS - [threads_scheduling.test_slice_reset] duration = 1.806 seconds
 - PASS - [threads_scheduling.test_slice_scheduling] duration = 13.022 seconds
 - PASS - [threads_scheduling.test_time_slicing_disable_preemptible] duration = 0.503 seconds
 - PASS - [threads_scheduling.test_time_slicing_preemptible] duration = 0.503 seconds
 - PASS - [threads_scheduling.test_unlock_nested_sched_lock] duration = 0.103 seconds
 - PASS - [threads_scheduling.test_unlock_preemptible] duration = 0.103 seconds
 - PASS - [threads_scheduling.test_user_k_is_preempt] duration = 0.005 seconds
 - PASS - [threads_scheduling.test_user_k_wakeup] duration = 0.003 seconds
 - PASS - [threads_scheduling.test_wakeup_expired_timer_thread] duration = 0.003 seconds
 - PASS - [threads_scheduling.test_yield_cooperative] duration = 0.003 seconds

SUITE PASS - 100.00% [threads_scheduling_1cpu]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.035 seconds
 - PASS - [threads_scheduling_1cpu.test_priority_preemptible_wait_prio] duration = 0.035 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL

```

while it was failing before
```sh
===================================================================
START - test_slice_scheduling
ABCDD
    Assertion failed at WEST_TOPDIR/zephyr/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c:64: thread_tslice: ((tdelta >= expected_slice_min) && (tdelta <= expected_slice_max) && (idx == thread_idx)) is false

E
    Assertion failed at WEST_TOPDIR/zephyr/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c:64: thread_tslice: ((tdelta >= expected_slice_min) && (tdelta <= expected_slice_max) && (idx == thread_idx)) is false

F
    Assertion failed at WEST_TOPDIR/zephyr/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c:64: thread_tslice: ((tdelta >= expected_slice_min) && (tdelta <= expected_slice_max) && (idx == thread_idx)) is false

G
    Assertion failed at WEST_TOPDIR/zephyr/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c:64: thread_tslice: ((tdelta >= expected_slice_min) && (tdelta <= expected_slice_max) && (idx == thread_idx)) is false

H
    Assertion failed at WEST_TOPDIR/zephyr/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c:64: thread_tslice: ((tdelta >= expected_slice_min) && (tdelta <= expected_slice_max) && (idx == thread_idx)) is false

I
    Assertion failed at WEST_TOPDIR/zephyr/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c:64: thread_tslice: ((tdelta >= expected_slice_min) && (tdelta <= expected_slice_max) && (idx == thread_idx)) is false


```