### PR TITLE
soc: st: stm32n6: Add DCMIPP CSI IRQ

### DIFF
--- a/drivers/video/Kconfig.stm32_dcmipp
+++ b/drivers/video/Kconfig.stm32_dcmipp
@@ -42,4 +42,11 @@ config VIDEO_STM32_DCMIPP_SENSOR_PIXEL_FORMAT
 	help
 	  Pixel format of the sensor video frame.
 
+config VIDEO_STM32_DCMIPP_CSI_ENABLE_IRQ
+	bool "CSI Interrupt"
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_DCMIPP),interrupt-names,dcmipp_csi)
+	help
+	  Enable the secondary DCMIPP interrupt dedicated to the CSI host. HAL callbacks
+	  HAL_DCMIPP_CSI_*Callback will be invoked and can be implemented by applications.
+
 endif

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1828,6 +1828,15 @@ static void stm32_dcmipp_isr(const struct device *dev)
 	HAL_DCMIPP_IRQHandler(&dcmipp->hdcmipp);
 }
 
+#if defined(STM32_DCMIPP_HAS_CSI) && defined(CONFIG_VIDEO_STM32_DCMIPP_CSI_ENABLE_IRQ)
+static void stm32_dcmipp_csi_isr(const struct device *dev)
+{
+	struct stm32_dcmipp_data *dcmipp = dev->data;
+
+	HAL_DCMIPP_CSI_IRQHandler(&dcmipp->hdcmipp);
+}
+#endif
+
 #define SOURCE_DEV(inst) DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(inst, 0, 0)))
 
 #define DCMIPP_PIPE_INIT_DEFINE(node_id, inst)						\
@@ -1856,8 +1865,20 @@ static void stm32_dcmipp_isr(const struct device *dev)
 					    (0),						\
 					    (DT_PROP_BY_IDX(DT_INST_ENDPOINT_BY_ID(inst, 0, 0),	\
 							    data_lanes, 1))),
+
+#if defined(CONFIG_VIDEO_STM32_DCMIPP_CSI_ENABLE_IRQ)
+#define STM32_DCMIPP_CSI_IRQ_INIT(inst)								\
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, dcmipp_csi, irq),				\
+			    DT_INST_IRQ_BY_NAME(inst, dcmipp_csi, priority),			\
+			    stm32_dcmipp_csi_isr, DEVICE_DT_INST_GET(inst), 0);			\
+		irq_enable(DT_INST_IRQ_BY_NAME(inst, dcmipp_csi, irq));
+#else
+#define STM32_DCMIPP_CSI_IRQ_INIT(inst)
+#endif
+
 #else
 #define STM32_DCMIPP_CSI_DT_PARAMS(inst)
+#define STM32_DCMIPP_CSI_IRQ_INIT(inst)
 #endif
 
 #if defined(STM32_DCMIPP_HAS_PIXEL_PIPES)
@@ -1871,9 +1892,11 @@ static void stm32_dcmipp_isr(const struct device *dev)
 #define STM32_DCMIPP_INIT(inst)									\
 	static void stm32_dcmipp_irq_config_##inst(const struct device *dev)			\
 	{											\
-		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority),			\
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, dcmipp, irq),				\
+			    DT_INST_IRQ_BY_NAME(inst, dcmipp, priority),			\
 			    stm32_dcmipp_isr, DEVICE_DT_INST_GET(inst), 0);			\
-		irq_enable(DT_INST_IRQN(inst));							\
+		irq_enable(DT_INST_IRQ_BY_NAME(inst, dcmipp, irq));				\
+		STM32_DCMIPP_CSI_IRQ_INIT(inst)							\
 	}											\
 												\
 	static struct stm32_dcmipp_data stm32_dcmipp_data_##inst = {				\

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1026,6 +1026,7 @@
 				 <&rcc STM32_SRC_PCLK5 NO_SEL>;
 			clock-names = "dcmipp", "dcmipp-ker";
 			interrupts = <95 0>;
+			interrupt-names = "dcmipp";
 			resets = <&rctl STM32_RESET(APB5, 2)>;
 			status = "disabled";
 

--- a/dts/arm/st/mp13/stm32mp135.dtsi
+++ b/dts/arm/st/mp13/stm32mp135.dtsi
@@ -15,6 +15,7 @@
 			compatible = "st,stm32-dcmipp";
 			reg = <0x5a000000 0x400>;
 			interrupts = <GIC_SPI 79 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "dcmipp";
 			clocks = <&rcc STM32_CLOCK(APB4, 1)>,
 				 <&rcc STM32_SRC_PLL2_Q DCMIPP_SEL(1)>;
 			clock-names = "dcmipp", "dcmipp-ker";

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -776,7 +776,8 @@
 			clocks = <&rcc STM32_CLOCK(APB5, 2)>,
 				 <&rcc STM32_SRC_IC17 DCMIPP_SEL(2)>,
 				 <&rcc STM32_CLOCK(APB5, 6)>;
-			interrupts = <48 0>;
+			interrupts = <48 0>, <47 0>;
+			interrupt-names = "dcmipp", "dcmipp_csi";
 			resets = <&rctl STM32_RESET(APB5, 2)>,
 				 <&rctl STM32_RESET(APB5, 6)>;
 			status = "disabled";

--- a/dts/bindings/video/st,stm32-dcmipp.yaml
+++ b/dts/bindings/video/st,stm32-dcmipp.yaml
@@ -49,6 +49,10 @@ properties:
   interrupts:
     required: true
 
+  interrupt-names:
+    required: true
+    enum: ["dcmipp", "dcmipp_csi"]
+
   resets:
     required: true
 


### PR DESCRIPTION
Currently, the DCMIPP driver for the STM32N6 only implements the DCMIPP's own IRQ. However, the CSI part of the DCMIPP has its own IRQ, which may be useful in some applications.

This PR adds the CSI IRQ to the STM32N6 devicetree and routes it to the ST HAL, just like the main DCMIPP ISR. Applications and libraries can then implement the various `HAL_DCMIPP_CSI_*Callback` weak methods they are interested in.

To demonstrate this, simply add something like below to the `drivers/video/capture` sample to log every CSI SOF:
```diff
diff --git a/samples/drivers/video/capture/src/main.c b/samples/drivers/video/capture/src/main.c
index f1b54aae110..bf5d86fc4c4 100644
--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -19,6 +19,11 @@ LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);
 #error No camera chosen in devicetree. Missing "--shield" or "--snippet video-sw-generator" flag?
 #endif
 
+void HAL_DCMIPP_CSI_StartOfFrameEventCallback(DCMIPP_HandleTypeDef *hdcmipp, uint32_t VirtualChannel)
+{
+       LOG_INF("DCMIPP CSI IRQ!");
+}
+
 static inline int app_setup_display(const struct device *const display_dev, const uint32_t pixfmt)
 {
        struct display_capabilities capabilities;
```

As far as I can tell, only the N6 has the DCMIPP with CSI, so I only added the new IRQ to this SoC.

Please let me know if anything should be changed or more specific APIs for the various CSI events and errors are wanted.