### PR TITLE
boards: rpi_pico2: doc: Add Wi-Fi firmware blob setup instructions

### DIFF
--- a/boards/raspberrypi/rpi_pico2/doc/index.rst
+++ b/boards/raspberrypi/rpi_pico2/doc/index.rst
@@ -55,7 +55,32 @@ Below is an example of building and flashing the :zephyr:code-sample:`blinky` ap
     :goals: build flash
     :flash-args: --openocd /usr/local/bin/openocd
 
-The blinky sample is not yet supported on Pico 2W, so try the :zephyr:code-sample:`wifi-shell` application to connect to the network:
+The blinky sample is not yet supported on Pico 2W, so try the :zephyr:code-sample:`wifi-shell` application to connect to the network.
+
+Wi-Fi Firmware Setup
+=====================
+
+Before building applications for the Pico 2W variant, you must fetch the required Wi-Fi firmware blobs.
+The Infineon CYW43439 chip requires proprietary firmware and CLM (Country Localization Module) files.
+
+Run the following command to download these blobs:
+
+.. code-block:: console
+
+   west blobs fetch hal_infineon
+
+This command downloads the necessary firmware files from Infineon's repositories, including:
+
+- ``43439A0.bin`` - Wi-Fi firmware for CYW43439
+- ``43439A0.clm_blob`` - Country localization data
+
+You only need to run this command once per workspace. Without these blobs, the build will fail with
+CMake errors about missing firmware files.
+
+Building Wi-Fi Applications
+============================
+
+After fetching the blobs, you can build Wi-Fi applications:
 
 .. zephyr-app-commands::
     :zephyr-app: samples/net/wifi/shell


### PR DESCRIPTION
Add missing documentation for the required Wi-Fi firmware blob download step when building for the Pico 2W variant (rpi_pico2/rp2350a/m33/w).

The Infineon CYW43439 Wi-Fi chip requires proprietary firmware files that must be fetched before building. Without this step, users encounter CMake errors about missing firmware files.

Added a new section explaining:
- The requirement to run 'west blobs fetch hal_infineon'
- What files are downloaded (43439A0.bin and 43439A0.clm_blob)
- That this only needs to be done once per workspace

This resolves a common issue where new users following the documentation cannot build Wi-Fi applications successfully.