### PR TITLE
soc: st: stm32: h7rsxx: Fix MPU region for read-only id flash region

### DIFF
--- a/soc/st/stm32/stm32h7rsx/mpu_regions.c
+++ b/soc/st/stm32/stm32h7rsx/mpu_regions.c
@@ -27,8 +27,8 @@ static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 3 */
 	MPU_REGION_ENTRY("SRAM_0", CONFIG_SRAM_BASE_ADDRESS, REGION_RAM_ATTR(REGION_SRAM_SIZE)),
 
-	/* Region 4 - Ready only flash with unique device id */
-	MPU_REGION_ENTRY("ID", 0x08FFF800, REGION_FLASH_ATTR(REGION_2K)),
+	/* Region 4 - Ready only flash with unique device id, package code and VREF/TS calib*/
+	MPU_REGION_ENTRY("ID", 0x08FFF800, REGION_IO_ATTR(REGION_512B)),
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mac))
 #define sram_eth_node DT_NODELABEL(sram2)


### PR DESCRIPTION
Set correct MPU memory type and size for the uniqe device id, package code and ADC VREF/TS calibration read-only flash region.

~~(DEVICE_NON_SHAREABLE | REGION_512B | P_RO_U_NA_Msk)) is the same as REGION_IO_ATTR (used for PERIPH region) but RO instead of RW.~~
_Edit:_ REGION_IO_ATTR configures the MPU region to device-memory with RW access, which is also used for the PERIPH region. To avoid complicating things unnecessarily, we use this type instead of defining a new device-RO. 

The size is reduced to 512 bytes, because RM0477 table 28 and chapter 5.3.12 state that this read-only flash area has a size of 512 bytes.

I introduced this region with PR #97364, both configurations work, but it is more correct with this one.

Testing: Network still initializes with this changes (reads uniqe device ID for creating the mac address per default). 
Cross-check: Will mem-fault during zephyr init when commenting out this `MPU_REGION_ENTRY`.

Open question: Create a `#define` for this type? `REGION_IO_ATTR_RO` for example