### PR TITLE
RFC: ADC: add support for injected channels for STM32

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -199,6 +199,8 @@ New APIs and options
   * :c:macro:`ADC_DT_SPEC_INST_GET_BY_IDX_OR`
   * :c:macro:`ADC_DT_SPEC_INST_GET_BY_NAME_OR`
   * :c:macro:`ADC_DT_SPEC_INST_GET_OR`
+  * :c:member:`adc_sequence.priority`
+  * :kconfig:option:`CONFIG_ADC_SEQUENCE_PRIORITY`
 
 * Architectures
 

--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -45,6 +45,22 @@ config ADC_CONFIGURABLE_EXCITATION_CURRENT_SOURCE_PIN
 config ADC_CONFIGURABLE_VBIAS_PIN
 	bool
 
+# By selecting or not this option particular ADC drivers indicate if they
+# support the sequence priority feature.
+config ADC_HAS_SEQUENCE_PRIORITY
+	bool
+
+config ADC_SEQUENCE_PRIORITY
+	bool "Sequence priority support"
+	depends on ADC_HAS_SEQUENCE_PRIORITY
+	help
+	  This option allows assigning a priority to ADC sequences.
+
+	  The priority assigned to a sequence reflects how time-sensitive it is
+	  compared to other sequences. The number of priority levels supported
+	  and the exact behavior obtained by assigning a specific priority to a
+	  sequence are hardware-specific.
+
 config ADC_ASYNC
 	bool "Asynchronous call support"
 	select POLL

--- a/drivers/adc/Kconfig.stm32
+++ b/drivers/adc/Kconfig.stm32
@@ -8,6 +8,8 @@
 # Copyright (c) 2024 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+ADC_STM32_INJECTED_SUPPORT := st,adc-has-injected-support
+
 config ADC_STM32
 	bool "STM32 ADC driver"
 	default y
@@ -15,13 +17,7 @@ config ADC_STM32
 	select PINCTRL
 	select ADC_ASYNC if ADC_STREAM
 	select ADC_HAS_SEQUENCE_PRIORITY if \
-		!SOC_SERIES_STM32C0X && \
-		!SOC_SERIES_STM32F0X && \
-		!SOC_SERIES_STM32G0X && \
-		!SOC_SERIES_STM32L0X && \
-		!SOC_SERIES_STM32U0X && \
-		!SOC_SERIES_STM32WBAX && \
-		!SOC_SERIES_STM32WLX
+		$(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_ADC),$(ADC_STM32_INJECTED_SUPPORT))
 	help
 	  Enable the driver implementation for the stm32xx ADC
 

--- a/drivers/adc/Kconfig.stm32
+++ b/drivers/adc/Kconfig.stm32
@@ -14,6 +14,14 @@ config ADC_STM32
 	depends on DT_HAS_ST_STM32_ADC_ENABLED
 	select PINCTRL
 	select ADC_ASYNC if ADC_STREAM
+	select ADC_HAS_SEQUENCE_PRIORITY if \
+		!SOC_SERIES_STM32C0X && \
+		!SOC_SERIES_STM32F0X && \
+		!SOC_SERIES_STM32G0X && \
+		!SOC_SERIES_STM32L0X && \
+		!SOC_SERIES_STM32U0X && \
+		!SOC_SERIES_STM32WBAX && \
+		!SOC_SERIES_STM32WLX
 	help
 	  Enable the driver implementation for the stm32xx ADC
 
@@ -33,5 +41,19 @@ config ADC_STM32_DMA
 	help
 	  Enable the ADC DMA mode for ADC instances
 	  that enable dma channels in their device tree node.
+
+config ADC_STM32_INJECTED_CHANNELS
+	def_bool y
+	depends on ADC_SEQUENCE_PRIORITY
+	help
+	  Enable the support for injected channels.
+	  To define a sequence as injected, set the `priority` field of the
+	  `struct adc_sequence` to 1. A regular sequence should have a value
+	  of 0. Any other values will return an error.
+	  When using injected channels, it is recommended to setup all channels
+	  that will be used (both regular and injected) before any measurement
+	  is started, because it is not possible to setup a new channel while
+	  conversions are running (typically, one can't configure an injected
+	  channel if a regular conversion is on-going).
 
 endif

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -281,6 +281,7 @@ struct adc_stm32_cfg {
 	bool has_channel_preselection	:1;
 	bool has_differential_support	:1;
 	bool differential_channels_used	:1;
+	bool has_injected_support	:1;
 };
 
 #ifdef CONFIG_ADC_STM32_DMA
@@ -1439,10 +1440,16 @@ static int adc_stm32_read(const struct device *dev,
 	int (*read_fn)(const struct device *dev, const struct adc_sequence *sequence);
 
 #ifdef CONFIG_ADC_STM32_INJECTED_CHANNELS
+	const struct adc_stm32_cfg *config = (const struct adc_stm32_cfg *)dev->config;
 	bool is_injected;
+
 	if (sequence->priority == STM32_REG_SEQ_PRIORITY) {
 		is_injected = false;
 	} else if (sequence->priority == STM32_INJ_SEQ_PRIORITY) {
+		if (!config->has_injected_support) {
+			LOG_ERR("Injected channels are not available on this ADC instance");
+			return -ENOTSUP;
+		}
 		is_injected = true;
 	} else {
 		LOG_ERR("Sequence priority %d is invalid", sequence->priority);
@@ -2373,6 +2380,7 @@ DT_INST_FOREACH_STATUS_OKAY(GENERATE_ISR)
 			DT_INST_PROP(index, st_adc_has_channel_preselection),			\
 		.has_differential_support =							\
 			DT_INST_PROP(index, st_adc_has_differential_support),			\
+		.has_injected_support = DT_INST_PROP(index, st_adc_has_injected_support),	\
 		.sampling_time_table = DT_INST_PROP(index, sampling_times),			\
 		.num_sampling_time_common_channels =						\
 			DT_INST_PROP_OR(index, num_sampling_time_common_channels, 0),		\

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -470,46 +470,65 @@ static void adc_stm32_start_conversion(const struct device *dev)
 #endif
 }
 
-/*
- * Disable ADC peripheral, and wait until it is disabled
+/* If force is true, this function will disable ADC peripheral (forcefully stopping on-going
+ * conversions, if any), and wait until it is disabled before returning 0.
+ * If force is false and there is no on-going conversion, the ADC will be disabled, and the
+ * function will wait until it is disabled before returning 0.
+ * If force is false but there is an on-going conversion, then the ADC won't be disabled, and the
+ * function returns -EBUSY.
  */
-static void adc_stm32_disable(ADC_TypeDef *adc)
+static int adc_stm32_disable(ADC_TypeDef *adc, bool force)
 {
+	int err = 0;
+
 	if (LL_ADC_IsEnabled(adc) != 1UL) {
-		return;
+		return 0;
 	}
 
-	/* Stop ongoing conversion if any
-	 * Software must poll ADSTART (or JADSTART) until the bit is reset before assuming
-	 * the ADC is completely stopped.
-	 */
-
-#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) && \
-	!DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) && !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
 	if (LL_ADC_REG_IsConversionOngoing(adc)) {
-		LL_ADC_REG_StopConversion(adc);
-		while (LL_ADC_REG_IsConversionOngoing(adc)) {
+		if (force) {
+			LL_ADC_REG_StopConversion(adc);
+			while (LL_ADC_REG_IsConversionOngoing(adc)) {
+			}
+		} else {
+			err = -EBUSY;
 		}
+	}
+#else
+	if ((stm32_reg_read(&adc->SR) & LL_ADC_FLAG_STRT) == LL_ADC_FLAG_STRT && !force) {
+		err = -EBUSY;
 	}
 #endif
 
 #ifdef CONFIG_ADC_STM32_INJECTED_CHANNELS
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) && !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
 	if (LL_ADC_INJ_IsConversionOngoing(adc)) {
-		LL_ADC_INJ_StopConversion(adc);
-		while (LL_ADC_INJ_IsConversionOngoing(adc)) {
+		if (force) {
+			LL_ADC_INJ_StopConversion(adc);
+			while (LL_ADC_INJ_IsConversionOngoing(adc)) {
+			}
+		} else {
+			err = -EBUSY;
 		}
+	}
+#else
+	if ((stm32_reg_read(&adc->SR) & LL_ADC_FLAG_JSTRT) == LL_ADC_FLAG_JSTRT && !force) {
+		err = -EBUSY;
 	}
 #endif
 #endif /* CONFIG_ADC_STM32_INJECTED_CHANNELS */
 
-	LL_ADC_Disable(adc);
-
-	/* Wait ADC is fully disabled so that we don't leave the driver into intermediate state
-	 * which could prevent enabling the peripheral
-	 */
-	while (LL_ADC_IsEnabled(adc) == 1UL) {
+	if (err == 0) {
+		LL_ADC_Disable(adc);
+		/* Wait ADC is fully disabled so that we don't leave the driver into intermediate
+		 * state which could prevent enabling the peripheral
+		 */
+		while (LL_ADC_IsEnabled(adc) == 1UL) {
+		}
 	}
+
+	return err;
 }
 
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
@@ -636,7 +655,7 @@ static void adc_stm32_calibration_start(const struct device *dev, bool single_en
 			stm32_reg_modify_bits(&adc->CALFACT2, 0xFFFFFF00UL, 0x03021100UL);
 			__DMB();
 			stm32_reg_set_bits(&adc->CALFACT, ADC_CALFACT_LATCH_COEF);
-			adc_stm32_disable(adc);
+			adc_stm32_disable(adc, true);
 		}
 	}
 	LL_ADC_StartCalibration(adc, LL_ADC_CALIB_OFFSET);
@@ -663,7 +682,7 @@ static void adc_stm32_calibration_start(const struct device *dev, bool single_en
 	}
 }
 
