### PR TITLE
arm: mpu: ArmV8: track regions when MPU gap filling is disabled

### DIFF
--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -201,45 +201,6 @@ static int mpu_configure_region(const uint8_t index,
 		(const struct arm_mpu_region *)&region_conf);
 }
 
-#if !defined(CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS) || \
-	!defined(CONFIG_MPU_GAP_FILLING)
-/* This internal function programs a set of given MPU regions
- * over a background memory area, optionally performing a
- * sanity check of the memory regions to be programmed.
- */
-static int mpu_configure_regions(const struct z_arm_mpu_partition
-	regions[], uint8_t regions_num, uint8_t start_reg_index,
-	bool do_sanity_check)
-{
-	int i;
-	int reg_index = start_reg_index;
-
-	for (i = 0; i < regions_num; i++) {
-		if (regions[i].size == 0U) {
-			continue;
-		}
-		/* Non-empty region. */
-
-		if (do_sanity_check &&
-				(!mpu_partition_is_valid(&regions[i]))) {
-			LOG_ERR("Partition %u: sanity check failed.", i);
-			return -EINVAL;
-		}
-
-		reg_index = mpu_configure_region(reg_index, &regions[i]);
-
-		if (reg_index == -EINVAL) {
-			return reg_index;
-		}
-
-		/* Increment number of programmed MPU indices. */
-		reg_index++;
-	}
-
-	return reg_index;
-}
-#endif
-
 /* ARM Core MPU Driver API Implementation for ARM MPU */
 
 


### PR DESCRIPTION
Optimizes MPU region usage on Armv8 when CONFIG_MPU_GAP_FILLING is disabled. Previously, available regions were not efficiently tracked, leading to waste. This change implements bitmask tracking to identify free indices, allowing dynamic regions to reuse slots released from static configuration.

Fixes #98606