### PR TITLE
drivers: adc: cc13x2_cc26x2: Fix PM

### DIFF
--- a/drivers/adc/adc_cc13xx_cc26xx.c
+++ b/drivers/adc/adc_cc13xx_cc26xx.c
@@ -27,6 +27,11 @@ LOG_MODULE_REGISTER(adc_cc13xx_cc26xx);
 #include <driverlib/aux_adc.h>
 #include <ti/devices/cc13x2_cc26x2/inc/hw_aux_evctl.h>
 
+#ifdef CONFIG_PM
+#include <ti/drivers/Power.h>
+#include <ti/drivers/power/PowerCC26XX.h>
+#endif
+
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
 
@@ -66,6 +71,9 @@ struct adc_cc13xx_cc26xx_data {
 	uint8_t sample_time;
 	uint16_t *buffer;
 	uint16_t *repeat_buffer;
+#ifdef CONFIG_PM
+	bool standby_disabled;
+#endif
 };
 
 struct adc_cc13xx_cc26xx_cfg {
@@ -84,8 +92,25 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 
 	data->repeat_buffer = data->buffer;
 
+#ifdef CONFIG_PM
+	if (!data->standby_disabled) {
+		Power_setConstraint(PowerCC26XX_DISALLOW_STANDBY);
+		data->standby_disabled = true;
+	}
+#endif
 	AUXADCEnableSync(data->ref_source, data->sample_time, AUXADC_TRIGGER_MANUAL);
 	AUXADCGenManualTrigger();
+}
+
+static void adc_stop_sampling(struct adc_cc13xx_cc26xx_data *data)
+{
+	AUXADCDisable();
+#ifdef CONFIG_PM
+	if (data->standby_disabled) {
+		Power_releaseConstraint(PowerCC26XX_DISALLOW_STANDBY);
+		data->standby_disabled = false;
+	}
+#endif
 }
 
 static void adc_context_update_buffer_pointer(struct adc_context *ctx,
@@ -109,7 +134,7 @@ static int adc_cc13xx_cc26xx_init(const struct device *dev)
 	data->dev = dev;
 
 	/* clear any previous events */
-	AUXADCDisable();
+	adc_stop_sampling(data);
 	HWREG(AUX_EVCTL_BASE + AUX_EVCTL_O_EVTOMCUFLAGSCLR) =
 		(AUX_EVCTL_EVTOMCUFLAGS_AUX_ADC_IRQ | AUX_EVCTL_EVTOMCUFLAGS_AUX_ADC_DONE);
 
@@ -183,7 +208,7 @@ static int adc_cc13xx_cc26xx_channel_setup(const struct device *dev,
 
 	LOG_DBG("Setup %d acq time %d", ch, data->sample_time);
 
-	AUXADCDisable();
+	adc_stop_sampling(data);
 	AUXADCSelectInput(ch);
 	return 0;
 }
@@ -269,7 +294,7 @@ static void adc_cc13xx_cc26xx_isr(const struct device *dev)
 	adc_value = AUXADCPopFifo();
 	LOG_DBG("ADC buf %04X val %d", (unsigned int)data->buffer, adc_value);
 	*data->buffer = adc_value;
-	AUXADCDisable();
+	adc_stop_sampling(data);
 
 	adc_context_on_sampling_done(&data->ctx, dev);
 }


### PR DESCRIPTION
- Currently, ADC driver does not implement any PM related constraints. Due to this, when using it with PM enabled (example ieee802154, which enabled PM by default), it will stall the system.
- Similar to pwm driver, disable standby when ADC is sampling. The variable standby_disabled is just a flag to ensure that we disable (or enable) standby only when ADC driver selects it. Otherwise, it is possible to have a condition where ADC enabled PM and ieee802154 disables it.
- This follows what TI SDK ADC driver does [0].

[0]: https://github.com/TexasInstruments/simplelink-lowpower-f2-sdk/blob/507c93efc8713238cf38dd0764964668629dbc07/source/ti/drivers/adc/ADCCC26XX.c#L186