### PR TITLE
Fix doc build on 4.1 branch

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -12,13 +12,7 @@ on:
   pull_request:
 
 env:
-  # NOTE: west docstrings will be extracted from the version listed here
-  WEST_VERSION: 1.2.0
-  # The latest CMake available directly with apt is 3.18, but we need >=3.20
-  # so we fetch that through pip.
-  CMAKE_VERSION: 3.20.5
-  DOXYGEN_VERSION: 1.12.0
-  JOB_COUNT: 4
+  JOB_COUNT: 8
 
 jobs:
   doc-file-check:
@@ -59,62 +53,77 @@ jobs:
     name: "Documentation Build (HTML)"
     needs: [doc-file-check]
     if: >
-      github.repository_owner == 'zephyrproject-rtos' &&
-        ( needs.doc-file-check.outputs.file_check == 'true' || github.event_name != 'pull_request' )
-    runs-on: ubuntu-24.04
-    timeout-minutes: 90
+      needs.doc-file-check.outputs.file_check == 'true' || github.event_name != 'pull_request'
+    runs-on:
+      group: zephyr-runner-v2-linux-x64-4xlarge
+    container:
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.6.20251003
+      options: '--entrypoint /bin/bash'
+    timeout-minutes: 20
     concurrency:
       group: doc-build-html-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      BASE_REF: ${{ github.base_ref }}
+
 
     steps:
-    - name: install-pkgs
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y wget python3-pip git ninja-build graphviz lcov
-        wget --no-verbose "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
-        sudo tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz -C /opt
-        echo "/opt/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH
-        echo "${HOME}/.local/bin" >> $GITHUB_PATH
 
-    - name: checkout
-      uses: actions/checkout@v4
+    - name: Print cloud service information
+      run: |
+        echo "ZEPHYR_RUNNER_CLOUD_PROVIDER = ${ZEPHYR_RUNNER_CLOUD_PROVIDER}"
+        echo "ZEPHYR_RUNNER_CLOUD_NODE = ${ZEPHYR_RUNNER_CLOUD_NODE}"
+        echo "ZEPHYR_RUNNER_CLOUD_POD = ${ZEPHYR_RUNNER_CLOUD_POD}"
+
+    - name: Apply container owner mismatch workaround
+      run: |
+        # FIXME: The owner UID of the GITHUB_WORKSPACE directory may not
+        #        match the container user UID because of the way GitHub
+        #        Actions runner is implemented. Remove this workaround when
+        #        GitHub comes up with a fundamental fix for this problem.
+        git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+    - name: Clone cached Zephyr repository
+      continue-on-error: true
+      run: |
+        git clone --shared /repo-cache/zephyrproject/zephyr .
+        git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+
+    - name: Checkout
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
-        path: zephyr
 
-    - name: Rebase
-      if: github.event_name == 'pull_request'
-      continue-on-error: true
-      env:
-        BASE_REF: ${{ github.base_ref }}
-        PR_HEAD: ${{ github.event.pull_request.head.sha }}
-      working-directory: zephyr
+    - name: Environment Setup
       run: |
-        git config --global user.email "actions@zephyrproject.org"
-        git config --global user.name "Github Actions"
-        rm -fr ".git/rebase-apply"
-        rm -fr ".git/rebase-merge"
-        git rebase origin/${BASE_REF}
-        git clean -f -d
-        git log --graph --oneline HEAD...${PR_HEAD}
+        if [ "${{github.event_name}}" = "pull_request" ]; then
+          git config --global user.email "bot@zephyrproject.org"
+          git config --global user.name "Zephyr Builder"
+          rm -fr ".git/rebase-apply"
+          rm -fr ".git/rebase-merge"
+          git rebase origin/${BASE_REF}
+          git clean -f -d
+          git log  --pretty=oneline | head -n 10
+        fi
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-    - name: Setup Zephyr project
-      uses: zephyrproject-rtos/action-zephyr-setup@v1
-      with:
-        app-path: zephyr
-        toolchains: 'all'
+        west init -l . || true
+        west config manifest.group-filter -- +ci,+optional
+        west config --global update.narrow true
+        west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
+        west forall -c 'git reset --hard HEAD'
 
-    - name: install-pip
-      working-directory: zephyr
+        echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
+
+    - name: Install Python packages required for documentation build
       run: |
         pip install -r doc/requirements.txt
         pip install coverxygen
 
-    - name: build-docs
+    - name: Build HTML documentation
       shell: bash
-      working-directory: zephyr
       run: |
         if [[ "$GITHUB_REF" =~ "refs/tags/v" ]]; then
           DOC_TAG="release"
@@ -139,26 +148,26 @@ jobs:
         lcov --remove doc-coverage.info \*/deprecated > new.info
         genhtml --no-function-coverage --no-branch-coverage new.info -o coverage-report
 
-    - name: compress-docs
-      working-directory: zephyr
+    - name: Compress documentation build artifacts
       run: |
         tar --use-compress-program="xz -T0" -cf html-output.tar.xz --exclude html/_sources --exclude html/doxygen/xml --directory=doc/_build html
         tar --use-compress-program="xz -T0" -cf api-output.tar.xz --directory=doc/_build html/doxygen/html
         tar --use-compress-program="xz -T0" -cf api-coverage.tar.xz coverage-report
 
-    - name: upload-build
-      uses: actions/upload-artifact@v4
+    - name: Upload HTML output
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: html-output
-        path: zephyr/html-output.tar.xz
+        path: html-output.tar.xz
 
-    - name: upload-api-coverage
-      uses: actions/upload-artifact@v4
+    - name: Upload Doxygen coverage artifacts
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: api-coverage
-        path: zephyr/api-coverage.tar.xz
+        path: api-coverage.tar.xz
 
-    - name: process-pr
+
+    - name: Summarize PR documentation URLs
       if: github.event_name == 'pull_request'
       run: |
         REPO_NAME="${{ github.event.repository.name }}"
@@ -172,8 +181,8 @@ jobs:
         echo "API Documentation will be available shortly at: ${API_DOC_URL}" >> $GITHUB_STEP_SUMMARY
         echo "API Coverage Report will be available shortly at: ${API_COVERAGE_URL}" >> $GITHUB_STEP_SUMMARY
 
-    - name: upload-pr-number
-      uses: actions/upload-artifact@v4
+    - name: Upload PR number
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: github.event_name == 'pull_request'
       with:
         name: pr_num

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -764,7 +764,6 @@ struct bt_bap_stream {
 	void *user_data;
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT) || defined(__DOXYGEN__)
-	/** @cond INTERNAL_HIDDEN */
 	/**
 	 * @brief Audio ISO reference
 	 *
@@ -781,6 +780,7 @@ struct bt_bap_stream {
 	uint16_t _prev_seq_num;
 #endif /* CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM */
 
+	/** @cond INTERNAL_HIDDEN */
 	/** Internally used list node */
 	sys_snode_t _node;
 	/** @endcond */


### PR DESCRIPTION
Running full documentation build on GH hosted runners is not really working for us anymore as we run out of disk space. Switch (back) to our self-hosted runners.

Cherry-picked from 0a9c7634a02a9e76f6779363f3561a7cc2e21c78 with adaptations for 4.1

Fixes #99771.