### PR TITLE
boards: nordic: nrf54h20dk: Add workaround for RISC-V debugging

### DIFF
--- a/boards/nordic/nrf54h20dk/board.cmake
+++ b/boards/nordic/nrf54h20dk/board.cmake
@@ -20,6 +20,7 @@ if(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUPPR OR CONFIG_BOARD_NRF54H20DK_NRF54H20_C
     set(JLINKSCRIPTFILE ${CMAKE_CURRENT_LIST_DIR}/support/nrf54h20_cpuflpr.JLinkScript)
   endif()
 
-  board_runner_args(jlink "--device=RISC-V" "--speed=4000" "-if SW" "--tool-opt=-jlinkscriptfile ${JLINKSCRIPTFILE}")
+  # Workaround: Use device nRF54L15_RV32 until nRF54H20_RV32 is defined.
+  board_runner_args(jlink "--device=nRF54L15_RV32" "--speed=4000" "--tool-opt=-jlinkscriptfile ${JLINKSCRIPTFILE}")
   include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 endif()


### PR DESCRIPTION
Add workaround that enables `west debug` and `west attach` on nrf54h20dk/nrf54h20/cpuppr and cpuflpr.

Remove "-if SW" as this generates warning
WARNING: runners.jlink: "f SW" does not match any known pattern

And breaks JLinkGDBServer command by setting option `-select` to `usb=f SW`.