### PR TITLE
pmci: mctp: samples: Remove unnecessary include

### DIFF
--- a/samples/subsys/pmci/mctp/endpoint/src/main.c
+++ b/samples/subsys/pmci/mctp/endpoint/src/main.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
-#include <unistd.h>
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/pmci/mctp/mctp_uart.h>

--- a/samples/subsys/pmci/mctp/host/src/main.c
+++ b/samples/subsys/pmci/mctp/host/src/main.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
-#include <unistd.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 #include <libmctp.h>

--- a/samples/subsys/pmci/mctp/i2c_gpio_bus_endpoint/src/main.c
+++ b/samples/subsys/pmci/mctp/i2c_gpio_bus_endpoint/src/main.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
-#include <unistd.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 #include <libmctp.h>

--- a/samples/subsys/pmci/mctp/i2c_gpio_bus_owner/src/main.c
+++ b/samples/subsys/pmci/mctp/i2c_gpio_bus_owner/src/main.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
-#include <unistd.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 #include <libmctp.h>

--- a/samples/subsys/pmci/mctp/usb_endpoint/src/main.c
+++ b/samples/subsys/pmci/mctp/usb_endpoint/src/main.c
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
-#include <unistd.h>
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/pmci/mctp/mctp_usb.h>


### PR DESCRIPTION
These samples do not seem to need the unistd.h header, but including it limits us to C libraries which have it, which, as it is a POSIX extension, is not all.
So let's not include it so we do not limit ourselves unnecessarily.

Without this fix building with a C library without this header would result on:
```
samples/subsys/pmci/mctp/endpoint/src/main.c:10:10: fatal error: unistd.h: No such file or directory
   10 | #include <unistd.h>
      |          ^~~~~~~~~~
```
With this fix all these samples build fine with libraries without it (like w `CONFIG_MINIMAL_LIBC=y`)