### PR TITLE
MAINTAINERS: add butok collaborator for NXP drivers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3491,6 +3491,7 @@ NXP Platform Drivers:
     - dbaluta
     - Holt-Sun
     - zejiang0jason
+    - butok
   files-regex:
     - ^drivers/.*nxp.*
     - ^drivers/.*mcux.*


### PR DESCRIPTION
Add "butok" (Andrej Butok) as a collaborator for "NXP Platform Drivers".