### PR TITLE
Bluetooth: Mesh: Document Static OOB entropy requirement

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/provisioning.rst
+++ b/doc/connectivity/bluetooth/api/mesh/provisioning.rst
@@ -124,7 +124,9 @@ provisionee:
 
 * **Static OOB:** An authentication value is assigned to the device in
   production, which the provisioner can query in some application specific
-  way.
+  way. For secure provisioning with the BTM_ECDH_P256_HMAC_SHA256_AES_CCM
+  algorithm, the Static OOB value should contain more than 128 bits of entropy
+  to provide adequate security against attacks.
 * **Input OOB:** The user inputs the authentication value. The available input
   actions are listed in :c:enum:`bt_mesh_input_action_t`.
 * **Output OOB:** Show the user the authentication value. The available output


### PR DESCRIPTION
Updates documentation for clarifying that for secure provisioning
with the BTM_ECDH_P256_HMAC_SHA256_AES_CCM algorithm,
the Static OOB value should contain more than 128 bits of
entropy to provide adequate security against attacks.