### PR TITLE
drivers: disk: loopback: Remove unnecessary include

### DIFF
--- a/drivers/disk/loopback_disk.c
+++ b/drivers/disk/loopback_disk.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/unistd.h>
 #include <zephyr/drivers/disk.h>
 #include <zephyr/fs/fs.h>
 #include <zephyr/fs/fs_interface.h>


### PR DESCRIPTION
This file does not seem to need unistd.h, and that header is a POSIX extension to the C library which is not avaiable in general. So let's not include it.

Without this change this file fails to build with minimal libc or other C libraries which do not have this extra header, with an error like:
```
drivers/disk/loopback_disk.c:7:10: fatal error: sys/unistd.h: No such file or directory
    7 | #include <sys/unistd.h>
      |          ^~~~~~~~~~~~~~
```
Since 31169705162a0291f8eabbd820c1e380a4c80cfb