### PR TITLE
soc: infinoen: edge: pse84: system clock

### DIFF
--- a/soc/infineon/edge/pse84/soc_pse84_m55.c
+++ b/soc/infineon/edge/pse84/soc_pse84_m55.c
@@ -95,6 +95,9 @@ void soc_early_init_hook(void)
 	/* Initializes the system */
 	ifx_cycfg_init();
 
+	/* Initialize SystemCoreClock variable. */
+	SystemCoreClockUpdate();
+
 	static cy_stc_ipc_pipe_ep_t systemIpcPipeEpArray[CY_IPC_MAX_ENDPOINTS];
 
 	Cy_IPC_Pipe_Config(systemIpcPipeEpArray);


### PR DESCRIPTION
Update system clock related variables (ex: cy_delayFreqKhz)
[Otherwise Cy_SysLib_Delay or Cy_SysLib_DelayUs are incorrect]