### PR TITLE
net: mqtt_sn: Disable support for GWINFO messages

### DIFF
--- a/tests/net/lib/mqtt_sn_client/src/mqtt_sn_client.c
+++ b/tests/net/lib/mqtt_sn_client/src/mqtt_sn_client.c
@@ -176,6 +176,15 @@ static void setup(void *f)
 	k_sem_init(&mqtt_sn_tx_sem, 0, 1);
 	k_sem_init(&mqtt_sn_rx_sem, 0, 1);
 	k_sem_init(&mqtt_sn_cb_sem, 0, 1);
+
+	/* The MQTT-SN client uses timestamp 0 as a special value which
+	 * indicates, that no gwinfo or searchgw message needs to be sent.
+	 * This means that the code effectively ignores such incoming messages
+	 * during timestamp 0. Since this is both unrealistic and unproblematic
+	 * on a real device, we simply sleep here to workaround that without
+	 * complicating the MQTT-SN implementation.
+	 */
+	k_sleep(K_MSEC(1));
 }
 
 static void cleanup(void *f)


### PR DESCRIPTION
The MQTT-SN v1.2 [0] specification specified the GwAddr as follows: The GwAdd field has a variable length and contains the address of a GW. Its depends on the network over which MQTT-SN operates and is indicated in the first octet of this field. For example, in a ZigBee network the network address is 2-octet long.

It specifies neither the possible values for the first octet, nor the format of the network-specific address that follows. Thus, the specification is incomplete and this functionality unusable.

I also wasn't able to find any implementation which implements a gwinfo message where the address length is not zero. This includes https://github.com/eclipse-paho/paho.mqtt-sn.embedded-c .

The current implementation in Zephyr simply copies a `struct sockaddr` into GwAddr. This is a bad idea for many reasons, the most important one being that the format is not even specified by POSIX [1]. They only say, which defines must exist, not what their values are. And in fact, these even differ between Zephyr and Linux.

Thus, I think it's best to disable the implementation without fully removing it, to prevent people from using this, which may even lead to memory safety issues, depending on the length of
CONFIG_MQTT_SN_LIB_MAX_ADDR_SIZE. If we were to receive an updated specification, all we'd have to do is to convert between `struct sockaddr` and mqtt-sn addresses both ways.

[0] https://groups.oasis-open.org/higherlogic/ws/public/download/66091/MQTT-SN_spec_v1.2.pdf
[1] https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/sys_socket.h.html