### PR TITLE
net/l2/ieee802154: logging improvement for utils and nrf5 driver

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -344,7 +344,7 @@ static int nrf5_set_pan_id(const struct device *dev, uint16_t pan_id)
 	sys_put_le16(pan_id, pan_id_le);
 	nrf_802154_pan_id_set(pan_id_le);
 
-	LOG_DBG("0x%x", pan_id);
+	LOG_DBG("pan_id 0x%x", pan_id);
 
 	return 0;
 }
@@ -358,7 +358,7 @@ static int nrf5_set_short_addr(const struct device *dev, uint16_t short_addr)
 	sys_put_le16(short_addr, short_addr_le);
 	nrf_802154_short_address_set(short_addr_le);
 
-	LOG_DBG("0x%x", short_addr);
+	LOG_DBG("short_addr 0x%x", short_addr);
 
 	return 0;
 }
@@ -381,7 +381,7 @@ static int nrf5_filter(const struct device *dev, bool set,
 		       enum ieee802154_filter_type type,
 		       const struct ieee802154_filter *filter)
 {
-	LOG_DBG("Applying filter %u", type);
+	LOG_DBG("Applying filter %u set=%d", type, set);
 
 	if (!set) {
 		return -ENOTSUP;

--- a/subsys/net/l2/ieee802154/ieee802154_utils.h
+++ b/subsys/net/l2/ieee802154/ieee802154_utils.h
@@ -245,7 +245,8 @@ static inline void ieee802154_radio_remove_src_short_addr(struct net_if *iface, 
 	const struct ieee802154_radio_api *radio =
 		net_if_get_device(iface)->api;
 
-	if (radio && (radio->get_capabilities(net_if_get_device(iface)) &
+	if (radio && (short_addr != IEEE802154_SHORT_ADDRESS_NOT_ASSOCIATED) &&
+		(radio->get_capabilities(net_if_get_device(iface)) &
 		      IEEE802154_HW_FILTER)) {
 		struct ieee802154_filter filter;
 
@@ -264,7 +265,8 @@ static inline void ieee802154_radio_remove_pan_id(struct net_if *iface, uint16_t
 	const struct ieee802154_radio_api *radio =
 		net_if_get_device(iface)->api;
 
-	if (radio && (radio->get_capabilities(net_if_get_device(iface)) &
+	if (radio && (pan_id != IEEE802154_PAN_ID_NOT_ASSOCIATED) &&
+		(radio->get_capabilities(net_if_get_device(iface)) &
 		      IEEE802154_HW_FILTER)) {
 		struct ieee802154_filter filter;
 


### PR DESCRIPTION
```
drivers: ieee802154: nrf5: improve debug logs

This commit prefixes "0x%x" debug logs with the entity, and prints the
"set" parameter when updating a filter.
```

----

```
net: l2: ieee802154: skip filter removal for unassociated values

Trying to remove filter with NOT_ASSOCIATED parameter results in noisy
warning logs in most of the radio drivers. It's safe to ignore it as
this is an invalid operation.
```