### PR TITLE
drivers: stepper: use only driver names in Kconfigs

### DIFF
--- a/drivers/stepper/adi_tmc/CMakeLists.txt
+++ b/drivers/stepper/adi_tmc/CMakeLists.txt
@@ -4,9 +4,9 @@
 zephyr_library()
 zephyr_library_property(ALLOW_EMPTY TRUE)
 
-add_subdirectory_ifdef(CONFIG_STEPPER_ADI_TMC2209 tmc22xx)
-add_subdirectory_ifdef(CONFIG_STEPPER_ADI_TMC50XX tmc50xx)
-add_subdirectory_ifdef(CONFIG_STEPPER_ADI_TMC51XX tmc51xx)
+add_subdirectory_ifdef(CONFIG_TMC2209 tmc22xx)
+add_subdirectory_ifdef(CONFIG_TMC50XX tmc50xx)
+add_subdirectory_ifdef(CONFIG_TMC51XX tmc51xx)
 
 add_subdirectory(bus)
 add_subdirectory(common)

--- a/drivers/stepper/adi_tmc/Kconfig.tmc_rampgen_template
+++ b/drivers/stepper/adi_tmc/Kconfig.tmc_rampgen_template
@@ -18,7 +18,7 @@ config STEPPER_ADI_$(module)_RAMPSTAT_POLL_STALLGUARD_LOG
 
 config STEPPER_ADI_$(module)_RAMP_GEN
 	bool "Use $(module-str) with Ramp Generator"
-	depends on STEPPER_ADI_$(module)
+	depends on $(module)_STEPPER
 	default y
 	help
 	  Enable ramp generator for trinamic stepper controller.

--- a/drivers/stepper/adi_tmc/common/include/adi_tmc_reg.h
+++ b/drivers/stepper/adi_tmc/common/include/adi_tmc_reg.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif
 
 /** Common Registers for TMC50XX and TMC51XX */
-#if defined(CONFIG_STEPPER_ADI_TMC50XX) || defined(CONFIG_STEPPER_ADI_TMC51XX)
+#if defined(CONFIG_TMC50XX) || defined(CONFIG_TMC51XX)
 
 #define TMC5XXX_WRITE_BIT        0x80U
 #define TMC5XXX_ADDRESS_MASK     0x7FU
