### PR TITLE
net: mqtt: fix log typo

### DIFF
--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
@@ -42,7 +42,7 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 				       ZSOCK_SO_BINDTODEVICE, &ifname,
 				       sizeof(struct net_ifreq));
 		if (ret < 0) {
-			NET_ERR("Failed to bind ot interface %s error (%d)",
+			NET_ERR("Failed to bind to interface %s (%d)",
 				ifname.ifr_name, -errno);
 			goto error;
 		}


### PR DESCRIPTION
Fix typo in a log message and remove a redundant “error” mention.