### PR TITLE
scripts: gen_relocate_app.py: Replace quoted section name with wildcard.

### DIFF
--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -332,9 +332,9 @@ def print_linker_sections(list_sections: 'list[OutputSection]'):
     out = ''
     for section in sorted(list_sections):
         template = PRINT_TEMPLATE if section.keep else PRINT_TEMPLATE_NOKEEP
-        out += template.format(
-            obj_file_name=section.obj_file_name, section_name=section.section_name
-        )
+        # Replace quoted section name with wildcard.
+        section_name = re.sub(r'\.\"[^\"]+\"\.', '.*.', section.section_name)
+        out += template.format(obj_file_name=section.obj_file_name, section_name=section_name)
     return out
 
 


### PR DESCRIPTION
ld seems to treat quotes in section names as literal characters, which makes it fail to match section names outputted by this script. This fix replaces quoted section names with a wildcard, which matches the section correctly.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/49155

Context: I'm trying to relocate the kernel heap to another SRAM, using `CONFIG_CODE_DATA_RELOCATION`. In `CMakeLists.txt` I have the following:

```
zephyr_code_relocate(FILES ${ZEPHYR_BASE}/kernel/mempool.c LOCATION SRAM2_BSS_NOINIT)
```

The generated linker scripts seems to have the right section in SRAM2. Note that the section name is quoted:
```
 .sram2_noinit_reloc (NOLOAD) :
        {
                . = ALIGN(4);
                KEEP(*mempool.c.obj(.noinit."WEST_TOPDIR/zephyr/kernel/mempool.c".kheap_buf__system_heap))
                . = ALIGN(4);
 } > SRAM2 AT > SRAM2
```

In the final elf, the section is empty because ld fails to match it:

```
  .sram2_noinit_reloc
                  0x0000000030020000        0x0
                  0x0000000030020000                . = ALIGN (0x4)
   *mempool.c.obj(SORT_BY_ALIGNMENT(.noinit.) SORT_BY_ALIGNMENT(WEST_TOPDIR/zephyr/kernel/mempool.c)
```

With this patch:
```
.sram2_noinit_reloc
                0x0000000030020000    0x20000
                0x0000000030020000                . = ALIGN (0x4)
 *mempool.c.obj(SORT_BY_ALIGNMENT(.noinit.*.kheap_buf__system_heap))
 .noinit."WEST_TOPDIR/zephyr/kernel/mempool.c".kheap_buf__system_heap
```