### PR TITLE
Add pwm driver support for microchip pic32cx sg family

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
@@ -13,4 +13,10 @@
 				 <PB13C_SERCOM4_PAD1>;
 		};
 	};
+
+	tcc0_pwm_default: tcc0_pwm_default {
+		group1 {
+			pinmux = <PC21F_TCC0_WO5>;
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -23,6 +23,7 @@
 	aliases {
 		led0 = &led1;
 		sw0 = &button0;
+		pwm-led0 = &pwm_led0;
 	};
 
 	leds {
@@ -36,6 +37,15 @@
 		led2: led_2 {
 			gpios = <&porta 16 GPIO_ACTIVE_LOW>;
 			label = "LED2";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&tcc0 5 PWM_MSEC(20) 0>;
+			status = "okay";
 		};
 	};
 
@@ -138,6 +148,16 @@
 		compatible = "microchip,sam-d5x-e5x-mclkperiph";
 		#clock-cells = <1>;
 	};
+};
+
+&tcc0 {
+	compatible = "microchip,tcc-g1-pwm";
+	#pwm-cells = <3>;
+	pinctrl-0 = <&tcc0_pwm_default>;
+	pinctrl-names = "default";
+	max-bit-width = <24>;
+	prescaler = <8>;
+	status = "okay";
 };
 
 &porta {

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -13,5 +13,6 @@ supported:
   - clock_control
   - gpio
   - pinctrl
+  - pwm
   - uart
 vendor: microchip

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult-pinctrl.dtsi
@@ -13,4 +13,10 @@
 				 <PB13C_SERCOM4_PAD1>;
 		};
 	};
+
+	tcc0_pwm_default: tcc0_pwm_default {
+		group1 {
+			pinmux = <PC21F_TCC0_WO5>;
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -23,6 +23,7 @@
 	aliases {
 		led0 = &led1;
 		sw0 = &button0;
+		pwm-led0 = &pwm_led0;
 	};
 
 	leds {
@@ -36,6 +37,15 @@
 		led2: led_2 {
 			gpios = <&porta 16 GPIO_ACTIVE_HIGH>;
 			label = "Yellow LED";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&tcc0 5 PWM_MSEC(20) 0>;
+			status = "okay";
 		};
 	};
 
@@ -132,6 +142,16 @@
 		compatible = "microchip,sam-d5x-e5x-mclkperiph";
 		#clock-cells = <1>;
 	};
+};
+
+&tcc0 {
+	compatible = "microchip,tcc-g1-pwm";
+	#pwm-cells = <3>;
+	pinctrl-0 = <&tcc0_pwm_default>;
+	pinctrl-names = "default";
+	max-bit-width = <24>;
+	prescaler = <8>;
+	status = "okay";
 };
 
 &porta {

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -13,5 +13,6 @@ supported:
   - clock_control
   - gpio
   - pinctrl
+  - pwm
   - uart
 vendor: microchip

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/clock/mchp_sam_d5x_e5x_clock.h>
 
 / {
@@ -161,6 +162,54 @@
 			status = "disabled";
 		};
 
+		tcc0: tcc@41016000 {
+			compatible = "microchip,tcc-g1";
+			reg = <0x41016000 0x2000>;
+			interrupts = <85 0>, <86 0>, <87 0>, <88 0>, <89 0>, <90 0>, <91 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBB_TCC0>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TCC0>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <24>;
+			channels = <6>;
+			status = "disabled";
+		};
+
+		tcc1: tcc@41018000 {
+			compatible = "microchip,tcc-g1";
+			reg = <0x41018000 0x2000>;
+			interrupts = <92 0>, <93 0>, <94 0>, <95 0>, <96 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBB_TCC1>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TCC1>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <24>;
+			channels = <4>;
+			status = "disabled";
+		};
+
+		tcc2: tcc@42000c00 {
+			compatible = "microchip,tcc-g1";
+			reg = <0x42000c00 0x2000>;
+			interrupts = <97 0>, <98 0>, <99 0>, <100 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TCC2>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TCC2>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			channels = <3>;
+			status = "disabled";
+		};
+
+		tcc3: tcc@42001000 {
+			compatible = "microchip,tcc-g1";
+			reg = <0x42001000 0x2000>;
+			interrupts = <101 0>, <102 0>, <103 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBC_TCC3>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TCC3>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			channels = <2>;
+			status = "disabled";
+		};
+
 		sercom4: sercom@43000000 {
 			compatible = "microchip,sercom-g1";
 			reg = <0x43000000 0x29>;
@@ -180,6 +229,18 @@
 			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_SERCOM5>,
 				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM5_CORE>;
 			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		tcc4: tcc@43001000 {
+			compatible = "microchip,tcc-g1";
+			reg = <0x43001000 0x2000>;
+			interrupts = <104 0>, <105 0>, <106 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBD_TCC4>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_TCC4>;
+			clock-names = "mclk", "gclk";
+			max-bit-width = <16>;
+			channels = <2>;
 			status = "disabled";
 		};
 	};

--- a/tests/drivers/pwm/pwm_api/boards/microchip/pic32cx_sg61_cult_tcc0.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/microchip/pic32cx_sg61_cult_tcc0.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &tcc0;
+	};
+};
+
+&tcc0 {
+	status = "okay";
+};

