### PR TITLE
scripts: gen_cfb_font_header.py: Improve PNG support

### DIFF
--- a/scripts/build/gen_cfb_font_header.py
+++ b/scripts/build/gen_cfb_font_header.py
@@ -126,9 +126,21 @@ def extract_image_glyphs():
     """Extract font glyphs from an image file"""
     image = Image.open(args.input)
 
+    if (image.width % args.width) != 0:
+        raise ValueError("Incorrect image width")
+    if (image.height % args.height) != 0:
+        raise ValueError("Incorrect image height")
+    if (image.width * image.height) < (args.width * args.height * (args.last - args.first + 1)):
+        raise ValueError("Incorrect image size")
+
     x_offset = 0
+    y_offset = 0
     for i in range(args.first, args.last + 1):
-        glyph = image.crop((x_offset, 0, x_offset + args.width, args.height))
+        if x_offset >= image.width:
+            x_offset = 0
+            y_offset += args.height
+
+        glyph = image.crop((x_offset, y_offset, x_offset + args.width, y_offset + args.height))
         generate_element(glyph, i)
         x_offset += args.width
 


### PR DESCRIPTION
Changes:
* Allow matrix arrangement of glyphs
* Remove the output file in case of a failure

The current implementation supports only glyphs arranges as a line thus making an image extremely wide.

The commit also fixes a bug in the script that keeps half-generated output files.
