### PR TITLE
Add SPSDK runner support for imx91_evk and frdm_imx91 boards

### DIFF
--- a/boards/nxp/frdm_imx91/CMakeLists.txt
+++ b/boards/nxp/frdm_imx91/CMakeLists.txt
@@ -1,0 +1,81 @@
+#
+# Copyright 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
+  AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
+  find_program(7Z_EXECUTABLE 7z REQUIRED)
+  # reuse EVK's firmware
+  set(FIRMWARE_RELEASE "imx91evk-boot-firmware-6.12.34-2.1.0")
+  # Parse SPSDK version
+  execute_process(
+    COMMAND spsdk --version
+    OUTPUT_VARIABLE SPSDK_VERSION_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" SPSDK_VERSION "${SPSDK_VERSION_OUTPUT}")
+  message(STATUS "SPSDK version is ${SPSDK_VERSION}")
+
+  file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx91_frdm_mimx9131_a55_ahab_primary.yaml
+    "
+    family: mimx9131
+    revision: a0
+    target_memory: serial_downloader
+    output:                   ${CMAKE_BINARY_DIR}/zephyr/primary_ahab.bin
+    containers:
+      - binary_container:
+          path:               ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/mx91a0-ahab-container.img
+      - container:
+          srk_set: none
+          images:
+            - lpddr_imem_1d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_imem_1d_v202201.bin
+              lpddr_imem_2d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_imem_2d_v202201.bin
+              lpddr_dmem_1d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_dmem_1d_v202201.bin
+              lpddr_dmem_2d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_dmem_2d_v202201.bin
+              spl_ddr:           ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/u-boot-spl.bin-imx91evk-sd
+  ")
+  file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx91_frdm_mimx9131_a55_ahab_secondary.yaml
+    "
+    family: mimx9131
+    revision: a0
+    target_memory: serial_downloader
+    output:                   ${CMAKE_BINARY_DIR}/zephyr/secondary_ahab.bin
+    containers:
+      - container:
+          srk_set: none
+          images:
+            - atf:            ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/bl31-imx91-zephyr.bin
+            - image_path:     ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
+              load_address:   '${CONFIG_SRAM_BASE_ADDRESS}'
+              entry_point:    '${CONFIG_SRAM_BASE_ADDRESS}'
+              image_type:     executable
+              core_id:        cortex-a55
+              is_encrypted:   false
+  ")
+  file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx91_frdm_mimx9131_a55_ahab_flash_template.yaml
+    "
+    family: mimx9131
+    revision: a0
+    memory_type: serial_downloader
+    primary_image_container_set: ${CMAKE_BINARY_DIR}/zephyr/imx91_frdm_mimx9131_a55_ahab_primary.yaml
+    secondary_image_container_set: ${CMAKE_BINARY_DIR}/zephyr/imx91_frdm_mimx9131_a55_ahab_secondary.yaml
+ ")
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+    COMMAND ${7Z_EXECUTABLE} x ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin -o./imx-boot-firmware -aos -bso0 -bse1
+    COMMAND ${7Z_EXECUTABLE} x imx-boot-firmware/${FIRMWARE_RELEASE} -aos -bso0 -bse1
+  )
+  if(SPSDK_VERSION VERSION_GREATER_EQUAL "3.0.0")
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND nxpimage bootable-image export -c ${CMAKE_BINARY_DIR}/zephyr/imx91_frdm_mimx9131_a55_ahab_flash_template.yaml -o flash.bin
+    )
+  else()
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND nxpimage bootable-image merge -c ${CMAKE_BINARY_DIR}/zephyr/imx91_frdm_mimx9131_a55_ahab_flash_template.yaml -o flash.bin
+    )
+  endif()
+
+  zephyr_blobs_verify(FILES
+    ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin
+    REQUIRED)
+endif()

--- a/boards/nxp/frdm_imx91/Kconfig
+++ b/boards/nxp/frdm_imx91/Kconfig
@@ -1,0 +1,6 @@
+# i.MX 91 FRDM board configuration
+
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+source "boards/nxp/common/Kconfig"

