### PR TITLE
sensor: rm3100: Add missing cycle_count in edata header.

### DIFF
--- a/drivers/sensor/pni/rm3100/rm3100_decoder.c
+++ b/drivers/sensor/pni/rm3100/rm3100_decoder.c
@@ -122,14 +122,14 @@ static int rm3100_convert_raw_to_q31(uint16_t cycle_count, uint32_t raw_reading,
 	raw_reading = sys_be24_to_cpu(raw_reading);
 	value = sign_extend(raw_reading, 23);
 
-	/** Convert to Gauss, assuming 1 LSB = 75 uT, given default Cycle-Counting (200).
+	/** Convert to Gauss, assuming 75 LSB = 1 uT, given default Cycle-Counting (200).
 	 * We can represent the largest sample (2^23 LSB) in Gauss with 11 bits.
 	 */
 	if (cycle_count == RM3100_CYCLE_COUNT_DEFAULT) {
 		*shift = 11;
 		divider = 75;
 	} else {
-		/** Otherwise, it's 1 LSB = 38 uT at Cycle-counting for 600 Hz ODR (100):
+		/** Otherwise, it's 38 LSB = 1 uT at Cycle-counting for 600 Hz ODR (100):
 		 * 12-bits max value.
 		 */
 		*shift = 12;

--- a/drivers/sensor/pni/rm3100/rm3100_stream.c
+++ b/drivers/sensor/pni/rm3100/rm3100_stream.c
@@ -7,6 +7,7 @@
 
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/sensor_clock.h>
+#include <zephyr/dt-bindings/sensor/rm3100.h>
 #include <zephyr/rtio/rtio.h>
 #include <zephyr/sys/check.h>
 #include "rm3100_stream.h"
@@ -67,6 +68,9 @@ static void rm3100_stream_get_data(const struct device *dev)
 	}
 
 	struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+	const struct sensor_chan_spec *const channels = cfg->channels;
+	const size_t num_channels = cfg->count;
 	uint8_t *buf;
 	uint32_t buf_len;
 	uint32_t min_buf_len = sizeof(struct rm3100_encoded_data);
@@ -82,6 +86,13 @@ static void rm3100_stream_get_data(const struct device *dev)
 	}
 
 	edata = (struct rm3100_encoded_data *)buf;
+
+	err = rm3100_encode(dev, channels, num_channels, buf);
+	if (err != 0) {
+		LOG_ERR("Failed to encode sensor data");
+		rtio_iodev_sqe_err(iodev_sqe, err);
+		return;
+	}
 
 	err = sensor_clock_get_cycles(&cycles);
 	CHECKIF(err) {


### PR DESCRIPTION
Fixes missing cycle_count configuration in `edata->header.cycle_count` which would result in decoding of stream data to always use the 600hz scale factor and values off by a factor of 2.

This was configured when performing one-shot submissions but missed for stream submissions.

Also corrects the units in the comments I found while searching for this problem.