### PR TITLE
scripts: twisterlib: display testplan build duration

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -16,6 +16,7 @@ import random
 import re
 import subprocess
 import sys
+import time
 from argparse import Namespace
 from collections import OrderedDict
 from itertools import islice
@@ -830,6 +831,7 @@ class TestPlan:
         integration_mode_list = test_config_options.get('integration_mode', [])
 
         logger.info("Building initial testsuite list...")
+        build_list_start = time.time()
 
         keyed_tests = {}
         for _, ts in self.testsuites.items():
@@ -1219,6 +1221,9 @@ class TestPlan:
         for inst in filtered_and_skipped_instances:
             change_skip_to_error_if_integration(self.options, inst)
             inst.add_missing_case_status(inst.status)
+
+        build_list_duration = time.time() - build_list_start
+        logger.info(f"Built testsuite list in {build_list_duration:.2f} seconds")
 
     def _find_required_instance(self, required_app, instance: TestInstance) -> TestInstance | None:
         if req_platform := required_app.get("platform", None):

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -182,7 +182,7 @@ def twister(options: argparse.Namespace, default_options: argparse.Namespace) ->
 
     if options.dry_run:
         duration = time.time() - start_time
-        logger.info(f"Completed in {duration} seconds")
+        logger.info(f"Completed in {duration:.2f} seconds")
         return 0
 
     if options.short_build_path:


### PR DESCRIPTION
Display how long it takes to build the testplan in the logs. This can be useful since the duration to build the plan can vary wildly depending on the arguments given. Without this information, it is difficult to tell (from CI logs) whether a long execution time is from actually building and running the tests, or just generating the testplan.

For example, in a downstream repo:
```
./zephyr/scripts/twister --integration -iv -T . --dry-run

INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 10.58 seconds
```
vs
```
./zephyr/scripts/twister --integration -iv -T . --dry-run --vendor nordic --vendor zephyr

INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 201.01 seconds
```