### PR TITLE
stm32: tests: drivers: app_development: vector_table_relocation: exclude STM32F4 series

### DIFF
--- a/boards/st/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/st/stm32f3_disco/stm32f3_disco.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &can1;
+		zephyr,dtcm = &ccm0;
 	};
 
 	leds {

--- a/tests/application_development/vector_table_relocation/testcase.yaml
+++ b/tests/application_development/vector_table_relocation/testcase.yaml
@@ -14,7 +14,11 @@ tests:
 
   application_development.vector_table_relocation.dtcm:
     arch_allow: arm
+    # Exclude STM32F4 series due to architectural constraints. STM32F4 CCM is only accessible
+    # over the D-bus but exception vectors are fetched over the I-bus.
+    # As such, the vector table can't be relocated to CCM.
     filter: CONFIG_CPU_CORTEX_M_HAS_VTOR and dt_chosen_enabled("zephyr,dtcm")
+            and not CONFIG_SOC_SERIES_STM32F4X
     extra_configs:
       - CONFIG_ARM_VECTOR_TABLE_DTCM=y
 


### PR DESCRIPTION
After commit 2d4feea8cea7c93d0b16b9544110ad0adc90e350, CCM RAM was treated as DTCM in the device tree, causing the test to incorrectly attempt relocation to CCM RAM. This results in failure because the CPU cannot fetch vectors from CCM RAM.

Based on RM0090 Rev 21 Page 60&69 

- The Cortex-M4 core always fetches the reset vector using the ICode bus, which only accesses the code region (typically Flash memory).

- The CCM RAM  on STM32F4 series is connected via the D-bus, not the ICode bus, and therefore cannot serve as an executable boot space for the vector table.


Additionally, let's add support for the STM32F3 disco (which also has a CCM RAM) to run this test.

