### PR TITLE
drivers: input: Add asserts for input touch inversions

### DIFF
--- a/drivers/input/input_chsc5x.c
+++ b/drivers/input/input_chsc5x.c
@@ -28,6 +28,8 @@ struct chsc5x_data {
 	struct gpio_callback int_gpio_cb;
 };
 
+INPUT_TOUCH_STRUCT_CHECK(struct chsc5x_config);
+
 enum {
 	CHSC5X_IC_TYPE_CHSC5472 = 0x00,
 	CHSC5X_IC_TYPE_CHSC5448 = 0x01,

--- a/drivers/input/input_touch.c
+++ b/drivers/input/input_touch.c
@@ -10,6 +10,10 @@ void input_touchscreen_report_pos(const struct device *dev,
 		k_timeout_t timeout)
 {
 	const struct input_touchscreen_common_config *cfg = dev->config;
+	__ASSERT(cfg->inverted_y == (cfg->screen_height > 0),
+		 "Y coordinate inversion requires screen-height");
+	__ASSERT(cfg->inverted_x == (cfg->screen_width > 0),
+		 "X coordinate inversion requires screen-width");
 	const uint32_t reported_x_code = cfg->swapped_x_y ? INPUT_ABS_Y : INPUT_ABS_X;
 	const uint32_t reported_y_code = cfg->swapped_x_y ? INPUT_ABS_X : INPUT_ABS_Y;
 	const uint32_t reported_x = cfg->inverted_x ? cfg->screen_width - x : x;


### PR DESCRIPTION
During development of https://github.com/zephyrproject-rtos/zephyr/pull/99585 I encountered cases where the reported coordinates were extremely large due to wrap around since the `screen-width` and `screen-height` properties default to 0.

Theoretically this would be catchable at build-time as well, however it would require another macro I guess, so I oopened this PR first with the less invasive assert.