### PR TITLE
nxp: linker: Add cmake linker generator support

### DIFF
--- a/boards/nxp/mimxrt1180_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1180_evk/CMakeLists.txt
@@ -9,12 +9,20 @@ zephyr_library_sources(board.c)
 
 if(CONFIG_SOC_MIMXRT1189_CM33)
 zephyr_linker_sources(DTCM_SECTION cm33/dtcm.ld)
+zephyr_linker_section_configure(
+  SECTION .dtcm_data
+  INPUT "NonCacheable"
+)
 endif()
 
 if(CONFIG_NXP_BOARD_SPECIFIC_MPU_SETTINGS)
   if(CONFIG_SOC_MIMXRT1189_CM7)
     zephyr_sources(cm7/mpu_regions.c)
     zephyr_linker_sources(DTCM_SECTION cm7/dtcm.ld)
+    zephyr_linker_section_configure(
+      SECTION .dtcm_data
+      INPUT "NonCacheable"
+    )
   endif()
 endif()
 

--- a/cmake/linker/iar/config_file_script.cmake
+++ b/cmake/linker/iar/config_file_script.cmake
@@ -79,14 +79,6 @@ function(process_region)
     endif()
     set(ZI)
 
-    if(${name_clean} STREQUAL last_ram_section)
-      # A trick to add the symbol for the nxp devices
-      # _flash_used = LOADADDR(.last_section) + SIZEOF(.last_section) - __rom_region_start;
-      create_symbol(OBJECT ${REGION_OBJECT} SYMBOL _flash_used
-        EXPR "(@LOADADDR(last_section)@ + @SIZE(last_section)@ - @__rom_region_start@)"
-        )
-    endif()
-
     if(${name_clean} STREQUAL rom_start)
       # The below two symbols is meant to make aliases to the _vector_table symbol.
       list(GET symbols 0 symbol_start)

--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -264,3 +264,5 @@ zephyr_linker_section(NAME .last_section VMA FLASH LMA FLASH
                       NOINPUT TYPE LINKER_SCRIPT_FOOTER)
 # KEEP can not be passed to zephyr_linker_section, so:
 zephyr_linker_section_configure(SECTION .last_section INPUT ".last_section" KEEP)
+
+zephyr_linker_symbol(SYMBOL "_flash_used" EXPR "(@__last_section_end@ - ${rom_start})")

