### PR TITLE
mbox: mbox_ti_secproxy: Driver optimization and bugfixes

### DIFF
--- a/drivers/mbox/mbox_ti_secproxy.c
+++ b/drivers/mbox/mbox_ti_secproxy.c
@@ -79,7 +79,7 @@ struct secproxy_mailbox_config {
 	DEVICE_MMIO_NAMED_ROM(target_data);
 	DEVICE_MMIO_NAMED_ROM(rt);
 	DEVICE_MMIO_NAMED_ROM(scfg);
-	uint32_t irq;
+	int32_t interrupts[MAILBOX_MAX_CHANNELS];
 };
 
 static inline int secproxy_verify_thread(struct secproxy_thread *spt, uint8_t dir)
@@ -113,75 +113,74 @@ static inline int secproxy_verify_thread(struct secproxy_thread *spt, uint8_t di
 	return 0;
 }
 
-static void secproxy_mailbox_isr(const struct device *dev)
+static void secproxy_mailbox_isr(const struct device *dev, uint32_t channel)
 {
 	struct secproxy_mailbox_data *data = DEV_DATA(dev);
 	struct secproxy_thread spt;
 	uint32_t data_word;
 	mem_addr_t data_reg;
 
-	for (int i_channel = 0; i_channel < MAILBOX_MAX_CHANNELS; i_channel++) {
-		if (!data->channel_enable[i_channel]) {
-			continue;
+	if (!data->channel_enable[channel]) {
+		return;
+	}
+
+	spt.target_data = SEC_PROXY_THREAD(DEV_TDATA(dev), channel);
+	spt.rt = SEC_PROXY_THREAD(DEV_RT(dev), channel);
+	spt.scfg = SEC_PROXY_THREAD(DEV_SCFG(dev), channel);
+
+	if (secproxy_verify_thread(&spt, THREAD_IS_RX)) {
+		/* Silent failure */
+		return;
+	}
+
+	data_reg = spt.target_data + SEC_PROXY_DATA_START_OFFS;
+	size_t msg_len = MAILBOX_MBOX_SIZE;
+	size_t num_words = msg_len / sizeof(uint32_t);
+	size_t i;
+	struct rx_msg *rx_data = data->user_data[channel];
+
+	if (!rx_data || !rx_data->buf) {
+		LOG_ERR("No buffer provided for channel %d", channel);
+		return;
+	}
+
+	if (rx_data->size < MAILBOX_MBOX_SIZE) {
+		LOG_ERR("Buffer too small for channel %d", channel);
+		return;
+	}
+
+	uint8_t *buf = (uint8_t *)rx_data->buf;
+
+	/* Copy full words */
+	for (i = 0; i < num_words; i++) {
+		data_word = sys_read32(data_reg);
+		memcpy(&buf[i * 4], &data_word, sizeof(uint32_t));
+		data_reg += sizeof(uint32_t);
+	}
+
+	/* Handle trail bytes */
+	size_t trail_bytes = msg_len % sizeof(uint32_t);
+
+	if (trail_bytes) {
+		uint32_t data_trail = sys_read32(data_reg);
+
+		i = msg_len - trail_bytes;
+
+		while (trail_bytes--) {
+			buf[i++] = data_trail & 0xff;
+			data_trail >>= 8;
 		}
+	}
 
-		spt.target_data = SEC_PROXY_THREAD(DEV_TDATA(dev), i_channel);
-		spt.rt = SEC_PROXY_THREAD(DEV_RT(dev), i_channel);
-		spt.scfg = SEC_PROXY_THREAD(DEV_SCFG(dev), i_channel);
+	/* Ensure we read the last register if we haven't already */
+	if (data_reg <= (spt.target_data + SEC_PROXY_DATA_END_OFFS)) {
+		sys_read32(spt.target_data + SEC_PROXY_DATA_END_OFFS);
+	}
 
-		if (secproxy_verify_thread(&spt, THREAD_IS_RX)) {
-			continue;
-		}
-
-		data_reg = spt.target_data + SEC_PROXY_DATA_START_OFFS;
-		size_t msg_len = MAILBOX_MBOX_SIZE;
-		size_t num_words = msg_len / sizeof(uint32_t);
-		size_t i;
-		struct rx_msg *rx_data = data->user_data[i_channel];
-
-		if (!rx_data || !rx_data->buf) {
-			LOG_ERR("No buffer provided for channel %d", i_channel);
-			continue;
-		}
-
-		if (rx_data->size < MAILBOX_MBOX_SIZE) {
-			LOG_ERR("Buffer too small for channel %d", i_channel);
-			continue;
-		}
-
-		uint8_t *buf = (uint8_t *)rx_data->buf;
-
-		/* Copy full words */
-		for (i = 0; i < num_words; i++) {
-			data_word = sys_read32(data_reg);
-			memcpy(&buf[i * 4], &data_word, sizeof(uint32_t));
-			data_reg += sizeof(uint32_t);
-		}
-
-		/* Handle trail bytes */
-		size_t trail_bytes = msg_len % sizeof(uint32_t);
-
-		if (trail_bytes) {
-			uint32_t data_trail = sys_read32(data_reg);
-
-			i = msg_len - trail_bytes;
-
-			while (trail_bytes--) {
-				buf[i++] = data_trail & 0xff;
-				data_trail >>= 8;
-			}
-		}
-
-		/* Ensure we read the last register if we haven't already */
-		if (data_reg <= (spt.target_data + SEC_PROXY_DATA_END_OFFS)) {
-			sys_read32(spt.target_data + SEC_PROXY_DATA_END_OFFS);
-		}
-
-		rx_data->size = msg_len;
-		rx_data->seq = GET_MSG_SEQ(buf);
-		if (data->cb[i_channel]) {
-			data->cb[i_channel](dev, i_channel, data->user_data[i_channel], NULL);
-		}
+	rx_data->size = msg_len;
+	rx_data->seq = GET_MSG_SEQ(buf);
+	if (data->cb[channel]) {
+		data->cb[channel](dev, channel, data->user_data[channel], NULL);
 	}
 }
 
@@ -310,13 +309,18 @@ static int secproxy_mailbox_set_enabled(const struct device *dev, uint32_t chann
 		return -EALREADY;
 	}
 
+	if (cfg->interrupts[channel] < 0) {
+		LOG_ERR("No interrupt configured for channel %d", channel);
+		return -EINVAL;
+	}
+
 	key = k_spin_lock(&data->lock);
 	data->channel_enable[channel] = enable;
 
 	if (enable) {
-		irq_enable(cfg->irq);
+		irq_enable(cfg->interrupts[channel]);
 	} else {
-		irq_disable(cfg->irq);
+		irq_disable(cfg->interrupts[channel]);
 	}
 
 	k_spin_unlock(&data->lock, key);
@@ -332,27 +336,54 @@ static DEVICE_API(mbox, secproxy_mailbox_driver_api) = {
 	.set_enabled = secproxy_mailbox_set_enabled,
 };
 
-#define MAILBOX_INSTANCE_DEFINE(idx)                                                               \
-	static struct secproxy_mailbox_data secproxy_mailbox_##idx##_data;                         \
-	const static struct secproxy_mailbox_config secproxy_mailbox_##idx##_config = {            \
-		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(target_data, DT_DRV_INST(idx)),                 \
-		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(rt, DT_DRV_INST(idx)),                          \
-		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(scfg, DT_DRV_INST(idx)),                        \
-		.irq = DT_INST_IRQN(idx),                                                          \
-	};                                                                                         \
-	static int secproxy_mailbox_##idx##_init(const struct device *dev)                         \
-	{                                                                                          \
-		DEVICE_MMIO_NAMED_MAP(dev, target_data, K_MEM_CACHE_NONE);                         \
-		DEVICE_MMIO_NAMED_MAP(dev, rt, K_MEM_CACHE_NONE);                                  \
-		DEVICE_MMIO_NAMED_MAP(dev, scfg, K_MEM_CACHE_NONE);                                \
-		IRQ_CONNECT(DT_INST_IRQN(idx), DT_INST_IRQ(idx, priority), secproxy_mailbox_isr,   \
-			    DEVICE_DT_INST_GET(idx),                                               \
-			    COND_CODE_1(DT_INST_IRQ_HAS_CELL(idx, flags),			\
-				(DT_INST_IRQ(idx, flags)), (0)));       \
-		return 0;                                                                          \
-	}                                                                                          \
-	DEVICE_DT_INST_DEFINE(idx, secproxy_mailbox_##idx##_init, NULL,                            \
-			      &secproxy_mailbox_##idx##_data, &secproxy_mailbox_##idx##_config,    \
+#define SECPROXY_THREAD_ISR(i, idx)                                                               \
+	COND_CODE_1(DT_INST_IRQ_HAS_NAME(idx, DT_CAT(rx_, i)),                                    \
+		(                                                                                 \
+			static void secproxy_mailbox_isr_##idx##_##i(const struct device *dev)    \
+			{                                                                         \
+				secproxy_mailbox_isr(dev, i);                                     \
+			}                                                                         \
+		),                                                                                \
+		())
+
+/* Generate IRQ number or -1 for array initialization */
+#define SECPROXY_IRQ_OR_INVALID(i, inst)                                                          \
+	COND_CODE_1(DT_INST_IRQ_HAS_NAME(inst, DT_CAT(rx_, i)),                                   \
+		(DT_INST_IRQ_BY_NAME(inst, DT_CAT(rx_, i), irq)),                                 \
+		(-1))
+
+#define SECPROXY_IRQ_CONNECT(i, inst)                                                             \
+	COND_CODE_1(DT_INST_IRQ_HAS_NAME(inst, DT_CAT(rx_, i)),                                   \
+		(                                                                                 \
+			IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, DT_CAT(rx_, i), irq),               \
+				DT_INST_IRQ_BY_NAME(inst, DT_CAT(rx_, i), priority),              \
+				secproxy_mailbox_isr_##inst##_##i,                                \
+				DEVICE_DT_INST_GET(inst),                                         \
+				COND_CODE_1(DT_INST_IRQ_HAS_CELL(inst, flags),                    \
+					(DT_INST_IRQ_BY_NAME(inst, DT_CAT(rx_, i), flags)),       \
+					(0)));                                                    \
+		),                                                                                \
+		())
+
+#define MAILBOX_INSTANCE_DEFINE(idx)                                                              \
+	LISTIFY(MAILBOX_MAX_CHANNELS, SECPROXY_THREAD_ISR, (), idx)                               \
+	static struct secproxy_mailbox_data secproxy_mailbox_##idx##_data;                        \
+	const static struct secproxy_mailbox_config secproxy_mailbox_##idx##_config = {           \
+		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(target_data, DT_DRV_INST(idx)),                \
+		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(rt, DT_DRV_INST(idx)),                         \
+		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(scfg, DT_DRV_INST(idx)),                       \
+		.interrupts = {LISTIFY(MAILBOX_MAX_CHANNELS,                                     \
+			 SECPROXY_IRQ_OR_INVALID, (,), idx) }};                              \
+	static int secproxy_mailbox_##idx##_init(const struct device *dev)                        \
+	{                                                                                         \
+		DEVICE_MMIO_NAMED_MAP(dev, target_data, K_MEM_CACHE_NONE);                        \
+		DEVICE_MMIO_NAMED_MAP(dev, rt, K_MEM_CACHE_NONE);                                 \
+		DEVICE_MMIO_NAMED_MAP(dev, scfg, K_MEM_CACHE_NONE);                               \
+		LISTIFY(MAILBOX_MAX_CHANNELS, SECPROXY_IRQ_CONNECT, (;), idx)                     \
+		return 0;                                                                         \
+	}                                                                                         \
+	DEVICE_DT_INST_DEFINE(idx, secproxy_mailbox_##idx##_init, NULL,                           \
+			      &secproxy_mailbox_##idx##_data, &secproxy_mailbox_##idx##_config,   \
 			      PRE_KERNEL_1, CONFIG_MBOX_INIT_PRIORITY,                             \
 			      &secproxy_mailbox_driver_api)
 

