### PR TITLE
soc: nxp: rw: fix GAU clock configuration for ADC accuracy

### DIFF
--- a/soc/nxp/rw/soc.c
+++ b/soc/nxp/rw/soc.c
@@ -149,9 +149,9 @@ __weak __ramfunc void clock_init(void)
 
 #if defined(CONFIG_ADC_MCUX_GAU) || defined(CONFIG_DAC_MCUX_GAU) || \
 	defined(CONFIG_COMPARATOR_NXP_ACOMP)
-	/* Attack clock for GAU and reset */
-	CLOCK_AttachClk(kMAIN_CLK_to_GAU_CLK);
-	CLOCK_SetClkDiv(kCLOCK_DivGauClk, 1U);
+	/* Set 64M GAU clock from T3 PLL 256M and reset */
+	CLOCK_AttachClk(kT3PLL_MCI_256M_to_GAU_CLK);
+	CLOCK_SetClkDiv(kCLOCK_DivGauClk, 4U);
 	CLOCK_EnableClock(kCLOCK_Gau);
 	RESET_PeripheralReset(kGAU_RST_SHIFT_RSTn);
 	GAU_BG->CTRL &= ~BG_CTRL_PD_MASK;


### PR DESCRIPTION
Configure the GAU (General Analog Unit) clock from T3 PLL 256M with a divider of 4 to achieve 64MHz, replacing the previous configuration that used the main clock at 260MHz main clock with a divider of 1.

The GAU ADC has a maximum clock frequency limit of 64MHz. The previous 260MHz clock configuration caused incorrect conversion results when operating at 12-bit and 14-bit resolutions. Using the T3 PLL 256M source divided by 4 provides the correct 64MHz clock frequency.

This change also corrects a typo in the comment from "Attack clock" to "Set 64M GAU clock from T3 PLL 256M and reset".