### PR TITLE
Bluetooth: Controller: Use macros for access address and CRC init sizes

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -181,15 +181,15 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 static int prepare_cb_common(struct lll_prepare_param *p)
 {
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
+	uint8_t crc_init[PDU_CRCINIT_SIZE];
 	struct lll_adv_iso *lll;
 	uint32_t ticks_at_event;
 	uint32_t ticks_at_start;
 	uint16_t event_counter;
-	uint8_t access_addr[4];
 	uint64_t payload_count;
 	uint16_t data_chan_id;
 	uint8_t data_chan_use;
-	uint8_t crc_init[3];
 	struct pdu_bis *pdu;
 	struct ull_hdr *ull;
 	uint32_t remainder;
@@ -490,13 +490,13 @@ static void isr_tx_common(void *param,
 			  radio_isr_cb_t isr_tx,
 			  radio_isr_cb_t isr_done)
 {
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
+	uint8_t crc_init[PDU_CRCINIT_SIZE];
 	struct pdu_bis *pdu = NULL;
 	uint8_t data_chan_use = 0;
 	struct lll_adv_iso *lll;
-	uint8_t access_addr[4];
 	uint64_t payload_count;
 	uint16_t data_chan_id;
-	uint8_t crc_init[3];
 	uint8_t is_ctrl;
 	uint8_t bis;
 
@@ -942,7 +942,7 @@ static void next_chan_calc_seq(struct lll_adv_iso *lll, uint16_t event_counter,
 					      &lll->data_chan.prn_s,
 					      &lll->data_chan.remap_idx);
 	} else if (lll->bis_curr < lll->num_bis) {
-		uint8_t access_addr[4];
+		uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 
 		/* Calculate the Access Address for the next BIS subevent */
 		util_bis_aa_le32((lll->bis_curr + 1U), lll->seed_access_addr,
@@ -977,7 +977,7 @@ static void next_chan_calc_int(struct lll_adv_iso *lll, uint16_t event_counter)
 	    (lll->bn_curr == 1U) &&
 	    (lll->irc_curr == 1U) &&
 	    (lll->ptc_curr == 0U)) {
-		uint8_t access_addr[4];
+		uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 
 		/* Calculate the Access Address for the next BIS subevent */
 		util_bis_aa_le32((lll->bis_curr + 1U), lll->seed_access_addr,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -164,18 +164,18 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 static int prepare_cb_common(struct lll_prepare_param *p)
 {
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 	struct lll_sync_iso_stream *stream;
+	uint8_t crc_init[PDU_CRCINIT_SIZE];
 	struct node_rx_pdu *node_rx;
 	struct lll_sync_iso *lll;
 	uint32_t ticks_at_event;
 	uint32_t ticks_at_start;
 	uint16_t stream_handle;
 	uint16_t event_counter;
-	uint8_t access_addr[4];
 	uint16_t data_chan_id;
 	uint8_t data_chan_use;
 	uint32_t remainder_us;
-	uint8_t crc_init[3];
 	struct ull_hdr *ull;
 	uint32_t remainder;
 	uint32_t hcto;
@@ -571,12 +571,12 @@ static void isr_rx_estab(void *param)
 
 static void isr_rx(void *param)
 {
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 	struct lll_sync_iso_stream *stream;
+	uint8_t crc_init[PDU_CRCINIT_SIZE];
 	struct lll_sync_iso *lll;
-	uint8_t access_addr[4];
 	uint16_t data_chan_id;
 	uint8_t data_chan_use;
-	uint8_t crc_init[3];
 	uint8_t stream_curr;
 	uint8_t rssi_ready;
 	uint32_t start_us;
@@ -1635,7 +1635,7 @@ static void next_chan_calc_seq(struct lll_sync_iso *lll, uint16_t event_counter,
 					      &lll->data_chan.prn_s,
 					      &lll->data_chan.remap_idx);
 	} else if (lll->bis_curr < lll->num_bis) {
-		uint8_t access_addr[4];
+		uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 
 		/* Calculate the Access Address for the next BIS subevent */
 		util_bis_aa_le32((lll->bis_curr + 1U), lll->seed_access_addr,
@@ -1690,7 +1690,7 @@ static void next_chan_calc_int(struct lll_sync_iso *lll, uint16_t event_counter)
 	    (lll->bn_curr == 1U) &&
 	    (lll->irc_curr == 1U) &&
 	    (lll->ptc_curr == 0U)) {
-		uint8_t access_addr[4];
+		uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 
 		/* Calculate the Access Address for the next BIS subevent */
 		util_bis_aa_le32((bis_prev + 1U), lll->seed_access_addr,

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -14,6 +14,7 @@
 #define PDU_HEADER_SIZE        2
 #define PDU_MIC_SIZE           4
 #define PDU_CRC_SIZE           3
+#define PDU_CRCINIT_SIZE       3  /* CRC initialization value size */
 #define PDU_OVERHEAD_SIZE(phy) (PDU_PREAMBLE_SIZE(phy) + \
 				PDU_ACCESS_ADDR_SIZE + \
 				PDU_HEADER_SIZE + \


### PR DESCRIPTION
## Description

This PR addresses issue #40378 by replacing hardcoded array size literals with symbolic constants for  and  arrays in the Bluetooth controller code.

## Changes

1. **New define added** ():
   -  (3 bytes) - Specifically for CRC initialization values

2. **Updated files**:
   -  - 6 instances
   -  - 6 instances