### PR TITLE
drivers: input: input_chsc5x: add delay after reset

### DIFF
--- a/drivers/input/Kconfig.chsc5x
+++ b/drivers/input/Kconfig.chsc5x
@@ -10,3 +10,11 @@ config INPUT_CHSC5X
 	select INPUT_TOUCH
 	help
 	  Enable CHSC5X driver for Chipsemi capacitive touch panel controller.
+
+config INPUT_CHSC5X_VERIFY_IC_TYPE
+	bool "IC type verification"
+	default y
+	depends on INPUT_CHSC5X
+	help
+	  This option enables the verification of the IC type which implies an
+	  additional delay of 100ms during initialization.

--- a/drivers/input/input_chsc5x.c
+++ b/drivers/input/input_chsc5x.c
@@ -252,6 +252,9 @@ static int chsc5x_init(const struct device *dev)
 		return ret;
 	}
 
+	/* It takes about 94ms until chip is ready after reset. */
+	k_msleep(100);
+
 	return chsc5x_chip_init(dev);
 };
 

--- a/drivers/input/input_chsc5x.c
+++ b/drivers/input/input_chsc5x.c
@@ -100,7 +100,8 @@ static void chsc5x_isr_handler(const struct device *dev, struct gpio_callback *c
 	k_work_submit(&data->work);
 }
 
-static int chsc5x_chip_init(const struct device *dev)
+#if defined(CONFIG_INPUT_CHSC5X_VERIFY_IC_TYPE)
+static int chsc5x_verify_ic(const struct device *dev)
 {
 	const struct chsc5x_config *cfg = dev->config;
 	int ret;
@@ -141,6 +142,7 @@ static int chsc5x_chip_init(const struct device *dev)
 
 	return 0;
 }
+#endif /* CONFIG_INPUT_CHSC5X_VERIFY_IC_TYPE */
 
 static int chsc5x_reset(const struct device *dev)
 {
@@ -252,10 +254,17 @@ static int chsc5x_init(const struct device *dev)
 		return ret;
 	}
 
+#if defined(CONFIG_INPUT_CHSC5X_VERIFY_IC_TYPE)
 	/* It takes about 94ms until chip is ready after reset. */
 	k_msleep(100);
 
-	return chsc5x_chip_init(dev);
+	ret =  chsc5x_verify_ic(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to verify ic: %d", ret);
+		return ret;
+	}
+#endif /* CONFIG_INPUT_CHSC5X_VERIFY_IC_TYPE */
+	return ret;
 };
 
 #define CHSC5X_DEFINE(index)                                                                       \


### PR DESCRIPTION
The sensor requires at least 94ms of delay before starting communication after a reset. This is not mentioned in the datasheet but is arbitrarily defined.