### PR TITLE
stm32: use lowercase hex for properties in Devicetree

### DIFF
--- a/boards/st/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.dts
@@ -197,9 +197,9 @@ zephyr_udc0: &usbotg_fs {
 		};
 
 		/* scratch slot: 256KB */
-		scratch_partition: partition@C0000 {
+		scratch_partition: partition@c0000 {
 			label = "image-scratch";
-			reg = <0x000C0000 DT_SIZE_K(256)>;
+			reg = <0x000c0000 DT_SIZE_K(256)>;
 		};
 	};
 };

--- a/boards/st/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/st/nucleo_f767zi/nucleo_f767zi.dts
@@ -264,9 +264,9 @@ zephyr_udc0: &usbotg_fs {
 		/*
 		 * Allocated 1 (256k) sector for image-scratch. Sector 11.
 		 */
-		scratch_partition: partition@1C0000 {
+		scratch_partition: partition@1c0000 {
 			label = "image-scratch";
-			reg = <0x001C0000 DT_SIZE_K(256)>;
+			reg = <0x001c0000 DT_SIZE_K(256)>;
 		};
 	};
 };

--- a/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -210,14 +210,14 @@ zephyr_udc0: &usb {
 			read-only;
 		};
 
-		slot0_partition: partition@C000 {
+		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 DT_SIZE_K(200)>;
+			reg = <0x0000c000 DT_SIZE_K(200)>;
 		};
 
-		slot1_partition: partition@3E000 {
+		slot1_partition: partition@3e000 {
 			label = "image-1";
-			reg = <0x0003E000 DT_SIZE_K(200)>;
+			reg = <0x0003e000 DT_SIZE_K(200)>;
 		};
 
 		/* final 64KiB reserved for app storage partition */

--- a/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -199,9 +199,9 @@ zephyr_udc0: &usbotg_fs {
 		#size-cells = <1>;
 
 		/* Reserve last 16KiB for property storage */
-		storage_partition: partition@1FB000 {
+		storage_partition: partition@1fb000 {
 			label = "storage";
-			reg = <0x001FB000 DT_SIZE_K(16)>;
+			reg = <0x001fb000 DT_SIZE_K(16)>;
 		};
 	};
 };

--- a/boards/st/sensortile_box/sensortile_box.dts
+++ b/boards/st/sensortile_box/sensortile_box.dts
@@ -235,12 +235,12 @@ zephyr_udc0: &usbotg_fs {
 
 		slot1_partition: partition@8c000 {
 			label = "image-1";
-			reg = <0x0008C000 DT_SIZE_K(432)>;
+			reg = <0x0008c000 DT_SIZE_K(432)>;
 		};
 
 		scratch_partition: partition@f8000 {
 			label = "image-scratch";
-			reg = <0x000F8000 DT_SIZE_K(24)>;
+			reg = <0x000f8000 DT_SIZE_K(24)>;
 		};
 
 		storage_partition: partition@fc000 {

--- a/boards/st/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/st/stm32f0_disco/stm32f0_disco.dts
@@ -136,7 +136,7 @@
 
 		scratch_partition: partition@c000 {
 			label = "image-scratch";
-			reg = <0x0000C000 DT_SIZE_K(16)>;
+			reg = <0x0000c000 DT_SIZE_K(16)>;
 		};
 	};
 };

--- a/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -269,9 +269,9 @@
 		vfront-porch = <4>;
 	};
 
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
+	def-back-color-red = <0xff>;
+	def-back-color-green = <0xff>;
+	def-back-color-blue = <0xff>;
 };
 
 zephyr_udc0: &usbotg_hs {

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -319,7 +319,7 @@ zephyr_udc0: &usbotg_fs {
 		vfront-porch = <4>;
 	};
 
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
+	def-back-color-red = <0xff>;
+	def-back-color-green = <0xff>;
+	def-back-color-blue = <0xff>;
 };

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -306,7 +306,7 @@ zephyr_udc0: &usbotg_fs {
 		vfront-porch = <4>;
 	};
 
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
+	def-back-color-red = <0xff>;
+	def-back-color-green = <0xff>;
+	def-back-color-blue = <0xff>;
 };

