### PR TITLE
edtlib: Fix the accidental merging of examples in the binding

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2701,7 +2701,7 @@ def _bad_overwrite(to_dict: dict, from_dict: dict, prop: str,
         return False
 
     # These are overridden deliberately
-    if prop in {"title", "description", "compatible"}:
+    if prop in {"title", "description", "compatible", "examples"}:
         return False
 
     if prop == "required":


### PR DESCRIPTION
Fix the example nodes in the examples block being accidentally merged and overwritten during build.

Fix CI: #100959
(Sorry. :( It appears I overlooked that.)