--- a/boards/nxp/frdm_imx91/board.cmake
+++ b/boards/nxp/frdm_imx91/board.cmake
@@ -5,3 +5,16 @@
 board_runner_args(jlink "--device=MIMX9131" "--no-reset" "--flash-sram")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+
+if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
+  AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
+  board_set_flasher_ifnset(spsdk)
+
+  board_runner_args(spsdk "--family=mimx9131")
+  # reuse evk board's bootloader
+  board_runner_args(spsdk "--bootloader=${CMAKE_BINARY_DIR}/zephyr/imx91evk-boot-firmware-6.12.34-2.1.0/imx-boot-imx91evk-sd.bin-flash_singleboot")
+  board_runner_args(spsdk "--flashbin=${CMAKE_BINARY_DIR}/zephyr/flash.bin")
+  board_runner_args(spsdk "--containers=one")
+
+  include(${ZEPHYR_BASE}/boards/common/spsdk.board.cmake)
+endif()

--- a/boards/nxp/frdm_imx91/doc/index.rst
+++ b/boards/nxp/frdm_imx91/doc/index.rst
@@ -5,7 +5,7 @@ Overview
 
 The FRDM-IMX91 board is a low-cost and compact platform designed to show
 the most commonly used features of the i.MX 91 Applications Processor in a
-small and low cost package. The FRDM-IMX93 board is an entry-level development
+small and low cost package. The FRDM-IMX91 board is an entry-level development
 board, which helps developers to get familiar with the processor before
 investing a large amount of resources in more specific designs.
 
@@ -206,5 +206,58 @@ Here is an example for the :zephyr:code-sample:`hello_world` application.
    :host-os: unix
    :board: frdm_imx91/mimx9131
    :goals: debug
