### PR TITLE
boards: nxp: remove unused definitions

### DIFF
--- a/boards/nxp/frdm_mcxn947/CMakeLists.txt
+++ b/boards/nxp/frdm_mcxn947/CMakeLists.txt
@@ -9,7 +9,6 @@ zephyr_library_sources(board.c)
 
 if(CONFIG_FLEXSPI_CONFIG_BLOCK_OFFSET)
   # Include flash configuration block
-  zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
   zephyr_library_sources(xip/mcxn_flexspi_nor_config.c)
   zephyr_library_include_directories(xip)
 endif()

--- a/boards/nxp/frdm_rw612/CMakeLists.txt
+++ b/boards/nxp/frdm_rw612/CMakeLists.txt
@@ -10,7 +10,6 @@ dt_nodelabel(xtal32 NODELABEL "xtal32")
 dt_node_has_status(xtal32_status PATH ${xtal32} STATUS okay)
 
 if(CONFIG_NXP_RW6XX_BOOT_HEADER)
-  zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
   # This FCB is specific to the flash on this board, it won't work
   # for boards with different flash chips. If you flash this FCB
   # onto a board with a different flash chip you may break it.

--- a/boards/nxp/mcx_nx4x_evk/CMakeLists.txt
+++ b/boards/nxp/mcx_nx4x_evk/CMakeLists.txt
@@ -9,7 +9,6 @@ zephyr_library_sources(board.c)
 
 if(CONFIG_FLEXSPI_CONFIG_BLOCK_OFFSET)
   # Include flash configuration block
-  zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
   zephyr_library_sources(xip/mcxn_flexspi_nor_config.c)
   zephyr_library_include_directories(xip)
 endif()

--- a/boards/nxp/rd_rw612_bga/CMakeLists.txt
+++ b/boards/nxp/rd_rw612_bga/CMakeLists.txt
@@ -16,7 +16,6 @@ if(CONFIG_NXP_RW6XX_BOOT_HEADER)
      "update your flash configuration block data")
   endif()
   zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)
-  zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
   zephyr_library_sources(MX25U51245GZ4I00_FCB.c)
 endif()
 


### PR DESCRIPTION
1. Remove 'XIP_BOOT_HEADER_ENABLE', it is not used in the mcxn947 build tree.
2. Remove 'BOARD_FLASH_SIZE', it is not used in the rw612 build tree.