### PR TITLE
soc: litex: deprecate 8 bit CSR data width

### DIFF
--- a/soc/litex/litex_vexriscv/Kconfig
+++ b/soc/litex/litex_vexriscv/Kconfig
@@ -19,6 +19,14 @@ config LITEX_CSR_DATA_WIDTH
 	int "Select Control/Status register width"
 	default 32
 
+config LITEX_CSR_DATA_WIDTH_DEPRECATED
+	def_bool y
+	depends on LITEX_CSR_DATA_WIDTH != 32
+	select DEPRECATED
+	help
+	  This option is there to select DEPRECATED, when LITEX_CSR_DATA_WIDTH is
+	  set to a value other than 32. It will be removed in future releases.
+
 choice LITEX_CSR_ORDERING
 	prompt "Select Control/Status register ordering"
 	default LITEX_CSR_ORDERING_BIG


### PR DESCRIPTION
5 years ago LiteX switched to 32 bit csr data width,
while the option is still available in litex, it doesn't really
work there, even if it can be build, the bios f.e. won't boot.
already described in https://github.com/enjoy-digital/litex/issues/1062

So it is currently only here for designs, that are older than
5 years and for fpgas, where also the fpga bitstream can be updated
it is time to remove the support and require the users, when they wan't
to update zephyr, that they also have to update their fpga bitstream.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>