### PR TITLE
sys: util: add sys_ prefix to SIGN, gcd, and lcm utils

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -1036,7 +1036,7 @@ static inline size_t sys_count_bits(const void *value, size_t len)
  * @retval -1 if x is negative
  * @retval 0 if x is zero
  */
-#define SIGN(x) (((x) > 0) - ((x) < 0))
+#define SYS_SIGN(x) (((x) > 0) - ((x) < 0))
 
 /**
  * @brief Compute the Greatest Common Divisor (GCD) of two integers
@@ -1048,12 +1048,12 @@ static inline size_t sys_count_bits(const void *value, size_t len)
  * @return The greatest common divisor of a and b, always returns an unsigned value.
  *         If one of the parameters is 0, returns the absolute value of the other parameter.
  */
-#define gcd(a, b) ((((__typeof__(a))-1) < 0) ? gcd_s(a, b) : gcd_u(a, b))
+#define sys_gcd(a, b) ((((__typeof__(a))-1) < 0) ? sys_gcd_s(a, b) : sys_gcd_u(a, b))
 
 /**
  * @cond INTERNAL_HIDDEN
  */
-static ALWAYS_INLINE uint32_t gcd_u(uint32_t a, uint32_t b)
+static ALWAYS_INLINE uint32_t sys_gcd_u(uint32_t a, uint32_t b)
 {
 	uint32_t c;
 
@@ -1075,9 +1075,9 @@ static ALWAYS_INLINE uint32_t gcd_u(uint32_t a, uint32_t b)
 	return b;
 }
 
-static ALWAYS_INLINE uint32_t gcd_s(int32_t a, int32_t b)
+static ALWAYS_INLINE uint32_t sys_gcd_s(int32_t a, int32_t b)
 {
-	return gcd_u(a < 0 ? -(uint32_t)a : (uint32_t)a, b < 0 ? -(uint32_t)b : (uint32_t)b);
+	return sys_gcd_u(a < 0 ? -(uint32_t)a : (uint32_t)a, b < 0 ? -(uint32_t)b : (uint32_t)b);
 }
 /**
  * @endcond
@@ -1092,23 +1092,23 @@ static ALWAYS_INLINE uint32_t gcd_s(int32_t a, int32_t b)
  * @retval The least common multiple of a and b.
  * @retval 0 if either input is 0.
  */
-#define lcm(a, b) ((((__typeof__(a))-1) < 0) ? lcm_s(a, b) : lcm_u(a, b))
+#define sys_lcm(a, b) ((((__typeof__(a))-1) < 0) ? sys_lcm_s(a, b) : sys_lcm_u(a, b))
 
 /**
  * @cond INTERNAL_HIDDEN
  */
-static ALWAYS_INLINE uint64_t lcm_u(uint32_t a, uint32_t b)
+static ALWAYS_INLINE uint64_t sys_lcm_u(uint32_t a, uint32_t b)
 {
 	if (a == 0 || b == 0) {
 		return 0;
 	}
 
-	return (uint64_t)(a / gcd_u(a, b)) * (uint64_t)b;
+	return (uint64_t)(a / sys_gcd_u(a, b)) * (uint64_t)b;
 }
 
-static ALWAYS_INLINE uint64_t lcm_s(int32_t a, int32_t b)
+static ALWAYS_INLINE uint64_t sys_lcm_s(int32_t a, int32_t b)
 {
-	return lcm_u(a < 0 ? -(uint32_t)a : (uint32_t)a, b < 0 ? -(uint32_t)b : (uint32_t)b);
+	return sys_lcm_u(a < 0 ? -(uint32_t)a : (uint32_t)a, b < 0 ? -(uint32_t)b : (uint32_t)b);
 }
 /**
  * @endcond

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -1050,6 +1050,9 @@ static inline size_t sys_count_bits(const void *value, size_t len)
  */
 #define gcd(a, b) ((((__typeof__(a))-1) < 0) ? gcd_s(a, b) : gcd_u(a, b))
 
