### PR TITLE
Minor updates of rm67162 and mipi dbi dcnano driver

### DIFF
--- a/drivers/display/display_rm67162.c
+++ b/drivers/display/display_rm67162.c
@@ -250,7 +250,7 @@ static int rm67162_init(const struct device *dev)
 		}
 		/* Per datasheet, reset low pulse width should be at least 10usec */
 		k_sleep(K_USEC(30));
-		gpio_pin_set_dt(&config->reset_gpio, 1);
+		ret = gpio_pin_set_dt(&config->reset_gpio, 1);
 		if (ret < 0) {
 			LOG_ERR("Could not pull reset high (%d)", ret);
 			return ret;

--- a/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
@@ -226,7 +226,7 @@ static int mipi_dbi_dcnano_lcdif_write_display(const struct device *dev,
 		bytes_per_pixel = 2U;
 		break;
 	default:
-		LOG_ERR("Bus tyoe not supported.");
+		LOG_ERR("Bus type not supported.");
 		ret = -ENODEV;
 		break;
 	}


### PR DESCRIPTION
1. Update display_rm67162 to check the return value of reset pin gpio configuration operation.
2. Fix typo in NXP DCnano DBI driver