### PR TITLE
tests: assert_custom_header: only build on some platforms

### DIFF
--- a/tests/subsys/debug/assert_custom_header/testcase.yaml
+++ b/tests/subsys/debug/assert_custom_header/testcase.yaml
@@ -1,6 +1,11 @@
 common:
   integration_platforms:
     - native_sim
+  platform_allow:
+    - native_sim
+    - native_sim/native/64
+    - qemu_x86
+    - qemu_cortex_m3
 
 tests:
   debug.assert_custom_header:


### PR DESCRIPTION
Breaks in weekly, example ` west build -p -b thingy53/nrf5340/cpuapp/ns tests/subsys/debug/assert_custom_header`

---


This test does not build correctly on some modules, namely TFM, just run
it on a few platform, that should be enough to validate that the feature
is working correctly.


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/100733