### PR TITLE
Bluetooth: Classic: conn: Fix br conn cannot be found issue

### DIFF
--- a/subsys/bluetooth/host/classic/conn_br.c
+++ b/subsys/bluetooth/host/classic/conn_br.c
@@ -90,13 +90,13 @@ struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 	cp->allow_role_switch = param->allow_role_switch ? 0x01 : 0x00;
 	cp->clock_offset = 0x0000; /* TODO used cached clock offset */
 
+	bt_conn_set_state(conn, BT_CONN_INITIATING);
+	conn->role = BT_CONN_ROLE_CENTRAL;
+
 	if (bt_hci_cmd_send_sync(BT_HCI_OP_CONNECT, buf, NULL) < 0) {
 		bt_conn_unref(conn);
 		return NULL;
 	}
-
-	bt_conn_set_state(conn, BT_CONN_INITIATING);
-	conn->role = BT_CONN_ROLE_CENTRAL;
 
 	return conn;
 }


### PR DESCRIPTION
There is a corner case that the connect complete event is notified before the function `bt_hci_cmd_send_sync()` returns. Because the created conn object is in the state of `BT_CONN_DISCONNECTED`, it cannot be found in the connect complete event. As a result, the connect can not established normally.

Fix the issue by setting the connect state and role before calling the function `bt_hci_cmd_send_sync()`.