### PR TITLE
samples & tests: Remove obsolete Wi-Fi overlays

### DIFF
--- a/samples/net/wifi/shell/socs/esp32s2.overlay
+++ b/samples/net/wifi/shell/socs/esp32s2.overlay
@@ -1,3 +1,0 @@
-&wifi {
-	status = "okay";
-};

--- a/samples/net/wifi/shell/socs/esp32s3_procpu.overlay
+++ b/samples/net/wifi/shell/socs/esp32s3_procpu.overlay
@@ -1,3 +1,0 @@
-&wifi {
-	status = "okay";
-};

--- a/tests/boards/espressif/wifi/socs/esp32_procpu.overlay
+++ b/tests/boards/espressif/wifi/socs/esp32_procpu.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wifi {
-	status = "okay";
-};

--- a/tests/boards/espressif/wifi/socs/esp32c2.overlay
+++ b/tests/boards/espressif/wifi/socs/esp32c2.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wifi {
-	status = "okay";
-};

--- a/tests/boards/espressif/wifi/socs/esp32c3.overlay
+++ b/tests/boards/espressif/wifi/socs/esp32c3.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wifi {
-	status = "okay";
-};

--- a/tests/boards/espressif/wifi/socs/esp32c3_usb.overlay
+++ b/tests/boards/espressif/wifi/socs/esp32c3_usb.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wifi {
-	status = "okay";
-};

--- a/tests/boards/espressif/wifi/socs/esp32c6_hpcore.overlay
+++ b/tests/boards/espressif/wifi/socs/esp32c6_hpcore.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wifi {
-	status = "okay";
-};

--- a/tests/boards/espressif/wifi/socs/esp32s2.overlay
+++ b/tests/boards/espressif/wifi/socs/esp32s2.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wifi {
-	status = "okay";
-};

--- a/tests/boards/espressif/wifi/socs/esp32s3_procpu.overlay
+++ b/tests/boards/espressif/wifi/socs/esp32s3_procpu.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&wifi {
-	status = "okay";
-};


### PR DESCRIPTION
Remove wifi-enabling overlays that became obsolete.