### PR TITLE
subsys: logging: backends: fix mqtt log backend on client disconnect

### DIFF
--- a/subsys/logging/backends/log_backend_mqtt.c
+++ b/subsys/logging/backends/log_backend_mqtt.c
@@ -44,11 +44,7 @@ static int log_output_func(uint8_t *data, size_t length, void *output_ctx)
 	param.message_id = sys_rand32_get();
 #endif
 
-	int ret = mqtt_publish(client, &param);
-
-	if (ret != 0) {
-		return ret;
-	}
+	(void)mqtt_publish(client, &param);
 
 	return length;
 }


### PR DESCRIPTION
The MQTT logging backend can cause the logging thread to take over idle time when the used client disconnects/fails to send the log messages. Fixed by always returning the length of the log in every case. 

Fixes zephyrproject-rtos/zephyr#101064

Signed-off-by: Roland Lux <roland.lux@blue-zone.at>

