### PR TITLE
drivers: i2c_dw: Add clock control

### DIFF
--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -6,6 +6,7 @@ menuconfig I2C_DW
 	default y
 	depends on DT_HAS_SNPS_DESIGNWARE_I2C_ENABLED
 	select PINCTRL if $(dt_compat_any_has_prop,$(DT_COMPAT_SNPS_DESIGNWARE_I2C),pinctrl-0)
+	depends on !$(dt_compat_any_has_prop,$(DT_COMPAT_SNPS_DESIGNWARE_I2C),clocks) || CLOCK_CONTROL
 	help
 	  Enable the Design Ware I2C driver
 

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1267,6 +1267,16 @@ static int i2c_dw_initialize(const struct device *dev)
 	uint32_t scl_timeout = rom->scl_timeout_value * CONFIG_I2C_DW_CLOCK_SPEED * 1000;
 #endif
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(clocks)
+	if (rom->clk_dev != NULL) {
+		ret = clock_control_on(rom->clk_dev, rom->clk_id);
+		if (ret < 0) {
+			LOG_ERR("Failed to enable the clock");
+			return ret;
+		}
+	}
+#endif
+
 #if defined(CONFIG_RESET)
 	if (rom->reset.dev) {
 		ret = reset_line_toggle_dt(&rom->reset);
@@ -1412,6 +1422,17 @@ static int i2c_dw_initialize(const struct device *dev)
 #define RESET_DW_CONFIG(n)
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(raspberrypi_pico_i2c)
+#define I2C_DW_CLK_ID	clk_id
+#else
+#define I2C_DW_CLK_ID	clkid
+#endif
+
+#define CLOCK_DW_CONFIG(n)                                                                         \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(n, clocks),                                               \
+			(.clk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                         \
+			 .clk_id = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, I2C_DW_CLK_ID),))
+
 #define I2C_DW_INIT_PCIE0(n)
 #define I2C_DW_INIT_PCIE1(n) DEVICE_PCIE_INST_INIT(n, pcie),
 #define I2C_DW_INIT_PCIE(n)  _CONCAT(I2C_DW_INIT_PCIE, DT_INST_ON_BUS(n, pcie))(n)
@@ -1492,7 +1513,7 @@ static int i2c_dw_initialize(const struct device *dev)
 		.fs_spk_len = MAX((uint8_t)DT_INST_PROP_OR(n, fs_spike_len, 0), DW_IC_SPKLEN_MIN), \
 		.hs_spk_len = MAX((uint8_t)DT_INST_PROP_OR(n, hs_spike_len, 0), DW_IC_SPKLEN_MIN), \
 		TIMEOUT_DW_CONFIG(n) RESET_DW_CONFIG(n) PINCTRL_DW_CONFIG(n) I2C_DW_INIT_PCIE(n)   \
-			I2C_CONFIG_DMA_INIT(n)};                                                   \
+			I2C_CONFIG_DMA_INIT(n) CLOCK_DW_CONFIG(n)};                                \
 	BUILD_ASSERT(DT_INST_PROP_OR(n, sda_hold_tx, 0) <= 0xffff, "Invalid SDA_HOLD_TX value");   \
 	BUILD_ASSERT(DT_INST_PROP_OR(n, sda_hold_rx, 0) <= 0xff, "Invalid SDA_HOLD_RX value");     \
 	static struct i2c_dw_dev_config i2c_##n##_runtime;                                         \

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -23,6 +23,7 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "DW I2C in DT needs CONFIG_PCIE");
 #if defined(CONFIG_RESET)
 #include <zephyr/drivers/reset.h>
 #endif
+#include <zephyr/drivers/clock_control.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -162,6 +163,10 @@ struct i2c_dw_rom_config {
 #endif
 #if defined(CONFIG_RESET)
 	const struct reset_dt_spec reset;
+#endif
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(clocks)
+	const struct device *clk_dev;
+	const clock_control_subsys_t clk_id;
 #endif
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)


### PR DESCRIPTION
This adds optional clock control support to the i2c_dw driver. The support currently assumes that the clock control binding uses clkid for the clock cell name.

See PR #100172