### PR TITLE
drivers: crc: add NXP CRC driver support

### DIFF
--- a/boards/nxp/frdm_mcxe247/frdm_mcxe247.dts
+++ b/boards/nxp/frdm_mcxe247/frdm_mcxe247.dts
@@ -31,6 +31,7 @@
 		zephyr,shell-uart = &lpuart2;
 		zephyr,canbus = &flexcan0;
 		zephyr,edac = &erm0;
+		zephyr,crc = &crc;
 	};
 
 	leds {
@@ -211,5 +212,9 @@
 };
 
 &counter_rtc {
+	status = "okay";
+};
+
+&crc {
 	status = "okay";
 };

--- a/drivers/crc/CMakeLists.txt
+++ b/drivers/crc/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2025 Renesas Electronics Corporation
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/crc.h)
@@ -6,6 +7,7 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/crc.h)
 zephyr_library()
 
 # zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_CRC_DRIVER_NXP crc_nxp.c)
 zephyr_library_sources_ifdef(CONFIG_CRC_DRIVER_RENESAS_RA crc_renesas_ra.c)
 zephyr_library_sources_ifdef(CONFIG_CRC_DRIVER_SF32LB crc_sf32lb.c)
 # zephyr-keep-sorted-stop

--- a/drivers/crc/Kconfig
+++ b/drivers/crc/Kconfig
@@ -1,4 +1,5 @@
 # Copyright (c) 2024 Brill Power Ltd.
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig CRC_DRIVER
@@ -20,6 +21,7 @@ config CRC_DRIVER_INIT_PRIORITY
 	  CRC driver device initialization priority.
 
 # zephyr-keep-sorted-start
+source "drivers/crc/Kconfig.nxp"
 source "drivers/crc/Kconfig.renesas_ra"
 source "drivers/crc/Kconfig.sf32lb"
 # zephyr-keep-sorted-stop

--- a/drivers/crc/Kconfig.nxp
+++ b/drivers/crc/Kconfig.nxp
@@ -1,0 +1,16 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config CRC_DRIVER_NXP
+	bool
+	depends on DT_HAS_NXP_CRC_ENABLED
+	default y
+	select CRC_DRIVER_HAS_CRC16
+	select CRC_DRIVER_HAS_CRC16_CCITT
+	select CRC_DRIVER_HAS_CRC16_ANSI
+	select CRC_DRIVER_HAS_CRC16_ITU_T
+	select CRC_DRIVER_HAS_CRC16_REFLECT
+	select CRC_DRIVER_HAS_CRC32_C
+	select CRC_DRIVER_HAS_CRC32_IEEE
+	help
+	  Enable the driver implementation for NXP microcontrollers

