### PR TITLE
test: benchmarks: update 'timing cycle to ns' conversion function

### DIFF
--- a/tests/benchmarks/app_kernel/src/mailbox_b.c
+++ b/tests/benchmarks/app_kernel/src/mailbox_b.c
@@ -96,7 +96,7 @@ void mailbox_test(void)
 void mailbox_put(uint32_t size, int count, uint32_t *time)
 {
 	int i;
-	unsigned int t;
+	uint64_t  t;
 	timing_t  start;
 	timing_t  end;
 
@@ -110,6 +110,6 @@ void mailbox_put(uint32_t size, int count, uint32_t *time)
 		k_mbox_put(&MAILB1, &message, K_FOREVER);
 	}
 	end = timing_timestamp_get();
-	t = (unsigned int)timing_cycles_get(&start, &end);
-	*time = SYS_CLOCK_HW_CYCLES_TO_NS_AVG(t, count);
+	t = timing_cycles_get(&start, &end);
+	*time = timing_cycles_to_ns_avg(t, count);
 }

--- a/tests/benchmarks/app_kernel/src/master.h
+++ b/tests/benchmarks/app_kernel/src/master.h
@@ -25,7 +25,7 @@
 #include <zephyr/timing/timing.h>
 
 /* printf format defines. */
-#define FORMAT "| %-65s|%10u|\n"
+#define FORMAT "| %-65s|%10llu|\n"
 
 /* length of the output line */
 #define SLINE_LEN 256

--- a/tests/benchmarks/app_kernel/src/memmap_b.c
+++ b/tests/benchmarks/app_kernel/src/memmap_b.c
@@ -14,7 +14,7 @@
  */
 void memorymap_test(void)
 {
-	uint32_t et; /* elapsed time */
+	uint64_t et; /* elapsed time */
 	timing_t  start;
 	timing_t  end;
 	int i;
@@ -27,14 +27,14 @@ void memorymap_test(void)
 		alloc_status = k_mem_slab_alloc(&MAP1, &p, K_FOREVER);
 		if (alloc_status != 0) {
 			PRINT_F(FORMAT,
-				"Error: Slab allocation failed.", alloc_status);
+				"Error: Slab allocation failed.", (int64_t)alloc_status);
 			break;
 		}
 		k_mem_slab_free(&MAP1, p);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "average alloc and dealloc memory page",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, (2 * NR_OF_MAP_RUNS)));
+		timing_cycles_to_ns_avg(et, (2 * NR_OF_MAP_RUNS)));
 }

--- a/tests/benchmarks/app_kernel/src/msgq_b.c
+++ b/tests/benchmarks/app_kernel/src/msgq_b.c
@@ -13,7 +13,7 @@
  */
 void message_queue_test(void)
 {
-	uint32_t et; /* elapsed time */
+	uint64_t et; /* elapsed time */
 	int i;
 	timing_t  start;
 	timing_t  end;
@@ -24,59 +24,59 @@ void message_queue_test(void)
 		k_msgq_put(&DEMOQX1, data_bench, K_FOREVER);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 	PRINT_F(FORMAT, "enqueue 1 byte msg in MSGQ",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_MSGQ_RUNS));
+		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
 		k_msgq_get(&DEMOQX1, data_bench, K_FOREVER);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "dequeue 1 byte msg from MSGQ",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_MSGQ_RUNS));
+		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
 		k_msgq_put(&DEMOQX4, data_bench, K_FOREVER);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "enqueue 4 bytes msg in MSGQ",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_MSGQ_RUNS));
+		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
 		k_msgq_get(&DEMOQX4, data_bench, K_FOREVER);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "dequeue 4 bytes msg in MSGQ",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_MSGQ_RUNS));
+		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
 		k_msgq_put(&DEMOQX192, data_bench, K_FOREVER);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "enqueue 192 bytes msg in MSGQ",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_MSGQ_RUNS));
+		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
 		k_msgq_get(&DEMOQX192, data_bench, K_FOREVER);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "dequeue 192 bytes msg in MSGQ",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_MSGQ_RUNS));
+		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	k_sem_give(&STARTRCV);
 
@@ -85,31 +85,31 @@ void message_queue_test(void)
 		k_msgq_put(&DEMOQX1, data_bench, K_FOREVER);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT,
 		"enqueue 1 byte msg in MSGQ to a waiting higher priority task",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_MSGQ_RUNS));
+		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
 		k_msgq_put(&DEMOQX4, data_bench, K_FOREVER);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT,
 		"enqueue 4 bytes in MSGQ to a waiting higher priority task",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_MSGQ_RUNS));
