### PR TITLE
drivers: usb: udc: fix OTGHS on STM32F7 SoCs with USBPHYC

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1421,6 +1421,11 @@ static int priv_clock_enable(void)
 	#if UDC_STM32_NODE_PHY_ITFACE(DT_DRV_INST(0)) == PCD_PHY_ULPI
 		LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 	#elif UDC_STM32_NODE_PHY_ITFACE(DT_DRV_INST(0)) == PCD_PHY_UTMI
+		/*
+		 * For some reason, the ULPI clock still needs to be
+		 * enabled when the internal USBPHYC HS PHY is used.
+		 */
+		LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 		LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_OTGPHYC);
 	#endif
 #else /* CONFIG_SOC_SERIES_STM32F2X || CONFIG_SOC_SERIES_STM32F4X */


### PR DESCRIPTION
From testing on STM32F723E-DISCO, it seems necessary to enable `OTGHSULPI` clock in addition to `USBPHYC` when the internal `USBPHYC` HS PHY is used. (`USBPHYC` is found on STM32F723xx, STM32F730Z8 and STM32F730I8 SoCs)