### PR TITLE
MAINTAINERS: add Arduino Platforms collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -361,6 +361,8 @@ Arduino Platforms:
     - pillo79
   collaborators:
     - facchinm
+    - iabdalkader
+    - pennam
   files:
     - boards/arduino/
     - boards/shields/arduino_*/


### PR DESCRIPTION
Add Ibrahim Abdelkader (@iabdalkader) and Mattia Pennasilico (@pennam) as collaborators for the Arduino Platforms area, as they have extensive experience on our boards and can provide insightful reviews.