### PR TITLE
pr_metadata_check: add a "all approval" check

### DIFF
--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -9,6 +9,7 @@ on:
       - labeled
       - unlabeled
       - edited
+  pull_request_review:
 
 permissions:
   contents: read


### PR DESCRIPTION
Hi, this is my proposed workflow for complex PR:

- the bot assignes to a single area as usual
- the maintainer for the area recognized that the scope is too broad, assigns to other maintainer and sets the "all assignees" label 
- the workflow fails until app approvers approved

---

Add an option to have the PR metadata check to validate that all assignees approvd a PR, if the PR has been labeled as such.

This is meant to be used for handling complex PR where we want to make sure that reviewers from multiple areas approved before the PR can be merged.