### PR TITLE
Bluetooth: Audio: Use BT_CONN_ROLE over BT_HCI_ROLE

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1221,7 +1221,7 @@ int bt_bap_stream_disable(struct bt_bap_stream *stream);
  * @retval 0 in case of success
  * @retval -EINVAL if the stream, endpoint, ISO channel or connection is NULL
  * @retval -EBADMSG if the stream or ISO channel is in an invalid state for connection
- * @retval -EOPNOTSUPP if the role of the stream is not @ref BT_HCI_ROLE_CENTRAL
+ * @retval -EOPNOTSUPP if the role of the stream is not @ref BT_CONN_ROLE_CENTRAL
  * @retval -EALREADY if the ISO channel is already connecting or connected
  * @retval -EBUSY if another ISO channel is connecting
  * @retval -ENOEXEC if otherwise rejected by the ISO layer
@@ -1265,7 +1265,7 @@ int bt_bap_stream_start(struct bt_bap_stream *stream);
  *
  * @retval 0 Success
  * @retval -EINVAL The @p stream does not have an endpoint or a connection, of the stream's
- *                 connection's role is not @p BT_HCI_ROLE_CENTRAL
+ *                 connection's role is not @p BT_CONN_ROLE_CENTRAL
  * @retval -EBADMSG The state of the @p stream endpoint is not @ref BT_BAP_EP_STATE_DISABLING
  * @retval -EALREADY The CIS state of the @p is not in a connected state, and thus is already
  *                   stopping

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -649,7 +649,7 @@ int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, str
 	}
 
 	role = conn_get_role(conn);
-	if (role != BT_HCI_ROLE_CENTRAL) {
+	if (role != BT_CONN_ROLE_CENTRAL) {
 		LOG_DBG("Invalid conn role: %u, shall be central", role);
 		return -EINVAL;
 	}
@@ -720,7 +720,7 @@ int bt_bap_stream_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group)
 	}
 
 	role = conn_get_role(conn);
-	if (role != BT_HCI_ROLE_CENTRAL) {
+	if (role != BT_CONN_ROLE_CENTRAL) {
 		LOG_DBG("Invalid conn role: %u, shall be central", role);
 		return -EINVAL;
 	}
@@ -747,7 +747,7 @@ int bt_bap_stream_enable(struct bt_bap_stream *stream, const uint8_t meta[], siz
 	}
 
 	role = conn_get_role(stream->conn);
-	if (role != BT_HCI_ROLE_CENTRAL) {
+	if (role != BT_CONN_ROLE_CENTRAL) {
 		LOG_DBG("Invalid conn role: %u, shall be central", role);
 		return -EINVAL;
 	}
@@ -779,7 +779,7 @@ int bt_bap_stream_stop(struct bt_bap_stream *stream)
 	}
 
 	role = conn_get_role(stream->conn);
-	if (role != BT_HCI_ROLE_CENTRAL) {
+	if (role != BT_CONN_ROLE_CENTRAL) {
 		LOG_DBG("Invalid conn role: %u, shall be central", role);
 		return -EINVAL;
 	}
@@ -839,9 +839,9 @@ int bt_bap_stream_reconfig(struct bt_bap_stream *stream,
 	}
 
 	role = conn_get_role(stream->conn);
-	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_HCI_ROLE_CENTRAL) {
+	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_CONN_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_config(stream, codec_cfg);
-	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_HCI_ROLE_PERIPHERAL) {
+	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_CONN_ROLE_PERIPHERAL) {
 		err = bt_bap_unicast_server_reconfig(stream, codec_cfg);
 	} else {
 		err = -EOPNOTSUPP;
@@ -882,7 +882,7 @@ int bt_bap_stream_connect(struct bt_bap_stream *stream)
 	}
 
 	/* Only a unicast client can connect a stream */
-	if (conn_get_role(stream->conn) == BT_HCI_ROLE_CENTRAL) {
+	if (conn_get_role(stream->conn) == BT_CONN_ROLE_CENTRAL) {
 		return bt_bap_unicast_client_connect(stream);
 	} else {
 		return -EOPNOTSUPP;
@@ -914,9 +914,9 @@ int bt_bap_stream_start(struct bt_bap_stream *stream)
 	}
 
 	role = conn_get_role(stream->conn);
-	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_HCI_ROLE_CENTRAL) {
+	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_CONN_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_start(stream);
-	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_HCI_ROLE_PERIPHERAL) {
+	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_CONN_ROLE_PERIPHERAL) {
 		err = bt_bap_unicast_server_start(stream);
 	} else {
 		err = -EOPNOTSUPP;
@@ -961,9 +961,9 @@ int bt_bap_stream_metadata(struct bt_bap_stream *stream, const uint8_t meta[], s
 	}
 
 	role = conn_get_role(stream->conn);
-	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_HCI_ROLE_CENTRAL) {
+	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_CONN_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_metadata(stream, meta, meta_len);
-	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_HCI_ROLE_PERIPHERAL) {
+	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_CONN_ROLE_PERIPHERAL) {
 		err = bt_bap_unicast_server_metadata(stream, meta, meta_len);
 	} else {
 		err = -EOPNOTSUPP;
@@ -1003,9 +1003,9 @@ int bt_bap_stream_disable(struct bt_bap_stream *stream)
 	}
 
 	role = conn_get_role(stream->conn);
-	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_HCI_ROLE_CENTRAL) {
+	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_CONN_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_disable(stream);
-	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_HCI_ROLE_PERIPHERAL) {
+	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_CONN_ROLE_PERIPHERAL) {
 		err = bt_bap_unicast_server_disable(stream);
 	} else {
 		err = -EOPNOTSUPP;
@@ -1051,9 +1051,9 @@ int bt_bap_stream_release(struct bt_bap_stream *stream)
 	}
 
 	role = conn_get_role(stream->conn);
