### PR TITLE
soc: st: stm32: add '-align' flag for signing tool v2.21.0+

### DIFF
--- a/soc/st/stm32/stm32n6x/CMakeLists.txt
+++ b/soc/st/stm32/stm32n6x/CMakeLists.txt
@@ -3,11 +3,11 @@
 zephyr_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_sources(
   soc.c
-  )
+)
 
 zephyr_sources_ifdef(CONFIG_STM32N6_NPU
   npu/npu_stm32n6.c
-  )
+)
 
 zephyr_include_directories(.)
 
@@ -22,26 +22,47 @@ zephyr_linker_sources_ifdef(CONFIG_BOOTLOADER_MCUBOOT SECTIONS ram_check.ld)
 
 if(NOT CONFIG_BOOTLOADER_MCUBOOT)
 
-  if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Windows)
-    set(SIGNING_TOOL STM32_SigningTool_CLI.exe)
-  else()
-    set(SIGNING_TOOL STM32_SigningTool_CLI)
-  endif()
+  set(signing_tool STM32_SigningTool_CLI)
 
-  find_file(SIGNING_TOOL_FIND ${SIGNING_TOOL})
-  if(SIGNING_TOOL_FIND STREQUAL SIGNING_TOOL_FIND-NOTFOUND)
+  # find_program will automatically search for .exe extension on Windows
+  find_program(signing_tool_find ${signing_tool})
+  if(signing_tool_find STREQUAL signing_tool_find-NOTFOUND)
     message(WARNING "
-    Signing Image tool (${SIGNING_TOOL}) is not available.
-    Signed image will not be generated.
-    You won't be able to run application on the board.
-    Refer to board documentation for more information")
+      Signing Image tool (${signing_tool}) is not available.
+      Signed image will not be generated.
+      You won't be able to run application on the board.
+      Refer to board documentation for more information.
+    ")
   else()
-    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND ${SIGNING_TOOL}
+    message(STATUS "Found STM32 signing tool: ${signing_tool_find}")
+
+    execute_process(
+      COMMAND ${signing_tool_find} --version
+      OUTPUT_VARIABLE version
+      RESULT_VARIABLE result
+    )
+
+    set(signing_tool_args
       -in ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.bin
       -nk -t fsbl -hv 2.3 --silent
       -o ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.signed.bin
       -dump ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.signed.bin
+    )
+
+    set(signing_tool_version_regex "v([0-9]+[.][0-9]+[.][0-9]+)")
+    if(result EQUAL 0 AND version MATCHES ${signing_tool_version_regex})
+      if(${CMAKE_MATCH_1} VERSION_GREATER_EQUAL 2.21.0)
+        list(APPEND signing_tool_args -align)
+      endif()
+    else()
+      message(FATAL_ERROR "
+        Unable to determine ${signing_tool} version (expected match to
+        ${signing_tool_version_regex} regex)
+      ")
+    endif()
+
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND ${signing_tool} ${signing_tool_args}
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     )
 


### PR DESCRIPTION
Starting in `v2.21.0`, the STM32 signing tool (`STM32_SigningTool_CLI`) stopped automatically adding padding bytes at the beginning of the payload to align it to the `0x400` offset. To restore this behavior, the `-align` flag must be passed to the signing tool post-build command.
    
This PR checks for signing tool version `v2.21.0` or higher and appends the `-align` flag to the post-build signing command. It also changes local CMake variable names to lower case and corrects some indentation issues.
    
Fixes zephyrproject-rtos/zephyr#99456