### PR TITLE
boards: nxp: mimxrt1180_evk: enable CM7 execution from hyperram

### DIFF
--- a/boards/nxp/mimxrt1180_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1180_evk/Kconfig.defconfig
@@ -29,17 +29,18 @@ config BUILD_OUTPUT_INFO_HEADER
 	default y
 
 DT_CHOSEN_IMAGE_M7 = nxp,m7-partition
+DT_CHOSEN_ZEPHYR_FLASH = zephyr,flash
 
-# Only adjust LMA if running from ITCM
+# Only adjust LMA if running from RAM
 if !CM7_BOOT_FROM_FLASH
 
-# Adjust the offset of the output image if building for RT118x SOC ITCM
+# Adjust the offset of the output image if building for RT118x SOC in RAM
 FLEXSPI_BASE := $(dt_nodelabel_reg_addr_hex,flexspi,1)
-ITCM_BASE := $(dt_nodelabel_reg_addr_hex,itcm,1)
+M7_CODE_BASE := $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_ZEPHYR_FLASH))
 IMAGE_M7_ADDR := $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_M7))
 
 config BUILD_OUTPUT_ADJUST_LMA
-	default "($(IMAGE_M7_ADDR) + $(FLEXSPI_BASE) - $(ITCM_BASE))"
+	default "($(IMAGE_M7_ADDR) + $(FLEXSPI_BASE) - $(M7_CODE_BASE))"
 
 endif # !CM7_BOOT_FROM_FLASH
 endif # SECOND_CORE_MCUX && BOARD_MIMXRT1180_EVK_MIMXRT1189_CM7

--- a/boards/nxp/mimxrt1180_evk/cm33_sram_dtcm.overlay
+++ b/boards/nxp/mimxrt1180_evk/cm33_sram_dtcm.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Remove property from DTCM: zephyr,memory-region = "DTCM"; */
+/delete-node/ &dtcm;
+
+/ {
+	chosen {
+		zephyr,sram = &dtcm;
+	};
+
+	soc {
+		dtcm: memory@30000000 {
+			compatible = "nmmio-sram";
+			reg = <0x30000000 DT_SIZE_K(128)>;
+		};
+	};
+};

--- a/boards/nxp/mimxrt1180_evk/cm7_code_hyperram.overlay
+++ b/boards/nxp/mimxrt1180_evk/cm7_code_hyperram.overlay
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+
+/ {
+	chosen {
+		zephyr,flash = &hyperram0;
+		zephyr,code-partition = &slot1_partition;
+	};
+};
+
+&flexspi2 {
+	status = "okay";
+};
+
+&hyperram0 {
+	/*
+	 * Currently, HyperRAM on this board must be accessed under XIP mode,
+	 * so that the ROM bootloader can initialize it by reading the XMCD configuration.
+	 * These XMCD configurations are stored in the default settings file
+	 * `xip/evkmimxrt1180_flexspi_nor_config.c`. (If modifications are needed,
+	 * please refer to the examples and the "System Boot" chapter in the
+	 * RT1180 Reference Manual.)
+	 * The CM33 core of the MIMXRT1180_EVK runs in XIP mode and uses the
+	 * HyperRAM space as the RAM region by default. Therefore, the status of the
+	 * full hyperram0 memory node is set to "okay" for cm33 core.
+	 * At this point, the CM7 core can also access the HyperRAM.
+	 * However, since the entire HyperRAM region is occupied in the CM33's DTS,
+	 * users can allocate the HyperRAM reasonably so that both cores (CM33 and CM7)
+	 * can use HyperRAM as their RAM region.
+	 *
+	 * If not configured by the ROM bootloader, the user must ensure the hyperram0
+	 * device is enabled in the DTS, otherwise, the user must set 'status = "disabled";
+	 * Note: mpu_region.c uses the status property from the DTS to configure the
+	 * corresponding MPU settings.
+	 */
+	zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_FLASH)>;
+	status = "okay";
+};


### PR DESCRIPTION
* adds CM7 HyperRAM overlay and documentation
* removes hardcoded Kconfig settings for ITCM
* adds example cm33_sram_dtcm.overlay

Resolves #97674 