### PR TITLE
doc: hardware: scmi: fix formatting of SCMI docs and add doxygen groups to headers

### DIFF
--- a/doc/hardware/arch/arm-scmi.rst
+++ b/doc/hardware/arch/arm-scmi.rst
@@ -159,6 +159,8 @@ example, ``POWER_STATE_GET`` and ``POWER_STATE_SET``.
 	This driver is vendor-agnostic. As such, it may be used on any
 	system that uses SCMI for power domain management operations.
 
+.. doxygengroup:: scmi_power
+
 System power management
 -----------------------
 
@@ -168,6 +170,8 @@ of functions implementing various commands, for example, ``SYSTEM_POWER_STATE_SE
 .. note::
 	This driver is vendor-agnostic. As such, it may be used on any
 	system that uses SCMI for system power management operations.
+
+.. doxygengroup:: scmi_system
 
 Clock management
 ----------------
@@ -195,6 +199,8 @@ supported command is ``PINCTRL_SETTINGS_CONFIGURE``.
 	their own definition of :code:`pinctrl_configure_pins`, which should
 	call into the SCMI pin control protocol function implementing the
 	``PINCTRL_SETTINGS_CONFIGURE`` command.
+
+.. doxygengroup:: scmi_pinctrl
 
 NXP - CPU domain management
 ---------------------------

--- a/doc/hardware/arch/arm-scmi.rst
+++ b/doc/hardware/arch/arm-scmi.rst
@@ -7,7 +7,7 @@ Overview
 ********
 
 What is SCMI?
-*************
+=============
 
 System Control and Management Interface (SCMI) is a specification developed by
 ARM, which describes a set of OS-agnostic software interfaces used to perform
@@ -15,52 +15,53 @@ system management (e.g: clock control, pinctrl, etc...).
 
 
 Agent, platform, protocol and transport
-***************************************
+=======================================
 
 The SCMI specification defines **four** key terms, which will also be used throughout
 this documentation:
 
-	#. Agent
-		Entity that performs SCMI requests (e.g: gating a clock or configuring
-		a pin). In this context, Zephyr itself is an agent.
-	#. Platform
-		This refers to a set of hardware components that handle the requests from
-		agents and provide the necessary functionality. In some cases, the requests
-		are handled by a firmware, running on a core dedicated to performing system
-		management tasks.
-	#. Protocol
-		A protocol is a set of messages grouped by functionality. Intuitively, a message
-		can be thought of as a remote procedure call.
+#. Agent
+	Entity that performs SCMI requests (e.g: gating a clock or configuring
+	a pin). In this context, Zephyr itself is an agent.
 
-		The SCMI specification defines ten standard protocols:
+#. Platform
+	This refers to a set of hardware components that handle the requests from
+	agents and provide the necessary functionality. In some cases, the requests
+	are handled by a firmware, running on a core dedicated to performing system
+	management tasks.
 
-		#. **Base** (0x10)
-		#. **Power domain management** (0x11)
-		#. **System power management** (0x12)
-		#. **Performance domain management** (0x13)
-		#. **Clock management** (0x14)
-		#. **Sensor management** (0x15)
-		#. **Reset domain management** (0x16)
-		#. **Voltage domain management** (0x17)
-		#. **Power capping and monitoring** (0x18)
-		#. **Pin Control** (0x19)
+#. Protocol
+	A protocol is a set of messages grouped by functionality. Intuitively, a message
+	can be thought of as a remote procedure call.
 
-		where each of these protocols is identified by an unique protocol ID
-		(listed between brackets).
+	The SCMI specification defines ten standard protocols:
 
-		Apart from the standard protocols, the SCMI specification reserves the
-		**0x80-0xFF** protocol ID range for vendor-specific protocols.
+	#. **Base** (0x10)
+	#. **Power domain management** (0x11)
+	#. **System power management** (0x12)
+	#. **Performance domain management** (0x13)
+	#. **Clock management** (0x14)
+	#. **Sensor management** (0x15)
+	#. **Reset domain management** (0x16)
+	#. **Voltage domain management** (0x17)
+	#. **Power capping and monitoring** (0x18)
+	#. **Pin Control** (0x19)
 
+	where each of these protocols is identified by an unique protocol ID
+	(listed between brackets).
 
-	#. Transport
-		This describes how messages are exchanged between agents and the platform.
-		The communication itself happens through channels.
+	Apart from the standard protocols, the SCMI specification reserves the
+	**0x80-0xFF** protocol ID range for vendor-specific protocols.
+
+#. Transport
+	This describes how messages are exchanged between agents and the platform.
+	The communication itself happens through channels.
 
 .. note::
 	A system may have more than one agent.
 
 Channels
-********
+========
 
 A **channel** is the medium through which agents and the platform exchange messages.
 The structure of a channel and the way it works is solely dependent on the transport.
