### PR TITLE
kernel: move_thread_to_end_of_prio_q() simplfication

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -72,7 +72,7 @@ void z_sched_start(struct k_thread *thread);
 void z_ready_thread(struct k_thread *thread);
 void z_requeue_current(struct k_thread *curr);
 struct k_thread *z_swap_next_thread(void);
-void move_thread_to_end_of_prio_q(struct k_thread *thread);
+void move_current_to_end_of_prio_q(void);
 bool thread_is_sliceable(struct k_thread *thread);
 
 static inline void z_reschedule_unlocked(void)

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -53,7 +53,6 @@ extern struct k_spinlock _sched_spinlock;
 extern struct k_thread _thread_dummy;
 
 void z_sched_init(void);
-void z_move_thread_to_end_of_prio_q(struct k_thread *thread);
 void z_unpend_thread_no_timeout(struct k_thread *thread);
 struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q);
 int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -352,10 +352,11 @@ void z_ready_thread(struct k_thread *thread)
 	}
 }
 
-void z_move_thread_to_end_of_prio_q(struct k_thread *thread)
+/* This routine only used for testing purposes */
+void z_yield_testing_only(void)
 {
 	K_SPINLOCK(&_sched_spinlock) {
-		move_thread_to_end_of_prio_q(thread);
+		move_thread_to_end_of_prio_q(_current);
 	}
 }
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -243,10 +243,8 @@ static ALWAYS_INLINE struct k_thread *next_up(void)
 
 void move_current_to_end_of_prio_q(void)
 {
-	if (z_is_thread_queued(_current)) {
-		dequeue_thread(_current);
-	}
-	queue_thread(_current);
+	runq_yield();
+
 	update_cache(1);
 }
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -241,13 +241,13 @@ static ALWAYS_INLINE struct k_thread *next_up(void)
 #endif /* CONFIG_SMP */
 }
 
-void move_thread_to_end_of_prio_q(struct k_thread *thread)
+void move_current_to_end_of_prio_q(void)
 {
-	if (z_is_thread_queued(thread)) {
-		dequeue_thread(thread);
+	if (z_is_thread_queued(_current)) {
+		dequeue_thread(_current);
 	}
-	queue_thread(thread);
-	update_cache(thread == _current);
+	queue_thread(_current);
+	update_cache(1);
 }
 
 /* Track cooperative threads preempted by metairqs so we can return to
@@ -356,7 +356,7 @@ void z_ready_thread(struct k_thread *thread)
 void z_yield_testing_only(void)
 {
 	K_SPINLOCK(&_sched_spinlock) {
-		move_thread_to_end_of_prio_q(_current);
+		move_current_to_end_of_prio_q();
 	}
 }
 

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -123,7 +123,7 @@ void z_time_slice(void)
 		}
 #endif
 		if (!z_is_thread_prevented_from_running(curr)) {
-			move_thread_to_end_of_prio_q(curr);
+			move_current_to_end_of_prio_q();
 		}
 		z_reset_time_slice(curr);
 	}

--- a/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
@@ -21,6 +21,8 @@
 #define PRIORITY 0
 #define DB_VAL   0xDEADBEEF
 
+extern void z_yield_testing_only(void);
+
 static struct k_thread user_thread;
 static K_THREAD_STACK_DEFINE(user_thread_stack, 1024 + CONFIG_TEST_EXTRA_STACK_SIZE);
 
@@ -90,7 +92,7 @@ void arm_isr_handler(const void *args)
 
 		/* Trigger thread yield() manually */
 		(void)irq_lock();
-		z_move_thread_to_end_of_prio_q(_current);
+		z_yield_testing_only();
 		SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
 		irq_unlock(0);
 

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -36,7 +36,7 @@
 #define FPSCR_MASK (0xffffffffU)
 #endif
 
-extern void z_move_thread_to_end_of_prio_q(struct k_thread *thread);
+extern void z_yield_testing_only(void);
 
 static struct k_thread alt_thread;
 static K_THREAD_STACK_DEFINE(alt_thread_stack, 1024 + CONFIG_TEST_EXTRA_STACK_SIZE);
@@ -268,7 +268,7 @@ static void alt_thread_entry(void *p1, void *p2, void *p3)
 	p_ztest_thread->arch.swap_return_value = SWAP_RETVAL;
 #endif
 
-	z_move_thread_to_end_of_prio_q(_current);
+	z_yield_testing_only();
 
 	/* Modify the callee-saved registers by zero-ing them.
 	 * The main test thread will, later, assert that they
@@ -482,7 +482,7 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 	 * explicitly required by the test.
 	 */
 	(void)irq_lock();
-	z_move_thread_to_end_of_prio_q(_current);
+	z_yield_testing_only();
 
 	/* Clear the thread's callee-saved registers' container.
 	 * The container will, later, be populated by the swap


### PR DESCRIPTION
Every time that _move_thread_to_end_of_prio_q()_ is called, the thread being operated upon is __current_. This presents an opportunity for simplification. Furthermore, its logic simplifies to the same as k_yield(), but without the schedule point.