### PR TITLE
 drivers: flash: flash_shell.c: Fix parsing of `flash read`

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -800,7 +800,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "<src_device> <dst_device> <src_offset> <dst_offset> <size>", cmd_copy, 5, 5),
 	SHELL_CMD_ARG(erase, &dsub_device_name, "[<device>] <page address> [<size>]", cmd_erase, 2,
 		      2),
-	SHELL_CMD_ARG(read, &dsub_device_name, "[<device>] <address> [<Dword count>]", cmd_read, 2,
+	SHELL_CMD_ARG(read, &dsub_device_name, "[<device>] <address> [<byte count>]", cmd_read, 2,
 		      2),
 	SHELL_CMD_ARG(test, &dsub_device_name, "[<device>] <address> <size> <repeat count>",
 		      cmd_test, 4, 1),

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -48,9 +48,8 @@ static const struct device *const zephyr_flash_controller =
 
 static uint8_t __aligned(4) test_arr[CONFIG_FLASH_SHELL_BUFFER_SIZE];
 
-static int parse_helper(const struct shell *sh, size_t *argc,
-		char **argv[], const struct device * *flash_dev,
-		uint32_t *addr)
+static int parse_helper(const struct shell *sh, size_t *argc, char **argv[],
+			const struct device **flash_dev, uint32_t *addr)
 {
 	char *endptr;
 
@@ -107,12 +106,13 @@ static int cmd_erase(const struct shell *sh, size_t argc, char *argv[])
 	} else {
 		struct flash_pages_info info;
 
-		result = flash_get_page_info_by_offs(flash_dev, page_addr,
-						     &info);
+		result = flash_get_page_info_by_offs(flash_dev, page_addr, &info);
 
 		if (result != 0) {
-			shell_error(sh, "Could not determine page size, "
-				    "code %d.", result);
+			shell_error(sh,
+				    "Could not determine page size, "
+				    "code %d.",
+				    result);
 			return -EINVAL;
 		}
 
@@ -273,8 +273,7 @@ static int cmd_test(const struct shell *sh, size_t argc, char *argv[])
 	size = strtoul(argv[2], NULL, 16);
 	repeat = strtoul(argv[3], NULL, 16);
 	if (size > CONFIG_FLASH_SHELL_BUFFER_SIZE) {
-		shell_error(sh, "<size> must be at most 0x%x.",
-			    CONFIG_FLASH_SHELL_BUFFER_SIZE);
+		shell_error(sh, "<size> must be at most 0x%x.", CONFIG_FLASH_SHELL_BUFFER_SIZE);
 		return -EINVAL;
 	}
 
@@ -330,7 +329,7 @@ static int cmd_test(const struct shell *sh, size_t argc, char *argv[])
 }
 
 #ifdef CONFIG_FLASH_SHELL_TEST_COMMANDS
-const static uint8_t speed_types[][4] = { "B", "KiB", "MiB", "GiB" };
+const static uint8_t speed_types[][4] = {"B", "KiB", "MiB", "GiB"};
 const static uint32_t speed_divisor = 1024;
 
 static int read_write_erase_validate(const struct shell *sh, size_t argc, char *argv[],
@@ -643,11 +642,11 @@ static void bypass_cb(const struct shell *sh, uint8_t *recv, size_t len, void *u
 		if (flash_load_boff == flash_load_buf_size) {
 			uint32_t addr = flash_load_addr + flash_load_written;
 			int rc = flash_write(flash_load_dev, addr, flash_load_buf,
-					flash_load_buf_size);
+					     flash_load_buf_size);
 
 			if (rc != 0) {
-				shell_error(sh, "Write to addr %x on dev %p ERROR!",
-						addr, flash_load_dev);
+				shell_error(sh, "Write to addr %x on dev %p ERROR!", addr,
+					    flash_load_dev);
 			}
 
 			shell_print(sh, "Written chunk %d", flash_load_chunk);
@@ -662,15 +661,14 @@ static void bypass_cb(const struct shell *sh, uint8_t *recv, size_t len, void *u
 	 * at the end.
 	 */
 	if (flash_load_written < flash_load_total &&
-			flash_load_written + flash_load_boff >= flash_load_total) {
+	    flash_load_written + flash_load_boff >= flash_load_total) {
 
 		uint32_t addr = flash_load_addr + flash_load_written;
 		int rc = flash_write(flash_load_dev, addr, flash_load_buf, flash_load_boff);
 
 		if (rc != 0) {
 			set_bypass(sh, NULL);
-			shell_error(sh, "Write to addr %x on dev %p ERROR!",
-					addr, flash_load_dev);
+			shell_error(sh, "Write to addr %x on dev %p ERROR!", addr, flash_load_dev);
 			return;
 		}
 
@@ -713,7 +711,7 @@ static int cmd_load(const struct shell *sh, size_t argc, char *argv[])
 
 	if (flash_load_buf_size < write_block_size) {
 		shell_error(sh, "Size of buffer is too small to be aligned to %zu.",
-				write_block_size);
+			    write_block_size);
 		return -ENOSPC;
 	}
 
@@ -723,7 +721,7 @@ static int cmd_load(const struct shell *sh, size_t argc, char *argv[])
 
 		shell_warn(sh, "Load buffer was not aligned to %zu.", write_block_size);
 		shell_warn(sh, "Effective load buffer size was set from %d to %d",
-				FLASH_LOAD_BUF_MAX, flash_load_buf_size);
+			   FLASH_LOAD_BUF_MAX, flash_load_buf_size);
 	}
 
 	/* Prepare data for callback. */
@@ -759,8 +757,8 @@ static int cmd_page_info(const struct shell *sh, size_t argc, char *argv[])
 		return -EINVAL;
 	}
 
-	shell_print(sh, "Page for address 0x%x:\nstart offset: 0x%lx\nsize: %zu\nindex: %d",
-			addr, info.start_offset, info.size, info.index);
+	shell_print(sh, "Page for address 0x%x:\nstart offset: 0x%lx\nsize: %zu\nindex: %d", addr,
+		    info.start_offset, info.size, info.index);
 	return 0;
 }
 
