### PR TITLE
drivers: mipi_dsi: Add support Renesas RA MIPI DSI for RA8P1

### DIFF
--- a/boards/renesas/ek_ra8p1/Kconfig.defconfig
+++ b/boards/renesas/ek_ra8p1/Kconfig.defconfig
@@ -10,4 +10,22 @@ config SD_CMD_TIMEOUT
 
 endif # DISK_DRIVER_SDMMC
 
+if DISPLAY
+
+config MEMC
+	default y
+
+config RENESAS_RA_GLCDC_FRAME_BUFFER_SECTION
+	default ".sdram"
+	depends on RENESAS_RA_GLCDC
+
+if LVGL
+
+config LV_Z_VDB_CUSTOM_SECTION
+	default y
+
+endif # LVGL
+
+endif # DISPLAY
+
 endif # BOARD_EK_RA8P1

--- a/boards/renesas/ek_ra8p1/ek_ra8p1.dtsi
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1.dtsi
@@ -143,6 +143,12 @@
 
 &ioport1 {
 	status = "okay";
+
+	mipi_dphy_gpio: mipi-dphy-enable {
+		gpio-hog;
+		gpios = <8 GPIO_ACTIVE_LOW>;
+		output-low;
+	};
 };
 
 &ioport2 {

--- a/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.dts
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.dts
@@ -25,6 +25,19 @@
 	aliases {
 		led0 = &led1;
 		sw0 = &button0;
+		mipi-dsi = &mipi_dsi;
+	};
+
+	renesas_mipi_connector: mipi-connector {
+		compatible = "renesas,ra-gpio-mipi-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <14 0 &ioport5 11 0>, /* IIC_SDA */
+			   <15 0 &ioport5 14 0>, /* DISP_BLEN */
+			   <16 0 &ioport5 12 0>, /* IIC_SCL */
+			   <17 0 &ioport1 11 0>, /* DISP_INT */
+			   <18 0 &ioport6 6 0>;  /* DISP_RST */
 	};
 };
 
@@ -171,7 +184,21 @@
 	};
 };
 
+&mipi_dsi {
+	interrupts = <24 12>, <25 12>, <26 12>, <27 12>, <28 12>, <29 12>;
+	interrupt-names = "sq0", "sq1", "vm", "rcv", "ferr", "ppi";
+};
+
+&lcdif {
+	interrupts = <30 1>;
+	interrupt-names = "line";
+};
+
 zephyr_lcdif: &lcdif {};
+
+zephyr_mipi_dsi: &mipi_dsi {};
+
+renesas_mipi_i2c: &iic1 {};
 
 pmod_sd_shield: &sdhc0 {};
 

--- a/boards/shields/rtkmipilcdb00000be/boards/ek_ra8p1_r7ka8p1kflcac_cm85.conf
+++ b/boards/shields/rtkmipilcdb00000be/boards/ek_ra8p1_r7ka8p1kflcac_cm85.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_LV_Z_FLUSH_THREAD=n
+CONFIG_LV_Z_BITS_PER_PIXEL=16
+CONFIG_LV_COLOR_DEPTH_16=y

--- a/boards/shields/rtkmipilcdb00000be/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
+++ b/boards/shields/rtkmipilcdb00000be/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mipi_dphy_gpio {
+	/delete-property/ output-low;
+	output-high;
+};
+
+&renesas_mipi_i2c {
+	clock-frequency = <DT_FREQ_K(100)>;
+};
+
+&zephyr_lcdif {
+	input-pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+};
+
+&zephyr_mipi_dsi {
+	pll-div = <3>;
+	pll-mul-int = <125>;
+	pll-mul-frac = "0.00";
+	pll-out-div = <1>;
+	lp-divisor = <5>;
+	ulps-wakeup-period = <97>;
+	video-mode-delay = <186>;
+	timing = <1183 11 26 40>;
+
+	phys-timing {
+		t-init = <74999>;
+		t-clk-prep = <9>;
+		t-hs-prep = <6>;
+		t-lp-exit = <7>;
+		dphytim4 = <28 1 20 7>;
+		dphytim5 = <19 8 12>;
+	};
+};

--- a/drivers/mipi_dsi/dsi_renesas_ra.c
+++ b/drivers/mipi_dsi/dsi_renesas_ra.c
@@ -224,9 +224,19 @@ static int mipi_dsi_renesas_ra_init(const struct device *dev)
 	return 0;
 }
 
