### PR TITLE
RFC: Wakeup Controller (WUC) Driver

### DIFF
--- a/doc/hardware/peripherals/index.rst
+++ b/doc/hardware/peripherals/index.rst
@@ -68,3 +68,4 @@ Peripherals
    tgpio.rst
    video.rst
    watchdog.rst
+   wuc.rst

--- a/doc/hardware/peripherals/wuc.rst
+++ b/doc/hardware/peripherals/wuc.rst
@@ -1,0 +1,72 @@
+.. _wuc_api:
+
+Wakeup Controller (WUC)
+#######################
+
+Overview
+********
+
+The Wakeup Controller (WUC) API provides a common interface for enabling and
+managing wakeup sources that can bring the system out of low-power states.
+WUC devices are typically described in Devicetree and referenced by clients
+using :c:struct:`wuc_dt_spec`.
+
+Devicetree Configuration
+************************
+
+Wakeup controllers are referenced from client nodes with the ``wakeup-ctrls``
+property. The property encodes a phandle to the WUC device and an identifier
+for the wakeup source.
+
+Example Devicetree fragment:
+
+.. code-block:: devicetree
+
+   wuc0: wakeup-controller@40000000 {
+       compatible = "nxp,mcx-wuc";
+       reg = <0x40000000 0x1000>;
+       #wakeup-ctrl-cells = <1>;
+   };
+
+   button0: button@0 {
+       wakeup-ctrls = <&wuc0 10>;
+   };
+
+Basic Operation
+***************
+
+Applications typically obtain a :c:struct:`wuc_dt_spec` using
+:c:macro:`WUC_DT_SPEC_GET` and then enable or disable the wakeup source as
+needed.
+
+.. code-block:: c
+   :caption: Enable a wakeup source from Devicetree
+
+   #define BUTTON0_NODE DT_NODELABEL(button0)
+
+   static const struct wuc_dt_spec button_wuc =
+       WUC_DT_SPEC_GET(BUTTON0_NODE);
+
+   if (!device_is_ready(button_wuc.dev)) {
+       return -ENODEV;
+   }
+
+   return wuc_enable_wakeup_source_dt(&button_wuc);
+
+If a driver supports it, applications can check and clear a wakeup source's
+triggered state. When not implemented, the APIs return ``-ENOSYS``.
+
+.. code-block:: c
+   :caption: Check and clear a wakeup source
+
+   int ret;
+
+   ret = wuc_check_wakeup_source_triggered_dt(&button_wuc);
+   if (ret > 0) {
+       (void)wuc_clear_wakeup_source_triggered_dt(&button_wuc);
+   }
+
+API Reference
+*************
+
+.. doxygengroup:: wuc_interface

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -100,5 +100,6 @@ add_subdirectory_ifdef(CONFIG_VIRTUALIZATION virtualization)
 add_subdirectory_ifdef(CONFIG_W1 w1)
 add_subdirectory_ifdef(CONFIG_WATCHDOG watchdog)
 add_subdirectory_ifdef(CONFIG_WIFI wifi)
+add_subdirectory_ifdef(CONFIG_WUC wuc)
 add_subdirectory_ifdef(CONFIG_XEN xen)
 # zephyr-keep-sorted-stop

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -99,6 +99,7 @@ source "drivers/virtualization/Kconfig"
 source "drivers/w1/Kconfig"
 source "drivers/watchdog/Kconfig"
 source "drivers/wifi/Kconfig"
+source "drivers/wuc/Kconfig"
 source "drivers/xen/Kconfig"
 # zephyr-keep-sorted-stop
 

--- a/drivers/wuc/CMakeLists.txt
+++ b/drivers/wuc/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+# zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_WUC_MCUX_LLWU wuc_nxp_llwu.c)
+
+# zephyr-keep-sorted-stop

--- a/drivers/wuc/Kconfig
+++ b/drivers/wuc/Kconfig
@@ -20,7 +20,7 @@ config WUC_INIT_PRIORITY
 
 
 # zephyr-keep-sorted-start
-
+rsource "Kconfig.mcux_wuc"
 # zephyr-keep-sorted-stop
 
 endif # WAKEUP_CONTROL

--- a/drivers/wuc/Kconfig
+++ b/drivers/wuc/Kconfig
@@ -1,0 +1,26 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig WUC
+	bool "Wakeup Controller drivers"
+	help
+	  Enable wakeup controller driver configuration
+
+if WUC
+
+module = WUC
+module-str = WUC
+source "subsys/logging/Kconfig.template.log_config"
+
+config WUC_INIT_PRIORITY
+	int "Wakeup controller init priority"
+	default KERNEL_INIT_PRIORITY_DEVICE
+	help
+	  Wakeup controller device driver initialization priority.
+
+
+# zephyr-keep-sorted-start
+
+# zephyr-keep-sorted-stop
+
+endif # WAKEUP_CONTROL

--- a/drivers/wuc/Kconfig.mcux_wuc
+++ b/drivers/wuc/Kconfig.mcux_wuc
@@ -1,0 +1,9 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config WUC_MCUX_LLWU
+	bool "NXP Low Leakage Wakeup Unit"
+	default y
+	depends on DT_HAS_NXP_LLWU_ENABLED
+	help
+	  Enable support for NXP LLWU(Low Leakage Wakeup Unit) wakeup controller driver.

