### PR TITLE
doc: develop: Link to West Projects index

### DIFF
--- a/doc/develop/index.rst
+++ b/doc/develop/index.rst
@@ -17,6 +17,7 @@ Developing with Zephyr
    flash_debug/index
    modules.rst
    west/index
+   manifest/index.rst
    test/index
    sca/index
    toolchains/index


### PR DESCRIPTION
Add a link to `doc/develop/manifest/`, which was introduced in commit dd7532dcf but never linked from the parent page.