### PR TITLE
drivers: wifi: Fix net API use

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -575,7 +575,7 @@ MODEM_CMD_DEFINE(on_cmd_cipdns)
 		}
 
 		addrs[i].sin_family = NET_AF_INET;
-		addrs[i].sin_port = htons(53);
+		addrs[i].sin_port = net_htons(53);
 
 		valid_servers++;
 	}
@@ -891,7 +891,7 @@ static int cmd_ipd_parse_hdr(struct esp_data *dev,
 		}
 
 		recv_addr->sin_family = NET_AF_INET;
-		recv_addr->sin_port = htons(port);
+		recv_addr->sin_port = net_htons(port);
 	}
 
 	*data_offset = (str - ipd_buf);

--- a/drivers/wifi/esp_at/esp.h
+++ b/drivers/wifi/esp_at/esp.h
@@ -224,9 +224,9 @@ struct esp_data {
 	enum wifi_conn_status conn_status;
 
 	/* addresses  */
-	struct in_addr ip;
-	struct in_addr gw;
-	struct in_addr nm;
+	struct net_in_addr ip;
+	struct net_in_addr gw;
+	struct net_in_addr nm;
 	uint8_t mac_addr[6];
 #if defined(ESP_MAX_DNS)
 	struct net_sockaddr_in dns_addresses[ESP_MAX_DNS];

--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -151,7 +151,7 @@ void esp_connect_work(struct k_work *work)
 }
 
 static int esp_bind(struct net_context *context, const struct net_sockaddr *addr,
-		    socklen_t addrlen)
+		    net_socklen_t addrlen)
 {
 	struct esp_socket *sock;
 	struct esp_data *dev;
@@ -182,7 +182,7 @@ static int esp_bind(struct net_context *context, const struct net_sockaddr *addr
 
 static int esp_connect(struct net_context *context,
 		       const struct net_sockaddr *addr,
-		       socklen_t addrlen,
+		       net_socklen_t addrlen,
 		       net_context_connect_cb_t cb,
 		       int32_t timeout,
 		       void *user_data)
@@ -422,7 +422,7 @@ void esp_send_work(struct k_work *work)
 
 static int esp_sendto(struct net_pkt *pkt,
 		      const struct net_sockaddr *dst_addr,
-		      socklen_t addrlen,
+		      net_socklen_t addrlen,
 		      net_context_send_cb_t cb,
 		      int32_t timeout,
 		      void *user_data)

--- a/drivers/wifi/esp_at/esp_socket.c
+++ b/drivers/wifi/esp_at/esp_socket.c
@@ -180,7 +180,7 @@ void esp_socket_rx(struct esp_socket *sock, struct net_buf *buf,
 	pkt = esp_socket_prepare_pkt(sock, buf, offset, len);
 	if (!pkt) {
 		LOG_ERR("Failed to get net_pkt: len %zu", len);
-		if (esp_socket_type(sock) == SOCK_STREAM) {
+		if (esp_socket_type(sock) == NET_SOCK_STREAM) {
 			if (!esp_socket_flags_test_and_set(sock,
 						ESP_SOCK_CLOSE_PENDING)) {
 				esp_socket_work_submit(sock, &sock->close_work);

--- a/drivers/wifi/eswifi/eswifi.h
+++ b/drivers/wifi/eswifi/eswifi.h
@@ -141,7 +141,7 @@ int __eswifi_off_start_client(struct eswifi_dev *eswifi,
 int __eswifi_listen(struct eswifi_dev *eswifi, struct eswifi_off_socket *socket, int backlog);
 int __eswifi_accept(struct eswifi_dev *eswifi, struct eswifi_off_socket *socket);
 int __eswifi_bind(struct eswifi_dev *eswifi, struct eswifi_off_socket *socket,
-		  const struct net_sockaddr *addr, socklen_t addrlen);
+		  const struct net_sockaddr *addr, net_socklen_t addrlen);
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
 int eswifi_socket_offload_init(struct eswifi_dev *leswifi);
 #endif

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -257,7 +257,7 @@ static void eswifi_scan(struct eswifi_dev *eswifi)
 static int eswifi_connect(struct eswifi_dev *eswifi)
 {
 	char connect[] = "C0\r";
-	struct in_addr addr;
+	struct net_in_addr addr;
 	char *rsp;
 	int err;
 

--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -22,7 +22,7 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 static int eswifi_off_bind(struct net_context *context,
 			   const struct net_sockaddr *addr,
-			   socklen_t addrlen)
+			   net_socklen_t addrlen)
 {
 	struct eswifi_off_socket *socket = context->offload_context;
 	struct eswifi_dev *eswifi = eswifi_by_iface_idx(context->iface);
@@ -98,7 +98,7 @@ static void eswifi_off_connect_work(struct k_work *work)
 
 static int eswifi_off_connect(struct net_context *context,
 			      const struct net_sockaddr *addr,
-			      socklen_t addrlen,
+			      net_socklen_t addrlen,
 			      net_context_connect_cb_t cb,
 			      int32_t timeout,
 			      void *user_data)
@@ -295,7 +295,7 @@ static int eswifi_off_send(struct net_pkt *pkt,
 
 static int eswifi_off_sendto(struct net_pkt *pkt,
 			     const struct net_sockaddr *dst_addr,
-			     socklen_t addrlen,
+			     net_socklen_t addrlen,
 			     net_context_send_cb_t cb,
 			     int32_t timeout,
 			     void *user_data)
@@ -446,7 +446,7 @@ void eswifi_offload_async_msg(struct eswifi_dev *eswifi, char *msg, size_t len)
 
 	if (!strncmp(msg, msg_tcp_accept, sizeof(msg_tcp_accept) - 1)) {
 		struct eswifi_off_socket *socket = NULL;
-		struct in_addr *sin_addr;
+		struct net_in_addr *sin_addr;
 		uint8_t ip[4];
 		uint16_t port = 0;
 		char *str;
@@ -488,7 +488,7 @@ void eswifi_offload_async_msg(struct eswifi_dev *eswifi, char *msg, size_t len)
 
 		sin_addr = &peer->sin_addr;
 		memcpy(&sin_addr->s4_addr, ip, 4);
-		peer->sin_port = htons(port);
+		peer->sin_port = net_htons(port);
 		peer->sin_family = NET_AF_INET;
 		socket->state = ESWIFI_SOCKET_STATE_CONNECTED;
 		socket->usage++;

--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -75,7 +75,7 @@ static int __read_data(struct eswifi_dev *eswifi, size_t len, char **data)
 }
 
 int __eswifi_bind(struct eswifi_dev *eswifi, struct eswifi_off_socket *socket,
-		      const struct net_sockaddr *addr, socklen_t addrlen)
+		      const struct net_sockaddr *addr, net_socklen_t addrlen)
 {
 	int err;
 
@@ -196,7 +196,7 @@ int __eswifi_off_start_client(struct eswifi_dev *eswifi,
 			      struct eswifi_off_socket *socket)
 {
 	struct net_sockaddr *addr = &socket->peer_addr;
-	struct in_addr *sin_addr = &net_sin(addr)->sin_addr;
+	struct net_in_addr *sin_addr = &net_sin(addr)->sin_addr;
 	int err;
 
 	LOG_DBG("");

--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -107,9 +107,9 @@ int nxp_wifi_wlan_event_callback(enum wlan_event_reason reason, void *data)
 	static int auth_fail;
 #ifdef CONFIG_NXP_WIFI_SOFTAP_SUPPORT
 	wlan_uap_client_disassoc_t *disassoc_resp = data;
-	struct in_addr dhcps_addr4;
-	struct in_addr base_addr;
-	struct in_addr netmask_addr;
+	struct net_in_addr dhcps_addr4;
+	struct net_in_addr base_addr;
+	struct net_in_addr netmask_addr;
 	struct wifi_ap_sta_info ap_sta_info = { 0 };
 #endif
 

--- a/drivers/wifi/simplelink/simplelink_support.c
+++ b/drivers/wifi/simplelink/simplelink_support.c
@@ -97,7 +97,7 @@ static int32_t configure_simplelink(void)
 	uint8_t power;
 
 #if defined(CONFIG_NET_IPV4) && defined(CONFIG_NET_CONFIG_MY_IPV4_ADDR)
-	struct in_addr addr4;
+	struct net_in_addr addr4;
 	SlNetCfgIpV4Args_t ipV4;
 
 	memset(&ipV4, 0, sizeof(ipV4));

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -326,8 +326,8 @@ static int winc1500_get(net_sa_family_t family,
  * This function is called when user wants to bind to local IP address.
  */
 static int winc1500_bind(struct net_context *context,
-			 const struct sockaddr *addr,
-			 socklen_t addrlen)
+			 const struct net_sockaddr *addr,
+			 net_socklen_t addrlen)
 {
 	SOCKET socket = (intptr_t)context->offload_context;
 	int ret;
@@ -383,8 +383,8 @@ static int winc1500_listen(struct net_context *context, int backlog)
  * to a peer host.
  */
 static int winc1500_connect(struct net_context *context,
-			    const struct sockaddr *addr,
-			    socklen_t addrlen,
+			    const struct net_sockaddr *addr,
+			    net_socklen_t addrlen,
 			    net_context_connect_cb_t cb,
 			    int32_t timeout,
 			    void *user_data)
@@ -485,8 +485,8 @@ out:
  * This function is called when user wants to send data to peer host.
  */
 static int winc1500_sendto(struct net_pkt *pkt,
-			   const struct sockaddr *dst_addr,
-			   socklen_t addrlen,
+			   const struct net_sockaddr *dst_addr,
+			   net_socklen_t addrlen,
 			   net_context_send_cb_t cb,
 			   int32_t timeout,
 			   void *user_data)
@@ -592,7 +592,7 @@ static int winc1500_put(struct net_context *context)
 	struct socket_data *sd = &w1500_data.socket_data[sock];
 	int ret;
 
-	memset(&(context->remote), 0, sizeof(struct sockaddr_in));
+	memset(&(context->remote), 0, sizeof(struct net_sockaddr_in));
 	context->flags &= ~NET_CONTEXT_REMOTE_ADDR_SET;
 	ret = winc1500_close(sock);
 
@@ -654,7 +654,7 @@ static void handle_wifi_con_state_changed(void *pvMsg)
 static void handle_wifi_dhcp_conf(void *pvMsg)
 {
 	uint8_t *pu8IPAddress = (uint8_t *)pvMsg;
-	struct in_addr addr;
+	struct net_in_addr addr;
 	uint8_t i;
 
 	/* Connected and got IP address*/
@@ -918,8 +918,8 @@ static void handle_socket_msg_accept(struct socket_data *sd, void *pvMsg)
 		a_sd->context->flags |= NET_CONTEXT_REMOTE_ADDR_SET;
 
 		sd->accept_cb(a_sd->context,
-			      (struct sockaddr *)&accept_msg->strAddr,
-			      sizeof(struct sockaddr_in),
+			      (struct net_sockaddr *)&accept_msg->strAddr,
+			      sizeof(struct net_sockaddr_in),
 			      (accept_msg->sock > 0) ?
 			      0 : accept_msg->sock,
 			      sd->accept_user_data);

--- a/modules/nrf_wifi/os/shim.c
+++ b/modules/nrf_wifi/os/shim.c
@@ -607,7 +607,7 @@ void *net_raw_pkt_from_nbuf(void *iface, void *frm,
 		goto out;
 	}
 
-	pkt = net_pkt_rx_alloc_with_buffer(iface, total_len, AF_PACKET, ETH_P_ALL, K_MSEC(100));
+	pkt = net_pkt_rx_alloc_with_buffer(iface, total_len, NET_AF_PACKET, ETH_P_ALL, K_MSEC(100));
 	if (!pkt) {
 		LOG_ERR("%s: Unable to allocate net packet buffer", __func__);
 		goto out;


### PR DESCRIPTION
In 55c49cdb8f7e93b018f908fc8356212cc0e42da8 wifi drivers were changed to use the Zephyr native net_ prefixed
types, but some were forgotten.
Without this fix/change the code still builds as we are by now setting CONFIG_NET_NAMESPACE_COMPAT_MODE. But when this is not set, things fail to build.

Notes: 
* The esp_at , eswifi and simplelink drivers have been test built with samples/net/wifi/shell/ setting `CONFIG_NET_NAMESPACE_COMPAT_MODE=n`.
* For the NXP driver, the HAL also uses the old/non-native names, so the HAL would also need changing to be able to build with `CONFIG_NET_NAMESPACE_COMPAT_MODE=n`
* For the winc1500 the Atmel API has not been touched. Just the API towards Zephyr.
