### PR TITLE
tests: kernel: usage: Adjustments for slower platforms

### DIFF
--- a/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
+++ b/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
@@ -87,7 +87,11 @@ ZTEST(usage_api, test_all_stats_usage)
 
 	k_thread_runtime_stats_all_get(&stats2);
 
+#if defined(CONFIG_RISCV)
+	k_sleep(K_TICKS(3));  /* Helper runs for 3 ticks - on slower platforms */
+#else
 	k_sleep(K_TICKS(2));  /* Helper runs for 2 ticks */
+#endif
 
 	k_thread_runtime_stats_all_get(&stats3);
 

--- a/tests/kernel/usage/thread_runtime_stats/testcase.yaml
+++ b/tests/kernel/usage/thread_runtime_stats/testcase.yaml
@@ -3,7 +3,7 @@ tests:
     tags: kernel
     # The following architectures are excluded as they have boards that
     # exhibit precision timing anomalies related to emulation.
-    #     posix, riscv32, sparc
+    #     posix, sparc
     # The following architectures are exluded as the necessary
     # thread runtime statistic hooks do not yet exist.
     #     mips


### PR DESCRIPTION
Adjusting sleep times as NRF54H20 PPR core is too slow to run the test with the default system clock frequency.
Also fixing an outdated comment in the test manifest file, since the `riscv32` arch is now supported by the test.
