### PR TITLE
boards: silabs: add missing clock frequency on spi eusart node

### DIFF
--- a/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
+++ b/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
@@ -181,6 +181,7 @@
 &eusart1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
+	clock-frequency = <DT_FREQ_M(8)>;
 	pinctrl-0 = <&eusart1_default>;
 	pinctrl-names = "default";
 	status = "okay";

--- a/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c.dts
+++ b/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c.dts
@@ -134,6 +134,7 @@
 &eusart1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
+	clock-frequency = <DT_FREQ_M(8)>;
 	pinctrl-0 = <&eusart1_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpioc 8 GPIO_ACTIVE_HIGH>, <&gpioc 4 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
This patch add the clock-frequency property for two board. Without this patch, the frequency is silently set to 1 Mhz which can introduce some lack of understanding.