### PR TITLE
Enable LCD_PAR_S035 shield 8080 mode for RT700

### DIFF
--- a/boards/nxp/mimxrt700_evk/doc/index.rst
+++ b/boards/nxp/mimxrt700_evk/doc/index.rst
@@ -229,14 +229,6 @@ should see the following message in the terminal:
    *** Booting Zephyr OS v3.7.0 ***
    Hello World! mimxrt700_evk/mimxrt798s/cm33_cpu0
 
-.. include:: ../../common/board-footer.rst.inc
-
-.. _i.MX RT700 Website:
-   https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/i-mx-rt-crossover-mcus/i-mx-rt700-crossover-mcu-with-arm-cortex-m33-npu-dsp-and-gpu-cores:i.MX-RT700
-
-.. _MIMXRT700-EVK Debug Firmware:
-   https://www.nxp.com/docs/en/application-note/AN13206.pdf
-
 Display Support
 ***************
 
@@ -289,3 +281,27 @@ for a list). The display sample can be built for this module like so:
    :zephyr-app: samples/drivers/display
    :goals: build
    :compact:
+
+NXP LCD_PAR_S035
+================
+
+The :ref:`lcd_par_s035` connects to the board's LCD socket J4 pin 1 to pin 28
+directly, but some modifications are required (see
+:zephyr_file:`boards/shields/lcd_par_s035/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay`
+for a list). Connect JP7 2&3 to use 3.3v interface, and remove resistance R60 to use the touch
+function. The display sample can be built for this module like so:
+
+.. zephyr-app-commands::
+   :board: mimxrt700_evk/mimxrt798s/cm33_cpu0
+   :shield: lcd_par_s035_8080
+   :zephyr-app: samples/drivers/display
+   :goals: build
+   :compact:
+
+.. include:: ../../common/board-footer.rst.inc
+
+.. _i.MX RT700 Website:
+   https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/i-mx-rt-crossover-mcus/i-mx-rt700-crossover-mcu-with-arm-cortex-m33-npu-dsp-and-gpu-cores:i.MX-RT700
+
+.. _MIMXRT700-EVK Debug Firmware:
+   https://www.nxp.com/docs/en/application-note/AN13206.pdf

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk-pinctrl.dtsi
@@ -272,4 +272,35 @@
 			input-enable;
 		};
 	};
+
+	pinmux_lcdif_dbi: pinmux_lcdif_dbi {
+		group0 {
+			pinmux = <LCDIF_DBI_DATA0_PIO2_6>,
+				 <LCDIF_DBI_DATA1_PIO2_7>,
+				 <LCDIF_DBI_DATA2_PIO2_8>,
+				 <LCDIF_DBI_DATA3_PIO2_9>,
+				 <LCDIF_DBI_DATA4_PIO2_10>,
+				 <LCDIF_DBI_DATA5_PIO2_11>,
+				 <LCDIF_DBI_DATA6_PIO2_12>,
+				 <LCDIF_DBI_DATA7_PIO2_13>;
+			slew-rate = "normal";
+			drive-strength = "normal";
+			bias-pull-up;
+		};
+
+		group1 {
+			pinmux = <GPIO2_GPIO15_PIO2_15>,
+				 <LCD_DBI_CSX_AB_PIO2_0>,
+				 <LCD_DBI_WRX_PIO2_4>;
+			slew-rate = "normal";
+			drive-strength = "normal";
+		};
+
+		group2 {
+			pinmux = <LCD_DBI_DCX_AB_PIO2_1>,
+				 <LCD_DBI_RWDX_PIO2_3>;
+			slew-rate = "normal";
+			drive-strength = "normal";
+		};
+	};
 };

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -118,6 +118,19 @@
 		status = "okay";
 		zephyr,memory-region = "PSRAM2";
 	};
