### PR TITLE
drivers: spi: siwx91x: Fix frequency > 40MHz

### DIFF
--- a/drivers/spi/spi_silabs_siwx91x_gspi.c
+++ b/drivers/spi/spi_silabs_siwx91x_gspi.c
@@ -25,7 +25,6 @@ LOG_MODULE_REGISTER(spi_siwx91x_gspi, CONFIG_SPI_LOG_LEVEL);
 #include "spi_context.h"
 
 #define GSPI_MAX_BAUDRATE_FOR_DYNAMIC_CLOCK   110000000
-#define GSPI_MAX_BAUDRATE_FOR_POS_EDGE_SAMPLE 40000000
 #define GSPI_DMA_MAX_DESCRIPTOR_TRANSFER_SIZE 4096
 #define SPI_HIGH_BURST_FREQ_THRESHOLD_HZ      10000000
 
@@ -155,11 +154,6 @@ static int gspi_siwx91x_config(const struct device *dev, const struct spi_config
 	if (clk_div_factor < 1) {
 		cfg->reg->GSPI_CLK_CONFIG_b.GSPI_CLK_EN = 1;
 		cfg->reg->GSPI_CLK_CONFIG_b.GSPI_CLK_SYNC = 1;
-	}
-
-	/* Configure data sampling edge for high-speed transfers */
-	if (spi_cfg->frequency > GSPI_MAX_BAUDRATE_FOR_POS_EDGE_SAMPLE) {
-		cfg->reg->GSPI_BUS_MODE_b.GSPI_DATA_SAMPLE_EDGE = 1;
 	}
 
 	/* Set the clock divider factor */

--- a/drivers/spi/spi_silabs_siwx91x_gspi.c
+++ b/drivers/spi/spi_silabs_siwx91x_gspi.c
@@ -105,7 +105,6 @@ static int gspi_siwx91x_config(const struct device *dev, const struct spi_config
 {
 	__maybe_unused struct gspi_siwx91x_data *data = dev->data;
 	const struct gspi_siwx91x_config *cfg = dev->config;
-	uint32_t bit_rate = spi_cfg->frequency;
 	uint32_t clk_div_factor;
 	uint32_t actual_freq;
 	uint32_t clock_rate;
@@ -137,7 +136,7 @@ static int gspi_siwx91x_config(const struct device *dev, const struct spi_config
 	}
 
 	/* Configure clock divider based on the requested bit rate */
-	if (bit_rate > GSPI_MAX_BAUDRATE_FOR_DYNAMIC_CLOCK) {
+	if (spi_cfg->frequency > GSPI_MAX_BAUDRATE_FOR_DYNAMIC_CLOCK) {
 		clk_div_factor = 1;
 	} else {
 		ret = clock_control_get_rate(cfg->clock_dev, cfg->clock_subsys, &clock_rate);
@@ -159,7 +158,7 @@ static int gspi_siwx91x_config(const struct device *dev, const struct spi_config
 	}
 
 	/* Configure data sampling edge for high-speed transfers */
-	if (bit_rate > GSPI_MAX_BAUDRATE_FOR_POS_EDGE_SAMPLE) {
+	if (spi_cfg->frequency > GSPI_MAX_BAUDRATE_FOR_POS_EDGE_SAMPLE) {
 		cfg->reg->GSPI_BUS_MODE_b.GSPI_DATA_SAMPLE_EDGE = 1;
 	}
 

--- a/drivers/spi/spi_silabs_siwx91x_gspi.c
+++ b/drivers/spi/spi_silabs_siwx91x_gspi.c
@@ -626,7 +626,7 @@ static int gspi_siwx91x_transceive(const struct device *dev, const struct spi_co
 				   spi_callback_t cb, void *userdata)
 {
 	struct gspi_siwx91x_data *data = dev->data;
-	int ret = 0;
+	int ret;
 
 	ret = pm_device_runtime_get(dev);
 	if (ret < 0) {
@@ -635,40 +635,38 @@ static int gspi_siwx91x_transceive(const struct device *dev, const struct spi_co
 
 	if (!spi_siwx91x_is_dma_enabled_instance(dev) && asynchronous) {
 		ret = -ENOTSUP;
-		pm_device_runtime_put(dev);
-		return ret;
+		goto pm;
 	}
 
 	spi_context_lock(&data->ctx, asynchronous, cb, userdata, config);
-	/* Configure the device if it is not already configured */
 	if (!spi_context_configured(&data->ctx, config)) {
 		ret = gspi_siwx91x_config(dev, config, cb, userdata);
 		if (ret) {
-			spi_context_release(&data->ctx, ret);
-			pm_device_runtime_put(dev);
-			return ret;
+			goto context;
 		}
 	}
 
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs,
 				  SPI_WORD_SIZE_GET(config->operation) / 8);
 
-	/* Check if DMA is enabled */
 	if (spi_siwx91x_is_dma_enabled_instance(dev)) {
-		/* Perform DMA transceive */
 		ret = gspi_siwx91x_transceive_dma(dev, config);
-		if (ret < 0) {
-			pm_device_runtime_put(dev);
-		}
-		spi_context_release(&data->ctx, ret);
 	} else {
-		/* Perform synchronous polling transceive */
 		ret = gspi_siwx91x_transceive_polling_sync(dev, &data->ctx);
-		spi_context_unlock_unconditionally(&data->ctx);
-		pm_device_runtime_put(dev);
 	}
 
+	if (spi_siwx91x_is_dma_enabled_instance(dev) && !ret) {
+		/* pm_device_runtime_put(dev) is called from the dma callback */
+		spi_context_release(&data->ctx, ret);
+		return ret;
+	}
+
+context:
+	spi_context_release(&data->ctx, ret);
+pm:
+	pm_device_runtime_put(dev);
 	return ret;
+
 }
 
 static int gspi_siwx91x_transceive_sync(const struct device *dev, const struct spi_config *config,

--- a/drivers/spi/spi_silabs_siwx91x_gspi.c
+++ b/drivers/spi/spi_silabs_siwx91x_gspi.c
@@ -151,11 +151,6 @@ static int gspi_siwx91x_config(const struct device *dev, const struct spi_config
 		}
 	}
 
-	if (clk_div_factor < 1) {
-		cfg->reg->GSPI_CLK_CONFIG_b.GSPI_CLK_EN = 1;
-		cfg->reg->GSPI_CLK_CONFIG_b.GSPI_CLK_SYNC = 1;
-	}
-
 	/* Set the clock divider factor */
 	cfg->reg->GSPI_CLK_DIV = clk_div_factor;
 


### PR DESCRIPTION
tests/drivers/spi/spi_loopback reported Rx errors on the last bit when requested frequency was > 40MHz. This was mainly caused by misuse of `GSPI_DATA_SAMPLE_EDGE`.

This PR take advantage of this change to slightly clean up the SPI driver.

I have successfully tested with code at 40Mhz and 80Mhz.