### PR TITLE
boards: soc: add configuration related files for KV260 cortex a53

### DIFF
--- a/boards/amd/kv260_a53/Kconfig.kv260_a53
+++ b/boards/amd/kv260_a53/Kconfig.kv260_a53
@@ -1,3 +1,4 @@
+# Copyright (c) 2022 Linaro.
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_KV260_A53

--- a/boards/amd/kv260_a53/Kconfig.kv260_a53
+++ b/boards/amd/kv260_a53/Kconfig.kv260_a53
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_KV260_A53
+        bool "AMD KV260 Cortex-A53" 
+	select SOC_XILINX_ZYNQMP_APU
+	default y

--- a/boards/amd/kv260_a53/board.cmake
+++ b/boards/amd/kv260_a53/board.cmake
@@ -1,0 +1,3 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/boards/amd/kv260_a53/board.cmake
+++ b/boards/amd/kv260_a53/board.cmake
@@ -1,3 +1,4 @@
+# Copyright (c) 2022 Linaro.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/boards/amd/kv260_a53/board.yml
+++ b/boards/amd/kv260_a53/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: kv260_a53
+  full_name: KV260 Development Board APU Cortex-A53
+  vendor: amd
+  socs:
+  - name: zynqmp_apu

--- a/boards/amd/kv260_a53/kv260_a53.dts
+++ b/boards/amd/kv260_a53/kv260_a53.dts
@@ -1,8 +1,9 @@
 /*
+ * Copyright (c) 2022 Linaro.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
-*/
+ */
 
 /dts-v1/;
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>

--- a/boards/amd/kv260_a53/kv260_a53.dts
+++ b/boards/amd/kv260_a53/kv260_a53.dts
@@ -1,0 +1,104 @@
+/*
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+*/
+
+/dts-v1/;
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+	model = "kv260 Cortex-A53";
+	compatible = "xlnx,zynqmp-a53";
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	sram0: memory@40000000 {
+		compatible = "mmio-sram";
+		reg = <0x0 0x40000000 0x0 0x08000000>;
+	};
+
+        cpus {
+            #address-cells = <2>;
+            #size-cells = <0>;
+	    cpu@0 {
+		device_type = "cpu";
+		compatible = "arm,cortex-a53";
+		reg = <0x0 0x0>;
+		status = "okay";
+	    };
+
+	    cpu@1 {
+		device_type = "cpu";
+		compatible = "arm,cortex-a53";
+		reg = <0x0 0x1>;
+	    };
+
+	    cpu@2 {
+		device_type = "cpu";
+		compatible = "arm,cortex-a53";
+		reg = <0x0 0x2>;
+	    };
+
+	    cpu@3 {
+		device_type = "cpu";
+		compatible = "arm,cortex-a53";
+		reg = <0x0 0x3>;
+	    };
+        };
+
+
+	gic: interrupt-controller@f9010000 {
+		compatible = "arm,gic-v2", "arm,gic";
+        	interrupt-controller;
+		#interrupt-cells = <4>;
+		reg = <0x0 0xf9010000 0x0 0x10000>,
+	      	      <0x0 0xf9020000 0x0 0x20000>,
+	      	      <0x0 0xf9040000 0x0 0x20000>,
+		      <0x0 0xf9060000 0x0 0x20000>;
+		status = "okay";
+	};
+		
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 14 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	};
+
+	uart1: serial@ff010000 {
+		compatible = "xlnx,xuartps";
+		status = "okay";
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 22 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		reg = <0x0 0xff010000 0x0 0x1000>;
+	};
+	
+	psci {
+		compatible = "arm,psci-0.2";
+		method = "smc";
+	};
+	
+	aliases {
+	        serial0 = &uart1;
+        };
+        
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
+		stdout-path = "serial0:115200n8";
+	};
+};
+
+
+
+&uart1 {
+	status = "okay";
+	current-speed = <115200>;
+	clock-frequency = <99999901>;
+};
+
+

--- a/boards/amd/kv260_a53/kv260_a53.yaml
+++ b/boards/amd/kv260_a53/kv260_a53.yaml
@@ -1,0 +1,12 @@
+identifier: kv260_a53
+name: Xilinx KV260 Development board for Cortex-A53
+type: mcu
+arch: arm64
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 131072
+flash: 65536
+supported:
+  - uart
+vendor: xlnx

--- a/boards/amd/kv260_a53/kv260_a53_defconfig
+++ b/boards/amd/kv260_a53/kv260_a53_defconfig
@@ -1,0 +1,13 @@
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+
+
+CONFIG_SMP=n
+
+
+

