### PR TITLE
samples/subsys/pmci/mctp: Add npcx4m8f_evb overlays for I2C-GPIO

### DIFF
--- a/samples/subsys/pmci/mctp/i2c_gpio_bus_endpoint/boards/npcx4m8f_evb.overlay
+++ b/samples/subsys/pmci/mctp/i2c_gpio_bus_endpoint/boards/npcx4m8f_evb.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/* SDA J18.2 */
+	/* SCL J18.1 */
+	/* GPIO J17.2 */
+	mctp_i2c: mctp_i2c {
+		compatible = "zephyr,mctp-i2c-gpio-target";
+		i2c = <&i2c0_0>;
+		i2c-addr = <70>;
+		endpoint-id = <11>;
+		endpoint-gpios = <&gpio4 3 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/samples/subsys/pmci/mctp/i2c_gpio_bus_owner/boards/npcx4m8f_evb.overlay
+++ b/samples/subsys/pmci/mctp/i2c_gpio_bus_owner/boards/npcx4m8f_evb.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/* SDA J18.2 */
+	/* SCL J18.1 */
+	/* GPIO J17.2 */
+	mctp_i2c: mctp_i2c {
+		compatible = "zephyr,mctp-i2c-gpio-controller";
+		i2c = <&i2c0_0>;
+		endpoint-ids = <11>;
+		endpoint-addrs = <70>;
+		endpoint-gpios = <&gpio4 3 GPIO_ACTIVE_HIGH>;
+	};
+};


### PR DESCRIPTION
So that one can run the I2C-GPIO owner/endpoint samples on it.