### PR TITLE
add: add esp32s3_wroom_n32r16.dtsi

### DIFF
--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n32r16.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n32r16.dtsi
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esp32s3_common.dtsi"
+
+/* 32MB flash */
+&flash0 {
+	reg = <0x0 DT_SIZE_M(32)>;
+};
+
+/* 16MB psram */
+&psram0 {
+	size = <DT_SIZE_M(16)>;
+};


### PR DESCRIPTION
When I was using the ESP32-S3, I found that my board has 32MB Flash and 16MB PSRAM. The specific model is N32R16. Therefore, I added this device tree include file.