### PR TITLE
drivers: counter: lptmr: Fix get_pending_int wrong implementation

### DIFF
--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -202,11 +202,8 @@ static uint32_t mcux_lptmr_get_pending_int(const struct device *dev)
 {
 	const struct mcux_lptmr_config *config = dev->config;
 	uint32_t mask = LPTMR_CSR_TCF_MASK | LPTMR_CSR_TIE_MASK;
-	uint32_t flags;
 
-	flags = LPTMR_GetStatusFlags(config->base);
-
-	return ((flags & mask) == mask);
+	return (uint32_t)!!((config->base->CSR & mask) == mask);
 }
 
 static uint32_t mcux_lptmr_get_top_value(const struct device *dev)


### PR DESCRIPTION
Originally, function 'mcux_lptmr_get_pending_int' checks if both
TCF and TIE flags are set to determine if an interrupt is pending.
But function 'LPTMR_GetStatusFlags' only returns the status flags,
that is we will never get TIE flag from it. then the function
always returns false.

The correct approach is to read the CSR register directly and check
if both TIE and TCF bits are 1. If yes, there's a pending interrupt;
if not, there isn't.