### PR TITLE
doc: spelling/typo fixes

### DIFF
--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -230,7 +230,7 @@ The full list of registered objects and resource IDs can be found in the
 Zephyr's LwM2M library lives in the :zephyr_file:`subsys/net/lib/lwm2m`, with a
 client sample in :zephyr_file:`samples/net/lwm2m_client`.  For more information
 about the provided sample see: :zephyr:code-sample:`lwm2m-client`. The sample can be
-configured to use normal unsecure network sockets or sockets secured via DTLS.
+configured to use normal insecure network sockets or sockets secured via DTLS.
 
 The Zephyr LwM2M library implements the following items:
 

--- a/doc/develop/flash_debug/probes.rst
+++ b/doc/develop/flash_debug/probes.rst
@@ -481,7 +481,7 @@ OpenOCD Deprecates HLA ST-Link Interface
 ========================================
 
 OpenOCD has deprecated the legacy HLA interface used by ST-Link firmware in favor to the
-generic DAP interface in Januray 2024 (see `OpenOCD deprecates ST-Link HLA Interface`_)
+generic DAP interface in January 2024 (see `OpenOCD deprecates ST-Link HLA Interface`_)
 in favor of the generic DAP interface. DAP interface is supported by ST-Link firmware
 since 2015 (from version v2j24).
 

--- a/doc/hardware/pinctrl/index.rst
+++ b/doc/hardware/pinctrl/index.rst
@@ -282,7 +282,7 @@ particular state are enclosed in a single Devicetree node.
 Another popular model is based on having a node for each pin configuration and
 state. While this model may lead to shorter board pin control files, it also
 requires to have one node for each pin mapping and state, since in general,
-nodes can not be re-used for multiple states. This method is discouraged if
+nodes can not be reused for multiple states. This method is discouraged if
 autogeneration is not an option.
 
 .. note::

--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -515,7 +515,7 @@ files for a board named ``plank``:
   Kconfig trees.
 
   This file selects the SoC in the Kconfig tree and potential other SoC related
-  Kconfig settings. This file must not select anything outside the re-usable
+  Kconfig settings. This file must not select anything outside the reusable
   Kconfig board and SoC trees.
 
   A :file:`Kconfig.plank` may look like this:

--- a/doc/hardware/porting/soc_porting.rst
+++ b/doc/hardware/porting/soc_porting.rst
@@ -225,7 +225,7 @@ files for a SoC:
 
   This file selects the SoC family and series in the Kconfig tree and potential
   other SoC related Kconfig settings. In some cases a SOC_PART_NUMBER.
-  This file must not select anything outside the re-usable Kconfig SoC tree.
+  This file must not select anything outside the reusable Kconfig SoC tree.
 
   A :file:`Kconfig.soc` may look like this:
 

--- a/doc/kernel/data_structures/slist.rst
+++ b/doc/kernel/data_structures/slist.rst
@@ -89,7 +89,7 @@ internal "Z_GENLIST" template API which allows for extracting those
 fields from arbitrary structures and emits an arbitrarily named set of
 functions.  This allows for implementing more complicated
 single-linked list variants using the same basic primitives.  The
-genlist implementor is responsible for a custom implementation of the
+genlist implementer is responsible for a custom implementation of the
 primitive operations only: an "init" step for each struct, and a "get"
 and "set" primitives for each of head, tail and next pointers on their
 relevant structs.  These inline functions are passed as parameters to

--- a/doc/kernel/services/threads/index.rst
+++ b/doc/kernel/services/threads/index.rst
@@ -93,7 +93,7 @@ thread self-exits, or the target thread aborts (either due to a
 
 Once a thread has terminated, the kernel guarantees that no use will
 be made of the thread struct.  The memory of such a struct can then be
-re-used for any purpose, including spawning a new thread.  Note that
+reused for any purpose, including spawning a new thread.  Note that
 the thread must be fully terminated, which presents race conditions
 where a thread's own logic signals completion which is seen by another
 thread before the kernel processing is complete.  Under normal
@@ -563,7 +563,7 @@ The following code illustrates the ways a thread can terminate.
     }
 
 If :kconfig:option:`CONFIG_USERSPACE` is enabled, aborting a thread will additionally
-mark the thread and stack objects as uninitialized so that they may be re-used.
+mark the thread and stack objects as uninitialized so that they may be reused.
 
 Runtime Statistics
 ******************

--- a/doc/security/security-overview.rst
+++ b/doc/security/security-overview.rst
@@ -66,7 +66,7 @@ with security implications. The effects on security of not implementing
 a MUST or SHOULD, or doing something the specification says MUST NOT or
 SHOULD NOT be done may be very subtle. Document authors should take the
 time to elaborate the security implications of not following
-recommendations or requirements as most implementors will not have had
+recommendations or requirements as most implementers will not have had
 the benefit of the experience and discussion that produced the
 specification."
 

--- a/doc/services/zbus/index.rst
+++ b/doc/services/zbus/index.rst
@@ -913,7 +913,7 @@ illustrates the runtime registration usage.
 
 .. warning::
 
-  The :c:struct:`zbus_observer_node` can only be re-used in :c:func:`zbus_chan_add_obs_with_node` after removing
+  The :c:struct:`zbus_observer_node` can only be reused in :c:func:`zbus_chan_add_obs_with_node` after removing
   the channel observer it was first associated with through :c:func:`zbus_chan_rm_obs`.
 
 
@@ -974,7 +974,7 @@ Related configuration options:
 * :kconfig:option:`CONFIG_ZBUS_OBSERVER_NAME` enables the name of observers to be available inside
   the channels metadata;
 * :kconfig:option:`CONFIG_ZBUS_PREFER_DYNAMIC_ALLOCATION` instructs zbus to
-  use dynamic allocation for its internals. That can be disabled by the user and tunned later;
+  use dynamic allocation for its internals. That can be disabled by the user and tuned later;
 * :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER` enables the message subscriber observer type;
 * :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC` uses the heap to allocate message
   buffers;


### PR DESCRIPTION
minor spelling/typo fixes, mainly around using proper US English