@@ -110,7 +110,7 @@ extern "C" {
 
 #endif
 
-#ifdef CONFIG_STEPPER_ADI_TMC50XX
+#ifdef CONFIG_TMC50XX
 
 #define TMC50XX_MOTOR_ADDR_PWM(m) ((m) << 3)
 
@@ -147,9 +147,9 @@ extern "C" {
 #define TMC50XX_MSCNT(motor)      (0x6A | TMC50XX_MOTOR_ADDR_DRV(motor))
 #define TMC50XX_MSCURACT(motor)   (0x6B | TMC50XX_MOTOR_ADDR_DRV(motor))
 
-#endif /* CONFIG_STEPPER_ADI_TMC50XX */
+#endif /* CONFIG_TMC50XX */
 
-#ifdef CONFIG_STEPPER_ADI_TMC51XX
+#ifdef CONFIG_TMC51XX
 
 #define TMC51XX_GCONF_EN_PWM_MODE_SHIFT        2
 #define TMC51XX_GCONF_SHAFT_SHIFT              4
@@ -182,7 +182,7 @@ extern "C" {
 #define TMC51XX_COOLCONF	TMC50XX_COOLCONF(0)
 #define TMC51XX_DRVSTATUS	TMC50XX_DRVSTATUS(0)
 
-#endif /* CONFIG_STEPPER_ADI_TMC51XX */
+#endif /* CONFIG_TMC51XX */
 
 /**
  * @}

--- a/drivers/stepper/adi_tmc/tmc22xx/Kconfig.tmc22xx
+++ b/drivers/stepper/adi_tmc/tmc22xx/Kconfig.tmc22xx
@@ -1,10 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-config STEPPER_ADI_TMC2209
-	bool "Activate trinamic tmc2209 stepper driver"
+config TMC2209
+	bool "ADI Trinamic TMC2209 stepper_drv driver"
 	depends on DT_HAS_ADI_TMC2209_ENABLED
 	select STEP_DIR_STEPPER
 	default y
-	help
-	  Stepper driver for TMC2209.

--- a/drivers/stepper/adi_tmc/tmc50xx/CMakeLists.txt
+++ b/drivers/stepper/adi_tmc/tmc50xx/CMakeLists.txt
@@ -2,6 +2,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Jilay Sandeep Pandya
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_sources_ifdef(CONFIG_STEPPER_ADI_TMC50XX tmc50xx.c)
-zephyr_library_sources_ifdef(CONFIG_STEPPER_ADI_TMC50XX_STEPPER tmc50xx_stepper.c)
-zephyr_library_sources_ifdef(CONFIG_STEPPER_ADI_TMC50XX_STEPPER_DRV tmc50xx_stepper_drv.c)
+zephyr_library_sources(tmc50xx.c)
+zephyr_library_sources_ifdef(CONFIG_TMC50XX_STEPPER tmc50xx_stepper.c)
+zephyr_library_sources_ifdef(CONFIG_TMC50XX_STEPPER_DRV tmc50xx_stepper_drv.c)

--- a/drivers/stepper/adi_tmc/tmc50xx/Kconfig.tmc50xx
+++ b/drivers/stepper/adi_tmc/tmc50xx/Kconfig.tmc50xx
@@ -2,26 +2,26 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Jilay Sandeep Pandya
 # SPDX-License-Identifier: Apache-2.0
 
-config STEPPER_ADI_TMC50XX
-	bool "Activate trinamic tmc50xx"
+config TMC50XX
+	bool "ADI Trinamic TMC50XX"
 	depends on DT_HAS_ADI_TMC50XX_ENABLED
 	select STEPPER_ADI_TMC_SPI
 	default y
 
-config STEPPER_ADI_TMC50XX_STEPPER
-	bool "Activate trinamic tmc50xx motion controller"
-	depends on DT_HAS_ADI_TMC50XX_STEPPER_ENABLED && STEPPER_ADI_TMC50XX
+if TMC50XX
+
+config TMC50XX_STEPPER
+	bool "ADI Trinamic TMC50XX stepper driver"
+	depends on DT_HAS_ADI_TMC50XX_STEPPER_ENABLED
 	default y
 
-config STEPPER_ADI_TMC50XX_STEPPER_DRV
-	bool "Activate trinamic tmc50xx stepper driver"
-	depends on DT_HAS_ADI_TMC50XX_STEPPER_DRV_ENABLED && STEPPER_ADI_TMC50XX
+config TMC50XX_STEPPER_DRV
+	bool "ADI Trinamic TMC50XX stepper_drv driver"
+	depends on DT_HAS_ADI_TMC50XX_STEPPER_DRV_ENABLED
 	default y
-
-if STEPPER_ADI_TMC50XX
 
 module = TMC50XX
 module-str = tmc50xx
 source "drivers/stepper/adi_tmc/Kconfig.tmc_rampgen_template"
 
-endif # STEPPER_ADI_TMC50XX
+endif # TMC50XX

--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
@@ -165,7 +165,7 @@ static void rampstat_work(const struct device *dev)
 
 	if (ramp_stat_values > 0) {
 		switch (ramp_stat_values) {
-#ifdef CONFIG_STEPPER_ADI_TMC50XX_STEPPER
+#ifdef CONFIG_TMC50XX_STEPPER
 		case TMC5XXX_STOP_LEFT_EVENT:
 			LOG_DBG("RAMPSTAT %s:Left end-stop detected", data->dev->name);
 			tmc50xx_stepper_trigger_cb(
@@ -189,7 +189,7 @@ static void rampstat_work(const struct device *dev)
 				STEPPER_EVENT_STEPS_COMPLETED);
 			break;
 #endif
-#ifdef CONFIG_STEPPER_ADI_TMC50XX_STEPPER_DRV
+#ifdef CONFIG_TMC50XX_STEPPER_DRV
 		case TMC5XXX_STOP_SG_EVENT:
 			LOG_DBG("RAMPSTAT %s:Stall detected", data->dev->name);
 			tmc50xx_stepper_stallguard_enable(data->dev, false);

--- a/drivers/stepper/adi_tmc/tmc51xx/CMakeLists.txt
+++ b/drivers/stepper/adi_tmc/tmc51xx/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Dipak Shetty
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_sources_ifdef(CONFIG_STEPPER_ADI_TMC51XX tmc51xx.c)
-zephyr_library_sources_ifdef(CONFIG_STEPPER_ADI_TMC51XX_STEPPER tmc51xx_stepper.c)
-zephyr_library_sources_ifdef(CONFIG_STEPPER_ADI_TMC51XX_STEPPER_DRV tmc51xx_stepper_drv.c)
+zephyr_library_sources(tmc51xx.c)
+zephyr_library_sources_ifdef(CONFIG_TMC51XX_STEPPER tmc51xx_stepper.c)
+zephyr_library_sources_ifdef(CONFIG_TMC51XX_STEPPER_DRV tmc51xx_stepper_drv.c)

--- a/drivers/stepper/adi_tmc/tmc51xx/Kconfig.tmc51xx
+++ b/drivers/stepper/adi_tmc/tmc51xx/Kconfig.tmc51xx
@@ -2,27 +2,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Jilay Sandeep Pandya
 # SPDX-License-Identifier: Apache-2.0
 
-config STEPPER_ADI_TMC51XX
-	bool "Activate trinamic tmc51xx"
+config TMC51XX
+	bool "ADI Trinamic TMC51XX"
 	depends on DT_HAS_ADI_TMC51XX_ENABLED
 	select STEPPER_ADI_TMC_UART if $(dt_compat_on_bus,$(DT_COMPAT_ADI_TMC51XX),uart)
 	select STEPPER_ADI_TMC_SPI if $(dt_compat_on_bus,$(DT_COMPAT_ADI_TMC51XX),spi)
 	default y
 
-config STEPPER_ADI_TMC51XX_STEPPER
-	bool "Activate trinamic tmc51xx motion controller"
-	depends on DT_HAS_ADI_TMC51XX_STEPPER_ENABLED && STEPPER_ADI_TMC51XX
+if TMC51XX
+
+config TMC51XX_STEPPER
+	bool "ADI Trinamic TMC51XX stepper driver"
+	depends on DT_HAS_ADI_TMC51XX_STEPPER_ENABLED
 	default y
 
-config STEPPER_ADI_TMC51XX_STEPPER_DRV
-	bool "Activate trinamic tmc51xx stepper driver"
-	depends on DT_HAS_ADI_TMC51XX_STEPPER_DRV_ENABLED && STEPPER_ADI_TMC51XX
+config TMC51XX_STEPPER_DRV
+	bool "ADI Trinamic TMC51XX stepper_drv driver"
+	depends on DT_HAS_ADI_TMC51XX_STEPPER_DRV_ENABLED
 	default y
-
-if STEPPER_ADI_TMC51XX
 
 module = TMC51XX
 module-str = tmc51xx
 source "drivers/stepper/adi_tmc/Kconfig.tmc_rampgen_template"
 
-endif # STEPPER_ADI_TMC51XX
+endif # TMC51XX

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
@@ -324,7 +324,7 @@ static void rampstat_work_handler(struct k_work *work)
 
 	if (ramp_stat_values > 0) {
 		switch (ramp_stat_values) {
-#ifdef CONFIG_STEPPER_ADI_TMC51XX_STEPPER
+#ifdef CONFIG_TMC51XX_STEPPER
 		case TMC5XXX_STOP_LEFT_EVENT:
 			LOG_DBG("RAMPSTAT %s:Left end-stop detected", dev->name);
 			tmc51xx_stepper_trigger_cb(motion_controller,
@@ -344,15 +344,15 @@ static void rampstat_work_handler(struct k_work *work)
 			tmc51xx_stepper_trigger_cb(motion_controller,
 						     STEPPER_EVENT_STEPS_COMPLETED);
 			break;
-#endif /* CONFIG_STEPPER_ADI_TMC51XX_STEPPER */
-#ifdef CONFIG_STEPPER_ADI_TMC51XX_STEPPER_DRV
+#endif /* CONFIG_TMC51XX_STEPPER */
+#ifdef CONFIG_TMC51XX_STEPPER_DRV
 		case TMC5XXX_STOP_SG_EVENT:
 			LOG_DBG("RAMPSTAT %s:Stall detected", dev->name);
 			tmc51xx_stepper_stallguard_enable(dev, false);
 			tmc51xx_stepper_drv_trigger_cb(stepper_driver,
 				STEPPER_DRV_EVENT_STALL_DETECTED);
 			break;
-#endif /* CONFIG_STEPPER_ADI_TMC51XX_STEPPER_DRV */
+#endif /* CONFIG_TMC51XX_STEPPER_DRV */
 		default:
 			LOG_ERR("Illegal ramp stat bit field 0x%x", ramp_stat_values);
 			break;

--- a/drivers/stepper/allegro/CMakeLists.txt
+++ b/drivers/stepper/allegro/CMakeLists.txt
@@ -4,4 +4,4 @@
 zephyr_library()
 zephyr_library_property(ALLOW_EMPTY TRUE)
 
-zephyr_library_sources_ifdef(CONFIG_A4979_STEPPER a4979.c)
+zephyr_library_sources_ifdef(CONFIG_A4979 a4979.c)

--- a/drivers/stepper/allegro/Kconfig.a4979
+++ b/drivers/stepper/allegro/Kconfig.a4979
@@ -1,10 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Carl Zeiss Meditec AG
 # SPDX-License-Identifier: Apache-2.0
 
-config A4979_STEPPER
-	bool "Activate allegro A4979 stepper driver"
+config A4979
+	bool "Allegro A4979 stepper_drv driver"
 	default y
 	depends on DT_HAS_ALLEGRO_A4979_ENABLED
 	select STEP_DIR_STEPPER
-	help
-	  Microstepping motor driver for stepper motors.

--- a/drivers/stepper/ti/Kconfig.drv84xx
+++ b/drivers/stepper/ti/Kconfig.drv84xx
@@ -2,9 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config DRV84XX
-	bool "TI DRV84XX stepper motor driver"
+	bool "TI DRV84XX stepper_drv driver"
 	default y
 	depends on DT_HAS_TI_DRV84XX_ENABLED
 	select STEP_DIR_STEPPER
-	help
-	  Enable driver for TI DRV84XX stepper motor driver.


### PR DESCRIPTION
Drop prefixes such as STEPPER and vendor names from the Kconfigs. Use only the name of the IC for which the driver is to be activated