### PR TITLE
Bluetooth: BAP: Fix bad check for ASE state for CIS connect

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -327,8 +327,8 @@ static void unicast_client_ep_iso_connected(struct bt_bap_ep *ep)
 		ep->unicast_group->has_been_connected = true;
 	}
 
-	if (ep->state != BT_BAP_EP_STATE_ENABLING) {
-		LOG_DBG("endpoint not in enabling state: %s", bt_bap_ep_state_str(ep->state));
+	if (ep->state != BT_BAP_EP_STATE_QOS_CONFIGURED && ep->state != BT_BAP_EP_STATE_ENABLING) {
+		LOG_DBG("endpoint in invalid state: %s", bt_bap_ep_state_str(ep->state));
 		return;
 	}
 


### PR DESCRIPTION
A CIS may be connected in either the QoS Configured state or the enabling state. The QoS Configured state is the earliest state it is allowed, due to it being the first state where the CIS_ID and ASE_ID are paired.
The enabling state is the "last" state it is allowed, as if the ASE is in the streaming, disabling or releasing state we should not allow/expect a CIS connection to happen.