### PR TITLE
tests: scripts: add west debug support in twister

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -51,13 +51,15 @@ class HardwareAdapter(DeviceAdapter):
 
         command = [
             self.west,
-            'flash',
+            self.device_config.west_flash_cmd,
             '--no-rebuild',
             '--build-dir',
             str(self.device_config.build_dir),
         ]
 
         command_extra_args = []
+        if self.device_config.west_flash_cmd == 'debug':
+            command_extra_args.append('--batch')
         if self.device_config.west_flash_extra_args:
             command_extra_args.extend(self.device_config.west_flash_extra_args)
 

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -139,6 +139,11 @@ def pytest_addoption(parser: pytest.Parser):
         '--extra-test-args',
         help='Additional args passed to the test binary'
     )
+    twister_harness_group.addoption(
+        '--west-flash-cmd',
+        choices=('flash', 'debug'),
+        help='west command to use, can be flash or debug'
+    )
 
 
 def pytest_configure(config: pytest.Config):

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -44,6 +44,7 @@ class DeviceConfig:
     fixtures: list[str] = None
     app_build_dir: Path | None = None
     extra_test_args: str = ''
+    west_flash_cmd: str = 'flash'
 
     def __post_init__(self):
         domains = self.build_dir / 'domains.yaml'
@@ -101,7 +102,8 @@ class TwisterHarnessConfig:
             post_script=_cast_to_path(config.option.post_script),
             post_flash_script=_cast_to_path(config.option.post_flash_script),
             fixtures=config.option.fixtures,
-            extra_test_args=config.option.extra_test_args
+            extra_test_args=config.option.extra_test_args,
+            west_flash_cmd=config.option.west_flash_cmd or 'flash'
         )
 
         devices.append(device_from_cli)

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -272,6 +272,16 @@ Artificially long but functional example:
     )
 
     parser.add_argument(
+        "--west-flash-cmd", choices=['flash', 'debug'],
+        help="""Uses the specified west command. twister will use flash if not set
+
+        E.g "twister --device-testing --device-serial /dev/ttyACM0
+                         --west-flash-cmd="flash"
+        will translate to "west flash ..."
+        """
+    )
+
+    parser.add_argument(
         "-a", "--arch", action="append",
         help="Arch filter for testing. Takes precedence over --platform. "
              "If unspecified, test all arches. Multiple invocations "

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -587,10 +587,14 @@ class DeviceHandler(Handler):
             return self._create_flash_command(hardware)
 
         command = ["west"]
+        command_extra_args = []
         if self.options.verbose > 2:
             command.append(f"-{'v' * (self.options.verbose - 2)}")
-        command += ["flash", "--no-rebuild", "-d", self.build_dir]
-        command_extra_args = []
+
+        west_flash_cmd = self.options.west_flash_cmd or hardware.west_flash_cmd or "flash"
+        if west_flash_cmd == "debug":
+            command_extra_args.append('--batch')
+        command.extend([west_flash_cmd, "--no-rebuild", "-d", self.build_dir])
 
         # There are three ways this option is used.
         # 1) bare: default flags

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -58,6 +58,7 @@ class DUT:
     probe_id: str | None = None
     notes: str | None = None
     match: bool = False
+    west_flash_cmd: str | None = None
 
     def __post_init__(self):
         """Initialize non-serializable objects after dataclass initialization."""
@@ -66,8 +67,10 @@ class DUT:
         self._available = Value("i", 1)
         self._failures = Value("i", 0)
         self.lock = Lock()
+
         # Ensure serial_baud has a default value
         self.serial_baud = self.serial_baud or 115200
+
 
     @property
     def available(self):
@@ -288,6 +291,7 @@ class HardwareMap:
             product = dut.get('product')
             fixtures = dut.get('fixtures', [])
             connected = dut.get('connected') and ((serial or serial_pty) is not None)
+            west_flash_cmd = dut.get('west_flash_cmd', "")
             if not connected:
                 continue
             for plat in platforms:
@@ -306,7 +310,8 @@ class HardwareMap:
                               post_flash_script=post_flash_script,
                               script_param=script_param,
                               flash_timeout=flash_timeout,
-                              flash_with_test=flash_with_test)
+                              flash_with_test=flash_with_test,
+                              west_flash_cmd=west_flash_cmd)
                 new_dut.fixtures = fixtures
                 new_dut.counter = 0
                 self.duts.append(new_dut)

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -475,6 +475,9 @@ class Pytest(Harness):
         if runner := hardware.runner or options.west_runner:
             command.append(f'--runner={runner}')
 
+        if west_flash_cmd := options.west_flash_cmd or hardware.west_flash_cmd:
+            command.append(f'--west-flash-cmd={west_flash_cmd}')
+
         if hardware.runner_params:
             for param in hardware.runner_params:
                 command.append(f'--runner-params={param}')

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -56,6 +56,8 @@ items:
         post_flash_timeout:
           type: integer
       additionalProperties: false
+    west_flash_cmd:
+      type: string
   required:
     - connected
     - id

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1185,6 +1185,7 @@ def test_devicehandler_create_command(
 ):
     handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
     handler.options = mock.Mock(west_flash=self_west_flash,
+                                west_flash_cmd='flash',
                                 flash_command=self_flash_command, verbose=0)
     handler.generator_cmd = 'generator_cmd'
 
@@ -1195,7 +1196,8 @@ def test_devicehandler_create_command(
         product=hardware_product_name,
         probe_id=12345 if hardware_probe else None,
         id=12345 if not hardware_probe else None,
-        runner_params=['param1', 'param2']
+        runner_params=['param1', 'param2'],
+        west_flash_cmd=None
     )
 
     command = handler._create_command(runner, hardware)


### PR DESCRIPTION
in some multi-core platform, `west flash` can not support all core. `west debug` is supported to test secondary core, add this to twister such as with
`--west-flash-cmd=debug` in twister command
or with
`--west-flash-cmd: debug` in hwmap.yaml

and same with pytest

twister command line setting will override the one in hwamp