### PR TITLE
dts: arm: nxp: rt700_cpu0: add uuid support

### DIFF
--- a/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1122,6 +1122,11 @@
 		compatible = "nxp,pmc-tmpsns";
 		status = "disabled";
 	};
+
+	uuid: uuid@2bc0 {
+		compatible = "nxp,lpc-uid";
+		reg = <0x2bc0 0x10>;
+	};
 };
 
 &xspi0 {


### PR DESCRIPTION
SYSCON0 IP can be accessed by CPU0, HiFi4, EZH-V, eDMA0, eDMA1. 
So cm33_cpu1 can't be supported this feature.
Test hwinfo/api case passed on cm33_cpu0 core