+
+Option 3. Boot Zephyr by Using SPSDK Runner
+===========================================
+
+SPSDK runner leverages SPSDK tools (https://spsdk.readthedocs.io), it builds an
+bootable flash image ``flash.bin`` which includes all necessary firmware components.
+Using west flash command will download the boot image flash.bin to DDR memory, SD card
+or eMMC flash. By using flash.bin, as no U-Boot image is available, so TF-A will boot
+up Zephyr on the Cortex-A55 Core directly.
+
+In order to use SPSDK runner, it requires fetching binary blobs, which can be achieved
+by running the following command:
+
+.. code-block:: console
+
+   west blobs fetch hal_nxp
+
+.. note::
+
+   It is recommended running the command above after :file:`west update`.
+
+SPSDK runner is enabled by configure item :kconfig:option:`CONFIG_BOARD_NXP_SPSDK_IMAGE`, currently
+it is not enabled by default for FRDM-IMX91 board, so use this configuration to enable
+it, for example, with the :zephyr:code-sample:`synchronization` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :host-os: unix
+   :board: frdm_imx91/mimx9131
+   :goals: build
+   :gen-args: -DCONFIG_BOARD_NXP_SPSDK_IMAGE=y
+
+If :kconfig:option:`CONFIG_BOARD_NXP_SPSDK_IMAGE` is available and enabled for the board variant,
+``flash.bin`` will be built automatically. The programming could be through below commands.
+Before that, onboard switch SW1[3:0] should be configured to 0b0001 for USB download mode
+to boot, and USB1 and DBG ports should be connected to Linux host PC. There are 2 serial ports
+enumerated (115200 8n1), the first port will be used for Cortex-A55 Zephyr's Console.
+(The flasher is spsdk which already installed via scripts/requirements.txt.
+On Linux host, USB device permission should be configured per Installation Guide
+of https://spsdk.readthedocs.io)
+
+.. code-block:: none
+
+   # load and run without programming. for next flashing, need to reset the board firstly
+   $ west flash -r spsdk
+
+   # program to SD card, then set SW1[3:0]=0b0011 to reboot from SD
+   $ west flash -r spsdk --bootdevice sd
+
+   # program to emmc card, then set SW1[3:0]=0b0010 to reboot from EMMC
+   $ west flash -r spsdk --bootdevice=emmc
+
+Then the Zephyr log will be displayed in the first serial port's console.
 
 .. include:: ../../common/board-footer.rst.inc

--- a/boards/nxp/imx91_evk/CMakeLists.txt
+++ b/boards/nxp/imx91_evk/CMakeLists.txt
@@ -1,0 +1,80 @@
+#
+# Copyright 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
+  AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
+  find_program(7Z_EXECUTABLE 7z REQUIRED)
+  set(FIRMWARE_RELEASE "imx91evk-boot-firmware-6.12.34-2.1.0")
+  # Parse SPSDK version
+  execute_process(
+    COMMAND spsdk --version
+    OUTPUT_VARIABLE SPSDK_VERSION_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" SPSDK_VERSION "${SPSDK_VERSION_OUTPUT}")
+  message(STATUS "SPSDK version is ${SPSDK_VERSION}")
+
+  file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx91_evk_mimx9131_a55_ahab_primary.yaml
+    "
+    family: mimx9131
+    revision: a0
+    target_memory: serial_downloader
+    output:                   ${CMAKE_BINARY_DIR}/zephyr/primary_ahab.bin
+    containers:
+      - binary_container:
+          path:               ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/mx91a0-ahab-container.img
+      - container:
+          srk_set: none
+          images:
+            - lpddr_imem_1d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_imem_1d_v202201.bin
+              lpddr_imem_2d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_imem_2d_v202201.bin
+              lpddr_dmem_1d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_dmem_1d_v202201.bin
+              lpddr_dmem_2d:     ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/lpddr4_dmem_2d_v202201.bin
+              spl_ddr:           ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/u-boot-spl.bin-imx91evk-sd
+  ")
+  file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx91_evk_mimx9131_a55_ahab_secondary.yaml
+    "
+    family: mimx9131
+    revision: a0
+    target_memory: serial_downloader
+    output:                   ${CMAKE_BINARY_DIR}/zephyr/secondary_ahab.bin
+    containers:
+      - container:
+          srk_set: none
+          images:
+            - atf:            ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/bl31-imx91-zephyr.bin
+            - image_path:     ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
+              load_address:   '${CONFIG_SRAM_BASE_ADDRESS}'
+              entry_point:    '${CONFIG_SRAM_BASE_ADDRESS}'
+              image_type:     executable
+              core_id:        cortex-a55
+              is_encrypted:   false
+  ")
+  file(WRITE ${CMAKE_BINARY_DIR}/zephyr/imx91_evk_mimx9131_a55_ahab_flash_template.yaml
+    "
+    family: mimx9131
+    revision: a0
+    memory_type: serial_downloader
+    primary_image_container_set: ${CMAKE_BINARY_DIR}/zephyr/imx91_evk_mimx9131_a55_ahab_primary.yaml
+    secondary_image_container_set: ${CMAKE_BINARY_DIR}/zephyr/imx91_evk_mimx9131_a55_ahab_secondary.yaml
+ ")
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+    COMMAND ${7Z_EXECUTABLE} x ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin -o./imx-boot-firmware -aos -bso0 -bse1
+    COMMAND ${7Z_EXECUTABLE} x imx-boot-firmware/${FIRMWARE_RELEASE} -aos -bso0 -bse1
+  )
+  if(SPSDK_VERSION VERSION_GREATER_EQUAL "3.0.0")
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND nxpimage bootable-image export -c ${CMAKE_BINARY_DIR}/zephyr/imx91_evk_mimx9131_a55_ahab_flash_template.yaml -o flash.bin
+    )
+  else()
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND nxpimage bootable-image merge -c ${CMAKE_BINARY_DIR}/zephyr/imx91_evk_mimx9131_a55_ahab_flash_template.yaml -o flash.bin
+    )
+  endif()
+
+  zephyr_blobs_verify(FILES
+    ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/imx-boot-firmware/${FIRMWARE_RELEASE}.bin
+    REQUIRED)
+endif()

--- a/boards/nxp/imx91_evk/Kconfig
+++ b/boards/nxp/imx91_evk/Kconfig
@@ -1,0 +1,6 @@
+# i.MX 91 EVK board configuration
+
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+source "boards/nxp/common/Kconfig"

--- a/boards/nxp/imx91_evk/board.cmake
+++ b/boards/nxp/imx91_evk/board.cmake
@@ -1,8 +1,20 @@
 #
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=MIMX9131" "--no-reset" "--flash-sram")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+
+if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
+  AND "$ENV{USE_NXP_SPSDK_IMAGE}" STREQUAL "y"))
+  board_set_flasher_ifnset(spsdk)
+
+  board_runner_args(spsdk "--family=mimx9131")
+  board_runner_args(spsdk "--bootloader=${CMAKE_BINARY_DIR}/zephyr/imx91evk-boot-firmware-6.12.34-2.1.0/imx-boot-imx91evk-sd.bin-flash_singleboot")
+  board_runner_args(spsdk "--flashbin=${CMAKE_BINARY_DIR}/zephyr/flash.bin")
+  board_runner_args(spsdk "--containers=one")
+
+  include(${ZEPHYR_BASE}/boards/common/spsdk.board.cmake)
+endif()

