### PR TITLE
modules: hal_infineon: fix build failure for Infineon CYT4BFC 320 BGA pin package

### DIFF
--- a/modules/hal_infineon/mtb-hal-cat1/CMakeLists.txt
+++ b/modules/hal_infineon/mtb-hal-cat1/CMakeLists.txt
@@ -74,7 +74,7 @@ zephyr_library_sources_ifdef(CONFIG_SOC_PACKAGE_XMC7200_176_TEQFP
 zephyr_library_sources_ifdef(CONFIG_SOC_PACKAGE_XMC7200_272_BGA
   ${hal_cat1c_dir}/source/pin_packages/cyhal_xmc7200_272_bga.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_PACKAGE_XMC7200_320_BGA
-  ${hal_cat1c_dir}/source/pin_packages/cyhal_xmc7200_320_bga.c.c)
+  ${hal_cat1c_dir}/source/pin_packages/cyhal_xmc7200_320_bga.c)
 
 zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_CYW20829
   ${hal_cat1b_dir}/source/triggers/cyhal_triggers_cyw20829.c)


### PR DESCRIPTION
Fixes #100523 which reports about error in Cmakelists.txt file within directory zephyr/modules/hal_infineon/mtb-hal-cat1/CMakeLists.txt.

### Details
Removed the extra inclusion of 'c' file extension which considers the correct source file 320 BGA Pin Package and considers the correct source file  cyhal_xmc7200_320_bga.c.