--- a/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
@@ -143,7 +143,7 @@
 					height = <240>;
 					x-offset = <0>;
 					y-offset = <0>;
-					vcom = <0x1F>;
+					vcom = <0x1f>;
 					gctrl = <0x35>;
 					vdvs = <0x20>;
 					mdac = <0x00>;

--- a/boards/st/stm32h750b_dk/stm32h750b_dk-common.dtsi
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk-common.dtsi
@@ -115,9 +115,9 @@
 		vfront-porch = <4>;
 	};
 
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
+	def-back-color-red = <0xff>;
+	def-back-color-green = <0xff>;
+	def-back-color-blue = <0xff>;
 };
 
 &pll {

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -275,9 +275,9 @@ st_cam_i2c: &i2c4 {
 		vfront-porch = <4>;
 	};
 
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
+	def-back-color-red = <0xff>;
+	def-back-color-green = <0xff>;
+	def-back-color-blue = <0xff>;
 };
 
 &octospi1 {

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -348,7 +348,7 @@ zephyr_udc0: &usb2 {};
 		vfront-porch = <8>;
 	};
 
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
+	def-back-color-red = <0xff>;
+	def-back-color-green = <0xff>;
+	def-back-color-blue = <0xff>;
 };

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.dts
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.dts
@@ -40,9 +40,9 @@
 			reg = <0x0 DT_SIZE_M(60)>;
 		};
 
