### PR TITLE
tests: secure_storage: psa: its: patch test scope

### DIFF
--- a/tests/subsys/secure_storage/psa/its/testcase.yaml
+++ b/tests/subsys/secure_storage/psa/its/testcase.yaml
@@ -2,10 +2,18 @@ common:
   integration_platforms:
     - native_sim
     - nrf54l15dk/nrf54l15/cpuapp
-  platform_exclude:
-    - qemu_cortex_m0 # settings subsystem initialization fails
-    - nrf54h20dk/nrf54h20/cpuapp
-    - nrf54h20dk/nrf54h20/cpurad
+  platform_allow:
+    - native_sim
+    - mps2/an385
+    - qemu_x86/atom
+    - qemu_x86_64/atom
+    - nrf54l15dk/nrf54l15/cpuapp
+    - nrf5340dk/nrf5340/cpuapp
+    - nrf52840dk/nrf52840
+    - nrf9151dk/nrf9151
+    - nrf9160dk/nrf9160
+    - nrf9161dk/nrf9161
+    - ophelia4ev/nrf54l15/cpuapp
   timeout: 600
   tags:
     - psa.secure_storage


### PR DESCRIPTION
The current testcase.yaml for the psa its test suite does not filter for targets which are supported, it rather accepts everything then excludes unsupported targets. This currently causes tiny unsupported riscv based targets to be included in the test scope.

Rather than extend the platform_exclude list, which can grow forever, refactor the filtering to whitelist supported targets.

See https://github.com/zephyrproject-rtos/zephyr/pull/100662 for an example of CI trying to run for many nrf54h RV32 cores.