### PR TITLE
drivers: ethernet: stm32: Add generic helper functions

### DIFF
--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -490,6 +490,47 @@ void HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth_handle)
 
 }
 
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+static void eth_stm32_update_dma_error(struct eth_stm32_hal_dev_data *dev_data, uint32_t dma_error)
+{
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet)
+	if ((dma_error & ETH_DMA_RX_WATCHDOG_TIMEOUT_FLAG) ||
+	    (dma_error & ETH_DMA_RX_PROCESS_STOPPED_FLAG) ||
+	    (dma_error & ETH_DMA_RX_BUFFER_UNAVAILABLE_FLAG)) {
+		eth_stats_update_errors_rx(dev_data->iface);
+	}
+	if ((dma_error & ETH_DMA_EARLY_TX_IT_FLAG) ||
+	    (dma_error & ETH_DMA_TX_PROCESS_STOPPED_FLAG)) {
+		eth_stats_update_errors_tx(dev_data->iface);
+	}
+#else
+	if ((dma_error & ETH_DMASR_RWTS) || (dma_error & ETH_DMASR_RPSS) ||
+	    (dma_error & ETH_DMASR_RBUS)) {
+		eth_stats_update_errors_rx(dev_data->iface);
+	}
+	if ((dma_error & ETH_DMASR_ETS) || (dma_error & ETH_DMASR_TPSS) ||
+	    (dma_error & ETH_DMASR_TJTS)) {
+		eth_stats_update_errors_tx(dev_data->iface);
+	}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet) */
+}
+
+static void eth_stm32_update_rx_error_details(ETH_HandleTypeDef *heth,
+					      struct eth_stm32_hal_dev_data *dev_data)
+{
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32mp13_ethernet)
+	dev_data->stats.error_details.rx_crc_errors = heth->Instance->MMCRXCRCEPR;
+	dev_data->stats.error_details.rx_align_errors = heth->Instance->MMCRXAEPR;
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet)
+	dev_data->stats.error_details.rx_crc_errors = heth->Instance->MMCRCRCEPR;
+	dev_data->stats.error_details.rx_align_errors = heth->Instance->MMCRAEPR;
+#else
+	dev_data->stats.error_details.rx_crc_errors = heth->Instance->MMCRFCECR;
+	dev_data->stats.error_details.rx_align_errors = heth->Instance->MMCRFAECR;
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32mp13_ethernet) */
+}
+#endif /* CONFIG_NET_STATISTICS_ETHERNET */
+
 void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth)
 {
 	/* Do not log errors. If errors are reported due to high traffic,
@@ -516,28 +557,8 @@ void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth)
 #endif
 		dma_error = HAL_ETH_GetDMAError(heth);
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet)
-		if ((dma_error & ETH_DMA_RX_WATCHDOG_TIMEOUT_FLAG)   ||
-			(dma_error & ETH_DMA_RX_PROCESS_STOPPED_FLAG)    ||
-			(dma_error & ETH_DMA_RX_BUFFER_UNAVAILABLE_FLAG)) {
-			eth_stats_update_errors_rx(dev_data->iface);
-		}
-		if ((dma_error & ETH_DMA_EARLY_TX_IT_FLAG) ||
-			(dma_error & ETH_DMA_TX_PROCESS_STOPPED_FLAG)) {
-			eth_stats_update_errors_tx(dev_data->iface);
-		}
-#else
-		if ((dma_error & ETH_DMASR_RWTS) ||
-			(dma_error & ETH_DMASR_RPSS) ||
-			(dma_error & ETH_DMASR_RBUS)) {
-			eth_stats_update_errors_rx(dev_data->iface);
-		}
-		if ((dma_error & ETH_DMASR_ETS)  ||
-			(dma_error & ETH_DMASR_TPSS) ||
-			(dma_error & ETH_DMASR_TJTS)) {
-			eth_stats_update_errors_tx(dev_data->iface);
-		}
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet) */
+		eth_stm32_update_dma_error(dev_data, dma_error);
+
 		break;
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet)
@@ -560,16 +581,7 @@ void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth)
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet) */
 	}
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32mp13_ethernet)
-	dev_data->stats.error_details.rx_crc_errors = heth->Instance->MMCRXCRCEPR;
-	dev_data->stats.error_details.rx_align_errors = heth->Instance->MMCRXAEPR;
-#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet)
-	dev_data->stats.error_details.rx_crc_errors = heth->Instance->MMCRCRCEPR;
-	dev_data->stats.error_details.rx_align_errors = heth->Instance->MMCRAEPR;
-#else
-	dev_data->stats.error_details.rx_crc_errors = heth->Instance->MMCRFCECR;
-	dev_data->stats.error_details.rx_align_errors = heth->Instance->MMCRFAECR;
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet) */
+	eth_stm32_update_rx_error_details(heth, dev_data);
 
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
 }


### PR DESCRIPTION
This commit introduces helper functions to avoid having large 
#if DT_HAS_COMPAT_STATUS_OKAY ... #else blocks,
improving readability.

Fixes #86406
