### PR TITLE
modules: hal_infineon: CMakeLists.txt

### DIFF
--- a/modules/hal_infineon/CMakeLists.txt
+++ b/modules/hal_infineon/CMakeLists.txt
@@ -35,12 +35,14 @@ if(CONFIG_SOC_FAMILY_INFINEON_CAT1
   add_subdirectory(mtb-template-cat1)
 endif()
 
+if(CONFIG_USE_INFINEON_LEGACY_HAL
+  AND NOT CONFIG_SOC_FAMILY_PSOC6_LEGACY)
+  add_subdirectory(mtb-hal-cat1)
+endif()
+
 if(CONFIG_SOC_FAMILY_INFINEON_CAT1
   AND NOT CONFIG_SOC_FAMILY_PSOC6_LEGACY
   AND NOT CONFIG_SOC_FAMILY_INFINEON_EDGE)
-
-  ## Add mtb-hal-cat1 sources for CAT1 devices
-  add_subdirectory(mtb-hal-cat1)
 
   ## Add catcm0p sleep images for CM0 Devices
   if(CONFIG_SOC_PSOC6_CM0P_IMAGE_SLEEP)
@@ -51,7 +53,6 @@ if(CONFIG_SOC_FAMILY_INFINEON_CAT1
   add_subdirectory(abstraction-rtos)
 
   add_subdirectory(serial-flash)
-
 endif()
 
 if(CONFIG_SOC_FAMILY_INFINEON_EDGE)

--- a/modules/hal_infineon/serial-flash/CMakeLists.txt
+++ b/modules/hal_infineon/serial-flash/CMakeLists.txt
@@ -7,4 +7,4 @@ set(serial_flash_dir ${ZEPHYR_HAL_INFINEON_MODULE_DIR}/serial-flash)
 
 zephyr_include_directories(${serial_flash_dir})
 
-zephyr_library_sources(${serial_flash_dir}/cy_serial_flash_qspi.c)
+zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_SMIF ${serial_flash_dir}/cy_serial_flash_qspi.c)


### PR DESCRIPTION
Only compile the mtb-hal-cat1 module's source when CONFIG_USE_INFINEON_LEGACY_HAL is set.