### PR TITLE
Drivers: flash: flash_shell.c: Requires device on destructive operations

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -991,6 +991,9 @@ Flash
 * ``CONFIG_FLASH_AREA_CHECK_INTEGRITY_PSA`` is also removed since there is
   now no alternative for the crypto library backend.
 
+* The flash shell commands ``flash erase`` and ``flash write`` now require an explicit
+  device argument. This avoids accidental corruption of the device's program flash.
+
 JWT
 ===
 

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -121,7 +121,7 @@ static int cmd_erase(const struct shell *sh, size_t argc, char *argv[])
 		return result;
 	}
 	if (argc > 3) {
-		size = strtoul(argv[2], NULL, 16);
+		size = strtoul(argv[2], NULL, 0);
 	} else {
 		struct flash_pages_info info;
 

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -24,7 +24,7 @@
 #define SPEED_TEST_MAX_REPETITIONS 10000
 
 /* Buffer is only needed for bytes that follow command and offset */
-#define BUF_ARRAY_CNT (CONFIG_SHELL_ARGC_MAX - 2)
+#define BUF_ARRAY_CNT (CONFIG_SHELL_ARGC_MAX - 3)
 
 #define FLASH_LOAD_BUF_MAX 256
 
@@ -99,12 +99,28 @@ static int cmd_erase(const struct shell *sh, size_t argc, char *argv[])
 	const struct device *flash_dev;
 	uint32_t page_addr;
 	uint32_t size;
+	char *endptr;
+
+	/* For safety, require explicit device name for erase operations */
+	if (argc < 2) {
+		shell_error(sh, "Missing argument");
+		return -EINVAL;
+	}
+
+	/* Check if first argument is a device name (not a number) */
+	(void)strtoul(argv[1], &endptr, 16);
+	if (*endptr == '\0') {
+		/* First argument is a number, not a device name */
+		shell_error(sh, "Incorrect device name");
+		shell_print(sh, "Usage: flash erase <device> <address> [size]");
+		return -EINVAL;
+	}
 
 	result = parse_helper(sh, &argc, &argv, &flash_dev, &page_addr);
 	if (result) {
 		return result;
 	}
-	if (argc > 2) {
+	if (argc > 3) {
 		size = strtoul(argv[2], NULL, 16);
 	} else {
 		struct flash_pages_info info;
@@ -120,6 +136,11 @@ static int cmd_erase(const struct shell *sh, size_t argc, char *argv[])
 		}
 
 		size = info.size;
+	}
+
+	if (size == 0) {
+		shell_error(sh, "Invalid size: 0");
+		return -EINVAL;
 	}
 
 	result = flash_erase(flash_dev, page_addr, size);
@@ -142,6 +163,22 @@ static int cmd_write(const struct shell *sh, size_t argc, char *argv[])
 	uint32_t w_addr;
 	int ret;
 	size_t op_size;
+	char *endptr;
+
+	/* For safety, require explicit device name for write operations */
+	if (argc < 3) {
+		shell_error(sh, "Missing argument");
+		return -EINVAL;
+	}
+
+	/* Check if first argument is a device name (not a number) */
+	(void)strtoul(argv[1], &endptr, 16);
+	if (*endptr == '\0') {
+		/* First argument is a number, not a device name */
+		shell_error(sh, "Incorrect device name");
+		shell_print(sh, "Usage: flash write <device> <address> <data>...");
+		return -EINVAL;
+	}
 
 	ret = parse_helper(sh, &argc, &argv, &flash_dev, &w_addr);
 	if (ret) {
@@ -802,14 +839,14 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	flash_cmds,
 	SHELL_CMD_ARG(copy, &dsub_device_name,
 		      "<src_device> <dst_device> <src_offset> <dst_offset> <size>", cmd_copy, 5, 5),
-	SHELL_CMD_ARG(erase, &dsub_device_name, "[<device>] <page address> [<size>]", cmd_erase, 2,
-		      2),
+	SHELL_CMD_ARG(erase, &dsub_device_name, "<device> <page address> [<size>]", cmd_erase, 3,
+		      1),
 	SHELL_CMD_ARG(read, &dsub_device_name, "[<device>] <address> [<byte count>]", cmd_read, 2,
 		      2),
 	SHELL_CMD_ARG(test, &dsub_device_name, "[<device>] <address> <size> <repeat count>",
 		      cmd_test, 4, 1),
-	SHELL_CMD_ARG(write, &dsub_device_name, "[<device>] <address> <dword> [<dword>...]",
-		      cmd_write, 3, BUF_ARRAY_CNT),
+	SHELL_CMD_ARG(write, &dsub_device_name, "<device> <address> <dword> [<dword>...]",
+		      cmd_write, 4, BUF_ARRAY_CNT),
 	SHELL_CMD_ARG(load, &dsub_device_name, "[<device>] <address> <size>", cmd_load, 3, 1),
 	SHELL_CMD_ARG(page_info, &dsub_device_name, "[<device>] <address>", cmd_page_info, 2, 1),
 

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -835,34 +835,49 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 	entry->subcmd = &dsub_device_name;
 }
 
+#define HELP_COPY                                                                                  \
+	SHELL_HELP("Copy data from one flash device to another",                                   \
+		   "<src_device> <dst_device> <src_offset> <dst_offset> <size>")
+#define HELP_ERASE SHELL_HELP("Erase pages on a flash device", "<device> <page address> [<size>]")
+#define HELP_READ  /**/                                                                            \
+	SHELL_HELP("Read data from a flash device", "[<device>] <address> [<byte count>]")
+#define HELP_TEST SHELL_HELP("Test flash device", "[<device>] <address> <size> <repeat count>")
+#define HELP_WRITE                                                                                 \
+	SHELL_HELP("Write data to a flash device", "<device> <address> <dword> [<dword>...]")
+#define HELP_LOAD      SHELL_HELP("Load data into a flash device", "[<device>] <address> <size>")
+#define HELP_PAGE_INFO SHELL_HELP("Get information about a flash page", "[<device>] <address>")
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
-	flash_cmds,
-	SHELL_CMD_ARG(copy, &dsub_device_name,
-		      "<src_device> <dst_device> <src_offset> <dst_offset> <size>", cmd_copy, 5, 5),
-	SHELL_CMD_ARG(erase, &dsub_device_name, "<device> <page address> [<size>]", cmd_erase, 3,
-		      1),
-	SHELL_CMD_ARG(read, &dsub_device_name, "[<device>] <address> [<byte count>]", cmd_read, 2,
-		      2),
-	SHELL_CMD_ARG(test, &dsub_device_name, "[<device>] <address> <size> <repeat count>",
-		      cmd_test, 4, 1),
-	SHELL_CMD_ARG(write, &dsub_device_name, "<device> <address> <dword> [<dword>...]",
-		      cmd_write, 4, BUF_ARRAY_CNT),
-	SHELL_CMD_ARG(load, &dsub_device_name, "[<device>] <address> <size>", cmd_load, 3, 1),
-	SHELL_CMD_ARG(page_info, &dsub_device_name, "[<device>] <address>", cmd_page_info, 2, 1),
+	flash_cmds, /**/
+	SHELL_CMD_ARG(copy, &dsub_device_name, HELP_COPY, cmd_copy, 5, 5),
+	SHELL_CMD_ARG(erase, &dsub_device_name, HELP_ERASE, cmd_erase, 3, 1),
+	SHELL_CMD_ARG(read, &dsub_device_name, HELP_READ, cmd_read, 2, 2),
+	SHELL_CMD_ARG(test, &dsub_device_name, HELP_TEST, cmd_test, 4, 1),
+	SHELL_CMD_ARG(write, &dsub_device_name, HELP_WRITE, cmd_write, 4, BUF_ARRAY_CNT),
+	SHELL_CMD_ARG(load, &dsub_device_name, HELP_LOAD, cmd_load, 3, 1),
+	SHELL_CMD_ARG(page_info, &dsub_device_name, HELP_PAGE_INFO, cmd_page_info, 2, 1),
 
 #if DT_HAS_COMPAT_STATUS_OKAY(fixed_partitions)
-	SHELL_CMD_ARG(partitions, &dsub_device_name, "", cmd_partitions, 0, 0),
+#define HELP_PARTITIONS SHELL_HELP("Get partitionsformation", "")
+	SHELL_CMD_ARG(partitions, &dsub_device_name, HELP_PARTITIONS, cmd_partitions, 0, 0),
 #endif
 
 #ifdef CONFIG_FLASH_SHELL_TEST_COMMANDS
-	SHELL_CMD_ARG(read_test, &dsub_device_name, "[<device>] <address> <size> <repeat count>",
-		      cmd_read_test, 4, 1),
-	SHELL_CMD_ARG(write_test, &dsub_device_name, "[<device>] <address> <size> <repeat count>",
-		      cmd_write_test, 4, 1),
-	SHELL_CMD_ARG(erase_test, &dsub_device_name, "[<device>] <address> <size> <repeat count>",
-		      cmd_erase_test, 4, 1),
-	SHELL_CMD_ARG(erase_write_test, &dsub_device_name,
-		      "[<device>] <address> <size> <repeat count>", cmd_erase_write_test, 4, 1),
+#define HELP_READ_TEST                                                                             \
+	SHELL_HELP("Read test on a flash device", "[<device>] <address> <size> <repeat count>")
+#define HELP_WRITE_TEST                                                                            \
+	SHELL_HELP("Write test on a flash device", "[<device>] <address> <size> <repeat count>")
+#define HELP_ERASE_TEST                                                                            \
+	SHELL_HELP("Erase test on a flash device", "[<device>] <address> <size> <repeat count>")
+#define HELP_ERASE_WRITE_TEST                                                                      \
+	SHELL_HELP("Erase and write test on a flash device",                                       \
+		   "[<device>] <address> <size> <repeat count>")
+
+	SHELL_CMD_ARG(read_test, &dsub_device_name, HELP_READ_TEST, cmd_read_test, 4, 1),
+	SHELL_CMD_ARG(write_test, &dsub_device_name, HELP_WRITE_TEST, cmd_write_test, 4, 1),
+	SHELL_CMD_ARG(erase_test, &dsub_device_name, HELP_ERASE_TEST, cmd_erase_test, 4, 1),
+	SHELL_CMD_ARG(erase_write_test, &dsub_device_name, HELP_ERASE_WRITE_TEST,
+		      cmd_erase_write_test, 4, 1),
 #endif
 
 	SHELL_SUBCMD_SET_END);


### PR DESCRIPTION
This patch avoids the use of the default device on destructive operations like erase and write. Allowing it might have catastrophic results like erasing parts or the whole of the application itself.