-static int adc_stm32_calibrate(const struct device *dev)
+static int adc_stm32_calibrate(const struct device *dev, bool force)
 {
 	const struct adc_stm32_cfg *config =
 		(const struct adc_stm32_cfg *)dev->config;
@@ -691,7 +710,10 @@ static int adc_stm32_calibrate(const struct device *dev)
 
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) && \
 	!defined(CONFIG_SOC_SERIES_STM32N6X)
-	adc_stm32_disable(adc);
+	err = adc_stm32_disable(adc, force);
+	if (err < 0) {
+		return err;
+	}
 	adc_stm32_calibration_start(dev, true);
 	if (config->differential_channels_used) {
 		adc_stm32_calibration_start(dev, false);
@@ -781,23 +803,23 @@ static const uint32_t table_oversampling_ratio[] = {
  * Function to configure the oversampling scope. It is basically a wrapper over
  * LL_ADC_SetOverSamplingScope() which in addition stops the ADC if needed.
  */
-static void adc_stm32_oversampling_scope(ADC_TypeDef *adc, uint32_t ovs_scope)
+static int adc_stm32_oversampling_scope(ADC_TypeDef *adc, uint32_t ovs_scope)
 {
-#if defined(CONFIG_SOC_SERIES_STM32G0X) || \
-	defined(CONFIG_SOC_SERIES_STM32L0X) || \
-	defined(CONFIG_SOC_SERIES_STM32WLX)
-	/*
-	 * Setting OVS bits is conditioned to ADC state: ADC must be disabled
-	 * or enabled without conversion on going : disable it, it will stop.
-	 * For the G0 series, ADC must be disabled to prevent CKMODE bitfield
-	 * from getting reset, see errata ES0418 section 2.6.4.
+	int err;
+
+	/* Setting OVS bits is conditioned to ADC state: ADC must be disabled
+	 * or enabled without conversion on going : disable it, it will stop
 	 */
 	if (LL_ADC_GetOverSamplingScope(adc) == ovs_scope) {
-		return;
+		return 0;
 	}
-	adc_stm32_disable(adc);
-#endif
-	LL_ADC_SetOverSamplingScope(adc, ovs_scope);
+
+	err = adc_stm32_disable(adc, false);
+	if (err == 0) {
+		LL_ADC_SetOverSamplingScope(adc, ovs_scope);
+	}
+
+	return err;
 }
 
 /*
@@ -805,19 +827,25 @@ static void adc_stm32_oversampling_scope(ADC_TypeDef *adc, uint32_t ovs_scope)
  * wrapper over LL_ADC_SetOverSamplingRatioShift() which in addition stops the
  * ADC if needed.
  */
-static void adc_stm32_oversampling_ratioshift(ADC_TypeDef *adc, uint32_t ratio, uint32_t shift)
+static int adc_stm32_oversampling_ratioshift(ADC_TypeDef *adc, uint32_t ratio, uint32_t shift)
 {
+	int err;
+
 	/*
 	 * setting OVS bits is conditioned to ADC state: ADC must be disabled
 	 * or enabled without conversion on going : disable it, it will stop
 	 */
 	if ((LL_ADC_GetOverSamplingRatio(adc) == ratio)
 	    && (LL_ADC_GetOverSamplingShift(adc) == shift)) {
-		return;
+		return 0;
 	}
-	adc_stm32_disable(adc);
 
-	LL_ADC_ConfigOverSamplingRatioShift(adc, ratio, shift);
+	err = adc_stm32_disable(adc, false);
+	if (err == 0) {
+		LL_ADC_ConfigOverSamplingRatioShift(adc, ratio, shift);
+	}
+
+	return err;
 }
 
 /*
@@ -921,6 +949,7 @@ static int set_resolution(const struct device *dev,
 {
 	const struct adc_stm32_cfg *config = dev->config;
 	__maybe_unused ADC_TypeDef *adc = config->base;
+	int err = 0;
 	int i;
 
 	for (i = 0; i < config->table_resolution_size; i++) {
@@ -936,15 +965,48 @@ static int set_resolution(const struct device *dev,
 
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc)
 	if (LL_ADC_GetResolution(adc) != config->table_ll_resolution[i]) {
-		adc_stm32_disable(adc);
-		LL_ADC_SetResolution(adc, config->table_ll_resolution[i]);
+		err = adc_stm32_disable(adc, false);
+		if (err == 0) {
+			LL_ADC_SetResolution(adc, config->table_ll_resolution[i]);
+		}
 	}
 #endif /* !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) */
 
-	return 0;
+	return err;
 }
 
-static void set_sequencer(const struct device *dev)
+#if ANY_ADC_HAS_CHANNEL_PRESELECTION
+static int adc_stm32_preselection_setup(const struct device *dev, uint32_t channel_id)
+{
+	const struct adc_stm32_cfg *config = (const struct adc_stm32_cfg *)dev->config;
+	ADC_TypeDef *adc = config->base;
+	uint32_t channel = __LL_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
+	int err;
+
+	if (!config->has_channel_preselection ||
+#ifdef CONFIG_SOC_SERIES_STM32H7X
+	    (LL_ADC_GetChannelPreselection(adc, channel) & channel) == channel) {
+#else
+	    (LL_ADC_GetChannelPreselection(adc) & channel) == channel) {
+#endif
+		/* Nothing to configure */
+		return 0;
+	}
+
+	err = adc_stm32_disable(adc, false);
+
+	if (err == 0) {
+		/* Each channel in the sequence must be previously enabled in PCSEL.
+		 * This register controls the analog switch integrated in the IO level.
+		 */
+		LL_ADC_SetChannelPreselection(adc, channel);
+	}
+
+	return err;
+}
+#endif /* ANY_ADC_HAS_CHANNEL_PRESELECTION */
+
+static int set_sequencer(const struct device *dev)
 {
 	const struct adc_stm32_cfg *config = dev->config;
 	struct adc_stm32_data *data = dev->data;
@@ -968,20 +1030,18 @@ static void set_sequencer(const struct device *dev)
 
 #if ANY_ADC_SEQUENCER_TYPE_IS(SEQUENCER_PROGRAMMABLE)
 		if (config->sequencer_type == SEQUENCER_PROGRAMMABLE) {
-#if ANY_ADC_HAS_CHANNEL_PRESELECTION && !defined(CONFIG_ADC_STM32_INJECTED_CHANNELS)
-			if (config->has_channel_preselection) {
-				/*
-				 * Each channel in the sequence must be previously enabled in PCSEL.
-				 * This register controls the analog switch integrated in the IO
-				 * level.
-				 */
-				LL_ADC_SetChannelPreselection(adc, channel);
-			}
-#endif /* ANY_ADC_HAS_CHANNEL_PRESELECTION && ! CONFIG_ADC_STM32_INJECTED_CHANNELS*/
 			LL_ADC_REG_SetSequencerRanks(adc, table_rank[channel_index], channel);
 			LL_ADC_REG_SetSequencerLength(adc, table_seq_len[channel_index]);
 		}
 #endif /* ANY_ADC_SEQUENCER_TYPE_IS(SEQUENCER_PROGRAMMABLE) */
+
+#if ANY_ADC_HAS_CHANNEL_PRESELECTION && !defined(CONFIG_ADC_STM32_INJECTED_CHANNELS)
+		int err = adc_stm32_preselection_setup(dev, channel_id);
+
+		if (err < 0) {
+			return err;
+		}
+#endif /* ANY_ADC_HAS_CHANNEL_PRESELECTION */
 	}
 
 #if ANY_ADC_SEQUENCER_TYPE_IS(SEQUENCER_FIXED)
@@ -1004,6 +1064,8 @@ static void set_sequencer(const struct device *dev)
 	DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
 	LL_ADC_SetSequencersScanMode(adc, LL_ADC_SEQ_SCAN_ENABLE);
 #endif /* st_stm32f1_adc || st_stm32f4_adc */
+
+	return 0;
 }
 
 #ifdef CONFIG_ADC_STM32_INJECTED_CHANNELS
