### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -339,7 +339,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 5eec7aca321735f5fc8e3e7c79e162f0e9810b16
+      revision: 0f0c43748111c65800c6920f1c0690676423a351
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 9f09f0785f9fc716514d8956a2a446021697400c


### PR DESCRIPTION
Update the HW models module to:
0f0c43748111c65800c6920f1c0690676423a351

Including the following:
0f0c437 nrfx: Replace nrfx_gppi_domain_id_get() (requires new nrfx) 1bead00 nrf_ppi: Add support for NRF_PPI_ENDPOINT_IS_EVENT in simulation 9f11c2f
NHW_misc: Add API to convert from/to simulated addr to real HW ones

Note: This requires an nrfx 4.0.x which is newer than 2025/12/03, 
i.e. modules/hal/nordic 0dbbf4794156ca09dc2d4bad8c42dcdb54acd662 or newer
which is has been used in Zephyr main since Zephyr's 242bf65d1d5432d43821b44f146e35d63c5334f0