### PR TITLE
include: crypto: add AES CFB and OFB modes

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -167,6 +167,13 @@ New APIs and options
     * :c:func:`bt_mesh_stat_lpn_timing_get`
     * :c:func:`bt_mesh_stat_lpn_timing_reset`
 
+* Crypto
+
+  * :c:enumerator:`CRYPTO_CIPHER_MODE_CFB`
+  * :c:enumerator:`CRYPTO_CIPHER_MODE_OFB`
+  * :c:func:`cipher_cfb_op`
+  * :c:func:`cipher_ofb_op`
+
 * Devicetree
 
   * :c:macro:`DT_IRQN_BY_NAME`
@@ -266,6 +273,10 @@ New Samples
 
 Libraries / Subsystems
 **********************
+
+* Crypto
+
+  * Added AES CFB and OFB cipher mode support.
 
 * DFU
 

--- a/include/zephyr/crypto/cipher.h
+++ b/include/zephyr/crypto/cipher.h
@@ -47,6 +47,8 @@ enum cipher_mode {
 	CRYPTO_CIPHER_MODE_CTR = 3, /**< Counter mode. */
 	CRYPTO_CIPHER_MODE_CCM = 4, /**< Counter with CBC-MAC mode. */
 	CRYPTO_CIPHER_MODE_GCM = 5, /**< Galois/Counter mode. */
+	CRYPTO_CIPHER_MODE_CFB = 6, /**< Cipher Feedback mode. */
+	CRYPTO_CIPHER_MODE_OFB = 7, /**< Output Feedback mode. */
 };
 
 /* Forward declarations */
@@ -124,6 +126,32 @@ typedef int (*gcm_op_t)(struct cipher_ctx *ctx, struct cipher_aead_pkt *pkt,
 			 uint8_t *nonce);
 
 /**
+ * @brief Perform a CFB cipher operation.
+ *
+ * @param ctx Cipher session context.
+ * @param pkt Packet containing input and output buffers.
+ * @param iv Initialization vector for this operation.
+ *
+ * @retval 0 Operation completed successfully.
+ * @retval -errno Negative errno code on failure.
+ */
+typedef int (*cfb_op_t)(struct cipher_ctx *ctx, struct cipher_pkt *pkt,
+			uint8_t *iv);
+
+/**
+ * @brief Perform an OFB cipher operation.
+ *
+ * @param ctx Cipher session context.
+ * @param pkt Packet containing input and output buffers.
+ * @param iv Initialization vector for this operation.
+ *
+ * @retval 0 Operation completed successfully.
+ * @retval -errno Negative errno code on failure.
+ */
+typedef int (*ofb_op_t)(struct cipher_ctx *ctx, struct cipher_pkt *pkt,
+			uint8_t *iv);
+
+/**
  * Cipher operation handlers selected for a session.
  *
  * The crypto driver populates this structure during cipher_begin_session()
@@ -146,6 +174,10 @@ struct cipher_ops {
 		ccm_op_t	ccm_crypt_hndlr;
 		/** Handler for GCM authenticated operations. */
 		gcm_op_t	gcm_crypt_hndlr;
+		/** Handler for CFB operations. */
+		cfb_op_t	cfb_crypt_hndlr;
+		/** Handler for OFB operations. */
+		ofb_op_t	ofb_crypt_hndlr;
 	};
 };
 

