### PR TITLE
samples: boards: nordic: coresight_stm: Benchmark only the cached code

### DIFF
--- a/samples/boards/nordic/coresight_stm/src/main.c
+++ b/samples/boards/nordic/coresight_stm/src/main.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(app);
 #define TEST_LOG(rpt, item)                                                                        \
 	({                                                                                         \
 		uint32_t key = irq_lock();                                                         \
+		__DEBRACKET item;                                                                  \
 		uint32_t t = k_cycle_get_32();                                                     \
 		for (uint32_t i = 0; i < rpt; i++) {                                               \
 			__DEBRACKET item;                                                          \


### PR DESCRIPTION
Add additional call before starting time measurement to ensure that all calls that are benchmarked are already cached. This change allows to get more stable results as all exectutions are from cache.