### PR TITLE
maintainers: Update to reflect current status for my work

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1205,8 +1205,8 @@ Documentation:
   status: maintained
   maintainers:
     - kartben
-    - carlescufi
   collaborators:
+    - carlescufi
     - nashif
   files:
     - CODE_OF_CONDUCT.md
@@ -6424,6 +6424,7 @@ nRF Platforms:
     - anangl
     - masz-nordic
     - bjarki-andreasen
+    - carlescufi
   collaborators:
     - jaz1-nordic
     - kl-cruz


### PR DESCRIPTION
I unfortunately do not have the time to maintain documentation, so mark myself as collaborator instead of maintainer. Since most of my work now revolves aournd the nRF platforms, add myself as a maintainer there.