### PR TITLE
rtio: executor: release mempool buffer before resetting it

### DIFF
--- a/subsys/rtio/rtio_executor.c
+++ b/subsys/rtio/rtio_executor.c
@@ -158,12 +158,6 @@ static inline void rtio_executor_handle_multishot(struct rtio_iodev_sqe *iodev_s
 	uint32_t cqe_flags = rtio_cqe_compute_flags(iodev_sqe);
 	void *userdata = iodev_sqe->sqe.userdata;
 
-	if (iodev_sqe->sqe.op == RTIO_OP_RX && uses_mempool) {
-		/* Reset the buffer info so the next request can get a new one */
-		iodev_sqe->sqe.rx.buf = NULL;
-		iodev_sqe->sqe.rx.buf_len = 0;
-	}
-
 	/** We're releasing reasources when erroring as an error handling scheme of multi-shot
 	 * submissions by requiring to stop re-submitting if something goes wrong. Let the
 	 * application decide what's best for handling the corresponding error: whether
@@ -176,6 +170,12 @@ static inline void rtio_executor_handle_multishot(struct rtio_iodev_sqe *iodev_s
 		rtio_sqe_pool_free(r->sqe_pool, iodev_sqe);
 	} else {
 		/* Request was not canceled, put the SQE back in the queue */
+		if (iodev_sqe->sqe.op == RTIO_OP_RX && uses_mempool) {
+			/* Reset the buffer info so the next request can get a new one */
+			iodev_sqe->sqe.rx.buf = NULL;
+			iodev_sqe->sqe.rx.buf_len = 0;
+		}
+
 		mpsc_push(&r->sq, &iodev_sqe->q);
 		rtio_executor_submit(r);
 	}


### PR DESCRIPTION
`rtio_executor_handle_multishot` releases the RX buffer in case of cancellation or error. However, in case of an sqe that uses a mempool, it reset the buffer before that, making the release a NOOP.  Fix that by moving the reset of the buffer to right before pushing the sqe back onto the queue.