### PR TITLE
kernel: time slicing: Minor fixes

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -73,7 +73,6 @@ void z_ready_thread(struct k_thread *thread);
 void z_requeue_current(struct k_thread *curr);
 struct k_thread *z_swap_next_thread(void);
 void move_current_to_end_of_prio_q(void);
-bool thread_is_sliceable(struct k_thread *thread);
 
 static inline void z_reschedule_unlocked(void)
 {

--- a/kernel/ipi.c
+++ b/kernel/ipi.c
@@ -191,9 +191,7 @@ void z_sched_ipi(void)
 #endif /* CONFIG_TRACE_SCHED_IPI */
 
 #ifdef CONFIG_TIMESLICING
-	if (thread_is_sliceable(_current)) {
-		z_time_slice();
-	}
+	z_time_slice();
 #endif /* CONFIG_TIMESLICING */
 
 #ifdef CONFIG_ARCH_IPI_LAZY_COPROCESSORS_SAVE

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -36,7 +36,7 @@ static inline int slice_time(struct k_thread *thread)
 	return ret;
 }
 
-bool thread_is_sliceable(struct k_thread *thread)
+static bool thread_is_sliceable(struct k_thread *thread)
 {
 	bool ret = thread_is_preemptible(thread)
 		&& slice_time(thread) != 0
@@ -99,7 +99,7 @@ void k_thread_time_slice_set(struct k_thread *thread, int32_t thread_slice_ticks
 }
 #endif
 
-/* Called out of each timer interrupt */
+/* Called out of each timer and IPI interrupt */
 void z_time_slice(void)
 {
 	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -36,19 +36,26 @@ static inline int slice_time(struct k_thread *thread)
 	return ret;
 }
 
-static bool thread_is_sliceable(struct k_thread *thread)
+static int z_time_slice_size(struct k_thread *thread)
 {
-	bool ret = thread_is_preemptible(thread)
-		&& slice_time(thread) != 0
-		&& !z_is_prio_higher(thread->base.prio, slice_max_prio)
-		&& !z_is_thread_prevented_from_running(thread)
-		&& !z_is_idle_thread_object(thread);
+	if (z_is_thread_prevented_from_running(thread) ||
+	    z_is_idle_thread_object(thread) ||
+	    (slice_time(thread) == 0)) {
+		return 0;
+	}
 
 #ifdef CONFIG_TIMESLICE_PER_THREAD
-	ret |= thread->base.slice_ticks != 0;
+	if (thread->base.slice_ticks != 0) {
+		return thread->base.slice_ticks;
+	}
 #endif
 
-	return ret;
+	if (thread_is_preemptible(thread) &&
+	    !z_is_prio_higher(thread->base.prio, slice_max_prio)) {
+		return slice_ticks;
+	}
+
+	return 0;
 }
 
 static void slice_timeout(struct _timeout *timeout)
@@ -68,12 +75,13 @@ static void slice_timeout(struct _timeout *timeout)
 void z_reset_time_slice(struct k_thread *thread)
 {
 	int cpu = _current_cpu->id;
+	int slice_size = z_time_slice_size(thread);
 
 	z_abort_timeout(&slice_timeouts[cpu]);
 	slice_expired[cpu] = false;
-	if (thread_is_sliceable(thread)) {
+	if (slice_size != 0) {
 		z_add_timeout(&slice_timeouts[cpu], slice_timeout,
-			      K_TICKS(slice_time(thread) - 1));
+			      K_TICKS(slice_size - 1));
 	}
 }
 
@@ -114,7 +122,7 @@ void z_time_slice(void)
 	pending_current = NULL;
 #endif
 
-	if (slice_expired[_current_cpu->id] && thread_is_sliceable(curr)) {
+	if (slice_expired[_current_cpu->id] && (z_time_slice_size(curr) != 0)) {
 #ifdef CONFIG_TIMESLICE_PER_THREAD
 		if (curr->base.slice_expired) {
 			k_spin_unlock(&_sched_spinlock, key);

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -144,9 +144,11 @@ void z_time_slice(void)
 
 	if (slice_expired[_current_cpu->id] && (z_time_slice_size(curr) != 0)) {
 #ifdef CONFIG_TIMESLICE_PER_THREAD
-		if (curr->base.slice_expired) {
+		k_thread_timeslice_fn_t handler = curr->base.slice_expired;
+
+		if (handler != NULL) {
 			k_spin_unlock(&_sched_spinlock, key);
-			curr->base.slice_expired(curr, curr->base.slice_data);
+			handler(curr, curr->base.slice_data);
 			key = k_spin_lock(&_sched_spinlock);
 		}
 #endif


### PR DESCRIPTION
This set of commits seeks to improve some aspects of the time slicing code.

1. A little code cleanup to remove a superfluous call to thread_is_sliceable()
2. Fixing the ordering of tests in thread_is_sliceable() to make it more sane.
3. k_sched_time_slice_set() no longer resets the time slice if the current thread is using a thread defined time slice.
4. Fixes a race condition in z_time_slice().