### PR TITLE
llext: Keep constant data in flash.

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -53,6 +53,9 @@ enum llext_mem {
 	LLEXT_MEM_PREINIT,      /**< Array of early setup functions */
 	LLEXT_MEM_INIT,         /**< Array of setup functions */
 	LLEXT_MEM_FINI,         /**< Array of cleanup functions */
+#ifdef CONFIG_LLEXT_RODATA_NO_RELOC
+	LLEXT_MEM_RODATA_NO_RELOC,  /**< Read-only data without relocations (kept in flash) */
+#endif
 
 	LLEXT_MEM_COUNT,        /**< Number of regions managed by LLEXT */
 };
@@ -61,6 +64,22 @@ enum llext_mem {
 
 /* Number of memory partitions used by LLEXT */
 #define LLEXT_MEM_PARTITIONS (LLEXT_MEM_BSS+1)
+
+#ifdef CONFIG_LLEXT_RODATA_NO_RELOC
+/* Section name for read-only data kept in flash */
+#define LLEXT_SECT_RODATA_NO_RELOC llext.rodata.noreloc
+
+/* Full section name as string for comparisons */
+#define LLEXT_SECTION_RODATA_NO_RELOC ("." STRINGIFY(LLEXT_SECT_RODATA_NO_RELOC))
+
+/**
+ * Use this attribute on read-only data that should remain in flash
+ * instead of being copied to RAM.
+ */
+#define LLEXT_RODATA_NO_RELOC Z_GENERIC_DOT_SECTION(LLEXT_SECT_RODATA_NO_RELOC)
+#else
+#define LLEXT_RODATA_NO_RELOC
+#endif
 
 struct llext_loader;
 /** @endcond */

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -108,6 +108,20 @@ config LLEXT_STORAGE_WRITABLE
 	  Select if LLEXT storage is writable, i.e. if extensions are stored in
 	  RAM and can be modified in place
 
+config LLEXT_RODATA_NO_RELOC
+	bool "Keep read-only data without relocations in flash"
+	depends on !MMU && !USERSPACE
+	help
+	  When enabled, read-only data sections (.rodata) that do not have
+	  any relocations are kept in their original location (typically flash)
+	  instead of being copied to RAM.
+
+	  This is useful for large constant data like certificates, lookup
+	  tables, or string literals that don't contain any pointers.
+
+	  This feature requires the extension to manually tag that data with
+	  the LLEXT_RODATA_NO_RELOC macro.
+
 config LLEXT_EXPORT_DEVICES
 	bool "Export all DT devices to llexts"
 	select LLEXT_EXPORT_SYMBOL_GROUP_DEVICE

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -262,6 +262,10 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 				mem_idx = LLEXT_MEM_TEXT;
 			} else if (shdr->sh_flags & SHF_WRITE) {
 				mem_idx = LLEXT_MEM_DATA;
+#ifdef CONFIG_LLEXT_RODATA_NO_RELOC
+			} else if (strcmp(name, LLEXT_SECTION_RODATA_NO_RELOC) == 0) {
+				mem_idx = LLEXT_MEM_RODATA_NO_RELOC;
+#endif
 			} else {
 				mem_idx = LLEXT_MEM_RODATA;
 			}
@@ -533,6 +537,13 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 			ldr->sect_map[i].offset = shdr->sh_offset - ldr->sects[mem_idx].sh_offset;
 		}
 	}
+
+#ifdef CONFIG_LLEXT_RODATA_NO_RELOC
+	if (ldr->sects[LLEXT_MEM_RODATA_NO_RELOC].sh_flags & SHF_LLEXT_HAS_RELOCS) {
+		LOG_ERR("%s has relocations", LLEXT_SECTION_RODATA_NO_RELOC);
+		return -ENOEXEC;
+	}
+#endif
 
 	return 0;
 }

--- a/tests/subsys/llext/CMakeLists.txt
+++ b/tests/subsys/llext/CMakeLists.txt
@@ -47,6 +47,10 @@ if(NOT CONFIG_LLEXT_TYPE_ELF_SHAREDLIB)
     list(APPEND ext_names init_fini)
 endif()
 
+if(CONFIG_LLEXT_RODATA_NO_RELOC)
+    list(APPEND ext_names rodata_no_reloc)
+endif()
+
 # generate extension targets for each extension in 'ext_names'
 foreach(ext_name ${ext_names})
   set(ext_src ${PROJECT_SOURCE_DIR}/src/${ext_name}_ext.c)

