### PR TITLE
tests: drivers: dma: loop_transfer: skip stop test if not supported

### DIFF
--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -24,7 +24,7 @@ extern "C" {
  * @brief Interfaces for DMA (Direct Memory Access) controllers.
  * @defgroup dma_interface DMA
  * @since 1.5
- * @version 1.0.0
+ * @version 1.1.0
  * @ingroup io_interfaces
  * @{
  */
@@ -471,12 +471,19 @@ static inline int dma_start(const struct device *dev, uint32_t channel)
  * @param channel Numeric identification of the channel where the transfer was
  *                being processed
  *
- * @retval 0 if successful.
- * @retval <0 Negative errno code if failure.
+ * @retval 0 If successful.
+ * @retval -ENOSYS If not implemented.
+ * @retval -EINVAL If invalid channel id.
+ * @retval -errno Other negative errno code failure.
  */
 static inline int dma_stop(const struct device *dev, uint32_t channel)
 {
-	return DEVICE_API_GET(dma, dev)->stop(dev, channel);
+	const struct dma_driver_api *api = DEVICE_API_GET(dma, dev);
+
+	if (api->stop == NULL) {
+		return -ENOSYS;
+	}
+	return api->stop(dev, channel);
 }
 
 /**

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -420,7 +420,13 @@ static int test_loop_repeated_start_stop(const struct device *dma)
 		return TC_FAIL;
 	}
 
-	if (dma_stop(dma, chan_id)) {
+	int res = dma_stop(dma, chan_id);
+
+	if (res == -ENOSYS) {
+		TC_PRINT("Stop not supported.\n");
+		ztest_test_skip();
+	}
+	if (res) {
 		TC_PRINT("ERROR: transfer stop on stopped channel (%d)\n", chan_id);
 		return TC_FAIL;
 	}


### PR DESCRIPTION
Skip the stop test if hardware does not support stopping a transaction. This allows a driver to still pass the loop transfer tests even if they don't implement `dma_stop()`.

This has been tested on Tenstorrent hardware,
<img width="953" height="204" alt="Screenshot 2025-11-21 at 4 20 20 PM" src="https://github.com/user-attachments/assets/954264cc-a7f7-48b8-885f-5942c7bb48b5" />
