### PR TITLE
Bluetooth: shell: improve a2dp shell and readme

### DIFF
--- a/doc/connectivity/bluetooth/shell/classic/a2dp.rst
+++ b/doc/connectivity/bluetooth/shell/classic/a2dp.rst
@@ -5,33 +5,80 @@ The :code:`a2dp` command exposes parts of the A2DP API.
 
 The following examples assume that you have two devices already connected.
 
-Here is a example connecting two devices:
- * Source and Sink sides register a2dp callbacks. using :code:`a2dp register_cb`.
- * Source and Sink sides register stream endpoints. using :code:`a2dp register_ep source sbc` and :code:`a2dp register_ep sink sbc`.
- * Source establish A2dp connection. It will create the AVDTP Signaling and Media L2CAP channels. using :code:`a2dp connect`.
- * Source and Sink side can discover remote device's stream endpoints. using :code:`a2dp discover_peer_eps`
- * Source or Sink configure the stream to create the stream after discover remote's endpoints. using :code:`a2dp configure`.
- * Source or Sink establish the stream. using :code:`a2dp establish`.
- * Source or Sink start the media. using :code:`a2dp start`.
- * Source test the media sending. using :code:`a2dp send_media` to send one test packet data.
- * Source or Sink suspend the media. using :code:`a2dp suspend`.
- * Source or Sink release the media. using :code:`a2dp release`.
+.. _a2dp_conn_disconn:
+
+A2DP Connection
+***************
+
+Demonstrate the flow of creating an A2DP connection:
+
+* Both sides register A2DP callbacks using :code:`a2dp register_cb`.
+* Either side establishes an A2DP connection, which will create the AVDTP Signaling channel, using :code:`a2dp connect`.
+* Either side can get the ACL connection using :code:`a2dp get_conn`.
+* Either side can disconnect the A2DP connection using :code:`a2dp disconnect`.
 
 .. tabs::
 
-        .. group-tab:: Device A (Audio Source Side)
+        .. group-tab:: Device A (initiator)
 
                 .. code-block:: console
 
                         uart:~$ a2dp register_cb
                         success
-                        uart:~$ a2dp register_ep source sbc
-                        SBC source endpoint is registered
                         uart:~$ a2dp connect
                         Bonded with XX:XX:XX:XX:XX:XX
                         Security changed: XX:XX:XX:XX:XX:XX level 2
                         a2dp connected
-                        uart:~$ a2dp discover_peer_eps
+                        uart:~$ a2dp get_conn
+                        a2dp conn is: 0xXXXXXXXX
+                        uart:~$ a2dp disconnect
+                        a2dp disconnected
+
+        .. group-tab:: Device B (acceptor)
+
+                .. code-block:: console
+
+                        uart:~$ a2dp register_cb
+                        success
+                        <input `a2dp connect` in initiator side>
+                        Connected: XX:XX:XX:XX:XX:XX
+                        Bonded with XX:XX:XX:XX:XX:XX
+                        Security changed: XX:XX:XX:XX:XX:XX level 2
+                        a2dp connected
+                        <input `a2dp disconnect` in initiator side>
+                        a2dp disconnected
+
+.. _a2dp_basic_operations:
+
+Basic A2DP Operations
+*********************
+
+Demonstrate the flow of basic A2DP operations:
+
+* Source and Sink sides register stream endpoints using :code:`a2dp register_ep source sbc` and :code:`a2dp register_ep sink sbc`.
+* Create an A2DP connection based on :ref:`a2dp connection <a2dp_conn_disconn>`.
+* Initiator discovers remote device's stream endpoints using :code:`a2dp discover_peer_eps 0x0104`.
+* Initiator configures the stream to create the stream after discovering remote endpoints using :code:`a2dp configure`.
+* Initiator establishes the stream using :code:`a2dp establish`.
+* Sink sends delay report using :code:`a2dp send_delay_report`.
+* Initiator starts the media using :code:`a2dp start`.
+* Source tests media sending using :code:`a2dp send_media` to send one test packet data.
+* Initiator suspends the media using :code:`a2dp suspend`.
+* Initiator releases the media using :code:`a2dp release`.
+
+.. note::
+   The initiator is the A2DP source role and the acceptor is the A2DP sink role in the following logs.
+   The delay report can only be sent by the sink role. The media data can only be sent by the source role.
+
+.. tabs::
+
+        .. group-tab:: Device A (initiator)
+
+                .. code-block:: console
+
+                        uart:~$ a2dp register_ep source sbc
+                        SBC source endpoint is registered
+                        uart:~$ a2dp discover_peer_eps 0x0104
                         endpoint id: 1, (sink), (idle):
                           codec type: SBC
                           sample frequency:
