### PR TITLE
stm32: boards: st: stm32n6570_dk: increase size ram size of serial boot variant

### DIFF
--- a/boards/st/stm32n6570_dk/twister.yaml
+++ b/boards/st/stm32n6570_dk/twister.yaml
@@ -1,7 +1,7 @@
 name: STM32N6570 Discovery Kit
 type: mcu
 arch: arm
-ram: 128
+ram: 192
 flash: 512
 vendor: st
 supported:


### PR DESCRIPTION
Increase the RAM size of the SB variant to enable execution of relevant tests that require at least 172 KB.

This ensures continuous tracking of these tests on CI.