### PR TITLE
MAINTAINERS: update SMF maintainers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4810,9 +4810,9 @@ Silabs SiM3U Platforms:
 State machine framework:
   status: maintained
   maintainers:
-    - sambhurst
     - vlad-kulikov
   collaborators:
+    - sambhurst
     - keith-zephyr
     - glenn-andrews
   files:


### PR DESCRIPTION
@sambhurst  has agreed to step down as maintainer of the State Machine Framework (SMF), per discussion with @keith-zephyr  (https://github.com/zephyrproject-rtos/zephyr/pull/98940#issuecomment-3533786510).

Right now I’ve removed @sambhurst from the SMF entry completely. If you prefer, I can instead move him under `collaborators:`. Please let me know and I’ll update the PR accordingly.