### PR TITLE
Bluetooth: userchan: Validate UNIX socket path fits in sockaddr_un

### DIFF
--- a/drivers/bluetooth/hci/userchan_bottom.c
+++ b/drivers/bluetooth/hci/userchan_bottom.c
@@ -20,6 +20,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <nsi_errno.h>
+#include <nsi_tracing.h>
 
 #define BTPROTO_HCI      1
 #define HCI_CHANNEL_USER 1
@@ -103,6 +104,12 @@ int user_chan_unix_connect(char socket_path[])
 {
 	int fd;
 	struct sockaddr_un addr;
+	size_t socket_path_size = strlen(socket_path);
+
+	if (socket_path_size >= sizeof(addr.sun_path)) {
+		nsi_print_error_and_exit("Unix socket path too long (%zu>=%zu)\n",
+					 socket_path_size, sizeof(addr.sun_path));
+	}
 
 	fd = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (fd < 0) {


### PR DESCRIPTION
sockaddr_un.sun_path is limited to 108 in Linux
(and to similarly small numbers in other systems).

Let's check that it fits before copying it, and error out otherwise (the user won't be able to connect to that socket if the path is truncated, and if we overflow we will just corrupt memory).

Introduced in #92263
Fixes #100009