### PR TITLE
tests: drivers: dma: Adding DMA testing for Infineon kit_psc3m5_evk board.  

### DIFF
--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.yaml
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.yaml
@@ -16,4 +16,5 @@ supported:
   - gpio
   - spi
   - uart
+  - dma
 vendor: infineon

--- a/tests/drivers/dma/chan_blen_transfer/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/kit_psc3m5_evk.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {
+	status = "okay";
+};

--- a/tests/drivers/dma/loop_transfer/boards/kit_psc3m5_evk.conf
+++ b/tests/drivers/dma/loop_transfer/boards/kit_psc3m5_evk.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_DMA_LOOP_TRANSFER_SIZE=256

--- a/tests/drivers/dma/loop_transfer/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/kit_psc3m5_evk.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &dma0 {
+	status = "okay";
+};


### PR DESCRIPTION
Adds support for DMA in the Infineon kit_psc3m5_evk board.  Adds support for the dma/loopback and dma/chan_blen_transfer tests.  