### PR TITLE
drivers: ieee802154: remove unused IEEE802154_CSL_DEBUG

### DIFF
--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -91,12 +91,6 @@ config IEEE802154_CSL_ENDPOINT
 	  Make this device a CSL (coordinated sampled listening) endpoint with delayed
 	  reception handling and CSL IE injection.
 
-config IEEE802154_CSL_DEBUG
-	bool "Support for CSL debugging"
-	depends on IEEE802154_CSL_ENDPOINT
-	help
-	  Enable support for CSL debugging by avoiding sleep state in favor of receive state.
-
 config IEEE802154_SELECTIVE_TXCHANNEL
 	bool "Support for selective TX channel setting"
 	help


### PR DESCRIPTION
The Kconfig option is not used anywhere for a while.