@@ -54,6 +101,9 @@ Here is a example connecting two devices:
                         uart:~$ a2dp establish
                         success to establish
                         stream established
+                        <input `a2dp send_delay_report` in sink side>
+                        receive delay report and accept
+                        received delay report: 1 1/10ms
                         uart:~$ a2dp start
                         success to start
                         stream started
@@ -67,36 +117,89 @@ Here is a example connecting two devices:
                         success to release
                         stream released
 
-        .. group-tab:: Device B (Audio Sink Side)
+        .. group-tab:: Device B (acceptor)
 
                 .. code-block:: console
 
-                        uart:~$ a2dp register_cb
-                        success
                         uart:~$ a2dp register_ep sink sbc
                         SBC sink endpoint is registered
-                        <after a2dp connect>
-                        Connected: XX:XX:XX:XX:XX:XX
-                        Bonded with XX:XX:XX:XX:XX:XX
-                        Security changed: XX:XX:XX:XX:XX:XX level 2
-                        a2dp connected
-                        <after a2dp configure of source side>
+                        <input `a2dp configure` in initiator side>
                         receive requesting config and accept
                         sample rate 44100Hz
                         stream configured
-                        <after a2dp establish of source side>
+                        <input `a2dp establish` in initiator side>
                         receive requesting establishment and accept
                         stream established
-                        <after a2dp start of source side>
+                        uart:~$ a2dp send_delay_report
+                        success to send report delay
+                        <input `a2dp start` in initiator side>
                         receive requesting start and accept
                         stream started
-                        <after a2dp send_media of source side>
+                        <input `a2dp send_media` in source side>
                         received, num of frames: 1, data length: 160
                         data: 1, 2, 3, 4, 5, 6 ......
-                        <after a2dp suspend of source side>
+                        <input `a2dp suspend` in initiator side>
                         receive requesting suspend and accept
                         stream suspended
-                        <after a2dp release of source side>
+                        <input `a2dp release` in initiator side>
                         receive requesting release and accept
                         stream released
-                        ...
+
+Abort Operation
+***************
+
+Demonstrate the abort operation:
+
+* Establish an A2DP stream based on :ref:`basic a2dp operations <a2dp_basic_operations>`.
+* Initiator aborts the stream using :code:`a2dp abort`.
+
+.. tabs::
+
+        .. group-tab:: Device A (initiator)
+
+                .. code-block:: console
+
+                        uart:~$ a2dp abort
+                        success to abort
+                        stream released
+
+        .. group-tab:: Device B (acceptor)
+
+                .. code-block:: console
+
+                        <input `a2dp abort` in initiator side>
+                        receive requesting abort and accept
+                        stream released
+
+Get Configuration and Reconfigure Operation
+********************************************
+
+Demonstrate the get configuration and reconfigure operations:
+
+* Establish an A2DP stream based on :ref:`basic a2dp operations <a2dp_basic_operations>`.
+* Initiator gets configuration using :code:`a2dp get_config`.
+* Initiator reconfigures the stream using :code:`a2dp reconfigure`.
+
+.. tabs::
+
+        .. group-tab:: Device A (initiator)
+
+                .. code-block:: console
+
+                        uart:~$ a2dp get_config
+                        get config result: 0
+                        sample rate 44100Hz
+                        uart:~$ a2dp reconfigure
+                        success to configure
+                        stream configured
+
+        .. group-tab:: Device B (acceptor)
+
+                .. code-block:: console
+
+                        <input `a2dp get_config` in initiator side>
+                        receive get config request and accept
+                        <input `a2dp reconfigure` in initiator side>
+                        receive requesting reconfig and accept
+                        sample rate 44100Hz
+                        stream configured

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -30,7 +30,7 @@
 struct bt_a2dp *default_a2dp;
 static uint8_t a2dp_sink_sdp_registered;
 static uint8_t a2dp_source_sdp_registered;
