### PR TITLE
drivers: sensor: Update ICM45686 driver to use TDK HAL

### DIFF
--- a/drivers/sensor/tdk/icm45686/CMakeLists.txt
+++ b/drivers/sensor/tdk/icm45686/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 zephyr_library()
 zephyr_library_include_directories(.)
+zephyr_library_include_directories(${ZEPHYR_HAL_TDK_MODULE_DIR}/icm456xx)
+
 zephyr_library_sources(
   icm45686.c
   icm45686_bus.c
@@ -13,6 +15,9 @@ zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API
 )
 zephyr_library_sources_ifdef(CONFIG_ICM45686_TRIGGER
   icm45686_trigger.c
+)
+zephyr_library_sources_ifdef(CONFIG_TDK_APEX
+  icm45686_apex.c
 )
 zephyr_library_sources_ifdef(CONFIG_ICM45686_STREAM
   icm45686_stream.c

--- a/drivers/sensor/tdk/icm45686/Kconfig
+++ b/drivers/sensor/tdk/icm45686/Kconfig
@@ -5,13 +5,46 @@
 menuconfig ICM45686
 	bool "ICM45686 High-precision 6-Axis Motion Tracking Device"
 	default y
-	depends on DT_HAS_INVENSENSE_ICM45686_ENABLED
-	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),spi)
-	select SPI_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),spi)
-	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i2c)
-	select I2C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i2c)
-	select I3C if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i3c)
-	select I3C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i3c)
+	depends on DT_HAS_INVENSENSE_ICM45605_ENABLED || \
+		DT_HAS_INVENSENSE_ICM45605S_ENABLED || \
+		DT_HAS_INVENSENSE_ICM45686_ENABLED || \
+		DT_HAS_INVENSENSE_ICM45686S_ENABLED || \
+		DT_HAS_INVENSENSE_ICM45688P_ENABLED
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605),spi) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605S),spi) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),spi) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686S),spi) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45688P),spi)
+	select SPI_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605),spi) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605S),spi) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),spi) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686S),spi) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45688P),spi)
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605),i2c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605S),i2c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i2c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686S),i2c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45688P),i2c)
+	select I2C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605),i2c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605S),i2c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i2c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686S),i2c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45688P),i2c)
+	select I3C if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605),i3c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605S),i3c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i3c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686S),i3c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45688P),i3c)
+	select I3C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605),i3c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605S),i3c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i3c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686S),i3c) \
+		|| $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45688P),i3c)
+	select USE_EMD_ICM45605 if DT_HAS_INVENSENSE_ICM45605_ENABLED
+	select USE_EMD_ICM45605S if DT_HAS_INVENSENSE_ICM45605S_ENABLED
+	select USE_EMD_ICM45686 if DT_HAS_INVENSENSE_ICM45686_ENABLED
+	select USE_EMD_ICM45686S if DT_HAS_INVENSENSE_ICM45686S_ENABLED
+	select USE_EMD_ICM45688P if DT_HAS_INVENSENSE_ICM45688P_ENABLED
 	help
 	  Enable driver for ICM45686 High-precision 6-axis motion
 	  tracking device.
@@ -30,18 +63,31 @@ config ICM45686_TRIGGER_NONE
 config ICM45686_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
-	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686),int-gpios)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45605),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45605S),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686S),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45688P),int-gpios)
 	depends on !ICM45686_STREAM
 	select ICM45686_TRIGGER
+	select TDK_APEX
 
 config ICM45686_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
-	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686),int-gpios)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45605),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45605S),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686S),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45688P),int-gpios)
 	depends on !ICM45686_STREAM
 	select ICM45686_TRIGGER
+	select TDK_APEX
 
 endchoice
+
+config TDK_APEX
+	bool
 
 config ICM45686_TRIGGER
 	bool
@@ -64,8 +110,16 @@ config ICM45686_STREAM
 	bool "Streaming mode"
 	depends on GPIO || \
 		   $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i3c)
-	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686),int-gpios) || \
-		   $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i3c)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45605),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45605S),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686S),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45688P),int-gpios) || \
+		   $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605),i3c) || \
+		   $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45605S),i3c) || \
+		   $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i3c) || \
+		   $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686S),i3c) || \
+		   $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45688P),i3c)
 	help
 	  Enable streaming of sensor data.
 

