### PR TITLE
boards: silabs: Enable additional peripherals

### DIFF
--- a/boards/silabs/dev_kits/sltb010a/sltb010a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a-pinctrl.dtsi
@@ -23,6 +23,14 @@
 		};
 	};
 
+	timer0_default: timer0_default {
+		group0 {
+			pins = <TIMER0_CC0_PB0>;
+			drive-push-pull;
+			output-high;
+		};
+	};
+
 	usart0_default: usart0_default {
 		group0 {
 			pins = <USART0_TX_PC0>, <USART0_CLK_PC2>;

--- a/boards/silabs/dev_kits/sltb010a/sltb010a.dts
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a.dts
@@ -14,6 +14,7 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
+		pwm-led0 = &pwm_led0;
 		spi0 = &usart0;
 		sw0 = &button0;
 		watchdog0 = &wdog0;

--- a/boards/silabs/dev_kits/sltb010a/sltb010a_0.yaml
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a_0.yaml
@@ -14,6 +14,7 @@ supported:
   - uart
   - i2c
   - dma
+  - pwm
   - spi
   - clock_control
 vendor: silabs

--- a/boards/silabs/dev_kits/sltb010a/sltb010a_0.yaml
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a_0.yaml
@@ -17,4 +17,5 @@ supported:
   - pwm
   - spi
   - clock_control
+  - watchdog
 vendor: silabs

--- a/boards/silabs/dev_kits/sltb010a/sltb010a_2.overlay
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a_2.overlay
@@ -27,6 +27,10 @@
 	enable-gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
 };
 
+&timer0_default {
+	pins = <TIMER0_CC0_PA4>;
+};
+
 &exp_header {
 	gpio-map = <3 0 &gpioa 8 0>,
 		   <4 0 &gpioc 0 0>,

--- a/boards/silabs/dev_kits/sltb010a/sltb010a_2.yaml
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a_2.yaml
@@ -14,5 +14,6 @@ supported:
   - uart
   - i2c
   - dma
+  - pwm
   - spi
 vendor: silabs

--- a/boards/silabs/dev_kits/sltb010a/sltb010a_2.yaml
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a_2.yaml
@@ -16,4 +16,5 @@ supported:
   - dma
   - pwm
   - spi
+  - watchdog
 vendor: silabs

--- a/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {
@@ -22,6 +23,15 @@
 		led0: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "LED 0";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&timer0_pwm 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "PWM LED 0";
 		};
 	};
 
@@ -72,6 +82,16 @@
 	pinctrl-0 = <&itm_default>;
 	pinctrl-names = "default";
 	swo-ref-frequency = <DT_FREQ_K(76800)>;
+};
+
+&timer0 {
+	status = "okay";
+
+	timer0_pwm: pwm {
+		pinctrl-0 = <&timer0_default>;
+		pinctrl-names = "default";
+		status = "okay";
+	};
 };
 
 &usart0 {

--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
@@ -32,6 +32,9 @@
 		pwm-led0 = &red_pwm_led;
 		pwm-led1 = &green_pwm_led;
 		pwm-led2 = &blue_pwm_led;
+		red-pwm-led = &red_pwm_led;
+		green-pwm-led = &green_pwm_led;
+		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdog0;

--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.yaml
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.yaml
@@ -18,6 +18,7 @@ supported:
   - comparator
   - adc
   - dac
+  - pwm
 testing:
   ignore_tags:
     - pm

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a-pinctrl.dtsi
@@ -15,6 +15,12 @@
 		};
 	};
 
+	iadc0_default: iadc0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_BEVEN1_IADC0>;
+		};
+	};
+
 	i2c0_default: i2c0_default {
 		group0 {
 			pins = <I2C0_SCL_PC4>, <I2C0_SDA_PC5>;
@@ -50,6 +56,12 @@
 			pins = <USART0_RX_PA6>;
 			input-enable;
 			silabs,input-filter;
+		};
+	};
+
+	vdac0_default: vdac0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_BEVEN0_VDAC0CH0>;
 		};
 	};
 };

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a-pinctrl.dtsi
@@ -31,6 +31,14 @@
 		};
 	};
 
