### PR TITLE
modules: hal_st: Fix Kconfig USE_STDC_LSM6DS3TR

### DIFF
--- a/modules/hal_st/Kconfig
+++ b/modules/hal_st/Kconfig
@@ -162,7 +162,7 @@ config USE_STDC_LSM303AH
 config USE_STDC_LSM6DS3
 	bool
 
-config USE_STDC_LSM6DS3TR
+config USE_STDC_LSM6DS3TR_C
 	bool
 
 config USE_STDC_LSM6DSL


### PR DESCRIPTION
Align Kconfig USE_STDC_LSM6DS3TR with hal_st
Fixes zephyrproject-rtos/zephyr#53546
See also hal_st PR #22