### PR TITLE
west.yml: Bump TF-M with stm32u5a sram5 support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -380,7 +380,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: 9889df41022c6679b71da55d93f9e3693a804976
+      revision: e295109067f71e1c8db76d02396baa050687b1df
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Enable SRAM5 region in the Global TrustZone controller (GTZC).