### PR TITLE
drivers: gpio: use I2C_INIT_PRIORITY as default for i2c gpio chips

### DIFF
--- a/drivers/gpio/Kconfig.cy8c95xx
+++ b/drivers/gpio/Kconfig.cy8c95xx
@@ -15,7 +15,7 @@ if GPIO_CY8C95XX
 
 config GPIO_CY8C95XX_INIT_PRIORITY
 	int "Init priority"
-	default 70
+	default I2C_INIT_PRIORITY
 	help
 	  Device driver initialization priority.
 

--- a/drivers/gpio/Kconfig.fxl6408
+++ b/drivers/gpio/Kconfig.fxl6408
@@ -13,7 +13,7 @@ if GPIO_FXL6408
 
 config GPIO_FXL6408_INIT_PRIORITY
 	int "Init priority"
-	default 80
+	default I2C_INIT_PRIORITY
 	help
 	  Device driver initialization priority.
 

--- a/drivers/gpio/Kconfig.mcp23xxx
+++ b/drivers/gpio/Kconfig.mcp23xxx
@@ -26,7 +26,7 @@ if GPIO_MCP230XX
 
 config GPIO_MCP230XX_INIT_PRIORITY
 	int "MCP230XX GPIO expander init priority"
-	default 75
+	default I2C_INIT_PRIORITY
 	help
 	  Device driver initialization priority.
 

--- a/drivers/gpio/Kconfig.pca953x
+++ b/drivers/gpio/Kconfig.pca953x
@@ -16,7 +16,7 @@ if GPIO_PCA953X
 
 config GPIO_PCA953X_INIT_PRIORITY
 	int "Init priority"
-	default 70
+	default I2C_INIT_PRIORITY
 	help
 	  Device driver initialization priority.
 

--- a/drivers/gpio/Kconfig.pca95xx
+++ b/drivers/gpio/Kconfig.pca95xx
@@ -15,7 +15,7 @@ if GPIO_PCA95XX
 
 config GPIO_PCA95XX_INIT_PRIORITY
 	int "Init priority"
-	default 70
+	default I2C_INIT_PRIORITY
 	help
 	  Device driver initialization priority.
 

--- a/drivers/gpio/Kconfig.pca95xx
+++ b/drivers/gpio/Kconfig.pca95xx
@@ -11,17 +11,19 @@ menuconfig GPIO_PCA95XX
 	help
 	  Enable driver for PCA95XX I2C-based GPIO chip.
 
+if GPIO_PCA95XX
+
 config GPIO_PCA95XX_INIT_PRIORITY
 	int "Init priority"
 	default 70
-	depends on GPIO_PCA95XX
 	help
 	  Device driver initialization priority.
 
 config GPIO_PCA95XX_INTERRUPT
 	bool "Interrupt enable"
-	depends on GPIO_PCA95XX
 	help
 	  Enable interrupt support in PCA95XX driver.
 	  Note that the PCA95XX cannot reliably detect
 	  short-pulse interrupts due to its design.
+
+endif # GPIO_PCA95XX

--- a/drivers/gpio/Kconfig.pca_series
+++ b/drivers/gpio/Kconfig.pca_series
@@ -20,7 +20,7 @@ if GPIO_PCA_SERIES
 
 config GPIO_PCA_SERIES_INIT_PRIORITY
 	int "Init priority"
-	default 70
+	default I2C_INIT_PRIORITY
 	help
 	  Device driver initialization priority.
 

--- a/drivers/gpio/Kconfig.pca_series
+++ b/drivers/gpio/Kconfig.pca_series
@@ -16,17 +16,17 @@ menuconfig GPIO_PCA_SERIES
 	help
 	  Enable driver for PCA_SERIES I2C-based GPIO chip.
 
+if GPIO_PCA_SERIES
+
 config GPIO_PCA_SERIES_INIT_PRIORITY
 	int "Init priority"
 	default 70
-	depends on GPIO_PCA_SERIES
 	help
 	  Device driver initialization priority.
 
 config GPIO_PCA_SERIES_INTERRUPT
 	bool "Interrupt enable"
 	default y
-	depends on GPIO_PCA_SERIES
 	help
 	  Enable interrupt support in PCA_SERIES driver.
 	  Note that the PCA_SERIES cannot reliably detect
@@ -35,10 +35,11 @@ config GPIO_PCA_SERIES_INTERRUPT
 config GPIO_PCA_SERIES_CACHE_ALL
 	bool "Cache all registers"
 	default y
-	depends on GPIO_PCA_SERIES
 	help
 	  Cache all registers in RAM for faster configuration.
 	  Enabled by default.
 	  When disabled, only output registers will be cached.
 	  On devices w/o interrupt status, it will also cache
 	  input state.
+
+endif # GPIO_PCA_SERIES

--- a/drivers/gpio/Kconfig.pcf857x
+++ b/drivers/gpio/Kconfig.pcf857x
@@ -15,7 +15,7 @@ menuconfig GPIO_PCF857X
 
 config GPIO_PCF857X_INIT_PRIORITY
 	int "Init priority"
-	default 70
+	default I2C_INIT_PRIORITY
 	depends on GPIO_PCF857X
 	help
 	  Device driver initialization priority.

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -15,7 +15,7 @@ if GPIO_SX1509B
 
 config GPIO_SX1509B_INIT_PRIORITY
 	int "Init priority"
-	default 70
+	default I2C_INIT_PRIORITY
 	help
 	  Device driver initialization priority.
 

--- a/drivers/gpio/Kconfig.tca6424a
+++ b/drivers/gpio/Kconfig.tca6424a
@@ -13,7 +13,7 @@ menuconfig GPIO_TCA6424A
 
 config GPIO_TCA6424A_INIT_PRIORITY
 	int "Init priority"
-	default 70
+	default I2C_INIT_PRIORITY
 	depends on GPIO_TCA6424A
 	help
 	  Device driver initialization priority.


### PR DESCRIPTION
use I2C_INIT_PRIORITY as default for gpio chips,
that are on a i2c bus.

If childs have the same priority as their parents,
the init order is decided by the devicetree ordinals. (introduced in https://github.com/zephyrproject-rtos/zephyr/pull/60410)
This ensures, that these childs are init after their parent.
Because of that gpio chips on a i2c bus can have the
same priority as the i2c controller. 