### PR TITLE
cmake: extensions: remove invalid add_dependencies

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1771,10 +1771,6 @@ function(zephyr_syscall_include_directories)
       syscalls_interface INTERFACE
       ${include_dir}
     )
-    add_dependencies(
-      syscalls_interface
-      ${include_dir}
-    )
 
     unset(include_dir)
   endforeach()
@@ -1793,10 +1789,6 @@ function(zephyr_syscall_header)
 
     target_sources(
       syscalls_interface INTERFACE
-      ${header_file}
-    )
-    add_dependencies(
-      syscalls_interface
       ${header_file}
     )
 


### PR DESCRIPTION
The `add_dependencies` command in CMake is used to specify dependencies between targets - here it was used to specify a dependency on a folder, which is not valid (and causes failures on CMake 4.2 when using the cmake-file-api, guess it's otherwise just silently ignored in earlier CMake versions).

This was introduced with commit 80a6a206289537fa220e34fe485b11fccef9ac85 - cc @gmarull 