### PR TITLE
drivers: serial: uart_mcux_iuart: Adjust fifo fill behavior for trans…

### DIFF
--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -89,7 +89,7 @@ static int mcux_iuart_fifo_fill(const struct device *dev,
 	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
-	       (UART_GetStatusFlag(config->base, kUART_TxEmptyFlag))) {
+	       !(config->base->UTS & UART_UTS_TXFULL_MASK)) {
 
 		UART_WriteByte(config->base, tx_data[num_tx++]);
 	}


### PR DESCRIPTION
Until now transmission FIFO was not used. With this chnage the FIFO will be filled up, until it is full.

Currently only Transmit Buffer FIFO Empty flag is checked:
<img width="1041" height="141" alt="image" src="https://github.com/user-attachments/assets/041386fe-cdeb-44e1-8ffb-7eed20faa37c" />
i.MX 8M Plus Applications Processor Reference Manual, Rev. 1, 06/2021

Now bytes are added to the FIFO until it is full:
<img width="1075" height="765" alt="image" src="https://github.com/user-attachments/assets/9cd69b0e-a1e1-46e2-8126-47a2bb8cf387" />
i.MX 8M Plus Applications Processor Reference Manual, Rev. 1, 06/2021