### PR TITLE
drivers: lora: LDRO and bandwith additions

### DIFF
--- a/drivers/lora/lora-basics-modem/lbm_common.c
+++ b/drivers/lora/lora-basics-modem/lbm_common.c
@@ -81,7 +81,8 @@ int lbm_lora_config(const struct device *dev, struct lora_modem_config *lora_con
 		.mod_params = {
 			.sf = lora_config->datarate,
 			.cr = lora_config->coding_rate,
-			.ldro = LORA_LDRO(lora_config->datarate, lora_config->bandwidth),
+			.ldro = config->force_ldro ? 1 : LORA_LDRO(lora_config->datarate,
+								   lora_config->bandwidth),
 		},
 		.pkt_params = {
 			.preamble_len_in_symb = lora_config->preamble_len,

--- a/drivers/lora/lora-basics-modem/lbm_common.c
+++ b/drivers/lora/lora-basics-modem/lbm_common.c
@@ -105,14 +105,50 @@ int lbm_lora_config(const struct device *dev, struct lora_modem_config *lora_con
 	}
 
 	switch (lora_config->bandwidth) {
+	case BW_7_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_007_KHZ;
+		break;
+	case BW_10_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_010_KHZ;
+		break;
+	case BW_15_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_015_KHZ;
+		break;
+	case BW_20_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_020_KHZ;
+		break;
+	case BW_31_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_031_KHZ;
+		break;
+	case BW_41_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_041_KHZ;
+		break;
+	case BW_62_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_062_KHZ;
+		break;
 	case BW_125_KHZ:
 		params.mod_params.bw = RAL_LORA_BW_125_KHZ;
+		break;
+	case BW_200_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_200_KHZ;
 		break;
 	case BW_250_KHZ:
 		params.mod_params.bw = RAL_LORA_BW_250_KHZ;
 		break;
+	case BW_400_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_400_KHZ;
+		break;
 	case BW_500_KHZ:
 		params.mod_params.bw = RAL_LORA_BW_500_KHZ;
+		break;
+	case BW_800_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_800_KHZ;
+		break;
+	case BW_1000_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_1000_KHZ;
+		break;
+	case BW_1600_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_1600_KHZ;
 		break;
 	default:
 		ret = -EINVAL;

--- a/drivers/lora/lora-basics-modem/lbm_common.h
+++ b/drivers/lora/lora-basics-modem/lbm_common.h
@@ -34,6 +34,7 @@ enum lbm_modem_mode {
 struct lbm_lora_config_common {
 	/* LBM radio abstration layer structure */
 	ralf_t ralf;
+	bool force_ldro;
 };
 
 /* Common LBM modem data, must be first element of device data */

--- a/drivers/lora/lora-basics-modem/lbm_sx126x.c
+++ b/drivers/lora/lora-basics-modem/lbm_sx126x.c
@@ -574,6 +574,7 @@ static int sx126x_init(const struct device *dev)
 #define SX126X_DEFINE(node_id, sx_variant)                                                         \
 	static const struct lbm_sx126x_config config_##node_id = {                                 \
 		.lbm_common.ralf = RALF_SX126X_INSTANTIATE(DEVICE_DT_GET(node_id)),                \
+		.lbm_common.force_ldro = DT_PROP(node_id, force_ldro),                             \
 		.spi = SPI_DT_SPEC_GET(                                                            \
 			node_id, SPI_WORD_SET(8) | SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB),         \
 		.reset = GPIO_DT_SPEC_GET(node_id, reset_gpios),                                   \

--- a/drivers/lora/lora-basics-modem/lbm_sx127x.c
+++ b/drivers/lora/lora-basics-modem/lbm_sx127x.c
@@ -467,6 +467,7 @@ static int sx127x_driver_init(const struct device *dev)
 	static struct lbm_sx127x_data data_##node_id;                                              \
 	static const struct lbm_sx127x_config config_##node_id = {                                 \
 		.lbm_common.ralf = RALF_SX127X_INSTANTIATE(&data_##node_id.radio),                 \
+		.lbm_common.force_ldro = DT_PROP(node_id, force_ldro),                             \
 		.spi = SPI_DT_SPEC_GET(                                                            \
 			node_id, SPI_WORD_SET(8) | SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB),         \
 		.reset = GPIO_DT_SPEC_GET(node_id, reset_gpios),                                   \

--- a/dts/bindings/lora/semtech,sx126x-base.yaml
+++ b/dts/bindings/lora/semtech,sx126x-base.yaml
@@ -70,3 +70,9 @@ properties:
     type: boolean
     description: |
       Use the internal LDO instead of the internal DCDC. Increases power consumption.
+
+  force-ldro:
+    type: boolean
+    description: |
+      Force usage of Low Data Rate Optimization even in cases where the symbol time is shorter than
+      16.38ms. Useful for designs using no TCXO or with bad heat dissipation.

--- a/dts/bindings/lora/semtech,sx127x-base.yaml
+++ b/dts/bindings/lora/semtech,sx127x-base.yaml
@@ -61,3 +61,9 @@ properties:
     type: int
     description: |
       Delay which has to be applied after enabling TCXO power.
+
+  force-ldro:
+    type: boolean
+    description: |
+      Force usage of Low Data Rate Optimization even in cases where the symbol time is shorter than
+      16.38ms. Useful for designs using no TCXO or with bad heat dissipation.

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -38,9 +38,21 @@ extern "C" {
  * higher data rates but typically reduce sensitivity and range.
  */
 enum lora_signal_bandwidth {
-	BW_125_KHZ = 0,	/**< 125 kHz */
-	BW_250_KHZ,	/**< 250 kHz */
-	BW_500_KHZ,	/**< 500 kHz */
+	BW_7_KHZ = 7,		/**< 7.81 kHz */
+	BW_10_KHZ = 10,		/**< 10.42 kHz */
+	BW_15_KHZ = 15,		/**< 15.63 kHz */
+	BW_20_KHZ = 20,		/**< 20.83 kHz */
+	BW_31_KHZ = 31,		/**< 31.25 kHz */
+	BW_41_KHZ = 41,		/**< 41.67 kHz */
+	BW_62_KHZ = 62,		/**< 62.5 kHz */
+	BW_125_KHZ = 125,	/**< 125 kHz */
+	BW_200_KHZ = 200,	/**< 203 kHz */
+	BW_250_KHZ = 250,	/**< 250 kHz */
+	BW_400_KHZ = 400,	/**< 406 kHz */
+	BW_500_KHZ = 500,	/**< 500 kHz */
+	BW_800_KHZ = 800,	/**< 812 kHz */
+	BW_1000_KHZ = 1000,	/**< 1000 kHz */
+	BW_1600_KHZ = 1600,	/**< 1625 kHz */
 };
 
 /**
@@ -52,13 +64,14 @@ enum lora_signal_bandwidth {
  * symbol). Higher values result in lower data rates but increased range and robustness.
  */
 enum lora_datarate {
-	SF_6 = 6, /**< Spreading factor 6 (fastest, shortest range) */
-	SF_7,     /**< Spreading factor 7 */
-	SF_8,     /**< Spreading factor 8 */
-	SF_9,     /**< Spreading factor 9 */
-	SF_10,    /**< Spreading factor 10 */
-	SF_11,    /**< Spreading factor 11 */
-	SF_12,    /**< Spreading factor 12 (slowest, longest range) */
+	SF_5 = 5,	/**< Spreading factor 5 (fastest, shortest range) */
+	SF_6 = 6,	/**< Spreading factor 6 */
+	SF_7 = 7,	/**< Spreading factor 7 */
+	SF_8 = 8,	/**< Spreading factor 8 */
+	SF_9 = 9,	/**< Spreading factor 9 */
+	SF_10 = 10,	/**< Spreading factor 10 */
+	SF_11 = 11,	/**< Spreading factor 11 */
+	SF_12 = 12,	/**< Spreading factor 12 (slowest, longest range) */
 };
 
 /**


### PR DESCRIPTION
Add missing bandwidths, set enum to be value in khz, add missing sf
use enum value in khz to calculate approximate symbol time
use symbol time to determine if ldro should be enabled
add option to always enable ldro regardless of symbol time

symbol time checked against lora calculator https://www.semtech.com/design-support/lora-calculator, formula is good enough to match without using floats.

See any modem datasheet for 16ms/16.38ms times and the symbol rate / symbol time formulas