### PR TITLE
maintainers: Add nRF boards sub-group and add self as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6446,6 +6446,13 @@ nRF Platforms:
   files-exclude:
     - drivers/wifi/nrf_wifi/
     - dts/bindings/wifi/
+  file-groups:
+    - name: nRF boards
+      collaborators:
+        - nordicjm
+      files:
+        - boards/nordic/
+        - dts/*/nordic/
   labels:
     - "platform: nRF"
 


### PR DESCRIPTION
Adds a new sub-group to nRF platforms, specifically for board files, and add myself to this sub-group as a collaborator