### PR TITLE
samples: drivers: uart: async_api: Add overlays for silabs boards

### DIFF
--- a/samples/drivers/uart/async_api/boards/bg29_rb4420a.overlay
+++ b/samples/drivers/uart/async_api/boards/bg29_rb4420a.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+&usart1 {
+	dmas = <&dma0 DMA_REQSEL_USART1TXBL>,
+	       <&dma0 DMA_REQSEL_USART1RXDATAV>;
+	dma-names = "tx", "rx";
+};

--- a/samples/drivers/uart/async_api/boards/slwrb4182a.overlay
+++ b/samples/drivers/uart/async_api/boards/slwrb4182a.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+&usart1 {
+	dmas = <&dma0 DMA_REQSEL_USART1TXBL>,
+	       <&dma0 DMA_REQSEL_USART1RXDATAV>;
+	dma-names = "tx", "rx";
+};

--- a/samples/drivers/uart/async_api/boards/slwrb4311a.overlay
+++ b/samples/drivers/uart/async_api/boards/slwrb4311a.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+&usart1 {
+	dmas = <&dma0 DMA_REQSEL_USART1TXBL>,
+	       <&dma0 DMA_REQSEL_USART1RXDATAV>;
+	dma-names = "tx", "rx";
+};

--- a/samples/drivers/uart/async_api/boards/xg24_rb4186c.overlay
+++ b/samples/drivers/uart/async_api/boards/xg24_rb4186c.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+&usart0 {
+	dmas = <&dma0 DMA_REQSEL_USART0TXBL>,
+	       <&dma0 DMA_REQSEL_USART0RXDATAV>;
+	dma-names = "tx", "rx";
+};

--- a/samples/drivers/uart/async_api/boards/xg24_rb4187c.overlay
+++ b/samples/drivers/uart/async_api/boards/xg24_rb4187c.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+&usart0 {
+	dmas = <&dma0 DMA_REQSEL_USART0TXBL>,
+	       <&dma0 DMA_REQSEL_USART0RXDATAV>;
+	dma-names = "tx", "rx";
+};

--- a/samples/drivers/uart/async_api/boards/xg27_rb4194a.overlay
+++ b/samples/drivers/uart/async_api/boards/xg27_rb4194a.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+&usart1 {
+	dmas = <&dma0 DMA_REQSEL_USART1TXBL>,
+	       <&dma0 DMA_REQSEL_USART1RXDATAV>;
+	dma-names = "tx", "rx";
+};

--- a/samples/drivers/uart/async_api/boards/xg29_rb4412a.overlay
+++ b/samples/drivers/uart/async_api/boards/xg29_rb4412a.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+&usart1 {
+	dmas = <&dma0 DMA_REQSEL_USART1TXBL>,
+	       <&dma0 DMA_REQSEL_USART1RXDATAV>;
+	dma-names = "tx", "rx";
+};


### PR DESCRIPTION
Add overlays enabling DMA for Silabs boards to enable use of the async API on the default shell uart.