--- a/drivers/sensor/tdk/icm45686/icm45686_apex.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_apex.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2025 TDK Invensense
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "icm45686.h"
+#include "icm456xx_h/imu/inv_imu.h"
+#include "imu/inv_imu_driver.h"
+#include "imu/inv_imu_edmp.h"
+#include "imu/inv_imu_driver_advanced.h"
+
+int icm45686_apex_enable(inv_imu_device_t *s)
+{
+	int rc = 0;
+	inv_imu_int_state_t int_config;
+	inv_imu_edmp_apex_parameters_t apex_parameters;
+	inv_imu_edmp_int_state_t apex_int_config;
+
+	rc |= icm456xx_get_config_int(s, INV_IMU_INT1, &int_config);
+	int_config.INV_FIFO_THS = INV_IMU_DISABLE;
+	int_config.INV_UI_DRDY = INV_IMU_DISABLE;
+	int_config.INV_EDMP_EVENT = INV_IMU_ENABLE;
+	rc |= icm456xx_set_config_int(s, INV_IMU_INT1, &int_config);
+
+	/* Set EDMP ODR */
+	rc |= icm456xx_edmp_set_frequency(s, DMP_EXT_SEN_ODR_CFG_APEX_ODR_50_HZ);
+
+	/* Set ODR */
+	rc |= icm456xx_set_accel_frequency(s, ACCEL_CONFIG0_ACCEL_ODR_50_HZ);
+
+	/* Set BW = ODR/4 */
+	rc |= icm456xx_set_accel_ln_bw(s, IPREG_SYS2_REG_131_ACCEL_UI_LPFBW_DIV_4);
+
+	/* Select WUOSC clock to have accel in ULP (lowest power mode) */
+	rc |= icm456xx_select_accel_lp_clk(s, SMC_CONTROL_0_ACCEL_LP_CLK_WUOSC);
+
+	/* Set AVG to 1x */
+	rc |= icm456xx_set_accel_lp_avg(s, IPREG_SYS2_REG_129_ACCEL_LP_AVG_1);
+
+	/* Ensure all DMP features are disabled before running init procedure */
+	rc |= icm456xx_edmp_disable_pedometer(s);
+	rc |= icm456xx_edmp_disable_tilt(s);
+	rc |= icm456xx_edmp_disable_tap(s);
+	rc |= icm456xx_edmp_disable(s);
+
+	/* Request DMP to re-initialize APEX */
+	rc |= icm456xx_edmp_recompute_apex_decimation(s);
+
+	/* Configure APEX parameters */
+	rc |= icm456xx_edmp_get_apex_parameters(s, &apex_parameters);
+	apex_parameters.power_save_en = INV_IMU_DISABLE;
+	rc |= icm456xx_adv_disable_wom(s);
+	rc |= icm456xx_edmp_set_apex_parameters(s, &apex_parameters);
+
+	/* Set accel in low-power mode if ODR slower than 800 Hz, otherwise in low-noise mode */
+	rc |= icm456xx_set_accel_mode(s, PWR_MGMT0_ACCEL_MODE_LP);
+
+	/* Wait for accel startup time */
+	k_msleep(10);
+
+	/* Disable all APEX interrupt and enable only the one we need */
+	memset(&apex_int_config, INV_IMU_DISABLE, sizeof(apex_int_config));
+
+	/* Apply interrupt configuration */
+	rc |= icm456xx_edmp_set_config_int_apex(s, &apex_int_config);
+
+	return rc;
+}
+
+int icm45686_apex_fetch_from_dmp(const struct device *dev)
+{
+	struct icm45686_data *data = dev->data;
+	int rc = 0;
+	inv_imu_int_state_t int_state;
+	inv_imu_edmp_int_state_t apex_state = {0};
+
+	/* Read APEX interrupt status */
+	rc |= icm456xx_get_int_status(&data->driver, INV_IMU_INT1, &int_state);
+
+	/* Test Pedometer interrupt */
+	if (int_state.INV_EDMP_EVENT) {
+		uint8_t step_cnt_ovflw = 0;
+		/* Read APEX interrupt status */
+		rc |= icm456xx_edmp_get_int_apex_status(&data->driver, &apex_state);
+
+		/* Pedometer */
+		if (apex_state.INV_STEP_CNT_OVFL) {
+			step_cnt_ovflw = 1;
+		}
+
+		if (apex_state.INV_STEP_DET) {
+			inv_imu_edmp_pedometer_data_t ped_data;
+
+			rc |= icm456xx_edmp_get_pedometer_data(&data->driver, &ped_data);
+			if (rc == INV_IMU_OK) {
+				data->pedometer_cnt = (unsigned long)ped_data.step_cnt +
+						      (step_cnt_ovflw * UINT16_MAX);
+				data->pedometer_activity = ped_data.activity_class;
+				data->pedometer_cadence = ped_data.step_cadence;
+			}
+		}
+
+		/* SMD */
+		if (apex_state.INV_SMD) {
+			data->apex_status = ICM45686_APEX_STATUS_MASK_SMD;
+		}
+
+		/* Tilt */
+		if (apex_state.INV_TILT_DET) {
+			data->apex_status = ICM45686_APEX_STATUS_MASK_TILT;
+		}
+
+		/* Tap & Double Tap */
+		if (apex_state.INV_TAP) {
+			inv_imu_edmp_tap_data_t tap_data;
+
+			icm456xx_edmp_get_tap_data(&data->driver, &tap_data);
+			if (tap_data.double_tap_timing == 0) {
+				data->apex_status = ICM45686_APEX_STATUS_MASK_TAP;
+			} else {
+				data->apex_status = ICM45686_APEX_STATUS_MASK_DOUBLE_TAP;
+			}
+		}
+	}
+
+	return rc;
+}
+
+void icm45686_apex_pedometer_cadence_convert(struct sensor_value *val, uint8_t raw_val,
+					     uint8_t dmp_odr_hz)
+{
+	int64_t conv_val;
+
+	/* Converting u6.2 */
+	conv_val = (int64_t)(dmp_odr_hz << 2) * 1000000 / (raw_val + (raw_val & 0x03));
+	val->val1 = conv_val / 1000000;
+	val->val2 = conv_val % 1000000;
+}
+
+int icm45686_apex_enable_pedometer(const struct device *dev, inv_imu_device_t *s)
+{
+
+	struct icm45686_data *data = dev->data;
+	int rc = 0;
+	inv_imu_edmp_int_state_t apex_int_config;
+
+	data->dmp_odr_hz = 50;
+
+	rc = icm456xx_edmp_get_config_int_apex(s, &apex_int_config);
+	apex_int_config.INV_STEP_CNT_OVFL = INV_IMU_ENABLE;
+	apex_int_config.INV_STEP_DET = INV_IMU_ENABLE;
+	/* Apply interrupt configuration */
+	rc |= icm456xx_edmp_set_config_int_apex(s, &apex_int_config);
+	rc |= icm456xx_edmp_enable_pedometer(s);
+	/* Enable EDMP if at least one feature is enabled */
+	rc |= icm456xx_edmp_enable(s);
+	return rc;
+}
+
+int icm45686_apex_enable_tilt(inv_imu_device_t *s)
+{
+	int rc = 0;
+	inv_imu_edmp_int_state_t apex_int_config;
+
+	rc = icm456xx_edmp_get_config_int_apex(s, &apex_int_config);
+	apex_int_config.INV_TILT_DET = INV_IMU_ENABLE;
+	/* Apply interrupt configuration */
+	rc |= icm456xx_edmp_set_config_int_apex(s, &apex_int_config);
+	rc |= icm456xx_edmp_enable_tilt(s);
+	/* Enable EDMP if at least one feature is enabled */
+	rc |= icm456xx_edmp_enable(s);
+	return rc;
+}
+
+int icm45686_apex_enable_smd(inv_imu_device_t *s)
+{
+	int rc = 0;
+	inv_imu_edmp_int_state_t apex_int_config;
+
+	rc = icm456xx_edmp_get_config_int_apex(s, &apex_int_config);
+	apex_int_config.INV_SMD = INV_IMU_ENABLE;
+	/* Apply interrupt configuration */
+	rc |= icm456xx_edmp_set_config_int_apex(s, &apex_int_config);
+	rc |= icm456xx_edmp_enable_smd(s);
+	/* Enable EDMP if at least one feature is enabled */
+	rc |= icm456xx_edmp_enable(s);
+
+	return rc;
+}
+
+int icm45686_apex_enable_wom(inv_imu_device_t *s)
+{
+	int rc = 0;
+
+	rc |= icm456xx_adv_configure_wom(s, DEFAULT_WOM_THS_MG, DEFAULT_WOM_THS_MG,
+					 DEFAULT_WOM_THS_MG, TMST_WOM_CONFIG_WOM_INT_MODE_ANDED,
+					 TMST_WOM_CONFIG_WOM_INT_DUR_1_SMPL);
+	rc |= icm456xx_adv_enable_wom(s);
+
+	return rc;
+}
+
+int icm45686_apex_enable_tap(inv_imu_device_t *s)
+{
+	int rc = 0;
+	inv_imu_edmp_int_state_t apex_int_config;
+
+	rc = icm456xx_edmp_get_config_int_apex(s, &apex_int_config);
+	apex_int_config.INV_TAP = INV_IMU_ENABLE;
+	/* Apply interrupt configuration */
+	rc |= icm456xx_edmp_set_config_int_apex(s, &apex_int_config);
+	rc |= icm456xx_edmp_enable_tap(s);
+	/* Enable EDMP if at least one feature is enabled */
+	rc |= icm456xx_edmp_enable(s);
+	return rc;
+}

