### PR TITLE
drivers: rcc: Improve the RCC definition for the sf32lb platform

### DIFF
--- a/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.dts
+++ b/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.dts
@@ -76,6 +76,7 @@
 	sifli,hdiv = <1>;
 	sifli,pdiv1 = <1>;
 	sifli,pdiv2 = <6>;
+	sifli,sys-clk-src = "dll1";
 
 	dll1 {
 		status = "okay";

--- a/drivers/clock_control/clock_control_sf32lb_rcc.c
+++ b/drivers/clock_control/clock_control_sf32lb_rcc.c
@@ -5,6 +5,7 @@
 
 #define DT_DRV_COMPAT sifli_sf32lb_rcc_clk
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <zephyr/arch/cpu.h>
@@ -13,6 +14,7 @@
 #include <zephyr/drivers/clock_control/sf32lb.h>
 #include <zephyr/dt-bindings/clock/sf32lb-clocks-common.h>
 #include <zephyr/dt-bindings/clock/sf32lb52x-clocks.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
 #include <register.h>
@@ -23,14 +25,9 @@
 
 #define HPSYS_RCC_CSR    offsetof(HPSYS_RCC_TypeDef, CSR)
 #define HPSYS_RCC_CFGR   offsetof(HPSYS_RCC_TypeDef, CFGR)
+#define HPSYS_RCC_USBCR  offsetof(HPSYS_RCC_TypeDef, USBCR)
 #define HPSYS_RCC_DLL1CR offsetof(HPSYS_RCC_TypeDef, DLL1CR)
 #define HPSYS_RCC_DLL2CR offsetof(HPSYS_RCC_TypeDef, DLL2CR)
-
-#define HPSYS_RCC_CSR_SEL_SYS_CLK_HXT48  FIELD_PREP(HPSYS_RCC_CSR_SEL_SYS_Msk, 1U)
-#define HPSYS_RCC_CSR_SEL_SYS_CLK_DLL1   FIELD_PREP(HPSYS_RCC_CSR_SEL_SYS_Msk, 3U)
-#define HPSYS_RCC_CSR_SEL_MPI1_CLK_DLL2  FIELD_PREP(HPSYS_RCC_CSR_SEL_MPI1_Msk, 2U)
-#define HPSYS_RCC_CSR_SEL_MPI2_CLK_DLL2  FIELD_PREP(HPSYS_RCC_CSR_SEL_MPI2_Msk, 2U)
-#define HPSYS_RCC_CSR_SEL_PERI_CLK_HXT48 FIELD_PREP(HPSYS_RCC_CSR_SEL_PERI_Msk, 1U)
 
 #define HPSYS_RCC_DLLXCR_EN          HPSYS_RCC_DLL1CR_EN
 #define HPSYS_RCC_DLLXCR_STG_Msk     HPSYS_RCC_DLL1CR_STG_Msk
@@ -39,6 +36,91 @@
 #define HPSYS_RCC_DLLXCR_OUT_DIV2_EN HPSYS_RCC_DLL1CR_OUT_DIV2_EN
 #define HPSYS_RCC_DLLXCR_READY       HPSYS_RCC_DLL1CR_READY
 
+#define SF32LB_CLOCK_FREQ_BY_NAME(inst, name)                                                      \
+	DT_PROP(DT_INST_CLOCKS_CTLR_BY_NAME(inst, name), clock_frequency)
+
+#define SF32LB_DLL_FREQ(inst, node)                                                                \
+	COND_CODE_1(DT_NODE_HAS_STATUS(DT_INST_CHILD(inst, node), okay),                        \
+		    (DT_PROP(DT_INST_CHILD(inst, node), clock_frequency)), (0U))
+
+#define SF32LB_DLL1_FREQ(inst) SF32LB_DLL_FREQ(inst, dll1)
+#define SF32LB_DLL2_FREQ(inst) SF32LB_DLL_FREQ(inst, dll2)
+
+/* Enum values match the register field encoding used by RCC */
+enum sf32lb_sys_clk_idx {
+	SF32LB_SYS_CLK_IDX_HRC48 = 0,
+	SF32LB_SYS_CLK_IDX_HXT48 = 1,
+	SF32LB_SYS_CLK_IDX_LPCLK = 2,
+	SF32LB_SYS_CLK_IDX_DLL1 = 3,
+};
+
+enum sf32lb_peri_clk_idx {
+	SF32LB_PERI_CLK_IDX_HRC48 = 0,
+	SF32LB_PERI_CLK_IDX_HXT48 = 1,
+};
+
+enum sf32lb_mpi_clk_idx {
+	SF32LB_MPI_CLK_IDX_PERI = 0,
+	SF32LB_MPI_CLK_IDX_DLL1 = 1,
+	SF32LB_MPI_CLK_IDX_DLL2 = 2,
+};
+
+enum sf32lb_usb_clk_idx {
+	SF32LB_USB_CLK_IDX_SYSCLK = 0,
+	SF32LB_USB_CLK_IDX_DLL2 = 1,
+};
+
+#define SF32LB_SYS_CLK_SRC_IDX(inst)                                                               \
+	DT_ENUM_IDX_OR(DT_DRV_INST(inst), sifli_sys_clk_src, SF32LB_SYS_CLK_IDX_HRC48)
+#define SF32LB_PERI_CLK_SRC_IDX(inst)                                                              \
+	DT_ENUM_IDX_OR(DT_DRV_INST(inst), sifli_peri_clk_src, SF32LB_PERI_CLK_IDX_HXT48)
+#define SF32LB_MPI1_CLK_SRC_IDX(inst)                                                              \
+	DT_ENUM_IDX_OR(DT_DRV_INST(inst), sifli_mpi1_clk_src, SF32LB_MPI_CLK_IDX_PERI)
+#define SF32LB_MPI2_CLK_SRC_IDX(inst)                                                              \
+	DT_ENUM_IDX_OR(DT_DRV_INST(inst), sifli_mpi2_clk_src, SF32LB_MPI_CLK_IDX_PERI)
+#define SF32LB_USB_CLK_SRC_IDX(inst)                                                               \
+	DT_ENUM_IDX_OR(DT_DRV_INST(inst), sifli_usb_clk_src, SF32LB_USB_CLK_IDX_SYSCLK)
+
+#define SF32LB_SYS_CLK_SRC_VALUE(inst)  SF32LB_SYS_CLK_SRC_IDX(inst)
+#define SF32LB_PERI_CLK_SRC_VALUE(inst) SF32LB_PERI_CLK_SRC_IDX(inst)
+#define SF32LB_MPI1_CLK_SRC_VALUE(inst) SF32LB_MPI1_CLK_SRC_IDX(inst)
+#define SF32LB_MPI2_CLK_SRC_VALUE(inst) SF32LB_MPI2_CLK_SRC_IDX(inst)
+#define SF32LB_USB_CLK_SRC_VALUE(inst)  SF32LB_USB_CLK_SRC_IDX(inst)
+
+#define SF32LB_SYS_CLK_FREQ(inst)                                                                  \
+	((SF32LB_SYS_CLK_SRC_IDX(inst) == SF32LB_SYS_CLK_IDX_HRC48)                                \
+		 ? SF32LB_CLOCK_FREQ_BY_NAME(inst, hrc48)                                          \
+	 : (SF32LB_SYS_CLK_SRC_IDX(inst) == SF32LB_SYS_CLK_IDX_HXT48)                              \
+		 ? SF32LB_CLOCK_FREQ_BY_NAME(inst, hxt48)                                          \
+	 : (SF32LB_SYS_CLK_SRC_IDX(inst) == SF32LB_SYS_CLK_IDX_LPCLK)                              \
+		 ? SF32LB_CLOCK_FREQ_BY_NAME(inst, lrc32)                                          \
+		 : SF32LB_DLL1_FREQ(inst))
+
+#define SF32LB_PERI_CLK_FREQ(inst)                                                                 \
+	((SF32LB_PERI_CLK_SRC_IDX(inst) == SF32LB_PERI_CLK_IDX_HXT48)                              \
+		 ? SF32LB_CLOCK_FREQ_BY_NAME(inst, hxt48)                                          \
+		 : SF32LB_CLOCK_FREQ_BY_NAME(inst, hrc48))
+
+#define SF32LB_USB_DIV_VALUE(inst) DT_INST_PROP_OR(DT_DRV_INST(inst), sifli_usb_div, 4)
+
+#define SF32LB_RCC_NEEDS_HXT48(inst)                                                               \
+	(DT_NODE_HAS_STATUS(DT_INST_CHILD(inst, dll1), okay) ||                                    \
+	 DT_NODE_HAS_STATUS(DT_INST_CHILD(inst, dll2), okay) ||                                    \
+	 (SF32LB_SYS_CLK_SRC_IDX(inst) == SF32LB_SYS_CLK_IDX_HXT48) ||                             \
+	 (SF32LB_PERI_CLK_SRC_IDX(inst) == SF32LB_PERI_CLK_IDX_HXT48))
+
+#define SF32LB_SYS_CLK_REQUIRES_DLL1(inst) (SF32LB_SYS_CLK_SRC_IDX(inst) == SF32LB_SYS_CLK_IDX_DLL1)
+#define SF32LB_MPI1_CLK_REQUIRES_DLL2(inst)                                                        \
+	(SF32LB_MPI1_CLK_SRC_VALUE(inst) == SF32LB_MPI_CLK_IDX_DLL2)
+#define SF32LB_MPI1_CLK_REQUIRES_DLL1(inst)                                                        \
+	(SF32LB_MPI1_CLK_SRC_VALUE(inst) == SF32LB_MPI_CLK_IDX_DLL1)
+#define SF32LB_MPI2_CLK_REQUIRES_DLL2(inst)                                                        \
+	(SF32LB_MPI2_CLK_SRC_VALUE(inst) == SF32LB_MPI_CLK_IDX_DLL2)
+#define SF32LB_MPI2_CLK_REQUIRES_DLL1(inst)                                                        \
+	(SF32LB_MPI2_CLK_SRC_VALUE(inst) == SF32LB_MPI_CLK_IDX_DLL1)
+#define SF32LB_USB_CLK_REQUIRES_DLL2(inst)                                                         \
+	(SF32LB_USB_CLK_SRC_VALUE(inst) == SF32LB_USB_CLK_IDX_DLL2)
+
 struct clock_control_sf32lb_rcc_config {
 	uintptr_t base;
 	uintptr_t cfg;
@@ -46,6 +128,19 @@ struct clock_control_sf32lb_rcc_config {
 	uint8_t hdiv;
 	uint8_t pdiv1;
 	uint8_t pdiv2;
+	uint8_t sys_clk_src;
+	uint8_t peri_clk_src;
+	uint8_t mpi1_clk_src;
+	uint8_t mpi2_clk_src;
+	uint8_t usb_clk_src;
+	uint8_t usb_div;
+	uint32_t sys_clk_freq;
+	uint32_t peri_clk_freq;
+	uint32_t hrc48_freq;
+	uint32_t hxt48_freq;
+	uint32_t lrc32_freq;
+	uint32_t lrc10_freq;
+	uint32_t lxt32_freq;
 	uint32_t dll1_freq;
 	uint32_t dll2_freq;
 	const struct device *hxt48;
@@ -70,6 +165,67 @@ static inline void configure_dll(const struct device *dev, uint32_t freq, uint32
 	do {
 		val = sys_read32(config->base + dllxcr);
 	} while ((val & HPSYS_RCC_DLLXCR_READY) == 0U);
+}
+
+static bool sf32lb_rcc_needs_hxt48(const struct clock_control_sf32lb_rcc_config *config)
+{
+	return (config->sys_clk_src == SF32LB_SYS_CLK_IDX_HXT48) ||
+	       (config->peri_clk_src == SF32LB_PERI_CLK_IDX_HXT48) || (config->dll1_freq != 0U) ||
+	       (config->dll2_freq != 0U);
+}
+
+static uint32_t sf32lb_get_sys_clk(const struct clock_control_sf32lb_rcc_config *config)
+{
+	return config->sys_clk_freq;
+}
+
+static uint32_t sf32lb_get_hclk(const struct clock_control_sf32lb_rcc_config *config)
+{
+	uint32_t hdiv = config->hdiv;
+
+	if (hdiv == 0U) {
+		return sf32lb_get_sys_clk(config);
+	}
+
+	return sf32lb_get_sys_clk(config) / hdiv;
+}
+
+static uint32_t sf32lb_get_pclk1(const struct clock_control_sf32lb_rcc_config *config)
+{
+	uint32_t divisor = BIT(config->pdiv1);
+
+	return sf32lb_get_hclk(config) / MAX(divisor, 1U);
+}
+
+static uint32_t sf32lb_get_clk_peri(const struct clock_control_sf32lb_rcc_config *config)
+{
+	return config->peri_clk_freq;
+}
+
+static uint32_t sf32lb_get_mpi_clk(const struct clock_control_sf32lb_rcc_config *config,
+				   uint8_t src)
+{
+	switch (src) {
+	case SF32LB_MPI_CLK_IDX_DLL1:
+		return config->dll1_freq;
+	case SF32LB_MPI_CLK_IDX_DLL2:
+		return config->dll2_freq;
+	default:
+		return config->peri_clk_freq;
+	}
+}
+
+static uint32_t sf32lb_get_usb_clk(const struct clock_control_sf32lb_rcc_config *config)
+{
+	uint32_t src = (config->usb_clk_src == SF32LB_USB_CLK_IDX_DLL2)
+			       ? config->dll2_freq
+			       : sf32lb_get_sys_clk(config);
+
+	if (config->usb_div == 0U) {
+		return src;
+	}
+
+	return src / config->usb_div;
 }
 
 static int clock_control_sf32lb_rcc_on(const struct device *dev, clock_control_subsys_t sys)
@@ -97,18 +253,66 @@ static int clock_control_sf32lb_rcc_off(const struct device *dev, clock_control_
 int clock_control_sf32lb_rcc_get_rate(const struct device *dev, clock_control_subsys_t sys,
 				      uint32_t *rate)
 {
+	const struct clock_control_sf32lb_rcc_config *config = dev->config;
 	uint16_t id = *(uint16_t *)sys;
 
-	if ((id == SF32LB52X_CLOCK_I2C1) ||
-	    (id == SF32LB52X_CLOCK_I2C2) ||
-	    (id == SF32LB52X_CLOCK_I2C3) ||
-	    (id == SF32LB52X_CLOCK_I2C4) ||
-	    (id == SF32LB52X_CLOCK_SPI1) ||
-	    (id == SF32LB52X_CLOCK_SPI2) ||
-	    (id == SF32LB52X_CLOCK_USART2) ||
-	    (id == SF32LB52X_CLOCK_USART3)) {
-		*rate = 48000000U; /* clk_peri_hpsys always 48MHZ */
+	switch (id) {
+	case SF32LB52X_CLOCK_DMAC1:
+	case SF32LB52X_CLOCK_EXTDMA:
+	case SF32LB52X_CLOCK_EPIC:
+	case SF32LB52X_CLOCK_EZIP1:
+	case SF32LB52X_CLOCK_LCDC1:
+	case SF32LB52X_CLOCK_AES:
+	case SF32LB52X_CLOCK_SDMMC1:
+	case SF32LB52X_CLOCK_CRC1:
+	case SF32LB52X_CLOCK_SECU1:
+		*rate = sf32lb_get_hclk(config);
 		return 0;
+	case SF32LB52X_CLOCK_MPI1:
+		*rate = sf32lb_get_mpi_clk(config, config->mpi1_clk_src);
+		return 0;
+	case SF32LB52X_CLOCK_MPI2:
+		*rate = sf32lb_get_mpi_clk(config, config->mpi2_clk_src);
+		return 0;
+	case SF32LB52X_CLOCK_USBC:
+		*rate = sf32lb_get_usb_clk(config);
+		return 0;
+	case SF32LB52X_CLOCK_MAILBOX1:
+	case SF32LB52X_CLOCK_PINMUX1:
+	case SF32LB52X_CLOCK_SYSCFG1:
+	case SF32LB52X_CLOCK_GPIO1:
+	case SF32LB52X_CLOCK_PTC1:
+	case SF32LB52X_CLOCK_TRNG:
+	case SF32LB52X_CLOCK_EFUSEC:
+	case SF32LB52X_CLOCK_GPADC:
+	case SF32LB52X_CLOCK_TSEN:
+	case SF32LB52X_CLOCK_GPTIM1:
+	case SF32LB52X_CLOCK_GPTIM2:
+	case SF32LB52X_CLOCK_ATIM1:
+		*rate = sf32lb_get_pclk1(config);
+		return 0;
+	case SF32LB52X_CLOCK_BTIM1:
+	case SF32LB52X_CLOCK_BTIM2:
+		*rate = sf32lb_get_pclk1(config) / 2U;
+		return 0;
+	case SF32LB52X_CLOCK_I2C1:
+	case SF32LB52X_CLOCK_I2C2:
+	case SF32LB52X_CLOCK_I2C3:
+	case SF32LB52X_CLOCK_I2C4:
+	case SF32LB52X_CLOCK_SPI1:
+	case SF32LB52X_CLOCK_SPI2:
+	case SF32LB52X_CLOCK_USART2:
+	case SF32LB52X_CLOCK_USART3:
+		*rate = sf32lb_get_clk_peri(config);
+		return 0;
+	case SF32LB52X_CLOCK_I2S1:
+	case SF32LB52X_CLOCK_AUDPRC:
+	case SF32LB52X_CLOCK_AUDCODEC:
+	case SF32LB52X_CLOCK_PDM1:
+		*rate = config->hxt48_freq;
+		return 0;
+	default:
+		break;
 	}
 
 	return -ENOTSUP;
@@ -138,19 +342,19 @@ static DEVICE_API(clock_control, clock_control_sf32lb_rcc_api) = {
 static int clock_control_sf32lb_rcc_init(const struct device *dev)
 {
 	const struct clock_control_sf32lb_rcc_config *config = dev->config;
+	bool need_hxt48 = sf32lb_rcc_needs_hxt48(config);
 	uint32_t val;
+	int ret;
 
-	if (config->hxt48 != NULL) {
-		(void)clock_control_on(config->hxt48, NULL);
+	if (need_hxt48) {
+		if ((config->hxt48 == NULL) || !device_is_ready(config->hxt48)) {
+			return -ENODEV;
+		}
 
-		/* TODO: make this configurable */
-		val = sys_read32(config->base + HPSYS_RCC_CSR);
-		val &= ~HPSYS_RCC_CSR_SEL_SYS_Msk;
-		val |= HPSYS_RCC_CSR_SEL_SYS_CLK_HXT48;
-
-		val &= ~HPSYS_RCC_CSR_SEL_PERI_Msk;
-		val |= HPSYS_RCC_CSR_SEL_PERI_CLK_HXT48;
-		sys_write32(val, config->base + HPSYS_RCC_CSR);
+		ret = clock_control_on(config->hxt48, NULL);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	if (config->dll1_freq != 0U || config->dll2_freq != 0U) {
@@ -163,24 +367,18 @@ static int clock_control_sf32lb_rcc_init(const struct device *dev)
 		sys_write32(val, config->cfg + HPSYS_CFG_CAU2_CR);
 
 		val = sys_read32(config->base + HPSYS_RCC_CSR);
+		val &= ~(HPSYS_RCC_CSR_SEL_SYS_Msk | HPSYS_RCC_CSR_SEL_PERI_Msk);
+		val |= FIELD_PREP(HPSYS_RCC_CSR_SEL_SYS_Msk, SF32LB_SYS_CLK_IDX_HXT48) |
+		       FIELD_PREP(HPSYS_RCC_CSR_SEL_PERI_Msk, SF32LB_PERI_CLK_IDX_HXT48);
+		sys_write32(val, config->base + HPSYS_RCC_CSR);
 
 		if (config->dll1_freq != 0U) {
 			configure_dll(dev, config->dll1_freq, HPSYS_RCC_DLL1CR);
-
-			/* TODO: make this configurable */
-			val &= ~HPSYS_RCC_CSR_SEL_SYS_Msk;
-			val |= HPSYS_RCC_CSR_SEL_SYS_CLK_DLL1;
 		}
 
 		if (config->dll2_freq != 0U) {
 			configure_dll(dev, config->dll2_freq, HPSYS_RCC_DLL2CR);
-
-			/* TODO: make this configurable */
-			val &= ~(HPSYS_RCC_CSR_SEL_MPI1_Msk | HPSYS_RCC_CSR_SEL_MPI2_Msk);
-			val |= HPSYS_RCC_CSR_SEL_MPI1_CLK_DLL2 | HPSYS_RCC_CSR_SEL_MPI2_CLK_DLL2;
 		}
-
-		sys_write32(val, config->base + HPSYS_RCC_CSR);
 	}
 
 	/* configure HDIV/PDIV1/PDIV2 dividers */
@@ -190,6 +388,20 @@ static int clock_control_sf32lb_rcc_init(const struct device *dev)
 	       FIELD_PREP(HPSYS_RCC_CFGR_PDIV1_Msk, config->pdiv1) |
 	       FIELD_PREP(HPSYS_RCC_CFGR_PDIV2_Msk, config->pdiv2);
 	sys_write32(val, config->base + HPSYS_RCC_CFGR);
+
+	val = sys_read32(config->base + HPSYS_RCC_CSR);
+	val &= ~(HPSYS_RCC_CSR_SEL_SYS_Msk | HPSYS_RCC_CSR_SEL_PERI_Msk |
+		 HPSYS_RCC_CSR_SEL_MPI1_Msk | HPSYS_RCC_CSR_SEL_MPI2_Msk |
+		 HPSYS_RCC_CSR_SEL_USBC_Msk);
+	val |= FIELD_PREP(HPSYS_RCC_CSR_SEL_SYS_Msk, config->sys_clk_src) |
+	       FIELD_PREP(HPSYS_RCC_CSR_SEL_PERI_Msk, config->peri_clk_src) |
+	       FIELD_PREP(HPSYS_RCC_CSR_SEL_MPI1_Msk, config->mpi1_clk_src) |
+	       FIELD_PREP(HPSYS_RCC_CSR_SEL_MPI2_Msk, config->mpi2_clk_src) |
+	       FIELD_PREP(HPSYS_RCC_CSR_SEL_USBC_Msk, config->usb_clk_src);
+	sys_write32(val, config->base + HPSYS_RCC_CSR);
+
+	val = FIELD_PREP(HPSYS_RCC_USBCR_DIV_Msk, config->usb_div);
+	sys_write32(val, config->base + HPSYS_RCC_USBCR);
 
 	return 0;
 }
@@ -221,6 +433,31 @@ IF_ENABLED(DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll2), okay), (
 		STRINGIFY(HPSYS_RCC_DLLXCR_STG_STEP)
 	   );))
 
+BUILD_ASSERT(!SF32LB_RCC_NEEDS_HXT48(0) ||
+		     DT_NODE_HAS_STATUS(DT_INST_CLOCKS_CTLR_BY_NAME(0, hxt48), okay),
+	     "HXT48 clock must be enabled when selected or when DLLs are used");
+
+BUILD_ASSERT(!SF32LB_SYS_CLK_REQUIRES_DLL1(0) || DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll1), okay),
+	     "DLL1 system clock selection requires the dll1 node to be enabled");
+
+BUILD_ASSERT(!SF32LB_MPI1_CLK_REQUIRES_DLL2(0) || DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll2), okay),
+	     "MPI1 clock selection requires the dll2 node to be enabled when set to DLL2");
+
+BUILD_ASSERT(!SF32LB_MPI1_CLK_REQUIRES_DLL1(0) || DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll1), okay),
+	     "MPI1 clock selection requires the dll1 node to be enabled when set to DLL1");
+
+BUILD_ASSERT(!SF32LB_MPI2_CLK_REQUIRES_DLL2(0) || DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll2), okay),
+	     "MPI2 clock selection requires the dll2 node to be enabled when set to DLL2");
+
+BUILD_ASSERT(!SF32LB_MPI2_CLK_REQUIRES_DLL1(0) || DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll1), okay),
+	     "MPI2 clock selection requires the dll1 node to be enabled when set to DLL1");
+
+BUILD_ASSERT(IN_RANGE(SF32LB_USB_DIV_VALUE(0), 1, 7),
+	     "USB clock divider must be in the range [1, 7]");
+
+BUILD_ASSERT(!SF32LB_USB_CLK_REQUIRES_DLL2(0) || DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll2), okay),
+	     "USB clock selection requires the dll2 node to be enabled when set to DLL2");
+
 static const struct clock_control_sf32lb_rcc_config config = {
 	.base = DT_REG_ADDR(DT_INST_PARENT(0)),
 	.cfg = DT_REG_ADDR(DT_INST_PHANDLE(0, sifli_cfg)),
@@ -229,9 +466,22 @@ static const struct clock_control_sf32lb_rcc_config config = {
 	.hdiv = DT_INST_PROP(0, sifli_hdiv),
 	.pdiv1 = DT_INST_PROP(0, sifli_pdiv1),
 	.pdiv2 = DT_INST_PROP(0, sifli_pdiv2),
+	.sys_clk_src = SF32LB_SYS_CLK_SRC_VALUE(0),
+	.peri_clk_src = SF32LB_PERI_CLK_SRC_VALUE(0),
+	.mpi1_clk_src = SF32LB_MPI1_CLK_SRC_VALUE(0),
+	.mpi2_clk_src = SF32LB_MPI2_CLK_SRC_VALUE(0),
+	.usb_clk_src = SF32LB_USB_CLK_SRC_VALUE(0),
+	.usb_div = SF32LB_USB_DIV_VALUE(0),
+	.sys_clk_freq = SF32LB_SYS_CLK_FREQ(0),
+	.peri_clk_freq = SF32LB_PERI_CLK_FREQ(0),
+	.hrc48_freq = SF32LB_CLOCK_FREQ_BY_NAME(0, hrc48),
+	.hxt48_freq = SF32LB_CLOCK_FREQ_BY_NAME(0, hxt48),
+	.lrc32_freq = SF32LB_CLOCK_FREQ_BY_NAME(0, lrc32),
+	.lrc10_freq = SF32LB_CLOCK_FREQ_BY_NAME(0, lrc10),
+	.lxt32_freq = SF32LB_CLOCK_FREQ_BY_NAME(0, lxt32),
 	.dll1_freq = COND_CODE_1(DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll1), okay),
 				 (DT_PROP(DT_INST_CHILD(0, dll1), clock_frequency)), (0U)),
