### PR TITLE
boards: rpi_pico2: fix I2C misconfiguration bug

### DIFF
--- a/boards/raspberrypi/rpi_pico2/Kconfig.defconfig
+++ b/boards/raspberrypi/rpi_pico2/Kconfig.defconfig
@@ -17,4 +17,11 @@ config WHD_DISABLE_SDIO_PULLUP_DURING_SPI_SLEEP
 
 endif # WIFI_AIROC
 
+if I2C_DW
+
+config I2C_DW_CLOCK_SPEED
+	default 150
+
+endif # I2C_DW
+
 endif # BOARD_RPI_PICO2


### PR DESCRIPTION
I2C controller on rpi_pico2 boards were getting misconfigured due to `CONFIG_I2C_DW_CLOCK_SPEED` not getting set properly. This change fixes the value for this Kconfig symbol to the correct clock speed (clk_peri) that is used by I2C controller.