### PR TITLE
soc: nxp: imx943: m33: fix build issue

### DIFF
--- a/soc/nxp/imx/imx9/imx943/m33/soc.c
+++ b/soc/nxp/imx/imx9/imx943/m33/soc.c
@@ -48,7 +48,9 @@ static int soc_clock_set_rate_and_parent(struct soc_clk *sclk)
 
 	return scmi_clock_rate_set(proto, &clk_cfg);
 }
+#endif
 
+#if DT_NUM_INST_STATUS_OKAY(nxp_mcux_i2s) > 0
 static int soc_clock_enable(struct soc_clk *sclk)
 {
 	const struct device *clk_dev = DEVICE_DT_GET(DT_NODELABEL(scmi_clk));


### PR DESCRIPTION
Fix build issue from the below commit:
c520b3da1ae4c5ffc2433c3ab5c9357e4aeb921d
soc: nxp: imx943: m33: add and reuse api to initialize clocks

error: soc_clock_enable defined but not used.