### PR TITLE
modem: cmux: Add retry counter for SABM, CLD and DISC control messages

### DIFF
--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -177,6 +177,7 @@ struct modem_cmux {
 
 	/* State */
 	enum modem_cmux_state state;
+	uint8_t retry_count;
 	bool flow_control_on : 1;
 	bool initiator : 1;
 

--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -1024,7 +1024,8 @@ static void modem_cmux_on_control_frame(struct modem_cmux *cmux)
 	modem_cmux_log_received_frame(&cmux->frame);
 
 	if (is_connected(cmux) && cmux->frame.cr == cmux->initiator) {
-		LOG_DBG("Received a response frame");
+		LOG_DBG("Drop a response frame");
+		return;
 	}
 
 	switch (cmux->frame.type) {


### PR DESCRIPTION
Add retry counter for opening and closing CMUX as well as opening and closing the DLCI channel.

Use same retry counter for both DLCI control messages as well as CMUX control messages as there is very minimal room for race condition. DLCI messages are only send when CMUX control channel is open.

Where relevant, use disconnect(cmux) for all closing calls. So we have one entry point for cleaning.

Similarly refactor modem_cmux_on_dlci_frame_dm() to dlci_close() as this is the single function to close and clean up a channel.