### PR TITLE
RFC: doc: glossary: Consolidate "software component" as a term

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -127,8 +127,9 @@ Glossary of Terms
       executing on the processor.
 
    kernel
-      The set of Zephyr-supplied files that implement the Zephyr kernel,
-      including its core services, device drivers, network stack, and so on.
+      The :term:`software component` in Zephyr that provides the
+      hardware-agnostic core of the RTOS, including booting, threading,
+      scheduling, synchronization, user mode, memory management and more.
 
    power domain
       A power domain is a collection of devices for which power is
@@ -169,9 +170,9 @@ Glossary of Terms
       features, and that the vendor typically names and markets together.
 
    software component
-      A software component is a self-contained, modular, and replaceable part of
-      the Zephyr source code. A driver, a subsystem or an applications are all
-      examples of software components present in Zephyr.
+      A software component is a well-defined and modular part of
+      the Zephyr source code. The kernel, a driver, a library, a subsystem or a
+      sample are all examples of software components present in Zephyr.
 
    subsystem
        A subsystem refers to a logically distinct part of the operating system

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -23,11 +23,11 @@ The Zephyr kernel supports multiple architectures, including:
 
 The full list of supported boards based on these architectures can be found :ref:`here <boards>`.
 
-In the context of the Zephyr OS, a :term:`subsystem` refers to a logically distinct
+In the context of the Zephyr OS, a :term:`software component` refers to a logically distinct
 part of the operating system that handles specific functionality or provides
-certain services. Subsystems can include components such as networking,
+certain services. Zephyr contains software components such as networking,
 file systems, device driver classes, power management, and communication protocols,
-among others. Each subsystem is designed to be modular and can be configured,
+among others. Each software component is designed to be modular and can be configured,
 customized, and extended to meet the requirements of different embedded
 applications.
 
@@ -182,7 +182,7 @@ Zephyr offers a large and ever growing number of features including:
 
 **Native port**
   :zephyr:board:`Native sim <native_sim>` allows running Zephyr as a Linux application with support
-  for various subsystems and networking.
+  for most components, including networking.
 
 
 .. include:: ../../README.rst


### PR DESCRIPTION
In order to define different parts of the Zephyr codebase, we first need a clear term that defines what a "part of the software" is, so generalize the existing term "software component" to be used from now on as the standardized term.

Given that the kernel is currently defined, as per: https://docs.zephyrproject.org/latest/kernel/services/index.html as:
"The Zephyr kernel lies at the heart of every Zephyr application. It provides a low footprint, high performance, multi-threaded execution environment with a rich set of available features. The rest of the Zephyr ecosystem, including device drivers, networking stack, and application-specific code, uses the kernel’s features to create a complete application."

label it as a software component as well.