### PR TITLE
sys: reboot and poweroff: disable ZLIs

### DIFF
--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -280,6 +280,28 @@ static inline void arch_irq_unlock(unsigned int key);
  */
 static inline bool arch_irq_unlocked(unsigned int key);
 
+#ifdef CONFIG_ZERO_LATENCY_IRQS
+
+/**
+ * @brief Lock all interrupts including zero latency interrupts on the current CPU.
+ *
+ * @details Intended to be used when breaking the promise of zero latency interrupts is
+ * unavoidable and necessary, like accessing shared core peripherals or powering down the
+ * SoC.
+ *
+ * @warning This lock breaks the promise of zero latency interrupts.
+ */
+static inline unsigned int arch_zli_lock(void);
+
+/**
+ * @brief Unlock all interrupts including zero latency interrupts on the current CPU
+ *
+ * @see arch_zli_lock()
+ */
+static inline void arch_zli_unlock(unsigned int key);
+
+#endif
+
 /**
  * Disable the specified interrupt line
  *

--- a/include/zephyr/arch/arm/asm_inline_gcc.h
+++ b/include/zephyr/arch/arm/asm_inline_gcc.h
@@ -105,6 +105,31 @@ static ALWAYS_INLINE bool arch_irq_unlocked(unsigned int key)
 	return key == 0U;
 }
 
+#ifdef CONFIG_ZERO_LATENCY_IRQS
+
+static ALWAYS_INLINE unsigned int arch_zli_lock(void)
+{
+	unsigned int key;
+
+	key = __get_PRIMASK();
+
+	/*
+	 * The cpsid instruction is self synchronizing within the instruction stream, no need for
+	 * an explicit __ISB().
+	 */
+	__disable_irq();
+
+	return key;
+}
+
+static ALWAYS_INLINE void arch_zli_unlock(unsigned int key)
+{
+	__set_PRIMASK(key);
+	__ISB();
+}
+
+#endif /* CONFIG_ZERO_LATENCY_IRQS */
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/os/poweroff.c
+++ b/lib/os/poweroff.c
@@ -10,5 +10,9 @@ void sys_poweroff(void)
 {
 	(void)irq_lock();
 
+#if defined(CONFIG_ZERO_LATENCY_IRQS)
+	(void)arch_zli_lock();
+#endif /* CONFIG_ZERO_LATENCY_IRQS */
+
 	z_sys_poweroff();
 }

--- a/lib/os/reboot.c
+++ b/lib/os/reboot.c
@@ -23,6 +23,10 @@ FUNC_NORETURN void sys_reboot(int type)
 
 	(void)irq_lock();
 
+#if defined(CONFIG_ZERO_LATENCY_IRQS)
+	(void)arch_zli_lock();
+#endif /* CONFIG_ZERO_LATENCY_IRQS */
+
 	/* Disable caches to ensure all data is flushed */
 #if defined(CONFIG_ARCH_CACHE)
 #if defined(CONFIG_DCACHE)


### PR DESCRIPTION
During `sys_reboot`, we discovered deadlocks as ZLIs where triggered while we where actively powering down the SoC.

When powering down or rebooting the SoC, neither ZLIs nor regular IRQs must interrupt the procedure, as we are actively powering down parts of the SoC, which quickly leads to undefined behavior if a ZLI tries to access some hardware which was just powered off or reset.

For regular IRQs, we have `irq_lock()`, we have nothing for disabling ZLIs, as by design, the zephyr kernel is not supposed to be able to interfere with them. However, the poweroff usecase presents a clear scenario where we must be able to disable them.

This PR adds an arch level API for disabling normal IRQs and ZLIs, `arch_zli_lock()` and complimenting `arch_zli_unlock()`. The API is clearly documented with warnings, expected usecase, and is not added exposed in `irq.h` to discourage "common" use of the API, its meant for arch level operations.

The sys_poweroff() and sys_reboot() functions have been extended to use the new API to ensure ZLIs are masked, which should ensure a safe, atomic poweroff/reboot procedure.