### PR TITLE
drivers: sensor: Fix RTIO fallback scaling from sensor_value to q31

### DIFF
--- a/drivers/sensor/default_rtio_sensor.c
+++ b/drivers/sensor/default_rtio_sensor.c
@@ -252,7 +252,7 @@ static void sensor_submit_fallback_sync(struct rtio_iodev_sqe *iodev_sqe)
 
 			/* Convert to q31 using the shift */
 			q[sample_idx + sample] =
-				((value_u * ((INT64_C(1) << 31) - 1)) / 1000000) >> header->shift;
+				((value_u * (INT64_C(1) << 31)) / 1000000) >> header->shift;
 
 			LOG_DBG("value[%d]=%s%d.%06d, q[%d]@%p=%d, shift: %d",
 				sample, value_u < 0 ? "-" : "",


### PR DESCRIPTION
If the sensor_value only has an integer part `N`, this always resulted in q31 value of `<N-1>.999999` for positive values.
As the calculated shift value already uses `abs(sample.val1) + 1` it is safe to assume we can't have 100% scaling of this integer part and we can omit the -1.