### PR TITLE
boards: st: nucleo_h563zi: fix PLL clocks

### DIFF
--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -71,6 +71,16 @@
 	div-m = <2>;
 	mul-n = <120>;
 	div-p = <2>;
+	div-q = <4>;
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&pll2 {
+	div-m = <2>;
+	mul-n = <120>;
+	div-p = <2>;
 	div-q = <3>;
 	div-r = <2>;
 	clocks = <&clk_hse>;
@@ -171,7 +181,7 @@
 	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
 	pinctrl-names = "default";
 	clocks = <&rcc STM32_CLOCK(APB1_2, 9)>,
-		 <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
+		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
 	clk-divider = <2>;
 	status = "okay";
 };

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -128,7 +128,7 @@
 			#size-cells = <0>;
 			reg = <0x40015404 0x20>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
-				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
+				 <&rcc STM32_SRC_PLL1_P SAI1_SEL(0)>;
 			dmas = <&gpdma1 1 53 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
 				STM32_DMA_16BITS)>;
 			status = "disabled";
@@ -140,7 +140,7 @@
 			#size-cells = <0>;
 			reg = <0x40015424 0x20>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
-				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
+				 <&rcc STM32_SRC_PLL1_P SAI1_SEL(0)>;
 			dmas = <&gpdma1 0 54 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
 				STM32_DMA_16BITS)>;
 			status = "disabled";

--- a/samples/drivers/i2s/output/boards/nucleo_h563zi.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_h563zi.overlay
@@ -11,18 +11,20 @@
 	};
 };
 
-&pll2 {
-	/* 44.1KHz (0.09% Error) */
-	div-m = <2>;
-	mul-n = <113>;
+&pll3 {
+	/* 44.1 KHz (0.0% Error) */
+	div-m = <1>;
+	mul-n = <35>;
 	div-q = <2>;
 	div-r = <2>;
-	div-p = <2>;
+	div-p = <25>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };
 
 &sai1_a {
+	clocks = <&rcc STM32_CLOCK(APB2, 21)>,
+		 <&rcc STM32_SRC_PLL3_P SAI1_SEL(2)>;
 	pinctrl-0 = <&sai1_mclk_a_pe2 &sai1_sd_a_pe6
 		     &sai1_fs_a_pe4 &sai1_sck_a_pe5>;
 	pinctrl-names = "default";


### PR DESCRIPTION
This change aligns max allowed SPI clock with the datasheet.

SPI1 on H5xx is using PLL1Q for their clock selection
https://github.com/zephyrproject-rtos/zephyr/blob/64a1477976b62606e8844a4bc8de880117a1cc47/dts/arm/st/h5/stm32h5.dtsi#L510

Based on [STM32H562/3xx Datasheet](https://www.st.com/resource/ja/datasheet/stm32h563ri.pdf), the  maximum allowed clock freq for SPI is 125MHz.
<img width="873" height="87" alt="f_spi" src="https://github.com/user-attachments/assets/c5118d24-97d8-4936-9a01-9f28aadd4dd4" />

By changing PLL1Q div to 4, SPI clock drops to 120MHz (just below the max allowed frequency)

The new proposed PLL clocks:
1. PLL1 will be used by SPI
2. PLL2 for FDCAN (as discussed) because clock freq should remain as is
3. PLL3 will be used in the _samples/i2s/output_ for the SAI

<img width="663" height="678" alt="h563_pll" src="https://github.com/user-attachments/assets/7c545f67-9490-4311-9c3b-29cd7a76d358" />

