### PR TITLE
doc: Sensor Read and Decode no longer Experimental

### DIFF
--- a/doc/hardware/peripherals/sensor/read_and_decode.rst
+++ b/doc/hardware/peripherals/sensor/read_and_decode.rst
@@ -3,13 +3,12 @@
 Read and Decode
 ###############
 
-The quickly stabilizing experimental APIs for reading sensor data are:
+The quickly stabilizing APIs for reading sensor data are:
 
 * :c:func:`sensor_read`
 * :c:func:`sensor_read_async_mempool`
 * :c:func:`sensor_get_decoder`
 * :c:func:`sensor_decode`
-
 
 Benefits over :ref:`sensor-fetch-and-get`
 *********************************************************


### PR DESCRIPTION
The docs signaled to readers that Read and Decode was an experimental API while Kconfig did not. These are no longer experimental APIs. We have a solid number of implementations in the tree now showing these APIs in use in the real world. They are still however stabilizing!