### PR TITLE
soc: silabs: Fix clock control dependency declarations

### DIFF
--- a/drivers/adc/Kconfig.silabs
+++ b/drivers/adc/Kconfig.silabs
@@ -15,6 +15,7 @@ config ADC_SILABS_IADC
 	bool "Silabs Incremental ADC driver"
 	default y
 	depends on DT_HAS_SILABS_IADC_ENABLED
+	depends on CLOCK_CONTROL
 	select SILABS_SISDK_IADC
 	select ADC_CONFIGURABLE_INPUTS
 	help

--- a/drivers/comparator/Kconfig.silabs_acmp
+++ b/drivers/comparator/Kconfig.silabs_acmp
@@ -4,6 +4,7 @@ config COMPARATOR_SILABS_ACMP
 	bool "Silabs ACMP comparator driver"
 	default y
 	depends on DT_HAS_SILABS_ACMP_ENABLED
+	depends on CLOCK_CONTROL
 	select PINCTRL
 	select SILABS_SISDK_ACMP
 	help

--- a/drivers/dac/Kconfig.silabs
+++ b/drivers/dac/Kconfig.silabs
@@ -5,6 +5,7 @@ config DAC_SILABS_VDAC
 	bool "Silabs DAC driver for VDAC"
 	default y
 	depends on DT_HAS_SILABS_VDAC_ENABLED
+	depends on CLOCK_CONTROL
 	select PINCTRL
 	select SILABS_SISDK_VDAC
 	help

--- a/drivers/gpio/Kconfig.silabs
+++ b/drivers/gpio/Kconfig.silabs
@@ -5,6 +5,7 @@ menuconfig GPIO_SILABS
 	bool "Silabs GPIO driver"
 	default y
 	depends on DT_HAS_SILABS_GPIO_ENABLED
+	depends on CLOCK_CONTROL
 	select SILABS_SISDK_GPIO
 	help
 	  Enable the Silabs gpio driver.

--- a/drivers/i2c/Kconfig.silabs
+++ b/drivers/i2c/Kconfig.silabs
@@ -5,6 +5,7 @@ menuconfig I2C_SILABS
 	bool "Silabs I2C_S2 driver"
 	default y
 	depends on DT_HAS_SILABS_I2C_ENABLED
+	depends on CLOCK_CONTROL
 	select SILABS_SISDK_I2C
 	help
 		Enable I2C series 2 driver for the Silabs gecko SoC series.

--- a/drivers/pwm/Kconfig.silabs
+++ b/drivers/pwm/Kconfig.silabs
@@ -5,6 +5,7 @@ config PWM_SILABS_LETIMER
 	bool "Silabs LETIMER PWM driver"
 	default y
 	depends on DT_HAS_SILABS_LETIMER_PWM_ENABLED
+	depends on CLOCK_CONTROL
 	select SILABS_SISDK_LETIMER
 	help
 	  Enable the PWM driver for the LETIMER peripheral on Silabs Series 2 SoCs.
@@ -17,6 +18,7 @@ config PWM_SILABS_TIMER
 	bool "Silabs TIMER PWM driver"
 	default y
 	depends on DT_HAS_SILABS_TIMER_PWM_ENABLED
+	depends on CLOCK_CONTROL
 	select SILABS_SISDK_TIMER
 	help
 	  Enable the PWM driver for the TIMER peripheral on Silabs Series 2 SoCs.

--- a/drivers/retained_mem/Kconfig.silabs
+++ b/drivers/retained_mem/Kconfig.silabs
@@ -5,5 +5,6 @@ config RETAINED_MEM_SILABS_BURAM
 	bool "Silicon Labs BURAM driver"
 	default y
 	depends on DT_HAS_SILABS_BURAM_ENABLED
+	depends on CLOCK_CONTROL
 	help
 	  Enable driver for Silicon Labs BURAM-based retained memory register support.

--- a/drivers/spi/Kconfig.silabs_eusart
+++ b/drivers/spi/Kconfig.silabs_eusart
@@ -9,6 +9,7 @@ config SPI_SILABS_EUSART
 	default y
 	depends on DT_HAS_SILABS_EUSART_SPI_ENABLED
 	depends on GPIO
+	depends on CLOCK_CONTROL
 	select SILABS_SISDK_EUSART
 	select PINCTRL if SOC_FAMILY_SILABS_S2
 	help

--- a/soc/silabs/silabs_s2/Kconfig.defconfig
+++ b/soc/silabs/silabs_s2/Kconfig.defconfig
@@ -20,6 +20,9 @@ configdefault SILABS_SLEEPTIMER_TIMER
 configdefault CORTEX_M_SYSTICK
 	default n if SILABS_SLEEPTIMER_TIMER || GECKO_BURTC_TIMER
 
+configdefault CLOCK_CONTROL
+	default y
+
 # silabs_s2 uses simplicity_sdk hal library, which already have by default a zero latency
 # IRQs mechanism with a hardcoded value. In order to be aligned with simplicity_sdk, we
 # need to activate Zero Latency IRQ in Zephyr by default. The level (2) depends on the


### PR DESCRIPTION
Most drivers for Series 2 depend on clock control, but didn't declare it. Enable clock control by default for Series 2 SoCs.

Fixes #100151 