### PR TITLE
edtlib: Relax 'lacks binding' error for nodes used in a specifier

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1946,6 +1946,10 @@ class Node:
         # byte array.
 
         if not controller._binding:
+            if not data:
+                # As long as the 'controller' has '#<basename>-cells = <0>',
+                # it's not required to have a binding with '<basename>-cells:'.
+                return {}
             _err(f"{basename} controller {controller._node!r} "
                  f"for {self._node!r} lacks binding")
 

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -425,8 +425,8 @@
 
 	props-2 {
 		compatible = "props";
-		phandle-array-foos = <&{/ctrl-0-1} 0 &{/ctrl-0-2}>;
-		phandle-array-foo-names = "a", "missing", "b";
+		phandle-array-foos = <&{/ctrl-0-1} 0 &{/ctrl-0-2} &{/ctrl-no-compat}>;
+		phandle-array-foo-names = "a", "missing", "b", "c";
 	};
 
 	ctrl-0-1 {
@@ -436,6 +436,10 @@
 
 	ctrl-0-2 {
 		compatible = "phandle-array-controller-0";
+		#phandle-array-foo-cells = <0>;
+	};
+
+	ctrl-no-compat {
 		#phandle-array-foo-cells = <0>;
 	};
 

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -665,7 +665,8 @@ def test_props():
                               "phandle-array-foos",
                               [(edt.get_node('/ctrl-0-1'), {}),
                                None,
-                               (edt.get_node('/ctrl-0-2'), {})])
+                               (edt.get_node('/ctrl-0-2'), {}),
+                               (edt.get_node('/ctrl-no-compat'), {})])
 
     verify_phandle_array_prop(props_node,
                               'foo-gpios',


### PR DESCRIPTION
Suppose that node A is referenced by node B's `foos` specifier property.
Consequently, node A is required to set a `#foo-cells = <n>` property.

If n > 0, then edtlib needs to look up the binding of node A for a list of names under the `foo-cells` key.

If n = 0, then `foo-cells` is optional and, if absent from the binding, implied to be an empty list. However, edtlib would still expect node A to have a binding, even though it serves no purpose in this context.

Therefore, let's only raise the 'lacks binding' error when n > 0, and update an existing test case to demonstrate this scenario.