### PR TITLE
soc: silabs: siwx91x: removed sscanf for nwp firmware version check

### DIFF
--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -178,6 +178,7 @@ if(CONFIG_SILABS_SIWX91X_NWP)
     ${WISECONNECT_DIR}/components/sli_wifi_command_engine/inc
   )
   zephyr_library_sources(
+    nwp_fw_version.c
     ${WISECONNECT_DIR}/components/common/src/sl_utility.c
     ${WISECONNECT_DIR}/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_ram.c
     ${WISECONNECT_DIR}/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_rom.c

--- a/modules/hal_silabs/wiseconnect/nwp_fw_version.c
+++ b/modules/hal_silabs/wiseconnect/nwp_fw_version.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* This value needs to be updated when the Wiseconnect SDK (hal_silabs/wiseconnect) is updated
+ * Currently mapped to Wiseconnect SDK 3.5.2
+ */
+
+#include <nwp_fw_version.h>
+
+const sl_wifi_firmware_version_t siwx91x_nwp_fw_expected_version = {
+	.rom_id = 0x0B,
+	.major = 2,
+	.minor = 14,
+	.security_version = 5,
+	.patch_num = 2,
+	.customer_id = 0,
+	.build_num = 7,
+};

--- a/modules/hal_silabs/wiseconnect/nwp_fw_version.h
+++ b/modules/hal_silabs/wiseconnect/nwp_fw_version.h
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* This value needs to be updated when the Wiseconnect SDK (hal_silabs/wiseconnect) is updated
- * Actually mapped to Wiseconnect SDK 3.5.0
- */
-#define SIWX91X_NWP_FW_EXPECTED_VERSION "B.2.14.5.2.0.7"
+#include <sl_wifi_types.h>
+
+extern const sl_wifi_firmware_version_t siwx91x_nwp_fw_expected_version;

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
@@ -261,7 +261,6 @@ static void siwx91x_configure_network_stack(sl_si91x_boot_configuration_t *boot_
 
 static int siwx91x_check_nwp_version(void)
 {
-	sl_wifi_firmware_version_t expected_version;
 	sl_wifi_firmware_version_t version;
 	int ret;
 
@@ -270,38 +269,29 @@ static int siwx91x_check_nwp_version(void)
 		return -EINVAL;
 	}
 
-	sscanf(SIWX91X_NWP_FW_EXPECTED_VERSION, "%hhX.%hhd.%hhd.%hhd.%hhd.%hhd.%hd",
-	       &expected_version.rom_id,
-	       &expected_version.major,
-	       &expected_version.minor,
-	       &expected_version.security_version,
-	       &expected_version.patch_num,
-	       &expected_version.customer_id,
-	       &expected_version.build_num);
-
 	/* Ignore rom_id:
-	 * B is parsed as an hex value and we get 11 in expected_version.rom_id
-	 * We received rom_id=17 in version.rom_id, we suspect a double hex->decimal conversion
+	 * the right value is 0x0B but we received 17 in version.rom_id, we suspect a double
+	 * hex->decimal conversion
 	 */
-	if (expected_version.major != version.major) {
+	if (siwx91x_nwp_fw_expected_version.major != version.major) {
 		return -EINVAL;
 	}
-	if (expected_version.minor != version.minor) {
+	if (siwx91x_nwp_fw_expected_version.minor != version.minor) {
 		return -EINVAL;
 	}
-	if (expected_version.security_version != version.security_version) {
+	if (siwx91x_nwp_fw_expected_version.security_version != version.security_version) {
 		return -EINVAL;
 	}
-	if (expected_version.patch_num != version.patch_num) {
+	if (siwx91x_nwp_fw_expected_version.patch_num != version.patch_num) {
 		return -EINVAL;
 	}
-	if (expected_version.customer_id != version.customer_id) {
-		LOG_DBG("customer_id diverge: expected %d, actual %d", expected_version.customer_id,
-			version.customer_id);
+	if (siwx91x_nwp_fw_expected_version.customer_id != version.customer_id) {
+		LOG_DBG("customer_id diverge: expected %d, actual %d",
+			siwx91x_nwp_fw_expected_version.customer_id, version.customer_id);
 	}
-	if (expected_version.build_num != version.build_num) {
-		LOG_DBG("build_num diverge: expected %d, actual %d", expected_version.build_num,
-			version.build_num);
+	if (siwx91x_nwp_fw_expected_version.build_num != version.build_num) {
+		LOG_DBG("build_num diverge: expected %d, actual %d",
+			siwx91x_nwp_fw_expected_version.build_num, version.build_num);
 	}
 
 	return 0;
@@ -414,8 +404,15 @@ static int siwx91x_nwp_init(const struct device *dev)
 	/* Check if the NWP firmware version is correct */
 	ret = siwx91x_check_nwp_version();
 	if (ret < 0) {
-		LOG_ERR("Unexpected NWP firmware version (expected: %s)",
-			SIWX91X_NWP_FW_EXPECTED_VERSION);
+		LOG_ERR("Unexpected NWP firmware version (expected: %X.%d.%d.%d.%d.%d.%d)",
+			siwx91x_nwp_fw_expected_version.rom_id,
+			siwx91x_nwp_fw_expected_version.major,
+			siwx91x_nwp_fw_expected_version.minor,
+			siwx91x_nwp_fw_expected_version.security_version,
+			siwx91x_nwp_fw_expected_version.patch_num,
+			siwx91x_nwp_fw_expected_version.customer_id,
+			siwx91x_nwp_fw_expected_version.build_num);
+		return -EINVAL;
 	}
 
 	if (IS_ENABLED(CONFIG_SOC_SIWX91X_PM_BACKEND_PMGR)) {


### PR DESCRIPTION
This patch removes the use of sscanf to maintain compatibility with tests that use the minimal cpp library. The expected version is now defined using multiple individual values rather than a single formatted string.

Fixes CI failure here:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/19623866468/job/56189276469?pr=99860
and here:
https://github.com/zephyrproject-rtos/zephyr/pull/99400
and here:
https://github.com/zephyrproject-rtos/zephyr/pull/100078