### PR TITLE
Add reset support for LPTIM on STM32

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -18,6 +18,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/irq.h>
 #include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/pm/policy.h>
 
 #include <zephyr/spinlock.h>
@@ -37,6 +38,8 @@
 static const struct stm32_pclken lptim_clk[] = STM32_DT_INST_CLOCKS(0);
 
 static const struct device *const clk_ctrl = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+
+static const struct reset_dt_spec lptim_reset = RESET_DT_SPEC_INST_GET(0);
 
 /*
  * Assumptions and limitations:
@@ -558,6 +561,9 @@ static int sys_clock_driver_init(void)
 		lptim_clock_freq = KHZ(32);
 	}
 #endif
+
+	/* Reset timer to default state using RCC */
+	(void)reset_line_toggle_dt(&lptim_reset);
 
 #if DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout)
 	uint32_t timeout = DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout);

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -259,6 +259,7 @@
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
+			resets = <&rctl STM32_RESET(APB1L, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -416,6 +416,7 @@
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
+			resets = <&rctl STM32_RESET(APB1L, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -231,6 +231,7 @@
 		lptim1: timers@44004400 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB3, 11)>;
+			resets = <&rctl STM32_RESET(APB3, 11)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44004400 0x400>;
@@ -242,6 +243,7 @@
 		lptim2: timers@40009400 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1_2, 5)>;
+			resets = <&rctl STM32_RESET(APB1H, 5)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40009400 0x400>;

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -81,6 +81,7 @@
 		lptim3: timers@44004800 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB3, 12)>;
+			resets = <&rctl STM32_RESET(APB3, 12)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44004800 0x400>;
@@ -92,6 +93,7 @@
 		lptim4: timers@44004c00 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB3, 13)>;
+			resets = <&rctl STM32_RESET(APB3, 13)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44004c00 0x400>;
@@ -103,6 +105,7 @@
 		lptim5: timers@44005000 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB3, 14)>;
+			resets = <&rctl STM32_RESET(APB3, 14)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44005000 0x400>;
@@ -114,6 +117,7 @@
 		lptim6: timers@44005400 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB3, 15)>;
+			resets = <&rctl STM32_RESET(APB3, 15)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44005400 0x400>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -932,6 +932,7 @@
 		lptim1: timers@40002400 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1, 9)>;
+			resets = <&rctl STM32_RESET(APB1L, 9)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40002400 0x400>;

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -868,6 +868,7 @@
 		lptim1: timers@40002400 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1, 9)>;
+			resets = <&rctl STM32_RESET(APB1L, 9)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40002400 0x400>;

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -311,6 +311,7 @@
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
+			resets = <&rctl STM32_RESET(APB1, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -490,6 +490,7 @@
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
+			resets = <&rctl STM32_RESET(APB1L, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
@@ -504,6 +505,7 @@
 			#size-cells = <0>;
 			reg = <0x40009400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 5)>;
+			resets = <&rctl STM32_RESET(APB1H, 5)>;
 			interrupts = <66 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -331,6 +331,7 @@
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
+			resets = <&rctl STM32_RESET(APB1L, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -582,6 +582,7 @@
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
+			resets = <&rctl STM32_RESET(APB1L, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
@@ -593,6 +594,7 @@
 		lptim2: timers@40009400 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
+			resets = <&rctl STM32_RESET(APB1L, 30)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40009400 0x400>;

--- a/dts/arm/st/u0/stm32u073.dtsi
+++ b/dts/arm/st/u0/stm32u073.dtsi
@@ -25,6 +25,7 @@
 		lptim3: timers@40009000 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1, 26)>;
+			resets = <&rctl STM32_RESET(APB1L, 26)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40009000 0x400>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -432,6 +432,7 @@
 			#size-cells = <0>;
 			reg = <0x46004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB3, 11)>;
+			resets = <&rctl STM32_RESET(APB3, 11)>;
 			interrupts = <67 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";
@@ -443,6 +444,7 @@
 			#size-cells = <0>;
 			reg = <0x40009400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 5)>;
+			resets = <&rctl STM32_RESET(APB1H, 5)>;
 			interrupts = <68 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -454,6 +456,7 @@
 			#size-cells = <0>;
 			reg = <0x46004800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB3, 12)>;
+			resets = <&rctl STM32_RESET(APB3, 12)>;
 			interrupts = <98 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -465,6 +468,7 @@
 			#size-cells = <0>;
 			reg = <0x46004c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB3, 13)>;
+			resets = <&rctl STM32_RESET(APB3, 13)>;
 			interrupts = <110 0>;
 			interrupt-names = "global";
 			status = "disabled";

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -457,6 +457,7 @@
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
+			resets = <&rctl STM32_RESET(APB1L, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -520,6 +520,7 @@
 			#size-cells = <0>;
 			reg = <0x46004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB7, 11)>;
+			resets = <&rctl STM32_RESET(APB7, 11)>;
 			interrupts = <49 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";
@@ -531,6 +532,7 @@
 			#size-cells = <0>;
 			reg = <0x40009400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 5)>;
+			resets = <&rctl STM32_RESET(APB1H, 5)>;
 			interrupts = <50 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -205,6 +205,7 @@
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
+			resets = <&rctl STM32_RESET(APB1L, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;

--- a/dts/bindings/timer/st,stm32-lptim.yaml
+++ b/dts/bindings/timer/st,stm32-lptim.yaml
@@ -15,8 +15,6 @@ compatible: "st,stm32-lptim"
 include:
   - name: st,stm32-timers.yaml
     property-blocklist:
-      # 'resets' property is not supported yet
-      - resets
       - st,prescaler
       - st,countermode
 


### PR DESCRIPTION
Add support for resetting the LPTIM peripheral to its default state on initialization. This ensures that any previous configurations do not interfere with the new settings.