### PR TITLE
boards: stm32h7s78_dk: add FDCAN1 support

### DIFF
--- a/boards/st/stm32h7s78_dk/doc/index.rst
+++ b/boards/st/stm32h7s78_dk/doc/index.rst
@@ -180,6 +180,7 @@ Default Zephyr Peripheral Mapping:
 - USB OTG FS DM/DP : PM12/PM11
 - XSPI1 NCS/DQS0/DQS1/CLK/IO: PO0/PO2/PO3/PO4/PP0..15
 - I2C1 SCL/SDA: PB6/PB9
+- FDCAN1 RX/TX : PB8/PB9
 
 System Clock
 ------------
@@ -199,6 +200,13 @@ USB
 
 STM32H7S78-DK Discovery board has 2 USB Type-C connectors. Currently, only
 USB port2 (FS) is supported.
+
+FDCAN
+-----
+
+STM32H7S78-DK Discovery board has 2 FDCAN bus interfaces.
+FDCAN1 is configured but not enabled by default. To enable it, make sure
+that ``i2c1`` is disabled, since they share the PB9 pin.
 
 Programming and Debugging
 *************************

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,display = &ltdc;
 		zephyr,touch = &display_ctp;
+		zephyr,canbus = &fdcan1;
 	};
 
 	psram: memory@90000000 {
@@ -202,6 +203,11 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+	/*
+	 * Make sure FDCAN and i2c1 are not enabled at the same time
+	 * because they share the pb9 pin
+	 * reference: DS14359 Rev 4 page 134
+	 */
 	status = "okay";
 
 	display_ctp: gt911@5d {
@@ -210,6 +216,16 @@
 		irq-gpios = <&gpioe 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		status = "okay";
 	};
+};
+
+&fdcan1 {
+	pinctrl-0 = <&fdcan1_rx_pb8 &fdcan1_tx_pb9>;
+	pinctrl-names = "default";
+	/*
+	 * fdcan1 is disabled by default in favor of i2c1 due to pb9 pin conflict
+	 * reference: DS14359 Rev 4 page 134
+	 */
+	status = "disabled";
 };
 
 &xspi1 {


### PR DESCRIPTION
## Changes
- Added FDCAN1 configuration to `stm32h7s78_dk-common.dtsi` and disabled it by default. Also explained that in order to use FDCAN1, the user needs to disable `i2c1`, since they share the `pb9` pin.
- ~Updated `stm32h7s78_dk.yaml` and `stm32h7s78_dk_stm32h7s7xx_ext_flash_app.yaml` to include the CAN feature.~
- Updated `index.rst` to include the CAN feature and documented the steps needed in order to use it.

## Tests
I tested these changes successfully with the following example: [can/counter](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/drivers/can/counter)



## Notes
Closes #99752