### PR TITLE
manifest: update hal_nordic to have fixes for examples

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 09f24fd6cc7df57a5b5d08102ceb4a38381e2c82
+      revision: 248eadcacf976bbd27f1c0bc0dd3f11d8ec8657e
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Update hal_nordic to have examples with SPIM+SPIS and TWIM+TWIS examples fixed.