### PR TITLE
drivers: i2s: mcux_sai: correct DMA burst length

### DIFF
--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -661,8 +661,8 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 		/*set up dma settings*/
 		dev_data->tx.dma_cfg.source_data_size = word_size_bytes;
 		dev_data->tx.dma_cfg.dest_data_size = word_size_bytes;
-		dev_data->tx.dma_cfg.source_burst_length = word_size_bits;
-		dev_data->tx.dma_cfg.dest_burst_length = word_size_bits;
+		dev_data->tx.dma_cfg.source_burst_length = word_size_bytes;
+		dev_data->tx.dma_cfg.dest_burst_length = word_size_bytes;
 		dev_data->tx.dma_cfg.user_data = (void *)dev;
 		dev_data->tx.state = I2S_STATE_READY;
 	} else {
@@ -687,8 +687,8 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 		/*set up dma settings*/
 		dev_data->rx.dma_cfg.source_data_size = word_size_bytes;
 		dev_data->rx.dma_cfg.dest_data_size = word_size_bytes;
-		dev_data->rx.dma_cfg.source_burst_length = word_size_bits;
-		dev_data->rx.dma_cfg.dest_burst_length = word_size_bits;
+		dev_data->rx.dma_cfg.source_burst_length = word_size_bytes;
+		dev_data->rx.dma_cfg.dest_burst_length = word_size_bytes;
 		dev_data->rx.dma_cfg.user_data = (void *)dev;
 		dev_data->rx.state = I2S_STATE_READY;
 	}


### PR DESCRIPTION
MCUX SAI is broken on most NXP boards since 658abfbfcc073dc5b8aede515a66f54ef28253b1 (#97777).
According to the documentation of [`dma_config`](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/drivers/dma.h#L254), the burst length must be in bytes.

> [!WARNING]
> I didn't check how this should be handled on the IMX9 platform. If necessary, it should be fixed in another PR.

Fixes #99484.