### PR TITLE
tests: drivers: spi: Run spi_loopback on H20 FLPR using fast instance

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &uart131;
+	};
+};
+
+&pinctrl {
+	spi120_default: spi120_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 7, 6)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
+		};
+	};
+
+	spi120_sleep: spi120_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
+				<NRF_PSEL(SPIM_MISO, 7, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
+			low-power-enable;
+		};
+	};
+
+	uart131_default_alt: uart131_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 11)>,
+				<NRF_PSEL(UART_RX, 1, 10)>,
+				<NRF_PSEL(UART_RTS, 1, 9)>,
+				<NRF_PSEL(UART_CTS, 1, 7)>;
+		};
+	};
+
+	uart131_sleep_alt: uart131_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 6)>,
+				<NRF_PSEL(UART_RX, 1, 10)>,
+				<NRF_PSEL(UART_RTS, 1, 9)>,
+				<NRF_PSEL(UART_CTS, 1, 7)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi120 {
+	status = "okay";
+	pinctrl-0 = <&spi120_default>;
+	pinctrl-1 = <&spi120_sleep>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	zephyr,pm-device-runtime-auto;
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
+	};
+
+	dut_fast: fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+};
+
+&uart120 {
+	status = "disabled";
+};
+
+&uart131 {
+	status = "okay";
+	pinctrl-0 = <&uart131_default_alt>;
+	pinctrl-1 = <&uart131_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	current-speed = <115200>;
+	hw-flow-control;
+};
+
+&gpiote130 {
+	status = "okay";
+	interrupts = <0x69 0x1>;
+};

--- a/tests/drivers/spi/spi_loopback/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -9,3 +9,12 @@
 	status = "reserved";
 	interrupt-parent = <&cpuppr_clic>;
 };
+
+&spi120 {
+	status = "reserved";
+	interrupt-parent = <&cpuflpr_clic>;
+};
+
+&uart120 {
+	status = "disabled";
+};


### PR DESCRIPTION
Extend SPI driver testing with configuration that executes on nrf54h20 cpuflpr core.

FLPR core may only use fast SPI instances (no interrupt routed from slow instances).