@@ -1061,17 +1123,20 @@ static int start_inj_read(const struct device *dev, const struct adc_sequence *s
 
 	err = check_buffer(sequence, data->inj_channel_count);
 	if (err < 0) {
+		LOG_ERR("ADC buffer error");
 		return err;
 	}
 
 	err = set_resolution(dev, sequence);
 	if (err < 0) {
+		LOG_ERR("Error setting the ADC resolution");
 		return err;
 	}
 
 	/* Configure the sequencer */
 	err = set_inj_sequencer(dev);
 	if (err < 0) {
+		LOG_ERR("Error setting the ADC injected sequencer");
 		return err;
 	}
 
@@ -1122,20 +1187,27 @@ static int start_read(const struct device *dev,
 	/* Check and set the resolution */
 	err = set_resolution(dev, sequence);
 	if (err < 0) {
+		LOG_ERR("Error setting the ADC resolution");
 		return err;
 	}
 
 	/* Configure the sequencer */
-	set_sequencer(dev);
+	err = set_sequencer(dev);
+	if (err < 0) {
+		LOG_ERR("Error setting the ADC sequencer");
+		return err;
+	}
 
 	err = check_buffer(sequence, data->channel_count);
 	if (err) {
+		LOG_ERR("ADC buffer error");
 		return err;
 	}
 
 #ifdef HAS_OVERSAMPLING
 	err = adc_stm32_oversampling(dev, sequence->oversampling);
 	if (err) {
+		LOG_ERR("Error setting the ADC oversampler");
 		return err;
 	}
 #else
@@ -1147,7 +1219,11 @@ static int start_read(const struct device *dev,
 
 	if (sequence->calibrate) {
 #if defined(HAS_CALIBRATION)
-		adc_stm32_calibrate(dev);
+		err = adc_stm32_calibrate(dev, false);
+		if (err < 0) {
+			LOG_ERR("Calibration error");
+			return err;
+		}
 #else
 		LOG_ERR("Calibration not supported");
 		return -ENOTSUP;
@@ -1520,22 +1596,29 @@ static int adc_stm32_sampling_time_setup(const struct device *dev, uint8_t id,
 }
 
 #if ANY_ADC_HAS_DIFFERENTIAL_SUPPORT
-static void set_channel_differential_mode(ADC_TypeDef *adc, uint8_t channel_id, bool differential)
+static int set_channel_differential_mode(ADC_TypeDef *adc, uint8_t channel_id, bool differential)
 {
 	const uint32_t mode = differential ? LL_ADC_DIFFERENTIAL_ENDED : LL_ADC_SINGLE_ENDED;
 	const uint32_t channel = __LL_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
+	int err;
 
 	/* The ADC must be disabled to change the single ended / differential mode setting. The
 	 * disable / re-enable cycle can take some time, so avoid doing this if the channel is
 	 * already set to the correct mode.
 	 */
 	if (LL_ADC_GetChannelSingleDiff(adc, channel) == mode) {
-		return;
+		return 0;
 	}
 
-	adc_stm32_disable(adc);
+	err = adc_stm32_disable(adc, false);
+	if (err < 0) {
+		return err;
+	}
+
 	LL_ADC_SetChannelSingleDiff(adc, channel, mode);
 	adc_stm32_enable(adc);
+
+	return 0;
 }
 #endif
 
@@ -1544,6 +1627,7 @@ static int adc_stm32_channel_setup(const struct device *dev,
 {
 	const struct adc_stm32_cfg *config = (const struct adc_stm32_cfg *)dev->config;
 	__maybe_unused ADC_TypeDef *adc = config->base;
+	__maybe_unused int err;
 
 	if (!config->has_differential_support) {
 		if (channel_cfg->differential) {
@@ -1560,7 +1644,12 @@ static int adc_stm32_channel_setup(const struct device *dev,
 		return -EINVAL;
 	}
 
-	set_channel_differential_mode(adc, channel_cfg->channel_id, channel_cfg->differential);
+	err = set_channel_differential_mode(adc, channel_cfg->channel_id,
+					    channel_cfg->differential);
+	if (err != 0) {
+		LOG_ERR("Error setting differential channel");
+		return err;
+	}
 #endif
 
 	if (channel_cfg->gain != ADC_GAIN_1) {
@@ -1579,18 +1668,13 @@ static int adc_stm32_channel_setup(const struct device *dev,
 		return -EINVAL;
 	}
 
-#if ANY_ADC_HAS_CHANNEL_PRESELECTION
-	if (config->has_channel_preselection) {
-		/*
-		 * Each channel in the sequence must be previously enabled in PCSEL.
-		 * This register controls the analog switch integrated in the IO
-		 * level.
-		 */
-		uint32_t channel = __LL_ADC_DECIMAL_NB_TO_CHANNEL(channel_cfg->channel_id);
-
-		LL_ADC_SetChannelPreselection(adc, channel);
+#if ANY_ADC_HAS_CHANNEL_PRESELECTION && defined(CONFIG_ADC_STM32_INJECTED_CHANNELS)
+	err = adc_stm32_preselection_setup(dev, channel_cfg->channel_id);
+	if (err < 0) {
+		LOG_ERR("Error setting preselection register");
+		return err;
 	}
-#endif /* ANY_ADC_HAS_CHANNEL_PRESELECTION */
+#endif /* ANY_ADC_HAS_CHANNEL_PRESELECTION && CONFIG_ADC_STM32_INJECTED_CHANNELS */
 
 #ifdef CONFIG_SOC_SERIES_STM32H5X
 	if (adc == ADC1) {
@@ -1877,7 +1961,7 @@ static int adc_stm32_init(const struct device *dev)
 	}
 
 #if defined(HAS_CALIBRATION)
-	adc_stm32_calibrate(dev);
+	adc_stm32_calibrate(dev, true);
 	LL_ADC_REG_SetTriggerSource(adc, LL_ADC_REG_TRIG_SOFTWARE);
 #endif /* HAS_CALIBRATION */
 
@@ -1886,7 +1970,7 @@ static int adc_stm32_init(const struct device *dev)
 	 * To that end, make sure to disable ADC at the end of the initialization, it will be
 	 * enabled later when necessary anyway.
 	 */
-	adc_stm32_disable(adc);
+	adc_stm32_disable(adc, true);
 
 	adc_context_unlock_unconditionally(&data->ctx);
 
@@ -1907,7 +1991,7 @@ static int adc_stm32_suspend_setup(const struct device *dev)
 	int err;
 
 	/* Disable ADC */
-	adc_stm32_disable(adc);
+	adc_stm32_disable(adc, true);
 
 #if ANY_ADC_INTERNAL_REGULATOR_TYPE_IS(INTERNAL_REGULATOR_STARTUP_SW_DELAY) || \
 	ANY_ADC_INTERNAL_REGULATOR_TYPE_IS(INTERNAL_REGULATOR_STARTUP_HW_STATUS)

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -173,6 +173,34 @@ static const uint32_t table_seq_len[] = {
 
 #endif /* ANY_ADC_SEQUENCER_TYPE_IS(SEQUENCER_PROGRAMMABLE) */
 
+#ifdef CONFIG_ADC_STM32_INJECTED_CHANNELS
+
+#define STM32_REG_SEQ_PRIORITY	0U
+#define STM32_INJ_SEQ_PRIORITY	1U
+
+/* Max number of injected channels  */
+#define STM32_NB_INJECTED_CHANNELS	4
+
+/* This macro, coupled with listify, creates an array containing values LL_ADC_INJ_RANK_x,
+ * where x ranges from 1 to STM32_NB_INJECTED_CHANNELS
+ */
+#define INJ_RANK(i, _)	CONCAT(LL_ADC_INJ_RANK_, UTIL_INC(i))
+static const uint32_t table_inj_rank[] = {
+	LISTIFY(STM32_NB_INJECTED_CHANNELS, INJ_RANK, (,))
+};
+
+/* This macro, coupled with listify, creates an array containing values
+ * LL_ADC_INJ_SEQ_SCAN_ENABLE_x_RANKS, where x ranges from 2 to STM32_NB_INJECTED_CHANNELS
+ */
+#define INJ_SEQ_LEN(i, _)	CONCAT(LL_ADC_INJ_SEQ_SCAN_ENABLE_, UTIL_INC(UTIL_INC(i)), RANKS)
+/* Length of this array signifies the maximum sequence length */
+static const uint32_t table_inj_seq_len[] = {
+	LL_ADC_INJ_SEQ_SCAN_DISABLE,
+	LISTIFY(UTIL_DEC(STM32_NB_INJECTED_CHANNELS), INJ_SEQ_LEN, (,))
+};
+
+#endif /* CONFIG_ADC_STM32_INJECTED_CHANNELS */
+
 /* Number of different sampling time values */
 #define STM32_NB_SAMPLING_TIME	8
 
@@ -205,6 +233,13 @@ struct adc_stm32_data {
 	uint8_t channel_count;
 	uint8_t samples_count;
 	int8_t acq_time_index[2];
+
+#ifdef CONFIG_ADC_STM32_INJECTED_CHANNELS
+	struct adc_context inj_ctx;
+	adc_data_size_t *inj_buffer;
+	uint32_t inj_channels;
+	uint8_t inj_channel_count;
+#endif /* CONFIG_ADC_STM32_INJECTED_CHANNELS */
 
 #ifdef CONFIG_ADC_STM32_DMA
 	volatile int dma_error;
@@ -403,6 +438,23 @@ static int adc_stm32_enable(ADC_TypeDef *adc)
 	return 0;
 }
 
+#ifdef CONFIG_ADC_STM32_INJECTED_CHANNELS
+static void adc_stm32_start_inj_conversion(const struct device *dev)
+{
+	const struct adc_stm32_cfg *config = dev->config;
+	ADC_TypeDef *adc = config->base;
+
+	LOG_DBG("Starting injected conversion");
+
+#if !defined(CONFIG_SOC_SERIES_STM32F1X) && \
+	!DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
+	LL_ADC_INJ_StartConversion(adc);
+#else
+	LL_ADC_INJ_StartConversionSWStart(adc);
+#endif
+}
+#endif /* CONFIG_ADC_STM32_INJECTED_CHANNELS */
+
 static void adc_stm32_start_conversion(const struct device *dev)
 {
 	const struct adc_stm32_cfg *config = dev->config;
@@ -441,21 +493,15 @@ static void adc_stm32_disable(ADC_TypeDef *adc)
 	}
 #endif
 
-#if !defined(CONFIG_SOC_SERIES_STM32C0X) && \
-	!defined(CONFIG_SOC_SERIES_STM32F0X) && \
-	!DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) && \
-	!DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc) && \
-	!defined(CONFIG_SOC_SERIES_STM32G0X) && \
-	!defined(CONFIG_SOC_SERIES_STM32L0X) && \
-	!defined(CONFIG_SOC_SERIES_STM32U0X) && \
-	!defined(CONFIG_SOC_SERIES_STM32WBAX) && \
-	!defined(CONFIG_SOC_SERIES_STM32WLX)
+#ifdef CONFIG_ADC_STM32_INJECTED_CHANNELS
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) && !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
 	if (LL_ADC_INJ_IsConversionOngoing(adc)) {
 		LL_ADC_INJ_StopConversion(adc);
 		while (LL_ADC_INJ_IsConversionOngoing(adc)) {
 		}
 	}
 #endif
+#endif /* CONFIG_ADC_STM32_INJECTED_CHANNELS */
 
 	LL_ADC_Disable(adc);
 
@@ -922,7 +968,7 @@ static void set_sequencer(const struct device *dev)
 
 #if ANY_ADC_SEQUENCER_TYPE_IS(SEQUENCER_PROGRAMMABLE)
 		if (config->sequencer_type == SEQUENCER_PROGRAMMABLE) {
-#if ANY_ADC_HAS_CHANNEL_PRESELECTION
+#if ANY_ADC_HAS_CHANNEL_PRESELECTION && !defined(CONFIG_ADC_STM32_INJECTED_CHANNELS)
 			if (config->has_channel_preselection) {
 				/*
 				 * Each channel in the sequence must be previously enabled in PCSEL.
@@ -931,7 +977,7 @@ static void set_sequencer(const struct device *dev)
 				 */
 				LL_ADC_SetChannelPreselection(adc, channel);
 			}
-#endif /* ANY_ADC_HAS_CHANNEL_PRESELECTION */
+#endif /* ANY_ADC_HAS_CHANNEL_PRESELECTION && ! CONFIG_ADC_STM32_INJECTED_CHANNELS*/
 			LL_ADC_REG_SetSequencerRanks(adc, table_rank[channel_index], channel);
 			LL_ADC_REG_SetSequencerLength(adc, table_seq_len[channel_index]);
 		}
@@ -959,6 +1005,85 @@ static void set_sequencer(const struct device *dev)
 	LL_ADC_SetSequencersScanMode(adc, LL_ADC_SEQ_SCAN_ENABLE);
 #endif /* st_stm32f1_adc || st_stm32f4_adc */
 }
+
+#ifdef CONFIG_ADC_STM32_INJECTED_CHANNELS
+static int set_inj_sequencer(const struct device *dev)
+{
+	const struct adc_stm32_cfg *config = dev->config;
+	struct adc_stm32_data *data = dev->data;
+	ADC_TypeDef *adc = config->base;
+	uint32_t channels = data->inj_channels;
+	uint8_t channel_count = data->inj_channel_count;
+
+	/* For F1 and F4 compatibles, it is essential to configure the injected sequencer length
+	 * first because the function LL_ADC_INJ_SetSequencerRanks uses this length to properly
+	 * configure the ranks. Use this sequence on all SoCs for sake of simplicity.
+	 */
+	LL_ADC_INJ_SetSequencerLength(adc, table_inj_seq_len[channel_count - 1]);
+
+	for (uint8_t i = 0; i < channel_count && channels != 0; i++) {
+		uint8_t channel_id = find_lsb_set(channels) - 1;
+		uint32_t channel = __LL_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
+
+		LL_ADC_INJ_SetSequencerRanks(adc, table_inj_rank[i], channel);
+
+		channels &= ~BIT(channel_id);
+	}
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) || DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
+	LL_ADC_SetSequencersScanMode(adc, LL_ADC_SEQ_SCAN_ENABLE);
+#endif /* st_stm32f1_adc || st_stm32f4_adc */
+
+	return 0;
+}
+
+static int start_inj_read(const struct device *dev, const struct adc_sequence *sequence)
+{
+	const struct adc_stm32_cfg *config = dev->config;
+	struct adc_stm32_data *data = dev->data;
+	ADC_TypeDef *adc = config->base;
+	int err;
+
+	data->inj_buffer = sequence->buffer;
+	data->inj_channels = sequence->channels;
+	data->inj_channel_count = POPCOUNT(data->inj_channels);
+
+	if (data->inj_channel_count == 0) {
+		LOG_ERR("No channels selected");
+		return -EINVAL;
+	}
+
+	if (data->inj_channel_count > STM32_NB_INJECTED_CHANNELS) {
+		LOG_ERR("Too many channels for injected sequencer. Max: %d",
+			STM32_NB_INJECTED_CHANNELS);
+		return -EINVAL;
+	}
+
+	err = check_buffer(sequence, data->inj_channel_count);
+	if (err < 0) {
+		return err;
+	}
+
+	err = set_resolution(dev, sequence);
+	if (err < 0) {
+		return err;
+	}
+
+	/* Configure the sequencer */
+	err = set_inj_sequencer(dev);
+	if (err < 0) {
+		return err;
+	}
+
+	adc_stm32_enable(adc);
+
+	LL_ADC_EnableIT_JEOS(adc);
+
+	adc_context_start_read(&data->inj_ctx, sequence);
+
+	return adc_context_wait_for_completion(&data->inj_ctx);
+}
+#endif /* CONFIG_ADC_STM32_INJECTED_CHANNELS */
 
 static int start_read(const struct device *dev,
 		      const struct adc_sequence *sequence)
@@ -1073,6 +1198,17 @@ static int start_read(const struct device *dev,
 
 static void adc_context_start_sampling(struct adc_context *ctx)
 {
+#ifdef CONFIG_ADC_STM32_INJECTED_CHANNELS
+	if (ctx->sequence.priority == STM32_INJ_SEQ_PRIORITY) {
+		struct adc_stm32_data *inj_data =
+			CONTAINER_OF(ctx, struct adc_stm32_data, inj_ctx);
+		const struct device *inj_dev = inj_data->dev;
+
+		adc_stm32_start_inj_conversion(inj_dev);
+		return;
+	}
+#endif /* CONFIG_ADC_STM32_INJECTED_CHANNELS */
+
 	struct adc_stm32_data *data =
 		CONTAINER_OF(ctx, struct adc_stm32_data, ctx);
 	const struct device *dev = data->dev;
@@ -1102,7 +1238,7 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx,
 	}
 }
 
-#ifndef CONFIG_ADC_STM32_DMA
+#if !defined(CONFIG_ADC_STM32_DMA) || defined(CONFIG_ADC_STM32_INJECTED_CHANNELS)
 static void adc_stm32_isr(const struct device *dev)
 {
 	struct adc_stm32_data *data = dev->data;
@@ -1116,6 +1252,23 @@ static void adc_stm32_isr(const struct device *dev)
 			"increase prescaler value or increase sampling times.");
 	}
 #endif /* !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) */
+
+#ifdef CONFIG_ADC_STM32_INJECTED_CHANNELS
+	if (LL_ADC_IsActiveFlag_JEOS(adc) == 1) {
+		LL_ADC_ClearFlag_JEOS(adc);
+		for (uint8_t i = 0; i < data->inj_channel_count; i++) {
+			*data->inj_buffer++ = LL_ADC_INJ_ReadConversionData32(adc,
+							   table_inj_rank[i]);
+		}
+
+		adc_context_on_sampling_done(&data->inj_ctx, dev);
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+
+		if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		}
+	}
+#endif /* CONFIG_ADC_STM32_INJECTED_CHANNELS */
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc)
 	if (LL_ADC_IsActiveFlag_EOS(adc) == 1) {
@@ -1185,6 +1338,7 @@ static void adc_context_on_complete(struct adc_context *ctx, int status)
 
 	ARG_UNUSED(status);
 
+#ifndef CONFIG_ADC_STM32_INJECTED_CHANNELS
 	/* Reset acquisition time used for the sequence */
 	data->acq_time_index[0] = -1;
 	data->acq_time_index[1] = -1;
@@ -1195,23 +1349,50 @@ static void adc_context_on_complete(struct adc_context *ctx, int status)
 		LL_ADC_SetChannelPreselection(adc, 0);
 	}
 #endif /* ANY_ADC_HAS_CHANNEL_PRESELECTION */
+#endif /* CONFIG_ADC_STM32_INJECTED_CHANNELS */
 }
 
 static int adc_stm32_read(const struct device *dev,
-			  const struct adc_sequence *sequence)
+			  const struct adc_sequence *sequence,
+			  struct k_poll_signal *async_sig,
+			  bool asynchronous)
 {
 	struct adc_stm32_data *data = dev->data;
 	int error;
+	struct adc_context *ctx;
+	int (*read_fn)(const struct device *dev, const struct adc_sequence *sequence);
 
-	adc_context_lock(&data->ctx, false, NULL);
+#ifdef CONFIG_ADC_STM32_INJECTED_CHANNELS
+	bool is_injected;
+	if (sequence->priority == STM32_REG_SEQ_PRIORITY) {
+		is_injected = false;
+	} else if (sequence->priority == STM32_INJ_SEQ_PRIORITY) {
+		is_injected = true;
+	} else {
+		LOG_ERR("Sequence priority %d is invalid", sequence->priority);
+		return -EINVAL;
+	}
+	ctx = is_injected ? &data->inj_ctx : &data->ctx;
+	read_fn = is_injected ? start_inj_read : start_read;
+#else /* CONFIG_ADC_STM32_INJECTED_CHANNELS */
+	ctx = &data->ctx;
+	read_fn = start_read;
+#endif /* CONFIG_ADC_STM32_INJECTED_CHANNELS */
+
+	adc_context_lock(ctx, asynchronous, async_sig);
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
 	if (IS_ENABLED(CONFIG_PM_S2RAM)) {
 		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
 	}
-	error = start_read(dev, sequence);
-	adc_context_release(&data->ctx, error);
+	error = read_fn(dev, sequence);
+	adc_context_release(ctx, error);
 
 	return error;
+}
+
+static int adc_stm32_read_sync(const struct device *dev, const struct adc_sequence *sequence)
+{
+	return adc_stm32_read(dev, sequence, NULL, false);
 }
 
 #ifdef CONFIG_ADC_ASYNC
@@ -1219,18 +1400,7 @@ static int adc_stm32_read_async(const struct device *dev,
 				 const struct adc_sequence *sequence,
 				 struct k_poll_signal *async)
 {
-	struct adc_stm32_data *data = dev->data;
-	int error;
-
-	adc_context_lock(&data->ctx, true, async);
-	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-	if (IS_ENABLED(CONFIG_PM_S2RAM)) {
-		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
-	}
-	error = start_read(dev, sequence);
-	adc_context_release(&data->ctx, error);
-
-	return error;
+	return adc_stm32_read(dev, sequence, async, true);
 }
 #endif
 
@@ -1373,9 +1543,7 @@ static int adc_stm32_channel_setup(const struct device *dev,
 				   const struct adc_channel_cfg *channel_cfg)
 {
 	const struct adc_stm32_cfg *config = (const struct adc_stm32_cfg *)dev->config;
-#if defined(CONFIG_SOC_SERIES_STM32H5X) || ANY_ADC_HAS_DIFFERENTIAL_SUPPORT
-	ADC_TypeDef *adc = config->base;
-#endif
+	__maybe_unused ADC_TypeDef *adc = config->base;
 
 	if (!config->has_differential_support) {
 		if (channel_cfg->differential) {
@@ -1410,6 +1578,19 @@ static int adc_stm32_channel_setup(const struct device *dev,
 		LOG_ERR("Invalid sampling time");
 		return -EINVAL;
 	}
+
+#if ANY_ADC_HAS_CHANNEL_PRESELECTION
+	if (config->has_channel_preselection) {
+		/*
+		 * Each channel in the sequence must be previously enabled in PCSEL.
+		 * This register controls the analog switch integrated in the IO
+		 * level.
+		 */
+		uint32_t channel = __LL_ADC_DECIMAL_NB_TO_CHANNEL(channel_cfg->channel_id);
+
+		LL_ADC_SetChannelPreselection(adc, channel);
+	}
+#endif /* ANY_ADC_HAS_CHANNEL_PRESELECTION */
 
 #ifdef CONFIG_SOC_SERIES_STM32H5X
 	if (adc == ADC1) {
@@ -1709,6 +1890,11 @@ static int adc_stm32_init(const struct device *dev)
 
 	adc_context_unlock_unconditionally(&data->ctx);
 
+#ifdef CONFIG_ADC_STM32_INJECTED_CHANNELS
+	LL_ADC_INJ_SetTriggerSource(adc, LL_ADC_INJ_TRIG_SOFTWARE);
+	adc_context_unlock_unconditionally(&data->inj_ctx);
+#endif /* CONFIG_ADC_STM32_INJECTED_CHANNELS */
+
 	return 0;
 }
 
@@ -1868,7 +2054,7 @@ static int adc_stm32_get_decoder(const struct device *dev, const struct adc_deco
 
 static DEVICE_API(adc, api_stm32_driver_api) = {
 	.channel_setup = adc_stm32_channel_setup,
-	.read = adc_stm32_read,
+	.read = adc_stm32_read_sync,
 #ifdef CONFIG_ADC_ASYNC
 	.read_async = adc_stm32_read_async,
 #endif
@@ -1944,10 +2130,13 @@ static DEVICE_API(adc, api_stm32_driver_api) = {
 			STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),			\
 	}
 
-#define ADC_STM32_IRQ_FUNC(index)					\
-	.irq_cfg_func = NULL,
-
 #else /* CONFIG_ADC_STM32_DMA */
+
+#define ADC_DMA_CHANNEL_INIT(index, src_dev, dest_dev)
+
+#endif /* CONFIG_ADC_STM32_DMA */
+
+#if !defined(CONFIG_ADC_STM32_DMA) || defined(CONFIG_ADC_STM32_INJECTED_CHANNELS)
 
 /*
  * For series that share interrupt lines for multiple ADC instances
@@ -2048,9 +2237,11 @@ DT_INST_FOREACH_STATUS_OKAY(GENERATE_ISR)
 	.irq_cfg_func = COND_CODE_1(IS_EQ(index, FIRST_WITH_IRQN(index)),                          \
 				    (UTIL_CAT(ISR_FUNC(index), _init)), (NULL)),
 
-#define ADC_DMA_CHANNEL_INIT(index, src_dev, dest_dev)
+#else /* !CONFIG_ADC_STM32_DMA || CONFIG_ADC_STM32_INJECTED_CHANNELS */
 
-#endif /* CONFIG_ADC_STM32_DMA */
+#define ADC_STM32_IRQ_FUNC(index)	.irq_cfg_func = NULL,
+
+#endif /* !CONFIG_ADC_STM32_DMA || CONFIG_ADC_STM32_INJECTED_CHANNELS */
 
 #define ADC_DMA_CHANNEL(id, src, dest)							\
 	COND_CODE_1(DT_INST_DMAS_HAS_IDX(id, 0),					\
@@ -2110,6 +2301,10 @@ DT_INST_FOREACH_STATUS_OKAY(GENERATE_ISR)
 		ADC_CONTEXT_INIT_TIMER(adc_stm32_data_##index, ctx),				\
 		ADC_CONTEXT_INIT_LOCK(adc_stm32_data_##index, ctx),				\
 		ADC_CONTEXT_INIT_SYNC(adc_stm32_data_##index, ctx),				\
+		IF_ENABLED(CONFIG_ADC_STM32_INJECTED_CHANNELS,					\
+			   (ADC_CONTEXT_INIT_TIMER(adc_stm32_data_##index, inj_ctx),		\
+			    ADC_CONTEXT_INIT_LOCK(adc_stm32_data_##index, inj_ctx),		\
+			    ADC_CONTEXT_INIT_SYNC(adc_stm32_data_##index, inj_ctx),))		\
 		ADC_DMA_CHANNEL(index, PERIPHERAL, MEMORY)					\
 	};											\
 												\

--- a/drivers/sensor/st/stm32_temp/Kconfig
+++ b/drivers/sensor/st/stm32_temp/Kconfig
@@ -25,4 +25,11 @@ config STM32_TEMP_READ_CALIB_VIA_NVMEM
 	  Read calibration data using the NVMEM subsystem
 	  instead of using raw memory accesses.
 
+config STM32_TEMP_INJECTED
+	bool "STM32 Temperature Sensor through injected channel"
+	depends on ADC_STM32_INJECTED_CHANNELS
+	help
+	  Temperature measurement is done using the injected channel feature.
+	  This will permanently enable the ADC temperature sensor (VSENSESEL bit set to 1).
+
 endif # STM32_TEMP

--- a/drivers/sensor/st/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/st/stm32_temp/stm32_temp.c
@@ -88,7 +88,7 @@ struct stm32_temp_config {
 	bool is_ntc;
 };
 
-static inline void adc_enable_tempsensor_channel(ADC_TypeDef *adc)
+static void stm32_temp_enable_tempsensor_channel(ADC_TypeDef *adc)
 {
 	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
 
@@ -98,7 +98,7 @@ static inline void adc_enable_tempsensor_channel(ADC_TypeDef *adc)
 	k_usleep(LL_ADC_DELAY_TEMPSENSOR_STAB_US);
 }
 
-static inline void adc_disable_tempsensor_channel(ADC_TypeDef *adc)
+__maybe_unused static void stm32_temp_disable_tempsensor_channel(ADC_TypeDef *adc)
 {
 	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
 
@@ -203,22 +203,26 @@ static int stm32_temp_sample_fetch(const struct device *dev, enum sensor_channel
 	k_mutex_lock(&data->mutex, K_FOREVER);
 	pm_device_runtime_get(cfg->adc);
 
+#ifndef CONFIG_STM32_TEMP_INJECTED
 	rc = adc_channel_setup(cfg->adc, &cfg->adc_cfg);
-	if (rc) {
+	if (rc != 0) {
 		LOG_DBG("Setup AIN%u got %d", cfg->adc_cfg.channel_id, rc);
 		goto unlock;
 	}
 
-	adc_enable_tempsensor_channel(cfg->adc_base);
+	stm32_temp_enable_tempsensor_channel(cfg->adc_base);
+#endif /* CONFIG_STM32_TEMP_INJECTED */
 
 	rc = adc_read(cfg->adc, sp);
 	if (rc == 0) {
 		data->raw = data->sample_buffer;
 	}
 
-	adc_disable_tempsensor_channel(cfg->adc_base);
+#ifndef CONFIG_STM32_TEMP_INJECTED
+	stm32_temp_disable_tempsensor_channel(cfg->adc_base);
 
 unlock:
+#endif /* CONFIG_STM32_TEMP_INJECTED */
 	pm_device_runtime_put(cfg->adc);
 	k_mutex_unlock(&data->mutex);
 
@@ -323,7 +327,21 @@ static int stm32_temp_init(const struct device *dev)
 		.buffer = &data->sample_buffer,
 		.buffer_size = sizeof(data->sample_buffer),
 		.resolution = CAL_RES,
+#ifdef CONFIG_STM32_TEMP_INJECTED
+		.priority = 1,
+#endif /* CONFIG_STM32_TEMP_INJECTED */
 	};
+
+#ifdef CONFIG_STM32_TEMP_INJECTED
+	int rc = adc_channel_setup(cfg->adc, &cfg->adc_cfg);
+
+	if (rc != 0) {
+		LOG_DBG("Setup AIN%u got %d", cfg->adc_cfg.channel_id, rc);
+		return rc;
+	}
+
+	stm32_temp_enable_tempsensor_channel(cfg->adc_base);
+#endif /* CONFIG_STM32_TEMP_INJECTED */
 
 	return 0;
 }

--- a/drivers/sensor/st/stm32_vbat/Kconfig
+++ b/drivers/sensor/st/stm32_vbat/Kconfig
@@ -12,3 +12,14 @@ config STM32_VBAT
 	select ADC
 	help
 	  Enable driver for STM32 Vbat sensor and then also ADC
+
+if STM32_VBAT
+
+config STM32_VBAT_INJECTED
+	bool "STM32 Vbat Sensor through injected channel"
+	depends on ADC_STM32_INJECTED_CHANNELS
+	help
+	  Vbat measurement is done using the injected channel feature.
+	  This will permanently enable the ADC Vbat sensor (VBATEN bit set to 1).
+
+endif

--- a/drivers/sensor/st/stm32_vbat/stm32_vbat.c
+++ b/drivers/sensor/st/stm32_vbat/stm32_vbat.c
@@ -34,12 +34,27 @@ struct stm32_vbat_config {
 	int ratio;
 };
 
+static void stm32_vbat_enable_vbatsensor_channel(ADC_TypeDef *adc)
+{
+	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
+
+	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
+					path | LL_ADC_PATH_INTERNAL_VBAT);
+}
+
+__maybe_unused static void stm32_vbat_disable_vbatsensor_channel(ADC_TypeDef *adc)
+{
+	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
+
+	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
+					path & ~LL_ADC_PATH_INTERNAL_VBAT);
+}
+
 static int stm32_vbat_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct stm32_vbat_data *data = dev->data;
 	struct adc_sequence *sp = &data->adc_seq;
 	int rc;
-	uint32_t path;
 
 	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_VOLTAGE) {
 		return -ENOTSUP;
@@ -48,27 +63,27 @@ static int stm32_vbat_sample_fetch(const struct device *dev, enum sensor_channel
 	k_mutex_lock(&data->mutex, K_FOREVER);
 	pm_device_runtime_get(data->adc);
 
+#ifndef CONFIG_STM32_VBAT_INJECTED
 	rc = adc_channel_setup(data->adc, &data->adc_cfg);
 
-	if (rc) {
+	if (rc != 0) {
 		LOG_DBG("Setup AIN%u got %d", data->adc_cfg.channel_id, rc);
 		goto unlock;
 	}
 
-	path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(data->adc_base));
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(data->adc_base),
-				       LL_ADC_PATH_INTERNAL_VBAT | path);
+	stm32_vbat_enable_vbatsensor_channel(data->adc_base);
+#endif /* CONFIG_STM32_VBAT_INJECTED */
 
 	rc = adc_read(data->adc, sp);
 	if (rc == 0) {
 		data->raw = data->sample_buffer;
 	}
 
-	path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(data->adc_base));
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(data->adc_base),
-				       path &= ~LL_ADC_PATH_INTERNAL_VBAT);
+#ifndef CONFIG_STM32_VBAT_INJECTED
+	stm32_vbat_disable_vbatsensor_channel(data->adc_base);
 
 unlock:
+#endif /* CONFIG_STM32_VBAT_INJECTED */
 	pm_device_runtime_put(data->adc);
 	k_mutex_unlock(&data->mutex);
 
@@ -119,7 +134,21 @@ static int stm32_vbat_init(const struct device *dev)
 		.buffer = &data->sample_buffer,
 		.buffer_size = sizeof(data->sample_buffer),
 		.resolution = 12U,
+#ifdef CONFIG_STM32_VBAT_INJECTED
+		.priority = 1,
+#endif /* CONFIG_STM32_VBAT_INJECTED */
 	};
+
+#ifdef CONFIG_STM32_VBAT_INJECTED
+	int rc = adc_channel_setup(data->adc, &data->adc_cfg);
+
+	if (rc != 0) {
+		LOG_DBG("Setup AIN%u got %d", data->adc_cfg.channel_id, rc);
+		return rc;
+	}
+
+	stm32_vbat_enable_vbatsensor_channel(data->adc_base);
+#endif /* CONFIG_STM32_VBAT_INJECTED */
 
 	return 0;
 }

--- a/drivers/sensor/st/stm32_vref/Kconfig
+++ b/drivers/sensor/st/stm32_vref/Kconfig
@@ -23,4 +23,11 @@ config STM32_VREF_READ_CALIB_VIA_NVMEM
 	  Read calibration data using the NVMEM subsystem
 	  instead of using raw memory accesses.
 
+config STM32_VREF_INJECTED
+	bool "STM32 Vref Sensor through injected channel"
+	depends on ADC_STM32_INJECTED_CHANNELS
+	help
+	  Vref measurement is done using the injected channel feature.
+	  This will permanently enable the ADC Vref sensor (VREFEN bit set to 1).
+
 endif # STM32_VREF

--- a/drivers/sensor/st/stm32_vref/stm32_vref.c
+++ b/drivers/sensor/st/stm32_vref/stm32_vref.c
@@ -51,13 +51,32 @@ struct stm32_vref_config {
 	uint8_t cal_shift;
 };
 
+static void stm32_vref_enable_vrefsensor_channel(ADC_TypeDef *adc)
+{
+	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
+
+	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
+					path | LL_ADC_PATH_INTERNAL_VREFINT);
+
+#ifdef LL_ADC_DELAY_VREFINT_STAB_US
+	k_usleep(LL_ADC_DELAY_VREFINT_STAB_US);
+#endif
+}
+
+__maybe_unused static void stm32_vref_disable_vrefsensor_channel(ADC_TypeDef *adc)
+{
+	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
+
+	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
+					path & ~LL_ADC_PATH_INTERNAL_VREFINT);
+}
+
 static int stm32_vref_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	const struct stm32_vref_config *cfg = dev->config;
 	struct stm32_vref_data *data = dev->data;
 	struct adc_sequence *sp = &data->adc_seq;
 	int rc;
-	uint32_t path;
 
 	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_VOLTAGE) {
 		return -ENOTSUP;
@@ -66,31 +85,27 @@ static int stm32_vref_sample_fetch(const struct device *dev, enum sensor_channel
 	k_mutex_lock(&data->mutex, K_FOREVER);
 	pm_device_runtime_get(cfg->adc);
 
+#ifndef CONFIG_STM32_VREF_INJECTED
 	rc = adc_channel_setup(cfg->adc, &cfg->adc_cfg);
 	if (rc) {
 		LOG_DBG("Setup AIN%u got %d", cfg->adc_cfg.channel_id, rc);
 		goto unlock;
 	}
 
-	path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(cfg->adc_base));
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(cfg->adc_base),
-				       LL_ADC_PATH_INTERNAL_VREFINT | path);
-
-#ifdef LL_ADC_DELAY_VREFINT_STAB_US
-	k_usleep(LL_ADC_DELAY_VREFINT_STAB_US);
-#endif
+	stm32_vref_enable_vrefsensor_channel(cfg->adc_base);
+#endif /* CONFIG_STM32_VREF_INJECTED */
 
 	rc = adc_read(cfg->adc, sp);
 	if (rc == 0) {
 		data->raw = data->sample_buffer;
 	}
 
-	path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(cfg->adc_base));
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(cfg->adc_base),
-				       path &= ~LL_ADC_PATH_INTERNAL_VREFINT);
+#ifndef CONFIG_STM32_VREF_INJECTED
+	stm32_vref_disable_vrefsensor_channel(cfg->adc_base);
 
 
 unlock:
+#endif /* CONFIG_STM32_VREF_INJECTED */
 	pm_device_runtime_put(cfg->adc);
 	k_mutex_unlock(&data->mutex);
 
@@ -141,6 +156,9 @@ static int stm32_vref_init(const struct device *dev)
 		.buffer = &data->sample_buffer,
 		.buffer_size = sizeof(data->sample_buffer),
 		.resolution = MEAS_RES,
+#ifdef CONFIG_STM32_VREF_INJECTED
+		.priority = 1,
+#endif /* CONFIG_STM32_VREF_INJECTED */
 	};
 
 /*
@@ -169,6 +187,17 @@ static int stm32_vref_init(const struct device *dev)
 #endif /* CONFIG_STM32_VREF_READ_CALIB_VIA_NVMEM */
 
 	data->vrefint_cal_numerator = cfg->cal_mv * (vrefint_cal >> cfg->cal_shift);
+
+#ifdef CONFIG_STM32_VREF_INJECTED
+	int rc = adc_channel_setup(cfg->adc, &cfg->adc_cfg);
+
+	if (rc != 0) {
+		LOG_DBG("Setup AIN%u got %d", cfg->adc_cfg.channel_id, rc);
+		return rc;
+	}
+
+	stm32_vref_enable_vrefsensor_channel(cfg->adc_base);
+#endif /* CONFIG_STM32_VREF_INJECTED */
 
 	return 0;
 }

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -408,6 +408,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -156,6 +156,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -171,6 +172,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -387,6 +387,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -403,6 +404,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -419,6 +421,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -126,6 +126,7 @@
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -162,6 +162,7 @@
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -179,6 +180,7 @@
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -99,6 +99,7 @@
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -291,6 +291,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -617,6 +617,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -270,6 +270,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -286,6 +287,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -129,6 +129,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -145,6 +146,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -898,6 +898,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -914,6 +915,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -930,6 +932,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -122,6 +122,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -139,6 +140,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -54,6 +54,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -71,6 +72,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -80,6 +80,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -365,6 +365,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -321,6 +321,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1004,6 +1004,7 @@
 			st,adc-has-deep-powerdown;
 			st,adc-has-channel-preselection;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -1022,6 +1023,7 @@
 			st,adc-has-deep-powerdown;
 			st,adc-has-channel-preselection;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -1041,6 +1043,7 @@
 			st,adc-has-deep-powerdown;
 			st,adc-has-channel-preselection;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -1059,6 +1062,7 @@
 			st,adc-has-deep-powerdown;
 			st,adc-has-channel-preselection;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -949,6 +949,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -966,6 +967,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -314,6 +314,7 @@
 			st,adc-sequencer = "programmable";
 			st,adc-oversampler = "none";
 			st,adc-internal-regulator = "none";
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -478,6 +478,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -495,6 +496,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -317,6 +317,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -776,6 +776,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -793,6 +794,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-deep-powerdown;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -495,6 +495,7 @@
 				st,adc-internal-regulator = "none";
 				st,adc-has-deep-powerdown;
 				st,adc-has-channel-preselection;
+				st,adc-has-injected-support;
 				status = "disabled";
 			};
 
