### PR TITLE
drivers: i2c: i2c_dw: added SDA hold control to DW I2C driver

### DIFF
--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -10,7 +10,7 @@ menuconfig I2C_DW
 	  Enable the Design Ware I2C driver
 
 config I2C_DW_CLOCK_SPEED
-	int "Set the clock speed for I2C"
+	int "Set the clock speed for I2C (MHz)"
 	depends on I2C_DW
 	default 100 if I2C_RTS5912
 	default 32
@@ -35,3 +35,8 @@ config I2C_DW_EXTENDED_SUPPORT
 	help
 	  This option enables support for the SCL/SDA timeout registers and some
 	  additional features of the DW I2C controller.
+	  
+config I2C_DW_SDA_HOLD_SUPPORT
+	bool "Enable SDA hold support"
+	help
+	  This option enables support for the SDA hold registers

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1036,17 +1036,61 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 			dw->hcnt = value;
 		} else {
 			rc = -EINVAL;
+			goto error;
 		}
 		break;
 	default:
 		/* TODO change */
 		rc = -EINVAL;
+		goto error;
 	}
 
 	/*
 	 * Clear any interrupts currently waiting in the controller
 	 */
 	value = read_clr_intr(reg_base);
+
+	/*
+	 * Check SDA hold
+	 */
+#ifdef CONFIG_I2C_DW_SDA_HOLD_SUPPORT
+	union ic_sda_hold_register sda_hold_reg = {.raw = read_sdahold(reg_base)};
+
+	/* 
+	 * According to the datasheet, the maximum value of SDA TX HOLD is N_SCL_LOW - 2, 
+	 * where N_SCL_LOW = IC_*_LCNT + 1
+	 */
+	int32_t max_sda_tx_hold = dw->lcnt - 1;
+	if ((int32_t)sda_hold_reg.bits.sda_tx_hold > max_sda_tx_hold) {
+		LOG_ERR("I2C: SDA TX hold (%d) cannot be larger than low part of the SCL period (%d)", 
+			    sda_hold_reg.bits.sda_tx_hold, max_sda_tx_hold);
+		rc = -EINVAL;
+		goto error;
+	}
+
+	/* All calculations are taken from datasheet (2.16.1 SDA Hold Timings in Receiver) */
+	int32_t max_sda_rx_hold;
+	if (I2C_SPEED_GET(dw->app_config) != I2C_SPEED_HIGH) {
+		max_sda_rx_hold = dw->hcnt - read_fs_spklen(reg_base) - 3;
+	} else {
+		/* 
+		 * WARNING: Initialization of the value returned by the read_fs_scl_hcnt()
+		 * function occurs when transferring the first message at Fast Speed.
+		 * Otherwise, the default register value is used (which may not correspond
+		 * to the I2C peripheral input frequency).
+		 */
+		max_sda_rx_hold = MIN(read_fs_scl_hcnt(reg_base) - read_fs_spklen(reg_base) - 3,
+				      dw->lcnt - read_hs_spklen(reg_base) - 3);
+	}
+
+	if ((int32_t)sda_hold_reg.bits.sda_rx_hold > max_sda_rx_hold) {
+		LOG_ERR("I2C: SDA RX hold (%d) bigger than the maximum permissible value (%d)",
+			sda_hold_reg.bits.sda_rx_hold, max_sda_rx_hold);
+		rc = -EINVAL;
+	}
+#endif
+
+error:
 
 	/*
 	 * TEMPORARY HACK - The I2C does not work in any mode other than Master
@@ -1325,6 +1369,40 @@ static int i2c_dw_initialize(const struct device *dev)
 
 	dw->app_config = I2C_MODE_CONTROLLER | i2c_map_dt_bitrate(rom->bitrate);
 
+#ifdef CONFIG_I2C_DW_SDA_HOLD_SUPPORT
+	/* 
+	 * Convert values in nanoseconds to values in ic_clk cycles.
+	 * These calculations are equivalent: 
+	 * sda_tx_hold = sda_tx_hold_ns / (input frequency of the periphery in ns)
+	 */
+	uint32_t sda_tx_hold = (rom->sda_tx_hold_ns * CONFIG_I2C_DW_CLOCK_SPEED) / KHZ(1);
+	uint32_t sda_rx_hold = (rom->sda_rx_hold_ns * CONFIG_I2C_DW_CLOCK_SPEED) / KHZ(1);
+
+	if (sda_tx_hold < 1) {
+		LOG_ERR("I2C: SDA TX hold (%d) cannot be less than 1", sda_tx_hold);
+		return -EINVAL;
+	}
+
+	if (sda_tx_hold > UINT16_MAX) {
+		LOG_ERR("I2C: SDA TX hold (%d) cannot be more than %d", sda_tx_hold, UINT16_MAX);
+		return -EINVAL;
+	}
+
+	if (sda_rx_hold > UINT8_MAX) {
+		LOG_ERR("I2C: SDA RX hold (%d) cannot be more than %d", sda_rx_hold, UINT8_MAX);
+		return -EINVAL;
+	}
+
+	union ic_sda_hold_register sda_hold_reg = {
+		.bits = {
+			.sda_tx_hold = (uint16_t)sda_tx_hold,
+			.sda_rx_hold = (uint8_t)sda_rx_hold,
+		}
+	};
+
+	write_sdahold(sda_hold_reg.raw, reg_base);
+#endif
+
 	if (i2c_dw_runtime_configure(dev, dw->app_config) != 0) {
 		LOG_DBG("I2C: Cannot set default configuration");
 		return -EIO;
@@ -1421,6 +1499,14 @@ static int i2c_dw_initialize(const struct device *dev)
 #define TIMEOUT_DW_CONFIG(n)
 #endif
 
+#ifdef CONFIG_I2C_DW_SDA_HOLD_SUPPORT
+#define I2C_CONFIG_SDA_HOLD_INIT(n)	\
+		.sda_tx_hold_ns = DT_INST_PROP(n, sda_tx_hold_ns), \
+		.sda_rx_hold_ns = DT_INST_PROP(n, sda_rx_hold_ns),
+#else
+#define I2C_CONFIG_SDA_HOLD_INIT(n)
+#endif
+
 #define I2C_DEVICE_INIT_DW(n)                                                                      \
 	PINCTRL_DW_DEFINE(n);                                                                      \
 	I2C_PCIE_DEFINE(n);                                                                        \
@@ -1432,7 +1518,7 @@ static int i2c_dw_initialize(const struct device *dev)
 		.lcnt_offset = (int16_t)DT_INST_PROP_OR(n, lcnt_offset, 0),                        \
 		.hcnt_offset = (int16_t)DT_INST_PROP_OR(n, hcnt_offset, 0),                        \
 		TIMEOUT_DW_CONFIG(n) RESET_DW_CONFIG(n) PINCTRL_DW_CONFIG(n) I2C_DW_INIT_PCIE(n)   \
-			I2C_CONFIG_DMA_INIT(n)};                                                   \
+			I2C_CONFIG_DMA_INIT(n) I2C_CONFIG_SDA_HOLD_INIT(n)};                       \
 	static struct i2c_dw_dev_config i2c_##n##_runtime;                                         \
 	I2C_DEVICE_DT_INST_DEFINE(n, i2c_dw_initialize, NULL, &i2c_##n##_runtime,                  \
 				  &i2c_config_dw_##n, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,       \

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -121,6 +121,11 @@ struct i2c_dw_rom_config {
 	uint32_t sda_timeout_value;
 	uint32_t scl_timeout_value;
 #endif
+
+#ifdef CONFIG_I2C_DW_SDA_HOLD_SUPPORT
+	uint32_t sda_tx_hold_ns;
+	uint32_t sda_rx_hold_ns;
+#endif
 };
 
 struct i2c_dw_dev_config {

--- a/drivers/i2c/i2c_dw_registers.h
+++ b/drivers/i2c/i2c_dw_registers.h
@@ -144,6 +144,16 @@ union ic_comp_param_1_register {
 	} bits;
 };
 
+/* IC_SDA_HOLD */
+union ic_sda_hold_register {
+	uint32_t raw;
+	struct {
+		uint32_t sda_tx_hold: 16 __packed;
+		uint32_t sda_rx_hold: 8 __packed;
+		uint32_t rsvd_sda_hold: 8 __packed;
+	} bits;
+};
+
 #define DW_IC_REG_CON           (0x00)
 #define DW_IC_REG_TAR           (0x04)
 #define DW_IC_REG_SAR           (0x08)
@@ -213,6 +223,7 @@ DEFINE_MM_REG_WRITE(ss_scl_hcnt, DW_IC_REG_SS_SCL_HCNT, 32)
 DEFINE_MM_REG_WRITE(ss_scl_lcnt, DW_IC_REG_SS_SCL_LCNT, 32)
 
 DEFINE_MM_REG_WRITE(fs_scl_hcnt, DW_IC_REG_FS_SCL_HCNT, 32)
+DEFINE_MM_REG_READ(fs_scl_hcnt, DW_IC_REG_FS_SCL_HCNT, 32)
 DEFINE_MM_REG_WRITE(fs_scl_lcnt, DW_IC_REG_FS_SCL_LCNT, 32)
 
 DEFINE_MM_REG_WRITE(hs_scl_hcnt, DW_IC_REG_HS_SCL_HCNT, 32)

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -32,3 +32,15 @@ properties:
     default: 30
     description: |
       Describe the SCL stuck at low timeout value, unit in ms
+      
+  sda-tx-hold-ns:
+    type: int
+    default: 300
+    description: |
+      Hold time in nanoseconds of SDA during transmit in both slave and master mode (after SCL goes from HIGH to LOW)
+
+  sda-rx-hold-ns:
+    type: int
+    default: 0
+    description: |
+      Extend the SDA transition (if any) whenever SCL is HIGH in the receiver in either master or slave mode (nanoseconds)


### PR DESCRIPTION
In some cases it is necessary to control the delay on the SDA line. Therefore, the ability to control SDA hold has been added by specifying the hold time in the device tree.