### PR TITLE
soc: nxp: mcxw2xx: Improve OS tick timer selection

### DIFF
--- a/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
+++ b/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
@@ -176,12 +176,11 @@
 	pinctrl-names = "default";
 };
 
-/*
- * MCXW23 FRDM board uses SYSTICK timer as the kernel timer.
- * In case we need to switch to OS timer, then
- * replace &systick with &os_timer
- */
 &systick {
+	status = "okay";
+};
+
+&os_timer {
 	status = "okay";
 };
 

--- a/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
+++ b/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
@@ -156,12 +156,11 @@
 	pinctrl-names = "default";
 };
 
-/*
- * MCXW23 EVK board uses SYSTICK timer as the kernel timer.
- * In case we need to switch to OS timer, then
- * replace &systick with &os_timer
- */
 &systick {
+	status = "okay";
+};
+
+&os_timer {
 	status = "okay";
 };
 

--- a/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig.defconfig
@@ -4,6 +4,12 @@
 
 if SOC_SERIES_MCXW2XX
 
+# MCXW23 uses SYSTICK timer as the kernel timer by default.
+# In case we need to switch to OS timer, then
+# define CONFIG_MCUX_OS_TIMER=y
+configdefault MCUX_OS_TIMER
+	default n
+
 config CORTEX_M_SYSTICK
 	default n if MCUX_OS_TIMER
 


### PR DESCRIPTION
When os_timer is enabled in dts, then os_timer will be used as OS tick timer.

To make systick as the default OS tick timer, currently os_timer is not enabled in dts. When users want to use os_timer as OS tick timer, they need to override the dts.

Improve the method, enable the os_timer is dts, but not enable in Kconfig by default. If need to use os_timer as OS tick, just pass CONFIG_MCUX_OS_TIMER=y