### PR TITLE
kernel: make static thread data variable const

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -961,7 +961,7 @@ struct _static_thread_data {
 			       entry, p1, p2, p3,			\
 			       prio, options, delay)			\
 	struct k_thread _k_thread_obj_##name;				\
-	STRUCT_SECTION_ITERABLE(_static_thread_data,			\
+	const STRUCT_SECTION_ITERABLE(_static_thread_data,		\
 				_k_thread_data_##name) =		\
 		Z_THREAD_INITIALIZER(&_k_thread_obj_##name,		\
 				     _k_thread_stack_##name, stack_size,\


### PR DESCRIPTION
When using modern versions (e.g. 13.2) of the gcc-arm-none-eabi toolchain the following linker warning is emitted when using static threads:

```
warning: zephyr/zephyr_pre0.elf has a LOAD segment with RWX permissions
warning: zephyr/zephyr.elf has a LOAD segment with RWX permissions
```

This can be reproduced with the following commands:

```
export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
export GNUARMEMB_TOOLCHAIN_PATH=<path to your 13.2 gcc-arm-none-eabi toolchain>
west build -b nrf54l15dk/nrf54l15/cpuapp zephyr/samples/basic/threads/
```

Taking a quick look at the program headers I found the following:

```
arm-none-eabi-readelf -l build/zephyr/zephyr.elf

Elf file type is EXEC (Executable file)
Entry point 0x13b9
There are 5 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  EXIDX          0x007564 0x00007484 0x00007484 0x00008 0x00008 R   0x4
  LOAD           0x0000e0 0x00000000 0x00000000 0x09c2c 0x09c2c RWE 0x10 <---------- This one
  LOAD           0x009d10 0x20000000 0x00009c2c 0x001f0 0x001f0 RW  0x8
  LOAD           0x009f00 0x00009e1c 0x00009e1c 0x00004 0x00004 RW  0x4
  LOAD           0x000000 0x200001f0 0x200001f0 0x00000 0x01ea8 RW  0x8
```

The linker is unhappy that our ROM region (code, rodata, etc) has the W (write) flag set when it should only be R (read) and E (execute).

Looking further to figure out why it's getting the W (write) flag:

```
arm-none-eabi-readelf -t build/zephyr/zephyr.elf
There are 34 section headers, starting at offset 0xe4bb0:

Section Headers:
  [Nr] Name
       Type            Addr     Off    Size   ES   Lk Inf Al
       Flags
  [ 0] 
       NULL            00000000 000000 000000 00   0   0  0
       [00000000]: 
  [ 1] rom_start
       PROGBITS        00000000 0000e0 00047c 00   0   0  4
       [00000006]: ALLOC, EXEC
  [ 2] text
       PROGBITS        0000047c 00055c 007008 00   0   0  4
       [00000006]: ALLOC, EXEC
  [ 3] .ARM.exidx
       ARM_EXIDX       00007484 007564 000008 00   2   0  4
       [00000082]: ALLOC, LINK ORDER
  [ 4] initlevel
       PROGBITS        0000748c 00756c 000058 00   0   0  4
       [00000002]: ALLOC
  [ 5] device_area
       PROGBITS        000074e4 0075c4 00008c 00   0   0  4
       [00000002]: ALLOC
  [ 6] sw_isr_table
       PROGBITS        00007570 007650 000878 00   0   0  4
       [00000002]: ALLOC
  [ 7] _static_thread_data_area
       PROGBITS        00007de8 007ec8 000090 00   0   0  8
       [00000003]: WRITE, ALLOC <---------- Culprit
  [ 8] gpio_driver_api_area
       PROGBITS        00007e78 007f58 000024 00   0   0  4
       [00000002]: ALLOC
  [ 9] clock_control_driver_api_area
       PROGBITS        00007e9c 007f7c 00001c 00   0   0  4
       [00000002]: ALLOC
  [10] uart_driver_api_area
       PROGBITS        00007eb8 007f98 00000c 00   0   0  4
       [00000002]: ALLOC
  [11] rodata
       PROGBITS        00007ed0 007fb0 001d5c 00   0   0 16
       [00000002]: ALLOC
  [12] .ramfunc
       PROGBITS        20000000 009f04 000000 00   0   0  1
       [00000001]: WRITE
  [13] datas
       PROGBITS        20000000 009d10 0001b8 00   0   0  8
       [00000003]: WRITE, ALLOC
  [14] device_states
       PROGBITS        200001b8 009ec8 00000c 00   0   0  1
       [00000003]: WRITE, ALLOC
  [15] k_heap_area
       PROGBITS        200001c4 009ed4 000018 00   0   0  4
       [00000003]: WRITE, ALLOC
  [16] k_fifo_area
       PROGBITS        200001dc 009eec 000014 00   0   0  4
       [00000003]: WRITE, ALLOC
  [17] .comment
       PROGBITS        00000000 009f04 000044 01   0   0  1
       [00000030]: MERGE, STRINGS
  [18] .debug_aranges
       PROGBITS        00000000 009f48 001628 00   0   0  8
       [00000000]: 
  [19] .debug_info
       PROGBITS        00000000 00b570 053a31 00   0   0  1
       [00000000]: 
  [20] .debug_abbrev
       PROGBITS        00000000 05efa1 00cba3 00   0   0  1
       [00000000]: 
  [21] .debug_line
       PROGBITS        00000000 06bb44 028fe7 00   0   0  1
       [00000000]: 
  [22] .debug_frame
       PROGBITS        00000000 094b2c 003594 00   0   0  4
       [00000000]: 
  [23] .debug_str
       PROGBITS        00000000 0980c0 00d966 01   0   0  1
       [00000030]: MERGE, STRINGS
  [24] .debug_loc
       PROGBITS        00000000 0a5a26 029f86 00   0   0  1
       [00000000]: 
  [25] .debug_ranges
       PROGBITS        00000000 0cf9b0 006a80 00   0   0  8
       [00000000]: 
  [26] .debug_line_str
       PROGBITS        00000000 0d6430 0000df 01   0   0  1
       [00000030]: MERGE, STRINGS
  [27] .ARM.attributes
       ARM_ATTRIBUTES  00000000 0d650f 000038 00   0   0  1
       [00000000]: 
  [28] .last_section
       PROGBITS        00009e1c 009f00 000004 00   0   0  4
       [00000003]: WRITE, ALLOC
  [29] bss
       NOBITS          200001f0 009f08 000461 00   0   0  8
       [00000003]: WRITE, ALLOC
  [30] noinit
       NOBITS          20000658 009f08 001a40 00   0   0  8
       [00000003]: WRITE, ALLOC
  [31] .symtab
       SYMTAB          00000000 0d6548 007600 10  32 919  4
       [00000000]: 
  [32] .strtab
       STRTAB          00000000 0ddb48 006ecb 00   0   0  1
       [00000000]: 
  [33] .shstrtab
       STRTAB          00000000 0e4a13 00019d 00   0   0  1
       [00000000]: 
```

From this we see that `_static_thread_data_area` has the WRITE flag. Looking further in to the zephyr.map file I found the exact variables being put in this section:

```
_static_thread_data_area
                0x00007de8       0x90
                0x00007de8                        __static_thread_data_list_start = .
 *(SORT_BY_NAME(SORT_BY_ALIGNMENT(.__static_thread_data.static.*)))
 .__static_thread_data.static._k_thread_data_blink0_id_
                0x00007de8       0x30 app/libapp.a(main.c.obj)
                0x00007de8                _k_thread_data_blink0_id
 .__static_thread_data.static._k_thread_data_blink1_id_
                0x00007e18       0x30 app/libapp.a(main.c.obj)
                0x00007e18                _k_thread_data_blink1_id
 .__static_thread_data.static._k_thread_data_uart_out_id_
                0x00007e48       0x30 app/libapp.a(main.c.obj)
                0x00007e48                _k_thread_data_uart_out_id
                0x00007e78                        __static_thread_data_list_end = .
```

So ultimately the issue boils down to the fact we are putting a non-const (writeable!) data in a ROM region (linker script snippet for static threads: https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld#L90). With this change the warning is no longer present and the program headers look correct:

```
arm-none-eabi-readelf -l build/zephyr/zephyr.elf 

Elf file type is EXEC (Executable file)
Entry point 0x13b9
There are 5 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  EXIDX          0x007564 0x00007484 0x00007484 0x00008 0x00008 R   0x4
  LOAD           0x0000e0 0x00000000 0x00000000 0x09c2c 0x09c2c R E 0x10 <---------- Write flag is gone
  LOAD           0x009d10 0x20000000 0x00009c2c 0x001f0 0x001f0 RW  0x8
  LOAD           0x009f00 0x00009e1c 0x00009e1c 0x00004 0x00004 RW  0x4
  LOAD           0x000000 0x200001f0 0x200001f0 0x00000 0x01ea8 RW  0x8
```

Additionally, this `const` keyword requirement for `STRUCT_SECTION_ITERABLE` in ROM is documented here: https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/sys/iterable_sections.h#L213
