### PR TITLE
treewide: use auto-generated Kconfig compatible macro variables

### DIFF
--- a/drivers/debug/Kconfig.nrf
+++ b/drivers/debug/Kconfig.nrf
@@ -1,8 +1,6 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_NORDIC_NRF_TBM := nordic,nrf-tbm
-
 config DEBUG_NRF_ETR
 	bool "Coresight ETR handler (with Nordic TBM)"
 	depends on $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_TBM))

--- a/drivers/ethernet/dwc_xgmac/Kconfig
+++ b/drivers/ethernet/dwc_xgmac/Kconfig
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-DT_COMPAT_DWC_XGMAC := snps,dwcxgmac
-
 menu "DWC XGMAC configuration"
 
 config ETH_DWC_XGMAC

--- a/drivers/i3c/Kconfig.nxp
+++ b/drivers/i3c/Kconfig.nxp
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_NXP_MCUX_I3C := nxp,mcux-i3c
-
 module = I3C_MCUX
 module-str = i3c-mcux
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/usb/uhc/Kconfig.max3421e
+++ b/drivers/usb/uhc/Kconfig.max3421e
@@ -1,8 +1,6 @@
 # Copyright (c) 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_UHC_MAX3421E := maxim,max3421e-spi
-
 config UHC_MAX3421E
 	bool "MAX3421E driver"
 	default y

--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -277,13 +277,9 @@ config NRFX_SPI2
 	depends on $(dt_nodelabel_exists,spi2) && SOC_SERIES_NRF52X
 	select NRFX_SPI
 
-DT_COMPAT_NORDIC_NRF_SPIM := nordic,nrf-spim
-
 config NRFX_SPIM
 	bool "SPIM driver"
 	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_SPIM))
-
-DT_COMPAT_NORDIC_NRF_SPIS := nordic,nrf-spis
 
 config NRFX_SPIS
 	bool "SPIS driver"

--- a/modules/nrf_wifi/bus/Kconfig
+++ b/modules/nrf_wifi/bus/Kconfig
@@ -4,12 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-DT_COMPAT_NORDIC_NRF7002_QSPI := nordic,nrf7002-qspi
-DT_COMPAT_NORDIC_NRF7002_SPI := nordic,nrf7002-spi
-DT_COMPAT_NORDIC_NRF7001_QSPI := nordic,nrf7001-qspi
-DT_COMPAT_NORDIC_NRF7001_SPI := nordic,nrf7001-spi
-DT_COMPAT_NORDIC_NRF7000_QSPI := nordic,nrf7000-qspi
-DT_COMPAT_NORDIC_NRF7000_SPI := nordic,nrf7000-spi
+# TODO: Use DTS generated Kconfig once the board support is added
 DT_COMPAT_NORDIC_WIFI71 := nordic,nrf7120
 
 menuconfig NRF70_BUSLIB

--- a/soc/nxp/common/Kconfig.flexspi_xip
+++ b/soc/nxp/common/Kconfig.flexspi_xip
@@ -2,12 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 DT_CHOSEN_Z_FLASH := zephyr,flash
-DT_COMPAT_FLEXSPI := nxp,imx-flexspi
 
 DT_CHOSEN_FLASH_NODE := $(dt_chosen_path,$(DT_CHOSEN_Z_FLASH))
 DT_CHOSEN_FLASH_PARENT := $(dt_node_parent,$(DT_CHOSEN_FLASH_NODE))
 
-DT_FLASH_PARENT_IS_FLEXSPI := $(dt_node_has_compat,$(DT_CHOSEN_FLASH_PARENT),$(DT_COMPAT_FLEXSPI))
+DT_FLASH_PARENT_IS_FLEXSPI := $(dt_node_has_compat,$(DT_CHOSEN_FLASH_PARENT),$(DT_COMPAT_NXP_IMX_FLEXSPI))
 DT_FLASH_HAS_SIZE_PROP := $(dt_node_has_prop,$(DT_CHOSEN_FLASH_NODE),size)
 
 config FLASH_BASE_ADDRESS

--- a/soc/nxp/common/Kconfig.xspi_xip
+++ b/soc/nxp/common/Kconfig.xspi_xip
@@ -2,13 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 DT_CHOSEN_Z_FLASH := zephyr,flash
-DT_COMPAT_XSPI := nxp,xspi
 
 DT_CHOSEN_FLASH_NODE := $(dt_chosen_path,$(DT_CHOSEN_Z_FLASH))
 DT_CHOSEN_FLASH_CTRL := $(dt_node_parent,$(DT_CHOSEN_FLASH_NODE))
 DT_CHOSEN_FLASH_CTRL_PARENT := $(dt_node_parent,$(DT_CHOSEN_FLASH_CTRL))
 
-DT_FLASH_CTRL_PARENT_IS_XSPI := $(dt_node_has_compat,$(DT_CHOSEN_FLASH_CTRL_PARENT),$(DT_COMPAT_XSPI))
+DT_FLASH_CTRL_PARENT_IS_XSPI := $(dt_node_has_compat,$(DT_CHOSEN_FLASH_CTRL_PARENT),$(DT_COMPAT_NXP_XSPI))
 DT_FLASH_CTRL_HAS_SIZE_PROP := $(dt_node_has_prop,$(DT_CHOSEN_FLASH_CTRL),size)
 
 config FLASH_BASE_ADDRESS

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -299,7 +299,6 @@ config FS_FATFS_CUSTOM_MOUNT_POINTS
 	   be used for mounting fatfs filesystems anymore.
 	depends on FS_FATFS_CUSTOM_MOUNT_POINT_COUNT > 0
 
-DT_COMPAT_ZEPHYR_FSTAB_FATFS := zephyr,fstab,fatfs
 config FS_FATFS_FSTAB_AUTOMOUNT
 	bool "Support for fstab auto-mounting"
 	depends on $(dt_compat_enabled,$(DT_COMPAT_ZEPHYR_FSTAB_FATFS))

--- a/subsys/fs/ext2/Kconfig
+++ b/subsys/fs/ext2/Kconfig
@@ -53,7 +53,6 @@ config EXT2_SUPERBLOCK_ALIGNMENT
 	  this value if they require alignment. This represents the alignment
 	  of struct ext2_disk_superblock in bytes.
 
-DT_COMPAT_ZEPHYR_FSTAB_EXT2 := zephyr,fstab,ext2
 config EXT2_FSTAB_AUTOMOUNT
 	bool "Support for fstab auto-mounting"
 	depends on $(dt_compat_enabled,$(DT_COMPAT_ZEPHYR_FSTAB_EXT2))


### PR DESCRIPTION
Replace some manually-defined `DT_COMPAT_<>` Kconfig macro variables with their automatically generated counterparts. In most cases, this is straightforward as the manually defined macro is named identically to the one generated by the build system.

See also #100215 