### PR TITLE
scripts: requirements: update pyocd version

### DIFF
--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -3,7 +3,7 @@
 # things used by twister or related in run time testing
 
 # used to flash & debug various boards
-pyocd>=0.35.0
+pyocd>=0.36.0
 
 # used by twister for board/hardware map
 tabulate


### PR DESCRIPTION
Update pyocd version to be greater than or equal to 0.36.0 to fix the potential hang issue when execute "west packages pip --install"

This PR is to fix the issue #99115.