### PR TITLE
drivers: ethernet: litex: Support MAC address config

### DIFF
--- a/drivers/ethernet/eth_litex_liteeth.c
+++ b/drivers/ethernet/eth_litex_liteeth.c
@@ -42,7 +42,7 @@ struct eth_litex_dev_data {
 struct eth_litex_config {
 	const struct device *phy_dev;
 	void (*config_func)(const struct device *dev);
-	bool random_mac_address;
+	struct net_eth_mac_config mcfg;
 	uint32_t rx_slot_addr;
 	uint32_t rx_length_addr;
 	uint32_t rx_ev_pending_addr;
@@ -69,10 +69,7 @@ static int eth_initialize(const struct device *dev)
 
 	config->config_func(dev);
 
-	if (config->random_mac_address) {
-		/* generate random MAC address */
-		gen_random_mac(context->mac_addr, 0x10, 0xe2, 0xd5);
-	}
+	(void)net_eth_mac_load(&config->mcfg, context->mac_addr);
 
 	return 0;
 }
@@ -330,14 +327,12 @@ static const struct ethernet_api eth_api = {
 		irq_enable(DT_INST_IRQN(n));                                                       \
 	}                                                                                          \
                                                                                                    \
-	static struct eth_litex_dev_data eth_data##n = {                                           \
-		.mac_addr = DT_INST_PROP_OR(n, local_mac_address, {0}),			           \
-	};                                                                                         \
+	static struct eth_litex_dev_data eth_data##n;                                              \
                                                                                                    \
 	static const struct eth_litex_config eth_config##n = {                                     \
 		.phy_dev = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(n, phy_handle)),                  \
 		.config_func = eth_irq_config##n,                                                  \
-		.random_mac_address = DT_INST_PROP(n, zephyr_random_mac_address),                  \
+		.mcfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(n),                                        \
 		.rx_slot_addr = DT_INST_REG_ADDR_BY_NAME(n, rx_slot),                              \
 		.rx_length_addr = DT_INST_REG_ADDR_BY_NAME(n, rx_length),                          \
 		.rx_ev_pending_addr = DT_INST_REG_ADDR_BY_NAME(n, rx_ev_pending),                  \


### PR DESCRIPTION
Update the litex,liteeth ethernet driver to use a MAC address configuration struct.