### PR TITLE
stm32 tests: boot: with_mcumgr: exclude wba6 platforms

### DIFF
--- a/tests/boot/with_mcumgr/testcase.yaml
+++ b/tests/boot/with_mcumgr/testcase.yaml
@@ -44,9 +44,11 @@ tests:
       - nucleo_u385rg_q
       - nucleo_wb55rg
       - nucleo_wba55cg
+      - nucleo_wba65ri
       - nucleo_wl55jc
       - stm32f3_disco
       - stm32u083c_dk
+      - stm32wba65i_dk1
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: EXTRA_CONF_FILE="overlay-bt.conf"


### PR DESCRIPTION
These platforms were mistakenly not excluded during PR #100385, which causes a build error in CI.