### PR TITLE
tests: Bluetooth: Audio: Reenable some diabled tests that now pass

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_12_441_1_2.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_12_441_1_2.sh
@@ -4,5 +4,4 @@
 
 source $(dirname "$0")/_ac_common.sh
 
-# BT_ISO_FLAGS_LOST
-# ac_config=12 ac_tx_preset=441_1_2 ac_acc_cnt=1 Execute_cap_broadcast_ac $@
+ac_config=12 ac_tx_preset=441_1_2 ac_acc_cnt=1 Execute_cap_broadcast_ac $@

--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_12_441_2_2.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_12_441_2_2.sh
@@ -4,5 +4,4 @@
 
 source $(dirname "$0")/_ac_common.sh
 
-# BT_ISO_FLAGS_LOST
-# ac_config=12 ac_tx_preset=441_2_2 ac_acc_cnt=1 Execute_cap_broadcast_ac $@
+ac_config=12 ac_tx_preset=441_2_2 ac_acc_cnt=1 Execute_cap_broadcast_ac $@

--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_14_441_1_2.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_14_441_1_2.sh
@@ -4,5 +4,4 @@
 
 source $(dirname "$0")/_ac_common.sh
 
-# BT_ISO_FLAGS_LOST
-# ac_config=14 ac_tx_preset=441_1_2 ac_acc_cnt=1 Execute_cap_broadcast_ac $@
+ac_config=14 ac_tx_preset=441_1_2 ac_acc_cnt=1 Execute_cap_broadcast_ac $@

--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_14_441_2_1.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_14_441_2_1.sh
@@ -4,6 +4,4 @@
 
 source $(dirname "$0")/_ac_common.sh
 
-# ASSERTION FAIL [err == ((isoal_status_t) 0x00) || err == ((isoal_status_t) 0x04)]
-# @ WEST_TOPDIR/zephyr/subsys/bluetooth/controller/hci/hci_driver.c:513
-# ac_config=14 ac_tx_preset=441_2_1 ac_acc_cnt=1 Execute_cap_broadcast_ac $@
+ac_config=14 ac_tx_preset=441_2_1 ac_acc_cnt=1 Execute_cap_broadcast_ac $@

--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_14_48_5_2.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_14_48_5_2.sh
@@ -4,5 +4,4 @@
 
 source $(dirname "$0")/_ac_common.sh
 
-# BT_ISO_FLAGS_ERROR
-# ac_config=14 ac_tx_preset=48_5_2 ac_acc_cnt=1 Execute_cap_broadcast_ac $@
+ac_config=14 ac_tx_preset=48_5_2 ac_acc_cnt=1 Execute_cap_broadcast_ac $@

--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_1_441_1_1.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_1_441_1_1.sh
@@ -4,6 +4,4 @@
 
 source $(dirname "$0")/_ac_common.sh
 
-# bap_stream_rx.c:66): ISO receive lost
-# https://github.com/zephyrproject-rtos/zephyr/issues/84303
-# ac_config=1 ac_tx_preset=441_1_1 ac_acc_cnt=1 Execute_cap_unicast_ac $@
+ac_config=1 ac_tx_preset=441_1_1 ac_acc_cnt=1 Execute_cap_unicast_ac $@

--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_1_441_2_1.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_1_441_2_1.sh
@@ -4,6 +4,4 @@
 
 source $(dirname "$0")/_ac_common.sh
 
-# bap_stream_rx.c:66): ISO receive lost
-# https://github.com/zephyrproject-rtos/zephyr/issues/84303
-# ac_config=1 ac_tx_preset=441_2_1 ac_acc_cnt=1 Execute_cap_unicast_ac $@
+ac_config=1 ac_tx_preset=441_2_1 ac_acc_cnt=1 Execute_cap_unicast_ac $@

--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_3_48_1_1.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_3_48_1_1.sh
@@ -4,6 +4,4 @@
 
 source $(dirname "$0")/_ac_common.sh
 
-# No sent callback on peripheral and no RX on peripheral
-# https://github.com/zephyrproject-rtos/zephyr/issues/83585
-# ac_config=3 ac_tx_preset=48_1_1 ac_rx_preset=48_1_1 ac_acc_cnt=1 Execute_cap_unicast_ac $@
+ac_config=3 ac_tx_preset=48_1_1 ac_rx_preset=48_1_1 ac_acc_cnt=1 Execute_cap_unicast_ac $@

--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_4_441_2_1.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_4_441_2_1.sh
@@ -4,6 +4,4 @@
 
 source $(dirname "$0")/_ac_common.sh
 
-# ASSERTION FAIL [err == ((isoal_status_t) 0x00)] @
-# zephyr/subsys/bluetooth/controller/hci/hci_driver.c:489
-# ac_config=4 ac_tx_preset=441_2_1 ac_acc_cnt=1 Execute_cap_unicast_ac $@
+ac_config=4 ac_tx_preset=441_2_1 ac_acc_cnt=1 Execute_cap_unicast_ac $@

--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_6_i_441_1_1.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_6_i_441_1_1.sh
@@ -4,6 +4,4 @@
 
 source $(dirname "$0")/_ac_common.sh
 
-# bap_stream_rx.c:66): ISO receive lost
-# https://github.com/zephyrproject-rtos/zephyr/issues/84303
-# ac_config=6_i ac_tx_preset=441_1_1 ac_acc_cnt=1 Execute_cap_unicast_ac $@
+ac_config=6_i ac_tx_preset=441_1_1 ac_acc_cnt=1 Execute_cap_unicast_ac $@

--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_7_i_48_1_1.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/cap_ac_7_i_48_1_1.sh
@@ -4,6 +4,4 @@
 
 source $(dirname "$0")/_ac_common.sh
 
-# No sent callback on peripheral and no RX on peripheral
-# https://github.com/zephyrproject-rtos/zephyr/issues/83585
-# ac_config=7_i ac_tx_preset=48_1_1 ac_rx_preset=48_1_1 ac_acc_cnt=1 Execute_cap_unicast_ac $@
+ac_config=7_i ac_tx_preset=48_1_1 ac_rx_preset=48_1_1 ac_acc_cnt=1 Execute_cap_unicast_ac $@


### PR DESCRIPTION
Enabled some tests that previously failed, but were not reenable when the fix was applied.