-static uint8_t a2dp_initied;
+static bool a2dp_cb_registered;
 BT_A2DP_SBC_SINK_EP_DEFAULT(sink_sbc_endpoint);
 BT_A2DP_SBC_SOURCE_EP_DEFAULT(source_sbc_endpoint);
 struct bt_a2dp_codec_ie peer_sbc_capabilities;
@@ -523,12 +523,22 @@ static struct bt_a2dp_cb a2dp_cb = {
 #endif
 };
 
+static int check_cb_registration(const struct shell *sh)
+{
+	if (!a2dp_cb_registered) {
+		shell_print(sh, "need to register a2dp connection callbacks");
+		return -EIO;
+	}
+
+	return 0;
+}
+
 static int cmd_register_cb(const struct shell *sh, int32_t argc, char *argv[])
 {
 	int err = -1;
 
-	if (a2dp_initied == 0) {
-		a2dp_initied = 1;
+	if (!a2dp_cb_registered) {
+		a2dp_cb_registered = true;
 
 		err = bt_a2dp_register_cb(&a2dp_cb);
 		if (!err) {
@@ -549,8 +559,7 @@ static int cmd_register_ep(const struct shell *sh, int32_t argc, char *argv[])
 	const char *type;
 	const char *action;
 
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -597,8 +606,7 @@ static int cmd_register_ep(const struct shell *sh, int32_t argc, char *argv[])
 
 static int cmd_connect(const struct shell *sh, int32_t argc, char *argv[])
 {
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -616,8 +624,7 @@ static int cmd_connect(const struct shell *sh, int32_t argc, char *argv[])
 
 static int cmd_disconnect(const struct shell *sh, int32_t argc, char *argv[])
 {
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -650,8 +657,7 @@ static int cmd_configure(const struct shell *sh, int32_t argc, char *argv[])
 {
 	int err;
 
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -682,8 +688,7 @@ static int cmd_configure(const struct shell *sh, int32_t argc, char *argv[])
 
 static int cmd_reconfigure(const struct shell *sh, int32_t argc, char *argv[])
 {
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -720,8 +725,7 @@ static int cmd_get_peer_eps(const struct shell *sh, int32_t argc, char *argv[])
 {
 	int err = 0;
 
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -746,8 +750,7 @@ static int cmd_get_peer_eps(const struct shell *sh, int32_t argc, char *argv[])
 
 static int cmd_establish(const struct shell *sh, int32_t argc, char *argv[])
 {
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -759,8 +762,7 @@ static int cmd_establish(const struct shell *sh, int32_t argc, char *argv[])
 
 static int cmd_release(const struct shell *sh, int32_t argc, char *argv[])
 {
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -772,8 +774,7 @@ static int cmd_release(const struct shell *sh, int32_t argc, char *argv[])
 
 static int cmd_start(const struct shell *sh, int32_t argc, char *argv[])
 {
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -785,8 +786,7 @@ static int cmd_start(const struct shell *sh, int32_t argc, char *argv[])
 
 static int cmd_suspend(const struct shell *sh, int32_t argc, char *argv[])
 {
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -798,8 +798,7 @@ static int cmd_suspend(const struct shell *sh, int32_t argc, char *argv[])
 
 static int cmd_abort(const struct shell *sh, int32_t argc, char *argv[])
 {
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -815,8 +814,7 @@ static int cmd_send_media(const struct shell *sh, int32_t argc, char *argv[])
 	struct net_buf *buf;
 	int ret;
 
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -847,8 +845,7 @@ static int cmd_send_delay_report(const struct shell *sh, int32_t argc, char *arg
 {
 	int err;
 
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 
@@ -863,8 +860,7 @@ static int cmd_send_delay_report(const struct shell *sh, int32_t argc, char *arg
 
 static int cmd_get_config(const struct shell *sh, int32_t argc, char *argv[])
 {
-	if (a2dp_initied == 0) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+	if (check_cb_registration(sh) != 0) {
 		return -ENOEXEC;
 	}
 

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -546,7 +546,7 @@ static struct bt_a2dp_cb a2dp_cb = {
 static int check_cb_registration(const struct shell *sh)
 {
 	if (!a2dp_cb_registered) {
-		shell_print(sh, "need to register a2dp connection callbacks");
+		bt_shell_print("need to register a2dp connection callbacks");
 		return -EIO;
 	}
 
@@ -562,12 +562,12 @@ static int cmd_register_cb(const struct shell *sh, int32_t argc, char *argv[])
 
 		err = bt_a2dp_register_cb(&a2dp_cb);
 		if (!err) {
-			shell_print(sh, "success");
+			bt_shell_print("success");
 		} else {
-			shell_print(sh, "fail");
+			bt_shell_print("fail");
 		}
 	} else {
-		shell_print(sh, "already registered");
+		bt_shell_print("already registered");
 	}
 
 	return 0;
@@ -612,7 +612,7 @@ static int cmd_register_ep(const struct shell *sh, int32_t argc, char *argv[])
 			err = bt_a2dp_register_ep(&sink_sbc_endpoint,
 				BT_AVDTP_AUDIO, BT_AVDTP_SINK);
 			if (!err) {
-				shell_print(sh, "SBC sink endpoint is registered");
+				bt_shell_print("SBC sink endpoint is registered");
 				registered_sbc_endpoint = &sink_sbc_endpoint;
 			}
 		} else if (!strcmp(type, "source")) {
@@ -628,7 +628,7 @@ static int cmd_register_ep(const struct shell *sh, int32_t argc, char *argv[])
 			err = bt_a2dp_register_ep(&source_sbc_endpoint,
 				BT_AVDTP_AUDIO, BT_AVDTP_SOURCE);
 			if (!err) {
-				shell_print(sh, "SBC source endpoint is registered");
+				bt_shell_print("SBC source endpoint is registered");
 				registered_sbc_endpoint = &source_sbc_endpoint;
 			}
 		} else {
@@ -641,7 +641,7 @@ static int cmd_register_ep(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (err) {
-		shell_print(sh, "fail to register endpoint");
+		bt_shell_print("fail to register endpoint");
 	}
 
 	return 0;
@@ -654,13 +654,13 @@ static int cmd_connect(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (!default_conn) {
-		shell_error(sh, "Not connected");
+		bt_shell_error("Not connected");
 		return -ENOEXEC;
 	}
 
 	default_a2dp = bt_a2dp_connect(default_conn);
 	if (NULL == default_a2dp) {
-		shell_error(sh, "fail to connect a2dp");
+		bt_shell_error("fail to connect a2dp");
 	}
 	return 0;
 }
@@ -675,7 +675,7 @@ static int cmd_disconnect(const struct shell *sh, int32_t argc, char *argv[])
 		bt_a2dp_disconnect(default_a2dp);
 		default_a2dp = NULL;
 	} else {
-		shell_error(sh, "a2dp is not connected");
+		bt_shell_error("a2dp is not connected");
 	}
 	return 0;
 }
@@ -706,12 +706,12 @@ static int cmd_configure(const struct shell *sh, int32_t argc, char *argv[])
 
 	if (default_a2dp != NULL) {
 		if (registered_sbc_endpoint == NULL) {
-			shell_error(sh, "no endpoint");
+			bt_shell_error("no endpoint");
 			return 0;
 		}
 
 		if (found_peer_sbc_endpoint == NULL) {
-			shell_error(sh, "don't find the peer sbc endpoint");
+			bt_shell_error("don't find the peer sbc endpoint");
 			return 0;
 		}
 
@@ -721,10 +721,10 @@ static int cmd_configure(const struct shell *sh, int32_t argc, char *argv[])
 			registered_sbc_endpoint, found_peer_sbc_endpoint,
 			&sbc_cfg_default);
 		if (err) {
-			shell_error(sh, "fail to configure");
+			bt_shell_error("fail to configure");
 		}
 	} else {
-		shell_error(sh, "a2dp is not connected");
+		bt_shell_error("a2dp is not connected");
 	}
 	return 0;
 }
@@ -736,7 +736,7 @@ static int cmd_reconfigure(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_reconfig(&sbc_stream, &sbc_cfg_default) != 0) {
-		shell_print(sh, "fail");
+		bt_shell_print("fail");
 	}
 	return 0;
 }
@@ -775,7 +775,7 @@ static int cmd_get_peer_eps(const struct shell *sh, int32_t argc, char *argv[])
 	if (default_a2dp != NULL) {
 		discover_param.avdtp_version = (uint16_t)shell_strtoul(argv[1], 0, &err);
 		if (err != 0) {
-			shell_error(sh, "failed to parse avdtp version: %d", err);
+			bt_shell_error("failed to parse avdtp version: %d", err);
 
 			return -ENOEXEC;
 		}
@@ -783,10 +783,10 @@ static int cmd_get_peer_eps(const struct shell *sh, int32_t argc, char *argv[])
 		err = bt_a2dp_discover(default_a2dp, &discover_param);
 
 		if (err) {
-			shell_error(sh, "discover fail");
+			bt_shell_error("discover fail");
 		}
 	} else {
-		shell_error(sh, "a2dp is not connected");
+		bt_shell_error("a2dp is not connected");
 	}
 	return 0;
 }
@@ -798,7 +798,7 @@ static int cmd_establish(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_establish(&sbc_stream) != 0) {
-		shell_print(sh, "fail");
+		bt_shell_print("fail");
 	}
 	return 0;
 }
@@ -810,7 +810,7 @@ static int cmd_release(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_release(&sbc_stream) != 0) {
-		shell_print(sh, "fail");
+		bt_shell_print("fail");
 	}
 	return 0;
 }
@@ -822,7 +822,7 @@ static int cmd_start(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_start(&sbc_stream) != 0) {
-		shell_print(sh, "fail");
+		bt_shell_print("fail");
 	}
 	return 0;
 }
@@ -834,7 +834,7 @@ static int cmd_suspend(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_suspend(&sbc_stream) != 0) {
-		shell_print(sh, "fail");
+		bt_shell_print("fail");
 	}
 	return 0;
 }
@@ -846,7 +846,7 @@ static int cmd_abort(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_abort(&sbc_stream) != 0) {
-		shell_print(sh, "fail");
+		bt_shell_print("fail");
 	}
 	return 0;
 }
@@ -864,7 +864,7 @@ static int cmd_send_media(const struct shell *sh, int32_t argc, char *argv[])
 
 	buf = bt_a2dp_stream_create_pdu(&a2dp_tx_pool, K_FOREVER);
 	if (buf == NULL) {
-		shell_error(sh, "fail to allocate buffer");
+		bt_shell_error("fail to allocate buffer");
 		return -ENOEXEC;
 	}
 
@@ -875,8 +875,8 @@ static int cmd_send_media(const struct shell *sh, int32_t argc, char *argv[])
 	data_len = min(min(sizeof(media_data), bt_a2dp_get_mtu(&sbc_stream)),
 		       net_buf_tailroom(buf));
 	net_buf_add_mem(buf, media_data, data_len);
-	shell_print(sh, "num of frames: %d, data length: %d", 1U, sizeof(media_data));
-	shell_print(sh, "data: %d, %d, %d, %d, %d, %d ......", media_data[0],
+	bt_shell_print("num of frames: %d, data length: %d", 1U, sizeof(media_data));
+	bt_shell_print("data: %d, %d, %d, %d, %d, %d ......", media_data[0],
 		media_data[1], media_data[2], media_data[3], media_data[4], media_data[5]);
 
 	ret = bt_a2dp_stream_send(&sbc_stream, buf, 0U, 0U);
@@ -899,7 +899,7 @@ static int cmd_send_delay_report(const struct shell *sh, int32_t argc, char *arg
 
 	err = bt_a2dp_stream_delay_report(&sbc_stream, 1);
 	if (err < 0) {
-		shell_print(sh, "fail to send delay report (%d)\n", err);
+		bt_shell_print("fail to send delay report (%d)\n", err);
 	}
 
 	return 0;
@@ -913,7 +913,7 @@ static int cmd_get_config(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_get_config(&sbc_stream) != 0) {
-		shell_error(sh, "fail");
+		bt_shell_error("fail");
 	}
 	return 0;
 }
@@ -928,10 +928,10 @@ static int cmd_get_conn(const struct shell *sh, int32_t argc, char *argv[])
 
 	conn = bt_a2dp_get_conn(default_a2dp);
 	if (conn != NULL) {
-		shell_print(sh, "a2dp conn is: %p", conn);
+		bt_shell_print("a2dp conn is: %p", conn);
 		bt_conn_unref(conn);
 	} else {
-		shell_print(sh, "a2dp conn is: NULL");
+		bt_shell_print("a2dp conn is: NULL");
 	}
 
 	return 0;
@@ -972,7 +972,7 @@ static int cmd_a2dp(const struct shell *sh, size_t argc, char **argv)
 		return 1;
 	}
 
-	shell_error(sh, "%s unknown parameter: %s", argv[0], argv[1]);
+	bt_shell_error("%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;
 }

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -295,7 +295,7 @@ static void app_connected(struct bt_a2dp *a2dp, int err)
 		default_a2dp = a2dp;
 		bt_shell_print("a2dp connected");
 	} else {
-		bt_shell_print("a2dp connecting fail");
+		bt_shell_error("a2dp connecting fail");
 	}
 }
 
@@ -342,7 +342,7 @@ static void app_config_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_code)
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to configure");
 	} else {
-		bt_shell_print("fail to configure");
+		bt_shell_error("fail to configure");
 	}
 }
 
@@ -358,7 +358,7 @@ static void app_establish_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_cod
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to establish");
 	} else {
-		bt_shell_print("fail to establish");
+		bt_shell_error("fail to establish");
 	}
 }
 
@@ -374,7 +374,7 @@ static void app_release_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_code)
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to release");
 	} else {
-		bt_shell_print("fail to release");
+		bt_shell_error("fail to release");
 	}
 }
 
