### PR TITLE
pm: device: add Wakeup Controller integration support

### DIFF
--- a/dts/bindings/base/pm.yaml
+++ b/dts/bindings/base/pm.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2021 Intel Corporation.
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 # Properties for Power Management (PM)
@@ -26,3 +27,14 @@ properties:
     type: phandles
     description: |
       List of power states that will disable this device power.
+
+  wakeup-ctrls:
+    type: phandle-array
+    description: |
+      Phandle to the wakeup controller used by this device.
+
+  '#wakeup-ctrl-cells':
+    type: int
+    const: 1
+    description: |
+      Number of cells in wakeup-ctrl property.

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -1,5 +1,6 @@
 # Copyright (c) 2014-2015 Wind River Systems, Inc.
 # Copyright (c) 2016 Intel Corporation
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 menu "Power Management"
@@ -126,6 +127,14 @@ config PM_DEVICE_RUNTIME
 	  Enable Runtime Power Management to save power. With device runtime PM
 	  enabled, devices can be suspended or resumed based on the device
 	  usage even while the CPU or system is running.
+
+config PM_WAKEUP_CONTROLLER
+	bool "Wakeup Controller Support"
+	default y
+	depends on WUC
+	help
+	  Enable support for Wakeup Controllers. When enabled, devices can be
+	  associated with a wakeup controller to manage wakeup events.
 
 if PM_DEVICE_RUNTIME
 


### PR DESCRIPTION
Depends on: #100559

Integrate Wakeup Controller (WUC) support into the power management
device infrastructure. This allows devices to be associated with wakeup
controllers to manage wakeup events during low-power states.

The changes include:

1. Add `pm_wuc_config` structure to store wakeup controller device
   reference and source argument
2. Extend `pm_device_base` structure with wakeup controller count and
   configuration array
3. Add device tree binding support for `wakeup-ctrls` property to
   associate devices with wakeup controllers
4. Implement wakeup controller enable/disable in `pm_device_wakeup_enable()`
   to automatically configure wakeup sources when device wakeup is enabled
   or disabled
5. Add `CONFIG_PM_WAKEUP_CONTROLLER` Kconfig option to enable this feature

When enabled, devices can specify wakeup controllers in their device tree
nodes, and the PM subsystem will automatically manage the wakeup source
configuration through the WUC driver API.

Signed-off-by: Albort Xue <yao.xue@nxp.com>