### PR TITLE
drivers: flash: Fix flash host type for CI builds

### DIFF
--- a/drivers/flash/Kconfig.esp32
+++ b/drivers/flash/Kconfig.esp32
@@ -61,7 +61,7 @@ config ESP_FLASH_ASYNC_IPM
 
 config ESP_FLASH_REMOTE
 	bool "Remote IPM flash driver"
-	default y if (SOC_ESP32_APPCPU || SOC_ESP32S3_APPCPU || SOC_ESP32C6_LPCORE)
+	default y if (SOC_ESP32_APPCPU || SOC_ESP32S3_APPCPU || SOC_ESP32C6_LPCORE) && (IPM || MBOX)
 
 config ESP_FLASH_HOST
 	bool "Host functionality flash driver"


### PR DESCRIPTION
This fixes the APPCPU synthetic builds.