--- a/boards/nxp/imx91_evk/doc/index.rst
+++ b/boards/nxp/imx91_evk/doc/index.rst
@@ -151,4 +151,57 @@ display the following console output:
     thread_a: Hello World from cpu 0 on imx91_evk!
     thread_b: Hello World from cpu 0 on imx91_evk!
 
+Option 3. Boot Zephyr by Using SPSDK Runner
+===========================================
+
+SPSDK runner leverages SPSDK tools (https://spsdk.readthedocs.io), it builds an
+bootable flash image ``flash.bin`` which includes all necessary firmware components.
+Using west flash command will download the boot image flash.bin to DDR memory, SD card
+or eMMC flash. By using flash.bin, as no U-Boot image is available, so TF-A will boot
+up Zephyr on the Cortex-A55 Core directly.
+
+In order to use SPSDK runner, it requires fetching binary blobs, which can be achieved
+by running the following command:
+
+.. code-block:: console
+
+   west blobs fetch hal_nxp
+
+.. note::
+
+   It is recommended running the command above after :file:`west update`.
+
+SPSDK runner is enabled by configure item :kconfig:option:`CONFIG_BOARD_NXP_SPSDK_IMAGE`, currently
+it is not enabled by default for IMX91 EVK board, so use this configuration to enable
+it, for example, with the :zephyr:code-sample:`synchronization` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :host-os: unix
+   :board: imx91_evk/mimx9131
+   :goals: build
+   :gen-args: -DCONFIG_BOARD_NXP_SPSDK_IMAGE=y
+
+If :kconfig:option:`CONFIG_BOARD_NXP_SPSDK_IMAGE` is available and enabled for the board variant,
+``flash.bin`` will be built automatically. The programming could be through below commands.
+Before that, onboard switch SW1301[3:0] should be configured to 0b0011 for USB download mode
+to boot, and USB1 and DBG ports should be connected to Linux host PC. There are 2 serial ports
+enumerated (115200 8n1), the first port will be used for Cortex-A55 Zephyr's Console.
+(The flasher is spsdk which already installed via scripts/requirements.txt.
+On Linux host, USB device permission should be configured per Installation Guide
+of https://spsdk.readthedocs.io)
+
+.. code-block:: none
+
+   # load and run without programming. for next flashing, need to reset the board firstly
+   $ west flash -r spsdk
+
+   # program to SD card, then set SW1301[3:0]=0b0010 to reboot from SD
+   $ west flash -r spsdk --bootdevice sd
+
+   # program to emmc card, then set SW1301[3:0]=0b0000 to reboot from EMMC
+   $ west flash -r spsdk --bootdevice=emmc
+
+Then the Zephyr log will be displayed in the first serial port's console.
+
 .. include:: ../../common/board-footer.rst.inc

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: d12ee715e5f7297806b9c3289e1343899b93750f
+      revision: 8d2f01538b8701d3bd817b379d94f6165c216967
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Added SPSDK runner support for imx91_evk and frdm_imx91 boards.

Depends on https://github.com/zephyrproject-rtos/hal_nxp/pull/642