### PR TITLE
tests: bluetooth: tester: add support for wid 145 and 167

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_gatt.h
+++ b/tests/bluetooth/tester/src/btp/btp_gatt.h
@@ -347,6 +347,21 @@ struct btp_gatt_cfg_notify_mult_cmd {
 	uint16_t cnt;
 	uint16_t attr_id[];
 } __packed;
+
+#define BTP_GATT_GET_HANDLE_FROM_UUID 0x22
+struct btp_gatt_get_handle_from_uuid_cmd {
+	uint8_t uuid_length;
+	uint8_t uuid[];
+} __packed;
+struct btp_gatt_get_handle_from_uuid_rp {
+	uint16_t handle;
+} __packed;
+
+#define BTP_GATT_REMOVE_HANDLE_FROM_DB 0x23
+struct btp_gatt_remove_handle_from_db_cmd {
+	uint16_t handle;
+} __packed;
+
 /* GATT events */
 #define BTP_GATT_EV_NOTIFICATION		0x80
 struct btp_gatt_notification_ev {


### PR DESCRIPTION
wid 145 requests handle of a UUID of a long characteristic. wid 167 requests to remove the characteristic by handle requested in wid 145.

2 new commands are added to support these wids:
- BTP_GATT_GET_HANDLE_FROM_UUID to request handle of a certain UUID
- BTP_GATT_REMOVE_HANDLE_FROM_DB to remove attribute by handle.

Corresponding AutoPTS PR: https://github.com/auto-pts/auto-pts/pull/1623