### PR TITLE
dts: arm: st: n6: add nodes for USB2 instance

### DIFF
--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1241,10 +1241,31 @@
 			status = "disabled";
 		};
 
+		usbotg_hs2: otghs@58080000 {
+			compatible = "st,stm32n6-otghs", "st,stm32-otghs";
+			reg = <0x58080000 0x2000>;
+			interrupts = <178 0>;
+			interrupt-names = "otghs";
+			num-bidir-endpoints = <9>;
+			ram-size = <4096>;
+			maximum-speed = "high-speed";
+			clocks = <&rcc STM32_CLOCK(AHB5, 29)>,
+				 <&rcc STM32_SRC_HSE OTGPHY2CKREF_SEL(1)>;
+			phys = <&usbphyc2>;
+			status = "disabled";
+		};
+
 		usbphyc1: usbphyc@5803fc00 {
 			compatible = "st,stm32-usbphyc";
 			reg = <0x5803FC00 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB5, 27)>;
+			#phy-cells = <0>;
+		};
+
+		usbphyc2: usbphyc@580c0000 {
+			compatible = "st,stm32-usbphyc";
+			reg = <0x580c0000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB5, 28)>;
 			#phy-cells = <0>;
 		};
 


### PR DESCRIPTION
Even though the USB driver does not support multi-instance yet, out-of-tree or custom boards may want to use the `USB2` instance instead of `USB1`, which is not currently possible because its node is not declared.

Add missing `USBOTGHS2` and corresponding `USBPHYC2` nodes to STM32N6 series root DTSI file.

Fixes #92933.

(Note that proper operation of the port has not been validated because Nucleo-N657X0 lacks it entirely, and STM32N6570-DK has it hardwired as host port but there is no STM32 UHC driver in Zephyr)