### PR TITLE
doc/requirements.in: clarify they are additional, not standalone

### DIFF
--- a/doc/requirements.in
+++ b/doc/requirements.in
@@ -1,4 +1,5 @@
-# DOC: used to generate docs
+# DOC: additional dependencies required to generate docs.
+#      Follow the "Getting Started" guide first.
 
 sphinx<8.3.0
 sphinx_rtd_theme~=3.0


### PR DESCRIPTION
Rephrase the file header to make sure these dependencies cannot be misinterpreted as standalone.

The doc requirements were standalone in January 2021 as demonstrated by commit e21ffe6baaca ("requirements-doc: add PyYAML which removes dependency on -base") and were most likely tested as standalone by CI until January 2025 when commit b6922c83a8a5 ("ci: doc: add action-zephyr-setup") added a Zephyr setup step to `.github/workflows/doc-build.yml`