### PR TITLE
drivers: watchdog: stm32: Add the Early Wakeup support for IWDG

### DIFF
--- a/drivers/watchdog/Kconfig.stm32
+++ b/drivers/watchdog/Kconfig.stm32
@@ -14,9 +14,10 @@ menuconfig IWDG_STM32
 	help
 	  Enable IWDG driver for STM32 line of MCUs
 
+if IWDG_STM32
+
 config IWDG_STM32_INITIAL_TIMEOUT
 	int "Value for IWDG timeout in ms"
-	depends on IWDG_STM32
 	default 100
 	range 1 26214
 	help
@@ -29,6 +30,25 @@ config IWDG_STM32_INITIAL_TIMEOUT
 
 	  Limiting maximum timeout to a safe value of 26214 ms here, which was
 	  calculated for highest LSI frequency among STM32 MCUs of 40 kHz.
+
+config IWDG_STM32_EARLY_WAKEUP
+	bool "Early Wakeup Interrupt support for STM32 IWDG"
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_WATCHDOG),interrupts)
+	help
+	  Enable support for Early Wakeup Interrupt.
+
+config IWDG_STM32_EWI_TIME
+	int "Value for IWDG early wake-up in ticks"
+	depends on IWDG_STM32_EARLY_WAKEUP
+	default 100
+	range 2 4095
+	help
+	  Set the early wake-up interrupt value for IWDG in ticks.
+	  It represents the time before reset when the early wake-up occurs.
+	  This value is ignored if the reload value provided at runtime
+	  is smaller. In such cases, the interrupt triggers one tick after
+	  the watchdog is reloaded.
+endif
 
 config WWDG_STM32
 	bool "System Window Watchdog (WWDG) Driver for STM32 family of MCUs"

--- a/drivers/watchdog/wdt_iwdg_stm32.h
+++ b/drivers/watchdog/wdt_iwdg_stm32.h
@@ -28,6 +28,8 @@ struct iwdg_stm32_config {
 struct iwdg_stm32_data {
 	uint32_t prescaler;
 	uint32_t reload;
+	/* IWDG user defined callback on EWI */
+	wdt_callback_t callback;
 };
 
 #endif	/* ZEPHYR_DRIVERS_WATCHDOG_IWDG_STM32_H_ */

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -289,6 +289,7 @@
 		iwdg: watchdog@40003000 {
 			compatible = "st,stm32-watchdog";
 			reg = <0x40003000 0x400>;
+			interrupts = <35 0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/mp2/stm32mp2_m33.dtsi
+++ b/dts/arm/st/mp2/stm32mp2_m33.dtsi
@@ -422,6 +422,7 @@
 			compatible = "st,stm32-watchdog";
 			reg = <0x44040000 DT_SIZE_K(1)>;
 			clocks = <&rcc STM32_CLOCK(IWDG4, STM32_CLK)>;
+			interrupts = <3 0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -270,6 +270,7 @@
 		iwdg: watchdog@40003000 {
 			compatible = "st,stm32-watchdog";
 			reg = <0x40003000 0x400>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -391,6 +391,7 @@
 		iwdg: watchdog@40003000 {
 			compatible = "st,stm32-watchdog";
 			reg = <0x40003000 0x400>;
+			interrupts = <27 0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -279,6 +279,7 @@
 		iwdg: watchdog@40003000 {
 			compatible = "st,stm32-watchdog";
 			reg = <0x40003000 0x400>;
+			interrupts = <27 0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -295,6 +295,7 @@
 		iwdg: watchdog@40003000 {
 			compatible = "st,stm32-watchdog";
 			reg = <0x40003000 0x400>;
+			interrupts = <27 0>;
 			status = "disabled";
 		};
 

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -101,6 +101,21 @@ tests:
       - stm32h573i_dk
     integration_platforms:
       - nucleo_f103rb
+  sample.drivers.watchdog.stm32_iwdg_ewi:
+    extra_args: DTC_OVERLAY_FILE=boards/stm32_iwdg.overlay
+    filter: dt_compat_enabled("st,stm32-watchdog")
+    extra_configs:
+      - CONFIG_IWDG_STM32_EARLY_WAKEUP=y
+    platform_allow:
+      - nucleo_h563zi
+      - nucleo_h7s3l8
+      - nucleo_u083rc
+      - nucleo_u385rg_q
+      - nucleo_u575zi_q
+      - b_u585i_iot02a
+      - nucleo_wba55cg
+    integration_platforms:
+      - nucleo_wba55cg
   sample.drivers.watchdog.gd32_fwdgt:
     filter: dt_compat_enabled("gd,gd32-fwdgt")
     extra_args: DTC_OVERLAY_FILE=boards/gd32_fwdgt.overlay


### PR DESCRIPTION
This PR adds the early wakeup fonctionnality for the IWDG.