### PR TITLE
soc: intel_adsp: ace30: allow userspace to execute cold functions

### DIFF
--- a/soc/intel/intel_adsp/ace/mmu_ace30.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace30.c
@@ -129,7 +129,7 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 	{
 		.start = (uint32_t)__cold_start,
 		.end   = (uint32_t)__cold_end,
-		.attrs = XTENSA_MMU_PERM_X,
+		.attrs = XTENSA_MMU_PERM_X | XTENSA_MMU_MAP_SHARED,
 		.name = "imr cold",
 	},
 	{


### PR DESCRIPTION
Add access to functions in cold section for XTENSA_MMU_MAP_SHARED (used for user-space threads). This allows to call functions marked with "__cold" from user threads.

Suggested-by: Guennadi Liakhovetski <guennadi.liakhovetski@linux.intel.com>