### PR TITLE
modules: nrf_wifi: spi: optimise SPI RX transaction

### DIFF
--- a/modules/nrf_wifi/bus/spi_if.c
+++ b/modules/nrf_wifi/bus/spi_if.c
@@ -51,33 +51,35 @@ static int spim_xfer_tx(unsigned int addr, void *data, unsigned int len)
 	return err;
 }
 
+#define HDR_SIZE          5
+#define MAX_DISCARD_BYTES 8
 
 static int spim_xfer_rx(unsigned int addr, void *data, unsigned int len, unsigned int discard_bytes)
 {
-	uint8_t hdr[] = {
+	uint8_t hdr[HDR_SIZE + MAX_DISCARD_BYTES] = {
 		0x0b, /* FASTREAD opcode */
 		(addr >> 16) & 0xFF,
 		(addr >> 8) & 0xFF,
 		addr & 0xFF,
 		0 /* dummy byte */
 	};
-	uint8_t discard[sizeof(hdr) + 2 * 4];
+	uint8_t discard[HDR_SIZE + MAX_DISCARD_BYTES];
 
 	const struct spi_buf tx_buf[] = {
-		{.buf = hdr,  .len = sizeof(hdr) },
+		{.buf = hdr,  .len = HDR_SIZE + discard_bytes},
 		{.buf = NULL, .len = len },
 	};
 
 	const struct spi_buf_set tx = { .buffers = tx_buf, .count = 2 };
 
 	const struct spi_buf rx_buf[] = {
-		{.buf = discard,  .len = sizeof(hdr) + discard_bytes},
+		{.buf = discard,  .len = HDR_SIZE + discard_bytes},
 		{.buf = data, .len = len },
 	};
 
 	const struct spi_buf_set rx = { .buffers = rx_buf, .count = 2 };
 
-	if (rx_buf[0].len > sizeof(discard)) {
+	if (discard_bytes > MAX_DISCARD_BYTES) {
 		LOG_ERR("Discard bytes too large, please adjust buf size");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Optimise the transactions queued by `spim_xfer_rx` to only require 2 sequences started by the SPI driver, instead of 3.

Previously:
  1. TX `sizeof(hdr)`, RX nothing
  2. TX nothing, finish receiving `sizeof(hdr) + discard_bytes`
  3. TX nothing, receive `len`

Now:
 1. TX `sizeof(hdr) + discard_bytes`, RX nothing
 2. TX nothing, receive `len`