### PR TITLE
spi: nrfx_spim: support cross power-domain GPIOs

### DIFF
--- a/dts/bindings/spi/nordic,nrf-spim.yaml
+++ b/dts/bindings/spi/nordic,nrf-spim.yaml
@@ -30,3 +30,13 @@ properties:
       of SCK (leading or trailing, depending on the CPHA setting used) until
       the input serial data on MISO is actually sampled. This property does
       not have any effect if the rx-delay-supported property is not set.
+
+  cross-power-domain-gpios:
+    type: boolean
+    description: |
+      Select P2 pins can be used for some serial interfaces in the peripheral domain,
+      when the device is in Constant Latency sub-power mode. This property notifies
+      the driver that this SPIM instance uses cross power-domain GPIOs, and therefore
+      requests the appropriate sub-power mode while active.
+
+      Only valid for SPIM20 on nRF54L devices. Depends on CONFIG_NRF_SYS_EVENT.


### PR DESCRIPTION
Add support for the cross power-domain GPIO functionality on nRF54LX devices. Tested on nRF54L15DK with external flash switched from SPIM00 to SPIM20.

Test procedure is an ERASE-WRITE-READ-ERASE cycle validating data at each step. With the external flash moved to SPIM20, this testing fails without the implementation and works with it.

Relevant Nordic docs: https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/chapters/pin.html#d380e188