### PR TITLE
drivers: usb: udc: stm32: move power configuration to common code

### DIFF
--- a/drivers/usb/common/CMakeLists.txt
+++ b/drivers/usb/common/CMakeLists.txt
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory_ifdef(CONFIG_HAS_NRFX nrf_usbd_common)
+add_subdirectory_ifdef(CONFIG_SOC_FAMILY_STM32 stm32)

--- a/drivers/usb/common/Kconfig
+++ b/drivers/usb/common/Kconfig
@@ -4,5 +4,6 @@
 menu "USB common"
 
 rsource "nrf_usbd_common/Kconfig"
+rsource "stm32/Kconfig"
 
 endmenu

--- a/drivers/usb/common/stm32/CMakeLists.txt
+++ b/drivers/usb/common/stm32/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_STM32_USB_COMMON)
+  zephyr_library()
+
+  zephyr_include_directories(.)
+
+  zephyr_library_sources(stm32_usb_pwr.c)
+endif()

--- a/drivers/usb/common/stm32/Kconfig
+++ b/drivers/usb/common/stm32/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2025 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_FAMILY_STM32
+
+config STM32_USB_COMMON
+	bool
+	help
+	  Enable compilation of STM32 USB common code.
+	  This option is selected by the USB drivers when appropriate.
+
+module = STM32_USB_COMMON
+module-str = STM32 USB common code
+source "subsys/logging/Kconfig.template.log_config"
+
+endif  # SOC_FAMILY_STM32

--- a/drivers/usb/common/stm32/stm32_usb_common.h
+++ b/drivers/usb/common/stm32/stm32_usb_common.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_USB_COMMON_STM32_STM32_USB_COMMON_H_
+#define ZEPHYR_DRIVERS_USB_COMMON_STM32_STM32_USB_COMMON_H_
+
+/**
+ * @brief Configures the Power Controller as necessary
+ * for proper operation of the USB controllers
+ *
+ * @returns 0 on success, negative error code otherwise.
+ */
+int stm32_usb_pwr_enable(void);
+
+#endif /* ZEPHYR_DRIVERS_USB_COMMON_STM32_STM32_USB_COMMON_H_ */

--- a/drivers/usb/common/stm32/stm32_usb_common.h
+++ b/drivers/usb/common/stm32/stm32_usb_common.h
@@ -15,4 +15,13 @@
  */
 int stm32_usb_pwr_enable(void);
 
+/**
+ * @brief Configures the Power Controller to disable
+ * USB-related regulators/etc if no controller is
+ * still active (refcounted).
+ *
+ * @returns 0 on success, negative error code otherwise.
+ */
+int stm32_usb_pwr_disable(void);
+
 #endif /* ZEPHYR_DRIVERS_USB_COMMON_STM32_STM32_USB_COMMON_H_ */

