### PR TITLE
zephyr: bluetooth: qualification: remove not supported ICS

### DIFF
--- a/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.bqw
+++ b/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.bqw
@@ -353,7 +353,6 @@
         <Feature>GATT 4/27</Feature>
         <Feature>GATT 4/5</Feature>
         <Feature>GATT 4/6</Feature>
-        <Feature>GATT 7/5</Feature>
         <Feature>GATT 10/7</Feature>
         <Feature>GATT 10/12</Feature>
         <Feature>GATT 9/8</Feature>
@@ -367,7 +366,6 @@
         <Feature>GATT 4/21</Feature>
         <Feature>GATT 4/22</Feature>
         <Feature>GATT 7/4</Feature>
-        <Feature>GATT 7/6</Feature>
         <Feature>GATT 10/11</Feature>
         <Feature>GATT 2/3a</Feature>
         <Feature>GATT 9/2</Feature>
@@ -381,7 +379,6 @@
         <Feature>GATT 3/4</Feature>
         <Feature>GATT 3/9</Feature>
         <Feature>GATT 4/1</Feature>
-        <Feature>GATT 4/13</Feature>
         <Feature>GATT 4/18</Feature>
         <Feature>GATT 4/3</Feature>
         <Feature>GATT 4a/1</Feature>

--- a/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.pts
+++ b/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.pts
@@ -939,10 +939,6 @@
       </item>
       <item>
         <table>35</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>35</table>
         <row>3</row>
       </item>
       <item>
@@ -1553,10 +1549,6 @@
       </item>
       <item>
         <table>4</table>
-        <row>13</row>
-      </item>
-      <item>
-        <table>4</table>
         <row>14</row>
       </item>
       <item>
@@ -1646,14 +1638,6 @@
       <item>
         <table>7</table>
         <row>4</row>
-      </item>
-      <item>
-        <table>7</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>7</table>
-        <row>6</row>
       </item>
       <item>
         <table>7</table>


### PR DESCRIPTION
Follow-up commit for: https://github.com/zephyrproject-rtos/zephyr/pull/99204/commits/4a0b937141bd3bcf5e206c4846c504b6418e6e0c

Removing ICS pics that are not supported.

- GATT 4/13: Signed Write Without Response
- GATT 7/5 Connection data signing procedure
- GATT 7/6 Authenticate signed data procedure
- GAP 35/2: LE Security mode 2

Following tests are not supported.

- GATT/SR/GAW/BI-01-C
- GATT/SR/GAW/BI-38-C
- GATT/SR/GAW/BI-40-C
- GATT/SR/GAW/BV-02-C
- SM/CEN/SIGN/BI-01-C
- SM/CEN/SIGN/BV-03-C