### PR TITLE
[Backport v3.7-branch] mbedtls: bump to version 3.6.5

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -41,6 +41,12 @@ The following CVEs are addressed by this release:
 * `CVE-2025-52497 <https://www.cve.org/CVERecord?id=CVE-2025-52497>`_
   `Heap buffer under-read when parsing PEM-encrypted material
   <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-06-2/>`_
+* `CVE-2025-59438 <https://www.cve.org/CVERecord?id=CVE-2025-59438>`_
+  `Padding oracle through timing of cipher error reporting
+  <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-10-invalid-padding-error/>`_
+* `CVE-2025-54764 <https://www.cve.org/CVERecord?id=CVE-2025-54764>`_
+  `Side channel in RSA key generation and operations (SSBleed, M-Step)
+  <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-10-ssbleed-mstep/>`_
 
 More detailed information can be found in:
 https://docs.zephyrproject.org/latest/security/vulnerabilities.html
@@ -143,7 +149,8 @@ These GitHub issues were addressed since the previous 3.7.1 tagged release:
 Mbed TLS
 ********
 
-Mbed TLS was updated to version 3.6.4 (from 3.6.2). The release notes can be found at:
+Mbed TLS was updated to version 3.6.5 (from 3.6.2). The release notes can be found at:
+https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.5
 https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.4
 https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.3
 

--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       revision: 2b498e6f36d6b82ae1da12c8b7742e318624ecf5
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 85440ef5fffa95d0e9971e9163719189cf34d979
+      revision: be1dd5b11d8f59af0ab0995985e348a429999013
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
This is the backport of https://github.com/zephyrproject-rtos/zephyr/pull/98786 to Zephyr LTS branch.

Fixes #100227