-		slot1_partition: partition@3C00000 {
+		slot1_partition: partition@3c00000 {
 			label = "image-1";
-			reg = <0x3C00000 DT_SIZE_M(60)>;
+			reg = <0x3c00000 DT_SIZE_M(60)>;
 		};
 
 		storage_partition: partition@7800000 {

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -104,7 +104,7 @@
 					height = <240>;
 					x-offset = <0>;
 					y-offset = <0>;
-					vcom = <0x1F>;
+					vcom = <0x1f>;
 					gctrl = <0x35>;
 					vdvs = <0x20>;
 					mdac = <0x00>;

--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -268,9 +268,9 @@ csi_interface: &dcmipp {
 		vfront-porch = <2>;
 	};
 
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
+	def-back-color-red = <0xff>;
+	def-back-color-green = <0xff>;
+	def-back-color-blue = <0xff>;
 };
 
 /*

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -525,9 +525,9 @@ zephyr_udc0: &usbotg_hs1 {
 		vfront-porch = <8>;
 	};
 
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
+	def-back-color-red = <0xff>;
+	def-back-color-green = <0xff>;
+	def-back-color-blue = <0xff>;
 };
 
 csi_interface: &dcmipp {

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -510,7 +510,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FFF756A>;
+		vrefint-cal-addr = <0x1fff756a>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 10>;
 		status = "disabled";

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -500,7 +500,7 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32c0-temp-cal";
-		ts-cal1-addr = <0x1FFF7568>;
+		ts-cal1-addr = <0x1fff7568>;
 		ts-cal1-temp = <30>;
 		ts-cal-vrefanalog = <3000>;
 		avgslope = "2.53";

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -288,7 +288,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 2>;
 			status = "disabled";
@@ -320,7 +320,7 @@
 
 		timers1: timers@40012c00 {
 			compatible = "st,stm32-timers";
-			reg = <0x40012C00 0x400>;
+			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
 			resets = <&rctl STM32_RESET(APB1H, 11)>;

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -227,7 +227,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 2>;
 			status = "disabled";

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -379,7 +379,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FFFF7BA>;
+		vrefint-cal-addr = <0x1ffff7ba>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/f0/stm32f030.dtsi
+++ b/dts/arm/st/f0/stm32f030.dtsi
@@ -13,7 +13,7 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32c0-temp-cal";
-		ts-cal1-addr = <0x1FFFF7B8>;
+		ts-cal1-addr = <0x1ffff7b8>;
 		ts-cal1-temp = <30>;
 		ts-cal-vrefanalog = <3300>;
 		avgslope = "4.3";

--- a/dts/arm/st/f0/stm32f031.dtsi
+++ b/dts/arm/st/f0/stm32f031.dtsi
@@ -44,8 +44,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FFFF7B8>;
-		ts-cal2-addr = <0x1FFFF7C2>;
+		ts-cal1-addr = <0x1ffff7b8>;
+		ts-cal2-addr = <0x1ffff7c2>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -152,7 +152,7 @@
 			compatible = "st,stm32f1-pinctrl";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			reg = <0x40010800 0x1C00>;
+			reg = <0x40010800 0x1c00>;
 
 			gpioa: gpio@40010800 {
 				compatible = "st,stm32-gpio";
@@ -264,7 +264,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -226,7 +226,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -178,7 +178,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -414,8 +414,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FFFF7B8>;
-		ts-cal2-addr = <0x1FFFF7C2>;
+		ts-cal1-addr = <0x1ffff7b8>;
+		ts-cal2-addr = <0x1ffff7c2>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -425,7 +425,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FFFF7BA>;
+		vrefint-cal-addr = <0x1ffff7ba>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 18>;
 		status = "disabled";

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -623,8 +623,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FFF7A2C>;
-		ts-cal2-addr = <0x1FFF7A2E>;
+		ts-cal1-addr = <0x1fff7a2c>;
+		ts-cal2-addr = <0x1fff7a2e>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -232,7 +232,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -634,7 +634,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FFF7A2A>;
+		vrefint-cal-addr = <0x1fff7a2a>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -26,7 +26,7 @@
 		};
 
 		pinctrl: pin-controller@40020000 {
-			reg = <0x40020000 0x2C00>;
+			reg = <0x40020000 0x2c00>;
 
 			gpioj: gpio@40022400 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -943,8 +943,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FF0F44C>;
-		ts-cal2-addr = <0x1FF0F44E>;
+		ts-cal1-addr = <0x1ff0f44c>;
+		ts-cal2-addr = <0x1ff0f44e>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -954,7 +954,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FF0F44A>;
+		vrefint-cal-addr = <0x1ff0f44a>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -198,11 +198,11 @@
 				clocks = <&rcc STM32_CLOCK(AHB1, 2)>;
 			};
 
-			gpiod: gpio@40020C00 {
+			gpiod: gpio@40020c00 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
-				reg = <0x40020C00 0x400>;
+				reg = <0x40020c00 0x400>;
 				clocks = <&rcc STM32_CLOCK(AHB1, 3)>;
 			};
 
@@ -230,11 +230,11 @@
 				clocks = <&rcc STM32_CLOCK(AHB1, 6)>;
 			};
 
-			gpioh: gpio@40021C00 {
+			gpioh: gpio@40021c00 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
-				reg = <0x40021C00 0x400>;
+				reg = <0x40021c00 0x400>;
 				clocks = <&rcc STM32_CLOCK(AHB1, 7)>;
 			};
 
@@ -255,7 +255,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";

--- a/dts/arm/st/f7/stm32f722.dtsi
+++ b/dts/arm/st/f7/stm32f722.dtsi
@@ -44,8 +44,8 @@
 	};
 
 	die_temp: dietemp {
-		ts-cal1-addr = <0x1FF07A2C>;
-		ts-cal2-addr = <0x1FF07A2E>;
+		ts-cal1-addr = <0x1ff07a2c>;
+		ts-cal2-addr = <0x1ff07a2e>;
 	};
 
 	vref: vref {

--- a/dts/arm/st/f7/stm32f722.dtsi
+++ b/dts/arm/st/f7/stm32f722.dtsi
@@ -49,6 +49,6 @@
 	};
 
 	vref: vref {
-		vrefint-cal-addr = <0x1FF07A2A>;
+		vrefint-cal-addr = <0x1ff07a2a>;
 	};
 };

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -25,7 +25,7 @@
 		compatible = "st,stm32f745", "st,stm32f7", "simple-bus";
 
 		pinctrl: pin-controller@40020000 {
-			reg = <0x40020000 0x2C00>;
+			reg = <0x40020000 0x2c00>;
 
 			gpioj: gpio@40022400 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -27,7 +27,7 @@
 		compatible = "st,stm32f765", "st,stm32f7", "simple-bus";
 
 		pinctrl: pin-controller@40020000 {
-			reg = <0x40020000 0x2C00>;
+			reg = <0x40020000 0x2c00>;
 
 			gpioj: gpio@40022400 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -530,8 +530,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FFF75A8>;
-		ts-cal2-addr = <0x1FFF75CA>;
+		ts-cal1-addr = <0x1fff75a8>;
+		ts-cal2-addr = <0x1fff75ca>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -232,7 +232,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 2>;
 			status = "disabled";
@@ -269,7 +269,7 @@
 
 		timers1: timers@40012c00 {
 			compatible = "st,stm32-timers";
-			reg = <0x40012C00 0x400>;
+			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 11)>,
 				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
 			resets = <&rctl STM32_RESET(APB1H, 11)>;

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -541,7 +541,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FFF75AA>;
+		vrefint-cal-addr = <0x1fff75aa>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 13>;
 		status = "disabled";

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -327,7 +327,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -792,7 +792,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FFF75AA>;
+		vrefint-cal-addr = <0x1fff75aa>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 18>;
 		status = "disabled";

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -781,8 +781,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FFF75A8>;
-		ts-cal2-addr = <0x1FFF75CA>;
+		ts-cal1-addr = <0x1fff75a8>;
+		ts-cal2-addr = <0x1fff75ca>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -665,7 +665,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x08FFF810>;
+		vrefint-cal-addr = <0x08fff810>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -219,11 +219,11 @@
 				clocks = <&rcc STM32_CLOCK(AHB4, 2)>;
 			};
 
-			gpiod: gpio@58020C00 {
+			gpiod: gpio@58020c00 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
-				reg = <0x58020C00 0x400>;
+				reg = <0x58020c00 0x400>;
 				clocks = <&rcc STM32_CLOCK(AHB4, 3)>;
 			};
 
@@ -251,11 +251,11 @@
 				clocks = <&rcc STM32_CLOCK(AHB4, 6)>;
 			};
 
-			gpioh: gpio@58021C00 {
+			gpioh: gpio@58021c00 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
-				reg = <0x58021C00 0x400>;
+				reg = <0x58021c00 0x400>;
 				clocks = <&rcc STM32_CLOCK(AHB4, 7)>;
 			};
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1237,8 +1237,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FF1E820>;
-		ts-cal2-addr = <0x1FF1E840>;
+		ts-cal1-addr = <0x1ff1e820>;
+		ts-cal2-addr = <0x1ff1e840>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1255,7 +1255,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FF1E860>;
+		vrefint-cal-addr = <0x1ff1e860>;
 		vrefint-cal-mv = <3300>;
 		vrefint-cal-resolution = <16>;
 		status = "disabled";

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -125,9 +125,9 @@
 	};
 
 	/* System data RAM accessible over AXI bus: AXI SRAM3 in CD domain */
-	sram2: memory@240A0000 {
+	sram2: memory@240a0000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x240A0000 DT_SIZE_K(384)>;
+		reg = <0x240a0000 DT_SIZE_K(384)>;
 		zephyr,memory-region = "SRAM2";
 	};
 

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -184,7 +184,7 @@
 	};
 
 	vref: vref {
-		vrefint-cal-addr = <0x08FFF810>;
+		vrefint-cal-addr = <0x08fff810>;
 		io-channels = <&adc2 19>;
 	};
 

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -177,8 +177,8 @@
 	};
 
 	die_temp: dietemp {
-		ts-cal1-addr = <0x08FFF814>;
-		ts-cal2-addr = <0x08FFF818>;
+		ts-cal1-addr = <0x08fff814>;
+		ts-cal2-addr = <0x08fff818>;
 		io-channels = <&adc2 18>;
 		ts-cal2-temp = <130>;
 	};

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -266,11 +266,11 @@
 				clocks = <&rcc STM32_CLOCK(AHB4, 2)>;
 			};
 
