### PR TITLE
drivers: sensor: qdec_stm32: don't enable LL full driver module

### DIFF
--- a/drivers/sensor/st/qdec_stm32/Kconfig
+++ b/drivers/sensor/st/qdec_stm32/Kconfig
@@ -7,6 +7,5 @@ config QDEC_STM32
 	default y
 	depends on DT_HAS_ST_STM32_QDEC_ENABLED
 	select PINCTRL
-	select USE_STM32_LL_TIM
 	help
 	  STM32 family Quadrature Decoder driver.


### PR DESCRIPTION
The QDEC driver does not use any of the functions implemented in the TIM LL full driver module (`stm32XXxx_ll_tim.c`), only those provided by the LL header (`stm32XXxx_ll_tim.h`).

Disable compilation of the unnecessary full driver module.

<details>

The functions provided by the LL full driver module are:

* `LL_TIM_DeInit`
* `LL_TIM_StructInit`
* `LL_TIM_Init`
* `LL_TIM_OC_StructInit`
* `LL_TIM_OC_Init`
* `LL_TIM_IC_StructInit`
* `LL_TIM_IC_Init`
* `LL_TIM_ENCODER_StructInit`
* `LL_TIM_ENCODER_Init`
* `LL_TIM_HALLSENSOR_StructInit`
* `LL_TIM_HALLSENSOR_Init`
* `LL_TIM_BDTR_StructInit`
* `LL_TIM_BDTR_Init`

</details>