### PR TITLE
drivers: i2c: support nuvoton m333x series

### DIFF
--- a/dts/arm/nuvoton/m333x.dtsi
+++ b/dts/arm/nuvoton/m333x.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/clock/numaker_m333x_clock.h>
 #include <zephyr/dt-bindings/reset/numaker_m333x_reset.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	chosen {
@@ -237,6 +238,42 @@
 				  NUMAKER_CLK_CLKDIV1_CANFD1(1)>;
 			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
 			status = "disabled";
+		};
+
+		i2c0: i2c@40080000 {
+			compatible = "nuvoton,numaker-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			reg = <0x40080000 0x1000>;
+			interrupts = <38 0>;
+			resets = <&rst NUMAKER_I2C0_RST>;
+			clocks = <&pcc NUMAKER_I2C0_MODULE 0 0>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1: i2c@40081000 {
+			compatible = "nuvoton,numaker-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			reg = <0x40081000 0x1000>;
+			interrupts = <39 0>;
+			resets = <&rst NUMAKER_I2C1_RST>;
+			clocks = <&pcc NUMAKER_I2C1_MODULE 0 0>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c2: i2c@40082000 {
+			compatible = "nuvoton,numaker-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			reg = <0x40082000 0x1000>;
+			interrupts = <82 0>;
+			resets = <&rst NUMAKER_I2C2_RST>;
+			clocks = <&pcc NUMAKER_I2C2_MODULE 0 0>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		rtc: rtc@40041000 {

--- a/tests/drivers/i2c/i2c_target_api/boards/numaker_m3334ki.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/numaker_m3334ki.conf
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Nuvoton Technology Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_I2C=y
+CONFIG_I2C_TARGET=y

--- a/tests/drivers/i2c/i2c_target_api/boards/numaker_m3334ki.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/numaker_m3334ki.overlay
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Nuvoton Technology Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	i2c1_default: i2c1_default {
+		group0 {
+			pinmux = <PB2MFP_I2C1_SDA>,  /* UNO D0 */
+				 <PB3MFP_I2C1_SCL>;  /* UNO D1 */
+		};
+	};
+
+	i2c0_default: i2c0_default {
+		group0 {
+			pinmux = <PC0MFP_I2C0_SDA>,  /* UNO D14 */
+				 <PC1MFP_I2C0_SCL>;  /* UNO D15 */
+		};
+	};
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		address-width = <16>;
+		size = <1024>;
+	};
+};
+
+&i2c0 {
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		address-width = <16>;
+		size = <1024>;
+	};
+};


### PR DESCRIPTION
This adds support for I2C driver for Nuvoton NuMaker M3331 SoC series.