### PR TITLE
boards: m5stack: add full_name for NanoC6 board

### DIFF
--- a/boards/m5stack/m5stack_nanoc6/board.yml
+++ b/boards/m5stack/m5stack_nanoc6/board.yml
@@ -1,5 +1,6 @@
 board:
   name: m5stack_nanoc6
+  full_name: NanoC6
   vendor: m5stack
   socs:
   - name: esp32c6


### PR DESCRIPTION
Add full_name field to the m5stack_nanoc6 board definition