### PR TITLE
Add a suggestive log for GitHub API rate-limiting issue during install

### DIFF
--- a/scripts/west_commands/sdk.py
+++ b/scripts/west_commands/sdk.py
@@ -247,6 +247,9 @@ class Sdk(WestCommand):
             params = {"page": page, "per_page": 100}
             resp = requests.get(url, headers=req_headers, params=params)
             if resp.status_code != 200:
+                rate_limit_log = "API rate limit exceeded"
+                if rate_limit_log in resp.text:
+                    self.inf(f"fetch_releases {rate_limit_log}. Try executing install script with --personal-access-token argument or use a .netrc file")
                 raise Exception(f"Failed to fetch: {resp.status_code}, {resp.text}")
 
             data = resp.json()


### PR DESCRIPTION
`west sdk install` may fail with a GitHub API rate-limit (HTTP 403) error. This typically occurs when the command is run multiple times after previous failures, which is common for new users setting up the project. Currently, the thrown exception only links to a generic GitHub rate-limit documentation page, which may be confusing to users.

Users can bypass the rate limit by authenticating with GitHub using a Personal Access Token. The install script supports this via the `--personal-access-token` argument. Therefore, detect rate-limit related failures and print a helpful message suggesting the use of this argument.

Fixes zephyrproject-rtos/zephyr#93693
