### PR TITLE
drivers: pwm: stm32: change the order of deadtime and enable all timers

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -706,11 +706,11 @@ static int pwm_stm32_init(const struct device *dev)
 	 * compile and this checks explicitly for the api instead of the soc
 	 */
 	if (IS_TIM_BREAK_INSTANCE(timer)) {
-		/* enable outputs and counter */
-		LL_TIM_EnableAllOutputs(timer);
-
 		/* set the deadtime from the configuration */
 		LL_TIM_OC_SetDeadTime(timer, cfg->deadtime);
+
+		/* enable outputs and counter */
+		LL_TIM_EnableAllOutputs(timer);
 	} else if (cfg->deadtime != 0) {
 		LOG_ERR("Setting deadtime %d on a non-break timer %s",
 			cfg->deadtime, dev->name);


### PR DESCRIPTION
For stm32h7 the order matters to get the pwm to output the values as expected. As reported for the the H730 doesn't produce PWM output when the LL_TIM_OC_SetDeadTime is called after LL_TIM_EnableAllOutputs. So, switch the order of the calls and this doesn't impact the stm32f413zh boards.