### PR TITLE
nxp: mimxrt595_evk: enable USBD support

### DIFF
--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -355,6 +355,14 @@ arduino_serial: &flexcomm12 {
 
 zephyr_udc0: &usbhs {
 	status = "okay";
+	phy-handle = <&usbphy>;
+};
+
+&usbphy {
+	status = "okay";
+	tx-d-cal = <12>;
+	tx-cal-45-dp-ohms = <6>;
+	tx-cal-45-dm-ohms = <6>;
 };
 
 &ctimer0 {

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.yaml
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.yaml
@@ -29,5 +29,6 @@ supported:
   - sdhc
   - spi
   - usb_device
+  - usbd
   - watchdog
 vendor: nxp

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -386,6 +386,12 @@
 		status = "disabled";
 	};
 
+	usbphy: usbphy@13b000 {
+		compatible = "nxp,usbphy";
+		reg = <0x13b000 0x1000>;
+		status = "disabled";
+	};
+
 	hs_lspi: spi@126000 {
 		compatible = "nxp,lpc-spi";
 		reg = <0x126000 0x1000>;

--- a/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
@@ -27,7 +27,7 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 #include "flash_clock_setup.h"
 #endif
 
-#if CONFIG_USB_DC_NXP_LPCIP3511
+#if CONFIG_USB_DC_NXP_LPCIP3511 || CONFIG_UDC_NXP_IP3511
 #include "usb_phy.h"
 #include "usb.h"
 #endif
@@ -71,7 +71,7 @@ const clock_frg_clk_config_t g_frg0Config_clock_init = {
 const clock_frg_clk_config_t g_frg12Config_clock_init = {
 	.num = 12, .sfg_clock_src = kCLOCK_FrgMainClk, .divider = 255U, .mult = 167};
 
-#if CONFIG_USB_DC_NXP_LPCIP3511
+#if CONFIG_USB_DC_NXP_LPCIP3511 || CONFIG_UDC_NXP_IP3511
 /* USB PHY configuration */
 #define BOARD_USB_PHY_D_CAL     (0x0CU)
 #define BOARD_USB_PHY_TXCAL45DP (0x06U)
@@ -127,7 +127,7 @@ __imx_boot_ivt_section void (*const image_vector_table[])(void) = {
 };
 #endif /* CONFIG_NXP_IMXRT_BOOT_HEADER */
 
-#if CONFIG_USB_DC_NXP_LPCIP3511
+#if CONFIG_USB_DC_NXP_LPCIP3511 || CONFIG_UDC_NXP_IP3511
 
 static void usb_device_clock_init(void)
 {
@@ -280,7 +280,7 @@ void __weak rt5xx_clock_init(void)
 	CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM0);
 #endif
 #endif
-#if CONFIG_USB_DC_NXP_LPCIP3511
+#if CONFIG_USB_DC_NXP_LPCIP3511 || CONFIG_UDC_NXP_IP3511
 	usb_device_clock_init();
 #endif
 


### PR DESCRIPTION
Enable use of USB Next stack and UDC driver for mimxrt595_evk (imxrt5xx)