### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: f3cc9476e233364031e9ab842290392f260fba82
+      revision: c11e845e2483917d7478ba1a7a3591a9f4e8d4a2
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  c11e845e2483917d7478ba1a7a3591a9f4e8d4a2

Brings following Zephyr relevant fixes:

 - c11e845e zephyr: mcuboot_config: align nrfx_wdt usage
 - 1bfb51aa zephyr: remove NRFX_WDT instance symbols
 - 85aecf63 iar: Avoid using double colons when defining labels
 - d319cbc6 boot: zephyr: deprecate MBEDTLS_MD

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.