-			gpiod: gpio@58020C00 {
+			gpiod: gpio@58020c00 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
-				reg = <0x58020C00 0x400>;
+				reg = <0x58020c00 0x400>;
 				clocks = <&rcc STM32_CLOCK(AHB4, 3)>;
 			};
 

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1012,8 +1012,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x08FFF814>;
-		ts-cal2-addr = <0x08FFF818>;
+		ts-cal1-addr = <0x08fff814>;
+		ts-cal2-addr = <0x08fff818>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -354,8 +354,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FF8007A>;
-		ts-cal2-addr = <0x1FF8007E>;
+		ts-cal1-addr = <0x1ff8007a>;
+		ts-cal2-addr = <0x1ff8007e>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -365,7 +365,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FF80078>;
+		vrefint-cal-addr = <0x1ff80078>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -209,7 +209,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 2>;
 			status = "disabled";

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -591,7 +591,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FF800F8>;
+		vrefint-cal-addr = <0x1ff800f8>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -557,7 +557,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -580,8 +580,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FF800FA>;
-		ts-cal2-addr = <0x1FF800FE>;
+		ts-cal1-addr = <0x1ff800fa>;
+		ts-cal2-addr = <0x1ff800fe>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -556,8 +556,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FFF75A8>;
-		ts-cal2-addr = <0x1FFF75CA>;
+		ts-cal1-addr = <0x1fff75a8>;
+		ts-cal2-addr = <0x1fff75ca>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -567,7 +567,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FFF75AA>;
+		vrefint-cal-addr = <0x1fff75aa>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 0>;
 		status = "disabled";

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -217,7 +217,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -268,7 +268,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 6>;
 			status = "disabled";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -840,7 +840,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x0BFA05AA>;
