### PR TITLE
boards: arduino: fix docs to remove note about BT only functionality

### DIFF
--- a/boards/arduino/giga_r1/doc/index.rst
+++ b/boards/arduino/giga_r1/doc/index.rst
@@ -43,8 +43,6 @@ that run the command:
 
    west blobs fetch hal_infineon
 
-.. note:: Only Bluetooth functionality is currently supported.
-
 Resources sharing
 =================
 

--- a/boards/arduino/nicla_vision/doc/index.rst
+++ b/boards/arduino/nicla_vision/doc/index.rst
@@ -47,8 +47,6 @@ that run the command:
 
    west blobs fetch hal_infineon
 
-.. note:: Only Bluetooth functionality is currently supported.
-
 Resources sharing
 =================
 

--- a/boards/arduino/portenta_h7/doc/index.rst
+++ b/boards/arduino/portenta_h7/doc/index.rst
@@ -48,8 +48,6 @@ that run the command:
 
    west blobs fetch hal_infineon
 
-.. note:: Only Bluetooth functionality is currently supported.
-
 Resources sharing
 =================
 


### PR DESCRIPTION
SDIO is now fully supported on STM32 targets since #89776, and this enabled the use of Wi-Fi functionality on Arduino H7 boards. Remove the note in the documentation that states only Bluetooth is supported.