### PR TITLE
Bluetooth: Host: settings without snprintk use

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -376,7 +376,6 @@ static struct net_buf *att_create_rsp_pdu(struct bt_att_chan *chan, uint8_t op);
 
 static void att_disconnect(struct bt_att_chan *chan)
 {
-	char addr[BT_ADDR_LE_STR_LEN];
 	int err;
 
 	/* In rare circumstances we are "forced" to disconnect the ATT bearer and the ACL.
@@ -385,8 +384,7 @@ static void att_disconnect(struct bt_att_chan *chan)
 	 * invalid
 	 */
 
-	bt_addr_le_to_str(bt_conn_get_dst(chan->att->conn), addr, sizeof(addr));
-	LOG_DBG("ATT disconnecting device %s", addr);
+	LOG_DBG("ATT disconnecting device %s", bt_addr_le_str(bt_conn_get_dst(chan->att->conn)));
 
 	bt_att_disconnected(&chan->chan.chan);
 
@@ -3195,12 +3193,11 @@ static void att_chan_detach(struct bt_att_chan *chan)
 
 static void att_timeout(struct k_work *work)
 {
-	char addr[BT_ADDR_LE_STR_LEN];
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct bt_att_chan *chan = CONTAINER_OF(dwork, struct bt_att_chan, timeout_work);
 
-	bt_addr_le_to_str(bt_conn_get_dst(chan->att->conn), addr, sizeof(addr));
-	LOG_ERR("ATT Timeout for device %s. Disconnecting...", addr);
+	LOG_ERR("ATT Timeout for device %s. Disconnecting...",
+		bt_addr_le_str(bt_conn_get_dst(chan->att->conn)));
 
 	/* BLUETOOTH SPECIFICATION Version 4.2 [Vol 3, Part F] page 480:
 	 *

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -87,9 +87,9 @@ int bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
 
 	/* Concatenate subsys as much the free space permits */
 	strncpy(&path[len], subsys, (path_size - len));
+	len += MIN(strlen(subsys), (path_size - len));
 
 	/* Postfix '/' if there is free space */
-	len = strlen(path);
 	if (len < path_size) {
 		path[len] = '/';
 		len++;
@@ -97,8 +97,7 @@ int bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
 
 	/* Concatenate addr as much the free space permits */
 	for (int8_t i = 5; i >= 0 && len < path_size; i--) {
-		len += bin2hex(&addr->a.val[i], 1, &path[len],
-			       path_size - len);
+		len += bin2hex(&addr->a.val[i], 1, &path[len], (path_size - len));
 	}
 
 	/* Postfix addr type if there is free space */
@@ -114,11 +113,11 @@ int bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
 	if ((key != NULL) && (len < path_size)) {
 		path[len] = '/';
 		len++;
-		strncpy(&path[len], key, path_size - len);
-		len += strlen(&path[len]);
+		strncpy(&path[len], key, (path_size - len));
+		len += MIN(strlen(key), (path_size - len));
 	}
 
-	/* Insufficient path_size, include null termination */
+	/* Insufficient path_size, including null termination */
 	if (len >= path_size) {
 		return -EINVAL;
 	}
@@ -143,10 +142,10 @@ static int bt_settings_encode_key_no_addr(char *path, size_t path_size, const ch
 	strcpy(path, "bt/");
 
 	/* Concatenate key as much the free space permits */
-	strncpy(&path[len], key, path_size - len);
-	len = strlen(path);
+	strncpy(&path[len], key, (path_size - len));
+	len += MIN(strlen(key), (path_size - len));
 
-	/* Insufficient path_size, include null termination */
+	/* Insufficient path_size, including null termination */
 	if (len >= path_size) {
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -24,7 +24,6 @@
 
 #include "common/bt_settings_commit.h"
 #include "common/bt_str.h"
-#include "common/assert.h"
 #include "hci_core.h"
 #include "settings.h"
 #include "sys/types.h"
@@ -76,8 +75,10 @@ int bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
 {
 	size_t len = 3;
 
-	/* path_size is less than 3; strlen("bt/") */
-	BT_ASSERT(path_size >= len);
+	/* path_size is less than or equal 3; strlen("bt/") */
+	if (path_size <= len) {
+		return -EINVAL;
+	}
 
 	/* Key format:
 	 *  "bt/<subsys>/<addr><type>/<key>", "/<key>" is optional
@@ -117,10 +118,9 @@ int bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
 		len += strlen(&path[len]);
 	}
 
-	/* If path string is full, always null terminate at path_size */
+	/* Insufficient path_size, include null termination */
 	if (len >= path_size) {
-		/* Truncate string */
-		path[path_size - 1] = '\0';
+		return -EINVAL;
 	}
 
 	LOG_DBG("Encoded path %s", path);
@@ -132,8 +132,10 @@ static int bt_settings_encode_key_no_addr(char *path, size_t path_size, const ch
 {
 	size_t len = 3;
 
-	/* path_size is less than 3; strlen("bt/") */
-	BT_ASSERT(path_size >= len);
+	/* path_size is less than or equal 3; strlen("bt/") */
+	if (path_size <= len) {
+		return -EINVAL;
+	}
 
 	/* Key format:
 	 *  "bt/<key>"
@@ -144,10 +146,9 @@ static int bt_settings_encode_key_no_addr(char *path, size_t path_size, const ch
 	strncpy(&path[len], key, path_size - len);
 	len = strlen(path);
 
-	/* If path string is full, always null terminate at path_size */
+	/* Insufficient path_size, include null termination */
 	if (len >= path_size) {
-		/* Truncate string */
-		path[path_size - 1] = '\0';
+		return -EINVAL;
 	}
 
 	LOG_DBG("Encoded path %s", path);

--- a/subsys/bluetooth/host/settings.h
+++ b/subsys/bluetooth/host/settings.h
@@ -32,7 +32,7 @@ void bt_testing_settings_store_hook(const char *key, const void *value, size_t v
 void bt_testing_settings_delete_hook(const char *key);
 
 /* Helpers for keys containing a bdaddr */
-void bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
+int bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
 			    const bt_addr_le_t *addr, const char *key);
 int bt_settings_decode_key(const char *key, bt_addr_le_t *addr);
 

--- a/tests/bsim/bluetooth/host/privacy/peripheral/prj_no_snprintk.conf
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/prj_no_snprintk.conf
@@ -18,8 +18,8 @@ CONFIG_NVS=y
 CONFIG_SETTINGS=y
 CONFIG_BT_SETTINGS=y
 
-# Lets cover settings with use of snprintk
-CONFIG_BT_SETTINGS_USE_PRINTK=y
+# Lets cover settings without use of snprintk
+CONFIG_BT_SETTINGS_USE_PRINTK=n
 
 # Increased stack due to settings API usage
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_no_snprintk.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_no_snprintk.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+verbosity_level=2
+simulation_id="host_privacy_peripheral_no_snprintk"
+EXECUTE_TIMEOUT=240
+
+central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_no_snprintk_conf"
+peripheral_exe="${central_exe}"
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute "$central_exe" \
+    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -RealEncryption=1 \
+    -flash="${simulation_id}.central.log.bin" -flash_erase
+
+Execute "$peripheral_exe" \
+    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -RealEncryption=1 \
+    -flash="${simulation_id}.peripheral.log.bin" -flash_erase
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+    -D=2 -sim_length=70e6 $@
+
+wait_for_background_jobs
+
+Execute "$central_exe" \
+    -v=${verbosity_level} -s=${simulation_id}.2 -d=0 -testid=central -RealEncryption=1 \
+    -flash="${simulation_id}.central.log.bin" -flash_rm
+
+Execute "$peripheral_exe" \
+    -v=${verbosity_level} -s=${simulation_id}.2 -d=1 -testid=peripheral -RealEncryption=1 \
+    -flash="${simulation_id}.peripheral.log.bin" -flash_rm
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id}.2 \
+    -D=2 -sim_length=70e6 $@
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/privacy/peripheral/testcase.yaml
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/testcase.yaml
@@ -12,6 +12,11 @@ tests:
   bluetooth.host.privacy.peripheral:
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_privacy_peripheral_prj_conf
+  bluetooth.host.privacy.peripheral_no_snprintk:
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_host_privacy_peripheral_prj_no_snprintk_conf
+    extra_args:
+      EXTRA_CONF_FILE=prj_no_snprintk.conf
   bluetooth.host.privacy.peripheral_rpa_expired:
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_privacy_peripheral_prj_rpa_expired_conf


### PR DESCRIPTION
Update settings implementation for not reusing the OS snprintk implementation with CONFIG_PRINTK=n.

With PR ​

```
west build -p -d build/peripheral_hids_nrf54l15dk -b nrf54l15dk/nrf54l15/cpuapp samples/bluetooth/peripheral_hids -DCONFIG_BOOT_BANNER=n -DCONFIG_PRINTK=n -DCONFIG_BT_SETTINGS_USE_PRINTK=n -DCONFIG_LOG=n -DCONFIG_OUTPUT_DISASSEMBLY=y
```


```
Memory region         Used Size  Region Size  %age Used
           FLASH:      155012 B      1428 KB     10.60%
             RAM:       27420 B       188 KB     14.24%
        IDT_LIST:          0 GB        32 KB      0.00%
```


Without PR, base branch https://github.com/zephyrproject-rtos/zephyr/tree/0b52928625b06b6b8de9b56524fbc1ae5f8cbd6a

```
Memory region         Used Size  Region Size  %age Used
           FLASH:      157012 B      1428 KB     10.74%
             RAM:       27420 B       188 KB     14.24%
        IDT_LIST:          0 GB        32 KB      0.00%
```
​

[0001-samples-Bluetooth-peripheral_hids-Reduce-code-size-w.patch](https://github.com/user-attachments/files/24770057/0001-samples-Bluetooth-peripheral_hids-Reduce-code-size-w.patch)

20260121:
```
-- Zephyr version: 4.3.99 (/home/vich/workspace/zephyrproject/zephyr), build: v4.3.0-2228-g3aa46ff1adea
[387/387] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      154912 B      1428 KB     10.59%
             RAM:       27420 B       188 KB     14.24%
        IDT_LIST:          0 GB        32 KB      0.00%
```