--- a/drivers/sensor/tdk/icm45686/icm45686_bus.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_bus.c
@@ -7,9 +7,8 @@
 
 #include "icm45686_bus.h"
 
-int icm45686_prep_reg_read_rtio_async(const struct icm45686_bus *bus,
-				    uint8_t reg, uint8_t *buf, size_t size,
-				    struct rtio_sqe **out)
+int icm45686_prep_reg_read_rtio_async(const struct icm45686_bus *bus, uint8_t reg, uint8_t *buf,
+				      size_t size, struct rtio_sqe **out)
 {
 	struct rtio *ctx = bus->rtio.ctx;
 	struct rtio_iodev *iodev = bus->rtio.iodev;
@@ -40,9 +39,8 @@ int icm45686_prep_reg_read_rtio_async(const struct icm45686_bus *bus,
 	return 2;
 }
 
-int icm45686_prep_reg_write_rtio_async(const struct icm45686_bus *bus,
-				     uint8_t reg, const uint8_t *buf, size_t size,
-				     struct rtio_sqe **out)
+int icm45686_prep_reg_write_rtio_async(const struct icm45686_bus *bus, uint8_t reg,
+				       const uint8_t *buf, size_t size, struct rtio_sqe **out)
 {
 	struct rtio *ctx = bus->rtio.ctx;
 	struct rtio_iodev *iodev = bus->rtio.iodev;

--- a/drivers/sensor/tdk/icm45686/icm45686_bus.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_bus.h
@@ -13,8 +13,8 @@
 #include <zephyr/drivers/i3c.h>
 
 enum icm45686_bus_type {
-	ICM45686_BUS_SPI,
 	ICM45686_BUS_I2C,
+	ICM45686_BUS_SPI,
 	ICM45686_BUS_I3C,
 };
 

--- a/drivers/sensor/tdk/icm45686/icm45686_decoder.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_decoder.h
@@ -13,12 +13,9 @@
 #include <zephyr/drivers/sensor.h>
 #include "icm45686.h"
 
-int icm45686_encode(const struct device *dev,
-		    const struct sensor_chan_spec *const channels,
-		    const size_t num_channels,
-		    uint8_t *buf);
+int icm45686_encode(const struct device *dev, const struct sensor_chan_spec *const channels,
+		    const size_t num_channels, uint8_t *buf);
 
-int icm45686_get_decoder(const struct device *dev,
-			 const struct sensor_decoder_api **decoder);
+int icm45686_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder);
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ICM45686_DECODER_H_ */

--- a/drivers/sensor/tdk/icm45686/icm45686_reg.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_reg.h
@@ -15,119 +15,71 @@
 /* Address value has a read bit */
 #define REG_READ_BIT BIT(7)
 
-/* Registers */
-/* Register Bank 0 */
-#define REG_ACCEL_DATA_X1_UI			0x00
-#define REG_ACCEL_DATA_X0_UI			0x01
-#define REG_ACCEL_DATA_Y1_UI			0x02
-#define REG_ACCEL_DATA_Y0_UI			0x03
-#define REG_ACCEL_DATA_Z1_UI			0x04
-#define REG_ACCEL_DATA_Z0_UI			0x05
-#define REG_GYRO_DATA_X1_UI			0x06
-#define REG_GYRO_DATA_X0_UI			0x07
-#define REG_GYRO_DATA_Y1_UI			0x08
-#define REG_GYRO_DATA_Y0_UI			0x09
-#define REG_GYRO_DATA_Z1_UI			0x0A
-#define REG_GYRO_DATA_Z0_UI			0x0B
-#define REG_TEMP_DATA1_UI			0x0C
-#define REG_TEMP_DATA0_UI			0x0D
-#define REG_PWR_MGMT0				0x10
-#define REG_FIFO_COUNT_0			0x12
-#define REG_FIFO_COUNT_1			0x13
-#define REG_FIFO_DATA				0x14
-#define REG_INT1_CONFIG0			0x16
-#define REG_INT1_CONFIG1			0x17
-#define REG_INT1_CONFIG2			0x18
-#define REG_INT1_STATUS0			0x19
-#define REG_INT1_STATUS1			0x1A
-#define REG_ACCEL_CONFIG0			0x1B
-#define REG_GYRO_CONFIG0			0x1C
-#define REG_FIFO_CONFIG0			0x1D
-#define REG_FIFO_CONFIG1_0			0x1E
-#define REG_FIFO_CONFIG1_1			0x1F
-#define REG_FIFO_CONFIG2			0x20
-#define REG_FIFO_CONFIG3			0x21
-#define REG_FIFO_CONFIG4			0x22
-#define REG_DRIVE_CONFIG0			0x32
-#define REG_DRIVE_CONFIG1			0x33
-#define REG_WHO_AM_I				0x72
-#define REG_IREG_ADDR_15_8			0x7C
-#define REG_IREG_ADDR_7_0			0x7D
-#define REG_IREG_DATA				0x7E
-#define REG_MISC2				0x7F
-
-/* User Bank IPREG_SYS1 - Gyro-related config settings */
-#define REG_IPREG_SYS1_OFFSET			0xA400
-#define REG_IPREG_SYS1_REG_172			0xAC
-
-/* User Bank IPREG_SYS2 - Accel-related config settings */
-#define REG_IPREG_SYS2_OFFSET			0xA500
-#define REG_IPREG_SYS2_REG_131			0x83
-
 /* Helper Macros for register manipulation */
-#define REG_PWR_MGMT0_ACCEL_MODE(val)			((val) & BIT_MASK(2))
-#define REG_PWR_MGMT0_GYRO_MODE(val)			(((val) & BIT_MASK(2)) << 2)
+#define REG_PWR_MGMT0_ACCEL_MODE(val) ((val) & BIT_MASK(2))
+#define REG_PWR_MGMT0_GYRO_MODE(val)  (((val) & BIT_MASK(2)) << 2)
 
-#define REG_ACCEL_CONFIG0_ODR(val)			((val) & BIT_MASK(4))
-#define REG_ACCEL_CONFIG0_FS(val)			(((val) & BIT_MASK(3)) << 4)
+#define REG_ACCEL_CONFIG0_ODR(val) ((val) & BIT_MASK(4))
+#define REG_ACCEL_CONFIG0_FS(val)  (((val) & BIT_MASK(3)) << 4)
 
-#define REG_GYRO_CONFIG0_ODR(val)			((val) & BIT_MASK(4))
-#define REG_GYRO_CONFIG0_FS(val)			(((val) & BIT_MASK(4)) << 4)
+#define REG_GYRO_CONFIG0_ODR(val) ((val) & BIT_MASK(4))
+#define REG_GYRO_CONFIG0_FS(val)  (((val) & BIT_MASK(4)) << 4)
 
-#define REG_DRIVE_CONFIG0_SPI_SLEW(val)			(((val) & BIT_MASK(2)) << 1)
-#define REG_DRIVE_CONFIG1_I3C_SLEW(val)			(((val) & BIT_MASK(3)) |		   \
-							 (((val) & BIT_MASK(3)) << 3))
+#define REG_DRIVE_CONFIG0_SPI_SLEW(val) (((val) & BIT_MASK(2)) << 1)
+#define REG_DRIVE_CONFIG1_I3C_SLEW(val) (((val) & BIT_MASK(3)) | (((val) & BIT_MASK(3)) << 3))
+#define REG_MISC2_SOFT_RST(val)         ((val << 1) & BIT(1))
 
