### PR TITLE
firmware: scmi: nxp: add "nxp" to the CPU protocol definitions

### DIFF
--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -10,14 +10,14 @@
 
 DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, nxp_scmi_cpu), NULL);
 
-struct scmi_cpu_info_get_reply {
+struct scmi_nxp_cpu_info_get_reply {
 	int32_t status;
-	struct scmi_cpu_info data;
+	struct scmi_nxp_cpu_info data;
 };
 
-int scmi_cpu_sleep_mode_set(struct scmi_cpu_sleep_mode_config *cfg)
+int scmi_nxp_cpu_sleep_mode_set(struct scmi_nxp_cpu_sleep_mode_config *cfg)
 {
-	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_CPU_DOMAIN);
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
 	struct scmi_message msg, reply;
 	int status, ret;
 	bool use_polling;
@@ -27,11 +27,11 @@ int scmi_cpu_sleep_mode_set(struct scmi_cpu_sleep_mode_config *cfg)
 		return -EINVAL;
 	}
 
-	if (proto->id != SCMI_PROTOCOL_CPU_DOMAIN) {
+	if (proto->id != SCMI_PROTOCOL_NXP_CPU_DOMAIN) {
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_CPU_DOMAIN_MSG_CPU_SLEEP_MODE_SET, SCMI_COMMAND,
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_NXP_CPU_DOMAIN_MSG_CPU_SLEEP_MODE_SET, SCMI_COMMAND,
 					proto->id, 0x0);
 	msg.len = sizeof(*cfg);
 	msg.content = cfg;
@@ -53,9 +53,9 @@ int scmi_cpu_sleep_mode_set(struct scmi_cpu_sleep_mode_config *cfg)
 	return scmi_status_to_errno(status);
 }
 
-int scmi_cpu_pd_lpm_set(struct scmi_cpu_pd_lpm_config *cfg)
+int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg)
 {
-	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_CPU_DOMAIN);
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
 	struct scmi_message msg, reply;
 	int status, ret;
 	bool use_polling;
@@ -65,11 +65,11 @@ int scmi_cpu_pd_lpm_set(struct scmi_cpu_pd_lpm_config *cfg)
 		return -EINVAL;
 	}
 
-	if (proto->id != SCMI_PROTOCOL_CPU_DOMAIN) {
+	if (proto->id != SCMI_PROTOCOL_NXP_CPU_DOMAIN) {
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_CPU_DOMAIN_MSG_CPU_PD_LPM_CONFIG_SET, SCMI_COMMAND,
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_NXP_CPU_DOMAIN_MSG_CPU_PD_LPM_CONFIG_SET, SCMI_COMMAND,
 					proto->id, 0x0);
 	msg.len = sizeof(*cfg);
 	msg.content = cfg;
@@ -88,9 +88,9 @@ int scmi_cpu_pd_lpm_set(struct scmi_cpu_pd_lpm_config *cfg)
 	return scmi_status_to_errno(status);
 }
 
-int scmi_cpu_set_irq_mask(struct scmi_cpu_irq_mask_config *cfg)
+int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg)
 {
-	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_CPU_DOMAIN);
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
 	struct scmi_message msg, reply;
 	int status, ret;
 
@@ -99,11 +99,11 @@ int scmi_cpu_set_irq_mask(struct scmi_cpu_irq_mask_config *cfg)
 		return -EINVAL;
 	}
 
-	if (proto->id != SCMI_PROTOCOL_CPU_DOMAIN) {
+	if (proto->id != SCMI_PROTOCOL_NXP_CPU_DOMAIN) {
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_CPU_DOMAIN_MSG_CPU_IRQ_WAKE_SET, SCMI_COMMAND,
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_NXP_CPU_DOMAIN_MSG_CPU_IRQ_WAKE_SET, SCMI_COMMAND,
 					proto->id, 0x0);
 	msg.len = sizeof(*cfg);
 	msg.content = cfg;
@@ -120,9 +120,9 @@ int scmi_cpu_set_irq_mask(struct scmi_cpu_irq_mask_config *cfg)
 	return scmi_status_to_errno(status);
 }
 
