### PR TITLE
drivers: regulator/fixed: Add voltage getter to fix device never ready

### DIFF
--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -74,11 +74,17 @@ static int regulator_fixed_list_voltage(const struct device *dev,
 	return 0;
 }
 
+static int regulator_fixed_get_voltage(const struct device *dev, int32_t *volt_uv)
+{
+	return regulator_common_get_min_voltage(dev, volt_uv);
+}
+
 static DEVICE_API(regulator, regulator_fixed_api) = {
 	.enable = regulator_fixed_enable,
 	.disable = regulator_fixed_disable,
 	.count_voltages = regulator_fixed_count_voltages,
 	.list_voltage = regulator_fixed_list_voltage,
+	.get_voltage = regulator_fixed_get_voltage,
 };
 
 static int regulator_fixed_init(const struct device *dev)


### PR DESCRIPTION
When regulator-min-microvolt and regulator-max-microvolt properties are provided in the devicetree node, a fixed regulator is never ready due to failed initialization in regulator_common_init().

At at commit 9463d9a51d9cb1094bf98ef437a39850a7b5705d regulator_common.c lines 68-71, if min or max voltages are set, then regulator_common_init() attempts to get the regulator's current voltage setting so that it might "Snap to closest interval value if out of range." However regulator-fixed has not implemented the regulator_get_voltage() api, so regulator_common_init() fails.

Adding an implementation for regulator_get_voltage() which returns min voltage, just like regulator_fixed_list_voltage() does, resolves this issue.

Fixes zephyrproject-rtos/zephyr#99339