### PR TITLE
Add RESET driver support for microchip pic32cx sg family

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - pinctrl
   - pwm
+  - reset
   - rtc
   - uart
 vendor: microchip

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - pinctrl
   - pwm
+  - reset
   - rtc
   - uart
 vendor: microchip

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -87,6 +87,11 @@
 			};
 		};
 
+		rstc: rstc@40000c00 {
+			compatible = "microchip,rstc-g1-reset";
+			reg = <0x40000c00 0x400>;
+		};
+
 		rtc: rtc@40002400 {
 			compatible = "microchip,rtc-g1";
 			reg = <0x40002400 0x400>;


### PR DESCRIPTION
- Add the device tree node for microchip RSTC G1 IP.
- Update pic32cx_sg61_cult.yaml to include RESET in the supported
   modules list.
- Update pic32cx_sg41_cult.yaml to include RESET in the supported
   modules list.
