### PR TITLE
net: dns: Make sure IPv6 address can be stored to a buf

### DIFF
--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -81,6 +81,7 @@ config DNS_RESOLVER_MAX_NAME_LEN
 	int "Max length of the resolved DNS name"
 	range 1 $(UINT8_MAX)
 	default 128 if DNS_SD
+	default 46 if NET_IPV6
 	default 20
 	help
 	  Max length of a buffer that is used to store information returned from


### PR DESCRIPTION
The CONFIG_DNS_RESOLVER_MAX_NAME_LEN should be large enough so that IPv6 address can be stored into it. So increase the max name length to 46 if IPv6 is enabled.