### PR TITLE
[Backport v3.7-branch] net: dns: Fix potential buffer overflow when unpacking labels

### DIFF
--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -482,7 +482,6 @@ int mdns_unpack_query_header(struct dns_msg_t *msg, uint16_t *src_id)
 static int dns_unpack_name(const uint8_t *msg, int maxlen, const uint8_t *src,
 			   struct net_buf *buf, const uint8_t **eol)
 {
-	int dest_size = net_buf_tailroom(buf);
 	const uint8_t *end_of_label = NULL;
 	const uint8_t *curr_src = src;
 	int loop_check = 0, len = -1;
@@ -521,6 +520,8 @@ static int dns_unpack_name(const uint8_t *msg, int maxlen, const uint8_t *src,
 				return -EMSGSIZE;
 			}
 		} else {
+			size_t dest_size = net_buf_tailroom(buf);
+
 			/* Max label length is 64 bytes (because 2 bits are
 			 * used for pointer)
 			 */
@@ -529,8 +530,7 @@ static int dns_unpack_name(const uint8_t *msg, int maxlen, const uint8_t *src,
 				return -EMSGSIZE;
 			}
 
-			if (((buf->data + label_len + 1) >=
-			     (buf->data + dest_size)) ||
+			if ((label_len + 1 >= dest_size) ||
 			    ((curr_src + label_len) >= (msg + maxlen))) {
 				return -EMSGSIZE;
 			}


### PR DESCRIPTION
Manual backport of 7bd45cd from https://github.com/zephyrproject-rtos/zephyr/pull/99683.

I've dropped the test commit, as on v3.7-branch `dns_unpack_name()` was a static function.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99682