-int scmi_cpu_reset_vector(struct scmi_cpu_vector_config *cfg)
+int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg)
 {
-	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_CPU_DOMAIN);
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
 	struct scmi_message msg, reply;
 	int status, ret;
 
@@ -131,11 +131,11 @@ int scmi_cpu_reset_vector(struct scmi_cpu_vector_config *cfg)
 		return -EINVAL;
 	}
 
-	if (proto->id != SCMI_PROTOCOL_CPU_DOMAIN) {
+	if (proto->id != SCMI_PROTOCOL_NXP_CPU_DOMAIN) {
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_CPU_DOMAIN_MSG_CPU_RESET_VECTOR_SET, SCMI_COMMAND,
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_NXP_CPU_DOMAIN_MSG_CPU_RESET_VECTOR_SET, SCMI_COMMAND,
 					proto->id, 0x0);
 	msg.len = sizeof(*cfg);
 	msg.content = cfg;
@@ -152,11 +152,11 @@ int scmi_cpu_reset_vector(struct scmi_cpu_vector_config *cfg)
 	return scmi_status_to_errno(status);
 }
 
-int scmi_cpu_info_get(uint32_t cpu_id, struct scmi_cpu_info *cfg)
+int scmi_nxp_cpu_info_get(uint32_t cpu_id, struct scmi_nxp_cpu_info *cfg)
 {
-	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_CPU_DOMAIN);
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_CPU_DOMAIN);
 	struct scmi_message msg, reply;
-	struct scmi_cpu_info_get_reply reply_buffer;
+	struct scmi_nxp_cpu_info_get_reply reply_buffer;
 	int ret;
 
 	/* sanity checks */
@@ -164,11 +164,11 @@ int scmi_cpu_info_get(uint32_t cpu_id, struct scmi_cpu_info *cfg)
 		return -EINVAL;
 	}
 
