### PR TITLE
modules: nrf_wifi: bus: SPI keep ACTIVE

### DIFF
--- a/modules/nrf_wifi/bus/Kconfig
+++ b/modules/nrf_wifi/bus/Kconfig
@@ -53,4 +53,14 @@ config NRF70_LOG_VERBOSE
 	bool "Maintains the verbosity of information in logs"
 	default y
 
+config NRF70_SPI_PM_CLAIM_WHILE_ACTIVE
+	bool "Keep SPI bus in ACTIVE state while nRF70 is powered"
+	depends on PM_DEVICE_RUNTIME
+	depends on NRF70_ON_SPI
+	help
+	  Requesting and releasing the SPI bus on every bus transaction when PM
+	  device runtime is enabled has a negative impact on data throughput.
+	  Enabling this option keeps the bus in the active state while the interface
+	  is powered up.
+
 endif # NRF70_BUSLIB

--- a/modules/nrf_wifi/bus/spi_if.c
+++ b/modules/nrf_wifi/bus/spi_if.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/spi.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/wifi/nrf_wifi/bus/qspi_if.h>
+#include <zephyr/pm/device_runtime.h>
 
 #include "spi_if.h"
 
@@ -286,11 +287,19 @@ int spim_init(struct qspi_config *config)
 		spi_spec.config.frequency / MHZ(1));
 	LOG_INF("SPIM %s: latency = %d", spi_spec.bus->name, spim_config->qspi_slave_latency);
 
+#ifdef CONFIG_NRF70_SPI_PM_CLAIM_WHILE_ACTIVE
+	return pm_device_runtime_get(spi_spec.bus);
+#else
 	return 0;
+#endif /* CONFIG_NRF70_SPI_PM_CLAIM_WHILE_ACTIVE */
 }
 
 int spim_deinit(void)
 {
+#ifdef CONFIG_NRF70_SPI_PM_CLAIM_WHILE_ACTIVE
+	(void)pm_device_runtime_put(spi_spec.bus);
+#endif /* CONFIG_NRF70_SPI_PM_CLAIM_WHILE_ACTIVE */
+
 	return spi_release_dt(&spi_spec);
 }
 


### PR DESCRIPTION
Add an option to keep the SPI bus in `ACTIVE` while the WiFi module is powered up. Previous testing has shown transitioning the bus on every SPI transaction to reduce UDP uplink throughput from 8 Mbps to 6 Mbps.

This is more relevant now since #93720 enables PM device runtime for all communications interfaces with no way to disable on a per-instance basis in devicetree. Not that disabling it entirely is a desirable configuration anyway, since we do want the bus idled while the modem is not powered.