### PR TITLE
runners: stm32cubeprogrammer: add support for --dev-id

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -103,11 +103,9 @@ class HardwareAdapter(DeviceAdapter):
             elif runner == "openocd" and self.device_config.product == "LPC-LINK2 CMSIS-DAP":
                 extra_args.append("--cmd-pre-init")
                 extra_args.append(f'adapter serial {board_id}')
-            elif runner == 'jlink':
+            elif runner == 'jlink' or (runner == 'stm32cubeprogrammer' and self.device_config.product != "BOOT-SERIAL"):
                 base_args.append('--dev-id')
                 base_args.append(board_id)
-            elif runner == 'stm32cubeprogrammer' and self.device_config.product != "BOOT-SERIAL":
-                base_args.append(f'--tool-opt=sn={board_id}')
             elif runner == 'linkserver':
                 base_args.append(f'--probe={board_id}')
         return base_args, extra_args

--- a/scripts/pylib/pytest-twister-harness/tests/device/hardware_adapter_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/device/hardware_adapter_test.py
@@ -112,7 +112,7 @@ def test_if_get_command_returns_proper_string_7(patched_which, device: HardwareA
     assert isinstance(device.command, list)
     assert device.command == [
         'west', 'flash', '--skip-rebuild', '--build-dir', 'build', '--runner', 'stm32cubeprogrammer',
-        '--tool-opt=sn=p_id'
+        '--dev-id', 'p_id'
     ]
 
 

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -638,7 +638,8 @@ class DeviceHandler(Handler):
                     # --probe=<serial number> select by probe serial number
                     command.append(f"--probe={board_id}")
                 elif runner == "stm32cubeprogrammer" and product != "BOOT-SERIAL":
-                    command.append(f"--tool-opt=sn={board_id}")
+                    command.append('--dev-id')
+                    command.append(board_id)
 
                 # Receive parameters from runner_params field.
                 if hardware.runner_params:

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1141,7 +1141,7 @@ TESTDATA_13 = [
         'product',
         None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
-         '--runner', 'stm32cubeprogrammer', '--tool-opt=sn=12345',
+         '--runner', 'stm32cubeprogrammer', '--dev-id', 12345,
          'param1', 'param2']
     ),
     (

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -32,6 +32,7 @@ from twisterlib.handlers import (
 from twisterlib.hardwaremap import DUT
 from twisterlib.statuses import TwisterStatus
 
+# pylint: disable=no-name-in-module
 from . import ZEPHYR_BASE
 
 

--- a/scripts/west_commands/runners/stm32cubeprogrammer.py
+++ b/scripts/west_commands/runners/stm32cubeprogrammer.py
@@ -32,6 +32,7 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
         self,
         cfg: RunnerConfig,
         port: str,
+        dev_id: str | None,
         frequency: int | None,
         reset_mode: str | None,
         download_address: int | None,
@@ -48,6 +49,7 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
         super().__init__(cfg)
 
         self._port = port
+        self._dev_id = dev_id
         self._frequency = frequency
 
         self._download_address = download_address
@@ -146,7 +148,7 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={"flash"}, erase=True, extload=True, tool_opt=True)
+        return RunnerCaps(commands={"flash"}, dev_id=True, erase=True, extload=True, tool_opt=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -230,6 +232,7 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
         return STM32CubeProgrammerBinaryRunner(
             cfg,
             port=args.port,
+            dev_id=args.dev_id,
             frequency=args.frequency,
             reset_mode=args.reset_mode,
             download_address=args.download_address,
@@ -262,6 +265,8 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
             connect_opts += f" reset={reset_mode}"
         if self._conn_modifiers:
             connect_opts += f" {self._conn_modifiers}"
+        if self._dev_id:
+            connect_opts += f" sn={self._dev_id}"
 
         cmd += ["--connect", connect_opts]
         cmd += self._tool_opt

--- a/scripts/west_commands/tests/test_stm32cubeprogrammer.py
+++ b/scripts/west_commands/tests/test_stm32cubeprogrammer.py
@@ -62,6 +62,7 @@ MACOS_CLI_PATH = (
 TEST_CASES = (
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": None,
         "reset_mode": None,
         "download_address": None,
@@ -89,6 +90,7 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": None,
         "reset_mode": None,
         "download_address": None,
@@ -117,6 +119,7 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": "4000",
         "reset_mode": None,
         "download_address": None,
@@ -144,6 +147,7 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": None,
         "reset_mode": "hw",
         "download_address": None,
@@ -171,6 +175,7 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": None,
         "reset_mode": "sw",
         "download_address": None,
@@ -198,6 +203,7 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": None,
         "reset_mode": "core",
         "download_address": None,
@@ -225,11 +231,12 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": "TEST",
         "frequency": None,
         "reset_mode": None,
         "download_address": None,
         "start_address": None,
-        "conn_modifiers": "br=115200 sn=TEST",
+        "conn_modifiers": "br=115200",
         "start_modifiers": [],
         "download_modifiers": [],
         "cli": CLI_PATH,
@@ -252,6 +259,7 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": None,
         "reset_mode": None,
         "download_address": None,
@@ -279,6 +287,7 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": None,
         "reset_mode": None,
         "download_address": None,
@@ -307,6 +316,7 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": None,
         "reset_mode": None,
         "download_address": None,
@@ -335,6 +345,7 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": None,
         "reset_mode": None,
         "download_address": None,
@@ -362,6 +373,7 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": None,
         "reset_mode": None,
         "download_address": None,
@@ -389,6 +401,7 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": None,
         "reset_mode": None,
         "download_address": None,
@@ -416,6 +429,7 @@ TEST_CASES = (
     },
     {
         "port": "swd",
+        "dev_id": None,
         "frequency": None,
         "reset_mode": None,
         "download_address": 0x80000000,
@@ -475,6 +489,7 @@ def test_stm32cubeprogrammer_init(
     runner = STM32CubeProgrammerBinaryRunner(
         cfg=runner_config,
         port=tc["port"],
+        dev_id=tc["dev_id"],
         frequency=tc["frequency"],
         reset_mode=tc["reset_mode"],
         download_address=tc["download_address"],
@@ -514,6 +529,8 @@ def test_stm32cubeprogrammer_create(
     system.return_value = tc["system"]
 
     args = ["--port", tc["port"]]
+    if tc["dev_id"]:
+        args.extend(["--dev-id", tc["dev_id"]])
     if tc["frequency"]:
         args.extend(["--frequency", tc["frequency"]])
     if tc["reset_mode"]:


### PR DESCRIPTION
Add support for the standard `--dev-id` argument used to select target ST-Link debug probe based on serial number. Note that this could already be achieved using custom argument `--conn-modifiers`. (`--dev-id <XXX>` is equivalent to `--conn-modifiers sn=<XXX>`)