### PR TITLE
 include: zephyr: espi: Add eSPI interrupt API

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -154,6 +154,15 @@ Display
   on the SDL pseudo-device node using the PANEL_PIXEL_FORMAT_* macros from
   :zephyr_file:`include/zephyr/dt-bindings/display/panel.h`. (:github:`104099`)
 
+ESPI
+====
+
+* ECUSTOM_HOST_SUBS_INTERRUPT_EN has been deprecated in favor of new API that allows fine-grained
+  enable/disable control of individual eSPI hardware interrupts.
+  This replaces the current all-or-nothing approach, which is tightly coupled to
+  CONFIG_ESPI_PERIPHERAL_CUSTOM_OPCODE and single eSPI ACPI HW block instance in all eSPI drivers.
+  This will be completely removed in the next Zephyr release to give time for transition.
+
 Ethernet
 ========
 

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -1399,6 +1399,21 @@ void npcx_espi_disable_interrupts(const struct device *dev)
 	npcx_miwu_irq_disable(&config->espi_rst_wui);
 }
 
+int espi_npcx_interrupt_config(const struct device *dev, uint32_t espi_flags,
+			       uint32_t espi_vendor_flags)
+{
+	/* Enable host interface interrupts if its interface is eSPI */
+	espi_host_interrupt_config(espi_flags, espi_vendor_flags);
+
+	if (espi_flags & ESPI_BUS_EVENTS) {
+		npcx_espi_enable_interrupts(dev);
+	} else {
+		npcx_espi_disable_interrupts(dev);
+	}
+
+	return 0;
+}
+
 /* eSPI driver registration */
 static int espi_npcx_init(const struct device *dev);
 
@@ -1410,6 +1425,7 @@ static DEVICE_API(espi, espi_npcx_driver_api) = {
 	.manage_callback = espi_npcx_manage_callback,
 	.read_lpc_request = espi_npcx_read_lpc_request,
 	.write_lpc_request = espi_npcx_write_lpc_request,
+	.interrupt_config = espi_npcx_interrupt_config,
 #if defined(CONFIG_ESPI_OOB_CHANNEL)
 	.send_oob = espi_npcx_send_oob,
 	.receive_oob = espi_npcx_receive_oob,

--- a/drivers/espi/espi_utils.h
+++ b/drivers/espi/espi_utils.h
@@ -64,4 +64,17 @@ static inline void espi_send_callbacks(sys_slist_t *list,
 	}
 }
 
+/**
+ * @brief Propagate eSPI driver interrupt control changes to eSPI host-specific implementations
+ *
+ * @param espi_flags the bitmap to select generic eSPI interrupt events.
+ * @param espi_vendor_flags the bitmap to select any vendor-specific eSPI interrupt events.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input / output error, failed to configure device.
+ * @retval -EINVAL invalid capabilities, failed to configure device.
+ * @retval -ENOTSUP capability not supported by eSPI target.
+ */
+int espi_host_interrupt_config(uint32_t espi_flags, uint32_t espi_vendor_flags);
+
 #endif /* ZEPHYR_DRIVERS_ESPI_UTILS_H_ */

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -607,6 +607,40 @@ static void host_port80_init(void)
 }
 #endif
 
