### PR TITLE
doc: add missing zephyr namespaced to include path where it was missing

### DIFF
--- a/arch/x86/include/ia32/kernel_arch_data.h
+++ b/arch/x86/include/ia32/kernel_arch_data.h
@@ -11,8 +11,8 @@
  * This file contains private kernel structures definitions and various
  * other definitions for the Intel Architecture 32 bit (IA-32) processor
  * architecture.
- * The header include/kernel.h contains the public kernel interface
- * definitions, with include/arch/x86/ia32/arch.h supplying the
+ * The header include/zephyr/kernel.h contains the public kernel interface
+ * definitions, with include/zephyr/arch/x86/ia32/arch.h supplying the
  * IA-32 specific portions of the public kernel interface.
  *
  * This file is also included by assembly language files which must #define

--- a/doc/connectivity/bluetooth/bluetooth-arch.rst
+++ b/doc/connectivity/bluetooth/bluetooth-arch.rst
@@ -192,7 +192,7 @@ The stack is split up as follows in the source tree:
   Implements the controller-side of HCI, the Link Layer as well as access to the
   radio transceiver.
 
-``include/bluetooth/``
+``include/zephyr/bluetooth/``
   :ref:`Public API <bluetooth_api>` header files. These are the header files
   applications need to include in order to use Bluetooth functionality.
 

--- a/doc/connectivity/networking/api/net_mgmt.rst
+++ b/doc/connectivity/networking/api/net_mgmt.rst
@@ -88,7 +88,7 @@ An example follows.
 
 	/*
 	 * Set of events to handle.
-	 * See e.g. include/net/net_event.h for some NET_EVENT_xxx values.
+	 * See e.g. include/zephyr/net/net_event.h for some NET_EVENT_xxx values.
 	 */
 	#define EVENT_IFACE_SET (NET_EVENT_IF_xxx | NET_EVENT_IF_yyy)
 	#define EVENT_IPV4_SET (NET_EVENT_IPV4_xxx | NET_EVENT_IPV4_yyy)

--- a/doc/connectivity/networking/overview.rst
+++ b/doc/connectivity/networking/overview.rst
@@ -166,7 +166,7 @@ The networking stack source code tree is organized as follows:
   Application-level protocols (DNS, MQTT, etc.) and additional stack
   components (BSD Sockets, etc.).
 
-``include/net/``
+``include/zephyr/net/``
   Public API header files. These are the header files applications need
   to include to use IP networking functionality.
 

--- a/doc/develop/toolchains/custom_cmake.rst
+++ b/doc/develop/toolchains/custom_cmake.rst
@@ -43,7 +43,7 @@ your :makevar:`ZEPHYR_TOOLCHAIN_VARIANT`, :makevar:`TOOLCHAIN_ROOT`, and other
 settings in a file named :file:`my-toolchain.cmake`, you can then invoke cmake
 as ``cmake -C my-toolchain.cmake ...`` to save typing.
 
-Zephyr includes :file:`include/toolchain.h` which again includes a toolchain
+Zephyr includes :file:`include/zephyr/toolchain.h` which again includes a toolchain
 specific header based on the compiler identifier, such as ``__llvm__`` or
 ``__GNUC__``.
 Some custom compilers identify themselves as the compiler on which they are
@@ -59,7 +59,7 @@ available out-of-tree and it must include the correct header for the custom
 toolchain.
 A good location for the :file:`other.h` header file, would be a
 directory under the directory specified in ``TOOLCHAIN_ROOT`` as
-:file:`include/toolchain`.
+:file:`include/zephyr/toolchain`.
 To get the toolchain header included in zephyr's build, the
 :makevar:`USERINCLUDE` can be set to point to the include directory, as shown
 here:

--- a/doc/hardware/porting/arch.rst
+++ b/doc/hardware/porting/arch.rst
@@ -911,7 +911,7 @@ GDB Stub
 To enable GDB stub for remote debugging on a new architecture:
 
 #. Create a new ``gdbstub.h`` header file under appropriate architecture
-   include directory (``include/arch/<arch>/gdbstub.h``).
+   include directory (:file:`include/zephyr/arch/<arch>/gdbstub.h`).
 
    * Create a new struct ``struct gdb_ctx`` as the GDB context.
 

--- a/doc/kernel/services/other/fatal.rst
+++ b/doc/kernel/services/other/fatal.rst
@@ -145,7 +145,7 @@ With GCC, the output resembles:
 .. code-block:: none
 
 	tests/kernel/fatal/src/main.c: In function 'test_main':
