### PR TITLE
tests: bluetooth: audio: ascs: fix build issues

### DIFF
--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -164,7 +164,8 @@ ZTEST_F(ascs_test_suite, test_sink_ase_read_state_idle)
 	zexpect_not_null(fixture->ase_snk.attr);
 
 	ret = ase->read(conn, ase, &hdr, sizeof(hdr), 0);
-	zassert_false(ret < 0, "attr->read returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+	zassert_false(ret < 0, "attr->read returned unexpected (err 0x%02x)",
+		      (uint8_t)BT_GATT_ERR(ret));
 	zassert_equal(0x00, hdr.ase_state, "unexpected ASE_State 0x%02x", hdr.ase_state);
 }
 

--- a/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
@@ -111,7 +111,7 @@ ZTEST_F(test_ase_control_params, test_sink_ase_control_operation_zero_length_wri
 
 	ret = fixture->ase_cp->write(&fixture->conn, fixture->ase_cp, (void *)buf, 0, 0, 0);
 	zassert_true(ret < 0, "ase_cp_attr->write returned unexpected (err 0x%02x)",
-		     BT_GATT_ERR(ret));
+		     (uint8_t)BT_GATT_ERR(ret));
 }
 
 static void test_expect_unsupported_opcode(struct test_ase_control_params_fixture *fixture,

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
@@ -375,7 +375,8 @@ static void expect_ase_state_releasing(struct bt_conn *conn, const struct bt_gat
 	zexpect_not_null(ase);
 
 	ret = ase->read(conn, ase, &hdr, sizeof(hdr), 0);
-	zassert_false(ret < 0, "attr->read returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+	zassert_false(ret < 0, "attr->read returned unexpected (err 0x%02x)",
+		      (uint8_t)BT_GATT_ERR(ret));
 	zassert_equal(BT_BAP_EP_STATE_RELEASING, hdr.ase_state,
 		      "unexpected ASE_State 0x%02x", hdr.ase_state);
 }

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -130,7 +130,8 @@ uint8_t test_ase_id_get(const struct bt_gatt_attr *ase)
 	ssize_t ret;
 
 	ret = ase->read(NULL, ase, &hdr, sizeof(hdr), 0);
-	zassert_false(ret < 0, "ase->read returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+	zassert_false(ret < 0, "ase->read returned unexpected (err 0x%02x)",
+		      (uint8_t)BT_GATT_ERR(ret));
 
 	return hdr.ase_id;
 }
@@ -177,7 +178,8 @@ void test_ase_control_client_config_codec(struct bt_conn *conn, uint8_t ase_id,
 	mock_bap_unicast_server_cb_config_fake.custom_fake = unicast_server_cb_config_custom_fake;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
-	zassert_false(ret < 0, "cp_attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+	zassert_false(ret < 0, "cp_attr->write returned unexpected (err 0x%02x)",
+		      (uint8_t)BT_GATT_ERR(ret));
 
 	stream_allocated = NULL;
 
@@ -204,7 +206,8 @@ void test_ase_control_client_config_qos(struct bt_conn *conn, uint8_t ase_id)
 	ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
-	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)",
+		      (uint8_t)BT_GATT_ERR(ret));
 
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 }
@@ -221,7 +224,8 @@ void test_ase_control_client_enable(struct bt_conn *conn, uint8_t ase_id)
 	ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
-	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)",
+		      (uint8_t)BT_GATT_ERR(ret));
 
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 }
@@ -237,7 +241,8 @@ void test_ase_control_client_disable(struct bt_conn *conn, uint8_t ase_id)
 	ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
-	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)",
+		      (uint8_t)BT_GATT_ERR(ret));
 
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 }
@@ -253,7 +258,8 @@ void test_ase_control_client_release(struct bt_conn *conn, uint8_t ase_id)
 	ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
-	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)",
+		      (uint8_t)BT_GATT_ERR(ret));
 
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 }
@@ -271,7 +277,8 @@ void test_ase_control_client_update_metadata(struct bt_conn *conn, uint8_t ase_i
 	ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
-	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)",
+		      (uint8_t)BT_GATT_ERR(ret));
 
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 }
@@ -287,7 +294,8 @@ void test_ase_control_client_receiver_start_ready(struct bt_conn *conn, uint8_t 
 	ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
-	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)",
+		      (uint8_t)BT_GATT_ERR(ret));
 
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 }
@@ -303,7 +311,8 @@ void test_ase_control_client_receiver_stop_ready(struct bt_conn *conn, uint8_t a
 	ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
-	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)",
+		      (uint8_t)BT_GATT_ERR(ret));
 
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 }


### PR DESCRIPTION
Fix build issues,
- error: format %x expects argument of type unsigned int, but argument 7 has type ssize_t {aka long int} [-Werror=format=] zassert_false(ret < 0, "attr->read returned unexpected (err 0x%02x)" , BT_GATT_ERR(ret));