### PR TITLE
docs: security: CVE assignment criteria

### DIFF
--- a/doc/security/cve-assignment-criteria.rst
+++ b/doc/security/cve-assignment-criteria.rst
@@ -1,0 +1,270 @@
+.. _cve-assignment-criteria:
+
+CVE Assignment Criteria
+#######################
+
+Introduction
+============
+
+This document outlines the criteria used by the Zephyr Project
+to determine whether a reported vulnerability qualifies for
+a Common Vulnerabilities and Exposures (CVE) assignment. These criteria
+ensure that CVEs are assigned only to security issues that represent
+actual exploitable vulnerabilities in the Zephyr RTOS.
+
+Scope
+=====
+
+The Zephyr Project assigns CVEs only to vulnerabilities that meet all of
+the following criteria:
+
+1. **Remotely Exploitable**: The vulnerability must be exploitable by an
+   external entity without requiring privileged access to the system or
+   physical access to the device (except where physical access is part
+   of the intended attack vector, such as USB-based attacks).
+
+2. **Not an Application Bug**: The vulnerability must exist in the Zephyr
+   RTOS codebase itself, not in application code built on top of Zephyr.
+   Application developers are responsible for securing their own code.
+
+3. **Demonstrable Exploitability**: The vulnerability report should include
+   a clear explanation of how the vulnerability can be exploited. A proof
+   of concept (PoC) is preferred but not required, especially for
+   straightforward vulnerabilities where the exploitability is clear from
+   the code analysis.
+
+4. **Triggered by External Data or Userspace Code**: The vulnerability
+   must be triggered by:
+
+   - Data received from external sources (network packets, USB data,
+     Bluetooth frames, serial input, etc.), OR
+   - Code executing in userspace (unprivileged mode) that can trigger
+     the vulnerability through system calls or other interfaces
+
+5. **Not a Hardware Attack**: The Zephyr Project does not protect against
+   hardware-level attacks. Vulnerabilities that require compromised or
+   malicious hardware components (such as a malicious Bluetooth controller,
+   compromised cryptographic hardware, or tampered memory) are outside
+   the scope of CVE assignment.
+
+Detailed Criteria
+=================
+
+Remotely Exploitable
+--------------------
+
+A vulnerability is considered remotely exploitable if an attacker can
+trigger it without:
+
+- Having root or administrative access to the system
+- Requiring physical access to the device (unless physical access is the
+  intended attack vector, e.g., USB attacks)
+- Needing to modify the Zephyr source code or firmware image
+
+Examples of remotely exploitable vulnerabilities include:
+
+- Network protocol parsing vulnerabilities (Bluetooth, Wi-Fi, TCP/IP, etc.)
+- USB device class vulnerabilities
+- Serial interface vulnerabilities (when accessible remotely via telnet or
+  similar)
+- Filesystem vulnerabilities triggered by malicious filesystem images
+
+Examples of issues that are NOT remotely exploitable:
+
+- Vulnerabilities requiring root access to exploit
+- Issues that can only be triggered by modifying kernel code
+- Problems requiring physical tampering of hardware components
+
+Not an Application Bug
+----------------------
+
+The Zephyr RTOS provides a foundation for embedded applications, but it
+cannot protect against vulnerabilities introduced by application code.
+CVEs are assigned only to vulnerabilities in:
+
+- Zephyr kernel code
+- Zephyr subsystem implementations (networking, filesystems, drivers, etc.)
+- Zephyr-provided libraries and APIs
+
+Issues in application code that uses Zephyr APIs incorrectly are not
+eligible for CVE assignment. Application developers are responsible for:
+
+- Validating input data before passing it to Zephyr APIs
+- Properly configuring security features
+- Implementing application-level security controls
+
+Demonstrable Exploitability
+---------------------------
+
+Vulnerability reports should include:
+
+1. **Clear Explanation**: A description of how the vulnerability can be
+   exploited. This may include:
+
+   - The attack vector (how the attacker delivers the malicious input)
+   - The vulnerable code path
+   - The impact (what the attacker can achieve)
+
+2. **Proof of Concept (recommended)**: A working PoC that demonstrates the
+   vulnerability is helpful but not required. If provided, the PoC may:
+
+   - Show how to trigger the vulnerability
+   - Demonstrate the impact (crash, code execution, information leak, etc.)
+   - Work against a standard Zephyr configuration
+
+3. **Reproducibility**: The vulnerability should ideally be reproducible with
+   specific steps or a provided PoC, but code analysis demonstrating
+   exploitability may be sufficient.
+
+Reports that merely state "possible buffer overflow" or "missing bounds
+check" without explaining how the issue can be exploited may be returned
+to the reporter for additional information, but code analysis showing
+clear exploitability may be sufficient.
+
+Examples of reports that may need additional information:
+
+- "Function X doesn't check buffer boundaries" (may be sufficient if code
+  analysis clearly shows how to trigger an overflow)
+- "Possible memory corruption in subsystem Y" (may be sufficient if the
+  code path to trigger it is clear)
+- "Code at line Z looks unsafe" (may be sufficient if the vulnerability
+  is obvious from code review)
+
+Examples of sufficient reports:
+
+- "Sending a malformed Bluetooth L2CAP packet with length field set to
+  0xFFFF causes a buffer overflow in function X, allowing remote code
+  execution. PoC attached."
+- "A userspace thread can call syscall Y with crafted parameters to
+  bypass memory protection checks. Here's a test program that demonstrates
+  privilege escalation."
+
+Triggered by External Data or Userspace Code
+---------------------------------------------
+
+The vulnerability must be exploitable through one of these vectors:
+
+**External Data Sources:**
+- Network protocols (Bluetooth, Wi-Fi, TCP/IP, CoAP, MQTT, etc.)
+- USB device classes
+- Serial interfaces (when accessible remotely)
+- Configuration data from external sources
+
+**Userspace Code:**
+- Unprivileged threads executing system calls
+- Application code running in userspace mode
+- Code that can be loaded and executed by the application
+
+Vulnerabilities that can only be triggered by:
+
+- Privileged kernel code
+- Code running in supervisor/kernel mode
+- Modifications to the Zephyr source code itself
+
+are NOT eligible for CVE assignment, as they require the attacker to
+already have compromised the system.
+
+Hardware Attacks Out of Scope
+------------------------------
+
+The Zephyr Project does not protect against hardware-level attacks or
+vulnerabilities that require compromised hardware components. The
+following are explicitly OUT OF SCOPE for CVE assignment:
+
+- **Malicious Hardware Components**: Vulnerabilities that require a
+  compromised or malicious hardware component (e.g., a malicious Bluetooth
+  controller, compromised cryptographic accelerator, tampered memory)
+
+- **Hardware Fault Injection**: Attacks that require physical manipulation
+  of hardware (glitching, voltage manipulation, etc.)
+
+- **Side-Channel Attacks**: Timing attacks, power analysis, or other
+  side-channel attacks that exploit hardware characteristics (unless the
+  vulnerability is in software countermeasures that Zephyr is responsible
+  for implementing)
+
+- **Hardware Design Flaws**: Issues that are inherent to the hardware
+  design rather than the software implementation
+
+The Zephyr Project assumes that hardware components are trusted and
+behave according to their specifications. If a hardware component is
+compromised or malicious, the security model breaks down, and this is
+outside the scope of what Zephyr can protect against.
+
+Examples of issues OUT OF SCOPE:
+
+- "A malicious Bluetooth controller can send malformed packets" (this is
+  a hardware attack)
+- "A compromised cryptographic accelerator can leak keys" (hardware
+  compromise)
+- "Fault injection can bypass security checks" (hardware attack)
+
+Examples of issues IN SCOPE:
+
+- "The Zephyr Bluetooth stack doesn't validate packet lengths, allowing
+  a remote attacker to trigger a buffer overflow" (software vulnerability
+  in Zephyr code)
+- "Missing input validation in USB device class allows a USB host to
+  cause memory corruption" (software vulnerability exploitable via
+  external data)
+
+Evaluation Process
+==================
+
+When a vulnerability is reported, the Security Subcommittee evaluates it
+against these criteria:
+
+1. **Initial Triage**: The report is reviewed to determine if it meets
+   the basic criteria (remotely exploitable, not an application bug,
+   etc.)
+
+2. **Exploitability Assessment**: The committee evaluates whether the
+   vulnerability can actually be exploited. Code analysis demonstrating
+   clear exploitability may be sufficient, though additional explanation
+   or PoC is helpful when available.
+
+3. **Scope Verification**: The committee verifies that the vulnerability
+   is in Zephyr code (not application code) and is not a hardware attack.
+
+4. **CVE Assignment**: If all criteria are met, a CVE is assigned and
+   the vulnerability is tracked through the security advisory process
+   (see :ref:`reporting`).
+
+Common Reasons for Rejection
+=============================
+
+Reports are commonly rejected or returned for additional information when:
+
+1. **Lack of Exploitability Proof**: The report identifies a potential
+   issue but doesn't demonstrate exploitability through code analysis,
+   explanation, or PoC.
+
+2. **Application-Level Issue**: The vulnerability exists in application
+   code, not in Zephyr itself.
+
+3. **Hardware Attack**: The vulnerability requires compromised or
+   malicious hardware.
+
+4. **Requires Privileged Access**: The vulnerability can only be
+   exploited by an attacker who already has privileged access to the
+   system.
+
+5. **Theoretical Only**: The vulnerability is theoretically possible but
+   cannot be practically exploited (e.g., requires an impossible
+   configuration or attack scenario).
+
+6. **Insufficient Information**: The report lacks sufficient detail to
+   understand or reproduce the vulnerability.
+
+Conclusion
+==========
+
+These criteria focus CVE assignments on vulnerabilities that pose real
+security threats to Zephyr-based systems. By requiring remote exploitability,
+demonstrable attack vectors, and clear impact, we ensure that security
+resources address actual risks that attackers can exploit in production
+environments. This practical approach prioritizes fixing vulnerabilities
+that can cause real harm.
+
+For information on how to report vulnerabilities, please see
+:ref:`reporting`.

--- a/doc/security/index.rst
+++ b/doc/security/index.rst
@@ -12,6 +12,7 @@ for ensuring security is addressed within the Zephyr project.
 
    security-overview.rst
    reporting.rst
+   cve-assignment-criteria.rst
    secure-coding.rst
    sensor-threat.rst
    hardening-tool.rst

--- a/doc/security/reporting.rst
+++ b/doc/security/reporting.rst
@@ -127,6 +127,10 @@ assigned a CVE number.  As fixes are created, it may be necessary to
 allocate additional CVE numbers, or to retire numbers that were
 assigned.
 
+For information on the criteria used to determine whether a vulnerability
+report qualifies for CVE assignment, please see
+:ref:`cve-assignment-criteria`.
+
 Vulnerability Notification
 ==========================
 


### PR DESCRIPTION
Add new documentation page explaining the criteria adopted to assign a CVE on Zephyr project.