### PR TITLE
soc: intel: intel_adsp: fix build for NVL

### DIFF
--- a/soc/intel/intel_adsp/common/gdbstub_backend_sram.c
+++ b/soc/intel/intel_adsp/common/gdbstub_backend_sram.c
@@ -19,15 +19,12 @@
 #include <zephyr/cache.h>
 
 #define RING_SIZE 512
-#if CONFIG_SOC_INTEL_CAVS_V25
-#define SOF_GDB_WINDOW_OFFSET 1024
-#elif CONFIG_SOC_INTEL_ACE15_MTPM || CONFIG_SOC_INTEL_ACE20_LNL || CONFIG_SOC_INTEL_ACE30
+
 /*
  * MTL has 2 usable slots in debug window, which is more than 1 slot on TGL, but
  * still slot 0 is always used for logging, slot 1 is assigned to shell
  */
 #define SOF_GDB_WINDOW_OFFSET 1024
-#endif
 
 struct gdb_sram_ring {
 	unsigned int head;


### PR DESCRIPTION
SOF_GDB_WINDOW_OFFSET is currently only defined for Intel ADSP platforms up to ACE 3.0. Remove the restriction to enable building for all platforms. The upcoming dynamic debug window management should deprecate this hard-coded configuration.