### PR TITLE
sensor: ti: ina2xx: fix fault on unsupported channels

### DIFF
--- a/drivers/sensor/ti/ina2xx/ina2xx_common.h
+++ b/drivers/sensor/ti/ina2xx/ina2xx_common.h
@@ -74,13 +74,27 @@ struct ina2xx_channel {
  * are available on all INA2XX variants.
  */
 struct ina2xx_channels {
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_BUS_VOLTAGE
 	const struct ina2xx_channel *voltage;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_BUS_VOLTAGE */
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_SHUNT_VOLTAGE
 	const struct ina2xx_channel *vshunt;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_SHUNT_VOLTAGE */
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_CURRENT
 	const struct ina2xx_channel *current;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_CURRENT */
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_POWER
 	const struct ina2xx_channel *power;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_POWER */
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_DIE_TEMP
 	const struct ina2xx_channel *die_temp;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_DIE_TEMP */
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_ENERGY
 	const struct ina2xx_channel *energy;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_ENERGY */
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_CHARGE
 	const struct ina2xx_channel *charge;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_CHARGE */
 };
 
 /**

--- a/drivers/sensor/ti/ina2xx/ina2xx_fetch.c
+++ b/drivers/sensor/ti/ina2xx/ina2xx_fetch.c
@@ -13,6 +13,10 @@ static int ina2xx_fetch_bus_voltage(const struct device *dev)
 		const struct ina2xx_channel *ch = config->channels->voltage;
 		struct ina2xx_data *data = dev->data;
 
+		if (ch == NULL) {
+			return -ENOTSUP;
+		}
+
 		return ina2xx_reg_read(&config->bus, ch->reg, data->voltage, sizeof(data->voltage));
 	}
 
@@ -25,6 +29,10 @@ static int ina2xx_fetch_shunt_voltage(const struct device *dev)
 		const struct ina2xx_config *config = dev->config;
 		const struct ina2xx_channel *ch = config->channels->vshunt;
 		struct ina2xx_data *data = dev->data;
+
+		if (ch == NULL) {
+			return -ENOTSUP;
+		}
 
 		return ina2xx_reg_read(&config->bus, ch->reg, data->vshunt, sizeof(data->vshunt));
 	}
@@ -39,6 +47,10 @@ static int ina2xx_fetch_current(const struct device *dev)
 		const struct ina2xx_channel *ch = config->channels->current;
 		struct ina2xx_data *data = dev->data;
 
+		if (ch == NULL) {
+			return -ENOTSUP;
+		}
+
 		return ina2xx_reg_read(&config->bus, ch->reg, data->current, sizeof(data->current));
 	}
 
@@ -52,6 +64,10 @@ static int ina2xx_fetch_power(const struct device *dev)
 		const struct ina2xx_channel *ch = config->channels->power;
 		struct ina2xx_data *data = dev->data;
 
+		if (ch == NULL) {
+			return -ENOTSUP;
+		}
+
 		return ina2xx_reg_read(&config->bus, ch->reg, data->power, sizeof(data->power));
 	}
 
@@ -64,6 +80,10 @@ static int ina2xx_fetch_die_temp(const struct device *dev)
 		const struct ina2xx_config *config = dev->config;
 		const struct ina2xx_channel *ch = config->channels->die_temp;
 		struct ina2xx_data *data = dev->data;
+
+		if (ch == NULL) {
+			return -ENOTSUP;
+		}
 
 		return ina2xx_reg_read(&config->bus, ch->reg, data->die_temp,
 			sizeof(data->die_temp));
@@ -79,6 +99,10 @@ static int ina2xx_fetch_energy(const struct device *dev)
 		const struct ina2xx_channel *ch = config->channels->energy;
 		struct ina2xx_data *data = dev->data;
 
+		if (ch == NULL) {
+			return -ENOTSUP;
+		}
+
 		return ina2xx_reg_read(&config->bus, ch->reg, data->energy, sizeof(data->energy));
 	}
 
@@ -91,6 +115,10 @@ static int ina2xx_fetch_charge(const struct device *dev)
 		const struct ina2xx_config *config = dev->config;
 		const struct ina2xx_channel *ch = config->channels->charge;
 		struct ina2xx_data *data = dev->data;
+
+		if (ch == NULL) {
+			return -ENOTSUP;
+		}
 
 		return ina2xx_reg_read(&config->bus, ch->reg, data->charge, sizeof(data->charge));
 	}

--- a/drivers/sensor/ti/ina2xx/ina2xx_fetch.c
+++ b/drivers/sensor/ti/ina2xx/ina2xx_fetch.c
@@ -8,122 +8,121 @@
 
 static int ina2xx_fetch_bus_voltage(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_INA2XX_HAS_CHANNEL_BUS_VOLTAGE)) {
-		const struct ina2xx_config *config = dev->config;
-		const struct ina2xx_channel *ch = config->channels->voltage;
-		struct ina2xx_data *data = dev->data;
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_BUS_VOLTAGE
+	const struct ina2xx_config *config = dev->config;
+	const struct ina2xx_channel *ch = config->channels->voltage;
+	struct ina2xx_data *data = dev->data;
 
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
-
-		return ina2xx_reg_read(&config->bus, ch->reg, data->voltage, sizeof(data->voltage));
+	if (ch == NULL) {
+		return -ENOTSUP;
 	}
 
+	return ina2xx_reg_read(&config->bus, ch->reg, data->voltage, sizeof(data->voltage));
+#else
 	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_BUS_VOLTAGE */
 }
 
 static int ina2xx_fetch_shunt_voltage(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_INA2XX_HAS_CHANNEL_SHUNT_VOLTAGE)) {
-		const struct ina2xx_config *config = dev->config;
-		const struct ina2xx_channel *ch = config->channels->vshunt;
-		struct ina2xx_data *data = dev->data;
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_SHUNT_VOLTAGE
+	const struct ina2xx_config *config = dev->config;
+	const struct ina2xx_channel *ch = config->channels->vshunt;
+	struct ina2xx_data *data = dev->data;
 
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
-
-		return ina2xx_reg_read(&config->bus, ch->reg, data->vshunt, sizeof(data->vshunt));
+	if (ch == NULL) {
+		return -ENOTSUP;
 	}
 
+	return ina2xx_reg_read(&config->bus, ch->reg, data->vshunt, sizeof(data->vshunt));
+#else
 	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_SHUNT_VOLTAGE */
 }
 
 static int ina2xx_fetch_current(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_INA2XX_HAS_CHANNEL_CURRENT)) {
-		const struct ina2xx_config *config = dev->config;
-		const struct ina2xx_channel *ch = config->channels->current;
-		struct ina2xx_data *data = dev->data;
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_CURRENT
+	const struct ina2xx_config *config = dev->config;
+	const struct ina2xx_channel *ch = config->channels->current;
+	struct ina2xx_data *data = dev->data;
 
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
-
-		return ina2xx_reg_read(&config->bus, ch->reg, data->current, sizeof(data->current));
+	if (ch == NULL) {
+		return -ENOTSUP;
 	}
 
+	return ina2xx_reg_read(&config->bus, ch->reg, data->current, sizeof(data->current));
+#else
 	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_CURRENT */
 }
 
 static int ina2xx_fetch_power(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_INA2XX_HAS_CHANNEL_POWER)) {
-		const struct ina2xx_config *config = dev->config;
-		const struct ina2xx_channel *ch = config->channels->power;
-		struct ina2xx_data *data = dev->data;
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_POWER
+	const struct ina2xx_config *config = dev->config;
+	const struct ina2xx_channel *ch = config->channels->power;
+	struct ina2xx_data *data = dev->data;
 
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
-
-		return ina2xx_reg_read(&config->bus, ch->reg, data->power, sizeof(data->power));
+	if (ch == NULL) {
+		return -ENOTSUP;
 	}
 
+	return ina2xx_reg_read(&config->bus, ch->reg, data->power, sizeof(data->power));
+#else
 	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_POWER */
 }
 
 static int ina2xx_fetch_die_temp(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_INA2XX_HAS_CHANNEL_DIE_TEMP)) {
-		const struct ina2xx_config *config = dev->config;
-		const struct ina2xx_channel *ch = config->channels->die_temp;
-		struct ina2xx_data *data = dev->data;
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_DIE_TEMP
+	const struct ina2xx_config *config = dev->config;
+	const struct ina2xx_channel *ch = config->channels->die_temp;
+	struct ina2xx_data *data = dev->data;
 
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
-
-		return ina2xx_reg_read(&config->bus, ch->reg, data->die_temp,
-			sizeof(data->die_temp));
+	if (ch == NULL) {
+		return -ENOTSUP;
 	}
 
+	return ina2xx_reg_read(&config->bus, ch->reg, data->die_temp, sizeof(data->die_temp));
+#else
 	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_DIE_TEMP */
 }
 
 static int ina2xx_fetch_energy(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_INA2XX_HAS_CHANNEL_ENERGY)) {
-		const struct ina2xx_config *config = dev->config;
-		const struct ina2xx_channel *ch = config->channels->energy;
-		struct ina2xx_data *data = dev->data;
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_ENERGY
+	const struct ina2xx_config *config = dev->config;
+	const struct ina2xx_channel *ch = config->channels->energy;
+	struct ina2xx_data *data = dev->data;
 
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
-
-		return ina2xx_reg_read(&config->bus, ch->reg, data->energy, sizeof(data->energy));
+	if (ch == NULL) {
+		return -ENOTSUP;
 	}
 
+	return ina2xx_reg_read(&config->bus, ch->reg, data->energy, sizeof(data->energy));
+#else
 	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_ENERGY */
 }
 
 static int ina2xx_fetch_charge(const struct device *dev)
 {
-	if (IS_ENABLED(CONFIG_INA2XX_HAS_CHANNEL_CHARGE)) {
-		const struct ina2xx_config *config = dev->config;
-		const struct ina2xx_channel *ch = config->channels->charge;
-		struct ina2xx_data *data = dev->data;
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_CHARGE
+	const struct ina2xx_config *config = dev->config;
+	const struct ina2xx_channel *ch = config->channels->charge;
+	struct ina2xx_data *data = dev->data;
 
-		if (ch == NULL) {
-			return -ENOTSUP;
-		}
-
-		return ina2xx_reg_read(&config->bus, ch->reg, data->charge, sizeof(data->charge));
+	if (ch == NULL) {
+		return -ENOTSUP;
 	}
 
+	return ina2xx_reg_read(&config->bus, ch->reg, data->charge, sizeof(data->charge));
+#else
 	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_CHARGE */
 }
 
 static int ina2xx_fetch_all(const struct device *dev)

--- a/drivers/sensor/ti/ina2xx/ina2xx_get.c
+++ b/drivers/sensor/ti/ina2xx/ina2xx_get.c
@@ -11,10 +11,11 @@
 
 static int ina2xx_get_bus_voltage(const struct device *dev, struct sensor_value *val)
 {
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_BUS_VOLTAGE
 	const struct ina2xx_config *config = dev->config;
 	const struct ina2xx_channel *ch = config->channels->voltage;
-	const size_t bytes = (ch->reg->size + 7) / 8;
 	struct ina2xx_data *data = dev->data;
+	size_t bytes;
 	union {
 		uint32_t u32;
 		int32_t s32;
@@ -23,6 +24,8 @@ static int ina2xx_get_bus_voltage(const struct device *dev, struct sensor_value 
 	if (ch == NULL) {
 		return -ENOTSUP;
 	}
+
+	bytes = (ch->reg->size + 7) / 8;
 
 	/* 16 or 20 bit, two's complement */
 	if (bytes == 2) {
@@ -38,14 +41,18 @@ static int ina2xx_get_bus_voltage(const struct device *dev, struct sensor_value 
 	value.s32 = (ch->mult * value.s32) / ch->div;
 
 	return sensor_value_from_micro(val, value.s32);
+#else
+	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_BUS_VOLTAGE */
 }
 
 static int ina2xx_get_shunt_voltage(const struct device *dev, struct sensor_value *val)
 {
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_SHUNT_VOLTAGE
 	const struct ina2xx_config *config = dev->config;
 	const struct ina2xx_channel *ch = config->channels->vshunt;
-	const size_t bytes = (ch->reg->size + 7) / 8;
 	struct ina2xx_data *data = dev->data;
+	size_t bytes;
 	union {
 		uint32_t u32;
 		int32_t s32;
@@ -54,6 +61,8 @@ static int ina2xx_get_shunt_voltage(const struct device *dev, struct sensor_valu
 	if (ch == NULL) {
 		return -ENOTSUP;
 	}
+
+	bytes = (ch->reg->size + 7) / 8;
 
 	/* 16 or 20 bit, two's complement */
 	if (bytes == 2) {
@@ -69,14 +78,18 @@ static int ina2xx_get_shunt_voltage(const struct device *dev, struct sensor_valu
 	value.s32 = (ch->mult * value.s32) / ch->div;
 
 	return sensor_value_from_micro(val, value.s32);
+#else
+	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_SHUNT_VOLTAGE */
 }
 
 static int ina2xx_get_current(const struct device *dev, struct sensor_value *val)
 {
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_CURRENT
 	const struct ina2xx_config *config = dev->config;
 	const struct ina2xx_channel *ch = config->channels->current;
-	const size_t bytes = (ch->reg->size + 7) / 8;
 	struct ina2xx_data *data = dev->data;
+	size_t bytes;
 	union {
 		uint32_t u32;
 		int32_t s32;
@@ -85,6 +98,8 @@ static int ina2xx_get_current(const struct device *dev, struct sensor_value *val
 	if (ch == NULL) {
 		return -ENOTSUP;
 	}
+
+	bytes = (ch->reg->size + 7) / 8;
 
 	/* 16 or 20 bit, two's complement. Multiplied by current lsb */
 	if (bytes == 2) {
@@ -100,19 +115,25 @@ static int ina2xx_get_current(const struct device *dev, struct sensor_value *val
 	value.s32 = ((config->current_lsb * value.s32) / ch->div) * ch->mult;
 
 	return sensor_value_from_micro(val, value.s32);
+#else
+	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_CURRENT */
 }
 
 static int ina2xx_get_power(const struct device *dev, struct sensor_value *val)
 {
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_POWER
 	const struct ina2xx_config *config = dev->config;
 	const struct ina2xx_channel *ch = config->channels->power;
-	const size_t bytes = (ch->reg->size + 7) / 8;
 	struct ina2xx_data *data = dev->data;
+	size_t bytes;
 	uint64_t value;
 
 	if (ch == NULL) {
 		return -ENOTSUP;
 	}
+
+	bytes = (ch->reg->size + 7) / 8;
 
 	/* 16 or 24 bit, unsigned. Multiplied by current lsb */
 	if (bytes == 2) {
@@ -126,14 +147,18 @@ static int ina2xx_get_power(const struct device *dev, struct sensor_value *val)
 	value = ((config->current_lsb * value) / ch->div) * ch->mult;
 
 	return sensor_value_from_micro(val, value);
+#else
+	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_POWER */
 }
 
 static int ina2xx_get_die_temp(const struct device *dev, struct sensor_value *val)
 {
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_DIE_TEMP
 	const struct ina2xx_config *config = dev->config;
 	const struct ina2xx_channel *ch = config->channels->die_temp;
-	const size_t bytes = (ch->reg->size + 7) / 8;
 	struct ina2xx_data *data = dev->data;
+	size_t bytes;
 	union {
 		uint64_t u64;
 		int64_t s64;
@@ -142,6 +167,8 @@ static int ina2xx_get_die_temp(const struct device *dev, struct sensor_value *va
 	if (ch == NULL) {
 		return -ENOTSUP;
 	}
+
+	bytes = (ch->reg->size + 7) / 8;
 
 	/* 12 or 16 bit, two's complement. */
 	if (bytes == 2) {
@@ -154,19 +181,25 @@ static int ina2xx_get_die_temp(const struct device *dev, struct sensor_value *va
 	value.s64 = (ch->mult * value.s64) / ch->div;
 
 	return sensor_value_from_micro(val, value.s64);
+#else
+	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_DIE_TEMP */
 }
 
 static int ina2xx_get_energy(const struct device *dev, struct sensor_value *val)
 {
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_ENERGY
 	const struct ina2xx_config *config = dev->config;
 	const struct ina2xx_channel *ch = config->channels->energy;
-	const size_t bytes = (ch->reg->size + 7) / 8;
 	struct ina2xx_data *data = dev->data;
+	size_t bytes;
 	uint64_t value;
 
 	if (ch == NULL) {
 		return -ENOTSUP;
 	}
+
+	bytes = (ch->reg->size + 7) / 8;
 
 	/* 40 bit, unsigned. Multiplied by current lsb */
 	if (bytes == 5) {
@@ -178,14 +211,18 @@ static int ina2xx_get_energy(const struct device *dev, struct sensor_value *val)
 	value = ((value * config->current_lsb) / ch->div) * ch->mult;
 
 	return sensor_value_from_micro(val, value);
+#else
+	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_ENERGY */
 }
 
 static int ina2xx_get_charge(const struct device *dev, struct sensor_value *val)
 {
+#ifdef CONFIG_INA2XX_HAS_CHANNEL_CHARGE
 	const struct ina2xx_config *config = dev->config;
 	const struct ina2xx_channel *ch = config->channels->charge;
-	const size_t bytes = (ch->reg->size + 7) / 8;
 	struct ina2xx_data *data = dev->data;
+	size_t bytes;
 	union {
 		uint64_t u64;
 		int64_t s64;
@@ -194,6 +231,8 @@ static int ina2xx_get_charge(const struct device *dev, struct sensor_value *val)
 	if (ch == NULL) {
 		return -ENOTSUP;
 	}
+
+	bytes = (ch->reg->size + 7) / 8;
 
 	/* 40 bit, two's complement. Multiplied by current lsb */
 	if (bytes == 5) {
@@ -206,10 +245,12 @@ static int ina2xx_get_charge(const struct device *dev, struct sensor_value *val)
 	value.s64 = ((config->current_lsb * value.s64) / ch->div) * ch->mult;
 
 	return sensor_value_from_micro(val, value.s64);
+#else
+	return -ENOTSUP;
+#endif /* CONFIG_INA2XX_HAS_CHANNEL_CHARGE */
 }
 
-int ina2xx_channel_get(const struct device *dev, enum sensor_channel chan,
-				  struct sensor_value *val)
+int ina2xx_channel_get(const struct device *dev, enum sensor_channel chan, struct sensor_value *val)
 {
 	/* Extended channels */
 	if (chan == (enum sensor_channel)SENSOR_CHAN_INA2XX_ENERGY) {

--- a/drivers/sensor/ti/ina2xx/ina2xx_get.c
+++ b/drivers/sensor/ti/ina2xx/ina2xx_get.c
@@ -20,6 +20,10 @@ static int ina2xx_get_bus_voltage(const struct device *dev, struct sensor_value 
 		int32_t s32;
 	} value;
 
+	if (ch == NULL) {
+		return -ENOTSUP;
+	}
+
 	/* 16 or 20 bit, two's complement */
 	if (bytes == 2) {
 		value.u32 = sys_get_be16(data->voltage) >> ch->shift;
@@ -46,6 +50,10 @@ static int ina2xx_get_shunt_voltage(const struct device *dev, struct sensor_valu
 		uint32_t u32;
 		int32_t s32;
 	} value;
+
+	if (ch == NULL) {
+		return -ENOTSUP;
+	}
 
 	/* 16 or 20 bit, two's complement */
 	if (bytes == 2) {
@@ -74,6 +82,10 @@ static int ina2xx_get_current(const struct device *dev, struct sensor_value *val
 		int32_t s32;
 	} value;
 
+	if (ch == NULL) {
+		return -ENOTSUP;
+	}
+
 	/* 16 or 20 bit, two's complement. Multiplied by current lsb */
 	if (bytes == 2) {
 		value.u32 = sys_get_be16(data->current) >> ch->shift;
@@ -97,6 +109,10 @@ static int ina2xx_get_power(const struct device *dev, struct sensor_value *val)
 	const size_t bytes = (ch->reg->size + 7) / 8;
 	struct ina2xx_data *data = dev->data;
 	uint64_t value;
+
+	if (ch == NULL) {
+		return -ENOTSUP;
+	}
 
 	/* 16 or 24 bit, unsigned. Multiplied by current lsb */
 	if (bytes == 2) {
@@ -123,6 +139,10 @@ static int ina2xx_get_die_temp(const struct device *dev, struct sensor_value *va
 		int64_t s64;
 	} value;
 
+	if (ch == NULL) {
+		return -ENOTSUP;
+	}
+
 	/* 12 or 16 bit, two's complement. */
 	if (bytes == 2) {
 		value.u64 = sys_get_be16(data->die_temp) >> ch->shift;
@@ -143,6 +163,10 @@ static int ina2xx_get_energy(const struct device *dev, struct sensor_value *val)
 	const size_t bytes = (ch->reg->size + 7) / 8;
 	struct ina2xx_data *data = dev->data;
 	uint64_t value;
+
+	if (ch == NULL) {
+		return -ENOTSUP;
+	}
 
 	/* 40 bit, unsigned. Multiplied by current lsb */
 	if (bytes == 5) {
@@ -166,6 +190,10 @@ static int ina2xx_get_charge(const struct device *dev, struct sensor_value *val)
 		uint64_t u64;
 		int64_t s64;
 	} value;
+
+	if (ch == NULL) {
+		return -ENOTSUP;
+	}
 
 	/* 40 bit, two's complement. Multiplied by current lsb */
 	if (bytes == 5) {


### PR DESCRIPTION
Fix calling `sensor_channel_get` on a channel that is not supported by the hardware from faulting with a NULL de-reference.

This fixes the following pattern (used by `fuel_guage/composite`):
```
sensor_sample_fetch(dev);
if (sensor_channel_get(dev, chan, val) == -EINVAL) {
    printk("Not supported\n");
}
````