### PR TITLE
net: ocpp: readonly is a bool

### DIFF
--- a/subsys/net/lib/ocpp/ocpp_j.c
+++ b/subsys/net/lib/ocpp/ocpp_j.c
@@ -410,7 +410,7 @@ static int frame_getconfig_msg(char *buf, int len, char *key, char *val,
 		JSON_OBJ_DESCR_PRIM_NAMED(struct json_ocpp_key_val, "key",
 					  key, JSON_TOK_STRING),
 		JSON_OBJ_DESCR_PRIM_NAMED(struct json_ocpp_key_val, "readonly",
-					  readonly, JSON_TOK_NUMBER),
+					  readonly, JSON_TOK_TRUE),
 		JSON_OBJ_DESCR_PRIM_NAMED(struct json_ocpp_key_val, "value",
 					  value, JSON_TOK_STRING),
 	};

--- a/subsys/net/lib/ocpp/ocpp_j.h
+++ b/subsys/net/lib/ocpp/ocpp_j.h
@@ -84,7 +84,7 @@ struct json_ocpp_start_txn_msg {
 struct json_ocpp_getconfig_msg {
 	struct json_ocpp_key_val {
 		char *key;
-		int readonly;
+		bool readonly;
 		char *value;
 	} configuration_key[1];
 


### PR DESCRIPTION
GetConfiguration.conf read_only is a bool according to https://openchargealliance.org/wp-content/uploads/2025/04/OCPP_1.6_documentation.zip.

The Python OCPP implementation (used in HomeAssistant) reports an error if read_only is reported as an integer: https://github.com/mobilityhouse/ocpp/blob/ae716a1507d708d83743d1132587cbb03522cda7/ocpp/v16/datatypes.py#L73

Should this be differentiated JSON_TOK_TRUE/JSON_TOK_FALSE based on msg.configuration_key[0].readonly?