@@ -512,6 +513,7 @@
 				st,adc-internal-regulator = "none";
 				st,adc-has-deep-powerdown;
 				st,adc-has-channel-preselection;
+				st,adc-has-injected-support;
 				status = "disabled";
 			};
 

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -292,6 +292,7 @@
 			st,adc-internal-regulator = "startup-hw-status";
 			st,adc-has-deep-powerdown;
 			st,adc-has-channel-preselection;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -309,6 +310,7 @@
 			st,adc-internal-regulator = "startup-hw-status";
 			st,adc-has-deep-powerdown;
 			st,adc-has-channel-preselection;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -907,6 +907,7 @@
 			st,adc-has-deep-powerdown;
 			st,adc-has-channel-preselection;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u595.dtsi
+++ b/dts/arm/st/u5/stm32u595.dtsi
@@ -88,6 +88,7 @@
 			st,adc-has-deep-powerdown;
 			st,adc-has-channel-preselection;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 
@@ -112,6 +113,7 @@
 			st,adc-has-deep-powerdown;
 			st,adc-has-channel-preselection;
 			st,adc-has-differential-support;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -478,6 +478,7 @@
 			st,adc-internal-regulator = "startup-sw-delay";
 			st,adc-has-differential-support;
 			st,adc-has-deep-powerdown;
