### PR TITLE
drivers: espressif: move ISRs into IRAM area

### DIFF
--- a/drivers/counter/counter_esp32_rtc.c
+++ b/drivers/counter/counter_esp32_rtc.c
@@ -59,7 +59,7 @@ static int counter_esp32_init(const struct device *dev)
 			       &data->clk_src_freq);
 
 	flags = ESP_PRIO_TO_FLAGS(cfg->irq_priority) | ESP_INT_FLAGS_CHECK(cfg->irq_flags) |
-			     ESP_INTR_FLAG_SHARED;
+		ESP_INTR_FLAG_SHARED | ESP_INTR_FLAG_IRAM;
 
 	ret = esp_intr_alloc(cfg->irq_source, flags,
 			     (intr_handler_t)counter_esp32_isr, (void *)dev, NULL);
@@ -288,7 +288,7 @@ static DEVICE_API(counter, rtc_timer_esp32_api) = {
 	.get_freq = counter_esp32_get_freq,
 };
 
-static void counter_esp32_isr(void *arg)
+static void IRAM_ATTR counter_esp32_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	struct counter_esp32_data *data = dev->data;

--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -92,7 +92,7 @@ static int counter_esp32_init(const struct device *dev)
 
 	int ret = esp_intr_alloc(cfg->irq_source,
 				 ESP_PRIO_TO_FLAGS(cfg->irq_priority) |
-					 ESP_INT_FLAGS_CHECK(cfg->irq_flags),
+					 ESP_INT_FLAGS_CHECK(cfg->irq_flags) | ESP_INTR_FLAG_IRAM,
 				 (intr_handler_t)counter_esp32_isr, (void *)dev, NULL);
 
 	if (ret != 0) {
@@ -330,7 +330,7 @@ static DEVICE_API(counter, counter_api) = {
 	.set_guard_period = counter_esp32_set_guard_period,
 };
 
-static void counter_esp32_isr(void *arg)
+static void IRAM_ATTR counter_esp32_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	struct counter_esp32_data *data = dev->data;

--- a/drivers/input/input_esp32_touch_sensor.c
+++ b/drivers/input/input_esp32_touch_sensor.c
@@ -136,7 +136,7 @@ static void esp32_touch_sensor_interrupt_cb(void *arg)
 	}
 }
 
-static void esp32_touch_rtc_isr(void *arg)
+static void IRAM_ATTR esp32_touch_rtc_isr(void *arg)
 {
 	uint32_t status = REG_READ(RTC_CNTL_INT_ST_REG);
 
@@ -274,7 +274,7 @@ static int esp32_touch_sensor_init(const struct device *dev)
 
 	flags = ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(touch), 0, priority)) |
 		ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(touch), 0, flags)) |
-		ESP_INTR_FLAG_SHARED;
+		ESP_INTR_FLAG_SHARED | ESP_INTR_FLAG_IRAM;
 	err = esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(touch), 0, irq), flags, esp32_touch_rtc_isr,
 			     (void *)dev, NULL);
 	if (err) {

--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -102,10 +102,9 @@ static int serial_esp32_usb_init(const struct device *dev)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	ret = esp_intr_alloc(config->irq_source,
-			ESP_PRIO_TO_FLAGS(config->irq_priority) |
-			ESP_INT_FLAGS_CHECK(config->irq_flags),
-			(intr_handler_t)serial_esp32_usb_isr,
-			(void *)dev, NULL);
+			     ESP_PRIO_TO_FLAGS(config->irq_priority) |
+				     ESP_INT_FLAGS_CHECK(config->irq_flags) | ESP_INTR_FLAG_IRAM,
+			     (intr_handler_t)serial_esp32_usb_isr, (void *)dev, NULL);
 #endif
 	return ret;
 }
@@ -222,7 +221,7 @@ static void serial_esp32_usb_irq_callback_set(const struct device *dev,
 	data->irq_cb = cb;
 }
 
-static void serial_esp32_usb_isr(void *arg)
+static void IRAM_ATTR serial_esp32_usb_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	struct serial_esp32_usb_data *data = dev->data;

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -517,7 +517,7 @@ static void uart_esp32_irq_rx_enable(const struct device *dev)
 	uart_hal_ena_intr_mask(&data->hal, UART_INTR_RXFIFO_TOUT);
 }
 
