### PR TITLE
manifest: update hal_nordic to have fix for nRF53/91 NS errata handling

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 564e754139944286208f3eac122781cec4262392
+      revision: pull/329/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Updated hal_nordic revision contains a fix in nrfx to properly address errata handling in nRF53 and nRF91 Series non-secure builds.