### PR TITLE
modules: tf-m: Add syscall header dependency for TF-M

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -429,6 +429,10 @@ if(CONFIG_BUILD_WITH_TFM)
     ${TFM_INTERFACE_LIB_DIR}/s_veneers.o
     )
 
+  # Ensure that the generated syscall include headers of Zephyr are available to TF-M
+  # because some platforms might use the same source files for both builds.
+  add_dependencies(tfm ${SYSCALL_LIST_H_TARGET})
+
   # To ensure that generated include files are created before they are used.
   add_dependencies(zephyr_interface tfm)
 


### PR DESCRIPTION
Zephyr generates the system call headers using CMake custom targets and various scripts. Some platforms, like the Nordic onces, reuse some files located in Zephyr inside the TF-M build as well. Because of this the generated Zephyr headers needs to exist before TF-M starts the build process in order to succeed.

This adds a dependency to make sure TF-M starts building after the Zephyr custom command which generates the system call headers is executed.