### PR TITLE
dts: arm: nxp: s32k146: remove CAN FD support from flexcan2

### DIFF
--- a/dts/arm/nxp/nxp_s32k146.dtsi
+++ b/dts/arm/nxp/nxp_s32k146.dtsi
@@ -74,6 +74,7 @@
 };
 
 &flexcan2 {
+	compatible = "nxp,flexcan";
 	interrupts = <92 0>, <93 0>, <95 0>;
 	interrupt-names = "warning", "error", "mb-0-15";
 	clocks = <&clock NXP_S32_FLEXCAN2_CLK>;


### PR DESCRIPTION
Remove the `nxp,flexcan-fd` compatible property from flexcan2 node for S32K146, keeping only `nxp,flexcan`. The FlexCAN2 instance on S32K146 does not support CAN FD functionality, unlike flexcan0 and flexcan1.