### PR TITLE
tests: subsys: secure_storage: psa: its: Exclude any nrf54h20 target

### DIFF
--- a/tests/subsys/secure_storage/psa/its/testcase.yaml
+++ b/tests/subsys/secure_storage/psa/its/testcase.yaml
@@ -6,6 +6,10 @@ common:
     - qemu_cortex_m0 # settings subsystem initialization fails
     - nrf54h20dk/nrf54h20/cpuapp
     - nrf54h20dk/nrf54h20/cpurad
+    - nrf54h20dk/nrf54h20/cpuppr
+    - nrf54h20dk/nrf54h20/cpuppr/xip
+    - nrf54h20dk/nrf54h20/cpuflpr
+    - nrf54h20dk/nrf54h20/cpuflpr/xip
   timeout: 600
   tags:
     - psa.secure_storage


### PR DESCRIPTION
6cc7bdb58a excluded cpuapp and cpurad targets but any nrf54h20dk target should be included. cpuppr and cpuflpr do not compile after 3ea2951bc01c.

CI is red due to that: https://github.com/zephyrproject-rtos/zephyr/actions/runs/20026231653/job/57424541403?pr=100505

Fixes: #100781