### PR TITLE
drivers: systick: Improve the logic for detecting counter wrap-around events when exiting low power mode.

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -109,6 +109,12 @@ static cycle_t cycle_pre_idle;
 /* Idle timer value before entering the idle state. */
 static uint32_t idle_timer_pre_idle;
 
+/* How many ticks the system was expected to sleep when
+ * idle timer was configured. Used to determine if the
+ * counter overflowed or not.
+ */
+static uint32_t idle_timer_scheduled_sleep_ticks;
+
 /* Idle timer used for timer while entering the idle state */
 static const struct device *idle_timer = DEVICE_DT_GET(DT_CHOSEN(zephyr_cortex_m_idle_timer));
 
@@ -154,6 +160,8 @@ void z_cms_lptim_hook_on_lpm_entry(uint64_t max_lpm_time_us)
 	 * difference in measurements after exiting the idle state.
 	 */
 	counter_get_value(idle_timer, &idle_timer_pre_idle);
+
+	idle_timer_scheduled_sleep_ticks = cfg.ticks;
 }
 
 uint64_t z_cms_lptim_hook_on_lpm_exit(void)
@@ -161,18 +169,34 @@ uint64_t z_cms_lptim_hook_on_lpm_exit(void)
 	/**
 	 * Calculate how much time elapsed according to counter.
 	 */
-	uint32_t idle_timer_post, idle_timer_diff;
+	uint32_t idle_timer_post, idle_timer_diff, idle_timer_top;
+	bool idle_timer_int_pending, idle_timer_wrap;
 
 	counter_get_value(idle_timer, &idle_timer_post);
+	idle_timer_int_pending = counter_get_pending_int(idle_timer) ? true : false;
+	idle_timer_top = counter_get_top_value(idle_timer);
 
 	/**
 	 * Check for counter timer overflow
 	 * (TODO: this doesn't work for downcounting timers!)
 	 */
 	if (idle_timer_pre_idle > idle_timer_post) {
-		idle_timer_diff =
-			(counter_get_top_value(idle_timer) - idle_timer_pre_idle) +
-			idle_timer_post + 1;
+		/* Pre > Post: counter wrapped (overflow occurred) */
+		idle_timer_wrap = true;
+	} else if (idle_timer_pre_idle == idle_timer_post) {
+		/* Pre == Post: consider wrap only if interrupt is pending */
+		idle_timer_wrap = idle_timer_int_pending;
+	} else {
+		/* Pre < Post: normally no wrap; if interrupt pending and the
+		 * expected sleep spans the counter top, treat as wrap.
+		 */
+		idle_timer_wrap = idle_timer_int_pending &&
+			((uint64_t)idle_timer_pre_idle + idle_timer_scheduled_sleep_ticks
+				>= idle_timer_top);
+	}
+
+	if (idle_timer_wrap) {
+		idle_timer_diff = idle_timer_top - idle_timer_pre_idle + idle_timer_post + 1;
 	} else {
 		idle_timer_diff = idle_timer_post - idle_timer_pre_idle;
 	}


### PR DESCRIPTION
When exiting from low power mode, there are three scenarios for `idle_timer_pre_idle `and `idle_timer_post`:

- `idle_timer_pre_idle > idle_timer_post` In this case, a wraparound has definitely occurred, so: `diff = top - pre + post + 1 `
```
    /* exmaples: Top=100, Scheduled=90, Pre=60, Post=50 */
    if (idle_timer_pre_idle > idle_timer_post) {
           idle_timer_diff = idle_timer_top - idle_timer_pre_idle + idle_timer_post + 1;
    }
```

- `idle_timer_pre_idle = idle_timer_post` In this case, there are two possibilities:

  - No wraparound occurred: `diff = post - pre`
  - Wraparound occurred (determined by `alarm_pending `being true): `diff = top - pre + post + 1`
```
    /* example: Top=100, Scheduled=100, Pre=0, Post=0 */
    if (idle_timer_pre_idle == idle_timer_post) {
        if (alarm_pending) {
            idle_timer_diff = idle_timer_top - idle_timer_pre_idle + idle_timer_post + 1;
        } else {
             idle_timer_diff = idle_timer_post - idle_timer_pre_idle; /* did not enter low power mode. */
        }   
    }
```


- `idle_timer_pre_idle < idle_timer_post` In this case, there are two possibilities:

  - No wraparound occurred: `diff = post - pre` (note that `alarm_pending ` maybe true caused by alarm, if `alarm_pending ` is not true, then it means it was woken up early by another event. )
  - Wraparound occurred: `diff = top - pre + post + 1` (note that `alarm_pending `is true caused by wraparound), in this situation, there are two possibilities: one is `pre + scheduled >= top`, and the other is `pre + scheduled < top`. Currently there is no suitable method to distinguish the latter case.
```
    if (idle_timer_pre_idle < idle_timer_post) {
        if (alarm_pending) {
             if () { /* Currently there is no way to find the corresponding condition for this case, so this situation will not be covered for now.  */
                 /* case: wraparound (CPU wakeup time is relatively long). example: Top=100, Scheduled=85, Pre=10, Post=15 (delay 20) */
                 idle_timer_diff = idle_timer_top - idle_timer_pre_idle + idle_timer_post + 1;
             } else if (idle_timer_scheduled_sleep_ticks != 0 && (uint64_t)idle_timer_pre_idle + idle_timer_scheduled_sleep_ticks >= idle_timer_top) {
                 /* case: wraparound (CPU wakeup time is relatively long). example: Top=100, Scheduled=95, Pre=10, Post=15 (delay 10) */
                 idle_timer_diff = idle_timer_top - idle_timer_pre_idle + idle_timer_post + 1;
             } else {
                 /* case: no wraparound. example: Top=100, Scheduled=60, Pre=10, Post=70 */
                 idle_timer_diff = idle_timer_post - idle_timer_pre_idle;
             }
        } else {
             /* case: wakeup early by another event. example: Top=100, Scheduled=60, Pre=10, Post=30 */
             idle_timer_diff = idle_timer_post - idle_timer_pre_idle;
        }   
    }
```