### PR TITLE
drivers: serial: uart_max32: Refactor IRQ flag clearing

### DIFF
--- a/drivers/serial/Kconfig.max32
+++ b/drivers/serial/Kconfig.max32
@@ -19,7 +19,7 @@ config UART_MAX32
 
 config UART_MAX32_TX_AE_WORKAROUND
 	bool
-	default y if SOC_MAX32690 || SOC_MAX32655
+	default y if SOC_MAX32690 || SOC_MAX32655 || SOC_MAX32657
 	depends on UART_MAX32 && UART_INTERRUPT_DRIVEN
 	help
 		This option enables a small workaround for almost-empty interrupts

--- a/drivers/serial/uart_max32.c
+++ b/drivers/serial/uart_max32.c
@@ -367,9 +367,6 @@ static int api_fifo_read(const struct device *dev, uint8_t *rx_data, const int s
 	const struct max32_uart_config *cfg = dev->config;
 
 	num_rx = MXC_UART_ReadRXFIFO(cfg->regs, (unsigned char *)rx_data, size);
-	if (num_rx == 0) {
-		MXC_UART_ClearFlags(cfg->regs, ADI_MAX32_UART_INT_RX);
-	}
 
 	return num_rx;
 }
@@ -438,9 +435,7 @@ static void api_irq_err_disable(const struct device *dev)
 
 static int api_irq_is_pending(const struct device *dev)
 {
-	struct max32_uart_data *const data = dev->data;
-
-	return (data->flags & (ADI_MAX32_UART_INT_RX | ADI_MAX32_UART_INT_TX));
+	return api_irq_rx_ready(dev) || api_irq_tx_ready(dev);
 }
 
 static int api_irq_update(const struct device *dev)
@@ -450,8 +445,6 @@ static int api_irq_update(const struct device *dev)
 
 	data->flags = MXC_UART_GetFlags(cfg->regs);
 	data->status = MXC_UART_GetStatus(cfg->regs);
-
-	MXC_UART_ClearFlags(cfg->regs, data->flags);
 
 	return 1;
 }


### PR DESCRIPTION
`api_irq_update` was clearing TX interrupt flags before the TX interrupt could be served, breaking synchronization in time-sensitive applications.

Changes:

- Remove unnecessary `MXC_UART_ClearFlags()` calls in `api_fifo_read()` and `api_irq_update()` to avoid premature flag clearing; ISR handler already clears them after returning from the callback.
- Replace raw flag checks in `irq_is_pending()` with more complete `api_irq_rx_ready()` and `api_irq_tx_ready()`.

Also enables TX almost-empty workaround for MAX32657 SoC.