### PR TITLE
tests: secure_storage: Options for auto erase for dependent test

### DIFF
--- a/tests/subsys/secure_storage/psa/its/CMakeLists.txt
+++ b/tests/subsys/secure_storage/psa/its/CMakeLists.txt
@@ -1,4 +1,15 @@
 cmake_minimum_required(VERSION 3.20.0)
+
+if((DEFINED SECURE_STORAGE_PSA_ITS_FLASH_ERASE_FIX) OR (BOARD MATCHES ".*/max32.*/ns"))
+  macro(app_set_runner_args)
+    board_runner_args(dfu-util "--dfuse-modifiers=force:mass-erase")
+    board_runner_args(pyocd "--erase")
+    board_runner_args(jlink "--erase")
+    board_runner_args(nrfjprog "--erase")
+    board_runner_args(openocd "--erase")
+  endmacro()
+endif()
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(app)
 


### PR DESCRIPTION
One test in the PSA ITS test requires the storage be empty/cleared before running the tests, and many NS targets can't clear the flash themselves, so add the option to opt into adjusting the runner args to make them erase when flashing the test application, and also default this on MAX32 NS targets.

A form of this was proposed in #97529 and I'm working to address the case where you can in fact erase this in the test itself in #99701 but for NS targets, we still need some way to erase as part of the flashing operation, so I'm proposing this again with some slight modifications to be *opt in* via CMake variable, and have also defaulted this in via BOARD matching for our max32 targets.

Thoughts?