@@ -390,7 +390,7 @@ static void app_start_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_code)
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to start");
 	} else {
-		bt_shell_print("fail to start");
+		bt_shell_error("fail to start");
 	}
 }
 
@@ -406,7 +406,7 @@ static void app_suspend_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_code)
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to suspend");
 	} else {
-		bt_shell_print("fail to suspend");
+		bt_shell_error("fail to suspend");
 	}
 }
 
@@ -462,7 +462,7 @@ static void app_delay_report_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to send report delay");
 	} else {
-		bt_shell_print("fail to send report delay");
+		bt_shell_error("fail to send report delay");
 	}
 }
 #endif
@@ -546,8 +546,8 @@ static struct bt_a2dp_cb a2dp_cb = {
 static int check_cb_registration(const struct shell *sh)
 {
 	if (!a2dp_cb_registered) {
-		bt_shell_print("need to register a2dp connection callbacks");
-		return -EIO;
+		bt_shell_error("need to register a2dp connection callbacks");
+		return -ENOENT;
 	}
 
 	return 0;
@@ -564,10 +564,10 @@ static int cmd_register_cb(const struct shell *sh, int32_t argc, char *argv[])
 		if (!err) {
 			bt_shell_print("success");
 		} else {
-			bt_shell_print("fail");
+			bt_shell_error("fail");
 		}
 	} else {
-		bt_shell_print("already registered");
+		bt_shell_error("already registered");
 	}
 
 	return 0;
@@ -641,7 +641,7 @@ static int cmd_register_ep(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (err) {
-		bt_shell_print("fail to register endpoint");
+		bt_shell_error("fail to register endpoint");
 	}
 
 	return 0;
@@ -736,7 +736,7 @@ static int cmd_reconfigure(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_reconfig(&sbc_stream, &sbc_cfg_default) != 0) {
-		bt_shell_print("fail");
+		bt_shell_error("fail");
 	}
 	return 0;
 }
@@ -798,7 +798,7 @@ static int cmd_establish(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_establish(&sbc_stream) != 0) {
-		bt_shell_print("fail");
+		bt_shell_error("fail");
 	}
 	return 0;
 }
