### PR TITLE
drivers: mcux_os_timer: Add Kconfig option for MIN_DELAY configuration

### DIFF
--- a/drivers/timer/Kconfig.mcux_os
+++ b/drivers/timer/Kconfig.mcux_os
@@ -21,4 +21,14 @@ config MCUX_OS_TIMER_PM_POWERED_OFF
 	  OS Timer is turned off in certain low power modes. When this option is
 	  picked, OS Timer will take steps to store state and reinitialize on wakeups.
 
+config MCUX_OS_TIMER_MIN_DELAY
+	int "Minimum delay cycles for OS timer match value"
+	default 1000
+	help
+	  Timer hardware requires a minimum setup time to reliably trigger
+	  interrupts. If a match value is set too close to the current timer
+	  count, the hardware may not have enough time to process it.
+	  Lower values can improve timing precision but may be less reliable.
+	  Higher values provide more safety margin but slightly reduce timing accuracy.
+
 endif # MCUX_OS_TIMER

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -28,7 +28,7 @@
 #define CYC_PER_US ((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec() / (uint64_t)USEC_PER_SEC))
 #define MAX_CYC    INT_MAX
 #define MAX_TICKS  ((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK)
-#define MIN_DELAY  1000
+#define MIN_DELAY  CONFIG_MCUX_OS_TIMER_MIN_DELAY
 
 static struct k_spinlock lock;
 static uint64_t last_count;


### PR DESCRIPTION
Introduce CONFIG_MCUX_OS_TIMER_MIN_DELAY to allow the configuration of the minimum delay cycles.