### PR TITLE
drivers: i2s: stm32 sai fix dma_cfg

### DIFF
--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -341,12 +341,12 @@ static int i2s_stm32_sai_dma_init(const struct device *dev)
 	hdma->Init.Request = dma_cfg->dma_slot;
 #endif
 
-	if (dma_cfg.source_data_size != dma_cfg.dest_data_size) {
+	if (dma_cfg->source_data_size != dma_cfg->dest_data_size) {
 		LOG_ERR("Source and destination data sizes are not aligned");
 		return -EINVAL;
 	}
 
-	int idx = find_lsb_set(dma_cfg.source_data_size) - 1;
+	int idx = find_lsb_set(dma_cfg->source_data_size) - 1;
 
 #if defined(CONFIG_DMA_STM32U5)
 	if (idx >= ARRAY_SIZE(dma_src_size)) {


### PR DESCRIPTION
This change fixes dma_cfg conflict between #99967 and #100223

Initially reported https://github.com/zephyrproject-rtos/zephyr/pull/100223#issuecomment-3640699797

```
s/drivers__i2s.dir/i2s_stm32_sai.c.obj -c /home/mario/zephyrproject/zephyr/drivers/i2s/i2s_stm32_sai.c
/home/mario/zephyrproject/zephyr/drivers/i2s/i2s_stm32_sai.c: In function 'i2s_stm32_sai_dma_init':
/home/mario/zephyrproject/zephyr/drivers/i2s/i2s_stm32_sai.c:344:20: error: 'dma_cfg' is a pointer; did you mean to use '->'?
  344 |         if (dma_cfg.source_data_size != dma_cfg.dest_data_size) {
      |                    ^
      |                    ->
/home/mario/zephyrproject/zephyr/drivers/i2s/i2s_stm32_sai.c:344:48: error: 'dma_cfg' is a pointer; did you mean to use '->'?
  344 |         if (dma_cfg.source_data_size != dma_cfg.dest_data_size) {
      |                                                ^
      |                                                ->
/home/mario/zephyrproject/zephyr/drivers/i2s/i2s_stm32_sai.c:349:39: error: 'dma_cfg' is a pointer; did you mean to use '->'?
  349 |         int idx = find_lsb_set(dma_cfg.source_data_size) - 1;
      |                                       ^
      |                                       ->
[124/164] Building C object modules/hal_stm32/stm32cube/CMakeFiles/..__modules__hal__stm32__stm32cube.dir/stm32u5xx/drivers/src/stm32u5xx_hal_dma_ex.c.obj
ninja: build stopped: subcommand failed.
```