### PR TITLE
xtensa: mmu: (cosmetic) clean up pointer types

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -561,8 +561,7 @@ static inline void __arch_mem_map(void *vaddr, uintptr_t paddr, uint32_t attrs, 
 {
 	bool ret;
 
-	ret = l2_page_table_map(xtensa_kernel_ptables, (void *)vaddr, paddr,
-				attrs, is_user);
+	ret = l2_page_table_map(xtensa_kernel_ptables, vaddr, paddr, attrs, is_user);
 	__ASSERT(ret, "Cannot map virtual address (%p)", vaddr);
 
 #ifndef CONFIG_USERSPACE
@@ -577,8 +576,7 @@ static inline void __arch_mem_map(void *vaddr, uintptr_t paddr, uint32_t attrs, 
 		SYS_SLIST_FOR_EACH_NODE(&xtensa_domain_list, node) {
 			domain = CONTAINER_OF(node, struct arch_mem_domain, node);
 
-			ret = l2_page_table_map(domain->ptables, (void *)vaddr, paddr,
-						attrs, is_user);
+			ret = l2_page_table_map(domain->ptables, vaddr, paddr, attrs, is_user);
 			__ASSERT(ret, "Cannot map virtual address (%p) for domain %p",
 				 vaddr, domain);
 
@@ -730,7 +728,7 @@ end:
 
 static inline void __arch_mem_unmap(void *vaddr)
 {
-	l2_page_table_unmap(xtensa_kernel_ptables, (void *)vaddr);
+	l2_page_table_unmap(xtensa_kernel_ptables, vaddr);
 
 #ifdef CONFIG_USERSPACE
 	sys_snode_t *node;
@@ -741,7 +739,7 @@ static inline void __arch_mem_unmap(void *vaddr)
 	SYS_SLIST_FOR_EACH_NODE(&xtensa_domain_list, node) {
 		domain = CONTAINER_OF(node, struct arch_mem_domain, node);
 
-		(void)l2_page_table_unmap(domain->ptables, (void *)vaddr);
+		(void)l2_page_table_unmap(domain->ptables, vaddr);
 	}
 	k_spin_unlock(&z_mem_domain_lock, key);
 #endif /* CONFIG_USERSPACE */

--- a/drivers/mm/mm_drv_common.c
+++ b/drivers/mm/mm_drv_common.c
@@ -81,7 +81,7 @@ bool sys_mm_drv_is_virt_region_mapped(void *virt, size_t size)
 	bool ret = true;
 
 	for (offset = 0; offset < size; offset += CONFIG_MM_DRV_PAGE_SIZE) {
-		uint8_t *va = (uint8_t *)virt + offset;
+		void *va = (uint8_t *)virt + offset;
 
 		if (sys_mm_drv_page_phys_get(va, NULL) != 0) {
 			ret = false;
@@ -98,7 +98,7 @@ bool sys_mm_drv_is_virt_region_unmapped(void *virt, size_t size)
 	bool ret = true;
 
 	for (offset = 0; offset < size; offset += CONFIG_MM_DRV_PAGE_SIZE) {
-		uint8_t *va = (uint8_t *)virt + offset;
+		void *va = (uint8_t *)virt + offset;
 
 		if (sys_mm_drv_page_phys_get(va, NULL) != -EFAULT) {
 			ret = false;
@@ -126,7 +126,7 @@ static int unmap_locked(void *virt, size_t size, bool is_reset)
 	size_t offset;
 
 	for (offset = 0; offset < size; offset += CONFIG_MM_DRV_PAGE_SIZE) {
-		uint8_t *va = (uint8_t *)virt + offset;
+		void *va = (uint8_t *)virt + offset;
 
 		int ret2 = sys_mm_drv_unmap_page(va);
 
@@ -161,7 +161,7 @@ int sys_mm_drv_simple_map_region(void *virt, uintptr_t phys,
 	key = k_spin_lock(&sys_mm_drv_common_lock);
 
 	for (offset = 0; offset < size; offset += CONFIG_MM_DRV_PAGE_SIZE) {
-		uint8_t *va = (uint8_t *)virt + offset;
+		void *va = (uint8_t *)virt + offset;
 		uintptr_t pa = phys + offset;
 
 		ret = sys_mm_drv_map_page(va, pa, flags);
@@ -207,7 +207,7 @@ int sys_mm_drv_simple_map_array(void *virt, uintptr_t *phys,
 	offset = 0;
 	idx = 0;
 	while (idx < cnt) {
-		uint8_t *va = (uint8_t *)virt + offset;
+		void *va = (uint8_t *)virt + offset;
 
 		ret = sys_mm_drv_map_page(va, phys[idx], flags);
 
@@ -289,8 +289,8 @@ int sys_mm_drv_simple_remap_region(void *virt_old, size_t size,
 	}
 
 	for (offset = 0; offset < size; offset += CONFIG_MM_DRV_PAGE_SIZE) {
-		uint8_t *va_old = (uint8_t *)virt_old + offset;
-		uint8_t *va_new = (uint8_t *)virt_new + offset;
+		void *va_old = (uint8_t *)virt_old + offset;
+		void *va_new = (uint8_t *)virt_new + offset;
 		uintptr_t pa;
 		uint32_t flags;
 
@@ -387,8 +387,8 @@ int sys_mm_drv_simple_move_region(void *virt_old, size_t size,
 	}
 
 	for (offset = 0; offset < size; offset += CONFIG_MM_DRV_PAGE_SIZE) {
-		uint8_t *va_old = (uint8_t *)virt_old + offset;
-		uint8_t *va_new = (uint8_t *)virt_new + offset;
+		void *va_old = (uint8_t *)virt_old + offset;
+		void *va_new = (uint8_t *)virt_new + offset;
 		uintptr_t pa = phys_new + offset;
 		uint32_t flags;
 
@@ -474,8 +474,8 @@ int sys_mm_drv_simple_move_array(void *virt_old, size_t size,
 	offset = 0;
 	idx = 0;
 	while (idx < phys_cnt) {
-		uint8_t *va_old = (uint8_t *)virt_old + offset;
-		uint8_t *va_new = (uint8_t *)virt_new + offset;
+		void *va_old = (uint8_t *)virt_old + offset;
+		void *va_new = (uint8_t *)virt_new + offset;
 		uint32_t flags;
 
 		ret = sys_mm_drv_page_flag_get(va_old, &flags);
@@ -547,7 +547,7 @@ int sys_mm_drv_simple_update_region_flags(void *virt, size_t size, uint32_t flag
 	key = k_spin_lock(&sys_mm_drv_common_lock);
 
 	for (offset = 0; offset < size; offset += CONFIG_MM_DRV_PAGE_SIZE) {
-		uint8_t *va = (uint8_t *)virt + offset;
+		void *va = (uint8_t *)virt + offset;
 
 		int ret2 = sys_mm_drv_update_page_flags(va, flags);
 


### PR DESCRIPTION
Use void * cleanly: avoid needless type-casts and use void * for generic pointers instead of uint8_t *.