### PR TITLE
drivers: lora: Add validator functions for configuration

### DIFF
--- a/drivers/lora/lora_basics_modem/lbm_common.c
+++ b/drivers/lora/lora_basics_modem/lbm_common.c
@@ -155,6 +155,11 @@ int lbm_lora_config(const struct device *dev, struct lora_modem_config *lora_con
 		goto release;
 	}
 
+	ret = config->config_validator(lora_config);
+	if (ret < 0) {
+		goto release;
+	}
+
 	/* Store TX parameters for use in the TX functions */
 	data->mod_params = params.mod_params;
 	data->pkt_params = params.pkt_params;

--- a/drivers/lora/lora_basics_modem/lbm_common.c
+++ b/drivers/lora/lora_basics_modem/lbm_common.c
@@ -81,7 +81,8 @@ int lbm_lora_config(const struct device *dev, struct lora_modem_config *lora_con
 		.mod_params = {
 			.sf = lora_config->datarate,
 			.cr = lora_config->coding_rate,
-			.ldro = LORA_LDRO(lora_config->datarate, lora_config->bandwidth),
+			.ldro = LORA_LDRO(lora_config->datarate, lora_config->bandwidth)
+				| (config->force_ldro ? 1 : 0),
 		},
 		.pkt_params = {
 			.preamble_len_in_symb = lora_config->preamble_len,

--- a/drivers/lora/lora_basics_modem/lbm_common.c
+++ b/drivers/lora/lora_basics_modem/lbm_common.c
@@ -16,6 +16,14 @@
 
 LOG_MODULE_REGISTER(lbm_driver, CONFIG_LORA_LOG_LEVEL);
 
+/* When Symbol Time exceeds 16.38 ms (6.1.1.4 SX1261/2 datasheet), enable LDRO
+ * Symbol Rate is bw / (2 ^ sf) so Symbol time is (2 ^ sf) / bw (6.1.1.1 SX1261/2 datasheet)
+ * Additionally, enable LDRO in additional situations described in Lora Basic Modem lr1mac
+ * where t < 16 from ral_compute_lora_ldro: Bandwidth less than 41 Khz, and SF9 with BW 41 KHz
+ */
+#define LORA_LDRO(sf, bw) (((1 << sf) / bw >= 16 ? 1 : 0) \
+	| (bw < BW_41_KHZ || (bw == BW_41_KHZ && sf == SF_9) ? 1 : 0))
+
 /**
  * @brief Attempt to acquire the modem for operations
  *
@@ -73,7 +81,7 @@ int lbm_lora_config(const struct device *dev, struct lora_modem_config *lora_con
 		.mod_params = {
 			.sf = lora_config->datarate,
 			.cr = lora_config->coding_rate,
-			.ldro = 0,
+			.ldro = LORA_LDRO(lora_config->datarate, lora_config->bandwidth),
 		},
 		.pkt_params = {
 			.preamble_len_in_symb = lora_config->preamble_len,

--- a/drivers/lora/lora_basics_modem/lbm_common.c
+++ b/drivers/lora/lora_basics_modem/lbm_common.c
@@ -96,14 +96,50 @@ int lbm_lora_config(const struct device *dev, struct lora_modem_config *lora_con
 	}
 
 	switch (lora_config->bandwidth) {
+	case BW_7_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_007_KHZ;
+		break;
+	case BW_10_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_010_KHZ;
+		break;
+	case BW_15_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_015_KHZ;
+		break;
+	case BW_20_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_020_KHZ;
+		break;
+	case BW_31_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_031_KHZ;
+		break;
+	case BW_41_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_041_KHZ;
+		break;
+	case BW_62_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_062_KHZ;
+		break;
 	case BW_125_KHZ:
 		params.mod_params.bw = RAL_LORA_BW_125_KHZ;
+		break;
+	case BW_200_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_200_KHZ;
 		break;
 	case BW_250_KHZ:
 		params.mod_params.bw = RAL_LORA_BW_250_KHZ;
 		break;
+	case BW_400_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_400_KHZ;
+		break;
 	case BW_500_KHZ:
 		params.mod_params.bw = RAL_LORA_BW_500_KHZ;
+		break;
+	case BW_800_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_800_KHZ;
+		break;
+	case BW_1000_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_1000_KHZ;
+		break;
+	case BW_1600_KHZ:
+		params.mod_params.bw = RAL_LORA_BW_1600_KHZ;
 		break;
 	default:
 		ret = -EINVAL;

--- a/drivers/lora/lora_basics_modem/lbm_common.h
+++ b/drivers/lora/lora_basics_modem/lbm_common.h
@@ -34,6 +34,7 @@ enum lbm_modem_mode {
 struct lbm_lora_config_common {
 	/* LBM radio abstration layer structure */
 	ralf_t ralf;
+	bool force_ldro;
 };
 
 /* Common LBM modem data, must be first element of device data */

