### PR TITLE
dts/dtsi: add missing zephyr prefix for consistency

### DIFF
--- a/boards/01space/esp32c3_042_oled/esp32c3_042_oled-pinctrl.dtsi
+++ b/boards/01space/esp32c3_042_oled/esp32c3_042_oled-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/actinius/icarus_som_dk/actinius_icarus_som_dk_common.dtsi
+++ b/boards/actinius/icarus_som_dk/actinius_icarus_som_dk_common.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "actinius_icarus_som_dk_common-pinctrl.dtsi"
-#include <dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/led.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {

--- a/boards/adafruit/feather_adalogger_rp2040/adafruit_feather_adalogger_rp2040-pinctrl.dtsi
+++ b/boards/adafruit/feather_adalogger_rp2040/adafruit_feather_adalogger_rp2040-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/adafruit/feather_adalogger_rp2040/adafruit_feather_adalogger_rp2040.dts
+++ b/boards/adafruit/feather_adalogger_rp2040/adafruit_feather_adalogger_rp2040.dts
@@ -9,7 +9,7 @@
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 #include "adafruit_feather_adalogger_rp2040-pinctrl.dtsi"

--- a/boards/adafruit/feather_canbus_rp2040/adafruit_feather_canbus_rp2040-pinctrl.dtsi
+++ b/boards/adafruit/feather_canbus_rp2040/adafruit_feather_canbus_rp2040-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/adafruit/feather_canbus_rp2040/adafruit_feather_canbus_rp2040.dts
+++ b/boards/adafruit/feather_canbus_rp2040/adafruit_feather_canbus_rp2040.dts
@@ -9,7 +9,7 @@
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 #include "adafruit_feather_canbus_rp2040-pinctrl.dtsi"

--- a/boards/adafruit/feather_esp32/adafruit_feather_esp32-pinctrl.dtsi
+++ b/boards/adafruit/feather_esp32/adafruit_feather_esp32-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2-pinctrl.dtsi
+++ b/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s2-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2_common.dtsi
+++ b/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2_common.dtsi
@@ -11,8 +11,8 @@
 #include "adafruit_feather_esp32s2-pinctrl.dtsi"
 #include <espressif/partitions_0x1000_default.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
-#include <dt-bindings/led/led.h>
-#include <dt-bindings/led/worldsemi_ws2812c.h>
+#include <zephyr/dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/worldsemi_ws2812c.h>
 #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {

--- a/boards/adafruit/feather_esp32s3/adafruit_feather_esp32s3-pinctrl.dtsi
+++ b/boards/adafruit/feather_esp32s3/adafruit_feather_esp32s3-pinctrl.dtsi
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/adafruit/feather_esp32s3_tft/adafruit_feather_esp32s3_tft-pinctrl.dtsi
+++ b/boards/adafruit/feather_esp32s3_tft/adafruit_feather_esp32s3_tft-pinctrl.dtsi
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/adafruit/feather_esp32s3_tft_reverse/adafruit_feather_esp32s3_tft_reverse-pinctrl.dtsi
+++ b/boards/adafruit/feather_esp32s3_tft_reverse/adafruit_feather_esp32s3_tft_reverse-pinctrl.dtsi
@@ -7,7 +7,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/adafruit/feather_rfm95_rp2040/adafruit_feather_rfm95_rp2040-pinctrl.dtsi
+++ b/boards/adafruit/feather_rfm95_rp2040/adafruit_feather_rfm95_rp2040-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/adafruit/feather_rfm95_rp2040/adafruit_feather_rfm95_rp2040.dts
+++ b/boards/adafruit/feather_rfm95_rp2040/adafruit_feather_rfm95_rp2040.dts
@@ -9,7 +9,7 @@
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 #include "adafruit_feather_rfm95_rp2040-pinctrl.dtsi"

--- a/boards/adafruit/feather_rp2040/adafruit_feather_rp2040-pinctrl.dtsi
+++ b/boards/adafruit/feather_rp2040/adafruit_feather_rp2040-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/adafruit/itsybitsy_rp2040/adafruit_itsybitsy_rp2040-pinctrl.dtsi
+++ b/boards/adafruit/itsybitsy_rp2040/adafruit_itsybitsy_rp2040-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/adafruit/itsybitsy_rp2040/adafruit_itsybitsy_rp2040.dts
+++ b/boards/adafruit/itsybitsy_rp2040/adafruit_itsybitsy_rp2040.dts
@@ -9,7 +9,7 @@
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 #include "adafruit_itsybitsy_rp2040-pinctrl.dtsi"

--- a/boards/adafruit/kb2040/adafruit_kb2040-pinctrl.dtsi
+++ b/boards/adafruit/kb2040/adafruit_kb2040-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040-pinctrl.dtsi
+++ b/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040-pinctrl.dtsi
@@ -1,4 +1,4 @@
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/adafruit/metro_rp2040/adafruit_metro_rp2040-pinctrl.dtsi
+++ b/boards/adafruit/metro_rp2040/adafruit_metro_rp2040-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/adafruit/metro_rp2040/adafruit_metro_rp2040.dts
+++ b/boards/adafruit/metro_rp2040/adafruit_metro_rp2040.dts
@@ -9,7 +9,7 @@
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 #include "adafruit_metro_rp2040-pinctrl.dtsi"

--- a/boards/adafruit/qt_py_esp32s3/adafruit_qt_py_esp32s3-pinctrl.dtsi
+++ b/boards/adafruit/qt_py_esp32s3/adafruit_qt_py_esp32s3-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040-pinctrl.dtsi
+++ b/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/adafruit/trinkey_qt2040/adafruit_trinkey_qt2040.dts
+++ b/boards/adafruit/trinkey_qt2040/adafruit_trinkey_qt2040.dts
@@ -9,7 +9,7 @@
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 

