### PR TITLE
drivers: ethernet: microchip: use timeout directly

### DIFF
--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -550,7 +550,6 @@ static int eth_enc28j60_tx(const struct device *dev, struct net_pkt *pkt)
 
 static void enc28j60_read_packet(const struct device *dev, uint16_t frm_len)
 {
-	const struct eth_enc28j60_config *config = dev->config;
 	struct eth_enc28j60_runtime *context = dev->data;
 	struct net_buf *pkt_buf;
 	struct net_pkt *pkt;
@@ -558,8 +557,8 @@ static void enc28j60_read_packet(const struct device *dev, uint16_t frm_len)
 	uint8_t dummy[4];
 
 	/* Get the frame from the buffer */
-	pkt = net_pkt_rx_alloc_with_buffer(get_iface(context), frm_len,
-					   NET_AF_UNSPEC, 0, K_MSEC(config->timeout));
+	pkt = net_pkt_rx_alloc_with_buffer(get_iface(context), frm_len, NET_AF_UNSPEC, 0,
+					   K_MSEC(CONFIG_ETH_ENC28J60_TIMEOUT));
 	if (!pkt) {
 		LOG_ERR("%s: Could not allocate rx buffer", dev->name);
 		eth_stats_update_errors_rx(get_iface(context));
@@ -917,7 +916,6 @@ static int eth_enc28j60_init(const struct device *dev)
 		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8)),                                \
 		.interrupt = GPIO_DT_SPEC_INST_GET(inst, int_gpios),                               \
 		.full_duplex = DT_INST_PROP(0, full_duplex),                                       \
-		.timeout = CONFIG_ETH_ENC28J60_TIMEOUT,                                            \
 		.hw_rx_filter = DT_INST_PROP_OR(inst, hw_rx_filter, ENC28J60_RECEIVE_FILTERS),     \
 		.random_mac = DT_INST_PROP(inst, zephyr_random_mac_address),                    \
 	};                                                                                         \

--- a/drivers/ethernet/eth_enc28j60_priv.h
+++ b/drivers/ethernet/eth_enc28j60_priv.h
@@ -223,7 +223,6 @@ struct eth_enc28j60_config {
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec interrupt;
 	uint8_t full_duplex;
-	int32_t timeout;
 	uint8_t hw_rx_filter;
 	bool random_mac;
 };

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -347,7 +347,6 @@ static int enc424j600_tx(const struct device *dev, struct net_pkt *pkt)
 static int enc424j600_rx(const struct device *dev)
 {
 	struct enc424j600_runtime *context = dev->data;
-	const struct enc424j600_config *config = dev->config;
 	uint8_t info[ENC424J600_RSV_SIZE + ENC424J600_PTR_NXP_PKT_SIZE];
 	struct net_buf *pkt_buf = NULL;
 	struct net_pkt *pkt;
@@ -386,9 +385,8 @@ static int enc424j600_rx(const struct device *dev)
 	}
 
 	/* Get the frame from the buffer */
