### PR TITLE
Openthread border router mdns packet limit

### DIFF
--- a/modules/openthread/Kconfig
+++ b/modules/openthread/Kconfig
@@ -257,6 +257,7 @@ config OPENTHREAD_CUSTOM_PARAMETERS
 
 config OPENTHREAD_NUM_MESSAGE_BUFFERS
 	int "The number of message buffers in the buffer pool"
+	default 512 if OPENTHREAD_ZEPHYR_BORDER_ROUTER
 	default 128
 	help
 	  "The number of message buffers in the buffer pool."
@@ -438,6 +439,15 @@ config OPENTHREAD_ZEPHYR_BORDER_ROUTER_MSG_POOL_NUM
 	help
 	  This value represents the maximum number of messages from backbone interface
 	  that could be stored without being processed.
+
+config OPENTHREAD_ZEPHYR_BORDER_ROUTER_MDNS_BUFFER_THRESHOLD
+	int "Threshold value to determine if an mDNS packet will be processed"
+	default 40
+	help
+	  This value is used to calculate if OpenThread mDNS module should
+	  accept an incoming message or not. It is used to determine if
+	  number of available OT message buffers will drop under a certain
+	  threshold if the mDNS packet is accepted and processed.
 
 endif # OPENTHREAD_ZEPHYR_BORDER_ROUTER
 


### PR DESCRIPTION
This commit decides if an mDNS incoming packet should be processed by verifying that a number of OT message buffers are still available after a packet to OT message conversion would be perform.
In this way, it ensures that application would still be up and running, and it will not eventually end up in an assert statement raised by OT mDNS module. OT mDNS module raises an assert if there are no free available OT message buffers to encapsulate a TX message.