### PR TITLE
include: flash: move spi_nor.h to public headers

### DIFF
--- a/drivers/flash/flash_andes_qspi.c
+++ b/drivers/flash/flash_andes_qspi.c
@@ -10,12 +10,12 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/init.h>
 #include <string.h>
 #include <zephyr/logging/log.h>
 
 #include "flash_andes_qspi.h"
-#include "spi_nor.h"
 #include "jesd216.h"
 #include "flash_priv.h"
 

--- a/drivers/flash/flash_andes_qspi_xip.c
+++ b/drivers/flash/flash_andes_qspi_xip.c
@@ -15,13 +15,13 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/cache.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/drivers/flash/andes_flash_xip_api_ex.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 
 #include "flash_andes_qspi.h"
-#include "spi_nor.h"
 
 LOG_MODULE_REGISTER(flash_andes_xip, CONFIG_FLASH_LOG_LEVEL);
 

--- a/drivers/flash/flash_max32_spixf_nor.c
+++ b/drivers/flash/flash_max32_spixf_nor.c
@@ -47,7 +47,7 @@
 
 #include <spixf.h>
 
-#include "spi_nor.h"
+#include <zephyr/drivers/flash/spi_nor.h>
 #include "jesd216.h"
 
 #include <zephyr/logging/log.h>

--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -7,10 +7,10 @@
 #define DT_DRV_COMPAT	nxp_imx_flexspi_mx25um51345g
 
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/util.h>
-#include "spi_nor.h"
 #include "memc_mcux_flexspi.h"
 
 #ifdef CONFIG_HAS_MCUX_CACHE

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -11,7 +11,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
-#include "spi_nor.h"
+#include <zephyr/drivers/flash/spi_nor.h>
 #include "jesd216.h"
 #include "memc_mcux_flexspi.h"
 

--- a/drivers/flash/flash_mcux_xspi.c
+++ b/drivers/flash/flash_mcux_xspi.c
@@ -8,13 +8,13 @@
 
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
 #include "memc_mcux_xspi.h"
-#include "spi_nor.h"
 
 LOG_MODULE_REGISTER(flash_mcux_xspi);
 

--- a/drivers/flash/flash_mspi_atxp032.c
+++ b/drivers/flash/flash_mspi_atxp032.c
@@ -25,7 +25,7 @@ typedef enum mspi_timing_param mspi_timing_param;
 #endif
 
 #include <zephyr/drivers/flash.h>
-#include "spi_nor.h"
+#include <zephyr/drivers/flash/spi_nor.h>
 LOG_MODULE_REGISTER(flash_mspi_atxp032, CONFIG_FLASH_LOG_LEVEL);
 
 #define NOR_WRITE_SIZE                      1

--- a/drivers/flash/flash_mspi_emul_device.c
+++ b/drivers/flash/flash_mspi_emul_device.c
@@ -13,7 +13,7 @@
 #include <zephyr/drivers/mspi.h>
 #include <zephyr/drivers/mspi_emul.h>
 #include <zephyr/drivers/flash.h>
-#include "spi_nor.h"
+#include <zephyr/drivers/flash/spi_nor.h>
 
 LOG_MODULE_REGISTER(zephyr_mspi_emul_flash, CONFIG_FLASH_LOG_LEVEL);
 

--- a/drivers/flash/flash_mspi_is25xX0xx.c
+++ b/drivers/flash/flash_mspi_is25xX0xx.c
@@ -17,7 +17,7 @@
 #include <zephyr/drivers/mspi.h>
 #include <zephyr/cache.h>
 #include <zephyr/drivers/flash.h>
