### PR TITLE
 STM32: Fix h7rs MPU memory type for XSPI external flash

### DIFF
--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -65,8 +65,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x70000000 DT_SIZE_M(32)>;
 		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
-		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_FLASH)>;
 	};
 };
 

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -75,8 +75,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x70000000 DT_SIZE_M(128)>;
 		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
-		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_FLASH)>;
 	};
 };
 

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -88,14 +88,6 @@
 		zephyr,memory-region = "ITCM";
 	};
 
-	ext_memory: memory@70000000 {
-		compatible = "zephyr,memory-region";
-		reg = <0x70000000 DT_SIZE_M(256)>;
-		zephyr,memory-region = "EXTMEM";
-		/* The ATTR_MPU_EXTMEM attribute causing a MPU FAULT */
-		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
-	};
-
 	clocks {
 		#address-cells = <1>;
 		#size-cells = <0>;


### PR DESCRIPTION
This adresses nr. 6 of #99505

Change the `zephyr,memory-attr` of the `ext_memory` / `ext_flash_mem` node to `ATTR_MPU_FLASH` because `ATTR_MPU_IO` does not allow unaligned memory accesses. 

Also remove the `ext_memory: memory@70000000` node from the SoC's dt, as the external flash memory is part of the board design. Same as with `psram`-node which is only defined at board level at the stm32h7s78_dk.
When someone connects the flash to XSPI1 or switches ports with XSPIM, external flash will not be at 0x70000000.
Note: The nucleo_h7s3l8 and stm32h7s78_dk boards already have this node.

