### PR TITLE
soc: xlnx: zynqmp_apu: Add basic SoC support for Zynq MPSoC APU

### DIFF
--- a/soc/xlnx/zynqmp_apu/CMakeLists.txt
+++ b/soc/xlnx/zynqmp_apu/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_sources_ifdef(CONFIG_ARM_MMU mmu_regions.c)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm64/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/xlnx/zynqmp_apu/Kconfig
+++ b/soc/xlnx/zynqmp_apu/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2019 Lexmark International, Inc.
+# Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_XILINX_ZYNQMP_APU
+    bool
+    select ARM64
+    select CPU_CORTEX_A53
+    select GIC
+    select GIC_V2
+    select ARM_ARCH_TIMER if SYS_CLOCK_EXISTS

--- a/soc/xlnx/zynqmp_apu/Kconfig.defconfig
+++ b/soc/xlnx/zynqmp_apu/Kconfig.defconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2019 Lexmark International, Inc.
+# Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_XILINX_ZYNQMP
+
+if SOC_XILINX_ZYNQMP_APU
+
+config NUM_IRQS
+	# must be >= the highest interrupt number used
+	# - include the UART interrupts
+	default 220
+
+config SYS_CLOCK_EXISTS
+       bool
+       default y
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	int
+	default 100000000
+
+endif # SOC_XILINX_ZYNQMP_APU
+
+endif # SOC_XILINX_ZYNQMP

--- a/soc/xlnx/zynqmp_apu/Kconfig.soc
+++ b/soc/xlnx/zynqmp_apu/Kconfig.soc
@@ -1,0 +1,18 @@
+# Copyright (c) 2019 Lexmark International, Inc.
+# Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_XILINX_ZYNQMP
+	bool
+
+config SOC_XILINX_ZYNQMP_APU
+	bool
+	select SOC_XILINX_ZYNQMP
+	help
+	  Xilinx ZynqMP APU
+
+config SOC_FAMILY
+	default "xilinx_zynqmp" if SOC_XILINX_ZYNQMP
+
+config SOC
+	default "zynqmp_apu" if SOC_XILINX_ZYNQMP_APU

--- a/soc/xlnx/zynqmp_apu/mmu_regions.c
+++ b/soc/xlnx/zynqmp_apu/mmu_regions.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Huawei France Technologies SASU
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/arch/arm64/arm_mmu.h>
+
+static const struct arm_mmu_region mmu_regions[] = {
+
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+};
+
+const struct arm_mmu_config mmu_config = {
+	.num_regions = ARRAY_SIZE(mmu_regions),
+	.mmu_regions = mmu_regions,
+};

--- a/soc/xlnx/zynqmp_apu/soc.yml
+++ b/soc/xlnx/zynqmp_apu/soc.yml
@@ -1,0 +1,4 @@
+family:
+- name: xilinx_zynqmp
+  socs:
+  - name: zynqmp_apu


### PR DESCRIPTION
Summary

Add initial SoC support for 
the Zynq UltraScale+ MPSoC APU (Cortex-A53), including:
Kconfig, Kconfig.soc, Kconfig.defconfig
CMakeLists.txt
mmu_regions.c
soc.yml

Rationale
ARM Generic Timer base frequency is not described in DT; 
it is provided by firmware via CNTFRQ_EL0.

Testing
twister build-only passes for kv260_a53 hello_world (board PR pending).
docs build unaffected (board docs will be added in the board PR).

Notes
This PR is a prerequisite for the kv260_a53 board support.
No DTS or driver changes here; board PR will add DTS and docs.

Signed-off-by: Manabu Tajima mana.taj@gmail.com