### PR TITLE
drivers: lora: ability to set custom sync word for LBM

### DIFF
--- a/drivers/lora/lora_basics_modem/lbm_common.c
+++ b/drivers/lora/lora_basics_modem/lbm_common.c
@@ -84,8 +84,7 @@ int lbm_lora_config(const struct device *dev, struct lora_modem_config *lora_con
 		},
 		.rf_freq_in_hz = lora_config->frequency,
 		.output_pwr_in_dbm = lora_config->tx_power,
-		.sync_word = lora_config->public_network ? LBM_LORA_SYNC_WORD_PUBLIC
-							 : LBM_LORA_SYNC_WORD_PRIVATE,
+		.sync_word = lora_config->sync_word,
 	};
 	ral_status_t status;
 	int ret;

--- a/drivers/lora/lora_basics_modem/lbm_common.h
+++ b/drivers/lora/lora_basics_modem/lbm_common.h
@@ -14,12 +14,6 @@
 #define STATE_BUSY    1
 #define STATE_CLEANUP 2
 
-/* LoRa sync words, taken from the legacy loramac-node sx1272.h/sx1276.h */
-enum lbm_modem_lora_sync_word {
-	LBM_LORA_SYNC_WORD_PRIVATE = 0x12,
-	LBM_LORA_SYNC_WORD_PUBLIC = 0x34,
-};
-
 /* Current operation mode of the LBM modem */
 enum lbm_modem_mode {
 	MODE_SLEEP = 0,

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -112,6 +112,8 @@ struct lora_modem_config {
 	 */
 	bool iq_inverted;
 
+#ifdef CONFIG_LORA_MODULE_BACKEND_LORAMAC_NODE
+
 	/**
 	 * Sets the sync-byte to use:
 	 *  - false: for using the private network sync-byte
@@ -122,6 +124,26 @@ struct lora_modem_config {
 	 * interacting with a public network.
 	 */
 	bool public_network;
+
+#else
+
+	/**
+	 * Sets the LoRa sync word.
+	 * The recommended values are as follow:
+	 *  - 0x12: for the private network
+	 *  - 0x34: for the public network
+	 * On SX126x, SX128x, and LLCC68, they are recomposed as 0x1424 and 0x3444 to ensure
+	 * compatibility with SX127x using the relevant registers' default values.
+	 * Later chips like LR1121 and LR2021 go back to using a single byte word.
+	 * The public network sync-byte is only intended for advanced usage.
+	 * Normally the private network sync-byte should be used for peer
+	 * to peer communications and the LoRaWAN APIs should be used for
+	 * interacting with a public network.
+	 * You may use another value like 0x71 or 0xF1 to filter out other private traffic.
+	 */
+	uint8_t sync_word;
+
+#endif
 };
 
 /**

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -55,12 +55,16 @@ int main(void)
 
 	config.frequency = 865100000;
 	config.bandwidth = BW_125_KHZ;
-	config.datarate = SF_10;
+	config.datarate = SF_9;
 	config.preamble_len = 8;
 	config.coding_rate = CR_4_5;
 	config.iq_inverted = false;
+#ifdef CONFIG_LORA_MODULE_BACKEND_LORAMAC_NODE
 	config.public_network = false;
-	config.tx_power = 14;
+#else
+	config.sync_word = 0x12;
+#endif
+	config.tx_power = 0;
 	config.tx = false;
 
 	ret = lora_config(lora_dev, &config);

--- a/samples/drivers/lora/send/src/main.c
+++ b/samples/drivers/lora/send/src/main.c
@@ -35,12 +35,16 @@ int main(void)
 
 	config.frequency = 865100000;
 	config.bandwidth = BW_125_KHZ;
-	config.datarate = SF_10;
+	config.datarate = SF_9;
 	config.preamble_len = 8;
 	config.coding_rate = CR_4_5;
 	config.iq_inverted = false;
+#ifdef CONFIG_LORA_MODULE_BACKEND_LORAMAC_NODE
 	config.public_network = false;
-	config.tx_power = 4;
+#else
+	config.sync_word = 0x12;
+#endif
+	config.tx_power = 0;
 	config.tx = true;
 
 	ret = lora_config(lora_dev, &config);


### PR DESCRIPTION
Change way the sync word is set for LoraBasicModem so as to permit using a custom sync word/byte
Modify samples in consequence, reduce default TX output for safety in case of mistake, set SF default to something LLCC68 will accept.

Article about the sync word compatibility: https://blog.classycode.com/lora-sync-word-compatibility-between-sx127x-and-sx126x-460324d1787a
otherwise looked through lbm to see what it did with them as you would expect.

cross checked with 433mhz sx1278 and llcc68.