### PR TITLE
drivers: sdhc: imx_usdhc: Extend all reset timeouts

### DIFF
--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -216,14 +216,14 @@ static void imx_usdhc_error_recovery(const struct device *dev)
 
 	if (status & kUSDHC_CommandInhibitFlag) {
 		/* Reset command line */
-		if (!USDHC_Reset(base, kUSDHC_ResetCommand, 100U)) {
+		if (!USDHC_Reset(base, kUSDHC_ResetCommand, 1000U)) {
 			LOG_ERR("Failed to reset command line");
 		}
 	}
 	if (((status & (uint32_t)kUSDHC_DataInhibitFlag) != 0U) ||
 	    (USDHC_GetAdmaErrorStatusFlags(base) != 0U)) {
 		/* Reset data line */
-		if (!USDHC_Reset(base, kUSDHC_ResetData, 100U)) {
+		if (!USDHC_Reset(base, kUSDHC_ResetData, 1000U)) {
 			LOG_ERR("Failed to reset data line");
 		}
 	}
@@ -568,7 +568,7 @@ static int imx_usdhc_execute_tuning(const struct device *dev)
 	transfer.data = &data;
 
 	/* Reset tuning circuit */
-	USDHC_Reset(base, kUSDHC_ResetTuning, 100U);
+	USDHC_Reset(base, kUSDHC_ResetTuning, 1000U);
 	/* Disable standard tuning */
 	USDHC_EnableStandardTuning(base, IMX_USDHC_STANDARD_TUNING_START, IMX_USDHC_TUNING_STEP,
 				   false);


### PR DESCRIPTION
commit bf61a47887ba ("drivers: sdhc: imx_usdhc: extend reset timeout duration") extended the timeout from 100 iterations to 1000 iterations for the `USDHC_Reset()` call in imx_usdhc_reset() but not in the other places it's called. I have observed a "usdhc: Failed to reset command line" error from `imx_usdhc_error_recovery()` on an i.MX RT1061, which goes away if I extend the timeout. Do so there and also at other call sites for good measure.