### PR TITLE
xtensa: fix unused func warning on l2_page_tables_counter_inc

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -336,7 +336,7 @@ static inline uint32_t *alloc_l2_table(void)
 
 	for (idx = 0; idx < CONFIG_XTENSA_MMU_NUM_L2_TABLES; idx++) {
 		if (l2_page_tables_counter[idx] == 0) {
-			l2_page_tables_counter[idx] = 1;
+			l2_page_tables_counter_inc(l2_page_tables[idx]);
 			ret = (uint32_t *)&l2_page_tables[idx];
 			break;
 		}


### PR DESCRIPTION
xt-clang complains about l2_page_tables_counter_inc() being unused but not GCC. So fix that by using it somewhere else.

Fixes #99753