### PR TITLE
riscv: pmp: Add support for unlocked global PMP entries

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -410,6 +410,14 @@ config PMP_GRANULARITY
 	  (ie 4, 8, 16, ...), but if neither TOR mode nor NA4 mode is
 	  supported, the minimum granularity is 8.
 
+config PMP_NO_LOCK_GLOBAL
+	bool "Do not lock the global PMP entries"
+	select PMP_KERNEL_MODE_DYNAMIC
+	help
+	  Configure the PMP entries as unlocked (L=0) to implement PMP relative
+	  features. This allows application to dynamically reconfigure PMP
+	  entries without requiring hard reset.
+
 endif #RISCV_PMP
 
 config PMP_STACK_GUARD

--- a/tests/arch/riscv/pmp/isr-stack-guard/testcase.yaml
+++ b/tests/arch/riscv/pmp/isr-stack-guard/testcase.yaml
@@ -23,3 +23,23 @@ tests:
     extra_args: EXTRA_CFLAGS=-DPMP_TEST_FUNC_IDX=1
     extra_configs:
       - CONFIG_MULTITHREADING=y
+  arch.riscv.pmp.no-mt.isr-stack-guard.unlocked:
+    extra_args: EXTRA_CFLAGS=-DPMP_TEST_FUNC_IDX=0
+    extra_configs:
+      - CONFIG_MULTITHREADING=n
+      - CONFIG_PMP_NO_LOCK_GLOBAL=y
+  arch.riscv.pmp.no-mt.main-stack-guard.unlocked:
+    extra_args: EXTRA_CFLAGS=-DPMP_TEST_FUNC_IDX=1
+    extra_configs:
+      - CONFIG_MULTITHREADING=n
+      - CONFIG_PMP_NO_LOCK_GLOBAL=y
+  arch.riscv.pmp.mt.isr-stack-guard.unlocked:
+    extra_args: EXTRA_CFLAGS=-DPMP_TEST_FUNC_IDX=0
+    extra_configs:
+      - CONFIG_MULTITHREADING=y
+      - CONFIG_PMP_NO_LOCK_GLOBAL=y
+  arch.riscv.pmp.mt.main-stack-guard.unlocked:
+    extra_args: EXTRA_CFLAGS=-DPMP_TEST_FUNC_IDX=1
+    extra_configs:
+      - CONFIG_MULTITHREADING=y
+      - CONFIG_PMP_NO_LOCK_GLOBAL=y


### PR DESCRIPTION
Adds the Kconfig option `PMP_NO_LOCK_GLOBAL` to remove the PMP Lock bit usage for global entries. The global entry is an internal detail of the driver implementation and should not be reflected in the user interface. This allows the application to dynamically reconfigure the PMP entries without requiring hard reset. This is essential for firmware that performs an RO-to-RW jump. By keeping these system entries unlocked, higher-privileged M-mode code can dynamically reconfigure memory permissions during the secure handover process, which is not possible if the entries are permanently locked during early boot.

Adds four new test cases to validate the PMP stack guard protection when `CONFIG_PMP_NO_LOCK_GLOBAL` is enabled (i.e., when PMP entries are not globally locked).

