### PR TITLE
soc: nxp: imx943: set dma tcd queue size

### DIFF
--- a/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m33
+++ b/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m33
@@ -47,4 +47,7 @@ config SYS_CLOCK_TICKS_PER_SEC
 
 endif
 
+configdefault DMA_TCD_QUEUE_SIZE
+	default 4
+
 endif # SOC_MIMX94398_M33

--- a/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m7_0
+++ b/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m7_0
@@ -49,4 +49,7 @@ config SYS_CLOCK_TICKS_PER_SEC
 
 endif
 
+configdefault DMA_TCD_QUEUE_SIZE
+	default 4
+
 endif # SOC_MIMX94398_M7_0

--- a/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m7_1
+++ b/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m7_1
@@ -49,4 +49,7 @@ config SYS_CLOCK_TICKS_PER_SEC
 
 endif
 
+configdefault DMA_TCD_QUEUE_SIZE
+	default 4
+
 endif # SOC_MIMX94398_M7_1


### PR DESCRIPTION
Set dma tcd queue size to 4 defaultly