### PR TITLE
scripts: west: nrfutil: Use build dir to store generated json

### DIFF
--- a/scripts/west_commands/runners/nrfutil.py
+++ b/scripts/west_commands/runners/nrfutil.py
@@ -152,7 +152,7 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
 
     def _exec_batch(self):
         # Use x-append-batch to get the JSON from nrfutil itself
-        json_file = Path(self.hex_).parent / 'generated_nrfutil_batch.json'
+        json_file = Path(self.cfg.build_dir) / 'zephyr' / 'generated_nrfutil_batch.json'
         json_file.unlink(missing_ok=True)
         for op in self._ops:
             self._append_batch(op, json_file)


### PR DESCRIPTION
Until now the code was using the path to the .hex file to select the directory where the generated JSON file required for nrfutil would be generated. But this has a problem: if the .hex file in a sysbuild project is located in the tree as a precompiled binary, the runner would place a file in there and make the tree dirty. Instead use the build_dir folder which always corresponds (in both sysbuild and regular builds) to the current target build directory.