### PR TITLE
boards: ai_m61_32s_kit: fix wrong values and supported test

### DIFF
--- a/boards/aithinker/ai_m61_32s_kit/ai_m61_32s.dtsi
+++ b/boards/aithinker/ai_m61_32s_kit/ai_m61_32s.dtsi
@@ -48,7 +48,7 @@
 
 			storage_partition: partition@100000 {
 				label = "storage";
-				reg = <0x00100000 (0x800000 - 0x2000)>;
+				reg = <0x00100000 (0x700000 - 0x2000)>;
 			};
 		};
 	};

--- a/boards/aithinker/ai_m61_32s_kit/ai_m61_32s_kit.yaml
+++ b/boards/aithinker/ai_m61_32s_kit/ai_m61_32s_kit.yaml
@@ -19,7 +19,6 @@ supported:
   - uart
   - dma
   - i2c
-  - display
   - spi
   - flash
 vendor: bflb


### PR DESCRIPTION
Input the wrong number in flash size, also should not run display tests.

Realized while updating another board.