-	include/toolchain/gcc.h:28:37: error: static assertion failed: "Invalid value of FOO"
+	include/zephyr/toolchain/gcc.h:28:37: error: static assertion failed: "Invalid value of FOO"
 	 #define BUILD_ASSERT(EXPR, MSG) _Static_assert(EXPR, "" MSG)
 					 ^~~~~~~~~~~~~~
 	tests/kernel/fatal/src/main.c:370:2: note: in expansion of macro 'BUILD_ASSERT'

--- a/doc/kernel/usermode/kernelobjects.rst
+++ b/doc/kernel/usermode/kernelobjects.rst
@@ -12,7 +12,7 @@ A kernel object can be one of three classes of data:
   set of subsystems
 
 The set of known kernel objects and driver subsystems is defined in
-include/kernel.h as :c:enum:`k_objects`.
+:zephyr_file:`include/zephyr/kernel.h` as :c:enum:`k_objects`.
 
 Kernel objects are completely opaque to user threads. User threads work
 with addresses to kernel objects when making API calls, but may never

--- a/doc/kernel/usermode/memory_domain.rst
+++ b/doc/kernel/usermode/memory_domain.rst
@@ -316,7 +316,7 @@ There are a few memory partitions which are pre-defined by the system:
    Required when using either the Minimal C library or the Newlib C Library.
    Required when :kconfig:option:`CONFIG_STACK_CANARIES` is enabled.
 
-Library-specific partitions are listed in ``include/app_memory/partitions.h``.
+Library-specific partitions are listed in :zephyr_file:`include/zephyr/app_memory/partitions.h`.
 For example, to use the MBEDTLS library from user mode, the
 ``k_mbedtls_partition`` must be added to the domain.
 
@@ -428,7 +428,7 @@ dependent.
 
 The complete list of available partition attributes for a specific architecture
 is found in the architecture-specific include file
-``include/zephyr/arch/<arch name>/arch.h``, (for example, ``include/zehpyr/arch/arm/arch.h``.)
+``include/zephyr/arch/<arch name>/arch.h``, (for example, :zephyr_file:`include/zephyr/arch/arm/arch.h`.)
 Some examples of partition attributes are:
 
 .. code-block:: c

--- a/doc/kernel/usermode/syscalls.rst
+++ b/doc/kernel/usermode/syscalls.rst
@@ -170,7 +170,8 @@ the project out directory under ``include/generated/``:
 
 The body of the API is created in the generated system header. Using the
 example of :c:func:`k_sem_init()`, this API is declared in
-``include/kernel.h``. At the bottom of ``include/kernel.h`` is::
+:zephyr_file:`include/zephyr/kernel.h`. At the bottom of
+:zephyr_file:`include/zephyr/kernel.h` is::
 
     #include <zephyr/syscalls/kernel.h>
 

--- a/doc/kernel/usermode/syscalls.rst
+++ b/doc/kernel/usermode/syscalls.rst
@@ -83,7 +83,7 @@ conditional visibility to the compiler.
 Any header file that declares system calls must include a special generated
 header at the very bottom of the header file. This header follows the
 naming convention ``syscalls/<name of header file>``. For example, at the
-bottom of ``include/sensor.h``:
+bottom of :zephyr_file:`include/zephyr/drivers/sensor.h`:
 
 .. code-block:: c
 

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -21,8 +21,8 @@
  * must eventually pull in full definitions for all of them (the actual macro
  * defines and inline function bodies)
  *
- * include/kernel.h and other public headers depend on definitions in this
- * header.
+ * include/zephyr/kernel.h and other public headers depend on definitions in
+ * this header.
  */
 #ifndef ZEPHYR_INCLUDE_ARCH_ARCH_INTERFACE_H_
 #define ZEPHYR_INCLUDE_ARCH_ARCH_INTERFACE_H_

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -56,7 +56,7 @@ struct _thread_base {
 	 */
 	_wait_q_t *pended_on;
 
-	/* user facing 'thread options'; values defined in include/kernel.h */
+	/* user facing 'thread options'; values defined in include/zephyr/kernel.h */
 	uint8_t user_options;
 
 	/* thread state */

--- a/scripts/west_commands/zspdx/getincludes.py
+++ b/scripts/west_commands/zspdx/getincludes.py
@@ -45,7 +45,7 @@ def extractIncludes(resp):
 
     # lines we want will start with one or more periods, followed by
     # a space and then the include file path, e.g.:
-    # .... /home/steve/programming/zephyr/zephyrproject/zephyr/include/kernel.h
+    # .... /home/steve/programming/zephyr/zephyrproject/zephyr/include/zephyr/kernel.h
     # the number of periods indicates the depth of nesting (for transitively-
     # included files), but here we aren't going to care about that. We'll
     # treat everything as tied to the corresponding source file.


### PR DESCRIPTION
- **doc: fix reference to kernel.h**
- **doc: various fixes for include path**
