### PR TITLE
drivers: timer: cortex_m_systick: Restore SysTick configuration after reset

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -522,7 +522,14 @@ void sys_clock_idle_exit(void)
 			last_load = CYC_PER_TICK;
 			SysTick->LOAD = last_load - 1;
 			SysTick->VAL = 0; /* resets timer to last_load */
-			SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
+			if (!IS_ENABLED(CONFIG_CORTEX_M_SYSTICK_RESET_BY_LPM)) {
+				SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
+			} else {
+				NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
+				SysTick->CTRL |= (SysTick_CTRL_ENABLE_Msk |
+						  SysTick_CTRL_TICKINT_Msk |
+						  SysTick_CTRL_CLKSOURCE_Msk);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Restore the clock source and exception bits in the `CTRL` register after waking up from low-power modes that reset SysTick. Interrupt priority setting is also lost so restore that as well.