### PR TITLE
Verify memory controller node while determining a running application partition.

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -19,7 +19,7 @@
  *
  * @defgroup flash_area_api flash area Interface
  * @since 1.11
- * @version 1.0.0
+ * @version 1.1.0
  * @ingroup storage_apis
  * @{
  */
@@ -464,6 +464,32 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
 		DT_FIXED_SUBPARTITION_EXISTS(node), \
 			(DT_MTD_FROM_FIXED_SUBPARTITION(node)), \
 			(DT_MTD_FROM_FIXED_PARTITION(node))))
+
+/**
+ * Get the node identifier of the flash controller the area/partition resides on
+ *
+ * @param label DTS node label of a partition
+ *
+ * @return Pointer to a device.
+ */
+#define FIXED_PARTITION_MTD(label) \
+	COND_CODE_1( \
+		DT_FIXED_SUBPARTITION_EXISTS(DT_NODELABEL(label)), \
+			(DT_MTD_FROM_FIXED_SUBPARTITION(DT_NODELABEL(label))), \
+			(DT_MTD_FROM_FIXED_PARTITION(DT_NODELABEL(label))))
+
+/**
+ * Get the node identifier of the flash controller the area/partition resides on
+ *
+ * @param node DTS node of a partition
+ *
+ * @return Pointer to a device.
+ */
+#define FIXED_PARTITION_NODE_MTD(node) \
+	COND_CODE_1( \
+		DT_FIXED_SUBPARTITION_EXISTS(node), \
+			(DT_MTD_FROM_FIXED_SUBPARTITION(node)), \
+			(DT_MTD_FROM_FIXED_PARTITION(node)))
 
 /**
  * Get pointer to flash_area object by partition label

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -24,13 +24,9 @@ LOG_MODULE_REGISTER(flash_img, CONFIG_IMG_MANAGER_LOG_LEVEL);
 #include <bootutil/bootutil_public.h>
 #endif
 
-#define FIXED_PARTITION_GET_FLASH_NODE(node_id)                                    \
-	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_PARENT(node_id), fixed_subpartitions),   \
-		    (DT_PARENT(DT_GPARENT(node_id))), (DT_GPARENT(node_id)))
-
 #define FIXED_PARTITION_IS_RUNNING_APP_PARTITION(label)                                            \
-	DT_SAME_NODE(FIXED_PARTITION_GET_FLASH_NODE(DT_CHOSEN(zephyr_code_partition)),             \
-		     FIXED_PARTITION_GET_FLASH_NODE(DT_NODELABEL(label))) &&                       \
+	DT_SAME_NODE(FIXED_PARTITION_NODE_MTD(DT_CHOSEN(zephyr_code_partition)),                   \
+		FIXED_PARTITION_MTD(label)) &&                                                     \
 	(FIXED_PARTITION_OFFSET(label) <= CONFIG_FLASH_LOAD_OFFSET &&                              \
 	 FIXED_PARTITION_OFFSET(label) + FIXED_PARTITION_SIZE(label) > CONFIG_FLASH_LOAD_OFFSET)
 

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -48,13 +48,9 @@
 	to be able to figure out application running slot.
 #endif
 
-#define FIXED_PARTITION_GET_FLASH_NODE(node_id)                                    \
-	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_PARENT(node_id), fixed_subpartitions),   \
-		    (DT_PARENT(DT_GPARENT(node_id))), (DT_GPARENT(node_id)))
-
 #define FIXED_PARTITION_IS_RUNNING_APP_PARTITION(label)                                            \
-	DT_SAME_NODE(FIXED_PARTITION_GET_FLASH_NODE(DT_CHOSEN(zephyr_code_partition)),             \
-		     FIXED_PARTITION_GET_FLASH_NODE(DT_NODELABEL(label))) &&                       \
+	DT_SAME_NODE(FIXED_PARTITION_NODE_MTD(DT_CHOSEN(zephyr_code_partition)),                   \
+		FIXED_PARTITION_MTD(label)) &&                                                     \
 	(FIXED_PARTITION_OFFSET(label) <= CONFIG_FLASH_LOAD_OFFSET &&                              \
 	 FIXED_PARTITION_OFFSET(label) + FIXED_PARTITION_SIZE(label) > CONFIG_FLASH_LOAD_OFFSET)
 

--- a/tests/subsys/dfu/img_util/src/main.c
+++ b/tests/subsys/dfu/img_util/src/main.c
@@ -13,13 +13,9 @@
 #define SLOT0_PARTITION		slot0_partition
 #define SLOT1_PARTITION		slot1_partition
 
-#define FIXED_PARTITION_GET_FLASH_NODE(node_id)                                    \
-	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_PARENT(node_id), fixed_subpartitions),   \
-		    (DT_PARENT(DT_GPARENT(node_id))), (DT_GPARENT(node_id)))
-
 #define FIXED_PARTITION_IS_RUNNING_APP_PARTITION(label)                                            \
-	DT_SAME_NODE(FIXED_PARTITION_GET_FLASH_NODE(DT_CHOSEN(zephyr_code_partition)),             \
-		     FIXED_PARTITION_GET_FLASH_NODE(DT_NODELABEL(label))) &&                       \
+	DT_SAME_NODE(FIXED_PARTITION_NODE_MTD(DT_CHOSEN(zephyr_code_partition)),                   \
+		FIXED_PARTITION_MTD(label)) &&                                                     \
 	(FIXED_PARTITION_OFFSET(label) <= CONFIG_FLASH_LOAD_OFFSET &&                              \
 	 FIXED_PARTITION_OFFSET(label) + FIXED_PARTITION_SIZE(label) > CONFIG_FLASH_LOAD_OFFSET)
 


### PR DESCRIPTION
Verify memory controller node while determining a running application partition.
Currently the check uses only offsets, which may give false results if there is a partition on the external memory with a matching offset range.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99762