### PR TITLE
STM32: fix incorrect burst length in drivers' DMA configurations

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1828,8 +1828,11 @@ static DEVICE_API(adc, api_stm32_driver_api) = {
 				STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),		\
 			.dest_data_size = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(	\
 				STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),		\
-			.source_burst_length = 1,       /* SINGLE transfer */		\
-			.dest_burst_length = 1,         /* SINGLE transfer */		\
+			/* single transfers (burst length = data size) */		\
+			.source_burst_length = STM32_DMA_CONFIG_##src_dev##_DATA_SIZE(	\
+				STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),		\
+			.dest_burst_length = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(	\
+				STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),		\
 			.channel_priority = STM32_DMA_CONFIG_PRIORITY(			\
 				STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),		\
 			.dma_callback = dma_callback,					\

--- a/drivers/adc/adc_stm32wb0.c
+++ b/drivers/adc/adc_stm32wb0.c
@@ -1230,8 +1230,11 @@ static struct adc_stm32wb0_data adc_data = {
 			STM32_DMA_CHANNEL_CONFIG_BY_IDX(ADC_INSTANCE, 0)),
 		.dest_data_size = STM32_DMA_CONFIG_MEMORY_DATA_SIZE(
 			STM32_DMA_CHANNEL_CONFIG_BY_IDX(ADC_INSTANCE, 0)),
-		.source_burst_length = 1,	/* SINGLE transfer */
-		.dest_burst_length = 1,		/* SINGLE transfer */
+		/* single transfers (burst length = data size) */
+		.source_burst_length = STM32_DMA_CONFIG_PERIPHERAL_DATA_SIZE(
+			STM32_DMA_CHANNEL_CONFIG_BY_IDX(ADC_INSTANCE, 0)),
+		.dest_burst_length = STM32_DMA_CONFIG_MEMORY_DATA_SIZE(
+			STM32_DMA_CHANNEL_CONFIG_BY_IDX(ADC_INSTANCE, 0)),
 		.block_count = 1,
 		.dma_callback = adc_stm32wb0_dma_callback,
 		/* head_block and user_data are initialized at runtime */

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -509,8 +509,11 @@ void i2c_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
 			.dest_data_size = STM32_DMA_CONFIG_##dest##_DATA_SIZE(			\
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
-			.source_burst_length = 1,						\
-			.dest_burst_length = 1,							\
+			/* single transfers (burst length = data size) */			\
+			.source_burst_length = STM32_DMA_CONFIG_##src##_DATA_SIZE(		\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
+			.dest_burst_length = STM32_DMA_CONFIG_##dest##_DATA_SIZE(		\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),				\
 			.dma_callback = i2c_stm32_dma_##dir##_cb,				\
 		},))
 

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -946,8 +946,9 @@ static const struct device *get_dev_from_tx_dma_channel(uint32_t dma_channel)
 			.channel_direction = src_dev##_TO_##dest_dev,		\
 			.source_data_size = 2,  /* 16bit default */		\
 			.dest_data_size = 2,    /* 16bit default */		\
-			.source_burst_length = 1, /* SINGLE transfer */		\
-			.dest_burst_length = 1,					\
+			/* single transfers (burst length = data size) */	\
+			.source_burst_length = 2,				\
+			.dest_burst_length = 2,					\
 			.channel_priority = STM32_DMA_CONFIG_PRIORITY(		\
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),		\
 			.dma_callback = dma_##dir##_callback,			\

--- a/drivers/i3c/i3c_stm32.c
+++ b/drivers/i3c/i3c_stm32.c
@@ -2150,8 +2150,11 @@ static DEVICE_API(i3c, i3c_stm32_driver_api) = {
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),                             \
 		.dest_data_size = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(                         \
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),                             \
-		.source_burst_length = 1, /* SINGLE transfer */                                    \
-		.dest_burst_length = 1,                                                            \
+		/* single transfers (burst length = data size) */                                  \
+		.source_burst_length = STM32_DMA_CONFIG_##src_dev##_DATA_SIZE(                     \
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),                             \
+		.dest_burst_length = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(                      \
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),                             \
 		.block_count = 1,                                                                  \
 		.dma_callback = i3c_stm32_dma_##dir##_cb,                                          \
 	},                                                                                         \

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -2504,8 +2504,11 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 					STM32_DMA_CHANNEL_CONFIG(index, dir)),\
 		.dest_data_size = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(\
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
-		.source_burst_length = 1, /* SINGLE transfer */		\
-		.dest_burst_length = 1,					\
+		/* single transfers (burst length = data size) */	\
+		.source_burst_length = STM32_DMA_CONFIG_##src_dev##_DATA_SIZE(\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
+		.dest_burst_length = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
 		.block_count = 1,					\
 		.dma_callback = uart_stm32_dma_##dir##_cb,		\
 	},								\

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -482,8 +482,11 @@ static void video_stm32_dcmi_irq_config_func(const struct device *dev)
 			STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),			\
 		.dest_data_size = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(		\
 			STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),			\
-		.source_burst_length = 1,       /* SINGLE transfer */			\
-		.dest_burst_length = 1,         /* SINGLE transfer */			\
+		/* single transfers (burst length = data size) */			\
+		.source_burst_length = STM32_DMA_CONFIG_##src_dev##_DATA_SIZE(		\
+			STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),			\
+		.dest_burst_length = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(		\
+			STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),			\
 		.channel_priority = STM32_DMA_CONFIG_PRIORITY(				\
 			STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),			\
 		.dma_callback = dcmi_dma_callback,					\

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
@@ -196,8 +196,11 @@ static int prepare_rx(struct ec_host_cmd_spi_ctx *hc_spi);
 				DT_DMAS_CELL_BY_NAME(id, dir, channel_config)),                    \
 			.dest_data_size = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(                 \
 				DT_DMAS_CELL_BY_NAME(id, dir, channel_config)),                    \
-			.source_burst_length = 1, /* SINGLE transfer */                            \
-			.dest_burst_length = 1,   /* SINGLE transfer */                            \
+			/* single transfers (burst length = data size) */                          \
+			.source_burst_length = STM32_DMA_CONFIG_##src_dev##_DATA_SIZE(             \
+				DT_DMAS_CELL_BY_NAME(id, dir, channel_config)),                    \
+			.dest_burst_length = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(              \
+				DT_DMAS_CELL_BY_NAME(id, dir, channel_config)),                    \
 			.channel_priority = STM32_DMA_CONFIG_PRIORITY(                             \
 				DT_DMAS_CELL_BY_NAME(id, dir, channel_config)),                    \
 			.dma_callback = dma_callback,                                              \


### PR DESCRIPTION
Since #99258, the `{source,dest}_burst_length` argument is no longer ignored by the `dma_stm32u5` driver (notably used on STM32N6 series). Many drivers were mistakenly setting its value to 1 under the assumption that the unit was *number of data-sized transfers*, which is WRONG - the parameter's unit is in *bytes*.

This means that most configurations were wrong unless byte-sized transfers were used.

Fix all drivers by setting a proper value for the `burst_length` parameters, equal to the data size (i.e., resulting in one transfer, as originally intended).

Fixes #100100.

cc @avolmat-st for video driver, @gautierg-st for ADC, ...