### PR TITLE
Zbus: channel from name

### DIFF
--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -807,6 +807,20 @@ const struct zbus_channel *zbus_chan_from_id(uint32_t channel_id);
 
 #endif
 
+#if defined(CONFIG_ZBUS_CHANNEL_NAME) || defined(__DOXYGEN__)
+
+/**
+ * @brief Retrieve a zbus channel from its name string
+ *
+ * @param name Name of the channel to retrieve.
+ *
+ * @retval NULL If channel with name @a name does not exist.
+ * @retval chan Channel pointer with name @a name otherwise.
+ */
+const struct zbus_channel *zbus_chan_from_name(const char *name);
+
+#endif
+
 /**
  * @brief Get the reference for a channel message directly.
  *

--- a/subsys/zbus/zbus.c
+++ b/subsys/zbus/zbus.c
@@ -156,6 +156,26 @@ const struct zbus_channel *zbus_chan_from_id(uint32_t channel_id)
 
 #endif /* CONFIG_ZBUS_CHANNEL_ID */
 
+#if defined(CONFIG_ZBUS_CHANNEL_NAME)
+
+const struct zbus_channel *zbus_chan_from_name(const char *name)
+{
+	CHECKIF(name == NULL) {
+		return NULL;
+	}
+
+	STRUCT_SECTION_FOREACH(zbus_channel, chan) {
+		if (strcmp(chan->name, name) == 0) {
+			/* Found matching channel */
+			return chan;
+		}
+	}
+	/* No matching channel exists */
+	return NULL;
+}
+
+#endif /* CONFIG_ZBUS_CHANNEL_NAME */
+
 static inline int _zbus_notify_observer(const struct zbus_channel *chan,
 					const struct zbus_observer *obs, k_timepoint_t end_time,
 					struct net_buf *buf)

--- a/tests/subsys/zbus/channel_name/CMakeLists.txt
+++ b/tests/subsys/zbus/channel_name/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(test_channel_name)
+
+FILE(GLOB app_sources src/main.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/zbus/channel_name/prj.conf
+++ b/tests/subsys/zbus/channel_name/prj.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_ZTEST=y
+CONFIG_ASSERT=y
+CONFIG_LOG=y
+CONFIG_ZBUS=y
+CONFIG_ZBUS_CHANNEL_NAME=y

--- a/tests/subsys/zbus/channel_name/src/main.c
+++ b/tests/subsys/zbus/channel_name/src/main.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zbus/zbus.h>
+#include <zephyr/ztest.h>
+#include <zephyr/ztest_assert.h>
+#include <zephyr/sys/util_macro.h>
+
+struct msg {
+	int x;
+};
+
+#define CHANNEL_COUNT 10
+
+#define DEFINE_TEST_CHANNELS(i, _)                                                                 \
+	ZBUS_CHAN_DEFINE(test_chan_##i, struct msg, NULL, NULL, ZBUS_OBSERVERS_EMPTY,              \
+			 ZBUS_MSG_INIT(0));
+
+LISTIFY(CHANNEL_COUNT, DEFINE_TEST_CHANNELS, (;))
+
+ZTEST(channel_name, test_channel_retrieval)
+{
+	/* invalid cases */
+	zexpect_is_null(zbus_chan_from_name("unknown"));
+	zexpect_is_null(zbus_chan_from_name(NULL));
+	zexpect_is_null(zbus_chan_from_name(""));
+
+	/* valid cases */
+	zexpect_equal_ptr(&test_chan_0, zbus_chan_from_name("test_chan_0"));
+	zexpect_equal_ptr(&test_chan_4, zbus_chan_from_name("test_chan_4"));
+	zexpect_equal_ptr(&test_chan_5, zbus_chan_from_name("test_chan_5"));
+	zexpect_equal_ptr(&test_chan_9, zbus_chan_from_name("test_chan_9"));
+}
+
+ZTEST_SUITE(channel_name, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/zbus/channel_name/testcase.yaml
+++ b/tests/subsys/zbus/channel_name/testcase.yaml
@@ -1,0 +1,5 @@
+tests:
+  message_bus.zbus.channel_name:
+    tags: zbus
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
Add a new API function zbus_chan_from_name() that allows retrieving a
zbus channel by its name string. This complements the existing
zbus_chan_from_id() function and provides more flexibility for channel
lookup operations.

Split from #96086