### PR TITLE
drivers: sensor: lsm6dso: Add support for Accel LP filter

### DIFF
--- a/drivers/sensor/st/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.c
@@ -700,25 +700,25 @@ static int lsm6dso_init_chip(const struct device *dev)
 	 * set the bank now.
 	 */
 	if (lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK) < 0) {
-		LOG_DBG("Failed to set user bank");
+		LOG_ERR("Failed to set user bank");
 		return -EIO;
 	}
 
 	if (lsm6dso_device_id_get(ctx, &chip_id) < 0) {
-		LOG_DBG("Failed reading chip id");
+		LOG_ERR("Failed reading chip id");
 		return -EIO;
 	}
 
 	LOG_INF("chip id 0x%x", chip_id);
 
 	if (chip_id != LSM6DSO_ID) {
-		LOG_DBG("Invalid chip id 0x%x", chip_id);
+		LOG_ERR("Invalid chip id 0x%x", chip_id);
 		return -EIO;
 	}
 
 	/* I3C disable stay preserved after s/w reset */
 	if (lsm6dso_i3c_disable_set(ctx, LSM6DSO_I3C_DISABLE) < 0) {
-		LOG_DBG("Failed to disable I3C");
+		LOG_ERR("Failed to disable I3C");
 		return -EIO;
 	}
 
@@ -726,7 +726,7 @@ static int lsm6dso_init_chip(const struct device *dev)
 	 * must be disabled, followed by a 300 μs wait."
 	 */
 	if (lsm6dso_sh_master_get(ctx, &master_on) < 0) {
-		LOG_DBG("Failed to get I2C_MASTER status");
+		LOG_ERR("Failed to get I2C_MASTER status");
 		return -EIO;
 	}
 	if (master_on) {
@@ -737,6 +737,7 @@ static int lsm6dso_init_chip(const struct device *dev)
 
 	/* reset device */
 	if (lsm6dso_reset_set(ctx, 1) < 0) {
+		LOG_ERR("Failed to reset device");
 		return -EIO;
 	}
 
@@ -803,12 +804,12 @@ static int lsm6dso_init_chip(const struct device *dev)
 
 	/* Set FIFO bypass mode */
 	if (lsm6dso_fifo_mode_set(ctx, LSM6DSO_BYPASS_MODE) < 0) {
-		LOG_DBG("failed to set FIFO mode");
+		LOG_ERR("failed to set FIFO mode");
 		return -EIO;
 	}
 
 	if (lsm6dso_block_data_update_set(ctx, 1) < 0) {
-		LOG_DBG("failed to set BDU mode");
+		LOG_ERR("failed to set BDU mode");
 		return -EIO;
 	}
 
@@ -826,7 +827,7 @@ static int lsm6dso_init(const struct device *dev)
 	data->dev = dev;
 
 	if (lsm6dso_init_chip(dev) < 0) {
-		LOG_DBG("failed to initialize chip");
+		LOG_ERR("failed to initialize chip");
 		return -EIO;
 	}
 

--- a/drivers/sensor/st/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.c
@@ -22,6 +22,14 @@ LOG_MODULE_REGISTER(LSM6DSO, CONFIG_SENSOR_LOG_LEVEL);
 
 static const uint16_t lsm6dso_odr_map[] = {0, 12, 26, 52, 104, 208, 417, 833,
 					1667, 3333, 6667};
+static const uint8_t lsm6dso_lp_filter_map[] = {0,
+						LSM6DSO_LP_ODR_DIV_10,
+						LSM6DSO_LP_ODR_DIV_20,
+						LSM6DSO_LP_ODR_DIV_45,
+						LSM6DSO_LP_ODR_DIV_100,
+						LSM6DSO_LP_ODR_DIV_200,
+						LSM6DSO_LP_ODR_DIV_400,
+						LSM6DSO_LP_ODR_DIV_800};
 
 static int lsm6dso_freq_to_odr_val(uint16_t freq)
 {
@@ -813,6 +821,19 @@ static int lsm6dso_init_chip(const struct device *dev)
 		return -EIO;
 	}
 
+	if (cfg->accel_lp_filter) {
+		if (lsm6dso_xl_filter_lp2_set(ctx, 1)) {
+			LOG_ERR("failed to enable low pass filter (LPF2)");
+			return -EIO;
+		}
+
+		if (lsm6dso_xl_hp_path_on_out_set(ctx,
+				lsm6dso_lp_filter_map[cfg->accel_lp_filter])) {
+			LOG_ERR("failed to configure low pass filter (LPF2)");
+			return -EIO;
+		}
+	}
+
 	return 0;
 }
 
