### PR TITLE
boards: nordic: Add bias-pull-up to UART TX pin sleep state

### DIFF
--- a/boards/nordic/nrf21540dk/nrf21540dk_nrf52840-pinctrl.dtsi
+++ b/boards/nordic/nrf21540dk/nrf21540dk_nrf52840-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 6)>,
-				<NRF_PSEL(UART_RX, 0, 8)>,
+			psels = <NRF_PSEL(UART_RX, 0, 8)>,
 				<NRF_PSEL(UART_RTS, 0, 5)>,
 				<NRF_PSEL(UART_CTS, 0, 7)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf51dk/nrf51dk_nrf51822-pinctrl.dtsi
+++ b/boards/nordic/nrf51dk/nrf51dk_nrf51822-pinctrl.dtsi
@@ -15,11 +15,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 9)>,
-				<NRF_PSEL(UART_RX, 0, 11)>,
+			psels = <NRF_PSEL(UART_RX, 0, 11)>,
 				<NRF_PSEL(UART_RTS, 0, 8)>,
 				<NRF_PSEL(UART_CTS, 0, 10)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 9)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf52833dk/nrf52833dk_nrf52820-pinctrl.dtsi
+++ b/boards/nordic/nrf52833dk/nrf52833dk_nrf52820-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 6)>,
-				<NRF_PSEL(UART_RX, 0, 8)>,
+			psels = <NRF_PSEL(UART_RX, 0, 8)>,
 				<NRF_PSEL(UART_RTS, 0, 5)>,
 				<NRF_PSEL(UART_CTS, 0, 7)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf52833dk/nrf52833dk_nrf52833-pinctrl.dtsi
+++ b/boards/nordic/nrf52833dk/nrf52833dk_nrf52833-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 6)>,
-				<NRF_PSEL(UART_RX, 0, 8)>,
+			psels = <NRF_PSEL(UART_RX, 0, 8)>,
 				<NRF_PSEL(UART_RTS, 0, 5)>,
 				<NRF_PSEL(UART_CTS, 0, 7)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52811-pinctrl.dtsi
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52811-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 6)>,
-				<NRF_PSEL(UART_RX, 0, 8)>,
+			psels = <NRF_PSEL(UART_RX, 0, 8)>,
 				<NRF_PSEL(UART_RTS, 0, 5)>,
 				<NRF_PSEL(UART_CTS, 0, 7)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840-pinctrl.dtsi
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 6)>,
-				<NRF_PSEL(UART_RX, 0, 8)>,
+			psels = <NRF_PSEL(UART_RX, 0, 8)>,
 				<NRF_PSEL(UART_RTS, 0, 5)>,
 				<NRF_PSEL(UART_CTS, 0, 7)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840-pinctrl.dtsi
+++ b/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 20)>,
-				<NRF_PSEL(UART_RX, 0, 24)>,
+			psels = <NRF_PSEL(UART_RX, 0, 24)>,
 				<NRF_PSEL(UART_RTS, 0, 17)>,
 				<NRF_PSEL(UART_CTS, 0, 22)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 20)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf52dk/nrf52dk_nrf52805-pinctrl.dtsi
+++ b/boards/nordic/nrf52dk/nrf52dk_nrf52805-pinctrl.dtsi
@@ -47,11 +47,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 6)>,
-				<NRF_PSEL(UART_RX, 0, 8)>,
+			psels = <NRF_PSEL(UART_RX, 0, 8)>,
 				<NRF_PSEL(UART_RTS, 0, 5)>,
 				<NRF_PSEL(UART_CTS, 0, 7)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 };

--- a/boards/nordic/nrf52dk/nrf52dk_nrf52810-pinctrl.dtsi
+++ b/boards/nordic/nrf52dk/nrf52dk_nrf52810-pinctrl.dtsi
@@ -15,11 +15,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 6)>,
-				<NRF_PSEL(UART_RX, 0, 8)>,
+			psels = <NRF_PSEL(UART_RX, 0, 8)>,
 				<NRF_PSEL(UART_RTS, 0, 5)>,
 				<NRF_PSEL(UART_CTS, 0, 7)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf52dk/nrf52dk_nrf52832-pinctrl.dtsi
+++ b/boards/nordic/nrf52dk/nrf52dk_nrf52832-pinctrl.dtsi
@@ -15,11 +15,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 6)>,
-				<NRF_PSEL(UART_RX, 0, 8)>,
+			psels = <NRF_PSEL(UART_RX, 0, 8)>,
 				<NRF_PSEL(UART_RTS, 0, 5)>,
 				<NRF_PSEL(UART_CTS, 0, 7)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_common-pinctrl.dtsi
