### PR TITLE
drivers: timer: mcux_lptmr: add Wakeup Controller integration

### DIFF
--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -12,6 +12,7 @@
 #include <zephyr/sys/time_units.h>
 #include <fsl_lptmr.h>
 #include <zephyr/irq.h>
+#include <zephyr/drivers/wuc.h>
 
 BUILD_ASSERT(DT_HAS_CHOSEN(zephyr_system_timer),
 	     "zephyr,system-timer must be set to an nxp,lptmr node");
@@ -131,6 +132,12 @@ void sys_clock_idle_exit(void)
 
 void sys_clock_disable(void)
 {
+	const struct wuc_dt_spec wuc = WUC_DT_SPEC_INST_GET_OR(0, {0});
+
+	if (wuc.dev != NULL) {
+		(void)wuc_disable_wakeup_source_dt(&wuc);
+	}
+
 	LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
 	LPTMR_StopTimer(LPTMR_BASE);
 }
@@ -180,6 +187,11 @@ static void mcux_lptmr_timer_isr(const void *arg)
 static int sys_clock_driver_init(void)
 {
 	lptmr_config_t config;
+	const struct wuc_dt_spec wuc = WUC_DT_SPEC_INST_GET_OR(0, {0});
+
+	if ((wuc.dev != NULL) && (wuc_enable_wakeup_source_dt(&wuc) != 0)) {
+		return -EIO;
+	}
 
 	LPTMR_GetDefaultConfig(&config);
 	config.timerMode = kLPTMR_TimerModeTimeCounter;

--- a/dts/bindings/counter/nxp,lptmr.yaml
+++ b/dts/bindings/counter/nxp,lptmr.yaml
@@ -5,7 +5,7 @@ description: NXP LPTMR
 
 compatible: "nxp,lptmr"
 
-include: rtc.yaml
+include: [rtc.yaml, wuc-device.yaml]
 
 properties:
   reg:


### PR DESCRIPTION
Fix: https://github.com/zephyrproject-rtos/zephyr/issues/100853
Depends on: #100559
Integrate Wakeup Controller (WUC) support into the MCUX LPTMR timer driver to enable wakeup from low-power states.

The changes include:

1. Add conditional WUC header inclusion when both `CONFIG_PM_WAKEUP_CONTROLLER` is enabled and device tree properties `wakeup-ctrls` and `wakeup-source` are present
2. Define macros to extract WUC device reference and source ID from device tree using `wakeup-ctrls` property
3. Enable wakeup source in `sys_clock_driver_init()` during timer initialization
   - Return `-EIO` if wakeup source enable fails
4. Disable wakeup source in `sys_clock_disable()` when timer is stopped

This allows the LPTMR timer to act as a wakeup source and be managed by the WUC subsystem when the system enters low-power states.