### PR TITLE
susbsys/mgmt/mcumgr/grp: add role field to parameters response

### DIFF
--- a/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
@@ -166,6 +166,17 @@ config MCUMGR_GRP_OS_DATETIME_HOOK
 config MCUMGR_GRP_OS_MCUMGR_PARAMS
 	bool "MCUMGR Parameters retrieval command"
 
+config MCUMGR_GRP_OS_MCUMGR_PARAMS_ROLE
+	bool "MCUMGR Parameter Role in response"
+	depends on MCUMGR_GRP_OS_MCUMGR_PARAMS
+
+config MCUMGR_GRP_OS_MCUMGR_PARAMS_ROLE_VALUE
+	int "MCUMGR Parameter Role value"
+	default 0
+	depends on MCUMGR_GRP_OS_MCUMGR_PARAMS_ROLE
+	help
+	  Value for `inst_role` field in response to MCUmgr Parameters request.
+
 config MCUMGR_GRP_OS_INFO
 	bool "Support for info command"
 	help

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -472,6 +472,10 @@ os_mgmt_mcumgr_params(struct smp_streamer *ctxt)
 	     zcbor_uint32_put(zse, CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE)	&&
 	     zcbor_tstr_put_lit(zse, "buf_count")		&&
 	     zcbor_uint32_put(zse, CONFIG_MCUMGR_TRANSPORT_NETBUF_COUNT);
+#ifdef CONFIG_MCUMGR_GRP_OS_MCUMGR_PARAMS_ROLE
+	ok &= zcbor_tstr_put_lit(zse, "inst_role")		&&
+	      zcbor_uint32_put(zse, CONFIG_MCUMGR_GRP_OS_MCUMGR_PARAMS_ROLE_VALUE);
+#endif
 
 	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }


### PR DESCRIPTION
Added optional `inst_role` field to MCUmgr Parameters response. Field is intended to express MCUmgr instance role on the device. Interpretation of the value is Application specific.

Purpose this additional field might be to express application specific: capabilities, requirements and cooperation schemes.
For instance I'm going to use this for distinguish MCUmgr instance in the application `A` from another MCumgr instance in the application `B` and also from MCumgr instance in the loader (ref.: SB_CONFIG_MCUBOOT_MODE_FIRMWARE_UPDATER=y).