### PR TITLE
tests: drivers: can: api: relax CAN sample point accuracy requirements

### DIFF
--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -528,7 +528,8 @@ ZTEST_USER(canfd, test_set_timing_data_while_started)
 	int err;
 
 	err = can_calc_timing_data(can_dev, &timing, TEST_BITRATE_3, TEST_SAMPLE_POINT);
-	zassert_ok(err, "failed to calculate data timing (err %d)", err);
+	zassert_true(err >= 0, "failed to calculate data timing (err %d)", err);
+	zassert_true(err <= CONFIG_CAN_SAMPLE_POINT_MARGIN, "sample point error %d too large", err);
 
 	err = can_set_timing_data(can_dev, &timing);
 	zassert_not_equal(err, 0, "changed data timing while started");

--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -527,7 +527,7 @@ ZTEST_USER(canfd, test_set_timing_data_while_started)
 	struct can_timing timing = { 0 };
 	int err;
 
-	err = can_calc_timing_data(can_dev, &timing, TEST_BITRATE_3, TEST_SAMPLE_POINT);
+	err = can_calc_timing_data(can_dev, &timing, TEST_BITRATE_3, TEST_SAMPLE_POINT_2);
 	zassert_true(err >= 0, "failed to calculate data timing (err %d)", err);
 	zassert_true(err <= CONFIG_CAN_SAMPLE_POINT_MARGIN, "sample point error %d too large", err);
 

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -1393,7 +1393,8 @@ ZTEST_USER(can_classic, test_set_timing_while_started)
 	int err;
 
 	err = can_calc_timing(can_dev, &timing, TEST_BITRATE_1, TEST_SAMPLE_POINT);
-	zassert_ok(err, "failed to calculate timing (err %d)", err);
+	zassert_true(err >= 0, "failed to calculate timing (err %d)", err);
+	zassert_true(err <= CONFIG_CAN_SAMPLE_POINT_MARGIN, "sample point error %d too large", err);
 
 	err = can_set_timing(can_dev, &timing);
 	zassert_not_equal(err, 0, "changed timing while started");


### PR DESCRIPTION
- Relax the CAN sample point location accuracy requirements in the CAN API test suites by taking `CONFIG_CAN_SAMPLE_POINT_MARGIN` into account.
- Use a sample point of 75% for the data phase timing to match the bitrate of 1Mbit/s.

Fixes: #100615