### PR TITLE
Bluetooth: Mesh: clang unaligned access suppress warning

### DIFF
--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -55,6 +55,7 @@
 #define TOOLCHAIN_WARNING_SIZEOF_ARRAY_DECAY            "-Wsizeof-array-decay"
 #define TOOLCHAIN_WARNING_UNNEEDED_INTERNAL_DECLARATION "-Wunneeded-internal-declaration"
 #define TOOLCHAIN_WARNING_USED_BUT_MARKED_UNUSED        "-Wused-but-marked-unused"
+#define TOOLCHAIN_WARNING_UNALIGNED_ACCESS              "-Wunaligned-access"
 
 #define TOOLCHAIN_DISABLE_CLANG_WARNING(warning) _TOOLCHAIN_DISABLE_WARNING(clang, warning)
 #define TOOLCHAIN_ENABLE_CLANG_WARNING(warning)  _TOOLCHAIN_ENABLE_WARNING(clang, warning)

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -62,11 +62,16 @@ struct pdu_ctx {
 	struct bt_mesh_net_rx *rx;
 };
 
+/* Suppress `net_val is less aligned than bt_mesh_key` clang warning.
+ * dev_key is handled in the source code according to it's alignment
+ */
+TOOLCHAIN_DISABLE_CLANG_WARNING(TOOLCHAIN_WARNING_UNALIGNED_ACCESS)
 /* Mesh network information for persistent storage. */
 struct net_val {
 	uint16_t primary_addr;
 	struct bt_mesh_key dev_key;
 } __packed;
+TOOLCHAIN_ENABLE_CLANG_WARNING(TOOLCHAIN_WARNING_UNALIGNED_ACCESS)
 
 /* Sequence number information for persistent storage. */
 struct seq_val {


### PR DESCRIPTION
1. added TOOLCHAIN_WARNING_UNALIGNED_ACCESS macro to allow suppressing -Wunaligned-access warnings
2. suppressed warnings in mesh net.c packed struct net_val declaration

Fixes #101144