-#include "spi_nor.h"
+#include <zephyr/drivers/flash/spi_nor.h>
 
 #if CONFIG_SOC_FAMILY_AMBIQ
 

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -12,9 +12,9 @@ extern "C" {
 #endif
 
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/drivers/mspi.h>
 #include "jesd216.h"
-#include "spi_nor.h"
 
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(supply_gpios)
 #define WITH_SUPPLY_GPIO 1

--- a/drivers/flash/flash_npcx_fiu_nor.c
+++ b/drivers/flash/flash_npcx_fiu_nor.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/drivers/flash/npcx_flash_api_ex.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/dt-bindings/flash_controller/npcx_fiu_qspi.h>
@@ -18,7 +19,6 @@
 #endif
 
 #include "flash_npcx_fiu_qspi.h"
-#include "spi_nor.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(flash_npcx_fiu_nor, CONFIG_FLASH_LOG_LEVEL);

--- a/drivers/flash/flash_nxp_s32_qspi_nor.c
+++ b/drivers/flash/flash_nxp_s32_qspi_nor.c
@@ -11,11 +11,11 @@ LOG_MODULE_REGISTER(nxp_s32_qspi_nor, CONFIG_FLASH_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/sys/util.h>
 
 #include <Qspi_Ip.h>
 
-#include "spi_nor.h"
 #include "jesd216.h"
 
 #include "memc_nxp_s32_qspi.h"

--- a/drivers/flash/flash_realtek_rts5912.c
+++ b/drivers/flash/flash_realtek_rts5912.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(flash_rts5912);
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #ifdef CONFIG_FLASH_EX_OP_ENABLED
 #include <zephyr/drivers/flash/rts5912_flash_api_ex.h>
 #endif
@@ -25,7 +26,6 @@ LOG_MODULE_REGISTER(flash_rts5912);
 #include <soc.h>
 #include <string.h>
 
-#include "spi_nor.h"
 #include "reg/reg_spic.h"
 
 #define FLASH_CMD_RDSFDP         0x5A /* Read SFDP */

--- a/drivers/flash/flash_renesas_ra_ospi_b.h
+++ b/drivers/flash/flash_renesas_ra_ospi_b.h
@@ -8,12 +8,12 @@
 #define ZEPHYR_DRIVERS_FLASH_RENESAS_RA_OSPI_B_H_
 
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 #include <r_spi_flash_api.h>
 #include <r_ospi_b.h>
 #include "spi_nor_s28hx512t.h"
-#include "spi_nor.h"
 
 /* Device node */
 #define RA_OSPI_B_NOR_NODE DT_INST(0, renesas_ra_ospi_b_nor)

--- a/drivers/flash/flash_renesas_ra_qspi.c
+++ b/drivers/flash/flash_renesas_ra_qspi.c
@@ -14,7 +14,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/drivers/flash/ra_flash_api_extensions.h>
-#include "spi_nor.h"
+#include <zephyr/drivers/flash/spi_nor.h>
 #include "r_spi_flash_api.h"
 #include "r_qspi.h"
 

--- a/drivers/flash/flash_renesas_rz_qspi.c
+++ b/drivers/flash/flash_renesas_rz_qspi.c
@@ -10,8 +10,8 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/cache.h>
-#include "spi_nor.h"
 #include "r_spi_flash_api.h"
 
 #if defined(CONFIG_FLASH_RENESAS_RZ_QSPI_SPIBSC)

--- a/drivers/flash/flash_sf32lb_mpi_qspi_nor.c
+++ b/drivers/flash/flash_sf32lb_mpi_qspi_nor.c
@@ -6,7 +6,6 @@
 #define DT_DRV_COMPAT sifli_sf32lb_mpi_qspi_nor
 
 #include "jesd216.h"
-#include "spi_nor.h"
 
 #include <stdint.h>
 
@@ -14,6 +13,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/dma/sf32lb.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/cache.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/sys/util.h>

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -18,11 +18,11 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/irq.h>
 
-#include "spi_nor.h"
 #include "jesd216.h"
 
 #include "flash_stm32_ospi.h"

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -21,6 +21,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/drivers/flash/stm32_flash_api_extensions.h>
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/dma/dma_stm32.h>
@@ -47,7 +48,6 @@
 
 #include <stm32_ll_dma.h>
 
-#include "spi_nor.h"
 #include "jesd216.h"
 
 #include <zephyr/logging/log.h>

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -21,11 +21,11 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/irq.h>
 
-#include "spi_nor.h"
 #include "jesd216.h"
 
 #include <zephyr/logging/log.h>

--- a/drivers/flash/jesd216.c
+++ b/drivers/flash/jesd216.c
@@ -8,7 +8,7 @@
 #include <sys/types.h>
 #include <zephyr/kernel.h>
 #include "jesd216.h"
-#include "spi_nor.h"
+#include <zephyr/drivers/flash/spi_nor.h>
 
 static bool extract_instr(uint16_t packed,
 			  struct jesd216_instr *res)

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/init.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
@@ -19,7 +20,6 @@
 #include <zephyr/irq.h>
 LOG_MODULE_REGISTER(qspi_nor, CONFIG_FLASH_LOG_LEVEL);
 
-#include "spi_nor.h"
 #include "jesd216.h"
 #include "flash_priv.h"
 #include <nrfx_qspi.h>

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -12,6 +12,7 @@
 
 #include <errno.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/flash/spi_nor.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/init.h>
@@ -21,7 +22,6 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 
-#include "spi_nor.h"
 #include "jesd216.h"
 #include "flash_priv.h"
 

--- a/include/zephyr/drivers/flash/spi_nor.h
+++ b/include/zephyr/drivers/flash/spi_nor.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __SPI_NOR_H__
-#define __SPI_NOR_H__
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FLASH_SPI_NOR_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FLASH_SPI_NOR_H_
 
 #include <zephyr/sys/util.h>
 
@@ -131,4 +131,4 @@
 
 #define CMD_RDCR 0x15 /* Read the configuration register. */
 
-#endif /*__SPI_NOR_H__*/
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FLASH_SPI_NOR_H_ */


### PR DESCRIPTION
This PR moves spi_nor.h from drivers/flash to include/drivers/flash directory and updates affected flash drivers with new include path