### PR TITLE
boards: st: stm32h573i_dk: Add TF-M non-secure app support

### DIFF
--- a/boards/st/stm32h573i_dk/board.cmake
+++ b/boards/st/stm32h573i_dk/board.cmake
@@ -1,4 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
+if(CONFIG_BUILD_WITH_TFM)
+  set(FLASH_BASE_ADDRESS_S 0x0C000000)
+
+  # Flash merged TF-M + Zephyr binary
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
+
+  if(CONFIG_HAS_FLASH_LOAD_OFFSET)
+    MATH(EXPR TFM_HEX_BASE_ADDRESS_NS "${FLASH_BASE_ADDRESS_S}+${CONFIG_FLASH_LOAD_OFFSET}")
+  else()
+    set(TFM_HEX_BASE_ADDRESS_NS ${TFM_FLASH_BASE_ADDRESS_S})
+  endif()
+endif()
 
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")

--- a/boards/st/stm32h573i_dk/board.yml
+++ b/boards/st/stm32h573i_dk/board.yml
@@ -6,3 +6,4 @@ board:
     - name: stm32h573xx
       variants:
         - name: ext_flash_app
+        - name: ns

--- a/boards/st/stm32h573i_dk/doc/index.rst
+++ b/boards/st/stm32h573i_dk/doc/index.rst
@@ -149,6 +149,50 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
+Zephyr board options
+====================
+
+The STM32H573 is an SoC with Cortex-M33 architecture. Zephyr provides support
+for building for both Secure and Non-Secure firmware.
+
+The BOARD options are summarized below:
+
++-----------------------------------------+------------------------------------------------------------------+
+| BOARD                                   | Description                                                      |
++=========================================+==================================================================+
+| stm32h573i_dk                           | For building firmware with TrustZone disabled for internal flash |
++-----------------------------------------+------------------------------------------------------------------+
+| stm32h573i_dk/stm32h573xx/ext_flash_app | For building firmware with TrustZone disabled for external flash |
++-----------------------------------------+------------------------------------------------------------------+
+| stm32h573i_dk/stm32h573xx/ns            | For building Non-Secure firmware for internal flash              |
++-----------------------------------------+------------------------------------------------------------------+
+
+Here are the instructions to build Zephyr with a non-secure configuration,
+using :zephyr:code-sample:`tfm_ipc` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/tfm_integration/tfm_ipc
+   :board: stm32h573i_dk/stm32h573xx/ns
+   :goals: build
+
+Once done, before flashing, you need to first run a generated script that
+will set platform Option Bytes config and erase platform (among others,
+Option Byte TZEN will be set).
+
+   .. code-block:: bash
+
+      $ ./build/tfm/api_ns/regression.sh
+      $ west flash
+
+Please note that, after having run a TF-M sample on the board, you will need to
+use STM32CubeProgrammer_ to return the board to a state with TrustZone disabled
+and be able to run usual binaries without TrustZone and TF-M. For example,
+when using a device in Open Product State, one can disable TZEN with:
+
+   .. code-block:: bash
+
+      $ STM32_Programmer_CLI -c port=swd -ob TZEN=0xC3
+
 Connections and IOs
 ===================
 

--- a/boards/st/stm32h573i_dk/stm32h573i_dk_stm32h573xx_ns.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk_stm32h573xx_ns.dts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ * Copyright (c) 2025 CodeWrights GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include "stm32h573i_dk-common.dtsi"
+
+/ {
+	model = "STMicroelectronics STM32H573I DISCOVERY KIT board";
+	compatible = "st,stm32h573i-dk";
+
+	chosen {
+		zephyr,flash = &flash0;
+		zephyr,flash-controller = &flash;
+		zephyr,code-partition = &slot0_ns_partition;
+	};
+};
+
+/* Last 64kB of SRAM1 are owned by TF-M */
+&sram1 {
+	reg = <0x20000000 DT_SIZE_K(256 - 64)>;
+};
+
+/* SRAM2 is owned by TF-M */
+&sram2 {
+	status = "disabled";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Keep in sync with partitions from flash_layout.h in TF-M
+		 * MCUboot (scratch area)                0000_0000 - 0000_C000 ( 48k)
+		 * MCUboot (anti-rollback counter)       0000_C000 - 0001_0000 ( 16k)
+		 * MCUboot (BL2)                         0001_0000 - 0002_8000 ( 96k)
+		 * MCUboot (OTP / non-volatile counters) 0002_8000 - 0002_C000 ( 16k)
+		 * MCUboot (non-volatile counters)       0002_C000 - 0003_0000 ( 16k)
+		 * Secure storage                        0003_0000 - 0003_4000 ( 16k)
+		 * Internal trusted storage              0003_4000 - 0003_8000 ( 16k)
+		 * Slot 0 Secure Partition               0003_8000 - 0008_8000 (320k)
+		 * Slot 0 Non-Secure Partition           0008_8000 - 0011_8000 (576k)
+		 * Slot 1 Secure Partition               0011_8000 - 0016_8000 (320k)
+		 * Slot 1 Non-Secure Partition           0016_8000 - 001F_8000 (576k)
+		 * Storage Partition                     001F_8000 - 0020_0000 ( 32k)
+		 */
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(192)>;
+		};
+
+		slot0_partition: partition@38000 {
+			label = "image-0";
+			reg = <0x00038000 DT_SIZE_K(320)>;
+		};
+
+		slot0_ns_partition: partition@88000 {
+			label = "image-0-nonsecure";
+			reg = <0x00088000 DT_SIZE_K(576)>;
+		};
+
+		slot1_partition: partition@118000 {
+			label = "image-1";
+			reg = <0x00118000 DT_SIZE_K(320)>;
+		};
+
+		slot1_ns_partition: partition@168000 {
+			label = "image-1-nonsecure";
+			reg = <0x00168000 DT_SIZE_K(576)>;
+		};
+
+		storage_partition: partition@1f8000 {
+			label = "storage";
+			reg = <0x001f8000 DT_SIZE_K(32)>;
+		};
+	};
+};
+
+&ext_flash {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "nor";
+			reg = <0x00000000 DT_SIZE_M(64)>;
+		};
+	};
+};

