### PR TITLE
soc: nordic: gen_uicr: Enable IS_GEN_UICR_IMAGE by default

### DIFF
--- a/soc/nordic/common/uicr/gen_uicr/Kconfig
+++ b/soc/nordic/common/uicr/gen_uicr/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config IS_GEN_UICR_IMAGE
+	default y
+
+source "Kconfig.zephyr"


### PR DESCRIPTION
Enable IS_GEN_UICR_IMAGE by default for the gen_uicr image.

A recent change accidentally made this default n, and broke a bunch of users.