### PR TITLE
doc: services: serialization: add JSON and CBOR doc pages

### DIFF
--- a/doc/services/misc.rst
+++ b/doc/services/misc.rst
@@ -19,11 +19,6 @@ CRC
 Structured Data APIs
 ********************
 
-JSON
-====
-
-.. doxygengroup:: json
-
 JWT
 ===
 

--- a/doc/services/serialization/cbor.rst
+++ b/doc/services/serialization/cbor.rst
@@ -1,0 +1,22 @@
+.. _cbor_api:
+
+CBOR
+####
+
+`CBOR <https://cbor.io/>`_ (Concise Binary Object Representation) is a data format whose design
+goals include the possibility of extremely small code size, fairly small message size, and
+extensibility without the need for version negotiation.
+
+Zephyr provides support for CBOR via the `zcbor`_ library, which is pulled in as a West module.
+
+Configuration
+*************
+
+To enable CBOR support, enable the :kconfig:option:`CONFIG_ZCBOR` Kconfig option.
+
+API Reference
+*************
+
+The zcbor library provides its own API documentation, please refer to it for more information.
+
+.. _`zcbor`: https://github.com/zephyrproject-rtos/zcbor

--- a/doc/services/serialization/index.rst
+++ b/doc/services/serialization/index.rst
@@ -9,4 +9,5 @@ structured data with a known format on-the-wire.
 .. toctree::
    :maxdepth: 1
 
+   json.rst
    nanopb.rst

--- a/doc/services/serialization/index.rst
+++ b/doc/services/serialization/index.rst
@@ -9,5 +9,6 @@ structured data with a known format on-the-wire.
 .. toctree::
    :maxdepth: 1
 
+   cbor.rst
    json.rst
    nanopb.rst

--- a/doc/services/serialization/json.rst
+++ b/doc/services/serialization/json.rst
@@ -1,0 +1,81 @@
+.. _json_api:
+
+JSON
+####
+
+Zephyr provides a JSON library that can be used to encode and decode JSON data.
+
+Usage
+*****
+
+Defining the Data Structure
+===========================
+
+First, define the C structure that corresponds to the JSON object and the descriptor that maps the
+structure fields to JSON tokens.
+
+.. code-block:: c
+
+   #include <zephyr/data/json.h>
+
+   struct foo {
+       int bar;
+       const char *baz;
+   };
+
+   static const struct json_obj_descr foo_descr[] = {
+       JSON_OBJ_DESCR_PRIM(struct foo, bar, JSON_TOK_NUMBER),
+       JSON_OBJ_DESCR_PRIM(struct foo, baz, JSON_TOK_STRING),
+   };
+
+Encoding
+========
+
+To encode a C structure into a JSON string, use :c:func:`json_obj_encode_buf`.
+
+.. code-block:: c
+
+   void encode_example(void)
+   {
+       struct foo data = { .bar = 42, .baz = "hello" };
+       char buffer[128];
+       int ret;
+
+       ret = json_obj_encode_buf(foo_descr, ARRAY_SIZE(foo_descr),
+                                 &data,
+                                 buffer, sizeof(buffer));
+       if (ret < 0) {
+           /* handle error */
+       }
+   }
+
+Decoding
+========
+
+To decode a JSON string into a C structure, use :c:func:`json_obj_parse`.
+
+.. code-block:: c
+
+   void decode_example(void)
+   {
+       struct foo data;
+       const char *json_text = "{\"bar\": 42, \"baz\": \"hello\"}";
+       int ret;
+
+       ret = json_obj_parse(json_text, strlen(json_text),
+                            foo_descr, ARRAY_SIZE(foo_descr),
+                            &data);
+       if (ret < 0) {
+           /* handle error */
+       }
+   }
+
+Configuration
+*************
+
+To enable JSON support, enable the :kconfig:option:`CONFIG_JSON_LIBRARY` Kconfig option.
+
+API Reference
+*************
+
+.. doxygengroup:: json

--- a/samples/net/secure_mqtt_sensor_actuator/README.rst
+++ b/samples/net/secure_mqtt_sensor_actuator/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: secure-mqtt-sensor-actuator
    :name: Secure MQTT Sensor/Actuator
-   :relevant-api: mqtt_socket sensor_interface
+   :relevant-api: mqtt_socket sensor_interface json
 
    Implement an MQTT-based IoT sensor/actuator device
 

--- a/samples/net/sockets/http_server/README.rst
+++ b/samples/net/sockets/http_server/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: sockets-http-server
    :name: HTTP Server
-   :relevant-api: http_service http_server tls_credentials
+   :relevant-api: http_service http_server tls_credentials json
 
    Implement an HTTP(s) Server demonstrating various resource types.
 

--- a/samples/subsys/mgmt/hawkbit/README.rst
+++ b/samples/subsys/mgmt/hawkbit/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: hawkbit-api
    :name: Eclipse hawkBit Direct Device Integration API
-   :relevant-api: hawkbit
+   :relevant-api: hawkbit json
 
    Update a device using Eclipse hawkBit DDI API.
 


### PR DESCRIPTION
[Serialization services docs](https://docs.zephyrproject.org/latest/services/serialization/index.html) only had tinypb, so add JSON and CBOR too.

New pages in CI accessible from here: https://builds.zephyrproject.io/zephyr/pr/100055/docs/services/serialization/index.html