### PR TITLE
soc: stm32: Introduce stm32_iocell driver

### DIFF
--- a/boards/ruiside/art_pi2/art_pi2.dts
+++ b/boards/ruiside/art_pi2/art_pi2.dts
@@ -121,3 +121,17 @@
 &vbat {
 	status = "okay";
 };
+
+&iocell {
+	status = "okay";
+
+	vddxspi1 {
+		hslv-mode = "on";
+		compensation-enabled;
+	};
+
+	vddxspi2 {
+		hslv-mode = "on";
+		compensation-enabled;
+	};
+};

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -32,3 +32,12 @@
 		};
 	};
 };
+
+&iocell {
+	status = "okay";
+
+	vddxspi2 {
+		hslv-mode = "on";
+		compensation-enabled;
+	};
+};

--- a/boards/st/nucleo_n657x0_q/Kconfig.defconfig
+++ b/boards/st/nucleo_n657x0_q/Kconfig.defconfig
@@ -8,4 +8,7 @@ if BOARD_NUCLEO_N657X0_Q
 configdefault NET_L2_ETHERNET
 	default y
 
+configdefault OTP
+	default y if ETH_STM32_HAL && NVMEM
+
 endif # BOARD_NUCLEO_N657X0_Q

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -256,6 +256,8 @@ zephyr_udc0: &usbotg_hs1 {
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	nvmem-cells = <&mac_address0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &mdio {
@@ -307,6 +309,10 @@ zephyr_udc0: &usbotg_hs1 {
 			};
 		};
 	};
