### PR TITLE
ci: assigner: only run on main branch

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -9,8 +9,6 @@ on:
     - ready_for_review
     branches:
     - main
-    - collab-*
-    - v*-branch
   issues:
     types:
     - labeled


### PR DESCRIPTION
See if this fixes the issue where this workflow runs on released
branches.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
