### PR TITLE
tests: mspi: flash: Use platform_allow for the no-multithreading test

### DIFF
--- a/tests/drivers/mspi/flash/testcase.yaml
+++ b/tests/drivers/mspi/flash/testcase.yaml
@@ -38,7 +38,7 @@ tests:
       - CONFIG_MSPI_DW_HANDLE_FIFOS_IN_SYSTEM_WORKQUEUE=y
   drivers.mspi.flash.mspi_nor_no_multithreading:
     filter: dt_alias_exists("mspi0") and CONFIG_FLASH_MSPI_NOR
-    integration_platforms:
+    platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_configs:
       - CONFIG_MULTITHREADING=n


### PR DESCRIPTION
Since many boards enable features that require multithreading (e.g. USB) that conflict directly with the `CONFIG_MULTITHREADING=n` required for the test variant, and the filter:
`filter: dt_alias_exists("mspi0") and CONFIG_FLASH_MSPI_NOR` does not work since that requires Devicetree and Kconfig building successfully, which is not the case here (Kconfig fails since dependencies are not met).