### PR TITLE
drivers: power_domain: Fix Kconfig endif comments

### DIFF
--- a/drivers/power_domain/Kconfig
+++ b/drivers/power_domain/Kconfig
@@ -35,7 +35,7 @@ config POWER_DOMAIN_GPIO_INIT_PRIORITY
 	help
 	  GPIO power domain initialization priority.
 
-endif #POWER_DOMAIN_GPIO_MONITOR
+endif #POWER_DOMAIN_GPIO
 
 config POWER_DOMAIN_INTEL_ADSP
 	bool "Use Intel ADSP power gating mechanisms"
@@ -129,4 +129,4 @@ rsource "Kconfig.nrfs_swext"
 rsource "Kconfig.silabs_siwx91x"
 # zephyr-keep-sorted-stop
 
-endif
+endif #POWER_DOMAIN


### PR DESCRIPTION
Fix the `endif`-comments in the drivers/power_domain/Kconfig file so they match to the corresponding `if`. 

I just stumpled upon this and made this trivial change.