### PR TITLE
modules: update west.yml for hal_atmel

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -159,7 +159,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: 065e57c5013051c8b7f2256271349c6942bd9344
+      revision: pull/39/head
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
The pinconfig YAML for the s70, e70 and v7x has some typos for the AFEC. In particular, pin PE4 extra and PE5 extra should be AFEC0 instead of AFEC1. Tested with SAM V71B eval board and Zephyr 3.7.1 LTS.

PR for hal_atmel #39

I previously made a PR #100915 with a wrong commit message (text format). Tried to "commit ammend" with git on windows and messed up the commit.

Thanks,
Ivan