@@ -792,56 +790,41 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;
-	entry->help  = NULL;
+	entry->help = NULL;
 	entry->subcmd = &dsub_device_name;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(flash_cmds,
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	flash_cmds,
 	SHELL_CMD_ARG(copy, &dsub_device_name,
-		"<src_device> <dst_device> <src_offset> <dst_offset> <size>",
-		cmd_copy, 5, 5),
-	SHELL_CMD_ARG(erase, &dsub_device_name,
-		"[<device>] <page address> [<size>]",
-		cmd_erase, 2, 2),
-	SHELL_CMD_ARG(read, &dsub_device_name,
-		"[<device>] <address> [<Dword count>]",
-		cmd_read, 2, 2),
-	SHELL_CMD_ARG(test, &dsub_device_name,
-		"[<device>] <address> <size> <repeat count>",
-		cmd_test, 4, 1),
-	SHELL_CMD_ARG(write, &dsub_device_name,
-		"[<device>] <address> <dword> [<dword>...]",
-		cmd_write, 3, BUF_ARRAY_CNT),
-	SHELL_CMD_ARG(load, &dsub_device_name,
-		"[<device>] <address> <size>",
-		cmd_load, 3, 1),
-	SHELL_CMD_ARG(page_info, &dsub_device_name,
-		"[<device>] <address>",
-		cmd_page_info, 2, 1),
+		      "<src_device> <dst_device> <src_offset> <dst_offset> <size>", cmd_copy, 5, 5),
+	SHELL_CMD_ARG(erase, &dsub_device_name, "[<device>] <page address> [<size>]", cmd_erase, 2,
+		      2),
+	SHELL_CMD_ARG(read, &dsub_device_name, "[<device>] <address> [<Dword count>]", cmd_read, 2,
+		      2),
+	SHELL_CMD_ARG(test, &dsub_device_name, "[<device>] <address> <size> <repeat count>",
+		      cmd_test, 4, 1),
+	SHELL_CMD_ARG(write, &dsub_device_name, "[<device>] <address> <dword> [<dword>...]",
+		      cmd_write, 3, BUF_ARRAY_CNT),
+	SHELL_CMD_ARG(load, &dsub_device_name, "[<device>] <address> <size>", cmd_load, 3, 1),
+	SHELL_CMD_ARG(page_info, &dsub_device_name, "[<device>] <address>", cmd_page_info, 2, 1),
 
 #if DT_HAS_COMPAT_STATUS_OKAY(fixed_partitions)
