### PR TITLE
i2c: shell: make the buffer configurable

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -22,6 +22,14 @@ config I2C_SHELL
 	  The I2C shell supports scanning, bus recovery, I2C read and write
 	  operations.
 
+config I2C_SHELL_BUFFER_SIZE
+	int "I2C shell buffer size"
+	default 16
+	help
+	  Size of the buffer used by some I2C commands, will determine the
+	  maximum size for read/write operations. Note that this is allocated
+	  on the stack.
+
 config I2C_STATS
 	bool "I2C device Stats"
 	depends on STATS

--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(i2c_shell, CONFIG_LOG_DEFAULT_LEVEL);
 #define ARGV_REG	3
 
 /* Maximum bytes we can write or read at once */
-#define MAX_I2C_BYTES	16
+#define MAX_I2C_BYTES	CONFIG_I2C_SHELL_BUFFER_SIZE
 
 static int get_bytes_count_for_hex(char *arg)
 {


### PR DESCRIPTION
Add a Kconfig option to tweak the i2c shell command buffer size, similarly to other shell commands.

This is allocated on the stack so add a note about it.