### PR TITLE
tests: Bluetooth: Classic: GAP_S: Fix case tc_gap_s_2 failure issue

### DIFF
--- a/tests/bluetooth/classic/gap_s/pytest/test_gap_s.py
+++ b/tests/bluetooth/classic/gap_s/pytest/test_gap_s.py
@@ -246,6 +246,9 @@ async def tc_gap_s_2(hci_port, shell, dut, address) -> None:
             await device.connect(dut_address, transport=BT_BR_EDR_TRANSPORT)
 
             logger.info('Step 5: DUT accepts connection request')
+            found, _ = await _wait_for_shell_response(dut, "Connected", max_wait_sec=5)
+            assert found, "DUT should accept connection request"
+
             # passive
 
             logger.info('Step 6: DUT initiates disconnection')


### PR DESCRIPTION
In the case, when the connection is established on the local side, the test script will require peer device to send ACL disconnection request. But due to the timing issue, the connected event may be not notified on the peer device side when the peer device received the ACL disconnection requirement. The exception will happen. It causes the case to fail.

Wait for the connected event of the peer device before sending the ACL disconnection request.