### PR TITLE
Add a Dom0 helper for deassigning DT-based devices from a Xen guest domain

### DIFF
--- a/drivers/xen/dom0/domctl.c
+++ b/drivers/xen/dom0/domctl.c
@@ -240,6 +240,21 @@ int xen_domctl_assign_dt_device(int domid, char *dtdev_path)
 
 }
 
+int xen_domctl_deassign_dt_device(int domid, char *dtdev_path)
+{
+	xen_domctl_t domctl = {
+		.domain = domid,
+		.cmd = XEN_DOMCTL_deassign_device,
+		.u.assign_device.flags = 0,
+		.u.assign_device.dev = XEN_DOMCTL_DEV_DT,
+		.u.assign_device.u.dt.size = strlen(dtdev_path),
+	};
+
+	set_xen_guest_handle(domctl.u.assign_device.u.dt.path, dtdev_path);
+
+	return do_domctl(&domctl);
+}
+
 int xen_domctl_bind_pt_irq(int domid, uint32_t machine_irq, uint8_t irq_type,
 		uint8_t bus, uint8_t device, uint8_t intx, uint8_t isa_irq,
 		uint16_t spi)

--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -176,6 +176,16 @@ int xen_domctl_memory_mapping(int domid, uint64_t first_gfn, uint64_t first_mfn,
 int xen_domctl_assign_dt_device(int domid, char *dtdev_path);
 
 /**
+ * @brief Deassign a device from a guest domain.
+ *
+ * @param domid The ID of the domain from which the device should be deassigned.
+ * @param dtdev_path The path of the device tree device to be deassigned.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
+int xen_domctl_deassign_dt_device(int domid, char *dtdev_path);
+
+/**
  * @brief Binds a physical IRQ to a specified domain.
  *
  * Only supports SPI IRQs for now.


### PR DESCRIPTION
This complements the existing xen_domctl_assign_dt_device() helper by exposing the XEN_DOMCTL_deassign_device domctl for Device Tree devices, allowing Dom0 to cleanly revoke a previously assigned device.

**Implementation details**

- Add xen_domctl_deassign_dt_device() in drivers/xen/dom0/domctl.c:
  - Initializes xen_domctl_t with cmd = XEN_DOMCTL_deassign_device.
  - Uses XEN_DOMCTL_DEV_DT and sets u.assign_device.u.dt.size based on the DT path length.
  - Uses set_xen_guest_handle() to point to the DT path and calls do_domctl().
- Declare the new helper and document its semantics in include/zephyr/xen/dom0/domctl.h.

**Rationale**

  - Provides a symmetric API to xen_domctl_assign_dt_device() for DT devices.
  - Makes it possible for Zephyr-based Dom0 code to explicitly deassign passthrough devices without re-implementing the domctl call.

**Testing**

- Built Zephyr that is running under Xen as Dom0 with this change.
- Verified device assignment and subsequent deassignment via xen_domctl_assign_dt_device() / xen_domctl_deassign_dt_device() in a Xen + Zephyr Dom0
    environment.