### PR TITLE
drivers: stm32 spi: do not unlock context unconditionally in PM_DEVICE_ACTION_RESUME

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1715,7 +1715,7 @@ static int spi_stm32_pinctrl_apply(const struct device *dev, uint8_t id)
 static int spi_stm32_pm_action(const struct device *dev,
 			       enum pm_device_action action)
 {
-	struct spi_stm32_data *data = dev->data;
+	__maybe_unused struct spi_stm32_data *data = dev->data;
 	const struct spi_stm32_config *config = dev->config;
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	int err;


### PR DESCRIPTION
- call spi_stm32_pm_policy_state_lock_xxx functions wenn context is locked
- do not call spi_stm32_pm_policy_state_lock_put() in internal helper spi_stm32_complete() (which gets called from various places) but at the end of a transfer where it belong

fixes https://github.com/zephyrproject-rtos/zephyr/issues/99751