### PR TITLE
mgmt: mcumgr: Fix remaining net API use

### DIFF
--- a/include/zephyr/mgmt/mcumgr/transport/smp_udp.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp_udp.h
@@ -58,7 +58,7 @@ int smp_udp_close(void);
  * @return	0 on success
  * @return	-errno code on failure.
  */
-int smp_client_udp_set_host_addr(struct smp_client_object *obj, struct sockaddr *addr);
+int smp_client_udp_set_host_addr(struct smp_client_object *obj, struct net_sockaddr *addr);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
In d45cd6716bbab3a805e3a5fd461934f0dcdc13e5 the mayority of the Zephyr codebased was changed to use the Zephyr native net_ prefixed types, but some were forgotten.
Without this fix/change the code still builds as we are by now setting CONFIG_NET_NAMESPACE_COMPAT_MODE. But when this is not set, things fail to build.