### PR TITLE
cmake: remove quotes around SUBALIGN

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5313,7 +5313,7 @@ function(zephyr_iterable_section)
   endif()
 
   if(DEFINED SECTION_SUBALIGN)
-    set(subalign "SUBALIGN ${SECTION_SUBALIGN}")
+    set(subalign SUBALIGN ${SECTION_SUBALIGN})
   endif()
 
   if(SECTION_ALIGN_WITH_INPUT)


### PR DESCRIPTION
Quotes around `"SUBALIGN ${SUBALIGN}"` results in the parameters to become a text string with a space, and therefore will give the warning

> CMake Warning at /.../extensions.cmake:5197 (message):
>  zephyr_linker_section(NAME ...) given unknown arguments: SUBALIGN 4
> Call Stack (most recent call first):
>   /.../extensions.cmake:5333 (zephyr_linker_section)
>   /.../CMakeLists.txt:x (zephyr_iterable_section)

Remove the quotes so that `SUBALIGN` and the value are correctly treated as argument name and value.