### PR TITLE
scripts: ci: `ruff` handling

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -278,10 +278,6 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
 ]
-"./scripts/ci/errno.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
-]
 "./scripts/ci/stats/merged_prs.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -1170,7 +1166,6 @@ exclude = [
     "./scripts/build/uf2conv.py",
     "./scripts/check_maintainers.py",
     "./scripts/ci/coverage/coverage_analysis.py",
-    "./scripts/ci/errno.py",
     "./scripts/ci/set_assignees.py",
     "./scripts/ci/stats/merged_prs.py",
     "./scripts/ci/test_plan.py",

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -1140,8 +1140,6 @@ exclude = [
     "./scripts/build/subfolder_list.py",
     "./scripts/build/uf2conv.py",
     "./scripts/check_maintainers.py",
-    "./scripts/ci/set_assignees.py",
-    "./scripts/ci/twister_report_analyzer.py",
     "./scripts/ci/upload_test_results_es.py",
     "./scripts/coredump/coredump_gdbserver.py",
     "./scripts/coredump/coredump_parser/elf_parser.py",

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -273,14 +273,6 @@
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
-"./scripts/ci/check_compliance.py" = [
-    "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "E741",     # https://docs.astral.sh/ruff/rules/ambiguous-variable-name
-    "F401",     # https://docs.astral.sh/ruff/rules/unused-import
-    "SIM112",   # https://docs.astral.sh/ruff/rules/uncapitalized-environment-variables
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
-]
 "./scripts/ci/coverage/coverage_analysis.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -1177,7 +1169,6 @@ exclude = [
     "./scripts/build/subfolder_list.py",
     "./scripts/build/uf2conv.py",
     "./scripts/check_maintainers.py",
-    "./scripts/ci/check_compliance.py",
     "./scripts/ci/coverage/coverage_analysis.py",
     "./scripts/ci/errno.py",
     "./scripts/ci/set_assignees.py",

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -299,11 +299,6 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
 ]
-"./scripts/ci/version_mgr.py" = [
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
-]
 "./scripts/coredump/coredump_gdbserver.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]
@@ -1171,7 +1166,6 @@ exclude = [
     "./scripts/ci/test_plan.py",
     "./scripts/ci/twister_report_analyzer.py",
     "./scripts/ci/upload_test_results_es.py",
-    "./scripts/ci/version_mgr.py",
     "./scripts/coredump/coredump_gdbserver.py",
     "./scripts/coredump/coredump_parser/elf_parser.py",
     "./scripts/coredump/coredump_parser/log_parser.py",

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -290,11 +290,6 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
 ]
-"./scripts/ci/guideline_check.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-]
 "./scripts/ci/stats/merged_prs.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
@@ -1185,7 +1180,6 @@ exclude = [
     "./scripts/ci/check_compliance.py",
     "./scripts/ci/coverage/coverage_analysis.py",
     "./scripts/ci/errno.py",
-    "./scripts/ci/guideline_check.py",
     "./scripts/ci/set_assignees.py",
     "./scripts/ci/stats/merged_prs.py",
     "./scripts/ci/test_plan.py",

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -273,11 +273,6 @@
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
-"./scripts/ci/coverage/coverage_analysis.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
-]
 "./scripts/ci/test_plan.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E401",     # https://docs.astral.sh/ruff/rules/multiple-imports-on-one-line
