### PR TITLE
doc: services: nvmem: Mention flash configuration

### DIFF
--- a/doc/services/nvmem/index.rst
+++ b/doc/services/nvmem/index.rst
@@ -34,6 +34,7 @@ Configuration
 
 * :kconfig:option:`CONFIG_NVMEM`: Enables the NVMEM subsystem.
 * :kconfig:option:`CONFIG_NVMEM_EEPROM`: Enables NVMEM support for EEPROM devices.
+* :kconfig:option-regex:`CONFIG_NVMEM_FLASH.*`: Configure NVMEM support for flash devices.
 
 Devicetree Bindings
 *******************


### PR DESCRIPTION
Add an entry to the configuration section for flash related Kconfig symbols.

Related to https://github.com/zephyrproject-rtos/zephyr/pull/98310