### PR TITLE
fix for zephyr issue #99527: PTP_TLV_TYPE_MANAGEMENT not working

### DIFF
--- a/subsys/net/lib/ptp/msg.c
+++ b/subsys/net/lib/ptp/msg.c
@@ -180,7 +180,7 @@ static int msg_tlv_post_recv(struct ptp_msg *msg, int length)
 		suffix += tlv_container->tlv->length;
 		suffix_len += tlv_container->tlv->length;
 
-		ret = ptp_tlv_post_recv(tlv_container->tlv);
+		ret = ptp_tlv_post_recv(&tlv_container->tlv);
 		if (ret) {
 			ptp_tlv_free(tlv_container);
 			return ret;

--- a/subsys/net/lib/ptp/tlv.h
+++ b/subsys/net/lib/ptp/tlv.h
@@ -366,11 +366,11 @@ enum ptp_tlv_type ptp_tlv_type(struct ptp_tlv *tlv);
 /**
  * @brief Function processing TLV after reception, and before processing by PTP stack.
  *
- * @param[in] tlv Pointer to the received TLV.
+ * @param[in] p_tlv Pointer to the pointer to the received TLV.
  *
  * @return Zero on success, otherwise negative.
  */
-int ptp_tlv_post_recv(struct ptp_tlv *tlv);
+int ptp_tlv_post_recv(struct ptp_tlv **p_tlv);
 
 /**
  * @brief Function preparing TLV to on-wire format before transmitting.


### PR DESCRIPTION
## Overview

Fixes #99527: PTP_TLV_TYPE_MANAGEMENT / PTP_MGMT_CLOCK_DESCRIPTION not working due to wrong use of CONTAINER_OF

Without this fix no TLV based message in PTP for PTP_TLV_TYPE_MANAGEMENT was parsed properly
 => *PTP_TLV_TYPE_MANAGEMENT / PTP_MGMT_CLOCK_DESCRIPTION  was not working*

Every message was discarded due to parsing errors since the pointer did not point to internal structures of TLVs but on somer wrong memory location

## Details

Our explanation for the cause of the problem:

The core problem is seen when trying to access clock_desc as part of a struct ptp_tlv_container in `static int tlv_mgmt_post_recv()`. The pointer to struct ptp_tlv_container should be obtained by `CONTAINER_OF` through a pointer to `struct ptp_tlv_mgmt`:
```
		container = CONTAINER_OF((void *)mgmt_tlv, struct ptp_tlv_container, tlv);
		clock_desc = &container->clock_desc;
```
To get a pointer to an instance of
```
struct ptp_tlv_container {
	/** Object list. */
	sys_snode_t		       node;
	/** Pointer to the TLV. */
	struct ptp_tlv		       *tlv;
	/** Structure holding pointers for Clock description. */
	struct ptp_tlv_mgmt_clock_desc clock_desc;
};
```

But to make `CONTAINER_OF` work through the field `tlv` we need `struct ptp_tlv**`, but in `static int tlv_mgmt_post_recv()` we only have `struct ptp_tlv*`. So `CONTAINER_OF` create a pointer to a wrong memory region and subsequent parsing of the PTP messages will fail.

In the python script attached to #99527 we have used this message type to see the problem:
 message_type = "management"