--- a/drivers/mbox/mbox_ti_secproxy.c
+++ b/drivers/mbox/mbox_ti_secproxy.c
@@ -205,6 +205,7 @@ static int secproxy_mailbox_send(const struct device *dev, uint32_t channel,
 	struct secproxy_mailbox_data *data = DEV_DATA(dev);
 	mem_addr_t data_reg;
 	k_spinlock_key_t key;
+	uint32_t status;
 
 	if (msg == NULL || msg->data == NULL) {
 		LOG_ERR("Invalid parameters");
@@ -226,13 +227,13 @@ static int secproxy_mailbox_send(const struct device *dev, uint32_t channel,
 	spt.rt = SEC_PROXY_THREAD(DEV_RT(dev), channel);
 	spt.scfg = SEC_PROXY_THREAD(DEV_SCFG(dev), channel);
 
-	if (secproxy_verify_thread(&spt, THREAD_IS_TX)) {
-		LOG_ERR("Thread is in error state\n");
+	status = secproxy_verify_thread(&spt, THREAD_IS_TX);
+	if (status != 0) {
 		k_spin_unlock(&data->lock, key);
-		return -EBUSY;
+		return status;
 	}
 
-	uint32_t status = sys_read32(spt.rt + RT_THREAD_STATUS);
+	status = sys_read32(spt.rt + RT_THREAD_STATUS);
 
 	if ((status & RT_THREAD_STATUS_CUR_CNT_MASK) == (SECPROXY_MAILBOX_NUM_MSGS)) {
 		k_spin_unlock(&data->lock, key);

--- a/drivers/mbox/mbox_ti_secproxy.c
+++ b/drivers/mbox/mbox_ti_secproxy.c
@@ -295,6 +295,21 @@ static uint32_t secproxy_mailbox_max_channels_get(const struct device *dev)
 	return MAILBOX_MAX_CHANNELS;
 }
 
+static void secproxy_mailbox_flush_thread(const struct device *dev, uint32_t channel)
+{
+	struct secproxy_thread spt;
+
+	spt.target_data = SEC_PROXY_THREAD(DEV_TDATA(dev), channel);
+	spt.rt = SEC_PROXY_THREAD(DEV_RT(dev), channel);
+	spt.scfg = SEC_PROXY_THREAD(DEV_SCFG(dev), channel);
+
+	/* Drain all pending messages from the thread */
+	while ((sys_read32(spt.rt + RT_THREAD_STATUS) & RT_THREAD_STATUS_CUR_CNT_MASK) > 0) {
+		/* Read from the last data register to consume one message */
+		(void)sys_read32(spt.target_data + SEC_PROXY_DATA_END_OFFS);
+	}
+}
+
 static int secproxy_mailbox_set_enabled(const struct device *dev, uint32_t channel, bool enable)
 {
 	const struct secproxy_mailbox_config *cfg = DEV_CFG(dev);
@@ -318,6 +333,7 @@ static int secproxy_mailbox_set_enabled(const struct device *dev, uint32_t chann
 	data->channel_enable[channel] = enable;
 
 	if (enable) {
+		secproxy_mailbox_flush_thread(dev, channel);
 		irq_enable(cfg->interrupts[channel]);
 	} else {
 		irq_disable(cfg->interrupts[channel]);

--- a/drivers/mbox/mbox_ti_secproxy.c
+++ b/drivers/mbox/mbox_ti_secproxy.c
@@ -38,9 +38,8 @@ LOG_MODULE_REGISTER(ti_secure_proxy);
 #define THREAD_IS_RX              1
 #define THREAD_IS_TX              0
 
-#define SECPROXY_MAILBOX_NUM_MSGS 5
-#define MAILBOX_MAX_CHANNELS      32
-#define MAILBOX_MBOX_SIZE         60
+#define MAILBOX_MAX_CHANNELS 32
+#define MAILBOX_MBOX_SIZE    60
 
 #define SEC_PROXY_DATA_START_OFFS 0x4
 #define SEC_PROXY_DATA_END_OFFS   0x3c
@@ -130,19 +129,7 @@ static void secproxy_mailbox_isr(const struct device *dev)
 		spt.rt = SEC_PROXY_THREAD(DEV_RT(dev), i_channel);
 		spt.scfg = SEC_PROXY_THREAD(DEV_SCFG(dev), i_channel);
 
-		uint32_t status = sys_read32(spt.rt + RT_THREAD_STATUS);
-
-		if (status & RT_THREAD_STATUS_ERROR_MASK) {
-			LOG_ERR("Thread %d error state detected in ISR", i_channel);
-			continue;
-		}
-
 		if (secproxy_verify_thread(&spt, THREAD_IS_RX)) {
-			LOG_ERR("Thread %d is in error state\n", i_channel);
-			continue;
-		}
-
-		if (!(sys_read32(spt.rt) & 0x7F)) {
 			continue;
 		}
 
@@ -231,13 +218,6 @@ static int secproxy_mailbox_send(const struct device *dev, uint32_t channel,
 	if (status != 0) {
 		k_spin_unlock(&data->lock, key);
 		return status;
-	}
-
-	status = sys_read32(spt.rt + RT_THREAD_STATUS);
-
-	if ((status & RT_THREAD_STATUS_CUR_CNT_MASK) == (SECPROXY_MAILBOX_NUM_MSGS)) {
-		k_spin_unlock(&data->lock, key);
-		return -EBUSY;
 	}
 
 	if (msg->size > MAILBOX_MBOX_SIZE) {

--- a/drivers/mbox/mbox_ti_secproxy.c
+++ b/drivers/mbox/mbox_ti_secproxy.c
@@ -32,7 +32,6 @@ LOG_MODULE_REGISTER(ti_secure_proxy);
 #define RT_THREAD_STATUS_CUR_CNT_MASK  GENMASK(7, 0)
 
 #define SCFG_THREAD_CTRL           0x1000
-#define SCFG_THREAD_CTRL_DIR_SHIFT 31
 #define SCFG_THREAD_CTRL_DIR_MASK  BIT(31)
 
 #define SEC_PROXY_THREAD(base, x) ((base) + (0x1000 * (x)))
@@ -45,8 +44,6 @@ LOG_MODULE_REGISTER(ti_secure_proxy);
 
 #define SEC_PROXY_DATA_START_OFFS 0x4
 #define SEC_PROXY_DATA_END_OFFS   0x3c
-
-#define SEC_PROXY_TIMEOUT_US 1000000
 
 #define GET_MSG_SEQ(buffer) ((uint32_t *)buffer)[1]
 struct secproxy_thread {
@@ -89,14 +86,15 @@ struct secproxy_mailbox_config {
 static inline int secproxy_verify_thread(struct secproxy_thread *spt, uint8_t dir)
 {
 	/* Check for any errors already available */
-	if (sys_read32(spt->rt + RT_THREAD_STATUS) & RT_THREAD_STATUS_ERROR_MASK) {
+	uint32_t status = sys_read32(spt->rt + RT_THREAD_STATUS);
+
+	if (status & RT_THREAD_STATUS_ERROR_MASK) {
 		LOG_ERR("Thread is corrupted, cannot send data.\n");
 		return -EINVAL;
 	}
 
 	/* Make sure thread is configured for right direction */
-	if ((sys_read32(spt->scfg + SCFG_THREAD_CTRL) & SCFG_THREAD_CTRL_DIR_MASK) !=
-	    (dir << SCFG_THREAD_CTRL_DIR_SHIFT)) {
+	if (FIELD_GET(SCFG_THREAD_CTRL_DIR_MASK, sys_read32(spt->scfg + SCFG_THREAD_CTRL)) != dir) {
 		if (dir == THREAD_IS_TX) {
 			LOG_ERR("Trying to send data on RX Thread\n");
 		} else {
@@ -105,18 +103,11 @@ static inline int secproxy_verify_thread(struct secproxy_thread *spt, uint8_t di
 		return -EINVAL;
 	}
 
-	/* Check the message queue before sending/receiving data */
-	int timeout_ms = SEC_PROXY_TIMEOUT_US;
-	int waited_ms = 0;
-	const int poll_interval_ms = 1000;
-
-	while (!(sys_read32(spt->rt + RT_THREAD_STATUS) & RT_THREAD_STATUS_CUR_CNT_MASK)) {
-		k_busy_wait(poll_interval_ms);
-		waited_ms += poll_interval_ms;
-		if (waited_ms >= timeout_ms) {
-			LOG_ERR("Timeout waiting for thread to %s\n",
-				(dir == THREAD_IS_TX) ? "empty" : "fill");
-			return -ETIMEDOUT;
+	if ((status & RT_THREAD_STATUS_CUR_CNT_MASK) == 0) {
+		if (dir == THREAD_IS_TX) {
+			return -EBUSY;
+		} else {
+			return -ENODATA;
 		}
 	}
 

--- a/dts/arm/ti/am64x_r5.dtsi
+++ b/dts/arm/ti/am64x_r5.dtsi
@@ -58,16 +58,6 @@
 	};
 };
 
-&dmsc {
-	ti,host-id = <36>;
-	mboxes = <&secure_proxy_main 2>, <&secure_proxy_main 3>;
-};
-
-&secure_proxy_main {
-	interrupts = <0 65 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
-	interrupt-parent = <&vim>;
-};
-
 &main_timer0 {
 	interrupts = <0 152 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&vim>;

--- a/dts/arm/ti/am64x_r5f0_0.dtsi
+++ b/dts/arm/ti/am64x_r5f0_0.dtsi
@@ -15,3 +15,15 @@
 	interrupts = <0 0 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&vim>;
 };
+
+&dmsc {
+	ti,host-id = <36>;
+	mboxes = <&secure_proxy_main 2>, <&secure_proxy_main 3>;
+};
+
+&secure_proxy_main {
+	interrupt-names = "rx_0", "rx_2";
+	interrupts = <0 64 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>,
+		     <0 65 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&vim>;
+};

--- a/dts/arm/ti/am64x_r5f0_1.dtsi
+++ b/dts/arm/ti/am64x_r5f0_1.dtsi
@@ -15,3 +15,15 @@
 	interrupts = <0 0 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&vim>;
 };
+
+&dmsc {
+	ti,host-id = <38>;
+	mboxes = <&secure_proxy_main 6>, <&secure_proxy_main 7>;
+};
+
+&secure_proxy_main {
+	interrupt-names = "rx_4", "rx_6";
+	interrupts = <0 66 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>,
+		     <0 67 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&vim>;
+};

--- a/dts/arm/ti/am64x_r5f1_0.dtsi
+++ b/dts/arm/ti/am64x_r5f1_0.dtsi
@@ -15,3 +15,15 @@
 	interrupts = <0 0 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&vim>;
 };
+
+&dmsc {
+	ti,host-id = <41>;
+	mboxes = <&secure_proxy_main 20>, <&secure_proxy_main 21>;
+};
+
+&secure_proxy_main {
+	interrupt-names = "rx_18", "rx_20";
+	interrupts = <0 64 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>,
+		     <0 65 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&vim>;
+};

--- a/dts/arm/ti/am64x_r5f1_1.dtsi
+++ b/dts/arm/ti/am64x_r5f1_1.dtsi
@@ -15,3 +15,15 @@
 	interrupts = <0 0 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&vim>;
 };
+
+&dmsc {
+	ti,host-id = <43>;
+	mboxes = <&secure_proxy_main 24>, <&secure_proxy_main 25>;
+};
+
+&secure_proxy_main {
+	interrupt-names = "rx_22", "rx_24";
+	interrupts = <0 66 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>,
+		     <0 67 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&vim>;
+};

--- a/dts/bindings/mbox/ti,secure-proxy.yaml
+++ b/dts/bindings/mbox/ti,secure-proxy.yaml
@@ -14,5 +14,8 @@ properties:
   interrupts:
     required: true
 
+  interrupt-names:
+    required: true
+
 mbox-cells:
   - channel


### PR DESCRIPTION
Improves the TI secure proxy mailbox driver with better error handling, per-channel interrupt support, and thread cleanup.

1: Fix thread verification
  - Replaced busy-wait loop with immediate error returns (-EINVAL, -EBUSY, -ENODATA)
  - Removed redundant message count checks
  - Simplified ISR error handling

  2: Support per-channel interrupts
  - Changed from single shared interrupt to per-channel interrupt array with individual ISR handlers
  - ISR now processes specific channels directly instead of polling all channels
  - Moved device tree configuration to core-specific files (am64x_r5f0_0.dtsi)
  - Added interrupt-names requirement to device tree binding

  3: Add thread flush on channel enable
  - Added secproxy_mailbox_flush_thread() to drain pending messages from RX thread
  - Automatically flushes thread when enabling channel to ensure clean state
  - Prevents stale messages from previous sessions

  4: Add SPDX License Identifier
 