### PR TITLE
tests: Bluetooth: Tester: Fix miss check and alloc in BAP broadcast

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -75,8 +75,9 @@ struct btp_bap_broadcast_local_source *
 btp_bap_broadcast_local_source_allocate(uint32_t broadcast_id)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(local_sources); i++) {
-		if (local_sources[i].broadcast_id == broadcast_id) {
-			LOG_ERR("Local source already allocated for broadcast id %d", broadcast_id);
+		if (local_sources[i].allocated && local_sources[i].broadcast_id == broadcast_id) {
+			LOG_ERR("Local source already allocated for broadcast id 0x%06X",
+				broadcast_id);
 
 			return NULL;
 		}
@@ -95,7 +96,7 @@ btp_bap_broadcast_local_source_allocate(uint32_t broadcast_id)
 	return NULL;
 }
 
-static int btp_bap_broadcast_local_source_free(struct btp_bap_broadcast_local_source *source)
+int btp_bap_broadcast_local_source_free(struct btp_bap_broadcast_local_source *source)
 {
 	if (source == NULL) {
 		return -EINVAL;
@@ -110,7 +111,7 @@ struct btp_bap_broadcast_local_source *
 btp_bap_broadcast_local_source_from_src_id_get(uint32_t source_id)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(local_sources); i++) {
-		if (local_sources[i].source_id == source_id) {
+		if (local_sources[i].allocated && local_sources[i].source_id == source_id) {
 			return &local_sources[i];
 		}
 	}
@@ -124,7 +125,7 @@ static struct btp_bap_broadcast_local_source *
 btp_bap_broadcast_local_source_from_brcst_id_get(uint32_t broadcast_id)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(local_sources); i++) {
-		if (local_sources[i].broadcast_id == broadcast_id) {
+		if (local_sources[i].allocated && local_sources[i].broadcast_id == broadcast_id) {
 			return &local_sources[i];
 		}
 	}

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.h
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.h
@@ -76,6 +76,10 @@ uint8_t btp_bap_broadcast_local_source_idx_get(struct btp_bap_broadcast_local_so
 struct btp_bap_broadcast_stream *btp_bap_broadcast_stream_alloc(
 	struct btp_bap_broadcast_local_source *source);
 
+struct btp_bap_broadcast_local_source *
+btp_bap_broadcast_local_source_allocate(uint32_t broadcast_id);
+int btp_bap_broadcast_local_source_free(struct btp_bap_broadcast_local_source *source);
+
 uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 				       void *rsp, uint16_t *rsp_len);
 uint8_t btp_bap_broadcast_source_setup_v2(const void *cmd, uint16_t cmd_len,


### PR DESCRIPTION
Some of the BAP broadcast functions was missing a check for allocated.

Adding the checks exposed a bug in the CAP commands where the broadcasts were never actually allocated. Since there is not a command for that in CAP, a workaround has been implemented to use the first command (setup_stream) to allocate a BAP broadcast with a dummy broadcast ID.