### PR TITLE
doc: releases: migration-guide-4.4: Ethernet MAC config compatibles

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -45,15 +45,14 @@ Ethernet
 * Driver MAC address configuration support using :c:struct:`net_eth_mac_config` has been introduced
   for the following drivers:
 
-  * :zephyr_file:`drivers/ethernet/eth_test.c` (:github:`96598`)
+  * :dtcompatible:`vnd,ethernet` (:github:`96598`)
 
-  * :zephyr_file:`drivers/ethernet/eth_sam_gmac.c` (:github:`96598`)
+  * :dtcompatible:`atmel,sam-gmac` and :dtcompatible:`atmel,sam0-gmac` (:github:`96598`)
 
     * Removed ``CONFIG_ETH_SAM_GMAC_MAC_I2C_EEPROM``
     * Removed ``CONFIG_ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS``
     * Removed ``CONFIG_ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS_SIZE``
-    * Removed ``mac-eeprom`` property from :dtcompatible:`atmel,sam-gmac` and
-      :dtcompatible:`atmel,sam0-gmac`
+    * Removed ``mac-eeprom`` property
 
 * The ``fixed-link`` property has been removed from :dtcompatible:`ethernet-phy`. Use
   the new :dtcompatible:`ethernet-phy-fixed-link` compatible instead, if that functionality

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -45,14 +45,20 @@ Ethernet
 * Driver MAC address configuration support using :c:struct:`net_eth_mac_config` has been introduced
   for the following drivers:
 
-  * :dtcompatible:`vnd,ethernet` (:github:`96598`)
-
   * :dtcompatible:`atmel,sam-gmac` and :dtcompatible:`atmel,sam0-gmac` (:github:`96598`)
 
     * Removed ``CONFIG_ETH_SAM_GMAC_MAC_I2C_EEPROM``
     * Removed ``CONFIG_ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS``
     * Removed ``CONFIG_ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS_SIZE``
     * Removed ``mac-eeprom`` property
+
+  * :dtcompatible:`litex,liteeth` (:github:`100620`)
+  * :dtcompatible:`microchip,lan865x` (:github:`100318`)
+  * :dtcompatible:`microchip,lan9250` (:github:`99127`)
+  * :dtcompatible:`sensry,sy1xx-mac` (:github:`100619`)
+  * :dtcompatible:`virtio,net` (:github:`100106`)
+  * :dtcompatible:`vnd,ethernet` (:github:`96598`)
+  * :dtcompatible:`wiznet,w5500` (:github:`100919`)
 
 * The ``fixed-link`` property has been removed from :dtcompatible:`ethernet-phy`. Use
   the new :dtcompatible:`ethernet-phy-fixed-link` compatible instead, if that functionality


### PR DESCRIPTION
This PR will collect the ethernet driver compatibles that have support for the ethernet MAC configuration from devicetree in release 4.4.

- #100620
- #100318
- #99127
- #100619
- #100106
- #100919