--- a/boards/st/stm32h573i_dk/stm32h573i_dk_stm32h573xx_ns.yaml
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk_stm32h573xx_ns.yaml
@@ -1,0 +1,9 @@
+identifier: stm32h573i_dk/stm32h573xx/ns
+name: ST STM32H573I Discovery Kit non-secure
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+ram: 192
+flash: 575 # size in kB of 1 app slot minus MCUboot header size (1KB)
+vendor: st

--- a/boards/st/stm32h573i_dk/stm32h573i_dk_stm32h573xx_ns_defconfig
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk_stm32h573xx_ns_defconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2023 STMicroelectronics
+# Copyright (c) 2025 CodeWrights GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable HW stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable GPIO
+CONFIG_GPIO=y
+
+# Enable TZ non-secure configuration
+CONFIG_TRUSTED_EXECUTION_NONSECURE=y
+CONFIG_RUNTIME_NMI=y
+CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE="RSA-3072"

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -24,6 +24,7 @@ config TFM_BOARD
 	default "nxp/lpcxpresso55s69" if BOARD_LPCXPRESSO55S69_LPC55S69_CPU0_NS
 	default "stm/b_u585i_iot02a" if BOARD_B_U585I_IOT02A
 	default "stm/nucleo_l552ze_q" if BOARD_NUCLEO_L552ZE_Q
+	default "stm/stm32h573i_dk" if BOARD_STM32H573I_DK
 	default "stm/stm32l562e_dk" if BOARD_STM32L562E_DK
 	default "stm/stm32wba65i_dk" if BOARD_NUCLEO_WBA65RI || BOARD_STM32WBA65I_DK1
 	default "$(ZEPHYR_BASE)/modules/trusted-firmware-m/nordic/nrf9160" if SOC_NRF9160

--- a/samples/tfm_integration/config_build/sample.yaml
+++ b/samples/tfm_integration/config_build/sample.yaml
@@ -28,6 +28,7 @@ tests:
       - mcuboot
     platform_allow:
       # Platform fails no_bl2
+      - stm32h573i_dk/stm32h573xx/ns
       - stm32l562e_dk/stm32l562xx/ns
     extra_configs:
       - CONFIG_TFM_MCUBOOT_IMAGE_NUMBER=1

--- a/samples/tfm_integration/psa_crypto/sample.yaml
+++ b/samples/tfm_integration/psa_crypto/sample.yaml
@@ -21,6 +21,7 @@ tests:
       - stm32l562e_dk/stm32l562xx/ns
       - bl5340_dvk/nrf5340/cpuapp/ns
       - max32657evkit/max32657/ns
+      - stm32h573i_dk/stm32h573xx/ns
     integration_platforms:
       - mps2/an521/cpu0/ns
     harness: console

--- a/samples/tfm_integration/psa_protected_storage/sample.yaml
+++ b/samples/tfm_integration/psa_protected_storage/sample.yaml
@@ -11,6 +11,7 @@ common:
     - bl5340_dvk/nrf5340/cpuapp/ns
     - lpcxpresso55s69/lpc55s69/cpu0/ns
     - max32657evkit/max32657/ns
+    - stm32h573i_dk/stm32h573xx/ns
   integration_platforms:
     - mps2/an521/cpu0/ns
   harness: console

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -17,6 +17,7 @@ tests:
       - v2m_musca_s1/musca_s1/ns
       - bl5340_dvk/nrf5340/cpuapp/ns
       - b_u585i_iot02a/stm32u585xx/ns
+      - stm32h573i_dk/stm32h573xx/ns
     integration_platforms:
       - mps2/an521/cpu0/ns
     harness: console

--- a/samples/tfm_integration/tfm_regression_test/sample.yaml
+++ b/samples/tfm_integration/tfm_regression_test/sample.yaml
@@ -9,6 +9,7 @@ common:
     - nrf9160dk/nrf9160/ns
     - nrf9161dk/nrf9161/ns
     - v2m_musca_s1/musca_s1/ns
+    - stm32h573i_dk/stm32h573xx/ns
   integration_platforms:
     - nrf5340dk/nrf5340/cpuapp/ns
   harness: console

--- a/samples/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/tfm_integration/tfm_secure_partition/sample.yaml
@@ -8,6 +8,7 @@ common:
     - nrf9160dk/nrf9160/ns
     - lpcxpresso55s69/lpc55s69/cpu0/ns
     - max32657evkit/max32657/ns
+    - stm32h573i_dk/stm32h573xx/ns
   integration_platforms:
     - mps2/an521/cpu0/ns
   harness: console

--- a/west.yml
+++ b/west.yml
@@ -380,7 +380,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: e295109067f71e1c8db76d02396baa050687b1df
+      revision: db82030ab21def6d170a7a7ef8def5081ed6f328
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Add support for building Trusted Firmware-M (TF-M) non-secure applications for the STM32H573I-DK board.