### PR TITLE
coredump: arm: Callee registers for armv6-m and v8-m baseline

### DIFF
--- a/arch/arm/core/cortex_m/swap_helper.S
+++ b/arch/arm/core/cortex_m/swap_helper.S
@@ -460,28 +460,36 @@ SECTION_FUNC(TEXT, z_arm_svc)
 .L_oops:
     push {r0, lr}
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-#if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
     /* Build _callee_saved_t. To match the struct
      * definition we push the psp & then r11-r4
      */
     mrs r1, PSP
-    push {r1, r2}
+    push {r1, r2} /* r2 for padding */
+#if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
     push {r4-r11}
+#elif defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+    mov  r1, r10
+    mov  r2, r11
+    push {r1, r2}
+    mov  r1, r8
+    mov  r2, r9
+    push {r1, r2}
+    push {r4-r7}
+#else
+#error Unknown ARM architecture
+#endif
     mov  r1, sp /* pointer to _callee_saved_t */
-#endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
     mov r2, lr /* EXC_RETURN */
     bl z_do_kernel_oops
     /* return from SVC exception is done here */
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-#if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
     /* We do not need to restore any register state here
      * because we did not use any callee-saved registers
      * in this routine. Therefore, we can just reset
      * the MSP to its value prior to entering the function
      */
     add sp, #40
-#endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
     pop {r0, pc}
 

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -137,21 +137,11 @@ void z_do_kernel_oops(const struct arch_esf *esf, _callee_saved_t *callee_regs, 
 	struct arch_esf esf_copy;
 
 	memcpy(&esf_copy, esf, offsetof(struct arch_esf, extra_info));
-#if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	/* extra exception info is collected in callee_reg param
-	 * on CONFIG_ARMV7_M_ARMV8_M_MAINLINE
-	 */
+	/* extra exception info is collected in callee_reg. */
 
 	esf_copy.extra_info = (struct __extra_esf_info) {
 		.callee = callee_regs,
 	};
-#else
-	/* extra exception info is not collected for kernel oops
-	 * path today so we make a copy of the ESF and zero out
-	 * that information
-	 */
-	esf_copy.extra_info = (struct __extra_esf_info) { 0 };
-#endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 
 	z_arm_fatal_error(reason, &esf_copy);
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */


### PR DESCRIPTION
Ensure callee registers included in coredump. Push callee registers onto stack for CONFIG_ARMV6_M_ARMV8_M_BASELINE as well when CONFIG_EXTRA_EXCEPTION_INFO enabled.

Effectively a complement to df6b8c3 by @mrkhldn.