### PR TITLE
twister: add hardware map hook support

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -553,20 +553,6 @@ class DeviceHandler(Handler):
             for _d in duts_shared_hw:
                 _d.available = 1
 
-    @staticmethod
-    def run_custom_script(script, timeout):
-        with subprocess.Popen(script, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
-            try:
-                stdout, stderr = proc.communicate(timeout=timeout)
-                logger.debug(stdout.decode())
-                if proc.returncode != 0:
-                    logger.error(f"Custom script failure: {stderr.decode(errors='ignore')}")
-
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.communicate()
-                logger.error(f"{script} timed out")
-
     def _create_flash_command(self, hardware):
         flash_command = next(csv.reader([self.options.flash_command]))
 
@@ -745,14 +731,7 @@ class DeviceHandler(Handler):
             return
 
         # Run pre-script BEFORE starting serial PTY to avoid conflicts
-        pre_script = hardware.pre_script
-        script_param = hardware.script_param
-
-        if pre_script:
-            timeout = 30
-            if script_param:
-                timeout = script_param.get("pre_script_timeout", timeout)
-            self.run_custom_script(pre_script, timeout)
+        hardware.run_hook("pre")
 
         runner = hardware.runner or self.options.west_runner
         serial_pty = hardware.serial_pty
@@ -766,9 +745,6 @@ class DeviceHandler(Handler):
         logger.debug(f"Using serial device {serial_device} @ {hardware.baud} baud")
 
         command = self._create_command(runner, hardware)
-
-        post_flash_script = hardware.post_flash_script
-        post_script = hardware.post_script
 
         flash_timeout = hardware.flash_timeout
         if hardware.flash_with_test:
@@ -835,11 +811,7 @@ class DeviceHandler(Handler):
             self.instance.reason = "Device issue (Flash error)"
             failure_type = Handler.FailureType.FLASH
 
-        if post_flash_script:
-            timeout = 30
-            if script_param:
-                timeout = script_param.get("post_flash_timeout", timeout)
-            self.run_custom_script(post_flash_script, timeout)
+        hardware.run_hook("post_flash")
 
         # Connect to device after flashing it
         if hardware.flash_before:
@@ -901,11 +873,7 @@ class DeviceHandler(Handler):
 
         self._final_handle_actions(harness)
 
-        if post_script:
-            timeout = 30
-            if script_param:
-                timeout = script_param.get("post_script_timeout", timeout)
-            self.run_custom_script(post_script, timeout)
+        hardware.run_hook("post")
 
         self.make_dut_available(hardware)
 

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import scl
 import yaml
 from natsort import natsorted
+import subprocess
 from twisterlib.environment import ZEPHYR_BASE
 
 try:
@@ -42,10 +43,7 @@ class DUT:
                  serial_pty=None,
                  connected=False,
                  runner_params=None,
-                 pre_script=None,
-                 post_script=None,
-                 post_flash_script=None,
-                 script_param=None,
+                 hooks=None,
                  runner=None,
                  flash_timeout=60,
                  flash_with_test=False,
@@ -59,17 +57,13 @@ class DUT:
         self._available = Value("i", 1)
         self._failures = Value("i", 0)
         self.connected = connected
-        self.pre_script = pre_script
+        self.hooks = hooks or {}
         self.id = id
         self.product = product
         self.runner = runner
         self.runner_params = runner_params
         self.flash_before = flash_before
         self.fixtures = []
-        self.post_flash_script = post_flash_script
-        self.post_script = post_script
-        self.pre_script = pre_script
-        self.script_param = script_param
         self.probe_id = None
         self.notes = None
         self.lock = Lock()
@@ -124,6 +118,32 @@ class DUT:
                 d[k] = v[k]
         return d
 
+
+    def run_hook(self, hook_type):
+        hook = None
+        for h in self.hooks:
+            if h.get('type', None) == hook_type:
+                hook = h
+        if not hook:
+            return
+
+        script = hook.get('script')
+        args = hook.get('args', [])
+        cmd = [script] + args
+        timeout = hook.get('timeout', 60)
+
+        logger.info(f"Running command {cmd}....")
+        with subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
+            try:
+                stdout, stderr = proc.communicate(timeout=timeout)
+                logger.debug(stdout.decode())
+                if proc.returncode != 0:
+                    logger.error(f"Custom script failure: {stderr.decode(errors='ignore')}")
+
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.communicate()
+                logger.error(f"{script} timed out")
 
     def __repr__(self):
         return f"<{self.platform} ({self.product}) on {self.serial}>"
@@ -251,10 +271,19 @@ class HardwareMap:
         flash_with_test=False,
         flash_before=False
     ):
