### PR TITLE
modules: uoscore-uedhoc: include improvement for compressed EC key parsing

### DIFF
--- a/modules/uoscore-uedhoc/Kconfig
+++ b/modules/uoscore-uedhoc/Kconfig
@@ -49,10 +49,5 @@ config UOSCORE_UEDHOC_CRYPTO_COMMON
 	select PSA_WANT_KEY_TYPE_HMAC
 	select PSA_WANT_ALG_HMAC
 	select PSA_WANT_ALG_SHA_256
-	# On TF-M platforms the PSA_WANT_xxx above do not enable the legacy
-	# MBEDTLS_ECP_C build symbol which is required to enable the
-	# mbedtls_pk_ec() function used in uOSCORE/uEDHOC.
-	select MBEDTLS_ECP_C if BUILD_WITH_TFM
-	select MBEDTLS_ECP_DP_SECP256R1_ENABLED if BUILD_WITH_TFM
 
 endif # UOSCORE || UEDHOC

--- a/west.yml
+++ b/west.yml
@@ -385,7 +385,7 @@ manifest:
       groups:
         - tee
     - name: uoscore-uedhoc
-      revision: 54abc109c9c0adfd53c70077744c14e454f04f4a
+      revision: ac80c3bf2b88deec86d129654fbde09761582342
       path: modules/lib/uoscore-uedhoc
     - name: zcbor
       revision: 9b07780aca6fb21f82a241ba386ad9b379809337


### PR DESCRIPTION
Remove dependency on legacy Mbed TLS legacy crypto functions which have been removed in the latest Mbed TLS/TF-PSA-Crypto release.

This has been tested using `modules/lib/uoscore-uedhoc/test/` (which is more complete than the test cases currently available on Zephyr repo) on `native_sim`. If you want to try it locally:
```
cd modules/lib/uoscore-uedhoc/test/
west build -p -b native_sim -t run
```