### PR TITLE
drivers: flash: flexspi_nor: Add RDSR2 command to quad enable LUT

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -583,6 +583,15 @@ static int flash_flexspi_nor_quad_enable(struct flash_flexspi_nor_data *data,
 		flexspi_lut[SCRATCH_CMD][0] = FLEXSPI_LUT_SEQ(
 				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_RDSR,
 				kFLEXSPI_Command_READ_SDR, kFLEXSPI_1PAD, 0x1);
+		flexspi_lut[SCRATCH_CMD][1] = FLEXSPI_LUT_SEQ(
+				kFLEXSPI_Command_JUMP_ON_CS, kFLEXSPI_1PAD, 0x2,
+				kFLEXSPI_Command_JUMP_ON_CS, kFLEXSPI_1PAD, 0x2);
+		flexspi_lut[SCRATCH_CMD][2] = FLEXSPI_LUT_SEQ(
+				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_RDSR2,
+				kFLEXSPI_Command_READ_SDR, kFLEXSPI_1PAD, 0x1);
+		flexspi_lut[SCRATCH_CMD][3] = FLEXSPI_LUT_SEQ(
+				kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0,
+				kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0);
 		flexspi_lut[SCRATCH_CMD2][0] = FLEXSPI_LUT_SEQ(
 				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_WRSR,
 				kFLEXSPI_Command_WRITE_SDR, kFLEXSPI_1PAD, 0x1);


### PR DESCRIPTION
Fixes: #101032

When qer is S2B1v1 or S2B1v4, reading Status Register 1 and Status Register 2 requires different opcodes, and writing Status Register 1/2 requires two bytes in a single write. Add the Read Status Register 2 command sequence to the LUT used by the quad-enable function, and ensure the write operation sends two bytes (SR1|SR2) when setting the QE bit.