### PR TITLE
net: core: Verify interface state in net_try_send_data()

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -384,6 +384,11 @@ int net_try_send_data(struct net_pkt *pkt, k_timeout_t timeout)
 		goto err;
 	}
 
+	if (!net_if_is_up(net_pkt_iface(pkt))) {
+		ret = -ENETDOWN;
+		goto err;
+	}
+
 	net_pkt_trim_buffer(pkt);
 	net_pkt_cursor_init(pkt);
 


### PR DESCRIPTION
Verify that the interface is in operational UP state before attempting to send the packet with `net_send_data()` / `net_try_send_data()`.

So far there's only been an NET_IF_LOWER_UP check in a lower level function, `net_if_try_send_data()`, however that didn't work well with interface like Wi-Fi, which could have carrier state set to ON, but was still not associated with the network (so the interface was not operational UP). Protocols like ICMP or DHCP, which use `net_send_data()` directly, should not be able to send packets in such case.