### PR TITLE
Support mipi dbi color coding

### DIFF
--- a/dts/bindings/mipi-dbi/mipi-dbi-device.yaml
+++ b/dts/bindings/mipi-dbi/mipi-dbi-device.yaml
@@ -27,6 +27,20 @@ properties:
       - "MIPI_DBI_MODE_8080_BUS_9_BIT"
       - "MIPI_DBI_MODE_8080_BUS_8_BIT"
 
+  color-coding:
+    type: string
+    description: |
+      Color coding for MIPI DBI Type A or Type B(6800/8080) interface. These definitions
+      should match those in dt-bindings/mipi_dbi/mipi_dbi.h
+    enum:
+      - "MIPI_DBI_MODE_RGB332"
+      - "MIPI_DBI_MODE_RGB444"
+      - "MIPI_DBI_MODE_RGB565"
+      - "MIPI_DBI_MODE_RGB666_1"
+      - "MIPI_DBI_MODE_RGB666_2"
+      - "MIPI_DBI_MODE_RGB888_1"
+      - "MIPI_DBI_MODE_RGB888_2"
+
   te-mode:
     type: string
     default: "MIPI_DBI_TE_NO_EDGE"

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -157,6 +157,8 @@ extern "C" {
 struct mipi_dbi_config {
 	/** MIPI DBI mode */
 	uint8_t mode;
+	/** MIPI DBI color coding for Type A or Type B(6800/8080) interface. */
+	uint8_t color_coding;
 	/** SPI configuration */
 	struct spi_config config;
 };

--- a/include/zephyr/dt-bindings/mipi_dbi/mipi_dbi.h
+++ b/include/zephyr/dt-bindings/mipi_dbi/mipi_dbi.h
@@ -160,15 +160,15 @@
  */
 #define MIPI_DBI_MODE_RGB666_2 (0x5 << 4U)
 /**
- * RGB666 (18 bpp).
+ * RGB888 (24 bpp).
  *
- * - For 8-bit data bus width, #MIPI_DBI_MODE_RGB666_1 and #MIPI_DBI_MODE_RGB666_2 are the same.
+ * - For 8-bit data bus width, #MIPI_DBI_MODE_RGB888_1 and #MIPI_DBI_MODE_RGB888_2 are the same.
  *   1 pixel is sent in 3 cycles, R component first.
- * - For 16-bit data bus width, #MIPI_DBI_MODE_RGB666_1 is option 1, 2 pixels are sent in 3 cycles.
+ * - For 16-bit data bus width, #MIPI_DBI_MODE_RGB888_1 is option 1, 2 pixels are sent in 3 cycles.
  *   The first pixel's R/G/B components are sent in cycle 1 bits 8-15, cycle 1 bits 0-7 and cycle 2
  *   bits 0-15. The second pixel's R/G/B components are sent in cycle 2 bits 0-7, cycle 3 bits 8-15
  *   and cycle 3 bits 0-7.
- *   #MIPI_DBI_MODE_RGB666_2 is option 2, 1 pixel is sent in 2 cycles. The pixel's R/G/B components
+ *   #MIPI_DBI_MODE_RGB888_2 is option 2, 1 pixel is sent in 2 cycles. The pixel's R/G/B components
  *   are sent in cycle 1 bits 0-7, cycle 2 bits 8-15 and cycle 2 bits 0-7.
  */
 #define MIPI_DBI_MODE_RGB888_1 (0x6 << 4U)


### PR DESCRIPTION
Add support of color coding in mipi-dbi-device binding property. The color coding is defined by MIPI Alliance Standard for
Display Bus Interface v2.0, which is required by some display controllers and device.