### PR TITLE
usb: device_next: msc: Do not leak SCSI buffer on dequeue

### DIFF
--- a/subsys/usb/device_next/class/usbd_msc.c
+++ b/subsys/usb/device_next/class/usbd_msc.c
@@ -718,6 +718,9 @@ ep_request_error:
 		}
 	}
 	msc_free_scsi_buf(ctx, buf->__buf);
+	if (buf->frags) {
+		msc_free_scsi_buf(ctx, buf->frags->__buf);
+	}
 	usbd_ep_buf_free(uds_ctx, buf);
 }
 


### PR DESCRIPTION
Multiple submitted requests are getting merged to single cancelled net_buf on endpoint dequeue. While MSC class was correctly decrementing the usage counters, it was not freeing SCSI buffer pointed to by frags.