### PR TITLE
boards: renesas: cpkcor_ra8d1b: correct mispelled DTS node props

### DIFF
--- a/boards/renesas/cpkcor_ra8d1b/cpkcor_ra8d1b.dts
+++ b/boards/renesas/cpkcor_ra8d1b/cpkcor_ra8d1b.dts
@@ -192,7 +192,7 @@
 	pinctrl-0 = <&sdram_default>;
 	pinctrl-names = "default";
 	status = "okay";
-	auto-refresh-interval = <SDRAM_AUTO_REFREDSH_INTERVEL_10CYCLES>;
+	auto-refresh-interval = <SDRAM_AUTO_REFRESH_INTERVAL_10CYCLES>;
 	auto-refresh-count = <SDRAM_AUTO_REFREDSH_COUNT_8TIMES>;
 	precharge-cycle-count = <SDRAM_AUTO_PRECHARGE_CYCLE_3CYCLES>;
 	multiplex-addr-shift = "8-bit";

--- a/boards/renesas/cpkcor_ra8d1b/cpkcor_ra8d1b.dts
+++ b/boards/renesas/cpkcor_ra8d1b/cpkcor_ra8d1b.dts
@@ -193,7 +193,7 @@
 	pinctrl-names = "default";
 	status = "okay";
 	auto-refresh-interval = <SDRAM_AUTO_REFRESH_INTERVAL_10CYCLES>;
-	auto-refresh-count = <SDRAM_AUTO_REFREDSH_COUNT_8TIMES>;
+	auto-refresh-count = <SDRAM_AUTO_REFRESH_COUNT_8TIMES>;
 	precharge-cycle-count = <SDRAM_AUTO_PRECHARGE_CYCLE_3CYCLES>;
 	multiplex-addr-shift = "8-bit";
 	edian-mode = "little-endian";


### PR DESCRIPTION
`SDRAM_AUTO_REFREDSH_INTERVEL_10CYCLES` -> `SDRAM_AUTO_REFRESH_INTERVAL_10CYCLES`
`SDRAM_AUTO_REFREDSH_COUNT_8TIMES` -> `SDRAM_AUTO_REFRESH_COUNT_8TIMES`

Showed up in https://github.com/zephyrproject-rtos/zephyr/pull/101192