--- a/drivers/wuc/wuc_nxp_llwu.c
+++ b/drivers/wuc/wuc_nxp_llwu.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#define DT_DRV_COMPAT nxp_llwu
+
+#include <zephyr/init.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/irq.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/wuc.h>
+
+#include <fsl_llwu.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_llwu.h>
+
+LOG_MODULE_REGISTER(mcux_llwu, CONFIG_WUC_LOG_LEVEL);
+
+struct mcux_llwu_config {
+	LLWU_Type *base;
+	uint32_t irqn;
+};
+
+struct mcux_llwu_data {
+#if FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN
+	/** Bitmask of pin sources that have triggered a wakeup event */
+	uint32_t triggered_pin_sources;
+	/** Bitmask of currently enabled wakeup pins */
+	uint32_t enabled_pins;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+	struct k_spinlock lock;
+};
+
+#if FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN
+static void mcux_llwu_isr(const struct device *dev)
+{
+	const struct mcux_llwu_config *config = dev->config;
+	struct mcux_llwu_data *data = dev->data;
+
+	K_SPINLOCK(&data->lock) {
+		for (int i = 0; i < 16; i++) {
+			if (IS_BIT_SET(data->enabled_pins, i)) {
+				if (LLWU_GetExternalWakeupPinFlag(config->base, i + 1) == true) {
+					data->triggered_pin_sources |= BIT(i);
+					LLWU_ClearExternalWakeupPinFlag(config->base, i + 1);
+				}
+			}
+		}
+	}
+}
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+
+static int mcux_llwu_enable_wakeup_source(const struct device *dev, uint32_t id)
+{
+	const struct mcux_llwu_config *config = dev->config;
+	struct mcux_llwu_data *data = dev->data;
+	int ret = -EINVAL;
+
+	K_SPINLOCK(&data->lock) {
+#if FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN
+		if (NXP_LLWU_IS_PIN_SOURCE(id)) {
+			ret = 0;
+			if (IS_BIT_SET(data->enabled_pins, (NXP_LLWU_GET_PIN_INDEX(id) - 1)) ==
+			    false) {
+				LLWU_SetExternalWakeupPinMode(
+					config->base, NXP_LLWU_GET_PIN_INDEX(id),
+					(llwu_external_pin_mode_t)NXP_LLWU_GET_PIN_EDGE(id));
+				data->enabled_pins |= BIT((NXP_LLWU_GET_PIN_INDEX(id) - 1));
+			}
+
+			if (data->enabled_pins != 0) {
+				irq_enable(config->irqn);
+			}
+		}
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+
+#if FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE
+		if (NXP_LLWU_IS_MODULE_SOURCE(id)) {
+			ret = 0;
+			LLWU_EnableInternalModuleInterruptWakup(
+				config->base, NXP_LLWU_GET_MODULE_INDEX(id), true);
+		}
+#endif /* FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE */
+	}
+
+	return ret;
+}
+
+static int mcux_llwu_disable_wakeup_source(const struct device *dev, uint32_t id)
+{
+	const struct mcux_llwu_config *config = dev->config;
+	struct mcux_llwu_data *data = dev->data;
+	int ret = -EINVAL;
+
+	K_SPINLOCK(&data->lock) {
+#if FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN
+		if (NXP_LLWU_IS_PIN_SOURCE(id)) {
+			ret = 0;
+			if (IS_BIT_SET(data->enabled_pins, (NXP_LLWU_GET_PIN_INDEX(id) - 1)) ==
+			    true) {
+				LLWU_SetExternalWakeupPinMode(config->base,
+							      NXP_LLWU_GET_PIN_INDEX(id),
+							      kLLWU_ExternalPinDisable);
+				data->enabled_pins &= ~BIT((NXP_LLWU_GET_PIN_INDEX(id) - 1));
+			}
+
+			if (data->enabled_pins == 0) {
+				irq_disable(config->irqn);
+			}
+		}
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+
+#if FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE
+		if (NXP_LLWU_IS_MODULE_SOURCE(id)) {
+			ret = 0;
+			LLWU_EnableInternalModuleInterruptWakup(
+				config->base, NXP_LLWU_GET_MODULE_INDEX(id), false);
+		}
+#endif /* FSL_FEATURE_LLWU_HAS_INTERNAL_MODULE */
+	}
+
+	return ret;
+}
+
+static int mcux_llwu_check_wakeup_source_triggered(const struct device *dev, uint32_t id)
+{
+	struct mcux_llwu_data *data = dev->data;
+	int ret = 0;
+
+	K_SPINLOCK(&data->lock) {
+#if FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN
+		if (NXP_LLWU_IS_PIN_SOURCE(id) &&
+		    IS_BIT_SET(data->triggered_pin_sources, (NXP_LLWU_GET_PIN_INDEX(id) - 1))) {
+			ret = 1;
+		}
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+	}
+
+	return ret;
+}
+
+static int mcux_llwu_clear_wakeup_source_triggered(const struct device *dev, uint32_t id)
+{
+	struct mcux_llwu_data *data = dev->data;
+
+	K_SPINLOCK(&data->lock) {
+#if FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN
+		if (NXP_LLWU_IS_PIN_SOURCE(id)) {
+			data->triggered_pin_sources &= ~BIT(NXP_LLWU_GET_PIN_INDEX(id) - 1);
+		}
+#endif
+	}
+
+	return 0;
+}
+
+static int mcux_llwu_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(action);
+
+	return 0;
+}
+
+static int mcux_llwu_init(const struct device *dev)
+{
+	struct mcux_llwu_data *data = dev->data;
+
+#if FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN
+	IRQ_CONNECT(DT_IRQN(DT_DRV_INST(0)), DT_IRQ(DT_DRV_INST(0), priority), mcux_llwu_isr,
+		    DEVICE_DT_GET(DT_DRV_INST(0)), 0);
+	data->triggered_pin_sources = 0;
+	data->enabled_pins = 0;
+#endif /* FSL_FEATURE_LLWU_HAS_EXTERNAL_PIN */
+
+	return pm_device_driver_init(dev, mcux_llwu_pm_action);
+}
+
+static const struct mcux_llwu_config llwu_config = {
+	.base = (LLWU_Type *)DT_REG_ADDR(DT_DRV_INST(0)),
+	.irqn = DT_IRQN(DT_DRV_INST(0)),
+};
+
+static struct mcux_llwu_data llwu_data;
+
+static const DEVICE_API(wuc, mcux_llwu_api) = {
+	.enable = mcux_llwu_enable_wakeup_source,
+	.disable = mcux_llwu_disable_wakeup_source,
+	.triggered = mcux_llwu_check_wakeup_source_triggered,
+	.clear = mcux_llwu_clear_wakeup_source_triggered,
+};
+
+DEVICE_DT_INST_DEFINE(0, mcux_llwu_init, NULL, &llwu_data, &llwu_config, POST_KERNEL,
+		      WUC_INIT_PRIORITY, &mcux_llwu_api);

--- a/dts/arm/nxp/mcx/nxp_mcxc_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxc_common.dtsi
@@ -393,6 +393,14 @@
 			#io-channel-cells = <1>;
 			voltage-reference = <2>;
 		};
