### PR TITLE
sensor: afbr_s50: Do not cut data-stream due to payload status

### DIFF
--- a/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
+++ b/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
@@ -119,7 +119,7 @@ static void data_ready_work_handler(struct rtio_iodev_sqe *iodev_sqe)
 						   0;
 
 	status = Argus_EvaluateData(data->platform.argus.handle, &edata->payload);
-	if (status != STATUS_OK || edata->payload.Status != STATUS_OK) {
+	if (status != STATUS_OK) {
 		LOG_ERR("Data not valid: %d, %d", status, edata->payload.Status);
 		handle_error_on_result(data, -EIO);
 	}


### PR DESCRIPTION
The payload status is evaluated when decoding, which may indicate sharp distance transitions (from very long to close) and requiring a few more cycles to stabilize. We don't want to stop the data-stream because of these, otherwise the data-stream continuity is compromised.