### PR TITLE
ipc: intel_adsp: rework host IPC service backend and add critical send support

### DIFF
--- a/include/zephyr/ipc/backends/intel_adsp_host_ipc.h
+++ b/include/zephyr/ipc/backends/intel_adsp_host_ipc.h
@@ -14,54 +14,6 @@
 
 #include <zephyr/ipc/ipc_service_backend.h>
 
-/** Enum on IPC send length argument to indicate IPC message type. */
-enum intel_adsp_send_len {
-	/** Normal IPC message. */
-	INTEL_ADSP_IPC_SEND_MSG,
-
-	/** Synchronous IPC message. */
-	INTEL_ADSP_IPC_SEND_MSG_SYNC,
-
-	/** Emergency IPC message. */
-	INTEL_ADSP_IPC_SEND_MSG_EMERGENCY,
-
-	/** Send a DONE message. */
-	INTEL_ADSP_IPC_SEND_DONE,
-
-	/** Query backend to see if IPC is complete. */
-	INTEL_ADSP_IPC_SEND_IS_COMPLETE,
-};
-
-/** Enum on callback return values. */
-enum intel_adsp_cb_ret {
-	/** Callback return to indicate no issue. Must be 0. */
-	INTEL_ADSP_IPC_CB_RET_OKAY = 0,
-
-	/** Callback return to signal needing external completion. */
-	INTEL_ADSP_IPC_CB_RET_EXT_COMPLETE,
-};
-
-/** Enum on callback length argument to indicate which triggers the callback. */
-enum intel_adsp_cb_len {
-	/** Callback length to indicate this is an IPC message. */
-	INTEL_ADSP_IPC_CB_MSG,
-
-	/** Callback length to indicate this is a DONE message. */
-	INTEL_ADSP_IPC_CB_DONE,
-};
-
-/** Struct for IPC message descriptor. */
-struct intel_adsp_ipc_msg {
-	/** Header specific to platform. */
-	uint32_t data;
-
-	/** Extension specific to platform. */
-	uint32_t ext_data;
-
-	/** Timeout for sending synchronuous message. */
-	k_timeout_t timeout;
-};
-
 #ifdef CONFIG_INTEL_ADSP_IPC_OLD_INTERFACE
 
 /**
@@ -89,6 +41,7 @@ struct intel_adsp_ipc_msg {
  */
 typedef bool (*intel_adsp_ipc_handler_t)(const struct device *dev, void *arg, uint32_t data,
 					 uint32_t ext_data);
+#endif /* CONFIG_INTEL_ADSP_IPC_OLD_INTERFACE */
 
 /**
  * @brief Intel ADSP IPC Message Complete Callback.
@@ -113,8 +66,6 @@ typedef bool (*intel_adsp_ipc_handler_t)(const struct device *dev, void *arg, ui
  * writing to IPC registers signalling message completion normally by this API.
  */
 typedef bool (*intel_adsp_ipc_done_t)(const struct device *dev, void *arg);
-
-#endif /* CONFIG_INTEL_ADSP_IPC_OLD_INTERFACE */
 
 #ifdef CONFIG_PM_DEVICE
 typedef int (*intel_adsp_ipc_resume_handler_t)(const struct device *dev, void *arg);
