### PR TITLE
tests: drivers: timer: nrf_grtc_timer: Add test with busy simulator

### DIFF
--- a/tests/drivers/timer/nrf_grtc_timer/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/timer/nrf_grtc_timer/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,4 +1,8 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 &grtc {
 	/delete-property/ child-owned-channels;
@@ -15,8 +19,19 @@ test_timer: &timer131 {
 	prescaler = <0>;
 };
 
+&timer132 {
+	status = "okay";
+	interrupts = <434 0>;
+};
+
 / {
 	chosen {
 		zephyr,cpu-load-counter = &timer130;
+	};
+
+	busy-sim {
+		compatible = "vnd,busy-sim";
+		status = "okay";
+		counter = <&timer132>;
 	};
 };

--- a/tests/drivers/timer/nrf_grtc_timer/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/timer/nrf_grtc_timer/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,4 +1,8 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 &grtc {
 	owned-channels = <5 6>;

--- a/tests/drivers/timer/nrf_grtc_timer/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/timer/nrf_grtc_timer/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,4 +1,8 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 &grtc {
 	interrupts = <228 2>;

--- a/tests/drivers/timer/nrf_grtc_timer/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/tests/drivers/timer/nrf_grtc_timer/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -1,4 +1,8 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 &grtc {
 	/*interrupts = <226 2>;*/
@@ -9,11 +13,6 @@ test_timer: &timer21 {
 	/*interrupts = <203 2>;*/
 };
 
-&timer20 {
-	status = "okay";
-	interrupts = <202 0>;
-};
-
 &timer00 {
 	status = "okay";
 	prescaler = <0>;
@@ -22,11 +21,5 @@ test_timer: &timer21 {
 / {
 	chosen {
 		zephyr,cpu-load-counter = &timer00;
-	};
-
-	busy-sim {
-		compatible = "vnd,busy-sim";
-		status = "okay";
-		counter = <&timer20>;
 	};
 };

--- a/tests/drivers/timer/nrf_grtc_timer/src/main.c
+++ b/tests/drivers/timer/nrf_grtc_timer/src/main.c
@@ -319,7 +319,7 @@ static void report_progress(uint32_t start, uint32_t end)
 	}
 }
 
-static void grtc_stress_test(bool busy_sim_en)
+ZTEST(nrf_grtc_timer, test_stress)
 {
 	static struct counter_alarm_cfg alarm_cfg;
 #if DT_NODE_EXISTS(DT_NODELABEL(test_timer)) && DT_NODE_HAS_STATUS(DT_NODELABEL(test_timer), okay)
@@ -354,7 +354,7 @@ static void grtc_stress_test(bool busy_sim_en)
 		counter_set(counter_dev, &alarm_cfg);
 	}
 
-	if (busy_sim_en) {
+	if (IS_ENABLED(CONFIG_TEST_BUSY_SIM)) {
 #ifdef CONFIG_TEST_BUSY_SIM
 		busy_sim_start(500, 200, 1000, 400, NULL);
 #endif
@@ -388,7 +388,7 @@ static void grtc_stress_test(bool busy_sim_en)
 	}
 	TC_PRINT("CPU load during test:%d.%d\n", load / 10, load % 10);
 
-	if (busy_sim_en) {
+	if (IS_ENABLED(CONFIG_TEST_BUSY_SIM)) {
 #ifdef CONFIG_TEST_BUSY_SIM
 		busy_sim_stop();
 #endif
@@ -397,11 +397,6 @@ static void grtc_stress_test(bool busy_sim_en)
 	if (counter_dev) {
 		counter_stop(counter_dev);
 	}
-}
-
-ZTEST(nrf_grtc_timer, test_stress)
-{
-	grtc_stress_test(false);
 }
 
 ZTEST_SUITE(nrf_grtc_timer, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
+++ b/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
@@ -1,23 +1,49 @@
 common:
   tags:
     - drivers
-  platform_allow:
-    - nrf54h20dk/nrf54h20/cpuapp
-    - nrf54h20dk/nrf54h20/cpurad
-    - nrf54h20dk/nrf54h20/cpuppr
-    - nrf54l15dk/nrf54l15/cpuapp
-    - nrf54l15dk/nrf54l15/cpuapp/ns
-    - nrf54l15dk/nrf54l15/cpuflpr
-    - nrf54l15bsim/nrf54l15/cpuapp
-    - nrf54lm20dk/nrf54lm20a/cpuapp
-    - nrf54lm20dk/nrf54lm20a/cpuflpr
-    - ophelia4ev/nrf54l15/cpuapp
-    - ophelia4ev/nrf54l15/cpuflpr
-  integration_platforms:
-    - nrf54lm20dk/nrf54lm20a/cpuapp
   timeout: 30
+
 tests:
-  drivers.timer.nrf_grtc_timer: {}
+  drivers.timer.nrf_grtc_timer:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+      - nrf54h20dk/nrf54h20/cpuppr
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuflpr
+      - nrf54l15bsim/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuflpr
+      - ophelia4ev/nrf54l15/cpuapp
+      - ophelia4ev/nrf54l15/cpuflpr
+    integration_platforms:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
   drivers.timer.nrf_grtc_timer.no_assert:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+      - nrf54h20dk/nrf54h20/cpuppr
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp/ns
+      - nrf54l15dk/nrf54l15/cpuflpr
+      - nrf54l15bsim/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuflpr
+      - ophelia4ev/nrf54l15/cpuapp
+      - ophelia4ev/nrf54l15/cpuflpr
+    integration_platforms:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     extra_configs:
       - CONFIG_ASSERT=n
+  drivers.timer.nrf_grtc_timer.busy_sim:
+    sysbuild: true
+    extra_configs:
+      - CONFIG_ASSERT=n
+      - CONFIG_TEST_BUSY_SIM=y
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Extend test to run with busy simulator enabled. There was some initial work done to support busy simulator but it was not used.

Configuration with busy simulator runs only on ARM Cortex-M targets as preemption is not support on RISCV cores.