### PR TITLE
tests: drivers: counter: nrf54h20/cpuflpr support

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuflpr_0_9_0.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuflpr_0_9_0.yaml
@@ -11,7 +11,6 @@ sysbuild: true
 ram: 46
 flash: 46
 supported:
-  - counter
   - gpio
   - i2c
   - pwm

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuflpr_xip_0_9_0.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuflpr_xip_0_9_0.yaml
@@ -12,3 +12,4 @@ ram: 46
 flash: 48
 supported:
   - gpio
+  - counter

--- a/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54h20dk_nrf54h20_common.dtsi"
+
+/* FLPR does not have interrupts for slow peripherals. */
+&timer130 {
+	status = "disabled";
+};
+
+&timer131 {
+	status = "disabled";
+};
+
+&timer132 {
+	status = "disabled";
+};
+
+&timer133 {
+	status = "disabled";
+};
+
+&timer134 {
+	status = "disabled";
+};
+
+&timer135 {
+	status = "disabled";
+};
+
+&timer136 {
+	status = "disabled";
+};
+
+&timer137 {
+	status = "disabled";
+};
+
+&rtc130 {
+	status = "disabled";
+};
+
+&rtc131 {
+	status = "disabled";
+};

--- a/tests/drivers/counter/counter_basic_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/counter/counter_basic_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,5 +1,15 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+&timer120 {
+	status = "reserved";
+	interrupt-parent = <&cpuflpr_clic>;
+};
+
+&timer121 {
+	status = "reserved";
+	interrupt-parent = <&cpuflpr_clic>;
+};
+
 &timer130 {
 	status = "reserved";
 	interrupt-parent = <&cpuppr_clic>;


### PR DESCRIPTION
Added new target nrf54h20/cpuflpr/xip to counter basic api tests. Only XIP is supported for cpuflpr since RAM memory for this cpu is too small to fit whole
counter basic test code and data.