### PR TITLE
soc: silabs: siwx91x: link pm state to power domain and adjust driver

### DIFF
--- a/drivers/dma/dma_silabs_siwx91x.c
+++ b/drivers/dma/dma_silabs_siwx91x.c
@@ -669,6 +669,7 @@ static void siwx91x_dma_isr(const struct device *dev)
 	}
 
 	if (data->chan_info[channel].Cnt == data->chan_info[channel].Size) {
+		sys_write32(BIT(channel), (mem_addr_t)&cfg->reg->UDMA_DONE_STATUS_REG);
 		if (data->zephyr_channel_info[channel].channel_active) {
 			pm_device_runtime_put_async(dev, K_NO_WAIT);
 			data->zephyr_channel_info[channel].channel_active = false;
@@ -678,7 +679,6 @@ static void siwx91x_dma_isr(const struct device *dev)
 			data->zephyr_channel_info[channel].dma_callback(
 				dev, data->zephyr_channel_info[channel].cb_data, channel, 0);
 		}
-		sys_write32(BIT(channel), (mem_addr_t)&cfg->reg->UDMA_DONE_STATUS_REG);
 	} else {
 		/* Call UDMA ROM IRQ handler. */
 		ROMAPI_UDMA_WRAPPER_API->uDMAx_IRQHandler(&udma_resources, udma_resources.desc,

--- a/drivers/dma/dma_silabs_siwx91x.c
+++ b/drivers/dma/dma_silabs_siwx91x.c
@@ -14,7 +14,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
-#include <zephyr/pm/policy.h>
+#include <zephyr/pm/device_runtime.h>
 #include <zephyr/types.h>
 #include "rsi_rom_udma.h"
 #include "rsi_rom_udma_wrapper.h"
@@ -62,16 +62,6 @@ struct dma_siwx91x_data {
 					      * related information
 					      */
 };
-
-static void siwx91x_dma_pm_policy_state_lock_get(void)
-{
-	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-}
-
-static void siwx91x_dma_pm_policy_state_lock_put(void)
-{
-	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-}
 
 static enum dma_xfer_dir siwx91x_transfer_direction(uint32_t dir)
 {
@@ -495,15 +485,14 @@ static int siwx91x_dma_start(const struct device *dev, uint32_t channel)
 		return -EINVAL;
 	}
 
-	/* Get the power management policy state lock */
 	if (!data->zephyr_channel_info[channel].channel_active) {
-		siwx91x_dma_pm_policy_state_lock_get();
+		pm_device_runtime_get(dev);
 		data->zephyr_channel_info[channel].channel_active = true;
 	}
 
 	if (RSI_UDMA_ChannelEnable(udma_handle, channel) != 0) {
 		if (data->zephyr_channel_info[channel].channel_active) {
-			siwx91x_dma_pm_policy_state_lock_put();
+			pm_device_runtime_put(dev);
 			data->zephyr_channel_info[channel].channel_active = false;
 		}
 		return -EINVAL;
@@ -534,7 +523,7 @@ static int siwx91x_dma_stop(const struct device *dev, uint32_t channel)
 	}
 
 	if (data->zephyr_channel_info[channel].channel_active) {
-		siwx91x_dma_pm_policy_state_lock_put();
+		pm_device_runtime_put(dev);
 		data->zephyr_channel_info[channel].channel_active = false;
 	}
 
@@ -680,16 +669,16 @@ static void siwx91x_dma_isr(const struct device *dev)
 	}
 
 	if (data->chan_info[channel].Cnt == data->chan_info[channel].Size) {
+		if (data->zephyr_channel_info[channel].channel_active) {
+			pm_device_runtime_put_async(dev, K_NO_WAIT);
+			data->zephyr_channel_info[channel].channel_active = false;
+		}
 		if (data->zephyr_channel_info[channel].dma_callback) {
 			/* Transfer complete, call user callback */
 			data->zephyr_channel_info[channel].dma_callback(
 				dev, data->zephyr_channel_info[channel].cb_data, channel, 0);
 		}
 		sys_write32(BIT(channel), (mem_addr_t)&cfg->reg->UDMA_DONE_STATUS_REG);
-		if (data->zephyr_channel_info[channel].channel_active) {
-			siwx91x_dma_pm_policy_state_lock_put();
-			data->zephyr_channel_info[channel].channel_active = false;
-		}
 	} else {
 		/* Call UDMA ROM IRQ handler. */
 		ROMAPI_UDMA_WRAPPER_API->uDMAx_IRQHandler(&udma_resources, udma_resources.desc,

--- a/drivers/i2s/i2s_silabs_siwx91x.c
+++ b/drivers/i2s/i2s_silabs_siwx91x.c
@@ -442,9 +442,7 @@ static void i2s_siwx91x_dma_rx_callback(const struct device *dma_dev, void *user
 
 rx_disable:
 	i2s_siwx91x_stream_disable(stream, dma_dev);
-	if (stream->state == I2S_STATE_READY && stream->last_block) {
-		pm_device_runtime_put_async(i2s_dev, K_NO_WAIT);
-	}
+	pm_device_runtime_put_async(i2s_dev, K_NO_WAIT);
 }
 
 static void i2s_siwx91x_dma_tx_callback(const struct device *dma_dev, void *user_data,
@@ -511,9 +509,7 @@ static void i2s_siwx91x_dma_tx_callback(const struct device *dma_dev, void *user
 
 tx_disable:
 	i2s_siwx91x_stream_disable(stream, dma_dev);
-	if (stream->state == I2S_STATE_READY && stream->last_block) {
-		pm_device_runtime_put_async(i2s_dev, K_NO_WAIT);
-	}
+	pm_device_runtime_put_async(i2s_dev, K_NO_WAIT);
 }
 
 static int i2s_siwx91x_param_config(const struct device *dev, enum i2s_dir dir)

--- a/drivers/power_domain/power_domain_silabs_siwx91x.c
+++ b/drivers/power_domain/power_domain_silabs_siwx91x.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/pm/device.h>
-#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/policy.h>
 
 #define DT_DRV_COMPAT silabs_siwx91x_power_domain
 
@@ -13,10 +13,12 @@ static int siwx91x_pd_pm_action(const struct device *dev, enum pm_device_action 
 {
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
+		pm_policy_device_power_lock_get(dev);
 		pm_device_children_action_run(dev, PM_DEVICE_ACTION_TURN_ON, NULL);
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
 		pm_device_children_action_run(dev, PM_DEVICE_ACTION_TURN_OFF, NULL);
+		pm_policy_device_power_lock_put(dev);
 		break;
 	case PM_DEVICE_ACTION_TURN_ON:
 		break;

--- a/drivers/spi/spi_silabs_siwx91x_gspi.c
+++ b/drivers/spi/spi_silabs_siwx91x_gspi.c
@@ -555,6 +555,7 @@ static int gspi_siwx91x_transceive(const struct device *dev, const struct spi_co
 		ret = gspi_siwx91x_config(dev, config, cb, userdata);
 		if (ret) {
 			spi_context_release(&data->ctx, ret);
+			pm_device_runtime_put(dev);
 			return ret;
 		}
 	}
@@ -566,6 +567,9 @@ static int gspi_siwx91x_transceive(const struct device *dev, const struct spi_co
 	if (spi_siwx91x_is_dma_enabled_instance(dev)) {
 		/* Perform DMA transceive */
 		ret = gspi_siwx91x_transceive_dma(dev, config);
+		if (ret < 0) {
+			pm_device_runtime_put(dev);
+		}
 		spi_context_release(&data->ctx, ret);
 	} else {
 		/* Perform synchronous polling transceive */

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -134,6 +134,7 @@
 		siwx91x_soc_pd: siwx91x-soc-pd {
 			compatible = "silabs,siwx91x-power-domain";
 			#power-domain-cells = <0>;
+			zephyr,disabling-power-states = <&pstate_ps4_sleep>;
 			zephyr,pm-device-runtime-auto;
 			status = "okay";
 		};

--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -27,6 +27,9 @@ configdefault PM_DEVICE_RUNTIME
 configdefault POWER_DOMAIN
 	default y
 
+configdefault PM_POLICY_DEVICE_CONSTRAINTS
+	default y
+
 endif # PM_DEVICE
 
 if SILABS_SIWX91X_NWP


### PR DESCRIPTION
The goal of this PR is to have correlation between pm state of the cpu and the soc power domain.
It also correct the driver behavior that are on the power domain.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/103339