### PR TITLE
cmake: toolchain/xt-clang: allow to skip FLIX generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -593,6 +593,14 @@ if(CONFIG_INSTRUMENTATION)
   endif()
 endif()
 
+if(CONFIG_COMPILER_CODEGEN_VLIW_ENABLED)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,generate_vliw>>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,generate_vliw>>)
+elseif(CONFIG_COMPILER_CODEGEN_VLIW_DISABLED)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,no_generate_vliw>>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,no_generate_vliw>>)
+endif()
+
 # Allow the user to inject options when calling cmake, e.g.
 # 'cmake -DEXTRA_CFLAGS="-Werror -Wno-deprecated-declarations" ..'
 include(cmake/extra_flags.cmake)

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -629,6 +629,37 @@ config TOOLCHAIN_SUPPORTS_VLA_IN_STATEMENTS
 	  Hidden symbol to state if the toolchain can handle vla in
 	  statements.
 
+menu "Code Generation"
+
+choice COMPILER_CODEGEN_VLIW
+	prompt "VLIW (Very Long Instruction Word)"
+	default COMPILER_CODEGEN_VLIW_AUTO
+	help
+	  This option instructs the compiler whether to use VLIW
+	  (Very Long Instruction Word) instructions. VLIW allows
+	  the compiler to fuse instructions for parallel execution.
+
+config COMPILER_CODEGEN_VLIW_AUTO
+	bool "Auto"
+	help
+	  Let the compiler decide whether to generate VLIW instructions.
+
+	  This usually means using the compiler defaults.
+
+config COMPILER_CODEGEN_VLIW_ENABLED
+	bool "Generate VLIW"
+	help
+	  Explicitly instructs the compiler to generate VLIW instructions if possible.
+
+config COMPILER_CODEGEN_VLIW_DISABLED
+	bool "DO NOT generate VLIW"
+	help
+	  Explicitly instructs the compiler to NEVER generate VLIW instructions.
+
+endchoice # COMPILER_CODEGEN_VLIW
+
+endmenu # Code Generation
+
 endmenu
 
 choice

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -177,3 +177,8 @@ set_compiler_property(PROPERTY no_data_sections)
 
 # Compiler flag to enable function instrumentation
 set_compiler_property(PROPERTY func_instrumentation)
+
+# Compiler flags to enable or disable code generation of VLIW
+# (Very Long Instruction Word) instructions.
+set_compiler_property(PROPERTY generate_vliw)
+set_compiler_property(PROPERTY no_generate_vliw)

--- a/cmake/compiler/xt-clang/compiler_flags.cmake
+++ b/cmake/compiler/xt-clang/compiler_flags.cmake
@@ -28,3 +28,6 @@ set_compiler_property(PROPERTY warning_shadow_variables)
 check_set_compiler_property(APPEND PROPERTY warning_extended
                             -Wno-unknown-warning-option
 )
+
+# Do not fuse instructions via FLIX
+set_compiler_property(PROPERTY no_generate_vliw -mno-generate-flix)

--- a/cmake/toolchain/xt-clang/Kconfig
+++ b/cmake/toolchain/xt-clang/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+if DT_HAS_CDNS_TENSILICA_XTENSA_LX7_ENABLED
+
+choice COMPILER_CODEGEN_VLIW
+	default COMPILER_CODEGEN_VLIW_DISABLED if USERSPACE
+
+endchoice
+
+endif # DT_HAS_CDNS_TENSILICA_XTENSA_LX7_ENABLED


### PR DESCRIPTION
This adds compiler flag to instruct xt-clang not to generate FLIX (Flexible Length Instruction Xtensions) instructions, where multiple instructions can be fused into one instruction. FLIX can provide performance and code size advantages.

When userspace is enabled, FLIX may reorder memory access where memory is accessed before code determines whether we should perform that memory access. For example, when guarding memory access via k_is_user_context(), and some kernel variables can only be accessed via kernel mode, FLIX may reorder memory access such that these variables are accessed before k_is_user_context(). This results in access violation.

FLIX generation is enabled by default. This lets the application developers to disable FLIX generation if needed.