### PR TITLE
usb: device_next: remove udc_buf_get_all()

### DIFF
--- a/drivers/usb/udc/udc_ambiq.c
+++ b/drivers/usb/udc/udc_ambiq.c
@@ -258,14 +258,10 @@ static int udc_ambiq_ep_dequeue(const struct device *dev, struct udc_ep_config *
 {
 	unsigned int lock_key;
 	struct udc_ambiq_data *priv = udc_get_private(dev);
-	struct net_buf *buf;
 
 	lock_key = irq_lock();
 
-	buf = udc_buf_get_all(ep_cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, ep_cfg);
 
 	udc_ep_set_busy(ep_cfg, false);
 	am_hal_usb_ep_state_reset(priv->usb_handle, ep_cfg->addr);

--- a/drivers/usb/udc/udc_bflb_v1.c
+++ b/drivers/usb/udc/udc_bflb_v1.c
@@ -1350,10 +1350,7 @@ static int udc_bflb_v1_ep_dequeue(const struct device *dev,
 		fifo_rx_clear(base, ep_idx);
 	}
 
-	buf = udc_buf_get_all(ep_cfg);
-	if (buf != NULL) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, ep_cfg);
 
 	/* Clear pending completion signal to prevent stale processing */
 	atomic_and(&priv->xfer_finished, ~BIT(ep_to_bnum(ep_cfg->addr)));

--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -81,27 +81,6 @@ struct net_buf *udc_buf_get(struct udc_ep_config *const ep_cfg)
 	return k_fifo_get(&ep_cfg->fifo, K_NO_WAIT);
 }
 
-struct net_buf *udc_buf_get_all(struct udc_ep_config *const ep_cfg)
-{
-	struct net_buf *buf;
-
-	buf = k_fifo_get(&ep_cfg->fifo, K_NO_WAIT);
-	if (!buf) {
-		return NULL;
-	}
-
-	LOG_DBG("ep 0x%02x dequeue %p", ep_cfg->addr, buf);
-	for (struct net_buf *n = buf; !k_fifo_is_empty(&ep_cfg->fifo); n = n->frags) {
-		n->frags = k_fifo_get(&ep_cfg->fifo, K_NO_WAIT);
-		LOG_DBG("|-> %p ", n->frags);
-		if (n->frags == NULL) {
-			break;
-		}
-	}
-
-	return buf;
-}
-
 struct net_buf *udc_buf_peek(struct udc_ep_config *const ep_cfg)
 {
 	return k_fifo_peek_head(&ep_cfg->fifo);
@@ -125,6 +104,15 @@ void udc_ep_buf_clear_zlp(const struct net_buf *const buf)
 	struct udc_buf_info *bi = udc_get_buf_info(buf);
 
 	bi->zlp = false;
+}
+
+void udc_ep_cancel_queued(const struct device *dev, struct udc_ep_config *const cfg)
+{
+	struct net_buf *buf;
+
+	for (buf = udc_buf_get(cfg); buf; buf = udc_buf_get(cfg)) {
+		udc_submit_ep_event(dev, buf, -ECONNABORTED);
+	}
 }
 
 void udc_setup_received(const struct device *dev, const void *const setup)

