### PR TITLE
cfb: Skip non-existent font glyphs

### DIFF
--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -69,6 +69,10 @@ static struct char_framebuffer char_fb;
 
 static inline uint8_t *get_glyph_ptr(const struct cfb_font *fptr, uint8_t c)
 {
+	if (c < fptr->first_char || c > fptr->last_char) {
+		return NULL;
+	}
+
 	return (uint8_t *)fptr->data +
 	       (c - fptr->first_char) *
 	       (fptr->width * fptr->height / 8U);


### PR DESCRIPTION
The change ensures that returned glyph exists in the current font.

This change fixes cases when neither a proper glyph nor space are present in a font.
The issue can be reproduced by changing the [cfb_custom_font](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/subsys/display/cfb_custom_font) sample to print any symbol except for digits `1` to `6` (e.g. `A`).