### PR TITLE
soc: st: stm32u5 set backup sram retention if regulator is LDO

### DIFF
--- a/soc/st/stm32/common/stm32_backup_sram.c
+++ b/soc/st/stm32/common/stm32_backup_sram.c
@@ -43,11 +43,23 @@ static int stm32_backup_sram_init(const struct device *dev)
 	/* Add a refcount to backup domain access and never remove it */
 	stm32_backup_domain_enable_access();
 
-	/* enable backup sram regulator (required to retain backup SRAM content
-	 * while in standby or VBAT modes).
-	 */
-	LL_PWR_EnableBkUpRegulator();
-	while (!LL_PWR_IsEnabledBkUpRegulator()) {
+	if (IS_ENABLED(CONFIG_SOC_SERIES_STM32U5X)) {
+		/*
+		 * On STM32U5 series, backup RAM retention can only be enabled
+		 * when the LDO is selected as voltage regulator. However, the
+		 * SMPS regulator may have been selected by the time this code
+		 * executes, which results in a deadlock. To avoid this, the
+		 * SoC initialization code is modified to enable the regulator
+		 * on our behalf, before switching regulators - don't try to
+		 * enable the regulator again.
+		 */
+	} else {
+		/* enable backup sram regulator (required to retain backup SRAM content
+		 * while in standby or VBAT modes).
+		 */
+		LL_PWR_EnableBkUpRegulator();
+		while (!LL_PWR_IsEnabledBkUpRegulator()) {
+		}
 	}
 
 	return 0;

--- a/soc/st/stm32/stm32u5x/soc.c
+++ b/soc/st/stm32/stm32u5x/soc.c
@@ -59,6 +59,17 @@ void soc_early_init_hook(void)
 		LL_PWR_DisableUCPDDeadBattery();
 	}
 #endif
+#ifdef CONFIG_STM32_BACKUP_SRAM
+	/*
+	 * Enabling the Backup SRAM regulator is possible only when the LDO
+	 * voltage regulator is selected, as is the case after reset. If the
+	 * backup SRAM driver is enabled, make sure to enable the Backup SRAM
+	 * regulator on its behalf before (potentially) switching to SMPS.
+	 */
+	LL_PWR_EnableBkUpRegulator();
+	while (!LL_PWR_IsEnabledBkUpRegulator()) {
+	}
+#endif /* CONFIG_STM32_BACKUP_SRAM */
 
 	/* Power Configuration */
 	LL_PWR_SetRegulatorSupply(SELECTED_POWER_SUPPLY);


### PR DESCRIPTION
On the stm32u5 series, this commit will enable backup sram regulator when the regulator is LDO, during SOC init.
Then stm32_backup_sram_init()  will not change the backup SRAM retention anymore.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99056