### PR TITLE
update SPSDK runner for i.MX 95 b0 silicon

### DIFF
--- a/boards/nxp/imx95_evk/CMakeLists.txt
+++ b/boards/nxp/imx95_evk/CMakeLists.txt
@@ -3,7 +3,7 @@
 if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
   AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
   find_program(7Z_EXECUTABLE 7z REQUIRED)
-  set(FIRMWARE_RELEASE "imx95-19x19-lpddr5-evk-boot-firmware-0.1")
+  set(FIRMWARE_RELEASE "imx95-evk-boot-firmware-6.12.34-2.1.0")
   # Parse SPSDK version
   execute_process(
     COMMAND spsdk --version
@@ -19,21 +19,20 @@ if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
     file(WRITE ${CMAKE_BINARY_DIR}/zephyr/${AHAB_CONFIG_FILE}
       "
       family: mimx9596
-      revision: a1
+      revision: b0
       target_memory: standard
       output:                   ${CMAKE_BINARY_DIR}/zephyr/flash.bin
       containers:
         - binary_container:
-            path:               ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/mx95a0-ahab-container.img
+            path:               ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/mx95b0-ahab-container.img
         - container:
             srk_set: none
             images:
-              - lpddr_imem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_imem_v202311.bin
-                lpddr_imem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_imem_qb_v202311.bin
-                lpddr_dmem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_dmem_v202311.bin
-                lpddr_dmem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_dmem_qb_v202311.bin
-                oei_ddr:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-ddr.bin
-              - oei_tcm:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-tcm.bin
+              - lpddr_imem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_imem_v202409.bin
+                lpddr_imem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_imem_qb_v202409.bin
+                lpddr_dmem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_dmem_v202409.bin
+                lpddr_dmem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_dmem_qb_v202409.bin
+                oei_ddr:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-ddr-lpddr5.bin
               - system_manager: ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/m33_image-mx95alt.bin
               - cortex_m7_app:  ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
               - v2x_dummy: true
@@ -47,21 +46,20 @@ if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
     file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_mimx9596_a55_ahab_primary.yaml
       "
       family: mimx9596
-      revision: a1
+      revision: b0
       target_memory: standard
       output:                   ${CMAKE_BINARY_DIR}/zephyr/primary_ahab.bin
       containers:
         - binary_container:
-            path:               ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/mx95a0-ahab-container.img
+            path:               ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/mx95b0-ahab-container.img
         - container:
             srk_set: none
             images:
-              - lpddr_imem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_imem_v202311.bin
-                lpddr_imem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_imem_qb_v202311.bin
-                lpddr_dmem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_dmem_v202311.bin
-                lpddr_dmem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_dmem_qb_v202311.bin
-                oei_ddr:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-ddr.bin
-              - oei_tcm:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-tcm.bin
+              - lpddr_imem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_imem_v202409.bin
+                lpddr_imem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_imem_qb_v202409.bin
+                lpddr_dmem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_dmem_v202409.bin
+                lpddr_dmem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr5_dmem_qb_v202409.bin
+                oei_ddr:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-ddr-lpddr5.bin
               - system_manager: ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/m33_image-mx95evk.bin
               - spl:            ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/u-boot-spl.bin-imx95-19x19-lpddr5-evk-sd
               - v2x_dummy: true
@@ -69,7 +67,7 @@ if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
     file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_mimx9596_a55_ahab_secondary.yaml
       "
       family: mimx9596
-      revision: a1
+      revision: b0
       target_memory: standard
       output:                   ${CMAKE_BINARY_DIR}/zephyr/secondary_ahab.bin
       containers:

--- a/boards/nxp/imx95_evk/board.cmake
+++ b/boards/nxp/imx95_evk/board.cmake
@@ -5,7 +5,7 @@ if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
   board_set_flasher_ifnset(spsdk)
 
   board_runner_args(spsdk "--family=mimx9596")
-  board_runner_args(spsdk "--bootloader=${CMAKE_BINARY_DIR}/zephyr/imx95-19x19-lpddr5-evk-boot-firmware-0.1/imx-boot-imx95-19x19-lpddr5-evk-sd.bin-flash_all")
+  board_runner_args(spsdk "--bootloader=${CMAKE_BINARY_DIR}/zephyr/imx95-evk-boot-firmware-6.12.34-2.1.0/imx-boot-imx95-19x19-lpddr5-evk-sd.bin-flash_all")
   board_runner_args(spsdk "--flashbin=${CMAKE_BINARY_DIR}/zephyr/flash.bin")
   if(CONFIG_CPU_CORTEX_A55)
     board_runner_args(spsdk "--containers=two")

--- a/boards/nxp/imx95_evk_15x15/CMakeLists.txt
+++ b/boards/nxp/imx95_evk_15x15/CMakeLists.txt
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
+  AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
+  find_program(7Z_EXECUTABLE 7z REQUIRED)
+  set(FIRMWARE_RELEASE "imx95-evk-boot-firmware-6.12.34-2.1.0")
+  # Parse SPSDK version
+  execute_process(
+    COMMAND spsdk --version
+    OUTPUT_VARIABLE SPSDK_VERSION_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" SPSDK_VERSION "${SPSDK_VERSION_OUTPUT}")
+  message(STATUS "SPSDK version is ${SPSDK_VERSION}")
+
+  if(CONFIG_BOARD_IMX95_EVK_15X15_MIMX9596_M7)
+    set(AHAB_CONFIG_FILE "imx95_evk_15x15_mimx9596_m7_ahab.yaml")
+
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/${AHAB_CONFIG_FILE}
+      "
+      family: mimx9596
+      revision: b0
+      target_memory: standard
+      output:                   ${CMAKE_BINARY_DIR}/zephyr/flash.bin
+      containers:
+        - binary_container:
+            path:               ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/mx95b0-ahab-container.img
+        - container:
+            srk_set: none
+            images:
+              - lpddr_imem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4x_imem_v202409.bin
+                lpddr_imem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4x_imem_qb_v202409.bin
+                lpddr_dmem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4x_dmem_v202409.bin
+                lpddr_dmem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4x_dmem_qb_v202409.bin
+                oei_ddr:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-ddr-lpddr4x.bin
+              - system_manager: ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/m33_image-mx95alt.bin
+              - cortex_m7_app:  ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
+              - v2x_dummy: true
+      ")
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND ${7Z_EXECUTABLE} x ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin -o./imx-boot-firmware -aos -bso0 -bse1
+      COMMAND ${7Z_EXECUTABLE} x imx-boot-firmware/${FIRMWARE_RELEASE} -aos -bso0 -bse1
+      COMMAND nxpimage ahab export -c ${CMAKE_BINARY_DIR}/zephyr/${AHAB_CONFIG_FILE}
+    )
+  elseif(CONFIG_SOC_MIMX9596_A55)
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_15x15_mimx9596_a55_ahab_primary.yaml
+      "
+      family: mimx9596
+      revision: b0
+      target_memory: standard
+      output:                   ${CMAKE_BINARY_DIR}/zephyr/primary_ahab.bin
+      containers:
+        - binary_container:
+            path:               ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/mx95b0-ahab-container.img
+        - container:
+            srk_set: none
+            images:
+              - lpddr_imem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4x_imem_v202409.bin
+                lpddr_imem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4x_imem_qb_v202409.bin
+                lpddr_dmem:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4x_dmem_v202409.bin
+                lpddr_dmem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4x_dmem_qb_v202409.bin
+                oei_ddr:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-ddr-lpddr4x.bin
+              - system_manager: ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/m33_image-mx95evk.bin
+              - spl:            ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/u-boot-spl.bin-imx95-15x15-lpddr4x-evk-sd
+              - v2x_dummy: true
+    ")
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_15x15_mimx9596_a55_ahab_secondary.yaml
+      "
+      family: mimx9596
+      revision: b0
+      target_memory: standard
+      output:                   ${CMAKE_BINARY_DIR}/zephyr/secondary_ahab.bin
+      containers:
+        - container:
+            srk_set: none
+            images:
+              - atf:            ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/bl31-imx95-zephyr.bin
+              - image_path:     ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
+                load_address:   '${CONFIG_SRAM_BASE_ADDRESS}'
+                entry_point:    '${CONFIG_SRAM_BASE_ADDRESS}'
+                image_type:     executable
+                core_id:        cortex-a55
+                is_encrypted:   false
+    ")
+    file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_15x15_mimx9596_a55_ahab_flash_template.yaml
+      "
+      family: mimx9596
+      revision: latest
+      memory_type: serial_downloader
+      primary_image_container_set: ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_15x15_mimx9596_a55_ahab_primary.yaml
+      secondary_image_container_set: ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_15x15_mimx9596_a55_ahab_secondary.yaml
+   ")
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND ${7Z_EXECUTABLE} x ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin -o./imx-boot-firmware -aos -bso0 -bse1
+      COMMAND ${7Z_EXECUTABLE} x imx-boot-firmware/${FIRMWARE_RELEASE} -aos -bso0 -bse1
+    )
+    if(SPSDK_VERSION VERSION_GREATER_EQUAL "3.0.0")
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+        COMMAND nxpimage bootable-image export -c ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_15x15_mimx9596_a55_ahab_flash_template.yaml -o flash.bin
+      )
+    else()
+      set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+        COMMAND nxpimage bootable-image merge -c ${CMAKE_BINARY_DIR}/zephyr/imx95_evk_15x15_mimx9596_a55_ahab_flash_template.yaml -o flash.bin
+      )
+    endif()
+  else()
+    message(FATAL_ERROR "SPSDK Image not supported on the platform!")
+  endif()
+  zephyr_blobs_verify(FILES
+    ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin
+    REQUIRED)
+endif()

