### PR TITLE
Rw61x fix memory driver issue

### DIFF
--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018-2023, NXP
+# Copyright 2018-2023, 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP FlexSPI controller
@@ -10,6 +10,28 @@ include: [spi-controller.yaml, pinctrl-device.yaml]
 properties:
   reg:
     required: true
+    description: |
+      FlexSPI controller register space and AHB memory windows.
+      reg[0]: FlexSPI controller registers
+      reg[1]: AHB flash memory windows for XIP
+
+  port-count:
+    type: int
+    default: 4
+    description: Number of FlexSPI ports supported by this controller
+
+  ahb-port-bases:
+    type: array
+    description: |
+      AHB base addresses for each FlexSPI port (0-3).
+      Specify the AHB window base address for each port directly.
+      Use 0 for unused ports.
+      Example: <0x18000000 0 0x38000000 0> means:
+        - Port 0: 0x18000000
+        - Port 1: unused (0)
+        - Port 2: 0x38000000
+        - Port 3: unused (0)
+      If omitted, falls back to legacy single window behavior.
 
   interrupts:
     required: true

--- a/samples/drivers/memc/boards/frdm_rw612.overlay
+++ b/samples/drivers/memc/boards/frdm_rw612.overlay
@@ -48,4 +48,6 @@
 &flexspi {
 	pinctrl-0 = <&pinmux_flexspi_safe>;
 	pinctrl-names = "default";
+	ahb-port-bases = <0x18000000 0 0x38000000 0>;
+	port-count = <4>;
 };

--- a/samples/drivers/memc/boards/rd_rw612_bga.overlay
+++ b/samples/drivers/memc/boards/rd_rw612_bga.overlay
@@ -39,4 +39,7 @@
  */
 &flexspi {
 	pinctrl-0 = <&pinmux_flexspi_safe>;
+
+	ahb-port-bases = <0x18000000 0 0x38000000 0>;
+	port-count = <4>;
 };

--- a/soc/nxp/rw/Kconfig
+++ b/soc/nxp/rw/Kconfig
@@ -53,4 +53,12 @@ endif # NXP_RW6XX_BOOT_HEADER
 rsource "../common/Kconfig.flexspi_xip"
 rsource "../common/Kconfig.nbu"
 
+config SOC_FLEXSPI_DISABLE_AHB_RXBUF7_PREFETCH
+    bool "Disable FlexSPI AHB RX buffer 7 prefetch (RW61x workaround)"
+    default y
+    help
+      Workaround for an RW61x FlexSPI / cache limitation: when enabled,
+      the memc FlexSPI driver clears the prefetch bit for AHB RX buffer 7
+      regardless of rx-buffer-config. Other SoCs are not affected.
+
 endif # SOC_SERIES_RW6XX


### PR DESCRIPTION
Fix RW612 flexspi multiple port support issues:
1. When using the psram through the MEMC sample application, all the psram AHB access are done through the cache0 addresses (starting from  0x18000000 + FlashSize), this has to be changed to access through cache1 addresses (starting from 0x128000000 + FlashSize).
2. There is a known issue with the portB when the prefetch for the AHB Rx buffer 7 is enabled. This causes an data incoherence in the cache and is causing a potential issue when reading data from the psram. This was found when working with a customer and the SoC team suggested this workaround. This has to be incuded in the "memc_mcux_flexspi.c" driver when the psram is enabled.
