### PR TITLE
RTIO: Add timeout option for consuming cqe items

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1182,6 +1182,23 @@ typedef void (*sensor_processing_callback_t)(int result, uint8_t *buf, uint32_t 
  */
 void sensor_processing_with_callback(struct rtio *ctx, sensor_processing_callback_t cb);
 
+/**
+ * @brief Helper function for common processing of sensor data with timeout
+ *
+ * Similar to @ref sensor_processing_with_callback but with a timeout. If no data comes
+ * through in the given time, the callback is trigerred with -ETIMEDOUT so user can act
+ * accordingly.
+ *
+ * @param[in] ctx The RTIO context to wait on
+ * @param[in] cb Callback to call when data is ready for processing
+ * @param[in] timeout Time to wait for a completion event, otherwise time-out
+ *
+ * @return 0 on success
+ * @return -ETIMEDOUT if no response was received.
+ */
+int sensor_processing_cb_with_timeout(struct rtio *ctx, sensor_processing_callback_t cb,
+				       k_timeout_t timeout);
+
 #endif /* defined(CONFIG_SENSOR_ASYNC_API) || defined(__DOXYGEN__) */
 
 /**


### PR DESCRIPTION
This PR adds an RTIO API to consume CQE items with a timeout parameter, allowing users to provide error-handling to streaming clients (e.g: if no data comes through in 100-ms assume it won't come vs block indefinitely).

This could happen for various reasons (e.g: no CQE items left to give back, or a bug in the RTIO IODEV code that causes it to omit the result). In any case, we want to provide a forgiving way to recover from these scenarios.

Additionally, this is extended to the sensor API, with a return code when consuming messages.

> [!NOTE]
> Marked as DNM as semaphore-less implementation isn't done yet.