@@ -810,7 +810,7 @@ static int cmd_release(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_release(&sbc_stream) != 0) {
-		bt_shell_print("fail");
+		bt_shell_error("fail");
 	}
 	return 0;
 }
@@ -822,7 +822,7 @@ static int cmd_start(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_start(&sbc_stream) != 0) {
-		bt_shell_print("fail");
+		bt_shell_error("fail");
 	}
 	return 0;
 }
@@ -834,7 +834,7 @@ static int cmd_suspend(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_suspend(&sbc_stream) != 0) {
-		bt_shell_print("fail");
+		bt_shell_error("fail");
 	}
 	return 0;
 }
@@ -846,7 +846,7 @@ static int cmd_abort(const struct shell *sh, int32_t argc, char *argv[])
 	}
 
 	if (bt_a2dp_stream_abort(&sbc_stream) != 0) {
-		bt_shell_print("fail");
+		bt_shell_error("fail");
 	}
 	return 0;
 }
@@ -881,7 +881,7 @@ static int cmd_send_media(const struct shell *sh, int32_t argc, char *argv[])
 
 	ret = bt_a2dp_stream_send(&sbc_stream, buf, 0U, 0U);
 	if (ret < 0) {
-		printk("  Failed to send SBC audio data on streams(%d)\n", ret);
+		bt_shell_error("  Failed to send SBC audio data on streams(%d)\n", ret);
 		net_buf_unref(buf);
 	}
 #endif
