### PR TITLE
modules: hostap: Fix connection failed with TLS cipher RSA3K

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -885,7 +885,8 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 						goto out;
 					}
 				} else if (params->TLS_cipher == WIFI_EAP_TLS_RSA_3K) {
-					snprintf(phase1, sizeof(phase1), "tls_suiteb=1");
+					snprintf(phase1, sizeof(phase1), "tls_suiteb=1 "
+						 "tls_disable_tlsv1_3=1");
 					if (!wpa_cli_cmd_v("set_network %d phase1 \"%s\"",
 							resp.network_id, &phase1[0])) {
 						goto out;


### PR DESCRIPTION
The TLS cipher RSA3K ciphersuites ECDHE-RSA-AES256-GCM-SHA384 and DHE-RSA-AES256-GCM-SHA384 only support TLS1.2, but TLS1.3 enabled, version check failed in ssl_tls13_validate_peer_ciphersuite during parse client hello.
Disable TLS1.3 for TLS cipher RSA3K to fix this issue.