### PR TITLE
Bluetooth: Controller: nRF54Lx: Fix DTM when using GRTC

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.h
@@ -18,7 +18,7 @@
 #define HAL_TICKER_CNTR_CMP_OFFSET_MIN 1
 
 /* Macro defining the max. counter update latency in ticks */
-#define HAL_TICKER_CNTR_SET_LATENCY 4
+#define HAL_TICKER_CNTR_SET_LATENCY 5
 
 #else /* !CONFIG_BT_CTLR_NRF_GRTC */
 #define HAL_TICKER_CNTR_CLK_UNIT_FSEC 30517578125UL
@@ -30,10 +30,10 @@
 #define HAL_TICKER_CNTR_MASK 0x00FFFFFF
 
 /* Macro defining the minimum counter compare offset */
-#define HAL_TICKER_CNTR_CMP_OFFSET_MIN 3
+#define HAL_TICKER_CNTR_CMP_OFFSET_MIN 2
 
 /* Macro defining the max. counter update latency in ticks */
-#define HAL_TICKER_CNTR_SET_LATENCY 0
+#define HAL_TICKER_CNTR_SET_LATENCY 1
 #endif /* !CONFIG_BT_CTLR_NRF_GRTC */
 
 #define HAL_TICKER_FSEC_PER_USEC      1000000000UL

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -12,9 +12,19 @@
 
 #include "hal/debug.h"
 
-/* Clock setup timeouts are unlikely, below values are experimental */
-#define LFCLOCK_TIMEOUT_MS 500
-#define HFCLOCK_TIMEOUT_MS 2
+/* LF (XO, RC) clock setup timeout.
+ * LF settling time can vary on the type of the source.
+ */
+#define LFCLOCK_TIMEOUT_MS 1000U
+
+/* HFXO clock setup timeout */
+#if DT_NODE_HAS_PROP(DT_NODELABEL(hfxo), startup_time_us)
+/* Use value from devicetree plus an additional margin */
+#define HFCLOCK_TIMEOUT_MS (DIV_ROUND_UP(DT_PROP(DT_NODELABEL(hfxo), startup_time_us), 1000U) + 3U)
+#else
+/* Use manually tested (peripheral role) value, includes added additional margin */
+#define HFCLOCK_TIMEOUT_MS 5U
+#endif
 
 static uint16_t const sca_ppm_lut[] = {500, 250, 150, 100, 75, 50, 30, 20};
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -14,6 +14,7 @@
 #include "hal/cpu.h"
 #include "hal/cntr.h"
 #include "hal/ccm.h"
+#include "hal/ticker.h"
 #include "hal/radio.h"
 #include "hal/radio_df.h"
 
@@ -45,7 +46,13 @@
 
 #include "hal/debug.h"
 
-#define CNTR_MIN_DELTA 3
+/* Define to setup radio start offset by a maximum ISR latency value that is less than inter-frame
+ * switching, plus minimum counter compare offset that can be set, plus minimum CPU latency to set
+ * the counter compare register.
+ */
+#define CNTR_MIN_DELTA (HAL_TICKER_US_TO_TICKS(HAL_RADIO_ISR_LATENCY_MAX_US) + \
+			HAL_TICKER_CNTR_CMP_OFFSET_MIN + \
+			HAL_TICKER_CNTR_SET_LATENCY)
 
 /* Helper definitions for repeated payload sequence */
 #define PAYLOAD_11110000 0x0f


### PR DESCRIPTION
Fix nRF54Lx DTM implementation when using GRTC. The Radio start needs to be offset by a maximum ISR latency value that is less than inter-frame switching, plus minimum counter compare offset that can be set, plus minimum CPU latency to set the counter compare register.

```
[2025-12-10 16:34:55.039] *** Booting Zephyr OS build v4.3.0-2132-geefa7f50055c ***
[2025-12-10 16:34:55.046] Type "help" for supported commands.Before any Bluetooth commands you must `bt init` to initialize the stack.
[2025-12-10 16:34:55.060] uart:~$ bt init
[2025-12-10 16:34:58.722] Bluetooth initialized
[2025-12-10 16:34:58.724] Settings Loaded
[2025-12-10 16:34:58.914] [00:00:03.687,403] <inf> fs_nvs: 8 Sectors of 4096 bytes
[2025-12-10 16:34:58.922] [00:00:03.687,417] <inf> fs_nvs: alloc wra: 0, ac0
[2025-12-10 16:34:58.929] [00:00:03.687,422] <inf> fs_nvs: data wra: 0, 600
[2025-12-10 16:34:58.937] [00:00:03.689,445] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[2025-12-10 16:34:58.947] [00:00:03.689,460] <inf> bt_hci_core: HW Variant: nRF54Lx (0x0005)
[2025-12-10 16:34:58.956] [00:00:03.689,474] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 4.3 Build 99
[2025-12-10 16:34:58.968] [00:00:03.689,710] <inf> bt_hci_core: No ID address. App must call settings_load()
[2025-12-10 16:34:58.978] [00:00:03.690,833] <err> settings: set-value failure. key: bt/mesh/AppKey/0 error(-2)
[2025-12-10 16:34:58.989] [00:00:03.690,921] <err> settings: set-value failure. key: bt/mesh/Seq error(-2)
[2025-12-10 16:34:58.999] [00:00:03.690,993] <err> settings: set-value failure. key: bt/mesh/IV error(-2)
[2025-12-10 16:34:59.010] [00:00:03.691,109] <err> settings: set-value failure. key: bt/mesh/Net error(-2)
[2025-12-10 16:34:59.020] [00:00:03.691,225] <err> settings: set-value failure. key: bt/mesh/NetKey/0 error(-2)
[2025-12-10 16:34:59.031] [00:00:03.691,938] <inf> bt_hci_core: HCI transport: Controller
[2025-12-10 16:34:59.039] [00:00:03.691,989] <inf> bt_hci_core: Identity: F4:BE:7F:30:2B:AC (random)
[2025-12-10 16:34:59.049] [00:00:03.692,007] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[2025-12-10 16:34:59.061] [00:00:03.692,025] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
[2025-12-10 16:34:59.070] uart:~$ bt test_tx 0 10 0 1
[2025-12-10 16:35:05.787] test_tx...
[2025-12-10 16:35:05.787] uart:~$ bt test_end
[2025-12-10 16:35:09.462] num_rx= 0.
[2025-12-10 16:35:09.463] uart:~$ 
```

Fixes #100754.