### PR TITLE
soc: atmel: sam: common: add warm reboot to soc_power.c

### DIFF
--- a/soc/atmel/sam/common/soc_power.c
+++ b/soc/atmel/sam/common/soc_power.c
@@ -19,6 +19,7 @@ void sys_arch_reboot(int type)
 	Rstc *regs = (Rstc *)DT_REG_ADDR(SAM_DT_RSTC_DRIVER);
 
 	switch (type) {
+	case SYS_REBOOT_WARM:
 	case SYS_REBOOT_COLD:
 		regs->RSTC_CR = RSTC_CR_KEY_PASSWD
 			      | RSTC_CR_PROCRST


### PR DESCRIPTION
If a warm reboot is issued (e.g., via mcumgr reset), the sam controller just hangs because of loop in reboot.c. This can be devastating if no watchdog is present to reboot the controller.