### PR TITLE
boards renesas cpkcor_ra8d1b: Fix DTS typos

### DIFF
--- a/boards/renesas/cpkcor_ra8d1b/cpkcor_ra8d1b.dts
+++ b/boards/renesas/cpkcor_ra8d1b/cpkcor_ra8d1b.dts
@@ -192,11 +192,11 @@
 	pinctrl-0 = <&sdram_default>;
 	pinctrl-names = "default";
 	status = "okay";
-	auto-refresh-interval = <SDRAM_AUTO_REFREDSH_INTERVEL_10CYCLES>;
-	auto-refresh-count = <SDRAM_AUTO_REFREDSH_COUNT_8TIMES>;
+	auto-refresh-interval = <SDRAM_AUTO_REFRESH_INTERVAL_10CYCLES>;
+	auto-refresh-count = <SDRAM_AUTO_REFRESH_COUNT_8TIMES>;
 	precharge-cycle-count = <SDRAM_AUTO_PRECHARGE_CYCLE_3CYCLES>;
 	multiplex-addr-shift = "8-bit";
-	edian-mode = "little-endian";
+	endian-mode = "little-endian";
 	continuous-access;
 	bus-width = "16-bit";
 


### PR DESCRIPTION
A few typos that prevent building for this target

Issue introduced due to fixes in https://github.com/zephyrproject-rtos/zephyr/pull/100556

Failure can be seen in:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/20299707862/job/58301979470#step:12:1017
It can be reproduced w `cmake -GNinja -DBOARD=cpkcor_ra8d1b/r7fa8d1bhecbd ../samples/synchronization`