### PR TITLE
drivers: adc: siwx91x: Silabs siwx91x adc ref voltage support

### DIFF
--- a/drivers/adc/adc_silabs_siwx91x.c
+++ b/drivers/adc/adc_silabs_siwx91x.c
@@ -378,13 +378,16 @@ static void adc_siwx91x_isr(const struct device *dev)
 	}
 }
 
-static DEVICE_API(adc, adc_siwx91x_driver_api) = {
-	.channel_setup = adc_siwx91x_channel_setup,
-	.read = adc_siwx91x_read,
-};
+#define ADC_SIWX91X_DRIVER_API(inst)                                                               \
+	static DEVICE_API(adc, adc_siwx91x_driver_api_##inst) = {                                  \
+		.channel_setup = adc_siwx91x_channel_setup,                                        \
+		.read = adc_siwx91x_read,                                                          \
+		.ref_internal = DT_INST_PROP(inst, silabs_adc_ref_voltage),                        \
+	};
 
 #define SIWX91X_ADC_INIT(inst)                                                                     \
 	PINCTRL_DT_INST_DEFINE(inst);                                                              \
+	ADC_SIWX91X_DRIVER_API(inst);                                                              \
                                                                                                    \
 	static struct adc_siwx91x_chan_data adc_chan_data_##inst[DT_CHILD_NUM(DT_DRV_INST(inst))]; \
                                                                                                    \
@@ -414,6 +417,7 @@ static DEVICE_API(adc, adc_siwx91x_driver_api) = {
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, adc_siwx91x_init, NULL, &adc_data_##inst, &adc_cfg_##inst,     \
-			      PRE_KERNEL_1, CONFIG_ADC_INIT_PRIORITY, &adc_siwx91x_driver_api);
+			      PRE_KERNEL_1, CONFIG_ADC_INIT_PRIORITY,                              \
+			      &adc_siwx91x_driver_api_##inst);
 
 DT_INST_FOREACH_STATUS_OKAY(SIWX91X_ADC_INIT)

--- a/drivers/adc/adc_silabs_siwx91x.c
+++ b/drivers/adc/adc_silabs_siwx91x.c
@@ -333,12 +333,6 @@ int16_t adc_siwx91x_read_data(const struct device *dev)
 		adc_temp = 0;
 	}
 
-	if (adc_temp >= 2048) {
-		adc_temp = adc_temp - 2048;
-	} else {
-		adc_temp = adc_temp + 2048;
-	}
-
 	return adc_temp;
 }
 

--- a/samples/drivers/adc/adc_dt/boards/siwx917_rb4338a.overlay
+++ b/samples/drivers/adc/adc_dt/boards/siwx917_rb4338a.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+	};
+};
+
+&pinctrl0 {
+	adc0_default: adc0_default {
+		group {
+			pinmux = <AGPIO_ULP1>;
+		};
+	};
+};
+
+&adc0 {
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	silabs,adc-ref-voltage = <3300>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <0>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <10>;
+	};
+	status = "okay";
+};


### PR DESCRIPTION
1. Add ref_internal to the device API.
2. Instead of returning a converted ADC reading, return the
raw ADC sample. Conversion is left to the user based on
the selected ADC mode (single-ended or differential).
3. Add adc_dt support for siwx917_rb4338a

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/100211