### PR TITLE
llext: adding missing parentheses on macro INSTR_FETCHABLE

### DIFF
--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -24,7 +24,7 @@
 	  (uintptr_t)(base_addr + alloc) <=                                                        \
 		  DT_REG_ADDR(DT_INST(inst, compat)) + DT_REG_SIZE(DT_INST(inst, compat)))) ||
 #define INSTR_FETCHABLE(base_addr, alloc)                                                          \
-	DT_COMPAT_FOREACH_STATUS_OKAY_VARGS(arc_iccm, IN_NODE, base_addr, alloc) false
+	(DT_COMPAT_FOREACH_STATUS_OKAY_VARGS(arc_iccm, IN_NODE, base_addr, alloc) false)
 #elif CONFIG_HARVARD && !CONFIG_ARC
 /* Unknown if section / region is in instruction memory; warn or compensate */
 #define INSTR_FETCHABLE(base_addr, alloc) false


### PR DESCRIPTION
C macro INSTR_FETCHABLE is missing parentheses in its definition, this could lead to incorrect expansion when combined with logical operators. For instance we can have incorrect behaviors at this line: https://github.com/zephyrproject-rtos/zephyr/blob/f908d0b5f22adaaf912e729317c323864f1e1641/subsys/llext/llext_mem.c#L147