### PR TITLE
drivers: rtc: stm32: don't enable LL full driver module

### DIFF
--- a/drivers/rtc/Kconfig.stm32
+++ b/drivers/rtc/Kconfig.stm32
@@ -5,6 +5,5 @@ config RTC_STM32
 	bool "STM32 RTC driver"
 	default y if !COUNTER
 	depends on DT_HAS_ST_STM32_RTC_ENABLED && !SOC_SERIES_STM32F1X
-	select USE_STM32_LL_RTC
 	help
 	  Build RTC driver for STM32 SoCs, excluding STM32F1 series.


### PR DESCRIPTION
The RTC driver does not use any of the functions implemented in the LL full driver module (`stm32XXxx_ll_rtc.c`), only those provided by the LL header (`stm32XXxx_ll_rtc.h`).

Disable compilation of the unnecessary full driver module.

<details>

The functions provided by the LL full driver module are:
* `LL_RTC_DeInit`
* `LL_RTC_Init`
* `LL_RTC_StructInit`
* `LL_RTC_TIME_Init`
* `LL_RTC_TIME_StructInit`
* `LL_RTC_DATE_Init`
* `LL_RTC_DATE_StructInit`
* `LL_RTC_ALMA_Init`
* `LL_RTC_ALMB_Init`
* `LL_RTC_ALMA_StructInit`
* `LL_RTC_ALMB_StructInit`
* `LL_RTC_EnterInitMode`
* `LL_RTC_ExitInitMode`
* `LL_RTC_WaitForSynchro`

</details>
