### PR TITLE
net: config: sntp: Asynchronous resynchronization

### DIFF
--- a/subsys/net/lib/config/Kconfig
+++ b/subsys/net/lib/config/Kconfig
@@ -249,6 +249,7 @@ config NET_CONFIG_SNTP_INIT_TIMEOUT
 
 config NET_CONFIG_SNTP_INIT_RESYNC
 	bool "Resync system clock using SNTP periodically"
+	depends on NET_SOCKETS_SERVICE
 	help
 	  Perform an SNTP request over networking periodically to get and
 	  absolute wall clock time, and resync system time from it.

--- a/subsys/net/lib/config/init_clock_sntp.c
+++ b/subsys/net/lib/config/init_clock_sntp.c
@@ -124,10 +124,232 @@ end:
 }
 
 #ifdef CONFIG_NET_CONFIG_SNTP_INIT_RESYNC
-static void sntp_resync_handler(struct k_work *work)
+#define SNTP_SERVER_PORT 123
+
+static void sntp_async_service_handler(struct net_socket_service_event *pev);
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(sntp_service_async, sntp_async_service_handler, 1);
+
+static void sntp_async_timeout(struct k_work *work);
+static K_WORK_DELAYABLE_DEFINE(sntp_async_timeout_work, sntp_async_timeout);
+
+static struct sntp_ctx sntp_async_ctx;
+static struct net_sockaddr_storage sntp_addr;
+static net_socklen_t sntp_addrlen;
+
+static void sntp_async_timeout(struct k_work *work)
 {
 	ARG_UNUSED(work);
-	(void)net_init_clock_via_sntp();
+
+	LOG_WRN("SNTP query timed out");
+
+	sntp_close_async(&sntp_service_async);
+
+	/* No response, reschedule */
+	k_work_reschedule(&sntp_resync_work_handle, RESYNC_FAILED_INTERVAL);
+}
+
+static void sntp_async_service_handler(struct net_socket_service_event *pev)
+{
+	struct sntp_time ts;
+	int ret;
+
+	ret = sntp_read_async(pev, &ts);
+	if (ret < 0) {
+		LOG_ERR("Failed to read SNTP response (%d)", ret);
+		goto out;
+	}
+
+	ret = sntp_set_clocks(&ts);
+
+out:
+	/* Close the service */
+	sntp_close_async(&sntp_service_async);
+
+	k_work_cancel_delayable(&sntp_async_timeout_work);
+
+	if (ret < 0) {
+		k_work_reschedule(&sntp_resync_work_handle, RESYNC_FAILED_INTERVAL);
+	}
+}
+
+static int sntp_query_async(struct net_sockaddr *addr, net_socklen_t addrlen)
+{
+	int ret;
+
+	ret = sntp_init_async(&sntp_async_ctx, addr, addrlen, &sntp_service_async);
+	if (ret < 0) {
+		LOG_ERR("Failed to initialize SNTP context (%d)", ret);
+		goto end;
+	}
+
+	ret = sntp_send_async(&sntp_async_ctx);
+	if (ret < 0) {
+		LOG_ERR("Failed to send SNTP query (%d)", ret);
+		sntp_close_async(&sntp_service_async);
+		goto end;
+	}
+
+	k_work_reschedule(&sntp_async_timeout_work,
+			  K_MSEC(CONFIG_NET_CONFIG_SNTP_INIT_TIMEOUT));
+
+end:
+	return ret;
+}
+
+static void dns_result_cb(enum dns_resolve_status status,
+			  struct dns_addrinfo *info,
+			  void *user_data)
+{
+	int ret;
+
+	if (status == DNS_EAI_CANCELED || status == DNS_EAI_FAIL) {
+		/* If IPv4 query failed, try IPv6. Otherwise, just schedule next retry. */
+		if (sntp_addr.ss_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV6)) {
+			sntp_addr.ss_family = NET_AF_INET6;
+			sntp_addrlen = 0;
+
+			ret = dns_get_addr_info(CONFIG_NET_CONFIG_SNTP_INIT_SERVER,
+						DNS_QUERY_TYPE_AAAA, NULL, dns_result_cb,
+						NULL, CONFIG_NET_CONFIG_SNTP_INIT_TIMEOUT);
+			if (ret == 0) {
+				return;
+			}
+		}
+
+		LOG_WRN("DNS query timed out");
+
+		k_work_reschedule(&sntp_resync_work_handle, RESYNC_FAILED_INTERVAL);
+
+		return;
+	}
+
+	if (status == DNS_EAI_ALLDONE) {
+		/* If address was found, schedule SNTP query, if that fails schedule next retry. */
+		ret = sntp_query_async(net_sad(&sntp_addr), sntp_addrlen);
+		if (ret < 0) {
+			k_work_reschedule(&sntp_resync_work_handle, RESYNC_FAILED_INTERVAL);
+		}
+
+		return;
+	}
+
+	if (status == DNS_EAI_INPROGRESS && info != NULL) {
+		if (sntp_addrlen > 0) {
+			/* Already got address, skip others. */
+			return;
+		}
+
+		if (IS_ENABLED(CONFIG_NET_IPV4) && info->ai_family == NET_AF_INET) {
+			sntp_addrlen = info->ai_addrlen;
+			sntp_addr.ss_family = NET_AF_INET;
+			net_ipv4_addr_copy_raw(net_sin(net_sad(&sntp_addr))->sin_addr.s4_addr,
+					       net_sin(&info->ai_addr)->sin_addr.s4_addr);
+		} else if (IS_ENABLED(CONFIG_NET_IPV6) && info->ai_family == NET_AF_INET6) {
+			sntp_addrlen = info->ai_addrlen;
+			sntp_addr.ss_family = NET_AF_INET6;
+			net_ipv6_addr_copy_raw(net_sin6(net_sad(&sntp_addr))->sin6_addr.s6_addr,
+					       net_sin6(&info->ai_addr)->sin6_addr.s6_addr);
+		} else {
+			/* Ignore. */
+			return;
+		}
+
+		(void)net_port_set_default(net_sad(&sntp_addr), SNTP_SERVER_PORT);
+	}
+}
+
+static int dns_query_async(void)
+{
+	enum dns_query_type type;
+	int ret;
+
+	memset(&sntp_addr, 0, sizeof(sntp_addr));
+	sntp_addrlen = 0;
+
+	if (IS_ENABLED(CONFIG_DNS_RESOLVER)) {
+		if (IS_ENABLED(CONFIG_NET_IPV4)) {
+			sntp_addr.ss_family = NET_AF_INET;
+			type = DNS_QUERY_TYPE_A;
+		} else {
+			sntp_addr.ss_family = NET_AF_INET6;
+			type = DNS_QUERY_TYPE_AAAA;
+		}
+
+		ret = dns_get_addr_info(CONFIG_NET_CONFIG_SNTP_INIT_SERVER,
+					type, NULL, dns_result_cb,
+					NULL, CONFIG_NET_CONFIG_SNTP_INIT_TIMEOUT);
+		if (ret < 0) {
+			LOG_ERR("Failed to initiate DNS query for SNTP server (%d)", ret);
+		}
+
+		return ret;
+	}
+
+	/* Fallback for IP address string. */
+	if (net_ipaddr_parse(CONFIG_NET_CONFIG_SNTP_INIT_SERVER,
+			     sizeof(CONFIG_NET_CONFIG_SNTP_INIT_SERVER) - 1,
+			     net_sad(&sntp_addr))) {
+		if (IS_ENABLED(CONFIG_NET_IPV4) && sntp_addr.ss_family == NET_AF_INET) {
+			sntp_addrlen = sizeof(struct net_sockaddr_in);
+		} else if (IS_ENABLED(CONFIG_NET_IPV6) && sntp_addr.ss_family == NET_AF_INET6) {
+			sntp_addrlen = sizeof(struct net_sockaddr_in6);
+		} else {
+			/* Unsupported family */
+			return -EINVAL;
+		}
+
+		ret = net_port_set_default(net_sad(&sntp_addr), SNTP_SERVER_PORT);
+		if (ret < 0) {
+			return ret;
+		}
+
+		ret = sntp_query_async(net_sad(&sntp_addr), sntp_addrlen);
+	} else {
+		LOG_ERR("Failed to parse SNTP server address, enable CONFIG_DNS_RESOLVER");
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
+static void sntp_resync_handler(struct k_work *work)
+{
+	int ret;
+
+	ARG_UNUSED(work);
+
+#ifdef CONFIG_NET_CONFIG_SNTP_INIT_SERVER_USE_DHCPV4_OPTION
+	struct net_if *iface = net_if_get_default();
+
+	if (!net_ipv4_is_addr_unspecified(&iface->config.dhcpv4.ntp_addr)) {
+		sntp_addrlen = sizeof(struct net_sockaddr_in);
+		sntp_addr.ss_family = NET_AF_INET;
+		net_ipv4_addr_copy_raw(net_sin(net_sad(&sntp_addr))->sin_addr.s4_addr,
+					       iface->config.dhcpv4.ntp_addr.s4_addr);
+		net_sin(net_sad(&sntp_addr))->sin_port = net_htons(SNTP_SERVER_PORT);
+
+		ret = sntp_query_async(net_sad(&sntp_addr), sntp_addrlen);
+		if (ret < 0) {
+			LOG_ERR("Cannot set time using SNTP: %d", ret);
+		}
+
+		goto out;
+	}
+
+	if (sizeof(CONFIG_NET_CONFIG_SNTP_INIT_SERVER) == 1) {
+		/* Empty address, skip using SNTP via Kconfig defaults */
+		ret = -EINVAL;
+		goto out;
+	}
+#endif
+
+	ret = dns_query_async();
+
+#ifdef CONFIG_NET_CONFIG_SNTP_INIT_SERVER_USE_DHCPV4_OPTION
+out:
+#endif
+	k_work_reschedule(&sntp_resync_work_handle,
+			  (ret < 0) ? RESYNC_FAILED_INTERVAL : RESYNC_INTERVAL);
 }
 #endif /* CONFIG_NET_CONFIG_SNTP_INIT_RESYNC */
 

--- a/subsys/net/lib/config/init_clock_sntp.c
+++ b/subsys/net/lib/config/init_clock_sntp.c
@@ -18,6 +18,8 @@ LOG_MODULE_DECLARE(net_config, CONFIG_NET_CONFIG_LOG_LEVEL);
 #ifdef CONFIG_NET_CONFIG_SNTP_INIT_RESYNC
 static void sntp_resync_handler(struct k_work *work);
 static K_WORK_DELAYABLE_DEFINE(sntp_resync_work_handle, sntp_resync_handler);
+#define RESYNC_FAILED_INTERVAL K_SECONDS(CONFIG_NET_CONFIG_SNTP_INIT_RESYNC_ON_FAILURE_INTERVAL)
+#define RESYNC_INTERVAL K_SECONDS(CONFIG_NET_CONFIG_SNTP_INIT_RESYNC_INTERVAL)
 #endif
 
 BUILD_ASSERT(
@@ -115,10 +117,8 @@ int net_init_clock_via_sntp(void)
 
 end:
 #ifdef CONFIG_NET_CONFIG_SNTP_INIT_RESYNC
-	k_work_reschedule(
-		&sntp_resync_work_handle,
-		(res < 0) ? K_SECONDS(CONFIG_NET_CONFIG_SNTP_INIT_RESYNC_ON_FAILURE_INTERVAL)
-			  : K_SECONDS(CONFIG_NET_CONFIG_SNTP_INIT_RESYNC_INTERVAL));
+	k_work_reschedule(&sntp_resync_work_handle,
+			  (res < 0) ? RESYNC_FAILED_INTERVAL : RESYNC_INTERVAL);
 #endif
 	return res;
 }


### PR DESCRIPTION
Make SNTP resynchronization asynchronous, so that it doesn't block the system work queue while waiting for response.

Fixes #99634