### PR TITLE
tests: app_dev: ram_context_for_isr: fix irq_num

### DIFF
--- a/tests/application_development/ram_context_for_isr/include/fake_driver.h
+++ b/tests/application_development/ram_context_for_isr/include/fake_driver.h
@@ -13,7 +13,11 @@ extern "C" {
 
 #if CONFIG_TEST_IRQ_NUM == 0
 /* For all the other platforms, use the last available IRQ line for testing. */
-#define TEST_IRQ_NUM (CONFIG_NUM_IRQS - 1)
+#ifdef CONFIG_MULTI_LEVEL_INTERRUPTS
+#define TEST_IRQ_NUM (CONFIG_2ND_LVL_ISR_TBL_OFFSET - 1)
+#else
+#define TEST_IRQ_NUM  (CONFIG_NUM_IRQS - 1)
+#endif
 #else
 #define TEST_IRQ_NUM CONFIG_TEST_IRQ_NUM
 #endif


### PR DESCRIPTION
This commit fixes build issue when multi level interrupts is enabled, define TEST_IRQ_NUM as (CONFIG_2ND_LVL_ISR_TBL_OFFSET - 1)
  - CMSIS/Core/Include/core_cm33.h:2438:15: error: array subscript 24 is above array bounds of volatile uint32_t[16]