### PR TITLE
Twister: fix serial port timeout

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -868,9 +868,15 @@ class DeviceHandler(Handler):
                     # Return to normal boot
                     ser.rts = False
                 else:
+                    # Wait for serial port to appear after flashing
+                    # To keep dependency between flash_timeout proposed 20% of this value
+                    # but not less than 10s. TO keep clarity of measurement,
+                    # declare new start time instead of using existing one start_time.
+                    serial_wait_timeout = max(10, int(flash_timeout * 0.2))
+                    flash_start_time = time.time()
                     while ser.port not in (p.name for p in list_ports.comports()):
                         time.sleep(0.1)
-                        if time.time() - start_time > flash_timeout:
+                        if time.time() - flash_start_time > serial_wait_timeout:
                             break
                     ser.open()
 


### PR DESCRIPTION
Fix for 1d70b70. Original code used start_time (set before flashing) to calculate serial port wait timeout, which caused wait loop to include flash duration, leading to exceed overall timeout. Added serial_wait_start timestamp for avoid
including flash time in serial port enumeration timeout. Make timeout dynamic (20% of flash_timeout, minimum 10s).