### PR TITLE
stm32l562e_dk:  tests: drivers: add support for I2C and update SDMMC and SPI tests

### DIFF
--- a/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
@@ -18,6 +18,7 @@ supported:
   - ble
   - dma
   - usart
+  - arduino_gpio
   - arduino_spi
   - usb_device
   - nvs

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -313,7 +313,7 @@ zephyr_udc0: &usb {
 		     &sdmmc1_cmd_pd2>;
 
 	pinctrl-names = "default";
-
+	idma;
 	cd-gpios = <&gpiof 2 GPIO_ACTIVE_LOW>;
 };
 

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32l562e_dk.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* I2C bus pins are exposed in the Arduino Uno header and Pmod.
+ *
+ *  Bus        SDA               SCL
+ *          Pin   Hdr         Pin   Hdr
+ *  i2c1    PB7   CN11:9      PB6   CN11:10
+ *  i2c2    PB11  CN12:2      PB13  CN4:1
+ *
+ * Short Pin PB7 to PB11, and PB6 to PB13, for the test to pass.
+ */
+
+&i2c1 {
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&i2c2 {
+	pinctrl-0 = <&i2c2_scl_pb13 &i2c2_sda_pb11>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_target_api/testcase.yaml
@@ -17,6 +17,7 @@ tests:
       - stm32f072b_disco
       - stm32f3_disco
       - stm32h573i_dk
+      - stm32l562e_dk
       - stm32n6570_dk/stm32n657xx/sb
       - stm32u083c_dk
       - nucleo_c071rb

--- a/tests/drivers/spi/spi_loopback/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32l562e_dk.overlay
@@ -4,9 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
-	dmas = <&dmamux1 0 12 STM32_DMA_PERIPH_TX>,
-	       <&dmamux1 7 11 STM32_DMA_PERIPH_RX>;
+/* SPI bus pins are exposed in the Arduino Uno header.
+ * SPI3 MISO  Arduino D12
+ * SPI3 MOSI  Arduino D11
+ * Short Pin PB4(D12) to PB5(D11) for the test to pass.
+ */
+
+&spi3 {
+	dmas = <&dmamux1 0 16 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 7 15 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 
 	slow@0 {


### PR DESCRIPTION
This pull request introduces multiple updates to improve STM32L562E-DK board support and ensure successful execution of driver tests in CI:


- I2C Target API Support


- SPI Loopback Test Update


- SDMMC iDMA Enablement

- GPIO basic API Enablement

