### PR TITLE
drivers: sensor: adxl345: add device PM support

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345.h
+++ b/drivers/sensor/adi/adxl345/adxl345.h
@@ -170,6 +170,7 @@ struct adxl345_dev_data {
 	uint8_t is_full_res;
 	uint8_t selected_range;
 	enum adxl345_odr odr;
+	enum adxl345_op_mode op_mode;
 #ifdef CONFIG_ADXL345_TRIGGER
 	struct gpio_callback gpio_cb;
 


### PR DESCRIPTION
Add support for the Zephyr device power management framework to enable runtime power control of the ADXL345 accelerometer.

This implementation adds a pm_device_action callback that handles SUSPEND and RESUME actions. When suspended, the sensor enters standby mode for low power operation. On resume, it returns to measurement mode.

The implementation follows the standard pattern used by other sensor drivers (lis2dh, bme280, vcnl4040) and integrates with the PM_DEVICE_DT_INST_DEFINE macro for automatic PM setup.

Tested on nRF52832 with CONFIG_PM_DEVICE enabled.