### PR TITLE
doc: net: ensure PTP docs appears in only one table of contents

### DIFF
--- a/doc/connectivity/networking/api/protocols.rst
+++ b/doc/connectivity/networking/api/protocols.rst
@@ -16,6 +16,5 @@ Protocols
    mqtt
    mqtt_sn
    ocpp
-   ptp
    tftp
    latmon


### PR DESCRIPTION
PTP docs are already included in the TSN section, so removing from protocols.rst to avoid duplication and Sphinx warnings.

Fixes zephyrproject-rtos/zephyr#95438.