### PR TITLE
Bluetooth: AVRCP: fix doxygen warning

### DIFF
--- a/include/zephyr/bluetooth/classic/avrcp.h
+++ b/include/zephyr/bluetooth/classic/avrcp.h
@@ -812,7 +812,7 @@ struct bt_avrcp_ct_cb {
 
 	/** @brief Callback for PDU ID LIST_PLAYER_APP_SETTING_VALS.
 	 *
-	 *  Called when the response for LIST_PLAYER_APP_SETTING_VALS is received.`
+	 *  Called when the response for LIST_PLAYER_APP_SETTING_VALS is received.
 	 *
 	 *  @param ct AVRCP CT connection object.
 	 *  @param tid The transaction label of the request.


### PR DESCRIPTION
fix a small typo that turns into a doxygen warning on recent doxygen versions