### PR TITLE
dts: bindings: mtd: spi-nor: write and erase alignments

### DIFF
--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -14,6 +14,19 @@
 include: "jedec,jesd216.yaml"
 
 properties:
+  erase-block-size:
+    type: int
+    default: 4096
+    description: |
+      Address alignment required by flash erase operations.
+      The default of 4096 is supported by the majority of vendors.
+
+  write-block-size:
+    type: int
+    default: 1
+    description: |
+      Address alignment required by flash write operations.
+
   requires-ulbpr:
     type: boolean
     description: |


### PR DESCRIPTION
Add devicetree properties for `erase-block-size` and `write-block-size`. These properties are already available for other flash devices (notably `soc-nv-flash`) and are consumed by MCUboot in order to automatically determine sector counts.

The default values are supported by the vast majority of devices on the market (everything that I have seen).

This resolves the following MCUboot warning when secondary images are on external flash:
```
CMake Warning at CMakeLists.txt:533 (message):
  Unable to determine erase size of slot1 partition, cannot calculate minimum
  sector usage
```