### PR TITLE
west.yml: update hal_stm32 modules with new WBxx, WLxx stm32cube packages

### DIFF
--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -60,7 +60,8 @@ typedef void (*dma_stm32_clear_flag_func)(DMA_TypeDef *DMAx);
 	!defined(CONFIG_SOC_SERIES_STM32H7X) && \
 	!defined(CONFIG_SOC_SERIES_STM32L4X) && \
 	!defined(CONFIG_SOC_SERIES_STM32MP13X) && \
-	!defined(CONFIG_SOC_SERIES_STM32U0X)
+	!defined(CONFIG_SOC_SERIES_STM32U0X) && \
+	!defined(CONFIG_SOC_SERIES_STM32WLX)
 typedef uint32_t (*dma_stm32_check_flag_func)(DMA_TypeDef *DMAx);
 #else
 typedef uint32_t (*dma_stm32_check_flag_func)(const DMA_TypeDef *DMAx);

--- a/west.yml
+++ b/west.yml
@@ -255,7 +255,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: b0dc1376b6af8c6b4d68b609e4815a6ca418edf7
+      revision: 21d2c68bc0d38cb9f4d9183b97adb82e47fbd25e
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
stm32wbxx bump to version to 1.24.0
stm32wlxx bump to version 1.4.0

Update dma_stm32.h to sync with HAL new function prototype for `LL_DMA_IsActiveFlag_HT*()` functions that now expect a const pointer on STM32WLX series.