### PR TITLE
tests: arch: arm: irq_advanced_features: fix build issue

### DIFF
--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_irq_target_state.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_irq_target_state.c
@@ -9,6 +9,11 @@
 #include <cmsis_core.h>
 
 #if defined(CONFIG_ARM_SECURE_FIRMWARE) && defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+#if CONFIG_2ND_LVL_ISR_TBL_OFFSET > 0
+#define TEST_1ST_LEVEL_INTERRUPTS_MAX (CONFIG_2ND_LVL_ISR_TBL_OFFSET - 1)
+#else
+#define TEST_1ST_LEVEL_INTERRUPTS_MAX (CONFIG_NUM_IRQS - 1)
+#endif
 
 extern irq_target_state_t irq_target_state_set(unsigned int irq, irq_target_state_t target_state);
 extern int irq_target_state_is_secure(unsigned int irq);
@@ -24,7 +29,7 @@ ZTEST(arm_irq_advanced_features, test_arm_irq_target_state)
 	 */
 	int i;
 
-	for (i = CONFIG_NUM_IRQS - 1; i >= 0; i--) {
+	for (i = TEST_1ST_LEVEL_INTERRUPTS_MAX; i >= 0; i--) {
 		if (NVIC_GetEnableIRQ(i) == 0) {
 			/*
 			 * In-use interrupts are automatically enabled by

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
@@ -9,6 +9,12 @@
 #include <cmsis_core.h>
 #include <zephyr/sys/barrier.h>
 
+#if CONFIG_2ND_LVL_ISR_TBL_OFFSET > 0
+#define TEST_1ST_LEVEL_INTERRUPTS_MAX (CONFIG_2ND_LVL_ISR_TBL_OFFSET - 1)
+#else
+#define TEST_1ST_LEVEL_INTERRUPTS_MAX (CONFIG_NUM_IRQS - 1)
+#endif
+
 static volatile int test_flag;
 
 void arm_zero_latency_isr_handler(const void *args)
@@ -39,7 +45,7 @@ ZTEST(arm_irq_advanced_features, test_arm_zero_latency_irqs)
 
 	zassert_false(init_flag, "Test flag not initialized to zero\n");
 
-	for (i = CONFIG_NUM_IRQS - 1; i >= 0; i--) {
+	for (i = TEST_1ST_LEVEL_INTERRUPTS_MAX; i >= 0; i--) {
 		if (NVIC_GetEnableIRQ(i) == 0) {
 			/*
 			 * Interrupts configured statically with IRQ_CONNECT(.)


### PR DESCRIPTION
This commit fixes build issue when multi level interrupts feature is enabled, define new macro TEST_1ST_LEVEL_INTERRUPTS_MAX to support multi level interrupts case.
  - error: array subscript 24 is above array bounds of 'volatile uint32_t[16]' {aka 'volatile unsigned int[16]'} [-Werror=array-bounds])