### PR TITLE
MAINTAINERS: add TF-M PSA Settings backend collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4748,6 +4748,16 @@ Settings:
     - samples/subsys/settings/
     - doc/services/storage/settings/
     - tests/subsys/settings_commit_prio/
+  file-groups:
+    - name: TF-M PSA backend
+      collaborators:
+        - dsseng
+        - seankyer
+        - tomi-font
+      files:
+        - subsys/settings/src/settings_tfm_psa*
+        - tests/subsys/settings/functional/tfm_psa/
+        - tests/subsys/settings/tfm_psa/
   labels:
     - "area: Settings"
   tests:


### PR DESCRIPTION
Add myself alongside @seankyer and @tomi-font as the engineers
involved in development of this backend.

Suggested here: https://github.com/zephyrproject-rtos/zephyr/pull/94947#pullrequestreview-3557435480

Requires #94947 (filenames according to that state)
