### PR TITLE
drivers: audio: wm8904: fix sample rate

### DIFF
--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -79,8 +79,6 @@ static int wm8904_audio_fmt_config(const struct device *dev, audio_dai_cfg_t *cf
 		wm_sample_rate = kWM8904_SampleRate8kHz;
 		break;
 	case 11025:
-		wm_sample_rate = kWM8904_SampleRate11025Hz;
-		break;
 	case 12000:
 		wm_sample_rate = kWM8904_SampleRate12kHz;
 		break;
@@ -88,8 +86,6 @@ static int wm8904_audio_fmt_config(const struct device *dev, audio_dai_cfg_t *cf
 		wm_sample_rate = kWM8904_SampleRate16kHz;
 		break;
 	case 22050:
-		wm_sample_rate = kWM8904_SampleRate22050Hz;
-		break;
 	case 24000:
 		wm_sample_rate = kWM8904_SampleRate24kHz;
 		break;
@@ -97,8 +93,6 @@ static int wm8904_audio_fmt_config(const struct device *dev, audio_dai_cfg_t *cf
 		wm_sample_rate = kWM8904_SampleRate32kHz;
 		break;
 	case 44100:
-		wm_sample_rate = kWM8904_SampleRate44100Hz;
-		break;
 	case 48000:
 		wm_sample_rate = kWM8904_SampleRate48kHz;
 		break;

--- a/drivers/audio/wm8904.h
+++ b/drivers/audio/wm8904.h
@@ -141,14 +141,11 @@ typedef enum _wm8904_fs_ratio {
 /*! @brief Sample rate. */
 typedef enum _wm8904_sample_rate {
 	kWM8904_SampleRate8kHz    = 0x0, /*!< 8 kHz */
-	kWM8904_SampleRate12kHz   = 0x1, /*!< 12kHz */
+	kWM8904_SampleRate12kHz   = 0x1, /*!< 11.025kHz, 12kHz */
 	kWM8904_SampleRate16kHz   = 0x2, /*!< 16kHz */
-	kWM8904_SampleRate24kHz   = 0x3, /*!< 24kHz */
+	kWM8904_SampleRate24kHz   = 0x3, /*!< 22.05kHz, 24kHz */
 	kWM8904_SampleRate32kHz   = 0x4, /*!< 32kHz */
-	kWM8904_SampleRate48kHz   = 0x5, /*!< 48kHz */
-	kWM8904_SampleRate11025Hz = 0x6, /*!< 11.025kHz */
-	kWM8904_SampleRate22050Hz = 0x7, /*!< 22.05kHz */
-	kWM8904_SampleRate44100Hz = 0x8  /*!< 44.1kHz */
+	kWM8904_SampleRate48kHz   = 0x5, /*!< 44.1kHz, 48kHz */
 } wm8904_sample_rate_t;
 
 #endif /* ZEPHYR_INCLUDE_CODEC_WM8904_H_ */


### PR DESCRIPTION
This change aligns sample rates to the datasheet and removes non existing values for 11.025kHz, 22.05kHz, & 44.1kHz

<img width="531" height="159" alt="wm8904_fs" src="https://github.com/user-attachments/assets/8a317ff8-8abc-4b32-a3b5-f49f197d761b" />
