### PR TITLE
code of conduct: change the title from the template

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Contributor Covenant Code of Conduct
+# Zephyr Project Code of Conduct
 
 ## Our Pledge
 


### PR DESCRIPTION
Change the Code of Conduct title from the one used in the template to reflect that this is the Code of Conduct for the Zephyr Project, not the Contributor Covenant project.

The attribution for the Contributor Covenant template is present at the very last paragraph.