### PR TITLE
sys: sys_heap: Fix _system_heap type

### DIFF
--- a/modules/nrf_wifi/os/shim.c
+++ b/modules/nrf_wifi/os/shim.c
@@ -37,7 +37,7 @@ LOG_MODULE_REGISTER(wifi_nrf, CONFIG_WIFI_NRF70_LOG_LEVEL);
 /* Memory pool management - unified pool-based API */
 #if defined(CONFIG_NRF_WIFI_GLOBAL_HEAP)
 /* Use global system heap */
-extern struct sys_heap _system_heap;
+extern struct k_heap _system_heap;
 static struct k_heap * const wifi_ctrl_pool = &_system_heap;
 static struct k_heap * const wifi_data_pool = &_system_heap;
 #else

--- a/samples/subsys/zbus/msg_subscriber/src/main.c
+++ b/samples/subsys/zbus/msg_subscriber/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/zbus/zbus.h>
 LOG_MODULE_REGISTER(sample, CONFIG_LOG_MAX_LEVEL);
 
-extern struct sys_heap _system_heap;
+extern struct k_heap _system_heap;
 static size_t total_allocated;
 
 void on_heap_alloc(uintptr_t heap_id, void *mem, size_t bytes)
@@ -28,10 +28,11 @@ void on_heap_free(uintptr_t heap_id, void *mem, size_t bytes)
 
 #if defined(CONFIG_ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC)
 
-HEAP_LISTENER_ALLOC_DEFINE(my_heap_listener_alloc, HEAP_ID_FROM_POINTER(&_system_heap),
+HEAP_LISTENER_ALLOC_DEFINE(my_heap_listener_alloc, HEAP_ID_FROM_POINTER(&_system_heap.heap),
 			   on_heap_alloc);
 
-HEAP_LISTENER_FREE_DEFINE(my_heap_listener_free, HEAP_ID_FROM_POINTER(&_system_heap), on_heap_free);
+HEAP_LISTENER_FREE_DEFINE(my_heap_listener_free, HEAP_ID_FROM_POINTER(&_system_heap.heap),
+			  on_heap_free);
 
 #endif /* CONFIG_ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC */
 struct acc_msg {

--- a/subsys/shell/modules/kernel_service/heap.c
+++ b/subsys/shell/modules/kernel_service/heap.c
@@ -8,9 +8,7 @@
 #if K_HEAP_MEM_POOL_SIZE > 0
 #include "kernel_shell.h"
 
-#include <zephyr/sys/sys_heap.h>
-
-extern struct sys_heap _system_heap;
+extern struct k_heap _system_heap;
 
 static int cmd_kernel_heap(const struct shell *sh, size_t argc, char **argv)
 {
@@ -20,7 +18,7 @@ static int cmd_kernel_heap(const struct shell *sh, size_t argc, char **argv)
 	int err;
 	struct sys_memory_stats stats;
 
-	err = sys_heap_runtime_stats_get(&_system_heap, &stats);
+	err = sys_heap_runtime_stats_get(&_system_heap.heap, &stats);
 	if (err) {
 		shell_error(sh, "Failed to read kernel system heap statistics (err %d)", err);
 		return -ENOEXEC;


### PR DESCRIPTION
Changes the type used in _system_heap extern declarations to use k_heap instead of sys_heap.

Fixes #100530