### PR TITLE
Fix include path to app_version.h

### DIFF
--- a/doc/build/version/index.rst
+++ b/doc/build/version/index.rst
@@ -72,7 +72,7 @@ Use in code
 ===========
 
 To use the version information in application code, the version file must be included, then the
-fields can be freely used. The include file name is :file:`app_version.h` (no path is needed), the
+fields can be freely used. The include file name is :file:`app_version.h` (use ``#include <zephyr/app_version.h>``), the
 following defines are available:
 
 +-----------------------------+-------------------+------------------------------------------------------+---------------------------+

--- a/soc/silabs/silabs_s2/soc_image_properties.c
+++ b/soc/silabs/silabs_s2/soc_image_properties.c
@@ -7,8 +7,8 @@
 #include <zephyr/kernel.h>
 
 #if defined __has_include
-#if __has_include("app_version.h")
-#include "app_version.h"
+#if __has_include(<zephyr/app_version.h>)
+#include <zephyr/app_version.h>
 #define SOC_IMAGE_VERSION APPVERSION
 #endif
 #endif

--- a/subsys/shell/modules/app_version_service.c
+++ b/subsys/shell/modules/app_version_service.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "app_version.h"
+#include <zephyr/app_version.h>
 #include <zephyr/shell/shell.h>
 
 static int cmd_app_version_string(const struct shell *sh)

--- a/tests/cmake/app_version/src/main.c
+++ b/tests/cmake/app_version/src/main.c
@@ -8,8 +8,7 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/kernel_version.h>
-
-#include "app_version.h"
+#include <zephyr/app_version.h>
 
 ZTEST(app_version, test_basic_ints)
 {


### PR DESCRIPTION
Add `zephyr/` namespace to `app_version.h`-includes to match with the changes made in #63973:

Fix #100458

I could also add commits to change the includes  in [`soc\silabs\silabs_s2\soc_image_properties.c`](https://github.com/zephyrproject-rtos/zephyr/blob/main/soc/silabs/silabs_s2/soc_image_properties.c#L10) and [`tests\cmake\app_version\src\main.c`](https://github.com/zephyrproject-rtos/zephyr/blob/main/tests/cmake/app_version/src/main.c#L12), but I can't test it (but maybe CI does in this PR?)
