### PR TITLE
bluetooth: host: consistent notification of subscription termination

### DIFF
--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -1578,7 +1578,7 @@ static void subscribe_mcs_char_func(struct bt_conn *conn, uint8_t err,
 	LOG_DBG("Subscribed: value handle: %d, ccc handle: %d",
 	       params->value_handle, params->ccc_handle);
 
-	if (params->value_handle == 0) {
+	if (params->value == 0) {
 		/* Unsubscribing, ignore */
 		return;
 	}

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -5272,6 +5272,12 @@ static void gatt_write_ccc_rsp(struct bt_conn *conn, int err,
 			return;
 		}
 
+		att_err = att_err_from_int(err);
+
+		if (params->subscribe) {
+			params->subscribe(conn, att_err, params);
+		}
+
 		prev = NULL;
 
 		SYS_SLIST_FOR_EACH_NODE_SAFE(&sub->list, node, tmp) {
@@ -5281,15 +5287,15 @@ static void gatt_write_ccc_rsp(struct bt_conn *conn, int err,
 			}
 			prev = node;
 		}
-	} else if (!params->value) {
-		/* Notify with NULL data to complete unsubscribe */
-		params->notify(conn, params, NULL, 0);
-	}
+	} else {
+		if (params->subscribe) {
+			params->subscribe(conn, BT_ATT_ERR_SUCCESS, params);
+		}
 
-	att_err = att_err_from_int(err);
-
-	if (params->subscribe) {
-		params->subscribe(conn, att_err, params);
+		if (!params->value) {
+			/* Notify with NULL data to complete unsubscribe */
+			params->notify(conn, params, NULL, 0);
+		}
 	}
 }
 


### PR DESCRIPTION
Ensure that the subscription params struct is not used after releasing it back to the application.

When subscribing to a characteristic, the `struct bt_gatt_subscribe_params` pointer [must remain valid](https://github.com/zephyrproject-rtos/zephyr/blob/7a65336edc345a81508303ae97caf8fa176a5a9f/include/zephyr/bluetooth/gatt.h#L2284-L2286) until the subscription is terminated. Applications are [notified of subscription termination](https://github.com/zephyrproject-rtos/zephyr/blob/7a65336edc345a81508303ae97caf8fa176a5a9f/include/zephyr/bluetooth/gatt.h#L2157) via a call to the `params->notify()` callback with `data == NULL`. However, when the subscription is terminated via an explicit write to the GATT server's CCC descriptor, the `params` pointer is [dereferenced after the call](https://github.com/zephyrproject-rtos/zephyr/blob/7a65336edc345a81508303ae97caf8fa176a5a9f/subsys/bluetooth/host/gatt.c#L5401-L5410) to `params->notify()`, in order to call `params->subscribe()`. This makes it difficult for applications to know when they can reuse or free the `params` struct and violates the API contract as defined in the function comments.

This commit moves the call to `params->notify()` after the call to `params->subscribe()`, which ensures that calling `params->notify()` with `data == NULL` is the last use of the `params` pointer in all cases.

The `params->subscribe()` callback is only called after an explicit write to the GATT server's CCC descriptor and is not called when the subscription is terminated for other reasons (e.g. if there are multiple subscribers to the same characteristic or after a disconnect), so this callback cannot be used to know when the `params` struct has been released.

Fixes: #111427