### PR TITLE
drivers: spi: stm32 fix bug on empty tx

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1316,14 +1316,14 @@ static int transceive(const struct device *dev,
 		}
 	} while (ret == 0 && spi_stm32_transfer_ongoing(data));
 #else /* CONFIG_SPI_STM32_INTERRUPT */
-	do {
+	while (ret == 0 && spi_stm32_transfer_ongoing(data)) {
 		ret = spi_stm32_shift_frames(cfg, data);
 
 		if (ret == 0 && transfer_dir == LL_SPI_HALF_DUPLEX_TX) {
 			ret = spi_stm32_half_duplex_switch_to_receive(cfg, data);
 			transfer_dir = LL_SPI_GetTransferDirection(spi);
 		}
-	} while (ret == 0 && spi_stm32_transfer_ongoing(data));
+	}
 
 	spi_stm32_complete(dev, ret);
 


### PR DESCRIPTION
When transceive is called on a chip without CONFIG_SPI_STM32_INTERRUPT,
spi_stm32_shift_frames was called even if there was no transfer ongoing.
This lead to an unwanted SPI transfer shifting the whole connection,
causing drivers to malfunction.
Fix it by replacing the do-while loop with a while loop