### PR TITLE
boards: silabs: xg24_dk2601b: Enable commander runner

### DIFF
--- a/boards/silabs/dev_kits/xg24_dk2601b/board.cmake
+++ b/boards/silabs/dev_kits/xg24_dk2601b/board.cmake
@@ -3,3 +3,6 @@
 
 board_runner_args(jlink "--device=EFR32MG24BxxxF1536" "--reset-after-load")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+
+board_runner_args(silabs_commander "--device=${CONFIG_SOC}")
+include(${ZEPHYR_BASE}/boards/common/silabs_commander.board.cmake)


### PR DESCRIPTION
Enable the use of Simplicity Commander as a runner on the xg24_dk2601b dev kit.