### PR TITLE
Bluetooth: Classic: HFP_HF: Refactor at parser

### DIFF
--- a/subsys/bluetooth/host/classic/at.c
+++ b/subsys/bluetooth/host/classic/at.c
@@ -17,11 +17,41 @@
 
 #include "at.h"
 
+typedef bool (*pull_char_t)(uint8_t *c, void *data);
+
+static void pull_chars(struct net_buf_simple *buf, pull_char_t cb, void *data)
+{
+	while (buf->len > 0) {
+		if (!cb(buf->data, data)) {
+			break;
+		}
+		net_buf_simple_pull_u8(buf);
+	}
+}
+
+struct at_comma_data {
+	bool found;
+};
+
+static bool pull_comma(uint8_t *c, void *data)
+{
+	struct at_comma_data *comma_data = data;
+
+	if (comma_data->found) {
+		return false;
+	}
+
+	comma_data->found = *c == ',';
+	return comma_data->found;
+}
+
 static void next_list(struct at_client *at)
 {
-	if (at->buf[at->pos] == ',') {
-		at->pos++;
-	}
+	struct at_comma_data data;
+
+	data.found = false;
+
+	pull_chars(&at->rsp_buf, pull_comma, &data);
 }
 
 int at_check_byte(struct net_buf *buf, char check_byte)
@@ -36,52 +66,87 @@ int at_check_byte(struct net_buf *buf, char check_byte)
 	return 0;
 }
 
