### PR TITLE
boards: frdm_mcxaxx6,frdm_mcxa577: enable reset driver

### DIFF
--- a/dts/arm/nxp/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxa5x_common.dtsi
@@ -94,7 +94,7 @@
 		#clock-cells = <1>;
 
 		reset: reset {
-			compatible = "nxp,lpc-syscon-reset";
+			compatible = "nxp,mrcc-reset";
 			#reset-cells = <1>;
 		};
 	};

--- a/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxaxx6_common.dtsi
@@ -41,7 +41,7 @@
 			#clock-cells = <1>;
 
 			reset: reset {
-				compatible = "nxp,lpc-syscon-reset";
+				compatible = "nxp,mrcc-reset";
 				#reset-cells = <1>;
 			};
 		};


### PR DESCRIPTION
1. enable reset driver for frdm mcxa boards below:
    - frdm_mcxa266
    - frdm_mcxa346
    - frdm_mcxa366
    - frdm_mcxa577