### PR TITLE
soc: nordic: common: gppi_init: Move initialization earlier

### DIFF
--- a/soc/nordic/common/gppi_init.c
+++ b/soc/nordic/common/gppi_init.c
@@ -9,7 +9,7 @@
 #include <soc/interconnect/nrfx_gppi_lumos.h>
 #endif
 
-static int gppi_init(void)
+static int _gppi_init(void)
 {
 	static nrfx_gppi_t gppi_instance;
 
@@ -55,5 +55,5 @@ static int gppi_init(void)
 }
 
 #if defined(CONFIG_NRFX_GPPI) && !defined(CONFIG_NRFX_GPPI_V1)
-SYS_INIT(gppi_init, PRE_KERNEL_1, 0);
+SYS_INIT(_gppi_init, EARLY, 0);
 #endif


### PR DESCRIPTION
GPPI initialization shall be executed as early as possible. Add _ prefix to the initialization function to reduce chances that other function calls uninitialized GPPI.