### PR TITLE
ci: compliance: Locate Kconfig symbols from top git repo as well

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -951,6 +951,24 @@ class KconfigCheck(ComplianceTest):
         if len(tmp_output) > 0:
             kconfigs += tmp_output + "\n"
 
+        if ZEPHYR_BASE != GIT_TOP:
+            # Use hard coded paths for Zephyr based tests and samples
+            tmp_output = git(
+                "grep",
+                "-I",
+                "-h",
+                "--perl-regexp",
+                regex,
+                "--",
+                ":tests",
+                ":samples",
+                cwd=GIT_TOP,
+                ignore_non_zero=True,
+            )
+
+            if len(tmp_output) > 0:
+                kconfigs += tmp_output + "\n"
+
         for project in manifest.get_projects([]):
             if not manifest.is_active(project):
                 continue


### PR DESCRIPTION
If the compliance script is being run in a project that brings in Zephyr as a module, that project may have its own samples/tests that define Kconfig symbols, so cheek for those symbols when checking compliance as well.

I'm not sure if the Zephyr project wants to support the compliance script being used for consuming projects, but if so, this would help us, since we define our own additional tests and samples and the compliance checks are unhappy with symbols defined therein without this additional check. TIA.