### PR TITLE
tests: crypto: mbedtls_psa: just use ztest

### DIFF
--- a/tests/crypto/mbedtls_psa/testcase.yaml
+++ b/tests/crypto/mbedtls_psa/testcase.yaml
@@ -19,19 +19,7 @@ common:
   tags:
     - mbedtls
     - psa
-  harness: console
-  harness_config:
-    type: multi_line
-    regex:
-      - " PASS - test_aes_ecb.*"
-      - " PASS - test_generate_random.*"
-      - " PASS - test_hmac_sha256.*"
-      - " PASS - test_md5.*"
-      - " PASS - test_sha1.*"
-      - " PASS - test_sha224.*"
-      - " PASS - test_sha256.*"
-      - " PASS - test_sha384.*"
-      - " PASS - test_sha512.*"
+
 tests:
   crypto.mbedtls_psa.with_entropy_driver:
     filter: CONFIG_CSPRNG_ENABLED


### PR DESCRIPTION
This is regular ztest, no need to console harness. (beside that console harness fails)