### PR TITLE
cc13xx/cc26xx radio fixes

### DIFF
--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -223,6 +223,7 @@ static int ieee802154_cc13xx_cc26xx_do_set_channel(const struct device *dev,
 		ret = -EIO;
 		goto out;
 	}
+	drv_data->rx_handle = cmd_handle;
 
 	ret = 0;
 
@@ -260,10 +261,14 @@ ieee802154_cc13xx_cc26xx_filter(const struct device *dev, bool set,
 				const struct ieee802154_filter *filter)
 {
 	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
+	RF_CmdHandle cmd_handle;
+	int ret = 0;
 
 	if (!set) {
 		return -ENOTSUP;
 	}
+
+	RF_cancelCmd(drv_data->rf_handle, drv_data->rx_handle, 0);
 
 	if (type == IEEE802154_FILTER_TYPE_IEEE_ADDR) {
 		memcpy((uint8_t *)&drv_data->cmd_ieee_rx.localExtAddr,
@@ -274,10 +279,21 @@ ieee802154_cc13xx_cc26xx_filter(const struct device *dev, bool set,
 	} else if (type == IEEE802154_FILTER_TYPE_PAN_ID) {
 		drv_data->cmd_ieee_rx.localPanID = filter->pan_id;
 	} else {
-		return -ENOTSUP;
+		ret = -ENOTSUP;
 	}
 
-	return 0;
+	/* Run BG receive process with requested filter updated */
+	drv_data->cmd_ieee_rx.status = IDLE;
+	cmd_handle = RF_scheduleCmd(drv_data->rf_handle,
+		(RF_Op *)&drv_data->cmd_ieee_rx, RF_PriorityNormal,
+		cmd_ieee_rx_callback, RF_EventRxEntryDone);
+	if (cmd_handle < 0) {
+		LOG_ERR("Failed to post RX command (%d)", cmd_handle);
+		return -EIO;
+	}
+	drv_data->rx_handle = cmd_handle;
+
+	return ret;
 }
 
 static int ieee802154_cc13xx_cc26xx_set_txpower(const struct device *dev,

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.h
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.h
@@ -93,6 +93,7 @@ struct ieee802154_cc13xx_cc26xx_data {
 #endif /* CONFIG_SOC_CCxx52x */
 
 	volatile int16_t saved_cmdhandle;
+	volatile RF_CmdHandle rx_handle;
 };
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_CC13XX_CC26XX_H_ */


### PR DESCRIPTION
This PR addresses some issues that happens using OpenThread joiner.
Some packet sent by the commissioner were never received by the joiner.
This improves set channel operation to only reconfigure channel (which implies many radio operations) only if this is required and this also makes sure any supported filter get applied by restarting RX operations. 

Note: This has been only tested using OpenThread but I would not expect any side effects for other radio stack based on 802.15.4.