### PR TITLE
Bluetooth: HFP AG: Add feature support check for voice recognition

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -5286,6 +5286,13 @@ int bt_hfp_ag_voice_recognition(struct bt_hfp_ag *ag, bool activate)
 	}
 	hfp_ag_unlock(ag);
 
+	feature = BOTH_SUPT_FEAT(ag, BT_HFP_HF_FEATURE_VOICE_RECG,
+				 BT_HFP_AG_FEATURE_VOICE_RECG);
+	if (!feature) {
+		LOG_WRN("VR feature is unsupported");
+		return -ENOTSUP;
+	}
+
 	if (activate && atomic_test_bit(ag->flags, BT_HFP_AG_VRE_ACTIVATE)) {
 		LOG_WRN("VR has been activated");
 		return -ENOTSUP;


### PR DESCRIPTION
Add feature support validation in `bt_hfp_ag_voice_recognition()` to verify that both HF and AG support voice recognition feature before attempting to activate/deactivate it.

This prevents attempting voice recognition operations when the feature is not supported by either the Hands-Free device or the Audio Gateway, returning -ENOTSUP in such cases.