--- a/drivers/crc/crc_nxp.c
+++ b/drivers/crc/crc_nxp.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2025 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_crc
+
+#include <zephyr/drivers/crc.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(nxp_crc, CONFIG_CRC_LOG_LEVEL);
+
+/* Namespace collision process: there are crc_result_t defined in both mcux and Zephyr */
+#define crc_result_t mcux_crc_result_t
+#include "fsl_crc.h"
+#undef crc_result_t
+
+struct crc_nxp_config {
+	CRC_Type *base;
+};
+
+struct crc_nxp_data {
+	struct k_sem lock;
+};
+
+static inline void crc_nxp_lock(const struct device *dev)
+{
+	struct crc_nxp_data *data = dev->data;
+
+	k_sem_take(&data->lock, K_FOREVER);
+}
+
+static inline void crc_nxp_unlock(const struct device *dev)
+{
+	struct crc_nxp_data *data = dev->data;
+
+	k_sem_give(&data->lock);
+}
+
+static int crc_nxp_prepare_config(const struct device *dev, const struct crc_ctx *ctx,
+				  crc_config_t *cfg, bool *use32)
+{
+	const struct crc_nxp_config *config = dev->config;
+
+	ARG_UNUSED(config);
+
+	if ((ctx == NULL) || (cfg == NULL)) {
+		return -EINVAL;
+	}
+
+	cfg->polynomial = ctx->polynomial;
+	cfg->seed = ctx->seed;
+	cfg->reflectIn = (ctx->reversed & CRC_FLAG_REVERSE_INPUT) != 0U;
+	cfg->reflectOut = (ctx->reversed & CRC_FLAG_REVERSE_OUTPUT) != 0U;
+	cfg->complementChecksum = false;
+	cfg->crcResult = kCrcFinalChecksum;
+
+	switch (ctx->type) {
+	case CRC16:
+		if (ctx->polynomial != CRC16_POLY) {
+			return -EINVAL;
+		}
+		cfg->seed &= 0xFFFFU;
+		cfg->crcBits = kCrcBits16;
+		*use32 = false;
+		break;
+	case CRC16_CCITT:
+		if (ctx->polynomial != CRC16_CCITT_POLY) {
+			return -EINVAL;
+		}
+		cfg->seed &= 0xFFFFU;
+		cfg->crcBits = kCrcBits16;
+		*use32 = false;
+		break;
+	case CRC16_ANSI:
+		if (ctx->polynomial != CRC16_REFLECT_POLY) {
+			return -EINVAL;
+		}
+		cfg->seed &= 0xFFFFU;
+		cfg->crcBits = kCrcBits16;
+		*use32 = false;
+		break;
+	case CRC16_ITU_T:
+		if (ctx->polynomial != CRC16_CCITT_POLY) {
+			return -EINVAL;
+		}
+		cfg->seed &= 0xFFFFU;
+		cfg->crcBits = kCrcBits16;
+		*use32 = false;
+		break;
+	case CRC32_C:
+		if (ctx->polynomial != CRC32C_POLY) {
+			return -EINVAL;
+		}
+		cfg->crcBits = kCrcBits32;
+		*use32 = true;
+		break;
+	case CRC32_IEEE:
+		if (ctx->polynomial != CRC32_IEEE_POLY) {
+			return -EINVAL;
+		}
+		cfg->crcBits = kCrcBits32;
+		cfg->complementChecksum = true; /* IEEE requires final XOR */
+		*use32 = true;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int crc_nxp_begin(const struct device *dev, struct crc_ctx *ctx)
+{
+	const struct crc_nxp_config *config = dev->config;
+	crc_config_t cfg;
+	bool use32 = false;
+	int ret;
+
+	if ((ctx == NULL) || (ctx->state != CRC_STATE_IDLE)) {
+		return -EINVAL;
+	}
+
+	crc_nxp_lock(dev);
+
+	ret = crc_nxp_prepare_config(dev, ctx, &cfg, &use32);
+	if (ret != 0) {
+		crc_nxp_unlock(dev);
+		return ret;
+	}
+
+	/* Initialize hardware with protocol settings and seed */
+	CRC_Init(config->base, &cfg);
+
+	ctx->state = CRC_STATE_IN_PROGRESS;
+
+	return 0;
+}
+
+static int crc_nxp_update(const struct device *dev, struct crc_ctx *ctx, const void *buffer,
+			  size_t bufsize)
+{
+	const struct crc_nxp_config *config = dev->config;
+
+	if (ctx->state != CRC_STATE_IN_PROGRESS) {
+		return -EINVAL;
+	}
+
+	/* Allow zero-length updates */
+	if ((bufsize > 0U) && (buffer == NULL)) {
+		ctx->state = CRC_STATE_IDLE;
+		crc_nxp_unlock(dev);
+		return -EINVAL;
+	}
+
+	if (bufsize > 0U) {
+		CRC_WriteData(config->base, (const uint8_t *)buffer, bufsize);
+	}
+
+	/* Keep an updated result for streaming verification */
+	if ((ctx->type == CRC32_C) || (ctx->type == CRC32_IEEE)) {
+		ctx->result = CRC_Get32bitResult(config->base);
+	} else {
+		ctx->result = (uint32_t)CRC_Get16bitResult(config->base);
+	}
+
+	return 0;
+}
+
+static int crc_nxp_finish(const struct device *dev, struct crc_ctx *ctx)
+{
+	const struct crc_nxp_config *config = dev->config;
+
+	if (ctx->state != CRC_STATE_IN_PROGRESS) {
+		return -EINVAL;
+	}
+
+	/* Read final result */
+	if (((ctx->type == CRC32_C) || (ctx->type == CRC32_IEEE))) {
+		ctx->result = CRC_Get32bitResult(config->base);
+	} else {
+		ctx->result = (uint32_t)CRC_Get16bitResult(config->base);
+	}
+
+	ctx->state = CRC_STATE_IDLE;
+	crc_nxp_unlock(dev);
+	return 0;
+}
+
+static DEVICE_API(crc, crc_nxp_driver_api) = {
+	.begin = crc_nxp_begin,
+	.update = crc_nxp_update,
+	.finish = crc_nxp_finish,
+};
+
+static int crc_nxp_init(const struct device *dev)
+{
+	struct crc_nxp_data *data = dev->data;
+
+	k_sem_init(&data->lock, 1, 1);
+	return 0;
+}
+
+#define CRC_NXP_INIT(inst)                                                                         \
+	static struct crc_nxp_data crc_nxp_data_##inst;                                            \
+	static const struct crc_nxp_config crc_nxp_config_##inst = {                               \
+		.base = (CRC_Type *)DT_INST_REG_ADDR(inst),                                        \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, crc_nxp_init, NULL, &crc_nxp_data_##inst,                      \
+			      &crc_nxp_config_##inst, POST_KERNEL,                                 \
+			      CONFIG_CRC_DRIVER_INIT_PRIORITY, &crc_nxp_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(CRC_NXP_INIT)

--- a/dts/arm/nxp/nxp_mcxe24x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxe24x_common.dtsi
@@ -692,6 +692,12 @@
 			clk-divider = <256>;
 			status = "disabled";
 		};
+
+		crc: crc@40032000 {
+			compatible = "nxp,crc";
+			reg = <0x40032000 0x1000>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/bindings/crc/nxp,crc.yaml
+++ b/dts/bindings/crc/nxp,crc.yaml
@@ -1,0 +1,14 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+title: NXP CRC (Cyclic Redundancy Check) device
+
+description: NXP CRC (Cyclic Redundancy Check) driver
+
+compatible: "nxp,crc"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -153,6 +153,7 @@ set_variable_ifdef(CONFIG_ETH_NXP_IMX_NETC          CONFIG_MCUX_COMPONENT_driver
 set_variable_ifdef(CONFIG_NXP_TMPSNS                CONFIG_MCUX_COMPONENT_driver.tempsensor)
 set_variable_ifdef(CONFIG_OPAMP_MCUX_OPAMP          CONFIG_MCUX_COMPONENT_driver.opamp)
 set_variable_ifdef(CONFIG_OPAMP_MCUX_OPAMP_FAST     CONFIG_MCUX_COMPONENT_driver.opamp_fast)
+set_variable_ifdef(CONFIG_CRC_DRIVER_NXP        CONFIG_MCUX_COMPONENT_driver.crc)
 
 if(NOT CONFIG_SOC_MIMX9596)
   set_variable_ifdef(CONFIG_ETH_NXP_IMX_NETC          CONFIG_MCUX_COMPONENT_driver.netc_switch)

--- a/samples/drivers/crc/Kconfig
+++ b/samples/drivers/crc/Kconfig
@@ -1,0 +1,28 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+menu "CRC sample application"
+
+choice SAMPLE_CRC_VARIANT
+	prompt "CRC variant to run"
+	default SAMPLE_CRC_VARIANT_CRC8
+	help
+	  Choose which CRC algorithm the sample computes.
+
+config SAMPLE_CRC_VARIANT_CRC8
+	bool "CRC8"
+
+config SAMPLE_CRC_VARIANT_CRC16_CCITT
+	bool "CRC16-CCITT"
+
+config SAMPLE_CRC_VARIANT_CRC32_IEEE
+	bool "CRC32-IEEE"
+
+config SAMPLE_CRC_VARIANT_CRC32_C
+	bool "CRC32-C"
+
+endchoice
+
+endmenu
+
+source "Kconfig.zephyr"

--- a/samples/drivers/crc/README.rst
+++ b/samples/drivers/crc/README.rst
@@ -8,6 +8,22 @@ Overview
 ********
 
 This sample demonstrates how to use the :ref:`CRC driver API <crc_api>`.
+It computes a single CRC variant selected via sample Kconfig and logs
+the computed result. Optionally, it verifies against an expected value.
+
+Configuration
+*************
+
+Select the CRC variant to run using the sample's Kconfig:
+
+- ``SAMPLE_CRC_VARIANT_CRC8``
+- ``SAMPLE_CRC_VARIANT_CRC16_CCITT``
+- ``SAMPLE_CRC_VARIANT_CRC32_IEEE``
+- ``SAMPLE_CRC_VARIANT_CRC32_C``
+
+The sample performs a build-time capability check and will emit a
+compile error if the selected variant is not supported by the target
+driver/platform.
 
 Building and Running
 ********************
@@ -29,16 +45,22 @@ To build for another board, change "ek_ra8m1" above to that board's name.
 Sample Output
 =============
 
+The console logs the selected variant and the computed value. If an
+expected value is provided, the sample verifies and logs the outcome.
+
 .. code-block:: console
 
-   crc_example: CRC verification succeed.
+   crc_example: CRC8 result: 0x000000b2
+   crc_example: CRC8 verification succeeded (expected 0x000000b2)
 
-.. note:: If the CRC is not supported, the output will be an error message.
+.. note:: If the selected CRC variant is not supported by the target,
+   the build will fail with an error message describing the mismatch.
 
 Expected Behavior
 *****************
 
 When the sample runs, it should:
 
-1. Compute the CRC8 values of predefined data.
-2. Verify the CRC result.
+1. Compute the selected CRC variant for predefined data.
+2. Log the computed CRC value.
+3. If an expected value is configured, verify it and log success/failure.

--- a/samples/drivers/crc/boards/frdm_mcxe247.conf
+++ b/samples/drivers/crc/boards/frdm_mcxe247.conf
@@ -1,0 +1,4 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SAMPLE_CRC_VARIANT_CRC16_CCITT=y

--- a/samples/drivers/crc/src/main.c
+++ b/samples/drivers/crc/src/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 Renesas Electronics Corporation
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +14,51 @@ LOG_MODULE_REGISTER(crc_example, CONFIG_LOG_DEFAULT_LEVEL);
 /* The devicetree node identifier for the "crc" */
 #define CRC_NODE DT_CHOSEN(zephyr_crc)
 
+/* Pre-select CRC variant and constants via Kconfig */
+#if defined(CONFIG_SAMPLE_CRC_VARIANT_CRC8)
+#if !IS_ENABLED(CONFIG_CRC_DRIVER_HAS_CRC8)
+#error "Selected CRC8 but driver/platform does not support it"
+#endif
+#define CRC_SAMPLE_TYPE     CRC8
+#define CRC_SAMPLE_POLY     CRC8_POLY
+#define CRC_SAMPLE_SEED     CRC8_INIT_VAL
+#define CRC_SAMPLE_REVERSED (CRC_FLAG_REVERSE_OUTPUT | CRC_FLAG_REVERSE_INPUT)
+#define CRC_SAMPLE_NAME     "CRC8"
+#define CRC_SAMPLE_EXPECTED 0xB2
+#elif defined(CONFIG_SAMPLE_CRC_VARIANT_CRC16_CCITT)
+#if !IS_ENABLED(CONFIG_CRC_DRIVER_HAS_CRC16_CCITT) && !IS_ENABLED(CONFIG_CRC_DRIVER_HAS_CRC16)
+#error "Selected CRC16-CCITT but platform does not support it"
+#endif
+#define CRC_SAMPLE_TYPE     CRC16_CCITT
+#define CRC_SAMPLE_POLY     CRC16_CCITT_POLY
+#define CRC_SAMPLE_SEED     CRC16_CCITT_INIT_VAL
+#define CRC_SAMPLE_REVERSED (CRC_FLAG_REVERSE_OUTPUT | CRC_FLAG_REVERSE_INPUT)
+#define CRC_SAMPLE_NAME     "CRC16-CCITT"
+#define CRC_SAMPLE_EXPECTED 0x445c
+#elif defined(CONFIG_SAMPLE_CRC_VARIANT_CRC32_IEEE)
+#if !IS_ENABLED(CONFIG_CRC_DRIVER_HAS_CRC32_IEEE)
+#error "Selected CRC32-IEEE but platform does not support it"
+#endif
+#define CRC_SAMPLE_TYPE     CRC32_IEEE
+#define CRC_SAMPLE_POLY     CRC32_IEEE_POLY
+#define CRC_SAMPLE_SEED     CRC32_IEEE_INIT_VAL
+#define CRC_SAMPLE_REVERSED (CRC_FLAG_REVERSE_OUTPUT | CRC_FLAG_REVERSE_INPUT)
+#define CRC_SAMPLE_NAME     "CRC32-IEEE"
+#define CRC_SAMPLE_EXPECTED 0xCEA4A6C2
+#elif defined(CONFIG_SAMPLE_CRC_VARIANT_CRC32_C)
+#if !IS_ENABLED(CONFIG_CRC_DRIVER_HAS_CRC32_C)
+#error "Selected CRC32-C but platform does not support it"
+#endif
+#define CRC_SAMPLE_TYPE     CRC32_C
+#define CRC_SAMPLE_POLY     CRC32_C_POLY
+#define CRC_SAMPLE_SEED     CRC32_C_INIT_VAL
+#define CRC_SAMPLE_REVERSED (CRC_FLAG_REVERSE_OUTPUT | CRC_FLAG_REVERSE_INPUT)
+#define CRC_SAMPLE_NAME     "CRC32-C"
+#define CRC_SAMPLE_EXPECTED 0xBB19ECB2
+#else
+#error "No CRC sample variant selected"
+#endif
+
 /*
  * A build error on this line means your board is unsupported.
  * See the sample documentation for information on how to fix this.
@@ -21,7 +67,6 @@ LOG_MODULE_REGISTER(crc_example, CONFIG_LOG_DEFAULT_LEVEL);
 int main(void)
 {
 	static const struct device *const dev = DEVICE_DT_GET(CRC_NODE);
-	/* Define the data to compute CRC */
 	uint8_t data[8] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4};
 	int ret;
 
@@ -31,55 +76,42 @@ int main(void)
 	}
 
 	struct crc_ctx ctx = {
-		.type = CRC8,
-		.polynomial = CRC8_POLY,
-		.seed = CRC8_INIT_VAL,
-		.reversed = CRC_FLAG_REVERSE_OUTPUT | CRC_FLAG_REVERSE_INPUT,
+		.type = CRC_SAMPLE_TYPE,
+		.polynomial = CRC_SAMPLE_POLY,
+		.seed = CRC_SAMPLE_SEED,
+		.reversed = CRC_SAMPLE_REVERSED,
 	};
 
-	/* Start CRC computation */
 	ret = crc_begin(dev, &ctx);
-
 	if (ret != 0) {
-		LOG_ERR("Failed to begin CRC: %d", ret);
+		LOG_ERR("Failed to begin %s: %d", CRC_SAMPLE_NAME, ret);
 		return ret;
 	}
 
-	/* Update CRC computation */
-	ret = crc_update(dev, &ctx, data, 8);
-
+	ret = crc_update(dev, &ctx, data, sizeof(data));
 	if (ret != 0) {
-		LOG_ERR("Failed to update CRC: %d", ret);
+		LOG_ERR("Failed to update %s: %d", CRC_SAMPLE_NAME, ret);
 		return ret;
 	}
 
-	/* Finish CRC computation */
 	ret = crc_finish(dev, &ctx);
-
 	if (ret != 0) {
-		LOG_ERR("Failed to finish CRC: %d", ret);
+		LOG_ERR("Failed to finish %s: %d", CRC_SAMPLE_NAME, ret);
 		return ret;
 	}
-	/* Verify CRC computation
-	 * (example expected value: 0xB2 with LSB, 0x4D with MSB bit order)
-	 */
-	if (ctx.reversed != (CRC_FLAG_REVERSE_OUTPUT | CRC_FLAG_REVERSE_INPUT)) {
-		ret = crc_verify(&ctx, 0x4D);
 
-		if (ret != 0) {
-			LOG_ERR("CRC verification failed: %d", ret);
-			return ret;
-		}
-	} else { /* Reversed is no reversed output */
-		ret = crc_verify(&ctx, 0xB2);
+	LOG_INF("%s result: 0x%08x", CRC_SAMPLE_NAME, (unsigned int)ctx.result);
 
-		if (ret != 0) {
-			LOG_ERR("CRC verification failed: %d", ret);
-			return ret;
-		}
+#if defined(CRC_SAMPLE_EXPECTED) && (CRC_SAMPLE_EXPECTED != 0)
+	ret = crc_verify(&ctx, CRC_SAMPLE_EXPECTED);
+	if (ret != 0) {
+		LOG_ERR("%s verification failed (expected 0x%08x): %d", CRC_SAMPLE_NAME,
+			CRC_SAMPLE_EXPECTED, ret);
+		return ret;
 	}
-
-	LOG_INF("CRC verification succeeded");
+	LOG_INF("%s verification succeeded (expected 0x%08x)", CRC_SAMPLE_NAME,
+		CRC_SAMPLE_EXPECTED);
+#endif
 
 	return 0;
 }

--- a/tests/drivers/crc/src/main.c
+++ b/tests/drivers/crc/src/main.c
@@ -19,7 +19,7 @@ K_THREAD_STACK_DEFINE(wait_thread_stack_area, WAIT_THREAD_STACK_SIZE);
 struct k_thread wait_thread_data;
 
 /* Define result of CRC computation */
-#define RESULT_CRC_16_THREADSAFE 0xD543
+#define RESULT_CRC_16_THREADSAFE_WAIT_THREAD_ENTRY 0xD543
 
 /**
  * 1) Take the semaphore
@@ -45,7 +45,7 @@ static void wait_thread_entry(void *a, void *b, void *c)
 
 	crc_update(dev, &ctx, data, sizeof(data));
 	crc_finish(dev, &ctx);
-	zassert_equal(crc_verify(&ctx, RESULT_CRC_16_THREADSAFE), 0);
+	zassert_equal(crc_verify(&ctx, RESULT_CRC_16_THREADSAFE_WAIT_THREAD_ENTRY), 0);
 }
 
 /* Define result of CRC computation */
@@ -56,6 +56,10 @@ static void wait_thread_entry(void *a, void *b, void *c)
  */
 ZTEST(crc, test_crc_8)
 {
+#ifndef CONFIG_CRC_DRIVER_HAS_CRC8
+	ztest_test_skip();
+#endif
+
 	static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_crc));
 
 	uint8_t data[8] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4};
