### PR TITLE
samples: usb: common: make vid configurable

### DIFF
--- a/samples/subsys/usb/common/Kconfig.sample_usbd
+++ b/samples/subsys/usb/common/Kconfig.sample_usbd
@@ -21,6 +21,12 @@ config SAMPLE_USBD_PRODUCT
 	help
 	  USB device sample product stringa.
 
+config SAMPLE_USBD_VID
+	hex "USB device sample Vendor ID"
+	default 0x2fe3
+	help
+	  USB device sample Vendor ID.
+
 config SAMPLE_USBD_PID
 	hex "USB device sample Product ID"
 	default 0x0001

--- a/samples/subsys/usb/common/Kconfig.sample_usbd
+++ b/samples/subsys/usb/common/Kconfig.sample_usbd
@@ -25,13 +25,16 @@ config SAMPLE_USBD_VID
 	hex "USB device sample Vendor ID"
 	default 0x2fe3
 	help
-	  USB device sample Vendor ID.
+	  USB device sample Vendor ID. The default id (0x2fe3) is associated to
+	  Zephyr Project, you must use your own VID for samples and applications
+	  outside of Zephyr Project.
 
 config SAMPLE_USBD_PID
 	hex "USB device sample Product ID"
 	default 0x0001
 	help
-	  USB device sample Product ID.
+	  USB device sample Product ID. You must use your own PID for samples
+	  and applications outside of Zephyr Project.
 
 config SAMPLE_USBD_SELF_POWERED
 	bool "USB device sample Self-powered attribute"

--- a/samples/subsys/usb/common/sample_usbd_init.c
+++ b/samples/subsys/usb/common/sample_usbd_init.c
@@ -13,8 +13,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(usbd_sample_config);
 
-#define ZEPHYR_PROJECT_USB_VID		0x2fe3
-
 /* By default, do not register the USB DFU class DFU mode instance. */
 static const char *const blocklist[] = {
 	"dfu_dfu",
@@ -29,7 +27,7 @@ static const char *const blocklist[] = {
  */
 USBD_DEVICE_DEFINE(sample_usbd,
 		   DEVICE_DT_GET(DT_NODELABEL(zephyr_udc0)),
-		   ZEPHYR_PROJECT_USB_VID, CONFIG_SAMPLE_USBD_PID);
+		   CONFIG_SAMPLE_USBD_VID, CONFIG_SAMPLE_USBD_PID);
 /* doc device instantiation end */
 
 /* doc string instantiation start */


### PR DESCRIPTION
Add a SAMPLE_USBD_VID Kconfig to allow changing the USB VID on samples using the common code. Can be handy for testing things against code that expects a specific vid.