--- a/drivers/usb/udc/udc_common.h
+++ b/drivers/usb/udc/udc_common.h
@@ -82,19 +82,6 @@ void udc_ep_set_busy(struct udc_ep_config *const ep_cfg,
 struct net_buf *udc_buf_get(struct udc_ep_config *const ep_cfg);
 
 /**
- * @brief Get all UDC request from endpoint FIFO.
- *
- * Get all UDC request from endpoint FIFO as single-linked list.
- * This function removes all request from endpoint FIFO and
- * is typically used to dequeue endpoint FIFO.
- *
- * @param[in] ep_cfg Pointer to endpoint configuration
- *
- * @return pointer to UDC request or NULL on error.
- */
-struct net_buf *udc_buf_get_all(struct udc_ep_config *const ep_cfg);
-
-/**
  * @brief Peek request at the head of endpoint FIFO.
  *
  * Return request from the head of endpoint FIFO without removing.
@@ -237,6 +224,19 @@ bool udc_ep_buf_has_zlp(const struct net_buf *const buf);
  * @param[in] buf    Pointer to UDC request buffer
  */
 void udc_ep_buf_clear_zlp(const struct net_buf *const buf);
+
+/**
+ * @brief Cancel all queued UDC requests
+ *
+ * UDC driver must ensure that driver will not access any of queued endpoint
+ * buffers before calling this funcition.
+ *
+ * Remove all queued requests from endpoint FIFO and submit them to USB stack.
+ *
+ * @param[in] dev Pointer to device struct of the driver instance
+ * @param[in] cfg Pointer to endpoint configuration
+ */
+void udc_ep_cancel_queued(const struct device *dev, struct udc_ep_config *const cfg);
 
 /**
  * @brief Submit control transfer data to USB stack

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1676,18 +1676,15 @@ static int udc_dwc2_ep_dequeue(const struct device *dev,
 			       struct udc_ep_config *const cfg)
 {
 	struct net_buf *buf;
+	bool invd;
 
 	udc_dwc2_ep_disable(dev, cfg, false, true);
 
-	buf = udc_buf_get_all(cfg);
-
-	if (dwc2_in_buffer_dma_mode(dev) && USB_EP_DIR_IS_OUT(cfg->addr)) {
-		for (struct net_buf *iter = buf; iter; iter = iter->frags) {
-			sys_cache_data_invd_range(iter->data, iter->len);
+	invd = dwc2_in_buffer_dma_mode(dev) && USB_EP_DIR_IS_OUT(cfg->addr);
+	for (buf = udc_buf_get(cfg); buf; buf = udc_buf_get(cfg)) {
+		if (invd) {
+			sys_cache_data_invd_range(buf->data, buf->len);
 		}
-	}
-
-	if (buf) {
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}
 
@@ -2142,6 +2139,7 @@ static int udc_dwc2_enable(const struct device *dev)
 static int udc_dwc2_disable(const struct device *dev)
 {
 	const struct udc_dwc2_config *const config = dev->config;
+	struct udc_ep_config *cfg_out = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
 	struct udc_dwc2_data *const priv = udc_get_private(dev);
 	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
 	mem_addr_t dctl_reg = (mem_addr_t)&base->dctl;
@@ -2181,8 +2179,7 @@ static int udc_dwc2_disable(const struct device *dev)
 	 * triggering Soft Reset seems to be enough on shutdown clean up.
 	 */
 	dwc2_core_soft_reset(dev);
-	buf = udc_buf_get_all(udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT));
-	if (buf) {
+	for (buf = udc_buf_get(cfg_out); buf; buf = udc_buf_get(cfg_out)) {
 		net_buf_unref(buf);
 	}
 

--- a/drivers/usb/udc/udc_it82xx2.c
+++ b/drivers/usb/udc/udc_it82xx2.c
@@ -509,7 +509,6 @@ static int it82xx2_ep_dequeue(const struct device *dev, struct udc_ep_config *co
 	const struct usb_it82xx2_config *config = dev->config;
 	struct usb_it82xx2_regs *const usb_regs = config->base;
 	struct it82xx2_usb_ep_fifo_regs *ff_regs = usb_regs->fifo_regs;
-	struct net_buf *buf;
 	unsigned int lock_key;
 	uint8_t fifo_idx;
 
@@ -522,10 +521,7 @@ static int it82xx2_ep_dequeue(const struct device *dev, struct udc_ep_config *co
 	}
 	irq_unlock(lock_key);
 
-	buf = udc_buf_get_all(cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, cfg);
 
 	udc_ep_set_busy(cfg, false);
 

--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -564,7 +564,6 @@ static int usbfsotg_ep_dequeue(const struct device *dev,
 {
 	struct usbfsotg_bd *bd;
 	unsigned int lock_key;
-	struct net_buf *buf;
 
 	bd = usbfsotg_get_ebd(dev, cfg, false);
 
@@ -573,10 +572,7 @@ static int usbfsotg_ep_dequeue(const struct device *dev,
 	irq_unlock(lock_key);
 
 	cfg->stat.halted = false;
-	buf = udc_buf_get_all(cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, cfg);
 
 	udc_ep_set_busy(cfg, false);
 

--- a/drivers/usb/udc/udc_max32.c
+++ b/drivers/usb/udc/udc_max32.c
@@ -340,16 +340,10 @@ static int udc_max32_ep_enqueue(const struct device *dev, struct udc_ep_config *
 static int udc_max32_ep_dequeue(const struct device *dev, struct udc_ep_config *const cfg)
 {
 	unsigned int lock_key;
-	struct net_buf *buf;
 
 	lock_key = irq_lock();
 
-	buf = udc_buf_get_all(cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	} else {
-		LOG_INF("ep 0x%02x queue is empty", cfg->addr);
-	}
+	udc_ep_cancel_queued(dev, cfg);
 
 	irq_unlock(lock_key);
 

--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -525,13 +525,8 @@ static int udc_mcux_ep_enqueue(const struct device *dev,
 static int udc_mcux_ep_dequeue(const struct device *dev,
 			       struct udc_ep_config *const cfg)
 {
-	struct net_buf *buf;
-
 	cfg->stat.halted = false;
-	buf = udc_buf_get_all(cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, cfg);
 
 	udc_mcux_lock(dev);
 	udc_ep_set_busy(cfg, false);

--- a/drivers/usb/udc/udc_mcux_ip3511.c
+++ b/drivers/usb/udc/udc_mcux_ip3511.c
@@ -511,13 +511,8 @@ static int udc_mcux_ep_enqueue(const struct device *dev,
 static int udc_mcux_ep_dequeue(const struct device *dev,
 			       struct udc_ep_config *const cfg)
 {
-	struct net_buf *buf;
-
 	cfg->stat.halted = false;
-	buf = udc_buf_get_all(cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, cfg);
 
 	udc_mcux_lock(dev);
 	udc_ep_set_busy(cfg, false);

--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -1503,16 +1503,9 @@ static int udc_nrf_ep_enqueue(const struct device *dev,
 static int udc_nrf_ep_dequeue(const struct device *dev,
 			      struct udc_ep_config *cfg)
 {
-	struct net_buf *buf;
-
 	nrf_usbd_legacy_ep_abort(cfg->addr);
 
-	buf = udc_buf_get_all(cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	} else {
-		LOG_INF("ep 0x%02x queue is empty", cfg->addr);
-	}
+	udc_ep_cancel_queued(dev, cfg);
 
 	udc_ep_set_busy(cfg, false);
 

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -2605,7 +2605,6 @@ static int udc_numaker_ep_enqueue(const struct device *dev, struct udc_ep_config
 
 static int udc_numaker_ep_dequeue(const struct device *dev, struct udc_ep_config *const ep_cfg)
 {
-	struct net_buf *buf;
 	struct numaker_usbd_ep *ep_cur;
 
 	/* Bind EP H/W context to EP address */
@@ -2617,10 +2616,7 @@ static int udc_numaker_ep_dequeue(const struct device *dev, struct udc_ep_config
 
 	numaker_usbd_ep_abort(ep_cur, false);
 
-	buf = udc_buf_get_all(ep_cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, ep_cfg);
 
 	return 0;
 }

--- a/drivers/usb/udc/udc_renesas_ra.c
+++ b/drivers/usb/udc/udc_renesas_ra.c
@@ -322,14 +322,10 @@ static int udc_renesas_ra_ep_dequeue(const struct device *dev, struct udc_ep_con
 {
 	struct udc_renesas_ra_data *data = udc_get_private(dev);
 	unsigned int lock_key;
-	struct net_buf *buf;
 
 	lock_key = irq_lock();
 
-	buf = udc_buf_get_all(cfg);
-	if (buf != NULL) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, cfg);
 
 	if (FSP_SUCCESS != R_USBD_XferAbort(&data->udc, cfg->addr)) {
 		return -EIO;

--- a/drivers/usb/udc/udc_rpi_pico.c
+++ b/drivers/usb/udc/udc_rpi_pico.c
@@ -734,15 +734,11 @@ static int udc_rpi_pico_ep_dequeue(const struct device *dev,
 				   struct udc_ep_config *const cfg)
 {
 	unsigned int lock_key;
-	struct net_buf *buf;
 
 	lock_key = irq_lock();
 
 	rpi_pico_ep_cancel(dev, cfg->addr);
-	buf = udc_buf_get_all(cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, cfg);
 
 	irq_unlock(lock_key);
 

--- a/drivers/usb/udc/udc_sam0.c
+++ b/drivers/usb/udc/udc_sam0.c
@@ -642,7 +642,6 @@ static int udc_sam0_ep_dequeue(const struct device *dev, struct udc_ep_config *c
 {
 	UsbDeviceEndpoint *const endpoint = sam0_get_ep_reg(dev, ep_cfg->addr);
 	unsigned int lock_key;
-	struct net_buf *buf;
 
 	lock_key = irq_lock();
 
@@ -652,11 +651,9 @@ static int udc_sam0_ep_dequeue(const struct device *dev, struct udc_ep_config *c
 		endpoint->EPSTATUSSET.bit.BK0RDY = 1;
 	}
 
-	buf = udc_buf_get_all(ep_cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-		udc_ep_set_busy(ep_cfg, false);
-	}
+	udc_ep_cancel_queued(dev, ep_cfg);
+
+	udc_ep_set_busy(ep_cfg, false);
 
 	irq_unlock(lock_key);
 

--- a/drivers/usb/udc/udc_sam_udp.c
+++ b/drivers/usb/udc/udc_sam_udp.c
@@ -567,7 +567,6 @@ static int udc_sam_udp_ep_dequeue(const struct device *dev,
 {
 	Udp *base = udc_sam_udp_get_base(dev);
 	uint8_t hw_ep = USB_EP_GET_IDX(cfg->addr);
-	struct net_buf *buf;
 
 	/* Cancel pending TX data for IN endpoints per datasheet 40.6.2.5 */
 	if (USB_EP_DIR_IS_IN(cfg->addr)) {
@@ -586,10 +585,7 @@ static int udc_sam_udp_ep_dequeue(const struct device *dev,
 	 * rapid queue/cancel cycles (unlink tests).
 	 */
 
-	buf = udc_buf_get_all(cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, cfg);
 
 	return 0;
 }

--- a/drivers/usb/udc/udc_sam_usbc.c
+++ b/drivers/usb/udc/udc_sam_usbc.c
@@ -887,7 +887,6 @@ static int udc_sam_usbc_ep_dequeue(const struct device *const dev,
 	Usbc *const base = config->base;
 	const uint8_t phys_ep = virt_to_phys_ep(dev, ep_cfg->addr);
 	unsigned int lock_key;
-	struct net_buf *buf;
 
 	lock_key = irq_lock();
 
@@ -905,11 +904,8 @@ static int udc_sam_usbc_ep_dequeue(const struct device *const dev,
 	}
 
 	/* Always dequeue pending buffers and notify class layer */
-	buf = udc_buf_get_all(ep_cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-		udc_ep_set_busy(ep_cfg, false);
-	}
+	udc_ep_cancel_queued(dev, ep_cfg);
+	udc_ep_set_busy(ep_cfg, false);
 
 	irq_unlock(lock_key);
 

--- a/drivers/usb/udc/udc_sam_usbhs.c
+++ b/drivers/usb/udc/udc_sam_usbhs.c
@@ -1038,7 +1038,6 @@ static int udc_sam_usbhs_ep_dequeue(const struct device *dev,
 	uint8_t ep_idx = ep_addr_to_hw_ep(ep_cfg->addr);
 	int bit = ep_to_bit(ep_cfg->addr);
 	unsigned int lock_key;
-	struct net_buf *buf;
 
 	lock_key = irq_lock();
 
@@ -1059,11 +1058,8 @@ static int udc_sam_usbhs_ep_dequeue(const struct device *dev,
 	 */
 	atomic_clear_bit(&priv->xfer_finished, bit);
 
-	buf = udc_buf_get_all(ep_cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-		udc_ep_set_busy(ep_cfg, false);
-	}
+	udc_ep_cancel_queued(dev, ep_cfg);
+	udc_ep_set_busy(ep_cfg, false);
 
 	irq_unlock(lock_key);
 

--- a/drivers/usb/udc/udc_skeleton.c
+++ b/drivers/usb/udc/udc_skeleton.c
@@ -119,14 +119,10 @@ static int udc_skeleton_ep_dequeue(const struct device *dev,
 				   struct udc_ep_config *const cfg)
 {
 	unsigned int lock_key;
-	struct net_buf *buf;
 
 	lock_key = irq_lock();
 
-	buf = udc_buf_get_all(cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, cfg);
 
 	irq_unlock(lock_key);
 

--- a/drivers/usb/udc/udc_smartbond.c
+++ b/drivers/usb/udc/udc_smartbond.c
@@ -675,7 +675,6 @@ static int udc_smartbond_ep_dequeue(const struct device *dev, struct udc_ep_conf
 {
 	const uint8_t ep = ep_cfg->addr;
 	unsigned int lock_key;
-	struct net_buf *buf;
 
 	LOG_INF("ep 0x%02x dequeue all", ep);
 
@@ -683,10 +682,7 @@ static int udc_smartbond_ep_dequeue(const struct device *dev, struct udc_ep_conf
 
 	udc_smartbond_ep_abort(dev, ep_cfg);
 
-	buf = udc_buf_get_all(ep_cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, ep_cfg);
 
 	udc_ep_set_busy(ep_cfg, false);
 

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1110,17 +1110,13 @@ static int udc_stm32_ep_dequeue(const struct device *dev,
 {
 	struct udc_stm32_data *priv = udc_get_private(dev);
 	__maybe_unused HAL_StatusTypeDef status;
-	struct net_buf *buf;
 
 	LOG_DBG("Flush ep 0x%02x", ep_cfg->addr);
 
 	status = HAL_PCD_EP_Flush(&priv->pcd, ep_cfg->addr);
 	__ASSERT_NO_MSG(status == HAL_OK);
 
-	buf = udc_buf_get_all(ep_cfg);
-	if (buf != NULL) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, ep_cfg);
 
 	udc_ep_set_busy(ep_cfg, false);
 

--- a/drivers/usb/udc/udc_virtual.c
+++ b/drivers/usb/udc/udc_virtual.c
@@ -306,14 +306,10 @@ static int udc_vrt_ep_dequeue(const struct device *dev,
 			      struct udc_ep_config *cfg)
 {
 	unsigned int lock_key;
-	struct net_buf *buf;
 
 	lock_key = irq_lock();
 	/* Draft dequeue implementation */
-	buf = udc_buf_get_all(cfg);
-	if (buf) {
-		udc_submit_ep_event(dev, buf, -ECONNABORTED);
-	}
+	udc_ep_cancel_queued(dev, cfg);
 	irq_unlock(lock_key);
 
 	return 0;

--- a/subsys/usb/device_next/class/usbd_msc.c
+++ b/subsys/usb/device_next/class/usbd_msc.c
@@ -708,19 +708,10 @@ static void usbd_msc_handle_request(struct usbd_class_data *c_data,
 ep_request_error:
 	if (bi->ep == msc_get_bulk_out(c_data)) {
 		ctx->num_out_queued--;
-		if (buf->frags) {
-			ctx->num_out_queued--;
-		}
 	} else if (bi->ep == msc_get_bulk_in(c_data)) {
 		ctx->num_in_queued--;
-		if (buf->frags) {
-			ctx->num_in_queued--;
-		}
 	}
 	msc_free_scsi_buf(ctx, buf->__buf);
-	if (buf->frags) {
-		msc_free_scsi_buf(ctx, buf->frags->__buf);
-	}
 	usbd_ep_buf_free(uds_ctx, buf);
 }
 

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -823,33 +823,20 @@ static int uac2_request(struct usbd_class_data *const c_data, struct net_buf *bu
 	terminal = cfg->as_terminals[as_idx];
 
 	if (is_feedback) {
-		bool clear_double = buf->frags;
-
 		if (ctx->fb_queued & BIT(as_idx)) {
 			ctx->fb_queued &= ~BIT(as_idx);
 		} else {
-			clear_double = true;
-		}
-
-		if (clear_double) {
 			ctx->fb_double &= ~BIT(as_idx);
 		}
-	} else if (!atomic_test_and_clear_bit(&ctx->as_queued, as_idx) || buf->frags) {
+	} else if (!atomic_test_and_clear_bit(&ctx->as_queued, as_idx)) {
 		atomic_clear_bit(&ctx->as_double, as_idx);
 	}
 
 	if (USB_EP_DIR_IS_OUT(ep)) {
 		ctx->ops->data_recv_cb(dev, terminal, buf->__buf, buf->len,
 				       ctx->user_data);
-		if (buf->frags) {
-			ctx->ops->data_recv_cb(dev, terminal, buf->frags->__buf,
-					       buf->frags->len, ctx->user_data);
-		}
 	} else if (!is_feedback) {
 		ctx->ops->buf_release_cb(dev, terminal, buf->__buf, ctx->user_data);
-		if (buf->frags) {
-			ctx->ops->buf_release_cb(dev, terminal, buf->frags->__buf, ctx->user_data);
-		}
 	}
 
 	usbd_ep_buf_free(uds_ctx, buf);


### PR DESCRIPTION
Function udc_buf_get_all() was intended to be a helper to remove all requests from endpoint FIFO. While for just freeing all queue the it may be argued that there may be some doubtful simplicity argument, merging multiple submitted transfers into one is just enforcing unnecessary complexity on class implementations.

At general level, every submitted (enqueued) request should get corresponding completion (request callback) call. UDC drivers were violating this sensible behavior when dequeuing (cancelling) requests by merging all submitted requests into one.

Remove udc_buf_get_all() and replace all uses with simple loops. For most classes (that submit just one request for an endpoint at a time) this has no functional difference. For classes that implement double buffering this simplifies completion handling.

---

Related discussion: https://github.com/zephyrproject-rtos/zephyr/discussions/99439