### PR TITLE
MAINTAINERS: Include native drivers host side in native area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3775,6 +3775,8 @@ Native_sim and POSIX arch:
     - scripts/valgrind.supp
     - soc/native/
     - tests/boards/native_sim/
+  files-regex:
+    - (drivers/|subsys/).*(bottom)\.([c|h])
   labels:
     - "area: native port"
   description: >-


### PR DESCRIPTION
Let's include the "bottom" side of native drivers in the native_sim area for the drivers which were missing. So they are covered from the "platform" side of things by this area.

The regex picks .c and .h files, in the drivers and subsys folders which have "bottom" at the end of their name.

Before we were already covering drivers which had "posix" or "native" anywhere in their name, but that did not include all which are not named following that pattern.
(i.e. userchan, linux_evdev, sdl_touch, display_sdl, gpio_emul_sdl, fuse_fs_access)