### PR TITLE
dts: stepper: move m0/m1-gpios property in stepper-controller

### DIFF
--- a/dts/bindings/stepper/adi/adi,tmc2209.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc2209.yaml
@@ -14,14 +14,6 @@ properties:
   step-width-ns:
     default: 100
 
-  m0-gpios:
-    type: phandle-array
-    description: Microstep configuration pin MS1.
-
-  m1-gpios:
-    type: phandle-array
-    description: Microstep configuration pin MS2.
-
   dual-edge-step:
     type: boolean
     description: |

--- a/dts/bindings/stepper/allegro/allegro,a4979.yaml
+++ b/dts/bindings/stepper/allegro/allegro,a4979.yaml
@@ -17,16 +17,6 @@ properties:
   step-width-ns:
     default: 1000
 
-  m0-gpios:
-    required: true
-    type: phandle-array
-    description: Microstep configuration pin 0.
-
-  m1-gpios:
-    required: true
-    type: phandle-array
-    description: Microstep configuration pin 1.
-
   reset-gpios:
     type: phandle-array
     required: true

--- a/dts/bindings/stepper/stepper-driver.yaml
+++ b/dts/bindings/stepper/stepper-driver.yaml
@@ -24,3 +24,11 @@ properties:
     type: phandle-array
     description: |
       GPIO pins used to control the enable signal of the motor driver.
+
+  m0-gpios:
+    type: phandle-array
+    description: Microstep configuration pin 0.
+
+  m1-gpios:
+    type: phandle-array
+    description: Microstep configuration pin 1.

--- a/dts/bindings/stepper/ti/ti,drv84xx.yaml
+++ b/dts/bindings/stepper/ti/ti,drv84xx.yaml
@@ -23,14 +23,6 @@ properties:
     type: phandle-array
     description: Sleep pin (active low).
 
-  m0-gpios:
-    type: phandle-array
-    description: Microstep configuration pin 0.
-
-  m1-gpios:
-    type: phandle-array
-    description: Microstep configuration pin 1.
-
 examples:
   - |
     drv8424: drv8424 {


### PR DESCRIPTION
m0-gpios and m1-gpios are common in step-dir stepper drivers and hence placing them in common stepper-controller.yaml along with step-gpios and dir-gpios