--- a/soc/xlnx/zynqmp_apu/CMakeLists.txt
+++ b/soc/xlnx/zynqmp_apu/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_sources_ifdef(CONFIG_ARM_MMU mmu_regions.c)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm64/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/xlnx/zynqmp_apu/Kconfig
+++ b/soc/xlnx/zynqmp_apu/Kconfig
@@ -1,0 +1,7 @@
+config SOC_XILINX_ZYNQMP_APU
+    bool
+    select ARM64
+    select CPU_CORTEX_A53
+    select GIC
+    select GIC_V2
+    select ARM_ARCH_TIMER if SYS_CLOCK_EXISTS

--- a/soc/xlnx/zynqmp_apu/Kconfig
+++ b/soc/xlnx/zynqmp_apu/Kconfig
@@ -1,3 +1,7 @@
+# Copyright (c) 2019 Lexmark International, Inc.
+# Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+# SPDX-License-Identifier: Apache-2.0
+
 config SOC_XILINX_ZYNQMP_APU
     bool
     select ARM64

--- a/soc/xlnx/zynqmp_apu/Kconfig.defconfig
+++ b/soc/xlnx/zynqmp_apu/Kconfig.defconfig
@@ -1,3 +1,5 @@
+# Copyright (c) 2019 Lexmark International, Inc.
+# Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_XILINX_ZYNQMP

--- a/soc/xlnx/zynqmp_apu/Kconfig.defconfig
+++ b/soc/xlnx/zynqmp_apu/Kconfig.defconfig
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_XILINX_ZYNQMP
+
+if SOC_XILINX_ZYNQMP_APU
+
+config NUM_IRQS
+	# must be >= the highest interrupt number used
+	# - include the UART interrupts
+	default 220
+
+config SYS_CLOCK_EXISTS
+       bool
+       default y
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	int
+	default 100000000
+
+endif # SOC_XILINX_ZYNQMP_APU
+
+endif # SOC_XILINX_ZYNQMP

--- a/soc/xlnx/zynqmp_apu/Kconfig.soc
+++ b/soc/xlnx/zynqmp_apu/Kconfig.soc
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_XILINX_ZYNQMP
+	bool
+
+config SOC_XILINX_ZYNQMP_APU
+	bool
+	select SOC_XILINX_ZYNQMP
+	help
+	  Xilinx ZynqMP APU
+
+config SOC_FAMILY
+	default "xilinx_zynqmp" if SOC_XILINX_ZYNQMP
+
+config SOC
+	default "zynqmp_apu" if SOC_XILINX_ZYNQMP_APU

--- a/soc/xlnx/zynqmp_apu/Kconfig.soc
+++ b/soc/xlnx/zynqmp_apu/Kconfig.soc
@@ -1,3 +1,5 @@
+# Copyright (c) 2019 Lexmark International, Inc.
+# Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_XILINX_ZYNQMP

--- a/soc/xlnx/zynqmp_apu/mmu_regions.c
+++ b/soc/xlnx/zynqmp_apu/mmu_regions.c
@@ -1,0 +1,25 @@
+/*
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/arch/arm64/arm_mmu.h>
+
+static const struct arm_mmu_region mmu_regions[] = {
+
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+};
+
+const struct arm_mmu_config mmu_config = {
+	.num_regions = ARRAY_SIZE(mmu_regions),
+	.mmu_regions = mmu_regions,
+};

--- a/soc/xlnx/zynqmp_apu/mmu_regions.c
+++ b/soc/xlnx/zynqmp_apu/mmu_regions.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Huawei France Technologies SASU
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/soc/xlnx/zynqmp_apu/soc.yml
+++ b/soc/xlnx/zynqmp_apu/soc.yml
@@ -1,0 +1,4 @@
+family:
+- name: xilinx_zynqmp
+  socs:
+  - name: zynqmp_apu


### PR DESCRIPTION
* what the change does,
  add the configuration related files 
  when using the KV260 ARM cortex-a53.
  The following folders and files have been added to 
  the existing directories boards/amd and soc/xlnx.
  boards/amd/kv260_a53
  soc/xlnx/zynqmp_apu

* To confirm that it worked,
  I placed the zephyr.elf file generated after the build onto the SD card, 
  ran the following u-boot command, and
  confirmed that the shell terminal was running on the kv260.

<pre>
  ZynqMP>
  ZynqMP> dcache off
  ZynqMP> icache off
  ZynqMP> setenv loadaddr 0x8000000
  ZynqMP> fatload mmc 1:1 ${loadaddr} zephyr.elf
  1212792 bytes read in 330 ms (3.5 MiB/s)
  ZynqMP> bootelf ${loadaddr}
  ## Star*** Booting Zephyr OS build v4.2.0-5452-g169cf86969d7 ***
  My Hello World! kv260_a53/zynqmp_apu
  
  uart:~$
  uart:~$
  uart:~$
  uart:~$
  </pre>

Signed-off-by: Manabu Tajima <mana.taj@gmail.com>