### PR TITLE
dts: arm: st: h7/h7rs: add memory-regions property to mac node

### DIFF
--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -27,7 +27,8 @@
 			clocks = <&rcc STM32_CLOCK(AHB1, 19)>;
 
 			mac: ethernet {
-				compatible = "st,stm32h7-ethernet", "st,stm32-ethernet";
+				compatible = "st,stm32h5-ethernet", "st,stm32h7-ethernet",
+					     "st,stm32-ethernet";
 				interrupts = <106 0>;
 				clock-names = "mac-clk-tx", "mac-clk-rx";
 				clocks = <&rcc STM32_CLOCK(AHB1, 20)>,

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1156,6 +1156,7 @@
 				clock-names = "mac-clk-tx", "mac-clk-rx";
 				clocks = <&rcc STM32_CLOCK(AHB1, 16)>,
 					 <&rcc STM32_CLOCK(AHB1, 17)>;
+				memory-regions = <&sram2>;
 				status = "disabled";
 			};
 

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -223,6 +223,7 @@
 		reg = <0x30004000 DT_SIZE_K(16)>;
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM2";
+		#memory-region-cells = <0>;
 	};
 
 	/* D3 domain, AHB SRAM  */

--- a/dts/arm/st/h7/stm32h742.dtsi
+++ b/dts/arm/st/h7/stm32h742.dtsi
@@ -81,6 +81,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30020000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM2";
+		#memory-region-cells = <0>;
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM4 in D3 domain  */

--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -25,6 +25,7 @@
 	/* System data RAM accessible over AHB bus: SRAM2 in D2 domain */
 	sram2: memory@30020000 {
 		reg = <0x30020000 DT_SIZE_K(128)>;
+		#memory-region-cells = <0>;
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM3 in D2 domain */
@@ -32,5 +33,10 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30040000 DT_SIZE_K(32)>;
 		zephyr,memory-region = "SRAM3";
+		#memory-region-cells = <0>;
 	};
+};
+
+&mac {
+	memory-regions = <&sram3>;
 };

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -109,6 +109,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30020000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "SRAM2";
+		#memory-region-cells = <0>;
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM3 in D2 domain */
@@ -116,6 +117,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30040000 DT_SIZE_K(32)>;
 		zephyr,memory-region = "SRAM3";
+		#memory-region-cells = <0>;
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM4 in D3 domain  */
@@ -137,4 +139,8 @@
 	vbat: vbat {
 		io-channels = <&adc3 17>;
 	};
+};
+
+&mac {
+	memory-regions = <&sram3>;
 };

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -129,6 +129,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x240a0000 DT_SIZE_K(384)>;
 		zephyr,memory-region = "SRAM2";
+		#memory-region-cells = <0>;
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM1 in CD domain */
@@ -136,6 +137,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "SRAM3";
+		#memory-region-cells = <0>;
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM2 in CD domain  */
@@ -179,4 +181,8 @@
 	vbat: vbat {
 		io-channels = <&adc2 14>;
 	};
+};
+
+&mac {
+	memory-regions = <&sram3>;
 };

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -61,6 +61,7 @@
 		reg = <0x30000000 DT_SIZE_K(16)>;
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM1";
+		#memory-region-cells = <0>;
 		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
 	};
 
@@ -69,6 +70,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30004000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM2";
+		#memory-region-cells = <0>;
 		/* Disable SRAM2 by default to avoid unintended access.
 		 * To enable it, explicitly define zephyr,memory-attr
 		 * to configure MPU attributes.
@@ -937,6 +939,7 @@
 				clock-names = "mac-clk-tx", "mac-clk-rx";
 				clocks = <&rcc STM32_CLOCK(AHB1, 16)>,
 					 <&rcc STM32_CLOCK(AHB1, 17)>;
+				memory-regions = <&sram2>;
 				status = "disabled";
 			};
 

--- a/dts/arm/st/h7rs/stm32h7s3.dtsi
+++ b/dts/arm/st/h7rs/stm32h7s3.dtsi
@@ -14,3 +14,7 @@
 		compatible = "st,stm32h7s3", "st,stm32h7rs", "simple-bus";
 	};
 };
+
+&mac {
+	memory-regions = <&sram1>;
+};

--- a/dts/arm/st/h7rs/stm32h7s7.dtsi
+++ b/dts/arm/st/h7rs/stm32h7s7.dtsi
@@ -14,3 +14,7 @@
 		compatible = "st,stm32h7s7", "st,stm32h7rs", "simple-bus";
 	};
 };
+
+&mac {
+	memory-regions = <&sram1>;
+};

--- a/dts/bindings/ethernet/st,stm32h5-ethernet.yaml
+++ b/dts/bindings/ethernet/st,stm32h5-ethernet.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2025, Benjamin Klaric <benjamin.klaric01@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32H5 Ethernet
+
+  This binding file describes the device tree properties required to configure
+  and use the Ethernet controller on STM32H5 series microcontrollers.
+
+compatible: "st,stm32h5-ethernet"
+
+include: st,stm32-ethernet-common.yaml

--- a/dts/bindings/ethernet/st,stm32h7-ethernet.yaml
+++ b/dts/bindings/ethernet/st,stm32h7-ethernet.yaml
@@ -9,4 +9,12 @@ description: |
 
 compatible: "st,stm32h7-ethernet"
 
-include: st,stm32-ethernet-common.yaml
+include:
+  - "st,stm32-ethernet-common.yaml"
+  - "memory-region.yaml"
+
+properties:
+  memory-regions:
+    required: true
+    description: |
+      Reference to SRAM node used for Ethernet DMA buffer and descriptor.

--- a/dts/bindings/ethernet/st,stm32h7-ethernet.yaml
+++ b/dts/bindings/ethernet/st,stm32h7-ethernet.yaml
@@ -5,9 +5,7 @@ description: |
   STM32H7 Ethernet
 
   This binding file describes the device tree properties required to configure
-  and use the Ethernet controller on STM32H7 and STM32H5 series microcontrollers.
-  The `st,stm32h7-ethernet` compatible string can be used for both series,
-  ensuring flexibility and ease of configuration.
+  and use the Ethernet controller on STM32H7 series microcontrollers.
 
 compatible: "st,stm32h7-ethernet"
 

--- a/soc/st/stm32/stm32h7rsx/sections.ld
+++ b/soc/st/stm32/stm32h7rsx/sections.ld
@@ -5,7 +5,8 @@
  */
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mac))
-#define sram_eth_node	DT_NODELABEL(sram2)
+#define sram_eth_node DT_PHANDLE(DT_NODELABEL(mac), memory_regions)
+
 #if DT_NODE_HAS_STATUS_OKAY(sram_eth_node)
 SECTION_DATA_PROLOGUE(eth_stm32,(NOLOAD),)
 {

--- a/soc/st/stm32/stm32h7x/mpu_regions.c
+++ b/soc/st/stm32/stm32h7x/mpu_regions.c
@@ -7,6 +7,13 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mac))
+#define sram_eth_node DT_PHANDLE(DT_NODELABEL(mac), memory_regions)
+
+BUILD_ASSERT(!DT_SAME_NODE(sram_eth_node, DT_CHOSEN(zephyr_sram)),
+	     "Ethernet buffer memory-region cannot be located in Zephyr system RAM.");
+#endif /* mac node enabled */
+
 static const struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("FLASH", CONFIG_FLASH_BASE_ADDRESS,
 					 REGION_FLASH_ATTR(REGION_FLASH_SIZE)),
