### PR TITLE
drivers: gpio: pcf857x: pcf857x_port_get_raw() output parameter check invalid

### DIFF
--- a/drivers/gpio/gpio_pcf857x.c
+++ b/drivers/gpio/gpio_pcf857x.c
@@ -135,11 +135,6 @@ static int pcf857x_port_get_raw(const struct device *dev, gpio_port_value_t *val
 		return -EWOULDBLOCK;
 	}
 
-	if ((~drv_data->pins_cfg.configured_as_outputs & (uint16_t)*value) != (uint16_t)*value) {
-		LOG_ERR("Pin(s) is/are configured as output which should be input.");
-		return -EOPNOTSUPP;
-	}
-
 	k_sem_take(&drv_data->lock, K_FOREVER);
 
 	/**


### PR DESCRIPTION
The dereferenced value of function parameter 'value' is checked against output pin configuration, which absolutely makes no sense because this parameter is intended as pure output buffer. Nothing is mentioned in the interface that the buffer should have any specific content on call of this function. Thus the nonsensical check is removed.

Fixes: #100365