### PR TITLE
using i2c standard frequency as the default frequency of i2c bus

### DIFF
--- a/drivers/i2c/i2c_ifx_xmc4.c
+++ b/drivers/i2c/i2c_ifx_xmc4.c
@@ -470,7 +470,7 @@ static DEVICE_API(i2c, i2c_xmc4_driver_api) = {
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		.scl_src = DT_INST_ENUM_IDX(n, scl_src),                                           \
 		.sda_src = DT_INST_ENUM_IDX(n, sda_src),                                           \
-		.bitrate = DT_INST_PROP_OR(n, clock_frequency, I2C_SPEED_STANDARD),                \
+		.bitrate = DT_INST_PROP_OR(n, clock_frequency, XMC4_I2C_SPEED_STANDARD),           \
 		XMC4_IRQ_HANDLER_STRUCT_INIT(n)                                                    \
 	};                                                                                         \
                                                                                                    \


### PR DESCRIPTION
Fixes zephyrproject-rtos/zephyr#99216.

This PR adds the default I2C bus clock frequency to the XMC47 relax kit DTS so that when developers enable the I2C peripheral, it automatically uses the standard frequency without requiring them to set it manually. It’s a small, beginner‑friendly change that improves usability and ensures consistent I2C behavior out of the box.

@ljd42 Feel free to give feedback on this if this is not the change you were expecting.