### PR TITLE
samples: sensor: accel_polling: remove duplicated header

### DIFF
--- a/samples/sensor/accel_polling/src/main.c
+++ b/samples/sensor/accel_polling/src/main.c
@@ -12,7 +12,6 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/kernel.h>
 #include <zephyr/rtio/rtio.h>
-#include <zephyr/drivers/sensor.h>
 
 #define ACCEL_ALIAS(i) DT_ALIAS(_CONCAT(accel, i))
 #define ACCELEROMETER_DEVICE(i, _)                                                           \

--- a/samples/sensor/stream_fifo/src/main.c
+++ b/samples/sensor/stream_fifo/src/main.c
@@ -12,7 +12,6 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/kernel.h>
 #include <zephyr/rtio/rtio.h>
-#include <zephyr/drivers/sensor.h>
 
 #define STREAMDEV_ALIAS(i) DT_ALIAS(_CONCAT(stream, i))
 #define STREAMDEV_DEVICE(i, _) \


### PR DESCRIPTION
On main.c from sample sensor/accel_polling the header <zephyr/drivers/sensor.h> is repeated, as well in
sample sensor/stream_fifo. This is solved on this PR

fixes #100920