### PR TITLE
cmake: Do not warn on deprecated symbols w CONFIG_WARN_DEPRECATED=n

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ if(CONFIG_COMPILER_WARNINGS_AS_ERRORS)
   zephyr_link_libraries($<TARGET_PROPERTY:linker,warnings_as_errors>)
 endif()
 
-if(CONFIG_DEPRECATION_TEST)
+if(CONFIG_DEPRECATION_TEST OR NOT CONFIG_WARN_DEPRECATED)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,no_deprecation_warning>>)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,no_deprecation_warning>>)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:asm,no_deprecation_warning>>)

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -1021,7 +1021,8 @@ config WARN_DEPRECATED
 	prompt "Warn on deprecated usage"
 	help
 	  Print a warning when the Kconfig tree is parsed if any deprecated
-	  features are enabled.
+	  features are enabled, or at compile time, when deprecated macros or
+	  symbols are used.
 
 config EXPERIMENTAL
 	bool

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -349,7 +349,7 @@ do {                                                                    \
 #define __WARN1(s) _Pragma(#s)
 
 /* Generic message */
-#ifndef CONFIG_DEPRECATION_TEST
+#if !(defined(CONFIG_DEPRECATION_TEST) || !defined(CONFIG_WARN_DEPRECATED))
 #define __DEPRECATED_MACRO __WARN("Macro is deprecated")
 /* When adding this, remember to follow the instructions in
  * https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#deprecated

--- a/include/zephyr/toolchain/iar/iccarm.h
+++ b/include/zephyr/toolchain/iar/iccarm.h
@@ -248,7 +248,7 @@ do {                                                                    \
 #define __WARN1(s) __PRAGMA(message = #s)
 
 /* Generic message */
-#ifndef CONFIG_DEPRECATION_TEST
+#if !(defined(CONFIG_DEPRECATION_TEST) || !defined(CONFIG_WARN_DEPRECATED))
 #define __DEPRECATED_MACRO __WARN("Macro is deprecated")
 #else
 #define __DEPRECATED_MACRO


### PR DESCRIPTION
CONFIG_WARN_DEPRECATED is 'y' by default.
When a user actively disables CONFIG_WARN_DEPRECATED, one would expect that they would stop getting all deprecation warnings, not just the ones from kconfig.
Otherwise users continue getting tons of these warnings when building deprecated functionality.

So let's indeed disable them also for symbols and macros.

Relates to:
* #47835 6066ab43b380e0d0b39a75eb5dbeb8a1471b3c3b  kconfig: add support for warnings when enabling deprecated features 
* #91849 892ac07a4a388187d4faf0d6e5f7bc53c1a86c32 cmake: Add a new no_deprecation_warning compiler flag
