### PR TITLE
drivers: spi: sam: Fix configuring with more than 4 chip selects

### DIFF
--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -115,9 +115,9 @@ static int spi_sam_configure(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	if (config->slave > (SAM_SPI_CHIP_SELECT_COUNT - 1)) {
+	if (spi_csr_idx > (SAM_SPI_CHIP_SELECT_COUNT - 1)) {
 		LOG_ERR("Slave %d is greater than %d",
-			config->slave, SAM_SPI_CHIP_SELECT_COUNT - 1);
+			spi_csr_idx, SAM_SPI_CHIP_SELECT_COUNT - 1);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
If `spi_sam_configure()` is called with more than 4 chip selects the current check fails even if the pins are used as gpios. The variable `spi_csr_idx` already has the correct index to be checked and must be used in this check.