+			st,adc-has-injected-support;
 			status = "disabled";
 		};
 

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -156,5 +156,10 @@ properties:
     description: |
       If present, it indicates that the ADC instance supports differential channel inputs.
 
+  st,adc-has-injected-support:
+    type: boolean
+    description: |
+      If present, it indicates that the ADC instance supports the injected channel feature.
+
 io-channel-cells:
   - input

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -760,6 +760,20 @@ struct adc_sequence {
 	 */
 	size_t buffer_size;
 
+#if defined(CONFIG_ADC_SEQUENCE_PRIORITY) || defined(__DOXYGEN__)
+	/**
+	 * Channel priority for arbitration.
+	 * 0 represents the default/lowest priority; higher numerical values
+	 * indicate higher priority; equal values indicate no preference.
+	 * No guarantee of kernel-style semantics like preemption/complete
+	 * blocking, it serves only as a hint for hardware/driver arbitration.
+	 * Number of possible priorities is HW specific.
+	 *
+	 * @kconfig_dep{CONFIG_ADC_SEQUENCE_PRIORITY}
+	 */
+	uint32_t priority;
+#endif
+
 	/**
 	 * ADC resolution.
 	 * For single-ended channels the sample values are from range:

--- a/tests/drivers/adc/adc_api/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/adc/adc_api/boards/b_u585i_iot02a.overlay
@@ -7,7 +7,13 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 15>, <&adc1 16>;
+		io-channels = <&adc1 1>, <&adc1 2>, <&adc1 3>, <&adc1 5>, <&adc1 6>,
+			      <&adc1 7>, <&adc1 8>, <&adc1 10>, <&adc1 11>, <&adc1 12>,
+			      <&adc1 13>, <&adc1 14>, <&adc1 15>, <&adc1 16>, <&adc1 17>;
+		prio0-io-channels = <&adc1 1>, <&adc1 2>, <&adc1 3>, <&adc1 5>,
+				    <&adc1 7>, <&adc1 8>, <&adc1 10>, <&adc1 11>,
+				    <&adc1 13>, <&adc1 14>, <&adc1 15>, <&adc1 16>;
+		prio1-io-channels = <&adc1 6>, <&adc1 12>, <&adc1 17>;
 	};
 };
 
@@ -15,9 +21,107 @@
 	dmas = <&gpdma1 0 0 (STM32_DMA_PERIPH_RX | STM32_DMA_MEM_16BITS | STM32_DMA_PERIPH_16BITS)>;
 	dma-names = "gpdma";
 
-	pinctrl-0 = <&adc1_in15_pb0 &adc1_in16_pb1>;
+	pinctrl-0 = <&adc1_in1_pc0 &adc1_in2_pc1 &adc1_in3_pc2 &adc1_in5_pa0 &adc1_in6_pa1
+		     &adc1_in7_pa2 &adc1_in8_pa3 &adc1_in10_pa5 &adc1_in11_pa6 &adc1_in12_pa7
+		     &adc1_in13_pc4 &adc1_in14_pc5 &adc1_in15_pb0 &adc1_in16_pb1 &adc1_in17_pb2>;
 	#address-cells = <1>;
 	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@5 {
+		reg = <5>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@7 {
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@8 {
+		reg = <8>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@a {
+		reg = <10>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@b {
+		reg = <11>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@c {
+		reg = <12>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@d {
+		reg = <13>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@e {
+		reg = <14>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
 
 	channel@f {
 		reg = <15>;
@@ -29,6 +133,14 @@
 
 	channel@10 {
 		reg = <16>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@11 {
+		reg = <17>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -33,14 +33,14 @@ typedef int16_t adc_data_size_t;
 #define __NOCACHE
 #endif /* CONFIG_NOCACHE_MEMORY */
 
-#define BUFFER_SIZE  6
+#define BUFFER_SIZE  15
 #ifdef CONFIG_TEST_USERSPACE
 static ZTEST_BMEM adc_data_size_t m_sample_buffer[BUFFER_SIZE];
 #else
 static __aligned(32) adc_data_size_t m_sample_buffer[BUFFER_SIZE] __NOCACHE;
 #endif
 
-#define DT_SPEC_AND_COMMA(node_id, prop, idx) ADC_DT_SPEC_GET_BY_IDX(node_id, idx),
+#define DT_SPEC_AND_COMMA(node_id, prop, idx)	ADC_DT_SPEC_GET_BY_IDX(node_id, idx),
 
 #if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), io_channels)
 /* Data of ADC io-channels specified in devicetree. */
@@ -51,6 +51,28 @@ static const int adc_channels_count = ARRAY_SIZE(adc_channels);
 #else
 #error "Unsupported board."
 #endif
+
+#ifdef CONFIG_ADC_SEQUENCE_PRIORITY
+static const struct adc_dt_spec adc_channels_prio0[] = {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), prio0_io_channels, DT_SPEC_AND_COMMA)
+};
+static const struct adc_dt_spec adc_channels_prio1[] = {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), prio1_io_channels, DT_SPEC_AND_COMMA)
+};
+static const int adc_channels_prio0_count = ARRAY_SIZE(adc_channels_prio0);
+static const int adc_channels_prio1_count = ARRAY_SIZE(adc_channels_prio1);
+
+#define PRIO0_BUFFER_SIZE	60
+#define PRIO1_BUFFER_SIZE	3
+
+#ifdef CONFIG_TEST_USERSPACE
+static ZTEST_BMEM adc_data_size_t m_prio0_sample_buffer[PRIO0_BUFFER_SIZE];
+static ZTEST_BMEM adc_data_size_t m_prio1_sample_buffer[PRIO1_BUFFER_SIZE];
+#else /* CONFIG_TEST_USERSPACE */
+static __aligned(32) adc_data_size_t m_prio0_sample_buffer[PRIO0_BUFFER_SIZE] __NOCACHE;
+static __aligned(32) adc_data_size_t m_prio1_sample_buffer[PRIO1_BUFFER_SIZE] __NOCACHE;
+#endif /* CONFIG_TEST_USERSPACE */
+#endif /* CONFIG_ADC_SEQUENCE_PRIORITY */
 
 const struct device *get_adc_device(void)
 {
@@ -97,19 +119,29 @@ static void init_adc(void)
 		m_sample_buffer[i] = INVALID_ADC_VALUE;
 	}
 
