### PR TITLE
Bluetooth: Host: Add random number clarification

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -2788,6 +2788,9 @@ struct bt_le_oob {
  *       - The local identity address conflicts with the local identity address used by other
  *         roles.
  *
+ * @note This function randomly generates cryptographic material used in the pairing process, and
+ *       should be called again for each new pairing process.
+ *
  * @param[in]  id  Local identity handle (typically @ref BT_ID_DEFAULT). Corresponds to the identity
  *                 address this function will be called for.
  * @param[out] oob LE OOB information
@@ -2814,6 +2817,9 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob);
  * @note If privacy is enabled the RPA cannot be refreshed in the following
  *       cases:
  *       - Creating a connection in progress, wait for the connected callback.
+ *
+ * @note This function randomly generates cryptographic material used in the pairing process, and
+ *       should be called again for each new pairing process.
  *
  * @param[in]  adv The advertising set object
  * @param[out] oob LE OOB information

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2617,7 +2617,8 @@ void bt_le_oob_set_legacy_flag(bool enable);
  *  callback provided that the legacy method is user pairing.
  *
  *  @param conn  @ref BT_CONN_TYPE_LE connection object.
- *  @param tk Pointer to 16 byte long TK array
+ *  @param tk Pointer to 16 byte long TK array. The TK value should be generated randomly for each
+ *            new pairing process.
  *
  *  @retval 0 Success
  *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_LE connection.


### PR DESCRIPTION
Updates the `bt_le_oob_set_legacy_tk` API docs to encourage the temp key to be generated randomly for each pairing process.

Updates the `bt_le_oob_get_local` and `bt_le_ext_adv_oob_get_local` to encourage the user to generate new OOB information for each paring process.