@@ -21,22 +28,13 @@ static const struct arm_mpu_region mpu_regions[] = {
 					REGION_512K |
 					MPU_RASR_XN_Msk | P_RW_U_NA_Msk) }),
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mac))
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram3))
-#define sram_eth_node	DT_NODELABEL(sram3)
-#else
-#define sram_eth_node	DT_NODELABEL(sram2)
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(sram_eth_node)
+#if defined(sram_eth_node) && DT_NODE_HAS_STATUS_OKAY(sram_eth_node)
 	MPU_REGION_ENTRY("SRAM_ETH_BUF",
 					 DT_REG_ADDR(sram_eth_node),
 					 REGION_RAM_NOCACHE_ATTR(REGION_16K)),
 	MPU_REGION_ENTRY("SRAM_ETH_DESC",
 					 DT_REG_ADDR(sram_eth_node),
 					 REGION_PPB_ATTR(REGION_256B)),
-#endif
 #endif
 };
 

--- a/soc/st/stm32/stm32h7x/sections.ld
+++ b/soc/st/stm32/stm32h7x/sections.ld
@@ -5,12 +5,7 @@
  */
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mac))
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sram3))
-#define sram_eth_node	DT_NODELABEL(sram3)
-#else
-#define sram_eth_node	DT_NODELABEL(sram2)
-#endif
+#define sram_eth_node DT_PHANDLE(DT_NODELABEL(mac), memory_regions)
 
 #if DT_NODE_HAS_STATUS_OKAY(sram_eth_node)
 SECTION_DATA_PROLOGUE(eth_stm32,(NOLOAD),)
@@ -21,6 +16,6 @@ SECTION_DATA_PROLOGUE(eth_stm32,(NOLOAD),)
     *(.eth_stm32_buf)
     . = ABSOLUTE(DT_REG_ADDR(sram_eth_node)) + 16K;
 } GROUP_DATA_LINK_IN(LINKER_DT_NODE_REGION_NAME(sram_eth_node), LINKER_DT_NODE_REGION_NAME(sram_eth_node))
-#endif
+#endif /* DT_NODE_HAS_STATUS_OKAY(sram_eth_node) */
 
-#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(mac), okay) */
+#endif /* DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mac)) */


### PR DESCRIPTION
## Changes
- Added the `memory-regions` property to `stm32h7.dtsi` and `stm32h7rs` with `sram2` as default, in order to explicitly locate ethernet buffer and descriptor to an sram region inside the DT. 
- Added override for `sram2` with `sram3` where possible.
- Added `#memory-region-cells` to `sram2` and `sram3` nodes, since it is needed by the `memory-regions` property.
- Added a check for memory-regions before the check for and definition of the `sram_eth_node` in `mpu_regions.c` and `sections.ld` to both h7 and h7rs SoCs.
- Added `memory-regions` property to `dts/bindings/ethernet/st,stm32h7-ethernet.yaml`.
- Added seperate compatible for h5 series, in form of `dts/bindings/ethernet/st,stm32h5-ethernet.yaml`.

## ~~Dependencies~~
~~- #99296 (due to the addition of the `memory-regions` property to `dts/bindings/ethernet/st,stm32h7-ethernet.yaml`)~~

## Notes
@etienne-lms suggested this change in #99296.