### PR TITLE
sensor: current_amp: fix incorrect PM error

### DIFF
--- a/drivers/sensor/current_amp/current_amp.c
+++ b/drivers/sensor/current_amp/current_amp.c
@@ -124,8 +124,7 @@ static int pm_action(const struct device *dev, enum pm_device_action action)
 	int ret;
 
 	if (config->power_gpio.port == NULL) {
-		LOG_ERR("PM not supported");
-		return -ENOTSUP;
+		return 0;
 	}
 
 	switch (action) {


### PR DESCRIPTION
Returning `-ENOTSUP` (and logging a `LOG_ERR`) is not the correct behaviour if there is no enable GPIO. The fact there was no work to do does not make the result an error.

From the docs for `pm_device_runtime_get`
```
 * @retval 0 If it succeeds. In case device runtime PM is not enabled or
 *  not available this function will be a no-op and will also return 0.
```