### PR TITLE
MAINTAINERS: drop the sensor area label from few ares

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2614,8 +2614,6 @@ Documentation Infrastructure:
     - wm-eisos
   files:
     - drivers/sensor/wsen/
-  labels:
-    - "area: Sensors"
   tests:
     - drivers.sensors
   description: >-
@@ -4875,8 +4873,6 @@ TDK Sensors:
     - gjabouley-invn
   files:
     - drivers/sensor/tdk/
-  labels:
-    - "area: Sensors"
   tests:
     - drivers.sensors
 


### PR DESCRIPTION
Drop the "area: Sensors" label from Wurth and TDK sensor areas, the current setup is causing the issue assigner script to pick up those maintainers for any issue labeled as sensor as it does not know better, if these areas wants a label for issue tracking their maintainer can make an area specific one and use it.