### PR TITLE
boards: adi: Ensure no flash access on MAX32657 NS

### DIFF
--- a/boards/adi/max32657evkit/max32657evkit_max32657_ns.dts
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_ns.dts
@@ -67,8 +67,8 @@
 		 * };
 		 */
 
-		storage_partition: partition@f0000 {
-			label = "storage";
+		tfm_storage_partition: partition@f0000 {
+			label = "tfm-storage";
 			reg = <0xf0000 DT_SIZE_K(64)>;
 		};
 	};

--- a/dts/arm/adi/max32/max32657_ns.dtsi
+++ b/dts/arm/adi/max32/max32657_ns.dtsi
@@ -38,7 +38,7 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
-			status = "okay";
+			status = "disabled";
 
 			flash0: flash@1000000 {
 				compatible = "soc-nv-flash";


### PR DESCRIPTION
MAX32657 NS does not have access to the flash peripheral, so ensure the placeholder flash controller node is disabled, and update the "storage" node in the evkit board definition to properly document its use for TFM.