-	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_HCI_ROLE_CENTRAL) {
+	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_CONN_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_release(stream);
-	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_HCI_ROLE_PERIPHERAL) {
+	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_CONN_ROLE_PERIPHERAL) {
 		err = bt_bap_unicast_server_release(stream);
 	} else {
 		err = -EOPNOTSUPP;

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -4667,7 +4667,7 @@ int bt_bap_unicast_client_discover(struct bt_conn *conn, enum bt_audio_dir dir)
 	}
 
 	role = conn->role;
-	if (role != BT_HCI_ROLE_CENTRAL) {
+	if (role != BT_CONN_ROLE_CENTRAL) {
 		LOG_DBG("Invalid conn role: %u, shall be central", role);
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/audio/cap_stream.c
+++ b/subsys/bluetooth/audio/cap_stream.c
@@ -38,7 +38,7 @@ static bool stream_is_central(struct bt_bap_stream *bap_stream)
 		}
 
 		err = bt_conn_get_info(bap_stream->conn, &info);
-		if (err == 0 && info.role == BT_HCI_ROLE_CENTRAL) {
+		if (err == 0 && info.role == BT_CONN_ROLE_CENTRAL) {
 			return true;
 		}
 	}

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -581,10 +581,10 @@ static void stream_enabled_cb(struct bt_bap_stream *stream)
 		 * the endpoint
 		 */
 		const bool start_stream =
-			(IS_ENABLED(CONFIG_BT_CENTRAL) && conn_info.role == BT_HCI_ROLE_CENTRAL &&
+			(IS_ENABLED(CONFIG_BT_CENTRAL) && conn_info.role == BT_CONN_ROLE_CENTRAL &&
 			 ep_info.dir == BT_AUDIO_DIR_SOURCE) ||
 			(IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
-			 conn_info.role == BT_HCI_ROLE_PERIPHERAL &&
+			 conn_info.role == BT_CONN_ROLE_PERIPHERAL &&
 			 ep_info.dir == BT_AUDIO_DIR_SINK);
 
 		if (start_stream) {
@@ -708,7 +708,7 @@ static void stream_connected_cb(struct bt_bap_stream *stream)
 
 	(void)bt_conn_get_info(stream->conn, &conn_info);
 
-	if (conn_info.role == BT_HCI_ROLE_CENTRAL) {
+	if (conn_info.role == BT_CONN_ROLE_CENTRAL) {
 		if (ep_info.dir == BT_AUDIO_DIR_SOURCE) {
 			if (ep_info.state == BT_BAP_EP_STATE_ENABLING) {
 				/* Automatically do the receiver start ready operation for source
@@ -1114,7 +1114,7 @@ uint8_t btp_bap_discover(const void *cmd, uint16_t cmd_len,
 	u_conn = &connections[bt_conn_index(conn)];
 	(void)bt_conn_get_info(conn, &conn_info);
 
-	if (u_conn->end_points_count > 0 || conn_info.role != BT_HCI_ROLE_CENTRAL) {
+	if (u_conn->end_points_count > 0 || conn_info.role != BT_CONN_ROLE_CENTRAL) {
 		bt_conn_unref(conn);
 
 		return BTP_STATUS_FAILED;
@@ -1448,7 +1448,7 @@ uint8_t btp_ascs_configure_codec(const void *cmd, uint16_t cmd_len, void *rsp, u
 		memcpy(codec_cfg.data, cp->cc_ltvs, cp->cc_ltvs_len);
 	}
 
-	if (conn_info.role == BT_HCI_ROLE_CENTRAL) {
+	if (conn_info.role == BT_CONN_ROLE_CENTRAL) {
 		err = client_configure_codec(u_conn, conn, cp->ase_id, &codec_cfg);
 	} else {
 		err = server_configure_codec(u_conn, conn, cp->ase_id, &codec_cfg);
@@ -1533,7 +1533,7 @@ uint8_t btp_ascs_configure_qos(const void *cmd, uint16_t cmd_len, void *rsp, uin
 	}
 
 	(void)bt_conn_get_info(conn, &conn_info);
-	if (conn_info.role == BT_HCI_ROLE_PERIPHERAL) {
+	if (conn_info.role == BT_CONN_ROLE_PERIPHERAL) {
 		bt_conn_unref(conn);
 
 		return BTP_STATUS_FAILED;
@@ -1637,7 +1637,7 @@ uint8_t btp_ascs_disable(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 			return BTP_STATUS_FAILED;
 		}
 
-		if (conn_info.role == BT_HCI_ROLE_PERIPHERAL) {
+		if (conn_info.role == BT_CONN_ROLE_PERIPHERAL) {
 			/* The server the operation completes immediately */
 			btp_send_ascs_operation_completed_ev(conn, stream->ase_id,
 							     BT_ASCS_DISABLE_OP,
@@ -1674,7 +1674,7 @@ uint8_t btp_ascs_receiver_start_ready(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	if (conn_info.role == BT_HCI_ROLE_PERIPHERAL) {
+	if (conn_info.role == BT_CONN_ROLE_PERIPHERAL) {
 		/* Cannot connect the CIS as the peripheral */
 		LOG_DBG("Cannot connect the CIS as the peripheral");
 		return BTP_STATUS_FAILED;
@@ -1762,7 +1762,7 @@ uint8_t btp_ascs_receiver_stop_ready(const void *cmd, uint16_t cmd_len,
 			return BTP_STATUS_FAILED;
 		}
 
-		if (conn_info.role == BT_HCI_ROLE_PERIPHERAL) {
+		if (conn_info.role == BT_CONN_ROLE_PERIPHERAL) {
 			/* The server the operation completes immediately */
 			btp_send_ascs_operation_completed_ev(conn, stream->ase_id, BT_ASCS_STOP_OP,
 							     BT_BAP_ASCS_RSP_CODE_SUCCESS);
@@ -1812,7 +1812,7 @@ uint8_t btp_ascs_release(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 			return BTP_STATUS_FAILED;
 		}
 
-		if (conn_info.role == BT_HCI_ROLE_PERIPHERAL) {
+		if (conn_info.role == BT_CONN_ROLE_PERIPHERAL) {
 			/* The server the operation completes immediately */
 			btp_send_ascs_operation_completed_ev(conn, stream->ase_id,
 							     BT_ASCS_RELEASE_OP,
@@ -1868,7 +1868,7 @@ uint8_t btp_ascs_update_metadata(const void *cmd, uint16_t cmd_len,
 			return BTP_STATUS_FAILED;
 		}
 
-		if (conn_info.role == BT_HCI_ROLE_PERIPHERAL) {
+		if (conn_info.role == BT_CONN_ROLE_PERIPHERAL) {
 			/* The server the operation completes immediately */
 			btp_send_ascs_operation_completed_ev(conn, stream->ase_id,
 							     BT_ASCS_METADATA_OP,
@@ -1898,7 +1898,7 @@ uint8_t btp_ascs_add_ase_to_cis(const void *cmd, uint16_t cmd_len,
 	}
 
 	(void)bt_conn_get_info(conn, &conn_info);
-	if (conn_info.role == BT_HCI_ROLE_PERIPHERAL) {
+	if (conn_info.role == BT_CONN_ROLE_PERIPHERAL) {
 		bt_conn_unref(conn);
 
 		return BTP_STATUS_FAILED;


### PR DESCRIPTION
Use the host defined roles, rather than the HCI defined ones.