### PR TITLE
bluetooth: host: Fix bt_conn reference leak in Frame Space Update

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1857,6 +1857,8 @@ static void le_frame_space_update_complete(struct net_buf *buf)
 	}
 
 	bt_conn_notify_frame_space_update_complete(conn, &params);
+
+	bt_conn_unref(conn);
 }
 #endif /* CONFIG_BT_FRAME_SPACE_UPDATE */
 


### PR DESCRIPTION
Fix a missing unref of a bt_conn reference, leading to a ref count mismatch, and causing the following warning to be printed: bt_conn: Found valid connection ... in disconnected state.