### PR TITLE
drivers: ksz8081: fix reset pin polarity

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -232,7 +232,7 @@ mikrobus_serial: &flexcomm0 {};
 		compatible = "microchip,ksz8081";
 		reg = <2>;
 		status = "okay";
-		reset-gpios = <&hsgpio1 23 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&hsgpio1 23 GPIO_ACTIVE_LOW>;
 		int-gpios = <&hsgpio0 21 GPIO_ACTIVE_HIGH>;
 		microchip,interface-type = "rmii";
 	};

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -160,7 +160,7 @@ arduino_serial: &lpuart2 {
 		compatible = "microchip,ksz8081";
 		reg = <0>;
 		status = "okay";
-		reset-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
 		int-gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
 		microchip,interface-type = "rmii";
 	};

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -152,7 +152,7 @@ arduino_serial: &lpuart2 {
 		compatible = "microchip,ksz8081";
 		reg = <0>;
 		status = "okay";
-		reset-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
 		int-gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
 		microchip,interface-type = "rmii";
 	};

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
@@ -200,7 +200,7 @@ zephyr_lcdif: &lcdif {
 		compatible = "microchip,ksz8081";
 		reg = <0>;
 		status = "okay";
-		reset-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 		int-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 		microchip,interface-type = "rmii";
 	};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
@@ -178,7 +178,7 @@ arduino_i2c: &lpi2c1 {
 		compatible = "microchip,ksz8081";
 		reg = <0>;
 		status = "okay";
-		reset-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 		int-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 		microchip,interface-type = "rmii";
 	};

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -244,7 +244,7 @@ arduino_serial: &lpuart3 {
 		compatible = "microchip,ksz8081";
 		reg = <0>;
 		status = "okay";
-		reset-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 		int-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 		microchip,interface-type = "rmii";
 	};

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -160,7 +160,7 @@
 		compatible = "microchip,ksz8081";
 		reg = <0>;
 		status = "okay";
-		reset-gpios = <&gpio12 12 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio12 12 GPIO_ACTIVE_LOW>;
 		int-gpios = <&gpio9 11 GPIO_ACTIVE_HIGH>;
 		microchip,interface-type = "rmii";
 	};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -154,7 +154,7 @@ arduino_serial: &lpuart2 {
 		compatible = "microchip,ksz8081";
 		reg = <0>;
 		status = "okay";
-		reset-gpios = <&gpio12 12 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio12 12 GPIO_ACTIVE_LOW>;
 		int-gpios = <&gpio9 11 GPIO_ACTIVE_HIGH>;
 		microchip,interface-type = "rmii";
 	};

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga_rw612_ethernet.dts
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga_rw612_ethernet.dts
@@ -33,7 +33,7 @@
 		compatible = "microchip,ksz8081";
 		reg = <2>;
 		status = "okay";
-		reset-gpios = <&hsgpio1 23 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&hsgpio1 23 GPIO_ACTIVE_LOW>;
 		int-gpios = <&hsgpio0 21 GPIO_ACTIVE_HIGH>;
 		microchip,interface-type = "rmii";
 	};

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -60,6 +60,10 @@ Ethernet
   is needed. There you need to specify the fixed link parameters using the ``default-speeds``
   property (:github:`100454`).
 
+* The ``reset-gpios`` property of :dtcompatible:`microchip,ksz8081` has been
+  reworked to be used as active low, you may have to set the pin as
+  ``GPIO_ACTIVE_LOW`` in devicetree (:github:`100751`).
+
 MDIO
 ====
 


### PR DESCRIPTION
The reset pin, like most reset pins, is active low. Fix the driver to treat it as active low and simplify the pin control logic while at it. Fix all current boards using the wrong pin definition and add a note for out of tree users.

