### PR TITLE
soc: xlnx: zynqmp: add ZynqMP SoC support (APU)

### DIFF
--- a/soc/xlnx/zynqmp/CMakeLists.txt
+++ b/soc/xlnx/zynqmp/CMakeLists.txt
@@ -2,16 +2,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources(
-  soc.c
-)
 zephyr_sources_ifdef(
   CONFIG_ARM_MPU
   arm_mpu_regions.c
+  soc.c
+)
+zephyr_sources_ifdef(
+  CONFIG_ARM_MMU
+  arm_mmu_regions.c
 )
 
 zephyr_include_directories(.)
 
 if(CONFIG_SOC_XILINX_ZYNQMP_RPU)
   set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld CACHE INTERNAL "")
+endif()
+
+if(CONFIG_SOC_XILINX_ZYNQMP_APU)
+  set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm64/scripts/linker.ld CACHE INTERNAL "")
 endif()

--- a/soc/xlnx/zynqmp/Kconfig
+++ b/soc/xlnx/zynqmp/Kconfig
@@ -10,3 +10,9 @@ config SOC_XILINX_ZYNQMP_RPU
 	select CPU_HAS_ARM_MPU
 	select ARM_MPU
 	select VFP_DP_D16
+
+config SOC_XILINX_ZYNQMP_APU
+    bool
+    select ARM64
+    select ARM_ARCH_TIMER
+    select CPU_CORTEX_A53

--- a/soc/xlnx/zynqmp/Kconfig.defconfig
+++ b/soc/xlnx/zynqmp/Kconfig.defconfig
@@ -16,6 +16,18 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 
 endif # SOC_XILINX_ZYNQMP_RPU
 
+if SOC_XILINX_ZYNQMP_APU
+
+config NUM_IRQS
+	# must be >= the highest interrupt number used
+	# - include the UART interrupts
+	default 220
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+
+endif # SOC_XILINX_ZYNQMP_APU
+
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_FLASH := zephyr,flash
 

--- a/soc/xlnx/zynqmp/Kconfig.soc
+++ b/soc/xlnx/zynqmp/Kconfig.soc
@@ -11,8 +11,15 @@ config SOC_XILINX_ZYNQMP_RPU
 	help
 	  Xilinx ZynqMP RPU
 
+config SOC_XILINX_ZYNQMP_APU
+	bool
+	select SOC_XILINX_ZYNQMP
+	help
+	  Xilinx ZynqMP APU
+
 config SOC_FAMILY
 	default "xilinx_zynqmp" if SOC_XILINX_ZYNQMP
 
 config SOC
 	default "zynqmp_rpu" if SOC_XILINX_ZYNQMP_RPU
+	default "zynqmp_apu" if SOC_XILINX_ZYNQMP_APU

--- a/soc/xlnx/zynqmp/arm_mmu_regions.c
+++ b/soc/xlnx/zynqmp/arm_mmu_regions.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/arm64/arm_mmu.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+
+static const struct arm_mmu_region mmu_regions[] = {
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+
+	MMU_REGION_FLAT_ENTRY("GIC",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+};
+
+const struct arm_mmu_config mmu_config = {
+	.num_regions = ARRAY_SIZE(mmu_regions),
+	.mmu_regions = mmu_regions,
+};

--- a/soc/xlnx/zynqmp/soc.yml
+++ b/soc/xlnx/zynqmp/soc.yml
@@ -2,3 +2,4 @@ family:
 - name: xilinx_zynqmp
   socs:
   - name: zynqmp_rpu
+  - name: zynqmp_apu


### PR DESCRIPTION
Summary  
  Introduce Xilinx ZynqMP SoC support under soc/xlnx/zynqmp with APU (Cortex-A53)  variants.  

Changes  
  Add soc.yml entry and Kconfig.soc/Kconfig/Kconfig.defconfig  
  Wire linker scripts for ARM64 and Cortex-A  
  Provide arm_mmu_regions.c (based on versalnet)  
  CMakeLists: build MMU/MPU sources conditionally  

Signed-off-by: Manabu Tajima mana.taj@gmail.com