+
+		llwu: llwu@4007c000 {
+			compatible = "nxp,llwu";
+			reg = <0x4007c000 0xa>;
+			interrupts = <7 0>;
+			#wakeup-ctrl-cells = <1>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/bindings/wuc/nxp,llwu.yaml
+++ b/dts/bindings/wuc/nxp,llwu.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP Low-Leakage Wakeup Unit
+
+compatible: "nxp,llwu"
+
+include: [base.yaml, wuc-controller.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  "#wakeup-ctrl-cells":
+    type: int
+    const: 1
+    description: |
+      Number of cells in wakeup-ctrls property.
+
+wakeup-ctrl-cells:
+  - id

--- a/dts/bindings/wuc/wuc-controller.yaml
+++ b/dts/bindings/wuc/wuc-controller.yaml
@@ -1,0 +1,13 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Common file for Wakeup Controllers
+
+properties:
+  "#wakeup-ctrl-cells":
+    type: int
+    required: true
+    description: |
+      Number of cells in wakeup-ctrls property. There must be a cell
+      name "id" to use.

--- a/dts/bindings/wuc/wuc-device.yaml
+++ b/dts/bindings/wuc/wuc-device.yaml
@@ -1,0 +1,11 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Common file for wake-up source devices referencing wake up controller(s).
+
+properties:
+  wakeup-ctrls:
+    type: phandle-array
+    description: |
+      Phandle and wakeup source identifier of the corresponding wakeup controller.

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -5695,5 +5695,6 @@
 #include <zephyr/devicetree/display.h>
 #include <zephyr/devicetree/hwspinlock.h>
 #include <zephyr/devicetree/map.h>
+#include <zephyr/devicetree/wuc.h>
 
 #endif /* ZEPHYR_INCLUDE_DEVICETREE_H_ */

--- a/include/zephyr/devicetree/wuc.h
+++ b/include/zephyr/devicetree/wuc.h
@@ -1,0 +1,209 @@
+/**
+ * @file
+ * @brief Wakeup Controller Devicetree macro public API header file.
+ */
+
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DEVICETREE_WUC_H_
+#define ZEPHYR_INCLUDE_DEVICETREE_WUC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup devicetree-wakeup-controller Devicetree WUC Controller API
+ * @ingroup devicetree
+ * @ingroup wuc_interface
+ * @{
+ */
+
+/**
+ * @brief Get the node identifier for the controller phandle from a
+ *        "wakeup-ctrls" phandle-array property at an index
+ *
+ * Example devicetree fragment:
+ *
+ *     wuc1: wakeup-controller@... { ... };
+ *
+ *     wuc2: wakeup-controller@... { ... };
+ *
+ *     n: node {
+ *             wakeup-ctrls = <&wuc1 10>, <&wuc2 20>;
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_WUC_BY_IDX(DT_NODELABEL(n), 0) // DT_NODELABEL(wuc1)
+ *     DT_WUC_BY_IDX(DT_NODELABEL(n), 1) // DT_NODELABEL(wuc2)
+ *
+ * @param node_id node identifier
+ * @param idx logical index into "wakeup-ctrls"
+ * @return the node identifier for the wakeup controller referenced at
+ *         index "idx"
+ * @see DT_PHANDLE_BY_IDX()
+ */
+#define DT_WUC_BY_IDX(node_id, idx) DT_PHANDLE_BY_IDX(node_id, wakeup_ctrls, idx)
+
+/**
+ * @brief Equivalent to DT_WUC_BY_IDX(node_id, 0)
+ * @param node_id node identifier
+ * @return a node identifier for the wakeup controller at index 0
+ *         in "wakeup-ctrls"
+ * @see DT_WUC_BY_IDX()
+ */
+#define DT_WUC(node_id) DT_WUC_BY_IDX(node_id, 0)
+
+/**
+ * @brief Get a wakeup controller specifier's cell value at an index
+ *
+ * Example devicetree fragment:
+ *
+ *     wuc: wakeup-controller@... {
+ *             compatible = "vnd,wuc";
+ *             #wakeup-ctrl-cells = <1>;
+ *     };
+ *
+ *     n: node {
+ *             wakeup-ctrls = <&wuc 10>;
+ *     };
+ *
+ * Bindings fragment for the vnd,wuc compatible:
+ *
+ *     wakeup-ctrl-cells:
+ *       - id
+ *
+ * Example usage:
+ *
+ *     DT_WUC_CELL_BY_IDX(DT_NODELABEL(n), 0, id) // 10
+ *
+ * @param node_id node identifier for a node with a wakeup-ctrls property
+ * @param idx logical index into wakeup-ctrls property
+ * @param cell lowercase-and-underscores cell name
+ * @return the cell value at index "idx"
+ * @see DT_PHA_BY_IDX()
+ */
+#define DT_WUC_CELL_BY_IDX(node_id, idx, cell) DT_PHA_BY_IDX(node_id, wakeup_ctrls, idx, cell)
+
+/**
+ * @brief Equivalent to DT_WUC_CELL_BY_IDX(node_id, 0, cell)
+ * @param node_id node identifier for a node with a wakeup-ctrls property
+ * @param cell lowercase-and-underscores cell name
+ * @return the cell value at index 0
+ * @see DT_WUC_CELL_BY_IDX()
+ */
+#define DT_WUC_CELL(node_id, cell) DT_WUC_CELL_BY_IDX(node_id, 0, cell)
+
+/**
+ * @brief Get the node identifier for the controller phandle from a
+ *        "wakeup-ctrls" phandle-array property at an index
+ *
+ * @param inst instance number
+ * @param idx logical index into "wakeup-ctrls"
+ * @return the node identifier for the wakeup controller referenced at
+ *         index "idx"
+ * @see DT_WUC_BY_IDX()
+ */
+#define DT_INST_WUC_BY_IDX(inst, idx) DT_WUC_BY_IDX(DT_DRV_INST(inst), idx)
+
+/**
+ * @brief Equivalent to DT_INST_WUC_BY_IDX(inst, 0)
+ * @param inst instance number
+ * @return a node identifier for the wakeup controller at index 0
+ *         in "wakeup-ctrls"
+ * @see DT_WUC_BY_IDX()
+ */
+#define DT_INST_WUC(inst) DT_INST_WUC_BY_IDX(inst, 0)
+
+/**
+ * @brief Get a DT_DRV_COMPAT instance's wakeup controller specifier's cell value
+ *        at an index
+ * @param inst DT_DRV_COMPAT instance number
+ * @param idx logical index into wakeup-ctrls property
+ * @param cell lowercase-and-underscores cell name
+ * @return the cell value at index "idx"
+ * @see DT_WUC_CELL_BY_IDX()
+ */
+#define DT_INST_WUC_CELL_BY_IDX(inst, idx, cell) DT_WUC_CELL_BY_IDX(DT_DRV_INST(inst), idx, cell)
+
+/**
+ * @brief Equivalent to DT_INST_WUC_CELL_BY_IDX(inst, 0, cell)
+ * @param inst DT_DRV_COMPAT instance number
+ * @param cell lowercase-and-underscores cell name
+ * @return the value of the cell inside the specifier at index 0
+ */
+#define DT_INST_WUC_CELL(inst, cell) DT_INST_WUC_CELL_BY_IDX(inst, 0, cell)
+
+/**
+ * @brief Get a Wakeup Controller specifier's id cell at an index
+ *
+ * This macro only works for Wakeup Controller specifiers with cells named "id".
+ * Refer to the node's binding to check if necessary.
+ *
+ * Example devicetree fragment:
+ *
+ *     wuc: wakeup-controller@... {
+ *             compatible = "vnd,wuc";
+ *             #wakeup-ctrl-cells = <1>;
+ *     };
+ *
+ *     n: node {
+ *             wakeup-ctrls = <&wuc 10>;
+ *     };
+ *
+ * Bindings fragment for the vnd,wuc compatible:
+ *
+ *     wakeup-ctrl-cells:
+ *       - id
+ *
+ * Example usage:
+ *
+ *     DT_WUC_ID_BY_IDX(DT_NODELABEL(n), 0) // 10
+ *
+ * @param node_id node identifier
+ * @param idx logical index into "wakeup-ctrls"
+ * @return the id cell value at index "idx"
+ * @see DT_PHA_BY_IDX()
+ */
+#define DT_WUC_ID_BY_IDX(node_id, idx) DT_PHA_BY_IDX(node_id, wakeup_ctrls, idx, id)
+
+/**
+ * @brief Equivalent to DT_WUC_ID_BY_IDX(node_id, 0)
+ * @param node_id node identifier
+ * @return the id cell value at index 0
+ * @see DT_WUC_ID_BY_IDX()
+ */
+#define DT_WUC_ID(node_id) DT_WUC_ID_BY_IDX(node_id, 0)
+
+/**
+ * @brief Get a DT_DRV_COMPAT instance's Wakeup Controller specifier's id cell value
+ *        at an index
+ * @param inst DT_DRV_COMPAT instance number
+ * @param idx logical index into "wakeup-ctrls"
+ * @return the id cell value at index "idx"
+ * @see DT_WUC_ID_BY_IDX()
+ */
+#define DT_INST_WUC_ID_BY_IDX(inst, idx) DT_WUC_ID_BY_IDX(DT_DRV_INST(inst), idx)
+
+/**
+ * @brief Equivalent to DT_INST_WUC_ID_BY_IDX(inst, 0)
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the id cell value at index 0
+ * @see DT_INST_WUC_ID_BY_IDX()
+ */
+#define DT_INST_WUC_ID(inst) DT_INST_WUC_ID_BY_IDX(inst, 0)
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DEVICETREE_WUC_H_ */

--- a/include/zephyr/drivers/wuc.h
+++ b/include/zephyr/drivers/wuc.h
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @ingroup wuc_interface
+ * @brief Main header file for WUC (Wakeup Controller) driver API.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_WUC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_WUC_H_
+
+/**
+ * @brief Wakeup Controller (WUC) Driver APIs
+ * @defgroup wuc_interface WUC
+ * @since 4.4
+ * @version 0.1.0
+ * @ingroup io_interfaces
+ * @{
+ */
+
+#include <errno.h>
+#include <stddef.h>
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Wakeup controller device configuration. */
+struct wuc_dt_spec {
+	/** Wakeup controller device. */
+	const struct device *dev;
+	/** Wakeup source identifier. */
+	uint32_t id;
+};
+
+/**
+ * @brief Static initializer for a @p wuc_dt_spec
+ *
+ * This returns a static initializer for a @p wuc_dt_spec structure given a
+ * devicetree node identifier, a property specifying a Wakeup Controller and an index.
+ *
+ * Example devicetree fragment:
+ *
+ *	n: node {
+ *		wakeup-ctrls = <&wuc 10>;
+ *	}
+ *
+ * Example usage:
+ *
+ *	const struct wuc_dt_spec spec = WUC_DT_SPEC_GET_BY_IDX(DT_NODELABEL(n), 0);
+ *	Initializes 'spec' to:
+ *	 {
+ *	         .dev = DEVICE_DT_GET(DT_NODELABEL(wuc)),
+ *	         .id = 10
+ *	 }
+ *
+ * The 'wuc' field must still be checked for readiness, e.g. using
+ * device_is_ready(). It is an error to use this macro unless the node
+ * exists, has the given property, and that property specifies a wakeup
+ * controller wakeup source id as shown above.
+ *
+ * @param node_id devicetree node identifier
+ * @param idx logical index into "wakeup-ctrls"
+ * @return static initializer for a struct wuc_dt_spec for the property
+ */
+#define WUC_DT_SPEC_GET_BY_IDX(node_id, idx)                                                       \
+	{.dev = DEVICE_DT_GET(DT_WUC_BY_IDX(node_id, idx)), .id = DT_WUC_ID_BY_IDX(node_id, idx)}
+
+/**
+ * @brief Like WUC_DT_SPEC_GET_BY_IDX(), with a fallback to a default value
+ *
+ * If the devicetree node identifier 'node_id' refers to a node with a
+ * 'wakeup-ctrls' property, this expands to
+ * <tt>WUC_DT_SPEC_GET_BY_IDX(node_id, idx)</tt>. The @p
+ * default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to @p default_value.
+ *
+ * @param node_id devicetree node identifier
+ * @param idx logical index into the 'wakeup-ctrls' property
+ * @param default_value fallback value to expand to
+ * @return static initializer for a struct wuc_dt_spec for the property,
+ *         or default_value if the node or property do not exist
+ */
+#define WUC_DT_SPEC_GET_BY_IDX_OR(node_id, idx, default_value)                                     \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, wakeup_ctrls),			\
+		    (WUC_DT_SPEC_GET_BY_IDX(node_id, idx)),		\
+		    (default_value))
+
+/**
+ * @brief Equivalent to WUC_DT_SPEC_GET_BY_IDX(node_id, 0).
+ *
+ * @param node_id devicetree node identifier
+ * @return static initializer for a struct wuc_dt_spec for the property
+ * @see WUC_DT_SPEC_GET_BY_IDX()
+ */
+#define WUC_DT_SPEC_GET(node_id) WUC_DT_SPEC_GET_BY_IDX(node_id, 0)
+
+/**
+ * @brief Equivalent to
+ *	  WUC_DT_SPEC_GET_BY_IDX_OR(node_id, 0, default_value).
+ *
+ * @param node_id devicetree node identifier
+ * @param default_value fallback value to expand to
+ * @return static initializer for a struct wuc_dt_spec for the property,
+ *         or default_value if the node or property do not exist
+ */
+#define WUC_DT_SPEC_GET_OR(node_id, default_value)                                                 \
+	WUC_DT_SPEC_GET_BY_IDX_OR(node_id, 0, default_value)
+
+/**
+ * @brief Static initializer for a @p wuc_dt_spec from a DT_DRV_COMPAT
+ * instance's Wakeup Controller property at an index.
+ *
+ * @param inst DT_DRV_COMPAT instance number
+ * @param idx logical index into "wakeup-ctrls"
+ * @return static initializer for a struct wuc_dt_spec for the property
+ * @see WUC_DT_SPEC_GET_BY_IDX()
+ */
+#define WUC_DT_SPEC_INST_GET_BY_IDX(inst, idx) WUC_DT_SPEC_GET_BY_IDX(DT_DRV_INST(inst), idx)
+
+/**
+ * @brief Static initializer for a @p wuc_dt_spec from a DT_DRV_COMPAT
+ *	  instance's 'wakeup-ctrls' property at an index, with fallback
+ *
+ * @param inst DT_DRV_COMPAT instance number
+ * @param idx logical index into the 'wakeup-ctrls' property
+ * @param default_value fallback value to expand to
+ * @return static initializer for a struct wuc_dt_spec for the property,
+ *         or default_value if the node or property do not exist
+ */
+#define WUC_DT_SPEC_INST_GET_BY_IDX_OR(inst, idx, default_value)                                   \
+	COND_CODE_1(DT_PROP_HAS_IDX(DT_DRV_INST(inst), wakeup_ctrls, idx), \
+		(WUC_DT_SPEC_GET_BY_IDX(DT_DRV_INST(inst), idx)),	\
+		(default_value))
+
+/**
+ * @brief Equivalent to WUC_DT_SPEC_INST_GET_BY_IDX(inst, 0).
+ *
+ * @param inst DT_DRV_COMPAT instance number
+ * @return static initializer for a struct wuc_dt_spec for the property
+ * @see WUC_DT_SPEC_INST_GET_BY_IDX()
+ */
+#define WUC_DT_SPEC_INST_GET(inst) WUC_DT_SPEC_INST_GET_BY_IDX(inst, 0)
+
+/**
+ * @brief Equivalent to
+ *	  WUC_DT_SPEC_INST_GET_BY_IDX_OR(node_id, 0, default_value).
+ *
+ * @param inst DT_DRV_COMPAT instance number
+ * @param default_value fallback value to expand to
+ * @return static initializer for a struct wuc_dt_spec for the property,
+ *         or default_value if the node or property do not exist
+ */
+#define WUC_DT_SPEC_INST_GET_OR(inst, default_value)                                               \
+	WUC_DT_SPEC_INST_GET_BY_IDX_OR(inst, 0, default_value)
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ * For internal use only, skip these in public documentation.
+ */
+typedef int (*wuc_api_enable_wakeup_source)(const struct device *dev, uint32_t id);
+
+typedef int (*wuc_api_disable_wakeup_source)(const struct device *dev, uint32_t id);
+
+typedef int (*wuc_api_check_wakeup_source_triggered)(const struct device *dev, uint32_t id);
+
+typedef int (*wuc_api_clear_wakeup_source_triggered)(const struct device *dev, uint32_t id);
+
+__subsystem struct wuc_driver_api {
+	wuc_api_enable_wakeup_source enable;
+	wuc_api_disable_wakeup_source disable;
+	wuc_api_check_wakeup_source_triggered triggered;
+	wuc_api_clear_wakeup_source_triggered clear;
+};
+/** @endcond */
+
+/**
+ * @brief Enable a wakeup source
+ *
+ * @param dev Pointer to the WUC device structure
+ * @param id Wakeup source identifier
+ *
+ * @retval 0 If successful
+ * @retval -errno Negative errno code on failure
+ */
+static inline int wuc_enable_wakeup_source(const struct device *dev, uint32_t id)
+{
+	return DEVICE_API_GET(wuc, dev)->enable(dev, id);
+}
+
+/**
+ * @brief Enable a wakeup source using a @ref wuc_dt_spec.
+ *
+ * @param spec Pointer to the WUC devicetree spec structure.
+ *
+ * @retval 0 If successful.
+ * @retval -errno Negative errno code on failure.
+ */
+static inline int wuc_enable_wakeup_source_dt(const struct wuc_dt_spec *spec)
+{
+	return wuc_enable_wakeup_source(spec->dev, spec->id);
+}
+
+/**
+ * @brief Disable a wakeup source.
+ *
+ * @param dev Pointer to the WUC device structure.
+ * @param id Wakeup source identifier.
+ *
+ * @retval 0 If successful.
+ * @retval -errno Negative errno code on failure.
+ */
+static inline int wuc_disable_wakeup_source(const struct device *dev, uint32_t id)
+{
+	return DEVICE_API_GET(wuc, dev)->disable(dev, id);
+}
+
+/**
+ * @brief Disable a wakeup source using a @ref wuc_dt_spec.
+ *
+ * @param spec Pointer to the WUC devicetree spec structure.
+ *
+ * @retval 0 If successful.
+ * @retval -errno Negative errno code on failure.
+ */
+static inline int wuc_disable_wakeup_source_dt(const struct wuc_dt_spec *spec)
+{
+	return wuc_disable_wakeup_source(spec->dev, spec->id);
+}
+
+/**
+ * @brief Check if a wakeup source triggered.
+ *
+ * @param dev Pointer to the WUC device structure.
+ * @param id Wakeup source identifier.
+ *
+ * @retval 1 If wakeup was triggered by this source.
+ * @retval 0 If wakeup was not triggered by this source.
+ * @retval -errno Negative errno code on failure.
+ * @retval -ENOSYS if the interface is not implemented.
+ */
+static inline int wuc_check_wakeup_source_triggered(const struct device *dev, uint32_t id)
+{
+	if (DEVICE_API_GET(wuc, dev)->triggered == NULL) {
+		return -ENOSYS;
+	}
+	return DEVICE_API_GET(wuc, dev)->triggered(dev, id);
+}
+
+/**
+ * @brief Check if a wakeup source triggered using a @ref wuc_dt_spec.
+ *
+ * @param spec Pointer to the WUC devicetree spec structure.
+ *
+ * @retval 1 If wakeup was triggered by this source.
+ * @retval 0 If wakeup was not triggered by this source.
+ * @retval -errno Negative errno code on failure.
+ * @retval -ENOSYS if the interface is not implemented.
+ */
+static inline int wuc_check_wakeup_source_triggered_dt(const struct wuc_dt_spec *spec)
+{
+	return wuc_check_wakeup_source_triggered(spec->dev, spec->id);
+}
+
+/**
+ * @brief Clear a wakeup source triggered status.
+ *
+ * @param dev Pointer to the WUC device structure.
+ * @param id Wakeup source identifier.
+ *
+ * @retval 0 If successful.
+ * @retval -errno Negative errno code on failure.
+ * @retval -ENOSYS if the interface is not implemented.
+ */
+static inline int wuc_clear_wakeup_source_triggered(const struct device *dev, uint32_t id)
+{
+	if (DEVICE_API_GET(wuc, dev)->clear == NULL) {
+		return -ENOSYS;
+	}
+	return DEVICE_API_GET(wuc, dev)->clear(dev, id);
+}
+
+/**
+ * @brief Clear a wakeup source triggered status using a @ref wuc_dt_spec.
+ *
+ * @param spec Pointer to the WUC devicetree spec structure.
+ *
+ * @retval 0 If successful.
+ * @retval -errno Negative errno code on failure.
+ * @retval -ENOSYS if the interface is not implemented.
+ */
+static inline int wuc_clear_wakeup_source_triggered_dt(const struct wuc_dt_spec *spec)
+{
+	return wuc_clear_wakeup_source_triggered(spec->dev, spec->id);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_WUC_H_ */

--- a/include/zephyr/dt-bindings/wuc/wuc_nxp_llwu.h
+++ b/include/zephyr/dt-bindings/wuc/wuc_nxp_llwu.h
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @ingroup wuc_interface
+ * @brief NXP LLWU wakeup source encodings.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_WUC_NXP_LLWU_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_WUC_NXP_LLWU_H_
+
+/**
+ * @brief Wakeup source encoding layout.
+ *
+ * Bit[31]: 0 = PIN, 1 = MODULE
+ *
+ * For PIN (bit[31] = 0):
+ *   - Bit[7:0]  : pin index (0-255)
+ *   - Bit[9:8]  : edge type (1 = rising, 2 = falling, 3 = any)
+ *
+ * For MODULE (bit[31] = 1):
+ *   - Bit[7:0]  : module index (0-255)
+ */
+
+/** @name Wakeup source type encodings */
+/** @{ */
+/** Wakeup source type encoding for a PIN source. */
+#define NXP_LLWU_WAKEUP_SOURCE_TYPE_PIN    (0U << 31)
+/** Wakeup source type encoding for a MODULE source. */
+#define NXP_LLWU_WAKEUP_SOURCE_TYPE_MODULE (1U << 31)
+/** @} */
+
+/** @name PIN edge encodings */
+/** @{ */
+/** PIN edge encoding for rising edge. */
+#define NXP_LLWU_PIN_EDGE_RISING  1
+/** PIN edge encoding for falling edge. */
+#define NXP_LLWU_PIN_EDGE_FALLING 2
+/** PIN edge encoding for any edge. */
+#define NXP_LLWU_PIN_EDGE_ANY     3
+/** @} */
+
+/**
+ * @brief Encode a PIN wakeup source.
+ *
+ * @param pin_index PIN index (0-255).
+ * @param edge_type Edge encoding (see NXP_LLWU_PIN_EDGE_*).
+ */
+#define NXP_LLWU_PIN_WAKEUP(pin_index, edge_type)                                                  \
+	(NXP_LLWU_WAKEUP_SOURCE_TYPE_PIN | (((edge_type) & 0x3) << 8) | ((pin_index) & 0xFF))
+
+/**
+ * @brief Encode a MODULE wakeup source.
+ *
+ * @param module_index Module index (0-255).
+ */
+#define NXP_LLWU_MODULE_WAKEUP(module_index)                                                       \
+	(NXP_LLWU_WAKEUP_SOURCE_TYPE_MODULE | ((module_index) & 0xFF))
+
+/** @name PIN wakeup sources (PIN 0-15) */
+/** @{ */
+/** PIN 0 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_0_RISING  NXP_LLWU_PIN_WAKEUP(1, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 0 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_0_FALLING NXP_LLWU_PIN_WAKEUP(1, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 0 wakeup source on any edge. */
+#define NXP_LLWU_PIN_0_ANY     NXP_LLWU_PIN_WAKEUP(1, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 1 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_1_RISING  NXP_LLWU_PIN_WAKEUP(2, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 1 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_1_FALLING NXP_LLWU_PIN_WAKEUP(2, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 1 wakeup source on any edge. */
+#define NXP_LLWU_PIN_1_ANY     NXP_LLWU_PIN_WAKEUP(2, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 2 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_2_RISING  NXP_LLWU_PIN_WAKEUP(3, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 2 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_2_FALLING NXP_LLWU_PIN_WAKEUP(3, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 2 wakeup source on any edge. */
+#define NXP_LLWU_PIN_2_ANY     NXP_LLWU_PIN_WAKEUP(3, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 3 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_3_RISING  NXP_LLWU_PIN_WAKEUP(4, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 3 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_3_FALLING NXP_LLWU_PIN_WAKEUP(4, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 3 wakeup source on any edge. */
+#define NXP_LLWU_PIN_3_ANY     NXP_LLWU_PIN_WAKEUP(4, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 4 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_4_RISING  NXP_LLWU_PIN_WAKEUP(5, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 4 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_4_FALLING NXP_LLWU_PIN_WAKEUP(5, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 4 wakeup source on any edge. */
+#define NXP_LLWU_PIN_4_ANY     NXP_LLWU_PIN_WAKEUP(5, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 5 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_5_RISING  NXP_LLWU_PIN_WAKEUP(6, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 5 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_5_FALLING NXP_LLWU_PIN_WAKEUP(6, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 5 wakeup source on any edge. */
+#define NXP_LLWU_PIN_5_ANY     NXP_LLWU_PIN_WAKEUP(6, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 6 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_6_RISING  NXP_LLWU_PIN_WAKEUP(7, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 6 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_6_FALLING NXP_LLWU_PIN_WAKEUP(7, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 6 wakeup source on any edge. */
+#define NXP_LLWU_PIN_6_ANY     NXP_LLWU_PIN_WAKEUP(7, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 7 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_7_RISING  NXP_LLWU_PIN_WAKEUP(8, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 7 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_7_FALLING NXP_LLWU_PIN_WAKEUP(8, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 7 wakeup source on any edge. */
+#define NXP_LLWU_PIN_7_ANY     NXP_LLWU_PIN_WAKEUP(8, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 8 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_8_RISING  NXP_LLWU_PIN_WAKEUP(9, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 8 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_8_FALLING NXP_LLWU_PIN_WAKEUP(9, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 8 wakeup source on any edge. */
+#define NXP_LLWU_PIN_8_ANY     NXP_LLWU_PIN_WAKEUP(9, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 9 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_9_RISING  NXP_LLWU_PIN_WAKEUP(10, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 9 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_9_FALLING NXP_LLWU_PIN_WAKEUP(10, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 9 wakeup source on any edge. */
+#define NXP_LLWU_PIN_9_ANY     NXP_LLWU_PIN_WAKEUP(10, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 10 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_10_RISING  NXP_LLWU_PIN_WAKEUP(11, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 10 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_10_FALLING NXP_LLWU_PIN_WAKEUP(11, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 10 wakeup source on any edge. */
+#define NXP_LLWU_PIN_10_ANY     NXP_LLWU_PIN_WAKEUP(11, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 11 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_11_RISING  NXP_LLWU_PIN_WAKEUP(12, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 11 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_11_FALLING NXP_LLWU_PIN_WAKEUP(12, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 11 wakeup source on any edge. */
+#define NXP_LLWU_PIN_11_ANY     NXP_LLWU_PIN_WAKEUP(12, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 12 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_12_RISING  NXP_LLWU_PIN_WAKEUP(13, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 12 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_12_FALLING NXP_LLWU_PIN_WAKEUP(13, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 12 wakeup source on any edge. */
+#define NXP_LLWU_PIN_12_ANY     NXP_LLWU_PIN_WAKEUP(13, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 13 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_13_RISING  NXP_LLWU_PIN_WAKEUP(14, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 13 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_13_FALLING NXP_LLWU_PIN_WAKEUP(14, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 13 wakeup source on any edge. */
+#define NXP_LLWU_PIN_13_ANY     NXP_LLWU_PIN_WAKEUP(14, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 14 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_14_RISING  NXP_LLWU_PIN_WAKEUP(15, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 14 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_14_FALLING NXP_LLWU_PIN_WAKEUP(15, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 14 wakeup source on any edge. */
+#define NXP_LLWU_PIN_14_ANY     NXP_LLWU_PIN_WAKEUP(15, NXP_LLWU_PIN_EDGE_ANY)
+
+/** PIN 15 wakeup source on rising edge. */
+#define NXP_LLWU_PIN_15_RISING  NXP_LLWU_PIN_WAKEUP(16, NXP_LLWU_PIN_EDGE_RISING)
+/** PIN 15 wakeup source on falling edge. */
+#define NXP_LLWU_PIN_15_FALLING NXP_LLWU_PIN_WAKEUP(16, NXP_LLWU_PIN_EDGE_FALLING)
+/** PIN 15 wakeup source on any edge. */
+#define NXP_LLWU_PIN_15_ANY     NXP_LLWU_PIN_WAKEUP(16, NXP_LLWU_PIN_EDGE_ANY)
+/** @} */
+
+/** @name MODULE wakeup sources (MODULE 0-7) */
+/** @{ */
+/** MODULE 0 wakeup source. */
+#define NXP_LLWU_MODULE_0 NXP_LLWU_MODULE_WAKEUP(1)
+/** MODULE 1 wakeup source. */
+#define NXP_LLWU_MODULE_1 NXP_LLWU_MODULE_WAKEUP(2)
+/** MODULE 2 wakeup source. */
+#define NXP_LLWU_MODULE_2 NXP_LLWU_MODULE_WAKEUP(3)
+/** MODULE 3 wakeup source. */
+#define NXP_LLWU_MODULE_3 NXP_LLWU_MODULE_WAKEUP(4)
+/** MODULE 4 wakeup source. */
+#define NXP_LLWU_MODULE_4 NXP_LLWU_MODULE_WAKEUP(5)
+/** MODULE 5 wakeup source. */
+#define NXP_LLWU_MODULE_5 NXP_LLWU_MODULE_WAKEUP(6)
+/** MODULE 6 wakeup source. */
+#define NXP_LLWU_MODULE_6 NXP_LLWU_MODULE_WAKEUP(7)
+/** MODULE 7 wakeup source. */
+#define NXP_LLWU_MODULE_7 NXP_LLWU_MODULE_WAKEUP(8)
+/** @} */
+
+/** @name Wakeup source field helpers */
+/** @{ */
+/** Check if a wakeup source encodes a PIN source. */
+#define NXP_LLWU_IS_PIN_SOURCE(source)    (((source) & (1U << 31)) == 0)
+/** Check if a wakeup source encodes a MODULE source. */
+#define NXP_LLWU_IS_MODULE_SOURCE(source) (((source) & (1U << 31)) != 0)
+/** Extract the PIN index from a wakeup source. */
+#define NXP_LLWU_GET_PIN_INDEX(source)    ((source) & 0xFF)
+/** Extract the PIN edge encoding from a wakeup source. */
+#define NXP_LLWU_GET_PIN_EDGE(source)     (((source) >> 8) & 0x3)
+/** Extract the MODULE index from a wakeup source. */
+#define NXP_LLWU_GET_MODULE_INDEX(source) ((source) & 0xFF)
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_WUC_NXP_LLWU_H_ */

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -158,6 +158,7 @@ set_variable_ifdef(CONFIG_OPAMP_MCUX_OPAMP          CONFIG_MCUX_COMPONENT_driver
 set_variable_ifdef(CONFIG_OPAMP_MCUX_OPAMP_FAST     CONFIG_MCUX_COMPONENT_driver.opamp_fast)
 set_variable_ifdef(CONFIG_CRC_DRIVER_NXP        CONFIG_MCUX_COMPONENT_driver.crc)
 set_variable_ifdef(CONFIG_CRC_DRIVER_NXP_LPC    CONFIG_MCUX_COMPONENT_driver.lpc_crc)
+set_variable_ifdef(CONFIG_WUC_MCUX_LLWU         CONFIG_MCUX_COMPONENT_driver.llwu)
 
 if(NOT CONFIG_SOC_MIMX9596)
   set_variable_ifdef(CONFIG_ETH_NXP_IMX_NETC          CONFIG_MCUX_COMPONENT_driver.netc_switch)

--- a/tests/drivers/wuc/wuc_api/CMakeLists.txt
+++ b/tests/drivers/wuc/wuc_api/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(wuc_api)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/wuc/wuc_api/boards/frdm_mcxc242.overlay
+++ b/tests/drivers/wuc/wuc_api/boards/frdm_mcxc242.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/wuc/wuc_nxp_llwu.h>
+
+/ {
+	zephyr,user {
+		wakeup-source;
+		wakeup-ctrls = <&llwu NXP_LLWU_PIN_0_RISING>,
+			       <&llwu NXP_LLWU_MODULE_0>;
+	};
+};
+
+&llwu {
+	status = "okay";
+};

--- a/tests/drivers/wuc/wuc_api/boards/frdm_mcxc444.overlay
+++ b/tests/drivers/wuc/wuc_api/boards/frdm_mcxc444.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/wuc/wuc_nxp_llwu.h>
+
+/ {
+	zephyr,user {
+		wakeup-source;
+		wakeup-ctrls = <&llwu NXP_LLWU_PIN_0_RISING>,
+			       <&llwu NXP_LLWU_MODULE_0>;
+	};
+};
+
+&llwu {
+	status = "okay";
+};

--- a/tests/drivers/wuc/wuc_api/prj.conf
+++ b/tests/drivers/wuc/wuc_api/prj.conf
@@ -1,0 +1,5 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_WUC=y
+CONFIG_ZTEST=y

--- a/tests/drivers/wuc/wuc_api/src/main.c
+++ b/tests/drivers/wuc/wuc_api/src/main.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/device.h>
+
+#include <zephyr/drivers/wuc.h>
+
+#define WUC_SPEC_INFO(node_id, prop, idx) WUC_DT_SPEC_GET_BY_IDX(node_id, idx),
+
+#if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), wakeup_ctrls)
+
+static const struct wuc_dt_spec test_wuc_dt_specs[] = {
+	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), wakeup_ctrls, WUC_SPEC_INFO)};
+static const int test_wuc_dt_spec_count = ARRAY_SIZE(test_wuc_dt_specs);
+#else
+#error "Unsupported board"
+#endif
+
+static void *wuc_api_setup(void)
+{
+	zassert_true(device_is_ready(test_wuc_dt_specs[0].dev), "WUC device is not ready");
+
+	return NULL;
+}
+
+/**
+ * @brief Test wuc_enable_wakeup_source API
+ */
+ZTEST(wuc_api, test_wuc_enable_wakeup_source)
+{
+	int ret;
+	int i;
+
+	for (i = 0; i < test_wuc_dt_spec_count; i++) {
+		ret = wuc_enable_wakeup_source_dt(&test_wuc_dt_specs[i]);
+		zassert_ok(ret, "Fail to enable wakeup source");
+	}
+}
+
+/**
+ * @brief Test wuc_disable_wakeup_source API
+ */
+ZTEST(wuc_api, test_wuc_disable_wakeup_source)
+{
+	int ret;
+	int i;
+
+	for (i = 0; i < test_wuc_dt_spec_count; i++) {
+		ret = wuc_disable_wakeup_source_dt(&test_wuc_dt_specs[i]);
+		zassert_ok(ret, "Failed to disable wakeup source");
+	}
+}
+
+ZTEST_SUITE(wuc_api, NULL, wuc_api_setup, NULL, NULL, NULL);

--- a/tests/drivers/wuc/wuc_api/testcase.yaml
+++ b/tests/drivers/wuc/wuc_api/testcase.yaml
@@ -1,0 +1,11 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  tags:
+    - drivers
+    - wuc
+tests:
+  drivers.wuc.api:
+    depends_on: wuc
+    filter: dt_node_has_prop("/zephyr,user", "wakeup-ctrls")


### PR DESCRIPTION
Fix: #100853

#100866 (c89a262d39a8933f34b22e40ddd6b2865d904075)demonstrates an implementation  of this new device driver.
#100865 (91fa5e4cc694666255320fb3d03714e4f2f8370c) demonstrates an integration with other device driver.

### Overview
This proposal introduces a new device driver for the Wakeup Controller (WUC). It involves:
- Adding new APIs to manage the WUC peripheral.

---

### Motivation
In some MCUs, waking up from low-power modes requires special configuration of a dedicated peripheral called the Wakeup Controller (WUC). Currently, Zephyr supports this functionality in two ways:

1. **Implemented in interrupt controllers** (e.g., [`wuc_ite_it51xxx.c`](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/interrupt_controller/wuc_ite_it51xxx.c)):
   This approach lacks a unified interface for WUC control. For example, if different devices share the same peripheral but use different WUC implementations, supporting a new device often requires modifying its driver (e.g., [`espi_it8xxx2.c`](https://github.com/zephyrproject-rtos/zephyr/blob/fd63bf93a5a18bf0dc0a18b67b821bfdd68ab5b9/drivers/espi/espi_it8xxx2.c#L2684C1-L2688C7)).

2. **Implemented in SoC-specific power management code**(e.g., [`power.c`](https://github.com/zephyrproject-rtos/zephyr/blob/fd63bf93a5a18bf0dc0a18b67b821bfdd68ab5b9/soc/nxp/mcx/mcxw/mcxw7xx/power.c#L25)):  
   This method only supports a limited set of peripherals and lacks flexibility. If an application needs to use an unsupported peripheral as a wakeup source, additional code changes are required, and developers must be familiar with the MCU internals.

Both approaches have common issues:
- WUC configuration is typically done during initialization, with no flexible API for user-space control.
- The relationship between peripherals and WUC is hidden in code rather than expressed in devicetree, reducing transparency and flexibility.

**Problems solved by this proposal:**
- Introduce a generic WUC device driver with APIs that can be reused by other drivers, reducing the need for driver-specific changes when supporting new SoCs.
- Represent the peripheral-to-WUC mapping in devicetree instead of hardcoding it in source code.

---

### Design Details
The proposal introduces a new Wakeup Controller (WUC) driver API and integrates it with Zephyr’s power management subsystem.

**[New WUC Driver API](https://github.com/nxp-upstream/zephyr/blob/create-wakeup-controller/include/zephyr/drivers/wuc.h):**
- `wuc_enable_wakeup_source()` – Enable a specific wakeup source.
- `wuc_disable_wakeup_source()` – Disable a specific wakeup source.
- `wuc_check_wakeup_triggered()` – Check if a wakeup was triggered by a specific source.
- `wuc_record_wakeup_source_triggered` - Recode a specific wakeup source occurs.
- `wuc_clear_wakeup_source_triggered` - Clear triggered wakeup source.

