### PR TITLE
kconfig: source autogenerated Kconfig.dts earlier than defconfigs

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -9,6 +9,10 @@ source "Kconfig.constants"
 
 osource "$(APPLICATION_SOURCE_DIR)/VERSION"
 
+# This should be sourced early since the autogen Kconfig.dts options
+# and macros may get used by shields/boards/SoC defconfig or modules.
+source "dts/Kconfig"
+
 # Include Kconfig.defconfig files first so that they can override defaults and
 # other symbol/choice properties by adding extra symbol/choice definitions.
 # After merging all definitions for a symbol/choice, Kconfig picks the first
@@ -32,10 +36,6 @@ source "$(KCONFIG_BINARY_DIR)/soc/Kconfig.defconfig"
 osource "$(TOOLCHAIN_KCONFIG_DIR)/Kconfig.defconfig"
 # This loads the testsuite defconfig
 source "subsys/testsuite/Kconfig.defconfig"
-
-# This should be early since the autogen Kconfig.dts symbols may get
-# used by modules
-source "dts/Kconfig"
 
 menu "Modules"
 


### PR DESCRIPTION
In addition to the `DT_HAS_<compat>_ENABLED` options, the autogenerated `Kconfig.dts` file also provides the `DT_COMPAT_<compat>` *macros* which avoid manually declaring them when working around the no comma limitation. Unlike options which can be referenced before their declaration, macros *MUST* be defined before their usage (otherwise, they expand to nothing ("")):
https://github.com/zephyrproject-rtos/zephyr/blob/3b23c76a246973fe7b1570447398f3bb1ef434e1/scripts/kconfig/kconfiglib.py#L2858

Because the defconfig files were sourced before `dts/Kconfig`, it was not possible to use the `DT_COMPAT` macros from shields/boards/SoC `defconfig`; this is not only confusing but also suboptimal because the macros must be defined manually.

Include `dts/Kconfig` earlier to allow usage of the `DT_COMPAT` macros from shields, boards and SoC defconfig. This should have no adverse effect since there is no reason to override the options provided by the autogenerated `Kconfig.dts` anyways.

This issue was encountered in https://github.com/zephyrproject-rtos/zephyr/pull/100215.