### PR TITLE
boards: m5stack: cores3: Correct touchscreen axis

### DIFF
--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
@@ -222,6 +222,7 @@
 		reg = <0x38>;
 		int-gpios = <&aw9523b_gpio 10 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&aw9523b_gpio 0 GPIO_ACTIVE_LOW>;
+		swapped-x-y;
 	};
 };
 


### PR DESCRIPTION
This PR correct the swapped X/Y touch axis.

https://github.com/user-attachments/assets/574305b3-4ba2-4280-9d74-aebe9eba4f15

Tested with:

```
west build -p -b m5stack_cores3/esp32s3/procpu/se -s samples/modules/lvgl/demos -- -DCONFIG_LV_Z_DEMO_KEYPAD_AND_ENCODER=y
```