### PR TITLE
soc: st: stm32f0: SRAM vector table CMake Linker Generator compatibility

### DIFF
--- a/soc/st/stm32/stm32f0x/CMakeLists.txt
+++ b/soc/st/stm32/stm32f0x/CMakeLists.txt
@@ -1,11 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# The vector table must be placed at the start of SRAM
-zephyr_linker_sources_ifdef(CONFIG_SRAM_VECTOR_TABLE
-  RAM_SECTIONS
-  SORT_KEY 0
-  sram_vector_table.ld
-)
+if(CONFIG_SRAM_VECTOR_TABLE)
+  # The vector table must be placed at the start of SRAM.
+  # Reserve the first sizeof(<vector table>) bytes for this purpose.
+  if(CONFIG_CMAKE_LINKER_GENERATOR)
+    # We use MIN_SIZE to perform the equivalent of GNU ld `. += <XXX>;`
+    # but we have to compute the size of the vector table manually as
+    # it must be a bytes count (can't be `_vector_end - _vector_start`).
+    # Fortunately, the vector table size can be easily computed:
+    # 16 words for the architectural exceptions plus one word per IRQ
+    # (each word is 32 bits = 4 bytes).
+    math(EXPR vect_tbl_size "(16 + ${CONFIG_NUM_IRQS}) * 4")
+    zephyr_linker_section(NAME .st_stm32f0x_vt TYPE NOLOAD GROUP RAM_REGION ADDRESS 0x20000000 NOINPUT NOINIT)
+    zephyr_linker_section_configure(SECTION .st_stm32f0x_vt MIN_SIZE ${vect_tbl_size} SYMBOLS _ram_vector_start _ram_vector_end)
+  else()
+    zephyr_linker_sources(
+      RAM_SECTIONS
+      SORT_KEY 0
+      sram_vector_table.ld
+    )
+  endif()
+endif()
+
 zephyr_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_sources(soc.c)
 


### PR DESCRIPTION
Add required CMake directives to enable working CONFIG_SRAM_VECTOR_TABLE=y on STM32F0 series when CONFIG_CMAKE_LINKER_GENERATOR=y.

Builds OK with both ZEPHYR_TOOLCHAIN_VARIANT undefined (uses GNU toolchain from Zephyr SDK) and set to "iar" (uses IAR toochain from EWARM v9.70.1).