### PR TITLE
drivers: wifi: siwx91x: Fix AP mode channel status when using auto channel

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -122,7 +122,7 @@ int siwx91x_status(const struct device *dev, struct wifi_iface_status *status)
 		status->link_mode = WIFI_4;
 		status->iface_mode = WIFI_MODE_AP;
 		status->mfp = WIFI_MFP_DISABLE;
-		status->channel = sl_ap_cfg.channel.channel;
+		status->channel = wlan_info.channel_number;
 		status->beacon_interval = sl_ap_cfg.beacon_interval;
 		status->dtim_period = sl_ap_cfg.dtim_beacon_count;
 		wlan_info.sec_type = (uint8_t)sl_ap_cfg.security;


### PR DESCRIPTION
Fixes the auto channel status by using the channel number from fetched wireless info, rather than the input config variable.