### PR TITLE
kernel: nothread: use k_timer to sleep instead of busy waiting

### DIFF
--- a/kernel/nothread.c
+++ b/kernel/nothread.c
@@ -14,14 +14,13 @@ bool k_is_in_isr(void)
 	return arch_is_in_isr();
 }
 
+static K_TIMER_DEFINE(sleep_timer, NULL, NULL);
+
 /* This is a fallback implementation of k_sleep() for when multi-threading is
  * disabled. The main implementation is in sched.c.
  */
 int32_t z_impl_k_sleep(k_timeout_t timeout)
 {
-	k_ticks_t ticks;
-	uint32_t ticks_to_wait;
-
 	__ASSERT(!arch_is_in_isr(), "");
 
 	SYS_PORT_TRACING_FUNC_ENTER(k_thread, sleep, timeout);
@@ -35,26 +34,18 @@ int32_t z_impl_k_sleep(k_timeout_t timeout)
 		return (int32_t) K_TICKS_FOREVER;
 	}
 
-	ticks = timeout.ticks;
-	if (Z_IS_TIMEOUT_RELATIVE(timeout)) {
-		/* ticks is delta timeout */
-		ticks_to_wait = ticks;
-	} else {
-		/* ticks is absolute timeout expiration */
-		uint32_t curr_ticks = sys_clock_tick_get_32();
+	k_timer_start(&sleep_timer, timeout, K_NO_WAIT);
 
-		if (Z_TICK_ABS(ticks) > curr_ticks) {
-			ticks_to_wait = Z_TICK_ABS(ticks) - curr_ticks;
-		} else {
-			ticks_to_wait = 0;
-		}
-	}
-	/* busy wait to be time coherent since subsystems may depend on it */
-	z_impl_k_busy_wait(k_ticks_to_us_ceil32(ticks_to_wait));
+	/* When multithreading is disabled, this will enter a low power state
+	 * using k_cpu_idle() until the timer has expired.
+	 */
+	k_timer_status_sync(&sleep_timer);
 
-	int32_t ret = k_ticks_to_ms_ceil64(0);
+	SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, 0);
 
-	SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, ret);
-
-	return ret;
+	/* This implementation is compiled when multithreading is disabled.
+	 * Therefore, unlike its multithreaded counterpart, it shall always
+	 * sleep for the entire timeout duration (no thread to awake).
+	 */
+	return 0;
 }


### PR DESCRIPTION
The current implementation of `k_sleep()`, when multi-threading is disabled, busy waits using `k_busy_wait()` until the sleep timeout has expired.

This patch aims to improve power efficiency of `k_sleep()` for single-threaded applications by starting a timer (`k_timer`) and idling the CPU until the timer interrupt wakes it up, thus avoiding busy-looping.