### PR TITLE
[Backport v4.3-branch] soc: silabs: siwx91x: introduce zero latency irq

### DIFF
--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -13,6 +13,12 @@ configdefault SYS_CLOCK_TICKS_PER_SEC
 configdefault UART_NS16550_DW8250_DW_APB
 	default y
 
+configdefault ZERO_LATENCY_IRQS
+	default y
+
+configdefault ZERO_LATENCY_LEVELS
+	default 2
+
 if PM_DEVICE
 
 configdefault PM_DEVICE_RUNTIME


### PR DESCRIPTION
Backport https://github.com/zephyrproject-rtos/zephyr/commit/87ab3e337a38079fc6f09a93835e53db269c46d0 from https://github.com/zephyrproject-rtos/zephyr/pull/99823

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/99904