-	if (proto->id != SCMI_PROTOCOL_CPU_DOMAIN) {
+	if (proto->id != SCMI_PROTOCOL_NXP_CPU_DOMAIN) {
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_CPU_DOMAIN_MSG_CPU_INFO_GET, SCMI_COMMAND,
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_NXP_CPU_DOMAIN_MSG_CPU_INFO_GET, SCMI_COMMAND,
 					proto->id, 0x0);
 	msg.len = sizeof(uint32_t);
 	msg.content = &cpu_id;

--- a/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
+++ b/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
@@ -17,30 +17,30 @@
 #include <scmi_cpu_soc.h>
 #endif
 
-#define SCMI_CPU_SLEEP_FLAG_IRQ_MUX 0x1U
+#define SCMI_NXP_CPU_SLEEP_FLAG_IRQ_MUX 0x1U
 
-#define SCMI_PROTOCOL_CPU_DOMAIN 130
+#define SCMI_PROTOCOL_NXP_CPU_DOMAIN 130
 
-#define SCMI_CPU_MAX_PDCONFIGS_T 7U
+#define SCMI_NXP_CPU_MAX_PDCONFIGS_T 7U
 
-#define SCMI_CPU_IRQ_WAKE_NUM	22U
+#define SCMI_NXP_CPU_IRQ_WAKE_NUM	22U
 
 /** CPU vector flag: Boot address (cold boot/reset) */
-#define SCMI_CPU_VEC_FLAGS_BOOT    BIT(29)
+#define SCMI_NXP_CPU_VEC_FLAGS_BOOT    BIT(29)
 
 /** CPU vector flag: Start address (warm start) */
-#define SCMI_CPU_VEC_FLAGS_START   BIT(30)
+#define SCMI_NXP_CPU_VEC_FLAGS_START   BIT(30)
 
 /** CPU vector flag: Resume address (exit from suspend) */
-#define SCMI_CPU_VEC_FLAGS_RESUME  BIT(31)
+#define SCMI_NXP_CPU_VEC_FLAGS_RESUME  BIT(31)
 
 /**
- * @struct scmi_cpu_sleep_mode_config
+ * @struct scmi_nxp_cpu_sleep_mode_config
  *
  * @brief Describes the parameters for the CPU_STATE_SET
  * command
  */
-struct scmi_cpu_sleep_mode_config {
+struct scmi_nxp_cpu_sleep_mode_config {
 	uint32_t cpu_id;
 	uint32_t flags;
 	uint32_t sleep_mode;
@@ -53,34 +53,34 @@ struct scmi_pd_lpm_settings {
 };
 
 /**
- * @struct scmi_cpu_pd_lpm_config
+ * @struct scmi_nxp_cpu_pd_lpm_config
  *
  * @brief Describes cpu power domain low power mode setting
  */
-struct scmi_cpu_pd_lpm_config {
+struct scmi_nxp_cpu_pd_lpm_config {
 	uint32_t cpu_id;
 	uint32_t num_cfg;
-	struct scmi_pd_lpm_settings cfgs[SCMI_CPU_MAX_PDCONFIGS_T];
+	struct scmi_pd_lpm_settings cfgs[SCMI_NXP_CPU_MAX_PDCONFIGS_T];
 };
 
 /**
- * @struct scmi_cpu_irq_mask_config
+ * @struct scmi_nxp_cpu_irq_mask_config
  *
  * @brief Describes the parameters for the CPU_IRQ_WAKE_SET command
  */
-struct scmi_cpu_irq_mask_config {
+struct scmi_nxp_cpu_irq_mask_config {
 	uint32_t cpu_id;
 	uint32_t mask_idx;
 	uint32_t num_mask;
-	uint32_t mask[SCMI_CPU_IRQ_WAKE_NUM];
+	uint32_t mask[SCMI_NXP_CPU_IRQ_WAKE_NUM];
 };
 
 /**
- * @struct scmi_cpu_vector_config
+ * @struct scmi_nxp_cpu_vector_config
  *
  * @brief Describes the parameters for the CPU_RESET_VECTOR_SET command
  */
-struct scmi_cpu_vector_config {
+struct scmi_nxp_cpu_vector_config {
 	uint32_t cpu_id;
 	uint32_t flags;
 	uint32_t vector_low;
@@ -88,11 +88,11 @@ struct scmi_cpu_vector_config {
 };
 
 /**
- * @struct scmi_cpu_info
+ * @struct scmi_nxp_cpu_info
  *
  * @brief Describes the parameters for the CPU_INFO_GET command
  */
-struct scmi_cpu_info {
+struct scmi_nxp_cpu_info {
 	uint32_t run_mode;
 	uint32_t sleep_mode;
 	uint32_t vector_low;
@@ -102,21 +102,21 @@ struct scmi_cpu_info {
 /**
  * @brief CPU domain protocol command message IDs
  */
-enum scmi_cpu_domain_message {
-	SCMI_CPU_DOMAIN_MSG_PROTOCOL_VERSION = 0x0,
-	SCMI_CPU_DOMAIN_MSG_PROTOCOL_ATTRIBUTES = 0x1,
-	SCMI_CPU_DOMAIN_MSG_PROTOCOL_MESSAGE_ATTRIBUTES = 0x2,
-	SCMI_CPU_DOMAIN_MSG_CPU_DOMAIN_ATTRIBUTES = 0x3,
-	SCMI_CPU_DOMAIN_MSG_CPU_START = 0x4,
-	SCMI_CPU_DOMAIN_MSG_CPU_STOP = 0x5,
-	SCMI_CPU_DOMAIN_MSG_CPU_RESET_VECTOR_SET = 0x6,
-	SCMI_CPU_DOMAIN_MSG_CPU_SLEEP_MODE_SET = 0x7,
-	SCMI_CPU_DOMAIN_MSG_CPU_IRQ_WAKE_SET = 0x8,
-	SCMI_CPU_DOMAIN_MSG_CPU_NON_IRQ_WAKE_SET = 0x9,
-	SCMI_CPU_DOMAIN_MSG_CPU_PD_LPM_CONFIG_SET = 0xA,
-	SCMI_CPU_DOMAIN_MSG_CPU_PER_LPM_CONFIG_SET = 0xB,
-	SCMI_CPU_DOMAIN_MSG_CPU_INFO_GET = 0xC,
-	SCMI_CPU_DOMAIN_MSG_NEGOTIATE_PROTOCOL_VERSION = 0x10,
+enum scmi_nxp_cpu_domain_message {
+	SCMI_NXP_CPU_DOMAIN_MSG_PROTOCOL_VERSION = 0x0,
+	SCMI_NXP_CPU_DOMAIN_MSG_PROTOCOL_ATTRIBUTES = 0x1,
+	SCMI_NXP_CPU_DOMAIN_MSG_PROTOCOL_MESSAGE_ATTRIBUTES = 0x2,
+	SCMI_NXP_CPU_DOMAIN_MSG_CPU_DOMAIN_ATTRIBUTES = 0x3,
+	SCMI_NXP_CPU_DOMAIN_MSG_CPU_START = 0x4,
+	SCMI_NXP_CPU_DOMAIN_MSG_CPU_STOP = 0x5,
+	SCMI_NXP_CPU_DOMAIN_MSG_CPU_RESET_VECTOR_SET = 0x6,
+	SCMI_NXP_CPU_DOMAIN_MSG_CPU_SLEEP_MODE_SET = 0x7,
+	SCMI_NXP_CPU_DOMAIN_MSG_CPU_IRQ_WAKE_SET = 0x8,
+	SCMI_NXP_CPU_DOMAIN_MSG_CPU_NON_IRQ_WAKE_SET = 0x9,
+	SCMI_NXP_CPU_DOMAIN_MSG_CPU_PD_LPM_CONFIG_SET = 0xA,
+	SCMI_NXP_CPU_DOMAIN_MSG_CPU_PER_LPM_CONFIG_SET = 0xB,
+	SCMI_NXP_CPU_DOMAIN_MSG_CPU_INFO_GET = 0xC,
+	SCMI_NXP_CPU_DOMAIN_MSG_NEGOTIATE_PROTOCOL_VERSION = 0x10,
 };
 
 /**
@@ -128,10 +128,10 @@ enum scmi_cpu_domain_message {
  * @retval 0 if successful
  * @retval negative errno if failure
  */
-int scmi_cpu_sleep_mode_set(struct scmi_cpu_sleep_mode_config *cfg);
+int scmi_nxp_cpu_sleep_mode_set(struct scmi_nxp_cpu_sleep_mode_config *cfg);
 
 /**
- * @brief Send the SCMI_CPU_DOMAIN_MSG_CPU_PD_LPM_CONFIG_SET command and get its reply
+ * @brief Send the SCMI_NXP_CPU_DOMAIN_MSG_CPU_PD_LPM_CONFIG_SET command and get its reply
  *
  * @param cfg pointer to structure containing configuration
  * to be set
@@ -139,7 +139,7 @@ int scmi_cpu_sleep_mode_set(struct scmi_cpu_sleep_mode_config *cfg);
  * @retval 0 if successful
  * @retval negative errno if failure
  */
-int scmi_cpu_pd_lpm_set(struct scmi_cpu_pd_lpm_config *cfg);
+int scmi_nxp_cpu_pd_lpm_set(struct scmi_nxp_cpu_pd_lpm_config *cfg);
 
 /**
  * @brief Send the CPU_IRQ_WAKE_SET command and get its reply
@@ -149,7 +149,7 @@ int scmi_cpu_pd_lpm_set(struct scmi_cpu_pd_lpm_config *cfg);
  * @retval 0 if successful
  * @retval negative errno if failure
  */
-int scmi_cpu_set_irq_mask(struct scmi_cpu_irq_mask_config *cfg);
+int scmi_nxp_cpu_set_irq_mask(struct scmi_nxp_cpu_irq_mask_config *cfg);
 
 /**
  * @brief Send the CPU_RESET_VECTOR_SET command and get its reply
@@ -159,7 +159,7 @@ int scmi_cpu_set_irq_mask(struct scmi_cpu_irq_mask_config *cfg);
  * @retval 0 if successful
  * @retval negative errno if failure
  */
-int scmi_cpu_reset_vector(struct scmi_cpu_vector_config *cfg);
+int scmi_nxp_cpu_reset_vector(struct scmi_nxp_cpu_vector_config *cfg);
 
 /**
  * @brief Send the CPU_INFO_GET command and get its reply
@@ -170,5 +170,5 @@ int scmi_cpu_reset_vector(struct scmi_cpu_vector_config *cfg);
  * @retval 0 if successful
  * @retval negative errno if failure
  */
-int scmi_cpu_info_get(uint32_t cpu_id, struct scmi_cpu_info *cfg);
+int scmi_nxp_cpu_info_get(uint32_t cpu_id, struct scmi_nxp_cpu_info *cfg);
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CPU_H_ */

--- a/soc/nxp/imx/imx9/imx943/a55/soc.c
+++ b/soc/nxp/imx/imx9/imx943/a55/soc.c
@@ -41,7 +41,7 @@ static int soc_netc_clock_init(int clk_id)
 static int soc_init(void)
 {
 #if defined(CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS)
-	struct scmi_cpu_sleep_mode_config cpu_cfg = {0};
+	struct scmi_nxp_cpu_sleep_mode_config cpu_cfg = {0};
 #endif /* CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS */
 	int ret = 0;
 

--- a/soc/nxp/imx/imx9/imx943/m33/soc.c
+++ b/soc/nxp/imx/imx9/imx943/m33/soc.c
@@ -50,7 +50,7 @@ static int soc_netc_clock_init(int clk_id)
 static int soc_init(void)
 {
 #if defined(CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS)
-	struct scmi_cpu_sleep_mode_config cpu_cfg = {0};
+	struct scmi_nxp_cpu_sleep_mode_config cpu_cfg = {0};
 #endif /* CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS */
 	int ret = 0;
 
@@ -114,7 +114,7 @@ static int soc_init(void)
 	cpu_cfg.cpu_id = CPU_IDX_M33P_S;
 	cpu_cfg.sleep_mode = CPU_SLEEP_MODE_RUN;
 
-	ret = scmi_cpu_sleep_mode_set(&cpu_cfg);
+	ret = scmi_nxp_cpu_sleep_mode_set(&cpu_cfg);
 	if (ret) {
 		return ret;
 	}

--- a/soc/nxp/imx/imx9/imx95/m7/soc.c
+++ b/soc/nxp/imx/imx9/imx95/m7/soc.c
@@ -27,7 +27,7 @@ static int soc_init(void)
 {
 	int ret = 0;
 #if defined(CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS)
-	struct scmi_cpu_sleep_mode_config cpu_cfg = {0};
+	struct scmi_nxp_cpu_sleep_mode_config cpu_cfg = {0};
 #endif /* CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS */
 
 #if defined(CONFIG_ETH_NXP_IMX_NETC) && (DT_CHILD_NUM_STATUS_OKAY(DT_NODELABEL(netc)) != 0)
@@ -75,7 +75,7 @@ static int soc_init(void)
 	cpu_cfg.cpu_id = CPU_IDX_M7P;
 	cpu_cfg.sleep_mode = CPU_SLEEP_MODE_RUN;
 
-	ret = scmi_cpu_sleep_mode_set(&cpu_cfg);
+	ret = scmi_nxp_cpu_sleep_mode_set(&cpu_cfg);
 	if (ret) {
 		return ret;
 	}
@@ -86,8 +86,8 @@ static int soc_init(void)
 
 void pm_state_before(void)
 {
-	struct scmi_cpu_pd_lpm_config cpu_pd_lpm_cfg;
-	struct scmi_cpu_irq_mask_config cpu_irq_mask_cfg;
+	struct scmi_nxp_cpu_pd_lpm_config cpu_pd_lpm_cfg;
+	struct scmi_nxp_cpu_irq_mask_config cpu_irq_mask_cfg;
 
 	/*
 	 * 1. Set M7 mix as power on state in suspend mode
@@ -110,7 +110,7 @@ void pm_state_before(void)
 	cpu_pd_lpm_cfg.cfgs[1].lpm_setting = SCMI_CPU_LPM_SETTING_ON_ALWAYS;
 	cpu_pd_lpm_cfg.cfgs[1].ret_mask = 0;
 
-	scmi_cpu_pd_lpm_set(&cpu_pd_lpm_cfg);
+	scmi_nxp_cpu_pd_lpm_set(&cpu_pd_lpm_cfg);
 
 	/* Set wakeup mask */
 	uint32_t wake_mask[GPC_CMC_IRQ_WAKEUP_MASK_COUNT] = {
@@ -130,12 +130,12 @@ void pm_state_before(void)
 		cpu_irq_mask_cfg.mask[val] = wake_mask[val];
 	}
 
-	scmi_cpu_set_irq_mask(&cpu_irq_mask_cfg);
+	scmi_nxp_cpu_set_irq_mask(&cpu_irq_mask_cfg);
 }
 
 void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
-	struct scmi_cpu_sleep_mode_config cpu_cfg = {0};
+	struct scmi_nxp_cpu_sleep_mode_config cpu_cfg = {0};
 
 	pm_state_before();
 
@@ -155,21 +155,21 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 	case PM_STATE_RUNTIME_IDLE:
 		cpu_cfg.cpu_id = CPU_IDX_M7P;
 		cpu_cfg.sleep_mode = CPU_SLEEP_MODE_WAIT;
-		scmi_cpu_sleep_mode_set(&cpu_cfg);
+		scmi_nxp_cpu_sleep_mode_set(&cpu_cfg);
 		__DSB();
 		__WFI();
 		break;
 	case PM_STATE_SUSPEND_TO_IDLE:
 		cpu_cfg.cpu_id = CPU_IDX_M7P;
 		cpu_cfg.sleep_mode = CPU_SLEEP_MODE_STOP;
-		scmi_cpu_sleep_mode_set(&cpu_cfg);
+		scmi_nxp_cpu_sleep_mode_set(&cpu_cfg);
 		__DSB();
 		__WFI();
 		break;
 	case PM_STATE_STANDBY:
 		cpu_cfg.cpu_id = CPU_IDX_M7P;
 		cpu_cfg.sleep_mode = CPU_SLEEP_MODE_SUSPEND;
-		scmi_cpu_sleep_mode_set(&cpu_cfg);
+		scmi_nxp_cpu_sleep_mode_set(&cpu_cfg);
 		__DSB();
 		__WFI();
 		break;
@@ -183,7 +183,7 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
 	ARG_UNUSED(state);
 
-	struct scmi_cpu_irq_mask_config cpu_irq_mask_cfg;
+	struct scmi_nxp_cpu_irq_mask_config cpu_irq_mask_cfg;
 
 	/* Restore scmi cpu wake mask */
 	uint32_t wake_mask[GPC_CMC_IRQ_WAKEUP_MASK_COUNT] = {
@@ -198,13 +198,13 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 		cpu_irq_mask_cfg.mask[val] = wake_mask[val];
 	}
 
-	scmi_cpu_set_irq_mask(&cpu_irq_mask_cfg);
+	scmi_nxp_cpu_set_irq_mask(&cpu_irq_mask_cfg);
 
-	struct scmi_cpu_sleep_mode_config cpu_cfg = {0};
+	struct scmi_nxp_cpu_sleep_mode_config cpu_cfg = {0};
 	/* restore M7 core state into ACTIVE. */
 	cpu_cfg.cpu_id = CPU_IDX_M7P;
 	cpu_cfg.sleep_mode = CPU_SLEEP_MODE_RUN;
-	scmi_cpu_sleep_mode_set(&cpu_cfg);
+	scmi_nxp_cpu_sleep_mode_set(&cpu_cfg);
 
 	/* Clear PRIMASK */
 	__enable_irq();


### PR DESCRIPTION
The SCMI CPU protocol is in fact a vendor extension from NXP. The current naming used for the CPU protocol definitions (i.e. functions, structures, macros) follows that of the SCMI standard protocols, which might be misleading.

Include "nxp" in the name all of the CPU protocol functions. No functional change.

This change was performed mechanically using "git grep" and "sed -i" with some manual intervention.