### PR TITLE
drivers: gpio: nxp: mcux_igpio: fix mcux_igpio_port_get_raw()

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -200,6 +200,9 @@ static int mcux_igpio_configure(const struct device *dev,
 	}
 #endif /* CONFIG_SOC_SERIES_IMXRT10XX */
 
+	/* Enable input buffer via Software Input On (SION). */
+	reg |= 0x1 << MCUX_IMX_INPUT_ENABLE_SHIFT;
+
 	memcpy(&pin_cfg.pinmux, &config->pin_muxes[cfg_idx], sizeof(pin_cfg.pinmux));
 	/* cfg register will be set by pinctrl_configure_pins */
 	pin_cfg.pin_ctrl_flags = reg;
@@ -226,7 +229,8 @@ static int mcux_igpio_port_get_raw(const struct device *dev, uint32_t *value)
 {
 	GPIO_Type *base = get_base(dev);
 
-	*value = base->DR;
+	/* Read the Pad Status Register to get current input value */
+	*value = base->PSR;
 
 	return 0;
 }


### PR DESCRIPTION
- Reads the Pad Status Register (PSR) to get the current GPIO input value, instead of the Data Register (DR). 
  Following IMXRT1170RM.pdf "13.5.2 GPIO Write Mode".
- Enables input buffer via Software Input On (SION) to get correct pin value in PSR for both input/output pins.
- Issue has been discovered during Safety DIO self-tests.