### PR TITLE
soc: nxp: fix DISABLE_WDOG value if WDT is not disabled at boot

### DIFF
--- a/soc/nxp/kinetis/CMakeLists.txt
+++ b/soc/nxp/kinetis/CMakeLists.txt
@@ -17,4 +17,4 @@ zephyr_linker_sources_ifdef(CONFIG_KINETIS_FLASH_CONFIG
 # CMSIS SystemInit will disable watchdog unless instructed not to.
 # Add a compiler definition here to leave watchdog untouched
 # if this Kconfig is not set
-zephyr_compile_definitions_ifndef(CONFIG_WDT_DISABLE_AT_BOOT DISABLE_WDOG=1)
+zephyr_compile_definitions_ifndef(CONFIG_WDT_DISABLE_AT_BOOT DISABLE_WDOG=0)


### PR DESCRIPTION
If `CONFIG_WDT_DISABLE_AT_BOOT` is not defined (i.e. WDT should be enabled at boot), `DISABLE_WDOG` should be 0.

Bug introduced in cf3d9424a5143b751625b47314e7add88a0ba74a, identified by @mathieuchopstm (https://github.com/zephyrproject-rtos/zephyr/pull/90736/commits/cf3d9424a5143b751625b47314e7add88a0ba74a#r2489608339)
It was implemented correctly in `soc/nxp/mcx/mcxc/CMakeLists.txt`, but incorrectly in `soc/nxp/kinetis/CMakeLists.txt`.