### PR TITLE
drivers/sensor: lsm6dsv16x: add device self test

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/Kconfig
+++ b/drivers/sensor/st/lsm6dsv16x/Kconfig
@@ -32,6 +32,13 @@ config LSM6DSV16X_STREAM
 	help
 	  Use this config option to enable streaming sensor data via RTIO subsystem.
 
+config LSM6DSV16X_SELF_TEST
+	bool "Self test attribute"
+	help
+	  Enable support for configuring the sensor self test bits.
+	  Refer to the datasheet of the sensor for a description of
+	  the appropriate self test procedure.
+
 choice LSM6DSV16X_TRIGGER_MODE
 	default LSM6DSV16X_TRIGGER_GLOBAL_THREAD if LSM6DSV16X_STREAM
 	default LSM6DSV16X_TRIGGER_NONE

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
@@ -68,6 +68,9 @@ struct lsm6dsv16x_config {
 		struct i3c_device_desc **i3c;
 #endif
 	} stmemsc_cfg;
+#ifdef CONFIG_LSM6DSV16X_SELF_TEST
+	uint8_t self_test_en;
+#endif
 	uint8_t accel_pm;
 	uint8_t accel_odr;
 	uint8_t accel_range;
@@ -155,6 +158,8 @@ struct lsm6dsv16x_data {
 	uint8_t shub_ext[LSM6DSV16X_SHUB_MAX_NUM_TARGETS];
 #endif /* CONFIG_LSM6DSV16X_SENSORHUB */
 
+	uint8_t xl_st_result;
+	uint8_t gy_st_result;
 	uint8_t accel_freq;
 	uint8_t accel_fs;
 	uint8_t gyro_freq;

--- a/dts/bindings/sensor/st,lsm6dsvxxx-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dsvxxx-common.yaml
@@ -53,6 +53,12 @@ properties:
       mandatory and if not present it defaults to 1 which is the
       configuration at power-up.
 
+  self-test:
+    type: boolean
+    description: |
+      Enable device self-test procedure, which applies an electrostatic force to the sensor to
+      simulate acceleration and rotation without actually moving the device.
+
   accel-odr:
     type: int
     default: 0x0

--- a/include/zephyr/drivers/sensor/lsm6dsvxxx.h
+++ b/include/zephyr/drivers/sensor/lsm6dsvxxx.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for extended sensor API of LSM6DSVXXX sensor
+ * @ingroup lsm6dsvxxx_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_LSM6DSVXXX_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_LSM6DSVXXX_H_
+
+/**
+ * @defgroup lsm6dsvxxx_interface LSM6DSVXXX
+ * @ingroup sensor_interface_ext
+ * @brief ST Microelectronics LSM6DSVXXX 3-axis IMU family
+ * @{
+ */
+
+#include <zephyr/drivers/sensor.h>
+
+/**
+ * @brief Custom sensor attributes for LSM6DSVXXX
+ */
+enum sensor_attribute_lsm6dsvxxx {
+	/**
+	 * Gets the self-test mode result in sensor_value.val1 field.
+	 */
+	SENSOR_ATTR_GET_SELF_TEST_RESULT = SENSOR_ATTR_PRIV_START,
+};
+
+enum lsm6dsvxxx_self_test_result {
+	LSM6DSVXXX_ST_OK = 0,
+	LSM6DSVXXX_ST_FAIL = 1,
+};
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_LSM6DSVXXX_H_ */


### PR DESCRIPTION
Add device Self Test procedure. It is required to enable the per device self-test DT property as well as the LSM6DSV16X_SELF_TEST configuration.