### PR TITLE
drivers: ethernet: dsa_nxp_imx_netc: Fix net API use

### DIFF
--- a/drivers/ethernet/dsa/dsa_nxp_imx_netc.c
+++ b/drivers/ethernet/dsa/dsa_nxp_imx_netc.c
@@ -142,7 +142,7 @@ static int dsa_netc_switch_setup(const struct dsa_switch_context *dsa_switch_ctx
 	 * Trap gPTP frames to cpu port to perform gPTP protocol.
 	 */
 	netc_tb_ipf_config_t ipf_entry_cfg = {
-		.keye.etherType = htons(NET_ETH_PTYPE_PTP),
+		.keye.etherType = net_htons(NET_ETH_PTYPE_PTP),
 		.keye.etherTypeMask = 0xffff,
 		.keye.srcPort = 0,
 		.keye.srcPortMask = 0x0,


### PR DESCRIPTION
In e6daacf3c9e3fbe879fe5b3cd451550d64d60784 the mayority of the ethernet drivers code was changed to use the Zephyr native net_ prefixed symbols, but some were forgotten.
Without this fix/change the code still builds as we are by now setting CONFIG_NET_NAMESPACE_COMPAT_MODE. But when this is not set, things fail to build.