### PR TITLE
Add support Counter driver for Renesas RZT2L, RZ/V2x, RZ/G2x 

### DIFF
--- a/boards/renesas/rzg2l_smarc/rzg2l_smarc_r9a07g044l23gbg_cm33.yaml
+++ b/boards/renesas/rzg2l_smarc/rzg2l_smarc_r9a07g044l23gbg_cm33.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - counter
   - uart
   - gpio
   - i2c

--- a/boards/renesas/rzg2lc_smarc/rzg2lc_smarc_r9a07g044c22gbg_cm33.yaml
+++ b/boards/renesas/rzg2lc_smarc/rzg2lc_smarc_r9a07g044c22gbg_cm33.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - counter
   - uart
   - gpio
   - i2c

--- a/boards/renesas/rzg2ul_smarc/rzg2ul_smarc_r9a07g043u11gbg_cm33.yaml
+++ b/boards/renesas/rzg2ul_smarc/rzg2ul_smarc_r9a07g043u11gbg_cm33.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - counter
   - uart
   - gpio
   - i2c

--- a/boards/renesas/rzt2l_rsk/rzt2l_rsk.yaml
+++ b/boards/renesas/rzt2l_rsk/rzt2l_rsk.yaml
@@ -9,6 +9,7 @@ toolchain:
   - zephyr
 supported:
   - adc
+  - counter
   - uart
   - gpio
   - i2c

--- a/boards/renesas/rzv2h_evk/rzv2h_evk_r9a09g057h44gbg_cm33.yaml
+++ b/boards/renesas/rzv2h_evk/rzv2h_evk_r9a09g057h44gbg_cm33.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - counter
   - uart
   - gpio
   - i2c

--- a/boards/renesas/rzv2h_evk/rzv2h_evk_r9a09g057h44gbg_cr8_0.yaml
+++ b/boards/renesas/rzv2h_evk/rzv2h_evk_r9a09g057h44gbg_cr8_0.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - counter
   - uart
   - gpio
   - i2c

--- a/boards/renesas/rzv2n_evk/rzv2n_evk_r9a09g056n48gbg_cm33.yaml
+++ b/boards/renesas/rzv2n_evk/rzv2n_evk_r9a09g056n48gbg_cm33.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - counter
   - uart
   - gpio
   - i2c

--- a/dts/arm/renesas/rz/rzg/r9a07g043.dtsi
+++ b/dts/arm/renesas/rz/rzg/r9a07g043.dtsi
@@ -233,6 +233,48 @@
 			status = "disabled";
 		};
 
+		gtm0: gtm@42801000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42801000 DT_SIZE_K(1)>;
+			channel = <0>;
+			interrupts = <46 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm1: gtm@42801400 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42801400 DT_SIZE_K(1)>;
+			channel = <1>;
+			interrupts = <47 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm2: gtm@42801800 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42801800 DT_SIZE_K(1)>;
+			channel = <2>;
+			interrupts = <48 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
 		i2c0: i2c@40058000 {
 			compatible = "renesas,rz-riic";
 			channel = <0>;

--- a/dts/arm/renesas/rz/rzg/r9a07g044.dtsi
+++ b/dts/arm/renesas/rz/rzg/r9a07g044.dtsi
@@ -744,6 +744,48 @@
 			};
 		};
 
+		gtm0: gtm@42801000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42801000 DT_SIZE_K(1)>;
+			channel = <0>;
+			interrupts = <46 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm1: gtm@42801400 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42801400 DT_SIZE_K(1)>;
+			channel = <1>;
+			interrupts = <47 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm2: gtm@42801800 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42801800 DT_SIZE_K(1)>;
+			channel = <2>;
+			interrupts = <48 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
 		intc: intc@410b0000 {
 			compatible = "renesas,rz-intc";
 			reg = <0x410b0000 DT_SIZE_K(64)>,

--- a/dts/arm/renesas/rz/rzt/r9a07g074.dtsi
+++ b/dts/arm/renesas/rz/rzt/r9a07g074.dtsi
@@ -661,6 +661,44 @@
 			};
 		};
 
