### PR TITLE
Formatting: Further refinement to dts-linter

### DIFF
--- a/boards/hardkernel/odroid_go/odroid_go_procpu.dts
+++ b/boards/hardkernel/odroid_go/odroid_go_procpu.dts
@@ -155,6 +155,7 @@
 			disk-name = "SD";
 			status = "okay";
 		};
+
 		spi-max-frequency = <20000000>;
 	};
 };

--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -173,6 +173,7 @@ arduino_spi: &spi0 {
 			disk-name = "SD";
 			status = "okay";
 		};
+
 		spi-max-frequency = <DT_FREQ_M(24)>;
 	};
 };

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.dts
@@ -96,6 +96,7 @@
 			pin-id = <5>;
 			prescaler = <1>;
 		};
+
 		status = "okay";
 	};
 };

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_0.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_0.dts
@@ -36,6 +36,7 @@
 			pin-id = <5>;
 			prescaler = <1>;
 		};
+
 		status = "okay";
 	};
 };

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_1.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_1.dts
@@ -36,6 +36,7 @@
 			pin-id = <5>;
 			prescaler = <1>;
 		};
+
 		status = "okay";
 	};
 };

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -379,6 +379,7 @@ zephyr_udc0: &usbhs {
 		disk-name = "SD2";
 		status = "okay";
 	};
+
 	pinctrl-0 = <&pinmux_usdhc>;
 	pinctrl-names = "default";
 	mmc-hs200-1_8v;

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -361,6 +361,7 @@ i2s1: &flexcomm3 {
 		disk-name = "SD";
 		status = "okay";
 	};
+
 	pinctrl-0 = <&pinmux_usdhc>;
 	pinctrl-names = "default";
 };

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -457,6 +457,7 @@ zephyr_udc0: &usb0 {
 		disk-name = "SD2";
 		status = "okay";
 	};
+
 	pinctrl-0 = <&pinmux_usdhc>;
 	pinctrl-names = "default";
 	mmc-hs200-1_8v;

--- a/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57.dts
+++ b/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57.dts
@@ -99,6 +99,7 @@
 		disk-name = "SD2";
 		status = "disabled";
 	};
+
 	bus-width = <8>;
 	mmc-hs200-1_8v;
 	mmc-hs400-1_8v;

--- a/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu_sense.dts
+++ b/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu_sense.dts
@@ -71,6 +71,7 @@
 			disk-name = "SD";
 			status = "okay";
 		};
+
 		spi-max-frequency = <20000000>;
 	};
 };

--- a/boards/shields/rk043fn02h_ct/rk043fn02h_ct.overlay
+++ b/boards/shields/rk043fn02h_ct/rk043fn02h_ct.overlay
@@ -42,6 +42,7 @@
 		vsync-active = <0>;
 		clock-frequency = <9210240>;
 	};
+
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 	data-bus-width = "16-bit";
 	backlight-gpios = <&nxp_parallel_lcd_connector 0 GPIO_ACTIVE_HIGH>;

--- a/boards/shields/rk043fn66hs_ctg/rk043fn66hs_ctg.overlay
+++ b/boards/shields/rk043fn66hs_ctg/rk043fn66hs_ctg.overlay
@@ -43,6 +43,7 @@
 		vsync-active = <0>;
 		clock-frequency = <9210240>;
 	};
+
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 	data-bus-width = "16-bit";
 	backlight-gpios = <&nxp_parallel_lcd_connector 0 GPIO_ACTIVE_HIGH>;

--- a/boards/shields/rk055hdmipi4m/rk055hdmipi4m.overlay
+++ b/boards/shields/rk055hdmipi4m/rk055hdmipi4m.overlay
@@ -55,6 +55,7 @@
 		 */
 		clock-frequency = <62346240>;
 	};
+
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 	data-bus-width = "24-bit";
 	backlight-gpios = <&nxp_mipi_connector 0 GPIO_ACTIVE_HIGH>;

--- a/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
+++ b/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
@@ -55,6 +55,7 @@
 		 */
 		clock-frequency = <62346240>;
 	};
+
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 	data-bus-width = "24-bit";
 	backlight-gpios = <&nxp_mipi_connector 0 GPIO_ACTIVE_HIGH>;