@@ -84,6 +88,10 @@ ZTEST(crc, test_crc_8)
  */
 ZTEST(crc, test_crc_16)
 {
+#ifndef CONFIG_CRC_DRIVER_HAS_CRC16
+	ztest_test_skip();
+#endif
+
 	static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_crc));
 
 	uint8_t data[8] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4};
@@ -110,6 +118,10 @@ ZTEST(crc, test_crc_16)
  */
 ZTEST(crc, test_crc_16_ccitt)
 {
+#ifndef CONFIG_CRC_DRIVER_HAS_CRC16_CCITT
+	ztest_test_skip();
+#endif
+
 	static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_crc));
 
 	uint8_t data[8] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4};
@@ -136,6 +148,10 @@ ZTEST(crc, test_crc_16_ccitt)
  */
 ZTEST(crc, test_crc_32_c)
 {
+#ifndef CONFIG_CRC_DRIVER_HAS_CRC32_C
+	ztest_test_skip();
+#endif
+
 	static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_crc));
 
 	uint8_t data[8] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4};
@@ -162,6 +178,10 @@ ZTEST(crc, test_crc_32_c)
  */
 ZTEST(crc, test_crc_32_ieee)
 {
+#ifndef CONFIG_CRC_DRIVER_HAS_CRC32_IEEE
+	ztest_test_skip();
+#endif
+
 	static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_crc));
 
 	uint8_t data[8] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4};
