### PR TITLE
Add sys_getopt_r, sys_getopt_long_r and sys_getopt_long_only_r

### DIFF
--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -686,12 +686,12 @@ the arguments string, looking for supported options. Typically, this task
 is accomplished by the ``getopt`` family functions.
 
 For this purpose shell supports a variant of the getopt and getopt_long libraries from
-the FreeBSD project called sys_getopt and sys_getopt_long. This feature is activated by:
+the FreeBSD project called sys_getopt_r and sys_getopt_long_r. This feature is activated by:
 :kconfig:option:`CONFIG_GETOPT` set to ``y`` and :kconfig:option:`CONFIG_GETOPT_LONG`
 set to ``y``.
 
-This feature can be used in thread safe as well as non thread safe manner.
-The former is full compatible with regular getopt usage while the latter
+This feature can be used in non thread safe as well as thread safe manner.
+The former is fully compatible with regular getopt usage while the latter
 a bit differs.
 
 An example non-thread safe usage:
@@ -714,20 +714,16 @@ An example thread safe usage:
 .. code-block:: c
 
   char *cvalue = NULL;
-  struct sys_getopt_state *state;
-  while ((char c = sys_getopt(argc, argv, "abhc:")) != -1) {
-        state = sys_getopt_state_get();
+  struct sys_getopt_state state = SYS_GETOPT_STATE_INITIALIZER;
+  while ((char c = sys_getopt_r(argc, argv, "abhc:", &state)) != -1) {
         switch (c) {
         case 'c':
-                cvalue = state->optarg;
+                cvalue = state.optarg;
                 break;
         default:
                 break;
         }
   }
-
-Thread safe sys_getopt functionality is activated by
-:kconfig:option:`CONFIG_SHELL_GETOPT` set to ``y``.
 
 Obscured Input Feature
 **********************

--- a/include/zephyr/sys/sys_getopt.h
+++ b/include/zephyr/sys/sys_getopt.h
@@ -34,6 +34,9 @@ extern int sys_getopt_opterr;
 extern int sys_getopt_optind;
 extern int sys_getopt_optopt;
 
+/* Initialize local sys_getopt_state with this value */
+#define SYS_GETOPT_STATE_INITIALIZER	{0}
+
 #define sys_getopt_no_argument       0
 #define sys_getopt_required_argument 1
 #define sys_getopt_optional_argument 2
@@ -52,6 +55,9 @@ struct sys_getopt_option {
 	int val;
 };
 
+/* Function initializes getopt_state structure */
+void sys_getopt_init_r(struct sys_getopt_state *state);
+
 /* Function initializes getopt_state structure for current thread */
 void sys_getopt_init(void);
 
@@ -67,16 +73,19 @@ struct sys_getopt_state *sys_getopt_state_get(void);
  * @param[in] nargc	   Arguments count.
  * @param[in] nargv	   Arguments.
  * @param[in] ostr	   String containing the legitimate option characters.
+ * @param[inout] state	   Current argument parsing state.
  *
  * @return		If an option was successfully found, function returns
  *			the option character.
  */
+int sys_getopt_r(int nargc, char *const nargv[], const char *ostr, struct sys_getopt_state *state);
+
 int sys_getopt(int nargc, char *const nargv[], const char *ostr);
 
 /**
  * @brief Parses the command-line arguments.
  *
- * The sys_getopt_long() function works like @ref sys_getopt() except
+ * The sys_getopt_long_r() function works like @ref sys_getopt_r() except
  * it also accepts long options, started with two dashes.
  *
  * @note This function is based on FreeBSD implementation but it does not
@@ -90,17 +99,22 @@ int sys_getopt(int nargc, char *const nargv[], const char *ostr);
  * @param[in] idx	   If idx is not NULL, it points to a variable
  *			   which is set to the index of the long option relative
  *			   to @p long_options.
+ * @param[inout] state	   Current argument parsing state.
  *
  * @return		If an option was successfully found, function returns
  *			the option character.
  */
+int sys_getopt_long_r(int nargc, char *const *nargv, const char *options,
+		      const struct sys_getopt_option *long_options, int *idx,
+		      struct sys_getopt_state *state);
+
 int sys_getopt_long(int nargc, char *const *nargv, const char *options,
 		    const struct sys_getopt_option *long_options, int *idx);
 
 /**
  * @brief Parses the command-line arguments.
  *
- * The sys_getopt_long_only() function works like @ref sys_getopt_long(),
+ * The sys_getopt_long_only_r() function works like @ref sys_getopt_long_r(),
  * but '-' as well as "--" can indicate a long option. If an option that starts
  * with '-' (not "--") doesn't match a long option, but does match a short
  * option, it is parsed as a short option instead.
@@ -116,10 +130,15 @@ int sys_getopt_long(int nargc, char *const *nargv, const char *options,
  * @param[in] idx	   If idx is not NULL, it points to a variable
  *			   which is set to the index of the long option relative
  *			   to @p long_options.
+ * @param[inout] state	   Current argument parsing state.
  *
  * @return		If an option was successfully found, function returns
  *			the option character.
  */
+int sys_getopt_long_only_r(int nargc, char *const *nargv, const char *options,
+			   const struct sys_getopt_option *long_options, int *idx,
+			   struct sys_getopt_state *state);
+
 int sys_getopt_long_only(int nargc, char *const *nargv, const char *options,
 			 const struct sys_getopt_option *long_options, int *idx);
 

--- a/lib/posix/c_lib_ext/getopt/getopt.h
+++ b/lib/posix/c_lib_ext/getopt/getopt.h
@@ -13,16 +13,11 @@
 extern "C" {
 #endif
 
-extern void getopt_init(void);
-
-#define getopt_state sys_getopt_state
 #define option sys_getopt_option
 
 #define no_argument       0
 #define required_argument 1
 #define optional_argument 2
-
-extern struct sys_getopt_state *getopt_state_get(void);
 
 extern int getopt_long(int nargc, char *const *nargv, const char *options,
 		       const struct option *long_options, int *idx);

--- a/lib/posix/c_lib_ext/getopt_shim.c
+++ b/lib/posix/c_lib_ext/getopt_shim.c
@@ -11,37 +11,52 @@
 char *optarg;
 int opterr, optind, optopt;
 
-void getopt_init(void)
+static struct sys_getopt_state	getopt_state = SYS_GETOPT_STATE_INITIALIZER;
+
+static void getopt_global_state_get(void)
 {
-	sys_getopt_init();
+	getopt_state.opterr = opterr;
+	getopt_state.optind = optind;
+	getopt_state.optopt = optopt;
+	getopt_state.optarg = optarg;
 }
 
-struct getopt_state *getopt_state_get(void)
+static void getopt_global_state_put(void)
 {
-	return sys_getopt_state_get();
+	opterr = getopt_state.opterr;
+	optind = getopt_state.optind;
+	optopt = getopt_state.optopt;
+	optarg = getopt_state.optarg;
 }
 
 int getopt(int argc, char *const argv[], const char *optstring)
 {
-	return sys_getopt(argc, argv, optstring);
-}
+	int ret;
 
-void z_getopt_global_state_update_shim(struct sys_getopt_state *state)
-{
-	opterr = state->opterr;
-	optind = state->optind;
-	optopt = state->optopt;
-	optarg = state->optarg;
+	getopt_global_state_get();
+	ret = sys_getopt_r(argc, argv, optstring, &getopt_state);
+	getopt_global_state_put();
+	return ret;
 }
 
 int getopt_long(int argc, char *const argv[], const char *shortopts,
 		const struct option *longopts, int *longind)
 {
-	return sys_getopt_long(argc, argv, shortopts, longopts, longind);
+	int ret;
+
+	getopt_global_state_get();
+	ret = sys_getopt_long_r(argc, argv, shortopts, longopts, longind, &getopt_state);
+	getopt_global_state_put();
+	return ret;
 }
 
 int getopt_long_only(int argc, char *const argv[], const char *shortopts,
 		     const struct option *longopts, int *longind)
 {
-	return sys_getopt_long_only(argc, argv, shortopts, longopts, longind);
+	int ret;
+
+	getopt_global_state_get();
+	ret = sys_getopt_long_only_r(argc, argv, shortopts, longopts, longind, &getopt_state);
+	getopt_global_state_put();
+	return ret;
 }

--- a/lib/posix/shell/uname.c
+++ b/lib/posix/shell/uname.c
@@ -42,7 +42,7 @@ static void uname_print_usage(const struct shell *sh)
 
 static int uname_cmd_handler(const struct shell *sh, size_t argc, char **argv)
 {
-	struct sys_getopt_state *state = sys_getopt_state_get();
+	struct sys_getopt_state state = SYS_GETOPT_STATE_INITIALIZER;
 	struct utsname info;
 	unsigned int set;
 	int option;
@@ -53,8 +53,7 @@ static int uname_cmd_handler(const struct shell *sh, size_t argc, char **argv)
 
 	/* Get the uname options */
 
-	optind = 1;
-	while ((option = sys_getopt(argc, argv, "asonrvmpi")) != -1) {
+	while ((option = sys_getopt_r(argc, argv, "asonrvmpi", &state)) != -1) {
 		switch (option) {
 		case 'a':
 			set = UNAME_ALL;
@@ -93,13 +92,13 @@ static int uname_cmd_handler(const struct shell *sh, size_t argc, char **argv)
 
 		case '?':
 		default:
-			badarg = (char)state->optopt;
+			badarg = (char)state.optopt;
 			break;
 		}
 	}
 
-	if (argc != optind) {
-		shell_error(sh, "uname: extra operand %s", argv[optind]);
+	if (argc != state.optind) {
+		shell_error(sh, "uname: extra operand %s", argv[state.optind]);
 		uname_print_usage(sh);
 		return -1;
 	}

--- a/lib/utils/getopt/getopt_common.c
+++ b/lib/utils/getopt/getopt_common.c
@@ -54,10 +54,6 @@ void z_getopt_global_state_update(struct sys_getopt_state *state)
 	sys_getopt_optopt = state->optopt;
 	sys_getopt_optreset = state->optreset;
 	sys_getopt_optarg = state->optarg;
-
-	if (!IS_ENABLED(CONFIG_NATIVE_LIBC) && IS_ENABLED(CONFIG_POSIX_C_LIB_EXT)) {
-		z_getopt_global_state_update_shim(state);
-	}
 }
 
 /* It is internal getopt API function, it shall not be called by the user. */

--- a/lib/utils/getopt/getopt_common.c
+++ b/lib/utils/getopt/getopt_common.c
@@ -38,12 +38,6 @@ static struct sys_getopt_state m_getopt_common_state = {
 #endif
 };
 
-/* Shim function to update global variables in getopt_shim.c if user wants to
- * still use the original non-posix compliant getopt. The shim will be deprecated
- * and eventually removed in the future.
- */
-extern void z_getopt_global_state_update_shim(struct sys_getopt_state *state);
-
 /* This function is not thread safe. All threads using getopt are calling
  * this function.
  */

--- a/lib/utils/getopt/getopt_long.c
+++ b/lib/utils/getopt/getopt_long.c
@@ -348,6 +348,11 @@ static int getopt_internal(struct sys_getopt_state *state, int nargc, char *cons
 		return -1;
 	}
 
+	/* Reset if optind is 0 */
+	if (state->optind == 0) {
+		sys_getopt_init_r(state);
+	}
+
 	/*
 	 * Disable GNU extensions if options string begins with a '+'.
 	 */
@@ -366,14 +371,6 @@ static int getopt_internal(struct sys_getopt_state *state, int nargc, char *cons
 #endif
 	if (*options == '+' || *options == '-') {
 		options++;
-	}
-
-	/*
-	 * XXX Some GNU programs (like cvs) set optind to 0 instead of
-	 * XXX using optreset.  Work around this braindamage.
-	 */
-	if (state->optind == 0) {
-		state->optind = state->optreset = 1;
 	}
 
 	state->optarg = NULL;
@@ -568,6 +565,13 @@ start:
  * getopt_long --
  *	Parse argc/argv argument vector.
  */
+int sys_getopt_long_r(int nargc, char *const *nargv, const char *options,
+		      const struct sys_getopt_option *long_options, int *idx,
+		      struct sys_getopt_state *state)
+{
+	return getopt_internal(state, nargc, nargv, options, long_options, idx, FLAG_PERMUTE);
+}
+
 int sys_getopt_long(int nargc, char *const *nargv, const char *options,
 		    const struct sys_getopt_option *long_options, int *idx)
 {
@@ -588,6 +592,14 @@ int sys_getopt_long(int nargc, char *const *nargv, const char *options,
  * getopt_long_only --
  *	Parse argc/argv argument vector.
  */
+int sys_getopt_long_only_r(int nargc, char *const *nargv, const char *options,
+			   const struct sys_getopt_option *long_options, int *idx,
+			   struct sys_getopt_state *state)
+{
+	return getopt_internal(state, nargc, nargv, options, long_options, idx,
+			       FLAG_PERMUTE | FLAG_LONGONLY);
+}
+
 int sys_getopt_long_only(int nargc, char *const *nargv, const char *options,
 			 const struct sys_getopt_option *long_options, int *idx)
 {

--- a/samples/shields/npm6001_ek/src/main.c
+++ b/samples/shields/npm6001_ek/src/main.c
@@ -15,8 +15,6 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/printk.h>
 
-#include <zephyr/sys/sys_getopt.h>
-
 struct regulators_map {
 	const char *name;
 	const struct device *dev;
@@ -312,27 +310,29 @@ static int cmd_gpio_configure(const struct shell *sh, size_t argc, char **argv)
 		{NULL, 0, NULL, 0},
 	};
 
+	struct sys_getopt_state state = SYS_GETOPT_STATE_INITIALIZER;
+
 	high_drive = 0;
 	pull_down = 0;
 	cmos = 0;
 
-	while ((opt = sys_getopt_long(argc, argv, "p:d:", long_options,
-				      &long_index)) != -1) {
+	while ((opt = sys_getopt_long_r(argc, argv, "p:d:", long_options,
+					&long_index, &state)) != -1) {
 		switch (opt) {
 		case 0:
 			/* options setting a flag, do nothing */
 			break;
 		case 'p':
-			pin = atoi(sys_getopt_optarg);
+			pin = atoi(state.optarg);
 			break;
 		case 'd':
-			if (strcmp(sys_getopt_optarg, "in") == 0) {
+			if (strcmp(state.optarg, "in") == 0) {
 				flags |= GPIO_INPUT;
-			} else if (strcmp(sys_getopt_optarg, "out") == 0) {
+			} else if (strcmp(state.optarg, "out") == 0) {
 				flags |= GPIO_OUTPUT;
-			} else if (strcmp(sys_getopt_optarg, "outh") == 0) {
+			} else if (strcmp(state.optarg, "outh") == 0) {
 				flags |= GPIO_OUTPUT_HIGH;
-			} else if (strcmp(sys_getopt_optarg, "outl") == 0) {
+			} else if (strcmp(state.optarg, "outl") == 0) {
 				flags |= GPIO_OUTPUT_LOW;
 			}
 			break;

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -12,12 +12,6 @@
 #include <zephyr/drivers/uart.h>
 #include <ctype.h>
 
-#ifdef CONFIG_NATIVE_LIBC
-#include <unistd.h>
-#else
-#include <zephyr/posix/unistd.h>
-#endif
-
 LOG_MODULE_REGISTER(app);
 
 extern void foo(void);
@@ -109,14 +103,13 @@ static int cmd_demo_board(const struct shell *sh, size_t argc, char **argv)
 static int cmd_demo_getopt_ts(const struct shell *sh, size_t argc,
 			      char **argv)
 {
-	struct sys_getopt_state *state;
 	char *cvalue = NULL;
 	int aflag = 0;
 	int bflag = 0;
 	int c;
+	struct sys_getopt_state state = SYS_GETOPT_STATE_INITIALIZER;
 
-	while ((c = sys_getopt(argc, argv, "abhc:")) != -1) {
-		state = sys_getopt_state_get();
+	while ((c = sys_getopt_r(argc, argv, "abhc:", &state)) != -1) {
 		switch (c) {
 		case 'a':
 			aflag = 1;
@@ -125,7 +118,7 @@ static int cmd_demo_getopt_ts(const struct shell *sh, size_t argc,
 			bflag = 1;
 			break;
 		case 'c':
-			cvalue = state->optarg;
+			cvalue = state.optarg;
 			break;
 		case 'h':
 			/* When getopt is active shell is not parsing
@@ -135,18 +128,18 @@ static int cmd_demo_getopt_ts(const struct shell *sh, size_t argc,
 			shell_help(sh);
 			return SHELL_CMD_HELP_PRINTED;
 		case '?':
-			if (state->optopt == 'c') {
+			if (state.optopt == 'c') {
 				shell_print(sh,
 					"Option -%c requires an argument.",
-					state->optopt);
-			} else if (isprint(state->optopt) != 0) {
+					state.optopt);
+			} else if (isprint(state.optopt) != 0) {
 				shell_print(sh,
 					"Unknown option `-%c'.",
-					state->optopt);
+					state.optopt);
 			} else {
 				shell_print(sh,
 					"Unknown option character `\\x%x'.",
-					state->optopt);
+					state.optopt);
 			}
 			return 1;
 		default:
@@ -165,8 +158,9 @@ static int cmd_demo_getopt(const struct shell *sh, size_t argc,
 	int aflag = 0;
 	int bflag = 0;
 	int c;
+	struct sys_getopt_state state = SYS_GETOPT_STATE_INITIALIZER;
 
-	while ((c = sys_getopt(argc, argv, "abhc:")) != -1) {
+	while ((c = sys_getopt_r(argc, argv, "abhc:", &state)) != -1) {
 		switch (c) {
 		case 'a':
 			aflag = 1;
@@ -175,7 +169,7 @@ static int cmd_demo_getopt(const struct shell *sh, size_t argc,
 			bflag = 1;
 			break;
 		case 'c':
-			cvalue = sys_getopt_optarg;
+			cvalue = state.optarg;
 			break;
 		case 'h':
 			/* When getopt is active shell is not parsing
@@ -185,17 +179,17 @@ static int cmd_demo_getopt(const struct shell *sh, size_t argc,
 			shell_help(sh);
 			return SHELL_CMD_HELP_PRINTED;
 		case '?':
-			if (sys_getopt_optopt == 'c') {
+			if (state.optopt == 'c') {
 				shell_print(sh,
 					"Option -%c requires an argument.",
-					sys_getopt_optopt);
-			} else if (isprint(sys_getopt_optopt) != 0) {
+					state.optopt);
+			} else if (isprint(state.optopt) != 0) {
 				shell_print(sh, "Unknown option `-%c'.",
-					    sys_getopt_optopt);
+					    state.optopt);
 			} else {
 				shell_print(sh,
 					"Unknown option character `\\x%x'.",
-					sys_getopt_optopt);
+					state.optopt);
 			}
 			return 1;
 		default:

--- a/subsys/crc/crc_shell.c
+++ b/subsys/crc/crc_shell.c
@@ -8,11 +8,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#ifdef CONFIG_NATIVE_LIBC
-#include <unistd.h>
-#else
-#include <zephyr/posix/unistd.h>
-#endif
 
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
@@ -79,9 +74,9 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 	void *addr = (void *)-1;
 	enum crc_type type = CRC32_IEEE;
 
-	sys_getopt_optind = 1;
+	struct sys_getopt_state state = SYS_GETOPT_STATE_INITIALIZER;
 
-	while ((rv = sys_getopt(argc, argv, "fhlp:rs:t:")) != -1) {
+	while ((rv = sys_getopt_r(argc, argv, "fhlp:rs:t:", &state)) != -1) {
 		switch (rv) {
 		case 'f':
 			first = true;
@@ -93,9 +88,9 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 			last = true;
 			break;
 		case 'p':
-			poly = (size_t)strtoul(sys_getopt_optarg, NULL, 16);
+			poly = (size_t)strtoul(state.optarg, NULL, 16);
 			if (poly == 0 && errno == EINVAL) {
-				shell_error(sh, "invalid seed '%s'", sys_getopt_optarg);
+				shell_error(sh, "invalid seed '%s'", state.optarg);
 				return -EINVAL;
 			}
 			break;
@@ -103,16 +98,16 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 			reflect = true;
 			break;
 		case 's':
-			seed = (size_t)strtoul(sys_getopt_optarg, NULL, 16);
+			seed = (size_t)strtoul(state.optarg, NULL, 16);
 			if (seed == 0 && errno == EINVAL) {
-				shell_error(sh, "invalid seed '%s'", sys_getopt_optarg);
+				shell_error(sh, "invalid seed '%s'", state.optarg);
 				return -EINVAL;
 			}
 			break;
 		case 't':
-			type = string_to_crc_type(sys_getopt_optarg);
+			type = string_to_crc_type(state.optarg);
 			if (type == -1) {
-				shell_error(sh, "invalid type '%s'", sys_getopt_optarg);
+				shell_error(sh, "invalid type '%s'", state.optarg);
 				return -EINVAL;
 			}
 			break;
@@ -123,21 +118,21 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 		}
 	}
 
-	if (sys_getopt_optind + 2 > argc) {
+	if (state.optind + 2 > argc) {
 		shell_error(sh, "'address' and 'size' arguments are mandatory");
 		usage(sh);
 		return -EINVAL;
 	}
 
-	addr = (void *)strtoul(argv[sys_getopt_optind], NULL, 16);
+	addr = (void *)strtoul(argv[state.optind], NULL, 16);
 	if (addr == 0 && errno == EINVAL) {
-		shell_error(sh, "invalid address '%s'", argv[sys_getopt_optind]);
+		shell_error(sh, "invalid address '%s'", argv[state.optind]);
 		return -EINVAL;
 	}
 
-	size = (size_t)strtoul(argv[sys_getopt_optind + 1], NULL, 0);
+	size = (size_t)strtoul(argv[state.optind + 1], NULL, 0);
 	if (size == 0 && errno == EINVAL) {
-		shell_error(sh, "invalid size '%s'", argv[sys_getopt_optind + 1]);
+		shell_error(sh, "invalid size '%s'", argv[state.optind + 1]);
 		return -EINVAL;
 	}
 

--- a/subsys/shell/modules/devmem_service.c
+++ b/subsys/shell/modules/devmem_service.c
@@ -10,11 +10,11 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include <stdlib.h>
-#include <zephyr/sys/sys_getopt.h>
 #include <zephyr/device.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/sys_getopt.h>
 
 static inline bool is_ascii(uint8_t data)
 {
@@ -113,30 +113,28 @@ static int cmd_dump(const struct shell *sh, size_t argc, char **argv)
 	size_t size = -1;
 	size_t width = 32;
 	mem_addr_t addr = -1;
+	struct sys_getopt_state state = SYS_GETOPT_STATE_INITIALIZER;
 
-	sys_getopt_optind = 1;
-	sys_getopt_init();
-
-	while ((rv = sys_getopt(argc, argv, "a:s:w:")) != -1) {
+	while ((rv = sys_getopt_r(argc, argv, "a:s:w:", &state)) != -1) {
 		switch (rv) {
 		case 'a':
-			addr = (mem_addr_t)shell_strtoul(sys_getopt_optarg, 16, &err);
+			addr = (mem_addr_t)shell_strtoul(state.optarg, 16, &err);
 			if (err != 0) {
-				shell_error(sh, "invalid addr '%s'", sys_getopt_optarg);
+				shell_error(sh, "invalid addr '%s'", state.optarg);
 				return -EINVAL;
 			}
 			break;
 		case 's':
-			size = (size_t)shell_strtoul(sys_getopt_optarg, 0, &err);
+			size = (size_t)shell_strtoul(state.optarg, 0, &err);
 			if (err != 0) {
-				shell_error(sh, "invalid size '%s'", sys_getopt_optarg);
+				shell_error(sh, "invalid size '%s'", state.optarg);
 				return -EINVAL;
 			}
 			break;
 		case 'w':
-			width = (size_t)shell_strtoul(sys_getopt_optarg, 0, &err);
+			width = (size_t)shell_strtoul(state.optarg, 0, &err);
 			if (err != 0) {
-				shell_error(sh, "invalid width '%s'", sys_getopt_optarg);
+				shell_error(sh, "invalid width '%s'", state.optarg);
 				return -EINVAL;
 			}
 			break;

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -545,10 +545,6 @@ static int exec_cmd(const struct shell *sh, size_t argc, const char **argv,
 	}
 
 	if (!ret_val) {
-#if CONFIG_SHELL_GETOPT
-		sys_getopt_init();
-#endif
-
 		z_flag_cmd_ctx_set(sh, true);
 		/* Unlock thread mutex in case command would like to borrow
 		 * shell context to other thread to avoid mutex deadlock.

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -1253,7 +1253,7 @@ static int cmd_runall(const struct shell *sh, size_t argc, char **argv)
 static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 {
 
-	struct sys_getopt_state *state;
+	struct sys_getopt_state state = SYS_GETOPT_STATE_INITIALIZER;
 	int opt;
 	static struct sys_getopt_option long_options[] = {
 		{"suite_iter", sys_getopt_required_argument, 0, 's'},
@@ -1266,11 +1266,11 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 	int suite_iter = 1;
 	int case_iter = 1;
 
-	while ((opt = sys_getopt_long(argc, argv, "s:c:", long_options, &opt_index)) != -1) {
-		state = sys_getopt_state_get();
+	while ((opt = sys_getopt_long_r(argc, argv, "s:c:",
+					long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 's':
-			val = atoi(state->optarg);
+			val = atoi(state.optarg);
 			if (val < 1) {
 				shell_error(sh, "Invalid number of suite iterations");
 				return -ENOEXEC;
@@ -1279,7 +1279,7 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 			opt_num++;
 			break;
 		case 'c':
-			val = atoi(state->optarg);
+			val = atoi(state.optarg);
 			if (val < 1) {
 				shell_error(sh, "Invalid number of case iterations");
 				return -ENOEXEC;
@@ -1302,7 +1302,7 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_run_suite(const struct shell *sh, size_t argc, char **argv)
 {
-	struct sys_getopt_state *state;
+	struct sys_getopt_state state = SYS_GETOPT_STATE_INITIALIZER;
 	int opt;
 	static struct sys_getopt_option long_options[] = {
 		{"repeat_iter", sys_getopt_required_argument, NULL, 'r'},
@@ -1313,11 +1313,11 @@ static int cmd_run_suite(const struct shell *sh, size_t argc, char **argv)
 	void *param = NULL;
 	int repeat_iter = 1;
 
-	while ((opt = sys_getopt_long(argc, argv, "r:p:", long_options, &opt_index)) != -1) {
-		state = sys_getopt_state_get();
+	while ((opt = sys_getopt_long_r(argc, argv, "r:p:",
+					long_options, &opt_index, &state)) != -1) {
 		switch (opt) {
 		case 'r':
-			val = atoi(state->optarg);
+			val = atoi(state.optarg);
 			if (val < 1) {
 				shell_fprintf(sh, SHELL_ERROR,
 					"Invalid number of suite interations\n");
@@ -1327,7 +1327,7 @@ static int cmd_run_suite(const struct shell *sh, size_t argc, char **argv)
 			opt_num++;
 			break;
 		case 'p':
-			param = state->optarg;
+			param = state.optarg;
 			opt_num++;
 			break;
 		default:

--- a/tests/posix/c_lib_ext/src/getopt.c
+++ b/tests/posix/c_lib_ext/src/getopt.c
@@ -28,10 +28,8 @@ ZTEST(posix_c_lib_ext, test_getopt_basic)
 	int c;
 	char **argv;
 
+	optind = 0;		/* Reset state */
 	argv = (char **)nargv;
-
-	/* Get state of the current thread */
-	getopt_init();
 
 	do {
 		c = getopt(argc, argv, accepted_opt);
@@ -55,7 +53,6 @@ enum getopt_idx {
 
 ZTEST(posix_c_lib_ext, test_getopt)
 {
-	struct getopt_state *state;
 	static const char *test_opts = "ac:";
 	static const char *const nargv[] = {
 		[GETOPT_IDX_CMD_NAME] = "cmd_name",
@@ -67,9 +64,7 @@ ZTEST(posix_c_lib_ext, test_getopt)
 	char **argv;
 	int c;
 
-	/* Get state of the current thread */
-	getopt_init();
-
+	optind = 0;		/* Reset state */
 	argv = (char **)nargv;
 
 	/* Test uknown option */
@@ -80,12 +75,7 @@ ZTEST(posix_c_lib_ext, test_getopt)
 	zassert_equal(c, 'c', "unexpected opt character");
 
 	c = getopt(argc, argv, test_opts);
-	state = getopt_state_get();
 
-	/* Thread safe usge: */
-	zassert_equal(0, strcmp(argv[GETOPT_IDX_OPTARG], state->optarg),
-		      "unexpected optarg result");
-	/* Non thread safe usage: */
 	zassert_equal(0, strcmp(argv[GETOPT_IDX_OPTARG], optarg), "unexpected optarg result");
 }
 
@@ -101,7 +91,6 @@ ZTEST(posix_c_lib_ext, test_getopt_long)
 	/* Below test is based on example
 	 * https://www.gnu.org/software/libc/manual/html_node/Getopt-Long-Option-Example.html
 	 */
-	struct getopt_state *state;
 	int verbose_flag = 0;
 	/* getopt_long stores the option index here. */
 	int option_index = 0;
@@ -156,33 +145,31 @@ ZTEST(posix_c_lib_ext, test_getopt_long)
 	int argc4 = ARRAY_SIZE(argv4);
 
 	/* Test scenario 1 */
-	/* Get state of the current thread */
-	getopt_init();
+
+	optind = 0;		/* Reset state */
 	argv = (char **)argv1;
 	c = getopt_long(argc1, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 1, "verbose flag expected");
 	c = getopt_long(argc1, argv, accepted_opt, long_options, &option_index);
-	state = getopt_state_get();
 	zassert_equal('c', c, "unexpected option");
-	zassert_equal(0, strcmp(state->optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
+	zassert_equal(0, strcmp(optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
 	c = getopt_long(argc1, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(-1, c, "getopt_long shall return -1");
 
 	/* Test scenario 2 */
+	optind = 0;		/* Reset state */
 	argv = (char **)argv2;
-	getopt_init();
 	c = getopt_long(argc2, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 0, "verbose flag expected");
 	c = getopt_long(argc2, argv, accepted_opt, long_options, &option_index);
 	zassert_equal('d', c, "unexpected option");
-	state = getopt_state_get();
-	zassert_equal(0, strcmp(state->optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
+	zassert_equal(0, strcmp(optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
 	c = getopt_long(argc2, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(-1, c, "getopt_long shall return -1");
 
 	/* Test scenario 3 */
+	optind = 0;		/* Reset state */
 	argv = (char **)argv3;
-	getopt_init();
 	c = getopt_long(argc3, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 0, "verbose flag expected");
 	c = getopt_long(argc3, argv, accepted_opt, long_options, &option_index);
@@ -191,8 +178,8 @@ ZTEST(posix_c_lib_ext, test_getopt_long)
 	zassert_equal(-1, c, "getopt_long shall return -1");
 
 	/* Test scenario 4 */
+	optind = 0;		/* Reset state */
 	argv = (char **)argv4;
-	getopt_init();
 	c = getopt_long(argc4, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 0, "verbose flag expected");
 	c = getopt_long(argc4, argv, accepted_opt, long_options, &option_index);
@@ -208,7 +195,6 @@ ZTEST(posix_c_lib_ext, test_getopt_long_only)
 	/* Below test is based on example
 	 * https://www.gnu.org/software/libc/manual/html_node/Getopt-Long-Option-Example.html
 	 */
-	struct getopt_state *state;
 	int verbose_flag = 0;
 	/* getopt_long stores the option index here. */
 	int option_index = 0;
@@ -263,33 +249,30 @@ ZTEST(posix_c_lib_ext, test_getopt_long_only)
 	int argc4 = ARRAY_SIZE(argv4);
 
 	/* Test scenario 1 */
+	optind = 0;		/* Reset state */
 	argv = (char **)argv1;
-	getopt_init();
 	c = getopt_long_only(argc1, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 1, "verbose flag expected");
 	c = getopt_long_only(argc1, argv, accepted_opt, long_options, &option_index);
-	state = getopt_state_get();
 	zassert_equal('c', c, "unexpected option");
-	zassert_equal(0, strcmp(state->optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
+	zassert_equal(0, strcmp(optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
 	c = getopt_long_only(argc1, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(-1, c, "getopt_long_only shall return -1");
 
 	/* Test scenario 2 */
+	optind = 0;		/* Reset state */
 	argv = (char **)argv2;
-	getopt_init();
-	state = getopt_state_get();
 	c = getopt_long_only(argc2, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 0, "verbose flag expected");
 	c = getopt_long_only(argc2, argv, accepted_opt, long_options, &option_index);
-	state = getopt_state_get();
 	zassert_equal('d', c, "unexpected option");
-	zassert_equal(0, strcmp(state->optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
+	zassert_equal(0, strcmp(optarg, argv[GETOPT_LONG_IDX_OPTARG]), "unexpected optarg");
 	c = getopt_long_only(argc2, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(-1, c, "getopt_long_only shall return -1");
 
 	/* Test scenario 3 */
+	optind = 0;		/* Reset state */
 	argv = (char **)argv3;
-	getopt_init();
 	c = getopt_long_only(argc3, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 0, "verbose flag expected");
 	c = getopt_long_only(argc3, argv, accepted_opt, long_options, &option_index);
@@ -298,8 +281,8 @@ ZTEST(posix_c_lib_ext, test_getopt_long_only)
 	zassert_equal(-1, c, "getopt_long_only shall return -1");
 
 	/* Test scenario 4 */
+	optind = 0;		/* Reset state */
 	argv = (char **)argv4;
-	getopt_init();
 	c = getopt_long_only(argc4, argv, accepted_opt, long_options, &option_index);
 	zassert_equal(verbose_flag, 0, "verbose flag expected");
 	c = getopt_long_only(argc4, argv, accepted_opt, long_options, &option_index);


### PR DESCRIPTION
Add getopt APIs inspired by the re-entrant newlib/picolibc versions. Instead of stashing getopt state in global or thread-local variables, have callers allocate space for them instead.

The existing APIs remain available and unchanged, but all in-tree users are migrated to the new APIs and the documentation
refers to the new ones.

As a part of this work, the POSIX getopt implementation has been aligned with the POSIX standard as closely as possible; one minor extension has been adapted from glibc/newlib/picolibc to make re-use of the API possible in testing.