### PR TITLE
lora: remove `EXPERIMENTAL` from already unstable api

### DIFF
--- a/drivers/lora/Kconfig
+++ b/drivers/lora/Kconfig
@@ -7,9 +7,8 @@
 # Top-level configuration file for LORA drivers.
 
 menuconfig LORA
-	bool "LoRa drivers [EXPERIMENTAL]"
+	bool "LoRa drivers"
 	select POLL
-	select EXPERIMENTAL
 	help
 	  Include LoRa drivers in the system configuration.
 
@@ -23,12 +22,12 @@ config LORA_MODULE_BACKEND_LORAMAC_NODE
 	depends on ZEPHYR_LORAMAC_NODE_MODULE
 
 config LORA_MODULE_BACKEND_LORA_BASICS_MODEM
-	bool "LoRa Basic modem backend [EXPERIMENTAL]"
+	bool "LoRa Basic modem backend"
 	depends on ZEPHYR_LORA_BASICS_MODEM_MODULE
 	depends on DT_HAS_SEMTECH_SX1262_ENABLED || DT_HAS_SEMTECH_SX1261_ENABLED || DT_HAS_SEMTECH_SX1272_ENABLED || DT_HAS_SEMTECH_SX1276_ENABLED
 	select USE_LORA_BASICS_MODEM_DRIVERS
 	help
-	  Experimental support for implementing the LoRa API using the LoRa Basics Modem module.
+	  LoRa API support using the LoRa Basics Modem module.
 
 endchoice
 


### PR DESCRIPTION
Based on api lifecycle documentation, the lora driver has been recently moved to unstable. This means that the state of this driver is no longer experimental. Due this new state, the change should be updated on Kconfig.

This commit remove the `EXPERIMENTAL` symbol selection from the driver itself. It also remove the word `experimental` from the lora basic modem backend since the api lifecycle documentation only describes the state of the api based upon the api itself and not any particular backend implementation.