### PR TITLE
drivers: modem: hl78xx: Add automatic baud rate detection and switching

### DIFF
--- a/boards/shields/swir_hl78xx_ev_kit/doc/auto_baudrate/hl78xx_auto_baudrate.rst
+++ b/boards/shields/swir_hl78xx_ev_kit/doc/auto_baudrate/hl78xx_auto_baudrate.rst
@@ -1,0 +1,319 @@
+.. _hl78xx_auto_baudrate:
+
+HL78xx Auto Baud Rate Switching
+===============================
+
+Overview
+--------
+
+This feature enables automatic baud rate detection and switching for the
+Sierra Wireless HL78xx modem driver. The driver can automatically detect
+the modem's current baud rate and switch to a configured target baud rate
+using the ``AT+IPR`` command.
+
+Features
+--------
+
+- **Auto-detection**: Automatically detects the modem's current baud rate
+  by trying a list of common baud rates
+- **Dynamic switching**: Changes the modem's baud rate to the configured
+  target using the ``AT+IPR`` command
+- **Configurable**: Supports multiple baud rates from 9600 to 921600 bps
+- **Retry mechanism**: Configurable retry count for robust detection
+- **State machine integration**: Seamlessly integrated into the modem
+  initialization sequence
+
+Configuration
+-------------
+
+Enable the feature in your project's ``prj.conf``:
+
+.. code-block:: ini
+
+   # Enable auto baud rate detection and switching
+   CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+
+   # Set target baud rate (default is 115200)
+   CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600=y
+
+   # Configure detection baud rates (comma-separated list)
+   CONFIG_MODEM_HL78XX_AUTOBAUD_DETECTION_BAUDRATES="115200,9600,57600,38400,19200"
+
+   # Set timeout for each detection attempt (in seconds)
+   CONFIG_MODEM_HL78XX_AUTOBAUD_TIMEOUT=4
+
+   # Set number of retries
+   CONFIG_MODEM_HL78XX_AUTOBAUD_RETRY_COUNT=3
+
+   # Save baud rate change to modem NVMEM (default: y, recommended)
+   CONFIG_MODEM_HL78XX_AUTOBAUD_CHANGE_PERSISTENT=y
+
+   # Try target baud rate first before detection list (default: y, faster)
+   CONFIG_MODEM_HL78XX_AUTOBAUD_START_WITH_TARGET_BAUDRATE=y
+
+   # Only perform auto-baud if initial communication fails (default: y, efficient)
+   CONFIG_MODEM_HL78XX_AUTOBAUD_ONLY_IF_COMMS_FAIL=y
+
+   # Perform auto-baud immediately at boot, skip KSUP wait (default: n)
+   CONFIG_MODEM_HL78XX_AUTOBAUD_AT_BOOT=n
+
+Supported Baud Rates
+--------------------
+
+The following baud rates are supported:
+
+- 9600 bps
+- 19200 bps
+- 38400 bps
+- 57600 bps
+- 115200 bps (default)
+- 230400 bps
+- 460800 bps
+- 921600 bps
+- 3000000 bps (HL7812 only)
+
+How It Works
+------------
+
+Detection Phase (``MODEM_HL78XX_STATE_SET_BAUDRATE``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the modem enters the ``SET_BAUDRATE`` state after power-on:
+
+1. The driver tries each baud rate from the detection list
+2. For each rate, it:
+
+   - Configures the UART to that baud rate
+   - Sends an ``AT`` command
+   - Waits for an ``OK`` response
+
+3. Once a response is received, the current baud rate is identified
+
+Switching Phase
+~~~~~~~~~~~~~~~
+
+If the detected baud rate differs from the target:
+
+1. Send ``AT+IPR=<target_baudrate>`` at the current baud rate
+2. Wait for ``OK`` response
+3. Wait 2.5 seconds for the modem to apply the change
+4. Reconfigure the host UART to the new baud rate
+5. Wait 50 ms for UART stabilization
+6. Verify communication by sending an ``AT`` test command
+7. Send ``AT&W`` to save configuration to NVMEM
+
+.. note::
+
+   After baud rate switching completes, the state machine runs the
+   post-restart script to wait for the KUSP URC message before proceeding
+   to initialization.
+
+State Transitions
+~~~~~~~~~~~~~~~~~
+
+::
+
+   AWAIT_POWER_ON --> SET_BAUDRATE --> RUN_INIT_SCRIPT
+                           |
+                           +--> [On Failure] --> RUN_INIT_FAIL_DIAGNOSTIC_SCRIPT
+
+Use Cases
+---------
+
+Use Case 1: Unknown Modem Baud Rate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: ini
+
+   CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_DETECTION_BAUDRATES="115200,9600,57600,38400,19200"
+
+Use Case 2: High-Speed Communication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: ini
+
+   CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600=y
+
+Use Case 3: Fast Boot with Known Baud Rate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: ini
+
+   CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_START_WITH_TARGET_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_ONLY_IF_COMMS_FAIL=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_TIMEOUT=2
+
+**Result:** Boot time ~50–100 ms if modem is already at target rate.
+
+Use Case 4: Production / Field Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: ini
+
+   CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_DETECTION_BAUDRATES="115200,57600,38400,19200,9600"
+   CONFIG_MODEM_HL78XX_AUTOBAUD_TIMEOUT=8
+   CONFIG_MODEM_HL78XX_AUTOBAUD_RETRY_COUNT=5
+   CONFIG_MODEM_HL78XX_AUTOBAUD_CHANGE_PERSISTENT=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_START_WITH_TARGET_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_ONLY_IF_COMMS_FAIL=y
+
+Use Case 5: Temporary Baud Rate Change
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: ini
+
+   CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_CHANGE_PERSISTENT=n
+
+.. note::
+
+   The modem will revert to the previous baud rate after a power cycle
+   or ``AT+CFUN`` reset.
+
+AT Commands Used
+----------------
+
+Query Current Baud Rate
+~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+   AT+IPR?
+
+Response::
+
+   +IPR: <rate>
+   +IPR: 0
+
+Set Fixed Baud Rate
+~~~~~~~~~~~~~~~~~~~
+
+::
+
+   AT+IPR=<rate>
+
+Where ``<rate>`` can be:
+
+- 9600
+- 19200
+- 38400
+- 57600
+- 115200
+- 230400
+- 460800
+- 921600
+- 3000000 (HL7812 only)
+
+.. important::
+
+   The new baud rate takes effect after ~2 seconds. Use ``AT&W`` to
+   persist the configuration across power cycles.
+
+Troubleshooting
+---------------
+
+Detection Fails
+~~~~~~~~~~~~~~~
+
+**Symptoms:** Modem enters diagnostic state after multiple retries
+
+**Solutions:**
+
+1. Verify detection list includes the modem's current baud rate
+2. Increase timeout
+3. Check UART wiring and signal quality
+4. Verify modem is powered and responsive
+
+Switching Fails
+~~~~~~~~~~~~~~~
+
+**Symptoms:** Detection succeeds but switching fails
+
+**Solutions:**
+
+1. Verify target baud rate is supported by modem and UART
+2. Check UART clock limitations
+3. Try a lower baud rate
+4. Verify firmware supports ``AT+IPR``
+
+Communication Lost After Switch
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Root Cause:** Host UART not reconfigured before sending ``AT&W``
+
+**Solutions:**
+
+1. Reconfigure host UART **before** ``AT&W``
+2. Wait 2.5 seconds after ``AT+IPR``
+3. Wait for KUSP URC
+4. Check UART buffering and flow control
+
+Disabling Auto-Baud Causes Failure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Root Cause:** Modem remains at saved baud rate while UART defaults differ.
+
+**Solutions:**
+
+- Keep auto-baud enabled (recommended)
+- Update device tree UART speed:
+
+.. code-block:: dts
+
+   &uart_modem {
+       current-speed = <921600>;
+   };
+
+- Manually reset modem baud rate before disabling auto-baud
+
+Implementation Details
+----------------------
+
+Key Functions
+~~~~~~~~~~~~~
+
+.. code-block:: c
+
+   static int hl78xx_try_baudrate(struct hl78xx_data *data, uint32_t baudrate);
+   static int hl78xx_detect_current_baudrate(struct hl78xx_data *data);
+   static int hl78xx_switch_baudrate(struct hl78xx_data *data, uint32_t target_baudrate);
+
+State Handler
+~~~~~~~~~~~~~
+
+.. code-block:: c
+
+   static int hl78xx_on_set_baudrate_state_enter(struct hl78xx_data *data);
+   static void hl78xx_set_baudrate_event_handler(struct hl78xx_data *data,
+                                                 enum hl78xx_event evt);
+
+Data Structure
+~~~~~~~~~~~~~~
+
+.. code-block:: c
+
+   struct uart_status {
+   #ifdef CONFIG_MODEM_HL78XX_AUTO_BAUDRATE
+       uint32_t current_baudrate;
+       uint32_t target_baudrate;
+       uint8_t baudrate_detection_retry;
+   #endif
+   };
+
+License
+-------
+
+Copyright (c) 2025 Netfeasa Ltd.
+
+SPDX-License-Identifier: Apache-2.0
+
+----
+
+**Last Updated:** 2025-12-06

--- a/boards/shields/swir_hl78xx_ev_kit/doc/auto_baudrate/hl78xx_auto_baudrate_quick_reference.rst
+++ b/boards/shields/swir_hl78xx_ev_kit/doc/auto_baudrate/hl78xx_auto_baudrate_quick_reference.rst
@@ -1,0 +1,271 @@
+.. _hl78xx_auto_baudrate_quick_reference:
+
+HL78xx Auto Baud Rate - Quick Reference
+=======================================
+
+Enable Feature
+--------------
+
+.. code-block:: ini
+
+   # In prj.conf
+   CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600=y  # Your target rate
+
+Common Configurations
+---------------------
+
+Preset 1: Smart Default (Recommended)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: ini
+
+   CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_DETECTION_BAUDRATES="921600,9600,57600,38400,115200"
+   CONFIG_MODEM_HL78XX_AUTOBAUD_TIMEOUT=4
+   CONFIG_MODEM_HL78XX_AUTOBAUD_RETRY_COUNT=3
+   CONFIG_MODEM_HL78XX_AUTOBAUD_CHANGE_PERSISTENT=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_START_WITH_TARGET_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_ONLY_IF_COMMS_FAIL=y
+
+- **Use when:** General purpose, known and unknown baud rates
+- **Boot time impact:** ~50-100 ms (already at target), ~4-20 s (detection)
+- **Why smart:** Full detection only runs if initial communication fails
+
+Preset 2: Ultra-Fast Boot (Known Rate)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: ini
+
+   CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_DETECTION_BAUDRATES="921600"
+   CONFIG_MODEM_HL78XX_AUTOBAUD_TIMEOUT=1
+   CONFIG_MODEM_HL78XX_AUTOBAUD_RETRY_COUNT=1
+   CONFIG_MODEM_HL78XX_AUTOBAUD_START_WITH_TARGET_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_ONLY_IF_COMMS_FAIL=y
+
+- **Use when:** Modem is known to be at target rate
+- **Boot time impact:** ~50-100 ms
+- **Warning:** Fails if modem baud rate differs
+
+Preset 3: High Speed
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: ini
+
+   CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_DETECTION_BAUDRATES="921600,460800,230400,115200"
+   CONFIG_MODEM_HL78XX_AUTOBAUD_TIMEOUT=3
+   CONFIG_MODEM_HL78XX_AUTOBAUD_RETRY_COUNT=3
+   CONFIG_MODEM_HL78XX_AUTOBAUD_CHANGE_PERSISTENT=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_START_WITH_TARGET_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_ONLY_IF_COMMS_FAIL=y
+
+- **Use when:** High throughput required
+- **Boot time impact:** ~50 ms (best), ~3-12 s (worst)
+- **Note:** Ensure UART hardware supports high baud rates
+
+Preset 4: Robust Production
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: ini
+
+   CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_DETECTION_BAUDRATES="115200,57600,38400,19200,9600,921600"
+   CONFIG_MODEM_HL78XX_AUTOBAUD_TIMEOUT=8
+   CONFIG_MODEM_HL78XX_AUTOBAUD_RETRY_COUNT=5
+   CONFIG_MODEM_HL78XX_AUTOBAUD_CHANGE_PERSISTENT=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_START_WITH_TARGET_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_ONLY_IF_COMMS_FAIL=y
+
+- **Use when:** Field deployment, maximum reliability
+- **Boot time impact:** ~50 ms (best), ~40 s (worst)
+- **Features:** Diagnostic fallback, comprehensive detection
+
+Preset 5: Testing / Development (Non-Persistent)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: ini
+
+   CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_CHANGE_PERSISTENT=n
+   CONFIG_MODEM_HL78XX_AUTOBAUD_START_WITH_TARGET_BAUDRATE=y
+   CONFIG_MODEM_HL78XX_AUTOBAUD_ONLY_IF_COMMS_FAIL=y
+
+- **Use when:** Temporary testing
+- **Note:** Modem reverts baud rate on power cycle
+
+Supported Baud Rates
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 45 30
+
+   * - Rate
+     - Kconfig Option
+     - Use Case
+   * - 9600
+     - ``CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_9600``
+     - Legacy
+   * - 19200
+     - ``CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_19200``
+     - Legacy
+   * - 38400
+     - ``CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_38400``
+     - Standard
+   * - 57600
+     - ``CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_57600``
+     - Standard
+   * - 115200
+     - ``CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_115200``
+     - Default (recommended)
+   * - 230400
+     - ``CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_230400``
+     - High speed
+   * - 460800
+     - ``CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_460800``
+     - High speed
+   * - 921600
+     - ``CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600``
+     - Very high speed
+   * - 3000000
+     - ``CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_3000000``
+     - Maximum (HL7812 only)
+
+State Flow
+----------
+
+::
+
+   Power ON
+       ↓
+   [START_WITH_TARGET=y?] → Try target first → [AUTOBAUD_AT_BOOT=y?]
+       ↓                                        ↓
+   Wait KSUP → [ONLY_IF_COMMS_FAIL=y?] → Try Target
+       ↓                                        ↓
+   Post-Restart → Communication Success? → Skip Detection
+       ↓                     ↓
+       |              Communication Fails
+       |                     ↓
+       +----------→ Detect Baud Rate
+                             ↓
+                     Rate Detected?
+                             ↓
+                    Switch to Target (AT+IPR)
+                             ↓
+                 [CHANGE_PERSISTENT=y?] → AT&W
+                             ↓
+                     Initialize Modem
+
+Log Messages
+------------
+
+Success - Smart Default
+~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+   [hl78xx] Checking if modem is ready at target baud rate 921600...
+   [hl78xx] Modem ready at target rate, skipping detection
+   [hl78xx] Baud rate switch not needed
+
+Detection Triggered
+~~~~~~~~~~~~~~~~~~~
+
+::
+
+   [hl78xx] Modem not responding at target rate 921600, starting detection...
+   [hl78xx] Trying baud rate: 9600
+   [hl78xx] Modem responded at 9600 baud
+   [hl78xx] Saving persistent baud rate with AT&W...
+
+Non-Persistent Mode
+~~~~~~~~~~~~~~~~~~~
+
+::
+
+   [hl78xx] Switching baud rate from 9600 to 921600
+   [hl78xx] Non-persistent mode: skipping AT&W
+
+Failure
+~~~~~~~
+
+::
+
+   [hl78xx] Failed to detect modem baud rate
+   [hl78xx] Retrying baud rate detection (attempt 2/3)
+
+Troubleshooting
+---------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Symptom
+     - Likely Cause
+     - Solution
+   * - Failed to detect modem baud rate
+     - Detection list missing rate
+     - Add rates to detection list
+   * - Times out on each rate
+     - Modem not ready
+     - Increase timeout
+   * - Hangs on AT&W
+     - UART mismatch
+     - Fixed: UART reconfigured first
+   * - Rate not persistent
+     - Persistence disabled
+     - Enable ``CHANGE_PERSISTENT``
+
+AT Commands Reference
+---------------------
+
+.. code-block:: bash
+
+   AT+IPR?
+   AT+IPR=115200
+   AT&W
+
+API Functions (Internal)
+------------------------
+
+.. code-block:: c
+
+   int hl78xx_try_baudrate(struct hl78xx_data *data, uint32_t baudrate);
+   int hl78xx_detect_current_baudrate(struct hl78xx_data *data);
+   int hl78xx_switch_baudrate(struct hl78xx_data *data, uint32_t target_baudrate);
+
+Performance Tips
+----------------
+
+1. Enable smart flags for fastest boot
+2. Order detection list by likelihood
+3. Use shorter timeouts in known environments
+4. Enable persistence to avoid re-detection
+5. Use ``AUTOBAUD_AT_BOOT`` only if timing is controlled
+
+Compatibility
+-------------
+
+- HL7812 / HL7800
+- Zephyr 4.4+
+- All supported boards
+- Smart detection reduces boot from ~20 s to ~50-100 ms
+
+License
+-------
+
+Copyright (c) 2025 Netfeasa Ltd.
+
+SPDX-License-Identifier: Apache-2.0
+
+----
+
+**Last Updated:** 2025-12-06

--- a/boards/shields/swir_hl78xx_ev_kit/doc/index.rst
+++ b/boards/shields/swir_hl78xx_ev_kit/doc/index.rst
@@ -14,12 +14,12 @@ for sending AT commands to the HL78 module and initiating data transmission.
    :align: center
    :alt: HL/RC Module Evaluation Kit Shield Shield
 
-   HL/RC Module Evaluation Kit Shield Shield (Credit: Sierrra Wireless)
+   HL/RC Module Evaluation Kit Shield Shield (Credit: Sierra Wireless)
 
 More information about the shield can be found at the `HL/RC Module Evaluation Kit Shield guide website`_.
 
-Pins Assignment of HL/RC Module Evaluation Kit Shield Shield
-============================================================
+Pins Assignment of HL/RC Module Evaluation Kit Shield
+=====================================================
 +--------------------------+----------------------------------------------------------+
 | Shield Connector Pin     | Function                                                 |
 +==========================+==========================================================+
@@ -67,6 +67,16 @@ example:
    :shield: swir_hl78xx_ev_kit
    :goals: build
 
+Documentation
+*************
+
+Automatic baud rate detection:
+==============================
+
+For full details, see :ref:`hl78xx_auto_baudrate`.
+
+For a condensed overview, see :ref:`hl78xx_auto_baudrate_quick_reference`.
+
 References
 **********
 
@@ -76,4 +86,4 @@ References
    https://source.sierrawireless.com/resources/airprime/development_kits/hl78xx-hl7900-development-kit-guide/
 
 .. _HL/RC Module Evaluation Kit Shield specification website:
-   https://info.sierrawireless.com/iot-modules-evaluation-kit#guide-for-the-hl78-series-evaluation-kit
+   https://info.sierrawireless.com/iot-modules-evaluation-kit#guide-for-the-hl78-series-evaluation-kit/

--- a/drivers/modem/hl78xx/Kconfig.hl78xx
+++ b/drivers/modem/hl78xx/Kconfig.hl78xx
@@ -78,6 +78,143 @@ config MODEM_AT_SHELL_RESPONSE_MAX_SIZE
 
 endif # MODEM_HL78XX_AT_SHELL
 
+menuconfig MODEM_HL78XX_AUTO_BAUDRATE
+	bool "Auto Baud Rate Detection and Switching"
+	select UART_USE_RUNTIME_CONFIGURE if SOC_SERIES_NRF52X
+	help
+	  Enable automatic baud rate detection and switching for the HL78xx modem.
+	  The driver will attempt to detect the modem's current baud rate and
+	  switch to the configured target baud rate using AT+IPR command.
+
+if MODEM_HL78XX_AUTO_BAUDRATE
+
+choice MODEM_HL78XX_TARGET_BAUDRATE
+	prompt "Target UART Baud Rate"
+	default MODEM_HL78XX_TARGET_BAUDRATE_115200
+	help
+	  Select the target baud rate for communication with the modem.
+	  The driver will configure the modem to use this baud rate after detection.
+
+config MODEM_HL78XX_TARGET_BAUDRATE_9600
+	bool "9600"
+	help
+	  Set modem baud rate to 9600 bps
+
+config MODEM_HL78XX_TARGET_BAUDRATE_19200
+	bool "19200"
+	help
+	  Set modem baud rate to 19200 bps
+
+config MODEM_HL78XX_TARGET_BAUDRATE_38400
+	bool "38400"
+	help
+	  Set modem baud rate to 38400 bps
+
+config MODEM_HL78XX_TARGET_BAUDRATE_57600
+	bool "57600"
+	help
+	  Set modem baud rate to 57600 bps
+
+config MODEM_HL78XX_TARGET_BAUDRATE_115200
+	bool "115200"
+	help
+	  Set modem baud rate to 115200 bps (default)
+
+config MODEM_HL78XX_TARGET_BAUDRATE_230400
+	bool "230400"
+	help
+	  Set modem baud rate to 230400 bps
+
+config MODEM_HL78XX_TARGET_BAUDRATE_460800
+	bool "460800"
+	help
+	  Set modem baud rate to 460800 bps
+
+config MODEM_HL78XX_TARGET_BAUDRATE_921600
+	bool "921600"
+	help
+	  Set modem baud rate to 921600 bps
+
+config MODEM_HL78XX_TARGET_BAUDRATE_3000000
+	bool "3000000"
+	depends on MODEM_HL78XX_12
+	help
+	  Set modem baud rate to 3000000 bps
+endchoice
+
+config MODEM_HL78XX_TARGET_BAUDRATE_VALUE
+	int
+	default 9600 if MODEM_HL78XX_TARGET_BAUDRATE_9600
+	default 19200 if MODEM_HL78XX_TARGET_BAUDRATE_19200
+	default 38400 if MODEM_HL78XX_TARGET_BAUDRATE_38400
+	default 57600 if MODEM_HL78XX_TARGET_BAUDRATE_57600
+	default 115200 if MODEM_HL78XX_TARGET_BAUDRATE_115200
+	default 230400 if MODEM_HL78XX_TARGET_BAUDRATE_230400
+	default 460800 if MODEM_HL78XX_TARGET_BAUDRATE_460800
+	default 921600 if MODEM_HL78XX_TARGET_BAUDRATE_921600
+	default 3000000 if MODEM_HL78XX_TARGET_BAUDRATE_3000000
+
+config MODEM_HL78XX_AUTOBAUD_DETECTION_BAUDRATES
+	string "Baud rates to try during auto-detection (comma-separated)"
+	default "115200,9600,57600,38400,19200"
+	help
+	  Comma-separated list of baud rates to try when auto-detecting
+	  the modem's current baud rate. The driver will try each rate
+	  in order until it successfully communicates with the modem.
+	  Common baud rates: 9600, 19200, 38400, 57600, 115200
+
+config MODEM_HL78XX_AUTOBAUD_TIMEOUT
+	int "Timeout for each baud rate detection attempt (seconds)"
+	default 4
+	range 1 120
+	help
+	  Maximum time to wait for a response from the modem when trying
+	  a specific baud rate during auto-detection.
+
+config MODEM_HL78XX_AUTOBAUD_RETRY_COUNT
+	int "Number of retries for baud rate detection"
+	default 3
+	range 1 10
+	help
+	  Number of times to retry baud rate detection before giving up.
+
+config MODEM_HL78XX_AUTOBAUD_CHANGE_PERSISTENT
+	bool "Save detected baud rate persistently"
+	default y
+	help
+	  Enable this option to save the configuration to the modem non-volatile memory,
+	  otherwise it will revert to previous setting on power cycle.
+	  Highly recommended to enable this option to detect unexpected modem reboots
+	  and quick recovery.
+
+	  Baudrate change will be permanent across power cycles.
+	  NOTE: Changing phone functionality (AT+CFUN) does reset baud rate to default.
+
+config MODEM_HL78XX_AUTOBAUD_START_WITH_TARGET_BAUDRATE
+	bool "Start auto baud rate detection with target baud rate"
+	default y
+	help
+	  Enable this option to start the auto baud rate detection process
+	  by first attempting communication at the configured target baud rate.
+	  This can speed up detection if the modem is already set to the target rate.
+
+config MODEM_HL78XX_AUTOBAUD_ONLY_IF_COMMS_FAIL
+	bool "Only perform auto baud rate detection on communication failure"
+	default y
+	help
+	  Enable this option to perform auto baud rate detection only
+	  if initial uart communication with the modem at the configured
+	  target baud rate fails.
+
+config MODEM_HL78XX_AUTOBAUD_AT_BOOT
+	bool "Perform auto baud rate detection at boot (skip KSUP wait)"
+	help
+	  When enabled, the driver will immediately perform auto baud rate detection
+	  as soon as the modem is powered up, without waiting for the KSUP URC
+	  (startup ready indication).
+
+endif # MODEM_HL78XX_AUTO_BAUDRATE
+
 choice MODEM_HL78XX_ADDRESS_FAMILY
 	prompt "IP Address family"
 	default MODEM_HL78XX_ADDRESS_FAMILY_IPV4V6
@@ -874,13 +1011,17 @@ config MODEM_HL78XX_DEV_RESET_PULSE_DURATION_MS
 
 config MODEM_HL78XX_DEV_STARTUP_TIME_MS
 	int "Wait before assuming the device is ready."
-	default 120
+	default 2000 if MODEM_HL78XX_AUTOBAUD_AT_BOOT
+	default 120 if !MODEM_HL78XX_AUTOBAUD_AT_BOOT
 	help
 	  The expected delay time (in milliseconds) the modem needs to fully power on
 	  and become operational.This delay before the driver opens the UART pipe
 	  and attaches the chat layer. The value must be long enough for the driver
 	  startup code to initialize, but short enough to ensure the pipe is ready
 	  before the modem sends its first URCs during boot.
+	  BUT,
+	  if auto baudrate detection at boot is enabled,
+	  a longer delay is recommended to allow the modem to complete its boot sequence.
 
 config MODEM_HL78XX_DEV_SHUTDOWN_TIME_MS
 	int "Wait before assuming the device is completely off."

--- a/drivers/modem/hl78xx/hl78xx.c
+++ b/drivers/modem/hl78xx/hl78xx.c
@@ -176,6 +176,8 @@ static const char *hl78xx_event_str(enum hl78xx_event event)
 #endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE */
 	case MODEM_HL78XX_EVENT_MDM_RESTART:
 		return "modem unexpected restart";
+	case MODEM_HL78XX_EVENT_AT_CMD_TIMEOUT:
+		return "AT command timeout";
 	default:
 		return "unknown event";
 	}