+		cmtw0: cmtw@80041000 {
+			compatible = "renesas,rz-cmtw";
+			reg = <0x80041000 0x400>;
+			channel = <0>;
+			interrupts = <GIC_SPI 59 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 60 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 61 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 62 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 63 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "cmwi", "ic0i", "ic01", "oc0i", "oc1i";
+			prescaler = <8>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-cmtw-counter";
+				status = "disabled";
+			};
+		};
+
+		cmtw1: cmtw@80041400 {
+			compatible = "renesas,rz-cmtw";
+			reg = <0x80041400 0x400>;
+			channel = <1>;
+			interrupts = <GIC_SPI 64 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 65 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 66 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 67 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 68 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "cmwi", "ic0i", "ic01", "oc0i", "oc1i";
+			prescaler = <8>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-cmtw-counter";
+				status = "disabled";
+			};
+		};
+
 		gpt0: gpt0@90002000 {
 			compatible = "renesas,rz-gpt";
 			reg = <0x90002000 0x100>;

--- a/dts/arm/renesas/rz/rzv/r9a09g056.dtsi
+++ b/dts/arm/renesas/rz/rzv/r9a09g056.dtsi
@@ -1020,6 +1020,118 @@
 				status = "disabled";
 			};
 		};
+
+		gtm0: gtm@41800000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x41800000 0x1000>;
+			channel = <0>;
+			interrupts = <17 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm1: gtm@41801000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x41801000 0x1000>;
+			channel = <1>;
+			interrupts = <18 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm2: gtm@44000000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x44000000 0x1000>;
+			channel = <2>;
+			interrupts = <19 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm3: gtm@44001000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x44001000 0x1000>;
+			channel = <3>;
+			interrupts = <20 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm4: gtm@42c00000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42c00000 0x1000>;
+			channel = <4>;
+			interrupts = <21 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm5: gtm@42c01000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42c01000 0x1000>;
+			channel = <5>;
+			interrupts = <22 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm6: gtm@42c02000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42c02000 0x1000>;
+			channel = <6>;
+			interrupts = <23 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm7: gtm@42c03000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42c03000 0x1000>;
+			channel = <7>;
+			interrupts = <24 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
 	};
 };
 

--- a/dts/arm/renesas/rz/rzv/r9a09g057_cm33.dtsi
+++ b/dts/arm/renesas/rz/rzv/r9a09g057_cm33.dtsi
@@ -996,6 +996,118 @@
 				status = "disabled";
 			};
 		};
+
+		gtm0: gtm@41800000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x41800000 0x1000>;
+			channel = <0>;
+			interrupts = <17 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm1: gtm@41801000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x41801000 0x1000>;
+			channel = <1>;
+			interrupts = <18 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm2: gtm@44000000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x44000000 0x1000>;
+			channel = <2>;
+			interrupts = <19 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm3: gtm@44001000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x44001000 0x1000>;
+			channel = <3>;
+			interrupts = <20 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm4: gtm@42c00000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42c00000 0x1000>;
+			channel = <4>;
+			interrupts = <21 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm5: gtm@42c01000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42c01000 0x1000>;
+			channel = <5>;
+			interrupts = <22 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm6: gtm@42c02000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42c02000 0x1000>;
+			channel = <6>;
+			interrupts = <23 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm7: gtm@42c03000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x42c03000 0x1000>;
+			channel = <7>;
+			interrupts = <24 1>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
 	};
 };
 

--- a/dts/arm/renesas/rz/rzv/r9a09g057_cr8.dtsi
+++ b/dts/arm/renesas/rz/rzv/r9a09g057_cr8.dtsi
@@ -1151,5 +1151,117 @@
 				status = "disabled";
 			};
 		};
