### PR TITLE
drivers: adc: Add adc_dt_spec _OR macros

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -94,6 +94,15 @@ New APIs and options
 
 .. zephyr-keep-sorted-start re(^\* \w)
 
+* ADC
+
+  * :c:macro:`ADC_DT_SPEC_GET_BY_IDX_OR`
+  * :c:macro:`ADC_DT_SPEC_GET_BY_NAME_OR`
+  * :c:macro:`ADC_DT_SPEC_GET_OR`
+  * :c:macro:`ADC_DT_SPEC_INST_GET_BY_IDX_OR`
+  * :c:macro:`ADC_DT_SPEC_INST_GET_BY_NAME_OR`
+  * :c:macro:`ADC_DT_SPEC_INST_GET_OR`
+
 * Architectures
 
   * Xtensa

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -280,8 +280,12 @@ IF_ENABLED(CONFIG_ADC_CONFIGURABLE_VBIAS_PIN, \
 /**
  * @brief Container for ADC channel information specified in devicetree.
  *
+ * @see ADC_DT_SPEC_GET_BY_NAME
+ * @see ADC_DT_SPEC_GET_BY_NAME_OR
  * @see ADC_DT_SPEC_GET_BY_IDX
+ * @see ADC_DT_SPEC_GET_BY_IDX_OR
  * @see ADC_DT_SPEC_GET
+ * @see ADC_DT_SPEC_GET_OR
  */
 struct adc_dt_spec {
 	/**
@@ -424,6 +428,22 @@ struct adc_dt_spec {
 	ADC_DT_SPEC_STRUCT(DT_IO_CHANNELS_CTLR_BY_NAME(node_id, name), \
 			   DT_IO_CHANNELS_INPUT_BY_NAME(node_id, name))
 
+/**
+ * @brief Like ADC_DT_SPEC_GET_BY_NAME(), with a fallback to a default value.
+ *
+ * @param node_id Devicetree node identifier.
+ * @param name Channel name.
+ * @param default_value Fallback value to expand to.
+ *
+ * @return Static initializer for a struct adc_dt_spec for the property,
+ *         or @p default_value if the node or property do not exist.
+ *
+ * @see ADC_DT_SPEC_INST_GET_BY_NAME_OR
+ */
+#define ADC_DT_SPEC_GET_BY_NAME_OR(node_id, name, default_value) \
+	COND_CODE_1(DT_PROP_HAS_NAME(node_id, io_channels, name), \
+		    (ADC_DT_SPEC_GET_BY_NAME(node_id, name)), (default_value))
+
 /** @brief Get ADC io-channel information from a DT_DRV_COMPAT devicetree
  *         instance by name.
  *
@@ -436,6 +456,21 @@ struct adc_dt_spec {
  */
 #define ADC_DT_SPEC_INST_GET_BY_NAME(inst, name) \
 	ADC_DT_SPEC_GET_BY_NAME(DT_DRV_INST(inst), name)
+
+/**
+ * @brief Like ADC_DT_SPEC_INST_GET_BY_NAME(), with a fallback to a default value.
+ *
+ * @param inst DT_DRV_COMPAT instance number
+ * @param name Channel name.
+ * @param default_value Fallback value to expand to.
+ *
+ * @return Static initializer for a struct adc_dt_spec for the property,
+ *         or @p default_value if the node or property do not exist.
+ *
+ * @see ADC_DT_SPEC_GET_BY_NAME_OR
+ */
+#define ADC_DT_SPEC_INST_GET_BY_NAME_OR(inst, name, default_value) \
+	ADC_DT_SPEC_GET_BY_NAME_OR(DT_DRV_INST(inst), name, default_value)
 
 /**
  * @brief Get ADC io-channel information from devicetree.
@@ -510,6 +545,22 @@ struct adc_dt_spec {
 	ADC_DT_SPEC_STRUCT(DT_IO_CHANNELS_CTLR_BY_IDX(node_id, idx), \
 			   DT_IO_CHANNELS_INPUT_BY_IDX(node_id, idx))
 
+/**
+ * @brief Like ADC_DT_SPEC_GET_BY_IDX(), with a fallback to a default value.
+ *
+ * @param node_id Devicetree node identifier.
+ * @param idx Channel index.
+ * @param default_value Fallback value to expand to.
+ *
+ * @return Static initializer for a struct adc_dt_spec for the property,
+ *         or @p default_value if the node or property do not exist.
+ *
+ * @see ADC_DT_SPEC_INST_GET_BY_IDX_OR
+ */
+#define ADC_DT_SPEC_GET_BY_IDX_OR(node_id, idx, default_value) \
+	COND_CODE_1(DT_PROP_HAS_IDX(node_id, io_channels, idx), \
+		    (ADC_DT_SPEC_GET_BY_IDX(node_id, idx)), (default_value))
+
 /** @brief Get ADC io-channel information from a DT_DRV_COMPAT devicetree
  *         instance.
  *
@@ -524,6 +575,20 @@ struct adc_dt_spec {
 	ADC_DT_SPEC_GET_BY_IDX(DT_DRV_INST(inst), idx)
 
 /**
+ * @brief Like ADC_DT_SPEC_INST_GET_BY_IDX(), with a fallback to a default value.
+ *
+ * @param inst DT_DRV_COMPAT instance number
+ * @param idx Channel index.
+ * @param default_value Fallback value to expand to.
+ *
+ * @return Static initializer for a struct adc_dt_spec for the property,
+ *         or @p default_value if the node or property do not exist.
+ *
+ * @see ADC_DT_SPEC_GET_BY_IDX_OR
+ */
+#define ADC_DT_SPEC_INST_GET_BY_IDX_OR(inst, idx, default_value) \
+	ADC_DT_SPEC_GET_BY_IDX_OR(DT_DRV_INST(inst), idx, default_value)
+/**
  * @brief Equivalent to ADC_DT_SPEC_GET_BY_IDX(node_id, 0).
  *
  * @see ADC_DT_SPEC_GET_BY_IDX()
@@ -534,7 +599,22 @@ struct adc_dt_spec {
  */
 #define ADC_DT_SPEC_GET(node_id) ADC_DT_SPEC_GET_BY_IDX(node_id, 0)
 
-/** @brief Equivalent to ADC_DT_SPEC_INST_GET_BY_IDX(inst, 0).
+/**
+ * @brief Equivalent to ADC_DT_SPEC_GET_BY_IDX_OR(node_id, 0, default_value).
+ *
+ * @see ADC_DT_SPEC_GET_BY_IDX_OR()
+ *
+ * @param node_id Devicetree node identifier.
+ * @param default_value Fallback value to expand to.
+ *
+ * @return Static initializer for a struct adc_dt_spec for the property,
+ *         or @p default_value if the node or property do not exist.
+ */
+#define ADC_DT_SPEC_GET_OR(node_id, default_value) \
+	ADC_DT_SPEC_GET_BY_IDX_OR(node_id, 0, default_value)
+
+/**
+ * @brief Equivalent to ADC_DT_SPEC_INST_GET_BY_IDX(inst, 0).
  *
  * @see ADC_DT_SPEC_GET()
  *
@@ -543,6 +623,20 @@ struct adc_dt_spec {
  * @return Static initializer for an adc_dt_spec structure.
  */
 #define ADC_DT_SPEC_INST_GET(inst) ADC_DT_SPEC_GET(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to ADC_DT_SPEC_INST_GET_BY_IDX_OR(inst, 0, default).
+ *
+ * @see ADC_DT_SPEC_GET_OR()
+ *
+ * @param inst DT_DRV_COMPAT instance number
+ * @param default_value Fallback value to expand to.
+ *
+ * @return Static initializer for a struct adc_dt_spec for the property,
+ *         or @p default_value if the node or property do not exist.
+ */
+#define ADC_DT_SPEC_INST_GET_OR(inst, default_value) \
+	ADC_DT_SPEC_GET_OR(DT_DRV_INST(inst), default_value)
 
 /* Forward declaration of the adc_sequence structure. */
 struct adc_sequence;

--- a/tests/lib/devicetree/api_ext/src/main.c
+++ b/tests/lib/devicetree/api_ext/src/main.c
@@ -33,17 +33,31 @@ ZTEST(devicetree_api_ext, test_adc_dt_spec)
 
 	/* ADC_DT_SPEC_GET_BY_NAME */
 	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_GET_BY_NAME(TEST_TEMP, ch1);
-	zassert_equal(adc_spec.channel_id, 10, "");
+	zexpect_equal(adc_spec.channel_id, 10, "");
 
 	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_GET_BY_NAME(TEST_TEMP, ch2);
-	zassert_equal(adc_spec.channel_id, 20, "");
+	zexpect_equal(adc_spec.channel_id, 20, "");
 
 	/* ADC_DT_SPEC_INST_GET_BY_NAME */
 	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_NAME(0, ch1);
-	zassert_equal(adc_spec.channel_id, 10, "");
+	zexpect_equal(adc_spec.channel_id, 10, "");
 
 	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_NAME(0, ch2);
-	zassert_equal(adc_spec.channel_id, 20, "");
+	zexpect_equal(adc_spec.channel_id, 20, "");
+
+	/* ADC_DT_SPEC_GET_BY_IDX */
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_GET_BY_IDX(TEST_TEMP, 0);
+	zexpect_equal(adc_spec.channel_id, 10, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_GET_BY_IDX(TEST_TEMP, 1);
+	zexpect_equal(adc_spec.channel_id, 20, "");
+
+	/* ADC_DT_SPEC_INST_GET_BY_IDX */
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_IDX(0, 0);
+	zexpect_equal(adc_spec.channel_id, 10, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_IDX(0, 1);
+	zexpect_equal(adc_spec.channel_id, 20, "");
 }
 
 DEVICE_DT_DEFINE(DT_NODELABEL(test_mbox), NULL, NULL, NULL, NULL, POST_KERNEL, 90, NULL);

--- a/tests/lib/devicetree/api_ext/src/main.c
+++ b/tests/lib/devicetree/api_ext/src/main.c
@@ -19,6 +19,7 @@
 #define TEST_SRAM1 DT_NODELABEL(test_sram1)
 #define TEST_SRAM2 DT_NODELABEL(test_sram2)
 #define TEST_TEMP  DT_NODELABEL(test_temp_sensor)
+#define TEST_MISSING DT_NODELABEL(test_non_existing)
 
 ZTEST(devicetree_api_ext, test_linker_regions)
 {
@@ -58,6 +59,58 @@ ZTEST(devicetree_api_ext, test_adc_dt_spec)
 
 	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_IDX(0, 1);
 	zexpect_equal(adc_spec.channel_id, 20, "");
+
+	/* ADC_DT_SPEC_GET_BY_NAME_OR */
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_GET_BY_NAME_OR(TEST_TEMP, ch1, {0});
+	zexpect_equal(adc_spec.channel_id, 10, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_GET_BY_NAME_OR(TEST_TEMP, ch2, {0});
+	zexpect_equal(adc_spec.channel_id, 20, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_GET_BY_NAME_OR(TEST_TEMP, ch_missing, {0});
+	zexpect_equal(adc_spec.channel_id, 0, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_GET_BY_NAME_OR(TEST_MISSING, ch1, {0});
+	zexpect_equal(adc_spec.channel_id, 0, "");
+
+	/* ADC_DT_SPEC_INST_GET_BY_NAME_OR */
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_NAME_OR(0, ch1, {0});
+	zexpect_equal(adc_spec.channel_id, 10, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_NAME_OR(0, ch2, {0});
+	zexpect_equal(adc_spec.channel_id, 20, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_NAME_OR(0, ch_missing, {0});
+	zexpect_equal(adc_spec.channel_id, 0, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_NAME_OR(100, ch1, {0});
+	zexpect_equal(adc_spec.channel_id, 0, "");
+
+	/* ADC_DT_SPEC_GET_BY_IDX_OR */
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_GET_BY_IDX_OR(TEST_TEMP, 0, {0});
+	zexpect_equal(adc_spec.channel_id, 10, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_GET_BY_IDX_OR(TEST_TEMP, 1, {0});
+	zexpect_equal(adc_spec.channel_id, 20, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_GET_BY_IDX_OR(TEST_TEMP, 100, {0});
+	zexpect_equal(adc_spec.channel_id, 0, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_GET_BY_IDX_OR(TEST_MISSING, 0, {0});
+	zexpect_equal(adc_spec.channel_id, 0, "");
+
+	/* ADC_DT_SPEC_INST_GET_BY_IDX_OR */
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_IDX_OR(0, 0, {0});
+	zexpect_equal(adc_spec.channel_id, 10, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_IDX_OR(0, 1, {0});
+	zexpect_equal(adc_spec.channel_id, 20, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_IDX_OR(0, 100, {0});
+	zexpect_equal(adc_spec.channel_id, 0, "");
+
+	adc_spec = (struct adc_dt_spec)ADC_DT_SPEC_INST_GET_BY_IDX_OR(100, 0, {0});
+	zexpect_equal(adc_spec.channel_id, 0, "");
 }
 
 DEVICE_DT_DEFINE(DT_NODELABEL(test_mbox), NULL, NULL, NULL, NULL, POST_KERNEL, 90, NULL);


### PR DESCRIPTION
Allow constructing an `struct adc_dt_spec` or fallback to a default value.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/99120