### PR TITLE
tests: watchdog: ensure .noinit retention with cache management.

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -61,6 +61,9 @@
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+#include <zephyr/cache.h>
+#endif
 
 /*
  * To use this test, either the devicetree's /aliases must have a
@@ -183,6 +186,9 @@ static void wdt_int_cb0(const struct device *wdt_dev, int channel_id)
 	ARG_UNUSED(wdt_dev);
 	ARG_UNUSED(channel_id);
 	m_testvalue += WDT_TEST_CB0_TEST_VALUE;
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	sys_cache_data_flush_range((void *)(uintptr_t)&m_testvalue, sizeof(m_testvalue));
+#endif
 }
 #endif
 
@@ -192,6 +198,9 @@ static void wdt_int_cb1(const struct device *wdt_dev, int channel_id)
 	ARG_UNUSED(wdt_dev);
 	ARG_UNUSED(channel_id);
 	m_testvalue += WDT_TEST_CB1_TEST_VALUE;
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	sys_cache_data_flush_range((void *)(uintptr_t)&m_testvalue, sizeof(m_testvalue));
+#endif
 }
 #endif
 
@@ -236,6 +245,12 @@ static int test_wdt_no_callback(void)
 	TC_PRINT("Waiting to restart MCU\n");
 	m_testvalue = 0U;
 	m_state = WDT_TEST_STATE_CHECK_RESET;
+
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	sys_cache_data_flush_range((void *)(uintptr_t)&m_state, sizeof(m_state));
+	sys_cache_data_flush_range((void *)(uintptr_t)&m_testvalue, sizeof(m_testvalue));
+#endif
+
 	while (1) {
 		k_yield();
 	}
@@ -300,6 +315,11 @@ static int test_wdt_callback_1(void)
 	TC_PRINT("Waiting to restart MCU\n");
 	m_testvalue = 0U;
 	m_state = WDT_TEST_STATE_CHECK_RESET;
+
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	sys_cache_data_flush_range((void *)(uintptr_t)&m_state, sizeof(m_state));
+#endif
+
 	while (1) {
 		k_yield();
 	}
@@ -369,6 +389,10 @@ static int test_wdt_callback_2(void)
 	TC_PRINT("Waiting to restart MCU\n");
 	m_testvalue = 0U;
 	m_state = WDT_TEST_STATE_CHECK_RESET;
+
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	sys_cache_data_flush_range((void *)(uintptr_t)&m_state, sizeof(m_state));
+#endif
 
 	while (1) {
 		wdt_feed(wdt, 0);
@@ -462,6 +486,12 @@ static int test_wdt_enable_wait_mode(void)
 	TC_PRINT("Waiting to restart MCU\n");
 	m_testvalue = 0U;
 	m_state = WDT_TEST_STATE_CHECK_RESET;
+
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	sys_cache_data_flush_range((void *)(uintptr_t)&m_state, sizeof(m_state));
+	sys_cache_data_flush_range((void *)(uintptr_t)&m_testvalue, sizeof(m_testvalue));
+#endif
+
 	while (1) {
 		k_yield();
 	}


### PR DESCRIPTION
If CAHCE_MANAGEMENT is enabled, flush D-cache before WWDT reset to keep .noinit values.
The issue is firstly found in RT700.

Fix https://github.com/zephyrproject-rtos/zephyr/issues/98968