### PR TITLE
drivers: ethernet: remove imply MDIO

### DIFF
--- a/drivers/ethernet/Kconfig.litex
+++ b/drivers/ethernet/Kconfig.litex
@@ -5,4 +5,3 @@ config ETH_LITEX_LITEETH
 	bool "LiteX LiteEth Ethernet core driver"
 	default y
 	depends on DT_HAS_LITEX_LITEETH_ENABLED
-	imply MDIO

--- a/drivers/ethernet/Kconfig.nxp_s32_gmac
+++ b/drivers/ethernet/Kconfig.nxp_s32_gmac
@@ -7,7 +7,6 @@ menuconfig ETH_NXP_S32_GMAC
 	depends on DT_HAS_NXP_S32_GMAC_ENABLED
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	select PINCTRL
-	imply MDIO
 	help
 	  Enable GMAC/EMAC Ethernet driver for NXP S32 SoCs.
 


### PR DESCRIPTION
remove `imply MDIO` from the
ethernet drivers, that don't directly use mdio
and only use the ethernet phy api, now that the
phys select MDIO.

in 648c8252b575879c2e926d0b051febf2cb1672d1 the
`select MDIO` ones were remove, unfortunatly I forgot
the implyed ones.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>