### PR TITLE
soc: nordic: nrf_sys_event: handle errors correctly

### DIFF
--- a/soc/nordic/common/nrf_sys_event.c
+++ b/soc/nordic/common/nrf_sys_event.c
@@ -76,12 +76,20 @@ int nrf_sys_event_release_global_constlat(void)
 
 int nrf_sys_event_request_global_constlat(void)
 {
-	return nrfx_power_constlat_mode_request();
+	int err;
+
+	err = nrfx_power_constlat_mode_request();
+
+	return (err == 0 || err == -EALREADY) ? 0 : -EAGAIN;
 }
 
 int nrf_sys_event_release_global_constlat(void)
 {
-	return nrfx_power_constlat_mode_free();
+	int err;
+
+	err = nrfx_power_constlat_mode_free();
+
+	return (err == 0 || err == -EBUSY) ? 0 : -EAGAIN;
 }
 
 #endif


### PR DESCRIPTION
nrfx_power_constlat API returns negative value if the requested action has no effect, which is expected in cases of multiple requests/releases. Align nrf_sys_event to not treat it as an error.

Essentially, restored the code from before nrfx 4.0.1 alignment but with updated error codes.