-#define REG_MISC2_SOFT_RST(val)				((val << 1) & BIT(1))
+#define REG_IPREG_SYS1_REG_172_GYRO_LPFBW_SEL(val) (val & BIT_MASK(3))
 
-#define REG_IPREG_SYS1_REG_172_GYRO_LPFBW_SEL(val)	(val & BIT_MASK(3))
+#define REG_IPREG_SYS2_REG_131_ACCEL_LPFBW_SEL(val) (val & BIT_MASK(3))
 
-#define REG_IPREG_SYS2_REG_131_ACCEL_LPFBW_SEL(val)	(val & BIT_MASK(3))
+#define REG_INT1_CONFIG0_STATUS_EN_DRDY(val)      (((val) & BIT_MASK(1)) << 2)
+#define REG_INT1_CONFIG0_STATUS_EN_FIFO_THS(val)  (((val) & BIT_MASK(1)) << 1)
+#define REG_INT1_CONFIG0_STATUS_EN_FIFO_FULL(val) ((val) & BIT_MASK(1))
 
-#define REG_INT1_CONFIG0_STATUS_EN_DRDY(val)		(((val) & BIT_MASK(1)) << 2)
-#define REG_INT1_CONFIG0_STATUS_EN_FIFO_THS(val)	(((val) & BIT_MASK(1)) << 1)
-#define REG_INT1_CONFIG0_STATUS_EN_FIFO_FULL(val)	((val) & BIT_MASK(1))
+#define REG_INT1_CONFIG2_EN_OPEN_DRAIN(val)  (((val) & BIT_MASK(1)) << 2)
+#define REG_INT1_CONFIG2_EN_LATCH_MODE(val)  (((val) & BIT_MASK(1)) << 1)
+#define REG_INT1_CONFIG2_EN_ACTIVE_HIGH(val) ((val) & BIT_MASK(1))
 
