### PR TITLE
boards: adi: Add full names for MAX32 boards that were missing them

### DIFF
--- a/boards/adi/max32657evkit/board.yml
+++ b/boards/adi/max32657evkit/board.yml
@@ -3,6 +3,7 @@
 
 board:
   name: max32657evkit
+  full_name: MAX32657EVKIT
   vendor: adi
   socs:
   - name: max32657

--- a/boards/adi/max32658evkit/board.yml
+++ b/boards/adi/max32658evkit/board.yml
@@ -3,6 +3,7 @@
 
 board:
   name: max32658evkit
+  full_name: MAX32658EVKIT
   vendor: adi
   socs:
   - name: max32658


### PR DESCRIPTION
Add missing `full_name` entries for MAX32657EVKIT and MAX32658EVKIT in their respective board.yml files. The names for these two boards appear in lowercase characters in the documentation.

https://docs.zephyrproject.org/latest/boards/adi/index.html