### PR TITLE
samples: code_relocation_nocopy: Allow flash to not start at address 0

### DIFF
--- a/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
+++ b/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
@@ -66,10 +66,13 @@
 
 /*
  * Add another fake portion of FLASH to simulate a secondary or external FLASH
- * that we can do XIP from.
+ * that we can do XIP from. The simulated EXTFLASH starts at an offset of 0x9000
+ * from the start of the main application FLASH area, taking the flash base address
+ * and load offset into account, and extends to the end of the physical FLASH.
  */
-#define EXTFLASH_ADDR	0x7000
-#define EXTFLASH_SIZE	(CONFIG_FLASH_SIZE * 1K - EXTFLASH_ADDR)
+#define EXTFLASH_OFFSET	0x9000
+#define EXTFLASH_ADDR	(CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET + EXTFLASH_OFFSET)
+#define EXTFLASH_SIZE	(CONFIG_FLASH_SIZE * 1K - CONFIG_FLASH_LOAD_OFFSET - EXTFLASH_OFFSET)
 
 #endif
 


### PR DESCRIPTION
The fallback when a XIP external flash doesn't exist assumed that main Flash starts at address 0. Adjust placement of the EXTFLASH region to take the Flash base address and load offset into account.

Also increase the offset of the fake EXTFLASH region to support larger apps.