### PR TITLE
hal_nordic: nrfs: select MULTITHREADING when NRFS_LOCAL_DOMAIN=y

### DIFF
--- a/modules/hal_nordic/nrfs/Kconfig
+++ b/modules/hal_nordic/nrfs/Kconfig
@@ -67,6 +67,7 @@ config NRFS_LOCAL_DOMAIN
 	select IPC_SERVICE
 	select MBOX
 	select EVENTS
+	select MULTITHREADING
 	select REBOOT
 	help
 	  This option enables the nRF Services Local Domain libraries.


### PR DESCRIPTION
NRFS_LOCAL_DOMAIN needs to enable MULTITHREADING for events handling. select MULTITHREADING when this option is selected.