### PR TITLE
Add Flash driver support for PIC32CX SG family

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -18,6 +18,8 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &sercom4;
 		zephyr,shell-uart = &sercom4;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,flash-controller = &nvmctrl;
 	};
 
 	aliases {
@@ -63,9 +65,21 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		storage_partition: partition@7c000 {
-			label = "storage";
-			reg = <0x0007c000 0x4000>;
+		boot_partition: partition@0 {
+			reg = <0x00000000 0x00010000>;  /* 64 KB bootloader */
+			read-only;
+		};
+
+		slot0_partition: partition@10000 {
+			reg = <0x00010000 0x00070000>;  /* 448 KB primary app slot */
+		};
+
+		slot1_partition: partition@80000 {
+			reg = <0x00080000 0x00070000>;  /* 448 KB secondary app slot */
+		};
+
+		storage_partition: partition@f0000 {
+			reg = <0x000f0000 0x00010000>;  /* 64 KB storage area */
 		};
 	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -11,6 +11,7 @@ flash: 1024
 ram: 256
 supported:
   - clock_control
+  - flash
   - gpio
   - pinctrl
   - uart

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -18,6 +18,8 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &sercom4;
 		zephyr,shell-uart = &sercom4;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,flash-controller = &nvmctrl;
 	};
 
 	aliases {
@@ -57,9 +59,21 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		storage_partition: partition@7c000 {
-			label = "storage";
-			reg = <0x0007c000 0x4000>;
+		boot_partition: partition@0 {
+			reg = <0x00000000 0x00010000>;  /* 64 KB bootloader */
+			read-only;
+		};
+
+		slot0_partition: partition@10000 {
+			reg = <0x00010000 0x00070000>;  /* 448 KB primary app slot */
+		};
+
+		slot1_partition: partition@80000 {
+			reg = <0x00080000 0x00070000>;  /* 448 KB secondary app slot */
+		};
+
+		storage_partition: partition@f0000 {
+			reg = <0x000f0000 0x00010000>;  /* 64 KB storage area */
 		};
 	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -11,6 +11,7 @@ flash: 1024
 ram: 256
 supported:
   - clock_control
+  - flash
   - gpio
   - pinctrl
   - uart

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -28,12 +28,6 @@
 	};
 
 	soc {
-		flash0: flash@0 {
-			compatible = "soc-nv-flash";
-			write-block-size = <8>;
-			reg = <0x0 DT_SIZE_K(1024)>;
-		};
-
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
 			reg = <0x20000000 DT_SIZE_K(256)>;
@@ -112,6 +106,33 @@
 				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM1_CORE>;
 			clock-names = "mclk", "gclk";
 			status = "disabled";
+		};
+
+		nvmctrl: nvmctrl@41004000 {
+			compatible = "microchip,nvmctrl-g1-flash";
+			reg = <0x41004000 0x30>;
+			interrupts = <29 0>, <30 0>;
+			interrupt-names = "flash", "eeprom";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBB_NVMCTRL>;
+			clock-names = "mclk";
+			lock-regions = <32>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			status = "okay";
+
+			flash0: flash@0 {
+				compatible = "soc-nv-flash";
+				reg = <0x0 DT_SIZE_K(1024)>;
+				write-block-size = <8>;
+				erase-block-size = <8192>;
+			};
+
+			userrow: nvmuserrow@804000 {
+				compatible = "soc-nv-flash";
+				reg = <0x00804000 0x200>;
+				write-block-size = <8>;
+				erase-block-size = <512>;
+			};
 		};
 
 		pinctrl: pinctrl@41008000 {

--- a/samples/sysbuild/with_mcuboot/sample.yaml
+++ b/samples/sysbuild/with_mcuboot/sample.yaml
@@ -21,6 +21,7 @@ tests:
       - stm32h573i_dk/stm32h573xx/ext_flash_app
       - stm32h750b_dk/stm32h750xx/ext_flash_app
       - sam_e54_xpro
+      - pic32cx_sg41_cult
     integration_platforms:
       - nrf52840dk/nrf52840
       - esp32_devkitc/esp32/procpu

--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -58,6 +58,7 @@ tests:
       - stm32h573i_dk
       - stm32h573i_dk/stm32h573xx/ext_flash_app
       - sam_e54_xpro
+      - pic32cx_sg41_cult
     integration_platforms:
       - frdm_k64f
       - nrf52840dk/nrf52840


### PR DESCRIPTION
This PR adds Flash driver support for the PIC32CX SG family of devices and board support for PIC32CX SG41 and SG61 Curiosity Ultra boards.