### PR TITLE
bluetooth: buf: Fix callback protection for ISR context

### DIFF
--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -196,15 +196,22 @@ struct net_buf *bt_buf_get_rx(enum bt_buf_type type, k_timeout_t timeout);
  * @ref bt_buf_get_rx function. However, this callback is called from the context of the buffer
  * freeing operation and must not attempt to allocate a new buffer from the same pool.
  *
- * @warning When this callback is called, the scheduler is locked and the callee must not perform
- * any action that makes the current thread unready. This callback must only be used for very
- * short non-blocking operation (e.g. submitting a work item).
+ * This callback must only be used for very short non-blocking operations (e.g. submitting a work
+ * item). When called from thread context, the scheduler is locked during execution and the
+ * callee must not perform any action that makes the current thread unready. When called from ISR
+ * context, the callback runs without scheduler lock.
+ *
+ * @funcprops \isr_ok
  *
  * @param type_mask A bit mask of buffer types that have been freed.
  */
 typedef void (*bt_buf_rx_freed_cb_t)(enum bt_buf_type type_mask);
 
 /** Set the callback to notify about freed buffer in the incoming data pool.
+ *
+ * It's safe to call this inside the callback itself.
+ *
+ * @funcprops \isr_ok
  *
  * @param cb Callback to notify about freed buffer in the incoming data pool. If NULL, the callback
  *           is disabled.


### PR DESCRIPTION
Fix assertion failure when buf_rx_freed_notify() is called from ISR by replacing k_sched_lock with atomic_ptr operations for callback pointer access.

The scheduler lock is retained during callback execution in thread context to maintain backward compatibility, but is skipped in ISR context where it's not available.

Updated documentation to clarify the behavior difference between thread and ISR contexts.