--- a/boards/shields/rtk7eka6m3b00001bu/rtk7eka6m3b00001bu.overlay
+++ b/boards/shields/rtk7eka6m3b00001bu/rtk7eka6m3b00001bu.overlay
@@ -47,5 +47,6 @@
 		hfront-porch = <4>;
 		vfront-porch = <35>;
 	};
+
 	backlight-gpios = <&lcd_expansion_rtk7eka6m3b00001bu 39 GPIO_ACTIVE_HIGH>;
 };

--- a/boards/shields/rtkmipilcdb00000be/rtkmipilcdb00000be.overlay
+++ b/boards/shields/rtkmipilcdb00000be/rtkmipilcdb00000be.overlay
@@ -58,5 +58,6 @@
 		hfront-porch = <72>;
 		vfront-porch = <17>;
 	};
+
 	backlight-gpios = <&renesas_mipi_connector 15 GPIO_ACTIVE_HIGH>;
 };

--- a/boards/shields/seeed_xiao_expansion_board/seeed_xiao_expansion_board.overlay
+++ b/boards/shields/seeed_xiao_expansion_board/seeed_xiao_expansion_board.overlay
@@ -65,6 +65,7 @@
 			disk-name = "SD";
 			status = "okay";
 		};
+
 		spi-max-frequency = <24000000>;
 	};
 };

--- a/boards/shields/seeed_xiao_round_display/seeed_xiao_round_display.overlay
+++ b/boards/shields/seeed_xiao_round_display/seeed_xiao_round_display.overlay
@@ -88,6 +88,7 @@
 			disk-name = "SD";
 			status = "okay";
 		};
+
 		spi-max-frequency = <DT_FREQ_M(24)>;
 	};
 };

--- a/boards/shields/sparkfun_carrier_asset_tracker/sparkfun_carrier_asset_tracker.overlay
+++ b/boards/shields/sparkfun_carrier_asset_tracker/sparkfun_carrier_asset_tracker.overlay
@@ -39,6 +39,7 @@
 			disk-name = "SD";
 			status = "okay";
 		};
+
 		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
 };

--- a/boards/witte/linum/linum.dts
+++ b/boards/witte/linum/linum.dts
@@ -404,6 +404,7 @@ zephyr_udc0: &usbotg_fs {
 		hfront-porch = <160>;
 		vfront-porch = <12>;
 	};
+
 	def-back-color-red = <0xFF>;
 	def-back-color-green = <0xFF>;
 	def-back-color-blue = <0xFF>;

--- a/dts/arm/adi/max32/max32666.dtsi
+++ b/dts/arm/adi/max32/max32666.dtsi
@@ -187,6 +187,7 @@
 				status = "disabled";
 				disk-name = "SD";
 			};
+
 			power-delay-ms = <1500>;
 			clocks = <&gcr ADI_MAX32_CLOCK_BUS1 10>;
 		};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -515,7 +515,8 @@
 			compatible = "nxp,flexcan";
 			reg = <0x40024000 0x1000>;
 			interrupts = <75 0>, <76 0>, <77 0>, <78 0>, <79 0>, <80 0>;
-			interrupt-names = "mb-0-15", "bus-off", "error", "tx-warning", "rx-warning", "wake-up";
+			interrupt-names = "mb-0-15", "bus-off", "error", "tx-warning", "rx-warning",
+					  "wake-up";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 4>;
 			clk-source = <1>;
 			status = "disabled";

--- a/dts/arm/silabs/efm32wg990f256.dtsi
+++ b/dts/arm/silabs/efm32wg990f256.dtsi
@@ -9,7 +9,8 @@
 
 / {
 	soc {
-		compatible = "silabs,efm32wg990f256", "silabs,efm32wg", "silabs,efm32", "simple-bus";
+		compatible = "silabs,efm32wg990f256", "silabs,efm32wg", "silabs,efm32",
+			     "simple-bus";
 	};
 };
 

