### PR TITLE
boards: doc: remove tfm note for stm32u0 boards

### DIFF
--- a/boards/st/nucleo_u031r8/doc/index.rst
+++ b/boards/st/nucleo_u031r8/doc/index.rst
@@ -231,10 +231,6 @@ Here is an example for the :zephyr:code-sample:`blinky` application.
    :board: nucleo_u031r8
    :goals: debug
 
-Note: Check the ``build/tfm`` directory to ensure that the commands required by these scripts
-(``readlink``, etc.) are available on your system. Please also check ``STM32_Programmer_CLI``
-(which is used for initialization) is available in the PATH.
-
 .. _NUCLEO_U031R8 website:
   https://www.st.com/en/evaluation-tools/nucleo-u031r8.html
 

--- a/boards/st/nucleo_u083rc/doc/index.rst
+++ b/boards/st/nucleo_u083rc/doc/index.rst
@@ -244,10 +244,6 @@ Here is an example for the :zephyr:code-sample:`blinky` application.
    :board: nucleo_u083rc
    :goals: debug
 
-Note: Check the ``build/tfm`` directory to ensure that the commands required by these scripts
-(``readlink``, etc.) are available on your system. Please also check ``STM32_Programmer_CLI``
-(which is used for initialization) is available in the PATH.
-
 .. _NUCLEO_U083RC website:
    https://www.st.com/en/evaluation-tools/nucleo-u083rc.html
 


### PR DESCRIPTION
The STM32U0 series MCUs don't support TF-M and therefore the note regarding the `build/tfm` directory needs to be removed from the corresponding documentation pages of the Nucleo boards using the STM32U0.

Sidenote: I couldn't get `west debug` working for neither of the U0 nucleo boards after flashing a Zephyr application (flashing works). It only runs without problems with the stock Nucleo firmware and/or after a chip-erase. Therefore, I couldn't really verify whether `west debug` works as advertised.