### PR TITLE
tests: posix: xsi_realtime: add missing includes

### DIFF
--- a/tests/posix/xsi_realtime/src/shm.c
+++ b/tests/posix/xsi_realtime/src/shm.c
@@ -9,6 +9,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/posix/fcntl.h>
+#include <zephyr/posix/unistd.h>
+#include <zephyr/posix/sys/stat.h>
 #include <zephyr/sys/fdtable.h>
 
 #include <zephyr/ztest.h>


### PR DESCRIPTION
Add missing includes to test.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