--- a/boards/nxp/imx95_evk_15x15/Kconfig
+++ b/boards/nxp/imx95_evk_15x15/Kconfig
@@ -1,0 +1,4 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+source "boards/nxp/common/Kconfig"

--- a/boards/nxp/imx95_evk_15x15/board.cmake
+++ b/boards/nxp/imx95_evk_15x15/board.cmake
@@ -1,5 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
+  AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
+  board_set_flasher_ifnset(spsdk)
+
+  board_runner_args(spsdk "--family=mimx9596")
+  board_runner_args(spsdk "--bootloader=${CMAKE_BINARY_DIR}/zephyr/imx95-evk-boot-firmware-6.12.34-2.1.0/imx-boot-imx95-15x15-lpddr4x-evk-sd.bin-flash_all")
+  board_runner_args(spsdk "--flashbin=${CMAKE_BINARY_DIR}/zephyr/flash.bin")
+  if(CONFIG_CPU_CORTEX_A55)
+    board_runner_args(spsdk "--containers=two")
+  else()
+    board_runner_args(spsdk "--containers=one")
+  endif()
+
+  include(${ZEPHYR_BASE}/boards/common/spsdk.board.cmake)
+endif()
+
 if(CONFIG_SOC_MIMX9596_A55)
   board_runner_args(jlink "--device=MIMX9596_A55_0" "--no-reset" "--flash-sram")
   include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 92cc3398bc562809ce3325a260751b5f855bd8ee
+      revision: d12ee715e5f7297806b9c3289e1343899b93750f
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
1) updated for b0 silicon
2) added spsdk runner support on imx95_evk_15x15

Depend on https://github.com/zephyrproject-rtos/hal_nxp/pull/643 to update boot firmware blob.