### PR TITLE
driver: spi: mcux_dspi: remove obsolete rx_bufs check

### DIFF
--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -687,13 +687,6 @@ static int transceive(const struct device *dev,
 	SPI_Type *base = config->base;
 #endif
 
-	if (rx_bufs == NULL) {
-		/* FIXME: for some reason this messes up the DMA configuration
-		 * probably because CITER is 0 and transfer is starting for some reason
-		 */
-		return -ENOTSUP;
-	}
-
 	spi_context_lock(&data->ctx, asynchronous, cb, userdata, spi_cfg);
 
 	ret = spi_mcux_configure(dev, spi_cfg);


### PR DESCRIPTION
This removes the `rx_bufs` NULL check that was introduced as a workaround for DMA misconfiguration issue.

The DMA misconfiguration workaround is no longer necessary since I was unable to reproduce the problem described in the comment.

Additionally, the workaround only covered the case where `rx_bufs == NULL`, but not cases where `rx_bufs->buffers == NULL` or `rx_bufs->count == 0`, which results in the same effective condition. Since the workaround was incomplete and the underlying issue does not appear reproducible anymore, it is clearer and safer to remove it.

Fixes: #98634