-#define REG_INT1_CONFIG2_EN_OPEN_DRAIN(val)		(((val) & BIT_MASK(1)) << 2)
-#define REG_INT1_CONFIG2_EN_LATCH_MODE(val)		(((val) & BIT_MASK(1)) << 1)
-#define REG_INT1_CONFIG2_EN_ACTIVE_HIGH(val)		((val) & BIT_MASK(1))
+#define REG_INT1_STATUS0_DRDY(val)      (((val) & BIT_MASK(1)) << 2)
+#define REG_INT1_STATUS0_FIFO_THS(val)  (((val) & BIT_MASK(1)) << 1)
+#define REG_INT1_STATUS0_FIFO_FULL(val) ((val) & BIT_MASK(1))
 
-#define REG_INT1_STATUS0_DRDY(val)			(((val) & BIT_MASK(1)) << 2)
-#define REG_INT1_STATUS0_FIFO_THS(val)			(((val) & BIT_MASK(1)) << 1)
-#define REG_INT1_STATUS0_FIFO_FULL(val)			((val) & BIT_MASK(1))
+#define REG_FIFO_CONFIG0_FIFO_MODE_BYPASS       0
+#define REG_FIFO_CONFIG0_FIFO_MODE_STREAM       1
+#define REG_FIFO_CONFIG0_FIFO_MODE_STOP_ON_FULL 2
 
-#define REG_FIFO_CONFIG0_FIFO_MODE_BYPASS		0
-#define REG_FIFO_CONFIG0_FIFO_MODE_STREAM		1
-#define REG_FIFO_CONFIG0_FIFO_MODE_STOP_ON_FULL		2
+#define REG_FIFO_CONFIG0_FIFO_DEPTH_2K 0x07
+#define REG_FIFO_CONFIG0_FIFO_DEPTH_8K 0x1F
 
-#define REG_FIFO_CONFIG0_FIFO_DEPTH_2K			0x07
-#define REG_FIFO_CONFIG0_FIFO_DEPTH_8K			0x1F
+#define REG_FIFO_CONFIG0_FIFO_MODE(val)  (((val) & BIT_MASK(2)) << 6)
+#define REG_FIFO_CONFIG0_FIFO_DEPTH(val) ((val) & BIT_MASK(6))
 
-#define REG_FIFO_CONFIG0_FIFO_MODE(val)			(((val) & BIT_MASK(2)) << 6)
-#define REG_FIFO_CONFIG0_FIFO_DEPTH(val)		((val) & BIT_MASK(6))
+#define REG_FIFO_CONFIG1_0_FIFO_WM_THS(val) ((val) & BIT_MASK(8))
+#define REG_FIFO_CONFIG1_1_FIFO_WM_THS(val) (((val) >> 8) & BIT_MASK(8))
 
-#define REG_FIFO_CONFIG1_0_FIFO_WM_THS(val)		((val) & BIT_MASK(8))
-#define REG_FIFO_CONFIG1_1_FIFO_WM_THS(val)		(((val) >> 8) & BIT_MASK(8))
+#define REG_FIFO_CONFIG2_FIFO_FLUSH(val)     (((val) & BIT_MASK(1)) << 7)
+#define REG_FIFO_CONFIG2_FIFO_WM_GT_THS(val) (((val) & BIT_MASK(1)) << 3)
 
-#define REG_FIFO_CONFIG2_FIFO_FLUSH(val)		(((val) & BIT_MASK(1)) << 7)
-#define REG_FIFO_CONFIG2_FIFO_WM_GT_THS(val)		(((val) & BIT_MASK(1)) << 3)
-
-#define REG_FIFO_CONFIG3_FIFO_HIRES_EN(val)		(((val) & BIT_MASK(1)) << 3)
-#define REG_FIFO_CONFIG3_FIFO_GYRO_EN(val)		(((val) & BIT_MASK(1)) << 2)
-#define REG_FIFO_CONFIG3_FIFO_ACCEL_EN(val)		(((val) & BIT_MASK(1)) << 1)
-#define REG_FIFO_CONFIG3_FIFO_EN(val)			((val) & BIT_MASK(1))
+#define REG_FIFO_CONFIG3_FIFO_HIRES_EN(val) (((val) & BIT_MASK(1)) << 3)
+#define REG_FIFO_CONFIG3_FIFO_GYRO_EN(val)  (((val) & BIT_MASK(1)) << 2)
+#define REG_FIFO_CONFIG3_FIFO_ACCEL_EN(val) (((val) & BIT_MASK(1)) << 1)
+#define REG_FIFO_CONFIG3_FIFO_EN(val)       ((val) & BIT_MASK(1))
 
 /* Misc. Defines */
 #define WHO_AM_I_ICM45686 0xE9
 
