### PR TITLE
drivers/timer/cortex_m_systick: Avoid division by zero

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -20,19 +20,19 @@
 
 #if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
 extern unsigned int z_clock_hw_cycles_per_sec;
+/* CYC_PER_TICK must be inside of systick capacities (<1Ghz) */
 #define CYC_PER_TICK (z_clock_hw_cycles_per_sec/CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 #else
 #define CYC_PER_TICK (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC/CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+#if (COUNTER_MAX / CYC_PER_TICK) == 1
+#pragma message("tickless does nothing as CONFIG_SYS_CLOCK_TICKS_PER_SEC too low")
+#endif
 #endif
 
 /* add MAX_TICKS protection */
 #define _MAX_TICKS (int)((k_ticks_t)(COUNTER_MAX / CYC_PER_TICK) - 1)
 #define MAX_TICKS ((_MAX_TICKS > 0) ? _MAX_TICKS : 1)
 #define MAX_CYCLES (MAX_TICKS * CYC_PER_TICK)
-
-#if (COUNTER_MAX / CYC_PER_TICK) == 1
-#pragma message("tickless does nothing as CONFIG_SYS_CLOCK_TICKS_PER_SEC too low")
-#endif
 
 /* Minimum cycles in the future to try to program.  Note that this is
  * NOT simply "enough cycles to get the counter read and reprogrammed


### PR DESCRIPTION
Preprocessor evaluates CYC_PER_TICK as zero in condition `(COUNTER_MAX / CYC_PER_TICK) == 1` when
CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME is defined.

This commit skips the check when
CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME is defined.

Fixes: #100040