@@ -898,6 +919,7 @@ static int lsm6dso_init(const struct device *dev)
 #define LSM6DSO_CONFIG_COMMON(inst)					\
 	.accel_pm = DT_INST_PROP(inst, accel_pm),			\
 	.accel_odr = DT_INST_PROP(inst, accel_odr),			\
+	.accel_lp_filter = DT_INST_PROP(inst, accel_lp_filter),		\
 	.accel_range = DT_INST_PROP(inst, accel_range) |		\
 		(DT_INST_NODE_HAS_COMPAT(inst, st_lsm6dso32) ?	        \
 			ACCEL_RANGE_DOUBLE : 0),			\

--- a/drivers/sensor/st/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.h
@@ -52,6 +52,7 @@ struct lsm6dso_config {
 	} stmemsc_cfg;
 	uint8_t accel_pm;
 	uint8_t accel_odr;
+	uint8_t accel_lp_filter;
 #define ACCEL_RANGE_DOUBLE	BIT(7)
 #define ACCEL_RANGE_MASK	BIT_MASK(6)
 	uint8_t accel_range;

--- a/dts/bindings/sensor/st,lsm6dso-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-common.yaml
@@ -94,6 +94,25 @@ properties:
 
     enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
+  accel-lp-filter:
+    type: int
+    default: 0
+    description: |
+      Specify the amount of low pass filtering applied to the accelerometer values.
+      Default is power-up configuration.
+      This will enable the LPF2 lowpass filter via the lpf2_xl_en bit in the CTRL1_XL register.
+
+      - 0 # LSM6DSO_DT_LP_ODR_DIV_2
+      - 1 # LSM6DSO_DT_LP_ODR_DIV_10
+      - 2 # LSM6DSO_DT_LP_ODR_DIV_20
+      - 3 # LSM6DSO_DT_LP_ODR_DIV_45
+      - 4 # LSM6DSO_DT_LP_ODR_DIV_100
+      - 5 # LSM6DSO_DT_LP_ODR_DIV_200
+      - 6 # LSM6DSO_DT_LP_ODR_DIV_400
+      - 7 # LSM6DSO_DT_LP_ODR_DIV_800
+
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+
   gyro-pm:
     type: int
     default: 0

--- a/include/zephyr/dt-bindings/sensor/lsm6dso.h
+++ b/include/zephyr/dt-bindings/sensor/lsm6dso.h
@@ -42,6 +42,16 @@
 #define LSM6DSO_DT_ODR_6667Hz			0xa
 #define LSM6DSO_DT_ODR_1Hz6			0xb
 
+/* Low pass filter dividers */
+#define LSM6DSO_DT_LP_ODR_DIV_2			0
+#define LSM6DSO_DT_LP_ODR_DIV_10		1
+#define LSM6DSO_DT_LP_ODR_DIV_20		2
+#define LSM6DSO_DT_LP_ODR_DIV_45		3
+#define LSM6DSO_DT_LP_ODR_DIV_100		4
+#define LSM6DSO_DT_LP_ODR_DIV_200		5
+#define LSM6DSO_DT_LP_ODR_DIV_400		6
+#define LSM6DSO_DT_LP_ODR_DIV_800		7
+
 /* Tap mode */
 #define LSM6DSO_DT_SINGLE_TAP			0
 #define LSM6DSO_DT_SINGLE_DOUBLE_TAP		1


### PR DESCRIPTION
Add device tree support for enabling the second low pass filter (LPF2) for the accelerometer output.

This adds additional low pass on top of the default ODR/2 from the LPF1 output.

https://github.com/zephyrproject-rtos/zephyr/pull/85711 went stale, so I'm reviving it with the previous comments amended.