@@ -186,6 +206,10 @@ ZTEST(crc, test_crc_32_ieee)
  */
 ZTEST(crc, test_crc_8_remain_3)
 {
+#ifndef CONFIG_CRC_DRIVER_HAS_CRC8
+	ztest_test_skip();
+#endif
+
 	static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_crc));
 
 	uint8_t data[11] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4, 0x3D, 0x4D, 0x51};
@@ -211,6 +235,10 @@ ZTEST(crc, test_crc_8_remain_3)
  */
 ZTEST(crc, test_crc_16_remain_1)
 {
+#ifndef CONFIG_CRC_DRIVER_HAS_CRC16
+	ztest_test_skip();
+#endif
+
 	static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_crc));
 
 	uint8_t data[9] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4, 0x3D};
@@ -237,6 +265,10 @@ ZTEST(crc, test_crc_16_remain_1)
  */
 ZTEST(crc, test_crc_16_ccitt_remain_2)
 {
+#ifndef CONFIG_CRC_DRIVER_HAS_CRC16_CCITT
+	ztest_test_skip();
+#endif
+
 	static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_crc));
 
 	uint8_t data[10] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4, 0xFF, 0xA0};
@@ -255,8 +287,26 @@ ZTEST(crc, test_crc_16_ccitt_remain_2)
 	zassert_equal(crc_verify(&ctx, RESULT_CRC_CCITT_REMAIN_2), 0);
 }
 
