### PR TITLE
boards: nxp: mimxrt1170_evkb: add BLE and BT Classic support

### DIFF
--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
@@ -32,4 +32,6 @@ supported:
   - usbd
   - video
   - watchdog
+  - ble
+  - bt_classic
 vendor: nxp


### PR DESCRIPTION
Add Bluetooth Low Energy (ble) and Bluetooth Classic (bt_classic) to the list of supported features for the MIMXRT1170 EVKB CM7 board.