### PR TITLE
Bluetooth: CAP: Clear params before handover continues

### DIFF
--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -904,6 +904,17 @@ static void cap_commander_proc_complete(void)
 				 * acceptors. We can now stop and delete the broadcast source before
 				 * starting the unicast audio
 				 */
+
+				/* Clear commander parameters. Normally this is done just before the
+				 * application callbacks with bt_cap_common_clear_active_proc, but
+				 * since that is not happening here, we clear them manually. They
+				 * need to be cleared as the call to the CAP APIs does not clear old
+				 * data, and we need to reset everything before calling
+				 * cap_initiator_unicast_audio_start
+				 */
+				memset(active_proc->proc_param.commander, 0,
+				       sizeof(active_proc->proc_param.commander));
+
 				err = bt_cap_handover_broadcast_reception_stopped();
 				if (err != 0) {
 					bt_cap_handover_complete();

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1242,6 +1242,16 @@ static void cap_initiator_unicast_audio_proc_complete(void)
 	proc_type = active_proc->proc_type;
 
 	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_handover_is_active()) {
+		/* Clear initiator parameters. Normally this is done just before the
+		 * application callbacks with bt_cap_common_clear_active_proc, but
+		 * since that is not happening here, we clear them manually. They
+		 * need to be cleared as the call to the CAP APIs does not clear old
+		 * data, and we need to reset everything before calling
+		 * cap_initiator_unicast_audio_start
+		 */
+		memset(active_proc->proc_param.initiator, 0,
+		       sizeof(active_proc->proc_param.initiator));
+
 		bt_cap_handover_unicast_proc_complete();
 		return;
 	}


### PR DESCRIPTION
When an unicast initiator procedure or a commander broadcast procedure is completed and we have handover enabled, the parameters used need to be cleared before continueing. This is due to the fact that the parameters are only cleared on completion, rather than at initialization, and that the initiator and commander parameters are in a union. Not clearing the parameters could set some values to an unknown/unexpected start value.