### PR TITLE
drivers: i2c: stm32: Fix hang on read log position

### DIFF
--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -270,12 +270,16 @@ static void i2c_stm32_slave_event(const struct device *dev)
 
 	if (LL_I2C_IsActiveFlag_TXIS(i2c)) {
 		uint8_t val = 0x00;
+		int ret = slave_cb->read_processed(slave_cfg, &val);
 
-		if (slave_cb->read_processed(slave_cfg, &val) < 0) {
+		/* We should transmit the data before logging because logging could
+		 * lead the i2c slave to stretch the clock if the data are not
+		 * transmitted fast enough.
+		 */
+		LL_I2C_TransmitData8(i2c, val);
+		if (ret < 0) {
 			LOG_ERR("Error continuing reading");
 		}
-
-		LL_I2C_TransmitData8(i2c, val);
 
 		return;
 	}


### PR DESCRIPTION
Ensure that data is transmitted before logging as it could cause lockups in some setups. see #93881 

Also update i2c_stm32_v2_rtio.c to match this behavior to always send data in order to avoid the I2C to lockup.

Fixes #93881 