### PR TITLE
dts: arm: st: stm32f723: disable USBPHYC by default

### DIFF
--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -14,6 +14,7 @@
 			compatible = "st,stm32-usbphyc";
 			reg = <0x40017c00 0x400>;
 			#phy-cells = <0>;
+			status = "disabled";
 		};
 
 		usbotg_hs: usb@40040000 {


### PR DESCRIPTION
Like other devices, the USBPHYC should be disabled by default. Add missing property `status` with value `disabled` on the node in DTSI. (This has no functional impact since the node status is currently ignored anyways)