+#ifdef CONFIG_ADC_SEQUENCE_PRIORITY
+	for (i = 0; i < PRIO1_BUFFER_SIZE; ++i) {
+		m_prio1_sample_buffer[i] = INVALID_ADC_VALUE;
+	}
+
+	for (i = 0; i < PRIO0_BUFFER_SIZE; ++i) {
+		m_prio0_sample_buffer[i] = INVALID_ADC_VALUE;
+	}
+#endif /* CONFIG_ADC_SEQUENCE_PRIORITY */
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(test_counter)) && \
 	defined(CONFIG_COUNTER)
 	init_counter();
 #endif
 }
 
-static void check_samples(int expected_count)
+static void check_samples(int expected_count, adc_data_size_t *sample_buffer, size_t buffer_size)
 {
 	int i;
 
 	TC_PRINT("Samples read: ");
-	for (i = 0; i < BUFFER_SIZE; i++) {
-		adc_data_size_t sample_value = m_sample_buffer[i];
+	for (i = 0; i < buffer_size; i++) {
+		adc_data_size_t sample_value = sample_buffer[i];
 
 #if CONFIG_ADC_32_BITS_DATA
 		TC_PRINT("0x%08x ", sample_value);
@@ -147,7 +179,7 @@ static int test_task_one_channel(void)
 	ret = adc_read_dt(&adc_channels[0], &sequence);
 	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
 
-	check_samples(1);
+	check_samples(1, m_sample_buffer, BUFFER_SIZE);
 
 	return TC_PASS;
 }
@@ -184,7 +216,7 @@ static int test_task_multiple_channels(void)
 	}
 	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
 
-	check_samples(adc_channels_count);
+	check_samples(adc_channels_count, m_sample_buffer, BUFFER_SIZE);
 
 	return TC_PASS;
 }
