### PR TITLE
soc: st: stm32wb0: IAR toolchain compatibility

### DIFF
--- a/soc/st/stm32/stm32wb0x/CMakeLists.txt
+++ b/soc/st/stm32/stm32wb0x/CMakeLists.txt
@@ -6,6 +6,30 @@ zephyr_sources(soc.c)
 zephyr_sources_ifdef(CONFIG_PM power.c s2ram_marking.S)
 zephyr_include_directories(.)
 
-zephyr_linker_sources(RAM_SECTIONS ram_sections.ld)
+if(CONFIG_CMAKE_LINKER_GENERATOR)
+  # The first word of SRAM (at 0x2000'0000) is reserved and followed
+  # by the RAM_VR structure. By using 0x2000'0004 as start address
+  # for the section, we obtain a similar result as the linker snippet
+  # which creates the section at 0x2000'0000 then skips 4 bytes using
+  # the GNU ld-specific construct `. += 0x4;` (c.f. ram_sections.ld)
+  if(CONFIG_BT)
+    # When CONFIG_BT is enabled, the BLUE_RAM section is reserved by `soc.c`.
+    # However, this section does NOT start immediately after RAM_VR. The
+    # little gap is ignored by GNU ld but NOT by the IAR linker which tries
+    # to be clever and places INITIALIZED data there. This results in an
+    # image where __data_region_end < __data_region_start which causes a
+    # catastrophic failure in arch_data_copy(). Prevent this by setting
+    # a MIN_SIZE on the section in such case to ensure there is no gap
+    # between the end of RAM_VR and start of BLUE_RAM.
+    #
+    # The minimum size is (<BLUE_RAM start> - <RAM_VR start>) = 0xBC.
+    #                      = 0x2000'00C0      = 0x2000'0004
+    set(ram_vr_minsize MIN_SIZE 0xBC)
+  endif()
+  zephyr_linker_section(NAME stm32wb0_RAM_VR TYPE NOLOAD GROUP RAM_REGION ADDRESS 0x20000004 ${ram_vr_minsize} NOINIT)
+  zephyr_linker_section(NAME stm32wb0_BLUE_RAM TYPE NOLOAD GROUP RAM_REGION ADDRESS 0x200000C0 NOINIT)
+else()
+  zephyr_linker_sources(RAM_SECTIONS ram_sections.ld)
+endif()
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/st/stm32/stm32wb0x/soc.c
+++ b/soc/st/stm32/stm32wb0x/soc.c
@@ -48,8 +48,8 @@ __used RAM_VR_TypeDef RAM_VR;
  * N.B.: radio driver defines CFG_BLE_NUM_RADIO_TASKS.
  */
 Z_GENERIC_SECTION(stm32wb0_BLUE_RAM)
-static uint8_t __used __blue_RAM[sizeof(GLOBALSTATMACH_TypeDef) +
-				 CFG_BLE_NUM_RADIO_TASKS * sizeof(STATMACH_TypeDef)];
+uint8_t __used __blue_RAM[sizeof(GLOBALSTATMACH_TypeDef) +
+			  CFG_BLE_NUM_RADIO_TASKS * sizeof(STATMACH_TypeDef)];
 #endif /* CONFIG_BT */
 
 /** Power Controller node (shorthand for upcoming macros) */

--- a/west.yml
+++ b/west.yml
@@ -250,7 +250,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 2c18f2b49d66d23cabfbd20dd7dbbaef8ee9520b
+      revision: pull/329/head
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Implements IAR toolchain compatibility on STM32WB0 series, both without and with Bluetooth enabled.