### PR TITLE
Bluetooth: TBS: Fix issues with friendly name buffer sizes

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -144,6 +144,7 @@ New APIs and options
 
     * :c:func:`bt_bap_ep_get_conn`
     * :c:member:`bt_ccp_call_control_client_cb.user_data`
+    * :kconfig:option:`CONFIG_BT_TBS_MAX_FRIENDLY_NAME_LENGTH`
 
   * Host
 

--- a/subsys/bluetooth/audio/Kconfig.tbs
+++ b/subsys/bluetooth/audio/Kconfig.tbs
@@ -254,15 +254,22 @@ config BT_TBS_MAX_URI_LENGTH
 	default 30
 	range 4 253
 	help
-	  Sets the maximum length of the call URI supported. Note that if this
-	  value is lower than a call URI, the call request will be rejected.
+	  Sets the maximum length of the call URI supported in octets (without NULL terminator).
+	  Note that if this value is lower than a call URI, the call request will be rejected.
 
 config BT_TBS_MAX_PROVIDER_NAME_LENGTH
 	int "The maximum length of the bearer provider name"
 	default 30
 	range 1 512
 	help
-	  Sets the maximum length of the bearer provider name.
+	  Sets the maximum length of the bearer provider name in octets (without NULL terminator).
+
+config BT_TBS_MAX_FRIENDLY_NAME_LENGTH
+	int "The maximum length of the friendly name supported"
+	default 30
+	range 1 512
+	help
+	  Sets the maximum length of the friendly name in octets (without NULL terminator).
 
 endif # BT_TBS || BT_TBS_CLIENT
 

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -1,7 +1,7 @@
 /* Bluetooth TBS - Telephone Bearer Service
  *
  * Copyright (c) 2020 Bose Corporation
- * Copyright (c) 2021-2024 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2025 Nordic Semiconductor ASA
  * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -81,7 +81,7 @@ struct tbs_inst {
 	uint16_t optional_opcodes;
 	uint16_t status_flags;
 	struct bt_tbs_in_uri incoming_uri;
-	struct bt_tbs_in_uri friendly_name;
+	struct bt_tbs_friendly_name friendly_name;
 	struct bt_tbs_in_uri in_call;
 	char uri_scheme_list[CONFIG_BT_TBS_MAX_SCHEME_LIST_LENGTH];
 	struct bt_tbs_terminate_reason terminate_reason;
@@ -965,12 +965,12 @@ static void notify_handler_cb(struct bt_conn *conn, void *data)
 	}
 
 	if (flags->call_friendly_name_changed) {
-		LOG_DBG("Notifying Friendly Name: call index 0x%02x, URI %s",
-			inst->friendly_name.call_index, inst->friendly_name.uri);
+		LOG_DBG("Notifying Friendly Name: call index 0x%02x, name %s",
+			inst->friendly_name.call_index, inst->friendly_name.name);
 
 		err = notify(conn, BT_UUID_TBS_FRIENDLY_NAME, inst->attrs, &inst->friendly_name,
 			     sizeof(inst->friendly_name.call_index) +
-				     strlen(inst->friendly_name.uri));
+				     strlen(inst->friendly_name.name));
 		if (err == 0) {
 			flags->call_friendly_name_changed = false;
 		} else {
@@ -1926,19 +1926,19 @@ static ssize_t read_friendly_name(struct bt_conn *conn, const struct bt_gatt_att
 		LOG_DBG("Value dirty for %p", (void *)conn);
 		ret = BT_GATT_ERR(BT_TBS_ERR_VAL_CHANGED);
 	} else {
-		const struct bt_tbs_in_uri *friendly_name = &inst->friendly_name;
+		const struct bt_tbs_friendly_name *friendly_name = &inst->friendly_name;
 
 		flags->call_friendly_name_dirty = false;
 
-		LOG_DBG("Index: 0x%02x call index 0x%02x, URI %s", inst_index(inst),
-			friendly_name->call_index, friendly_name->uri);
+		LOG_DBG("Index: 0x%02x call index 0x%02x, name %s", inst_index(inst),
+			friendly_name->call_index, friendly_name->name);
 
 		if (friendly_name->call_index == BT_TBS_FREE_CALL_INDEX) {
-			LOG_DBG("URI not set");
+			LOG_DBG("Friendly name not set");
 			ret = 0;
 		} else {
 			const size_t val_len =
-				sizeof(friendly_name->call_index) + strlen(friendly_name->uri);
+				sizeof(friendly_name->call_index) + strlen(friendly_name->name);
 
 			ret = bt_gatt_attr_read(conn, attr, buf, len, offset, friendly_name,
 						val_len);
@@ -2772,7 +2772,8 @@ static void tbs_inst_remote_incoming(struct tbs_inst *inst, const char *to, cons
 
 	if (friendly_name) {
 		inst->friendly_name.call_index = call->index;
-		utf8_lcpy(inst->friendly_name.uri, friendly_name, sizeof(inst->friendly_name.uri));
+		utf8_lcpy(inst->friendly_name.name, friendly_name,
+			  sizeof(inst->friendly_name.name));
 	} else {
 		inst->friendly_name.call_index = BT_TBS_FREE_CALL_INDEX;
 	}

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -1,7 +1,7 @@
 /*  Bluetooth TBS - Telephone Bearer Service - Client
  *
  * Copyright (c) 2020 Bose Corporation
- * Copyright (c) 2021-2024 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -32,6 +32,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
+#include "common/bt_str.h"
 #include "tbs_internal.h"
 
 LOG_MODULE_REGISTER(bt_tbs_client, CONFIG_BT_TBS_CLIENT_LOG_LEVEL);
@@ -54,7 +55,13 @@ LOG_MODULE_REGISTER(bt_tbs_client, CONFIG_BT_TBS_CLIENT_LOG_LEVEL);
 
 BUILD_ASSERT(CONFIG_BT_ATT_TX_COUNT >= TBS_CLIENT_BUF_COUNT, "Too few ATT buffers");
 
-#include "common/bt_str.h"
+/* The maximum size of all supported string values */
+#define MAX_STR_LEN                                                                                \
+	MAX(CONFIG_BT_TBS_MAX_URI_LENGTH,                                                          \
+	    (MAX(COND_CODE_1(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME,                            \
+			     (CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH), (0U)),                      \
+		 COND_CODE_1(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME,                              \
+			     (CONFIG_BT_TBS_MAX_FRIENDLY_NAME_LENGTH), (0U)))))
 
 struct bt_tbs_server_inst {
 #if defined(CONFIG_BT_TBS_CLIENT_TBS)
@@ -353,10 +360,10 @@ static void call_cp_callback_handler(struct bt_conn *conn, int err,
 }
 #endif /* defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES) */
 
-const char *parse_string_value(const void *data, uint16_t length,
-				      uint16_t max_len)
+__maybe_unused static const char *parse_string_value(const void *data, uint16_t length,
+						     uint16_t max_len)
 {
-	static char string_val[CONFIG_BT_TBS_MAX_URI_LENGTH + 1];
+	static char string_val[MAX_STR_LEN + 1];
 	const size_t len = MIN(length, max_len);
 
 	if (len != 0) {
@@ -671,8 +678,7 @@ static void friendly_name_notify_handler(struct bt_conn *conn,
 					 const struct bt_tbs_instance *tbs_inst,
 					 const void *data, uint16_t length)
 {
-	const char *name = parse_string_value(data, length,
-					      CONFIG_BT_TBS_MAX_URI_LENGTH);
+	const char *name = parse_string_value(data, length, CONFIG_BT_TBS_MAX_FRIENDLY_NAME_LENGTH);
 
 	LOG_DBG("%s", name);
 

--- a/subsys/bluetooth/audio/tbs_internal.h
+++ b/subsys/bluetooth/audio/tbs_internal.h
@@ -47,9 +47,6 @@
 #define BT_TBS_CALL_FLAG_SET_INCOMING(flag) (flag &= ~BT_TBS_CALL_FLAG_OUTGOING)
 #define BT_TBS_CALL_FLAG_SET_OUTGOING(flag) (flag |= BT_TBS_CALL_FLAG_OUTGOING)
 
-const char *parse_string_value(const void *data, uint16_t length,
-				      uint16_t max_len);
-
 static inline const char *bt_tbs_state_str(uint8_t state)
 {
 	switch (state) {
@@ -289,6 +286,11 @@ struct bt_tbs_current_call_item {
 struct bt_tbs_in_uri {
 	uint8_t call_index;
 	char uri[CONFIG_BT_TBS_MAX_URI_LENGTH + 1];
+} __packed;
+
+struct bt_tbs_friendly_name {
+	uint8_t call_index;
+	char name[CONFIG_BT_TBS_MAX_FRIENDLY_NAME_LENGTH + 1];
 } __packed;
 
 #if defined(CONFIG_BT_TBS_CLIENT)


### PR DESCRIPTION
The friendly name buffer sizes used the URI length, but since the friendly name is specifically not an URI that did not make sense. Added a new Kconfig option to configure the maximum supported friendly name, which is shared between both TBS and the TBS client, similar to the other max Kconfig options.