### PR TITLE
ci: assigner: Fix maintainer file check

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -34,7 +34,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up Python
-      uses: zephyrproject-rtos/action-python-env@ace91a63fd503cd618ff1eb83fbcf302dabd7d44 # main
+      uses: zephyrproject-rtos/action-python-env@32e53bef090c33d53aa94f1d9a9d29c93cfdc5f7 # main
       with:
         python-version: 3.12
 


### PR DESCRIPTION
The commit 1fe332de611738bd5742b2e898b1b384da978d06 moved the maintainer file check step from a standalone workflow to the assigner workflow, which uses the `action-python-env` action to install the Python requirements.

The version of PyGithub package installed by the `action-python-env` action in the assigner workflow is 2.6.1, which is older than the minimum required version 2.7.0 (see 5a4b0ac4d79bed95f25651f163b91e0da8349c4c for more details), and this caused the maintainer file check to erroneously flag the users with "Triage" role.

This commit updates the assigner workflow to use the action-python-env@32e53bef090c33d53aa94f1d9a9d29c93cfdc5f7, the latest version at the time of this change with up-to-date requirements file, in order to ensure that PyGithub>=2.7.0 is installed.