### PR TITLE
tests: posix: headers: Tests disable POSIX API but use POSIX symbols

### DIFF
--- a/tests/posix/headers/testcase.yaml
+++ b/tests/posix/headers/testcase.yaml
@@ -13,26 +13,14 @@ tests:
   portability.posix.headers.with_posix_api:
     extra_configs:
       - CONFIG_POSIX_API=y
-  portability.posix.headers.without_posix_api:
-    extra_configs:
-      - CONFIG_POSIX_API=n
   portability.posix.headers.minimal.with_posix_api:
     extra_configs:
       - CONFIG_POSIX_API=y
-  portability.posix.headers.minimal.without_posix_api:
-    extra_configs:
-      - CONFIG_POSIX_API=n
   portability.posix.headers.picolibc.with_posix_api:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_POSIX_API=y
-      - CONFIG_PICOLIBC=y
-  portability.posix.headers.picolibc.without_posix_api:
-    tags: picolibc
-    filter: CONFIG_PICOLIBC_SUPPORTED
-    extra_configs:
-      - CONFIG_POSIX_API=n
       - CONFIG_PICOLIBC=y
   portability.posix.headers.newlib.with_posix_api:
     tags: newlib
@@ -40,18 +28,8 @@ tests:
     extra_configs:
       - CONFIG_POSIX_API=y
       - CONFIG_NEWLIB_LIBC=y
-  portability.posix.headers.newlib.without_posix_api:
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
-    extra_configs:
-      - CONFIG_POSIX_API=n
-      - CONFIG_NEWLIB_LIBC=y
   portability.posix.headers.arcmwdtlib.with_posix_api:
     toolchain_allow: arcmwdt
     extra_configs:
       - CONFIG_POSIX_API=y
-      - CONFIG_ARCMWDT_LIBC=y
-  portability.posix.headers.arcmwdtlib.without_posix_api:
-    toolchain_allow: arcmwdt
-    extra_configs:
-      - CONFIG_POSIX_API=n
       - CONFIG_ARCMWDT_LIBC=y


### PR DESCRIPTION
This cannot possibly work, if POSIX is disabled, then the POSIX symbols are also not found so remove the "without_posix_api" tests.