### PR TITLE
drivers: udc_mcux_ip3511: mark ep0 as not busy after setup.

### DIFF
--- a/drivers/usb/udc/udc_mcux_ip3511.c
+++ b/drivers/usb/udc/udc_mcux_ip3511.c
@@ -186,10 +186,26 @@ static int udc_mcux_ctrl_feed_dout(const struct device *dev,
 
 static int udc_mcux_handler_setup(const struct device *dev, struct usb_setup_packet *setup)
 {
+	struct udc_ep_config *cfg_out = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
+	struct udc_ep_config *cfg_in = udc_get_ep_cfg(dev, USB_CONTROL_EP_IN);
 	int err;
 	struct net_buf *buf;
 
 	LOG_DBG("setup packet");
+
+	buf = udc_buf_get_all(cfg_out);
+	if (buf) {
+		net_buf_unref(buf);
+	}
+
+	buf = udc_buf_get_all(cfg_in);
+	if (buf) {
+		net_buf_unref(buf);
+	}
+
+	udc_ep_set_busy(cfg_out, false);
+	udc_ep_set_busy(cfg_in, false);
+
 	buf = udc_ctrl_alloc(dev, USB_CONTROL_EP_OUT,
 			sizeof(struct usb_setup_packet));
 	if (buf == NULL) {


### PR DESCRIPTION
if a setup token is received before the previous out data is handled the endpoint needs to be marked as not busy. this is done similar in dwc2 and nrf udc drivers.

i ran into this issue on a imxrt685 board when connected to a macbook pro m5.
when i was able to reproduce the issue the host sends out a zlp to end the previous transaction, but sends a setup packet around 3 uS later.