@@ -71,31 +72,34 @@ by two different agents for example.
 Channels are **bidirectional** (exception: FastChannels), and, depending on which entity
 initiates the communication, can be one of **two** types:
 
-	#. A2P (agent to platform)
-		The agent is the initiator/requester. The messages passed through these
-		channels are known as **commands**.
-	#. P2A (platform to agent)
-		The platform is the initiator/requester.
+#. A2P (agent to platform)
+	The agent is the initiator/requester. The messages passed through these
+	channels are known as **commands**.
+
+#. P2A (platform to agent)
+	The platform is the initiator/requester.
 
 Messages
-********
+========
 
 The SCMI specification defines **four** types of messages:
 
-	#. Synchronous
-		These are commands that block until the platform has completed the
-		requested work and are sent over A2P channels.
-	#. Asynchronous
-		For these commands, the platform schedules the requested work to
-		be performed at a later time. As such, they return almost immediately.
-		These commands are sent over A2P channels.
-	#. Delayed response
-		These messages indicate the completion of the work associated
-		with an asynchronous command. These are sent over P2A channels.
+#. Synchronous
+	These are commands that block until the platform has completed the
+	requested work and are sent over A2P channels.
 
-	#. Notification
-		These messages are used to notify agents of events that take place on
-		the platform. These are sent over P2A channels.
+#. Asynchronous
+	For these commands, the platform schedules the requested work to
+	be performed at a later time. As such, they return almost immediately.
+	These commands are sent over A2P channels.
+
+#. Delayed response
+	These messages indicate the completion of the work associated
+	with an asynchronous command. These are sent over P2A channels.
+
+#. Notification
+	These messages are used to notify agents of events that take place on
+	the platform. These are sent over P2A channels.
 
 The Zephyr support for SCMI is based on the documentation provided by ARM:
 `DEN0056E <https://developer.arm.com/documentation/den0056/latest/>`_. For more details
@@ -105,7 +109,7 @@ SCMI support in Zephyr
 **********************
 
 Shared memory and doorbell-based transport
-******************************************
+==========================================
 
 This form of transport uses shared memory for reading/writing messages
 and doorbells for signaling. The interaction with the shared
@@ -120,10 +124,10 @@ transport driver (:file:`drivers/firmware/scmi/mailbox.c`).
 The steps below exemplify how the communication between the Zephyr agent
 and the platform may happen using this transport:
 
-	#. Write message to the shared memory area.
-	#. Zephyr rings request doorbell. If in ``PRE_KERNEL_1`` or ``PRE_KERNEL_2`` phase start polling for reply, otherwise wait for reply doorbell ring.
-	#. Platform reads message from shared memory area, processes it, writes the reply back to the same area and rings the reply doorbell.
-	#. Zephyr reads reply from the shared memory area.
+#. Write message to the shared memory area.
+#. Zephyr rings request doorbell. If in ``PRE_KERNEL_1`` or ``PRE_KERNEL_2`` phase start polling for reply, otherwise wait for reply doorbell ring.
+#. Platform reads message from shared memory area, processes it, writes the reply back to the same area and rings the reply doorbell.
+#. Zephyr reads reply from the shared memory area.
 
 In the context of this transport, a channel is comprised of a **single** shared
 memory area and one or more mailbox channels. This is because users may need/want
@@ -131,19 +135,20 @@ to use different mailbox channels for the request/reply doorbells.
 
 
 Protocols
-*********
+=========
 
 Currently, Zephyr has support for the following standard protocols:
 
-	#. **Power domain management**
-	#. **Clock management**
-	#. **Pin Control**
+#. **Power domain management**
+#. **Clock management**
+#. **Pin Control**
 
 NXP-specific protocols:
-	#. **CPU domain management**
+
+#. **CPU domain management**
 
 Power domain management
-***********************
+-----------------------
 
 This protocol is intended for management of power states of power domains.
 This is done via a set of functions implementing various commands, for
@@ -153,8 +158,8 @@ example, ``POWER_STATE_GET`` and ``POWER_STATE_SET``.
 	This driver is vendor-agnostic. As such, it may be used on any
 	system that uses SCMI for power domain management operations.
 
-Clock management protocol
-*************************
+Clock management
+----------------
 
 This protocol is used to perform clock management operations. This is done
 via a driver (:file:`drivers/clock_control/clock_control_arm_scmi.c`), which
@@ -166,8 +171,8 @@ management driver.
 	This driver is vendor-agnostic. As such, it may be used on any
 	system that uses SCMI for clock management operations.
 
-Pin Control protocol
-********************
+Pin Control
+-----------
 
 This protocol is used to perform pin configuration operations. This is done
 via a set of functions implementing various commands. Currently, the only
