### PR TITLE
tests: drivers: gpio: gpio_basic_api: Device runtime pm support for gpio basic api

### DIFF
--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -205,6 +205,7 @@
 				ngpios = <16>;
 				gpio-reserved-ranges = <0 6>;
 				silabs,pads = [ff ff ff ff ff ff 01 02 03 04 05 06 07 ff ff 08];
+				zephyr,pm-device-runtime-auto;
 				status = "okay";
 			};
 
@@ -215,6 +216,7 @@
 				#gpio-cells = <2>;
 				ngpios = <16>;
 				silabs,pads = [ff ff ff ff ff ff ff ff ff 00 00 00 00 00 00 09];
+				zephyr,pm-device-runtime-auto;
 				status = "okay";
 			};
 
@@ -225,6 +227,7 @@
 				#gpio-cells = <2>;
 				ngpios = <16>;
 				silabs,pads = [09 09 09 ff ff ff ff ff ff ff ff ff ff ff 0a 0b];
+				zephyr,pm-device-runtime-auto;
 				status = "okay";
 			};
 
@@ -235,6 +238,7 @@
 				#gpio-cells = <2>;
 				ngpios = <10>;
 				silabs,pads = [0c 0d 0e 0f 10 11 12 13 14 15 ff ff ff ff ff ff];
+				zephyr,pm-device-runtime-auto;
 				status = "okay";
 			};
 		};
@@ -259,6 +263,7 @@
 				ngpios = <12>;
 				gpio-reserved-ranges = <3 1>;
 				silabs,pads = [16 17 18 19 1a 1b 1c 1d 1e 1f 20 21 ff ff ff ff];
+				zephyr,pm-device-runtime-auto;
 				status = "okay";
 			};
 		};

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -142,3 +142,10 @@ tests:
     extra_args: "DTC_OVERLAY_FILE=boards/frdm_rw612_hsgpio.overlay"
     harness_config:
       fixture: hsgpio_loopback
+  drivers.gpio.device_runtime_pm:
+    platform_allow:
+      - siwx917_rb4338a
+    extra_configs:
+      - CONFIG_PM=y
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_ZTEST_NO_YIELD=n


### PR DESCRIPTION
1. Implement device runtime PM for Si91x GPIO ports.
2. Add device runtime PM compatibility for gpio_basic_test