### PR TITLE
fix build warnings in hal_st module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -245,7 +245,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: 6d03b42859c2f8cedd6872da20b1dbdbef5c2392
+      revision: 6d963459acecfd2f9748ab506385a3188d8768f0
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
Fix hal_st module that broke CI.

See https://github.com/zephyrproject-rtos/zephyr/actions/runs/19462651912/job/55690305883

https://github.com/zephyrproject-rtos/hal_st/pull/29