### PR TITLE
Fix pwm ctimer prescaler error

### DIFF
--- a/drivers/pwm/pwm_mcux_ctimer.c
+++ b/drivers/pwm/pwm_mcux_ctimer.c
@@ -1,5 +1,6 @@
 /*
  * (c) Meta Platforms, Inc. and affiliates.
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -206,9 +207,9 @@ static int mcux_ctimer_pwm_get_cycles_per_sec(const struct device *dev, uint32_t
 		return err;
 	}
 
-	if (config->prescale > 0) {
-		*cycles /= config->prescale;
-	}
+	*cycles /= (uint64_t)config->prescale + 1;
+	__ASSERT((*cycles) > 0, "Invalid PWM frequency: cycles per second is 0(check clock rate
+		and prescaler)");
 
 	return err;
 }

--- a/dts/bindings/pwm/nxp,ctimer-pwm.yaml
+++ b/dts/bindings/pwm/nxp,ctimer-pwm.yaml
@@ -14,7 +14,9 @@ properties:
   prescaler:
     type: int
     default: 1
-    description: prescaling value
+    description: |
+      Specifies the prescale value. Valid range: 0x0 - 0xFFFFFFFF.
+      The clock is divided by (prescaler + 1).
 
   clk-source:
     type: int

--- a/tests/drivers/pwm/pwm_api/boards/frdm_mcxa153.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/frdm_mcxa153.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &ctimer0;
+	};
+};
+
+&pinctrl {
+	ctimer0_default: ctimer0_default {
+		group0 {
+			/* PWM output P2_12 (J2_12) */
+			pinmux = <CT0_MAT0_P2_12>;
+			drive-strength = "high";
+			slew-rate = "fast";
+		};
+	};
+};
+
+&ctimer0 {
+	compatible = "nxp,ctimer-pwm";
+	status = "okay";
+	pinctrl-0 = <&ctimer0_default>;
+	pinctrl-names = "default";
+	#pwm-cells = <3>;
+	prescaler = <1>;
+};


### PR DESCRIPTION
The prescaler divides the clock by (prescaler + 1), not by the prescaler value directly. Update the calculation to correctly account for this.