### PR TITLE
boards: nxp: rw612_bga: enable USB host support

### DIFF
--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -257,6 +257,10 @@ zephyr_udc0: &usb_otg {
 	status = "okay";
 };
 
+zephyr_uhc0: &usbh {
+	status = "okay";
+};
+
 &dma0 {
 	status = "okay";
 };

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.yaml
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.yaml
@@ -28,6 +28,7 @@ supported:
   - pwm
   - spi
   - usb_device
+  - usb_host
   - watchdog
   - netif:eth
   - netif:openthread


### PR DESCRIPTION
Add USB host support for rw612_bga board:
- Update board YAML to include usb_host
- Add zephyr_uhc0 node in device tree with status "okay"