### PR TITLE
tests: watchdog: fixed incorrect skip statement

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/boards/frdm_mcxc444.conf
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/frdm_mcxc444.conf
@@ -1,4 +1,0 @@
-# Copyright 2025 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_WDT_DISABLE_AT_BOOT=y

--- a/tests/drivers/watchdog/wdt_basic_api/boards/frdm_mcxc444.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/frdm_mcxc444.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cop {
+	timeout-cycles = <8192>;
+};

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -70,8 +70,8 @@
 #if DT_NODE_HAS_STATUS_OKAY(DT_ALIAS(watchdog0))
 #define WDT_NODE DT_ALIAS(watchdog0)
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_window_watchdog)
-#define WDT_NODE DT_INST(0, st_stm32_window_watchdog)
-#define TIMEOUTS 0
+#define WDT_NODE            DT_INST(0, st_stm32_window_watchdog)
+#define TIMEOUTS            0
 #define WDT_TEST_MAX_WINDOW 200
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_watchdog)
 #define WDT_NODE DT_INST(0, st_stm32_watchdog)
@@ -105,16 +105,16 @@
 #define WDT_NODE DT_INST(0, nuvoton_numaker_wwdt)
 #define TIMEOUTS 1
 #elif DT_HAS_COMPAT_STATUS_OKAY(andestech_atcwdt200)
-#define WDT_NODE DT_INST(0, andestech_atcwdt200)
-#define TIMEOUTS 0
+#define WDT_NODE            DT_INST(0, andestech_atcwdt200)
+#define TIMEOUTS            0
 #define WDT_TEST_MAX_WINDOW 200U
 #endif
 #if DT_HAS_COMPAT_STATUS_OKAY(raspberrypi_pico_watchdog)
 #define WDT_TEST_MAX_WINDOW 8000U
-#define TIMEOUTS 0
+#define TIMEOUTS            0
 #endif
 #if DT_HAS_COMPAT_STATUS_OKAY(intel_tco_wdt)
-#define TIMEOUTS 0
+#define TIMEOUTS            0
 #define WDT_TEST_MAX_WINDOW 3000U
 #endif
 #if DT_HAS_COMPAT_STATUS_OKAY(nxp_wdog32)
@@ -124,22 +124,21 @@
 #define WDT_TEST_STATE_IDLE        0
 #define WDT_TEST_STATE_CHECK_RESET 1
 
-#define WDT_TEST_CB0_TEST_VALUE    0x0CB0
-#define WDT_TEST_CB1_TEST_VALUE    0x0CB1
+#define WDT_TEST_CB0_TEST_VALUE 0x0CB0
+#define WDT_TEST_CB1_TEST_VALUE 0x0CB1
 
 #ifndef WDT_TEST_MAX_WINDOW
-#define WDT_TEST_MAX_WINDOW                2000U
+#define WDT_TEST_MAX_WINDOW 2000U
 #endif
 
 #ifndef TIMEOUTS
-#define TIMEOUTS                   1
+#define TIMEOUTS 1
 #endif
 
 #if !(defined(CONFIG_HAS_WDT_NO_CALLBACKS) && CONFIG_HAS_WDT_NO_CALLBACKS)
-#define TEST_WDT_CALLBACK_1        (TIMEOUTS > 0)
-#define TEST_WDT_CALLBACK_2        (TIMEOUTS > 1)
+#define TEST_WDT_CALLBACK_1 (TIMEOUTS > 0)
+#define TEST_WDT_CALLBACK_2 (TIMEOUTS > 1)
 #endif
-
 
 static struct wdt_timeout_cfg m_cfg_wdt0;
 #if TEST_WDT_CALLBACK_2
@@ -281,7 +280,6 @@ static int test_wdt_callback_1(void)
 			TC_PRINT("CB1 not supported on platform\n");
 			m_testcase_index++;
 			return TC_PASS;
-
 		}
 		TC_PRINT("Watchdog install error\n");
 		return TC_FAIL;
@@ -472,8 +470,7 @@ static int test_wdt_enable_wait_mode(void)
 
 ZTEST(wdt_basic_test_suite, test_wdt)
 {
-	if ((m_testcase_index != 1U) && (m_testcase_index != 2U)
-		&& (m_testcase_index != 3U)) {
+	if ((m_testcase_index != 1U) && (m_testcase_index != 2U) && (m_testcase_index != 3U)) {
 		zassert_true(test_wdt_no_callback() == TC_PASS);
 	}
 	if (m_testcase_index == 1U) {


### PR DESCRIPTION
Fix #101028
- Remove ztest_test_skip in sub testcase because it will skip all following code in the testcase.
- Print sub testcase name at the case begining.
- Wrap bad window and wait mode test with macros.
- For nxp,cop, need disable it when the testcase ends.