### PR TITLE
drivers: ethernet: phy: split generic phy

### DIFF
--- a/boards/segger/ip_k66f/ip_k66f.dts
+++ b/boards/segger/ip_k66f/ip_k66f.dts
@@ -120,10 +120,10 @@
 	pinctrl-names = "default";
 
 	phy: phy@0 {
-		compatible = "ethernet-phy";
+		compatible = "ethernet-phy-fixed-link";
 		reg = <0>;
 		status = "okay";
-		fixed-link = "100BASE-T Full-Duplex";
+		default-speeds = "100BASE Full-Duplex";
 	};
 };
 

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -55,6 +55,11 @@ Ethernet
     * Removed ``mac-eeprom`` property from :dtcompatible:`atmel,sam-gmac` and
       :dtcompatible:`atmel,sam0-gmac`
 
+* The ``fixed-link`` property has been removed from :dtcompatible:`ethernet-phy`. Use
+  the new :dtcompatible:`ethernet-phy-fixed-link` compatible instead, if that functionality
+  is needed. There you need to specify the fixed link parameters using the ``default-speeds``
+  property (:github:`100454`).
+
 MDIO
 ====
 

--- a/drivers/ethernet/phy/CMakeLists.txt
+++ b/drivers/ethernet/phy/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library_sources_ifdef(CONFIG_PHY_GENERIC_MII phy_mii.c)
+zephyr_library_sources_ifdef(CONFIG_PHY_GENERIC_FIXED_LINK phy_fixed_link.c)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_PHY_ADIN2111 phy_adin2111.c)

--- a/drivers/ethernet/phy/Kconfig
+++ b/drivers/ethernet/phy/Kconfig
@@ -38,6 +38,17 @@ config PHY_GENERIC_MII
 	  This is a generic MII PHY interface that communicates with the
 	  PHY using the MDIO bus.
 
+config PHY_GENERIC_FIXED_LINK
+	bool "Generic MII PHY with Fixed Link Driver"
+	default y
+	depends on DT_HAS_ETHERNET_PHY_FIXED_LINK_ENABLED
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ETHERNET_PHY_FIXED_LINK),reset-gpios)
+	help
+	  This is a generic MII PHY with Fixed Link interface that does not
+	  communicate with the PHY using the MDIO bus. Can be used as a placeholder
+	  when the ethernet driver requires a PHY but there is no interface to configure
+	  the PHY.
+
 config PHY_ADIN2111
 	bool "ADIN2111 PHY driver"
 	default y

