### PR TITLE
drivers: led: pca9533: fix ms_to_psc wrap-around

### DIFF
--- a/drivers/led/pca9533.c
+++ b/drivers/led/pca9533.c
@@ -65,9 +65,9 @@ struct pca9533_data {
  */
 static uint8_t ms_to_psc(uint32_t period_ms)
 {
-	uint32_t tmp = (period_ms * 152U + 500U) / 1000U;
+	int32_t tmp = (period_ms * 152U + 500U) / 1000U;
 
-	return CLAMP(tmp - 1U, 0U, UINT8_MAX);
+	return CLAMP(tmp - 1, 0U, UINT8_MAX);
 }
 
 /**


### PR DESCRIPTION
If `period_ms` is 3 or less `tmp` is 0. Since `tmp` is type `uint32` subtracting 1 from 0 will wrap around to `UINT32_MAX` and is then clamped to `UINT8_MAX`.

Fix the issue by changing `tmp` and `1` to signed types.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/100020