--- a/tests/drivers/pwm/pwm_api/boards/microchip/pic32cx_sg61_cult_tcc1.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/microchip/pic32cx_sg61_cult_tcc1.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &tcc1;
+	};
+};
+
+&tcc1 {
+	compatible = "microchip,tcc-g1-pwm";
+	status = "okay";
+	#pwm-cells = <0x3>;
+	pinctrl-0 = <&tcc1_pwm_default>;
+	pinctrl-names = "default";
+	prescaler = <0x1>;
+};
+
+&tcc0 {
+	status = "disabled";
+};
+
+&pinctrl {
+	tcc1_pwm_default: tcc1_pwm_default {
+		group1 {
+			pinmux = <PA8G_TCC1_WO4>;
+		};
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/microchip/pic32cx_sg61_cult_tcc2.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/microchip/pic32cx_sg61_cult_tcc2.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &tcc2;
+	};
+};
+
+&tcc2 {
+	compatible = "microchip,tcc-g1-pwm";
+	status = "okay";
+	#pwm-cells = <0x3>;
+	pinctrl-0 = <&tcc2_pwm_default>;
+	pinctrl-names = "default";
+	prescaler = <0x1>;
+};
+
+&tcc0 {
+	status = "disabled";
+};
+
+&pinctrl {
+	tcc2_pwm_default: tcc2_pwm_default {
+		group1 {
+			pinmux = <PA24F_TCC2_WO2>;
+		};
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/microchip/pic32cx_sg61_cult_tcc3.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/microchip/pic32cx_sg61_cult_tcc3.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &tcc3;
+	};
+};
+
+&tcc3 {
+	compatible = "microchip,tcc-g1-pwm";
+	status = "okay";
+	#pwm-cells = <0x3>;
+	pinctrl-0 = <&tcc3_pwm_default>;
+	pinctrl-names = "default";
+	prescaler = <0x1>;
+};
+
+&tcc0 {
+	status = "disabled";
+};
+
+&pinctrl {
+	tcc3_pwm_default: tcc3_pwm_default {
+		group1 {
+			pinmux = <PB17F_TCC3_WO1>;
+		};
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/microchip/pic32cx_sg61_cult_tcc4.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/microchip/pic32cx_sg61_cult_tcc4.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &tcc4;
+	};
+};
+
+&tcc4 {
+	compatible = "microchip,tcc-g1-pwm";
+	status = "okay";
+	#pwm-cells = <0x3>;
+	pinctrl-0 = <&tcc4_pwm_default>;
+	pinctrl-names = "default";
+	prescaler = <0x1>;
+};
+
+&tcc0 {
+	status = "disabled";
+};
+
+&pinctrl {
+	tcc4_pwm_default: tcc4_pwm_default {
+		group1 {
+			pinmux = <PB30F_TCC4_WO0>;
+		};
+	};
+};

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -67,27 +67,42 @@ tests:
      and CONFIG_DT_HAS_NXP_FLEXIO_PWM_ENABLED
     depends_on: pwm
   drivers.pwm.mchp_tcc0:
-    extra_args: DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tcc0.overlay"
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tcc0.overlay"
+      - DTC_OVERLAY_FILE="boards/microchip/pic32cx_sg61_cult_tcc0.overlay"
     platform_allow:
       - sam_e54_xpro
+      - pic32cx_sg61_cult
     filter: dt_alias_exists("pwm-test")
   drivers.pwm.mchp_tcc1:
-    extra_args: DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tcc1.overlay"
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tcc1.overlay"
+      - DTC_OVERLAY_FILE="boards/microchip/pic32cx_sg61_cult_tcc1.overlay"
     platform_allow:
       - sam_e54_xpro
+      - pic32cx_sg61_cult
     filter: dt_alias_exists("pwm-test")
   drivers.pwm.mchp_tcc2:
-    extra_args: DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tcc2.overlay"
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tcc2.overlay"
+      - DTC_OVERLAY_FILE="boards/microchip/pic32cx_sg61_cult_tcc2.overlay"
     platform_allow:
       - sam_e54_xpro
+      - pic32cx_sg61_cult
     filter: dt_alias_exists("pwm-test")
   drivers.pwm.mchp_tcc3:
-    extra_args: DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tcc3.overlay"
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tcc3.overlay"
+      - DTC_OVERLAY_FILE="boards/microchip/pic32cx_sg61_cult_tcc3.overlay"
     platform_allow:
       - sam_e54_xpro
+      - pic32cx_sg61_cult
     filter: dt_alias_exists("pwm-test")
   drivers.pwm.mchp_tcc4:
-    extra_args: DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tcc4.overlay"
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_tcc4.overlay"
+      - DTC_OVERLAY_FILE="boards/microchip/pic32cx_sg61_cult_tcc4.overlay"
     platform_allow:
       - sam_e54_xpro
+      - pic32cx_sg61_cult
     filter: dt_alias_exists("pwm-test")


### PR DESCRIPTION
This PR adds PWM driver support for the PIC32CX SG family of devices and board support for PIC32CX SG41 and SG61 Curiosity Ultra boards.