### PR TITLE
lora: preamble and header detection callbacks

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -282,6 +282,12 @@ Libsbc
 * Libsbc (sbc.c and sbc.h) is moved under the Bluetooth subsystem. The sbc.h is in
   include/zephyr/bluetooth now.
 
+LoRa/LoRaWAN
+============
+
+* The ``recv`` and ``user_data`` arguments previously supplied to :c:func:`lora_recv_async` are now
+  fields of a single struct (:c:struct:`lora_recv_async_callbacks`), which is provided by reference.
+
 Tracing
 ========
 

--- a/drivers/lora/lora_basics_modem/lbm_common.c
+++ b/drivers/lora/lora_basics_modem/lbm_common.c
@@ -289,7 +289,7 @@ release:
 	return ret;
 }
 
-int lbm_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user_data)
+int lbm_lora_recv_async(const struct device *dev, const struct lora_recv_async_callbacks *cb)
 {
 	const struct lbm_lora_config_common *config = dev->config;
 	struct lbm_lora_data_common *data = dev->data;
@@ -304,6 +304,10 @@ int lbm_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user_da
 		return 0;
 	}
 
+	if (cb->recv == NULL) {
+		return -EINVAL;
+	}
+
 	/* Ensure available */
 	if (!modem_acquire(dev)) {
 		return -EBUSY;
@@ -314,8 +318,8 @@ int lbm_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user_da
 	data->modem_mode = MODE_RX_ASYNC;
 
 	/* Store user state */
-	data->rx_state.async.rx_cb = cb;
-	data->rx_state.async.user_data = user_data;
+	data->rx_state.async.rx_cb = cb->recv;
+	data->rx_state.async.user_data = cb->user_data;
 
 	/* Start the reception in continuous mode */
 	status = ral_set_rx(&config->ralf.ral, RAL_RX_TIMEOUT_CONTINUOUS_MODE);

--- a/drivers/lora/lora_basics_modem/lbm_common.c
+++ b/drivers/lora/lora_basics_modem/lbm_common.c
@@ -11,8 +11,8 @@
 
 /* LoRa interrupts from the RAL library */
 #define RAL_IRQ_LORA                                                                               \
-	RAL_IRQ_TX_DONE | RAL_IRQ_RX_DONE | RAL_IRQ_RX_HDR_ERROR | RAL_IRQ_RX_CRC_ERROR |          \
-		RAL_IRQ_CAD_DONE | RAL_IRQ_CAD_OK
+	(RAL_IRQ_TX_DONE | RAL_IRQ_RX_DONE | RAL_IRQ_RX_HDR_ERROR | RAL_IRQ_RX_CRC_ERROR |         \
+	 RAL_IRQ_CAD_DONE | RAL_IRQ_CAD_OK)
 
 LOG_MODULE_REGISTER(lbm_driver, CONFIG_LORA_LOG_LEVEL);
 
@@ -293,10 +293,15 @@ int lbm_lora_recv_async(const struct device *dev, const struct lora_recv_async_c
 {
 	const struct lbm_lora_config_common *config = dev->config;
 	struct lbm_lora_data_common *data = dev->data;
+	ral_irq_t irqs = RAL_IRQ_LORA;
 	ral_status_t status;
 
 	/* Cancel ongoing reception */
 	if (cb == NULL) {
+		if (data->rx_state.async.preamble_detected || data->rx_state.async.header_valid) {
+			/* Reset IRQ state */
+			(void)ral_set_dio_irq_params(&config->ralf.ral, irqs);
+		}
 		if (!modem_release(dev)) {
 			/* Not receiving or already being stopped */
 			return -EINVAL;
@@ -313,13 +318,28 @@ int lbm_lora_recv_async(const struct device *dev, const struct lora_recv_async_c
 		return -EBUSY;
 	}
 
+	/* Configure interrupts for desired events */
+	if (cb->preamble_detected) {
+		irqs |= RAL_IRQ_RX_PREAMBLE_DETECTED;
+	}
+	if (cb->header_valid) {
+		irqs |= RAL_IRQ_RX_HDR_OK;
+	}
+	if (irqs != RAL_IRQ_LORA) {
+		status = ral_set_dio_irq_params(&config->ralf.ral, irqs);
+		if (status != RAL_STATUS_OK) {
+			modem_release(dev);
+			LOG_ERR("RAL DIO init failure (%d)", status);
+			return -EIO;
+		}
+	}
+
 	/* Configure modem for asynchronous RX */
 	lbm_driver_antenna_configure(dev, MODE_RX_ASYNC);
 	data->modem_mode = MODE_RX_ASYNC;
 
 	/* Store user state */
-	data->rx_state.async.rx_cb = cb->recv;
-	data->rx_state.async.user_data = cb->user_data;
+	data->rx_state.async = *cb;
 
 	/* Start the reception in continuous mode */
 	status = ral_set_rx(&config->ralf.ral, RAL_RX_TIMEOUT_CONTINUOUS_MODE);
@@ -440,8 +460,8 @@ static void op_done_async_rx(const struct device *dev)
 		       : pkt_status.signal_rssi_pkt_in_dbm;
 
 	/* Run the user callback */
-	data->rx_state.async.rx_cb(dev, rx_buffer, size, rssi, pkt_status.snr_pkt_in_db,
-				   data->rx_state.async.user_data);
+	data->rx_state.async.recv(dev, rx_buffer, size, rssi, pkt_status.snr_pkt_in_db,
+				  data->rx_state.async.user_data);
 }
 
 static void op_done_work_handler(struct k_work *work)
@@ -458,7 +478,25 @@ static void op_done_work_handler(struct k_work *work)
 	bool error_irq;
 	int ret = 0;
 
-	LOG_DBG("%d", data->modem_mode);
+	/* Get and reset the current IRQ state */
+	(void)ral_get_irq_status(&config->ralf.ral, &irq_state);
+	(void)ral_clear_irq_status(&config->ralf.ral, RAL_IRQ_ALL);
+	error_irq = irq_state & (RAL_IRQ_RX_TIMEOUT | RAL_IRQ_RX_HDR_ERROR | RAL_IRQ_RX_CRC_ERROR);
+
+	LOG_DBG("%d: IRQ %08X", data->modem_mode, irq_state);
+
+	if ((irq_state & RAL_IRQ_RX_PREAMBLE_DETECTED) && data->rx_state.async.preamble_detected) {
+		LOG_DBG("Preamble detected IRQ");
+		/* Run the user callback */
+		data->rx_state.async.preamble_detected(dev, data->rx_state.async.user_data);
+		return;
+	}
+	if ((irq_state & RAL_IRQ_RX_HDR_OK) && data->rx_state.async.header_valid) {
+		LOG_DBG("Header valid IRQ");
+		/* Run the user callback */
+		data->rx_state.async.header_valid(dev, data->rx_state.async.user_data);
+		return;
+	}
 
 	switch (data->modem_mode) {
 	case MODE_SLEEP:
@@ -493,15 +531,7 @@ static void op_done_work_handler(struct k_work *work)
 		break;
 	}
 
-	/* Get and reset the current IRQ state */
-	(void)ral_get_irq_status(&config->ralf.ral, &irq_state);
-	(void)ral_clear_irq_status(&config->ralf.ral, RAL_IRQ_ALL);
-	error_irq = irq_state & (RAL_IRQ_RX_TIMEOUT | RAL_IRQ_RX_HDR_ERROR | RAL_IRQ_RX_CRC_ERROR);
-
-	/* Release the modem before running the user callback so that the notified thread can
-	 * immediately start another operation before the work item terminates. This requires
-	 * preserving the operation_done pointer, since modem_release clears it.
-	 */
+	/* Preserve the operation_done pointer, since modem_release clears it */
 	sig_done = data->operation_done;
 
 	/* Modem should return to idle */

--- a/drivers/lora/lora_basics_modem/lbm_common.h
+++ b/drivers/lora/lora_basics_modem/lbm_common.h
@@ -54,11 +54,8 @@ struct lbm_lora_data_common {
 			int16_t rssi_dbm;
 			int8_t snr_db;
 		} sync;
-		struct {
-			/* Async RX params */
-			lora_recv_cb rx_cb;
-			void *user_data;
-		} async;
+		/* Async RX params */
+		struct lora_recv_async_callbacks async;
 	} rx_state;
 	/* User signal */
 	struct k_poll_signal *operation_done;

--- a/drivers/lora/loramac_node/sx12xx_common.c
+++ b/drivers/lora/loramac_node/sx12xx_common.c
@@ -307,7 +307,7 @@ int sx12xx_lora_recv(const struct device *dev, uint8_t *data, uint8_t size,
 	return size;
 }
 
-int sx12xx_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user_data)
+int sx12xx_lora_recv_async(const struct device *dev, const struct lora_recv_async_callbacks *cb)
 {
 	/* Cancel ongoing reception */
 	if (cb == NULL) {
@@ -318,14 +318,18 @@ int sx12xx_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user
 		return 0;
 	}
 
+	if (cb->recv == NULL) {
+		return -EINVAL;
+	}
+
 	/* Ensure available */
 	if (!modem_acquire(&dev_data)) {
 		return -EBUSY;
 	}
 
 	/* Store parameters */
-	dev_data.async_rx_cb = cb;
-	dev_data.async_user_data = user_data;
+	dev_data.async_rx_cb = cb->recv;
+	dev_data.async_user_data = cb->user_data;
 
 	/* Start reception */
 	Radio.SetMaxPayloadLength(MODEM_LORA, 255);

--- a/drivers/lora/loramac_node/sx12xx_common.c
+++ b/drivers/lora/loramac_node/sx12xx_common.c
@@ -321,6 +321,9 @@ int sx12xx_lora_recv_async(const struct device *dev, const struct lora_recv_asyn
 	if (cb->recv == NULL) {
 		return -EINVAL;
 	}
+	if (cb->preamble_detected || cb->header_valid) {
+		LOG_DBG("LoRaMAC-node only supports the `recv` callback");
+	}
 
 	/* Ensure available */
 	if (!modem_acquire(&dev_data)) {

--- a/drivers/lora/loramac_node/sx12xx_common.h
+++ b/drivers/lora/loramac_node/sx12xx_common.h
@@ -29,7 +29,7 @@ int sx12xx_lora_send_async(const struct device *dev, uint8_t *data,
 int sx12xx_lora_recv(const struct device *dev, uint8_t *data, uint8_t size,
 		     k_timeout_t timeout, int16_t *rssi, int8_t *snr);
 
-int sx12xx_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user_data);
+int sx12xx_lora_recv_async(const struct device *dev, const struct lora_recv_async_callbacks *cb);
 
 int sx12xx_lora_config(const struct device *dev,
 		       struct lora_modem_config *config);

--- a/drivers/lora/rylrxxx.c
+++ b/drivers/lora/rylrxxx.c
@@ -520,7 +520,7 @@ exit:
 	return ret;
 }
 
-int rylr_recv_async(const struct device *dev, lora_recv_cb cb, void *user_data)
+int rylr_recv_async(const struct device *dev, const struct lora_recv_async_callbacks *cb)
 {
 	int err = 0;
 	struct rylr_data *data = dev->data;
@@ -531,8 +531,13 @@ int rylr_recv_async(const struct device *dev, lora_recv_cb cb, void *user_data)
 		return err;
 	}
 
-	/* This is not a user error but the documeted way to cancel async reception in lora api*/
+	/* This is not a user error but the documented way to cancel async reception in lora api */
 	if (cb == NULL) {
+		goto bail;
+	}
+
+	if (cb->recv == NULL) {
+		err = -EINVAL;
 		goto bail;
 	}
 
@@ -542,8 +547,8 @@ int rylr_recv_async(const struct device *dev, lora_recv_cb cb, void *user_data)
 		goto bail;
 	}
 
-	data->async_rx_cb = cb;
-	data->async_user_data = user_data;
+	data->async_rx_cb = cb->recv;
+	data->async_user_data = cb->user_data;
 	if (RYLR_IS_ASYNC_OP_PENDING(data->pending_async_flags)) {
 		LOG_ERR("pending async operation");
 		err = -EBUSY;

--- a/drivers/lora/rylrxxx.c
+++ b/drivers/lora/rylrxxx.c
@@ -540,6 +540,9 @@ int rylr_recv_async(const struct device *dev, const struct lora_recv_async_callb
 		err = -EINVAL;
 		goto bail;
 	}
+	if (cb->preamble_detected || cb->header_valid) {
+		LOG_DBG("Only the `recv` callback supported");
+	}
 
 	if (data->is_tx) {
 		LOG_ERR("radio is configured for tx");

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -131,6 +131,12 @@ struct lora_modem_config {
  */
 
 /**
+ * @typedef lora_event_cb()
+ * @brief Callback API for receiving events asynchronously
+ */
+typedef void (*lora_event_cb)(const struct device *dev, void *user_data);
+
+/**
  * @typedef lora_recv_cb()
  * @brief Callback API for receiving data asynchronously
  *
@@ -179,6 +185,10 @@ typedef int (*lora_api_recv)(const struct device *dev, uint8_t *data,
 
 /** Callbacks for asynchronous reception */
 struct lora_recv_async_callbacks {
+	/** Callback when a packet preamble is detected */
+	lora_event_cb preamble_detected;
+	/** Callback when a valid LoRa header is received */
+	lora_event_cb header_valid;
 	/** Callback when a packet is received */
 	lora_recv_cb recv;
 	/** User data provided to callbacks */

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -177,15 +177,23 @@ typedef int (*lora_api_recv)(const struct device *dev, uint8_t *data,
 			     uint8_t size,
 			     k_timeout_t timeout, int16_t *rssi, int8_t *snr);
 
+/** Callbacks for asynchronous reception */
+struct lora_recv_async_callbacks {
+	/** Callback when a packet is received */
+	lora_recv_cb recv;
+	/** User data provided to callbacks */
+	void *user_data;
+};
+
 /**
  * @typedef lora_api_recv_async()
  * @brief Callback API for receiving data asynchronously over LoRa
  *
  * @param dev Modem to receive data on.
- * @param cb Callback to run on receiving data.
+ * @param cb Callbacks to run on RX events.
  */
-typedef int (*lora_api_recv_async)(const struct device *dev, lora_recv_cb cb,
-			     void *user_data);
+typedef int (*lora_api_recv_async)(const struct device *dev,
+				   const struct lora_recv_async_callbacks *cb);
 
 /**
  * @typedef lora_api_test_cw()
@@ -301,18 +309,17 @@ static inline int lora_recv(const struct device *dev, uint8_t *data,
  * This can be done within the callback handler.
  *
  * @param dev Modem to receive data on.
- * @param cb Callback to run on receiving data. If NULL, any pending
+ * @param cb Callbacks to run on RX events. If NULL, any pending
  *	     asynchronous receptions will be cancelled.
- * @param user_data User data passed to callback
  * @return 0 when reception successfully setup, negative on error
  */
-static inline int lora_recv_async(const struct device *dev, lora_recv_cb cb,
-			       void *user_data)
+static inline int lora_recv_async(const struct device *dev,
+				  const struct lora_recv_async_callbacks *cb)
 {
 	const struct lora_driver_api *api =
 		(const struct lora_driver_api *)dev->api;
 
-	return api->recv_async(dev, cb, user_data);
+	return api->recv_async(dev, cb);
 }
 
 /**

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -35,13 +35,17 @@ void lora_receive_cb(const struct device *dev, uint8_t *data, uint16_t size,
 	/* Stop receiving after 10 packets */
 	if (++cnt == 10) {
 		LOG_INF("Stopping packet receptions");
-		lora_recv_async(dev, NULL, NULL);
+		lora_recv_async(dev, NULL);
 	}
 }
 
 int main(void)
 {
 	const struct device *const lora_dev = DEVICE_DT_GET(DEFAULT_RADIO_NODE);
+	const struct lora_recv_async_callbacks async_cb = {
+		.recv = lora_receive_cb,
+		.user_data = NULL,
+	};
 	struct lora_modem_config config;
 	int ret, len;
 	uint8_t data[MAX_DATA_LEN] = {0};
@@ -86,7 +90,7 @@ int main(void)
 
 	/* Enable asynchronous reception */
 	LOG_INF("Asynchronous reception");
-	lora_recv_async(lora_dev, lora_receive_cb, NULL);
+	lora_recv_async(lora_dev, &async_cb);
 	k_sleep(K_FOREVER);
 	return 0;
 }


### PR DESCRIPTION
Add the option to receive callbacks when the LoRa modem detects a valid preamble or packet header. This can be used to detect whether the modem is in the middle of receiving a packet, allowing the user to possibly defer a mode switch (to TX or IDLE) if it is. This is useful due to the generally long packet durations on LoRa.

Only implemented and tested for the `lora-basics-modem` backend. Example interrupt timings when receiving a 15 byte packet at 125kHz bandwidth, SF 10: 
```
[00:00:30.675,264] <err> lbm_driver: Preamble detected IRQ
[00:00:30.821,120] <err> lbm_driver: Header valid IRQ
[00:00:30.985,216] <inf> phy_lora: LoRa RX RSSI: -15 dBm, SNR: 9 dB
```