### PR TITLE
west.yml: update hal_stm32 module with new H7RS/L4/L5/N6 stm32cube packages

### DIFF
--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -58,6 +58,8 @@ typedef void (*dma_stm32_clear_flag_func)(DMA_TypeDef *DMAx);
 #if !defined(CONFIG_SOC_SERIES_STM32C0X) && \
 	!defined(CONFIG_SOC_SERIES_STM32G0X) && \
 	!defined(CONFIG_SOC_SERIES_STM32H7X) && \
+	!defined(CONFIG_SOC_SERIES_STM32L4X) && \
+	!defined(CONFIG_SOC_SERIES_STM32MP13X) && \
 	!defined(CONFIG_SOC_SERIES_STM32U0X)
 typedef uint32_t (*dma_stm32_check_flag_func)(DMA_TypeDef *DMAx);
 #else

--- a/west.yml
+++ b/west.yml
@@ -255,7 +255,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 9325b43737ffca79ffe1af6300c90ffde98919da
+      revision: ec0fe4a09a5bbf0e482ab1f4bd42d66131c64369
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
stm32h7rsxx bump to version to 1.3.0
stm32l4xx bump to version 1.18.2
stm32l5xx bump to version 1.6.0
stm32n6xx bump to version 1.3.0