### PR TITLE
add spsdk runner support for both imx93_evk and frdm_imx93 Cortex-A55

### DIFF
--- a/boards/nxp/frdm_imx93/CMakeLists.txt
+++ b/boards/nxp/frdm_imx93/CMakeLists.txt
@@ -1,0 +1,84 @@
+#
+# Copyright 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
+  AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
+  find_program(7Z_EXECUTABLE 7z REQUIRED)
+  # reuse EVK's firmware
+  set(FIRMWARE_RELEASE "imx93evk-boot-firmware-6.12.34-2.1.0")
+  # Parse SPSDK version
+  execute_process(
+    COMMAND spsdk --version
+    OUTPUT_VARIABLE SPSDK_VERSION_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" SPSDK_VERSION "${SPSDK_VERSION_OUTPUT}")
+  message(STATUS "SPSDK version is ${SPSDK_VERSION}")
+
+  if(CONFIG_SOC_MIMX9352_A55)
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx93_frdm_mimx9352_a55_ahab_primary.yaml
+      "
+      family: mimx9352
+      revision: a1
+      target_memory: serial_downloader
+      output:                   ${CMAKE_BINARY_DIR}/zephyr/primary_ahab.bin
+      containers:
+        - binary_container:
+            path:               ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/mx93a1-ahab-container.img
+        - container:
+            srk_set: none
+            images:
+              - lpddr_imem_1d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_imem_1d_v202201.bin
+                lpddr_imem_2d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_imem_2d_v202201.bin
+                lpddr_dmem_1d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_dmem_1d_v202201.bin
+                lpddr_dmem_2d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_dmem_2d_v202201.bin
+                spl_ddr:           ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/u-boot-spl.bin-imx93evk-sd
+    ")
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx93_frdm_mimx9352_a55_ahab_secondary.yaml
+      "
+      family: mimx9352
+      revision: a1
+      target_memory: serial_downloader
+      output:                   ${CMAKE_BINARY_DIR}/zephyr/secondary_ahab.bin
+      containers:
+        - container:
+            srk_set: none
+            images:
+              - atf:            ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/bl31-imx93-zephyr.bin
+              - image_path:     ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
+                load_address:   '${CONFIG_SRAM_BASE_ADDRESS}'
+                entry_point:    '${CONFIG_SRAM_BASE_ADDRESS}'
+                image_type:     executable
+                core_id:        cortex-a55
+                is_encrypted:   false
+    ")
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx93_frdm_mimx9352_a55_ahab_flash_template.yaml
+      "
+      family: mimx9352
+      revision: a1
+      memory_type: serial_downloader
+      primary_image_container_set: ${CMAKE_BINARY_DIR}/zephyr/imx93_frdm_mimx9352_a55_ahab_primary.yaml
+      secondary_image_container_set: ${CMAKE_BINARY_DIR}/zephyr/imx93_frdm_mimx9352_a55_ahab_secondary.yaml
+   ")
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND ${7Z_EXECUTABLE} x ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin -o./imx-boot-firmware -aos -bso0 -bse1
+      COMMAND ${7Z_EXECUTABLE} x imx-boot-firmware/${FIRMWARE_RELEASE} -aos -bso0 -bse1
+    )
+    if(SPSDK_VERSION VERSION_GREATER_EQUAL "3.0.0")
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+        COMMAND nxpimage bootable-image export -c ${CMAKE_BINARY_DIR}/zephyr/imx93_frdm_mimx9352_a55_ahab_flash_template.yaml -o flash.bin
+      )
+    else()
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+        COMMAND nxpimage bootable-image merge -c ${CMAKE_BINARY_DIR}/zephyr/imx93_frdm_mimx9352_a55_ahab_flash_template.yaml -o flash.bin
+      )
+    endif()
+  else()
+    message(FATAL_ERROR "SPSDK Image not supported on the platform!")
+  endif()
+  zephyr_blobs_verify(FILES
+    ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin
+    REQUIRED)
+endif()

--- a/boards/nxp/frdm_imx93/Kconfig
+++ b/boards/nxp/frdm_imx93/Kconfig
@@ -1,0 +1,6 @@
+# i.MX 93 FRDM board configuration
+
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+source "boards/nxp/common/Kconfig"

