### PR TITLE
drivers: usb: uhc: fix unused variable warning for phy_config

### DIFF
--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -93,8 +93,7 @@ static usb_status_t mcux_host_callback(usb_device_handle deviceHandle,
 
 static int uhc_mcux_init(const struct device *dev)
 {
-	const struct uhc_mcux_config *config = dev->config;
-	usb_phy_config_struct_t *phy_config;
+	const struct uhc_mcux_ehci_config *config = dev->config;
 	struct uhc_mcux_data *priv = uhc_get_private(dev);
 	k_thread_entry_t thread_entry = NULL;
 	usb_status_t status;
@@ -109,9 +108,8 @@ static int uhc_mcux_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_DT_HAS_NXP_USBPHY_ENABLED
-	phy_config = ((const struct uhc_mcux_ehci_config *)dev->config)->phy_config;
-	if (phy_config != NULL) {
-		USB_EhciPhyInit(priv->controller_id, 0u, phy_config);
+	if (config->phy_config != NULL) {
+		USB_EhciPhyInit(priv->controller_id, 0u, config->phy_config);
 	}
 #endif
 
@@ -125,8 +123,9 @@ static int uhc_mcux_init(const struct device *dev)
 	}
 
 	/* Create MCUX USB host driver task */
-	k_thread_create(&priv->drv_stack_data, config->drv_stack, CONFIG_UHC_NXP_THREAD_STACK_SIZE,
-			thread_entry, (void *)dev, NULL, NULL, K_PRIO_COOP(2), 0, K_NO_WAIT);
+	k_thread_create(&priv->drv_stack_data, config->uhc_config.drv_stack,
+			CONFIG_UHC_NXP_THREAD_STACK_SIZE, thread_entry,
+			(void *)dev, NULL, NULL, K_PRIO_COOP(2), 0, K_NO_WAIT);
 	k_thread_name_set(&priv->drv_stack_data, "uhc_mcux_ehci");
 
 	return 0;

--- a/drivers/usb/uhc/uhc_mcux_ip3516hs.c
+++ b/drivers/usb/uhc/uhc_mcux_ip3516hs.c
@@ -68,8 +68,7 @@ static usb_status_t mcux_host_callback(usb_device_handle deviceHandle,
 
 static int uhc_mcux_init(const struct device *dev)
 {
-	const struct uhc_mcux_config *config = dev->config;
-	usb_phy_config_struct_t *phy_config;
+	const struct uhc_mcux_ip3516hs_config *config = dev->config;
 	struct uhc_mcux_data *priv = uhc_get_private(dev);
 	k_thread_entry_t thread_entry = NULL;
 	usb_status_t status;
@@ -84,9 +83,8 @@ static int uhc_mcux_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_DT_HAS_NXP_USBPHY_ENABLED
-	phy_config = ((const struct uhc_mcux_ip3516hs_config *)dev->config)->phy_config;
-	if (phy_config != NULL) {
-		USB_EhciPhyInit(priv->controller_id, 0u, phy_config);
+	if (config->phy_config != NULL) {
+		USB_EhciPhyInit(priv->controller_id, 0u, config->phy_config);
 	}
 #endif
 
@@ -100,8 +98,9 @@ static int uhc_mcux_init(const struct device *dev)
 	}
 
 	/* Create MCUX USB host driver task */
-	k_thread_create(&priv->drv_stack_data, config->drv_stack, CONFIG_UHC_NXP_THREAD_STACK_SIZE,
-			thread_entry, (void *)dev, NULL, NULL, K_PRIO_COOP(2), 0, K_NO_WAIT);
+	k_thread_create(&priv->drv_stack_data, config->uhc_config.drv_stack,
+			CONFIG_UHC_NXP_THREAD_STACK_SIZE, thread_entry,
+			(void *)dev, NULL, NULL, K_PRIO_COOP(2), 0, K_NO_WAIT);
 	k_thread_name_set(&priv->drv_stack_data, "uhc_mcux_ip3516hs");
 
 	return 0;


### PR DESCRIPTION
Wrap phy_config declaration with CONFIG_DT_HAS_NXP_USBPHY_ENABLED to avoid compiler warning when USB PHY is not enabled.