### PR TITLE
dts: bindings: usb: Fix max3421e compatible to use hyphen word separator

### DIFF
--- a/boards/shields/max3421e/sparkfun_max3421e.overlay
+++ b/boards/shields/max3421e/sparkfun_max3421e.overlay
@@ -11,7 +11,7 @@
 	cs-gpios = <&arduino_header ARDUINO_HEADER_R3_D10 GPIO_ACTIVE_LOW>;
 
 	zephyr_uhc0: max3421e@0 {
-		compatible = "maxim,max3421e_spi";
+		compatible = "maxim,max3421e-spi";
 		spi-max-frequency = <26000000>;
 		int-gpios = <&arduino_header ARDUINO_HEADER_R3_D9 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&arduino_header ARDUINO_HEADER_R3_D7 GPIO_ACTIVE_LOW>;

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -110,6 +110,11 @@ STM32
 
   * ``CONFIG_POWER_SUPPLY_EXTERNAL_SOURCE``
 
+USB
+===
+
+  * :dtcompatible:`maxim,max3421e_spi` has been renamed to :dtcompatible:`maxim,max3421e-spi`.
+
 .. zephyr-keep-sorted-stop
 
 Bluetooth

--- a/drivers/usb/uhc/Kconfig.max3421e
+++ b/drivers/usb/uhc/Kconfig.max3421e
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_UHC_MAX3421E := maxim,max3421e_spi
+DT_COMPAT_UHC_MAX3421E := maxim,max3421e-spi
 
 config UHC_MAX3421E
 	bool "MAX3421E driver"

--- a/dts/bindings/usb/maxim,max3421e-spi.yaml
+++ b/dts/bindings/usb/maxim,max3421e-spi.yaml
@@ -4,7 +4,7 @@
 description: |
     MAX3421E USB Peripheral/Host Controller controller with SPI interface
 
-compatible: "maxim,max3421e_spi"
+compatible: "maxim,max3421e-spi"
 
 include: [spi-device.yaml]
 

--- a/tests/drivers/build_all/usb/spi_devices.overlay
+++ b/tests/drivers/build_all/usb/spi_devices.overlay
@@ -32,7 +32,7 @@
 				   <&test_gpio 0 0>;
 
 			max3421e_spi: max3421e_spi@0 {
-				compatible = "maxim,max3421e_spi";
+				compatible = "maxim,max3421e-spi";
 				reg = <0>;
 				spi-max-frequency = <5000000>;
 				int-gpios = <&test_gpio 0 0>;


### PR DESCRIPTION
Fixes the max3421e devicetree compatible to follow the convention of using a hyphen rather than an underscore as the word separator.