### PR TITLE
sys: util: Add COND_CASE_1 macro

### DIFF
--- a/include/zephyr/sys/util_internal.h
+++ b/include/zephyr/sys/util_internal.h
@@ -71,6 +71,66 @@
 /* Used to remove brackets from around a single argument. */
 #define __DEBRACKET(...) __VA_ARGS__
 
+/* Used by COND_CASE_1(); supports up to 16 flag/value pairs */
+#define Z_COND_CASE_1(...) \
+	Z_COND_CASE_1_SELECT(NUM_VA_ARGS_LESS_1(__VA_ARGS__), __VA_ARGS__)
+
+#define Z_COND_CASE_1_SELECT(count_minus_one, ...) \
+	UTIL_CAT(Z_COND_CASE_1_LEVEL_, count_minus_one)(__VA_ARGS__)
+
+#define Z_COND_CASE_1_LEVEL_0(_default) __DEBRACKET _default
+#define Z_COND_CASE_1_LEVEL_1(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_2(flag0, value0, _default) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (__DEBRACKET _default))
+#define Z_COND_CASE_1_LEVEL_3(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_4(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_2(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_5(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_6(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_4(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_7(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_8(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_6(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_9(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_10(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_8(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_11(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_12(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_10(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_13(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_14(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_12(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_15(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_16(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_14(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_17(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_18(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_16(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_19(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_20(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_18(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_21(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_22(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_20(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_23(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_24(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_22(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_25(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_26(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_24(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_27(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_28(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_26(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_29(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_30(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_28(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_31(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_LEVEL_32(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_30(__VA_ARGS__)))
+#define Z_COND_CASE_1_LEVEL_33(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
+
+#define Z_COND_CASE_1_REQUIRES_FLAG_VALUE_PAIRS Z_COND_CASE_1_REQUIRES_FLAG_VALUE_PAIRS
+
 /* Used by IS_EMPTY() */
 /* reference: https://gustedt.wordpress.com/2010/06/08/detect-empty-macro-arguments/ */
 #define Z_HAS_COMMA(...) \

--- a/include/zephyr/sys/util_internal.h
+++ b/include/zephyr/sys/util_internal.h
@@ -73,63 +73,44 @@
 
 /* Used by COND_CASE_1(); supports up to 16 flag/value pairs */
 #define Z_COND_CASE_1(...) \
-	Z_COND_CASE_1_SELECT(NUM_VA_ARGS_LESS_1(__VA_ARGS__), __VA_ARGS__)
+	Z_COND_CASE_1_CAT_N(NUM_VA_ARGS_LESS_1(__VA_ARGS__), __VA_ARGS__)
 
-#define Z_COND_CASE_1_SELECT(count_minus_one, ...) \
-	UTIL_CAT(Z_COND_CASE_1_LEVEL_, count_minus_one)(__VA_ARGS__)
+#define Z_COND_CASE_1_CAT_N(count_minus_one, ...) \
+	UTIL_CAT(Z_COND_CASE_1_N_, count_minus_one)(__VA_ARGS__)
 
-#define Z_COND_CASE_1_LEVEL_0(_default) __DEBRACKET _default
-#define Z_COND_CASE_1_LEVEL_1(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_2(flag0, value0, _default) \
+#define Z_COND_CASE_1_N_0(_default) __DEBRACKET _default
+#define Z_COND_CASE_1_N_2(flag0, value0, _default) \
 	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (__DEBRACKET _default))
