### PR TITLE
Add hardware info driver support for microchip pic32cx sg family

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: pic32cx_sg41_cult
@@ -14,6 +14,7 @@ supported:
   - dma
   - flash
   - gpio
+  - hwinfo
   - i2c
   - pinctrl
   - pwm

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: pic32cx_sg61_cult
@@ -14,6 +14,7 @@ supported:
   - dma
   - flash
   - gpio
+  - hwinfo
   - i2c
   - pinctrl
   - pwm

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +29,14 @@
 	};
 
 	soc {
+		hwinfo: device_id@8061fc {
+			compatible = "microchip,hwinfo-g1";
+			reg = <0x008061fc 0x4>,
+			      <0x00806010 0x4>,
+			      <0x00806014 0x4>,
+			      <0x00806018 0x4>;
+		};
+
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
 			reg = <0x20000000 DT_SIZE_K(256)>;


### PR DESCRIPTION
Add the device tree node for microchip hwinfo G1 IP.
Update pic32cx_sg41_cult.yaml to reflect hwinfo G1 support on the board.
Update pic32cx_sg61_cult.yaml to reflect hwinfo G1 support on the board.