--- a/boards/nxp/frdm_imx93/board.cmake
+++ b/boards/nxp/frdm_imx93/board.cmake
@@ -3,9 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_SOC_MIMX9352_A55)
+  board_runner_args(jlink "--device=MIMX9352_A55_0" "--no-reset" "--flash-sram")
 
-board_runner_args(jlink "--device=MIMX9352_A55_0" "--no-reset" "--flash-sram")
+  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+endif()
 
-include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
+  AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
+  board_set_flasher_ifnset(spsdk)
 
+  board_runner_args(spsdk "--family=mimx9352")
+  # reuse evk board's bootloader
+  board_runner_args(spsdk "--bootloader=${CMAKE_BINARY_DIR}/zephyr/imx93evk-boot-firmware-6.12.34-2.1.0/imx-boot-imx93evk-sd.bin-flash_singleboot")
+  board_runner_args(spsdk "--flashbin=${CMAKE_BINARY_DIR}/zephyr/flash.bin")
+  board_runner_args(spsdk "--containers=one")
+
+  include(${ZEPHYR_BASE}/boards/common/spsdk.board.cmake)
 endif()

--- a/boards/nxp/frdm_imx93/doc/index.rst
+++ b/boards/nxp/frdm_imx93/doc/index.rst
@@ -124,7 +124,7 @@ Programming and Debugging (A55)
 
 .. zephyr:board-supported-runners::
 
-There are multiple methods to program and debug Zephyr
+There are multiple method to program and debug Zephyr on the A55 core:
 
 Option 1. Boot Zephyr by Using U-Boot Command
 =============================================
@@ -234,6 +234,59 @@ Here is an example for the :zephyr:code-sample:`hello_world` application.
    :host-os: unix
    :board: frdm_imx93/mimx9352/a55
    :goals: debug
