### PR TITLE
drivers: xen: Fix uninitialized variable warning

### DIFF
--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -196,7 +196,7 @@ static void gop_eagain_retry(int cmd, struct gnttab_map_grant_ref *gref)
 
 void *gnttab_get_pages(unsigned int npages)
 {
-	int ret;
+	int ret = 0;
 	void *page_addr;
 	unsigned int removed;
 	xen_pfn_t gfn;


### PR DESCRIPTION
gcc complains about the possibility of ret and gfn being used unitialized (with the input npages == 0).
Let's fix it by initializing ret to 0.

The warnings being:
```
      zephyr/CMakeFiles/zephyr.dir/drivers/xen/gnttab.c.obj
In file included from include/zephyr/logging/log.h:11,
                 from drivers/xen/gnttab.c:31:
include/zephyr/logging/log_core.h: In function 'gnttab_get_pages':
include/zephyr/logging/log_core.h:221:9: warning: 'gfn' may be used
uninitialized [-Wmaybe-uninitialized]
  221 |         z_log_minimal_printk("%c: " fmt "\n", \
      |         ^~~~~~~~~~~~~~~~~~~~
drivers/xen/gnttab.c:202:19: note: 'gfn' was declared here
  202 |         xen_pfn_t gfn;
      |                   ^~~
include/zephyr/logging/log_core.h:221:9: warning: 'ret' may be used
uninitialized [-Wmaybe-uninitialized]
  221 |         z_log_minimal_printk("%c: " fmt "\n", \
      |         ^~~~~~~~~~~~~~~~~~~~
drivers/xen/gnttab.c:199:13: note: 'ret' was declared here
  199 |         int ret;
      |             ^~~
```

Introduced in #95934
6 failures in weekly: https://github.com/zephyrproject-rtos/zephyr/actions/runs/19997797171
For example:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/19997797171/job/57348088051#step:14:3364

Fixes #101048