### PR TITLE
cmake: allow spaces in install path of GNU Arm Embedded linker

### DIFF
--- a/cmake/compiler/target_template.cmake
+++ b/cmake/compiler/target_template.cmake
@@ -102,7 +102,7 @@ if(NOT COMMAND compiler_set_linker_properties)
     # Compute the library directory name
 
     get_filename_component(library_dir ${library_path} DIRECTORY)
-    set_linker_property(PROPERTY lib_include_dir "-L${library_dir}")
+    set_linker_property(PROPERTY lib_include_dir "-L\"${library_dir}\"")
 
     # Compute the linker option for this library
 


### PR DESCRIPTION
This commit fixes #95402. When the GNU toolchain is installed in its default path the library include dir will contain spaces.  By encasulating the library path in quotes the linker works again.