### PR TITLE
mgmt: mcumgr: grp: img_mgmt: Fix detecting where a slot resides

### DIFF
--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/dfu/flash_img.h>
 #include <zephyr/dfu/mcuboot.h>
@@ -23,11 +24,16 @@ LOG_MODULE_REGISTER(flash_img, CONFIG_IMG_MANAGER_LOG_LEVEL);
 #include <bootutil/bootutil_public.h>
 #endif
 
+#define FIXED_PARTITION_GET_FLASH_NODE(node_id)                                    \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_PARENT(node_id), fixed_subpartitions),   \
+		    (DT_PARENT(DT_GPARENT(node_id))), (DT_GPARENT(node_id)))
+
 #define FIXED_PARTITION_IS_RUNNING_APP_PARTITION(label)                                            \
+	DT_SAME_NODE(FIXED_PARTITION_GET_FLASH_NODE(DT_CHOSEN(zephyr_code_partition)),             \
+		     FIXED_PARTITION_GET_FLASH_NODE(DT_NODELABEL(label))) &&                       \
 	(FIXED_PARTITION_OFFSET(label) <= CONFIG_FLASH_LOAD_OFFSET &&                              \
 	 FIXED_PARTITION_OFFSET(label) + FIXED_PARTITION_SIZE(label) > CONFIG_FLASH_LOAD_OFFSET)
 
-#include <zephyr/devicetree.h>
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) && (CONFIG_TFM_MCUBOOT_IMAGE_NUMBER == 2)
 #define UPLOAD_FLASH_AREA_LABEL slot1_ns_partition
 #else

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
- * Copyright (c) 2022-2024 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -48,7 +48,13 @@
 	to be able to figure out application running slot.
 #endif
 
+#define FIXED_PARTITION_GET_FLASH_NODE(node_id)                                    \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_PARENT(node_id), fixed_subpartitions),   \
+		    (DT_PARENT(DT_GPARENT(node_id))), (DT_GPARENT(node_id)))
+
 #define FIXED_PARTITION_IS_RUNNING_APP_PARTITION(label)                                            \
+	DT_SAME_NODE(FIXED_PARTITION_GET_FLASH_NODE(DT_CHOSEN(zephyr_code_partition)),             \
+		     FIXED_PARTITION_GET_FLASH_NODE(DT_NODELABEL(label))) &&                       \
 	(FIXED_PARTITION_OFFSET(label) <= CONFIG_FLASH_LOAD_OFFSET &&                              \
 	 FIXED_PARTITION_OFFSET(label) + FIXED_PARTITION_SIZE(label) > CONFIG_FLASH_LOAD_OFFSET)
 

--- a/tests/subsys/dfu/img_util/src/main.c
+++ b/tests/subsys/dfu/img_util/src/main.c
@@ -6,13 +6,20 @@
  */
 
 #include <zephyr/ztest.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/dfu/flash_img.h>
 
 #define SLOT0_PARTITION		slot0_partition
 #define SLOT1_PARTITION		slot1_partition
 
+#define FIXED_PARTITION_GET_FLASH_NODE(node_id)                                    \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_PARENT(node_id), fixed_subpartitions),   \
+		    (DT_PARENT(DT_GPARENT(node_id))), (DT_GPARENT(node_id)))
+
 #define FIXED_PARTITION_IS_RUNNING_APP_PARTITION(label)                                            \
+	DT_SAME_NODE(FIXED_PARTITION_GET_FLASH_NODE(DT_CHOSEN(zephyr_code_partition)),             \
+		     FIXED_PARTITION_GET_FLASH_NODE(DT_NODELABEL(label))) &&                       \
 	(FIXED_PARTITION_OFFSET(label) <= CONFIG_FLASH_LOAD_OFFSET &&                              \
 	 FIXED_PARTITION_OFFSET(label) + FIXED_PARTITION_SIZE(label) > CONFIG_FLASH_LOAD_OFFSET)
 


### PR DESCRIPTION
Fixes an issue introduced in commit
32615695ad1b96670be8f2a38a8a9fd27e2d8ae5 which wrongly did not check what the residing device was on before determining if a slot was part of a partition area

Fixes #99762