### PR TITLE
drivers: display: Change display buffer pitch from pixel to byte

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -340,6 +340,10 @@ Display
   :kconfig:option:`SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_565X` and :kconfig:option:`ST7789V_RGB565X`
   respectively. (:github:`99276`)
 
+* The variale :c:member:`pitch` in :c:struct:`display_buffer_descriptor` changes from
+  number of pixels to number of bytes between consecutive rows in the data buffer.
+  (:github:`100749`).
+
 DMA
 ===
 

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -63,6 +63,11 @@ API Changes
       * :kconfig:option:`CONFIG_XTENSA_CACHED_REGION`
       * :kconfig:option:`CONFIG_XTENSA_UNCACHED_REGION`
 
+* Display
+
+  * :c:member:`pitch` in :c:struct:`display_buffer_descriptor` changes from number of pixels
+    to number of bytes between consecutive rows in the data buffer.
+
 Removed APIs and options
 ========================
 

--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -37,19 +37,21 @@ static int dummy_display_write(const struct device *dev, const uint16_t x,
 			       const void *buf)
 {
 	const struct dummy_display_config *config = dev->config;
+	struct dummy_display_data *disp_data = dev->data;
+	uint8_t bytes_per_pixel;
 
-	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
-	__ASSERT(desc->pitch <= config->width,
-		"Pitch in descriptor is larger than screen size");
+	bytes_per_pixel = DISPLAY_BITS_PER_PIXEL(disp_data->current_pixel_format) / 8;
+
+	__ASSERT(desc->width * bytes_per_pixel <= desc->pitch, "Pitch is smaller than width");
 	__ASSERT(desc->height <= config->height,
 		"Height in descriptor is larger than screen size");
-	__ASSERT(x + desc->pitch <= config->width,
+	__ASSERT(x + desc->width <= config->width,
 		 "Writing outside screen boundaries in horizontal direction");
 	__ASSERT(y + desc->height <= config->height,
 		 "Writing outside screen boundaries in vertical direction");
 
-	if (desc->width > desc->pitch ||
-	    x + desc->pitch > config->width ||
+	if (desc->width * bytes_per_pixel > desc->pitch ||
+	    x + desc->width > config->width ||
 	    y + desc->height > config->height) {
 		return -EINVAL;
 	}

--- a/drivers/display/display_gc9x01x.c
+++ b/drivers/display/display_gc9x01x.c
@@ -516,8 +516,8 @@ static int gc9x01x_write(const struct device *dev, const uint16_t x, const uint1
 	uint16_t nbr_of_writes;
 	uint16_t write_h;
 
-	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
-	__ASSERT((desc->pitch * data->bytes_per_pixel * desc->height) <= desc->buf_size,
+	__ASSERT(desc->width * data->bytes_per_pixel <= desc->pitch, "Pitch is smaller than width");
+	__ASSERT((desc->pitch * desc->height) <= desc->buf_size,
 		 "Input buffer too small");
 
 	LOG_DBG("Writing %dx%d (w,h) @ %dx%d (x,y)", desc->width, desc->height, x, y);
@@ -526,7 +526,7 @@ static int gc9x01x_write(const struct device *dev, const uint16_t x, const uint1
 		return ret;
 	}
 
-	if (desc->pitch > desc->width) {
+	if (desc->pitch > desc->width * data->bytes_per_pixel) {
 		write_h = 1U;
 		nbr_of_writes = desc->height;
 		mipi_desc.height = 1;
@@ -540,7 +540,7 @@ static int gc9x01x_write(const struct device *dev, const uint16_t x, const uint1
 
 	mipi_desc.width = desc->width;
 	/* Per MIPI API, pitch must always match width */
-	mipi_desc.pitch = desc->width;
+	mipi_desc.pitch = desc->width * data->bytes_per_pixel;
 	mipi_desc.frame_incomplete = desc->frame_incomplete;
 
 	ret = gc9x01x_transmit(dev, GC9X01X_CMD_MEMWR, NULL, 0);
@@ -558,7 +558,7 @@ static int gc9x01x_write(const struct device *dev, const uint16_t x, const uint1
 			return ret;
 		}
 
-		write_data_start += desc->pitch * data->bytes_per_pixel;
+		write_data_start += desc->pitch;
 	}
 
 	return 0;

--- a/drivers/display/display_hub12.c
+++ b/drivers/display/display_hub12.c
@@ -157,7 +157,7 @@ static int hub12_write(const struct device *dev, const uint16_t x, const uint16_
 		return -EINVAL;
 	}
 
-	if (desc->pitch != desc->width) {
+	if (desc->pitch != (desc->width / HUB12_PIXELS_PER_BYTE)) {
 		LOG_ERR("Unsupported pitch");
 		return -ENOTSUP;
 	}
@@ -173,7 +173,7 @@ static int hub12_write(const struct device *dev, const uint16_t x, const uint16_
 		memcpy(data->framebuffer, src, fb_size);
 	} else {
 		/* Partial update */
-		size_t src_pitch_bytes = desc->pitch / HUB12_PIXELS_PER_BYTE;
+		size_t src_pitch_bytes = desc->pitch;
 		size_t dest_pitch_bytes = config->width / HUB12_PIXELS_PER_BYTE;
 
 		for (uint16_t j = 0; j < desc->height; j++) {

--- a/drivers/display/display_mcux_dcnano_lcdif.c
+++ b/drivers/display/display_mcux_dcnano_lcdif.c
@@ -60,7 +60,7 @@ static int mcux_dcnano_lcdif_write(const struct device *dev, const uint16_t x,
 	const uint8_t *src;
 	uint8_t *dst;
 
-	__ASSERT((data->pixel_bytes * desc->pitch * desc->height) <=
+	__ASSERT((desc->pitch * desc->height) <=
 		desc->buf_size, "Input buffer too small");
 
 	LOG_DBG("W=%d, H=%d @%d,%d", desc->width, desc->height, x, y);
@@ -68,7 +68,7 @@ static int mcux_dcnano_lcdif_write(const struct device *dev, const uint16_t x,
 	if ((x == 0) && (y == 0) &&
 		(desc->width == config->dpi_config.panelWidth) &&
 		(desc->height == config->dpi_config.panelHeight) &&
-		(desc->pitch == desc->width)) {
+		(desc->pitch == (desc->width * data->pixel_bytes))) {
 		/* We can use the display buffer directly, without copying */
 		LOG_DBG("Setting FB from %p->%p",
 			(void *)data->active_fb, (void *)buf);
@@ -94,7 +94,7 @@ static int mcux_dcnano_lcdif_write(const struct device *dev, const uint16_t x,
 
 		for (h_idx = 0; h_idx < desc->height; h_idx++) {
 			memcpy(dst, src, data->pixel_bytes * desc->width);
-			src += data->pixel_bytes * desc->pitch;
+			src += desc->pitch;
 			dst += data->pitch_bytes;
 		}
 		LOG_DBG("Setting FB from %p->%p", (void *) data->active_fb,

--- a/drivers/display/display_mcux_lcdifv3.c
+++ b/drivers/display/display_mcux_lcdifv3.c
@@ -80,13 +80,14 @@ static int mcux_lcdifv3_write(const struct device *dev, const uint16_t x, const 
 	const uint8_t *src;
 	uint8_t *dst;
 
-	__ASSERT((data->pixel_bytes * desc->pitch * desc->height) <= desc->buf_size,
+	__ASSERT((desc->pitch * desc->height) <= desc->buf_size,
 		 "Input buffer too small");
 
 	LOG_DBG("W=%d, H=%d @%d,%d", desc->width, desc->height, x, y);
 
 	if ((x == 0) && (y == 0) && (desc->width == config->display_config.panelWidth) &&
-	    (desc->height == config->display_config.panelHeight) && (desc->pitch == desc->width)) {
+	    (desc->height == config->display_config.panelHeight) &&
+	    (desc->pitch == desc->width * data->pixel_bytes)) {
 		/* We can use the display buffer directly, without copying */
 		LOG_DBG("Setting FB from %p->%p", (void *)data->active_fb, (void *)buf);
 		data->active_fb = buf;
@@ -111,7 +112,7 @@ static int mcux_lcdifv3_write(const struct device *dev, const uint16_t x, const 
 
 		for (h_idx = 0; h_idx < desc->height; h_idx++) {
 			memcpy(dst, src, data->pixel_bytes * desc->width);
-			src += data->pixel_bytes * desc->pitch;
+			src += desc->pitch;
 			dst += data->pixel_bytes * config->display_config.panelWidth;
 		}
 		LOG_DBG("Setting FB from %p->%p", (void *)data->active_fb,

--- a/drivers/display/display_nrf_led_matrix.c
+++ b/drivers/display/display_nrf_led_matrix.c
@@ -247,11 +247,11 @@ static int api_write(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (desc->pitch < desc->width) {
+	if (desc->pitch < DIV_ROUND_UP(desc->width, 8U)) {
 		return -EINVAL;
 	}
 
-	uint16_t to_skip = desc->pitch - desc->width;
+	uint16_t to_skip = (desc->pitch * 8) - desc->width;
 	uint8_t mask = 0;
 	uint8_t data = 0;
 

--- a/drivers/display/display_renesas_lcdc.c
+++ b/drivers/display/display_renesas_lcdc.c
@@ -508,7 +508,7 @@ static int display_smartbond_read(const struct device *dev,
 		k_sem_take(&data->dma_sync_sem, K_FOREVER);
 
 		src += data->layer.stride;
-		dst += (desc->pitch * config->pixel_size);
+		dst += desc->pitch;
 	}
 
 	if (dma_stop(data->dma, data->dma_channel)) {
@@ -577,7 +577,7 @@ static int display_smartbond_write(const struct device *dev,
 		k_sem_take(&data->dma_sync_sem, K_FOREVER);
 
 		dst += data->layer.stride;
-		src += (desc->pitch * config->pixel_size);
+		src += desc->pitch;
 	}
 
 	if (dma_stop(data->dma, data->dma_channel)) {

--- a/drivers/display/display_renesas_ra.c
+++ b/drivers/display/display_renesas_ra.c
@@ -71,12 +71,12 @@ static int ra_display_write(const struct device *dev, const uint16_t x, const ui
 	bool vsync_wait = false;
 	fsp_err_t err;
 
-	if (desc->pitch < desc->width) {
-		LOG_ERR("Pitch is smaller than width");
+	if (desc->pitch < (desc->width * data->pixel_size)) {
+		LOG_ERR("Pitch is too small");
 		return -EINVAL;
 	}
 
-	if ((desc->pitch * data->pixel_size * desc->height) > desc->buf_size) {
+	if ((desc->pitch * desc->height) > desc->buf_size) {
 		LOG_ERR("Input buffer too small");
 		return -EINVAL;
 	}
@@ -113,7 +113,7 @@ static int ra_display_write(const struct device *dev, const uint16_t x, const ui
 		for (row = 0; row < desc->height; row++) {
 			(void)memcpy(dst, src, desc->width * data->pixel_size);
 			dst += (config->width * data->pixel_size);
-			src += (desc->pitch * data->pixel_size);
+			src += desc->pitch;
 		}
 #endif /* CONFIG_RENESAS_RA_GLCDC_FB_NUM == 0 */
 	}
@@ -166,7 +166,7 @@ static int ra_display_read(const struct device *dev, const uint16_t x, const uin
 	for (row = 0; row < desc->height; row++) {
 		(void)memcpy(dst, src, desc->width * data->pixel_size);
 		src += (config->width * data->pixel_size);
-		dst += (desc->pitch * data->pixel_size);
+		dst += desc->pitch;
 	}
 
 	return 0;

--- a/drivers/display/display_rm67162.c
+++ b/drivers/display/display_rm67162.c
@@ -381,10 +381,10 @@ static int rm67162_write_fb(const struct device *dev, bool first_write,
 			return (int)wlen;
 		}
 		/* Advance source pointer and decrement remaining */
-		if (desc->pitch > desc->width) {
+		if (desc->pitch > desc->width * data->bytes_per_pixel) {
 			len_sent += wlen;
 			local_src += wlen + len_sent / (desc->width * data->bytes_per_pixel) *
-				((desc->pitch - desc->width) * data->bytes_per_pixel);
+				(desc->pitch - desc->width * data->bytes_per_pixel);
 		} else {
 			local_src += wlen;
 		}

--- a/drivers/display/display_sh1122.c
+++ b/drivers/display/display_sh1122.c
@@ -218,7 +218,7 @@ static int sh1122_write_pixels_mipi(const struct device *dev, const uint8_t *buf
 	struct display_buffer_descriptor mipi_desc;
 
 	mipi_desc.buf_size = desc->width / 2;
-	mipi_desc.pitch = desc->pitch;
+	mipi_desc.pitch = desc->width / 2; /* One byte contains 2 pixels */
 	mipi_desc.width = desc->width;
 	mipi_desc.height = 1;
 
@@ -261,6 +261,7 @@ static int sh1122_write(const struct device *dev, const uint16_t x, const uint16
 	int total = 0;
 	uint8_t ybuf = y;
 
+	/* Supported pixel format is PIXEL_FORMAT_L_8, pitch equals width */
 	if (desc->pitch != desc->width) {
 		LOG_ERR("Pitch is not width");
 		return -EINVAL;

--- a/drivers/display/display_ssd1320.c
+++ b/drivers/display/display_ssd1320.c
@@ -268,7 +268,8 @@ static int ssd1320_write_pixels_mipi(const struct device *dev, const uint8_t *bu
 	int ret, i;
 	int total = 0;
 
-	mipi_desc.pitch = desc->pitch;
+	/* In the conversion buffer, we store 2 pixels per byte, see ssd1320_convert_L_8. */
+	mipi_desc.pitch = desc->pitch / 2;
 
 	while (pixel_count > total) {
 		i = ssd1320_convert_L_8(dev, buf, total, pixel_count);

--- a/drivers/display/display_ssd1331.c
+++ b/drivers/display/display_ssd1331.c
@@ -194,8 +194,8 @@ static int ssd1331_write(const struct device *dev, const uint16_t x, const uint1
 	uint8_t x_position[] = {x, x + desc->width - 1};
 	uint8_t y_position[] = {y, y + desc->height - 1};
 
-	if (desc->pitch != desc->width) {
-		LOG_ERR("Pitch is not width");
+	if (desc->pitch != desc->width * 2) {
+		LOG_ERR("Pitch is not width * bytes per pixel");
 		return -EINVAL;
 	}
 

--- a/drivers/display/display_ssd135x.c
+++ b/drivers/display/display_ssd135x.c
@@ -181,8 +181,8 @@ static int ssd135x_write(const struct device *dev, const uint16_t x, const uint1
 		(x + desc->width - 1 + config->column_offset) & 0x7F};
 	uint8_t y_position[] = {y & 0x7F, (y + desc->height - 1) & 0x7F};
 
-	if (desc->pitch != desc->width) {
-		LOG_ERR("Pitch is not width");
+	if (desc->pitch != desc->width * 2) {
+		LOG_ERR("Pitch is not width * bytes per pixel");
 		return -EINVAL;
 	}
 

--- a/drivers/display/display_ssd1363.c
+++ b/drivers/display/display_ssd1363.c
@@ -253,7 +253,8 @@ static int ssd1363_write_pixels_mipi(const struct device *dev, const uint8_t *bu
 	int ret, i;
 	int total = 0;
 
-	mipi_desc.pitch = desc->pitch;
+	/* In conversion buf, two pixels are saved in one byte, see ssd1363_convert_L_8. */
+	mipi_desc.pitch = desc->pitch / 2;
 
 	while (pixel_count > total) {
 		i = ssd1363_convert_L_8(dev, buf, total, pixel_count);
@@ -306,7 +307,7 @@ static int ssd1363_write(const struct device *dev, const uint16_t x, const uint1
 	size_t buf_len;
 	int32_t pixel_count = desc->width * desc->height;
 
-	if (desc->pitch != desc->width) {
+	if (desc->pitch != desc->width * DISPLAY_BITS_PER_PIXEL(PIXEL_FORMAT_L_8) / 8) {
 		LOG_ERR("Pitch is not width");
 		return -EINVAL;
 	}

--- a/drivers/display/display_st730x.c
+++ b/drivers/display/display_st730x.c
@@ -365,8 +365,8 @@ static int st730x_write(const struct device *dev, const uint16_t x, const uint16
 	uint8_t x_position[] = {x_start, x_end};
 	uint8_t y_position[] = {y / ST730X_PPYA, (y + desc->height) / ST730X_PPYA - 1};
 
-	if (desc->pitch != desc->width) {
-		LOG_ERR("Pitch is not width");
+	if (desc->pitch * ST730X_PPB != desc->width) {
+		LOG_ERR("Pitch x ST730X_PPB is not width");
 		return -EINVAL;
 	}
 
@@ -416,6 +416,7 @@ static int st730x_write(const struct device *dev, const uint16_t x, const uint16
 		mipi_desc.buf_size = i * desc->width / ST730X_PPB;
 		mipi_desc.width = desc->width;
 		mipi_desc.height = i;
+		mipi_desc.pitch = desc->width / ST730X_PPB;
 
 		err = mipi_dbi_write_display(config->mipi_dev, &config->dbi_config,
 						config->conversion_buf, &mipi_desc,

--- a/drivers/display/display_st7567.c
+++ b/drivers/display/display_st7567.c
@@ -328,18 +328,18 @@ static int st7567_write(const struct device *dev, const uint16_t x, const uint16
 {
 	size_t buf_len;
 
-	if (desc->pitch < desc->width) {
-		LOG_ERR("Pitch is smaller than width");
+	if (desc->pitch < DIV_ROUND_UP(desc->width, 8)) {
+		LOG_ERR("Pitch is smaller than width in bytes");
 		return -EINVAL;
 	}
 
-	buf_len = MIN(desc->buf_size, desc->height * desc->width / 8);
+	buf_len = MIN(desc->buf_size, desc->height * DIV_ROUND_UP(desc->width, 8));
 	if (buf == NULL || buf_len == 0U) {
 		LOG_ERR("Display buffer is not available");
 		return -EINVAL;
 	}
 
-	if (desc->pitch > desc->width) {
+	if (desc->pitch > DIV_ROUND_UP(desc->width, 8)) {
 		LOG_ERR("Unsupported mode");
 		return -EINVAL;
 	}

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -190,7 +190,7 @@ static int stm32_ltdc_write(const struct device *dev, const uint16_t x,
 	if ((x == 0) && (y == 0) &&
 	    (desc->width == config->width) &&
 	    (desc->height ==  config->height) &&
-	    (desc->pitch == desc->width)) {
+	    (desc->pitch == desc->width * data->current_pixel_size)) {
 		/* Use buf as ltdc frame buffer directly if it length same as ltdc frame buffer. */
 		pend_buf = buf;
 	} else {
@@ -221,7 +221,7 @@ static int stm32_ltdc_write(const struct device *dev, const uint16_t x,
 			(void) memcpy(dst, src, desc->width * data->current_pixel_size);
 			sys_cache_data_flush_range(dst, desc->width * data->current_pixel_size);
 			dst += (config->width * data->current_pixel_size);
-			src += (desc->pitch * data->current_pixel_size);
+			src += desc->pitch;
 		}
 
 	}
@@ -269,7 +269,7 @@ static int stm32_ltdc_read(const struct device *dev, const uint16_t x,
 		(void) memcpy(dst, src, desc->width * data->current_pixel_size);
 		sys_cache_data_flush_range(dst, desc->width * data->current_pixel_size);
 		src += (config->width * data->current_pixel_size);
-		dst += (desc->pitch * data->current_pixel_size);
+		dst += desc->pitch;
 	}
 
 	return 0;

--- a/drivers/display/ls0xx.c
+++ b/drivers/display/ls0xx.c
@@ -253,7 +253,7 @@ static int ls0xx_write(const struct device *dev, const uint16_t x,
 		return -EINVAL;
 	}
 
-	if (desc->pitch != desc->width) {
+	if ((desc->pitch * LS0XX_PIXELS_PER_BYTE) != desc->width) {
 		LOG_ERR("Unsupported mode");
 		return -ENOTSUP;
 	}

--- a/drivers/display/mb_display.c
+++ b/drivers/display/mb_display.c
@@ -83,7 +83,7 @@ static int update_content(struct mb_display *disp, const struct mb_image *img)
 		.buf_size = sizeof(struct mb_image),
 		.width    = MB_DISP_XRES,
 		.height   = MB_DISP_YRES,
-		.pitch    = 8,
+		.pitch    = 1,
 	};
 	struct mb_image tmp_img;
 	int ret;

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -338,8 +338,8 @@ static int ssd1306_write(const struct device *dev, const uint16_t x, const uint1
 	const struct ssd1306_config *config = dev->config;
 	const size_t buf_len = (desc->height * desc->width) >> SSD1306_PPB_SHIFT;
 
-	if (desc->pitch != desc->width) {
-		LOG_ERR("Pitch is not width");
+	if (desc->pitch != DIV_ROUND_UP(desc->width, 8)) {
+		LOG_ERR("Pitch is not width in bytes");
 		return -EINVAL;
 	}
 

--- a/drivers/display/ssd1327.c
+++ b/drivers/display/ssd1327.c
@@ -285,8 +285,8 @@ static int ssd1327_write(const struct device *dev, const uint16_t x, const uint1
 	uint8_t x_position[] = {x / 2, (x + desc->width - 1) / 2};
 	uint8_t y_position[] = {y, y + desc->height - 1};
 
-	if (desc->pitch != desc->width) {
-		LOG_ERR("Pitch is not width");
+	if (desc->pitch != desc->width * sizeof(uint8_t)) {
+		LOG_ERR("Pitch is not width in bytes");
 		return -EINVAL;
 	}
 

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -316,12 +316,12 @@ static int ssd16xx_set_window(const struct device *dev,
 	uint16_t panel_h = config->height -
 			   config->height % EPD_PANEL_NUMOF_ROWS_PER_PAGE;
 
-	if (desc->pitch < desc->width) {
-		LOG_ERR("Pitch is smaller than width");
+	if (desc->pitch * SSD16XX_PIXELS_PER_BYTE < desc->width) {
+		LOG_ERR("Pitch is smaller than width in bytes");
 		return -EINVAL;
 	}
 
-	if (desc->pitch > desc->width) {
+	if (desc->pitch * SSD16XX_PIXELS_PER_BYTE > desc->width) {
 		LOG_ERR("Unsupported mode");
 		return -ENOTSUP;
 	}
@@ -422,7 +422,7 @@ static int ssd16xx_write(const struct device *dev, const uint16_t x,
 		config->profiles[SSD16XX_PROFILE_PARTIAL] != NULL;
 	const bool partial_refresh = !data->blanking_on && have_partial_refresh;
 	const size_t buf_len = MIN(desc->buf_size,
-				   desc->height * desc->width / 8);
+				   desc->height * desc->pitch);
 	int err;
 
 	if (buf == NULL || buf_len == 0U) {
@@ -498,7 +498,7 @@ int ssd16xx_read_ram(const struct device *dev, enum ssd16xx_ram ram_type,
 {
 	const struct ssd16xx_data *data = dev->data;
 	const size_t buf_len = MIN(desc->buf_size,
-				   desc->height * desc->width / 8);
+				   desc->height * desc->pitch);
 	int err;
 	uint8_t ram_ctrl;
 

--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -399,9 +399,9 @@ static int uc81xx_write(const struct device *dev, const uint16_t x, const uint16
 	LOG_DBG("x %u, y %u, height %u, width %u, pitch %u",
 		x, y, desc->height, desc->width, desc->pitch);
 
-	buf_len = MIN(desc->buf_size,
-		      desc->height * desc->width / UC81XX_PIXELS_PER_BYTE);
-	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
+	buf_len = MIN(desc->buf_size, desc->height * desc->pitch);
+	__ASSERT(desc->width <= desc->pitch * UC81XX_PIXELS_PER_BYTE,
+		 "Pitch is smaller than width in bytes");
 	__ASSERT(buf != NULL, "Buffer is not available");
 	__ASSERT(buf_len != 0U, "Buffer of length zero");
 	__ASSERT(!(desc->width % UC81XX_PIXELS_PER_BYTE),

--- a/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
@@ -195,6 +195,7 @@ static int mipi_dbi_dcnano_lcdif_write_display(const struct device *dev,
 	struct mcux_dcnano_lcdif_dbi_data *lcdif_data = dev->data;
 	int ret = 0;
 	uint8_t bytes_per_pixel = 0U;
+	uint32_t local_pitch;
 
 	/* The DBI bus type and color coding. */
 	ret = mcux_dcnano_lcdif_dbi_configure(dev, dbi_config);
@@ -248,10 +249,11 @@ static int mipi_dbi_dcnano_lcdif_write_display(const struct device *dev,
 		/* For RGB888 the stride shall be calculated as
 		 * 4 bytes per pixel instead of 3.
 		 */
-		LCDIF_SetFrameBufferStride(config->base, 0, 4U * desc->pitch);
+		local_pitch = desc->pitch * 4U / 3U;
 	} else {
-		LCDIF_SetFrameBufferStride(config->base, 0, bytes_per_pixel * desc->pitch);
+		local_pitch = desc->pitch;
 	}
+	LCDIF_SetFrameBufferStride(config->base, 0, local_pitch);
 
 	/* Set the updated area's size according to desc. */
 	LCDIF_SetFrameBufferPosition(config->base, 0U, 0U, 0U, desc->width,

--- a/drivers/mipi_dsi/dsi_mcux_2l.c
+++ b/drivers/mipi_dsi/dsi_mcux_2l.c
@@ -647,8 +647,7 @@ static ssize_t dsi_mcux_transfer(const struct device *dev, uint8_t channel,
 		 */
 		if (desc != NULL) {
 #endif
-			if ((desc->pitch * data->src_bytes_per_pixel) >
-				(msg->tx_len / desc->height)) {
+			if (desc->pitch > (msg->tx_len / desc->height)) {
 				data->data_left_each_line = desc->width * data->src_bytes_per_pixel;
 				msg->tx_len = data->data_left_each_line;
 				data->update_tx_len = true;

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -216,7 +216,38 @@ struct display_capabilities {
 	enum display_orientation current_orientation;
 };
 
-/** @brief Structure to describe display data buffer layout */
+/**
+ * @brief Structure to describe display data buffer layout
+ *
+ * @verbatim
+ *  Frame Buffer Memory Layout:
+ *
+ *   <----------------- pitch (bytes per row) ------------------>
+ *   <------ width * bytes_per_pixel ------>
+ *  +---------------------------------------+--------------------+
+ *  | Pixel | Pixel | Pixel | ... | Pixel   |   Padding/Unused   |  ^
+ *  | (0,0) | (1,0) | (2,0) |     |(w-1,0)  |                    |  |
+ *  +---------------------------------------+--------------------+  |
+ *  | Pixel | Pixel | Pixel | ... | Pixel   |   Padding/Unused   |  |
+ *  | (0,1) | (1,1) | (2,1) |     |(w-1,1)  |                    | height
+ *  +---------------------------------------+--------------------+ (rows)
+ *  | Pixel | Pixel | Pixel | ... | Pixel   |   Padding/Unused   |  |
+ *  | (0,2) | (1,2) | (2,2) |     |(w-1,2)  |                    |  |
+ *  +---------------------------------------+--------------------+  |
+ *  |  ...  |  ...  |  ...  | ... |  ...    |        ...         |  |
+ *  +---------------------------------------+--------------------+  |
+ *  | Pixel | Pixel | Pixel | ... | Pixel   |   Padding/Unused   |  |
+ *  |(0,h-1)|(1,h-1)|(2,h-1)|     |(w-1,h-1)|                    |  v
+ *  +---------------------------------------+---------------------+
+ *
+ *  width  = Number of pixels per row (visible width)
+ *  height = Number of rows (visible height)
+ *  pitch  = Number of bytes per row (including padding for alignment)
+ *
+ *  Note: pitch >= width * bytes_per_pixel
+ *        The difference is padding added for memory alignment requirements.
+ * @endverbatim
+ */
 struct display_buffer_descriptor {
 	/** Data buffer size in bytes */
 	uint32_t buf_size;
@@ -224,7 +255,7 @@ struct display_buffer_descriptor {
 	uint16_t width;
 	/** Data buffer column height in pixels */
 	uint16_t height;
-	/** Number of pixels between consecutive rows in the data buffer */
+	/** Number of bytes between consecutive rows in the data buffer */
 	uint16_t pitch;
 	/** Indicates that this is not the last write buffer of the frame */
 	bool frame_incomplete;

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -260,7 +260,8 @@ static inline int mipi_dbi_command_read(const struct device *dev,
  * @param config MIPI DBI configuration
  * @param framebuf: framebuffer to write to display
  * @param desc: descriptor of framebuffer to write. Note that the pitch must
- *   be equal to width. "buf_size" field determines how many bytes will be
+ *   be equal to width * bytes_per_pixel (pitch is now in bytes per row).
+ *   "buf_size" field determines how many bytes will be
  *   written.
  * @param pixfmt: pixel format of framebuffer data
  * @retval 0 buffer write succeeded.

--- a/modules/lvgl/lvgl_display_16bit.c
+++ b/modules/lvgl/lvgl_display_16bit.c
@@ -18,10 +18,10 @@ void lvgl_flush_cb_16bit(lv_display_t *display, const lv_area_t *area, uint8_t *
 	flush.display = display;
 	flush.x = area->x1;
 	flush.y = area->y1;
-	flush.desc.buf_size = w * 2U * h;
 	flush.desc.width = w;
-	flush.desc.pitch = ROUND_UP(w * 2U, LV_DRAW_BUF_STRIDE_ALIGN) / 2U;
+	flush.desc.pitch = ROUND_UP(w * 2U, LV_DRAW_BUF_STRIDE_ALIGN);
 	flush.desc.height = h;
+	flush.desc.buf_size = flush.desc.pitch * h;
 	flush.buf = (void *)px_map;
 
 	lvgl_flush_display(&flush);

--- a/modules/lvgl/lvgl_display_24bit.c
+++ b/modules/lvgl/lvgl_display_24bit.c
@@ -18,10 +18,10 @@ void lvgl_flush_cb_24bit(lv_display_t *display, const lv_area_t *area, uint8_t *
 	flush.display = display;
 	flush.x = area->x1;
 	flush.y = area->y1;
-	flush.desc.buf_size = w * 3U * h;
 	flush.desc.width = w;
-	flush.desc.pitch = ROUND_UP(w * 3U, LV_DRAW_BUF_STRIDE_ALIGN) / 3U;
+	flush.desc.pitch = ROUND_UP(w * 3U, LV_DRAW_BUF_STRIDE_ALIGN);
 	flush.desc.height = h;
+	flush.desc.buf_size = flush.desc.pitch * h;
 	flush.buf = (void *)px_map;
 
 	if (IS_ENABLED(CONFIG_LV_Z_COLOR_24_BGR_TO_RGB)) {

--- a/modules/lvgl/lvgl_display_32bit.c
+++ b/modules/lvgl/lvgl_display_32bit.c
@@ -18,10 +18,10 @@ void lvgl_flush_cb_32bit(lv_display_t *display, const lv_area_t *area, uint8_t *
 	flush.display = display;
 	flush.x = area->x1;
 	flush.y = area->y1;
-	flush.desc.buf_size = w * 4U * h;
 	flush.desc.width = w;
-	flush.desc.pitch = ROUND_UP(w * 4U, LV_DRAW_BUF_STRIDE_ALIGN) / 4U;
+	flush.desc.pitch = ROUND_UP(w * 4U, LV_DRAW_BUF_STRIDE_ALIGN);
 	flush.desc.height = h;
+	flush.desc.buf_size = flush.desc.pitch * h;
 	flush.buf = (void *)px_map;
 	lvgl_flush_display(&flush);
 }

--- a/modules/lvgl/lvgl_display_8bit.c
+++ b/modules/lvgl/lvgl_display_8bit.c
@@ -17,10 +17,10 @@ void lvgl_flush_cb_8bit(lv_display_t *display, const lv_area_t *area, uint8_t *p
 	flush.display = display;
 	flush.x = area->x1;
 	flush.y = area->y1;
-	flush.desc.buf_size = w * h;
 	flush.desc.width = w;
 	flush.desc.pitch = ROUND_UP(w, LV_DRAW_BUF_STRIDE_ALIGN);
 	flush.desc.height = h;
+	flush.desc.buf_size = flush.desc.pitch * h;
 	flush.buf = (void *)px_map;
 
 	lvgl_flush_display(&flush);

--- a/modules/lvgl/lvgl_display_mono.c
+++ b/modules/lvgl/lvgl_display_mono.c
@@ -104,9 +104,9 @@ void lvgl_flush_cb_mono(lv_display_t *display, const lv_area_t *area, uint8_t *p
 	}
 
 	struct display_buffer_descriptor desc = {
-		.buf_size = (w * h) / 8U,
+		.buf_size = h * DIV_ROUND_UP(w, 8),
 		.width = w,
-		.pitch = w,
+		.pitch = DIV_ROUND_UP(w, 8),
 		.height = h,
 		.frame_incomplete = !is_last,
 	};

--- a/samples/boards/nordic/nrf_led_matrix/src/main.c
+++ b/samples/boards/nordic/nrf_led_matrix/src/main.c
@@ -18,7 +18,7 @@ static const struct display_buffer_descriptor buf_desc = {
 	.buf_size = sizeof(buf),
 	.width    = 5,
 	.height   = 5,
-	.pitch    = 8,
+	.pitch    = 1,
 };
 
 static void update_block_3x3(const struct device *dev)

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -78,7 +78,7 @@ static int app_display_frame(const struct device *const display_dev,
 	struct display_buffer_descriptor buf_desc = {
 		.buf_size = vbuf->bytesused,
 		.width = fmt->width,
-		.pitch = buf_desc.width,
+		.pitch = fmt->pitch,
 		.height = vbuf->bytesused / fmt->pitch,
 	};
 

--- a/samples/subsys/input/draw_touch_events/src/main.c
+++ b/samples/subsys/input/draw_touch_events/src/main.c
@@ -77,6 +77,7 @@ static int clear_screen(void)
 
 			ddesc.width = MIN(buf_desc.width, rem_w);
 			ddesc.height = MIN(buf_desc.height, rem_h);
+			ddesc.pitch = ddesc.width * BPP;
 			ddesc.buf_size = ddesc.width * ddesc.height * BPP;
 
 			ret = display_write(display_dev, x, y, &ddesc, buffer_cross_empty);
@@ -143,6 +144,7 @@ int main(void)
 		return 0;
 	}
 	fill_cross_buffer();
+	buf_desc.pitch = CROSS_DIM * BPP;
 	ret = display_blanking_off(display_dev);
 	if (ret < 0 && ret != -ENOSYS) {
 		LOG_ERR("Failed to turn blanking off (error %d)", ret);

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -576,7 +576,7 @@ int cfb_framebuffer_finalize(const struct device *dev)
 		.buf_size = fb->size,
 		.width = fb->x_res,
 		.height = fb->y_res,
-		.pitch = fb->x_res,
+		.pitch = DIV_ROUND_UP(fb->x_res, 8),
 	};
 
 	if ((fb->pixel_format == PIXEL_FORMAT_MONO10) == fb->inverted) {

--- a/tests/drivers/display/display_check/src/main.c
+++ b/tests/drivers/display/display_check/src/main.c
@@ -28,7 +28,7 @@ enum corner {
 };
 
 typedef void (*fill_buffer)(enum corner corner, uint8_t grey, uint8_t *buf,
-			    size_t buf_size);
+			    struct display_buffer_descriptor *buf_desc);
 
 
 #ifdef CONFIG_ARCH_POSIX
@@ -39,7 +39,7 @@ static void posix_exit_main(int exit_code)
 #endif
 
 static void fill_buffer_argb8888(enum corner corner, uint8_t grey, uint8_t *buf,
-				 size_t buf_size)
+				 struct display_buffer_descriptor *buf_desc)
 {
 	uint32_t color = 0;
 
@@ -58,13 +58,16 @@ static void fill_buffer_argb8888(enum corner corner, uint8_t grey, uint8_t *buf,
 		break;
 	}
 
-	for (size_t idx = 0; idx < buf_size; idx += 4) {
-		*((uint32_t *)(buf + idx)) = color;
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = 0; col < buf_desc->width; col++) {
+			size_t idx = row * buf_desc->pitch + col * 4;
+			*((uint32_t *)(buf + idx)) = color;
+		}
 	}
 }
 
 static void fill_buffer_rgb888(enum corner corner, uint8_t grey, uint8_t *buf,
-			       size_t buf_size)
+			       struct display_buffer_descriptor *buf_desc)
 {
 	uint32_t color = 0;
 
@@ -83,10 +86,13 @@ static void fill_buffer_rgb888(enum corner corner, uint8_t grey, uint8_t *buf,
 		break;
 	}
 
-	for (size_t idx = 0; idx < buf_size; idx += 3) {
-		*(buf + idx + 0) = color >> 16;
-		*(buf + idx + 1) = color >> 8;
-		*(buf + idx + 2) = color >> 0;
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = 0; col < buf_desc->width; col++) {
+			size_t idx = row * buf_desc->pitch + col * 3;
+			*(buf + idx + 0) = color >> 16;
+			*(buf + idx + 1) = color >> 8;
+			*(buf + idx + 2) = color >> 0;
+		}
 	}
 }
 
@@ -115,31 +121,38 @@ static uint16_t get_rgb565_color(enum corner corner, uint8_t grey)
 }
 
 static void fill_buffer_rgb565x(enum corner corner, uint8_t grey, uint8_t *buf,
-				size_t buf_size)
+			       struct display_buffer_descriptor *buf_desc)
 {
 	uint16_t color = get_rgb565_color(corner, grey);
 
-	for (size_t idx = 0; idx < buf_size; idx += 2) {
-		*(buf + idx + 0) = (color >> 8) & 0xFFu;
-		*(buf + idx + 1) = (color >> 0) & 0xFFu;
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = 0; col < buf_desc->width; col++) {
+			size_t idx = row * buf_desc->pitch + col * 2;
+			*(buf + idx + 0) = (color >> 8) & 0xFFu;
+			*(buf + idx + 1) = (color >> 0) & 0xFFu;
+		}
 	}
 }
 
 static void fill_buffer_rgb565(enum corner corner, uint8_t grey, uint8_t *buf,
-			       size_t buf_size)
+			       struct display_buffer_descriptor *buf_desc)
 {
 	uint16_t color = get_rgb565_color(corner, grey);
 
-	for (size_t idx = 0; idx < buf_size; idx += 2) {
-		*(uint16_t *)(buf + idx) = color;
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = 0; col < buf_desc->width; col++) {
+			size_t idx = row * buf_desc->pitch + col * 2;
+			*(uint16_t *)(buf + idx) = color;
+		}
 	}
 }
 
 static void fill_buffer_mono(enum corner corner, uint8_t grey,
 			     uint8_t black, uint8_t white,
-			     uint8_t *buf, size_t buf_size)
+			     uint8_t *buf,
+			     struct display_buffer_descriptor *buf_desc)
 {
-	uint16_t color;
+	uint8_t color;
 
 	switch (corner) {
 	case BOTTOM_LEFT:
@@ -150,18 +163,27 @@ static void fill_buffer_mono(enum corner corner, uint8_t grey,
 		break;
 	}
 
-	memset(buf, color, buf_size);
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = 0; col < DIV_ROUND_UP(buf_desc->width, 8U); col++) {
+			size_t idx = row * buf_desc->pitch + col;
+			*(uint8_t *)(buf + idx) = color;
+		}
+	}
 }
 
-static inline void fill_buffer_l_8(enum corner corner, uint8_t grey, uint8_t *buf, size_t buf_size)
+static inline void fill_buffer_l_8(enum corner corner, uint8_t grey, uint8_t *buf,
+				   struct display_buffer_descriptor *buf_desc)
 {
-	for (size_t idx = 0; idx < buf_size; idx += 1) {
-		*(uint8_t *)(buf + idx) = grey;
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = 0; col < buf_desc->width; col++) {
+			size_t idx = row * buf_desc->pitch + col;
+			*(uint8_t *)(buf + idx) = grey;
+		}
 	}
 }
 
 static void fill_buffer_al_88(enum corner corner, uint8_t grey, uint8_t *buf,
-				 size_t buf_size)
+			      struct display_buffer_descriptor *buf_desc)
 {
 	uint16_t color;
 
@@ -183,21 +205,26 @@ static void fill_buffer_al_88(enum corner corner, uint8_t grey, uint8_t *buf,
 		break;
 	}
 
-	for (size_t idx = 0; idx < buf_size; idx += 2) {
-		*((uint16_t *)(buf + idx)) = color;
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = 0; col < buf_desc->width; col++) {
+			size_t idx = row * buf_desc->pitch + col * 2;
+			*((uint16_t *)(buf + idx)) = color;
+		}
 	}
 }
 
 static inline void fill_buffer_mono01(enum corner corner, uint8_t grey,
-				      uint8_t *buf, size_t buf_size)
+				      uint8_t *buf,
+				      struct display_buffer_descriptor *buf_desc)
 {
-	fill_buffer_mono(corner, grey, 0x00u, 0xFFu, buf, buf_size);
+	fill_buffer_mono(corner, grey, 0x00u, 0xFFu, buf, buf_desc);
 }
 
 static inline void fill_buffer_mono10(enum corner corner, uint8_t grey,
-				      uint8_t *buf, size_t buf_size)
+				      uint8_t *buf,
+				      struct display_buffer_descriptor *buf_desc)
 {
-	fill_buffer_mono(corner, grey, 0xFFu, 0x00u, buf, buf_size);
+	fill_buffer_mono(corner, grey, 0xFFu, 0x00u, buf, buf_desc);
 }
 
 int test_display(void)
@@ -217,6 +244,8 @@ int test_display(void)
 	struct display_buffer_descriptor buf_desc;
 	size_t buf_size = 0;
 	fill_buffer fill_buffer_fnc = NULL;
+	uint16_t rect_pitch;
+	uint16_t full_screen_pitch;
 
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {
@@ -265,53 +294,58 @@ int test_display(void)
 		rect_w = capabilities.x_resolution;
 	}
 
-	buf_size = rect_w * rect_h;
-
-	if (buf_size < (capabilities.x_resolution * h_step)) {
-		buf_size = capabilities.x_resolution * h_step;
-	}
-
 	switch (capabilities.current_pixel_format) {
 	case PIXEL_FORMAT_ARGB_8888:
 		bg_color = 0x00u;
 		fill_buffer_fnc = fill_buffer_argb8888;
-		buf_size *= 4;
+		rect_pitch = rect_w * 4;
+		full_screen_pitch = capabilities.x_resolution * 4;
 		break;
 	case PIXEL_FORMAT_RGB_888:
 		bg_color = 0xFFu;
 		fill_buffer_fnc = fill_buffer_rgb888;
-		buf_size *= 3;
+		rect_pitch = rect_w * 3;
+		full_screen_pitch = capabilities.x_resolution * 3;
 		break;
 	case PIXEL_FORMAT_RGB_565:
 		bg_color = 0xFFu;
 		fill_buffer_fnc = fill_buffer_rgb565;
-		buf_size *= 2;
+		rect_pitch = rect_w * 2;
+		full_screen_pitch = capabilities.x_resolution * 2;
 		break;
 	case PIXEL_FORMAT_RGB_565X:
 		bg_color = 0xFFu;
 		fill_buffer_fnc = fill_buffer_rgb565x;
-		buf_size *= 2;
+		rect_pitch = rect_w * 2;
+		full_screen_pitch = capabilities.x_resolution * 2;
 		break;
 	case PIXEL_FORMAT_L_8:
 		bg_color = 0xFFu;
 		fill_buffer_fnc = fill_buffer_l_8;
+		rect_pitch = rect_w;
+		full_screen_pitch = capabilities.x_resolution;
 		break;
 	case PIXEL_FORMAT_AL_88:
 		bg_color = 0x00u;
 		fill_buffer_fnc = fill_buffer_al_88;
-		buf_size *= 2;
+		rect_pitch = rect_w * 2;
+		full_screen_pitch = capabilities.x_resolution * 2;
 		break;
 	case PIXEL_FORMAT_MONO01:
 		bg_color = 0xFFu;
 		fill_buffer_fnc = fill_buffer_mono01;
-		buf_size = DIV_ROUND_UP(DIV_ROUND_UP(
-			buf_size, NUM_BITS(uint8_t)), sizeof(uint8_t));
+		rect_pitch = DIV_ROUND_UP(DIV_ROUND_UP(
+			rect_w, NUM_BITS(uint8_t)), sizeof(uint8_t));
+		full_screen_pitch = DIV_ROUND_UP(DIV_ROUND_UP(
+			capabilities.x_resolution, NUM_BITS(uint8_t)), sizeof(uint8_t));
 		break;
 	case PIXEL_FORMAT_MONO10:
 		bg_color = 0x00u;
 		fill_buffer_fnc = fill_buffer_mono10;
-		buf_size = DIV_ROUND_UP(DIV_ROUND_UP(
-			buf_size, NUM_BITS(uint8_t)), sizeof(uint8_t));
+		rect_pitch = DIV_ROUND_UP(DIV_ROUND_UP(
+			rect_w, NUM_BITS(uint8_t)), sizeof(uint8_t));
+		full_screen_pitch = DIV_ROUND_UP(DIV_ROUND_UP(
+			capabilities.x_resolution, NUM_BITS(uint8_t)), sizeof(uint8_t));
 		break;
 	default:
 		LOG_ERR("Unsupported pixel format. Aborting test.");
@@ -322,8 +356,8 @@ int test_display(void)
 #endif
 	}
 
+	buf_size = MAX(rect_pitch * rect_h, full_screen_pitch * h_step);
 	buf = k_malloc(buf_size);
-
 	if (buf == NULL) {
 		LOG_ERR("Could not allocate memory. Aborting test.");
 #ifdef CONFIG_ARCH_POSIX
@@ -336,7 +370,7 @@ int test_display(void)
 	(void)memset(buf, bg_color, buf_size);
 
 	buf_desc.buf_size = buf_size;
-	buf_desc.pitch = capabilities.x_resolution;
+	buf_desc.pitch = full_screen_pitch;
 	buf_desc.width = capabilities.x_resolution;
 	buf_desc.height = h_step;
 
@@ -360,16 +394,16 @@ int test_display(void)
 		display_write(display_dev, 0, idx, &buf_desc, buf);
 	}
 
-	buf_desc.pitch = rect_w;
+	buf_desc.pitch = rect_pitch;
 	buf_desc.width = rect_w;
 	buf_desc.height = rect_h;
 
-	fill_buffer_fnc(TOP_LEFT, 0, buf, buf_size);
+	fill_buffer_fnc(TOP_LEFT, 0, buf, &buf_desc);
 	x = 0;
 	y = 0;
 	display_write(display_dev, x, y, &buf_desc, buf);
 
-	fill_buffer_fnc(TOP_RIGHT, 0, buf, buf_size);
+	fill_buffer_fnc(TOP_RIGHT, 0, buf, &buf_desc);
 	x = capabilities.x_resolution - rect_w;
 	y = 0;
 	display_write(display_dev, x, y, &buf_desc, buf);
@@ -381,7 +415,7 @@ int test_display(void)
 	 */
 	buf_desc.frame_incomplete = false;
 
-	fill_buffer_fnc(BOTTOM_RIGHT, 0, buf, buf_size);
+	fill_buffer_fnc(BOTTOM_RIGHT, 0, buf, &buf_desc);
 	x = capabilities.x_resolution - rect_w;
 	y = capabilities.y_resolution - rect_h;
 	display_write(display_dev, x, y, &buf_desc, buf);
@@ -394,7 +428,7 @@ int test_display(void)
 
 	LOG_INF("Display starts");
 	while (1) {
-		fill_buffer_fnc(BOTTOM_LEFT, grey_count, buf, buf_size);
+		fill_buffer_fnc(BOTTOM_LEFT, grey_count, buf, &buf_desc);
 		display_write(display_dev, x, y, &buf_desc, buf);
 		k_msleep(grey_scale_sleep);
 	}

--- a/tests/drivers/display/display_read_write/src/main.c
+++ b/tests/drivers/display/display_read_write/src/main.c
@@ -60,7 +60,7 @@ static void verify_bytes_of_area(uint8_t *data, int cmp_x, int cmp_y, size_t wid
 {
 	struct display_buffer_descriptor desc = {
 		.height = height,
-		.pitch = width,
+		.pitch = width * bpp,
 		.width = width,
 		.buf_size = buffer_size(width, height),
 	};
@@ -77,7 +77,7 @@ static void verify_background_color(int x, int y, size_t width, size_t height, u
 	size_t buf_size = buffer_size(width, height);
 	struct display_buffer_descriptor desc = {
 		.height = height,
-		.pitch = width,
+		.pitch = width * bpp,
 		.width = width,
 		.buf_size = buf_size,
 	};
@@ -131,7 +131,7 @@ static void display_before(void *text_fixture)
 
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = display_width * bpp,
 		.width = display_width,
 		.buf_size = display_height * display_width * bpp,
 	};
@@ -161,7 +161,7 @@ ZTEST(display_read_write, test_write_to_buffer_head)
 	uint16_t buf_size = width * bpp;
 	struct display_buffer_descriptor desc = {
 		.height = height,
-		.pitch = width,
+		.pitch = width * bpp,
 		.width = width,
 		.buf_size = buf_size,
 	};
@@ -189,13 +189,13 @@ ZTEST(display_read_write, test_write_to_buffer_tail)
 	uint16_t buf_size = width * bpp;
 	struct display_buffer_descriptor desc = {
 		.height = height,
-		.pitch = width,
+		.pitch = width * bpp,
 		.width = width,
 		.buf_size = buf_size,
 	};
 	struct display_buffer_descriptor desc_whole = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = display_width * bpp,
 		.width = display_width,
 		.buf_size = buffer_size(display_width, display_height),
 	};
@@ -231,13 +231,13 @@ ZTEST(display_read_write, test_read_does_not_clear_existing_buffer)
 	uint16_t buf_size = width * bpp;
 	struct display_buffer_descriptor desc = {
 		.height = height,
-		.pitch = width,
+		.pitch = width * bpp,
 		.width = width,
 		.buf_size = buf_size,
 	};
 	struct display_buffer_descriptor desc_whole = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = display_width * bpp,
 		.width = display_width,
 		.buf_size = buffer_size(display_width, display_height),
 	};

--- a/tests/subsys/display/cfb/basic/src/clear.c
+++ b/tests/subsys/display/cfb/basic/src/clear.c
@@ -26,9 +26,9 @@ static void cfb_test_before(void *text_fixture)
 {
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = DIV_ROUND_UP(display_width, 8),
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_height * DIV_ROUND_UP(display_width, 8),
 	};
 
 	memset(read_buffer, 0xAA, sizeof(read_buffer));

--- a/tests/subsys/display/cfb/basic/src/draw_circle.c
+++ b/tests/subsys/display/cfb/basic/src/draw_circle.c
@@ -26,9 +26,9 @@ static void cfb_test_before(void *text_fixture)
 {
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = DIV_ROUND_UP(display_width, 8),
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_height * DIV_ROUND_UP(display_width, 8),
 	};
 
 	memset(read_buffer, 0, sizeof(read_buffer));

--- a/tests/subsys/display/cfb/basic/src/draw_line.c
+++ b/tests/subsys/display/cfb/basic/src/draw_line.c
@@ -26,9 +26,9 @@ static void cfb_test_before(void *text_fixture)
 {
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = DIV_ROUND_UP(display_width, 8),
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_height * DIV_ROUND_UP(display_width, 8),
 	};
 
 	memset(read_buffer, 0, sizeof(read_buffer));

--- a/tests/subsys/display/cfb/basic/src/draw_point.c
+++ b/tests/subsys/display/cfb/basic/src/draw_point.c
@@ -26,9 +26,9 @@ static void cfb_test_before(void *text_fixture)
 {
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = DIV_ROUND_UP(display_width, 8),
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_height * DIV_ROUND_UP(display_width, 8),
 	};
 
 	memset(read_buffer, 0, sizeof(read_buffer));

--- a/tests/subsys/display/cfb/basic/src/draw_rect.c
+++ b/tests/subsys/display/cfb/basic/src/draw_rect.c
@@ -26,9 +26,9 @@ static void cfb_test_before(void *text_fixture)
 {
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = DIV_ROUND_UP(display_width, 8),
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_height * DIV_ROUND_UP(display_width, 8),
 	};
 
 	memset(read_buffer, 0, sizeof(read_buffer));

--- a/tests/subsys/display/cfb/basic/src/draw_text_rectspace1016.c
+++ b/tests/subsys/display/cfb/basic/src/draw_text_rectspace1016.c
@@ -26,9 +26,9 @@ static void cfb_test_before(void *text_fixture)
 {
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = DIV_ROUND_UP(display_width, 8),
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_height * DIV_ROUND_UP(display_width, 8),
 	};
 	uint8_t font_width;
 	uint8_t font_height;

--- a/tests/subsys/display/cfb/basic/src/invert.c
+++ b/tests/subsys/display/cfb/basic/src/invert.c
@@ -26,9 +26,9 @@ static void cfb_test_before(void *text_fixture)
 {
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = DIV_ROUND_UP(display_width, 8),
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_height * DIV_ROUND_UP(display_width, 8),
 	};
 
 	memset(read_buffer, 0, sizeof(read_buffer));

--- a/tests/subsys/display/cfb/basic/src/invert_area.c
+++ b/tests/subsys/display/cfb/basic/src/invert_area.c
@@ -26,9 +26,9 @@ static void cfb_test_before(void *text_fixture)
 {
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = DIV_ROUND_UP(display_width, 8),
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_height * DIV_ROUND_UP(display_width, 8),
 	};
 
 	memset(read_buffer, 0, sizeof(read_buffer));

--- a/tests/subsys/display/cfb/basic/src/print_rectspace1016.c
+++ b/tests/subsys/display/cfb/basic/src/print_rectspace1016.c
@@ -26,9 +26,9 @@ static void cfb_test_before(void *text_fixture)
 {
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = DIV_ROUND_UP(display_width, 8),
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_height * DIV_ROUND_UP(display_width, 8),
 	};
 	uint8_t font_width;
 	uint8_t font_height;

--- a/tests/subsys/display/cfb/basic/src/utils.c
+++ b/tests/subsys/display/cfb/basic/src/utils.c
@@ -53,9 +53,9 @@ bool verify_pixel(int x, int y, uint32_t color)
 {
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = DIV_ROUND_UP(display_width, 8),
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_height * DIV_ROUND_UP(display_width, 8),
 	};
 
 	zassert_ok(display_read(dev, 0, 0, &desc, read_buffer), "display_read failed");
@@ -67,9 +67,9 @@ bool verify_image(int cmp_x, int cmp_y, const uint32_t *img, size_t width, size_
 {
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = DIV_ROUND_UP(display_width, 8),
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_height * DIV_ROUND_UP(display_width, 8),
 	};
 
 	zassert_ok(display_read(dev, 0, 0, &desc, read_buffer), "display_read failed");
@@ -98,9 +98,9 @@ bool verify_color_inside_rect(int x, int y, size_t width, size_t height, uint32_
 {
 	struct display_buffer_descriptor desc = {
 		.height = display_height,
-		.pitch = display_width,
+		.pitch = DIV_ROUND_UP(display_width, 8),
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_height * DIV_ROUND_UP(display_width, 8),
 	};
 
 	zassert_ok(display_read(dev, 0, 0, &desc, read_buffer), "display_read failed");


### PR DESCRIPTION
The `pitch` in `struct display_buffer_descriptor` is defined as "Number of pixels between consecutive rows in the data buffer".

Limitation:
Some display controller needs the pitch of byte be dividable by an even value (e.g., 4, 64, ...), if the parameter pitch here is the number of pixels, then the RGB888 (3 bytes per pixel) can't work

Change the unit of `pitch` from pixel to byte.

For easy review:
- The first patch https://github.com/zephyrproject-rtos/zephyr/pull/100749/commits/e621c234bcc41baddd6b004a771b0e148d96b2e8 changes the structure definition, it is the key change,
- The second patch https://github.com/zephyrproject-rtos/zephyr/pull/100749/commits/e5229fed0bd66d5693ff5a2ee64d81b71fd5177f updates the display controller and samples accordingly. Currently it is created by AI tool, I am still check the content to make sure no issues.