### PR TITLE
arch: arm: fix start of the privileged stack

### DIFF
--- a/arch/arm/core/cortex_a_r/thread.c
+++ b/arch/arm/core/cortex_a_r/thread.c
@@ -107,6 +107,18 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #endif /* FP_GUARD_EXTRA_SIZE */
 #endif /* CONFIG_MPU_STACK_GUARD */
 
+#if defined(CONFIG_ARM_STORE_EXC_RETURN) || defined(CONFIG_USERSPACE)
+	thread->arch.mode = 0;
+#if defined(CONFIG_ARM_STORE_EXC_RETURN)
+	thread->arch.mode_exc_return = DEFAULT_EXC_RETURN;
+#endif
+#if FP_GUARD_EXTRA_SIZE > 0
+	if ((thread->base.user_options & K_FP_REGS) != 0) {
+		thread->arch.mode |= Z_ARM_MODE_MPU_GUARD_FLOAT_Msk;
+	}
+#endif
+#endif
+
 	iframe = Z_STACK_PTR_TO_FRAME(struct __basic_sf, stack_ptr);
 #if defined(CONFIG_USERSPACE)
 	thread->arch.priv_stack_start = 0;
@@ -144,17 +156,6 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	thread->callee_saved.psp = (uint32_t)iframe;
 	thread->arch.basepri = 0;
 
-#if defined(CONFIG_ARM_STORE_EXC_RETURN) || defined(CONFIG_USERSPACE)
-	thread->arch.mode = 0;
-#if defined(CONFIG_ARM_STORE_EXC_RETURN)
-	thread->arch.mode_exc_return = DEFAULT_EXC_RETURN;
-#endif
-#if FP_GUARD_EXTRA_SIZE > 0
-	if ((thread->base.user_options & K_FP_REGS) != 0) {
-		thread->arch.mode |= Z_ARM_MODE_MPU_GUARD_FLOAT_Msk;
-	}
-#endif
-#endif
 	/*
 	 * initial values in all other registers/thread entries are
 	 * irrelevant.

--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -115,6 +115,18 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack, char *sta
 #endif /* FP_GUARD_EXTRA_SIZE */
 #endif /* CONFIG_MPU_STACK_GUARD */
 
+#if defined(CONFIG_ARM_STORE_EXC_RETURN) || defined(CONFIG_USERSPACE)
+	thread->arch.mode = 0;
+#if defined(CONFIG_ARM_STORE_EXC_RETURN)
+	thread->arch.mode_exc_return = DEFAULT_EXC_RETURN;
+#endif
+#if FP_GUARD_EXTRA_SIZE > 0
+	if ((thread->base.user_options & K_FP_REGS) != 0) {
+		thread->arch.mode |= Z_ARM_MODE_MPU_GUARD_FLOAT_Msk;
+	}
+#endif
+#endif
+
 	iframe = Z_STACK_PTR_TO_FRAME(struct __basic_sf, stack_ptr);
 #if defined(CONFIG_USERSPACE)
 	thread->arch.priv_stack_start = 0;
@@ -141,17 +153,6 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack, char *sta
 	thread->callee_saved.psp = (uint32_t)iframe;
 	thread->arch.basepri = 0;
 
-#if defined(CONFIG_ARM_STORE_EXC_RETURN) || defined(CONFIG_USERSPACE)
-	thread->arch.mode = 0;
-#if defined(CONFIG_ARM_STORE_EXC_RETURN)
-	thread->arch.mode_exc_return = DEFAULT_EXC_RETURN;
-#endif
-#if FP_GUARD_EXTRA_SIZE > 0
-	if ((thread->base.user_options & K_FP_REGS) != 0) {
-		thread->arch.mode |= Z_ARM_MODE_MPU_GUARD_FLOAT_Msk;
-	}
-#endif
-#endif
 #ifdef CONFIG_ARM_PAC_PER_THREAD
 	/* Generate PAC key and save it in thread context to be set later
 	 * when the thread is actually switched in


### PR DESCRIPTION
Make sure that arch.mode is set with appropriate flags before setting up the privileged stack start.

Fixes #99895