+        _hooks = {}
+        if pre_script:
+            pre_hook = {
+                'script': pre_script,
+                'args': [],
+                'timeout': 60
+            }
+            _hooks['pre'] = pre_hook
+
         device = DUT(
             platform=platform,
             connected=True,
-            pre_script=pre_script,
+            hooks=_hooks,
             serial_baud=baud,
             flash_timeout=flash_timeout,
             flash_with_test=flash_with_test,
@@ -271,11 +300,41 @@ class HardwareMap:
         hwm_schema = scl.yaml_load(self.schema_path)
         duts = scl.yaml_load_verify(map_file, hwm_schema)
         for dut in duts:
+            # deprecated fields are still supported for backward compatibility
             pre_script = dut.get('pre_script')
             script_param = dut.get('script_param')
             post_script = dut.get('post_script')
             post_flash_script = dut.get('post_flash_script')
+            # prepare hooks dictionary for forward compatibility
+            _hooks = {}
+            if pre_script:
+                pre_hook = {
+                    'script': pre_script,
+                    'args': [],
+                    'timeout': script_param.get('pre_script_timeout', 60) if script_param else 60
+                }
+                _hooks['pre'] = pre_hook
+            if post_script:
+                post_hook = {
+                    'script': post_script,
+                    'args': [],
+                    'timeout': script_param.get('post_script_timeout', 60) if script_param else 60
+                }
+                _hooks['post'] = post_hook
+            if post_flash_script:
+                post_flash_hook = {
+                    'script': post_flash_script,
+                    'args': [],
+                    'timeout': script_param.get('post_flash_timeout', 60) if script_param else 60
+                }
+                _hooks['post_flash'] = post_flash_hook
+
+
             flash_timeout = dut.get('flash_timeout') or self.options.device_flash_timeout
+
+            # get hooks from hardware map if available
+            hooks = dut.get('hooks', _hooks)
+
             flash_with_test = dut.get('flash_with_test')
             if flash_with_test is None:
                 flash_with_test = self.options.device_flash_with_test
@@ -310,11 +369,8 @@ class HardwareMap:
                               serial=serial,
                               serial_baud=baud,
                               connected=connected,
-                              pre_script=pre_script,
+                              hooks=hooks,
                               flash_before=flash_before,
-                              post_script=post_script,
-                              post_flash_script=post_flash_script,
-                              script_param=script_param,
                               flash_timeout=flash_timeout,
                               flash_with_test=flash_with_test)
                 new_dut.fixtures = fixtures

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -77,3 +77,27 @@ sequence:
           "post_flash_timeout":
             type: int
             required: false
+      "hooks":
+        type: seq
+        seq:
+          - type: map
+            mapping:
+              "type":
+                type: str
+                required: true
+                enum:
+                  - "pre"
+                  - "post"
+                  - "pre_flash"
+                  - "post_flash"
+              "script":
+                type: str
+                required: true
+              "args":
+                type: seq
+                required: false
+                sequence:
+                  - type: str
+              "timeout":
+                type: int
+                required: false


### PR DESCRIPTION
This deprecates old support for custom scripts which was done for each
type of script individually and was duplicating code and adding too many
options for supporting and extending scripting.

This also does what #98197 is trying to do.

pushed as DRAFT to get early feedback while things are being reworked....
