### PR TITLE
tests: crypto: mbedtls: Exclude mpfs_icicle and hifive_unmatched

### DIFF
--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -12,6 +12,10 @@ tests:
     extra_args: EXTRA_CONF_FILE=prj_mtls_shim.conf
     integration_platforms:
       - native_sim
+    platform_exclude:
+      - hifive_unmatched/fu740/s7
+      - hifive_unmatched/fu740/u74
+      - mpfs_icicle/polarfire/e51
     harness_config:
       type: multi_line
       regex:


### PR DESCRIPTION
The regression causes system halt in `sample.drivers.crypto.mbedtls` for `mpfs_icicle` and `hifive_unmatched` with the error `mcause: 6, Store/AMO address misaligned`.

Exclude platforms that support simulation as these errors impact CI. Non-simulated targets are also impacted, for example `beaglev_fire/polarfire/u54`, but these are not excluded to not hide the underlying problem.

The underlying issue is tracked in https://github.com/zephyrproject-rtos/zephyr/issues/100572.