### PR TITLE
bluetooth: hci: spi: fix length check

### DIFF
--- a/drivers/bluetooth/hci/hci_spi_st.c
+++ b/drivers/bluetooth/hci/hci_spi_st.c
@@ -567,8 +567,7 @@ static int bt_spi_send(const struct device *dev, struct net_buf *buf)
 
 	LOG_DBG("");
 
-	/* Buffer needs an additional byte for type */
-	if (buf->len >= SPI_MAX_MSG_LEN) {
+	if (buf->len > SPI_MAX_MSG_LEN) {
 		LOG_ERR("Message too long (%d)", buf->len);
 		return -EINVAL;
 	}

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -309,8 +309,7 @@ static int bt_spi_send(const struct device *dev, struct net_buf *buf)
 
 	LOG_DBG("");
 
-	/* Buffer needs an additional byte for type */
-	if (buf->len >= SPI_MAX_MSG_LEN) {
+	if (buf->len > SPI_MAX_MSG_LEN) {
 		LOG_ERR("Message too long (%d)", buf->len);
 		return -EINVAL;
 	}


### PR DESCRIPTION
The buffer length check was not updated with the change to the H4 header push location (changed in 6113230c). As the complete buffer is now provided, a buffer of length `SPI_MAX_MSG_LEN` is now valid.