### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -1071,8 +1071,6 @@ menu "Boot Options"
 
 config IS_BOOTLOADER
 	bool "Act as a bootloader"
-	depends on XIP
-	depends on ARM
 	help
 	  This option indicates that Zephyr will act as a bootloader to execute
 	  a separate Zephyr image payload.

--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: c11e845e2483917d7478ba1a7a3591a9f4e8d4a2
+      revision: 234c66e66ee39c0f836a57ba805245534be332f2
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  234c66e66ee39c0f836a57ba805245534be332f2

Brings following Zephyr relevant fixes:

  - 55ae5342 doc: imgtool: Update available options
  - cd96b62f boot: zephyr: Fix comment in banner.c
  - 1357a70f Updates for v2.3.0-rc2 release
  - afcca2c7 boot: zephyr: Fix Espressif build issues
  - d95ca5c7 boot: zephyr: Remove BOOT_MAX_IMG settings
  - 623f0230 boot: zephyr: stm32n657xx: Move overlay to socs
  - 31469b43 boot: zephyr: kconfig: Flip swap move defaults for esp32/stm32
  - a2ee0a75 scripts: imgtool: Fix verification with public ed25519 key file
  - 49bbbabf boot: zephyr: Add watchdog setup/timeout configurability options
  - c25d2506 boot: zephyr: Move watchdog code to separate file
  - 9efb9d3f boot: zephyr: kconfig: Move modes to choice Kconfig
  - 92854b7b boot: zephyr: kconfig: Only show signature file when needed
  - 716f338a boot: zephyr: Remove weird custom key directory handling
  - c52f8af7 boot: zephyr: select `IS_BOOTLOADER`

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.