### PR TITLE
drivers/pwm/it8xxx2: add pwm init output level property

### DIFF
--- a/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
+++ b/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
@@ -28,6 +28,12 @@ properties:
       3 = PWM_CHANNEL_3, 4 = PWM_CHANNEL_4, 5 = PWM_CHANNEL_5,
       6 = PWM_CHANNEL_6, 7 = PWM_CHANNEL_7
 
+  pwm-init-high:
+    type: boolean
+    description: |
+      After setting PWM pin to alternate mode, initialize PWM pin to output high,
+      otherwise output low.
+
   pwmctrl:
     type: phandle
     required: true


### PR DESCRIPTION
When EC reboot, pwm pins go back to default GPI mode, and after we set pin mode to pwm mode, it would output low, this may cause PWM-LED flicker, so add the property to set PWM channel init output level.