### PR TITLE
MAINTAINERS: Add Yongxu Wang as Firmware collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1682,6 +1682,8 @@ Documentation Infrastructure:
   status: maintained
   maintainers:
     - LaurentiuM1234
+  collaborators:
+    - yongxu-wang15
   files:
     - drivers/firmware/
     - include/zephyr/drivers/firmware/


### PR DESCRIPTION
Add myself as a collaborator for the firmware drivers subsystem. I have been actively contributing to SCMI protocol implementations and will continue developing new features, reviewing patches, and testing firmware functionality

Contributor Nomination link: https://github.com/zephyrproject-rtos/zephyr/issues/100267