### PR TITLE
cmake: hwmv2: optimize list_hardware.py output parsing

### DIFF
--- a/cmake/modules/hwm_v2.cmake
+++ b/cmake/modules/hwm_v2.cmake
@@ -54,11 +54,13 @@ endif()
 
 set(kconfig_soc_source_dir)
 
-while(TRUE)
-  string(FIND "${ret_hw}" "\n" idx REVERSE)
-  math(EXPR start "${idx} + 1")
-  string(SUBSTRING "${ret_hw}" ${start} -1 line)
-  string(SUBSTRING "${ret_hw}" 0 ${idx} ret_hw)
+# Convert to list format (protecting existing semicolons)
+string(REPLACE ";" "@@SEMICOLON@@" ret_hw_escaped "${ret_hw}")
+string(REPLACE "\n" ";" hw_lines "${ret_hw_escaped}")
+list(REVERSE hw_lines)
+
+foreach(line IN LISTS hw_lines)
+  string(REPLACE "@@SEMICOLON@@" ";" line "${line}")
 
   cmake_parse_arguments(HWM "" "TYPE" "" ${line})
   if(HWM_TYPE STREQUAL "arch")
@@ -87,11 +89,7 @@ while(TRUE)
       set(SOC_${HWM_TYPE_UPPER}_${SOC_V2_NAME_UPPER}_DIR ${SOC_V2_DIR})
     endif()
   endif()
-
-  if(idx EQUAL -1)
-    break()
-  endif()
-endwhile()
+endforeach()
 list(REMOVE_DUPLICATES kconfig_soc_source_dir)
 
 # Support multiple ARCH_ROOT, SOC_ROOT and BOARD_ROOT


### PR DESCRIPTION
Replace inefficient string parsing loop with CMake list iteration for processing list_hardware.py output. The previous implementation used repeated string operations on the **entire** output string for each line, which is increasingly slow as hardware list grows...

**Local tests show hwmv2.cmake module loading in ~350 ms instead of 540 ms on my machine.**