+
+		gtm0: gtm@11800000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x11800000 0x1000>;
+			channel = <0>;
+			interrupts = <GIC_SPI 17 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm1: gtm@11801000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x11801000 0x1000>;
+			channel = <1>;
+			interrupts = <GIC_SPI 18 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm2: gtm@14000000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x14000000 0x1000>;
+			channel = <2>;
+			interrupts = <GIC_SPI 19 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm3: gtm@14001000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x14001000 0x1000>;
+			channel = <3>;
+			interrupts = <GIC_SPI 20 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm4: gtm@12c00000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x12c00000 0x1000>;
+			channel = <4>;
+			interrupts = <GIC_SPI 21 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm5: gtm@12c01000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x12c01000 0x1000>;
+			channel = <5>;
+			interrupts = <GIC_SPI 22 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm6: gtm@12c02000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x12c02000 0x1000>;
+			channel = <6>;
+			interrupts = <GIC_SPI 23 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
+
+		gtm7: gtm@12c03000 {
+			compatible = "renesas,rz-gtm";
+			reg = <0x12c03000 0x1000>;
+			channel = <7>;
+			interrupts = <GIC_SPI 24 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "overflow";
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
+		};
 	};
 };

--- a/samples/drivers/counter/alarm/boards/rzg2l_smarc_r9a07g044l23gbg_cm33.overlay
+++ b/samples/drivers/counter/alarm/boards/rzg2l_smarc_r9a07g044l23gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/rzg2lc_smarc_r9a07g044c22gbg_cm33.overlay
+++ b/samples/drivers/counter/alarm/boards/rzg2lc_smarc_r9a07g044c22gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/rzg2ul_smarc_r9a07g043u11gbg_cm33.overlay
+++ b/samples/drivers/counter/alarm/boards/rzg2ul_smarc_r9a07g043u11gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/rzt2l_rsk.overlay
+++ b/samples/drivers/counter/alarm/boards/rzt2l_rsk.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cmtw0 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/rzv2h_evk_r9a09g057h44gbg_cm33.overlay
+++ b/samples/drivers/counter/alarm/boards/rzv2h_evk_r9a09g057h44gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/rzv2h_evk_r9a09g057h44gbg_cr8_0.overlay
+++ b/samples/drivers/counter/alarm/boards/rzv2h_evk_r9a09g057h44gbg_cr8_0.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/rzv2n_evk_r9a09g056n48gbg_cm33.overlay
+++ b/samples/drivers/counter/alarm/boards/rzv2n_evk_r9a09g056n48gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/rzg2l_smarc_r9a07g044l23gbg_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/rzg2l_smarc_r9a07g044l23gbg_cm33.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm1 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm2 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/rzg2lc_smarc_r9a07g044c22gbg_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/rzg2lc_smarc_r9a07g044c22gbg_cm33.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm1 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm2 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/rzg2ul_smarc_r9a07g043u11gbg_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/rzg2ul_smarc_r9a07g043u11gbg_cm33.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm1 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm2 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/rzt2l_rsk.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/rzt2l_rsk.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cmtw0 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&cmtw1 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/rzv2h_evk_r9a09g057h44gbg_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/rzv2h_evk_r9a09g057h44gbg_cm33.overlay
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm1 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm2 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm3 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm4 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm5 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm6 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm7 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/rzv2h_evk_r9a09g057h44gbg_cr8_0.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/rzv2h_evk_r9a09g057h44gbg_cr8_0.overlay
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm1 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm2 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm3 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm4 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm5 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm6 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm7 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/rzv2n_evk_r9a09g056n48gbg_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/rzv2n_evk_r9a09g056n48gbg_cm33.overlay
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm1 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm2 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm3 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm4 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm5 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm6 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm7 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Add Counter driver support for Renesas RZ/T2L, V2H, V2N, G2L, G2LC, G2UL:

- Update `drivers/counter/counter_renesas_rz_cmtw.c` and `drivers/counter/counter_renesas_rz_gtm.c` to use common source code for Renesas RZ devices
- Add nodes to dts and dtsi of Renesas RZ/T2L, V2H, V2N, G2L, G2LC, G2UL
- Sample: enable `alarm` sample for RZ/T2L-RSK, RZ/G2L-SMARC, RZ/G2LC-SMARC, RZ/G2UL-SMARC, RZ/V2N-EVK, RZ/V2H-EVK
- Test: enable `counter_basic_api` test for RZ/T2L-RSK, RZ/G2L-SMARC, RZ/G2LC-SMARC, RZ/G2UL-SMARC, RZ/V2N-EVK, RZ/V2H-EVK