### PR TITLE
soc: espressif: power: register power log module

### DIFF
--- a/soc/espressif/esp32/power.c
+++ b/soc/espressif/esp32/power.c
@@ -11,7 +11,7 @@
 #include <hal/rtc_io_hal.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+LOG_MODULE_REGISTER(soc_pm, CONFIG_SOC_LOG_LEVEL);
 
 static uint32_t intenable;
 

--- a/soc/espressif/esp32c2/power.c
+++ b/soc/espressif/esp32c2/power.c
@@ -9,7 +9,7 @@
 #include <esp_sleep.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+LOG_MODULE_REGISTER(soc_pm, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
 void pm_state_set(enum pm_state state, uint8_t substate_id)

--- a/soc/espressif/esp32c3/power.c
+++ b/soc/espressif/esp32c3/power.c
@@ -9,7 +9,7 @@
 #include <esp_sleep.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+LOG_MODULE_REGISTER(soc_pm, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
 void pm_state_set(enum pm_state state, uint8_t substate_id)

--- a/soc/espressif/esp32c6/power.c
+++ b/soc/espressif/esp32c6/power.c
@@ -9,7 +9,7 @@
 #include <esp_sleep.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+LOG_MODULE_REGISTER(soc_pm, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
 void pm_state_set(enum pm_state state, uint8_t substate_id)

--- a/soc/espressif/esp32h2/power.c
+++ b/soc/espressif/esp32h2/power.c
@@ -9,7 +9,7 @@
 #include <esp_sleep.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+LOG_MODULE_REGISTER(soc_pm, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */
 void pm_state_set(enum pm_state state, uint8_t substate_id)

--- a/soc/espressif/esp32s2/power.c
+++ b/soc/espressif/esp32s2/power.c
@@ -9,7 +9,7 @@
 #include <esp_sleep.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+LOG_MODULE_REGISTER(soc_pm, CONFIG_SOC_LOG_LEVEL);
 
 static uint32_t intenable;
 

--- a/soc/espressif/esp32s3/power.c
+++ b/soc/espressif/esp32s3/power.c
@@ -9,7 +9,7 @@
 #include <esp_sleep.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+LOG_MODULE_REGISTER(soc_pm, CONFIG_SOC_LOG_LEVEL);
 
 static uint32_t intenable;
 


### PR DESCRIPTION
All power.c files in Espressif SoCs depends on un-registered soc log module. When CONFIG_LOG=y and CONFIG_LOG_DEFAULT_LEVEL=4, build fails as LOG_DBG used in those files won't have its proper declaration.

Fixes #100542