### PR TITLE
doc: releases: Fix duplicate Bluetooth entry

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -70,13 +70,6 @@ Deprecated APIs and options
 
 New APIs and options
 ====================
-
-* Bluetooth
-
-  * Host
-
-    * :c:func:`bt_gatt_cb_unregister` Added an API to unregister GATT callback handlers.
-
 ..
   Link to new APIs here, in a group if you think it's necessary, no need to get
   fancy just list the link, that should contain the documentation. If you feel
@@ -86,6 +79,10 @@ New APIs and options
 .. zephyr-keep-sorted-start re(^\* \w)
 
 * Bluetooth
+
+  * Host
+
+    * :c:func:`bt_gatt_cb_unregister` Added an API to unregister GATT callback handlers.
 
   * Mesh
 


### PR DESCRIPTION
There were 2 entries for Bluetooth in the New APIs and options