### PR TITLE
boards/native nrf54lm20bsim: Remove experimental warning

### DIFF
--- a/boards/native/nrf_bsim/doc/nrf54lm20bsim.rst
+++ b/boards/native/nrf_bsim/doc/nrf54lm20bsim.rst
@@ -33,10 +33,6 @@ support for the application core, on the simulated nRF54LM20 SOC.
 
    This simulated target does **not** yet support targeting the cpuflpr core.
 
-.. warning::
-
-   This target is experimental.
-
 This board includes models of some of the nRF54LM20 SOC peripherals:
 
 * AAR (Accelerated Address Resolver)


### PR DESCRIPTION
This simulated board has been there for more than 5 months. The real board (nrf54lm20dk) is properly supported and already in the market. So there is no need to have this warning anymore.