### PR TITLE
soc: it8xxx2: block idle if timer is close to expiration

### DIFF
--- a/soc/ite/ec/common/soc_timer.h
+++ b/soc/ite/ec/common/soc_timer.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _ITE_IT8XXX2_SOC_TIMER_H_
+#define _ITE_IT8XXX2_SOC_TIMER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef CONFIG_SOC_IT8XXX2
+bool ite_ec_timer_block_idle(void);
+#else
+static inline bool ite_ec_timer_block_idle(void)
+{
+	return false;
+}
+#endif /* CONFIG_SOC_IT8XXX2 */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ITE_IT8XXX2_SOC_TIMER_H_ */


### PR DESCRIPTION
If the event timer or free-run timer is close to expiration when system enters idle with I2C target DMA mode enabled, the memory and CPU clocks may become unsynchronized after wakeup. This causes CPU to fetch incorrect data and eventually trigger SoC watchdog timeout.

Due to this hardware limitation, SoC should skip entering idle mode if the remaining timer value is less than 150µs(safe margin).