### PR TITLE
dts: vendor: nordic: Fix invalid nrf54lm20a partition layout

### DIFF
--- a/dts/vendor/nordic/nrf54lm20a_partition.dtsi
+++ b/dts/vendor/nordic/nrf54lm20a_partition.dtsi
@@ -21,17 +21,17 @@
 
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x10000 DT_SIZE_K(922)>;
+			reg = <0x10000 DT_SIZE_K(920)>;
 		};
 
-		slot1_partition: partition@f6800 {
+		slot1_partition: partition@f6000 {
 			label = "image-1";
-			reg = <0xf6800 DT_SIZE_K(922)>;
+			reg = <0xf6000 DT_SIZE_K(920)>;
 		};
 
-		storage_partition: partition@1dd000 {
+		storage_partition: partition@1dc000 {
 			label = "storage";
-			reg = <0x1dd000 DT_SIZE_K(32)>;
+			reg = <0x1dc000 DT_SIZE_K(36)>;
 		};
 	};
 };


### PR DESCRIPTION
This device indicates 4KiB sector size and has an impossible partition layout that starts part the way through a sector, this fixes the issue by having proper partition alignment