### PR TITLE
dts: arm: silabs: add clock to acmp node on xg21

### DIFF
--- a/dts/arm/silabs/xg21/xg21.dtsi
+++ b/dts/arm/silabs/xg21/xg21.dtsi
@@ -488,6 +488,7 @@
 		acmp0: acmp@5a008000 {
 			compatible = "silabs,acmp";
 			reg = <0x5a008000 0x4000>;
+			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_INVALID>;
 			interrupt-names = "acmp0";
 			interrupts = <41 2>;
 			status = "disabled";
@@ -496,6 +497,7 @@
 		acmp1: acmp@5a00c000 {
 			compatible = "silabs,acmp";
 			reg = <0x5a00c000 0x4000>;
+			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_INVALID>;
 			interrupt-names = "acmp1";
 			interrupts = <42 2>;
 			status = "disabled";

--- a/tests/drivers/comparator/gpio_loopback/boards/slwrb4180a.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/slwrb4180a.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/comparator/silabs-acmp.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg21-pinctrl.h>
+
+/ {
+	aliases {
+		test-comp = &acmp0;
+	};
+
+	zephyr,user {
+		test-gpios = <&gpioc 3 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	acmp0_default: acmp0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_CDODD0_ACMP0>;
+		};
+	};
+};
+
+&acmp0 {
+	pinctrl-0 = <&acmp0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	hysteresis-mode = "disabled";
+	accuracy-mode = "high";
+	input-range = "full";
+	input-positive = <ACMP_INPUT_PC3>;
+	input-negative = <ACMP_INPUT_VREFDIV1V25>;
+	vref-divider = <63>;
+};

--- a/tests/drivers/comparator/gpio_loopback/boards/xg23_rb4210a.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/xg23_rb4210a.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/comparator/silabs-acmp.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg23-pinctrl.h>
+
+/ {
+	aliases {
+		test-comp = &acmp0;
+	};
+
+	zephyr,user {
+		test-gpios = <&gpioc 1 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	acmp0_default: acmp0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_CDODD0_ACMP0>;
+		};
+	};
+};
+
+&acmp0 {
+	pinctrl-0 = <&acmp0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	hysteresis-mode = "disabled";
+	accuracy-mode = "high";
+	input-range = "full";
+	input-positive = <ACMP_INPUT_PC1>;
+	input-negative = <ACMP_INPUT_VREFDIV1V25>;
+	vref-divider = <63>;
+};

--- a/tests/drivers/comparator/gpio_loopback/boards/xg28_rb4401c.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/xg28_rb4401c.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/comparator/silabs-acmp.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg28-pinctrl.h>
+
+/ {
+	aliases {
+		test-comp = &acmp0;
+	};
+
+	zephyr,user {
+		test-gpios = <&gpiod 7 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	acmp0_default: acmp0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_CDODD0_ACMP0>;
+		};
+	};
+};
+
+&acmp0 {
+	pinctrl-0 = <&acmp0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	hysteresis-mode = "disabled";
+	accuracy-mode = "high";
+	input-range = "full";
+	input-positive = <ACMP_INPUT_PD7>;
+	input-negative = <ACMP_INPUT_VREFDIV1V25>;
+	vref-divider = <63>;
+};

--- a/tests/drivers/comparator/gpio_loopback/testcase.yaml
+++ b/tests/drivers/comparator/gpio_loopback/testcase.yaml
@@ -10,8 +10,11 @@ common:
 tests:
   drivers.comparator.gpio_loopback.silabs_acmp:
     platform_allow:
+      - slwrb4180a
+      - xg23_rb4210a
       - xg24_dk2601b
       - xg24_rb4187c
+      - xg28_rb4401c
       - xg29_rb4412a
       - bg29_rb4420a
   drivers.comparator.gpio_loopback.mcux_acmp:


### PR DESCRIPTION
This PR add clock to acmp node in xg21 dtsi. It removes a compilation error when using acmp peripheral with xg21 SoC.
It also adds some overlays to test acmp peripheral over board that have different acmp peripheral ip version.