### PR TITLE
boards nxp/frdm_mcxn236: remove unused GPIO5 configuration

### DIFF
--- a/boards/nxp/frdm_mcxn236/board.c
+++ b/boards/nxp/frdm_mcxn236/board.c
@@ -181,10 +181,6 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_Gpio4);
 #endif
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio5))
-	CLOCK_EnableClock(kCLOCK_Gpio5);
-#endif
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt0))
 	CLOCK_SetClkDiv(kCLOCK_DivWdt0Clk, 1u);
 #endif


### PR DESCRIPTION
The GPIO5 has no sofware configurable clock gate in the MCXN236. Also, there is no `kCLOCK_Gpio5 `in clock [driver](https://github.com/zephyrproject-rtos/hal_nxp/blob/master/mcux/mcux-sdk-ng/devices/MCX/MCXN/MCXN236/drivers/fsl_clock.h).