### PR TITLE
boards: st: stm32u5g9j_dk: adjust adc prescaler

### DIFF
--- a/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
+++ b/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
@@ -248,7 +248,7 @@
 	pinctrl-0 = <&adc1_in5_pa0 &adc1_in12_pa7>;
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";
-	st,adc-prescaler = <1>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 
 	#address-cells = <1>;


### PR DESCRIPTION
Set ADC prescaler to 2 instead of 1 for the STM32U5G9J-DK board. A prescaler of 1 results in incorrect measurements while 2 returns the expected values.