### PR TITLE
bluetooth: host: obex: Allow MOPL to exceed MTU for mobile compatibility

### DIFF
--- a/subsys/bluetooth/host/classic/obex.c
+++ b/subsys/bluetooth/host/classic/obex.c
@@ -961,7 +961,12 @@ static int obex_client_connect(struct bt_obex_client *client, uint8_t rsp_code, 
 
 	if (mopl > client->obex->tx.mtu) {
 		LOG_WRN("MOPL exceeds MTU (%d > %d)", mopl, client->obex->tx.mtu);
-		goto failed;
+		/* In mainstream mobile operating system settings, such as IPhone and Android,
+		 * MOPL is usually greater than the MTU of rfcomm or l2cap.
+		 * Therefore, the smaller value among them is selected as the final MOPL and
+		 * transmitted to the application by callback.
+		 */
+		mopl = client->obex->tx.mtu;
 	}
 
 	client->tx.mopl = mopl;


### PR DESCRIPTION
When MOPL  exceeds MTU, adjust it to match MTU instead of failing the connection. This handles the common case where mainstream mobile operating systems (iPhone and Android) negotiate
MOPL values greater than the RFCOMM or L2CAP MTU.