### PR TITLE
drivers: interrupt: pint: Add API to get pin used IRQ slot

### DIFF
--- a/drivers/interrupt_controller/intc_nxp_pint.c
+++ b/drivers/interrupt_controller/intc_nxp_pint.c
@@ -175,6 +175,22 @@ void nxp_pint_pin_unset_callback(uint8_t pin)
 	pint_irq_cfg[slot].callback = NULL;
 }
 
+int nxp_pint_pin_get_slot_index(uint8_t pin)
+{
+	int slot;
+
+	if (pin > ARRAY_SIZE(pin_pint_id)) {
+		return -EINVAL;
+	}
+
+	slot = pin_pint_id[pin];
+	if (slot == NO_PINT_ID) {
+		return -EINVAL;
+	}
+
+	return slot;
+}
+
 /* NXP PINT ISR handler- called with PINT slot ID */
 static void nxp_pint_isr(uint8_t *slot)
 {

--- a/include/zephyr/drivers/interrupt_controller/nxp_pint.h
+++ b/include/zephyr/drivers/interrupt_controller/nxp_pint.h
@@ -79,5 +79,12 @@ int nxp_pint_pin_set_callback(uint8_t pin, nxp_pint_cb_t cb, void *data);
  */
 void nxp_pint_pin_unset_callback(uint8_t pin);
 
+/**
+ * @brief Get PINT slot index the pin is allocated to
+ *
+ * @param pin: The pin to get the PINT slot index for
+ * @return The allocated slot index, if not allocated, return -EINVAL.
+ */
+int nxp_pint_pin_get_slot_index(uint8_t pin);
 
 #endif /* ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_NXP_PINT_H_ */


### PR DESCRIPTION
PINT connects GPIO pin to seperate IRQ slot. This info is hidden in PINT driver, there is no way to know which IRQ actually the GPIO pin is connected to.
Add new API to get which IRQ slot is connected to, based on pin index.