### PR TITLE
Fix Smartbond timer issues detected by kernel/context test

### DIFF
--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -17,7 +17,7 @@
 #define COUNTER_SPAN BIT(24)
 #define CYC_PER_TICK k_ticks_to_cyc_ceil32(1)
 #define TICK_TO_CYC(tick) k_ticks_to_cyc_ceil32(tick)
-#define CYC_TO_TICK(cyc) k_cyc_to_ticks_ceil32(cyc)
+#define CYC_TO_TICK(cyc) k_cyc_to_ticks_floor32(cyc)
 #define MAX_TICKS (((COUNTER_SPAN / 2) - CYC_PER_TICK) / (CYC_PER_TICK))
 #define SMARTBOND_CLOCK_CONTROLLER DEVICE_DT_GET(DT_NODELABEL(osc))
 /* Margin values are based on DA1469x characterization data */

--- a/tests/kernel/context/boards/da14695_dk_usb.conf
+++ b/tests/kernel/context/boards/da14695_dk_usb.conf
@@ -1,0 +1,3 @@
+# Disable power management to prevent sleep code interfering
+# with time critical tests.
+CONFIG_PM=n

--- a/tests/kernel/context/boards/da1469x_dk_pro.conf
+++ b/tests/kernel/context/boards/da1469x_dk_pro.conf
@@ -1,0 +1,3 @@
+# Disable power management to prevent sleep code interfering
+# with time critical tests.
+CONFIG_PM=n


### PR DESCRIPTION
kernel context test check timing and extra interrupts
being thrown during sleep tests.

One problem that caused test to fails was caused by extra time spent when device started to go to sleep when k_sleep was executed.
Extra time was taken by UART driver that was still transmitting previous logs from test, that resulted in delayed sleep.
To mitigate this PM is off for **contex** test.

Second issue was caused by rounding during conversion from HW cycles to SYS tick.
Conversion rounded up when reported passed ticks while actually tick was not yet finished.
This resulted in application that slept to short and needed extra tick get to expected time.
Now rounding is corrected

fixes: #99558

Output from passing test;
```sh
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [context]: pass = 1, fail = 0, skip = 1, total = 2 duration = 0.013 seconds
 - PASS - [context.test_ctx_thread] duration = 0.012 seconds
 - SKIP - [context.test_interrupts] duration = 0.001 seconds

SUITE PASS - 100.00% [context_cpu_idle]: pass = 1, fail = 0, skip = 1, total = 2 duration = 0.054 seconds
 - PASS - [context_cpu_idle.test_cpu_idle] duration = 0.053 seconds
 - SKIP - [context_cpu_idle.test_cpu_idle_atomic] duration = 0.001 seconds

SUITE PASS - 100.00% [context_one_cpu]: pass = 4, fail = 0, skip = 1, total = 5 duration = 5.371 seconds
 - PASS - [context_one_cpu.test_busy_wait] duration = 0.041 seconds
 - PASS - [context_one_cpu.test_k_sleep] duration = 5.326 seconds
 - PASS - [context_one_cpu.test_k_yield] duration = 0.002 seconds
 - PASS - [context_one_cpu.test_thread] duration = 0.001 seconds
 - SKIP - [context_one_cpu.test_timer_interrupts] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```