### PR TITLE
include: xen: public: hvm: add HVM_PARAM_MAGIC_BASE_PFN key in hvm

### DIFF
--- a/include/zephyr/xen/public/hvm/params.h
+++ b/include/zephyr/xen/public/hvm/params.h
@@ -33,6 +33,7 @@
  */
 #define HVM_PARAM_STORE_PFN		1
 #define HVM_PARAM_STORE_EVTCHN		2
+#define HVM_PARAM_MAGIC_BASE_PFN	3
 
 /* Console debug shared memory ring and event channel */
 #define HVM_PARAM_CONSOLE_PFN		17


### PR DESCRIPTION
This is a item needs to compiling zephyr-xenlib that were omitted in commit #95556, so I will add them.

---

Add a new HVMOP key HVM_PARAM_MAGIC_BASE_PFN for storing the magic page region base PFN. The value will be set at Dom0less DomU construction time after Dom0less DomU's magic page region has been allocated.

HACK. to indicate that Xen upstream work is in progress and things may change.

[1] https://patchew.org/Xen/20240426031455.579637-1-xin.wang2@amd.com/20240426031455.579637-3-xin.wang2@amd.com/
[2] https://patchew.org/Xen/alpine.DEB.2.22.394.2405241552240.2557291@ubuntu-linux-20-04-desktop/

Acked-by: Dmytro Firsov <dmytro_firsov@epam.com>