### PR TITLE
drivers: pinctrl: sam: Add PIO alternate functions

### DIFF
--- a/drivers/pinctrl/pinctrl_sam.c
+++ b/drivers/pinctrl/pinctrl_sam.c
@@ -68,9 +68,24 @@ static void pinctrl_configure_pin(pinctrl_soc_pin_t pin)
 	soc_pin.mask = 1 << SAM_PINMUX_PIN_GET(pin);
 	soc_pin.flags = SAM_PINCTRL_FLAGS_GET(pin) << SOC_GPIO_FLAGS_POS;
 
-	if (port_func == SAM_PINMUX_FUNC_periph) {
-		soc_pin.flags |= (SAM_PINMUX_PERIPH_GET(pin)
-				  << SOC_GPIO_FUNC_POS);
+	switch(port_func)
+	{
+		case SAM_PINMUX_FUNC_periph:
+			soc_pin.flags |= (SAM_PINMUX_PERIPH_GET(pin)
+					<< SOC_GPIO_FUNC_POS);
+			break;
+		case SAM_PINMUX_FUNC_extra:
+			soc_pin.flags |= SOC_GPIO_FUNC_E;
+			break;
+		case SAM_PINMUX_FUNC_system:
+			soc_pin.flags |= SOC_GPIO_FUNC_F;
+			break;
+		case SAM_PINMUX_FUNC_lpm:
+			soc_pin.flags |= SOC_GPIO_FUNC_G;
+			break;
+		case SAM_PINMUX_FUNC_wakeup:
+			soc_pin.flags |= SOC_GPIO_FUNC_H;
+			break;
 	}
 
 	soc_gpio_configure(&soc_pin);

--- a/soc/atmel/sam/common/soc_gpio.c
+++ b/soc/atmel/sam/common/soc_gpio.c
@@ -163,6 +163,26 @@ void soc_gpio_configure(const struct soc_gpio_pin *pin)
 		break;
 #endif
 
+	case SOC_GPIO_FUNC_E: // extra
+	case SOC_GPIO_FUNC_F: // system
+	case SOC_GPIO_FUNC_G: // lpm
+	case SOC_GPIO_FUNC_H: // wakeup
+		/* Disable the interrupt. */
+		pio->PIO_IDR = mask;
+		/* Disable pull-up. */
+		pio->PIO_PUDR = mask;
+#if defined(CONFIG_SOC_SERIES_SAM4S) || \
+	defined(CONFIG_SOC_SERIES_SAM4E) || \
+	defined(CONFIG_SOC_SERIES_SAMX7X)
+		/* Disable pull-down. */
+		pio->PIO_PPDDR = mask;
+#endif
+		/* Let the PIO control the pin (instead of a peripheral). */
+		pio->PIO_PER = mask;
+		/* Disable output. */
+		pio->PIO_ODR = mask;
+		break;
+
 	case SOC_GPIO_FUNC_IN:
 		/* Enable module's clock */
 		soc_pmc_peripheral_enable(periph_id);


### PR DESCRIPTION
The PIO alternate function is not correctly muxed. More peripheral function has been introduced (E, F, G, H) to enable the extra (E), system (F), lpm (G), and wakeup (H) alternate function. This approach has been choosen to be consistent with the current implementation. Tested the extra function (AFEC0, AFEC1) with SAM V71B: working.

Fixes zephyrproject-rtos/zephyr#95353

The system, lpm, and wakeup alternate functions behaviour are assumed to be like the extra function.