### PR TITLE
boards: doc: index: do no mix minicom and screen instructions

### DIFF
--- a/boards/aithinker/ai_m61_32s_kit/doc/index.rst
+++ b/boards/aithinker/ai_m61_32s_kit/doc/index.rst
@@ -57,8 +57,7 @@ application:
 
       $ screen /dev/ttyUSB0 115200
 
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
+   Connection should be configured as follows:
 
       - Speed: 115200
       - Data: 8 bits

--- a/boards/aithinker/ai_m61_32s_kit/doc/index.rst
+++ b/boards/aithinker/ai_m61_32s_kit/doc/index.rst
@@ -43,7 +43,7 @@ Samples
 =======
 
 #. Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample
-application:
+   application:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world

--- a/boards/aithinker/ai_m62_12f_kit/doc/index.rst
+++ b/boards/aithinker/ai_m62_12f_kit/doc/index.rst
@@ -57,8 +57,7 @@ application:
 
       $ screen /dev/ttyUSB0 115200
 
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
+   Connection should be configured as follows:
 
       - Speed: 115200
       - Data: 8 bits

--- a/boards/aithinker/ai_m62_12f_kit/doc/index.rst
+++ b/boards/aithinker/ai_m62_12f_kit/doc/index.rst
@@ -43,7 +43,7 @@ Samples
 =======
 
 #. Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample
-application:
+   application:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world

--- a/boards/aithinker/ai_wb2_12f_kit/doc/index.rst
+++ b/boards/aithinker/ai_wb2_12f_kit/doc/index.rst
@@ -68,8 +68,7 @@ application:
 
       $ screen /dev/ttyUSB0 115200
 
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
+   Connection should be configured as follows:
 
       - Speed: 115200
       - Data: 8 bits

--- a/boards/aithinker/ai_wb2_12f_kit/doc/index.rst
+++ b/boards/aithinker/ai_wb2_12f_kit/doc/index.rst
@@ -54,7 +54,7 @@ Samples
 =======
 
 #. Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample
-application:
+   application:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world

--- a/boards/bflb/bl60x/bl604e_iot_dvk/doc/index.rst
+++ b/boards/bflb/bl60x/bl604e_iot_dvk/doc/index.rst
@@ -55,7 +55,7 @@ Samples
 =======
 
 #. Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample
-application:
+   application:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world

--- a/boards/doiting/dt_bl10_devkit/doc/index.rst
+++ b/boards/doiting/dt_bl10_devkit/doc/index.rst
@@ -58,7 +58,7 @@ Samples
 =======
 
 #. Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample
-application:
+   application:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world

--- a/boards/doiting/dt_xt_zb1_devkit/doc/index.rst
+++ b/boards/doiting/dt_xt_zb1_devkit/doc/index.rst
@@ -47,7 +47,7 @@ Samples
 =======
 
 #. Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample
-application:
+   application:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world

--- a/boards/doiting/dt_xt_zb1_devkit/doc/index.rst
+++ b/boards/doiting/dt_xt_zb1_devkit/doc/index.rst
@@ -61,8 +61,7 @@ application:
 
       $ screen /dev/ttyUSB0 115200
 
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
+   Connection should be configured as follows:
 
       - Speed: 115200
       - Data: 8 bits


### PR DESCRIPTION
Dependency:

- https://github.com/zephyrproject-rtos/zephyr/pull/98261

There was a note about `minicom -o` but it's not used in the example command.