### PR TITLE
ci: Switch to CI image v0.28.7

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.6.20251003
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.7.20251127
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.6.20251003
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.7.20251127
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.6.20251003
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.7.20251127
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.6.20251003
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.7.20251127
       options: '--entrypoint /bin/bash'
     timeout-minutes: 60
     concurrency:

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -28,7 +28,7 @@ jobs:
       group: zephyr-runner-v2-linux-x64-4xlarge
     if: github.repository_owner == 'zephyrproject-rtos'
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.6.20251003
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.7.20251127
       options: '--entrypoint /bin/bash'
     defaults:
       run:

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -127,7 +127,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.6.20251003
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.28.7.20251127
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false


### PR DESCRIPTION
This commit updates the CI workflows to use the CI image v0.28.7, which updates versions of the following components:
- Doxygen 1.15.0.
- Renode 1.16.0.
- BSIM 3.0.