@@ -152,13 +103,13 @@ struct intel_adsp_ipc_data {
 
 	/** Argument for message handler callback. */
 	void *handler_arg;
+#endif /* CONFIG_INTEL_ADSP_IPC_OLD_INTERFACE */
 
 	/** Callback for done notification. */
 	intel_adsp_ipc_done_t done_notify;
 
 	/** Argument for done notification callback. */
 	void *done_arg;
-#endif /* CONFIG_INTEL_ADSP_IPC_OLD_INTERFACE */
 
 #ifdef CONFIG_PM_DEVICE
 	/** Pointer to resume handler. */
@@ -179,9 +130,8 @@ struct intel_adsp_ipc_data {
  * Endpoint private data struct.
  */
 struct intel_adsp_ipc_ept_priv_data {
-	/** Callback return value (enum intel_adsp_cb_ret). */
-	int cb_ret;
-
+	/* Message done flag. */
+	bool msg_done;
 	/** Pointer to additional private data. */
 	void *priv;
 };

--- a/include/zephyr/ipc/ipc_service.h
+++ b/include/zephyr/ipc/ipc_service.h
@@ -315,6 +315,36 @@ int ipc_service_deregister_endpoint(struct ipc_ept *ept);
  */
 int ipc_service_send(struct ipc_ept *ept, const void *data, size_t len);
 
+/** @brief Send a high-priority message bypassing normal state checks.
+ *
+ *  This function sends a high-priority message using the backend in a
+ *  special fast path that skips normal state and busy checking. It is
+ *  intended for critical system notifications such as crash reports,
+ *  fatal errors, or emergency shutdown signals that must be delivered
+ *  even when the IPC channel is otherwise considered busy or blocked.
+ *
+ *  WARNING: This function should only be used for critical system notifications.
+ *  Misuse can lead to data corruption or system instability. The backend must
+ *  support this operation.
+ *
+ *  @param[in] ept Registered endpoint by @ref ipc_service_register_endpoint.
+ *  @param[in] data Pointer to the critical message buffer to send.
+ *  @param[in] len Number of bytes to send.
+ *
+ *  @retval -EIO when no backend is registered or send_critical hook is missing
+ *               from backend.
+ *  @retval -EINVAL when instance or endpoint is invalid.
+ *  @retval -ENOENT when the endpoint is not registered with the instance.
+ *  @retval -EBADMSG when the data is invalid (i.e. invalid data format,
+ *                   invalid length exceeds backend limits, ...).
+ *  @retval -ENOTSUP when the operation is not supported by backend.
+ *  @retval -ENOMEM when even critical path buffers are exhausted.
+ *
+ *  @retval bytes number of bytes sent.
+ *  @retval other errno codes depending on the implementation of the backend.
+ */
+int ipc_service_send_critical(struct ipc_ept *ept, const void *data, size_t len);
+
 /** @brief Get the TX buffer size
  *
  *  Get the maximal size of a buffer which can be obtained by @ref

--- a/include/zephyr/ipc/ipc_service_backend.h
+++ b/include/zephyr/ipc/ipc_service_backend.h
@@ -71,6 +71,29 @@ struct ipc_service_backend {
 	int (*send)(const struct device *instance, void *token,
 		    const void *data, size_t len);
 
+	/** @brief Pointer to the function that sends critical messages bypassing flow control.
+	 *
+	 *  This function sends high-priority messages directly, bypassing busy checks
+	 *  and normal queuing mechanisms. It should be used only for critical system
+	 *  notifications like crash reports or fatal errors.
+	 *
+	 *  @param[in] instance Instance pointer.
+	 *  @param[in] token Backend-specific token.
+	 *  @param[in] data Pointer to the buffer to send.
+	 *  @param[in] len Number of bytes to send.
+	 *
+	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -ENOENT when the endpoint is not registered with the instance.
+	 *  @retval -EBADMSG when the message is invalid.
+	 *  @retval -ENOTSUP when critical send is not supported.
+	 *  @retval -ENOMEM when even critical buffers are unavailable.
+	 *
+	 *  @retval bytes number of bytes sent.
+	 *  @retval other errno codes depending on the implementation of the backend.
+	 */
+	int (*send_critical)(const struct device *instance, void *token,
+			     const void *data, size_t len);
+
 	/** @brief Pointer to the function that will be used to register endpoints.
 	 *
 	 *  @param[in] instance Instance to register the endpoint onto.

--- a/subsys/ipc/ipc_service/ipc_service.c
+++ b/subsys/ipc/ipc_service/ipc_service.c
@@ -144,6 +144,30 @@ int ipc_service_send(struct ipc_ept *ept, const void *data, size_t len)
 	return backend->send(ept->instance, ept->token, data, len);
 }
 
+int ipc_service_send_critical(struct ipc_ept *ept, const void *data, size_t len)
+{
+	const struct ipc_service_backend *backend;
+
+	if (!ept) {
+		LOG_ERR("Invalid endpoint");
+		return -EINVAL;
+	}
+
+	if (!ept->instance) {
+		LOG_ERR("Endpoint not registered\n");
+		return -ENOENT;
+	}
+
+	backend = ept->instance->api;
+
+	if (!backend || !backend->send_critical) {
+		LOG_ERR("Invalid backend configuration");
+		return -EIO;
+	}
+
+	return backend->send_critical(ept->instance, ept->token, data, len);
+}
+
 int ipc_service_get_tx_buffer_size(struct ipc_ept *ept)
 {
 	const struct ipc_service_backend *backend;


### PR DESCRIPTION
This pull request extends the generic IPC service API with a function to support sending critical messages/notifications and refactors the Intel Audio DSP host IPC service backend.

Summary of changes:

- ipc_service: Add ipc_service_send_critical() API and a matching send_critical() backend hook to send high-priority messages via a dedicated fast path that bypasses normal busy checks.
- ipc: intel_adsp: Simplify the host IPC service backend by replacing the custom intel_adsp_ipc_msg descriptor and enum-based length encoding with a fixed two-word (header + payload) IPC payload used consistently in send and receive paths.
- intel_adsp: Wire the emergency/critical send path through the new ipc_service_send_critical() API while keeping the normal IPC flow unchanged.
- intel_adsp: Move the synchronous IPC wait logic into the common intel_adsp_ipc_send_message_sync() helper used by tests, and remove the now-redundant backend-specific sync helper.
- intel_adsp: Update and clarify backend documentation comments to describe the new data format, the role of ipc_ept_cfg::priv, and the semantics of the TX-buffer readiness and RX-buffer release helpers.

Status / TODO:

- ~~Existing intel_adsp IPC tests have not yet been adapted to the refactored backend and will currently fail. Test updates will be added as part of this PR before it is ready to merge.~~