### PR TITLE
samples: st: power_mgmt: wkup_pins: correct overlay for Nucleo-F103RB

### DIFF
--- a/samples/boards/st/power_mgmt/wkup_pins/boards/nucleo_f103rb.overlay
+++ b/samples/boards/st/power_mgmt/wkup_pins/boards/nucleo_f103rb.overlay
@@ -10,9 +10,14 @@
 	};
 
 	gpio_keys {
+		/*
+		 * PA0 is not connected to any button: you
+		 * must connect it to Vdd using a jumper wire.
+		 * (N.B.: PA0 is Arduino "A0"; Vdd is "+3.3V")
+		 */
 		wkup_button: wkup {
 			label = "WKUP";
-			gpios = <&gpioa 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			gpios = <&gpioa 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_POWER>;
 		};
 	};


### PR DESCRIPTION
The overlay indicated the pin was active-low with a pull-up resistor, but the hardware forces a pull-**DOWN** which makes the pin active-**HIGH** instead. Also add a comment indicating that the pin is not wired to a button and a short (to Vdd!) must be applied via a jumper wire.

c.f. RM0008:
<img width="1287" height="803" alt="image" src="https://github.com/user-attachments/assets/8a4cbb4e-bbbb-4135-9f20-ab023f34701f" />