@@ -1022,6 +1024,10 @@ static void hl78xx_await_power_on_event_handler(struct hl78xx_data *data, enum h
 		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_INIT_SCRIPT);
 		break;
 
+	case MODEM_HL78XX_EVENT_AT_CMD_TIMEOUT:
+		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_INIT_FAIL_DIAGNOSTIC_SCRIPT);
+		break;
+
 	default:
 		break;
 	}
@@ -1077,6 +1083,7 @@ static void hl78xx_run_init_fail_script_event_handler(struct hl78xx_data *data,
 		}
 		break;
 	case MODEM_HL78XX_EVENT_TIMEOUT:
+	case MODEM_HL78XX_EVENT_AT_CMD_TIMEOUT:
 		if (hl78xx_gpio_is_enabled(&config->mdm_gpio_pwr_on)) {
 			hl78xx_enter_state(data, MODEM_HL78XX_STATE_POWER_ON_PULSE);
 			break;

--- a/drivers/modem/hl78xx/hl78xx.c
+++ b/drivers/modem/hl78xx/hl78xx.c
@@ -1141,7 +1141,8 @@ static int hl78xx_on_rat_cfg_script_state_enter(struct hl78xx_data *data)
 	if (modem_require_restart) {
 		HL78XX_LOG_DBG("Modem restart required to apply new RAT/Band settings");
 		ret = modem_dynamic_cmd_send(data, NULL, cmd_restart, strlen(cmd_restart),
-					     hl78xx_get_ok_match(), 1, false);
+					     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
+					     MDM_CMD_TIMEOUT, false);
 		if (ret < 0) {
 			goto error;
 		}

--- a/drivers/modem/hl78xx/hl78xx.c
+++ b/drivers/modem/hl78xx/hl78xx.c
@@ -768,7 +768,7 @@ int modem_dynamic_cmd_send(
 			modem_chat_script_callback script_user_callback,
 			const uint8_t *cmd, uint16_t cmd_size,
 			const struct modem_chat_match *response_matches, uint16_t matches_size,
-			bool user_cmd
+			uint16_t response_timeout, bool user_cmd
 		)
 {
 	int ret = 0;
@@ -784,7 +784,7 @@ int modem_dynamic_cmd_send(
 		.request_size = cmd_size,
 		.response_matches = response_matches,
 		.response_matches_size = matches_size,
-		.timeout = 1000,
+		.timeout = 0, /* Has no effect */
 	};
 	struct modem_chat_script chat_script = {
 		.name = "dynamic_script",
@@ -793,7 +793,7 @@ int modem_dynamic_cmd_send(
 		.abort_matches = hl78xx_get_abort_matches(),
 		.abort_matches_size = hl78xx_get_abort_matches_size(),
 		.callback = script_user_callback,
-		.timeout = 1000
+		.timeout = response_timeout, /* overall script timeout */
 	};
 
 	ret = k_mutex_lock(&data->tx_lock, K_NO_WAIT);

--- a/drivers/modem/hl78xx/hl78xx.h
+++ b/drivers/modem/hl78xx/hl78xx.h
@@ -113,6 +113,9 @@
  */
 #define WDSI_USER_INITIATED_CONNECTION_START_CMD "AT+WDSS=1,1"
 #define WDSI_USER_INITIATED_CONNECTION_STOP_CMD  "AT+WDSS=1,0"
+/* Baud rate commands */
+#define GET_BAUDRATE_CMD                         "AT+IPR?"
+#define SET_BAUDRATE_CMD_FMT                     "AT+IPR=%d"
 
 /* Helper macros */
 #define ATOI(s_, value_, desc_) modem_atoi(s_, value_, desc_, __func__)
@@ -184,6 +187,7 @@ enum hl78xx_event {
 	MODEM_HL78XX_EVENT_WDSI_FIRMWARE_INSTALL_SUCCEEDED,
 	MODEM_HL78XX_EVENT_WDSI_FIRMWARE_INSTALL_FAILED,
 #endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE */
+	MODEM_HL78XX_EVENT_AT_CMD_TIMEOUT,
 	MODEM_HL78XX_EVENT_COUNT
 };
 
@@ -325,6 +329,13 @@ struct hl78xx_wdsi_status {
 
 #endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE */
 
+struct hl78xx_modem_uart_status {
+	uint32_t current_baudrate;
+#ifdef CONFIG_MODEM_HL78XX_AUTO_BAUDRATE
+	uint32_t target_baudrate;
+	uint8_t baudrate_detection_retry;
+#endif /* CONFIG_MODEM_HL78XX_AUTO_BAUDRATE */
+};
 struct modem_status {
 	struct registration_status registration;
 	int16_t rssi;
@@ -343,6 +354,7 @@ struct modem_status {
 #ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
 	struct hl78xx_wdsi_status wdsi;
 #endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE */
+	struct hl78xx_modem_uart_status uart;
 };
 
 struct modem_gpio_callbacks {

--- a/drivers/modem/hl78xx/hl78xx.h
+++ b/drivers/modem/hl78xx/hl78xx.h
@@ -73,6 +73,7 @@
 #define TERMINATION_PATTERN "+++"
 #define CONNECT_STRING      "CONNECT"
 #define CME_ERROR_STRING    "+CME ERROR: "
+#define ERROR_STRING        "ERROR"
 #define OK_STRING           "OK"
 
 /* RAT (Radio Access Technology) commands */

--- a/drivers/modem/hl78xx/hl78xx.h
+++ b/drivers/modem/hl78xx/hl78xx.h
@@ -25,8 +25,8 @@
 #include "../modem_context.h"
 #include "../modem_socket.h"
 #include <stdint.h>
-
-#define MDM_CMD_TIMEOUT                      (10)  /*K_SECONDS*/
+/* clang-format off */
+#define MDM_CMD_TIMEOUT                      (40)  /*K_SECONDS*/
 #define MDM_DNS_TIMEOUT                      (70)  /*K_SECONDS*/
 #define MDM_CELL_BAND_SEARCH_TIMEOUT         (60)  /*K_SECONDS*/
 #define MDM_CMD_CONN_TIMEOUT                 (120) /*K_SECONDS*/
@@ -122,6 +122,8 @@
 	COND_CODE_1(CONFIG_MODEM_HL78XX_LOG_CONTEXT_VERBOSE_DEBUG, \
 		    (LOG_DBG(str, ##__VA_ARGS__)), \
 		    ((void)0))
+
+/* clang-format on */
 
 /* HL78XX States */
 enum hl78xx_state {
@@ -473,13 +475,14 @@ void iface_status_work_cb(struct hl78xx_data *data,
  * @param cmd_len Length of the command in bytes.
  * @param response_matches Array of expected response match patterns.
  * @param matches_size Number of elements in the response_matches array.
+ * @param response_timeout Response timeout in seconds.
  *
  * @return 0 on success, negative errno code on failure.
  */
 int modem_dynamic_cmd_send(struct hl78xx_data *data,
 			   modem_chat_script_callback script_user_callback, const uint8_t *cmd,
 			   uint16_t cmd_len, const struct modem_chat_match *response_matches,
-			   uint16_t matches_size, bool user_cmd);
+			   uint16_t matches_size, uint16_t response_timeout, bool user_cmd);
 
 #define HASH_MULTIPLIER 37
 /**

--- a/drivers/modem/hl78xx/hl78xx_apis.c
+++ b/drivers/modem/hl78xx/hl78xx_apis.c
@@ -266,7 +266,8 @@ int hl78xx_api_func_set_phone_functionality(const struct device *dev,
 	struct hl78xx_data *data = (struct hl78xx_data *)dev->data;
 	/* configure modem functionality with/without restart  */
 	snprintf(cmd_string, sizeof(cmd_string), "AT+CFUN=%d,%d", functionality, reset);
-	return hl78xx_send_cmd(data, cmd_string, NULL, hl78xx_get_ok_match(), 1);
+	return hl78xx_send_cmd(data, cmd_string, NULL, hl78xx_get_ok_match(),
+			       hl78xx_get_ok_match_size());
 }
 
 int hl78xx_api_func_get_phone_functionality(const struct device *dev,
@@ -275,7 +276,8 @@ int hl78xx_api_func_get_phone_functionality(const struct device *dev,
 	const char *cmd_string = GET_FULLFUNCTIONAL_MODE_CMD;
 	struct hl78xx_data *data = (struct hl78xx_data *)dev->data;
 	/* get modem phone functionality */
-	return hl78xx_send_cmd(data, cmd_string, NULL, hl78xx_get_ok_match(), 1);
+	return hl78xx_send_cmd(data, cmd_string, NULL, hl78xx_get_ok_match(),
+			       hl78xx_get_ok_match_size());
 }
 
 int hl78xx_api_func_modem_dynamic_cmd_send(const struct device *dev, const char *cmd,
@@ -300,7 +302,8 @@ int hl78xx_start_airvantage_dm_session(const struct device *dev)
 
 	ret = modem_dynamic_cmd_send(data, NULL, WDSI_USER_INITIATED_CONNECTION_START_CMD,
 				     strlen(WDSI_USER_INITIATED_CONNECTION_START_CMD),
-				     hl78xx_get_ok_match(), 1, false);
+				     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
+				     MDM_CMD_TIMEOUT, false);
 	if (ret < 0) {
 		LOG_ERR("Start DM session error %d", ret);
 		return ret;
@@ -315,7 +318,8 @@ int hl78xx_stop_airvantage_dm_session(const struct device *dev)
 
 	ret = modem_dynamic_cmd_send(data, NULL, WDSI_USER_INITIATED_CONNECTION_STOP_CMD,
 				     strlen(WDSI_USER_INITIATED_CONNECTION_STOP_CMD),
-				     hl78xx_get_ok_match(), 1, false);
+				     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
+				     MDM_CMD_TIMEOUT, false);
 	if (ret < 0) {
 		LOG_ERR("Stop DM session error %d", ret);
 		return ret;

--- a/drivers/modem/hl78xx/hl78xx_apis.c
+++ b/drivers/modem/hl78xx/hl78xx_apis.c
@@ -28,7 +28,7 @@ static int hl78xx_send_cmd(struct hl78xx_data *data, const char *cmd,
 		return -EINVAL;
 	}
 	return modem_dynamic_cmd_send(data, chat_cb, cmd, (uint16_t)strlen(cmd), matches,
-				      match_count, true);
+				      match_count, MDM_CMD_TIMEOUT, true);
 }
 
 int hl78xx_api_func_get_signal(const struct device *dev, const enum cellular_signal_type type,
@@ -292,7 +292,7 @@ int hl78xx_api_func_modem_dynamic_cmd_send(const struct device *dev, const char 
 	}
 	/* respect provided matches_size and serialize modem access */
 	return modem_dynamic_cmd_send(data, NULL, cmd, cmd_size, response_matches, matches_size,
-				      true);
+				      MDM_CMD_TIMEOUT, true);
 }
 #ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
 int hl78xx_start_airvantage_dm_session(const struct device *dev)

--- a/drivers/modem/hl78xx/hl78xx_apis.c
+++ b/drivers/modem/hl78xx/hl78xx_apis.c
@@ -179,6 +179,9 @@ int hl78xx_api_func_get_modem_info_vendor(const struct device *dev,
 		safe_strncpy(info, (const char *)data->identity.serial_number,
 			     MIN(size, sizeof(data->identity.serial_number)));
 		break;
+	case HL78XX_MODEM_INFO_CURRENT_BAUD_RATE:
+		*(uint32_t *)info = data->status.uart.current_baudrate;
+		break;
 	default:
 		break;
 	}

--- a/drivers/modem/hl78xx/hl78xx_cfg.c
+++ b/drivers/modem/hl78xx/hl78xx_cfg.c
@@ -35,7 +35,8 @@ int hl78xx_rat_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 		char cmd_kselq[] = "AT+KSELACQ=0," CONFIG_MODEM_HL78XX_AUTORAT_PRL_PROFILES;
 
 		ret = modem_dynamic_cmd_send(data, NULL, cmd_kselq, strlen(cmd_kselq),
-					     hl78xx_get_ok_match(), 1, false);
+					     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
+					     MDM_CMD_TIMEOUT, false);
 		if (ret < 0) {
 			goto error;
 		} else {
@@ -52,8 +53,8 @@ int hl78xx_rat_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 	if (data->kselacq_data.rat1 != 0 && data->kselacq_data.rat2 != 0 &&
 	    data->kselacq_data.rat3 != 0) {
 		ret = modem_dynamic_cmd_send(data, NULL, cmd_kselq_disable,
-					     strlen(cmd_kselq_disable), hl78xx_get_ok_match(), 1,
-					     false);
+					     strlen(cmd_kselq_disable), hl78xx_get_ok_match(),
+					     hl78xx_get_ok_match_size(), MDM_CMD_TIMEOUT, false);
 		if (ret < 0) {
 			goto error;
 		}
@@ -97,7 +98,8 @@ int hl78xx_rat_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 
 	if (*rat_request != data->status.registration.rat_mode) {
 		ret = modem_dynamic_cmd_send(data, NULL, cmd_set_rat, strlen(cmd_set_rat),
-					     hl78xx_get_ok_match(), 1, false);
+					     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
+					     MDM_CMD_TIMEOUT, false);
 		if (ret < 0) {
 			goto error;
 		} else {
@@ -162,8 +164,9 @@ int hl78xx_band_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 			char cmd_bnd[80] = {0};
 
 			snprintf(cmd_bnd, sizeof(cmd_bnd), "AT+KBNDCFG=%d,%s", rat, bnd_bitmap);
-			ret = modem_dynamic_cmd_send(data, NULL, cmd_bnd, strlen(cmd_bnd),
-						     hl78xx_get_ok_match(), 1, false);
+			ret = modem_dynamic_cmd_send(
+				data, NULL, cmd_bnd, strlen(cmd_bnd), hl78xx_get_ok_match(),
+				hl78xx_get_ok_match_size(), MDM_CMD_TIMEOUT, false);
 			if (ret < 0) {
 				goto error;
 			} else {
@@ -205,20 +208,23 @@ int hl78xx_set_apn_internal(struct hl78xx_data *data, const char *apn, uint16_t 
 		 apn);
 
 	ret = modem_dynamic_cmd_send(data, NULL, cmd_string, strlen(cmd_string),
-				     hl78xx_get_ok_match(), 1, false);
+				     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
+				     MDM_CMD_TIMEOUT, false);
 	if (ret < 0) {
 		goto error;
 	}
 	snprintk(cmd_string, cmd_max_len,
 		 "AT+KCNXCFG=1,\"GPRS\",\"%s\",,,\"" MODEM_HL78XX_ADDRESS_FAMILY "\"", apn);
 	ret = modem_dynamic_cmd_send(data, NULL, cmd_string, strlen(cmd_string),
-				     hl78xx_get_ok_match(), 1, false);
+				     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
+				     MDM_CMD_TIMEOUT, false);
 	if (ret < 0) {
 		goto error;
 	}
 #ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
 	ret = modem_dynamic_cmd_send(data, NULL, "AT+WDSS=2,1", strlen("AT+WDSS=2,1"),
-				     hl78xx_get_ok_match(), 1, false);
+				     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
+				     MDM_CMD_TIMEOUT, false);
 	if (ret < 0) {
 		goto error;
 	}
@@ -245,7 +251,8 @@ int hl78xx_gsm_pdp_activate(struct hl78xx_data *data)
 	}
 
 	ret = modem_dynamic_cmd_send(data, NULL, cmd_activate_pdp, strlen(cmd_activate_pdp),
-				     hl78xx_get_ok_match(), 1, false);
+				     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
+				     MDM_CMD_TIMEOUT, false);
 	if (ret < 0) {
 		LOG_ERR("GSM PDP activation failed: %d", ret);
 		return ret;

--- a/drivers/modem/hl78xx/hl78xx_cfg.c
+++ b/drivers/modem/hl78xx/hl78xx_cfg.c
@@ -21,6 +21,8 @@ LOG_MODULE_DECLARE(hl78xx_dev);
 #define IMSI_PREFIX_LEN             6
 #define MAX_BANDS                   32
 #define MDM_APN_FULL_STRING_MAX_LEN 256
+/* Delay after AT+IPR command for new rate to take effect */
+#define BAUDRATE_SWITCH_DELAY_MS    2500
 
 int hl78xx_rat_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 		   enum hl78xx_cell_rat_mode *rat_request)
@@ -649,3 +651,194 @@ void hl78xx_extract_essential_part_apn(const char *full_apn, char *essential_apn
 		essential_apn[max_len - 1] = '\0';
 	}
 }
+
+int hl78xx_get_uart_config(struct hl78xx_data *data)
+{
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	struct uart_config uart_cfg;
+	int ret;
+	/* Get current UART configuration */
+	ret = uart_config_get(config->uart, &uart_cfg);
+	if (ret < 0) {
+		LOG_ERR("Failed to get UART config: %d", ret);
+		return ret;
+	}
+	data->status.uart.current_baudrate = uart_cfg.baudrate;
+	return 0;
+}
+
+#ifdef CONFIG_MODEM_HL78XX_AUTO_BAUDRATE
+
+int configure_uart_for_auto_baudrate(struct hl78xx_data *data, uint32_t baudrate)
+{
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	struct uart_config uart_cfg;
+	int ret;
+
+	/* Get current UART configuration */
+	ret = uart_config_get(config->uart, &uart_cfg);
+	if (ret < 0) {
+		LOG_ERR("Failed to get UART config: %d", ret);
+		return ret;
+	}
+
+	/* Update baud rate */
+	uart_cfg.baudrate = baudrate;
+	LOG_INF("Trying baud rate: %d", baudrate);
+	/* Apply new UART configuration */
+	ret = uart_configure(config->uart, &uart_cfg);
+	if (ret < 0) {
+		LOG_ERR("Failed to set UART baud rate to %d: %d", baudrate, ret);
+		return ret;
+	}
+
+	/* Give the modem time to stabilize */
+	k_sleep(K_MSEC(50));
+	return 0;
+}
+
+int hl78xx_try_baudrate(struct hl78xx_data *data, uint32_t baudrate)
+{
+	int ret;
+	/* Configure UART to the target baud rate */
+	ret = configure_uart_for_auto_baudrate(data, baudrate);
+	if (ret < 0) {
+		return ret;
+	}
+	/* Try to send AT command and wait for response */
+	const char *test_cmd = "AT";
+
+	ret = modem_dynamic_cmd_send(data, NULL, test_cmd, strlen(test_cmd),
+				     hl78xx_get_sockets_allow_matches(),
+				     hl78xx_get_sockets_allow_matches_size(),
+				     CONFIG_MODEM_HL78XX_AUTOBAUD_TIMEOUT, false);
+
+	if (ret == 0) {
+		LOG_INF("Modem responded at %d baud", baudrate);
+		data->status.uart.current_baudrate = baudrate;
+		return 0;
+	}
+
+	return -ENOENT;
+}
+
+int hl78xx_detect_current_baudrate(struct hl78xx_data *data)
+{
+	const char *baudrate_list = CONFIG_MODEM_HL78XX_AUTOBAUD_DETECTION_BAUDRATES;
+	char baudrate_str[16];
+	const char *ptr = baudrate_list;
+	int idx = 0;
+	int ret;
+
+	LOG_INF("Starting baud rate detection...");
+
+	while (*ptr != '\0') {
+		/* Extract baud rate from string */
+		while (*ptr == ' ' || *ptr == ',') {
+			ptr++;
+		}
+
+		if (*ptr == '\0') {
+			break;
+		}
+
+		idx = 0;
+		while (*ptr >= '0' && *ptr <= '9' && idx < sizeof(baudrate_str) - 1) {
+			baudrate_str[idx++] = *ptr++;
+		}
+		baudrate_str[idx] = '\0';
+
+		if (idx > 0) {
+			uint32_t baudrate = (uint32_t)strtol(baudrate_str, NULL, 10);
+
+			LOG_DBG("Trying baud rate: %d", baudrate);
+			ret = hl78xx_try_baudrate(data, baudrate);
+			if (ret == 0) {
+				return 0;
+			}
+		}
+	}
+
+	LOG_ERR("Failed to detect modem baud rate");
+	return -ENOENT;
+}
+
+int hl78xx_switch_baudrate(struct hl78xx_data *data, uint32_t target_baudrate)
+{
+	char cmd_buf[32];
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	struct uart_config uart_cfg;
+	int ret;
+
+	if (data->status.uart.current_baudrate == target_baudrate) {
+		LOG_INF("Already at target baud rate %d", target_baudrate);
+		return 0;
+	}
+
+	LOG_INF("Switching baud rate from %d to %d", data->status.uart.current_baudrate,
+		target_baudrate);
+
+	/* Send AT+IPR command to set baud rate */
+	snprintf(cmd_buf, sizeof(cmd_buf), SET_BAUDRATE_CMD_FMT, target_baudrate);
+	ret = modem_dynamic_cmd_send(data, NULL, cmd_buf, strlen(cmd_buf), hl78xx_get_ok_match(),
+				     hl78xx_get_ok_match_size(), MDM_CMD_TIMEOUT, false);
+
+	if (ret < 0) {
+		LOG_ERR("Failed to send baud rate change command: %d", ret);
+		return ret;
+	}
+
+	/* Wait for new baud rate to take effect (~2s per AT command guide) */
+	LOG_DBG("Waiting %d ms for modem to apply new baud rate", BAUDRATE_SWITCH_DELAY_MS);
+	k_sleep(K_MSEC(BAUDRATE_SWITCH_DELAY_MS));
+
+	/* Get current UART configuration */
+	ret = uart_config_get(config->uart, &uart_cfg);
+	if (ret < 0) {
+		LOG_ERR("Failed to get UART config: %d", ret);
+		return ret;
+	}
+
+	/* Update to new baud rate */
+	uart_cfg.baudrate = target_baudrate;
+	ret = uart_configure(config->uart, &uart_cfg);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure new baud rate: %d", ret);
+		return ret;
+	}
+
+	/* Wait for UART to stabilize */
+	k_sleep(K_MSEC(50));
+
+	/* Verify communication at new baud rate */
+	const char *test_cmd = "AT";
+
+	ret = modem_dynamic_cmd_send(data, NULL, test_cmd, strlen(test_cmd), hl78xx_get_ok_match(),
+				     hl78xx_get_ok_match_size(),
+				     CONFIG_MODEM_HL78XX_AUTOBAUD_TIMEOUT, false);
+
+	if (ret < 0) {
+		LOG_ERR("Failed to communicate at new baud rate %d", target_baudrate);
+		return ret;
+	}
+
+#ifdef CONFIG_MODEM_HL78XX_AUTOBAUD_CHANGE_PERSISTENT
+	/* Save configuration to non-volatile memory (required per AT command guide) */
+	const char *cmd_save = "AT&W";
+
+	ret = modem_dynamic_cmd_send(data, NULL, cmd_save, strlen(cmd_save), hl78xx_get_ok_match(),
+				     hl78xx_get_ok_match_size(), MDM_CMD_TIMEOUT, false);
+
+	if (ret < 0) {
+		LOG_WRN("Failed to save baud rate to NVRAM: %d (will be temporary)", ret);
+		/* Continue anyway - baud rate is still active for current session */
+	} else {
+		LOG_DBG("Baud rate configuration saved to NVRAM");
+	}
+#endif /* CONFIG_MODEM_HL78XX_AUTOBAUD_CHANGE_PERSISTENT */
+	data->status.uart.current_baudrate = target_baudrate;
+	LOG_INF("Successfully switched to baud rate %d", target_baudrate);
+
+	return 0;
+}
+#endif /* CONFIG_MODEM_HL78XX_AUTO_BAUDRATE */

--- a/drivers/modem/hl78xx/hl78xx_cfg.c
+++ b/drivers/modem/hl78xx/hl78xx_cfg.c
@@ -61,7 +61,7 @@ int hl78xx_rat_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 	}
 	/* Query current rat */
 	ret = modem_dynamic_cmd_send(data, NULL, cmd_ksrat_query, strlen(cmd_ksrat_query),
-				     hl78xx_get_ksrat_match(), 1, false);
+				     hl78xx_get_ksrat_match(), 1, MDM_CMD_TIMEOUT, false);
 	if (ret < 0) {
 		goto error;
 	}