+/**
+ * @cond INTERNAL_HIDDEN
+ */
 static ALWAYS_INLINE uint32_t gcd_u(uint32_t a, uint32_t b)
 {
 	uint32_t c;
@@ -1076,6 +1079,9 @@ static ALWAYS_INLINE uint32_t gcd_s(int32_t a, int32_t b)
 {
 	return gcd_u(a < 0 ? -(uint32_t)a : (uint32_t)a, b < 0 ? -(uint32_t)b : (uint32_t)b);
 }
+/**
+ * @endcond
+ */
 
 /**
  * @brief Compute the Least Common Multiple (LCM) of two integers.
@@ -1088,6 +1094,9 @@ static ALWAYS_INLINE uint32_t gcd_s(int32_t a, int32_t b)
  */
 #define lcm(a, b) ((((__typeof__(a))-1) < 0) ? lcm_s(a, b) : lcm_u(a, b))
 
+/**
+ * @cond INTERNAL_HIDDEN
+ */
 static ALWAYS_INLINE uint64_t lcm_u(uint32_t a, uint32_t b)
 {
 	if (a == 0 || b == 0) {
@@ -1101,6 +1110,9 @@ static ALWAYS_INLINE uint64_t lcm_s(int32_t a, int32_t b)
 {
 	return lcm_u(a < 0 ? -(uint32_t)a : (uint32_t)a, b < 0 ? -(uint32_t)b : (uint32_t)b);
 }
+/**
+ * @endcond
+ */
 
 #ifdef __cplusplus
 }

--- a/lib/utils/getopt/getopt_long.c
+++ b/lib/utils/getopt/getopt_long.c
@@ -52,6 +52,7 @@
 
 #include <string.h>
 #include <zephyr/sys/sys_getopt.h>
+#include <zephyr/sys/util.h>
 #include "getopt_common.h"
 
 #include <zephyr/logging/log.h>
@@ -120,7 +121,7 @@ static void permute_args(int panonopt_start, int panonopt_end, int opt_end, char
 	 */
 	nnonopts = panonopt_end - panonopt_start;
 	nopts = opt_end - panonopt_end;
-	ncycle = gcd(nnonopts, nopts);
+	ncycle = sys_gcd(nnonopts, nopts);
 	cyclelen = (opt_end - panonopt_start) / ncycle;
 
 	for (int i = 0; i < ncycle; i++) {

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -1240,67 +1240,67 @@ ZTEST(util, test_bitmask_find_gap)
 	test_single_bitmask_find_gap(0x0000000F, 2, 6, false, 4, __LINE__);
 }
 
-ZTEST(util, test_gcd)
+ZTEST(util, test_sys_gcd)
 {
 	/* Zero cases */
-	zassert_equal(gcd(0, 0), 0, "should be 0");
-	zassert_equal(gcd(0, INT_MAX), INT_MAX, "should be 0");
-	zassert_equal(gcd(INT_MAX, 0), INT_MAX, "should be 0");
+	zassert_equal(sys_gcd(0, 0), 0, "should be 0");
+	zassert_equal(sys_gcd(0, INT_MAX), INT_MAX, "should be 0");
+	zassert_equal(sys_gcd(INT_MAX, 0), INT_MAX, "should be 0");
 
 	/* Normal cases */
-	zassert_equal(gcd(12, 8), 4, "should be 4");
+	zassert_equal(sys_gcd(12, 8), 4, "should be 4");
 
 	/* Negative number cases */
-	zassert_equal(gcd(-12, 8), 4, "should be 4");
-	zassert_equal(gcd(-12, -8), 4, "should be 4");
+	zassert_equal(sys_gcd(-12, 8), 4, "should be 4");
+	zassert_equal(sys_gcd(-12, -8), 4, "should be 4");
 
 	/* Prime numbers */
-	zassert_equal(gcd(17, 13), 1, "should be 1");
-	zassert_equal(gcd(25, 49), 1, "should be 1");
+	zassert_equal(sys_gcd(17, 13), 1, "should be 1");
+	zassert_equal(sys_gcd(25, 49), 1, "should be 1");
 
 	/* Boundary values */
-	zassert_equal(gcd(INT_MAX, INT_MAX), INT_MAX, "should be INT_MAX");
-	zassert_equal(gcd(INT_MIN, INT_MIN), (uint32_t)(-(int64_t)INT_MIN),
+	zassert_equal(sys_gcd(INT_MAX, INT_MAX), INT_MAX, "should be INT_MAX");
+	zassert_equal(sys_gcd(INT_MIN, INT_MIN), (uint32_t)(-(int64_t)INT_MIN),
 		      "should be INT_MAX + 1");
-	zassert_equal(gcd(INT_MIN, INT_MAX), 1, "should be 1");
-	zassert_equal(gcd(UINT32_MAX, UINT32_MAX), UINT32_MAX, "should be UINT32_MAX");
+	zassert_equal(sys_gcd(INT_MIN, INT_MAX), 1, "should be 1");
+	zassert_equal(sys_gcd(UINT32_MAX, UINT32_MAX), UINT32_MAX, "should be UINT32_MAX");
 
 	/* Macro expansion */
 	int a = 12, b = 8;
 
-	zassert_equal(gcd(a++, b++), 4, "should be 4");
+	zassert_equal(sys_gcd(a++, b++), 4, "should be 4");
 	zassert_equal(a, 13, "should be 13");
 	zassert_equal(b, 9, "should be 9");
 }
 
-ZTEST(util, test_lcm)
+ZTEST(util, test_sys_lcm)
 {
 	/* Zero cases - lcm with 0 should be 0 */
-	zassert_equal(lcm(0, 0), 0, "should be 0");
-	zassert_equal(lcm(0, INT_MAX), 0, "should be 0");
+	zassert_equal(sys_lcm(0, 0), 0, "should be 0");
+	zassert_equal(sys_lcm(0, INT_MAX), 0, "should be 0");
 
 	/* Normal cases */
-	zassert_equal(lcm(12, 8), 24, "should be 24");
-	zassert_equal(lcm(8, 12), 24, "should be 24");
+	zassert_equal(sys_lcm(12, 8), 24, "should be 24");
+	zassert_equal(sys_lcm(8, 12), 24, "should be 24");
 
 	/* Negative number cases - lcm should always be positive */
-	zassert_equal(lcm(-12, 8), 24, "should be 24");
+	zassert_equal(sys_lcm(-12, 8), 24, "should be 24");
 
 	/* Prime numbers (gcd = 1, so lcm = a * b) */
-	zassert_equal(lcm(17, 13), 221, "should be 221");
+	zassert_equal(sys_lcm(17, 13), 221, "should be 221");
 
 	/* Boundary values */
-	zassert_equal(lcm(INT_MAX, INT_MAX - 1), (uint64_t)INT_MAX * (INT_MAX - 1),
+	zassert_equal(sys_lcm(INT_MAX, INT_MAX - 1), (uint64_t)INT_MAX * (INT_MAX - 1),
 		      "should be INT_MAX * (INT_MAX - 1)");
-	zassert_equal(lcm(INT_MIN, INT_MIN), (uint64_t)INT_MAX + 1, "should be INT_MAX + 1");
-	zassert_equal(lcm(INT_MIN, INT_MAX), (uint64_t)INT_MAX * (uint64_t)(-(int64_t)INT_MIN),
+	zassert_equal(sys_lcm(INT_MIN, INT_MIN), (uint64_t)INT_MAX + 1, "should be INT_MAX + 1");
+	zassert_equal(sys_lcm(INT_MIN, INT_MAX), (uint64_t)INT_MAX * (uint64_t)(-(int64_t)INT_MIN),
 		      "should be INT_MAX * (INT_MAX + 1)");
-	zassert_equal(lcm(UINT32_MAX, UINT32_MAX), UINT32_MAX, "should be UINT32_MAX");
+	zassert_equal(sys_lcm(UINT32_MAX, UINT32_MAX), UINT32_MAX, "should be UINT32_MAX");
 
 	/* Macro expansion */
 	int a = 12, b = 8;
 
-	zassert_equal(lcm(a++, b++), 24, "should be 4");
+	zassert_equal(sys_lcm(a++, b++), 24, "should be 4");
 	zassert_equal(a, 13, "should be 13");
 	zassert_equal(b, 9, "should be 9");
 }


### PR DESCRIPTION
As per our naming conventions for public symbols, these utility functions and macros should be prefixed with "sys_".

These were introduced with https://github.com/zephyrproject-rtos/zephyr/pull/98875 with a lack of prefix.