### PR TITLE
Bluetooth: Classic: HFP: Fix SCO conn cannot be released issue

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_ag_internal.h
@@ -291,7 +291,7 @@ struct bt_hfp_ag {
 	struct bt_sco_chan sco_chan;
 
 	/* SCO connect */
-	struct bt_conn *sco_conn;
+	atomic_ptr_t sco_conn;
 
 	/* SDP discover params */
 	struct bt_sdp_discover_params sdp_param;

--- a/subsys/bluetooth/host/classic/hfp_hf_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_hf_internal.h
@@ -215,7 +215,7 @@ struct bt_hfp_hf {
 	/* SCO Channel */
 	struct bt_sco_chan chan;
 	/* SCO connect */
-	struct bt_conn *sco_conn;
+	atomic_ptr_t sco_conn;
 
 	/* SDP discover params */
 	struct bt_sdp_discover_params sdp_param;


### PR DESCRIPTION
There is an issue found that the sco conn cannot be released when the SCO has been disconnected. The sco conn count is referred in the sco connected callback due to the `sco_conn` is NULL while `sco_conn` should not be NULL when the sco connected callback is triggered.

It is a race condition issue where the sco connected callback is triggered before `sco_conn` is updated. The sco conn reference count has been referred incorrectly, actually it should not be referred.

Replace direct pointer access to `sco_conn` with atomic operations to prevent race conditions in concurrent SCO connection scenarios.

If the value of `sco_conn` is not NULL when trying to set the return value of `bt_conn_create_sco()` to `sco_conn`, it means the race condition occurs. In this situation, discount the sco conn reference count to fix the issue.