### PR TITLE
tests: Bluetooth: tester: Removed bad guard in btp_gap.h

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_gap.h
+++ b/tests/bluetooth/tester/src/btp/btp_gap.h
@@ -619,7 +619,6 @@ struct btp_gap_periodic_biginfo_ev {
 	uint8_t encryption;
 } __packed;
 
-#if defined(CONFIG_BT_EXT_ADV)
 struct bt_le_per_adv_param;
 struct bt_le_per_adv_sync_param;
 struct bt_le_adv_param;
@@ -640,4 +639,3 @@ int tester_gap_padv_start(struct bt_le_ext_adv *ext_adv);
 int tester_gap_padv_stop(struct bt_le_ext_adv *ext_adv);
 int tester_gap_padv_create_sync(struct bt_le_per_adv_sync_param *create_params);
 int tester_gap_padv_stop_sync(void);
-#endif /* defined(CONFIG_BT_EXT_ADV) */


### PR DESCRIPTION
As per the Zephyr coding guidelines, functions declarations in header files should not be conditionally compiled.

This fixes an issue with tester_gap_clear_adv_instance where btp_gap.c always expect it to be available.