### PR TITLE
MAINTAINERS: bouffalolab: add extra boards

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -757,7 +757,9 @@ Bouffalolab Platforms:
   collaborators:
     - josuah
   files:
+    - boards/aithinker/ai_*/
     - boards/bflb/
+    - boards/doiting/
     - boards/sipeed/maix_m0s_dock/
     - drivers/*/*bflb*
     - dts/riscv/bflb/


### PR DESCRIPTION
Add boards from 3rd-party vendors that use Bouffalo Lab chips.