### PR TITLE
dts: vendor: nordic: nrf54h: add missing newline

### DIFF
--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -136,6 +136,7 @@
 				min-residency-us = <700>;
 				exit-latency-us = <5>;
 			};
+
 			idle_cache_disabled: idle_cache_disabled {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";


### PR DESCRIPTION
Add missing newline found by dts-linter. The missing newline is failing CI for any change that modifies nrf54h20.dtsi.