### PR TITLE
openthread: Kconfig: fix MTD build by enabling OPENTHREAD_UPTIME

### DIFF
--- a/modules/openthread/Kconfig.features
+++ b/modules/openthread/Kconfig.features
@@ -421,7 +421,7 @@ config OPENTHREAD_UDP_FORWARD
 
 config OPENTHREAD_UPTIME
 	bool "Openthread uptime counter"
-	default y if OPENTHREAD_FTD
+	default y if OPENTHREAD_FTD || OPENTHREAD_MTD
 
 config OPENTHREAD_VERHOEFF_CHECKSUM
 	bool "Verhoeff checksum"


### PR DESCRIPTION
The 250745e1985f OT stack upmerge pulled upstream commit 079852b67e9b ("[uptime] enforce `UPTIME` feature for MTD and FTD builds (#11354)") which made `OPENTHREAD_CONFIG_UPTIME_ENABLE` mandatory for MTD builds.

Update the module configuration accordingly to fix a build failure with `CONFIG_OPENTHREAD_MTD=y`.