### PR TITLE
drivers: crypto_mbedtls_shim: Fix build with Clang/LLVM

### DIFF
--- a/drivers/crypto/crypto_mbedtls_shim.c
+++ b/drivers/crypto/crypto_mbedtls_shim.c
@@ -306,7 +306,7 @@ static int mbedtls_cipher_session_setup(const struct device *dev,
 		break;
 #endif /* CONFIG_PSA_WANT_ALG_CBC_NO_PADDING */
 #if CONFIG_PSA_WANT_ALG_CCM
-	case CRYPTO_CIPHER_MODE_CCM:
+	case CRYPTO_CIPHER_MODE_CCM: {
 		uint16_t tag_len = ctx->mode_params.ccm_info.tag_len;
 
 		if (tag_len > PSA_AEAD_TAG_MAX_SIZE) {
@@ -315,6 +315,7 @@ static int mbedtls_cipher_session_setup(const struct device *dev,
 		session->psa_alg = PSA_ALG_AEAD_WITH_AT_LEAST_THIS_LENGTH_TAG(PSA_ALG_CCM, tag_len);
 		ctx->ops.ccm_crypt_hndlr = mbedtls_aead;
 		break;
+	}
 #endif /* CONFIG_PSA_WANT_ALG_CCM */
 #if CONFIG_PSA_WANT_ALG_GCM
 	case CRYPTO_CIPHER_MODE_GCM:


### PR DESCRIPTION
drivers/crypto/crypto_mbedtls_shim.c:310:3: error: label followed by a declaration is a C23 extension [-Werror,-Wc23-extensions]
                 uint16_t tag_len = ctx->mode_params.ccm_info.tag_len;
                 ^