### PR TITLE
bluetooth: mesh: lpn shouldn't relay messages received over friendship

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -924,10 +924,13 @@ void bt_mesh_net_recv(struct net_buf_simple *data, int8_t rssi,
 	}
 
 	/* Relay if this was a group/virtual address, or if the destination
-	 * was neither a local element nor an LPN we're Friends for.
+	 * was neither a local element nor an LPN we're Friends for, and
+	 * device is not in Friendship as the Low Power node or the message is not encrypted using
+	 * friendship security credentials.
 	 */
-	if (!BT_MESH_ADDR_IS_UNICAST(rx.ctx.recv_dst) ||
-	    (!rx.local_match && !rx.friend_match)) {
+	if ((!BT_MESH_ADDR_IS_UNICAST(rx.ctx.recv_dst) ||
+	    (!rx.local_match && !rx.friend_match)) &&
+	    (!bt_mesh_lpn_established() || !rx.friend_cred)) {
 		net_buf_simple_restore(&buf, &state);
 		bt_mesh_net_relay(&buf, &rx, false);
 	}


### PR DESCRIPTION
Commit fixes the issue when lpn device relays broad- and group cast messages received over friendship queue. This is specification violation, see Table 3.13: Network layer Network PDU retransmission requirements. Also, it does not have sense since sending messages have already happened and lpn just consumes extra power to retransmit useless data. In general, lpn device will be more power efficient after this fix.