### PR TITLE
modem: ppp: Fix remaining net API use

### DIFF
--- a/subsys/modem/modem_ppp.c
+++ b/subsys/modem/modem_ppp.c
@@ -232,7 +232,7 @@ static void modem_ppp_process_received_byte(struct modem_ppp *ppp, uint8_t byte)
 	case MODEM_PPP_RECEIVE_STATE_HDR_23:
 		if (modem_ppp_is_byte_expected(byte, 0x23)) {
 			ppp->rx_pkt = net_pkt_rx_alloc_with_buffer(ppp->iface,
-				CONFIG_MODEM_PPP_NET_BUF_FRAG_SIZE, AF_UNSPEC, 0, K_NO_WAIT);
+				CONFIG_MODEM_PPP_NET_BUF_FRAG_SIZE, NET_AF_UNSPEC, 0, K_NO_WAIT);
 
 			if (ppp->rx_pkt == NULL) {
 				LOG_WRN("Dropped frame, no net_pkt available");

--- a/tests/subsys/modem/modem_ppp/src/main.c
+++ b/tests/subsys/modem/modem_ppp/src/main.c
@@ -377,7 +377,7 @@ ZTEST(modem_ppp, test_ppp_frame_send)
 	int ret;
 
 	/* Allocate net pkt */
-	pkt = net_pkt_alloc_with_buffer(&test_iface, 256, AF_UNSPEC, 0, K_NO_WAIT);
+	pkt = net_pkt_alloc_with_buffer(&test_iface, 256, NET_AF_UNSPEC, 0, K_NO_WAIT);
 
 	zassert_true(pkt != NULL, "Failed to allocate network packet");
 
@@ -406,7 +406,7 @@ ZTEST(modem_ppp, test_ppp_frame_send_custom_accm1)
 	int ret;
 
 	/* Allocate net pkt */
-	pkt = net_pkt_alloc_with_buffer(&test_iface, 256, AF_UNSPEC, 0, K_NO_WAIT);
+	pkt = net_pkt_alloc_with_buffer(&test_iface, 256, NET_AF_UNSPEC, 0, K_NO_WAIT);
 
 	zassert_true(pkt != NULL, "Failed to allocate network packet");
 
@@ -437,7 +437,7 @@ ZTEST(modem_ppp, test_ppp_frame_send_custom_accm2)
 	int ret;
 
 	/* Allocate net pkt */
-	pkt = net_pkt_alloc_with_buffer(&test_iface, 256, AF_UNSPEC, 0, K_NO_WAIT);
+	pkt = net_pkt_alloc_with_buffer(&test_iface, 256, NET_AF_UNSPEC, 0, K_NO_WAIT);
 
 	zassert_true(pkt != NULL, "Failed to allocate network packet");
 
@@ -495,7 +495,7 @@ ZTEST(modem_ppp, test_ip_frame_send)
 	int ret;
 
 	/* Allocate net pkt */
-	pkt = net_pkt_alloc_with_buffer(&test_iface, 256, AF_UNSPEC, 0, K_NO_WAIT);
+	pkt = net_pkt_alloc_with_buffer(&test_iface, 256, NET_AF_UNSPEC, 0, K_NO_WAIT);
 	zassert_true(pkt != NULL, "Failed to allocate network packet");
 
 	/* Set network packet data */
@@ -524,7 +524,7 @@ ZTEST(modem_ppp, test_ip_frame_send_multiple)
 
 	/* Allocate net pkts */
 	for (uint8_t i = 0; i < TEST_MODEM_PPP_IP_FRAME_SEND_MULT_N; i++) {
-		pkts[i] = net_pkt_alloc_with_buffer(&test_iface, 256, AF_UNSPEC, 0, K_NO_WAIT);
+		pkts[i] = net_pkt_alloc_with_buffer(&test_iface, 256, NET_AF_UNSPEC, 0, K_NO_WAIT);
 		zassert_true(pkts[i] != NULL, "Failed to allocate network packet");
 		net_pkt_cursor_init(pkts[i]);
 		ret = net_pkt_write(pkts[i], ip_frame_unwrapped, sizeof(ip_frame_unwrapped));
@@ -551,7 +551,7 @@ ZTEST(modem_ppp, test_ip_frame_send_large)
 	int ret;
 
 	pkt = net_pkt_alloc_with_buffer(&test_iface, TEST_MODEM_PPP_IP_FRAME_SEND_LARGE_N,
-					AF_UNSPEC, 0, K_NO_WAIT);
+					NET_AF_UNSPEC, 0, K_NO_WAIT);
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_set_family(pkt, NET_AF_INET);


### PR DESCRIPTION
In d45cd6716bbab3a805e3a5fd461934f0dcdc13e5 the mayority of the Zephyr codebased was changed to use the Zephyr native net_ prefixed types, but some were forgotten.
Without this fix/change the code still builds as we are by now setting CONFIG_NET_NAMESPACE_COMPAT_MODE. But when this is not set, things fail to build.