### PR TITLE
dma: rpi_pico: fix transfer count calculation

### DIFF
--- a/drivers/dma/dma_rpi_pico.c
+++ b/drivers/dma/dma_rpi_pico.c
@@ -43,6 +43,7 @@ struct dma_rpi_pico_channel {
 	void *source_address;
 	void *dest_address;
 	size_t block_size;
+	uint32_t source_data_size;
 };
 
 struct dma_rpi_pico_data {
@@ -197,6 +198,7 @@ static int dma_rpi_pico_config(const struct device *dev, uint32_t channel,
 
 	data->channels[channel].callback = dma_cfg->dma_callback;
 	data->channels[channel].user_data = dma_cfg->user_data;
+	data->channels[channel].source_data_size = dma_cfg->source_data_size;
 	data->channels[channel].direction = dma_cfg->channel_direction;
 
 	return 0;
@@ -221,7 +223,8 @@ static int dma_rpi_pico_reload(const struct device *dev, uint32_t ch, uint32_t s
 	data->channels[ch].dest_address = (void *)dst;
 	data->channels[ch].block_size = size;
 	dma_channel_configure(ch, &data->channels[ch].config, data->channels[ch].dest_address,
-			      data->channels[ch].source_address, data->channels[ch].block_size,
+			      data->channels[ch].source_address,
+			      data->channels[ch].block_size / data->channels[ch].source_data_size,
 			      true);
 
 	return 0;
@@ -241,7 +244,8 @@ static int dma_rpi_pico_start(const struct device *dev, uint32_t ch)
 	dma_irqn_set_channel_enabled(dma_rpi_pico_channel_irq(dev, ch), ch, true);
 
 	dma_channel_configure(ch, &data->channels[ch].config, data->channels[ch].dest_address,
-			      data->channels[ch].source_address, data->channels[ch].block_size,
+			      data->channels[ch].source_address,
+			      data->channels[ch].block_size / data->channels[ch].source_data_size,
 			      true);
 
 	return 0;


### PR DESCRIPTION
The Pico SDK expects a transfer count (items), not a byte count. The driver incorrectly passed the byte size, causing buffer overflows on 16-bit and 32-bit transfers.Fix this by storing the transfer width in the channel configuration and dividing the block size by that width to calculate the correct transfer count.

Fixes #99435

Signed-off-by: Ashirwad Paswan ashi06712@gmail.com