### PR TITLE
drivers: display: st: allow-ltdc-callback-override

### DIFF
--- a/include/zephyr/drivers/display/display_stm32_ltdc.h
+++ b/include/zephyr/drivers/display/display_stm32_ltdc.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DISPLAY_STM32_LTDC_H_
+#define ZEPHYR_INCLUDE_DISPLAY_STM32_LTDC_H_
+
+/* Prototypes of external ISR handler weak functions */
+int ltdc_isr_custom_handler(LTDC_HandleTypeDef *hltdc);
+
+#endif /* ZEPHYR_INCLUDE_DISPLAY_STM32_LTDC_H_ */


### PR DESCRIPTION
Allow overriding the LTDC callback for manual handling or extension. In some cases, the default handling may not be desired, for example if a line interrrupt has been set up to do an operation after a certain line has been passed, or if the user wants to use the HAL IRQ handler.