### PR TITLE
manifest: Update segger with enabling DT sections

### DIFF
--- a/modules/segger/Kconfig
+++ b/modules/segger/Kconfig
@@ -97,6 +97,8 @@ config SEGGER_RTT_SECTION_CUSTOM
 
 config SEGGER_RTT_SECTION_CUSTOM_DTS_REGION
 	bool "Place RTT data in custom linker section defined by a memory region in DTS"
+	help
+	  The DTS memory section needs to have the "rtt_custom_section" alias.
 
 endif
 

--- a/west.yml
+++ b/west.yml
@@ -365,7 +365,7 @@ manifest:
         - testing
         - tee
     - name: segger
-      revision: 9f08435a79d41133d7046b7c59d1b25929eda450
+      revision: 7c843ea24b9b4f100c226bce0b4eb807e50a42ac
       path: modules/debug/segger
       groups:
         - debug


### PR DESCRIPTION
Update segger with a change in SEGGER_RTT_Conf.h that allows to use DT memory section for RTT data.

Added help section to SEGGER_RTT_SECTION_CUSTOM_DTS_REGION Kconfig explaining what alias need to be added to DTS.