-#define REG_IREG_PREPARE_WRITE_ARRAY(base, reg, val)	{((base) >> 8) & 0xFF, reg, val}
+#define REG_IREG_PREPARE_WRITE_ARRAY(base, reg, val)                                               \
+	{                                                                                          \
+		((base) >> 8) & 0xFF, reg, val                                                     \
+	}
 
-#define FIFO_HEADER_EXT_HEADER_EN(val)			(((val) & BIT_MASK(1)) << 7)
-#define FIFO_HEADER_ACCEL_EN(val)			(((val) & BIT_MASK(1)) << 6)
-#define FIFO_HEADER_GYRO_EN(val)			(((val) & BIT_MASK(1)) << 5)
-#define FIFO_HEADER_HIRES_EN(val)			(((val) & BIT_MASK(1)) << 4)
+#define FIFO_HEADER_EXT_HEADER_EN(val) (((val) & BIT_MASK(1)) << 7)
+#define FIFO_HEADER_ACCEL_EN(val)      (((val) & BIT_MASK(1)) << 6)
+#define FIFO_HEADER_GYRO_EN(val)       (((val) & BIT_MASK(1)) << 5)
+#define FIFO_HEADER_HIRES_EN(val)      (((val) & BIT_MASK(1)) << 4)
 
-#define FIFO_NO_DATA					0x8000
-#define FIFO_COUNT_MAX_HIGH_RES				104
+#define FIFO_NO_DATA            0x8000
+#define FIFO_COUNT_MAX_HIGH_RES 104
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ICM45686_REG_H_ */

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.h
@@ -10,7 +10,6 @@
 
 int icm45686_stream_init(const struct device *dev);
 
-void icm45686_stream_submit(const struct device *dev,
-			    struct rtio_iodev_sqe *iodev_sqe);
+void icm45686_stream_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ICM45686_STREAM_H_ */

--- a/drivers/sensor/tdk/icm45686/icm45686_trigger.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_trigger.h
@@ -14,8 +14,7 @@
 #include <zephyr/drivers/sensor.h>
 
 /* Configure triggers for the icm45686 sensor */
-int icm45686_trigger_set(const struct device *dev,
-			 const struct sensor_trigger *trig,
+int icm45686_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
 			 sensor_trigger_handler_t handler);
 
 /* Initialization for icm45686 Triggers module */

