### PR TITLE
dts: arm: st: h7: add ITCM and DTCM memory regions for STM32H7

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -49,6 +49,18 @@
 		};
 	};
 
+	itcm: memory@0 {
+		compatible = "zephyr,memory-region", "arm,itcm";
+		reg = <0x00000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "ITCM";
+	};
+
+	dtcm: memory@20000000 {
+		compatible = "zephyr,memory-region", "arm,dtcm";
+		reg = <0x20000000 DT_SIZE_K(128)>;
+		zephyr,memory-region = "DTCM";
+	};
+
 	ext_memory: memory@90000000 {
 		compatible = "zephyr,memory-region";
 		reg = <0x90000000 DT_SIZE_M(256)>; /* max addressable area */

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -232,20 +232,6 @@
 		zephyr,memory-region = "SRAM4";
 	};
 
-	/* Data TCM RAM */
-	dtcm: memory@20000000 {
-		compatible = "zephyr,memory-region", "arm,dtcm";
-		reg = <0x20000000 DT_SIZE_K(128)>;
-		zephyr,memory-region = "DTCM";
-	};
-
-	/* Instruction TCM RAM (64KB as `TCM_AXI_SHARED` is `000`) */
-	itcm: memory@0 {
-		compatible = "zephyr,memory-region", "arm,itcm";
-		reg = <0x00000000 DT_SIZE_K(64)>;
-		zephyr,memory-region = "ITCM";
-	};
-
 	otghs_fs_phy: otghs_fs_phy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;

--- a/dts/arm/st/h7/stm32h742.dtsi
+++ b/dts/arm/st/h7/stm32h742.dtsi
@@ -90,18 +90,6 @@
 		zephyr,memory-region = "SRAM4";
 	};
 
-	dtcm: memory@20000000 {
-		compatible = "zephyr,memory-region", "arm,dtcm";
-		reg = <0x20000000 DT_SIZE_K(128)>;
-		zephyr,memory-region = "DTCM";
-	};
-
-	itcm: memory@0 {
-		compatible = "zephyr,memory-region", "arm,itcm";
-		reg = <0x00000000 DT_SIZE_K(64)>;
-		zephyr,memory-region = "ITCM";
-	};
-
 	otghs_fs_phy: otghs_fs_phy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;

--- a/dts/arm/st/h7/stm32h745Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h745Xi_m4.dtsi
@@ -6,6 +6,8 @@
 
 #include <st/h7/stm32h745.dtsi>
 
+/delete-node/ &itcm;
+/delete-node/ &dtcm;
 /delete-node/ &flash0;
 
 / {

--- a/dts/arm/st/h7/stm32h745Xi_m7.dtsi
+++ b/dts/arm/st/h7/stm32h745Xi_m7.dtsi
@@ -13,12 +13,6 @@
 		/delete-node/ cpu@1;
 	};
 
-	dtcm: memory@20000000 {
-		compatible = "zephyr,memory-region", "arm,dtcm";
-		reg = <0x20000000 DT_SIZE_K(128)>;
-		zephyr,memory-region = "DTCM";
-	};
-
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {

--- a/dts/arm/st/h7/stm32h747Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h747Xi_m4.dtsi
@@ -6,6 +6,8 @@
 
 #include <st/h7/stm32h747.dtsi>
 
+/delete-node/ &itcm;
+/delete-node/ &dtcm;
 /delete-node/ &flash0;
 
 / {

--- a/dts/arm/st/h7/stm32h755Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h755Xi_m4.dtsi
@@ -6,6 +6,8 @@
 
 #include <st/h7/stm32h755.dtsi>
 
+/delete-node/ &itcm;
+/delete-node/ &dtcm;
 /delete-node/ &flash0;
 
 / {

--- a/dts/arm/st/h7/stm32h755Xi_m7.dtsi
+++ b/dts/arm/st/h7/stm32h755Xi_m7.dtsi
@@ -13,12 +13,6 @@
 		/delete-node/ cpu@1;
 	};
 
-	dtcm: memory@20000000 {
-		compatible = "zephyr,memory-region", "arm,dtcm";
-		reg = <0x20000000 DT_SIZE_K(128)>;
-		zephyr,memory-region = "DTCM";
-	};
-
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {

--- a/dts/arm/st/h7/stm32h757Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h757Xi_m4.dtsi
@@ -6,6 +6,8 @@
 
 #include <st/h7/stm32h757.dtsi>
 
+/delete-node/ &itcm;
+/delete-node/ &dtcm;
 /delete-node/ &flash0;
 
 / {

--- a/dts/arm/st/h7/stm32h757Xi_m7.dtsi
+++ b/dts/arm/st/h7/stm32h757Xi_m7.dtsi
@@ -13,12 +13,6 @@
 		/delete-node/ cpu@1;
 	};
 
-	dtcm: memory@20000000 {
-		compatible = "zephyr,memory-region", "arm,dtcm";
-		reg = <0x20000000 DT_SIZE_K(128)>;
-		zephyr,memory-region = "DTCM";
-	};
-
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -152,18 +152,6 @@
 		zephyr,memory-region = "SRAM5";
 	};
 
-	dtcm: memory@20000000 {
-		compatible = "zephyr,memory-region", "arm,dtcm";
-		reg = <0x20000000 DT_SIZE_K(128)>;
-		zephyr,memory-region = "DTCM";
-	};
-
-	itcm: memory@0 {
-		compatible = "zephyr,memory-region", "arm,itcm";
-		reg = <0x00000000 DT_SIZE_K(64)>;
-		zephyr,memory-region = "ITCM";
-	};
-
 	ext_memory2: memory@70000000 {
 		compatible = "zephyr,memory-region";
 		reg = <0x70000000 DT_SIZE_M(256)>; /* max addressable area */


### PR DESCRIPTION
Add ITCM and DTCM memory region definitions for the STM32H7.

ITCM: 64 KB @ 0x00000000
DTCM: 128 KB @ 0x20000000