### PR TITLE
drivers: allow for two different infineon clock init flows

### DIFF
--- a/drivers/clock_control/Kconfig.infineon
+++ b/drivers/clock_control/Kconfig.infineon
@@ -35,16 +35,12 @@ config CLOCK_CONTROL_IFX_PERI_CLOCK
 
 
 if CLOCK_CONTROL_IFX_FIXED_FACTOR_CLOCK
-
 config CLOCK_CONTROL_IFX_FIXED_FACTOR_CLOCK_INIT_PRIORITY
 	int "Infineon fixed factor clock driver init priority"
-	default 31
+	default 29 if !SOC_FAMILY_INFINEON_PSOC4
+	default 31 if SOC_FAMILY_INFINEON_PSOC4
 	help
 	  Infineon fixed factor clock control driver initialization priority.
-	  This should be higher than CLOCK_CONTROL_INIT_PRIORITY to ensure
-	  fixed-rate clocks are initialized before fixed-factor clocks that
-	  depend on them.Since fixed-factor clocks depend on fixed-rate clocks,
-	  they need a HIGHER priority number so they initialize after their
-	  dependencies.
-
+	  This should be lower than the priority of fixed factor clock driver
+	  to ensure the clock paths are initialized before.
 endif # CLOCK_CONTROL_IFX_FIXED_FACTOR_CLOCK


### PR DESCRIPTION
- differentiate fixed_factor init priority based on soc family
- hotfix for a clash in clock flow caused by[ pull/98564](https://github.com/zephyrproject-rtos/zephyr/pull/98564), causing existing boards to have init issues