### PR TITLE
drivers: nrf: Clean up remnants of nrfx error codes

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -90,7 +90,7 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 			break;
 		}
 
-		if (data->res != NRFX_SUCCESS) {
+		if (data->res != 0) {
 			ret = -EIO;
 			break;
 		}

--- a/drivers/i2c/i2c_nrfx_twi_common.h
+++ b/drivers/i2c/i2c_nrfx_twi_common.h
@@ -36,17 +36,17 @@ struct i2c_nrfx_twi_config {
 	const struct pinctrl_dev_config *pcfg;
 };
 
-static inline nrfx_err_t i2c_nrfx_twi_get_evt_result(nrfx_twi_evt_t const *p_event)
+static inline int i2c_nrfx_twi_get_evt_result(nrfx_twi_evt_t const *p_event)
 {
 	switch (p_event->type) {
 	case NRFX_TWI_EVT_DONE:
-		return NRFX_SUCCESS;
+		return 0;
 	case NRFX_TWI_EVT_ADDRESS_NACK:
-		return NRFX_ERROR_DRV_TWI_ERR_ANACK;
+		__fallthrough;
 	case NRFX_TWI_EVT_DATA_NACK:
-		return NRFX_ERROR_DRV_TWI_ERR_DNACK;
+		return -EIO;
 	default:
-		return NRFX_ERROR_INTERNAL;
+		return -EINVAL;
 	}
 }
 

--- a/drivers/i2c/i2c_nrfx_twi_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twi_rtio.c
@@ -154,7 +154,7 @@ static void event_handler(nrfx_twi_evt_t const *p_event, void *p_context)
 	const struct device *dev = p_context;
 	int status = 0;
 
-	if (i2c_nrfx_twi_get_evt_result(p_event) != NRFX_SUCCESS) {
+	if (i2c_nrfx_twi_get_evt_result(p_event) != 0) {
 		status = -EIO;
 	}
 

--- a/drivers/usb/common/nrf_usbd_common/nrf_usbd_common.c
+++ b/drivers/usb/common/nrf_usbd_common/nrf_usbd_common.c
@@ -248,7 +248,7 @@ typedef struct {
 	size_t transfer_cnt;
 	/** Configured endpoint size. */
 	uint16_t max_packet_size;
-	/** NRFX_SUCCESS or error code, never NRFX_ERROR_BUSY - this one is calculated. */
+	/** NRF_USBD_COMMON_EP_* - this one is calculated. */
 	nrf_usbd_common_ep_status_t status;
 } usbd_ep_state_t;
 
@@ -1096,12 +1096,12 @@ void nrf_usbd_common_irq_handler(void)
 /** @} */
 /** @} */
 
-nrfx_err_t nrf_usbd_common_init(nrf_usbd_common_event_handler_t event_handler)
+int nrf_usbd_common_init(nrf_usbd_common_event_handler_t event_handler)
 {
 	__ASSERT_NO_MSG(event_handler);
 
 	if (m_drv_state != NRFX_DRV_STATE_UNINITIALIZED) {
-		return NRFX_ERROR_INVALID_STATE;
+		return -EALREADY;
 	}
 
 	m_event_handler = event_handler;
@@ -1132,7 +1132,7 @@ nrfx_err_t nrf_usbd_common_init(nrf_usbd_common_event_handler_t event_handler)
 		p_state->transfer_cnt = 0;
 	}
 
-	return NRFX_SUCCESS;
+	return 0;
 }
 
 void nrf_usbd_common_uninit(void)
@@ -1458,10 +1458,10 @@ void nrf_usbd_common_ep_disable(nrf_usbd_common_ep_t ep)
 	usbd_int_rise();
 }
 
