### PR TITLE
tests: Bluetooth: Classic: Fix sm_init_035 failure issue

### DIFF
--- a/tests/bluetooth/classic/smp_general/pytest/test_smp.py
+++ b/tests/bluetooth/classic/smp_general/pytest/test_smp.py
@@ -1814,6 +1814,12 @@ async def sm_init_035(hci_port, shell, dut, address, snoop_file) -> None:
         )
         lines = shell.exec_command(f"l2cap_br connect {format(l2cap_server_psm, 'x')} sec 3")
         found = check_shell_response(lines, f"Enter 16 digits wide PIN code for {bumble_address}")
+        if not found:
+            found, _ = await wait_for_shell_response(
+                dut,
+                [f"Enter 16 digits wide PIN code for {bumble_address}"],
+            )
+
         assert found is True
 
         await send_cmd_to_iut(shell, dut, f"br auth-pincode {pin_code}", None)


### PR DESCRIPTION
For the case sm_init_035, the similar issue also be found. The message `Enter 16 digits wide PIN code for` may be printed after the shell prompt. The assert issue also be found in this case.

For the case sm_init_035, check the message `Enter 16 digits wide PIN code for` in the captured log. If it is not found, wait the message until timeout.