### PR TITLE
samples: net: openthread: coprocessor: Add nrf52840dongle config

### DIFF
--- a/samples/net/openthread/coprocessor/boards/nrf52840dongle_nrf52840.overlay
+++ b/samples/net/openthread/coprocessor/boards/nrf52840dongle_nrf52840.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ot-uart = &board_cdc_acm_uart;
+	};
+};


### PR DESCRIPTION
Add a config for the nrf52840dongle to use the CDC_ACM interface for the ot_uart. Without this building the OpenThread coprocessor fails to build when using the nrf52840 dongle because the UART isn't defined so fix it.