### PR TITLE
boards: sifli: sf32lb52_devkit_lcd: enable reset

### DIFF
--- a/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.dts
+++ b/boards/sifli/sf32lb52_devkit_lcd/sf32lb52_devkit_lcd.dts
@@ -85,6 +85,10 @@
 	};
 };
 
+&rcc_rst {
+	status = "okay";
+};
+
 &gpioa_00_31 {
 	status = "okay";
 };


### PR DESCRIPTION
Enable reset on sf32lb52_devkit_lcd board