### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -339,7 +339,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 26ed181181eed53e400db8f63fa83c566a05d971
+      revision: 0aebb20e3883537b79741c71d54683ac2fa2c205
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: a39e9b155830461c9d1cf587afb151b894369b91


### PR DESCRIPTION
Update the HW models module to:
0aebb20e3883537b79741c71d54683ac2fa2c205

Including the following:
0aebb20 5340: nhw_convert_periph_base_addr: Add GPIO/P0/P1 
103d08c 5340: nhw_convert_periph_base_addr: Add GPIOTE 
e572da0 RTC: Fix setting EVENTS_COMPARE too early when using ppi connection