### PR TITLE
drivers: display: SDL: Add SDL_DISPLAY_ROUNDED_MASK option

### DIFF
--- a/drivers/display/Kconfig.sdl
+++ b/drivers/display/Kconfig.sdl
@@ -100,6 +100,19 @@ config SDL_DISPLAY_COLOR_TINT
 	  Can be used to simulate colored monochrome displays, like R8 (L8 + tint 0xff0000).
 	  Byte order: RGB_888
 
+config SDL_DISPLAY_ROUNDED_MASK
+	bool "Use rounded mask"
+	help
+	  If enabled, a rounded mask will be applied to the display output.
+	  This is useful to simulate rounded displays.
+
+config SDL_DISPLAY_ROUNDED_MASK_COLOR
+	hex "Rounded mask color"
+	default 0x000000
+	help
+	  The color of the rounded mask.
+	  Byte order: RGB_888
+
 config SDL_DISPLAY_THREAD_PRIORITY
 	int "SDL display thread priority"
 	default MAIN_THREAD_PRIORITY

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -83,19 +83,36 @@ static void exec_sdl_task(const struct device *dev, const struct sdl_display_tas
 	struct sdl_display_data *disp_data = dev->data;
 
 	switch (task->op) {
-	case SDL_WRITE:
-		sdl_display_write_bottom(task->write.desc->height, task->write.desc->width,
-					 task->write.x, task->write.y, disp_data->renderer,
-					 disp_data->mutex, disp_data->texture,
-					 disp_data->background_texture, disp_data->buf,
-					 disp_data->display_on, task->write.desc->frame_incomplete,
-					 CONFIG_SDL_DISPLAY_COLOR_TINT, disp_data->round_disp_mask);
+	case SDL_WRITE: {
+		struct sdl_display_write_params write_params = {
+			.height = task->write.desc->height,
+			.width = task->write.desc->width,
+			.x = task->write.x,
+			.y = task->write.y,
+			.renderer = disp_data->renderer,
+			.mutex = disp_data->mutex,
+			.texture = disp_data->texture,
+			.background_texture = disp_data->background_texture,
+			.buf = disp_data->buf,
+			.display_on = disp_data->display_on,
+			.frame_incomplete = task->write.desc->frame_incomplete,
+			.color_tint = CONFIG_SDL_DISPLAY_COLOR_TINT,
+			.round_disp_mask = disp_data->round_disp_mask,
+		};
+		sdl_display_write_bottom(&write_params);
 		break;
-	case SDL_BLANKING_OFF:
-		sdl_display_blanking_off_bottom(
-			disp_data->renderer, disp_data->texture, disp_data->background_texture,
-			CONFIG_SDL_DISPLAY_COLOR_TINT, disp_data->round_disp_mask);
+	}
+	case SDL_BLANKING_OFF: {
+		struct sdl_display_blanking_off_params blanking_off_params = {
+			.renderer = disp_data->renderer,
+			.texture = disp_data->texture,
+			.background_texture = disp_data->background_texture,
+			.color_tint = CONFIG_SDL_DISPLAY_COLOR_TINT,
+			.round_disp_mask = disp_data->round_disp_mask,
+		};
+		sdl_display_blanking_off_bottom(&blanking_off_params);
 		break;
+	}
 	case SDL_BLANKING_ON:
 		sdl_display_blanking_on_bottom(disp_data->renderer);
 		break;
@@ -118,15 +135,28 @@ static void sdl_task_thread(void *p1, void *p2, void *p3)
 		sdl_display_zoom_pct = CONFIG_SDL_DISPLAY_ZOOM_PCT;
 	}
 
-	int rc = sdl_display_init_bottom(
-		config->height, config->width, sdl_display_zoom_pct, use_accelerator,
-		&disp_data->window, dev, config->title, &disp_data->renderer, &disp_data->mutex,
-		&disp_data->texture, &disp_data->read_texture, &disp_data->background_texture,
-		CONFIG_SDL_DISPLAY_TRANSPARENCY_GRID_CELL_COLOR_1,
-		CONFIG_SDL_DISPLAY_TRANSPARENCY_GRID_CELL_COLOR_2,
-		CONFIG_SDL_DISPLAY_TRANSPARENCY_GRID_CELL_SIZE,
-		COND_CODE_1(CONFIG_SDL_DISPLAY_ROUNDED_MASK, (&disp_data->round_disp_mask), (NULL)),
-							     CONFIG_SDL_DISPLAY_ROUNDED_MASK_COLOR);
+	struct sdl_display_init_params init_params = {
+		.height = config->height,
+		.width = config->width,
+		.zoom_pct = sdl_display_zoom_pct,
+		.use_accelerator = use_accelerator,
+		.window = &disp_data->window,
+		.window_user_data = dev,
+		.title = config->title,
+		.renderer = &disp_data->renderer,
+		.mutex = &disp_data->mutex,
+		.texture = &disp_data->texture,
+		.read_texture = &disp_data->read_texture,
+		.background_texture = &disp_data->background_texture,
+		.transparency_grid_color1 = CONFIG_SDL_DISPLAY_TRANSPARENCY_GRID_CELL_COLOR_1,
+		.transparency_grid_color2 = CONFIG_SDL_DISPLAY_TRANSPARENCY_GRID_CELL_COLOR_2,
+		.transparency_grid_cell_size = CONFIG_SDL_DISPLAY_TRANSPARENCY_GRID_CELL_SIZE,
+		.round_disp_mask = COND_CODE_1(CONFIG_SDL_DISPLAY_ROUNDED_MASK,
+						(&disp_data->round_disp_mask), NULL),
+		.mask_color = CONFIG_SDL_DISPLAY_ROUNDED_MASK_COLOR,
+		};
+
+	int rc = sdl_display_init_bottom(&init_params);
 
 	k_sem_give(&disp_data->task_sem);
 
@@ -612,9 +642,20 @@ static int sdl_display_read(const struct device *dev, const uint16_t x, const ui
 	k_mutex_lock(&disp_data->task_mutex, K_FOREVER);
 	memset(disp_data->read_buf, 0, desc->pitch * desc->height * 4);
 
-	err = sdl_display_read_bottom(desc->height, desc->width, x, y, disp_data->renderer,
-				      disp_data->read_buf, desc->pitch, disp_data->mutex,
-				      disp_data->texture, disp_data->read_texture);
+	struct sdl_display_read_params read_params = {
+		.height = desc->height,
+		.width = desc->width,
+		.x = x,
+		.y = y,
+		.renderer = disp_data->renderer,
+		.buf = disp_data->read_buf,
+		.pitch = desc->pitch,
+		.mutex = disp_data->mutex,
+		.texture = disp_data->texture,
+		.read_texture = disp_data->read_texture,
+	};
+
+	err = sdl_display_read_bottom(&read_params);
 
 	if (err) {
 		k_mutex_unlock(&disp_data->task_mutex);
@@ -780,9 +821,16 @@ static int sdl_display_set_pixel_format(const struct device *dev,
 
 static void sdl_display_cleanup(struct sdl_display_data *disp_data)
 {
-	sdl_display_cleanup_bottom(&disp_data->window, &disp_data->renderer, &disp_data->mutex,
-				   &disp_data->texture, &disp_data->read_texture,
-				   &disp_data->background_texture, &disp_data->round_disp_mask);
+	struct sdl_display_cleanup_params cleanup_params = {
+		.window = &disp_data->window,
+		.renderer = &disp_data->renderer,
+		.mutex = &disp_data->mutex,
+		.texture = &disp_data->texture,
+		.read_texture = &disp_data->read_texture,
+		.background_texture = &disp_data->background_texture,
+		.round_disp_mask = &disp_data->round_disp_mask,
+	};
+	sdl_display_cleanup_bottom(&cleanup_params);
 }
 
 static DEVICE_API(display, sdl_display_api) = {

--- a/drivers/display/display_sdl_bottom.c
+++ b/drivers/display/display_sdl_bottom.c
@@ -66,63 +66,63 @@ static int sdl_create_rounded_display_mask(uint16_t width, uint16_t height, uint
 	return 0;
 }
 
-int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
-			    bool use_accelerator, void **window, const void *window_user_data,
-			    const char *title, void **renderer, void **mutex, void **texture,
-			    void **read_texture, void **background_texture,
-			    uint32_t transparency_grid_color1, uint32_t transparency_grid_color2,
-			    uint16_t transparency_grid_cell_size, void **round_disp_mask,
-			    uint32_t mask_color)
+int sdl_display_init_bottom(struct sdl_display_init_params *params)
 {
 	/* clang-format off */
-	*window = SDL_CreateWindow(title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-				   width * zoom_pct / 100,
-				   height * zoom_pct / 100, SDL_WINDOW_SHOWN);
+	*params->window = SDL_CreateWindow(params->title, SDL_WINDOWPOS_UNDEFINED,
+				   SDL_WINDOWPOS_UNDEFINED,
+				   params->width * params->zoom_pct / 100,
+				   params->height * params->zoom_pct / 100, SDL_WINDOW_SHOWN);
 	/* clang-format on */
-	if (*window == NULL) {
-		nsi_print_warning("Failed to create SDL window %s: %s", title, SDL_GetError());
+	if (*params->window == NULL) {
+		nsi_print_warning("Failed to create SDL window %s: %s", params->title,
+				  SDL_GetError());
 		return -1;
 	}
-	SDL_SetWindowData(*window, "zephyr_display", (void *)window_user_data);
+	SDL_SetWindowData(*params->window, "zephyr_display", (void *)params->window_user_data);
 
-	if (use_accelerator) {
-		*renderer = SDL_CreateRenderer(*window, -1, SDL_RENDERER_ACCELERATED);
+	if (params->use_accelerator) {
+		*params->renderer =
+			SDL_CreateRenderer(*params->window, -1, SDL_RENDERER_ACCELERATED);
 	} else {
-		*renderer = SDL_CreateRenderer(*window, -1, SDL_RENDERER_SOFTWARE);
+		*params->renderer = SDL_CreateRenderer(*params->window, -1, SDL_RENDERER_SOFTWARE);
 	}
 
-	if (*renderer == NULL) {
+	if (*params->renderer == NULL) {
 		nsi_print_warning("Failed to create SDL renderer: %s",
 				SDL_GetError());
 		return -1;
 	}
 
-	*mutex = SDL_CreateMutex();
-	if (*mutex == NULL) {
+	*params->mutex = SDL_CreateMutex();
+	if (*params->mutex == NULL) {
 		nsi_print_warning("Failed to create SDL mutex: %s", SDL_GetError());
 		return -1;
 	}
 
-	SDL_RenderSetLogicalSize(*renderer, width, height);
+	SDL_RenderSetLogicalSize(*params->renderer, params->width, params->height);
 
-	*texture = SDL_CreateTexture(*renderer, SDL_PIXELFORMAT_ARGB8888,
-				     SDL_TEXTUREACCESS_STATIC, width, height);
-	if (*texture == NULL) {
+	*params->texture =
+		SDL_CreateTexture(*params->renderer, SDL_PIXELFORMAT_ARGB8888,
+				  SDL_TEXTUREACCESS_STATIC, params->width, params->height);
+	if (*params->texture == NULL) {
 		nsi_print_warning("Failed to create SDL texture: %s", SDL_GetError());
 		return -1;
 	}
-	SDL_SetTextureBlendMode(*texture, SDL_BLENDMODE_BLEND);
+	SDL_SetTextureBlendMode(*params->texture, SDL_BLENDMODE_BLEND);
 
-	*read_texture = SDL_CreateTexture(*renderer, SDL_PIXELFORMAT_ARGB8888,
-					  SDL_TEXTUREACCESS_TARGET, width, height);
-	if (*read_texture == NULL) {
+	*params->read_texture =
+		SDL_CreateTexture(*params->renderer, SDL_PIXELFORMAT_ARGB8888,
+				  SDL_TEXTUREACCESS_TARGET, params->width, params->height);
+	if (*params->read_texture == NULL) {
 		nsi_print_warning("Failed to create SDL texture for read: %s", SDL_GetError());
 		return -1;
 	}
 
-	*background_texture = SDL_CreateTexture(*renderer, SDL_PIXELFORMAT_ARGB8888,
-						SDL_TEXTUREACCESS_STREAMING, width, height);
-	if (*background_texture == NULL) {
+	*params->background_texture =
+		SDL_CreateTexture(*params->renderer, SDL_PIXELFORMAT_ARGB8888,
+				  SDL_TEXTUREACCESS_STREAMING, params->width, params->height);
+	if (*params->background_texture == NULL) {
 		nsi_print_warning("Failed to create SDL texture: %s", SDL_GetError());
 		return -1;
 	}
@@ -131,142 +131,137 @@ int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
 	int background_pitch;
 	int err;
 
-	err = SDL_LockTexture(*background_texture, NULL, &background_data, &background_pitch);
+	err = SDL_LockTexture(*params->background_texture, NULL, &background_data,
+			      &background_pitch);
 	if (err != 0) {
 		nsi_print_warning("Failed to lock background texture: %d", err);
 		return -1;
 	}
-	for (int y = 0; y < height; y++) {
+	for (int y = 0; y < params->height; y++) {
 		uint32_t *row = (uint32_t *)((uint8_t *)background_data + background_pitch * y);
 
-		for (int x = 0; x < width; x++) {
-			bool x_cell_even = ((x / transparency_grid_cell_size) % 2) == 0;
-			bool y_cell_even = ((y / transparency_grid_cell_size) % 2) == 0;
+		for (int x = 0; x < params->width; x++) {
+			bool x_cell_even = ((x / params->transparency_grid_cell_size) % 2) == 0;
+			bool y_cell_even = ((y / params->transparency_grid_cell_size) % 2) == 0;
 
 			if (x_cell_even == y_cell_even) {
-				row[x] = transparency_grid_color1 | 0xff000000;
+				row[x] = params->transparency_grid_color1 | 0xff000000;
 			} else {
-				row[x] = transparency_grid_color2 | 0xff000000;
+				row[x] = params->transparency_grid_color2 | 0xff000000;
 			}
 		}
 	}
-	SDL_UnlockTexture(*background_texture);
+	SDL_UnlockTexture(*params->background_texture);
 
 	/* Create ellipse mask texture if rounded mask is enabled */
-	if (round_disp_mask != NULL) {
-		err = sdl_create_rounded_display_mask(width, height, mask_color, round_disp_mask,
-						      *renderer);
+	if (params->round_disp_mask != NULL) {
+		err = sdl_create_rounded_display_mask(params->width, params->height,
+						      params->mask_color, params->round_disp_mask,
+						      *params->renderer);
 		if (err != 0) {
 			nsi_print_warning("Failed to create rounded display mask");
 			return -1;
 		}
 	}
 
-	SDL_SetRenderDrawColor(*renderer, 0, 0, 0, 0xFF);
-	SDL_RenderClear(*renderer);
-	SDL_RenderCopy(*renderer, *background_texture, NULL, NULL);
-	SDL_RenderPresent(*renderer);
+	SDL_SetRenderDrawColor(*params->renderer, 0, 0, 0, 0xFF);
+	SDL_RenderClear(*params->renderer);
+	SDL_RenderCopy(*params->renderer, *params->background_texture, NULL, NULL);
+	SDL_RenderPresent(*params->renderer);
 
 	return 0;
 }
 
-void sdl_display_write_bottom(const uint16_t height, const uint16_t width, const uint16_t x,
-			      const uint16_t y, void *renderer, void *mutex, void *texture,
-			      void *background_texture, uint8_t *buf, bool display_on,
-			      bool frame_incomplete, uint32_t color_tint, void *round_disp_mask)
+void sdl_display_write_bottom(const struct sdl_display_write_params *params)
 {
 	SDL_Rect rect;
 	int err;
 
-	rect.x = x;
-	rect.y = y;
-	rect.w = width;
-	rect.h = height;
+	rect.x = params->x;
+	rect.y = params->y;
+	rect.w = params->width;
+	rect.h = params->height;
 
-	err = SDL_TryLockMutex(mutex);
+	err = SDL_TryLockMutex(params->mutex);
 	if (err) {
 		nsi_print_warning("Failed to lock SDL mutex: %s", SDL_GetError());
 		return;
 	}
 
-	SDL_UpdateTexture(texture, &rect, buf, 4 * rect.w);
+	SDL_UpdateTexture(params->texture, &rect, params->buf, 4 * rect.w);
 
-	if (display_on && !frame_incomplete) {
-		SDL_RenderClear(renderer);
-		SDL_RenderCopy(renderer, background_texture, NULL, NULL);
-		SDL_SetTextureColorMod(texture,
-				       (color_tint >> 16) & 0xff,
-				       (color_tint >> 8) & 0xff,
-				       color_tint & 0xff);
-		SDL_RenderCopy(renderer, texture, NULL, NULL);
-		SDL_SetTextureColorMod(texture, 255, 255, 255);
+	if (params->display_on && !params->frame_incomplete) {
+		SDL_RenderClear(params->renderer);
+		SDL_RenderCopy(params->renderer, params->background_texture, NULL, NULL);
+		SDL_SetTextureColorMod(params->texture,
+				       (params->color_tint >> 16) & 0xff,
+				       (params->color_tint >> 8) & 0xff,
+				       params->color_tint & 0xff);
+		SDL_RenderCopy(params->renderer, params->texture, NULL, NULL);
+		SDL_SetTextureColorMod(params->texture, 255, 255, 255);
 
-		if (round_disp_mask != NULL) {
-			SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_MOD);
-			SDL_RenderCopy(renderer, round_disp_mask, NULL, NULL);
-			SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+		/* Apply ellipse mask if enabled */
+		if (params->round_disp_mask != NULL) {
+			SDL_SetRenderDrawBlendMode(params->renderer, SDL_BLENDMODE_MOD);
+			SDL_RenderCopy(params->renderer, params->round_disp_mask, NULL, NULL);
+			SDL_SetRenderDrawBlendMode(params->renderer, SDL_BLENDMODE_BLEND);
 		}
 
-		SDL_RenderPresent(renderer);
+		SDL_RenderPresent(params->renderer);
 	}
 
-	SDL_UnlockMutex(mutex);
+	SDL_UnlockMutex(params->mutex);
 }
 
-int sdl_display_read_bottom(const uint16_t height, const uint16_t width,
-			    const uint16_t x, const uint16_t y,
-			    void *renderer, void *buf, uint16_t pitch,
-			    void *mutex, void *texture, void *read_texture)
+int sdl_display_read_bottom(const struct sdl_display_read_params *params)
 {
 	SDL_Rect rect;
 	int err;
 
-	rect.x = x;
-	rect.y = y;
-	rect.w = width;
-	rect.h = height;
+	rect.x = params->x;
+	rect.y = params->y;
+	rect.w = params->width;
+	rect.h = params->height;
 
-	err = SDL_TryLockMutex(mutex);
+	err = SDL_TryLockMutex(params->mutex);
 	if (err) {
 		nsi_print_warning("Failed to lock SDL mutex: %s", SDL_GetError());
 		return -1;
 	}
 
-	SDL_SetRenderTarget(renderer, read_texture);
-	SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_NONE);
+	SDL_SetRenderTarget(params->renderer, params->read_texture);
+	SDL_SetTextureBlendMode(params->texture, SDL_BLENDMODE_NONE);
 
-	SDL_RenderClear(renderer);
-	SDL_RenderCopy(renderer, texture, NULL, NULL);
-	SDL_RenderReadPixels(renderer, &rect, SDL_PIXELFORMAT_ARGB8888, buf, width * 4);
+	SDL_RenderClear(params->renderer);
+	SDL_RenderCopy(params->renderer, params->texture, NULL, NULL);
+	SDL_RenderReadPixels(params->renderer, &rect, SDL_PIXELFORMAT_ARGB8888, params->buf,
+			     params->width * 4);
 
-	SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
-	SDL_SetRenderTarget(renderer, NULL);
+	SDL_SetTextureBlendMode(params->texture, SDL_BLENDMODE_BLEND);
+	SDL_SetRenderTarget(params->renderer, NULL);
 
-	SDL_UnlockMutex(mutex);
+	SDL_UnlockMutex(params->mutex);
 
 	return err;
 }
 
-void sdl_display_blanking_off_bottom(void *renderer, void *texture, void *background_texture,
-				     uint32_t color_tint, void *round_disp_mask)
+void sdl_display_blanking_off_bottom(const struct sdl_display_blanking_off_params *params)
 {
-	SDL_RenderClear(renderer);
-	SDL_RenderCopy(renderer, background_texture, NULL, NULL);
-	SDL_SetTextureColorMod(texture,
-			       (color_tint >> 16) & 0xff,
-			       (color_tint >> 8) & 0xff,
-			       color_tint & 0xff);
-	SDL_RenderCopy(renderer, texture, NULL, NULL);
-	SDL_SetTextureColorMod(texture, 255, 255, 255);
+	SDL_RenderClear(params->renderer);
+	SDL_RenderCopy(params->renderer, params->background_texture, NULL, NULL);
+	SDL_SetTextureColorMod(params->texture, (params->color_tint >> 16) & 0xff,
+			       (params->color_tint >> 8) & 0xff, params->color_tint & 0xff);
+	SDL_RenderCopy(params->renderer, params->texture, NULL, NULL);
+	SDL_SetTextureColorMod(params->texture, 255, 255, 255);
 
 	/* Apply ellipse mask if enabled */
-	if (round_disp_mask != NULL) {
-		SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_MOD);
-		SDL_RenderCopy(renderer, round_disp_mask, NULL, NULL);
-		SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+	if (params->round_disp_mask != NULL) {
+		SDL_SetRenderDrawBlendMode(params->renderer, SDL_BLENDMODE_MOD);
+		SDL_RenderCopy(params->renderer, params->round_disp_mask, NULL, NULL);
+		SDL_SetRenderDrawBlendMode(params->renderer, SDL_BLENDMODE_BLEND);
 	}
 
-	SDL_RenderPresent(renderer);
+	SDL_RenderPresent(params->renderer);
 }
 
 void sdl_display_blanking_on_bottom(void *renderer)
@@ -275,42 +270,40 @@ void sdl_display_blanking_on_bottom(void *renderer)
 	SDL_RenderPresent(renderer);
 }
 
-void sdl_display_cleanup_bottom(void **window, void **renderer, void **mutex, void **texture,
-				void **read_texture, void **background_texture,
-				void **round_disp_mask)
+void sdl_display_cleanup_bottom(const struct sdl_display_cleanup_params *params)
 {
-	if (*round_disp_mask != NULL) {
-		SDL_DestroyTexture(*round_disp_mask);
-		*round_disp_mask = NULL;
+	if (*params->round_disp_mask != NULL) {
+		SDL_DestroyTexture(*params->round_disp_mask);
+		*params->round_disp_mask = NULL;
 	}
 
-	if (*background_texture != NULL) {
-		SDL_DestroyTexture(*background_texture);
-		*background_texture = NULL;
+	if (*params->background_texture != NULL) {
+		SDL_DestroyTexture(*params->background_texture);
+		*params->background_texture = NULL;
 	}
 
-	if (*read_texture != NULL) {
-		SDL_DestroyTexture(*read_texture);
-		*read_texture = NULL;
+	if (*params->read_texture != NULL) {
+		SDL_DestroyTexture(*params->read_texture);
+		*params->read_texture = NULL;
 	}
 
-	if (*texture != NULL) {
-		SDL_DestroyTexture(*texture);
-		*texture = NULL;
+	if (*params->texture != NULL) {
+		SDL_DestroyTexture(*params->texture);
+		*params->texture = NULL;
 	}
 
-	if (*mutex != NULL) {
-		SDL_DestroyMutex(*mutex);
-		*mutex = NULL;
+	if (*params->mutex != NULL) {
+		SDL_DestroyMutex(*params->mutex);
+		*params->mutex = NULL;
 	}
 
-	if (*renderer != NULL) {
-		SDL_DestroyRenderer(*renderer);
-		*renderer = NULL;
+	if (*params->renderer != NULL) {
+		SDL_DestroyRenderer(*params->renderer);
+		*params->renderer = NULL;
 	}
 
-	if (*window != NULL) {
-		SDL_DestroyWindow(*window);
-		*window = NULL;
+	if (*params->window != NULL) {
+		SDL_DestroyWindow(*params->window);
+		*params->window = NULL;
 	}
 }

--- a/drivers/display/display_sdl_bottom.h
+++ b/drivers/display/display_sdl_bottom.h
@@ -20,26 +20,79 @@ extern "C" {
 
 /* Note: None of these functions are public interfaces. But internal to the SDL display driver */
 
-int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
-			    bool use_accelerator, void **window, const void *window_user_data,
-			    const char *title, void **renderer, void **mutex, void **texture,
-			    void **read_texture, void **background_texture,
-			    uint32_t transparency_grid_color1, uint32_t transparency_grid_color2,
-			    uint16_t transparency_grid_cell_size, void **round_disp_mask,
-			    uint32_t mask_color);
-void sdl_display_write_bottom(const uint16_t height, const uint16_t width, const uint16_t x,
-			      const uint16_t y, void *renderer, void *mutex, void *texture,
-			      void *background_texture, uint8_t *buf, bool display_on,
-			      bool frame_incomplete, uint32_t color_tint, void *round_disp_mask);
-int sdl_display_read_bottom(const uint16_t height, const uint16_t width, const uint16_t x,
-			    const uint16_t y, void *renderer, void *buf, uint16_t pitch,
-			    void *mutex, void *texture, void *read_texture);
-void sdl_display_blanking_off_bottom(void *renderer, void *texture, void *background_texture,
-				     uint32_t color_tint, void *round_disp_mask);
+struct sdl_display_init_params {
+	uint16_t height;
+	uint16_t width;
+	uint16_t zoom_pct;
+	bool use_accelerator;
+	void **window;
+	const void *window_user_data;
+	const char *title;
+	void **renderer;
+	void **mutex;
+	void **texture;
+	void **read_texture;
+	void **background_texture;
+	uint32_t transparency_grid_color1;
+	uint32_t transparency_grid_color2;
+	uint16_t transparency_grid_cell_size;
+	void **round_disp_mask;
+	uint32_t mask_color;
+};
+
+struct sdl_display_write_params {
+	uint16_t height;
+	uint16_t width;
+	uint16_t x;
+	uint16_t y;
+	void *renderer;
+	void *mutex;
+	void *texture;
+	void *background_texture;
+	uint8_t *buf;
+	bool display_on;
+	bool frame_incomplete;
+	uint32_t color_tint;
+	void *round_disp_mask;
+};
+
+struct sdl_display_read_params {
+	uint16_t height;
+	uint16_t width;
+	uint16_t x;
+	uint16_t y;
+	void *renderer;
+	void *buf;
+	uint16_t pitch;
+	void *mutex;
+	void *texture;
+	void *read_texture;
+};
+
+struct sdl_display_blanking_off_params {
+	void *renderer;
+	void *texture;
+	void *background_texture;
+	uint32_t color_tint;
+	void *round_disp_mask;
+};
+
+struct sdl_display_cleanup_params {
+	void **window;
+	void **renderer;
+	void **mutex;
+	void **texture;
+	void **read_texture;
+	void **background_texture;
+	void **round_disp_mask;
+};
+
+int sdl_display_init_bottom(struct sdl_display_init_params *params);
+void sdl_display_write_bottom(const struct sdl_display_write_params *params);
+int sdl_display_read_bottom(const struct sdl_display_read_params *params);
+void sdl_display_blanking_off_bottom(const struct sdl_display_blanking_off_params *params);
 void sdl_display_blanking_on_bottom(void *renderer);
-void sdl_display_cleanup_bottom(void **window, void **renderer, void **mutex, void **texture,
-				void **read_texture, void **background_texture,
-				void **round_disp_mask);
+void sdl_display_cleanup_bottom(const struct sdl_display_cleanup_params *params);
 
 #ifdef __cplusplus
 }

--- a/drivers/display/display_sdl_bottom.h
+++ b/drivers/display/display_sdl_bottom.h
@@ -25,19 +25,21 @@ int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
 			    const char *title, void **renderer, void **mutex, void **texture,
 			    void **read_texture, void **background_texture,
 			    uint32_t transparency_grid_color1, uint32_t transparency_grid_color2,
-			    uint16_t transparency_grid_cell_size);
+			    uint16_t transparency_grid_cell_size, void **round_disp_mask,
+			    uint32_t mask_color);
 void sdl_display_write_bottom(const uint16_t height, const uint16_t width, const uint16_t x,
 			      const uint16_t y, void *renderer, void *mutex, void *texture,
 			      void *background_texture, uint8_t *buf, bool display_on,
-			      bool frame_incomplete, uint32_t color_tint);
+			      bool frame_incomplete, uint32_t color_tint, void *round_disp_mask);
 int sdl_display_read_bottom(const uint16_t height, const uint16_t width, const uint16_t x,
 			    const uint16_t y, void *renderer, void *buf, uint16_t pitch,
 			    void *mutex, void *texture, void *read_texture);
 void sdl_display_blanking_off_bottom(void *renderer, void *texture, void *background_texture,
-				     uint32_t color_tint);
+				     uint32_t color_tint, void *round_disp_mask);
 void sdl_display_blanking_on_bottom(void *renderer);
 void sdl_display_cleanup_bottom(void **window, void **renderer, void **mutex, void **texture,
-				void **read_texture, void **background_texture);
+				void **read_texture, void **background_texture,
+				void **round_disp_mask);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
While designing some GUI for rounded displays, I encountered the convenience issue that I like to prototype my UIs in the native sim and only do a final check on actual hardware, since its much fast to iterate. Anyways for rounded displays its annoying to have to guess which part of the screen is not visible. It might not be completely pixel perfect but it allows for first good estimate:

<img width="256" height="275" alt="Screenshot 2025-11-28 192851" src="https://github.com/user-attachments/assets/70a521c1-246c-441c-bd55-4a185f11fa48" />

On real hardware:
![Unbenannt](https://github.com/user-attachments/assets/8e33699a-698d-49b0-9d94-46e99ea0f785)

Note: the second commit may be considered optional, but at the point where the function takes 18 parameters it felt sensibly to add this refactoring.