--- a/drivers/modem/hl78xx/hl78xx_cfg.h
+++ b/drivers/modem/hl78xx/hl78xx_cfg.h
@@ -29,6 +29,16 @@ int hl78xx_gsm_pdp_activate(struct hl78xx_data *data);
 
 int hl78xx_set_apn_internal(struct hl78xx_data *data, const char *apn, uint16_t size);
 
+int hl78xx_get_uart_config(struct hl78xx_data *data);
+
+#ifdef CONFIG_MODEM_HL78XX_AUTO_BAUDRATE
+/* Baud rate detection and switching */
+int configure_uart_for_auto_baudrate(struct hl78xx_data *data, uint32_t baudrate);
+int hl78xx_try_baudrate(struct hl78xx_data *data, uint32_t baudrate);
+int hl78xx_detect_current_baudrate(struct hl78xx_data *data);
+int hl78xx_switch_baudrate(struct hl78xx_data *data, uint32_t target_baudrate);
+#endif /* CONFIG_MODEM_HL78XX_AUTO_BAUDRATE */
+
 /**
  * @brief Convert a binary bitmap to a trimmed hexadecimal string.
  *

--- a/drivers/modem/hl78xx/hl78xx_chat.c
+++ b/drivers/modem/hl78xx/hl78xx_chat.c
@@ -186,7 +186,7 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(hl78xx_post_restart_chat_script_cmds,
 );
 
 MODEM_CHAT_SCRIPT_DEFINE(hl78xx_post_restart_chat_script, hl78xx_post_restart_chat_script_cmds,
-			 hl78xx_abort_matches, hl78xx_chat_callback_handler, 1000);
+			 hl78xx_abort_matches, hl78xx_chat_callback_handler, 12);
 
 /* init_fail_script moved from hl78xx.c */
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(init_fail_script_cmds,

--- a/drivers/modem/hl78xx/hl78xx_chat.c
+++ b/drivers/modem/hl78xx/hl78xx_chat.c
@@ -325,6 +325,8 @@ void hl78xx_chat_callback_handler(struct modem_chat *chat, enum modem_chat_scrip
 
 	if (result == MODEM_CHAT_SCRIPT_RESULT_SUCCESS) {
 		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_SCRIPT_SUCCESS);
+	} else if (result == MODEM_CHAT_SCRIPT_RESULT_TIMEOUT) {
+		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_AT_CMD_TIMEOUT);
 	} else {
 		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_SCRIPT_FAILED);
 	}

