### PR TITLE
drivers: clock_control: sf32lb: fix GPTIM2 clock rate

### DIFF
--- a/drivers/clock_control/clock_control_sf32lb_rcc.c
+++ b/drivers/clock_control/clock_control_sf32lb_rcc.c
@@ -287,9 +287,11 @@ int clock_control_sf32lb_rcc_get_rate(const struct device *dev, clock_control_su
 	case SF32LB52X_CLOCK_GPADC:
 	case SF32LB52X_CLOCK_TSEN:
 	case SF32LB52X_CLOCK_GPTIM1:
-	case SF32LB52X_CLOCK_GPTIM2:
 	case SF32LB52X_CLOCK_ATIM1:
 		*rate = sf32lb_get_pclk1(config);
+		return 0;
+	case SF32LB52X_CLOCK_GPTIM2:
+		*rate = 24000000U;
 		return 0;
 	case SF32LB52X_CLOCK_BTIM1:
 	case SF32LB52X_CLOCK_BTIM2:


### PR DESCRIPTION
Fix GPTIM2 clock rate