-nrfx_err_t nrf_usbd_common_ep_transfer(nrf_usbd_common_ep_t ep,
+int nrf_usbd_common_ep_transfer(nrf_usbd_common_ep_t ep,
 				       nrf_usbd_common_transfer_t const *p_transfer)
 {
-	nrfx_err_t ret;
+	int ret;
 	const uint8_t ep_bitpos = ep2bit(ep);
 	unsigned int irq_lock_key = irq_lock();
 
@@ -1469,7 +1469,7 @@ nrfx_err_t nrf_usbd_common_ep_transfer(nrf_usbd_common_ep_t ep,
 
 	/* Setup data transaction can go only in one direction at a time */
 	if ((NRF_USBD_COMMON_EP_NUM(ep) == 0) && (ep != m_last_setup_dir)) {
-		ret = NRFX_ERROR_INVALID_ADDR;
+		ret = -EFAULT;
 		if (NRF_USBD_COMMON_FAILED_TRANSFERS_DEBUG &&
 		    (NRF_USBD_COMMON_ISO_DEBUG || (!NRF_USBD_COMMON_EP_IS_ISO(ep)))) {
 			LOG_DBG("Transfer failed: Invalid EPr\n");
@@ -1478,7 +1478,7 @@ nrfx_err_t nrf_usbd_common_ep_transfer(nrf_usbd_common_ep_t ep,
 		   (1U << ep_bitpos)) {
 		/* IN (Device -> Host) transfer has to be transmitted out to allow new transmission
 		 */
-		ret = NRFX_ERROR_BUSY;
+		ret = -EBUSY;
 		if (NRF_USBD_COMMON_FAILED_TRANSFERS_DEBUG) {
 			LOG_DBG("Transfer failed: EP is busy");
 		}
@@ -1494,7 +1494,7 @@ nrfx_err_t nrf_usbd_common_ep_transfer(nrf_usbd_common_ep_t ep,
 		p_state->transfer_cnt = 0;
 		p_state->status = NRF_USBD_COMMON_EP_OK;
 		m_ep_dma_waiting |= 1U << ep_bitpos;
-		ret = NRFX_SUCCESS;
+		ret = 0;
 		usbd_int_rise();
 	}
 

--- a/drivers/usb/common/nrf_usbd_common/nrf_usbd_common.h
+++ b/drivers/usb/common/nrf_usbd_common/nrf_usbd_common.h
@@ -276,10 +276,10 @@ typedef struct {
  *
  * @param[in] event_handler Event handler provided by the user. Cannot be null.
  *
- * @retval NRFX_SUCCESS             Initialization successful.
- * @retval NRFX_ERROR_INVALID_STATE Driver was already initialized.
+ * @retval 0         Initialization successful.
+ * @retval -EALREADY Driver was already initialized.
  */
-nrfx_err_t nrf_usbd_common_init(nrf_usbd_common_event_handler_t event_handler);
+int nrf_usbd_common_init(nrf_usbd_common_event_handler_t event_handler);
 
 /**
  * @brief Driver deinitialization.
@@ -503,11 +503,11 @@ void nrf_usbd_common_ep_disable(nrf_usbd_common_ep_t ep);
  *                       For OUT endpoint receiving would be initiated.
  * @param[in] p_transfer Transfer parameters.
  *
- * @retval NRFX_SUCCESS             Transfer queued or started.
- * @retval NRFX_ERROR_BUSY          Selected endpoint is pending.
- * @retval NRFX_ERROR_INVALID_ADDR  Unexpected transfer on EPIN0 or EPOUT0.
+ * @retval 0                        Transfer queued or started.
+ * @retval -EBUSY                   Selected endpoint is pending.
+ * @retval -EFAULT                  Unexpected transfer on EPIN0 or EPOUT0.
  */
-nrfx_err_t nrf_usbd_common_ep_transfer(nrf_usbd_common_ep_t ep,
+int nrf_usbd_common_ep_transfer(nrf_usbd_common_ep_t ep,
 				       nrf_usbd_common_transfer_t const *p_transfer);
 
 /**

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -795,9 +795,9 @@ static inline void usbd_work_process_recvreq(struct nrf_usbd_ctx *ctx,
 	k_mutex_lock(&ctx->drv_lock, K_FOREVER);
 	NRF_USBD_COMMON_TRANSFER_OUT(transfer, ep_ctx->buf.data,
 				     ep_ctx->cfg.max_sz);
-	nrfx_err_t err = nrf_usbd_common_ep_transfer(
+	int err = nrf_usbd_common_ep_transfer(
 		ep_addr_to_nrfx(ep_ctx->cfg.addr), &transfer);
-	if (err != NRFX_SUCCESS) {
+	if (err != 0) {
 		LOG_ERR("nRF USBD transfer error (OUT): 0x%02x", err);
 	}
 	k_mutex_unlock(&ctx->drv_lock);
@@ -1146,7 +1146,7 @@ static void usbd_event_handler(nrf_usbd_common_evt_t const *const p_event)
 static inline void usbd_reinit(void)
 {
 	int ret;
-	nrfx_err_t err;
+	int err;
 
 	nrfx_power_usbevt_disable();
 	nrf_usbd_common_disable();
@@ -1160,7 +1160,7 @@ static inline void usbd_reinit(void)
 	nrfx_power_usbevt_enable();
 	err = nrf_usbd_common_init(usbd_event_handler);
 
-	if (err != NRFX_SUCCESS) {
+	if (err != 0) {
 		LOG_DBG("nRF USBD driver reinit failed. Code: %d", err);
 		__ASSERT_NO_MSG(0);
 	}
@@ -1692,9 +1692,9 @@ int usb_dc_ep_write(const uint8_t ep, const uint8_t *const data,
 
 	ep_ctx->write_in_progress = true;
 	NRF_USBD_COMMON_TRANSFER_IN(transfer, data, data_len, 0);
-	nrfx_err_t err = nrf_usbd_common_ep_transfer(ep_addr_to_nrfx(ep), &transfer);
+	int err = nrf_usbd_common_ep_transfer(ep_addr_to_nrfx(ep), &transfer);
 
-	if (err != NRFX_SUCCESS) {
+	if (err != 0) {
 		ep_ctx->write_in_progress = false;
 		if (ret_bytes) {
 			*ret_bytes = 0;
@@ -1883,7 +1883,7 @@ int usb_dc_wakeup_request(void)
 static int usb_init(void)
 {
 	struct nrf_usbd_ctx *ctx = get_usbd_ctx();
-	nrfx_err_t err;
+	int err;
 
 #ifdef CONFIG_HAS_HW_NRF_USBREG
 	/* Use CLOCK/POWER priority for compatibility with other series where
@@ -1909,12 +1909,12 @@ static int usb_init(void)
 	};
 
 	err = nrf_usbd_common_init(usbd_event_handler);
-	if (err != NRFX_SUCCESS) {
+	if (err != 0) {
 		LOG_DBG("nRF USBD driver init failed. Code: %d", (uint32_t)err);
 		return -EIO;
 	}
 
-	/* Ignore the return value, as NRFX_ERROR_ALREADY is not
+	/* Ignore the return value, as -EALREADY is not
 	 * a problem here.
 	 */
 	(void)nrfx_power_init(&power_config);

--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -257,16 +257,6 @@ void nrfx_busy_wait(uint32_t usec_to_wait);
 //------------------------------------------------------------------------------
 
 /**
- * @brief When set to a non-zero value, this macro specifies that the
- *        @ref nrfx_error_codes and the @ref nrfx_err_t type itself are defined
- *        in a customized way and the default definitions from @c <nrfx_error.h>
- *        should not be used.
- */
-#define NRFX_CUSTOM_ERROR_CODES 0
-
-//------------------------------------------------------------------------------
-
-/**
  * @brief When set to a non-zero value, this macro specifies that inside HALs
  *        the event registers are read back after clearing, on devices that
  *        otherwise could defer the actual register modification.

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1941,13 +1941,13 @@ uint32_t radio_tmr_sample_get(void)
 int radio_gpio_pa_lna_init(void)
 {
 #if defined(HAL_RADIO_GPIO_HAVE_PA_PIN) || defined(HAL_RADIO_GPIO_HAVE_LNA_PIN)
-	if (nrfx_gpiote_channel_alloc(gpiote_palna, &gpiote_ch_palna) != NRFX_SUCCESS) {
+	if (nrfx_gpiote_channel_alloc(gpiote_palna, &gpiote_ch_palna) != 0) {
 		return -ENOMEM;
 	}
 #endif
 
 #if defined(NRF_GPIO_PDN_PIN)
-	if (nrfx_gpiote_channel_alloc(gpiote_pdn, &gpiote_ch_pdn) != NRFX_SUCCESS) {
+	if (nrfx_gpiote_channel_alloc(gpiote_pdn, &gpiote_ch_pdn) != 0) {
 		return -ENOMEM;
 	}
 #endif


### PR DESCRIPTION
Starting with nrfx 4.0.0, the nrfx_err_t, NRFX_SUCCESS and NRFX_ERROR_* have been deprecated. Most of them were removed here:

https://github.com/zephyrproject-rtos/zephyr/pull/99399

but a few were missed.