### PR TITLE
drivers: ethernet: renesas: implement get_phy

### DIFF
--- a/drivers/ethernet/eth_renesas_ra.c
+++ b/drivers/ethernet/eth_renesas_ra.c
@@ -309,9 +309,17 @@ error:
 	return -1;
 }
 
+static const struct device *renesas_ra_eth_get_phy(const struct device *dev)
+{
+	const struct renesas_ra_eth_config *config = dev->config;
+
+	return config->phy_dev;
+}
+
 static const struct ethernet_api api_funcs = {
 	.iface_api.init = renesas_ra_eth_initialize,
 	.get_capabilities = renesas_ra_eth_get_capabilities,
+	.get_phy = renesas_ra_eth_get_phy,
 	.send = renesas_ra_eth_tx,
 };
 


### PR DESCRIPTION
implement get_phy for the renesas ethernet
driver.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>