### PR TITLE
kernel: Add ifdef guard around ipi_lock definition

### DIFF
--- a/kernel/ipi.c
+++ b/kernel/ipi.c
@@ -8,7 +8,9 @@
 #include <ksched.h>
 #include <ipi.h>
 
+#ifdef CONFIG_SCHED_IPI_SUPPORTED
 static struct k_spinlock ipi_lock;
+#endif
 
 #ifdef CONFIG_TRACE_SCHED_IPI
 extern void z_trace_sched_ipi(void);


### PR DESCRIPTION
The global variable ipi_lock is both local to the file ipi.c and only used when CONFIG_SCHED_IPI_SUPPORTED is enabled. As such its definition should be wrapped with an ifdef.