-#define Z_COND_CASE_1_LEVEL_3(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_4(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_2(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_5(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_6(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_4(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_7(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_8(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_6(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_9(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_10(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_8(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_11(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_12(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_10(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_13(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_14(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_12(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_15(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_16(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_14(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_17(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_18(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_16(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_19(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_20(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_18(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_21(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_22(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_20(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_23(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_24(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_22(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_25(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_26(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_24(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_27(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_28(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_26(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_29(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_30(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_28(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_31(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-#define Z_COND_CASE_1_LEVEL_32(flag0, value0, ...) \
-	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_LEVEL_30(__VA_ARGS__)))
-#define Z_COND_CASE_1_LEVEL_33(...) Z_COND_SWITCH_REQUIRES_FLAG_VALUE_PAIRS
-
-#define Z_COND_CASE_1_REQUIRES_FLAG_VALUE_PAIRS Z_COND_CASE_1_REQUIRES_FLAG_VALUE_PAIRS
+#define Z_COND_CASE_1_N_4(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_2(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_6(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_4(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_8(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_6(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_10(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_8(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_12(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_10(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_14(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_12(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_16(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_14(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_18(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_16(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_20(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_18(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_22(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_20(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_24(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_22(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_26(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_24(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_28(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_26(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_30(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_28(__VA_ARGS__)))
+#define Z_COND_CASE_1_N_32(flag0, value0, ...) \
+	Z_COND_CODE_1(flag0, (__DEBRACKET value0), (Z_COND_CASE_1_N_30(__VA_ARGS__)))
 
 /* Used by IS_EMPTY() */
 /* reference: https://gustedt.wordpress.com/2010/06/08/detect-empty-macro-arguments/ */

--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -220,6 +220,31 @@ extern "C" {
 	Z_COND_CODE_0(_flag, _if_0_code, _else_code)
 
 /**
+ * @brief Evaluate a list of COND_CODE_1-style cases.
+ *
+ * Each case consists of a flag and a value wrapped in parentheses. The
+ * arguments are processed from left to right until a flag expands to the
+ * literal 1, in which case the corresponding value is expanded. If no flags
+ * expand to 1, the last argument (which must also be wrapped in parentheses)
+ * is used as the default value. Supplying only the default argument is also
+ * supported.
+ *
+ * Example:
+ *
+ *     int foo = COND_CASE_1(CONFIG_SOME_BOOL, (handle_a()),
+ *                           CONFIG_SOME_OTHER_BOOL, (handle_b()),
+ *                           (handle_default()));
+ *
+ * Supports up to 16 flag/value pairs before the default.
+ *
+ * @param ... Flag/value pairs followed by the default value. Each value must
+ *            be provided in parentheses to avoid comma handling issues.
+ * @see COND_CODE_1()
+ */
+#define COND_CASE_1(...) \
+	Z_COND_CASE_1(__VA_ARGS__)
+
+/**
  * @brief Insert code if @p _flag is defined and equals 1.
  *
  * Like COND_CODE_1(), this expands to @p _code if @p _flag is defined to 1;

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -165,6 +165,37 @@ ZTEST(util, test_COND_CODE_0) {
 	zassert_true((y3 == 1));
 }
 
+ZTEST(util, test_COND_CASE_1) {
+	/* Intentionally undefined symbols used to verify that only the selected
+	 * branch expands.
+	 */
+	int val;
+
+	#define CASE_TRUE 1
+	#define CASE_FALSE 0
+
+	val = COND_CASE_1(CASE_TRUE, (42),
+			  CASE_TRUE, (COND_CASE_1_SHOULD_NOT_REACH_SECOND_TRUE_CASE),
+			  (0));
+	zexpect_equal(val, 42);
+
+	val = COND_CASE_1(CASE_FALSE, (COND_CASE_1_SHOULD_NOT_USE_FIRST_CASE),
+			  CASE_TRUE, (7),
+			  (11));
+	zexpect_equal(val, 7);
+
+	val = COND_CASE_1(CASE_FALSE, (COND_CASE_1_SHOULD_NOT_USE_SECOND_CASE),
+			  CASE_FALSE, (COND_CASE_1_SHOULD_NOT_USE_THIRD_CASE),
+			  (5));
+	zexpect_equal(val, 5);
+
+	val = COND_CASE_1((9));
+	zexpect_equal(val, 9);
+
+	#undef CASE_TRUE
+	#undef CASE_FALSE
+}
+
 #undef ZERO
 #undef SEVEN
 #undef A_BUILD_ERROR


### PR DESCRIPTION
Add a switch/case like variant of the `COND_CODE_1` macro where the first flag that equals 1 has its value expanded, with a default fallback.