### PR TITLE
spi: cdns: Fix RX detection and enable large slave transfers

### DIFF
--- a/drivers/spi/spi_cdns.c
+++ b/drivers/spi/spi_cdns.c
@@ -66,7 +66,7 @@ LOG_MODULE_REGISTER(spi_cadence, CONFIG_SPI_LOG_LEVEL);
 #define SPI_INT_MF  BIT(1)
 #define SPI_INT_ROF BIT(0)
 
-#define SPI_INT_DEFAULT (SPI_INT_RNE | SPI_INT_TNF | SPI_INT_ROF | SPI_INT_TUF)
+#define SPI_INT_DEFAULT (SPI_INT_TNF | SPI_INT_ROF | SPI_INT_TUF)
 
 /* SPI enable register bit offset */
 #define SPI_SPI_ENABLE_SPIE BIT(0)
@@ -319,11 +319,11 @@ static void spi_cdns_recv(const struct device *dev)
 				}
 				break;
 			}
+			spi_context_update_rx(ctx, dfs, 1);
 		}
 		if (data->fifo_diff > 0) {
 			data->fifo_diff--;
 		}
-		spi_context_update_rx(ctx, dfs, 1);
 	}
 }
 
@@ -370,32 +370,10 @@ static void spi_cdns_push_data(const struct device *dev)
  */
 static void spi_cdns_pull_data(const struct device *dev)
 {
-	const struct spi_cdns_cfg *config = dev->config;
 	struct spi_cdns_data *data = dev->data;
-	uint32_t rx_threshold_tmp;
-	uint32_t rx_remain_entry;
 
-	/*
-	 * As there is no rx fifo empty status bit, Write the rx threshold
-	 * to so the rne status bit will report when there is less than 1
-	 * item in the fifo
-	 */
-	rx_threshold_tmp = sys_read32(SPI_REG(dev, SPI_RX_THRESHOLD));
-	sys_write32(1, SPI_REG(dev, SPI_RX_THRESHOLD));
-
-	while (sys_read32(SPI_REG(dev, SPI_INT_STATUS)) & SPI_INT_RNE) {
+	while (data->fifo_diff > 0) {
 		spi_cdns_recv(dev);
-	}
-
-	/*
-	 * The threshold is designed to trigger by FIFO I/O.
-	 * Therefore, it is necessary to set rx threshold before pulling.
-	 */
-	rx_remain_entry = DIV_ROUND_UP(data->fifo_diff, (config->fifo_width / 8));
-	if ((rx_remain_entry != 0) && (rx_remain_entry < rx_threshold_tmp)) {
-		sys_write32(rx_remain_entry, SPI_REG(dev, SPI_RX_THRESHOLD));
-	} else {
-		sys_write32(rx_threshold_tmp, SPI_REG(dev, SPI_RX_THRESHOLD));
 	}
 }
 
@@ -544,21 +522,24 @@ static void spi_cdns_isr(const struct device *dev)
 		goto complete;
 	}
 
-	if (int_status & SPI_INT_RNE) {
+	if (int_status & SPI_INT_TNF) {
+		if (spi_context_is_slave(&data->ctx)) {
+			/* Fixed delay due to controller limitation with
+			 * RX_NEMPTY incorrect status
+			 * Xilinx AR:65885 contains more details
+			 */
+			k_busy_wait(10);
+		}
 		spi_cdns_pull_data(dev);
 	}
 
-	if (int_status & SPI_INT_TNF) {
+	if (!spi_context_tx_buf_on(&data->ctx) && !spi_context_rx_buf_on(&data->ctx)) {
+		/* Both TX and RX are done - transfer complete */
+		goto complete;
+	} else {
+		/* Still have data to process - continue transfer */
 		spi_cdns_push_data(dev);
-	}
-
-	if (!spi_context_tx_buf_on(&data->ctx)) {
-		/* Disable Tx-FIFO interrupt for no transfer data */
-		sys_write32(SPI_INT_TNF, SPI_REG(dev, SPI_INT_DISABLE));
-	}
-
-	if (spi_context_tx_buf_on(&data->ctx) || spi_context_rx_buf_on(&data->ctx)) {
-		return;
+		sys_write32(SPI_INT_TNF, SPI_REG(dev, SPI_INT_ENABLE));
 	}
 
 	if (data->fifo_diff != 0) {
@@ -636,7 +617,6 @@ static int spi_cdns_transceive(const struct device *dev, const struct spi_config
 			       const struct spi_buf_set *tx_bufs, const struct spi_buf_set *rx_bufs,
 			       bool asynchronous, spi_callback_t cb, void *userdata)
 {
-	const struct spi_cdns_cfg *dev_config = dev->config;
 	struct spi_cdns_data *data = dev->data;
 	uint32_t dfs;
 	int ret;
@@ -683,24 +663,13 @@ static int spi_cdns_transceive(const struct device *dev, const struct spi_config
 		goto out;
 	}
 
-	/* Set fifo thresholds */
-	if (spi_context_is_slave(&data->ctx)) {
-		sys_write32(1, SPI_REG(dev, SPI_RX_THRESHOLD));
-		sys_write32(dev_config->tx_fifo_depth - 1, SPI_REG(dev, SPI_TX_THRESHOLD));
-	} else {
-		uint32_t fifo_words = MIN(DIV_ROUND_UP(spi_context_total_rx_len(&data->ctx),
-						       (dev_config->fifo_width / 8)),
-					  dev_config->rx_fifo_depth * 5 / 8);
-		sys_write32(fifo_words, SPI_REG(dev, SPI_RX_THRESHOLD));
-		sys_write32(dev_config->tx_fifo_depth / 2, SPI_REG(dev, SPI_TX_THRESHOLD));
-	}
-
 	if (spi_cs_is_gpio(data->ctx.config)) {
 		spi_context_cs_control(&data->ctx, true);
 	} else {
 		spi_cdns_cs_control(dev, true);
 	}
 
+	spi_cdns_push_data(dev);
 	sys_write32(SPI_INT_DEFAULT, SPI_REG(dev, SPI_INT_ENABLE));
 
 	ret = spi_context_wait_for_completion(&data->ctx);


### PR DESCRIPTION
This patch series adds support for reliable RX FIFO handling and
enables slave mode transfers larger than FIFO depth.