### PR TITLE
logging: log_output: Fix formatting of function prefix

### DIFF
--- a/samples/subsys/cpu_freq/on_demand/sample.yaml
+++ b/samples/subsys/cpu_freq/on_demand/sample.yaml
@@ -8,11 +8,11 @@ common:
     type: multi_line
     regex:
       - "^.*<inf> cpu_freq_on_demand_sample: Starting CPU Freq on-demand policy Sample!"
-      - "^.*<dbg> cpu_load_metric: cpu_load_metric_get: CPU[0-9]+ Execution cycles: \
+      - "^.*<dbg> cpu_load_metric.cpu_load_metric_get: CPU[0-9]+ Execution cycles: \
          [0-9]+, Total cycles: [0-9]+"
-      - "^.*<dbg> cpu_freq_policy_on_demand: cpu_freq_policy_select_pstate: \
+      - "^.*<dbg> cpu_freq_policy_on_demand.cpu_freq_policy_select_pstate: \
          CPU[0-9]+ Load: [0-9]+%"
-      - "^.*<dbg> cpu_freq_policy_on_demand: cpu_freq_policy_select_pstate: On-Demand Policy: \
+      - "^.*<dbg> cpu_freq_policy_on_demand.cpu_freq_policy_select_pstate: On-Demand Policy: \
          Selected P-state [0-9]+ with load_threshold=[0-9]+%"
 
 tests:

--- a/samples/subsys/cpu_freq/pressure/sample.yaml
+++ b/samples/subsys/cpu_freq/pressure/sample.yaml
@@ -8,21 +8,21 @@ common:
     type: multi_line
     regex:
       - "^.*<inf> cpu_freq_pressure_sample: Mode 1: Low only"
-      - "^.*<dbg> cpu_freq_policy_pressure: thread_eval_cb: Evaluating thread: 0x[0-9a-fA-F]+ \
+      - "^.*<dbg> cpu_freq_policy_pressure.thread_eval_cb: Evaluating thread: 0x[0-9a-fA-F]+ \
          with prio: [0-9]+ status: [0-9]+"
-      - "^.*<dbg> cpu_freq_policy_pressure: thread_eval_cb: Evaluating thread: 0x[0-9a-fA-F]+ \
+      - "^.*<dbg> cpu_freq_policy_pressure.thread_eval_cb: Evaluating thread: 0x[0-9a-fA-F]+ \
          with prio: [0-9]+ status: [0-9]+"
-      - "^.*<dbg> cpu_freq_policy_pressure: thread_eval_cb: Evaluating thread: 0x[0-9a-fA-F]+ \
+      - "^.*<dbg> cpu_freq_policy_pressure.thread_eval_cb: Evaluating thread: 0x[0-9a-fA-F]+ \
          with prio: [0-9]+ status: [0-9]+"
-      - "^.*<dbg> cpu_freq_policy_pressure: thread_eval_cb: Evaluating thread: 0x[0-9a-fA-F]+ \
+      - "^.*<dbg> cpu_freq_policy_pressure.thread_eval_cb: Evaluating thread: 0x[0-9a-fA-F]+ \
          with prio: [0-9]+ status: [0-9]+"
-      - "^.*<dbg> cpu_freq_policy_pressure: thread_eval_cb: Evaluating thread: 0x[0-9a-fA-F]+ \
+      - "^.*<dbg> cpu_freq_policy_pressure.thread_eval_cb: Evaluating thread: 0x[0-9a-fA-F]+ \
          with prio: [0-9]+ status: [0-9]+"
-      - "^.*<dbg> cpu_freq_policy_pressure: get_normalized_sys_pressure: System pressure is: \
+      - "^.*<dbg> cpu_freq_policy_pressure.get_normalized_sys_pressure: System pressure is: \
          [0-9]+% \\(raw: [0-9]+ / max: [0-9]+\\)"