--- a/dts/bindings/sensor/invensense,icm45600-common.yaml
+++ b/dts/bindings/sensor/invensense,icm45600-common.yaml
@@ -1,0 +1,147 @@
+# Copyright (c) 2024 Intel Corporation
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2025 CogniPilot Foundation
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+include: sensor-device.yaml
+
+properties:
+  int-gpios:
+    type: phandle-array
+    description: |
+      The INT signal default configuration is active-high. The
+      property value should ensure the flags properly describe the
+      signal that is presented to the driver.
+
+  accel-pwr-mode:
+    type: int
+    default: 0
+    description: |
+      Specify the default accelerometer power mode.
+      Default is power-up configuration.
+    enum:
+      - 0 # ICM45686_DT_ACCEL_OFF
+      - 2 # ICM45686_DT_ACCEL_LP
+      - 3 # ICM45686_DT_ACCEL_LN
+
+  accel-odr:
+    type: int
+    default: 6
+    description: |
+      Specify the default accelerometer output data rate expressed in samples per second (Hz).
+      Default is power-up configuration.
+    enum:
+      - 3 # ICM45686_DT_ACCEL_ODR_6400 (LN-mode only)
+      - 4 # ICM45686_DT_ACCEL_ODR_3200 (LN-mode only)
+      - 5 # ICM45686_DT_ACCEL_ODR_1600 (LN-mode only)
+      - 6 # ICM45686_DT_ACCEL_ODR_800 (LN-mode only)
+      - 7 # ICM45686_DT_ACCEL_ODR_400
+      - 8 # ICM45686_DT_ACCEL_ODR_200
+      - 9 # ICM45686_DT_ACCEL_ODR_100
+      - 10 # ICM45686_DT_ACCEL_ODR_50
+      - 11 # ICM45686_DT_ACCEL_ODR_25
+      - 12 # ICM45686_DT_ACCEL_ODR_12_5
+      - 13 # ICM45686_DT_ACCEL_ODR_6_25 (LP-mode only)
+      - 14 # ICM45686_DT_ACCEL_ODR_3_125 (LP-mode only)
+      - 15 # ICM45686_DT_ACCEL_ODR_1_5625 (LP-mode only)
+
+  accel-lpf:
+    type: int
+    default: 0
+    description: |
+      Specify the accelerometer low pass filter cut-off frequency
+      as a fraction of the output data rate.
+      Default is power-up configuration.
+    enum:
+      - 0 # ICM45686_DT_ACCEL_LPF_BW_OFF
+      - 1 # ICM45686_DT_ACCEL_LPF_BW_1_4
+      - 2 # ICM45686_DT_ACCEL_LPF_BW_1_8
+      - 3 # ICM45686_DT_ACCEL_LPF_BW_1_16
+      - 4 # ICM45686_DT_ACCEL_LPF_BW_1_32
+      - 5 # ICM45686_DT_ACCEL_LPF_BW_1_64
+      - 6 # ICM45686_DT_ACCEL_LPF_BW_1_128
+
+  gyro-pwr-mode:
+    type: int
+    default: 0
+    description: |
+      Specify the default gyro power mode.
+      Default is power-up configuration.
+    enum:
+      - 0 # ICM42688_DT_GYRO_OFF
+      - 1 # ICM42688_DT_GYRO_STANDBY
+      - 2 # ICM42688_DT_GYRO_LP
+      - 3 # ICM42688_DT_GYRO_LN
+
+  gyro-odr:
+    type: int
+    default: 6
+    description: |
+      Specify the default gyro output data rate expressed in samples per second (Hz).
+      Default is power-up configuration.
+    enum:
+      - 3 # ICM45686_DT_GYRO_ODR_6400 (LN-mode only)
+      - 4 # ICM45686_DT_GYRO_ODR_3200 (LN-mode only)
+      - 5 # ICM45686_DT_GYRO_ODR_1600 (LN-mode only)
+      - 6 # ICM45686_DT_GYRO_ODR_800 (LN-mode only)
+      - 7 # ICM45686_DT_GYRO_ODR_400
+      - 8 # ICM45686_DT_GYRO_ODR_200
+      - 9 # ICM45686_DT_GYRO_ODR_100
+      - 10 # ICM45686_DT_GYRO_ODR_50
+      - 11 # ICM45686_DT_GYRO_ODR_25
+      - 12 # ICM45686_DT_GYRO_ODR_12_5
+      - 13 # ICM45686_DT_GYRO_ODR_6_25 (LP-mode only)
+      - 14 # ICM45686_DT_GYRO_ODR_3_125 (LP-mode only)
+      - 15 # ICM45686_DT_GYRO_ODR_1_5625 (LP-mode only)
+
+  gyro-lpf:
+    type: int
+    default: 0
+    description: |
+      Specify the gyro low pass filter cut-off frequency
+      as a fraction of the output data rate.
+      Default is power-up configuration.
+    enum:
+      - 0 # ICM45686_DT_GYRO_LPF_BW_OFF
+      - 1 # ICM45686_DT_GYRO_LPF_BW_1_4
+      - 2 # ICM45686_DT_GYRO_LPF_BW_1_8
+      - 3 # ICM45686_DT_GYRO_LPF_BW_1_16
+      - 4 # ICM45686_DT_GYRO_LPF_BW_1_32
+      - 5 # ICM45686_DT_GYRO_LPF_BW_1_64
+      - 6 # ICM45686_DT_GYRO_LPF_BW_1_128
+
+  fifo-watermark:
+    type: int
+    default: 0
+    description: |
+      Specify the FIFO watermark level in frame count.
+      Default is power-up configuration (disabled).
+      Valid range: 0 - 104
+
+  fifo-watermark-equals:
+    type: boolean
+    description: |
+      This value changes the FIFO watermark interrupt behavior by only triggering when the number
+      of samples is equal to the threshold (count = watermark).
+
+      Otherwise, it will generate interrupts when the level is greater or equals the FIFO Watermark
+      Threshold (count >= watermark).
+
+  apex:
+    type: string
+    default: "none"
+    description: |
+      APEX (Advanced Pedometer and Event Detection) features. It consists of:
+      * Pedometer: Tracks step count, and provide details such as the cadence and
+                   the estimated activity type (Walk, Run, Unknown).
+      * Tilt Detection: Detects the Tilt when tilting the board with an angle of
+                        30 degrees or more held for 4 seconds.
+      * Wake on Motion (WoM): Detects motion per axis exceeding 195 mg threshold.
+      * Significant Motion Detector (SMD): Detects when the user has moved significantly.
+    enum:
+      - "none"
+      - "pedometer"
+      - "tilt"
+      - "smd"
+      - "wom"

--- a/dts/bindings/sensor/invensense,icm45605-common.yaml
+++ b/dts/bindings/sensor/invensense,icm45605-common.yaml
@@ -7,12 +7,11 @@
 properties:
   accel-fs:
     type: int
-    default: 0
+    default: 1
     description: |
       Specify the accelerometer range in g.
       Default is power-up configuration.
     enum:
-      - 0 # ICM45686_DT_ACCEL_FS_32
       - 1 # ICM45686_DT_ACCEL_FS_16
       - 2 # ICM45686_DT_ACCEL_FS_8
       - 3 # ICM45686_DT_ACCEL_FS_4
@@ -20,12 +19,11 @@ properties:
 
   gyro-fs:
     type: int
-    default: 0
+    default: 1
     description: |
       Specify the gyro range in degrees per second.
       Default is power-up configuration.
     enum:
-      - 0 # ICM45686_DT_GYRO_FS_4000
       - 1 # ICM45686_DT_GYRO_FS_2000
       - 2 # ICM45686_DT_GYRO_FS_1000
       - 3 # ICM45686_DT_GYRO_FS_500

