### PR TITLE
net: ocpp: Correct way of getting strdup prototype

### DIFF
--- a/samples/net/ocpp/src/main.c
+++ b/samples/net/ocpp/src/main.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* for strdup() */
 #include <stdio.h>
 #include <time.h>
 
@@ -23,10 +25,6 @@
 #include <zephyr/zbus/zbus.h>
 
 #include "net_sample_common.h"
-
-#if __POSIX_VISIBLE < 200809
-char    *strdup(const char *);
-#endif
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
 

--- a/subsys/net/lib/ocpp/key_mgmt.c
+++ b/subsys/net/lib/ocpp/key_mgmt.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* for strdup() */
 #include "ocpp_i.h"
 
 #if defined(CONFIG_OCPP_PROFILE_SMART_CHARGE)

--- a/subsys/net/lib/ocpp/ocpp.c
+++ b/subsys/net/lib/ocpp/ocpp.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* for strdup() */
 #include "ocpp_i.h"
 
 #include <time.h>

--- a/subsys/net/lib/ocpp/ocpp_i.h
+++ b/subsys/net/lib/ocpp/ocpp_i.h
@@ -14,10 +14,6 @@
 #include <zephyr/net/websocket.h>
 #include <zephyr/sys/slist.h>
 
-#if __POSIX_VISIBLE < 200809
-char    *strdup(const char *);
-#endif
-
 /* case-insensitive */
 #define CISTR20	20
 #define CISTR25	25


### PR DESCRIPTION
Zephyr subsystems' headers should not duplicate C library prototypes (in this case strdup(), which is either ISO C23 or a POSIX extension to the C library <string.h>).

Instead they should request those prototypes from the C library. By now Zephyr only requires ISO C17, but many C libraries will have strdup() and expose it also when the POSIX extensions prototypes are requested, so let's request this prototype from the C library by setting the feature test macro _POSIX_C_SOURCE to version 2008.09 which includes it.