+		vrefint-cal-addr = <0x0bfa05aa>;
 		vrefint-cal-mv = <3000>;
 		io-channels = <&adc1 0>;
 		status = "disabled";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -829,8 +829,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x0BFA05A8>;
-		ts-cal2-addr = <0x0BFA05CA>;
+		ts-cal1-addr = <0x0bfa05a8>;
+		ts-cal2-addr = <0x0bfa05ca>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -45,7 +45,7 @@
 		sysram: memory@2ffe0000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
 			zephyr,memory-region = "SYSRAM";
-			reg = <0x2FFE0000 DT_SIZE_K(128)>;
+			reg = <0x2ffe0000 DT_SIZE_K(128)>;
 		};
 
 		uart4: serial@40010000 {
@@ -153,7 +153,7 @@
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			#address-cells = <0>;
-			reg = <0x5000D000 0x400>;
+			reg = <0x5000d000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB3_S, 0)>;
 			num-lines = <96>;
 			interrupts = <GIC_SPI 6 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -275,25 +275,25 @@
 		};
 	};
 
-	gic: gic@A0021000 {
+	gic: gic@a0021000 {
 		compatible = "arm,gic-v2", "arm,gic";
-		reg = <0xA0021000 0x1000>,
-		      <0xA0022000 0x2000>;
+		reg = <0xa0021000 0x1000>,
+		      <0xa0022000 0x2000>;
 		interrupt-controller;
 		#interrupt-cells = <4>;
 		status = "okay";
 	};
 
-	ddr_code: memory@C0000000 {
+	ddr_code: memory@c0000000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "DDR_CODE";
-		reg = <0xC0000000 0x10000000>;
+		reg = <0xc0000000 0x10000000>;
 	};
 
-	ddr_data: memory@D0000000 {
+	ddr_data: memory@d0000000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "DDR_DATA";
-		reg = <0xD0000000 0x10000000>;
+		reg = <0xd0000000 0x10000000>;
 	};
 
 	clocks {

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -420,7 +420,7 @@
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
-				reg = <0x56023C00 0x400>;
+				reg = <0x56023c00 0x400>;
 				clocks = <&rcc STM32_CLOCK(AHB4, 15)>;
 			};
 
@@ -475,7 +475,7 @@
 
 		fdcan1: can@5000a000 {
 			compatible = "st,stm32h7-fdcan";
-			reg = <0x5000A000 0x400>, <0x5000C000 0xd54>;
+			reg = <0x5000a000 0x400>, <0x5000c000 0xd54>;
 			reg-names = "m_can", "message_ram";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 8)>;
 			interrupts = <180 0>, <181 0>, <186 0>;
@@ -486,7 +486,7 @@
 
 		fdcan2: can@5000a400 {
 			compatible = "st,stm32h7-fdcan";
-			reg = <0x5000A400 0x400>, <0x5000C000 0x1aa8>;
+			reg = <0x5000a400 0x400>, <0x5000c000 0x1aa8>;
 			reg-names = "m_can", "message_ram";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 8)>;
 			interrupts = <182 0>, <183 0>;
@@ -497,7 +497,7 @@
 
 		fdcan3: can@5000e800 {
 			compatible = "st,stm32h7-fdcan";
-			reg = <0x5000E800 0x400>, <0x5000C000 0x2800>;
+			reg = <0x5000e800 0x400>, <0x5000c000 0x2800>;
 			reg-names = "m_can", "message_ram";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 8)>;
 			interrupts = <184 0>, <185 0>;
@@ -535,7 +535,7 @@
 
 		uart4: serial@50004c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
-			reg = <0x50004C00 0x400>;
+			reg = <0x50004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1L, 19)>;
 			interrupts = <162 0>;