--- a/drivers/usb/common/stm32/stm32_usb_pwr.c
+++ b/drivers/usb/common/stm32/stm32_usb_pwr.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <soc.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_system.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(stm32_usb_pwr, CONFIG_STM32_USB_COMMON_LOG_LEVEL);
+
+/*
+ * Keep track of whether power is already
+ * enabled here to simplify the USB drivers.
+ */
+static K_SEM_DEFINE(pwr_refcount_mutex, 1, 1);
+static uint32_t usb_pwr_refcount;
+
+int stm32_usb_pwr_enable(void)
+{
+	uint32_t old_count;
+	int err;
+
+	err = k_sem_take(&pwr_refcount_mutex, K_FOREVER);
+	if (err != 0) {
+		return err;
+	}
+
+	old_count = usb_pwr_refcount++;
+	if (old_count > 0) {
+		/* Already enabled - nothing to do */
+		err = 0;
+		goto fini;
+	}
+
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	LL_PWR_EnableUSBVoltageDetector();
+
+	/* Per AN2606: USBREGEN not supported when running in FS mode. */
+	LL_PWR_DisableUSBReg();
+	while (!LL_PWR_IsActiveFlag_USB()) {
+		LOG_INF("PWR not active yet");
+		k_msleep(100);
+	}
+#elif defined(CONFIG_SOC_SERIES_STM32U5X)
+	__ASSERT_NO_MSG(LL_AHB3_GRP1_IsEnabledClock(LL_AHB3_GRP1_PERIPH_PWR));
+
+	/* Check that power range is 1 or 2 */
+	if (LL_PWR_GetRegulVoltageScaling() < LL_PWR_REGU_VOLTAGE_SCALE2) {
+		LOG_ERR("Wrong Power range to use USB OTG HS");
+		err = -EIO;
+		goto fini;
+	}
+
+	LL_PWR_EnableVddUSB();
+
+# if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)
+	/* Enable HS PHY power supply */
+	LL_PWR_EnableUSBPowerSupply();
+	LL_PWR_EnableUSBEPODBooster();
+	while (LL_PWR_IsActiveFlag_USBBOOST() != 1) {
+		/* Wait for USB EPOD BOOST ready */
+	}
+# endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs) */
+#elif defined(CONFIG_SOC_SERIES_STM32N6X)
+	/* Enable Vdd33USB voltage monitoring */
+	LL_PWR_EnableVddUSBMonitoring();
+	while (!LL_PWR_IsActiveFlag_USB33RDY()) {
+		/* Wait for Vdd33USB ready */
+	}
+
+	/* Enable VDDUSB */
+	LL_PWR_EnableVddUSB();
+#elif defined(CONFIG_SOC_SERIES_STM32WBAX)
+	/* Remove VDDUSB power isolation */
+	LL_PWR_EnableVddUSB();
+
+	/* Make sure that voltage scaling is Range 1 */
+	__ASSERT_NO_MSG(LL_PWR_GetRegulCurrentVOS() == LL_PWR_REGU_VOLTAGE_SCALE1);
+
+	/* Enable VDD11USB */
+	LL_PWR_EnableVdd11USB();
+
+	/* Enable USB OTG internal power */
+	LL_PWR_EnableUSBPWR();
+
+	while (!LL_PWR_IsActiveFlag_VDD11USBRDY()) {
+		/* Wait for VDD11USB supply to be ready */
+	}
+
+	/* Enable USB OTG booster */
+	LL_PWR_EnableUSBBooster();
+
+	while (!LL_PWR_IsActiveFlag_USBBOOSTRDY()) {
+		/* Wait for USB OTG booster to be ready */
+	}
+#elif defined(PWR_USBSCR_USB33SV) || defined(PWR_SVMCR_USV)
+	/*
+	 * VDDUSB independent USB supply (PWR clock is on)
+	 * with LL_PWR_EnableVDDUSB function (higher case)
+	 */
+	LL_PWR_EnableVDDUSB();
+#elif defined(PWR_CR2_USV)
+	/*
+	 * Required for at least STM32L4 devices as they electrically
+	 * isolate USB features from VDDUSB. It must be enabled before
+	 * USB can function. Refer to section 5.1.3 in DM00083560 or
+	 * DM00310109.
+	 */
+	LL_PWR_EnableVddUSB();
+#endif
+	/* Successful control flow in series-specific code above
+	 * will fall here. Set `err` to success value in a single
+	 * place to avoid duplication.
+	 */
+	err = 0;
+
+fini:
+	if (err != 0) {
+		/* An error occurred - drop reference before unlocking */
+		usb_pwr_refcount--;
+	}
+
+	k_sem_give(&pwr_refcount_mutex);
+
+	return err;
+}

--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -10,6 +10,7 @@ config UDC_STM32
 	select USE_STM32_HAL_PCD
 	select USE_STM32_HAL_PCD_EX
 	select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT
+	select STM32_USB_COMMON
 	select PINCTRL
 	default y
 	help

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -22,6 +22,7 @@
 #include <zephyr/sys/util.h>
 
 #include "udc_common.h"
+#include <stm32_usb_common.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(udc_stm32, CONFIG_UDC_DRIVER_LOG_LEVEL);
@@ -720,6 +721,13 @@ int udc_stm32_init(const struct device *dev)
 	struct udc_stm32_data *priv = udc_get_private(dev);
 	const struct udc_stm32_config *cfg = dev->config;
 	HAL_StatusTypeDef status;
+	int err;
+
+	err = stm32_usb_pwr_enable();
+	if (err != 0) {
+		LOG_ERR("Error enabling USB power: %d", err);
+		return err;
+	}
 
 	if (udc_stm32_clock_enable(dev) < 0) {
 		LOG_ERR("Error enabling clock(s)");
@@ -1296,76 +1304,6 @@ static int udc_stm32_clock_enable(const struct device *dev)
 		return -ENODEV;
 	}
 