@@ -181,7 +186,7 @@ supported command is ``PINCTRL_SETTINGS_CONFIGURE``.
 	``PINCTRL_SETTINGS_CONFIGURE`` command.
 
 NXP - CPU domain management
-***************************
+---------------------------
 
 This protocol is intended for management of cpu states.
 This is done via a set of functions implementing various commands, for

--- a/doc/hardware/arch/arm-scmi.rst
+++ b/doc/hardware/arch/arm-scmi.rst
@@ -140,6 +140,7 @@ Protocols
 Currently, Zephyr has support for the following standard protocols:
 
 #. **Power domain management**
+#. **System power management**
 #. **Clock management**
 #. **Pin Control**
 
@@ -157,6 +158,16 @@ example, ``POWER_STATE_GET`` and ``POWER_STATE_SET``.
 .. note::
 	This driver is vendor-agnostic. As such, it may be used on any
 	system that uses SCMI for power domain management operations.
+
+System power management
+-----------------------
+
+This protocol is intended for system power management. This is done via a set
+of functions implementing various commands, for example, ``SYSTEM_POWER_STATE_SET``.
+
+.. note::
+	This driver is vendor-agnostic. As such, it may be used on any
+	system that uses SCMI for system power management operations.
 
 Clock management
 ----------------

--- a/include/zephyr/drivers/firmware/scmi/clk.h
+++ b/include/zephyr/drivers/firmware/scmi/clk.h
@@ -6,13 +6,21 @@
 
 /**
  * @file
- * @brief SCMI clock protocol helpers
+ * @ingroup scmi_clk
+ * @brief Header file for the SCMI Clock Protocol.
  */
 
 #ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CLK_H_
 #define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CLK_H_
 
 #include <zephyr/drivers/firmware/scmi/protocol.h>
+
+/**
+ * @brief Clock management operations via SCMI
+ * @defgroup scmi_clk Clock Protocol
+ * @ingroup scmi_protocols
+ * @{
+ */
 
 #define SCMI_CLK_CONFIG_DISABLE_ENABLE_MASK GENMASK(1, 0)
 #define SCMI_CLK_CONFIG_ENABLE_DISABLE(x)\
@@ -148,5 +156,9 @@ int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
  * @retval negative errno if failure
  */
 int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t parent_id);
+
+/**
+ * @}
+ */
 
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CLK_H_ */

--- a/include/zephyr/drivers/firmware/scmi/pinctrl.h
+++ b/include/zephyr/drivers/firmware/scmi/pinctrl.h
@@ -6,13 +6,21 @@
 
 /**
  * @file
- * @brief SCMI pinctrl protocol helpers
+ * @ingroup scmi_pinctrl
+ * @brief Header file for the SCMI Pin Control Protocol.
  */
 
 #ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PINCTRL_H_
 #define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PINCTRL_H_
 
 #include <zephyr/drivers/firmware/scmi/protocol.h>
+
+/**
+ * @brief Pin configuration and control via SCMI
+ * @defgroup scmi_pinctrl Pin Control Protocol
+ * @ingroup scmi_protocols
+ * @{
+ */
 
 #define ARM_SCMI_PINCTRL_MAX_CONFIG_SIZE (10 * 2)
 
@@ -101,5 +109,9 @@ struct scmi_pinctrl_settings {
  * @retval negative errno if failure
  */
 int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings);
+
+/**
+ * @}
+ */
 
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PINCTRL_H_ */

--- a/include/zephyr/drivers/firmware/scmi/power.h
+++ b/include/zephyr/drivers/firmware/scmi/power.h
@@ -6,13 +6,21 @@
 
 /**
  * @file
- * @brief SCMI power domain protocol helpers
+ * @ingroup scmi_power
+ * @brief Header file for the SCMI Power Domain Protocol.
  */
 
 #ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_POWER_H_
 #define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_POWER_H_
 
 #include <zephyr/drivers/firmware/scmi/protocol.h>
+
+/**
+ * @brief Power domain state management via SCMI
+ * @defgroup scmi_power Power Domain Protocol
+ * @ingroup scmi_protocols
+ * @{
+ */
 
 #define SCMI_POWER_STATE_SET_FLAGS_ASYNC BIT(0)
 
@@ -102,5 +110,9 @@ int scmi_power_state_set(struct scmi_power_state_config *cfg);
  * @retval negative errno if failure
  */
 int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state);
+
+/**
+ * @}
+ */
 
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_POWER_H_ */

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -6,11 +6,19 @@
 
 /**
  * @file
- * @brief SCMI protocol generic functions and structures
+ * @ingroup scmi_interface
+ * @brief Header file for the SCMI (System Control and Management Interface) driver API.
  */
 
 #ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PROTOCOL_H_
 #define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PROTOCOL_H_
