### PR TITLE
soc: nxp: mcxw7xx: migrate to Wakeup Controller subsystem

### DIFF
--- a/drivers/wuc/CMakeLists.txt
+++ b/drivers/wuc/CMakeLists.txt
@@ -5,5 +5,5 @@ zephyr_library()
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_WUC_MCUX_LLWU wuc_nxp_llwu.c)
-
+zephyr_library_sources_ifdef(CONFIG_WUC_MCUX_WUU wuc_nxp_wuu.c)
 # zephyr-keep-sorted-stop

--- a/drivers/wuc/Kconfig.mcux_wuc
+++ b/drivers/wuc/Kconfig.mcux_wuc
@@ -7,3 +7,10 @@ config WUC_MCUX_LLWU
 	depends on DT_HAS_NXP_LLWU_ENABLED
 	help
 	  Enable support for NXP LLWU(Low Leakage Wakeup Unit) wakeup controller driver.
+
+config WUC_MCUX_WUU
+	bool "NXP WUU wakeup control"
+	default y
+	depends on DT_HAS_NXP_WUC_WUU_ENABLED
+	help
+		Enable support for NXP WUU (Wakeup Unit) wakeup controller driver.

--- a/drivers/wuc/wuc_nxp_wuu.c
+++ b/drivers/wuc/wuc_nxp_wuu.c
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2025-2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_wuc_wuu
+
+#include <zephyr/init.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/logging/log.h>
+
+#include <fsl_wuu.h>
+#include <zephyr/drivers/wuc.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
+
+LOG_MODULE_REGISTER(mcux_wuu, CONFIG_WUC_LOG_LEVEL);
+
+struct mcux_wuu_config {
+	WUU_Type *base;
+	uint32_t irqn;
+};
+
+struct mcux_wuu_data {
+	uint32_t triggered_pin_sources;
+	struct k_spinlock lock;
+};
+
+/** Union of WUU wakeup event types */
+union wuu_wakeup_event {
+	/** Pin event type */
+	wuu_external_wakeup_pin_event_t pin_event;
+	/** Module event type */
+	wuu_internal_wakeup_module_event_t module_event;
+};
+
+struct wakeup_source_detail {
+	int8_t type;
+	uint8_t index;
+	wuu_external_pin_edge_detection_t edge;
+	union wuu_wakeup_event event;
+} __packed;
+
+static const char * const module_event_name[] = {
+	"Interrupt",
+	"DMA Trigger",
+};
+
+static const char * const pin_edge_name[] = {
+	"Disabled",
+	"Rising Edge",
+	"Falling Edge",
+	"Any Edge",
+};
+
+static const char * const pin_event_name[] = {
+	"Interrupt",
+	"DMA Request",
+	"Trigger",
+};
+
+static void mcux_wuu_isr(const struct device *dev)
+{
+	const struct mcux_wuu_config *config = (const struct mcux_wuu_config *)dev->config;
+	struct mcux_wuu_data *data = (struct mcux_wuu_data *)dev->data;
+	uint32_t triggered;
+
+	triggered = WUU_GetExternalWakeUpPinsFlag(config->base);
+	WUU_ClearExternalWakeUpPinsFlag(config->base, triggered);
+
+	data->triggered_pin_sources = triggered;
+}
+
+static void mcux_wuu_decode_source(struct wakeup_source_detail *detail, uint32_t source)
+{
+	memset((void *)detail, 0, sizeof(struct wakeup_source_detail));
+
+	detail->type = NXP_WUU_WAKEUP_SOURCE_DECODE_TYPE(source);
+	detail->index = NXP_WUU_WAKEUP_SOURCE_DECODE_INDEX(source);
+	if (detail->type == NXP_WUU_SOURCE_TYPE_PIN) {
+		detail->edge = (wuu_external_pin_edge_detection_t)NXP_WUU_WAKEUP_SOURCE_DECODE_EDGE(
+			source);
+		detail->event.pin_event =
+			(wuu_external_wakeup_pin_event_t)NXP_WUU_WAKEUP_SOURCE_DECODE_EVENT(source);
+	} else if (detail->type == NXP_WUU_SOURCE_TYPE_MODULE) {
+		detail->event.module_event =
+			(wuu_internal_wakeup_module_event_t)NXP_WUU_WAKEUP_SOURCE_DECODE_EVENT(
+				source);
+	} else {
+		LOG_ERR("Invalid wakeup source type %d", detail->type);
+	}
+}
+
+static int mcux_wuu_enable_wakeup_source(const struct device *dev, uint32_t source)
+{
+	const struct mcux_wuu_config *config = (const struct mcux_wuu_config *)dev->config;
+	struct wakeup_source_detail detail;
+	int ret = 0;
+
+	mcux_wuu_decode_source(&detail, source);
+
+	if (detail.type == NXP_WUU_SOURCE_TYPE_MODULE) {
+		WUU_SetInternalWakeUpModulesConfig(
+			config->base, detail.index,
+			(wuu_internal_wakeup_module_event_t)detail.event.module_event);
+		LOG_DBG("WUU module %d, %s enabled as wakeup source", detail.index,
+			module_event_name[(uint8_t)detail.event.module_event]);
+	} else if (detail.type == NXP_WUU_SOURCE_TYPE_PIN) {
+		wuu_external_wakeup_pin_config_t pin_config = {
+			.edge = (wuu_external_pin_edge_detection_t)detail.edge,
+			.event = (wuu_external_wakeup_pin_event_t)detail.event.pin_event,
+			.mode = kWUU_ExternalPinActiveDSPD,
+		};
+		WUU_SetExternalWakeUpPinsConfig(config->base, detail.index, &pin_config);
+
+		if (pin_config.event == kWUU_ExternalPinInterrupt) {
+			/* Pin interrupt event requires IRQ to be enabled */
+			irq_enable(config->irqn);
+		}
+
+		LOG_DBG("WUU external pin %d %s %s enabled as wakeup source", detail.index,
+			pin_edge_name[(uint8_t)pin_config.edge],
+			pin_event_name[(uint8_t)pin_config.event]);
+	} else {
+		ret = -ENOTSUP;
+	}
+
+	return ret;
+}
+
+static int mcux_wuu_disable_wakeup_source(const struct device *dev, uint32_t source)
+{
+	const struct mcux_wuu_config *config = (const struct mcux_wuu_config *)dev->config;
+	struct wakeup_source_detail detail;
+	int ret = 0;
+
+	mcux_wuu_decode_source(&detail, source);
+
+	if (detail.type == NXP_WUU_SOURCE_TYPE_MODULE) {
+		WUU_ClearInternalWakeUpModulesConfig(
+			config->base, detail.index,
+			(wuu_internal_wakeup_module_event_t)detail.event.module_event);
+
+		LOG_DBG("WUU module %d %s disabled as wakeup source", detail.index,
+			module_event_name[(uint8_t)detail.event.module_event]);
+	} else if (detail.type == NXP_WUU_SOURCE_TYPE_PIN) {
+		WUU_ClearExternalWakeupPinsConfig(config->base, detail.index);
+		if ((detail.event.pin_event == kWUU_ExternalPinInterrupt) &&
+		    (config->base->PE1 == 0) && (config->base->PE2 == 0)) {
+			/* Disable wuu interrupt, if none of pin interrupt events are enabled */
+			irq_disable(config->irqn);
+		}
+		LOG_DBG("WUU external pin %d %s %s disabled as wakeup source", detail.index,
+			pin_edge_name[(uint8_t)detail.edge],
+			pin_event_name[(uint8_t)detail.event.pin_event]);
+	} else {
+		ret = -ENOTSUP;
+	}
+
+	return ret;
+}
+
+static int mcux_wuu_check_wakeup_source_triggered(const struct device *dev, uint32_t source)
+{
+#if (defined(FSL_FEATURE_WUU_HAS_MF) && FSL_FEATURE_WUU_HAS_MF)
+	const struct mcux_wuu_config *config = (const struct mcux_wuu_config *)dev->config;
+#endif
+	struct mcux_wuu_data *data = (struct mcux_wuu_data *)dev->data;
+	struct wakeup_source_detail detail;
+	int ret = 0;
+
+	mcux_wuu_decode_source(&detail, source);
+	if (detail.type == NXP_WUU_SOURCE_TYPE_MODULE) {
+#if (defined(FSL_FEATURE_WUU_HAS_MF) && FSL_FEATURE_WUU_HAS_MF)
+		ret = WUU_GetInternalWakeupModuleFlag(config->base, detail.index) ? 1 : 0;
+#else
+		ret = -ENOTSUP;
+#endif
+	} else if (detail.type == NXP_WUU_SOURCE_TYPE_PIN) {
+		ret = (data->triggered_pin_sources & BIT(detail.index)) ? 1 : 0;
+	} else {
+		ret = -ENOTSUP;
+	}
+
+	return ret;
+}
+
+static int mcux_wuu_clear_wakeup_source_triggered(const struct device *dev, uint32_t id)
+{
+	struct mcux_wuu_data *data = dev->data;
+
+	if (NXP_WUU_IS_PIN_SOURCE(id)) {
+		K_SPINLOCK(&data->lock) {
+			data->triggered_pin_sources &= ~BIT(NXP_WUU_WAKEUP_SOURCE_DECODE_INDEX(id));
+		}
+	}
+
+	return 0;
+}
+
+static int mcux_wuu_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(action);
+
+	return 0;
+}
+
+static int mcux_wuu_init(const struct device *dev)
+{
+	struct mcux_wuu_data *data = (struct mcux_wuu_data *)dev->data;
+
+	IRQ_CONNECT(DT_IRQN(DT_DRV_INST(0)), DT_IRQ(DT_DRV_INST(0), priority), mcux_wuu_isr,
+		    DEVICE_DT_INST_GET(0), 0);
+
+	data->triggered_pin_sources = 0;
+
+	return pm_device_driver_init(dev, mcux_wuu_pm_action);
+}
+
+static struct mcux_wuu_config wuu_config = {
+	.base = (WUU_Type *)DT_REG_ADDR(DT_DRV_INST(0)),
+	.irqn = DT_IRQN(DT_DRV_INST(0)),
+};
+
+static struct mcux_wuu_data wuu_data;
+
+static const DEVICE_API(wuc, wuu_api) = {
+	.enable = mcux_wuu_enable_wakeup_source,
+	.disable = mcux_wuu_disable_wakeup_source,
+	.triggered = mcux_wuu_check_wakeup_source_triggered,
+	.clear = mcux_wuu_clear_wakeup_source_triggered,
+};
+
+DEVICE_DT_INST_DEFINE(0, mcux_wuu_init, NULL, &wuu_data, &wuu_config, PRE_KERNEL_1,
+		      WUC_INIT_PRIORITY, &wuu_api);

