### PR TITLE
net: lib: dhcpv4_server: Add client hardware ID to client_id

### DIFF
--- a/include/zephyr/net/dhcpv4_server.h
+++ b/include/zephyr/net/dhcpv4_server.h
@@ -33,6 +33,12 @@ struct net_if;
 
 #define DHCPV4_CLIENT_ID_MAX_SIZE 20
 
+/**
+ * Max DHCP hardware address size is defined in RFC2131
+ * https://www.rfc-editor.org/rfc/rfc2131
+ */
+#define DHCPV4_HARDWARE_ADDRESS_MAX_SIZE 16
+
 enum dhcpv4_server_addr_state {
 	DHCPV4_SERVER_ADDR_FREE,
 	DHCPV4_SERVER_ADDR_RESERVED,
@@ -41,6 +47,10 @@ enum dhcpv4_server_addr_state {
 };
 
 struct dhcpv4_client_id {
+	uint8_t hw_addr_type;
+	uint8_t hw_addr_buf[DHCPV4_HARDWARE_ADDRESS_MAX_SIZE];
+	uint8_t hw_addr_len;
+
 	uint8_t buf[DHCPV4_CLIENT_ID_MAX_SIZE];
 	uint8_t len;
 };

--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -741,6 +741,11 @@ static int dhcpv4_get_client_id(struct dhcp_msg *msg, uint8_t *options,
 {
 	int ret;
 
+	client_id->hw_addr_type = msg->htype;
+	memcpy(client_id->hw_addr_buf, msg->chaddr, min(msg->hlen,
+			DHCPV4_HARDWARE_ADDRESS_MAX_SIZE));
+	client_id->hw_addr_len = msg->hlen;
+
 	client_id->len = sizeof(client_id->buf);
 
 	ret = dhcpv4_find_client_id_option(options, optlen, client_id->buf,


### PR DESCRIPTION
This is useful if you specifically need the hardware address
 and not the client_id option.