--- a/include/zephyr/crypto/crypto.h
+++ b/include/zephyr/crypto/crypto.h
@@ -335,6 +335,48 @@ static inline int cipher_cbc_op(struct cipher_ctx *ctx,
 }
 
 /**
+ * @brief Perform Cipher Feedback (CFB) crypto operation.
+ *
+ * @param  ctx       Pointer to the crypto context of this op.
+ * @param  pkt   Structure holding the input/output buffer pointers.
+ * @param  iv        Initialization Vector (IV) for the operation. Same
+ *			 IV value should not be reused across multiple
+ *			 operations (within a session context) for security.
+ *
+ * @return 0 on success, negative errno code on fail.
+ */
+static inline int cipher_cfb_op(struct cipher_ctx *ctx,
+				struct cipher_pkt *pkt, uint8_t *iv)
+{
+	__ASSERT(ctx->ops.cipher_mode == CRYPTO_CIPHER_MODE_CFB, "CFB mode "
+		 "session invoking a different mode handler");
+
+	pkt->ctx = ctx;
+	return ctx->ops.cfb_crypt_hndlr(ctx, pkt, iv);
+}
+
+/**
+ * @brief Perform Output Feedback (OFB) mode crypto operation.
+ *
+ * @param  ctx       Pointer to the crypto context of this op.
+ * @param  pkt   Structure holding the input/output buffer pointers.
+ * @param  iv        Initialization Vector (IV) for the operation. Same
+ *			 IV value should not be reused across multiple
+ *			 operations (within a session context) for security.
+ *
+ * @return 0 on success, negative errno code on fail.
+ */
+static inline int cipher_ofb_op(struct cipher_ctx *ctx,
+				struct cipher_pkt *pkt, uint8_t *iv)
+{
+	__ASSERT(ctx->ops.cipher_mode == CRYPTO_CIPHER_MODE_OFB, "OFB mode "
+		 "session invoking a different mode handler");
+
+	pkt->ctx = ctx;
+	return ctx->ops.ofb_crypt_hndlr(ctx, pkt, iv);
+}
+
+/**
  * @brief Perform Counter (CTR) mode crypto operation.
  *
  * @param  ctx       Pointer to the crypto context of this op.

--- a/samples/drivers/crypto/src/main.c
+++ b/samples/drivers/crypto/src/main.c
@@ -295,6 +295,171 @@ out:
 	cipher_free_session(dev, &ini);
 }
 
+static const uint8_t cfb_ciphertext[64] = {
+	0x3b, 0x3f, 0xd9, 0x2e, 0xb7, 0x2d, 0xad, 0x20, 0x33, 0x34, 0x49, 0xf8,
+	0xe8, 0x3c, 0xfb, 0x4a, 0xc8, 0xa6, 0x45, 0x37, 0xa0, 0xb3, 0xa9, 0x3f,
+	0xcd, 0xe3, 0xcd, 0xad, 0x9f, 0x1c, 0xe5, 0x8b, 0x26, 0x75, 0x1f, 0x67,
+	0xa3, 0xcb, 0xb1, 0x40, 0xb1, 0x80, 0x8c, 0xf1, 0x87, 0xa4, 0xf4, 0xdf,
+	0xc0, 0x4b, 0x05, 0x35, 0x7c, 0x5d, 0x1c, 0x0e, 0xea, 0xc4, 0xc6, 0x6f,
+	0x9f, 0xf7, 0xf2, 0xe6
+};
+
+void cfb_mode(const struct device *dev)
+{
+	uint8_t encrypted[64] __aligned(IO_ALIGNMENT_BYTES) = {0};
+	uint8_t decrypted[64] __aligned(IO_ALIGNMENT_BYTES) = {0};
+	struct cipher_ctx ini = {
+		.keylen = sizeof(key),
+		.key.bit_stream = key,
+		.flags = cap_flags,
+	};
+	struct cipher_pkt encrypt = {
+		.in_buf = plaintext,
+		.in_len = sizeof(plaintext),
+		.out_buf_max = sizeof(encrypted),
+		.out_buf = encrypted,
+	};
+	struct cipher_pkt decrypt = {
+		.in_buf = encrypt.out_buf,
+		.in_len = sizeof(encrypted),
+		.out_buf = decrypted,
+		.out_buf_max = sizeof(decrypted),
+	};
+
+	static uint8_t iv[16] = {
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+	};
+
+	if (cipher_begin_session(dev, &ini, CRYPTO_CIPHER_ALGO_AES, CRYPTO_CIPHER_MODE_CFB,
+				 CRYPTO_CIPHER_OP_ENCRYPT)) {
+		return;
+	}
+
+	if (cipher_cfb_op(&ini, &encrypt, iv)) {
+		LOG_ERR("CFB mode ENCRYPT - Failed");
+		goto out;
+	}
+
+	LOG_INF("Output length (encryption): %d", encrypt.out_len);
+
+	if (memcmp(encrypt.out_buf, cfb_ciphertext, sizeof(cfb_ciphertext))) {
+		LOG_ERR("CFB mode ENCRYPT - Mismatch between expected and "
+			    "returned cipher text");
+		print_buffer_comparison(cfb_ciphertext, encrypt.out_buf,
+					sizeof(cfb_ciphertext));
+		goto out;
+	}
+
+	LOG_INF("CFB mode ENCRYPT - Match");
+	cipher_free_session(dev, &ini);
+
+	if (cipher_begin_session(dev, &ini, CRYPTO_CIPHER_ALGO_AES, CRYPTO_CIPHER_MODE_CFB,
+				 CRYPTO_CIPHER_OP_DECRYPT)) {
+		return;
+	}
+
+	if (cipher_cfb_op(&ini, &decrypt, iv)) {
+		LOG_ERR("CFB mode DECRYPT - Failed");
+		goto out;
+	}
+
+	LOG_INF("Output length (decryption): %d", decrypt.out_len);
+
+	if (memcmp(decrypt.out_buf, plaintext, sizeof(plaintext))) {
+		LOG_ERR("CFB mode DECRYPT - Mismatch between plaintext and "
+			    "decrypted cipher text");
+		print_buffer_comparison(plaintext, decrypt.out_buf, sizeof(plaintext));
+		goto out;
+	}
+
+	LOG_INF("CFB mode DECRYPT - Match");
+out:
+	cipher_free_session(dev, &ini);
+}
+
+static const uint8_t ofb_ciphertext[64] = {
+	0x3b, 0x3f, 0xd9, 0x2e, 0xb7, 0x2d, 0xad, 0x20, 0x33, 0x34, 0x49, 0xf8,
+	0xe8, 0x3c, 0xfb, 0x4a, 0x77, 0x89, 0x50, 0x8d, 0x16, 0x91, 0x8f, 0x03,
+	0xf5, 0x3c, 0x52, 0xda, 0xc5, 0x4e, 0xd8, 0x25, 0x97, 0x40, 0x05, 0x1e,
+	0x9c, 0x5f, 0xec, 0xf6, 0x43, 0x44, 0xf7, 0xa8, 0x22, 0x60, 0xed, 0xcc,
+	0x30, 0x4c, 0x65, 0x28, 0xf6, 0x59, 0xc7, 0x78, 0x66, 0xa5, 0x10, 0xd9,
+	0xc1, 0xd6, 0xae, 0x5e
+};
+
+void ofb_mode(const struct device *dev)
+{
+	uint8_t encrypted[64] __aligned(IO_ALIGNMENT_BYTES) = {0};
+	uint8_t decrypted[64] __aligned(IO_ALIGNMENT_BYTES) = {0};
+	struct cipher_ctx ini = {
+		.keylen = sizeof(key),
+		.key.bit_stream = key,
+		.flags = cap_flags,
+	};
+	struct cipher_pkt encrypt = {
+		.in_buf = plaintext,
+		.in_len = sizeof(plaintext),
+		.out_buf_max = sizeof(encrypted),
+		.out_buf = encrypted,
+	};
+	struct cipher_pkt decrypt = {
+		.in_buf = encrypt.out_buf,
+		.in_len = sizeof(encrypted),
+		.out_buf = decrypted,
+		.out_buf_max = sizeof(decrypted),
+	};
+
+	static uint8_t iv[16] = {
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+	};
+
+	if (cipher_begin_session(dev, &ini, CRYPTO_CIPHER_ALGO_AES, CRYPTO_CIPHER_MODE_OFB,
+				 CRYPTO_CIPHER_OP_ENCRYPT)) {
+		return;
+	}
+
+	if (cipher_ofb_op(&ini, &encrypt, iv)) {
+		LOG_ERR("OFB mode ENCRYPT - Failed");
+		goto out;
+	}
+
+	LOG_INF("Output length (encryption): %d", encrypt.out_len);
+
+	if (memcmp(encrypt.out_buf, ofb_ciphertext, sizeof(ofb_ciphertext))) {
+		LOG_ERR("OFB mode ENCRYPT - Mismatch between expected and "
+			    "returned cipher text");
+		print_buffer_comparison(ofb_ciphertext, encrypt.out_buf, sizeof(ofb_ciphertext));
+		goto out;
+	}
+
+	LOG_INF("OFB mode ENCRYPT - Match");
+	cipher_free_session(dev, &ini);
+
+	if (cipher_begin_session(dev, &ini, CRYPTO_CIPHER_ALGO_AES, CRYPTO_CIPHER_MODE_OFB,
+				 CRYPTO_CIPHER_OP_DECRYPT)) {
+		return;
+	}
+
+	if (cipher_ofb_op(&ini, &decrypt, iv)) {
+		LOG_ERR("OFB mode DECRYPT - Failed");
+		goto out;
+	}
+
+	LOG_INF("Output length (decryption): %d", decrypt.out_len);
+
+	if (memcmp(decrypt.out_buf, plaintext, sizeof(plaintext))) {
+		LOG_ERR("OFB mode DECRYPT - Mismatch between plaintext and "
+			    "decrypted cipher text");
+		print_buffer_comparison(plaintext, decrypt.out_buf, sizeof(plaintext));
+		goto out;
+	}
+
+	LOG_INF("OFB mode DECRYPT - Match");
+out:
+	cipher_free_session(dev, &ini);
+}
+
 static const uint8_t ctr_ciphertext[64] = {
 	0x22, 0xe5, 0x2f, 0xb1, 0x77, 0xd8, 0x65, 0xb2,
 	0xf7, 0xc6, 0xb5, 0x12, 0x69, 0x2d, 0x11, 0x4d,
@@ -619,6 +784,8 @@ int main(void)
 	const struct mode_test modes[] = {
 		{ .mode = "ECB Mode", .mode_func = ecb_mode },
 		{ .mode = "CBC Mode", .mode_func = cbc_mode },
+		{ .mode = "CFB Mode", .mode_func = cfb_mode },
+		{ .mode = "OFB Mode", .mode_func = ofb_mode },
 		{ .mode = "CTR Mode", .mode_func = ctr_mode },
 		{ .mode = "CCM Mode", .mode_func = ccm_mode },
 		{ .mode = "GCM Mode", .mode_func = gcm_mode },


### PR DESCRIPTION
This PR extends the Zephyr crypto cipher API to support AES Cipher Feedback
(CFB) and Output Feedback (OFB) modes of operation.

Changes:
- Add CFB and OFB cipher mode identifiers to `include/zephyr/crypto/cipher.h`.
- Update `include/zephyr/crypto/crypto.h` comments to describe the new modes.