### PR TITLE
sysbuild: cmake: Only touch empty conf file if it does not exist

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
@@ -86,7 +86,9 @@ if(NOT EXISTS "${APPLICATION_CONFIG_DIR}")
 endif()
 
 # Empty files to make kconfig.py happy.
-file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/empty.conf)
+if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/empty.conf)
+  file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/empty.conf)
+endif()
 set(APPLICATION_SOURCE_DIR ${sysbuild_toplevel_SOURCE_DIR})
 set(AUTOCONF_H             ${CMAKE_CURRENT_BINARY_DIR}/autoconf.h)
 set(CONF_FILE              ${SB_CONF_FILE})


### PR DESCRIPTION
Prevents a random occurance whereby sysbuild reconfigures itself after a reconfiguration for no known discernable reason