### PR TITLE
tests: arch: arm: vector_table: disable PM for nrf54h20 cpurad

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpurad.conf
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_POWER_DOMAIN=n
+CONFIG_PM=n


### PR DESCRIPTION
The nrf54h20 cpurad has CONFIG_PM enabled by default. This causes some of the IRQs reserved for the test to be triggered as they are used for PM as well. Disable PM for the test to make sure nothing triggers the IRQs outside of the test itself.

Fault caused if CONFIG_PM is enabled
```
E: ***** MPU FAULT *****
E:   Instruction Access Violation
E: r0/a1:  0x00000000  r1/a2:  0x00000000  r2/a3:  0x00000001
E: r3/a4:  0x5f9c6000 r12/ip:  0x00000000 r14/lr:  0xfffffffd
E:  xpsr:  0x090001d6
E: Faulting instruction address (r15/pc): 0xf487fab6
E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
E: Fault during interrupt handling

E: Current thread: 0x23000308 (main)
E: Halting system
```