### PR TITLE
gpio: mcux_rgpio: Support IRQ output select and secure access checks for i.MX95 M7

### DIFF
--- a/dts/bindings/gpio/nxp,imx-rgpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-rgpio.yaml
@@ -23,6 +23,17 @@ properties:
   "#gpio-cells":
     const: 2
 
+  irq-output-select:
+    type: int
+    default: 0
+    description: |
+      Select which IRQ line the GPIO controller outputs to.
+      0 = First IRQ line (default)
+      1 = Second IRQ line
+    enum:
+      - 0
+      - 1
+
 gpio-cells:
   - pin
   - flags


### PR DESCRIPTION
Support for selecting the IRQ output via the `irq-output-select` property in devicetree. Updates interrupt configuration and ISR logic to use the selected IRQ index. For i.MX95 M7, ensures pins and IRQs are configured only when secure access is allowed by checking PCNS and ICNS registers.