### PR TITLE
Mspi dw format and data only support

### DIFF
--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -162,6 +162,9 @@ DEFINE_MM_REG_WR(xip_write_wrap_inst,	0x144)
 DEFINE_MM_REG_WR(xip_write_ctrl,	0x148)
 #endif
 
+/* Ceiling division by 32 */
+#define CEIL_DIV_32(x) (((x) + 31U) >> 5)
+
 #include "mspi_dw_vendor_specific.h"
 
 static int start_next_packet(const struct device *dev);
@@ -1288,15 +1291,15 @@ static int start_next_packet(const struct device *dev)
 #if defined(CONFIG_MSPI_DMA)
 	if (dev_data->xfer.xfer_mode == MSPI_DMA) {
 		/* For DMA mode, set start level based on transfer length to prevent underflow */
-		uint32_t total_transfer_bytes = packet->num_bytes + dev_data->xfer.addr_length +
-						dev_data->xfer.cmd_length;
-		uint32_t transfer_frames = total_transfer_bytes >> dev_data->bytes_per_frame_exp;
+		uint32_t transfer_frames = (packet->num_bytes >> dev_data->bytes_per_frame_exp) +
+					   CEIL_DIV_32(dev_data->xfer.addr_length)
+					 + CEIL_DIV_32(dev_data->xfer.cmd_length);
 
-		/* Use minimum of transfer length or FIFO depth, but at least 1 */
+		/* Above dma_start_level, the transfer will start.
+		 * Use minimum of transfer length and FIFO depth.
+		 */
 		uint8_t dma_start_level = MIN(transfer_frames - 1,
 					      dev_config->tx_fifo_depth_minus_1);
-
-		dma_start_level = (dma_start_level > 0 ? dma_start_level : 1);
 
 		/* Only TXFTHR needs to be set to the minimum number of frames */
 		write_txftlr(dev, FIELD_PREP(TXFTLR_TXFTHR_MASK, dma_start_level));

--- a/drivers/mspi/mspi_dw_vendor_specific.h
+++ b/drivers/mspi/mspi_dw_vendor_specific.h
@@ -140,18 +140,8 @@ static inline void vendor_specific_irq_clear(const struct device *dev)
 
 #if defined(CONFIG_MSPI_DMA)
 /* DMA support */
-
-#define EVDMA_ATTR_LEN_Pos (0UL)
-#define EVDMA_ATTR_LEN_Msk (0x00FFFFFFUL)
-
 #define EVDMA_ATTR_ATTR_Pos (24UL)
 #define EVDMA_ATTR_ATTR_Msk (0x3FUL << EVDMA_ATTR_ATTR_Pos)
-
-#define EVDMA_ATTR_32AXI_Pos (30UL)
-#define EVDMA_ATTR_32AXI_Msk (0x1UL << EVDMA_ATTR_32AXI_Pos)
-
-#define EVDMA_ATTR_EVENTS_Pos (31UL)
-#define EVDMA_ATTR_EVENTS_Msk (0x1UL << EVDMA_ATTR_EVENTS_Pos)
 
 typedef enum {
 	EVDMA_BYTE_SWAP = 0,
@@ -160,12 +150,8 @@ typedef enum {
 	EVDMA_FIXED_ATTR = 3,
 	EVDMA_STATIC_ADDR = 4,
 	EVDMA_PLAIN_DATA_BUF_WR = 5,
+	EVDMA_PLAIN_DATA = 0x3f,
 } EVDMA_ATTR_Type;
-
-/* Setup EVDMA attribute with the following configuratrion */
-#define EVDMA_ATTRIBUTE (BIT(EVDMA_BYTE_SWAP)   | BIT(EVDMA_JOBLIST)    | \
-			 BIT(EVDMA_BUFFER_FILL) | BIT(EVDMA_FIXED_ATTR) | \
-			 BIT(EVDMA_STATIC_ADDR) | BIT(EVDMA_PLAIN_DATA_BUF_WR))
 
 typedef struct {
 	uint8_t *addr;
@@ -228,13 +214,14 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 
 	/*
 	 * The Command and Address will always have a length of 4 from the DMA's
-	 * perspective. QSPI peripheral will use length of data specified in core registers
+	 * perspective. QSPI peripheral will use length of data specified in core registers.
+	 * Since the cmd and address are stored as uint32_t, byte swap is never needed.
 	 */
 	if (dev_data->xfer.cmd_length > 0) {
-		joblist[job_idx++] = EVDMA_JOB(&packet->cmd, 4, EVDMA_ATTRIBUTE);
+		joblist[job_idx++] = EVDMA_JOB(&packet->cmd, 4, EVDMA_PLAIN_DATA);
 	}
 	if (dev_data->xfer.addr_length > 0) {
-		joblist[job_idx++] = EVDMA_JOB(&packet->address, 4, EVDMA_ATTRIBUTE);
+		joblist[job_idx++] = EVDMA_JOB(&packet->address, 4, EVDMA_PLAIN_DATA);
 	}
 
 	if (packet->dir == MSPI_TX) {
@@ -242,7 +229,7 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 
 		if (packet->num_bytes > 0) {
 			joblist[job_idx++] = EVDMA_JOB(packet->data_buf, packet->num_bytes,
-						EVDMA_ATTRIBUTE);
+						       EVDMA_PLAIN_DATA);
 		}
 
 		/* Always terminate with null job */
@@ -262,7 +249,7 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 			joblist[job_idx++] = EVDMA_NULL_JOB();
 			transfer_list->rx_job = &joblist[job_idx];
 			joblist[job_idx++] = EVDMA_JOB(packet->data_buf, packet->num_bytes,
-						       EVDMA_ATTRIBUTE);
+						       EVDMA_PLAIN_DATA);
 			joblist[job_idx]   = EVDMA_NULL_JOB();
 		} else {
 			/* Sending command or address while configured as target isn't supported */
@@ -270,7 +257,7 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 
 			transfer_list->rx_job = &joblist[0];
 			joblist[0] = EVDMA_JOB(packet->data_buf, packet->num_bytes,
-					       EVDMA_ATTRIBUTE);
+					       EVDMA_PLAIN_DATA);
 			joblist[1] = EVDMA_NULL_JOB();
 			transfer_list->tx_job = &joblist[1];
 		}

