### PR TITLE
doc: Bluetooth: Update PBP version

### DIFF
--- a/doc/connectivity/bluetooth/api/audio/bluetooth-le-audio-arch.rst
+++ b/doc/connectivity/bluetooth/api/audio/bluetooth-le-audio-arch.rst
@@ -828,12 +828,12 @@ Bluetooth Audio Stack.
    |        |                               |         |                  | - BSIM test           |                                                  |
    |        |                               |         |                  | - Sample Application  |                                                  |
    +--------+-------------------------------+---------+------------------+-----------------------+--------------------------------------------------+
-   | PBP    | Public Broadcast Source       | 1.0.0   | 3.5              | - Feature complete    |                                                  |
+   | PBP    | Public Broadcast Source       | 1.0.2   | 3.5              | - Feature complete    |                                                  |
    |        |                               |         |                  | - Shell Module        |                                                  |
    |        |                               |         |                  | - BSIM test           |                                                  |
    |        |                               |         |                  | - Sample Application  |                                                  |
    |        +-------------------------------+---------+------------------+-----------------------+--------------------------------------------------+
-   |        | Public Broadcast Sink         | 1.0.0   | 3.5              | - Feature complete    |                                                  |
+   |        | Public Broadcast Sink         | 1.0.2   | 3.5              | - Feature complete    |                                                  |
    |        |                               |         |                  | - Shell Module        |                                                  |
    |        |                               |         |                  | - BSIM test           |                                                  |
    |        |                               |         |                  | - Sample Application  |                                                  |


### PR DESCRIPTION
Update the PBP version support to 1.0.2. There are no functional changes needed by the stack for this update.