### PR TITLE
Flex pwm capture support

### DIFF
--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, Linaro
- *
+ * Copyright 2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,11 +15,26 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 
+#ifdef CONFIG_PWM_CAPTURE
+#include <zephyr/irq.h>
+#endif
+
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(pwm_mcux, CONFIG_PWM_LOG_LEVEL);
 
 #define CHANNEL_COUNT 2
+
+#ifdef CONFIG_PWM_CAPTURE
+struct pwm_mcux_capture_data {
+	pwm_capture_callback_handler_t callback;
+	void *user_data;
+	uint32_t overflow_count;
+	uint32_t capture_channel;
+	bool continuous : 1;
+	bool pulse_capture : 1;
+};
+#endif /* CONFIG_PWM_CAPTURE */
 
 struct pwm_mcux_config {
 	PWM_Type *base;
@@ -32,12 +47,21 @@ struct pwm_mcux_config {
 	bool run_wait;
 	bool run_debug;
 	const struct pinctrl_dev_config *pincfg;
+#ifdef CONFIG_PWM_CAPTURE
+	uint8_t input_filter_count;
+	uint8_t input_filter_period;
+	void (*irq_config_func)(const struct device *dev);
+#endif
 };
 
 struct pwm_mcux_data {
 	uint32_t period_cycles[CHANNEL_COUNT];
 	pwm_signal_param_t channel[CHANNEL_COUNT];
 	struct k_mutex lock;
+#ifdef CONFIG_PWM_CAPTURE
+	struct pwm_mcux_capture_data capture;
+	bool capture_active;
+#endif
 };
 
 static int mcux_pwm_set_cycles_internal(const struct device *dev, uint32_t channel,
@@ -47,6 +71,13 @@ static int mcux_pwm_set_cycles_internal(const struct device *dev, uint32_t chann
 	const struct pwm_mcux_config *config = dev->config;
 	struct pwm_mcux_data *data = dev->data;
 	pwm_level_select_t level;
+
+#ifdef CONFIG_PWM_CAPTURE
+	if (data->capture_active) {
+		LOG_ERR("PWM capture is active, cannot set PWM output");
+		return -EBUSY;
+	}
+#endif
 
 	if (flags & PWM_POLARITY_INVERTED) {
 		level = kPWM_LowTrue;
@@ -204,6 +235,287 @@ static int mcux_pwm_get_cycles_per_sec(const struct device *dev,
 	return 0;
 }
 
+#ifdef CONFIG_PWM_CAPTURE
+static int mcux_pwm_calc_ticks(uint16_t first_capture, uint16_t second_capture, uint32_t mod,
+			       uint32_t overflows, uint32_t *result)
+{
+	uint32_t ticks;
+
+	if (second_capture >= first_capture) {
+		/* No timer overflow between captures */
+		ticks = second_capture - first_capture;
+	} else {
+		/* Timer overflowed between captures */
+		ticks = (mod - first_capture) + second_capture + 1U;
+		if (overflows > 0) {
+			/* Account for the overflow we just calculated */
+			overflows--;
+		}
+	}
+
+	/* Add additional overflows */
+	if (u32_mul_overflow(overflows, mod, &overflows)) {
+		LOG_ERR("overflow while calculating overflow cycles.");
+		return -ERANGE;
+	}
+
+	if (u32_add_overflow(ticks, overflows, &ticks)) {
+		LOG_ERR("overflow while calculating capture cycles.");
+		return -ERANGE;
+	}
+
+	*result = ticks;
+
+	return 0;
+}
+
+static void mcux_pwm_isr(const struct device *dev)
+{
+	const struct pwm_mcux_config *config = dev->config;
+	struct pwm_mcux_data *data = dev->data;
+	struct pwm_mcux_capture_data *capture = &data->capture;
+	uint32_t status;
+	uint16_t first_edge_value;
+	uint16_t second_edge_value;
+	uint32_t ticks = 0;
+	int err = 0;
+
+	uint16_t modValue = config->base->SM[config->index].VAL1 -
+		config->base->SM[config->index].INIT;
+
+	status = PWM_GetStatusFlags(config->base, config->index);
+	PWM_ClearStatusFlags(config->base, config->index, status);
+
+	if (status & kPWM_ReloadFlag) {
+		err = u32_add_overflow(capture->overflow_count, 1, &capture->overflow_count);
+	}
+
+	if (status & kPWM_CaptureX0Flag) {
+		capture->overflow_count = 0;
+	}
+
+	if (status & kPWM_CaptureX1Flag) {
+		if (err != 0) {
+			LOG_ERR("overflow_count overflows.");
+		} else {
+			first_edge_value = config->base->SM[config->index].CVAL0;
+			second_edge_value = config->base->SM[config->index].CVAL1;
+			err = mcux_pwm_calc_ticks(first_edge_value, second_edge_value, modValue,
+					capture->overflow_count, &ticks);
+			LOG_DBG("First edge capture: %d, second edge capture: %d,"
+				"overflow: %d, ticks: %d", first_edge_value, second_edge_value,
+				capture->overflow_count, ticks);
+		}
+
+		if (capture->pulse_capture) {
+			capture->callback(dev, capture->capture_channel, 0, ticks, err,
+					capture->user_data);
+		} else {
+			capture->callback(dev, capture->capture_channel, ticks, 0, err,
+					capture->user_data);
+		}
+
+		capture->overflow_count = 0;
+	}
+}
+
+static int check_channel(const struct device *dev, uint32_t channel)
+{
+	struct pwm_mcux_data *data = dev->data;
+
+	/* Check if the channel is already used for PWM output */
+	if (channel < CHANNEL_COUNT && data->period_cycles[channel] != 0) {
+		LOG_ERR("Channel %d is already used for PWM output", channel);
+		return -EBUSY;
+	}
+
+	/* Check if the channel supports capture based on hardware features */
+	if (channel == 0U) {
+#if defined(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELA) && \
+	(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELA == 0U)
+		LOG_ERR("Channel A does not support capture on this hardware");
+		return -ENOTSUP;
+#endif
+	} else if (channel == 1U) {
+#if defined(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELB) && \
+	(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELB == 0U)
+		LOG_ERR("Channel B does not support capture on this hardware");
+		return -ENOTSUP;
+#endif
+	} else if (channel == 2U) {
+#if defined(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELX) && \
+	(FSL_FEATURE_PWM_HAS_CAPTURE_ON_CHANNELX == 0U)
+		LOG_ERR("Channel X does not support capture on this hardware");
+		return -ENOTSUP;
+#endif
+	} else {
+		LOG_ERR("Invalid channel %d", channel);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int mcux_pwm_configure_capture(const struct device *dev,
+				      uint32_t channel, pwm_flags_t flags,
+				      pwm_capture_callback_handler_t cb,
+				      void *user_data)
+{
+	const struct pwm_mcux_config *config = dev->config;
+	struct pwm_mcux_data *data = dev->data;
+	bool inverted = (flags & PWM_POLARITY_MASK) == PWM_POLARITY_INVERTED;
+	int ret;
+	pwm_channels_t pwm_channel;
+	pwm_input_capture_param_t capture_config;
+
+	memset(&capture_config, 0, sizeof(capture_config));
+
+	ret = check_channel(dev, channel);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (cb == NULL) {
+		LOG_ERR("PWM capture callback is not configured");
+		return -EINVAL;
+	}
+
+	if (data->capture_active) {
+		LOG_ERR("PWM capture already in progress");
+		return -EBUSY;
+	}
+
+	if (!(flags & PWM_CAPTURE_TYPE_MASK)) {
+		LOG_ERR("No capture type specified");
+		return -EINVAL;
+	}
+
+	if ((flags & PWM_CAPTURE_TYPE_MASK) == PWM_CAPTURE_TYPE_BOTH) {
+		LOG_ERR("Cannot capture both period and pulse width");
+		return -ENOTSUP;
+	}
+
+	/* Initialize capture data */
+	data->capture.callback = cb;
+	data->capture.user_data = user_data;
+	data->capture.capture_channel = channel;
+	data->capture.continuous =
+		(flags & PWM_CAPTURE_MODE_MASK) == PWM_CAPTURE_MODE_CONTINUOUS;
+	data->capture.pulse_capture =
+		(flags & PWM_CAPTURE_TYPE_MASK) == PWM_CAPTURE_TYPE_PULSE;
+	data->capture.overflow_count = 0;
+
+	/* Configure input capture parameters */
+	capture_config.captureInputSel = false;        /* Use raw input signal (not edge counter) */
+	if (data->capture.pulse_capture) {
+		capture_config.edge0 = inverted ? kPWM_FallingEdge : kPWM_RisingEdge;
+		capture_config.edge1 = inverted ? kPWM_RisingEdge : kPWM_FallingEdge;
+	} else {
+		capture_config.edge0 = inverted ? kPWM_FallingEdge : kPWM_RisingEdge;
+		capture_config.edge1 = inverted ? kPWM_FallingEdge : kPWM_RisingEdge;
+	}
+	capture_config.enableOneShotCapture = !data->capture.continuous;
+	capture_config.fifoWatermark = 0;
+
+	/* Fix mismatch because kPWM_PwmA is 1U, kPWM_PwmB is 0U */
+	if (channel == 0U) {
+		pwm_channel = kPWM_PwmA;
+	} else if (channel == 1U) {
+		pwm_channel = kPWM_PwmB;
+	} else {
+		pwm_channel = kPWM_PwmX;
+	}
+
+	/* Setup input capture on channel */
+	PWM_SetupInputCapture(config->base, config->index, pwm_channel, &capture_config);
+
+	/* Set capture filter */
+	PWM_SetFilterSampleCount(config->base, pwm_channel, config->index,
+		config->input_filter_count);
+	PWM_SetFilterSamplePeriod(config->base, pwm_channel, config->index,
+		config->input_filter_period);
+
+	return 0;
+}
+
+static int mcux_pwm_enable_capture(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_mcux_config *config = dev->config;
+	struct pwm_mcux_data *data = dev->data;
+	uint32_t status;
+	int ret;
+
+	ret = check_channel(dev, channel);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (!data->capture.callback) {
+		LOG_ERR("PWM capture not configured");
+		return -EINVAL;
+	}
+
+	if (data->capture_active) {
+		LOG_ERR("PWM capture already enabled");
+		return -EBUSY;
+	}
+
+	data->capture_active = true;
+	/* Make sure the flags are cleared in case it enters IRQ immediately after enable
+	 * interrupts, results in error result at first.
+	 */
+	status = PWM_GetStatusFlags(config->base, config->index);
+	PWM_ClearStatusFlags(config->base, config->index, status);
+
+	if (channel == 0U) {
+		PWM_EnableInterrupts(config->base, config->index, kPWM_CaptureA0InterruptEnable |
+			kPWM_CaptureA1InterruptEnable | kPWM_ReloadInterruptEnable);
+	} else if (channel == 1U) {
+		PWM_EnableInterrupts(config->base, config->index, kPWM_CaptureB0InterruptEnable |
+			kPWM_CaptureB1InterruptEnable | kPWM_ReloadInterruptEnable);
+	} else {
+		PWM_EnableInterrupts(config->base, config->index, kPWM_CaptureX0InterruptEnable |
+			kPWM_CaptureX1InterruptEnable | kPWM_ReloadInterruptEnable);
+	}
+
+	/* Start the PWM counter if it's stopped.*/
+	if ((config->base->MCTRL & PWM_MCTRL_RUN_MASK) == 0) {
+		PWM_StartTimer(config->base, (1U << config->index));
+	}
+
+	return 0;
+}
+
+static int mcux_pwm_disable_capture(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_mcux_config *config = dev->config;
+	struct pwm_mcux_data *data = dev->data;
+	int ret;
+
+	ret = check_channel(dev, channel);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Disable capture interrupts */
+	if (channel == 0U) {
+		PWM_DisableInterrupts(config->base, config->index, kPWM_CaptureA0InterruptEnable |
+			kPWM_CaptureA1InterruptEnable | kPWM_ReloadInterruptEnable);
+	} else if (channel == 1U) {
+		PWM_DisableInterrupts(config->base, config->index, kPWM_CaptureB0InterruptEnable |
+			kPWM_CaptureB1InterruptEnable | kPWM_ReloadInterruptEnable);
+	} else {
+		PWM_DisableInterrupts(config->base, config->index, kPWM_CaptureX0InterruptEnable |
+			kPWM_CaptureX1InterruptEnable | kPWM_ReloadInterruptEnable);
+	}
+
+	data->capture_active = false;
+	data->capture.callback = NULL;
+
+	return 0;
+}
+#endif /* CONFIG_PWM_CAPTURE */
+
 static int pwm_mcux_init(const struct device *dev)
 {
 	const struct pwm_mcux_config *config = dev->config;
@@ -233,6 +545,10 @@ static int pwm_mcux_init(const struct device *dev)
 	pwm_config.clockSource = kPWM_BusClock;
 	pwm_config.enableDebugMode = config->run_debug;
 #if !defined(FSL_FEATURE_PWM_HAS_NO_WAITEN) || (!FSL_FEATURE_PWM_HAS_NO_WAITEN)
+	/* Note: When the CPU enters a low-power mode, if enableWait is not set to true,
+	 * the FlexPWM module will stop operating, which may interfere with input capture
+	 * functionality
+	 */
 	pwm_config.enableWait = config->run_wait;
 #endif
 
@@ -252,17 +568,47 @@ static int pwm_mcux_init(const struct device *dev)
 	data->channel[1].pwmChannel = kPWM_PwmB;
 	data->channel[1].level = kPWM_HighTrue;
 
+#ifdef CONFIG_PWM_CAPTURE
+	if (config->irq_config_func) {
+		config->irq_config_func(dev);
+	}
+#endif
+
 	return 0;
 }
 
 static DEVICE_API(pwm, pwm_mcux_driver_api) = {
 	.set_cycles = mcux_pwm_set_cycles,
 	.get_cycles_per_sec = mcux_pwm_get_cycles_per_sec,
+#ifdef CONFIG_PWM_CAPTURE
+	.configure_capture = mcux_pwm_configure_capture,
+	.enable_capture = mcux_pwm_enable_capture,
+	.disable_capture = mcux_pwm_disable_capture,
+#endif
 };
+
+#ifdef CONFIG_PWM_CAPTURE
+
+#define PWM_MCUX_IRQ_CONFIG_FUNC(n) \
+	static void pwm_mcux_config_func_##n(const struct device *dev) \
+	{	\
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), \
+				mcux_pwm_isr, DEVICE_DT_INST_GET(n), 0); \
+		irq_enable(DT_INST_IRQN(n));	\
+	}
+#define PWM_MCUX_CAPTURE_CONFIG_INIT(n) \
+	.irq_config_func = pwm_mcux_config_func_##n,	\
+	.input_filter_count = DT_INST_PROP_OR(n, input_filter_count, 0),	\
+	.input_filter_period = DT_INST_PROP_OR(n, input_filter_period, 0),
+#else
+#define PWM_MCUX_IRQ_CONFIG_FUNC(n)
+#define PWM_MCUX_CAPTURE_CONFIG_INIT(n)
+#endif /* CONFIG_PWM_CAPTURE */
 
 #define PWM_DEVICE_INIT_MCUX(n)			  \
 	static struct pwm_mcux_data pwm_mcux_data_ ## n;		  \
 	PINCTRL_DT_INST_DEFINE(n);					  \
+	PWM_MCUX_IRQ_CONFIG_FUNC(n)					  \
 									  \
 	static const struct pwm_mcux_config pwm_mcux_config_ ## n = {     \
 		.base = (PWM_Type *)DT_REG_ADDR(DT_INST_PARENT(n)),	  \
@@ -276,6 +622,7 @@ static DEVICE_API(pwm, pwm_mcux_driver_api) = {
 		.run_wait = DT_INST_PROP(n, run_in_wait),		  \
 		.run_debug = DT_INST_PROP(n, run_in_debug),		  \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		  \
+		PWM_MCUX_CAPTURE_CONFIG_INIT(n)	\
 	};								  \
 									  \
 	DEVICE_DT_INST_DEFINE(n,					  \

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -82,7 +82,7 @@ static int mcux_pwm_set_cycles_internal(const struct device *dev, uint32_t chann
 
 		status = PWM_SetupPwm(config->base, config->index,
 				      &data->channel[channel], 1U,
-				      config->mode, 1U, clock_freq);
+				      config->mode, clock_freq >> config->prescale, clock_freq);
 		if (status != kStatus_Success) {
 			LOG_ERR("Could not set up pwm");
 			return -ENOTSUP;

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -1,4 +1,5 @@
-# Copyright (c) 2019, Linaro Limited
+# Copyright (c) 2019 Linaro Limited
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP MCUX PWM
@@ -46,6 +47,24 @@ properties:
       "half-cycle" - registers loaded on a PWM half cycle;
       "full-cycle" - registers loaded on a PWM full cycle;
       "half-and-full-cycle" - registers loaded on a PWM half & full cycle.
+
+  input-filter-count:
+    type: int
+    description: |
+      Set the number of consecutive samples that must agree prior to
+      the input filter accepting an input transition. The number of samples
+      is the decimal value of this field plus three: the bit field value of 0-7
+      represents 3-10 samples, respectively. The value affects the input latency.
+      Valid range: 0 - 7
+
+  input-filter-period:
+    type: int
+    description: |
+      Set the sampling period (in IPBus clock cycles) of the input capture pin input filter.
+      Each input is sampled multiple times at the rate specified by this field.
+      If the value is 0x00 (default), then the input filter is bypassed. The value affects
+      the input latency.
+      Valid range: 0 - 255
 
   "#pwm-cells":
     const: 3

--- a/tests/drivers/pwm/pwm_loopback/boards/mimxrt1180_evk_mimxrt1189_cm33_flexpwm.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/mimxrt1180_evk_mimxrt1189_cm33_flexpwm.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+&pinctrl {
+	flexpwm1_pwm0_default: flexpwm1_pwm0_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_00_flexpwm1_pwm0_a>;
+			drive-strength = "normal";
+			slew-rate = "fast";
+		};
+
+		group1 {
+			pinmux = <&iomuxc_gpio_ad_06_flexpwm1_pwm0_x>;
+			drive-strength = "normal";
+			slew-rate = "fast";
+		};
+	};
+};
+/* To test this sample, connect
+ * gpio_ad_00(J69-3) ---> gpio_ad_06(J70-1)
+ */
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&flexpwm1_pwm0 0 0 PWM_POLARITY_NORMAL>, /* gpio_ad_00 J69-3, out */
+		       <&flexpwm1_pwm0 2 0 PWM_POLARITY_NORMAL>; /*  gpio_ad_06 J70-1, in */
+	};
+};
+
+&flexpwm1_pwm0 {
+	status = "okay";
+	pinctrl-0 = <&flexpwm1_pwm0_default>;
+	pinctrl-names = "default";
+	input-filter-count = <1>;
+	input-filter-period = <1>;
+};


### PR DESCRIPTION
 Add support for PWM input capture functionality to the NXP MCUX PWM
    driver. This enables measurement of pulse width and period of external
    PWM signals.

    Key features added:
    - PWM capture configuration and control APIs
    - Interrupt-driven capture with overflow handling
    - Support for both pulse width and period measurement
    - Configurable input filtering
    - Support for continuous and one-shot capture modes

    The implementation uses FlexPWM channel X as the dedicated input
    capture channel, while channels 0 and 1 remain available for PWM
    output. Capture functionality is conditionally compiled based on
    CONFIG_PWM_CAPTURE configuration option.