### PR TITLE
dts: arm: mcxw23x: Fix dts-linter check failure

### DIFF
--- a/dts/arm/nxp/nxp_mcxw23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw23x_common.dtsi
@@ -148,7 +148,7 @@
 		#interrupt-cells = <1>;
 		#address-cells = <0>;
 		interrupts = <4 2>, <5 2>, <6 2>, <7 2>,
-			<32 2>, <33 2>, <34 2>, <35 2>;
+			     <32 2>, <33 2>, <34 2>, <35 2>;
 		num-lines = <8>;
 		num-inputs = <64>;
 	};


### PR DESCRIPTION
Fix the error:
File:dts/arm/nxp/nxp_mcxw23x_common.dtsi
ERROR   : Test DevicetreeLinting failed:
:Fix indentation. Expecting →→→·····