@@ -899,7 +899,7 @@ static int cmd_send_delay_report(const struct shell *sh, int32_t argc, char *arg
 
 	err = bt_a2dp_stream_delay_report(&sbc_stream, 1);
 	if (err < 0) {
-		bt_shell_print("fail to send delay report (%d)\n", err);
+		bt_shell_error("fail to send delay report (%d)\n", err);
 	}
 
 	return 0;
@@ -931,7 +931,7 @@ static int cmd_get_conn(const struct shell *sh, int32_t argc, char *argv[])
 		bt_shell_print("a2dp conn is: %p", conn);
 		bt_conn_unref(conn);
 	} else {
-		bt_shell_print("a2dp conn is: NULL");
+		bt_shell_error("a2dp conn is: NULL");
 	}
 
 	return 0;

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -342,7 +342,7 @@ static void app_config_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_code)
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to configure");
 	} else {
-		bt_shell_error("fail to configure");
+		bt_shell_error("fail to configure (err code %u)", rsp_err_code);
 	}
 }
 
@@ -358,7 +358,7 @@ static void app_establish_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_cod
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to establish");
 	} else {
-		bt_shell_error("fail to establish");
+		bt_shell_error("fail to establish (err code %u)", rsp_err_code);
 	}
 }
 
@@ -374,7 +374,7 @@ static void app_release_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_code)
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to release");
 	} else {
-		bt_shell_error("fail to release");
+		bt_shell_error("fail to release (err code %u)", rsp_err_code);
 	}
 }
 