--- a/dts/bindings/sensor/invensense,icm45605-i2c.yaml
+++ b/dts/bindings/sensor/invensense,icm45605-i2c.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45605 High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &i2c0 {
+      ...
+
+      icm45605: icm45605@68 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_16>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_2000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45605"
+
+include: ["i2c-device.yaml", "invensense,icm45605-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45605-i3c.yaml
+++ b/dts/bindings/sensor/invensense,icm45605-i3c.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45605 High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &i3c1 {
+      ...
+
+      icm45605: icm45605@680000046a00000011 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_16>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_2000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45605"
+
+include: ["i3c-device.yaml", "invensense,icm45605-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45605-spi.yaml
+++ b/dts/bindings/sensor/invensense,icm45605-spi.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45605 High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &spi0 {
+      ...
+
+      icm45605: icm45605@0 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_16>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_2000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45605"
+
+include: ["spi-device.yaml", "invensense,icm45605-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45605s-i2c.yaml
+++ b/dts/bindings/sensor/invensense,icm45605s-i2c.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45605S High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &i2c0 {
+      ...
+
+      icm45605s: icm45605s@68 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_16>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_2000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45605s"
+
+include: ["i2c-device.yaml", "invensense,icm45605-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45605s-i3c.yaml
+++ b/dts/bindings/sensor/invensense,icm45605s-i3c.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45605S High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &i3c1 {
+      ...
+
+      icm45605s: icm45605s@680000046a00000011 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_16>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_2000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45605s"
+
+include: ["i3c-device.yaml", "invensense,icm45605-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45605s-spi.yaml
+++ b/dts/bindings/sensor/invensense,icm45605s-spi.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45605S High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &spi0 {
+      ...
+
+      icm45605s: icm45605s@0 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_16>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_2000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45605s"
+
+include: ["spi-device.yaml", "invensense,icm45605-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45686s-i2c.yaml
+++ b/dts/bindings/sensor/invensense,icm45686s-i2c.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45686S High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &i2c0 {
+      ...
+
+      icm45686s: icm45686s@68 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_32>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_4000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45686s"
+
+include: ["i2c-device.yaml", "invensense,icm45686-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45686s-i3c.yaml
+++ b/dts/bindings/sensor/invensense,icm45686s-i3c.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45686S High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &i3c1 {
+      ...
+
+      icm45686s: icm45686s@680000046a00000011 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_32>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_4000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45686s"
+
+include: ["i3c-device.yaml", "invensense,icm45686-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45686s-spi.yaml
+++ b/dts/bindings/sensor/invensense,icm45686s-spi.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45686S High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &spi0 {
+      ...
+
+      icm45686s: icm45686s@0 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_32>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_4000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45686s"
+
+include: ["spi-device.yaml", "invensense,icm45686-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45688p-i2c.yaml
+++ b/dts/bindings/sensor/invensense,icm45688p-i2c.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45688P High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &i2c0 {
+      ...
+
+      icm45688p: icm45688p@68 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_32>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_4000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45688p"
+
+include: ["i2c-device.yaml", "invensense,icm45686-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45688p-i3c.yaml
+++ b/dts/bindings/sensor/invensense,icm45688p-i3c.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45688P High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &i3c1 {
+      ...
+
+      icm45688p: icm45688p@680000046a00000011 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_32>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_4000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45688p"
+
+include: ["i3c-device.yaml", "invensense,icm45686-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45688p-spi.yaml
+++ b/dts/bindings/sensor/invensense,icm45688p-spi.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Croxel Inc.
+# Copyright (c) 2026 TDK Invensense
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45688P High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &spi0 {
+      ...
+
+      icm45688p: icm45688p@0 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_32>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_4000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45688p"
+
+include: ["spi-device.yaml", "invensense,icm45686-common.yaml"]

--- a/modules/hal_tdk/Kconfig
+++ b/modules/hal_tdk/Kconfig
@@ -17,6 +17,41 @@ config USE_EMD_ICM42670
 	depends on DT_HAS_INVENSENSE_ICM42670P_ENABLED \
 		|| DT_HAS_INVENSENSE_ICM42670S_ENABLED
 
+config USE_EMD_ICM45605
+	bool "ICM45605 High Performance 6-Axis MotionTracking IMU"
+	default y
+	imply TDK_HAL
+	depends on ZEPHYR_HAL_TDK_MODULE
+	depends on DT_HAS_INVENSENSE_ICM45605_ENABLED
+
+config USE_EMD_ICM45605S
+	bool "ICM45605S High Performance 6-Axis MotionTracking IMU"
+	default y
+	imply TDK_HAL
+	depends on ZEPHYR_HAL_TDK_MODULE
+	depends on DT_HAS_INVENSENSE_ICM45605S_ENABLED
+
+config USE_EMD_ICM45686
+	bool "ICM45686 High Performance 6-Axis MotionTracking IMU"
+	default y
+	imply TDK_HAL
+	depends on ZEPHYR_HAL_TDK_MODULE
+	depends on DT_HAS_INVENSENSE_ICM45686_ENABLED
+
+config USE_EMD_ICM45686S
+	bool "ICM45686S High Performance 6-Axis MotionTracking IMU"
+	default y
+	imply TDK_HAL
+	depends on ZEPHYR_HAL_TDK_MODULE
+	depends on DT_HAS_INVENSENSE_ICM45686S_ENABLED
+
+config USE_EMD_ICM45688P
+	bool "ICM45688P High Performance 6-Axis MotionTracking IMU"
+	default y
+	imply TDK_HAL
+	depends on ZEPHYR_HAL_TDK_MODULE
+	depends on DT_HAS_INVENSENSE_ICM45688P_ENABLED
+
 config USE_EMD_ICM42370
 	bool "ICM42370P High Performance 3-Axis MotionTracking Accelerometer"
 	default y

--- a/west.yml
+++ b/west.yml
@@ -260,7 +260,7 @@ manifest:
       groups:
         - hal
     - name: hal_tdk
-      revision: 60708f2c7bf078bc9cc3a7737ef955ec572c23e2
+      revision: fa54cb65535b0ed69564423c9e0bf4e7ee47dcb1
       path: modules/hal/tdk
       groups:
         - hal


### PR DESCRIPTION
Subject : Update ICM45686 driver to use TDK HAL

Update : Driver Integration with TDK HAL. We have updated the driver to utilize the TDK HAL. The TDK HAL is implemented based on TDK InvenSense's eMD (Embedded Motion Driver) and significantly streamlines the driver development process.
Also APEX(Advanced Pedometer and Event Detection) features are applied.

Signed-off-by: JuHyun Kim <jh.kim@tdk.com>