### PR TITLE
net: ethernet: Allow to disable the auto-start of ethernet interfaces

### DIFF
--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -99,3 +99,13 @@ config ETH_INIT_PRIORITY
 	  Do not mess with it unless you know what you are doing.
 	  Note that the priority needs to be lower than the net stack
 	  so that it can start before the networking sub-system.
+
+config ETH_NET_IF_NO_AUTO_START
+	bool "Disable Ethernet interface auto-start"
+	depends on NET_L2_ETHERNET || ETH_DRIVER
+	help
+	  This option allows user to set any configuration before the interface
+	  becomes operational. For instance, the MAC address can be configured using
+	  net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET).
+	  When all configurations are done net_if_up() has to be invoked to
+	  bring the interface up.

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -1070,6 +1070,11 @@ void ethernet_init(struct net_if *iface)
 	dsa_eth_init(iface);
 #endif
 
+	if (IS_ENABLED(CONFIG_ETH_NET_IF_NO_AUTO_START)) {
+		/* Do not start Ethernet interface automatically */
+		net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	}
+
 	ctx->ethernet_l2_flags = NET_L2_MULTICAST;
 	ctx->iface = iface;
 	k_work_init(&ctx->carrier_work, carrier_on_off);


### PR DESCRIPTION
Adds CONFIG_ETH_NET_IF_NO_AUTO_START to allow pre-configuration of Ethernet interfaces (e.g., filters, EUI-64) before they become operational. When enabled, net_if_up() must be explicitly called by the application.