### PR TITLE
REUSE.toml: Default annotate json files

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,6 +1,6 @@
 version = 1
 
-# Declare default license and copyright text for files that typically do not include them.
+# Declare default license and copyright text for files that typically do not or cannot include them.
 [[annotations]]
 path = [
     # zephyr-keep-sorted-start
@@ -9,6 +9,7 @@ path = [
     "**/*.conf",
     "**/*.ecl",
     "**/*.html",
+    "**/*.json",
     "**/*.rst",
     "**/*.yaml",
     "**/*.yml",


### PR DESCRIPTION
It's not possible to add comments to a json file, so there's no option to add license or copyright text.