### PR TITLE
scripts: ci: set_assignee: Fix process_pr if manifest file has changed

### DIFF
--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -248,7 +248,6 @@ def process_pr(gh, maintainer_file, number):
                 continue
             parsed_areas = process_manifest(old_manifest_file=args.updated_manifest)
             for _area in parsed_areas:
-                collab_per_path.update(_area.get_collaborators_for_path(changed_file.filename))
                 area_match = maintainer_file.name2areas(_area)
                 if area_match:
                     areas.extend(area_match)


### PR DESCRIPTION
The parsed_areas is a list of strings, not a list of area objects.