### PR TITLE
drivers: input: gt911: Add touchscreen common config

### DIFF
--- a/drivers/input/Kconfig.gt911
+++ b/drivers/input/Kconfig.gt911
@@ -7,6 +7,7 @@ menuconfig INPUT_GT911
 	default y
 	depends on DT_HAS_GOODIX_GT911_ENABLED
 	select I2C
+	select INPUT_TOUCH
 	help
 	  Enable driver for multiple Goodix capacitive touch panel controllers.
 	  This driver should support gt9110, gt912, gt927, gt9271, gt928,

--- a/dts/bindings/input/goodix,gt911.yaml
+++ b/dts/bindings/input/goodix,gt911.yaml
@@ -5,7 +5,7 @@ description: GT9xx / GT9xxx capacitive touch panels
 
 compatible: "goodix,gt911"
 
-include: i2c-device.yaml
+include: [i2c-device.yaml, touchscreen-common.yaml]
 
 properties:
   irq-gpios:


### PR DESCRIPTION
Adds the touchscreen common config to the gt911 controller. 