### PR TITLE
include: zephyr: Replace nested COND_CODE_1 with COND_CASE_1

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -1246,10 +1246,10 @@ device_get_dt_nodelabels(const struct device *dev)
  * @param level Init level
  */
 #define Z_DEVICE_CHECK_INIT_LEVEL(level)                                       \
-	COND_CODE_1(Z_INIT_PRE_KERNEL_1_##level, (),                           \
-	(COND_CODE_1(Z_INIT_PRE_KERNEL_2_##level, (),                          \
-	(COND_CODE_1(Z_INIT_POST_KERNEL_##level, (),                           \
-	(ZERO_OR_COMPILE_ERROR(0)))))))
+	COND_CASE_1(Z_INIT_PRE_KERNEL_1_##level, (),                           \
+		    Z_INIT_PRE_KERNEL_2_##level, (),                           \
+		    Z_INIT_POST_KERNEL_##level, (),                            \
+		    (ZERO_OR_COMPILE_ERROR(0)))
 
 /**
  * @brief Define the init entry for a device.

--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -118,12 +118,12 @@ struct emul {
 
 /* Conditionally places text based on what bus _dev_node_id is on. */
 #define Z_EMUL_BUS(_dev_node_id, _i2c, _espi, _spi, _mspi, _uart, _none)                           \
-	COND_CODE_1(DT_ON_BUS(_dev_node_id, i2c), (_i2c),                                          \
-	(COND_CODE_1(DT_ON_BUS(_dev_node_id, espi), (_espi),                                       \
-	(COND_CODE_1(DT_ON_BUS(_dev_node_id, spi), (_spi),                                         \
-	(COND_CODE_1(DT_ON_BUS(_dev_node_id, mspi), (_mspi),                                       \
-	(COND_CODE_1(DT_ON_BUS(_dev_node_id, uart), (_uart),                                       \
-	(_none))))))))))
+	COND_CASE_1(DT_ON_BUS(_dev_node_id, i2c), (_i2c),                                          \
+		    DT_ON_BUS(_dev_node_id, espi), (_espi),                                        \
+		    DT_ON_BUS(_dev_node_id, spi), (_spi),                                          \
+		    DT_ON_BUS(_dev_node_id, mspi), (_mspi),                                        \
+		    DT_ON_BUS(_dev_node_id, uart), (_uart),                                        \
+		    (_none))
 
 /**
  * @brief Define a new emulator

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -123,13 +123,13 @@ struct init_entry {
  * @return Init level ordinal.
  */
 #define INIT_LEVEL_ORD(level)                                                  \
-	COND_CODE_1(Z_INIT_EARLY_##level, (Z_INIT_ORD_EARLY),                  \
-	(COND_CODE_1(Z_INIT_PRE_KERNEL_1_##level, (Z_INIT_ORD_PRE_KERNEL_1),   \
-	(COND_CODE_1(Z_INIT_PRE_KERNEL_2_##level, (Z_INIT_ORD_PRE_KERNEL_2),   \
-	(COND_CODE_1(Z_INIT_POST_KERNEL_##level, (Z_INIT_ORD_POST_KERNEL),     \
-	(COND_CODE_1(Z_INIT_APPLICATION_##level, (Z_INIT_ORD_APPLICATION),     \
-	(COND_CODE_1(Z_INIT_SMP_##level, (Z_INIT_ORD_SMP),                     \
-	(ZERO_OR_COMPILE_ERROR(0)))))))))))))
+	COND_CASE_1(Z_INIT_EARLY_##level, (Z_INIT_ORD_EARLY),                  \
+		    Z_INIT_PRE_KERNEL_1_##level, (Z_INIT_ORD_PRE_KERNEL_1),    \
+		    Z_INIT_PRE_KERNEL_2_##level, (Z_INIT_ORD_PRE_KERNEL_2),    \
+		    Z_INIT_POST_KERNEL_##level, (Z_INIT_ORD_POST_KERNEL),      \
+		    Z_INIT_APPLICATION_##level, (Z_INIT_ORD_APPLICATION),      \
+		    Z_INIT_SMP_##level, (Z_INIT_ORD_SMP),                      \
+		    (ZERO_OR_COMPILE_ERROR(0)))
 
 /**
  * @brief Register an initialization function.

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -1423,14 +1423,13 @@ static inline int net_eth_mac_load(const struct net_eth_mac_config *cfg, uint8_t
  * @param node_id Node identifier.
  */
 #define NET_ETH_MAC_DT_CONFIG_INIT(node_id)                                                        \
-	COND_CODE_1(DT_PROP(node_id, zephyr_random_mac_address),                                   \
+	COND_CASE_1(DT_PROP(node_id, zephyr_random_mac_address),                                   \
 		    (Z_NET_ETH_MAC_DT_CONFIG_INIT_RANDOM(node_id)),                                \
-		    (COND_CODE_1(DT_NVMEM_CELLS_HAS_NAME(node_id, mac_address),                    \
-				 (Z_NET_ETH_MAC_DT_CONFIG_INIT_NVMEM(node_id)),                    \
-				 (COND_CODE_1(DT_NODE_HAS_PROP(node_id, local_mac_address),        \
-					      (Z_NET_ETH_MAC_DT_CONFIG_INIT_STATIC(node_id)),      \
-					      (Z_NET_ETH_MAC_DT_CONFIG_INIT_DEFAULT(node_id)))))))
-
+		    DT_NVMEM_CELLS_HAS_NAME(node_id, mac_address),                                 \
+		    (Z_NET_ETH_MAC_DT_CONFIG_INIT_NVMEM(node_id)),                                 \
+		    DT_NODE_HAS_PROP(node_id, local_mac_address),                                  \
+		    (Z_NET_ETH_MAC_DT_CONFIG_INIT_STATIC(node_id)),                                \
+		    (Z_NET_ETH_MAC_DT_CONFIG_INIT_DEFAULT(node_id)))
 
 /**
  * @brief Like NET_ETH_MAC_DT_CONFIG_INIT for an instance of a DT_DRV_COMPAT compatible


### PR DESCRIPTION
Update some header files with nested COND_CODE_1 macros to use a single COND_CASE_1 macro instead.

Possible after https://github.com/zephyrproject-rtos/zephyr/pull/100224