### PR TITLE
tests: benchmark: Mbed TLs: filter for posix arch

### DIFF
--- a/tests/benchmarks/mbedtls/testcase.yaml
+++ b/tests/benchmarks/mbedtls/testcase.yaml
@@ -6,6 +6,8 @@ common:
       - "Benchmark completed"
   timeout: 10
   tags: crypto
+  arch_exclude:
+    - posix
 tests:
   benchmark.crypto.mbedtls:
     filter: CONFIG_TEST_RANDOM_GENERATOR


### PR DESCRIPTION
There is no point benchmarking on the posix architecture, and how the test is now it just hangs. So let's filter it.


**Issue:**
tests/benchmarks/mbedtls is hanging in main after  f5ec45bf49e4a1a9756baec44a4395eefd622795 , for the  nrf5340bsim/nrf5340/cpuapp .
Before it was filtered by kconfig for this platform.

Note it would also be possible to do something like this below, so the test does not hang, but the result of the benchmark is just given by that artificial delay. So it seems a bit pointless.
```diff
diff --git a/tests/benchmarks/mbedtls/src/benchmark.c b/tests/benchmarks/mbedtls/src/benchmark.c
index 890652d14a4..c4526d51661 100644
--- a/tests/benchmarks/mbedtls/src/benchmark.c
+++ b/tests/benchmarks/mbedtls/src/benchmark.c
@@ -33,6 +33,7 @@ do {                                                                  \
        k_timer_start(&timer, TIMER_DURATION, TIMER_PERIOD);            \
        for (i = 1; status == PSA_SUCCESS && !timer_expired; i++) {     \
                status = CODE;                                          \
+               Z_SPIN_DELAY(10);                                       \
        }                                                               \
                                                                        \
```