+static bool pull_space(uint8_t *c, void *data)
+{
+	return *c == ' ';
+}
+
 static void skip_space(struct at_client *at)
 {
-	while (at->buf[at->pos] == ' ') {
-		at->pos++;
+	pull_chars(&at->rsp_buf, pull_space, NULL);
+}
+
+struct at_number_data {
+	uint32_t val;
+	bool found;
+};
+
+static bool pull_number(uint8_t *c, void *data)
+{
+	struct at_number_data *num_data = data;
+
+	if (isdigit((unsigned char)(*c)) == 0) {
+		return false;
 	}
+
+	num_data->found = true;
+	num_data->val = num_data->val * 10 + *c - (uint8_t)'0';
+	return true;
 }
 
 int at_get_number(struct at_client *at, uint32_t *val)
 {
-	uint32_t i;
+	struct at_number_data data;
 
 	skip_space(at);
 
-	for (i = 0U, *val = 0U;
-	     isdigit((unsigned char)at->buf[at->pos]) != 0;
-	     at->pos++, i++) {
-		*val = *val * 10U + at->buf[at->pos] - '0';
-	}
+	data.found = false;
+	data.val = 0;
 
-	if (i == 0U) {
+	pull_chars(&at->rsp_buf, pull_number, &data);
+
+	if (!data.found) {
 		return -ENODATA;
 	}
+
+	*val = data.val;
 
 	next_list(at);
 	return 0;
 }
 
-static bool str_has_prefix(const char *str, const char *prefix)
+static bool str_has_prefix(struct at_client *at, const char *prefix)
 {
-	if (strncmp(str, prefix, strlen(prefix)) != 0) {
+	size_t len = strlen(prefix);
+
+	if (at->rsp_buf.len < len) {
+		return false;
+	}
+
+	if (strncmp(at->rsp_buf.data, prefix, len) != 0) {
 		return false;
 	}
 
 	return true;
 }
 
-static int at_parse_result(const char *str, struct net_buf *buf,
+static int at_parse_result(struct at_client *at, struct net_buf *buf,
 			   enum at_result *result)
 {
+	char *ok = "OK";
+	char *error = "ERROR";
+	size_t ok_len = strlen(ok);
+	size_t error_len = strlen(error);
+
 	/* Map the result and check for end lf */
-	if ((!strncmp(str, "OK", 2)) && (at_check_byte(buf, '\n') == 0)) {
+	if ((at->rsp_buf.len >= ok_len) && (strncmp(at->rsp_buf.data, ok, ok_len) == 0) &&
+	    (at_check_byte(buf, '\n') == 0)) {
 		*result = AT_RESULT_OK;
 		return 0;
 	}
 
-	if ((!strncmp(str, "ERROR", 5)) && (at_check_byte(buf, '\n')) == 0) {
+	if ((at->rsp_buf.len >= error_len) && (strncmp(at->rsp_buf.data, error, error_len) == 0) &&
+	    (at_check_byte(buf, '\n') == 0)) {
 		*result = AT_RESULT_ERROR;
 		return 0;
 	}
@@ -89,31 +154,38 @@ static int at_parse_result(const char *str, struct net_buf *buf,
 	return -ENOMSG;
 }
 
+static void init_rsp_buffer(struct at_client *at, struct net_buf *buf)
+{
+	at->rsp_buf.data = buf->data;
+	at->rsp_buf.__buf = buf->data;
+	at->rsp_buf.size = buf->len;
+	/* Although the valid data is buf->data[0:buf->len], at->rsp_buf.len is set to 0 here.
+	 * This is because it is unclear how much data needs to be processed.
+	 * The value at->rsp_buf.len will be updated later when preprocess the received AT
+	 * responses or unsolicited response code.
+	 */
+	at->rsp_buf.len = 0;
+}
+
 static int get_cmd_value(struct at_client *at, struct net_buf *buf,
 			 char stop_byte, enum at_cmd_state cmd_state)
 {
-	int cmd_len = 0;
-	uint8_t pos = at->pos;
-	const char *str = (char *)buf->data;
+	if (at->rsp_buf.len == 0) {
+		init_rsp_buffer(at, buf);
+	}
 
-	while (cmd_len < buf->len && at->pos != at->buf_max_len) {
-		if (*str != stop_byte) {
-			at->buf[at->pos++] = *str;
-			cmd_len++;
-			str++;
-			pos = at->pos;
-		} else {
-			cmd_len++;
-			at->buf[at->pos] = '\0';
-			at->pos = 0U;
+	while (buf->len > 0) {
+		if (buf->data[0] == stop_byte) {
 			at->cmd_state = cmd_state;
+			net_buf_pull_u8(buf);
 			break;
 		}
+		net_buf_simple_add(&at->rsp_buf, sizeof(uint8_t));
+		net_buf_pull_u8(buf);
 	}
-	net_buf_pull(buf, cmd_len);
 
-	if (pos == at->buf_max_len) {
-		return -ENOBUFS;
+	if (at->rsp_buf.len == 0) {
+		return -ENODATA;
 	}
 
 	return 0;
@@ -126,46 +198,45 @@ static bool is_stop_byte(char target, char *stop_string)
 
 static bool is_vgm_or_vgs(struct at_client *at)
 {
-	if (!strcmp(at->buf, "VGM")) {
+	if (at->rsp_buf.len == 0) {
+		return false;
+	}
+
+	if (!strncmp(at->rsp_buf.data, "VGM", strlen("VGM"))) {
 		return true;
 	}
 
-	if (!strcmp(at->buf, "VGS")) {
+	if (!strncmp(at->rsp_buf.data, "VGS", strlen("VGS"))) {
 		return true;
 	}
+
 	return false;
 }
 
 static int get_response_string(struct at_client *at, struct net_buf *buf, char *stop_string,
 			       enum at_state state)
 {
-	int cmd_len = 0;
-	uint8_t pos = at->pos;
-	const char *str = (char *)buf->data;
+	if (at->rsp_buf.len == 0) {
+		init_rsp_buffer(at, buf);
+	}
 
-	while (cmd_len < buf->len && at->pos != at->buf_max_len) {
-		if (!is_stop_byte(*str, stop_string)) {
-			at->buf[at->pos++] = *str;
-			cmd_len++;
-			str++;
-			pos = at->pos;
-		} else {
-			char stop_byte = at->buf[at->pos];
+	while (buf->len > 0) {
+		if (is_stop_byte(buf->data[0], stop_string)) {
+			char stop_byte = buf->data[0];
 
-			cmd_len++;
-			at->buf[at->pos] = '\0';
-			at->pos = 0U;
 			at->state = state;
 			if ((stop_byte == '=') && !is_vgm_or_vgs(at)) {
 				return -EINVAL;
 			}
+			net_buf_pull_u8(buf);
 			break;
 		}
+		net_buf_simple_add(&at->rsp_buf, sizeof(uint8_t));
+		net_buf_pull_u8(buf);
 	}
-	net_buf_pull(buf, cmd_len);
 
-	if (pos == at->buf_max_len) {
-		return -ENOBUFS;
+	if (at->rsp_buf.len == 0) {
+		return -ENODATA;
 	}
 
 	return 0;
@@ -173,8 +244,7 @@ static int get_response_string(struct at_client *at, struct net_buf *buf, char *
 
 static void reset_buffer(struct at_client *at)
 {
-	(void)memset(at->buf, 0, at->buf_max_len);
-	at->pos = 0U;
+	net_buf_simple_init_with_data(&at->rsp_buf, NULL, 0);
 }
 
 static int at_state_start(struct at_client *at, struct net_buf *buf)
@@ -224,7 +294,14 @@ static int at_state_get_cmd_string(struct at_client *at, struct net_buf *buf)
 
 static bool is_cmer(struct at_client *at)
 {
-	if (strncmp(at->buf, "CME ERROR", 9) == 0) {
+	char *cmer = "CME ERROR";
+	size_t len = strlen(cmer);
+
+	if (at->rsp_buf.len < len) {
+		return false;
+	}
+
+	if (strncmp(at->rsp_buf.data, cmer, len) == 0) {
 		return true;
 	}
 
@@ -254,7 +331,14 @@ static int at_state_get_result_string(struct at_client *at, struct net_buf *buf)
 
 static bool is_ring(struct at_client *at)
 {
-	if (strncmp(at->buf, "RING", 4) == 0) {
+	char *ring = "RING";
+	size_t len = strlen(ring);
+
+	if (at->rsp_buf.len < len) {
+		return false;
+	}
+
+	if (strncmp(at->rsp_buf.data, ring, len) == 0) {
 		return true;
 	}
 
@@ -271,7 +355,7 @@ static int at_state_process_result(struct at_client *at, struct net_buf *buf)
 		return 0;
 	}
 
-	if (at_parse_result(at->buf, buf, &result) == 0) {
+	if (at_parse_result(at, buf, &result) == 0) {
 		if (at->finish) {
 			/* cme_err is 0 - Is invalid until result is
 			 * AT_RESULT_CME_ERROR
@@ -359,7 +443,7 @@ static int at_cmd_start(struct at_client *at, struct net_buf *buf,
 			const char *prefix, parse_val_t func,
 			enum at_cmd_type type)
 {
-	if (!str_has_prefix(at->buf, prefix)) {
+	if (!str_has_prefix(at, prefix)) {
 		if (type == AT_CMD_TYPE_NORMAL) {
 			at->state = AT_STATE_UNSOLICITED_CMD;
 		}
@@ -447,66 +531,147 @@ int at_parse_cmd_input(struct at_client *at, struct net_buf *buf,
 	return 0;
 }
 
-int at_has_next_list(struct at_client *at)
+struct has_next_list_data {
+	bool found;
+};
+
+static bool at_has_next_list_cb(uint8_t *c, void *data)
 {
-	return at->buf[at->pos] != '\0' && at->buf[at->pos] != ')';
+	struct has_next_list_data *list_data = data;
+
+	list_data->found = *c != ')';
+	return false;
+}
+
+bool at_has_next_list(struct at_client *at)
+{
+	struct has_next_list_data data;
+
+	data.found = false;
+
+	pull_chars(&at->rsp_buf, at_has_next_list_cb, &data);
+
+	return data.found;
+}
+
+struct open_list_data {
+	bool found;
+};
+
+static bool at_open_list_cb(uint8_t *c, void *data)
+{
+	struct open_list_data *list_data = data;
+
+	if (list_data->found) {
+		return false;
+	}
+
+	list_data->found = *c == '(';
+	return list_data->found;
 }
 
 int at_open_list(struct at_client *at)
 {
+	struct open_list_data data;
+
 	skip_space(at);
 
-	/* The list shall start with '(' open parenthesis */
-	if (at->buf[at->pos] != '(') {
+	data.found = false;
+
+	pull_chars(&at->rsp_buf, at_open_list_cb, &data);
+
+	if (!data.found) {
 		return -ENODATA;
 	}
-	at->pos++;
 
 	return 0;
+}
+
+struct close_list_data {
+	bool found;
+};
+
+static bool at_close_list_cb(uint8_t *c, void *data)
+{
+	struct close_list_data *list_data = data;
+
+	if (list_data->found) {
+		return false;
+	}
+
+	list_data->found = *c == ')';
+	return list_data->found;
 }
 
 int at_close_list(struct at_client *at)
 {
+	struct close_list_data data;
+
 	skip_space(at);
 
-	if (at->buf[at->pos] != ')') {
+	data.found = false;
+
+	pull_chars(&at->rsp_buf, at_close_list_cb, &data);
+
+	if (!data.found) {
 		return -ENODATA;
 	}
-	at->pos++;
-
 	next_list(at);
 
 	return 0;
+}
+
+struct get_string_data {
+	uint8_t *start;
+	uint8_t *end;
+};
+
+static bool at_get_string_cb(uint8_t *c, void *data)
+{
+	struct get_string_data *str_data = data;
+
+	if ((str_data->start != NULL) && (str_data->end != NULL)) {
+		return false;
+	}
+
+	if (str_data->start == NULL) {
+		if (*c != '"') {
+			return false;
+		}
+		str_data->start = c + 1;
+		return true;
+	}
+
+	if (*c == '"') {
+		str_data->end = c;
+	}
+
+	return true;
 }
 
 int at_list_get_string(struct at_client *at, char *name, uint8_t len)
 {
-	int i = 0;
+	struct get_string_data data;
+	size_t str_len;
 
 	skip_space(at);
 
-	if (at->buf[at->pos] != '"') {
-		return -ENODATA;
-	}
-	at->pos++;
+	data.start = NULL;
+	data.end = NULL;
 
-	while (at->buf[at->pos] != '\0' && at->buf[at->pos] != '"') {
-		if (i == len) {
-			return -ENODATA;
-		}
-		name[i++] = at->buf[at->pos++];
-	}
+	pull_chars(&at->rsp_buf, at_get_string_cb, &data);
 
-	if (i == len) {
+	if (data.start >= data.end) {
 		return -ENODATA;
 	}
 
-	name[i] = '\0';
-
-	if (at->buf[at->pos] != '"') {
-		return -ENODATA;
+	str_len = data.end - data.start;
+	if (str_len > (len - 1)) {
+		return -ENOMEM;
 	}
-	at->pos++;
+
+	memcpy(name, data.start, str_len);
+	name[str_len] = '\0';
 
 	skip_space(at);
 	next_list(at);
@@ -514,28 +679,40 @@ int at_list_get_string(struct at_client *at, char *name, uint8_t len)
 	return 0;
 }
 
+struct get_range_connector_data {
+	bool found;
+};
+
+static bool at_get_range_connector_cb(uint8_t *c, void *data)
+{
+	struct get_range_connector_data *connector_data = data;
+
+	if (connector_data->found) {
+		return false;
+	}
+
+	connector_data->found = *c == '-';
+
+	return connector_data->found;
+}
+
 int at_list_get_range(struct at_client *at, uint32_t *min, uint32_t *max)
 {
+	struct get_range_connector_data data;
 	uint32_t low, high;
-	int ret;
+	int err;
 
-	ret = at_get_number(at, &low);
-	if (ret < 0) {
-		return ret;
+	err = at_get_number(at, &low);
+	if (err < 0) {
+		return err;
 	}
 
-	if (at->buf[at->pos] == '-') {
-		at->pos++;
-		goto out;
-	}
+	data.found = false;
+	pull_chars(&at->rsp_buf, at_get_range_connector_cb, &data);
 
-	if (isdigit((unsigned char)at->buf[at->pos]) == 0) {
-		return -ENODATA;
-	}
-out:
-	ret = at_get_number(at, &high);
-	if (ret < 0) {
-		return ret;
+	err = at_get_number(at, &high);
+	if (err < 0) {
+		return err;
 	}
 
 	*min = low;
@@ -560,56 +737,68 @@ void at_register(struct at_client *at, at_resp_cb_t resp, at_finish_cb_t finish)
 
 char *at_get_string(struct at_client *at)
 {
-	uint8_t pos = at->pos;
-	char *string;
+	struct get_string_data data;
 
 	skip_space(at);
 
-	if (at->buf[at->pos] != '"') {
-		at->pos = pos;
-		return NULL;
-	}
-	at->pos++;
-	string = &at->buf[at->pos];
+	data.start = NULL;
+	data.end = NULL;
 
-	while (at->buf[at->pos] != '\0' && at->buf[at->pos] != '"') {
-		at->pos++;
-	}
+	pull_chars(&at->rsp_buf, at_get_string_cb, &data);
 
-	if (at->buf[at->pos] != '"') {
-		at->pos = pos;
+	if (data.start >= data.end) {
 		return NULL;
 	}
 
-	at->buf[at->pos] = '\0';
-	at->pos++;
+	data.end[0] = '\0';
 
 	skip_space(at);
 	next_list(at);
 
-	return string;
+	return data.start;
+}
+
+struct get_raw_string_data {
+	uint8_t *start;
+	uint8_t *end;
+};
+
+static bool at_get_raw_string_cb(uint8_t *c, void *data)
+{
+	struct get_raw_string_data *str_data = data;
+
+	if ((*c == ',') || (*c == ')')) {
+		return false;
+	}
+
+	if (str_data->start == NULL) {
+		str_data->start = c;
+	}
+	str_data->end = c;
+	return true;
 }
 
 char *at_get_raw_string(struct at_client *at, size_t *string_len)
 {
-	char *string;
+	struct get_raw_string_data data;
 
 	skip_space(at);
 
-	string = &at->buf[at->pos];
+	data.start = NULL;
+	data.end = NULL;
 
-	while (at->buf[at->pos] != '\0' &&
-		   at->buf[at->pos] != ',' &&
-		   at->buf[at->pos] != ')') {
-		at->pos++;
+	pull_chars(&at->rsp_buf, at_get_raw_string_cb, &data);
+
+	if (data.start > data.end) {
+		return NULL;
 	}
 
-	if (string_len) {
-		*string_len = &at->buf[at->pos] - string;
+	if (string_len != NULL) {
+		*string_len = data.end - data.start + 1;
 	}
 
 	skip_space(at);
 	next_list(at);
 
-	return string;
+	return data.start;
 }

--- a/subsys/bluetooth/host/classic/at.h
+++ b/subsys/bluetooth/host/classic/at.h
@@ -89,9 +89,7 @@ typedef int (*handle_cmd_input_t)(struct at_client *at, struct net_buf *buf,
 				  enum at_cmd_type type);
 
 struct at_client {
-	char *buf;
-	uint8_t pos;
-	uint8_t buf_max_len;
+	struct net_buf_simple rsp_buf;
 	uint8_t state;
 	uint8_t cmd_state;
 	at_resp_cb_t resp;
@@ -115,6 +113,6 @@ int at_list_get_range(struct at_client *at, uint32_t *min, uint32_t *max);
 int at_list_get_string(struct at_client *at, char *name, uint8_t len);
 int at_close_list(struct at_client *at);
 int at_open_list(struct at_client *at);
-int at_has_next_list(struct at_client *at);
+bool at_has_next_list(struct at_client *at);
 char *at_get_string(struct at_client *at);
 char *at_get_raw_string(struct at_client *at, size_t *string_len);

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -1901,11 +1901,11 @@ static const struct unsolicited {
 
 static const struct unsolicited *hfp_hf_unsol_lookup(struct at_client *hf_at)
 {
-	int i;
+	ARRAY_FOR_EACH(handlers, i) {
+		size_t len = strlen(handlers[i].cmd);
 
-	for (i = 0; i < ARRAY_SIZE(handlers); i++) {
-		if (!strncmp(hf_at->buf, handlers[i].cmd,
-			     strlen(handlers[i].cmd))) {
+		if ((hf_at->rsp_buf.len >= len) &&
+		    (strncmp(hf_at->rsp_buf.data, handlers[i].cmd, len) == 0)) {
 			return &handlers[i];
 		}
 	}
@@ -4389,8 +4389,6 @@ static struct bt_hfp_hf *hfp_hf_create(struct bt_conn *conn)
 	}
 
 	hf->acl = conn;
-	hf->at.buf = hf->hf_buffer;
-	hf->at.buf_max_len = HF_MAX_BUF_LEN;
 
 	hf->rfcomm_dlc.ops = &ops;
 	hf->rfcomm_dlc.mtu = BT_HFP_MAX_MTU;

--- a/tests/bluetooth/at/src/main.c
+++ b/tests/bluetooth/at/src/main.c
@@ -15,7 +15,6 @@
 #include <zephyr/ztest.h>
 
 static struct at_client at;
-static char buffer[140];
 
 NET_BUF_POOL_DEFINE(at_pool, 1, 140, 0, NULL);
 
@@ -49,9 +48,6 @@ ZTEST(at_tests, test_at)
 {
 	struct net_buf *buf;
 	int len;
-
-	at.buf_max_len = 140U;
-	at.buf = buffer;
 
 	buf = net_buf_alloc(&at_pool, K_FOREVER);
 	zassert_not_null(buf, "Failed to get buffer");


### PR DESCRIPTION
In current implementation, the additional buffer is required by AT to store the parsing AT response data temporarily. To store the parsed AT response data completely, the buffer size is as high as the MTU of the RFCOMM connection. And the buffer is dedicated for each HFP HF connection. That means the RAM usage depends on the MAX HFP HF connection count. Actually, the RFCOMM receiving buffer is valid when processing the received AT response. The changes aim to remove the additional buffer and leverage the receiving buffer to process the AT response.

And there is an issue found that the type of the additional buffer length is `uint8_t`, while the configured RFCOMM receiving data length is 65535. When the additional buffer length exceeds 255, the AT cannot process the received data normally.

Replace manual buffer management with net_buf_simple in the AT command parser. This change eliminates the need for manual position tracking and buffer length management by leveraging Zephyr's existing buffer utilities. And leverage RFCOMM receiving buffer instead of allocating dedicated buffer.
