### PR TITLE
dts: arm: st: f2: add adc2 and adc3 to devicetree

### DIFF
--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -388,6 +388,44 @@
 			status = "disabled";
 		};
 
+		adc2: adc@40012100 {
+			compatible = "st,stm32f4-adc", "st,stm32-adc";
+			reg = <0x40012100 0x50>;
+			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
+			clock-names = "adcx";
+			interrupts = <18 0>;
+			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 15 28 58 84 112 144 480>;
+			st,adc-clock-source = "SYNC";
+			st,adc-sequencer = "programmable";
+			st,adc-oversampler = "none";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
+		};
+
+		adc3: adc@40012200 {
+			compatible = "st,stm32f4-adc", "st,stm32-adc";
+			reg = <0x40012200 0x50>;
+			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
+			clock-names = "adcx";
+			interrupts = <18 0>;
+			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 15 28 58 84 112 144 480>;
+			st,adc-clock-source = "SYNC";
+			st,adc-sequencer = "programmable";
+			st,adc-oversampler = "none";
+			st,adc-internal-regulator = "none";
+			status = "disabled";
+		};
+
 		dma1: dma@40026000 {
 			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;


### PR DESCRIPTION
Add missing ADC2 and ADC3 nodes to stm32f2.dtsi.

Signed-off-by: Jaagup Averin <jaagup.averin@gmail.com>