### PR TITLE
Set AHB RX buffer defaults for FlexSPI cache/DMA on RW612 boards

### DIFF
--- a/samples/drivers/memc/boards/frdm_rw612.overlay
+++ b/samples/drivers/memc/boards/frdm_rw612.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -48,4 +48,6 @@
 &flexspi {
 	pinctrl-0 = <&pinmux_flexspi_safe>;
 	pinctrl-names = "default";
+	rx-buffer-config = <1 0 10 512>, <0 0 0 0>, <0 0 0 0>, <0 0 0 0>,
+			   <0 0 0 0>, <0 0 0 0>, <0 0 0 0>, <1 0 0 512>;
 };

--- a/samples/drivers/memc/boards/rd_rw612_bga.overlay
+++ b/samples/drivers/memc/boards/rd_rw612_bga.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023, 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -39,4 +39,6 @@
  */
 &flexspi {
 	pinctrl-0 = <&pinmux_flexspi_safe>;
+	rx-buffer-config = <1 0 10 512>, <0 0 0 0>, <0 0 0 0>, <0 0 0 0>,
+			   <0 0 0 0>, <0 0 0 0>, <0 0 0 0>, <1 0 0 512>;
 };


### PR DESCRIPTION
This PR updates the FRDM and RD RW612 board overlays for the MEMC sample to provide explicit AHB RX buffer configuration for the FlexSPI controller, ensuring proper cache and DMA functionality when PSRAM is enabled.