@@ -571,7 +571,7 @@
 
 		uart8: serial@50007c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
-			reg = <0x50007C00 0x400>;
+			reg = <0x50007c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			resets = <&rctl STM32_RESET(APB1L, 31)>;
 			interrupts = <166 0>;
@@ -589,7 +589,7 @@
 
 		usart10: serial@52001c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
-			reg = <0x52001C00 0x400>;
+			reg = <0x52001c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 7)>;
 			resets = <&rctl STM32_RESET(APB2, 7)>;
 			interrupts = <168 0>;
@@ -625,7 +625,7 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x50005C00 0x400>;
+			reg = <0x50005c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <104 0>, <105 0>;
 			interrupt-names = "event", "error";
@@ -637,7 +637,7 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x56001C00 0x400>;
+			reg = <0x56001c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB4, 7)>;
 			interrupts = <106 0>, <107 0>;
 			interrupt-names = "event", "error";
@@ -694,7 +694,7 @@
 			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x50003C00 0x400>;
+			reg = <0x50003c00 0x400>;
 			interrupts = <155 0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			status = "disabled";
@@ -1216,7 +1216,7 @@
 
 		xspi2: spi@5802a000 {
 			compatible = "st,stm32-xspi";
-			reg = <0x5802A000 0x1000>, <0x70000000 DT_SIZE_M(256)>;
+			reg = <0x5802a000 0x1000>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <171 0>;
 			clock-names = "xspix", "xspi-ker", "xspi-mgr";
 			clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
@@ -1243,7 +1243,7 @@
 
 		usbphyc1: usbphyc@5803fc00 {
 			compatible = "st,stm32-usbphyc";
-			reg = <0x5803FC00 0x400>;
+			reg = <0x5803fc00 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB5, 27)>;
 			#phy-cells = <0>;
 		};
@@ -1293,7 +1293,7 @@
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x52005C04 0x20>;
+			reg = <0x52005c04 0x20>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
 			dmas = <&gpdma1 3 93 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
 				STM32_DMA_16BITS)>;
@@ -1304,7 +1304,7 @@
 			compatible = "st,stm32-sai";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x52005C24 0x20>;
+			reg = <0x52005c24 0x20>;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
 			dmas = <&gpdma1 2 94 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
 				STM32_DMA_16BITS)>;

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -188,11 +188,11 @@
 				clocks = <&rcc STM32_CLOCK(IOP, 2)>;
 			};
 
-			gpiod: gpio@50000C00 {
+			gpiod: gpio@50000c00 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
-				reg = <0x50000C00 0x400>;
+				reg = <0x50000c00 0x400>;
 				clocks = <&rcc STM32_CLOCK(IOP, 3)>;
 			};
 
