### PR TITLE
twister: pytest: fix duplicate log lines from pytest

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -403,6 +403,7 @@ class Pytest(Harness):
             'pytest',
             '--twister-harness',
             '-s', '-v',
+            '--log-level=DEBUG',
             f'--build-dir={self.running_dir}',
             f'--junit-xml={self.report_file}',
             f'--platform={self.instance.platform.name}'
@@ -413,12 +414,6 @@ class Pytest(Harness):
 
         if pytest_dut_scope:
             command.append(f'--dut-scope={pytest_dut_scope}')
-
-        # Always pass output from the pytest test and the test image up to Twister log.
-        command.extend([
-            '--log-cli-level=DEBUG',
-            '--log-cli-format=%(levelname)s: %(message)s'
-        ])
 
         # Use the test timeout as the base timeout for pytest
         base_timeout = handler.get_test_timeout()


### PR DESCRIPTION
The combination of pytest's `-s` (--capture=no) option and `--log-cli-level=DEBUG` was causing duplicate log output. Fixed by replacing `--log-cli-level=DEBUG` with `--log-level=DEBUG`. `--log-cli-format` removed as is not used.

Try to run command:
`./scripts/twister -vv -ll debug -T samples/subsys/testsuite/pytest/shell -s sample.pytest.shell -p native_sim --no-clean`

before fix, lines from pytest are duplicated (also in twister.log and twister_harness.log):
```
DEBUG   - PYTEST: DEBUG:twister_harness.helpers.shell:Got prompt
DEBUG   - PYTEST: DEBUG: Got prompt
DEBUG   - PYTEST: INFO:test_shell:send "kernel version" command
DEBUG   - PYTEST: INFO: send "kernel version" command
DEBUG   - PYTEST: DEBUG:twister_harness.device.device_adapter:#: uart:~$ kernel version
DEBUG   - PYTEST: DEBUG: #: uart:~$ kernel version
DEBUG   - PYTEST: DEBUG:twister_harness.device.device_adapter:#: Zephyr version 4.3.99
DEBUG   - PYTEST: DEBUG: #: Zephyr version 4.3.99
```
With this PR you receive:
```
DEBUG   - PYTEST: DEBUG:twister_harness.helpers.shell:Got prompt
DEBUG   - PYTEST: INFO:test_shell:send "kernel version" command
DEBUG   - PYTEST: DEBUG:twister_harness.device.device_adapter:#: uart:~$ kernel version
DEBUG   - PYTEST: DEBUG:twister_harness.device.device_adapter:#: Zephyr version 4.3.99
```

If we want to use formatting (to have shorter lines without module names, we can keep `--log-cli-level` and `--log-cli-format`, but we must remove the `-s` option (--capture=no). However, then we would miss every log not logged with logger (just print() statements). I found a couple of tests that use normal print(), so we keep `-s`.

