### PR TITLE
MAINTAINERS: relegate some Microchip RISC-V maintainers to colalborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3385,6 +3385,7 @@ Microchip RISC-V Platforms:
   status: maintained
   maintainers:
     - fkokosinski
+  collaborators:
     - kgugala
     - tgorochowik
   files:


### PR DESCRIPTION
This PR relegates some of the Microchip RISC-V area maitainers to the collabolator tier.