### PR TITLE
llext: make 2 arguments of llext_get_section_header() const

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -396,7 +396,7 @@ ssize_t llext_find_section(struct llext_loader *loader, const char *search_name)
  * @retval -ENOTSUP "peek" method not supported
  * @retval -ENOENT section not found
  */
-int llext_get_section_header(struct llext_loader *loader, struct llext *ext,
+int llext_get_section_header(const struct llext_loader *loader, const struct llext *ext,
 			     const char *search_name, elf_shdr_t *shdr);
 
 /**

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -39,8 +39,8 @@ int llext_section_shndx(const struct llext_loader *ldr, const struct llext *ext,
 	return -ENOENT;
 }
 
-int llext_get_section_header(struct llext_loader *ldr, struct llext *ext, const char *search_name,
-			     elf_shdr_t *shdr)
+int llext_get_section_header(const struct llext_loader *ldr, const struct llext *ext,
+			     const char *search_name, elf_shdr_t *shdr)
 {
 	int ret;
 


### PR DESCRIPTION
ext and loader aren't modified inside llext_get_section_header(), they are just passed to llext_section_shndx(), where they're already const. Make them const in this function too.