### PR TITLE
ci: tags: add posix headers to posix group in tags

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -79,6 +79,8 @@ net:
 posix:
   files:
     - lib/posix/
+    - include/zephyr/posix/
+    - tests/posix/
 
 test_framework:
   files:


### PR DESCRIPTION
When posix headers change, make sure we verify the posix portability
layer.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
