### PR TITLE
tests: kconfig: fix path for different repo names

### DIFF
--- a/tests/kconfig/tracing/validate_tracing.py
+++ b/tests/kconfig/tracing/validate_tracing.py
@@ -26,7 +26,7 @@ EXPECTED_TRACES = [
         "string",
         "native_sim",
         "default",
-        [ "zephyr/boards/Kconfig", None ] # only test the file name
+        [ "boards/Kconfig", None ] # only test the file name
     ],
     [
         "CONFIG_MAIN_FLAG",


### PR DESCRIPTION
Test expected path "zephyr/boards/Kconfig" but failed when the repository had a different name.
Changed to "boards/Kconfig" to work with any repository name, as code below.