### PR TITLE
tests: riscv Remove redundant z_riscv_pmp_read_config declaration

### DIFF
--- a/tests/arch/riscv/pmp/clear-pmp-unlocked-entries/src/main.c
+++ b/tests/arch/riscv/pmp/clear-pmp-unlocked-entries/src/main.c
@@ -7,8 +7,6 @@
 #include <zephyr/tc_util.h>
 #include <zephyr/ztest.h>
 
-void z_riscv_pmp_read_config(unsigned long *pmp_cfg, size_t pmp_cfg_size);
-
 /* Checks if the Machine Privilege Register Virtualization (MPRV) bit in mstatus is 1 (enabled). */
 static bool riscv_mprv_is_enabled(void)
 {


### PR DESCRIPTION
The function prototype for `z_riscv_pmp_read_config()` was previously declared in `tests/arch/riscv/pmp/clear-pmp-unlocked-entries/src/main.c`.

This local declaration is no longer necessary as the prototype is now defined within the centralized PMP header, `include/arch/riscv/pmp.h`, which is already included via `kernel_internal.h`. The prototype is guarded by the `CONFIG_ZTEST` Kconfig option.