### PR TITLE
drivers: counter: fix mcux lptmr unit test issue.

### DIFF
--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -247,6 +247,7 @@ static void mcux_lptmr_isr(const struct device *dev)
 		uint32_t current_count = LPTMR_GetCurrentTimerCount(config->base);
 
 		LPTMR_StopTimer(config->base);
+		LPTMR_SetTimerPeriod(config->base, config->info.max_top_value);
 
 		callback(dev, 0, current_count, user_data);
 

--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -51,3 +51,12 @@ tests:
       - CONFIG_TEST_DRIVER_COUNTER_MCUX_LPC_RTC_HIGHRES=n
     extra_args:
       DTC_OVERLAY_FILE="enable_standby.overlay"
+  drivers.counter.basic_api.mcux_lptmr_alarm:
+    tags:
+      - drivers
+      - counter
+    filter: dt_compat_enabled("nxp,lptmr")
+    depends_on: counter
+    timeout: 600
+    extra_configs:
+      - CONFIG_COUNTER_MCUX_LPTMR_ALARM=y


### PR DESCRIPTION
Fix the MCUX LPTMR counter driver alarm behavior so that, after an alarm
fires, the match value is reset to the maximum top value. Without this,
restarting the LPTMR may hit the previous match value almost
immediately, causing the counter_basic_api test
test_valid_function_without_alarm to fail intermittently.

Extend the counter_basic_api test suite with a dedicated test
configuration that enables CONFIG_COUNTER_MCUX_LPTMR_ALARM and runs
the same tests on any board that instantiates an nxp,lptmr device.
This verifies the alarm-only LPTMR configuration against the common
counter API.

Depends-On: https://github.com/zephyrproject-rtos/zephyr/pull/100558