### PR TITLE
MAINTAINERS: update Infineon Platforms collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2919,6 +2919,8 @@ Infineon Platforms:
   collaborators:
     - mcatee-infineon
     - talih0
+    - billwatersiii
+    - jsbatch
   files:
     - boards/cypress/
     - boards/infineon/
@@ -5611,6 +5613,8 @@ West:
     - parthitce
     - talih0
     - mcatee-infineon
+    - billwatersiii
+    - jsbatch
   files:
     - modules/Kconfig.infineon
     - modules/hal_infineon/


### PR DESCRIPTION
Adds jsbatch and billwatersiii as collaborators for Infineon Platform and hal_infineon west project.  Both users have been working on the Infineon Zephyr integration team contributing driver and SOC updates for new devices and maintenance of existing devices. 