### PR TITLE
silabs: siwx91x: Fix to enable PSRAM half-sleep support to reduce sleep current

### DIFF
--- a/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a.dts
+++ b/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a.dts
@@ -120,6 +120,7 @@ zephyr_i2c: &ulpi2c {
 	device-id = [0d 5d 00 00 00 00 00 00];
 	fast-freq = <DT_FREQ_M(144)>;
 	normal-freq = <DT_FREQ_M(33)>;
+	external-ldo;
 	status = "okay";
 
 	psram: psram@a000000 {

--- a/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
@@ -125,6 +125,8 @@
 	device-id = [0d 5d 00 00 00 00 00 00];
 	fast-freq = <DT_FREQ_M(144)>;
 	normal-freq = <DT_FREQ_M(33)>;
+	half-sleep-supported;
+	external-ldo;
 	status = "okay";
 
 	psram: psram@a000000 {

--- a/dts/bindings/memory-controllers/silabs,siwx91x-qspi-memory.yaml
+++ b/dts/bindings/memory-controllers/silabs,siwx91x-qspi-memory.yaml
@@ -42,3 +42,17 @@ properties:
   fast-freq:
     type: int
     required: true
+
+  half-sleep-supported:
+    type: boolean
+    description: |
+      Indicates that the attached PSRAM supports entry into and exit from
+      half-sleep mode using the C0 half-sleep command sequence. When set to
+      true, the driver will enable low-power sequences utilizing half-sleep
+      mode. If false, half-sleep features are disabled.
+
+  external-ldo:
+    type: boolean
+    description: |
+      Present if the PSRAM is powered from the external LDO.
+      If absent, internal LDO (PSRAM) is assumed.

--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -105,10 +105,29 @@ zephyr_library_sources_ifdef(CONFIG_ENTROPY_SILABS_SIWX91X
   ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_rng.c
 )
 
-zephyr_library_sources_ifdef(CONFIG_MEMC_SILABS_SIWX91X_QSPI
-  ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_psram.c
-  ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_qspi.c
-)
+if(CONFIG_MEMC_SILABS_SIWX91X_QSPI)
+  zephyr_library_sources(
+    ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_psram.c
+    ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_qspi.c
+    ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/unified_api/src/rsi_d_cache.c
+  )
+  zephyr_compile_definitions(
+    SLI_SI91X_MCU_PSRAM_PRESENT
+    SLI_SI91X_MCU_ENABLE_PSRAM_FEATURE
+    SL_SI91X_REQUIRES_INTF_PLL
+  )
+  dt_nodelabel(memc_path NODELABEL "memc")
+  dt_prop(half_sleep PATH "${memc_path}" PROPERTY "half-sleep-supported")
+  if(half_sleep)
+    zephyr_compile_definitions(PSRAM_HALF_SLEEP_SUPPORTED)
+  endif()
+  dt_prop(ext_ldo PATH "${memc_path}" PROPERTY "external-ldo")
+  if(ext_ldo)
+    zephyr_compile_definitions(SLI_SI91X_MCU_EXTERNAL_LDO_FOR_PSRAM)
+  else()
+    zephyr_compile_definitions(SLI_SI91X_MCU_INTERNAL_LDO_FOR_PSRAM)
+  endif()
+endif() # CONFIG_MEMC_SILABS_SIWX91X_QSPI
 
 if(CONFIG_WIFI_SILABS_SIWX91X)
   zephyr_library_sources(

--- a/west.yml
+++ b/west.yml
@@ -240,7 +240,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 091a5bbd2f83b83d4f00f166c6781b19bee0d03d
+      revision: pull/155/head
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Previously, the PSRAM boards exhibited high sleep current due to lack of half-sleep support. This PR implements half-sleep mode for PSRAM, reducing power consumption during device sleep.

Changes include:
- DeviceTree and bindings updated to support 'half-sleep-supported' and 'ldo' for PSRAM
- Build system updates for necessary sources and driver flags

With these fixes, PSRAM now enters half-sleep mode correctly, resulting in lower sleep current on siwx91x-PSRAM based boards which supports half sleep mode.

Signed-off-by: S Mohamed Fiaz <Fiaz.Mohamed@silabs.com>