### PR TITLE
net: Initialize unspec_addr to avoid -Werror=maybe-uninitialized

### DIFF
--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -2358,7 +2358,7 @@ void net_dhcpv6_restart(struct net_if *iface)
 
 int net_dhcpv6_init(void)
 {
-	struct net_sockaddr unspec_addr;
+	struct net_sockaddr unspec_addr = {0};
 	int ret;
 
 	net_ipaddr_copy(&net_sin6(&unspec_addr)->sin6_addr,


### PR DESCRIPTION
The variable 'unspec_addr' in net_dhcpv6_init() is implicitly initialized on some platforms and optimization levels, but not guaranteed to be initialized on all code paths when built with compiler instrumentation.

This leads to a build failure with the strict '-Werror=maybe-uninitialized' warning when code coverage flags are enabled (e.g., via twister --coverage).

```
zephyr/subsys/net/lib/dhcpv6/dhcpv6.c:2325:26: error: ‘unspec_addr’
may be used uninitialized [-Werror=maybe-uninitialized]
         net_ipaddr_copy(&net_sin6(&unspec_addr)->sin6_addr,
```