### PR TITLE
net: lib: ocpp: cleanup outdated code from initial design

### DIFF
--- a/subsys/net/lib/ocpp/core.c
+++ b/subsys/net/lib/ocpp/core.c
@@ -66,7 +66,10 @@ int ocpp_boot_notification(ocpp_session_handle_t hndl,
 	struct ocpp_wamp_rpc_msg rmsg = {0};
 
 	fn = ctx->cfn[PDU_BOOTNOTIFICATION];
-	sh->uid = fn(buf, sizeof(ctx->pdu_buf), sh, cpi);
+	ret = fn(buf, sizeof(ctx->pdu_buf), sh, cpi);
+	if (ret < 0) {
+		return ret;
+	}
 
 	rmsg.ctx = ctx;
 	rmsg.msg = buf;
@@ -212,7 +215,10 @@ int ocpp_authorize(ocpp_session_handle_t hndl, char *idtag,
 	strncpy(sh->idtag, idtag, sizeof(sh->idtag));
 	ui = &ctx->ui;
 	fn = ctx->cfn[PDU_AUTHORIZE];
-	sh->uid = fn(buf, sizeof(buf), sh);
+	ret = fn(buf, sizeof(buf), sh);
+	if (ret < 0) {
+		return ret;
+	}
 
 	rmsg.ctx = ctx;
 	rmsg.msg = buf;
@@ -243,7 +249,10 @@ int ocpp_heartbeat(ocpp_session_handle_t hndl)
 	char *buf = ctx->pdu_buf;
 
 	fn = ctx->cfn[PDU_HEARTBEAT];
-	sh->uid = fn(buf, sizeof(ctx->pdu_buf), sh);
+	ret = fn(buf, sizeof(ctx->pdu_buf), sh);
+	if (ret < 0) {
+		return ret;
+	}
 
 	rmsg.ctx = ctx;
 	rmsg.msg = buf;
@@ -293,7 +302,10 @@ int ocpp_start_transaction(ocpp_session_handle_t hndl,
 
 	fn = ctx->cfn[PDU_START_TRANSACTION];
 	ocpp_get_utc_now(utc);
-	sh->uid = fn(buf, sizeof(buf), sh, meter_val, -1, utc);
+	ret = fn(buf, sizeof(buf), sh, meter_val, -1, utc);
+	if (ret < 0) {
+		return ret;
+	}
 
 	ui = &ctx->ui;
 	rmsg.ctx = ctx;
@@ -367,7 +379,10 @@ int ocpp_stop_transaction(ocpp_session_handle_t hndl,
 
 	fn = ctx->cfn[PDU_STOP_TRANSACTION];
 	ocpp_get_utc_now(utc);
-	sh->uid = fn(buf, sizeof(buf), sh, meter_val, NULL, utc);
+	ret = fn(buf, sizeof(buf), sh, meter_val, NULL, utc);
+	if (ret < 0) {
+		return ret;
+	}
 
 	ui = &ctx->ui;
 	rmsg.ctx = ctx;
@@ -494,9 +509,12 @@ int ocpp_meter_values(ocpp_session_handle_t hndl,
 
 	fn = ctx->cfn[PDU_METER_VALUES];
 	ocpp_get_utc_now(utc);
-	sh->uid = fn(buf, sizeof(ctx->pdu_buf), sh, utc, sval,
-			mtr_ref_table[mes].smes,
-			mtr_ref_table[mes].unit);
+	ret = fn(buf, sizeof(ctx->pdu_buf), sh, utc, sval,
+		 mtr_ref_table[mes].smes,
+		 mtr_ref_table[mes].unit);
+	if (ret < 0) {
+		return ret;
+	}
 
 	rmsg.ctx = ctx;
 	rmsg.msg = buf;

--- a/subsys/net/lib/ocpp/ocpp_i.h
+++ b/subsys/net/lib/ocpp/ocpp_i.h
@@ -171,7 +171,6 @@ struct ocpp_session {
 	uint8_t idcon;
 	int idtxn;
 	int resp_status;
-	int uid;
 	sys_snode_t node;
 	struct ocpp_info *ctx;
 };


### PR DESCRIPTION
Cleanup outdated code from initial design.
now unique id of RPC message is stored on pdu_buffer itself.