### PR TITLE
manifest: Update nrf_wifi with latest rpu bins

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -808,6 +808,32 @@ config NRF_WIFI_FEAT_WMM
 	help
 	  This option controls disable/enable of the WMM (Wireless Multi-Media) feature.
 
+config NRF_WIFI_QOS_NOACK_POLICY
+	bool "QoS No-ACK policy for Tx packets"
+	help
+	  Enable this option to set No-ACK policy for Tx packets with a specific TID.
+	  When enabled, all Tx frames for the configured TID will be marked with
+	  the No-ACK policy flag, indicating that the receiver should not send
+	  ACK frames for these packets.
+	  Use with caution:
+	  Enabling No-ACK for BE (Best Effort) or BK (Background) can cause link
+	  issues (ARP/IP failures due to no retries).
+
+	  Recommended usage:
+	  Ideally for VI (Video) or VO (Voice) access category.
+	  The application must correctly encode TID via TOS to activate this feature.
+
+if NRF_WIFI_QOS_NOACK_POLICY
+config NRF_WIFI_QOS_NOACK_POLICY_TID
+	int "TID (Traffic Identifier) for No-ACK policy"
+	range 0 7
+	default 0
+	help
+	  Specify the TID (Traffic Identifier) for which No-ACK policy should be applied.
+	  TID values range from 0 to 7, corresponding to different QoS priority levels.
+	  All Tx frames with this TID will be marked with the No-ACK policy flag.
+endif # NRF_WIFI_QOS_NOACK_POLICY
+
 choice NRF_WIFI_PS_DATA_RETRIEVAL_MECHANISM
 	prompt "Power save data retrieval mechanism"
 	default NRF_WIFI_PS_POLL_BASED_RETRIEVAL

--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
@@ -290,8 +290,10 @@ static inline enum wifi_security_type drv_to_wifi_mgmt(int drv_security_type)
 		return WIFI_SECURITY_TYPE_PSK;
 	case NRF_WIFI_WPA2_256:
 		return WIFI_SECURITY_TYPE_PSK_SHA256;
-	case NRF_WIFI_WPA3:
+	case NRF_WIFI_WPA3_HNP:
 		return WIFI_SECURITY_TYPE_SAE;
+	case NRF_WIFI_WPA3_H2E:
+		return WIFI_SECURITY_TYPE_SAE_H2E;
 	case NRF_WIFI_WAPI:
 		return WIFI_SECURITY_TYPE_WAPI;
 	case NRF_WIFI_EAP:

--- a/west.yml
+++ b/west.yml
@@ -347,7 +347,7 @@ manifest:
       revision: 0f0c43748111c65800c6920f1c0690676423a351
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 9f09f0785f9fc716514d8956a2a446021697400c
+      revision: eaf223da0c3f987caa1156cbed54b513bee4ba37
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 5efe7974f9546582e99f5a842a816ea4b65f5227

--- a/west.yml
+++ b/west.yml
@@ -291,7 +291,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 5af8b179632c602b8a05c34c74a50dda3d546eaa
+      revision: 1a2fbb7910f23822a785294eab9f4922c6119711
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
   1. Fixes an issue in UMAC where valid P2P devices were filtered during a connect scan due to strict SSID length matching.
   2. P2P NOA Bug Fix.
   3. Linker issue fix in Raw modes.
   4. LMAC BIMG offset change.
   4. RPU Version update from 1.2.14.6 to 1.2.14.7.