### PR TITLE
drivers: remove on-stack copying of dma cfg on stm32 drivers

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -2242,7 +2242,7 @@ static int flash_stm32_ospi_init(const struct device *dev)
 	 * the minimum information to inform the DMA slot will be in used and
 	 * how to route callbacks.
 	 */
-	struct dma_config dma_cfg = dev_data->dma.cfg;
+	struct dma_config *dma_cfg = &dev_data->dma.cfg;
 	static DMA_HandleTypeDef hdma;
 
 	if (!device_is_ready(dev_data->dma.dev)) {
@@ -2251,22 +2251,22 @@ static int flash_stm32_ospi_init(const struct device *dev)
 	}
 
 	/* Proceed to the minimum Zephyr DMA driver init */
-	dma_cfg.user_data = &hdma;
+	dma_cfg->user_data = &hdma;
 	/* HACK: This field is used to inform driver that it is overridden */
-	dma_cfg.linked_channel = STM32_DMA_HAL_OVERRIDE;
-	ret = dma_config(dev_data->dma.dev, dev_data->dma.channel, &dma_cfg);
+	dma_cfg->linked_channel = STM32_DMA_HAL_OVERRIDE;
+	ret = dma_config(dev_data->dma.dev, dev_data->dma.channel, dma_cfg);
 	if (ret != 0) {
 		LOG_ERR("Failed to configure DMA channel %d", dev_data->dma.channel);
 		return ret;
 	}
 
 	/* Proceed to the HAL DMA driver init */
