### PR TITLE
boards: nxp: adjusting the scope of boot-related build flags

### DIFF
--- a/boards/nxp/mimxrt1010_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1010_evk/CMakeLists.txt
@@ -17,7 +17,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This flash configuration block may need modification if another
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(xip/evkmimxrt1010_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1010_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1010_evk/CMakeLists.txt
@@ -18,7 +18,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
-    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(xip/evkmimxrt1010_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1010_evk/xip/evkmimxrt1010_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1010_evk/xip/evkmimxrt1010_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkmimxrt1010_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 const flexspi_nor_config_t qspi_flash_config = {
@@ -63,4 +63,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.is_uniform_block_size = false,
 };
 
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1015_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1015_evk/CMakeLists.txt
@@ -16,7 +16,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This flash configuration block may need modification if another
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(xip/evkmimxrt1015_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1015_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1015_evk/CMakeLists.txt
@@ -17,7 +17,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
-    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(xip/evkmimxrt1015_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1015_evk/xip/evkmimxrt1015_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1015_evk/xip/evkmimxrt1015_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkmimxrt1015_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 const flexspi_nor_config_t qspi_flash_config = {
@@ -65,4 +65,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.is_uniform_block_size = false,
 };
 
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1020_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1020_evk/CMakeLists.txt
@@ -22,7 +22,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   if(CONFIG_DEVICE_CONFIGURATION_DATA)
     # This device configuration block may need modification if another
     # SDRAM chip is used on your custom board.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
     zephyr_library_sources(dcd/dcd.c)
   else()
     if(CONFIG_SRAM_BASE_ADDRESS EQUAL 0x80000000)

--- a/boards/nxp/mimxrt1020_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1020_evk/CMakeLists.txt
@@ -16,7 +16,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This flash configuration block may need modification if another
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(xip/evkmimxrt1020_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1020_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1020_evk/CMakeLists.txt
@@ -17,7 +17,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
-    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(xip/evkmimxrt1020_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1020_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1020_evk/dcd/dcd.c
@@ -8,7 +8,7 @@
 #include "dcd.h"
 
 #if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
-#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
 const uint8_t dcd_data[] = {
@@ -591,5 +591,5 @@ const uint8_t dcd_data[] = {
 
 #else
 const uint8_t dcd_data[] = {0x00};
-#endif /* XIP_BOOT_HEADER_DCD_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA) */
 #endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1020_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1020_evk/dcd/dcd.c
@@ -7,7 +7,7 @@
 
 #include "dcd.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 #if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
@@ -592,4 +592,4 @@ const uint8_t dcd_data[] = {
 #else
 const uint8_t dcd_data[] = {0x00};
 #endif /* XIP_BOOT_HEADER_DCD_ENABLE */
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1020_evk/xip/evkmimxrt1020_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1020_evk/xip/evkmimxrt1020_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkmimxrt1020_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 #define FLASH_DUMMY_CYCLES 0x08
@@ -85,4 +85,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.is_uniform_block_size = false,
 };
 
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1024_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1024_evk/CMakeLists.txt
@@ -16,7 +16,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This flash configuration block may need modification if another
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(xip/evkmimxrt1024_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1024_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1024_evk/CMakeLists.txt
@@ -17,7 +17,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
-    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(xip/evkmimxrt1024_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1024_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1024_evk/CMakeLists.txt
@@ -22,7 +22,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   if(CONFIG_DEVICE_CONFIGURATION_DATA)
     # This device configuration block may need modification if another
     # SDRAM chip is used on your custom board.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
     zephyr_library_sources(dcd/dcd.c)
   else()
     if(CONFIG_SRAM_BASE_ADDRESS EQUAL 0x80000000)

--- a/boards/nxp/mimxrt1024_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1024_evk/dcd/dcd.c
@@ -8,7 +8,7 @@
 #include "dcd.h"
 
 #if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
-#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
 const uint8_t dcd_data[] = {
@@ -591,5 +591,5 @@ const uint8_t dcd_data[] = {
 
 #else
 const uint8_t dcd_data[] = {0x00};
-#endif /* XIP_BOOT_HEADER_DCD_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA) */
 #endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1024_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1024_evk/dcd/dcd.c
@@ -7,7 +7,7 @@
 
 #include "dcd.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 #if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
@@ -592,4 +592,4 @@ const uint8_t dcd_data[] = {
 #else
 const uint8_t dcd_data[] = {0x00};
 #endif /* XIP_BOOT_HEADER_DCD_ENABLE */
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1024_evk/xip/evkmimxrt1024_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1024_evk/xip/evkmimxrt1024_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkmimxrt1024_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 const flexspi_nor_config_t qspi_flash_config = {
@@ -65,4 +65,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.is_uniform_block_size = false,
 };
 
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1040_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1040_evk/CMakeLists.txt
@@ -27,7 +27,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   if(CONFIG_DEVICE_CONFIGURATION_DATA)
     # This device configuration block may need modification if another
     # SDRAM chip is used on your custom board.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
     zephyr_library_sources(dcd/dcd.c)
   else()
     if(CONFIG_SRAM_BASE_ADDRESS EQUAL 0x80000000)

--- a/boards/nxp/mimxrt1040_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1040_evk/CMakeLists.txt
@@ -22,7 +22,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
-    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(xip/evkmimxrt1040_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1040_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1040_evk/CMakeLists.txt
@@ -21,7 +21,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This flash configuration block may need modification if another
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(xip/evkmimxrt1040_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1040_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1040_evk/dcd/dcd.c
@@ -8,7 +8,7 @@
 #include "dcd.h"
 
 #if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
-#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
 const uint8_t dcd_data[] = {
@@ -615,5 +615,5 @@ const uint8_t dcd_data[] = {
 
 #else
 const uint8_t dcd_data[] = {0x00};
-#endif /* XIP_BOOT_HEADER_DCD_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA) */
 #endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1040_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1040_evk/dcd/dcd.c
@@ -7,7 +7,7 @@
 
 #include "dcd.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 #if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
@@ -616,4 +616,4 @@ const uint8_t dcd_data[] = {
 #else
 const uint8_t dcd_data[] = {0x00};
 #endif /* XIP_BOOT_HEADER_DCD_ENABLE */
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1040_evk/xip/evkmimxrt1040_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1040_evk/xip/evkmimxrt1040_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkmimxrt1040_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 const flexspi_nor_config_t qspi_flash_config = {
@@ -60,4 +60,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.is_uniform_block_size = false,
 };
 
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1050_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1050_evk/CMakeLists.txt
@@ -33,7 +33,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   if(CONFIG_DEVICE_CONFIGURATION_DATA)
     # This device configuration block may need modification if another
     # SDRAM chip is used on your custom board.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
     zephyr_library_sources(dcd/dcd.c)
   else()
     if(CONFIG_SRAM_BASE_ADDRESS EQUAL 0x80000000)

--- a/boards/nxp/mimxrt1050_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1050_evk/CMakeLists.txt
@@ -27,7 +27,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This flash configuration block may need modification if another
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(xip/${FLASH_CONF})
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1050_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1050_evk/CMakeLists.txt
@@ -28,7 +28,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
-    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(xip/${FLASH_CONF})
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1050_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1050_evk/dcd/dcd.c
@@ -8,7 +8,7 @@
 #include "dcd.h"
 
 #if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
-#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
 const uint8_t dcd_data[] = {
@@ -615,5 +615,5 @@ const uint8_t dcd_data[] = {
 
 #else
 const uint8_t dcd_data[] = {0x00};
-#endif /* XIP_BOOT_HEADER_DCD_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA) */
 #endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1050_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1050_evk/dcd/dcd.c
@@ -7,7 +7,7 @@
 
 #include "dcd.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 #if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
@@ -616,4 +616,4 @@ const uint8_t dcd_data[] = {
 #else
 const uint8_t dcd_data[] = {0x00};
 #endif /* XIP_BOOT_HEADER_DCD_ENABLE */
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkbimxrt1050_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 const flexspi_nor_config_t hyperflash_config = {
@@ -224,4 +224,4 @@ const flexspi_nor_config_t hyperflash_config = {
 	.is_uniform_block_size = true,
 };
 
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_qspi_config.c
+++ b/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_qspi_config.c
@@ -7,7 +7,7 @@
 
 #include "evkbimxrt1050_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 const flexspi_nor_config_t qspi_flash_config = {
@@ -34,4 +34,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.block_size = 64u * 1024u,
 	.is_uniform_block_size = false,
 };
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1060_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1060_evk/CMakeLists.txt
@@ -37,7 +37,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This flash configuration block may need modification if another
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(${RT1060_BOARD_DIR}/xip/${FLASH_CONF})
     zephyr_library_include_directories(${RT1060_BOARD_DIR}/xip)
   endif()

--- a/boards/nxp/mimxrt1060_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1060_evk/CMakeLists.txt
@@ -38,7 +38,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
-    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(${RT1060_BOARD_DIR}/xip/${FLASH_CONF})
     zephyr_library_include_directories(${RT1060_BOARD_DIR}/xip)
   endif()

--- a/boards/nxp/mimxrt1060_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1060_evk/CMakeLists.txt
@@ -43,7 +43,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   if(CONFIG_DEVICE_CONFIGURATION_DATA)
     # This device configuration data block may need modification if another
     # SDRAM chip is used on your custom board.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
     zephyr_library_sources(${RT1060_BOARD_DIR}/dcd/dcd.c)
   else()
     if(CONFIG_SRAM_BASE_ADDRESS EQUAL 0x80000000)

--- a/boards/nxp/mimxrt1060_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1060_evk/dcd/dcd.c
@@ -8,7 +8,7 @@
 #include "dcd.h"
 
 #if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
-#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
 const uint8_t dcd_data[] = {
@@ -615,5 +615,5 @@ const uint8_t dcd_data[] = {
 
 #else
 const uint8_t dcd_data[] = {0x00};
-#endif /* XIP_BOOT_HEADER_DCD_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA) */
 #endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1060_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1060_evk/dcd/dcd.c
@@ -7,7 +7,7 @@
 
 #include "dcd.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 #if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
@@ -616,4 +616,4 @@ const uint8_t dcd_data[] = {
 #else
 const uint8_t dcd_data[] = {0x00};
 #endif /* XIP_BOOT_HEADER_DCD_ENABLE */
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1060_evk/xip/evkbmimxrt1060_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1060_evk/xip/evkbmimxrt1060_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkbmimxrt1060_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 const flexspi_nor_config_t qspi_flash_config = {
@@ -65,4 +65,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.is_uniform_block_size = false,
 };
 
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1060_evk/xip/evkmimxrt1060_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1060_evk/xip/evkmimxrt1060_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkmimxrt1060_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 const flexspi_nor_config_t qspi_flash_config = {
@@ -65,4 +65,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.is_uniform_block_size = false,
 };
 
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1062_fmurt6/CMakeLists.txt
+++ b/boards/nxp/mimxrt1062_fmurt6/CMakeLists.txt
@@ -18,7 +18,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # Include flash configuration block for RT1050 EVK from NXP's HAL.
     # This configuration block may need modification if another flash chip is
     # used on your custom board. See NXP AN12238 for more information.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(${RT1062_BOARD_DIR}/xip/${FLASH_CONF})
     zephyr_library_include_directories(${RT1062_BOARD_DIR}/xip)
   endif()

--- a/boards/nxp/mimxrt1062_fmurt6/CMakeLists.txt
+++ b/boards/nxp/mimxrt1062_fmurt6/CMakeLists.txt
@@ -19,7 +19,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This configuration block may need modification if another flash chip is
     # used on your custom board. See NXP AN12238 for more information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
-    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(${RT1062_BOARD_DIR}/xip/${FLASH_CONF})
     zephyr_library_include_directories(${RT1062_BOARD_DIR}/xip)
   endif()

--- a/boards/nxp/mimxrt1062_fmurt6/CMakeLists.txt
+++ b/boards/nxp/mimxrt1062_fmurt6/CMakeLists.txt
@@ -25,7 +25,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # Include device configuration data block for RT1050 EVK from NXP's HAL.
     # This configuration block may need modification if another SDRAM chip
     # is used on your custom board.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
     zephyr_library_sources(${RT1062_BOARD_DIR}/dcd/dcd.c)
   endif()
 endif()

--- a/boards/nxp/mimxrt1064_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1064_evk/CMakeLists.txt
@@ -22,7 +22,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
-    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(xip/evkmimxrt1064_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1064_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1064_evk/CMakeLists.txt
@@ -27,7 +27,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   if(CONFIG_DEVICE_CONFIGURATION_DATA)
     # This device configuration block may need modification if another
     # SDRAM chip is used on your custom board.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
     zephyr_library_sources(dcd/dcd.c)
   else()
     if(CONFIG_SRAM_BASE_ADDRESS EQUAL 0x80000000)

--- a/boards/nxp/mimxrt1064_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1064_evk/CMakeLists.txt
@@ -21,7 +21,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This flash configuration block may need modification if another
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(xip/evkmimxrt1064_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1064_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1064_evk/dcd/dcd.c
@@ -8,7 +8,7 @@
 
 #include "dcd.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 #if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
@@ -618,4 +618,4 @@ const uint8_t dcd_data[] = {
 #else
 const uint8_t dcd_data[] = {0x00};
 #endif /* XIP_BOOT_HEADER_DCD_ENABLE */
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1064_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1064_evk/dcd/dcd.c
@@ -9,7 +9,7 @@
 #include "dcd.h"
 
 #if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
-#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
 /* COMMENTS BELOW ARE USED AS SETTINGS FOR DCD DATA */
@@ -617,5 +617,5 @@ const uint8_t dcd_data[] = {
 
 #else
 const uint8_t dcd_data[] = {0x00};
-#endif /* XIP_BOOT_HEADER_DCD_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA) */
 #endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1064_evk/xip/evkmimxrt1064_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1064_evk/xip/evkmimxrt1064_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkmimxrt1064_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 const flexspi_nor_config_t qspi_flash_config = {
@@ -65,4 +65,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.is_uniform_block_size = false,
 };
 
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1160_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1160_evk/CMakeLists.txt
@@ -17,7 +17,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
-    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(xip/evkmimxrt1160_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1160_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1160_evk/CMakeLists.txt
@@ -16,7 +16,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This flash configuration block may need modification if another
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(xip/evkmimxrt1160_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1160_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1160_evk/CMakeLists.txt
@@ -22,7 +22,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   if(CONFIG_DEVICE_CONFIGURATION_DATA)
     # This device configuration block may need modification if another
     # SDRAM chip is used on your custom board.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
     zephyr_library_sources(dcd/dcd.c)
   else()
     if(CONFIG_SRAM_BASE_ADDRESS EQUAL 0x80000000)

--- a/boards/nxp/mimxrt1160_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1160_evk/dcd/dcd.c
@@ -8,7 +8,7 @@
 #include "dcd.h"
 
 #if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
-#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
 const uint8_t dcd_data[] = {
@@ -745,5 +745,5 @@ const uint8_t dcd_data[] = {
 
 #else
 const uint8_t dcd_data[] = {0x00};
-#endif /* XIP_BOOT_HEADER_DCD_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA) */
 #endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1160_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1160_evk/dcd/dcd.c
@@ -7,7 +7,7 @@
 
 #include "dcd.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 #if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
@@ -746,4 +746,4 @@ const uint8_t dcd_data[] = {
 #else
 const uint8_t dcd_data[] = {0x00};
 #endif /* XIP_BOOT_HEADER_DCD_ENABLE */
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1160_evk/xip/evkmimxrt1160_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1160_evk/xip/evkmimxrt1160_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkmimxrt1160_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 #define FLASH_DUMMY_CYCLES 0x09
@@ -89,4 +89,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.is_uniform_block_size = false,
 };
 
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1170_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1170_evk/CMakeLists.txt
@@ -22,7 +22,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
-    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(xip/${RT1170_BOARD_NAME}_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1170_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1170_evk/CMakeLists.txt
@@ -21,7 +21,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This flash configuration block may need modification if another
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(xip/${RT1170_BOARD_NAME}_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1170_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1170_evk/dcd/dcd.c
@@ -7,7 +7,7 @@
 
 #include "dcd.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 #if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
@@ -884,4 +884,4 @@ const uint8_t dcd_data[] = {
 #else
 const uint8_t dcd_data[] = {0x00};
 #endif /* XIP_BOOT_HEADER_DCD_ENABLE */
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1170_evk/dcd/dcd.c
+++ b/boards/nxp/mimxrt1170_evk/dcd/dcd.c
@@ -8,7 +8,7 @@
 #include "dcd.h"
 
 #if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
-#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA)
 __attribute__((section(".boot_hdr.dcd_data"), used))
 
 const uint8_t dcd_data[] = {
@@ -883,5 +883,5 @@ const uint8_t dcd_data[] = {
 
 #else
 const uint8_t dcd_data[] = {0x00};
-#endif /* XIP_BOOT_HEADER_DCD_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_DEVICE_CONFIGURATION_DATA) */
 #endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1170_evk/xip/evkbmimxrt1170_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1170_evk/xip/evkbmimxrt1170_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkbmimxrt1170_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 #define FLASH_DUMMY_CYCLES 0x08
@@ -88,4 +88,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.is_uniform_block_size = false,
 };
 
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1170_evk/xip/evkmimxrt1170_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1170_evk/xip/evkmimxrt1170_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkmimxrt1170_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 #define FLASH_DUMMY_CYCLES 0x09
@@ -86,4 +86,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.is_uniform_block_size = false,
 };
 
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1170_evk/xmcd/xmcd.c
+++ b/boards/nxp/mimxrt1170_evk/xmcd/xmcd.c
@@ -7,7 +7,7 @@
 
 #include "xmcd.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 
 #if defined(XIP_BOOT_HEADER_XMCD_ENABLE) && (XIP_BOOT_HEADER_XMCD_ENABLE == 1)
 __attribute__((section(".boot_hdr.xmcd_data"), used))
@@ -31,4 +31,4 @@ const uint32_t xmcd_data[] = {
 	0x02};
 
 #endif /* XIP_BOOT_HEADER_XMCD_ENABLE */
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/boards/nxp/mimxrt1180_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1180_evk/CMakeLists.txt
@@ -29,7 +29,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This flash configuration block may need modification if another
     # flash chip is used on your custom board.
     zephyr_library_compile_definitions(XIP_EXTERNAL_FLASH=1)
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(xip/evkmimxrt1180_flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/mimxrt1180_evk/xip/evkmimxrt1180_flexspi_nor_config.c
+++ b/boards/nxp/mimxrt1180_evk/xip/evkmimxrt1180_flexspi_nor_config.c
@@ -8,8 +8,8 @@
 #include "evkmimxrt1180_flexspi_nor_config.h"
 
 /* clang-format off */
-#if defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1) &&		\
-	defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1) && \
+	defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 /* clang-format on */
 
 #if defined(USE_HYPERRAM)

--- a/boards/nxp/mimxrt595_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt595_evk/CMakeLists.txt
@@ -16,11 +16,11 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
       "the MIMXRT595-EVK, but targeting a custom board. You may need to "
       "update your flash configuration block data")
   endif()
+
   # This flash configuration block may need modification if another
   # flash chip is used on your custom board. See NXP AN13304 for more
   # information.
   zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)
-  zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
   zephyr_library_sources(flash_config/flash_config.c)
   zephyr_library_include_directories(flash_config)
 endif()

--- a/boards/nxp/mimxrt595_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt595_evk/CMakeLists.txt
@@ -20,11 +20,9 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   # This flash configuration block may need modification if another
   # flash chip is used on your custom board. See NXP AN13304 for more
   # information.
-  zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)
   zephyr_library_sources(flash_config/flash_config.c)
   zephyr_library_include_directories(flash_config)
 endif()
-
 # Add custom linker section to relocate framebuffers to PSRAM
 zephyr_linker_sources_ifdef(CONFIG_LV_Z_VDB_CUSTOM_SECTION
   SECTIONS dc_ram.ld)

--- a/boards/nxp/mimxrt595_evk/flash_config/flash_config.c
+++ b/boards/nxp/mimxrt595_evk/flash_config/flash_config.c
@@ -6,7 +6,7 @@
  */
 #include "flash_config.h"
 
-#if defined(BOOT_HEADER_ENABLE) && (BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && (CONFIG_NXP_IMXRT_BOOT_HEADER == 1)
 __attribute__((section(".flash_conf"), used))
 
 const flexspi_nor_config_t flash_config = {
@@ -105,4 +105,4 @@ const flexspi_nor_config_t flash_config = {
 	.flashStateCtx = 0x07008200u,
 };
 
-#endif /* BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && (CONFIG_NXP_IMXRT_BOOT_HEADER == 1) */

--- a/boards/nxp/mimxrt685_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt685_evk/CMakeLists.txt
@@ -22,7 +22,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   # This flash configuration block may need modification if another
   # flash chip is used on your custom board. See NXP AN13386 for more
   # information.
-  zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)
   zephyr_library_sources(flash_config/flash_config.c)
   zephyr_library_include_directories(flash_config)
 endif()

--- a/boards/nxp/mimxrt685_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt685_evk/CMakeLists.txt
@@ -18,11 +18,11 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
       "the MIMXRT685-EVK, but targeting a custom board. You may need to "
       "update your flash configuration block data")
   endif()
+
   # This flash configuration block may need modification if another
   # flash chip is used on your custom board. See NXP AN13386 for more
   # information.
   zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)
-  zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
   zephyr_library_sources(flash_config/flash_config.c)
   zephyr_library_include_directories(flash_config)
 endif()

--- a/boards/nxp/mimxrt685_evk/flash_config/flash_config.c
+++ b/boards/nxp/mimxrt685_evk/flash_config/flash_config.c
@@ -6,7 +6,7 @@
  */
 #include "flash_config.h"
 
-#if defined(BOOT_HEADER_ENABLE) && (BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && (CONFIG_NXP_IMXRT_BOOT_HEADER == 1)
 __attribute__((section(".flash_conf"), used))
 
 const flexspi_nor_config_t flexspi_config = {
@@ -135,4 +135,4 @@ const flexspi_nor_config_t flexspi_config = {
 	.flash_state_ctx = 0x07008100u,
 };
 
-#endif /* BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && (CONFIG_NXP_IMXRT_BOOT_HEADER == 1) */

--- a/boards/nxp/mimxrt700_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt700_evk/CMakeLists.txt
@@ -20,7 +20,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   # This flash configuration block may need modification if another
   # flash chip is used on your custom board. See NXP AN13304 for more
   # information.
-  zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)
   zephyr_library_sources(flash_config/flash_config.c)
   zephyr_library_include_directories(flash_config)
 endif()

--- a/boards/nxp/mimxrt700_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt700_evk/CMakeLists.txt
@@ -16,11 +16,11 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     "the MIMXRT7xx-EVK, but targeting a custom board. You may need to "
     "update your flash configuration block data")
   endif()
+
   # This flash configuration block may need modification if another
   # flash chip is used on your custom board. See NXP AN13304 for more
   # information.
   zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)
-  zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
   zephyr_library_sources(flash_config/flash_config.c)
   zephyr_library_include_directories(flash_config)
 endif()

--- a/boards/nxp/mimxrt700_evk/flash_config/flash_config.c
+++ b/boards/nxp/mimxrt700_evk/flash_config/flash_config.c
@@ -5,7 +5,7 @@
  */
 #include "flash_config.h"
 
-#if defined(BOOT_HEADER_ENABLE) && (BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && (CONFIG_NXP_IMXRT_BOOT_HEADER == 1)
 __attribute__((section(".flash_conf"), used))
 
 const fc_static_platform_config_t flash_config = {
@@ -139,4 +139,4 @@ const fc_static_platform_config_t flash_config = {
 #endif
 };
 
-#endif /* BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && (CONFIG_NXP_IMXRT_BOOT_HEADER == 1) */

--- a/boards/nxp/rd_rw612_bga/CMakeLists.txt
+++ b/boards/nxp/rd_rw612_bga/CMakeLists.txt
@@ -15,7 +15,6 @@ if(CONFIG_NXP_RW6XX_BOOT_HEADER)
       "the RD_RW612_BGA, but targeting a custom board. You may need to "
      "update your flash configuration block data")
   endif()
-  zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)
   zephyr_library_sources(MX25U51245GZ4I00_FCB.c)
 endif()
 

--- a/boards/nxp/vmu_rt1170/CMakeLists.txt
+++ b/boards/nxp/vmu_rt1170/CMakeLists.txt
@@ -10,7 +10,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # This flash configuration block may need modification if another
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
-    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_library_sources(flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/vmu_rt1170/CMakeLists.txt
+++ b/boards/nxp/vmu_rt1170/CMakeLists.txt
@@ -11,7 +11,6 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     # flash chip is used on your custom board. See NXP AN12238 for more
     # information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
-    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(flexspi_nor_config.c)
     zephyr_library_include_directories(xip)
   endif()

--- a/boards/nxp/vmu_rt1170/xip/evkmimxrt1170_flexspi_nor_config.c
+++ b/boards/nxp/vmu_rt1170/xip/evkmimxrt1170_flexspi_nor_config.c
@@ -7,7 +7,7 @@
 
 #include "evkmimxrt1170_flexspi_nor_config.h"
 
-#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR)
 __attribute__((section(".boot_hdr.conf"), used))
 
 #define FLASH_DUMMY_CYCLES 0x09
@@ -86,4 +86,4 @@ const flexspi_nor_config_t qspi_flash_config = {
 	.block_size = 64u * 1024u,
 	.is_uniform_block_size = false,
 };
-#endif /* XIP_BOOT_HEADER_ENABLE */
+#endif /* defined(CONFIG_NXP_IMXRT_BOOT_HEADER) && defined(CONFIG_BOOT_FLEXSPI_NOR) */

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -44,6 +44,43 @@ Boards
   in the respective board CMakeLists.txt files. Applications that depended on these definitions
   being globally available may need to be updated. (:github:`101322`)
 
+* NXP has changed the scope of some in-tree compile flags to limit their visibility to only where
+  they are needed. Out-of-tree applications or boards that depended on these flags being globally
+  available may need to add them to their own CMakeLists.txt files to ensure they continue to build
+  correctly. (:github:`100252`)
+  The affected flags are listed below:
+
+  * For the RT10xx and RT11xx families, the compile flag ``BOARD_FLASH_SIZE``, originally defined in
+    ``boards/nxp/mimxrt10xx_evk/CMakeLists.txt`` and ``boards/nxp/mimxrt11xx_evk/CMakeLists.txt``, is
+    used only by the HAL header ``fsl_flexspi_nor_boot.h``, which is included by
+    :zephyr_file:`soc/nxp/imxrt/imxrt10xx/soc.c` and :zephyr_file:`soc/nxp/imxrt/imxrt11xx/soc.c`.
+    To avoid potential collisions with other global flags, the macro is now defined at the SoC layer
+    using ``zephyr_library_compile_definitions()`` in :zephyr_file:`soc/nxp/imxrt/imxrt10xx/CMakeLists.txt`
+    and :zephyr_file:`soc/nxp/imxrt/imxrt11xx/CMakeLists.txt`. This change has been applied to all
+    RTxxxx boards.
+
+  * For the RTxxx family, the compile flag ``BOARD_FLASH_SIZE``, originally defined in
+    ``boards/nxp/mimxrtxxx_evk/CMakeLists.txt``, is not used in the Zephyr tree and has
+    therefore been removed from all RTxxx board CMakeLists.txt files.
+
+  * For the RTxxx family, the compile flag ``BOOT_HEADER_ENABLE``, previously defined in
+    ``boards/nxp/mimxrtxxx_evk/CMakeLists.txt`` and used in ``boards/nxp/rtxxx/<boot_header>.c``,
+    has been replaced by a Kconfig option. Consequently, the line
+    ``zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)`` has been removed from the RTxxx board
+    CMakeLists.txt files.
+
+  * Removed compile flag ``BOOT_HEADER_ENABLE`` definition from :zephyr_file:`boards/nxp/rd_rw612_bga/CMakeLists.txt`,
+    as it is not used in the Zephyr tree.
+
+  * Originally, the compile flags ``XIP_BOOT_HEADER_ENABLE`` and ``XIP_BOOT_HEADER_DCD_ENABLE`` were
+    used in ``boards/nxp/rt1xxx/<boot_header>.c``. These flags have been converted to Kconfig options
+    across NXP RTxxxx evaluation boards, allowing boot-header configuration via the Kconfig build system
+    instead of compile-time defines. Consequently, we removed ``zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)``
+    and ``zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)`` from the RTxxxx board-level CMakeLists.txt files.
+    Because these macros are also required by ``hal_nxp/rt10xx/fsl_flexspi_nor_boot.h`` and
+    ``hal_nxp/rt11xx/fsl_flexspi_nor_boot.h``, they were added to the corresponding SoC-layer CMakeLists.txt files
+    using ``zephyr_library_compile_definitions()`` to limit their scope.
+
 Device Drivers and Devicetree
 *****************************
 

--- a/soc/nxp/imxrt/imxrt10xx/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt10xx/CMakeLists.txt
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_sources(soc.c)
+zephyr_library()
+zephyr_library_sources(soc.c)
 
 if(CONFIG_PM)
   zephyr_sources(power.c)

--- a/soc/nxp/imxrt/imxrt10xx/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt10xx/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,6 +20,12 @@ if(CONFIG_MEMC_MCUX_FLEXSPI)
   zephyr_sources(flexspi.c)
   if(CONFIG_FLASH_MCUX_FLEXSPI_XIP)
     zephyr_code_relocate(FILES flexspi.c LOCATION ${CONFIG_FLASH_MCUX_FLEXSPI_XIP_MEM}_TEXT)
+  endif()
+endif()
+
+if(CONFIG_NXP_IMXRT_BOOT_HEADER)
+  if(CONFIG_BOOT_FLEXSPI_NOR)
+    zephyr_library_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
   endif()
 endif()
 

--- a/soc/nxp/imxrt/imxrt10xx/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt10xx/CMakeLists.txt
@@ -27,6 +27,10 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   if(CONFIG_BOOT_FLEXSPI_NOR)
     zephyr_library_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
   endif()
+
+  if(CONFIG_DEVICE_CONFIGURATION_DATA)
+    zephyr_library_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
+  endif()
 endif()
 
 zephyr_include_directories(.)

--- a/soc/nxp/imxrt/imxrt11xx/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt11xx/CMakeLists.txt
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_sources(soc.c)
+zephyr_library()
+zephyr_library_sources(soc.c)
 zephyr_sources_ifdef(CONFIG_PM power.c)
 
 zephyr_include_directories(.)

--- a/soc/nxp/imxrt/imxrt11xx/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt11xx/CMakeLists.txt
@@ -27,6 +27,10 @@ if(CONFIG_NXP_IMXRT_BOOT_HEADER)
     zephyr_library_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
   endif()
+
+  if(CONFIG_DEVICE_CONFIGURATION_DATA)
+    zephyr_library_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
+  endif()
 endif()
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/nxp/imxrt/imxrt11xx/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt11xx/CMakeLists.txt
@@ -22,5 +22,10 @@ if(CONFIG_SECOND_CORE_MCUX_REMOTE_DIR)
   zephyr_include_directories(${CONFIG_SECOND_CORE_MCUX_REMOTE_DIR})
 endif()
 
+if(CONFIG_NXP_IMXRT_BOOT_HEADER)
+  if(CONFIG_BOOT_FLEXSPI_NOR)
+    zephyr_library_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
+  endif()
+endif()
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/nxp/imxrt/imxrt11xx/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt11xx/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   if(CONFIG_BOOT_FLEXSPI_NOR)
     zephyr_library_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
+    zephyr_library_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
   endif()
 endif()
 


### PR DESCRIPTION
  * For the RT10xx and RT11xx families, the compile flag ``BOARD_FLASH_SIZE``, originally defined in
    ``boards/nxp/mimxrt10xx_evk/CMakeLists.txt`` and ``boards/nxp/mimxrt11xx_evk/CMakeLists.txt``, is
    used only by the HAL header ``fsl_flexspi_nor_boot.h``, which is included by
    :zephyr_file:`soc/nxp/imxrt/imxrt10xx/soc.c` and :zephyr_file:`soc/nxp/imxrt/imxrt11xx/soc.c`.
    To avoid potential collisions with other global flags, the macro is now defined at the SoC layer
    using ``zephyr_library_compile_definitions()`` in :zephyr_file:`soc/nxp/imxrt/imxrt10xx/CMakeLists.txt`
    and :zephyr_file:`soc/nxp/imxrt/imxrt11xx/CMakeLists.txt`. This change has been applied to all
    RTxxxx boards.

  * For the RTxxx family, the compile flag ``BOARD_FLASH_SIZE``, originally defined in
    ``boards/nxp/mimxrtxxx_evk/CMakeLists.txt``, is not used in the Zephyr tree and has
    therefore been removed from all RTxxx board CMakeLists.txt files.

  * For the RTxxx family, the compile flag ``BOOT_HEADER_ENABLE``, previously defined in
    ``boards/nxp/mimxrtxxx_evk/CMakeLists.txt`` and used in ``boards/nxp/rtxxx/<boot_header>.c``,
    has been replaced by a Kconfig option. Consequently, the line
    ``zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)`` has been removed from the RTxxx board
    CMakeLists.txt files.

  * Removed compile flag ``BOOT_HEADER_ENABLE`` definition from :zephyr_file:`boards/nxp/rd_rw612_bga/CMakeLists.txt`,
    as it is not used in the Zephyr tree.

  * Originally, the compile flags ``XIP_BOOT_HEADER_ENABLE`` and ``XIP_BOOT_HEADER_DCD_ENABLE`` were
    used in ``boards/nxp/rt1xxx/<boot_header>.c``. These flags have been converted to Kconfig options
    across NXP RTxxxx evaluation boards, allowing boot-header configuration via the Kconfig build system
    instead of compile-time defines. Consequently, we removed ``zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)``
    and ``zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)`` from the RTxxxx board-level CMakeLists.txt files.
    Because these macros are also required by ``hal_nxp/rt10xx/fsl_flexspi_nor_boot.h`` and
    ``hal_nxp/rt11xx/fsl_flexspi_nor_boot.h``, they were added to the corresponding SoC-layer CMakeLists.txt files
    using ``zephyr_library_compile_definitions()`` to limit their scope.

rework https://github.com/zephyrproject-rtos/zephyr/pull/96902