### PR TITLE
drivers: display: stm32_ltdc: remove unnecessary `depends on` in Kconfig

### DIFF
--- a/drivers/display/Kconfig.stm32_ltdc
+++ b/drivers/display/Kconfig.stm32_ltdc
@@ -19,7 +19,6 @@ if STM32_LTDC
 choice STM32_LTDC_PIXEL_FORMAT
 	prompt "Color pixel format"
 	default STM32_LTDC_RGB565
-	depends on STM32_LTDC
 	help
 	  Specify the color pixel format for the STM32 LCD-TFT display controller.
 


### PR DESCRIPTION
`choice STM32_LTDC_PIXEL_FORMAT` is already enclosed in an `if STM32_LTDC` block - there is no need to add a `depends on` on this option.