### PR TITLE
drivers: pwm: mcux: enable when CPU is inactive

### DIFF
--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -242,6 +242,10 @@ static int pwm_mcux_init(const struct device *dev)
 		return -EIO;
 	}
 
+	/* Enable WAITEN bit to not disable FlexPWM when CPU is inactive */
+	/* see: https://github.com/zephyrproject-rtos/zephyr/issues/95096 */
+	config->base->SM[config->index].CTRL2 |= 1 << 14;
+
 	/* Disable fault sources */
 	for (i = 0; i < FSL_FEATURE_PWM_FAULT_CH_COUNT; i++) {
 		config->base->SM[config->index].DISMAP[i] = 0x0000;


### PR DESCRIPTION
Set the undocumented WAITEN bit so that the PWM remains on even if the CPU goes into a sleep mode, which AFAIK is the default behavior for other PWM drivers in Zephyr.

Fixes [#95096](https://github.com/zephyrproject-rtos/zephyr/issues/95096).

The comment includes the GitHub issue because the WAITEN bit is not mentioned in the reference manual.

