### PR TITLE
riscv: pmp: Add API to change region permissions at runtime

### DIFF
--- a/include/zephyr/arch/riscv/pmp.h
+++ b/include/zephyr/arch/riscv/pmp.h
@@ -12,6 +12,32 @@
 #ifdef CONFIG_RISCV_PMP
 
 /**
+ * @brief Change the memory protection (R/W/X) permissions for a defined region.
+ *
+ * This function locates the PMP entry that corresponds to a region defined in
+ * the device tree via memory attributes (as managed by mem_attr_get_regions)
+ * and updates the PMP configuration register (pmpcfg) to reflect the new
+ * permissions.
+ *
+ * It first iterates through all configured PMP entries, decodes their address
+ * and size, and attempts to find a full match for the specified region's start
+ * address and size. Once the matching PMP entry is found, its R, W, and X
+ * bits are updated based on the provided 'perm' mask, and the change is
+ * committed to the PMP configuration registers.
+ *
+ * @kconfig_dep{CONFIG_MEM_ATTR}
+ *
+ * @param region_idx Index of the memory attribute region (from
+ * mem_attr_get_regions) whose permissions should be changed.
+ * @param perm The new PMP permissions (a combination of PMP_R, PMP_W, PMP_X).
+ *
+ * @retval 0 On success.
+ * @retval -EINVAL If 'perm' contains invalid bits or 'region_idx' is out of bounds.
+ * @retval -ENOENT If no matching PMP entry is found for the specified memory region.
+ */
+int z_riscv_pmp_change_permissions(size_t region_idx, uint8_t perm);
+
+/**
  * @brief Resets all unlocked PMP entries to OFF mode (Null Region).
  *
  * This function is used to securely clear the PMP configuration. It first

--- a/tests/arch/riscv/pmp/mem-attr-entries/src/main.c
+++ b/tests/arch/riscv/pmp/mem-attr-entries/src/main.c
@@ -8,6 +8,7 @@
 #include <zephyr/mem_mgmt/mem_attr.h>
 #include <zephyr/tc_util.h>
 #include <zephyr/ztest.h>
+#include <zephyr/arch/riscv/pmp.h>
 
 /* Checks if the Machine Privilege Register Virtualization (MPRV) bit in mstatus is 1 (enabled). */
 static bool riscv_mprv_is_enabled(void)
@@ -122,6 +123,75 @@ ZTEST(riscv_pmp_memattr_entries, test_dt_pmp_perm_conversion)
 					  DT_MEM_RISCV_TYPE_IO_X);
 	zassert_equal(result, PMP_R | PMP_W | PMP_X, "Expected R|W|X (0x%x), got 0x%x",
 		      PMP_R | PMP_W | PMP_X, result);
+}
+
+ZTEST(riscv_pmp_memattr_entries, test_pmp_change_perm_invalid_permission)
+{
+	/* Invalid permission: 0x08 (bit 3) is outside of R|W|X (0x7) mask */
+	zassert_equal(z_riscv_pmp_change_permissions(0, 0x08), -EINVAL,
+		      "Should return -EINVAL for invalid permission bits.");
+}
+
+ZTEST(riscv_pmp_memattr_entries, test_pmp_change_perm_invalid_region_index)
+{
+	/* region_idx = 2, which is out of bounds */
+	size_t idx = 2;
+
+	zassert_equal(z_riscv_pmp_change_permissions(idx, PMP_R), -EINVAL,
+		      "Should return -EINVAL for region index out of bounds.");
+}
+
+ZTEST(riscv_pmp_memattr_entries, test_successful_permission_change)
+{
+	const uint8_t new_perm = 0x03; /* Read (0x1) | Write (0x2) */
+	const size_t idx = 0;
+
+	zassert_not_equal(new_perm, dt_regions[idx].perm,
+			  "Ensure new permission is different from existing permission");
+
+	int ret = z_riscv_pmp_change_permissions(idx, new_perm);
+
+	dt_regions[idx].perm = new_perm;
+
+	zassert_equal(ret, 0, "Function should return 0 on success.");
+
+	const size_t num_pmpcfg_regs = CONFIG_PMP_SLOTS / sizeof(unsigned long);
+	const size_t num_pmpaddr_regs = CONFIG_PMP_SLOTS;
+
+	unsigned long current_pmpcfg_regs[num_pmpcfg_regs];
+	unsigned long current_pmpaddr_regs[num_pmpaddr_regs];
+
+	/* Read the current PMP configuration from the control registers */
+	z_riscv_pmp_read_config(current_pmpcfg_regs, num_pmpcfg_regs);
+	z_riscv_pmp_read_addr(current_pmpaddr_regs, num_pmpaddr_regs);
+
+	const uint8_t *const current_pmp_cfg_entries = (const uint8_t *)current_pmpcfg_regs;
+
+	for (unsigned int index = 0; index < CONFIG_PMP_SLOTS; ++index) {
+		unsigned long start, end;
+		uint8_t cfg_byte = current_pmp_cfg_entries[index];
+
+		/* Decode the configured PMP region (start and end addresses) */
+		pmp_decode_region(cfg_byte, current_pmpaddr_regs, index, &start, &end);
+
+		/* Compare the decoded region against the list of expected DT regions */
+		for (size_t i = 0; i < ARRAY_SIZE(dt_regions); ++i) {
+			if ((start == dt_regions[i].base) &&
+			    (end == dt_regions[i].base + dt_regions[i].size - 1) &&
+			    ((cfg_byte & 0x07) == dt_regions[i].perm)) {
+
+				dt_regions[i].found = true;
+				break;
+			}
+		}
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(dt_regions); i++) {
+		zassert_true(dt_regions[i].found,
+			     "PMP entry for DT region %zu (base 0x%lx, size 0x%zx, perm 0x%x) not "
+			     "found.",
+			     i + 1, dt_regions[i].base, dt_regions[i].size, dt_regions[i].perm);
+	}
 }
 
 ZTEST_SUITE(riscv_pmp_memattr_entries, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Introduce function `z_riscv_pmp_change_permissions` provides a mechanism to modify the Read, Write, and Execute (R/W/X) permissions of an existing PMP region based on its memory attribute index.

This function locates the PMP entry that corresponds to a region defined in the device tree via memory attributes (as managed by `mem_attr_get_regions`) and updates the PMP configuration register (`pmpcfg`) to reflect the new permissions.

It first iterates through all configured PMP entries, decodes their address and size, and attempts to find a full match for the specified region's start address and size. Once the matching PMP entry is found, its R, W, and X bits are updated based on the provided 'perm' mask, and the change is committed to the PMP configuration registers.

This commit implements a new unit test suite to validate the `z_riscv_pmp_change_permissions` function.