### PR TITLE
Bluetooth: BAP: Missing assignment to aggregated_bis_syncs

### DIFF
--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -1568,6 +1568,8 @@ static bool valid_bt_bap_scan_delegator_add_src_param(
 			return false;
 		}
 
+		aggregated_bis_syncs |= subgroup->bis_sync;
+
 		if (subgroup->metadata_len > CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE) {
 			LOG_DBG("subgroup[%u]: Invalid metadata_len: %u",
 				i, subgroup->metadata_len);
@@ -1678,6 +1680,8 @@ static bool valid_bt_bap_scan_delegator_mod_src_param(
 
 			return false;
 		}
+
+		aggregated_bis_syncs |= subgroup->bis_sync;
 
 		if (subgroup->metadata_len > CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE) {
 			LOG_DBG("subgroup[%u]: Invalid metadata_len: %u",


### PR DESCRIPTION
When using the add_src and mod_src APIs the
aggregated_bis_syncs variable was only ever set to 0 and never updated, thus making all calls to
bis_syncs_unique_or_no_pref to be true.