### PR TITLE
doc: kconfig: document DT_COMPAT_<...> macro variables

### DIFF
--- a/doc/build/kconfig/tips.rst
+++ b/doc/build/kconfig/tips.rst
@@ -628,6 +628,11 @@ argument, as follows:
         bool
         default y if $(dt_chosen_enabled,$(DT_CHOSEN_ZEPHYR_BAR))
 
+.. note::
+
+   A variable :samp:`DT_COMPAT_{VND_MY_DEVICE} := {vnd,my-device}`
+   is automatically created by Zephyr for every ``compatible`` found
+   in Devicetree bindings; there is no need to define such variables.
 
 Checking changes in menuconfig/guiconfig
 ****************************************

--- a/doc/contribute/style/kconfig.rst
+++ b/doc/contribute/style/kconfig.rst
@@ -66,6 +66,10 @@ Naming Conventions
 * When the enabling symbol is dependent on a devicetree node, consider
   depending on the automatically created ``DT_HAS_<node>_ENABLED`` symbol.
 
+* When building complex expressions based on devicetree node compatibles,
+  use the automatically defined :samp:`DT_COMPAT_{VND_DEVICE}` instead
+  of defining a variable equal to :samp:`{vnd,device}` manually.
+
 The specific formats by subtree:
 
 * **Drivers (/drivers)**: Use the format ``{Driver Type}_{Driver Name}`` for


### PR DESCRIPTION
The `DT_COMPAT_<...>` macro variables are generated for every compatible found in bindings: document them as existing and recommend using them in various Kconfig documentation pages.