### PR TITLE
MAINTAINERS: add laurenmurphyx64 as LLEXT collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3147,6 +3147,7 @@ Kernel:
   collaborators:
     - lyakh
     - pillo79
+    - laurenmurphyx64
   files:
     - cmake/llext-edk.cmake
     - samples/subsys/llext/


### PR DESCRIPTION
Adds me as a LLEXT collaborator since I added preliminary x86 / ARC and plan to continue contributing to LLEXT.

Just a suggestion by @teburd, let me know what y'all think. 