### PR TITLE
openthread: platform: infra_if: Add IPV4 packet filtering rule for NAT64 translator

### DIFF
--- a/modules/openthread/Kconfig
+++ b/modules/openthread/Kconfig
@@ -367,7 +367,9 @@ menu "OpenThread Border Router"
 config OPENTHREAD_ZEPHYR_BORDER_ROUTER
 	bool "Adds support for Border Router functionality [EXPERIMENTAL]"
 	select EXPERIMENTAL
-	imply NET_ROUTING
+	select NET_ROUTING
+	select NET_PKT_FILTER if OPENTHREAD_NAT64_TRANSLATOR
+	select NET_PKT_FILTER_IPV4_HOOK if OPENTHREAD_NAT64_TRANSLATOR
 	help
 	  Enable support for Border Router using Openthread's implementation.
 


### PR DESCRIPTION
This commit aims to implement an L3 handler for NAT64 translator. If packets are consumed, those are not processed anymore by network stack.
NAT64 packets are created by OpenThread stack and sent on backbone interface using a raw socket.

This commit attempts to fix an issue where a TCP connection is initiated by an OpenThread node, but discarded by network stack since there is no active known connection.