### PR TITLE
Add RTC driver support for microchip pic32cx sg family

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -26,6 +26,7 @@
 		led0 = &led1;
 		sw0 = &button0;
 		pwm-led0 = &pwm_led0;
+		rtc = &rtc;
 	};
 
 	leds {
@@ -66,6 +67,11 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+};
+
+&rtc {
+	prescaler = <1024>;
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -16,5 +16,6 @@ supported:
   - gpio
   - pinctrl
   - pwm
+  - rtc
   - uart
 vendor: microchip

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -26,6 +26,7 @@
 		led0 = &led1;
 		sw0 = &button0;
 		pwm-led0 = &pwm_led0;
+		rtc = &rtc;
 	};
 
 	leds {
@@ -60,6 +61,11 @@
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};
+};
+
+&rtc {
+	prescaler = <1024>;
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -16,5 +16,6 @@ supported:
   - gpio
   - pinctrl
   - pwm
+  - rtc
   - uart
 vendor: microchip

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -87,6 +87,19 @@
 			};
 		};
 
+		rtc: rtc@40002400 {
+			compatible = "microchip,rtc-g1";
+			reg = <0x40002400 0x400>;
+			interrupts = <11 0>;
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBA_RTC>,
+				 <&rtcclock CLOCK_MCHP_RTC_ID>;
+			clock-names = "mclk", "rtcclk";
+			prescaler = <1>;
+			alarms-count = <2>;
+			cal-constant = <1048576>;
+			status = "disabled";
+		};
+
 		sercom0: sercom@40003000 {
 			compatible = "microchip,sercom-g1";
 			reg = <0x40003000 0x29>;

--- a/tests/drivers/rtc/rtc_api/boards/pic32cx_sg41_cult.conf
+++ b/tests/drivers/rtc/rtc_api/boards/pic32cx_sg41_cult.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_ALARM=y
+CONFIG_TEST_RTC_ALARM_TIME_MASK=63
+CONFIG_RTC_CALIBRATION=y

--- a/tests/drivers/rtc/rtc_api/boards/pic32cx_sg61_cult.conf
+++ b/tests/drivers/rtc/rtc_api/boards/pic32cx_sg61_cult.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_ALARM=y
+CONFIG_TEST_RTC_ALARM_TIME_MASK=63
+CONFIG_RTC_CALIBRATION=y


### PR DESCRIPTION
- Add the device tree node for microchip RTC G1 IP.
- Add RTC node in pic32cx_sg41_cult.dts.
- Update pic32cx_sg41_cult.yaml to reflect RTC G1 support on the board.
- Add RTC node in pic32cx_sg61_cult.dts.
- Update pic32cx_sg61_cult.yaml to reflect RTC G1 support on the board.
- Added pic32cx_sg41_cult.conf and pic32cx_sg61_cult.conf files in tests.