### PR TITLE
mcumgr: Prevent FW loader from self-destruction

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -361,15 +361,13 @@ img_mgmt_state_any_pending(void)
 int
 img_mgmt_slot_in_use(int slot)
 {
-#if defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER)
-	return 0;
-#else
 	int image = img_mgmt_slot_to_image(slot);
 	int active_slot = img_mgmt_active_slot(image);
 
 #if !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP) && \
 	!defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD) && \
-	!defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD_WITH_REVERT)
+	!defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD_WITH_REVERT) && \
+	!defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER)
 	enum img_mgmt_next_boot_type type = NEXT_BOOT_TYPE_NORMAL;
 	int nbs = img_mgmt_get_next_boot_slot(image, &type);
 
@@ -391,7 +389,6 @@ img_mgmt_slot_in_use(int slot)
 #endif
 
 	return (active_slot == slot);
-#endif /* !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER) */
 }
 
 /**


### PR DESCRIPTION
The FW loader reports and manages exactly two slots:
 - slot 0: this is the slot for the application code to update
 - slot 1: this is the slot, in which the FW loader is placed

The slot 1 is reported, so tools can fetch metadata about the FW loader installed on the device.
Unfortunately, currently SMP-based FW loader allows to issue slot erase command for the slot 1, effectively erasing the FW loader code that is being executed.

This change correctly identifies the slot 1 as an active one, marking it as used and blocking erase operation on that slot.

Fixes #100715