### PR TITLE
MAINTAINERS: add alxelax as bt qualification collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -685,6 +685,7 @@ Bluetooth Qualification:
   collaborators:
     - Thalley
     - jhedberg
+    - alxelax
   files:
     - doc/connectivity/bluetooth/autopts/
     - tests/bluetooth/qualification/


### PR DESCRIPTION
Add myself (alxelax) as Bluetooth Qualification collaborator. The main reason is I as Bluetooth Mesh collaborator would like to follow up qualification tool updates since it impacts Mesh qualification too.