### PR TITLE
net: l2: ppp: Add support for LCP MRU negotiation

### DIFF
--- a/subsys/net/l2/ppp/Kconfig
+++ b/subsys/net/l2/ppp/Kconfig
@@ -60,6 +60,13 @@ config NET_L2_PPP_OPTION_MRU
 	help
 	  Enable support for LCP MRU option.
 
+config NET_L2_PPP_OPTION_MAX_MRU
+	int "LCP MRU maximum size"
+	default 1500
+	help
+	  Set the maximal MRU size which is allowed while negotiation with peer over LCP.
+	  The default value is defined by RFC 1661.
+
 config NET_L2_PPP_OPTION_SERVE_IP
 	bool "Serve IP address to peer"
 	help


### PR DESCRIPTION
Previously, the LCP MRU option sent by the peer was ignored. This could result in the interface MTU remaining at the default (1500), even if the peer requested a smaller MRU, potentially leading to packet loss. This commit adds parsing for the peer's MRU option and updates the network interface MTU accordingly.