### PR TITLE
net: websocket: Fix truncated string warning on copying

### DIFF
--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -365,7 +365,7 @@ int websocket_connect(int sock, struct websocket_request *wreq,
 		key_len);
 
 	olen = MIN(sizeof(key_accept) - 1 - key_len, sizeof(WS_MAGIC) - 1);
-	strncpy(key_accept + key_len, WS_MAGIC, olen);
+	memcpy(key_accept + key_len, WS_MAGIC, olen);
 
 	/* This SHA-1 value is then checked when we receive the response */
 #ifdef CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT


### PR DESCRIPTION
WS_MAGIC is a constant string and when calculating lengths for copying we always exclude the NULL terminator. In result, using strncpy() for copying can generate a warning about truncated string, as WS_MAGIC will always be truncated from the NULL terminator. Therefore replace strncpy() with memcpy() as it seems more appropriate for this case.

Fixes #99678