### PR TITLE
MAINTAINERS: Remove Johan & Chris from release notes

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4462,9 +4462,6 @@ Release:
 Release Notes:
   status: maintained
   maintainers:
-    - cfriedt
-    - jhedberg
-  collaborators:
     - kartben
   files:
     - doc/releases/migration-guide-*


### PR DESCRIPTION
Remove the 4.3 release managers from the maintainers list for the release notes.