### PR TITLE
usb: device_next: use slist to store completed transfer requests

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -287,6 +287,10 @@ struct usbd_context {
 	const struct device *dev;
 	/** Notification message recipient callback */
 	usbd_msg_cb_t msg_cb;
+	/** slist to keep endpoint events */
+	sys_slist_t ep_events;
+	/** Endpoint event list spinlock */
+	struct k_spinlock ep_event_lock;
 	/** Middle layer runtime data */
 	struct usbd_ch9_data ch9_data;
 	/** slist to manage descriptors like string, BOS */


### PR DESCRIPTION
USBD_MAX_UDC_MSG configures the number of events coming from the UDC driver that the stack can keep. This can be filled very quickly if there would be multiple bus events for some reason, or function handlers of those events are blocked for long time. As a consequence, subsequent events could be dropped, and completed transfers not handled. To avoid it, we can store completed transfer requests in a slist and check it on every event.

Resolves: #74058