### PR TITLE
dts: arm: nxp: rt118x: correct ocram1_available address

### DIFF
--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -1628,7 +1628,7 @@
 
 		ocram1_available: memory@4000 {
 			/* OCRAM1 first 16K access is blocked by TRDC */
-			reg = <0x0 DT_SIZE_K(496)>;
+			reg = <0x4000 DT_SIZE_K(496)>;
 		};
 	};
 


### PR DESCRIPTION
correct ocram1_available reg address to fix warning log