### PR TITLE
drivers: input: Add sleep-mode-enable property for Pinnacle

### DIFF
--- a/drivers/input/input_pinnacle.c
+++ b/drivers/input/input_pinnacle.c
@@ -174,6 +174,7 @@ struct pinnacle_config {
 
 	enum pinnacle_sensitivity sensitivity;
 	bool relative_mode;
+	bool sleep_mode_enable;
 	uint8_t idle_packets_count;
 
 	bool clipping_enabled;
@@ -786,7 +787,12 @@ static int pinnacle_init(const struct device *dev)
 		return -EIO;
 	}
 
-	rc = pinnacle_write(dev, PINNACLE_REG_SYS_CONFIG1, 0x00);
+	value = 0x00;
+	if (config->sleep_mode_enable) {
+		value |= PINNACLE_SYS_CONFIG1_LOW_POWER_MODE;
+	}
+
+	rc = pinnacle_write(dev, PINNACLE_REG_SYS_CONFIG1, value);
 	if (rc) {
 		LOG_ERR("Failed to write SysConfig1");
 		return rc;
@@ -880,6 +886,7 @@ static int pinnacle_init(const struct device *dev)
 		.relative_mode = DT_INST_ENUM_IDX(inst, data_mode),                                \
 		.sensitivity = DT_INST_ENUM_IDX(inst, sensitivity),                                \
 		.idle_packets_count = DT_INST_PROP(inst, idle_packets_count),                      \
+		.sleep_mode_enable = DT_INST_PROP(inst, sleep_mode_enable),                        \
 		.clipping_enabled = DT_INST_PROP(inst, clipping_enable),                           \
 		.active_range_x_min = DT_INST_PROP(inst, active_range_x_min),                      \
 		.active_range_x_max = DT_INST_PROP(inst, active_range_x_max),                      \

--- a/dts/bindings/input/cirque,pinnacle-common.yaml
+++ b/dts/bindings/input/cirque,pinnacle-common.yaml
@@ -44,6 +44,12 @@ properties:
       taps. When set to 0, no empty packets are sent. Supported values from 0
       to 255.
 
+  sleep-mode-enable:
+    type: boolean
+    description: |
+      Enable sleep mode, allowing the hardware to enter a lower power mode
+      after 5 seconds with no finger detected.
+
   clipping-enable:
     type: boolean
     description: |


### PR DESCRIPTION
Add a new sleep-mode-enable property for the Cirque Pinnacle input driver, to enable the sleep-mode for those peripherals, which will go into a lower power state after 5 seconds with no fingers detected.