### PR TITLE
tests: net: socket: offload_dispatcher: Add extra test case for TLS

### DIFF
--- a/tests/net/socket/offload_dispatcher/src/main.c
+++ b/tests/net/socket/offload_dispatcher/src/main.c
@@ -845,6 +845,44 @@ ZTEST(net_socket_offload_tls, test_tls_native_iface_native)
 	zassert_equal(0, ret, "sendto() should've been dispatched to native iface");
 }
 
+/* Verify that the TLS and underlying sockets are dispatched to a native socket
+ * implementation if the socket is bound to a native interface.
+ */
+ZTEST(net_socket_offload_tls, test_tls_native_iface_native_bindtodevice_only)
+{
+	int ret;
+	const struct fd_op_vtable *vtable;
+	void *obj;
+	struct net_ifreq ifreq = {
+#if defined(CONFIG_NET_INTERFACE_NAME)
+		.ifr_name = "dummy0"
+#else
+		.ifr_name = "dummy_native"
+#endif
+	};
+	struct net_sockaddr_in addr = test_peer_addr;
+
+	ret = zsock_setsockopt(test_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_BINDTODEVICE,
+			       &ifreq, sizeof(ifreq));
+	zassert_ok(ret, "setsockopt() failed");
+	zassert_false(test_socket_ctx[OFFLOAD_1].socket_called,
+		     "Underlying socket dispatched to wrong iface");
+	zassert_false(test_socket_ctx[OFFLOAD_2].socket_called,
+		     "Underlying socket dispatched to wrong iface");
+
+	obj = zvfs_get_fd_obj_and_vtable(test_sock, &vtable, NULL);
+	zassert_not_null(obj, "No obj found");
+	zassert_true(net_socket_is_tls(obj), "Socket is not a native TLS sock");
+
+	/* Ignore connect result as it will fail anyway. Just verify the
+	 * call/packets were forwarded to a valid iface.
+	 */
+	(void)zsock_connect(test_sock, (struct net_sockaddr *)&addr, sizeof(addr));
+
+	ret = k_sem_take(&test_native_send_called, K_MSEC(200));
+	zassert_ok(ret, "sendto() should've been dispatched to native iface");
+}
+
 ZTEST_SUITE(net_socket_offload_udp, NULL, NULL, test_socket_setup_udp,
 	    test_socket_teardown, NULL);
 ZTEST_SUITE(net_socket_offload_tls, NULL, NULL, test_socket_setup_tls,


### PR DESCRIPTION
Socket dispatcher should create a native TLS socket with a native underlying socket even if the socket is only bound to a native interface, it shouldn't be needed to call ZSOCK_TLS_NATIVE specifically. This works just fine, so add a test case for this scenario to make sure it remains that way.