-	/* Power configuration */
-#if defined(CONFIG_SOC_SERIES_STM32H7X)
-	LL_PWR_EnableUSBVoltageDetector();
-
-	/* Per AN2606: USBREGEN not supported when running in FS mode. */
-	LL_PWR_DisableUSBReg();
-	while (!LL_PWR_IsActiveFlag_USB()) {
-		LOG_INF("PWR not active yet");
-		k_msleep(100);
-	}
-#elif defined(CONFIG_SOC_SERIES_STM32U5X)
-	/* Sequence to enable the power of the OTG HS on a stm32U5 serie : Enable VDDUSB */
-	__ASSERT_NO_MSG(LL_AHB3_GRP1_IsEnabledClock(LL_AHB3_GRP1_PERIPH_PWR));
-
-	/* Check that power range is 1 or 2 */
-	if (LL_PWR_GetRegulVoltageScaling() < LL_PWR_REGU_VOLTAGE_SCALE2) {
-		LOG_ERR("Wrong Power range to use USB OTG HS");
-		return -EIO;
-	}
-
-	LL_PWR_EnableVddUSB();
-
-	#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)
-		/* Configure VOSR register of USB HSTransceiverSupply(); */
-		LL_PWR_EnableUSBPowerSupply();
-		LL_PWR_EnableUSBEPODBooster();
-		while (LL_PWR_IsActiveFlag_USBBOOST() != 1) {
-			/* Wait for USB EPOD BOOST ready */
-		}
-	#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs) */
-#elif defined(CONFIG_SOC_SERIES_STM32N6X)
-	/* Enable Vdd33USB voltage monitoring */
-	LL_PWR_EnableVddUSBMonitoring();
-	while (!LL_PWR_IsActiveFlag_USB33RDY()) {
-		/* Wait for Vdd33USB ready */
-	}
-
-	/* Enable VDDUSB */
-	LL_PWR_EnableVddUSB();
-#elif defined(CONFIG_SOC_SERIES_STM32WBAX)
-	/* Remove VDDUSB power isolation */
-	LL_PWR_EnableVddUSB();
-
-	/* Make sure that voltage scaling is Range 1 */
-	__ASSERT_NO_MSG(LL_PWR_GetRegulCurrentVOS() == LL_PWR_REGU_VOLTAGE_SCALE1);
-
-	/* Enable VDD11USB */
-	LL_PWR_EnableVdd11USB();
-
-	/* Enable USB OTG internal power */
-	LL_PWR_EnableUSBPWR();
-
-	while (!LL_PWR_IsActiveFlag_VDD11USBRDY()) {
-		/* Wait for VDD11USB supply to be ready */
-	}
-
-	/* Enable USB OTG booster */
-	LL_PWR_EnableUSBBooster();
-
-	while (!LL_PWR_IsActiveFlag_USBBOOSTRDY()) {
-		/* Wait for USB OTG booster to be ready */
-	}
-#elif defined(PWR_USBSCR_USB33SV) || defined(PWR_SVMCR_USV)
-	/*
-	 * VDDUSB independent USB supply (PWR clock is on)
-	 * with LL_PWR_EnableVDDUSB function (higher case)
-	 */
-	LL_PWR_EnableVDDUSB();
-#endif
-
 	if (cfg->num_clocks > 1) {
 		if (clock_control_configure(clk, &cfg->pclken[1], NULL) != 0) {
 			LOG_ERR("Could not select USB domain clock");
@@ -1617,26 +1555,6 @@ static int udc_stm32_driver_init0(const struct device *dev)
 			return -EIO;
 		}
 	}
-
-	/*cd
-	 * Required for at least STM32L4 devices as they electrically
-	 * isolate USB features from VDDUSB. It must be enabled before
-	 * USB can function. Refer to section 5.1.3 in DM00083560 or
-	 * DM00310109.
-	 */
-#ifdef PWR_CR2_USV
-#if defined(LL_APB1_GRP1_PERIPH_PWR)
-	if (LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_PWR)) {
-		LL_PWR_EnableVddUSB();
-	} else {
-		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
-		LL_PWR_EnableVddUSB();
-		LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_PWR);
-	}
-	#else
-	LL_PWR_EnableVddUSB();
-#endif /* defined(LL_APB1_GRP1_PERIPH_PWR) */
-#endif /* PWR_CR2_USV */
 
 	return 0;
 }

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -954,6 +954,7 @@ static int udc_stm32_shutdown(const struct device *dev)
 	struct udc_stm32_data *priv = udc_get_private(dev);
 	const struct udc_stm32_config *cfg = dev->config;
 	HAL_StatusTypeDef status;
+	int err;
 
 	status = HAL_PCD_DeInit(&priv->pcd);
 	if (status != HAL_OK) {
@@ -963,6 +964,12 @@ static int udc_stm32_shutdown(const struct device *dev)
 
 	if (udc_stm32_clock_disable(dev) < 0) {
 		LOG_ERR("Error disabling clock(s)");
+		/* continue anyway */
+	}
+
+	err = stm32_usb_pwr_disable();
+	if (err != 0) {
+		LOG_ERR("Error disabling USB power: %d", err);
 		/* continue anyway */
 	}
 


### PR DESCRIPTION
Create infrastructure for shared USB common code on STM32 family, and move the Power Controller configuration logic to common code.

The power configuration is left unchanged for now, but it can be further cleaned up and improved in the future.