### PR TITLE
dts: arm: nuvoton: add PWM nodes for numaker m333x

### DIFF
--- a/dts/arm/nuvoton/m333x.dtsi
+++ b/dts/arm/nuvoton/m333x.dtsi
@@ -339,6 +339,30 @@
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
+
+		epwm0: epwm@40058000 {
+			compatible = "nuvoton,numaker-pwm";
+			reg = <0x40058000 0x37c>;
+			interrupts = <25 0>, <26 0>, <27 0>;
+			interrupt-names = "pair0", "pair1", "pair2";
+			resets = <&rst NUMAKER_EPWM0_RST>;
+			prescaler = <19>;
+			clocks = <&pcc NUMAKER_EPWM0_MODULE NUMAKER_CLK_CLKSEL2_EPWM0SEL_PCLK0 0>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		epwm1: epwm@40059000 {
+			compatible = "nuvoton,numaker-pwm";
+			reg = <0x40059000 0x37c>;
+			interrupts = <29 0>, <30 0>, <31 0>;
+			interrupt-names = "pair0", "pair1", "pair2";
+			resets = <&rst NUMAKER_EPWM1_RST>;
+			prescaler = <19>;
+			clocks = <&pcc NUMAKER_EPWM1_MODULE NUMAKER_CLK_CLKSEL2_EPWM1SEL_PCLK1 0>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/numaker_m3334ki.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/numaker_m3334ki.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Test requires jumper between:
+ *  - EVB's D3(PC10) -- D5(PC12)
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	zephyr,user {
+		pwms = <&epwm1 2 PWM_MSEC(2) PWM_POLARITY_NORMAL>;
+		gpios = <&gpioc 12 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	epwm1_default: epwm1_default {
+		group0 {
+			/* EVB's D3 --> PC10 */
+			pinmux = <PC10MFP_EPWM1_CH2>;
+		};
+	};
+};
+
+&epwm1 {
+	status = "okay";
+	prescaler = <19>;
+	pinctrl-0 = <&epwm1_default>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
This PR is to add PWM nodes for Nuvoton NuMaker M333X series.
Also add support of Nuvoton numaker board numaker_m3334ki in pwm_gpio_loopback test.

Test results on numaker_m3334ki board are as follows:
```
===================================================================
TESTSUITE pwm_gpio_loopback succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [pwm_gpio_loopback]: pass = 2, fail = 0, skip = 0, total = 2 duration = 0.885 seconds
 - PASS - [pwm_gpio_loopback.test_pwm] duration = 0.264 seconds
 - PASS - [pwm_gpio_loopback.test_pwm_cross] duration = 0.621 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```