### PR TITLE
samples: driver: counter: Fix silabs timer name

### DIFF
--- a/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.yaml
+++ b/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.yaml
@@ -11,6 +11,7 @@ supported:
   - adc
   - bluetooth
   - comparator
+  - counter
   - dma
   - entropy
   - gpio

--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -49,6 +49,10 @@ tests:
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
       - lp_em_cc2340r5
+      - slwrb4180b
+      - xg24_rb4187c
+      - xg27_rb4194a
+      - xg29_rb4412a
     integration_platforms:
       - nucleo_f746zg
   sample.drivers.counter.alarm.stm32_rtc:

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -48,7 +48,10 @@ struct counter_alarm_cfg alarm_cfg;
 #elif defined(CONFIG_COUNTER_GECKO_RTCC)
 #define TIMER DT_NODELABEL(rtcc0)
 #elif defined(CONFIG_COUNTER_GECKO_STIMER)
-#define TIMER DT_NODELABEL(stimer0)
+#ifdef TIMER
+#undef TIMER
+#endif
+#define TIMER DT_CHOSEN(silabs_sleeptimer)
 #elif defined(CONFIG_COUNTER_INFINEON_CAT1) || defined(CONFIG_COUNTER_INFINEON_TCPWM)
 #define TIMER DT_NODELABEL(counter0_0)
 #elif defined(CONFIG_COUNTER_AMBIQ)


### PR DESCRIPTION
The Counter alarm sample contains a hard-coded list of devicetree nodes to use. Since the definition of the counter node was changed on Series 2 devices in #97912, this sample hasn't compiled.

Update the sample to select the correct devicetree node, and add representative boards to platform_allow to allow the sample to be tested on Series 2 boards.