### PR TITLE
boards: nordic: nrf54h20dk: cpurad: enable lfclk

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -140,3 +140,7 @@ zephyr_udc0: &usbhs {
 &gpiote130 {
 	owned-channels = <7>;
 };
+
+&lfclk {
+	status = "okay";
+};


### PR DESCRIPTION
The lfclk is required for bluetooth, so enable it by default for the radio core. Applications are only affected if they enable CLOCK_CONTROL, in which case either only the lfclk or all clocks are enabled, so enabling lfclk alone is the lowest common denominator.