### PR TITLE
drivers: i3c: fix nibi builds

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -2774,7 +2774,9 @@ static void cdns_i3c_target_sdr_tx_thr_int_handler(const struct device *dev,
 static void cdns_i3c_irq_handler(const struct device *dev)
 {
 	const struct cdns_i3c_config *config = dev->config;
+#if defined(CONFIG_I3C_CONTROLLER) && defined(CONFIG_I3C_USE_IBI) || defined(CONFIG_I3C_TARGET)
 	struct cdns_i3c_data *data = dev->data;
+#endif
 #ifdef CONFIG_I3C_CONTROLLER
 	uint32_t int_st = sys_read32(config->base + MST_ISR);
 

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -470,6 +470,7 @@ int i3c_sec_i2c_attach(const struct device *dev, uint8_t static_addr, uint8_t lv
 	return ret;
 }
 
+#ifdef CONFIG_I3C_USE_IBI
 static void i3c_sec_bus_reset(const struct device *dev)
 {
 	struct i3c_device_desc *i3c_desc;
@@ -483,7 +484,7 @@ static void i3c_sec_bus_reset(const struct device *dev)
 		i3c_detach_i2c_device(i3c_i2c_desc);
 	}
 }
-#ifdef CONFIG_I3C_USE_IBI
+
 /* call this from a workq after the interrupt from a controller */
 void i3c_sec_handoffed(struct k_work *work)
 {

--- a/tests/drivers/build_all/i3c/testcase.yaml
+++ b/tests/drivers/build_all/i3c/testcase.yaml
@@ -19,3 +19,18 @@ tests:
     platform_allow: qemu_cortex_m3
     tags: i3c_cdns i3c_dw
     extra_args: "CONFIG_I3C_TARGET_ROLE_ONLY=y"
+  drivers.i3c.build.dual_role_nibi:
+    # will cover drivers without in-tree boards
+    platform_allow: qemu_cortex_m3
+    tags: i3c_cdns i3c_dw
+    extra_args: "CONFIG_I3C_DUAL_ROLE=y CONFIG_I3C_RTIO=y CONFIG_I3C_USE_IBI=n"
+  drivers.i3c.build.controller_role_only_nibi:
+    # will cover drivers without in-tree boards
+    platform_allow: qemu_cortex_m3
+    tags: i3c_cdns i3c_dw
+    extra_args: "CONFIG_I3C_CONTROLLER_ROLE_ONLY=y CONFIG_I3C_RTIO=y CONFIG_I3C_USE_IBI=n"
+  drivers.i3c.build.target_role_only_nibi:
+    # will cover drivers without in-tree boards
+    platform_allow: qemu_cortex_m3
+    tags: i3c_cdns i3c_dw
+    extra_args: "CONFIG_I3C_TARGET_ROLE_ONLY=y CONFIG_I3C_USE_IBI=n"


### PR DESCRIPTION
Fix unused function warning when building withouth CONFIG_I3C_USE_IBI. Also fix an unused variable warning in `i3c_cdns.c`

Also add a build test case so this can't happen again.