### PR TITLE
arch: arm: cortex_m: Allow VTOR to be relocated to TCM

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -190,4 +190,43 @@ config HAS_SWO
 	help
 	  When enabled, indicates that SoC has an SWO output
 
+DT_CHOSEN_Z_DTCM := zephyr,dtcm
+DT_CHOSEN_Z_ITCM := zephyr,itcm
+
+choice
+	prompt "Vector table memory location"
+	depends on SRAM_VECTOR_TABLE
+	default ARM_VECTOR_TABLE_SRAM
+
+config ARM_VECTOR_TABLE_SRAM
+	bool "Place the vector table in DT Chosen SRAM instead of DT Chosen Flash"
+	help
+	  When executing in place (XiP), selecting this option will result in the
+	  interrupt vector table being relocated from DT 'zephyr,flash' chosen
+	  memory to DT 'zephyr,sram' chosen memory.
+
+config ARM_VECTOR_TABLE_DTCM
+	bool "Place the vector table in DT Chosen DTCM instead of DT Chosen Flash"
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_Z_DTCM))
+	help
+	  When executing in place (XiP), selecting this option will result in the
+	  interrupt vector table being relocated from DT 'zephyr,flash' chosen
+	  memory to DT 'zephyr,dtcm' chosen memory. While the vector table is
+	  instruction-fetched during exception entry, a DTCM option is provided
+	  for systems where ITCM is unavailable. DTCM still offers low-latency,
+	  deterministic access compared to normal RAM, but is not the optimal
+	  location for instruction fetch performance.
+
+config ARM_VECTOR_TABLE_ITCM
+	bool "Place the vector table in DT Chosen ITCM instead of DT Chosen Flash"
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_Z_ITCM))
+	help
+	  When executing in place (XiP), selecting this option will result in the
+	  interrupt vector table being relocated from DT 'zephyr,flash' chosen
+	  memory to DT 'zephyr,itcm' chosen memory. ITCM provides single-cycle,
+	  deterministic instruction fetches via the CPU instruction bus, it offers
+	  the lowest interrupt latency and is the preferred location when available.
+
+endchoice
+
 endmenu

--- a/arch/arm/core/cortex_m/ram_vector_table.ld
+++ b/arch/arm/core/cortex_m/ram_vector_table.ld
@@ -28,5 +28,11 @@ SECTION_PROLOGUE(.sram_vt,,)
 	. += _vector_end - _vector_start;
 	MPU_ALIGN(_sram_vector_size);
 	_sram_vector_end = .;
+#if defined(CONFIG_ARM_VECTOR_TABLE_ITCM)
+} GROUP_DATA_LINK_IN(ITCM, ROMABLE_REGION)
+#elif defined(CONFIG_ARM_VECTOR_TABLE_DTCM)
+} GROUP_DATA_LINK_IN(DTCM, ROMABLE_REGION)
+#else
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#endif
 _sram_vector_size = _sram_vector_end - _sram_vector_start;

--- a/tests/application_development/vector_table_relocation/testcase.yaml
+++ b/tests/application_development/vector_table_relocation/testcase.yaml
@@ -11,3 +11,15 @@ tests:
       - mps3/corstone310/fvp
       - mps4/corstone315/fvp
       - mps4/corstone320/fvp
+
+  application_development.vector_table_relocation.dtcm:
+    arch_allow: arm
+    filter: CONFIG_CPU_CORTEX_M_HAS_VTOR and dt_chosen_enabled("zephyr,dtcm")
+    extra_configs:
+      - CONFIG_ARM_VECTOR_TABLE_DTCM=y
+
+  application_development.vector_table_relocation.itcm:
+    arch_allow: arm
+    filter: CONFIG_CPU_CORTEX_M_HAS_VTOR and dt_chosen_enabled("zephyr,itcm")
+    extra_configs:
+      - CONFIG_ARM_VECTOR_TABLE_ITCM=y


### PR DESCRIPTION
This change allows you to move the interrupt vector table to ITCM or DTCM instead of SRAM, which provides deterministic, single-cycle access, unlike multi-cycle SRAM reads that may incur additional wait states. This reduces exception entry latency and benefits real-time and interrupt-driven workloads.

Both ITCM and DTCM are supported for vector table placement. ITCM is accessed via the CPU instruction bus and typically provides the lowest possible interrupt latency, making it the preferred location when available. DTCM, while on the data bus, still offers significantly faster and more predictable access compared to SRAM and serves as a suitable alternative where ITCM is unavailable or reserved for hot code.