### PR TITLE
net: http: server: websocket: Fix truncated string warning on copying

### DIFF
--- a/subsys/net/lib/http/http_server_ws.c
+++ b/subsys/net/lib/http/http_server_ws.c
@@ -50,7 +50,7 @@ int handle_http1_to_websocket_upgrade(struct http_client_ctx *client)
 	key_len = strlen(key_accept);
 
 	olen = MIN(sizeof(key_accept) - 1 - key_len, sizeof(WS_MAGIC) - 1);
-	strncpy(key_accept + key_len, WS_MAGIC, olen);
+	memcpy(key_accept + key_len, WS_MAGIC, olen);
 
 	mbedtls_sha1(key_accept, olen + key_len, accept);
 


### PR DESCRIPTION
WS_MAGIC is a constant string and when calculating lengths for copying we always exclude the NULL terminator. In result, using strncpy() for copying can generate a warning about truncated string, as WS_MAGIC will always be truncated from the NULL terminator. Therefore replace strncpy() with memcpy() as it seems more appropriate for this case.

Fixes #100713