### PR TITLE
doc: generation: bump up known-good Doxygen and Latexmk versions

### DIFF
--- a/doc/contribute/documentation/generation.rst
+++ b/doc/contribute/documentation/generation.rst
@@ -76,9 +76,9 @@ Installing the documentation processors
 
 Our documentation processing has been tested to run with:
 
-* Doxygen version 1.8.13
+* Doxygen version 1.15.0
 * Graphviz 2.43
-* Latexmk version 4.56
+* Latexmk version 4.83
 * All Python dependencies listed in the repository file
   ``doc/requirements.txt``
 


### PR DESCRIPTION
The `Documentation Generation` page listed a severely outdated "known-good" version for Doxygen (1.8.13) which is no longer correct: recent attempts to build the documentation using 1.9.1 failed miserably.

Update the minimum version to 1.15.0 which matches the version used by the Zephyr-build Docker image, also used as part of CI, to ensure that what we document as "known-good" is indeed a configuration known to work.

Following the same logic, bump up the known-good version of Latexmk to 4.80 which should match the version found in the Docker image. Even though some older versions (such as 4.76) are also working, this documentation page is informative rather than authoritative, so it's fine to not document the exact minimum version required but merely a version that is known to work.

The Graphviz version is untouched as it seems to match the Docker image.


(see also: #98082)