### PR TITLE
dts: nordic: Fix ngpios for nRF54L15 (and variants)

### DIFF
--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -695,7 +695,7 @@
 				gpio-controller;
 				reg = <0x10a000 0x300>;
 				#gpio-cells = <2>;
-				ngpios = <5>;
+				ngpios = <7>;
 				status = "disabled";
 				port = <0>;
 				gpiote-instance = <&gpiote30>;


### PR DESCRIPTION
The correct number is 7, since the QFN52 (QGAA) variant has P0.00 to P0.06 present. See:
https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/chapters/pin.html#ariaid-title6