### PR TITLE
stm32: xspi: Allow flash driver usage in RAM_LOAD mode

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -23,7 +23,7 @@
 		zephyr,touch = &gt911;
 		spi-flash0 = &mx66uw1g45g;
 		zephyr,flash-controller = &mx66uw1g45g;
-		zephyr,flash = &mx66uw1g45g;
+		zephyr,flash = &ext_flash;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -400,32 +400,40 @@ zephyr_udc0: &usbotg_hs1 {
 		four-byte-opcodes;
 		status = "okay";
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x70000000 DT_SIZE_M(128)>;
 
-			/*
-			 * Following flash partition is dedicated to the use of bootloader
-			 */
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
-			};
+		ext_flash: ext-flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(128)>;
+			write-block-size = <1>;
+			erase-block-size = <DT_SIZE_K(4)>;
 
-			slot0_partition: partition@10000 {
-				label = "image-0";
-				reg = <0x10000 DT_SIZE_K(1536)>;
-			};
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
 
-			slot1_partition: partition@210000 {
-				label = "image-1";
-				reg = <0x210000 DT_SIZE_K(1536)>;
-			};
+				boot_partition: partition@0 {
+					label = "mcuboot";
+					reg = <0x00000000 DT_SIZE_K(64)>;
+				};
 
-			storage_partition: partition@410000 {
-				label = "storage";
-				reg = <0x410000 DT_SIZE_K(64)>;
+				slot0_partition: partition@10000 {
+					label = "image-0";
+					reg = <0x10000 DT_SIZE_K(1536)>;
+				};
+
+				slot1_partition: partition@210000 {
+					label = "image-1";
+					reg = <0x210000 DT_SIZE_K(1536)>;
+				};
+
+				storage_partition: partition@410000 {
+					label = "storage";
+					reg = <0x410000 DT_SIZE_K(64)>;
+				};
 			};
 		};
 	};


### PR DESCRIPTION
Currently, STM32 XSPI flash driver initialization aborts if application is run from external flash.
Though, constraints are actually different if:
- application runs in XIP and is read from ext flash
- application runs in RAM LOAD mode and is read from RAM, leaving the ext flash available for flash driver operations

Fix XSPI driver to allow flash operations in RAM LOAD.
Make necessary changes on N6 DK to be able to make use of it.

Once approved, it will have to be extended to O/QSPI drivers.
Then, we should also make sure this work using MSPI drivers.

Edit: Depends on https://github.com/mcu-tools/mcuboot/pull/2547