### PR TITLE
boards: nxp: Fix rt700 display sample build cmd in doc

### DIFF
--- a/boards/nxp/mimxrt700_evk/doc/index.rst
+++ b/boards/nxp/mimxrt700_evk/doc/index.rst
@@ -225,14 +225,6 @@ should see the following message in the terminal:
    *** Booting Zephyr OS v3.7.0 ***
    Hello World! mimxrt700_evk/mimxrt798s/cm33_cpu0
 
-.. include:: ../../common/board-footer.rst.inc
-
-.. _i.MX RT700 Website:
-   https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/i-mx-rt-crossover-mcus/i-mx-rt700-crossover-mcu-with-arm-cortex-m33-npu-dsp-and-gpu-cores:i.MX-RT700
-
-.. _MIMXRT700-EVK Debug Firmware:
-   https://www.nxp.com/docs/en/application-note/AN13206.pdf
-
 Display Support
 ***************
 
@@ -248,8 +240,16 @@ directly, but some modifications are required (see
 for a list). The display sample can be built for this module like so:
 
 .. zephyr-app-commands::
-   :board: mimxrt700_evk
+   :board: mimxrt700_evk/mimxrt798s/cm33_cpu0
    :shield: g1120b0mipi
    :zephyr-app: samples/drivers/display
    :goals: build
    :compact:
+
+.. include:: ../../common/board-footer.rst.inc
+
+.. _i.MX RT700 Website:
+   https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/i-mx-rt-crossover-mcus/i-mx-rt700-crossover-mcu-with-arm-cortex-m33-npu-dsp-and-gpu-cores:i.MX-RT700
+
+.. _MIMXRT700-EVK Debug Firmware:
+   https://www.nxp.com/docs/en/application-note/AN13206.pdf


### PR DESCRIPTION
- Use correct board with id.
- Move display support chapter before board footer.