### PR TITLE
drivers: clock_control: numaker: support get_rate/set_rate

### DIFF
--- a/drivers/clock_control/clock_control_numaker_scc.c
+++ b/drivers/clock_control/clock_control_numaker_scc.c
@@ -22,6 +22,18 @@ struct numaker_scc_config {
 	uint32_t core_clock;
 };
 
+/* Clock module index
+ *
+ * virtual: passed from dts as 32-bit (one dts cell)
+ * real: passed to BSP CLK driver CLK_EnableModuleClock() and/or
+ *       CLK_SetModuleClock() as: 32-bit or 64-bit
+ *
+ * For 32-bit real, real = virtual, e.g. m46x and m2l31x
+ * For 64-bit real, real = virtual as index into lookup table, e.g. m55m1x
+ */
+#define NUMAKER_PCC_MODIDX_REAL_TYPE                                                               \
+	__typeof__(((struct numaker_scc_subsys_pcc_rate *)0)->clk_modidx_real)
+
 #if defined(CONFIG_SOC_SERIES_M55M1X)
 static const uint64_t numaker_clkmodidx_tab[] = {
 	0x0000000000000000, 0x0000000000000400, 0x0000800000000000, 0x0001008000800000,
@@ -53,7 +65,160 @@ static const uint64_t numaker_clkmodidx_tab[] = {
 	0x001D0D0880878000, 0x001D800000000000, 0x001E000000000000, 0x001E8D8000800000,
 	0x001E8D8000800480, 0x001F0F8000800000, 0x001F0F8000800480,
 };
+
+#define NUMAKER_PCC_MODIDX_VIRT2REAL(modidx)                                                       \
+	({                                                                                         \
+		__ASSERT_NO_MSG(modidx < ARRAY_SIZE(numaker_clkmodidx_tab));                       \
+		numaker_clkmodidx_tab[modidx];                                                     \
+	})
+#else
+#define NUMAKER_PCC_MODIDX_VIRT2REAL(modidx) ((uint32_t)modidx)
 #endif
+
+static inline int numaker_pcc_get_max_divider(NUMAKER_PCC_MODIDX_REAL_TYPE clk_modidx_real,
+					      uint32_t *max_divider)
+{
+	__ASSERT_NO_MSG(max_divider);
+
+	switch (clk_modidx_real) {
+#if defined(CONFIG_SOC_SERIES_M46X)
+	case CANFD0_MODULE:
+	case CANFD1_MODULE:
+	case CANFD2_MODULE:
+	case CANFD3_MODULE:
+		*max_divider = (CLK_CLKDIV5_CANFD0DIV_Msk >> CLK_CLKDIV5_CANFD0DIV_Pos) + 1;
+		break;
+#elif defined(CONFIG_SOC_SERIES_M2L31X)
+	case CANFD0_MODULE:
+	case CANFD1_MODULE:
+		*max_divider = (CLK_CLKDIV5_CANFD0DIV_Msk >> CLK_CLKDIV5_CANFD0DIV_Pos) + 1;
+		break;
+#elif defined(CONFIG_SOC_SERIES_M55M1X)
+	case CANFD0_MODULE:
+	case CANFD1_MODULE:
+		*max_divider = (CLK_CANFDDIV_CANFD0DIV_Msk >> CLK_CANFDDIV_CANFD0DIV_Pos) + 1;
+		break;
+#elif defined(CONFIG_SOC_SERIES_M333X)
+	case CANFD0_MODULE:
+	case CANFD1_MODULE:
+		*max_divider = (CLK_CLKDIV1_CANFD0DIV_Msk >> CLK_CLKDIV1_CANFD0DIV_Pos) + 1;
+		break;
+#endif
+	default:
+		LOG_ERR("Unsupported clock module index: 0x%" PRIx64, (uint64_t)clk_modidx_real);
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static inline int numaker_pcc_get_source_rate(NUMAKER_PCC_MODIDX_REAL_TYPE clk_modidx_real,
+					      uint32_t clksrc_idx, uint32_t *source_rate)
+{
+	__ASSERT_NO_MSG(source_rate);
+
+	switch (clk_modidx_real) {
+#if defined(CONFIG_SOC_SERIES_M46X)
+	case CANFD0_MODULE:
+	case CANFD1_MODULE:
+	case CANFD2_MODULE:
+	case CANFD3_MODULE:
+		switch (clksrc_idx) {
+		case (CLK_CLKSEL0_CANFD0SEL_HXT >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = __HXT;
+			break;
+		case (CLK_CLKSEL0_CANFD0SEL_PLL_DIV2 >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = CLK_GetPLLClockFreq() / 2;
+			break;
+		case (CLK_CLKSEL0_CANFD0SEL_HCLK >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = CLK_GetHCLKFreq();
+			break;
+		case (CLK_CLKSEL0_CANFD0SEL_HIRC >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = __HIRC;
+			break;
+		default:
+			LOG_ERR("Unsupported clock module/source index: 0x%" PRIx64 "/%d",
+				(uint64_t)clk_modidx_real, clksrc_idx);
+			return -ENOTSUP;
+		}
+		break;
+#elif defined(CONFIG_SOC_SERIES_M2L31X)
+	case CANFD0_MODULE:
+	case CANFD1_MODULE:
+		switch (clksrc_idx) {
+		case (CLK_CLKSEL0_CANFD0SEL_HXT >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = __HXT;
+			break;
+		case (CLK_CLKSEL0_CANFD0SEL_HIRC48M >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = __HIRC48;
+			break;
+		case (CLK_CLKSEL0_CANFD0SEL_HCLK >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = CLK_GetHCLKFreq();
+			break;
+		case (CLK_CLKSEL0_CANFD0SEL_HIRC >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = __HIRC;
+			break;
+		default:
+			LOG_ERR("Unsupported clock module/source index: 0x%" PRIx64 "/%d",
+				(uint64_t)clk_modidx_real, clksrc_idx);
+			return -ENOTSUP;
+		}
+		break;
+#elif defined(CONFIG_SOC_SERIES_M55M1X)
+	case CANFD0_MODULE:
+	case CANFD1_MODULE:
+		switch (clksrc_idx) {
+		case (CLK_CANFDSEL_CANFD0SEL_HXT >> CLK_CANFDSEL_CANFD0SEL_Pos):
+			*source_rate = __HXT;
+			break;
+		case (CLK_CANFDSEL_CANFD0SEL_APLL0_DIV2 >> CLK_CANFDSEL_CANFD0SEL_Pos):
+			*source_rate = CLK_GetAPLL0ClockFreq() / 2;
+			break;
+		case (CLK_CANFDSEL_CANFD0SEL_HCLK0 >> CLK_CANFDSEL_CANFD0SEL_Pos):
+			*source_rate = CLK_GetHCLK0Freq();
+			break;
+		case (CLK_CANFDSEL_CANFD0SEL_HIRC >> CLK_CANFDSEL_CANFD0SEL_Pos):
+			*source_rate = __HIRC;
+			break;
+		case (CLK_CANFDSEL_CANFD0SEL_HIRC48M_DIV4 >> CLK_CANFDSEL_CANFD0SEL_Pos):
+			*source_rate = __HIRC48M / 4;
+			break;
+		default:
+			LOG_ERR("Unsupported clock module/source index: 0x%" PRIx64 "/%d",
+				(uint64_t)clk_modidx_real, clksrc_idx);
+			return -ENOTSUP;
+		}
+		break;
+#elif defined(CONFIG_SOC_SERIES_M333X)
+	case CANFD0_MODULE:
+	case CANFD1_MODULE:
+		switch (clksrc_idx) {
+		case (CLK_CLKSEL0_CANFD0SEL_HXT >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = __HXT;
+			break;
+		case (CLK_CLKSEL0_CANFD0SEL_PLL_DIV2 >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = CLK_GetPLLClockFreq() / 2;
+			break;
+		case (CLK_CLKSEL0_CANFD0SEL_HCLK >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = CLK_GetHCLKFreq();
+			break;
+		case (CLK_CLKSEL0_CANFD0SEL_HIRC >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = __HIRC;
+			break;
+		default:
+			LOG_ERR("Unsupported clock module/source index: 0x%" PRIx64 "/%d",
+				(uint64_t)clk_modidx_real, clksrc_idx);
+			return -ENOTSUP;
+		}
+		break;
+#endif
+	default:
+		LOG_ERR("Unsupported clock module index: 0x%" PRIx64, (uint64_t)clk_modidx_real);
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
 
 static inline int numaker_scc_on(const struct device *dev, clock_control_subsys_t subsys)
 {
@@ -99,22 +264,147 @@ static inline int numaker_scc_off(const struct device *dev, clock_control_subsys
 	return 0;
 }
 
+static inline int numaker_scc_configure(const struct device *dev, clock_control_subsys_t subsys,
+					void *data);
+
 static inline int numaker_scc_get_rate(const struct device *dev, clock_control_subsys_t subsys,
 				       uint32_t *rate)
 {
+	struct numaker_scc_subsys *scc_subsys = (struct numaker_scc_subsys *)subsys;
+	int rc;
+
 	ARG_UNUSED(dev);
-	ARG_UNUSED(subsys);
-	ARG_UNUSED(rate);
-	return -ENOTSUP;
+
+	if (!rate) {
+		LOG_ERR("NULL rate pointer");
+		return -EINVAL;
+	}
+
+	if (scc_subsys->subsys_id == NUMAKER_SCC_SUBSYS_ID_PCC) {
+		struct numaker_scc_subsys_pcc *pcc = &scc_subsys->pcc;
+		uint32_t clk_modidx_virt = pcc->clk_modidx;
+		NUMAKER_PCC_MODIDX_REAL_TYPE clk_modidx_real =
+			NUMAKER_PCC_MODIDX_VIRT2REAL(clk_modidx_virt);
+		uint32_t clksrc_idx;
+		uint32_t source_rate;
+		uint32_t clkdiv_value;
+
+		/* Clock source index and rate */
+		clksrc_idx = CLK_GetModuleClockSource(clk_modidx_real);
+		rc = numaker_pcc_get_source_rate(clk_modidx_real, clksrc_idx, &source_rate);
+		if (rc < 0) {
+			return rc;
+		}
+
+		/* Clock divider value */
+		clkdiv_value = CLK_GetModuleClockDivider(clk_modidx_real) + 1;
+
+		*rate = source_rate / clkdiv_value;
+	} else {
+		LOG_ERR("Invalid subsys (%d)", scc_subsys->subsys_id);
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 static inline int numaker_scc_set_rate(const struct device *dev, clock_control_subsys_t subsys,
 				       clock_control_subsys_rate_t rate)
 {
-	ARG_UNUSED(dev);
-	ARG_UNUSED(subsys);
-	ARG_UNUSED(rate);
-	return -ENOTSUP;
+	struct numaker_scc_subsys *scc_subsys = (struct numaker_scc_subsys *)subsys;
+	struct numaker_scc_subsys_rate *scc_subsys_rate = (struct numaker_scc_subsys_rate *)rate;
+	int rc;
+
+	if (scc_subsys->subsys_id == NUMAKER_SCC_SUBSYS_ID_PCC) {
+		struct numaker_scc_subsys scc_subsys_im = *scc_subsys;
+		struct numaker_scc_subsys_pcc *pcc = &scc_subsys_im.pcc;
+		struct numaker_scc_subsys_pcc_rate *pcc_rate = &scc_subsys_rate->pcc;
+		uint32_t clk_modidx_virt = pcc->clk_modidx;
+		NUMAKER_PCC_MODIDX_REAL_TYPE clk_modidx_real =
+			NUMAKER_PCC_MODIDX_VIRT2REAL(clk_modidx_virt);
+		uint32_t clksrc_idx;
+		uint32_t source_rate;
+		uint32_t clkdiv_value;
+		uint32_t clkdiv_value_max;
+
+		/* Degenerate to get_rate on clk_mod_rate being zero */
+
+		/* Supported max divider value */
+		rc = numaker_pcc_get_max_divider(clk_modidx_real, &clkdiv_value_max);
+		if (rc < 0) {
+			return rc;
+		}
+
+		/* First run to prepare for CLK_GetModuleClockSource
+		 *
+		 * CLK_GetModuleClockSource will see CLKSEL register for
+		 * clock source, so first run is needed to get CLKSEL register
+		 * ready. Besides, first run will also set up CLKDIV register
+		 * with max divider value for safe.
+		 */
+		if (pcc_rate->clk_mod_rate != 0) {
+			pcc->clk_div = (clkdiv_value_max - 1)
+				       << ((uint32_t)MODULE_CLKDIV_Pos(clk_modidx_real));
+			rc = numaker_scc_configure(dev, &scc_subsys_im, NULL);
+			if (rc < 0) {
+				return rc;
+			}
+		}
+
+		/* Clock source index and rate */
+		clksrc_idx = CLK_GetModuleClockSource(clk_modidx_real);
+		rc = numaker_pcc_get_source_rate(clk_modidx_real, clksrc_idx, &source_rate);
+		if (rc < 0) {
+			return rc;
+		}
+
+		/* Calculate out proper clock divider value
+		 *
+		 * 1. Equal to or lower than target rate for safe
+		 * 2. Clamp divider value to supported min and max values
+		 *
+		 * NOTE: When max divider value is chosen, configured rate
+		 * can be higher than target rate.
+		 */
+		if (pcc_rate->clk_mod_rate != 0) {
+			clkdiv_value = source_rate / pcc_rate->clk_mod_rate;
+			if (clkdiv_value == 0) {
+				clkdiv_value = 1;
+			}
+			if (pcc_rate->clk_mod_rate < (source_rate / clkdiv_value)) {
+				clkdiv_value++;
+			}
+			if (clkdiv_value > clkdiv_value_max) {
+				clkdiv_value = clkdiv_value_max;
+			}
+		} else {
+			/* Clock divider value */
+			clkdiv_value = CLK_GetModuleClockDivider(clk_modidx_real) + 1;
+		}
+
+		/* Second run for real configure */
+		if (pcc_rate->clk_mod_rate != 0) {
+			pcc->clk_div = (clkdiv_value - 1)
+				       << ((uint32_t)MODULE_CLKDIV_Pos(clk_modidx_real));
+			rc = numaker_scc_configure(dev, &scc_subsys_im, NULL);
+			if (rc < 0) {
+				return rc;
+			}
+		}
+
+		/* Detailed PCC module clock information */
+		pcc_rate->clk_src_idx = clksrc_idx;
+		pcc_rate->clk_src_rate = source_rate;
+		pcc_rate->clk_modidx_real = clk_modidx_real;
+		pcc_rate->clk_div_value = clkdiv_value;
+		pcc_rate->clk_div_value_max = clkdiv_value_max;
+		pcc_rate->clk_mod_rate = source_rate / clkdiv_value;
+	} else {
+		LOG_ERR("Invalid subsys (%d)", scc_subsys->subsys_id);
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 static inline int numaker_scc_configure(const struct device *dev, clock_control_subsys_t subsys,
@@ -130,8 +420,7 @@ static inline int numaker_scc_configure(const struct device *dev, clock_control_
 #if defined(CONFIG_SOC_SERIES_M55M1X)
 		__ASSERT_NO_MSG(scc_subsys->pcc.clk_modidx < ARRAY_SIZE(numaker_clkmodidx_tab));
 		CLK_SetModuleClock(numaker_clkmodidx_tab[scc_subsys->pcc.clk_modidx],
-				   scc_subsys->pcc.clk_src,
-				   scc_subsys->pcc.clk_div);
+				   scc_subsys->pcc.clk_src, scc_subsys->pcc.clk_div);
 #else
 		CLK_SetModuleClock(scc_subsys->pcc.clk_modidx, scc_subsys->pcc.clk_src,
 				   scc_subsys->pcc.clk_div);
@@ -206,7 +495,7 @@ static int numaker_scc_init(const struct device *dev)
 		.core_clock = DT_INST_PROP_OR(inst, core_clock, 0),                                \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, numaker_scc_init, NULL, NULL, &numaker_scc_config_##inst,     \
+	DEVICE_DT_INST_DEFINE(inst, numaker_scc_init, NULL, NULL, &numaker_scc_config_##inst,      \
 			      PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &numaker_scc_api);
 
 DT_INST_FOREACH_STATUS_OKAY(NUMICRO_SCC_INIT);

--- a/include/zephyr/drivers/clock_control/clock_control_numaker.h
+++ b/include/zephyr/drivers/clock_control/clock_control_numaker.h
@@ -21,20 +21,51 @@
  */
 #define NUMAKER_SCC_SUBSYS_ID_PCC 1
 
+/* Peripheral clock control configuration structure
+ *
+ * clk_modidx is virtual of u32ModuleIdx/u64ModuleIdx in BSP CLK_SetModuleClock().
+ * clk_src is same as u32ClkSrc in BSP CLK_SetModuleClock().
+ * clk_div is same as u32ClkDiv in BSP CLK_SetModuleClock().
+ */
+struct numaker_scc_subsys_pcc {
+	uint32_t clk_modidx;
+	uint32_t clk_src;
+	uint32_t clk_div;
+};
+
+/* Peripheral clock control rate structure
+ *
+ * clk_modidx_real is real of u32ModuleIdx/u64ModuleIdx in BSP CLK_SetModuleClock().
+ * clk_src_idx is decoded clock source index of clk_src.
+ * clk_src_rate is clock source rate of clk_src_idx.
+ * clk_div_value is decoded clock divider value of clk_div.
+ * clk_div_value_max is supported maximum divider value of clk_div_value.
+ * clk_mod_rate is module rate.
+ */
+struct numaker_scc_subsys_pcc_rate {
+#if defined(CONFIG_SOC_SERIES_M55M1X)
+	uint64_t clk_modidx_real;
+#else
+	uint32_t clk_modidx_real;
+#endif
+	uint32_t clk_src_idx;
+	uint32_t clk_src_rate;
+	uint32_t clk_div_value;
+	uint32_t clk_div_value_max;
+	uint32_t clk_mod_rate;
+};
+
 struct numaker_scc_subsys {
 	uint32_t subsys_id; /* SCC subsystem ID */
 
-	/* Peripheral clock control configuration structure
-	 * clk_modidx is same as u32ModuleIdx in BSP CLK_SetModuleClock().
-	 * clk_src is same as u32ClkSrc in BSP CLK_SetModuleClock().
-	 * clk_div is same as u32ClkDiv in BSP CLK_SetModuleClock().
-	 */
 	union {
-		struct {
-			uint32_t clk_modidx;
-			uint32_t clk_src;
-			uint32_t clk_div;
-		} pcc;
+		struct numaker_scc_subsys_pcc pcc;
+	};
+};
+
+struct numaker_scc_subsys_rate {
+	union {
+		struct numaker_scc_subsys_pcc_rate pcc;
 	};
 };
 


### PR DESCRIPTION
This adds `clock_control_get_rate`/` clock_control_set_rate` support into Nuvoton NuMaker clock_control driver, so that module clock rate can read or modify via these APIs in Hz. Note only CANFD support is added here as an reference example and other module support will be added as-needed.

To modify module (IP) clock rate to 2MHz, run:
```
struct numaker_scc_subsys scc_subsys = {.subsys_id = NUMAKER_SCC_SUBSYS_ID_PCC,
                                        .pcc.clk_modidx = config->clk_modidx,
                                        .pcc.clk_src = config->clk_src};
struct numaker_scc_subsys_rate scc_subsys_rate = {.pcc.clk_mod_rate = 2000000};
clock_control_set_rate(config->clk_dev,
                       (clock_control_subsys_t)&scc_subsys,
                       (clock_control_subsys_rate_t)&scc_subsys_rate);
```

To fetch module (IP) clock rate, run:
```
struct numaker_scc_subsys scc_subsys = {.subsys_id = NUMAKER_SCC_SUBSYS_ID_PCC,
                                        .pcc.clk_modidx = config->clk_modidx};
uint32_t rate;
clock_control_get_rate(config->clk_dev,
                       (clock_control_subsys_t)&scc_subsys,
                       &rate);
```