### PR TITLE
Feature/fix non cache buffer of uhc ehci

### DIFF
--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -341,8 +341,13 @@ int uhc_mcux_hal_init_transfer_common(const struct device *dev, usb_host_transfe
 	mcux_xfer->callbackParam = (void *)dev;
 	mcux_xfer->setupPacket = (usb_setup_struct_t *)&xfer->setup_pkt[0];
 	if (xfer->buf != NULL) {
-		mcux_xfer->transferLength = xfer->buf->size;
-		mcux_xfer->transferBuffer = xfer->buf->__buf;
+		if (USB_EP_DIR_IS_OUT(xfer->ep)) {
+			mcux_xfer->transferLength = xfer->buf->len;
+			mcux_xfer->transferBuffer = xfer->buf->data;
+		} else {
+			mcux_xfer->transferLength = net_buf_tailroom(xfer->buf);
+			mcux_xfer->transferBuffer = net_buf_tail(xfer->buf);
+		}
 	} else {
 		mcux_xfer->transferBuffer = NULL;
 		mcux_xfer->transferLength = 0;

--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -168,13 +168,12 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 		uhc_mcux_nocache_free(transfer->setupPacket);
 	}
 #endif
-	if ((xfer->buf != NULL) && (transfer->transferBuffer != NULL)) {
-		if (transfer->transferSofar > 0) {
+	if ((xfer->buf != NULL) && (transfer->transferBuffer != NULL) &&
+	    USB_EP_DIR_IS_IN(xfer->ep) && (transfer->transferSofar > 0)) {
 #if defined(CONFIG_NOCACHE_MEMORY)
-			memcpy(xfer->buf->__buf, transfer->transferBuffer, transfer->transferSofar);
+		memcpy(xfer->buf->__buf, transfer->transferBuffer, transfer->transferSofar);
 #endif
-			net_buf_add(xfer->buf, transfer->transferSofar);
-		}
+		net_buf_add(xfer->buf, transfer->transferSofar);
 #if defined(CONFIG_NOCACHE_MEMORY)
 		uhc_mcux_nocache_free(transfer->transferBuffer);
 #endif

--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -171,7 +171,7 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 	if ((xfer->buf != NULL) && (transfer->transferBuffer != NULL) &&
 	    USB_EP_DIR_IS_IN(xfer->ep) && (transfer->transferSofar > 0)) {
 #if defined(CONFIG_NOCACHE_MEMORY)
-		memcpy(xfer->buf->__buf, transfer->transferBuffer, transfer->transferSofar);
+		memcpy(net_buf_tail(xfer->buf), transfer->transferBuffer, transfer->transferSofar);
 #endif
 		net_buf_add(xfer->buf, transfer->transferSofar);
 #if defined(CONFIG_NOCACHE_MEMORY)
@@ -199,8 +199,20 @@ static usb_host_transfer_t *uhc_mcux_hal_init_transfer(const struct device *dev,
 #if defined(CONFIG_NOCACHE_MEMORY)
 	mcux_xfer->setupPacket = uhc_mcux_nocache_alloc(8u);
 	memcpy(mcux_xfer->setupPacket, xfer->setup_pkt, 8u);
-	if (xfer->buf != NULL) {
-		mcux_xfer->transferBuffer = uhc_mcux_nocache_alloc(mcux_xfer->transferLength);
+
+	if (mcux_xfer->transferBuffer != NULL && mcux_xfer->transferLength != 0) {
+		uint8_t *nocache_buf = uhc_mcux_nocache_alloc(mcux_xfer->transferLength);
+
+		if (nocache_buf == NULL) {
+			k_mem_slab_free(&mcux_uhc_transfer_pool, mcux_xfer);
+			return NULL;
+		}
+
+		if (USB_EP_DIR_IS_OUT(xfer->ep)) {
+			memcpy(nocache_buf, mcux_xfer->transferBuffer, mcux_xfer->transferLength);
+		}
+
+		mcux_xfer->transferBuffer = nocache_buf;
 	}
 #endif
 

--- a/drivers/usb/uhc/uhc_mcux_ip3516hs.c
+++ b/drivers/usb/uhc/uhc_mcux_ip3516hs.c
@@ -138,10 +138,9 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 		}
 	}
 
-	if ((xfer->buf != NULL) && (transfer->transferBuffer != NULL)) {
-		if (transfer->transferSofar > 0) {
-			net_buf_add(xfer->buf, transfer->transferSofar);
-		}
+	if ((xfer->buf != NULL) && (transfer->transferBuffer != NULL) &&
+	    USB_EP_DIR_IS_IN(xfer->ep) && (transfer->transferSofar > 0)) {
+		net_buf_add(xfer->buf, transfer->transferSofar);
 	}
 
 	transfer->setupPacket = NULL;

--- a/drivers/usb/uhc/uhc_mcux_khci.c
+++ b/drivers/usb/uhc/uhc_mcux_khci.c
@@ -124,10 +124,9 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 		}
 	}
 
-	if ((xfer->buf != NULL) && (transfer->transferBuffer != NULL)) {
-		if (transfer->transferSofar > 0) {
-			net_buf_add(xfer->buf, transfer->transferSofar);
-		}
+	if ((xfer->buf != NULL) && (transfer->transferBuffer != NULL) &&
+	    USB_EP_DIR_IS_IN(xfer->ep) && (transfer->transferSofar > 0)) {
+		net_buf_add(xfer->buf, transfer->transferSofar);
 	}
 
 	transfer->setupPacket = NULL;

--- a/drivers/usb/uhc/uhc_mcux_ohci.c
+++ b/drivers/usb/uhc/uhc_mcux_ohci.c
@@ -124,10 +124,9 @@ static void uhc_mcux_transfer_callback(void *param, usb_host_transfer_t *transfe
 		}
 	}
 
-	if ((xfer->buf != NULL) && (transfer->transferBuffer != NULL)) {
-		if (transfer->transferSofar > 0) {
-			net_buf_add(xfer->buf, transfer->transferSofar);
-		}
+	if ((xfer->buf != NULL) && (transfer->transferBuffer != NULL) &&
+	    USB_EP_DIR_IS_IN(xfer->ep) && (transfer->transferSofar > 0)) {
+		net_buf_add(xfer->buf, transfer->transferSofar);
 	}
 
 	transfer->setupPacket = NULL;


### PR DESCRIPTION
- Differentiating between IN and OUT transfers for proper buffer setup.
    For OUT transfers: use existing data from buf->data with buf->len.
    For IN transfers: use available space from net_buf_tail() with tailroom.
- Improves buffer management in MCUX USB host controller driver by:
    Using net_buf_tailroom() to prevent buffer overflows in transfer callback.
    Add proper error handling for nocache memory allocation failures.
    Only allocate setup packet for control endpoint (EP0).
    Copy data to nocache buffer for OUT transfers.