### PR TITLE
maintainers: hal_nxp: update maintainers and collaborators.

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5750,15 +5750,17 @@ West:
     - dleach02
     - mmahadevan108
     - decsny
+    - ZhaoxiangJin
   collaborators:
     - manuargue
     - PetervdPerk-NXP
     - bperseghetti
     - JiafeiPan
-    - ZhaoxiangJin
     - EmilioCBen
     - MaochenWang1
     - axelnxp
+    - zejiang0jason
+    - Holt-Sun
   files:
     - modules/hal_nxp/
   labels:


### PR DESCRIPTION
Expanding responsibilities for hal_nxp:

- Add ZhaoxiangJin to the maintainers list to allow merge rights on HAL
- Add zejiang0jason and Holt-Sun to the collaborators list for review