### PR TITLE
drivers: pwm: sctimer: Add PowerManagement support

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim_common.h
+++ b/drivers/i2c/i2c_nrfx_twim_common.h
@@ -75,6 +75,7 @@ struct i2c_nrfx_twim_common_config {
 	uint8_t *msg_buf;
 	uint16_t max_transfer_size;
 	nrfx_twim_t *twim;
+	void *mem_reg;
 };
 
 int i2c_nrfx_twim_common_init(const struct device *dev);

--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -8,6 +8,7 @@
 #define DT_DRV_COMPAT nxp_sctimer_pwm
 
 #include <errno.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/drivers/pwm.h>
 #include <fsl_sctimer.h>
 #include <fsl_clock.h>


### PR DESCRIPTION
pwm_mcux_sctimer driver doesn't support power management actions. PM Actions added, as well support to save/restore for pwm channels configurations after exitig from PM3