### PR TITLE
drivers: flash: mcux_flexspi: fix unused variable warnings

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -388,7 +388,9 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		const void *buffer, size_t len)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
+#ifdef CONFIG_HAS_MCUX_CACHE
 	size_t size = len;
+#endif
 	uint8_t *src = (uint8_t *) buffer;
 	int i;
 	unsigned int key = 0;
@@ -396,6 +398,10 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 	uint8_t *dst = memc_flexspi_get_ahb_address(data->controller,
 						    data->port,
 						    offset);
+
+	if (!dst) {
+		return -EINVAL;
+	}
 
 	if (memc_flexspi_is_running_xip(data->controller)) {
 		/*
@@ -464,6 +470,10 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 	uint8_t *dst = memc_flexspi_get_ahb_address(data->controller,
 						    data->port,
 						    offset);
+
+	if (!dst) {
+		return -EINVAL;
+	}
 
 	if (offset % SPI_NOR_SECTOR_SIZE) {
 		LOG_ERR("Invalid offset");

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -357,7 +357,9 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		const void *buffer, size_t len)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
-
+#ifdef CONFIG_HAS_MCUX_CACHE
+	size_t size = len;
+#endif
 	if (!buffer) {
 		return -EINVAL;
 	}
@@ -366,7 +368,6 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		return -EINVAL;
 	}
 
-	size_t size = len;
 	uint8_t *src = (uint8_t *) buffer;
 	int i;
 	unsigned int key = 0;
@@ -374,6 +375,10 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 	uint8_t *dst = memc_flexspi_get_ahb_address(&data->controller,
 						    data->port,
 						    offset);
+
+	if (!dst) {
+		return -EINVAL;
+	}
 
 	if (memc_flexspi_is_running_xip(&data->controller)) {
 		/*
@@ -440,6 +445,10 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 	uint8_t *dst = memc_flexspi_get_ahb_address(&data->controller,
 						    data->port,
 						    offset);
+
+	if (!dst) {
+		return -EINVAL;
+	}
 
 	if (offset % SPI_NOR_SECTOR_SIZE) {
 		LOG_ERR("Invalid offset");


### PR DESCRIPTION
Fix compiler warnings when CONFIG_HAS_MCUX_CACHE is not defined:
- Add pointer validity checks before cache invalidation operations
- Remove unnecessary intermediate 'size' variable and use 'len' 
  directly in DCACHE_InvalidateByRange() to eliminate unused 
  variable when CONFIG_HAS_MCUX_CACHE is disabled