### PR TITLE
drivers: can: Select pin control in max32 driver

### DIFF
--- a/drivers/can/Kconfig.max32
+++ b/drivers/can/Kconfig.max32
@@ -5,6 +5,7 @@ config CAN_MAX32
 	bool "ADI MAX32 CAN Driver"
 	default y
 	depends on DT_HAS_ADI_MAX32_CAN_ENABLED
+	select PINCTRL
 	help
 	  Enable ADI MAX32 CAN Driver
 


### PR DESCRIPTION
Fixes the max32 can driver to follow the convention for drivers to select pin control if they need it.