### PR TITLE
include: zephyr: arch: add GCC/Clang check for CFI support

### DIFF
--- a/include/zephyr/arch/cfi.h
+++ b/include/zephyr/arch/cfi.h
@@ -13,6 +13,10 @@
 
 #include <zephyr/arch/arch_interface.h>
 
+#if defined(__GNUC__) || defined(__clang__)
+/* DWARF Control Flow Integrity (CFI) support for architectures is only
+ * supported by LLVM and GCC toolchains.
+ */
 #if defined(CONFIG_X86_64)
 #include <zephyr/arch/x86/intel64/cfi.h>
 #elif defined(CONFIG_X86)
@@ -23,6 +27,7 @@
 #include <zephyr/arch/arm/cfi.h>
 #elif defined(CONFIG_RISCV)
 #include <zephyr/arch/riscv/cfi.h>
+#endif
 #endif
 
 /*


### PR DESCRIPTION
Add a preprocessor check to ensure that DWARF Control Flow Integrity (CFI) headers are only included when building with GCC or Clang toolchains, as CFI support is currently limited to these compilers. This prevents unsupported compilers from including architecture-specific CFI headers.

@RobinKastberg should fix IAR Toolchain compatiblity, could you run your tests against this branch?

