### PR TITLE
test: drivers: spi: siwx91x: Fix undefined CS

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/siwx917_dk2605a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/siwx917_dk2605a.overlay
@@ -33,7 +33,7 @@
 
 	fast@1 {
 		compatible = "test-spi-loopback-fast";
-		reg = <1>;
+		reg = <0>;
 		spi-max-frequency = <10000000>;
 	};
 };


### PR DESCRIPTION
No GPIO was defined for CS 1. It caused NULL pointer exception during the test.