### PR TITLE
tests: drivers: spi: loopback: wait for idle before timed test

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -359,7 +359,13 @@ ZTEST(spi_loopback, test_spi_complete_multiple_timed)
 	 */
 	zassert_ok(pm_device_runtime_get(spec->bus));
 
-	/* since this is a test program, there shouldn't be much to interfere with measurement */
+	/*
+	 * since this is a test program, there shouldn't be much to interfere with measurement.
+	 * still let's wait for the console to complete printing so it does not complete and
+	 * suspend near the end of the spi transaction.
+	 */
+	k_msleep(10);
+
 	start_time = k_cycle_get_32();
 	spi_loopback_transceive(spec, &tx, &rx, 2);
 	end_time = k_cycle_get_32();


### PR DESCRIPTION
During the SPI loopback timed test, an unfortunate timing of the UART console printing these lines
```
===================================================================
START - test_spi_complete_multiple_timed
```
completed near the end of the spi transaction, which introduced additional latency into the measurement as the test thread was blocked until the UART was suspended:
```
===================================================================
START - test_spi_complete_multiple_timed
Transfer took 1230 us vs theoretical minimum 54 us
Latency measurement: 1176 us

    Assertion failed at WEST_TOPDIR/zephyr/tests/drivers/spi/spi_loopback/src/spi.c:367: spi_loopback_test_spi_complete_multiple_timed: (time_spent_us <= expected_transfer_time_us * CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING is false)
Very high latency
 FAIL - test_spi_complete_multiple_timed in 0.035 seconds
```
Adding a short delay before the test makes it way more likely the UART console is idle before performing the timed SPI transfer:
```
	/*
	 * since this is a test program, there shouldn't be much to interfere with measurement.
	 * still let's wait for the console to complete printing so it does not complete and
	 * suspend near the end of the spi transaction.
	 */
	k_msleep(10);
```
Now the test succeed every time:
```
 ===================================================================
START - test_spi_complete_multiple_timed
Transfer took 1431 us vs theoretical minimum 864 us
Latency measurement: 567 us
 PASS - test_spi_complete_multiple_timed in 0.021 seconds
```