### PR TITLE
soc: silabs: siwx91x: fix irq priority

### DIFF
--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -13,6 +13,12 @@ configdefault SYS_CLOCK_TICKS_PER_SEC
 configdefault UART_NS16550_DW8250_DW_APB
 	default y
 
+configdefault ZERO_LATENCY_IRQS
+	default y
+
+configdefault ZERO_LATENCY_LEVELS
+	default 2
+
 if PM_DEVICE
 
 configdefault PM_DEVICE_RUNTIME


### PR DESCRIPTION
The HAL used by the SiWx91x SoC implements a mechanism to protect atomic sections. Since this HAL also supports a zero-latency interrupt (ZLI) mechanism, we need to ensure the same number of bits are used for ZLI interrupts.

The interrupt priority level (2) depends on a hardcoded value in the Simplicity SDK (CORE_ATOMIC_BASE_PRIORITY_LEVEL).
Without this fix, arch_irq_lock (which sets the BASEPRI register to 0x4 when zero-latency interrupts are not enabled) is overridden by CORE_EnterAtomic in the HAL, which sets BASEPRI to 0xC since the HAL does not use the BASEPRI_MAX function. IRQ might then fires since it's register with a lowest priority in Zephyr.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/99904