### PR TITLE
LoRa: LBM: Fix LBM driver init and add GPIO callback API

### DIFF
--- a/drivers/lora/lora_basics_modem/Kconfig
+++ b/drivers/lora/lora_basics_modem/Kconfig
@@ -34,4 +34,12 @@ config LORA_BASICS_MODEM_RSSI_REPORT_TYPE_SIGNAL
 
 endchoice
 
+config LORA_BASICS_MODEM_DEFERRED_INIT
+	bool "Defer radio initialization until first use"
+	help
+	  When enabled, radio hardware initialization (reset, interrupt
+	  configuration) is deferred until the first call to lora_config().
+	  This allows applications to perform setup before the radio is
+	  initialized. When disabled, the radio is fully initialized at boot.
+
 endif

--- a/drivers/lora/lora_basics_modem/lbm_common.c
+++ b/drivers/lora/lora_basics_modem/lbm_common.c
@@ -90,6 +90,15 @@ int lbm_lora_config(const struct device *dev, struct lora_modem_config *lora_con
 	ral_status_t status;
 	int ret;
 
+	/* Perform deferred radio initialization on first config */
+	if (IS_ENABLED(CONFIG_LORA_BASICS_MODEM_DEFERRED_INIT) && !data->radio_initialized) {
+		ret = lbm_driver_radio_init(dev);
+		if (ret < 0) {
+			return ret;
+		}
+		data->radio_initialized = true;
+	}
+
 	/* Ensure available, decremented after configuration */
 	if (!modem_acquire(dev)) {
 		return -EBUSY;

--- a/drivers/lora/lora_basics_modem/lbm_common.h
+++ b/drivers/lora/lora_basics_modem/lbm_common.h
@@ -105,3 +105,40 @@ static inline int lbm_optional_gpio_set_dt(const struct gpio_dt_spec *spec, int 
 
 /* Common LBM implementation of the LoRa API */
 extern const struct lora_driver_api lbm_lora_api;
+
+/**
+ * @brief Add a GPIO callback for DIO1 interrupts
+ *
+ * This function registers a user callback that will be invoked from interrupt
+ * context when the DIO1 interrupt fires. The user must provide a pre-allocated
+ * gpio_callback structure. The driver will initialize the callback with the
+ * provided handler and the correct pin mask for the DIO1 pin.
+ *
+ * @param dev Modem device
+ * @param callback GPIO callback structure (will be initialized by driver)
+ * @param handler Callback handler function to be invoked on DIO1 interrupt
+ *
+ * @retval 0 On success
+ * @retval -ENODEV If device is not ready
+ * @retval -EINVAL If callback or handler is NULL
+ * @retval -ENOTSUP If GPIO driver doesn't support callbacks
+ * @retval -errno Other negative errno code on failure
+ */
+int lbm_driver_add_dio1_gpio_callback(const struct device *dev,
+				      struct gpio_callback *callback,
+				      gpio_callback_handler_t handler);
+
+/**
+ * @brief Remove a GPIO callback for DIO1 interrupts
+ *
+ * Remove a previously added GPIO callback.
+ *
+ * @param dev Modem device
+ * @param callback GPIO callback structure to remove
+ *
+ * @retval 0 On success
+ * @retval -EINVAL If callback not found
+ * @retval -errno Negative errno code on failure
+ */
+int lbm_driver_remove_dio1_gpio_callback(const struct device *dev,
+					 struct gpio_callback *callback);

--- a/drivers/lora/lora_basics_modem/lbm_common.h
+++ b/drivers/lora/lora_basics_modem/lbm_common.h
@@ -65,6 +65,8 @@ struct lbm_lora_data_common {
 	/* Current modem state */
 	atomic_t modem_state;
 	enum lbm_modem_mode modem_mode;
+	/* Radio initialization state */
+	bool radio_initialized;
 };
 
 /**
@@ -76,6 +78,19 @@ struct lbm_lora_data_common {
  * @retval -errno On failure
  */
 int lbm_lora_common_init(const struct device *dev);
+
+/**
+ * @brief Initialize radio hardware
+ *
+ * Called by lbm_lora_config on first configuration to defer radio
+ * initialization until needed. Each driver must implement this function.
+ *
+ * @param dev Modem to initialize
+ *
+ * @retval 0 On success
+ * @retval -errno On failure
+ */
+int lbm_driver_radio_init(const struct device *dev);
 
 /**
  * @brief Configure modem for a given mode


### PR DESCRIPTION
A bit of context here.

I'm working on making LBM a first-class backend citizen for LoRaWAN on Zephyr, so these couple of commits are part of a preparatory work to that.

The LBM HAL needs a bit more control over the stack than what Zephyr is currently able to guarantee or give. The `sx12xx` radio drivers in particular are doing too much during init, relinquishing the stack and configuring it at init stage. We need a way to let the HAL doing its job, configuring the radio as it please before being stepped over by Zephyr, so I'm moving the radio initialization into the `.config` hook instead of doing it at init time. The other viable option was to modify the API adding an `.init` hook but that would require an API change and I prefer to avoid that if possible.

The second commit is about adding a way for the HAL to install its own `DIO1` callback, simple as that.