--- a/dts/arm/silabs/xg1/efm32pg1b200f256gm48.dtsi
+++ b/dts/arm/silabs/xg1/efm32pg1b200f256gm48.dtsi
@@ -9,7 +9,8 @@
 
 / {
 	soc {
-		compatible = "silabs,efm32pg1b200f256gm48", "silabs,efm32pg1b", "silabs,efm32", "simple-bus";
+		compatible = "silabs,efm32pg1b200f256gm48", "silabs,efm32pg1b", "silabs,efm32",
+			     "simple-bus";
 	};
 };
 

--- a/dts/arm/silabs/xg1/efr32fg1p133f256gm48.dtsi
+++ b/dts/arm/silabs/xg1/efr32fg1p133f256gm48.dtsi
@@ -9,7 +9,8 @@
 
 / {
 	soc {
-		compatible = "silabs,efr32fg1p133f256gm48", "silabs,efr32fg1p", "silabs,efr32", "simple-bus";
+		compatible = "silabs,efr32fg1p133f256gm48", "silabs,efr32fg1p", "silabs,efr32",
+			     "simple-bus";
 	};
 };
 

--- a/dts/arm/silabs/xg12/efm32jg12b500f1024gl125.dtsi
+++ b/dts/arm/silabs/xg12/efm32jg12b500f1024gl125.dtsi
@@ -9,7 +9,8 @@
 
 / {
 	soc {
-		compatible = "silabs,efm32jg12b500f1024gl125", "silabs,efm32jg12b", "silabs,efm32", "simple-bus";
+		compatible = "silabs,efm32jg12b500f1024gl125", "silabs,efm32jg12b", "silabs,efm32",
+			     "simple-bus";
 	};
 };
 

--- a/dts/arm/silabs/xg12/efm32pg12b500f1024gl125.dtsi
+++ b/dts/arm/silabs/xg12/efm32pg12b500f1024gl125.dtsi
@@ -9,7 +9,8 @@
 
 / {
 	soc {
-		compatible = "silabs,efm32pg12b500f1024gl125", "silabs,efm32pg12b", "silabs,efm32", "simple-bus";
+		compatible = "silabs,efm32pg12b500f1024gl125", "silabs,efm32pg12b", "silabs,efm32",
+			     "simple-bus";
 	};
 };
 

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -82,7 +82,6 @@
 #ifdef USE_NON_SECURE_ADDRESS_MAP
 		/* intentionally empty because UICR is hardware fixed to Secure */
 #else
-
 		uicr: uicr@ffd000 {
 			compatible = "nordic,nrf-uicr";
 			reg = <0xffd000 0x1000>;
@@ -108,7 +107,6 @@
 			#size-cells = <1>;
 			ranges = <0x0 0x40000000 0x10000000>;
 #else
-
 		global_peripherals: peripheral@50000000 {
 			reg = <0x50000000 0x10000000>;
 			#address-cells = <1>;
@@ -674,7 +672,6 @@
 #ifdef USE_NON_SECURE_ADDRESS_MAP
 			/* intentionally empty because WDT30 is hardware fixed to Secure */
 #else
-
 			wdt30: watchdog@108000 {
 				compatible = "nordic,nrf-wdt";
 				reg = <0x108000 0x620>;

--- a/dts/vendor/nordic/nrf54lm20a.dtsi
+++ b/dts/vendor/nordic/nrf54lm20a.dtsi
@@ -99,7 +99,6 @@
 #ifdef USE_NON_SECURE_ADDRESS_MAP
 		/* intentionally empty because UICR is hardware fixed to Secure */
 #else
-
 		uicr: uicr@ffd000 {
 			compatible = "nordic,nrf-uicr";
 			reg = <0xffd000 0x1000>;
@@ -129,7 +128,6 @@
 			#size-cells = <1>;
 			ranges = <0x0 0x40000000 0x10000000>;
 #else
-
 		global_peripherals: peripheral@50000000 {
 			reg = <0x50000000 0x10000000>;
 			ranges = <0x0 0x50000000 0x10000000>;
@@ -765,7 +763,6 @@
 #ifdef USE_NON_SECURE_ADDRESS_MAP
 			/* intentionally empty because WDT30 is hardware fixed to Secure */
 #else
-
 			wdt30: watchdog@108000 {
 				compatible = "nordic,nrf-wdt";
 				reg = <0x108000 0x620>;

--- a/samples/drivers/adc/adc_dt/boards/da1469x_dk_pro.overlay
+++ b/samples/drivers/adc/adc_dt/boards/da1469x_dk_pro.overlay
@@ -75,6 +75,7 @@
 		zephyr,oversampling = <0>;
 		zephyr,input-positive = <SMARTBOND_GPADC_P1_19>;
 	};
+
 	pinctrl-0 = <&adc_default>;
 	pinctrl-names = "default";
 };
@@ -114,6 +115,7 @@
 		zephyr,oversampling = <7>;
 		zephyr,input-positive = <SMARTBOND_SDADC_VBAT>;
 	};
+
 	pinctrl-0 = <&sdadc_default>;
 	pinctrl-names = "default";
 };

--- a/samples/drivers/adc/adc_dt/boards/siwx917_rb4338a.overlay
+++ b/samples/drivers/adc/adc_dt/boards/siwx917_rb4338a.overlay
@@ -31,5 +31,6 @@
 		zephyr,resolution = <12>;
 		zephyr,input-positive = <10>;
 	};
+
 	status = "okay";
 };

