### PR TITLE
drivers: sensor: adi: adxl345: take selected g-range into account when converting samples

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345.c
+++ b/drivers/sensor/adi/adxl345/adxl345.c
@@ -312,14 +312,22 @@ int adxl345_read_sample(const struct device *dev,
 	return 0;
 }
 
-void adxl345_accel_convert(struct sensor_value *val, int16_t sample)
+static void adxl345_accel_convert(struct sensor_value *val, int16_t sample,
+				  uint8_t selected_range)
 {
+	const int32_t sensitivity[] = {
+		[ADXL345_RANGE_2G] = INT32_C(SENSOR_G / 256),
+		[ADXL345_RANGE_4G] = INT32_C(SENSOR_G / 128),
+		[ADXL345_RANGE_8G] = INT32_C(SENSOR_G / 64),
+		[ADXL345_RANGE_16G] = INT32_C(SENSOR_G / 32),
+	};
+
 	if (sample & BIT(9)) {
 		sample |= ADXL345_COMPLEMENT;
 	}
 
-	val->val1 = ((sample * SENSOR_G) / 32) / 1000000;
-	val->val2 = ((sample * SENSOR_G) / 32) % 1000000;
+	val->val1 = (sample * sensitivity[selected_range]) / 1000000;
+	val->val2 = (sample * sensitivity[selected_range]) % 1000000;
 }
 
 static int adxl345_sample_fetch(const struct device *dev,
@@ -349,18 +357,26 @@ static int adxl345_channel_get(const struct device *dev,
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_X:
-		adxl345_accel_convert(val, data->samples.x);
+		adxl345_accel_convert(val, data->samples.x,
+				      data->selected_range);
 		break;
 	case SENSOR_CHAN_ACCEL_Y:
-		adxl345_accel_convert(val, data->samples.y);
+		adxl345_accel_convert(val, data->samples.y,
+				      data->selected_range);
 		break;
 	case SENSOR_CHAN_ACCEL_Z:
-		adxl345_accel_convert(val, data->samples.z);
+		adxl345_accel_convert(val, data->samples.z,
+				      data->selected_range);
 		break;
 	case SENSOR_CHAN_ACCEL_XYZ:
-		adxl345_accel_convert(val++, data->samples.x);
-		adxl345_accel_convert(val++, data->samples.y);
-		adxl345_accel_convert(val,   data->samples.z);
+		adxl345_accel_convert(val, data->samples.x,
+				      data->selected_range);
+		val++;
+		adxl345_accel_convert(val, data->samples.y,
+				      data->selected_range);
+		val++;
+		adxl345_accel_convert(val, data->samples.z,
+				      data->selected_range);
 		break;
 	default:
 		return -ENOTSUP;

--- a/drivers/sensor/adi/adxl345/adxl345.h
+++ b/drivers/sensor/adi/adxl345/adxl345.h
@@ -291,7 +291,6 @@ int adxl345_read_sample(const struct device *dev, struct adxl345_sample *sample)
 #ifdef CONFIG_SENSOR_ASYNC_API
 void adxl345_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
 int adxl345_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder);
-void adxl345_accel_convert(struct sensor_value *val, int16_t sample);
 #endif /* CONFIG_SENSOR_ASYNC_API */
 
 #ifdef CONFIG_ADXL345_STREAM


### PR DESCRIPTION
When running the samples/sensor/accel_trig sample with a adxl345 sensor the logged output values were doubled compared to the expected values.

The sensor_channel_get() path calls adxl345_accel_convert which did not handle the configured g-range, resulting in invalid sample values except for the +/-16g range. To fix this issue the configured range is taken into account and different conversion factors are applied.

adxl345_accel_convert is also made static as it is not used by another file.