### PR TITLE
drivers: serial: uart_stm32: Fix typo in LOG_ERR string

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -2464,7 +2464,7 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 		/* Stop device clock. Note: fixed clocks are not handled yet. */
 		err = clock_control_off(data->clock, (clock_control_subsys_t)&config->pclken[0]);
 		if (err < 0) {
-			LOG_ERR("Could not enable (LP)UART clock");
+			LOG_ERR("Could not disable (LP)UART clock");
 			return err;
 		}
 


### PR DESCRIPTION
Change "Could not enable (LP)UART clock" to "[...] disable [...]" when clock_control_off() fails.