@@ -45,11 +45,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 5)>,
-				<NRF_PSEL(UART_RX, 1, 4)>,
+			psels = <NRF_PSEL(UART_RX, 1, 4)>,
 				<NRF_PSEL(UART_RTS, 1, 7)>,
 				<NRF_PSEL(UART_CTS, 1, 6)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 1, 5)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpunet-pinctrl.dtsi
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpunet-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 9)>,
-				<NRF_PSEL(UART_RX, 1, 8)>,
+			psels = <NRF_PSEL(UART_RX, 1, 8)>,
 				<NRF_PSEL(UART_RTS, 1, 10)>,
 				<NRF_PSEL(UART_CTS, 1, 11)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 1, 9)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf5340dk/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/nordic/nrf5340dk/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -34,11 +34,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 20)>,
-				<NRF_PSEL(UART_RX, 0, 22)>,
+			psels = <NRF_PSEL(UART_RX, 0, 22)>,
 				<NRF_PSEL(UART_RTS, 0, 19)>,
 				<NRF_PSEL(UART_CTS, 0, 21)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 20)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpunet-pinctrl.dtsi
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpunet-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 1)>,
-				<NRF_PSEL(UART_RX, 1, 0)>,
+			psels = <NRF_PSEL(UART_RX, 1, 0)>,
 				<NRF_PSEL(UART_RTS, 0, 11)>,
 				<NRF_PSEL(UART_CTS, 0, 10)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 1, 1)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-pinctrl.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-pinctrl.dtsi
@@ -19,8 +19,13 @@
 	/omit-if-no-ref/ uart120_sleep: uart120_sleep {
 		group1 {
 			low-power-enable;
-			psels = <NRF_PSEL(UART_TX, 7, 7)>,
-				<NRF_PSEL(UART_RX, 7, 4)>;
+			psels = <NRF_PSEL(UART_RX, 7, 4)>;
+		};
+
+		group2 {
+			low-power-enable;
+			bias-pull-up;
+			psels = <NRF_PSEL(UART_TX, 7, 7)>;
 		};
 	};
 
@@ -40,10 +45,15 @@
 	/omit-if-no-ref/ uart135_sleep: uart135_sleep {
 		group1 {
 			low-power-enable;
-			psels = <NRF_PSEL(UART_TX, 1, 11)>,
-				<NRF_PSEL(UART_RX, 1, 10)>,
+			psels = <NRF_PSEL(UART_RX, 1, 10)>,
 				<NRF_PSEL(UART_RTS, 1, 9)>,
 				<NRF_PSEL(UART_CTS, 1, 7)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 1, 11)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 
@@ -63,10 +73,15 @@
 	/omit-if-no-ref/ uart136_sleep: uart136_sleep {
 		group1 {
 			low-power-enable;
-			psels = <NRF_PSEL(UART_TX, 2, 6)>,
-				<NRF_PSEL(UART_RX, 2, 4)>,
+			psels = <NRF_PSEL(UART_RX, 2, 4)>,
 				<NRF_PSEL(UART_RTS, 2, 7)>,
 				<NRF_PSEL(UART_CTS, 2, 5)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 2, 6)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l_05_10_15-pinctrl.dtsi
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l_05_10_15-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	/omit-if-no-ref/ uart20_sleep: uart20_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 4)>,
-				<NRF_PSEL(UART_RX, 1, 5)>,
+			psels = <NRF_PSEL(UART_RX, 1, 5)>,
 				<NRF_PSEL(UART_RTS, 1, 6)>,
 				<NRF_PSEL(UART_CTS, 1, 7)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 1, 4)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a-pinctrl.dtsi
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	/omit-if-no-ref/ uart20_sleep: uart20_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 16)>,
-				<NRF_PSEL(UART_RX, 1, 17)>,
+			psels = <NRF_PSEL(UART_RX, 1, 17)>,
 				<NRF_PSEL(UART_RTS, 1, 18)>,
 				<NRF_PSEL(UART_CTS, 1, 19)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 1, 16)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common_pinctrl.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common_pinctrl.dtsi
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &pinctrl {
 	i2c1_default: i2c1_default {
 		group1 {
@@ -29,11 +34,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 20)>,
-				<NRF_PSEL(UART_RX, 0, 22)>,
+			psels = <NRF_PSEL(UART_RX, 0, 22)>,
 				<NRF_PSEL(UART_RTS, 0, 19)>,
 				<NRF_PSEL(UART_CTS, 0, 21)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 20)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet_pinctrl.dtsi
+++ b/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet_pinctrl.dtsi
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &pinctrl {
 	uart0_default: uart0_default {
 		group1 {
@@ -14,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 1)>,
-				<NRF_PSEL(UART_RX, 1, 0)>,
+			psels = <NRF_PSEL(UART_RX, 1, 0)>,
 				<NRF_PSEL(UART_RTS, 1, 5)>,
 				<NRF_PSEL(UART_CTS, 1, 4)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 1, 1)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf9131ek/nrf9131ek_nrf9131_common-pinctrl.dtsi
+++ b/boards/nordic/nrf9131ek/nrf9131ek_nrf9131_common-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 11)>,
-				<NRF_PSEL(UART_RX, 0, 12)>,
+			psels = <NRF_PSEL(UART_RX, 0, 12)>,
 				<NRF_PSEL(UART_RTS, 0, 10)>,
 				<NRF_PSEL(UART_CTS, 0, 9)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 11)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_common-pinctrl.dtsi
