### PR TITLE
boards: esp32c6_devkitc: Enable USB Serial/JTAG by default

### DIFF
--- a/boards/espressif/esp32c6_devkitc/esp32c6_devkitc_hpcore.dts
+++ b/boards/espressif/esp32c6_devkitc/esp32c6_devkitc_hpcore.dts
@@ -17,8 +17,8 @@
 
 	chosen {
 		zephyr,sram = &sramhp;
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
+		zephyr,console = &usb_serial;
+		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,ieee802154 = &ieee802154;
@@ -45,6 +45,10 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&uart0_default>;
 	pinctrl-names = "default";
+};
+
+&usb_serial {
+	status = "okay";
 };
 
 &trng0 {


### PR DESCRIPTION
Enable USB Serial/JTAG as the default console for ESP32-C6 DevKitC board. This aligns with the typical usage pattern where users connect via the USB port for console output rather than traditional UART pins.

The ESP32-C6 has built-in USB Serial/JTAG functionality that provides both console output and JTAG debugging over a single USB connection, making it more convenient than UART0 for development.