### PR TITLE
boards: stm32: b_u585i_iot2a: update flash controller's node

### DIFF
--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -167,7 +167,7 @@ stm32_lp_tick_source: &lptim1 {
 
 	status = "okay";
 
-	mx25lm51245: ospi-nor-flash@0 {
+	ext_flash_ctrl: ospi-flash-controller@0 {
 		compatible = "st,stm32-ospi-nor";
 		reg = <0>;
 		size = <DT_SIZE_M(512)>; /* 512 Megabits */
@@ -176,6 +176,18 @@ stm32_lp_tick_source: &lptim1 {
 		data-rate = <OSPI_DTR_TRANSFER>;
 		four-byte-opcodes;
 		status = "okay";
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		ranges = <0x0 0x70000000 DT_SIZE_M(64)>; /* Ext Flash mem-mapped to 0x70000000 */
+
+		ext_flash: mx25lm51245: ext-flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(64)>;
+			write-block-size = <1>;
+			erase-block-size = <DT_SIZE_K(4)>;
+		};
 	};
 };
 


### PR DESCRIPTION
Update the STM32 b_u585_iot02a board's flash controller node similar to how it is done in other stm32 boards; for example, here: https://github.com/zephyrproject-rtos/zephyr/blob/923ece1eea7d303d06b617bb85159832c6b9c12e/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi#L369

This would allow us to have a proper hierarchy, where the flash device's node is defined under the flash controllers, as well as introducing `ranges` properties, mem-mapping to the physical address. This will allow as to consistently access this address via Kconfig macros like `"$(add_hex,$(dt_node_reg_addr_hex,$(dt_node_parent,$(dt_node_parent,$(dt_nodelabel_path,storage_partition)))),$(dt_nodelabel_reg_addr_hex,storage_partition))"` both for internal and external memory. 

- Refactor the flash controller's node
- Introduce flash device's node under the flash controller's
- Introduce `ranges` property with mem-mapped address

See related: https://github.com/zephyrproject-rtos/zephyr/issues/88404
