### PR TITLE
boards: infineon: cy8cproto_041tp: board.cmake

### DIFF
--- a/boards/infineon/cy8cproto_041tp/board.cmake
+++ b/boards/infineon/cy8cproto_041tp/board.cmake
@@ -3,8 +3,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# OpenOCD cfg
-board_runner_args(openocd "--config=${ZEPHYR_BASE}/boards/infineon/cy8cproto_041tp/support/openocd.cfg")
-
 # Include standard OpenOCD runner helpers
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)


### PR DESCRIPTION
The openocd --config paramter is not needed.
And it causes an error when used on a ci runner.
The path created by
scripts/west_commands/runners/openocd.py is wrong.