--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -198,7 +198,6 @@ zephyr_linker_symbol(SYMBOL ARM_LIB_STACKHEAP EXPR "(${RAM_ADDR} + ${RAM_SIZE})"
 
 set(VECTOR_ALIGN 4)
 if(CONFIG_CPU_CORTEX_M_HAS_VTOR)
-  math(EXPR VECTOR_ALIGN "4 * (16 + ${CONFIG_NUM_IRQS})")
   # Calculate minimum alignment based on architecture variant
   # This matches the logic in arch/arm/core/vector_table.ld
   if(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
@@ -213,10 +212,15 @@ if(CONFIG_CPU_CORTEX_M_HAS_VTOR)
     set(MIN_VECTOR_ALIGN 128)
   endif()
 
+  if(CONFIG_ARCH_IRQ_VECTOR_TABLE_ALIGN)
+    set(VECTOR_ALIGN ${CONFIG_ARCH_IRQ_VECTOR_TABLE_ALIGN})
+  else()
+    math(EXPR VECTOR_ALIGN "4 * (16 + ${CONFIG_NUM_IRQS})")
+    pow2round(VECTOR_ALIGN)
+  endif()
+
   if(${VECTOR_ALIGN} LESS ${MIN_VECTOR_ALIGN})
     set(VECTOR_ALIGN ${MIN_VECTOR_ALIGN})
-  else()
-    pow2round(VECTOR_ALIGN)
   endif()
 endif()
 

--- a/modules/hal_nxp/mcux/CMakeLists.txt
+++ b/modules/hal_nxp/mcux/CMakeLists.txt
@@ -75,17 +75,44 @@ else()
   zephyr_linker_sources(RWDATA
     ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/quick_access_data.ld
     )
+  zephyr_linker_section_configure(
+    SECTION .data
+    INPUT "DataQuickAccess"
+    ALIGN 4
+  )
 
   zephyr_linker_sources_ifdef(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
     RAMFUNC_SECTION
     ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/quick_access_code.ld
     )
+
+  if(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT)
+    zephyr_linker_section_configure(
+      SECTION .ramfunc
+      INPUT "CodeQuickAccess"
+      ALIGN 4
+    )
+  endif()
 endif()
 
 zephyr_linker_sources_ifdef(CONFIG_NOCACHE_MEMORY
   NOCACHE_SECTION
   ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/nocache.ld
   )
+
+if(CONFIG_NOCACHE_MEMORY)
+  zephyr_linker_section_configure(
+    SECTION nocache # _NOCACHE_SECTION_NAME
+    INPUT "NonCacheable"
+    ALIGN 4
+  )
+
+  zephyr_linker_section_configure(
+    SECTION nocache_load # _NOCACHE_LOAD_SECTION_NAME
+    INPUT "NonCacheable.init"
+    ALIGN 4
+  )
+endif()
 
 if(NOT CONFIG_ASSERT OR CONFIG_FORCE_NO_ASSERT)
   zephyr_compile_definitions(NDEBUG) # squelch fsl_flexcan.c warning

--- a/modules/hal_nxp/s32/CMakeLists.txt
+++ b/modules/hal_nxp/s32/CMakeLists.txt
@@ -60,14 +60,41 @@ if(CONFIG_HAS_MCUX)
   zephyr_linker_sources(RWDATA
     ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/quick_access_data.ld
   )
+  zephyr_linker_section_configure(
+    SECTION .data
+    INPUT "DataQuickAccess"
+    ALIGN 4
+  )
+
   zephyr_linker_sources_ifdef(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
     RAMFUNC_SECTION
     ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/quick_access_code.ld
   )
+  if(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT)
+    zephyr_linker_section_configure(
+      SECTION .ramfunc
+      INPUT "CodeQuickAccess"
+      ALIGN 4
+    )
+  endif()
+
   zephyr_linker_sources_ifdef(CONFIG_NOCACHE_MEMORY
     NOCACHE_SECTION
     ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/nocache.ld
   )
+  if(CONFIG_NOCACHE_MEMORY)
+    zephyr_linker_section_configure(
+      SECTION nocache # _NOCACHE_SECTION_NAME
+      INPUT "NonCacheable"
+      ALIGN 4
+    )
+
+    zephyr_linker_section_configure(
+      SECTION nocache_load # _NOCACHE_LOAD_SECTION_NAME
+      INPUT "NonCacheable.init"
+      ALIGN 4
+    )
+  endif()
 
   # Load MCUX SDK NG code.
   include(../mcux/mcux-sdk-ng/basic.cmake)

--- a/soc/nxp/imxrt/CMakeLists.txt
+++ b/soc/nxp/imxrt/CMakeLists.txt
@@ -30,12 +30,20 @@ if(CONFIG_SOC_SERIES_IMXRT10XX OR CONFIG_SOC_SERIES_IMXRT11XX)
     INPUT ".boot_hdr.ivt"
           ".boot_hdr.data"
           ${boot_hdr_dcd_data_section}
-          ${boot_hdr_xmcd_data_section}
     OFFSET ${CONFIG_IMAGE_VECTOR_TABLE_OFFSET}
     FIRST
     KEEP
     PRIO 11
   )
+  if(CONFIG_EXTERNAL_MEM_CONFIG_DATA)
+    zephyr_linker_section_configure(
+      SECTION .rom_start
+      INPUT ${boot_hdr_xmcd_data_section}
+      OFFSET ${CONFIG_EXTERNAL_MEM_CONFIG_OFFSET}
+      KEEP
+      PRIO 12
+    )
+  endif()
   zephyr_compile_definitions(XIP_EXTERNAL_FLASH)
 endif()
 
@@ -55,14 +63,25 @@ if(CONFIG_SOC_SERIES_IMXRT118X)
     INPUT ${boot_hdr_xmcd_data_section}
     OFFSET ${CONFIG_EXTERNAL_MEM_CONFIG_OFFSET}
     KEEP
-    PRIO 10
+    PRIO 11
   )
   zephyr_linker_section_configure(
     SECTION .rom_start
     INPUT ".boot_hdr.container"
     OFFSET ${CONFIG_IMAGE_CONTAINER_OFFSET}
     KEEP
-    PRIO 11
+    PRIO 12
+  )
+  zephyr_compile_definitions(XIP_EXTERNAL_FLASH)
+endif()
+
+if(CONFIG_SOC_SERIES_IMXRT6XX OR CONFIG_SOC_SERIES_IMXRT5XX OR CONFIG_SOC_SERIES_IMXRT7XX)
+  zephyr_linker_section_configure(
+    SECTION .rom_start
+    INPUT ".flash_conf"
+    OFFSET ${CONFIG_FLEXSPI_CONFIG_BLOCK_OFFSET}
+    KEEP
+    PRIO 10
   )
   zephyr_compile_definitions(XIP_EXTERNAL_FLASH)
 endif()

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -770,6 +770,22 @@ static int imxrt_init(void)
  */
 
 #ifdef CONFIG_SOC_RESET_HOOK
