### PR TITLE
net: lib: ptp: fix BTCA grandmaster selection and related state transition

### DIFF
--- a/subsys/net/lib/ptp/btca.c
+++ b/subsys/net/lib/ptp/btca.c
@@ -97,17 +97,37 @@ int ptp_btca_ds_cmp(const struct ptp_dataset *a, const struct ptp_dataset *b)
 	if (id_diff == 0) {
 		return btca_ds_cmp2(a, b);
 	}
+
+	if (a->priority1 < b->priority1) {
+		return A_BETTER;
+	}
 	if (a->priority1 > b->priority1) {
 		return B_BETTER;
+	}
+
+	if (a->clk_quality.cls < b->clk_quality.cls) {
+		return A_BETTER;
 	}
 	if (a->clk_quality.cls > b->clk_quality.cls) {
 		return B_BETTER;
 	}
+
+	if (a->clk_quality.accuracy < b->clk_quality.accuracy) {
+		return A_BETTER;
+	}
 	if (a->clk_quality.accuracy > b->clk_quality.accuracy) {
 		return B_BETTER;
 	}
+
+	if (a->clk_quality.offset_scaled_log_variance < b->clk_quality.offset_scaled_log_variance) {
+		return A_BETTER;
+	}
 	if (a->clk_quality.offset_scaled_log_variance > b->clk_quality.offset_scaled_log_variance) {
 		return B_BETTER;
+	}
+
+	if (a->priority2 < b->priority2) {
+		return A_BETTER;
 	}
 	if (a->priority2 > b->priority2) {
 		return B_BETTER;

--- a/subsys/net/lib/ptp/state_machine.c
+++ b/subsys/net/lib/ptp/state_machine.c
@@ -125,6 +125,9 @@ enum ptp_port_state ptp_state_machine(enum ptp_port_state state,
 			new_state = IS_ENABLED(CONFIG_PTP_FAULTY_PRESENT) ?
 					PTP_PS_FAULTY : new_state;
 			break;
+		case PTP_EVT_RS_GRAND_MASTER:
+			new_state = PTP_PS_GRAND_MASTER;
+			break;
 		case PTP_EVT_RS_PASSIVE:
 			new_state = PTP_PS_PASSIVE;
 			break;


### PR DESCRIPTION
The BTCA comparator ptp_btca_ds_cmp() did not follow the IEEE1588 ranking order: priority fields handled only the “greater” case, causing valid winners to fall through to the clockIdentity tie-breaker and resulting in incorrect grandmaster selection. This also caused the state transition from TIME_TRANSMITTER to GRAND_MASTER to be missed.

Fixes: #99562
Fixes: #99566