--- a/drivers/modem/hl78xx/hl78xx_chat.c
+++ b/drivers/modem/hl78xx/hl78xx_chat.c
@@ -252,11 +252,11 @@ MODEM_CHAT_SCRIPT_DEFINE(hl78xx_fota_install_accept_script, hl78xx_fota_install_
  */
 MODEM_CHAT_MATCHES_DEFINE(connect_matches, MODEM_CHAT_MATCH(CONNECT_STRING, "", NULL),
 			  MODEM_CHAT_MATCH(CME_ERROR_STRING, "", NULL),
-			  MODEM_CHAT_MATCH(ERROR_STRING, "", NULL), );
+			  MODEM_CHAT_MATCH(ERROR_STRING, "", NULL));
 MODEM_CHAT_MATCHES_DEFINE(kudpind_allow_match,
 			  MODEM_CHAT_MATCH("+KUDP_IND: ", ",", hl78xx_on_kudpsocket_create),
 			  MODEM_CHAT_MATCH(CME_ERROR_STRING, "", NULL),
-			  MODEM_CHAT_MATCH(ERROR_STRING, "", NULL), );
+			  MODEM_CHAT_MATCH(ERROR_STRING, "", NULL));
 MODEM_CHAT_MATCH_DEFINE(ktcpind_match, "+KTCP_IND: ", ",", hl78xx_on_ktcpind);
 MODEM_CHAT_MATCH_DEFINE(ktcpcfg_match, "+KTCPCFG: ", "", hl78xx_on_ktcpsocket_create);
 MODEM_CHAT_MATCH_DEFINE(cgdcontrdp_match, "+CGCONTRDP: ", ",", hl78xx_on_cgdcontrdp);

