### PR TITLE
drivers: dai: extend user-space support to more DAI drivers

### DIFF
--- a/drivers/dai/intel/alh/alh.c
+++ b/drivers/dai/intel/alh/alh.c
@@ -158,6 +158,25 @@ static const struct dai_properties *dai_alh_get_properties(const struct device *
 	return prop;
 }
 
+static int dai_alh_get_properties_copy(const struct device *dev,
+				       enum dai_dir dir, int stream_id,
+				       struct dai_properties *prop)
+{
+	const struct dai_properties *kernel_prop = dai_alh_get_properties(dev, dir, stream_id);
+
+	if (!prop) {
+		return -EINVAL;
+	}
+
+	if (!kernel_prop) {
+		return -ENOENT;
+	}
+
+	memcpy(prop, kernel_prop, sizeof(*kernel_prop));
+
+	return 0;
+}
+
 static int dai_alh_probe(const struct device *dev)
 {
 	k_spinlock_key_t key;
@@ -201,6 +220,7 @@ static DEVICE_API(dai, dai_intel_alh_api_funcs) = {
 	.config_get		= dai_alh_config_get,
 	.trigger		= dai_alh_trigger,
 	.get_properties		= dai_alh_get_properties,
+	.get_properties_copy	= dai_alh_get_properties_copy,
 };
 
 #define DAI_INTEL_ALH_DEVICE_INIT(n)						\

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -686,6 +686,25 @@ const struct dai_properties *dai_dmic_get_properties(const struct device *dev,
 	return prop;
 }
 
+static int dai_dmic_get_properties_copy(const struct device *dev,
+				       enum dai_dir dir, int stream_id,
+				       struct dai_properties *prop)
+{
+	const struct dai_properties *kernel_prop = dai_dmic_get_properties(dev, dir, stream_id);
+
+	if (!prop) {
+		return -EINVAL;
+	}
+
+	if (!kernel_prop) {
+		return -ENOENT;
+	}
+
+	memcpy(prop, kernel_prop, sizeof(*kernel_prop));
+
+	return 0;
+}
+
 static int dai_dmic_trigger(const struct device *dev, enum dai_dir dir,
 			    enum dai_trigger_cmd cmd)
 {
@@ -857,6 +876,7 @@ DEVICE_API(dai, dai_dmic_ops) = {
 	.config_set		= dai_dmic_set_config,
 	.config_get		= dai_dmic_get_config,
 	.get_properties		= dai_dmic_get_properties,
+	.get_properties_copy	= dai_dmic_get_properties_copy,
 	.trigger		= dai_dmic_trigger,
 	.ts_config		= dai_dmic_timestamp_config,
 	.ts_start		= dai_timestamp_dmic_start,

--- a/drivers/dai/intel/hda/hda.c
+++ b/drivers/dai/intel/hda/hda.c
@@ -92,6 +92,25 @@ static const struct dai_properties *dai_hda_get_properties(const struct device *
 	return prop;
 }
 
+static int dai_hda_get_properties_copy(const struct device *dev,
+				       enum dai_dir dir, int stream_id,
+				       struct dai_properties *prop)
+{
+	const struct dai_properties *kernel_prop = dai_hda_get_properties(dev, dir, stream_id);
+
+	if (!prop) {
+		return -EINVAL;
+	}
+
+	if (!kernel_prop) {
+		return -ENOENT;
+	}
+
+	memcpy(prop, kernel_prop, sizeof(*kernel_prop));
+
+	return 0;
+}
+
 static int dai_hda_probe(const struct device *dev)
 {
 	LOG_DBG("%s", __func__);
@@ -139,6 +158,7 @@ static DEVICE_API(dai, dai_intel_hda_api_funcs) = {
 	.config_get		= dai_hda_config_get,
 	.trigger		= dai_hda_trigger,
 	.get_properties		= dai_hda_get_properties,
+	.get_properties_copy	= dai_hda_get_properties_copy,
 };
 
 #define DAI_INTEL_HDA_DEVICE_INIT(n)				\

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -2558,6 +2558,10 @@ static int dai_ssp_get_properties_copy(const struct device *dev,
 		return -EINVAL;
 	}
 
+	if (!kernel_prop) {
+		return -ENOENT;
+	}
+
 	memcpy(prop, kernel_prop, sizeof(*kernel_prop));
 
 	return 0;

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -2549,7 +2549,8 @@ static const struct dai_properties *dai_ssp_get_properties(const struct device *
 }
 
 static int dai_ssp_get_properties_copy(const struct device *dev,
-				enum dai_dir dir, int stream_id, struct dai_properties *prop)
+				       enum dai_dir dir, int stream_id,
+				       struct dai_properties *prop)
 {
 	const struct dai_properties *kernel_prop = dai_ssp_get_properties(dev, dir, stream_id);
 

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -463,12 +463,17 @@ static inline const struct dai_properties *dai_get_properties(const struct devic
 /**
  * @brief Fetch properties of a DAI driver
  *
+ * Optional method.
+ *
  * @param dev Pointer to the device structure for the driver instance
  * @param dir Stream direction: RX or TX as defined by DAI_DIR_*
  * @param stream_id Stream id: some drivers may have stream specific
  *        properties, this id specifies the stream.
  * @param dst address where to write properties to
- * @retval Zero on success
+ * @retval 0 if success
+ * @retval -EINVAL if arguments are incorrect
+ * @retval -ENOENT if there are no properties for the device
+ * @retval -ENOSYS if method not implemented by the driver
  */
 __syscall int dai_get_properties_copy(const struct device *dev,
 				      enum dai_dir dir,
@@ -481,6 +486,10 @@ static inline int z_impl_dai_get_properties_copy(const struct device *dev,
 						 struct dai_properties *dst)
 {
 	const struct dai_driver_api *api = (const struct dai_driver_api *)dev->api;
+
+	if (!api->get_properties_copy) {
+		return -ENOSYS;
+	}
 
 	return api->get_properties_copy(dev, dir, stream_id, dst);
 }


### PR DESCRIPTION
Follow up to https://github.com/zephyrproject-rtos/zephyr/pull/99811 , with:
- improve documentation
- fix issues in syscall handlers and make the checks more robust
- add missing get_properties to all Intel DAI types, allowing them all to be used from user-space