### PR TITLE
nordic: nrf54h: bicrgen: patch lfosc lfxo accuracy parsing

### DIFF
--- a/soc/nordic/nrf54h/bicr/bicrgen.py
+++ b/soc/nordic/nrf54h/bicr/bicrgen.py
@@ -324,7 +324,7 @@ class LFXOConfig:
             raise ValueError("Invalid LFXO startup time (not configured)")
 
         return cls(
-            accuracy_ppm=int(lfosc_lfxoconfig.enum_get("ACCURACY")[:3]),
+            accuracy_ppm=int(lfosc_lfxoconfig.enum_get("ACCURACY")[:-3]),
             mode=LFXOMode(lfosc_lfxoconfig.enum_get("MODE")),
             builtin_load_capacitors=builtin_load_capacitors,
             builtin_load_capacitance_pf=builtin_load_capacitance_pf,


### PR DESCRIPTION
The accuracy field of lfocs lfxo is incorrectly parsed from the SVD file. Instead of stripping the "ppm" from the value before converting it to an int, we are taking only the first three digits. This works for 500ppm, but not for 20ppm.

Patch to strip last three digits instead.