-static void uart_esp32_isr(void *arg)
+static void IRAM_ATTR uart_esp32_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	struct uart_esp32_data *data = dev->data;
@@ -955,11 +955,9 @@ static int uart_esp32_init(const struct device *dev)
 
 #if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
 	ret = esp_intr_alloc(config->irq_source,
-			ESP_PRIO_TO_FLAGS(config->irq_priority) |
-			ESP_INT_FLAGS_CHECK(config->irq_flags),
-			(intr_handler_t)uart_esp32_isr,
-			(void *)dev,
-			NULL);
+			     ESP_PRIO_TO_FLAGS(config->irq_priority) |
+				     ESP_INT_FLAGS_CHECK(config->irq_flags) | ESP_INTR_FLAG_IRAM,
+			     (intr_handler_t)uart_esp32_isr, (void *)dev, NULL);
 	if (ret < 0) {
 		LOG_ERR("Error allocating UART interrupt (%d)", ret);
 		return ret;

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -57,7 +57,7 @@ static uint64_t get_systimer_alarm(void)
 	return systimer_hal_get_counter_value(&systimer_hal, SYSTIMER_COUNTER_OS_TICK);
 }
 
-static void sys_timer_isr(void *arg)
+static void IRAM_ATTR sys_timer_isr(void *arg)
 {
 	ARG_UNUSED(arg);
 	systimer_ll_clear_alarm_int(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0);
@@ -146,12 +146,12 @@ static int sys_clock_driver_init(void)
 {
 	int ret;
 
-	ret = esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, irq),
+	ret = esp_intr_alloc(
+		DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, irq),
 		ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, priority)) |
-		ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, flags)),
-		sys_timer_isr,
-		NULL,
-		NULL);
+			ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, flags)) |
+			ESP_INTR_FLAG_IRAM,
+		sys_timer_isr, NULL, NULL);
 
 	if (ret != 0) {
 		return ret;

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -159,7 +159,8 @@ static int wdt_esp32_init(const struct device *dev)
 
 	wdt_hal_init(&data->hal, config->wdt_inst, MWDT_TICK_PRESCALER, true);
 
-	flags = ESP_PRIO_TO_FLAGS(config->irq_priority) | ESP_INT_FLAGS_CHECK(config->irq_flags);
+	flags = ESP_PRIO_TO_FLAGS(config->irq_priority) | ESP_INT_FLAGS_CHECK(config->irq_flags) |
+		ESP_INTR_FLAG_IRAM;
 	ret = esp_intr_alloc(config->irq_source, flags, (intr_handler_t)wdt_esp32_isr, (void *)dev,
 			     NULL);
 
@@ -201,7 +202,7 @@ static DEVICE_API(wdt, wdt_api) = {
 			      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	   \
 			      &wdt_api)
 
-static void wdt_esp32_isr(void *arg)
+static void IRAM_ATTR wdt_esp32_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	struct wdt_esp32_data *data = dev->data;

--- a/drivers/watchdog/xt_wdt_esp32.c
+++ b/drivers/watchdog/xt_wdt_esp32.c
@@ -7,7 +7,7 @@
 
 #include <soc/rtc_cntl_reg.h>
 #include <hal/xt_wdt_hal.h>
-#include <rom/ets_sys.h>
+#include <esp_attr.h>
 
 #include <string.h>
 #include <zephyr/drivers/watchdog.h>
@@ -85,7 +85,7 @@ static int esp32_xt_wdt_install_timeout(const struct device *dev,
 	return 0;
 }
 
-static void esp32_xt_wdt_isr(void *arg)
+static void IRAM_ATTR esp32_xt_wdt_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	const struct esp32_xt_wdt_config *cfg = dev->config;
@@ -123,7 +123,7 @@ static int esp32_xt_wdt_init(const struct device *dev)
 	xt_wdt_hal_enable_backup_clk(&data->hal, ESP32_RTC_SLOW_CLK_SRC_RC_SLOW_FREQ/1000);
 
 	flags = ESP_PRIO_TO_FLAGS(cfg->irq_priority) | ESP_INT_FLAGS_CHECK(cfg->irq_flags) |
-		ESP_INTR_FLAG_SHARED;
+		ESP_INTR_FLAG_SHARED | ESP_INTR_FLAG_IRAM;
 	err = esp_intr_alloc(cfg->irq_source, flags, (intr_handler_t)esp32_xt_wdt_isr, (void *)dev,
 			     NULL);
 	if (err) {


### PR DESCRIPTION
Most of Espressif drivers ISRs are already running in IRAM area, except those in this PR. Move ISRs accordingly so we avoid any interrupt miss when cache is disabled.