### PR TITLE
includes: remove duplicated entries in zephyr-tree

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -20,7 +20,6 @@
 #include <kernel_internal.h>
 #include <mmu.h>
 #include <zephyr/drivers/interrupt_controller/loapic.h>
-#include <mmu.h>
 #include <zephyr/arch/x86/memmap.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);

--- a/arch/x86/include/ia32/kernel_arch_data.h
+++ b/arch/x86/include/ia32/kernel_arch_data.h
@@ -53,7 +53,6 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -16,7 +16,6 @@
 #include <zephyr/zsr.h>
 #include <zephyr/arch/common/exc_handle.h>
 
-#include <kernel_internal.h>
 #include <xtensa_internal.h>
 #include <xtensa_stack.h>
 

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -35,7 +35,6 @@
 #ifdef CONFIG_ADC_STM32_DMA
 #include <zephyr/drivers/dma/dma_stm32.h>
 #include <zephyr/drivers/dma.h>
-#include <zephyr/toolchain.h>
 #include <stm32_ll_dma.h>
 #endif
 
@@ -54,7 +53,6 @@ LOG_MODULE_REGISTER(adc_stm32);
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32H7RSX)
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
-#include <stm32_ll_system.h>
 #endif
 
 #include <zephyr/linker/linker-defs.h>

--- a/drivers/audio/tlv320aic3110.c
+++ b/drivers/audio/tlv320aic3110.c
@@ -13,7 +13,6 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
-#include <zephyr/sys/util.h>
 #include <zephyr/audio/codec.h>
 #include <zephyr/drivers/clock_control.h>
 #include "tlv320aic3110.h"

--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -13,7 +13,6 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/sys/util.h>
 #include <zephyr/audio/codec.h>
 #include "tlv320dac310x.h"
 

--- a/drivers/bluetooth/hci/hci_infineon_cyw208xx.c
+++ b/drivers/bluetooth/hci/hci_infineon_cyw208xx.c
@@ -72,7 +72,6 @@
 #include "cyhal_syspm.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(cyw208xx);
 
 #define DT_DRV_COMPAT infineon_cyw208xx_hci

--- a/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
@@ -24,7 +24,6 @@
 #include <zephyr/logging/log.h>
 
 #define LOG_LEVEL      CONFIG_BT_HCI_DRIVER_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(psoc6_bless);
 
 #include "cy_ble_stack_pvt.h"

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -15,7 +15,6 @@
 #include <zephyr/irq.h>
 #include <soc.h>
 #include <zephyr/drivers/clock_control/arm_clock_control.h>
-#include <zephyr/irq.h>
 
 #include "dualtimer_cmsdk_apb.h"
 

--- a/drivers/dma/dma_bflb.c
+++ b/drivers/dma/dma_bflb.c
@@ -14,7 +14,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dma_bflb, CONFIG_DMA_LOG_LEVEL);
 
-#include <soc.h>
 #include <bflb_soc.h>
 #include <glb_reg.h>
 #include <common_defines.h>

--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -18,8 +18,6 @@ LOG_MODULE_REGISTER(eth_adin2111, CONFIG_ETHERNET_LOG_LEVEL);
 #include <errno.h>
 
 #include <zephyr/net/net_if.h>
-#include <zephyr/net/ethernet.h>
-#include <zephyr/net/phy.h>
 #include <zephyr/drivers/ethernet/eth_adin2111.h>
 
 #include "phy/phy_adin2111_priv.h"

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -16,8 +16,6 @@ LOG_MODULE_REGISTER(eth_lan865x, CONFIG_ETHERNET_LOG_LEVEL);
 #include <errno.h>
 
 #include <zephyr/net/net_if.h>
-#include <zephyr/net/ethernet.h>
-#include <zephyr/net/phy.h>
 #include <zephyr/drivers/ethernet/eth_lan865x.h>
 
 #include "eth_lan865x_priv.h"

