### PR TITLE
drivers: misc: pio_rpi_pico: fix linker error with -O0

### DIFF
--- a/include/zephyr/drivers/misc/pio_rpi_pico/pio_rpi_pico.h
+++ b/include/zephyr/drivers/misc/pio_rpi_pico/pio_rpi_pico.h
@@ -148,7 +148,7 @@
  * @param dev Pointer to device structure for rpi_pio device instance
  * @return PIO object
  */
-inline PIO pio_rpi_pico_get_pio(const struct device *dev)
+static inline PIO pio_rpi_pico_get_pio(const struct device *dev)
 {
 	return *(PIO *)(dev->config);
 }


### PR DESCRIPTION
The inline function pio_rpi_pico_get_pio() caused undefined reference errors during the linking stage when `CONFIG_NO_OPTIMIZATIONS=y`.

By changing the function to 'static inline', we ensure that the compiler generates a local symbol even when optimizations are disabled, fixing the regression introduced in #85167.

Fixes #101155