--- a/drivers/ethernet/phy/phy_fixed_link.c
+++ b/drivers/ethernet/phy/phy_fixed_link.c
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ethernet_phy_fixed_link
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/net/phy.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(phy_mii_fixed_link, CONFIG_PHY_LOG_LEVEL);
+
+#include "phy_mii.h"
+
+#define ANY_RESET_GPIO   DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
+
+struct phy_mii_fixed_dev_config {
+	enum phy_link_speed fixed_speed;
+#if ANY_RESET_GPIO
+	const struct gpio_dt_spec reset_gpio;
+	uint32_t reset_assert_duration_us;
+	uint32_t reset_deassertion_timeout_ms;
+#endif /* ANY_RESET_GPIO */
+};
+
+static int phy_mii_fixed_get_link_state(const struct device *dev, struct phy_link_state *state)
+{
+	const struct phy_mii_fixed_dev_config *const cfg = dev->config;
+
+	state->speed = cfg->fixed_speed;
+	state->is_up = true;
+
+	return 0;
+}
+
+static int phy_mii_fixed_link_cb_set(const struct device *dev, phy_callback_t cb, void *user_data)
+{
+	const struct phy_mii_fixed_dev_config *const cfg = dev->config;
+	struct phy_link_state state;
+
+	if (cb == NULL) {
+		return 0;
+	}
+
+	state.speed = cfg->fixed_speed;
+	state.is_up = true;
+
+	cb(dev, &state, user_data);
+
+	return 0;
+}
+
+#if ANY_RESET_GPIO
+static int phy_mii_fixed_init(const struct device *dev)
+{
+	const struct phy_mii_fixed_dev_config *const cfg = dev->config;
+	int ret;
+
+	if (gpio_is_ready_dt(&cfg->reset_gpio)) {
+		/* Issue a hard reset */
+		ret = gpio_pin_configure_dt(&cfg->reset_gpio, GPIO_OUTPUT_ACTIVE);
+		if (ret < 0) {
+			LOG_ERR("Failed to configure RST pin (%d)", ret);
+			return ret;
+		}
+
+		/* assertion time */
+		k_busy_wait(cfg->reset_assert_duration_us);
+
+		ret = gpio_pin_set_dt(&cfg->reset_gpio, 0);
+		if (ret < 0) {
+			LOG_ERR("Failed to de-assert RST pin (%d)", ret);
+			return ret;
+		}
+
+		k_msleep(cfg->reset_deassertion_timeout_ms);
+	}
+
+	return 0;
+}
+#endif /* ANY_RESET_GPIO */
+
+static DEVICE_API(ethphy, phy_mii_fixed_driver_api) = {
+	.get_link = phy_mii_fixed_get_link_state,
+	.link_cb_set = phy_mii_fixed_link_cb_set,
+};
+
+#if ANY_RESET_GPIO
+#define RESET_GPIO(n)                                                                              \
+	.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),                               \
+	.reset_assert_duration_us = DT_INST_PROP_OR(n, reset_assert_duration_us, 0),               \
+	.reset_deassertion_timeout_ms = DT_INST_PROP_OR(n, reset_deassertion_timeout_ms, 0),
+#else
+#define RESET_GPIO(n)
+#endif /* ANY_RESET_GPIO */
+
+#define PHY_MII_FIXED_INIT(n)                                                                      \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, reset_gpios), (&phy_mii_fixed_init), (NULL))
+
+#define PHY_MII_FIXED_DEVICE(n)                                                                    \
+	BUILD_ASSERT((DT_INST_PROP_LEN(n, default_speeds) == 1) &&                                 \
+		     (PHY_INST_GENERATE_DEFAULT_SPEEDS(n) != 0),                                   \
+		     "Exactly one valid default speed must be configured");                        \
+                                                                                                   \
+	static const struct phy_mii_fixed_dev_config phy_mii_fixed_dev_config_##n = {              \
+		.fixed_speed = PHY_INST_GENERATE_DEFAULT_SPEEDS(n),                                \
+		RESET_GPIO(n)                                                                      \
+	};                                                                                         \
+												   \
+DEVICE_DT_INST_DEFINE(n, PHY_MII_FIXED_INIT(n), NULL, NULL, &phy_mii_fixed_dev_config_##n,         \
+		      POST_KERNEL, CONFIG_PHY_INIT_PRIORITY, &phy_mii_fixed_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PHY_MII_FIXED_DEVICE)

--- a/dts/bindings/ethernet/phy/common/ethernet-phy-common.yaml
+++ b/dts/bindings/ethernet/phy/common/ethernet-phy-common.yaml
@@ -1,0 +1,13 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for MIIPHY devices
+
+include:
+  - name: phy.yaml
+  - name: ethernet-phy-default-speeds.yaml
+
+properties:
+  reg:
+    required: true
+    description: PHY address

--- a/dts/bindings/ethernet/phy/common/ethernet-phy-default-speeds.yaml
+++ b/dts/bindings/ethernet/phy/common/ethernet-phy-default-speeds.yaml
@@ -1,14 +1,9 @@
 # Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# Common fields for MIIPHY devices
-
-include: phy.yaml
+# Common default speeds property for MIIPHY devices
 
 properties:
-  reg:
-    required: true
-    description: PHY address
   default-speeds:
     type: string-array
     description: The selected speeds are used to configure the PHY during initialization

--- a/dts/bindings/ethernet/phy/common/ethernet-phy-reset-gpios.yaml
+++ b/dts/bindings/ethernet/phy/common/ethernet-phy-reset-gpios.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Common reset gpio properties for MIIPHY devices
+
+properties:
+  reset-gpios:
+    type: phandle-array
+    description: |
+      Optional GPIO used to reset the PHY
+  reset-assert-duration-us:
+    type: int
+    description: |
+      Minimum duration in microseconds to assert the reset-gpios pin.
+  reset-deassertion-timeout-ms:
+    type: int
+    description: |
+      Timeout in milliseconds after the reset-gpios pin is deasserted.

