### PR TITLE
manifest: update hal_renesas rev to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -231,7 +231,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: 69c3df17e3788f1ba8c7ace191e21e20bbd8d641
+      revision: 0164f2f515ad196674103f33cab10a7d547ce3cf
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Fix the Renesas RA UDC not sending ZLP at the end of the control data phase