### PR TITLE
modules: Update trusted-firmware-m for picolibc

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -380,7 +380,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: 9889df41022c6679b71da55d93f9e3693a804976
+      revision: fe2b9109fe5de8c4e09f3ccc502a64429b8d45dd
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
This adds linker script bits and compiler options so that trusted-firmware-m will build with picolibc.

This has been merged to the Zephyr trusted-firmware-m repository.