### PR TITLE
dts: nordic: nrf54h20: disable lfclk by default

### DIFF
--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -203,7 +203,6 @@
 			status = "disabled";
 			#clock-cells = <0>;
 			clock-frequency = <32768>;
-			status = "okay";
 			lfrc-accuracy-ppm = <500>;
 			lflprc-accuracy-ppm = <1000>;
 			lfrc-startup-time-us = <200>; /* To be measured */


### PR DESCRIPTION
The lfclk was left enabled by mistake, it has status disabled followed by status okay a few lines down. Remove the spurious status = "okay";