### PR TITLE
boards: frdm_mcxe247: Add RTC support and update counter sample

### DIFF
--- a/boards/nxp/frdm_mcxe247/board.c
+++ b/boards/nxp/frdm_mcxe247/board.c
@@ -131,6 +131,16 @@ static const scg_spll_config_t scg_spll_config = {
 };
 #endif
 
+static void board_set_rtc_clock(uint8_t src)
+{
+	uint32_t temp;
+
+	temp = SIM->LPOCLKS;
+	temp &= ~SIM_LPOCLKS_RTCCLKSEL_MASK;
+	temp |= SIM_LPOCLKS_RTCCLKSEL(src);
+	SIM->LPOCLKS = temp;
+}
+
 __weak void clock_init(void)
 {
 	scg_sys_clk_config_t current;
@@ -258,6 +268,10 @@ __weak void clock_init(void)
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(enet_ptp_clock))
 	CLOCK_SetIpSrc(kCLOCK_Enet,
 		       DT_CLOCKS_CELL(DT_NODELABEL(enet_ptp_clock), ip_source));
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(rtc))
+	/* Set RTC clock source to LPO32K_CLK */
+	board_set_rtc_clock(0x01);
 #endif
 }
 

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -76,6 +76,8 @@ struct counter_alarm_cfg alarm_cfg;
 #define TIMER DT_INST(0, renesas_rz_cmtw_counter)
 #elif defined(CONFIG_COUNTER_MCUX_RTC_JDP)
 #define TIMER DT_NODELABEL(rtc)
+#elif defined(CONFIG_COUNTER_MCUX_RTC)
+#define TIMER DT_NODELABEL(rtc)
 #else
 #error Unable to find a counter device node in devicetree
 #endif


### PR DESCRIPTION
1. Enable nxp_rtc device for samples/driver/counter/alarm
2. Enable RTC clock source selection for frdm_mcxe247