### PR TITLE
samples: bluetooth: peripheral_past: Fix uninitialized parameter

### DIFF
--- a/samples/bluetooth/peripheral_past/src/main.c
+++ b/samples/bluetooth/peripheral_past/src/main.c
@@ -139,6 +139,7 @@ int main(void)
 	printk("Subscribing to periodic advertising sync transfers\n");
 	past_param.skip = 1;
 	past_param.timeout = 1000; /* 10 seconds */
+	past_param.options = BT_LE_PER_ADV_SYNC_TRANSFER_OPT_NONE;
 	err = bt_le_per_adv_sync_transfer_subscribe(NULL /* any peer */,
 						    &past_param);
 	if (err) {


### PR DESCRIPTION
The uninitialized past_param.options is uncertain and causes bt_le_per_adv_sync_transfer_subscribe() returning error.

> PAST subscribe failed (err -22)