### PR TITLE
doc: requirements: add missing junitparser, needed by twister

### DIFF
--- a/doc/requirements.in
+++ b/doc/requirements.in
@@ -20,6 +20,9 @@ pykwalify
 pytest
 pyserial
 
+# Since commit cae12e6d6a7d5, building docs runs "twister"
+junitparser
+
 # Doxygen doxmlparser
 doxmlparser
 


### PR DESCRIPTION
Fixes commit cae12e6d6a7d5  ("doc: twister: inline `twister --help` output into the docs")

---------

cc:
- #92854