### PR TITLE
net_buf: Fixed race condition in net_buf_ref() / net_buf_unref() functions

### DIFF
--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -1011,7 +1011,7 @@ struct net_buf {
 	struct net_buf *frags;
 
 	/** Reference count. */
-	uint8_t ref;
+	atomic_uchar_t ref;
 
 	/** Bit-field of buffer flags. */
 	uint8_t flags;

--- a/include/zephyr/sys/atomic.h
+++ b/include/zephyr/sys/atomic.h
@@ -42,6 +42,364 @@ extern "C" {
 #error "CONFIG_ATOMIC_OPERATIONS_* not defined"
 #endif
 
+/*
+ * Atomic unsigned char operations.
+ *
+ * Some architectures (RISC-V, Xtensa, ARC, RX, Cortex-M0/M0+) don't have
+ * native byte-sized atomic instructions. On these platforms, atomic_uchar_t
+ * is typedef'd to atomic_t and we simply use the existing word-sized
+ * atomic functions.
+ *
+ * On architectures with native byte atomics (ARM Cortex-M3+, x86), we use
+ * either C11 stdatomic (when available in C mode) or GCC __atomic_* builtins
+ * (in C++ mode or when C11 is not available).
+ */
+
+#if defined(CONFIG_RISCV) || defined(CONFIG_XTENSA) || \
+	defined(CONFIG_CPU_CORTEX_M0) || defined(CONFIG_CPU_CORTEX_M0PLUS) || \
+	defined(CONFIG_RX) || defined(CONFIG_ARC)
+/*
+ * On platforms without byte-sized atomics, atomic_uchar_t is atomic_t,
+ * so we just map to the existing atomic_* functions using inline functions
+ * (not macros) to avoid unused-value warnings.
+ */
+
+/**
+ * @brief Atomic unsigned char compare-and-set.
+ */
+static inline bool atomic_uchar_cas(atomic_uchar_t *target,
+				    unsigned char old_value,
+				    unsigned char new_value)
+{
+	return atomic_cas(target, (atomic_val_t)old_value,
+			  (atomic_val_t)new_value);
+}
+
+/**
+ * @brief Atomic unsigned char addition.
+ */
+static inline unsigned char atomic_uchar_add(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return (unsigned char)atomic_add(target, (atomic_val_t)value);
+}
+
+/**
+ * @brief Atomic unsigned char subtraction.
+ */
+static inline unsigned char atomic_uchar_sub(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return (unsigned char)atomic_sub(target, (atomic_val_t)value);
+}
+
+/**
+ * @brief Atomic unsigned char increment.
+ */
+static inline unsigned char atomic_uchar_inc(atomic_uchar_t *target)
+{
+	return (unsigned char)atomic_inc(target);
+}
+
+/**
+ * @brief Atomic unsigned char decrement.
+ */
+static inline unsigned char atomic_uchar_dec(atomic_uchar_t *target)
+{
+	return (unsigned char)atomic_dec(target);
+}
+
+/**
+ * @brief Atomic unsigned char get.
+ */
+static inline unsigned char atomic_uchar_get(const atomic_uchar_t *target)
+{
+	return (unsigned char)atomic_get(target);
+}
+
+/**
+ * @brief Atomic unsigned char set.
+ */
+static inline unsigned char atomic_uchar_set(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return (unsigned char)atomic_set(target, (atomic_val_t)value);
+}
+
+/**
+ * @brief Atomic unsigned char clear.
+ */
+static inline unsigned char atomic_uchar_clear(atomic_uchar_t *target)
+{
+	return (unsigned char)atomic_clear(target);
+}
+
+/**
+ * @brief Atomic unsigned char OR.
+ */
+static inline unsigned char atomic_uchar_or(atomic_uchar_t *target,
+					    unsigned char value)
+{
+	return (unsigned char)atomic_or(target, (atomic_val_t)value);
+}
+
+/**
+ * @brief Atomic unsigned char XOR.
+ */
+static inline unsigned char atomic_uchar_xor(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return (unsigned char)atomic_xor(target, (atomic_val_t)value);
+}
+
+/**
+ * @brief Atomic unsigned char AND.
+ */
+static inline unsigned char atomic_uchar_and(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return (unsigned char)atomic_and(target, (atomic_val_t)value);
+}
+
+/**
+ * @brief Atomic unsigned char NAND.
+ */
+static inline unsigned char atomic_uchar_nand(atomic_uchar_t *target,
+					      unsigned char value)
+{
+	return (unsigned char)atomic_nand(target, (atomic_val_t)value);
+}
+
+#elif defined(ZEPHYR_HAS_C11_STDATOMIC)
+/*
+ * Tier 1: C11 stdatomic available. Use C11 stdatomic operations directly.
+ * GCC __atomic_* builtins cannot operate on _Atomic qualified types in clang.
+ */
+
+/**
+ * @brief Atomic unsigned char compare-and-set.
+ */
+static inline bool atomic_uchar_cas(atomic_uchar_t *target,
+				    unsigned char old_value,
+				    unsigned char new_value)
+{
+	return atomic_compare_exchange_strong(target, &old_value, new_value);
+}
+
+/**
+ * @brief Atomic unsigned char addition.
+ */
+static inline unsigned char atomic_uchar_add(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return atomic_fetch_add(target, value);
+}
+
+/**
+ * @brief Atomic unsigned char subtraction.
+ */
+static inline unsigned char atomic_uchar_sub(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return atomic_fetch_sub(target, value);
+}
+
+/**
+ * @brief Atomic unsigned char increment.
+ */
+static inline unsigned char atomic_uchar_inc(atomic_uchar_t *target)
+{
+	return atomic_fetch_add(target, 1);
+}
+
+/**
+ * @brief Atomic unsigned char decrement.
+ */
+static inline unsigned char atomic_uchar_dec(atomic_uchar_t *target)
+{
+	return atomic_fetch_sub(target, 1);
+}
+
+/**
+ * @brief Atomic unsigned char get.
+ */
+static inline unsigned char atomic_uchar_get(const atomic_uchar_t *target)
+{
+	return atomic_load(target);
+}
+
+/**
+ * @brief Atomic unsigned char set.
+ */
+static inline unsigned char atomic_uchar_set(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return atomic_exchange(target, value);
+}
+
+/**
+ * @brief Atomic unsigned char clear.
+ */
+static inline unsigned char atomic_uchar_clear(atomic_uchar_t *target)
+{
+	return atomic_exchange(target, 0);
+}
+
+/**
+ * @brief Atomic unsigned char OR.
+ */
+static inline unsigned char atomic_uchar_or(atomic_uchar_t *target,
+					    unsigned char value)
+{
+	return atomic_fetch_or(target, value);
+}
+
+/**
+ * @brief Atomic unsigned char XOR.
+ */
+static inline unsigned char atomic_uchar_xor(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return atomic_fetch_xor(target, value);
+}
+
+/**
+ * @brief Atomic unsigned char AND.
+ */
+static inline unsigned char atomic_uchar_and(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return atomic_fetch_and(target, value);
+}
+
+/**
+ * @brief Atomic unsigned char NAND.
+ *
+ * C11 stdatomic has no fetch_nand, so use a CAS loop.
+ */
+static inline unsigned char atomic_uchar_nand(atomic_uchar_t *target,
+					      unsigned char value)
+{
+	unsigned char old_val = atomic_load(target);
+
+	while (!atomic_compare_exchange_weak(target, &old_val,
+					     (unsigned char)~(old_val & value))) {
+		/* old_val is updated by compare_exchange_weak on failure */
+	}
+	return old_val;
+}
+
+#else /* Tier 2: C++ mode or no C11 - use GCC __atomic_* builtins */
+
+/**
+ * @brief Atomic unsigned char compare-and-set.
+ */
+static inline bool atomic_uchar_cas(atomic_uchar_t *target,
+				    unsigned char old_value,
+				    unsigned char new_value)
+{
+	return __atomic_compare_exchange_n(target, &old_value, new_value,
+					   0, __ATOMIC_SEQ_CST,
+					   __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char addition.
+ */
+static inline unsigned char atomic_uchar_add(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return __atomic_fetch_add(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char subtraction.
+ */
+static inline unsigned char atomic_uchar_sub(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return __atomic_fetch_sub(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char increment.
+ */
+static inline unsigned char atomic_uchar_inc(atomic_uchar_t *target)
+{
+	return __atomic_fetch_add(target, 1, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char decrement.
+ */
+static inline unsigned char atomic_uchar_dec(atomic_uchar_t *target)
+{
+	return __atomic_fetch_sub(target, 1, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char get.
+ */
+static inline unsigned char atomic_uchar_get(const atomic_uchar_t *target)
+{
+	return __atomic_load_n(target, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char set.
+ */
+static inline unsigned char atomic_uchar_set(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return __atomic_exchange_n(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char clear.
+ */
+static inline unsigned char atomic_uchar_clear(atomic_uchar_t *target)
+{
+	return __atomic_exchange_n(target, 0, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char OR.
+ */
+static inline unsigned char atomic_uchar_or(atomic_uchar_t *target,
+					    unsigned char value)
+{
+	return __atomic_fetch_or(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char XOR.
+ */
+static inline unsigned char atomic_uchar_xor(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return __atomic_fetch_xor(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char AND.
+ */
+static inline unsigned char atomic_uchar_and(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return __atomic_fetch_and(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char NAND.
+ */
+static inline unsigned char atomic_uchar_nand(atomic_uchar_t *target,
+					      unsigned char value)
+{
+	return __atomic_fetch_nand(target, value, __ATOMIC_SEQ_CST);
+}
+
+#endif /* CONFIG_RISCV || CONFIG_XTENSA */
+
 /* Portable higher-level utilities: */
 
 /**

--- a/include/zephyr/sys/atomic_types.h
+++ b/include/zephyr/sys/atomic_types.h
@@ -8,6 +8,13 @@
 #ifndef ZEPHYR_INCLUDE_SYS_ATOMIC_TYPES_H_
 #define ZEPHYR_INCLUDE_SYS_ATOMIC_TYPES_H_
 
+/* Detect C11 stdatomic support (C mode only, not C++) */
+#if !defined(__cplusplus) && defined(__STDC_VERSION__) && \
+	(__STDC_VERSION__ >= 201112L) && !defined(__STDC_NO_ATOMICS__)
+#define ZEPHYR_HAS_C11_STDATOMIC 1
+#include <stdatomic.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -16,6 +23,33 @@ typedef long atomic_t;
 typedef atomic_t atomic_val_t;
 typedef void *atomic_ptr_t;
 typedef atomic_ptr_t atomic_ptr_val_t;
+
+/**
+ * @brief Atomic unsigned char type.
+ *
+ * Named atomic_uchar_t to avoid conflicts with C11 stdatomic.h's atomic_uchar.
+ *
+ * Three-tier type system:
+ * - Tier 3 (Fallback): On platforms without native byte-sized atomics
+ *   (RISC-V, Xtensa, Cortex-M0/M0+, RX, ARC), falls back to atomic_t
+ *   and uses word-sized atomic operations.
+ * - Tier 1 (C11): When C11 stdatomic is available, uses atomic_uchar
+ *   from <stdatomic.h> for true atomic semantics.
+ * - Tier 2 (GCC Builtins): In C++ mode or without C11 support, uses
+ *   unsigned char with GCC __atomic_* builtins.
+ */
+#if defined(CONFIG_RISCV) || defined(CONFIG_XTENSA) || \
+	defined(CONFIG_CPU_CORTEX_M0) || defined(CONFIG_CPU_CORTEX_M0PLUS) || \
+	defined(CONFIG_RX) || defined(CONFIG_ARC)
+/* Tier 3: These architectures lack native byte-sized atomics, use word type */
+typedef atomic_t atomic_uchar_t;
+#elif defined(ZEPHYR_HAS_C11_STDATOMIC)
+/* Tier 1: C11 stdatomic available - use atomic_uchar from <stdatomic.h> */
+typedef atomic_uchar atomic_uchar_t;
+#else
+/* Tier 2: C++ mode or no C11 support - use unsigned char with GCC builtins */
+typedef unsigned char atomic_uchar_t;
+#endif
 
 #ifdef __cplusplus
 }

--- a/lib/net_buf/buf.c
+++ b/lib/net_buf/buf.c
@@ -344,7 +344,7 @@ success:
 		buf->__buf = NULL;
 	}
 
-	buf->ref   = 1U;
+	atomic_uchar_set(&buf->ref, 1);
 	buf->flags = 0U;
 	buf->frags = NULL;
 	buf->size  = size;
@@ -446,18 +446,18 @@ void net_buf_unref(struct net_buf *buf)
 		struct net_buf *frags = buf->frags;
 		struct net_buf_pool *pool;
 
-		__ASSERT(buf->ref, "buf %p double free", buf);
-		if (!buf->ref) {
+__ASSERT(atomic_uchar_get(&buf->ref) > 0, "buf %p double free", buf);
+		if (atomic_uchar_get(&buf->ref) == 0) {
 #if defined(CONFIG_NET_BUF_LOG)
 			NET_BUF_ERR("%s():%d: buf %p double free", func, line,
 				    buf);
 #endif
 			return;
 		}
-		NET_BUF_DBG("buf %p ref %u pool_id %u frags %p", buf, buf->ref,
-			    buf->pool_id, buf->frags);
+		NET_BUF_DBG("buf %p ref %u pool_id %u frags %p", buf,
+			    atomic_uchar_get(&buf->ref), buf->pool_id, buf->frags);
 
-		if (--buf->ref > 0) {
+		if (atomic_uchar_dec(&buf->ref) != 1) {
 			return;
 		}
 
@@ -485,9 +485,12 @@ struct net_buf *net_buf_ref(struct net_buf *buf)
 {
 	__ASSERT_NO_MSG(buf);
 
+	__ASSERT(atomic_uchar_get(&buf->ref) > 0,
+		 "buf %p refcount zero, use-after-free", buf);
+
 	NET_BUF_DBG("buf %p (old) ref %u pool_id %u",
-		    buf, buf->ref, buf->pool_id);
-	buf->ref++;
+buf, atomic_uchar_get(&buf->ref), buf->pool_id);
+	atomic_uchar_inc(&buf->ref);
 	return buf;
 }
 

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -6259,8 +6259,10 @@ int bt_l2cap_br_echo_req(struct bt_conn *conn, struct net_buf *buf)
 
 	LOG_DBG("ACL conn %p buf %p len %u", conn, buf, buf->len);
 
-	if (buf->ref != 1) {
-		LOG_WRN("Expecting 1 ref, got %d", buf->ref);
+	unsigned char ref = atomic_uchar_get(&buf->ref);
+
+	if (ref != 1) {
+		LOG_WRN("Expecting 1 ref, got %u", ref);
 		return -EINVAL;
 	}
 
@@ -6316,8 +6318,10 @@ int bt_l2cap_br_echo_rsp(struct bt_conn *conn, uint8_t identifier, struct net_bu
 
 	LOG_DBG("ACL conn %p buf %p len %u", conn, buf, buf->len);
 
-	if (buf->ref != 1) {
-		LOG_WRN("Expecting 1 ref, got %d", buf->ref);
+	unsigned char ref = atomic_uchar_get(&buf->ref);
+
+	if (ref != 1) {
+		LOG_WRN("Expecting 1 ref, got %u", ref);
 		return -EINVAL;
 	}
 
@@ -6430,8 +6434,10 @@ int bt_l2cap_br_connless_send(struct bt_conn *conn, uint16_t psm, struct net_buf
 
 	LOG_DBG("ACL conn %p buf %p len %u", conn, buf, buf->len);
 
-	if (buf->ref != 1) {
-		LOG_WRN("Expecting 1 ref, got %d", buf->ref);
+	unsigned char ref = atomic_uchar_get(&buf->ref);
+
+	if (ref != 1) {
+		LOG_WRN("Expecting 1 ref, got %u", ref);
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -704,7 +704,8 @@ static int send_buf(struct bt_conn *conn, struct net_buf *buf,
 	 * from the conn tx_queue). It would be 2 if the
 	 * tx_data_pull kept it on the tx_queue for segmentation.
 	 */
-	__ASSERT_NO_MSG((buf->ref == 1) || (buf->ref == 2));
+__ASSERT_NO_MSG((atomic_uchar_get(&buf->ref) == 1) ||
+		       (atomic_uchar_get(&buf->ref) == 2));
 
 	/* The reference is always transferred to the frag, so when
 	 * the frag is destroyed, the parent reference is decremented.

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -778,13 +778,15 @@ int bt_l2cap_send_pdu(struct bt_l2cap_le_chan *le_chan, struct net_buf *pdu,
 		return -ENOTCONN;
 	}
 
-	if (pdu->ref != 1) {
+	unsigned char ref = atomic_uchar_get(&pdu->ref);
+
+	if (ref != 1) {
 		/* The host may alter the buf contents when fragmenting. Higher
 		 * layers cannot expect the buf contents to stay intact. Extra
 		 * refs suggests a silent data corruption would occur if not for
 		 * this error.
 		 */
-		LOG_ERR("Expecting 1 ref, got %d", pdu->ref);
+		LOG_ERR("Expecting 1 ref, got %u", ref);
 		return -EINVAL;
 	}
 
@@ -3362,7 +3364,7 @@ static int bt_l2cap_dyn_chan_send(struct bt_l2cap_le_chan *le_chan, struct net_b
 		return -EMSGSIZE;
 	}
 
-	if (buf->ref != 1) {
+	if (atomic_uchar_get(&buf->ref) != 1) {
 		/* The host may alter the buf contents when segmenting. Higher
 		 * layers cannot expect the buf contents to stay intact. Extra
 		 * refs suggests a silent data corruption would occur if not for
@@ -3433,8 +3435,10 @@ int bt_l2cap_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 	LOG_DBG("chan %p buf %p len %u", chan, buf, buf->len);
 
-	if (buf->ref != 1) {
-		LOG_WRN("Expecting 1 ref, got %d", buf->ref);
+	unsigned char ref = atomic_uchar_get(&buf->ref);
+
+	if (ref != 1) {
+		LOG_WRN("Expecting 1 ref, got %u", ref);
 		return -EINVAL;
 	}
 

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -410,15 +410,15 @@ struct net_buf *net_pkt_get_reserve_data(struct net_buf_pool *pool,
 	}
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
-	NET_FRAG_CHECK_IF_NOT_IN_USE(frag, frag->ref + 1U);
+	NET_FRAG_CHECK_IF_NOT_IN_USE(frag, atomic_uchar_get(&frag->ref) + 1);
 #endif
 
 	net_pkt_alloc_add(frag, false, caller, line);
 
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
-	NET_DBG("%s (%s) [%d] frag %p ref %d (%s():%d)",
+	NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
 		pool2str(pool), get_name(pool), get_frees(pool),
-		frag, frag->ref, caller, line);
+		frag, atomic_uchar_get(&frag->ref), caller, line);
 #endif
 
 	return frag;
@@ -571,14 +571,14 @@ void net_pkt_unref(struct net_pkt *pkt)
 	frag = pkt->frags;
 	while (frag) {
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
-		NET_DBG("%s (%s) [%d] frag %p ref %d frags %p (%s():%d)",
+		NET_DBG("%s (%s) [%d] frag %p ref %u frags %p (%s():%d)",
 			pool2str(net_buf_pool_get(frag->pool_id)),
 			get_name(net_buf_pool_get(frag->pool_id)),
 			get_frees(net_buf_pool_get(frag->pool_id)), frag,
-			frag->ref - 1U, frag->frags, caller, line);
+			atomic_uchar_get(&frag->ref) - 1, frag->frags, caller, line);
 #endif
 
-		if (!frag->ref) {
+		if (!atomic_uchar_get(&frag->ref)) {
 			const char *func_freed;
 			int line_freed;
 
@@ -665,11 +665,11 @@ struct net_buf *net_pkt_frag_ref(struct net_buf *frag)
 	}
 
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
-	NET_DBG("%s (%s) [%d] frag %p ref %d (%s():%d)",
+	NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
 		pool2str(net_buf_pool_get(frag->pool_id)),
 		get_name(net_buf_pool_get(frag->pool_id)),
 		get_frees(net_buf_pool_get(frag->pool_id)),
-		frag, frag->ref + 1U, caller, line);
+		frag, atomic_uchar_get(&frag->ref) + 1, caller, line);
 #endif
 
 	return net_buf_ref(frag);
@@ -691,14 +691,14 @@ void net_pkt_frag_unref(struct net_buf *frag)
 	}
 
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
-	NET_DBG("%s (%s) [%d] frag %p ref %d (%s():%d)",
+	NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
 		pool2str(net_buf_pool_get(frag->pool_id)),
 		get_name(net_buf_pool_get(frag->pool_id)),
 		get_frees(net_buf_pool_get(frag->pool_id)),
-		frag, frag->ref - 1U, caller, line);
+		frag, atomic_uchar_get(&frag->ref) - 1, caller, line);
 #endif
 
-	if (frag->ref == 1U) {
+	if (atomic_uchar_get(&frag->ref) == 1) {
 		net_pkt_alloc_del(frag, caller, line);
 	}
 
@@ -718,13 +718,13 @@ struct net_buf *net_pkt_frag_del(struct net_pkt *pkt,
 {
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
 	NET_DBG("pkt %p parent %p frag %p ref %u (%s:%d)",
-		pkt, parent, frag, frag->ref, caller, line);
+		pkt, parent, frag, atomic_uchar_get(&frag->ref), caller, line);
 #endif
 
 	if (pkt->frags == frag && !parent) {
 		struct net_buf *tmp;
 
-		if (frag->ref == 1U) {
+		if (atomic_uchar_get(&frag->ref) == 1) {
 			net_pkt_alloc_del(frag, caller, line);
 		}
 
@@ -734,7 +734,7 @@ struct net_buf *net_pkt_frag_del(struct net_pkt *pkt,
 		return tmp;
 	}
 
-	if (frag->ref == 1U) {
+	if (atomic_uchar_get(&frag->ref) == 1) {
 		net_pkt_alloc_del(frag, caller, line);
 	}
 
@@ -987,13 +987,13 @@ static struct net_buf *pkt_alloc_buffer(struct net_pkt *pkt,
 		timeout = sys_timepoint_timeout(end);
 
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
-		NET_FRAG_CHECK_IF_NOT_IN_USE(new, new->ref + 1);
+		NET_FRAG_CHECK_IF_NOT_IN_USE(new, atomic_uchar_get(&new->ref) + 1);
 
 		net_pkt_alloc_add(new, false, caller, line);
 
-		NET_DBG("%s (%s) [%d] frag %p ref %d (%s():%d)",
+		NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
 			pool2str(pool), get_name(pool), get_frees(pool),
-			new, new->ref, caller, line);
+			new, atomic_uchar_get(&new->ref), caller, line);
 #endif
 	} while (size);
 
@@ -1045,13 +1045,15 @@ static struct net_buf *pkt_alloc_buffer(struct net_pkt *pkt,
 	buf = net_buf_alloc_len(pool, size + headroom, timeout);
 
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
-	NET_FRAG_CHECK_IF_NOT_IN_USE(buf, buf->ref + 1);
+	unsigned char ref = atomic_uchar_get(&buf->ref);
+
+	NET_FRAG_CHECK_IF_NOT_IN_USE(buf, ref + 1);
 
 	net_pkt_alloc_add(buf, false, caller, line);
 
-	NET_DBG("%s (%s) [%d] frag %p ref %d (%s():%d)",
+	NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
 		pool2str(pool), get_name(pool), get_frees(pool),
-		buf, buf->ref, caller, line);
+		buf, ref, caller, line);
 #endif
 
 #if defined(CONFIG_NET_PKT_ALLOC_STATS)

--- a/subsys/net/lib/shell/allocs.c
+++ b/subsys/net/lib/shell/allocs.c
@@ -58,8 +58,8 @@ buf:
 		struct net_buf_pool *pool = net_buf_pool_get(buf->pool_id);
 
 		if (in_use) {
-			PR("%p/%d\t%5s\t%5s\t%s():%d\n",
-			   buf, buf->ref,
+			PR("%p/%u\t%5s\t%5s\t%s():%d\n",
+			   buf, atomic_uchar_get(&buf->ref),
 			   str, net_pkt_pool2str(pool), func_alloc,
 			   line_alloc);
 		} else {

--- a/subsys/net/lib/shell/conn.c
+++ b/subsys/net/lib/shell/conn.c
@@ -190,7 +190,7 @@ static void tcp_sent_list_cb(struct tcp *conn, void *user_data)
 			}
 
 			while (frag) {
-				PR("%p[%d/%d]", frag, frag->ref, frag->len);
+				PR("%p[%u/%d]", frag, atomic_uchar_get(&frag->ref), frag->len);
 
 				frag = frag->frags;
 				if (frag) {

--- a/subsys/net/lib/shell/pkt.c
+++ b/subsys/net/lib/shell/pkt.c
@@ -131,7 +131,7 @@ static void net_pkt_buffer_hexdump(const struct shell *sh,
 	struct net_buf *buf = pkt->buffer;
 	int i = 0;
 
-	if (!buf || buf->ref == 0) {
+	if (!buf || atomic_uchar_get(&buf->ref) == 0) {
 		return;
 	}
 


### PR DESCRIPTION
which could cause an incorrect buffer ref count when the same buffer was referenced/dereferenced from two different threads, causing a memory leak.