### PR TITLE
boards: cy8cproto_041tp: i2c support

### DIFF
--- a/boards/infineon/cy8cproto_041tp/cy8cproto_041tp-pinctrl.dtsi
+++ b/boards/infineon/cy8cproto_041tp/cy8cproto_041tp-pinctrl.dtsi
@@ -13,3 +13,13 @@
 &p5_1_scb0_uart_rx {
 	input-enable;
 };
+
+&p6_3_scb1_i2c_scl {
+	drive-open-drain;
+	input-enable;
+};
+
+&p6_4_scb1_i2c_sda {
+	drive-open-drain;
+	input-enable;
+};

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -163,6 +163,10 @@ static void ifx_master_event_handler(void *callback_arg, uint32_t event)
 		k_sem_give(&data->transfer_sem);
 	}
 
+	if (data->p_target_config == NULL) {
+		return;
+	}
+
 	if (0 != (CY_SCB_I2C_SLAVE_READ_EVENT & event)) {
 		if (data->p_target_config->callbacks->read_requested) {
 			data->p_target_config->callbacks->read_requested(data->p_target_config,
@@ -318,6 +322,7 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 	const struct ifx_cat1_i2c_config *config = dev->config;
 	cy_en_scb_i2c_status_t rslt;
 	int ret;
+	bool is_target_mode = false;
 
 	if (dev_config != 0) {
 		switch (I2C_SPEED_GET(dev_config)) {
@@ -343,9 +348,13 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 
 		if (dev_config & I2C_MODE_CONTROLLER) {
 			_i2c_default_config.i2cMode = CY_SCB_I2C_MASTER;
+			is_target_mode = false;
 		} else {
 			_i2c_default_config.i2cMode = CY_SCB_I2C_SLAVE;
+			is_target_mode = true;
 		}
+	} else {
+		is_target_mode = (_i2c_default_config.i2cMode == CY_SCB_I2C_SLAVE);
 	}
 
 	/* Acquire semaphore (block I2C operation for another thread) */
@@ -356,7 +365,16 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 
 	_i2c_default_config.slaveAddress = data->slave_address;
 
-	/* Configure the I2C resource to be master */
+	if (is_target_mode) {
+		_i2c_default_config.slaveAddressMask = 0;
+		_i2c_default_config.ackGeneralAddr = false;
+	}
+
+	/* De-initialize SCB before re-configuring (required when switching modes) */
+	Cy_SCB_I2C_Disable(config->base, &data->context);
+	Cy_SCB_I2C_DeInit(config->base);
+
+	/* Configure the I2C resource */
 	rslt = Cy_SCB_I2C_Init(config->base, &_i2c_default_config, &data->context);
 	if (rslt != CY_SCB_I2C_SUCCESS) {
 		LOG_ERR("I2C configure failed with err 0x%x", rslt);
@@ -367,7 +385,6 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 #ifdef USE_I2C_SET_PERI_DIVIDER
 	_i2c_set_peri_divider(dev, CAT1_I2C_SPEED_STANDARD_HZ,
 			      (_i2c_default_config.i2cMode == CY_SCB_I2C_SLAVE));
-
 #endif
 
 #if defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -370,7 +370,11 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 
 #endif
 
+#if defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
+	Cy_SCB_I2C_Enable(config->base, &data->context);
+#else
 	Cy_SCB_I2C_Enable(config->base);
+#endif
 	irq_enable(config->irq_num);
 
 	/* Register an I2C event callback handler */
@@ -575,7 +579,7 @@ static int ifx_cat1_i2c_init(const struct device *dev)
 
 	config->irq_config_func(dev);
 
-	return 0;
+	return ifx_cat1_i2c_configure(dev, I2C_MODE_CONTROLLER | I2C_SPEED_SET(I2C_SPEED_STANDARD));
 }
 
 void _i2c_free(const struct device *dev)

--- a/dts/arm/infineon/psoc4/psoc4100tp/psoc4100tp.64-tqfp.dtsi
+++ b/dts/arm/infineon/psoc4/psoc4100tp/psoc4100tp.64-tqfp.dtsi
@@ -12,6 +12,72 @@
 / {
 	soc {
 		pinctrl: pinctrl@40020000 {
+			/* scb_i2c_scl */
+			/omit-if-no-ref/ p0_0_scb0_i2c_scl: p0_0_scb0_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(0, 0, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p1_4_scb1_i2c_scl: p1_4_scb1_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(1, 4, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p2_0_scb0_i2c_scl: p2_0_scb0_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(2, 0, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p3_3_scb0_i2c_scl: p3_3_scb0_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(3, 3, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p4_0_scb1_i2c_scl: p4_0_scb1_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(4, 0, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p5_1_scb1_i2c_scl: p5_1_scb1_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(5, 1, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p6_0_scb0_i2c_scl: p6_0_scb0_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(6, 0, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p6_3_scb1_i2c_scl: p6_3_scb1_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(6, 3, HSIOM_SEL_DS_2)>;
+			};
+
+			/* scb_i2c_sda */
+			/omit-if-no-ref/ p0_1_scb0_i2c_sda: p0_1_scb0_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(0, 1, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p1_5_scb1_i2c_sda: p1_5_scb1_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(1, 5, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p2_1_scb0_i2c_sda: p2_1_scb0_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(2, 1, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p3_2_scb0_i2c_sda: p3_2_scb0_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(3, 2, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p4_1_scb1_i2c_sda: p4_1_scb1_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(4, 1, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p5_2_scb1_i2c_sda: p5_2_scb1_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(5, 2, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p6_1_scb0_i2c_sda: p6_1_scb0_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(6, 1, HSIOM_SEL_DS_2)>;
+			};
+
+			/omit-if-no-ref/ p6_4_scb1_i2c_sda: p6_4_scb1_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(6, 4, HSIOM_SEL_DS_2)>;
+			};
+
 			/* scb_uart_cts */
 			/omit-if-no-ref/ p0_2_scb0_uart_cts: p0_2_scb0_uart_cts {
 				pinmux = <DT_CAT1_PINMUX(1, 0, HSIOM_SEL_ACT_1)>;

--- a/samples/sensor/bme280/boards/cy8cproto_041tp.overlay
+++ b/samples/sensor/bme280/boards/cy8cproto_041tp.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+i2c1: &scb1 {
+	status = "okay";
+	compatible = "infineon,i2c";
+	clocks = <&peri_clk_div2>;
+	pinctrl-0 = <&p6_3_scb1_i2c_scl &p6_4_scb1_i2c_sda>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	bme280@76 {
+		status = "okay";
+		compatible = "bosch,bme280";
+		reg = <0x76>;
+		label = "BME280_I2C";
+	};
+};

--- a/samples/sensor/mpu6050/boards/cy8cproto_041tp.overlay
+++ b/samples/sensor/mpu6050/boards/cy8cproto_041tp.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+i2c1: &scb1 {
+	status = "okay";
+	compatible = "infineon,i2c";
+	clocks = <&peri_clk_div2>;
+	pinctrl-0 = <&p6_3_scb1_i2c_scl &p6_4_scb1_i2c_sda>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	mpu6050@68 {
+		compatible = "invensense,mpu6050";
+		reg = <0x68>;
+		status = "okay";
+		smplrt-div = <249>;
+	};
+};


### PR DESCRIPTION
I2C Driver for cy8cproto_041tp.This PR has dependency on https://github.com/zephyrproject-rtos/zephyr/pull/100894