### PR TITLE
boards: nxp: frdm_mcxw71: Connect Arduino header I2C

### DIFF
--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -138,6 +138,8 @@
 	};
 };
 
+arduino_i2c: &lpi2c1 {};
+
 &lpspi1 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpspi1>;

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
@@ -15,6 +15,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - arduino_i2c
   - can
   - counter
   - dma

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -18,6 +18,7 @@
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+#include <zephyr/kernel.h>
 LOG_MODULE_REGISTER(wdt_mcux_wdog32);
 
 #define MIN_TIMEOUT 1


### PR DESCRIPTION
The I2C bus of the lpi2c1 I2C controller is connected to the Arduino Shield header on the usual pins. Label it with "arduino_i2c" in the board device tree so that the frdm_mcxw71 board can be used with I2C shields.