### PR TITLE
net: l2: Add new stats API

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -130,6 +130,13 @@ New APIs and options
     * :c:struct:`net_eth_mac_config`
     * :c:macro:`NET_ETH_MAC_DT_CONFIG_INIT` and :c:macro:`NET_ETH_MAC_DT_INST_CONFIG_INIT`
 
+  * Added :c:enum:`ethernet_stats_type` and optional ``get_stats_type`` callback in
+    :c:struct:`ethernet_api` to allow filtering of ethernet statistics by type
+    (common, vendor, or all). Drivers that support vendor-specific statistics can
+    implement ``get_stats_type`` to skip expensive FW queries when only common stats
+    are requested. The existing ``get_stats`` API remains unchanged for backward
+    compatibility.
+
 * Flash
 
   * :dtcompatible:`jedec,mspi-nor` now allows MSPI configuration of read, write and

--- a/drivers/wifi/nrf_wifi/inc/net_if.h
+++ b/drivers/wifi/nrf_wifi/inc/net_if.h
@@ -56,7 +56,10 @@ enum nrf_wifi_status nrf_wifi_if_carr_state_chg(void *os_vif_ctx,
 int nrf_wifi_stats_get(const struct device *dev,
 		       struct net_stats_wifi *stats);
 
-struct net_stats_eth *nrf_wifi_eth_stats_get(const struct device *dev);
+#ifdef CONFIG_NET_STATISTICS_ETHERNET
+struct net_stats_eth *nrf_wifi_eth_stats_get_type(const struct device *dev,
+						   uint32_t type);
+#endif /* CONFIG_NET_STATISTICS_ETHERNET */
 
 void nrf_wifi_set_iface_event_handler(void *os_vif_ctx,
 						struct nrf_wifi_umac_event_set_interface *event,

--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -978,7 +978,7 @@ static const struct net_wifi_mgmt_offload wifi_offload_ops = {
 	.wifi_iface.get_capabilities = nrf_wifi_if_caps_get,
 	.wifi_iface.send = nrf_wifi_if_send,
 #ifdef CONFIG_NET_STATISTICS_ETHERNET
-	.wifi_iface.get_stats = nrf_wifi_eth_stats_get,
+	.wifi_iface.get_stats_type = nrf_wifi_eth_stats_get_type,
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
 #ifdef CONFIG_NET_L2_WIFI_MGMT
 	.wifi_mgmt_api = &nrf_wifi_mgmt_ops,

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -529,6 +529,16 @@ struct ethernet_config {
 
 /** @endcond */
 
+/** Ethernet statistics type (bitmap) */
+enum ethernet_stats_type {
+	/** Common statistics only (excludes vendor statistics) */
+	ETHERNET_STATS_TYPE_COMMON = BIT(0),
+	/** Vendor statistics only */
+	ETHERNET_STATS_TYPE_VENDOR = BIT(1),
+	/** All statistics */
+	ETHERNET_STATS_TYPE_ALL = 0xFFFFFFFFU,
+};
+
 /** Ethernet L2 API operations. */
 struct ethernet_api {
 	/**
@@ -543,6 +553,14 @@ struct ethernet_api {
 	 */
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	struct net_stats_eth *(*get_stats)(const struct device *dev);
+
+	/** Optional function to collect ethernet specific statistics with
+	 * type filter. If NULL, get_stats() will be called instead, which
+	 * is equivalent to calling this with ETHERNET_STATS_TYPE_ALL.
+	 * @param type Bitmask of ethernet_stats_type values.
+	 */
+	struct net_stats_eth *(*get_stats_type)(const struct device *dev,
+						 uint32_t type);
 #endif
 
 	/** Start the device */

--- a/subsys/net/l2/ethernet/eth_stats.h
+++ b/subsys/net/l2/ethernet/eth_stats.h
@@ -14,211 +14,123 @@
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/ethernet.h>
 
-static inline void eth_stats_update_bytes_rx(struct net_if *iface,
-					     uint32_t bytes)
+static inline struct net_stats_eth *eth_stats_get_common(struct net_if *iface)
 {
 	const struct ethernet_api *api = (const struct ethernet_api *)
 		net_if_get_device(iface)->api;
-	struct net_stats_eth *stats;
 
-	if (!api->get_stats) {
-		return;
+	if (api->get_stats_type != NULL) {
+		return api->get_stats_type(net_if_get_device(iface),
+					   ETHERNET_STATS_TYPE_COMMON);
+	} else if (api->get_stats != NULL) {
+		return api->get_stats(net_if_get_device(iface));
 	}
 
-	stats = api->get_stats(net_if_get_device(iface));
-	if (!stats) {
-		return;
-	}
-
-	stats->bytes.received += bytes;
+	return NULL;
 }
 
-static inline void eth_stats_update_bytes_tx(struct net_if *iface,
-					     uint32_t bytes)
+static inline void eth_stats_update_bytes_rx(struct net_if *iface, uint32_t bytes)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
-		net_if_get_device(iface)->api;
-	struct net_stats_eth *stats;
+	struct net_stats_eth *stats = eth_stats_get_common(iface);
 
-	if (!api->get_stats) {
-		return;
+	if (stats != NULL) {
+		stats->bytes.received += bytes;
 	}
+}
 
-	stats = api->get_stats(net_if_get_device(iface));
-	if (!stats) {
-		return;
+static inline void eth_stats_update_bytes_tx(struct net_if *iface, uint32_t bytes)
+{
+	struct net_stats_eth *stats = eth_stats_get_common(iface);
+
+	if (stats != NULL) {
+		stats->bytes.sent += bytes;
 	}
-
-	stats->bytes.sent += bytes;
 }
 
 static inline void eth_stats_update_pkts_rx(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
-		net_if_get_device(iface)->api;
-	struct net_stats_eth *stats;
+	struct net_stats_eth *stats = eth_stats_get_common(iface);
 
-	if (!api->get_stats) {
-		return;
+	if (stats != NULL) {
+		stats->pkts.rx++;
 	}
-
-	stats = api->get_stats(net_if_get_device(iface));
-	if (!stats) {
-		return;
-	}
-
-	stats->pkts.rx++;
 }
 
 static inline void eth_stats_update_pkts_tx(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
-		net_if_get_device(iface)->api;
-	struct net_stats_eth *stats;
+	struct net_stats_eth *stats = eth_stats_get_common(iface);
 
-	if (!api->get_stats) {
-		return;
+	if (stats != NULL) {
+		stats->pkts.tx++;
 	}
-
-	stats = api->get_stats(net_if_get_device(iface));
-	if (!stats) {
-		return;
-	}
-
-	stats->pkts.tx++;
 }
 
 static inline void eth_stats_update_broadcast_rx(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
-		net_if_get_device(iface)->api;
-	struct net_stats_eth *stats;
+	struct net_stats_eth *stats = eth_stats_get_common(iface);
 
-	if (!api->get_stats) {
-		return;
+	if (stats != NULL) {
+		stats->broadcast.rx++;
 	}
-
-	stats = api->get_stats(net_if_get_device(iface));
-	if (!stats) {
-		return;
-	}
-
-	stats->broadcast.rx++;
 }
 
 static inline void eth_stats_update_broadcast_tx(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
-		net_if_get_device(iface)->api;
-	struct net_stats_eth *stats;
+	struct net_stats_eth *stats = eth_stats_get_common(iface);
 
-	if (!api->get_stats) {
-		return;
+	if (stats != NULL) {
+		stats->broadcast.tx++;
 	}
-
-	stats = api->get_stats(net_if_get_device(iface));
-	if (!stats) {
-		return;
-	}
-
-	stats->broadcast.tx++;
 }
 
 static inline void eth_stats_update_multicast_rx(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
-		net_if_get_device(iface)->api;
-	struct net_stats_eth *stats;
+	struct net_stats_eth *stats = eth_stats_get_common(iface);
 
-	if (!api->get_stats) {
-		return;
+	if (stats != NULL) {
+		stats->multicast.rx++;
 	}
-
-	stats = api->get_stats(net_if_get_device(iface));
-	if (!stats) {
-		return;
-	}
-
-	stats->multicast.rx++;
 }
 
 static inline void eth_stats_update_multicast_tx(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
-		net_if_get_device(iface)->api;
-	struct net_stats_eth *stats;
+	struct net_stats_eth *stats = eth_stats_get_common(iface);
 
-	if (!api->get_stats) {
-		return;
+	if (stats != NULL) {
+		stats->multicast.tx++;
 	}
-
-	stats = api->get_stats(net_if_get_device(iface));
-	if (!stats) {
-		return;
-	}
-
-	stats->multicast.tx++;
 }
-
 
 static inline void eth_stats_update_errors_rx(struct net_if *iface)
 {
 	struct net_stats_eth *stats;
-	const struct ethernet_api *api;
 
 	if (!iface) {
 		return;
 	}
 
-	api = ((const struct ethernet_api *)
-	       net_if_get_device(iface)->api);
-
-	if (!api->get_stats) {
-		return;
+	stats = eth_stats_get_common(iface);
+	if (stats != NULL) {
+		stats->errors.rx++;
 	}
-
-	stats = api->get_stats(net_if_get_device(iface));
-	if (!stats) {
-		return;
-	}
-
-	stats->errors.rx++;
 }
 
 static inline void eth_stats_update_errors_tx(struct net_if *iface)
 {
-	struct net_stats_eth *stats;
-	const struct ethernet_api *api = ((const struct ethernet_api *)
-		net_if_get_device(iface)->api);
+	struct net_stats_eth *stats = eth_stats_get_common(iface);
 
-	if (!api->get_stats) {
-		return;
+	if (stats != NULL) {
+		stats->errors.tx++;
 	}
-
-	stats = api->get_stats(net_if_get_device(iface));
-	if (!stats) {
-		return;
-	}
-
-	stats->errors.tx++;
 }
 
 static inline void eth_stats_update_unknown_protocol(struct net_if *iface)
 {
-	struct net_stats_eth *stats;
-	const struct ethernet_api *api = ((const struct ethernet_api *)
-		net_if_get_device(iface)->api);
+	struct net_stats_eth *stats = eth_stats_get_common(iface);
 
-	if (!api->get_stats) {
-		return;
+	if (stats != NULL) {
+		stats->unknown_protocol++;
 	}
-
-	stats = api->get_stats(net_if_get_device(iface));
-	if (!stats) {
-		return;
-	}
-
-	stats->unknown_protocol++;
 }
 
 #else /* CONFIG_NET_STATISTICS_ETHERNET */

--- a/subsys/net/l2/ethernet/ethernet_stats.c
+++ b/subsys/net/l2/ethernet/ethernet_stats.c
@@ -31,12 +31,18 @@ static int eth_stats_get(uint64_t mgmt_request, struct net_if *iface,
 		}
 
 		eth = net_if_get_device(iface)->api;
-		if (eth == NULL || eth->get_stats == NULL) {
+		if (eth == NULL ||
+		    (eth->get_stats == NULL && eth->get_stats_type == NULL)) {
 			return -ENOENT;
 		}
 
 		len_chk = sizeof(struct net_stats_eth);
-		src = eth->get_stats(net_if_get_device(iface));
+		if (eth->get_stats_type != NULL) {
+			src = eth->get_stats_type(net_if_get_device(iface),
+						  ETHERNET_STATS_TYPE_ALL);
+		} else {
+			src = eth->get_stats(net_if_get_device(iface));
+		}
 		break;
 	}
 

--- a/tests/drivers/wifi/nrf_wifi/testcase.yaml
+++ b/tests/drivers/wifi/nrf_wifi/testcase.yaml
@@ -44,3 +44,7 @@ tests:
     extra_configs:
       - CONFIG_NET_PKT_BUF_TX_DATA_ALLOC_ALIGN_LEN=4
       - CONFIG_NET_BUF_VARIABLE_DATA_SIZE=y
+  drivers.wifi.build.ethernet_stats:
+    extra_configs:
+      - CONFIG_NET_STATISTICS_ETHERNET=y
+      - CONFIG_NET_STATISTICS_ETHERNET_VENDOR=y


### PR DESCRIPTION
This new API takes a category as input primarily to bypass vendor stats query (to avoid FW interactions) as this is called per-packet by the networking stack.