### PR TITLE
Clean a few sys_getopt global status variable uses after #98845

### DIFF
--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -702,7 +702,7 @@ An example non-thread safe usage:
   while ((char c = sys_getopt(argc, argv, "abhc:")) != -1) {
         switch (c) {
         case 'c':
-                cvalue = optarg;
+                cvalue = sys_getopt_optarg;
                 break;
         default:
                 break;

--- a/samples/shields/npm6001_ek/src/main.c
+++ b/samples/shields/npm6001_ek/src/main.c
@@ -323,16 +323,16 @@ static int cmd_gpio_configure(const struct shell *sh, size_t argc, char **argv)
 			/* options setting a flag, do nothing */
 			break;
 		case 'p':
-			pin = atoi(optarg);
+			pin = atoi(sys_getopt_optarg);
 			break;
 		case 'd':
-			if (strcmp(optarg, "in") == 0) {
+			if (strcmp(sys_getopt_optarg, "in") == 0) {
 				flags |= GPIO_INPUT;
-			} else if (strcmp(optarg, "out") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "out") == 0) {
 				flags |= GPIO_OUTPUT;
-			} else if (strcmp(optarg, "outh") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "outh") == 0) {
 				flags |= GPIO_OUTPUT_HIGH;
-			} else if (strcmp(optarg, "outl") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "outl") == 0) {
 				flags |= GPIO_OUTPUT_LOW;
 			}
 			break;

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -175,7 +175,7 @@ static int cmd_demo_getopt(const struct shell *sh, size_t argc,
 			bflag = 1;
 			break;
 		case 'c':
-			cvalue = optarg;
+			cvalue = sys_getopt_optarg;
 			break;
 		case 'h':
 			/* When getopt is active shell is not parsing
@@ -185,17 +185,17 @@ static int cmd_demo_getopt(const struct shell *sh, size_t argc,
 			shell_help(sh);
 			return SHELL_CMD_HELP_PRINTED;
 		case '?':
-			if (optopt == 'c') {
+			if (sys_getopt_optopt == 'c') {
 				shell_print(sh,
 					"Option -%c requires an argument.",
-					optopt);
-			} else if (isprint(optopt) != 0) {
+					sys_getopt_optopt);
+			} else if (isprint(sys_getopt_optopt) != 0) {
 				shell_print(sh, "Unknown option `-%c'.",
-					optopt);
+					    sys_getopt_optopt);
 			} else {
 				shell_print(sh,
 					"Unknown option character `\\x%x'.",
-					optopt);
+					sys_getopt_optopt);
 			}
 			return 1;
 		default:

--- a/subsys/crc/Kconfig
+++ b/subsys/crc/Kconfig
@@ -156,7 +156,7 @@ config CRC32_K_4_2_TABLE_256
 config CRC_SHELL
 	bool "CRC Shell"
 	depends on SHELL
-	select POSIX_C_LIB_EXT
+	select GETOPT
 	help
 	  Enable CRC checking for memory regions from the shell.
 

--- a/subsys/crc/crc_shell.c
+++ b/subsys/crc/crc_shell.c
@@ -79,7 +79,7 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 	void *addr = (void *)-1;
 	enum crc_type type = CRC32_IEEE;
 
-	optind = 1;
+	sys_getopt_optind = 1;
 
 	while ((rv = sys_getopt(argc, argv, "fhlp:rs:t:")) != -1) {
 		switch (rv) {
@@ -93,9 +93,9 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 			last = true;
 			break;
 		case 'p':
-			poly = (size_t)strtoul(optarg, NULL, 16);
+			poly = (size_t)strtoul(sys_getopt_optarg, NULL, 16);
 			if (poly == 0 && errno == EINVAL) {
-				shell_error(sh, "invalid seed '%s'", optarg);
+				shell_error(sh, "invalid seed '%s'", sys_getopt_optarg);
 				return -EINVAL;
 			}
 			break;
@@ -103,16 +103,16 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 			reflect = true;
 			break;
 		case 's':
-			seed = (size_t)strtoul(optarg, NULL, 16);
+			seed = (size_t)strtoul(sys_getopt_optarg, NULL, 16);
 			if (seed == 0 && errno == EINVAL) {
-				shell_error(sh, "invalid seed '%s'", optarg);
+				shell_error(sh, "invalid seed '%s'", sys_getopt_optarg);
 				return -EINVAL;
 			}
 			break;
 		case 't':
-			type = string_to_crc_type(optarg);
+			type = string_to_crc_type(sys_getopt_optarg);
 			if (type == -1) {
-				shell_error(sh, "invalid type '%s'", optarg);
+				shell_error(sh, "invalid type '%s'", sys_getopt_optarg);
 				return -EINVAL;
 			}
 			break;
@@ -123,21 +123,21 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 		}
 	}
 
-	if (optind + 2 > argc) {
+	if (sys_getopt_optind + 2 > argc) {
 		shell_error(sh, "'address' and 'size' arguments are mandatory");
 		usage(sh);
 		return -EINVAL;
 	}
 
-	addr = (void *)strtoul(argv[optind], NULL, 16);
+	addr = (void *)strtoul(argv[sys_getopt_optind], NULL, 16);
 	if (addr == 0 && errno == EINVAL) {
-		shell_error(sh, "invalid address '%s'", argv[optind]);
+		shell_error(sh, "invalid address '%s'", argv[sys_getopt_optind]);
 		return -EINVAL;
 	}
 
-	size = (size_t)strtoul(argv[optind + 1], NULL, 0);
+	size = (size_t)strtoul(argv[sys_getopt_optind + 1], NULL, 0);
 	if (size == 0 && errno == EINVAL) {
-		shell_error(sh, "invalid size '%s'", argv[optind + 1]);
+		shell_error(sh, "invalid size '%s'", argv[sys_getopt_optind + 1]);
 		return -EINVAL;
 	}
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -25,7 +25,6 @@ LOG_MODULE_REGISTER(net_wifi_shell, LOG_LEVEL_INF);
 #include <zephyr/net/net_event.h>
 #include <zephyr/net/wifi_mgmt.h>
 #include <zephyr/net/wifi_utils.h>
-#include <zephyr/posix/unistd.h>
 #include <zephyr/sys/slist.h>
 
 #include "net_shell_private.h"

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -2300,24 +2300,25 @@ static int cmd_wifi_reg_domain(const struct shell *sh, size_t argc,
 		}
 	}
 
-	if (optind == argc) {
+	if (sys_getopt_optind == argc) {
 		regd.chan_info = &chan_info[0];
 		regd.oper = WIFI_MGMT_GET;
-	} else if (optind == argc - 1) {
-		if (strlen(argv[optind]) != 2) {
+	} else if (sys_getopt_optind == argc - 1) {
+		if (strlen(argv[sys_getopt_optind]) != 2) {
 			PR_WARNING("Invalid reg domain: Length should be two letters/digits\n");
 			return -ENOEXEC;
 		}
 
 		/* Two letter country code with special case of 00 for WORLD */
-		if (((argv[optind][0] < 'A' || argv[optind][0] > 'Z') ||
-			(argv[optind][1] < 'A' || argv[optind][1] > 'Z')) &&
-			(argv[optind][0] != '0' || argv[optind][1] != '0')) {
-			PR_WARNING("Invalid reg domain %c%c\n", argv[optind][0], argv[optind][1]);
+		if (((argv[sys_getopt_optind][0] < 'A' || argv[sys_getopt_optind][0] > 'Z') ||
+			(argv[sys_getopt_optind][1] < 'A' || argv[sys_getopt_optind][1] > 'Z')) &&
+			(argv[sys_getopt_optind][0] != '0' || argv[sys_getopt_optind][1] != '0')) {
+			PR_WARNING("Invalid reg domain %c%c\n", argv[sys_getopt_optind][0],
+				   argv[sys_getopt_optind][1]);
 			return -ENOEXEC;
 		}
-		regd.country_code[0] = argv[optind][0];
-		regd.country_code[1] = argv[optind][1];
+		regd.country_code[0] = argv[sys_getopt_optind][0];
+		regd.country_code[1] = argv[sys_getopt_optind][1];
 		regd.force = force;
 		regd.oper = WIFI_MGMT_SET;
 	} else {


### PR DESCRIPTION
sys_getopt has now its global status variables prefixed with sys_getopt_
Let's fix the few uses in tree that were forgotten in #98845. 
Note using the old names worked as before as Zephyr's POSIX_C_LIB_EXT keeps a replica of these variables without the prefix, but this is not something one can count on, as in general the C library provided getopt is not going to have any relationship to sys_getopt()

And since sys_getopt was split from POSIX_C_LIB_EXT the CRC_SHELL component only needs to enable GETOPT and not the whole POSIX_C_LIB_EXT.

Fixes #95477

And an extra commit removing a now unnecessary include of unistd.h from subsys/net/l2/wifi/wifi_shell.c (since we use sys_getopt and not the posix_api getopt shim)