### PR TITLE
pytest: Fix shell tests on IOTDK and HSDK

### DIFF
--- a/boards/snps/hsdk/hsdk.yaml
+++ b/boards/snps/hsdk/hsdk.yaml
@@ -9,6 +9,7 @@ toolchain:
 supported:
   - smp
 testing:
+  flash_before: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/snps/hsdk/hsdk_arc_hsdk_2cores.yaml
+++ b/boards/snps/hsdk/hsdk_arc_hsdk_2cores.yaml
@@ -9,6 +9,7 @@ toolchain:
 supported:
   - smp
 testing:
+  flash_before: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/snps/hsdk4xd/hsdk4xd.yaml
+++ b/boards/snps/hsdk4xd/hsdk4xd.yaml
@@ -9,6 +9,7 @@ toolchain:
 supported:
   - smp
 testing:
+  flash_before: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/snps/iotdk/iotdk.yaml
+++ b/boards/snps/iotdk/iotdk.yaml
@@ -7,6 +7,7 @@ toolchain:
   - cross-compile
 ram: 128
 testing:
+  flash_before: true
   ignore_tags:
     - net
     - bluetooth

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -223,6 +223,11 @@ testing:
     power-efficient but slow CPU or simulation platform which can perform instruction accurate
     simulation but does it slowly.
 
+  flash_before: [True|False] (default False)
+    For pytest/shell harness hardware testing, flash the device before opening the serial port.
+    This prevents serial port disconnection issues during flashing on some boards (e.g., those
+    with USB CDC that reset during flash operations).
+
 env:
   A list of environment variables. Twister will check if all these environment variables are set,
   and otherwise skip this platform. This allows the user to define a platform which should be

--- a/samples/sensor/sensor_shell/sample.yaml
+++ b/samples/sensor/sensor_shell/sample.yaml
@@ -23,6 +23,7 @@ tests:
     timeout: 180
     extra_configs:
       - arch:posix:CONFIG_UART_NATIVE_PTY_0_ON_STDINOUT=y
+      - platform:iotdk/arc_iot:CONFIG_ARC_IOT_CUSTOM_CPU_IDLE=y
     extra_args: DTC_OVERLAY_FILE=fake_sensor.overlay
     integration_platforms:
       - native_sim

--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -13,6 +13,7 @@ tests:
       - native_sim
     extra_configs:
       - arch:posix:CONFIG_UART_NATIVE_PTY_0_ON_STDINOUT=y
+      - platform:iotdk/arc_iot:CONFIG_ARC_IOT_CUSTOM_CPU_IDLE=y
   sample.shell.shell_module.usb:
     depends_on: usbd
     tags:

--- a/samples/subsys/smf/hsm_psicc2/sample.yaml
+++ b/samples/subsys/smf/hsm_psicc2/sample.yaml
@@ -15,5 +15,7 @@ common:
       - ".*<inf> hsm_psicc2_thread: s2_entry.*"
       - ".*<inf> hsm_psicc2_thread: s21_entry.*"
       - ".*<inf> hsm_psicc2_thread: s211_entry.*"
+  extra_configs:
+    - platform:iotdk/arc_iot:CONFIG_ARC_IOT_CUSTOM_CPU_IDLE=y
 tests:
   sample.smf.hsm_psicc2: {}

--- a/samples/subsys/testsuite/pytest/shell/testcase.yaml
+++ b/samples/subsys/testsuite/pytest/shell/testcase.yaml
@@ -7,6 +7,7 @@ common:
   filter: CONFIG_SERIAL and not CONFIG_SMP and dt_chosen_enabled("zephyr,shell-uart")
   extra_configs:
     - arch:posix:CONFIG_UART_NATIVE_PTY_0_ON_STDINOUT=y
+    - platform:iotdk/arc_iot:CONFIG_ARC_IOT_CUSTOM_CPU_IDLE=y
   min_ram: 40
   integration_platforms:
     - native_sim

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -500,8 +500,11 @@ class Pytest(Harness):
         if hardware.post_script:
             command.append(f'--post-script={hardware.post_script}')
 
