### PR TITLE
USB class: support multiple USB host controllers

### DIFF
--- a/include/zephyr/usb/usbh.h
+++ b/include/zephyr/usb/usbh.h
@@ -98,8 +98,7 @@ struct usbh_class_filter {
  */
 struct usbh_class_api {
 	/** Host initialization handler, before any device is connected */
-	int (*init)(struct usbh_class_data *const c_data,
-		    struct usbh_context *const uhs_ctx);
+	int (*init)(struct usbh_class_data *const c_data);
 	/** Request completion handler */
 	int (*completion_cb)(struct usbh_class_data *const c_data,
 			     struct uhc_transfer *const xfer);
@@ -121,8 +120,6 @@ struct usbh_class_api {
 struct usbh_class_data {
 	/** Name of the USB host class instance */
 	const char *name;
-	/** Pointer to USB host stack context structure */
-	struct usbh_context *uhs_ctx;
 	/** Pointer to USB device this class is used for */
 	struct usb_device *udev;
 	/** First interface number or claimed function */

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -51,8 +51,7 @@ static int usbh_uvc_removed(struct usbh_class_data *const c_data)
 	return 0;
 }
 
-static int usbh_uvc_init(struct usbh_class_data *const c_data,
-			 struct usbh_context *const uhs_ctx)
+static int usbh_uvc_init(struct usbh_class_data *const c_data)
 {
 	return 0;
 }

--- a/subsys/usb/host/usbh_class.c
+++ b/subsys/usb/host/usbh_class.c
@@ -14,11 +14,9 @@
 
 LOG_MODULE_REGISTER(usbh_class, CONFIG_USBH_LOG_LEVEL);
 
-void usbh_class_init_all(struct usbh_context *const uhs_ctx)
+void usbh_class_init_all(void)
 {
 	int ret;
-
-	usbh_host_lock(uhs_ctx);
 
 	STRUCT_SECTION_FOREACH(usbh_class_node, c_node) {
 		struct usbh_class_data *const c_data = c_node->c_data;
@@ -29,15 +27,13 @@ void usbh_class_init_all(struct usbh_context *const uhs_ctx)
 			continue;
 		}
 
-		ret = usbh_class_init(c_data, uhs_ctx);
+		ret = usbh_class_init(c_data);
 		if (ret != 0) {
 			LOG_WRN("Failed to initialize class %s (%d)",
 				c_data->name, ret);
 			c_node->state = USBH_CLASS_STATE_ERROR;
 		}
 	}
-
-	usbh_host_unlock(uhs_ctx);
 }
 
 void usbh_class_remove_all(struct usb_device *const udev)

--- a/subsys/usb/host/usbh_class.h
+++ b/subsys/usb/host/usbh_class.h
@@ -36,10 +36,8 @@ bool usbh_class_is_matching(const struct usbh_class_filter *const filter_rules,
 
 /**
  * @brief Initialize all available host class instances.
- *
- * @param[in] uhs_ctx USB Host context to pass to the class.
  */
-void usbh_class_init_all(struct usbh_context *const uhs_ctx);
+void usbh_class_init_all(void);
 
 /**
  * @brief Probe an USB device function against all available host class instances.

--- a/subsys/usb/host/usbh_class_api.h
+++ b/subsys/usb/host/usbh_class_api.h
@@ -23,16 +23,14 @@
  * It can be used to initialize underlying systems.
  *
  * @param[in] c_data Pointer to USB host class data
- * @param[in] uhs_ctx USB host context to assign to this class
  * @return 0 on success, negative error code on failure.
  */
-static inline int usbh_class_init(struct usbh_class_data *const c_data,
-				  struct usbh_context *const uhs_ctx)
+static inline int usbh_class_init(struct usbh_class_data *const c_data)
 {
 	const struct usbh_class_api *api = c_data->api;
 
 	if (api->init != NULL) {
-		return api->init(c_data, uhs_ctx);
+		return api->init(c_data);
 	}
 
 	return -ENOTSUP;

--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -198,8 +198,6 @@ int usbh_init_device_intl(struct usbh_context *const uhs_ctx)
 
 	sys_dlist_init(&uhs_ctx->udevs);
 
-	usbh_class_init_all(uhs_ctx);
-
 	return 0;
 }
 
@@ -220,6 +218,8 @@ static int uhs_pre_init(void)
 			K_PRIO_COOP(9), 0, K_NO_WAIT);
 
 	k_thread_name_set(&usbh_bus_thread_data, "usbh_bus");
+
+	usbh_class_init_all();
 
 	return 0;
 }

--- a/tests/subsys/usb/host/src/class.c
+++ b/tests/subsys/usb/host/src/class.c
@@ -38,8 +38,7 @@ static struct usbh_foo_priv usbh_foo_priv = {
 	.state = FOO_CLASS_PRIV_INACTIVE,
 };
 
-static int usbh_foo_init(struct usbh_class_data *const c_data,
-			 struct usbh_context *const uhs_ctx)
+static int usbh_foo_init(struct usbh_class_data *const c_data)
 {
 	struct usbh_foo_priv *priv = c_data->priv;
 


### PR DESCRIPTION
Dependencies:

- https://github.com/zephyrproject-rtos/zephyr/pull/94590

Do not bind an USB host controller context during init.
Instead only use the `c_data->udev = udev;` assignment that happens in `probe()` to give the class the USB context.

This means that class can be used by a controller or another depending on which side the USB device is connected, and this shares resources between the ports.