### PR TITLE
cmake: linker_script: arm: place IDT_LIST where ld linker script does

### DIFF
--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -54,7 +54,6 @@ endif()
 
 set(RAM_ADDR ${CONFIG_SRAM_BASE_ADDRESS})
 math(EXPR RAM_SIZE "(${CONFIG_SRAM_SIZE} + 0) * 1024" OUTPUT_FORMAT HEXADECIMAL)
-math(EXPR IDT_ADDR "${RAM_ADDR} + ${RAM_SIZE}" OUTPUT_FORMAT HEXADECIMAL)
 
 # ToDo: decide on the optimal location for this.
 # linker/ld/target.cmake based on arch, or directly in arch and scatter_script.cmake can ignore
@@ -63,7 +62,7 @@ zephyr_linker(ENTRY ${CONFIG_KERNEL_ENTRY})
 
 zephyr_linker_memory(NAME FLASH    FLAGS rx START ${FLASH_ADDR} SIZE ${FLASH_SIZE})
 zephyr_linker_memory(NAME RAM      FLAGS wx START ${RAM_ADDR}   SIZE ${RAM_SIZE})
-zephyr_linker_memory(NAME IDT_LIST FLAGS wx START ${IDT_ADDR}   SIZE 2K)
+zephyr_linker_memory(NAME IDT_LIST FLAGS wx START 0xFFFF8000    SIZE 2K)
 
 dt_comp_path(paths COMPATIBLE "zephyr,memory-region")
 foreach(path IN LISTS paths)


### PR DESCRIPTION
Instead of mirroring the `ld` linker script, the CMake Linker Generator for ARM was placing the `IDT_LIST` region right after the Zephyr SRAM. While this may work fine in most cases, this scheme leads to build errors on some SoCs such as STM32WBxx, where there are multiple RAM banks that are contiguous but split over multiple `zephyr,memory-region`s: in such scenarios, the `IDT_LIST` region will overlap with one of these `zephyr,memory-region` and cause a build failure.

Mimic the `IDT_LIST` placement found in `ld` linker script to avoid this issue, except that the region start address is aligned: `0xFFFF8000` instead of `0xFFFF7FFF`. This is required by `gen_isr_tables.py` which otherwise errors out due to finding one more byte than expected in the `.intList` section. (The exact reason is not clear, but aligning the region fixes the issue)