### PR TITLE
drivers: espi: npcx: workaround for missed IRQ1/12 on NPCX9M7FB

### DIFF
--- a/drivers/espi/Kconfig.npcx
+++ b/drivers/espi/Kconfig.npcx
@@ -88,6 +88,14 @@ config ESPI_NPCX_PERIPHERAL_DEBUG_PORT_80_RING_BUF_SIZE
 	  The size of the ring buffer in byte used by the Port80 ISR to store
 	  Postcodes from Host.
 
+config ESPI_NPCX_i8042_KBC_AUX_VWIRE_IRQ_WORKAROUND
+	bool
+	default y if SOC_NPCX9M7FB
+	help
+	  This option enables the workaround to prevent missing IRQ1/IRQ12 when the
+	  firmware writes data to the output buffer immediately after detecting that
+	  the buffer is empty.
+
 config ESPI_NPCX_VWIRE_ENABLE_SEND_CHECK
 	bool "Check the value was read by host after wire bits changed"
 	help

--- a/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
@@ -713,6 +713,7 @@ struct espi_reg {
 #define NPCX_ESPISTS_BMBURSTDONE         23
 #define NPCX_ESPISTS_ESPIRST_LVL         24
 #define NPCX_ESPISTS_AUTO_RD_DIS_STS     29
+#define NPCX_STATUS_IMG_VWIRE_AVAIL      6
 #define NPCX_VWSWIRQ_IRQ_NUM             FIELD(0, 7)
 #define NPCX_VWSWIRQ_IRQ_LVL             7
 #define NPCX_VWSWIRQ_INDEX               FIELD(8, 7)
@@ -977,6 +978,8 @@ struct kbc_reg {
 #define NPCX_HICTRL_PMIOCIE 5
 #define NPCX_HICTRL_PMICIE  6
 #define NPCX_HICTRL_FW_OBF  7
+#define NPCX_HIIRQC_IRQ1B   0
+#define NPCX_HIIRQC_IRQ12B  1
 #define NPCX_HIKMST_OBF     0
 #define NPCX_HIKMST_IBF     1
 #define NPCX_HIKMST_F0      2


### PR DESCRIPTION
When the firmware writes data to the KBC/AUX output buffer, the hardware automatically generates IRQ1/12 to notify the host. After the host read the data, the EC received an output buffer empty (OBE) interrupt to indicate that the next byte could be written. However, on the NPCX9M7FB, this mechanism may cause IRQ1/12 to be missed if the firmware writes new data immediately after detecting that the output buffer is empty, resulting in incorrect behavior.

To avoid missing IRQ1/12, the flow is modified so that it first checks VWIRE_AVAIL to ensure there are no pending VW events. If no VW event is pending, the firmware writes data to the output buffer and explicitly asserts IRQ1/12 to notify the host. After the host reads the data and the OBE interrupt triggers, the firmware clears IRQ1/12.

This updated sequence prevents IRQ1/12 from being lost and ensures correct notification behavior.