### PR TITLE
drivers: timer: MCUX os timer improvement

### DIFF
--- a/drivers/timer/Kconfig.mcux_os
+++ b/drivers/timer/Kconfig.mcux_os
@@ -9,6 +9,7 @@ config MCUX_OS_TIMER
 	depends on DT_HAS_NXP_OS_TIMER_ENABLED
 	select TICKLESS_CAPABLE
 	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	select RESET
 	help
 	  This module implements a kernel device driver for the NXP OS
 	  event timer and provides the standard "system clock driver" interfaces.

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -343,7 +343,9 @@ static int sys_clock_driver_init(void)
 /* On some SoC's, OS Timer cannot wakeup from low power mode in standby modes */
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
 	counter_dev = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(0, deep_sleep_counter));
-	counter_max_val = counter_get_max_top_value(counter_dev);
+	if (NULL != counter_dev) {
+		counter_max_val = counter_get_max_top_value(counter_dev);
+	}
 #endif
 
 #if (DT_INST_PROP(0, wakeup_source))

--- a/dts/arm/nxp/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/nxp_mcxa153.dtsi
@@ -339,6 +339,7 @@
 			compatible = "nxp,os-timer";
 			reg = <0x400ad000 0x1000>;
 			interrupts = <57 0>;
+			resets = <&reset NXP_SYSCON_RESET(0, 25)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -8,6 +8,7 @@
 #include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -516,6 +516,7 @@
 			compatible = "nxp,os-timer";
 			reg = <0x400ad000 0x1000>;
 			interrupts = <57 0>;
+			resets = <&reset NXP_SYSCON_RESET(1, 0)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/nxp_mcxa344.dtsi
@@ -458,6 +458,7 @@
 			compatible = "nxp,os-timer";
 			reg = <0x400ad000 0x1000>;
 			interrupts = <57 0>;
+			resets = <&reset NXP_SYSCON_RESET(1, 1)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/nxp_mcxa344.dtsi
@@ -7,6 +7,7 @@
 #include <mem.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 

--- a/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
@@ -8,6 +8,7 @@
 #include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 

--- a/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
@@ -476,6 +476,7 @@
 			compatible = "nxp,os-timer";
 			reg = <0x400ad000 0x1000>;
 			interrupts = <57 0>;
+			resets = <&reset NXP_SYSCON_RESET(1, 0)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -630,6 +630,7 @@
 		compatible = "nxp,os-timer";
 		reg = <0x49000 0x1000>;
 		interrupts = <57 0>;
+		resets = <&reset NXP_SYSCON_RESET(1, 1)>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -726,6 +726,7 @@
 		compatible = "nxp,os-timer";
 		reg = <0x49000 0x1000>;
 		interrupts = <57 0>;
+		resets = <&reset NXP_SYSCON_RESET(1, 1)>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_mcxw23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw23x_common.dtsi
@@ -239,6 +239,7 @@
 		compatible = "nxp,os-timer";
 		reg = <0x2d000 0x1000>;
 		interrupts = <38 1>;
+		resets = <&reset NXP_SYSCON_RESET(1, 1)>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -494,6 +494,7 @@
 		compatible = "nxp,os-timer";
 		reg = <0x113000 0x1000>;
 		interrupts = <41 0>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(0, 27)>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -438,6 +438,7 @@
 		compatible = "nxp,os-timer";
 		reg = <0x113000 0x1000>;
 		interrupts = <41 0>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(0, 27)>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -610,6 +610,7 @@
 		compatible = "nxp,os-timer";
 		reg = <0x13b000 0x1000>;
 		interrupts = <41 0>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(0, 27)>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/timer/nxp,os-timer.yaml
+++ b/dts/bindings/timer/nxp,os-timer.yaml
@@ -20,3 +20,7 @@ properties:
       Instance of a counter peripheral. The OS Timer maybe powered off in
       certain deep power down modes. The OS Timer driver will use this
       counter to wakeup and also to keep track of system time.
+
+  resets:
+    type: phandle-array
+    description: reset line


### PR DESCRIPTION
1. User reset API to reset the IP.
2. Fix run fail when no deep_sleep_counter used