### PR TITLE
boards: st: update board.cmake and docs for nucleo_u0x

### DIFF
--- a/boards/st/nucleo_u031r8/board.cmake
+++ b/boards/st/nucleo_u031r8/board.cmake
@@ -5,7 +5,10 @@ board_runner_args(pyocd "--target=stm32u031r8tx")
 
 board_runner_args(jlink "--device=STM32U031R8" "--reset-after-load")
 
+board_runner_args(stlink_gdbserver "--apid=0")
+
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)

--- a/boards/st/nucleo_u031r8/doc/index.rst
+++ b/boards/st/nucleo_u031r8/doc/index.rst
@@ -171,6 +171,15 @@ Programming and Debugging
 Nucleo U031R8 board includes an ST-LINK/V3 embedded debug tool interface.
 This probe allows to flash the board using various tools.
 
+.. warning::
+   The onboard ST-LINK/V3 debug probe cannot be `converted into a JLink probe`_;
+   as such, usage of the JLink runner requires an external JLink debug probe.
+
+.. warning::
+   There are known issues about the usage of the pyOCD runner with this board.
+   If issues are encountered (e.g., debugging does not work), use the
+   :ref:`ST-Link GDB Server <runner_stlink_gdbserver>` runner instead.
+
 Flashing
 ========
 
@@ -223,7 +232,6 @@ You should see the following message on the console:
 Debugging
 =========
 
-Default flasher for this board is openocd. It could be used in the usual way.
 Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
@@ -249,3 +257,6 @@ Note: Check the ``build/tfm`` directory to ensure that the commands required by 
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html
+
+.. _converted into a JLink probe:
+   https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/

--- a/boards/st/nucleo_u083rc/board.cmake
+++ b/boards/st/nucleo_u083rc/board.cmake
@@ -7,7 +7,10 @@ board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 
 board_runner_args(jlink "--device=STM32U083RC" "--reset-after-load")
 
+board_runner_args(stlink_gdbserver "--apid=0")
+
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)

--- a/boards/st/nucleo_u083rc/doc/index.rst
+++ b/boards/st/nucleo_u083rc/doc/index.rst
@@ -184,6 +184,15 @@ Programming and Debugging
 Nucleo U083RC board includes an ST-LINK/V3 embedded debug tool interface.
 This probe allows to flash the board using various tools.
 
+.. warning::
+   The onboard ST-LINK/V3 debug probe cannot be `converted into a JLink probe`_;
+   as such, usage of the JLink runner requires an external JLink debug probe.
+
+.. warning::
+   There are known issues about the usage of the pyOCD runner with this board.
+   If issues are encountered (e.g., debugging does not work), use the
+   :ref:`ST-Link GDB Server <runner_stlink_gdbserver>` runner instead.
+
 Flashing
 ========
 
@@ -236,7 +245,6 @@ You should see the following message on the console:
 Debugging
 =========
 
-Default flasher for this board is openocd. It could be used in the usual way.
 Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
@@ -262,3 +270,6 @@ Note: Check the ``build/tfm`` directory to ensure that the commands required by 
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html
+
+.. _converted into a JLink probe:
+   https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/


### PR DESCRIPTION
Added stlink_gdbserver as a runner for the nucleo_u0x boards. Updated the boards' documentation to mention that JLink runners do not work with the onboard debug probe and removed mention of the unsupported openocd runner.