+};
+
+&bsec {
+	status = "okay";
 };
 
 csi_interface: &dcmipp {

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -312,7 +312,17 @@ zephyr_udc0: &usbotg_hs1 {
 };
 
 &bsec {
+	/* Required by "iocell" and "ethernet" drivers */
 	status = "okay";
+};
+
+&iocell {
+	status = "okay";
+
+	vddio3 {
+		hslv-mode = "on";
+		compensation-enabled;
+	};
 };
 
 csi_interface: &dcmipp {

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -367,6 +367,20 @@ st_cam_i2c: &i2c1 {
 	status = "okay";
 };
 
+&iocell {
+	status = "okay";
+
+	vddxspi1 {
+		hslv-mode = "on";
+		compensation-enabled;
+	};
+
+	vddxspi2 {
+		hslv-mode = "on";
+		compensation-enabled;
+	};
+};
+
 usb2: &usbotg_fs {
 	pinctrl-0 = <&usb_otg_fs_dm_pm12 &usb_otg_fs_dp_pm11>;
 	pinctrl-names = "default";

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -234,6 +234,20 @@
 	timg-prescaler = <2>;
 };
 
+&iocell {
+	status = "okay";
+
+	vddio2 {
+		hslv-mode = "on";
+		compensation-enabled;
+	};
+
+	vddio3 {
+		hslv-mode = "on";
+		compensation-enabled;
+	};
+};
+
 &adc1 {
 	clocks = <&rcc STM32_CLOCK(AHB1, 5)>,
 		 <&rcc STM32_SRC_CKPER ADC12_SEL(1)>;
@@ -442,6 +456,7 @@ zephyr_udc0: &usbotg_hs1 {
 };
 
 &bsec {
+	/* Required by "iocell" and "ethernet" drivers */
 	status = "okay";
 };
 

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2114,18 +2114,6 @@ static int flash_stm32_xspi_init(const struct device *dev)
 		LOG_ERR("XSPI mode SPI|DUAL|QUAD/DTR is not valid");
 		return -ENOTSUP;
 	}
-#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
-	__HAL_RCC_SBS_CLK_ENABLE();
-	if (dev_data->hxspi.Instance == XSPI1) {
-		LL_PWR_EnableXSPIM1();
-		LL_SBS_EnableXSPI1SpeedOptim();
-	} else if (dev_data->hxspi.Instance == XSPI2) {
-		LL_PWR_EnableXSPIM2();
-		LL_SBS_EnableXSPI2SpeedOptim();
-	} else {
-		__ASSERT(0, "Not an XSPI instance?!");
-	}
-#endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 
 	/* Signals configuration */
 	ret = pinctrl_apply_state(dev_cfg->pcfg, PINCTRL_STATE_DEFAULT);

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -18,6 +18,7 @@
 #include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/video/video-interfaces.h>
+#include <zephyr/dt-bindings/power/stm32h7rs_iocell.h>
 #include <freq.h>
 #include <mem.h>
 
@@ -178,6 +179,23 @@
 	};
 
 	soc {
+		iocell: iocell {
+			compatible = "st,stm32-iocell";
+			status = "disabled";
+
+			vddio {
+				domain = <STM32_DT_IOCELL_VDDIO>;
+			};
+
+			vddxspi1 {
+				domain = <STM32_DT_IOCELL_XSPI1>;
+			};
+
+			vddxspi2 {
+				domain = <STM32_DT_IOCELL_XSPI2>;
+			};
+		};
+
 		flash: flash-controller@52002000 {
 			compatible = "st,stm32-flash-controller", "st,stm32h7-flash-controller";
 			reg = <0x52002000 0x400>;

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -16,6 +16,7 @@
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-nor-psram.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/video/video-interfaces.h>
+#include <zephyr/dt-bindings/power/stm32n6_iocell.h>
 #include <freq.h>
 #include <mem.h>
 
@@ -239,6 +240,37 @@
 	};
 
 	soc {
+		iocell: iocell {
+			compatible = "st,stm32-iocell";
+			status = "disabled";
+
+			/* If iocell is enabled,
+			 * the bsec node needs to be enabled as well
+			 */
+			nvmem-cells = <&otp124_hconf1>;
+			nvmem-cell-names = "safeguard";
+
+			vddio {
+				domain = <STM32_DT_IOCELL_VDD>;
+			};
+
+			vddio2 {
+				domain = <STM32_DT_IOCELL_VDDIO2>;
+			};
+
+			vddio3 {
+				domain = <STM32_DT_IOCELL_VDDIO3>;
+			};
+
+			vddio4 {
+				domain = <STM32_DT_IOCELL_VDDIO4>;
+			};
+
+			vddio5 {
+				domain = <STM32_DT_IOCELL_VDDIO5>;
+			};
+		};
+
 		rcc: rcc@56028000 {
 			compatible = "st,stm32n6-rcc";
 			clocks-controller;
@@ -756,6 +788,11 @@
 				compatible = "fixed-layout";
 				#address-cells = <1>;
 				#size-cells = <1>;
+
+				otp124_hconf1: opt124_hconf1@1f0 {
+					reg = <0x1f0 0x4>;
+					#nvmem-cell-cells = <0>;
+				};
 
 				mac_address0: mac-address@2a4 {
 					reg = <0x2a4 0x6>;

--- a/dts/bindings/power/st,stm32-iocell.yaml
+++ b/dts/bindings/power/st,stm32-iocell.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32 I/O cell controller
+
+compatible: "st,stm32-iocell"
+
+include:
+  - name: base.yaml
+  - name: nvmem-consumer.yaml
+
+properties:
+  "#address-cells":
+    const: 0
+
+  "#size-cells":
+    const: 0
+
+  nvmem-cells:
+    description: |
+      Single nvmem-cells entry named "safeguard" can be provided to access
+      OTP/option byte value where HSLV enable bit is stored.
+      This is optional depending on the SoC series.
+
+child-binding:
+  description: |
+    IO power domains
+
+  properties:
+    domain:
+      type: int
+      description: |
+        I/O domain managed by the cell.
+        This must be one of the SoC-specific values defined in header
+        `include/zephyr/dt-bindings/power/stm32XXX_iocell.h`.
+
+    hslv-mode:
+      type: string
+      default: "off"
+      enum:
+        - "off"
+        - "on"
+        - "auto"
+      description: |
+        Allows to turn on HSLV (high-speed low voltage) option.
+        This option will work only if the corresponding bit is set in
+        option bytes / OTP fuse.
+        Enabling this option on domain that is powered from 3.3V
+        can permanently damage the device! Please consult datasheet for
+        precise threshold value.
+        Selecting "auto" will follow the setting in option bytes / OTP.
+        This can be useful for board allowing both 1.8V and 3.3V operation.
+
+    compensation-enabled:
+      type: boolean
+      description: |
+        Enables the I/O compensation cell

--- a/include/zephyr/dt-bindings/power/stm32h7rs_iocell.h
+++ b/include/zephyr/dt-bindings/power/stm32h7rs_iocell.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief I/O cell definitions for STM32H7R/S devices
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_POWER_STM32H7RS_IOCELL_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_POWER_STM32H7RS_IOCELL_H_
+
+/**
+ * @name I/O power domains used to configure STM32 iocell device
+ * @{
+ */
+
+#define STM32_DT_IOCELL_VDDIO (0) /**< I/O domain powered by VDD supply */
+#define STM32_DT_IOCELL_XSPI1 (1) /**< I/O domain powered by VDDXSPI1 supply */
+#define STM32_DT_IOCELL_XSPI2 (2) /**< I/O domain powered by VDDXSPI2 supply */
+
+/** @brief Return true if @a domain is valid I/O domain */
+#define STM32_DT_IOCELL_DOMAIN_VALID(domain) (((domain) >= 0) && ((domain) <= 2))
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_POWER_STM32H7RS_IOCELL_H_ */

--- a/include/zephyr/dt-bindings/power/stm32n6_iocell.h
+++ b/include/zephyr/dt-bindings/power/stm32n6_iocell.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief I/O cell definitions for STM32N6 devices
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_POWER_STM32N6_IOCELL_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_POWER_STM32N6_IOCELL_H_
+
+/**
+ * @name I/O power domains used to configure STM32 iocell device
+ * @{
+ */
+
+#define STM32_DT_IOCELL_VDDIO2 (0) /**< I/O domain powered by VDDIO2 supply */
+#define STM32_DT_IOCELL_VDDIO3 (1) /**< I/O domain powered by VDDIO3 supply */
+#define STM32_DT_IOCELL_VDDIO4 (2) /**< I/O domain powered by VDDIO4 supply */
+#define STM32_DT_IOCELL_VDDIO5 (3) /**< I/O domain powered by VDDIO5 supply */
+#define STM32_DT_IOCELL_VDD    (4) /**< I/O domain powered by VDD supply */
+
+/** @brief Return true if @a domain is valid I/O domain */
+#define STM32_DT_IOCELL_DOMAIN_VALID(domain) (((domain) >= 0) && ((domain) <= 4))
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_POWER_STM32N6_IOCELL_H_ */

--- a/soc/st/stm32/common/CMakeLists.txt
+++ b/soc/st/stm32/common/CMakeLists.txt
@@ -18,6 +18,10 @@ if(CONFIG_STM32_WKUP_PINS)
   zephyr_sources(stm32_wkup_pins.c)
 endif()
 
+if(CONFIG_STM32_IOCELL)
+  zephyr_sources(stm32_iocell.c)
+endif()
+
 if(CONFIG_PM AND CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP)
   message(WARNING "\
 SoC Power Management (CONFIG_PM) enabled but the DBGMCU is still enabled \

--- a/soc/st/stm32/common/Kconfig
+++ b/soc/st/stm32/common/Kconfig
@@ -51,3 +51,26 @@ config STM32_BACKUP_PROTECTION
 	help
 	  Enabled for SoCs for which access protection to backup domain
 	  resources needs to be explicitly handled.
+
+config STM32_IOCELL
+	bool "STM32 I/O cell"
+	default y
+	depends on DT_HAS_ST_STM32_IOCELL_ENABLED
+	help
+	  Enable support for STM32 I/O compensation cell and HSLV configuration
+
+config STM32_IOCELL_PRIORITY
+	int "STM32 I/O cell initialization priority"
+	default 50
+	help
+	  Initialization priority of the routine within the EARLY level.
+
+config STM32_IOCELL_CHECK_ENABLE
+	bool "STM32 I/O cell check"
+	default y
+	depends on LOG
+	depends on DT_HAS_ST_STM32_IOCELL_ENABLED
+	help
+	  Enables logging of I/O cell driver. This can be useful for reporting
+	  discrepancy between device-tree configuration and value stored in
+	  device OTP/option bytes

--- a/soc/st/stm32/common/stm32_iocell.c
+++ b/soc/st/stm32/common/stm32_iocell.c
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/types.h>
+#include <soc.h>
+#include <zephyr/devicetree.h>
+
+#include <stm32_ll_system.h>
+#include <stm32_ll_pwr.h>
+#include <stm32_bitops.h>
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(iocell, CONFIG_SOC_LOG_LEVEL);
+
+#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+#include <zephyr/dt-bindings/power/stm32h7rs_iocell.h>
+#elif defined(CONFIG_SOC_SERIES_STM32N6X)
+#include <zephyr/dt-bindings/power/stm32n6_iocell.h>
+#include <zephyr/nvmem.h>
+#define STM32_IOCELL_USE_NVMEM          1
+#define STM32_IOCELL_OTP_HCONF1_DEFAULT 0x0
+#endif /* CONFIG_SOC_SERIES_... */
+
+#define DT_DRV_COMPAT     st_stm32_iocell
+#define STM32_IOCELL_NODE DT_DRV_INST(0)
+
+#if defined(CONFIG_SOC_SERIES_STM32N6X)
+#define IOCELL_FUSE_NAME "OTP fuse"
+#else
+#define IOCELL_FUSE_NAME "option bit"
+#endif /* CONFIG_SOC_SERIES_... */
+
+#define IOCELL_HSLV_DISCLAIMER                                                                     \
+	"The I/O HSLV configuration must not be enabled "                                          \
+	"if the corresponding power supply is above certain threshold. "                           \
+	"Enabling it while the voltage is higher can damage the device"
+
+struct stm32_iocell_config {
+#if defined(STM32_IOCELL_USE_NVMEM)
+	struct nvmem_cell cell;
+#endif
+};
+
+struct stm32_iocell_data {
+#if defined(CONFIG_SOC_SERIES_STM32N6X)
+	uint32_t otp_hconf1_value;
+	int otp_correct;
+#endif
+};
+
+static const struct stm32_iocell_config iocell_config = {
+#if defined(STM32_IOCELL_USE_NVMEM)
+	.cell = NVMEM_CELL_GET_BY_NAME_OR(STM32_IOCELL_NODE, safeguard, {0}),
+#endif
+};
+
+static struct stm32_iocell_data iocell_data = {
+#if defined(CONFIG_SOC_SERIES_STM32N6X)
+	.otp_hconf1_value = STM32_IOCELL_OTP_HCONF1_DEFAULT,
+#endif
+};
+
+/* Returns 1 if HSLV can be configured
+ * Returns 0 if HSLV can't be configured
+ * Returns < 0 on error
+ */
+static int iocell_is_hslv_allowed(uint16_t domain)
+{
+#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	switch (domain) {
+	case STM32_DT_IOCELL_VDDIO:
+		return (FLASH->OBW1SR & FLASH_OBW1SR_VDDIO_HSLV) == FLASH_OBW1SR_VDDIO_HSLV;
+	case STM32_DT_IOCELL_XSPI1:
+		return (FLASH->OBW1SR & FLASH_OBW1SR_XSPI1_HSLV) == FLASH_OBW1SR_XSPI1_HSLV;
+	case STM32_DT_IOCELL_XSPI2:
+		return (FLASH->OBW1SR & FLASH_OBW1SR_XSPI2_HSLV) == FLASH_OBW1SR_XSPI2_HSLV;
+	default:
+		return -EINVAL;
+	}
+#elif defined(CONFIG_SOC_SERIES_STM32N6X)
+	struct stm32_iocell_data *data = &iocell_data;
+
+	if (!data->otp_correct) {
+		return -EIO;
+	}
+	switch (domain) {
+	case STM32_DT_IOCELL_VDD:
+		return (data->otp_hconf1_value & BIT(17)) != 0;
+	case STM32_DT_IOCELL_VDDIO2:
+		return (data->otp_hconf1_value & BIT(16)) != 0;
+	case STM32_DT_IOCELL_VDDIO3:
+		return (data->otp_hconf1_value & BIT(15)) != 0;
+	case STM32_DT_IOCELL_VDDIO4:
+		return (data->otp_hconf1_value & BIT(14)) != 0;
+	case STM32_DT_IOCELL_VDDIO5:
+		return (data->otp_hconf1_value & BIT(13)) != 0;
+	default:
+		return -EINVAL;
+	}
+#endif /* CONFIG_SOC_SERIES_... */
+}
+
+/* Returns 0 on success
+ * Returns < 0 on error
+ */
+static int iocell_enable_hslv_runtime(uint16_t domain)
+{
+#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	switch (domain) {
+	case STM32_DT_IOCELL_VDDIO:
+		LL_SBS_EnableIOSpeedOptim();
+		break;
+	case STM32_DT_IOCELL_XSPI1:
+		LL_SBS_EnableXSPI1SpeedOptim();
+		break;
+	case STM32_DT_IOCELL_XSPI2:
+		LL_SBS_EnableXSPI2SpeedOptim();
+		break;
+	default:
+		return -EINVAL;
+	}
+	return 0;
+#elif defined(CONFIG_SOC_SERIES_STM32N6X)
+	switch (domain) {
+	case STM32_DT_IOCELL_VDD:
+		LL_PWR_SetVddIOVoltageRange(LL_PWR_VDDIO_VOLTAGE_RANGE_1V8);
+		break;
+	case STM32_DT_IOCELL_VDDIO2:
+		LL_PWR_SetVddIO2VoltageRange(LL_PWR_VDDIO_VOLTAGE_RANGE_1V8);
+		break;
+	case STM32_DT_IOCELL_VDDIO3:
+		LL_PWR_SetVddIO3VoltageRange(LL_PWR_VDDIO_VOLTAGE_RANGE_1V8);
+		break;
+	case STM32_DT_IOCELL_VDDIO4:
+		LL_PWR_SetVddIO4VoltageRange(LL_PWR_VDDIO_VOLTAGE_RANGE_1V8);
+		break;
+	case STM32_DT_IOCELL_VDDIO5:
+		LL_PWR_SetVddIO5VoltageRange(LL_PWR_VDDIO_VOLTAGE_RANGE_1V8);
+		break;
+	default:
+		return -EINVAL;
+	}
+	return 0;
+#endif /* CONFIG_SOC_SERIES_... */
+}
+
+static int iocell_config_domain_auto(uint16_t domain, const char *domain_name)
+{
+	int is_allowed = iocell_is_hslv_allowed(domain);
+
+	if (is_allowed < 0) {
+		LOG_ERR("Failed to read " IOCELL_FUSE_NAME " value of HSLV: \"%s\" (%d)",
+			domain_name, domain);
+		return is_allowed;
+	} else if (is_allowed > 0) {
+		return iocell_enable_hslv_runtime(domain);
+	}
+	return 0;
+}
+
+static int iocell_enable_compensation(uint16_t domain)
+{
+#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	/* Currently targets MCU revisions Y & B */
+
+	/* This implements workaround described in ES0596:
+	 * 2.2.15. I/O compensation could alter duty-cycle of high-frequency output signal
+	 */
+	uint32_t shift;
+	uint32_t nmos, pmos;
+
+	switch (domain) {
+	case STM32_DT_IOCELL_VDDIO:
+		shift = 0;
+		break;
+	case STM32_DT_IOCELL_XSPI1:
+		shift = 1;
+		break;
+	case STM32_DT_IOCELL_XSPI2:
+		shift = 2;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	uint32_t codesel_bit = BIT((shift * 2) + 1);
+	uint32_t en_bit = BIT(shift * 2);
+
+	if (SBS->CCCSR & en_bit) {
+		/* Compensation cell already enabled */
+		return 0;
+	}
+
+	/* Configure Cell selection for domain and enable.
+	 * Clear COMP_CODESEL bit and set COMP_EN bit.
+	 */
+	stm32_reg_modify_bits(&SBS->CCCSR, codesel_bit, en_bit);
+
+	/* Wait for ready flag */
+	while ((SBS->CCCSR & BIT(shift + 8)) == 0) {
+	}
+
+	/* Read and adjust PMOS and NMOS values*/
+	nmos = (SBS->CCVALR >> (8 * shift)) & 0xF;
+	pmos = (SBS->CCVALR >> (8 * shift + 4)) & 0xF;
+	/* Add/subtract 2 from values, preventing overflow/underflow */
+	nmos = (nmos < 0xD) ? (nmos + 2) : 0xF;
+	pmos = (pmos > 0x2) ? (pmos - 2) : 0x0;
+
+	/* Write modified values back */
+	stm32_reg_modify_bits(&SBS->CCSWVALR, 0xFF << (shift * 8),
+			      ((pmos << 4) | nmos) << (shift * 8));
+
+	/* Configure Cell selection for register
+	 * Set COMP_CODESEL bit.
+	 */
+	stm32_reg_set_bits(&SBS->CCCSR, codesel_bit);
+#elif defined(CONFIG_SOC_SERIES_STM32N6X)
+	/* There is a global workaround implemnted in SystemInit.
+	 * For N6 IO compensation cell is always active.
+	 */
+	ARG_UNUSED(domain);
+#endif /* CONFIG_SOC_SERIES_... */
+	return 0;
+}
+
+__maybe_unused static void iocell_hslv_check_log(int domain_id, int is_allowed, int hslv,
+						 const char *domain_name)
+{
+	if (is_allowed < 0) {
+		/* This shouldn't happen with proper implementation */
+		LOG_ERR("Failed to read " IOCELL_FUSE_NAME " value of HSLV: \"%s\" (%d)",
+			domain_name, domain_id);
+	} else if (!is_allowed && hslv) {
+		LOG_ERR("HSLV configuration for \"%s\" blocked by " IOCELL_FUSE_NAME, domain_name);
+		LOG_ERR(IOCELL_HSLV_DISCLAIMER);
+	} else if (is_allowed && !hslv) {
+		LOG_WRN("HSLV allowed in " IOCELL_FUSE_NAME " for domain \"%s\", but not enabled",
+			domain_name);
+		LOG_WRN(IOCELL_HSLV_DISCLAIMER);
+	} else {
+		/* Everything ok */
+	}
+}
+
+#define STM32_IOCELL_INIT(node_id)                                                                 \
+	BUILD_ASSERT(STM32_DT_IOCELL_DOMAIN_VALID(DT_PROP(node_id, domain)),                       \
+		     "Invalid domain ID for: " DT_NODE_FULL_NAME(node_id));                        \
+	if (DT_ENUM_HAS_VALUE(node_id, hslv_mode, auto)) {                                         \
+		result = iocell_config_domain_auto(DT_PROP(node_id, domain),                       \
+						   DT_NODE_FULL_NAME(node_id));                    \
+	} else if (DT_ENUM_HAS_VALUE(node_id, hslv_mode, on)) {                                    \
+		result = iocell_enable_hslv_runtime(DT_PROP(node_id, domain));                     \
+	}                                                                                          \
+	if (result < 0)                                                                            \
+		ret = result;                                                                      \
+	if (DT_PROP(node_id, compensation_enabled)) {                                              \
+		result = iocell_enable_compensation(DT_PROP(node_id, domain));                     \
+	}                                                                                          \
+	if (IS_ENABLED(CONFIG_STM32_IOCELL_CHECK_ENABLE)) {                                        \
+		iocell_hslv_check_log(DT_PROP(node_id, domain),                                    \
+				      iocell_is_hslv_allowed(DT_PROP(node_id, domain)),            \
+				      DT_ENUM_HAS_VALUE(node_id, hslv_mode, on),                   \
+				      DT_NODE_FULL_NAME(node_id));                                 \
+	}                                                                                          \
+	if (result < 0)                                                                            \
+		ret = result;
+
+static int iocell_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	int ret = 0, result = 0;
+#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	__HAL_RCC_SBS_CLK_ENABLE();
+	/* CSI is required by IO compensation cell */
+	__HAL_RCC_CSI_ENABLE();
+#elif defined(CONFIG_SOC_SERIES_STM32N6X)
+	/* PWR & BSEC clocks enabled by default */
+
+	if (nvmem_cell_read(&iocell_config.cell, &iocell_data.otp_hconf1_value, 0, 4) != 0) {
+		iocell_data.otp_hconf1_value = STM32_IOCELL_OTP_HCONF1_DEFAULT;
+		iocell_data.otp_correct = 0;
+	} else {
+		iocell_data.otp_correct = 1;
+	}
+#endif /* CONFIG_SOC_SERIES_... */
+	DT_FOREACH_CHILD_STATUS_OKAY(STM32_IOCELL_NODE, STM32_IOCELL_INIT)
+
+	return ret;
+}
+
+DEVICE_DT_DEFINE(STM32_IOCELL_NODE, iocell_init, NULL, &iocell_data, &iocell_config, PRE_KERNEL_1,
+		 CONFIG_STM32_IOCELL_PRIORITY, NULL);

--- a/soc/st/stm32/stm32n6x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32n6x/Kconfig.defconfig
@@ -30,4 +30,14 @@ config STM32_LTDC_FB_SMH_ALIGN
 config ROM_START_OFFSET
 	default 0x400 if BOOTLOADER_MCUBOOT
 
+if STM32_IOCELL
+
+configdefault OTP
+	default y
+
+configdefault NVMEM
+	default y
+
+endif # STM32_IOCELL
+
 endif # SOC_SERIES_STM32N6X

--- a/soc/st/stm32/stm32n6x/soc.c
+++ b/soc/st/stm32/stm32n6x/soc.c
@@ -103,10 +103,6 @@ void soc_early_init_hook(void)
 	LL_PWR_EnableVddIO4();
 	LL_PWR_EnableVddIO5();
 
-	/* Set Vdd IO2 and IO3 to 1.8V */
-	LL_PWR_SetVddIO2VoltageRange(LL_PWR_VDDIO_VOLTAGE_RANGE_1V8);
-	LL_PWR_SetVddIO3VoltageRange(LL_PWR_VDDIO_VOLTAGE_RANGE_1V8);
-
 	/* RIF configuration */
 	if (IS_ENABLED(CONFIG_STM32N6_RIF_OPEN)) {
 		soc_rif_config();


### PR DESCRIPTION
### Goal
This PR aims to move HSLV (high-speed low voltage) to dedicated driver, since it is now hardcoded in soc or driver files.
The HSLV option is used on advanced devices if the corresponding power supply (e.g. VDD or VDDXSPI) is powered from 1.8V. So, it depends on board and should be handled by device tree.
### Open points
This is still draft since I'm not sure about several points:
* The driver is called via SYS_INIT before kernel is started, but maybe it should be called directly from SoC specific file like `soc/st/stm32/stm32h7rsx/soc.c`
* The driver allows some error logging, but maybe it is too verbose. Also, it is run later, once the kernel is initialized.
* The PR also removes the current fixed configuration in XSPI driver and SoC for N6, but maybe this should be separate PR.
* Make sure the PR covers all affected board (currently only DK boards are updated).