### PR TITLE
utils: timeutil: option to disable clock skew

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -119,6 +119,10 @@ New APIs and options
    * :kconfig:option:`CONFIG_SETTINGS_SAVE_SINGLE_SUBTREE_WITHOUT_MODIFICATION`
    * :kconfig:option:`CONFIG_SETTINGS_SAVE_SINGLE_SUBTREE_WITHOUT_MODIFICATION_VALUE_SIZE`
 
+* Timeutil
+
+  * :kconfig:option:`CONFIG_TIMEUTIL_APPLY_SKEW`
+
 .. zephyr-keep-sorted-stop
 
 New Boards

--- a/include/zephyr/sys/timeutil.h
+++ b/include/zephyr/sys/timeutil.h
@@ -296,6 +296,8 @@ float timeutil_sync_estimate_skew(const struct timeutil_sync_state *tsp);
  * produces an error.  If interpolation fails the referenced object is
  * not modified.
  *
+ * @note Clock skews are only applied with @kconfig{CONFIG_TIMEUTIL_APPLY_SKEW}
+ *
  * @retval 0 if interpolated using a skew of 1
  * @retval 1 if interpolated using a skew not equal to 1
  * @retval -EINVAL
@@ -320,6 +322,8 @@ int timeutil_sync_ref_from_local(const struct timeutil_sync_state *tsp,
  * timescale should be stored.  An interpolated value before local
  * time 0 is provided without error.  If interpolation fails the
  * referenced object is not modified.
+ *
+ * @note Clock skews are only applied with @kconfig{CONFIG_TIMEUTIL_APPLY_SKEW}
  *
  * @retval 0 if successful with a skew of 1
  * @retval 1 if successful with a skew not equal to 1

--- a/lib/utils/Kconfig
+++ b/lib/utils/Kconfig
@@ -98,4 +98,14 @@ config GETOPT_LONG
 	  for other threads by extending function sys_getopt_state_get in
 	  getopt_common.c file.
 
+config TIMEUTIL_APPLY_SKEW
+	bool "Support applying clock skew corrections in conversion functions"
+	default y
+	help
+	  Accurately applying clock skew correction in timeutil_sync_ref_from_local
+	  and timeutil_sync_local_from_ref requires double-precision floating point
+	  operations. If this is the only usage of double precision logic in the
+	  build, but clocks skews are not used, this can be a significant ROM
+	  overhead. Disabling this option can save ~2.4 kB of ROM.
+
 endmenu

--- a/lib/utils/timeutil.c
+++ b/lib/utils/timeutil.c
@@ -139,12 +139,14 @@ int timeutil_sync_ref_from_local(const struct timeutil_sync_state *tsp,
 	if ((tsp->skew > 0) && (tsp->base.ref > 0) && (refp != NULL)) {
 		const struct timeutil_sync_config *cfg = tsp->cfg;
 		int64_t local_delta = local - tsp->base.local;
+#ifdef CONFIG_TIMEUTIL_APPLY_SKEW
 		/* (x * 1.0) != x for large values of x.
 		 * Therefore only apply the multiplication if the skew is not one.
 		 */
 		if (tsp->skew != 1.0f) {
 			local_delta *= (double)tsp->skew;
 		}
+#endif /* CONFIG_TIMEUTIL_APPLY_SKEW */
 		int64_t ref_delta = local_delta * cfg->ref_Hz / cfg->local_Hz;
 		int64_t ref_abs = (int64_t)tsp->base.ref + ref_delta;
 
@@ -167,14 +169,15 @@ int timeutil_sync_local_from_ref(const struct timeutil_sync_state *tsp,
 	if ((tsp->skew > 0) && (tsp->base.ref > 0) && (localp != NULL)) {
 		const struct timeutil_sync_config *cfg = tsp->cfg;
 		int64_t ref_delta = (int64_t)(ref - tsp->base.ref);
+		int64_t local_delta = (ref_delta * cfg->local_Hz) / cfg->ref_Hz;
+#ifdef CONFIG_TIMEUTIL_APPLY_SKEW
 		/* (x / 1.0) != x for large values of x.
 		 * Therefore only apply the division if the skew is not one.
 		 */
-		int64_t local_delta = (ref_delta * cfg->local_Hz) / cfg->ref_Hz;
-
 		if (tsp->skew != 1.0f) {
 			local_delta /= (double)tsp->skew;
 		}
+#endif /* CONFIG_TIMEUTIL_APPLY_SKEW */
 		int64_t local_abs = (int64_t)tsp->base.local
 				    + (int64_t)local_delta;
 

--- a/tests/unit/timeutil/testcase.yaml
+++ b/tests/unit/timeutil/testcase.yaml
@@ -8,3 +8,7 @@ tests:
 
   utilities.time.64bit:
     extra_args: M64_MODE=1
+
+  utilities.time.no_skew:
+    extra_configs:
+      - CONFIG_TIMEUTIL_APPLY_SKEW=n


### PR DESCRIPTION
Accurately applying clock skew correction in `timeutil_sync_ref_from_local` and `timeutil_sync_local_from_ref` requires double-precision floating point operations. If this is the only usage of double precision logic in the build, but clocks skews are not used, this can be a significant ROM overhead. Disabling this option can save ~2.4 kB of ROM.

Defaulting the symbol to `y` means there is no application behavior change unless the user takes action.