### PR TITLE
net: Using const char * in net_hostname_set()

### DIFF
--- a/include/zephyr/net/hostname.h
+++ b/include/zephyr/net/hostname.h
@@ -76,9 +76,9 @@ static inline const char *net_hostname_get(void)
  * @return 0 if ok, <0 on error
  */
 #if defined(CONFIG_NET_HOSTNAME_DYNAMIC)
-int net_hostname_set(char *host, size_t len);
+int net_hostname_set(const char *host, size_t len);
 #else
-static inline int net_hostname_set(char *host, size_t len)
+static inline int net_hostname_set(const char *host, size_t len)
 {
 	ARG_UNUSED(host);
 	ARG_UNUSED(len);

--- a/subsys/net/hostname.c
+++ b/subsys/net/hostname.c
@@ -43,7 +43,7 @@ const char *net_hostname_get(void)
 }
 
 #if defined(CONFIG_NET_HOSTNAME_DYNAMIC)
-int net_hostname_set(char *host, size_t len)
+int net_hostname_set(const char *host, size_t len)
 {
 	if (len > NET_HOSTNAME_MAX_LEN) {
 		return -ENOMEM;


### PR DESCRIPTION
When calling net_hostname_set() from C++, you will hit compile errors if you attempt to use a const char *. Since the internals of net_hostname_set() just uses memcpy(), we should pass in the new hostname as a const char * to better support C++.

Tested using samples/cpp/hello_world, with an added call to net_hostname_set().

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99873