### PR TITLE
ci: assigner: fix condition for running script

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -63,7 +63,7 @@ jobs:
         FLAGS+=" -r ${{ github.event.repository.name }}"
         FLAGS+=" -M MAINTAINERS.yml"
         if [ "${{ github.event_name }}" = "pull_request_target" ]; then
-          if [ "${{ github.base_ref }}" != "main" ]; then
+          if [ "${{ github.base_ref }}" = "main" ]; then
             FLAGS+=" -P ${{ github.event.pull_request.number }} --updated-manifest pr_west.yml --updated-maintainer-file pr_MAINTAINERS.yml"
           else
             FLAGS+=" -P ${{ github.event.pull_request.number }}"


### PR DESCRIPTION
Wrong logic in condition results in running the script with the wrong
arguments.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
