### PR TITLE
doc: use dnf5 for Fedora documentation tools

### DIFF
--- a/doc/contribute/documentation/generation.rst
+++ b/doc/contribute/documentation/generation.rst
@@ -107,11 +107,11 @@ as described below:
          sudo apt-get install --no-install-recommends doxygen graphviz librsvg2-bin \
          texlive-latex-base texlive-latex-extra latexmk texlive-fonts-recommended imagemagick
 
-      On Fedora Linux:
+      On Fedora Linux (Use "dnf" or "dnf5" depending on your Fedora version):
 
       .. code-block:: console
 
-         sudo dnf install doxygen graphviz texlive-latex latexmk \
+         sudo dnf5 install doxygen graphviz texlive-latex latexmk \
          texlive-collection-fontsrecommended librsvg2-tools ImageMagick
 
       On Clear Linux:


### PR DESCRIPTION
In newer Fedora versions the package manager CLI is dnf5 instead of dnf, so commands using dnf may fail. This change updates the Fedora documentation tools instructions to use dnf5 and mentions that some systems may still use dnf.