### PR TITLE
drivers: input: Support invert x/y in rel mode

### DIFF
--- a/drivers/input/input_pinnacle.c
+++ b/drivers/input/input_pinnacle.c
@@ -819,13 +819,16 @@ static int pinnacle_init(const struct device *dev)
 	value = PINNACLE_FEED_CONFIG1_FEED_ENABLE;
 	if (!config->relative_mode) {
 		value |= PINNACLE_FEED_CONFIG1_DATA_MODE_ABSOLUTE;
-		if (config->invert_x) {
-			value |= PINNACLE_FEED_CONFIG1_X_INVERT;
-		}
-		if (config->invert_y) {
-			value |= PINNACLE_FEED_CONFIG1_Y_INVERT;
-		}
 	}
+
+	/* Datasheet states these are absolute only, but they also work in rel mode */
+	if (config->invert_x) {
+		value |= PINNACLE_FEED_CONFIG1_X_INVERT;
+	}
+	if (config->invert_y) {
+		value |= PINNACLE_FEED_CONFIG1_Y_INVERT;
+	}
+
 	rc = pinnacle_write(dev, PINNACLE_REG_FEED_CONFIG1, value);
 	if (rc) {
 		LOG_ERR("Failed to enable Feed in FeedConfig1");

--- a/dts/bindings/input/cirque,pinnacle-common.yaml
+++ b/dts/bindings/input/cirque,pinnacle-common.yaml
@@ -94,12 +94,12 @@ properties:
   invert-x:
     type: boolean
     description: |
-      In the absolute mode invert X coordinate.
+      Invert X coordinate values, in both relative and absolute modes.
 
   invert-y:
     type: boolean
     description: |
-      In the absolute mode invert Y coordinate.
+      Invert Y coordinate values, in both relative and absolute modes.
 
   primary-tap-enable:
     type: boolean


### PR DESCRIPTION
Despite the datasheet stating otherwise, the Pinnacle based trackpads can have their X/Y data inverted when operating in relative mode, so set those configs in all modes during init.