### PR TITLE
posix: add Coverity note for unreachable code in mutex

### DIFF
--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -196,10 +196,10 @@ static void gop_eagain_retry(int cmd, struct gnttab_map_grant_ref *gref)
 
 void *gnttab_get_pages(unsigned int npages)
 {
-	int ret;
+	int ret = 0;
 	void *page_addr;
 	unsigned int removed;
-	xen_pfn_t gfn;
+	xen_pfn_t gfn = 0;
 
 	if (npages == 0) {
 		return NULL;

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -113,12 +113,15 @@
 /*let's not segfault if this were to happen for some reason*/
 #define CODE_UNREACHABLE \
 {\
+	/* [coverity : unreachable] */\
 	posix_print_error_and_exit("CODE_UNREACHABLE reached from %s:%d\n",\
 		__FILE__, __LINE__);\
 	__builtin_unreachable(); \
 }
 #else
-#define CODE_UNREACHABLE __builtin_unreachable()
+#define CODE_UNREACHABLE \
+	/* [coverity : unreachable] */ \
+	__builtin_unreachable()
 #endif
 #define FUNC_NORETURN    __attribute__((__noreturn__))
 

--- a/include/zephyr/toolchain/iar/iccarm.h
+++ b/include/zephyr/toolchain/iar/iccarm.h
@@ -82,8 +82,10 @@
 #define FUNC_ALIAS(real_func, new_alias, return_type) \
 	return_type new_alias() ALIAS_OF(real_func)
 
-#define CODE_UNREACHABLE __builtin_unreachable()
-#define FUNC_NORETURN    __attribute__((__noreturn__))
+#define CODE_UNREACHABLE \
+	/* [coverity : unreachable] */ \
+	__builtin_unreachable()
+#define FUNC_NORETURN __attribute__((__noreturn__))
 
 #define _NODATA_SECTION(segment)  __attribute__((section(#segment)))
 

--- a/lib/posix/options/mutex.c
+++ b/lib/posix/options/mutex.c
@@ -148,6 +148,7 @@ static int acquire_mutex(pthread_mutex_t *mu, k_timeout_t timeout)
 			do {
 				(void)k_sleep(K_FOREVER);
 			} while (true);
+			/* [coverity : unreachable] */
 			CODE_UNREACHABLE;
 			break;
 		case PTHREAD_MUTEX_RECURSIVE:


### PR DESCRIPTION
Coverity flags the non-recursive mutex relock path as unreachable due to the intentional infinite loop matching POSIX behaviour. Add a brief annotation to clarify this and avoid false positives.