--- a/drivers/modem/hl78xx/hl78xx_chat.c
+++ b/drivers/modem/hl78xx/hl78xx_chat.c
@@ -74,7 +74,8 @@ void hl78xx_on_wdsi(struct modem_chat *chat, char **argv, uint16_t argc, void *u
 #endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE */
 MODEM_CHAT_MATCH_DEFINE(hl78xx_ok_match, "OK", "", NULL);
 MODEM_CHAT_MATCHES_DEFINE(hl78xx_allow_match, MODEM_CHAT_MATCH("OK", "", NULL),
-			  MODEM_CHAT_MATCH(CME_ERROR_STRING, "", NULL));
+			  MODEM_CHAT_MATCH(CME_ERROR_STRING, "", NULL),
+			  MODEM_CHAT_MATCH(ERROR_STRING, "", NULL));
 /* clang-format off */
 MODEM_CHAT_MATCHES_DEFINE(hl78xx_unsol_matches,
 			  MODEM_CHAT_MATCH("+KSUP: ", "", hl78xx_on_ksup),
@@ -250,17 +251,16 @@ MODEM_CHAT_SCRIPT_DEFINE(hl78xx_fota_install_accept_script, hl78xx_fota_install_
  * definitions.
  */
 MODEM_CHAT_MATCHES_DEFINE(connect_matches, MODEM_CHAT_MATCH(CONNECT_STRING, "", NULL),
-			  MODEM_CHAT_MATCH(CME_ERROR_STRING, "", NULL));
-MODEM_CHAT_MATCH_DEFINE(kudpind_match, "+KUDP_IND: ", ",", hl78xx_on_kudpsocket_create);
+			  MODEM_CHAT_MATCH(CME_ERROR_STRING, "", NULL),
+			  MODEM_CHAT_MATCH(ERROR_STRING, "", NULL), );
+MODEM_CHAT_MATCHES_DEFINE(kudpind_allow_match,
+			  MODEM_CHAT_MATCH("+KUDP_IND: ", ",", hl78xx_on_kudpsocket_create),
+			  MODEM_CHAT_MATCH(CME_ERROR_STRING, "", NULL),
+			  MODEM_CHAT_MATCH(ERROR_STRING, "", NULL), );
 MODEM_CHAT_MATCH_DEFINE(ktcpind_match, "+KTCP_IND: ", ",", hl78xx_on_ktcpind);
 MODEM_CHAT_MATCH_DEFINE(ktcpcfg_match, "+KTCPCFG: ", "", hl78xx_on_ktcpsocket_create);
 MODEM_CHAT_MATCH_DEFINE(cgdcontrdp_match, "+CGCONTRDP: ", ",", hl78xx_on_cgdcontrdp);
 MODEM_CHAT_MATCH_DEFINE(ktcp_state_match, "+KTCPSTAT: ", ",", NULL);
-
-const struct modem_chat_match *hl78xx_get_sockets_ok_match(void)
-{
-	return &hl78xx_ok_match;
-}
 
 const struct modem_chat_match *hl78xx_get_connect_matches(void)
 {
@@ -284,7 +284,12 @@ size_t hl78xx_get_sockets_allow_matches_size(void)
 
 const struct modem_chat_match *hl78xx_get_kudpind_match(void)
 {
-	return &kudpind_match;
+	return kudpind_allow_match;
+}
+
+size_t hl78xx_get_kudpind_allow_matches_size(void)
+{
+	return (size_t)ARRAY_SIZE(kudpind_allow_match);
 }
 
 const struct modem_chat_match *hl78xx_get_ktcpind_match(void)
@@ -329,6 +334,11 @@ void hl78xx_chat_callback_handler(struct modem_chat *chat, enum modem_chat_scrip
 const struct modem_chat_match *hl78xx_get_ok_match(void)
 {
 	return &hl78xx_ok_match;
+}
+
+size_t hl78xx_get_ok_match_size(void)
+{
+	return 1;
 }
 
 const struct modem_chat_match *hl78xx_get_abort_matches(void)

--- a/drivers/modem/hl78xx/hl78xx_chat.h
+++ b/drivers/modem/hl78xx/hl78xx_chat.h
@@ -33,6 +33,7 @@ void hl78xx_chat_callback_handler(struct modem_chat *chat, enum modem_chat_scrip
  */
 const struct modem_chat_match *hl78xx_get_at_ready_match(void);
 const struct modem_chat_match *hl78xx_get_ok_match(void);
+size_t hl78xx_get_ok_match_size(void);
 const struct modem_chat_match *hl78xx_get_abort_matches(void);
 const struct modem_chat_match *hl78xx_get_unsol_matches(void);
 size_t hl78xx_get_unsol_matches_size(void);
@@ -69,12 +70,12 @@ int hl78xx_run_periodic_script_async(struct hl78xx_data *data);
 const struct modem_chat_match *hl78xx_get_ksrat_match(void);
 
 /* Socket-related chat matches used by the sockets TU */
-const struct modem_chat_match *hl78xx_get_sockets_ok_match(void);
 const struct modem_chat_match *hl78xx_get_connect_matches(void);
 size_t hl78xx_get_connect_matches_size(void);
 const struct modem_chat_match *hl78xx_get_sockets_allow_matches(void);
 size_t hl78xx_get_sockets_allow_matches_size(void);
 const struct modem_chat_match *hl78xx_get_kudpind_match(void);
+size_t hl78xx_get_kudpind_allow_matches_size(void);
 const struct modem_chat_match *hl78xx_get_ktcpind_match(void);
 const struct modem_chat_match *hl78xx_get_ktcpcfg_match(void);
 const struct modem_chat_match *hl78xx_get_cgdcontrdp_match(void);

--- a/drivers/modem/hl78xx/hl78xx_sockets.c
+++ b/drivers/modem/hl78xx/hl78xx_sockets.c
@@ -1179,7 +1179,7 @@ void iface_status_work_cb(struct hl78xx_data *data, modem_chat_script_callback s
 	int ret = 0;
 
 	ret = modem_dynamic_cmd_send(data, script_user_callback, cmd, strlen(cmd),
-				     hl78xx_get_cgdcontrdp_match(), 1, false);
+				     hl78xx_get_cgdcontrdp_match(), 1, MDM_CMD_TIMEOUT, false);
 	if (ret < 0) {
 		LOG_ERR("Failed to send AT+CGCONTRDP command: %d", ret);
 		return;
@@ -1402,7 +1402,7 @@ static int send_tcp_or_tls_config(struct modem_socket *sock, uint16_t dst_port, 
 	snprintk(cmd_buf, sizeof(cmd_buf), "AT+KTCPCFG=1,%d,\"%s\",%u,,,,%d,%s,0", mode,
 		 socket_data->tls.hostname, dst_port, af, mode == 3 ? "0" : "");
 	ret = modem_dynamic_cmd_send(socket_data->mdata_global, NULL, cmd_buf, strlen(cmd_buf),
-				     hl78xx_get_ktcpcfg_match(), 1, false);
+				     hl78xx_get_ktcpcfg_match(), 1, MDM_CMD_TIMEOUT, false);
 	if (ret < 0 ||
 	    socket_data->tcp_conn_status[HL78XX_TCP_STATUS_ID(sock->id)].is_created == false) {
 		LOG_ERR("%s ret:%d", cmd_buf, ret);
@@ -1430,7 +1430,9 @@ static int send_udp_config(const struct net_sockaddr *addr, struct hl78xx_socket
 		 (addr->sa_family - 1), 0);
 
 	ret = modem_dynamic_cmd_send(socket_data->mdata_global, NULL, cmd_buf, strlen(cmd_buf),
-				     hl78xx_get_kudpind_match(), hl78xx_get_kudpind_allow_matches_size(), MDM_CMD_TIMEOUT_MS, false);
+				     hl78xx_get_kudpind_match(),
+				     hl78xx_get_kudpind_allow_matches_size(), MDM_CMD_TIMEOUT,
+				     false);
 	if (ret < 0) {
 		goto error;
 	}
@@ -1493,7 +1495,8 @@ static int socket_close(struct hl78xx_socket_data *socket_data, struct modem_soc
 	}
 	ret = modem_dynamic_cmd_send(socket_data->mdata_global, NULL, buf, strlen(buf),
 				     hl78xx_get_sockets_allow_matches(),
-				     hl78xx_get_sockets_allow_matches_size(), false);
+				     hl78xx_get_sockets_allow_matches_size(), MDM_CMD_TIMEOUT,
+				     false);
 	if (ret < 0) {
 		LOG_ERR("%s ret:%d", buf, ret);
 	}
@@ -1516,7 +1519,8 @@ static int socket_delete(struct hl78xx_socket_data *socket_data, struct modem_so
 	snprintk(buf, sizeof(buf), "AT+KTCPDEL=%d", sock->id);
 	ret = modem_dynamic_cmd_send(socket_data->mdata_global, NULL, buf, strlen(buf),
 				     hl78xx_get_sockets_allow_matches(),
-				     hl78xx_get_sockets_allow_matches_size(), false);
+				     hl78xx_get_sockets_allow_matches_size(), MDM_CMD_TIMEOUT,
+				     false);
 	if (ret < 0) {
 		LOG_ERR("%s ret:%d", buf, ret);
 	}
@@ -1649,7 +1653,7 @@ static int offload_connect(void *obj, const struct net_sockaddr *addr, net_sockl
 	/* send connect command */
 	snprintk(cmd_buf, sizeof(cmd_buf), "AT+KTCPCNX=%d", sock->id);
 	ret = modem_dynamic_cmd_send(socket_data->mdata_global, NULL, cmd_buf, strlen(cmd_buf),
-				     hl78xx_get_ktcpind_match(), 1, false);
+				     hl78xx_get_ktcpind_match(), 1, MDM_CMD_TIMEOUT, false);
 	if (ret < 0 ||
 	    socket_data->tcp_conn_status[HL78XX_TCP_STATUS_ID(sock->id)].is_connected == false) {
 		sock->is_connected = false;
@@ -1784,7 +1788,7 @@ static void check_tcp_state_if_needed(struct hl78xx_socket_data *socket_data,
 	    sock && sock->ip_proto == NET_IPPROTO_TCP) {
 		modem_dynamic_cmd_send(socket_data->mdata_global, NULL, check_ktcp_stat,
 				       strlen(check_ktcp_stat), hl78xx_get_ktcp_state_match(), 1,
-				       true);
+				       MDM_CMD_TIMEOUT, true);
 	}
 }
 
@@ -2016,7 +2020,7 @@ static ssize_t send_socket_data(void *obj, struct hl78xx_socket_data *socket_dat
 	}
 	ret = modem_dynamic_cmd_send(socket_data->mdata_global, NULL, cmd_buf, strlen(cmd_buf),
 				     (const struct modem_chat_match *)hl78xx_get_connect_matches(),
-				     hl78xx_get_connect_matches_size(), false);
+				     hl78xx_get_connect_matches_size(), MDM_CMD_TIMEOUT, false);
 	if (ret < 0 || socket_data->socket_data_error) {
 		hl78xx_set_errno_from_code(ret);
 		ret = -1;
@@ -2417,7 +2421,7 @@ static ssize_t hl78xx_send_cert(struct hl78xx_socket_data *socket_data, const ch
 	}
 	ret = modem_dynamic_cmd_send(socket_data->mdata_global, NULL, send_buf, strlen(send_buf),
 				     (const struct modem_chat_match *)hl78xx_get_connect_matches(),
-				     hl78xx_get_connect_matches_size(), false);
+				     hl78xx_get_connect_matches_size(), MDM_CMD_TIMEOUT, false);
 	if (ret < 0) {
 		LOG_ERR("Error sending AT command %d", ret);
 	}

--- a/drivers/modem/hl78xx/hl78xx_sockets.c
+++ b/drivers/modem/hl78xx/hl78xx_sockets.c
@@ -1430,7 +1430,7 @@ static int send_udp_config(const struct net_sockaddr *addr, struct hl78xx_socket
 		 (addr->sa_family - 1), 0);
 
 	ret = modem_dynamic_cmd_send(socket_data->mdata_global, NULL, cmd_buf, strlen(cmd_buf),
-				     hl78xx_get_kudpind_match(), 1, false);
+				     hl78xx_get_kudpind_match(), hl78xx_get_kudpind_allow_matches_size(), MDM_CMD_TIMEOUT_MS, false);
 	if (ret < 0) {
 		goto error;
 	}
@@ -1998,9 +1998,8 @@ static int transmit_regular_data(struct hl78xx_socket_data *socket_data, const c
 
 /* send binary data via the +KUDPSND/+KTCPSND commands */
 static ssize_t send_socket_data(void *obj, struct hl78xx_socket_data *socket_data,
-				const struct net_sockaddr *dst_addr,
-				const char *buf, size_t buf_len,
-				k_timeout_t timeout)
+				const struct net_sockaddr *dst_addr, const char *buf,
+				size_t buf_len, k_timeout_t timeout)
 {
 	struct modem_socket *sock = (struct modem_socket *)obj;
 	char cmd_buf[82] = {0}; /* AT+KUDPSND/KTCP=,IP,PORT,LENGTH */
@@ -2030,8 +2029,8 @@ static ssize_t send_socket_data(void *obj, struct hl78xx_socket_data *socket_dat
 		goto cleanup;
 	}
 	modem_chat_attach(&socket_data->mdata_global->chat, socket_data->mdata_global->uart_pipe);
-	ret = modem_dynamic_cmd_send(socket_data->mdata_global, NULL, "", 0,
-				     hl78xx_get_sockets_ok_match(), 1, false);
+	ret = modem_dynamic_cmd_send(socket_data->mdata_global, NULL, "", 0, hl78xx_get_ok_match(),
+				     hl78xx_get_ok_match_size(), MDM_CMD_TIMEOUT, false);
 	if (ret < 0) {
 		LOG_ERR("Final confirmation failed: %d", ret);
 		goto cleanup;
@@ -2373,9 +2372,10 @@ static int hl78xx_configure_chipper_suit(struct hl78xx_socket_data *socket_data)
 {
 	const char *cmd_chipper_suit = "AT+KSSLCRYPTO=0,8,1,8192,4,4,3,0";
 
-	return modem_dynamic_cmd_send(
-		socket_data->mdata_global, NULL, cmd_chipper_suit, strlen(cmd_chipper_suit),
-		(const struct modem_chat_match *)hl78xx_get_ok_match(), 1, false);
+	return modem_dynamic_cmd_send(socket_data->mdata_global, NULL, cmd_chipper_suit,
+				      strlen(cmd_chipper_suit),
+				      (const struct modem_chat_match *)hl78xx_get_ok_match(),
+				      hl78xx_get_ok_match_size(), MDM_CMD_TIMEOUT, false);
 }
 /* send binary data via the K....STORE commands */
 static ssize_t hl78xx_send_cert(struct hl78xx_socket_data *socket_data, const char *cert_data,
@@ -2444,8 +2444,8 @@ static ssize_t hl78xx_send_cert(struct hl78xx_socket_data *socket_data, const ch
 	}
 	modem_chat_attach(&socket_data->mdata_global->chat, socket_data->mdata_global->uart_pipe);
 	ret = modem_dynamic_cmd_send(socket_data->mdata_global, NULL, "", 0,
-				     (const struct modem_chat_match *)hl78xx_get_ok_match(), 1,
-				     false);
+				     (const struct modem_chat_match *)hl78xx_get_ok_match(),
+				     hl78xx_get_ok_match_size(), MDM_CMD_TIMEOUT, false);
 	if (ret < 0) {
 		LOG_ERR("Final confirmation failed: %d", ret);
 		goto cleanup;

--- a/include/zephyr/drivers/modem/hl78xx_apis.h
+++ b/include/zephyr/drivers/modem/hl78xx_apis.h
@@ -106,6 +106,8 @@ enum hl78xx_modem_info_type {
 	HL78XX_MODEM_INFO_NETWORK_OPERATOR,
 	/* <Serial Number> */
 	HL78XX_MODEM_INFO_SERIAL_NUMBER,
+	/* Current Baud Rate */
+	HL78XX_MODEM_INFO_CURRENT_BAUD_RATE,
 };
 
 /** Cellular network structure */

--- a/samples/drivers/modem/hello_hl78xx/overlay-swir_hl78xx-verbose-logging.conf
+++ b/samples/drivers/modem/hello_hl78xx/overlay-swir_hl78xx-verbose-logging.conf
@@ -1,8 +1,22 @@
-# Logging
+# ============================================================================
+# Verbose Logging Configuration for HL78XX Modem
+# ============================================================================
+# Use this overlay for detailed debugging and troubleshooting
+# Build with: west build -- -DEXTRA_CONF_FILE=overlay-swir_hl78xx-verbose-logging.conf
+
+# ============================================================================
+# Logging Infrastructure
+# ============================================================================
+# Large log buffer to prevent message loss during verbose logging
 CONFIG_LOG_BUFFER_SIZE=85536
 
-# For extra verbosity
+# ============================================================================
+# Modem Debug Logging
+# ============================================================================
+# Enable debug-level logging for all modem modules
 CONFIG_MODEM_MODULES_LOG_LEVEL_DBG=y
 CONFIG_MODEM_LOG_LEVEL_DBG=y
+# Larger buffer for modem chat logs (captures AT commands and responses)
 CONFIG_MODEM_CHAT_LOG_BUFFER_SIZE=1024
+# Enable verbose debug context for HL78XX driver
 CONFIG_MODEM_HL78XX_LOG_CONTEXT_VERBOSE_DEBUG=y

--- a/samples/drivers/modem/hello_hl78xx/prj.conf
+++ b/samples/drivers/modem/hello_hl78xx/prj.conf
@@ -11,7 +11,6 @@
 CONFIG_HEAP_MEM_POOL_SIZE=4096
 CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-CONFIG_POSIX_API=y
 
 # ============================================================================
 # Power Management (Optional)

--- a/samples/drivers/modem/hello_hl78xx/prj.conf
+++ b/samples/drivers/modem/hello_hl78xx/prj.conf
@@ -5,67 +5,72 @@
 
 # The HL78xx driver gets its IP settings from the cell network
 
-#system
+# ============================================================================
+# System Configuration
+# ============================================================================
 CONFIG_HEAP_MEM_POOL_SIZE=4096
 CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
 CONFIG_POSIX_API=y
 
-#PM
+# ============================================================================
+# Power Management (Optional)
+# ============================================================================
 # CONFIG_PM_DEVICE=y
 
-#uart
+# ============================================================================
+# UART Configuration
+# ============================================================================
 CONFIG_UART_ASYNC_API=y
+# CONFIG_UART_INTERRUPT_DRIVEN=y
+# CONFIG_MODEM_BACKEND_UART_ASYNC_HWFC=y
 
-# Generic networking options
+# ============================================================================
+# Networking Stack
+# ============================================================================
 CONFIG_NETWORKING=y
 CONFIG_NET_UDP=y
 CONFIG_NET_TCP=y
 CONFIG_NET_IPV6=n
 CONFIG_NET_IPV4=y
 CONFIG_NET_SOCKETS=y
-
 # DNS
 CONFIG_DNS_RESOLVER=y
 CONFIG_NET_SOCKETS_DNS_TIMEOUT=12000
-
 # Wait for the network to be ready
 CONFIG_NET_SAMPLE_COMMON_WAIT_DNS_SERVER_ADDITION=y
-
 # Network management
 CONFIG_NET_MGMT=y
 CONFIG_NET_MGMT_EVENT=y
 # NB-IoT has large latency, so increase timeouts. It is ok to use this for Cat-M1 as well.
 CONFIG_NET_SOCKETS_CONNECT_TIMEOUT=15000
 CONFIG_NET_CONNECTION_MANAGER=y
-
 # Network buffers
 CONFIG_NET_PKT_RX_COUNT=32
 CONFIG_NET_PKT_TX_COUNT=16
 CONFIG_NET_BUF_RX_COUNT=64
 CONFIG_NET_BUF_TX_COUNT=32
 
-# Modem driver
+# ============================================================================
+# Modem Driver - HL78XX
+# ============================================================================
 CONFIG_MODEM=y
-
 #hl78xx modem
 CONFIG_MODEM_HL78XX=y
-
 # Statistics
 CONFIG_MODEM_STATS=y
 
-# shell
-CONFIG_SHELL=y
-CONFIG_MODEM_HL78XX_AT_SHELL=y
-CONFIG_MODEM_AT_SHELL_COMMAND_MAX_SIZE=256
-
-#apn source
+# ============================================================================
+# APN Configuration (Disabled - using defaults)
+# ============================================================================
 # CONFIG_MODEM_HL78XX_APN_SOURCE_KCONFIG=y
 # CONFIG_MODEM_HL78XX_APN="internet"
 # CONFIG_MODEM_HL78XX_APN_SOURCE_ICCID=y
 # CONFIG_MODEM_HL78XX_APN_PROFILES="hologram=23450, wm=20601, vodafone=8988239, em=8988303"
 
-# RAT selection
+# ============================================================================
+# Radio Access Technology (RAT) Configuration
+# ============================================================================
 CONFIG_MODEM_HL78XX_AUTORAT=n
 # CONFIG_MODEM_HL78XX_AUTORAT_PRL_PROFILES="2,1,3"
 # CONFIG_MODEM_HL78XX_AUTORAT_NB_BAND_CFG="3,8,20,28"
@@ -75,13 +80,28 @@ CONFIG_MODEM_HL78XX_AUTORAT=n
 # Stay in boot mode until registered to a network
 # CONFIG_MODEM_HL78XX_STAY_IN_BOOT_MODE_FOR_ROAMING=y
 
-# Enable AirVantage support
+# ============================================================================
+# AirVantage Over-The-Air (OTA) Support
+# ============================================================================
 CONFIG_MODEM_HL78XX_AIRVANTAGE=y
 CONFIG_MODEM_HL78XX_AIRVANTAGE_USER_AGREEMENT=y
 CONFIG_MODEM_HL78XX_AIRVANTAGE_UA_CONNECT_AIRVANTAGE=y
 CONFIG_MODEM_HL78XX_AIRVANTAGE_UA_DOWNLOAD_FIRMWARE=y
 CONFIG_MODEM_HL78XX_AIRVANTAGE_UA_INSTALL_FIRMWARE=y
-#  Monitor modem events
+
+# ============================================================================
+# Shell and Debug Tools
+# ============================================================================
+CONFIG_SHELL=y
+CONFIG_MODEM_HL78XX_AT_SHELL=y
+CONFIG_MODEM_AT_SHELL_COMMAND_MAX_SIZE=256
+
+# ============================================================================
+# Event Monitoring
+# ============================================================================
 CONFIG_HL78XX_EVT_MONITOR=y
+
+# ============================================================================
 # Logging
+# ============================================================================
 CONFIG_LOG=y

--- a/samples/drivers/modem/hello_hl78xx/prj.conf
+++ b/samples/drivers/modem/hello_hl78xx/prj.conf
@@ -60,6 +60,26 @@ CONFIG_MODEM_HL78XX=y
 CONFIG_MODEM_STATS=y
 
 # ============================================================================
+# Auto Baud Rate Detection and Switching
+# ============================================================================
+CONFIG_MODEM_HL78XX_AUTO_BAUDRATE=y
+# CONFIG_MODEM_HL78XX_AUTOBAUD_AT_BOOT=y
+# CONFIG_MODEM_HL78XX_AUTOBAUD_ONLY_IF_COMMS_FAIL=n
+# CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_9600=y
+# CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_115200=y
+CONFIG_MODEM_HL78XX_TARGET_BAUDRATE_921600=y
+CONFIG_MODEM_HL78XX_AUTOBAUD_DETECTION_BAUDRATES="9600,115200,921600,57600,38400,19200"
+CONFIG_MODEM_HL78XX_AUTOBAUD_TIMEOUT=4
+CONFIG_MODEM_HL78XX_AUTOBAUD_RETRY_COUNT=3
+# After enabling auto-baud once WITH CONFIG_MODEM_HL78XX_AUTOBAUD_CHANGE_PERSISTENT,
+# the modem's baud rate is saved to NV-MEM with AT&W, so it persists across power cycles.
+# If you later disable CONFIG_MODEM_HL78XX_AUTO_BAUDRATE, the driver won't detect/switch,
+# but the modem is still at the target baud rate (e.g., 921600)
+# If your device tree UART is at 115200 but the modem is at 921600, communication will fail
+# CONFIG_MODEM_HL78XX_AUTOBAUD_CHANGE_PERSISTENT=n
+# CONFIG_MODEM_HL78XX_AUTOBAUD_START_WITH_TARGET_BAUDRATE=n
+
+# ============================================================================
 # APN Configuration (Disabled - using defaults)
 # ============================================================================
 # CONFIG_MODEM_HL78XX_APN_SOURCE_KCONFIG=y

--- a/samples/drivers/modem/hello_hl78xx/src/main.c
+++ b/samples/drivers/modem/hello_hl78xx/src/main.c
@@ -298,7 +298,7 @@ int main(void)
 	char serial_number[MDM_SERIAL_NUMBER_LENGTH] = {0};
 	enum hl78xx_cell_rat_mode tech;
 	enum cellular_registration_status status;
-	int16_t rsrp;
+	int16_t signal_strength = 0;
 	const char *newapn = "";
 	const char *sample_cmd = "AT";
 
@@ -335,7 +335,11 @@ int main(void)
 	/* Get the current registration status */
 	cellular_get_registration_status(modem, hl78xx_rat_to_access_tech(tech), &status);
 	/* Get the current signal strength */
-	cellular_get_signal(modem, CELLULAR_SIGNAL_RSRP, &rsrp);
+#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
+	cellular_get_signal(modem, CELLULAR_SIGNAL_RSSI, &signal_strength);
+#else
+	cellular_get_signal(modem, CELLULAR_SIGNAL_RSRP, &signal_strength);
+#endif
 	/* Get the current network operator name */
 	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_NETWORK_OPERATOR, (char *)operator,
 			      sizeof(operator));
@@ -350,7 +354,11 @@ int main(void)
 	LOG_INF("Imei: %s", imei);
 	LOG_INF("RAT: %s", rat_get_in_string(tech));
 	LOG_INF("Connection status: %s(%d)", reg_status_get_in_string(status), status);
-	LOG_INF("RSRP : %d", rsrp);
+#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
+	LOG_INF("RSSI : %d", signal_strength);
+#else
+	LOG_INF("RSRP : %d", signal_strength);
+#endif
 	LOG_INF("Operator: %s", (strlen(operator) > 0) ? operator : "\"\"");
 	LOG_RAW("**********************************************************\n\n");
 

--- a/samples/drivers/modem/hello_hl78xx/src/main.c
+++ b/samples/drivers/modem/hello_hl78xx/src/main.c
@@ -299,6 +299,7 @@ int main(void)
 	enum hl78xx_cell_rat_mode tech;
 	enum cellular_registration_status status;
 	int16_t signal_strength = 0;
+	uint32_t current_baudrate = 0;
 	const char *newapn = "";
 	const char *sample_cmd = "AT";
 
@@ -343,6 +344,9 @@ int main(void)
 	/* Get the current network operator name */
 	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_NETWORK_OPERATOR, (char *)operator,
 			      sizeof(operator));
+	/* Get the current baudrate */
+	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_CURRENT_BAUD_RATE, &current_baudrate,
+			      sizeof(current_baudrate));
 
 	LOG_RAW("\n**********************************************************\n");
 	LOG_RAW("********* Hello HL78XX Modem Sample Application **********\n");
@@ -360,6 +364,7 @@ int main(void)
 	LOG_INF("RSRP : %d", signal_strength);
 #endif
 	LOG_INF("Operator: %s", (strlen(operator) > 0) ? operator : "\"\"");
+	LOG_INF("Current Baudrate: %dbps", current_baudrate);
 	LOG_RAW("**********************************************************\n\n");
 
 	LOG_INF("Setting new APN: %s", newapn);

--- a/samples/drivers/modem/hello_hl78xx/src/main.c
+++ b/samples/drivers/modem/hello_hl78xx/src/main.c
@@ -16,10 +16,6 @@
 #include <zephyr/net/conn_mgr_monitor.h>
 #include <zephyr/net/socket.h>
 
-#include <zephyr/posix/sys/socket.h>
-#include <zephyr/posix/arpa/inet.h>
-#include <zephyr/posix/netdb.h>
-
 /* Macros used to subscribe to specific Zephyr NET management events. */
 #if defined(CONFIG_NET_SAMPLE_COMMON_WAIT_DNS_SERVER_ADDITION)
 #define L4_EVENT_MASK (NET_EVENT_DNS_SERVER_ADD | NET_EVENT_L4_DISCONNECTED)
@@ -186,9 +182,9 @@ static void hl78xx_on_ok(struct modem_chat *chat, char **argv, uint16_t argc, vo
 static int resolve_broker_addr(struct sockaddr_in *broker)
 {
 	int ret;
-	struct addrinfo *ai = NULL;
+	struct zsock_addrinfo *ai = NULL;
 
-	const struct addrinfo hints = {
+	const struct zsock_addrinfo hints = {
 		.ai_family = AF_INET,
 		.ai_socktype = SOCK_STREAM,
 		.ai_protocol = 0,
@@ -196,19 +192,19 @@ static int resolve_broker_addr(struct sockaddr_in *broker)
 	char port_string[6] = {0};
 
 	snprintf(port_string, sizeof(port_string), "%d", TEST_SERVER_PORT);
-	ret = getaddrinfo(TEST_SERVER_ENDPOINT, port_string, &hints, &ai);
+	ret = zsock_getaddrinfo(TEST_SERVER_ENDPOINT, port_string, &hints, &ai);
 	if (ret == 0) {
 		char addr_str[INET_ADDRSTRLEN];
 
 		memcpy(broker, ai->ai_addr, MIN(ai->ai_addrlen, sizeof(struct sockaddr_storage)));
 
-		inet_ntop(AF_INET, &broker->sin_addr, addr_str, sizeof(addr_str));
+		zsock_inet_ntop(AF_INET, &broker->sin_addr, addr_str, sizeof(addr_str));
 		LOG_INF("Resolved: %s:%u", addr_str, htons(broker->sin_port));
 	} else {
 		LOG_ERR("failed to resolve hostname err = %d (errno = %d)", ret, errno);
 	}
 
-	freeaddrinfo(ai);
+	zsock_freeaddrinfo(ai);
 
 	return ret;
 }


### PR DESCRIPTION
### Summary
This PR adds automatic baud rate detection and switching capability to the Sierra Wireless HL78xx modem driver (HL7812/HL7800). The feature enables the driver to automatically detect the modem's current UART baud rate and switch to a configured target rate, improving reliability and flexibility in production environments.

In production deployments, modems may be configured with different baud rates from previous sessions, factory defaults, or manual AT commands. Currently, if the modem's baud rate doesn't match the device tree configuration, communication fails and the driver cannot initialize. This feature eliminates manual baud rate synchronization and enables automatic recovery from baud rate mismatches.

### Key Features

- Smart Detection: Automatically detects modem's current baud rate by testing a configurable list of rates
- Dynamic Switching: Changes modem baud rate using AT+IPR command and reconfigures UART accordingly
- Persistent Storage: Optionally saves configuration to modem NVRAM using AT&W for persistence across power cycles
  - Optimization Flags: Five smart configuration options for minimal boot time impact:
  - AUTOBAUD_ONLY_IF_COMMS_FAIL: Skip detection if modem already responds (default: enabled)
  - AUTOBAUD_START_WITH_TARGET_BAUDRATE: Try target rate first (default: enabled)
  - AUTOBAUD_CHANGE_PERSISTENT: Save with AT&W to NVRAM (default: enabled)
  - AUTOBAUD_DIAGNOSING_FIRST: Automatic recovery from diagnostic state (default: disabled)
  - AUTOBAUD_AT_BOOT: Ultra-fast boot mode, skip KSUP wait (default: disabled, advanced)
- Configurable: Supports baud rates from 9600 to 3000000 bps
- Robust: Configurable timeout (1-120 seconds) and retry count (1-10 attempts)
- State Machine Integration: Seamlessly integrated into modem initialization flow