### PR TITLE
boards: nordic: nrf54h20dk: Add cpuapp TCM memory section

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -334,26 +334,24 @@ zephyr_udc0: &usbhs {
 	status = "okay";
 };
 
-/* Trim this RAM block for power management related features. */
 &cpuapp_ram0 {
-	reg = <0x22000000 (DT_SIZE_K(32) - 256)>;
-	ranges = <0x0 0x22000000 (0x8000 - 0x100)>;
-};
+	cpuapp_tcm_region: cpuapp_ram0@0 {
+		compatible = "zephyr,memory-region";
+		reg = <0x00000000 (DT_SIZE_K(32) - 256)>;
+		zephyr,memory-region = "APP_RAM0";
+	};
 
-/ {
-	soc {
-		/* cache control functions - must be executed from local SRAM */
-		pm_ramfunc: cpuapp_s2ram@22007f00 {
-			compatible = "zephyr,memory-region", "mmio-sram";
-			reg = <0x22007f00 192>;
-			zephyr,memory-region = "PMLocalRamfunc";
-		};
+	/* cache control functions - must be executed from local SRAM */
+	pm_ramfunc: cpuapp_s2ram@7f00 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x00007f00 192>;
+		zephyr,memory-region = "PMLocalRamfunc";
+	};
 
-		/* run-time common S2RAM cpu context RAM */
-		pm_s2ram: cpuapp_s2ram@22007fe0 {
-			compatible = "zephyr,memory-region", "mmio-sram";
-			reg = <0x22007fe0 32>;
-			zephyr,memory-region = "pm_s2ram_context";
-		};
+	/* run-time common S2RAM cpu context RAM */
+	pm_s2ram: cpuapp_s2ram@7fe0 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x00007fe0 32>;
+		zephyr,memory-region = "pm_s2ram_context";
 	};
 };


### PR DESCRIPTION
Add memory section which is placed in cpuapp TCM (Tightly Coupled Memory) RAM0 which is fast, non-cacheable.

~~Contains #100564 which fixes failing CI.~~