### PR TITLE
[Backport v4.2-branch] stm32: usb: fix OTGHS on STM32F723/F730 (embedded USBPHYC)

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -447,6 +447,12 @@ static int usb_dc_stm32_clock_enable(void)
 
 #if USB_OTG_HS_EMB_PHYC
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_otghs)
+	/*
+	 * STM32F723 and STM32F730 embedded HS PHY requires ULPI
+	 * clock to be enabled (RUN and LP) in addition to USBPHYC.
+	 */
+	LL_AHB1_GRP1_EnableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
+	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_OTGPHYC);
 #endif
 #endif

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1161,6 +1161,12 @@ static int priv_clock_enable(void)
 
 #if USB_OTG_HS_EMB_PHY
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_otghs)
+	/*
+	 * STM32F723 and STM32F730 embedded HS PHY requires ULPI
+	 * clock to be enabled (RUN and LP) in addition to USBPHYC.
+	 */
+	LL_AHB1_GRP1_EnableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
+	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_OTGPHYC);
 #endif
 #endif


### PR DESCRIPTION
Lightweight patch addressing https://github.com/zephyrproject-rtos/zephyr/issues/84934. Same as #100792 but for Zephyr v4.2.

A similar patch is found in https://github.com/zephyrproject-rtos/zephyr/pull/99756 on main branch but direct backport isn't possible.

(Note that unlike #100792, `usb_next` stack is functional with this patch on v4.2)

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/84934 (<== required by CI to pass backport test...)