### PR TITLE
boards: alientek: dnesp32s3b: Enable additional peripherals

### DIFF
--- a/boards/alientek/dnesp32s3b/dnesp32s3b-pinctrl.dtsi
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b-pinctrl.dtsi
@@ -20,6 +20,30 @@
 		};
 	};
 
+	uart1_default: uart1_default {
+		group1 {
+			pinmux = <UART1_TX_GPIO18>;
+			output-high;
+		};
+
+		group2 {
+			pinmux = <UART1_RX_GPIO8>;
+			bias-pull-up;
+		};
+	};
+
+	uart2_default: uart2_default {
+		group1 {
+			pinmux = <UART2_TX_GPIO5>;
+			output-high;
+		};
+
+		group2 {
+			pinmux = <UART2_RX_GPIO6>;
+			bias-pull-up;
+		};
+	};
+
 	i2c0_default: i2c0_default {
 		group1 {
 			pinmux = <I2C0_SCL_GPIO45>,

--- a/boards/alientek/dnesp32s3b/dnesp32s3b-pinctrl.dtsi
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b-pinctrl.dtsi
@@ -63,4 +63,14 @@
 			bias-pull-up;
 		};
 	};
+
+	sdhc0_default: sdhc0_default {
+		group1 {
+			pinmux = <SDHC0_CLKOUT_GPIO7>,
+				 <SDHC0_CMD_GPIO16>,
+				 <SDHC0_DATA0_GPIO15>;
+			bias-pull-up;
+			output-high;
+		};
+	};
 };

--- a/boards/alientek/dnesp32s3b/dnesp32s3b-pinctrl.dtsi
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b-pinctrl.dtsi
@@ -28,6 +28,15 @@
 		};
 	};
 
+	i2s0_default: i2s0_default {
+		group1 {
+			pinmux = <I2S0_O_BCK_GPIO21>,
+				 <I2S0_O_SD_GPIO14>,
+				 <I2S0_O_WS_GPIO13>,
+				 <I2S0_I_SD_GPIO47>;
+		};
+	};
+
 	lcd_cam_default: lcd_cam_default {
 		group1 {
 			pinmux = <LCD_CAM_DATA_OUT0_GPIO40>, /* LCD_D0 */

--- a/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.dts
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.dts
@@ -90,6 +90,10 @@
 	status = "disabled";
 };
 
+zephyr_udc0: &usb_otg {
+	status = "okay";
+};
+
 &uart0 {
 	status = "okay";
 	pinctrl-0 = <&uart0_default>;

--- a/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.dts
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.dts
@@ -20,6 +20,7 @@
 		sw1 = &k1;
 		sw2 = &k2;
 		watchdog0 = &wdt0;
+		eeprom-0 = &eeprom;
 	};
 
 	chosen {
@@ -110,6 +111,15 @@
 		#gpio-cells = <2>;
 		ngpios = <16>;
 		int-gpios = <&gpio0 3 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+
+	eeprom: 24c02@50 {
+		compatible = "atmel,at24c02b", "atmel,at24";
+		reg = <0x50>;
+		size = <DT_SIZE_K(2)>;
+		pagesize = <8>;
+		address-width = <8>;
+		timeout = <5>;
 	};
 };
 

--- a/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.dts
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.dts
@@ -23,6 +23,7 @@
 		eeprom-0 = &eeprom;
 		i2s-tx = &i2s0;
 		i2s-rx = &i2s0;
+		sdhc0 = &sdhc0;
 	};
 
 	chosen {
@@ -147,6 +148,23 @@
 
 &dma {
 	status = "okay";
+};
+
+&sdhc {
+	sdhc0: sdhc@0 {
+		status = "okay";
+
+		pinctrl-0 = <&sdhc0_default>;
+		pinctrl-names = "default";
+		max-bus-freq = <DT_FREQ_M(40)>;
+		bus-width = <1>;
+
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			disk-name = "SD";
+			status = "okay";
+		};
+	};
 };
 
 &wifi {

--- a/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.dts
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.dts
@@ -21,6 +21,8 @@
 		sw2 = &k2;
 		watchdog0 = &wdt0;
 		eeprom-0 = &eeprom;
+		i2s-tx = &i2s0;
+		i2s-rx = &i2s0;
 	};
 
 	chosen {
@@ -67,6 +69,12 @@
 			label = "KEY2";
 			zephyr,code = <INPUT_KEY_2>;
 		};
+	};
+
+	spk_ctrl_reg: spk-ctrl {
+		compatible = "regulator-fixed";
+		regulator-name = "SPK_CTRL";
+		enable-gpios = <&io_expander 5 GPIO_ACTIVE_HIGH>;
 	};
 
 	lcd_bl: LCD_BL {
@@ -123,11 +131,21 @@
 	};
 };
 
+&i2s0 {
+	status = "okay";
+	pinctrl-0 = <&i2s0_default>;
+	pinctrl-names = "default";
+};
+
 &trng0 {
 	status = "okay";
 };
 
 &wdt0 {
+	status = "okay";
+};
+
+&dma {
 	status = "okay";
 };
 

--- a/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.dts
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.dts
@@ -102,6 +102,16 @@ zephyr_udc0: &usb_otg {
 	current-speed = <115200>;
 };
 
+&uart1 {
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-names = "default";
+};
+
+&uart2 {
+	pinctrl-0 = <&uart2_default>;
+	pinctrl-names = "default";
+};
+
 &gpio0 {
 	status = "okay";
 };

--- a/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.yaml
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
 supported:
   - display
+  - eeprom
   - gpio
   - uart
   - i2c

--- a/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.yaml
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.yaml
@@ -11,5 +11,6 @@ supported:
   - gpio
   - uart
   - i2c
+  - sdhc
   - watchdog
 vendor: alientek

--- a/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.yaml
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b_procpu.yaml
@@ -5,6 +5,7 @@ arch: xtensa
 toolchain:
   - zephyr
 supported:
+  - audio
   - display
   - eeprom
   - gpio

--- a/samples/drivers/i2s/echo/boards/dnesp32s3b_procpu.conf
+++ b/samples/drivers/i2s/echo/boards/dnesp32s3b_procpu.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Chen Xingyu <hi@xingrz.me>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_REGULATOR=y

--- a/samples/drivers/i2s/echo/boards/dnesp32s3b_procpu.overlay
+++ b/samples/drivers/i2s/echo/boards/dnesp32s3b_procpu.overlay
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2025 Chen Xingyu <hi@xingrz.me>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+i2s_rxtx: &i2s0 {};


### PR DESCRIPTION
This PR builds on #99114 and enables additional peripherals on the DNESP32S3B board. DT configurations are added for the following on-board peripherals with existing in-tree support:

* AT24x EEPROM
* Speaker and DMIC
* microSD card slot
* USB device controller
* 2 PH-2.0 UART connectors (pinctrl only, remain disabled)

Support for the I8080-driven LCD is submitted separately in #99863.

Remaining peripherals:

* QMI8658A 6-axis IMU - not yet supported; may be implemented in the future
* AP3216C ALS&PS - not planned; manufacturer is gone and documentation is no longer accessible