### PR TITLE
drivers: mbox: Use nordic_tasks from dts instead of VPR_TASK definiton

### DIFF
--- a/drivers/mbox/mbox_nrf_vevif_task_rx.c
+++ b/drivers/mbox/mbox_nrf_vevif_task_rx.c
@@ -39,7 +39,7 @@ static const uint8_t vevif_irqs[VEVIF_TASKS_NUM] = {
 
 static void vevif_task_rx_isr(const void *parameter)
 {
-	uint8_t channel = *(uint8_t *)parameter;
+	uint8_t channel = *(const uint8_t *)parameter;
 	uint8_t idx = channel - TASKS_IDX_MIN;
 
 	nrf_vpr_csr_vevif_tasks_clear(BIT(channel));
@@ -65,11 +65,12 @@ static int vevif_task_rx_register_callback(const struct device *dev, uint32_t id
 					   mbox_callback_t cb, void *user_data)
 {
 	ARG_UNUSED(dev);
-	uint8_t idx = id - TASKS_IDX_MIN;
 
 	if (!vevif_task_rx_is_task_valid(id)) {
 		return -EINVAL;
 	}
+
+	uint8_t idx = id - TASKS_IDX_MIN;
 
 	cbs.cb[idx] = cb;
 	cbs.user_data[idx] = user_data;
@@ -80,11 +81,12 @@ static int vevif_task_rx_register_callback(const struct device *dev, uint32_t id
 static int vevif_task_rx_set_enabled(const struct device *dev, uint32_t id, bool enable)
 {
 	ARG_UNUSED(dev);
-	uint8_t idx = id - TASKS_IDX_MIN;
 
 	if (!vevif_task_rx_is_task_valid(id)) {
 		return -EINVAL;
 	}
+
+	uint8_t idx = id - vevif_irqs[0];
 
 	if (enable) {
 		if ((cbs.enabled_mask & BIT(id)) != 0U) {


### PR DESCRIPTION
This PR fixes the VEVIF task indexing issue by calculating TASKS_IDX_MIN from the DTS nordic,tasks-mask property instead of using the chip-specific NRF_VPR_TASKS_TRIGGER_MIN, ensuring consistent and bounds-safe array indexing across all Nordic chips.


The VPR has chip-specific task trigger indices:

| Chip | `VPR_TASKS_TRIGGER_MinIndex` | `VPR_TASKS_TRIGGER_MaxIndex` | CLIC IRQs Available |
|------|------------------------------|------------------------------|---------------------|
| nRF54L15 | **16** | 22 | 16-22 (VPRCLIC_16-22_IRQn) |
| nRF7120 | **0** | 31 | 16-22 (VPRCLIC_16-22_IRQn) |

Looking at `nrf7120_enga_flpr.h`:
```c
VPRCLIC_16_IRQn = 16,
VPRCLIC_17_IRQn = 17,
VPRCLIC_18_IRQn = 18,
VPRCLIC_19_IRQn = 19,
VPRCLIC_20_IRQn = 20,
VPRCLIC_21_IRQn = 21,
VPRCLIC_22_IRQn = 22,
```

Even though nRF7120's `VPR_TASKS_TRIGGER_MinIndex = 0` (meaning VPR task array indices 0-31 are valid), the **CLIC interrupt numbers** for VEVIF are still **16-22**!

The `MinIndex` defines the task array bounds, NOT the interrupt numbers.

Tracing the issue;
```c
#define TASKS_IDX_MIN NRF_VPR_TASKS_TRIGGER_MIN  // = 0 on nRF7120, 16 on nRF54L15

static const uint8_t vevif_irqs[VEVIF_TASKS_NUM] = {
    LISTIFY(DT_NUM_IRQS(DT_DRV_INST(0)), VEVIF_IRQN, (,))
};  // = {16, 17, 18, 19, 20, 21, 22} - 7 elements

static int vevif_task_rx_set_enabled(...)
{
    uint8_t idx = id - TASKS_IDX_MIN;  // THE BUG
    ...
    irq_enable(vevif_irqs[idx]);
}
```
**On nRF54L15** (MinIndex = 16):
```
Channel 21: idx = 21 - 16 = 5
vevif_irqs[5] = 21 ✓ (within bounds, correct IRQ)
```

**On nRF7120** (MinIndex = 0):
```
Channel 21: idx = 21 - 0 = 21
vevif_irqs[21] = ??? ✗ (OUT OF BOUNDS! Array only has 7 elements)

vevif_irqs array (7 elements):
┌────┬────┬────┬────┬────┬────┬────┐
│ 16 │ 17 │ 18 │ 19 │ 20 │ 21 │ 22 │
└────┴────┴────┴────┴────┴────┴────┘
  [0]  [1]  [2]  [3]  [4]  [5]  [6]

nRF54L15 (MinIndex=16):
  Channel 21 → idx = 21-16 = 5 → vevif_irqs[5] = 21 ✓

nRF7120 (MinIndex=0):
  Channel 21 → idx = 21-0 = 21 → vevif_irqs[21] = ??? (garbage)

```
---
PR at sdk-zephyr: https://github.com/nrfconnect/sdk-zephyr/pull/3628
Full CI run for the sdk-zephyr/pull/3628: https://github.com/nrfconnect/sdk-nrf/pull/26838
