### PR TITLE
drivers: modem/wifi/ethernet: Fix some more net API use

### DIFF
--- a/drivers/ethernet/intel/eth_intel_igc.c
+++ b/drivers/ethernet/intel/eth_intel_igc.c
@@ -650,7 +650,7 @@ static int eth_intel_igc_tx_data(const struct device *dev, struct net_pkt *pkt)
 /**
  * @brief Identify the address family of received packets as per header type.
  */
-static sa_family_t eth_intel_igc_get_sa_family(uint8_t *rx_buf)
+static net_sa_family_t eth_intel_igc_get_sa_family(uint8_t *rx_buf)
 {
 	struct net_eth_hdr *eth_hdr = (struct net_eth_hdr *)rx_buf;
 

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -377,7 +377,7 @@ static const char OK_STRING[] = "OK";
 
 struct hl7800_socket {
 	struct net_context *context;
-	sa_family_t family;
+	net_sa_family_t family;
 	enum net_sock_type type;
 	enum net_ip_protocol ip_proto;
 	struct net_sockaddr src;
@@ -418,9 +418,9 @@ struct hl7800_config {
 struct hl7800_iface_ctx {
 	struct net_if *iface;
 	uint8_t mac_addr[6];
-	struct in_addr ipv4Addr, subnet, gateway, dns_v4;
+	struct net_in_addr ipv4Addr, subnet, gateway, dns_v4;
 #ifdef CONFIG_NET_IPV6
-	struct in6_addr ipv6Addr, dns_v6;
+	struct net_in6_addr ipv6Addr, dns_v6;
 	char dns_v6_string[HL7800_IPV6_ADDR_LEN];
 #endif
 	bool restarting;
@@ -1454,7 +1454,7 @@ static int send_data(struct hl7800_socket *sock, struct net_pkt *pkt)
 	send_len = net_buf_frags_len(frag);
 	/* start sending data */
 	k_sem_reset(&sock->sock_send_sem);
-	if (sock->type == SOCK_STREAM) {
+	if (sock->type == NET_SOCK_STREAM) {
 		snprintk(buf, sizeof(buf), "AT+KTCPSND=%d,%zu", sock->socket_id,
 			 send_len);
 	} else {
@@ -1504,7 +1504,7 @@ static int send_data(struct hl7800_socket *sock, struct net_pkt *pkt)
 		ret = -ETIMEDOUT;
 	}
 done:
-	if (sock->type == SOCK_STREAM) {
+	if (sock->type == NET_SOCK_STREAM) {
 		if (sock->error == 0) {
 			sock->state = SOCK_CONNECTED;
 		}
@@ -2008,7 +2008,7 @@ char *mdm_hl7800_get_imsi(void)
  * a01.a02.a03.a04.a05.a06.a07.a08.a09.a10.a11.a12.a13.a14.a15.a16 to
  * an IPv6 address.
  */
-static int hl7800_net_addr6_pton(const char *src, struct in6_addr *dst)
+static int hl7800_net_addr6_pton(const char *src, struct net_in6_addr *dst)
 {
 	int num_sections = 8;
 	int i, len;
@@ -2062,8 +2062,8 @@ static bool on_cmd_atcmdinfo_ipaddr(struct net_buf **buf, uint16_t len)
 	size_t out_len;
 	char value[MDM_IP_INFO_RESP_SIZE];
 	char *search_start, *addr_start, *sm_start;
-	struct in_addr new_ipv4_addr;
-	struct in6_addr new_ipv6_addr;
+	struct net_in_addr new_ipv4_addr;
+	struct net_in6_addr new_ipv6_addr;
 	bool is_ipv4;
 	int addr_len;
 	char temp_addr_str[HL7800_IPV6_ADDR_LEN];
@@ -5958,7 +5958,7 @@ done:
 	return ret;
 }
 
-static int offload_get(sa_family_t family, enum net_sock_type type,
+static int offload_get(net_sa_family_t family, enum net_sock_type type,
 		       enum net_ip_protocol ip_proto,
 		       struct net_context **context)
 {
@@ -6010,7 +6010,7 @@ done:
 }
 
 static int offload_bind(struct net_context *context,
-			const struct net_sockaddr *addr, socklen_t addr_len)
+			const struct net_sockaddr *addr, net_socklen_t addr_len)
 {
 	struct hl7800_socket *sock = NULL;
 
@@ -6049,7 +6049,7 @@ static int offload_listen(struct net_context *context, int backlog)
 }
 
 static int offload_connect(struct net_context *context,
-			   const struct net_sockaddr *addr, socklen_t addr_len,
+			   const struct net_sockaddr *addr, net_socklen_t addr_len,
 			   net_context_connect_cb_t cb, int32_t timeout,
 			   void *user_data)
 {
@@ -6136,7 +6136,7 @@ static int offload_accept(struct net_context *context, net_tcp_accept_cb_t cb,
 }
 
 static int offload_sendto(struct net_pkt *pkt, const struct net_sockaddr *dst_addr,
-			  socklen_t addr_len, net_context_send_cb_t cb,
+			  net_socklen_t addr_len, net_context_send_cb_t cb,
 			  int32_t timeout, void *user_data)
 {
 	struct net_context *context = net_pkt_context(pkt);
@@ -6192,7 +6192,7 @@ static int offload_send(struct net_pkt *pkt, net_context_send_cb_t cb,
 			int32_t timeout, void *user_data)
 {
 	struct net_context *context = net_pkt_context(pkt);
-	socklen_t addr_len;
+	net_socklen_t addr_len;
 
 	addr_len = 0;
 

--- a/drivers/modem/hl78xx/hl78xx_sockets.c
+++ b/drivers/modem/hl78xx/hl78xx_sockets.c
@@ -828,12 +828,12 @@ static int validate_socket(const struct modem_socket *sock, struct hl78xx_socket
 		return -1;
 	}
 
-	bool not_connected = (!sock->is_connected && sock->type != SOCK_DGRAM);
+	bool not_connected = (!sock->is_connected && sock->type != NET_SOCK_DGRAM);
 	bool tcp_disconnected =
-		(sock->type == SOCK_STREAM &&
+		(sock->type == NET_SOCK_STREAM &&
 		 !socket_data->tcp_conn_status[HL78XX_TCP_STATUS_ID(sock->id)].is_connected);
 	bool udp_not_created =
-		(sock->type == SOCK_DGRAM &&
+		(sock->type == NET_SOCK_DGRAM &&
 		 !socket_data->udp_conn_status[HL78XX_UDP_STATUS_ID(sock->id)].is_created);
 
 	if (not_connected || tcp_disconnected || udp_not_created) {
@@ -1959,7 +1959,7 @@ static int validate_and_prepare(struct modem_socket *sock, const struct net_sock
 		errno = EINVAL;
 		return -1;
 	}
-	if (sock->type != SOCK_DGRAM && !sock->is_connected) {
+	if (sock->type != NET_SOCK_DGRAM && !sock->is_connected) {
 		errno = ENOTCONN;
 		return -1;
 	}
@@ -1967,7 +1967,7 @@ static int validate_and_prepare(struct modem_socket *sock, const struct net_sock
 		*dst_addr = &sock->dst;
 	}
 	if (*buf_len > MDM_MAX_DATA_LENGTH) {
-		if (sock->type == SOCK_DGRAM) {
+		if (sock->type == NET_SOCK_DGRAM) {
 			errno = EMSGSIZE;
 			return -1;
 		}
@@ -2137,7 +2137,7 @@ static ssize_t offload_sendto(void *obj, const void *buf, size_t len, int flags,
 	 * destination address is provided or the socket has a stored dst. The
 	 * helper validate_and_prepare will supply sock->dst for UDP when needed.
 	 */
-	if (sock->type != SOCK_DGRAM && !sock->is_connected) {
+	if (sock->type != NET_SOCK_DGRAM && !sock->is_connected) {
 		errno = ENOTCONN;
 		return -1;
 	}

--- a/drivers/modem/modem_socket.h
+++ b/drivers/modem/modem_socket.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 __net_socket struct modem_socket {
-	sa_family_t family;
+	net_sa_family_t family;
 	enum net_sock_type type;
 	int ip_proto;
 	struct net_sockaddr src;

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -2038,7 +2038,7 @@ static const struct socket_dns_offload offload_dns_ops = {
 };
 #endif
 
-static int net_offload_dummy_get(sa_family_t family,
+static int net_offload_dummy_get(net_sa_family_t family,
 				 enum net_sock_type type,
 				 enum net_ip_protocol ip_proto,
 				 struct net_context **context)

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -105,7 +105,7 @@ static struct k_work_q wncm14a2a_workq;
 
 struct wncm14a2a_socket {
 	struct net_context *context;
-	sa_family_t family;
+	net_sa_family_t family;
 	enum net_sock_type type;
 	enum net_ip_protocol ip_proto;
 	struct net_sockaddr src;
@@ -1430,7 +1430,7 @@ error:
 
 /*** OFFLOAD FUNCTIONS ***/
 
-static int offload_get(sa_family_t family,
+static int offload_get(net_sa_family_t family,
 		       enum net_sock_type type,
 		       enum net_ip_protocol ip_proto,
 		       struct net_context **context)

--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -748,7 +748,7 @@ static int esp_put(struct net_context *context)
 	return 0;
 }
 
-static int esp_get(sa_family_t family,
+static int esp_get(net_sa_family_t family,
 		   enum net_sock_type type,
 		   enum net_ip_protocol ip_proto,
 		   struct net_context **context)

--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -404,7 +404,7 @@ done:
 	return ret;
 }
 
-static int eswifi_off_get(sa_family_t family,
+static int eswifi_off_get(net_sa_family_t family,
 			  enum net_sock_type type,
 			  enum net_ip_protocol ip_proto,
 			  struct net_context **context)

--- a/drivers/wifi/simplelink/simplelink.c
+++ b/drivers/wifi/simplelink/simplelink.c
@@ -192,7 +192,7 @@ static int simplelink_mgmt_disconnect(const struct device *dev)
 	return ret ? -EIO : ret;
 }
 
-static int simplelink_dummy_get(sa_family_t family,
+static int simplelink_dummy_get(net_sa_family_t family,
 				enum net_sock_type type,
 				enum net_ip_protocol ip_proto,
 				struct net_context **context)

--- a/drivers/wifi/siwx91x/siwx91x_wifi_socket.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_socket.c
@@ -166,7 +166,7 @@ static void siwx91x_sock_on_recv(sl_si91x_fdset_t *read_fd, sl_si91x_fdset_t *wr
 			siwx91x_sock_on_recv);
 }
 
-static int siwx91x_sock_get(sa_family_t family, enum net_sock_type type,
+static int siwx91x_sock_get(net_sa_family_t family, enum net_sock_type type,
 			    enum net_ip_protocol ip_proto, struct net_context **context)
 {
 	struct siwx91x_dev *sidev = net_if_get_first_wifi()->if_dev->dev->data;

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -289,7 +289,7 @@ static char *socket_message_to_string(uint8_t message)
 /**
  * This function is called when the socket is to be opened.
  */
-static int winc1500_get(sa_family_t family,
+static int winc1500_get(net_sa_family_t family,
 			enum net_sock_type type,
 			enum net_ip_protocol ip_proto,
 			struct net_context **context)

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -381,7 +381,7 @@ struct net_cmsghdr {
 #if defined(CONFIG_NET_NATIVE_OFFLOADED_SOCKETS)
 #define UNIX_PATH_MAX 108
 #undef NET_SOCKADDR_MAX_SIZE
-/* Define NET_SOCKADDR_MAX_SIZE to be struct of sa_family_t + char[UNIX_PATH_MAX] */
+/* Define NET_SOCKADDR_MAX_SIZE to be struct of net_sa_family_t + char[UNIX_PATH_MAX] */
 #define NET_SOCKADDR_MAX_SIZE (UNIX_PATH_MAX+sizeof(net_sa_family_t))
 #if !defined(CONFIG_NET_SOCKETS_PACKET)
 #undef NET_SOCKADDR_PTR_MAX_SIZE


### PR DESCRIPTION
In #99169 the mayority of the Zephyr drivers were changed to use the Zephyr native net_ prefixed types, but some symbols were forgotten.
Without these fixes/changes the code still builds in most cases as we are by now setting CONFIG_NET_NAMESPACE_COMPAT_MODE.
But when this is not set, things fail to build.

Note that the net_offload struct was updated accordingly in d45cd6716bbab3a805e3a5fd461934f0dcdc13e5

There is currently a failure in main:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/19997797171
```
drivers/modem/hl7800.c:380:9: error: unknown type name 'sa_family_t'
  380 |         sa_family_t family;
drivers/modem/hl7800.c:5961:24: error: unknown type name 'sa_family_t'; did you mean 'net_sa_family_t'?
```