+
+/**
+ * @brief Interfaces for ARM System Control and Management Interface (SCMI)
+ * @defgroup scmi_interface SCMI
+ * @ingroup io_interfaces
+ * @{
+ */
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/firmware/scmi/util.h>
@@ -183,5 +191,15 @@ int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
  * @retval negative errno if failure
  */
 int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t version);
+
+/**
+ * @}
+ */
+
+/**
+ * @brief Standard SCMI Protocol definitions
+ * @defgroup scmi_protocols Protocols
+ * @ingroup scmi_interface
+ */
 
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PROTOCOL_H_ */

--- a/include/zephyr/drivers/firmware/scmi/shmem.h
+++ b/include/zephyr/drivers/firmware/scmi/shmem.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief SCMI SHMEM API
+ * @ingroup scmi_shmem
+ * @brief Header file for the SCMI Shared Memory.
  */
 
 #ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_SHMEM_H_
@@ -15,6 +16,13 @@
 #include <zephyr/device.h>
 #include <zephyr/arch/cpu.h>
 #include <errno.h>
+
+/**
+ * @brief Shared memory transport definitions for SCMI
+ * @defgroup scmi_shmem Shared Memory
+ * @ingroup scmi_transport
+ * @{
+ */
 
 #define SCMI_SHMEM_CHAN_STATUS_BUSY_BIT BIT(0)
 #define SCMI_SHMEM_CHAN_FLAG_IRQ_BIT BIT(0)
@@ -92,5 +100,9 @@ int scmi_shmem_vendor_write_message(struct scmi_shmem_layout *layout);
  * @retval negative errno if failure
  */
 int scmi_shmem_vendor_read_message(const struct scmi_shmem_layout *layout);
+
+/**
+ * @}
+ */
 
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_SHMEM_H_ */

--- a/include/zephyr/drivers/firmware/scmi/system.h
+++ b/include/zephyr/drivers/firmware/scmi/system.h
@@ -9,12 +9,20 @@
 
 /**
  * @file
- * @brief SCMI System Power Management Protocol
+ * @ingroup scmi_system
+ * @brief Header file for the SCMI System Power Management Protocol.
  */
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/firmware/scmi/protocol.h>
 #include <stdint.h>
+
+/**
+ * @brief System-wide power state management via SCMI
+ * @defgroup scmi_system System Power Protocol
+ * @ingroup scmi_protocols
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -149,5 +157,9 @@ int scmi_system_power_state_set(struct scmi_system_power_state_config *cfg);
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_SYSTEM_H_ */

--- a/include/zephyr/drivers/firmware/scmi/transport.h
+++ b/include/zephyr/drivers/firmware/scmi/transport.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public APIs for the SCMI transport layer drivers
+ * @ingroup scmi_transport
+ * @brief Header file for the SCMI Transport Layer.
  */
 
 #ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_TRANSPORT_H_
@@ -14,6 +15,13 @@
 
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
+
+/**
+ * @brief SCMI Transport Layer abstraction and definitions
+ * @defgroup scmi_transport Transport
+ * @ingroup scmi_interface
+ * @{
+ */
 
 struct scmi_message;
 struct scmi_channel;
@@ -270,5 +278,9 @@ static inline bool scmi_transport_channel_is_free(const struct device *transport
  * @retval negative errno code if failure
  */
 int scmi_core_transport_init(const struct device *transport);
+
+/**
+ * @}
+ */
 
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_TRANSPORT_H_ */

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief ARM SCMI utility header
+ * @ingroup scmi_util
+ * @brief Header file for SCMI Utility Macros.
  *
  * Contains various utility macros and macros used for protocol and
  * transport "registration".
@@ -14,6 +15,13 @@
 
 #ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_UTIL_H_
 #define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_UTIL_H_
+
+/**
+ * @brief Helper macros and utilities for SCMI drivers
+ * @defgroup scmi_util Utilities
+ * @ingroup scmi_interface
+ * @{
+ */
 
 /**
  * @brief Build protocol name from its ID
@@ -285,5 +293,9 @@
 #define SCMI_PROTOCOL_VOLTAGE_DOMAIN 23
 #define SCMI_PROTOCOL_PCAP_MONITOR 24
 #define SCMI_PROTOCOL_PINCTRL 25
+
+/**
+ * @}
+ */
 
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_UTIL_H_ */


### PR DESCRIPTION
- Fix incorrect indentation that caused some elements to render as defintion lists.
- Added proper nesting of the various headings as everything was top-level
- Added doxygen groups

https://builds.zephyrproject.io/zephyr/pr/100968/docs/hardware/arch/arm-scmi.html
https://builds.zephyrproject.io/zephyr/pr/100968/docs/doxygen/html/group__scmi__interface.html