### PR TITLE
arm: ethos_u: Add Timing Adapter devicetree binding, driver support, and sample overlays

### DIFF
--- a/drivers/misc/ethos_u/ethos_u_arm.c
+++ b/drivers/misc/ethos_u/ethos_u_arm.c
@@ -9,12 +9,145 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/util.h>
+
 #include <ethosu_driver.h>
 
 #include "ethos_u_common.h"
 
+#include <stdint.h>
+#include <stdbool.h>
+#include <inttypes.h>
+
 #define DT_DRV_COMPAT arm_ethos_u
 LOG_MODULE_REGISTER(arm_ethos_u, CONFIG_ETHOS_U_LOG_LEVEL);
+
+#define TA_MAXR_MASK     0x3Fu
+#define TA_MAXW_MASK     0x3Fu
+#define TA_MAXRW_MASK    0x3Fu
+#define TA_RLATENCY_MASK 0xFFFu
+#define TA_WLATENCY_MASK 0xFFFu
+#define TA_PULSE_MASK    0xFFFFu
+#define TA_BWCAP_MASK    0xFFFFu
+#define TA_PERFCTRL_MASK 0x3Fu
+#define TA_MODE_MASK     0xFFFu
+#define TA_HISTBIN_MASK  0xFu
+
+#define TA_VERSION_UNSPECIFIED UINT32_MAX
+#define TA_VERSION_1_1_23      0x1117u
+
+/* Register offsets */
+#define TA_MAXR      0x00
+#define TA_MAXW      0x04
+#define TA_MAXRW     0x08
+#define TA_RLATENCY  0x0C
+#define TA_WLATENCY  0x10
+#define TA_PULSE_ON  0x14
+#define TA_PULSE_OFF 0x18
+#define TA_BWCAP     0x1C
+#define TA_PERFCTRL  0x20
+#define TA_PERFCNT   0x24
+#define TA_MODE      0x28
+#define TA_HISTBIN   0x30
+#define TA_HISTCNT   0x34
+#define TA_VERSION   0x38
+
+struct ethosu_ta_cfg {
+	uintptr_t base;     /* MMIO base for the TA block */
+	uint32_t version;   /* Optional: expected TA version (validation/logging) */
+	uint32_t maxr;      /* 6-bit: max pending reads (0 = infinite) */
+	uint32_t maxw;      /* 6-bit: max pending writes (0 = infinite) */
+	uint32_t maxrw;     /* 6-bit: max combined R+W (0 = infinite) */
+	uint32_t rlatency;  /* 12-bit: read latency (cycles) */
+	uint32_t wlatency;  /* 12-bit: write latency (cycles) */
+	uint32_t pulse_on;  /* 16-bit: burst pulse ON cycles */
+	uint32_t pulse_off; /* 16-bit: burst pulse OFF cycles */
+	uint32_t bwcap;     /* 16-bit: bandwidth cap (bus words / window; 0 = no cap) */
+	uint32_t perfctrl;  /* 6-bit: perf control */
+	uint32_t perfcnt;   /* 32-bit: perf counter preload/reset */
+	uint32_t mode;      /* Mode bits (0..11). Bit 0 enables dynamic clocking. */
+	uint32_t histbin;   /* 0..15: histogram bin selector */
+	uint32_t histcnt;   /* 32-bit: histogram bin value */
+};
+
+#define TA_CFG_FROM_NODE(n)                                                                        \
+	{                                                                                          \
+		.base = DT_REG_ADDR(n),                                                            \
+		.version = DT_PROP_OR(n, version, TA_VERSION_UNSPECIFIED),                         \
+		.maxr = DT_PROP_OR(n, maxr, 0u),                                                   \
+		.maxw = DT_PROP_OR(n, maxw, 0u),                                                   \
+		.maxrw = DT_PROP_OR(n, maxrw, 0u),                                                 \
+		.rlatency = DT_PROP_OR(n, rlatency, 0u),                                           \
+		.wlatency = DT_PROP_OR(n, wlatency, 0u),                                           \
+		.pulse_on = DT_PROP_OR(n, pulse_on, 0u),                                           \
+		.pulse_off = DT_PROP_OR(n, pulse_off, 0u),                                         \
+		.bwcap = DT_PROP_OR(n, bwcap, 0u),                                                 \
+		.perfctrl = DT_PROP_OR(n, perfctrl, 0u),                                           \
+		.perfcnt = DT_PROP_OR(n, perfcnt, 0u),                                             \
+		.mode = DT_PROP_OR(n, mode, 1u),                                                   \
+		.histbin = DT_PROP_OR(n, histbin, 0u),                                             \
+		.histcnt = DT_PROP_OR(n, histcnt, 0u),                                             \
+	}
+
+#define TA_CFG_IF_COMPAT(n)                                                                        \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(n, arm_axi_timing_adapter), (TA_CFG_FROM_NODE(n)), ())
+
+/* clang-format off */
+#define ETHOSU_TA_CFGS(inst)                                                                       \
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_DRV_INST(inst), TA_CFG_IF_COMPAT, (,))
+/* clang-format on */
+
+static const struct ethosu_ta_cfg g_ta_cfgs[] = {ETHOSU_TA_CFGS(0)};
+
+static bool ethosu_ta_version_supported(uint32_t version)
+{
+	switch (version) {
+	case TA_VERSION_1_1_23:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static inline void ethosu_ta_apply(const struct ethosu_ta_cfg *c)
+{
+	if ((c == NULL) || (c->base == 0U)) {
+		return;
+	}
+
+	const uintptr_t base = c->base;
+	const uint32_t hw_version = sys_read32(base + TA_VERSION);
+
+	if (!ethosu_ta_version_supported(hw_version)) {
+		LOG_ERR("TA@0x%08" PRIxPTR " has unsupported version 0x%08x", base, hw_version);
+		return;
+	}
+
+	if ((c->version != TA_VERSION_UNSPECIFIED) && (c->version != hw_version)) {
+		LOG_WRN("TA@0x%08" PRIxPTR " version mismatch: DT=0x%08x HW=0x%08x", base,
+			c->version, hw_version);
+	}
+
+	LOG_DBG("TA base=0x%08" PRIxPTR " ver=0x%08x maxr=%u maxw=%u maxrw=%u rlat=%u wlat=%u "
+		"pulse_on=%u pulse_off=%u bwcap=%u perfctrl=%u perfcnt=0x%08x mode=%u "
+		"histbin=%u histcnt=%u",
+		base, hw_version, c->maxr, c->maxw, c->maxrw, c->rlatency, c->wlatency, c->pulse_on,
+		c->pulse_off, c->bwcap, c->perfctrl, c->perfcnt, c->mode, c->histbin, c->histcnt);
+	sys_write32((c->maxr & TA_MAXR_MASK), base + TA_MAXR);
+	sys_write32((c->maxw & TA_MAXW_MASK), base + TA_MAXW);
+	sys_write32((c->maxrw & TA_MAXRW_MASK), base + TA_MAXRW);
+	sys_write32((c->rlatency & TA_RLATENCY_MASK), base + TA_RLATENCY);
+	sys_write32((c->wlatency & TA_WLATENCY_MASK), base + TA_WLATENCY);
+	sys_write32((c->pulse_on & TA_PULSE_MASK), base + TA_PULSE_ON);
+	sys_write32((c->pulse_off & TA_PULSE_MASK), base + TA_PULSE_OFF);
+	sys_write32((c->bwcap & TA_BWCAP_MASK), base + TA_BWCAP);
+	sys_write32((c->perfctrl & TA_PERFCTRL_MASK), base + TA_PERFCTRL);
+	sys_write32(c->perfcnt, base + TA_PERFCNT);
+	sys_write32((c->mode & TA_MODE_MASK), base + TA_MODE);
+	sys_write32((c->histbin & TA_HISTBIN_MASK), base + TA_HISTBIN);
+	sys_write32(c->histcnt, base + TA_HISTCNT);
+}
 
 /* DT helpers: use fast-memory-region if present; else NULL/0. */
 #define ETHOSU_FAST_BASE(n)                                                                        \
@@ -51,6 +184,10 @@ static int ethosu_zephyr_init(const struct device *dev)
 
 	LOG_DBG("Version. major=%u, minor=%u, patch=%u", version.major, version.minor,
 		version.patch);
+	for (size_t i = 0; i < ARRAY_SIZE(g_ta_cfgs); ++i) {
+		LOG_DBG("TA[%zu] base=0x%08" PRIxPTR, i, g_ta_cfgs[i].base);
+		ethosu_ta_apply(&g_ta_cfgs[i]);
+	}
 
 	if (ethosu_init(drv, config->base_addr, config->fast_mem_base, config->fast_mem_size,
 			config->secure_enable, config->privilege_enable)) {

--- a/dts/bindings/arm/arm,axi-timing-adapter.yaml
+++ b/dts/bindings/arm/arm,axi-timing-adapter.yaml
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: <text>Copyright 2025-2026 Arm Limited and/or
+# its affiliates <open-source-office@arm.com></text>
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "arm,axi-timing-adapter"
+
+include: base.yaml
+
+description: |
+  The timing adapter is an AXI-to-AXI bridge for providing well-defined
+  memory timing to allow performance evaluation of an AXI master. The
+  bridge works by delaying the responses from the memory or, when
+  enabled, clock-gating the DUT to simulate faster access times as
+  observed from the DUT, according to run-time configurable parameters
+  that can be set in the timing adapter. Parameters include read and
+  write response latencies, number of outstanding transactions, and a
+  model of interfering traffic.
+
+  - Common tuning parameters (most users will adjust these):
+    - maxr, maxw, maxrw
+    - rlatency, wlatency
+    - pulse-on, pulse-off
+    - bwcap
+
+  - Other parameters are available for completeness or specialized use
+    (e.g. mode, performance counters, histograms). They are typically
+    left at defaults.
+
+  - Performance counter: When measuring from outside the NPU, the
+    performance counter can be used to count DUT clock-off cycles.
+    See timing_adapter_perfctrl_settings in the official driver:
+    https://gitlab.arm.com/artificial-intelligence/ethos-u/
+    ethos-u-core-platform/-/blob/main/drivers/timing_adapter/
+    include/timing_adapter.h
+
+properties:
+  reg:
+    type: array
+    required: true
+    description: TA base address
+
+  # Optional hardware/RTL version (for info/logging)
+  version:
+    type: int
+    description: Optional TA block version (informational).
+
+  # --- Common tuning parameters ---
+  maxr:
+    type: int
+    description: |
+      6-bit. Maximum number of pending read operations allowed.
+      0 is inferred as infinite. [Common tuning parameter]
+
+  maxw:
+    type: int
+    description: |
+      6-bit. Maximum number of pending write operations allowed.
+      0 is inferred as infinite. [Common tuning parameter]
+
+  maxrw:
+    type: int
+    description: |
+      6-bit. Maximum number of pending read and write operations combined.
+      0 is inferred as infinite. [Common tuning parameter]
+
+  rlatency:
+    type: int
+    description: |
+      12-bit. Minimum latency, in cycles, for a read operation.
+      This is the duration between ARVALID and RVALID signals.
+      [Common tuning parameter]
+
+  wlatency:
+    type: int
+    description: |
+      12-bit. Minimum latency, in cycles, for a write operation.
+      This is the duration between WVALID and WLAST, with BVALID being deasserted.
+      [Common tuning parameter]
+
+  pulse-on:
+    type: int
+    description: |
+      Number of cycles where addresses are let through
+      in a pulse window (0-65535). [Common tuning parameter]
+
+  pulse-off:
+    type: int
+    description: |
+      Number of cycles where addresses are blocked
+      in a pulse window (0-65535). [Common tuning parameter]
+
+  bwcap:
+    type: int
+    description: >
+      16-bit. Maximum number of bus words transferred per pulse cycle.
+      A pulse cycle is defined by pulse-on and pulse-off. 0 is inferred as infinite.
+      A bus word is 64 bits on Ethos-U55, and 128 bits on Ethos-U65/U85.
+      [Common tuning parameter]
+
+  # --- Other parameters (typically left at defaults) ---
+  perfctrl:
+    type: int
+    description: |
+      6-bit event selector for the performance counter.
+      Commonly used to count DUT clock-on/off cycles when profiling from
+      outside the NPU. See the official driver's timing_adapter_perfctrl_settings
+      for enumerated values.
+
+  perfcnt:
+    type: int
+    description: |
+      32-bit performance counter preload/reset value.
+      Optional preload before measurement; read back after the run when
+      perfctrl is configured (e.g. to count DUT clock-off cycles).
+
+  mode:
+    type: int
+    description: |
+      Timing adapter operation mode (bits 0-11).
+      On FVP only bit 0 is implemented; other bits are ignored/reserved.
+      Bit 0 controls dynamic clocking:
+        0 = static clocking (no dynamic adjustment).
+        1 = dynamic clocking enabled to avoid underrun (recommended).
+      Bit 1: 1 = enable random AR reordering (0 = default).
+      Bit 2: 1 = enable random R reordering (0 = default).
+      Bit 3: 1 = enable random B reordering (0 = default).
+
+  histbin:
+    type: int
+    description: Histogram bin selector (0-15).
+
+  histcnt:
+    type: int
+    description: Histogram bin value (32-bit).

--- a/samples/modules/tflite-micro/tflm_ethosu/README.rst
+++ b/samples/modules/tflite-micro/tflm_ethosu/README.rst
@@ -150,3 +150,33 @@ compact, machine-parseable style:
    ethosu_pmu_cntr2 : 111744
    ethosu_pmu_cntr3 : 0
    # (if supported, counters 4..7 are also printed.)
+
+
+Timing Adapters (TA)
+********************
+
+The timing adapters allows the platform to simulate user provided memory
+bandwidth and latency constraints on platforms that support it (FVP/FPGA).
+This sample does **not** auto-add overlays; apply a TA overlay explicitly with
+``-DDTC_OVERLAY_FILE=...``.
+
+For a full overview of TA behavior, controls, and usage guidance, see the
+`Evaluation Kit documentation: Timing Adapters <https://gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit/-/blob/main/docs/sections/timing_adapters.md>`_.
+
+TA overlay only (Corstone-320)
+------------------------------
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/modules/tflite-micro/tflm_ethosu
+   :board: mps4/corstone320/fvp
+   :goals: run
+   :gen-args: -DDTC_OVERLAY_FILE=boards/mps4_corstone320_fvp.ta.overlay
+
+TA overlay only (Corstone-300)
+------------------------------
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/modules/tflite-micro/tflm_ethosu
+   :board: mps3/corstone300/fvp
+   :goals: run
+   :gen-args: -DDTC_OVERLAY_FILE=boards/mps3_corstone300_fvp.ta.overlay

--- a/samples/modules/tflite-micro/tflm_ethosu/boards/mps3_corstone300_fvp.ta.overlay
+++ b/samples/modules/tflite-micro/tflm_ethosu/boards/mps3_corstone300_fvp.ta.overlay
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright 2025 Arm Limited and/or its
+ * affiliates <open-source-office@arm.com></text>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ethosu0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/*
+	 * Corstone-300 FVP: TAs on AXI ports (SRAM, Flash/DRAM)
+	 * Vela: System_Config.Ethos_U55_High_End_Embedded
+	 * (core_clock=500 MHz, SRAM=4 GB/s, Flash=0.5 GB/s)
+	 */
+
+	ta0: timing-adapter@48103000 {
+		compatible = "arm,axi-timing-adapter";
+		reg = <0x48103000>;
+		status = "okay";
+
+		version = <0x1117>;
+		maxr = <8>;
+		maxw = <8>;
+		maxrw = <0>;
+		rlatency = <32>;
+		wlatency = <32>;
+		pulse-on = <3999>;
+		pulse-off = <1>;
+		bwcap = <4000>;
+		mode = <1>;
+		perfctrl = <0>;
+		perfcnt = <0>;
+		histbin = <0>;
+		histcnt = <0>;
+	};
+
+	ta1: timing-adapter@48103200 {
+		compatible = "arm,axi-timing-adapter";
+		reg = <0x48103200>;
+		status = "okay";
+
+		version = <0x1117>;
+		maxr = <2>;
+		maxw = <0>;
+		maxrw = <0>;
+		rlatency = <64>;
+		wlatency = <0>;
+		pulse-on = <320>;
+		pulse-off = <80>;
+		bwcap = <50>;
+		mode = <1>;
+		perfctrl = <0>;
+		perfcnt = <0>;
+		histbin = <0>;
+		histcnt = <0>;
+	};
+};

--- a/samples/modules/tflite-micro/tflm_ethosu/boards/mps4_corstone320_fvp.ta.overlay
+++ b/samples/modules/tflite-micro/tflm_ethosu/boards/mps4_corstone320_fvp.ta.overlay
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright 2025 Arm Limited and/or its
+ * affiliates <open-source-office@arm.com></text>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ethosu0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/*
+	 * Corstone-320 FVP: TAs on AXI ports (SRAM, DRAM)
+	 * Vela: System_Config.Ethos_U85_SYS_DRAM_High
+	 * (core_clock=1 GHz, SRAMx4=64 GB/s, DRAMx2=24 GB/s)
+	 */
+
+	ta0: timing-adapter@50006000 {
+		compatible = "arm,axi-timing-adapter";
+		reg = <0x50006000>;
+		status = "okay";
+
+		version = <0x1117>;
+		maxr = <8>;
+		maxw = <8>;
+		maxrw = <0>;
+		rlatency = <32>;
+		wlatency = <32>;
+		pulse-on = <3999>;
+		pulse-off = <1>;
+		bwcap = <4000>;
+		mode = <1>;
+		perfctrl = <0>;
+		perfcnt = <0>;
+		histbin = <0>;
+		histcnt = <0>;
+	};
+
+	ta1: timing-adapter@50006800 {
+		compatible = "arm,axi-timing-adapter";
+		reg = <0x50006800>;
+		status = "okay";
+
+		version = <0x1117>;
+		maxr = <64>;
+		maxw = <32>;
+		maxrw = <0>;
+		rlatency = <500>;
+		wlatency = <250>;
+		pulse-on = <4000>;
+		pulse-off = <1000>;
+		bwcap = <3750>;
+		mode = <1>;
+		perfctrl = <0>;
+		perfcnt = <0>;
+		histbin = <0>;
+		histcnt = <0>;
+	};
+};


### PR DESCRIPTION
Adds support for AXI Timing Adapters for Ethos-U based platforms.

- New devicetree binding: arm,axi-timing-adapter
- Ethos-U driver configures TA child nodes at init
- Sample overlays added for Corstone-300/320 to model memory timing on FVP

Tested on Corstone-300/320 FVP builds. No impact on platforms not using TAs.
