### PR TITLE
lib: cobs: fix for non-zero delimiters

### DIFF
--- a/lib/utils/cobs.c
+++ b/lib/utils/cobs.c
@@ -8,41 +8,47 @@
 #include <stdint.h>
 #include <zephyr/data/cobs.h>
 
+static inline uint8_t cobs_code_base(uint8_t delimiter)
+{
+	return (delimiter == 0x01) ? 2 : 1;
+}
+
+static inline uint8_t cobs_finish_code(uint8_t delimiter)
+{
+	if (delimiter <= 0x01) {
+		return 0xFF;
+	}
+	return delimiter - 1;
+}
+
 int cobs_encode(struct net_buf *src, struct net_buf *dst, uint32_t flags)
 {
 	uint8_t delimiter = COBS_FLAG_CUSTOM_DELIMITER(flags);
-
-	/* Calculate required space for worst case */
+	uint8_t code_base = cobs_code_base(delimiter);
+	uint8_t finish_code = cobs_finish_code(delimiter);
 	size_t max_encoded_size = cobs_max_encoded_len(src->len, flags);
 
-	/* Check if destination has enough space */
 	if (net_buf_tailroom(dst) < max_encoded_size) {
 		return -ENOMEM;
 	}
 
 	uint8_t *code_ptr = net_buf_add(dst, 1);
-	uint8_t code = 1;
-
-	/* Process all input bytes */
-	uint8_t data = 0;
+	uint8_t code = code_base;
+	uint8_t data;
 
 	while (src->len > 0) {
 		data = net_buf_pull_u8(src);
 		if (data == delimiter) {
-			/* Delimiter found - write current code and start new block */
 			*code_ptr = code;
 			code_ptr = net_buf_add(dst, 1);
-			code = 1;
+			code = code_base;
 		} else {
-			/* Add non-zero byte to output */
 			net_buf_add_u8(dst, data);
 			code++;
-
-			/* If we've reached maximum block size, start a new block */
-			if (code == 0xFF && (src->len - 1 >= 0)) {
-				*code_ptr = code;
+			if (code == finish_code && src->len > 0) {
+				*code_ptr = finish_code;
 				code_ptr = net_buf_add(dst, 1);
-				code = 1;
+				code = code_base;
 			}
 		}
 	}
@@ -50,7 +56,6 @@ int cobs_encode(struct net_buf *src, struct net_buf *dst, uint32_t flags)
 	*code_ptr = code;
 
 	if (flags & COBS_FLAG_TRAILING_DELIMITER) {
-		/* Add final delimiter */
 		net_buf_add_u8(dst, delimiter);
 	}
 
@@ -60,30 +65,29 @@ int cobs_encode(struct net_buf *src, struct net_buf *dst, uint32_t flags)
 int cobs_decode(struct net_buf *src, struct net_buf *dst, uint32_t flags)
 {
 	uint8_t delimiter = COBS_FLAG_CUSTOM_DELIMITER(flags);
+	uint8_t code_base = cobs_code_base(delimiter);
+	uint8_t finish_code = cobs_finish_code(delimiter);
 
 	if (flags & COBS_FLAG_TRAILING_DELIMITER) {
-		uint8_t end_delim = net_buf_remove_u8(src);
-
-		if (end_delim != delimiter) {
+		if (net_buf_remove_u8(src) != delimiter) {
 			return -EINVAL;
 		}
 	}
 
 	while (src->len > 0) {
-		/* Pull the COBS offset byte */
 		uint8_t offset = net_buf_pull_u8(src);
 
-		if (offset == delimiter && !(flags & COBS_FLAG_TRAILING_DELIMITER)) {
+		if (offset == delimiter || offset < code_base) {
 			return -EINVAL;
 		}
 
-		/* Verify we have enough data */
-		if (src->len < (offset - 1)) {
+		uint8_t bytes_to_read = offset - code_base;
+
+		if (src->len < bytes_to_read) {
 			return -EINVAL;
 		}
 
-		/* Copy offset-1 bytes */
-		for (uint8_t i = 0; i < offset - 1; i++) {
+		for (uint8_t i = 0; i < bytes_to_read; i++) {
 			uint8_t byte = net_buf_pull_u8(src);
 
 			if (byte == delimiter) {
@@ -92,10 +96,7 @@ int cobs_decode(struct net_buf *src, struct net_buf *dst, uint32_t flags)
 			net_buf_add_u8(dst, byte);
 		}
 
-		/* If this wasn't a maximum offset and we have more data,
-		 * there was a delimiter here in the original data
-		 */
-		if (offset != 0xFF && src->len > 0) {
+		if (offset != finish_code && src->len > 0) {
 			net_buf_add_u8(dst, delimiter);
 		}
 	}

--- a/tests/lib/cobs/src/main.c
+++ b/tests/lib/cobs/src/main.c
@@ -108,6 +108,63 @@ static const struct cobs_test_item cobs_dataset[] = {
 	COBS_ITEM(U8({0x7F, 0x7F}), U8({0x01, 0x01, 0x01}), 0x7F, "Two 0x7F delimiters"),
 	COBS_ITEM(U8({0x7F, 0x7F, 0x7F}), U8({0x01, 0x01, 0x01, 0x01}), 0x7F,
 		  "Three 0x7F delimiters"),
+	COBS_ITEM(U8({'1', '2', '3', '4', '5'}), U8({0x06, '1', '2', '3', '4', '5'}), 0x7F,
+		  "Five chars with 0x7F delimiter"),
+	COBS_ITEM(U8({'1', '2', '3', '4', '5', 0x7F, '6', '7', '8', '9'}),
+		  U8({0x06, '1', '2', '3', '4', '5', 0x05, '6', '7', '8', '9'}), 0x7F,
+		  "Embedded 0x7F delimiter"),
+	COBS_ITEM(U8({0x7F, '1', '2', '3', '4', '5', 0x7F, '6', '7', '8', '9'}),
+		  U8({0x01, 0x06, '1', '2', '3', '4', '5', 0x05, '6', '7', '8', '9'}), 0x7F,
+		  "Starting 0x7F delimiter"),
+	COBS_ITEM(U8({'1', '2', '3', '4', '5', 0x7F, '6', '7', '8', '9', 0x7F}),
+		  U8({0x06, '1', '2', '3', '4', '5', 0x05, '6', '7', '8', '9', 0x01}), 0x7F,
+		  "Trailing 0x7F delimiter"),
+	COBS_ITEM(U8({0x00}), U8({0x02, 0x00}), 0x7F, "Zero byte with 0x7F delimiter"),
+	COBS_ITEM(U8({0x00, 0x00}), U8({0x03, 0x00, 0x00}), 0x7F,
+		  "Two zero bytes with 0x7F delimiter"),
+	COBS_ITEM(U8({}), U8({0x01}), 0xFF, "Empty with 0xFF delimiter"),
+	COBS_ITEM(U8({'1'}), U8({0x02, '1'}), 0xFF, "One char with 0xFF delimiter"),
+	COBS_ITEM(U8({0xFF}), U8({0x01, 0x01}), 0xFF, "One 0xFF delimiter"),
+	COBS_ITEM(U8({0xFF, 0xFF}), U8({0x01, 0x01, 0x01}), 0xFF, "Two 0xFF delimiters"),
+	COBS_ITEM(U8({'1', '2', '3', '4', '5', 0xFF, '6', '7', '8', '9'}),
+		  U8({0x06, '1', '2', '3', '4', '5', 0x05, '6', '7', '8', '9'}), 0xFF,
+		  "Embedded 0xFF delimiter"),
+	COBS_ITEM(U8({0xFF, '1', '2', '3', '4', '5', 0xFF, '6', '7', '8', '9'}),
+		  U8({0x01, 0x06, '1', '2', '3', '4', '5', 0x05, '6', '7', '8', '9'}), 0xFF,
+		  "Starting 0xFF delimiter"),
+	COBS_ITEM(U8({0x00}), U8({0x02, 0x00}), 0xFF, "Zero byte with 0xFF delimiter"),
+	/* Long data with custom delimiter 0x7F - tests block boundary behavior */
+	COBS_ITEM(U8({'0', '1', '2', '3', '4', '5', '6', '7', '8',  '9', 'A', 'B', 'C', 'D',
+		      'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',  'N', 'O', 'P', 'Q', 'R',
+		      'S', 'T', 'a', 'b', 'c', 'd', 'e', 'f', 'g',  'h', 'i', 'j', 'k', 'l',
+		      'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 0x7F, '1', '2', '3', '4', '5',
+		      '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E',  'F', 'G', 'H', 'I', 'J'}),
+		  U8({0x33, '0', '1', '2', '3', '4', '5',  '6', '7', '8', '9', 'A', 'B', 'C', 'D',
+		      'E',  'F', 'G', 'H', 'I', 'J', 'K',  'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
+		      'T',  'a', 'b', 'c', 'd', 'e', 'f',  'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+		      'o',  'p', 'q', 'r', 's', 't', 0x14, '1', '2', '3', '4', '5', '6', '7', '8',
+		      '9',  'A', 'B', 'C', 'D', 'E', 'F',  'G', 'H', 'I', 'J'}),
+		  0x7F, "70 chars with embedded 0x7F delimiter"),
+	/* Long data with leading 0x7F delimiter */
+	COBS_ITEM(U8({0x7F, '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B',
+		      'C',  'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
+		      'P',  'Q', 'R', 'S', 'T', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
+		      'i',  'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't'}),
+		  U8({0x01, 0x33, '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A',
+		      'B',  'C',  'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
+		      'O',  'P',  'Q', 'R', 'S', 'T', 'a', 'b', 'c', 'd', 'e', 'f', 'g',
+		      'h',  'i',  'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't'}),
+		  0x7F, "50 chars with leading 0x7F delimiter"),
+	/* Long data with trailing 0x7F delimiter */
+	COBS_ITEM(U8({'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C',
+		      'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+		      'Q', 'R', 'S', 'T', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
+		      'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 0x7F}),
+		  U8({0x33, '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B',
+		      'C',  'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
+		      'P',  'Q', 'R', 'S', 'T', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
+		      'i',  'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 0x01}),
+		  0x7F, "50 chars with trailing 0x7F delimiter"),
 	COBS_ITEM(
 		U8({'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
 		    'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'a', 'b',
@@ -511,4 +568,153 @@ ZTEST_F(cobs_tests, test_cobs_invalid_overrun)
 	net_buf_add_mem(fixture->encoded, data_enc, sizeof(data_enc));
 	ret = cobs_decode(fixture->encoded, fixture->decoded, 0);
 	zassert_true(ret == -EINVAL, "Decoding insufficient data not caught");
+}
+
+ZTEST_F(cobs_tests, test_cobs_invalid_delim_pos_custom_0x7F)
+{
+	int ret;
+	const uint8_t data_enc[] = {0x02, 0x7F, 0x01};
+
+	net_buf_add_mem(fixture->encoded, data_enc, sizeof(data_enc));
+	ret = cobs_decode(fixture->encoded, fixture->decoded, COBS_FLAG_CUSTOM_DELIMITER(0x7F));
+	zassert_true(ret == -EINVAL, "Decoding invalid 0x7F delimiter position not caught");
+}
+
+ZTEST_F(cobs_tests, test_cobs_consecutive_delims_custom_0x7F)
+{
+	int ret;
+	const uint8_t data_enc[] = {0x01, 0x7F, 0x7F, 0x01};
+
+	net_buf_add_mem(fixture->encoded, data_enc, sizeof(data_enc));
+	ret = cobs_decode(fixture->encoded, fixture->decoded, COBS_FLAG_CUSTOM_DELIMITER(0x7F));
+	zassert_true(ret == -EINVAL, "Decoding consecutive 0x7F delimiters not caught");
+}
+
+ZTEST_F(cobs_tests, test_cobs_invalid_overrun_custom_0x7F)
+{
+	int ret;
+	const uint8_t data_enc[] = {0x03, 0x01};
+
+	net_buf_add_mem(fixture->encoded, data_enc, sizeof(data_enc));
+	ret = cobs_decode(fixture->encoded, fixture->decoded, COBS_FLAG_CUSTOM_DELIMITER(0x7F));
+	zassert_true(ret == -EINVAL, "Decoding insufficient data with 0x7F delimiter not caught");
+}
+
+ZTEST_F(cobs_tests, test_cobs_invalid_delim_pos_custom_0xFF)
+{
+	int ret;
+	const uint8_t data_enc[] = {0x02, 0xFF, 0x01};
+
+	net_buf_add_mem(fixture->encoded, data_enc, sizeof(data_enc));
+	ret = cobs_decode(fixture->encoded, fixture->decoded, COBS_FLAG_CUSTOM_DELIMITER(0xFF));
+	zassert_true(ret == -EINVAL, "Decoding invalid 0xFF delimiter position not caught");
+}
+
+ZTEST_F(cobs_tests, test_cobs_consecutive_delims_custom_0xFF)
+{
+	int ret;
+	const uint8_t data_enc[] = {0x01, 0xFF, 0xFF, 0x01};
+
+	net_buf_add_mem(fixture->encoded, data_enc, sizeof(data_enc));
+	ret = cobs_decode(fixture->encoded, fixture->decoded, COBS_FLAG_CUSTOM_DELIMITER(0xFF));
+	zassert_true(ret == -EINVAL, "Decoding consecutive 0xFF delimiters not caught");
+}
+
+/*
+ * Test case that exposes bug: overhead byte equals custom delimiter.
+ *
+ * With delimiter 0x7F (127), if we have exactly 126 non-delimiter bytes
+ * followed by a delimiter, the code/overhead byte would be 127 = 0x7F,
+ * which is indistinguishable from the delimiter itself.
+ *
+ * This test verifies round-trip encode/decode with data that triggers
+ * this edge case. The current implementation will fail this test.
+ */
+ZTEST_F(cobs_tests, test_cobs_overhead_equals_delimiter_0x7F)
+{
+	int ret;
+	uint8_t test_input[128];
+
+	/* Create 126 non-0x7F bytes followed by 0x7F delimiter and one more byte */
+	for (int i = 0; i < 126; i++) {
+		test_input[i] = (i % 127 == 0x7F) ? 0x00 : (i % 127);
+	}
+	test_input[126] = 0x7F; /* delimiter */
+	test_input[127] = 'X';  /* byte after delimiter */
+
+	net_buf_add_mem(fixture->test_data, test_input, sizeof(test_input));
+
+	/* Encode with custom delimiter 0x7F */
+	ret = cobs_encode(fixture->test_data, fixture->encoded, COBS_FLAG_CUSTOM_DELIMITER(0x7F));
+	zassert_ok(ret, "Encoding failed");
+
+	/* Decode back */
+	ret = cobs_decode(fixture->encoded, fixture->decoded, COBS_FLAG_CUSTOM_DELIMITER(0x7F));
+	zassert_ok(ret, "Decoding failed");
+
+	/* Verify round-trip: decoded should match original input */
+	zassert_equal(sizeof(test_input), fixture->decoded->len,
+		      "Round-trip length mismatch: expected %zu, got %u", sizeof(test_input),
+		      fixture->decoded->len);
+	zassert_mem_equal(test_input, fixture->decoded->data, sizeof(test_input),
+			  "Round-trip data mismatch - overhead byte collision with delimiter");
+}
+
+/*
+ * Similar test for 0xFF delimiter - code byte could equal 0xFF (254 bytes)
+ * but this conflicts with the existing 0xFF block-continuation semantic.
+ */
+ZTEST_F(cobs_tests, test_cobs_overhead_equals_delimiter_0xFF)
+{
+	int ret;
+	uint8_t test_input[256];
+
+	/* Create 254 non-0xFF bytes followed by 0xFF delimiter and one more byte */
+	for (int i = 0; i < 254; i++) {
+		test_input[i] = i % 255; /* 0x00-0xFE, never 0xFF */
+	}
+	test_input[254] = 0xFF; /* delimiter */
+	test_input[255] = 'X';  /* byte after delimiter */
+
+	net_buf_add_mem(fixture->test_data, test_input, sizeof(test_input));
+
+	/* Encode with custom delimiter 0xFF */
+	ret = cobs_encode(fixture->test_data, fixture->encoded, COBS_FLAG_CUSTOM_DELIMITER(0xFF));
+	zassert_ok(ret, "Encoding failed");
+
+	/* Decode back */
+	ret = cobs_decode(fixture->encoded, fixture->decoded, COBS_FLAG_CUSTOM_DELIMITER(0xFF));
+	zassert_ok(ret, "Decoding failed");
+
+	/* Verify round-trip */
+	zassert_equal(sizeof(test_input), fixture->decoded->len,
+		      "Round-trip length mismatch: expected %zu, got %u", sizeof(test_input),
+		      fixture->decoded->len);
+	zassert_mem_equal(test_input, fixture->decoded->data, sizeof(test_input),
+			  "Round-trip data mismatch - overhead byte collision with delimiter");
+}
+
+ZTEST_F(cobs_tests, test_cobs_delimiter_0x01_roundtrip)
+{
+	int ret;
+	uint8_t test_input[8];
+
+	for (int i = 0; i < 7; i++) {
+		test_input[i] = i + 2;
+	}
+	test_input[7] = 0x01;
+
+	net_buf_add_mem(fixture->test_data, test_input, sizeof(test_input));
+
+	ret = cobs_encode(fixture->test_data, fixture->encoded, COBS_FLAG_CUSTOM_DELIMITER(0x01));
+	zassert_ok(ret, "Encoding failed");
+
+	ret = cobs_decode(fixture->encoded, fixture->decoded, COBS_FLAG_CUSTOM_DELIMITER(0x01));
+	zassert_ok(ret, "Decoding failed");
+
+	zassert_equal(sizeof(test_input), fixture->decoded->len,
+		      "Round-trip length mismatch: expected %zu, got %u", sizeof(test_input),
+		      fixture->decoded->len);
+	zassert_mem_equal(test_input, fixture->decoded->data, sizeof(test_input),
+			  "Round-trip data mismatch for delimiter 0x01");
 }


### PR DESCRIPTION
Adds fix for case where custom delimiter is equal to overhead byte
Adds tests for custom delimiters
Simplified implementation

Signed-off-by: Helmut Lord <kellyhlord@gmail.com>
