### PR TITLE
debug: coredump: add cpp header guards

### DIFF
--- a/include/zephyr/debug/coredump.h
+++ b/include/zephyr/debug/coredump.h
@@ -11,6 +11,10 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Define COREDUMP_*_STR as public to allow coredump_backend_other to re-use
  * these strings if necessary
@@ -353,5 +357,9 @@ static inline int coredump_cmd(enum coredump_cmd_id query_id, void *arg)
 /**
  * @}
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_DEBUG_COREDUMP_H_ */


### PR DESCRIPTION
Add header guards to support usage from C++.