--- a/samples/drivers/adc/adc_dt/boards/xmc45_relax_kit.overlay
+++ b/samples/drivers/adc/adc_dt/boards/xmc45_relax_kit.overlay
@@ -21,5 +21,6 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,resolution = <12>;
 	};
+
 	status = "okay";
 };

--- a/samples/subsys/display/lvgl/boards/wio_terminal.overlay
+++ b/samples/subsys/display/lvgl/boards/wio_terminal.overlay
@@ -17,7 +17,8 @@
 	lvgl_keypad_input {
 		compatible = "zephyr,lvgl-keypad-input";
 		input = <&joystick>;
-		input-codes = <INPUT_KEY_ENTER INPUT_KEY_DOWN INPUT_KEY_UP INPUT_KEY_LEFT INPUT_KEY_RIGHT>;
+		input-codes = <INPUT_KEY_ENTER INPUT_KEY_DOWN INPUT_KEY_UP INPUT_KEY_LEFT
+			       INPUT_KEY_RIGHT>;
 		lvgl-codes = <LV_KEY_ENTER LV_KEY_DOWN LV_KEY_UP LV_KEY_LEFT LV_KEY_RIGHT>;
 	};
 };

--- a/samples/subsys/fs/fs_sample/boards/hifive_unmatched.overlay
+++ b/samples/subsys/fs/fs_sample/boards/hifive_unmatched.overlay
@@ -17,6 +17,7 @@
 			disk-name = "SD";
 			status = "okay";
 		};
+
 		spi-max-frequency = <20000000>;
 	};
 };

--- a/samples/subsys/fs/fs_sample/boards/nrf52840_blip.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nrf52840_blip.overlay
@@ -18,6 +18,7 @@
 			disk-name = "SD";
 			status = "okay";
 		};
+
 		spi-max-frequency = <24000000>;
 	};
 };

--- a/samples/subsys/fs/fs_sample/boards/nucleo_f429zi.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nucleo_f429zi.overlay
@@ -15,6 +15,7 @@
 			disk-name = "SD";
 			status = "okay";
 		};
+
 		spi-max-frequency = <25000000>;
 		spi-clock-mode-cpol;
 		spi-clock-mode-cpha;

--- a/samples/subsys/fs/littlefs/boards/rcar_h3ulcb_r8a77951_a57.overlay
+++ b/samples/subsys/fs/littlefs/boards/rcar_h3ulcb_r8a77951_a57.overlay
@@ -4,5 +4,6 @@
 	disk {
 		status = "okay";
 	};
+
 	status = "okay";
 };

--- a/samples/subsys/fs/littlefs/boards/rcar_salvator_xs.overlay
+++ b/samples/subsys/fs/littlefs/boards/rcar_salvator_xs.overlay
@@ -4,5 +4,6 @@
 	disk {
 		status = "okay";
 	};
+
 	status = "okay";
 };

--- a/samples/subsys/modbus/rtu_client/boards/arduino_opta_stm32h747xx_m7.overlay
+++ b/samples/subsys/modbus/rtu_client/boards/arduino_opta_stm32h747xx_m7.overlay
@@ -8,5 +8,6 @@
 	modbus0 {
 		status = "okay";
 	};