-/* Define result of CRC computation */
-#define RESULT_DISCONTINUOUS_BUFFER 0x75
+/* Select CRC test variant macros */
+#ifdef CONFIG_CRC_DRIVER_HAS_CRC8
+#define CRC_TEST_VARIANT                    CRC8
+#define CRC_TEST_POLY                       CRC8_POLY
+#define CRC_TEST_INIT_VAL                   CRC8_INIT_VAL
+#define CRC_TEST_REVERSE_CONFIG             (CRC_FLAG_REVERSE_INPUT | CRC_FLAG_REVERSE_OUTPUT)
+#define CRC_TEST_DISCONTINUOUS_BUF_EXPECTED 0x75
+#elif defined(CONFIG_CRC_DRIVER_HAS_CRC16)
+#define CRC_TEST_VARIANT                    CRC16
+#define CRC_TEST_POLY                       CRC16_POLY
+#define CRC_TEST_INIT_VAL                   CRC16_INIT_VAL
+#define CRC_TEST_REVERSE_CONFIG             (CRC_FLAG_REVERSE_INPUT | CRC_FLAG_REVERSE_OUTPUT)
+#define CRC_TEST_DISCONTINUOUS_BUF_EXPECTED 0xBDE3
+#else
+#define CRC_TEST_VARIANT                    CRC32_C
+#define CRC_TEST_POLY                       CRC32C_POLY
+#define CRC_TEST_INIT_VAL                   CRC32_C_INIT_VAL
+#define CRC_TEST_REVERSE_CONFIG             (CRC_FLAG_REVERSE_INPUT | CRC_FLAG_REVERSE_OUTPUT)
+#define CRC_TEST_DISCONTINUOUS_BUF_EXPECTED 0x20477127
+#endif
 
 /**
  * @brief Test CRC calculation with discontinuous buffers.
@@ -269,21 +319,27 @@ ZTEST(crc, test_discontinuous_buf)
 	uint8_t data2[5] = {0x49, 0x00, 0xC4, 0x3B, 0x78};
 
 	struct crc_ctx ctx = {
-		.type = CRC8,
-		.polynomial = CRC8_POLY,
-		.seed = CRC8_INIT_VAL,
-		.reversed = CRC_FLAG_REVERSE_INPUT | CRC_FLAG_REVERSE_OUTPUT,
+		.type = CRC_TEST_VARIANT,
+		.polynomial = CRC_TEST_POLY,
+		.seed = CRC_TEST_INIT_VAL,
+		.reversed = CRC_TEST_REVERSE_CONFIG,
 	};
 
 	zassert_equal(crc_begin(dev, &ctx), 0);
 	zassert_equal(crc_update(dev, &ctx, data1, sizeof(data1)), 0);
 	zassert_equal(crc_update(dev, &ctx, data2, sizeof(data2)), 0);
 	zassert_equal(crc_finish(dev, &ctx), 0);
-	zassert_equal(crc_verify(&ctx, RESULT_DISCONTINUOUS_BUFFER), 0);
+	zassert_equal(crc_verify(&ctx, CRC_TEST_DISCONTINUOUS_BUF_EXPECTED), 0);
 }
 
 /* Define result of CRC computation */
