### PR TITLE
soc: nxp: mcxw23: increase system workque stack size when BT

### DIFF
--- a/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/mcxw2xx/Kconfig.defconfig
@@ -34,6 +34,9 @@ config BT_LONG_WQ_STACK_SIZE
 config MAIN_STACK_SIZE
 	default 2048
 
+config SYSTEM_WORKQUEUE_STACK_SIZE
+	default 2048
+
 endif # BT
 
 endif # SOC_SERIES_MCXW2XX


### PR DESCRIPTION
Fix sysworkq stack overflow in various bluetooth samples due to using mbedtls for crypto.