+
+Option 3. Boot Zephyr by Using SPSDK Runner
+===========================================
+
+SPSDK runner leverages SPSDK tools (https://spsdk.readthedocs.io), it builds an
+bootable flash image ``flash.bin`` which includes all necessary firmware components.
+Using west flash command will download the boot image flash.bin to DDR memory, SD card
+or eMMC flash. By using flash.bin, as no U-Boot image is available, so TF-A will boot
+up Zephyr on the first Cortex-A55 Core directly.
+
+In order to use SPSDK runner, it requires fetching binary blobs, which can be achieved
+by running the following command:
+
+.. code-block:: console
+
+   west blobs fetch hal_nxp
+
+.. note::
+
+   It is recommended running the command above after :file:`west update`.
+
+SPSDK runner is enabled by configure item :kconfig:option:`CONFIG_BOARD_NXP_SPSDK_IMAGE`, currently
+it is not enabled by default for FRDM-IMX93 board, so use this configuration to enable
+it, for example, with the :zephyr:code-sample:`synchronization` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :host-os: unix
+   :board: frdm_imx93/mimx9352/a55
+   :goals: build
+   :gen-args: -DCONFIG_BOARD_NXP_SPSDK_IMAGE=y
+
+If :kconfig:option:`CONFIG_BOARD_NXP_SPSDK_IMAGE` is available and enabled for the board variant,
+``flash.bin`` will be built automatically. The programming could be through below commands.
+Before that, onboard switch SW1[3:0] should be configured to 0b0001 for USB download mode
+to boot, and USB1 and DBG ports should be connected to Linux host PC. There are 2 serial ports
+enumerated (115200 8n1), the second port will be used for Cortex-A55 Zephyr's Console.
+(The flasher is spsdk which already installed via scripts/requirements.txt.
+On Linux host, USB device permission should be configured per Installation Guide
+of https://spsdk.readthedocs.io)
+
+.. code-block:: none
+
+   # load and run without programming. for next flashing, need to reset the board firstly
+   $ west flash -r spsdk
+
+   # program to SD card, then set SW1[3:0]=0b0011 to reboot from SD
+   $ west flash -r spsdk --bootdevice sd
+
+   # program to emmc card, then set SW1[3:0]=0b0010 to reboot from EMMC
+   $ west flash -r spsdk --bootdevice=emmc
+
+Then the Zephyr log will be displayed in the second serial port's Console.
 
 System Reboot (A55)
 ===================

--- a/boards/nxp/imx93_evk/CMakeLists.txt
+++ b/boards/nxp/imx93_evk/CMakeLists.txt
@@ -1,7 +1,86 @@
 #
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
+  AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
+  find_program(7Z_EXECUTABLE 7z REQUIRED)
+  set(FIRMWARE_RELEASE "imx93evk-boot-firmware-6.12.34-2.1.0")
+  # Parse SPSDK version
+  execute_process(
+    COMMAND spsdk --version
+    OUTPUT_VARIABLE SPSDK_VERSION_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" SPSDK_VERSION "${SPSDK_VERSION_OUTPUT}")
+  message(STATUS "SPSDK version is ${SPSDK_VERSION}")
+
+  if(CONFIG_SOC_MIMX9352_A55)
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx93_evk_mimx9352_a55_ahab_primary.yaml
+      "
+      family: mimx9352
+      revision: a1
+      target_memory: serial_downloader
+      output:                   ${CMAKE_BINARY_DIR}/zephyr/primary_ahab.bin
+      containers:
+        - binary_container:
+            path:               ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/mx93a1-ahab-container.img
+        - container:
+            srk_set: none
+            images:
+              - lpddr_imem_1d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_imem_1d_v202201.bin
+                lpddr_imem_2d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_imem_2d_v202201.bin
+                lpddr_dmem_1d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_dmem_1d_v202201.bin
+                lpddr_dmem_2d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_dmem_2d_v202201.bin
+                spl_ddr:           ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/u-boot-spl.bin-imx93evk-sd
+    ")
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx93_evk_mimx9352_a55_ahab_secondary.yaml
+      "
+      family: mimx9352
+      revision: a1
+      target_memory: serial_downloader
+      output:                   ${CMAKE_BINARY_DIR}/zephyr/secondary_ahab.bin
+      containers:
+        - container:
+            srk_set: none
+            images:
+              - atf:            ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/bl31-imx93-zephyr.bin
+              - image_path:     ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
+                load_address:   '${CONFIG_SRAM_BASE_ADDRESS}'
+                entry_point:    '${CONFIG_SRAM_BASE_ADDRESS}'
+                image_type:     executable
+                core_id:        cortex-a55
+                is_encrypted:   false
+    ")
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx93_evk_mimx9352_a55_ahab_flash_template.yaml
+      "
+      family: mimx9352
+      revision: a1
+      memory_type: serial_downloader
+      primary_image_container_set: ${CMAKE_BINARY_DIR}/zephyr/imx93_evk_mimx9352_a55_ahab_primary.yaml
+      secondary_image_container_set: ${CMAKE_BINARY_DIR}/zephyr/imx93_evk_mimx9352_a55_ahab_secondary.yaml
+   ")
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND ${7Z_EXECUTABLE} x ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin -o./imx-boot-firmware -aos -bso0 -bse1
+      COMMAND ${7Z_EXECUTABLE} x imx-boot-firmware/${FIRMWARE_RELEASE} -aos -bso0 -bse1
+    )
+    if(SPSDK_VERSION VERSION_GREATER_EQUAL "3.0.0")
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+        COMMAND nxpimage bootable-image export -c ${CMAKE_BINARY_DIR}/zephyr/imx93_evk_mimx9352_a55_ahab_flash_template.yaml -o flash.bin
+      )
+    else()
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+        COMMAND nxpimage bootable-image merge -c ${CMAKE_BINARY_DIR}/zephyr/imx93_evk_mimx9352_a55_ahab_flash_template.yaml -o flash.bin
+      )
+    endif()
+  else()
+    message(FATAL_ERROR "SPSDK Image not supported on the platform!")
+  endif()
+  zephyr_blobs_verify(FILES
+    ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin
+    REQUIRED)
+endif()
 
 zephyr_library()
 zephyr_library_sources(board.c)

--- a/boards/nxp/imx93_evk/Kconfig
+++ b/boards/nxp/imx93_evk/Kconfig
@@ -1,6 +1,6 @@
 # i.MX 93 EVK board configuration
 
-# Copyright 2024 NXP
+# Copyright 2024-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_MIMX93_EVK_EXP_SEL_INIT
@@ -14,3 +14,5 @@ config BOARD_MIMX93_EVK_EXP_SEL_INIT_PRIO
 module = BOARD_MIMX93_EVK
 module-str = Board Control
 source "subsys/logging/Kconfig.template.log_config"
+
+source "boards/nxp/common/Kconfig"

