### PR TITLE
drivers: ethernet: eth_lan9250: Support MAC address config

### DIFF
--- a/drivers/ethernet/eth_lan9250_priv.h
+++ b/drivers/ethernet/eth_lan9250_priv.h
@@ -8,6 +8,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/net/ethernet.h>
 
 #ifndef _LAN9250_
 #define _LAN9250_
@@ -312,6 +313,7 @@ struct lan9250_config {
 	struct gpio_dt_spec reset;
 	uint8_t full_duplex;
 	int32_t timeout;
+	struct net_eth_mac_config mac_cfg;
 };
 
 struct lan9250_runtime {


### PR DESCRIPTION
Update the microchip,lan9250 ethernet driver to use a MAC address configuration struct.