### PR TITLE
scripts: test_plan: Fix issue introduced in 3f77560

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -288,8 +288,8 @@ class Filters:
         # be removed from further consideration
         for _, board in matched_boards.items():
             relative_board_dir = str(board.dir.relative_to(zephyr_base))
-            resolved_filter = lambda f, rel_dir=relative_board_dir: rel_dir in f, resolved_files
-            self.resolved_files.extend(list(filter(resolved_filter)))
+            rel_resolved_files = [f for f in resolved_files if relative_board_dir in f]
+            self.resolved_files.extend(rel_resolved_files)
 
         _options = []
         if len(matched_boards) > 20:


### PR DESCRIPTION
The rewrite by ruff seems to wrongly pass a single argument to filter(), as seen in the logs:

```
    f.process()
  File "/home/runner/work/zephyr/zephyr/zephyr/./scripts/ci/test_plan.py", line 145, in process
    self.find_boards()
  File "/home/runner/work/zephyr/zephyr/zephyr/./scripts/ci/test_plan.py", line 292, in find_boards
    self.resolved_files.extend(list(filter(resolved_filter)))
                                    ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: filter expected 2 arguments, got 1
```

Split things up properly to avoid this.