### PR TITLE
Bluetooth: att: Fix NULL pointer access issue

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3678,7 +3678,8 @@ static void eatt_auto_connect(struct bt_conn *conn, bt_security_t level,
 {
 	int eatt_err;
 
-	if (err || level < BT_SECURITY_L2 || !bt_att_fixed_chan_only(conn)) {
+	if (!bt_conn_is_le(conn) || (err != 0) || level < BT_SECURITY_L2 ||
+	    !bt_att_fixed_chan_only(conn)) {
 		return;
 	}
 


### PR DESCRIPTION
If the connect type is not `LE`, the return value of function `bt_conn_get_dst()` is a NULL pointer. In function `bt_addr_le_str()`,
 the NULL pointer will be accessed without any checking. It will cause the issue `Segmentation fault` in the platform `native_sim`.

Fix the issue by checking the conn type at the beginning of the function `eatt_auto_connect()`.