### PR TITLE
Fix Grove port pin mappings and add missing node labels for M5Stack Fire

### DIFF
--- a/boards/m5stack/m5stack_fire/grove_connectors.dtsi
+++ b/boards/m5stack/m5stack_fire/grove_connectors.dtsi
@@ -35,4 +35,6 @@
 	};
 };
 
+zephyr_i2c: &i2c0 {};
+
 grove_uart: &uart1 {};

--- a/boards/m5stack/m5stack_fire/m5stack_fire-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_fire/m5stack_fire-pinctrl.dtsi
@@ -20,20 +20,12 @@
 		bias-pull-up;
 	};
 
-	uart1_rx_gpio33: uart1_rx_gpio33 {
-		pinmux = <UART1_RX_GPIO33>;
+	uart1_tx_gpio16: uart1_tx_gpio16 {
+		pinmux = <UART1_TX_GPIO16>;
 	};
 
-	uart2_rx_gpio13: uart2_rx_gpio13 {
-		pinmux = <UART2_RX_GPIO13>;
-	};
-
-	uart2_tx_gpio14: uart2_rx_gpio14 {
-		pinmux = <UART2_TX_GPIO14>;
-	};
-
-	uart1_tx_gpio32: uart1_tx_gpio32 {
-		pinmux = <UART1_TX_GPIO32>;
+	uart1_rx_gpio17: uart1_rx_gpio17 {
+		pinmux = <UART1_RX_GPIO17>;
 	};
 
 	spim3_default: spim3_default {

--- a/boards/m5stack/m5stack_fire/m5stack_fire_procpu.dts
+++ b/boards/m5stack/m5stack_fire/m5stack_fire_procpu.dts
@@ -122,7 +122,7 @@
 &uart1 {
 	status = "disabled";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart1_rx_gpio33 &uart1_tx_gpio32>;
+	pinctrl-0 = <&uart1_tx_gpio16 &uart1_rx_gpio17>;
 	pinctrl-names = "default";
 };
 

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -29,6 +29,10 @@ Kernel
 Boards
 ******
 
+* m5stack_fire: Removed unused pinctrl entries for UART2, and updated the UART1
+  pin mapping from GPIO32/GPIO33 to GPIO16/GPIO17 to match the documented Grove
+  PORT.C wiring.
+
 Device Drivers and Devicetree
 *****************************
 


### PR DESCRIPTION
This PR fixes several Grove port definitions in the M5Stack Fire v2.7 board DTS files to align them with the official hardware documentation.

- Fix the UART pin mapping for Grove PORT.C to use GPIO16/17 as [documented](https://docs.m5stack.com/en/core/fire_v2.7).
  <img width="1762" height="616" alt="image" src="https://github.com/user-attachments/assets/17c0dff4-cec7-494c-a245-8dbcf5bc5b2f" />
- Add a `zephyr_i2c` node label pointing to `i2c0` for Grove PORT.A, matching the conventions already used on the Core2 and CoreS3 boards.

These changes prepare the board for future Grove shields, ensuring they can be integrated consistently once added to Zephyr.