### PR TITLE
tests: crypto: mbedtls: Ensure at least one operation succeeded

### DIFF
--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -20,6 +20,7 @@ tests:
         - ".*: CTR Mode"
         - ".*: CCM Mode"
         - ".*: GCM Mode"
+        - "ENCRYPT - Match"
   sample.drivers.crypto.stm32:
     tags: crypto
     filter: dt_compat_enabled("st,stm32-aes") or dt_compat_enabled("st,stm32-cryp")


### PR DESCRIPTION
Prevent uncaught regression by hardening regex pattern. The regression was detected in #100572,
but was uncaught by the original regex.