### PR TITLE
west.yml: hal_stm32: update to add LPTIM pins

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -255,7 +255,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 9d05ebdff47b5071fa092de243a1244e7c27f518
+      revision: 90e120b55e6b7134048f1469eda620e8b21bb84d
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update hal_stm32 to include pin definitions for LPTIM peripheral.