### PR TITLE
manifest: Update nrf_wifi for bimg offset change

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -342,7 +342,7 @@ manifest:
       revision: 5eec7aca321735f5fc8e3e7c79e162f0e9810b16
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: a39e9b155830461c9d1cf587afb151b894369b91
+      revision: pull/91/head
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: c30a6d8b92fcebdb797fc1a7698e8729e250f637


### PR DESCRIPTION
Update nrf_wifi for umac bimg offset change in all operating modes.