### PR TITLE
drivers: uhc: use correct endpoint type and interval

### DIFF
--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -101,6 +101,8 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	const struct uhc_api *api = dev->api;
 	struct uhc_transfer *xfer = NULL;
 	uint16_t mps;
+	uint16_t interval;
+	uint8_t type;
 
 	api->lock(dev);
 
@@ -109,6 +111,8 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	}
 
 	if (ep_idx == 0) {
+		interval = 0;
+		type = USB_EP_TYPE_CONTROL;
 		mps = udev->dev_desc.bMaxPacketSize0;
 	} else {
 		struct usb_ep_descriptor *ep_desc;
@@ -125,6 +129,8 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 		}
 
 		mps = ep_desc->wMaxPacketSize;
+		interval = ep_desc->bInterval;
+		type = ep_desc->bmAttributes & USB_EP_TRANSFER_TYPE_MASK;
 	}
 
 	LOG_DBG("Allocate xfer, ep 0x%02x mps %u cb %p", ep, mps, cb);
@@ -137,6 +143,8 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	memset(xfer, 0, sizeof(struct uhc_transfer));
 	xfer->ep = ep;
 	xfer->mps = mps;
+	xfer->interval = interval;
+	xfer->type = type;
 	xfer->udev = udev;
 	xfer->cb = cb;
 	xfer->priv = cb_priv;

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -280,14 +280,14 @@ usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct uhc_trans
 	/* USB_HostHelperGetPeripheralInformation uses this value as first parameter */
 	pipe_init.devInstance = xfer->udev;
 	pipe_init.nakCount = USB_HOST_CONFIG_MAX_NAK;
-	pipe_init.maxPacketSize = xfer->mps;
+	pipe_init.maxPacketSize = USB_MPS_EP_SIZE(xfer->mps);
 	pipe_init.endpointAddress = USB_EP_GET_IDX(xfer->ep);
 	pipe_init.direction = USB_EP_GET_IDX(xfer->ep) == 0 ? USB_OUT :
 			      USB_EP_GET_DIR(xfer->ep) ? USB_IN : USB_OUT;
 	/* Current Zephyr Host stack is experimental, the endpoint's interval,
 	 * 'number per uframe' and the endpoint type cannot be got yet.
 	 */
-	pipe_init.numberPerUframe = 0; /* TODO: need right way to implement it. */
+	pipe_init.numberPerUframe = USB_MPS_ADDITIONAL_TRANSACTIONS(xfer->mps);
 	pipe_init.interval = xfer->interval;
 	pipe_init.pipeType = xfer->type;
 

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -245,7 +245,7 @@ static usb_host_pipe_handle uhc_mcux_check_hal_ep(const struct device *dev,
 
 	if (mcux_ep != NULL && mcux_ep->pipeType == xfer->type &&
 	    (mcux_ep->maxPacketSize != xfer->mps ||
-	     mcux_ep->interval != xfer->interval)) {
+	    priv->mcux_eps_interval[i] != xfer->interval)) {
 		/* re-initialize the ep */
 		status = priv->mcux_if->controllerClosePipe(priv->mcux_host.controllerHandle,
 							    mcux_ep);
@@ -255,6 +255,7 @@ static usb_host_pipe_handle uhc_mcux_check_hal_ep(const struct device *dev,
 
 		uhc_mcux_lock(dev);
 		priv->mcux_eps[i] = NULL;
+		priv->mcux_eps_interval[i] = 0;
 		uhc_mcux_unlock(dev);
 		mcux_ep = NULL;
 	}
@@ -308,6 +309,7 @@ usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct uhc_trans
 	for (i = 0; i < USB_HOST_CONFIG_MAX_PIPES; i++) {
 		if (priv->mcux_eps[i] == NULL) {
 			priv->mcux_eps[i] = mcux_ep;
+			priv->mcux_eps_interval[i] = xfer->interval;
 			break;
 		}
 	}

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -243,8 +243,7 @@ static usb_host_pipe_handle uhc_mcux_check_hal_ep(const struct device *dev,
 		}
 	}
 
-	/* TODO: need to check endpoint type too */
-	if (mcux_ep != NULL &&
+	if (mcux_ep != NULL && mcux_ep->pipeType == xfer->type &&
 	    (mcux_ep->maxPacketSize != xfer->mps ||
 	     mcux_ep->interval != xfer->interval)) {
 		/* re-initialize the ep */
@@ -289,12 +288,7 @@ usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct uhc_trans
 	 */
 	pipe_init.numberPerUframe = 0; /* TODO: need right way to implement it. */
 	pipe_init.interval = xfer->interval;
-	/* TODO: need right way to implement it. */
-	if (pipe_init.endpointAddress == 0) {
-		pipe_init.pipeType = USB_ENDPOINT_CONTROL;
-	} else {
-		pipe_init.pipeType = USB_ENDPOINT_BULK;
-	}
+	pipe_init.pipeType = xfer->type;
 
 	status = priv->mcux_if->controllerOpenPipe(priv->mcux_host.controllerHandle,
 						   (usb_host_pipe_handle *)&mcux_ep, &pipe_init);

--- a/drivers/usb/uhc/uhc_mcux_common.h
+++ b/drivers/usb/uhc/uhc_mcux_common.h
@@ -12,6 +12,7 @@ struct uhc_mcux_data {
 	const usb_host_controller_interface_t *mcux_if;
 	/* TODO: Maybe make it to link with udev->ep_in and udev->ep_out */
 	usb_host_pipe_t *mcux_eps[USB_HOST_CONFIG_MAX_PIPES];
+	uint16_t mcux_eps_interval[USB_HOST_CONFIG_MAX_PIPES];
 	usb_host_instance_t mcux_host;
 	struct k_thread drv_stack_data;
 	uint8_t controller_id; /* MCUX hal controller id, 0xFF is invalid value */

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -120,6 +120,8 @@ struct uhc_transfer {
 	struct net_buf *buf;
 	/** Endpoint to which request is associated */
 	uint8_t ep;
+	/** Endpoint type */
+	uint8_t type;
 	/** Maximum packet size */
 	uint16_t mps;
 	/** Interval, used for periodic transfers only */


### PR DESCRIPTION
For usb xfer, set endpoint type and interval by the selected endpoint desc.