@@ -1156,7 +1151,6 @@ exclude = [
     "./scripts/build/subfolder_list.py",
     "./scripts/build/uf2conv.py",
     "./scripts/check_maintainers.py",
-    "./scripts/ci/coverage/coverage_analysis.py",
     "./scripts/ci/set_assignees.py",
     "./scripts/ci/test_plan.py",
     "./scripts/ci/twister_report_analyzer.py",

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -273,17 +273,6 @@
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
-"./scripts/ci/test_plan.py" = [
-    "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
-    "E401",     # https://docs.astral.sh/ruff/rules/multiple-imports-on-one-line
-    "E402",     # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-    "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
-    "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
-    "UP032",    # https://docs.astral.sh/ruff/rules/f-string
-]
 "./scripts/ci/upload_test_results_es.py" = [
     "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "E713",     # https://docs.astral.sh/ruff/rules/not-in-test
@@ -1152,7 +1141,6 @@ exclude = [
     "./scripts/build/uf2conv.py",
     "./scripts/check_maintainers.py",
     "./scripts/ci/set_assignees.py",
-    "./scripts/ci/test_plan.py",
     "./scripts/ci/twister_report_analyzer.py",
     "./scripts/ci/upload_test_results_es.py",
     "./scripts/coredump/coredump_gdbserver.py",

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -278,10 +278,6 @@
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "UP015",    # https://docs.astral.sh/ruff/rules/redundant-open-modes
 ]
-"./scripts/ci/stats/merged_prs.py" = [
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/ci/test_plan.py" = [
     "B006",     # https://docs.astral.sh/ruff/rules/mutable-argument-default
     "E401",     # https://docs.astral.sh/ruff/rules/multiple-imports-on-one-line
@@ -1162,7 +1158,6 @@ exclude = [
     "./scripts/check_maintainers.py",
     "./scripts/ci/coverage/coverage_analysis.py",
     "./scripts/ci/set_assignees.py",
-    "./scripts/ci/stats/merged_prs.py",
     "./scripts/ci/test_plan.py",
     "./scripts/ci/twister_report_analyzer.py",
     "./scripts/ci/upload_test_results_es.py",

--- a/scripts/ci/coverage/coverage_analysis.py
+++ b/scripts/ci/coverage/coverage_analysis.py
@@ -1,23 +1,41 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Intel Corporation
 
-import yaml
-import ijson
+import argparse
 import json
 import re
-import argparse
-import xlsxwriter
-class Json_report:
 
-    json_object = {
-        "components":[]
-    }
+import ijson
+import xlsxwriter
+import yaml
+
+
+class ComponentStats:
+    def __init__(
+        self,
+        testsuites: int,
+        runnable: int,
+        build_only: int,
+        sim_only: int,
+        hw_only: int,
+        mixed: int,
+    ):
+        self.testsuites = testsuites
+        self.runnable = runnable
+        self.build_only = build_only
+        self.sim_only = sim_only
+        self.hw_only = hw_only
+        self.mixed = mixed
+
+
+class Json_report:
+    json_object = {"components": []}
 
     simulators = [
         'unit_testing',
         'native',
         'qemu',
-        'mps2/an385'
+        'mps2/an385',
     ]
 
     report_json = {}
@@ -25,190 +43,172 @@ class Json_report:
     def __init__(self):
         args = parse_args()
         self.parse_testplan(args.testplan)
-        self.maintainers_file = self.get_maintainers_file( args.maintainers)
-        self.report_json = self.generate_json_report( args.coverage)
+        self.maintainers_file = self.get_maintainers_file(args.maintainers)
+        self.report_json = self.generate_json_report(args.coverage)
 
         if args.format == "json":
-            self.save_json_report( args.output, self.report_json)
+            self.save_json_report(args.output, self.report_json)
         elif args.format == "xlsx":
             self.generate_xlsx_report(self.report_json, args.output)
         elif args.format == "all":
-            self.save_json_report( args.output, self.report_json)
+            self.save_json_report(args.output, self.report_json)
             self.generate_xlsx_report(self.report_json, args.output)
         else:
             print("Format incorrect")
 
     def get_maintainers_file(self, maintainers):
         maintainers_file = ""
-        with open(maintainers, 'r') as file:
+        with open(maintainers) as file:
             maintainers_file = yaml.safe_load(file)
             file.close()
         return maintainers_file
 
+    def _parse_testcase(self, testsuite, testcase):
+        if testcase['status'] == 'None':
+            testcase_name = testsuite['name']
+            component_name = testcase_name[: testcase_name.find('.')]
+            component = {"name": component_name, "sub_components": [], "files": []}
+            features = self.json_object['components']
+            known_component_flag = False
+            for item in features:
+                if component_name == item['name']:
+                    component = item
+                    known_component_flag = True
+                    break
+            sub_component_name = testcase_name[testcase_name.find('.') :]
+            sub_component_name = sub_component_name[1:]
+            if idx := sub_component_name.find(".") > 0:
+                sub_component_name = sub_component_name[:idx]
+            if known_component_flag is False:
+                sub_component = {"name": sub_component_name, "test_suites": []}
+                test_suite = {
+                    "name": testsuite['name'],
+                    "path": testsuite['path'],
+                    "platforms": [],
+                    "runnable": testsuite['runnable'],
+                    "status": "",
+                    "test_cases": [],
+                }
+                test_case = {"name": testcase_name}
+                if any(platform in testsuite['platform'] for platform in self.simulators):
+                    if test_suite['status'] == "":
+                        test_suite['status'] = 'sim_only'
+
+                    if test_suite['status'] == 'hw_only':
+                        test_suite['status'] = 'mixed'
+                else:
+                    if test_suite['status'] == "":
+                        test_suite['status'] = 'hw_only'
+
+                    if test_suite['status'] == 'sim_only':
+                        test_suite['status'] = 'mixed'
+                test_suite['test_cases'].append(test_case)
+                test_suite['platforms'].append(testsuite['platform'])
+                sub_component["test_suites"].append(test_suite)
+                component['sub_components'].append(sub_component)
+                self.json_object['components'].append(component)
+            else:
+                sub_component = {}
+                sub_components = component['sub_components']
+                known_sub_component_flag = False
+                for i_sub_component in sub_components:
+                    if sub_component_name == i_sub_component['name']:
+                        sub_component = i_sub_component
+                        known_sub_component_flag = True
+                        break
+                if known_sub_component_flag is False:
+                    sub_component = {"name": sub_component_name, "test_suites": []}
+                    test_suite = {
+                        "name": testsuite['name'],
+                        "path": testsuite['path'],
+                        "platforms": [],
+                        "runnable": testsuite['runnable'],
+                        "status": "",
+                        "test_cases": [],
+                    }
+                    test_case = {"name": testcase_name}
+                    if any(platform in testsuite['platform'] for platform in self.simulators):
+                        if test_suite['status'] == "":
+                            test_suite['status'] = 'sim_only'
+
+                        if test_suite['status'] == 'hw_only':
+                            test_suite['status'] = 'mixed'
+                    else:
+                        if test_suite['status'] == "":
+                            test_suite['status'] = 'hw_only'
+
+                        if test_suite['status'] == 'sim_only':
+                            test_suite['status'] = 'mixed'
+                    test_suite['test_cases'].append(test_case)
+                    test_suite['platforms'].append(testsuite['platform'])
+                    sub_component["test_suites"].append(test_suite)
+                    component['sub_components'].append(sub_component)
+                else:
+                    test_suite = {}
+                    test_suites = sub_component['test_suites']
+                    known_testsuite_flag = False
+                    for i_testsuite in test_suites:
+                        if testsuite['name'] == i_testsuite['name']:
+                            test_suite = i_testsuite
+                            known_testsuite_flag = True
+                            break
+                    if known_testsuite_flag is False:
+                        test_suite = {
+                            "name": testsuite['name'],
+                            "path": testsuite['path'],
+                            "platforms": [],
+                            "runnable": testsuite['runnable'],
+                            "status": "",
+                            "test_cases": [],
+                        }
+                        test_case = {"name": testcase_name}
+                        if any(platform in testsuite['platform'] for platform in self.simulators):
+                            if test_suite['status'] == "":
+                                test_suite['status'] = 'sim_only'
+
+                            if test_suite['status'] == 'hw_only':
+                                test_suite['status'] = 'mixed'
+                        else:
+                            if test_suite['status'] == "":
+                                test_suite['status'] = 'hw_only'
+
+                            if test_suite['status'] == 'sim_only':
+                                test_suite['status'] = 'mixed'
+                        test_suite['test_cases'].append(test_case)
+                        test_suite['platforms'].append(testsuite['platform'])
+                        sub_component["test_suites"].append(test_suite)
+                    else:
+                        if any(platform in testsuite['platform'] for platform in self.simulators):
+                            if test_suite['status'] == "":
+                                test_suite['status'] = 'sim_only'
+
+                            if test_suite['status'] == 'hw_only':
+                                test_suite['status'] = 'mixed'
+                        else:
+                            if test_suite['status'] == "":
+                                test_suite['status'] = 'hw_only'
+
+                            if test_suite['status'] == 'sim_only':
+                                test_suite['status'] = 'mixed'
+                        test_case = {}
+                        test_cases = test_suite['test_cases']
+                        known_testcase_flag = False
+                        for i_testcase in test_cases:
+                            if testcase_name == i_testcase['name']:
+                                test_case = i_testcase
+                                known_testcase_flag = True
+                                break
+                        if known_testcase_flag is False:
+                            test_case = {"name": testcase_name}
+                            test_suite['test_cases'].append(test_case)
 
     def parse_testplan(self, testplan_path):
-        with open(testplan_path, 'r') as file:
+        with open(testplan_path) as file:
             parser = ijson.items(file, 'testsuites')
             for element in parser:
                 for testsuite in element:
                     for testcase in testsuite['testcases']:
-                        if testcase['status'] == 'None':
-                            testcase_name = testsuite['name']
-                            component_name = testcase_name[:testcase_name.find('.')]
-                            component = {
-                                "name": component_name,
-                                "sub_components":[],
-                                "files":[]
-                            }
-                            features = self.json_object['components']
-                            known_component_flag = False
-                            for item in features:
-                                if component_name == item['name']:
-                                    component = item
-                                    known_component_flag = True
-                                    break
-                            sub_component_name = testcase_name[testcase_name.find('.'):]
-                            sub_component_name = sub_component_name[1:]
-                            if sub_component_name.find(".") > 0:
-                                sub_component_name = sub_component_name[:sub_component_name.find(".")]
-                            if known_component_flag is False:
-
-                                sub_component = {
-                                    "name":sub_component_name,
-                                    "test_suites":[]
-                                }
-                                test_suite = {
-                                    "name":testsuite['name'],
-                                    "path":testsuite['path'],
-                                    "platforms":[],
-                                    "runnable": testsuite['runnable'],
-                                    "status":"",
-                                    "test_cases":[]
-                                }
-                                test_case = {
-                                    "name":testcase_name
-                                }
-                                if any(platform in testsuite['platform'] for platform in self.simulators):
-                                    if test_suite['status'] == "":
-                                        test_suite['status'] = 'sim_only'
-
-                                    if test_suite['status'] == 'hw_only':
-                                        test_suite['status'] = 'mixed'
-                                else:
-                                    if test_suite['status'] == "":
-                                        test_suite['status'] = 'hw_only'
-
-                                    if test_suite['status'] == 'sim_only':
-                                        test_suite['status'] = 'mixed'
-                                test_suite['test_cases'].append(test_case)
-                                test_suite['platforms'].append(testsuite['platform'])
-                                sub_component["test_suites"].append(test_suite)
-                                component['sub_components'].append(sub_component)
-                                self.json_object['components'].append(component)
-                            else:
-                                sub_component = {}
-                                sub_components = component['sub_components']
-                                known_sub_component_flag = False
-                                for i_sub_component in sub_components:
-                                    if sub_component_name == i_sub_component['name']:
-                                        sub_component = i_sub_component
-                                        known_sub_component_flag = True
-                                        break
-                                if known_sub_component_flag is False:
-                                    sub_component = {
-                                        "name":sub_component_name,
-                                        "test_suites":[]
-                                    }
-                                    test_suite = {
-                                        "name":testsuite['name'],
-                                        "path":testsuite['path'],
-                                        "platforms":[],
-                                        "runnable": testsuite['runnable'],
-                                        "status":"",
-                                        "test_cases":[]
-                                    }
-                                    test_case = {
-                                        "name": testcase_name
-                                    }
-                                    if any(platform in testsuite['platform'] for platform in self.simulators):
-                                        if test_suite['status'] == "":
-                                            test_suite['status'] = 'sim_only'
-
-                                        if test_suite['status'] == 'hw_only':
-                                            test_suite['status'] = 'mixed'
-                                    else:
-                                        if test_suite['status'] == "":
-                                            test_suite['status'] = 'hw_only'
-
-                                        if test_suite['status'] == 'sim_only':
-                                            test_suite['status'] = 'mixed'
-                                    test_suite['test_cases'].append(test_case)
-                                    test_suite['platforms'].append(testsuite['platform'])
-                                    sub_component["test_suites"].append(test_suite)
-                                    component['sub_components'].append(sub_component)
-                                else:
-                                    test_suite = {}
-                                    test_suites = sub_component['test_suites']
-                                    known_testsuite_flag = False
-                                    for i_testsuite in test_suites:
-                                        if testsuite['name'] == i_testsuite['name']:
-                                            test_suite = i_testsuite
-                                            known_testsuite_flag = True
-                                            break
-                                    if known_testsuite_flag is False:
-                                        test_suite = {
-                                            "name":testsuite['name'],
-                                            "path":testsuite['path'],
-                                            "platforms":[],
-                                            "runnable": testsuite['runnable'],
-                                            "status":"",
-                                            "test_cases":[]
-                                        }
-                                        test_case  = {
-                                            "name": testcase_name
-                                        }
-                                        if any(platform in testsuite['platform'] for platform in self.simulators):
-                                            if test_suite['status'] == "":
-                                                test_suite['status'] = 'sim_only'
-
-                                            if test_suite['status'] == 'hw_only':
-                                                test_suite['status'] = 'mixed'
-                                        else:
-                                            if test_suite['status'] == "":
-                                                test_suite['status'] = 'hw_only'
-
-                                            if test_suite['status'] == 'sim_only':
-                                                test_suite['status'] = 'mixed'
-                                        test_suite['test_cases'].append(test_case)
-                                        test_suite['platforms'].append(testsuite['platform'])
-                                        sub_component["test_suites"].append(test_suite)
-                                    else:
-                                        if any(platform in testsuite['platform'] for platform in self.simulators):
-                                            if test_suite['status'] == "":
-                                                test_suite['status'] = 'sim_only'
-
-                                            if test_suite['status'] == 'hw_only':
-                                                test_suite['status'] = 'mixed'
-                                        else:
-                                            if test_suite['status'] == "":
-                                                test_suite['status'] = 'hw_only'
-
-                                            if test_suite['status'] == 'sim_only':
-                                                test_suite['status'] = 'mixed'
-                                        test_case = {}
-                                        test_cases = test_suite['test_cases']
-                                        known_testcase_flag = False
-                                        for i_testcase in test_cases:
-                                            if testcase_name == i_testcase['name']:
-                                                test_case = i_testcase
-                                                known_testcase_flag = True
-                                                break
-                                        if known_testcase_flag is False:
-                                            test_case = {
-                                                "name":testcase_name
-                                            }
-                                            test_suite['test_cases'].append(test_case)
-            file.close()
+                        self._parse_testcase(testsuite, testcase)
 
     def get_files_from_maintainers_file(self, component_name):
         files_path = []
@@ -222,67 +222,66 @@ class Json_report:
 
                 if _found_flag is True:
                     for path in self.maintainers_file[item]['files']:
-                        path = path.replace('*','.*')
+                        path = path.replace('*', '.*')
                         files_path.append(path)
             except TypeError:
                 print("ERROR: Fail while parsing MAINTAINERS file at %s", component_name)
         return files_path
 
-    def generate_json_report(self, coverage):
-        output_json = {
-            "components":[]
-        }
+    def _generate_component_report(self, element, component) -> dict:
+        json_component = {}
+        json_component["name"] = component["name"]
+        json_component["sub_components"] = component["sub_components"]
+        json_component["Comment"] = ""
+        files_path = self.get_files_from_maintainers_file(component["name"])
 
-        with open(coverage, 'r') as file:
+        if len(files_path) == 0:
+            json_component["files"] = []
+            json_component["Comment"] = "Missed in maintainers.yml file."
+            return json_component
+
+        json_files = []
+        for i_file in files_path:
+            for covered_file in element:
+                x = re.search(('.*' + i_file + '.*'), covered_file['file'])
+                if not x:
+                    continue
+
+                file_name = covered_file['file'][covered_file['file'].rfind('/') + 1 :]
+                file_path = covered_file['file']
+                file_coverage, file_lines, file_hit = self._calculate_coverage_of_file(covered_file)
+                json_file = {
+                    "Name": file_name,
+                    "Path": file_path,
+                    "Lines": file_lines,
+                    "Hit": file_hit,
+                    "Coverage": file_coverage,
+                    "Covered_Functions": [],
+                    "Uncovered_Functions": [],
+                }
+                for i_fun in covered_file['functions']:
+                    if i_fun['execution_count'] != 0:
+                        json_covered_funciton = {"Name": i_fun['name']}
+                        json_file['Covered_Functions'].append(json_covered_funciton)
+                for i_fun in covered_file['functions']:
+                    if i_fun['execution_count'] == 0:
+                        json_uncovered_funciton = {"Name": i_fun['name']}
+                        json_file['Uncovered_Functions'].append(json_uncovered_funciton)
+                comp_exists = [x for x in json_files if x['Path'] == json_file['Path']]
+                if not comp_exists:
+                    json_files.append(json_file)
+        json_component['files'] = json_files
+        return json_component
+
+    def generate_json_report(self, coverage):
+        output_json = {"components": []}
+
+        with open(coverage) as file:
             parser = ijson.items(file, 'files')
             for element in parser:
-
                 for i_json_component in self.json_object['components']:
-                    json_component = {}
-                    json_component["name"]=i_json_component["name"]
-                    json_component["sub_components"] = i_json_component["sub_components"]
-                    json_component["Comment"] = ""
-                    files_path = []
-                    files_path = self.get_files_from_maintainers_file(i_json_component["name"])
-                    json_files = []
-                    if len(files_path) != 0:
-                        for i_file in files_path:
-                            for i_covered_file in element:
-                                x = re.search(('.*'+i_file+'.*'), i_covered_file['file'])
-                                if x:
-                                    file_name =  i_covered_file['file'][i_covered_file['file'].rfind('/')+1:]
-                                    file_path = i_covered_file['file']
-                                    file_coverage, file_lines, file_hit = self._calculate_coverage_of_file(i_covered_file)
-                                    json_file = {
-                                            "Name":file_name,
-                                            "Path":file_path,
-                                            "Lines": file_lines,
-                                            "Hit":file_hit,
-                                            "Coverage": file_coverage,
-                                            "Covered_Functions": [],
-                                            "Uncovered_Functions": []
-                                        }
-                                    for i_fun in i_covered_file['functions']:
-                                        if i_fun['execution_count'] != 0:
-                                            json_covered_funciton ={
-                                                "Name":i_fun['name']
-                                            }
-                                            json_file['Covered_Functions'].append(json_covered_funciton)
-                                    for i_fun in i_covered_file['functions']:
-                                        if i_fun['execution_count'] == 0:
-                                            json_uncovered_funciton ={
-                                                "Name":i_fun['name']
-                                            }
-                                            json_file['Uncovered_Functions'].append(json_uncovered_funciton)
-                                    comp_exists = [x for x in json_files if x['Path'] == json_file['Path']]
-                                    if not comp_exists:
-                                        json_files.append(json_file)
-                        json_component['files']=json_files
-                        output_json['components'].append(json_component)
-                    else:
-                        json_component["files"] = []
-                        json_component["Comment"] = "Missed in maintainers.yml file."
-                        output_json['components'].append(json_component)
+                    json_component = self._generate_component_report(element, i_json_component)
+                    output_json['components'].append(json_component)
 
         return output_json
 
@@ -292,11 +291,11 @@ class Json_report:
         for line in file['lines']:
             if line['count'] != 0:
                 covered_lines += 1
-        return ((covered_lines/tracked_lines)*100), tracked_lines, covered_lines
+        return ((covered_lines / tracked_lines) * 100), tracked_lines, covered_lines
 
     def save_json_report(self, output_path, json_object):
         json_object = json.dumps(json_object, indent=4)
-        with open(output_path+'.json', "w") as outfile:
+        with open(output_path + '.json', "w") as outfile:
             outfile.write(json_object)
 
     def _find_char(self, path, str, n):
@@ -305,7 +304,7 @@ class Json_report:
             return -1
         return len(path) - len(sep[-1]) - len(str)
 
-    def _component_calculate_stats(self, json_component):
+    def _component_calculate_stats(self, json_component) -> ComponentStats:
         testsuites_count = 0
         runnable_count = 0
         build_only_count = 0
@@ -326,49 +325,56 @@ class Json_report:
                     sim_only_count += 1
                 else:
                     mixed_count += 1
-        return testsuites_count, runnable_count, build_only_count, sim_only_count, hw_only_count, mixed_count
+        return ComponentStats(
+            testsuites_count,
+            runnable_count,
+            build_only_count,
+            sim_only_count,
+            hw_only_count,
+            mixed_count,
+        )
 
     def _xlsx_generate_summary_page(self, workbook, json_report):
         # formats
         header_format = workbook.add_format(
             {
                 "bold": True,
-                "fg_color":  "#538DD5",
-                "font_color":"white"
+                "fg_color": "#538DD5",
+                "font_color": "white",
             }
         )
         cell_format = workbook.add_format(
             {
-                'valign': 'vcenter'
+                'valign': 'vcenter',
             }
         )
 
-        #generate summary page
+        # generate summary page
         worksheet = workbook.add_worksheet('Summary')
         row = 0
         col = 0
-        worksheet.write(row,col,"Components",header_format)
-        worksheet.write(row,col+1,"TestSuites",header_format)
-        worksheet.write(row,col+2,"Runnable",header_format)
-        worksheet.write(row,col+3,"Build only",header_format)
-        worksheet.write(row,col+4,"Simulators only",header_format)
-        worksheet.write(row,col+5,"Hardware only",header_format)
-        worksheet.write(row,col+6,"Mixed",header_format)
-        worksheet.write(row,col+7,"Coverage [%]",header_format)
-        worksheet.write(row,col+8,"Total Functions",header_format)
-        worksheet.write(row,col+9,"Uncovered Functions",header_format)
-        worksheet.write(row,col+10,"Comment",header_format)
+        worksheet.write(row, col, "Components", header_format)
+        worksheet.write(row, col + 1, "TestSuites", header_format)
+        worksheet.write(row, col + 2, "Runnable", header_format)
+        worksheet.write(row, col + 3, "Build only", header_format)
+        worksheet.write(row, col + 4, "Simulators only", header_format)
+        worksheet.write(row, col + 5, "Hardware only", header_format)
+        worksheet.write(row, col + 6, "Mixed", header_format)
+        worksheet.write(row, col + 7, "Coverage [%]", header_format)
+        worksheet.write(row, col + 8, "Total Functions", header_format)
+        worksheet.write(row, col + 9, "Uncovered Functions", header_format)
+        worksheet.write(row, col + 10, "Comment", header_format)
         row = 1
         col = 0
         for item in json_report['components']:
-            worksheet.write(row, col, item['name'],cell_format)
-            testsuites,runnable,build_only,sim_only,hw_only, mixed= self._component_calculate_stats(item)
-            worksheet.write(row,col+1,testsuites,cell_format)
-            worksheet.write(row,col+2,runnable,cell_format)
-            worksheet.write(row,col+3,build_only,cell_format)
-            worksheet.write(row,col+4,sim_only,cell_format)
-            worksheet.write(row,col+5,hw_only,cell_format)
-            worksheet.write(row,col+6,mixed,cell_format)
+            worksheet.write(row, col, item['name'], cell_format)
+            stats = self._component_calculate_stats(item)
+            worksheet.write(row, col + 1, stats.testsuites, cell_format)
+            worksheet.write(row, col + 2, stats.runnable, cell_format)
+            worksheet.write(row, col + 3, stats.build_only, cell_format)
+            worksheet.write(row, col + 4, stats.sim_only, cell_format)
+            worksheet.write(row, col + 5, stats.hw_only, cell_format)
+            worksheet.write(row, col + 6, stats.mixed, cell_format)
             lines = 0
             hit = 0
             coverage = 0.0
@@ -377,35 +383,40 @@ class Json_report:
             for i_file in item['files']:
                 lines += i_file['Lines']
                 hit += i_file['Hit']
-                total_funs += (len(i_file['Covered_Functions'])+len(i_file['Uncovered_Functions']))
+                total_funs += len(i_file['Covered_Functions']) + len(i_file['Uncovered_Functions'])
                 uncovered_funs += len(i_file['Uncovered_Functions'])
 
             if lines != 0:
-                coverage = (hit/lines)*100
+                coverage = (hit / lines) * 100
 
-            worksheet.write_number(row,col+7,coverage,workbook.add_format({'num_format':'#,##0.00'}))
-            worksheet.write_number(row,col+8,total_funs)
-            worksheet.write_number(row,col+9,uncovered_funs)
-            worksheet.write(row,col+10,item["Comment"],cell_format)
+            worksheet.write_number(
+                row, col + 7, coverage, workbook.add_format({'num_format': '#,##0.00'})
+            )
+            worksheet.write_number(row, col + 8, total_funs)
+            worksheet.write_number(row, col + 9, uncovered_funs)
+            worksheet.write(row, col + 10, item["Comment"], cell_format)
             row += 1
             col = 0
-        worksheet.conditional_format(1,col+7,row,col+7, {'type':     'data_bar',
-                                                            'min_value':  0,
-                                                            'max_value':  100,
-                                                            'bar_color': '#3fd927',
-                                                            'bar_solid': True,
-                                                                })
+        worksheet.conditional_format(
+            1,
+            col + 7,
+            row,
+            col + 7,
+            {
+                'type': 'data_bar',
+                'min_value': 0,
+                'max_value': 100,
+                'bar_color': '#3fd927',
+                'bar_solid': True,
+            },
+        )
         worksheet.autofit()
         worksheet.set_default_row(15)
 
     def generate_xlsx_report(self, json_report, output):
-        self.report_book = xlsxwriter.Workbook(output+".xlsx")
+        self.report_book = xlsxwriter.Workbook(output + ".xlsx")
         header_format = self.report_book.add_format(
-            {
-                "bold": True,
-                "fg_color":  "#538DD5",
-                "font_color":"white"
-            }
+            {"bold": True, "fg_color": "#538DD5", "font_color": "white"}
         )
 
         # Create a format to use in the merged range.
@@ -414,15 +425,11 @@ class Json_report:
                 "bold": 1,
                 "align": "center",
                 "valign": "vcenter",
-                "fg_color":  "#538DD5",
-                "font_color":"white"
+                "fg_color": "#538DD5",
+                "font_color": "white",
             }
         )
-        cell_format = self.report_book.add_format(
-            {
-                'valign': 'vcenter'
-            }
-        )
+        cell_format = self.report_book.add_format({'valign': 'vcenter'})
 
         self._xlsx_generate_summary_page(self.report_book, self.report_json)
         row = 0
@@ -431,57 +438,81 @@ class Json_report:
             worksheet = self.report_book.add_worksheet(item['name'])
             row = 0
             col = 0
-            worksheet.write(row,col,"File Name",header_format)
-            worksheet.write(row,col+1,"File Path",header_format)
-            worksheet.write(row,col+2,"Coverage [%]",header_format)
-            worksheet.write(row,col+3,"Lines",header_format)
-            worksheet.write(row,col+4,"Hits",header_format)
-            worksheet.write(row,col+5,"Diff",header_format)
+            worksheet.write(row, col, "File Name", header_format)
+            worksheet.write(row, col + 1, "File Path", header_format)
+            worksheet.write(row, col + 2, "Coverage [%]", header_format)
+            worksheet.write(row, col + 3, "Lines", header_format)
+            worksheet.write(row, col + 4, "Hits", header_format)
+            worksheet.write(row, col + 5, "Diff", header_format)
             row += 1
             col = 0
             for i_file in item['files']:
-                worksheet.write(row,col,i_file['Path'][i_file['Path'].rfind('/')+1:],cell_format)
-                worksheet.write(row,col+1,i_file["Path"][(self._find_char(i_file["Path"],'/',3)+1):],cell_format)
-                worksheet.write_number(row,col+2,i_file["Coverage"],self.report_book.add_format({'num_format':'#,##0.00'}))
-                worksheet.write(row,col+3,i_file["Lines"],cell_format)
-                worksheet.write(row,col+4,i_file["Hit"],cell_format)
-                worksheet.write(row,col+5,i_file["Lines"]-i_file["Hit"],cell_format)
+                worksheet.write(
+                    row, col, i_file['Path'][i_file['Path'].rfind('/') + 1 :], cell_format
+                )
+                worksheet.write(
+                    row,
+                    col + 1,
+                    i_file["Path"][(self._find_char(i_file["Path"], '/', 3) + 1) :],
+                    cell_format,
+                )
+                worksheet.write_number(
+                    row,
+                    col + 2,
+                    i_file["Coverage"],
+                    self.report_book.add_format({'num_format': '#,##0.00'}),
+                )
+                worksheet.write(row, col + 3, i_file["Lines"], cell_format)
+                worksheet.write(row, col + 4, i_file["Hit"], cell_format)
+                worksheet.write(row, col + 5, i_file["Lines"] - i_file["Hit"], cell_format)
                 row += 1
                 col = 0
             row += 1
             col = 0
-            worksheet.conditional_format(1,col+2,row,col+2, {'type':     'data_bar',
-                                                            'min_value':  0,
-                                                            'max_value':  100,
-                                                            'bar_color': '#3fd927',
-                                                            'bar_solid': True,
-                                                                })
-            worksheet.merge_range(row,col,row,col+2, "Uncovered Functions", merge_format)
+            worksheet.conditional_format(
+                1,
+                col + 2,
+                row,
+                col + 2,
+                {
+                    'type': 'data_bar',
+                    'min_value': 0,
+                    'max_value': 100,
+                    'bar_color': '#3fd927',
+                    'bar_solid': True,
+                },
+            )
+            worksheet.merge_range(row, col, row, col + 2, "Uncovered Functions", merge_format)
             row += 1
-            worksheet.write(row,col,'Function Name',header_format)
-            worksheet.write(row,col+1,'Implementation File',header_format)
-            worksheet.write(row,col+2,'Comment',header_format)
+            worksheet.write(row, col, 'Function Name', header_format)
+            worksheet.write(row, col + 1, 'Implementation File', header_format)
+            worksheet.write(row, col + 2, 'Comment', header_format)
             row += 1
             col = 0
             for i_file in item['files']:
                 for i_uncov_fun in i_file['Uncovered_Functions']:
-                    worksheet.write(row,col,i_uncov_fun["Name"],cell_format)
-                    worksheet.write(row,col+1,i_file["Path"][self._find_char(i_file["Path"],'/',3)+1:],cell_format)
+                    worksheet.write(row, col, i_uncov_fun["Name"], cell_format)
+                    worksheet.write(
+                        row,
+                        col + 1,
+                        i_file["Path"][self._find_char(i_file["Path"], '/', 3) + 1 :],
+                        cell_format,
+                    )
                     row += 1
                     col = 0
             row += 1
             col = 0
-            worksheet.write(row,col,"Components",header_format)
-            worksheet.write(row,col+1,"Sub-Components",header_format)
-            worksheet.write(row,col+2,"TestSuites",header_format)
-            worksheet.write(row,col+3,"Runnable",header_format)
-            worksheet.write(row,col+4,"Build only",header_format)
-            worksheet.write(row,col+5,"Simulation only",header_format)
-            worksheet.write(row,col+6,"Hardware only",header_format)
-            worksheet.write(row,col+7,"Mixed",header_format)
+            worksheet.write(row, col, "Components", header_format)
+            worksheet.write(row, col + 1, "Sub-Components", header_format)
+            worksheet.write(row, col + 2, "TestSuites", header_format)
+            worksheet.write(row, col + 3, "Runnable", header_format)
+            worksheet.write(row, col + 4, "Build only", header_format)
+            worksheet.write(row, col + 5, "Simulation only", header_format)
+            worksheet.write(row, col + 6, "Hardware only", header_format)
+            worksheet.write(row, col + 7, "Mixed", header_format)
             row += 1
             col = 0
-            worksheet.write(row,col,item['name'],cell_format)
+            worksheet.write(row, col, item['name'], cell_format)
             for i_sub_component in item['sub_components']:
                 testsuites_count = 0
                 runnable_count = 0
@@ -489,7 +520,7 @@ class Json_report:
                 sim_only_count = 0
                 hw_only_count = 0
                 mixed_count = 0
-                worksheet.write(row,col+1,i_sub_component['name'],cell_format)
+                worksheet.write(row, col + 1, i_sub_component['name'], cell_format)
                 for i_testsuit in i_sub_component['test_suites']:
                     testsuites_count += 1
                     if i_testsuit['runnable'] is True:
@@ -503,12 +534,12 @@ class Json_report:
                         sim_only_count += 1
                     else:
                         mixed_count += 1
-                worksheet.write(row,col+2,testsuites_count,cell_format)
-                worksheet.write(row,col+3,runnable_count,cell_format)
-                worksheet.write(row,col+4,build_only_count,cell_format)
-                worksheet.write(row,col+5,sim_only_count,cell_format)
-                worksheet.write(row,col+6,hw_only_count,cell_format)
-                worksheet.write(row,col+7,mixed_count,cell_format)
+                worksheet.write(row, col + 2, testsuites_count, cell_format)
+                worksheet.write(row, col + 3, runnable_count, cell_format)
+                worksheet.write(row, col + 4, build_only_count, cell_format)
+                worksheet.write(row, col + 5, sim_only_count, cell_format)
+                worksheet.write(row, col + 6, hw_only_count, cell_format)
+                worksheet.write(row, col + 7, mixed_count, cell_format)
                 row += 1
                 col = 0
 
@@ -516,16 +547,24 @@ class Json_report:
             worksheet.set_default_row(15)
         self.report_book.close()
 
+
 def parse_args():
     parser = argparse.ArgumentParser(allow_abbrev=False)
-    parser.add_argument('-m','--maintainers', help='Path to maintainers.yml [Required]', required=True)
-    parser.add_argument('-t','--testplan', help='Path to testplan [Required]', required=True)
-    parser.add_argument('-c','--coverage', help='Path to components file [Required]', required=True)
-    parser.add_argument('-o','--output', help='Report name [Required]', required=True)
-    parser.add_argument('-f','--format', help='Output format (json, xlsx, all) [Required]', required=True)
+    parser.add_argument(
+        '-m', '--maintainers', help='Path to maintainers.yml [Required]', required=True
+    )
+    parser.add_argument('-t', '--testplan', help='Path to testplan [Required]', required=True)
+    parser.add_argument(
+        '-c', '--coverage', help='Path to components file [Required]', required=True
+    )
+    parser.add_argument('-o', '--output', help='Report name [Required]', required=True)
+    parser.add_argument(
+        '-f', '--format', help='Output format (json, xlsx, all) [Required]', required=True
+    )
 
     args = parser.parse_args()
     return args
+
 
 if __name__ == '__main__':
     Json_report()

--- a/scripts/ci/errno.py
+++ b/scripts/ci/errno.py
@@ -11,14 +11,14 @@ contents against the SDK's newlib errno.h. This is done to ensure that both C
 libraries are aligned at all times.
 """
 
-
 import os
-from pathlib import Path
 import re
 import sys
+from pathlib import Path
+
 
 def parse_errno(path):
-    with open(path, 'r') as f:
+    with open(path) as f:
         r = re.compile(r'^\s*#define\s+([A-Z]+)\s+([0-9]+)')
         errnos = []
         for line in f:
@@ -28,8 +28,8 @@ def parse_errno(path):
 
     return errnos
 
-def main():
 
+def main():
     minimal = Path("lib/libc/minimal/include/errno.h")
     newlib = Path("arm-zephyr-eabi/arm-zephyr-eabi/include/sys/errno.h")
 
@@ -44,13 +44,16 @@ def main():
     newlib = parse_errno(newlib)
 
     for e in minimal:
-        if e[0] not in [x[0] for x in newlib] or e[1] != next(
-            filter(lambda _e: _e[0] == e[0], newlib))[1]:
+        if (
+            e[0] not in [x[0] for x in newlib]
+            or e[1] != next(filter(lambda _e: _e[0] == e[0], newlib))[1]
+        ):
             print('Invalid entry in errno.h:', file=sys.stderr)
             print(f'{e[0]} (with value {e[1]})', file=sys.stderr)
             sys.exit(1)
 
     print('errno.h validated correctly')
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -89,12 +89,14 @@ def parse_args():
 
     args = parser.parse_args()
 
+
 def load_areas(filename: str):
     with open(filename) as f:
         doc = yaml.safe_load(f)
     return {
         k: v for k, v in doc.items() if isinstance(v, dict) and ("files" in v or "files-regex" in v)
     }
+
 
 def process_manifest(old_manifest_file):
     log("Processing manifest changes")
@@ -124,8 +126,10 @@ def process_manifest(old_manifest_file):
     log(f'manifest areas: {areas}')
     return areas
 
+
 def set_or_empty(d, key):
     return set(d.get(key, []) or [])
+
 
 def compare_areas(old, new, repo_fullname=None, token=None):
     old_areas = set(old.keys())
@@ -212,6 +216,7 @@ def compare_areas(old, new, repo_fullname=None, token=None):
 
     return added_areas | removed_areas | changed_areas
 
+
 def process_pr(gh, maintainer_file, number):
     gh_repo = gh.get_repo(f"{args.org}/{args.repo}")
     pr = gh_repo.get_pull(number)
@@ -255,9 +260,7 @@ def process_pr(gh, maintainer_file, number):
         elif changed_file.filename in ['MAINTAINERS.yml']:
             areas = maintainer_file.path2areas(changed_file.filename)
             if args.updated_maintainer_file:
-                log(
-                    "cannot process MAINTAINERS.yml changes, skipping..."
-                )
+                log("cannot process MAINTAINERS.yml changes, skipping...")
 
                 old_areas = load_areas(args.updated_maintainer_file)
                 new_areas = load_areas('MAINTAINERS.yml')

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -4,16 +4,18 @@
 
 # A script to generate twister options based on modified files.
 
-import re, os
 import argparse
-import yaml
 import fnmatch
-import subprocess
+import glob
 import json
 import logging
+import os
+import re
+import subprocess
 import sys
-import glob
 from pathlib import Path
+
+import yaml
 from git import Repo
 from west.manifest import Manifest
 
@@ -35,9 +37,8 @@ logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
 logging.getLogger("pykwalify.core").setLevel(50)
 
 sys.path.append(os.path.join(zephyr_base, 'scripts'))
-import list_boards
-
-from pylib.twister.twisterlib.statuses import TwisterStatus
+import list_boards  # noqa: E402
+from pylib.twister.twisterlib.statuses import TwisterStatus  # noqa: E402
 
 
 def _get_match_fn(globs, regexes):
@@ -57,8 +58,7 @@ def _get_match_fn(globs, regexes):
         glob_regexes = []
         for glob in globs:
             # Construct a regex equivalent to the glob
-            glob_regex = glob.replace(".", "\\.").replace("*", "[^/]*") \
-                             .replace("?", "[^/]")
+            glob_regex = glob.replace(".", "\\.").replace("*", "[^/]*").replace("?", "[^/]")
 
             if not glob.endswith("/"):
                 # Require a full match for globs that don't end in /
@@ -77,6 +77,7 @@ def _get_match_fn(globs, regexes):
 
     return re.compile(regex).search
 
+
 class Tag:
     """
     Represents an entry for a tag in tags.yaml.
@@ -91,18 +92,33 @@ class Tag:
         Text from 'description' key, or None if the area has no 'description'
         key
     """
+
     def _contains(self, path):
         # Returns True if the area contains 'path', and False otherwise
 
-        return self._match_fn and self._match_fn(path) and not \
-            (self._exclude_match_fn and self._exclude_match_fn(path))
+        return (
+            self._match_fn
+            and self._match_fn(path)
+            and not (self._exclude_match_fn and self._exclude_match_fn(path))
+        )
 
     def __repr__(self):
-        return "<Tag {}>".format(self.name)
+        return f"<Tag {self.name}>"
+
 
 class Filters:
-    def __init__(self, modified_files, ignore_path, alt_tags, testsuite_root,
-                 pull_request=False, platforms=[], detailed_test_id=False, quarantine_list=None, tc_roots_th=20):
+    def __init__(
+        self,
+        modified_files,
+        ignore_path,
+        alt_tags,
+        testsuite_root,
+        pull_request=False,
+        platforms=None,
+        detailed_test_id=False,
+        quarantine_list=None,
+        tc_roots_th=20,
+    ):
         self.modified_files = modified_files
         self.testsuite_root = testsuite_root
         self.resolved_files = []
@@ -111,7 +127,7 @@ class Filters:
         self.all_tests = []
         self.tag_options = []
         self.pull_request = pull_request
-        self.platforms = platforms
+        self.platforms = platforms if platforms else []
         self.detailed_test_id = detailed_test_id
         self.ignore_path = ignore_path
         self.tag_cfg_file = alt_tags
@@ -125,7 +141,7 @@ class Filters:
         if not self.platforms:
             # disable for now, this is generating lots of churn when changing
             # architectures that is otherwise covered elsewhere.
-            #self.find_archs()
+            # self.find_archs()
             self.find_boards()
         else:
             for file in self.modified_files:
@@ -136,12 +152,12 @@ class Filters:
 
     def get_plan(self, options, integration=False, use_testsuite_root=True):
         fname = "_test_plan_partial.json"
-        cmd = [f"{zephyr_base}/scripts/twister", "-c"] + options + ["--save-tests", fname ]
+        cmd = [f"{zephyr_base}/scripts/twister", "-c"] + options + ["--save-tests", fname]
         if self.detailed_test_id:
             cmd += ["--detailed-test-id"]
         if self.testsuite_root and use_testsuite_root:
             for root in self.testsuite_root:
-                cmd+=["-T", root]
+                cmd += ["-T", root]
         if integration:
             cmd.append("--integration")
         if self.quarantine_list:
@@ -159,7 +175,7 @@ class Filters:
 
     def find_modules(self):
         if 'west.yml' in self.modified_files and args.commits is not None:
-            print(f"Manifest file 'west.yml' changed")
+            print("Manifest file 'west.yml' changed")
             print("=========")
             old_manifest_content = repo_to_scan.git.show(f"{args.commits[:-2]}:west.yml")
             with open("west_old.yml", "w") as manifest:
@@ -171,11 +187,13 @@ class Filters:
             logging.debug(f'old_projs: {old_projs}')
             logging.debug(f'new_projs: {new_projs}')
             # Removed projects
-            rprojs = set(filter(lambda p: p[0] not in list(p[0] for p in new_projs),
-                old_projs - new_projs))
+            rprojs = set(
+                filter(lambda p: p[0] not in list(p[0] for p in new_projs), old_projs - new_projs)
+            )
             # Updated projects
-            uprojs = set(filter(lambda p: p[0] in list(p[0] for p in old_projs),
-                new_projs - old_projs))
+            uprojs = set(
+                filter(lambda p: p[0] in list(p[0] for p in old_projs), new_projs - old_projs)
+            )
             # Added projects
             aprojs = new_projs - old_projs - uprojs
 
@@ -192,14 +210,13 @@ class Filters:
                 return
             _options = []
             for p in projs_names:
-                _options.extend(["-t", p ])
+                _options.extend(["-t", p])
 
             if self.platforms:
                 for platform in self.platforms:
                     _options.extend(["-p", platform])
 
             self.get_plan(_options, True)
-
 
     def find_archs(self):
         # we match both arch/<arch>/* and include/zephyr/arch/<arch> and skip common.
@@ -209,18 +226,17 @@ class Filters:
             p = re.match(r"^arch\/([^/]+)\/", f)
             if not p:
                 p = re.match(r"^include\/zephyr\/arch\/([^/]+)\/", f)
-            if p:
-                if p.group(1) != 'common':
-                    archs.add(p.group(1))
-                    # Modified file is treated as resolved, since a matching scope was found
-                    self.resolved_files.append(f)
+            if p and p.group(1) != 'common':
+                archs.add(p.group(1))
+                # Modified file is treated as resolved, since a matching scope was found
+                self.resolved_files.append(f)
 
         _options = []
         for arch in archs:
-            _options.extend(["-a", arch ])
+            _options.extend(["-a", arch])
 
         if _options:
-            logging.info(f'Potential architecture filters...')
+            logging.info('Potential architecture filters...')
             if self.platforms:
                 for platform in self.platforms:
                     _options.extend(["-p", platform])
@@ -246,8 +262,15 @@ class Filters:
             roots.append(repository_path)
 
         # Look for boards in monitored repositories
-        lb_args = argparse.Namespace(**{'arch_roots': roots, 'board_roots': roots, 'board': None, 'soc_roots':roots,
-                                        'board_dir': None})
+        lb_args = argparse.Namespace(
+            **{
+                'arch_roots': roots,
+                'board_roots': roots,
+                'board': None,
+                'soc_roots': roots,
+                'board_dir': None,
+            }
+        )
         known_boards = list_boards.find_v2_boards(lb_args).values()
 
         for changed in changed_boards:
@@ -255,29 +278,32 @@ class Filters:
                 c = (zephyr_base / changed).resolve()
                 if c.is_relative_to(board.dir.resolve()):
                     for file in glob.glob(os.path.join(board.dir, f"{board.name}*.yaml")):
-                        with open(file, 'r', encoding='utf-8') as f:
+                        with open(file, encoding='utf-8') as f:
                             b = yaml.load(f.read(), Loader=SafeLoader)
                             matched_boards[b['identifier']] = board
 
-
         logging.info(f"found boards: {','.join(matched_boards.keys())}")
-        # If modified file is caught by "find_boards" workflow (change in "boards" dir AND board recognized)
-        # it means a proper testing scope for this file was found and this file can be removed
-        # from further consideration
+        # If modified file is caught by "find_boards" workflow (change in "boards" dir AND board
+        # recognized) it means a proper testing scope for this file was found and this file can
+        # be removed from further consideration
         for _, board in matched_boards.items():
-            self.resolved_files.extend(list(filter(lambda f: str(board.dir.relative_to(zephyr_base)) in f, resolved_files)))
+            relative_board_dir = str(board.dir.relative_to(zephyr_base))
+            resolved_filter = lambda f, rel_dir=relative_board_dir: rel_dir in f, resolved_files
+            self.resolved_files.extend(list(filter(resolved_filter)))
 
         _options = []
         if len(matched_boards) > 20:
-            logging.warning(f"{len(matched_boards)} boards changed, this looks like a global change, skipping test handling, revert to default.")
+            msg = f"{len(matched_boards)} boards changed, this looks like a global change, "
+            msg += "skipping test handling, revert to default."
+            logging.warning(msg)
             self.full_twister = True
             return
 
         for board in matched_boards:
-            _options.extend(["-p", board ])
+            _options.extend(["-p", board])
 
         if _options:
-            logging.info(f'Potential board filters...')
+            logging.info('Potential board filters...')
             self.get_plan(_options)
 
     def find_tests(self):
@@ -289,17 +315,19 @@ class Filters:
             scope_found = False
             while not scope_found and d:
                 head, tail = os.path.split(d)
-                if os.path.exists(os.path.join(d, "testcase.yaml")) or \
-                    os.path.exists(os.path.join(d, "sample.yaml")):
+                if os.path.exists(os.path.join(d, "testcase.yaml")) or os.path.exists(
+                    os.path.join(d, "sample.yaml")
+                ):
                     tests.add(d)
                     # Modified file is treated as resolved, since a matching scope was found
                     self.resolved_files.append(f)
                     scope_found = True
                 elif tail == "common":
                     # Look for yamls in directories collocated with common
+                    testcase_yamls = glob.iglob(head + '/**/testcase.yaml', recursive=True)
+                    sample_yamls = glob.iglob(head + '/**/sample.yaml', recursive=True)
 
-                    yamls_found = [yaml for yaml in glob.iglob(head + '/**/testcase.yaml', recursive=True)]
-                    yamls_found.extend([yaml for yaml in glob.iglob(head + '/**/sample.yaml', recursive=True)])
+                    yamls_found = [*testcase_yamls, *sample_yamls]
                     if yamls_found:
                         for yaml in yamls_found:
                             tests.add(os.path.dirname(yaml))
@@ -312,10 +340,12 @@ class Filters:
 
         _options = []
         for t in tests:
-            _options.extend(["-T", t ])
+            _options.extend(["-T", t])
 
         if len(tests) > self.tc_roots_th:
-            logging.warning(f"{len(tests)} tests changed, this looks like a global change, skipping test handling, revert to default")
+            msg = f"{len(tests)} tests changed, this looks like a global change, "
+            msg += "skipping test handling, revert to default"
+            logging.warning(msg)
             self.full_twister = True
             return
 
@@ -327,12 +357,11 @@ class Filters:
             self.get_plan(_options, use_testsuite_root=False)
 
     def find_tags(self):
-
-        with open(self.tag_cfg_file, 'r') as ymlfile:
+        with open(self.tag_cfg_file) as ymlfile:
             tags_config = yaml.safe_load(ymlfile)
 
         tags = {}
-        for t,x in tags_config.items():
+        for t, x in tags_config.items():
             tag = Tag()
             tag.exclude = True
             tag.name = t
@@ -343,8 +372,9 @@ class Filters:
 
             # Like tag._match_fn(path), but for files-exclude and
             # files-regex-exclude
-            tag._exclude_match_fn = \
-                _get_match_fn(x.get("files-exclude"), x.get("files-regex-exclude"))
+            tag._exclude_match_fn = _get_match_fn(
+                x.get("files-exclude"), x.get("files-regex-exclude")
+            )
 
             tags[tag.name] = tag
 
@@ -359,18 +389,19 @@ class Filters:
                 exclude_tags.add(t.name)
 
         for tag in exclude_tags:
-            self.tag_options.extend(["-e", tag ])
+            self.tag_options.extend(["-e", tag])
 
         if exclude_tags:
             logging.info(f'Potential tag based filters: {exclude_tags}')
 
-    def find_excludes(self, skip=[]):
-        with open(self.ignore_path, "r") as twister_ignore:
+    def find_excludes(self):
+        with open(self.ignore_path) as twister_ignore:
             ignores = twister_ignore.read().splitlines()
             ignores = filter(lambda x: not x.startswith("#"), ignores)
 
         found = set()
-        files_not_resolved = list(filter(lambda x: x not in self.resolved_files, self.modified_files))
+        not_resolved = lambda x: x not in self.resolved_files  # noqa: E731
+        files_not_resolved = list(filter(not_resolved, self.modified_files))
 
         for pattern in ignores:
             if pattern:
@@ -385,7 +416,7 @@ class Filters:
 
         if self.full_twister:
             _options = []
-            logging.info(f'Need to run full or partial twister...')
+            logging.info('Need to run full or partial twister...')
             if self.platforms:
                 for platform in self.platforms:
                     _options.extend(["-p", platform])
@@ -396,53 +427,88 @@ class Filters:
                 _options.extend(self.tag_options)
                 self.get_plan(_options, True)
         else:
-            logging.info(f'No twister needed or partial twister run only...')
+            logging.info('No twister needed or partial twister run only...')
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
-                description="Generate twister argument files based on modified file",
-                allow_abbrev=False)
-    parser.add_argument('-c', '--commits', default=None,
-            help="Commit range in the form: a..b")
-    parser.add_argument('-m', '--modified-files', default=None,
-            help="File with information about changed/deleted/added files.")
-    parser.add_argument('-o', '--output-file', default="testplan.json",
-            help="JSON file with the test plan to be passed to twister")
-    parser.add_argument('-P', '--pull-request', action="store_true",
-            help="This is a pull request")
-    parser.add_argument('-p', '--platform', action="append",
-            help="Limit this for a platform or a list of platforms.")
-    parser.add_argument('-t', '--tests_per_builder', default=700, type=int,
-            help="Number of tests per builder")
-    parser.add_argument('-n', '--default-matrix', default=10, type=int,
-            help="Number of tests per builder")
-    parser.add_argument('--testcase-roots-threshold', default=20, type=int,
-            help="Threshold value for number of modified testcase roots, up to which an optimized scope is still applied."
-                 "When exceeded, full scope will be triggered")
-    parser.add_argument('--detailed-test-id', action='store_true',
-            help="Include paths to tests' locations in tests' names.")
-    parser.add_argument("--no-detailed-test-id", dest='detailed_test_id', action="store_false",
-            help="Don't put paths into tests' names.")
-    parser.add_argument('-r', '--repo-to-scan', default=None,
-            help="Repo to scan")
-    parser.add_argument('--ignore-path',
-            default=os.path.join(zephyr_base, 'scripts', 'ci', 'twister_ignore.txt'),
-            help="Path to a text file with patterns of files to be matched against changed files")
-    parser.add_argument('--alt-tags',
-            default=os.path.join(zephyr_base, 'scripts', 'ci', 'tags.yaml'),
-            help="Path to a file describing relations between directories and tags")
+        description="Generate twister argument files based on modified file", allow_abbrev=False
+    )
+    parser.add_argument('-c', '--commits', default=None, help="Commit range in the form: a..b")
     parser.add_argument(
-            "-T", "--testsuite-root", action="append", default=[],
-            help="Base directory to recursively search for test cases. All "
-                "testcase.yaml files under here will be processed. May be "
-                "called multiple times. Defaults to the 'samples/' and "
-                "'tests/' directories at the base of the Zephyr tree.")
+        '-m',
+        '--modified-files',
+        default=None,
+        help="File with information about changed/deleted/added files.",
+    )
     parser.add_argument(
-            "--quarantine-list", action="append", metavar="FILENAME",
-            help="Load list of test scenarios under quarantine. The entries in "
-                "the file need to correspond to the test scenarios names as in "
-                "corresponding tests .yaml files. These scenarios "
-                "will be skipped with quarantine as the reason.")
+        '-o',
+        '--output-file',
+        default="testplan.json",
+        help="JSON file with the test plan to be passed to twister",
+    )
+    parser.add_argument('-P', '--pull-request', action="store_true", help="This is a pull request")
+    parser.add_argument(
+        '-p',
+        '--platform',
+        action="append",
+        help="Limit this for a platform or a list of platforms.",
+    )
+    parser.add_argument(
+        '-t', '--tests_per_builder', default=700, type=int, help="Number of tests per builder"
+    )
+    parser.add_argument(
+        '-n', '--default-matrix', default=10, type=int, help="Number of tests per builder"
+    )
+    parser.add_argument(
+        '--testcase-roots-threshold',
+        default=20,
+        type=int,
+        help="Threshold value for number of modified testcase roots, "
+        "up to which an optimized scope is still applied. "
+        "When exceeded, full scope will be triggered",
+    )
+    parser.add_argument(
+        '--detailed-test-id',
+        action='store_true',
+        help="Include paths to tests' locations in tests' names.",
+    )
+    parser.add_argument(
+        "--no-detailed-test-id",
+        dest='detailed_test_id',
+        action="store_false",
+        help="Don't put paths into tests' names.",
+    )
+    parser.add_argument('-r', '--repo-to-scan', default=None, help="Repo to scan")
+    parser.add_argument(
+        '--ignore-path',
+        default=os.path.join(zephyr_base, 'scripts', 'ci', 'twister_ignore.txt'),
+        help="Path to a text file with patterns of files to be matched against changed files",
+    )
+    parser.add_argument(
+        '--alt-tags',
+        default=os.path.join(zephyr_base, 'scripts', 'ci', 'tags.yaml'),
+        help="Path to a file describing relations between directories and tags",
+    )
+    parser.add_argument(
+        "-T",
+        "--testsuite-root",
+        action="append",
+        default=[],
+        help="Base directory to recursively search for test cases. All "
+        "testcase.yaml files under here will be processed. May be "
+        "called multiple times. Defaults to the 'samples/' and "
+        "'tests/' directories at the base of the Zephyr tree.",
+    )
+    parser.add_argument(
+        "--quarantine-list",
+        action="append",
+        metavar="FILENAME",
+        help="Load list of test scenarios under quarantine. The entries in "
+        "the file need to correspond to the test scenarios names as in "
+        "corresponding tests .yaml files. These scenarios "
+        "will be skipped with quarantine as the reason.",
+    )
 
     # Do not include paths in names by default.
     parser.set_defaults(detailed_test_id=False)
@@ -451,7 +517,6 @@ def parse_args():
 
 
 if __name__ == "__main__":
-
     args = parse_args()
     files = []
     errors = 0
@@ -462,7 +527,7 @@ if __name__ == "__main__":
         commit = repo_to_scan.git.diff("--name-only", args.commits)
         files = commit.split("\n")
     elif args.modified_files:
-        with open(args.modified_files, "r") as fp:
+        with open(args.modified_files) as fp:
             files = json.load(fp)
 
     if files:
@@ -470,9 +535,17 @@ if __name__ == "__main__":
         print("\n".join(files))
         print("=========")
 
-    f = Filters(files, args.ignore_path, args.alt_tags, args.testsuite_root,
-                args.pull_request, args.platform, args.detailed_test_id, args.quarantine_list,
-                args.testcase_roots_threshold)
+    f = Filters(
+        files,
+        args.ignore_path,
+        args.alt_tags,
+        args.testsuite_root,
+        args.pull_request,
+        args.platform,
+        args.detailed_test_id,
+        args.quarantine_list,
+        args.testcase_roots_threshold,
+    )
     f.process()
 
     # remove dupes and filtered cases
@@ -491,7 +564,14 @@ if __name__ == "__main__":
             errors += 1
         if (n, a, p, t) not in dup_free_set:
             dup_free.append(ts)
-            dup_free_set.add((n, a, p, t,))
+            dup_free_set.add(
+                (
+                    n,
+                    a,
+                    p,
+                    t,
+                )
+            )
 
     logging.info(f'Total tests to be run: {len(dup_free)}')
     with open(".testplan", "w") as tp:
@@ -506,14 +586,23 @@ if __name__ == "__main__":
         tp.write(f"TWISTER_FULL={f.full_twister}\n")
         logging.info(f'Total nodes to launch: {nodes}')
 
-    header = ['test', 'arch', 'platform', 'status', 'extra_args', 'handler',
-            'handler_time', 'used_ram', 'used_rom']
+    header = [
+        'test',
+        'arch',
+        'platform',
+        'status',
+        'extra_args',
+        'handler',
+        'handler_time',
+        'used_ram',
+        'used_rom',
+    ]
 
     # write plan
     if dup_free:
         data = {}
         data['testsuites'] = dup_free
         with open(args.output_file, 'w', newline='') as json_file:
-            json.dump(data, json_file, indent=4, separators=(',',':'))
+            json.dump(data, json_file, indent=4, separators=(',', ':'))
 
     sys.exit(errors)

--- a/scripts/ci/twister_report_analyzer.py
+++ b/scripts/ci/twister_report_analyzer.py
@@ -36,7 +36,7 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         '--error-patterns',
         type=str,
-        help='text file with custom error patterns, ' 'each entry must be separated by newlines',
+        help='text file with custom error patterns, each entry must be separated by newlines',
     )
     parser.add_argument(
         '--output',

--- a/scripts/ci/version_mgr.py
+++ b/scripts/ci/version_mgr.py
@@ -12,56 +12,54 @@ Syntax of file:
         },
     ]
 """
-import json
+
 import argparse
-import urllib.request
+import json
 import os
 import tempfile
+import urllib.request
+from datetime import datetime
 
 from git import Git
-from datetime import datetime
 
 VERSIONS_FILE = "versions.json"
 
 
 def parse_args():
     parser = argparse.ArgumentParser(
-                description="Manage versions to be tested.", allow_abbrev=False)
-    parser.add_argument('-l', '--list', action="store_true",
-                        help="List all published versions")
-    parser.add_argument('-u', '--update',
-                        help="Update versions file from tree.")
-    parser.add_argument('-L', '--latest', action="store_true",
-                        help="Get latest published version")
-    parser.add_argument('-w', '--weekly', action="store_true",
-                        help="Mark as weekly")
-    parser.add_argument('-W', '--list-weekly', action="store_true",
-                        help="List weekly commits")
-    parser.add_argument('-v', '--verbose', action="store_true",
-                        help="Verbose output")
+        description="Manage versions to be tested.", allow_abbrev=False
+    )
+    parser.add_argument('-l', '--list', action="store_true", help="List all published versions")
+    parser.add_argument('-u', '--update', help="Update versions file from tree.")
+    parser.add_argument('-L', '--latest', action="store_true", help="Get latest published version")
+    parser.add_argument('-w', '--weekly', action="store_true", help="Mark as weekly")
+    parser.add_argument('-W', '--list-weekly', action="store_true", help="List weekly commits")
+    parser.add_argument('-v', '--verbose', action="store_true", help="Verbose output")
     return parser.parse_args()
 
 
 def get_versions():
     data = None
-    fo = tempfile.NamedTemporaryFile()
-    if not os.path.exists('versions.json'):
-        url = 'https://testing.zephyrproject.org/daily_tests/versions.json'
-        urllib.request.urlretrieve(url, fo.name)
-    with open(fo.name, "r") as fp:
-        data = json.load(fp)
+    with tempfile.NamedTemporaryFile() as fo:
+        if not os.path.exists('versions.json'):
+            url = 'https://testing.zephyrproject.org/daily_tests/versions.json'
+            urllib.request.urlretrieve(url, fo.name)
+        with open(fo.name) as fp:
+            data = json.load(fp)
     return data
+
 
 def handle_compat(item):
     item_compat = {}
     if isinstance(item, str):
-        item_compat['version'] =  item
+        item_compat['version'] = item
         item_compat['weekly'] = False
         item_compat['date'] = None
     else:
         item_compat = item
 
     return item_compat
+
 
 def show_versions(weekly=False):
     data = get_versions()
@@ -82,7 +80,6 @@ def show_versions(weekly=False):
             print(f"- {item_compat['version']} {datestr} {wstr}")
         else:
             print(f"{item_compat['version']}")
-
 
 
 def show_latest():
@@ -117,8 +114,13 @@ def update(git_tree, is_weekly=False):
         if wday == 'Monday':
             is_weekly = True
 
-    found = list(filter(lambda item: (isinstance(item, dict) and
-                        item.get('version') == version) or item == version, data))
+    found = list(
+        filter(
+            lambda item: (isinstance(item, dict) and item.get('version') == version)
+            or item == version,
+            data,
+        )
+    )
     if found:
         published = True
         print("version already published")
@@ -134,6 +136,7 @@ def update(git_tree, is_weekly=False):
             data.append(item)
             json.dump(data, versions)
 
+
 def main():
     global args
 
@@ -146,6 +149,7 @@ def main():
         show_latest()
     else:
         print("You did not specify any options")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fix the existing `ruff` errors on `scripts/ci` scripts and enable checking in CI.

Errors mostly consisted of:
 * Things automatically fixed by `ruff check scripts/ci --fix`
 * Long line lengths