+
 	status = "okay";
 };

--- a/samples/subsys/modbus/rtu_server/boards/arduino_opta_stm32h747xx_m7.overlay
+++ b/samples/subsys/modbus/rtu_server/boards/arduino_opta_stm32h747xx_m7.overlay
@@ -8,5 +8,6 @@
 	modbus0 {
 		status = "okay";
 	};
+
 	status = "okay";
 };

--- a/samples/subsys/sensing/simple/boards/native_sim.overlay
+++ b/samples/subsys/sensing/simple/boards/native_sim.overlay
@@ -29,7 +29,8 @@
 		base_accel_gyro: base-accel-gyro {
 			compatible = "zephyr,sensing-phy-3d-sensor";
 			status = "okay";
-			sensor-types = <SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D>;
+			sensor-types = <SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D
+					SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D>;
 			friendly-name = "Base Accel Gyro Sensor";
 			minimal-interval = <625>;
 			underlying-device = <&bmi160_i2c>;
@@ -38,7 +39,8 @@
 		lid_accel_gyro: lid-accel-gyro {
 			compatible = "zephyr,sensing-phy-3d-sensor";
 			status = "okay";
-			sensor-types = <SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D>;
+			sensor-types = <SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D
+					SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D>;
 			friendly-name = "Lid Accel Gyro Sensor";
 			minimal-interval = <625>;
 			underlying-device = <&bmi160_spi>;

--- a/samples/subsys/usb_c/source/boards/stm32g081b_eval.overlay
+++ b/samples/subsys/usb_c/source/boards/stm32g081b_eval.overlay
@@ -73,7 +73,8 @@
 			vbus = <&vbus1>;
 			power-role = "source";
 			typec-power-opmode = "3.0A";
-			source-pdos = <PDO_FIXED(5000, 100, 0) PDO_FIXED(9000, 100, 0) PDO_FIXED(15000, 100, 0)>;
+			source-pdos = <PDO_FIXED(5000, 100, 0) PDO_FIXED(9000, 100, 0)
+				       PDO_FIXED(15000, 100, 0)>;
 		};
 		/* usbc.rst usbc-port end */
 	};

--- a/scripts/ci/package-lock.json
+++ b/scripts/ci/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "dts-linter": "^0.3.6"
+        "dts-linter": "^0.3.7-hotfix2"
       }
     },
     "node_modules/devicetree-language-server": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/devicetree-language-server/-/devicetree-language-server-0.6.7.tgz",
-      "integrity": "sha512-ov/f8B8WcKAgOR4TVmr3cgH5KWsrmFnHZJL4Zha6x7b7gpux9eXWWAg/XsgE0Aifexu8ht0txy1us7/IiUs/dg==",
+      "version": "0.7.2-hotfix1",
+      "resolved": "https://registry.npmjs.org/devicetree-language-server/-/devicetree-language-server-0.7.2-hotfix1.tgz",
+      "integrity": "sha512-46UFopMrfO5sNEPZSqCmWfkwVRn370roIUt3W99KwLpF/4rEt2FOxFtp/uZ+T+h09HLx013L3h7jTKnMtTLU4g==",
       "license": "Apache-2.0",
       "bin": {
         "devicetree-language-server": "dist/server.js"
@@ -21,12 +21,12 @@
       }
     },
     "node_modules/dts-linter": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/dts-linter/-/dts-linter-0.3.6.tgz",
-      "integrity": "sha512-MG7r0hWOcmhue4k0oSd0+/mNC9nNnpdRKfW4EhQevOd1apHUhmTW4SsI6Um5zfVP1fNpy95IpBS0/dja9UYCXw==",
+      "version": "0.3.7-hotfix2",
+      "resolved": "https://registry.npmjs.org/dts-linter/-/dts-linter-0.3.7-hotfix2.tgz",
+      "integrity": "sha512-pFR/Zpwsh8djV9Gd9sO8mSvTwOpW3Y4DRKD+Y4Scka+KXVYQQB8Z1uGxNFMjMQVdg9plwYUSLLt9//QkN48ulw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "devicetree-language-server": "^0.6.7"
+        "devicetree-language-server": "0.7.2-hotfix1"
       },
       "bin": {
         "dts-linter": "dist/dts-linter.js"

--- a/scripts/ci/package.json
+++ b/scripts/ci/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "dts-linter": "^0.3.6"
+    "dts-linter": "^0.3.7-hotfix2"
   }
 }