-	.dll2_freq = COND_CODE_1(DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll2), okay),
+		 .dll2_freq = COND_CODE_1(DT_NODE_HAS_STATUS(DT_INST_CHILD(0, dll2), okay),
 				 (DT_PROP(DT_INST_CHILD(0, dll2), clock_frequency)), (0U)),
 };
 

--- a/dts/bindings/clock/sifli,sf32lb-rcc-clk.yaml
+++ b/dts/bindings/clock/sifli,sf32lb-rcc-clk.yaml
@@ -65,5 +65,56 @@ properties:
     description: |
       Divider for PCLK2 (0-7). fPCLK2 = fHCLK / 2^PDIV2.
 
+  sifli,sys-clk-src:
+    type: string
+    enum: ["hrc48", "hxt48", "lpclk", "dll1"]
+    default: "hrc48"
+    description: |
+      Source used for the HPSYS system clock. When set to ``dll1`` the DLL1 child
+      node must be enabled. Defaults to ``hrc48`` if not provided (reset default).
+
+  sifli,peri-clk-src:
+    type: string
+    enum: ["hrc48", "hxt48"]
+    default: "hxt48"
+    description: |
+      Source used for the HPSYS peripheral clock domain. Defaults to ``hxt48`` if
+      not provided (reset default).
+
+  sifli,mpi1-clk-src:
+    type: string
+    enum: ["peri", "dll1", "dll2"]
+    default: "peri"
+    description: |
+      Source used for the MPI1/QSPI clock tree. Selecting ``dll1`` or ``dll2``
+      requires the corresponding DLL child node to be enabled. Defaults to
+      ``peri`` if not provided (reset default).
+
+  sifli,mpi2-clk-src:
+    type: string
+    enum: ["peri", "dll1", "dll2"]
+    default: "peri"
+    description: |
+      Source used for the MPI2/QSPI clock tree. Selecting ``dll1`` or ``dll2``
+      requires the corresponding DLL child node to be enabled. Defaults to
+      ``peri`` if not provided (reset default).
+
+  sifli,usb-clk-src:
+    type: string
+    enum: ["sysclk", "dll2"]
+    default: "sysclk"
+    description: |
+      Source used for the USB full-speed controller clock. Selecting ``dll2``
+      requires the DLL2 child node to be enabled. Defaults to ``sysclk`` if not
+      provided (reset default).
+
+  sifli,usb-div:
+    type: int
+    default: 4
+    description: |
+      Divider applied to the selected USB clock source. The divided clock must
+      be 60 MHz. For example, when ``clk_dll2`` runs at 240 MHz the divider must
+      be ``4`` (reset default).
+
 clock-cells:
   - id


### PR DESCRIPTION
Improve the RCC definition for the sf32lb platform.
All RCC configurations in sf32lb have been completed, with the following additions:
- sys-clk-src
- peri-clk-src
- mpi1/2-clk-src
- usb-clk-src
- usb-div