### PR TITLE
shields: buydisplay_3_5_tft: disable pointer axes inversion

### DIFF
--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
@@ -49,8 +49,6 @@
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		swapped-x-y;
-		inverted-x;
-		inverted-y;
 		screen-width = <320>;
 		screen-height = <480>;
 		/* Uncomment if IRQ line is available (requires to solder jumper) */


### PR DESCRIPTION
The current configuration of the lvgl_pointer node inverts the x and y axes, which doesn't match the current display configuration in the ili9488_buydisplay_3_5_tft_touch_arduino node, ie. pointing to the right/bottom side of the screen registers a touch in the left/top side.

Fix it by removing the invert-x and invert-y properties.

