### PR TITLE
drivers: i2c: esp32: remove unused macros

### DIFF
--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -35,12 +35,6 @@ LOG_MODULE_REGISTER(i2c_esp32, CONFIG_I2C_LOG_LEVEL);
 #define I2C_CLR_BUS_HALF_PERIOD_US 5	/* Period of SCL clock to restore SDA signal */
 #define I2C_TRANSFER_TIMEOUT_MSEC 500	/* Transfer timeout period */
 
-/* Freq limitation when using different clock sources */
-#define I2C_CLK_LIMIT_REF_TICK (1 * 1000 * 1000 / 20)	/* REF_TICK, no more than REF_TICK/20*/
-#define I2C_CLK_LIMIT_APB (80 * 1000 * 1000 / 20)	/* Limited by APB, no more than APB/20 */
-#define I2C_CLK_LIMIT_RTC (20 * 1000 * 1000 / 20)	/* Limited by RTC, no more than RTC/20 */
-#define I2C_CLK_LIMIT_XTAL (40 * 1000 * 1000 / 20)	/* Limited by RTC, no more than XTAL/20 */
-
 #define I2C_CLOCK_INVALID                 (-1)
 
 enum i2c_status_t {


### PR DESCRIPTION
Removed frequency limitation definitions for I2C clock sources because they are unused macros.