### PR TITLE
net: coap: add client verification to server

### DIFF
--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -272,6 +272,13 @@ config COAP_SERVER_SHELL
 	help
 	  Enable CoAP service shell commands.
 
+config COAP_SERVER_CLIENT_VERIFY
+	bool "Verify CoAP client when using DTLS"
+	depends on NET_SOCKETS_ENABLE_DTLS
+	help
+	  Enable mutual authentication by requiring that clients also
+	  authenticate themselves when using DTLS.
+
 endif
 
 module = COAP

--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -487,6 +487,16 @@ int coap_service_start(const struct coap_service *service)
 			ret = -errno;
 			goto close;
 		}
+#if defined(CONFIG_COAP_SERVER_CLIENT_VERIFY)
+		const int peer_required = TLS_PEER_VERIFY_REQUIRED;
+		ret = zsock_setsockopt(service->data->sock_fd, SOL_TLS, TLS_PEER_VERIFY,
+				       &peer_required, sizeof(peer_required));
+		if (ret < 0) {
+			ret = -errno;
+			goto close;
+		}
+#endif
+
 
 		ret = zsock_setsockopt(service->data->sock_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_DTLS_ROLE,
 				       &role, sizeof(role));


### PR DESCRIPTION
Introduce new CONFIG_COAP_SERVER_CLIENT_VERIFY
kconfig option that enables mutual DTLS authentication by setting TLS_PEER_VERIFY_REQUIRED on the secure
socket of the CoAP server.