--- a/boards/nxp/imx93_evk/board.cmake
+++ b/boards/nxp/imx93_evk/board.cmake
@@ -1,12 +1,25 @@
 #
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
+  AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
+  board_set_flasher_ifnset(spsdk)
+
+  board_runner_args(spsdk "--family=mimx9352")
+  board_runner_args(spsdk "--bootloader=${CMAKE_BINARY_DIR}/zephyr/imx93evk-boot-firmware-6.12.34-2.1.0/imx-boot-imx93evk-sd.bin-flash_singleboot")
+  board_runner_args(spsdk "--flashbin=${CMAKE_BINARY_DIR}/zephyr/flash.bin")
+  if(CONFIG_CPU_CORTEX_A55)
+    board_runner_args(spsdk "--containers=one")
+  else()
+    board_runner_args(spsdk "--containers=one")
+  endif()
+
+  include(${ZEPHYR_BASE}/boards/common/spsdk.board.cmake)
+endif()
+
 if(CONFIG_SOC_MIMX9352_A55)
-
-board_runner_args(jlink "--device=MIMX9352_A55_0" "--no-reset" "--flash-sram")
-
-include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
-
+  board_runner_args(jlink "--device=MIMX9352_A55_0" "--no-reset" "--flash-sram")
+  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 endif()

--- a/boards/nxp/imx93_evk/doc/index.rst
+++ b/boards/nxp/imx93_evk/doc/index.rst
@@ -289,6 +289,59 @@ display the following console output:
     thread_a: Hello World from cpu 0 on imx93_evk!
     thread_b: Hello World from cpu 0 on imx93_evk!
 
+Option 4. Boot Zephyr by Using SPSDK Runner
+===========================================
+
+SPSDK runner leverages SPSDK tools (https://spsdk.readthedocs.io), it builds an
+bootable flash image ``flash.bin`` which includes all necessary firmware components.
+Using west flash command will download the boot image flash.bin to DDR memory, SD card
+or eMMC flash. By using flash.bin, as no U-Boot image is available, so TF-A will boot
+up Zephyr on the first Cortex-A55 Core directly.
+
+In order to use SPSDK runner, it requires fetching binary blobs, which can be achieved
+by running the following command:
+
+.. code-block:: console
+
+   west blobs fetch hal_nxp
+
+.. note::
+
+   It is recommended running the command above after :file:`west update`.
+
+SPSDK runner is enabled by configure item :kconfig:option:`CONFIG_BOARD_NXP_SPSDK_IMAGE`, currently
+it is not enabled by default for i.MX93 EVK board, so use this configuration to enable
+it, for example, with the :zephyr:code-sample:`synchronization` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :host-os: unix
+   :board: imx93_evk/mimx9352/a55
+   :goals: build
+   :gen-args: -DCONFIG_BOARD_NXP_SPSDK_IMAGE=y
+
+If :kconfig:option:`CONFIG_BOARD_NXP_SPSDK_IMAGE` is available and enabled for the board variant,
+``flash.bin`` will be built automatically. The programming could be through below commands.
+Before that, onboard switch SW1301[3:0] should be configured to 0b0011 for USB download mode
+to boot, and USB1 and DBG ports should be connected to Linux host PC. There are 4 serial ports
+enumerated (115200 8n1), the fourth serial port will be used for Cortex-A55 Zephyr's Console.
+(The flasher is spsdk which already installed via scripts/requirements.txt.
+On linux host, USB device permission should be configured per Installation Guide
+of https://spsdk.readthedocs.io)
+
+.. code-block:: none
+
+   # load and run without programming. for next flashing, need to reset the board firstly
+   $ west flash -r spsdk
+
+   # program to SD card, then set SW1301[3:0]=0b0010 to reboot from SD
+   $ west flash -r spsdk --bootdevice sd
+
+   # program to emmc card, then set SW1301[3:0]=0b0000 to reboot from EMMC
+   $ west flash -r spsdk --bootdevice=emmc
+
+Then the Zephyr log will be displayed in the fourth serial port's Console.
+
 System Reboot (A55)
 ===================
 


### PR DESCRIPTION
Added SPSDK runner support, it could be used to flash Zephyr image.

Depends on https://github.com/zephyrproject-rtos/hal_nxp/pull/642 which has been merged.