### PR TITLE
modules: hal_infineon: Fix whd includes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -185,7 +185,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: e81d26f77faa419a6b2286418dbe6796c92ed18a
+      revision: 470f874ce432763a2b82cd322d0ff6efc89240cd
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
Updates hal_infineon to remove stray includes of cyhal  that broke the build for folks using our wireless parts with non-Infineon microcontrollers when building with Zephyr.

Wrap #include's of cyhal such that they are not included when building.