--- a/boards/adi/sdp_k1/adi_sdp_120pin_connector.dtsi
+++ b/boards/adi/sdp_k1/adi_sdp_120pin_connector.dtsi
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/adi-sdp-120.h>
+#include <zephyr/dt-bindings/gpio/adi-sdp-120.h>
 
 / {
 	sdp_k1_120_hdr: connector {

--- a/boards/aithinker/ai_m62_12f/ai_m62_12f-pinctrl.dtsi
+++ b/boards/aithinker/ai_m62_12f/ai_m62_12f-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/bl616x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl616x-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/aithinker/ai_wb2_12f/ai_wb2_12f-pinctrl.dtsi
+++ b/boards/aithinker/ai_wb2_12f/ai_wb2_12f-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/bl602x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl602x-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/aithinker/esp32_cam/esp32_cam-pinctrl.dtsi
+++ b/boards/aithinker/esp32_cam/esp32_cam-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/alientek/dnesp32s3b/dnesp32s3b-pinctrl.dtsi
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 

--- a/boards/ambiq/apollo2_evb/apollo2_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo2_evb/apollo2_evb-pinctrl.dtsi
@@ -5,7 +5,7 @@
  * Author: Sri Surya  <srisurya@linumiz.com>
  */
 
-#include <dt-bindings/pinctrl/ambiq-apollo2-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/ambiq-apollo2-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/ambiq/apollo3_evb/apollo3_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo3_evb/apollo3_evb-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h>
 #include "apollo3_evb_connector.dtsi"
 
 &pinctrl {

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h>
 #include "apollo3p_evb_connector.dtsi"
 
 &pinctrl {

--- a/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/ambiq-apollo4-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/ambiq-apollo4-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/ambiq/apollo4p_evb/apollo4p_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo4p_evb/apollo4p_evb-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/ambiq-apollo4-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/ambiq-apollo4-pinctrl.h>
 #include "apollo4p_evb_connector.dtsi"
 
 &pinctrl {

--- a/boards/arduino/nano_matter/arduino_nano_matter.dts
+++ b/boards/arduino/nano_matter/arduino_nano_matter.dts
@@ -8,7 +8,7 @@
 /dts-v1/;
 #include <silabs/xg24/mgm240sd22vna.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include "arduino_nano_matter-pinctrl.dtsi"
 #include "arduino_nano_matter_connector.dtsi"

--- a/boards/arduino/portenta_c33/arduino_portenta_c33.dts
+++ b/boards/arduino/portenta_c33/arduino_portenta_c33.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra6/r7fa6m5bh3cfc.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 

--- a/boards/bflb/bl60x/bl604e_iot_dvk/bl604e_iot_dvk-pinctrl.dtsi
+++ b/boards/bflb/bl60x/bl604e_iot_dvk/bl604e_iot_dvk-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/bl604x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl604x-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/dfrobot/beetle_rp2040/beetle_rp2040-pinctrl.dtsi
+++ b/boards/dfrobot/beetle_rp2040/beetle_rp2040-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/dfrobot/beetle_rp2040/beetle_rp2040.dts
+++ b/boards/dfrobot/beetle_rp2040/beetle_rp2040.dts
@@ -9,7 +9,7 @@
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 #include "beetle_rp2040-pinctrl.dtsi"

--- a/boards/doiting/dt_bl10_devkit/dt_bl10_devkit-pinctrl.dtsi
+++ b/boards/doiting/dt_bl10_devkit/dt_bl10_devkit-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/bl602x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl602x-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/doiting/dt_xt_zb1_devkit/dt_xt_zb1_devkit-pinctrl.dtsi
+++ b/boards/doiting/dt_xt_zb1_devkit/dt_xt_zb1_devkit-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/bl702x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl702x-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/dptechnics/walter/walter-pinctrl.dtsi
+++ b/boards/dptechnics/walter/walter-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/enclustra/mercury_xu/mercury_xu-pinctrl.dtsi
+++ b/boards/enclustra/mercury_xu/mercury_xu-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/pinctrl-zynqmp.h>
+#include <zephyr/dt-bindings/pinctrl/pinctrl-zynqmp.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/ene/kb1200_evb/kb1200_evb.dts
+++ b/boards/ene/kb1200_evb/kb1200_evb.dts
@@ -9,7 +9,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <ene/kb1200.dtsi>
 #include <ene/kb1200-pinctrl.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	model = "KB1200 board";

--- a/boards/espressif/esp32_devkitc/esp32_devkitc-pinctrl.dtsi
+++ b/boards/espressif/esp32_devkitc/esp32_devkitc-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp32_ethernet_kit/esp32_ethernet_kit-pinctrl.dtsi
+++ b/boards/espressif/esp32_ethernet_kit/esp32_ethernet_kit-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp32c3_devkitc/esp32c3_devkitc-pinctrl.dtsi
+++ b/boards/espressif/esp32c3_devkitc/esp32c3_devkitc-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp32c3_devkitm/esp32c3_devkitm-pinctrl.dtsi
+++ b/boards/espressif/esp32c3_devkitm/esp32c3_devkitm-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp32c3_rust/esp32c3_rust-pinctrl.dtsi
+++ b/boards/espressif/esp32c3_rust/esp32c3_rust-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp32c6_devkitc/esp32c6_devkitc_hpcore-pinctrl.dtsi
+++ b/boards/espressif/esp32c6_devkitc/esp32c6_devkitc_hpcore-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c6-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp32h2_devkitm/esp32h2_devkitm-pinctrl.dtsi
+++ b/boards/espressif/esp32h2_devkitm/esp32h2_devkitm-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32h2-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32h2-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32h2-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp32s2_devkitc/esp32s2_devkitc-pinctrl.dtsi
+++ b/boards/espressif/esp32s2_devkitc/esp32s2_devkitc-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s2-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp32s2_saola/esp32s2_saola-pinctrl.dtsi
+++ b/boards/espressif/esp32s2_saola/esp32s2_saola-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s2-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp32s3_devkitc/esp32s3_devkitc-pinctrl.dtsi
+++ b/boards/espressif/esp32s3_devkitc/esp32s3_devkitc-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp32s3_devkitm/esp32s3_devkitm-pinctrl.dtsi
+++ b/boards/espressif/esp32s3_devkitm/esp32s3_devkitm-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp32s3_eye/esp32s3_eye-pinctrl.dtsi
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp8684_devkitm/esp8684_devkitm-pinctrl.dtsi
+++ b/boards/espressif/esp8684_devkitm/esp8684_devkitm-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c2-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c2-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c2-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/espressif/esp_wrover_kit/esp_wrover_kit-pinctrl.dtsi
+++ b/boards/espressif/esp_wrover_kit/esp_wrover_kit-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/franzininho/esp32s2_franzininho/esp32s2_franzininho-pinctrl.dtsi
+++ b/boards/franzininho/esp32s2_franzininho/esp32s2_franzininho-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s2-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/hardkernel/odroid_go/odroid_go-pinctrl.dtsi
+++ b/boards/hardkernel/odroid_go/odroid_go-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2-pinctrl.dtsi
+++ b/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3-pinctrl.dtsi
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3-pinctrl.dtsi
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/heltec/heltec_wireless_tracker/heltec_wireless_tracker-pinctrl.dtsi
+++ b/boards/heltec/heltec_wireless_tracker/heltec_wireless_tracker-pinctrl.dtsi
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/kincony/kincony_kc868_a32/kincony_kc868_a32-pinctrl.dtsi
+++ b/boards/kincony/kincony_kc868_a32/kincony_kc868_a32-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/lilygo/tdongle_s3/tdongle_s3-pinctrl.dtsi
+++ b/boards/lilygo/tdongle_s3/tdongle_s3-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/lilygo/ttgo_lora32/ttgo_lora32-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_lora32/ttgo_lora32-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/lilygo/ttgo_t7v1_5/ttgo_t7v1_5-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_t7v1_5/ttgo_t7v1_5-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/lilygo/ttgo_t8c3/ttgo_t8c3-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_t8c3/ttgo_t8c3-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/lilygo/ttgo_t8s3/ttgo_t8s3-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_t8s3/ttgo_t8s3-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/lilygo/ttgo_tbeam/ttgo_tbeam-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_tbeam/ttgo_tbeam-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/lilygo/ttgo_toiplus/ttgo_toiplus-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_toiplus/ttgo_toiplus-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/lilygo/twatch_s3/twatch_s3-pinctrl.dtsi
+++ b/boards/lilygo/twatch_s3/twatch_s3-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/luatos/esp32c3_luatos_core/esp32c3_luatos_core-pinctrl.dtsi
+++ b/boards/luatos/esp32c3_luatos_core/esp32c3_luatos_core-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core-pinctrl.dtsi
+++ b/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/m5stack/m5stack_atom_lite/m5stack_atom_lite-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_atom_lite/m5stack_atom_lite-pinctrl.dtsi
@@ -7,7 +7,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/m5stack/m5stack_atoms3/m5stack_atoms3-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_atoms3/m5stack_atoms3-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite-pinctrl.dtsi
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite_procpu.dts
+++ b/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite_procpu.dts
@@ -8,8 +8,8 @@
 
 #include <espressif/esp32s3/esp32s3_fn8.dtsi>
 #include "m5stack_atoms3_lite-pinctrl.dtsi"
-#include <dt-bindings/led/led.h>
-#include <dt-bindings/led/worldsemi_ws2812c.h>
+#include <zephyr/dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/worldsemi_ws2812c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <espressif/partitions_0x0_amp.dtsi>
 

--- a/boards/m5stack/m5stack_core2/m5stack_core2-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_core2/m5stack_core2-pinctrl.dtsi
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/m5stack/m5stack_fire/m5stack_fire-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_fire/m5stack_fire-pinctrl.dtsi
@@ -7,7 +7,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/m5stack/m5stack_stamps3/m5stack_stamps3-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_stamps3/m5stack_stamps3-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/m5stack/m5stack_stamps3/m5stack_stamps3_procpu.dts
+++ b/boards/m5stack/m5stack_stamps3/m5stack_stamps3_procpu.dts
@@ -9,8 +9,8 @@
 #include "m5stack_stamps3-pinctrl.dtsi"
 #include "m5stack_stamps3_connectors.dtsi"
 #include <zephyr/dt-bindings/pwm/pwm.h>
-#include <dt-bindings/led/led.h>
-#include <dt-bindings/led/worldsemi_ws2812c.h>
+#include <zephyr/dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/worldsemi_ws2812c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <espressif/partitions_0x0_amp.dtsi>
 

--- a/boards/m5stack/m5stickc_plus/m5stickc_plus-pinctrl.dtsi
+++ b/boards/m5stack/m5stickc_plus/m5stickc_plus-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/m5stack/stamp_c3/stamp_c3-pinctrl.dtsi
+++ b/boards/m5stack/stamp_c3/stamp_c3-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.dts
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.dts
@@ -7,7 +7,7 @@
 
 /dts-v1/;
 #include <common/freq.h>
-#include <dt-bindings/mfd/mfd_mchp_sam_flexcom.h>
+#include <zephyr/dt-bindings/mfd/mfd_mchp_sam_flexcom.h>
 #include <dt-bindings/sam/sama7d6/sama7d65/sama7d65-pinctrl.h>
 #include <microchip/sam/sama7d6.dtsi>
 

--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
@@ -7,12 +7,12 @@
 
 /dts-v1/;
 #include <common/freq.h>
-#include <dt-bindings/mfd/mfd_mchp_sam_flexcom.h>
+#include <zephyr/dt-bindings/mfd/mfd_mchp_sam_flexcom.h>
 #include <dt-bindings/sam/sama7g5/sama7g54/sama7g54-pinctrl.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/gpio/microchip-sam-gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/microchip-sam-gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include <microchip/sam/sama7g5.dtsi>
 
 / {

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
@@ -8,7 +8,7 @@
 
 #include <nxp/nxp_mcxe31b.dtsi>
 #include "frdm_mcxe31b-pinctrl.dtsi"
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 

--- a/boards/nxp/mr_canhubk3/mr_canhubk3_common.dtsi
+++ b/boards/nxp/mr_canhubk3/mr_canhubk3_common.dtsi
@@ -5,10 +5,10 @@
  */
 
 #include <arm/nxp/nxp_s32k344_m7.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <freq.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "mr_canhubk3-pinctrl.dtsi"
 #include <zephyr/dt-bindings/sensor/qdec_nxp_s32.h>
 

--- a/boards/olimex/olimex_esp32_evb/olimex_esp32_evb-pinctrl.dtsi
+++ b/boards/olimex/olimex_esp32_evb/olimex_esp32_evb-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/others/doit_esp32_devkit_v1/doit_esp32_devkit_v1-pinctrl.dtsi
+++ b/boards/others/doit_esp32_devkit_v1/doit_esp32_devkit_v1-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/others/esp32c3_supermini/esp32c3_supermini-pinctrl.dtsi
+++ b/boards/others/esp32c3_supermini/esp32c3_supermini-pinctrl.dtsi
@@ -4,7 +4,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/others/icev_wireless/icev_wireless-pinctrl.dtsi
+++ b/boards/others/icev_wireless/icev_wireless-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/pcbcupid/glyph_c6/glyph_c6-pinctrl.dtsi
+++ b/boards/pcbcupid/glyph_c6/glyph_c6-pinctrl.dtsi
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c6-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/qemu/rx/qemu_rx.dts
+++ b/boards/qemu/rx/qemu_rx.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <renesas/rx-qemu.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	model = "Renesas QEMU";

--- a/boards/rakwireless/rak11720/rak11720_apollo3-pinctrl.dtsi
+++ b/boards/rakwireless/rak11720/rak11720_apollo3-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/rakwireless/rak3112/rak3112-pinctrl.dtsi
+++ b/boards/rakwireless/rak3112/rak3112-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 

--- a/boards/raspberrypi/rpi_debug_probe/rpi_debug_probe-pincontrol.dtsi
+++ b/boards/raspberrypi/rpi_debug_probe/rpi_debug_probe-pincontrol.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/raspberrypi/rpi_debug_probe/rpi_debug_probe.dts
+++ b/boards/raspberrypi/rpi_debug_probe/rpi_debug_probe.dts
@@ -9,7 +9,7 @@
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 #include "rpi_debug_probe-pincontrol.dtsi"

--- a/boards/renesas/ek_ra2l1/ek_ra2l1.dts
+++ b/boards/renesas/ek_ra2l1/ek_ra2l1.dts
@@ -15,7 +15,7 @@
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/adc/adc.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "ek_ra2l1-pinctrl.dtsi"
 
 / {

--- a/boards/renesas/ek_ra4c1/ek_ra4c1.dts
+++ b/boards/renesas/ek_ra4c1/ek_ra4c1.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra4/r7fa4c1bd3cfp.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include "ek_ra4c1-pinctrl.dtsi"
 

--- a/boards/renesas/ek_ra4e2/ek_ra4e2.dts
+++ b/boards/renesas/ek_ra4e2/ek_ra4e2.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra4/r7fa4e2b93cfm.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include "ek_ra4e2-pinctrl.dtsi"
 

--- a/boards/renesas/ek_ra4l1/ek_ra4l1.dts
+++ b/boards/renesas/ek_ra4l1/ek_ra4l1.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra4/r7fa4l1bd4cfp.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include "ek_ra4l1-pinctrl.dtsi"
 

--- a/boards/renesas/ek_ra4m1/ek_ra4m1.dts
+++ b/boards/renesas/ek_ra4m1/ek_ra4m1.dts
@@ -6,9 +6,9 @@
 /dts-v1/;
 
 #include <renesas/ra/ra4/r7fa4m1ab3cfp.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/adc/adc.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "ek_ra4m1-pinctrl.dtsi"
 
 / {

--- a/boards/renesas/ek_ra4m2/ek_ra4m2.dts
+++ b/boards/renesas/ek_ra4m2/ek_ra4m2.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra4/r7fa4m2ad3cfp.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include "ek_ra4m2-pinctrl.dtsi"
 

--- a/boards/renesas/ek_ra4m3/ek_ra4m3.dts
+++ b/boards/renesas/ek_ra4m3/ek_ra4m3.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra4/r7fa4m3af3cfb.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include "ek_ra4m3-pinctrl.dtsi"
 

--- a/boards/renesas/ek_ra4w1/ek_ra4w1.dts
+++ b/boards/renesas/ek_ra4w1/ek_ra4w1.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra4/r7fa4w1ad2cng.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include "ek_ra4w1-pinctrl.dtsi"
 

--- a/boards/renesas/ek_ra6e2/ek_ra6e2.dts
+++ b/boards/renesas/ek_ra6e2/ek_ra6e2.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra6/r7fa6e2bb3cfm.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 
 #include "ek_ra6e2-pinctrl.dtsi"

--- a/boards/renesas/ek_ra6m1/ek_ra6m1.dts
+++ b/boards/renesas/ek_ra6m1/ek_ra6m1.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra6/r7fa6m1ad3cfp.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 
 #include "ek_ra6m1-pinctrl.dtsi"

--- a/boards/renesas/ek_ra6m2/ek_ra6m2.dts
+++ b/boards/renesas/ek_ra6m2/ek_ra6m2.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra6/r7fa6m2af3cfb.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 
 #include "ek_ra6m2-pinctrl.dtsi"

--- a/boards/renesas/ek_ra6m3/ek_ra6m3.dts
+++ b/boards/renesas/ek_ra6m3/ek_ra6m3.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra6/r7fa6m3ah3cfc.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 
 #include "ek_ra6m3-pinctrl.dtsi"

--- a/boards/renesas/ek_ra6m4/ek_ra6m4.dts
+++ b/boards/renesas/ek_ra6m4/ek_ra6m4.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra6/r7fa6m4af3cfb.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 

--- a/boards/renesas/ek_ra6m5/ek_ra6m5.dts
+++ b/boards/renesas/ek_ra6m5/ek_ra6m5.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra6/r7fa6m5bh3cfc.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 

--- a/boards/renesas/ek_ra8d1/ek_ra8d1.dts
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1.dts
@@ -7,8 +7,8 @@
 
 #include <renesas/ra/ra8/r7fa8d1bhecbd.dtsi>
 #include <zephyr/dt-bindings/flash_controller/xspi.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/memory-controller/renesas,ra-sdram.h>
 #include <zephyr/dt-bindings/adc/adc.h>

--- a/boards/renesas/ek_ra8d2/ek_ra8d2.dtsi
+++ b/boards/renesas/ek_ra8d2/ek_ra8d2.dtsi
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/memory-controller/renesas,ra-sdram.h>
 #include <zephyr/dt-bindings/gpio/arducam-ffc-40pin-connector.h>

--- a/boards/renesas/ek_ra8m1/ek_ra8m1.dts
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1.dts
@@ -6,7 +6,7 @@
 /dts-v1/;
 
 #include <renesas/ra/ra8/r7fa8m1ahecbd.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>

--- a/boards/renesas/ek_ra8m2/ek_ra8m2.dtsi
+++ b/boards/renesas/ek_ra8m2/ek_ra8m2.dtsi
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "ek_ra8m2-pinctrl.dtsi"
 
 / {

--- a/boards/renesas/ek_ra8p1/ek_ra8p1.dtsi
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1.dtsi
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/gpio/arducam-ffc-40pin-connector.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "ek_ra8p1-pinctrl.dtsi"
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/memory-controller/renesas,ra-sdram.h>

--- a/boards/renesas/ek_rx261/ek_rx261.dts
+++ b/boards/renesas/ek_rx261/ek_rx261.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <renesas/r5f52618bgfp.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include "ek_rx261-pinctrl.dtsi"
 
 / {

--- a/boards/renesas/fpb_ra4e1/fpb_ra4e1.dts
+++ b/boards/renesas/fpb_ra4e1/fpb_ra4e1.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra4/r7fa4e10d2cfm.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include "fpb_ra4e1-pinctrl.dtsi"
 

--- a/boards/renesas/fpb_ra6e1/fpb_ra6e1.dts
+++ b/boards/renesas/fpb_ra6e1/fpb_ra6e1.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra6/r7fa6e10f2cfp.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 
 #include "fpb_ra6e1-pinctrl.dtsi"

--- a/boards/renesas/fpb_ra6e2/fpb_ra6e2.dts
+++ b/boards/renesas/fpb_ra6e2/fpb_ra6e2.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra6/r7fa6e2bb3cfm.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 
 #include "fpb_ra6e2-pinctrl.dtsi"

--- a/boards/renesas/fpb_rx261/fpb_rx261.dts
+++ b/boards/renesas/fpb_rx261/fpb_rx261.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <renesas/r5f52618bgfp.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include "fpb_rx261-pinctrl.dtsi"
 
 / {

--- a/boards/renesas/mcb_rx26t/mcb_rx26t.dts
+++ b/boards/renesas/mcb_rx26t/mcb_rx26t.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <renesas/r5f526tfddfp.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include "mcb_rx26t-pinctrl.dtsi"
 
 / {

--- a/boards/renesas/mck_ra4t1/mck_ra4t1.dts
+++ b/boards/renesas/mck_ra4t1/mck_ra4t1.dts
@@ -6,7 +6,7 @@
 /dts-v1/;
 
 #include <renesas/ra/ra4/r7fa4t1bb3cfm.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include "mck_ra4t1-pinctrl.dtsi"
 
 / {

--- a/boards/renesas/mck_ra8t1/mck_ra8t1.dts
+++ b/boards/renesas/mck_ra8t1/mck_ra8t1.dts
@@ -6,7 +6,7 @@
 /dts-v1/;
 
 #include <renesas/ra/ra8/r7fa8t1ahecbd.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include "mck_ra8t1-pinctrl.dtsi"
 

--- a/boards/renesas/mck_ra8t2/mck_ra8t2.dtsi
+++ b/boards/renesas/mck_ra8t2/mck_ra8t2.dtsi
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include "mck_ra8t2-pinctrl.dtsi"
 

--- a/boards/renesas/rcar_spider_s4/rcar_spider_s4_r8a779f0_r52-pinctrl.dtsi
+++ b/boards/renesas/rcar_spider_s4/rcar_spider_s4_r8a779f0_r52-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/renesas/pinctrl-r8a779f0.h>
+#include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a779f0.h>
 
 &pfc {
 	scif0_data_tx_default: scif0_data_tx_default {

--- a/boards/renesas/rsk_rx130/rsk_rx130.dts
+++ b/boards/renesas/rsk_rx130/rsk_rx130.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <renesas/r5f51308axfp.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include "rsk_rx130_512kb-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>

--- a/boards/renesas/voice_ra4e1/voice_ra4e1.dts
+++ b/boards/renesas/voice_ra4e1/voice_ra4e1.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra4/r7fa4e10d2cne.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include "voice_ra4e1-pinctrl.dtsi"
 

--- a/boards/ruiside/ra8d1_vision_board/ra8d1_vision_board.dts
+++ b/boards/ruiside/ra8d1_vision_board/ra8d1_vision_board.dts
@@ -6,8 +6,8 @@
 /dts-v1/;
 
 #include <renesas/ra/ra8/r7fa8d1bhecbd.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/memory-controller/renesas,ra-sdram.h>
 #include "ra8d1_vision_board-pinctrl.dtsi"

--- a/boards/seeed/xiao_esp32c3/xiao_esp32c3-pinctrl.dtsi
+++ b/boards/seeed/xiao_esp32c3/xiao_esp32c3-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/seeed/xiao_esp32c6/xiao_esp32c6-pinctrl.dtsi
+++ b/boards/seeed/xiao_esp32c6/xiao_esp32c6-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c6-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/seeed/xiao_esp32s3/xiao_esp32s3-pinctrl.dtsi
+++ b/boards/seeed/xiao_esp32s3/xiao_esp32s3-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/seeed/xiao_mg24/xiao_mg24.dts
+++ b/boards/seeed/xiao_mg24/xiao_mg24.dts
@@ -8,7 +8,7 @@
 /dts-v1/;
 #include <silabs/xg24/efr32mg24b220f1536im48.dtsi>
 #include <zephyr/dt-bindings/pwm/pwm.h>
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include "xiao_mg24-pinctrl.dtsi"
 #include "seeed_xiao_connector.dtsi"
 

--- a/boards/seeed/xiao_ra4m1/xiao_ra4m1.dts
+++ b/boards/seeed/xiao_ra4m1/xiao_ra4m1.dts
@@ -7,9 +7,9 @@
 /dts-v1/;
 
 #include <renesas/ra/ra4/r7fa4m1ab3cne.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/adc/adc.h>
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "xiao_ra4m1-pinctrl.dtsi"
 
 / {

--- a/boards/seeed/xiao_rp2040/xiao_rp2040-pinctrl.dtsi
+++ b/boards/seeed/xiao_rp2040/xiao_rp2040-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/shields/adafruit_neopixel_grid_bff/boards/adafruit_qt_py_rp2040.overlay
+++ b/boards/shields/adafruit_neopixel_grid_bff/boards/adafruit_qt_py_rp2040.overlay
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	pinctrl_bff_ws2812: pinctrl_bff_ws2812 {

--- a/boards/shields/adafruit_pca9685/adafruit_pca9685.overlay
+++ b/boards/shields/adafruit_pca9685/adafruit_pca9685.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 &arduino_i2c {
 	status = "okay";

--- a/boards/shields/npm1300_ek/npm1300_ek.overlay
+++ b/boards/shields/npm1300_ek/npm1300_ek.overlay
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/regulator/npm13xx.h>
+#include <zephyr/dt-bindings/regulator/npm13xx.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 &arduino_i2c {

--- a/boards/shields/npm1304_ek/npm1304_ek.overlay
+++ b/boards/shields/npm1304_ek/npm1304_ek.overlay
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/regulator/npm13xx.h>
+#include <zephyr/dt-bindings/regulator/npm13xx.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 &arduino_i2c {

--- a/boards/shields/npm2100_ek/npm2100_ek.overlay
+++ b/boards/shields/npm2100_ek/npm2100_ek.overlay
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/regulator/npm2100.h>
+#include <zephyr/dt-bindings/regulator/npm2100.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 &arduino_i2c {

--- a/boards/shields/waveshare_dsi_lcd/boards/frdm_imx93_mimx9352_a55.overlay
+++ b/boards/shields/waveshare_dsi_lcd/boards/frdm_imx93_mimx9352_a55.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/mipi_dsi/mipi_dsi.h>
+#include <zephyr/dt-bindings/mipi_dsi/mipi_dsi.h>
 
 / {
 	chosen {

--- a/boards/shields/waveshare_dsi_lcd/waveshare_7inch_dsi_lcd_c.overlay
+++ b/boards/shields/waveshare_dsi_lcd/waveshare_7inch_dsi_lcd_c.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/mipi_dsi/mipi_dsi.h>
+#include <zephyr/dt-bindings/mipi_dsi/mipi_dsi.h>
 
 &display_i2c {
 	dsi_panel: waveshare_panel@45 {

--- a/boards/silabs/explorer_kits/xg22/xg22_explorer_kit-pinctrl.dtsi
+++ b/boards/silabs/explorer_kits/xg22/xg22_explorer_kit-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg22-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg22-pinctrl.h>
 
 &pinctrl {
 	euart0_default: euart0_default {

--- a/boards/silabs/explorer_kits/xg22/xg22_explorer_kit.dtsi
+++ b/boards/silabs/explorer_kits/xg22/xg22_explorer_kit.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>

--- a/boards/silabs/explorer_kits/xg26/xg26_explorer_kit-pinctrl.dtsi
+++ b/boards/silabs/explorer_kits/xg26/xg26_explorer_kit-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg26-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg26-pinctrl.h>
 
 &pinctrl {
 	eusart1_default: eusart1_default {

--- a/boards/silabs/explorer_kits/xg26/xg26_explorer_kit.dtsi
+++ b/boards/silabs/explorer_kits/xg26/xg26_explorer_kit.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>

--- a/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
+++ b/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 #include <silabs/xg21/efr32mg21a020f1024im32.dtsi>
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "slwrb4180a-pinctrl.dtsi"
 

--- a/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
+++ b/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
@@ -7,7 +7,7 @@
 
 /dts-v1/;
 #include <silabs/xg21/efr32mg21a020f1024im32.dtsi>
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "slwrb4180b-pinctrl.dtsi"
 

--- a/boards/silabs/radio_boards/xg27/xg27_rb4194a.dts
+++ b/boards/silabs/radio_boards/xg27/xg27_rb4194a.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 #include <silabs/xg27/efr32mg27c140f768im40.dtsi>
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>

--- a/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg28-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg28-pinctrl.h>
 
 &pinctrl {
 	eusart1_default: eusart1_default {

--- a/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.dts
+++ b/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 #include <silabs/xg29/efr32mg29b140f1024im40.dtsi>
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>

--- a/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040-pinctrl.dtsi
+++ b/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
@@ -9,7 +9,7 @@
 /dts-v1/;
 #include <silabs/xg24/mgm240pb32vna.dtsi>
 #include <zephyr/dt-bindings/pwm/pwm.h>
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 #include "sparkfun_thing_plus_matter_mgm240p-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>

--- a/boards/vcc-gnd/yd_esp32/yd_esp32-pinctrl.dtsi
+++ b/boards/vcc-gnd/yd_esp32/yd_esp32-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/waveshare/esp32s3_matrix/esp32s3_matrix-pinctrl.dtsi
+++ b/boards/waveshare/esp32s3_matrix/esp32s3_matrix-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28-pinctrl.dtsi
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 

--- a/boards/waveshare/rp2040_geek/rp2040_geek-pincontrol.dtsi
+++ b/boards/waveshare/rp2040_geek/rp2040_geek-pincontrol.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/waveshare/rp2040_geek/rp2040_geek.dts
+++ b/boards/waveshare/rp2040_geek/rp2040_geek.dts
@@ -9,7 +9,7 @@
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>

--- a/boards/waveshare/rp2040_keyboard_3/rp2040_keyboard_3.dts
+++ b/boards/waveshare/rp2040_keyboard_3/rp2040_keyboard_3.dts
@@ -9,7 +9,7 @@
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 

--- a/boards/waveshare/rp2040_matrix/rp2040_matrix-pinctrl.dtsi
+++ b/boards/waveshare/rp2040_matrix/rp2040_matrix-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	adc_default: adc_default {

--- a/boards/waveshare/rp2040_matrix/rp2040_matrix.dts
+++ b/boards/waveshare/rp2040_matrix/rp2040_matrix.dts
@@ -9,7 +9,7 @@
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 #include "rp2040_matrix-pinctrl.dtsi"

--- a/boards/waveshare/rp2040_plus/rp2040_plus-pinctrl.dtsi
+++ b/boards/waveshare/rp2040_plus/rp2040_plus-pinctrl.dtsi
@@ -2,8 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/waveshare/rp2040_zero/rp2040_zero-pinctrl.dtsi
+++ b/boards/waveshare/rp2040_zero/rp2040_zero-pinctrl.dtsi
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/we/orthosie1ev/we_orthosie1ev-pinctrl.dtsi
+++ b/boards/we/orthosie1ev/we_orthosie1ev-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/weact/esp32c3_mini/weact_esp32c3_mini-pinctrl.dtsi
+++ b/boards/weact/esp32c3_mini/weact_esp32c3_mini-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/weact/esp32c6_mini/weact_esp32c6_mini_hpcore-pinctrl.dtsi
+++ b/boards/weact/esp32c6_mini/weact_esp32c6_mini_hpcore-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32c6-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/weact/esp32s3_mini/weact_esp32s3_mini-pinctrl.dtsi
+++ b/boards/weact/esp32s3_mini/weact_esp32s3_mini-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/weact/weact_esp32s3_b/weact_esp32s3_b-pinctrl.dtsi
+++ b/boards/weact/weact_esp32s3_b/weact_esp32s3_b-pinctrl.dtsi
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/wemos/esp32s2_lolin_mini/esp32s2_lolin_mini-pinctrl.dtsi
+++ b/boards/wemos/esp32s2_lolin_mini/esp32s2_lolin_mini-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32s2-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
 
 &pinctrl {

--- a/boards/wemos/lolin32_lite/lolin32_lite-pinctrl.dtsi
+++ b/boards/wemos/lolin32_lite/lolin32_lite-pinctrl.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -359,7 +359,7 @@ Pin Control
 
     .. code-block:: devicetree
 
-      #include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
+      #include <zephyr/dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
 
       &pinctrl {
         i2c0_default: i2c0_default {

--- a/dts/arm/infineon/cat1b/psc3/system_clocks.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/system_clocks.dtsi
@@ -10,8 +10,8 @@
 #define DIV_16_5_BIT 02
 #define DIV_24_5_BIT 03
 
-#include <dt-bindings/clock/ifx_clock_source_common.h>
-#include <dt-bindings/clock/ifx_clock_source_psc3xx.h>
+#include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
+#include <zephyr/dt-bindings/clock/ifx_clock_source_psc3xx.h>
 
 / {
 	srss_power: srss_power {

--- a/dts/arm/infineon/edge/pse84/system_clocks.dtsi
+++ b/dts/arm/infineon/edge/pse84/system_clocks.dtsi
@@ -10,8 +10,8 @@
 #define DIV_16_5_BIT 02
 #define DIV_24_5_BIT 03
 
-#include <dt-bindings/clock/ifx_clock_source_common.h>
-#include <dt-bindings/clock/ifx_clock_source_pse8xx.h>
+#include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
+#include <zephyr/dt-bindings/clock/ifx_clock_source_pse8xx.h>
 
 / {
 	/* iho */

--- a/dts/arm/nxp/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/nxp_imx94x.dtsi
@@ -6,7 +6,7 @@
 
 #include <mem.h>
 #include <freq.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/imx943_clock.h>
 #include <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -6,7 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/clock/imx95_clock.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
 #include <freq.h>

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/clock/imx_ccm_rev2.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/ethernet/dsa_tag_proto.h>

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -5,11 +5,11 @@
  */
 
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/power/nxp_rw_pmu.h>
-#include <dt-bindings/adc/nxp,gau-adc.h>
+#include <zephyr/dt-bindings/adc/nxp,gau-adc.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 

--- a/dts/arm/nxp/nxp_s32k146.dtsi
+++ b/dts/arm/nxp/nxp_s32k146.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/clock/nxp_s32k146_clock.h>
+#include <zephyr/dt-bindings/clock/nxp_s32k146_clock.h>
 #include <nxp/nxp_s32k1xx.dtsi>
 
 / {

--- a/dts/arm/nxp/nxp_s32k148.dtsi
+++ b/dts/arm/nxp/nxp_s32k148.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/clock/nxp_s32k148_clock.h>
+#include <zephyr/dt-bindings/clock/nxp_s32k148_clock.h>
 #include <nxp/nxp_s32k1xx.dtsi>
 
 / {

--- a/dts/arm/renesas/rz/rzg/r9a08g045.dtsi
+++ b/dts/arm/renesas/rz/rzg/r9a08g045.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <mem.h>
 #include <freq.h>
 #include <zephyr/dt-bindings/adc/adc.h>

--- a/dts/arm64/nxp/nxp_mimx95_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx95_a55.dtsi
@@ -9,7 +9,7 @@
 #include <mem.h>
 #include <freq.h>
 #include <arm64/armv8-a.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/imx95_clock.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 

--- a/dts/arm64/renesas/r8a779f0.dtsi
+++ b/dts/arm64/renesas/r8a779f0.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <arm64/armv8-a.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/clock/renesas_cpg_mssr.h>
 #include <zephyr/dt-bindings/clock/r8a779f0_cpg_mssr.h>
 

--- a/dts/arm64/renesas/rcar_gen3_ca57.dtsi
+++ b/dts/arm64/renesas/rcar_gen3_ca57.dtsi
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <arm64/armv8-a.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/clock/renesas_cpg_mssr.h>
 #include <zephyr/dt-bindings/clock/r8a7795_cpg_mssr.h>
 

--- a/dts/bindings/input/adc-keys.yaml
+++ b/dts/bindings/input/adc-keys.yaml
@@ -10,7 +10,7 @@ description: |
 
   Example:
 
-  #include <dt-bindings/input/input-event-codes.h>
+  #include <zephyr/dt-bindings/input/input-event-codes.h>
 
   / {
           buttons {

--- a/dts/bindings/input/renesas,ra-ctsu-button.yaml
+++ b/dts/bindings/input/renesas,ra-ctsu-button.yaml
@@ -10,7 +10,7 @@ description: |
 
   Example:
 
-  #include <dt-bindings/input/input-event-codes.h>
+  #include <zephyr/dt-bindings/input/input-event-codes.h>
 
   &ctsu {
     compatible = "renesas,ra-ctsu";

--- a/dts/bindings/input/renesas,ra-ctsu-slider.yaml
+++ b/dts/bindings/input/renesas,ra-ctsu-slider.yaml
@@ -10,7 +10,7 @@ description: |
 
   Example:
 
-  #include <dt-bindings/input/input-event-codes.h>
+  #include <zephyr/dt-bindings/input/input-event-codes.h>
 
   &ctsu {
     compatible = "renesas,ra-ctsu";

--- a/dts/bindings/input/renesas,ra-ctsu-wheel.yaml
+++ b/dts/bindings/input/renesas,ra-ctsu-wheel.yaml
@@ -10,7 +10,7 @@ description: |
 
   Example:
 
-  #include <dt-bindings/input/input-event-codes.h>
+  #include <zephyr/dt-bindings/input/input-event-codes.h>
 
   &ctsu {
     compatible = "renesas,ra-ctsu";

--- a/dts/bindings/input/tsc-keys.yaml
+++ b/dts/bindings/input/tsc-keys.yaml
@@ -10,7 +10,7 @@ description: |
 
   Example:
 
-  #include <dt-bindings/input/input-event-codes.h>
+  #include <zephyr/dt-bindings/input/input-event-codes.h>
 
   &tsc {
     compatible = "st,stm32-tsc";

--- a/dts/bindings/pinctrl/ambiq,apollo2-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ambiq,apollo2-pinctrl.yaml
@@ -16,7 +16,7 @@ description: |
 
   Example usage in a board or overlay:
 
-  #include <dt-bindings/pinctrl/ambiq-apollo2-pinctrl.h>
+  #include <zephyr/dt-bindings/pinctrl/ambiq-apollo2-pinctrl.h>
 
   &pinctrl {
     uart0_default: uart0_default {

--- a/dts/bindings/pinctrl/ambiq,apollo3-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ambiq,apollo3-pinctrl.yaml
@@ -23,7 +23,7 @@ description: |
   */
 
   /* include pre-defined combinations for the SoC variant used by the board */
-  #include <dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h>
+  #include <zephyr/dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h>
 
   &pinctrl {
     uart0_default: uart0_default {

--- a/dts/bindings/pinctrl/ambiq,apollo4-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ambiq,apollo4-pinctrl.yaml
@@ -23,7 +23,7 @@ description: |
        */
 
       /* include pre-defined combinations for the SoC variant used by the board */
-      #include <dt-bindings/pinctrl/ambiq-apollo4-pinctrl.h>
+      #include <zephyr/dt-bindings/pinctrl/ambiq-apollo4-pinctrl.h>
 
       &pinctrl {
         uart0_default: uart0_default {

--- a/dts/bindings/pinctrl/ambiq,apollo5-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ambiq,apollo5-pinctrl.yaml
@@ -23,7 +23,7 @@ description: |
        */
 
       /* include pre-defined combinations for the SoC variant used by the board */
-      #include <dt-bindings/pinctrl/ambiq-apollo5-pinctrl.h>
+      #include <zephyr/dt-bindings/pinctrl/ambiq-apollo5-pinctrl.h>
 
       &pinctrl {
         uart0_default: uart0_default {

--- a/dts/bindings/pinctrl/ite,it8xxx2-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ite,it8xxx2-pinctrl.yaml
@@ -22,7 +22,7 @@ description: |
        */
 
       /* include pre-defined pins and functions for the SoC used by the board */
-      #include <dt-bindings/pinctrl/it8xxx2-pinctrl.h>
+      #include <zephyr/dt-bindings/pinctrl/it8xxx2-pinctrl.h>
 
       &pinctrl {
         /* configuration for I2C0 default state */

--- a/dts/bindings/pinctrl/quicklogic,eos-s3-pinctrl.yaml
+++ b/dts/bindings/pinctrl/quicklogic,eos-s3-pinctrl.yaml
@@ -10,7 +10,7 @@ description: |
 
   For example, setting pins 44 and 45 for use as UART would look like this:
 
-    #include <dt-bindings/pinctrl/quicklogic-eos-s3-pinctrl.h>
+    #include <zephyr/dt-bindings/pinctrl/quicklogic-eos-s3-pinctrl.h>
 
     &pinctrl {
       uart0_rx_default: uart0_rx_default {

--- a/dts/bindings/pinctrl/raspberrypi,pico-pinctrl.yaml
+++ b/dts/bindings/pinctrl/raspberrypi,pico-pinctrl.yaml
@@ -24,7 +24,7 @@ description: |
        */
 
       /* include pre-defined combinations for the SoC variant used by the board */
-      #include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+      #include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
       &pinctrl {
         /* configuration for the usart0 "default" state */

--- a/dts/bindings/pinctrl/renesas,ra-pincrl-pfs.yaml
+++ b/dts/bindings/pinctrl/renesas,ra-pincrl-pfs.yaml
@@ -22,7 +22,7 @@ description: |
        */
 
       /* include pre-defined combinations for the SoC variant used by the board */
-      #include <dt-bindings/pinctrl/renesas/pinctrl-ra.h>
+      #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 
       &pinctrl {
         /* configuration for the sci0 "default" state */

--- a/dts/bindings/pinctrl/renesas,rcar-pfc.yaml
+++ b/dts/bindings/pinctrl/renesas,rcar-pfc.yaml
@@ -24,7 +24,7 @@ description: |
        */
 
       /* include pre-defined pins and functions for the SoC used by the board */
-      #include <dt-bindings/pinctrl/renesas/pinctrl-r8a77951.h>
+      #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a77951.h>
 
       &pfc {
         /* configuration for can0 data a tx default state */

--- a/dts/bindings/pinctrl/renesas,rx-pinctrl.yaml
+++ b/dts/bindings/pinctrl/renesas,rx-pinctrl.yaml
@@ -22,7 +22,7 @@ description: |
       */
 
     /* include pre-defined combinations for the SoC variant used by the board */
-    #include <dt-bindings/pinctrl/renesas/rx-pinctrl.h>
+    #include <zephyr/dt-bindings/pinctrl/renesas/rx-pinctrl.h>
 
     &pinctrl {
       sci1_default: sci1_default {

--- a/dts/bindings/pinctrl/renesas,rzt2m-pinctrl.yaml
+++ b/dts/bindings/pinctrl/renesas,rzt2m-pinctrl.yaml
@@ -23,7 +23,7 @@ description: |
        */
 
       /* include pre-defined combinations for the SoC variant used by the board */
-      #include <dt-bindings/pinctrl/renesas-rzt2m-pinctrl.h>
+      #include <zephyr/dt-bindings/pinctrl/renesas-rzt2m-pinctrl.h>
 
       &pinctrl {
         uart0_default: uart0_default {

--- a/dts/bindings/pinctrl/renesas,smartbond-pinctrl.yaml
+++ b/dts/bindings/pinctrl/renesas,smartbond-pinctrl.yaml
@@ -23,7 +23,7 @@ description: |
        */
 
      /* include definitions and utility macros for the SoC used by the board */
-     #include <dt-bindings/pinctrl/smartbond-pinctrl.h>
+     #include <zephyr/dt-bindings/pinctrl/smartbond-pinctrl.h>
 
       &pinctrl {
         /* configuration for uart device, default state */

--- a/dts/bindings/pinctrl/sifive,pinctrl.yaml
+++ b/dts/bindings/pinctrl/sifive,pinctrl.yaml
@@ -14,7 +14,7 @@ description: |
 
   For example, setting pins 16 and 17 both to IOF0 would look like this:
 
-    #include <dt-bindings/pinctrl/sifive-pinctrl.h>
+    #include <zephyr/dt-bindings/pinctrl/sifive-pinctrl.h>
 
     &pinctrl {
       uart0_rx_default: uart0_rx_default {

--- a/dts/bindings/pinctrl/telink,b91-pinctrl.yaml
+++ b/dts/bindings/pinctrl/telink,b91-pinctrl.yaml
@@ -22,7 +22,7 @@ description: |
        */
 
       /* include pre-defined pins and functions for the SoC used by the board */
-      #include <dt-bindings/pinctrl/b91-pinctrl.h>
+      #include <zephyr/dt-bindings/pinctrl/b91-pinctrl.h>
 
       &pinctrl {
         /* configuration for UART0 TX default state */

--- a/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinctrl.yaml
@@ -34,7 +34,7 @@ description: |
     An example for CC13XX family, include the chip level pinctrl
     DTSI file in the board level DTS:
 
-      #include <dt-bindings/pinctrl/cc13xx_cc26xx-pinctrl.h>
+      #include <zephyr/dt-bindings/pinctrl/cc13xx_cc26xx-pinctrl.h>
 
     We want to configure the I2C pins to open drain, with pullup enabled
     and input enabled.

--- a/dts/bindings/pinctrl/ti,mspm0-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ti,mspm0-pinctrl.yaml
@@ -35,7 +35,7 @@ description: |
     An example for MSPM0 family, include the chip level pinctrl
     DTSI file in the board level DTS:
 
-      #include <dt-bindings/pinctrl/mspm0-pinctrl.h>
+      #include <zephyr/dt-bindings/pinctrl/mspm0-pinctrl.h>
 
     We want to configure the I2C pins to open drain, with pullup enabled
     and input enabled.

--- a/dts/riscv/bflb/bl602.dtsi
+++ b/dts/riscv/bflb/bl602.dtsi
@@ -5,4 +5,4 @@
  */
 
 #include <bflb/bl60x.dtsi>
-#include <dt-bindings/pinctrl/bl602x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl602x-pinctrl.h>

--- a/dts/riscv/bflb/bl604.dtsi
+++ b/dts/riscv/bflb/bl604.dtsi
@@ -5,4 +5,4 @@
  */
 
 #include <bflb/bl60x.dtsi>
-#include <dt-bindings/pinctrl/bl604x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl604x-pinctrl.h>

--- a/dts/riscv/bflb/bl60x.dtsi
+++ b/dts/riscv/bflb/bl60x.dtsi
@@ -7,9 +7,9 @@
 
 #include <freq.h>
 #include <mem.h>
-#include <dt-bindings/pinctrl/bflb-common-pinctrl.h>
-#include <dt-bindings/pinctrl/bl60x-pinctrl.h>
-#include <dt-bindings/clock/bflb_bl60x_clock.h>
+#include <zephyr/dt-bindings/pinctrl/bflb-common-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl60x-pinctrl.h>
+#include <zephyr/dt-bindings/clock/bflb_bl60x_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/riscv/bflb/bl616.dtsi
+++ b/dts/riscv/bflb/bl616.dtsi
@@ -5,4 +5,4 @@
  */
 
 #include <bflb/bl61x.dtsi>
-#include <dt-bindings/pinctrl/bl616x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl616x-pinctrl.h>

--- a/dts/riscv/bflb/bl618.dtsi
+++ b/dts/riscv/bflb/bl618.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <bflb/bl61x.dtsi>
-#include <dt-bindings/pinctrl/bl618x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl618x-pinctrl.h>
 
 &psram {
 	status = "okay";

--- a/dts/riscv/bflb/bl61x.dtsi
+++ b/dts/riscv/bflb/bl61x.dtsi
@@ -6,9 +6,9 @@
 
 #include <freq.h>
 #include <mem.h>
-#include <dt-bindings/pinctrl/bflb-common-pinctrl.h>
-#include <dt-bindings/pinctrl/bl61x-pinctrl.h>
-#include <dt-bindings/clock/bflb_bl61x_clock.h>
+#include <zephyr/dt-bindings/pinctrl/bflb-common-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl61x-pinctrl.h>
+#include <zephyr/dt-bindings/clock/bflb_bl61x_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/riscv/bflb/bl702.dtsi
+++ b/dts/riscv/bflb/bl702.dtsi
@@ -5,4 +5,4 @@
  */
 
 #include <bflb/bl70x.dtsi>
-#include <dt-bindings/pinctrl/bl702x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl702x-pinctrl.h>

--- a/dts/riscv/bflb/bl704.dtsi
+++ b/dts/riscv/bflb/bl704.dtsi
@@ -5,4 +5,4 @@
  */
 
 #include <bflb/bl70x.dtsi>
-#include <dt-bindings/pinctrl/bl704x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl704x-pinctrl.h>

--- a/dts/riscv/bflb/bl706.dtsi
+++ b/dts/riscv/bflb/bl706.dtsi
@@ -5,4 +5,4 @@
  */
 
 #include <bflb/bl70x.dtsi>
-#include <dt-bindings/pinctrl/bl706x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl706x-pinctrl.h>

--- a/dts/riscv/bflb/bl70x.dtsi
+++ b/dts/riscv/bflb/bl70x.dtsi
@@ -6,9 +6,9 @@
 
 #include <freq.h>
 #include <mem.h>
-#include <dt-bindings/pinctrl/bflb-common-pinctrl.h>
-#include <dt-bindings/pinctrl/bl70x-pinctrl.h>
-#include <dt-bindings/clock/bflb_bl70x_clock.h>
+#include <zephyr/dt-bindings/pinctrl/bflb-common-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/bl70x-pinctrl.h>
+#include <zephyr/dt-bindings/clock/bflb_bl70x_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
@@ -10,7 +10,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/interrupt-controller/esp-esp32c2-intmux.h>
 #include <zephyr/dt-bindings/clock/esp32c2_clock.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 
 / {
 	#address-cells = <1>;

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -10,7 +10,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/interrupt-controller/esp-esp32c3-intmux.h>
 #include <zephyr/dt-bindings/clock/esp32c3_clock.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 
 / {
 	#address-cells = <1>;

--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -10,7 +10,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/interrupt-controller/esp-esp32c6-intmux.h>
 #include <zephyr/dt-bindings/clock/esp32c6_clock.h>
-#include <dt-bindings/pinctrl/esp32c6-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
 
 / {
 	#address-cells = <1>;

--- a/dts/riscv/espressif/esp32c6/esp32c6_lpcore.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_lpcore.dtsi
@@ -8,7 +8,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/interrupt-controller/esp-esp32c6-intmux.h>
 #include <zephyr/dt-bindings/clock/esp32c6_clock.h>
-#include <dt-bindings/pinctrl/esp32c6-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
 
 / {
 	#address-cells = <1>;

--- a/dts/riscv/espressif/esp32h2/esp32h2_common.dtsi
+++ b/dts/riscv/espressif/esp32h2/esp32h2_common.dtsi
@@ -10,7 +10,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/interrupt-controller/esp-esp32h2-intmux.h>
 #include <zephyr/dt-bindings/clock/esp32h2_clock.h>
-#include <dt-bindings/pinctrl/esp32h2-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32h2-pinctrl.h>
 
 / {
 	#address-cells = <1>;

--- a/dts/sparc/gaisler/gr716a.dtsi
+++ b/dts/sparc/gaisler/gr716a.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include "skeleton.dtsi"
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	cpus {

--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -5,8 +5,8 @@
  */
 
 #include "skeleton.dtsi"
-#include <dt-bindings/interrupt-controller/intel-ioapic.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <mem.h>
 
 / {

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -12,7 +12,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/esp32_clock.h>
 #include <zephyr/dt-bindings/interrupt-controller/esp-xtensa-intmux.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {

--- a/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
@@ -11,7 +11,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/esp32s2_clock.h>
 #include <zephyr/dt-bindings/interrupt-controller/esp32s2-xtensa-intmux.h>
-#include <dt-bindings/pinctrl/esp32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
 
 / {
 	#address-cells = <1>;

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -11,7 +11,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/esp32s3_clock.h>
 #include <zephyr/dt-bindings/interrupt-controller/esp32s3-xtensa-intmux.h>
-#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 
 / {
 	aliases {

--- a/include/zephyr/dt-bindings/pinctrl/silabs/xg28-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/silabs/xg28-pinctrl.h
@@ -11,7 +11,7 @@
 #ifndef ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG28_PINCTRL_H_
 #define ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG28_PINCTRL_H_
 
-#include <dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
+#include <zephyr/dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
 
 #define SILABS_DBUS_ACMP0_ACMPOUT(port, pin) SILABS_DBUS(port, pin, 16, 1, 0, 1)
 

--- a/samples/bluetooth/bap_broadcast_sink/app.overlay
+++ b/samples/bluetooth/bap_broadcast_sink/app.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/usb/audio.h>
+#include <zephyr/dt-bindings/usb/audio.h>
 
 / {
 	uac2_microphone: usb_audio2 {

--- a/samples/bluetooth/bap_broadcast_source/app.overlay
+++ b/samples/bluetooth/bap_broadcast_source/app.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/usb/audio.h>
+#include <zephyr/dt-bindings/usb/audio.h>
 
 / {
 	uac2_broadcaster: usb_audio2 {

--- a/samples/drivers/sent/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/samples/drivers/sent/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/sent/sent.h>
+#include <zephyr/dt-bindings/sent/sent.h>
 
 / {
 	aliases {

--- a/samples/subsys/usb/uac2_explicit_feedback/app.overlay
+++ b/samples/subsys/usb/uac2_explicit_feedback/app.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/usb/audio.h>
+#include <zephyr/dt-bindings/usb/audio.h>
 
 / {
 	uac2_headphones: usb_audio2 {

--- a/samples/subsys/usb/uac2_implicit_feedback/app.overlay
+++ b/samples/subsys/usb/uac2_implicit_feedback/app.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/usb/audio.h>
+#include <zephyr/dt-bindings/usb/audio.h>
 
 / {
 	uac2_headset: usb_audio2 {

--- a/samples/subsys/usb_c/sink/boards/b_g474e_dpow1.overlay
+++ b/samples/subsys/usb_c/sink/boards/b_g474e_dpow1.overlay
@@ -5,7 +5,7 @@
  *
  */
 
-#include <dt-bindings/usb-c/pd.h>
+#include <zephyr/dt-bindings/usb-c/pd.h>
 
 / {
 	aliases {

--- a/samples/subsys/usb_c/sink/boards/numaker_m2l31ki.overlay
+++ b/samples/subsys/usb_c/sink/boards/numaker_m2l31ki.overlay
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include <dt-bindings/usb-c/pd.h>
+#include <zephyr/dt-bindings/usb-c/pd.h>
 
 / {
 	aliases {

--- a/samples/subsys/usb_c/sink/boards/stm32g081b_eval.overlay
+++ b/samples/subsys/usb_c/sink/boards/stm32g081b_eval.overlay
@@ -5,7 +5,7 @@
  *
  */
 
-#include <dt-bindings/usb-c/pd.h>
+#include <zephyr/dt-bindings/usb-c/pd.h>
 
 / {
 	aliases {

--- a/samples/subsys/usb_c/sink/boards/weact_stm32g431_core.overlay
+++ b/samples/subsys/usb_c/sink/boards/weact_stm32g431_core.overlay
@@ -5,7 +5,7 @@
  *
  */
 
-#include <dt-bindings/usb-c/pd.h>
+#include <zephyr/dt-bindings/usb-c/pd.h>
 
 &adc2 {
 	status = "okay";

--- a/samples/subsys/usb_c/source/boards/stm32g081b_eval.overlay
+++ b/samples/subsys/usb_c/source/boards/stm32g081b_eval.overlay
@@ -5,7 +5,7 @@
  *
  */
 
-#include <dt-bindings/usb-c/pd.h>
+#include <zephyr/dt-bindings/usb-c/pd.h>
 
 / {
 	aliases {

--- a/tests/bluetooth/shell/usb_audio.overlay
+++ b/tests/bluetooth/shell/usb_audio.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/usb/audio.h>
+#include <zephyr/dt-bindings/usb/audio.h>
 
 / {
 	uac2_headset: usb_audio2 {

--- a/tests/drivers/adc/adc_accuracy_test/boards/sltb010a.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/sltb010a.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2025 Silicon Laboratories Inc.
  */
 
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 
 / {
 	zephyr,user {

--- a/tests/drivers/adc/adc_accuracy_test/boards/slwrb4180a.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/slwrb4180a.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2025 Silicon Laboratories Inc.
  */
 
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 
 / {
 	zephyr,user {

--- a/tests/drivers/adc/adc_accuracy_test/boards/xg23_rb4210a.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/xg23_rb4210a.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2025 Silicon Laboratories Inc.
  */
 
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 
 / {
 	zephyr,user {

--- a/tests/drivers/adc/adc_api/boards/sltb010a.overlay
+++ b/tests/drivers/adc/adc_api/boards/sltb010a.overlay
@@ -6,7 +6,7 @@
  *
  */
 
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 
 / {
 	zephyr,user {

--- a/tests/drivers/adc/adc_api/boards/slwrb4180a.overlay
+++ b/tests/drivers/adc/adc_api/boards/slwrb4180a.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2025 Silicon Laboratories Inc.
  */
 
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 
 / {
 	zephyr,user {

--- a/tests/drivers/adc/adc_api/boards/xg23_rb4210a.overlay
+++ b/tests/drivers/adc/adc_api/boards/xg23_rb4210a.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2025 Silicon Laboratories Inc.
  */
 
-#include <dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
 
 / {
 	zephyr,user {

--- a/tests/drivers/gpio/gpio_api_1pin/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -5,7 +5,7 @@
  */
 
 #include <nxp/s32/S32Z27-BGA594-pinctrl.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	aliases {

--- a/tests/drivers/gpio/gpio_api_1pin/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -5,7 +5,7 @@
  */
 
 #include <nxp/s32/S32Z27-BGA594-pinctrl.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	aliases {

--- a/tests/drivers/gpio/gpio_get_direction/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/gpio/gpio_get_direction/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	aliases {

--- a/tests/drivers/gpio/gpio_get_direction/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/gpio/gpio_get_direction/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	aliases {

--- a/tests/drivers/sent/sent_api/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/sent/sent_api/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/sent/sent.h>
+#include <zephyr/dt-bindings/sent/sent.h>
 
 / {
 	aliases {

--- a/tests/drivers/spi/spi_loopback/boards/bg29_rb4420a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/bg29_rb4420a.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg29-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg29-pinctrl.h>
 
 /*
  * Connect EXP4 (PC0) and EXP6 (PC1) of the Expansion Pin header

--- a/tests/drivers/spi/spi_loopback/boards/gd32f403z_eval.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f403z_eval.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
  */
 
-#include <dt-bindings/dma/gd32_dma.h>
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 &dma0 {
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/gd32f407v_start.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f407v_start.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
  */
 
-#include <dt-bindings/dma/gd32_dma.h>
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 &dma1 {
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/gd32f450i_eval.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f450i_eval.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
  */
 
-#include <dt-bindings/dma/gd32_dma.h>
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 &dma1 {
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/gd32f450v_start.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f450v_start.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
  */
 
-#include <dt-bindings/dma/gd32_dma.h>
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 &dma1 {
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/gd32f450z_eval.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f450z_eval.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
  */
 
-#include <dt-bindings/dma/gd32_dma.h>
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 &dma1 {
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/gd32f470i_eval.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f470i_eval.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
  */
 
-#include <dt-bindings/dma/gd32_dma.h>
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 &dma1 {
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/gd32vf103c_starter.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32vf103c_starter.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
  */
 
-#include <dt-bindings/dma/gd32_dma.h>
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 &dma0 {
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/gd32vf103v_eval.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32vf103v_eval.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
  */
 
-#include <dt-bindings/dma/gd32_dma.h>
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 &dma0 {
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/longan_nano.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/longan_nano.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
  */
 
-#include <dt-bindings/dma/gd32_dma.h>
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 &dma0 {
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/longan_nano_gd32vf103_lite.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/longan_nano_gd32vf103_lite.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
  */
 
-#include <dt-bindings/dma/gd32_dma.h>
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 &dma0 {
 	status = "okay";

--- a/tests/drivers/spi/spi_loopback/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/xg24_rb4187c.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
 
 &pinctrl {
 	eusart1_default: eusart1_default {

--- a/tests/drivers/spi/spi_loopback/boards/xg29_rb4412a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/xg29_rb4412a.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg29-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg29-pinctrl.h>
 
 /*
  * Connect EXP4 (PC0) and EXP6 (PC1) of the Expansion Pin header

--- a/tests/subsys/usb/device_next/build_all.overlay
+++ b/tests/subsys/usb/device_next/build_all.overlay
@@ -6,7 +6,7 @@
 
 /delete-node/ &zephyr_udc0;
 
-#include <dt-bindings/usb/audio.h>
+#include <zephyr/dt-bindings/usb/audio.h>
 
 / {
 	uac2_headphones: usb_audio2 {

--- a/tests/subsys/usb/uac2/app.overlay
+++ b/tests/subsys/usb/uac2/app.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/usb/audio.h>
+#include <zephyr/dt-bindings/usb/audio.h>
 
 / {
 	uac2_headset: usb_audio2 {


### PR DESCRIPTION
Many dts/dtsi files where its dt-bindings are in-tree
do not include zephyr prefix in the #include path.
Add it to make it consistent globally.

dt-bindings that resides in hal can not be changed.