### PR TITLE
drivers: mdio: remove bus_enable/bus_disable from api

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -32,6 +32,13 @@ Boards
 Device Drivers and Devicetree
 *****************************
 
+MDIO
+====
+
+* The ``mdio_bus_enable()`` and ``mdio_bus_disable()`` functions have been removed.
+  MDIO bus enabling/disabling is now handled internally by the MDIO drivers.
+  (:github:`99690`).
+
 QSPI
 ===
 

--- a/drivers/ethernet/phy/phy_adin2111.c
+++ b/drivers/ethernet/phy/phy_adin2111.c
@@ -187,31 +187,13 @@ static int phy_adin2111_c45_write(const struct device *dev, uint16_t devad,
 static int phy_adin2111_reg_read(const struct device *dev, uint16_t reg_addr,
 				 uint32_t *data)
 {
-	const struct phy_adin2111_config *cfg = dev->config;
-	int ret;
-
-	mdio_bus_enable(cfg->mdio);
-
-	ret = phy_adin2111_c22_read(dev, reg_addr, (uint16_t *) data);
-
-	mdio_bus_disable(cfg->mdio);
-
-	return ret;
+	return phy_adin2111_c22_read(dev, reg_addr, (uint16_t *) data);
 }
 
 static int phy_adin2111_reg_write(const struct device *dev, uint16_t reg_addr,
 				  uint32_t data)
 {
-	const struct phy_adin2111_config *cfg = dev->config;
-	int ret;
-
-	mdio_bus_enable(cfg->mdio);
-
-	ret = phy_adin2111_c22_write(dev, reg_addr, (uint16_t) data);
-
-	mdio_bus_disable(cfg->mdio);
-
-	return ret;
+	return phy_adin2111_c22_write(dev, reg_addr, (uint16_t) data);
 }
 
 static int phy_adin2111_await_phy(const struct device *dev)

--- a/drivers/ethernet/phy/phy_microchip_ksz8081.c
+++ b/drivers/ethernet/phy/phy_microchip_ksz8081.c
@@ -681,8 +681,6 @@ static int phy_mc_ksz8081_init(const struct device *dev)
 		return ret;
 	}
 
