### PR TITLE
doc: _extensions: adjust link-roles regex to be non-greedy

### DIFF
--- a/doc/_extensions/zephyr/link-roles.py
+++ b/doc/_extensions/zephyr/link-roles.py
@@ -76,7 +76,7 @@ def modulelink(default_module=None, format="blob"):
         source, line = inliner.reporter.get_source_and_line(lineno)
         trace = f"at '{source}:{line}'"
 
-        m = re.search(r"(.*)\s*<(.*)>", text)
+        m = re.search(r"(.*?)\s*<(.*)>", text)
         if m:
             link_text = m.group(1)
             link = m.group(2)


### PR DESCRIPTION
Currently, if the role is used like this: ``:zephyr_file:`blah <link>` `` the regex for the link text group is greedy and captures "blah " (note trailing space). This is incorrect and causes the link to render poorly. Make regex non-greedy.

Before

<img width="838" height="121" alt="image" src="https://github.com/user-attachments/assets/9212ac8b-dbb6-4dac-95fc-0e892dd3465b" />

After

<img width="807" height="134" alt="image" src="https://github.com/user-attachments/assets/f64c1761-4950-4ade-ab49-72f7dbfdca7c" />

