### PR TITLE
tests: Bluetooth: Classic: Fix sm_key_persist_004 failure issue

### DIFF
--- a/tests/bluetooth/classic/smp_key_persist/pytest/test_smp.py
+++ b/tests/bluetooth/classic/smp_key_persist/pytest/test_smp.py
@@ -407,9 +407,18 @@ async def sm_key_persist_004(hci_port, shell, dut, address) -> None:
                 device, shell, dut, bumble_address, iut_address
             )
 
-            await send_cmd_to_iut(shell, dut, "br clear all", "Pairings successfully cleared")
+            lines = await send_cmd_to_iut(
+                shell, dut, "br clear all", "Pairings successfully cleared"
+            )
 
-            await sm_test_initial_disconnect(dut, connection)
+            disconnected = False
+            for line in lines:
+                if "Disconnected:" in line:
+                    disconnected = True
+                    break
+
+            if not disconnected:
+                await sm_test_initial_disconnect(dut, connection)
 
             await sm_test_reboot(shell, dut)
 


### PR DESCRIPTION
For the case sm_key_persist_004, the disconnected event may be printed before the log `Pairings successfully cleared` since there is no order between log `Pairings successfully cleared` and the disconnected event. It causes the script discards the disconnected event in this case and rise the assert issue.

For the case sm_key_persist_004, check the disconnected event in the captured log. If it is not found, wait the disconnected event until timeout.