### PR TITLE
boards: st: *c0: add missing wake-up pins

### DIFF
--- a/boards/st/nucleo_c031c6/nucleo_c031c6.dts
+++ b/boards/st/nucleo_c031c6/nucleo_c031c6.dts
@@ -59,6 +59,17 @@
 	};
 };
 
+/* Add the STM32C031Cx package-specific wake-up pins */
+&pwr {
+	wkup-pin@2 {
+		wkup-gpios = <&gpioc 13 STM32_PWR_WKUP_PIN_NOT_MUXED>;
+	};
+
+	wkup-pin@6 {
+		wkup-gpios = <&gpiob 5 STM32_PWR_WKUP_PIN_NOT_MUXED>;
+	};
+};
+
 &clk_lse {
 	status = "okay";
 };

--- a/boards/st/nucleo_c071rb/nucleo_c071rb.dts
+++ b/boards/st/nucleo_c071rb/nucleo_c071rb.dts
@@ -65,6 +65,21 @@
 	};
 };
 
+/* Add the STM32C071Rx package-specific wake-up pins */
+&pwr {
+	wkup-pin@2 {
+		wkup-gpios = <&gpioc 13 STM32_PWR_WKUP_PIN_NOT_MUXED>;
+	};
+
+	wkup-pin@5 {
+		wkup-gpios = <&gpioc 5 STM32_PWR_WKUP_PIN_NOT_MUXED>;
+	};
+
+	wkup-pin@6 {
+		wkup-gpios = <&gpiob 5 STM32_PWR_WKUP_PIN_NOT_MUXED>;
+	};
+};
+
 &clk_lse {
 	status = "okay";
 };

--- a/boards/st/nucleo_c092rc/nucleo_c092rc.dts
+++ b/boards/st/nucleo_c092rc/nucleo_c092rc.dts
@@ -74,6 +74,7 @@
 	};
 };
 
+/* Add the STM32C09xCx package-specific wake-up pins */
 &pwr {
 	wkup-pin@2 {
 		reg = <0x2>;

--- a/boards/st/stm32c0116_dk/stm32c0116_dk.dts
+++ b/boards/st/stm32c0116_dk/stm32c0116_dk.dts
@@ -89,6 +89,13 @@
 	};
 };
 
+/* Add the STM32C011Fx package-specific wake-up pins */
+&pwr {
+	wkup-pin@2 {
+		wkup-gpios = <&gpioa 4 STM32_PWR_WKUP_PIN_NOT_MUXED>;
+	};
+};
+
 &clk_hsi {
 	status = "okay";
 };


### PR DESCRIPTION
On the STM32C0 series, the availability of certain wake-up pins depends on the exact SoC in use. To avoid providing a large amout of SoC DTSI files, boards are responsible for defining these "optional" wake-up pins inside their own DTS.

Update existing STM32C0 boards' DTS to include the missing wake-up pins. While at it, align Nucleo-C092RC which has the pins, but no comment about why they are provided.