### PR TITLE
soc: renesas: rzv: Retrieve itcm, dtcm from dtsi for mpu settings

### DIFF
--- a/soc/renesas/rz/rzv2h/cr8/arm_mpu_regions.c
+++ b/soc/renesas/rz/rzv2h/cr8/arm_mpu_regions.c
@@ -13,21 +13,25 @@ extern const uint32_t __rom_region_mpu_size_bits;
 static const struct arm_mpu_region mpu_regions[] = {
 
 	/* clang-format off */
+#if DT_NODE_EXISTS(DT_NODELABEL(itcm))
 	/* Vectors is relocated to ITCM region */
 	MPU_REGION_ENTRY(
 		"itcm",
-		0x00000000,
-		REGION_128K,
+		DT_REG_ADDR(DT_NODELABEL(itcm)),
+		REGION_CUSTOMED_MEMORY_SIZE(DT_REG_SIZE(DT_NODELABEL(itcm)) / 1024),
 		{.rasr = P_RO_U_NA_Msk |
 			 NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE}),
+#endif
 
+#if DT_NODE_EXISTS(DT_NODELABEL(dtcm))
 	MPU_REGION_ENTRY(
 		"dtcm",
-		0x00020000,
-		REGION_128K,
+		DT_REG_ADDR(DT_NODELABEL(dtcm)),
+		REGION_CUSTOMED_MEMORY_SIZE(DT_REG_SIZE(DT_NODELABEL(dtcm)) / 1024),
 		{.rasr = P_RW_U_RW_Msk |
 			 NORMAL_OUTER_INNER_NON_CACHEABLE_NON_SHAREABLE |
 			 NOT_EXEC}),
+#endif
 
 	/* Basic SRAM mapping is all data, R/W + XN */
 	MPU_REGION_ENTRY(


### PR DESCRIPTION
Retrieve itcm and dtcm size and base address from dtsi for mpu settings instead of hardcode.