### PR TITLE
soc: nxp: imx943: m33: Define soc_clock_enable() only when needed

### DIFF
--- a/soc/nxp/imx/imx9/imx943/m33/soc.c
+++ b/soc/nxp/imx/imx9/imx943/m33/soc.c
@@ -48,7 +48,9 @@ static int soc_clock_set_rate_and_parent(struct soc_clk *sclk)
 
 	return scmi_clock_rate_set(proto, &clk_cfg);
 }
+#endif
 
+#if (DT_NUM_INST_STATUS_OKAY(nxp_mcux_i2s) > 0)
 static int soc_clock_enable(struct soc_clk *sclk)
 {
 	const struct device *clk_dev = DEVICE_DT_GET(DT_NODELABEL(scmi_clk));


### PR DESCRIPTION
Define soc_clock_enable() with the same condition with which it is used to avoid the build warning `'soc_clock_enable' defined but not used.`

The issue was introduced in c520b3da1ae4c5ffc2433c3ab5c9357e4aeb921d

Can be seen failing in main in 
https://github.com/zephyrproject-rtos/zephyr/actions/runs/20274946738/job/58220894138#step:12:1049
and in PRs