### PR TITLE
wifi: coex: Fix 54H CPURAD

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -219,9 +219,10 @@ slot3_partition: &cpurad_slot1_partition {
 	memory-regions = <&cpuapp_dma_region>;
 };
 
+/* Leave one channel for CPURAD */
 &gpiote130 {
 	status = "okay";
-	owned-channels = <0 1 2 3 4 5 6 7>;
+	owned-channels = <0 1 2 3 4 5 6>;
 };
 
 &gpio0 {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -135,3 +135,8 @@ zephyr_udc0: &usbhs {
 		};
 	};
 };
+
+/* For coex-grant GPIO */
+&gpiote130 {
+	owned-channels = <7>;
+};

--- a/boards/shields/nrf7002eb/Kconfig.shield
+++ b/boards/shields/nrf7002eb/Kconfig.shield
@@ -6,3 +6,6 @@ config SHIELD_NRF7002EB
 
 config SHIELD_NRF7002EB_COEX
 	def_bool $(shields_list_contains,nrf7002eb_coex)
+
+config SHIELD_NRF7002EB_COEX_SA
+	def_bool $(shields_list_contains,nrf7002eb_coex_sa)

--- a/boards/shields/nrf7002eb/doc/index.rst
+++ b/boards/shields/nrf7002eb/doc/index.rst
@@ -51,6 +51,7 @@ edge-connector on some boards, like earlier revisions of the Thingy53 than v1.0.
 
 - ``nrf7002eb``: The default variant.
 - ``nrf7002eb_coex``: Variant which includes the COEX pins.
+- ``nrf7002eb_coex_sa``: Variant which includes the COEX pins and is standalone.
 
 SR Co-existence
 ***************

--- a/boards/shields/nrf7002eb/nrf7002eb_coex_sa.overlay
+++ b/boards/shields/nrf7002eb/nrf7002eb_coex_sa.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	nrf_radio_coex: coex {
+		compatible = "nordic,nrf7002-coex";
+		status = "okay";
+
+		status0-gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
+		req-gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+		grant-gpios = <&gpio1 3 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpiote130 {
+	status = "okay";
+};

--- a/boards/shields/nrf7002eb/shield.yml
+++ b/boards/shields/nrf7002eb/shield.yml
@@ -10,3 +10,9 @@ shields:
     vendor: nordic
     supported_features:
       - wifi
+
+  - name: nrf7002eb_coex_sa
+    full_name: nRF7002 Evaluation Board Shield (SR Co-Existence) standalone
+    vendor: nordic
+    supported_features:
+      - wifi


### PR DESCRIPTION
Fixes for CPURAD boot and also to get the Wi-Fi BLE coex working in 54H.