@@ -234,10 +266,66 @@ static int test_task_asynchronous_call(void)
 	ret = k_poll(&async_evt, 1, K_MSEC(1000));
 	zassert_equal(ret, 0, "k_poll failed with error %d", ret);
 
-	check_samples(1 + options.extra_samplings);
+	check_samples(1 + options.extra_samplings, m_sample_buffer, BUFFER_SIZE);
 
 	return TC_PASS;
 }
+
+#if defined(CONFIG_ADC_SEQUENCE_PRIORITY)
+static int test_task_different_priorities_sequences(void)
+{
+	int ret;
+	const struct adc_sequence_options options = {
+		.extra_samplings = 4,
+		/* Start consecutive samplings as fast as possible. */
+		.interval_us     = CONFIG_ADC_API_SAMPLE_INTERVAL_US,
+	};
+	struct adc_sequence prio0_sequence = {
+		.options     = &options,
+		.buffer      = m_prio0_sample_buffer,
+		.buffer_size = PRIO0_BUFFER_SIZE * sizeof(adc_data_size_t),
+		.priority    = 0U,
+	};
+	struct adc_sequence prio1_sequence = {
+		.buffer      = m_prio1_sample_buffer,
+		.buffer_size = PRIO1_BUFFER_SIZE * sizeof(adc_data_size_t),
+		.priority    = 1U,
+	};
+	struct k_poll_event async_evt = K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL,
+								 K_POLL_MODE_NOTIFY_ONLY,
+								 &async_sig);
+
+	init_adc();
+
+	(void)adc_sequence_init_dt(&adc_channels_prio0[0], &prio0_sequence);
+
+	for (int i = 1; i < adc_channels_prio0_count; i++) {
+		prio0_sequence.channels |= BIT(adc_channels_prio0[i].channel_id);
+	}
+
+	(void)adc_sequence_init_dt(&adc_channels_prio1[0], &prio1_sequence);
+
+	for (int i = 1; i < adc_channels_prio1_count; i++) {
+		prio1_sequence.channels |= BIT(adc_channels_prio1[i].channel_id);
+	}
+
+	ret = adc_read_async_dt(&adc_channels_prio0[0], &prio0_sequence, &async_sig);
+	zassert_equal(ret, 0, "adc_read_async() failed with code %d", ret);
+
+	ret = adc_read_dt(&adc_channels_prio1[0], &prio1_sequence);
+	zassert_equal(ret, 0, "adc_read_dt() failed with code %d", ret);
+
+	check_samples(adc_channels_prio1_count, m_prio1_sample_buffer, PRIO1_BUFFER_SIZE);
+
+	ret = k_poll(&async_evt, 1, K_MSEC(1000));
+	zassert_equal(ret, 0, "k_poll failed with error %d", ret);
+
+	check_samples(adc_channels_prio0_count * (options.extra_samplings + 1),
+		      m_prio0_sample_buffer, PRIO0_BUFFER_SIZE);
+
+	return TC_PASS;
+}
+#endif /* defined(CONFIG_ADC_SEQUENCE_PRIORITY) */
 #endif /* defined(CONFIG_ADC_ASYNC) */
 
 ZTEST_USER(adc_basic, test_adc_asynchronous_call)