+	timer0_default: timer0_default {
+		group0 {
+			pins = <TIMER0_CC0_PA4>, <TIMER0_CC1_PA7>;
+			drive-push-pull;
+			output-high;
+		};
+	};
+
 	usart0_default: usart0_default {
 		group0 {
 			pins = <USART0_TX_PA5>;

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <silabs/xg24/efr32mg24b210f1536im48.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>
 #include "xg24_ek2703a-pinctrl.dtsi"
 
@@ -27,6 +28,8 @@
 	aliases {
 		led0 = &led0;
 		led1 = &led1;
+		pwm-led0 = &pwm_led0;
+		pwm-led1 = &pwm_led1;
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdog0;
@@ -41,6 +44,20 @@
 
 		led1: led_1 {
 			gpios = <&gpioa 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&timer0_pwm 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "PWM LED 0";
+		};
+
+		pwm_led1: pwm_led_1 {
+			pwms = <&timer0_pwm 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "PWM LED 1";
 		};
 	};
 
@@ -122,6 +139,16 @@
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&timer0 {
+	status = "okay";
+
+	timer0_pwm: pwm {
+		pinctrl-0 = <&timer0_default>;
+		pinctrl-names = "default";
+		status = "okay";
+	};
 };
 
 &gpio {

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
@@ -6,6 +6,8 @@
 
 /dts-v1/;
 #include <silabs/xg24/efr32mg24b210f1536im48.dtsi>
+#include <zephyr/dt-bindings/adc/silabs-adc.h>
+#include <zephyr/dt-bindings/dac/silabs-vdac.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>
@@ -73,6 +75,13 @@
 			gpios = <&gpiob 3 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_1>;
 		};
+	};
+
+	mikrobus_adc: mikrobus_dac: zephyr,user {
+		io-channels = <&adc0 0>;
+		dac = <&vdac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
 	};
 };
 
@@ -220,11 +229,33 @@
 };
 
 &adc0 {
+	pinctrl-0 = <&iadc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
 	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,input-positive = <IADC_INPUT_PB0>;
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
 };
 
 &vdac0 {
+	pinctrl-0 = <&vdac0_default>;
+	pinctrl-names = "default";
+	voltage-reference = "AVDD";
 	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		aux-output = <VDAC_OUTPUT_PB0>;
+	};
 };
 
 &vdac1 {

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.yaml
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.yaml
@@ -16,6 +16,7 @@ supported:
   - clock_control
   - comparator
   - dac
+  - pwm
 testing:
   ignore_tags:
     - pm

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.yaml
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.yaml
@@ -8,6 +8,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
   - bluetooth
   - counter
   - gpio

--- a/boards/silabs/dev_kits/xg27_dk2602a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/xg27_dk2602a/thunderboard.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {
@@ -22,6 +23,15 @@
 		led0: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "LED 0";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&timer0_pwm 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "PWM LED 0";
 		};
 	};
 
@@ -86,6 +96,16 @@
 	pinctrl-0 = <&itm_default>;
 	pinctrl-names = "default";
 	swo-ref-frequency = <DT_FREQ_K(76800)>;
+};
+
+&timer0 {
+	status = "okay";
+
+	timer0_pwm: pwm {
+		pinctrl-0 = <&timer0_default>;
+		pinctrl-names = "default";
+		status = "okay";
+	};
 };
 
 &usart0 {

--- a/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a-pinctrl.dtsi
@@ -31,6 +31,14 @@
 		};
 	};
 
+	timer0_default: timer0_default {
+		group0 {
+			pins = <TIMER0_CC0_PA4>;
+			drive-push-pull;
+			output-low;
+		};
+	};
+
 	usart0_default: usart0_default {
 		group0 {
 			pins = <USART0_TX_PC0>, <USART0_CLK_PC2>;

--- a/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.dts
+++ b/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.dts
@@ -18,6 +18,7 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
+		pwm-led0 = &pwm_led0;
 		spi0 = &usart0;
 		sw0 = &button0;
 		watchdog0 = &wdog0;

--- a/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.yaml
+++ b/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.yaml
@@ -16,5 +16,6 @@ supported:
   - clock_control
   - comparator
   - adc
+  - pwm
   - watchdog
 vendor: silabs

--- a/boards/silabs/explorer_kits/xg22/bg22_ek4108a.yaml
+++ b/boards/silabs/explorer_kits/xg22/bg22_ek4108a.yaml
@@ -8,6 +8,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
   - bluetooth
   - counter
   - gpio

--- a/boards/silabs/explorer_kits/xg22/bg22_ek4108a.yaml
+++ b/boards/silabs/explorer_kits/xg22/bg22_ek4108a.yaml
@@ -18,6 +18,7 @@ supported:
   - i2c
   - dma
   - spi
+  - pwm
 testing:
   ignore_tags:
     - pm

--- a/boards/silabs/explorer_kits/xg22/xg22_ek2710a.yaml
+++ b/boards/silabs/explorer_kits/xg22/xg22_ek2710a.yaml
@@ -8,6 +8,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
   - bluetooth
   - counter
   - gpio


### PR DESCRIPTION
Configure PWM, ADC and DAC on boards that support it, and declare support for pwm, adc, dac and watchdog testing in board yaml files.