### PR TITLE
subsys/net: Fix EVENTFD kconfig selection

### DIFF
--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -35,7 +35,8 @@ menuconfig HTTP_SERVER
 	select HTTP_PARSER_URL
 	select EXPERIMENTAL
 	select NET_SOCKETS
-	select EVENTFD
+	select ZVFS
+	select ZVFS_EVENTFD
 	imply NET_IPV4_MAPPING_TO_IPV6 if NET_IPV4 && NET_IPV6
 	help
 	  HTTP1 and HTTP2 server support.

--- a/subsys/net/lib/ptp/Kconfig
+++ b/subsys/net/lib/ptp/Kconfig
@@ -4,7 +4,8 @@
 menuconfig PTP
 	bool "IEEE 1588 (PTP) support [EXPERIMENTAL]"
 	select EXPERIMENTAL
-	select EVENTFD
+	select ZVFS
+	select ZVFS_EVENTFD
 	select NET_SOCKETS
 	select NET_CONTEXT_PRIORITY
 	select NET_L2_PTP

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -85,7 +85,8 @@ config NET_SOCKET_MAX_SEND_WAIT
 
 config NET_SOCKETS_SERVICE
 	bool "Socket service support"
-	select EVENTFD
+	select ZVFS
+	select ZVFS_EVENTFD
 	help
 	  The socket service can monitor multiple sockets and save memory
 	  by only having one thread listening socket data. If data is received
@@ -99,7 +100,7 @@ config ZVFS_OPEN_ADD_SIZE_SOCKETS_SERVICE
 	int "Socket service file descriptor requirements"
 	default 1
 	help
-	  The socket service opens a permanent eventfd, which consumes a file
+	  The socket service opens a permanent zvfs_eventfd, which consumes a file
 	  descriptor.
 
 config NET_SOCKETS_SERVICE_THREAD_PRIO


### PR DESCRIPTION
Since 820cd34dbb5d817bacc6cbdeade99aaa01007a5c (#98765) these net components use ZVFS_EVENTFD directly instead of thru EVENTFD. So, let's select ZVFS_EVENTFD directly instead of indirectly through EVENTFD.