### PR TITLE
support nxp wifi with custom host platform

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -26,6 +26,22 @@ config HEAP_MEM_POOL_ADD_SIZE_NXP_WIFI
 config WIFI_MGMT_SCAN_CHAN_MAX_MANUAL
 	default 50
 
+config NXP_MONOLITHIC_WIFI
+	bool "WiFi firmware monolithic build"
+	default y
+	depends on !NXP_WIFI_CUSTOM
+	help
+	   If enabled, the WiFi firmware used by the device will be linked with the
+	   application directly.
+
+config NXP_WIFI_CUSTOM_HOST
+	bool "Custom host platform for NXP Wi-Fi"
+	default y if BOARD_NATIVE_SIM
+	default y if !HAS_MCUX && !HAS_IMX_HAL && !HAS_NXP_S32_HAL
+	depends on !NXP_RW610
+	help
+	  Customize host platform eg. non NXP host platform for NXP Wi-Fi.
+
 config NXP_WIFI_CUSTOM
 	bool "Custom NXP Wi-Fi part"
 	help
@@ -830,8 +846,8 @@ config NXP_WIFI_CSI_AMI
 config NXP_WIFI_RESET
 	bool "Wi-Fi reset"
 	default y
-	imply NXP_WIFI_IND_DNLD if NXP_IW610
-	imply NXP_WIFI_IND_RESET if NXP_IW610
+	imply NXP_WIFI_IND_DNLD if NXP_IW610 && !NXP_WIFI_CUSTOM_HOST
+	imply NXP_WIFI_IND_RESET if NXP_IW610 && !NXP_WIFI_CUSTOM_HOST
 	help
 	  This option is used to enable/disable/reset Wi-Fi.
 

--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -111,6 +111,7 @@ int nxp_wifi_wlan_event_callback(enum wlan_event_reason reason, void *data)
 	struct in_addr base_addr;
 	struct in_addr netmask_addr;
 	struct wifi_ap_sta_info ap_sta_info = { 0 };
+	sta_node *con_sta_info;
 #endif
 
 	LOG_DBG("WLAN: received event %d", reason);
@@ -293,7 +294,7 @@ int nxp_wifi_wlan_event_callback(enum wlan_event_reason reason, void *data)
 #endif
 		break;
 	case WLAN_REASON_UAP_CLIENT_ASSOC:
-		sta_node *con_sta_info = (sta_node *)data;
+		con_sta_info = (sta_node *)data;
 
 		if (con_sta_info->is_11n_enabled) {
 			ap_sta_info.link_mode = WIFI_4;

--- a/modules/hal_nxp/CMakeLists.txt
+++ b/modules/hal_nxp/CMakeLists.txt
@@ -34,4 +34,8 @@ else()
   add_subdirectory_ifdef(CONFIG_HAS_MCUX mcux)
 endif()
 
+if(CONFIG_WIFI_NXP)
+  add_subdirectory(wifi)
+endif()
+
 add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR}/zephyr/src hal_nxp)

--- a/modules/hal_nxp/mcux/CMakeLists.txt
+++ b/modules/hal_nxp/mcux/CMakeLists.txt
@@ -135,11 +135,6 @@ add_subdirectory_ifdef(CONFIG_IEEE802154_KW41Z
   ${CMAKE_CURRENT_BINARY_DIR}/middleware/wireless/framework
   )
 
-add_subdirectory_ifdef(CONFIG_WIFI_NXP
-  ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/middleware/wifi_nxp
-  ${CMAKE_CURRENT_BINARY_DIR}/middleware/wifi_nxp
-  )
-
 add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR}/mcux/middleware
   ${CMAKE_CURRENT_BINARY_DIR}/middleware
   )

--- a/modules/hal_nxp/mcux/Kconfig.mcux
+++ b/modules/hal_nxp/mcux/Kconfig.mcux
@@ -73,12 +73,6 @@ config NXP_FW_LOADER
 	   The firmware loader is used to load firmwares to embedded transceivers.
 	   It is needed to enable connectivity features.
 
-config NXP_MONOLITHIC_WIFI
-	bool "WiFi firmware monolithic build"
-	help
-	   If enabled, the WiFi firmware used by the device will be linked with the
-	   application directly.
-
 config NXP_MONOLITHIC_NBU
 	bool "Narrowband Unit (BT/15.4) firmware monolithic build"
 	depends on HAS_NXP_MONOLITHIC_NBU

--- a/modules/hal_nxp/wifi/CMakeLists.txt
+++ b/modules/hal_nxp/wifi/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(
+  ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/middleware/wifi_nxp
+  ${CMAKE_CURRENT_BINARY_DIR}/middleware/wifi_nxp
+)
+
+add_subdirectory(
+  ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/mcux-sdk-ng/components/osa
+  ${CMAKE_CURRENT_BINARY_DIR}/components/osa
+)
+
+add_subdirectory(
+  ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/mcux-sdk-ng/components/wifi_bt_module
+  ${CMAKE_CURRENT_BINARY_DIR}/components/wifi_bt_module
+)
+
+zephyr_compile_definitions_ifdef(CONFIG_NXP_WIFI_CUSTOM_HOST
+  SDK_COMPONENT_DEPENDENCY_FSL_COMMON=0
+)
+
+set(CONFIG_MCUX_COMPONENT_component.wifi_bt_module.tx_pwr_limits ON)
+set(CONFIG_MCUX_COMPONENT_component.osa_template_config ON)
+set(CONFIG_MCUX_COMPONENT_component.osa_zephyr ON)
+set(CONFIG_MCUX_COMPONENT_component.osa_interface ON)

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: d622701b7fced803edb96b979fb97c10e8518759
+      revision: e8a0f68e8d5797ac174580b872df379bdf2f5c4a
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
manifest: update hal_nxp revision to support custom host platform for WiFi
    
    Add CONFIG_NXP_WIFI_CUSTOM_HOST to customize host platform for
    NXP Wi-Fi card.

wifi: nxp: support nxp wifi with custom host platform
    
    Add CONFIG_NXP_WIFI_CUSTOM_HOST to build with custom
    host platform.