### PR TITLE
maintainer: hal_openisa: Add zejiang0jason as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5768,6 +5768,7 @@ West:
   status: odd fixes
   collaborators:
     - dleach02
+    - zejiang0jason
   files:
     - modules/Kconfig.vega
   labels:


### PR DESCRIPTION
Adding Zejiang0jason as collaborator to the openisa HAL. He was the developer of the original SDK.