### PR TITLE
drivers: ethernet: lan865x: fix seed for random backoff

### DIFF
--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -233,6 +233,9 @@ static void lan865x_write_macaddress(const struct device *dev)
 	 */
 	val = (mac[5] << 24) | (mac[4] << 16) | (mac[3] << 8) | mac[2];
 	oa_tc6_reg_write(ctx->tc6, LAN865x_MAC_SAB1, val);
+	/* SPEC_ADD1_TOP - write top register too for activation */
+	val = mac[1] << 8 | mac[0];
+	oa_tc6_reg_write(ctx->tc6, LAN865x_MAC_SAT1, val);
 }
 
 static int lan865x_set_specific_multicast_addr(const struct device *dev)

--- a/drivers/ethernet/eth_lan865x_priv.h
+++ b/drivers/ethernet/eth_lan865x_priv.h
@@ -32,6 +32,7 @@
 #define LAN865x_MAC_HRB          MMS_REG(0x1, 0x020)
 #define LAN865x_MAC_HRT          MMS_REG(0x1, 0x021)
 #define LAN865x_MAC_SAB1         MMS_REG(0x1, 0x022)
+#define LAN865x_MAC_SAT1         MMS_REG(0x1, 0x023)
 #define LAN865x_MAC_SAB2         MMS_REG(0x1, 0x024)
 #define LAN865x_MAC_SAT2         MMS_REG(0x1, 0x025)
 /* LAN8650/1 configuration fixup from AN1760 */


### PR DESCRIPTION
To activate changes in mac address registers
the top register has to be written