### PR TITLE
arch/posix: Support cross-compiling

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -39,32 +39,27 @@ set_property(TARGET native_simulator PROPERTY LOCALIZE_EXTRA_OPTIONS "")
 
 set(NSI_DIR ${ZEPHYR_BASE}/scripts/native_simulator CACHE PATH "Path to the native simulator")
 
-if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/${CMAKE_HOST_SYSTEM_NAME}.${CMAKE_HOST_SYSTEM_PROCESSOR}.cmake)
-  # @Intent: Set necessary compiler & linker options for this specific host architecture & OS
-  include(${CMAKE_HOST_SYSTEM_NAME}.${CMAKE_HOST_SYSTEM_PROCESSOR}.cmake)
-else() # Linux.x86_64
-  if(CONFIG_64BIT)
-    # some gcc versions fail to build without -fPIC
-    zephyr_compile_options(-m64 -fPIC)
-    zephyr_link_libraries(-m64)
-
-    target_link_options(native_simulator INTERFACE "-m64")
-    target_compile_options(native_simulator INTERFACE "-m64")
+if(NATIVE_TARGET_HOST) # Allow users to manually select the target for cross-compiling use cases
+  set(TARGET_HOST ${NATIVE_TARGET_HOST})
+else()
+  if("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "arm.*")
+    # All 32bit arm variants
+    set(TARGET_HOST "arm")
+  elseif("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES ".*86.*")
+    # x86_64/i*86
+    set(TARGET_HOST "x86_64")
   else()
-    zephyr_compile_options(-m32)
-    zephyr_link_libraries(-m32)
-
-    target_link_options(native_simulator INTERFACE "-m32")
-    target_compile_options(native_simulator INTERFACE "-m32")
-
-    # When building for 32bits x86, gcc defaults to using the old 8087 float arithmetic
-    # which causes some issues with literal float comparisons. So we set it
-    # to use the SSE2 float path instead
-    # (clang defaults to use SSE, but, setting this option for it is safe)
-    check_set_compiler_property(APPEND PROPERTY fpsse2 "SHELL:-msse2 -mfpmath=sse")
-    zephyr_compile_options($<TARGET_PROPERTY:compiler,fpsse2>)
-    target_compile_options(native_simulator INTERFACE "$<TARGET_PROPERTY:compiler,fpsse2>")
+    set(TARGET_HOST ${CMAKE_HOST_SYSTEM_PROCESSOR})
   endif()
+endif()
+
+if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/${TARGET_HOST}.cmake)
+  # Set necessary compiler & linker options for this specific host architecture
+  include(${TARGET_HOST}.cmake)
+elseif(DEFINED NATIVE_TARGET_HOST)
+  message(WARNING "NATIVE_TARGET_HOST set to ${NATIVE_TARGET_HOST}, but ${CMAKE_CURRENT_LIST_DIR}/"
+          "${TARGET_HOST}.cmake not found. No custom target options will be applied."
+  )
 endif()
 
 zephyr_compile_options(

--- a/arch/posix/aarch64.cmake
+++ b/arch/posix/aarch64.cmake
@@ -4,7 +4,7 @@
 # distributions. Userspace is (generally) either 32-bit or 64-bit but not
 # both.
 
-# @Intent: Call a script to get userspace wordsize for comparison with CONFIG_64BIT
+# Get userspace wordsize for comparison with CONFIG_64BIT
 execute_process(
   COMMAND
   ${PYTHON_EXECUTABLE}

--- a/arch/posix/arm.cmake
+++ b/arch/posix/arm.cmake
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_64BIT)
+  message(FATAL_ERROR
+    "CONFIG_64BIT=y while targeting a 32-bit ARM processor.\n"
+    "If you were targeting native_sim/native/64, target native_sim instead.\n"
+    "Otherwise, be sure to define CONFIG_64BIT appropriately.\n"
+  )
+endif()

--- a/arch/posix/x86_64.cmake
+++ b/arch/posix/x86_64.cmake
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_64BIT)
+  # some gcc versions fail to build without -fPIC
+  zephyr_compile_options(-m64 -fPIC)
+  zephyr_link_libraries(-m64)
+
+  target_link_options(native_simulator INTERFACE "-m64")
+  target_compile_options(native_simulator INTERFACE "-m64")
+else()
+  zephyr_compile_options(-m32)
+  zephyr_link_libraries(-m32)
+
+  target_link_options(native_simulator INTERFACE "-m32")
+  target_compile_options(native_simulator INTERFACE "-m32")
+
+  # When building for 32bits x86, gcc defaults to using the old 8087 float arithmetic
+  # which causes some issues with literal float comparisons. So we set it
+  # to use the SSE2 float path instead
+  # (clang defaults to use SSE, but, setting this option for it is safe)
+  check_set_compiler_property(APPEND PROPERTY fpsse2 "SHELL:-msse2 -mfpmath=sse")
+  zephyr_compile_options($<TARGET_PROPERTY:compiler,fpsse2>)
+  target_compile_options(native_simulator INTERFACE "$<TARGET_PROPERTY:compiler,fpsse2>")
+endif()

--- a/boards/native/native_sim/doc/cross_compile.rst
+++ b/boards/native/native_sim/doc/cross_compile.rst
@@ -1,0 +1,101 @@
+.. _posix_arch_cross_compile:
+
+Cross-compiling the POSIX architecture
+**************************************
+
+Even though the main use case for native_sim and other POSIX architecture based targets is to allow
+you to debug and instrument your code in your workstation during development, in some cases it can
+be useful to build it in one machine and execute it in another. When these machines have different
+processor architectures, we need to cross compile it.
+
+.. warning::
+
+   native_sim is a development and debug aid, meant to be reproducible and allow easy
+   instrumentation and access to the execution status. For security reasons, you should never
+   deliver final products in which the production code is being run in native_sim.
+
+Preparing your host
+===================
+
+.. note::
+
+   This instructions guide you on how to set an Ubuntu 24.04 x86_64 development machine for
+   cross-compiling for 32bit (``arm`` or ``armhf``) and 64bit (``aarch64``) ARM targets.
+   And with that setup how to cross-compile for such a target.
+   But there is different ways to setup your cross-compiling environment, and you may have a
+   different host or target architecture. Therefore you can treat this guide as inspiration.
+
+The first thing you need, is to have a cross-compiling toolchain in your development computer.
+On an Ubuntu 24.04 x86_64 you can install the ``gcc-aarch64-linux-gnu`` package for 64bit ARM
+builds. This will install these toolchain binaries as ``/usr/bin/aarch64-linux-gnu-*`` and its
+libraries and headers in ``/usr/aarch64-linux-gnu/``.
+Similarly, for the 32bit ``armhf`` the ``gcc-arm-linux-gnueabihf`` package, will install the
+binaries as ``/usr/bin/arm-linux-gnueabihf-*`` and its libraries and headers in
+``/usr/arm-linux-gnueabihf/``.
+
+.. note::
+
+   In Ubuntu 24.04 the ``gcc-multilib`` package conflicts with the ``gcc-aarch64-linux-gnu``
+   package, and, to support 32bit builds in x86_64, instructions guide you to install it.
+   This is not strictly a problem, as ``gcc-multilib`` is mostly a meta-package. What is required
+   for 32bit builds in ``x86_64`` machines are the *dependencies* of ``gcc-multilib``. It is fine to
+   remove ``gcc-multilib`` and ``g++-multilib`` after installing them, while leaving their
+   dependencies, or installing these dependencies directly. Just be sure to not remove these
+   dependencies after.
+
+Building
+========
+
+To build you need to pass to cmake the following options:
+
+  * ``ZEPHYR_TOOLCHAIN_VARIANT=cross-compile``
+  * ``NATIVE_TARGET_HOST`` set for the target machine. In this example, that is ``aarch64``
+    for 64bit ARM builds, or ``arm`` for 32bit ARM builds.
+  * ``CROSS_COMPILE`` with the cross-compiling toolchain prefix. That is
+    ``/usr/bin/aarch64-linux-gnu-``, or ``/usr/bin/arm-linux-gnueabihf-``.
+
+Depending on your compiler you may also need to set ``SYSROOT_DIR`` to your compiler sysroot path.
+
+In this example, building the ``hello_world`` sample for ``aarch64`` would be:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: native_sim//64
+   :goals: build
+   :gen-args: -DNATIVE_TARGET_HOST=aarch64 -DZEPHYR_TOOLCHAIN_VARIANT=cross-compile -DCROSS_COMPILE=/usr/bin/aarch64-linux-gnu-
+   :compact:
+
+Or for 32bit ``armhf``:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: native_sim
+   :goals: build
+   :gen-args: -DNATIVE_TARGET_HOST=arm -DZEPHYR_TOOLCHAIN_VARIANT=cross-compile -DCROSS_COMPILE=/usr/bin/arm-linux-gnueabihf-
+   :compact:
+
+Now you have an executable, ``zephyr/zephyr.exe``, you can copy and run in your target machine.
+
+A quick test: Executing it in your host
+=======================================
+
+It is possible to execute this cross compiled executable in your development host. For this you need
+`qemu's user space emulator <https://www.qemu.org/docs/master/user/main.html>`_, which in
+Ubuntu 24.04 you can install with the ``qemu-user`` package. With this, you can run the executable
+as:
+
+.. code-block:: console
+
+   $ qemu-aarch64 -L /usr/aarch64-linux-gnu/ build/zephyr/zephyr.exe
+   # Press Ctrl+C to exit
+
+For the 64bit ARM version, or
+
+.. code-block:: console
+
+   $ qemu-armhf -L /usr/arm-linux-gnueabihf/ build/zephyr/zephyr.exe
+   # Press Ctrl+C to exit
+
+for the 32bit ARM version.

--- a/boards/native/native_sim/doc/index.rst
+++ b/boards/native/native_sim/doc/index.rst
@@ -182,6 +182,11 @@ but, accessing the host for test purposes from your embedded code will be more
 difficult, and you will have a limited choice of
 :ref:`drivers and backends to chose from<native_sim_peripherals_c_compat>`.
 
+Cross-compiling native_sim
+**************************
+
+It is possible to :ref:`cross compile native_sim<posix_arch_cross_compile>`.
+
 Rationale for this port and comparison with other options
 *********************************************************
 

--- a/cmake/modules/FindHostTools.cmake
+++ b/cmake/modules/FindHostTools.cmake
@@ -70,10 +70,13 @@ if("${PTY_INTERFACE}" STREQUAL "PTY_INTERFACE-NOTFOUND")
   set(PTY_INTERFACE "")
 endif()
 
-# Default to the host system's toolchain if we are targeting a host based target
+# When targeting a host based target default to the host system's toolchain,
+# unless the user has selected to build with llvm (which is also valid for hosts builds)
+# or they are clearly trying to cross-compile a native simulator based target
 if((${BOARD_DIR} MATCHES "boards\/native") OR ("${ARCH}" STREQUAL "posix")
    OR ("${BOARD}" STREQUAL "unit_testing"))
-  if(NOT "${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "llvm")
+  if((NOT "${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "llvm") AND
+     (NOT ("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "cross-compile" AND DEFINED NATIVE_TARGET_HOST)))
     set(ZEPHYR_TOOLCHAIN_VARIANT "host")
   endif()
 endif()

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -533,7 +533,7 @@ do {                                                                    \
  * to generate named symbol/value pairs for kconfigs.
  */
 
-#if defined(CONFIG_ARM)
+#if defined(CONFIG_ARM) || (defined(CONFIG_ARCH_POSIX) && defined(__arm__))
 
 /*
  * GNU/ARM backend does not have a proper operand modifier which does not
@@ -553,19 +553,9 @@ do {                                                                    \
 		"\n\t.equ\t" #name "," #value       \
 		"\n\t.type\t" #name ",%object")
 
-#elif defined(CONFIG_X86)
-
-#define GEN_ABSOLUTE_SYM(name, value)               \
-	__asm__(".globl\t" #name "\n\t.equ\t" #name \
-		",%c0"                              \
-		"\n\t.type\t" #name ",@object" :  : "n"(value))
-
-#define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
-	__asm__(".globl\t" #name                    \
-		"\n\t.equ\t" #name "," #value       \
-		"\n\t.type\t" #name ",@object")
-
-#elif defined(CONFIG_ARC) || defined(CONFIG_ARM64)
+#elif defined(CONFIG_ARC) || defined(CONFIG_ARM64) \
+	|| defined(CONFIG_ARCH_POSIX) /*&& (__x86_64 or __i*86 or __aarch64__)*/ \
+	|| defined(CONFIG_X86)
 
 #define GEN_ABSOLUTE_SYM(name, value)               \
 	__asm__(".globl\t" #name "\n\t.equ\t" #name \
@@ -589,17 +579,6 @@ do {                                                                    \
 	__asm__(".globl\t" #name                    \
 		"\n\t.equ\t" #name "," #value       \
 		"\n\t.type\t" #name ",%object")
-
-#elif defined(CONFIG_ARCH_POSIX)
-#define GEN_ABSOLUTE_SYM(name, value)               \
-	__asm__(".globl\t" #name "\n\t.equ\t" #name \
-		",%c0"                              \
-		"\n\t.type\t" #name ",@object" :  : "n"(value))
-
-#define GEN_ABSOLUTE_SYM_KCONFIG(name, value)       \
-	__asm__(".globl\t" #name                    \
-		"\n\t.equ\t" #name "," #value       \
-		"\n\t.type\t" #name ",@object")
 
 #elif defined(CONFIG_SPARC)
 #define GEN_ABSOLUTE_SYM(name, value)			\


### PR DESCRIPTION
Support cross-compiling native/posix_arch boards from one Linux host for another Linux target host.
This is done by allowing users to set NATIVE_TARGET_HOST for cmake which will override the automatic detection.

New doc: https://builds.zephyrproject.io/zephyr/pr/100182/docs/boards/native/native_sim/doc/cross_compile.html 

As pre-work: Fix building native/posix_arch boards on 32bit arm hosts.

Fixes #70967
Fixes: #99434