-      - "^.*<dbg> cpu_freq_policy_pressure: cpu_freq_policy_select_pstate: CPU[0-9]+ Pressure: \
+      - "^.*<dbg> cpu_freq_policy_pressure.cpu_freq_policy_select_pstate: CPU[0-9]+ Pressure: \
          [0-9]+%"
-      - "^.*<dbg> cpu_freq_policy_pressure: cpu_freq_policy_select_pstate: Pressure Policy: \
+      - "^.*<dbg> cpu_freq_policy_pressure.cpu_freq_policy_select_pstate: Pressure Policy: \
          Selected P-state [0-9]+ with load_threshold=[0-9]+%"
 
 tests:

--- a/samples/subsys/llext/modules/prj.conf
+++ b/samples/subsys/llext/modules/prj.conf
@@ -20,7 +20,7 @@ CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y # supported by all targets
 # This test consumes large amounts of stack when loading the LLEXT.
 # Increase the available size to avoid overflowing (see issue #74536).
 
-CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_MAIN_STACK_SIZE=2096
 
 # NOTE
 #

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -47,6 +47,18 @@ static const char *const colors[] = {
 	IS_ENABLED(CONFIG_LOG_DBG_COLOR_BLUE) ? LOG_COLOR_CODE_BLUE : NULL,   /* dbg */
 };
 
+static const bool func_prefix_used = IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_ERR) ||
+				     IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_WRN) ||
+				     IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_INF) ||
+				     IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_DBG);
+static const bool func_on_lut[] = {
+	false,
+	IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_ERR),
+	IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_WRN),
+	IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_INF),
+	IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_DBG),
+};
+
 static uint32_t freq;
 static log_timestamp_t timestamp_div;
 
