### PR TITLE
soc: silabs: siwx91x: clean sys clock definition for the siwx91x soc

### DIFF
--- a/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a.dts
+++ b/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a.dts
@@ -85,6 +85,10 @@
 	};
 };
 
+&cpu0 {
+	clock-frequency = <180000000>;
+};
+
 &ulpuart {
 	pinctrl-0 = <&ulpuart_default>;
 	pinctrl-names = "default";

--- a/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a_defconfig
+++ b/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a_defconfig
@@ -1,7 +1,6 @@
 # Copyright (c) 2025 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=180000000
 CONFIG_USE_DT_CODE_PARTITION=y
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y

--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
@@ -77,6 +77,10 @@
 	};
 };
 
+&cpu0 {
+	clock-frequency = <180000000>;
+};
+
 &ulpuart {
 	pinctrl-0 = <&ulpuart_default>;
 	pinctrl-names = "default";

--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a_defconfig
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a_defconfig
@@ -1,7 +1,6 @@
 # Copyright (c) 2024 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=180000000
 CONFIG_USE_DT_CODE_PARTITION=y
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y

--- a/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
@@ -78,6 +78,10 @@
 	};
 };
 
+&cpu0 {
+	clock-frequency = <180000000>;
+};
+
 &ulpuart {
 	pinctrl-0 = <&ulpuart_default>;
 	pinctrl-names = "default";

--- a/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a_defconfig
+++ b/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a_defconfig
@@ -1,7 +1,6 @@
 # Copyright (c) 2025 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=180000000
 CONFIG_USE_DT_CODE_PARTITION=y
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y

--- a/drivers/clock_control/clock_control_silabs_siwx91x.c
+++ b/drivers/clock_control/clock_control_silabs_siwx91x.c
@@ -245,10 +245,12 @@ static int siwx91x_clock_init(const struct device *dev)
 	sl_si91x_clock_manager_init();
 
 	/* Use SoC PLL at configured frequency as core clock */
-	sl_si91x_clock_manager_m4_set_core_clk(M4_SOCPLLCLK, CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
+	sl_si91x_clock_manager_m4_set_core_clk(M4_SOCPLLCLK,
+					       DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency));
 
 	/* Use interface PLL at configured frequency as peripheral clock */
-	sl_si91x_clock_manager_set_pll_freq(INFT_PLL, CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
+	sl_si91x_clock_manager_set_pll_freq(INFT_PLL,
+					    DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency),
 					    PLL_REF_CLK_VAL_XTAL);
 
 	/* FIXME: Currently the clock consumer use clocks without power on them.

--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -6,6 +6,10 @@ if SOC_FAMILY_SILABS_SIWX91X
 configdefault CORTEX_M_SYSTICK
 	default n if SILABS_SLEEPTIMER_TIMER
 
+configdefault SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
+	default 32768
+
 configdefault SYS_CLOCK_TICKS_PER_SEC
 	default 128 if !TICKLESS_KERNEL && SILABS_SLEEPTIMER_TIMER
 	default 1024 if SILABS_SLEEPTIMER_TIMER

--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -10,9 +10,11 @@ configdefault SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
 	default 32768
 
+# WiseConnect create threads with realtime priority. Default (10kHz) clock tick
+# prevent proper use of the system with these threads.
 configdefault SYS_CLOCK_TICKS_PER_SEC
 	default 128 if !TICKLESS_KERNEL && SILABS_SLEEPTIMER_TIMER
-	default 1024 if SILABS_SLEEPTIMER_TIMER
+	default 1024 if SILABS_SLEEPTIMER_TIMER || SILABS_SIWX91X_NWP
 
 configdefault UART_NS16550_DW8250_DW_APB
 	default y
@@ -34,11 +36,6 @@ configdefault POWER_DOMAIN
 endif # PM_DEVICE
 
 if SILABS_SIWX91X_NWP
-
-# WiseConnect create threads with realtime priority. Default (10kHz) clock tick
-# prevent proper use of the system with these threads.
-config SYS_CLOCK_TICKS_PER_SEC
-	default 1024
 
 # Wiseconnect needs more than 1024 bytes of main stack size to initialize
 # (especially with PM)


### PR DESCRIPTION
This PR removes the definition of  ```SYS_CLOCK_HW_CYCLES_PER_SEC``` in the board defconfig and defined it from the dts in soc defconfig.
It also gathered all default definitions of ```of SYS_CLOCK_TICKS_PER_SEC``` and put it at the same place. 
