### PR TITLE
MAINTAINERS: remove maintainers/collaborators due to inactivity

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -506,7 +506,6 @@ Bluetooth Controller:
   collaborators:
     - carlescufi
     - thoh-ot
-    - ppryga
     - wopu-ot
     - erbr-ot
     - Tronil

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2561,8 +2561,6 @@ Documentation Infrastructure:
   status: maintained
   maintainers:
     - str4t0m
-  collaborators:
-    - casparfriedrich
   files:
     - doc/hardware/peripherals/w1.rst
     - doc/hardware/peripherals/1-Wire_bus_topology.drawio.svg

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -658,7 +658,6 @@ Bluetooth Mesh:
     - jhedberg
     - LingaoM
     - alxelax
-    - Andrewpini
     - akredalen
     - HaavardRei
     - omkar3141

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -266,7 +266,6 @@ ARM64 arch:
   status: odd fixes
   collaborators:
     - npitre
-    - sgrrzhf
     - wearyzen
     - ithinuel
     - JiafeiPan

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4225,7 +4225,6 @@ PMCI:
     - teburd
   collaborators:
     - nashif
-    - inteljiangwe1
     - kehintel
   files:
     - subsys/pmci/
@@ -5952,7 +5951,6 @@ West:
     - teburd
   collaborators:
     - nashif
-    - inteljiangwe1
     - dkalowsk
   files: []
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5573,7 +5573,6 @@ West:
     - bperseghetti
   collaborators:
     - PetervdPerk-NXP
-    - jgoppert
   files:
     - modules/hal_afbr/
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5939,7 +5939,6 @@ West:
 "West project: liblc3":
   status: maintained
   maintainers:
-    - Casper-Bonde-Bose
     - MariuszSkamra
   collaborators:
     - thalley

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5809,7 +5809,6 @@ West:
     - asmellby
   collaborators:
     - jerome-pouiller
-    - sateeshkotapati
     - yonsch
     - rettichschnidi
     - Martinhoff-maker

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -266,7 +266,6 @@ ARM64 arch:
   status: odd fixes
   collaborators:
     - npitre
-    - povergoing
     - sgrrzhf
     - wearyzen
     - ithinuel
@@ -5485,8 +5484,6 @@ West:
   status: maintained
   maintainers:
     - stephanosio
-  collaborators:
-    - povergoing
   files:
     - modules/cmsis/
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2159,7 +2159,6 @@ Documentation Infrastructure:
   status: odd fixes
   collaborators:
     - gdengi
-    - nbalabak
   files:
     - drivers/pm_cpu_ops/
     - include/zephyr/drivers/pm_cpu_ops/
@@ -2980,8 +2979,6 @@ Intel Platforms (Agilex):
   status: maintained
   maintainers:
     - gdengi
-  collaborators:
-    - nbalabak
   files:
     - boards/intel/socfpga/
     - soc/intel/intel_socfpga/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -141,9 +141,7 @@
 
 # zephyr-keep-sorted-start strip(":) nofold
 ACPI:
-  status: maintained
-  maintainers:
-    - najumon1980
+  status: odd fixes
   files:
     - lib/acpi/
     - include/zephyr/acpi/
@@ -3017,7 +3015,6 @@ Intel Platforms (X86):
   maintainers:
     - edersondisouza
   collaborators:
-    - najumon1980
     - dcpleung
     - ceolin
   files:
@@ -5363,9 +5360,7 @@ West:
     - "area: West"
 
 "West project: acpica":
-  status: maintained
-  maintainers:
-    - najumon1980
+  status: odd fixes
   files:
     - modules/acpica/
   labels:
@@ -6462,7 +6457,6 @@ x86 arch:
     - dcpleung
     - ceolin
     - laurenmurphyx64
-    - najumon1980
     - nashif
   files:
     - arch/x86/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4593,7 +4593,6 @@ SPDX Tooling:
     - kartben
   collaborators:
     - pdgendt
-    - swinslow
   files:
     - scripts/west_commands/spdx.py
     - scripts/west_commands/zspdx/
@@ -5344,7 +5343,6 @@ West:
   collaborators:
     - mbolivar
     - carlescufi
-    - swinslow
     - marc-hb
   files:
     - scripts/west-commands.yml

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3087,8 +3087,6 @@ JSON Web Token:
   status: maintained
   maintainers:
     - d3zd3z
-  collaborators:
-    - mrfuchs
   files:
     - subsys/jwt/
     - include/zephyr/data/json.h

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4719,8 +4719,6 @@ Sensor Subsystem:
   maintainers:
     - lixuzha
     - yperess
-  collaborators:
-    - qianruh
   files:
     - dts/bindings/sensor/zephyr,sensing.yaml
     - dts/bindings/sensor/zephyr,sensing*.yaml


### PR DESCRIPTION
Ran a [script](https://gist.github.com/kartben/2928d2f314b3cc820a229ac248a8d26a) using GH API to look at maintainers/collaborators that haven't engaged in any way over the past 18 months

Individual commit messages include details wrt the 3 most recent activities (if any).

FYI @Andrewpini @Casper-Bonde-Bose @casparfriedrich @inteljiangwe1 @jgoppert @mrfuchs @najumon1980 @povergoing @qianruh @ppryga @sateeshkotapati @sgrrzhf @swinslow @nbalabak

You folks are of course all more than welcome to come back anytime in the future. We just want to make sure the MAINTAINERS file reflects the reality of people's current availability and sets the right expectations for contributors about who is currently able to review and help move things forward.

I have double checked the conclusions of the script for every person affected but in case I got anything wrong, or if you are still interested in being listed as a maintainer/collaborator but just haven’t had a chance to engage recently, please drop a comment!