--- a/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
@@ -377,9 +377,10 @@
 	};
 
 	wuu_0: system-modules@14000 {
-		compatible = "nxp,wuu";
+		compatible = "nxp,wuc-wuu", "nxp,wuu";
 		reg = <0x14000 0x5c>;
 		interrupts = <24 0>;
+		#wakeup-ctrl-cells = <1>;
 	};
 
 	scg_0: clock-controller@2000 {

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 
 / {
 	aliases {

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -189,9 +189,10 @@
 	};
 
 	wuu: system-modules@19000 {
-		compatible = "nxp,wuu";
+		compatible = "nxp,wuc-wuu", "nxp,wuu";
 		reg = <0x19000 0x1000>;
 		interrupts = <22 0>;
+		#wakeup-ctrl-cells = <1>;
 	};
 
 	clk_ctrl: clock-controller {
@@ -422,6 +423,8 @@
 		prescale-glitch-filter-bypass;
 		resolution = <32>;
 		status = "disabled";
+		wakeup-source;
+		wakeup-ctrls = <&wuu NXP_WUU_MODULE_0_INT>;
 	};
 
 	lptmr1: timer@2e000 {
@@ -443,6 +446,7 @@
 		/* Max TX power can be overridden by the board */
 		max-tx-power-dbm = <7>;
 		wakeup-source;
+		wakeup-ctrls = <&wuu NXP_WUU_MODULE_2_DMA>;
 	};
 
 	hci: hci_ble {

--- a/dts/bindings/arm/nxp,nbu.yaml
+++ b/dts/bindings/arm/nxp,nbu.yaml
@@ -3,7 +3,7 @@
 
 description: NXP NBU interruption information
 
-include: [base.yaml, pinctrl-device.yaml]
+include: [base.yaml, pinctrl-device.yaml, wuc-device.yaml]
 
 compatible: "nxp,nbu"
 

--- a/dts/bindings/wuc/nxp,wuc-wuu.yaml
+++ b/dts/bindings/wuc/nxp,wuc-wuu.yaml
@@ -1,0 +1,33 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  NXP Wakeup Unit (WUU) acting as a Wakeup Controller (WUC).
+
+  This binding is used by SoCs that consume the WUU through the WUC
+  subsystem (i.e. via "wakeup-ctrls" properties), and therefore must
+  declare the "#wakeup-ctrl-cells" property required by wuc-controller.
+
+  SoCs that only need the legacy "nxp,wuu" interrupt-controller view
+  should keep using the binding under
+  dts/bindings/interrupt-controller/nxp,wuu.yaml.
+
+compatible: "nxp,wuc-wuu"
+
+include: [base.yaml, wuc-controller.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  '#wakeup-ctrl-cells':
+    type: int
+    const: 1
+    description: |
+      Number of cells in wakeup-ctrls property.
+
+wakeup-ctrl-cells:
+  - id

--- a/include/zephyr/dt-bindings/wuc/wuc_nxp_wuu.h
+++ b/include/zephyr/dt-bindings/wuc/wuc_nxp_wuu.h
@@ -1,0 +1,802 @@
+/*
+ * Copyright (c) 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief NXP WUU (Wakeup Unit) wakeup-source encoding helpers.
+ *
+ * Defines the bit-field layout used to encode a WUU wakeup source as a
+ * single 32-bit value, plus helper macros to build and decode such
+ * values for use with the NXP WUU driver and devicetree wakeup-source
+ * properties.
+ *
+ * Wakeup source encoding:
+ *   Bits [31:24] - Source type (0=PIN, 1=MODULE)
+ *   Bits [23:16] - Index (pin/module number)
+ *   Bits [15:8]  - Edge type (1=RISING, 2=FALLING, 3=ANY) - for PIN only
+ *   Bits [7:0]   - Event type (0=INT, 1=DMA, 2=TRIGGER)
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_WUC_NXP_WUU_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_WUC_NXP_WUU_H_
+
+/** Bit position of the source-type field in an encoded wakeup source. */
+#define NXP_WUU_SOURCE_TYPE_POS  24
+/** Bit position of the index field (pin or module number). */
+#define NXP_WUU_SOURCE_INDEX_POS 16
+/** Bit position of the edge-type field (PIN sources only). */
+#define NXP_WUU_SOURCE_EDGE_POS  8
+/** Bit position of the event-type field. */
+#define NXP_WUU_SOURCE_EVENT_POS 0
+
+/** Mask covering one 8-bit field of the encoded wakeup source. */
+#define NXP_WUU_SOURCE_MASK 0xFF
+
+/** Source-type value: external WUU pin. */
+#define NXP_WUU_SOURCE_TYPE_PIN    0
+/** Source-type value: internal peripheral module. */
+#define NXP_WUU_SOURCE_TYPE_MODULE 1
+
+/** Edge-type value: trigger on rising edge. */
+#define NXP_WUU_EDGE_RISING  1
+/** Edge-type value: trigger on falling edge. */
+#define NXP_WUU_EDGE_FALLING 2
+/** Edge-type value: trigger on any edge. */
+#define NXP_WUU_EDGE_ANY     3
+
+/** Event-type value: deliver as interrupt. */
+#define NXP_WUU_EVENT_INT     0
+/** Event-type value: deliver as DMA request. */
+#define NXP_WUU_EVENT_DMA     1
+/** Event-type value: deliver as trigger output. */
+#define NXP_WUU_EVENT_TRIGGER 2
+
+/**
+ * @brief Encode a WUU wakeup source into a single 32-bit value.
+ *
+ * @param type  Source type (NXP_WUU_SOURCE_TYPE_PIN or NXP_WUU_SOURCE_TYPE_MODULE).
+ * @param index Pin or module index.
+ * @param edge  Edge type (NXP_WUU_EDGE_*); ignored for MODULE sources.
+ * @param event Event type (NXP_WUU_EVENT_*).
+ */
+#define NXP_WUU_WAKEUP_SOURCE_ENCODE(type, index, edge, event)                                     \
+	(((type) << NXP_WUU_SOURCE_TYPE_POS) | ((index) << NXP_WUU_SOURCE_INDEX_POS) |             \
+	 ((edge) << NXP_WUU_SOURCE_EDGE_POS) | ((event) << NXP_WUU_SOURCE_EVENT_POS))
+
+/**
+ * @brief Extract one 8-bit field from an encoded wakeup source.
+ *
+ * @param source Encoded wakeup source value.
+ * @param pos    Bit position of the field (one of NXP_WUU_SOURCE_*_POS).
+ */
+#define NXP_WUU_WAKEUP_SOURCE_DECODE(source, pos) (((source) >> (pos)) & NXP_WUU_SOURCE_MASK)
+
+/** @brief Decode the source-type field of an encoded wakeup source. */
+#define NXP_WUU_WAKEUP_SOURCE_DECODE_TYPE(source)                                                  \
+	NXP_WUU_WAKEUP_SOURCE_DECODE(source, NXP_WUU_SOURCE_TYPE_POS)
+
+/** @brief Test whether an encoded wakeup source describes a PIN source. */
+#define NXP_WUU_IS_PIN_SOURCE(source)                                                              \
+	(NXP_WUU_WAKEUP_SOURCE_DECODE_TYPE(source) == NXP_WUU_SOURCE_TYPE_PIN)
+
+/** @brief Test whether an encoded wakeup source describes a MODULE source. */
+#define NXP_WUU_IS_MODULE_SOURCE(source)                                                           \
+	(NXP_WUU_WAKEUP_SOURCE_DECODE_TYPE(source) == NXP_WUU_SOURCE_TYPE_MODULE)
+
+/** @brief Decode the index field (pin or module number). */
+#define NXP_WUU_WAKEUP_SOURCE_DECODE_INDEX(source)                                                 \
+	NXP_WUU_WAKEUP_SOURCE_DECODE(source, NXP_WUU_SOURCE_INDEX_POS)
+
+/** @brief Decode the edge-type field (only meaningful for PIN sources). */
+#define NXP_WUU_WAKEUP_SOURCE_DECODE_EDGE(source)                                                  \
+	NXP_WUU_WAKEUP_SOURCE_DECODE(source, NXP_WUU_SOURCE_EDGE_POS)
+
+/** @brief Decode the event-type field of an encoded wakeup source. */
+#define NXP_WUU_WAKEUP_SOURCE_DECODE_EVENT(source)                                                 \
+	NXP_WUU_WAKEUP_SOURCE_DECODE(source, NXP_WUU_SOURCE_EVENT_POS)
+
+/** Helper macros for PIN wakeup sources */
+#define NXP_WUU_PIN(index, edge, event)                                                            \
+	NXP_WUU_WAKEUP_SOURCE_ENCODE(NXP_WUU_SOURCE_TYPE_PIN, index, edge, event)
+
+/** Helper macros for MODULE wakeup sources */
+#define NXP_WUU_MODULE(index, event)                                                               \
+	NXP_WUU_WAKEUP_SOURCE_ENCODE(NXP_WUU_SOURCE_TYPE_MODULE, index, 0, event)
+
+/**
+ * WUU supported Internal Modules
+ */
+
+/** Module 0 interrupt event */
+#define NXP_WUU_MODULE_0_INT NXP_WUU_MODULE(0, NXP_WUU_EVENT_INT)
+/** Module 0 DMA event */
+#define NXP_WUU_MODULE_0_DMA NXP_WUU_MODULE(0, NXP_WUU_EVENT_DMA)
+
+/** Module 1 interrupt event */
+#define NXP_WUU_MODULE_1_INT NXP_WUU_MODULE(1, NXP_WUU_EVENT_INT)
+/** Module 1 DMA event */
+#define NXP_WUU_MODULE_1_DMA NXP_WUU_MODULE(1, NXP_WUU_EVENT_DMA)
+
+/** Module 2 interrupt event */
+#define NXP_WUU_MODULE_2_INT NXP_WUU_MODULE(2, NXP_WUU_EVENT_INT)
+/** Module 2 DMA event */
+#define NXP_WUU_MODULE_2_DMA NXP_WUU_MODULE(2, NXP_WUU_EVENT_DMA)
+
+/** Module 3 interrupt event */
+#define NXP_WUU_MODULE_3_INT NXP_WUU_MODULE(3, NXP_WUU_EVENT_INT)
+/** Module 3 DMA event */
+#define NXP_WUU_MODULE_3_DMA NXP_WUU_MODULE(3, NXP_WUU_EVENT_DMA)
+
+/** Module 4 interrupt event */
+#define NXP_WUU_MODULE_4_INT NXP_WUU_MODULE(4, NXP_WUU_EVENT_INT)
+/** Module 4 DMA event */
+#define NXP_WUU_MODULE_4_DMA NXP_WUU_MODULE(4, NXP_WUU_EVENT_DMA)
+
+/** Module 5 interrupt event */
+#define NXP_WUU_MODULE_5_INT NXP_WUU_MODULE(5, NXP_WUU_EVENT_INT)
+/** Module 5 DMA event */
+#define NXP_WUU_MODULE_5_DMA NXP_WUU_MODULE(5, NXP_WUU_EVENT_DMA)
+
+/** Module 6 interrupt event */
+#define NXP_WUU_MODULE_6_INT NXP_WUU_MODULE(6, NXP_WUU_EVENT_INT)
+/** Module 6 DMA event */
+#define NXP_WUU_MODULE_6_DMA NXP_WUU_MODULE(6, NXP_WUU_EVENT_DMA)
+
+/** Module 7 interrupt event */
+#define NXP_WUU_MODULE_7_INT NXP_WUU_MODULE(7, NXP_WUU_EVENT_INT)
+/** Module 7 DMA event */
+#define NXP_WUU_MODULE_7_DMA NXP_WUU_MODULE(7, NXP_WUU_EVENT_DMA)
+
+/** Module 8 interrupt event */
+#define NXP_WUU_MODULE_8_INT NXP_WUU_MODULE(8, NXP_WUU_EVENT_INT)
+/** Module 8 DMA event */
+#define NXP_WUU_MODULE_8_DMA NXP_WUU_MODULE(8, NXP_WUU_EVENT_DMA)
+
+/**
+ * WUU PIN wakeup sources
+ */
+
+/* Pin 0 wakeup sources */
+/** Pin 0 rising edge interrupt */
+#define NXP_WUU_PIN_0_RISING_INT      NXP_WUU_PIN(0, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 0 rising edge DMA */
+#define NXP_WUU_PIN_0_RISING_DMA      NXP_WUU_PIN(0, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 0 rising edge trigger */
+#define NXP_WUU_PIN_0_RISING_TRIGGER  NXP_WUU_PIN(0, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 0 falling edge interrupt */
+#define NXP_WUU_PIN_0_FALLING_INT     NXP_WUU_PIN(0, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 0 falling edge DMA */
+#define NXP_WUU_PIN_0_FALLING_DMA     NXP_WUU_PIN(0, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 0 falling edge trigger */
+#define NXP_WUU_PIN_0_FALLING_TRIGGER NXP_WUU_PIN(0, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 0 any edge interrupt */
+#define NXP_WUU_PIN_0_ANY_INT         NXP_WUU_PIN(0, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 0 any edge DMA */
+#define NXP_WUU_PIN_0_ANY_DMA         NXP_WUU_PIN(0, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 0 any edge trigger */
+#define NXP_WUU_PIN_0_ANY_TRIGGER     NXP_WUU_PIN(0, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 1 wakeup sources */
+/** Pin 1 rising edge interrupt */
+#define NXP_WUU_PIN_1_RISING_INT      NXP_WUU_PIN(1, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 1 rising edge DMA */
+#define NXP_WUU_PIN_1_RISING_DMA      NXP_WUU_PIN(1, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 1 rising edge trigger */
+#define NXP_WUU_PIN_1_RISING_TRIGGER  NXP_WUU_PIN(1, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 1 falling edge interrupt */
+#define NXP_WUU_PIN_1_FALLING_INT     NXP_WUU_PIN(1, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 1 falling edge DMA */
+#define NXP_WUU_PIN_1_FALLING_DMA     NXP_WUU_PIN(1, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 1 falling edge trigger */
+#define NXP_WUU_PIN_1_FALLING_TRIGGER NXP_WUU_PIN(1, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 1 any edge interrupt */
+#define NXP_WUU_PIN_1_ANY_INT         NXP_WUU_PIN(1, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 1 any edge DMA */
+#define NXP_WUU_PIN_1_ANY_DMA         NXP_WUU_PIN(1, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 1 any edge trigger */
+#define NXP_WUU_PIN_1_ANY_TRIGGER     NXP_WUU_PIN(1, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 2 wakeup sources */
+/** Pin 2 rising edge interrupt */
+#define NXP_WUU_PIN_2_RISING_INT      NXP_WUU_PIN(2, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 2 rising edge DMA */
+#define NXP_WUU_PIN_2_RISING_DMA      NXP_WUU_PIN(2, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 2 rising edge trigger */
+#define NXP_WUU_PIN_2_RISING_TRIGGER  NXP_WUU_PIN(2, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 2 falling edge interrupt */
+#define NXP_WUU_PIN_2_FALLING_INT     NXP_WUU_PIN(2, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 2 falling edge DMA */
+#define NXP_WUU_PIN_2_FALLING_DMA     NXP_WUU_PIN(2, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 2 falling edge trigger */
+#define NXP_WUU_PIN_2_FALLING_TRIGGER NXP_WUU_PIN(2, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 2 any edge interrupt */
+#define NXP_WUU_PIN_2_ANY_INT         NXP_WUU_PIN(2, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 2 any edge DMA */
+#define NXP_WUU_PIN_2_ANY_DMA         NXP_WUU_PIN(2, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 2 any edge trigger */
+#define NXP_WUU_PIN_2_ANY_TRIGGER     NXP_WUU_PIN(2, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 3 wakeup sources */
+/** Pin 3 rising edge interrupt */
+#define NXP_WUU_PIN_3_RISING_INT      NXP_WUU_PIN(3, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 3 rising edge DMA */
+#define NXP_WUU_PIN_3_RISING_DMA      NXP_WUU_PIN(3, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 3 rising edge trigger */
+#define NXP_WUU_PIN_3_RISING_TRIGGER  NXP_WUU_PIN(3, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 3 falling edge interrupt */
+#define NXP_WUU_PIN_3_FALLING_INT     NXP_WUU_PIN(3, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 3 falling edge DMA */
+#define NXP_WUU_PIN_3_FALLING_DMA     NXP_WUU_PIN(3, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 3 falling edge trigger */
+#define NXP_WUU_PIN_3_FALLING_TRIGGER NXP_WUU_PIN(3, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 3 any edge interrupt */
+#define NXP_WUU_PIN_3_ANY_INT         NXP_WUU_PIN(3, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 3 any edge DMA */
+#define NXP_WUU_PIN_3_ANY_DMA         NXP_WUU_PIN(3, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 3 any edge trigger */
+#define NXP_WUU_PIN_3_ANY_TRIGGER     NXP_WUU_PIN(3, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 4 wakeup sources */
+/** Pin 4 rising edge interrupt */
+#define NXP_WUU_PIN_4_RISING_INT      NXP_WUU_PIN(4, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 4 rising edge DMA */
+#define NXP_WUU_PIN_4_RISING_DMA      NXP_WUU_PIN(4, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 4 rising edge trigger */
+#define NXP_WUU_PIN_4_RISING_TRIGGER  NXP_WUU_PIN(4, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 4 falling edge interrupt */
+#define NXP_WUU_PIN_4_FALLING_INT     NXP_WUU_PIN(4, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 4 falling edge DMA */
+#define NXP_WUU_PIN_4_FALLING_DMA     NXP_WUU_PIN(4, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 4 falling edge trigger */
+#define NXP_WUU_PIN_4_FALLING_TRIGGER NXP_WUU_PIN(4, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 4 any edge interrupt */
+#define NXP_WUU_PIN_4_ANY_INT         NXP_WUU_PIN(4, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 4 any edge DMA */
+#define NXP_WUU_PIN_4_ANY_DMA         NXP_WUU_PIN(4, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 4 any edge trigger */
+#define NXP_WUU_PIN_4_ANY_TRIGGER     NXP_WUU_PIN(4, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 5 wakeup sources */
+/** Pin 5 rising edge interrupt */
+#define NXP_WUU_PIN_5_RISING_INT      NXP_WUU_PIN(5, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 5 rising edge DMA */
+#define NXP_WUU_PIN_5_RISING_DMA      NXP_WUU_PIN(5, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 5 rising edge trigger */
+#define NXP_WUU_PIN_5_RISING_TRIGGER  NXP_WUU_PIN(5, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 5 falling edge interrupt */
+#define NXP_WUU_PIN_5_FALLING_INT     NXP_WUU_PIN(5, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 5 falling edge DMA */
+#define NXP_WUU_PIN_5_FALLING_DMA     NXP_WUU_PIN(5, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 5 falling edge trigger */
+#define NXP_WUU_PIN_5_FALLING_TRIGGER NXP_WUU_PIN(5, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 5 any edge interrupt */
+#define NXP_WUU_PIN_5_ANY_INT         NXP_WUU_PIN(5, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 5 any edge DMA */
+#define NXP_WUU_PIN_5_ANY_DMA         NXP_WUU_PIN(5, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 5 any edge trigger */
+#define NXP_WUU_PIN_5_ANY_TRIGGER     NXP_WUU_PIN(5, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 6 wakeup sources */
+/** Pin 6 rising edge interrupt */
+#define NXP_WUU_PIN_6_RISING_INT      NXP_WUU_PIN(6, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 6 rising edge DMA */
+#define NXP_WUU_PIN_6_RISING_DMA      NXP_WUU_PIN(6, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 6 rising edge trigger */
+#define NXP_WUU_PIN_6_RISING_TRIGGER  NXP_WUU_PIN(6, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 6 falling edge interrupt */
+#define NXP_WUU_PIN_6_FALLING_INT     NXP_WUU_PIN(6, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 6 falling edge DMA */
+#define NXP_WUU_PIN_6_FALLING_DMA     NXP_WUU_PIN(6, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 6 falling edge trigger */
+#define NXP_WUU_PIN_6_FALLING_TRIGGER NXP_WUU_PIN(6, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 6 any edge interrupt */
+#define NXP_WUU_PIN_6_ANY_INT         NXP_WUU_PIN(6, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 6 any edge DMA */
+#define NXP_WUU_PIN_6_ANY_DMA         NXP_WUU_PIN(6, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 6 any edge trigger */
+#define NXP_WUU_PIN_6_ANY_TRIGGER     NXP_WUU_PIN(6, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 7 wakeup sources */
+/** Pin 7 rising edge interrupt */
+#define NXP_WUU_PIN_7_RISING_INT      NXP_WUU_PIN(7, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 7 rising edge DMA */
+#define NXP_WUU_PIN_7_RISING_DMA      NXP_WUU_PIN(7, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 7 rising edge trigger */
+#define NXP_WUU_PIN_7_RISING_TRIGGER  NXP_WUU_PIN(7, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 7 falling edge interrupt */
+#define NXP_WUU_PIN_7_FALLING_INT     NXP_WUU_PIN(7, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 7 falling edge DMA */
+#define NXP_WUU_PIN_7_FALLING_DMA     NXP_WUU_PIN(7, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 7 falling edge trigger */
+#define NXP_WUU_PIN_7_FALLING_TRIGGER NXP_WUU_PIN(7, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 7 any edge interrupt */
+#define NXP_WUU_PIN_7_ANY_INT         NXP_WUU_PIN(7, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 7 any edge DMA */
+#define NXP_WUU_PIN_7_ANY_DMA         NXP_WUU_PIN(7, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 7 any edge trigger */
+#define NXP_WUU_PIN_7_ANY_TRIGGER     NXP_WUU_PIN(7, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 8 wakeup sources */
+/** Pin 8 rising edge interrupt */
+#define NXP_WUU_PIN_8_RISING_INT      NXP_WUU_PIN(8, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 8 rising edge DMA */
+#define NXP_WUU_PIN_8_RISING_DMA      NXP_WUU_PIN(8, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 8 rising edge trigger */
+#define NXP_WUU_PIN_8_RISING_TRIGGER  NXP_WUU_PIN(8, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 8 falling edge interrupt */
+#define NXP_WUU_PIN_8_FALLING_INT     NXP_WUU_PIN(8, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 8 falling edge DMA */
+#define NXP_WUU_PIN_8_FALLING_DMA     NXP_WUU_PIN(8, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 8 falling edge trigger */
+#define NXP_WUU_PIN_8_FALLING_TRIGGER NXP_WUU_PIN(8, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 8 any edge interrupt */
+#define NXP_WUU_PIN_8_ANY_INT         NXP_WUU_PIN(8, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 8 any edge DMA */
+#define NXP_WUU_PIN_8_ANY_DMA         NXP_WUU_PIN(8, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 8 any edge trigger */
+#define NXP_WUU_PIN_8_ANY_TRIGGER     NXP_WUU_PIN(8, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 9 wakeup sources */
+/** Pin 9 rising edge interrupt */
+#define NXP_WUU_PIN_9_RISING_INT      NXP_WUU_PIN(9, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 9 rising edge DMA */
+#define NXP_WUU_PIN_9_RISING_DMA      NXP_WUU_PIN(9, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 9 rising edge trigger */
+#define NXP_WUU_PIN_9_RISING_TRIGGER  NXP_WUU_PIN(9, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 9 falling edge interrupt */
+#define NXP_WUU_PIN_9_FALLING_INT     NXP_WUU_PIN(9, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 9 falling edge DMA */
+#define NXP_WUU_PIN_9_FALLING_DMA     NXP_WUU_PIN(9, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 9 falling edge trigger */
+#define NXP_WUU_PIN_9_FALLING_TRIGGER NXP_WUU_PIN(9, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 9 any edge interrupt */
+#define NXP_WUU_PIN_9_ANY_INT         NXP_WUU_PIN(9, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 9 any edge DMA */
+#define NXP_WUU_PIN_9_ANY_DMA         NXP_WUU_PIN(9, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 9 any edge trigger */
+#define NXP_WUU_PIN_9_ANY_TRIGGER     NXP_WUU_PIN(9, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 10 wakeup sources */
+/** Pin 10 rising edge interrupt */
+#define NXP_WUU_PIN_10_RISING_INT      NXP_WUU_PIN(10, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 10 rising edge DMA */
+#define NXP_WUU_PIN_10_RISING_DMA      NXP_WUU_PIN(10, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 10 rising edge trigger */
+#define NXP_WUU_PIN_10_RISING_TRIGGER  NXP_WUU_PIN(10, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 10 falling edge interrupt */
+#define NXP_WUU_PIN_10_FALLING_INT     NXP_WUU_PIN(10, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 10 falling edge DMA */
+#define NXP_WUU_PIN_10_FALLING_DMA     NXP_WUU_PIN(10, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 10 falling edge trigger */
+#define NXP_WUU_PIN_10_FALLING_TRIGGER NXP_WUU_PIN(10, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 10 any edge interrupt */
+#define NXP_WUU_PIN_10_ANY_INT         NXP_WUU_PIN(10, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 10 any edge DMA */
+#define NXP_WUU_PIN_10_ANY_DMA         NXP_WUU_PIN(10, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 10 any edge trigger */
+#define NXP_WUU_PIN_10_ANY_TRIGGER     NXP_WUU_PIN(10, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 11 wakeup sources */
+/** Pin 11 rising edge interrupt */
+#define NXP_WUU_PIN_11_RISING_INT      NXP_WUU_PIN(11, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 11 rising edge DMA */
+#define NXP_WUU_PIN_11_RISING_DMA      NXP_WUU_PIN(11, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 11 rising edge trigger */
+#define NXP_WUU_PIN_11_RISING_TRIGGER  NXP_WUU_PIN(11, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 11 falling edge interrupt */
+#define NXP_WUU_PIN_11_FALLING_INT     NXP_WUU_PIN(11, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 11 falling edge DMA */
+#define NXP_WUU_PIN_11_FALLING_DMA     NXP_WUU_PIN(11, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 11 falling edge trigger */
+#define NXP_WUU_PIN_11_FALLING_TRIGGER NXP_WUU_PIN(11, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 11 any edge interrupt */
+#define NXP_WUU_PIN_11_ANY_INT         NXP_WUU_PIN(11, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 11 any edge DMA */
+#define NXP_WUU_PIN_11_ANY_DMA         NXP_WUU_PIN(11, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 11 any edge trigger */
+#define NXP_WUU_PIN_11_ANY_TRIGGER     NXP_WUU_PIN(11, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 12 wakeup sources */
+/** Pin 12 rising edge interrupt */
+#define NXP_WUU_PIN_12_RISING_INT      NXP_WUU_PIN(12, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 12 rising edge DMA */
+#define NXP_WUU_PIN_12_RISING_DMA      NXP_WUU_PIN(12, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 12 rising edge trigger */
+#define NXP_WUU_PIN_12_RISING_TRIGGER  NXP_WUU_PIN(12, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 12 falling edge interrupt */
+#define NXP_WUU_PIN_12_FALLING_INT     NXP_WUU_PIN(12, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 12 falling edge DMA */
+#define NXP_WUU_PIN_12_FALLING_DMA     NXP_WUU_PIN(12, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 12 falling edge trigger */
+#define NXP_WUU_PIN_12_FALLING_TRIGGER NXP_WUU_PIN(12, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 12 any edge interrupt */
+#define NXP_WUU_PIN_12_ANY_INT         NXP_WUU_PIN(12, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 12 any edge DMA */
+#define NXP_WUU_PIN_12_ANY_DMA         NXP_WUU_PIN(12, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 12 any edge trigger */
+#define NXP_WUU_PIN_12_ANY_TRIGGER     NXP_WUU_PIN(12, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 13 wakeup sources */
+/** Pin 13 rising edge interrupt */
+#define NXP_WUU_PIN_13_RISING_INT      NXP_WUU_PIN(13, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 13 rising edge DMA */
+#define NXP_WUU_PIN_13_RISING_DMA      NXP_WUU_PIN(13, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 13 rising edge trigger */
+#define NXP_WUU_PIN_13_RISING_TRIGGER  NXP_WUU_PIN(13, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 13 falling edge interrupt */
+#define NXP_WUU_PIN_13_FALLING_INT     NXP_WUU_PIN(13, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 13 falling edge DMA */
+#define NXP_WUU_PIN_13_FALLING_DMA     NXP_WUU_PIN(13, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 13 falling edge trigger */
+#define NXP_WUU_PIN_13_FALLING_TRIGGER NXP_WUU_PIN(13, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 13 any edge interrupt */
+#define NXP_WUU_PIN_13_ANY_INT         NXP_WUU_PIN(13, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 13 any edge DMA */
+#define NXP_WUU_PIN_13_ANY_DMA         NXP_WUU_PIN(13, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 13 any edge trigger */
+#define NXP_WUU_PIN_13_ANY_TRIGGER     NXP_WUU_PIN(13, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 14 wakeup sources */
+/** Pin 14 rising edge interrupt */
+#define NXP_WUU_PIN_14_RISING_INT      NXP_WUU_PIN(14, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 14 rising edge DMA */
+#define NXP_WUU_PIN_14_RISING_DMA      NXP_WUU_PIN(14, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 14 rising edge trigger */
+#define NXP_WUU_PIN_14_RISING_TRIGGER  NXP_WUU_PIN(14, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 14 falling edge interrupt */
+#define NXP_WUU_PIN_14_FALLING_INT     NXP_WUU_PIN(14, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 14 falling edge DMA */
+#define NXP_WUU_PIN_14_FALLING_DMA     NXP_WUU_PIN(14, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 14 falling edge trigger */
+#define NXP_WUU_PIN_14_FALLING_TRIGGER NXP_WUU_PIN(14, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 14 any edge interrupt */
+#define NXP_WUU_PIN_14_ANY_INT         NXP_WUU_PIN(14, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 14 any edge DMA */
+#define NXP_WUU_PIN_14_ANY_DMA         NXP_WUU_PIN(14, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 14 any edge trigger */
+#define NXP_WUU_PIN_14_ANY_TRIGGER     NXP_WUU_PIN(14, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 15 wakeup sources */
+/** Pin 15 rising edge interrupt */
+#define NXP_WUU_PIN_15_RISING_INT      NXP_WUU_PIN(15, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 15 rising edge DMA */
+#define NXP_WUU_PIN_15_RISING_DMA      NXP_WUU_PIN(15, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 15 rising edge trigger */
+#define NXP_WUU_PIN_15_RISING_TRIGGER  NXP_WUU_PIN(15, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 15 falling edge interrupt */
+#define NXP_WUU_PIN_15_FALLING_INT     NXP_WUU_PIN(15, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 15 falling edge DMA */
+#define NXP_WUU_PIN_15_FALLING_DMA     NXP_WUU_PIN(15, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 15 falling edge trigger */
+#define NXP_WUU_PIN_15_FALLING_TRIGGER NXP_WUU_PIN(15, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 15 any edge interrupt */
+#define NXP_WUU_PIN_15_ANY_INT         NXP_WUU_PIN(15, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 15 any edge DMA */
+#define NXP_WUU_PIN_15_ANY_DMA         NXP_WUU_PIN(15, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 15 any edge trigger */
+#define NXP_WUU_PIN_15_ANY_TRIGGER     NXP_WUU_PIN(15, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 16 wakeup sources */
+/** Pin 16 rising edge interrupt */
+#define NXP_WUU_PIN_16_RISING_INT      NXP_WUU_PIN(16, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 16 rising edge DMA */
+#define NXP_WUU_PIN_16_RISING_DMA      NXP_WUU_PIN(16, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 16 rising edge trigger */
+#define NXP_WUU_PIN_16_RISING_TRIGGER  NXP_WUU_PIN(16, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 16 falling edge interrupt */
+#define NXP_WUU_PIN_16_FALLING_INT     NXP_WUU_PIN(16, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 16 falling edge DMA */
+#define NXP_WUU_PIN_16_FALLING_DMA     NXP_WUU_PIN(16, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 16 falling edge trigger */
+#define NXP_WUU_PIN_16_FALLING_TRIGGER NXP_WUU_PIN(16, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 16 any edge interrupt */
+#define NXP_WUU_PIN_16_ANY_INT         NXP_WUU_PIN(16, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 16 any edge DMA */
+#define NXP_WUU_PIN_16_ANY_DMA         NXP_WUU_PIN(16, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 16 any edge trigger */
+#define NXP_WUU_PIN_16_ANY_TRIGGER     NXP_WUU_PIN(16, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 17 wakeup sources */
+/** Pin 17 rising edge interrupt */
+#define NXP_WUU_PIN_17_RISING_INT      NXP_WUU_PIN(17, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 17 rising edge DMA */
+#define NXP_WUU_PIN_17_RISING_DMA      NXP_WUU_PIN(17, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 17 rising edge trigger */
+#define NXP_WUU_PIN_17_RISING_TRIGGER  NXP_WUU_PIN(17, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 17 falling edge interrupt */
+#define NXP_WUU_PIN_17_FALLING_INT     NXP_WUU_PIN(17, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 17 falling edge DMA */
+#define NXP_WUU_PIN_17_FALLING_DMA     NXP_WUU_PIN(17, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 17 falling edge trigger */
+#define NXP_WUU_PIN_17_FALLING_TRIGGER NXP_WUU_PIN(17, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 17 any edge interrupt */
+#define NXP_WUU_PIN_17_ANY_INT         NXP_WUU_PIN(17, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 17 any edge DMA */
+#define NXP_WUU_PIN_17_ANY_DMA         NXP_WUU_PIN(17, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 17 any edge trigger */
+#define NXP_WUU_PIN_17_ANY_TRIGGER     NXP_WUU_PIN(17, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 18 wakeup sources */
+/** Pin 18 rising edge interrupt */
+#define NXP_WUU_PIN_18_RISING_INT      NXP_WUU_PIN(18, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 18 rising edge DMA */
+#define NXP_WUU_PIN_18_RISING_DMA      NXP_WUU_PIN(18, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 18 rising edge trigger */
+#define NXP_WUU_PIN_18_RISING_TRIGGER  NXP_WUU_PIN(18, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 18 falling edge interrupt */
+#define NXP_WUU_PIN_18_FALLING_INT     NXP_WUU_PIN(18, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 18 falling edge DMA */
+#define NXP_WUU_PIN_18_FALLING_DMA     NXP_WUU_PIN(18, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 18 falling edge trigger */
+#define NXP_WUU_PIN_18_FALLING_TRIGGER NXP_WUU_PIN(18, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 18 any edge interrupt */
+#define NXP_WUU_PIN_18_ANY_INT         NXP_WUU_PIN(18, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 18 any edge DMA */
+#define NXP_WUU_PIN_18_ANY_DMA         NXP_WUU_PIN(18, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 18 any edge trigger */
+#define NXP_WUU_PIN_18_ANY_TRIGGER     NXP_WUU_PIN(18, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 19 wakeup sources */
+/** Pin 19 rising edge interrupt */
+#define NXP_WUU_PIN_19_RISING_INT      NXP_WUU_PIN(19, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 19 rising edge DMA */
+#define NXP_WUU_PIN_19_RISING_DMA      NXP_WUU_PIN(19, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 19 rising edge trigger */
+#define NXP_WUU_PIN_19_RISING_TRIGGER  NXP_WUU_PIN(19, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 19 falling edge interrupt */
+#define NXP_WUU_PIN_19_FALLING_INT     NXP_WUU_PIN(19, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 19 falling edge DMA */
+#define NXP_WUU_PIN_19_FALLING_DMA     NXP_WUU_PIN(19, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 19 falling edge trigger */
+#define NXP_WUU_PIN_19_FALLING_TRIGGER NXP_WUU_PIN(19, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 19 any edge interrupt */
+#define NXP_WUU_PIN_19_ANY_INT         NXP_WUU_PIN(19, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 19 any edge DMA */
+#define NXP_WUU_PIN_19_ANY_DMA         NXP_WUU_PIN(19, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 19 any edge trigger */
+#define NXP_WUU_PIN_19_ANY_TRIGGER     NXP_WUU_PIN(19, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 20 wakeup sources */
+/** Pin 20 rising edge interrupt */
+#define NXP_WUU_PIN_20_RISING_INT      NXP_WUU_PIN(20, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 20 rising edge DMA */
+#define NXP_WUU_PIN_20_RISING_DMA      NXP_WUU_PIN(20, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 20 rising edge trigger */
+#define NXP_WUU_PIN_20_RISING_TRIGGER  NXP_WUU_PIN(20, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 20 falling edge interrupt */
+#define NXP_WUU_PIN_20_FALLING_INT     NXP_WUU_PIN(20, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 20 falling edge DMA */
+#define NXP_WUU_PIN_20_FALLING_DMA     NXP_WUU_PIN(20, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 20 falling edge trigger */
+#define NXP_WUU_PIN_20_FALLING_TRIGGER NXP_WUU_PIN(20, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 20 any edge interrupt */
+#define NXP_WUU_PIN_20_ANY_INT         NXP_WUU_PIN(20, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 20 any edge DMA */
+#define NXP_WUU_PIN_20_ANY_DMA         NXP_WUU_PIN(20, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 20 any edge trigger */
+#define NXP_WUU_PIN_20_ANY_TRIGGER     NXP_WUU_PIN(20, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 21 wakeup sources */
+/** Pin 21 rising edge interrupt */
+#define NXP_WUU_PIN_21_RISING_INT      NXP_WUU_PIN(21, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 21 rising edge DMA */
+#define NXP_WUU_PIN_21_RISING_DMA      NXP_WUU_PIN(21, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 21 rising edge trigger */
+#define NXP_WUU_PIN_21_RISING_TRIGGER  NXP_WUU_PIN(21, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 21 falling edge interrupt */
+#define NXP_WUU_PIN_21_FALLING_INT     NXP_WUU_PIN(21, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 21 falling edge DMA */
+#define NXP_WUU_PIN_21_FALLING_DMA     NXP_WUU_PIN(21, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 21 falling edge trigger */
+#define NXP_WUU_PIN_21_FALLING_TRIGGER NXP_WUU_PIN(21, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 21 any edge interrupt */
+#define NXP_WUU_PIN_21_ANY_INT         NXP_WUU_PIN(21, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 21 any edge DMA */
+#define NXP_WUU_PIN_21_ANY_DMA         NXP_WUU_PIN(21, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 21 any edge trigger */
+#define NXP_WUU_PIN_21_ANY_TRIGGER     NXP_WUU_PIN(21, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 22 wakeup sources */
+/** Pin 22 rising edge interrupt */
+#define NXP_WUU_PIN_22_RISING_INT      NXP_WUU_PIN(22, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 22 rising edge DMA */
+#define NXP_WUU_PIN_22_RISING_DMA      NXP_WUU_PIN(22, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 22 rising edge trigger */
+#define NXP_WUU_PIN_22_RISING_TRIGGER  NXP_WUU_PIN(22, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 22 falling edge interrupt */
+#define NXP_WUU_PIN_22_FALLING_INT     NXP_WUU_PIN(22, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 22 falling edge DMA */
+#define NXP_WUU_PIN_22_FALLING_DMA     NXP_WUU_PIN(22, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 22 falling edge trigger */
+#define NXP_WUU_PIN_22_FALLING_TRIGGER NXP_WUU_PIN(22, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 22 any edge interrupt */
+#define NXP_WUU_PIN_22_ANY_INT         NXP_WUU_PIN(22, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 22 any edge DMA */
+#define NXP_WUU_PIN_22_ANY_DMA         NXP_WUU_PIN(22, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 22 any edge trigger */
+#define NXP_WUU_PIN_22_ANY_TRIGGER     NXP_WUU_PIN(22, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 23 wakeup sources */
+/** Pin 23 rising edge interrupt */
+#define NXP_WUU_PIN_23_RISING_INT      NXP_WUU_PIN(23, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 23 rising edge DMA */
+#define NXP_WUU_PIN_23_RISING_DMA      NXP_WUU_PIN(23, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 23 rising edge trigger */
+#define NXP_WUU_PIN_23_RISING_TRIGGER  NXP_WUU_PIN(23, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 23 falling edge interrupt */
+#define NXP_WUU_PIN_23_FALLING_INT     NXP_WUU_PIN(23, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 23 falling edge DMA */
+#define NXP_WUU_PIN_23_FALLING_DMA     NXP_WUU_PIN(23, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 23 falling edge trigger */
+#define NXP_WUU_PIN_23_FALLING_TRIGGER NXP_WUU_PIN(23, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 23 any edge interrupt */
+#define NXP_WUU_PIN_23_ANY_INT         NXP_WUU_PIN(23, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 23 any edge DMA */
+#define NXP_WUU_PIN_23_ANY_DMA         NXP_WUU_PIN(23, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 23 any edge trigger */
+#define NXP_WUU_PIN_23_ANY_TRIGGER     NXP_WUU_PIN(23, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 24 wakeup sources */
+/** Pin 24 rising edge interrupt */
+#define NXP_WUU_PIN_24_RISING_INT      NXP_WUU_PIN(24, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 24 rising edge DMA */
+#define NXP_WUU_PIN_24_RISING_DMA      NXP_WUU_PIN(24, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 24 rising edge trigger */
+#define NXP_WUU_PIN_24_RISING_TRIGGER  NXP_WUU_PIN(24, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 24 falling edge interrupt */
+#define NXP_WUU_PIN_24_FALLING_INT     NXP_WUU_PIN(24, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 24 falling edge DMA */
+#define NXP_WUU_PIN_24_FALLING_DMA     NXP_WUU_PIN(24, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 24 falling edge trigger */
+#define NXP_WUU_PIN_24_FALLING_TRIGGER NXP_WUU_PIN(24, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 24 any edge interrupt */
+#define NXP_WUU_PIN_24_ANY_INT         NXP_WUU_PIN(24, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 24 any edge DMA */
+#define NXP_WUU_PIN_24_ANY_DMA         NXP_WUU_PIN(24, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 24 any edge trigger */
+#define NXP_WUU_PIN_24_ANY_TRIGGER     NXP_WUU_PIN(24, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 25 wakeup sources */
+/** Pin 25 rising edge interrupt */
+#define NXP_WUU_PIN_25_RISING_INT      NXP_WUU_PIN(25, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 25 rising edge DMA */
+#define NXP_WUU_PIN_25_RISING_DMA      NXP_WUU_PIN(25, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 25 rising edge trigger */
+#define NXP_WUU_PIN_25_RISING_TRIGGER  NXP_WUU_PIN(25, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 25 falling edge interrupt */
+#define NXP_WUU_PIN_25_FALLING_INT     NXP_WUU_PIN(25, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 25 falling edge DMA */
+#define NXP_WUU_PIN_25_FALLING_DMA     NXP_WUU_PIN(25, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 25 falling edge trigger */
+#define NXP_WUU_PIN_25_FALLING_TRIGGER NXP_WUU_PIN(25, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 25 any edge interrupt */
+#define NXP_WUU_PIN_25_ANY_INT         NXP_WUU_PIN(25, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 25 any edge DMA */
+#define NXP_WUU_PIN_25_ANY_DMA         NXP_WUU_PIN(25, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 25 any edge trigger */
+#define NXP_WUU_PIN_25_ANY_TRIGGER     NXP_WUU_PIN(25, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 26 wakeup sources */
+/** Pin 26 rising edge interrupt */
+#define NXP_WUU_PIN_26_RISING_INT      NXP_WUU_PIN(26, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 26 rising edge DMA */
+#define NXP_WUU_PIN_26_RISING_DMA      NXP_WUU_PIN(26, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 26 rising edge trigger */
+#define NXP_WUU_PIN_26_RISING_TRIGGER  NXP_WUU_PIN(26, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 26 falling edge interrupt */
+#define NXP_WUU_PIN_26_FALLING_INT     NXP_WUU_PIN(26, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 26 falling edge DMA */
+#define NXP_WUU_PIN_26_FALLING_DMA     NXP_WUU_PIN(26, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 26 falling edge trigger */
+#define NXP_WUU_PIN_26_FALLING_TRIGGER NXP_WUU_PIN(26, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 26 any edge interrupt */
+#define NXP_WUU_PIN_26_ANY_INT         NXP_WUU_PIN(26, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 26 any edge DMA */
+#define NXP_WUU_PIN_26_ANY_DMA         NXP_WUU_PIN(26, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 26 any edge trigger */
+#define NXP_WUU_PIN_26_ANY_TRIGGER     NXP_WUU_PIN(26, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 27 wakeup sources */
+/** Pin 27 rising edge interrupt */
+#define NXP_WUU_PIN_27_RISING_INT      NXP_WUU_PIN(27, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 27 rising edge DMA */
+#define NXP_WUU_PIN_27_RISING_DMA      NXP_WUU_PIN(27, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 27 rising edge trigger */
+#define NXP_WUU_PIN_27_RISING_TRIGGER  NXP_WUU_PIN(27, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 27 falling edge interrupt */
+#define NXP_WUU_PIN_27_FALLING_INT     NXP_WUU_PIN(27, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 27 falling edge DMA */
+#define NXP_WUU_PIN_27_FALLING_DMA     NXP_WUU_PIN(27, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 27 falling edge trigger */
+#define NXP_WUU_PIN_27_FALLING_TRIGGER NXP_WUU_PIN(27, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 27 any edge interrupt */
+#define NXP_WUU_PIN_27_ANY_INT         NXP_WUU_PIN(27, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 27 any edge DMA */
+#define NXP_WUU_PIN_27_ANY_DMA         NXP_WUU_PIN(27, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 27 any edge trigger */
+#define NXP_WUU_PIN_27_ANY_TRIGGER     NXP_WUU_PIN(27, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 28 wakeup sources */
+/** Pin 28 rising edge interrupt */
+#define NXP_WUU_PIN_28_RISING_INT      NXP_WUU_PIN(28, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 28 rising edge DMA */
+#define NXP_WUU_PIN_28_RISING_DMA      NXP_WUU_PIN(28, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 28 rising edge trigger */
+#define NXP_WUU_PIN_28_RISING_TRIGGER  NXP_WUU_PIN(28, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 28 falling edge interrupt */
+#define NXP_WUU_PIN_28_FALLING_INT     NXP_WUU_PIN(28, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 28 falling edge DMA */
+#define NXP_WUU_PIN_28_FALLING_DMA     NXP_WUU_PIN(28, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 28 falling edge trigger */
+#define NXP_WUU_PIN_28_FALLING_TRIGGER NXP_WUU_PIN(28, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 28 any edge interrupt */
+#define NXP_WUU_PIN_28_ANY_INT         NXP_WUU_PIN(28, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 28 any edge DMA */
+#define NXP_WUU_PIN_28_ANY_DMA         NXP_WUU_PIN(28, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 28 any edge trigger */
+#define NXP_WUU_PIN_28_ANY_TRIGGER     NXP_WUU_PIN(28, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 29 wakeup sources */
+/** Pin 29 rising edge interrupt */
+#define NXP_WUU_PIN_29_RISING_INT      NXP_WUU_PIN(29, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 29 rising edge DMA */
+#define NXP_WUU_PIN_29_RISING_DMA      NXP_WUU_PIN(29, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 29 rising edge trigger */
+#define NXP_WUU_PIN_29_RISING_TRIGGER  NXP_WUU_PIN(29, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 29 falling edge interrupt */
+#define NXP_WUU_PIN_29_FALLING_INT     NXP_WUU_PIN(29, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 29 falling edge DMA */
+#define NXP_WUU_PIN_29_FALLING_DMA     NXP_WUU_PIN(29, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 29 falling edge trigger */
+#define NXP_WUU_PIN_29_FALLING_TRIGGER NXP_WUU_PIN(29, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 29 any edge interrupt */
+#define NXP_WUU_PIN_29_ANY_INT         NXP_WUU_PIN(29, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 29 any edge DMA */
+#define NXP_WUU_PIN_29_ANY_DMA         NXP_WUU_PIN(29, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 29 any edge trigger */
+#define NXP_WUU_PIN_29_ANY_TRIGGER     NXP_WUU_PIN(29, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 30 wakeup sources */
+/** Pin 30 rising edge interrupt */
+#define NXP_WUU_PIN_30_RISING_INT      NXP_WUU_PIN(30, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 30 rising edge DMA */
+#define NXP_WUU_PIN_30_RISING_DMA      NXP_WUU_PIN(30, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 30 rising edge trigger */
+#define NXP_WUU_PIN_30_RISING_TRIGGER  NXP_WUU_PIN(30, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 30 falling edge interrupt */
+#define NXP_WUU_PIN_30_FALLING_INT     NXP_WUU_PIN(30, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 30 falling edge DMA */
+#define NXP_WUU_PIN_30_FALLING_DMA     NXP_WUU_PIN(30, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 30 falling edge trigger */
+#define NXP_WUU_PIN_30_FALLING_TRIGGER NXP_WUU_PIN(30, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 30 any edge interrupt */
+#define NXP_WUU_PIN_30_ANY_INT         NXP_WUU_PIN(30, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 30 any edge DMA */
+#define NXP_WUU_PIN_30_ANY_DMA         NXP_WUU_PIN(30, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 30 any edge trigger */
+#define NXP_WUU_PIN_30_ANY_TRIGGER     NXP_WUU_PIN(30, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+/* Pin 31 wakeup sources */
+/** Pin 31 rising edge interrupt */
+#define NXP_WUU_PIN_31_RISING_INT      NXP_WUU_PIN(31, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_INT)
+/** Pin 31 rising edge DMA */
+#define NXP_WUU_PIN_31_RISING_DMA      NXP_WUU_PIN(31, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_DMA)
+/** Pin 31 rising edge trigger */
+#define NXP_WUU_PIN_31_RISING_TRIGGER  NXP_WUU_PIN(31, NXP_WUU_EDGE_RISING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 31 falling edge interrupt */
+#define NXP_WUU_PIN_31_FALLING_INT     NXP_WUU_PIN(31, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_INT)
+/** Pin 31 falling edge DMA */
+#define NXP_WUU_PIN_31_FALLING_DMA     NXP_WUU_PIN(31, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_DMA)
+/** Pin 31 falling edge trigger */
+#define NXP_WUU_PIN_31_FALLING_TRIGGER NXP_WUU_PIN(31, NXP_WUU_EDGE_FALLING, NXP_WUU_EVENT_TRIGGER)
+/** Pin 31 any edge interrupt */
+#define NXP_WUU_PIN_31_ANY_INT         NXP_WUU_PIN(31, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_INT)
+/** Pin 31 any edge DMA */
+#define NXP_WUU_PIN_31_ANY_DMA         NXP_WUU_PIN(31, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_DMA)
+/** Pin 31 any edge trigger */
+#define NXP_WUU_PIN_31_ANY_TRIGGER     NXP_WUU_PIN(31, NXP_WUU_EDGE_ANY, NXP_WUU_EVENT_TRIGGER)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_WUC_NXP_WUU_H_ */

--- a/soc/nxp/common/nxp_nbu.c
+++ b/soc/nxp/common/nxp_nbu.c
@@ -14,7 +14,11 @@
 /* -------------------------------------------------------------------------- */
 #include <zephyr/irq.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/wuc.h>
+#include <zephyr/logging/log.h>
 #include <soc.h>
+
+LOG_MODULE_REGISTER(nxp_nbu, CONFIG_SOC_LOG_LEVEL);
 
 /* -------------------------------------------------------------------------- */
 /*                                  Definitions                               */
@@ -97,7 +101,19 @@ void nxp_nbu_init(void)
 	IRQ_CONNECT(NBU_WAKE_UP_IRQ_N, NBU_WAKE_UP_IRQ_P, nbu_wakeup_done_handler, 0, 0);
 #endif
 #if (DT_INST_PROP(0, wakeup_source)) && CONFIG_PM
+#if DT_INST_NODE_HAS_PROP(0, wakeup_ctrls)
+	{
+		const struct wuc_dt_spec wuc = WUC_DT_SPEC_INST_GET(0);
+		int ret = wuc_enable_wakeup_source_dt(&wuc);
+
+		if (ret != 0) {
+			LOG_ERR("nbu: failed to enable wuc wakeup source (%d)", ret);
+			return;
+		}
+	}
+#else
 	NXP_ENABLE_WAKEUP_SIGNAL(NBU_RX_IRQ_N);
+#endif
 #endif
 #if DT_INST_NODE_HAS_PROP(0, pinctrl_0)
 	/* NBU HDI pin configuration */

--- a/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/Kconfig.defconfig
@@ -85,3 +85,6 @@ config ROM_START_OFFSET
 endif # NXP_MCXW7XX_BOOT_HEADER
 
 endif
+
+config WUC
+	default y if "$(dt_nodelabel_enabled,wuu)"

--- a/soc/nxp/mcx/mcxw/mcxw7xx/power.c
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/power.c
@@ -8,36 +8,16 @@
 #include <fsl_cmc.h>
 #include <fsl_spc.h>
 #include <fsl_vbat.h>
-#include <fsl_wuu.h>
 
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
-#define MCXW7_WUU_ADDR (WUU_Type *)DT_REG_ADDR(DT_INST(0, nxp_wuu))
 #define MCXW7_CMC_ADDR (CMC_Type *)DT_REG_ADDR(DT_INST(0, nxp_cmc))
 #define MCXW7_VBAT_ADDR (VBAT_Type *)DT_REG_ADDR(DT_INST(0, nxp_vbat))
 #define MCXW7_SPC_ADDR (SPC_Type *)DT_REG_ADDR(DT_INST(0, nxp_spc))
 
-/* Get the IRQ number for lptmr0 */
-#define MCXW7_LPTMR0_IRQ_N           DT_IRQN(DT_NODELABEL(lptmr0))
-#define MCXW7_WUU_WAKEUP_LPTMR_IDX   0
-/* Get the IRQ number used by NBU */
-#define MCXW7_RF_IMU0_IRQ_N          DT_IRQN(DT_NODELABEL(nbu))
-#define MCXW7_WUU_WAKEUP_RF_IMU0_IDX 2
-
 #define MCXW7_LPWKUP_DELAY_10MHz (0xAAU)
-
-void mcxw7xx_set_wakeup(int32_t irqn)
-{
-	if (irqn == MCXW7_LPTMR0_IRQ_N) {
-		WUU_SetInternalWakeUpModulesConfig(MCXW7_WUU_ADDR, MCXW7_WUU_WAKEUP_LPTMR_IDX,
-						   kWUU_InternalModuleInterrupt);
-	} else if (irqn == MCXW7_RF_IMU0_IRQ_N) {
-		WUU_SetInternalWakeUpModulesConfig(MCXW7_WUU_ADDR, MCXW7_WUU_WAKEUP_RF_IMU0_IDX,
-						   kWUU_InternalModuleDMATrigger);
-	}
-}
 
 /*
  * 1. Set power mode protection
@@ -196,6 +176,4 @@ __weak void set_spc_configuration(void)
 void nxp_mcxw7x_power_init(void)
 {
 	set_spc_configuration();
-	/* Enable LPTMR0 as wakeup source */
-	NXP_ENABLE_WAKEUP_SIGNAL(MCXW7_LPTMR0_IRQ_N);
 }

--- a/soc/nxp/mcx/mcxw/mcxw7xx/soc.h
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/soc.h
@@ -17,10 +17,6 @@
 #define nbu_handler RF_IMU0_IRQHandler
 #endif
 
-#undef NXP_ENABLE_WAKEUP_SIGNAL
-void mcxw7xx_set_wakeup(int32_t irqn);
-#define NXP_ENABLE_WAKEUP_SIGNAL(irqn) mcxw7xx_set_wakeup(irqn)
-
 #if CONFIG_PM
 void nxp_mcxw7x_power_init(void);
 #else

--- a/tests/drivers/wuc/wuc_api/boards/frdm_mcxw72_mcxw727c_cpu0.overlay
+++ b/tests/drivers/wuc/wuc_api/boards/frdm_mcxw72_mcxw727c_cpu0.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/wuc/wuc_nxp_wuu.h>
+
+/ {
+	zephyr,user {
+		wakeup-source;
+		wakeup-ctrls = <&wuu NXP_WUU_PIN_0_RISING_INT>,
+			       <&wuu NXP_WUU_MODULE_0_INT>;
+	};
+};


### PR DESCRIPTION

Migrate MCXW7xx SoC power management from direct WUU HAL usage to the new Wakeup Controller (WUC) subsystem.

The changes include:

1. Remove direct WUU HAL usage from power.c
2. Remove wakeup signal macro from soc.h
3. Add WUC device tree configuration in nxp_mcxw7x_common.dtsi
4. Enable WUC subsystem in Kconfig.defconfig

This migration allows LPTMR0 wakeup configuration to be managed automatically through the WUC subsystem integration in the LPTMR driver, eliminating the need for SoC-specific wakeup initialization code.