### PR TITLE
soc: renesas: rzv: Fix pin function bitfield

### DIFF
--- a/soc/renesas/rz/common/pinctrl_rzv.h
+++ b/soc/renesas/rz/common/pinctrl_rzv.h
@@ -25,7 +25,7 @@ typedef struct pinctrl_cfg_data_t {
 	uint32_t filonoff_reg: 1;
 	uint32_t filnum_reg: 2;
 	uint32_t filclksel_reg: 2;
-	uint32_t pfc_reg: 3;
+	uint32_t pfc_reg: 4;
 } pinctrl_cfg_data_t;
 
 typedef struct pinctrl_soc_pin_t {


### PR DESCRIPTION
Adjust the pin function bitfield to 4 bits to fit all RZ/V SoCs (RZ/V2L, V2H, V2N). PFC bitfield of RZ/VH, V2N have 4 bits, so the current 3-bit width does not fit them.