@@ -428,7 +428,7 @@
 
 		timers1: timers@40012c00 {
 			compatible = "st,stm32-timers";
-			reg = <0x40012C00 0x400>;
+			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 11)>,
 				 <&rcc STM32_SRC_PCLK TIM1_SEL(0)>;
 			resets = <&rctl STM32_RESET(APB1H, 11)>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -1015,8 +1015,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x0BFA0710>;
-		ts-cal2-addr = <0x0BFA0742>;
+		ts-cal1-addr = <0x0bfa0710>;
+		ts-cal2-addr = <0x0bfa0742>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -1027,7 +1027,7 @@
 
 	vref1: vref_1 {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x0BFA07A5>;
+		vrefint-cal-addr = <0x0bfa07a5>;
 		vrefint-cal-mv = <3000>;
 		vrefint-cal-resolution = <14>;
 		io-channels = <&adc1 0>;
@@ -1036,7 +1036,7 @@
 
 	vref4: vref_4 {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x0BFA07A5>;
+		vrefint-cal-addr = <0x0bfa07a5>;
 		vrefint-cal-mv = <3000>;
 		vrefint-cal-resolution = <14>;
 		io-channels = <&adc4 0>;

--- a/dts/arm/st/u5/stm32u599.dtsi
+++ b/dts/arm/st/u5/stm32u599.dtsi
@@ -29,7 +29,7 @@
 			compatible = "st,stm32u5-mipi-dsi", "st,stm32-mipi-dsi";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x40016C00 0x1000>;
+			reg = <0x40016c00 0x1000>;
 			clock-names = "dsiclk", "dsisrc", "refclk", "pixelclk";
 			clocks = <&rcc STM32_CLOCK(APB2, 27U)>,
 				 <&rcc STM32_SRC_DSIPHY DSI_SEL(1)>,

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -564,8 +564,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FFF75A8>;
-		ts-cal2-addr = <0x1FFF75CA>;
+		ts-cal1-addr = <0x1fff75a8>;
+		ts-cal2-addr = <0x1fff75ca>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -249,7 +249,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -575,7 +575,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FFF75AA>;
+		vrefint-cal-addr = <0x1fff75aa>;
 		vrefint-cal-mv = <3600>;
 		io-channels = <&adc1 0>;
 		status = "disabled";

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -300,7 +300,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";

--- a/dts/arm/st/wba/stm32wba52.dtsi
+++ b/dts/arm/st/wba/stm32wba52.dtsi
@@ -11,7 +11,7 @@
 	};
 
 	die_temp: dietemp {
-		ts-cal1-addr = <0x0BF90710>;
-		ts-cal2-addr = <0x0BF90742>;
+		ts-cal1-addr = <0x0bf90710>;
+		ts-cal2-addr = <0x0bf90742>;
 	};
 };

--- a/dts/arm/st/wba/stm32wba65.dtsi
+++ b/dts/arm/st/wba/stm32wba65.dtsi
@@ -133,8 +133,8 @@
 	};
 
 	die_temp: dietemp {
-		ts-cal1-addr = <0x0BFA0710>;
-		ts-cal2-addr = <0x0BFA0742>;
+		ts-cal1-addr = <0x0bfa0710>;
+		ts-cal2-addr = <0x0bfa0742>;
 	};
 };
 

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -244,7 +244,7 @@
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -567,7 +567,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FFF75AA>;
+		vrefint-cal-addr = <0x1fff75aa>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 13>;
 		status = "disabled";

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -556,8 +556,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FFF75A8>;
-		ts-cal2-addr = <0x1FFF75C8>;
+		ts-cal1-addr = <0x1fff75a8>;
+		ts-cal2-addr = <0x1fff75c8>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3300>;


### PR DESCRIPTION
Improve compliance with [DTS Coding Style](https://docs.kernel.org/devicetree/bindings/dts-coding-style.html) which says that:
> 4. Hex values in properties, e.g. “reg”, shall use lowercase hex. The address part can be padded with leading zeros.

Found using (case-sensitive) regexps `0x[0-9a-f]*[A-F]+` and `@[0-9a-f]*[A-F]+` with file filter `*.dts,*.dtsi`.