--- a/drivers/mspi/mspi_dw_vendor_specific.h
+++ b/drivers/mspi/mspi_dw_vendor_specific.h
@@ -138,6 +138,7 @@ static inline void vendor_specific_irq_clear(const struct device *dev)
 	preg->EVENTS_DMA.DONE = 0;
 }
 
+#if defined(CONFIG_MSPI_DMA)
 /* DMA support */
 
 #define EVDMA_ATTR_LEN_Pos (0UL)
@@ -307,6 +308,7 @@ static inline bool vendor_specific_read_dma_irq(const struct device *dev)
 
 	return (bool) preg->EVENTS_DMA.DONE;
 }
+#endif /*defined(CONFIG_MSPI_DMA)*/
 
 #else /* Supply empty vendor specific macros for generic case */
 

--- a/drivers/mspi/mspi_dw_vendor_specific.h
+++ b/drivers/mspi/mspi_dw_vendor_specific.h
@@ -250,9 +250,8 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 		transfer_list->rx_job = &joblist[job_idx];
 		tmod = QSPI_TMOD_TX_ONLY;
 	} else {
-		preg->CONFIG.RXTRANSFERLENGTH = ((packet->num_bytes + dev_data->xfer.addr_length +
-						dev_data->xfer.cmd_length) >>
-						dev_data->bytes_per_frame_exp) - 1;
+		preg->CONFIG.RXTRANSFERLENGTH = ((packet->num_bytes) >>
+						dev_data->bytes_per_frame_exp);
 
 		/* If sending address or command while being configured as controller */
 		if (job_idx > 0 && config->op_mode == MSPI_OP_MODE_CONTROLLER) {

--- a/drivers/mspi/mspi_dw_vendor_specific.h
+++ b/drivers/mspi/mspi_dw_vendor_specific.h
@@ -209,8 +209,7 @@ static inline void vendor_specific_start_dma_xfer(const struct device *dev)
 {
 	struct mspi_dw_data *dev_data = dev->data;
 	const struct mspi_dw_config *config = dev->config;
-	const struct mspi_xfer_packet *packet =
-		&dev_data->xfer.packets[dev_data->packets_done];
+	struct mspi_xfer_packet *packet = &dev_data->current_packet;
 	NRF_QSPI_Type *preg = (NRF_QSPI_Type *)config->wrapper_regs;
 
 	/* Use vendor-specific data from config - stores job and transfer lists */

--- a/dts/bindings/mspi/nordic,nrf-qspi-v2.yaml
+++ b/dts/bindings/mspi/nordic,nrf-qspi-v2.yaml
@@ -6,3 +6,16 @@ description: Nordic QSPI v2 Interface using SSI IP
 compatible: "nordic,nrf-qspi-v2"
 
 include: snps,designware-ssi.yaml
+properties:
+  bits-per-pixel:
+    type: int
+    default: 0
+    enum:
+      - 0
+      - 4
+      - 8
+      - 16
+    description: |
+      When using the peripheral to drive the display in controller mode, the wrapper needs to know
+      how many bits per pixel (BPP) are being used. If 0, the reordering of the data based on the
+      BPP is disabled.


### PR DESCRIPTION
Data only transfer:
The IP doesn't support a data only transfer (no cmd or addr). It is required instead that the first dataframe of the data buffer is sent as an address.

`current_packet` has been added as a variable in the dev data structure to create a copy of the packet so it can be modified and used during a data only transfer. The first dataframe can then be safely copied to the address without modifying the original packet passed through by the user.

Format registers:
Since the API takes in an input buffer of uint8_t, data will appear big-endian in memory. Since the system is little-endian, when for example DFS = 32, the order will come out in reverse order. Therefore, we can use the format registers and set BPP to 8 which results in the data being formatted to big-endian. Setting BPP to always be 8 ensures big-endian output, regardless of the DFS. These format registers are also used for display use-case and can be overwritten to match the BPP of your display in the devicetree