-#define RESULT_CRC_8_REMAIN_3_THREADSAFE 0xBB
+#ifdef CONFIG_CRC_DRIVER_HAS_CRC8
+#define CRC_TEST_THREADSAFE_EXPECTED 0xBB
+#elif defined(CONFIG_CRC_DRIVER_HAS_CRC16)
+#define CRC_TEST_THREADSAFE_EXPECTED 0x24CA
+#else
+#define CRC_TEST_THREADSAFE_EXPECTED 0x9BCEE9AB
+#endif
 
 /**
  * @brief Test CRC function semaphore wait for thread safety
@@ -293,15 +349,16 @@ ZTEST(crc, test_discontinuous_buf)
  */
 ZTEST(crc, test_crc_threadsafe)
 {
+
 	static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_crc));
 
 	uint8_t data[11] = {0x0A, 0x2B, 0x4C, 0x6D, 0x8E, 0x49, 0x00, 0xC4, 0x3D, 0x4D, 0x51};
 
 	struct crc_ctx ctx = {
-		.type = CRC8,
-		.polynomial = CRC8_POLY,
-		.seed = CRC8_INIT_VAL,
-		.reversed = CRC_FLAG_REVERSE_OUTPUT | CRC_FLAG_REVERSE_INPUT,
+		.type = CRC_TEST_VARIANT,
+		.polynomial = CRC_TEST_POLY,
+		.seed = CRC_TEST_INIT_VAL,
+		.reversed = CRC_TEST_REVERSE_CONFIG,
 	};
 
 	/**
@@ -323,7 +380,7 @@ ZTEST(crc, test_crc_threadsafe)
 	crc_begin(dev, &ctx);
 	crc_update(dev, &ctx, data, sizeof(data));
 	crc_finish(dev, &ctx);
-	zassert_equal(crc_verify(&ctx, RESULT_CRC_8_REMAIN_3_THREADSAFE), 0);
+	zassert_equal(crc_verify(&ctx, CRC_TEST_THREADSAFE_EXPECTED), 0);
 }
 
 ZTEST_SUITE(crc, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
This PR adds driver support for the NXP CRC (Cyclic Redundancy Check) peripheral found on MCX series microcontrollers, along with device tree bindings, board configuration, and updated samples and tests.