### PR TITLE
boards: amd: versalnet_apu: Add SMP board variant support

### DIFF
--- a/boards/amd/versalnet_apu/board.cmake
+++ b/boards/amd/versalnet_apu/board.cmake
@@ -18,11 +18,19 @@ set(QEMU_FLAGS_${ARCH}
   -m 2g
 )
 
+# Add SMP support if configured maxcpus parameter value is aligned with QEMU DT
+if(CONFIG_SMP AND CONFIG_MP_MAX_NUM_CPUS GREATER 1)
+  list(APPEND QEMU_SMP_FLAGS -smp maxcpus=20)
+endif()
+
 # Set TF-A platform for ARM Trusted Firmware builds
 if(CONFIG_BUILD_WITH_TFA)
   set(TFA_PLAT "versal_net")
-  # Add Versal NET specific TF-A build parameters
-  set(TFA_EXTRA_ARGS "TFA_NO_PM=1;PRELOADED_BL33_BASE=0x0")
+  # Configure TF-A memory location for Versal NET platform
+  # TF-A runs from DDR at address 0xf000000 (changed from default 0xbbf00000).
+  # This DDR location (VERSAL_NET_ATF_MEM_BASE=0xf000000) works for all possible designs.
+  # Note: If TF-A needs to run from OCM instead of DDR, PDI changes would be required.
+  set(TFA_EXTRA_ARGS "RESET_TO_BL31=1;PRELOADED_BL33_BASE=0x0;TFA_NO_PM=1;VERSAL_NET_ATF_MEM_BASE=0xf000000;VERSAL_NET_ATF_MEM_SIZE=0x50000")
   if(CONFIG_TFA_MAKE_BUILD_TYPE_DEBUG)
     set(BUILD_FOLDER "debug")
   else()

--- a/boards/amd/versalnet_apu/board.yml
+++ b/boards/amd/versalnet_apu/board.yml
@@ -4,3 +4,5 @@ board:
   vendor: amd
   socs:
   - name: amd_versalnet_apu
+    variants:
+    - name: smp

--- a/boards/amd/versalnet_apu/versalnet_apu_amd_versalnet_apu_smp.dts
+++ b/boards/amd/versalnet_apu/versalnet_apu_amd_versalnet_apu_smp.dts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include "versalnet_apu.dts"

--- a/boards/amd/versalnet_apu/versalnet_apu_amd_versalnet_apu_smp.yaml
+++ b/boards/amd/versalnet_apu/versalnet_apu_amd_versalnet_apu_smp.yaml
@@ -1,0 +1,11 @@
+identifier: versalnet_apu/amd_versalnet_apu/smp
+name: AMD Development board for Versal NET APU
+arch: arm
+toolchain:
+  - zephyr
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
+    - fpu
+vendor: amd

--- a/boards/amd/versalnet_apu/versalnet_apu_amd_versalnet_apu_smp_defconfig
+++ b/boards/amd/versalnet_apu/versalnet_apu_amd_versalnet_apu_smp_defconfig
@@ -1,0 +1,35 @@
+# The Zephyr build from this defconfig is expected to boot from
+# Xilinx Arm Trusted Firmware (ATF).
+# Boot Flow is: Boot PDI -> TF-A -> Zephyr
+CONFIG_BUILD_WITH_TFA=y
+
+CONFIG_ARM64_VA_BITS_40=y
+CONFIG_ARM64_PA_BITS_40=y
+CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME=y
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable serial port
+CONFIG_UART_PL011=y
+
+# This should be commented in order to test at EL1 S (EL1 Secure)
+CONFIG_ARMV8_A_NS=y
+
+# Enable Clock Manager
+CONFIG_CLOCK_CONTROL=y
+
+# Reset Manager
+CONFIG_RESET=y
+
+# PSCI support Enable
+CONFIG_PM_CPU_OPS=y
+CONFIG_PM_CPU_OPS_PSCI=y
+
+# Enable SMP support
+CONFIG_SMP=y
+CONFIG_MP_MAX_NUM_CPUS=4


### PR DESCRIPTION
Add a new board variant versalnet_apu/amd_versalnet_apu/smp to support Symmetric Multi-Processing (SMP) configuration for AMD Versal NET APU.

This commit introduces:
- SMP board variant with 4-core configuration (CONFIG_MP_MAX_NUM_CPUS=4)
- PSCI support for CPU power management operations
- ARM64 40-bit virtual and physical address space support
- Non-secure world execution (EL1 NS) configuration
- Compatible with Xilinx ARM Trusted Firmware boot flow

The SMP variant enables out-of-box multicore support for applications that require parallel processing capabilities on the Versal NET APU platform.

Usage:
  west build -b versalnet_apu/amd_versalnet_apu/smp <application>

Boot Flow: Boot PDI -> TF-A -> Zephyr (SMP)

Files added:
- boards/amd/versalnet_apu/versalnet_apu_amd_versalnet_apu_smp.yaml
- boards/amd/versalnet_apu/versalnet_apu_amd_versalnet_apu_smp.dts
- boards/amd/versalnet_apu/versalnet_apu_amd_versalnet_apu_smp_defconfig

Files modified:
- boards/amd/versalnet_apu/board.yml (added smp variant)