### PR TITLE
tests: settings: its: enable lpcxpresso55s69_cpu0_ns platform

### DIFF
--- a/tests/subsys/settings/its/testcase.yaml
+++ b/tests/subsys/settings/its/testcase.yaml
@@ -12,7 +12,6 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp/ns
       - nrf54lm20dk/nrf54lm20a/cpuapp/ns
       - mps2/an521/cpu0/ns
-    platform_exclude:
       - lpcxpresso55s69/lpc55s69/cpu0/ns
     tags:
       - trusted-firmware-m


### PR DESCRIPTION
Enable the lpcxpresso55s69_cpu0_ns board for the Internal Trusted Storage (ITS) settings test case. This platform supports the required settings subsystem functionality needed for ITS testing.