### PR TITLE
tests: Fix typo in "Unsupported configuration" error message

### DIFF
--- a/tests/boards/nrf/rram_throttling/src/main.c
+++ b/tests/boards/nrf/rram_throttling/src/main.c
@@ -20,7 +20,7 @@
 #define TEST_AREA_SIZE   FIXED_PARTITION_SIZE(TEST_AREA)
 #define TEST_AREA_DEVICE FIXED_PARTITION_DEVICE(TEST_AREA)
 #else
-#error "Unsupported configuraiton"
+#error "Unsupported configuration"
 #endif
 
 #define BUF_SIZE        512

--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -61,7 +61,7 @@
 #endif
 
 #else
-#error "Unsupported configuraiton"
+#error "Unsupported configuration"
 #endif
 
 #define EXPECTED_SIZE	512

--- a/tests/drivers/flash/negative_tests/src/main.c
+++ b/tests/drivers/flash/negative_tests/src/main.c
@@ -37,7 +37,7 @@
 #endif
 
 #else
-#error "Unsupported configuraiton"
+#error "Unsupported configuration"
 #endif
 
 #define EXPECTED_SIZE 512


### PR DESCRIPTION
Several test sources used the misspelled string "Unsupported configuraiton".

Fix the typo across all affected files to improve clarity and consistency.

Updated files:
 - tests/boards/nrf/rram_throttling/src/main.c
 - tests/drivers/flash/common/src/main.c
 - tests/drivers/flash/negative_tests/src/main.c

No functional change.