### PR TITLE
include: crypto: remove experimental API note

### DIFF
--- a/include/zephyr/crypto/crypto.h
+++ b/include/zephyr/crypto/crypto.h
@@ -9,9 +9,6 @@
  * @brief Crypto Cipher APIs
  *
  * This file contains the Crypto Abstraction layer APIs.
- *
- * [Experimental] Users should note that the APIs can change
- * as a part of ongoing development.
  */
 
 #ifndef ZEPHYR_INCLUDE_CRYPTO_H_


### PR DESCRIPTION
Update top-level comment of `include/zephyr/crypto/crypto.h` as the API is no longer experimental, as indicated by the `@version 1.0.0` tag in Doxygen:

https://github.com/zephyrproject-rtos/zephyr/blob/d21f6b5ecd3b3f057f1d5105736298cb38ee3e1e/include/zephyr/crypto/crypto.h#L27-L34