### PR TITLE
tests: boards: nrf: i2c: add twi variant

### DIFF
--- a/tests/boards/nrf/i2c/i2c_slave/boards/nrf52840dk_nrf52840_common.overlay
+++ b/tests/boards/nrf/i2c/i2c_slave/boards/nrf52840dk_nrf52840_common.overlay
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Two loopbacks are required:
+ * P1.01 - P1.02
+ * P1.03 - P1.04
+ */
+
+/ {
+	aliases {
+		i2c-slave = &i2c1;
+	};
+};
+
+&pinctrl {
+	i2c0_default_alt: i2c0_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 1)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+		};
+	};
+
+	i2c0_sleep_alt: i2c0_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 1)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			low-power-enable;
+		};
+	};
+
+	i2c1_default_alt: i2c1_default_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 2)>,
+				<NRF_PSEL(TWIS_SCL, 1, 4)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c1_sleep_alt: i2c1_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(TWIS_SDA, 1, 2)>,
+				<NRF_PSEL(TWIS_SCL, 1, 4)>;
+			low-power-enable;
+		};
+	};
+};
+
+&i2c0 {
+	status = "okay";
+	pinctrl-0 = <&i2c0_default_alt>;
+	pinctrl-1 = <&i2c0_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+
+	sensor: sensor@54 {
+		reg = <0x54>;
+	};
+};
+
+dut_twis: &i2c1 {
+	compatible = "nordic,nrf-twis";
+	status = "okay";
+	pinctrl-0 = <&i2c1_default_alt>;
+	pinctrl-1 = <&i2c1_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+};

--- a/tests/boards/nrf/i2c/i2c_slave/boards/nrf52840dk_nrf52840_twi.overlay
+++ b/tests/boards/nrf/i2c/i2c_slave/boards/nrf52840dk_nrf52840_twi.overlay
@@ -1,10 +1,10 @@
 /*
- * Copyright 2024 Nordic Semiconductor ASA
+ * Copyright 2025 Nordic Semiconductor ASA
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "nrf52840dk_nrf52840_common.overlay"
 
-dut_twim: &i2c0 {
-	compatible = "nordic,nrf-twim";
+&i2c0 {
+	compatible = "nordic,nrf-twi";
 };

--- a/tests/boards/nrf/i2c/i2c_slave/testcase.yaml
+++ b/tests/boards/nrf/i2c/i2c_slave/testcase.yaml
@@ -24,6 +24,12 @@ tests:
       - nrf54h20dk/nrf54h20/cpuppr
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
+  boards.nrf.i2c.i2c_slave.twi:
+    platform_allow:
+      - nrf52840dk/nrf52840
+    integration_platforms:
+      - nrf52840dk/nrf52840
+    extra_args: DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840_twi.overlay"
   boards.nrf.i2c.i2c_slave.fast:
     platform_allow:
       - nrf52840dk/nrf52840


### PR DESCRIPTION
Currently only TWIM peripheral is verified against TWIS. Add new test variant to verify nRF52 TWI peripheral as well.