### PR TITLE
tests: twister blackbox: filter module installation

### DIFF
--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -50,6 +50,8 @@ jobs:
         app-path: zephyr
         toolchains: all
         enable-ccache: false
+        west-group-filter: -tools,-bootloader,-babblesim,-hal
+        west-project-filter: -nrf_hw_models,+cmsis,+hal_xtensa,+cmsis_6
 
     - name: Run Pytest For Twister Black Box Tests
       if: ${{ runner.os == 'Linux' }}
@@ -74,7 +76,8 @@ jobs:
         elif [ "${{ runner.os }}" = "Windows" ]; then
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
-        ./scripts/twister --runtime-artifact-cleanup --force-color --inline-logs -T samples/hello_world -T samples/cpp/hello_world -v $EXTRA_TWISTER_FLAGS
+        ./scripts/twister --runtime-artifact-cleanup --force-color --inline-logs -T samples/hello_world -T samples/cpp/hello_world -v $EXTRA_TWISTER_FLAGS -P qemu_cortex_m0
+        rm -rf twister-out*
 
     - name: Build firmware No. 2 - save and load with emulation only
       working-directory: zephyr
@@ -86,9 +89,10 @@ jobs:
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
         BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -T samples/hello_world -T samples/cpp/hello_world -v $EXTRA_TWISTER_FLAGS"
-        ./scripts/twister --save-tests tests.file $BASIC_FLAGS
-        ./scripts/twister --load-tests tests.file --emulation-only $BASIC_FLAGS
+        ./scripts/twister --save-tests tests.file $BASIC_FLAGS -P qemu_cortex_m0
+        ./scripts/twister --load-tests tests.file --emulation-only $BASIC_FLAGS -P qemu_cortex_m0
         rm tests.file
+        rm -rf twister-out*
 
     - name: Build firmware No. 3 - print out test plan
       working-directory: zephyr
@@ -99,8 +103,9 @@ jobs:
         elif [ "${{ runner.os }}" = "Windows" ]; then
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
-        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS -P qemu_cortex_m0"
         ./scripts/twister --test-tree -T tests/kernel/spinlock $BASIC_FLAGS
+        rm -rf twister-out*
 
     - name: Build firmware No. 4 - integration, exclude tag, filter, shuffle, dry run
       working-directory: zephyr
@@ -111,8 +116,9 @@ jobs:
         elif [ "${{ runner.os }}" = "Windows" ]; then
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
-        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS -P qemu_cortex_m0"
         ./scripts/twister --dry-run --integration --subset 1/3 --shuffle-tests --shuffle-tests-seed 1 --filter runnable --exclude-tag audio --exclude-tag driver $BASIC_FLAGS
+        rm -rf twister-out*
 
     - name: Build firmware No. 5 - test, arch, vendor, exclude-platform, platform-reports
       working-directory: zephyr
@@ -123,8 +129,9 @@ jobs:
         elif [ "${{ runner.os }}" = "Windows" ]; then
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
-        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS -P qemu_cortex_m0"
         ./scripts/twister --test kernel.multiprocessing.spinlock --arch x86 --exclude-platform qemu_x86_64 --vendor qemu --platform-reports $BASIC_FLAGS
+        rm -rf twister-out*
 
     - name: Build firmware No. 6 - subtest, platform, rom-ram report, ROM footprint report from buildlog, size report
       working-directory: zephyr
@@ -135,8 +142,9 @@ jobs:
         elif [ "${{ runner.os }}" = "Windows" ]; then
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
-        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS -P qemu_cortex_m0"
         ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --platform qemu_x86 --create-rom-ram-report --footprint-report ROM --enable-size-report --footprint-from-buildlog $BASIC_FLAGS --detailed-test-id
+        rm -rf twister-out*
 
     - name: Build firmware No. 7 - list tags
       working-directory: zephyr
@@ -147,8 +155,9 @@ jobs:
         elif [ "${{ runner.os }}" = "Windows" ]; then
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
-        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS -P qemu_cortex_m0"
         ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --list-tags $BASIC_FLAGS --detailed-test-id
+        rm -rf twister-out*
 
     - name: Build firmware No. 8 - list tests
       working-directory: zephyr
@@ -159,8 +168,9 @@ jobs:
         elif [ "${{ runner.os }}" = "Windows" ]; then
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
-        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS -P qemu_cortex_m0"
         ./scripts/twister -T tests/posix/common --list-tests $BASIC_FLAGS
+        rm -rf twister-out*
 
     - name: Build firmware No. 9 - report flags - dir, name, suffix, summary, all-options, filtered
       working-directory: zephyr
@@ -171,8 +181,9 @@ jobs:
         elif [ "${{ runner.os }}" = "Windows" ]; then
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
-        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS -P qemu_cortex_m0"
         ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --platform qemu_x86 --report-dir . --report-name test_name --report-suffix suffix --report-summary 0 --report-all-options --report-filtered $BASIC_FLAGS --detailed-test-id
+        rm -rf twister-out*
 
     - name: Build firmware No. 10 - force platform and toolchain, log level, timestamps, logfile
       working-directory: zephyr
@@ -183,6 +194,7 @@ jobs:
         elif [ "${{ runner.os }}" = "Windows" ]; then
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
-        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
+        BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS -P qemu_cortex_m0"
         ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --force-platform --platform qemu_x86 --force-toolchain --log-level WARNING --log-file log.file $BASIC_FLAGS --detailed-test-id
         rm log.file
+        rm -rf twister-out*


### PR DESCRIPTION
Do not install modules we do not need for testing to save space.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
