### PR TITLE
doc: developer: enhance manifest index with introductory text

### DIFF
--- a/doc/develop/manifest/index.rst
+++ b/doc/develop/manifest/index.rst
@@ -5,8 +5,17 @@
 West Projects index
 ###################
 
-See :ref:`external-contributions` for more information about
-this contributing and review process for imported components.
+This page acts as an index of projects (modules) compatible with the
+:ref:`West <west>` meta-tool.
+
+It primarily lists the components declared in Zephyr's default
+:zephyr_file:`manifest file <west.yml>`. See :ref:`external-contributions` for
+more information about the contribution and review process for these imported
+components.
+
+It also maintains a registry of :ref:`external projects
+<west_external_projects>`, maintained outside of the Zephyr Project, that can
+easily be integrated into a Zephyr workspace.
 
 Active Projects/Modules
 +++++++++++++++++++++++
@@ -28,7 +37,6 @@ following commands::
 Inactive and Optional Projects/Modules
 ++++++++++++++++++++++++++++++++++++++
 
-
 The projects below are optional and will not be downloaded when you
 call :command:`west update`. You can add any of the projects or modules listed below
 and use them to write application code and extend your workspace with the added
@@ -42,9 +50,10 @@ To enable any of the modules below, use the following commands::
 .. manifest-projects-table::
    :filter: inactive
 
+.. _west_external_projects:
+
 External Projects/Modules
 ++++++++++++++++++++++++++
-
 
 The projects listed below are external and are not directly imported into the
 default manifest.
@@ -53,8 +62,8 @@ file which includes them.  See :ref:`west-manifest-import` for information on
 recommended ways to do this while still inheriting the mandatory modules from
 Zephyr's :file:`west.yml`.
 
-Use the template :file:`doc/develop/manifest/external/external.rst.tmpl` to add
-external modules to the list below:
+Use the :zephyr_file:`dedicated template file <doc/develop/manifest/external/external.rst.tmpl>`
+to contribute new external modules to the list below:
 
 .. toctree::
    :titlesonly:


### PR DESCRIPTION
The "West Projects Index" could use a bit more context so this commit adds just that.

https://builds.zephyrproject.io/zephyr/pr/100393/docs/develop/manifest/index.html