+#ifdef __ICCARM__
+void __used _soc_reset_hook(void);
+__root __stackless void soc_reset_hook(void)
+{
+	extern char z_main_stack[];
+	char *stack_top = z_main_stack + CONFIG_MAIN_STACK_SIZE;
+
+	__asm volatile(
+		"msr msp, %0"
+		:
+		: "r" (stack_top)
+	);
+
+	_soc_reset_hook();
+}
+#else /* !__ICCARM__ */
 __asm__ (
 	".global soc_reset_hook\n"
 	"soc_reset_hook:\n"
@@ -777,6 +793,7 @@ __asm__ (
 	"msr msp, r0;\n"
 	"b _soc_reset_hook;\n"
 );
+#endif /* __ICCARM__ */
 
 void __used _soc_reset_hook(void)
 {

--- a/soc/nxp/kinetis/CMakeLists.txt
+++ b/soc/nxp/kinetis/CMakeLists.txt
@@ -13,6 +13,15 @@ zephyr_linker_sources_ifdef(CONFIG_KINETIS_FLASH_CONFIG
   SORT_KEY ${CONFIG_KINETIS_FLASH_CONFIG_OFFSET}
   flash_config.ld
   )
+if(CONFIG_KINETIS_FLASH_CONFIG)
+  zephyr_linker_section_configure(
+    SECTION .rom_start
+    INPUT ".kinetis_flash_config"
+          ".kinetis_flash_config.*"
+    OFFSET ${CONFIG_KINETIS_FLASH_CONFIG_OFFSET}
+    KEEP
+    )
+endif()
 
 # CMSIS SystemInit will disable watchdog unless instructed not to.
 # Add a compiler definition here to leave watchdog untouched

--- a/soc/nxp/lpc/lpc55xxx/CMakeLists.txt
+++ b/soc/nxp/lpc/lpc55xxx/CMakeLists.txt
@@ -19,6 +19,35 @@ zephyr_linker_sources_ifdef(CONFIG_USB_DEVICE_DRIVER
   zephyr_linker_sources_ifdef(CONFIG_UHC_DRIVER
   SECTIONS usb.ld)
 
+if(CONFIG_USB_DEVICE_DRIVER OR CONFIG_UDC_DRIVER OR CONFIG_UHC_DRIVER)
+  zephyr_linker_group(NAME USB_BDT VMA USB_SRAM)
+
+  zephyr_linker_section(
+    NAME  _USB_BDT_SECTION_NAME
+    GROUP USB_BDT
+    TYPE  NOLOAD
+  )
+
+  zephyr_linker_section_configure(
+    SECTION _USB_BDT_SECTION_NAME
+    INPUT "m_usb_bdt"
+    ALIGN 512
+  )
+
+  zephyr_linker_group(NAME USB_GLOBAL VMA USB_SRAM)
+
+  zephyr_linker_section(
+    NAME  _USB_GLOBAL_SECTION_NAME
+    GROUP USB_GLOBAL
+    TYPE  NOLOAD
+  )
+
+  zephyr_linker_section_configure(
+    SECTION _USB_GLOBAL_SECTION_NAME
+    INPUT "m_usb_global"
+  )
+endif()
+
 zephyr_compile_definitions_ifdef(CONFIG_USB_DEVICE_DRIVER USB_STACK_USE_DEDICATED_RAM=1)
 zephyr_compile_definitions_ifdef(CONFIG_UDC_DRIVER USB_STACK_USE_DEDICATED_RAM=1)
 zephyr_compile_definitions_ifdef(CONFIG_UHC_DRIVER USB_STACK_USE_DEDICATED_RAM=1)
@@ -37,3 +66,10 @@ endif()
 zephyr_include_directories(.)
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")
+
+# workaround:
+# Only IAR defines the symbol __Vectors, there is not good way to detect
+# whether the symbol is defined.
+if(NOT CMAKE_C_COMPILER_ID MATCHES "IAR")
+zephyr_linker_symbol(SYMBOL __Vectors EXPR "@_vector_table@")
+endif()

--- a/soc/nxp/mcx/mcxc/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxc/CMakeLists.txt
@@ -13,7 +13,19 @@ zephyr_linker_sources_ifdef(CONFIG_MCXC_FLASH_CONFIG
   ROM_START
   SORT_KEY ${CONFIG_MCXC_FLASH_CONFIG_OFFSET}
   flash_config.ld
+)
+
+if(CONFIG_MCXC_FLASH_CONFIG)
+  dt_nodelabel(ftfa_node NODELABEL "ftfa")
+  dt_prop(flash_config_offset PATH ${ftfa_node} PROPERTY "config-field-offset")
+  zephyr_linker_section_configure(
+    SECTION .rom_start
+    INPUT ".kinetis_flash_config"
+          ".kinetis_flash_config.*"
+    OFFSET ${flash_config_offset}
+    KEEP
   )
+endif()
 
 # CMSIS SystemInit will disable watchdog unless instructed not to.
 # Add a compiler definition here to leave watchdog untouched

--- a/soc/nxp/mcx/mcxe/mcxe24x/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxe/mcxe24x/CMakeLists.txt
@@ -15,6 +15,16 @@ zephyr_linker_sources_ifdef(CONFIG_MCXE_FLASH_CONFIG
   flash_config.ld
   )
 
+if(CONFIG_MCXE_FLASH_CONFIG)
+  zephyr_linker_section_configure(
+    SECTION .rom_start
+    INPUT ".kinetis_flash_config"
+          ".kinetis_flash_config.*"
+    OFFSET 0x400
+    KEEP
+  )
+endif()
+
 # CMSIS SystemInit will disable watchdog unless instructed not to.
 # Add a compiler definition here to leave watchdog untouched
 # if this Kconfig is set

--- a/soc/nxp/mcx/mcxw/mcxw7xx/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/CMakeLists.txt
@@ -14,4 +14,20 @@ set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")
 
 if(CONFIG_NXP_NBU)
   zephyr_linker_sources(RAM_SECTIONS sections.ld)
+
+  zephyr_linker_section(NAME .noinit_rpmsg_sh_mem VMA rpmsg_sh_mem TYPE NOLOAD NOINIT)
+  zephyr_linker_section_configure(
+    SECTION .noinit_rpmsg_sh_mem
+    INPUT ".noinit.$rpmsg_sh_mem*"
+    ALIGN 4
+    SYMBOLS __RPMSG_SH_MEM_START__ __RPMSG_SH_MEM_END__
+  )
+  zephyr_linker_symbol(
+    SYMBOL rpmsg_sh_mem_start
+    EXPR "@__RPMSG_SH_MEM_START__@"
+  )
+  zephyr_linker_symbol(
+    SYMBOL rpmsg_sh_mem_end
+    EXPR "@__RPMSG_SH_MEM_END__@"
+  )
 endif()

--- a/soc/nxp/rw/CMakeLists.txt
+++ b/soc/nxp/rw/CMakeLists.txt
@@ -18,6 +18,24 @@ zephyr_sources_ifdef(CONFIG_PM
 zephyr_linker_sources_ifdef(CONFIG_NXP_RW6XX_BOOT_HEADER
   ROM_START SORT_KEY 0 boot_header.ld)
 
+if(CONFIG_NXP_RW6XX_BOOT_HEADER)
+  zephyr_linker_section_configure(
+    SECTION .rom_start
+    INPUT ".flash_conf"
+    OFFSET ${CONFIG_FLASH_CONFIG_OFFSET}
+    KEEP
+    PRIO 10
+  )
+
+  zephyr_linker_section_configure(
+    SECTION .rom_start
+    INPUT ".boot_hdr.ivt"
+    OFFSET ${CONFIG_IMAGE_VECTOR_TABLE_OFFSET}
+    KEEP
+    PRIO 11
+  )
+endif()
+
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
 
 zephyr_include_directories(.)
@@ -25,4 +43,83 @@ zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)
 
 zephyr_linker_sources(RODATA firmwares.ld)
 
+# Configure WiFi firmware section
+if(CONFIG_NXP_MONOLITHIC_WIFI)
+  zephyr_linker_section_configure(
+    SECTION rodata
+    INPUT ".fw_cpu1"
+    ALIGN 4
+    KEEP
+  )
+  # For RW612, fw_cpu1 is used for wifi firmware.
+  # Place the wifi and ble firmwares in rodata section. If both binaries
+  # are placed next to each other, the firmware loader will detect the
+  # second binary as part of the first one, leading to initialization
+  # issue, so add a padding of one word
+  zephyr_linker_section_configure(
+    SECTION rodata
+    NOINPUT
+    OFFSET 4
+  )
+endif()
+
+# Configure NBU (BLE) firmware section
+if(CONFIG_NXP_MONOLITHIC_NBU)
+  zephyr_linker_section_configure(
+    SECTION rodata
+    INPUT ".fw_cpu2"
+    ALIGN 4
+    KEEP
+  )
+endif()
+
 zephyr_linker_sources(RAM_SECTIONS sections.ld)
+
+set(TXQ23_SIZE 0x1080)
+dt_nodelabel(smu1_data_node NODELABEL "smu1_data")
+dt_reg_size(SMU1_SIZE PATH ${smu1_data_node})
+dt_nodelabel(smu2_data_node NODELABEL "smu2_data")
+dt_reg_size(SMU2_SIZE PATH ${smu2_data_node})
+
+zephyr_linker_section(
+  NAME .smu1
+  VMA SMU1
+  TYPE NOLOAD
+  # Size is reserved for CPU3/CPU1 operations
+  MIN_SIZE ${SMU1_SIZE}
+)
+
+zephyr_linker_section_configure(
+  SECTION .smu1
+  INPUT ".smu_cpu13_mbox" # CPU3 <-> CPU1 mailbox
+        ".smu_cpu31_txq"  # CPU3 -> CPU1 TXQ
+  ALIGN 4
+  KEEP
+)
+
+zephyr_linker_section(
+  NAME .smu2
+  VMA SMU2
+  TYPE NOLOAD
+  MIN_SIZE ${SMU2_SIZE}
+)
+
+zephyr_linker_section_configure(
+  SECTION .smu2
+  INPUT ".smu_cpu23_mbox" # CPU3 <-> CPU2 mailbox
+  ALIGN 4
+  KEEP
+)
+
+# Reserve space for CPU1 -> CPU3 TXQ (allocated by the CPU2)
+zephyr_linker_section_configure(
+  SECTION .smu2
+  MIN_SIZE ${TXQ23_SIZE}
+  MAX_SIZE ${TXQ23_SIZE}
+)
+
+zephyr_linker_section_configure(
+  SECTION .smu2
+  INPUT ".smu_cpu32_txq" # CPU3 -> CPU2 TXQ
+  KEEP
+)

--- a/soc/nxp/s32/s32k1/CMakeLists.txt
+++ b/soc/nxp/s32/s32k1/CMakeLists.txt
@@ -10,3 +10,12 @@ zephyr_sources_ifdef(CONFIG_ARM_MPU nxp_mpu_regions.c)
 
 zephyr_sources_ifdef(CONFIG_NXP_S32_FLASH_CONFIG flash_configuration.c)
 zephyr_linker_sources_ifdef(CONFIG_NXP_S32_FLASH_CONFIG ROM_START SORT_KEY 0x1 flash_config.ld)
+if(CONFIG_NXP_S32_FLASH_CONFIG)
+  zephyr_linker_section_configure(
+    SECTION .rom_start
+    INPUT ".kinetis_flash_config"
+          ".kinetis_flash_config.*"
+    OFFSET ${CONFIG_NXP_S32_FLASH_CONFIG_OFFSET}
+    KEEP
+  )
+endif()


### PR DESCRIPTION
Support cmake linker generator for some NXP boards, use build option `-DCONFIG_CMAKE_LINKER_GENERATOR=y` to enable the feature

RT500/RT600/RT700/MCXE31 not supported yet, because the these SOCs use code relocation feature, which need to improve cmake linker generator common part.

Depends on: https://github.com/zephyrproject-rtos/zephyr/pull/101039