### PR TITLE
modules: Bump lora-basics-modem to v4.9.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -307,7 +307,7 @@ manifest:
         - fs
       revision: 8f5ca347843363882619d8f96c00d8dbd88a8e79
     - name: lora-basics-modem
-      revision: 9a14f6772c1d6e303bacb2d594c8063bb804b6ee
+      revision: a8ddc544043e72807cf7db532478e1dda734ae7c
       path: modules/lib/lora-basics-modem
     - name: loramac-node
       revision: fb00b383072518c918e2258b0916c996f2d4eebe


### PR DESCRIPTION
Bump `lora-basics-modem` module to v4.9.0.