### PR TITLE
tests: arch: interrupt: Exclude mpfs_icicle SMP platform from LTO test

### DIFF
--- a/tests/arch/common/interrupt/testcase.yaml
+++ b/tests/arch/common/interrupt/testcase.yaml
@@ -51,8 +51,11 @@ tests:
       - CONFIG_SHARED_INTERRUPTS=y
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
   arch.shared_interrupt.lto: &shared-interrupt-lto
-    # excluded because of failures during test_prevent_interruption
-    platform_exclude: qemu_cortex_m0
+    platform_exclude:
+      # excluded because of failures during test_prevent_interruption
+      - qemu_cortex_m0
+      # excluded because of assertion during test_isr_offload_job_identi (issue #98658)
+      - mpfs_icicle/polarfire/u54/smp
     arch_exclude:
       # test needs 2 working interrupt lines
       - xtensa


### PR DESCRIPTION
Other variants of `arch.interrupt` test pass on this platform, but `arch.shared_interrupt.lto` asserts in `test_isr_offload_job_identi`.

The issue was reported in #98658.