### PR TITLE
nxp: linker: update kinetis cmake linker script

### DIFF
--- a/soc/nxp/kinetis/CMakeLists.txt
+++ b/soc/nxp/kinetis/CMakeLists.txt
@@ -13,6 +13,15 @@ zephyr_linker_sources_ifdef(CONFIG_KINETIS_FLASH_CONFIG
   SORT_KEY ${CONFIG_KINETIS_FLASH_CONFIG_OFFSET}
   flash_config.ld
   )
+if(CONFIG_KINETIS_FLASH_CONFIG)
+  zephyr_linker_section_configure(
+    SECTION .rom_start
+    INPUT ".kinetis_flash_config"
+          ".kinetis_flash_config.*"
+    OFFSET ${CONFIG_KINETIS_FLASH_CONFIG_OFFSET}
+    KEEP
+    )
+endif()
 
 # CMSIS SystemInit will disable watchdog unless instructed not to.
 # Add a compiler definition here to leave watchdog untouched


### PR DESCRIPTION
This is needed to place the `kinetis_flash_config` sections when using a cmake-based linker script generator.
output from linking `ZEPHYR_TOOLCHAIN_VARIANT=iar  west build -p -b frdm_k64f/mk64f12  samples/hello_world/` on IAR is:

```
  Section                 Kind         Address  Alignment    Size  Object
  -------                 ----         -------  ---------    ----  ------
".rom_start":                                               0x410
  rom_start                                0x0          4   0x410  <Block>
    rom_start_50                           0x0        512   0x400  <Block>
      .exc_vector_table._vector_table_section
                          ro code          0x0          4    0x40  vector_table.S.obj [7]
      .gnu.linkonce.irq_vector_table
                          const           0x40          4   0x158  isr_tables.c.o [2]
      rom_start_50        const          0x198              0x268  <Block tail>
    rom_start_100                        0x400          4    0x10  <Block>
      .kinetis_flash_config."/workdir/zephyr/soc/nxp/kinetis/flash_configuration.c".0
                          rw data        0x400          4    0x10  flash_configuration.c.o [21]
                                       - 0x410              0x410
```