### PR TITLE
Add mcxaxx6 arduino gpio and usb support

### DIFF
--- a/boards/nxp/frdm_mcxaxx6/board.c
+++ b/boards/nxp/frdm_mcxaxx6/board.c
@@ -315,6 +315,11 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kFRO_HF_DIV_to_FLEXCAN0);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb))
+	RESET_PeripheralReset(kUSB0_RST_SHIFT_RSTn);
+	CLOCK_EnableUsbfsClock();
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 }

--- a/boards/nxp/frdm_mcxaxx6/board_common.dtsi
+++ b/boards/nxp/frdm_mcxaxx6/board_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	compatible = "nxp,mcx";
@@ -63,6 +64,35 @@
 			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_1>;
 		};
+	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio2 5 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio2 7 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio3 30 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio1 0 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio2 3 0>,   /* GPIO, Not a RX */
+			   <ARDUINO_HEADER_R3_D1 0 &gpio2 2 0>,   /* GPIO, Not a TX */
+			   <ARDUINO_HEADER_R3_D2 0 &gpio3 31 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio3 14 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio4 7 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio3 1 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio3 17 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio3 22 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio4 3 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio3 13 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio3 11 0>,  /* CS */
+			   <ARDUINO_HEADER_R3_D11 0 &gpio3 8 0>, /* MOSI */
+			   <ARDUINO_HEADER_R3_D12 0 &gpio3 9 0>, /* MISO */
+			   <ARDUINO_HEADER_R3_D13 0 &gpio3 10 0>, /* SCK */
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 8 0>,  /* SDA */
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 9 0>;  /* SCL */
 	};
 };
 

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.dts
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.dts
@@ -47,3 +47,8 @@
 &flexio0 {
 	status = "okay";
 };
+
+zephyr_udc0: &usb {
+	status = "okay";
+	num-bidir-endpoints = <8>;
+};

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.yaml
@@ -26,4 +26,5 @@ supported:
   - i3c
   - entropy
   - can
+  - arduino_gpio
 vendor: nxp

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.yaml
@@ -27,4 +27,5 @@ supported:
   - entropy
   - can
   - arduino_gpio
+  - usbd
 vendor: nxp

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa346.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa346.yaml
@@ -25,4 +25,5 @@ supported:
   - dma
   - opamp
   - can
+  - arduino_gpio
 vendor: nxp

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.dts
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.dts
@@ -58,3 +58,8 @@
 &flexio0 {
 	status = "okay";
 };
+
+zephyr_udc0: &usb {
+	status = "okay";
+	num-bidir-endpoints = <8>;
+};

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.yaml
@@ -28,4 +28,5 @@ supported:
   - entropy
   - can
   - arduino_gpio
+  - usbd
 vendor: nxp

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.yaml
@@ -27,4 +27,5 @@ supported:
   - opamp
   - entropy
   - can
+  - arduino_gpio
 vendor: nxp

--- a/dts/arm/nxp/nxp_mcxa346.dtsi
+++ b/dts/arm/nxp/nxp_mcxa346.dtsi
@@ -10,3 +10,4 @@
 /delete-node/ &flexio0;
 /delete-node/ &trng;
 /delete-node/ &flexcan1;
+/delete-node/ &usb;

--- a/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
@@ -576,6 +576,16 @@
 			number-of-mb-fd = <7>;
 			status = "disabled";
 		};
+
+		usb: usbd@400a4000 {
+			compatible = "nxp,kinetis-usbd";
+			reg = <0x400a4000 0x1000>;
+			interrupts = <36 1>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <16>;
+			status = "disabled";
+			no-voltage-regulator;
+		};
 	};
 };
 


### PR DESCRIPTION
Add arduino_header node labels to frdm_mcxa366,frdm_mcxa346 and frdm_mcxa266 device tree board definition.
Add usb support for frdm_mcxa366 and frdmmcxa266 boards.