+int espi_host_interrupt_config(uint32_t espi_flags, uint32_t espi_vendor_flags)
+{
+	if (IS_ENABLED(CONFIG_ESPI_PERIPHERAL_8042_KBC)) {
+		if (espi_flags & ESPI_PERIPHERAL_8042_KBC_EVENTS) {
+			irq_enable(DT_INST_IRQ_BY_NAME(0, kbc_ibf, irq));
+			irq_enable(DT_INST_IRQ_BY_NAME(0, kbc_obe, irq));
+		} else {
+			irq_disable(DT_INST_IRQ_BY_NAME(0, kbc_ibf, irq));
+			irq_disable(DT_INST_IRQ_BY_NAME(0, kbc_obe, irq));
+		}
+	}
+
+	/* Enable host PM channel (Host IO) sub-device interrupt */
+	if (IS_ENABLED(CONFIG_ESPI_PERIPHERAL_HOST_IO) ||
+	    IS_ENABLED(CONFIG_ESPI_PERIPHERAL_EC_HOST_CMD)) {
+		if (espi_flags & ESPI_PERIPHERAL_HOST_IO_EVENTS) {
+			irq_enable(DT_INST_IRQ_BY_NAME(0, pmch_ibf, irq));
+		} else {
+			irq_disable(DT_INST_IRQ_BY_NAME(0, pmch_ibf, irq));
+		}
+	}
+
+	/* Enable host Port80 sub-device interrupt installation */
+	if (IS_ENABLED(CONFIG_ESPI_PERIPHERAL_DEBUG_PORT_80)) {
+		if (espi_flags & ESPI_PERIPHERAL_DEBUG_PORT80_EVENTS) {
+			irq_enable(DT_INST_IRQ_BY_NAME(0, p80_fifo, irq));
+		} else {
+			irq_disable(DT_INST_IRQ_BY_NAME(0, p80_fifo, irq));
+		}
+	}
+
+	return 0;
+}
+
 #if defined(CONFIG_ESPI_PERIPHERAL_CUSTOM_OPCODE)
 static void host_cus_opcode_enable_interrupts(void)
 {

--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -222,6 +222,51 @@ enum espi_virtual_peripheral {
 };
 
 /**
+ * @brief eSPI interrupt flags.
+ *
+ * eSPI interrupt flags.
+ */
+enum espi_interrupt_flags {
+	/** Enables eSPI bus reset interrupts and channel negotiation changes */
+	ESPI_BUS_EVENTS = BIT(0),
+	/** Enables eSPI VW received interrupt */
+	ESPI_VIRTUAL_WIRE_CHANNEL_EVENTS = BIT(1),
+	/** Enables eSPI OOB received interrupt */
+	ESPI_OOB_CHANNEL_EVENTS = BIT(2),
+	/** Enables eSPI Flash operations interrupt */
+	ESPI_FLASH_CHANNEL_EVENTS = BIT(3),
+
+	/** Enables UART interrupt if HW supports it */
+	ESPI_PERIPHERAL_UART_EVENTS = BIT(4),
+	/** Enables Port80 eSPI interrupt if HW supports it */
+	ESPI_PERIPHERAL_DEBUG_PORT80_EVENTS = BIT(5),
+	/** Enables 8042 interrupt if HW supports it */
+	ESPI_PERIPHERAL_8042_KBC_EVENTS = BIT(6),
+	/** Enables all ACPI eSPI host interface interrupt if HW supports it */
+	ESPI_PERIPHERAL_HOST_IO_EVENTS = BIT(7),
+	/** Enables eSPI shared memory interrupt if HW supports it */
+	ESPI_PERIPHERAL_SHARED_MEMORY_EVENTS = BIT(8),
+};
+
+/** Selects all eSPI generic interrupts
+ *
+ *  Note this does not include UART tunneled over eSPI interrupts
+ *  Since this is usually desired by eSPI driver clients
+ */
+#define ESPI_INT_ALL_MASK  (ESPI_BUS_EVENTS | ESPI_VIRTUAL_WIRE_CHANNEL_EVENTS | \
+			ESPI_OOB_CHANNEL_EVENTS | ESPI_FLASH_CHANNEL_EVENTS | \
+			ESPI_PERIPHERAL_DEBUG_PORT80_EVENTS | ESPI_PERIPHERAL_8042_KBC_EVENTS | \
+			ESPI_PERIPHERAL_HOST_IO_EVENTS | ESPI_PERIPHERAL_SHARED_MEMORY_EVENTS)
+
+/** Selects only eSPI bus HW interrupts */
+#define ESPI_INT_BUS_ONLY_MASK (ESPI_BUS_EVENTS | ESPI_VIRTUAL_WIRE_CHANNEL_EVENTS | \
+			ESPI_OOB_CHANNEL_EVENTS | ESPI_FLASH_CHANNEL_EVENTS)
+
+/** Disables all eSPI HW events */
+#define ESPI_INT_NONE_MASK	0U
+
+
+/**
  * @brief eSPI cycle types supported over eSPI peripheral channel
  */
 enum espi_cycle_type {
@@ -359,6 +404,7 @@ enum lpc_peripheral_opcode {
 	/**
 	 * Enable host subsystem interrupt (custom)
 	 * @kconfig_dep{CONFIG_ESPI_PERIPHERAL_CUSTOM_OPCODE}
+	 * @deprecated Use @ref espi_interrupt_config instead
 	 */
 	ECUSTOM_HOST_SUBS_INTERRUPT_EN = ECUSTOM_START_OPCODE,
 	/**
@@ -604,10 +650,16 @@ typedef int (*espi_api_flash_write)(const struct device *dev,
 				    struct espi_flash_packet *pckt);
 typedef int (*espi_api_flash_erase)(const struct device *dev,
 				    struct espi_flash_packet *pckt);
+
 /* Callbacks and traffic intercept */
 typedef int (*espi_api_manage_callback)(const struct device *dev,
 					struct espi_callback *callback,
 					bool set);
+
+/* eSPI interrupt control */
+typedef int (*espi_api_interrupt_configure)(const struct device *dev,
+					    uint32_t espi_interrupt_flags,
+					    uint32_t espi_interrupt_vendor);
 
 __subsystem struct espi_driver_api {
 	espi_api_config config;
@@ -624,6 +676,7 @@ __subsystem struct espi_driver_api {
 	espi_api_flash_write flash_write;
 	espi_api_flash_erase flash_erase;
 	espi_api_manage_callback manage_callback;
+	espi_api_interrupt_configure interrupt_config;
 };
 
 /**
@@ -1147,6 +1200,71 @@ static inline int espi_remove_callback(const struct device *dev,
 	return api->manage_callback(dev, callback, false);
 }
 
+/**
+ * @brief Control eSPI interrupts.
+ *
+ * This routine provides a method for eSPI driver clients to enable/disable
+ * eSPI driver blocks interrupts.
+ *
+ * If the eSPI driver does not enable interrupts during driver initialization,
+ * eSPI driver clients need to enable interrupts explicitly after eSPI configuration and
+ * and after eSPI bus reset event.
+ *
+ * @code
+ * +---------+        +---------+     +------+          +---------+   +---------+
+ * |  eSPI   |        |  eSPI   |     | eSPI |          |  eSPI   |   |  eSPI   |
+ * |  target |        | driver  |     |  bus |          |  driver |   |  host   |
+ * +--------+        +---------+     +------+          +---------+   +---------+
+ *     |                   |            |                   |             |
+ *     |                   +- eSPI---|  |                   |             |
+ *     +                   +<- init--|  |                   |             |
+ *     |                   |            |                   |             |
+ *     |                   |            |                   |             |
+ *     | espi_config       | Set eSPI   |                   |             |
+ *     +-------------------+ ctrl regs  |                   |             |
+ *     |                   +-------+    |                   |             |
+ *     |                   |<------+    |                   |             |
+ *     |                   |            |                   |             |
+ *     | interrupt_config  |            |                   |             |
+ *     +-------------------+            |                   |             |
+ *     |                   |            |                   |             |  eSPI host
+ *     |                   |            |    VW  packet     +<------------+  sends VW
+ *     |                   |    ISR     | <-----------------+             |
+ *     |  VWIRE_RECEIVED   |<-----------|                   |             |
+ *     +<------------------+            +                   +             +
+ *     |                   |            |                   |             |
+ *     |                   |            |                   |             |  eSPI host
+ *     |                   |            |    eSPI reset     +<------------+  resets the
+ *     |                   |    ISR     | <-----------------+             |  bus
+ *     |      callback     |<-----------|                   |             |
+ *     +<------------------+            +                   +             +
+ *     |                   |            |                   |             |
+ *     | interrupt_config  |            |                   |             |
+ *     +-------------------+            |                   |             |
+ * @endcode
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param espi_flags the bitmap to select generic eSPI interrupt events.
+ * @param espi_vendor_flags the bitmap to select any vendor-specific eSPI interrupt events.
+ *
+ * Note: For both cases a 1 enables the corresponding interrupt event, and 0 disables it.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input / output error, failed to configure device.
+ * @retval -EINVAL invalid capabilities, failed to configure device.
+ * @retval -ENOTSUP capability not supported by eSPI target.
+ */
+static inline int espi_interrupt_config(const struct device *dev, uint32_t espi_flags,
+					uint32_t espi_vendor_flags)
+{
+	const struct espi_driver_api *api = DEVICE_API_GET(espi, dev);
+
+	if (!api->interrupt_config) {
+		return -ENOTSUP;
+	}
+
+	return api->interrupt_config(dev, espi_flags, espi_vendor_flags);
+}
 #ifdef __cplusplus
 }
 #endif

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -87,6 +87,11 @@ static void espi_reset_handler(const struct device *dev, struct espi_callback *c
 	if (event.evt_type == ESPI_BUS_RESET) {
 		espi_rst_sts = event.evt_data;
 		LOG_INF("eSPI BUS reset %d", event.evt_data);
+
+		/* Re-enable interrupts after eSPI reset event */
+		if (espi_rst_sts) {
+			espi_interrupt_config(espi_dev, ESPI_INT_ALL_MASK, 0);
+		}
 	}
 }
 
@@ -206,12 +211,7 @@ int espi_init(void)
 	espi_add_callback(espi_dev, &oob_cb);
 #endif
 
-#if defined(CONFIG_SOC_SERIES_NPCX4) || defined(CONFIG_SOC_SERIES_NPCX9)
-	uint32_t enable = 1;
-
-	espi_write_lpc_request(espi_dev, ECUSTOM_HOST_SUBS_INTERRUPT_EN, &enable);
-#endif
-
+	espi_interrupt_config(espi_dev, ESPI_INT_BUS_ONLY_MASK, 0);
 	LOG_INF("complete");
 
 	return ret;


### PR DESCRIPTION
Introduce standard eSPI interrupt configuration API to consolidate SoC-specific implementations 

This allows to enable/disable different eSPI interrupts granularly

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