--- a/tests/subsys/llext/src/rodata_no_reloc_ext.c
+++ b/tests/subsys/llext/src/rodata_no_reloc_ext.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Arduino SA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Test extension for CONFIG_LLEXT_RODATA_NO_RELOC feature.
+ */
+
+#include <stdint.h>
+#include <zephyr/llext/llext.h>
+#include <zephyr/llext/symbol.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/ztest_assert.h>
+
+/* Exported by the main test to provide ELF buffer location */
+extern const void *rodata_no_reloc_ext_ptr;
+extern const size_t rodata_no_reloc_ext_size;
+
+/* rodata with a relocation - forces .rodata to be relocated */
+Z_GENERIC_SECTION(.rodata)
+static const void *relocated_data = &printk;
+
+/* rodata with no relocation - should stay in place */
+LLEXT_RODATA_NO_RELOC
+static const uint32_t noreloc_data = 0x12345678;
+
+void test_entry(void)
+{
+	uintptr_t elf_start = (uintptr_t)rodata_no_reloc_ext_ptr;
+	uintptr_t elf_end = elf_start + rodata_no_reloc_ext_size;
+	uintptr_t noreloc_addr = (uintptr_t)&noreloc_data;
+	uintptr_t relocated_addr = (uintptr_t)&relocated_data;
+
+	printk("noreloc at %p, relocated at %p, ELF: %p - %p\n",
+	       (void *)noreloc_addr, (void *)relocated_addr,
+	       (void *)elf_start, (void *)elf_end);
+
+	/* Verify data is correct */
+	zassert_equal(noreloc_data, 0x12345678, "noreloc_data value mismatch");
+
+	/* noreloc_data should stay in original ELF buffer */
+	zassert_true(noreloc_addr >= elf_start && noreloc_addr < elf_end,
+		     "noreloc_data should remain in ELF buffer");
+
+	/* relocated_data should be outside ELF buffer */
+	zassert_true(relocated_addr < elf_start || relocated_addr >= elf_end,
+		     "relocated_data should be outside ELF buffer");
+}
+EXPORT_SYMBOL(test_entry);

--- a/tests/subsys/llext/src/test_llext.c
+++ b/tests/subsys/llext/src/test_llext.c
@@ -332,6 +332,17 @@ static LLEXT_CONST uint8_t inspect_ext[] LLEXT_SECT ELF_ALIGN = {
 	#include "inspect.inc"
 };
 
+#if defined(CONFIG_LLEXT_RODATA_NO_RELOC)
+static LLEXT_CONST uint8_t rodata_no_reloc_ext[] ELF_ALIGN = {
+	#include "rodata_no_reloc.inc"
+};
+const void *rodata_no_reloc_ext_ptr = rodata_no_reloc_ext;
+EXPORT_SYMBOL(rodata_no_reloc_ext_ptr);
+const size_t rodata_no_reloc_ext_size = sizeof(rodata_no_reloc_ext);
+EXPORT_SYMBOL(rodata_no_reloc_ext_size);
+LLEXT_LOAD_UNLOAD(rodata_no_reloc)
+#endif
+
 void do_inspect_checks(struct llext_loader *ldr, struct llext *ext, enum llext_mem reg_idx,
 		       const char *sect_name, const char *sym_name)
 {

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -44,6 +44,7 @@ tests:
     extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
+      - CONFIG_LLEXT_RODATA_NO_RELOC=y
   llext.readonly_mpu:
     arch_allow:
       - arm # Xtensa needs writable storage, currently not supported on RISC-V
@@ -64,6 +65,7 @@ tests:
     extra_configs:
       - CONFIG_LLEXT_HEAP_SIZE=128 # qemu_cortex_a9 requires larger heap
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
+      - CONFIG_LLEXT_RODATA_NO_RELOC=y
   llext.writable:
     arch_allow:
       - arm


### PR DESCRIPTION
This patch adds a new Kconfig option that allows read-only data sections without relocations to be mapped directly (remain in flash) instead of being copied to RAM during extension loading. This helps extensions that have large constant data, such as certificates, lookup tables etc.. to save significant RAM, especially with MPU enabled.

This feature requires the extension's linker script to place rodata sections without relocations into separate, non-overlapping section called `.rodata.noreloc`. In our application, we automate this by performing two-pass linking with a simple Python/Go script, that separates rodata with/without relocations. The final linker script looks something like this:

```ld
SECTIONS
{
    /* Read-only data WITH relocations - will be copied to RAM by LLEXT */
    .rodata : {
        *(.rodata)
        *(.rodata._ZTVN7arduino10SerialUSB_E)
        *(.rodata._ZTVN7arduino12ZephyrSerialE)
        *(.rodata._ZTVN7arduino14HardwareSerialE)
        *(.rodata._ZTVN7arduino5PrintE)
        *(.rodata._ZTVN7arduino6StreamE)
    }

    /* Read-only data WITHOUT relocations - kept in flash by LLEXT */
    .rodata.noreloc : {
        *(.rodata._ZL10cacert_pem)
        *(.rodata._ZN7arduino5Print7printlnEv.str1.4)
        *(.rodata.setup.str1.4)
        *(.rodata.str1.4)
    }

    /* Merge all .rel.rodata.* sections into .rel.rodata */
    .rel.rodata : {
        *(.rel.rodata)
        *(.rel.rodata.*)
    }

    /* Merge all .rela.rodata.* sections into .rela.rodata */
    .rela.rodata : {
        *(.rela.rodata)
        *(.rela.rodata.*)
    }
}
```

Note that we chose to disable this optimization when MMU or USERSPACE is enabled because the NO_RELOC section may not be aligned to the MPU/MMU requirements on some architectures. If we leave it in place, llext will attempt to create an MPU region for it using a misaligned address, and if we allow it to be copied to RAM, it defeats the purpose of this feature.