-	if (dma_cfg.source_data_size != dma_cfg.dest_data_size) {
+	if (dma_cfg->source_data_size != dma_cfg->dest_data_size) {
 		LOG_ERR("Source and destination data sizes not aligned");
 		return -EINVAL;
 	}
 
-	int index = find_lsb_set(dma_cfg.source_data_size) - 1;
+	int index = find_lsb_set(dma_cfg->source_data_size) - 1;
 
 #if CONFIG_DMA_STM32U5
 	/* Fill the structure for dma init */
@@ -2286,14 +2286,14 @@ static int flash_stm32_ospi_init(const struct device *dev)
 	hdma.Init.MemInc = DMA_MINC_ENABLE;
 #endif /* CONFIG_DMA_STM32U5 */
 	hdma.Init.Mode = DMA_NORMAL;
-	hdma.Init.Priority = table_priority[dma_cfg.channel_priority];
+	hdma.Init.Priority = table_priority[dma_cfg->channel_priority];
 	hdma.Init.Direction = DMA_PERIPH_TO_MEMORY;
 	hdma.Instance = STM32_DMA_GET_INSTANCE(dev_data->dma.reg, dev_data->dma.channel);
 #ifdef CONFIG_DMA_STM32_V1
 	/* TODO: Not tested in this configuration */
-	hdma.Init.Channel = dma_cfg.dma_slot;
+	hdma.Init.Channel = dma_cfg->dma_slot;
 #else
-	hdma.Init.Request = dma_cfg.dma_slot;
+	hdma.Init.Request = dma_cfg->dma_slot;
 #endif /* CONFIG_DMA_STM32_V1 */
 
 	/* Initialize DMA HAL */

--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -279,7 +279,7 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 {
 	struct i2s_stm32_sai_data *dev_data = dev->data;
 	struct stream *stream = &dev_data->stream;
-	struct dma_config dma_cfg = dev_data->stream.dma_cfg;
+	struct dma_config *dma_cfg = &dev_data->stream.dma_cfg;
 	int ret;
 
 	SAI_HandleTypeDef *hsai = &dev_data->hsai;
@@ -291,12 +291,12 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 	}
 
 	/* Proceed to the minimum Zephyr DMA driver init */
-	dma_cfg.user_data = hdma;
+	dma_cfg->user_data = hdma;
 
 	/* HACK: This field is used to inform driver that it is overridden */
-	dma_cfg.linked_channel = STM32_DMA_HAL_OVERRIDE;
+	dma_cfg->linked_channel = STM32_DMA_HAL_OVERRIDE;
 
-	ret = dma_config(stream->dma_dev, stream->dma_channel, &dma_cfg);
+	ret = dma_config(stream->dma_dev, stream->dma_channel, dma_cfg);
 	if (ret != 0) {
 		LOG_ERR("Failed to configure DMA channel %d", stream->dma_channel);
 		return ret;
@@ -305,16 +305,16 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 	hdma->Instance = STM32_DMA_GET_INSTANCE(stream->reg, stream->dma_channel);
 	hdma->Init.Mode = DMA_NORMAL;
 
-	if (dma_cfg.channel_priority >= ARRAY_SIZE(dma_priority)) {
+	if (dma_cfg->channel_priority >= ARRAY_SIZE(dma_priority)) {
 		LOG_ERR("Invalid DMA channel priority");
 		return -EINVAL;
 	}
-	hdma->Init.Priority = dma_priority[dma_cfg.channel_priority];
+	hdma->Init.Priority = dma_priority[dma_cfg->channel_priority];
 
 #if defined(DMA_CHANNEL_1)
-	hdma->Init.Channel = dma_cfg.dma_slot * DMA_CHANNEL_1;
+	hdma->Init.Channel = dma_cfg->dma_slot * DMA_CHANNEL_1;
 #else
-	hdma->Init.Request = dma_cfg.dma_slot;
+	hdma->Init.Request = dma_cfg->dma_slot;
 #endif
 
 #if defined(CONFIG_DMA_STM32U5)
@@ -336,7 +336,7 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 	hdma->Init.FIFOMode = DMA_FIFOMODE_DISABLE;
 #endif
 
-	if (stream->dma_cfg.channel_direction == (enum dma_channel_direction)MEMORY_TO_PERIPHERAL) {
+	if (dma_cfg->channel_direction == (enum dma_channel_direction)MEMORY_TO_PERIPHERAL) {
 		hdma->Init.Direction = DMA_MEMORY_TO_PERIPH;
 
 #if defined(CONFIG_DMA_STM32U5)

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -45,6 +45,7 @@ struct video_stm32_dcmi_data {
 	struct k_fifo fifo_in;
 	struct k_fifo fifo_out;
 	struct video_buffer *vbuf;
+	struct stream dma;
 };
 
 struct video_stm32_dcmi_config {
@@ -52,7 +53,6 @@ struct video_stm32_dcmi_config {
 	irq_config_func_t irq_config;
 	const struct pinctrl_dev_config *pctrl;
 	const struct device *sensor_dev;
-	const struct stream dma;
 };
 
 static void stm32_dcmi_process_dma_error(DCMI_HandleTypeDef *hdcmi)
@@ -130,12 +130,12 @@ static void dcmi_dma_callback(const struct device *dev, void *arg, uint32_t chan
 static int stm32_dma_init(const struct device *dev)
 {
 	struct video_stm32_dcmi_data *data = dev->data;
-	const struct video_stm32_dcmi_config *config = dev->config;
+	struct stream *dma = &data->dma;
 	int ret;
 
 	/* Check if the DMA device is ready */
-	if (!device_is_ready(config->dma.dma_dev)) {
-		LOG_ERR("%s DMA device not ready", config->dma.dma_dev->name);
+	if (!device_is_ready(dma->dma_dev)) {
+		LOG_ERR("%s DMA device not ready", dma->dma_dev->name);
 		return -ENODEV;
 	}
 
@@ -147,16 +147,16 @@ static int stm32_dma_init(const struct device *dev)
 	 * the minimum information to inform the DMA slot will be in used and
 	 * how to route callbacks.
 	 */
-	struct dma_config dma_cfg = config->dma.cfg;
+	struct dma_config *dma_cfg = &dma->cfg;
 	static DMA_HandleTypeDef hdma;
 
 	/* Proceed to the minimum Zephyr DMA driver init */
-	dma_cfg.user_data = &hdma;
+	dma_cfg->user_data = &hdma;
 	/* HACK: This field is used to inform driver that it is overridden */
-	dma_cfg.linked_channel = STM32_DMA_HAL_OVERRIDE;
-	ret = dma_config(config->dma.dma_dev, config->dma.channel, &dma_cfg);
+	dma_cfg->linked_channel = STM32_DMA_HAL_OVERRIDE;
+	ret = dma_config(dma->dma_dev, dma->channel, dma_cfg);
 	if (ret != 0) {
-		LOG_ERR("Failed to configure DMA channel %d", config->dma.channel);
+		LOG_ERR("Failed to configure DMA channel %d", dma->channel);
 		return ret;
 	}
 
@@ -170,8 +170,7 @@ static int stm32_dma_init(const struct device *dev)
 	hdma.Init.MemDataAlignment	= DMA_MDATAALIGN_WORD;
 	hdma.Init.Mode			= DMA_CIRCULAR;
 	hdma.Init.Priority		= DMA_PRIORITY_HIGH;
-	hdma.Instance			= STM32_DMA_GET_INSTANCE(config->dma.reg,
-								 config->dma.channel);
+	hdma.Instance			= STM32_DMA_GET_INSTANCE(dma->reg, dma->channel);
 #if defined(CONFIG_SOC_SERIES_STM32F7X) || defined(CONFIG_SOC_SERIES_STM32H7X)
 	hdma.Init.FIFOMode		= DMA_FIFOMODE_DISABLE;
 #endif
@@ -530,6 +529,7 @@ static struct video_stm32_dcmi_data video_stm32_dcmi_data_0 = {
 				.LineSelectStart = DCMI_OELS_ODD,
 		},
 	},
+	DCMI_DMA_CHANNEL(0, PERIPHERAL, MEMORY)
 };
 
 #define SOURCE_DEV(n) DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(n, 0, 0)))
@@ -539,7 +539,6 @@ static const struct video_stm32_dcmi_config video_stm32_dcmi_config_0 = {
 	.irq_config = video_stm32_dcmi_irq_config_func,
 	.pctrl = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 	.sensor_dev = SOURCE_DEV(0),
-	DCMI_DMA_CHANNEL(0, PERIPHERAL, MEMORY)
 };
 
 static int video_stm32_dcmi_init(const struct device *dev)


### PR DESCRIPTION
This change removes the on-stack copying and instead uses a pointer to the configuration to  avoid unnecessary stack usage