### PR TITLE
Fix relocation of unique section names

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -200,13 +200,17 @@ do {                                                                    \
 				"." Z_STRINGIFY(c))))
 #define __in_section(a, b, c) ___in_section(a, b, c)
 
+#define ___in_section_unique(a, b) \
+	__attribute__((section("." Z_STRINGIFY(a)		\
+				"." __FILE__			\
+				"." Z_STRINGIFY(b))))
+
 #ifndef __in_section_unique
-#define __in_section_unique(seg) ___in_section(seg, __FILE__, __COUNTER__)
+#define __in_section_unique(seg) ___in_section_unique(seg, __COUNTER__)
 #endif
 
 #ifndef __in_section_unique_named
-#define __in_section_unique_named(seg, name) \
-	___in_section(seg, __FILE__, name)
+#define __in_section_unique_named(seg, name) ___in_section_unique(seg, name)
 #endif
 
 /* When using XIP, using '__ramfunc' places a function into RAM instead

--- a/include/zephyr/toolchain/iar/iccarm.h
+++ b/include/zephyr/toolchain/iar/iccarm.h
@@ -121,10 +121,14 @@ do {                                                                    \
 				"." Z_STRINGIFY(c))))
 #define __in_section(a, b, c) ___in_section(a, b, c)
 
-#define __in_section_unique(seg) ___in_section(seg, __FILE__, __COUNTER__)
+#define ___in_section_unique(a, b) \
+	__attribute__((section("." Z_STRINGIFY(a)		\
+				"." __FILE__			\
+				"." Z_STRINGIFY(b))))
 
-#define __in_section_unique_named(seg, name) \
-	___in_section(seg, __FILE__, name)
+#define __in_section_unique(seg) ___in_section_unique(seg, __COUNTER__)
+
+#define __in_section_unique_named(seg, name) ___in_section_unique(seg, name)
 
 /* When using XIP, using '__ramfunc' places a function into RAM instead
  * of FLASH. Make sure '__ramfunc' is defined only when

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -101,11 +101,11 @@ class OutputSection(NamedTuple):
 
 
 PRINT_TEMPLATE = """
-                KEEP(*{obj_file_name}({section_name}))
+                KEEP(*{obj_file_name}("{section_name}"))
 """
 
 PRINT_TEMPLATE_NOKEEP = """
-                *{obj_file_name}({section_name})
+                *{obj_file_name}("{section_name}")
 """
 
 SECTION_LOAD_MEMORY_SEQ = """


### PR DESCRIPTION
Ld splits section names with quotes into multiple blocks, which is why it cannot match such patterns.
This fix adds macro ___in_section_unique(), which uses __FILE__ to generate unique section names without re-stringification.
Also this fix updates gen_relocate_app.py script to work with section names containing special characters.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/49155

I've attempted to relocate thread stacks from SRAM to TCM memory using CONFIG_CODE_DATA_RELOCATION:
```
zephyr_code_relocate(FILES ${ZEPHYR_BASE}/src/main.c LOCATION TCM_NOINIT)
```

With it I have such generated linker.cmd:
```
 .tcm_noinit_reloc (NOLOAD) :
        {
                . = ALIGN(4);
                KEEP(*main.c.obj(.noinit."WEST_TOPDIR/src/main.c".0))
                . = ALIGN(4);
 } > TCM
```

In compiled app I see a strange pattern and that TCM has no required sections:
```
.tcm_noinit_reloc
                0x42000000        0x0
                0x42000000                        . = ALIGN (0x4)
 *main.c.obj(SORT_BY_ALIGNMENT(.noinit.) SORT_BY_ALIGNMENT(WEST_TOPDIR/src/main.c) SORT_BY_ALIGNMENT(.0))
                0x42000000                        . = ALIGN (0x4)
                0x42000000                        __tcm_noinit_reloc_end = .
                0x42000000                        __tcm_noinit_reloc_start = ADDR (.tcm_noinit_reloc)
                0x00000000                        __tcm_noinit_reloc_size = (__tcm_noinit_reloc_end - __tcm_noinit_reloc_start)
```

Sections I wanted to relocate were processed with wildcard pattern `.noinit.*` and placed in SRAM:
```
noinit          0x80058c90     0xa818
 *(SORT_BY_ALIGNMENT(.noinit))
 *(SORT_BY_ALIGNMENT(.noinit.*))
 .noinit."WEST_TOPDIR/src/main.c".0
                0x80058c90     0x1000 app/libapp.a(main.c.obj)
                0x80058c90                mgm_stack_area
```

With this patch generated linker.cmd:
```
 .tcm_noinit_reloc (NOLOAD) :
        {
                . = ALIGN(4);
                KEEP(*main.c.obj(".noinit.WEST_TOPDIR/src/main.c.0"))
                . = ALIGN(4);
 } > TCM
```

Expected sections are correctly transferred to TCM (and pattern is correct):
```
.tcm_noinit_reloc
                0x42000000     0x1000
                0x42000000                        . = ALIGN (0x4)
 *main.c.obj(SORT_BY_ALIGNMENT(.noinit.WEST_TOPDIR/src/main.c.0))
 .noinit.WEST_TOPDIR/src/main.c.0
                0x42000000     0x1000 app/libapp.a(main.c.obj)
                0x42000000                mgm_stack_area
```

I tested the fix with paths contain '@' in directory names. Section relocation works without issues.

But I tested the fix only using gcc and llvm, not iar. I don't have it.
