### PR TITLE
drivers: udc_dwc2: Avoid endpoint disable timeouts on bus reset

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1746,20 +1746,11 @@ static int udc_dwc2_ep_deactivate(const struct device *dev,
 		dxepctl_reg = dwc2_get_dxepctl_reg(dev, cfg->addr);
 	}
 
+	udc_dwc2_ep_disable(dev, cfg, false, true);
+
 	dxepctl = sys_read32(dxepctl_reg);
-
-	if (dxepctl & USB_DWC2_DEPCTL_USBACTEP) {
-		LOG_DBG("Disable ep 0x%02x DxEPCTL%u %x",
-			cfg->addr, ep_idx, dxepctl);
-
-		udc_dwc2_ep_disable(dev, cfg, false, true);
-
-		dxepctl = sys_read32(dxepctl_reg);
-		dxepctl &= ~USB_DWC2_DEPCTL_USBACTEP;
-	} else {
-		LOG_WRN("ep 0x%02x is not active DxEPCTL%u %x",
-			cfg->addr, ep_idx, dxepctl);
-	}
+	LOG_DBG("Disable ep 0x%02x DxEPCTL%u %x", cfg->addr, ep_idx, dxepctl);
+	dxepctl &= ~USB_DWC2_DEPCTL_USBACTEP;
 
 	if (USB_EP_DIR_IS_IN(cfg->addr) && udc_mps_ep_size(cfg) != 0U &&
 	    ep_idx != 0U) {


### PR DESCRIPTION
DWC2 core automatically clears USBActEP (for all endpoints other than endpoint 0) on bus reset. While core is deactivating the endpoint, it does not disarm it.

On bus reset USB stack first calls ep_disable API and then ep_dequeue. This was leading to endpoint is not active warning followed by endpoint disable timeout. Disable timeout was effectively caused by waiting for EPDisbld interrupt on endpoint with disabled interrupts.

Solve the issue by unconditionally disarming endpoint in ep_disable API handler. Remove the false warning because USBActEP cannot really be used for sanity checking as it is not only the driver that clears it.