### PR TITLE
drivers: uart: save individual uart instances interrupts in PM Action

### DIFF
--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -89,7 +89,6 @@ struct mcux_flexcomm_data {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t irq_callback;
 	void *irq_cb_data;
-	uint32_t usart_intenset;
 #endif
 #ifdef CONFIG_UART_ASYNC_API
 	uart_callback_t async_callback;
@@ -109,6 +108,7 @@ struct mcux_flexcomm_data {
 	bool pm_policy_state_lock;
 	struct k_work pm_lock_work;
 #endif
+	uint32_t usart_intenset;
 };
 
 #ifdef CONFIG_PM_POLICY_DEVICE_CONSTRAINTS
@@ -1208,10 +1208,8 @@ static void mcux_flexcomm_pm_restore_wake(const struct device *dev,
 
 static int mcux_flexcomm_pm_action(const struct device *dev, enum pm_device_action action)
 {
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	const struct mcux_flexcomm_config *config = dev->config;
 	struct mcux_flexcomm_data *data = dev->data;
-#endif
 	int ret;
 
 	switch (action) {
@@ -1220,18 +1218,14 @@ static int mcux_flexcomm_pm_action(const struct device *dev, enum pm_device_acti
 	case PM_DEVICE_ACTION_SUSPEND:
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
 		data->usart_intenset = USART_GetEnabledInterrupts(config->base);
-#endif
 		break;
 	case PM_DEVICE_ACTION_TURN_ON:
 		ret = mcux_flexcomm_init_common(dev);
 		if (ret) {
 			return ret;
 		}
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
 		USART_EnableInterrupts(config->base, data->usart_intenset);
-#endif
 		break;
 	default:
 		return -ENOTSUP;


### PR DESCRIPTION
The PM action saves the interrupts enabled using a global variable called usart_intenset. The problem is when you have multiple uart instances that have different configurations, when entering/exiting from a power level, only one configuration is saved and will be applied to all uart instances when exiting from a power level. We need to keep this setting individual for each instance. To do this, usart_intenset was added as a new element to mcux_flexcomm_data structure. In this way, each uart instance will keep/restore its own setting.