+++ b/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_common-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 27)>,
-				<NRF_PSEL(UART_RX, 0, 26)>,
+			psels = <NRF_PSEL(UART_RX, 0, 26)>,
 				<NRF_PSEL(UART_RTS, 0, 14)>,
 				<NRF_PSEL(UART_CTS, 0, 15)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 27)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf52840-pinctrl.dtsi
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf52840-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 5)>,
-				<NRF_PSEL(UART_RX, 0, 3)>,
+			psels = <NRF_PSEL(UART_RX, 0, 3)>,
 				<NRF_PSEL(UART_RTS, 0, 7)>,
 				<NRF_PSEL(UART_CTS, 1, 8)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 5)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 };

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_common-pinctrl.dtsi
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_common-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 29)>,
-				<NRF_PSEL(UART_RX, 0, 28)>,
+			psels = <NRF_PSEL(UART_RX, 0, 28)>,
 				<NRF_PSEL(UART_RTS, 0, 27)>,
 				<NRF_PSEL(UART_CTS, 0, 26)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 29)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_common-pinctrl.dtsi
+++ b/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_common-pinctrl.dtsi
@@ -19,11 +19,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 27)>,
-				<NRF_PSEL(UART_RX, 0, 26)>,
+			psels = <NRF_PSEL(UART_RX, 0, 26)>,
 				<NRF_PSEL(UART_RTS, 0, 14)>,
 				<NRF_PSEL(UART_CTS, 0, 15)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 27)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-pinctrl.dtsi
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-pinctrl.dtsi
@@ -21,10 +21,15 @@
 	/omit-if-no-ref/ uart135_sleep: uart135_sleep {
 		group1 {
 			low-power-enable;
-			psels = <NRF_PSEL(UART_TX, 1, 4)>,
-				<NRF_PSEL(UART_RX, 1, 5)>,
+			psels = <NRF_PSEL(UART_RX, 1, 5)>,
 				<NRF_PSEL(UART_RTS, 1, 0)>,
 				<NRF_PSEL(UART_CTS, 1, 6)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 1, 4)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 
@@ -44,10 +49,15 @@
 	/omit-if-no-ref/ uart136_sleep: uart136_sleep {
 		group1 {
 			low-power-enable;
-			psels = <NRF_PSEL(UART_TX, 0, 4)>,
-				<NRF_PSEL(UART_RX, 0, 5)>,
+			psels = <NRF_PSEL(UART_RX, 0, 5)>,
 				<NRF_PSEL(UART_RTS, 0, 0)>,
 				<NRF_PSEL(UART_CTS, 0, 6)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 4)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/thingy52/thingy52_nrf52832-pinctrl.dtsi
+++ b/boards/nordic/thingy52/thingy52_nrf52832-pinctrl.dtsi
@@ -13,9 +13,14 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 3)>,
-				<NRF_PSEL(UART_RX, 0, 2)>;
+			psels = <NRF_PSEL(UART_RX, 0, 2)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 3)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/thingy53/thingy53_nrf5340_common-pinctrl.dtsi
+++ b/boards/nordic/thingy53/thingy53_nrf5340_common-pinctrl.dtsi
@@ -77,11 +77,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 12)>,
-				<NRF_PSEL(UART_RX, 0, 11)>,
+			psels = <NRF_PSEL(UART_RX, 0, 11)>,
 				<NRF_PSEL(UART_RTS, 0, 10)>,
 				<NRF_PSEL(UART_CTS, 0, 9)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 12)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/nordic/thingy53/thingy53_nrf5340_cpunet-pinctrl.dtsi
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpunet-pinctrl.dtsi
@@ -15,11 +15,16 @@
 
 	uart0_sleep: uart0_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 12)>,
-				<NRF_PSEL(UART_RX, 0, 11)>,
+			psels = <NRF_PSEL(UART_RX, 0, 11)>,
 				<NRF_PSEL(UART_RTS, 0, 10)>,
 				<NRF_PSEL(UART_CTS, 0, 9)>;
 			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 12)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 


### PR DESCRIPTION
When UART TX pin is in sleep state it should have pull up. So far it was floating and that could lead to garbage output on terminal.