### PR TITLE
drivers: dai: add size parameter to dai_config_set API

### DIFF
--- a/drivers/dai/intel/alh/alh.c
+++ b/drivers/dai/intel/alh/alh.c
@@ -124,7 +124,7 @@ static int dai_alh_config_get(const struct device *dev, struct dai_config *cfg,
 }
 
 static int dai_alh_config_set(const struct device *dev, const struct dai_config *cfg,
-				  const void *bespoke_cfg)
+				  const void *bespoke_cfg, size_t size)
 {
 	struct dai_intel_alh *dp = (struct dai_intel_alh *)dev->data;
 

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -745,7 +745,7 @@ static int dai_dmic_get_config(const struct device *dev, struct dai_config *cfg,
 }
 
 static int dai_dmic_set_config(const struct device *dev,
-		const struct dai_config *cfg, const void *bespoke_cfg)
+		const struct dai_config *cfg, const void *bespoke_cfg, size_t size)
 
 {
 	struct dai_intel_dmic *dmic = (struct dai_intel_dmic *)dev->data;

--- a/drivers/dai/intel/hda/hda.c
+++ b/drivers/dai/intel/hda/hda.c
@@ -67,7 +67,7 @@ static int dai_hda_config_get(const struct device *dev, struct dai_config *cfg, 
 }
 
 static int dai_hda_config_set(const struct device *dev, const struct dai_config *cfg,
-				  const void *bespoke_cfg)
+				  const void *bespoke_cfg, size_t size)
 {
 	struct dai_intel_hda *dp = (struct dai_intel_hda *)dev->data;
 

--- a/drivers/dai/intel/ssp/dai-params-intel-ipc4.h
+++ b/drivers/dai/intel/ssp/dai-params-intel-ipc4.h
@@ -125,6 +125,7 @@ struct ssp_intel_link_ctl {
 #define SSP_DMA_SYNC_DATA                       5
 #define SSP_DMA_CLK_CONTROLS_EXT                6
 #define SSP_LINK_CLK_SOURCE                     7
+#define SSP_GTW_DMA_CONFIG_ID			0x1000
 
 /**< Base top-level structure of an address of a gateway. */
 /*!

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -1875,6 +1875,9 @@ static int dai_ssp_check_aux_data(struct ssp_intel_aux_tlv *aux_tlv, int aux_len
 #else
 		return 0;
 #endif
+	case SSP_GTW_DMA_CONFIG_ID:
+		/* ignored */
+		return 0;
 	default:
 		LOG_ERR("undefined aux data type %u", aux_tlv->type);
 		return -EINVAL;
@@ -1999,6 +2002,9 @@ static int dai_ssp_parse_tlv(struct dai_intel_ssp *dp, const uint8_t *aux_ptr, s
 #endif
 			LOG_INF("link clock_source %u", link->clock_source);
 #endif
+			break;
+		case SSP_GTW_DMA_CONFIG_ID:
+			/* ignored */
 			break;
 		default:
 			LOG_ERR("undefined aux data type %u", aux_tlv->type);

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -2018,7 +2018,7 @@ static int dai_ssp_parse_tlv(struct dai_intel_ssp *dp, const uint8_t *aux_ptr, s
 	return 0;
 }
 
-static int dai_ssp_parse_aux_data(struct dai_intel_ssp *dp, const void *spec_config)
+static int dai_ssp_parse_aux_data(struct dai_intel_ssp *dp, const void *spec_config, size_t size)
 {
 	const struct dai_intel_ipc4_ssp_configuration_blob_ver_1_5 *blob15 = spec_config;
 	const struct dai_intel_ipc4_ssp_configuration_blob_ver_3_0 *blob30 = spec_config;
@@ -2032,7 +2032,7 @@ static int dai_ssp_parse_aux_data(struct dai_intel_ssp *dp, const void *spec_con
 		aux_len = cfg_len - pre_aux_len;
 		aux_ptr = (uint8_t *)blob15 + pre_aux_len;
 	} else if (blob30->version == SSP_BLOB_VER_3_0) {
-		cfg_len = blob30->size;
+		cfg_len = size;
 		pre_aux_len = sizeof(*blob30) +
 			      blob30->i2s_mclk_control.mdivrcnt * sizeof(uint32_t);
 		aux_len = cfg_len - pre_aux_len;
@@ -2186,7 +2186,7 @@ static void dai_ssp_set_reg_config(struct dai_intel_ssp *dp, const struct dai_co
 #endif
 
 static int dai_ssp_set_config_blob(struct dai_intel_ssp *dp, const struct dai_config *cfg,
-				   const void *spec_config)
+				   const void *spec_config, size_t size)
 {
 	const struct dai_intel_ipc4_ssp_configuration_blob_ver_1_5 *blob15 = spec_config;
 	const struct dai_intel_ipc4_ssp_configuration_blob_ver_3_0 *blob30 = spec_config;
@@ -2206,7 +2206,7 @@ static int dai_ssp_set_config_blob(struct dai_intel_ssp *dp, const struct dai_co
 	}
 
 	if (blob15->version == SSP_BLOB_VER_1_5) {
-		err = dai_ssp_parse_aux_data(dp, spec_config);
+		err = dai_ssp_parse_aux_data(dp, spec_config, size);
 		if (err) {
 			return err;
 		}
@@ -2216,7 +2216,7 @@ static int dai_ssp_set_config_blob(struct dai_intel_ssp *dp, const struct dai_co
 			return err;
 		}
 	} else if (blob30->version == SSP_BLOB_VER_3_0) {
-		err = dai_ssp_parse_aux_data(dp, spec_config);
+		err = dai_ssp_parse_aux_data(dp, spec_config, size);
 		if (err) {
 			return err;
 		}
@@ -2517,7 +2517,7 @@ static int dai_ssp_config_set(const struct device *dev, const struct dai_config 
 	if (cfg->type == DAI_INTEL_SSP) {
 		ret = dai_ssp_set_config_tplg(dp, cfg, bespoke_cfg);
 	} else {
-		ret = dai_ssp_set_config_blob(dp, cfg, bespoke_cfg);
+		ret = dai_ssp_set_config_blob(dp, cfg, bespoke_cfg, size);
 	}
 	dai_ssp_program_channel_map(dp, cfg, ssp_plat_data->ssp_index, bespoke_cfg);
 

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -2508,7 +2508,7 @@ static int dai_ssp_config_get(const struct device *dev, struct dai_config *cfg, 
 }
 
 static int dai_ssp_config_set(const struct device *dev, const struct dai_config *cfg,
-			      const void *bespoke_cfg)
+			      const void *bespoke_cfg, size_t size)
 {
 	struct dai_intel_ssp *dp = (struct dai_intel_ssp *)dev->data;
 	struct dai_intel_ssp_plat_data *ssp_plat_data = dai_get_plat_data(dp);

--- a/drivers/dai/nxp/esai/esai.c
+++ b/drivers/dai/nxp/esai/esai.c
@@ -376,7 +376,7 @@ static void esai_commit_config(ESAI_Type *base,
 
 static int esai_config_set(const struct device *dev,
 			   const struct dai_config *cfg,
-			   const void *bespoke_data)
+			   const void *bespoke_data, size_t size)
 {
 	const struct esai_bespoke_config *bespoke;
 	struct esai_data *data;

--- a/drivers/dai/nxp/micfil/micfil.c
+++ b/drivers/dai/nxp/micfil/micfil.c
@@ -112,7 +112,7 @@ static int dai_nxp_micfil_get_config(const struct device *dev, struct dai_config
 }
 
 static int dai_nxp_micfil_set_config(const struct device *dev,
-		const struct dai_config *cfg, const void *bespoke_cfg)
+		const struct dai_config *cfg, const void *bespoke_cfg, size_t size)
 
 {
 	const struct micfil_bespoke_config *bespoke = bespoke_cfg;

--- a/drivers/dai/nxp/sai/sai.c
+++ b/drivers/dai/nxp/sai/sai.c
@@ -207,7 +207,7 @@ static void sai_config_set_err_051421(I2S_Type *base,
 
 static int sai_config_set(const struct device *dev,
 			  const struct dai_config *cfg,
-			  const void *bespoke_data)
+			  const void *bespoke_data, size_t size)
 {
 	const struct sai_bespoke_config *bespoke;
 	sai_transceiver_t *rx_config, *tx_config;

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -315,7 +315,7 @@ __subsystem struct dai_driver_api {
 	int (*probe)(const struct device *dev);
 	int (*remove)(const struct device *dev);
 	int (*config_set)(const struct device *dev, const struct dai_config *cfg,
-			  const void *bespoke_cfg);
+			  const void *bespoke_cfg, size_t size);
 	int (*config_get)(const struct device *dev, struct dai_config *cfg,
 			  enum dai_dir dir);
 
@@ -390,6 +390,7 @@ static inline int dai_remove(const struct device *dev)
  * @param dev Pointer to the device structure for the driver instance.
  * @param cfg Pointer to the structure containing configuration parameters.
  * @param bespoke_cfg Pointer to the structure containing bespoke config.
+ * @param size Bespoke config size.
  *
  * @retval 0 If successful.
  * @retval -EINVAL Invalid argument.
@@ -397,11 +398,12 @@ static inline int dai_remove(const struct device *dev)
  */
 static inline int dai_config_set(const struct device *dev,
 				 const struct dai_config *cfg,
-				 const void *bespoke_cfg)
+				 const void *bespoke_cfg,
+				 size_t size)
 {
 	const struct dai_driver_api *api = (const struct dai_driver_api *)dev->api;
 
-	return api->config_set(dev, cfg, bespoke_cfg);
+	return api->config_set(dev, cfg, bespoke_cfg, size);
 }
 
 /**

--- a/tests/boards/intel_adsp/ssp/src/main.c
+++ b/tests/boards/intel_adsp/ssp/src/main.c
@@ -360,7 +360,7 @@ ZTEST(adsp_ssp, test_adsp_ssp_config_set)
 	ssp_config.quirks = 1 << 6; /* loopback bit on */
 	ssp_config.bclk_delay = 0;
 
-	ret = dai_config_set(dev_dai_ssp, &config, &ssp_config);
+	ret = dai_config_set(dev_dai_ssp, &config, &ssp_config, sizeof(ssp_config));
 
 	zassert_equal(ret, TC_PASS);
 }


### PR DESCRIPTION
- Add size parameter to dai_config_set API
    Add explicit bespoke_cfg_size parameter to the dai_config_set()
    function and its underlying driver API to improve configuration
    validation and security.
- Add support for SSP_GTW_DMA_CONFIG_ID TLV type
    Add handling for SSP_GTW_DMA_CONFIG_ID (0x1000) TLV type in SSP driver's
    auxiliary data parsing functions. This TLV type is explicitly ignored as
    it does not require any processing by the driver.
- Fix SSP blob v3.0 TLV parsing
    Fix incorrect TLV (Type-Length-Value) data length calculation for
    SSP configuration blob version 3.0. The blob30->size field does not
    include auxiliary TLV data appended after the main structure, leading
    to incorrect parsing boundaries.

