### PR TITLE
bluetooth: classic: avdtp: fix the early callback of stream established

### DIFF
--- a/include/zephyr/bluetooth/classic/avdtp.h
+++ b/include/zephyr/bluetooth/classic/avdtp.h
@@ -132,20 +132,52 @@ enum bt_avdtp_recovery_type {
 	BT_ADVTP_RECOVERY_TYPE_RFC2733 = 0x01,
 };
 
+struct bt_avdtp_sep;
+
+/** @brief avdtp sep operations structure */
+struct bt_avdtp_sep_ops {
+	/** @brief Stream End Point (SEP) l2cap connected callback
+	 *
+	 *  If this callback is provided it will be called whenever the
+	 *  stream l2cap connection completes.
+	 *
+	 *  @param sep The sep that has been connected
+	 */
+	void (*connected)(struct bt_avdtp_sep *sep);
+
+	/** @brief Stream End Point (SEP) l2cap disconnected callback
+	 *
+	 *  If this callback is provided it will be called whenever the
+	 *  stream l2cap channel is disconnected, including when a
+	 *  connection gets rejected.
+	 *
+	 *  @param sep The sep that has been disconnected
+	 */
+	void (*disconnected)(struct bt_avdtp_sep *sep);
+
+	/** @brief Stream End Point (SEP) received data
+	 *
+	 *  If this callback is provided it will be called whenever the
+	 *  stream l2cap channel receives data.
+	 *
+	 *  @param sep The sep that has received data.
+	 *  @param buf The data buf
+	 */
+	void (*media_data_cb)(struct bt_avdtp_sep *sep, struct net_buf *buf);
+};
+
 /** @brief AVDTP Stream End Point */
 struct bt_avdtp_sep {
 	/** Stream End Point information */
 	struct bt_avdtp_sep_info sep_info;
 	/** Media Transport Channel*/
 	struct bt_l2cap_br_chan chan;
-	/** the endpoint media data */
-	void (*media_data_cb)(struct bt_avdtp_sep *sep, struct net_buf *buf);
 	/* semaphore for lock/unlock */
 	struct k_sem sem_lock;
 	/** avdtp session */
 	struct bt_avdtp *session;
-	/** endpoint becomes idle */
-	int (*endpoint_released)(struct bt_avdtp_sep *sep);
+	/** sep ops */
+	const struct bt_avdtp_sep_ops *ops;
 	/** delay worker for disconnecting l2cap media channel */
 	struct k_work_delayable _delay_work;
 	/** delay_work_state */

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -192,10 +192,17 @@ static bool avdtp_media_chan_valid(struct bt_avdtp_sep *sep)
 	return false;
 }
 
+static void avdtp_endpoint_established(struct bt_avdtp_sep *sep)
+{
+	if (sep->ops != NULL && sep->ops->connected != NULL) {
+		sep->ops->connected(sep);
+	}
+}
+
 static void avdtp_endpoint_released(struct bt_avdtp_sep *sep)
 {
-	if (sep->endpoint_released != NULL) {
-		sep->endpoint_released(sep);
+	if (sep->ops != NULL && sep->ops->disconnected != NULL) {
+		sep->ops->disconnected(sep);
 	}
 }
 
@@ -279,6 +286,8 @@ void bt_avdtp_media_l2cap_connected(struct bt_l2cap_chan *chan)
 			req->func(req, NULL);
 		}
 	}
+
+	avdtp_endpoint_established(sep);
 }
 
 void bt_avdtp_media_l2cap_disconnected(struct bt_l2cap_chan *chan)
@@ -324,8 +333,8 @@ int bt_avdtp_media_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	/* media data is received */
 	struct bt_avdtp_sep *sep = CONTAINER_OF(chan, struct bt_avdtp_sep, chan.chan);
 
-	if (sep->media_data_cb != NULL) {
-		sep->media_data_cb(sep, buf);
+	if (sep->ops != NULL && sep->ops->media_data_cb != NULL) {
+		sep->ops->media_data_cb(sep, buf);
 	}
 	return 0;
 }


### PR DESCRIPTION
Refactored the Stream End Point (SEP) callback mechanism to use a unified bt_avdtp_sep_ops structure instead of individual function pointers. This change consolidates the connected, disconnected, and media_data_cb callbacks into a single operations structure. The stream established callback is called when the stream l2cap is connected not the open cmd is finished.