-        if hardware.flash_before:
-            command.append(f'--flash-before={hardware.flash_before}')
+        # Check flash_before from both hardware map and platform (board YAML)
+        # Platform flash_before is intended for boards with USB reset issues during flashing
+        flash_before = hardware.flash_before or self.instance.platform.flash_before
+        if flash_before:
+            command.append(f'--flash-before={flash_before}')
 
         for fixture in hardware.fixtures:
             command.append(f'--twister-fixture={fixture}')

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -72,6 +72,7 @@ class Platform:
         self.ignore_tags = []
         self.only_tags = []
         self.default = False
+        self.flash_before = False
         # if no flash size is specified by the board, take a default of 512K
         self.flash = 512
         self.supported = set()
@@ -116,6 +117,7 @@ class Platform:
         self.default = testing.get("default", self.default)
         self.binaries = testing.get("binaries", [])
         self.timeout_multiplier = testing.get("timeout_multiplier", self.timeout_multiplier)
+        self.flash_before = testing.get("flash_before", self.flash_before)
 
         # testing data for variant
         testing_var = variant_data.get("testing", data.get("testing", {}))
@@ -124,6 +126,7 @@ class Platform:
         self.only_tags = testing_var.get("only_tags", self.only_tags)
         self.default = testing_var.get("default", self.default)
         self.binaries = testing_var.get("binaries", self.binaries)
+        self.flash_before = testing_var.get("flash_before", self.flash_before)
         renode = testing.get("renode", {})
         self.uart = renode.get("uart", "")
         self.resc = renode.get("resc", "")

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -104,6 +104,9 @@ schema;platform-schema:
           required: false
         "default":
           type: bool
+        "flash_before":
+          type: bool
+          required: false
         "binaries":
           type: seq
           seq:

--- a/soc/snps/arc_iot/CMakeLists.txt
+++ b/soc/snps/arc_iot/CMakeLists.txt
@@ -7,4 +7,6 @@ zephyr_sources(
   sysconf.c
   )
 
+zephyr_sources_ifdef(CONFIG_ARC_IOT_CUSTOM_CPU_IDLE soc_idle.c)
+
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/snps/arc_iot/Kconfig
+++ b/soc/snps/arc_iot/Kconfig
@@ -7,3 +7,16 @@ config SOC_ARC_IOT
 	select CPU_HAS_MPU
 	select CPU_HAS_FPU
 	select SOC_EARLY_INIT_HOOK
+
+config ARC_IOT_CUSTOM_CPU_IDLE
+	bool "Use custom CPU idle that skips sleep"
+	default n
+	depends on SOC_ARC_IOT
+	select ARCH_HAS_CUSTOM_CPU_IDLE
+	select ARCH_HAS_CUSTOM_CPU_ATOMIC_IDLE
+	help
+	  The ARC IoT SoC has a hardware limitation where entering sleep mode
+	  causes peripherals (e.g., UART) to lose power, preventing wake-up
+	  from peripheral interrupts. Enable this option to use a custom idle
+	  implementation that skips sleep, keeping peripherals powered.
+	  Enable for tests that require continuous UART operation during idle.

--- a/soc/snps/arc_iot/soc_idle.c
+++ b/soc/snps/arc_iot/soc_idle.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Synopsys, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Custom CPU idle implementation for ARC IoT SoC
+ *
+ * The ARC IoT SoC has a hardware limitation where entering sleep mode
+ * causes peripherals (e.g., UART) to lose power. This prevents wake-up
+ * from peripheral interrupts. These custom implementations skip the sleep
+ * instruction and only enable interrupts.
+ */
+
+#include <zephyr/irq.h>
+#include <zephyr/tracing/tracing.h>
+
+void arch_cpu_idle(void)
+{
+	sys_trace_idle();
+	irq_unlock(0);
+}
+
+void arch_cpu_atomic_idle(unsigned int key)
+{
+	sys_trace_idle();
+	irq_unlock(key);
+}


### PR DESCRIPTION
This change adds a board-level `testing.flash_before flag` in Twister so the pytest/shell harness flashes the board before opening the serial port (enabled on snps/hsdk, snps/hsdk4xd, and snps/iotdk). It also introduces a configurable `CONFIG_ARC_IOT_CUSTOM_CPU_IDLE` option for the arc_iot SoC that skips sleep to keep peripherals powered when needed.

Why:

Avoid USB CDC disconnects during flashing on ARC development boards
Prevent UART power loss on iotdk when entering sleep

Fixes: #99911