### PR TITLE
samples: net: ocpp: add websocket path configuration option

### DIFF
--- a/samples/net/ocpp/Kconfig
+++ b/samples/net/ocpp/Kconfig
@@ -14,6 +14,13 @@ config NET_SAMPLE_OCPP_PORT
 	help
 	  OCPP central system server port
 
+config NET_SAMPLE_OCPP_WS_PATH
+	string "OCPP websocket path"
+	default "/steve/websocket/CentralSystemService/zephyr"
+	help
+	  WebSocket URL path (excluding IP address and port) for OCPP connection to the central
+	  system server.
+
 config NET_SAMPLE_SNTP_SERVER
 	string "SNTP server ip"
 	help

--- a/samples/net/ocpp/README.rst
+++ b/samples/net/ocpp/README.rst
@@ -26,6 +26,21 @@ Requirements
 - SteVe Demo Server (<https://github.com/steve-community/steve/blob/master/README.md>)
 - LAN for testing purposes (Ethernet)
 
+Configuration
+*************
+
+The sample application supports several configuration options that can be set
+via Kconfig:
+
+- ``CONFIG_NET_SAMPLE_OCPP_SERVER``: OCPP central system server IP address
+
+- ``CONFIG_NET_SAMPLE_OCPP_PORT``: OCPP central system server port number
+
+- ``CONFIG_NET_SAMPLE_OCPP_WS_PATH``: WebSocket URL path.
+
+- ``CONFIG_NET_SAMPLE_SNTP_SERVER``: SNTP server IP address to get the time
+  from network
+
 Building and Running
 ********************
 

--- a/samples/net/ocpp/src/main.c
+++ b/samples/net/ocpp/src/main.c
@@ -289,10 +289,10 @@ int main(void)
 	char *ip = NULL;
 
 	struct ocpp_cp_info cpi = { "basic", "zephyr", .num_of_con = NO_OF_CONN };
-	struct ocpp_cs_info csi = { NULL,
-				    "/steve/websocket/CentralSystemService/zephyr",
-				    CONFIG_NET_SAMPLE_OCPP_PORT,
-				    AF_INET };
+	struct ocpp_cs_info csi = {NULL,
+				   CONFIG_NET_SAMPLE_OCPP_WS_PATH,
+				   CONFIG_NET_SAMPLE_OCPP_PORT,
+				   AF_INET};
 
 	printk("OCPP sample %s\n", CONFIG_BOARD);
 


### PR DESCRIPTION
Make the WebSocket path configurable since having it hardcoded in the sample is not practical.