### PR TITLE
arch: arm: cortex_a_r: place .ARM.{extab, exidx} sections in rodata

### DIFF
--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -165,6 +165,12 @@ SECTIONS
         . = ALIGN(_region_min_align);
     } GROUP_LINK_IN(ROMABLE_REGION)
 
+    SECTION_PROLOGUE(rodata_start,,)
+    {
+        . = ALIGN(_region_min_align);
+        __rodata_region_start = .;
+    } GROUP_LINK_IN(ROMABLE_REGION)
+
 #if defined (CONFIG_CPP)
     SECTION_PROLOGUE(.ARM.extab,,)
     {
@@ -188,12 +194,6 @@ SECTIONS
         *(.ARM.exidx* gnu.linkonce.armexidx.*)
 #endif
         __exidx_end = .;
-    } GROUP_LINK_IN(ROMABLE_REGION)
-
-    SECTION_PROLOGUE(rodata_start,,)
-    {
-        . = ALIGN(_region_min_align);
-        __rodata_region_start = .;
     } GROUP_LINK_IN(ROMABLE_REGION)
 
 #include <zephyr/linker/common-rom.ld>

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -138,6 +138,9 @@ SECTIONS
     __text_region_end = .;
     __text_region_size = __text_region_end - __text_region_start;
 
+    MMU_ALIGN;
+    __rodata_region_start = .;
+
 #if defined (CONFIG_CPP)
     SECTION_PROLOGUE(.ARM.extab,,)
     {
@@ -162,9 +165,6 @@ SECTIONS
 #endif
         __exidx_end = .;
     } GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-    MMU_ALIGN;
-    __rodata_region_start = .;
 
 #include <zephyr/linker/common-rom.ld>
 #include <snippets-rom-sections.ld>


### PR DESCRIPTION
The .ARM.extab and .ARM.exidx sections are now mapped under the zephyr_rodata MMU region, ensuring they remain accessible at runtime. These sections contain unwind information required for C++ exception handling, so they must reside in readable memory.

Fixes #96070