### PR TITLE
ci: bsim tests: run_parallel: Print in which board we failed a test

### DIFF
--- a/tests/bsim/ci.net.sh
+++ b/tests/bsim/ci.net.sh
@@ -12,5 +12,6 @@ cd ${ZEPHYR_BASE}
 set -uex
 
 WORK_DIR=${ZEPHYR_BASE}/bsim_net nice tests/bsim/net/compile.sh
+BOARD=nrf52_bsim/native \
 RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.net.52.xml \
 SEARCH_PATH=tests/bsim/net/ tests/bsim/run_parallel.sh

--- a/tests/bsim/run_parallel.sh
+++ b/tests/bsim/run_parallel.sh
@@ -62,6 +62,10 @@ set -u
 RESULTS_FILE="${RESULTS_FILE:-`pwd`/../RunResults.xml}"
 tmp_res_file=tmp.xml
 
+if [[ -v BOARD ]]; then
+	export FAILURE_EXTRA_INFO=" on ${BOARD}"
+fi
+
 all_cases_a=( $all_cases )
 n_cases=$((${#all_cases_a[@]}))
 
@@ -84,7 +88,7 @@ if [ `command -v parallel` ]; then
     dur=$(($(date +%s%N) - $start))
     dur_s=$(awk -vdur=$dur "BEGIN { printf(\"%0.3f\", dur/1000000000)}")
     if [ $result -ne 0 ]; then
-      (>&2 echo -e "\e[91m{} FAILED\e[39m ($dur_s s)")
+      (>&2 echo -e "\e[91m{} FAILED${FAILURE_EXTRA_INFO}\e[39m ($dur_s s)")
       (>&2 cat {#}.log)
       echo "<failure message=\"failed\" type=\"failure\">"
       cat {#}.log | eval $CLEAN_XML
@@ -105,7 +109,7 @@ else #fallback in case parallel is not installed
     echo "<testcase name=\"$case\" time=\"0\">" >> $tmp_res_file
     $case $@ &> $i.log
     if [ $? -ne 0 ]; then
-      echo -e "\e[91m$case FAILED\e[39m"
+      echo -e "\e[91m$case FAILED${FAILURE_EXTRA_INFO}\e[39m"
       cat $i.log
       echo "<failure message=\"failed\" type=\"failure\">" >> $tmp_res_file
       cat $i.log | eval $CLEAN_XML >> $tmp_res_file


### PR DESCRIPTION
In the console log, print out in which board the test failed, so it is easier for developers, so they don't need to scroll up to the beginning of the batch to see it.

&
ci: bsim tests: net: Explicitly define the BOARD
Instead of relying on this board being the default. Let's explicitly set it in the script.