### PR TITLE
ci: tags: Make sure openthread tag is used on OT changes

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6109,6 +6109,8 @@ West:
     - modules/openthread/
   labels:
     - "area: OpenThread"
+  tests:
+    - openthread
 
 "West project: percepio":
   status: maintained

--- a/modules/openthread/platform/infra_if.c
+++ b/modules/openthread/platform/infra_if.c
@@ -392,21 +392,21 @@ static void remove_checksums_for_eth_offloading(uint8_t *buf, uint16_t len)
 	}
 
 	switch (ipv4_hdr->proto) {
-	case NET_IPPROTO_ICMP:
+	case IPPROTO_ICMP:
 		if ((config.chksum_support & NET_IF_CHECKSUM_IPV4_ICMP) != 0) {
 			struct net_icmp_hdr *icmp_hdr = (struct net_icmp_hdr *)pkt_cursor;
 
 			icmp_hdr->chksum = 0;
 		}
 	break;
-	case NET_IPPROTO_UDP:
+	case IPPROTO_UDP:
 		if ((config.chksum_support & NET_IF_CHECKSUM_IPV4_UDP) != 0) {
 			struct net_udp_hdr *udp_hdr = (struct net_udp_hdr *)pkt_cursor;
 
 			udp_hdr->chksum = 0;
 		}
 	break;
-	case NET_IPPROTO_TCP:
+	case IPPROTO_TCP:
 		if ((config.chksum_support & NET_IF_CHECKSUM_IPV4_TCP) != 0) {
 			struct net_tcp_hdr *tcp_hdr = (struct net_tcp_hdr *)pkt_cursor;
 

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -76,6 +76,11 @@ net:
     - drivers/ieee802154/
     - drivers/ptp_clock/
 
+openthread:
+  files:
+    - modules/openthread/
+    - subsys/net/l2/openthread/
+
 posix:
   files:
     - lib/posix/


### PR DESCRIPTION
Use namespaced variants instead.

Note: I have purposedly skipped one symbol to see if CI triggers and catches the issue this time. Will update after getting results.