@@ -670,8 +682,8 @@ void log_output_process(const struct log_output *output,
 	cbprintf_cb cb;
 
 	if (!raw_string) {
-		prefix_offset = prefix_print(output, flags, 0, timestamp,
-					     domain, source, tid, core_id, level);
+		prefix_offset = prefix_print(output, flags, func_prefix_used && func_on_lut[level],
+					     timestamp, domain, source, tid, core_id, level);
 		cb = out_func;
 	} else {
 		prefix_offset = 0;

--- a/tests/subsys/logging/log_output/src/log_output_test.c
+++ b/tests/subsys/logging/log_output/src/log_output_test.c
@@ -167,30 +167,58 @@ ZTEST(test_log_output, test_ts_to_us)
 	zassert_equal(log_output_timestamp_to_us(10), 305);
 }
 
+static bool use_func_prefix(uint8_t level)
+{
+	switch (level) {
+	case LOG_LEVEL_ERR:
+		return IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_ERR);
+	case LOG_LEVEL_WRN:
+		return IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_WRN);
+	case LOG_LEVEL_INF:
+		return IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_INF);
+	case LOG_LEVEL_DBG:
+		return IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_DBG);
+	default:
+		return false;
+	}
+}
+
 ZTEST(test_log_output, test_levels)
 {
 	char package[256];
-	static const char *const exp_strs[] = {
-		"<err> " SNAME ": " TEST_STR "\r\n",
-		"<wrn> " SNAME ": " TEST_STR "\r\n",
-		"<inf> " SNAME ": " TEST_STR "\r\n",
-		"<dbg> " SNAME ": " TEST_STR "\r\n"
+	static const char *const level_strs[] = {
+		"<err>",
+		"<wrn>",
+		"<inf>",
+		"<dbg>"
 	};
 	uint8_t levels[] = {LOG_LEVEL_ERR, LOG_LEVEL_WRN, LOG_LEVEL_INF, LOG_LEVEL_DBG};
 	uint32_t flags = LOG_OUTPUT_FLAG_LEVEL;
+	char exp_str[128];
 	int err;
 
-	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
-	zassert_true(err > 0);
+	ARRAY_FOR_EACH(levels, i) {
+		int slen;
 
-	for (int i = 0; i < ARRAY_SIZE(exp_strs); i++) {
 		reset_mock_buffer();
+
+		if (use_func_prefix(levels[i])) {
+			slen = sprintf(exp_str, "%s %s.%s: %s\r\n",
+				level_strs[i], SNAME, __func__, TEST_STR);
+			err = cbprintf_package(package, sizeof(package), 0,
+						"%s: " TEST_STR, __func__);
+		} else {
+			slen = sprintf(exp_str, "%s %s: %s\r\n", level_strs[i], SNAME, TEST_STR);
+			err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
+		}
+		zassert_true(err > 0);
 
 		log_output_process(&log_output, 0, NULL, SNAME, NULL, 0, levels[i],
 				   package, NULL, 0, flags);
 
 		mock_buffer[mock_len] = '\0';
-		zassert_str_equal(exp_strs[i], mock_buffer);
+		zassert_equal(mock_len, slen);
+		zassert_str_equal(exp_str, mock_buffer, "exp:%s, got:%s", exp_str, mock_buffer);
 	}
 }
 
@@ -215,27 +243,48 @@ ZTEST(test_log_output, test_colors)
 #endif /* CONFIG_LOG_BACKEND_SHOW_COLOR */
 
 	char package[256];
-	static const char *const exp_strs[] = {
-		LOG_COLOR_ERR "<err> " SNAME ": " TEST_STR LOG_COLOR_CODE_DEFAULT "\r\n",
-		LOG_COLOR_WRN "<wrn> " SNAME ": " TEST_STR LOG_COLOR_CODE_DEFAULT "\r\n",
-		LOG_COLOR_INF "<inf> " SNAME ": " TEST_STR LOG_COLOR_CODE_DEFAULT "\r\n",
-		LOG_COLOR_DBG "<dbg> " SNAME ": " TEST_STR LOG_COLOR_CODE_DEFAULT "\r\n"
+	static const char *const color_strs[] = {
+		LOG_COLOR_ERR,
+		LOG_COLOR_WRN,
+		LOG_COLOR_INF,
+		LOG_COLOR_DBG
+	};
+	static const char *const level_strs[] = {
+		"<err>",
+		"<wrn>",
+		"<inf>",
+		"<dbg>"
 	};
 	uint8_t levels[] = {LOG_LEVEL_ERR, LOG_LEVEL_WRN, LOG_LEVEL_INF, LOG_LEVEL_DBG};
 	uint32_t flags = LOG_OUTPUT_FLAG_LEVEL | LOG_OUTPUT_FLAG_COLORS;
+	char exp_str[128];
 	int err;
 
-	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
-	zassert_true(err > 0);
+	ARRAY_FOR_EACH(levels, i) {
+		int slen;
 
-	for (int i = 0; i < ARRAY_SIZE(exp_strs); i++) {
+		if (use_func_prefix(levels[i])) {
+			slen = sprintf(exp_str, "%s%s %s.%s: %s%s\r\n",
+				color_strs[i], level_strs[i], SNAME, __func__, TEST_STR,
+				LOG_COLOR_CODE_DEFAULT);
+			err = cbprintf_package(package, sizeof(package), 0,
+						"%s: " TEST_STR, __func__);
+			zassert_true(err >= 0);
+		} else {
+			slen = sprintf(exp_str, "%s%s %s: %s%s\r\n",
+				color_strs[i], level_strs[i], SNAME, TEST_STR,
+				LOG_COLOR_CODE_DEFAULT);
+			err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
+			zassert_true(err >= 0);
+		}
 		reset_mock_buffer();
 
 		log_output_process(&log_output, 0, NULL, SNAME, NULL, 0, levels[i],
 				   package, NULL, 0, flags);
 
 		mock_buffer[mock_len] = '\0';
-		zassert_str_equal(exp_strs[i], mock_buffer);
+		zassert_equal(mock_len, slen);
+		zassert_str_equal(exp_str, mock_buffer, "exp:%s got:%s", exp_str, mock_buffer);
 	}
 }
 


### PR DESCRIPTION
Log_output module is fixed to use expected formatting of function prefix and test need to be aligned to validate that correct formatting is used for debug level where function name prefix is by default enabled.

Test is aligned to validate correctness of the formatting.