### PR TITLE
Bluetooth: AVRCP: Fix typo in callback name and opid/state

### DIFF
--- a/include/zephyr/bluetooth/classic/avrcp.h
+++ b/include/zephyr/bluetooth/classic/avrcp.h
@@ -297,9 +297,9 @@ struct bt_avrcp_subunit_info_rsp {
 };
 
 #define BT_AVRCP_PASSTHROUGH_GET_STATE(payload)                                                    \
-	((bt_avrcp_opid_t)(FIELD_GET(BIT(7), ((payload)->opid_state))))
+	((bt_avrcp_button_state_t)(FIELD_GET(BIT(7), ((payload)->opid_state))))
 #define BT_AVRCP_PASSTHROUGH_GET_OPID(payload)                                                     \
-	((bt_avrcp_button_state_t)(FIELD_GET(GENMASK(6, 0), ((payload)->opid_state))))
+	((bt_avrcp_opid_t)(FIELD_GET(GENMASK(6, 0), ((payload)->opid_state))))
 #define BT_AVRCP_PASSTHROUGH_SET_STATE_OPID(payload, state, opid)                                  \
 	(payload)->opid_state = FIELD_PREP(BIT(7), state) | FIELD_PREP(GENMASK(6, 0), opid)
 

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -1969,7 +1969,7 @@ static void avrcp_pass_through_rsp_handler(struct bt_avrcp *avrcp, uint8_t tid, 
 
 	avrcp_hdr = net_buf_pull_mem(buf, sizeof(*avrcp_hdr));
 
-	if ((avrcp_ct_cb != NULL) && (avrcp_ct_cb->subunit_info_rsp != NULL)) {
+	if ((avrcp_ct_cb != NULL) && (avrcp_ct_cb->passthrough_rsp != NULL)) {
 		if (buf->len < sizeof(*rsp)) {
 			LOG_ERR("Invalid passthrough length: %d", buf->len);
 			return;

--- a/subsys/bluetooth/host/classic/shell/avrcp.c
+++ b/subsys/bluetooth/host/classic/shell/avrcp.c
@@ -1327,8 +1327,8 @@ static void avrcp_passthrough_req(struct bt_avrcp_tg *tg, uint8_t tid, struct ne
 
 	tg_tid = tid;
 	cmd = net_buf_pull_mem(buf, sizeof(*cmd));
-	opid = BT_AVRCP_PASSTHROUGH_GET_STATE(cmd);
-	state = BT_AVRCP_PASSTHROUGH_GET_OPID(cmd);
+	state = BT_AVRCP_PASSTHROUGH_GET_STATE(cmd);
+	opid = BT_AVRCP_PASSTHROUGH_GET_OPID(cmd);
 
 	if (cmd->data_len > 0U) {
 		if (buf->len < sizeof(struct bt_avrcp_passthrough_opvu_data)) {


### PR DESCRIPTION
Correct typo and fix opid/state assignment.