### PR TITLE
Stm32h7dks: Fix sdram available size for stm32h750b-dk and stm32h745i_disco

### DIFF
--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -37,7 +37,8 @@
 	sdram2: sdram@d0000000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		device_type = "memory";
-		reg = <0xd0000000 DT_SIZE_M(16)>; /* 128Mbit */
+		/* 128Mbit, but only half is available by HW design */
+		reg = <0xd0000000 DT_SIZE_M(8)>;
 		zephyr,memory-region = "SDRAM2";
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
 	};

--- a/boards/st/stm32h750b_dk/stm32h750b_dk-common.dtsi
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk-common.dtsi
@@ -20,7 +20,8 @@
 	sdram2: sdram@d0000000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		device_type = "memory";
-		reg = <0xd0000000 DT_SIZE_M(16)>; /* 128Mbit */
+		/* 128Mbit, but only half is available by HW design */
+		reg = <0xd0000000 DT_SIZE_M(8)>;
 		zephyr,memory-region = "SDRAM2";
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
 	};


### PR DESCRIPTION
According to UM2488 section 6.12[1], the available SDRAM size is only 8MB
by hardware design, though 128Bit SDRAM is connected.

Link: https://www.st.com/resource/en/user_manual/um2488-discovery-kits-with-stm32h745xi-and-stm32h750xb-mcus-stmicroelectronics.pdf [1]