@@ -247,6 +335,15 @@ ZTEST_USER(adc_basic, test_adc_asynchronous_call)
 #else
 	ztest_test_skip();
 #endif /* defined(CONFIG_ADC_ASYNC) */
+}
+
+ZTEST_USER(adc_basic, test_task_different_priorities_sequences)
+{
+#if defined(CONFIG_ADC_ASYNC) && defined(CONFIG_ADC_SEQUENCE_PRIORITY)
+	zassert_true(test_task_different_priorities_sequences() == TC_PASS);
+#else
+	ztest_test_skip();
+#endif /* defined(CONFIG_ADC_ASYNC) && defined(CONFIG_ADC_SEQUENCE_PRIORITY) */
 }
 
 /*
@@ -300,7 +397,7 @@ static int test_task_with_interval(void)
 		"Invalid user data: %p, expected: %p",
 		user_data, sequence.options->user_data);
 
-	check_samples(1 + options.extra_samplings);
+	check_samples(1 + options.extra_samplings, m_sample_buffer, BUFFER_SIZE);
 
 	return TC_PASS;
 }
@@ -321,12 +418,12 @@ static enum adc_action repeated_samplings_callback(const struct device *dev,
 	++m_samplings_done;
 	TC_PRINT("%s: done %d\n", __func__, m_samplings_done);
 	if (m_samplings_done == 1U) {
-		check_samples(MIN(adc_channels_count, 2));
+		check_samples(MIN(adc_channels_count, 2), m_sample_buffer, BUFFER_SIZE);
 
 		/* After first sampling continue normally. */
 		return ADC_ACTION_CONTINUE;
 	} else {
-		check_samples(2 * MIN(adc_channels_count, 2));
+		check_samples(2 * MIN(adc_channels_count, 2), m_sample_buffer, BUFFER_SIZE);
 
 		/*
 		 * The second sampling is repeated 9 times (the samples are
@@ -421,7 +518,7 @@ static int test_task_invalid_request(void)
 	ret = adc_read_dt(&adc_channels[0], &sequence);
 	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
 
-	check_samples(1);
+	check_samples(1, m_sample_buffer, BUFFER_SIZE);
 
 	return TC_PASS;
 }


### PR DESCRIPTION
This PR adds the support for the STM32 ADC injected channels. Starting an injected sequence means that the sequence is executed immediately. If a regular sequence is being executed, it will be paused and resumed once the injected one is done.

It makes a slight change to the ADC API by adding a boolean in the `adc_sequence` structure to indicate if the sequence should be injected or not. This boolean is itself hidden behind a specific Kconfig. That way, there is no difference for ADC that do not support this feature.

An ADC test is added to test the feature on an STM32U5 board. The PR is functional but the implementation stays open for discussion.