### PR TITLE
i2c/i3c: rtio: explicit zeroing of SQE flags

### DIFF
--- a/drivers/i2c/i2c_rtio.c
+++ b/drivers/i2c/i2c_rtio.c
@@ -213,6 +213,7 @@ int i2c_rtio_configure(struct i2c_rtio *ctx, uint32_t i2c_config)
 	}
 
 	sqe->op = RTIO_OP_I2C_CONFIGURE;
+	sqe->flags = 0;
 	sqe->iodev = iodev;
 	sqe->i2c_config = i2c_config;
 
@@ -245,6 +246,7 @@ int i2c_rtio_recover(struct i2c_rtio *ctx)
 	}
 
 	sqe->op = RTIO_OP_I2C_RECOVER;
+	sqe->flags = 0;
 	sqe->iodev = iodev;
 
 	rtio_submit(r, 1);

--- a/drivers/i3c/i3c_rtio.c
+++ b/drivers/i3c/i3c_rtio.c
@@ -176,6 +176,7 @@ int i3c_rtio_configure(struct i3c_rtio *ctx, enum i3c_config_type type, void *co
 	}
 
 	sqe->op = RTIO_OP_I3C_CONFIGURE;
+	sqe->flags = 0;
 	sqe->iodev = iodev;
 	sqe->i3c_config.type = type;
 	sqe->i3c_config.config = config;
@@ -213,6 +214,7 @@ int i3c_rtio_ccc(struct i3c_rtio *ctx, struct i3c_ccc_payload *payload)
 	}
 
 	sqe->op = RTIO_OP_I3C_CCC;
+	sqe->flags = 0;
 	sqe->iodev = iodev;
 	sqe->ccc_payload = payload;
 
@@ -249,6 +251,7 @@ int i3c_rtio_recover(struct i3c_rtio *ctx)
 	}
 
 	sqe->op = RTIO_OP_I3C_RECOVER;
+	sqe->flags = 0;
 	sqe->iodev = iodev;
 
 	rtio_submit(r, 1);


### PR DESCRIPTION
Explcitly zero the flags of the SQE obtained from `rtio_sqe_acquire` when the `rtio_sqe_prep_*` helpers aren't used (the helpers memset the entire struct to 0).

The flags must be reset to ensure the `RTIO_SQE_TRANSACTION` and `RTIO_SQE_CHAINED` are not retained from a previous SQE.