-	pkt = net_pkt_rx_alloc_with_buffer(context->iface, frm_len,
-					   NET_AF_UNSPEC, 0,
-					   K_MSEC(config->timeout));
+	pkt = net_pkt_rx_alloc_with_buffer(context->iface, frm_len, NET_AF_UNSPEC, 0,
+					   K_MSEC(CONFIG_ETH_ENC424J600_TIMEOUT));
 	if (!pkt) {
 		LOG_ERR("Could not allocate rx buffer");
 		eth_stats_update_errors_rx(context->iface);
@@ -780,7 +778,6 @@ static struct enc424j600_runtime enc424j600_0_runtime = {
 static const struct enc424j600_config enc424j600_0_config = {
 	.spi = SPI_DT_SPEC_INST_GET(0, SPI_WORD_SET(8)),
 	.interrupt = GPIO_DT_SPEC_INST_GET(0, int_gpios),
-	.timeout = CONFIG_ETH_ENC424J600_TIMEOUT,
 };
 
 ETH_NET_DEVICE_DT_INST_DEFINE(0,

--- a/drivers/ethernet/eth_enc424j600_priv.h
+++ b/drivers/ethernet/eth_enc424j600_priv.h
@@ -277,7 +277,6 @@ struct enc424j600_config {
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec interrupt;
 	uint8_t full_duplex;
-	int32_t timeout;
 };
 
 struct enc424j600_runtime {

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -287,13 +287,12 @@ static void lan865x_int_callback(const struct device *dev, struct gpio_callback 
 
 static void lan865x_read_chunks(const struct device *dev)
 {
-	const struct lan865x_config *cfg = dev->config;
 	struct lan865x_data *ctx = dev->data;
 	struct oa_tc6 *tc6 = ctx->tc6;
 	struct net_pkt *pkt;
 	int ret;
 
-	pkt = net_pkt_rx_alloc(K_MSEC(cfg->timeout));
+	pkt = net_pkt_rx_alloc(K_MSEC(CONFIG_ETH_LAN865X_TIMEOUT));
 	if (!pkt) {
 		LOG_ERR("OA RX: Could not allocate packet!");
 		return;
@@ -481,7 +480,6 @@ static const struct ethernet_api lan865x_api_func = {
 		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8)),                                \
 		.interrupt = GPIO_DT_SPEC_INST_GET(inst, int_gpios),                               \
 		.reset = GPIO_DT_SPEC_INST_GET(inst, rst_gpios),                                   \
-		.timeout = CONFIG_ETH_LAN865X_TIMEOUT,                                             \
 		.phy = DEVICE_DT_GET(                                                              \
 			DT_CHILD(DT_INST_CHILD(inst, lan865x_mdio), ethernet_phy_##inst)),         \
 		.mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(inst),                                  \

--- a/drivers/ethernet/eth_lan865x_priv.h
+++ b/drivers/ethernet/eth_lan865x_priv.h
@@ -50,7 +50,6 @@ struct lan865x_config {
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec interrupt;
 	struct gpio_dt_spec reset;
-	int32_t timeout;
 	struct net_eth_mac_config mac_cfg;
 
 	/* MAC */

--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -455,7 +455,6 @@ static int lan9250_read_buf(const struct device *dev, uint8_t *data_buffer, uint
 
 static int lan9250_rx(const struct device *dev)
 {
-	const struct lan9250_config *config = dev->config;
 	struct lan9250_runtime *ctx = dev->data;
 	const uint16_t buf_rx_size = CONFIG_NET_BUF_DATA_SIZE;
 	struct net_pkt *pkt;
@@ -487,7 +486,7 @@ static int lan9250_rx(const struct device *dev)
 
 	/* Get the frame from the buffer */
 	pkt = net_pkt_rx_alloc_with_buffer(ctx->iface, pkt_len, NET_AF_UNSPEC, 0,
-					   K_MSEC(config->timeout));
+					   K_MSEC(CONFIG_ETH_LAN9250_BUF_ALLOC_TIMEOUT));
 	if (!pkt) {
 		LOG_ERR("%s: Could not allocate rx buffer", dev->name);
 		eth_stats_update_errors_rx(ctx->iface);
@@ -753,7 +752,6 @@ static int lan9250_init(const struct device *dev)
 		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8)),                                \
 		.interrupt = GPIO_DT_SPEC_INST_GET(inst, int_gpios),                               \
 		.reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {0}),                         \
-		.timeout = CONFIG_ETH_LAN9250_BUF_ALLOC_TIMEOUT,                                   \
 		.mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(inst),                                  \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/ethernet/eth_lan9250_priv.h
+++ b/drivers/ethernet/eth_lan9250_priv.h
@@ -311,7 +311,6 @@ struct lan9250_config {
 	struct gpio_dt_spec interrupt;
 	struct gpio_dt_spec reset;
 	uint8_t full_duplex;
-	int32_t timeout;
 	struct net_eth_mac_config mac_cfg;
 };
 


### PR DESCRIPTION
use Kconfig timeout directly.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>