+		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
 		k_msgq_put(&DEMOQX192, data_bench, K_FOREVER);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT,
 		"enqueue 192 bytes in MSGQ to a waiting higher priority task",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_MSGQ_RUNS));
+		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 }

--- a/tests/benchmarks/app_kernel/src/mutex_b.c
+++ b/tests/benchmarks/app_kernel/src/mutex_b.c
@@ -13,7 +13,7 @@
  */
 void mutex_test(void)
 {
-	uint32_t et; /* elapsed time */
+	uint64_t et; /* elapsed time */
 	int i;
 	timing_t  start;
 	timing_t  end;
@@ -25,8 +25,8 @@ void mutex_test(void)
 		k_mutex_unlock(&DEMO_MUTEX);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "average lock and unlock mutex",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, (2 * NR_OF_MUTEX_RUNS)));
+		timing_cycles_to_ns_avg(et, (2 * NR_OF_MUTEX_RUNS)));
 }

--- a/tests/benchmarks/app_kernel/src/pipe_b.c
+++ b/tests/benchmarks/app_kernel/src/pipe_b.c
@@ -159,7 +159,7 @@ int pipeput(struct k_pipe *pipe,
 	    uint32_t *time)
 {
 	int i;
-	unsigned int t;
+	uint64_t t;
 	timing_t  start;
 	timing_t  end;
 	size_t sizexferd_total = 0;
@@ -192,9 +192,9 @@ int pipeput(struct k_pipe *pipe,
 	}
 
 	end = timing_timestamp_get();
-	t = (unsigned int)timing_cycles_get(&start, &end);
+	t = timing_cycles_get(&start, &end);
 
-	*time = SYS_CLOCK_HW_CYCLES_TO_NS_AVG(t, count);
+	*time = timing_cycles_to_ns_avg(t, count);
 
 	return 0;
 }

--- a/tests/benchmarks/app_kernel/src/pipe_r.c
+++ b/tests/benchmarks/app_kernel/src/pipe_r.c
@@ -83,7 +83,7 @@ int pipeget(struct k_pipe *pipe, enum pipe_options option, int size, int count,
 			unsigned int *time)
 {
 	int i;
-	unsigned int t;
+	uint64_t t;
 	timing_t  start;
 	timing_t  end;
 	size_t sizexferd_total = 0;
@@ -116,8 +116,8 @@ int pipeget(struct k_pipe *pipe, enum pipe_options option, int size, int count,
 	}
 
 	end = timing_timestamp_get();
-	t = (unsigned int) timing_cycles_get(&start, &end);
-	*time = SYS_CLOCK_HW_CYCLES_TO_NS_AVG(t, count);
+	t = timing_cycles_get(&start, &end);
+	*time = timing_cycles_to_ns_avg(t, count);
 
 	return 0;
 }

--- a/tests/benchmarks/app_kernel/src/sema_b.c
+++ b/tests/benchmarks/app_kernel/src/sema_b.c
@@ -13,7 +13,7 @@
  */
 void sema_test(void)
 {
-	uint32_t et; /* elapsed Time */
+	uint64_t et; /* elapsed Time */
 	int i;
 	timing_t  start;
 	timing_t  end;
@@ -24,10 +24,10 @@ void sema_test(void)
 	  k_sem_give(&SEM0);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "signal semaphore",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_SEMA_RUNS));
+		timing_cycles_to_ns_avg(et, NR_OF_SEMA_RUNS));
 
 	k_sem_reset(&SEM1);
 	k_sem_give(&STARTRCV);
@@ -37,18 +37,18 @@ void sema_test(void)
 		k_sem_give(&SEM1);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "signal to waiting high pri task",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_SEMA_RUNS));
+		timing_cycles_to_ns_avg(et, NR_OF_SEMA_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_SEMA_RUNS; i++) {
 		k_sem_give(&SEM1);
 	}
 	end = timing_timestamp_get();
-	et = (uint32_t)timing_cycles_get(&start, &end);
+	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "signal to waiting high pri task, with timeout",
-		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_SEMA_RUNS));
+		timing_cycles_to_ns_avg(et, NR_OF_SEMA_RUNS));
 }


### PR DESCRIPTION
SYS_CLOCK_HW_CYCLES_TO_NS_AVG is not correct since we are tracking cpu tick and SYS_CLOCK_HW_CYCLES_TO_NS_AVG convert it with the clock frequency; which is not the cpu frequency.
This patch used the correct conversion function (same api as function to get the timestamp).