### PR TITLE
soc: st: stm32: wkup_pins: break after configuring I/O retention on pin

### DIFF
--- a/soc/st/stm32/common/stm32_wkup_pins.c
+++ b/soc/st/stm32/common/stm32_wkup_pins.c
@@ -346,6 +346,7 @@ int stm32_pwr_wkup_pin_cfg_gpio(const struct gpio_dt_spec *gpio)
 			volatile uint32_t *ioretenr_x = (&PWR->IORETENRA) + 2 * i;
 
 			stm32_reg_set_bits(ioretenr_x, 1U << gpio->pin);
+			break;
 		}
 	}
 #endif /* CONFIG_SOC_SERIES_STM32WBAX */


### PR DESCRIPTION
As reported here: https://github.com/zephyrproject-rtos/zephyr/pull/99656#discussion_r2556306943

After we found the target GPIO port and configured I/O retention on target wake-up pin, break from the search loop.

Applies only to STM32WBA series.

