### PR TITLE
arch: riscv: fix mstatus restore order in trap exit with userspace

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -757,7 +757,6 @@ fp_trap_exit:
 #endif /* CONFIG_CLIC_SUPPORT_INTERRUPT_LEVEL */
 
 	csrw mepc, t0
-	csrw mstatus, t2
 
 #ifdef CONFIG_USERSPACE
 	/*
@@ -795,6 +794,8 @@ fp_trap_exit:
 	sr t0, __struct_arch_esf_sp_OFFSET(sp)
 2:
 #endif
+
+	csrw mstatus, t2
 
 	/* Restore s0 (it is no longer ours) */
 	lr s0, __struct_arch_esf_s0_OFFSET(sp)


### PR DESCRIPTION
When returning from a trap to user mode with CONFIG_PMP_KERNEL_MODE_DYNAMIC enabled, z_riscv_pmp_usermode_enable() is called to reconfigure PMP entries. This function modifies mstatus (clears MPRV, sets MPP).

The original code restored mstatus from the exception frame before calling z_riscv_pmp_usermode_enable(), causing the function's mstatus modifications to be lost. This resulted in incorrect PMP enforcement after returning to user mode.

Move the mstatus restore to after the userspace PMP reconfiguration block to ensure the saved mstatus value is properly restored after all PMP setup is complete.