### PR TITLE
drivers: stepper_shell: refactor stepper_ctrl commands

### DIFF
--- a/drivers/stepper/stepper_shell.c
+++ b/drivers/stepper/stepper_shell.c
@@ -572,6 +572,15 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(get_micro_step_res, &dsub_pos_stepper_driver_name,
 		      SHELL_HELP("Get micro-step resolution", "<device>"),
 		      cmd_stepper_get_micro_step_res, 2, 0),
+	SHELL_CMD_ARG(info, &dsub_pos_stepper_driver_name,
+		      SHELL_HELP("Show stepper hardware driver info", "<device>"),
+		      cmd_stepper_info, 2, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_REGISTER(stepper, &stepper_cmds, "Stepper hardware driver commands", NULL);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	stepper_ctrl_cmds,
 	SHELL_CMD_ARG(set_reference_position, &dsub_pos_stepper_controller_name,
 		      SHELL_HELP("Set reference position", "<device> <position>"),
 		      cmd_stepper_ctrl_set_reference_position, 3, 0),
@@ -594,11 +603,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      SHELL_HELP("Stop motor", "<device>"),
 		      cmd_stepper_ctrl_stop, 2, 0),
 	SHELL_CMD_ARG(control_info, &dsub_pos_stepper_controller_name,
-		      SHELL_HELP("Show controller info", "<device>"),
+		      SHELL_HELP("Show stepper motion controller info", "<device>"),
 		      cmd_stepper_control_info, 2, 0),
-	SHELL_CMD_ARG(info, &dsub_pos_stepper_driver_name,
-		      SHELL_HELP("Show stepper info", "<device>"),
-		      cmd_stepper_info, 2, 0),
 	SHELL_SUBCMD_SET_END);
 
-SHELL_CMD_REGISTER(stepper, &stepper_cmds, "Stepper motor commands", NULL);
+SHELL_CMD_REGISTER(stepper_ctrl, &stepper_ctrl_cmds, "Stepper motion controller commands", NULL);

--- a/tests/drivers/stepper/shell/src/main.c
+++ b/tests/drivers/stepper/shell/src/main.c
@@ -65,7 +65,7 @@ ZTEST(stepper_shell, test_stepper_driver_disable)
 ZTEST(stepper_shell, test_stepper_ctrl_move_by)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper move_by " FAKE_STEPPER_CONTROLLER " 1000");
+	int err = shell_execute_cmd(sh, "stepper_ctrl move_by " FAKE_STEPPER_CONTROLLER " 1000");
 
 	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_ctrl_move_by_fake, fake_stepper_controller_dev,
 				   err);
@@ -75,8 +75,8 @@ ZTEST(stepper_shell, test_stepper_ctrl_move_by)
 ZTEST(stepper_shell, test_stepper_ctrl_set_microstep_interval)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper set_microstep_interval " FAKE_STEPPER_CONTROLLER
-					" 200");
+	int err = shell_execute_cmd(
+		sh, "stepper_ctrl set_microstep_interval " FAKE_STEPPER_CONTROLLER " 200");
 
 	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_ctrl_set_microstep_interval_fake,
 				   fake_stepper_controller_dev, err);
@@ -115,8 +115,8 @@ ZTEST(stepper_shell, test_stepper_driver_get_micro_step_res)
 ZTEST(stepper_shell, test_stepper_ctrl_set_reference_position)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper set_reference_position " FAKE_STEPPER_CONTROLLER
-					" 100");
+	int err = shell_execute_cmd(
+		sh, "stepper_ctrl set_reference_position " FAKE_STEPPER_CONTROLLER " 100");
 
 	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_ctrl_set_reference_position_fake,
 				   fake_stepper_controller_dev, err);
@@ -127,7 +127,8 @@ ZTEST(stepper_shell, test_stepper_ctrl_set_reference_position)
 ZTEST(stepper_shell, test_stepper_ctrl_get_actual_position)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper get_actual_position " FAKE_STEPPER_CONTROLLER);
+	int err =
+		shell_execute_cmd(sh, "stepper_ctrl get_actual_position " FAKE_STEPPER_CONTROLLER);
 
 	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_ctrl_get_actual_position_fake,
 				   fake_stepper_controller_dev, err);
@@ -136,7 +137,7 @@ ZTEST(stepper_shell, test_stepper_ctrl_get_actual_position)
 ZTEST(stepper_shell, test_stepper_ctrl_move_to)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper move_to " FAKE_STEPPER_CONTROLLER " 200");
+	int err = shell_execute_cmd(sh, "stepper_ctrl move_to " FAKE_STEPPER_CONTROLLER " 200");
 
 	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_ctrl_move_to_fake, fake_stepper_controller_dev,
 				   err);
@@ -146,7 +147,7 @@ ZTEST(stepper_shell, test_stepper_ctrl_move_to)
 ZTEST(stepper_shell, test_stepper_ctrl_run)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper run " FAKE_STEPPER_CONTROLLER " positive");
+	int err = shell_execute_cmd(sh, "stepper_ctrl run " FAKE_STEPPER_CONTROLLER " positive");
 
 	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_ctrl_run_fake, fake_stepper_controller_dev, err);
 	zassert_equal(fake_stepper_ctrl_run_fake.arg1_val, STEPPER_CTRL_DIRECTION_POSITIVE,
@@ -156,7 +157,7 @@ ZTEST(stepper_shell, test_stepper_ctrl_run)
 ZTEST(stepper_shell, test_stepper_ctrl_run_invalid_direction)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper run " FAKE_STEPPER_CONTROLLER " foo");
+	int err = shell_execute_cmd(sh, "stepper_ctrl run " FAKE_STEPPER_CONTROLLER " foo");
 
 	zassert_not_equal(err, 0, " executed run with invalid direction value");
 }
@@ -164,7 +165,7 @@ ZTEST(stepper_shell, test_stepper_ctrl_run_invalid_direction)
 ZTEST(stepper_shell, test_stepper_ctrl_stop)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper stop " FAKE_STEPPER_CONTROLLER);
+	int err = shell_execute_cmd(sh, "stepper_ctrl stop " FAKE_STEPPER_CONTROLLER);
 
 	ASSERT_STEPPER_FUNC_CALLED(fake_stepper_ctrl_stop_fake, fake_stepper_controller_dev, err);
 	zassert_equal(err, 0, "stepper stop could not be executed");
@@ -173,7 +174,7 @@ ZTEST(stepper_shell, test_stepper_ctrl_stop)
 ZTEST(stepper_shell, test_stepper_controller_info)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	int err = shell_execute_cmd(sh, "stepper control_info " FAKE_STEPPER_CONTROLLER);
+	int err = shell_execute_cmd(sh, "stepper_ctrl control_info " FAKE_STEPPER_CONTROLLER);
 
 	zassert_ok(err, "failed to execute shell command (err %d)", err);
 


### PR DESCRIPTION
Split the stepper_cmds in stepper and stepper_ctrl_cmds respectively to address the recent api split