--- a/dts/bindings/ethernet/phy/ethernet-phy-fixed-link.yaml
+++ b/dts/bindings/ethernet/phy/ethernet-phy-fixed-link.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for MIIPHY devices
+
+description: Generic MII PHY with fixed link and no PHY configuration
+
+compatible: "ethernet-phy-fixed-link"
+
+include:
+  - name: phy.yaml
+  - name: ethernet-phy-default-speeds.yaml
+  - name: ethernet-phy-reset-gpios.yaml
+
+properties:
+  default-speeds:
+    required: true

--- a/dts/bindings/ethernet/phy/ethernet-phy.yaml
+++ b/dts/bindings/ethernet/phy/ethernet-phy.yaml
@@ -11,20 +11,12 @@ include:
   - name: ethernet-phy-common.yaml
   - name: ethernet-phy-reset-gpios.yaml
 
+on-bus: mdio
+
 properties:
   no-reset:
     type: boolean
     description: Do not reset the PHY during initialization
-  fixed-link:
-    type: string
-    description: This link is fixed and does not require PHY configuration
-    enum:
-      - "10BASE-T Half-Duplex"
-      - "10BASE-T Full-Duplex"
-      - "100BASE-T Half-Duplex"
-      - "100BASE-T Full-Duplex"
-      - "1000BASE-T Half-Duplex"
-      - "1000BASE-T Full-Duplex"
   default-speeds:
     default: ["10BASE Half-Duplex", "10BASE Full-Duplex", "100BASE Half-Duplex",
               "100BASE Full-Duplex", "1000BASE Half-Duplex", "1000BASE Full-Duplex"]

--- a/dts/bindings/ethernet/phy/ethernet-phy.yaml
+++ b/dts/bindings/ethernet/phy/ethernet-phy.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 IP-Logix Inc.
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # Common fields for MIIPHY devices
@@ -7,7 +7,9 @@ description: Generic MII PHY
 
 compatible: "ethernet-phy"
 
-include: ethernet-phy-common.yaml
+include:
+  - name: ethernet-phy-common.yaml
+  - name: ethernet-phy-reset-gpios.yaml
 
 properties:
   no-reset:
@@ -26,15 +28,3 @@ properties:
   default-speeds:
     default: ["10BASE Half-Duplex", "10BASE Full-Duplex", "100BASE Half-Duplex",
               "100BASE Full-Duplex", "1000BASE Half-Duplex", "1000BASE Full-Duplex"]
-  reset-gpios:
-    type: phandle-array
-    description: Reset pin.
-      Optional GPIO used to reset the PHY
-  reset-assert-duration-us:
-    type: int
-    description:
-      Minimum duration in microseconds to assert the reset-gpios pin.
-  reset-deassertion-timeout-ms:
-    type: int
-    description:
-      Timeout in milliseconds after the reset-gpios pin is deasserted.

--- a/include/zephyr/drivers/ethernet/eth_nxp_enet.h
+++ b/include/zephyr/drivers/ethernet/eth_nxp_enet.h
@@ -46,9 +46,13 @@ struct nxp_enet_ptp_data {
 	void *enet; /* enet_handle poiniter used by PTP driver */
 };
 
+#ifdef CONFIG_MDIO_NXP_ENET
 extern void nxp_enet_mdio_callback(const struct device *mdio_dev,
 		enum nxp_enet_callback_reason event,
 		void *data);
+#else
+#define nxp_enet_mdio_callback(...)
+#endif
 
 #ifdef CONFIG_PTP_CLOCK_NXP_ENET
 extern void nxp_enet_ptp_clock_callback(const struct device *dev,


### PR DESCRIPTION
moves the fixed link functionality of the
generic ethernet phy into its own driver.
This makes both drivers more readable and
efficient.

Also makes it easier to use the normal generic
phy as a base for a vendor specific driver, as
the fixed link functionality is not needed on
them.

CONFIG_MDIO is now also no longer needed for the
fixed link and therefore no longer selected.