-	mdio_bus_enable(config->mdio_dev);
-
 	ret = ksz8081_init_reset_gpios(dev);
 	if (ret) {
 		return ret;

--- a/drivers/ethernet/phy/phy_microchip_ksz9131.c
+++ b/drivers/ethernet/phy/phy_microchip_ksz9131.c
@@ -550,8 +550,6 @@ static int phy_mchp_ksz9131_init(const struct device *dev)
 	data->dev = dev;
 	data->cb = NULL;
 
-	mdio_bus_enable(cfg->mdio);
-
 	ret = phy_mchp_ksz9131_reset(dev);
 	if (ret < 0) {
 		return ret;

--- a/drivers/ethernet/phy/phy_microchip_lan8742.c
+++ b/drivers/ethernet/phy/phy_microchip_lan8742.c
@@ -389,8 +389,6 @@ static int phy_lan8742_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	mdio_bus_enable(cfg->mdio);
-
 	ret = phy_lan8742_reset(dev);
 	if (ret < 0) {
 		LOG_ERR("Failed to reset PHY (%d): %d", cfg->phy_addr, ret);

--- a/drivers/ethernet/phy/phy_microchip_t1s.c
+++ b/drivers/ethernet/phy/phy_microchip_t1s.c
@@ -135,32 +135,18 @@ struct mc_t1s_data {
 static int phy_mc_t1s_read(const struct device *dev, uint16_t reg, uint32_t *data)
 {
 	const struct mc_t1s_config *cfg = dev->config;
-	int ret;
 
 	/* Make sure excessive bits 16-31 are reset */
 	*data = 0U;
 
-	mdio_bus_enable(cfg->mdio);
-
-	ret = mdio_read(cfg->mdio, cfg->phy_addr, reg, (uint16_t *)data);
-
-	mdio_bus_disable(cfg->mdio);
-
-	return ret;
+	return mdio_read(cfg->mdio, cfg->phy_addr, reg, (uint16_t *)data);
 }
 
 static int phy_mc_t1s_write(const struct device *dev, uint16_t reg, uint32_t data)
 {
 	const struct mc_t1s_config *cfg = dev->config;
-	int ret;
 
-	mdio_bus_enable(cfg->mdio);
-
-	ret = mdio_write(cfg->mdio, cfg->phy_addr, reg, (uint16_t)data);
-
-	mdio_bus_disable(cfg->mdio);
-
-	return ret;
+	return mdio_write(cfg->mdio, cfg->phy_addr, reg, (uint16_t)data);
 }
 
 static int mdio_setup_c45_indirect_access(const struct device *dev, uint16_t devad, uint16_t reg)
@@ -192,20 +178,13 @@ static int phy_mc_t1s_c45_read(const struct device *dev, uint8_t devad, uint16_t
 		return mdio_read_c45(cfg->mdio, cfg->phy_addr, devad, reg, val);
 	}
 
-	mdio_bus_enable(cfg->mdio);
-
 	/* Read C45 registers using C22 indirect access registers */
 	ret = mdio_setup_c45_indirect_access(dev, devad, reg);
 	if (ret < 0) {
-		mdio_bus_disable(cfg->mdio);
 		return ret;
 	}
 
-	ret = mdio_read(cfg->mdio, cfg->phy_addr, MII_MMD_AADR, val);
-
-	mdio_bus_disable(cfg->mdio);
-
-	return ret;
+	return mdio_read(cfg->mdio, cfg->phy_addr, MII_MMD_AADR, val);
 }
 
 static int phy_mc_t1s_c45_write(const struct device *dev, uint8_t devad, uint16_t reg, uint16_t val)
@@ -219,20 +198,13 @@ static int phy_mc_t1s_c45_write(const struct device *dev, uint8_t devad, uint16_
 		return mdio_write_c45(cfg->mdio, cfg->phy_addr, devad, reg, val);
 	}
 
-	mdio_bus_enable(cfg->mdio);
-
 	/* Write C45 registers using C22 indirect access registers */
 	ret = mdio_setup_c45_indirect_access(dev, devad, reg);
 	if (ret < 0) {
-		mdio_bus_disable(cfg->mdio);
 		return ret;
 	}
 
-	ret = mdio_write(cfg->mdio, cfg->phy_addr, MII_MMD_AADR, val);
-
-	mdio_bus_disable(cfg->mdio);
-
-	return ret;
+	return mdio_write(cfg->mdio, cfg->phy_addr, MII_MMD_AADR, val);
 }
 
 static int phy_mc_t1s_get_link(const struct device *dev, struct phy_link_state *state)

--- a/drivers/ethernet/phy/phy_microchip_vsc8541.c
+++ b/drivers/ethernet/phy/phy_microchip_vsc8541.c
@@ -442,7 +442,6 @@ static int phy_mc_vsc8541_read(const struct device *dev, uint16_t reg_addr, uint
 	reg_addr &= 0x00ff;
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
-	mdio_bus_enable(cfg->mdio_dev);
 
 	/* select page, given by register upper byte */
 	if (dev_data->active_page != page) {
@@ -457,7 +456,6 @@ static int phy_mc_vsc8541_read(const struct device *dev, uint16_t reg_addr, uint
 	ret = mdio_read(cfg->mdio_dev, cfg->addr, reg_addr, data);
 
 read_end:
-	mdio_bus_disable(cfg->mdio_dev);
 	k_mutex_unlock(&dev_data->mutex);
 
 	return ret;
@@ -493,7 +491,6 @@ static int phy_mc_vsc8541_write(const struct device *dev, uint16_t reg_addr, uin
 	reg_addr &= 0x00ff;
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
-	mdio_bus_enable(cfg->mdio_dev);
 
 	/* select page, given by register upper byte */
 	if (dev_data->active_page != page) {
@@ -508,7 +505,6 @@ static int phy_mc_vsc8541_write(const struct device *dev, uint16_t reg_addr, uin
 	ret = mdio_write(cfg->mdio_dev, cfg->addr, reg_addr, data);
 
 write_end:
-	mdio_bus_disable(cfg->mdio_dev);
 	k_mutex_unlock(&dev_data->mutex);
 
 	return ret;

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -499,8 +499,6 @@ static int phy_mii_initialize_dynamic_link(const struct device *dev)
 
 	data->state.is_up = false;
 
-	mdio_bus_enable(cfg->mdio);
-
 	if (cfg->no_reset == false) {
 		ret = reset(dev);
 		if (ret < 0) {

--- a/drivers/ethernet/phy/phy_motorcomm_yt8521.c
+++ b/drivers/ethernet/phy/phy_motorcomm_yt8521.c
@@ -526,13 +526,10 @@ static int mc_ytphy_get_id(const struct device *dev, uint32_t *phy_id)
 
 static int mc_ytphy_init(const struct device *dev)
 {
-	const struct mc_ytphy_config *const config = dev->config;
 	struct mc_ytphy_data *const data = dev->data;
 	int ret;
 
 	k_sem_init(&data->sem, 1, 1);
-
-	mdio_bus_enable(config->mdio);
 
 	data->state.is_up = false;
 	data->dev = dev;

--- a/drivers/ethernet/phy/phy_qualcomm_ar8031.c
+++ b/drivers/ethernet/phy/phy_qualcomm_ar8031.c
@@ -327,8 +327,6 @@ static int qc_ar8031_init(const struct device *dev)
 
 	k_sem_init(&data->sem, 1, 1);
 
-	mdio_bus_enable(cfg->mdio_dev);
-
 	data->state.is_up = false;
 
 	data->dev = dev;

--- a/drivers/ethernet/phy/phy_realtek_rtl8211f.c
+++ b/drivers/ethernet/phy/phy_realtek_rtl8211f.c
@@ -452,8 +452,6 @@ static int phy_rt_rtl8211f_init(const struct device *dev)
 		return ret;
 	}
 
-	mdio_bus_enable(config->mdio_dev);
-
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 	/* Configure reset pin */
 	if (config->reset_gpio.port) {

--- a/drivers/ethernet/phy/phy_ti_dp83825.c
+++ b/drivers/ethernet/phy/phy_ti_dp83825.c
@@ -496,8 +496,6 @@ static int phy_ti_dp83825_init(const struct device *dev)
 		return ret;
 	}
 
-	mdio_bus_enable(config->mdio_dev);
-
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 	if (config->reset_gpio.port) {
 		ret = gpio_pin_configure_dt(&config->reset_gpio, GPIO_OUTPUT_INACTIVE);

--- a/drivers/ethernet/phy/phy_ti_dp83867.c
+++ b/drivers/ethernet/phy/phy_ti_dp83867.c
@@ -467,8 +467,6 @@ static int phy_ti_dp83867_init(const struct device *dev)
 		return ret;
 	}
 
-	mdio_bus_enable(config->mdio_dev);
-
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 	if (config->reset_gpio.port) {
 		ret = gpio_pin_configure_dt(&config->reset_gpio, GPIO_OUTPUT_INACTIVE);

--- a/drivers/ethernet/phy/phy_tja1103.c
+++ b/drivers/ethernet/phy/phy_tja1103.c
@@ -112,30 +112,12 @@ static inline int phy_tja1103_c45_read(const struct device *dev, uint16_t devad,
 
 static int phy_tja1103_reg_read(const struct device *dev, uint16_t reg_addr, uint32_t *data)
 {
-	const struct phy_tja1103_config *cfg = dev->config;
-	int ret;
-
-	mdio_bus_enable(cfg->mdio);
-
-	ret = phy_tja1103_c22_read(dev, reg_addr, (uint16_t *)data);
-
-	mdio_bus_disable(cfg->mdio);
-
-	return ret;
+	return phy_tja1103_c22_read(dev, reg_addr, (uint16_t *)data);
 }
 
 static int phy_tja1103_reg_write(const struct device *dev, uint16_t reg_addr, uint32_t data)
 {
-	const struct phy_tja1103_config *cfg = dev->config;
-	int ret;
-
-	mdio_bus_enable(cfg->mdio);
-
-	ret = phy_tja1103_c22_write(dev, reg_addr, (uint16_t)data);
-
-	mdio_bus_disable(cfg->mdio);
-
-	return ret;
+	return phy_tja1103_c22_write(dev, reg_addr, (uint16_t)data);
 }
 
 static int phy_tja1103_id(const struct device *dev, uint32_t *phy_id)

--- a/drivers/ethernet/phy/phy_tja11xx.c
+++ b/drivers/ethernet/phy/phy_tja11xx.c
@@ -58,30 +58,12 @@ static inline int phy_tja11xx_c22_write(const struct device *dev, uint16_t reg, 
 
 static int phy_tja11xx_reg_read(const struct device *dev, uint16_t reg_addr, uint32_t *data)
 {
-	const struct phy_tja11xx_config *cfg = dev->config;
-	int ret;
-
-	mdio_bus_enable(cfg->mdio);
-
-	ret = phy_tja11xx_c22_read(dev, reg_addr, (uint16_t *)data);
-
-	mdio_bus_disable(cfg->mdio);
-
-	return ret;
+	return phy_tja11xx_c22_read(dev, reg_addr, (uint16_t *)data);
 }
 
 static int phy_tja11xx_reg_write(const struct device *dev, uint16_t reg_addr, uint32_t data)
 {
-	const struct phy_tja11xx_config *cfg = dev->config;
-	int ret;
-
-	mdio_bus_enable(cfg->mdio);
-
-	ret = phy_tja11xx_c22_write(dev, reg_addr, (uint16_t)data);
-
-	mdio_bus_disable(cfg->mdio);
-
-	return ret;
+	return phy_tja11xx_c22_write(dev, reg_addr, (uint16_t)data);
 }
 
 static int update_link_state(const struct device *dev)

--- a/drivers/mdio/mdio_sam.c
+++ b/drivers/mdio/mdio_sam.c
@@ -122,20 +122,6 @@ static int mdio_sam_write_c45(const struct device *dev, uint8_t prtad,
 	return err;
 }
 
-static void mdio_sam_bus_enable(const struct device *dev)
-{
-	const struct mdio_sam_dev_config *const cfg = dev->config;
-
-	cfg->regs->GMAC_NCR |= GMAC_NCR_MPE;
-}
-
-static void mdio_sam_bus_disable(const struct device *dev)
-{
-	const struct mdio_sam_dev_config *const cfg = dev->config;
-
-	cfg->regs->GMAC_NCR &= ~GMAC_NCR_MPE;
-}
-
 static int mdio_sam_initialize(const struct device *dev)
 {
 	const struct mdio_sam_dev_config *const cfg = dev->config;
@@ -156,6 +142,10 @@ static int mdio_sam_initialize(const struct device *dev)
 #endif
 
 	retval = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (retval >= 0) {
+		/* Enable MDIO */
+		cfg->regs->GMAC_NCR |= GMAC_NCR_MPE;
+	}
 
 	return retval;
 }
@@ -165,8 +155,6 @@ static DEVICE_API(mdio, mdio_sam_driver_api) = {
 	.write = mdio_sam_write,
 	.read_c45 = mdio_sam_read_c45,
 	.write_c45 = mdio_sam_write_c45,
-	.bus_enable = mdio_sam_bus_enable,
-	.bus_disable = mdio_sam_bus_disable,
 };
 
 #define MDIO_SAM_CLOCK(n)						\

--- a/drivers/mdio/mdio_shell.c
+++ b/drivers/mdio/mdio_shell.c
@@ -76,8 +76,6 @@ static int cmd_mdio_scan(const struct shell *sh, size_t argc, char **argv)
 		    reg_addr);
 	cnt = 0;
 
-	mdio_bus_enable(dev);
-
 	for (int i = 0; i < 32; i++) {
 		data = 0;
 		if (mdio_read(dev, i, reg_addr, &data) >= 0 &&
@@ -86,8 +84,6 @@ static int cmd_mdio_scan(const struct shell *sh, size_t argc, char **argv)
 			shell_print(sh, "Found MDIO device @ 0x%x", i);
 		}
 	}
-
-	mdio_bus_disable(dev);
 
 	shell_print(sh, "%u devices found on %s", cnt, dev->name);
 
@@ -112,16 +108,11 @@ static int cmd_mdio_write(const struct shell *sh, size_t argc, char **argv)
 	reg_addr = strtol(argv[3], NULL, 16);
 	data = strtol(argv[4], NULL, 16);
 
-	mdio_bus_enable(dev);
-
 	if (mdio_write(dev, port_addr, reg_addr, data) < 0) {
 		shell_error(sh, "Failed to write to device: %s", dev->name);
-		mdio_bus_disable(dev);
 
 		return -EIO;
 	}
-
-	mdio_bus_disable(dev);
 
 	return 0;
 }
@@ -143,16 +134,11 @@ static int cmd_mdio_read(const struct shell *sh, size_t argc, char **argv)
 	port_addr = strtol(argv[2], NULL, 16);
 	reg_addr = strtol(argv[3], NULL, 16);
 
-	mdio_bus_enable(dev);
-
 	if (mdio_read(dev, port_addr, reg_addr, &data) < 0) {
 		shell_error(sh, "Failed to read from device: %s", dev->name);
-		mdio_bus_disable(dev);
 
 		return -EIO;
 	}
-
-	mdio_bus_disable(dev);
 
 	shell_print(sh, "%x[%x]: 0x%x", port_addr, reg_addr, data);
 
@@ -179,16 +165,11 @@ static int cmd_mdio_write_45(const struct shell *sh, size_t argc, char **argv)
 	reg_addr = strtol(argv[4], NULL, 16);
 	data = strtol(argv[5], NULL, 16);
 
-	mdio_bus_enable(dev);
-
 	if (mdio_write_c45(dev, port_addr, dev_addr, reg_addr, data) < 0) {
 		shell_error(sh, "Failed to write to device: %s", dev->name);
-		mdio_bus_disable(dev);
 
 		return -EIO;
 	}
-
-	mdio_bus_disable(dev);
 
 	return 0;
 }
@@ -212,16 +193,11 @@ static int cmd_mdio_read_c45(const struct shell *sh, size_t argc, char **argv)
 	dev_addr = strtol(argv[3], NULL, 16);
 	reg_addr = strtol(argv[4], NULL, 16);
 
-	mdio_bus_enable(dev);
-
 	if (mdio_read_c45(dev, port_addr, dev_addr, reg_addr, &data) < 0) {
 		shell_error(sh, "Failed to read from device: %s", dev->name);
-		mdio_bus_disable(dev);
 
 		return -EIO;
 	}
-
-	mdio_bus_disable(dev);
 
 	shell_print(sh, "%x[%x:%x]: 0x%x", port_addr, dev_addr, reg_addr, data);
 

--- a/drivers/mdio/mdio_xilinx_axienet.c
+++ b/drivers/mdio/mdio_xilinx_axienet.c
@@ -71,21 +71,6 @@ static uint32_t xilinx_axienet_read_mdio_register(const struct mdio_xilinx_axien
 	return ret;
 }
 
-static void mdio_xilinx_axienet_bus_disable(const struct device *dev)
-{
-	const struct mdio_xilinx_axienet_config *config = dev->config;
-	struct mdio_xilinx_axienet_data *data = dev->data;
-
-	LOG_DBG("Disable MDIO Bus!");
-
-	xilinx_axienet_mdio_write_register(config, XILINX_AXIENET_MDIO_INTERRUPT_ENABLE_REG_OFFSET,
-					   XILINX_AXIENET_MDIO_INTERRUPT_DISABLE_ALL_MASK);
-
-	xilinx_axienet_mdio_write_register(config, XILINX_AXIENET_MDIO_SETUP_REG_OFFSET,
-					   XILINX_AXIENET_MDIO_SETUP_REG_MDIO_DISABLE_MASK);
-	data->bus_enabled = false;
-}
-
 static void enable_mdio_bus(const struct mdio_xilinx_axienet_config *config,
 			    struct mdio_xilinx_axienet_data *data)
 {
@@ -319,12 +304,12 @@ static int xilinx_axienet_mdio_probe(const struct device *dev)
 	LOG_INF("Enabling IRQ!");
 	config->config_func(data);
 
+	mdio_xilinx_axienet_bus_enable(dev);
+
 	return 0;
 }
 
 static DEVICE_API(mdio, mdio_xilinx_axienet_api) = {
-	.bus_disable = mdio_xilinx_axienet_bus_disable,
-	.bus_enable = mdio_xilinx_axienet_bus_enable,
 	.read = mdio_xilinx_axienet_read,
 	.write = mdio_xilinx_axienet_write,
 };

--- a/drivers/mdio/mdio_xmc4xxx.c
+++ b/drivers/mdio/mdio_xmc4xxx.c
@@ -103,19 +103,6 @@ static int mdio_xmc4xxx_write(const struct device *dev, uint8_t phy_addr,
 	return mdio_xmc4xxx_transfer(dev, phy_addr, reg_addr, 1, data, NULL);
 }
 
-static void mdio_xmc4xxx_bus_enable(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	/* this will enable the clock for ETH, which generates to MDIO clk  */
-	XMC_ETH_MAC_Enable(NULL);
-}
-
-static void mdio_xmc4xxx_bus_disable(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	XMC_ETH_MAC_Disable(NULL);
-}
-
 static int mdio_xmc4xxx_set_clock_divider(const struct device *dev)
 {
 	struct mdio_xmc4xxx_dev_data *dev_data = dev->data;
@@ -161,14 +148,15 @@ static int mdio_xmc4xxx_initialize(const struct device *dev)
 	port_ctrl.mdio = dev_cfg->mdi_port_ctrl;
 	ETH0_CON->CON = port_ctrl.raw;
 
+	/* this will enable the clock for ETH, which generates to MDIO clk  */
+	XMC_ETH_MAC_Enable(NULL);
+
 	return ret;
 }
 
 static DEVICE_API(mdio, mdio_xmc4xxx_driver_api) = {
 	.read = mdio_xmc4xxx_read,
 	.write = mdio_xmc4xxx_write,
-	.bus_enable = mdio_xmc4xxx_bus_enable,
-	.bus_disable = mdio_xmc4xxx_bus_disable,
 };
 
 PINCTRL_DT_INST_DEFINE(0);

--- a/include/zephyr/drivers/mdio.h
+++ b/include/zephyr/drivers/mdio.h
@@ -35,12 +35,6 @@ extern "C" {
  * public documentation.
  */
 __subsystem struct mdio_driver_api {
-	/** Enable the MDIO bus device */
-	void (*bus_enable)(const struct device *dev);
-
-	/** Disable the MDIO bus device */
-	void (*bus_disable)(const struct device *dev);
-
 	/** Read data from MDIO bus */
 	int (*read)(const struct device *dev, uint8_t prtad, uint8_t regad,
 		    uint16_t *data);
@@ -60,36 +54,6 @@ __subsystem struct mdio_driver_api {
 /**
  * @endcond
  */
-
-/**
- * @brief      Enable MDIO bus
- *
- * @param[in]  dev   Pointer to the device structure for the controller
- *
- */
-__syscall void mdio_bus_enable(const struct device *dev);
-
-static inline void z_impl_mdio_bus_enable(const struct device *dev)
-{
-	if (DEVICE_API_GET(mdio, dev)->bus_enable != NULL) {
-		DEVICE_API_GET(mdio, dev)->bus_enable(dev);
-	}
-}
-
-/**
- * @brief      Disable MDIO bus and tri-state drivers
- *
- * @param[in]  dev   Pointer to the device structure for the controller
- *
- */
-__syscall void mdio_bus_disable(const struct device *dev);
-
-static inline void z_impl_mdio_bus_disable(const struct device *dev)
-{
-	if (DEVICE_API_GET(mdio, dev)->bus_disable != NULL) {
-		DEVICE_API_GET(mdio, dev)->bus_disable(dev);
-	}
-}
 
 /**
  * @brief      Read from MDIO Bus


### PR DESCRIPTION
remove mdio_bus_enable/mdio_bus_disable, as they are no
longer needed and make the mdio api simpler.

MDIO is not a stable api, according to https://docs.zephyrproject.org/latest/develop/api/overview.html

More infos in: #95147

Closes: #95147