### PR TITLE
modules: lvgl: Prevent false pointer input events

### DIFF
--- a/modules/lvgl/input/lvgl_pointer_input.c
+++ b/modules/lvgl/input/lvgl_pointer_input.c
@@ -57,6 +57,8 @@ static void lvgl_pointer_process_event(struct input_event *evt, void *user_data)
 		data->common_data.pending_event.state =
 			evt->value ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
 		break;
+	default:
+		return;
 	}
 
 	if (!evt->sync) {


### PR DESCRIPTION
Fixes an issue where input events which have the sync flag set but are neither X/Y coordiante updates nor press/release updates triggers a false reporting of input to LVGL.

(Chosen explictily not to add any log statements because in the case where the input device phandle is not set and all input events end up in the input-pointer device handler this will produce quite the amount of logs.)