### PR TITLE
Fix detection of native C library in the tree

### DIFF
--- a/include/zephyr/net/socket_types.h
+++ b/include/zephyr/net/socket_types.h
@@ -40,7 +40,7 @@ struct timeval {
 
 #else /* CONFIG_NEWLIB_LIBC */
 
-#if defined(CONFIG_ARCH_POSIX) && defined(CONFIG_EXTERNAL_LIBC)
+#if defined(CONFIG_NATIVE_LIBC)
 #include <bits/types/struct_timeval.h>
 #else
 #include <sys/_timeval.h>

--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_TYPES_H_
 #define ZEPHYR_INCLUDE_POSIX_TYPES_H_
 
-#if !(defined(CONFIG_ARCH_POSIX) && defined(CONFIG_EXTERNAL_LIBC))
+#if !(defined(CONFIG_NATIVE_LIBC))
 #include <sys/types.h>
 #endif
 

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -12,7 +12,7 @@
 #include <zephyr/drivers/uart.h>
 #include <ctype.h>
 
-#ifdef CONFIG_ARCH_POSIX
+#ifdef CONFIG_NATIVE_LIBC
 #include <unistd.h>
 #else
 #include <zephyr/posix/unistd.h>

--- a/subsys/crc/crc_shell.c
+++ b/subsys/crc/crc_shell.c
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#ifdef CONFIG_ARCH_POSIX
+#ifdef CONFIG_NATIVE_LIBC
 #include <unistd.h>
 #else
 #include <zephyr/posix/unistd.h>

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -141,7 +141,7 @@ static void help_item_print(const struct shell *sh, const char *item_name,
 	}
 
 	if (!IS_ENABLED(CONFIG_NEWLIB_LIBC) &&
-	    !IS_ENABLED(CONFIG_ARCH_POSIX)) {
+	    !IS_ENABLED(CONFIG_NATIVE_LIBC)) {
 		/* print option name */
 		z_shell_fprintf(sh, SHELL_NORMAL, "%s%-*s", tabulator,
 				item_name_width, item_name);

--- a/tests/posix/net/src/inet_addr.c
+++ b/tests/posix/net/src/inet_addr.c
@@ -19,7 +19,7 @@ ZTEST(net, test_inet_addr)
 		int out;
 	} parms[] = {
 	/* expect failure */
-#ifndef CONFIG_ARCH_POSIX
+#ifndef CONFIG_NATIVE_LIBC
 		{NULL, (uint32_t)-1}, /* this value will segfault using the host libc */
 #endif
 		{".", (uint32_t)-1},


### PR DESCRIPTION
Let's use CONFIG_NATIVE_LIBC to detect builds with the host C library
instead of presuming that any build targeting the POSIX architecture
uses it. This has not been the case for several years now, as we can
select different C libraries when targeting the POSIX architecture.

Let's use CONFIG_NATIVE_LIBC to detect builds with the host C library
instead of checking for both CONFIG_ARCH_POSIX && CONFIG_EXTERNAL_LIBC
as it is just simpler since we added this CONFIG_NATIVE_LIBC option.