### PR TITLE
Add DMA driver support for PIC32CX SG boards

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -200,3 +200,7 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&dmac {
+	status = "okay";
+};

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -11,6 +11,7 @@ flash: 1024
 ram: 256
 supported:
   - clock_control
+  - dma
   - flash
   - gpio
   - pinctrl

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -194,3 +194,7 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&dmac {
+	status = "okay";
+};

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -11,6 +11,7 @@ flash: 1024
 ram: 256
 supported:
   - clock_control
+  - dma
   - flash
   - gpio
   - pinctrl

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -161,6 +161,18 @@
 			};
 		};
 
+		dmac: dmac@4100a000 {
+			compatible = "microchip,dmac-g1-dma";
+			reg = <0x4100A000 0x50>;
+			interrupts = <31 0>, <32 0>, <33 0>, <34 0>, <35 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_AHB_DMAC>;
+			clock-names = "mclk";
+			dma-channels = <32>;
+			dma-alignment = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
 		sercom2: sercom@41012000 {
 			compatible = "microchip,sercom-g1";
 			reg = <0x41012000 0x29>;

--- a/soc/microchip/pic32c/pic32cx_sg/common/mchp_dt_helper.h
+++ b/soc/microchip/pic32c/pic32cx_sg/common/mchp_dt_helper.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file mchp_dt_helper.h
+ * @brief device tree helper macros.
+ *
+ * This file contains the device tree helper macros.
+ */
+
+#ifndef SOC_MICROCHIP_PIC32CX_SG_COMMON_MCHP_DT_HELPER_H_
+
+/* clang-format off */
+/* Helper macros for use with DMAC controller
+ * return 0xff as default value if there is no 'dmas' property
+ */
+#define MCHP_DT_INST_DMA_CELL(n, name, cell)						\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas),					\
+			(DT_INST_DMAS_CELL_BY_NAME(n, name, cell)),			\
+			(0xff))
+#define MCHP_DT_INST_DMA_TRIGSRC(n, name) MCHP_DT_INST_DMA_CELL(n, name, trigsrc)
+#define MCHP_DT_INST_DMA_CHANNEL(n, name) MCHP_DT_INST_DMA_CELL(n, name, channel)
+#define MCHP_DT_INST_DMA_CTLR(n, name)							\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas),					\
+			(DT_INST_DMAS_CTLR_BY_NAME(n, name)),				\
+			(DT_INVALID_NODE))
+/* clang-format on */
+
+#endif /* SOC_MICROCHIP_PIC32CX_SG_COMMON_MCHP_DT_HELPER_H_ */

--- a/tests/drivers/dma/chan_blen_transfer/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dmac {
+	status = "okay";
+};

--- a/tests/drivers/dma/chan_blen_transfer/boards/pic32cx_sg61_cult.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/pic32cx_sg61_cult.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dmac {
+	status = "okay";
+};

--- a/tests/drivers/dma/loop_transfer/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dmac {
+	status = "okay";
+};

--- a/tests/drivers/dma/loop_transfer/boards/pic32cx_sg61_cult.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/pic32cx_sg61_cult.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dmac {
+	status = "okay";
+};


### PR DESCRIPTION
This PR adds the DMA controller node for the PIC32CX SG family and updates the corresponding PIC32CX-SG61 board device tree to enable DMA support.