-	SHELL_CMD_ARG(partitions, &dsub_device_name,
-		"",
-		cmd_partitions, 0, 0),
+	SHELL_CMD_ARG(partitions, &dsub_device_name, "", cmd_partitions, 0, 0),
 #endif
 
 #ifdef CONFIG_FLASH_SHELL_TEST_COMMANDS
-	SHELL_CMD_ARG(read_test, &dsub_device_name,
-		"[<device>] <address> <size> <repeat count>",
-		cmd_read_test, 4, 1),
-	SHELL_CMD_ARG(write_test, &dsub_device_name,
-		"[<device>] <address> <size> <repeat count>",
-		cmd_write_test, 4, 1),
-	SHELL_CMD_ARG(erase_test, &dsub_device_name,
-		"[<device>] <address> <size> <repeat count>",
-		cmd_erase_test, 4, 1),
+	SHELL_CMD_ARG(read_test, &dsub_device_name, "[<device>] <address> <size> <repeat count>",
+		      cmd_read_test, 4, 1),
+	SHELL_CMD_ARG(write_test, &dsub_device_name, "[<device>] <address> <size> <repeat count>",
+		      cmd_write_test, 4, 1),
+	SHELL_CMD_ARG(erase_test, &dsub_device_name, "[<device>] <address> <size> <repeat count>",
+		      cmd_erase_test, 4, 1),
 	SHELL_CMD_ARG(erase_write_test, &dsub_device_name,
-		"[<device>] <address> <size> <repeat count>",
-		cmd_erase_write_test, 4, 1),
+		      "[<device>] <address> <size> <repeat count>", cmd_erase_write_test, 4, 1),
 #endif
 
-	SHELL_SUBCMD_SET_END
-);
+	SHELL_SUBCMD_SET_END);
 
 static int cmd_flash(const struct shell *sh, size_t argc, char **argv)
 {
@@ -849,5 +832,4 @@ static int cmd_flash(const struct shell *sh, size_t argc, char **argv)
 	return -EINVAL;
 }
 
-SHELL_CMD_ARG_REGISTER(flash, &flash_cmds, "Flash shell commands",
-		       cmd_flash, 2, 0);
+SHELL_CMD_ARG_REGISTER(flash, &flash_cmds, "Flash shell commands", cmd_flash, 2, 0);

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -232,7 +232,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (argc > 2) {
-		cnt = strtoul(argv[2], NULL, 16);
+		cnt = strtoul(argv[2], NULL, 0);
 	} else {
 		cnt = 1;
 	}

--- a/tests/subsys/shell/shell_flash/src/shell_flash_test.c
+++ b/tests/subsys/shell/shell_flash/src/shell_flash_test.c
@@ -38,7 +38,7 @@ ZTEST(shell_flash, test_flash_read)
 	const struct device *const flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 	const char *buf;
 	const int test_base = FLASH_SIMULATOR_BASE_OFFSET;
-	const int test_size = 0x24;  /* 32-alignment required */
+	const int test_size = 0x24; /* 32-alignment required */
 	uint8_t data[test_size];
 	size_t size;
 	int ret;
@@ -48,8 +48,7 @@ ZTEST(shell_flash, test_flash_read)
 		data[i] = 'A' + i;
 	}
 
-	zassert_true(device_is_ready(flash_dev),
-		     "Simulated flash driver not ready");
+	zassert_true(device_is_ready(flash_dev), "Simulated flash driver not ready");
 
 	ret = flash_write(flash_dev, test_base, data, test_size);
 	zassert_equal(0, ret, "flash_write() failed: %d", ret);

--- a/tests/subsys/shell/shell_flash/src/shell_flash_test.c
+++ b/tests/subsys/shell/shell_flash/src/shell_flash_test.c
@@ -53,7 +53,7 @@ ZTEST(shell_flash, test_flash_read)
 	ret = flash_write(flash_dev, test_base, data, test_size);
 	zassert_equal(0, ret, "flash_write() failed: %d", ret);
 
-	ret = shell_execute_cmd(NULL, "flash read 0 23");
+	ret = shell_execute_cmd(NULL, "flash read 0 0x23");
 	zassert_equal(0, ret, "flash read failed: %d", ret);
 
 	buf = shell_backend_dummy_get_output(sh, &size);


### PR DESCRIPTION
The parsing of the number of bytes to read in the read command was being done in hexadecimal, causing unexpected behavior.

Now the number can be interpreted in decimal or hexadecimal if prefixed with 0x.

Also fixes the help test of the `flash read` command.
