### PR TITLE
usb: device_next: class: cdc_acm: throughput improvements (low hanging fruit)

### DIFF
--- a/subsys/usb/device_next/class/Kconfig.cdc_acm
+++ b/subsys/usb/device_next/class/Kconfig.cdc_acm
@@ -37,6 +37,16 @@ config USBD_CDC_ACM_BUF_POOL
 	  ACM instances and the size of the bulk endpoints. When disabled, the
 	  implementation uses the UDC driver's pool.
 
+config USBD_CDC_ACM_BUF_POOL_SIZE
+	int "Size of the buffers in the dedicated buffer pool"
+	depends on USBD_CDC_ACM_BUF_POOL
+	default 512 if USBD_MAX_SPEED_HIGH
+	default 64 if USBD_MAX_SPEED_FULL
+	help
+	  Increasing the size of buffers past the endpoint MPS can reduce the
+	  number of round trips through the CDC ACM class when the TX FIFO is larger,
+	  than the endpoint MPS, increasing throughput.
+
 module = USBD_CDC_ACM
 module-str = usbd cdc_acm
 default-count = 1

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -132,7 +132,8 @@ static void cdc_acm_irq_rx_enable(const struct device *dev);
 #if CONFIG_USBD_CDC_ACM_BUF_POOL
 UDC_BUF_POOL_DEFINE(cdc_acm_ep_pool,
 		    DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) * 2,
-		    USBD_MAX_BULK_MPS, sizeof(struct udc_buf_info), NULL);
+		    CONFIG_USBD_CDC_ACM_BUF_POOL_SIZE, sizeof(struct udc_buf_info),
+		    NULL);
 
 static struct net_buf *cdc_acm_buf_alloc(struct usbd_class_data *const c_data, const uint8_t ep,
 					 const size_t bytes_pending)


### PR DESCRIPTION
Do not artificially limit the size of the USB request to the endpoint MPS, as this forces multiple round trips through the CDC ACM class implementation when the TX FIFO is larger than the endpoint MPS. The lower USB layers handles packetizing to the maximum endpoint size. The maximum allocation size is limited to prevent starving other USB users.

When a custom pool is used for CDC ACM, allow the buffer sizes to be configured in Kconfig.

Throughput testing on a nRF52840DK with `CONFIG_UDC_BUF_POOL_SIZE=1024` shows a throughput increase from ~1.7 Mbps to ~2.7 Mbps.

Steps towards improving the issue of #99779, but this is only the absolute lowest hanging fruit).
Throughput tested on the reproducer steps from the linked issue.
The limit of `CONFIG_UDC_BUF_POOL_SIZE / 4` was picked out of thin air as a reasonable default, happy to hear arguments against.