### PR TITLE
soc: microchip: mec: add missing GPIO reg include in soc.h

### DIFF
--- a/soc/microchip/mec/mec165xb/soc.h
+++ b/soc/microchip/mec/mec165xb/soc.h
@@ -13,6 +13,9 @@
 
 #include "device_mec5.h"
 
+/* common peripheral register defines */
+#include <reg/mec_gpio.h>
+
 /* common SoC API */
 #include <soc_dt.h>
 #include <soc_ecia.h>

--- a/soc/microchip/mec/mech172x/soc.h
+++ b/soc/microchip/mec/mech172x/soc.h
@@ -13,6 +13,9 @@
 
 #include <device_mec5.h>
 
+/* common peripheral register defines */
+#include <reg/mec_gpio.h>
+
 /* common SoC API */
 #include <soc_dt.h>
 #include <soc_ecia.h>


### PR DESCRIPTION
Complement #99761 that added register includes to too few files. Fix build error for some boards using these SoCs.