### PR TITLE
drivers: modem: Fix net API use

### DIFF
--- a/drivers/modem/hl78xx/hl78xx_sockets.c
+++ b/drivers/modem/hl78xx/hl78xx_sockets.c
@@ -60,11 +60,11 @@ RING_BUF_DECLARE(mdm_recv_pool, CONFIG_MODEM_HL78XX_UART_BUFFER_SIZES);
 struct hl78xx_dns_info {
 #ifdef CONFIG_NET_IPV4
 	char v4_string[NET_IPV4_ADDR_LEN];
-	struct in_addr v4;
+	struct net_in_addr v4;
 #endif
 #ifdef CONFIG_NET_IPV6
 	char v6_string[NET_IPV6_ADDR_LEN];
-	struct in6_addr v6;
+	struct net_in6_addr v6;
 #endif
 	bool ready;
 };
@@ -72,19 +72,19 @@ struct hl78xx_dns_info {
 /* IPv4 information is optional and only present when IPv4 is enabled */
 #ifdef CONFIG_NET_IPV4
 struct hl78xx_ipv4_info {
-	struct in_addr addr;
-	struct in_addr subnet;
-	struct in_addr gateway;
-	struct in_addr new_addr;
+	struct net_in_addr addr;
+	struct net_in_addr subnet;
+	struct net_in_addr gateway;
+	struct net_in_addr new_addr;
 };
 #endif
 /* IPv6 information is optional and only present when IPv6 is enabled */
 #ifdef CONFIG_NET_IPV6
 struct hl78xx_ipv6_info {
-	struct in6_addr addr;
-	struct in6_addr subnet;
-	struct in6_addr gateway;
-	struct in6_addr new_addr;
+	struct net_in6_addr addr;
+	struct net_in6_addr subnet;
+	struct net_in6_addr gateway;
+	struct net_in6_addr new_addr;
 };
 #endif
 /* TLS information is optional and only present when TLS is enabled */
@@ -1776,7 +1776,7 @@ static void check_tcp_state_if_needed(struct hl78xx_socket_data *socket_data,
 {
 	const char *check_ktcp_stat = "AT+KTCPSTAT";
 	/* Only check for TCP sockets */
-	if (sock->type != SOCK_STREAM) {
+	if (sock->type != NET_SOCK_STREAM) {
 		return;
 	}
 	if (atomic_test_and_clear_bit(&socket_data->mdata_global->state_leftover,
@@ -2229,7 +2229,7 @@ static ssize_t offload_write(void *obj, const void *buffer, size_t count)
 static ssize_t offload_sendmsg(void *obj, const struct net_msghdr *msg, int flags)
 {
 	ssize_t sent = 0;
-	struct iovec bkp_iovec = {0};
+	struct net_iovec bkp_iovec = {0};
 	struct net_msghdr crafted_msg = {
 		.msg_name = msg->msg_name,
 		.msg_namelen = msg->msg_namelen

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -519,7 +519,7 @@ exit:
  */
 static ssize_t offload_sendto(void *obj, const void *buf, size_t len,
 			      int flags, const struct net_sockaddr *to,
-			      socklen_t tolen)
+			      net_socklen_t tolen)
 {
 	int ret;
 	struct modem_socket *sock = (struct modem_socket *) obj;
@@ -576,7 +576,7 @@ static ssize_t offload_sendto(void *obj, const void *buf, size_t len,
  */
 static ssize_t offload_recvfrom(void *obj, void *buf, size_t len,
 				int flags, struct net_sockaddr *from,
-				socklen_t *fromlen)
+				net_socklen_t *fromlen)
 {
 	struct modem_socket *sock = (struct modem_socket *)obj;
 	char   sendbuf[sizeof("AT+QIRD=##,####")] = {0};
@@ -685,7 +685,7 @@ static int offload_ioctl(void *obj, unsigned int request, va_list args)
  * Desc: This function will connect with a provided TCP.
  */
 static int offload_connect(void *obj, const struct net_sockaddr *addr,
-						   socklen_t addrlen)
+						   net_socklen_t addrlen)
 {
 	struct modem_socket *sock     = (struct modem_socket *) obj;
 	uint16_t	    dst_port  = 0;

--- a/drivers/modem/simcom/sim7080/sim7080_dns.c
+++ b/drivers/modem/simcom/sim7080/sim7080_dns.c
@@ -99,7 +99,7 @@ static int offload_getaddrinfo(const char *node, const char *service,
 
 	if (port > 0U) {
 		if (dns_result.ai_family == NET_AF_INET) {
-			net_sin(&dns_result_addr)->sin_port = htons(port);
+			net_sin(&dns_result_addr)->sin_port = net_htons(port);
 		}
 	}
 
@@ -111,7 +111,7 @@ static int offload_getaddrinfo(const char *node, const char *service,
 	}
 
 	/* user flagged node as numeric host, but we failed net_addr_pton */
-	if (hints && hints->ai_flags & AI_NUMERICHOST) {
+	if (hints && hints->ai_flags & ZSOCK_AI_NUMERICHOST) {
 		return DNS_EAI_NONAME;
 	}
 

--- a/drivers/modem/simcom/sim7080/sim7080_sock.c
+++ b/drivers/modem/simcom/sim7080/sim7080_sock.c
@@ -31,7 +31,7 @@ MODEM_CMD_DEFINE(on_cmd_caopen)
 /*
  * Connects an modem socket. Protocol can either be TCP or UDP.
  */
-static int offload_connect(void *obj, const struct net_sockaddr *addr, socklen_t addrlen)
+static int offload_connect(void *obj, const struct net_sockaddr *addr, net_socklen_t addrlen)
 {
 	struct modem_socket *sock = (struct modem_socket *)obj;
 	uint16_t dst_port = 0;
@@ -67,7 +67,7 @@ static int offload_connect(void *obj, const struct net_sockaddr *addr, socklen_t
 	}
 
 	/* Get protocol */
-	protocol = (sock->type == SOCK_STREAM) ? "TCP" : "UDP";
+	protocol = (sock->type == NET_SOCK_STREAM) ? "TCP" : "UDP";
 
 	ret = modem_context_sprint_ip_addr(addr, ip_str, sizeof(ip_str));
 	if (ret != 0) {
@@ -304,7 +304,7 @@ MODEM_CMD_DEFINE(on_cmd_carecv)
  * Read data from a given socket.
  */
 static ssize_t offload_recvfrom(void *obj, void *buf, size_t max_len, int flags,
-				struct net_sockaddr *src_addr, socklen_t *addrlen)
+				struct net_sockaddr *src_addr, net_socklen_t *addrlen)
 {
 	struct modem_socket *sock = (struct modem_socket *)obj;
 	char sendbuf[sizeof("AT+CARECV=##,####")];

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1465,7 +1465,7 @@ static int offload_get(net_sa_family_t family,
 
 static int offload_bind(struct net_context *context,
 			const struct net_sockaddr *addr,
-			socklen_t addrlen)
+			net_socklen_t addrlen)
 {
 	struct wncm14a2a_socket *sock = NULL;
 
@@ -1505,7 +1505,7 @@ static int offload_listen(struct net_context *context, int backlog)
 
 static int offload_connect(struct net_context *context,
 			   const struct net_sockaddr *addr,
-			   socklen_t addrlen,
+			   net_socklen_t addrlen,
 			   net_context_connect_cb_t cb,
 			   int32_t timeout,
 			   void *user_data)
@@ -1590,7 +1590,7 @@ static int offload_accept(struct net_context *context,
 
 static int offload_sendto(struct net_pkt *pkt,
 			  const struct net_sockaddr *dst_addr,
-			  socklen_t addrlen,
+			  net_socklen_t addrlen,
 			  net_context_send_cb_t cb,
 			  int32_t timeout,
 			  void *user_data)
@@ -1629,7 +1629,7 @@ static int offload_send(struct net_pkt *pkt,
 			void *user_data)
 {
 	struct net_context *context = net_pkt_context(pkt);
-	socklen_t addrlen;
+	net_socklen_t addrlen;
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) && net_pkt_family(pkt) == NET_AF_INET6) {
 		addrlen = sizeof(struct net_sockaddr_in6);


### PR DESCRIPTION
In b5588ed684365eedfb55822804af3d0c3cd944ab, and after in e19d78e6070c4c3a2d315219d38ea66a100ec161 the mayority of the Zephyr modem drivers were changed to use the Zephyr native net_ prefixed types, but a few were missing.
Without this fix/change the code still builds as we are by now setting CONFIG_NET_NAMESPACE_COMPAT_MODE. But when this is not set, things fail to build.

They have been tested by building the corresponding build test from `tests/drivers/build_all/modem/` setting `CONFIG_NET_NAMESPACE_COMPAT_MODE=n`.  (except for hello_hl78xx which doesn't have a test there and was built with samples/drivers/modem/hello_hl78xx)