### PR TITLE
[Backport v3.7-branch] stm32: usb: fix OTGHS on STM32F723/F730 (embedded USBPHYC)

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -282,6 +282,12 @@ static int usb_dc_stm32_clock_enable(void)
 #endif
 
 #if USB_OTG_HS_EMB_PHY
+	/*
+	 * STM32F723 and STM32F730 embedded HS PHY requires ULPI
+	 * clock to be enabled (RUN and LP) in addition to USBPHYC.
+	 */
+	LL_AHB1_GRP1_EnableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
+	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_OTGPHYC);
 #endif
 #endif /* USB_OTG_HS_ULPI_PHY */

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1042,6 +1042,12 @@ static int priv_clock_enable(void)
 #endif /* defined(CONFIG_SOC_SERIES_STM32H7X) */
 
 #if USB_OTG_HS_EMB_PHY
+	/*
+	 * STM32F723 and STM32F730 embedded HS PHY requires ULPI
+	 * clock to be enabled (RUN and LP) in addition to USBPHYC.
+	 */
+	LL_AHB1_GRP1_EnableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
+	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_OTGPHYC);
 #endif
 #elif defined(CONFIG_SOC_SERIES_STM32H7X) && DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otgfs)


### PR DESCRIPTION
Lightweight patch addressing https://github.com/zephyrproject-rtos/zephyr/issues/84934.

A similar patch is found in #99756 on main branch but direct backport isn't possible.

(Note that using the `usb_next` stack is still broken, but this does allow the USB IP to initialize)

Fixes #84934 (<== required by CI to pass backport test...)