--- a/tests/drivers/adc/adc_api/boards/siwx917_dk2605a.overlay
+++ b/tests/drivers/adc/adc_api/boards/siwx917_dk2605a.overlay
@@ -41,5 +41,6 @@
 		zephyr,resolution = <12>;
 		zephyr,input-positive = <7>;
 	};
+
 	status = "okay";
 };

--- a/tests/drivers/adc/adc_api/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/adc/adc_api/boards/siwx917_rb4338a.overlay
@@ -40,5 +40,6 @@
 		zephyr,resolution = <12>;
 		zephyr,input-positive = <7>;
 	};
+
 	status = "okay";
 };

--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -69,6 +69,7 @@
 				gpios = <&test_gpio 0 0>;
 				zephyr,code = <0>;
 			};
+
 			polling-mode;
 		};
 

--- a/tests/drivers/disk/disk_performance/boards/rcar_h3ulcb_r8a77951_a57.overlay
+++ b/tests/drivers/disk/disk_performance/boards/rcar_h3ulcb_r8a77951_a57.overlay
@@ -4,5 +4,6 @@
 	disk {
 		status = "okay";
 	};
+
 	status = "okay";
 };

--- a/tests/drivers/disk/disk_performance/boards/rcar_salvator_xs.overlay
+++ b/tests/drivers/disk/disk_performance/boards/rcar_salvator_xs.overlay
@@ -4,5 +4,6 @@
 	disk {
 		status = "okay";
 	};
+
 	status = "okay";
 };

--- a/tests/drivers/pwm/pwm_api/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/siwx917_rb4338a.overlay
@@ -27,6 +27,7 @@
 	pwm_channel1: pwm_channel1 {
 		pwms = <&pwm 0 1000000>;
 	};
+
 	silabs,pwm-polarity = <PWM_POLARITY_NORMAL>;
 	status = "okay";
 };

--- a/tests/drivers/pwm/pwm_api/boards/siwx917_rb4342a.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/siwx917_rb4342a.overlay
@@ -27,6 +27,7 @@
 	pwm_channel1: pwm_channel1 {
 		pwms = <&pwm 0 1000000>;
 	};
+
 	silabs,pwm-polarity = <PWM_POLARITY_NORMAL>;
 	status = "okay";
 };

--- a/tests/drivers/spi/spi_controller_peripheral/boards/frdm_mcxa156.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/frdm_mcxa156.overlay
@@ -18,6 +18,7 @@
 		reg = <0>;
 		spi-max-frequency = <10000000>;
 	};
+
 	transfer-delay = <100>;
 	sck-pcs-delay = <10>;
 	pcs-sck-delay = <10>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1010_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1010_evk.overlay
@@ -16,6 +16,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1015_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1015_evk.overlay
@@ -16,6 +16,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1020_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1020_evk.overlay
@@ -16,6 +16,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1024_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1024_evk.overlay
@@ -16,6 +16,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1040_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1040_evk.overlay
@@ -16,6 +16,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
@@ -16,6 +16,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -17,6 +17,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1064_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1064_evk.overlay
@@ -16,6 +16,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -16,6 +16,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
@@ -20,6 +20,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -16,6 +16,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -18,6 +18,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -30,6 +30,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	transfer-delay = <100>;
 	pcs-sck-delay = <100>;
 	sck-pcs-delay = <100>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -51,6 +51,7 @@
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
+
 	cs-gpios = <&gpio7 0 0>;
 };
 

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m2l31ki.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m2l31ki.overlay
@@ -28,6 +28,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m3334ki.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m3334ki.overlay
@@ -28,6 +28,7 @@
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(16)>;
 	};
+
 	status = "okay";
 	pinctrl-0 = <&spi2_default>;
 	pinctrl-names = "default";

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m55m1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m55m1.overlay
@@ -24,6 +24,7 @@
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(16)>;
 	};
