### PR TITLE
soc: nxp: imxrt: Initialize FlexRAM before first stack use

### DIFF
--- a/soc/nxp/imxrt/imxrt10xx/soc.c
+++ b/soc/nxp/imxrt/imxrt10xx/soc.c
@@ -360,12 +360,12 @@ void soc_early_init_hook(void)
 #ifdef CONFIG_SOC_RESET_HOOK
 void soc_reset_hook(void)
 {
-	/* Call CMSIS SystemInit */
-	SystemInit();
-
 #if defined(FLEXRAM_RUNTIME_BANKS_USED)
 	/* Configure flexram if not running from RAM */
 	flexram_dt_partition();
 #endif
+
+	/* Call CMSIS SystemInit */
+	SystemInit();
 }
 #endif

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -780,12 +780,12 @@ __asm__ (
 
 void __used _soc_reset_hook(void)
 {
-	SystemInit();
-
 #if defined(FLEXRAM_RUNTIME_BANKS_USED)
 	/* Configure flexram if not running from RAM */
 	flexram_dt_partition();
 #endif
+
+	SystemInit();
 }
 #endif
 


### PR DESCRIPTION
If the stack is in ITCM, DTCM, or FlexRAM OCRAM, `flexram_dt_partition()` may change its contents. The comment on `flexram_dt_partition()` acknowledges that, stating that it's inlined because it "cannot use [the] stack". But we currently call `SystemInit()`, which is not inlined and does use the stack, prior to `flexram_dt_partition()`! Fix that issue by reordering the calls.

It seems to me that `flexram_dt_partition()` would be safer as a soc_early_reset_hook implemented in assembly, but this fix does work for the moment. Tested on an i.MX RT1061, with the stack in FlexRAM OCRAM and entering Zephyr with all FlexRAM allocated to ITCM and DTCM.