### PR TITLE
tests: riscv: Add unit tests for riscv_pmp_decode_region

### DIFF
--- a/tests/arch/riscv/pmp/pmp-decode-region/CMakeLists.txt
+++ b/tests/arch/riscv/pmp/pmp-decode-region/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(riscv_pmp)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+target_include_directories(app PRIVATE
+  ${ZEPHYR_BASE}/kernel/include
+  ${ZEPHYR_BASE}/arch/${ARCH}/include
+  )

--- a/tests/arch/riscv/pmp/pmp-decode-region/prj.conf
+++ b/tests/arch/riscv/pmp/pmp-decode-region/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/arch/riscv/pmp/pmp-decode-region/src/main.c
+++ b/tests/arch/riscv/pmp/pmp-decode-region/src/main.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel_internal.h>
+#include <zephyr/tc_util.h>
+#include <zephyr/ztest.h>
+
+ZTEST(riscv_pmp_decode_region, test_pmp_tor_index_0)
+{
+	unsigned long pmp_addr[] = {
+		0x10000000U >> 2,
+		0,
+	};
+	uint8_t cfg = PMP_TOR;
+	unsigned int index = 0;
+	unsigned long start_addr, end_addr;
+
+	unsigned long expected_end = 0x10000000U - 1;
+
+	pmp_decode_region(cfg, pmp_addr, index, &start_addr, &end_addr);
+
+	zassert_equal(0, start_addr, "TOR index 0 start address mismatch");
+	zassert_equal(expected_end, end_addr, "TOR index 0 end address mismatch");
+}
+
+ZTEST(riscv_pmp_decode_region, test_pmp_tor_index_n)
+{
+	unsigned long pmp_addr[] = {
+		0x10000000U >> 2,
+		0x20000000U >> 2,
+	};
+	uint8_t cfg = PMP_TOR;
+	unsigned int index = 1;
+	unsigned long start_addr, end_addr;
+
+	unsigned long expected_start = 0x10000000U;
+	unsigned long expected_end = 0x20000000U - 1;
+
+	pmp_decode_region(cfg, pmp_addr, index, &start_addr, &end_addr);
+
+	zassert_equal(expected_start, start_addr, "TOR index n start address mismatch");
+	zassert_equal(expected_end, end_addr, "TOR index n end address mismatch");
+}
+
+ZTEST(riscv_pmp_decode_region, test_pmp_na4)
+{
+	unsigned long pmp_addr[] = {
+		0xADBEEF00U >> 2,
+	};
+	uint8_t cfg = PMP_NA4;
+	unsigned int index = 0;
+	unsigned long start_addr, end_addr;
+
+	unsigned long expected_start = 0xADBEEF00U;
+	unsigned long expected_end = 0xADBEEF00U + 3;
+
+	pmp_decode_region(cfg, pmp_addr, index, &start_addr, &end_addr);
+
+	zassert_equal(expected_start, start_addr, "NA4 start address mismatch");
+	zassert_equal(expected_end, end_addr, "NA4 end address mismatch");
+}
+
+ZTEST(riscv_pmp_decode_region, test_pmp_napot)
+{
+	unsigned long pmp_addr[] = {0x20000000U >> 2};
+	uint8_t cfg = PMP_NAPOT;
+	unsigned int index = 0;
+	unsigned long start_addr, end_addr;
+
+	unsigned long expected_start = 0x20000000U;
+	unsigned long expected_end = 0x20000007U;
+
+	pmp_decode_region(cfg, pmp_addr, index, &start_addr, &end_addr);
+	zassert_equal(expected_start, start_addr, "NAPOT 8-byte start address mismatch");
+	zassert_equal(expected_end, end_addr, "NAPOT 8-byte end address mismatch");
+}
+
+ZTEST(riscv_pmp_decode_region, test_pmp_default_disabled)
+{
+	unsigned long pmp_addr[] = {0x12345678U >> 2};
+	uint8_t cfg = 0x00;
+	unsigned int index = 0;
+	unsigned long start_addr, end_addr;
+
+	pmp_decode_region(cfg, pmp_addr, index, &start_addr, &end_addr);
+	zassert_equal(0, start_addr, "Default start address mismatch");
+	zassert_equal(0, end_addr, "Default end address mismatch");
+}
+
+ZTEST_SUITE(riscv_pmp_decode_region, NULL, NULL, NULL, NULL, NULL);

--- a/tests/arch/riscv/pmp/pmp-decode-region/testcase.yaml
+++ b/tests/arch/riscv/pmp/pmp-decode-region/testcase.yaml
@@ -1,0 +1,9 @@
+common:
+  platform_allow:
+    - qemu_riscv32
+    - qemu_riscv32e
+    - qemu_riscv64
+  filter: CONFIG_RISCV_PMP
+
+tests:
+  arch.riscv.pmp.decode.region: {}


### PR DESCRIPTION
This commit introduces a suite of unit tests for the `pmp_decode_region` function using the Ztest framework. The tests validate the correct calculation of start and end addresses for various RISC-V PMP (Physical Memory Protection) entry configurations.

The following scenarios are covered:
- TOR (Top of Range) mode for index 0.
- TOR (Top of Range) mode for index > 0.
- NA4 (Naturally Aligned Four-byte) mode.
- NAPOT (Naturally Aligned Power-of-Two) mode.
- Default behavior for a disabled PMP entry.

These tests ensure the PMP region decoding logic is accurate across different addressing modes.