### PR TITLE
kernel: thread: mark return undefined in z_thread_entry using DWARF

### DIFF
--- a/include/zephyr/arch/arm/cfi.h
+++ b/include/zephyr/arch/arm/cfi.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 NXP Semicondutors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_CFI_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_CFI_H_
+
+#define ARCH_CFI_UNDEFINED_RETURN_ADDRESS() __asm__ volatile(".cfi_undefined lr")
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_CFI_H_ */

--- a/include/zephyr/arch/arm64/cfi.h
+++ b/include/zephyr/arch/arm64/cfi.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 NXP Semicondutors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM64_CFI_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM64_CFI_H_
+
+#define ARCH_CFI_UNDEFINED_RETURN_ADDRESS() __asm__ volatile(".cfi_undefined lr")
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM64_CFI_H_ */

--- a/include/zephyr/arch/cfi.h
+++ b/include/zephyr/arch/cfi.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 NXP Semicondutors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * DWARF Control Flow Integrity (CFI) support for architectures.
+ */
+
+#ifndef ZEPHYR_INCLUDE_CFI_H_
+#define ZEPHYR_INCLUDE_CFI_H_
+
+#include <zephyr/arch/arch_interface.h>
+
+#if defined(CONFIG_X86_64)
+#include <zephyr/arch/x86/intel64/cfi.h>
+#elif defined(CONFIG_X86)
+#include <zephyr/arch/x86/ia32/cfi.h>
+#elif defined(CONFIG_ARM64)
+#include <zephyr/arch/arm64/cfi.h>
+#elif defined(CONFIG_ARM)
+#include <zephyr/arch/arm/cfi.h>
+#elif defined(CONFIG_RISCV)
+#include <zephyr/arch/riscv/cfi.h>
+#endif
+
+/*
+ * Inform the unwinder that the return address is undefined.
+ * This prevents bogus unwinding and potential faults.
+ */
+#ifndef ARCH_CFI_UNDEFINED_RETURN_ADDRESS
+#define ARCH_CFI_UNDEFINED_RETURN_ADDRESS()
+#endif
+
+#endif /* ZEPHYR_INCLUDE_CFI_H_ */

--- a/include/zephyr/arch/riscv/cfi.h
+++ b/include/zephyr/arch/riscv/cfi.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 NXP Semicondutors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_RISCV_CFI_H_
+#define ZEPHYR_INCLUDE_ARCH_RISCV_CFI_H_
+
+#define ARCH_CFI_UNDEFINED_RETURN_ADDRESS() __asm__ volatile(".cfi_undefined ra")
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_CFI_H_ */

--- a/include/zephyr/arch/x86/ia32/cfi.h
+++ b/include/zephyr/arch/x86/ia32/cfi.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 NXP Semicondutors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_X86_IA32_CFI_H_
+#define ZEPHYR_INCLUDE_ARCH_X86_IA32_CFI_H_
+
+#define ARCH_CFI_UNDEFINED_RETURN_ADDRESS() __asm__ volatile(".cfi_undefined eip")
+
+#endif /* ZEPHYR_INCLUDE_ARCH_X86_IA32_CFI_H_ */

--- a/include/zephyr/arch/x86/intel64/cfi.h
+++ b/include/zephyr/arch/x86/intel64/cfi.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 NXP Semicondutors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_X86_INTEL64_CFI_H_
+#define ZEPHYR_INCLUDE_ARCH_X86_INTEL64_CFI_H_
+
+#define ARCH_CFI_UNDEFINED_RETURN_ADDRESS() __asm__ volatile(".cfi_undefined rip")
+
+#endif /* ZEPHYR_INCLUDE_ARCH_X86_INTEL64_CFI_H_ */

--- a/lib/os/thread_entry.c
+++ b/lib/os/thread_entry.c
@@ -12,6 +12,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/arch/cfi.h>
 #ifdef CONFIG_CURRENT_THREAD_USE_TLS
 #include <zephyr/random/random.h>
 
@@ -35,6 +36,17 @@ extern Z_THREAD_LOCAL volatile uintptr_t __stack_chk_guard;
 FUNC_NORETURN void z_thread_entry(k_thread_entry_t entry,
 				 void *p1, void *p2, void *p3)
 {
+/*
+ * Inform the unwinder that the current return address is undefined.
+ *
+ * This is typically used at points in the code where execution does not
+ * return like a normal function (for example, thread entry routines).
+ * Marking the return address as undefined prevents stack unwinding or
+ * backtrace tools from following a bogus return address, which could
+ * otherwise lead to reading invalid memory and cause faults during
+ * unwinding or debugging.
+ */
+	ARCH_CFI_UNDEFINED_RETURN_ADDRESS();
 #ifdef CONFIG_CURRENT_THREAD_USE_TLS
 	z_tls_current = k_sched_current_thread_query();
 #endif


### PR DESCRIPTION
Add DWARF hint for Cortex-M targets to handle z_thread_entry correctly in debuggers. This function starts a new thread and never returns. Use `.cfi_undefined lr` so DWARF-based unwinding does not rely on LR. Without this, unwinding may follow a bogus return address, leading to invalid memory reads and potential bus faults during backtrace.

Situation before this patch
<img width="1222" height="423" alt="image" src="https://github.com/user-attachments/assets/8f423f5f-a6df-4e2a-901c-3d9747df1971" />

Situation after this patch
<img width="1203" height="425" alt="image" src="https://github.com/user-attachments/assets/d3591e22-4b1c-4ea6-8522-b2f1ebc82890" />

As you can the debugger doesn't try to read at address 0xAAAAAAAA, which in the case of vmu_rt1170 would lead to a fault.