--- a/drivers/lora/lora_basics_modem/lbm_common.h
+++ b/drivers/lora/lora_basics_modem/lbm_common.h
@@ -30,11 +30,15 @@ enum lbm_modem_mode {
 	MODE_CAD = 5,
 };
 
+/* Typedef for configuration validation function */
+typedef int(*lbm_lora_validate_config_t)(struct lora_modem_config *lora_config);
+
 /* Common LBM modem configuration, must be first element of device config */
 struct lbm_lora_config_common {
 	/* LBM radio abstration layer structure */
 	ralf_t ralf;
 	bool force_ldro;
+	lbm_lora_validate_config_t config_validator;
 };
 
 /* Common LBM modem data, must be first element of device data */

--- a/drivers/lora/lora_basics_modem/lbm_sx126x.c
+++ b/drivers/lora/lora_basics_modem/lbm_sx126x.c
@@ -501,6 +501,7 @@ static int sx126x_init(const struct device *dev)
 #define SX126X_DEFINE(node_id, sx_variant)                                                         \
 	static const struct lbm_sx126x_config config_##node_id = {                                 \
 		.lbm_common.ralf = RALF_SX126X_INSTANTIATE(DEVICE_DT_GET(node_id)),                \
+		.lbm_common.force_ldro = DT_PROP(node_id, force_ldro),                             \
 		.spi = SPI_DT_SPEC_GET(                                                            \
 			node_id, SPI_WORD_SET(8) | SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB),         \
 		.reset = GPIO_DT_SPEC_GET(node_id, reset_gpios),                                   \

