### PR TITLE
dts: nordic: nrf54lm20a: remove clockpin from TDM

### DIFF
--- a/dts/vendor/nordic/nrf54lm20a.dtsi
+++ b/dts/vendor/nordic/nrf54lm20a.dtsi
@@ -616,8 +616,6 @@
 				interrupts = <232 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
 				clocks = <&pclk32m>;
-				nordic,clockpin-enable = <NRF_FUN_TDM_SCK_M>,
-							 <NRF_FUN_TDM_MCK>;
 			};
 
 			i2c23: i2c@ed000 {


### PR DESCRIPTION
Not needed as nRF54LM20A does not support clockpin feature in GPIO.