@@ -390,7 +390,7 @@ static void app_start_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_code)
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to start");
 	} else {
-		bt_shell_error("fail to start");
+		bt_shell_error("fail to start (err code %u)", rsp_err_code);
 	}
 }
 
@@ -406,7 +406,7 @@ static void app_suspend_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_code)
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to suspend");
 	} else {
-		bt_shell_error("fail to suspend");
+		bt_shell_error("fail to suspend (err code %u)", rsp_err_code);
 	}
 }
 
@@ -462,7 +462,7 @@ static void app_delay_report_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to send report delay");
 	} else {
-		bt_shell_error("fail to send report delay");
+		bt_shell_error("fail to send report delay (err code %u)", rsp_err_code);
 	}
 }
 #endif
@@ -513,7 +513,7 @@ static void app_abort_rsp(struct bt_a2dp_stream *stream, uint8_t rsp_err_code)
 	if (rsp_err_code == 0) {
 		bt_shell_print("success to abort");
 	} else {
-		bt_shell_error("fail to abort");
+		bt_shell_error("fail to abort (err code %u)", rsp_err_code);
 	}
 }
 

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -61,6 +61,8 @@ NET_BUF_POOL_DEFINE(a2dp_tx_pool, CONFIG_BT_MAX_CONN,
 		BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_TX_MTU),
 		CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
+#define A2DP_VERSION 0x0104U
+
 static struct bt_sdp_attribute a2dp_sink_attrs[] = {
 	BT_SDP_NEW_SERVICE,
 	BT_SDP_LIST(
@@ -118,7 +120,7 @@ static struct bt_sdp_attribute a2dp_sink_attrs[] = {
 			},
 			{
 				BT_SDP_TYPE_SIZE(BT_SDP_UINT16), /* 09 */
-				BT_SDP_ARRAY_16(0x0103U) /* 01 03 */
+				BT_SDP_ARRAY_16(A2DP_VERSION) /* 01 04 */
 			},
 			)
 		},
@@ -187,7 +189,7 @@ static struct bt_sdp_attribute a2dp_source_attrs[] = {
 			},
 			{
 				BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
-				BT_SDP_ARRAY_16(0x0103U)
+				BT_SDP_ARRAY_16(A2DP_VERSION)
 			},
 			)
 		},


### PR DESCRIPTION
Before every cmd, call one common function to check whether a2dp is initialized.
Add abort req and rsp callbacks, improve register_ep cmd to support delay report, check buf tailroom for sending media, add get_conn cmd to test bt_a2dp_get_conn.
Improve a2dp shell doc