### PR TITLE
usb: device_next: uvc: fix frame interval sorting

### DIFF
--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -1498,7 +1498,7 @@ static int uvc_compare_frmival_desc(const void *const a, const void *const b)
 	memcpy(&ia, a, sizeof(uint32_t));
 	memcpy(&ib, b, sizeof(uint32_t));
 
-	return ib - ia;
+	return ia - ib;
 }
 
 static void uvc_set_vs_bitrate_range(struct uvc_frame_descriptor *const desc,


### PR DESCRIPTION
The `qsort()` function takes a callback argument that is having the same semantics as `strcmp()`. Fix `uvc_compare_frmival_desc()` sorting to make `qsort()` list frame intervals in increasing values.

Fix a bug where Windows would not enumerate devices when the video device have multiple frame interval supported.

Bug found with USB Tree Viewer and tested with the "Camera" application.