### PR TITLE
mbedtls: include option to enable version information

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -266,6 +266,12 @@ Libraries / Subsystems
 
    * :c:func:`lora_airtime`
 
+* Mbed TLS
+
+  * Added :kconfig:option:`CONFIG_MBEDTLS_VERSION_C` to simplify the
+    export of version information from Mbed TLS. If enabled, the
+    :c:func:`mbedtls_version_get_number()` function will be available.
+
 Other notable changes
 *********************
 

--- a/modules/mbedtls/Kconfig.mbedtls
+++ b/modules/mbedtls/Kconfig.mbedtls
@@ -604,6 +604,12 @@ config MBEDTLS_LMS_C
 	depends on MBEDTLS_SHA256
 	select PSA_WANT_ALG_SHA_256
 
+config MBEDTLS_VERSION_C
+	bool "Support version information"
+	help
+	  Enable the mbedtls_version_get_number() function to get version
+	  information from Mbed TLS.
+
 if MBEDTLS_PSA_CRYPTO_C
 
 config MBEDTLS_PSA_P256M_DRIVER_ENABLED

--- a/modules/mbedtls/configs/config-mbedtls.h
+++ b/modules/mbedtls/configs/config-mbedtls.h
@@ -45,6 +45,10 @@
 #define MBEDTLS_LMS_C
 #endif
 
+#if defined(CONFIG_MBEDTLS_VERSION_C)
+#define MBEDTLS_VERSION_C
+#endif
+
 #if defined(CONFIG_MBEDTLS_HAVE_TIME_DATE)
 #define MBEDTLS_HAVE_TIME
 #define MBEDTLS_HAVE_TIME_DATE


### PR DESCRIPTION
Some libraries like libcoap make use of mbedtls_version_get_number which is enabled by MBEDTLS_VERSION_C.

We add a config option to be able to selectively enable it.