--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -673,7 +673,7 @@ static void flash_cpu01_receive_cb(const struct device *ipm, void *user_data, ui
 				volatile void *shm)
 {
 	struct flash_esp32_dev_data *data = (struct flash_esp32_dev_data *) user_data;
-	struct flash_req *req = (struct flash_req *) shm;
+	volatile struct flash_req *req = (volatile struct flash_req *)shm;
 
 #ifdef CONFIG_ESP_FLASH_HOST
 	if (id == CMD_REQUEST) {

--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -24,12 +24,13 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
+#include <stdint.h>
 #include <zephyr/drivers/flash.h>
 #include <soc.h>
-
 #ifdef CONFIG_ESP_FLASH_ASYNC_IPM
 #include <zephyr/drivers/ipm.h>
 #endif
@@ -130,12 +131,6 @@ static inline void flash_esp32_sem_give(const struct device *dev)
 #define flash_esp32_sem_give(dev) do {} while (0)
 
 #endif /* CONFIG_MULTITHREADING && !CONFIG_ESP_FLASH_ASYNC */
-
-#include <zephyr/kernel.h>
-#include <zephyr/logging/log.h>
-#include <zephyr/sys/util.h>
-#include <stdint.h>
-#include <string.h>
 
 #ifdef CONFIG_ESP_FLASH_HOST
 #ifndef CONFIG_MCUBOOT

--- a/drivers/gnss/gnss_nmea0183.c
+++ b/drivers/gnss/gnss_nmea0183.c
@@ -8,7 +8,6 @@
 
 #include <string.h>
 #include <stdarg.h>
-#include <stdarg.h>
 
 #include "gnss_nmea0183.h"
 #include "gnss_parse.h"

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -28,9 +28,6 @@
 #endif
 #include <fsl_gpio.h>
 #include <fsl_device_registers.h>
-#ifdef MCI_IO_MUX
-#include <zephyr/drivers/pinctrl.h>
-#endif
 
 /* Interrupt sources, matching int-source enum in DTS binding definition */
 #define INT_SOURCE_PINT 0

--- a/drivers/gpio/gpio_rzt2m.c
+++ b/drivers/gpio/gpio_rzt2m.c
@@ -14,7 +14,6 @@
 #include <zephyr/sys/errno_private.h>
 #include <zephyr/dt-bindings/gpio/renesas-rzt2m-gpio.h>
 #include <soc.h>
-#include <zephyr/drivers/gpio/gpio_utils.h>
 #include <zephyr/irq.h>
 
 static const struct device *const ns_portnf_md_dev = DEVICE_DT_GET(DT_NODELABEL(ns_portnf_md));

--- a/drivers/gpio/gpio_sn74hc595.c
+++ b/drivers/gpio/gpio_sn74hc595.c
@@ -14,7 +14,6 @@
 #include <zephyr/drivers/spi.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
-#include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -21,7 +21,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/pm/device.h>
-#include <zephyr/arch/cpu.h>
 #include <zephyr/irq.h>
 #include <string.h>
 
@@ -50,7 +49,6 @@
 #include "i2c_dw_registers.h"
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
-#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_dw);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_infineon.c
+++ b/drivers/i2c/i2c_infineon.c
@@ -15,7 +15,6 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <cyhal_i2c.h>
 #include <cyhal_utils_impl.h>
-#include <cyhal_utils_impl.h>
 #include <cyhal_scb_common.h>
 
 #include <zephyr/logging/log.h>

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -21,7 +21,6 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
-#include <stm32_cache.h>
 #include <zephyr/cache.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/mem_mgmt/mem_attr.h>

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -26,7 +26,6 @@
 #endif
 
 #include <zephyr/sys/barrier.h>
-#include <zephyr/device.h>
 #include <soc.h>
 
 #include <fsl_sai.h>

--- a/drivers/i2s/i2s_silabs_siwx91x.c
+++ b/drivers/i2s/i2s_silabs_siwx91x.c
@@ -26,7 +26,6 @@
 #include "rsi_power_save.h"
 #include "rsi_pll.h"
 #include "rsi_ulpss_clk.h"
-#include "clock_update.h"
 
 #define DMA_MAX_TRANSFER_COUNT 1024
 #define I2S_SIWX91X_UNSUPPORTED_OPTIONS                                                            \

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -19,7 +19,6 @@ LOG_MODULE_REGISTER(dw1000, LOG_LEVEL_INF);
 #include <zephyr/sys/byteorder.h>
 #include <string.h>
 #include <zephyr/random/random.h>
-#include <zephyr/debug/stack.h>
 #include <math.h>
 
 #include <zephyr/drivers/gpio.h>

--- a/drivers/ieee802154/ieee802154_esp32.c
+++ b/drivers/ieee802154/ieee802154_esp32.c
@@ -26,7 +26,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/device.h>
 #include <zephyr/init.h>
-#include <zephyr/debug/stack.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
 

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -28,7 +28,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/sys/byteorder.h>
 #include <string.h>
 #include <zephyr/random/random.h>
-#include <zephyr/debug/stack.h>
 
 #include <zephyr/drivers/gpio.h>
 

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -34,7 +34,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/device.h>
 #include <zephyr/init.h>
-#include <zephyr/debug/stack.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
 

--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -10,7 +10,6 @@
 #include <zephyr/input/input.h>
 #include <zephyr/input/input_kbd_matrix.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -19,7 +19,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
-#include <zephyr/device.h>
 
 #define DT_DRV_COMPAT snps_arcv2_intc
 

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -17,7 +17,6 @@
 #include <zephyr/modem/backend/uart.h>
 #include <zephyr/net/ppp.h>
 #include <zephyr/pm/device.h>
-#include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/atomic.h>
 

--- a/drivers/peci/peci_ite_it8xxx2.c
+++ b/drivers/peci/peci_ite_it8xxx2.c
@@ -12,7 +12,6 @@
 #include <zephyr/kernel.h>
 #include <errno.h>
 #include <zephyr/device.h>
-#include <zephyr/drivers/peci.h>
 #include <soc.h>
 #include <soc_dt.h>
 #include <zephyr/logging/log.h>

--- a/drivers/power_domain/power_domain_intel_adsp.c
+++ b/drivers/power_domain/power_domain_intel_adsp.c
@@ -10,10 +10,6 @@
 #include <adsp_shim.h>
 #include <adsp_power.h>
 
-#if CONFIG_SOC_INTEL_ACE15_MTPM
-#include <adsp_power.h>
-#endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
-
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(power_domain_intel_adsp, LOG_LEVEL_INF);
 

--- a/drivers/sensor/adi/adxl345/adxl345.h
+++ b/drivers/sensor/adi/adxl345/adxl345.h
@@ -28,7 +28,6 @@
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 #include <zephyr/drivers/spi.h>
 #endif
-#include <zephyr/sys/util.h>
 
 /* ADXL345 communication commands */
 #define ADXL345_WRITE_CMD          0x00

--- a/drivers/sensor/bosch/bmm150/bmm150.h
+++ b/drivers/sensor/bosch/bmm150/bmm150.h
@@ -52,13 +52,10 @@ extern const struct bmm150_bus_io bmm150_bus_io_spi;
 extern const struct bmm150_bus_io bmm150_bus_io_i2c;
 #endif
 
-#include <zephyr/types.h>
-#include <zephyr/drivers/i2c.h>
 #include <stdint.h>
 #include <zephyr/sys/util.h>
 
 #include <zephyr/kernel.h>
-#include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/sys/byteorder.h>

--- a/drivers/sensor/bosch/bmm350/bmm350.h
+++ b/drivers/sensor/bosch/bmm350/bmm350.h
@@ -56,12 +56,9 @@ struct bmm350_bus_io {
 
 extern const struct bmm350_bus_io bmm350_bus_rtio;
 
-#include <zephyr/types.h>
-#include <zephyr/drivers/i2c.h>
 #include <zephyr/sys/util.h>
 
 #include <zephyr/kernel.h>
-#include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/sys/byteorder.h>

--- a/drivers/sensor/ist8310/ist8310.h
+++ b/drivers/sensor/ist8310/ist8310.h
@@ -17,7 +17,6 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
-#include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/drivers/gpio.h>

--- a/drivers/sensor/nxp/mcux_lpcmp/mcux_lpcmp.c
+++ b/drivers/sensor/nxp/mcux_lpcmp/mcux_lpcmp.c
@@ -15,7 +15,6 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 #include <zephyr/drivers/sensor/mcux_lpcmp.h>
-#include <fsl_lpcmp.h>
 
 LOG_MODULE_REGISTER(mcux_lpcmp, CONFIG_SENSOR_LOG_LEVEL);
 

--- a/drivers/sensor/st/lis2dux12/lis2dux12_trigger.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_trigger.c
@@ -11,7 +11,6 @@
 #include <zephyr/logging/log.h>
 #include "lis2dux12.h"
 
-#include "lis2dux12.h"
 #include "lis2dux12_rtio.h"
 
 LOG_MODULE_DECLARE(LIS2DUX12, CONFIG_SENSOR_LOG_LEVEL);

--- a/drivers/sensor/st/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.h
@@ -11,7 +11,6 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_LIS2DW12_LIS2DW12_H_
 #define ZEPHYR_DRIVERS_SENSOR_LIS2DW12_LIS2DW12_H_
 
-#include <zephyr/drivers/spi.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/sensor.h>

--- a/drivers/sensor/st/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.h
@@ -14,7 +14,6 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/types.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/drivers/spi.h>
 #include <zephyr/sys/util.h>
 #include <stmemsc.h>
 #include "lsm6dso_reg.h"

--- a/drivers/serial/uart_native_pty_bottom.c
+++ b/drivers/serial/uart_native_pty_bottom.c
@@ -21,7 +21,6 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <unistd.h>
-#include <poll.h>
 #include <nsi_tracing.h>
 
 #define ERROR nsi_print_error_and_exit

--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -20,7 +20,6 @@
 #include <zephyr/rtio/rtio.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/drivers/spi/rtio.h>
 
 #include <wrap_max32_spi.h>
 

--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <zephyr/drivers/usb/usb_dc.h>
 #include <zephyr/usb/usb_device.h>
-#include <soc.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/pinctrl.h>

--- a/drivers/usb/udc/udc_ambiq.c
+++ b/drivers/usb/udc/udc_ambiq.c
@@ -10,7 +10,6 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/usb/udc.h>
-#include <zephyr/sys/util.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/cache.h>

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -11,7 +11,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/init.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/usb/uhc.h>
 
 #include "uhc_common.h"

--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -13,7 +13,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/init.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/usb/uhc.h>
 #include <zephyr/drivers/pinctrl.h>
 

--- a/drivers/usb/uhc/uhc_mcux_ip3516hs.c
+++ b/drivers/usb/uhc/uhc_mcux_ip3516hs.c
@@ -13,7 +13,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/init.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/usb/uhc.h>
 #include <zephyr/drivers/pinctrl.h>
 

--- a/drivers/usb/uhc/uhc_mcux_khci.c
+++ b/drivers/usb/uhc/uhc_mcux_khci.c
@@ -13,7 +13,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/init.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/usb/uhc.h>
 #include <zephyr/drivers/pinctrl.h>
 

--- a/drivers/usb/uhc/uhc_mcux_ohci.c
+++ b/drivers/usb/uhc/uhc_mcux_ohci.c
@@ -13,7 +13,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/init.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/usb/uhc.h>
 #include <zephyr/drivers/pinctrl.h>
 

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -14,7 +14,6 @@
 #include <em_cmu.h>
 
 #include <zephyr/logging/log.h>
-#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(wdt_gecko, CONFIG_WDT_LOG_LEVEL);
 
 #ifdef cmuClock_CORELE

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -30,7 +30,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/net/ethernet.h>
 #include <net_private.h>
 #include <zephyr/net/net_core.h>
-#include <zephyr/net/net_pkt.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -38,7 +38,6 @@
 #endif /* CONFIG_NRF70_STA_MODE */
 
 #include <system/fmac_api.h>
-#include <zephyr/net/conn_mgr_connectivity.h>
 #else
 #include <radio_test/fmac_api.h>
 #endif /* !CONFIG_NRF70_RADIO_TEST */

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -108,8 +108,6 @@ typedef struct {
 	struct sockaddr_in	strRemoteAddr;
 } tstrSocketRecvMsg;
 
-#include <driver/include/m2m_wifi.h>
-#include <socket/include/m2m_socket_host_if.h>
 
 #if defined(CONFIG_WIFI_WINC1500_REGION_NORTH_AMERICA)
 #define WINC1500_REGION		NORTH_AMERICA

--- a/include/zephyr/arch/arm64/timer.h
+++ b/include/zephyr/arch/arm64/timer.h
@@ -13,7 +13,6 @@
 
 #include <zephyr/drivers/timer/arm_arch_timer.h>
 #include <zephyr/types.h>
-#include <limits.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -35,7 +35,6 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys/slist.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/mic_privacy/intel/mic_privacy.h
+++ b/include/zephyr/drivers/mic_privacy/intel/mic_privacy.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <errno.h>
 #include <stdbool.h>
-#include <stdint.h>
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/devicetree.h>

--- a/lib/libc/minimal/source/string/strspn.c
+++ b/lib/libc/minimal/source/string/strspn.c
@@ -5,7 +5,6 @@
  */
 
 #include <string.h>
-#include <string.h>
 
 size_t strspn(const char *s,
 	      const char *accept)

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
@@ -20,10 +20,6 @@
 #include "../../spinel_base/spinel.h"
 #include "../../src/include/nrf_802154_spinel.h"
 
-#if defined(CONFIG_SOC_NRF5340_CPUAPP)
-#include <nrf53_cpunet_mgmt.h>
-#endif
-
 #define LOG_LEVEL LOG_LEVEL_INFO
 #define LOG_MODULE_NAME spinel_ipc_backend
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);

--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -43,7 +43,6 @@ static K_THREAD_STACK_DEFINE(iface_wq_stack, CONFIG_WIFI_NM_WPA_SUPPLICANT_WQ_ST
 #include "wpa_supplicant/config.h"
 #include "wpa_supplicant_i.h"
 #include "fst/fst.h"
-#include "includes.h"
 #include "wpa_cli_zephyr.h"
 #include "ctrl_iface_zephyr.h"
 #ifdef CONFIG_WIFI_NM_HOSTAPD_AP

--- a/modules/openthread/platform/infra_if.c
+++ b/modules/openthread/platform/infra_if.c
@@ -21,11 +21,9 @@
 #include <zephyr/net/openthread.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/socket_service.h>
-#include <zephyr/net/icmp.h>
 #include <icmpv6.h>
 
 #if defined(CONFIG_OPENTHREAD_NAT64_TRANSLATOR)
-#include <zephyr/net/icmp.h>
 #include <zephyr/net/net_pkt_filter.h>
 #include <openthread/nat64.h>
 #endif /* CONFIG_OPENTHREAD_NAT64_TRANSLATOR */

--- a/modules/openthread/platform/mdns_socket.c
+++ b/modules/openthread/platform/mdns_socket.c
@@ -18,7 +18,6 @@
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/openthread.h>
 #include <zephyr/net/socket_service.h>
-#include <openthread/nat64.h>
 #include "sockets_internal.h"
 #include <errno.h>
 

--- a/samples/bluetooth/bap_unicast_client/src/stream_lc3.c
+++ b/samples/bluetooth/bap_unicast_client/src/stream_lc3.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <errno.h>
-#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>

--- a/samples/bluetooth/bap_unicast_server/src/stream_lc3.c
+++ b/samples/bluetooth/bap_unicast_server/src/stream_lc3.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <errno.h>
-#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>

--- a/samples/bluetooth/direction_finding_central/src/main.c
+++ b/samples/bluetooth/direction_finding_central/src/main.c
@@ -17,7 +17,6 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
-#include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_vs.h>
 
 /* Latency set to zero, to enforce PDU exchange every connection event */

--- a/samples/bluetooth/hci_uart_async/src/hci_uart_async.c
+++ b/samples/bluetooth/hci_uart_async/src/hci_uart_async.c
@@ -10,7 +10,6 @@
 #include <stddef.h>
 #include <string.h>
 
-#include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/logging/log.h>

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -21,7 +21,6 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
-#include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/services/bas.h>
 
 #define CSC_SUPPORTED_LOCATIONS		{ CSC_LOC_OTHER, \

--- a/samples/boards/nordic/clock_control/src/main.c
+++ b/samples/boards/nordic/clock_control/src/main.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel.h>
 #include <zephyr/devicetree/clocks.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 

--- a/samples/boards/renesas/comparator/src/main.c
+++ b/samples/boards/renesas/comparator/src/main.c
@@ -8,7 +8,6 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/comparator.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/printk.h>
 #ifdef CONFIG_DAC_REFERENCE_SOURCE

--- a/samples/boards/renesas/lvd/src/main.c
+++ b/samples/boards/renesas/lvd/src/main.c
@@ -8,7 +8,6 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/comparator.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/printk.h>
 

--- a/samples/boards/renesas/openamp_linux_zephyr/src/main_remote.c
+++ b/samples/boards/renesas/openamp_linux_zephyr/src/main_remote.c
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <zephyr/drivers/mbox.h>
 

--- a/samples/drivers/clock_control_xec/src/main.c
+++ b/samples/drivers/clock_control_xec/src/main.c
@@ -15,7 +15,6 @@
 #include <zephyr/sys/printk.h>
 LOG_MODULE_REGISTER(clock32k, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 
-#include <soc.h>
 
 #ifdef CONFIG_SOC_SERIES_MEC15XX
 static void pcr_clock_regs(void)

--- a/samples/net/ethernet/dsa/src/dsa_lldp.c
+++ b/samples/net/ethernet/dsa/src/dsa_lldp.c
@@ -17,7 +17,6 @@
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_l2.h>
 #include <zephyr/net/net_if.h>
-#include <zephyr/net/socket.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/lldp.h>
 #include <errno.h>

--- a/samples/net/prometheus/src/main.c
+++ b/samples/net/prometheus/src/main.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/sensor.h>
-#include <zephyr/kernel.h>
 #include <zephyr/net/tls_credentials.h>
 #include <zephyr/net/http/server.h>
 #include <zephyr/net/http/service.h>

--- a/samples/net/prometheus/src/stats.c
+++ b/samples/net/prometheus/src/stats.c
@@ -8,7 +8,6 @@
 LOG_MODULE_DECLARE(main, LOG_LEVEL_DBG);
 
 #include <zephyr/kernel.h>
-#include <zephyr/kernel.h>
 #include <zephyr/net/tls_credentials.h>
 #include <zephyr/net/http/server.h>
 #include <zephyr/net/http/service.h>

--- a/samples/net/sockets/echo_server/src/ws_console/ws.c
+++ b/samples/net/sockets/echo_server/src/ws_console/ws.c
@@ -54,7 +54,6 @@ struct http_resource_detail_static favicon_16x16_png_gz_resource_detail = {
 };
 
 #if defined(CONFIG_NET_SAMPLE_HTTPS_SERVICE)
-#include <zephyr/net/tls_credentials.h>
 #include "../certificate.h"
 
 static const sec_tag_t sec_tag_list_verify_none[] = {

--- a/samples/sensor/accel_polling/src/main.c
+++ b/samples/sensor/accel_polling/src/main.c
@@ -12,7 +12,6 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/kernel.h>
 #include <zephyr/rtio/rtio.h>
-#include <zephyr/drivers/sensor.h>
 
 #define ACCEL_ALIAS(i) DT_ALIAS(_CONCAT(accel, i))
 #define ACCELEROMETER_DEVICE(i, _)                                                           \

--- a/samples/sensor/grove_temperature/src/main.c
+++ b/samples/sensor/grove_temperature/src/main.c
@@ -11,7 +11,6 @@
 
 #ifdef CONFIG_GROVE_LCD_RGB
 #include <zephyr/drivers/misc/grove_lcd/grove_lcd.h>
-#include <stdio.h>
 #include <string.h>
 #endif
 

--- a/samples/sensor/stream_drdy/src/main.c
+++ b/samples/sensor/stream_drdy/src/main.c
@@ -12,7 +12,6 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/kernel.h>
 #include <zephyr/rtio/rtio.h>
-#include <zephyr/drivers/sensor.h>
 
 #define STREAMDEV_ALIAS(i) DT_ALIAS(_CONCAT(stream, i))
 #define STREAMDEV_DEVICE(i, _) \

--- a/samples/sensor/stream_fifo/src/main.c
+++ b/samples/sensor/stream_fifo/src/main.c
@@ -12,7 +12,6 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/kernel.h>
 #include <zephyr/rtio/rtio.h>
-#include <zephyr/drivers/sensor.h>
 
 #define STREAMDEV_ALIAS(i) DT_ALIAS(_CONCAT(stream, i))
 #define STREAMDEV_DEVICE(i, _) \

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <zephyr/drivers/ipm.h>
 

--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/src/main.c
@@ -85,7 +85,6 @@ osSemaphoreId forks[NUM_PHIL];
 #define PR_DEBUG(...)
 #endif
 
-#include "phil_obj_abstract.h"
 
 static void set_phil_state_pos(int id)
 {

--- a/samples/subsys/portability/cmsis_rtos_v2/philosophers/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v2/philosophers/src/main.c
@@ -115,7 +115,6 @@ static osThreadAttr_t thread_attr[] = {
 #define PR_DEBUG(...)
 #endif
 
-#include "phil_obj_abstract.h"
 
 static void set_phil_state_pos(int id)
 {

--- a/soc/infineon/cat1a/psoc6_legacy/soc.c
+++ b/soc/infineon/cat1a/psoc6_legacy/soc.c
@@ -12,7 +12,6 @@
 #include "cy_syslib.h"
 #include "cy_gpio.h"
 #include "cy_scb_uart.h"
-#include "cy_syslib.h"
 #include "cy_syspm.h"
 #include "cy_sysclk.h"
 

--- a/soc/intel/intel_adsp/cavs/power.c
+++ b/soc/intel/intel_adsp/cavs/power.c
@@ -11,7 +11,6 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/pm.h>
-#include <zephyr/device.h>
 #include <zephyr/cache.h>
 #include <cpu_init.h>
 

--- a/soc/intel/intel_adsp/common/include/intel_adsp_hda.h
+++ b/soc/intel/intel_adsp/common/include/intel_adsp_hda.h
@@ -11,7 +11,6 @@
 #include <zephyr/sys/util.h>
 #include <adsp_shim.h>
 #include <adsp_memory.h>
-#include <adsp_shim.h>
 
 /**
  * @brief HDA stream functionality for Intel ADSP

--- a/soc/microchip/mec/mec174x/soc.h
+++ b/soc/microchip/mec/mec174x/soc.h
@@ -39,7 +39,6 @@
 #include <soc_pcr.h>
 #include <soc_pins.h>
 
-#include <reg/mec_gpio.h>
 
 #endif
 #endif

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -21,7 +21,6 @@
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/pacs.h>
-#include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/uuid.h>

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -9,7 +9,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdint.h>
 
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/audio.h>

--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -28,7 +28,6 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
-#include <zephyr/types.h>
 #include <zephyr/shell/shell.h>
 
 #include "host/shell/bt.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
@@ -30,7 +30,6 @@
 #include "lll_df.h"
 #include "lll_df_internal.h"
 
-#include <soc.h>
 #include "hal/debug.h"
 
 /* Minimum number of antenna switch patterns required by Direction Finding Extension to be

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -18,7 +18,6 @@
 #include "util/util.h"
 #include "util/memq.h"
 #include "util/dbuf.h"
-#include "util/util.h"
 
 #include "pdu_df.h"
 #include "pdu_vendor.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -65,7 +65,6 @@
 #include "ull_llcp.h"
 #include "ll.h"
 
-#include <soc.h>
 #include "hal/debug.h"
 
 /* Check that timeout_reload member is at safe offset when ll_sync_set is

--- a/subsys/bluetooth/services/ias/shell/ias.c
+++ b/subsys/bluetooth/services/ias/shell/ias.c
@@ -11,7 +11,6 @@
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/conn.h>
 
-#include <zephyr/types.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/bluetooth.h>

--- a/subsys/debug/gdbstub/gdbstub.c
+++ b/subsys/debug/gdbstub/gdbstub.c
@@ -19,7 +19,6 @@ LOG_MODULE_REGISTER(gdbstub);
 #include <string.h>
 #include <zephyr/toolchain.h>
 #include <sys/types.h>
-#include <zephyr/sys/util.h>
 
 #include <zephyr/debug/gdbstub.h>
 #include "gdbstub_backend.h"

--- a/subsys/debug/thread_analyzer/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer/thread_analyzer.c
@@ -13,7 +13,6 @@
 #include <kernel_internal.h>
 #include <zephyr/debug/thread_analyzer.h>
 #include <zephyr/debug/stack.h>
-#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <stdio.h>
 #include <zephyr/init.h>

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -14,7 +14,6 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/dfu/flash_img.h>
-#include <zephyr/dfu/mcuboot.h>
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/storage/stream_flash.h>
 

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -12,7 +12,6 @@
 #include <zephyr/init.h>
 #include <zephyr/fs/fs.h>
 #include <zephyr/sd/sd_spec.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
 #include <limits.h>

--- a/subsys/logging/log_minimal.c
+++ b/subsys/logging/log_minimal.c
@@ -7,7 +7,6 @@
 #include <zephyr/sys/printk.h>
 #include <ctype.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys/printk.h>
 #include <zephyr/llext/symbol.h>
 
 #define HEXDUMP_BYTES_IN_LINE 8U

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -45,7 +45,6 @@
 #endif
 
 #if defined(CONFIG_MCUMGR_GRP_OS_INFO) || defined(CONFIG_MCUMGR_GRP_OS_BOOTLOADER_INFO)
-#include <stdio.h>
 #include <zephyr/version.h>
 #if defined(CONFIG_MCUMGR_GRP_OS_INFO)
 #include <os_mgmt_processor.h>
@@ -53,7 +52,6 @@
 #if defined(CONFIG_MCUMGR_GRP_OS_BOOTLOADER_INFO)
 #include <bootutil/boot_status.h>
 #endif
-#include <mgmt/mcumgr/util/zcbor_bulk.h>
 #if defined(CONFIG_NET_HOSTNAME_ENABLE)
 #include <zephyr/net/hostname.h>
 #elif defined(CONFIG_BT)

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -41,10 +41,6 @@ LOG_MODULE_REGISTER(net_ctx, CONFIG_NET_CONTEXT_LOG_LEVEL);
 #include "net_stats.h"
 #include "pmtu.h"
 
-#if defined(CONFIG_NET_TCP)
-#include "tcp_internal.h"
-#endif
-
 #ifdef CONFIG_NET_INITIAL_MCAST_TTL
 #define INITIAL_MCAST_TTL CONFIG_NET_INITIAL_MCAST_TTL
 #else

--- a/subsys/net/lib/shell/ppp.c
+++ b/subsys/net/lib/shell/ppp.c
@@ -13,7 +13,6 @@ LOG_MODULE_DECLARE(net_shell);
 #include "net_shell_private.h"
 
 #if defined(CONFIG_NET_L2_PPP)
-#include <zephyr/net/ppp.h>
 #include "ppp/ppp_internal.h"
 #endif
 

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -409,7 +409,6 @@ void ztest_skip_failed_assumption(void)
  */
 #include <setjmp.h> /* parasoft-suppress MISRAC2012-RULE_21_4-a MISRAC2012-RULE_21_4-b*/
 #include <signal.h>
-#include <stdlib.h>
 #include <string.h>
 
 #define FAIL_FAST 0

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -20,9 +20,7 @@
 #include <zephyr/drivers/video-controls.h>
 #include <zephyr/logging/log.h>
 
-#include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/usb/usb_ch9.h>
 #include <zephyr/usb/class/usbd_uvc.h>
 
 #include "usbd_uvc.h"

--- a/tests/bluetooth/audio/cap_initiator/uut/csip.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/csip.c
@@ -9,9 +9,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
 
 #include <zephyr/bluetooth/audio/csip.h>
 #include <zephyr/bluetooth/conn.h>

--- a/tests/bluetooth/audio/mocks/include/conn.h
+++ b/tests/bluetooth/audio/mocks/include/conn.h
@@ -9,7 +9,6 @@
 #define MOCKS_CONN_H_
 #include <stdint.h>
 
-#include <stdint.h>
 
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>

--- a/tests/bluetooth/audio/mocks/include/expects_util.h
+++ b/tests/bluetooth/audio/mocks/include/expects_util.h
@@ -9,12 +9,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <stdint.h>
 
 #include <zephyr/sys/util_internal.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/sys/util_internal.h>
 #include <zephyr/ztest.h>
 #include <zephyr/ztest_assert.h>
 

--- a/tests/bluetooth/audio/mocks/src/conn.c
+++ b/tests/bluetooth/audio/mocks/src/conn.c
@@ -4,13 +4,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <stdint.h>
 
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/controller/ctrl_data_length_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_data_length_update/src/main.c
@@ -11,7 +11,6 @@
 #define ULL_LLCP_UNITTEST
 
 #include <zephyr/bluetooth/hci.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include "hal/ccm.h"

--- a/tests/bluetooth/controller/ctrl_feature_exchange/src/main.c
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/src/main.c
@@ -11,7 +11,6 @@
 #define ULL_LLCP_UNITTEST
 
 #include <zephyr/bluetooth/hci.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include "hal/ccm.h"

--- a/tests/bluetooth/controller/ctrl_feature_exchange/src/main_hci.c
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/src/main_hci.c
@@ -11,7 +11,6 @@
 #define ULL_LLCP_UNITTEST
 
 #include <zephyr/bluetooth/hci.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include "hal/ccm.h"

--- a/tests/bluetooth/controller/ctrl_hci/src/main.c
+++ b/tests/bluetooth/controller/ctrl_hci/src/main.c
@@ -11,7 +11,6 @@
 #define ULL_LLCP_UNITTEST
 
 #include <zephyr/bluetooth/hci.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include "hal/ccm.h"

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -36,7 +36,6 @@
 #include "btp_bap_audio_stream.h"
 #include "bap_endpoint.h"
 #include "btp/btp.h"
-#include "btp_bap_audio_stream.h"
 #include "btp_bap_broadcast.h"
 
 #define LOG_MODULE_NAME bttester_bap_broadcast

--- a/tests/bluetooth/tester/src/audio/btp_mcp.c
+++ b/tests/bluetooth/tester/src/audio/btp_mcp.c
@@ -17,7 +17,6 @@
 #include <zephyr/bluetooth/audio/media_proxy.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/services/ots.h>
-#include <zephyr/bluetooth/audio/media_proxy.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util.h>

--- a/tests/boards/native_sim/rtc/src/main.c
+++ b/tests/boards/native_sim/rtc/src/main.c
@@ -16,7 +16,6 @@
 #include <nsi_timer_model.h>
 #include "native_rtc.h"
 
-#include <stdio.h>
 
 static char *us_time_to_str(char *dest, uint64_t time)
 {

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -11,7 +11,6 @@
 #include <string.h>
 
 #include <zephyr/autoconf.h>
-#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>

--- a/tests/bsim/bluetooth/host/iso/frag_2/src/broadcaster.c
+++ b/tests/bsim/bluetooth/host/iso/frag_2/src/broadcaster.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/bluetooth/hci_types.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/logging/log.h>

--- a/tests/bsim/bluetooth/host/misc/conn_stress/central/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/central/src/main.c
@@ -27,7 +27,6 @@ LOG_MODULE_REGISTER(central, LOG_LEVEL_INF);
 #include "bstests.h"
 #include "bs_types.h"
 #include "bs_tracing.h"
-#include "bstests.h"
 #include "bs_pc_backchannel.h"
 
 #include "babblekit/testcase.h"

--- a/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
@@ -29,7 +29,6 @@ LOG_MODULE_REGISTER(peripheral, LOG_LEVEL_INF);
 #include "bstests.h"
 #include "bs_types.h"
 #include "bs_tracing.h"
-#include "bstests.h"
 #include "bs_pc_backchannel.h"
 #include "argparse.h"
 

--- a/tests/bsim/bluetooth/ll/bis/src/test_past.c
+++ b/tests/bsim/bluetooth/ll/bis/src/test_past.c
@@ -10,18 +10,15 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
-#include <stddef.h>
 #include <errno.h>
 #include <zephyr/kernel.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/iso.h>
-#include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
-#include <zephyr/sys/byteorder.h>
 
 #include "subsys/bluetooth/host/hci_core.h"
 #include "subsys/bluetooth/controller/include/ll.h"

--- a/tests/drivers/adc/adc_accuracy_test/src/dac_source.c
+++ b/tests/drivers/adc/adc_accuracy_test/src/dac_source.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/dac.h>
-#include <zephyr/drivers/adc.h>
 #include <zephyr/ztest.h>
 
 #define DIV 2

--- a/tests/net/shell/src/main.c
+++ b/tests/net/shell/src/main.c
@@ -48,7 +48,6 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #define NET_LOG_ENABLED 1
 #endif
 #include "net_private.h"
-#include "ipv4.h"
 
 static bool test_failed;
 static struct k_sem recv_lock;

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -48,7 +48,6 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #define NET_LOG_ENABLED 1
 #endif
 #include "net_private.h"
-#include "ipv4.h"
 
 static bool test_failed;
 static bool fail = true;

--- a/tests/subsys/fs/multi-fs/src/test_fat_mount.c
+++ b/tests/subsys/fs/multi-fs/src/test_fat_mount.c
@@ -8,7 +8,6 @@
 #include <ff.h>
 #include "test_common.h"
 #include "test_fs_shell.h"
-#include "test_fat.h"
 #include "test_fat_priv.h"
 
 /* for mount using FS api */

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -12,7 +12,6 @@
 #include <zephyr/ztest.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_utf8.h>
-#include <zephyr/ztest.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 


### PR DESCRIPTION
Remove duplicated #include directives within the same preprocessor scope across the Zephyr tree.

Duplicates inside different #ifdef branches are preserved as they may be intentional.