+#if defined(CONFIG_SOC_SERIES_RA8D1)
+#define RENESAS_RA_PHY_PLL_MUL_INT_MIN 20
+#define RENESAS_RA_PHY_PLL_MUL_INT_MAX 180
+#elif defined(CONFIG_SOC_SERIES_RA8P1)
+#define RENESAS_RA_PHY_PLL_MUL_INT_MIN 40
+#define RENESAS_RA_PHY_PLL_MUL_INT_MAX 375
+#else
+#error "Unsupported SoC series"
+#endif
+
 #define RENESAS_RA_MIPI_PHYS_SETTING_DEFINE(n)                                                     \
 	static const mipi_phy_timing_t mipi_phy_##n##_timing = {                                   \
-		.t_init = CLAMP(DT_PROP(DT_INST_CHILD(n, phys_timing), t_init), 0, 0x7FFF),        \
+		.t_init = CLAMP(DT_PROP(DT_INST_CHILD(n, phys_timing), t_init), 0, 0x7FFFF),       \
 		.dphytim2_b =                                                                      \
 			{                                                                          \
 				.t_clk_prep =                                                      \
@@ -266,8 +276,12 @@ static int mipi_dsi_renesas_ra_init(const struct device *dev)
 		.pll_settings =                                                                    \
 			{                                                                          \
 				.div = DT_INST_PROP(n, pll_div) - 1,                               \
+				.pll_div = DT_INST_ENUM_IDX_OR(n, pll_out_div, 0),                 \
 				.mul_frac = DT_INST_ENUM_IDX(n, pll_mul_frac),                     \
-				.mul_int = CLAMP(DT_INST_PROP(n, pll_mul_int), 20, 180) - 1,       \
+				.mul_int = CLAMP(DT_INST_PROP(n, pll_mul_int),                     \
+						 RENESAS_RA_PHY_PLL_MUL_INT_MIN,                   \
+						 RENESAS_RA_PHY_PLL_MUL_INT_MAX) -                 \
+					   1,                                                      \
 			},                                                                         \
 		.lp_divisor = CLAMP(DT_INST_PROP(n, lp_divisor), 1, 32) - 1,                       \
 		.p_timing = &mipi_phy_##n##_timing,                                                \

--- a/dts/bindings/mipi-dsi/renesas,ra-mipi-dsi.yaml
+++ b/dts/bindings/mipi-dsi/renesas,ra-mipi-dsi.yaml
@@ -23,7 +23,7 @@ properties:
     type: int
     enum: [1, 2, 3, 4]
     description:
-      PHY PLL divisor.
+      PHY PLL input frequency divisor.
 
   pll-mul-int:
     type: int
@@ -35,6 +35,12 @@ properties:
     enum: ["0.00", "0.33", "0.66", "0.50"]
     description:
       PHY PLL fractional multiplier.
+
+  pll-out-div:
+    type: int
+    enum: [1, 2, 4, 8]
+    description: |
+      PHY PLL output frequency divisor.
 
   lp-divisor:
     type: int

--- a/samples/modules/lvgl/demos/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
+++ b/samples/modules/lvgl/demos/boards/ek_ra8p1_r7ka8p1kflcac_cm85.overlay
@@ -4,10 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&code_mram_cm85 {
-	reg = <0x2000000 DT_SIZE_K(950)>;
+/delete-node/ &code_mram_cm85;
+/delete-node/ &code_mram_cm33;
+
+/ {
+	chosen {
+		/delete-property/ zephyr,code-partition;
+	};
 };
 
-&code_mram_cm33 {
-	reg = <0x20ed800 DT_SIZE_K(74)>;
+&mram_ctrl {
+	code_mram_cm85: mram@2000000 {
+		compatible = "renesas,ra-nv-mram";
+		reg = <0x2000000 DT_SIZE_M(1)>;
+		write-block-size = <1>;
+		erase-block-size = <32>;
+	};
 };

--- a/samples/modules/lvgl/demos/sample.yaml
+++ b/samples/modules/lvgl/demos/sample.yaml
@@ -65,7 +65,9 @@ tests:
     tags:
       - shield
   sample.modules.lvgl.demos.rtkmipilcdb00000be:
-    platform_allow: ek_ra8d1
+    platform_allow:
+      - ek_ra8d1
+      - ek_ra8p1/r7ka8p1kflcac/cm85
     extra_args: SHIELD=rtkmipilcdb00000be
     tags:
       - shield


### PR DESCRIPTION
- Update `dsi_renesas_ra.c` driver and `renesas,ra-mipi-dsi.yaml` binding to align with `RA8P1` support
- Add dts node for MIPI support for `ek_ra8p1/r7ka8p1kflcac/cm85`
- Add `rtkmipilcdb00000be` shield support for `ek_ra8p1/r7ka8p1kflcac/cm85`
- Add support `samples/modules/lvgl/demos` for `ek_ra8p1/r7ka8p1kflcac/cm85` running with the `rtkmipilcdb00000be` shield