### PR TITLE
Bluetooth: Classic: OBEX: Fix unchecked return value issue

### DIFF
--- a/subsys/bluetooth/host/classic/obex.c
+++ b/subsys/bluetooth/host/classic/obex.c
@@ -351,8 +351,11 @@ static int obex_server_put_common(struct bt_obex_server *server, bool final, uin
 			goto failed;
 		}
 
-		if (opcode != req_code) {
-			atomic_cas(&server->_opcode, opcode, req_code);
+		if ((opcode != req_code) && !atomic_cas(&server->_opcode, opcode, req_code)) {
+			LOG_WRN("OP code mismatch %u != %u", (uint8_t)atomic_get(&server->_opcode),
+				opcode);
+			rsp_code = BT_OBEX_RSP_CODE_INTER_ERROR;
+			goto failed;
 		}
 	}
 
@@ -432,8 +435,11 @@ static int obex_server_get_common(struct bt_obex_server *server, bool final, uin
 			goto failed;
 		}
 
-		if (opcode != req_code) {
-			atomic_cas(&server->_opcode, opcode, req_code);
+		if ((opcode != req_code) && !atomic_cas(&server->_opcode, opcode, req_code)) {
+			LOG_WRN("OP code mismatch %u != %u", (uint8_t)atomic_get(&server->_opcode),
+				opcode);
+			rsp_code = BT_OBEX_RSP_CODE_INTER_ERROR;
+			goto failed;
 		}
 	}
 
@@ -569,8 +575,11 @@ static int obex_server_action_common(struct bt_obex_server *server, bool final, 
 			goto failed;
 		}
 
-		if (opcode != req_code) {
-			atomic_cas(&server->_opcode, opcode, req_code);
+		if ((opcode != req_code) && !atomic_cas(&server->_opcode, opcode, req_code)) {
+			LOG_WRN("OP code mismatch %u != %u", (uint8_t)atomic_get(&server->_opcode),
+				opcode);
+			rsp_code = BT_OBEX_RSP_CODE_INTER_ERROR;
+			goto failed;
 		}
 	}
 
@@ -1818,8 +1827,10 @@ int bt_obex_put(struct bt_obex_client *client, bool final, struct net_buf *buf)
 			return -EBUSY;
 		}
 
-		if (opcode != req_code) {
-			atomic_cas(&client->_opcode, opcode, req_code);
+		if ((opcode != req_code) && !atomic_cas(&client->_opcode, opcode, req_code)) {
+			LOG_WRN("OP code mismatch %u != %u", (uint8_t)atomic_get(&client->_opcode),
+				opcode);
+			return -EINVAL;
 		}
 	}
 
@@ -1953,8 +1964,10 @@ int bt_obex_get(struct bt_obex_client *client, bool final, struct net_buf *buf)
 			return -EBUSY;
 		}
 
-		if (opcode != req_code) {
-			atomic_cas(&client->_opcode, opcode, req_code);
+		if ((opcode != req_code) && !atomic_cas(&client->_opcode, opcode, req_code)) {
+			LOG_WRN("OP code mismatch %u != %u", (uint8_t)atomic_get(&client->_opcode),
+				opcode);
+			return -EINVAL;
 		}
 	}
 
@@ -2339,8 +2352,10 @@ int bt_obex_action(struct bt_obex_client *client, bool final, struct net_buf *bu
 			return -EBUSY;
 		}
 
-		if (opcode != req_code) {
-			atomic_cas(&client->_opcode, opcode, req_code);
+		if ((opcode != req_code) && !atomic_cas(&client->_opcode, opcode, req_code)) {
+			LOG_WRN("OP code mismatch %u != %u", (uint8_t)atomic_get(&client->_opcode),
+				opcode);
+			return -EINVAL;
 		}
 	}
 


### PR DESCRIPTION
Check the return value of the function `atomic_cas()`. If the new value cannot be set for the OBEX server, return the error code `BT_OBEX_RSP_CODE_INTER_ERROR`. If the new value cannot be set for the OBEX client, return the error code `-EINVAL`.

Fix #100012
Fix #100018
Fix #100019
Fix #100021
Fix #100022
Fix #100023