### PR TITLE
drivers: i2c: Fix default setting for I2C dump allowlist

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -47,6 +47,7 @@ config I2C_DUMP_MESSAGES_ALLOWLIST
 	bool "Use allowlist for logging of I2C transactions"
 	depends on I2C_DUMP_MESSAGES
 	depends on DT_HAS_ZEPHYR_I2C_DUMP_ALLOWLIST_ENABLED
+	default y
 	help
 	  Use allowlist to specify which devices transactions should be logged.
 	  The allowlist is defined in the devicetree using the compatible string of


### PR DESCRIPTION
The option CONFIG_I2C_DUMP_MESSAGES_ALLOWLIST should automatically be turned on if the depedencies are satisfied.