### PR TITLE
Fix USB network API namespacing

### DIFF
--- a/subsys/usb/device/class/netusb/function_ecm.c
+++ b/subsys/usb/device/class/netusb/function_ecm.c
@@ -292,7 +292,7 @@ static void ecm_read_cb(uint8_t ep, int size, void *priv)
 		}
 	}
 
-	pkt = net_pkt_rx_alloc_with_buffer(netusb_net_iface(), size, AF_UNSPEC,
+	pkt = net_pkt_rx_alloc_with_buffer(netusb_net_iface(), size, NET_AF_UNSPEC,
 					   0, K_FOREVER);
 	if (!pkt) {
 		LOG_ERR("no memory for network packet");

--- a/subsys/usb/device/class/netusb/function_eem.c
+++ b/subsys/usb/device/class/netusb/function_eem.c
@@ -177,7 +177,7 @@ static void eem_read_cb(uint8_t ep, int size, void *priv)
 
 		pkt = net_pkt_rx_alloc_with_buffer(netusb_net_iface(),
 						   eem_size - sizeof(sentinel),
-						   AF_UNSPEC, 0, K_FOREVER);
+						   NET_AF_UNSPEC, 0, K_FOREVER);
 		if (!pkt) {
 			LOG_ERR("Unable to alloc pkt");
 			break;

--- a/subsys/usb/device/class/netusb/function_rndis.c
+++ b/subsys/usb/device/class/netusb/function_rndis.c
@@ -345,7 +345,7 @@ static void rndis_bulk_out(uint8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 		}
 
 		pkt = net_pkt_rx_alloc_with_buffer(netusb_net_iface(),
-						   rndis.in_pkt_len, AF_UNSPEC,
+						   rndis.in_pkt_len, NET_AF_UNSPEC,
 						   0, K_NO_WAIT);
 		if (!pkt) {
 			/* In case of low memory: skip the whole packet

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -257,7 +257,7 @@ static int cdc_ecm_acl_out_cb(struct usbd_class_data *const c_data,
 	}
 
 	pkt = net_pkt_rx_alloc_with_buffer(data->iface, buf->len,
-					   AF_UNSPEC, 0, K_FOREVER);
+					   NET_AF_UNSPEC, 0, K_FOREVER);
 	if (!pkt) {
 		LOG_ERR("No memory for net_pkt");
 		goto restart_out_transfer;

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -571,7 +571,7 @@ static int cdc_ncm_acl_out_cb(struct usbd_class_data *const c_data,
 			break;
 		}
 
-		pkt = net_pkt_rx_alloc_with_buffer(data->iface, len, AF_UNSPEC, 0, K_FOREVER);
+		pkt = net_pkt_rx_alloc_with_buffer(data->iface, len, NET_AF_UNSPEC, 0, K_FOREVER);
 		if (!pkt) {
 			LOG_ERR("No memory for net_pkt");
 			goto unref_packet;


### PR DESCRIPTION
Do not use POSIX symbols directly but use network namespaced APIs instead.
