### PR TITLE
tests: Bluetooth: Classic: GAP_S: Reduce time consumption

### DIFF
--- a/tests/bluetooth/classic/gap_s/pytest/test_gap_s.py
+++ b/tests/bluetooth/classic/gap_s/pytest/test_gap_s.py
@@ -45,6 +45,8 @@ async def _wait_for_shell_response(dut, response, max_wait_sec=20):
                     found = True
                     break
             lines = lines + read_lines
+            if found:
+                break
             await asyncio.sleep(1)
         logger.info(f'{str(lines)}')
     except Exception as e:


### PR DESCRIPTION
In current implementation, the useless for loop is called in function `_wait_for_shell_response()` if the target message has been found. It causes the case will consume too much time.

Exit the useless for loop to reduce the time consumption when the target message is found.