+
+	/*
+	 * This node describes the GPIO pins of the LCD-PAR-S035 panel 8080 interface.
+	 */
+	nxp_lcd_8080_connector: lcd-8080-connector {
+		compatible = "nxp,lcd-8080";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <9 0 &gpio2 5 0>,	/* Pin 9, LCD touch INT */
+			   <10 0 &gpio2 2 0>,	/* Pin 10, LCD backlight control */
+			   <11 0 &gpio2 15 0>;	/* Pin 11, LCD and touch reset */
+	};
 };
 
 &ctimer0 {
@@ -295,6 +308,10 @@ nxp_mipi_i2c: &flexcomm8_lpi2c8 {};
 zephyr_mipi_dsi: &mipi_dsi {};
 
 zephyr_lcdif: &lcdif {};
+
+zephyr_mipi_dbi_parallel: &lcdif {};
+
+nxp_8080_touch_panel_i2c: &flexcomm8_lpi2c8 {};
 
 &gpio0 {
 	status = "okay";

--- a/boards/shields/lcd_par_s035/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.conf
+++ b/boards/shields/lcd_par_s035/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.conf
@@ -1,0 +1,1 @@
+CONFIG_DCACHE=n # DCNano DBI controller cannot be used with data cahce

--- a/boards/shields/lcd_par_s035/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
+++ b/boards/shields/lcd_par_s035/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+#include <zephyr/dt-bindings/display/panel.h>
+
+&zephyr_lcdif {
+	status = "okay";
+	clock-frequency = <279000000>;
+	wr-period = <14>;
+	wr-assert = <6>;
+	wr-deassert = <13>;
+	cs-assert = <1>;
+	cs-deassert = <4>;
+	reset-gpios = <&gpio2 15 GPIO_ACTIVE_HIGH>;
+	pinctrl-0 = <&pinmux_lcdif_dbi>;
+	pinctrl-names = "default";
+};
+
+&st7796s {
+	status = "okay";
+	mipi-mode = "MIPI_DBI_MODE_8080_BUS_8_BIT";
+	color-coding = "MIPI_DBI_MODE_RGB565";
+};

--- a/drivers/display/display_st7796s.c
+++ b/drivers/display/display_st7796s.c
@@ -167,6 +167,9 @@ static int st7796s_write(const struct device *dev,
 
 	mipi_desc.buf_size = desc->width * desc->height * ST7796S_PIXEL_SIZE;
 	mipi_desc.frame_incomplete = desc->frame_incomplete;
+	mipi_desc.pitch = desc->pitch;
+	mipi_desc.width = desc->width;
+	mipi_desc.height = desc->height;
 
 	ret =  mipi_dbi_command_write(config->mipi_dbi,
 				      &config->dbi_config, ST7796S_CMD_RAMWR,
@@ -379,8 +382,11 @@ static DEVICE_API(display, st7796s_api) = {
 						SPI_OP_MODE_MASTER |		\
 						SPI_WORD_SET(8),		\
 						0),				\
-			.mode = DT_INST_STRING_UPPER_TOKEN_OR(n, mipi_mode,     \
+			.mode = DT_INST_STRING_UPPER_TOKEN_OR(n, mipi_mode,	\
 						MIPI_DBI_MODE_SPI_4WIRE),	\
+			.color_coding = DT_INST_STRING_UPPER_TOKEN_OR(n,	\
+						color_coding,			\
+						MIPI_DBI_MODE_RGB565),		\
 		},								\
 		.width = DT_INST_PROP(n, width),				\
 		.height = DT_INST_PROP(n, height),				\

--- a/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
@@ -93,7 +93,7 @@ static int mcux_dcnano_lcdif_dbi_configure(const struct device *dev,
 	const struct mcux_dcnano_lcdif_dbi_config *config = dev->config;
 	struct mcux_dcnano_lcdif_dbi_data *lcdif_data = dev->data;
 	uint8_t bus_type = dbi_config->mode & 0xFU;
-	uint8_t color_coding = dbi_config->mode & 0xF0U;
+	uint8_t color_coding = dbi_config->color_coding & 0xF0U;
 	lcdif_dbi_config_t lcdif_dbi_config = config->dbi_config;
 	status_t status;
 

--- a/drivers/mipi_dsi/dsi_mcux_2l.c
+++ b/drivers/mipi_dsi/dsi_mcux_2l.c
@@ -272,13 +272,13 @@ static status_t dsi_mcux_dcnano_transfer(const struct device *dev, uint8_t chann
 		switch (data->src_bytes_per_pixel) {
 		case 2:
 			pixfmt = PIXEL_FORMAT_RGB_565;
-			dbi_config.mode |= MIPI_DBI_MODE_RGB565;
+			dbi_config.color_coding = MIPI_DBI_MODE_RGB565;
 			DSI_SetDbiPixelFormat(config->base, kDSI_DbiRGB565);
 			break;
 		case 3:
 			pixfmt = PIXEL_FORMAT_RGB_888;
 			/* If using the DBI, only RGB888 option 1 is supported. */
-			dbi_config.mode |= MIPI_DBI_MODE_RGB888_1;
+			dbi_config.color_coding = MIPI_DBI_MODE_RGB888_1;
 			DSI_SetDbiPixelFormat(config->base, kDSI_DbiRGB888);
 			break;
 		default:

--- a/dts/bindings/mipi-dbi/nxp,mipi-dbi-dcnano-lcdif.yaml
+++ b/dts/bindings/mipi-dbi/nxp,mipi-dbi-dcnano-lcdif.yaml
@@ -17,7 +17,9 @@ description: |
 
 compatible: "nxp,mipi-dbi-dcnano-lcdif"
 
-include: [base.yaml]
+include: ["base.yaml", "pinctrl-device.yaml"]
+
+bus: mipi-dbi
 
 properties:
   clock-frequency:

--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -116,3 +116,4 @@ tests:
       - platform:ek_ra8d1:SHIELD=rtkmipilcdb00000be
       - platform:ek_ra8d1:SHIELD=rtk7eka6m3b00001bu
       - platform:nucleo_g071rb/stm32g071xx:SHIELD=x_nucleo_gfx01m2
+      - platform:mimxrt700_evk/mimxrt798s/cm33_cpu0:SHIELD=lcd_par_s035_8080


### PR DESCRIPTION
1.Fix wrong handling of color coding in NXP DCnano DBI driver and dsi_mcux_2l driver
2.Update st7796s display driver to support color coding
3.Enable shield LCD_PAR_S035 8080 mode on RT700