### PR TITLE
dts: rx: renesas: Add SPI support on RX261

### DIFF
--- a/boards/renesas/ek_rx261/ek_rx261-pinctrl.dtsi
+++ b/boards/renesas/ek_rx261/ek_rx261-pinctrl.dtsi
@@ -11,4 +11,13 @@
 				<RX_PSEL(RX_PSEL_SCI_6, 11, 0)>; /* RX */
 		};
 	};
+
+	rspi0_default: rspi0_default {
+		group1 {
+			psels = <RX_PSEL(RX_PSEL_PAnPFS_RSPCKA, 10, 5)>,
+				<RX_PSEL(RX_PSEL_PAnPFS_MOSIA, 10, 6)>,
+				<RX_PSEL(RX_PSEL_PAnPFS_MISOA, 10, 7)>,
+				<RX_PSEL(RX_PSEL_PAnPFS_SSLA0, 10, 4)>;
+		};
+	};
 };

--- a/boards/renesas/ek_rx261/ek_rx261.dts
+++ b/boards/renesas/ek_rx261/ek_rx261.dts
@@ -95,3 +95,10 @@
 		status = "okay";
 	};
 };
+
+&rspi0 {
+	pinctrl-0 = <&rspi0_default>;
+	pinctrl-names = "default";
+	ssl-assert = <0>;
+	status = "okay";
+};

--- a/boards/renesas/fpb_rx261/fpb_rx261-pinctrl.dtsi
+++ b/boards/renesas/fpb_rx261/fpb_rx261-pinctrl.dtsi
@@ -11,4 +11,13 @@
 				<RX_PSEL(RX_PSEL_SCI_5, 0xC, 0x2)>; /* RX */
 		};
 	};
+
+	rspi0_default: rspi0_default {
+		group1 {
+			psels = <RX_PSEL(RX_PSEL_PAnPFS_RSPCKA, 10, 5)>,
+				<RX_PSEL(RX_PSEL_PAnPFS_MOSIA, 10, 6)>,
+				<RX_PSEL(RX_PSEL_PAnPFS_MISOA, 10, 7)>,
+				<RX_PSEL(RX_PSEL_PAnPFS_SSLA0, 10, 4)>;
+		};
+	};
 };

--- a/boards/renesas/fpb_rx261/fpb_rx261.dts
+++ b/boards/renesas/fpb_rx261/fpb_rx261.dts
@@ -84,3 +84,10 @@
 		status = "okay";
 	};
 };
+
+&rspi0 {
+	pinctrl-0 = <&rspi0_default>;
+	pinctrl-names = "default";
+	ssl-assert = <0>;
+	status = "okay";
+};

--- a/dts/rx/renesas/rx261-common.dtsi
+++ b/dts/rx/renesas/rx261-common.dtsi
@@ -509,6 +509,18 @@
 				interrupt-names = "cmi";
 				status = "disabled";
 			};
+
+			rspi0: spi@88380 {
+				compatible = "renesas,rx-rspi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <0x00088380 0x100>;
+				channel = <0>;
+				clocks = <&pclkb MSTPB 17>;
+				interrupts = <44 1>, <45 1>, <46 1>, <47 1>;
+				interrupt-names = "spei", "spri", "spti", "spii";
+				status = "disabled";
+			};
 		};
 
 		ofsm: ofsm@ffffff80 {

--- a/tests/drivers/spi/spi_loopback/boards/ek_rx261.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ek_rx261.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&rspi0 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <3000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/boards/fpb_rx261.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/fpb_rx261.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&rspi0 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <3000000>;
+	};
+};


### PR DESCRIPTION
Add SPI dts support on RX261 (including EK-RX261 and FPB-RX261 boards)