### PR TITLE
boards: shields: m5stack_cardputer: Correct the display parameter

### DIFF
--- a/boards/shields/m5stack_cardputer/m5stack_cardputer.overlay
+++ b/boards/shields/m5stack_cardputer/m5stack_cardputer.overlay
@@ -33,7 +33,7 @@
 
 			width = <135>;
 			height = <240>;
-			x-offset = <53>;
+			x-offset = <52>;
 			y-offset = <40>;
 
 			vcom = <0x28>;


### PR DESCRIPTION
Refer to the M5Stack official code, it need to correct the value of x-offset of st7789v display driver from 53 to 52, or the leftmost column of the LCD shows an anomaly.