### PR TITLE
tests: secure_storage: Don't try to erase flash with no controller

### DIFF
--- a/tests/subsys/secure_storage/psa/its/src/main.c
+++ b/tests/subsys/secure_storage/psa/its/src/main.c
@@ -8,7 +8,8 @@
 #include <psa/internal_trusted_storage.h>
 
 /* The flash must be erased after this test suite is run for the write-once entry test to pass. */
-#if !defined(CONFIG_BUILD_WITH_TFM) && defined(CONFIG_FLASH_PAGE_LAYOUT)
+#if !defined(CONFIG_BUILD_WITH_TFM) && defined(CONFIG_FLASH_PAGE_LAYOUT) &&                        \
+	DT_HAS_CHOSEN(zephyr_flash_controller)
 static int erase_flash(void)
 {
 	const struct device *const fdev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));


### PR DESCRIPTION
Add a check for a chosen flash controller to avoid attempting to clear the settings flash with no controller available.

See #100694 
This addresses a regression introduced by #99701