### PR TITLE
Bluetooth: Host: Legacy passkey entry 6.2 update

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -51,6 +51,10 @@ Bluetooth Host
 * :c:member:`bt_conn_le_info.interval` has been deprecated. Use
   :c:member:`bt_conn_le_info.interval_us` instead. Note that the units have changed: ``interval``
   was in units of 1.25 milliseconds, while ``interval_us`` is in microseconds.
+* Legacy Bluetooth LE pairing using the passkey entry method no longer grants authenticated (MITM)
+  protection as of the Bluetooth Core Specification v6.2. Stored bonds that were generated using
+  this method will be downgraded to unauthenticated when loaded from persistent storage, resulting
+  in a lower security level.
 
 Networking
 **********


### PR DESCRIPTION
As of Core v6.2, the passkey entry pairing method for legacy pairing does no longer grant authenticated MITM protection. This commit updates `smp.c` accordingly to not grant the authenticated states when using legacy passkey entry pairing.

Adds a check to make sure that keys that have been stored persistently adheres to these changes. Keys that have been generated using the legacy passkey entry pairing method will thus be cleared when attempting to restore keys from storage.