### PR TITLE
drivers: fpga_ice40: fix CS hack; fix `k_usleep` during spinlock

### DIFF
--- a/drivers/fpga/fpga_ice40_common.c
+++ b/drivers/fpga/fpga_ice40_common.c
@@ -31,10 +31,9 @@ void fpga_ice40_crc_to_str(uint32_t crc, char *s)
 enum FPGA_status fpga_ice40_get_status(const struct device *dev)
 {
 	enum FPGA_status st;
-	k_spinlock_key_t key;
 	struct fpga_ice40_data *data = dev->data;
 
-	key = k_spin_lock(&data->lock);
+	k_mutex_lock(&data->lock, K_FOREVER);
 
 	if (data->loaded && data->on) {
 		st = FPGA_STATUS_ACTIVE;
@@ -42,7 +41,7 @@ enum FPGA_status fpga_ice40_get_status(const struct device *dev)
 		st = FPGA_STATUS_INACTIVE;
 	}
 
-	k_spin_unlock(&data->lock, key);
+	k_mutex_unlock(&data->lock);
 
 	return st;
 }
@@ -50,11 +49,10 @@ enum FPGA_status fpga_ice40_get_status(const struct device *dev)
 static int fpga_ice40_on_off(const struct device *dev, bool on)
 {
 	int ret;
-	k_spinlock_key_t key;
 	struct fpga_ice40_data *data = dev->data;
 	const struct fpga_ice40_config *config = dev->config;
 
-	key = k_spin_lock(&data->lock);
+	k_mutex_lock(&data->lock, K_FOREVER);
 
 	ret = gpio_pin_configure_dt(&config->creset, on ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW);
 	if (ret < 0) {
@@ -65,7 +63,7 @@ static int fpga_ice40_on_off(const struct device *dev, bool on)
 	ret = 0;
 
 unlock:
-	k_spin_unlock(&data->lock, key);
+	k_mutex_unlock(&data->lock);
 
 	return ret;
 }
@@ -96,6 +94,11 @@ int fpga_ice40_init(const struct device *dev)
 {
 	int ret;
 	const struct fpga_ice40_config *config = dev->config;
+	struct fpga_ice40_data *data = dev->data;
+
+	k_mutex_init(&data->lock);
+	k_work_init(&data->work_item.work, config->load_handler);
+	k_sem_init(&data->work_item.finished, 0, 1);
 
 	if (!device_is_ready(config->creset.port)) {
 		LOG_ERR("%s: GPIO for creset is not ready", dev->name);
@@ -120,4 +123,25 @@ int fpga_ice40_init(const struct device *dev)
 	}
 
 	return 0;
+}
+
+int fpga_ice40_load(const struct device *dev, uint32_t *image_ptr, uint32_t img_size)
+{
+	struct fpga_ice40_data *data = dev->data;
+
+	struct fpga_ice40_work_item *work_item = &data->work_item;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	work_item->dev = dev;
+	work_item->image_ptr = image_ptr;
+	work_item->image_size = img_size;
+
+	k_work_submit(&work_item->work);
+	k_sem_take(&work_item->finished, K_FOREVER);
+	int result = work_item->result;
+
+	k_mutex_unlock(&data->lock);
+
+	return result;
 }


### PR DESCRIPTION
Fixes #99948.

Two asserts were triggered in this module:
- Holding a spinlock while `k_usleep` triggers an assert in `k_swap`
- All gpio_set must be on valid pin configs, which the CS hack in this module breaks.