### PR TITLE
drivers: nrf: remove GPIO HAL inclusion

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -14,7 +14,6 @@
 #include <zephyr/pm/device_runtime.h>
 #include <dmm.h>
 #include <soc.h>
-#include <hal/nrf_gpio.h>
 
 LOG_MODULE_REGISTER(adc_nrfx_saadc, CONFIG_ADC_LOG_LEVEL);
 

--- a/drivers/comparator/comparator_nrf_comp.c
+++ b/drivers/comparator/comparator_nrf_comp.c
@@ -5,7 +5,6 @@
  */
 
 #include <nrfx_comp.h>
-#include <hal/nrf_gpio.h>
 
 #include <zephyr/drivers/comparator/nrf_comp.h>
 #include <zephyr/kernel.h>

--- a/drivers/comparator/comparator_nrf_lpcomp.c
+++ b/drivers/comparator/comparator_nrf_lpcomp.c
@@ -5,7 +5,6 @@
  */
 
 #include <nrfx_lpcomp.h>
-#include <hal/nrf_gpio.h>
 
 #include <zephyr/drivers/comparator/nrf_lpcomp.h>
 #include <zephyr/kernel.h>


### PR DESCRIPTION
Since pin retention handling was moved to nrfx, GPIO HAL no longer has to be included in analog drivers.