### PR TITLE
drivers: serial: esp32: add UHCI SLIP encoding control

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -78,6 +78,8 @@ struct uart_esp32_config {
 	const struct device *dma_dev;
 	uint8_t tx_dma_channel;
 	uint8_t rx_dma_channel;
+	bool uhci_slip_tx;
+	bool uhci_slip_rx;
 #endif
 };
 
@@ -973,6 +975,11 @@ static int uart_esp32_init(const struct device *dev)
 		clock_control_on(config->clock_dev, (clock_control_subsys_t)ESP32_UHCI0_MODULE);
 		uhci_ll_init(data->uhci_dev);
 		uhci_ll_set_eof_mode(data->uhci_dev, UHCI_RX_IDLE_EOF | UHCI_RX_LEN_EOF);
+
+		/* Configure SLIP encoding/decoding */
+		data->uhci_dev->escape_conf.tx_c0_esc_en = config->uhci_slip_tx ? 1 : 0;
+		data->uhci_dev->escape_conf.rx_c0_esc_en = config->uhci_slip_rx ? 1 : 0;
+
 		uhci_ll_attach_uart_port(data->uhci_dev, uart_hal_get_port_num(&data->hal));
 		data->uart_dev = dev;
 
@@ -1021,7 +1028,9 @@ static DEVICE_API(uart, uart_esp32_api) = {
 #define ESP_UART_DMA_INIT(n)                                                                       \
 	.dma_dev = ESP32_DT_INST_DMA_CTLR(n, tx),                                                  \
 	.tx_dma_channel = ESP32_DT_INST_DMA_CELL(n, tx, channel),                                  \
-	.rx_dma_channel = ESP32_DT_INST_DMA_CELL(n, rx, channel)
+	.rx_dma_channel = ESP32_DT_INST_DMA_CELL(n, rx, channel),                                  \
+	.uhci_slip_tx = DT_INST_PROP_OR(n, uhci_slip_tx, false),                                   \
+	.uhci_slip_rx = DT_INST_PROP_OR(n, uhci_slip_rx, false)
 
 #define ESP_UART_UHCI_INIT(n)                                                                      \
 	.uhci_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas), (&UHCI0), (NULL))

--- a/dts/bindings/serial/espressif,esp32-uart.yaml
+++ b/dts/bindings/serial/espressif,esp32-uart.yaml
@@ -31,3 +31,19 @@ properties:
       Overrides hw-flow-control if both are set.
       Using this mode, the pin assigned to DTR
       is asserted during transmission.
+
+  uhci-slip-tx:
+    type: boolean
+    description: |
+      Enable SLIP encoding on TX when using UART with DMA (async API).
+      When enabled, the UHCI hardware automatically encodes transmitted data
+      using SLIP framing (0xC0 -> 0xDB 0xDC, 0xDB -> 0xDB 0xDD).
+      Disabled by default to prevent unintended data corruption.
+
+  uhci-slip-rx:
+    type: boolean
+    description: |
+      Enable SLIP decoding on RX when using UART with DMA (async API).
+      When enabled, the UHCI hardware automatically decodes received data
+      using SLIP framing (0xDB 0xDC -> 0xC0, 0xDB 0xDD -> 0xDB).
+      Disabled by default to prevent unintended data corruption.


### PR DESCRIPTION
Add devicetree properties to control UHCI SLIP encoding/decoding when using UART with DMA (async API). Both properties default to disabled to prevent unintended data corruption.

Fixes #101075