### PR TITLE
Add i2s test with block_size of 4 or 8 bytes

### DIFF
--- a/drivers/i2s/i2s_nrf_tdm.c
+++ b/drivers/i2s/i2s_nrf_tdm.c
@@ -32,6 +32,11 @@ LOG_MODULE_REGISTER(tdm_nrf, CONFIG_I2S_LOG_LEVEL);
  */
 #define NRFX_TDM_STATUS_TRANSFER_STOPPED BIT(1)
 
+/* Due to hardware limitations, the TDM peripheral requires the rx/tx size
+ * to be greater than 8 bytes.
+ */
+#define NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED 8
+
 /* Maximum clock divider value. Corresponds to CKDIV2. */
 #define NRFX_TDM_MAX_SCK_DIV_VALUE TDM_CONFIG_SCK_DIV_SCKDIV_Max
 #define NRFX_TDM_MAX_MCK_DIV_VALUE TDM_CONFIG_MCK_DIV_DIV_Max
@@ -475,9 +480,11 @@ static int tdm_nrf_configure(const struct device *dev, enum i2s_dir dir,
 
 	__ASSERT_NO_MSG(tdm_cfg->mem_slab != NULL && tdm_cfg->block_size != 0);
 
-	if ((tdm_cfg->block_size % sizeof(uint32_t)) != 0) {
-		LOG_ERR("This device can transfer only full 32-bit words");
-		return -EINVAL;
+	if ((tdm_cfg->block_size % sizeof(uint32_t)) != 0 ||
+		tdm_cfg->block_size <= NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED) {
+		LOG_ERR("This device can only transmit full 32-bit words greater than %u bytes.",
+			NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED);
+		return -EIO;
 	}
 
 	switch (tdm_cfg->word_size) {
@@ -673,11 +680,18 @@ static int tdm_nrf_write(const struct device *dev, void *mem_block, size_t size)
 		return -EIO;
 	}
 
-	if (size > drv_data->tx.cfg.block_size || size < sizeof(uint32_t)) {
+	if (size > drv_data->tx.cfg.block_size) {
 		LOG_ERR("This device can only write blocks up to %u bytes",
 			drv_data->tx.cfg.block_size);
 		return -EIO;
 	}
+
+	if ((size % sizeof(uint32_t)) != 0 || size <= NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED) {
+		LOG_ERR("This device can only write full 32-bit words greater than %u bytes.",
+			NRFX_TDM_MIN_TRANSFER_SIZE_ALLOWED);
+		return -EIO;
+	}
+
 	ret = dmm_buffer_out_prepare(drv_cfg->mem_reg, buf.mem_block, buf.size,
 				     (void **)&buf.dmm_buf);
 	ret = k_msgq_put(&drv_data->tx_queue, &buf, SYS_TIMEOUT_MS(drv_data->tx.cfg.timeout));

--- a/tests/drivers/i2s/i2s_additional/Kconfig
+++ b/tests/drivers/i2s/i2s_additional/Kconfig
@@ -142,9 +142,23 @@ config I2S_TEST_FRAME_CLK_INV_UNSUPPORTED
 	  When set to 'y', test will check that i2s_configure() returns -EINVAL.
 	  When set to 'n', test will do the transmission.
 
+config I2S_TEST_BLOCK_SIZE_4_UNSUPPORTED
+	bool "Block_size of 4 bytes is not supported by the driver"
+	default y if DT_HAS_NORDIC_NRF_TDM_ENABLED
+	help
+	  When set to 'y', test will check that i2s_configure() returns -EINVAL.
+	  When set to 'n', test will do the transmission.
+
 config I2S_TEST_BLOCK_SIZE_6_UNSUPPORTED
-	bool "Block_size of 6 is not supported by the driver"
+	bool "Block_size of 6 bytes is not supported by the driver"
 	default y if DT_HAS_NORDIC_NRF_I2S_ENABLED || DT_HAS_NORDIC_NRF_TDM_ENABLED
+	help
+	  When set to 'y', test will check that i2s_configure() returns -EINVAL.
+	  When set to 'n', test will do the transmission.
+
+config I2S_TEST_BLOCK_SIZE_8_UNSUPPORTED
+	bool "Block_size of 8 bytes is not supported by the driver"
+	default y if DT_HAS_NORDIC_NRF_TDM_ENABLED
 	help
 	  When set to 'y', test will check that i2s_configure() returns -EINVAL.
 	  When set to 'n', test will do the transmission.

--- a/tests/drivers/i2s/i2s_additional/src/main.c
+++ b/tests/drivers/i2s/i2s_additional/src/main.c
@@ -748,15 +748,53 @@ ZTEST(i2s_additional, test_05b_format_frame_clk_inv)
 #endif
 }
 
+/** @brief Test I2S transfer with block_size set to 4.
+ */
+ZTEST(i2s_additional, test_06a_block_size_4)
+{
+	struct i2s_config i2s_cfg = default_i2s_cfg;
+
+	i2s_cfg.block_size = 4;
+	i2s_cfg.word_size = 8;
+
+#if defined(CONFIG_I2S_TEST_BLOCK_SIZE_4_UNSUPPORTED)
+	int ret;
+
+	ret = i2s_configure(dev_i2s, I2S_DIR_TX, &i2s_cfg);
+	zassert_equal(ret, -EINVAL, "Unexpected result %d", ret);
+#else
+	i2s_dir_both_transfer_long(&i2s_cfg);
+#endif
+}
+
 /** @brief Test I2S transfer with block_size set to 6.
  */
-ZTEST(i2s_additional, test_06_block_size_6)
+ZTEST(i2s_additional, test_06b_block_size_6)
 {
 	struct i2s_config i2s_cfg = default_i2s_cfg;
 
 	i2s_cfg.block_size = 6;
 
 #if defined(CONFIG_I2S_TEST_BLOCK_SIZE_6_UNSUPPORTED)
+	int ret;
+
+	ret = i2s_configure(dev_i2s, I2S_DIR_TX, &i2s_cfg);
+	zassert_equal(ret, -EINVAL, "Unexpected result %d", ret);
+#else
+	i2s_dir_both_transfer_long(&i2s_cfg);
+#endif
+}
+
+/** @brief Test I2S transfer with block_size set to 8.
+ */
+ZTEST(i2s_additional, test_06c_block_size_8)
+{
+	struct i2s_config i2s_cfg = default_i2s_cfg;
+
+	i2s_cfg.block_size = 8;
+	i2s_cfg.word_size = 8;
+
+#if defined(CONFIG_I2S_TEST_BLOCK_SIZE_8_UNSUPPORTED)
 	int ret;
 
 	ret = i2s_configure(dev_i2s, I2S_DIR_TX, &i2s_cfg);


### PR DESCRIPTION
Add test that validates I2S driver when buffer with audio samples has small size.