### PR TITLE
doc: migration: 4.4: place Video drivers section in sorted block

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -211,12 +211,12 @@ USB
 
   * :dtcompatible:`maxim,max3421e_spi` has been renamed to :dtcompatible:`maxim,max3421e-spi`.
 
-.. zephyr-keep-sorted-stop
-
 Video
 ===
 
 * CONFIG_VIDEO_OV7670 is now gone and replaced by CONFIG_VIDEO_OV767X.  This allows supporting both the OV7670 and 0V7675.
+
+.. zephyr-keep-sorted-stop
 
 Bluetooth
 *********


### PR DESCRIPTION
The Video drivers section was mistakenly placed below the end marker of the zephyr-keep-sorted block.

Move it back inside the block for proper ordering.