### PR TITLE
subsys: tracing: sysview: add config option to name selected ISRs.

### DIFF
--- a/subsys/tracing/sysview/Kconfig
+++ b/subsys/tracing/sysview/Kconfig
@@ -32,4 +32,11 @@ config SEGGER_SYSVIEW_SECTION_DTCM
 
 endchoice
 
+config SEGGER_SYSVIEW_CUSTOM_ISR_NAMES
+	string "SystemView ISR name descriptions"
+	help
+	  Custom ISR name descriptions for SystemView tracing.
+	  Format: "I#<num>=<name>, I#<num>=<name>, ..."
+	  Example: "I#33=RTC1, I#19=SPI0/TWI0"
+
 endif

--- a/subsys/tracing/sysview/sysview_config.c
+++ b/subsys/tracing/sysview/sysview_config.c
@@ -62,7 +62,9 @@ static void cbSendSystemDesc(void)
 	SEGGER_SYSVIEW_SendSysDesc("C=" CONFIG_BOARD_QUALIFIERS);
 #endif
 
-#ifdef CONFIG_SYMTAB
+#ifdef CONFIG_SEGGER_SYSVIEW_CUSTOM_ISR_NAMES
+	SEGGER_SYSVIEW_SendSysDesc(CONFIG_SEGGER_SYSVIEW_CUSTOM_ISR_NAMES);
+#elif defined(CONFIG_SYMTAB)
 	char isr_desc[SEGGER_SYSVIEW_MAX_STRING_LEN];
 
 	for (int idx = 0; idx < IRQ_TABLE_SIZE; idx++) {


### PR DESCRIPTION
This commit allows a user to select specific ISRs to be named in the SystemView output. The format for the option value is as described in the SystemView documentation, e.g. "I#33=RTC1, I#19=SPI0/TWI0".