### PR TITLE
samples: ipc: openamp_rsc_table: add stm32mp257F boards support

### DIFF
--- a/boards/st/stm32mp257f_dk/stm32mp257f_dk_stm32mp257fxx_m33.dts
+++ b/boards/st/stm32mp257f_dk/stm32mp257f_dk_stm32mp257fxx_m33.dts
@@ -74,6 +74,10 @@
 	status = "okay";
 };
 
+&mailbox {
+	status = "okay";
+};
+
 &uart5 {
 	pinctrl-0 = <&uart5_tx_pg9 &uart5_rx_pg10>;
 	pinctrl-names = "default";

--- a/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.dts
+++ b/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.dts
@@ -70,6 +70,10 @@
 	status = "okay";
 };
 
+&mailbox {
+	status = "okay";
+};
+
 &spi3 {
 	pinctrl-0 = <&spi3_nss_pb1 &spi3_sck_pb7
 		     &spi3_miso_pb10 &spi3_mosi_pb8>;

--- a/dts/arm/st/mp2/stm32mp2_m33.dtsi
+++ b/dts/arm/st/mp2/stm32mp2_m33.dtsi
@@ -68,6 +68,14 @@
 				      <12 1>, <13 1>, <14 1>, <15 1>;
 		};
 
+		mailbox: ipcc1@40490000 {
+			compatible = "st,stm32-ipcc-mailbox";
+			reg = <0x40490000 0x400>;
+			interrupts = <171 0>, <172 0>;
+			interrupt-names = "rxo", "txf";
+			status = "disabled";
+		};
+
 		pinctrl: pin-controller@44240000 {
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;

--- a/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
+++ b/dts/bindings/ipm/st,stm32-ipcc-mailbox.yaml
@@ -6,7 +6,3 @@ description: STM32 IPCC MAILBOX
 compatible: "st,stm32-ipcc-mailbox"
 
 include: base.yaml
-
-properties:
-  clocks:
-    required: true

--- a/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp257f_dk_stm32mp257fxx_m33.conf
+++ b/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp257f_dk_stm32mp257fxx_m33.conf
@@ -1,0 +1,1 @@
+CONFIG_LOG=y

--- a/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp257f_dk_stm32mp257fxx_m33.overlay
+++ b/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp257f_dk_stm32mp257fxx_m33.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025, STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		/*
+		 * shared memory reserved for the inter-processor communication
+		 */
+		zephyr,ipc_shm = &ipc_shmem;
+		zephyr,ipc = &mailbox;
+	};
+
+	ipc_shmem: memory1@81200000 {
+		compatible = "mmio-sram";
+		reg = <0x81200000 DT_SIZE_M(1)>;
+	};
+};

--- a/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp257f_ev1_stm32mp257fxx_m33.conf
+++ b/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp257f_ev1_stm32mp257fxx_m33.conf
@@ -1,0 +1,1 @@
+CONFIG_LOG=y

--- a/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp257f_ev1_stm32mp257fxx_m33.overlay
+++ b/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp257f_ev1_stm32mp257fxx_m33.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025, STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		/*
+		 * shared memory reserved for the inter-processor communication
+		 */
+		zephyr,ipc_shm = &ipc_shmem;
+		zephyr,ipc = &mailbox;
+	};
+
+	ipc_shmem: memory1@81200000 {
+		compatible = "mmio-sram";
+		reg = <0x81200000 DT_SIZE_M(1)>;
+	};
+};


### PR DESCRIPTION
- Enable the IPCC1 for the stm32mp25F series.
- Add the support of the stm32mp257F EVA and DK board  for the  openamp_rsc_table sample.