### PR TITLE
boards: shields: Add support for Semtech SX1261MB2BAS LoRa shield

### DIFF
--- a/boards/shields/semtech_sx1261mb2bas/Kconfig.shield
+++ b/boards/shields/semtech_sx1261mb2bas/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Carlo Caione <carlo.caione@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_SEMTECH_SX1261MB2BAS
+	def_bool $(shields_list_contains,semtech_sx1261mb2bas)

--- a/boards/shields/semtech_sx1261mb2bas/doc/index.rst
+++ b/boards/shields/semtech_sx1261mb2bas/doc/index.rst
@@ -1,0 +1,65 @@
+.. _semtech_sx1261mb2bas:
+
+Semtech SX1261MB2BAS LoRa Shield
+################################
+
+Overview
+********
+
+The Semtech SX1261MB2BAS LoRa shield is an Arduino
+compatible shield based on the SX1261 LoRa transceiver
+from Semtech.
+
+More information about the shield can be found
+at the `mbed SX126xMB2xAS website`_.
+
+Pins Assignment of the Semtech SX1261MB2BAS LoRa Shield
+=======================================================
+
++-----------------------+-----------------+
+| Shield Connector Pin  | Function        |
++=======================+=================+
+| A0                    | SX1261 RESET    |
++-----------------------+-----------------+
+| D3                    | SX1261 BUSY     |
++-----------------------+-----------------+
+| D5                    | SX1261 DIO1     |
++-----------------------+-----------------+
+| D7                    | SX1261 SPI NSS  |
++-----------------------+-----------------+
+| D8                    | SX1261 ANT SW   |
++-----------------------+-----------------+
+| D11                   | SX1261 SPI MOSI |
++-----------------------+-----------------+
+| D12                   | SX1261 SPI MISO |
++-----------------------+-----------------+
+| D13                   | SX1261 SPI SCK  |
++-----------------------+-----------------+
+
+The SX1261 signals DIO2 and DIO3 are not available at the shield connector.
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration
+for Arduino connectors (see :ref:`shields` for more details).
+
+Programming
+***********
+
+Set ``--shield semtech_sx1261mb2bas`` when you invoke ``west build``. For
+example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/lorawan/class_a
+   :board: nucleo_f429zi
+   :shield: semtech_sx1261mb2bas
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _mbed SX126xMB2xAS website:
+   https://os.mbed.com/components/SX126xMB2xAS/

--- a/boards/shields/semtech_sx1261mb2bas/semtech_sx1261mb2bas.overlay
+++ b/boards/shields/semtech_sx1261mb2bas/semtech_sx1261mb2bas.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Carlo Caione <carlo.caione@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
+/ {
+	aliases {
+		lora0 = &lora_semtech_sx1261mb2bas;
+	};
+};
+
+&arduino_spi {
+	status = "okay";
+
+	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>;
+
+	lora_semtech_sx1261mb2bas: sx1261@0 {
+		compatible = "semtech,sx1261";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+		label = "SX1261";
+		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_A0 GPIO_ACTIVE_LOW>;
+		busy-gpios = <&arduino_header ARDUINO_HEADER_R3_D3 GPIO_ACTIVE_HIGH>;
+		antenna-enable-gpios = <&arduino_header ARDUINO_HEADER_R3_D8 GPIO_ACTIVE_HIGH>;
+		dio1-gpios = <&arduino_header ARDUINO_HEADER_R3_D5 GPIO_ACTIVE_HIGH>;
+		dio2-tx-enable;
+		tcxo-power-startup-delay-ms = <5>;
+	};
+};

--- a/boards/shields/semtech_sx1261mb2bas/shield.yml
+++ b/boards/shields/semtech_sx1261mb2bas/shield.yml
@@ -1,0 +1,6 @@
+shield:
+  name: semtech_sx1261mb2bas
+  full_name: Semtech SX1261MB2BAS LoRa Shield
+  vendor: semtech
+  supported_features:
+    - lora


### PR DESCRIPTION
Add board shield definition for the Semtech `SX1261MB2BAS` LoRa module. This is mostly copied over from `semtech_sx1262mb2das`.