### PR TITLE
drivers: gpio: gpio_pca_series: fix unresponsive gpio_pca_series

### DIFF
--- a/drivers/gpio/gpio_pca_series.c
+++ b/drivers/gpio/gpio_pca_series.c
@@ -1757,6 +1757,10 @@ out:
 		int_status = sys_le32_to_cpu(int_status);
 		gpio_fire_callbacks(&data->callbacks, dev, int_status);
 	}
+
+	if (gpio_pin_get_dt(&cfg->gpio_int) == 1) {
+		k_work_submit(&data->int_work);
+	}
 }
 
 static void gpio_pca_series_interrupt_worker_standard(struct k_work *work)


### PR DESCRIPTION
The gpio_pca_series driver may stop responding if the gpio_int is asserted between reading the interrupt status and clearing it. If the interrupt gpio_int is not deasserted by the time the handler finishes, the interrupt work should be rescheduled.