### PR TITLE
MAINTAINERS.yml: drivers: ethernet: add usb ethernet drivers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1656,6 +1656,9 @@ Documentation Infrastructure:
     - include/zephyr/net/mii.h
     - include/zephyr/net/ethernet.h
     - samples/drivers/ethernet/
+    - subsys/usb/device/class/netusb/
+    - subsys/usb/device_next/class/usbd_cdc_ecm.c
+    - subsys/usb/device_next/class/usbd_cdc_ncm.c
   labels:
     - "area: Ethernet"
   tests:


### PR DESCRIPTION
add usb ethernet/networking drivers to
ethernet drivers area, as they use the
ethernet api. Generally I would like them
to move, buts that's for later.