### PR TITLE
fix dac generic clock source for samd5x

### DIFF
--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -394,7 +394,7 @@
 
 			clocks = <&gclk 42>, <&mclk 0x20 9>;
 			clock-names = "GCLK", "MCLK";
-			atmel,assigned-clocks = <&gclk 0>;
+			atmel,assigned-clocks = <&gclk 2>;
 			atmel,assigned-clock-names = "GCLK";
 			status = "disabled";
 


### PR DESCRIPTION
DAC for these MCUs has a similar limitation to clock speed as the ADC. Changed generic DAC clock source to use the same GCLK Gen as the ADC.