### PR TITLE
Boards: frdm ke15z: add adc support

### DIFF
--- a/boards/nxp/frdm_ke15z/doc/index.rst
+++ b/boards/nxp/frdm_ke15z/doc/index.rst
@@ -37,7 +37,7 @@ Supported Features
 System Clock
 ============
 
-The KE15 SoC is configured to run at 48 MHz using the FIRC.
+The KE15 SoC is configured to run at 72 MHz using the LPFLL.
 
 Serial Port
 ===========

--- a/boards/nxp/frdm_ke15z/frdm_ke15z-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z-pinctrl.dtsi
@@ -6,6 +6,14 @@
 #include <nxp/kinetis/MKE15Z256VLL7-pinctrl.h>
 
 &pinctrl {
+	adc0_default: adc0_default {
+		group0 {
+			pinmux = <ADC0_SE0_PTA0>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+
 	lpuart1_default: lpuart1_default {
 		group0 {
 			pinmux = <LPUART1_RX_PTC6>,

--- a/boards/nxp/frdm_ke15z/frdm_ke15z.dts
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.dts
@@ -102,6 +102,14 @@
 	pinctrl-names = "default";
 };
 
+&adc0 {
+	status = "okay";
+	sample-time = <12>;
+	vref-mv = <3300>;
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+};
+
 &gpiob {
 	status = "okay";
 };

--- a/boards/nxp/frdm_ke15z/frdm_ke15z.yaml
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.yaml
@@ -8,6 +8,7 @@ toolchain:
 flash: 256
 ram: 24
 supported:
+  - adc
   - flash
   - gpio
   - uart

--- a/boards/nxp/frdm_ke17z/doc/index.rst
+++ b/boards/nxp/frdm_ke17z/doc/index.rst
@@ -39,7 +39,7 @@ Supported Features
 System Clock
 ============
 
-The KE17Z SoC is configured to run at 48 MHz using the FIRC.
+The KE17Z SoC is configured to run at 72 MHz using the LPFLL.
 
 Serial Port
 ===========

--- a/boards/nxp/frdm_ke17z512/doc/index.rst
+++ b/boards/nxp/frdm_ke17z512/doc/index.rst
@@ -40,7 +40,7 @@ Supported Features
 System Clock
 ============
 
-The KE17Z9 SoC is configured to run at 48 MHz using the FIRC.
+The KE17Z9 SoC is configured to run at 72 MHz using the LPFLL.
 
 Serial Port
 ===========

--- a/samples/drivers/adc/adc_dt/boards/frdm_ke15z.overlay
+++ b/samples/drivers/adc/adc_dt/boards/frdm_ke15z.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/adc_dt/sample.yaml
+++ b/samples/drivers/adc/adc_dt/sample.yaml
@@ -45,6 +45,7 @@ tests:
       - slwrb4180a
       - xg27_rb4194a
       - xg29_rb4412a
+      - frdm_ke15z
       - frdm_mcxa346
       - frdm_mcxa266
       - frdm_mcxa366

--- a/samples/drivers/adc/adc_sequence/boards/frdm_ke15z.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/frdm_ke15z.overlay
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2025 NXP
+ */
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/*
+	 * To use this sample:
+	 * - Connect ADC0 SE0 signal to voltage between 0~3.3V (J4 pin 2)
+	 */
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/adc_sequence/sample.yaml
+++ b/samples/drivers/adc/adc_sequence/sample.yaml
@@ -26,6 +26,7 @@ tests:
       - ophelia4ev/nrf54l15/cpuapp
       - ucans32k1sic
       - s32k148_evb
+      - frdm_ke15z
       - frdm_mcxc242
       - frdm_mcxe247
       - slwrb4180a

--- a/tests/drivers/adc/adc_api/boards/frdm_ke15z.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_ke15z.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};


### PR DESCRIPTION
Fix the KE1xZ boards docs regarding system clock frequency. 
Enabled ADC for frdm_ke15z