### PR TITLE
Revert "drivers: adc: nrfx: Temporary fix for SAADC power consumption"

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -662,7 +662,6 @@ static void event_handler(const nrfx_saadc_evt_t *event)
 			correct_single_ended(&m_data.ctx.sequence, m_data.user_buffer,
 					     event->data.done.size);
 		}
-		nrfy_saadc_disable(NRF_SAADC);
 		adc_context_on_sampling_done(&m_data.ctx, DEVICE_DT_INST_GET(0));
 	} else if (event->type == NRFX_SAADC_EVT_CALIBRATEDONE) {
 		err = nrfx_saadc_mode_trigger();


### PR DESCRIPTION
New hal_nordic was merged some time ago, fix no longer needed.

This reverts commit fe0b6b3b55f70c7306bcc21cf5242c00f483dc21.