### PR TITLE
drivers: ieee802154: Properly namespace AF_UNSPEC by NET_AF_UNSPEC

### DIFF
--- a/drivers/ieee802154/ieee802154_esp32.c
+++ b/drivers/ieee802154/ieee802154_esp32.c
@@ -232,7 +232,7 @@ static int handle_ack(struct ieee802154_esp32_data *data)
 		ack_len = data->ack_frame[0] - IEEE802154_FCS_LENGTH;
 	}
 
-	ack_pkt = net_pkt_rx_alloc_with_buffer(data->iface, ack_len, AF_UNSPEC, 0, K_NO_WAIT);
+	ack_pkt = net_pkt_rx_alloc_with_buffer(data->iface, ack_len, NET_AF_UNSPEC, 0, K_NO_WAIT);
 	if (!ack_pkt) {
 		LOG_ERR("No free packet available.");
 		err = -ENOMEM;

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -581,7 +581,7 @@ static void handle_ack(struct kw41z_context *kw41z, uint8_t seq_number)
 	uint8_t ack_psdu[ACK_FRAME_LEN];
 
 	ack_pkt = net_pkt_rx_alloc_with_buffer(kw41z->iface, ACK_FRAME_LEN,
-					       AF_UNSPEC, 0, K_NO_WAIT);
+					       NET_AF_UNSPEC, 0, K_NO_WAIT);
 	if (!ack_pkt) {
 		LOG_ERR("No free packet available.");
 		return;


### PR DESCRIPTION
Couple of AF_UNSPEC need to be replaced by NET_AF_UNSPEC so that OpenThread tests will pass.

Fixes #99847