### PR TITLE
net: ocpp: Change Current.OfferedMaximum to Current.Offered

### DIFF
--- a/subsys/net/lib/ocpp/core.c
+++ b/subsys/net/lib/ocpp/core.c
@@ -21,7 +21,7 @@ static struct {
 	FILL_METER_TABLE(OCPP_OMM_CURRENT_TO_EV,
 			 "Current.Import", "A"),
 	FILL_METER_TABLE(OCPP_OMM_CURRENT_MAX_OFFERED_TO_EV,
-			 "Current.OfferedMaximum", "A"),
+			 "Current.Offered", "A"),
 	FILL_METER_TABLE(OCPP_OMM_ACTIVE_ENERGY_FROM_EV,
 			 "Energy.Active.Export.Register", "Wh"),
 	FILL_METER_TABLE(OCPP_OMM_ACTIVE_ENERGY_TO_EV,


### PR DESCRIPTION
According to https://openchargealliance.org/wp-content/uploads/2025/04/OCPP_1.6_documentation.zip  the Measurand value is called `Current.Offered` (Maximum current offered to EV).