### PR TITLE
soc: ambiq: apollo4x: Add cache initialization for proper timing

### DIFF
--- a/soc/ambiq/apollo4x/soc.c
+++ b/soc/ambiq/apollo4x/soc.c
@@ -13,6 +13,9 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 extern void ambiq_power_init(void);
 void soc_early_init_hook(void)
 {
+	/* Configure and enable cache for proper interrupt timing */
+	am_hal_cachectrl_config(&am_hal_cachectrl_defaults);
+	am_hal_cachectrl_enable();
 
 	/* Initialize for low power in the power control block */
 	am_hal_pwrctrl_low_power_init();


### PR DESCRIPTION
Apollo4P requires cache to be configured and enabled early in the boot process for proper interrupt timing and 96 MHz operation. Without cache initialization, interrupts can be delayed by hundreds of microseconds, causing timing anomalies in time-critical applications.

This aligns Apollo4P initialization with:
- Apollo3 SoC initialization (which includes cache init)
- Official Ambiq SDK examples (uart_async, etc.)
- Ambiq application notes for maximum performance

The cache must be initialized before low power init to ensure proper memory access timing throughout the boot sequence.

Fixes interrupt timing delays observed in UART TDMA applications running at 2 Mbaud with 1ms frame timing.

--