--- a/drivers/lora/lora_basics_modem/lbm_sx127x.c
+++ b/drivers/lora/lora_basics_modem/lbm_sx127x.c
@@ -211,35 +211,31 @@ void ral_sx127x_bsp_get_tx_cfg(const void *context,
 			       ral_sx127x_bsp_tx_cfg_output_params_t *output_params)
 
 {
+	const sx127x_t *radio = context;
+	const struct device *dev = radio->hal_context;
+	const struct lbm_sx127x_config *config = dev->config;
 	int16_t power = input_params->system_output_pwr_in_dbm;
-#if defined(SX1272)
-	output_params->pa_cfg.pa_select = SX127X_PA_SELECT_RFO;
-	output_params->pa_cfg.is_20_dbm_output_on = false;
-#elif defined(SX1276)
-	if (input_params->freq_in_hz > RF_FREQUENCY_MID_BAND_THRESHOLD) {
-		output_params->pa_cfg.pa_select = SX127X_PA_SELECT_BOOST;
-		output_params->pa_cfg.is_20_dbm_output_on = true;
-	} else {
-		output_params->pa_cfg.pa_select = SX127X_PA_SELECT_RFO;
-		output_params->pa_cfg.is_20_dbm_output_on = false;
-	}
-#endif
 
-	if (output_params->pa_cfg.pa_select == SX127X_PA_SELECT_BOOST) {
-		if (output_params->pa_cfg.is_20_dbm_output_on == true) {
+	if (config->power_amplifier_output == SX127X_PA_SELECT_BOOST) {
+		output_params->pa_cfg.pa_select = SX127X_PA_SELECT_BOOST;
+		if (power > 17) {
+			output_params->pa_cfg.is_20_dbm_output_on = true;
 			power = MAX(power, 5);
 			power = MIN(power, 20);
 		} else {
+			output_params->pa_cfg.is_20_dbm_output_on = false;
 			power = MAX(power, 2);
 			power = MIN(power, 17);
 		}
 	} else {
+		output_params->pa_cfg.pa_select = SX127X_PA_SELECT_RFO;
+		output_params->pa_cfg.is_20_dbm_output_on = false;
 #if defined(SX1272)
-		power = MAX(power, -1);
-		power = MIN(power, 14);
+			power = MAX(power, -1);
+			power = MIN(power, 14);
 #elif defined(SX1276)
-		power = MAX(power, -4);
-		power = MIN(power, 15);
+			power = MAX(power, -4);
+			power = MIN(power, 15);
 #endif
 	}
 

--- a/drivers/lora/lora_basics_modem/lbm_sx127x.c
+++ b/drivers/lora/lora_basics_modem/lbm_sx127x.c
@@ -441,6 +441,7 @@ static int sx127x_driver_init(const struct device *dev)
 	static struct lbm_sx127x_data data_##node_id;                                              \
 	static const struct lbm_sx127x_config config_##node_id = {                                 \
 		.lbm_common.ralf = RALF_SX127X_INSTANTIATE(&data_##node_id.radio),                 \
+		.lbm_common.force_ldro = DT_PROP(node_id, force_ldro),                             \
 		.spi = SPI_DT_SPEC_GET(                                                            \
 			node_id, SPI_WORD_SET(8) | SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB),         \
 		.reset = GPIO_DT_SPEC_GET(node_id, reset_gpios),                                   \

--- a/dts/bindings/lora/semtech,sx126x-base.yaml
+++ b/dts/bindings/lora/semtech,sx126x-base.yaml
@@ -70,3 +70,9 @@ properties:
     type: boolean
     description: |
       Use the internal LDO instead of the internal DCDC. Increases power consumption.
+
+  force-ldro:
+    type: boolean
+    description: |
+      Force usage of Low Data Rate Optimization even in cases where the symbol time is shorter than
+      16.38ms. Useful for designs using no TCXO or with bad heat dissipation.

--- a/dts/bindings/lora/semtech,sx127x-base.yaml
+++ b/dts/bindings/lora/semtech,sx127x-base.yaml
@@ -61,3 +61,9 @@ properties:
     type: int
     description: |
       Delay which has to be applied after enabling TCXO power.
+
+  force-ldro:
+    type: boolean
+    description: |
+      Force usage of Low Data Rate Optimization even in cases where the symbol time is shorter than
+      16.38ms. Useful for designs using no TCXO or with bad heat dissipation.

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -38,9 +38,21 @@ extern "C" {
  * higher data rates but typically reduce sensitivity and range.
  */
 enum lora_signal_bandwidth {
-	BW_125_KHZ = 0,	/**< 125 kHz */
-	BW_250_KHZ,	/**< 250 kHz */
-	BW_500_KHZ,	/**< 500 kHz */
+	BW_7_KHZ = 7,		/**< 7.81 kHz */
+	BW_10_KHZ = 10,		/**< 10.42 kHz */
+	BW_15_KHZ = 15,		/**< 15.63 kHz */
+	BW_20_KHZ = 20,		/**< 20.83 kHz */
+	BW_31_KHZ = 31,		/**< 31.25 kHz */
+	BW_41_KHZ = 41,		/**< 41.67 kHz */
+	BW_62_KHZ = 62,		/**< 62.5 kHz */
+	BW_125_KHZ = 125,	/**< 125 kHz */
+	BW_200_KHZ = 200,	/**< 203 kHz */
+	BW_250_KHZ = 250,	/**< 250 kHz */
+	BW_400_KHZ = 400,	/**< 406 kHz */
+	BW_500_KHZ = 500,	/**< 500 kHz */
+	BW_800_KHZ = 800,	/**< 812 kHz */
+	BW_1000_KHZ = 1000,	/**< 1000 kHz */
+	BW_1600_KHZ = 1600,	/**< 1625 kHz */
 };
 
 /**
@@ -52,13 +64,14 @@ enum lora_signal_bandwidth {
  * symbol). Higher values result in lower data rates but increased range and robustness.
  */
 enum lora_datarate {
-	SF_6 = 6, /**< Spreading factor 6 (fastest, shortest range) */
-	SF_7,     /**< Spreading factor 7 */
-	SF_8,     /**< Spreading factor 8 */
-	SF_9,     /**< Spreading factor 9 */
-	SF_10,    /**< Spreading factor 10 */
-	SF_11,    /**< Spreading factor 11 */
-	SF_12,    /**< Spreading factor 12 (slowest, longest range) */
+	SF_5 = 5,	/**< Spreading factor 5 (fastest, shortest range) */
+	SF_6 = 6,	/**< Spreading factor 6 */
+	SF_7 = 7,	/**< Spreading factor 7 */
+	SF_8 = 8,	/**< Spreading factor 8 */
+	SF_9 = 9,	/**< Spreading factor 9 */
+	SF_10 = 10,	/**< Spreading factor 10 */
+	SF_11 = 11,	/**< Spreading factor 11 */
+	SF_12 = 12,	/**< Spreading factor 12 (slowest, longest range) */
 };
 
 /**

--- a/tests/drivers/build_all/lora/lbm_sx126x.overlay
+++ b/tests/drivers/build_all/lora/lbm_sx126x.overlay
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 MASSDRIVER EI (massdriver.space)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	test {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		test_gpio: gpio@deadbeef {
+			compatible = "vnd,gpio";
+			gpio-controller;
+			reg = <0xdeadbeef 0x1000>;
+			#gpio-cells = <0x2>;
+			status = "okay";
+		};
+
+		test_spi: spi@33334444 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "vnd,spi";
+			reg = <0x33334444 0x1000>;
+			status = "okay";
+
+			cs-gpios = <&test_gpio 0 0>,
+				   <&test_gpio 0 0>,
+				   <&test_gpio 0 0>;
+
+			test_semtech_sx1268: sx1268@0 {
+				compatible = "semtech,sx1268";
+				status = "okay";
+				reg = <0>;
+				spi-max-frequency = <16000000>;
+				reset-gpios = <&test_gpio 0 0>;
+				busy-gpios = <&test_gpio 9 0>;
+				antenna-enable-gpios = <&test_gpio 0 0>;
+				dio1-gpios = <&test_gpio 11 0>;
+				dio2-tx-enable;
+				tcxo-power-startup-delay-ms = <5>;
+				force-ldro;
+			};
+
+			test_semtech_llcc68: llcc68@1 {
+				compatible = "semtech,llcc68";
+				status = "okay";
+				reg = <1>;
+				spi-max-frequency = <16000000>;
+				reset-gpios = <&test_gpio 0 0>;
+				busy-gpios = <&test_gpio 9 0>;
+				antenna-enable-gpios = <&test_gpio 0 0>;
+				dio1-gpios = <&test_gpio 11 0>;
+				dio2-tx-enable;
+				tcxo-power-startup-delay-ms = <5>;
+				force-ldro;
+			};
+		};
+	};
+};

--- a/tests/drivers/build_all/lora/lbm_sx127x.overlay
+++ b/tests/drivers/build_all/lora/lbm_sx127x.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 MASSDRIVER EI (massdriver.space)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	test {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		test_gpio: gpio@deadbeef {
+			compatible = "vnd,gpio";
+			gpio-controller;
+			reg = <0xdeadbeef 0x1000>;
+			#gpio-cells = <0x2>;
+			status = "okay";
+		};
+
+		test_spi: spi@33334444 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "vnd,spi";
+			reg = <0x33334444 0x1000>;
+			status = "okay";
+
+			cs-gpios = <&test_gpio 0 0>,
+				   <&test_gpio 0 0>,
+				   <&test_gpio 0 0>;
+
+			test_semtech_sx1278: sx1278@0 {
+				compatible = "semtech,sx1278";
+				status = "okay";
+				reg = <0x0>;
+				spi-max-frequency = <3000000>;
+				reset-gpios = <&test_gpio 0 0>;
+				dio-gpios = <&test_gpio 0 0>,
+					    <&test_gpio 0 0>,
+					    <&test_gpio 0 0>,
+					    <&test_gpio 0 0>;
+				power-amplifier-output = "pa-boost";
+				force-ldro;
+			};
+		};
+	};
+};

--- a/tests/drivers/build_all/lora/testcase.yaml
+++ b/tests/drivers/build_all/lora/testcase.yaml
@@ -1,7 +1,13 @@
+common:
+  tags:
+    - drivers
+    - lora
+
 tests:
   sample.driver.lora.rylr.send:
     extra_args: SHIELD=reyax_lora
     platform_allow: cy8ckit_062s4
+
   sample.driver.lora.build.uart:
     build_only: true
     extra_args: DTC_OVERLAY_FILE="uart_devices.overlay"
@@ -11,6 +17,7 @@ tests:
     platform_allow:
       - native_sim
       - native_sim/native/64
+
   sample.driver.lora.build.sx1262:
     build_only: true
     extra_args: DTC_OVERLAY_FILE="sx1262.overlay"
@@ -19,9 +26,28 @@ tests:
     platform_allow:
       - native_sim
       - native_sim/native/64
+
   sample.driver.lora.build.sx1272:
     build_only: true
     extra_args: DTC_OVERLAY_FILE="sx1272.overlay"
+    extra_configs:
+      - CONFIG_SPI=y
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+
+  sample.driver.lora.build.lbm.sx126x:
+    build_only: true
+    extra_args: DTC_OVERLAY_FILE="lbm_sx126x.overlay"
+    extra_configs:
+      - CONFIG_SPI=y
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+
+  sample.driver.lora.build.lbm.sx127x:
+    build_only: true
+    extra_args: DTC_OVERLAY_FILE="lbm_sx127x.overlay"
     extra_configs:
       - CONFIG_SPI=y
     platform_allow:


### PR DESCRIPTION
- fixes sx127x not handling pa boost correctly: when reading datasheet PA_HP can handle the whole range of frequencies despite the diagram indicating it is not connected to HF. It also appears this specific configuration setup came from a devboard: https://github.com/ARMmbed/mbed-semtech-lora-rf-drivers/issues/27, https://github.com/Lora-net/LoRaMac-node/issues/38#issuecomment-187096651
- add validation to lora_config: add per-chip variant checking of various parameters, display a helpful message, and say no to doing it.
- Add build_all tests using Lora Basics Modem instead of loramacnode and excercise new variants and settings.

Dependent on https://github.com/zephyrproject-rtos/zephyr/pull/100977