+
 	status = "okay";
 	pinctrl-0 = <&spi2_default>;
 	pinctrl-names = "default";

--- a/tests/drivers/spi/spi_loopback/boards/numaker_pfm_m467.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_pfm_m467.overlay
@@ -28,6 +28,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
 	status = "okay";
 	pinctrl-0 = <&spi2_default>;
 	pinctrl-names = "default";

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -72,7 +72,8 @@
 			phs = <&test_i2c &test_spi>;
 			phs-or = <&test_enum_default_0 &test_enum_default_1>;
 			gpios = <&test_gpio_1 10 20>, <&test_gpio_2 30 40>;
-			pha-gpios = <&test_gpio_1 50 60>, <0>, <&test_gpio_3 70>, <&test_gpio_2 80 90>;
+			pha-gpios = <&test_gpio_1 50 60>, <0>, <&test_gpio_3 70>,
+				    <&test_gpio_2 80 90>;
 			foos = <&test_gpio_1 100>, <&test_gpio_2 110>;
 			foo-names = "A", "b-c";
 			pwms = <&test_pwm1 8 200 3>, <&test_pwm2 5 100 1>;

--- a/tests/subsys/fs/ext2/boards/hifive_unmatched_fu740_s7.overlay
+++ b/tests/subsys/fs/ext2/boards/hifive_unmatched_fu740_s7.overlay
@@ -17,6 +17,7 @@
 			disk-name = "SD";
 			status = "okay";
 		};
+
 		spi-max-frequency = <20000000>;
 	};
 };

--- a/tests/subsys/fs/ext2/boards/hifive_unmatched_fu740_u74.overlay
+++ b/tests/subsys/fs/ext2/boards/hifive_unmatched_fu740_u74.overlay
@@ -17,6 +17,7 @@
 			disk-name = "SD";
 			status = "okay";
 		};
+
 		spi-max-frequency = <20000000>;
 	};
 };

--- a/tests/subsys/modbus/boards/arduino_opta_stm32h747xx_m7.overlay
+++ b/tests/subsys/modbus/boards/arduino_opta_stm32h747xx_m7.overlay
@@ -8,5 +8,6 @@
 	modbus0 {
 		status = "okay";
 	};
+
 	status = "okay";
 };

--- a/tests/subsys/sd/mmc/boards/rcar_h3ulcb_r8a77951_a57.overlay
+++ b/tests/subsys/sd/mmc/boards/rcar_h3ulcb_r8a77951_a57.overlay
@@ -4,5 +4,6 @@
 	disk {
 		status = "okay";
 	};
+
 	status = "okay";
 };

--- a/tests/subsys/sensing/boards/native_sim.overlay
+++ b/tests/subsys/sensing/boards/native_sim.overlay
@@ -29,7 +29,8 @@
 		base_accel_gyro: base-accel-gyro {
 			compatible = "zephyr,sensing-phy-3d-sensor";
 			status = "okay";
-			sensor-types = <SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D>;
+			sensor-types = <SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D
+					SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D>;
 			friendly-name = "Base Accel Gyro Sensor";
 			minimal-interval = <625>;
 			underlying-device = <&bmi160_i2c>;
@@ -38,7 +39,8 @@
 		lid_accel_gyro: lid-accel-gyro {
 			compatible = "zephyr,sensing-phy-3d-sensor";
 			status = "okay";
-			sensor-types = <SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D>;
+			sensor-types = <SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D
+					SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D>;
 			friendly-name = "Lid Accel Gyro Sensor";
 			minimal-interval = <625>;
 			underlying-device = <&bmi160_spi>;


### PR DESCRIPTION
The PR:
- Ensure that properties have 2 new lines when node is above it.
- Enures that 1 new line is required between a node and #if/#ifdef...
   - @nordicjm @tmon-nordic this will address the issue noted in this PR https://github.com/zephyrproject-rtos/zephyr/pull/99510
- Enures that 2 new line are required between #endif and node.
- Wraps property values that exceed 100 characters in length.

These chnages need dts-linter version 0.3.7-hotfix2

dts-linter 0.3.7-hotfix2 also addresses
- Update `glob` to address CVE-2025-64756
- Update `js-yaml` to address CVE-2025-64718