### PR TITLE
doc: develop: macOS: use correct Python executable for venv

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -127,7 +127,7 @@ The current minimum required version for the main dependencies are:
             brew install cmake ninja gperf python3 python-tk ccache qemu dtc libmagic wget openocd
 
       #. Add the Homebrew Python folder to the path, in order to be able to
-         execute ``python`` and ``pip`` as well ``python3`` and ``pip3``.
+         execute ``python`` and ``pip``.
 
            .. code-block:: bash
 
@@ -272,7 +272,7 @@ chosen. You'll also install Zephyr's additional Python dependencies in a
 
          .. code-block:: bash
 
-            python3 -m venv ~/zephyrproject/.venv
+            python -m venv ~/zephyrproject/.venv
 
       #. Activate the virtual environment:
 


### PR DESCRIPTION
The brew-installed Python is accessible via 'python', not 'python3'. When using:
  export PATH="$(brew --prefix)/opt/python/libexec/bin:$PATH" 

The 'python' executable points to the brew installation, while 'python3' remains the Xcode-bundled version (3.9.x in latest Xcode).

Using 'python3 -m venv' creates a venv with the older Xcode Python instead of the intended brew version.

Since Homebrew requires Xcode Command Line Tools to be installed, we can assume 'python3' exists and may cause this version confusion.

Change the documentation to use 'python -m venv' to ensure the correct Python version is used.