### PR TITLE
drivers: flash: esp32: only link APIs when compiled in

### DIFF
--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -760,7 +760,7 @@ static DEVICE_API(flash, flash_esp32_driver_api) = {
 	.read = flash_esp32_read_async,
 	.write = flash_esp32_write_async,
 	.erase = flash_esp32_erase_async,
-#else
+#elif CONFIG_ESP_FLASH_HOST
 	.read = flash_esp32_read,
 	.write = flash_esp32_write,
 	.erase = flash_esp32_erase,


### PR DESCRIPTION
Heya, this was broken in the weekly, tested with

`west build -p -b esp32_devkitc/esp32/appcpu tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported`

--

The flash_esp32_read, flash_esp32_write and flash_esp32_erase are only implemented if CONFIG_ESP_FLASH_HOST is defined, do not try to reference them when they are not compiled in.