### PR TITLE
boards: amd: kv260_a53: Add KV260 A53 board definition

### DIFF
--- a/boards/amd/kv260_a53/Kconfig.kv260_a53
+++ b/boards/amd/kv260_a53/Kconfig.kv260_a53
@@ -1,0 +1,7 @@
+# Copyright (c) 2019 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_KV260_A53
+        bool "AMD KV260 Cortex-A53" 
+	select SOC_XILINX_ZYNQMP_APU
+	default y

--- a/boards/amd/kv260_a53/board.cmake
+++ b/boards/amd/kv260_a53/board.cmake
@@ -1,0 +1,3 @@
+# Copyright (c) 2022 Linaro.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/boards/amd/kv260_a53/board.yml
+++ b/boards/amd/kv260_a53/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: kv260_a53
+  full_name: KV260 Development Board APU Cortex-A53
+  vendor: amd
+  socs:
+  - name: zynqmp_apu

--- a/boards/amd/kv260_a53/doc/index.rst
+++ b/boards/amd/kv260_a53/doc/index.rst
@@ -1,0 +1,58 @@
+.. zephyr:board:: kv260_a53
+
+Overview
+********
+This board configuration targets the Application Processing Unit (APU) on the AMD/Xilinx KV260 development board. The APU consists of ARM Cortex‑A53 cores and provides a general‑purpose application execution environment.
+
+This processing unit is based on an ARM Cortex-A53 CPU, it also enables the following devices:
+
+* ARM Generic Timer (system timer)
+* Xilinx Zynq UART
+* SMP: disabled by default (enable as needed)
+
+Devices
+========
+System Timer
+------------
+
+* Zephyr tick rate: CONFIG_SYS_CLOCK_TICKS_PER_SEC.
+* Hardware timer frequency: set via CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC in the defconfig.
+* The ARM Generic Timer is used.
+
+Serial Port
+-----------
+
+* This board configuration uses a single serial communication channel with the on-chip UART1.
+* baud rate: 115200 (ensure DTS chosen/aliases align with the UART chosen for console).
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+To build a Zephyr application, such as the hello world sample shown below.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: kv260_a53
+   :goals: build
+
+To confirm a Zephyr application, it is able to use u-boot command.
+
+.. code-block:: console
+
+        ZynqMP>
+        ZynqMP> dcache off
+        ZynqMP> icache off
+        ZynqMP> setenv loadaddr 0x8000000
+        ZynqMP> fatload mmc 1:1 ${loadaddr} zephyr.elf
+        1212792 bytes read in 330 ms (3.5 MiB/s)
+        ZynqMP> bootelf ${loadaddr}
+        ## Star*** Booting Zephyr OS build v4.2.0-5452-g169cf86969d7 ***
+
+Notes
+*************************
+
+* The mmc device/partition (e.g., 1:1) and loadaddr may vary depending on the platform setup; adjust as needed.
+

--- a/boards/amd/kv260_a53/kv260_a53.dts
+++ b/boards/amd/kv260_a53/kv260_a53.dts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/dts-v1/;
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+	model = "kv260 Cortex-A53";
+	compatible = "xlnx,zynqmp-a53";
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	sram0: memory@40000000 {
+		compatible = "mmio-sram";
+		reg = <0x0 0x40000000 0x0 0x08000000>;
+	};
+
+        cpus {
+            #address-cells = <2>;
+            #size-cells = <0>;
+	    cpu@0 {
+		device_type = "cpu";
+		compatible = "arm,cortex-a53";
+		reg = <0x0 0x0>;
+		status = "okay";
+	    };
+
+	    cpu@1 {
+		device_type = "cpu";
+		compatible = "arm,cortex-a53";
+		reg = <0x0 0x1>;
+	    };
+
+	    cpu@2 {
+		device_type = "cpu";
+		compatible = "arm,cortex-a53";
+		reg = <0x0 0x2>;
+	    };
+
+	    cpu@3 {
+		device_type = "cpu";
+		compatible = "arm,cortex-a53";
+		reg = <0x0 0x3>;
+	    };
+        };
+
+
+	gic: interrupt-controller@f9010000 {
+		compatible = "arm,gic-v2", "arm,gic";
+        	interrupt-controller;
+		#interrupt-cells = <4>;
+		reg = <0x0 0xf9010000 0x0 0x10000>,
+	      	      <0x0 0xf9020000 0x0 0x20000>,
+	      	      <0x0 0xf9040000 0x0 0x20000>,
+		      <0x0 0xf9060000 0x0 0x20000>;
+		status = "okay";
+	};
+		
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 14 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	};
+
+	uart1: serial@ff010000 {
+		compatible = "xlnx,xuartps";
+		status = "okay";
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 22 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		reg = <0x0 0xff010000 0x0 0x1000>;
+	};
+	
+	psci {
+		compatible = "arm,psci-0.2";
+		method = "smc";
+	};
+	
+	aliases {
+	        serial0 = &uart1;
+        };
+        
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
+		stdout-path = "serial0:115200n8";
+	};
+};
+
+
+
+&uart1 {
+	status = "okay";
+	current-speed = <115200>;
+	clock-frequency = <99999901>;
+};

--- a/boards/amd/kv260_a53/kv260_a53.yaml
+++ b/boards/amd/kv260_a53/kv260_a53.yaml
@@ -1,0 +1,12 @@
+identifier: kv260_a53
+name: Xilinx KV260 Development board for Cortex-A53
+type: mcu
+arch: arm64
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 131072
+flash: 65536
+supported:
+  - uart
+vendor: xlnx

--- a/boards/amd/kv260_a53/kv260_a53_defconfig
+++ b/boards/amd/kv260_a53/kv260_a53_defconfig
@@ -1,0 +1,6 @@
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y


### PR DESCRIPTION
Summary

Add KV260 A53 board definition under boards/amd/kv260_a53:
DTS: PS UART1 console
Kconfig.board, board.cmake
kv260_a53.yaml (includes documentation: doc/index.rst)
Documentation with build/run instructions


Testing

hello_world builds and runs via U-Boot (console at 115200).
twister build-only for hello_world succeeds.
docs build succeeds (htmldocs).
Depends-on

Depends-on: zephyrproject-rtos/zephyr#100190

Notes

SMP disabled by default.
ARM Generic Timer used; base frequency matches CNTFRQ_EL0.

Signed-off-by: Manabu Tajima mana.taj@gmail.com